### PR TITLE
[math][minuit2] Avoid hiding member functions with `using`

### DIFF
--- a/math/minuit2/inc/Minuit2/FumiliMinimizer.h
+++ b/math/minuit2/inc/Minuit2/FumiliMinimizer.h
@@ -91,65 +91,7 @@ public:
    FunctionMinimum Minimize(const FCNGradientBase &, const MnUserParameterState &, const MnStrategy &,
                                     unsigned int maxfcn = 0, double toler = 0.1) const override;
 
-   // need to re-implement all function in ModularFuncitionMinimizer otherwise they will be hided
-
-   FunctionMinimum Minimize(const FCNBase &fcn, const std::vector<double> &par, const std::vector<double> &err,
-                                    unsigned int stra = 1, unsigned int maxfcn = 0, double toler = 0.1) const override
-   {
-      return ModularFunctionMinimizer::Minimize(fcn, par, err, stra, maxfcn, toler);
-   }
-
-   FunctionMinimum Minimize(const FCNGradientBase &fcn, const std::vector<double> &par,
-                                    const std::vector<double> &err, unsigned int stra = 1, unsigned int maxfcn = 0,
-                                    double toler = 0.1) const override
-   {
-      return ModularFunctionMinimizer::Minimize(fcn, par, err, stra, maxfcn, toler);
-   }
-
-   FunctionMinimum Minimize(const FCNBase &fcn, const std::vector<double> &par, unsigned int nrow,
-                                    const std::vector<double> &cov, unsigned int stra = 1, unsigned int maxfcn = 0,
-                                    double toler = 0.1) const override
-   {
-      return ModularFunctionMinimizer::Minimize(fcn, par, nrow, cov, stra, maxfcn, toler);
-   }
-
-   FunctionMinimum Minimize(const FCNGradientBase &fcn, const std::vector<double> &par, unsigned int nrow,
-                                    const std::vector<double> &cov, unsigned int stra = 1, unsigned int maxfcn = 0,
-                                    double toler = 0.1) const override
-   {
-      return ModularFunctionMinimizer::Minimize(fcn, par, nrow, cov, stra, maxfcn, toler);
-   }
-
-   FunctionMinimum Minimize(const FCNBase &fcn, const MnUserParameters &par, const MnStrategy &stra,
-                                    unsigned int maxfcn = 0, double toler = 0.1) const override
-   {
-      return ModularFunctionMinimizer::Minimize(fcn, par, stra, maxfcn, toler);
-   }
-
-   FunctionMinimum Minimize(const FCNGradientBase &fcn, const MnUserParameters &par, const MnStrategy &stra,
-                                    unsigned int maxfcn = 0, double toler = 0.1) const override
-   {
-      return ModularFunctionMinimizer::Minimize(fcn, par, stra, maxfcn, toler);
-   }
-
-   FunctionMinimum Minimize(const FCNBase &fcn, const MnUserParameters &par, const MnUserCovariance &cov,
-                                    const MnStrategy &stra, unsigned int maxfcn = 0, double toler = 0.1) const override
-   {
-      return ModularFunctionMinimizer::Minimize(fcn, par, cov, stra, maxfcn, toler);
-   }
-
-   FunctionMinimum Minimize(const FCNGradientBase &fcn, const MnUserParameters &par,
-                                    const MnUserCovariance &cov, const MnStrategy &stra, unsigned int maxfcn = 0,
-                                    double toler = 0.1) const override
-   {
-      return ModularFunctionMinimizer::Minimize(fcn, par, cov, stra, maxfcn, toler);
-   }
-
-   FunctionMinimum Minimize(const MnFcn &mfcn, const GradientCalculator &gc, const MinimumSeed &seed,
-                                    const MnStrategy &stra, unsigned int maxfcn, double toler) const override
-   {
-      return ModularFunctionMinimizer::Minimize(mfcn, gc, seed, stra, maxfcn, toler);
-   }
+   using ModularFunctionMinimizer::Minimize;
 
 private:
    MnSeedGenerator fMinSeedGen;


### PR DESCRIPTION
We can avoid quite some code repetition by employing a single `using` statement to ensure that the base class methods are not hidden.