### PR TITLE
[RF] Disable the BatchMode usage in RooBinIntegrator for now

### DIFF
--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -236,8 +236,6 @@ public:
   double getValV(const RooArgSet* set=nullptr) const override ;
   virtual double getLogVal(const RooArgSet* set=nullptr) const ;
 
-  RooSpan<const double> getValues(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const override;
-  using RooAbsReal::getValues;
   RooSpan<const double> getLogValBatch(std::size_t begin, std::size_t batchSize,
       const RooArgSet* normSet = nullptr) const;
   RooSpan<const double> getLogProbabilities(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet = nullptr) const;

--- a/roofit/roofitcore/inc/RooBinIntegrator.h
+++ b/roofit/roofitcore/inc/RooBinIntegrator.h
@@ -31,7 +31,7 @@ public:
   // Constructors, assignment etc
   RooBinIntegrator() ;
 
-  RooBinIntegrator(const RooAbsFunc& function) ;
+  RooBinIntegrator(const RooAbsFunc& function, int numBins=100) ;
   RooBinIntegrator(const RooAbsFunc& function, const RooNumIntConfig& config) ;
 
   RooAbsIntegrator* clone(const RooAbsFunc& function, const RooNumIntConfig& config) const override ;

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -427,32 +427,6 @@ double RooAbsPdf::getValV(const RooArgSet* nset) const
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Compute batch of values for given input data, and normalise by integrating over
-/// the observables in `normSet`. Store result in `evalData`, and return a span pointing to
-/// it.
-/// This uses evaluateSpan() to perform an (unnormalised) computation of data points. This computation
-/// is finalised by normalising the bare values, and by checking for computation errors.
-/// Derived classes should override evaluateSpan() to reach maximal performance.
-///
-/// \param[in,out] evalData Object holding data that should be used in computations. Results are also stored here.
-/// \param[in] normSet      If not nullptr, normalise results by integrating over
-/// the variables in this set. The normalisation is only computed once, and applied
-/// to the full batch.
-/// \return RooSpan with probabilities. The memory of this span is owned by `evalData`.
-/// \see RooAbsReal::getValues().
-RooSpan<const double> RooAbsPdf::getValues(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const {
-  // To avoid side effects of this function, the pointer to the last norm
-  // sets and integral objects are remembered and reset at the end of this
-  // function.
-  auto * prevNorm = _norm;
-  auto * prevNormSet = _normSet;
-  auto out = RooAbsReal::getValues(evalData, normSet);
-  _norm = prevNorm;
-  _normSet = prevNormSet;
-  return out;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Analytical integral with normalization (see RooAbsReal::analyticalIntegralWN() for further information)
 ///
 /// This function applies the normalization specified by 'normSet' to the integral returned

--- a/roofit/roofitcore/src/RooBinIntegrator.cxx
+++ b/roofit/roofitcore/src/RooBinIntegrator.cxx
@@ -87,7 +87,15 @@ RooBinIntegrator::RooBinIntegrator(const RooAbsFunc& function, int numBins):
   _xmax.resize(_function->getDimension()) ;
 
   auto realBinding = dynamic_cast<const RooRealBinding*>(_function);
-  if (realBinding) {
+
+  // We could use BatchMode for RooRealBindings as they implement getValues().
+  // However, this is not efficient right now, because every time getValue() is
+  // called, a new RooFitDriver is created. Needs to be refactored.
+
+  //const bool useBatchMode = realBinding;
+  const bool useBatchMode = false;
+
+  if (useBatchMode) {
     _evalData.reset(new RooBatchCompute::RunContext());
     _evalDataOrig.reset(new RooBatchCompute::RunContext());
   }
@@ -108,7 +116,7 @@ RooBinIntegrator::RooBinIntegrator(const RooAbsFunc& function, int numBins):
     }
     _binb.emplace_back(tmp->begin(), tmp->end());
 
-    if (realBinding) {
+    if (useBatchMode) {
       const std::vector<double>& binb = _binb.back();
       RooSpan<double> binCentres = _evalDataOrig->makeBatch(realBinding->observable(i), binb.size() - 1);
       for (unsigned int ibin = 0; ibin < binb.size() - 1; ++ibin) {


### PR DESCRIPTION
The batched evaluation mode in the RooBinIntegrator was still
implemented with the old `getValues()` interface. Nowadays,
`getValues()` can still be used, but it's not the intended entry point
to the batched evaluation anymore. There is still a compatibility layer,
but it has lots of overhead because the new `RooFitDriver` is created
everytime `getValues()` is called.

Therefore, it is better to disable the batched evaluation code path for
now. Until the `RooRealBinding` is refactored to not create a new
RooFitDriver everytime `getValues()` is called.

Two other minor changes are also done in this PR in the first two commits. For more detail, see the commit description.

