### PR TITLE
[geom] fix SavePrimitive methods

### DIFF
--- a/geom/geom/inc/TGeoMaterial.h
+++ b/geom/geom/inc/TGeoMaterial.h
@@ -111,7 +111,7 @@ public:
    virtual TGeoElement     *GetElement(Int_t i) const;
    virtual void             GetElementProp(Double_t &a, Double_t &z, Double_t &w, Int_t i=0);
    TGeoElement             *GetBaseElement() const {return fElement;}
-   char                    *GetPointerName() const;
+   const char              *GetPointerName() const;
    virtual Double_t         GetRadLen() const  {return fRadLen;}
    virtual Double_t         GetIntLen() const  {return fIntLen;}
    Int_t                    GetIndex();

--- a/geom/geom/inc/TGeoMatrix.h
+++ b/geom/geom/inc/TGeoMatrix.h
@@ -77,7 +77,7 @@ public :
    Bool_t               IsRegistered()  const {return TestBit(kGeoRegistered);}
    Bool_t               IsRotAboutZ()   const;
    void                 GetHomogenousMatrix(Double_t *hmat) const;
-   char                *GetPointerName() const;
+   const char          *GetPointerName() const;
 
    virtual Int_t              GetByteCount() const;
    virtual const Double_t    *GetTranslation()    const = 0;

--- a/geom/geom/inc/TGeoMedium.h
+++ b/geom/geom/inc/TGeoMedium.h
@@ -48,7 +48,7 @@ public:
    Int_t                    GetId()   const     {return fId;}
    Double_t                 GetParam(Int_t i) const {return fParams[i];}
    void                     SetParam(Int_t i, Double_t val)   {fParams[i] = val;}
-   char                    *GetPointerName() const;
+   const char              *GetPointerName() const;
    TGeoMaterial            *GetMaterial() const {return fMaterial;}
    virtual void             SavePrimitive(std::ostream &out, Option_t *option = "");
    void                     SetId(Int_t id)     {fId = id;}

--- a/geom/geom/inc/TGeoVolume.h
+++ b/geom/geom/inc/TGeoVolume.h
@@ -184,7 +184,7 @@ public:
    virtual char   *GetObjectInfo(Int_t px, Int_t py) const;
    Bool_t          GetOptimalVoxels() const;
    Option_t       *GetOption() const { return fOption.Data(); }
-   char           *GetPointerName() const;
+   const char     *GetPointerName() const;
    Char_t          GetTransparency() const { return !fMedium ? 0 : fMedium->GetMaterial()->GetTransparency(); }
    TGeoShape      *GetShape() const                  {return fShape;}
    void            GrabFocus(); // *MENU*

--- a/geom/geom/src/TGeoMaterial.cxx
+++ b/geom/geom/src/TGeoMaterial.cxx
@@ -460,11 +460,11 @@ TGeoExtension *TGeoMaterial::GrabFWExtension() const
 ////////////////////////////////////////////////////////////////////////////////
 /// Provide a pointer name containing uid.
 
-char *TGeoMaterial::GetPointerName() const
+const char *TGeoMaterial::GetPointerName() const
 {
    static TString name;
-   name = TString::Format("pMat%d", GetUniqueID());
-   return (char*)name.Data();
+   name.Form("pMat%d", GetUniqueID());
+   return name.Data();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -563,7 +563,7 @@ void TGeoMaterial::Print(const Option_t * /*option*/) const
 void TGeoMaterial::SavePrimitive(std::ostream &out, Option_t * /*option*/ /*= ""*/)
 {
    if (TestBit(TGeoMaterial::kMatSavePrimitive)) return;
-   char *name = GetPointerName();
+   const char *name = GetPointerName();
    out << "// Material: " << GetName() << std::endl;
    out << "   a       = " << fA << ";" << std::endl;
    out << "   z       = " << fZ << ";" << std::endl;
@@ -1145,11 +1145,11 @@ void TGeoMixture::Print(const Option_t * /*option*/) const
 void TGeoMixture::SavePrimitive(std::ostream &out, Option_t * /*option*/ /*= ""*/)
 {
    if (TestBit(TGeoMaterial::kMatSavePrimitive)) return;
-   char *name = GetPointerName();
+   const char *name = GetPointerName();
    out << "// Mixture: " << GetName() << std::endl;
    out << "   nel     = " << fNelements << ";" << std::endl;
    out << "   density = " << fDensity << ";" << std::endl;
-   out << "   " << name << " = new TGeoMixture(\"" << GetName() << "\", nel,density);" << std::endl;
+   out << "   auto " << name << " = new TGeoMixture(\"" << GetName() << "\", nel, density);" << std::endl;
    for (Int_t i=0; i<fNelements; i++) {
       TGeoElement *el = GetElement(i);
       out << "      a = " << fAmixture[i] << ";   z = "<< fZmixture[i] << ";   w = " << fWeights[i] << ";  // " << el->GetName() << std::endl;

--- a/geom/geom/src/TGeoMaterial.cxx
+++ b/geom/geom/src/TGeoMaterial.cxx
@@ -571,7 +571,7 @@ void TGeoMaterial::SavePrimitive(std::ostream &out, Option_t * /*option*/ /*= ""
    out << "   radl    = " << fRadLen << ";" << std::endl;
    out << "   absl    = " << fIntLen << ";" << std::endl;
 
-   out << "   " << name << " = new TGeoMaterial(\"" << GetName() << "\", a,z,density,radl,absl);" << std::endl;
+   out << "   auto " << name << " = new TGeoMaterial(\"" << GetName() << "\", a, z, density, radl, absl);" << std::endl;
    out << "   " << name << "->SetIndex(" << GetIndex() << ");" << std::endl;
    SetBit(TGeoMaterial::kMatSavePrimitive);
 }

--- a/geom/geom/src/TGeoMatrix.cxx
+++ b/geom/geom/src/TGeoMatrix.cxx
@@ -2046,11 +2046,11 @@ void TGeoCombiTrans::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    out << "   dz = " << fTranslation[2] << ";" << std::endl;
    if (fRotation && fRotation->IsRotation()) {
       fRotation->SavePrimitive(out,option);
-      out << "   " << GetPointerName() << " = new TGeoCombiTrans(\"" << GetName() << "\", dx,dy,dz,";
-      out << fRotation->GetPointerName() << ");" << std::endl;
+      out << "   auto " << GetPointerName() << " = new TGeoCombiTrans(\"" << GetName() << "\", dx, dy, dz, "
+          << fRotation->GetPointerName() << ");" << std::endl;
    } else {
-      out << "   " << GetPointerName() << " = new TGeoCombiTrans(\"" << GetName() << "\");" << std::endl;
-      out << "   " << GetPointerName() << "->SetTranslation(dx,dy,dz);" << std::endl;
+      out << "   auto " << GetPointerName() << " = new TGeoCombiTrans(\"" << GetName() << "\");" << std::endl;
+      out << "   " << GetPointerName() << "->SetTranslation(dx, dy, dz);" << std::endl;
    }
    TObject::SetBit(kGeoSavePrimitive);
 }

--- a/geom/geom/src/TGeoMatrix.cxx
+++ b/geom/geom/src/TGeoMatrix.cxx
@@ -291,11 +291,11 @@ Int_t TGeoMatrix::GetByteCount() const
 ////////////////////////////////////////////////////////////////////////////////
 /// Provide a pointer name containing uid.
 
-char *TGeoMatrix::GetPointerName() const
+const char *TGeoMatrix::GetPointerName() const
 {
    static TString name;
-   name = TString::Format("pMatrix%d", GetUniqueID());
-   return (char*)name.Data();
+   name.Form("pMatrix%d", GetUniqueID());
+   return name.Data();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2785,8 +2785,8 @@ void TGeoHMatrix::SavePrimitive(std::ostream &out, Option_t * /*option*/ /*= ""*
    out << "   rot[0] =" << rot[0] << ";    " << "rot[1] = " << rot[1] << ";    " << "rot[2] = " << rot[2] << ";" << std::endl;
    out << "   rot[3] =" << rot[3] << ";    " << "rot[4] = " << rot[4] << ";    " << "rot[5] = " << rot[5] << ";" << std::endl;
    out << "   rot[6] =" << rot[6] << ";    " << "rot[7] = " << rot[7] << ";    " << "rot[8] = " << rot[8] << ";" << std::endl;
-   char *name = GetPointerName();
-   out << "   TGeoHMatrix *" << name << " = new TGeoHMatrix(\"" << GetName() << "\");" << std::endl;
+   const char *name = GetPointerName();
+   out << "   auto " << name << " = new TGeoHMatrix(\"" << GetName() << "\");" << std::endl;
    out << "   " << name << "->SetTranslation(tr);" << std::endl;
    out << "   " << name << "->SetRotation(rot);" << std::endl;
    if (IsTranslation()) out << "   " << name << "->SetBit(TGeoMatrix::kGeoTranslation);" << std::endl;

--- a/geom/geom/src/TGeoMedium.cxx
+++ b/geom/geom/src/TGeoMedium.cxx
@@ -149,6 +149,6 @@ void TGeoMedium::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    out << "   par[6]  = " << fParams[6] << "; // epsil" << std::endl;
    out << "   par[7]  = " << fParams[7] << "; // stmin" << std::endl;
 
-   out << "   " << GetPointerName() << " = new TGeoMedium(\"" << GetName() << "\", numed," << fMaterial->GetPointerName() << ", par);" << std::endl;
+   out << "   auto " << GetPointerName() << " = new TGeoMedium(\"" << GetName() << "\", numed, " << fMaterial->GetPointerName() << ", par);" << std::endl;
    SetBit(TGeoMedium::kMedSavePrimitive);
 }

--- a/geom/geom/src/TGeoMedium.cxx
+++ b/geom/geom/src/TGeoMedium.cxx
@@ -124,11 +124,11 @@ TGeoMedium::~TGeoMedium()
 ////////////////////////////////////////////////////////////////////////////////
 /// Provide a pointer name containing uid.
 
-char *TGeoMedium::GetPointerName() const
+const char *TGeoMedium::GetPointerName() const
 {
    static TString name;
-   name = TString::Format("pMed%d", GetUniqueID());
-   return (char*)name.Data();
+   name.Form("pMed%d", GetUniqueID());
+   return name.Data();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/geom/geom/src/TGeoPcon.cxx
+++ b/geom/geom/src/TGeoPcon.cxx
@@ -1274,14 +1274,13 @@ void TGeoPcon::SavePrimitive(std::ostream &out, Option_t * /*option*/ /*= ""*/)
    out << "   phi1  = " << fPhi1 << ";" << std::endl;
    out << "   dphi  = " << fDphi << ";" << std::endl;
    out << "   nz    = " << fNz << ";" << std::endl;
-   out << "   TGeoPcon *pcon = new TGeoPcon(\"" << GetName() << "\",phi1,dphi,nz);" << std::endl;
+   out << "   auto " << GetPointerName() << " = new TGeoPcon(\"" << GetName() << "\", phi1, dphi, nz);" << std::endl;
    for (Int_t i=0; i<fNz; i++) {
       out << "      z     = " << fZ[i] << ";" << std::endl;
       out << "      rmin  = " << fRmin[i] << ";" << std::endl;
       out << "      rmax  = " << fRmax[i] << ";" << std::endl;
-      out << "   pcon->DefineSection(" << i << ", z,rmin,rmax);" << std::endl;
+      out << "   " << GetPointerName() << "->DefineSection(" << i << ", z,rmin,rmax);" << std::endl;
    }
-   out << "   TGeoShape *" << GetPointerName() << " = pcon;" << std::endl;
    TObject::SetBit(TGeoShape::kGeoSavePrimitive);
 }
 

--- a/geom/geom/src/TGeoPgon.cxx
+++ b/geom/geom/src/TGeoPgon.cxx
@@ -1926,14 +1926,13 @@ void TGeoPgon::SavePrimitive(std::ostream &out, Option_t * /*option*/ /*= ""*/)
    out << "   dphi    = " << fDphi << ";" << std::endl;
    out << "   nedges = " << fNedges << ";" << std::endl;
    out << "   nz      = " << fNz << ";" << std::endl;
-   out << "   TGeoPgon *pgon = new TGeoPgon(\"" << GetName() << "\",phi1,dphi,nedges,nz);" << std::endl;
+   out << "   auto " << GetPointerName() << " = new TGeoPgon(\"" << GetName() << "\", phi1, dphi, nedges, nz);" << std::endl;
    for (Int_t i = 0; i < fNz; i++) {
       out << "      z     = " << fZ[i] << ";" << std::endl;
       out << "      rmin  = " << fRmin[i] << ";" << std::endl;
       out << "      rmax  = " << fRmax[i] << ";" << std::endl;
-      out << "   pgon->DefineSection(" << i << ", z,rmin,rmax);" << std::endl;
+      out << "   " << GetPointerName() << "->DefineSection(" << i << ", z, rmin, rmax);" << std::endl;
    }
-   out << "   TGeoShape *" << GetPointerName() << " = pgon;" << std::endl;
    TObject::SetBit(TGeoShape::kGeoSavePrimitive);
 }
 

--- a/geom/geom/src/TGeoScaledShape.cxx
+++ b/geom/geom/src/TGeoScaledShape.cxx
@@ -330,10 +330,10 @@ void TGeoScaledShape::SavePrimitive(std::ostream &out, Option_t *option)
    TString sname = fShape->GetPointerName();
    const Double_t *sc = fScale->GetScale();
    out << "   // Scale factor:" << std::endl;
-   out << "   TGeoScale *pScale = new TGeoScale(\"" << fScale->GetName()
+   out << "   auto pScale_" << GetPointerName() << " = new TGeoScale(\"" << fScale->GetName()
        << "\"," << sc[0] << "," << sc[1] << "," << sc[2] << ");" << std::endl;
    out << "   TGeoScaledShape *" << GetPointerName() << " = new TGeoScaledShape(\""
-       << GetName() << "\"," << sname << ", pScale);" << std::endl;
+       << GetName() << "\"," << sname << ", pScale_" << GetPointerName() << " );" << std::endl;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/geom/geom/src/TGeoTube.cxx
+++ b/geom/geom/src/TGeoTube.cxx
@@ -3071,7 +3071,8 @@ void TGeoCtub::SavePrimitive(std::ostream &out, Option_t * /*option*/ /*= ""*/)
    out << "   tx   = " << fNhigh[0] << ";" << std::endl;
    out << "   ty   = " << fNhigh[1] << ";" << std::endl;
    out << "   tz   = " << fNhigh[2] << ";" << std::endl;
-   out << "   TGeoShape *" << GetPointerName() << " = new TGeoCtub(\"" << GetName() << "\",rmin,rmax,dz,phi1,phi2,lx,ly,lz,tx,ty,tz);" << std::endl;   TObject::SetBit(TGeoShape::kGeoSavePrimitive);
+   out << "   TGeoShape *" << GetPointerName() << " = new TGeoCtub(\"" << GetName() << "\",rmin,rmax,dz,phi1,phi2,lx,ly,lz,tx,ty,tz);" << std::endl;
+   TObject::SetBit(TGeoShape::kGeoSavePrimitive);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/geom/geom/src/TGeoVolume.cxx
+++ b/geom/geom/src/TGeoVolume.cxx
@@ -1457,7 +1457,7 @@ void TGeoVolume::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       out << "   new TGeoManager(\"" << fGeoManager->GetName() << "\", \"" << fGeoManager->GetTitle() << "\");" << std::endl << std::endl;
 //      if (mustDraw) out << "   Bool_t mustDraw = kTRUE;" << std::endl;
 //      else          out << "   Bool_t mustDraw = kFALSE;" << std::endl;
-      out << "   Double_t dx,dy,dz;" << std::endl;
+      out << "   Double_t dx, dy, dz;" << std::endl;
       out << "   Double_t dx1, dx2, dy1, dy2;" << std::endl;
       out << "   Double_t vert[20], par[20];" << std::endl;
       out << "   Double_t theta, phi, h1, bl1, tl1, alpha1, h2, bl2, tl2, alpha2;" << std::endl;
@@ -1465,19 +1465,18 @@ void TGeoVolume::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       out << "   Double_t origin[3];" << std::endl;
       out << "   Double_t rmin, rmax, rmin1, rmax1, rmin2, rmax2;" << std::endl;
       out << "   Double_t r, rlo, rhi;" << std::endl;
-      out << "   Double_t phi1, phi2;" << std::endl;
-      out << "   Double_t a,b;" << std::endl;
+      out << "   Double_t a, b;" << std::endl;
       out << "   Double_t point[3], norm[3];" << std::endl;
       out << "   Double_t rin, stin, rout, stout;" << std::endl;
       out << "   Double_t thx, phx, thy, phy, thz, phz;" << std::endl;
       out << "   Double_t alpha, theta1, theta2, phi1, phi2, dphi;" << std::endl;
       out << "   Double_t tr[3], rot[9];" << std::endl;
       out << "   Double_t z, density, radl, absl, w;" << std::endl;
-      out << "   Double_t lx,ly,lz,tx,ty,tz;" << std::endl;
+      out << "   Double_t lx, ly, lz, tx, ty, tz;" << std::endl;
       out << "   Double_t xvert[50], yvert[50];" << std::endl;
-      out << "   Double_t zsect,x0,y0,scale0;" << std::endl;
+      out << "   Double_t zsect, x0, y0, scale0;" << std::endl;
       out << "   Int_t nel, numed, nz, nedges, nvert;" << std::endl;
-      out << "   TGeoBoolNode *pBoolNode = 0;" << std::endl << std::endl;
+      out << "   TGeoBoolNode *pBoolNode = nullptr;" << std::endl << std::endl;
       // first save materials/media
       out << "   // MATERIALS, MIXTURES AND TRACKING MEDIA" << std::endl;
       SavePrimitive(out, "m");
@@ -1506,16 +1505,14 @@ void TGeoVolume::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       if (!IsAssembly()) {
          fShape->SavePrimitive(out,option);
          out << "   // Volume: " << GetName() << std::endl;
-         if (fMedium) out << "   " << GetPointerName() << " = new TGeoVolume(\"" << GetName() << "\"," << fShape->GetPointerName() << ", "<< fMedium->GetPointerName() << ");" << std::endl;
-         else out << "   " << GetPointerName() << " = new TGeoVolume(\"" << GetName() << "\"," << fShape->GetPointerName() <<  ");" << std::endl;
-
+         out << "   TGeoVolume *" << GetPointerName() << " = new TGeoVolume(\"" << GetName() << "\"," << fShape->GetPointerName();
+         if (fMedium) out << ", " << fMedium->GetPointerName();
+         out << ");" << std::endl;
       } else {
          out << "   // Assembly: " << GetName() << std::endl;
          out << "   " << GetPointerName() << " = new TGeoVolumeAssembly(\"" << GetName() << "\"" << ");" << std::endl;
       }
-      if (fLineColor != 1) out << "   " << GetPointerName() << "->SetLineColor(" << fLineColor << ");" << std::endl;
-      if (fLineWidth != 1) out << "   " << GetPointerName() << "->SetLineWidth(" << fLineWidth << ");" << std::endl;
-      if (fLineStyle != 1) out << "   " << GetPointerName() << "->SetLineStyle(" << fLineStyle << ");" << std::endl;
+      SaveLineAttributes(out, GetPointerName(), 1, 1, 1);
       if (!IsVisible() && !IsAssembly()) out << "   " << GetPointerName() << "->SetVisibility(kFALSE);" << std::endl;
       if (!IsVisibleDaughters()) out << "   " << GetPointerName() << "->VisibleDaughters(kFALSE);" << std::endl;
       if (IsVisContainers()) out << "   " << GetPointerName() << "->SetVisContainers(kTRUE);" << std::endl;
@@ -1558,9 +1555,8 @@ void TGeoVolume::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
          out << "   TGeoVolume *" << dvol->GetPointerName() << " = ";
          out << GetPointerName() << "->Divide(\"" << dvol->GetName() << "\", ";
          fFinder->SavePrimitive(out,option);
-         if (fMedium != dvol->GetMedium()) {
+         if (fMedium != dvol->GetMedium())
             out << ", " << dvol->GetMedium()->GetId();
-         }
          out << ");" << std::endl;
          dvol->SavePrimitive(out,"d");
          return;

--- a/geom/geom/src/TGeoVolume.cxx
+++ b/geom/geom/src/TGeoVolume.cxx
@@ -1671,11 +1671,11 @@ Bool_t TGeoVolume::GetOptimalVoxels() const
 ////////////////////////////////////////////////////////////////////////////////
 /// Provide a pointer name containing uid.
 
-char *TGeoVolume::GetPointerName() const
+const char *TGeoVolume::GetPointerName() const
 {
    static TString name;
-   name = TString::Format("p%s_%zx", GetName(), (size_t)this);
-   return (char*)name.Data();
+   name.Form("p%s_%zx", GetName(), (size_t)this);
+   return name.Data();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/geom/geom/src/TGeoXtru.cxx
+++ b/geom/geom/src/TGeoXtru.cxx
@@ -1081,23 +1081,14 @@ void TGeoXtru::SavePrimitive(std::ostream &out, Option_t * /*option*/ /*= ""*/)
 {
    if (TObject::TestBit(kGeoSavePrimitive)) return;
    out << "   // Shape: " << GetName() << " type: " << ClassName() << std::endl;
-   out << "   nz       = " << fNz << ";" << std::endl;
-   out << "   nvert    = " << fNvert << ";" << std::endl;
-   out << "   TGeoXtru *xtru = new TGeoXtru(nz);" << std::endl;
-   out << "   xtru->SetName(\"" << GetName() << "\");" << std::endl;
-   Int_t i;
-   for (i=0; i<fNvert; i++) {
+   out << "   auto " << GetPointerName() << " = new TGeoXtru(" << fNz << ");" << std::endl;
+   out << "   " << GetPointerName() << "->SetName(\"" << GetName() << "\");" << std::endl;
+   for (Int_t i=0; i<fNvert; i++) {
       out << "   xvert[" << i << "] = " << fX[i] << ";   yvert[" << i << "] = " << fY[i] << ";" << std::endl;
    }
-   out << "   xtru->DefinePolygon(nvert,xvert,yvert);" << std::endl;
-   for (i=0; i<fNz; i++) {
-      out << "   zsect  = " << fZ[i] << ";" << std::endl;
-      out << "   x0     = " << fX0[i] << ";" << std::endl;
-      out << "   y0     = " << fY0[i] << ";" << std::endl;
-      out << "   scale0 = " << fScale[i] << ";" << std::endl;
-      out << "   xtru->DefineSection(" << i << ",zsect,x0,y0,scale0);" << std::endl;
-   }
-   out << "   TGeoShape *" << GetPointerName() << " = xtru;" << std::endl;
+   out << "   " << GetPointerName() << "->DefinePolygon(" << fNvert << ", xvert, yvert);" << std::endl;
+   for (Int_t i=0; i<fNz; i++)
+      out << "   " << GetPointerName() << "->DefineSection(" << i << ", " << fZ[i] << ", " << fX0[i] << ", " << fY0[i] << ", " << fScale[i] << ");" << std::endl;
    TObject::SetBit(TGeoShape::kGeoSavePrimitive);
 }
 

--- a/tutorials/geom/geodemo.C
+++ b/tutorials/geom/geodemo.C
@@ -305,7 +305,7 @@ void box(Int_t iaxis=0, Int_t ndiv=8, Double_t start=0, Double_t step=0)
       printf("Wrong division axis. Range is 1-3.\n");
       return;
    }
-   TCanvas *c = new TCanvas("box shape", "A simple box", 700,1000);
+   TCanvas *c = new TCanvas("box_shape", "A simple box", 700,1000);
    if (comments) {
       c->Divide(1,2,0,0);
       c->cd(2);
@@ -369,7 +369,7 @@ void box(Int_t iaxis=0, Int_t ndiv=8, Double_t start=0, Double_t step=0)
 void para(Int_t iaxis=0, Int_t ndiv=8, Double_t start=0, Double_t step=0)
 {
    gROOT->GetListOfCanvases()->Delete();
-   TCanvas *c = new TCanvas("para shape", "A parallelepiped", 700,1000);
+   TCanvas *c = new TCanvas("para_shape", "A parallelepiped", 700,1000);
    if (comments) {
       c->Divide(1,2,0,0);
       c->cd(2);
@@ -436,7 +436,7 @@ void tube(Int_t iaxis=0, Int_t ndiv=8, Double_t start=0, Double_t step=0)
       printf("Wrong division axis. Range is 1-3.\n");
       return;
    }
-   TCanvas *c = new TCanvas("tube shape", "A tube", 700,1000);
+   TCanvas *c = new TCanvas("tube_shape", "A tube", 700,1000);
    if (comments) {
       c->Divide(1,2,0,0);
       c->cd(2);
@@ -501,7 +501,7 @@ void tubeseg(Int_t iaxis=0, Int_t ndiv=8, Double_t start=0, Double_t step=0)
       printf("Wrong division axis. Range is 1-3.\n");
       return;
    }
-   TCanvas *c = new TCanvas("tubeseg shape", "A tube segment ", 700,1000);
+   TCanvas *c = new TCanvas("tubeseg_shape", "A tube segment ", 700,1000);
    if (comments) {
       c->Divide(1,2,0,0);
       c->cd(2);
@@ -568,7 +568,7 @@ void ctub(Int_t iaxis=0, Int_t ndiv=8, Double_t start=0, Double_t step=0)
       printf("Wrong division axis. Range is 1-2.\n");
       return;
    }
-   TCanvas *c = new TCanvas("ctub shape", "A cut tube segment ", 700,1000);
+   TCanvas *c = new TCanvas("ctub_shape", "A cut tube segment ", 700,1000);
    if (comments) {
       c->Divide(1,2,0,0);
       c->cd(2);
@@ -641,7 +641,7 @@ void cone(Int_t iaxis=0, Int_t ndiv=8, Double_t start=0, Double_t step=0)
       printf("cannot divide cone on Rxy\n");
       return;
    }
-   TCanvas *c = new TCanvas("cone shape", "A cone", 700,1000);
+   TCanvas *c = new TCanvas("cone_shape", "A cone", 700,1000);
    if (comments) {
       c->Divide(1,2,0,0);
       c->cd(2);
@@ -707,7 +707,7 @@ void coneseg(Int_t iaxis=0, Int_t ndiv=8, Double_t start=0, Double_t step=0)
       printf("Wrong division axis. Range is 1-3.\n");
       return;
    }
-   TCanvas *c = new TCanvas("coneseg shape", "A cone segment", 700,1000);
+   TCanvas *c = new TCanvas("coneseg_shape", "A cone segment", 700,1000);
    if (comments) {
       c->Divide(1,2,0,0);
       c->cd(2);
@@ -771,7 +771,7 @@ void coneseg(Int_t iaxis=0, Int_t ndiv=8, Double_t start=0, Double_t step=0)
 void eltu(Int_t iaxis=0, Int_t ndiv=8, Double_t start=0, Double_t step=0)
 {
    gROOT->GetListOfCanvases()->Delete();
-   TCanvas *c = new TCanvas("eltu shape", "An Elliptical tube", 700,1000);
+   TCanvas *c = new TCanvas("eltu_shape", "An Elliptical tube", 700,1000);
    if (comments) {
       c->Divide(1,2,0,0);
       c->cd(2);
@@ -835,7 +835,7 @@ void sphere(Int_t iaxis=0, Int_t ndiv=8, Double_t start=0, Double_t step=0)
       printf("Cannot divide spheres\n");
       return;
    }
-   TCanvas *c = new TCanvas("Sphere shap", "A spherical sector", 700,1000);
+   TCanvas *c = new TCanvas("Sphere_shape", "A spherical sector", 700,1000);
    if (comments) {
       c->Divide(1,2,0,0);
       c->cd(2);
@@ -891,7 +891,7 @@ void torus(Int_t iaxis=0, Int_t ndiv=8, Double_t start=0, Double_t step=0)
       printf("Cannot divide a torus\n");
       return;
    }
-   TCanvas *c = new TCanvas("torus shape", "A toroidal segment", 700,1000);
+   TCanvas *c = new TCanvas("torus_shape", "A toroidal segment", 700,1000);
    if (comments) {
       c->Divide(1,2,0,0);
       c->cd(2);
@@ -949,7 +949,7 @@ void trd1(Int_t iaxis=0, Int_t ndiv=8, Double_t start=0, Double_t step=0)
       return;
    }
 
-   TCanvas *c = new TCanvas("trd1 shape", "A trapezoid with dX varying", 700,1000);
+   TCanvas *c = new TCanvas("trd1_shape", "A trapezoid with dX varying", 700,1000);
    if (comments) {
       c->Divide(1,2,0,0);
       c->cd(2);
@@ -1010,7 +1010,7 @@ void trd1(Int_t iaxis=0, Int_t ndiv=8, Double_t start=0, Double_t step=0)
 void parab()
 {
    gROOT->GetListOfCanvases()->Delete();
-   TCanvas *c = new TCanvas("parab shape", "A paraboloid segment", 700,1000);
+   TCanvas *c = new TCanvas("parab_shape", "A paraboloid segment", 700,1000);
    if (comments) {
       c->Divide(1,2,0,0);
       c->cd(2);
@@ -1063,7 +1063,7 @@ void parab()
 void hype()
 {
    gROOT->GetListOfCanvases()->Delete();
-   TCanvas *c = new TCanvas("hype shape", "A hyperboloid", 700,1000);
+   TCanvas *c = new TCanvas("hype_shape", "A hyperboloid", 700,1000);
    if (comments) {
       c->Divide(1,2,0,0);
       c->cd(2);
@@ -1124,7 +1124,7 @@ void pcon(Int_t iaxis=0, Int_t ndiv=8, Double_t start=0, Double_t step=0)
       printf("Cannot divide pcon on Rxy\n");
       return;
    }
-   TCanvas *c = new TCanvas("pcon shape", "A polycone", 700,1000);
+   TCanvas *c = new TCanvas("pcon_shape", "A polycone", 700,1000);
    if (comments) {
       c->Divide(1,2,0,0);
       c->cd(2);
@@ -1204,7 +1204,7 @@ void pgon(Int_t iaxis=0, Int_t ndiv=8, Double_t start=0, Double_t step=0)
       printf("Cannot divide pgon on Rxy\n");
       return;
    }
-   TCanvas *c = new TCanvas("pgon shape", "A polygone", 700,1000);
+   TCanvas *c = new TCanvas("pgon_shape", "A polygone", 700,1000);
    if (comments) {
       c->Divide(1,2,0,0);
       c->cd(2);
@@ -1282,7 +1282,7 @@ void arb8(Int_t iaxis=0, Int_t ndiv=8, Double_t start=0, Double_t step=0)
       printf("Cannot divide arb8\n");
       return;
    }
-   TCanvas *c = new TCanvas("arb8 shape", "An arbitrary polyhedron", 700,1000);
+   TCanvas *c = new TCanvas("arb8_shape", "An arbitrary polyhedron", 700,1000);
    if (comments) {
       c->Divide(1,2,0,0);
       c->cd(2);
@@ -1361,7 +1361,7 @@ void trd2(Int_t iaxis=0, Int_t ndiv=8, Double_t start=0, Double_t step=0)
       printf("Wrong division axis. Can divide only in Z (3)\n");
       return;
    }
-   TCanvas *c = new TCanvas("trd2 shape", "A trapezoid with dX and dY varying with Z", 700,1000);
+   TCanvas *c = new TCanvas("trd2_shape", "A trapezoid with dX and dY varying with Z", 700,1000);
    if (comments) {
       c->Divide(1,2,0,0);
       c->cd(2);
@@ -1427,7 +1427,7 @@ void trap(Int_t iaxis=0, Int_t ndiv=8, Double_t start=0, Double_t step=0)
       printf("Wrong division axis. Can divide only in Z (3)\n");
       return;
    }
-   TCanvas *c = new TCanvas("trap shape", "A more general trapezoid", 700,1000);
+   TCanvas *c = new TCanvas("trap_shape", "A more general trapezoid", 700,1000);
    if (comments) {
       c->Divide(1,2,0,0);
       c->cd(2);
@@ -1499,7 +1499,7 @@ void gtra(Int_t iaxis=0, Int_t ndiv=8, Double_t start=0, Double_t step=0)
       printf("Wrong division axis. Can divide only in Z (3)\n");
       return;
    }
-   TCanvas *c = new TCanvas("gtra shape", "A twisted trapezoid", 700,1000);
+   TCanvas *c = new TCanvas("gtra_shape", "A twisted trapezoid", 700,1000);
    if (comments) {
       c->Divide(1,2,0,0);
       c->cd(2);
@@ -1568,7 +1568,7 @@ void gtra(Int_t iaxis=0, Int_t ndiv=8, Double_t start=0, Double_t step=0)
 void xtru()
 {
    gROOT->GetListOfCanvases()->Delete();
-   TCanvas *c = new TCanvas("gtra shape", "A twisted trapezoid", 700,1000);
+   TCanvas *c = new TCanvas("xtru_shape", "A twisted trapezoid", 700,1000);
    if (comments) {
       c->Divide(1,2,0,0);
       c->cd(2);
@@ -1631,7 +1631,7 @@ void tessellated()
 {
    // Create a [triacontahedron solid](https://en.wikipedia.org/wiki/Rhombic_triacontahedron)
    gROOT->GetListOfCanvases()->Delete();
-   TCanvas *c = new TCanvas("tessellated shape", "A tessellated shape", 700,1000);
+   TCanvas *c = new TCanvas("tessellated_shape", "A tessellated shape", 700,1000);
    if (comments) {
       c->Divide(1,2,0,0);
       c->cd(2);
@@ -1742,7 +1742,7 @@ void tessellated()
 void composite()
 {
    gROOT->GetListOfCanvases()->Delete();
-   TCanvas *c = new TCanvas("composite shape", "A Boolean shape composition", 700,1000);
+   TCanvas *c = new TCanvas("composite_shape", "A Boolean shape composition", 700,1000);
    if (comments) {
       c->Divide(1,2,0,0);
       c->cd(2);
@@ -1838,7 +1838,7 @@ void ideal()
 //   check = optional check if the new aligned node is overlapping
 // gGeoManager->SetDrawExtraPaths(Bool_t flag)
    gROOT->GetListOfCanvases()->Delete();
-   TCanvas *c = new TCanvas("composite shape", "A Boolean shape composition", 700,1000);
+   TCanvas *c = new TCanvas("composite_shape", "A Boolean shape composition", 700,1000);
    if (comments) {
       c->Divide(1,2,0,0);
       c->cd(2);

--- a/tutorials/geom/mp3player.C
+++ b/tutorials/geom/mp3player.C
@@ -29,7 +29,6 @@ void mp3player()
   TGeoManager *geom=new TGeoManager("geom","My first 3D geometry");
 
 
-
   //materials
   TGeoMaterial *vacuum=new TGeoMaterial("vacuum",0,0,0);
   TGeoMaterial *Fe=new TGeoMaterial("Fe",55.845,26,7.87);
@@ -44,7 +43,7 @@ void mp3player()
 
   TGeoVolume *top=geom->MakeBox("top",Air,800,800,800);
   geom->SetTopVolume(top);
-  geom->SetTopVisible(0);
+  geom->SetTopVisible(kFALSE);
   // If you want to see the boundary, please input the number, 1 instead of 0.
   // Like this, geom->SetTopVisible(1);
 
@@ -145,7 +144,6 @@ void mp3player()
   b28->SetLineColor(17);
   TGeoVolume *b29=geom->MakeTube("b29",Iron,71,74,150);
   b29->SetLineColor(17);
-
   TGeoVolume *b30=geom->MakeTube("b30",Iron,76,79,150);
   b30->SetLineColor(17);
   TGeoVolume *b31=geom->MakeTube("b31",Iron,81,84,150);
@@ -184,11 +182,8 @@ void mp3player()
   TGeoVolume *b46=geom->MakeTube("b46",Iron,25,30,150);
   b46->SetLineColor(17);
 
-
-
   TGeoVolume *b47=geom->MakeBox("b47",Iron,140,194,504);
   b47->SetLineColor(32);
-
 
   TGeoVolume *b48=geom->MakeBox("b48",Iron,150,176,236);
   b48->SetLineColor(37);
@@ -223,129 +218,134 @@ void mp3player()
   b54->SetLineColor(37);
   top->AddNodeOverlap(b54,54,new TGeoTranslation(25,0,0));
 
+  auto r1 = new TGeoRotation("r1",90,90,0);
+
   TGeoVolume *b55=geom->MakeTubs("b55",Iron,0,54,15,270,360);
   b55->SetLineColor(37);
-  top->AddNodeOverlap(b55,55,new TGeoCombiTrans(25,200,-600,new TGeoRotation("r1",90,90,0)));
+  top->AddNodeOverlap(b55,55,new TGeoCombiTrans(25,200,-600,r1));
 
 
   TGeoVolume *b56=geom->MakeTubs("b56",Iron,0,54,15,180,270);
   b56->SetLineColor(37);
-  top->AddNodeOverlap(b56,56,new TGeoCombiTrans(25,-200,-600,new TGeoRotation("r1",90,90,0)));
+  top->AddNodeOverlap(b56,56,new TGeoCombiTrans(25,-200,-600,r1));
 
 
   TGeoVolume *b57=geom->MakeTubs("b57",Iron,0,54,15,0,90);
   b57->SetLineColor(37);
-  top->AddNodeOverlap(b57,57,new TGeoCombiTrans(25,200,600,new TGeoRotation("r1",90,90,0)));
+  top->AddNodeOverlap(b57,57,new TGeoCombiTrans(25,200,600,r1));
 
   TGeoVolume *b58=geom->MakeTubs("b58",Iron,0,54,15,90,180);
   b58->SetLineColor(37);
-  top->AddNodeOverlap(b58,58,new TGeoCombiTrans(25,-200,600,new TGeoRotation("r1",90,90,0)));
+  top->AddNodeOverlap(b58,58,new TGeoCombiTrans(25,-200,600,r1));
 
   //TGeoVolume *b59=geom->MakePgon("b59",Iron,100,100,100,100);
   //b59->SetLineColor(37);
-  //top->AddNodeOverlap(b59,59,new TGeoCombiTrans(200,200,100,new TGeoRotation("r1",90,90,0)));
+  //top->AddNodeOverlap(b59,59,new TGeoCombiTrans(200,200,100,r1));
 
 
 
 //IAudid
 
 
+  auto r2 = new TGeoRotation("r2",90,90,30);
 
   TGeoVolume *b61=geom->MakeBox("b61",Iron,5,19,150);
   b61->SetLineColor(38);
-  top->AddNodeOverlap(b61,61,new TGeoCombiTrans(-4,-87,-495,new TGeoRotation("r1",90,90,30)));
+  top->AddNodeOverlap(b61,61,new TGeoCombiTrans(-4,-87,-495,r2));
 
   TGeoVolume *b62=geom->MakeBox("b62",Iron,5,19,150);
   b62->SetLineColor(38);
-  top->AddNodeOverlap(b62,62,new TGeoCombiTrans(-4,-65,-495,new TGeoRotation("r1",90,90,330)));
+  top->AddNodeOverlap(b62,62,new TGeoCombiTrans(-4,-65,-495,r2));
 //u
   TGeoVolume *b63=geom->MakeBox("b63",Iron,5,15,150);
   b63->SetLineColor(38);
-  top->AddNodeOverlap(b63,63,new TGeoCombiTrans(-4,-40,-497,new TGeoRotation("r1",90,90,0)));
+  top->AddNodeOverlap(b63,63,new TGeoCombiTrans(-4,-40,-497,r1));
 
   TGeoVolume *b64=geom->MakeBox("b64",Iron,5,15,150);
   b64->SetLineColor(38);
-  top->AddNodeOverlap(b64,64,new TGeoCombiTrans(-4,-10,-497,new TGeoRotation("r1",90,90,0)));
+  top->AddNodeOverlap(b64,64,new TGeoCombiTrans(-4,-10,-497,r1));
 
   TGeoVolume *b65=geom->MakeTubs("b65",Iron,7,17,150,0,180);
   b65->SetLineColor(38);
-  top->AddNodeOverlap(b65,65,new TGeoCombiTrans(-4,-25,-490,new TGeoRotation("r1",90,90,0)));
+  top->AddNodeOverlap(b65,65,new TGeoCombiTrans(-4,-25,-490,r1));
 
 
 //D
 
   TGeoVolume *b66=geom->MakeBox("b66",Iron,5,19,150);
   b66->SetLineColor(38);
-  top->AddNodeOverlap(b66,66,new TGeoCombiTrans(-4,10,-495,new TGeoRotation("r1",90,90,0)));
+  top->AddNodeOverlap(b66,66,new TGeoCombiTrans(-4,10,-495,r1));
 
 
   TGeoVolume *b67=geom->MakeTubs("b67",Iron,10,20,150,230,480);
   b67->SetLineColor(38);
-  top->AddNodeOverlap(b67,67,new TGeoCombiTrans(-4,23,-495,new TGeoRotation("r1",90,90,0)));
+  top->AddNodeOverlap(b67,67,new TGeoCombiTrans(-4,23,-495,r1));
 
 //I
 
   TGeoVolume *b68=geom->MakeBox("b68",Iron,5,20,150);
   b68->SetLineColor(38);
-  top->AddNodeOverlap(b68,68,new TGeoCombiTrans(-4,53,-495,new TGeoRotation("r1",90,90,0)));
+  top->AddNodeOverlap(b68,68,new TGeoCombiTrans(-4,53,-495,r1));
 
 //O
 
   TGeoVolume *b69=geom->MakeTubs("b69",Iron,10,22,150,0,360);
   b69->SetLineColor(38);
-  top->AddNodeOverlap(b69,69,new TGeoCombiTrans(-4,85,-495,new TGeoRotation("r1",90,90,0)));
+  top->AddNodeOverlap(b69,69,new TGeoCombiTrans(-4,85,-495,r1));
 
 
 // I
   TGeoVolume *b60=geom->MakeTube("b60",Iron,0,10,150);
   b60->SetLineColor(38);
-  top->AddNodeOverlap(b60,60,new TGeoCombiTrans(-4,-120,-550,new TGeoRotation("r1",90,90,0)));
+  top->AddNodeOverlap(b60,60,new TGeoCombiTrans(-4,-120,-550,r1));
 
 
   TGeoVolume *b70=geom->MakeBox("b70",Iron,2,19,150);
   b70->SetLineColor(38);
-  top->AddNodeOverlap(b70,70,new TGeoCombiTrans(-4,-114,-495,new TGeoRotation("r1",90,90,0)));
+  top->AddNodeOverlap(b70,70,new TGeoCombiTrans(-4,-114,-495,r1));
 
   TGeoVolume *b71=geom->MakeBox("b71",Iron,2,19,150);
   b71->SetLineColor(38);
-  top->AddNodeOverlap(b71,71,new TGeoCombiTrans(-4,-126,-495,new TGeoRotation("r1",90,90,0)));
+  top->AddNodeOverlap(b71,71,new TGeoCombiTrans(-4,-126,-495,r1));
 
 
   TGeoVolume *b72=geom->MakeBox("b72",Iron,8,2,150);
   b72->SetLineColor(38);
-  top->AddNodeOverlap(b72,72,new TGeoCombiTrans(-4,-120,-515,new TGeoRotation("r1",90,90,0)));
+  top->AddNodeOverlap(b72,72,new TGeoCombiTrans(-4,-120,-515,r1));
 
 
   TGeoVolume *b73=geom->MakeBox("b73",Iron,8,2,150);
   b73->SetLineColor(38);
-  top->AddNodeOverlap(b73,73,new TGeoCombiTrans(-4,-120,-475,new TGeoRotation("r1",90,90,0)));
+  top->AddNodeOverlap(b73,73,new TGeoCombiTrans(-4,-120,-475,r1));
 
 
 // button
 
+  auto r0 = nullptr; // new TGeoRotation("r0",0,0,0);
 
   TGeoVolume *b74=geom->MakeBox("b74",Iron,35,250,70);
   b74->SetLineColor(38);
-  top->AddNodeOverlap(b74,74,new TGeoCombiTrans(-25,10,-60,new TGeoRotation("r1",0,0,0)));
+  top->AddNodeOverlap(b74,74,new TGeoCombiTrans(-25,10,-60,r0));
 
   TGeoVolume *b75=geom->MakeBox("b75",Iron,35,250,35);
   b75->SetLineColor(38);
-  top->AddNodeOverlap(b75,75,new TGeoCombiTrans(-25,10,-175,new TGeoRotation("r1",0,0,0)));
+  top->AddNodeOverlap(b75,75,new TGeoCombiTrans(-25,10,-175,r0));
 
 
   TGeoVolume *b76=geom->MakeBox("b76",Iron,35,250,35);
   b76->SetLineColor(38);
-  top->AddNodeOverlap(b76,76,new TGeoCombiTrans(-25,10,55,new TGeoRotation("r1",0,0,0)));
+  top->AddNodeOverlap(b76,76,new TGeoCombiTrans(-25,10,55,r0));
 
 
+  auto r3 = new TGeoRotation("r3",0,90,0);
   TGeoVolume *b77=geom->MakeTubs("b77",Iron,0,70,250,180,270);
   b77->SetLineColor(38);
-  top->AddNodeOverlap(b77,77,new TGeoCombiTrans(10,10,-210,new TGeoRotation("r1",0,90,0)));
+  top->AddNodeOverlap(b77,77,new TGeoCombiTrans(10,10,-210,r3));
 
 
   TGeoVolume *b78=geom->MakeTubs("b78",Iron,0,70,250,90,180);
   b78->SetLineColor(38);
-  top->AddNodeOverlap(b78,78,new TGeoCombiTrans(10,10,90,new TGeoRotation("r1",0,90,0)));
+  top->AddNodeOverlap(b78,78,new TGeoCombiTrans(10,10,90,r3));
 
 
 
@@ -353,201 +353,190 @@ void mp3player()
 
   TGeoVolume *b79=geom->MakeBox("b79",Iron,40,250,150);
   b79->SetLineColor(10);
-  top->AddNodeOverlap(b79,79,new TGeoCombiTrans(60,0,450,new TGeoRotation("r1",0,0,0)));
+  top->AddNodeOverlap(b79,79,new TGeoCombiTrans(60,0,450,r0));
 
   TGeoVolume *b80=geom->MakeTubs("b80",Iron,50,100,250,180,270);
   b80->SetLineColor(10);
-  top->AddNodeOverlap(b80,80,new TGeoCombiTrans(10,0,350,new TGeoRotation("r1",0,90,0)));
-
+  top->AddNodeOverlap(b80,80,new TGeoCombiTrans(10,0,350,r3));
 
   TGeoVolume *b81=geom->MakeTubs("b81",Iron,50,100,250,90,180);
   b81->SetLineColor(10);
-  top->AddNodeOverlap(b81,81,new TGeoCombiTrans(10,0,400,new TGeoRotation("r1",0,90,0)));
-
+  top->AddNodeOverlap(b81,81,new TGeoCombiTrans(10,0,400,r3));
 
   TGeoVolume *b82=geom->MakeBox("b82",Iron,30,250,150);
   b82->SetLineColor(10);
-  top->AddNodeOverlap(b82,82,new TGeoCombiTrans(-70,0,450,new TGeoRotation("r1",0,0,0)));
-
+  top->AddNodeOverlap(b82,82,new TGeoCombiTrans(-70,0,450,r0));
 
   TGeoVolume *b83=geom->MakeBox("b83",Iron,30,250,60);
   b83->SetLineColor(10);
-  top->AddNodeOverlap(b83,83,new TGeoCombiTrans(-20,0,540,new TGeoRotation("r1",0,0,0)));
-
-
-
+  top->AddNodeOverlap(b83,83,new TGeoCombiTrans(-20,0,540,r0));
 
   TGeoVolume *b85=geom->MakeTubs("b85",Iron,0,40,240,180,270);
   b85->SetLineColor(38);
-  top->AddNodeOverlap(b85,85,new TGeoCombiTrans(10,10,370,new TGeoRotation("r1",0,90,0)));
-
-
-
+  top->AddNodeOverlap(b85,85,new TGeoCombiTrans(10,10,370,r3));
 
   TGeoVolume *b84=geom->MakeTubs("b84",Iron,0,40,240,90,180);
   b84->SetLineColor(38);
-  top->AddNodeOverlap(b84,84,new TGeoCombiTrans(10,10,400,new TGeoRotation("r1",0,90,0)));
-
+  top->AddNodeOverlap(b84,84,new TGeoCombiTrans(10,10,400,r3));
 
   TGeoVolume *b86=geom->MakeBox("b86",Iron,20,240,20);
   b86->SetLineColor(38);
-  top->AddNodeOverlap(b86,86,new TGeoCombiTrans(-10,10,380,new TGeoRotation("r1",0,0,0)));
+  top->AddNodeOverlap(b86,86,new TGeoCombiTrans(-10,10,380,r0));
 
 
   TGeoVolume *b87=geom->MakeBox("b87",Iron,20,250,10);
   b87->SetLineColor(35);
-  top->AddNodeOverlap(b87,87,new TGeoCombiTrans(-10,20,385,new TGeoRotation("r1",0,0,0)));
+  top->AddNodeOverlap(b87,87,new TGeoCombiTrans(-10,20,385,r0));
 
 
   TGeoVolume *b88=geom->MakeBox("b88",Iron,100,220,600);
   b88->SetLineColor(10);
-  top->AddNodeOverlap(b88,88,new TGeoCombiTrans(0,-30,0,new TGeoRotation("r1",0,0,0)));
+  top->AddNodeOverlap(b88,88,new TGeoCombiTrans(0,-30,0,r0));
 
 
   TGeoVolume *b89=geom->MakeTube("b89",Iron,25,95,650);
   b89->SetLineColor(10);
-  top->AddNodeOverlap(b89,89,new TGeoCombiTrans(0,-60,0,new TGeoRotation("r1",0,0,0)));
+  top->AddNodeOverlap(b89,89,new TGeoCombiTrans(0,-60,0,r0));
 
   TGeoVolume *b90=geom->MakeTube("b90",Iron,25,95,650);
   b90->SetLineColor(10);
-  top->AddNodeOverlap(b90,90,new TGeoCombiTrans(0,60,0,new TGeoRotation("r1",0,0,0)));
+  top->AddNodeOverlap(b90,90,new TGeoCombiTrans(0,60,0,r0));
 
 
   TGeoVolume *b91=geom->MakeBox("b91",Iron,40,200,650);
   b91->SetLineColor(10);
-  top->AddNodeOverlap(b91,91,new TGeoCombiTrans(70,0,0,new TGeoRotation("r1",0,0,0)));
+  top->AddNodeOverlap(b91,91,new TGeoCombiTrans(70,0,0,r0));
 
   TGeoVolume *b92=geom->MakeBox("b92",Iron,100,50,650);
   b92->SetLineColor(10);
-  top->AddNodeOverlap(b92,92,new TGeoCombiTrans(0,150,0,new TGeoRotation("r1",0,0,0)));
+  top->AddNodeOverlap(b92,92,new TGeoCombiTrans(0,150,0,r0));
 
   TGeoVolume *b93=geom->MakeBox("b93",Iron,100,50,650);
   b93->SetLineColor(10);
-  top->AddNodeOverlap(b93,93,new TGeoCombiTrans(0,-150,0,new TGeoRotation("r1",0,0,0)));
+  top->AddNodeOverlap(b93,93,new TGeoCombiTrans(0,-150,0,r0));
 
 
   TGeoVolume *b94=geom->MakeBox("b94",Iron,40,200,650);
   b94->SetLineColor(10);
-  top->AddNodeOverlap(b94,94,new TGeoCombiTrans(-70,0,0,new TGeoRotation("r1",0,0,0)));
+  top->AddNodeOverlap(b94,94,new TGeoCombiTrans(-70,0,0,r0));
 
 
   TGeoVolume *b95=geom->MakeTube("b95",Iron,25,35,650);
   b95->SetLineColor(1);
-  top->AddNodeOverlap(b95,95,new TGeoCombiTrans(0,-60,-10,new TGeoRotation("r1",0,0,0)));
+  top->AddNodeOverlap(b95,95,new TGeoCombiTrans(0,-60,-10,r0));
 
   TGeoVolume *b96=geom->MakeTube("b96",Iron,25,35,650);
   b96->SetLineColor(1);
-  top->AddNodeOverlap(b96,96,new TGeoCombiTrans(0,60,-10,new TGeoRotation("r1",0,0,0)));
+  top->AddNodeOverlap(b96,96,new TGeoCombiTrans(0,60,-10,r0));
 //usb
 
   TGeoVolume *b97=geom->MakeBox("b97",Iron,70,70,600);
   b97->SetLineColor(17);
-  top->AddNodeOverlap(b97,97,new TGeoCombiTrans(0,0,57,new TGeoRotation("r1",0,0,0)));
+  top->AddNodeOverlap(b97,97,new TGeoCombiTrans(0,0,57,r0));
 
 
   TGeoVolume *b98=geom->MakeTubs("b98",Iron,0,50,600,0,90);
   b98->SetLineColor(17);
-  top->AddNodeOverlap(b98,98,new TGeoCombiTrans(20,60,57,new TGeoRotation("r1",0,0,0)));
+  top->AddNodeOverlap(b98,98,new TGeoCombiTrans(20,60,57,r0));
 
   TGeoVolume *b99=geom->MakeTubs("b99",Iron,0,50,600,180,270);
   b99->SetLineColor(17);
-  top->AddNodeOverlap(b99,99,new TGeoCombiTrans(-20,-60,57,new TGeoRotation("r1",0,0,0)));
+  top->AddNodeOverlap(b99,99,new TGeoCombiTrans(-20,-60,57,r0));
 
 
   TGeoVolume *b100=geom->MakeTubs("b100",Iron,0,50,600,90,180);
   b100->SetLineColor(17);
-  top->AddNodeOverlap(b100,100,new TGeoCombiTrans(-20,60,57,new TGeoRotation("r1",0,0,0)));
+  top->AddNodeOverlap(b100,100,new TGeoCombiTrans(-20,60,57,r0));
 
 
   TGeoVolume *b101=geom->MakeTubs("b101",Iron,0,50,600,270,360);
   b101->SetLineColor(17);
-  top->AddNodeOverlap(b101,101,new TGeoCombiTrans(20,-60,57,new TGeoRotation("r1",0,0,0)));
+  top->AddNodeOverlap(b101,101,new TGeoCombiTrans(20,-60,57,r0));
 
   TGeoVolume *b102=geom->MakeBox("b102",Iron,20,110,600);
   b102->SetLineColor(17);
-  top->AddNodeOverlap(b102,102,new TGeoCombiTrans(0,0,57,new TGeoRotation("r1",0,0,0)));
+  top->AddNodeOverlap(b102,102,new TGeoCombiTrans(0,0,57,r0));
 
 
   TGeoVolume *b103=geom->MakeBox("b103",Iron,15,200,600);
   b103->SetLineColor(37);
-  top->AddNodeOverlap(b103,103,new TGeoCombiTrans(25,0,57,new TGeoRotation("r1",0,0,0)));
+  top->AddNodeOverlap(b103,103,new TGeoCombiTrans(25,0,57,r0));
 //AddNode
   top->AddNodeOverlap(b1,1,new TGeoTranslation(0,0,0));
-  top->AddNodeOverlap(b2,2,new TGeoCombiTrans(100,0,600,new TGeoRotation("r1",0,90,0)));
-  top->AddNodeOverlap(b3,3,new TGeoCombiTrans(-100,0,600,new TGeoRotation("r1",0,90,0)));
-  top->AddNodeOverlap(b4,4,new TGeoCombiTrans(-100,0,-600,new TGeoRotation("r1",0,90,0)));
-  top->AddNodeOverlap(b5,5,new TGeoCombiTrans(100,0,-600,new TGeoRotation("r1",0,90,0)));
-  top->AddNodeOverlap(b6,6,new TGeoCombiTrans(100,200,0,new TGeoRotation("r1",0,0,0)));
-  top->AddNodeOverlap(b7,7,new TGeoCombiTrans(-100,200,0,new TGeoRotation("r1",0,0,0)));
-  top->AddNodeOverlap(b8,8,new TGeoCombiTrans(-100,-200,0,new TGeoRotation("r1",0,0,0)));
-  top->AddNodeOverlap(b9,9,new TGeoCombiTrans(100,-200,0,new TGeoRotation("r1",0,0,0)));
+  top->AddNodeOverlap(b2,2,new TGeoCombiTrans(100,0,600,r3));
+  top->AddNodeOverlap(b3,3,new TGeoCombiTrans(-100,0,600,r3));
+  top->AddNodeOverlap(b4,4,new TGeoCombiTrans(-100,0,-600,r3));
+  top->AddNodeOverlap(b5,5,new TGeoCombiTrans(100,0,-600,r3));
+  top->AddNodeOverlap(b6,6,new TGeoCombiTrans(100,200,0,r0));
+  top->AddNodeOverlap(b7,7,new TGeoCombiTrans(-100,200,0,r0));
+  top->AddNodeOverlap(b8,8,new TGeoCombiTrans(-100,-200,0,r0));
+  top->AddNodeOverlap(b9,9,new TGeoCombiTrans(100,-200,0,r0));
 
-  top->AddNodeOverlap(b10,10,new TGeoCombiTrans(0,200,600,new TGeoRotation("r2",90,90,0)));
-  top->AddNodeOverlap(b11,11,new TGeoCombiTrans(0,-200,600,new TGeoRotation("r2",90,90,0)));
-  top->AddNodeOverlap(b12,12,new TGeoCombiTrans(0,-200,-600, new TGeoRotation("r2",90,90,0)));
-  top->AddNodeOverlap(b13,13,new TGeoCombiTrans(0,200,-600,new TGeoRotation("r2",90,90,0)));
+  top->AddNodeOverlap(b10,10,new TGeoCombiTrans(0,200,600,r1));
+  top->AddNodeOverlap(b11,11,new TGeoCombiTrans(0,-200,600,r1));
+  top->AddNodeOverlap(b12,12,new TGeoCombiTrans(0,-200,-600, r1));
+  top->AddNodeOverlap(b13,13,new TGeoCombiTrans(0,200,-600,r1));
   top->AddNodeOverlap(b14,14,new TGeoTranslation(0,200,-150));
   top->AddNodeOverlap(b15,15,new TGeoTranslation(100,0,0));
 
-  top->AddNodeOverlap(b16,16,new TGeoCombiTrans(100,200,600,new TGeoRotation("r2",0,0,0)));
-  top->AddNodeOverlap(b17,17,new TGeoCombiTrans(100,-200,600,new TGeoRotation("r2",0,0,0)));
-  top->AddNodeOverlap(b18,18,new TGeoCombiTrans(-100,-200,600,new TGeoRotation("r2",0,0,0)));
-  top->AddNodeOverlap(b19,19,new TGeoCombiTrans(-100,200,600,new TGeoRotation("r2",0,0,0)));
-  top->AddNodeOverlap(b20,20,new TGeoCombiTrans(-3,0,350,new TGeoRotation("r2",90,90,0)));
-  top->AddNodeOverlap(b21,21,new TGeoCombiTrans(100,200,-600,new TGeoRotation("r2",0,0,0)));
-  top->AddNodeOverlap(b22,22,new TGeoCombiTrans(100,-200,-600,new TGeoRotation("r2",0,0,0)));
-  top->AddNodeOverlap(b23,23,new TGeoCombiTrans(-100,-200,-600,new TGeoRotation("r2",0,0,0)));
-  top->AddNodeOverlap(b24,24,new TGeoCombiTrans(-100,200,-600,new TGeoRotation("r2",0,0,0)));
+  top->AddNodeOverlap(b16,16,new TGeoCombiTrans(100,200,600,r0));
+  top->AddNodeOverlap(b17,17,new TGeoCombiTrans(100,-200,600,r0));
+  top->AddNodeOverlap(b18,18,new TGeoCombiTrans(-100,-200,600,r0));
+  top->AddNodeOverlap(b19,19,new TGeoCombiTrans(-100,200,600,r0));
+  top->AddNodeOverlap(b20,20,new TGeoCombiTrans(-3,0,350,r1));
+  top->AddNodeOverlap(b21,21,new TGeoCombiTrans(100,200,-600,r0));
+  top->AddNodeOverlap(b22,22,new TGeoCombiTrans(100,-200,-600,r0));
+  top->AddNodeOverlap(b23,23,new TGeoCombiTrans(-100,-200,-600,r0));
+  top->AddNodeOverlap(b24,24,new TGeoCombiTrans(-100,200,-600,r0));
 
 
 
-  top->AddNodeOverlap(b25,25,new TGeoCombiTrans(-9,0,350,new TGeoRotation("r2",90,90,0)));
-  top->AddNodeOverlap(b26,26,new TGeoCombiTrans(-9,0,350,new TGeoRotation("r2",90,90,0)));
-  top->AddNodeOverlap(b27,27,new TGeoCombiTrans(-9,0,350,new TGeoRotation("r2",90,90,0)));
-  top->AddNodeOverlap(b28,28,new TGeoCombiTrans(-9,0,350,new TGeoRotation("r2",90,90,0)));
-  top->AddNodeOverlap(b29,29,new TGeoCombiTrans(-9,0,350,new TGeoRotation("r2",90,90,0)));
-  top->AddNodeOverlap(b30,30,new TGeoCombiTrans(-9,0,350,new TGeoRotation("r2",90,90,0)));
-  top->AddNodeOverlap(b31,31,new TGeoCombiTrans(-9,0,350,new TGeoRotation("r2",90,90,0)));
-  top->AddNodeOverlap(b32,32,new TGeoCombiTrans(-9,0,350,new TGeoRotation("r2",90,90,0)));
-  top->AddNodeOverlap(b33,33,new TGeoCombiTrans(-9,0,350,new TGeoRotation("r2",90,90,0)));
-  top->AddNodeOverlap(b34,34,new TGeoCombiTrans(-9,0,350,new TGeoRotation("r2",90,90,0)));
-  top->AddNodeOverlap(b35,35,new TGeoCombiTrans(-9,0,350,new TGeoRotation("r2",90,90,0)));
-  top->AddNodeOverlap(b36,36,new TGeoCombiTrans(-9,0,350,new TGeoRotation("r2",90,90,0)));
-  top->AddNodeOverlap(b37,37,new TGeoCombiTrans(-9,0,350,new TGeoRotation("r2",90,90,0)));
-  top->AddNodeOverlap(b38,38,new TGeoCombiTrans(-9,0,350,new TGeoRotation("r2",90,90,0)));
-  top->AddNodeOverlap(b39,39,new TGeoCombiTrans(-9,0,350,new TGeoRotation("r2",90,90,0)));
-  top->AddNodeOverlap(b40,40,new TGeoCombiTrans(-9,0,350,new TGeoRotation("r2",90,90,0)));
-  top->AddNodeOverlap(b41,41,new TGeoCombiTrans(-9,0,350,new TGeoRotation("r2",90,90,0)));
-  top->AddNodeOverlap(b42,42,new TGeoCombiTrans(-9,0,350,new TGeoRotation("r2",90,90,0)));
-  top->AddNodeOverlap(b43,43,new TGeoCombiTrans(-9,0,350,new TGeoRotation("r2",90,90,0)));
-  top->AddNodeOverlap(b44,44,new TGeoCombiTrans(-9,0,350,new TGeoRotation("r2",90,90,0)));
+  top->AddNodeOverlap(b25,25,new TGeoCombiTrans(-9,0,350,r1));
+  top->AddNodeOverlap(b26,26,new TGeoCombiTrans(-9,0,350,r1));
+  top->AddNodeOverlap(b27,27,new TGeoCombiTrans(-9,0,350,r1));
+  top->AddNodeOverlap(b28,28,new TGeoCombiTrans(-9,0,350,r1));
+  top->AddNodeOverlap(b29,29,new TGeoCombiTrans(-9,0,350,r1));
+  top->AddNodeOverlap(b30,30,new TGeoCombiTrans(-9,0,350,r1));
+  top->AddNodeOverlap(b31,31,new TGeoCombiTrans(-9,0,350,r1));
+  top->AddNodeOverlap(b32,32,new TGeoCombiTrans(-9,0,350,r1));
+  top->AddNodeOverlap(b33,33,new TGeoCombiTrans(-9,0,350,r1));
+  top->AddNodeOverlap(b34,34,new TGeoCombiTrans(-9,0,350,r1));
+  top->AddNodeOverlap(b35,35,new TGeoCombiTrans(-9,0,350,r1));
+  top->AddNodeOverlap(b36,36,new TGeoCombiTrans(-9,0,350,r1));
+  top->AddNodeOverlap(b37,37,new TGeoCombiTrans(-9,0,350,r1));
+  top->AddNodeOverlap(b38,38,new TGeoCombiTrans(-9,0,350,r1));
+  top->AddNodeOverlap(b39,39,new TGeoCombiTrans(-9,0,350,r1));
+  top->AddNodeOverlap(b40,40,new TGeoCombiTrans(-9,0,350,r1));
+  top->AddNodeOverlap(b41,41,new TGeoCombiTrans(-9,0,350,r1));
+  top->AddNodeOverlap(b42,42,new TGeoCombiTrans(-9,0,350,r1));
+  top->AddNodeOverlap(b43,43,new TGeoCombiTrans(-9,0,350,r1));
+  top->AddNodeOverlap(b44,44,new TGeoCombiTrans(-9,0,350,r1));
 
 
-  top->AddNodeOverlap(b45,45,new TGeoCombiTrans(-20,0,350,new TGeoRotation("r2",90,90,0)));
-  top->AddNodeOverlap(b46,46,new TGeoCombiTrans(-25,0,350,new TGeoRotation("r2",90,90,0)));
+  top->AddNodeOverlap(b45,45,new TGeoCombiTrans(-20,0,350,r1));
+  top->AddNodeOverlap(b46,46,new TGeoCombiTrans(-25,0,350,r1));
 
   top->AddNodeOverlap(b47,47,new TGeoTranslation(5,0,85));
   top->AddNodeOverlap(b48,48,new TGeoTranslation(-2,0,-150));
   geom->CloseGeometry();
 
 
-
   TCanvas *can=new TCanvas("can","My virtual laboratory",800,800);
 
 
-//Mp3
-   TPad *pad=new TPad("pad","Pad",0,0.5,0.5,1);
-   pad->SetFillColor(1);
-   pad->Draw();
-   pad->cd();
-  top->Draw();
-//Sound
+  //Mp3
+   TPad *pad1 = new TPad("pad1","Pad1",0,0.5,0.5,1);
+   pad1->SetFillColor(1);
+   pad1->Draw();
+   pad1->cd();
+   top->Draw();
+
+   //Sound
    can->cd();
    TPad *pad2=new TPad("pad2","Pad2",0.5,0.5,1,1);
    pad2->SetFillColor(10);
    pad2->Draw();
    pad2->cd();
-
 
    TPaveText *pt = new TPaveText(0.4,0.90,0.6,0.95,"br");
    pt->SetFillColor(30);
@@ -587,33 +576,30 @@ void mp3player()
    Tex.SetTextSize(0.04);
    Tex.SetTextColor(15);
    Tex.DrawLatex(0.2,0.11,"Click Button!! You Can Listen to Musics");
-   TButton *but1=new TButton("","Sound(1)",0.2,0.8,0.25,0.85);
+   TButton *but1=new TButton("","gSystem->Exec(\"cat sound1.wav > /dev/audio\")",0.2,0.8,0.25,0.85);
    but1->Draw();
    but1->SetFillColor(29);
-   TButton *but2=new TButton("","Sound(2)",0.2,0.7,0.25,.75);
+   TButton *but2=new TButton("","gSystem->Exec(\"cat sound2.wav > /dev/audio\")",0.2,0.7,0.25,.75);
    but2->Draw();
    but2->SetFillColor(29);
-   TButton *but3=new TButton("","Sound(3)",0.2,0.6,0.25,0.65);
+   TButton *but3=new TButton("","gSystem->Exec(\"cat sound3.wav > /dev/audio\")",0.2,0.6,0.25,0.65);
    but3->Draw();
    but3->SetFillColor(29);
-   TButton *but4=new TButton("","Sound(4)",0.2,0.5,0.25,0.55);
+   TButton *but4=new TButton("","gSystem->Exec(\"cat sound4.wav > /dev/audio\")",0.2,0.5,0.25,0.55);
    but4->Draw();
    but4->SetFillColor(29);
-   TButton *but5=new TButton("","Sound(5)",0.2,0.4,0.25,0.45);
+   TButton *but5=new TButton("","gSystem->Exec(\"cat sound5.wav > /dev/audio\")",0.2,0.4,0.25,0.45);
    but5->Draw();
    but5->SetFillColor(29);
-   TButton *but6=new TButton("","Sound(6)",0.2,0.3,0.25,0.35);
+   TButton *but6=new TButton("","gSystem->Exec(\"cat sound6.wav > /dev/audio\")",0.2,0.3,0.25,0.35);
    but6->Draw();
    but6->SetFillColor(29);
-   TButton *but7=new TButton("","Sound(7)",0.2,0.2,0.25,0.25);
+   TButton *but7=new TButton("","gSystem->Exec(\"cat sound7.wav > /dev/audio\")",0.2,0.2,0.25,0.25);
    but7->Draw();
    but7->SetFillColor(29);
 
-   pad->cd();
-
-//introduction
+   //introduction
    can->cd();
-
    TPad *pad3=new TPad("pad3","Pad3",0,0,1,0.5);
    pad3->SetFillColor(10);
    pad3->Draw();
@@ -622,20 +608,16 @@ void mp3player()
    //TImage *image=TImage::Open("mp3.jpg");
    //image->Draw();
 
-
-
    TPad *pad4=new TPad("pad4","Pad4",0.6,0.1,0.9,0.9);
    pad4->SetFillColor(1);
    pad4->Draw();
    pad4->cd();
-
 
    TLine L;
 
    Tex.SetTextSize(0.08);
    Tex.SetTextColor(10);
    Tex.DrawLatex(0.06,0.85,"IAudio U3 Mp3 Player");
-
 
    L.SetLineColor(10);
    L.SetLineWidth(3);
@@ -670,15 +652,5 @@ void mp3player()
    Tex.DrawLatex(0.06,0.15,"+ The Best Quality of Sound");
 
 
-   pad->cd();
-
-
-
-}
-
-void Sound(int i)
-{
-   char sound[128];
-   sprintf(sound,"cat sound%d.wav > /dev/audio",i);
-   gSystem->Exec(sound);
+   pad1->cd();
 }


### PR DESCRIPTION
After introducing cling it is not allowed to redefine already existing variables in the macro.
Therefore one always should use unique names.
Also type of created variable always should be specified - at least `auto`.
Now one can store geometry which is defined in `tutorials/geom/mp3player.C` macro together with all other components.

Adjust `tutorials/geom/mp3player.C` macro to avoid many duplicated transformation objects - it is enough to have few of them.

Do not use canvas with spaces in names in `tutorials/geom/geodemo.C`


