### PR TITLE
[RF] Enable setting max minimizer iterations and calls in `fitTo()`

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabspdf.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabspdf.py
@@ -15,6 +15,31 @@ from ._rooabsreal import RooAbsReal
 from ._utils import _kwargs_to_roocmdargs, cpp_signature
 
 
+def _pack_cmd_args(*args, **kwargs):
+    # Pack command arguments passed into a RooLinkedList.
+
+    import ROOT
+
+    # If the second argument is already a RooLinkedList, do nothing
+    if len(kwargs) == 0 and len(args) == 1 and isinstance(args[0], ROOT.RooLinkedList):
+        return args[0]
+
+    # Transform keyword arguments to RooCmdArgs
+    args, kwargs = _kwargs_to_roocmdargs(*args, **kwargs)
+
+    # All keyword arguments should be transformed now
+    assert len(kwargs) == 0
+
+    # Put RooCmdArgs in a RooLinkedList
+    cmdList = ROOT.RooLinkedList()
+    for cmd in args:
+        if not isinstance(cmd, ROOT.RooCmdArg):
+            raise TypeError("This function only takes RooFit command arguments.")
+        cmdList.Add(cmd)
+
+    return cmdList
+
+
 class RooAbsPdf(RooAbsReal):
     r"""Some member functions of RooAbsPdf that take a RooCmdArg as argument also support keyword arguments.
     So far, this applies to RooAbsPdf::fitTo, RooAbsPdf::plotOn, RooAbsPdf::generate, RooAbsPdf::paramOn, RooAbsPdf::createCdf,
@@ -28,16 +53,13 @@ class RooAbsPdf(RooAbsReal):
     pdf.fitTo(data, Range="r1")
     \endcode"""
 
-    @cpp_signature(
-        "RooAbsPdf::fitTo(RooAbsData&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&)"
-    )
+    @cpp_signature("RooAbsPdf::fitTo(RooAbsData&, const RooLinkedList&) ;")
     def fitTo(self, *args, **kwargs):
         r"""The RooAbsPdf::fitTo() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
         # Redefinition of `RooAbsPdf.fitTo` for keyword arguments.
-        args, kwargs = _kwargs_to_roocmdargs(*args, **kwargs)
-        return self._fitTo(*args, **kwargs)
+        return self._fitTo(args[0], _pack_cmd_args(*args[1:], **kwargs))
 
     @cpp_signature(
         "RooPlot *RooAbsPdf::plotOn(RooPlot* frame,"
@@ -85,18 +107,13 @@ class RooAbsPdf(RooAbsReal):
         args, kwargs = _kwargs_to_roocmdargs(*args, **kwargs)
         return self._paramOn(*args, **kwargs)
 
-    @cpp_signature(
-        "RooAbsReal *RooAbsPdf::createNLL(RooAbsData& data, const RooCmdArg& arg1=RooCmdArg::none(),  const RooCmdArg& arg2=RooCmdArg::none(),"
-        "    const RooCmdArg& arg3=RooCmdArg::none(),  const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(),"
-        "    const RooCmdArg& arg6=RooCmdArg::none(),  const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;"
-    )
+    @cpp_signature("RooAbsPdf::createNLL(RooAbsData&, const RooLinkedList&) ;")
     def createNLL(self, *args, **kwargs):
         r"""The RooAbsPdf::createNLL() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
         # Redefinition of `RooAbsPdf.createNLL` for keyword arguments.
-        args, kwargs = _kwargs_to_roocmdargs(*args, **kwargs)
-        return self._createNLL(*args, **kwargs)
+        return self._createNLL(args[0], _pack_cmd_args(*args[1:], **kwargs))
 
     @cpp_signature(
         "RooAbsReal *RooAbsPdf::createChi2(RooDataHist& data, const RooCmdArg& arg1=RooCmdArg::none(),  const RooCmdArg& arg2=RooCmdArg::none(),"

--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -18,7 +18,7 @@
 
 #include "RooAbsReal.h"
 #include "RooObjCacheManager.h"
-#include "RooCmdArg.h"
+#include "RooGlobalFunc.h"
 #include "RooFit/UniqueId.h"
 
 class RooDataSet;
@@ -32,7 +32,6 @@ class TPaveText;
 class TH1F;
 class TH2F;
 class TList ;
-class RooLinkedList ;
 class RooMinimizer ;
 class RooNumGenConfig ;
 class RooRealIntegral ;
@@ -161,10 +160,14 @@ public:
   void setGeneratorConfig(const RooNumGenConfig& config) ;
 
   // -log(L) fits to binned and unbinned data
-  virtual RooFitResult* fitTo(RooAbsData& data, const RooCmdArg& arg1=RooCmdArg::none(),  const RooCmdArg& arg2=RooCmdArg::none(),
-                              const RooCmdArg& arg3=RooCmdArg::none(),  const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(),
-                              const RooCmdArg& arg6=RooCmdArg::none(),  const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;
-  virtual RooFitResult* fitTo(RooAbsData& data, const RooLinkedList& cmdList) ;
+  virtual RooFitResult* fitTo(RooAbsData& data, const RooLinkedList& cmdList={}) ;
+  /// Takes an arbitrary number of RooCmdArg command options and calls
+  /// RooAbsPdf::fitTo(RooAbsData& data, const RooLinkedList& cmdList).
+  template <typename... Args>
+  RooFitResult* fitTo(RooAbsData& data, RooCmdArg const& arg1, Args const&... args)
+  {
+    return fitTo(data, *RooFit::Detail::createCmdList(&arg1, &args...));
+  }
 
   /// Configuration struct for RooAbsPdf::minimizeNLL with all the default
   //values that also should be taked as the default values for
@@ -195,10 +198,14 @@ public:
   };
   std::unique_ptr<RooFitResult> minimizeNLL(RooAbsReal & nll, RooAbsData const& data, MinimizerConfig const& cfg);
 
-  virtual RooAbsReal* createNLL(RooAbsData& data, const RooLinkedList& cmdList) ;
-  virtual RooAbsReal* createNLL(RooAbsData& data, const RooCmdArg& arg1=RooCmdArg::none(),  const RooCmdArg& arg2=RooCmdArg::none(),
-            const RooCmdArg& arg3=RooCmdArg::none(),  const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(),
-            const RooCmdArg& arg6=RooCmdArg::none(),  const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;
+  virtual RooAbsReal* createNLL(RooAbsData& data, const RooLinkedList& cmdList={}) ;
+  /// Takes an arbitrary number of RooCmdArg command options and calls
+  /// RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList).
+  template <typename... Args>
+  RooAbsReal* createNLL(RooAbsData& data, RooCmdArg const& arg1, Args const&... args)
+  {
+    return createNLL(data, *RooFit::Detail::createCmdList(&arg1, &args...));
+  }
 
   // Chi^2 fits to histograms
   using RooAbsReal::chi2FitTo ;

--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -185,6 +185,7 @@ public:
       int doWarn = 1;
       int doSumW2 = -1;
       int doAsymptotic = -1;
+      int maxCalls = -1;
       int nWorkers = 1;
       bool parallelGradient = false;
       bool parallelLikelihood = false;

--- a/roofit/roofitcore/inc/RooGlobalFunc.h
+++ b/roofit/roofitcore/inc/RooGlobalFunc.h
@@ -255,6 +255,7 @@ RooCmdArg Minos(const RooArgSet& minosArgs) ;
 RooCmdArg SplitRange(bool flag=true) ;
 RooCmdArg SumCoefRange(const char* rangeName) ;
 RooCmdArg Constrain(const RooArgSet& params) ;
+RooCmdArg MaxCalls(int n) ;
 
 template<class... Args_t>
 RooCmdArg GlobalObservables(Args_t &&... argsOrArgSet) {

--- a/roofit/roofitcore/inc/RooGlobalFunc.h
+++ b/roofit/roofitcore/inc/RooGlobalFunc.h
@@ -17,6 +17,7 @@
 #define ROO_GLOBAL_FUNC
 
 #include "RooCmdArg.h"
+#include "RooLinkedList.h"
 #include "RooArgSet.h"
 
 #include "ROOT/RConfig.hxx"
@@ -395,7 +396,24 @@ RooConstVar& RooConst(double val) ;
 /**
  * @}
  */
+
+namespace Detail {
+
+// Function to pack an arbitrary number of RooCmdArgs into a RooLinkedList. Implementation detail of many high-level RooFit functions.
+template <typename... Args>
+inline std::unique_ptr<RooLinkedList> createCmdList(Args &&... args)
+{
+  auto cmdList = std::make_unique<RooLinkedList>();
+  for (auto * arg : {args...}) {
+    cmdList->Add(const_cast<RooCmdArg*>(arg));
+    //cmdList->Add(new RooCmdArg{arg});
+  }
+  return cmdList;
 }
+
+} // namespace Detail
+
+} // namespace RooFit
 
 namespace RooFitShortHand {
 

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1440,6 +1440,7 @@ int RooAbsPdf::calcSumW2CorrectedCovariance(RooMinimizer &minimizer, RooAbsReal 
 /// <tr><td> `Minos(const RooArgSet& set)`     <td>  Only run MINOS on given subset of arguments
 /// <tr><td> `Save(bool flag)`               <td>  Flag controls if RooFitResult object is produced and returned, off by default
 /// <tr><td> `Strategy(Int_t flag)`            <td>  Set Minuit strategy (0 to 2, default is 1)
+/// <tr><td> `MaxCalls(int n)`              <td> Change maximum number of likelihood function calss from MINUIT (if `n <= 0`, the default of 500 * #%parameters is used)
 /// <tr><td> `EvalErrorWall(bool flag=true)`    <td>  When parameters are in disallowed regions (e.g. PDF is negative), return very high value to fitter
 ///                                                  to force it out of that region. This can, however, mean that the fitter gets lost in this region. If
 ///                                                  this happens, try switching it off.
@@ -1567,6 +1568,7 @@ std::unique_ptr<RooFitResult> RooAbsPdf::minimizeNLL(RooAbsReal & nll,
   m.setEvalErrorWall(cfg.doEEWall);
   m.setRecoverFromNaNStrength(cfg.recoverFromNaN);
   m.setPrintEvalErrors(cfg.numee);
+  if (cfg.maxCalls > 0) m.setMaxFunctionCalls(cfg.maxCalls);
   if (cfg.printLevel!=1) m.setPrintLevel(cfg.printLevel);
   if (cfg.optConst) m.optimizeConst(cfg.optConst); // Activate constant term optimization
   if (cfg.verbose) m.setVerbose(1); // Activate verbose options
@@ -1640,6 +1642,7 @@ RooFitResult* RooAbsPdf::fitTo(RooAbsData& data, const RooLinkedList& cmdList)
   pc.defineInt("doWarn","Warnings",0,minimizerDefaults.doWarn) ;
   pc.defineInt("doSumW2","SumW2Error",0,minimizerDefaults.doSumW2) ;
   pc.defineInt("doAsymptoticError","AsymptoticError",0,minimizerDefaults.doAsymptotic) ;
+  pc.defineInt("maxCalls","MaxCalls",0,minimizerDefaults.maxCalls);
   pc.defineInt("doOffset","OffsetLikelihood",0,0) ;
   pc.defineInt("nWorkers", "Parallelize", 0, 0); // Three parallelize arguments
   pc.defineInt("parallelGradient", "Parallelize", 1, 0);
@@ -1732,6 +1735,7 @@ RooFitResult* RooAbsPdf::fitTo(RooAbsData& data, const RooLinkedList& cmdList)
   cfg.doWarn = pc.getInt("doWarn");
   cfg.doSumW2 = pc.getInt("doSumW2");
   cfg.doAsymptotic = pc.getInt("doAsymptoticError");
+  cfg.maxCalls = pc.getInt("maxCalls");
   cfg.minosSet = pc.getSet("minosSet");
   cfg.minType = pc.getString("mintype","");
   cfg.minAlg = pc.getString("minalg","minuit");

--- a/roofit/roofitcore/src/RooGlobalFunc.cxx
+++ b/roofit/roofitcore/src/RooGlobalFunc.cxx
@@ -236,6 +236,7 @@ namespace RooFit {
   RooCmdArg Save(bool flag)            { return RooCmdArg("Save",flag) ; }
   RooCmdArg Timer(bool flag)           { return RooCmdArg("Timer",flag) ; }
   RooCmdArg PrintLevel(Int_t level)      { return RooCmdArg("PrintLevel",level) ; }
+  RooCmdArg MaxCalls(int n)            { return RooCmdArg("MaxCalls",n) ; }
   RooCmdArg Warnings(bool flag)        { return RooCmdArg("Warnings",flag) ; }
   RooCmdArg Strategy(Int_t code)         { return RooCmdArg("Strategy",code) ; }
   RooCmdArg InitialHesse(bool flag)    { return RooCmdArg("InitialHesse",flag) ; }


### PR DESCRIPTION
Closes https://github.com/root-project/root/issues/11875.

As the number of command arguments for fitTo and createNLL is very large by now, their signatures were changed to take an arbitrary number of command arguments via variadic templates.

