### PR TITLE
[RF] Make old test statistic classes transient with `ClassDef(0)`

### DIFF
--- a/roofit/roofitcore/inc/RooAbsOptTestStatistic.h
+++ b/roofit/roofitcore/inc/RooAbsOptTestStatistic.h
@@ -91,7 +91,7 @@ protected:
   bool      _optimized ; ///<!
   double      _integrateBinsPrecision{-1.}; // Precision for finer sampling of bins.
 
-  ClassDefOverride(RooAbsOptTestStatistic,5) // Abstract base class for optimized test statistics
+  ClassDefOverride(RooAbsOptTestStatistic,0) // Abstract base class for optimized test statistics
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooAbsTestStatistic.h
+++ b/roofit/roofitcore/inc/RooAbsTestStatistic.h
@@ -157,7 +157,7 @@ protected:
   mutable ROOT::Math::KahanSum<double> _offset = 0.0; ///<! Offset as KahanSum to avoid loss of precision
   mutable double _evalCarry = 0.0;                  ///<! carry of Kahan sum in evaluatePartition
 
-  ClassDefOverride(RooAbsTestStatistic,4) // Abstract base class for real-valued test statistics
+  ClassDefOverride(RooAbsTestStatistic,0) // Abstract base class for real-valued test statistics
 
 };
 

--- a/roofit/roofitcore/inc/RooChi2Var.h
+++ b/roofit/roofitcore/inc/RooChi2Var.h
@@ -69,7 +69,7 @@ protected:
   RooDataHist::ErrorType _etype ;     ///< Error type store in associated RooDataHist
   FuncMode _funcMode ;                ///< Function, P.d.f. or extended p.d.f?
 
-  ClassDefOverride(RooChi2Var,1) // Chi^2 function of p.d.f w.r.t a binned dataset
+  ClassDefOverride(RooChi2Var,0) // Chi^2 function of p.d.f w.r.t a binned dataset
 };
 
 

--- a/roofit/roofitcore/inc/RooDataWeightedAverage.h
+++ b/roofit/roofitcore/inc/RooDataWeightedAverage.h
@@ -51,7 +51,7 @@ protected:
   bool _showProgress ; ///< Show progress indication during evaluation if true
   double evaluatePartition(std::size_t firstEvent, std::size_t lastEvent, std::size_t stepSize) const override ;
 
-  ClassDefOverride(RooDataWeightedAverage,1) // Optimized calculator of data weighted average of a RooAbsReal
+  ClassDefOverride(RooDataWeightedAverage,0) // Optimized calculator of data weighted average of a RooAbsReal
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooNLLVar.h
+++ b/roofit/roofitcore/inc/RooNLLVar.h
@@ -92,7 +92,7 @@ private:
   mutable RooRealSumPdf* _binnedPdf{nullptr}; ///<!
   mutable std::unique_ptr<RooBatchCompute::RunContext> _evalData; ///<! Struct to store function evaluation workspaces.
 
-  ClassDefOverride(RooNLLVar,3) // Function representing (extended) -log(L) of p.d.f and dataset
+  ClassDefOverride(RooNLLVar,0) // Function representing (extended) -log(L) of p.d.f and dataset
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooXYChi2Var.h
+++ b/roofit/roofitcore/inc/RooXYChi2Var.h
@@ -83,7 +83,7 @@ protected:
   RooAbsReal*       _funcInt = nullptr; ///<! Function integral
   std::list<RooAbsBinning*> _binList ; ///<! Bin ranges
 
-  ClassDefOverride(RooXYChi2Var,1) // Chi^2 function of p.d.f w.r.t a unbinned dataset with X and Y values
+  ClassDefOverride(RooXYChi2Var,0) // Chi^2 function of p.d.f w.r.t a unbinned dataset with X and Y values
 };
 
 


### PR DESCRIPTION
The IO for the tests statistics never worked anyway, not even for a simple Gaussian likelihood. It is better to exclude the old test statistics classes complete from IO. Like this, the users don't even attempt to do IO with them, and to developers it's clear that IO backwards compatibility is not necessary, taking away some maintenance burden.

Here are some simple scripts to show that storing test statistics doesn't work anyway.

Create a NLL object, write it of file and minimize it:
```c++
void write()
{
   using namespace RooFit;

   RooRealVar x("x", "x", -10, 10);
   RooRealVar mean("mean", "mean of gaussian", 1, -10, 10);
   RooRealVar sigma("sigma", "width of gaussian", 1, 0.1, 10);

   RooGaussian gauss("gauss", "gaussian PDF", x, mean, sigma);

   auto *data = gauss.generateBinned(x, 10000);

   auto nll = gauss.createNLL(*data);

   RooWorkspace ws("ws");
   ws.import(*nll);

   ws.Print();

   ws.writeToFile("ws.root");

    RooMinimizer m{*nll};
    m.setPrintLevel(-1);
    m.minimize("Minuit", "migrad");
    auto res = m.save();

    res->Print();
}
```

Attempt to read the NLL and minimize it again:
```c++
void open() {

    auto f = TFile::Open("ws.root");

    auto ws = f->Get<RooWorkspace>("ws");

    ws->Print();

    ws->function("nll_gauss_genData")->Print();

    auto nll = static_cast<RooNLLVar*>(ws->function("nll_gauss_genData"));

    auto& pdf = nll->function();
    auto& data = nll->data();

    RooMinimizer m{*nll};
    m.setPrintLevel(-1);
    m.minimize("Minuit", "migrad");
    auto res = m.save();

    res->Print();
}
```

The result is completely off this time. It was also confirmed with Wouter in one of the RooFit meetings that IO of the old test statistics never really worked and was also not intended to be done.