### PR TITLE
[tmva][sofie] Fix Keras parsing for  Python2

### DIFF
--- a/tmva/pymva/inc/TMVA/PyMethodBase.h
+++ b/tmva/pymva/inc/TMVA/PyMethodBase.h
@@ -141,6 +141,7 @@ namespace TMVA {
       static const char* PyStringAsString(PyObject *string); // Python Utility function for converting a Python String object to const char*
       static std::vector<size_t> GetDataFromTuple(PyObject *tupleObject);  // Function casts Python Tuple object into vector of size_t
       static std::vector<size_t> GetDataFromList(PyObject *listObject);    // Function casts Python List object into vector of size_t
+      static PyObject* GetValueFromDict(PyObject* dict, const char* key);  // Function to check for a key in dict and return the associated value if present
       ClassDef(PyMethodBase, 0) // Virtual base class for all TMVA method
 
    };

--- a/tmva/pymva/src/PyMethodBase.cxx
+++ b/tmva/pymva/src/PyMethodBase.cxx
@@ -431,3 +431,23 @@ std::vector<size_t> PyMethodBase::GetDataFromList(PyObject* listObject){
          }
    return listVec;
 }
+
+//////////////////////////////////////////////////////////////////////////////////
+/// \brief Utility function which checks if a given key is present in a Python 
+///        dictionary object and returns the associated value or throws runtime
+///        error. This is to replace PyDict_GetItemWithError in Python 2.
+///
+/// \param[in] listObject Python Dict object
+/// \return Associated value PyObject
+PyObject* PyMethodBase::GetValueFromDict(PyObject* dict, const char* key){
+   #if PY_MAJOR_VERSION >= 3   // using PyDict_GetItemWithError that is available only in Python3
+   return PyDict_GetItemWithError(dict,PyUnicode_FromString(key));
+   #else
+   if(!PyDict_Contains(dict, PyUnicode_FromString(key))){
+      throw std::runtime_error("Key "+key+" does not exist in the dictionary.")
+   } else {
+      return PyDict_GetItemString(dict, key);
+   }
+   #endif
+}
+

--- a/tmva/pymva/test/EmitFromKeras.cxx
+++ b/tmva/pymva/test/EmitFromKeras.cxx
@@ -36,16 +36,18 @@ int main(){
    modelBatchNorm.Generate();
    modelBatchNorm.OutputGenerated("KerasBatchNormModel.hxx");
 
-   //Emitting header file for Keras Conv2D Model with valid padding
+#if PY_MAJOR_VERSION >= 3  // parsing of convolutional models supported only for Python3
+   // Emitting header file for Keras Conv2D Model with valid padding
    RModel modelConv2D_Valid = TMVA::Experimental::SOFIE::PyKeras::Parse("KerasModelConv2D_Valid.h5");
    modelConv2D_Valid.Generate();
    modelConv2D_Valid.OutputGenerated("KerasConv2D_Valid.hxx");
 
-   //Emitting header file for Keras Conv2D Model with valid padding
+   // Emitting header file for Keras Conv2D Model with valid padding
    RModel modelConv2D_Same = TMVA::Experimental::SOFIE::PyKeras::Parse("KerasModelConv2D_Same.h5");
    modelConv2D_Same.Generate();
    modelConv2D_Same.OutputGenerated("KerasConv2D_Same.hxx");
- 
+#endif
+
    //Emitting header file for Keras model with Reshape layer
    RModel modelReshape = TMVA::Experimental::SOFIE::PyKeras::Parse("KerasModelReshape.h5");
    modelReshape.Generate();

--- a/tmva/pymva/test/TestRModelParserKeras.C
+++ b/tmva/pymva/test/TestRModelParserKeras.C
@@ -154,7 +154,11 @@ TEST(RModelParser_Keras, BATCH_NORM)
     }
 }
 
+#if PY_MAJOR_VERSION >= 3
 TEST(RModelParser_Keras, CONV_VALID)
+#else
+TEST(DISABLED_RModelParser_Keras, CONV_VALID)
+#endif
 {
     constexpr float TOLERANCE = DEFAULT_TOLERANCE;
     float inputConv2D_Valid[]= {1,1,1,1,
@@ -196,7 +200,11 @@ TEST(RModelParser_Keras, CONV_VALID)
     }
 }
 
+#if PY_MAJOR_VERSION >= 3
 TEST(RModelParser_Keras, CONV_SAME)
+#else
+TEST(DISABLED_RModelParser_Keras, CONV_SAME)
+#endif
 {
     constexpr float TOLERANCE = DEFAULT_TOLERANCE;
     float inputConv2D_Same[]= {1,1,1,1,


### PR DESCRIPTION

This PR fixes compiling the code for parsing Keras model when the C-API of Python 2 is used. In this case some functions are not available in Python.h. Those functions are used to parse the convolutional layers from Keras. 
This PR excludes the parsing of this layer and avoid calling those functions available only in Python3. 
Also the tests using the cone layer parsing are disabled. 

