### PR TITLE
[geo] fix TGeoManagerEditor::LoadLib

### DIFF
--- a/geom/geombuilder/inc/TGeoManagerEditor.h
+++ b/geom/geombuilder/inc/TGeoManagerEditor.h
@@ -113,7 +113,7 @@ public:
                     UInt_t options = kChildFrame,
                     Pixel_t back = GetDefaultFrameBackground());
    virtual ~TGeoManagerEditor();
-   static void    LoadLib() {}
+   static void    LoadLib();
    virtual void   SetModel(TObject *obj);
 
    virtual void   SelectedSlot(TVirtualPad* pad, TObject* obj, Int_t event);

--- a/geom/geombuilder/src/TGeoManagerEditor.cxx
+++ b/geom/geombuilder/src/TGeoManagerEditor.cxx
@@ -1423,3 +1423,12 @@ void TGeoManagerEditor::ShowSelectMatrix(Bool_t show)
    if (show) cont->ShowFrame(f6);
    else      cont->HideFrame(f6);
 }
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Dummy static function, used to load plugin
+
+void TGeoManagerEditor::LoadLib()
+{
+
+}


### PR DESCRIPTION
Not allowed to put implementation of static method in header file Windows will not work

One of the reasons for crash, but not only