### PR TITLE
[ntuple] Register post-read callbacks for `#pragma read` rules on user-defined classes

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -393,7 +393,7 @@ public:
    std::vector<Detail::RFieldValue> SplitValue(const Detail::RFieldValue &value) const final;
    size_t GetValueSize() const override;
    size_t GetAlignment() const final { return fMaxAlignment; }
-   std::uint32_t GetTypeVersion() const override;
+   std::uint32_t GetTypeVersion() const final;
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const override;
 };
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -376,6 +376,7 @@ protected:
    std::size_t AppendImpl(const Detail::RFieldValue& value) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue *value) final;
    void ReadInClusterImpl(const RClusterIndex &clusterIndex, Detail::RFieldValue *value) final;
+   void RegisterReadCallbacks() final;
 
 public:
    RClassField(std::string_view fieldName, std::string_view className);

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -162,9 +162,9 @@ protected:
    /// Register post-read callbacks corresponding to a list of ROOT I/O customization rules. `classp` is used to
    /// fill the `TVirtualObject` instance passed to the user function.
    void AddReadCallbacksFromIORules(const std::span<const TSchemaRule *> rules, TClass *classp = nullptr);
-   /// Called by `ConnectPageSource()` to register read callbacks only once connected; derived classes may override this
+   /// Called by `ConnectPageSource()` only once connected; derived classes may override this
    /// as appropriate
-   virtual void RegisterReadCallbacks() {}
+   virtual void OnConnectPageSource() {}
 
 private:
    void InvokeReadCallbacks(RFieldValue &value)
@@ -377,7 +377,7 @@ protected:
    std::size_t AppendImpl(const Detail::RFieldValue& value) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue *value) final;
    void ReadInClusterImpl(const RClusterIndex &clusterIndex, Detail::RFieldValue *value) final;
-   void RegisterReadCallbacks() final;
+   void OnConnectPageSource() final;
 
 public:
    RClassField(std::string_view fieldName, std::string_view className);

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -161,6 +161,9 @@ protected:
    /// Register post-read callbacks corresponding to a list of ROOT I/O customization rules. `classp` is used to
    /// fill the `TVirtualObject` instance passed to the user function.
    void AddReadCallbacksFromIORules(const std::span<const TSchemaRule *> rules, TClass *classp = nullptr);
+   /// Called by `ConnectPageSource()` to register read callbacks only once connected; derived classes may override this
+   /// as appropriate
+   virtual void RegisterReadCallbacks() {}
 
 private:
    void InvokeReadCallbacks(RFieldValue &value)

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -389,6 +389,7 @@ public:
    std::vector<Detail::RFieldValue> SplitValue(const Detail::RFieldValue &value) const final;
    size_t GetValueSize() const override;
    size_t GetAlignment() const final { return fMaxAlignment; }
+   std::uint32_t GetTypeVersion() const override;
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const override;
 };
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -46,6 +46,9 @@
 class TClass;
 
 namespace ROOT {
+
+class TSchemaRule;
+
 namespace Experimental {
 
 class RCollectionField;
@@ -153,6 +156,9 @@ protected:
    /// Returns an index that can be used to remove the callback.
    size_t AddReadCallback(ReadCallback_t func);
    void RemoveReadCallback(size_t idx);
+   /// Register post-read callbacks corresponding to a list of ROOT I/O customization rules. `classp` is used to
+   /// fill the `TVirtualObject` instance passed to the user function.
+   void AddReadCallbacksFromIORules(const std::span<const TSchemaRule *> rules, TClass *classp = nullptr);
 
 private:
    void InvokeReadCallbacks(RFieldValue &value)

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -83,6 +83,7 @@ class RFieldBase {
    using ReadCallback_t = std::function<void(RFieldValue &)>;
 
 public:
+   static constexpr std::uint32_t kInvalidTypeVersion = -1U;
    /// No constructor needs to be called, i.e. any bit pattern in the allocated memory represents a valid type
    /// A trivially constructible field has a no-op GenerateValue() implementation
    static constexpr int kTraitTriviallyConstructible = 0x01;
@@ -128,7 +129,7 @@ protected:
    /// List of functions to be called after reading a value
    std::vector<ReadCallback_t> fReadCallbacks;
    /// C++ type version cached from the descriptor after a call to `ConnectPageSource()`
-   std::uint32_t fOnDiskTypeVersion = 0;
+   std::uint32_t fOnDiskTypeVersion = kInvalidTypeVersion;
 
    /// Creates the backing columns corresponsing to the field type for writing
    virtual void GenerateColumnsImpl() = 0;

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -127,6 +127,8 @@ protected:
    int fTraits = 0;
    /// List of functions to be called after reading a value
    std::vector<ReadCallback_t> fReadCallbacks;
+   /// C++ type version cached from the descriptor after a call to `ConnectPageSource()`
+   std::uint32_t fOnDiskTypeVersion = 0;
 
    /// Creates the backing columns corresponsing to the field type for writing
    virtual void GenerateColumnsImpl() = 0;
@@ -312,6 +314,8 @@ public:
    virtual std::uint32_t GetFieldVersion() const { return 0; }
    /// Indicates an evolution of the C++ type itself
    virtual std::uint32_t GetTypeVersion() const { return 0; }
+   /// Return the C++ type version stored in the field descriptor; only valid after a call to `ConnectPageSource()`
+   std::uint32_t GetOnDiskTypeVersion() const { return fOnDiskTypeVersion; }
 
    RSchemaIterator begin();
    RSchemaIterator end();

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -159,9 +159,6 @@ protected:
    /// Returns an index that can be used to remove the callback.
    size_t AddReadCallback(ReadCallback_t func);
    void RemoveReadCallback(size_t idx);
-   /// Register post-read callbacks corresponding to a list of ROOT I/O customization rules. `classp` is used to
-   /// fill the `TVirtualObject` instance passed to the user function.
-   void AddReadCallbacksFromIORules(const std::span<const TSchemaRule *> rules, TClass *classp = nullptr);
    /// Called by `ConnectPageSource()` only once connected; derived classes may override this
    /// as appropriate
    virtual void OnConnectPageSource() {}
@@ -371,6 +368,9 @@ private:
 private:
    RClassField(std::string_view fieldName, std::string_view className, TClass *classp);
    void Attach(std::unique_ptr<Detail::RFieldBase> child, RSubFieldInfo info);
+   /// Register post-read callbacks corresponding to a list of ROOT I/O customization rules. `classp` is used to
+   /// fill the `TVirtualObject` instance passed to the user function.
+   void AddReadCallbacksFromIORules(const std::span<const TSchemaRule *> rules, TClass *classp = nullptr);
 
 protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -165,10 +165,10 @@ public:
       : fField(pageSource->GetSharedDescriptorGuard()->GetFieldDescriptor(fieldId).GetFieldName()),
         fValue(fField.GenerateValue())
    {
-      if ((fField.GetTraits() & Detail::RFieldBase::kTraitMappable) && fField.HasReadCallbacks())
-         throw RException(R__FAIL("view disallowed on field with mappable type and read callback"));
       fField.SetOnDiskId(fieldId);
       fField.ConnectPageSource(*pageSource);
+      if ((fField.GetTraits() & Detail::RFieldBase::kTraitMappable) && fField.HasReadCallbacks())
+         throw RException(R__FAIL("view disallowed on field with mappable type and read callback"));
       for (auto &f : fField) {
          auto subFieldId =
             pageSource->GetSharedDescriptorGuard()->FindFieldId(f.GetName(), f.GetParent()->GetOnDiskId());

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -466,6 +466,7 @@ void ROOT::Experimental::Detail::RFieldBase::ConnectPageSource(RPageSource &page
       fPrincipalColumn = fColumns[0].get();
    for (auto& column : fColumns)
       column->Connect(fOnDiskId, &pageSource);
+   RegisterReadCallbacks();
 }
 
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1026,6 +1026,11 @@ size_t ROOT::Experimental::RClassField::GetValueSize() const
    return fClass->GetClassSize();
 }
 
+std::uint32_t ROOT::Experimental::RClassField::GetTypeVersion() const
+{
+   return fClass->GetClassVersion();
+}
+
 void ROOT::Experimental::RClassField::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitClassField(*this);

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -466,7 +466,7 @@ void ROOT::Experimental::Detail::RFieldBase::ConnectPageSource(RPageSource &page
       fPrincipalColumn = fColumns[0].get();
    for (auto& column : fColumns)
       column->Connect(fOnDiskId, &pageSource);
-   RegisterReadCallbacks();
+   OnConnectPageSource();
 }
 
 
@@ -963,7 +963,7 @@ void ROOT::Experimental::RClassField::ReadInClusterImpl(const RClusterIndex &clu
    }
 }
 
-void ROOT::Experimental::RClassField::RegisterReadCallbacks()
+void ROOT::Experimental::RClassField::OnConnectPageSource()
 {
    // Add post-read callbacks for I/O customization rules; only rules that target transient members are allowed for now
    // TODO(jalopezg): revise after supporting schema evolution

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -923,27 +923,6 @@ ROOT::Experimental::RClassField::RClassField(std::string_view fieldName, std::st
       Attach(std::move(subField),
 	     RSubFieldInfo{kDataMember, static_cast<std::size_t>(dataMember->GetOffset())});
    }
-
-   // Add post-read callbacks for I/O customization rules; only rules that target transient members are allowed for now
-   // TODO(jalopezg): revise after supporting schema evolution
-   if (const auto ruleset = fClass->GetSchemaRules()) {
-      auto referencesNonTransientMembers = [this](const ROOT::TSchemaRule *rule) {
-         R__ASSERT(rule->GetTarget() != nullptr);
-         for (auto target : ROOT::Detail::TRangeStaticCast<TObjString>(*rule->GetTarget())) {
-            const auto dataMember = fClass->GetDataMember(target->GetString());
-            if (!dataMember || dataMember->IsPersistent()) {
-               R__LOG_WARNING(NTupleLog())
-                  << "ignoring I/O customization rule with non-transient member: " << dataMember->GetName();
-               return true;
-            }
-         }
-         return false;
-      };
-
-      auto rules = ruleset->FindRules(std::string(className).c_str());
-      rules.erase(std::remove_if(rules.begin(), rules.end(), referencesNonTransientMembers), rules.end());
-      AddReadCallbacksFromIORules(rules, fClass);
-   }
 }
 
 void ROOT::Experimental::RClassField::Attach(std::unique_ptr<Detail::RFieldBase> child, RSubFieldInfo info)
@@ -981,6 +960,30 @@ void ROOT::Experimental::RClassField::ReadInClusterImpl(const RClusterIndex &clu
    for (unsigned i = 0; i < fSubFields.size(); i++) {
       auto memberValue = fSubFields[i]->CaptureValue(value->Get<unsigned char>() + fSubFieldsInfo[i].fOffset);
       fSubFields[i]->Read(clusterIndex, &memberValue);
+   }
+}
+
+void ROOT::Experimental::RClassField::RegisterReadCallbacks()
+{
+   // Add post-read callbacks for I/O customization rules; only rules that target transient members are allowed for now
+   // TODO(jalopezg): revise after supporting schema evolution
+   if (const auto ruleset = fClass->GetSchemaRules()) {
+      auto referencesNonTransientMembers = [klass = fClass](const ROOT::TSchemaRule *rule) {
+         R__ASSERT(rule->GetTarget() != nullptr);
+         for (auto target : ROOT::Detail::TRangeStaticCast<TObjString>(*rule->GetTarget())) {
+            const auto dataMember = klass->GetDataMember(target->GetString());
+            if (!dataMember || dataMember->IsPersistent()) {
+               R__LOG_WARNING(NTupleLog())
+                  << "ignoring I/O customization rule with non-transient member: " << dataMember->GetName();
+               return true;
+            }
+         }
+         return false;
+      };
+
+      auto rules = ruleset->FindRules(fClass->GetName());
+      rules.erase(std::remove_if(rules.begin(), rules.end(), referencesNonTransientMembers), rules.end());
+      AddReadCallbacksFromIORules(rules, fClass);
    }
 }
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -429,15 +429,15 @@ void ROOT::Experimental::Detail::RFieldBase::AddReadCallbacksFromIORules(
          R__LOG_WARNING(NTupleLog()) << "ignoring I/O customization rule with unsupported type";
          continue;
       }
-      if (auto func = rule->GetReadFunctionPointer()) {
-         fReadCallbacks.emplace_back([func, classp](Detail::RFieldValue &value) {
-            TVirtualObject oldObj{nullptr};
-            oldObj.fClass = classp;
-            oldObj.fObject = value.GetRawPtr();
-            func(static_cast<char *>(value.GetRawPtr()), &oldObj);
-            oldObj.fClass = nullptr; // TVirtualObject does not own the value
-         });
-      }
+      auto func = rule->GetReadFunctionPointer();
+      R__ASSERT(func != nullptr);
+      fReadCallbacks.emplace_back([func, classp](Detail::RFieldValue &value) {
+         TVirtualObject oldObj{nullptr};
+         oldObj.fClass = classp;
+         oldObj.fObject = value.GetRawPtr();
+         func(static_cast<char *>(value.GetRawPtr()), &oldObj);
+         oldObj.fClass = nullptr; // TVirtualObject does not own the value
+      });
    }
 }
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -981,7 +981,7 @@ void ROOT::Experimental::RClassField::RegisterReadCallbacks()
          return false;
       };
 
-      auto rules = ruleset->FindRules(fClass->GetName());
+      auto rules = ruleset->FindRules(fClass->GetName(), static_cast<Int_t>(GetOnDiskTypeVersion()));
       rules.erase(std::remove_if(rules.begin(), rules.end(), referencesNonTransientMembers), rules.end());
       AddReadCallbacksFromIORules(rules, fClass);
    }

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -918,6 +918,12 @@ ROOT::Experimental::RClassField::RClassField(std::string_view fieldName, std::st
       Attach(std::move(subField),
 	     RSubFieldInfo{kDataMember, static_cast<std::size_t>(dataMember->GetOffset())});
    }
+
+   // Add post-read callbacks for I/O customization rules
+   if (const auto ruleset = fClass->GetSchemaRules()) {
+      auto rules = ruleset->FindRules(std::string(className).c_str());
+      AddReadCallbacksFromIORules(rules, fClass);
+   }
 }
 
 void ROOT::Experimental::RClassField::Attach(std::unique_ptr<Detail::RFieldBase> child, RSubFieldInfo info)

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -927,7 +927,7 @@ ROOT::Experimental::RClassField::RClassField(std::string_view fieldName, std::st
          R__ASSERT(rule->GetTarget() != nullptr);
          for (auto target : ROOT::Detail::TRangeStaticCast<TObjString>(*rule->GetTarget())) {
             const auto dataMember = fClass->GetDataMember(target->GetString());
-            if (dataMember && dataMember->IsPersistent()) {
+            if (!dataMember || dataMember->IsPersistent()) {
                R__LOG_WARNING(NTupleLog())
                   << "ignoring I/O customization rule with non-transient member: " << dataMember->GetName();
                return true;

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -31,6 +31,7 @@
 #include <TDataMember.h>
 #include <TError.h>
 #include <TList.h>
+#include <TObjString.h>
 #include <TRealData.h>
 #include <TSchemaRule.h>
 #include <TSchemaRuleSet.h>
@@ -919,9 +920,24 @@ ROOT::Experimental::RClassField::RClassField(std::string_view fieldName, std::st
 	     RSubFieldInfo{kDataMember, static_cast<std::size_t>(dataMember->GetOffset())});
    }
 
-   // Add post-read callbacks for I/O customization rules
+   // Add post-read callbacks for I/O customization rules; only rules that target transient members are allowed for now
+   // TODO(jalopezg): revise after supporting schema evolution
    if (const auto ruleset = fClass->GetSchemaRules()) {
+      auto referencesNonTransientMembers = [this](const ROOT::TSchemaRule *rule) {
+         R__ASSERT(rule->GetTarget() != nullptr);
+         for (auto target : ROOT::Detail::TRangeStaticCast<TObjString>(*rule->GetTarget())) {
+            const auto dataMember = fClass->GetDataMember(target->GetString());
+            if (dataMember && dataMember->IsPersistent()) {
+               R__LOG_WARNING(NTupleLog())
+                  << "ignoring I/O customization rule with non-transient member: " << dataMember->GetName();
+               return true;
+            }
+         }
+         return false;
+      };
+
       auto rules = ruleset->FindRules(std::string(className).c_str());
+      rules.erase(std::remove_if(rules.begin(), rules.end(), referencesNonTransientMembers), rules.end());
       AddReadCallbacksFromIORules(rules, fClass);
    }
 }

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -457,7 +457,10 @@ void ROOT::Experimental::Detail::RFieldBase::ConnectPageSource(RPageSource &page
    R__ASSERT(fColumns.empty());
    {
       const auto descriptorGuard = pageSource.GetSharedDescriptorGuard();
-      GenerateColumnsImpl(descriptorGuard.GetRef());
+      const RNTupleDescriptor &desc = descriptorGuard.GetRef();
+      GenerateColumnsImpl(desc);
+      if (fOnDiskId != kInvalidDescriptorId)
+         fOnDiskTypeVersion = desc.GetFieldDescriptor(fOnDiskId).GetTypeVersion();
    }
    if (!fColumns.empty())
       fPrincipalColumn = fColumns[0].get();

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -135,9 +135,22 @@ struct DestructorTraits : TrivialTraitsBase {
    ~DestructorTraits() {}
 };
 
-struct StructWithIORules {
+struct StructWithIORulesBase {
    float a;
    float b; //! transient member
+};
+
+struct StructWithTransientString {
+   char chars[4];
+   std::string str; //! transient member
+};
+
+struct StructWithIORules : StructWithIORulesBase {
+   StructWithTransientString s;
+   float c = 0.0f; //! transient member
+
+   StructWithIORules() = default;
+   StructWithIORules(float _a, char _c[4]) : StructWithIORulesBase{_a, 0.0f}, s{{_c[0], _c[1], _c[2], _c[3]}, {}} {}
 };
 
 #endif

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -135,4 +135,9 @@ struct DestructorTraits : TrivialTraitsBase {
    ~DestructorTraits() {}
 };
 
+struct StructWithIORules {
+   float a;
+   float b; //! transient member
+};
+
 #endif

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -39,5 +39,9 @@
 #pragma link C++ class StructWithIORules + ;
 #pragma read sourceClass = "StructWithIORules" source = "float a" version = "[1-]" targetClass = \
    "StructWithIORules" target = "b" code = "{ b = onfile.a + 1.0f; }"
+// Including a non-transient member in `target` should issue a warning and ignore the rule; thus, `a` remains unchanged
+// in the test
+#pragma read sourceClass = "StructWithIORules" source = "float a" version = "[1-]" targetClass = \
+   "StructWithIORules" target = "a" code = "{ a = 0.0f; }"
 
 #endif

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -36,12 +36,21 @@
 #pragma link C++ class ConstructorTraits + ;
 #pragma link C++ class DestructorTraits + ;
 
+#pragma link C++ class StructWithIORulesBase + ;
+#pragma link C++ class StructWithTransientString + ;
 #pragma link C++ class StructWithIORules + ;
-#pragma read sourceClass = "StructWithIORules" source = "float a" version = "[1-]" targetClass = \
-   "StructWithIORules" target = "b" code = "{ b = onfile.a + 1.0f; }"
+
+#pragma read sourceClass = "StructWithIORulesBase" source = "float a" version = "[1-]" targetClass = \
+   "StructWithIORulesBase" target = "b" code = "{ b = onfile.a + 1.0f; }"
 // Including a non-transient member in `target` should issue a warning and ignore the rule; thus, `a` remains unchanged
 // in the test
-#pragma read sourceClass = "StructWithIORules" source = "float a" version = "[1-]" targetClass = \
-   "StructWithIORules" target = "a" code = "{ a = 0.0f; }"
+#pragma read sourceClass = "StructWithIORulesBase" source = "float a" version = "[1-]" targetClass = \
+   "StructWithIORulesBase" target = "a" code = "{ a = 0.0f; }"
+
+#pragma read sourceClass = "StructWithTransientString" source = "char chars[4]" version = "[1-]" targetClass = \
+   "StructWithTransientString" target = "str" include = "string" code = "{ str = std::string{onfile.chars, 4}; }"
+
+#pragma read sourceClass = "StructWithIORules" source = "float a;float b" version = "[1-]" targetClass = \
+   "StructWithIORules" target = "c" code = "{ c = onfile.a + onfile.b; }"
 
 #endif

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -36,4 +36,8 @@
 #pragma link C++ class ConstructorTraits + ;
 #pragma link C++ class DestructorTraits + ;
 
+#pragma link C++ class StructWithIORules + ;
+#pragma read sourceClass = "StructWithIORules" source = "float a" version = "[1-]" targetClass = \
+   "StructWithIORules" target = "b" code = "{ b = onfile.a + 1.0f; }"
+
 #endif

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -36,16 +36,19 @@
 #pragma link C++ class ConstructorTraits + ;
 #pragma link C++ class DestructorTraits + ;
 
-#pragma link C++ class StructWithIORulesBase + ;
-#pragma link C++ class StructWithTransientString + ;
-#pragma link C++ class StructWithIORules + ;
+#pragma link C++ options = version(3) class StructWithIORulesBase + ;
+#pragma link C++ options = version(3) class StructWithTransientString + ;
+#pragma link C++ options = version(3) class StructWithIORules + ;
 
-#pragma read sourceClass = "StructWithIORulesBase" source = "float a" version = "[1-]" targetClass = \
+#pragma read sourceClass = "StructWithIORulesBase" source = "float a" version = "[1-99]" targetClass = \
    "StructWithIORulesBase" target = "b" code = "{ b = onfile.a + 1.0f; }"
 // Including a non-transient member in `target` should issue a warning and ignore the rule; thus, `a` remains unchanged
 // in the test
 #pragma read sourceClass = "StructWithIORulesBase" source = "float a" version = "[1-]" targetClass = \
    "StructWithIORulesBase" target = "a" code = "{ a = 0.0f; }"
+// This rule is ignored due to type version mismatch
+#pragma read sourceClass = "StructWithIORulesBase" source = "float a" version = "[100-]" targetClass = \
+   "StructWithIORulesBase" target = "b" code = "{ b = 0.0f; }"
 
 #pragma read sourceClass = "StructWithTransientString" source = "char chars[4]" version = "[1-]" targetClass = \
    "StructWithTransientString" target = "str" include = "string" code = "{ str = std::string{onfile.chars, 4}; }"

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -1,5 +1,6 @@
 #include "ntuple_test.hxx"
 #include "SimpleCollectionProxy.hxx"
+#include "ROOT/TestSupport.hxx"
 #include "TInterpreter.h"
 
 #include <cstring>
@@ -627,6 +628,12 @@ TEST(RNTuple, Traits)
 
 TEST(RNTuple, TClassReadRules)
 {
+   ROOT::TestSupport::CheckDiagsRAII diags;
+   diags.requiredDiag(kWarning, "[ROOT.NTuple]", "ignoring I/O customization rule with non-transient member: a", false);
+   diags.requiredDiag(kWarning, "ROOT::Experimental::Detail::RPageSinkFile::RPageSinkFile",
+                      "The RNTuple file format will change.", false);
+   diags.requiredDiag(kWarning, "[ROOT.NTuple]", "Pre-release format version: RC 1", false);
+
    FileRaii fileGuard("test_ntuple_tclassrules.ntuple");
    char c[4] = {'R', 'O', 'O', 'T'};
    {


### PR DESCRIPTION
Pull request #11731 introduced internal support for per field post-read callbacks.  This follow-up pull request registers a callback for each `#pragma read` rule on user-defined classes.
Currently, `#pragma read` rules referencing non-transient members as a `target` are intentionally disallowed -- a warning is logged in that case.  Only target class version is checked, i.e. checksum is ignored.

Raw read rules are not (and will likely not be) supported, as they take a `TBuffer &`.

## Changes or fixes:
- Introduce `RFieldBase::AddReadCallbacksFromIORules()`. This function registers a post-read callback for each of the given `ROOT::TSchemaRule`s.
- `RFieldBase::ConnectPageSource()`: cache C++ type version as stored in the RNTupleDescriptor.  This information can be accessed via `GetOnDiskTypeVersion()`.
`RFieldBase::RegisterReadCallbacks()` is called as part of `ConnectPageSource()`.  This function can be overridden; in particular, derived classes can make use of the on-disk type version to enable/disable read rules.
- RClassField: register a post-read callback for each of the custom I/O rules associated with the target class version.
- I/O customization rules referencing non-transient members are ignored for now. Such rules shall trigger a warning, e.g.
```
210: Warning in <[ROOT.NTuple] Warning /home/jalopezg/CERN/repos/root/tree/ntuple/v7/src/RField.cxx:931 in 
ROOT::Experimental::RClassField::RClassField(std::string_view, std::string_view, TClass*)::<lambda(const 
ROOT::TSchemaRule*)>>: ignoring I/O customization rule with non-transient member: a
```

## Checklist:
- [X] tested changes locally
- [X] updated the docs (if necessary)

This PR partially takes care of #10019.