### PR TITLE
[hist] Rewrite `TH1::GetCumulative` to produce sensible 2D and 3D cumulative histograms

### DIFF
--- a/README/ReleaseNotes/v642/index.md
+++ b/README/ReleaseNotes/v642/index.md
@@ -57,6 +57,20 @@ The following people have contributed to this new version:
 
 ## Histograms
 
+### Cumulative histograms in more than one dimension
+
+`TH1::GetCumulative()` now computes a true multi-dimensional cumulative for 2D
+(`TH2`) and 3D (`TH3`) histograms, using the inclusion-exclusion principle: each
+bin of the result holds the sum of all bins whose indices are no greater than
+(forward) or no less than (backward) those of the target bin along *every* axis.
+Previously the method accumulated a single running sum over the flattened bin
+iteration, which did not correspond to a meaningful cumulative distribution in
+more than one dimension.
+
+The behavior for one-dimensional histograms is unchanged. Code that relied on
+the previous 2D/3D output (for example to build per-axis selection efficiency
+maps) will now obtain different, mathematically consistent values.
+
 ## Math
 
 ## RooFit

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -2642,51 +2642,99 @@ Double_t *TH1::GetIntegral()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-///  Return a pointer to a histogram containing the cumulative content.
-///  The cumulative can be computed both in the forward (default) or backward
-///  direction; the name of the new histogram is constructed from
-///  the name of this histogram with the suffix "suffix" appended provided
-///  by the user. If not provided a default suffix="_cumulative" is used.
-///
-/// The cumulative distribution is formed by filling each bin of the
-/// resulting histogram with the sum of that bin and all previous
-/// (forward == kTRUE) or following (forward = kFALSE) bins.
-///
-/// Note: while cumulative distributions make sense in one dimension, you
-/// may not be getting what you expect in more than 1D because the concept
-/// of a cumulative distribution is much trickier to define; make sure you
-/// understand the order of summation before you use this method with
-/// histograms of dimension >= 2.
-///
-/// Note 2: By default the cumulative is computed from bin 1 to Nbins
-/// If an axis range is set, values between the minimum and maximum of the range
-/// are set.
-/// Setting an axis range can also be used for including underflow and overflow in
-/// the cumulative (e.g. by setting h->GetXaxis()->SetRange(0, h->GetNbinsX()+1); )
-///
+/**
+ * Return a pointer to the corresponding cumulative histogram.
+ *
+ * The cumulative can be computed both in the forward (default) or backward
+ * direction; the name of the new histogram is constructed from
+ * the name of this histogram with a custom suffix (`suffix`) appended,
+ * which defaults to "_cumulative".
+ *
+ * The cumulative distribution is formed by filling each bin of the
+ * resulting histogram with the sum of all the bins whose indice is
+ * no greater than (forward) or no less than (backward)
+ * that of the target bin. To be exact,
+ * \f[
+ *   S_{i_x, i_y, i_z} =
+ *   \begin{cases}
+ *     \sum_{j_x = 1}^{i_x} \sum_{j_y = 1}^{i_y} \sum_{j_z = 1}^{i_z} a_{j_x, j_y, j_z} & \text{(forward)} \\
+ *     \sum_{j_x = i_x}^{n_x} \sum_{j_y = i_y}^{n_y} \sum_{j_z = i_z}^{n_z} a_{j_x, j_y, j_z} & \text{(backward)}
+ *   \end{cases}
+ * \f]
+ *
+ * The implementation is based on the Inclusion-Exclusion principle. That is,
+ * \f[
+ *   S_{i_x, i_y, i_z} = a_{i_x, i_y, i_z}
+ *     + S_{i_x, i_y, i_z-1} + S_{i_x, i_y-1, i_z} + S_{i_x-1, i_y, i_z}
+ *     - S_{i_x, i_y-1, i_z-1} + S_{i_x-1, i_y-1, i_z} + S_{i_x, i_y, i_z-1}
+ *     + S_{i_x+1, i_y-1, i_z-1}
+ * \f]
+ *
+ * This ensures that the result make sense in higher dimension,
+ * especially in the case of selection efficiency computing.
+ * For example, one can get a histogram (`*h2_eff_pt_eta`) in which each bin represents
+ * the selection efficiency where pt and eta is greater than or equal to the lower edges of the bin
+ * from the 2D histogram of these variables (`*h2_pt_eta`) with the followin code,
+ * ~~~{.cpp}
+ * TH2 *h2_eff_pt_eta = h2_pt_eta->GetCumulative(kFALSE, "_efficiency");
+ * h2_eff_pt_eta->Scale(1. / h2_eff_pt_eta->GetBinContent(1, 1));
+ * ~~~
+ *
+ * Note: By default, the cumulative is computed from bin 1 to Nbins.
+ * If an axis range is set,
+ * values between the minimum and maximum of the range are set.
+ * Setting an axis range can also be used for including underflow and overflow in
+ * the cumulative (e.g. by setting h->GetXaxis()->SetRange(0, h->GetNbinsX()+1); )
+ **/
 
-TH1 *TH1::GetCumulative(Bool_t forward, const char* suffix) const
+TH1 *TH1::GetCumulative(Bool_t forward, const char *suffix) const
 {
    const Int_t firstX = fXaxis.GetFirst();
-   const Int_t lastX  = fXaxis.GetLast();
-   const Int_t firstY = (fDimension > 1) ? fYaxis.GetFirst() : 1;
-   const Int_t lastY = (fDimension > 1) ? fYaxis.GetLast() : 1;
-   const Int_t firstZ = (fDimension > 1) ? fZaxis.GetFirst() : 1;
-   const Int_t lastZ = (fDimension > 1) ? fZaxis.GetLast() : 1;
+   const Int_t lastX = fXaxis.GetLast();
+   const Int_t firstY = (fDimension >= 2) ? fYaxis.GetFirst() : 1;
+   const Int_t lastY = (fDimension >= 2) ? fYaxis.GetLast() : 1;
+   const Int_t firstZ = (fDimension >= 3) ? fZaxis.GetFirst() : 1;
+   const Int_t lastZ = (fDimension >= 3) ? fZaxis.GetLast() : 1;
 
-   TH1* hintegrated = (TH1*) Clone(fName + suffix);
+   TH1 *hintegrated = static_cast<TH1 *>(Clone(fName + suffix));
    hintegrated->Reset();
-   Double_t sum = 0.;
-   Double_t esum = 0;
    if (forward) { // Forward computation
       for (Int_t binz = firstZ; binz <= lastZ; ++binz) {
          for (Int_t biny = firstY; biny <= lastY; ++biny) {
             for (Int_t binx = firstX; binx <= lastX; ++binx) {
                const Int_t bin = hintegrated->GetBin(binx, biny, binz);
-               sum += RetrieveBinContent(bin);
-               hintegrated->AddBinContent(bin, sum);
+               Double_t sum = RetrieveBinContent(bin);
+               if (binz != firstZ)
+                  sum += hintegrated->RetrieveBinContent(hintegrated->GetBin(binx, biny, binz - 1));
+               if (biny != firstY)
+                  sum += hintegrated->RetrieveBinContent(hintegrated->GetBin(binx, biny - 1, binz));
+               if (binx != firstX)
+                  sum += hintegrated->RetrieveBinContent(hintegrated->GetBin(binx - 1, biny, binz));
+               if (binz != firstZ && biny != firstY)
+                  sum -= hintegrated->RetrieveBinContent(hintegrated->GetBin(binx, biny - 1, binz - 1));
+               if (biny != firstY && binx != firstX)
+                  sum -= hintegrated->RetrieveBinContent(hintegrated->GetBin(binx - 1, biny - 1, binz));
+               if (binx != firstX && binz != firstZ)
+                  sum -= hintegrated->RetrieveBinContent(hintegrated->GetBin(binx - 1, biny, binz - 1));
+               if (binz != firstZ && biny != firstY && binx != firstX)
+                  sum += hintegrated->RetrieveBinContent(hintegrated->GetBin(binx - 1, biny - 1, binz - 1));
+               hintegrated->SetBinContent(bin, sum);
                if (fSumw2.fN) {
-                  esum += GetBinErrorSqUnchecked(bin);
+                  Double_t esum = GetBinErrorSqUnchecked(bin);
+                  if (binz != firstZ)
+                     esum += hintegrated->fSumw2.fArray[hintegrated->GetBin(binx, biny, binz - 1)];
+                  if (biny != firstY)
+                     esum += hintegrated->fSumw2.fArray[hintegrated->GetBin(binx, biny - 1, binz)];
+                  if (binx != firstX)
+                     esum += hintegrated->fSumw2.fArray[hintegrated->GetBin(binx - 1, biny, binz)];
+                  if (binz != firstZ && biny != firstY)
+                     esum -= hintegrated->fSumw2.fArray[hintegrated->GetBin(binx, biny - 1, binz - 1)];
+                  if (biny != firstY && binx != firstX)
+                     esum -= hintegrated->fSumw2.fArray[hintegrated->GetBin(binx - 1, biny - 1, binz)];
+                  if (binx != firstX && binz != firstZ)
+                     esum -= hintegrated->fSumw2.fArray[hintegrated->GetBin(binx - 1, biny, binz - 1)];
+                  if (binz != firstZ && biny != firstY && binx != firstX)
+                     esum += hintegrated->fSumw2.fArray[hintegrated->GetBin(binx - 1, biny - 1, binz - 1)];
                   hintegrated->fSumw2.fArray[bin] = esum;
                }
             }
@@ -2697,10 +2745,38 @@ TH1 *TH1::GetCumulative(Bool_t forward, const char* suffix) const
          for (Int_t biny = lastY; biny >= firstY; --biny) {
             for (Int_t binx = lastX; binx >= firstX; --binx) {
                const Int_t bin = hintegrated->GetBin(binx, biny, binz);
-               sum += RetrieveBinContent(bin);
-               hintegrated->AddBinContent(bin, sum);
+               Double_t sum = RetrieveBinContent(bin);
+               if (binz != lastZ)
+                  sum += hintegrated->RetrieveBinContent(hintegrated->GetBin(binx, biny, binz + 1));
+               if (biny != lastY)
+                  sum += hintegrated->RetrieveBinContent(hintegrated->GetBin(binx, biny + 1, binz));
+               if (binx != lastX)
+                  sum += hintegrated->RetrieveBinContent(hintegrated->GetBin(binx + 1, biny, binz));
+               if (binz != lastZ && biny != lastY)
+                  sum -= hintegrated->RetrieveBinContent(hintegrated->GetBin(binx, biny + 1, binz + 1));
+               if (biny != lastY && binx != lastX)
+                  sum -= hintegrated->RetrieveBinContent(hintegrated->GetBin(binx + 1, biny + 1, binz));
+               if (binx != lastX && binz != lastZ)
+                  sum -= hintegrated->RetrieveBinContent(hintegrated->GetBin(binx + 1, biny, binz + 1));
+               if (binz != lastZ && biny != lastY && binx != lastX)
+                  sum += hintegrated->RetrieveBinContent(hintegrated->GetBin(binx + 1, biny + 1, binz + 1));
+               hintegrated->SetBinContent(bin, sum);
                if (fSumw2.fN) {
-                  esum += GetBinErrorSqUnchecked(bin);
+                  Double_t esum = GetBinErrorSqUnchecked(bin);
+                  if (binz != lastZ)
+                     esum += hintegrated->fSumw2.fArray[hintegrated->GetBin(binx, biny, binz + 1)];
+                  if (biny != lastY)
+                     esum += hintegrated->fSumw2.fArray[hintegrated->GetBin(binx, biny + 1, binz)];
+                  if (binx != lastX)
+                     esum += hintegrated->fSumw2.fArray[hintegrated->GetBin(binx + 1, biny, binz)];
+                  if (binz != lastZ && biny != lastY)
+                     esum -= hintegrated->fSumw2.fArray[hintegrated->GetBin(binx, biny + 1, binz + 1)];
+                  if (biny != lastY && binx != lastX)
+                     esum -= hintegrated->fSumw2.fArray[hintegrated->GetBin(binx + 1, biny + 1, binz)];
+                  if (binx != lastX && binz != lastZ)
+                     esum -= hintegrated->fSumw2.fArray[hintegrated->GetBin(binx + 1, biny, binz + 1)];
+                  if (binz != lastZ && biny != lastY && binx != lastX)
+                     esum += hintegrated->fSumw2.fArray[hintegrated->GetBin(binx + 1, biny + 1, binz + 1)];
                   hintegrated->fSumw2.fArray[bin] = esum;
                }
             }

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -2651,9 +2651,9 @@ Double_t *TH1::GetIntegral()
  * which defaults to "_cumulative".
  *
  * The cumulative distribution is formed by filling each bin of the
- * resulting histogram with the sum of all the bins whose indice is
+ * resulting histogram with the sum of all the bins whose indices are
  * no greater than (forward) or no less than (backward)
- * that of the target bin. To be exact,
+ * those of the target bin. To be exact,
  * \f[
  *   S_{i_x, i_y, i_z} =
  *   \begin{cases}
@@ -2663,18 +2663,22 @@ Double_t *TH1::GetIntegral()
  * \f]
  *
  * The implementation is based on the Inclusion-Exclusion principle. That is,
+ * for the forward case,
  * \f[
  *   S_{i_x, i_y, i_z} = a_{i_x, i_y, i_z}
- *     + S_{i_x, i_y, i_z-1} + S_{i_x, i_y-1, i_z} + S_{i_x-1, i_y, i_z}
- *     - S_{i_x, i_y-1, i_z-1} + S_{i_x-1, i_y-1, i_z} + S_{i_x, i_y, i_z-1}
- *     + S_{i_x+1, i_y-1, i_z-1}
+ *     + S_{i_x-1, i_y, i_z} + S_{i_x, i_y-1, i_z} + S_{i_x, i_y, i_z-1}
+ *     - S_{i_x-1, i_y-1, i_z} - S_{i_x-1, i_y, i_z-1} - S_{i_x, i_y-1, i_z-1}
+ *     + S_{i_x-1, i_y-1, i_z-1}
  * \f]
+ * where any term referring to a bin outside the summation range is taken to
+ * be zero (and the backward case is obtained by replacing the \f$-1\f$ index
+ * offsets with \f$+1\f$).
  *
- * This ensures that the result make sense in higher dimension,
+ * This ensures that the result makes sense in higher dimensions,
  * especially in the case of selection efficiency computing.
  * For example, one can get a histogram (`*h2_eff_pt_eta`) in which each bin represents
- * the selection efficiency where pt and eta is greater than or equal to the lower edges of the bin
- * from the 2D histogram of these variables (`*h2_pt_eta`) with the followin code,
+ * the selection efficiency where pt and eta are greater than or equal to the lower edges of the bin
+ * from the 2D histogram of these variables (`*h2_pt_eta`) with the following code,
  * ~~~{.cpp}
  * TH2 *h2_eff_pt_eta = h2_pt_eta->GetCumulative(kFALSE, "_efficiency");
  * h2_eff_pt_eta->Scale(1. / h2_eff_pt_eta->GetBinContent(1, 1));

--- a/hist/hist/test/test_TH1.cxx
+++ b/hist/hist/test/test_TH1.cxx
@@ -11,6 +11,7 @@
 
 #include <cmath>
 #include <cstddef>
+#include <memory>
 #include <random>
 #include <vector>
 
@@ -429,4 +430,135 @@ TEST(TH1L, SetBinContent)
    static constexpr long long Large = 1LL << 42;
    h.SetBinContent(1, Large);
    EXPECT_EQ(h.GetBinContent(1), Large);
+}
+
+// Reference cumulative bin content computed directly from the definition:
+// the sum of all source bins whose indices are no greater than (forward) or no
+// less than (backward) those of the target bin along every axis. Works for 1D,
+// 2D and 3D histograms (unused axes have a single bin at index 1).
+static double BruteForceCumulative(const TH1 &h, int ix, int iy, int iz, bool forward)
+{
+   double sum = 0.;
+   for (int jz = 1; jz <= h.GetNbinsZ(); ++jz) {
+      if (forward ? (jz > iz) : (jz < iz))
+         continue;
+      for (int jy = 1; jy <= h.GetNbinsY(); ++jy) {
+         if (forward ? (jy > iy) : (jy < iy))
+            continue;
+         for (int jx = 1; jx <= h.GetNbinsX(); ++jx) {
+            if (forward ? (jx > ix) : (jx < ix))
+               continue;
+            sum += h.GetBinContent(jx, jy, jz);
+         }
+      }
+   }
+   return sum;
+}
+
+// Same as above but accumulating the squared bin errors (variances add for the
+// independent bins entering each cumulative bin).
+static double BruteForceCumulativeErrorSq(const TH1 &h, int ix, int iy, int iz, bool forward)
+{
+   double sum = 0.;
+   for (int jz = 1; jz <= h.GetNbinsZ(); ++jz) {
+      if (forward ? (jz > iz) : (jz < iz))
+         continue;
+      for (int jy = 1; jy <= h.GetNbinsY(); ++jy) {
+         if (forward ? (jy > iy) : (jy < iy))
+            continue;
+         for (int jx = 1; jx <= h.GetNbinsX(); ++jx) {
+            if (forward ? (jx > ix) : (jx < ix))
+               continue;
+            const double err = h.GetBinError(jx, jy, jz);
+            sum += err * err;
+         }
+      }
+   }
+   return sum;
+}
+
+// 1D cumulative must match the textbook prefix/suffix sum in both directions.
+TEST(TH1, GetCumulative1D)
+{
+   TH1D h("h1", "h1", 5, 0, 5);
+   for (int i = 1; i <= 5; ++i)
+      h.SetBinContent(i, i); // 1, 2, 3, 4, 5
+
+   for (bool forward : {true, false}) {
+      std::unique_ptr<TH1> c{h.GetCumulative(forward)};
+      for (int i = 1; i <= 5; ++i)
+         EXPECT_DOUBLE_EQ(c->GetBinContent(i), BruteForceCumulative(h, i, 1, 1, forward)) << "bin " << i;
+   }
+}
+
+// 2D cumulative uses the inclusion-exclusion principle along both axes, not a
+// running sum over the flattened bins (the pre-6.42 behavior).
+TEST(TH1, GetCumulative2D)
+{
+   TH2D h("h2", "h2", 3, 0, 3, 3, 0, 3);
+   double v = 1.;
+   for (int iy = 1; iy <= 3; ++iy)
+      for (int ix = 1; ix <= 3; ++ix)
+         h.SetBinContent(ix, iy, v++); // 1..9
+
+   for (bool forward : {true, false}) {
+      std::unique_ptr<TH1> c{h.GetCumulative(forward)};
+      for (int iy = 1; iy <= 3; ++iy)
+         for (int ix = 1; ix <= 3; ++ix)
+            EXPECT_DOUBLE_EQ(c->GetBinContent(ix, iy), BruteForceCumulative(h, ix, iy, 1, forward))
+               << "bin (" << ix << ", " << iy << ")";
+   }
+
+   // Explicit hand-checked forward anchor: the top-right bin must hold the grand
+   // total, and bin (2,2) the sum of the lower-left 2x2 block (1+2+4+5 = 12).
+   std::unique_ptr<TH1> c{h.GetCumulative(true)};
+   EXPECT_DOUBLE_EQ(c->GetBinContent(1, 1), 1.);
+   EXPECT_DOUBLE_EQ(c->GetBinContent(2, 2), 12.);
+   EXPECT_DOUBLE_EQ(c->GetBinContent(3, 3), 45.);
+}
+
+// 3D cumulative must agree with the brute-force inclusion-exclusion result.
+TEST(TH1, GetCumulative3D)
+{
+   TH3D h("h3", "h3", 2, 0, 2, 3, 0, 3, 2, 0, 2);
+   double v = 1.;
+   for (int iz = 1; iz <= 2; ++iz)
+      for (int iy = 1; iy <= 3; ++iy)
+         for (int ix = 1; ix <= 2; ++ix)
+            h.SetBinContent(ix, iy, iz, v++);
+
+   for (bool forward : {true, false}) {
+      std::unique_ptr<TH1> c{h.GetCumulative(forward)};
+      for (int iz = 1; iz <= 2; ++iz)
+         for (int iy = 1; iy <= 3; ++iy)
+            for (int ix = 1; ix <= 2; ++ix)
+               EXPECT_DOUBLE_EQ(c->GetBinContent(ix, iy, iz), BruteForceCumulative(h, ix, iy, iz, forward))
+                  << "bin (" << ix << ", " << iy << ", " << iz << ")";
+   }
+}
+
+// When Sumw2 is enabled, the squared errors must accumulate over the same region
+// as the contents.
+TEST(TH1, GetCumulativeErrors)
+{
+   TH2D h("h2err", "h2err", 3, 0, 3, 3, 0, 3);
+   h.Sumw2();
+   double v = 1.;
+   for (int iy = 1; iy <= 3; ++iy) {
+      for (int ix = 1; ix <= 3; ++ix) {
+         h.SetBinContent(ix, iy, v);
+         h.SetBinError(ix, iy, 0.5 * v); // errors differ from contents
+         v += 1.;
+      }
+   }
+
+   for (bool forward : {true, false}) {
+      std::unique_ptr<TH1> c{h.GetCumulative(forward)};
+      for (int iy = 1; iy <= 3; ++iy)
+         for (int ix = 1; ix <= 3; ++ix) {
+            const double err = c->GetBinError(ix, iy);
+            EXPECT_DOUBLE_EQ(err * err, BruteForceCumulativeErrorSq(h, ix, iy, 1, forward))
+               << "bin (" << ix << ", " << iy << ")";
+         }
+   }
 }


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

This PR re-implements the `TH1` method `GetCumulative(forward, suffix)`, which is equivalent to the original implementation (with #11948 applied) on 1D histograms, but produces more sensible result for 2D and 3D histograms. That is,

$$S_{i_x i_y i_z} = \sum_{j_x = n_{x0}}^{i_x} \sum_{j_y = n_{y0}}^{i_y} \sum_{j_z = n_{z0}}^{i_z} a_{j_x j_y j_z}\ (\text{forward})$$

$$S_{i_x i_y i_z} = \sum_{j_x = i_x}^{n_x} \sum_{j_y = i_y}^{n_y} \sum_{j_z = i_z}^{n_z} a_{j_x j_y j_z}\ (\text{backward})$$

To achieve $O(n_x n_y n_z)$ time complexity (instead of $O(n_x^2 n_y^2 n_z^2)$ ), the method is implemented using the [inclusion-exclusion principle](https://en.wikipedia.org/wiki/Inclusion%E2%80%93exclusion_principle) while referencing the content of the previously-computed neighboring bins. Namely,

$$\begin{cases}
S_{i_x i_y i_z} = a_{i_x i_y i_z} + S_{(i_x-1) i_y i_z} + S_{i_x (i_y-1) i_z} + S_{i_x i_y (i_z-1)} - S_{(i_x-1) (i_y-1) i_z} - S_{i_x (i_y-1) (i_z-1)} - S_{(i_x-1) i_y (i_z-1)} + S_{(i_x-1) (i_y-1) (i_z-1)} & (\text{forward}) \\
S_{i_x i_y i_z} = a_{i_x i_y i_z} + S_{(i_x+1) i_y i_z} + S_{i_x (i_y+1) i_z} + S_{i_x i_y (i_z+1)} - S_{(i_x+1) (i_y+1) i_z} - S_{i_x (i_y+1) (i_z+1)} - S_{(i_x+1) i_y (i_z+1)} + S_{(i_x+1) (i_y+1) (i_z+1)} & (\text{backward})
\end{cases}$$

This is useful when computing the selection efficiency of two variables:
For example, one can get a histogram (`*h2_eff_pt_eta`) in which each bin represents the selection efficiency where pt and eta is greater than the lower edges of the bin from the 2D histogram of these variables (`*h2_pt_eta`) with the following code,

```c++
TH2 *h2_eff_pt_eta = h2_pt_eta->GetCumulative(kFALSE, "_efficiency");
h2_eff_pt_eta->Scale(h2_eff_pt_eta->GetBinContent(1, 1));
```

## Checklist:

- [X] tested changes locally
- [X] updated the docs (if necessary)

This PR fixes # 

