### PR TITLE
[math] make KahanSum::operator+= and -= consistent

### DIFF
--- a/math/mathcore/inc/Math/Util.h
+++ b/math/mathcore/inc/Math/Util.h
@@ -269,8 +269,8 @@ namespace ROOT {
        /// Note that while Tian et al. add the carry in the first step, we subtract
        /// the carry, in accordance with the Add(Indexed) implementation(s) above.
        /// This is purely an implementation choice that has no impact on performance.
-       template<typename U>
-       KahanSum& operator+=(const KahanSum<U>& other) {
+       template<typename U, unsigned int M>
+       KahanSum<T, N>& operator+=(const KahanSum<U, M>& other) {
          U corrected_arg_sum = other.Sum() - (fCarry[0] + other.Carry());
          U sum = fSum[0] + corrected_arg_sum;
          U correction = (sum - fSum[0]) - corrected_arg_sum;
@@ -282,8 +282,8 @@ namespace ROOT {
        /// Subtract other KahanSum. Does not vectorise.
        ///
        /// Based on KahanIncrement from: Tian et al., 2012 (see operator+= documentation).
-       template<typename U>
-       KahanSum& operator-=(KahanSum<U> const& other) {
+       template<typename U, unsigned int M>
+       KahanSum<T, N>& operator-=(KahanSum<U, M> const& other) {
          U corrected_arg_sum = -other.Sum() - (fCarry[0] - other.Carry());
          U sum = fSum[0] + corrected_arg_sum;
          U correction = (sum - fSum[0]) - corrected_arg_sum;
@@ -292,7 +292,7 @@ namespace ROOT {
          return *this;
        }
 
-       KahanSum<T> operator-()
+       KahanSum<T, N> operator-()
        {
           return {-this->fSum[0], -this->fCarry[0]};
        }
@@ -303,17 +303,17 @@ namespace ROOT {
    };
 
    /// Add two non-vectorized KahanSums.
-   template<typename T = double>
-   KahanSum<T> operator+(const KahanSum<T>& left, const KahanSum<T>& right) {
-      KahanSum<T> sum(left);
+   template<typename T, unsigned int N, typename U, unsigned int M>
+   KahanSum<T, N> operator+(const KahanSum<T, N>& left, const KahanSum<U, M>& right) {
+      KahanSum<T, N> sum(left);
       sum += right;
       return sum;
    }
 
    /// Subtract two non-vectorized KahanSums.
-   template<typename T = double>
-   KahanSum<T> operator-(const KahanSum<T>& left, const KahanSum<T>& right) {
-      KahanSum<T> sum(left);
+   template<typename T, unsigned int N, typename U, unsigned int M>
+   KahanSum<T, N> operator-(const KahanSum<T, N>& left, const KahanSum<U, M>& right) {
+      KahanSum<T, N> sum(left);
       sum -= right;
       return sum;
    }

--- a/math/mathcore/test/testKahan.cxx
+++ b/math/mathcore/test/testKahan.cxx
@@ -1,6 +1,7 @@
 #include "Math/Util.h"
 #include <vector>
 #include <random>
+#include <cmath>  // std::nextafter, INFINITY
 
 #include "gtest/gtest.h"
 
@@ -184,3 +185,232 @@ TEST(KahanTest, VectorisableVsLegacy)
   EXPECT_FLOAT_EQ(allVecKahan5.Sum(), kahan4AccAll.Sum() + 10.) << "Initial value works.";
 }
 
+// The KahanAddSubtractAssignTest suite tests some edge cases of operator+= and operator-= with another KahanSum as parameter
+
+TEST(KahanAddSubtractAssignTest, BelowFloatPrecision)
+{
+   // When we add something and subsequently subtract the same (and vice versa), we expect to return
+   // to the starting state
+   double large_number = 1e18;
+   double small_number = 1;
+   ROOT::Math::KahanSum<double, 1> sum(large_number);
+   ROOT::Math::KahanSum<double, 1> small_sum(small_number);
+
+   sum += small_sum;
+   EXPECT_EQ(sum.Sum(), large_number);
+   EXPECT_EQ(sum.Carry(), -small_number); // note that the carry stores the remainder of the sum as its negative
+   sum -= small_sum;
+   EXPECT_EQ(sum.Sum(), large_number);
+   EXPECT_EQ(sum.Carry(), 0);
+
+   // the other way around
+   sum -= small_sum;
+   EXPECT_EQ(sum.Sum(), large_number);
+   EXPECT_EQ(sum.Carry(), small_number);
+   sum += small_sum;
+   EXPECT_EQ(sum.Sum(), large_number);
+   EXPECT_EQ(sum.Carry(), 0);
+}
+
+TEST(KahanAddSubtractAssignTest, LargestLargeEnoughCarry)
+{
+   // Check if the largest large enough carry is added to the sum instead of kept in the carry
+   // when it could have been added to the sum
+   double large_number = 1e18;
+   ROOT::Math::KahanSum<double, 1> sum(large_number);
+
+   double largest_large_enough_carry = std::nextafter(large_number, INFINITY) - large_number;
+
+   ROOT::Math::KahanSum<double, 1> large_carry_sum( largest_large_enough_carry);
+
+   sum += large_carry_sum;
+   EXPECT_EQ(sum.Sum(), large_number + largest_large_enough_carry);
+   EXPECT_EQ(sum.Carry(), 0);
+   sum -= large_carry_sum;
+   EXPECT_EQ(sum.Sum(), large_number);
+   EXPECT_EQ(sum.Carry(), 0);
+
+   // the other way around
+   sum -= large_carry_sum;
+   EXPECT_EQ(sum.Sum(), large_number - largest_large_enough_carry);
+   EXPECT_EQ(sum.Carry(), 0);
+   sum += large_carry_sum;
+   EXPECT_EQ(sum.Sum(), large_number);
+   EXPECT_EQ(sum.Carry(), 0);
+}
+
+TEST(KahanAddSubtractAssignTest, SmallestLargeEnoughCarry)
+{
+   // Check if the smallest large enough carry is added to the number instead of kept in the
+   // carry when it could have been added to the sum. Unlike test LargestLargeEnoughCarry, in this
+   // case there will also be a non-zero carry.
+   double large_number = 1e18;
+   ROOT::Math::KahanSum<double, 1> sum(large_number);
+
+   double largest_large_enough_carry = std::nextafter(large_number, INFINITY) - large_number;
+   double a_bit_too_small_carry = largest_large_enough_carry / 2;
+   double smallest_large_enough_carry = std::nextafter(a_bit_too_small_carry, INFINITY);
+   // here we check that these are the right numbers:
+   EXPECT_EQ(large_number + largest_large_enough_carry, large_number + smallest_large_enough_carry);
+   EXPECT_GT(large_number + largest_large_enough_carry, large_number);
+
+   ROOT::Math::KahanSum<double, 1> smallest_large_carry_sum(smallest_large_enough_carry);
+
+   sum += smallest_large_carry_sum;
+   EXPECT_EQ(sum.Sum(), large_number + smallest_large_enough_carry);
+   // Note: because carry terms are stored negatively, the positive carry value here actually means that
+   // the summed floating point result is higher than the corresponding algebraic result!
+   EXPECT_EQ(sum.Carry(), largest_large_enough_carry - smallest_large_enough_carry);
+   sum -= smallest_large_carry_sum;
+   EXPECT_EQ(sum.Sum(), large_number);
+   EXPECT_EQ(sum.Carry(), 0);
+
+   // the other way around
+   sum -= smallest_large_carry_sum;
+   EXPECT_EQ(sum.Sum(), large_number - smallest_large_enough_carry);
+   EXPECT_EQ(sum.Carry(), -(largest_large_enough_carry - smallest_large_enough_carry));
+   sum += smallest_large_carry_sum;
+   EXPECT_EQ(sum.Sum(), large_number);
+   EXPECT_EQ(sum.Carry(), 0);
+}
+
+TEST(KahanAddSubtractAssignTest, ABitTooSmallCarry)
+{
+   // Check what happens with the value just below the limit of being large enough to influence the normal floating point sum
+   double large_number = 1e18;
+   ROOT::Math::KahanSum<double, 1> sum(large_number);
+
+   double largest_large_enough_carry = std::nextafter(large_number, INFINITY) - large_number;
+   double a_bit_too_small_carry = largest_large_enough_carry / 2;
+
+   ROOT::Math::KahanSum<double, 1> small_carry_sum(a_bit_too_small_carry);
+
+   sum += small_carry_sum;
+   EXPECT_EQ(sum.Sum(), large_number);
+   // This time, the stored carry in sum is again negative because it still has to be added. This is
+   // in contrast to the case above where the floating point sum already yielded a higher Sum value,
+   // but in fact should be corrected downwards by the Carry term (which was hence positive in
+   // SmallestLargeEnoughCarry).
+   EXPECT_EQ(sum.Carry(), -a_bit_too_small_carry);
+   sum += small_carry_sum;
+   EXPECT_EQ(sum.Sum(), large_number + 2 * a_bit_too_small_carry);
+   EXPECT_EQ(sum.Carry(), 0);
+   sum -= small_carry_sum;
+   EXPECT_EQ(sum.Sum(), large_number);
+   EXPECT_EQ(sum.Carry(), -a_bit_too_small_carry);
+   sum -= small_carry_sum;
+   EXPECT_EQ(sum.Sum(), large_number);
+   EXPECT_EQ(sum.Carry(), 0);
+
+   // compare to when just adding regular numbers (not KahanSum objects)
+   auto compare_sum {sum};
+   sum += small_carry_sum;
+   compare_sum += a_bit_too_small_carry;
+   EXPECT_EQ(sum.Sum(), compare_sum.Sum());
+   EXPECT_EQ(sum.Carry(), compare_sum.Carry());
+   sum += small_carry_sum;
+   compare_sum += a_bit_too_small_carry;
+   EXPECT_EQ(sum.Sum(), compare_sum.Sum());
+   EXPECT_EQ(sum.Carry(), compare_sum.Carry());
+   // reset state
+   sum -= small_carry_sum;
+   sum -= small_carry_sum;
+
+   // the other way around
+   sum -= small_carry_sum;
+   EXPECT_EQ(sum.Sum(), large_number);
+   EXPECT_EQ(sum.Carry(), a_bit_too_small_carry);
+   sum -= small_carry_sum;
+   EXPECT_EQ(sum.Sum(), large_number - 2 * a_bit_too_small_carry);
+   EXPECT_EQ(sum.Carry(), 0);
+   sum += small_carry_sum;
+   EXPECT_EQ(sum.Sum(), large_number);
+   EXPECT_EQ(sum.Carry(), a_bit_too_small_carry);
+   sum += small_carry_sum;
+   EXPECT_EQ(sum.Sum(), large_number);
+   EXPECT_EQ(sum.Carry(), 0);
+}
+
+TEST(KahanAddSubtractAssignTest, SubtractWithABitTooSmallCarry)
+{
+   // Subtract a large value with half of the largest large enough carry, which
+   // is exactly one bit too small to be added to the large number in normal
+   // floating point addition. Compare this (where possible) to behavior of a
+   // regular Kahan sum.
+   double large_number = 1e18;
+   ROOT::Math::KahanSum<double, 1> sum(large_number);
+
+   double largest_large_enough_carry = std::nextafter(large_number, INFINITY) - large_number;
+   double a_bit_too_small_carry = largest_large_enough_carry / 2;
+
+   // note: we initialize the carry with negative sign, meaning it should have been added, but hasn't yet
+   ROOT::Math::KahanSum<double, 1> large_carry_sum(large_number, -a_bit_too_small_carry);
+
+   sum -= large_carry_sum;
+   // The carry completely disappears in this case, never to be seen again:
+   EXPECT_EQ(sum.Sum(), 0);
+   EXPECT_EQ(sum.Carry(), 0);
+   sum += large_carry_sum;
+   EXPECT_EQ(sum.Sum(), large_number);
+   // Surprisingly, it also doesn't turn up in the carry after adding it back in:
+   EXPECT_EQ(sum.Carry(), 0);
+
+   // With the terms reversed, it gives the same resulting values as above:
+
+   large_carry_sum -= sum;
+   // This time we also do another sum to compare behavior of += for KahanSum vs double
+   // arguments.
+   ROOT::Math::KahanSum<double, 1> another_large_carry_sum(large_number, -a_bit_too_small_carry);
+   another_large_carry_sum += -large_number;
+   EXPECT_EQ(large_carry_sum.Sum(), 0);
+   EXPECT_EQ(large_carry_sum.Carry(), 0);
+   EXPECT_EQ(another_large_carry_sum.Sum(), 0);
+   EXPECT_EQ(another_large_carry_sum.Carry(), 0);
+   large_carry_sum += sum;
+   another_large_carry_sum += large_number;
+   EXPECT_EQ(large_carry_sum.Sum(), large_number);
+   EXPECT_EQ(another_large_carry_sum.Sum(), large_number);
+   // ... meaning we do not return to the original state after two opposite operations!
+   EXPECT_EQ(large_carry_sum.Carry(), 0);
+   // However, this is expected behavior, because it also happens to the regular
+   // Kahan summation:
+   EXPECT_EQ(another_large_carry_sum.Carry(), large_carry_sum.Carry());
+
+   // the other way around (first + then -) also loses the small carry:
+   ROOT::Math::KahanSum<double, 1> minus_large_carry_sum(-large_number, a_bit_too_small_carry);
+
+   sum += minus_large_carry_sum;
+   EXPECT_EQ(sum.Sum(), 0);
+   EXPECT_EQ(sum.Carry(), 0);
+   sum -= minus_large_carry_sum;
+   EXPECT_EQ(sum.Sum(), large_number);
+   EXPECT_EQ(sum.Carry(), 0);
+}
+
+TEST(KahanAddSubtractAssignTest, XMinusXIsZero)
+{
+   // x - x should always be zero
+   double large_number = 1e18;
+   double small_number = 1;
+   ROOT::Math::KahanSum<double, 1> sum(large_number, -small_number);
+   ROOT::Math::KahanSum<double, 1> sum2(large_number, -small_number);
+
+   auto diff = sum - sum2;
+   EXPECT_EQ(diff.Sum(), 0);
+   EXPECT_EQ(diff.Carry(), 0);
+}
+
+TEST(KahanAddSubtractAssignTest, AddMinusXEqualsSubtractX)
+{
+   // y + (-x) should equal y - x
+   double large_number = 1e18;
+   double small_number = 1;
+   ROOT::Math::KahanSum<double, 1> sum(large_number);
+   ROOT::Math::KahanSum<double, 1> small_sum(small_number);
+
+   auto addMinusX = sum + (-small_sum);
+   auto subtractX = sum - small_sum;
+
+   EXPECT_EQ(addMinusX.Sum(), subtractX.Sum());
+   EXPECT_EQ(addMinusX.Carry(), subtractX.Carry());
+}


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

The behavior of `-=` and `+=` on a `KahanSum` were not symmetric, leading to slight bit-wise inaccuracies. In fits, where such operations are done a lot of times (e.g. through the offsetting mechanism in RooFit which subtracts a constant `KahanSum` term after each likelihood evaluation), this can add up to significant numerical divergence. This in turn makes it hard to test the accuracy of new numerical implementations. In particular, we are trying to fix a bug in `MultiProcess::LikelihoodJob`, which builds on this `KahanSum` fix.

This commit adds test cases around the precision limits, making sure that all behavior is now symmetric and internally consistent.

To aid in the test cases and also make the `KahanSum` objects more versatile, the commit also adds some extra `-` and `+` operators. Using these, we verify some additional desirable symmetry properties: that x - x = 0, and y + (-x) = y - x.

The improved implementation is based on an algorithm for combining Kahan sums and carry terms used in literature (citation in comments).

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)