### PR TITLE
[RF] Exclude `RooGrid` class from IO

### DIFF
--- a/roofit/roofitcore/inc/LinkDef.h
+++ b/roofit/roofitcore/inc/LinkDef.h
@@ -124,7 +124,6 @@
 #pragma link C++ class RooGenContext+ ;
 #pragma link C++ class RooGenericPdf+ ;
 #pragma link C++ class RooGenProdProj+ ;
-#pragma link C++ class RooGrid+ ;
 #pragma link C++ class RooHistError+ ;
 #pragma link C++ class RooHist+ ;
 #pragma link C++ class RooImproperIntegrator1D+ ;

--- a/roofit/roofitcore/inc/RooGrid.h
+++ b/roofit/roofitcore/inc/RooGrid.h
@@ -16,27 +16,21 @@
 #ifndef ROO_GRID
 #define ROO_GRID
 
-#include "TObject.h"
-#include "RooPrintable.h"
+#include <RtypesCore.h>
 
+#include <ostream>
 #include <vector>
 
 class RooAbsFunc;
 
-class RooGrid : public TObject, public RooPrintable {
+// Utility class for RooMCIntegrator holding a multi-dimensional grid
+class RooGrid {
 public:
   RooGrid() {}
   RooGrid(const RooAbsFunc &function);
 
   // Printing interface
-  void printName(std::ostream& os) const override ;
-  void printTitle(std::ostream& os) const override ;
-  void printClassName(std::ostream& os) const override ;
-  void printMultiline(std::ostream& os, Int_t contents, bool verbose=false, TString indent="") const override;
-
-  inline void Print(Option_t *options= nullptr) const override {
-    printStream(defaultPrintStream(),defaultPrintContents(options),defaultPrintStyle(options));
-  }
+  void print(std::ostream& os, bool verbose=false, std::string const& indent="") const;
 
   inline bool isValid() const { return _valid; }
   inline UInt_t getDimension() const { return _dim; }
@@ -59,15 +53,13 @@ public:
   enum { maxBins = 50 }; // must be even
 
   // Accessor for the j-th normalized grid point along the i-th dimension
-public:
   inline double coord(Int_t i, Int_t j) const { return _xi[i*_dim + j]; }
   inline double value(Int_t i,Int_t j) const { return _d[i*_dim + j]; }
+
 protected:
   inline double& coord(Int_t i, Int_t j) { return _xi[i*_dim + j]; }
   inline double& value(Int_t i,Int_t j) { return _d[i*_dim + j]; }
   inline double& newCoord(Int_t i) { return _xin[i]; }
-
-protected:
 
   bool _valid = false;         ///< Is configuration valid
   UInt_t _dim = 0;             ///< Number of dimensions, bins and boxes
@@ -83,7 +75,6 @@ protected:
   std::vector<double> _xin;    ///<! Internal workspace
   std::vector<double> _weight; ///<! Internal workspace
 
-  ClassDefOverride(RooGrid,1) // Utility class for RooMCIntegrator holding a multi-dimensional grid
 };
 
 #endif

--- a/roofit/roofitcore/src/RooGrid.cxx
+++ b/roofit/roofitcore/src/RooGrid.cxx
@@ -30,15 +30,11 @@ integration, following the VEGAS algorithm.
 #include "RooRandom.h"
 #include "TMath.h"
 #include "RooMsgService.h"
-#include "TClass.h"
 
 #include <math.h>
 #include "Riostream.h"
 #include <iomanip>
 
-using namespace std;
-
-ClassImp(RooGrid);
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -49,7 +45,7 @@ RooGrid::RooGrid(const RooAbsFunc &function)
 {
   // check that the input function is valid
   if(!(_valid= function.isValid())) {
-    oocoutE(nullptr,InputArguments) << ClassName() << ": cannot initialize using an invalid function" << endl;
+    oocoutE(nullptr,InputArguments) << "RooGrid: cannot initialize using an invalid function" << std::endl;
     return;
   }
 
@@ -80,18 +76,18 @@ bool RooGrid::initialize(const RooAbsFunc &function)
   for(UInt_t index= 0; index < _dim; index++) {
     _xl[index]= function.getMinLimit(index);
     if(RooNumber::isInfinite(_xl[index])) {
-      oocoutE(nullptr,Integration) << ClassName() << ": lower limit of dimension " << index << " is infinite" << endl;
+      oocoutE(nullptr,Integration) << "RooGrid: lower limit of dimension " << index << " is infinite" << std::endl;
       return false;
     }
     _xu[index]= function.getMaxLimit(index);
     if(RooNumber::isInfinite(_xl[index])) {
-      oocoutE(nullptr,Integration) << ClassName() << ": upper limit of dimension " << index << " is infinite" << endl;
+      oocoutE(nullptr,Integration) << "RooGrid: upper limit of dimension " << index << " is infinite" << std::endl;
       return false;
     }
     double dx= _xu[index] - _xl[index];
     if(dx <= 0) {
-      oocoutE(nullptr,Integration) << ClassName() << ": bad range for dimension " << index << ": [" << _xl[index]
-                   << "," << _xu[index] << "]" << endl;
+      oocoutE(nullptr,Integration) << "RooGrid: bad range for dimension " << index << ": [" << _xl[index]
+                   << "," << _xu[index] << "]" << std::endl;
       return false;
     }
     _delx[index]= dx;
@@ -186,7 +182,7 @@ void RooGrid::generatePoint(const UInt_t box[], double x[], UInt_t bin[], double
     // store the bin in which this point lies along the j-th
     // coordinate axis and calculate its width and position y
     // in normalized bin coordinates.
-    Int_t k= (Int_t)z;
+    Int_t k= static_cast<Int_t>(z);
     bin[j] = k;
     double y, bin_width;
     if(k == 0) {
@@ -242,49 +238,21 @@ bool RooGrid::nextBox(UInt_t box[]) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Print info about this object to the specified stream.
 
-void RooGrid::printMultiline(ostream& os, Int_t /*contents*/, bool verbose, TString indent) const
+void RooGrid::print(std::ostream& os, bool verbose, std::string const& indent) const
 {
-  os << ClassName() << ": volume = " << getVolume() << endl;
+  os << "RooGrid: volume = " << getVolume() << std::endl;
   os << indent << "  Has " << getDimension() << " dimension(s) each subdivided into "
-     << getNBins() << " bin(s) and sampled with " << _boxes << " box(es)" << endl;
-  for(UInt_t index= 0; index < getDimension(); index++) {
+     << getNBins() << " bin(s) and sampled with " << _boxes << " box(es)" << std::endl;
+  for(std::size_t index= 0; index < getDimension(); index++) {
     os << indent << "  (" << index << ") ["
-       << setw(10) << _xl[index] << "," << setw(10) << _xu[index] << "]" << endl;
+       << std::setw(10) << _xl[index] << "," << std::setw(10) << _xu[index] << "]" << std::endl;
     if(!verbose) continue;
-    for(UInt_t bin= 0; bin < _bins; bin++) {
+    for(std::size_t bin= 0; bin < _bins; bin++) {
       os << indent << "    bin-" << bin << " : x = " << coord(bin,index) << " , y = "
-    << value(bin,index) << endl;
+    << value(bin,index) << std::endl;
     }
   }
 }
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Print name of grid object
-
-void RooGrid::printName(ostream& os) const
-{
-  os << GetName() ;
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Print title of grid object
-
-void RooGrid::printTitle(ostream& os) const
-{
-  os << GetTitle() ;
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Print class name of grid object
-
-void RooGrid::printClassName(ostream& os) const
-{
-  os << ClassName() ;
-}
-
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -345,9 +313,8 @@ void RooGrid::refine(double alpha)
     double xnew = 0;
     double dw = 0;
 
-    UInt_t k;
     i = 1;
-    for (k = 0; k < _bins; k++) {
+    for (UInt_t k = 0; k < _bins; k++) {
       dw += _weight[k];
       xold = xnew;
       xnew = coord(k+1,j);
@@ -358,7 +325,7 @@ void RooGrid::refine(double alpha)
       }
     }
 
-    for (k = 1 ; k < _bins ; k++) {
+    for (UInt_t k = 1 ; k < _bins ; k++) {
       coord( k, j) = newCoord(k);
     }
 

--- a/roofit/roofitcore/src/RooMCIntegrator.cxx
+++ b/roofit/roofitcore/src/RooMCIntegrator.cxx
@@ -113,7 +113,7 @@ RooMCIntegrator::RooMCIntegrator(const RooAbsFunc& function, SamplingMode mode,
 {
   // coverity[UNINIT_CTOR]
   if(!(_valid= _grid.isValid())) return;
-  if(_verbose) _grid.Print();
+  if(_verbose) _grid.print(std::cout);
 }
 
 
@@ -136,7 +136,7 @@ RooMCIntegrator::RooMCIntegrator(const RooAbsFunc& function, const RooNumIntConf
 
   // check that our grid initialized without errors
   if(!(_valid= _grid.isValid())) return;
-  if(_verbose) _grid.Print();
+  if(_verbose) _grid.print(std::cout);
 }
 
 
@@ -358,7 +358,7 @@ double RooMCIntegrator::vegas(Stage stage, UInt_t calls, UInt_t iterations, doub
                  << ")" << endl;
     // print the grid after the final iteration
     if (oodologD((TObject*)0,Integration)) {
-      if(it + 1 == iterations) _grid.Print("V");
+      if(it + 1 == iterations) _grid.print(std::cout, true);
     }
     _grid.refine(_alpha);
   }


### PR DESCRIPTION
The `RooGrid` is a utility class for the `RooMCIntegrator`, which doesn't support IO itself. Therefore, it doesn't make sense to have a `ClassDef(1)` macro. It is only putting the unnecessary burden of keeping backwards compatibility on the developers.

Therefore, this commit suggests to leave out the `ClassDef` macro out of `RooGrid`, and also remove the unnecessary base classes `TObject` and `RooPrintable`. There is only one printing function that makes sense anyway, which is kept without implementing the full `RooPrintable` interface.