### PR TITLE
[cling] Revert "Disable GlobalISel on AArch64 (#7419)"

### DIFF
--- a/interpreter/cling/lib/Interpreter/IncrementalJIT.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalJIT.cpp
@@ -330,28 +330,7 @@ CreateHostTargetMachine(const clang::CompilerInstance& CI) {
   JTMB->setCodeModel(CodeModel::Large);
 #endif
 
-  std::unique_ptr<TargetMachine> TM = cantFail(JTMB->createTargetMachine());
-
-  // Forcefully disable GlobalISel, it might be enabled on AArch64 without
-  // optimizations. In tests on an Apple M1 after the upgrade to LLVM 9, this
-  // new instruction selection framework emits branches / calls that expect all
-  // code to be reachable in +/- 128 MB. This cannot be guaranteed during JIT,
-  // which generates code into allocated pages on the heap and could span the
-  // entire address space of the process.
-  //
-  // TODO:
-  // 1. Try to reproduce the problem with vanilla lli of LLVM 9 to check that
-  //    this is not related to the way Cling incrementally JITs and executes.
-  // 2. Figure out exactly why GlobalISel emits different branch instructions,
-  //    and whether this is a problem in the framework or of the generated IR.
-  // 3. Verify if the same happens with LLVM 11/12 (whatever Cling will move to
-  //    next), and possibly fix the underlying issue in LLVM upstream's `main`.
-  //
-  // FIXME: Lift this restriction and allow the target to enable GlobalISel,
-  // if deemed ready by upstream developers.
-  TM->setGlobalISel(false);
-
-  return TM;
+  return cantFail(JTMB->createTargetMachine());
 }
 } // unnamed namespace
 

--- a/tree/dataframe/test/dataframe_vary.cxx
+++ b/tree/dataframe/test/dataframe_vary.cxx
@@ -127,9 +127,8 @@ TEST(RDFVary, RequireVariationsHaveConsistentType)
       std::runtime_error);
 }
 
-// throwing exceptions from jitted code cause problems on windows and MacOS+M1
+// throwing exceptions from jitted code cause problems on windows
 #if !defined(_MSC_VER) || defined(R__ENABLE_BROKEN_WIN_TESTS)
-#if !(defined(R__MACOSX) && defined(__arm64__))
 TEST(RDFVary, RequireVariationsHaveConsistentTypeJitted)
 {
    // non-jitted Define, jitted Vary with incompatible type
@@ -198,7 +197,6 @@ TEST(RDFVary, RequireVariationsHaveConsistentTypeJitted)
          std::runtime_error);
    }
 }
-#endif
 #endif
 
 TEST(RDFVary, RequireReturnTypeIsRVec)


### PR DESCRIPTION
This reverts fcab0add4a79379b5087fe786261f4ab0cc9776a which is not needed anymore since llvm13 / Orc-v2.

This is on top of https://github.com/root-project/root/pull/11945 (for proactive conflict resolution)
