### PR TITLE
Fix `TColor::SaveColor`, optimize `SavePrimitive` methos

### DIFF
--- a/core/base/inc/TColor.h
+++ b/core/base/inc/TColor.h
@@ -94,7 +94,7 @@ public:
    static void    Pixel2RGB(ULong_t pixel, Int_t &r, Int_t &g, Int_t &b);
    static void    Pixel2RGB(ULong_t pixel, Float_t &r, Float_t &g, Float_t &b);
    static const char *PixelAsHexString(ULong_t pixel);
-   static void    SaveColor(std::ostream &out, Int_t ci);
+   static Bool_t  SaveColor(std::ostream &out, Int_t ci);
    static void    SetColorThreshold(Float_t t);
    static Bool_t  DefinedColors();
    static void    InvertPalette();

--- a/core/base/src/TAttAxis.cxx
+++ b/core/base/src/TAttAxis.cxx
@@ -114,17 +114,15 @@ void TAttAxis::SaveAttributes(std::ostream &out, const char *name, const char *s
       out<<"   "<<name<<subname<<"->SetNdivisions("<<fNdivisions<<");"<<std::endl;
    }
    if (fAxisColor != 1) {
-      if (fAxisColor > 228) {
-         TColor::SaveColor(out, fAxisColor);
+      if (TColor::SaveColor(out, fAxisColor))
          out<<"   "<<name<<subname<<"->SetAxisColor(ci);" << std::endl;
-      } else
+      else
          out<<"   "<<name<<subname<<"->SetAxisColor("<<fAxisColor<<");"<<std::endl;
    }
    if (fLabelColor != 1) {
-      if (fLabelColor > 228) {
-         TColor::SaveColor(out, fLabelColor);
+      if (TColor::SaveColor(out, fLabelColor))
          out<<"   "<<name<<subname<<"->SetLabelColor(ci);" << std::endl;
-      } else
+      else
          out<<"   "<<name<<subname<<"->SetLabelColor("<<fLabelColor<<");"<<std::endl;
    }
    if (fLabelFont != 62) {
@@ -146,10 +144,9 @@ void TAttAxis::SaveAttributes(std::ostream &out, const char *name, const char *s
       out<<"   "<<name<<subname<<"->SetTitleOffset("<<fTitleOffset<<");"<<std::endl;
    }
    if (fTitleColor != 1) {
-      if (fTitleColor > 228) {
-         TColor::SaveColor(out, fTitleColor);
+      if (TColor::SaveColor(out, fTitleColor))
          out<<"   "<<name<<subname<<"->SetTitleColor(ci);" << std::endl;
-      } else
+      else
          out<<"   "<<name<<subname<<"->SetTitleColor("<<fTitleColor<<");"<<std::endl;
    }
    if (fTitleFont != 62) {

--- a/core/base/src/TAttFill.cxx
+++ b/core/base/src/TAttFill.cxx
@@ -237,15 +237,13 @@ void TAttFill::ResetAttFill(Option_t *)
 void TAttFill::SaveFillAttributes(std::ostream &out, const char *name, Int_t coldef, Int_t stydef)
 {
    if (fFillColor != coldef) {
-      if (fFillColor > 228) {
-         TColor::SaveColor(out, fFillColor);
+      if (TColor::SaveColor(out, fFillColor))
          out<<"   "<<name<<"->SetFillColor(ci);" << std::endl;
-      } else
+      else
          out<<"   "<<name<<"->SetFillColor("<<fFillColor<<");"<<std::endl;
    }
-   if (fFillStyle != stydef) {
+   if (fFillStyle != stydef)
       out<<"   "<<name<<"->SetFillStyle("<<fFillStyle<<");"<<std::endl;
-   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/base/src/TAttLine.cxx
+++ b/core/base/src/TAttLine.cxx
@@ -273,10 +273,9 @@ void TAttLine::ResetAttLine(Option_t *)
 void TAttLine::SaveLineAttributes(std::ostream &out, const char *name, Int_t coldef, Int_t stydef, Int_t widdef)
 {
    if (fLineColor != coldef) {
-      if (fLineColor > 228) {
-         TColor::SaveColor(out, fLineColor);
+      if (TColor::SaveColor(out, fLineColor))
          out<<"   "<<name<<"->SetLineColor(ci);" << std::endl;
-      } else
+      else
          out<<"   "<<name<<"->SetLineColor("<<fLineColor<<");"<<std::endl;
    }
    if (fLineStyle != stydef) {

--- a/core/base/src/TAttMarker.cxx
+++ b/core/base/src/TAttMarker.cxx
@@ -345,10 +345,9 @@ void TAttMarker::ResetAttMarker(Option_t *)
 void TAttMarker::SaveMarkerAttributes(std::ostream &out, const char *name, Int_t coldef, Int_t stydef, Int_t sizdef)
 {
    if (fMarkerColor != coldef) {
-      if (fMarkerColor > 228) {
-         TColor::SaveColor(out, fMarkerColor);
+      if (TColor::SaveColor(out, fMarkerColor))
          out<<"   "<<name<<"->SetMarkerColor(ci);" << std::endl;
-      } else
+      else
          out<<"   "<<name<<"->SetMarkerColor("<<fMarkerColor<<");"<<std::endl;
    }
    if (fMarkerStyle != stydef) {

--- a/core/base/src/TAttText.cxx
+++ b/core/base/src/TAttText.cxx
@@ -381,10 +381,9 @@ void TAttText::SaveTextAttributes(std::ostream &out, const char *name, Int_t ali
       out<<"   "<<name<<"->SetTextAlign("<<fTextAlign<<");"<<std::endl;
    }
    if (fTextColor != coldef) {
-      if (fTextColor > 228) {
-         TColor::SaveColor(out, fTextColor);
+      if (TColor::SaveColor(out, fTextColor))
          out<<"   "<<name<<"->SetTextColor(ci);" << std::endl;
-      } else
+      else
          out<<"   "<<name<<"->SetTextColor("<<fTextColor<<");"<<std::endl;
    }
    if (fTextFont != fondef) {

--- a/core/base/src/TColor.cxx
+++ b/core/base/src/TColor.cxx
@@ -2183,21 +2183,18 @@ const char *TColor::PixelAsHexString(ULong_t pixel)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Save a color with index > 228 as a C++ statement(s) on output stream out.
+/// Return kFALSE if color not saved in the output stream
 
-void TColor::SaveColor(std::ostream &out, Int_t ci)
+Bool_t TColor::SaveColor(std::ostream &out, Int_t ci)
 {
+   if (ci <= 228)
+      return kFALSE;
+
    char quote = '"';
-   Float_t r,g,b,a;
-   Int_t ri, gi, bi;
-   TString cname;
 
    TColor *c = gROOT->GetColor(ci);
-   if (c) {
-      c->GetRGB(r, g, b);
-      a = c->GetAlpha();
-   } else {
-      return;
-   }
+   if (!c)
+      return kFALSE;
 
    if (gROOT->ClassSaved(TColor::Class())) {
       out << std::endl;
@@ -2207,17 +2204,24 @@ void TColor::SaveColor(std::ostream &out, Int_t ci)
       out << "   TColor *color; // for color definition with alpha" << std::endl;
    }
 
-   if (a<1) {
+   Float_t r, g, b, a;
+
+   c->GetRGB(r, g, b);
+   a = c->GetAlpha();
+
+   if (a < 1.) {
       out<<"   ci = "<<ci<<";"<<std::endl;
       out<<"   color = new TColor(ci, "<<r<<", "<<g<<", "<<b<<", "
       <<"\" \", "<<a<<");"<<std::endl;
    } else {
-      ri = (Int_t)(255*r);
-      gi = (Int_t)(255*g);
-      bi = (Int_t)(255*b);
-      cname.Form("#%02x%02x%02x", ri, gi, bi);
+      Int_t ri = (Int_t)(255*r),
+            gi = (Int_t)(255*g),
+            bi = (Int_t)(255*b);
+      TString cname = TString::Format("#%02x%02x%02x", ri, gi, bi);
       out<<"   ci = TColor::GetColor("<<quote<<cname.Data()<<quote<<");"<<std::endl;
    }
+
+   return kTRUE;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/gpad/src/TCanvas.cxx
+++ b/graf2d/gpad/src/TCanvas.cxx
@@ -1788,10 +1788,9 @@ void TCanvas::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       out<<"   "<<GetName()<<"->ToggleToolBar();"<<std::endl;
    }
    if (GetHighLightColor() != 5) {
-      if (GetHighLightColor() > 228) {
-         TColor::SaveColor(out, GetHighLightColor());
+      if (TColor::SaveColor(out, GetHighLightColor()))
          out<<"   "<<GetName()<<"->SetHighLightColor(ci);" << std::endl;
-      } else
+      else
          out<<"   "<<GetName()<<"->SetHighLightColor("<<GetHighLightColor()<<");"<<std::endl;
    }
 
@@ -1918,10 +1917,9 @@ void TCanvas::SaveSource(const char *filename, Option_t *option)
       out<<"   "<<GetName()<<"->ToggleToolTips();"<<std::endl;
    }
    if (GetHighLightColor() != 5) {
-      if (GetHighLightColor() > 228) {
-         TColor::SaveColor(out, GetHighLightColor());
+      if (TColor::SaveColor(out, GetHighLightColor()))
          out<<"   "<<GetName()<<"->SetHighLightColor(ci);" << std::endl;
-      } else
+      else
          out<<"   "<<GetName()<<"->SetHighLightColor("<<GetHighLightColor()<<");"<<std::endl;
    }
 

--- a/graf2d/gpad/src/TGroupButton.cxx
+++ b/graf2d/gpad/src/TGroupButton.cxx
@@ -103,7 +103,6 @@ void TGroupButton::DisplayColorTable(const char *action, Double_t x0, Double_t y
 
 void TGroupButton::ExecuteAction()
 {
-   TVirtualPad *pad;
    char line[128];
    strlcpy(line,GetMethod(),128);
    char *method = line;
@@ -119,28 +118,28 @@ void TGroupButton::ExecuteAction()
    TObject *obj = canvas->GetRefObject();
    if (!obj) return;
    if (strcmp(method,"PIXELS")) {
-      obj->Execute(method,params);
+      obj->Execute(method, params);
    } else {
       TText *text = (TText*)GetListOfPrimitives()->First();
       Int_t npixels = Int_t((YtoPixel(0) - YtoPixel(1))*text->GetTextSize());
-      Double_t dy;
-      pad = gROOT->GetSelectedPad();
+      Double_t dy = 0;
+      auto pad = gROOT->GetSelectedPad();
       if (!params) return;
-      Int_t nmax = (Int_t)(params-method);
+      Int_t nmax = (Int_t)(params - method);
       if (obj->InheritsFrom("TPaveLabel")) {
          TBox *pl = (TBox*)obj;
-         dy = pad->AbsPixeltoY(0) - pad->AbsPixeltoY(npixels);
-         snprintf(params,nmax,"%f",dy/(pl->GetY2() - pl->GetY1()));
+         if (pad)
+            dy = (pad->AbsPixeltoY(0) - pad->AbsPixeltoY(npixels))/(pl->GetY2() - pl->GetY1());
+         snprintf(params, nmax, "%f", dy);
+         obj->Execute("SetTextSize",params);
+      } else if (obj->InheritsFrom("TPave")) {
+         if (pad)
+            dy = (pad->AbsPixeltoY(0) - pad->AbsPixeltoY(npixels))/(pad->GetY2() - pad->GetY1());
+         snprintf(params, nmax, "%f", dy);
          obj->Execute("SetTextSize",params);
       } else {
-         if (obj->InheritsFrom("TPave")) {
-            dy = pad->AbsPixeltoY(0) - pad->AbsPixeltoY(npixels);
-            snprintf(params,nmax,"%f",dy/(pad->GetY2() - pad->GetY1()));
-            obj->Execute("SetTextSize",params);
-         } else {
-            snprintf(params,nmax,"%d",npixels);
-            obj->Execute("SetTextSizePixels",params);
-         }
+         snprintf(params, nmax, "%d", npixels);
+         obj->Execute("SetTextSizePixels", params);
       }
    }
 }
@@ -223,12 +222,12 @@ void TGroupButton::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 {
    TVirtualPad::TContext ctxt(kTRUE);
    char quote = '"';
-   if (gROOT->ClassSaved(TGroupButton::Class())) {
+   if (gROOT->ClassSaved(TGroupButton::Class()))
       out<<"   ";
-   } else {
+   else
       out<<"   TGroupButton *";
-   }
-   out<<"button = new TGroupButton("<<quote<<GetName()<<quote<<", "<<quote<<GetTitle()
+
+   out<<"grbutton = new TGroupButton("<<quote<<GetName()<<quote<<", "<<quote<<GetTitle()
       <<quote<<","<<quote<<GetMethod()<<quote
       <<","<<fXlowNDC
       <<","<<fYlowNDC
@@ -236,26 +235,28 @@ void TGroupButton::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
       <<","<<fYlowNDC+fHNDC
       <<");"<<std::endl;
 
-   SaveFillAttributes(out,"button",0,1001);
-   SaveLineAttributes(out,"button",1,1,1);
-   SaveTextAttributes(out,"button",22,0,1,62,.75);
+   SaveFillAttributes(out, "grbutton", 0, 1001);
+   SaveLineAttributes(out, "grbutton", 1, 1, 1);
+   SaveTextAttributes(out, "grbutton", 22, 0, 1, 62, .75);
 
-   if (GetBorderSize() != 2) {
-      out<<"   button->SetBorderSize("<<GetBorderSize()<<");"<<std::endl;
-   }
-   if (GetBorderMode() != 1) {
-      out<<"   button->SetBorderMode("<<GetBorderMode()<<");"<<std::endl;
-   }
+   if (GetBorderSize() != 2)
+      out<<"   grbutton->SetBorderSize("<<GetBorderSize()<<");"<<std::endl;
 
-   out<<"   button->Draw();"<<std::endl;
-   out<<"   button->cd();"<<std::endl;
+   if (GetBorderMode() != 1)
+      out<<"   grbutton->SetBorderMode("<<GetBorderMode()<<");"<<std::endl;
+
+   out<<"   grbutton->Draw();"<<std::endl;
 
    TIter next(GetListOfPrimitives());
    next();  //do not save first primitive
 
-   while (auto obj = next())
+   Int_t nprim = 0;
+   while (auto obj = next()) {
+      if (nprim++ == 0)
+         out<<"   grbutton->cd();"<<std::endl;
       obj->SavePrimitive(out, (Option_t *)next.GetOption());
+   }
 
-   if (ctxt.GetSaved())
+   if (ctxt.GetSaved() && (nprim > 0))
       out<<"   "<<ctxt.GetSaved()->GetName()<<"->cd();"<<std::endl;
 }

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -5693,10 +5693,9 @@ void TPad::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
                                <<rmax[0]<<","<<rmax[1]<<","<<rmax[2]<<");"<<std::endl;
    }
    if (GetFillColor() != 19) {
-      if (GetFillColor() > 228) {
-         TColor::SaveColor(out, GetFillColor());
+      if (TColor::SaveColor(out, GetFillColor()))
          out<<"   "<<cname<<"->SetFillColor(ci);" << std::endl;
-      } else
+      else
          out<<"   "<<cname<<"->SetFillColor("<<GetFillColor()<<");"<<std::endl;
    }
    if (GetFillStyle() != 1001) {
@@ -5749,10 +5748,9 @@ void TPad::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
    }
 
    if (GetFrameFillColor() != GetFillColor()) {
-      if (GetFrameFillColor() > 228) {
-         TColor::SaveColor(out, GetFrameFillColor());
+      if (TColor::SaveColor(out, GetFrameFillColor()))
          out<<"   "<<cname<<"->SetFrameFillColor(ci);" << std::endl;
-      } else
+      else
          out<<"   "<<cname<<"->SetFrameFillColor("<<GetFrameFillColor()<<");"<<std::endl;
    }
    if (GetFrameFillStyle() != 1001) {
@@ -5762,10 +5760,9 @@ void TPad::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
       out<<"   "<<cname<<"->SetFrameLineStyle("<<GetFrameLineStyle()<<");"<<std::endl;
    }
    if (GetFrameLineColor() != 1) {
-      if (GetFrameLineColor() > 228) {
-         TColor::SaveColor(out, GetFrameLineColor());
+      if (TColor::SaveColor(out, GetFrameLineColor()))
          out<<"   "<<cname<<"->SetFrameLineColor(ci);" << std::endl;
-      } else
+      else
          out<<"   "<<cname<<"->SetFrameLineColor("<<GetFrameLineColor()<<");"<<std::endl;
    }
    if (GetFrameLineWidth() != 1) {
@@ -5782,10 +5779,9 @@ void TPad::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
    if (!frame) frame = (TFrame*)GetPrimitive("TFrame");
    if (frame) {
       if (frame->GetFillColor() != GetFillColor()) {
-         if (frame->GetFillColor() > 228) {
-            TColor::SaveColor(out, frame->GetFillColor());
+         if (TColor::SaveColor(out, frame->GetFillColor()))
             out<<"   "<<cname<<"->SetFrameFillColor(ci);" << std::endl;
-         } else
+         else
             out<<"   "<<cname<<"->SetFrameFillColor("<<frame->GetFillColor()<<");"<<std::endl;
       }
       if (frame->GetFillStyle() != 1001) {
@@ -5795,10 +5791,9 @@ void TPad::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
          out<<"   "<<cname<<"->SetFrameLineStyle("<<frame->GetLineStyle()<<");"<<std::endl;
       }
       if (frame->GetLineColor() != 1) {
-         if (frame->GetLineColor() > 228) {
-            TColor::SaveColor(out, frame->GetLineColor());
+         if (TColor::SaveColor(out, frame->GetLineColor()))
             out<<"   "<<cname<<"->SetFrameLineColor(ci);" << std::endl;
-         } else
+         else
             out<<"   "<<cname<<"->SetFrameLineColor("<<frame->GetLineColor()<<");"<<std::endl;
       }
       if (frame->GetLineWidth() != 1) {

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -5651,7 +5651,7 @@ void TPad::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
    TContext ctxt(this, kFALSE); // not interactive
 
    char quote = '"';
-   char lcname[10];
+   char lcname[100];
    const char *cname = GetName();
    size_t nch = strlen(cname);
    if (nch < sizeof(lcname)) {
@@ -5684,23 +5684,17 @@ void TPad::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
    }
    out<<"   "<<cname<<"->Range("<<fX1<<","<<fY1<<","<<fX2<<","<<fY2<<");"<<std::endl;
    TView *view = GetView();
-   Double_t rmin[3], rmax[3];
    if (view) {
+      Double_t rmin[3], rmax[3];
       view->GetRange(rmin, rmax);
       static Int_t viewNumber = 0;
       out<<"   TView *view"<<++viewNumber<<" = TView::CreateView(1);"<<std::endl;
       out<<"   view"<<viewNumber<<"->SetRange("<<rmin[0]<<","<<rmin[1]<<","<<rmin[2]<<","
                                <<rmax[0]<<","<<rmax[1]<<","<<rmax[2]<<");"<<std::endl;
    }
-   if (GetFillColor() != 19) {
-      if (TColor::SaveColor(out, GetFillColor()))
-         out<<"   "<<cname<<"->SetFillColor(ci);" << std::endl;
-      else
-         out<<"   "<<cname<<"->SetFillColor("<<GetFillColor()<<");"<<std::endl;
-   }
-   if (GetFillStyle() != 1001) {
-      out<<"   "<<cname<<"->SetFillStyle("<<GetFillStyle()<<");"<<std::endl;
-   }
+
+   SaveFillAttributes(out, cname, 19, 1001);
+
    if (GetBorderMode() != 1) {
       out<<"   "<<cname<<"->SetBorderMode("<<GetBorderMode()<<");"<<std::endl;
    }

--- a/graf2d/graf/src/TGaxis.cxx
+++ b/graf2d/graf/src/TGaxis.cxx
@@ -2574,17 +2574,15 @@ void TGaxis::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
    }
 
    if (fLabelColor != 1) {
-      if (fLabelColor > 228) {
-         TColor::SaveColor(out, fLabelColor);
+      if (TColor::SaveColor(out, fLabelColor))
          out<<"   gaxis->SetLabelColor(ci);" << std::endl;
-      } else
+      else
          out<<"   gaxis->SetLabelColor("<<GetLabelColor()<<");"<<std::endl;
    }
    if (fLineColor != 1) {
-      if (fLineColor > 228) {
-         TColor::SaveColor(out, fLineColor);
+      if (TColor::SaveColor(out, fLineColor))
          out<<"   gaxis->SetLineColor(ci);" << std::endl;
-      } else
+      else
          out<<"   gaxis->SetLineColor("<<GetLineColor()<<");"<<std::endl;
    }
    if (fLineStyle != 1) {

--- a/graf2d/graf/src/TPaveText.cxx
+++ b/graf2d/graf/src/TPaveText.cxx
@@ -684,150 +684,94 @@ void TPaveText::SaveLines(std::ostream &out, const char *name, Bool_t saved)
 
    // Iterate over all lines
    char quote = '"';
-   TObject *line;
-   TText *linet;
-   TLatex *latex;
-   TLine *linel;
-   TBox  *lineb;
    TIter next(fLines);
-   Bool_t savedlt = kFALSE;
-   Bool_t savedt = kFALSE;
-   Bool_t savedl = kFALSE;
-   Bool_t savedb = kFALSE;
 
-   while ((line = (TObject*) next())) {
-   // Next primitive is a line
+   Bool_t savedlt = kFALSE, savedt = kFALSE, savedl = kFALSE, savedb = kFALSE;
+
+   while (auto line = next()) {
+      // Next primitive is a line
       if (line->IsA() == TLine::Class()) {
-         linel = (TLine*)line;
+         auto linel = (TLine*)line;
          if (saved || savedl) {
             out<<"   ";
          } else {
             out<<"   TLine *";
             savedl = kTRUE;
          }
-         out<<name<<"_Line = "<<name<<"->AddLine("
+
+         auto line_name = TString::Format("%s_Line", name);
+
+         out<<line_name<<" = "<<name<<"->AddLine("
             <<linel->GetX1()<<","<<linel->GetY1()<<","<<linel->GetX2()<<","<<linel->GetY2()<<");"<<std::endl;
-         if (linel->GetLineColor() != 1) {
-            if (TColor::SaveColor(out, linel->GetLineColor()))
-               out<<"   "<<name<<"_Line->SetLineColor(ci);" << std::endl;
-            else
-               out<<"   "<<name<<"_Line->SetLineColor("<<linel->GetLineColor()<<");"<<std::endl;
-         }
-         if (linel->GetLineStyle() != 1) {
-            out<<"   "<<name<<"_Line->SetLineStyle("<<linel->GetLineStyle()<<");"<<std::endl;
-         }
-         if (linel->GetLineWidth() != 1) {
-            out<<"   "<<name<<"_Line->SetLineWidth("<<linel->GetLineWidth()<<");"<<std::endl;
-         }
+
+         linel->SaveLineAttributes(out, line_name.Data(), 1, 1, 1);
          continue;
       }
-   // Next primitive is a box
+      // Next primitive is a box
       if (line->IsA() == TBox::Class()) {
-         lineb = (TBox*)line;
+         auto lineb = (TBox*)line;
          if (saved || savedb) {
             out<<"   ";
          } else {
             out<<"   TBox *";
             savedb = kTRUE;
          }
-         out<<name<<"_Box = "<<name<<"->AddBox("
+
+         auto box_name = TString::Format("%s_Box", name);
+
+         out<<box_name<<" = "<<name<<"->AddBox("
             <<lineb->GetX1()<<","<<lineb->GetY1()<<","<<lineb->GetX2()<<","<<lineb->GetY2()<<");"<<std::endl;
-         if (lineb->GetFillColor() != 18) {
-            if (TColor::SaveColor(out, lineb->GetFillColor()))
-               out<<"   "<<name<<"_Box->SetFillColor(ci);" << std::endl;
-            else
-               out<<"   "<<name<<"_Box->SetFillColor("<<lineb->GetFillColor()<<");"<<std::endl;
-         }
-         if (lineb->GetFillStyle() != 1001) {
-            out<<"   "<<name<<"_Box->SetFillStyle("<<lineb->GetFillStyle()<<");"<<std::endl;
-         }
-         if (lineb->GetLineColor() != 1) {
-            if (TColor::SaveColor(out, lineb->GetLineColor()))
-               out<<"   "<<name<<"_Box->SetLineColor(ci);" << std::endl;
-            else
-               out<<"   "<<name<<"_Box->SetLineColor("<<lineb->GetLineColor()<<");"<<std::endl;
-         }
-         if (lineb->GetLineStyle() != 1) {
-            out<<"   "<<name<<"_Box->SetLineStyle("<<lineb->GetLineStyle()<<");"<<std::endl;
-         }
-         if (lineb->GetLineWidth() != 1) {
-            out<<"   "<<name<<"_Box->SetLineWidth("<<lineb->GetLineWidth()<<");"<<std::endl;
-         }
+
+         lineb->SaveFillAttributes(out, box_name.Data(), 18, 1001);
+         lineb->SaveLineAttributes(out, box_name.Data(), 1, 1, 1);
          continue;
       }
-   // Next primitive is a text
+      // Next primitive is a text
       if (line->IsA() == TText::Class()) {
-         linet = (TText*)line;
+         auto linet = (TText*)line;
          if (saved || savedt) {
             out<<"   ";
          } else {
             out<<"   TText *";
             savedt = kTRUE;
          }
-         if (!linet->GetX() && !linet->GetY()) {
-            TString s = linet->GetTitle();
-            s.ReplaceAll("\"","\\\"");
-            out<<name<<"_Text = "<<name<<"->AddText("
-               <<quote<<s.Data()<<quote<<");"<<std::endl;
-         } else {
-            out<<name<<"_Text = "<<name<<"->AddText("
-               <<linet->GetX()<<","<<linet->GetY()<<","<<quote<<linet->GetTitle()<<quote<<");"<<std::endl;
-         }
-         if (linet->GetTextColor()) {
-            if (TColor::SaveColor(out, linet->GetTextColor()))
-               out<<"   "<<name<<"_Text->SetTextColor(ci);" << std::endl;
-            else
-               out<<"   "<<name<<"_Text->SetTextColor("<<linet->GetTextColor()<<");"<<std::endl;
-         }
-         if (linet->GetTextFont()) {
-            out<<"   "<<name<<"_Text->SetTextFont("<<linet->GetTextFont()<<");"<<std::endl;
-         }
-         if (linet->GetTextSize()) {
-            out<<"   "<<name<<"_Text->SetTextSize("<<linet->GetTextSize()<<");"<<std::endl;
-         }
-         if (linet->GetTextAngle() != GetTextAngle()) {
-            out<<"   "<<name<<"_Text->SetTextAngle("<<linet->GetTextAngle()<<");"<<std::endl;
-         }
-         if (linet->GetTextAlign()) {
-            out<<"   "<<name<<"_Text->SetTextAlign("<<linet->GetTextAlign()<<");"<<std::endl;
-         }
+
+         auto text_name = TString::Format("%s_Text", name);
+
+         TString s = linet->GetTitle();
+         s.ReplaceSpecialCppChars();
+
+         if (!linet->GetX() && !linet->GetY())
+            out<<text_name<<" = "<<name<<"->AddText(" <<quote<<s<<quote<<");"<<std::endl;
+         else
+            out<<text_name<<" = "<<name<<"->AddText("
+               <<linet->GetX()<<","<<linet->GetY()<<","<<quote<<s<<quote<<");"<<std::endl;
+
+         linet->SaveTextAttributes(out, text_name.Data(), 0, GetTextAngle(), 0, 0, 0);
+         continue;
       }
-   // Next primitive is a Latex text
+      // Next primitive is a Latex text
       if (line->IsA() == TLatex::Class()) {
-         latex = (TLatex*)line;
+         auto latex = (TLatex*)line;
          if (saved || savedlt) {
             out<<"   ";
          } else {
             out<<"   TText *";
             savedlt = kTRUE;
          }
-         if (!latex->GetX() && !latex->GetY()) {
-            TString sl = latex->GetTitle();
-            sl.ReplaceAll("\"","\\\"");
-            out<<name<<"_LaTex = "<<name<<"->AddText("
-               <<quote<<sl.Data()<<quote<<");"<<std::endl;
-         } else {
-            out<<name<<"_LaTex = "<<name<<"->AddText("
-               <<latex->GetX()<<","<<latex->GetY()<<","<<quote<<latex->GetTitle()<<quote<<");"<<std::endl;
-         }
-         if (latex->GetTextColor()) {
-            if (TColor::SaveColor(out, latex->GetTextColor()))
-               out<<"   "<<name<<"_LaTex->SetTextColor(ci);" << std::endl;
-            else
-               out<<"   "<<name<<"_LaTex->SetTextColor("<<latex->GetTextColor()<<");"<<std::endl;
-         }
-         if (latex->GetTextFont()) {
-            out<<"   "<<name<<"_LaTex->SetTextFont("<<latex->GetTextFont()<<");"<<std::endl;
-         }
-         if (latex->GetTextSize()) {
-            out<<"   "<<name<<"_LaTex->SetTextSize("<<latex->GetTextSize()<<");"<<std::endl;
-         }
-         if (latex->GetTextAngle() != GetTextAngle()) {
-            out<<"   "<<name<<"_LaTex->SetTextAngle("<<latex->GetTextAngle()<<");"<<std::endl;
-         }
-         if (latex->GetTextAlign()) {
-            out<<"   "<<name<<"_LaTex->SetTextAlign("<<latex->GetTextAlign()<<");"<<std::endl;
-         }
+
+         auto latex_name = TString::Format("%s_LaTex", name);
+
+         TString sl = latex->GetTitle();
+         sl.ReplaceSpecialCppChars();
+
+         if (!latex->GetX() && !latex->GetY())
+            out<< latex_name << " = "<<name<<"->AddText(" <<quote<<sl<<quote<<");"<<std::endl;
+         else
+            out<< latex_name << " = "<<name<<"->AddText("
+               <<latex->GetX()<<","<<latex->GetY()<<","<<quote<<sl<<quote<<");"<<std::endl;
+
+         latex->SaveTextAttributes(out, latex_name.Data(), 0, GetTextAngle(), 0, 0, 0);
       }
    }
 }

--- a/graf2d/graf/src/TPaveText.cxx
+++ b/graf2d/graf/src/TPaveText.cxx
@@ -708,10 +708,9 @@ void TPaveText::SaveLines(std::ostream &out, const char *name, Bool_t saved)
          out<<name<<"_Line = "<<name<<"->AddLine("
             <<linel->GetX1()<<","<<linel->GetY1()<<","<<linel->GetX2()<<","<<linel->GetY2()<<");"<<std::endl;
          if (linel->GetLineColor() != 1) {
-            if (linel->GetLineColor() > 228) {
-               TColor::SaveColor(out, linel->GetLineColor());
+            if (TColor::SaveColor(out, linel->GetLineColor()))
                out<<"   "<<name<<"_Line->SetLineColor(ci);" << std::endl;
-            } else
+            else
                out<<"   "<<name<<"_Line->SetLineColor("<<linel->GetLineColor()<<");"<<std::endl;
          }
          if (linel->GetLineStyle() != 1) {
@@ -734,20 +733,18 @@ void TPaveText::SaveLines(std::ostream &out, const char *name, Bool_t saved)
          out<<name<<"_Box = "<<name<<"->AddBox("
             <<lineb->GetX1()<<","<<lineb->GetY1()<<","<<lineb->GetX2()<<","<<lineb->GetY2()<<");"<<std::endl;
          if (lineb->GetFillColor() != 18) {
-            if (lineb->GetFillColor() > 228) {
-               TColor::SaveColor(out, lineb->GetFillColor());
+            if (TColor::SaveColor(out, lineb->GetFillColor()))
                out<<"   "<<name<<"_Box->SetFillColor(ci);" << std::endl;
-            } else
+            else
                out<<"   "<<name<<"_Box->SetFillColor("<<lineb->GetFillColor()<<");"<<std::endl;
          }
          if (lineb->GetFillStyle() != 1001) {
             out<<"   "<<name<<"_Box->SetFillStyle("<<lineb->GetFillStyle()<<");"<<std::endl;
          }
          if (lineb->GetLineColor() != 1) {
-            if (lineb->GetLineColor() > 228) {
-               TColor::SaveColor(out, lineb->GetLineColor());
+            if (TColor::SaveColor(out, lineb->GetLineColor()))
                out<<"   "<<name<<"_Box->SetLineColor(ci);" << std::endl;
-            } else
+            else
                out<<"   "<<name<<"_Box->SetLineColor("<<lineb->GetLineColor()<<");"<<std::endl;
          }
          if (lineb->GetLineStyle() != 1) {
@@ -777,10 +774,9 @@ void TPaveText::SaveLines(std::ostream &out, const char *name, Bool_t saved)
                <<linet->GetX()<<","<<linet->GetY()<<","<<quote<<linet->GetTitle()<<quote<<");"<<std::endl;
          }
          if (linet->GetTextColor()) {
-            if (linet->GetTextColor() > 228) {
-               TColor::SaveColor(out, linet->GetTextColor());
+            if (TColor::SaveColor(out, linet->GetTextColor()))
                out<<"   "<<name<<"_Text->SetTextColor(ci);" << std::endl;
-            } else
+            else
                out<<"   "<<name<<"_Text->SetTextColor("<<linet->GetTextColor()<<");"<<std::endl;
          }
          if (linet->GetTextFont()) {
@@ -815,10 +811,9 @@ void TPaveText::SaveLines(std::ostream &out, const char *name, Bool_t saved)
                <<latex->GetX()<<","<<latex->GetY()<<","<<quote<<latex->GetTitle()<<quote<<");"<<std::endl;
          }
          if (latex->GetTextColor()) {
-            if (latex->GetTextColor() > 228) {
-               TColor::SaveColor(out, latex->GetTextColor());
+            if (TColor::SaveColor(out, latex->GetTextColor()))
                out<<"   "<<name<<"_LaTex->SetTextColor(ci);" << std::endl;
-            } else
+            else
                out<<"   "<<name<<"_LaTex->SetTextColor("<<latex->GetTextColor()<<");"<<std::endl;
          }
          if (latex->GetTextFont()) {

--- a/graf2d/graf/src/TPie.cxx
+++ b/graf2d/graf/src/TPie.cxx
@@ -12,19 +12,20 @@
 #include "TPie.h"
 #include "TPieSlice.h"
 
+#include "TROOT.h"
+#include "TVirtualPad.h"
+#include "TVirtualX.h"
+#include "TArc.h"
+#include "TLegend.h"
+#include "TMath.h"
+#include "TStyle.h"
+#include "TLatex.h"
+#include "TPaveText.h"
+#include "TH1.h"
+#include "TColor.h"
+#include "TLine.h"
+
 #include <iostream>
-#include <TROOT.h>
-#include <TVirtualPad.h>
-#include <TVirtualX.h>
-#include <TArc.h>
-#include <TLegend.h>
-#include <TMath.h>
-#include <TStyle.h>
-#include <TLatex.h>
-#include <TPaveText.h>
-#include <TH1.h>
-#include <TColor.h>
-#include <TLine.h>
 
 ClassImp(TPie);
 
@@ -1118,52 +1119,29 @@ void TPie::Paint(Option_t *option)
 void TPie::SavePrimitive(std::ostream &out, Option_t *option)
 {
    out << "   " << std::endl;
-   if (gROOT->ClassSaved(TPie::Class())) {
+   if (gROOT->ClassSaved(TPie::Class()))
       out << "   ";
-   } else {
+   else
       out << "   TPie *";
-   }
-   out << GetName() << " = new TPie(\"" << GetName() << "\", \"" << GetTitle()
-       << "\", " << fNvals << ");" << std::endl;
-   out << "   " << GetName() << "->SetCircle(" << fX << ", " << fY << ", "
-       << fRadius << ");" << std::endl;
-   out << "   " << GetName() << "->SetValueFormat(\"" << GetValueFormat()
-       << "\");" << std::endl;
-   out << "   " << GetName() << "->SetLabelFormat(\"" << GetLabelFormat()
-       << "\");" << std::endl;
-   out << "   " << GetName() << "->SetPercentFormat(\"" << GetPercentFormat()
-       << "\");" << std::endl;
-   out << "   " << GetName() << "->SetLabelsOffset(" << GetLabelsOffset()
-       << ");" << std::endl;
-   out << "   " << GetName() << "->SetAngularOffset(" << GetAngularOffset()
-       << ");" << std::endl;
-   out << "   " << GetName() << "->SetTextAngle(" << GetTextAngle() << ");" << std::endl;
-   out << "   " << GetName() << "->SetTextColor(" << GetTextColor() << ");" << std::endl;
-   out << "   " << GetName() << "->SetTextFont(" << GetTextFont() << ");" << std::endl;
-   out << "   " << GetName() << "->SetTextSize(" << GetTextSize() << ");" << std::endl;
 
+   out << "pie = new TPie(\"" << GetName() << "\", \"" << GetTitle()
+       << "\", " << fNvals << ");" << std::endl;
+   out << "   pie->SetCircle(" << fX << ", " << fY << ", " << fRadius << ");" << std::endl;
+   out << "   pie->SetValueFormat(\"" << GetValueFormat() << "\");" << std::endl;
+   out << "   pie->SetLabelFormat(\"" << GetLabelFormat() << "\");" << std::endl;
+   out << "   pie->SetPercentFormat(\"" << GetPercentFormat()   << "\");" << std::endl;
+   out << "   pie->SetLabelsOffset(" << GetLabelsOffset() << ");" << std::endl;
+   out << "   pie->SetAngularOffset(" << GetAngularOffset() << ");" << std::endl;
+
+   SaveTextAttributes(out,"pie",11,0,1,62,0.05);
 
    // Save the values for the slices
-   for (Int_t i=0;i<fNvals;++i) {
-      out << "   " << GetName() << "->GetSlice(" << i << ")->SetTitle(\""
-          << fPieSlices[i]->GetTitle() << "\");" << std::endl;
-      out << "   " << GetName() << "->GetSlice(" << i << ")->SetValue("
-          << fPieSlices[i]->GetValue() << ");" << std::endl;
-      out << "   " << GetName() << "->GetSlice(" << i << ")->SetRadiusOffset("
-          << fPieSlices[i]->GetRadiusOffset() << ");" << std::endl;
-      out << "   " << GetName() << "->GetSlice(" << i << ")->SetFillColor("
-          << fPieSlices[i]->GetFillColor() << ");" << std::endl;
-      out << "   " << GetName() << "->GetSlice(" << i << ")->SetFillStyle("
-          << fPieSlices[i]->GetFillStyle() << ");" << std::endl;
-      out << "   " << GetName() << "->GetSlice(" << i << ")->SetLineColor("
-          << fPieSlices[i]->GetLineColor() << ");" << std::endl;
-      out << "   " << GetName() << "->GetSlice(" << i << ")->SetLineStyle("
-          << fPieSlices[i]->GetLineStyle() << ");" << std::endl;
-      out << "   " << GetName() << "->GetSlice(" << i << ")->SetLineWidth("
-          << fPieSlices[i]->GetLineWidth() << ");" << std::endl;
+   for (Int_t i = 0; i < fNvals; ++i) {
+      auto slice_name = TString::Format("pie->GetSlice(%d)", i);
+      fPieSlices[i]->SavePrimitive(out, slice_name.Data());
    }
 
-   out << "   " << GetName() << "->Draw(\"" << option << "\");" << std::endl;
+   out << "   pie->Draw(\"" << option << "\");" << std::endl;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/graf/src/TPieSlice.cxx
+++ b/graf2d/graf/src/TPieSlice.cxx
@@ -6,11 +6,14 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include <TPieSlice.h>
+#include "TPieSlice.h"
 
-#include <TError.h>
-#include <TVirtualPad.h>
-#include <TPie.h>
+#include "TError.h"
+#include "TVirtualPad.h"
+#include "TPie.h"
+
+#include <iostream>
+#include <cstring>
 
 ClassImp(TPieSlice);
 
@@ -79,10 +82,20 @@ Double_t TPieSlice::GetValue() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Do nothing.
+/// Save as C++ macro, used directly from TPie
 
-void TPieSlice::SavePrimitive(std::ostream &/*out*/, Option_t * /*opts*/)
+void TPieSlice::SavePrimitive(std::ostream &out, Option_t *opts)
 {
+   const char *name = opts;
+   if (!name || !*name || strncmp(name, "pie->", 5))
+      return;
+
+   out << "   " << name << "->SetTitle(\"" << GetTitle() << "\");" << std::endl;
+   out << "   " << name << "->SetValue(" << GetValue() << ");" << std::endl;
+   out << "   " << name << "->SetRadiusOffset(" << GetRadiusOffset() << ");" << std::endl;
+
+   SaveFillAttributes(out, name, 0, 1001);
+   SaveLineAttributes(out, name, 1, 1, 1);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/graf/src/TPolyLine.cxx
+++ b/graf2d/graf/src/TPolyLine.cxx
@@ -50,19 +50,15 @@ TPolyLine::TPolyLine()
 
 ////////////////////////////////////////////////////////////////////////////////
 /// PolyLine normal constructor without initialisation.
-/// Allocates n points.  The option string is ignored.
+/// Allocates n points.
 
 TPolyLine::TPolyLine(Int_t n, Option_t *option)
       :TObject(), TAttLine(), TAttFill()
 {
    fOption = option;
-   fLastPoint = -1;
-   if (n <= 0) {
-      fN = 0;
-      fLastPoint = -1;
-      fX = fY = nullptr;
+   if (n <= 0)
       return;
-   }
+
    fN = n;
    fX = new Double_t[fN];
    fY = new Double_t[fN];
@@ -71,19 +67,14 @@ TPolyLine::TPolyLine(Int_t n, Option_t *option)
 ////////////////////////////////////////////////////////////////////////////////
 /// PolyLine normal constructor (single precision).
 /// Makes n points with (x, y) coordinates from x and y.
-/// The option string is ignored.
 
 TPolyLine::TPolyLine(Int_t n, Float_t *x, Float_t *y, Option_t *option)
       :TObject(), TAttLine(), TAttFill()
 {
    fOption = option;
-   fLastPoint = -1;
-   if (n <= 0) {
-      fN = 0;
-      fLastPoint = -1;
-      fX = fY = nullptr;
+   if (n <= 0)
       return;
-   }
+
    fN = n;
    fX = new Double_t[fN];
    fY = new Double_t[fN];
@@ -98,24 +89,21 @@ TPolyLine::TPolyLine(Int_t n, Float_t *x, Float_t *y, Option_t *option)
 ////////////////////////////////////////////////////////////////////////////////
 /// PolyLine normal constructor (double precision).
 /// Makes n points with (x, y) coordinates from x and y.
-/// The option string is ignored.
 
 TPolyLine::TPolyLine(Int_t n, Double_t *x, Double_t *y, Option_t *option)
       :TObject(), TAttLine(), TAttFill()
 {
    fOption = option;
-   fLastPoint = -1;
-   if (n <= 0) {
-      fN = 0;
-      fLastPoint = -1;
-      fX = fY = nullptr;
+   if (n <= 0)
       return;
-   }
    fN = n;
    fX = new Double_t[fN];
    fY = new Double_t[fN];
    if (!x || !y) return;
-   for (Int_t i=0; i<fN;i++) { fX[i] = x[i]; fY[i] = y[i];}
+   for (Int_t i=0; i<fN;i++) {
+      fX[i] = x[i];
+      fY[i] = y[i];
+   }
    fLastPoint = fN-1;
 }
 
@@ -143,10 +131,6 @@ TPolyLine::~TPolyLine()
 
 TPolyLine::TPolyLine(const TPolyLine &polyline) : TObject(polyline), TAttLine(polyline), TAttFill(polyline)
 {
-   fN = 0;
-   fX = nullptr;
-   fY = nullptr;
-   fLastPoint = -1;
    polyline.TPolyLine::Copy(*this);
 }
 
@@ -596,22 +580,20 @@ void TPolyLine::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
    char quote = '"';
    out<<"   "<<std::endl;
-   if (gROOT->ClassSaved(TPolyLine::Class())) {
+   if (gROOT->ClassSaved(TPolyLine::Class()))
       out<<"   ";
-   } else {
-      out<<"   Double_t *dum = 0;"<<std::endl;
+   else
       out<<"   TPolyLine *";
-   }
-   out<<"pline = new TPolyLine("<<fN<<",dum,dum,"<<quote<<fOption<<quote<<");"<<std::endl;
 
-   SaveFillAttributes(out,"pline",0,1001);
-   SaveLineAttributes(out,"pline",1,1,1);
+   out<<"pline = new TPolyLine("<<fN<<","<<quote<<fOption<<quote<<");"<<std::endl;
 
-   for (Int_t i=0;i<Size();i++) {
+   SaveFillAttributes(out, "pline", 0, 1001);
+   SaveLineAttributes(out, "pline", 1, 1, 1);
+
+   for (Int_t i=0;i<Size();i++)
       out<<"   pline->SetPoint("<<i<<","<<fX[i]<<","<<fY[i]<<");"<<std::endl;
-   }
-   out<<"   pline->Draw("
-      <<quote<<option<<quote<<");"<<std::endl;
+
+   out<<"   pline->Draw("<<quote<<option<<quote<<");"<<std::endl;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -663,7 +645,7 @@ void TPolyLine::SetPoint(Int_t n, Double_t x, Double_t y)
    }
    fX[n] = x;
    fY[n] = y;
-   fLastPoint = TMath::Max(fLastPoint,n);
+   fLastPoint = TMath::Max(fLastPoint, n);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -3307,20 +3307,18 @@ void TF1::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       out << "   " << f1Name.Data() << "->SetBit(TF1::kNotDraw);" << std::endl;
    }
    if (GetFillColor() != 0) {
-      if (GetFillColor() > 228) {
-         TColor::SaveColor(out, GetFillColor());
+      if (TColor::SaveColor(out, GetFillColor()))
          out << "   " << f1Name.Data() << "->SetFillColor(ci);" << std::endl;
-      } else
+      else
          out << "   " << f1Name.Data() << "->SetFillColor(" << GetFillColor() << ");" << std::endl;
    }
    if (GetFillStyle() != 1001) {
       out << "   " << f1Name.Data() << "->SetFillStyle(" << GetFillStyle() << ");" << std::endl;
    }
    if (GetMarkerColor() != 1) {
-      if (GetMarkerColor() > 228) {
-         TColor::SaveColor(out, GetMarkerColor());
+      if (TColor::SaveColor(out, GetMarkerColor()))
          out << "   " << f1Name.Data() << "->SetMarkerColor(ci);" << std::endl;
-      } else
+      else
          out << "   " << f1Name.Data() << "->SetMarkerColor(" << GetMarkerColor() << ");" << std::endl;
    }
    if (GetMarkerStyle() != 1) {
@@ -3330,10 +3328,9 @@ void TF1::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       out << "   " << f1Name.Data() << "->SetMarkerSize(" << GetMarkerSize() << ");" << std::endl;
    }
    if (GetLineColor() != 1) {
-      if (GetLineColor() > 228) {
-         TColor::SaveColor(out, GetLineColor());
+      if (TColor::SaveColor(out, GetLineColor()))
          out << "   " << f1Name.Data() << "->SetLineColor(ci);" << std::endl;
-      } else
+      else
          out << "   " << f1Name.Data() << "->SetLineColor(" << GetLineColor() << ");" << std::endl;
    }
    if (GetLineWidth() != 4) {

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -3306,39 +3306,11 @@ void TF1::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    if (TestBit(kNotDraw)) {
       out << "   " << f1Name.Data() << "->SetBit(TF1::kNotDraw);" << std::endl;
    }
-   if (GetFillColor() != 0) {
-      if (TColor::SaveColor(out, GetFillColor()))
-         out << "   " << f1Name.Data() << "->SetFillColor(ci);" << std::endl;
-      else
-         out << "   " << f1Name.Data() << "->SetFillColor(" << GetFillColor() << ");" << std::endl;
-   }
-   if (GetFillStyle() != 1001) {
-      out << "   " << f1Name.Data() << "->SetFillStyle(" << GetFillStyle() << ");" << std::endl;
-   }
-   if (GetMarkerColor() != 1) {
-      if (TColor::SaveColor(out, GetMarkerColor()))
-         out << "   " << f1Name.Data() << "->SetMarkerColor(ci);" << std::endl;
-      else
-         out << "   " << f1Name.Data() << "->SetMarkerColor(" << GetMarkerColor() << ");" << std::endl;
-   }
-   if (GetMarkerStyle() != 1) {
-      out << "   " << f1Name.Data() << "->SetMarkerStyle(" << GetMarkerStyle() << ");" << std::endl;
-   }
-   if (GetMarkerSize() != 1) {
-      out << "   " << f1Name.Data() << "->SetMarkerSize(" << GetMarkerSize() << ");" << std::endl;
-   }
-   if (GetLineColor() != 1) {
-      if (TColor::SaveColor(out, GetLineColor()))
-         out << "   " << f1Name.Data() << "->SetLineColor(ci);" << std::endl;
-      else
-         out << "   " << f1Name.Data() << "->SetLineColor(" << GetLineColor() << ");" << std::endl;
-   }
-   if (GetLineWidth() != 4) {
-      out << "   " << f1Name.Data() << "->SetLineWidth(" << GetLineWidth() << ");" << std::endl;
-   }
-   if (GetLineStyle() != 1) {
-      out << "   " << f1Name.Data() << "->SetLineStyle(" << GetLineStyle() << ");" << std::endl;
-   }
+
+   SaveFillAttributes(out, f1Name.Data(), 0, 1001);
+   SaveMarkerAttributes(out, f1Name.Data(), 1, 1, 1);
+   SaveLineAttributes(out, f1Name.Data(), 1, 1, 4);
+
    if (GetChisquare() != 0) {
       out << "   " << f1Name.Data() << "->SetChisquare(" << GetChisquare() << ");" << std::endl;
       out << "   " << f1Name.Data() << "->SetNDF(" << GetNDF() << ");" << std::endl;

--- a/hist/hist/src/TF2.cxx
+++ b/hist/hist/src/TF2.cxx
@@ -855,20 +855,18 @@ void TF2::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    }
 
    if (GetFillColor() != 0) {
-      if (GetFillColor() > 228) {
-         TColor::SaveColor(out, GetFillColor());
+      if (TColor::SaveColor(out, GetFillColor()))
          out<<"   "<<GetName()<<"->SetFillColor(ci);" << std::endl;
-      } else
+      else
          out<<"   "<<GetName()<<"->SetFillColor("<<GetFillColor()<<");"<<std::endl;
    }
    if (GetFillStyle() != 1001) {
       out<<"   "<<GetName()<<"->SetFillStyle("<<GetFillStyle()<<");"<<std::endl;
    }
    if (GetMarkerColor() != 1) {
-      if (GetMarkerColor() > 228) {
-         TColor::SaveColor(out, GetMarkerColor());
+      if (TColor::SaveColor(out, GetMarkerColor()))
          out<<"   "<<GetName()<<"->SetMarkerColor(ci);" << std::endl;
-      } else
+      else
          out<<"   "<<GetName()<<"->SetMarkerColor("<<GetMarkerColor()<<");"<<std::endl;
    }
    if (GetMarkerStyle() != 1) {
@@ -878,10 +876,9 @@ void TF2::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       out<<"   "<<GetName()<<"->SetMarkerSize("<<GetMarkerSize()<<");"<<std::endl;
    }
    if (GetLineColor() != 1) {
-      if (GetLineColor() > 228) {
-         TColor::SaveColor(out, GetLineColor());
+      if (TColor::SaveColor(out, GetLineColor()))
          out<<"   "<<GetName()<<"->SetLineColor(ci);" << std::endl;
-      } else
+      else
          out<<"   "<<GetName()<<"->SetLineColor("<<GetLineColor()<<");"<<std::endl;
    }
    if (GetLineWidth() != 4) {

--- a/hist/hist/src/TF2.cxx
+++ b/hist/hist/src/TF2.cxx
@@ -854,45 +854,15 @@ void TF2::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       out<<GetName()<<" = new TF2("<<quote<<GetName()<<quote<<","<<GetTitle()<<","<<fXmin<<","<<fXmax<<","<<fYmin<<","<<fYmax<<","<<GetNpar()<<");"<<std::endl;
    }
 
-   if (GetFillColor() != 0) {
-      if (TColor::SaveColor(out, GetFillColor()))
-         out<<"   "<<GetName()<<"->SetFillColor(ci);" << std::endl;
-      else
-         out<<"   "<<GetName()<<"->SetFillColor("<<GetFillColor()<<");"<<std::endl;
-   }
-   if (GetFillStyle() != 1001) {
-      out<<"   "<<GetName()<<"->SetFillStyle("<<GetFillStyle()<<");"<<std::endl;
-   }
-   if (GetMarkerColor() != 1) {
-      if (TColor::SaveColor(out, GetMarkerColor()))
-         out<<"   "<<GetName()<<"->SetMarkerColor(ci);" << std::endl;
-      else
-         out<<"   "<<GetName()<<"->SetMarkerColor("<<GetMarkerColor()<<");"<<std::endl;
-   }
-   if (GetMarkerStyle() != 1) {
-      out<<"   "<<GetName()<<"->SetMarkerStyle("<<GetMarkerStyle()<<");"<<std::endl;
-   }
-   if (GetMarkerSize() != 1) {
-      out<<"   "<<GetName()<<"->SetMarkerSize("<<GetMarkerSize()<<");"<<std::endl;
-   }
-   if (GetLineColor() != 1) {
-      if (TColor::SaveColor(out, GetLineColor()))
-         out<<"   "<<GetName()<<"->SetLineColor(ci);" << std::endl;
-      else
-         out<<"   "<<GetName()<<"->SetLineColor("<<GetLineColor()<<");"<<std::endl;
-   }
-   if (GetLineWidth() != 4) {
-      out<<"   "<<GetName()<<"->SetLineWidth("<<GetLineWidth()<<");"<<std::endl;
-   }
-   if (GetLineStyle() != 1) {
-      out<<"   "<<GetName()<<"->SetLineStyle("<<GetLineStyle()<<");"<<std::endl;
-   }
-   if (GetNpx() != 100) {
+   SaveFillAttributes(out, GetName(), 0, 1001);
+   SaveMarkerAttributes(out, GetName(), 1, 1, 1);
+   SaveLineAttributes(out, GetName(), 1, 1, 4);
+
+   if (GetNpx() != 100)
       out<<"   "<<GetName()<<"->SetNpx("<<GetNpx()<<");"<<std::endl;
-   }
-   if (GetChisquare() != 0) {
+   if (GetChisquare() != 0)
       out<<"   "<<GetName()<<"->SetChisquare("<<GetChisquare()<<");"<<std::endl;
-   }
+
    Double_t parmin, parmax;
    for (Int_t i=0;i<GetNpar();i++) {
       out<<"   "<<GetName()<<"->SetParameter("<<i<<","<<GetParameter(i)<<");"<<std::endl;
@@ -900,8 +870,7 @@ void TF2::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       GetParLimits(i,parmin,parmax);
       out<<"   "<<GetName()<<"->SetParLimits("<<i<<","<<parmin<<","<<parmax<<");"<<std::endl;
    }
-   out<<"   "<<GetName()<<"->Draw("
-      <<quote<<option<<quote<<");"<<std::endl;
+   out<<"   "<<GetName()<<"->Draw("<<quote<<option<<quote<<");"<<std::endl;
 }
 
 

--- a/hist/hist/src/TF3.cxx
+++ b/hist/hist/src/TF3.cxx
@@ -620,17 +620,15 @@ void TF3::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    }
 
    if (GetFillColor() != 0) {
-      if (GetFillColor() > 228) {
-         TColor::SaveColor(out, GetFillColor());
+      if (TColor::SaveColor(out, GetFillColor()))
          out<<"   "<<GetName()<<"->SetFillColor(ci);" << std::endl;
-      } else
+      else
          out<<"   "<<GetName()<<"->SetFillColor("<<GetFillColor()<<");"<<std::endl;
    }
    if (GetLineColor() != 1) {
-      if (GetLineColor() > 228) {
-         TColor::SaveColor(out, GetLineColor());
+      if (TColor::SaveColor(out, GetLineColor()))
          out<<"   "<<GetName()<<"->SetLineColor(ci);" << std::endl;
-      } else
+      else
          out<<"   "<<GetName()<<"->SetLineColor("<<GetLineColor()<<");"<<std::endl;
    }
    if (GetNpz() != 100) {

--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -2398,18 +2398,7 @@ void TChain::SavePrimitive(std::ostream &out, Option_t *option)
    }
    out << std::endl;
 
-   if (GetMarkerColor() != 1) {
-      if (TColor::SaveColor(out, GetMarkerColor()))
-         out << "   " << chName.Data() << "->SetMarkerColor(ci);" << std::endl;
-      else
-         out << "   " << chName.Data() << "->SetMarkerColor(" << GetMarkerColor() << ");" << std::endl;
-   }
-   if (GetMarkerStyle() != 1) {
-      out << "   " << chName.Data() << "->SetMarkerStyle(" << GetMarkerStyle() << ");" << std::endl;
-   }
-   if (GetMarkerSize() != 1) {
-      out << "   " << chName.Data() << "->SetMarkerSize(" << GetMarkerSize() << ");" << std::endl;
-   }
+   SaveMarkerAttributes(out, chName.Data(), 1, 1, 1);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -2399,10 +2399,9 @@ void TChain::SavePrimitive(std::ostream &out, Option_t *option)
    out << std::endl;
 
    if (GetMarkerColor() != 1) {
-      if (GetMarkerColor() > 228) {
-         TColor::SaveColor(out, GetMarkerColor());
+      if (TColor::SaveColor(out, GetMarkerColor()))
          out << "   " << chName.Data() << "->SetMarkerColor(ci);" << std::endl;
-      } else
+      else
          out << "   " << chName.Data() << "->SetMarkerColor(" << GetMarkerColor() << ");" << std::endl;
    }
    if (GetMarkerStyle() != 1) {


### PR DESCRIPTION
Fixes #11916

When `TColor` object with required index not exists, it will not be saved.
Making produced macro either not working or not correctly working.

To resolve problem making `TColor::SaveColor` return boolean to decide that to do. 
Adjust all methods where `SaveColor` was used.
Code based on old behavior will work as before.

Shrink many `SavePrimitive` methods using attributes method to save fill/line/text attributes.

