### PR TITLE
[RF] Fix and improvements in `testSumW2Error`

### DIFF
--- a/roofit/hs3/test/testHS3HistFactory.cxx
+++ b/roofit/hs3/test/testHS3HistFactory.cxx
@@ -9,7 +9,7 @@
 #include <RooStats/HistFactory/Measurement.h>
 #include <RooStats/HistFactory/MakeModelAndMeasurementsFast.h>
 
-#include <RooMsgService.h>
+#include <RooHelpers.h>
 
 #include <TROOT.h>
 
@@ -73,8 +73,7 @@ measurement(std::string const &inputFileName = "test_hs3_histfactory_json_input.
 
 TEST(TestHS3HistFactoryJSON, Create)
 {
-   auto &msg = RooMsgService::instance();
-   msg.setGlobalKillBelow(RooFit::WARNING);
+   RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
 
    toJSON(*measurement(), "hf.json");
 }

--- a/roofit/hs3/test/testRooFitHS3.cxx
+++ b/roofit/hs3/test/testRooFitHS3.cxx
@@ -25,8 +25,7 @@ TEST(RooFitHS3, RooArgusBG)
 {
    using namespace RooFit;
 
-   auto &msg = RooMsgService::instance();
-   msg.setGlobalKillBelow(RooFit::WARNING);
+   RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
 
    // --- Observable ---
    RooRealVar mes("mes", "m_{ES} (GeV)", 5.20, 5.30);

--- a/roofit/roofit/test/testRooParamHistFunc.cxx
+++ b/roofit/roofit/test/testRooParamHistFunc.cxx
@@ -1,7 +1,7 @@
 // Tests for RooParamHistFunc
 // Author: Jonas Rembser, CERN  03/2020
 
-#include <RooMsgService.h>
+#include <RooHelpers.h>
 #include <RooParamHistFunc.h>
 #include <RooRealSumPdf.h>
 #include <RooRealVar.h>
@@ -20,8 +20,7 @@ TEST(RooParamHistFunc, Integration)
    // inspired by this issue on GitHub:
    // https://github.com/root-project/root/issues/7182
 
-   auto& msg = RooMsgService::instance();
-   msg.setGlobalKillBelow(RooFit::WARNING);
+   RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
 
    constexpr int nBins = 20;
    constexpr double xMin = 0;
@@ -76,8 +75,7 @@ TEST(RooParamHistFunc, IntegrationAndCloning)
    // The test was inspired by this error reported on the forum:
    // https://root-forum.cern.ch/t/barlow-beeston-in-subrange/43909/5
 
-   auto& msg = RooMsgService::instance();
-   msg.setGlobalKillBelow(RooFit::WARNING);
+   RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
 
    using namespace RooFit;
 

--- a/roofit/roofitcore/inc/RooHelpers.h
+++ b/roofit/roofitcore/inc/RooHelpers.h
@@ -36,7 +36,7 @@ namespace RooHelpers {
 /// Can also temporarily activate / deactivate message topics.
 /// Use as
 /// ~~~{.cpp}
-/// RooHelpers::LocalChangeMessageLevel changeMsgLvl(RooFit::WARNING);
+/// RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
 /// [ statements that normally generate a lot of output ]
 /// ~~~
 class LocalChangeMsgLevel {

--- a/roofit/roofitcore/test/TestStatistics/RooRealL.cpp
+++ b/roofit/roofitcore/test/TestStatistics/RooRealL.cpp
@@ -20,6 +20,7 @@
 #include <RooWorkspace.h>
 #include <RooAbsPdf.h>
 #include <RooDataSet.h>
+#include <RooHelpers.h>
 #include <RooMinimizer.h>
 #include <RooFitResult.h>
 #include <RooProdPdf.h>
@@ -105,7 +106,7 @@ void count_NLL_components(RooAbsReal *nll)
 
 TEST_P(RooRealL, getValRooAddition)
 {
-   RooMsgService::instance().setGlobalKillBelow(RooFit::ERROR);
+   RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::ERROR);
 
    RooRandom::randomGenerator()->SetSeed(std::get<0>(GetParam()));
 
@@ -134,7 +135,7 @@ TEST_P(RooRealL, getValRooConstraintSumAddition)
    // modified from
    // https://github.com/roofit-dev/rootbench/blob/43d12f33e8dac7af7d587b53a2804ddf6717e92f/root/roofit/roofit/RooFitASUM.cxx#L417
 
-   RooMsgService::instance().setGlobalKillBelow(RooFit::ERROR);
+   RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::ERROR);
 
    RooWorkspace ws;
    ws.factory("Polynomial::p0(x[0, 10000])");
@@ -235,7 +236,7 @@ TEST_P(RealLVsMPFE, getVal)
 {
    // Compare our MP NLL to actual RooRealMPFE results using the same strategies.
 
-   RooMsgService::instance().setGlobalKillBelow(RooFit::ERROR);
+   RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::ERROR);
 
    // parameters
    std::size_t seed = std::get<0>(GetParam());
@@ -266,7 +267,7 @@ TEST_P(RealLVsMPFE, minimize)
 {
    // do a minimization (e.g. like in GradMinimizer_Gaussian1D test)
 
-   RooMsgService::instance().setGlobalKillBelow(RooFit::ERROR);
+   RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::ERROR);
 
    // parameters
    std::size_t seed = std::get<0>(GetParam());

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cpp
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cpp
@@ -18,6 +18,7 @@
 #include "RooWorkspace.h"
 #include "RooDataHist.h" // complete type in Binned test
 #include "RooCategory.h" // complete type in MultiBinnedConstraint test
+#include "RooHelpers.h"
 #include "RooMinimizer.h"
 #include "RooFitResult.h"
 #include "RooFit/TestStatistics/LikelihoodWrapper.h"
@@ -62,9 +63,15 @@ class Environment : public testing::Environment {
 public:
    void SetUp() override
    {
-      RooMsgService::instance().setGlobalKillBelow(RooFit::ERROR);
+      _changeMsgLvl = std::make_unique<RooHelpers::LocalChangeMsgLevel>(RooFit::ERROR);
       ROOT::Math::MinimizerOptions::SetDefaultMinimizer("Minuit2");
    }
+   void TearDown() override
+   {
+      _changeMsgLvl.reset();
+   }
+private:
+   std::unique_ptr<RooHelpers::LocalChangeMsgLevel> _changeMsgLvl;
 };
 
 // Previously, we just called AddGlobalTestEnvironment in global namespace, but this caused either a warning about an

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodJob.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodJob.cxx
@@ -45,9 +45,15 @@ class Environment : public testing::Environment {
 public:
    void SetUp() override
    {
-      RooMsgService::instance().setGlobalKillBelow(RooFit::ERROR);
+      _changeMsgLvl = std::make_unique<RooHelpers::LocalChangeMsgLevel>(RooFit::ERROR);
       RooFit::MultiProcess::Config::setDefaultNWorkers(2);
    }
+   void TearDown() override
+   {
+      _changeMsgLvl.reset();
+   }
+private:
+   std::unique_ptr<RooHelpers::LocalChangeMsgLevel> _changeMsgLvl;
 };
 
 // Previously, we just called AddGlobalTestEnvironment in global namespace, but this caused either a warning about an

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodSerial.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodSerial.cxx
@@ -37,7 +37,16 @@ using RooFit::TestStatistics::LikelihoodWrapper;
 
 class Environment : public testing::Environment {
 public:
-   void SetUp() override { RooMsgService::instance().setGlobalKillBelow(RooFit::ERROR); }
+   void SetUp() override
+   {
+      _changeMsgLvl = std::make_unique<RooHelpers::LocalChangeMsgLevel>(RooFit::ERROR);
+   }
+   void TearDown() override
+   {
+      _changeMsgLvl.reset();
+   }
+private:
+   std::unique_ptr<RooHelpers::LocalChangeMsgLevel> _changeMsgLvl;
 };
 
 // Previously, we just called AddGlobalTestEnvironment in global namespace, but this caused either a warning about an

--- a/roofit/roofitcore/test/TestStatistics/testPlot.cpp
+++ b/roofit/roofitcore/test/TestStatistics/testPlot.cpp
@@ -33,9 +33,15 @@ class Environment : public testing::Environment {
 public:
    void SetUp() override
    {
-      RooMsgService::instance().setGlobalKillBelow(RooFit::ERROR);
+      _changeMsgLvl = std::make_unique<RooHelpers::LocalChangeMsgLevel>(RooFit::ERROR);
       ROOT::Math::MinimizerOptions::SetDefaultMinimizer("Minuit2");
    }
+   void TearDown() override
+   {
+      _changeMsgLvl.reset();
+   }
+private:
+   std::unique_ptr<RooHelpers::LocalChangeMsgLevel> _changeMsgLvl;
 };
 
 int main(int argc, char **argv)

--- a/roofit/roofitcore/test/TestStatistics/testRooAbsL.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testRooAbsL.cxx
@@ -37,7 +37,16 @@ using RooFit::TestStatistics::LikelihoodWrapper;
 
 class Environment : public testing::Environment {
 public:
-   void SetUp() override { RooMsgService::instance().setGlobalKillBelow(RooFit::ERROR); }
+   void SetUp() override
+   {
+      _changeMsgLvl = std::make_unique<RooHelpers::LocalChangeMsgLevel>(RooFit::ERROR);
+   }
+   void TearDown() override
+   {
+      _changeMsgLvl.reset();
+   }
+private:
+   std::unique_ptr<RooHelpers::LocalChangeMsgLevel> _changeMsgLvl;
 };
 
 // Previously, we just called AddGlobalTestEnvironment in global namespace, but this caused either a warning about an

--- a/roofit/roofitcore/test/testGlobalObservables.cxx
+++ b/roofit/roofitcore/test/testGlobalObservables.cxx
@@ -4,7 +4,7 @@
 #include <RooAbsPdf.h>
 #include <RooDataSet.h>
 #include <RooFitResult.h>
-#include <RooMsgService.h>
+#include <RooHelpers.h>
 #include <RooRealVar.h>
 #include <RooWorkspace.h>
 
@@ -42,7 +42,7 @@ public:
    void SetUp() override
    {
       // silence log output
-      RooMsgService::instance().setGlobalKillBelow(RooFit::WARNING);
+      RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
 
       // We use the global observable also in the model for the event
       // observables. It's unusual, but let's better do this to also cover the

--- a/roofit/roofitcore/test/testNaNPacker.cxx
+++ b/roofit/roofitcore/test/testNaNPacker.cxx
@@ -3,6 +3,7 @@
 #include "RooNaNPacker.h"
 #include "RooRealVar.h"
 #include "RooGenericPdf.h"
+#include "RooHelpers.h"
 #include "RooMinimizer.h"
 #include "RooFitResult.h"
 #include "RooDataSet.h"
@@ -121,7 +122,7 @@ TEST(RooNaNPacker, FitSimpleLinear) {
 /// The minimiser needs to recover from that.
 /// Test also that when recovery with NaN packing is switched off, the minimiser fails to recover.
 TEST(RooNaNPacker, FitParabola) {
-  RooMsgService::instance().setGlobalKillBelow(RooFit::WARNING); // We don't need integration messages
+  RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING); // We don't need integration messages
 
   RooRealVar x("x", "x", -10, 10);
   RooRealVar a1("a1", "a1", 12., -10., 20.);

--- a/roofit/roofitcore/test/testRooAbsPdf.cxx
+++ b/roofit/roofitcore/test/testRooAbsPdf.cxx
@@ -30,8 +30,7 @@ TEST(RooAbsPdf, AsymptoticallyCorrectErrors)
 {
    using namespace RooFit;
 
-   auto &msg = RooMsgService::instance();
-   msg.setGlobalKillBelow(RooFit::WARNING);
+   RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
 
    RooRealVar x("x", "xxx", 0, 0, 10);
    RooRealVar a("a", "aaa", 2, 0, 10);
@@ -146,8 +145,7 @@ TEST(RooAbsPdf, ConditionalFitBatchMode)
 TEST(RooAbsPdf, MultiRangeFit)
 {
    using namespace RooFit;
-   auto &msg = RooMsgService::instance();
-   msg.setGlobalKillBelow(RooFit::WARNING);
+   RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
 
    RooWorkspace ws;
 
@@ -205,8 +203,7 @@ TEST(RooAbsPdf, MultiRangeFit)
 TEST(RooAbsPdf, MultiRangeFit2D)
 {
    using namespace RooFit;
-   auto &msg = RooMsgService::instance();
-   msg.setGlobalKillBelow(RooFit::WARNING);
+   RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
 
    // model taken from the rf312_multirangefit.C tutorial
    RooWorkspace ws;

--- a/roofit/roofitcore/test/testRooAddPdf.cxx
+++ b/roofit/roofitcore/test/testRooAddPdf.cxx
@@ -28,8 +28,7 @@
 /// is taken from the GitHub issue thread, with the plotting part removed.
 TEST(RooAddPdf, TestSPlot)
 {
-   auto &msg = RooMsgService::instance();
-   msg.setGlobalKillBelow(RooFit::WARNING);
+   RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
 
    double lowRange = 0.;
    double highRange = 200.;
@@ -121,8 +120,7 @@ TEST(RooAddPdf, TestSPlot)
 /// issues of RooAddPdf integrals.
 TEST(RooAddPdf, Issue10988)
 {
-   auto &msg = RooMsgService::instance();
-   msg.setGlobalKillBelow(RooFit::WARNING);
+   RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
 
    using namespace RooFit;
 

--- a/roofit/roofitcore/test/testRooBinSamplingPdf.cxx
+++ b/roofit/roofitcore/test/testRooBinSamplingPdf.cxx
@@ -8,7 +8,7 @@
 #include <RooDataSet.h>
 #include <RooDataHist.h>
 #include <RooRealVar.h>
-#include <RooMsgService.h>
+#include <RooHelpers.h>
 
 #include <gtest/gtest.h>
 
@@ -20,8 +20,7 @@ TEST(RooBinSamplingPdf, LinearPdfCrossCheck)
 {
    using namespace RooFit;
 
-   auto& msg = RooMsgService::instance();
-   msg.setGlobalKillBelow(RooFit::WARNING);
+   RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
 
    RooRandom::randomGenerator()->SetSeed(1337ul);
 
@@ -50,8 +49,7 @@ TEST(RooBinSamplingPdf, LinearPdfSubRangeCrossCheck)
 {
    using namespace RooFit;
 
-   auto& msg = RooMsgService::instance();
-   msg.setGlobalKillBelow(RooFit::WARNING);
+   RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
 
    RooRandom::randomGenerator()->SetSeed(1337ul);
 

--- a/roofit/roofitcore/test/testRooDataSet.cxx
+++ b/roofit/roofitcore/test/testRooDataSet.cxx
@@ -277,8 +277,7 @@ TEST(RooDataSet, CrashAfterImportFromTree)
 // root-project/root#6951: Broken weights after reducing RooDataSet created with RooAbsPdf::generate()
 TEST(RooDataSet, ReduceWithCompositeDataStore)
 {
-   auto &msg = RooMsgService::instance();
-   msg.setGlobalKillBelow(RooFit::WARNING);
+   RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
 
    RooWorkspace ws{};
    ws.factory("Gaussian::gauss(x[-10,10], mean[3,-10,10], sig    ma[1,0.1,10])");

--- a/roofit/roofitcore/test/testRooSimultaneous.cxx
+++ b/roofit/roofitcore/test/testRooSimultaneous.cxx
@@ -7,6 +7,7 @@
 #include <RooDataSet.h>
 #include <RooFitResult.h>
 #include <RooGenericPdf.h>
+#include <RooHelpers.h>
 #include <RooRealVar.h>
 #include <RooSimultaneous.h>
 #include <RooProdPdf.h>
@@ -25,7 +26,7 @@ TEST(RooSimultaneous, SingleChannelCrossCheck)
    using namespace RooFit;
 
    // silence log output
-   RooMsgService::instance().setGlobalKillBelow(RooFit::WARNING);
+   RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
 
    RooWorkspace ws;
    ws.factory("Gaussian::gauss1(x[0, 10], mean[1., 0., 10.], width[1, 0.1, 10])");

--- a/roofit/roofitcore/test/testSumW2Error.cxx
+++ b/roofit/roofitcore/test/testSumW2Error.cxx
@@ -7,6 +7,7 @@
 #include <RooRandom.h>
 #include <RooDataHist.h>
 #include <RooDataSet.h>
+#include <RooHelpers.h>
 #include <RooRealVar.h>
 #include <RooWorkspace.h>
 
@@ -15,54 +16,39 @@
 // GitHub issue 9118: Problem running weighted binned fit in batch mode
 TEST(SumW2Error, BatchMode)
 {
-   auto &msg = RooMsgService::instance();
-   msg.setGlobalKillBelow(RooFit::WARNING);
+   RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
 
    RooWorkspace ws{"workspace"};
    ws.factory("Gaussian::sig(x[0,0,10],mu[3,0,10],s[1, 0.1, 5])");
    ws.factory("Exponential::bkg(x,c1[-0.5, -3, -0.1])");
    ws.factory("SUM::model(f[0.2, 0.0, 1.0] * sig, bkg)");
 
-   auto &x = *ws.var("x");
-   auto &mu = *ws.var("mu");
-   auto &s = *ws.var("s");
-   auto &c1 = *ws.var("c1");
-   auto &f = *ws.var("f");
-
    auto &model = *ws.pdf("model");
 
-   auto resetParametersToInitialFitValues = [&]() {
-      mu.setVal(4.0);
-      mu.setError(0.0);
-      s.setVal(2.0);
-      s.setError(0.0);
-      c1.setVal(-0.4);
-      c1.setError(0.0);
-      f.setVal(0.3);
-      f.setError(0.0);
-   };
-
-   std::size_t nEvents = 1000;
-
    RooRandom::randomGenerator()->SetSeed(4357);
-   std::unique_ptr<RooAbsData> dataHist{model.generateBinned(x, nEvents)};
-   std::unique_ptr<RooAbsData> dataSet{model.generate(x, nEvents)};
+   std::unique_ptr<RooDataSet> dataSet{model.generate(*ws.var("x"), 1000)};
+
+   RooArgSet params;
+   RooArgSet initialParams;
+
+   model.getParameters(dataSet->get(), params);
+   params.snapshot(initialParams);
 
    // these datasets will be filled with a weight that is not unity
    RooRealVar weight("weight", "weight", 0.5, 0.0, 1.0);
-   RooDataHist dataHistWeighted("dataHistWeighted", "dataHistWeighted", x);
-   RooDataSet dataSetWeighted("dataSetWeighted", "dataSetWeighted", {x, weight}, "weight");
+   RooDataSet dataSetWeighted("dataSetWeighted", "dataSetWeighted", {*dataSet->get(), weight}, "weight");
 
-   for (std::size_t i = 0; i < nEvents; ++i) {
-      dataHistWeighted.add(*dataSet->get(), 0.5); // filling the histogram from a dataset is easier
-      dataSetWeighted.add(*dataSet->get(), 0.5);
+   for (int i = 0; i < dataSet->numEntries(); ++i) {
+      dataSetWeighted.add(*dataSet->get(i), 0.5);
    }
 
+   std::unique_ptr<RooDataHist> dataHist{dataSet->binnedClone()};
+   std::unique_ptr<RooDataHist> dataHistWeighted{dataSetWeighted.binnedClone()};
+
    auto fit = [&](RooAbsData &data, bool sumw2, bool batchmode, std::string const &minimizer, int printLevel = -1) {
+      params.assign(initialParams);
+
       using namespace RooFit;
-
-      resetParametersToInitialFitValues();
-
       return std::unique_ptr<RooFitResult>{model.fitTo(data, Save(), SumW2Error(sumw2), Strategy(1),
                                                        BatchMode(batchmode), Minimizer(minimizer.c_str()),
                                                        PrintLevel(printLevel))};
@@ -96,16 +82,18 @@ TEST(SumW2Error, BatchMode)
    // Compare batch mode vs. scalar mode for SumW2 fits on WEIGHTED datasets
    EXPECT_TRUE(fit(dataSetWeighted, 1, 0, "Minuit")->isIdenticalNoCov(*fit(dataSetWeighted, 1, 1, "Minuit")))
       << " different results for Minuit fit to weighted RooDataSet with SumW2Error correction.";
-   EXPECT_TRUE(fit(dataHistWeighted, 1, 0, "Minuit")->isIdenticalNoCov(*fit(dataHistWeighted, 1, 1, "Minuit")))
+   EXPECT_TRUE(fit(*dataHistWeighted, 1, 0, "Minuit")->isIdenticalNoCov(*fit(*dataHistWeighted, 1, 1, "Minuit")))
       << " different results for Minuit fit to weighted RooDataHist with SumW2Error correction.";
    EXPECT_TRUE(fit(dataSetWeighted, 1, 0, "Minuit2")->isIdenticalNoCov(*fit(dataSetWeighted, 1, 1, "Minuit2")))
       << " different results for Minuit2 fit to weighted RooDataSet with SumW2Error correction.";
-   EXPECT_TRUE(fit(dataHistWeighted, 1, 0, "Minuit2")->isIdenticalNoCov(*fit(dataHistWeighted, 1, 1, "Minuit2")))
+   EXPECT_TRUE(fit(*dataHistWeighted, 1, 0, "Minuit2")->isIdenticalNoCov(*fit(*dataHistWeighted, 1, 1, "Minuit2")))
       << " different results for Minuit2 fit to weighted RooDataHist with SumW2Error correction.";
 }
 
 TEST(SumW2Error, ExtendedFit)
 {
+   RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
+
    using namespace RooFit;
 
    RooWorkspace ws("workspace");
@@ -138,20 +126,14 @@ TEST(SumW2Error, ExtendedFit)
                    w->GetName()};
    RooDataHist datahist{"datahist", "datahist", *data.get(), data};
 
-   std::vector<std::pair<std::string, double>> inVals;
-   for (auto const *v : ws.allVars()) {
-      inVals.emplace_back(v->GetName(), static_cast<RooRealVar const *>(v)->getVal());
-   }
+   RooArgSet params;
+   RooArgSet initialParams;
 
-   auto resetVals = [&]() {
-      for (auto const &item : inVals) {
-         ws.var(item.first)->setError(0.0);
-         ws.var(item.first)->setVal(item.second);
-      }
-   };
+   shp->getParameters(dataNoWeights->get(), params);
+   params.snapshot(initialParams);
 
    auto doFit = [&](bool batchMode, bool sumW2Error, const char *range) {
-      resetVals();
+      params.assign(initialParams);
       return std::unique_ptr<RooFitResult>{shp->fitTo(datahist, Extended(), Range(range), Save(),
                                                       SumW2Error(sumW2Error), Strategy(1), PrintLevel(-1),
                                                       BatchMode(batchMode), Minimizer("Minuit2", "migrad"))};


### PR DESCRIPTION
In `testSumW2Error`, a weighted clone of an unweighted dataset is
created, where each event gets the weight `0.5`.

However, in the loop over the original dataset used to fill the new
dataset, `get(i)` is never called, meaning the new weighted dataset is
only filled with the same values. This resulted in an unstable fit,
necessitating careful tweaking of the initial parameters to even get
convergence. That's why it's better to copy the dataset correctly, even
if this is just the test case. I noticed this problem when I was
copy-pasting code to create another new unit test.

Also, the binned dataset is now a binned clone of the unbinned dataset
in the test, reducing the degree of randomness.

Furthermore, some general code improvements are applied to the source
file.