### PR TITLE
[math] remove implicit conversions to/from KahanSum

### DIFF
--- a/math/mathcore/inc/Math/Util.h
+++ b/math/mathcore/inc/Math/Util.h
@@ -123,7 +123,7 @@ namespace ROOT {
      public:
        /// Initialise the sum.
        /// \param[in] initialValue Initialise with this value. Defaults to 0.
-       KahanSum(T initialValue = T{}) {
+       explicit KahanSum(T initialValue = T{}) {
          fSum[0] = initialValue;
          std::fill(std::begin(fSum)+1, std::end(fSum), 0.);
          std::fill(std::begin(fCarry), std::end(fCarry), 0.);
@@ -243,11 +243,6 @@ namespace ROOT {
 
        /// \return Compensated sum.
        T Result() const {
-         return Sum();
-       }
-
-       /// Auto-convert to type T
-       operator T() const {
          return Sum();
        }
 

--- a/roofit/roofitcore/inc/RooAbsTestStatistic.h
+++ b/roofit/roofitcore/inc/RooAbsTestStatistic.h
@@ -154,7 +154,7 @@ protected:
   RooFit::MPSplit _mpinterl = RooFit::BulkPartition;  ///< Use interleaving strategy rather than N-wise split for partioning of dataset for multiprocessor-split
   bool         _doOffset = false;                   ///< Apply interval value offset to control numeric precision?
   const bool  _takeGlobalObservablesFromData = false; ///< If the global observable values are taken from data
-  mutable ROOT::Math::KahanSum<double> _offset = 0.0; ///<! Offset as KahanSum to avoid loss of precision
+  mutable ROOT::Math::KahanSum<double> _offset {0.0}; ///<! Offset as KahanSum to avoid loss of precision
   mutable double _evalCarry = 0.0;                  ///<! carry of Kahan sum in evaluatePartition
 
   ClassDefOverride(RooAbsTestStatistic,0) // Abstract base class for real-valued test statistics

--- a/roofit/roofitcore/inc/RooFit/TestStatistics/LikelihoodWrapper.h
+++ b/roofit/roofitcore/inc/RooFit/TestStatistics/LikelihoodWrapper.h
@@ -103,7 +103,7 @@ protected:
 
    bool do_offset_ = false;
    ROOT::Math::KahanSum<double> offset_;
-   ROOT::Math::KahanSum<double> offset_save_ = 0; ///<!
+   ROOT::Math::KahanSum<double> offset_save_ {0.}; ///<!
    OffsettingMode offsetting_mode_ = OffsettingMode::legacy;
    ROOT::Math::KahanSum<double> applyOffsetting(ROOT::Math::KahanSum<double> current_value);
    void swapOffsets();

--- a/roofit/roofitcore/inc/RooFit/TestStatistics/RooBinnedL.h
+++ b/roofit/roofitcore/inc/RooFit/TestStatistics/RooBinnedL.h
@@ -42,7 +42,7 @@ private:
    mutable std::vector<double> _binw; ///<!
    std::unique_ptr<RooChangeTracker> paramTracker_;
    Section lastSection_ = {0, 0};  // used for cache together with the parameter tracker
-   mutable ROOT::Math::KahanSum<double> cachedResult_ = 0;
+   mutable ROOT::Math::KahanSum<double> cachedResult_ {0.};
 };
 
 } // namespace TestStatistics

--- a/roofit/roofitcore/inc/RooFit/TestStatistics/RooUnbinnedL.h
+++ b/roofit/roofitcore/inc/RooFit/TestStatistics/RooUnbinnedL.h
@@ -50,7 +50,7 @@ private:
    bool useBatchedEvaluations_ = false;
    std::unique_ptr<RooChangeTracker> paramTracker_;
    Section lastSection_ = {0, 0};  // used for cache together with the parameter tracker
-   mutable ROOT::Math::KahanSum<double> cachedResult_ = 0;
+   mutable ROOT::Math::KahanSum<double> cachedResult_ {0.};
 };
 
 } // namespace TestStatistics

--- a/roofit/roofitcore/src/RooAbsData.cxx
+++ b/roofit/roofitcore/src/RooAbsData.cxx
@@ -1021,7 +1021,7 @@ double RooAbsData::moment(const RooRealVar& var, double order, double offset, co
     sum += weight() * TMath::Power(varPtr->getVal() - offset,order);
   }
 
-  return sum/sumEntries(cutSpec, cutRange);
+  return sum.Sum()/sumEntries(cutSpec, cutRange);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooAbsTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsTestStatistic.cxx
@@ -588,7 +588,7 @@ void RooAbsTestStatistic::enableOffsetting(bool flag)
     _doOffset = flag ;
     // Clear offset if feature is disabled to that it is recalculated next time it is enabled
     if (!_doOffset) {
-      _offset = 0 ;
+      _offset = ROOT::Math::KahanSum<double>{0.} ;
     }
     setValueDirty() ;
     break ;

--- a/roofit/roofitcore/src/RooBinIntegrator.cxx
+++ b/roofit/roofitcore/src/RooBinIntegrator.cxx
@@ -283,7 +283,7 @@ double RooBinIntegrator::integral(const double *)
     }
   }
 
-  return sum;
+  return sum.Sum();
 }
 
 

--- a/roofit/roofitcore/src/RooCurve.cxx
+++ b/roofit/roofitcore/src/RooCurve.cxx
@@ -591,7 +591,7 @@ double RooCurve::chiSquare(const RooHist& hist, Int_t nFitParam) const
   }
 
   // Return chisq/nDOF
-  return chisq / (nbin-nFitParam) ;
+  return chisq.Sum() / (nbin-nFitParam) ;
 }
 
 

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -1812,9 +1812,9 @@ double RooDataHist::sum(bool correctForBinSize, bool inverseBinCor) const
 
   // Store result in cache
   _cache_sum_valid = cache_code;
-  _cache_sum = kahanSum;
+  _cache_sum = kahanSum.Sum();
 
-  return kahanSum;
+  return kahanSum.Sum();
 }
 
 
@@ -1888,7 +1888,7 @@ double RooDataHist::sum(const RooArgSet& sumSet, const RooArgSet& sliceSet, bool
 
   _vars.assign(varSave) ;
 
-  return total;
+  return total.Sum();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1997,7 +1997,7 @@ double RooDataHist::sum(const RooArgSet& sumSet, const RooArgSet& sliceSet,
 
   _vars.assign(varSave);
 
-  return total;
+  return total.Sum();
 }
 
 
@@ -2055,7 +2055,7 @@ const std::vector<double>& RooDataHist::calculatePartialBinVolume(const RooArgSe
 ////////////////////////////////////////////////////////////////////////////////
 /// Sum the weights of all bins.
 double RooDataHist::sumEntries() const {
-  return ROOT::Math::KahanSum<double>::Accumulate(_wgt, _wgt + _arrSize);
+  return ROOT::Math::KahanSum<double>::Accumulate(_wgt, _wgt + _arrSize).Sum();
 }
 
 
@@ -2089,7 +2089,7 @@ double RooDataHist::sumEntries(const char* cutSpec, const char* cutRange) const
       kahanSum += weight(i);
     }
 
-    return kahanSum;
+    return kahanSum.Sum();
   }
 }
 

--- a/roofit/roofitcore/src/RooNLLVar.cxx
+++ b/roofit/roofitcore/src/RooNLLVar.cxx
@@ -334,8 +334,8 @@ double RooNLLVar::evaluatePartition(std::size_t firstEvent, std::size_t lastEven
   if (_doOffset) {
 
     // If no offset is stored enable this feature now
-    if (_offset==0 && result !=0 ) {
-      coutI(Minimization) << "RooNLLVar::evaluatePartition(" << GetName() << ") first = "<< firstEvent << " last = " << lastEvent << " Likelihood offset now set to " << result << std::endl ;
+    if (_offset.Sum() == 0 && _offset.Carry() == 0 && (result.Sum() != 0 || result.Carry() != 0)) {
+      coutI(Minimization) << "RooNLLVar::evaluatePartition(" << GetName() << ") first = "<< firstEvent << " last = " << lastEvent << " Likelihood offset now set to " << result.Sum() << std::endl ;
       _offset = result ;
     }
 
@@ -454,7 +454,7 @@ RooNLLVar::ComputeResult RooNLLVar::computeBatchedFunc(const RooAbsPdf *pdfClone
 
     // Some events with evaluation errors. Return "badness" of errors.
     if (nanPacker.getPayload() > 0.) {
-      return {{nanPacker.getNaNWithPayload()}, sumOfWeights};
+      return {ROOT::Math::KahanSum<double>{nanPacker.getNaNWithPayload()}, sumOfWeights};
     } else {
       return {kahanSanitised, sumOfWeights};
     }
@@ -505,7 +505,7 @@ RooNLLVar::ComputeResult RooNLLVar::computeScalarFunc(const RooAbsPdf *pdfClone,
 
   if (packedNaN.getPayload() != 0.) {
     // Some events with evaluation errors. Return "badness" of errors.
-    return {{packedNaN.getNaNWithPayload()}, kahanWeight.Sum()};
+    return {ROOT::Math::KahanSum<double>{packedNaN.getNaNWithPayload()}, kahanWeight.Sum()};
   }
 
   return {kahanProb, kahanWeight.Sum()};

--- a/roofit/roofitcore/src/RooNLLVarNew.cxx
+++ b/roofit/roofitcore/src/RooNLLVarNew.cxx
@@ -291,7 +291,7 @@ double RooNLLVarNew::finalizeResult(ROOT::Math::KahanSum<double> &&result, doubl
    }
 
    // Check if value offset flag is set.
-   if (_offset) {
+   if (_doOffset) {
 
       // If no offset is stored enable this feature now
       if (_offset.Sum() == 0 && _offset.Carry() == 0 && (result.Sum() != 0 || result.Carry() != 0)) {

--- a/roofit/roofitcore/src/RooNLLVarNew.cxx
+++ b/roofit/roofitcore/src/RooNLLVarNew.cxx
@@ -197,7 +197,7 @@ void RooNLLVarNew::computeBatch(cudaStream_t * /*stream*/, double *output, size_
 
    if (packedNaN.getPayload() != 0.) {
       // Some events with evaluation errors. Return "badness" of errors.
-      kahanProb = packedNaN.getNaNWithPayload();
+      kahanProb = Math::KahanSum<double>(packedNaN.getNaNWithPayload());
    }
 
    if (_isExtended) {
@@ -279,7 +279,7 @@ RooNLLVarNew::fillNormSetForServer(RooArgSet const & /*normSet*/, RooAbsArg cons
 void RooNLLVarNew::enableOffsetting(bool flag)
 {
    _doOffset = flag;
-   _offset = {};
+   _offset = ROOT::Math::KahanSum<double>{};
 }
 
 double RooNLLVarNew::finalizeResult(ROOT::Math::KahanSum<double> &&result, double weightSum) const
@@ -294,7 +294,7 @@ double RooNLLVarNew::finalizeResult(ROOT::Math::KahanSum<double> &&result, doubl
    if (_offset) {
 
       // If no offset is stored enable this feature now
-      if (_offset == 0 && result != 0) {
+      if (_offset.Sum() == 0 && _offset.Carry() == 0 && (result.Sum() != 0 || result.Carry() != 0)) {
          _offset = result;
       }
 

--- a/roofit/roofitcore/src/RooNLLVarNew.h
+++ b/roofit/roofitcore/src/RooNLLVarNew.h
@@ -77,7 +77,7 @@ private:
    RooTemplateProxy<RooAbsReal> _weightSquaredVar;
    mutable std::vector<double> _binw;                  ///<!
    mutable std::vector<double> _logProbasBuffer;       ///<!
-   mutable ROOT::Math::KahanSum<double> _offset = 0.0; ///<! Offset as KahanSum to avoid loss of precision
+   mutable ROOT::Math::KahanSum<double> _offset {0.}; ///<! Offset as KahanSum to avoid loss of precision
 
 }; // end class RooNLLVar
 

--- a/roofit/roofitcore/src/TestStatistics/LikelihoodJob.cxx
+++ b/roofit/roofitcore/src/TestStatistics/LikelihoodJob.cxx
@@ -193,7 +193,8 @@ void LikelihoodJob::evaluate()
       // wait for task results back from workers to master
       gather_worker_results();
 
-      result_ = 0;
+      result_ = ROOT::Math::KahanSum<double>{0.};
+//      printf("Master evaluate: ");
       for (auto const &item : results_) {
          result_ += item;
       }

--- a/roofit/roofitcore/src/TestStatistics/LikelihoodWrapper.cxx
+++ b/roofit/roofitcore/src/TestStatistics/LikelihoodWrapper.cxx
@@ -86,7 +86,7 @@ void LikelihoodWrapper::enableOffsetting(bool flag)
    do_offset_ = flag;
    // Clear offset if feature is disabled so that it is recalculated next time it is enabled
    if (!do_offset_) {
-      offset_ = {};
+      offset_ = ROOT::Math::KahanSum<double>();
    }
 }
 
@@ -97,7 +97,7 @@ void LikelihoodWrapper::setOffsettingMode(OffsettingMode mode)
       oocoutI(nullptr, Minimization)
          << "LikelihoodWrapper::setOffsettingMode(" << GetName()
          << "): changed offsetting mode while offsetting was enabled; resetting offset values" << std::endl;
-      offset_ = {};
+      offset_ = ROOT::Math::KahanSum<double>();
    }
 }
 
@@ -106,7 +106,7 @@ ROOT::Math::KahanSum<double> LikelihoodWrapper::applyOffsetting(ROOT::Math::Kaha
    if (do_offset_) {
 
       // If no offset is stored enable this feature now
-      if (offset_ == 0 && current_value != 0) {
+      if (offset_.Sum() == 0 && offset_.Carry() == 0 && (current_value.Sum() != 0 || current_value.Carry() != 0)) {
          offset_ = current_value;
          if (offsetting_mode_ == OffsettingMode::legacy) {
             auto sum_likelihood = dynamic_cast<RooSumL *>(likelihood_.get());
@@ -115,11 +115,11 @@ ROOT::Math::KahanSum<double> LikelihoodWrapper::applyOffsetting(ROOT::Math::Kaha
                // "undo" the addition of the subsidiary value to emulate legacy behavior
                offset_ -= subsidiary_value;
                // manually calculate result with zero carry, again to emulate legacy behavior
-               return {current_value.Result() - offset_.Result()};
+               return ROOT::Math::KahanSum<double>{current_value.Result() - offset_.Result()};
             }
          }
          oocoutI(nullptr, Minimization)
-            << "LikelihoodWrapper::applyOffsetting(" << GetName() << "): Likelihood offset now set to " << offset_
+            << "LikelihoodWrapper::applyOffsetting(" << GetName() << "): Likelihood offset now set to " << offset_.Sum()
             << std::endl;
       }
 

--- a/roofit/roofitcore/src/TestStatistics/RooBinnedL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooBinnedL.cxx
@@ -94,7 +94,7 @@ RooBinnedL::evaluatePartition(Section bins, std::size_t /*components_begin*/, st
    ROOT::Math::KahanSum<double> result;
 
    // Do not reevaluate likelihood if parameters nor event range have changed
-   if (!paramTracker_->hasChanged(true) && bins == lastSection_ && (cachedResult_ != 0)) return cachedResult_;
+   if (!paramTracker_->hasChanged(true) && bins == lastSection_ && (cachedResult_.Sum() != 0 || cachedResult_.Carry() != 0)) return cachedResult_;
 
 //   data->store()->recalculateCache(_projDeps, firstEvent, lastEvent, stepSize, (_binnedPdf?false:true));
    // TODO: check when we might need _projDeps (it seems to be mostly empty); ties in with TODO below
@@ -137,7 +137,7 @@ RooBinnedL::evaluatePartition(Section bins, std::size_t /*components_begin*/, st
    // If part of simultaneous PDF normalize probability over
    // number of simultaneous PDFs: -sum(log(p/n)) = -sum(log(p)) + N*log(n)
    if (sim_count_ > 1) {
-      result += sumWeight * log(1.0 * sim_count_);
+      result += sumWeight.Sum() * log(1.0 * sim_count_);
    }
 
    // At the end of the first full calculation, wire the caches

--- a/roofit/roofitcore/src/TestStatistics/RooSumL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooSumL.cxx
@@ -117,7 +117,7 @@ ROOT::Math::KahanSum<double> RooSumL::getSubsidiaryValue()
          return (*component)->evaluatePartition({0, 1}, 0, 0);
       }
    }
-   return {};
+   return ROOT::Math::KahanSum<double>{};
 }
 
 void RooSumL::constOptimizeTestStatistic(RooAbsArg::ConstOpCode opcode, bool doAlsoTrackingOpt)

--- a/roofit/roofitcore/src/TestStatistics/RooUnbinnedL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooUnbinnedL.cxx
@@ -89,7 +89,7 @@ RooUnbinnedL::evaluatePartition(Section events, std::size_t /*components_begin*/
    double sumWeight;
 
    // Do not reevaluate likelihood if parameters nor event range have changed
-   if (!paramTracker_->hasChanged(true) && events == lastSection_ && (cachedResult_ != 0)) return cachedResult_;
+   if (!paramTracker_->hasChanged(true) && events == lastSection_ && (cachedResult_.Sum() != 0 || cachedResult_.Carry() != 0)) return cachedResult_;
 
    data_->store()->recalculateCache(nullptr, events.begin(N_events_), events.end(N_events_), 1, true);
 

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cpp
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cpp
@@ -366,7 +366,7 @@ TEST(SimBinnedConstrainedTestBasic, BasicParameters)
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
 
-   EXPECT_DOUBLE_EQ(nll0, nll1);
+   EXPECT_DOUBLE_EQ(nll0, nll1.Sum());
 }
 
 class SimBinnedConstrainedTest : public ::testing::TestWithParam<std::tuple<bool>> {};

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodJob.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodJob.cxx
@@ -116,7 +116,7 @@ TEST_F(LikelihoodJobTest, UnbinnedGaussian1D)
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
 
-   EXPECT_EQ(nll0, nll1);
+   EXPECT_EQ(nll0, nll1.Sum());
 }
 
 TEST_F(LikelihoodJobTest, UnbinnedGaussian1DTwice)
@@ -132,7 +132,7 @@ TEST_F(LikelihoodJobTest, UnbinnedGaussian1DTwice)
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
 
-   EXPECT_EQ(nll0, nll1);
+   EXPECT_EQ(nll0, nll1.Sum());
 }
 
 TEST_F(LikelihoodJobTest, UnbinnedGaussianND)
@@ -148,7 +148,8 @@ TEST_F(LikelihoodJobTest, UnbinnedGaussianND)
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
 
-   EXPECT_EQ(nll0, nll1);
+   EXPECT_EQ(nll0, nll1.Sum());
+//   printf("%a =?= %a\n", nll0, nll1.Sum());
 }
 
 TEST_F(LikelihoodJobBinnedDatasetTest, UnbinnedPdf)
@@ -165,7 +166,7 @@ TEST_F(LikelihoodJobBinnedDatasetTest, UnbinnedPdf)
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
 
-   EXPECT_EQ(nll0, nll1);
+   EXPECT_EQ(nll0, nll1.Sum());
 }
 
 TEST_F(LikelihoodJobBinnedDatasetTest, BinnedManualNLL)
@@ -190,7 +191,7 @@ TEST_F(LikelihoodJobBinnedDatasetTest, BinnedManualNLL)
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
 
-   EXPECT_EQ(nll0, nll1);
+   EXPECT_EQ(nll0, nll1.Sum());
 }
 
 TEST_F(LikelihoodJobTest, SimBinned)
@@ -237,7 +238,7 @@ TEST_F(LikelihoodJobTest, SimBinned)
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
 
-   EXPECT_EQ(nll0, nll1);
+   EXPECT_EQ(nll0, nll1.Sum());
 }
 
 TEST_F(LikelihoodJobTest, BinnedConstrained)
@@ -283,7 +284,7 @@ TEST_F(LikelihoodJobTest, BinnedConstrained)
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
 
-   EXPECT_DOUBLE_EQ(nll0, nll1);
+   EXPECT_DOUBLE_EQ(nll0, nll1.Sum());
 }
 
 TEST_F(LikelihoodJobTest, SimUnbinned)
@@ -310,7 +311,7 @@ TEST_F(LikelihoodJobTest, SimUnbinned)
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
 
-   EXPECT_DOUBLE_EQ(nll0, nll1);
+   EXPECT_DOUBLE_EQ(nll0, nll1.Sum());
 }
 
 TEST_F(LikelihoodJobTest, SimUnbinnedNonExtended)
@@ -343,7 +344,7 @@ TEST_F(LikelihoodJobTest, SimUnbinnedNonExtended)
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
 
-   EXPECT_EQ(nll0, nll1);
+   EXPECT_EQ(nll0, nll1.Sum());
 }
 
 class LikelihoodJobSimBinnedConstrainedTest : public LikelihoodJobTest {
@@ -410,7 +411,7 @@ TEST_F(LikelihoodJobSimBinnedConstrainedTest, BasicParameters)
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
 
-   EXPECT_DOUBLE_EQ(nll0, nll1);
+   EXPECT_DOUBLE_EQ(nll0, nll1.Sum());
 }
 
 TEST_F(LikelihoodJobSimBinnedConstrainedTest, ConstrainedAndOffset)
@@ -437,8 +438,8 @@ TEST_F(LikelihoodJobSimBinnedConstrainedTest, ConstrainedAndOffset)
    // manually add the offset.
    ROOT::Math::KahanSum<double> nll1 = nll_ts->getResult() + nll_ts->offset();
 
-   EXPECT_DOUBLE_EQ(nll0, nll1);
-   EXPECT_FALSE(nll_ts->offset() == 0);
+   EXPECT_DOUBLE_EQ(nll0, nll1.Sum());
+   EXPECT_FALSE(nll_ts->offset().Sum() == 0);
 
    // also check against RooRealL value
    RooFit::TestStatistics::RooRealL nll_real("real_nll", "RooRealL version", likelihood);
@@ -446,7 +447,7 @@ TEST_F(LikelihoodJobSimBinnedConstrainedTest, ConstrainedAndOffset)
    auto nll2 = nll_real.getVal();
 
    EXPECT_EQ(nll0, nll2);
-   EXPECT_DOUBLE_EQ(nll1, nll2);
+   EXPECT_DOUBLE_EQ(nll1.Sum(), nll2);
 }
 
 TEST_F(LikelihoodJobTest, BatchedUnbinnedGaussianND)
@@ -472,7 +473,7 @@ TEST_F(LikelihoodJobTest, BatchedUnbinnedGaussianND)
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
 
-   EXPECT_NEAR(nll0, nll1, 1e-14 * nll0);
+   EXPECT_NEAR(nll0, nll1.Sum(), 1e-14 * nll0);
 }
 
 class LikelihoodJobSplitStrategies : public LikelihoodJobSimBinnedConstrainedTest, public testing::WithParamInterface<std::tuple<std::size_t, std::size_t>> {};
@@ -505,8 +506,8 @@ TEST_P(LikelihoodJobSplitStrategies, SimBinnedConstrainedAndOffset)
    // manually add the offset.
    ROOT::Math::KahanSum<double> nll1 = nll_ts->getResult() + nll_ts->offset();
 
-   EXPECT_DOUBLE_EQ(nll0, nll1);
-   EXPECT_FALSE(nll_ts->offset() == 0);
+   EXPECT_DOUBLE_EQ(nll0, nll1.Sum());
+   EXPECT_FALSE(nll_ts->offset().Sum() == 0);
 
    // also check against RooRealL value
    RooFit::TestStatistics::RooRealL nll_real("real_nll", "RooRealL version", likelihood);
@@ -514,7 +515,7 @@ TEST_P(LikelihoodJobSplitStrategies, SimBinnedConstrainedAndOffset)
    auto nll2 = nll_real.getVal();
 
    EXPECT_EQ(nll0, nll2);
-   EXPECT_DOUBLE_EQ(nll1, nll2);
+   EXPECT_DOUBLE_EQ(nll1.Sum(), nll2);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodSerial.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodSerial.cxx
@@ -106,7 +106,7 @@ TEST_F(LikelihoodSerialTest, UnbinnedGaussian1D)
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
 
-   EXPECT_EQ(nll0, nll1);
+   EXPECT_EQ(nll0, nll1.Sum());
 }
 
 TEST_F(LikelihoodSerialTest, UnbinnedGaussianND)
@@ -122,7 +122,7 @@ TEST_F(LikelihoodSerialTest, UnbinnedGaussianND)
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
 
-   EXPECT_EQ(nll0, nll1);
+   EXPECT_EQ(nll0, nll1.Sum());
 }
 
 TEST_F(LikelihoodSerialBinnedDatasetTest, UnbinnedPdf)
@@ -139,7 +139,7 @@ TEST_F(LikelihoodSerialBinnedDatasetTest, UnbinnedPdf)
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
 
-   EXPECT_EQ(nll0, nll1);
+   EXPECT_EQ(nll0, nll1.Sum());
 }
 
 TEST_F(LikelihoodSerialBinnedDatasetTest, BinnedManualNLL)
@@ -164,7 +164,7 @@ TEST_F(LikelihoodSerialBinnedDatasetTest, BinnedManualNLL)
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
 
-   EXPECT_EQ(nll0, nll1);
+   EXPECT_EQ(nll0, nll1.Sum());
 }
 
 TEST_F(LikelihoodSerialTest, SimBinned)
@@ -211,7 +211,7 @@ TEST_F(LikelihoodSerialTest, SimBinned)
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
 
-   EXPECT_EQ(nll0, nll1);
+   EXPECT_EQ(nll0, nll1.Sum());
 }
 
 TEST_F(LikelihoodSerialTest, BinnedConstrained)
@@ -257,7 +257,7 @@ TEST_F(LikelihoodSerialTest, BinnedConstrained)
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
 
-   EXPECT_EQ(nll0, nll1);
+   EXPECT_EQ(nll0, nll1.Sum());
 }
 
 TEST_F(LikelihoodSerialTest, SimUnbinned)
@@ -284,7 +284,7 @@ TEST_F(LikelihoodSerialTest, SimUnbinned)
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
 
-   EXPECT_EQ(nll0, nll1);
+   EXPECT_EQ(nll0, nll1.Sum());
 }
 
 TEST_F(LikelihoodSerialTest, SimUnbinnedNonExtended)
@@ -317,7 +317,7 @@ TEST_F(LikelihoodSerialTest, SimUnbinnedNonExtended)
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
 
-   EXPECT_EQ(nll0, nll1);
+   EXPECT_EQ(nll0, nll1.Sum());
 }
 
 class LikelihoodSerialSimBinnedConstrainedTest : public LikelihoodSerialTest {
@@ -384,7 +384,7 @@ TEST_F(LikelihoodSerialSimBinnedConstrainedTest, BasicParameters)
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
 
-   EXPECT_DOUBLE_EQ(nll0, nll1);
+   EXPECT_DOUBLE_EQ(nll0, nll1.Sum());
 }
 
 TEST_F(LikelihoodSerialSimBinnedConstrainedTest, ConstrainedAndOffset)
@@ -411,8 +411,8 @@ TEST_F(LikelihoodSerialSimBinnedConstrainedTest, ConstrainedAndOffset)
    // manually add the offset.
    ROOT::Math::KahanSum<double> nll1 = nll_ts->getResult() + nll_ts->offset();
 
-   EXPECT_DOUBLE_EQ(nll0, nll1);
-   EXPECT_FALSE(nll_ts->offset() == 0);
+   EXPECT_DOUBLE_EQ(nll0, nll1.Sum());
+   EXPECT_FALSE(nll_ts->offset().Sum() == 0);
 
    // also check against RooRealL value
    RooFit::TestStatistics::RooRealL nll_real("real_nll", "RooRealL version", likelihood);
@@ -420,7 +420,7 @@ TEST_F(LikelihoodSerialSimBinnedConstrainedTest, ConstrainedAndOffset)
    auto nll2 = nll_real.getVal();
 
    EXPECT_EQ(nll0, nll2);
-   EXPECT_DOUBLE_EQ(nll1, nll2);
+   EXPECT_DOUBLE_EQ(nll1.Sum(), nll2);
 }
 
 TEST_F(LikelihoodSerialTest, BatchedUnbinnedGaussianND)
@@ -446,5 +446,5 @@ TEST_F(LikelihoodSerialTest, BatchedUnbinnedGaussianND)
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
 
-   EXPECT_NEAR(nll0, nll1, 1e-14 * nll0);
+   EXPECT_NEAR(nll0, nll1.Sum(), 1e-14 * nll0);
 }

--- a/roofit/roofitcore/test/TestStatistics/testRooAbsL.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testRooAbsL.cxx
@@ -215,7 +215,7 @@ TEST_F(BinnedDatasetTest, EventSections)
    auto whole = likelihood->evaluatePartition({0, 1}, 0, 0);
    auto part1 = likelihood->evaluatePartition({0, 0.5}, 0, 0);
    auto part2 = likelihood->evaluatePartition({0.5, 1}, 0, 0);
-   EXPECT_EQ(whole, part1 + part2);
+   EXPECT_EQ(whole.Sum(), (part1 + part2).Sum());
 }
 
 TEST_F(SimBinnedConstrainedTest, EventSections)
@@ -228,13 +228,13 @@ TEST_F(SimBinnedConstrainedTest, EventSections)
    auto whole = likelihood->evaluatePartition({0, 1}, 0, likelihood->getNComponents());
    auto part1 = likelihood->evaluatePartition({0, 0.5}, 0, likelihood->getNComponents());
    auto part2 = likelihood->evaluatePartition({0.5, 1}, 0, likelihood->getNComponents());
-   EXPECT_EQ(whole, part1 + part2);
+   EXPECT_EQ(whole.Sum(), (part1 + part2).Sum());
 
    auto part1of4 = likelihood->evaluatePartition({0, 0.25}, 0, likelihood->getNComponents());
    auto part2of4 = likelihood->evaluatePartition({0.25, 0.5}, 0, likelihood->getNComponents());
    auto part3of4 = likelihood->evaluatePartition({0.5, 0.75}, 0, likelihood->getNComponents());
    auto part4of4 = likelihood->evaluatePartition({0.75, 1}, 0, likelihood->getNComponents());
-   EXPECT_EQ(whole, part1of4 + part2of4 + part3of4 + part4of4);
+   EXPECT_EQ(whole.Sum(), (part1of4 + part2of4 + part3of4 + part4of4).Sum());
 }
 
 TEST_F(RooAbsLTest, SubEventSections)
@@ -253,17 +253,17 @@ TEST_F(RooAbsLTest, SubEventSections)
    for (std::size_t ix = 0; ix < 9; ++ix) {
       nine_parts += likelihood->evaluatePartition({static_cast<double>(ix)/9, static_cast<double>(ix+1)/9}, 0, likelihood->getNComponents());
    }
-   EXPECT_EQ(whole, nine_parts);
+   EXPECT_EQ(whole.Sum(), nine_parts.Sum());
 
    for (std::size_t ix = 0; ix < 11; ++ix) {
       eleven_parts += likelihood->evaluatePartition({static_cast<double>(ix)/11, static_cast<double>(ix+1)/11}, 0, likelihood->getNComponents());
    }
-   EXPECT_EQ(whole, eleven_parts);
+   EXPECT_EQ(whole.Sum(), eleven_parts.Sum());
 
    for (std::size_t ix = 0; ix < 20; ++ix) {
       twenty_parts += likelihood->evaluatePartition({static_cast<double>(ix)/20, static_cast<double>(ix+1)/20}, 0, likelihood->getNComponents());
    }
-   EXPECT_EQ(whole, twenty_parts);
+   EXPECT_EQ(whole.Sum(), twenty_parts.Sum());
 }
 
 TEST_F(SimBinnedConstrainedTest, SubEventSections)
@@ -284,7 +284,7 @@ TEST_F(SimBinnedConstrainedTest, SubEventSections)
    for (std::size_t ix = 0; ix < N_events_total; ++ix) {
       N_events_total_parts += likelihood->evaluatePartition({static_cast<double>(ix)/N_events_total, static_cast<double>(ix+1)/N_events_total}, 0, likelihood->getNComponents());
    }
-   EXPECT_EQ(whole, N_events_total_parts);
+   EXPECT_EQ(whole.Sum(), N_events_total_parts.Sum());
 
    // now let's do it again over a number of sections 3 times the number of events
    ROOT::Math::KahanSum<double> thrice_N_events_total_parts;
@@ -292,5 +292,5 @@ TEST_F(SimBinnedConstrainedTest, SubEventSections)
    for (std::size_t ix = 0; ix < 3 * N_events_total; ++ix) {
       thrice_N_events_total_parts += likelihood->evaluatePartition({static_cast<double>(ix)/(3 * N_events_total), static_cast<double>(ix+1)/(3 * N_events_total)}, 0, likelihood->getNComponents());
    }
-   EXPECT_EQ(whole, thrice_N_events_total_parts);
+   EXPECT_EQ(whole.Sum(), thrice_N_events_total_parts.Sum());
 }


### PR DESCRIPTION
# This Pull request:

Follow-up on #11940; ~please merge that one before this one~ it has been merged, so this one can also be merged.

## Changes or fixes:

The auto-conversion to type `T` and implicit type `T` constructor in `KahanSum` make it hard to debug `KahanSum`, because it is easy to overlook implicit conversions in code, especially in lines where the type of the return value is `auto`. The second commit in this PR (the first commit is the same as that in #11940) removes them and where they were necessary replaces them with an explicit construction or explicit conversion to double via `Sum()`

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)