### PR TITLE
[RF] Add missing `XROOFIT_NAMESPACE` definition

### DIFF
--- a/roofit/xroofit/inc/RooBrowser.h
+++ b/roofit/xroofit/inc/RooBrowser.h
@@ -53,6 +53,10 @@ Many more features are available in the `RooBrowser`, and further documentation 
 #ifndef RooFit_RooBrowser_h
 #define RooFit_RooBrowser_h
 
+#ifndef XROOFIT_NAMESPACE
+#define XROOFIT_NAMESPACE RooFit::Detail::XRooFit
+#endif
+
 #include "RooFit/xRooFit/xRooBrowser.h"
 
 namespace ROOT::Experimental {


### PR DESCRIPTION
In case the nightly builds are failing with `root7`, I think this is the fix.

Follow up to https://github.com/root-project/root/pull/11851.