### PR TITLE
[hist] TH1::GetCumulative: fix error setting

### DIFF
--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -2616,7 +2616,7 @@ TH1 *TH1::GetCumulative(Bool_t forward, const char* suffix) const
                hintegrated->AddBinContent(bin, sum);
                if (fSumw2.fN) {
                   esum += GetBinErrorSqUnchecked(bin);
-                  fSumw2.fArray[bin] = esum;
+                  hintegrated->fSumw2.fArray[bin] = esum;
                }
             }
          }
@@ -2630,7 +2630,7 @@ TH1 *TH1::GetCumulative(Bool_t forward, const char* suffix) const
                hintegrated->AddBinContent(bin, sum);
                if (fSumw2.fN) {
                   esum += GetBinErrorSqUnchecked(bin);
-                  fSumw2.fArray[bin] = esum;
+                  hintegrated->fSumw2.fArray[bin] = esum;
                }
             }
          }


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

This PR fixes the `TH1::GetCumulative()` method by assigning the cumulative error to the newly generated histogram instead of the original one.

## Checklist:

- [X] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #11947

