### PR TITLE
[RF] New `Offset("bin")` command argument for createNLL 

### DIFF
--- a/roofit/roofitcore/inc/RooGlobalFunc.h
+++ b/roofit/roofitcore/inc/RooGlobalFunc.h
@@ -65,8 +65,12 @@ enum MsgTopic { Generation=1, Minimization=2, Plotting=4, Fitting=8, Integration
 enum MPSplit { BulkPartition=0, Interleave=1, SimComponents=2, Hybrid=3 } ;
 
 /// For setting the batch mode flag with the BatchMode() command argument to
-/// RooAbsPdf::fitTo();
+/// RooAbsPdf::fitTo()
 enum class BatchModeOption { Off, Cpu, Cuda, Old };
+
+/// For setting the offset mode with the Offset() command argument to
+/// RooAbsPdf::fitTo()
+enum class OffsetMode { Off, Initial, Bin };
 
 namespace Experimental {
 
@@ -279,7 +283,13 @@ RooCmdArg AsymptoticError(bool flag) ;
 RooCmdArg CloneData(bool flag) ;
 RooCmdArg Integrate(bool flag) ;
 RooCmdArg Minimizer(const char* type, const char* alg=nullptr) ;
-RooCmdArg Offset(bool flag=true) ;
+RooCmdArg Offset(std::string const& mode);
+// The const char * overload is necessary, otherwise the compiler will cast a
+// C-Style string to a bool and choose the Offset(bool) overload if one
+// calls for example Offset("off").
+inline RooCmdArg Offset(const char * mode) { return Offset(std::string(mode)); }
+// For backwards compatibility
+inline RooCmdArg Offset(bool flag=true) { return flag ? Offset("initial") : Offset("off"); }
 RooCmdArg RecoverFromUndefinedRegions(double strength);
 /** @} */
 

--- a/roofit/roofitcore/inc/RooNLLVar.h
+++ b/roofit/roofitcore/inc/RooNLLVar.h
@@ -61,6 +61,10 @@ public:
     _batchEvaluations = on;
   }
 
+  void templateRatioOffset(bool on = true) {
+    _templateRatioOffset = on;
+  }
+
   using ComputeResult = std::pair<ROOT::Math::KahanSum<double>, double>;
 
   static RooNLLVar::ComputeResult computeBatchedFunc(const RooAbsPdf *pdfClone, RooAbsData *dataClone,
@@ -69,7 +73,7 @@ public:
                                                  std::size_t firstEvent, std::size_t lastEvent);
   static RooNLLVar::ComputeResult computeScalarFunc(const RooAbsPdf *pdfClone, RooAbsData *dataClone, RooArgSet *normSet,
                                                 bool weightSq, std::size_t stepSize, std::size_t firstEvent,
-                                                std::size_t lastEvent);
+                                                std::size_t lastEvent, bool templateRatioOffset=false);
 
 protected:
 
@@ -84,6 +88,7 @@ private:
 
   bool _extended{false};
   bool _batchEvaluations{false};
+  bool _templateRatioOffset{false};
   bool _weightSq{false}; ///< Apply weights squared?
   mutable bool _first{true}; ///<!
   ROOT::Math::KahanSum<double> _offsetSaveW2{0.0}; ///<!

--- a/roofit/roofitcore/src/RooFit/BatchModeHelpers.h
+++ b/roofit/roofitcore/src/RooFit/BatchModeHelpers.h
@@ -32,10 +32,11 @@ class RooFitDriver;
 namespace RooFit {
 namespace BatchModeHelpers {
 
-std::unique_ptr<RooAbsReal>
-createNLL(std::unique_ptr<RooAbsPdf> &&pdf, RooAbsData &data, std::unique_ptr<RooAbsReal> &&constraints,
-          std::string const &rangeName, RooArgSet const &projDeps, bool isExtended, double integrateOverBinsPrecision,
-          RooFit::BatchModeOption batchMode, bool doOffset, bool splitRange, bool takeGlobalObservablesFromData);
+std::unique_ptr<RooAbsReal> createNLL(std::unique_ptr<RooAbsPdf> &&pdf, RooAbsData &data,
+                                      std::unique_ptr<RooAbsReal> &&constraints, std::string const &rangeName,
+                                      RooArgSet const &projDeps, bool isExtended, double integrateOverBinsPrecision,
+                                      RooFit::BatchModeOption batchMode, RooFit::OffsetMode offset, bool splitRange,
+                                      bool takeGlobalObservablesFromData);
 
 void logArchitectureInfo(RooFit::BatchModeOption batchMode);
 

--- a/roofit/roofitcore/src/RooGlobalFunc.cxx
+++ b/roofit/roofitcore/src/RooGlobalFunc.cxx
@@ -278,7 +278,17 @@ namespace RooFit {
   RooCmdArg CloneData(bool flag)                       { return RooCmdArg("CloneData",flag,0,0,0,0,0,0,0) ; }
   RooCmdArg Integrate(bool flag)                       { return RooCmdArg("Integrate",flag,0,0,0,0,0,0,0) ; }
   RooCmdArg Minimizer(const char* type, const char* alg) { return RooCmdArg("Minimizer",0,0,0,0,type,alg,0,0) ; }
-  RooCmdArg Offset(bool flag)                          { return RooCmdArg("OffsetLikelihood",flag,0,0,0,0,0,0,0) ; }
+
+  RooCmdArg Offset(std::string const& mode) {
+      std::string lower = mode;
+      std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c){ return std::tolower(c); });
+      OffsetMode modeVal = OffsetMode::Off;
+      if(lower == "off") modeVal = OffsetMode::Off;
+      else if(lower == "initial") modeVal = OffsetMode::Initial;
+      else if(lower == "bin") modeVal = OffsetMode::Bin;
+      return RooCmdArg("OffsetLikelihood", static_cast<int>(modeVal));
+  }
+
   /// When parameters are chosen such that a PDF is undefined, try to indicate to the minimiser how to leave this region.
   /// \param strength Strength of hints for minimiser. Set to zero to switch off.
   RooCmdArg RecoverFromUndefinedRegions(double strength) { return RooCmdArg("RecoverFromUndefinedRegions",0,0,strength,0,0,0,0,0) ; }

--- a/roofit/roofitcore/src/RooNLLVarNew.cxx
+++ b/roofit/roofitcore/src/RooNLLVarNew.cxx
@@ -72,7 +72,7 @@ RooArgSet getObs(RooAbsArg const &arg, RooArgSet const &observables)
 \param isExtended Set to true if this is an extended fit
 **/
 RooNLLVarNew::RooNLLVarNew(const char *name, const char *title, RooAbsPdf &pdf, RooArgSet const &observables,
-                           bool isExtended, bool doOffset, bool binnedL)
+                           bool isExtended, RooFit::OffsetMode offsetMode, bool binnedL)
    : RooAbsReal(name, title), _pdf{"pdf", "pdf", this, pdf}, _observables{getObs(pdf, observables)},
      _isExtended{isExtended}, _binnedL{binnedL},
      _weightVar{"weightVar", "weightVar", this, *new RooRealVar(weightVarName, weightVarName, 1.0), true, false, true},
@@ -105,7 +105,8 @@ RooNLLVarNew::RooNLLVarNew(const char *name, const char *title, RooAbsPdf &pdf, 
    }
 
    resetWeightVarNames();
-   enableOffsetting(doOffset);
+   enableOffsetting(offsetMode == RooFit::OffsetMode::Initial);
+   // TODO: implement template offsetting mode as well
 }
 
 RooNLLVarNew::RooNLLVarNew(const RooNLLVarNew &other, const char *name)
@@ -290,7 +291,7 @@ double RooNLLVarNew::finalizeResult(ROOT::Math::KahanSum<double> &&result, doubl
    }
 
    // Check if value offset flag is set.
-   if (_doOffset) {
+   if (_offset) {
 
       // If no offset is stored enable this feature now
       if (_offset == 0 && result != 0) {

--- a/roofit/roofitcore/src/RooNLLVarNew.h
+++ b/roofit/roofitcore/src/RooNLLVarNew.h
@@ -14,9 +14,10 @@
 #ifndef RooFit_RooNLLVarNew_h
 #define RooFit_RooNLLVarNew_h
 
-#include "RooAbsPdf.h"
-#include "RooAbsReal.h"
-#include "RooTemplateProxy.h"
+#include <RooAbsPdf.h>
+#include <RooAbsReal.h>
+#include <RooGlobalFunc.h>
+#include <RooTemplateProxy.h>
 
 #include <Math/Util.h>
 
@@ -34,7 +35,7 @@ public:
 
    RooNLLVarNew(){};
    RooNLLVarNew(const char *name, const char *title, RooAbsPdf &pdf, RooArgSet const &observables, bool isExtended,
-                bool doOffset, bool binnedL = false);
+                RooFit::OffsetMode offsetMode, bool binnedL = false);
    RooNLLVarNew(const RooNLLVarNew &other, const char *name = nullptr);
    TObject *clone(const char *newname) const override { return new RooNLLVarNew(*this, newname); }
 


### PR DESCRIPTION
Add support for a new `Offset("bin")` command argument to create NLL.
With this new offset mode, the NLL is offsetted by the likelihood for a
template histogram model based on the obersved data. This can
drastically improve numeric stability, because the offsetting is done
for each bin. This results in per-bin values that are all in the same
order of magnitude, which reduces precision loss in the sum.

So far, it is only supported in the old test statistics when do do the
fit with a `RooDataHist` with the old test statistics.
