### PR TITLE
Fix: moved std::__ROOT::span to non-inlined namespace std::__ROOT_NI.

### DIFF
--- a/core/foundation/inc/ROOT/span.hxx
+++ b/core/foundation/inc/ROOT/span.hxx
@@ -21,6 +21,18 @@
 #define R__CONSTEXPR_IF_CXX14
 #endif
 
+
+#ifndef R__INLINE_CXX20
+#if __cplusplus>=202002L
+#define R__INLINE_CXX20
+#include <span>
+#else
+// std::span should not be defined, so we inline std::ROOT_CXX20
+// which contains a span implementation
+#define R__INLINE_CXX20 inline
+#endif
+#endif
+
 // From https://github.com/rhysd/array_view/blob/master/include/array_view.hpp
 
 #include <cstddef>
@@ -144,7 +156,8 @@ using make_indices = typename make_indices_< Start, Last, Step >::type;
 
 namespace std {
 
-inline namespace __ROOT {
+R__INLINE_CXX20
+namespace __ROOT_CXX20 {
 
 // span {{{
 
@@ -465,7 +478,9 @@ bool operator_equal_impl(ArrayL const& lhs, size_t const lhs_size, ArrayR const&
 } // namespace ROOT
 
 namespace std {
-inline namespace __ROOT {
+
+R__INLINE_CXX20
+namespace __ROOT_CXX20 {
 
 template<class T1, class T2>
 inline constexpr


### PR DESCRIPTION
## Checklist:

- [X] tested changes locally
- ~[ ] updated the docs (if necessary)~

Dear ROOT maintainers,
While the ROOT version shipped with FairSoft (v6-26-10) seems not to compile with C++20 yet, the ROOT libraries (compiled with C++17) can be linked against C++20 code. 

But while trying to do that, I noticed that my compiler got confused because it had multiple definitions of ``std::span``:
One in [span.hxx](https://github.com/root-project/root/blob/master/core/foundation/inc/ROOT/span.hxx#L147)
```
namespace std {
inline namespace __ROOT {
template<class T>
class span { ... };
}}
```
and one provided in a header by g++ or libstdc++. 

I feel that unless one is developing a libstdc++, there are few valid cases of declaring stuff in the std namespace. (Exceptions include overloading operators for iostream with custom classes.) The point of having namespaces in the first place is to avoid such collisions!

The following actions would resolve my complaint:
* Merging this PR or something similar and replacing std::span with std::__ROOT_NI::span (or perhaps ROOT::span?) 
* Removing span.hxx from the API, using it only internally during ROOT compilation.
* Requiring C++20 and using the std::span which comes with the users libstdc++
* Shipping your own libstdc++, thus taking responsibility for the whole std namespace. 

Cheers,
   Philipp