### PR TITLE
[RF] Officially deprecate RooMinuit

### DIFF
--- a/roofit/roofitcore/inc/LinkDef.h
+++ b/roofit/roofitcore/inc/LinkDef.h
@@ -149,7 +149,6 @@
 #pragma read sourceClass="RooMappedCategory::Entry" targetClass="RooMappedCategory::Entry" version="[1]" include="RooFitLegacy/RooCatTypeLegacy.h" \
     source="RooCatType _cat" target="_catIdx" code="{ _catIdx = onfile._cat.getVal(); }"
 #pragma link C++ class RooMCIntegrator+ ;
-#pragma link C++ class RooMinuit+ ;
 #pragma link C++ class RooMPSentinel+ ;
 #pragma link C++ class RooMultiCategory+ ;
 #pragma link off class RooNameReg+ ;

--- a/roofit/roofitcore/inc/RooFitLegacy/RooMinuit.h
+++ b/roofit/roofitcore/inc/RooFitLegacy/RooMinuit.h
@@ -145,8 +145,13 @@ private:
 
   RooMinuit(const RooMinuit&) ;
 
-  ClassDefOverride(RooMinuit,0) // RooFit minimizer based on MINUIT
-} R__SUGGEST_ALTERNATIVE("Please use RooMinimizer instead of RooMinuit");
+// Undocumented preprocessor define such that the implementation in
+// RooMinuit.cxx can suppress the deprecation warning.
+#ifndef __ROOFIT_SUPPRESS_ROOMINIMIZER_DEPRECATION_WARNING
+} R__DEPRECATED(6, 30, "Please use RooMinimizer instead of RooMinuit");
+#else
+};
+#endif
 
 
 #endif

--- a/roofit/roofitcore/inc/RooMinuit.h
+++ b/roofit/roofitcore/inc/RooMinuit.h
@@ -1,5 +1,5 @@
 #warning "The deprecated RooMinuit class was replaced by the more general RooMinimizer. \
-Migrating to the RooMinimizer is easy because the interface is backwards compatible. \
-If you still want to use the old RooMinuit, #include \"RooFitLegacy/RooMinuit\" instead."
+The RooMinuit class will be gone in ROOT 6.30! \
+Migrating to the RooMinimizer is easy because the interface is backwards compatible.
 
 #include "RooFitLegacy/RooMinuit.h"

--- a/roofit/roofitcore/src/RooFitLegacy/RooMinuit.cxx
+++ b/roofit/roofitcore/src/RooFitLegacy/RooMinuit.cxx
@@ -37,7 +37,10 @@ Various methods are available to control verbosity, profiling,
 automatic PDF optimization.
 **/
 
+// At least for building the implementation we have to suppress the deprecation warning
+#define __ROOFIT_SUPPRESS_ROOMINIMIZER_DEPRECATION_WARNING
 #include "RooFitLegacy/RooMinuit.h"
+#undef __ROOFIT_SUPPRESS_ROOMINIMIZER_DEPRECATION_WARNING
 
 #include "TClass.h"
 
@@ -68,7 +71,6 @@ char* operator+( streampos&, char* );
 
 using namespace std;
 
-ClassImp(RooMinuit);
 
 TVirtualFitter *RooMinuit::_theFitter = nullptr;
 


### PR DESCRIPTION
Officially deprecate RooMinuit with attributes for the compiler, indicating that it will be removed in ROOT 6.30.

The dictionary generation via `ClassDef` etc. is also removed, because otherwise we would get the deprecation warning in the dictionary generation.