### PR TITLE
Fixing `TExec::SavePrimitive` and `TMethod::SavePrimitive` 

### DIFF
--- a/core/base/inc/TExec.h
+++ b/core/base/inc/TExec.h
@@ -2,7 +2,7 @@
 // Author: Rene Brun   29/12/99
 
 /*************************************************************************
- * Copyright (C) 1995-2000, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2022, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -17,13 +17,11 @@
 //                                                                      //
 // TExec                                                                //
 //                                                                      //
-// A TExec object can execute a CINT command.                           //
+// A TExec object can execute a CLING command.                           //
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
-
 #include "TNamed.h"
-
 
 class TExec : public TNamed {
 
@@ -33,13 +31,12 @@ public:
    TExec(const char *name, const char *command);
    TExec(const TExec &text);
    virtual ~TExec();
-   virtual void     Exec(const char *command="");
+   virtual void     Exec(const char *command = "");
    void             Paint(Option_t *option="") override;
    void             SavePrimitive(std::ostream &out, Option_t *option = "") override;
-   virtual void     SetAction(const char *action) {SetTitle(action);}
+   virtual void     SetAction(const char *action) { SetTitle(action); }
 
-   ClassDefOverride(TExec,1);  //To execute a CINT command
+   ClassDefOverride(TExec,1);  //To execute a CLING command
 };
 
 #endif
-

--- a/core/base/inc/TString.h
+++ b/core/base/inc/TString.h
@@ -434,6 +434,7 @@ public:
    TString     &ReplaceAll(const    char *s1, const TString &s2); // Find&Replace all s1 with s2 if any
    TString     &ReplaceAll(const char *s1, const char *s2);       // Find&Replace all s1 with s2 if any
    TString     &ReplaceAll(const char *s1, Ssiz_t ls1, const char *s2, Ssiz_t ls2);  // Find&Replace all s1 with s2 if any
+   TString     &ReplaceSpecialCppChars();
    void         Resize(Ssiz_t n);                       // Truncate or add blanks as necessary
    TSubString   Strip(EStripType s = kTrailing, char c = ' ') const;
    TString     &Swap(TString &other); // Swap the contents of this and other without reallocation

--- a/core/base/src/TExec.cxx
+++ b/core/base/src/TExec.cxx
@@ -2,7 +2,7 @@
 // Author: Rene Brun   29/12/99
 
 /*************************************************************************
- * Copyright (C) 1995-2000, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2022, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -12,7 +12,6 @@
 #include <iostream>
 #include "TROOT.h"
 #include "TExec.h"
-#include "snprintf.h"
 
 ClassImp(TExec);
 
@@ -143,16 +142,15 @@ TExec::TExec(const TExec &e) : TNamed(e)
 
 void TExec::Exec(const char *command)
 {
-   if (command && (strlen(command) > 1))  gROOT->ProcessLine(command);
-   else  {
-      if (strlen(GetTitle()) > 0)         gROOT->ProcessLine(GetTitle());
-      else  {
-         if (strchr(GetName(),'('))      {gROOT->ProcessLine(GetName()); return;}
-         if (strchr(GetName(),'.'))      {gROOT->ProcessLine(GetName()); return;}
-         char action[512];
-         snprintf(action, sizeof(action), ".x %s.C", GetName());
-         gROOT->ProcessLine(action);
-      }
+   if (command && (strlen(command) > 1))
+      gROOT->ProcessLine(command);
+   else if (strlen(GetTitle()) > 0)
+      gROOT->ProcessLine(GetTitle());
+   else if (strchr(GetName(),'(') || strchr(GetName(),'.'))
+      gROOT->ProcessLine(GetName());
+   else {
+      auto action = TString::Format(".x %s.C", GetName());
+      gROOT->ProcessLine(action.Data());
    }
 }
 
@@ -170,11 +168,11 @@ void TExec::Paint(Option_t *)
 void TExec::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 {
    char quote = '"';
-   if (gROOT->ClassSaved(TExec::Class())) {
+   if (gROOT->ClassSaved(TExec::Class()))
       out<<"   ";
-   } else {
+   else
       out<<"   TExec *";
-   }
+
    out<<"exec = new TExec("<<quote<<GetName()<<quote<<","<<quote<<GetTitle()<<quote<<");"<<std::endl;
 
    out<<"   exec->Draw();"<<std::endl;

--- a/core/base/src/TExec.cxx
+++ b/core/base/src/TExec.cxx
@@ -173,7 +173,12 @@ void TExec::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
    else
       out<<"   TExec *";
 
-   out<<"exec = new TExec("<<quote<<GetName()<<quote<<","<<quote<<GetTitle()<<quote<<");"<<std::endl;
+   TString cmethod = GetTitle();
+   cmethod.ReplaceAll("\"", "\\\"");
+   cmethod.ReplaceAll("\\n", "\\\\n");
+   cmethod.ReplaceAll("\\t", "\\\\t");
+
+   out<<"exec = new TExec("<<quote<<GetName()<<quote<<", "<<quote<<cmethod<<quote<<");"<<std::endl;
 
    out<<"   exec->Draw();"<<std::endl;
 }

--- a/core/base/src/TExec.cxx
+++ b/core/base/src/TExec.cxx
@@ -173,12 +173,8 @@ void TExec::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
    else
       out<<"   TExec *";
 
-   TString cmethod = GetTitle();
-   cmethod.ReplaceAll("\"", "\\\"");
-   cmethod.ReplaceAll("\\n", "\\\\n");
-   cmethod.ReplaceAll("\\t", "\\\\t");
-
-   out<<"exec = new TExec("<<quote<<GetName()<<quote<<", "<<quote<<cmethod<<quote<<");"<<std::endl;
+   out<<"exec = new TExec("<<quote<<GetName()<<quote<<", "
+      <<quote<<TString(GetTitle()).ReplaceSpecialCppChars()<<quote<<");"<<std::endl;
 
    out<<"   exec->Draw();"<<std::endl;
 }

--- a/core/base/src/TMacro.cxx
+++ b/core/base/src/TMacro.cxx
@@ -397,18 +397,19 @@ void TMacro::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
    char quote = '"';
    out<<"   "<<std::endl;
-   if (gROOT->ClassSaved(TMacro::Class())) {
+   if (gROOT->ClassSaved(TMacro::Class()))
       out<<"   ";
-   } else {
+   else
       out<<"   "<<ClassName()<<" *";
-   }
+
    out<<"macro = new "<<ClassName()<<"("<<quote<<GetName()<<quote<<","<<quote<<GetTitle()<<quote<<");"<<std::endl;
-   if (!fLines) return;
+
    TIter next(fLines);
-   TObjString *obj;
-   while ((obj = (TObjString*) next())) {
+   while (auto obj = next()) {
       TString s = obj->GetName();
       s.ReplaceAll("\"","\\\"");
+      s.ReplaceAll("\\n", "\\\\n");
+      s.ReplaceAll("\\t", "\\\\t");
       out<<"   macro->AddLine("<<quote<<s.Data()<<quote<<");"<<std::endl;
    }
    out<<"   macro->Draw("<<quote<<option<<quote<<");"<<std::endl;

--- a/core/base/src/TMacro.cxx
+++ b/core/base/src/TMacro.cxx
@@ -393,10 +393,7 @@ void TMacro::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    TIter next(fLines);
    while (auto obj = next()) {
       TString s = obj->GetName();
-      s.ReplaceAll("\"","\\\"");
-      s.ReplaceAll("\\n", "\\\\n");
-      s.ReplaceAll("\\t", "\\\\t");
-      out<<"   macro->AddLine("<<quote<<s.Data()<<quote<<");"<<std::endl;
+      out<<"   macro->AddLine("<<quote<<s.ReplaceSpecialCppChars()<<quote<<");"<<std::endl;
    }
    out<<"   macro->Draw("<<quote<<option<<quote<<");"<<std::endl;
 }

--- a/core/base/src/TMacro.cxx
+++ b/core/base/src/TMacro.cxx
@@ -81,7 +81,7 @@ TMacro::TMacro(const char *name, const char *title): TNamed(name,title)
    strlcpy(s,name,nch+1);
    char *slash = (char*)strrchr(s,'/');
    if (!slash) slash = s;
-   else ++slash;
+          else ++slash;
    char *dot   = (char*)strchr(slash,'.');
    if (dot) {
       *dot = 0;
@@ -99,10 +99,9 @@ TMacro::TMacro(const TMacro &macro): TNamed(macro)
 {
    fLines = new TList();
    TIter next(macro.GetListOfLines());
-   TObjString *obj;
-   while ((obj = (TObjString*) next())) {
+   while (auto obj = next())
       fLines->Add(new TObjString(obj->GetName()));
-   }
+
    fParams = macro.fParams;
 }
 
@@ -126,10 +125,8 @@ TMacro& TMacro::operator=(const TMacro &macro)
       delete fLines;
       fLines = new TList();
       TIter next(macro.GetListOfLines());
-      TObjString *obj;
-      while ((obj = (TObjString*) next())) {
+      while (auto obj = next())
          fLines->Add(new TObjString(obj->GetName()));
-      }
       fParams = macro.fParams;
    }
    return *this;
@@ -206,12 +203,11 @@ TMD5 *TMacro::Checksum()
    Long64_t left = bufSize;
 
    TIter nxl(fLines);
-   TObjString *l;
-   while ((l = (TObjString *) nxl())) {
+   while (auto l = (TObjString *) nxl()) {
       TString line = l->GetString();
       line += '\n';
       Int_t len = line.Length();
-      char *p = (char *) line.Data();
+      const char *p = line.Data();
       if (left > len) {
          strlcpy((char *)&buf[pos], p, len+1);
          pos += len;
@@ -250,10 +246,9 @@ Bool_t TMacro::Load() const
    std::stringstream ss;
 
    TIter next(fLines);
-   TObjString *obj;
-   while ((obj = (TObjString*) next())) {
+   while (auto obj = (TObjString*) next())
       ss << obj->GetName() << std::endl;
-   }
+
    return gInterpreter->LoadText(ss.str().c_str());
 }
 
@@ -303,9 +298,9 @@ TObjString *TMacro::GetLineWith(const char *text) const
 {
    if (!fLines) return nullptr;
    TIter next(fLines);
-   TObjString *obj;
-   while ((obj = (TObjString*) next())) {
-      if (strstr(obj->GetName(),text)) return obj;
+   while (auto obj = (TObjString*) next()) {
+      if (strstr(obj->GetName(),text))
+         return obj;
    }
    return nullptr;
 }
@@ -323,12 +318,9 @@ void TMacro::Paint(Option_t *option)
 
 void TMacro::Print(Option_t * /*option*/) const
 {
-   if (!fLines) return;
    TIter next(fLines);
-   TObjString *obj;
-   while ((obj = (TObjString*) next())) {
-      printf("%s\n",obj->GetName());
-   }
+   while (auto obj = next())
+      printf("%s\n", obj->GetName());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -363,16 +355,13 @@ void TMacro::SaveSource(const char *filename)
 {
    std::ofstream out;
    out.open(filename, std::ios::out);
-   if (!out.good ()) {
-      Printf("SaveSource cannot open file: %s",filename);
+   if (!out.good()) {
+      Error("SaveSource", "cannot open file: %s",filename);
       return;
    }
-   if (!fLines) {out.close(); return;}
    TIter next(fLines);
-   TObjString *obj;
-   while ((obj = (TObjString*) next())) {
-      out<<obj->GetName()<<std::endl;
-   }
+   while (auto obj = next())
+      out << obj->GetName() << std::endl;
    out.close();
 }
 
@@ -381,12 +370,9 @@ void TMacro::SaveSource(const char *filename)
 
 void TMacro::SaveSource(FILE *fp)
 {
-   if (!fLines) {fclose(fp); return;}
    TIter next(fLines);
-   TObjString *obj;
-   while ((obj = (TObjString*) next())) {
+   while (auto obj = next())
       fprintf(fp, "%s\n", obj->GetName());
-   }
    fclose(fp);
 }
 

--- a/core/base/src/TString.cxx
+++ b/core/base/src/TString.cxx
@@ -1094,6 +1094,21 @@ TString& TString::ReplaceAll(const char *s1, Ssiz_t ls1, const char *s2,
    return *this;
 }
 
+
+////////////////////////////////////////////////////////////////////////////////
+/// Find special characters which are typically used in `printf()` calls
+/// and replace them by appropriate escape sequences. Result can be
+/// stored as string argument in ROOT macros. The content of TString will be changed!
+/// Following symbols are handled: ", \n, \t, \a, \b, \r, \0, \v, \?, \'
+
+TString &TString::ReplaceSpecialCppChars()
+{
+   return ReplaceAll("\"", "\\\"").ReplaceAll("\\n", "\\\\n").ReplaceAll("\\t", "\\\\t").ReplaceAll("\\a", "\\\\a")
+          .ReplaceAll("\\b", "\\\\b").ReplaceAll("\\r", "\\\\r").ReplaceAll("\0", "\\\\0").ReplaceAll("\\v", "\\\\v")
+          .ReplaceAll("\\?", "\\\\?").ReplaceAll("\\'", "\\\\'");
+}
+
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Remove char c at begin and/or end of string (like Strip()) but
 /// modifies directly the string.

--- a/core/base/src/TString.cxx
+++ b/core/base/src/TString.cxx
@@ -1099,13 +1099,10 @@ TString& TString::ReplaceAll(const char *s1, Ssiz_t ls1, const char *s2,
 /// Find special characters which are typically used in `printf()` calls
 /// and replace them by appropriate escape sequences. Result can be
 /// stored as string argument in ROOT macros. The content of TString will be changed!
-/// Following symbols are handled: ", \n, \t, \a, \b, \r, \0, \v, \?, \'
 
 TString &TString::ReplaceSpecialCppChars()
 {
-   return ReplaceAll("\"", "\\\"").ReplaceAll("\\n", "\\\\n").ReplaceAll("\\t", "\\\\t").ReplaceAll("\\a", "\\\\a")
-          .ReplaceAll("\\b", "\\\\b").ReplaceAll("\\r", "\\\\r").ReplaceAll("\0", "\\\\0").ReplaceAll("\\v", "\\\\v")
-          .ReplaceAll("\\?", "\\\\?").ReplaceAll("\\'", "\\\\'");
+   return ReplaceAll("\\","\\\\").ReplaceAll("\"","\\\"");
 }
 
 

--- a/graf2d/gpad/src/TButton.cxx
+++ b/graf2d/gpad/src/TButton.cxx
@@ -275,12 +275,9 @@ void TButton::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
       out<<"   TButton *";
 
    TString cmethod = GetMethod();
-   cmethod.ReplaceAll("\"", "\\\"");
-   cmethod.ReplaceAll("\\n", "\\\\n");
-   cmethod.ReplaceAll("\\t", "\\\\t");
 
    out << "button = new TButton(" << quote << GetTitle() << quote << ","
-         << quote << cmethod << quote << "," << fXlowNDC << "," << fYlowNDC
+         << quote << cmethod.ReplaceSpecialCppChars() << quote << "," << fXlowNDC << "," << fYlowNDC
          << "," << fXlowNDC + fWNDC << "," << fYlowNDC + fHNDC << ");"
          << std::endl;
 

--- a/graf2d/gpad/src/TSlider.cxx
+++ b/graf2d/gpad/src/TSlider.cxx
@@ -173,12 +173,8 @@ void TSlider::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
    out<<"   slider->SetRange("<< fMinimum <<", "<< fMaximum <<");"<<std::endl;
 
    TString cmethod = GetMethod();
-   if (cmethod.Length() > 0) {
-      cmethod.ReplaceAll("\"", "\\\"");
-      cmethod.ReplaceAll("\\n", "\\\\n");
-      cmethod.ReplaceAll("\\t", "\\\\t");
-      out<<"   slider->SetMethod("<<quote<<cmethod<<quote<<");"<<std::endl;
-   }
+   if (cmethod.Length() > 0)
+      out<<"   slider->SetMethod("<<quote<<cmethod.ReplaceSpecialCppChars()<<quote<<");"<<std::endl;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/graf/src/TLatex.cxx
+++ b/graf2d/graf/src/TLatex.cxx
@@ -2647,21 +2647,20 @@ void TLatex::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 {
    char quote = '"';
 
-   if (gROOT->ClassSaved(TLatex::Class())) {
+   if (gROOT->ClassSaved(TLatex::Class()))
       out<<"   ";
-   } else {
+   else
       out<<"   TLatex *";
-   }
 
    TString s = GetTitle();
+   s.ReplaceSpecialCppChars();
 
-   s.ReplaceAll("\\","\\\\");
-   s.ReplaceAll("\"","\\\"");
-   out<<"   tex = new TLatex("<<fX<<","<<fY<<","<<quote<<s.Data()<<quote<<");"<<std::endl;
-   if (TestBit(kTextNDC)) out<<"tex->SetNDC();"<<std::endl;
+   out<<"   tex = new TLatex("<<fX<<","<<fY<<","<<quote<<s<<quote<<");"<<std::endl;
+   if (TestBit(kTextNDC))
+      out<<"   tex->SetNDC();"<<std::endl;
 
-   SaveTextAttributes(out,"tex",11,0,1,62,0.05);
-   SaveLineAttributes(out,"tex",1,1,1);
+   SaveTextAttributes(out, "tex", 11, 0, 1, 62, 0.05);
+   SaveLineAttributes(out, "tex", 1, 1, 1);
 
    out<<"   tex->Draw();"<<std::endl;
 }

--- a/graf2d/graf/src/TText.cxx
+++ b/graf2d/graf/src/TText.cxx
@@ -792,17 +792,19 @@ void TText::Print(Option_t *) const
 void TText::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 {
    char quote = '"';
-   if (gROOT->ClassSaved(TText::Class())) {
-       out<<"   ";
-   } else {
-       out<<"   TText *";
-   }
-   TString s = GetTitle();
-   s.ReplaceAll("\"","\\\"");
-   out<<"text = new TText("<<fX<<","<<fY<<","<<quote<<s.Data()<<quote<<");"<<std::endl;
-   if (TestBit(kTextNDC)) out<<"   text->SetNDC();"<<std::endl;
+   if (gROOT->ClassSaved(TText::Class()))
+      out<<"   ";
+   else
+      out<<"   TText *";
 
-   SaveTextAttributes(out,"text",11,0,1,62,0.05);
+   TString s = GetTitle();
+   s.ReplaceSpecialCppChars();
+
+   out<<"text = new TText("<<fX<<","<<fY<<","<<quote<<s<<quote<<");"<<std::endl;
+   if (TestBit(kTextNDC))
+      out<<"   text->SetNDC();"<<std::endl;
+
+   SaveTextAttributes(out, "text", 11, 0, 1, 62, 0.05);
 
    out<<"   text->Draw();"<<std::endl;
 }


### PR DESCRIPTION
Handle obvious escape characters.
Fix #11913 