### PR TITLE
[ntuple] Add support for stored field projections

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -270,7 +270,6 @@ The flags field can have one of the following bits set
 | Bit      | Meaning                                                                    |
 |----------|----------------------------------------------------------------------------|
 | 0x01     | Repetitive field, i.e. for every entry $n$ copies of the field are stored  |
-| 0x02     | Alias field, the columns referring to this field are alias columns         |
 
 The structural role of the field can have on of the following values
 
@@ -356,7 +355,7 @@ An alias column has the following format
 ```
 
 The first 32bit integer references the physical column ID.
-The second 32bit integer references a field that needs to have the "alias field" flag set.
+The second 32bit integer references the associated "projected" field.
 The ID of the alias column itself is given implicitly by the serialization order.
 In particular, alias columns have larger IDs than physical columns.
 In the footer and page list envelopes, only physical column IDs must be referenced.

--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -353,7 +353,7 @@ An alias column has the following format
 |                           Field ID                            |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ```
-
+Alias columns do not have associated data pages.  Instead, their data comes from another column referred to below as "physical column".
 The first 32bit integer references the physical column ID.
 The second 32bit integer references the associated "projected" field.
 The ID of the alias column itself is given implicitly by the serialization order.

--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -356,6 +356,7 @@ An alias column has the following format
 Alias columns do not have associated data pages.  Instead, their data comes from another column referred to below as "physical column".
 The first 32bit integer references the physical column ID.
 The second 32bit integer references the associated "projected" field.
+A projected field is a field using alias columns to present available data by an alternative C++ type.
 The ID of the alias column itself is given implicitly by the serialization order.
 In particular, alias columns have larger IDs than physical columns.
 In the footer and page list envelopes, only physical column IDs must be referenced.

--- a/tree/ntuple/v7/inc/ROOT/RCluster.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RCluster.hxx
@@ -158,7 +158,7 @@ public:
    /// The identifiers that specifies the content of a (partial) cluster
    struct RKey {
       DescriptorId_t fClusterId = kInvalidDescriptorId;
-      ColumnSet_t fColumnSet;
+      ColumnSet_t fPhysicalColumnSet;
    };
 
 protected:

--- a/tree/ntuple/v7/inc/ROOT/RCluster.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RCluster.hxx
@@ -167,7 +167,7 @@ protected:
    /// Multiple page maps can be combined in a single RCluster
    std::vector<std::unique_ptr<ROnDiskPageMap>> fPageMaps;
    /// Set of the (complete) columns represented by the RCluster
-   ColumnSet_t fAvailColumns;
+   ColumnSet_t fAvailPhysicalColumns;
    /// Lookup table for the on-disk pages
    std::unordered_map<ROnDiskPage::Key, ROnDiskPage> fOnDiskPages;
 
@@ -192,12 +192,12 @@ public:
    /// Marks the column as complete; must be done for all columns, even empty ones without associated pages,
    /// before the cluster is given from the page storage to the cluster pool.  Marking the available columns is
    /// typically the last step of RPageSouce::LoadCluster().
-   void SetColumnAvailable(DescriptorId_t columnId);
+   void SetColumnAvailable(DescriptorId_t physicalColumnId);
    const ROnDiskPage *GetOnDiskPage(const ROnDiskPage::Key &key) const;
 
    DescriptorId_t GetId() const { return fClusterId; }
-   const ColumnSet_t &GetAvailColumns() const { return fAvailColumns; }
-   bool ContainsColumn(DescriptorId_t columnId) const { return fAvailColumns.count(columnId) > 0; }
+   const ColumnSet_t &GetAvailPhysicalColumns() const { return fAvailPhysicalColumns; }
+   bool ContainsColumn(DescriptorId_t colId) const { return fAvailPhysicalColumns.count(colId) > 0; }
    size_t GetNOnDiskPages() const { return fOnDiskPages.size(); }
 };
 

--- a/tree/ntuple/v7/inc/ROOT/RCluster.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RCluster.hxx
@@ -51,11 +51,11 @@ public:
    /// On-disk pages within a page source are identified by the column and page number. The key is used for
    /// associative collections of on-disk pages.
    struct Key {
-      DescriptorId_t fColumnId;
+      DescriptorId_t fPhysicalColumnId;
       std::uint64_t fPageNo;
-      Key(DescriptorId_t columnId, std::uint64_t pageNo) : fColumnId(columnId), fPageNo(pageNo) {}
+      Key(DescriptorId_t columnId, std::uint64_t pageNo) : fPhysicalColumnId(columnId), fPageNo(pageNo) {}
       friend bool operator ==(const Key &lhs, const Key &rhs) {
-         return lhs.fColumnId == rhs.fColumnId && lhs.fPageNo == rhs.fPageNo;
+         return lhs.fPhysicalColumnId == rhs.fPhysicalColumnId && lhs.fPageNo == rhs.fPageNo;
       }
    };
 
@@ -81,8 +81,9 @@ namespace std
       // TODO(jblomer): quick and dirty hash, likely very sub-optimal, to be revised later.
       size_t operator()(const ROOT::Experimental::Detail::ROnDiskPage::Key &key) const
       {
-         return ((std::hash<ROOT::Experimental::DescriptorId_t>()(key.fColumnId) ^
-                 (hash<ROOT::Experimental::NTupleSize_t>()(key.fPageNo) << 1)) >> 1);
+         return ((std::hash<ROOT::Experimental::DescriptorId_t>()(key.fPhysicalColumnId) ^
+                  (hash<ROOT::Experimental::NTupleSize_t>()(key.fPageNo) << 1)) >>
+                 1);
       }
    };
 }

--- a/tree/ntuple/v7/inc/ROOT/RClusterPool.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RClusterPool.hxx
@@ -136,10 +136,10 @@ private:
    /// The unzip thread routine which takes a loaded cluster and passes it to fPageSource.UnzipCluster (which
    /// might be a no-op if IMT is off). Marks the cluster as ready to be picked up by the main thread.
    void ExecUnzipClusters();
-   /// Returns the given cluster from the pool, which needs to contain at least the columns `columns`.
+   /// Returns the given cluster from the pool, which needs to contain at least the columns `physicalColumns`.
    /// Executed at the end of GetCluster when all missing data pieces have been sent to the load queue.
    /// Ideally, the function returns without blocking if the cluster is already in the pool.
-   RCluster *WaitFor(DescriptorId_t clusterId, const RCluster::ColumnSet_t &columns);
+   RCluster *WaitFor(DescriptorId_t clusterId, const RCluster::ColumnSet_t &physicalColumns);
 
 public:
    static constexpr unsigned int kDefaultClusterBunchSize = 1;
@@ -151,11 +151,11 @@ public:
 
    /// Returns the requested cluster either from the pool or, in case of a cache miss, lets the I/O thread load
    /// the cluster in the pool, blocks until done, and then returns it.  Triggers along the way the background loading
-   /// of the following fWindowPost number of clusters.  The returned cluster has at least all the pages of `columns`
-   /// and possibly pages of other columns, too.  If implicit multi-threading is turned on, the uncompressed pages
-   /// of the returned cluster are already pushed into the page pool associated with the page source upon return.
-   /// The cluster remains valid until the next call to GetCluster().
-   RCluster *GetCluster(DescriptorId_t clusterId, const RCluster::ColumnSet_t &columns);
+   /// of the following fWindowPost number of clusters.  The returned cluster has at least all the pages of
+   /// `physicalColumns` and possibly pages of other columns, too.  If implicit multi-threading is turned on, the
+   /// uncompressed pages of the returned cluster are already pushed into the page pool associated with the page source
+   /// upon return. The cluster remains valid until the next call to GetCluster().
+   RCluster *GetCluster(DescriptorId_t clusterId, const RCluster::ColumnSet_t &physicalColumns);
 
    /// Used by the unit tests to drain the queue of clusters to be preloaded
    void WaitForInFlightClusters();

--- a/tree/ntuple/v7/inc/ROOT/RClusterPool.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RClusterPool.hxx
@@ -81,7 +81,8 @@ private:
 
       bool operator ==(const RInFlightCluster &other) const {
          return (fClusterKey.fClusterId == other.fClusterKey.fClusterId) &&
-                (fClusterKey.fColumnSet == other.fClusterKey.fColumnSet); }
+                (fClusterKey.fPhysicalColumnSet == other.fClusterKey.fPhysicalColumnSet);
+      }
       bool operator !=(const RInFlightCluster &other) const { return !(*this == other); }
       /// First order by cluster id, then by number of columns, than by the column ids in fColumns
       bool operator <(const RInFlightCluster &other) const;

--- a/tree/ntuple/v7/inc/ROOT/RColumnModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnModel.hxx
@@ -75,6 +75,7 @@ public:
    bool operator ==(const RColumnModel &other) const {
       return (fType == other.fType) && (fIsSorted == other.fIsSorted);
    }
+   bool operator!=(const RColumnModel &other) const { return !(other == *this); }
 };
 
 } // namespace Experimental

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -283,6 +283,8 @@ public:
    void Attach(std::unique_ptr<Detail::RFieldBase> child);
 
    std::string GetName() const { return fName; }
+   /// Returns the field name and parent field names separated by dots ("grandparent.parent.child")
+   std::string GetQualifiedFieldName() const;
    std::string GetType() const { return fType; }
    ENTupleStructure GetStructure() const { return fStructure; }
    std::size_t GetNRepetitions() const { return fNRepetitions; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -165,7 +165,7 @@ class RColumnGroupDescriptor {
 
 private:
    DescriptorId_t fColumnGroupId = kInvalidDescriptorId;
-   std::unordered_set<DescriptorId_t> fColumnIds;
+   std::unordered_set<DescriptorId_t> fPhysicalColumnIds;
 
 public:
    RColumnGroupDescriptor() = default;
@@ -177,9 +177,12 @@ public:
    bool operator==(const RColumnGroupDescriptor &other) const;
 
    DescriptorId_t GetId() const { return fColumnGroupId; }
-   const std::unordered_set<DescriptorId_t> &GetColumnIds() const { return fColumnIds; }
-   bool Contains(DescriptorId_t columnId) const { return fColumnIds.empty() || fColumnIds.count(columnId) > 0; }
-   bool HasAllColumns() const { return fColumnIds.empty(); }
+   const std::unordered_set<DescriptorId_t> &GetPhysicalColumnIds() const { return fPhysicalColumnIds; }
+   bool Contains(DescriptorId_t physicalId) const
+   {
+      return fPhysicalColumnIds.empty() || fPhysicalColumnIds.count(physicalId) > 0;
+   }
+   bool HasAllColumns() const { return fPhysicalColumnIds.empty(); }
 };
 
 // clang-format off
@@ -940,7 +943,7 @@ public:
       fColumnGroup.fColumnGroupId = columnGroupId;
       return *this;
    }
-   void AddColumn(DescriptorId_t columnId) { fColumnGroup.fColumnIds.insert(columnId); }
+   void AddColumn(DescriptorId_t physicalId) { fColumnGroup.fPhysicalColumnIds.insert(physicalId); }
 
    RResult<RColumnGroupDescriptor> MoveDescriptor();
 };

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -704,7 +704,7 @@ public:
 
    /// We know the number of entries from adding the cluster summaries
    NTupleSize_t GetNEntries() const { return fNEntries; }
-   NTupleSize_t GetNElements(DescriptorId_t columnId) const;
+   NTupleSize_t GetNElements(DescriptorId_t physicalColumnId) const;
 
    /// Returns the logical parent of all top-level NTuple data fields.
    DescriptorId_t GetFieldZeroId() const;
@@ -714,7 +714,7 @@ public:
    DescriptorId_t FindFieldId(std::string_view fieldName) const;
    DescriptorId_t FindLogicalColumnId(DescriptorId_t fieldId, std::uint32_t columnIndex) const;
    DescriptorId_t FindPhysicalColumnId(DescriptorId_t fieldId, std::uint32_t columnIndex) const;
-   DescriptorId_t FindClusterId(DescriptorId_t columnId, NTupleSize_t index) const;
+   DescriptorId_t FindClusterId(DescriptorId_t physicalColumnId, NTupleSize_t index) const;
    DescriptorId_t FindNextClusterId(DescriptorId_t clusterId) const;
    DescriptorId_t FindPrevClusterId(DescriptorId_t clusterId) const;
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -402,6 +402,7 @@ private:
    std::uint64_t fOnDiskFooterSize = 0; ///< Like fOnDiskHeaderSize, contains both cluster summaries and page locations
 
    std::uint64_t fNEntries = 0; ///< Updated by the descriptor builder when the cluster summaries are added
+   std::uint64_t fNPhysicalColumns = 0; ///< Updated by the descriptor builder when columns are added
 
    /**
     * Once constructed by an RNTupleDescriptorBuilder, the descriptor is mostly immutable except for set of
@@ -696,7 +697,8 @@ public:
    std::string GetDescription() const { return fDescription; }
 
    std::size_t GetNFields() const { return fFieldDescriptors.size(); }
-   std::size_t GetNColumns() const { return fColumnDescriptors.size(); }
+   std::size_t GetNLogicalColumns() const { return fColumnDescriptors.size(); }
+   std::size_t GetNPhysicalColumns() const { return fNPhysicalColumns; }
    std::size_t GetNClusterGroups() const { return fClusterGroupDescriptors.size(); }
    std::size_t GetNClusters() const { return fClusterDescriptors.size(); }
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -204,7 +204,7 @@ class RClusterDescriptor {
 public:
    /// The window of element indexes of a particular column in a particular cluster
    struct RColumnRange {
-      DescriptorId_t fColumnId = kInvalidDescriptorId;
+      DescriptorId_t fPhysicalColumnId = kInvalidDescriptorId;
       /// A 64bit element index
       NTupleSize_t fFirstElementIndex = kInvalidNTupleIndex;
       /// A 32bit value for the number of column elements in the cluster
@@ -217,7 +217,7 @@ public:
       // Should this be done on the field level?
 
       bool operator==(const RColumnRange &other) const {
-         return fColumnId == other.fColumnId && fFirstElementIndex == other.fFirstElementIndex &&
+         return fPhysicalColumnId == other.fPhysicalColumnId && fFirstElementIndex == other.fFirstElementIndex &&
                 fNElements == other.fNElements && fCompressionSettings == other.fCompressionSettings;
       }
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -259,7 +259,7 @@ public:
 
       RPageRange Clone() const {
          RPageRange clone;
-         clone.fColumnId = fColumnId;
+         clone.fPhysicalColumnId = fPhysicalColumnId;
          clone.fPageInfos = fPageInfos;
          return clone;
       }
@@ -267,11 +267,11 @@ public:
       /// Find the page in the RPageRange that contains the given element. The element must exist.
       RPageInfoExtended Find(RClusterSize::ValueType idxInCluster) const;
 
-      DescriptorId_t fColumnId = kInvalidDescriptorId;
+      DescriptorId_t fPhysicalColumnId = kInvalidDescriptorId;
       std::vector<RPageInfo> fPageInfos;
 
       bool operator==(const RPageRange &other) const {
-         return fColumnId == other.fColumnId && fPageInfos == other.fPageInfos;
+         return fPhysicalColumnId == other.fPhysicalColumnId && fPageInfos == other.fPageInfos;
       }
    };
 
@@ -307,17 +307,17 @@ public:
    DescriptorId_t GetId() const { return fClusterId; }
    NTupleSize_t GetFirstEntryIndex() const { return fFirstEntryIndex; }
    ClusterSize_t GetNEntries() const { return fNEntries; }
-   const RColumnRange &GetColumnRange(DescriptorId_t columnId) const
+   const RColumnRange &GetColumnRange(DescriptorId_t physicalId) const
    {
       EnsureHasPageLocations();
-      return fColumnRanges.at(columnId);
+      return fColumnRanges.at(physicalId);
    }
-   const RPageRange &GetPageRange(DescriptorId_t columnId) const
+   const RPageRange &GetPageRange(DescriptorId_t physicalId) const
    {
       EnsureHasPageLocations();
-      return fPageRanges.at(columnId);
+      return fPageRanges.at(physicalId);
    }
-   bool ContainsColumn(DescriptorId_t columnId) const;
+   bool ContainsColumn(DescriptorId_t physicalId) const;
    std::unordered_set<DescriptorId_t> GetColumnIds() const;
    std::uint64_t GetBytesOnStorage() const;
    bool HasPageLocations() const { return fHasPageLocations; }
@@ -877,7 +877,7 @@ public:
    {
    }
 
-   RResult<void> CommitColumnRange(DescriptorId_t columnId, std::uint64_t firstElementIndex,
+   RResult<void> CommitColumnRange(DescriptorId_t physicalId, std::uint64_t firstElementIndex,
                                    std::uint32_t compressionSettings, const RClusterDescriptor::RPageRange &pageRange);
 
    /// Move out the full cluster descriptor including page locations

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -982,7 +982,8 @@ public:
    void AddField(const RFieldDescriptor& fieldDesc);
    RResult<void> AddFieldLink(DescriptorId_t fieldId, DescriptorId_t linkId);
 
-   void AddColumn(DescriptorId_t columnId, DescriptorId_t fieldId, const RColumnModel &model, std::uint32_t index);
+   void AddColumn(DescriptorId_t logicalId, DescriptorId_t physicalId, DescriptorId_t fieldId,
+                  const RColumnModel &model, std::uint32_t index);
    RResult<void> AddColumn(RColumnDescriptor &&columnDesc);
 
    RResult<void> AddClusterSummary(DescriptorId_t clusterId, std::uint64_t firstEntry, std::uint64_t nEntries);

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -17,13 +17,16 @@
 #define ROOT7_RNTupleModel
 
 #include <ROOT/REntry.hxx>
+#include <ROOT/RError.hxx>
 #include <ROOT/RField.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 #include <ROOT/RFieldValue.hxx>
 #include <ROOT/RStringView.hxx>
 
 #include <cstdint>
+#include <functional>
 #include <memory>
+#include <string>
 #include <unordered_set>
 #include <utility>
 
@@ -66,9 +69,13 @@ class RNTupleModel {
    /// Throws an RException if fDefaultEntry is nullptr
    void EnsureNotBare() const;
 
+   void EnsureValidFieldMapping(const Detail::RFieldBase &target, const std::string &source) const;
+
    RNTupleModel();
 
 public:
+   using FieldMapper_t = std::function<std::string(const Detail::RFieldBase &)>;
+
    RNTupleModel(const RNTupleModel&) = delete;
    RNTupleModel& operator =(const RNTupleModel&) = delete;
    ~RNTupleModel() = default;
@@ -169,6 +176,8 @@ public:
       fDefaultEntry->CaptureValue(field->CaptureValue(fromWhere));
       fFieldZero->Attach(std::move(field));
    }
+
+   RResult<void> AddProjectedField(std::unique_ptr<Detail::RFieldBase> field, FieldMapper_t mapping);
 
    template <typename T>
    T *Get(std::string_view fieldName) const

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -53,7 +53,7 @@ public:
    /// to the models zero field.  Only the real source fields are written to, projected fields are stored as meta-data
    /// (header) information only.  Only top-level projected fields are supported because otherwise the layout of types
    /// could be altered in unexpected ways.
-   /// All projected fields the the source fields used to back them are kept in this class.
+   /// All projected fields and the source fields used to back them are kept in this class.
    class RProjectedFields {
    public:
       /// The map keys are the projected target fields, the map values are the backing source fields

--- a/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
@@ -85,20 +85,20 @@ public:
    };
 
    /// The serialization context is used for the piecewise serialization of a descriptor.  During header serialization,
-   /// the mapping of in-memory field and column IDs to physical IDs is built so that it can be used for the
+   /// the mapping of in-memory field and column IDs to on-disk IDs is built so that it can be used for the
    /// footer serialization in a second step.
    class RContext {
    private:
       std::uint32_t fHeaderSize = 0;
       std::uint32_t fHeaderCrc32 = 0;
-      std::map<DescriptorId_t, DescriptorId_t> fMem2PhysFieldIDs;
-      std::map<DescriptorId_t, DescriptorId_t> fMem2PhysColumnIDs;
-      std::map<DescriptorId_t, DescriptorId_t> fMem2PhysClusterIDs;
-      std::map<DescriptorId_t, DescriptorId_t> fMem2PhysClusterGroupIDs;
-      std::vector<DescriptorId_t> fPhys2MemFieldIDs;
-      std::vector<DescriptorId_t> fPhys2MemColumnIDs;
-      std::vector<DescriptorId_t> fPhys2MemClusterIDs;
-      std::vector<DescriptorId_t> fPhys2MemClusterGroupIDs;
+      std::map<DescriptorId_t, DescriptorId_t> fMem2OnDiskFieldIDs;
+      std::map<DescriptorId_t, DescriptorId_t> fMem2OnDiskColumnIDs;
+      std::map<DescriptorId_t, DescriptorId_t> fMem2OnDiskClusterIDs;
+      std::map<DescriptorId_t, DescriptorId_t> fMem2OnDiskClusterGroupIDs;
+      std::vector<DescriptorId_t> fOnDisk2MemFieldIDs;
+      std::vector<DescriptorId_t> fOnDisk2MemColumnIDs;
+      std::vector<DescriptorId_t> fOnDisk2MemClusterIDs;
+      std::vector<DescriptorId_t> fOnDisk2MemClusterGroupIDs;
 
    public:
       void SetHeaderSize(std::uint32_t size) { fHeaderSize = size; }
@@ -106,38 +106,44 @@ public:
       void SetHeaderCRC32(std::uint32_t crc32) { fHeaderCrc32 = crc32; }
       std::uint32_t GetHeaderCRC32() const { return fHeaderCrc32; }
       DescriptorId_t MapFieldId(DescriptorId_t memId) {
-         auto physId = fPhys2MemFieldIDs.size();
-         fMem2PhysFieldIDs[memId] = physId;
-         fPhys2MemFieldIDs.push_back(memId);
-         return physId;
+         auto onDiskId = fOnDisk2MemFieldIDs.size();
+         fMem2OnDiskFieldIDs[memId] = onDiskId;
+         fOnDisk2MemFieldIDs.push_back(memId);
+         return onDiskId;
       }
       DescriptorId_t MapColumnId(DescriptorId_t memId) {
-         auto physId = fPhys2MemColumnIDs.size();
-         fMem2PhysColumnIDs[memId] = physId;
-         fPhys2MemColumnIDs.push_back(memId);
-         return physId;
+         auto onDiskId = fOnDisk2MemColumnIDs.size();
+         fMem2OnDiskColumnIDs[memId] = onDiskId;
+         fOnDisk2MemColumnIDs.push_back(memId);
+         return onDiskId;
       }
       DescriptorId_t MapClusterId(DescriptorId_t memId) {
-         auto physId = fPhys2MemClusterIDs.size();
-         fMem2PhysClusterIDs[memId] = physId;
-         fPhys2MemClusterIDs.push_back(memId);
-         return physId;
+         auto onDiskId = fOnDisk2MemClusterIDs.size();
+         fMem2OnDiskClusterIDs[memId] = onDiskId;
+         fOnDisk2MemClusterIDs.push_back(memId);
+         return onDiskId;
       }
       DescriptorId_t MapClusterGroupId(DescriptorId_t memId)
       {
-         auto physId = fPhys2MemClusterGroupIDs.size();
-         fMem2PhysClusterGroupIDs[memId] = physId;
-         fPhys2MemClusterGroupIDs.push_back(memId);
-         return physId;
+         auto onDiskId = fOnDisk2MemClusterGroupIDs.size();
+         fMem2OnDiskClusterGroupIDs[memId] = onDiskId;
+         fOnDisk2MemClusterGroupIDs.push_back(memId);
+         return onDiskId;
       }
-      DescriptorId_t GetPhysFieldId(DescriptorId_t memId) const { return fMem2PhysFieldIDs.at(memId); }
-      DescriptorId_t GetPhysColumnId(DescriptorId_t memId) const { return fMem2PhysColumnIDs.at(memId); }
-      DescriptorId_t GetPhysClusterId(DescriptorId_t memId) const { return fMem2PhysClusterIDs.at(memId); }
-      DescriptorId_t GetPhysClusterGroupId(DescriptorId_t memId) const { return fMem2PhysClusterGroupIDs.at(memId); }
-      DescriptorId_t GetMemFieldId(DescriptorId_t physId) const { return fPhys2MemFieldIDs[physId]; }
-      DescriptorId_t GetMemColumnId(DescriptorId_t physId) const { return fPhys2MemColumnIDs[physId]; }
-      DescriptorId_t GetMemClusterId(DescriptorId_t physId) const { return fPhys2MemClusterIDs[physId]; }
-      DescriptorId_t GetMemClusterGroupId(DescriptorId_t physId) const { return fPhys2MemClusterGroupIDs[physId]; }
+      DescriptorId_t GetOnDiskFieldId(DescriptorId_t memId) const { return fMem2OnDiskFieldIDs.at(memId); }
+      DescriptorId_t GetOnDiskColumnId(DescriptorId_t memId) const { return fMem2OnDiskColumnIDs.at(memId); }
+      DescriptorId_t GetOnDiskClusterId(DescriptorId_t memId) const { return fMem2OnDiskClusterIDs.at(memId); }
+      DescriptorId_t GetOnDiskClusterGroupId(DescriptorId_t memId) const
+      {
+         return fMem2OnDiskClusterGroupIDs.at(memId);
+      }
+      DescriptorId_t GetMemFieldId(DescriptorId_t onDiskId) const { return fOnDisk2MemFieldIDs[onDiskId]; }
+      DescriptorId_t GetMemColumnId(DescriptorId_t onDiskId) const { return fOnDisk2MemColumnIDs[onDiskId]; }
+      DescriptorId_t GetMemClusterId(DescriptorId_t onDiskId) const { return fOnDisk2MemClusterIDs[onDiskId]; }
+      DescriptorId_t GetMemClusterGroupId(DescriptorId_t onDiskId) const
+      {
+         return fOnDisk2MemClusterGroupIDs[onDiskId];
+      }
    };
 
    /// Writes a CRC32 checksum of the byte range given by data and length.

--- a/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
@@ -59,7 +59,6 @@ public:
    static constexpr std::uint32_t kReleaseCandidateTag    = 1;
 
    static constexpr std::uint16_t kFlagRepetitiveField = 0x01;
-   static constexpr std::uint16_t kFlagAliasField      = 0x02;
 
    static constexpr std::uint32_t kFlagSortAscColumn     = 0x01;
    static constexpr std::uint32_t kFlagSortDesColumn     = 0x02;

--- a/tree/ntuple/v7/inc/ROOT/RPage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPage.hxx
@@ -57,7 +57,7 @@ public:
    };
 
 private:
-   ColumnId_t fColumnId;
+   ColumnId_t fPhysicalColumnId;
    void *fBuffer;
    ClusterSize_t::ValueType fElementSize;
    ClusterSize_t::ValueType fNElements;
@@ -68,15 +68,18 @@ private:
 
 public:
    RPage()
-      : fColumnId(kInvalidColumnId), fBuffer(nullptr), fElementSize(0), fNElements(0), fMaxElements(0), fRangeFirst(0)
-   {}
-   RPage(ColumnId_t columnId, void* buffer, ClusterSize_t::ValueType elementSize, ClusterSize_t::ValueType maxElements)
-      : fColumnId(columnId), fBuffer(buffer), fElementSize(elementSize), fNElements(0), fMaxElements(maxElements),
+      : fPhysicalColumnId(kInvalidColumnId), fBuffer(nullptr), fElementSize(0), fNElements(0), fMaxElements(0),
         fRangeFirst(0)
+   {
+   }
+   RPage(ColumnId_t physicalColumnId, void *buffer, ClusterSize_t::ValueType elementSize,
+         ClusterSize_t::ValueType maxElements)
+      : fPhysicalColumnId(physicalColumnId), fBuffer(buffer), fElementSize(elementSize), fNElements(0),
+        fMaxElements(maxElements), fRangeFirst(0)
    {}
    ~RPage() = default;
 
-   ColumnId_t GetColumnId() const { return fColumnId; }
+   ColumnId_t GetPhysicalColumnId() const { return fPhysicalColumnId; }
    /// The space taken by column elements in the buffer
    ClusterSize_t::ValueType GetNBytes() const { return fElementSize * fNElements; }
    ClusterSize_t::ValueType GetElementSize() const { return fElementSize; }
@@ -121,9 +124,9 @@ public:
    void ResetCluster(const RClusterInfo &clusterInfo) { fNElements = 0; fClusterInfo = clusterInfo; }
 
    /// Used by virtual page sources to map the physical column and cluster IDs to ther virtual counterparts
-   void ChangeIds(DescriptorId_t columnId, DescriptorId_t clusterId)
+   void ChangeIds(DescriptorId_t physicalColumnId, DescriptorId_t clusterId)
    {
-      fColumnId = columnId;
+      fPhysicalColumnId = physicalColumnId;
       fClusterInfo = RClusterInfo(clusterId, fClusterInfo.GetIndexOffset());
    }
 

--- a/tree/ntuple/v7/inc/ROOT/RPage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPage.hxx
@@ -57,7 +57,7 @@ public:
    };
 
 private:
-   ColumnId_t fPhysicalColumnId;
+   ColumnId_t fColumnId;
    void *fBuffer;
    ClusterSize_t::ValueType fElementSize;
    ClusterSize_t::ValueType fNElements;
@@ -68,18 +68,15 @@ private:
 
 public:
    RPage()
-      : fPhysicalColumnId(kInvalidColumnId), fBuffer(nullptr), fElementSize(0), fNElements(0), fMaxElements(0),
+      : fColumnId(kInvalidColumnId), fBuffer(nullptr), fElementSize(0), fNElements(0), fMaxElements(0), fRangeFirst(0)
+   {}
+   RPage(ColumnId_t columnId, void* buffer, ClusterSize_t::ValueType elementSize, ClusterSize_t::ValueType maxElements)
+      : fColumnId(columnId), fBuffer(buffer), fElementSize(elementSize), fNElements(0), fMaxElements(maxElements),
         fRangeFirst(0)
-   {
-   }
-   RPage(ColumnId_t physicalColumnId, void *buffer, ClusterSize_t::ValueType elementSize,
-         ClusterSize_t::ValueType maxElements)
-      : fPhysicalColumnId(physicalColumnId), fBuffer(buffer), fElementSize(elementSize), fNElements(0),
-        fMaxElements(maxElements), fRangeFirst(0)
    {}
    ~RPage() = default;
 
-   ColumnId_t GetPhysicalColumnId() const { return fPhysicalColumnId; }
+   ColumnId_t GetColumnId() const { return fColumnId; }
    /// The space taken by column elements in the buffer
    ClusterSize_t::ValueType GetNBytes() const { return fElementSize * fNElements; }
    ClusterSize_t::ValueType GetElementSize() const { return fElementSize; }
@@ -124,9 +121,9 @@ public:
    void ResetCluster(const RClusterInfo &clusterInfo) { fNElements = 0; fClusterInfo = clusterInfo; }
 
    /// Used by virtual page sources to map the physical column and cluster IDs to ther virtual counterparts
-   void ChangeIds(DescriptorId_t physicalColumnId, DescriptorId_t clusterId)
+   void ChangeIds(DescriptorId_t columnId, DescriptorId_t clusterId)
    {
-      fPhysicalColumnId = physicalColumnId;
+      fColumnId = columnId;
       fClusterInfo = RClusterInfo(clusterId, fClusterInfo.GetIndexOffset());
    }
 

--- a/tree/ntuple/v7/inc/ROOT/RPagePool.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPagePool.hxx
@@ -69,8 +69,8 @@ public:
    void PreloadPage(const RPage &page, const RPageDeleter &deleter);
    /// Tries to find the page corresponding to column and index in the cache. If the page is found, its reference
    /// counter is increased
-   RPage GetPage(ColumnId_t columnId, NTupleSize_t globalIndex);
-   RPage GetPage(ColumnId_t columnId, const RClusterIndex &clusterIndex);
+   RPage GetPage(ColumnId_t physicalColumnId, NTupleSize_t globalIndex);
+   RPage GetPage(ColumnId_t physicalColumnId, const RClusterIndex &clusterIndex);
    /// Give back a page to the pool and decrease the reference counter. There must not be any pointers anymore into
    /// this page. If the reference counter drops to zero, the page pool might decide to call the deleter given in
    /// during registration.

--- a/tree/ntuple/v7/inc/ROOT/RPagePool.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPagePool.hxx
@@ -69,8 +69,8 @@ public:
    void PreloadPage(const RPage &page, const RPageDeleter &deleter);
    /// Tries to find the page corresponding to column and index in the cache. If the page is found, its reference
    /// counter is increased
-   RPage GetPage(ColumnId_t physicalColumnId, NTupleSize_t globalIndex);
-   RPage GetPage(ColumnId_t physicalColumnId, const RClusterIndex &clusterIndex);
+   RPage GetPage(ColumnId_t columnId, NTupleSize_t globalIndex);
+   RPage GetPage(ColumnId_t columnId, const RClusterIndex &clusterIndex);
    /// Give back a page to the pool and decrease the reference counter. There must not be any pointers anymore into
    /// this page. If the reference counter drops to zero, the page pool might decide to call the deleter given in
    /// during registration.

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -129,7 +129,7 @@ private:
 protected:
    void CreateImpl(const RNTupleModel &model, unsigned char *serializedHeader, std::uint32_t length) final;
    RNTupleLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) final;
-   RNTupleLocator CommitSealedPageImpl(DescriptorId_t columnId, const RSealedPage &sealedPage) final;
+   RNTupleLocator CommitSealedPageImpl(DescriptorId_t physicalColumnId, const RSealedPage &sealedPage) final;
    std::uint64_t CommitClusterImpl(NTupleSize_t nEntries) final;
    RNTupleLocator CommitClusterGroupImpl(unsigned char *serializedPageList, std::uint32_t length) final;
    void CommitDatasetImpl(unsigned char *serializedFooter, std::uint32_t length) final;

--- a/tree/ntuple/v7/inc/ROOT/RPageSourceFriends.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSourceFriends.hxx
@@ -99,7 +99,8 @@ public:
    RPage PopulatePage(ColumnHandle_t columnHandle, const RClusterIndex &clusterIndex) final;
    void ReleasePage(RPage &page) final;
 
-   void LoadSealedPage(DescriptorId_t columnId, const RClusterIndex &clusterIndex, RSealedPage &sealedPage) final;
+   void
+   LoadSealedPage(DescriptorId_t physicalColumnId, const RClusterIndex &clusterIndex, RSealedPage &sealedPage) final;
 
    std::vector<std::unique_ptr<RCluster>> LoadClusters(std::span<RCluster::RKey> clusterKeys) final;
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -438,7 +438,7 @@ public:
    void Attach() { GetExclDescriptorGuard().MoveIn(AttachImpl()); }
    NTupleSize_t GetNEntries();
    NTupleSize_t GetNElements(ColumnHandle_t columnHandle);
-   ColumnId_t GetPhysicalColumnId(ColumnHandle_t columnHandle);
+   ColumnId_t GetColumnId(ColumnHandle_t columnHandle);
 
    /// Allocates and fills a page that contains the index-th element
    virtual RPage PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t globalIndex) = 0;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -125,12 +125,12 @@ public:
    virtual EPageStorageType GetType() = 0;
 
    struct RColumnHandle {
-      DescriptorId_t fId = kInvalidDescriptorId;
+      DescriptorId_t fPhysicalId = kInvalidDescriptorId;
       const RColumn *fColumn = nullptr;
 
-      /// Returns true for a valid column handle; fColumn and fId should always either both
+      /// Returns true for a valid column handle; fColumn and fPhysicalId should always either both
       /// be valid or both be invalid.
-      explicit operator bool() const { return fId != kInvalidDescriptorId && fColumn; }
+      explicit operator bool() const { return fPhysicalId != kInvalidDescriptorId && fColumn; }
    };
    /// The column handle identifies a column with the current open page storage
    using ColumnHandle_t = RColumnHandle;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -368,13 +368,27 @@ protected:
       RNTupleCalcPerf &fFractionReadOverhead;
       RNTupleCalcPerf &fCompressionRatio;
    };
+
+   /// Keeps track of the requested physical column IDs. When using alias columns (projected fields), physical
+   /// columns may be requested multiple times.
+   class RActiveColumns {
+   private:
+      std::vector<DescriptorId_t> fPhysicalColumnIDs;
+      std::vector<std::size_t> fRefCounters;
+
+   public:
+      void Insert(DescriptorId_t physicalColumnID);
+      void Erase(DescriptorId_t physicalColumnID);
+      RCluster::ColumnSet_t ToColumnSet();
+   };
+
    std::unique_ptr<RCounters> fCounters;
    /// Wraps the I/O counters and is observed by the RNTupleReader metrics
    RNTupleMetrics fMetrics;
 
    RNTupleReadOptions fOptions;
    /// The active columns are implicitly defined by the model fields or views
-   RCluster::ColumnSet_t fActiveColumns;
+   RActiveColumns fActiveColumns;
 
    /// Helper to unzip pages and header/footer; comprises a 16MB (kMAXZIPBUF) unzip buffer.
    /// Not all page sources need a decompressor (e.g. virtual ones for chains and friends don't), thus we

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -438,7 +438,7 @@ public:
    void Attach() { GetExclDescriptorGuard().MoveIn(AttachImpl()); }
    NTupleSize_t GetNEntries();
    NTupleSize_t GetNElements(ColumnHandle_t columnHandle);
-   ColumnId_t GetColumnId(ColumnHandle_t columnHandle);
+   ColumnId_t GetPhysicalColumnId(ColumnHandle_t columnHandle);
 
    /// Allocates and fills a page that contains the index-th element
    virtual RPage PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t globalIndex) = 0;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -379,7 +379,7 @@ protected:
    public:
       void Insert(DescriptorId_t physicalColumnID);
       void Erase(DescriptorId_t physicalColumnID);
-      RCluster::ColumnSet_t ToColumnSet();
+      RCluster::ColumnSet_t ToColumnSet() const;
    };
 
    std::unique_ptr<RCounters> fCounters;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -99,12 +99,12 @@ public:
    using SealedPageSequence_t = std::deque<RSealedPage>;
    /// A range of sealed pages referring to the same column that can be used for vector commit
    struct RSealedPageGroup {
-      DescriptorId_t fColumnId;
+      DescriptorId_t fPhysicalColumnId;
       SealedPageSequence_t::const_iterator fFirst;
       SealedPageSequence_t::const_iterator fLast;
 
       RSealedPageGroup(DescriptorId_t d, SealedPageSequence_t::const_iterator b, SealedPageSequence_t::const_iterator e)
-         : fColumnId(d), fFirst(b), fLast(e)
+         : fPhysicalColumnId(d), fFirst(b), fLast(e)
       {
       }
    };

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -371,9 +371,9 @@ protected:
 
    /// Keeps track of the requested physical column IDs. When using alias columns (projected fields), physical
    /// columns may be requested multiple times.
-   class RActiveColumns {
+   class RActivePhysicalColumns {
    private:
-      std::vector<DescriptorId_t> fPhysicalColumnIDs;
+      std::vector<DescriptorId_t> fIDs;
       std::vector<std::size_t> fRefCounters;
 
    public:
@@ -388,7 +388,7 @@ protected:
 
    RNTupleReadOptions fOptions;
    /// The active columns are implicitly defined by the model fields or views
-   RActiveColumns fActiveColumns;
+   RActivePhysicalColumns fActivePhysicalColumns;
 
    /// Helper to unzip pages and header/footer; comprises a 16MB (kMAXZIPBUF) unzip buffer.
    /// Not all page sources need a decompressor (e.g. virtual ones for chains and friends don't), thus we

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -128,7 +128,7 @@ struct RDaosContainerNTupleLocator {
 \ingroup NTuple
 \brief Storage provider that writes ntuple pages to into a DAOS container
 
-Currently, an object is allocated for ntuple metadata (anchor/header/footer). 
+Currently, an object is allocated for ntuple metadata (anchor/header/footer).
 Objects can correspond to pages or clusters of pages depending on the RNTuple-DAOS mapping strategy.
 */
 // clang-format on
@@ -156,7 +156,8 @@ private:
 protected:
    void CreateImpl(const RNTupleModel &model, unsigned char *serializedHeader, std::uint32_t length) final;
    RNTupleLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) final;
-   RNTupleLocator CommitSealedPageImpl(DescriptorId_t columnId, const RPageStorage::RSealedPage &sealedPage) final;
+   RNTupleLocator
+   CommitSealedPageImpl(DescriptorId_t physicalColumnId, const RPageStorage::RSealedPage &sealedPage) final;
    std::vector<RNTupleLocator> CommitSealedPageVImpl(std::span<RPageStorage::RSealedPageGroup> ranges) final;
    std::uint64_t CommitClusterImpl(NTupleSize_t nEntries) final;
    RNTupleLocator CommitClusterGroupImpl(unsigned char *serializedPageList, std::uint32_t length) final;
@@ -241,7 +242,8 @@ public:
    RPage PopulatePage(ColumnHandle_t columnHandle, const RClusterIndex &clusterIndex) final;
    void ReleasePage(RPage &page) final;
 
-   void LoadSealedPage(DescriptorId_t columnId, const RClusterIndex &clusterIndex, RSealedPage &sealedPage) final;
+   void
+   LoadSealedPage(DescriptorId_t physicalColumnId, const RClusterIndex &clusterIndex, RSealedPage &sealedPage) final;
 
    std::vector<std::unique_ptr<RCluster>> LoadClusters(std::span<RCluster::RKey> clusterKeys) final;
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -71,7 +71,8 @@ private:
 protected:
    void CreateImpl(const RNTupleModel &model, unsigned char *serializedHeader, std::uint32_t length) final;
    RNTupleLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) final;
-   RNTupleLocator CommitSealedPageImpl(DescriptorId_t columnId, const RPageStorage::RSealedPage &sealedPage) final;
+   RNTupleLocator
+   CommitSealedPageImpl(DescriptorId_t physicalColumnId, const RPageStorage::RSealedPage &sealedPage) final;
    std::uint64_t CommitClusterImpl(NTupleSize_t nEntries) final;
    RNTupleLocator CommitClusterGroupImpl(unsigned char *serializedPageList, std::uint32_t length) final;
    void CommitDatasetImpl(unsigned char *serializedFooter, std::uint32_t length) final;
@@ -180,8 +181,8 @@ public:
    RPage PopulatePage(ColumnHandle_t columnHandle, const RClusterIndex &clusterIndex) final;
    void ReleasePage(RPage &page) final;
 
-   void LoadSealedPage(DescriptorId_t columnId, const RClusterIndex &clusterIndex,
-                       RSealedPage &sealedPage) final;
+   void
+   LoadSealedPage(DescriptorId_t physicalColumnId, const RClusterIndex &clusterIndex, RSealedPage &sealedPage) final;
 
    std::vector<std::unique_ptr<RCluster>> LoadClusters(std::span<RCluster::RKey> clusterKeys) final;
 };

--- a/tree/ntuple/v7/src/RCluster.cxx
+++ b/tree/ntuple/v7/src/RCluster.cxx
@@ -59,15 +59,14 @@ void ROOT::Experimental::Detail::RCluster::Adopt(RCluster &&other)
    fOnDiskPages.insert(std::make_move_iterator(pages.begin()), std::make_move_iterator(pages.end()));
    other.fOnDiskPages.clear();
 
-   auto &columns = other.fAvailColumns;
-   fAvailColumns.insert(std::make_move_iterator(columns.begin()), std::make_move_iterator(columns.end()));
-   other.fAvailColumns.clear();
+   auto &columns = other.fAvailPhysicalColumns;
+   fAvailPhysicalColumns.insert(std::make_move_iterator(columns.begin()), std::make_move_iterator(columns.end()));
+   other.fAvailPhysicalColumns.clear();
    std::move(other.fPageMaps.begin(), other.fPageMaps.end(), std::back_inserter(fPageMaps));
    other.fPageMaps.clear();
 }
 
-
-void ROOT::Experimental::Detail::RCluster::SetColumnAvailable(DescriptorId_t columnId)
+void ROOT::Experimental::Detail::RCluster::SetColumnAvailable(DescriptorId_t physicalColumnId)
 {
-   fAvailColumns.insert(columnId);
+   fAvailPhysicalColumns.insert(physicalColumnId);
 }

--- a/tree/ntuple/v7/src/RClusterPool.cxx
+++ b/tree/ntuple/v7/src/RClusterPool.cxx
@@ -33,10 +33,9 @@
 bool ROOT::Experimental::Detail::RClusterPool::RInFlightCluster::operator <(const RInFlightCluster &other) const
 {
    if (fClusterKey.fClusterId == other.fClusterKey.fClusterId) {
-      if (fClusterKey.fColumnSet.size() == other.fClusterKey.fColumnSet.size()) {
-         for (auto itr1 = fClusterKey.fColumnSet.begin(), itr2 = other.fClusterKey.fColumnSet.begin();
-              itr1 != fClusterKey.fColumnSet.end(); ++itr1, ++itr2)
-         {
+      if (fClusterKey.fPhysicalColumnSet.size() == other.fClusterKey.fPhysicalColumnSet.size()) {
+         for (auto itr1 = fClusterKey.fPhysicalColumnSet.begin(), itr2 = other.fClusterKey.fPhysicalColumnSet.begin();
+              itr1 != fClusterKey.fPhysicalColumnSet.end(); ++itr1, ++itr2) {
             if (*itr1 == *itr2)
                continue;
             return *itr1 < *itr2;
@@ -44,7 +43,7 @@ bool ROOT::Experimental::Detail::RClusterPool::RInFlightCluster::operator <(cons
          // *this == other
          return false;
       }
-      return fClusterKey.fColumnSet.size() < other.fClusterKey.fColumnSet.size();
+      return fClusterKey.fPhysicalColumnSet.size() < other.fClusterKey.fPhysicalColumnSet.size();
    }
    return fClusterKey.fClusterId < other.fClusterKey.fClusterId;
 }
@@ -298,7 +297,7 @@ ROOT::Experimental::Detail::RClusterPool::GetCluster(
 
          if (itr->fFuture.wait_for(std::chrono::seconds(0)) != std::future_status::ready) {
             // Remove the set of columns that are already scheduled for being loaded
-            provide.Erase(itr->fClusterKey.fClusterId, itr->fClusterKey.fColumnSet);
+            provide.Erase(itr->fClusterKey.fClusterId, itr->fClusterKey.fPhysicalColumnSet);
             ++itr;
             continue;
          }
@@ -352,11 +351,11 @@ ROOT::Experimental::Detail::RClusterPool::GetCluster(
             RReadItem readItem;
             readItem.fClusterKey.fClusterId = kv.first;
             readItem.fBunchId = kv.second.fBunchId;
-            readItem.fClusterKey.fColumnSet = kv.second.fColumnSet;
+            readItem.fClusterKey.fPhysicalColumnSet = kv.second.fColumnSet;
 
             RInFlightCluster inFlightCluster;
             inFlightCluster.fClusterKey.fClusterId = kv.first;
-            inFlightCluster.fClusterKey.fColumnSet = kv.second.fColumnSet;
+            inFlightCluster.fClusterKey.fPhysicalColumnSet = kv.second.fColumnSet;
             inFlightCluster.fFuture = readItem.fPromise.get_future();
             fInFlightClusters.emplace_back(std::move(inFlightCluster));
 

--- a/tree/ntuple/v7/src/RClusterPool.cxx
+++ b/tree/ntuple/v7/src/RClusterPool.cxx
@@ -325,7 +325,7 @@ ROOT::Experimental::Detail::RClusterPool::GetCluster(
       for (auto &cptr : fPool) {
          if (!cptr)
             continue;
-         provide.Erase(cptr->GetId(), cptr->GetAvailColumns());
+         provide.Erase(cptr->GetId(), cptr->GetAvailPhysicalColumns());
       }
 
       // Figure out if enough work accumulated to justify I/O calls

--- a/tree/ntuple/v7/src/RColumn.cxx
+++ b/tree/ntuple/v7/src/RColumn.cxx
@@ -57,7 +57,7 @@ void ROOT::Experimental::Detail::RColumn::Connect(DescriptorId_t fieldId, RPageS
       fPageSource = static_cast<RPageSource*>(pageStorage);
       fHandleSource = fPageSource->AddColumn(fieldId, *this);
       fNElements = fPageSource->GetNElements(fHandleSource);
-      fColumnIdSource = fPageSource->GetPhysicalColumnId(fHandleSource);
+      fColumnIdSource = fPageSource->GetColumnId(fHandleSource);
       break;
    default:
       R__ASSERT(false);

--- a/tree/ntuple/v7/src/RColumn.cxx
+++ b/tree/ntuple/v7/src/RColumn.cxx
@@ -57,7 +57,7 @@ void ROOT::Experimental::Detail::RColumn::Connect(DescriptorId_t fieldId, RPageS
       fPageSource = static_cast<RPageSource*>(pageStorage);
       fHandleSource = fPageSource->AddColumn(fieldId, *this);
       fNElements = fPageSource->GetNElements(fHandleSource);
-      fColumnIdSource = fPageSource->GetColumnId(fHandleSource);
+      fColumnIdSource = fPageSource->GetPhysicalColumnId(fHandleSource);
       break;
    default:
       R__ASSERT(false);

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -189,6 +189,17 @@ ROOT::Experimental::Detail::RFieldBase::~RFieldBase()
 {
 }
 
+std::string ROOT::Experimental::Detail::RFieldBase::GetQualifiedFieldName() const
+{
+   std::string result = GetName();
+   RFieldBase *parent = GetParent();
+   while (parent && !parent->GetName().empty()) {
+      result = parent->GetName() + "." + result;
+      parent = parent->GetParent();
+   }
+   return result;
+}
+
 ROOT::Experimental::RResult<std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>>
 ROOT::Experimental::Detail::RFieldBase::Create(const std::string &fieldName, const std::string &typeName)
 {

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -376,13 +376,13 @@ ROOT::Experimental::EColumnType ROOT::Experimental::Detail::RFieldBase::EnsureCo
    const std::vector<EColumnType> &requestedTypes, unsigned int columnIndex, const RNTupleDescriptor &desc)
 {
    R__ASSERT(!requestedTypes.empty());
-   auto columnId = desc.FindColumnId(fOnDiskId, columnIndex);
-   if (columnId == kInvalidDescriptorId) {
+   auto logicalId = desc.FindLogicalColumnId(fOnDiskId, columnIndex);
+   if (logicalId == kInvalidDescriptorId) {
       throw RException(R__FAIL("Column missing: column #" + std::to_string(columnIndex) +
                                " for field " + fName));
    }
 
-   const auto &columnDesc = desc.GetColumnDescriptor(columnId);
+   const auto &columnDesc = desc.GetColumnDescriptor(logicalId);
    for (auto type : requestedTypes) {
       if (type == columnDesc.GetModel().GetType())
          return type;

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -109,7 +109,7 @@ ROOT::Experimental::RNTupleReader::RNTupleReader(
       throw RException(R__FAIL("null model"));
    }
    if (!fModel->GetProjectedFields().IsEmpty()) {
-      throw RException(R__FAIL("model has projected fields, which is not supported for a read model"));
+      throw RException(R__FAIL("model has projected fields, which is incompatible with providing a read model"));
    }
    fModel->Freeze();
    InitPageSource();

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -108,6 +108,9 @@ ROOT::Experimental::RNTupleReader::RNTupleReader(
    if (!fModel) {
       throw RException(R__FAIL("null model"));
    }
+   if (!fModel->GetProjectedFields().IsEmpty()) {
+      throw RException(R__FAIL("model has projected fields, which is not supported for a read model"));
+   }
    fModel->Freeze();
    InitPageSource();
    ConnectModel(*fModel);

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -201,14 +201,14 @@ bool ROOT::Experimental::RNTupleDescriptor::operator==(const RNTupleDescriptor &
           fClusterDescriptors == other.fClusterDescriptors;
 }
 
-
-ROOT::Experimental::NTupleSize_t ROOT::Experimental::RNTupleDescriptor::GetNElements(DescriptorId_t columnId) const
+ROOT::Experimental::NTupleSize_t
+ROOT::Experimental::RNTupleDescriptor::GetNElements(DescriptorId_t physicalColumnId) const
 {
    NTupleSize_t result = 0;
    for (const auto &cd : fClusterDescriptors) {
-      if (!cd.second.ContainsColumn(columnId))
+      if (!cd.second.ContainsColumn(physicalColumnId))
          continue;
-      auto columnRange = cd.second.GetColumnRange(columnId);
+      auto columnRange = cd.second.GetColumnRange(physicalColumnId);
       result = std::max(result, columnRange.fFirstElementIndex + columnRange.fNElements);
    }
    return result;
@@ -279,13 +279,13 @@ ROOT::Experimental::RNTupleDescriptor::FindPhysicalColumnId(DescriptorId_t field
 }
 
 ROOT::Experimental::DescriptorId_t
-ROOT::Experimental::RNTupleDescriptor::FindClusterId(DescriptorId_t columnId, NTupleSize_t index) const
+ROOT::Experimental::RNTupleDescriptor::FindClusterId(DescriptorId_t physicalColumnId, NTupleSize_t index) const
 {
    // TODO(jblomer): binary search?
    for (const auto &cd : fClusterDescriptors) {
-      if (!cd.second.ContainsColumn(columnId))
+      if (!cd.second.ContainsColumn(physicalColumnId))
          continue;
-      auto columnRange = cd.second.GetColumnRange(columnId);
+      auto columnRange = cd.second.GetColumnRange(physicalColumnId);
       if (columnRange.Contains(index))
          return cd.second.GetId();
    }

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -151,11 +151,10 @@ std::unordered_set<ROOT::Experimental::DescriptorId_t> ROOT::Experimental::RClus
    return result;
 }
 
-
-bool ROOT::Experimental::RClusterDescriptor::ContainsColumn(DescriptorId_t columnId) const
+bool ROOT::Experimental::RClusterDescriptor::ContainsColumn(DescriptorId_t physicalId) const
 {
    EnsureHasPageLocations();
-   return fColumnRanges.find(columnId) != fColumnRanges.end();
+   return fColumnRanges.find(physicalId) != fColumnRanges.end();
 }
 
 
@@ -404,21 +403,22 @@ ROOT::Experimental::RClusterGroupDescriptor ROOT::Experimental::RClusterGroupDes
 ////////////////////////////////////////////////////////////////////////////////
 
 ROOT::Experimental::RResult<void>
-ROOT::Experimental::RClusterDescriptorBuilder::CommitColumnRange(
-   DescriptorId_t columnId, std::uint64_t firstElementIndex, std::uint32_t compressionSettings,
-   const RClusterDescriptor::RPageRange &pageRange)
+ROOT::Experimental::RClusterDescriptorBuilder::CommitColumnRange(DescriptorId_t physicalId,
+                                                                 std::uint64_t firstElementIndex,
+                                                                 std::uint32_t compressionSettings,
+                                                                 const RClusterDescriptor::RPageRange &pageRange)
 {
-   if (columnId != pageRange.fColumnId)
+   if (physicalId != pageRange.fPhysicalColumnId)
       return R__FAIL("column ID mismatch");
-   if (fCluster.fPageRanges.count(columnId) > 0)
+   if (fCluster.fPageRanges.count(physicalId) > 0)
       return R__FAIL("column ID conflict");
-   RClusterDescriptor::RColumnRange columnRange{columnId, firstElementIndex, RClusterSize(0)};
+   RClusterDescriptor::RColumnRange columnRange{physicalId, firstElementIndex, RClusterSize(0)};
    columnRange.fCompressionSettings = compressionSettings;
    for (const auto &pi : pageRange.fPageInfos) {
       columnRange.fNElements += pi.fNElements;
    }
-   fCluster.fPageRanges[columnId] = pageRange.Clone();
-   fCluster.fColumnRanges[columnId] = columnRange;
+   fCluster.fPageRanges[physicalId] = pageRange.Clone();
+   fCluster.fColumnRanges[physicalId] = columnRange;
    return RResult<void>::Success();
 }
 

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -612,6 +612,8 @@ void ROOT::Experimental::RNTupleDescriptorBuilder::AddColumn(DescriptorId_t logi
    c.fFieldId = fieldId;
    c.fModel = model;
    c.fIndex = index;
+   if (!c.IsAliasColumn())
+      fDescriptor.fNPhysicalColumns++;
    fDescriptor.fColumnDescriptors.emplace(logicalId, std::move(c));
 }
 
@@ -638,6 +640,8 @@ ROOT::Experimental::RNTupleDescriptorBuilder::AddColumn(RColumnDescriptor &&colu
    }
 
    auto logicalId = columnDesc.GetLogicalId();
+   if (!columnDesc.IsAliasColumn())
+      fDescriptor.fNPhysicalColumns++;
    fDescriptor.fColumnDescriptors.emplace(logicalId, std::move(columnDesc));
 
    return RResult<void>::Success();

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -602,16 +602,17 @@ ROOT::Experimental::RNTupleDescriptorBuilder::AddFieldLink(DescriptorId_t fieldI
    return RResult<void>::Success();
 }
 
-void ROOT::Experimental::RNTupleDescriptorBuilder::AddColumn(DescriptorId_t columnId, DescriptorId_t fieldId,
-                                                             const RColumnModel &model, std::uint32_t index)
+void ROOT::Experimental::RNTupleDescriptorBuilder::AddColumn(DescriptorId_t logicalId, DescriptorId_t physicalId,
+                                                             DescriptorId_t fieldId, const RColumnModel &model,
+                                                             std::uint32_t index)
 {
    RColumnDescriptor c;
-   c.fLogicalColumnId = columnId;
-   c.fPhysicalColumnId = columnId;
+   c.fLogicalColumnId = logicalId;
+   c.fPhysicalColumnId = physicalId;
    c.fFieldId = fieldId;
    c.fModel = model;
    c.fIndex = index;
-   fDescriptor.fColumnDescriptors.emplace(columnId, std::move(c));
+   fDescriptor.fColumnDescriptors.emplace(logicalId, std::move(c));
 }
 
 

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -381,7 +381,7 @@ std::unique_ptr<ROOT::Experimental::RNTupleDescriptor> ROOT::Experimental::RNTup
 
 bool ROOT::Experimental::RColumnGroupDescriptor::operator==(const RColumnGroupDescriptor &other) const
 {
-   return fColumnGroupId == other.fColumnGroupId && fColumnIds == other.fColumnIds;
+   return fColumnGroupId == other.fColumnGroupId && fPhysicalColumnIds == other.fPhysicalColumnIds;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
@@ -43,7 +43,7 @@ struct ClusterInfo {
 };
 
 struct ColumnInfo {
-   ROOT::Experimental::DescriptorId_t fColumnId = 0;
+   ROOT::Experimental::DescriptorId_t fPhysicalColumnId = 0;
    ROOT::Experimental::DescriptorId_t fFieldId = 0;
    std::uint64_t fLocalOrder = 0;
    std::uint64_t fNElements = 0;
@@ -97,12 +97,15 @@ void ROOT::Experimental::RNTupleDescriptor::PrintInfo(std::ostream &output) cons
    std::uint64_t nPages = 0;
    int compression = -1;
    for (const auto &column : fColumnDescriptors) {
+      if (column.second.IsAliasColumn())
+         continue;
+
       // We generate the default memory representation for the given column type in order
       // to report the size _in memory_ of column elements
       auto elementSize = Detail::RColumnElementBase::Generate(column.second.GetModel().GetType())->GetSize();
 
       ColumnInfo info;
-      info.fColumnId = column.second.GetId();
+      info.fPhysicalColumnId = column.second.GetPhysicalId();
       info.fFieldId = column.second.GetFieldId();
       info.fLocalOrder = column.second.GetIndex();
       info.fElementSize = elementSize;
@@ -178,7 +181,7 @@ void ROOT::Experimental::RNTupleDescriptor::PrintInfo(std::ostream &output) cons
       auto avgElementsPerPage = (col.fNPages == 0) ? 0 : (col.fNElements / col.fNPages);
       std::string nameAndType = std::string("  ") + col.fFieldName + " [#" + std::to_string(col.fLocalOrder) + "]"
          + "  --  " + Detail::RColumnElementBase::GetTypeName(col.fType);
-      std::string id = std::string("{id:") + std::to_string(col.fColumnId) + "}";
+      std::string id = std::string("{id:") + std::to_string(col.fPhysicalColumnId) + "}";
       output << nameAndType << std::setw(60 - nameAndType.length()) << id << std::endl;
       if (!col.fFieldDescription.empty())
          output << "    Description:         " << col.fFieldDescription << std::endl;

--- a/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
@@ -140,7 +140,7 @@ void ROOT::Experimental::RNTupleDescriptor::PrintInfo(std::ostream &output) cons
    output << "------------------------------------------------------------" << std::endl;
    output << "  # Entries:        " << GetNEntries() << std::endl;
    output << "  # Fields:         " << GetNFields() << std::endl;
-   output << "  # Columns:        " << GetNColumns() << std::endl;
+   output << "  # Columns:        " << GetNPhysicalColumns() << std::endl;
    output << "  # Pages:          " << nPages << std::endl;
    output << "  # Clusters:       " << GetNClusters() << std::endl;
    output << "  Size on storage:  " << bytesOnStorage << " B" << std::endl;

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -69,7 +69,7 @@ ROOT::Experimental::RNTupleModel::RProjectedFields::EnsureValidMapping(const Det
          // Source and target are children of the same collection
          return RResult<void>::Success();
       }
-      if ((fieldMap.count(targetBreakPoint) > 0) && fieldMap.at(targetBreakPoint) == sourceBreakPoint) {
+      if ((fieldMap.find(targetBreakPoint) != fieldMap.end()) && (fieldMap.at(targetBreakPoint) == sourceBreakPoint)) {
          // The parent collection of parent is mapped to the parent collection of the source
          return RResult<void>::Success();
       }
@@ -102,7 +102,7 @@ ROOT::Experimental::RNTupleModel::RProjectedFields::Add(std::unique_ptr<Detail::
 const ROOT::Experimental::Detail::RFieldBase *
 ROOT::Experimental::RNTupleModel::RProjectedFields::GetSourceField(const Detail::RFieldBase *target) const
 {
-   if (fFieldMap.count(target) > 0)
+   if (fFieldMap.find(target) != fFieldMap.end())
       return fFieldMap.at(target);
    return nullptr;
 }

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -25,6 +25,102 @@
 #include <typeinfo>
 #include <utility>
 
+ROOT::Experimental::RResult<void>
+ROOT::Experimental::RNTupleModel::RProjectedFields::EnsureValidMapping(const Detail::RFieldBase *target,
+                                                                       const FieldMap_t &fieldMap)
+{
+   auto source = fieldMap.at(target);
+   if (typeid(*target) != typeid(*source))
+      return R__FAIL("field mapping type mismatch: " + source->GetName() + " --> " + target->GetName());
+
+   // We support projections only across records and collections. In the following, we check that the projected
+   // field is on the same path of collection fields in the field tree than the source field.
+
+   // Finds the first non-record parent field of the input field
+   auto fnBreakPoint = [](const Detail::RFieldBase *f) -> const Detail::RFieldBase * {
+      auto parent = f->GetParent();
+      while (parent) {
+         if (parent->GetStructure() != ENTupleStructure::kRecord)
+            return parent;
+         parent = parent->GetParent();
+      }
+      // We reached the zero field
+      return nullptr;
+   };
+
+   // If source or target has a variant or reference as a parent, error out
+   auto *sourceBreakPoint = fnBreakPoint(source);
+   if (sourceBreakPoint && sourceBreakPoint->GetStructure() != ENTupleStructure::kCollection)
+      return R__FAIL("unsupported field mapping (source structure)");
+   auto *targetBreakPoint = fnBreakPoint(target);
+   if (targetBreakPoint && sourceBreakPoint->GetStructure() != ENTupleStructure::kCollection)
+      return R__FAIL("unsupported field mapping (target structure)");
+
+   if (!sourceBreakPoint && !targetBreakPoint) {
+      // Source and target have no collections as parent
+      return RResult<void>::Success();
+   }
+   if (sourceBreakPoint && targetBreakPoint) {
+      if (sourceBreakPoint == targetBreakPoint) {
+         // Source and target are children of the same collection
+         return RResult<void>::Success();
+      }
+      if ((fieldMap.count(targetBreakPoint) > 0) && fieldMap.at(targetBreakPoint) == sourceBreakPoint) {
+         // The parent collection of parent is mapped to the parent collection of the source
+         return RResult<void>::Success();
+      }
+      // Source and target are children of different collections
+      return R__FAIL("field mapping structure mismatch: " + source->GetName() + " --> " + target->GetName());
+   }
+
+   // Either source or target have no collection as a parent, but the other one has; that doesn't fit
+   return R__FAIL("field mapping structure mismatch: " + source->GetName() + " --> " + target->GetName());
+}
+
+ROOT::Experimental::RResult<void>
+ROOT::Experimental::RNTupleModel::RProjectedFields::Add(std::unique_ptr<Detail::RFieldBase> field,
+                                                        const FieldMap_t &fieldMap)
+{
+   auto result = EnsureValidMapping(field.get(), fieldMap);
+   if (!result)
+      return R__FORWARD_ERROR(result);
+   for (const auto &f : *field) {
+      result = EnsureValidMapping(&f, fieldMap);
+      if (!result)
+         return R__FORWARD_ERROR(result);
+   }
+
+   fFieldMap.insert(fieldMap.begin(), fieldMap.end());
+   fFieldZero->Attach(std::move(field));
+   return RResult<void>::Success();
+}
+
+const ROOT::Experimental::Detail::RFieldBase *
+ROOT::Experimental::RNTupleModel::RProjectedFields::GetSourceField(const Detail::RFieldBase *target) const
+{
+   if (fFieldMap.count(target) > 0)
+      return fFieldMap.at(target);
+   return nullptr;
+}
+
+std::unique_ptr<ROOT::Experimental::RNTupleModel::RProjectedFields>
+ROOT::Experimental::RNTupleModel::RProjectedFields::Clone(const RNTupleModel *newModel) const
+{
+   auto cloneFieldZero = std::unique_ptr<RFieldZero>(static_cast<RFieldZero *>(fFieldZero->Clone("").release()));
+   auto clone = std::unique_ptr<RProjectedFields>(new RProjectedFields(std::move(cloneFieldZero)));
+   clone->fModel = newModel;
+   // TODO(jblomer): improve quadratic search to re-wire the field mappings given the new model and the cloned
+   // projected fields. Not too critical as we generally expect a limited number of projected fields
+   for (const auto &[k, v] : fFieldMap) {
+      for (const auto &f : *clone->GetFieldZero()) {
+         if (f.GetQualifiedFieldName() == k->GetQualifiedFieldName()) {
+            clone->fFieldMap[&f] = clone->fModel->GetField(v->GetQualifiedFieldName());
+            break;
+         }
+      }
+   }
+   return clone;
+}
 
 void ROOT::Experimental::RNTupleModel::EnsureValidFieldName(std::string_view fieldName)
 {
@@ -50,19 +146,16 @@ void ROOT::Experimental::RNTupleModel::EnsureNotBare() const
       throw RException(R__FAIL("invalid attempt to use default entry of bare model"));
 }
 
-void ROOT::Experimental::RNTupleModel::EnsureValidFieldMapping(const Detail::RFieldBase &fieldTarget,
-                                                               const std::string &source) const
-{
-   auto fieldSource = GetField(source);
-   if (!fieldSource)
-      throw RException(R__FAIL("unknown source field for mapping: " + source));
-   if (typeid(fieldTarget) != typeid(*fieldSource))
-      throw RException(R__FAIL("field mapping type mismatch: " + source + " --> " + fieldTarget.GetName()));
-}
-
 ROOT::Experimental::RNTupleModel::RNTupleModel()
   : fFieldZero(std::make_unique<RFieldZero>())
 {}
+
+std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleModel::CreateBare()
+{
+   auto model = std::unique_ptr<RNTupleModel>(new RNTupleModel());
+   model->fProjectedFields = std::make_unique<RProjectedFields>(model.get());
+   return model;
+}
 
 std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleModel::Create()
 {
@@ -79,6 +172,7 @@ std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleMod
    cloneModel->fFieldZero = std::unique_ptr<RFieldZero>(static_cast<RFieldZero *>(cloneFieldZero.release()));
    cloneModel->fFieldNames = fFieldNames;
    cloneModel->fDescription = fDescription;
+   cloneModel->fProjectedFields = fProjectedFields->Clone(cloneModel.get());
    if (fDefaultEntry) {
       cloneModel->fDefaultEntry = std::unique_ptr<REntry>(new REntry(fModelId));
       for (const auto &f : cloneModel->fFieldZero->GetSubFields()) {
@@ -102,20 +196,31 @@ void ROOT::Experimental::RNTupleModel::AddField(std::unique_ptr<Detail::RFieldBa
 }
 
 ROOT::Experimental::RResult<void>
-ROOT::Experimental::RNTupleModel::AddProjectedField(std::unique_ptr<Detail::RFieldBase> field, FieldMapper_t mapping)
+ROOT::Experimental::RNTupleModel::AddProjectedField(std::unique_ptr<Detail::RFieldBase> field,
+                                                    std::function<std::string(const std::string &)> mapping)
 {
    EnsureNotFrozen();
    if (!field)
       throw RException(R__FAIL("null field"));
 
-   printf("MAPPING %s\n", field->GetName().c_str());
-   mapping(*field);
+   RProjectedFields::FieldMap_t fieldMap;
+   auto sourceField = GetField(mapping(field->GetName()));
+   if (!sourceField)
+      return R__FAIL("no such field: " + mapping(field->GetName()));
+   fieldMap[field.get()] = sourceField;
    for (const auto &subField : *field) {
-      printf("MAPPING %s\n", subField.GetName().c_str());
-      auto mappedField = mapping(subField);
+      sourceField = GetField(mapping(subField.GetQualifiedFieldName()));
+      if (!sourceField)
+         return R__FAIL("no such field: " + mapping(field->GetName()));
+      fieldMap[&subField] = sourceField;
    }
 
    EnsureValidFieldName(field->GetName());
+   auto result = fProjectedFields->Add(std::move(field), fieldMap);
+   if (!result) {
+      fFieldNames.erase(field->GetName());
+      return R__FORWARD_ERROR(result);
+   }
    return RResult<void>::Success();
 }
 

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -22,7 +22,6 @@
 #include <atomic>
 #include <cstdlib>
 #include <memory>
-#include <typeinfo>
 #include <utility>
 
 ROOT::Experimental::RResult<void>
@@ -33,7 +32,7 @@ ROOT::Experimental::RNTupleModel::RProjectedFields::EnsureValidMapping(const Det
    if (source->GetStructure() != target->GetStructure())
       return R__FAIL("field mapping structural mismatch: " + source->GetName() + " --> " + target->GetName());
    if (target->GetStructure() == ENTupleStructure::kLeaf) {
-      if (typeid(*target) != typeid(*source))
+      if (target->GetType() != source->GetType())
          return R__FAIL("field mapping type mismatch: " + source->GetName() + " --> " + target->GetName());
    }
 

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -68,7 +68,7 @@ ROOT::Experimental::RNTupleModel::RProjectedFields::EnsureValidMapping(const Det
          // Source and target are children of the same collection
          return RResult<void>::Success();
       }
-      if ((fieldMap.find(targetBreakPoint) != fieldMap.end()) && (fieldMap.at(targetBreakPoint) == sourceBreakPoint)) {
+      if (auto it = fieldMap.find(targetBreakPoint); it != fieldMap.end() && it->second == sourceBreakPoint) {
          // The parent collection of parent is mapped to the parent collection of the source
          return RResult<void>::Success();
       }
@@ -101,8 +101,8 @@ ROOT::Experimental::RNTupleModel::RProjectedFields::Add(std::unique_ptr<Detail::
 const ROOT::Experimental::Detail::RFieldBase *
 ROOT::Experimental::RNTupleModel::RProjectedFields::GetSourceField(const Detail::RFieldBase *target) const
 {
-   if (fFieldMap.find(target) != fFieldMap.end())
-      return fFieldMap.at(target);
+   if (auto it = fFieldMap.find(target); it != fFieldMap.end())
+      return it->second;
    return nullptr;
 }
 

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -1246,18 +1246,18 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::Internal::RNTupleSerialize
    result = DeserializeFrameHeader(bytes, fnBufSizeLeft(), frameSize, nAliasColumns);
    if (!result)
       return R__FORWARD_ERROR(result);
-   bytes += result.Unwrap();
    if (nAliasColumns > 0)
       R__LOG_WARNING(NTupleLog()) << "Alias columns are still unsupported! ";
+   bytes = frame + frameSize;
 
    std::uint32_t nTypeInfo;
    frame = bytes;
    result = DeserializeFrameHeader(bytes, fnBufSizeLeft(), frameSize, nTypeInfo);
    if (!result)
       return R__FORWARD_ERROR(result);
-   bytes += result.Unwrap();
    if (nTypeInfo > 0)
       R__LOG_WARNING(NTupleLog()) << "Extra type information is still unsupported! ";
+   bytes = frame + frameSize;
 
    return RResult<void>::Success();
 }

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -180,6 +180,9 @@ std::uint32_t SerializeColumnListV1(
       idQueue.pop_front();
 
       for (const auto &c : desc.GetColumnIterable(parentId)) {
+         if (c.IsAliasColumn())
+            continue;
+
          auto frame = pos;
          pos += RNTupleSerializer::SerializeRecordFramePreamble(*where);
 
@@ -198,7 +201,7 @@ std::uint32_t SerializeColumnListV1(
 
          pos += RNTupleSerializer::SerializeFramePostscript(buffer ? frame : nullptr, pos - frame);
 
-         context.MapColumnId(c.GetId());
+         context.MapColumnId(c.GetLogicalId());
       }
 
       for (const auto &f : desc.GetFieldIterable(parentId))
@@ -1220,7 +1223,7 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::Internal::RNTupleSerialize
          idx = maxIdx->second + 1;
       maxIndexes[fieldId] = idx;
 
-      auto columnDesc = columnBuilder.Index(idx).ColumnId(columnId).MakeDescriptor();
+      auto columnDesc = columnBuilder.Index(idx).LogicalColumnId(columnId).PhysicalColumnId(columnId).MakeDescriptor();
       if (!columnDesc)
          return R__FORWARD_ERROR(columnDesc);
       auto resVoid = descBuilder.AddColumn(columnDesc.Unwrap());

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -302,8 +302,6 @@ void DeserializeLocatorPayloadObject64(const unsigned char *buffer, ROOT::Experi
 std::uint32_t SerializeAliasColumnList(const ROOT::Experimental::RNTupleDescriptor &desc,
                                        ROOT::Experimental::Internal::RNTupleSerializer::RContext &context, void *buffer)
 {
-   using RNTupleSerializer = ROOT::Experimental::Internal::RNTupleSerializer;
-
    auto base = reinterpret_cast<unsigned char *>(buffer);
    auto pos = base;
    void **where = (buffer == nullptr) ? &buffer : reinterpret_cast<void **>(&pos);
@@ -338,8 +336,6 @@ std::uint32_t SerializeAliasColumnList(const ROOT::Experimental::RNTupleDescript
 RResult<std::uint32_t> DeserializeAliasColumn(const void *buffer, std::uint32_t bufSize,
                                               std::uint32_t &physicalColumnId, std::uint32_t &fieldId)
 {
-   using RNTupleSerializer = ROOT::Experimental::Internal::RNTupleSerializer;
-
    auto base = reinterpret_cast<const unsigned char *>(buffer);
    auto bytes = base;
    std::uint32_t frameSize;

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -984,7 +984,7 @@ ROOT::Experimental::Internal::RNTupleSerializer::SerializeHeaderV1(
    pos += SerializeFramePostscript(buffer ? frame : nullptr, pos - frame);
 
    frame = pos;
-   pos += SerializeListFramePreamble(desc.GetNColumns(), *where);
+   pos += SerializeListFramePreamble(desc.GetNPhysicalColumns(), *where);
    pos += SerializeColumnListV1(desc, context, *where);
    pos += SerializeFramePostscript(buffer ? frame : nullptr, pos - frame);
 

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -1411,7 +1411,7 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::Internal::RNTupleSerialize
          bytes += result.Unwrap();
 
          RClusterDescriptor::RPageRange pageRange;
-         pageRange.fColumnId = j;
+         pageRange.fPhysicalColumnId = j;
          for (std::uint32_t k = 0; k < nPages; ++k) {
             if (fnInnerFrameSizeLeft() < static_cast<int>(sizeof(std::uint32_t)))
                return R__FAIL("inner frame too short");

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -34,8 +34,8 @@ using RResult = ROOT::Experimental::RResult<T>;
 namespace {
 using RNTupleSerializer = ROOT::Experimental::Internal::RNTupleSerializer;
 
-std::uint32_t SerializeFieldV1(
-   const ROOT::Experimental::RFieldDescriptor &fieldDesc, ROOT::Experimental::DescriptorId_t physParentId, void *buffer)
+std::uint32_t SerializeFieldV1(const ROOT::Experimental::RFieldDescriptor &fieldDesc,
+                               ROOT::Experimental::DescriptorId_t onDiskParentId, bool isAliasField, void *buffer)
 {
 
    auto base = reinterpret_cast<unsigned char *>(buffer);
@@ -46,13 +46,15 @@ std::uint32_t SerializeFieldV1(
 
    pos += RNTupleSerializer::SerializeUInt32(fieldDesc.GetFieldVersion(), *where);
    pos += RNTupleSerializer::SerializeUInt32(fieldDesc.GetTypeVersion(), *where);
-   pos += RNTupleSerializer::SerializeUInt32(physParentId, *where);
+   pos += RNTupleSerializer::SerializeUInt32(onDiskParentId, *where);
    pos += RNTupleSerializer::SerializeFieldStructure(fieldDesc.GetStructure(), *where);
+   std::uint16_t flags = isAliasField ? RNTupleSerializer::kFlagAliasField : 0;
    if (fieldDesc.GetNRepetitions() > 0) {
-      pos += RNTupleSerializer::SerializeUInt16(RNTupleSerializer::kFlagRepetitiveField, *where);
+      flags |= RNTupleSerializer::kFlagRepetitiveField;
+      pos += RNTupleSerializer::SerializeUInt16(flags, *where);
       pos += RNTupleSerializer::SerializeUInt64(fieldDesc.GetNRepetitions(), *where);
    } else {
-      pos += RNTupleSerializer::SerializeUInt16(0, *where);
+      pos += RNTupleSerializer::SerializeUInt16(flags, *where);
    }
    pos += RNTupleSerializer::SerializeString(fieldDesc.GetFieldName(), *where);
    pos += RNTupleSerializer::SerializeString(fieldDesc.GetTypeName(), *where);
@@ -83,7 +85,14 @@ std::uint32_t SerializeFieldTree(
       for (const auto &f : desc.GetFieldIterable(parentId)) {
          auto onDiskFieldId = context.MapFieldId(f.GetId());
          auto onDiskParentId = (parentId == desc.GetFieldZeroId()) ? onDiskFieldId : context.GetOnDiskFieldId(parentId);
-         pos += SerializeFieldV1(f, onDiskParentId, *where);
+         bool isAliasField = false;
+         for (const auto &c : desc.GetColumnIterable(f.GetId())) {
+            if (c.IsAliasColumn()) {
+               isAliasField = true;
+               break;
+            }
+         }
+         pos += SerializeFieldV1(f, onDiskParentId, isAliasField, *where);
          idQueue.push_back(f.GetId());
       }
    }

--- a/tree/ntuple/v7/src/RPagePool.cxx
+++ b/tree/ntuple/v7/src/RPagePool.cxx
@@ -59,15 +59,14 @@ void ROOT::Experimental::Detail::RPagePool::ReturnPage(const RPage& page)
    R__ASSERT(false);
 }
 
-ROOT::Experimental::Detail::RPage
-ROOT::Experimental::Detail::RPagePool::GetPage(ColumnId_t physicalColumnId, NTupleSize_t globalIndex)
+ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPagePool::GetPage(
+   ColumnId_t columnId, NTupleSize_t globalIndex)
 {
    std::lock_guard<std::mutex> lockGuard(fLock);
    unsigned int N = fPages.size();
    for (unsigned int i = 0; i < N; ++i) {
       if (fReferences[i] < 0) continue;
-      if (fPages[i].GetPhysicalColumnId() != physicalColumnId)
-         continue;
+      if (fPages[i].GetColumnId() != columnId) continue;
       if (!fPages[i].Contains(globalIndex)) continue;
       fReferences[i]++;
       return fPages[i];
@@ -75,15 +74,14 @@ ROOT::Experimental::Detail::RPagePool::GetPage(ColumnId_t physicalColumnId, NTup
    return RPage();
 }
 
-ROOT::Experimental::Detail::RPage
-ROOT::Experimental::Detail::RPagePool::GetPage(ColumnId_t physicalColumnId, const RClusterIndex &clusterIndex)
+ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPagePool::GetPage(
+   ColumnId_t columnId, const RClusterIndex &clusterIndex)
 {
    std::lock_guard<std::mutex> lockGuard(fLock);
    unsigned int N = fPages.size();
    for (unsigned int i = 0; i < N; ++i) {
       if (fReferences[i] < 0) continue;
-      if (fPages[i].GetPhysicalColumnId() != physicalColumnId)
-         continue;
+      if (fPages[i].GetColumnId() != columnId) continue;
       if (!fPages[i].Contains(clusterIndex)) continue;
       fReferences[i]++;
       return fPages[i];

--- a/tree/ntuple/v7/src/RPagePool.cxx
+++ b/tree/ntuple/v7/src/RPagePool.cxx
@@ -59,14 +59,15 @@ void ROOT::Experimental::Detail::RPagePool::ReturnPage(const RPage& page)
    R__ASSERT(false);
 }
 
-ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPagePool::GetPage(
-   ColumnId_t columnId, NTupleSize_t globalIndex)
+ROOT::Experimental::Detail::RPage
+ROOT::Experimental::Detail::RPagePool::GetPage(ColumnId_t physicalColumnId, NTupleSize_t globalIndex)
 {
    std::lock_guard<std::mutex> lockGuard(fLock);
    unsigned int N = fPages.size();
    for (unsigned int i = 0; i < N; ++i) {
       if (fReferences[i] < 0) continue;
-      if (fPages[i].GetColumnId() != columnId) continue;
+      if (fPages[i].GetPhysicalColumnId() != physicalColumnId)
+         continue;
       if (!fPages[i].Contains(globalIndex)) continue;
       fReferences[i]++;
       return fPages[i];
@@ -74,14 +75,15 @@ ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPagePool::GetPage
    return RPage();
 }
 
-ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPagePool::GetPage(
-   ColumnId_t columnId, const RClusterIndex &clusterIndex)
+ROOT::Experimental::Detail::RPage
+ROOT::Experimental::Detail::RPagePool::GetPage(ColumnId_t physicalColumnId, const RClusterIndex &clusterIndex)
 {
    std::lock_guard<std::mutex> lockGuard(fLock);
    unsigned int N = fPages.size();
    for (unsigned int i = 0; i < N; ++i) {
       if (fReferences[i] < 0) continue;
-      if (fPages[i].GetColumnId() != columnId) continue;
+      if (fPages[i].GetPhysicalColumnId() != physicalColumnId)
+         continue;
       if (!fPages[i].Contains(clusterIndex)) continue;
       fReferences[i]++;
       return fPages[i];

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -76,10 +76,10 @@ ROOT::Experimental::Detail::RPageSinkBuf::CommitPageImpl(ColumnHandle_t columnHa
 }
 
 ROOT::Experimental::RNTupleLocator
-ROOT::Experimental::Detail::RPageSinkBuf::CommitSealedPageImpl(
-   DescriptorId_t columnId, const RSealedPage &sealedPage)
+ROOT::Experimental::Detail::RPageSinkBuf::CommitSealedPageImpl(DescriptorId_t physicalColumnId,
+                                                               const RSealedPage &sealedPage)
 {
-   fInnerSink->CommitSealedPage(columnId, sealedPage);
+   fInnerSink->CommitSealedPage(physicalColumnId, sealedPage);
    // we're feeding bad locators to fOpenPageRanges but it should not matter
    // because they never get written out
    return RNTupleLocator{};

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -37,7 +37,7 @@ void ROOT::Experimental::Detail::RPageSinkBuf::CreateImpl(const RNTupleModel &mo
                                                           unsigned char * /* serializedHeader */,
                                                           std::uint32_t /* length */)
 {
-   fBufferedColumns.resize(fDescriptorBuilder.GetDescriptor().GetNColumns());
+   fBufferedColumns.resize(fDescriptorBuilder.GetDescriptor().GetNPhysicalColumns());
    fInnerModel = model.Clone();
    fInnerSink->Create(*fInnerModel);
 }

--- a/tree/ntuple/v7/src/RPageSourceFriends.cxx
+++ b/tree/ntuple/v7/src/RPageSourceFriends.cxx
@@ -54,7 +54,7 @@ void ROOT::Experimental::Detail::RPageSourceFriends::AddVirtualField(const RNTup
 
    for (const auto &c: originDesc.GetColumnIterable(originField)) {
       fBuilder.AddColumn(fNextId, virtualFieldId, c.GetModel(), c.GetIndex());
-      fIdBiMap.Insert({originIdx, c.GetId()}, fNextId);
+      fIdBiMap.Insert({originIdx, c.GetLogicalId()}, fNextId);
       fNextId++;
    }
 }

--- a/tree/ntuple/v7/src/RPageSourceFriends.cxx
+++ b/tree/ntuple/v7/src/RPageSourceFriends.cxx
@@ -96,7 +96,7 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceFri
             DescriptorId_t virtualColumnId = fIdBiMap.GetVirtualId({i, originColumnId});
 
             auto pageRange = c.GetPageRange(originColumnId).Clone();
-            pageRange.fColumnId = virtualColumnId;
+            pageRange.fPhysicalColumnId = virtualColumnId;
 
             auto firstElementIndex = c.GetColumnRange(originColumnId).fFirstElementIndex;
             auto compressionSettings = c.GetColumnRange(originColumnId).fCompressionSettings;

--- a/tree/ntuple/v7/src/RPageSourceFriends.cxx
+++ b/tree/ntuple/v7/src/RPageSourceFriends.cxx
@@ -175,16 +175,16 @@ ROOT::Experimental::Detail::RPageSourceFriends::PopulatePage(
    return page;
 }
 
-
-void ROOT::Experimental::Detail::RPageSourceFriends::LoadSealedPage(
-   DescriptorId_t columnId, const RClusterIndex &clusterIndex, RSealedPage &sealedPage)
+void ROOT::Experimental::Detail::RPageSourceFriends::LoadSealedPage(DescriptorId_t physicalColumnId,
+                                                                    const RClusterIndex &clusterIndex,
+                                                                    RSealedPage &sealedPage)
 {
-   auto originColumnId = fIdBiMap.GetOriginId(columnId);
+   auto originColumnId = fIdBiMap.GetOriginId(physicalColumnId);
    RClusterIndex originClusterIndex(
       fIdBiMap.GetOriginId(clusterIndex.GetClusterId()).fId,
       clusterIndex.GetIndex());
 
-   fSources[originColumnId.fSourceIdx]->LoadSealedPage(columnId, originClusterIndex, sealedPage);
+   fSources[originColumnId.fSourceIdx]->LoadSealedPage(physicalColumnId, originClusterIndex, sealedPage);
 }
 
 

--- a/tree/ntuple/v7/src/RPageSourceFriends.cxx
+++ b/tree/ntuple/v7/src/RPageSourceFriends.cxx
@@ -135,8 +135,8 @@ ROOT::Experimental::Detail::RPageSourceFriends::AddColumn(DescriptorId_t fieldId
 void ROOT::Experimental::Detail::RPageSourceFriends::DropColumn(ColumnHandle_t columnHandle)
 {
    RPageSource::DropColumn(columnHandle);
-   auto originColumnId = fIdBiMap.GetOriginId(columnHandle.fId);
-   columnHandle.fId = originColumnId.fId;
+   auto originColumnId = fIdBiMap.GetOriginId(columnHandle.fPhysicalId);
+   columnHandle.fPhysicalId = originColumnId.fId;
    fSources[originColumnId.fSourceIdx]->DropColumn(columnHandle);
 }
 
@@ -145,9 +145,9 @@ ROOT::Experimental::Detail::RPage
 ROOT::Experimental::Detail::RPageSourceFriends::PopulatePage(
    ColumnHandle_t columnHandle, NTupleSize_t globalIndex)
 {
-   auto virtualColumnId = columnHandle.fId;
+   auto virtualColumnId = columnHandle.fPhysicalId;
    auto originColumnId = fIdBiMap.GetOriginId(virtualColumnId);
-   columnHandle.fId = originColumnId.fId;
+   columnHandle.fPhysicalId = originColumnId.fId;
 
    auto page = fSources[originColumnId.fSourceIdx]->PopulatePage(columnHandle, globalIndex);
 
@@ -162,12 +162,12 @@ ROOT::Experimental::Detail::RPage
 ROOT::Experimental::Detail::RPageSourceFriends::PopulatePage(
    ColumnHandle_t columnHandle, const RClusterIndex &clusterIndex)
 {
-   auto virtualColumnId = columnHandle.fId;
+   auto virtualColumnId = columnHandle.fPhysicalId;
    auto originColumnId = fIdBiMap.GetOriginId(virtualColumnId);
    RClusterIndex originClusterIndex(
       fIdBiMap.GetOriginId(clusterIndex.GetClusterId()).fId,
       clusterIndex.GetIndex());
-   columnHandle.fId = originColumnId.fId;
+   columnHandle.fPhysicalId = originColumnId.fId;
 
    auto page = fSources[originColumnId.fSourceIdx]->PopulatePage(columnHandle, originClusterIndex);
 

--- a/tree/ntuple/v7/src/RPageSourceFriends.cxx
+++ b/tree/ntuple/v7/src/RPageSourceFriends.cxx
@@ -53,7 +53,8 @@ void ROOT::Experimental::Detail::RPageSourceFriends::AddVirtualField(const RNTup
       AddVirtualField(originDesc, originIdx, f, virtualFieldId, f.GetFieldName());
 
    for (const auto &c: originDesc.GetColumnIterable(originField)) {
-      fBuilder.AddColumn(fNextId, virtualFieldId, c.GetModel(), c.GetIndex());
+      auto physicalId = c.IsAliasColumn() ? fIdBiMap.GetVirtualId({originIdx, c.GetPhysicalId()}) : fNextId;
+      fBuilder.AddColumn(fNextId, physicalId, virtualFieldId, c.GetModel(), c.GetIndex());
       fIdBiMap.Insert({originIdx, c.GetLogicalId()}, fNextId);
       fNextId++;
    }

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -99,8 +99,9 @@ ROOT::Experimental::NTupleSize_t ROOT::Experimental::Detail::RPageSource::GetNEl
    return GetSharedDescriptorGuard()->GetNElements(columnHandle.fPhysicalId);
 }
 
-ROOT::Experimental::ColumnId_t ROOT::Experimental::Detail::RPageSource::GetPhysicalColumnId(ColumnHandle_t columnHandle)
+ROOT::Experimental::ColumnId_t ROOT::Experimental::Detail::RPageSource::GetColumnId(ColumnHandle_t columnHandle)
 {
+   // TODO(jblomer) distinguish trees
    return columnHandle.fPhysicalId;
 }
 

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -304,7 +304,7 @@ std::unique_ptr<ROOT::Experimental::Detail::RPageSink> ROOT::Experimental::Detai
 ROOT::Experimental::Detail::RPageStorage::ColumnHandle_t
 ROOT::Experimental::Detail::RPageSink::AddColumn(DescriptorId_t fieldId, const RColumn &column)
 {
-   auto columnId = fDescriptorBuilder.GetDescriptor().GetNColumns();
+   auto columnId = fDescriptorBuilder.GetDescriptor().GetNPhysicalColumns();
    fDescriptorBuilder.AddColumn(columnId, columnId, fieldId, column.GetModel(), column.GetIndex());
    return ColumnHandle_t{columnId, &column};
 }
@@ -326,7 +326,7 @@ void ROOT::Experimental::Detail::RPageSink::Create(RNTupleModel &model)
       f.ConnectPageSink(*this); // issues in turn one or several calls to AddColumn()
    }
 
-   auto nColumns = descriptor.GetNColumns();
+   auto nColumns = descriptor.GetNPhysicalColumns();
    for (DescriptorId_t i = 0; i < nColumns; ++i) {
       RClusterDescriptor::RColumnRange columnRange;
       columnRange.fPhysicalColumnId = i;

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -324,17 +324,16 @@ void ROOT::Experimental::Detail::RPageSink::CommitPage(ColumnHandle_t columnHand
    fOpenPageRanges.at(columnHandle.fPhysicalId).fPageInfos.emplace_back(pageInfo);
 }
 
-
 void ROOT::Experimental::Detail::RPageSink::CommitSealedPage(
-   ROOT::Experimental::DescriptorId_t columnId,
+   ROOT::Experimental::DescriptorId_t physicalColumnId,
    const ROOT::Experimental::Detail::RPageStorage::RSealedPage &sealedPage)
 {
-   fOpenColumnRanges.at(columnId).fNElements += sealedPage.fNElements;
+   fOpenColumnRanges.at(physicalColumnId).fNElements += sealedPage.fNElements;
 
    RClusterDescriptor::RPageRange::RPageInfo pageInfo;
    pageInfo.fNElements = sealedPage.fNElements;
-   pageInfo.fLocator = CommitSealedPageImpl(columnId, sealedPage);
-   fOpenPageRanges.at(columnId).fPageInfos.emplace_back(pageInfo);
+   pageInfo.fLocator = CommitSealedPageImpl(physicalColumnId, sealedPage);
+   fOpenPageRanges.at(physicalColumnId).fPageInfos.emplace_back(pageInfo);
 }
 
 std::vector<ROOT::Experimental::RNTupleLocator>

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -86,7 +86,7 @@ ROOT::Experimental::Detail::RPageSource::AddColumn(DescriptorId_t fieldId, const
 
 void ROOT::Experimental::Detail::RPageSource::DropColumn(ColumnHandle_t columnHandle)
 {
-   fActiveColumns.erase(columnHandle.fId);
+   fActiveColumns.erase(columnHandle.fPhysicalId);
 }
 
 ROOT::Experimental::NTupleSize_t ROOT::Experimental::Detail::RPageSource::GetNEntries()
@@ -96,13 +96,13 @@ ROOT::Experimental::NTupleSize_t ROOT::Experimental::Detail::RPageSource::GetNEn
 
 ROOT::Experimental::NTupleSize_t ROOT::Experimental::Detail::RPageSource::GetNElements(ColumnHandle_t columnHandle)
 {
-   return GetSharedDescriptorGuard()->GetNElements(columnHandle.fId);
+   return GetSharedDescriptorGuard()->GetNElements(columnHandle.fPhysicalId);
 }
 
 ROOT::Experimental::ColumnId_t ROOT::Experimental::Detail::RPageSource::GetColumnId(ColumnHandle_t columnHandle)
 {
    // TODO(jblomer) distinguish trees
-   return columnHandle.fId;
+   return columnHandle.fPhysicalId;
 }
 
 void ROOT::Experimental::Detail::RPageSource::UnzipCluster(RCluster *cluster)
@@ -316,12 +316,12 @@ void ROOT::Experimental::Detail::RPageSink::Create(RNTupleModel &model)
 
 void ROOT::Experimental::Detail::RPageSink::CommitPage(ColumnHandle_t columnHandle, const RPage &page)
 {
-   fOpenColumnRanges.at(columnHandle.fId).fNElements += page.GetNElements();
+   fOpenColumnRanges.at(columnHandle.fPhysicalId).fNElements += page.GetNElements();
 
    RClusterDescriptor::RPageRange::RPageInfo pageInfo;
    pageInfo.fNElements = page.GetNElements();
    pageInfo.fLocator = CommitPageImpl(columnHandle, page);
-   fOpenPageRanges.at(columnHandle.fId).fPageInfos.emplace_back(pageInfo);
+   fOpenPageRanges.at(columnHandle.fPhysicalId).fPageInfos.emplace_back(pageInfo);
 }
 
 

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -305,7 +305,7 @@ ROOT::Experimental::Detail::RPageStorage::ColumnHandle_t
 ROOT::Experimental::Detail::RPageSink::AddColumn(DescriptorId_t fieldId, const RColumn &column)
 {
    auto columnId = fDescriptorBuilder.GetDescriptor().GetNColumns();
-   fDescriptorBuilder.AddColumn(columnId, fieldId, column.GetModel(), column.GetIndex());
+   fDescriptorBuilder.AddColumn(columnId, columnId, fieldId, column.GetModel(), column.GetIndex());
    return ColumnHandle_t{columnId, &column};
 }
 

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -329,7 +329,7 @@ void ROOT::Experimental::Detail::RPageSink::Create(RNTupleModel &model)
    auto nColumns = descriptor.GetNColumns();
    for (DescriptorId_t i = 0; i < nColumns; ++i) {
       RClusterDescriptor::RColumnRange columnRange;
-      columnRange.fColumnId = i;
+      columnRange.fPhysicalColumnId = i;
       columnRange.fFirstElementIndex = 0;
       columnRange.fNElements = 0;
       columnRange.fCompressionSettings = GetWriteOptions().GetCompression();

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -99,9 +99,8 @@ ROOT::Experimental::NTupleSize_t ROOT::Experimental::Detail::RPageSource::GetNEl
    return GetSharedDescriptorGuard()->GetNElements(columnHandle.fPhysicalId);
 }
 
-ROOT::Experimental::ColumnId_t ROOT::Experimental::Detail::RPageSource::GetColumnId(ColumnHandle_t columnHandle)
+ROOT::Experimental::ColumnId_t ROOT::Experimental::Detail::RPageSource::GetPhysicalColumnId(ColumnHandle_t columnHandle)
 {
-   // TODO(jblomer) distinguish trees
    return columnHandle.fPhysicalId;
 }
 

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -111,10 +111,10 @@ ROOT::Experimental::Detail::RPageStorage::ColumnHandle_t
 ROOT::Experimental::Detail::RPageSource::AddColumn(DescriptorId_t fieldId, const RColumn &column)
 {
    R__ASSERT(fieldId != kInvalidDescriptorId);
-   auto columnId = GetSharedDescriptorGuard()->FindColumnId(fieldId, column.GetIndex());
-   R__ASSERT(columnId != kInvalidDescriptorId);
-   fActivePhysicalColumns.Insert(columnId);
-   return ColumnHandle_t{columnId, &column};
+   auto physicalId = GetSharedDescriptorGuard()->FindPhysicalColumnId(fieldId, column.GetIndex());
+   R__ASSERT(physicalId != kInvalidDescriptorId);
+   fActivePhysicalColumns.Insert(physicalId);
+   return ColumnHandle_t{physicalId, &column};
 }
 
 void ROOT::Experimental::Detail::RPageSource::DropColumn(ColumnHandle_t columnHandle)

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -45,24 +45,24 @@ ROOT::Experimental::Detail::RPageStorage::~RPageStorage()
 
 //------------------------------------------------------------------------------
 
-void ROOT::Experimental::Detail::RPageSource::RActiveColumns::Insert(DescriptorId_t physicalColumnID)
+void ROOT::Experimental::Detail::RPageSource::RActivePhysicalColumns::Insert(DescriptorId_t physicalColumnID)
 {
-   for (unsigned i = 0; i < fPhysicalColumnIDs.size(); ++i) {
-      if (fPhysicalColumnIDs[i] == physicalColumnID) {
+   for (unsigned i = 0; i < fIDs.size(); ++i) {
+      if (fIDs[i] == physicalColumnID) {
          fRefCounters[i]++;
          return;
       }
    }
-   fPhysicalColumnIDs.emplace_back(physicalColumnID);
+   fIDs.emplace_back(physicalColumnID);
    fRefCounters.emplace_back(1);
 }
 
-void ROOT::Experimental::Detail::RPageSource::RActiveColumns::Erase(DescriptorId_t physicalColumnID)
+void ROOT::Experimental::Detail::RPageSource::RActivePhysicalColumns::Erase(DescriptorId_t physicalColumnID)
 {
-   for (unsigned i = 0; i < fPhysicalColumnIDs.size(); ++i) {
-      if (fPhysicalColumnIDs[i] == physicalColumnID) {
+   for (unsigned i = 0; i < fIDs.size(); ++i) {
+      if (fIDs[i] == physicalColumnID) {
          if (--fRefCounters[i] == 0) {
-            fPhysicalColumnIDs.erase(fPhysicalColumnIDs.begin() + i);
+            fIDs.erase(fIDs.begin() + i);
             fRefCounters.erase(fRefCounters.begin() + i);
          }
          return;
@@ -70,10 +70,11 @@ void ROOT::Experimental::Detail::RPageSource::RActiveColumns::Erase(DescriptorId
    }
 }
 
-ROOT::Experimental::Detail::RCluster::ColumnSet_t ROOT::Experimental::Detail::RPageSource::RActiveColumns::ToColumnSet()
+ROOT::Experimental::Detail::RCluster::ColumnSet_t
+ROOT::Experimental::Detail::RPageSource::RActivePhysicalColumns::ToColumnSet()
 {
    RCluster::ColumnSet_t result;
-   for (const auto &id : fPhysicalColumnIDs)
+   for (const auto &id : fIDs)
       result.insert(id);
    return result;
 }
@@ -112,13 +113,13 @@ ROOT::Experimental::Detail::RPageSource::AddColumn(DescriptorId_t fieldId, const
    R__ASSERT(fieldId != kInvalidDescriptorId);
    auto columnId = GetSharedDescriptorGuard()->FindColumnId(fieldId, column.GetIndex());
    R__ASSERT(columnId != kInvalidDescriptorId);
-   fActiveColumns.Insert(columnId);
+   fActivePhysicalColumns.Insert(columnId);
    return ColumnHandle_t{columnId, &column};
 }
 
 void ROOT::Experimental::Detail::RPageSource::DropColumn(ColumnHandle_t columnHandle)
 {
-   fActiveColumns.Erase(columnHandle.fPhysicalId);
+   fActivePhysicalColumns.Erase(columnHandle.fPhysicalId);
 }
 
 ROOT::Experimental::NTupleSize_t ROOT::Experimental::Detail::RPageSource::GetNEntries()

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -343,7 +343,7 @@ ROOT::Experimental::Detail::RPageSink::CommitSealedPageVImpl(std::span<RPageStor
    std::vector<ROOT::Experimental::RNTupleLocator> locators;
    for (auto &range : ranges) {
       for (auto sealedPageIt = range.fFirst; sealedPageIt != range.fLast; ++sealedPageIt)
-         locators.push_back(CommitSealedPageImpl(range.fColumnId, *sealedPageIt));
+         locators.push_back(CommitSealedPageImpl(range.fPhysicalColumnId, *sealedPageIt));
    }
    return locators;
 }
@@ -355,12 +355,12 @@ void ROOT::Experimental::Detail::RPageSink::CommitSealedPageV(std::span<RPageSto
 
    for (auto &range : ranges) {
       for (auto sealedPageIt = range.fFirst; sealedPageIt != range.fLast; ++sealedPageIt) {
-         fOpenColumnRanges.at(range.fColumnId).fNElements += sealedPageIt->fNElements;
+         fOpenColumnRanges.at(range.fPhysicalColumnId).fNElements += sealedPageIt->fNElements;
 
          RClusterDescriptor::RPageRange::RPageInfo pageInfo;
          pageInfo.fNElements = sealedPageIt->fNElements;
          pageInfo.fLocator = locators[i++];
-         fOpenPageRanges.at(range.fColumnId).fPageInfos.emplace_back(pageInfo);
+         fOpenPageRanges.at(range.fPhysicalColumnId).fPageInfos.emplace_back(pageInfo);
       }
    }
 }

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -335,7 +335,7 @@ void ROOT::Experimental::Detail::RPageSink::Create(RNTupleModel &model)
       columnRange.fCompressionSettings = GetWriteOptions().GetCompression();
       fOpenColumnRanges.emplace_back(columnRange);
       RClusterDescriptor::RPageRange pageRange;
-      pageRange.fColumnId = i;
+      pageRange.fPhysicalColumnId = i;
       fOpenPageRanges.emplace_back(std::move(pageRange));
    }
 
@@ -407,7 +407,7 @@ std::uint64_t ROOT::Experimental::Detail::RPageSink::CommitCluster(ROOT::Experim
                                             nEntriesInCluster);
    for (unsigned int i = 0; i < fOpenColumnRanges.size(); ++i) {
       RClusterDescriptor::RPageRange fullRange;
-      fullRange.fColumnId = i;
+      fullRange.fPhysicalColumnId = i;
       std::swap(fullRange, fOpenPageRanges[i]);
       clusterBuilder.CommitColumnRange(i, fOpenColumnRanges[i].fFirstElementIndex,
                                        fOpenColumnRanges[i].fCompressionSettings, fullRange);

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -71,7 +71,7 @@ void ROOT::Experimental::Detail::RPageSource::RActivePhysicalColumns::Erase(Desc
 }
 
 ROOT::Experimental::Detail::RCluster::ColumnSet_t
-ROOT::Experimental::Detail::RPageSource::RActivePhysicalColumns::ToColumnSet()
+ROOT::Experimental::Detail::RPageSource::RActivePhysicalColumns::ToColumnSet() const
 {
    RCluster::ColumnSet_t result;
    for (const auto &id : fIDs)

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -541,7 +541,7 @@ ROOT::Experimental::Detail::RPageSourceDaos::PopulatePageFromCluster(ColumnHandl
       sealedPageBuffer = directReadBuffer.get();
    } else {
       if (!fCurrentCluster || (fCurrentCluster->GetId() != clusterId) || !fCurrentCluster->ContainsColumn(columnId))
-         fCurrentCluster = fClusterPool->GetCluster(clusterId, fActiveColumns);
+         fCurrentCluster = fClusterPool->GetCluster(clusterId, fActiveColumns.ToColumnSet());
       R__ASSERT(fCurrentCluster->ContainsColumn(columnId));
 
       auto cachedPage = fPagePool->GetPage(columnId, RClusterIndex(clusterId, idxInCluster));

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -541,7 +541,7 @@ ROOT::Experimental::Detail::RPageSourceDaos::PopulatePageFromCluster(ColumnHandl
       sealedPageBuffer = directReadBuffer.get();
    } else {
       if (!fCurrentCluster || (fCurrentCluster->GetId() != clusterId) || !fCurrentCluster->ContainsColumn(columnId))
-         fCurrentCluster = fClusterPool->GetCluster(clusterId, fActiveColumns.ToColumnSet());
+         fCurrentCluster = fClusterPool->GetCluster(clusterId, fActivePhysicalColumns.ToColumnSet());
       R__ASSERT(fCurrentCluster->ContainsColumn(columnId));
 
       auto cachedPage = fPagePool->GetPage(columnId, RClusterIndex(clusterId, idxInCluster));

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -737,7 +737,7 @@ void ROOT::Experimental::Detail::RPageSourceDaos::UnzipClusterImpl(RCluster *clu
 
    std::vector<std::unique_ptr<RColumnElementBase>> allElements;
 
-   const auto &columnsInCluster = cluster->GetAvailColumns();
+   const auto &columnsInCluster = cluster->GetAvailPhysicalColumns();
    for (const auto columnId : columnsInCluster) {
       const auto &columnDesc = descriptorGuard->GetColumnDescriptor(columnId);
 

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -303,7 +303,8 @@ ROOT::Experimental::Detail::RPageSinkDaos::CommitSealedPageVImpl(std::span<RPage
          d_iov_set(&pageIov, const_cast<void *>(s.fBuffer), s.fSize);
          auto offsetData = fPageId.fetch_add(1);
 
-         RDaosKey daosKey = GetPageDaosKey<kDefaultDaosMapping>(fNTupleIndex, clusterId, range.fColumnId, offsetData);
+         RDaosKey daosKey =
+            GetPageDaosKey<kDefaultDaosMapping>(fNTupleIndex, clusterId, range.fPhysicalColumnId, offsetData);
          auto odPair = RDaosContainer::ROidDkeyPair{daosKey.fOid, daosKey.fDkey};
          auto [it, ret] = writeRequests.emplace(odPair, RDaosContainer::RWOperation(odPair));
          it->second.insert(daosKey.fAkey, pageIov);

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -668,12 +668,12 @@ ROOT::Experimental::Detail::RPageSourceDaos::LoadClusters(std::span<RCluster::RK
          const auto &clusterDesc = descriptorGuard->GetClusterDescriptor(clusterId);
 
          // Collect the necessary page meta-data and sum up the total size of the compressed and packed pages
-         for (auto columnId : clusterKey.fColumnSet) {
-            const auto &pageRange = clusterDesc.GetPageRange(columnId);
+         for (auto physicalColumnId : clusterKey.fPhysicalColumnSet) {
+            const auto &pageRange = clusterDesc.GetPageRange(physicalColumnId);
             NTupleSize_t columnPageCount = 0;
             for (const auto &pageInfo : pageRange.fPageInfos) {
                const auto &pageLocator = pageInfo.fLocator;
-               onDiskClusterPages.push_back(RDaosSealedPageLocator(clusterId, columnId, columnPageCount,
+               onDiskClusterPages.push_back(RDaosSealedPageLocator(clusterId, physicalColumnId, columnPageCount,
                                                                    pageLocator.GetPosition<std::uint64_t>(),
                                                                    pageLocator.fBytesOnStorage, clusterBufSz));
                ++columnPageCount;
@@ -718,7 +718,7 @@ ROOT::Experimental::Detail::RPageSourceDaos::LoadClusters(std::span<RCluster::RK
    for (unsigned i = 0; i < clusterKeys.size(); ++i) {
       auto cluster = std::make_unique<RCluster>(clusterKeys[i].fClusterId);
       cluster->Adopt(std::move(pageMaps[i]));
-      for (auto colId : clusterKeys[i].fColumnSet)
+      for (auto colId : clusterKeys[i].fPhysicalColumnSet)
          cluster->SetColumnAvailable(colId);
 
       result.emplace_back(std::move(cluster));

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -256,7 +256,7 @@ ROOT::Experimental::Detail::RPageSinkDaos::CommitPageImpl(ColumnHandle_t columnH
    }
 
    fCounters->fSzZip.Add(page.GetNBytes());
-   return CommitSealedPageImpl(columnHandle.fId, sealedPage);
+   return CommitSealedPageImpl(columnHandle.fPhysicalId, sealedPage);
 }
 
 ROOT::Experimental::RNTupleLocator
@@ -399,7 +399,7 @@ ROOT::Experimental::Detail::RPageSinkDaos::ReservePage(ColumnHandle_t columnHand
    if (nElements == 0)
       throw RException(R__FAIL("invalid call: request empty page"));
    auto elementSize = columnHandle.fColumn->GetElement()->GetSize();
-   return fPageAllocator->NewPage(columnHandle.fId, elementSize, nElements);
+   return fPageAllocator->NewPage(columnHandle.fPhysicalId, elementSize, nElements);
 }
 
 void ROOT::Experimental::Detail::RPageSinkDaos::ReleasePage(RPage &page)
@@ -517,7 +517,7 @@ ROOT::Experimental::Detail::RPageSourceDaos::PopulatePageFromCluster(ColumnHandl
                                                                      const RClusterInfo &clusterInfo,
                                                                      ClusterSize_t::ValueType idxInCluster)
 {
-   const auto columnId = columnHandle.fId;
+   const auto columnId = columnHandle.fPhysicalId;
    const auto clusterId = clusterInfo.fClusterId;
    const auto &pageInfo = clusterInfo.fPageInfo;
 
@@ -573,7 +573,7 @@ ROOT::Experimental::Detail::RPageSourceDaos::PopulatePageFromCluster(ColumnHandl
 ROOT::Experimental::Detail::RPage
 ROOT::Experimental::Detail::RPageSourceDaos::PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t globalIndex)
 {
-   const auto columnId = columnHandle.fId;
+   const auto columnId = columnHandle.fPhysicalId;
    auto cachedPage = fPagePool->GetPage(columnId, globalIndex);
    if (!cachedPage.IsNull())
       return cachedPage;
@@ -600,7 +600,7 @@ ROOT::Experimental::Detail::RPageSourceDaos::PopulatePage(ColumnHandle_t columnH
 {
    const auto clusterId = clusterIndex.GetClusterId();
    const auto idxInCluster = clusterIndex.GetIndex();
-   const auto columnId = columnHandle.fId;
+   const auto columnId = columnHandle.fPhysicalId;
    auto cachedPage = fPagePool->GetPage(columnId, clusterIndex);
    if (!cachedPage.IsNull())
       return cachedPage;

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -335,7 +335,7 @@ ROOT::Experimental::Detail::RPageSourceFile::PopulatePageFromCluster(ColumnHandl
       sealedPageBuffer = directReadBuffer.get();
    } else {
       if (!fCurrentCluster || (fCurrentCluster->GetId() != clusterId) || !fCurrentCluster->ContainsColumn(columnId))
-         fCurrentCluster = fClusterPool->GetCluster(clusterId, fActiveColumns);
+         fCurrentCluster = fClusterPool->GetCluster(clusterId, fActiveColumns.ToColumnSet());
       R__ASSERT(fCurrentCluster->ContainsColumn(columnId));
 
       auto cachedPage = fPagePool->GetPage(columnId, RClusterIndex(clusterId, idxInCluster));

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -129,13 +129,12 @@ ROOT::Experimental::Detail::RPageSinkFile::CommitPageImpl(ColumnHandle_t columnH
    return WriteSealedPage(sealedPage, element->GetPackedSize(page.GetNElements()));
 }
 
-
 ROOT::Experimental::RNTupleLocator
-ROOT::Experimental::Detail::RPageSinkFile::CommitSealedPageImpl(
-   DescriptorId_t columnId, const RPageStorage::RSealedPage &sealedPage)
+ROOT::Experimental::Detail::RPageSinkFile::CommitSealedPageImpl(DescriptorId_t physicalColumnId,
+                                                                const RPageStorage::RSealedPage &sealedPage)
 {
    const auto bitsOnStorage = RColumnElementBase::GetBitsOnStorage(
-      fDescriptorBuilder.GetDescriptor().GetColumnDescriptor(columnId).GetModel().GetType());
+      fDescriptorBuilder.GetDescriptor().GetColumnDescriptor(physicalColumnId).GetModel().GetType());
    const auto bytesPacked = (bitsOnStorage * sealedPage.fNElements + 7) / 8;
 
    return WriteSealedPage(sealedPage, bytesPacked);
@@ -290,9 +289,9 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceFil
    return ntplDesc;
 }
 
-
-void ROOT::Experimental::Detail::RPageSourceFile::LoadSealedPage(
-   DescriptorId_t columnId, const RClusterIndex &clusterIndex, RSealedPage &sealedPage)
+void ROOT::Experimental::Detail::RPageSourceFile::LoadSealedPage(DescriptorId_t physicalColumnId,
+                                                                 const RClusterIndex &clusterIndex,
+                                                                 RSealedPage &sealedPage)
 {
    const auto clusterId = clusterIndex.GetClusterId();
 
@@ -300,7 +299,7 @@ void ROOT::Experimental::Detail::RPageSourceFile::LoadSealedPage(
    {
       auto descriptorGuard = GetSharedDescriptorGuard();
       const auto &clusterDescriptor = descriptorGuard->GetClusterDescriptor(clusterId);
-      pageInfo = clusterDescriptor.GetPageRange(columnId).Find(clusterIndex.GetIndex());
+      pageInfo = clusterDescriptor.GetPageRange(physicalColumnId).Find(clusterIndex.GetIndex());
    }
 
    const auto bytesOnStorage = pageInfo.fLocator.fBytesOnStorage;

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -584,7 +584,7 @@ void ROOT::Experimental::Detail::RPageSourceFile::UnzipClusterImpl(RCluster *clu
 
    std::vector<std::unique_ptr<RColumnElementBase>> allElements;
 
-   const auto &columnsInCluster = cluster->GetAvailColumns();
+   const auto &columnsInCluster = cluster->GetAvailPhysicalColumns();
    for (const auto columnId : columnsInCluster) {
       const auto &columnDesc = descriptorGuard->GetColumnDescriptor(columnId);
 

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -179,7 +179,7 @@ ROOT::Experimental::Detail::RPageSinkFile::ReservePage(ColumnHandle_t columnHand
    if (nElements == 0)
       throw RException(R__FAIL("invalid call: request empty page"));
    auto elementSize = columnHandle.fColumn->GetElement()->GetSize();
-   return fPageAllocator->NewPage(columnHandle.fId, elementSize, nElements);
+   return fPageAllocator->NewPage(columnHandle.fPhysicalId, elementSize, nElements);
 }
 
 void ROOT::Experimental::Detail::RPageSinkFile::ReleasePage(RPage &page)
@@ -316,7 +316,7 @@ ROOT::Experimental::Detail::RPageSourceFile::PopulatePageFromCluster(ColumnHandl
                                                                      const RClusterInfo &clusterInfo,
                                                                      ClusterSize_t::ValueType idxInCluster)
 {
-   const auto columnId = columnHandle.fId;
+   const auto columnId = columnHandle.fPhysicalId;
    const auto clusterId = clusterInfo.fClusterId;
    const auto pageInfo = clusterInfo.fPageInfo;
 
@@ -372,7 +372,7 @@ ROOT::Experimental::Detail::RPageSourceFile::PopulatePageFromCluster(ColumnHandl
 ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageSourceFile::PopulatePage(
    ColumnHandle_t columnHandle, NTupleSize_t globalIndex)
 {
-   const auto columnId = columnHandle.fId;
+   const auto columnId = columnHandle.fPhysicalId;
    auto cachedPage = fPagePool->GetPage(columnId, globalIndex);
    if (!cachedPage.IsNull())
       return cachedPage;
@@ -400,7 +400,7 @@ ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageSourceFile::P
 {
    const auto clusterId = clusterIndex.GetClusterId();
    const auto idxInCluster = clusterIndex.GetIndex();
-   const auto columnId = columnHandle.fId;
+   const auto columnId = columnHandle.fPhysicalId;
    auto cachedPage = fPagePool->GetPage(columnId, clusterIndex);
    if (!cachedPage.IsNull())
       return cachedPage;

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -335,7 +335,7 @@ ROOT::Experimental::Detail::RPageSourceFile::PopulatePageFromCluster(ColumnHandl
       sealedPageBuffer = directReadBuffer.get();
    } else {
       if (!fCurrentCluster || (fCurrentCluster->GetId() != clusterId) || !fCurrentCluster->ContainsColumn(columnId))
-         fCurrentCluster = fClusterPool->GetCluster(clusterId, fActiveColumns.ToColumnSet());
+         fCurrentCluster = fClusterPool->GetCluster(clusterId, fActivePhysicalColumns.ToColumnSet());
       R__ASSERT(fCurrentCluster->ContainsColumn(columnId));
 
       auto cachedPage = fPagePool->GetPage(columnId, RClusterIndex(clusterId, idxInCluster));

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -451,14 +451,14 @@ ROOT::Experimental::Detail::RPageSourceFile::PrepareSingleCluster(
       const auto &clusterDesc = descriptorGuard->GetClusterDescriptor(clusterKey.fClusterId);
 
       // Collect the page necessary page meta-data and sum up the total size of the compressed and packed pages
-      for (auto columnId : clusterKey.fColumnSet) {
-         const auto &pageRange = clusterDesc.GetPageRange(columnId);
+      for (auto physicalColumnId : clusterKey.fPhysicalColumnSet) {
+         const auto &pageRange = clusterDesc.GetPageRange(physicalColumnId);
          NTupleSize_t pageNo = 0;
          for (const auto &pageInfo : pageRange.fPageInfos) {
             const auto &pageLocator = pageInfo.fLocator;
             activeSize += pageLocator.fBytesOnStorage;
             onDiskPages.push_back(
-               {columnId, pageNo, pageLocator.GetPosition<std::uint64_t>(), pageLocator.fBytesOnStorage, 0});
+               {physicalColumnId, pageNo, pageLocator.GetPosition<std::uint64_t>(), pageLocator.fBytesOnStorage, 0});
             ++pageNo;
          }
       }
@@ -544,7 +544,7 @@ ROOT::Experimental::Detail::RPageSourceFile::PrepareSingleCluster(
 
    auto cluster = std::make_unique<RCluster>(clusterKey.fClusterId);
    cluster->Adopt(std::move(pageMap));
-   for (auto colId : clusterKey.fColumnSet)
+   for (auto colId : clusterKey.fPhysicalColumnSet)
       cluster->SetColumnAvailable(colId);
    return cluster;
 }

--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -33,6 +33,7 @@ ROOT_ADD_GTEST(ntuple_metrics ntuple_metrics.cxx LIBRARIES ROOTDataFrame ROOTNTu
 ROOT_ADD_GTEST(ntuple_packing ntuple_packing.cxx LIBRARIES ROOTDataFrame ROOTNTuple MathCore CustomStruct)
 ROOT_ADD_GTEST(ntuple_pages ntuple_pages.cxx LIBRARIES ROOTDataFrame ROOTNTuple MathCore CustomStruct)
 ROOT_ADD_GTEST(ntuple_print ntuple_print.cxx LIBRARIES ROOTDataFrame ROOTNTuple MathCore CustomStruct)
+ROOT_ADD_GTEST(ntuple_project ntuple_project.cxx LIBRARIES ROOTDataFrame ROOTNTuple)
 ROOT_ADD_GTEST(ntuple_rdf ntuple_rdf.cxx LIBRARIES ROOTDataFrame ROOTNTuple MathCore CustomStruct)
 ROOT_ADD_GTEST(ntuple_serialize ntuple_serialize.cxx LIBRARIES ROOTDataFrame ROOTNTuple MathCore CustomStruct)
 if(NOT MSVC OR ${LLVM_VERSION} VERSION_LESS 13.0.0 OR llvm13_broken_tests)

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -411,6 +411,10 @@ TEST(RNTupleModel, GetField)
    EXPECT_EQ(m->GetField("cs.v1")->GetType(), "std::vector<float>");
    EXPECT_EQ(m->GetField("nonexistent"), nullptr);
    EXPECT_EQ(m->GetField(""), nullptr);
+   EXPECT_EQ("", m->GetFieldZero()->GetQualifiedFieldName());
+   EXPECT_EQ("x", m->GetField("x")->GetQualifiedFieldName());
+   EXPECT_EQ("cs", m->GetField("cs")->GetQualifiedFieldName());
+   EXPECT_EQ("cs.v1", m->GetField("cs.v1")->GetQualifiedFieldName());
 }
 
 TEST(RNTuple, EmptyString)

--- a/tree/ntuple/v7/test/ntuple_cluster.cxx
+++ b/tree/ntuple/v7/test/ntuple_cluster.cxx
@@ -310,7 +310,7 @@ TEST(PageStorageFile, LoadClusters)
       auto descriptorGuard = source.GetSharedDescriptorGuard();
       ptId = descriptorGuard->FindFieldId("pt");
       EXPECT_NE(ROOT::Experimental::kInvalidDescriptorId, ptId);
-      colId = descriptorGuard->FindColumnId(ptId, 0);
+      colId = descriptorGuard->FindPhysicalColumnId(ptId, 0);
       EXPECT_NE(ROOT::Experimental::kInvalidDescriptorId, colId);
    }
 

--- a/tree/ntuple/v7/test/ntuple_cluster.cxx
+++ b/tree/ntuple/v7/test/ntuple_cluster.cxx
@@ -80,10 +80,10 @@ public:
       std::vector<std::unique_ptr<RCluster>> result;
       for (auto key : clusterKeys) {
          fReqsClusterIds.emplace_back(key.fClusterId);
-         fReqsColumns.emplace_back(key.fColumnSet);
+         fReqsColumns.emplace_back(key.fPhysicalColumnSet);
          auto cluster = std::make_unique<RCluster>(key.fClusterId);
          auto pageMap = std::make_unique<ROOT::Experimental::Detail::ROnDiskPageMap>();
-         for (auto colId : key.fColumnSet) {
+         for (auto colId : key.fPhysicalColumnSet) {
             pageMap->Register(ROnDiskPage::Key(colId, 0), ROnDiskPage(nullptr, 0));
             cluster->SetColumnAvailable(colId);
          }
@@ -325,7 +325,7 @@ TEST(PageStorageFile, LoadClusters)
          ROOT::Experimental::RColumnModel(ROOT::Experimental::EColumnType::kReal32, false), 0));
    column->Connect(ptId, &source);
    clusterKeys[0].fClusterId = 1;
-   clusterKeys[0].fColumnSet.insert(colId);
+   clusterKeys[0].fPhysicalColumnSet.insert(colId);
    cluster = std::move(source.LoadClusters(clusterKeys)[0]);
    EXPECT_EQ(1U, cluster->GetId());
    EXPECT_EQ(1U, cluster->GetNOnDiskPages());

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -84,7 +84,7 @@ public:
    RPage PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t i) final
    {
       auto pageBuffer = RPageSource::UnsealPage(fPages[i], fElement);
-      RPage newPage(columnHandle.fId, pageBuffer.release(), fElement.GetSize(), fPages[i].fNElements);
+      RPage newPage(columnHandle.fPhysicalId, pageBuffer.release(), fElement.GetSize(), fPages[i].fNElements);
       newPage.GrowUnchecked(fPages[i].fNElements);
       return newPage;
    }

--- a/tree/ntuple/v7/test/ntuple_friends.cxx
+++ b/tree/ntuple/v7/test/ntuple_friends.cxx
@@ -29,7 +29,8 @@ TEST(RPageStorageFriends, Empty)
    EXPECT_EQ(0u, reader->GetModel()->GetFieldZero()->GetOnDiskId());
    EXPECT_EQ(0u, std::distance(reader->GetModel()->GetDefaultEntry()->begin(),
                                reader->GetModel()->GetDefaultEntry()->end()));
-   EXPECT_EQ(0u, reader->GetDescriptor()->GetNColumns());
+   EXPECT_EQ(0u, reader->GetDescriptor()->GetNLogicalColumns());
+   EXPECT_EQ(0u, reader->GetDescriptor()->GetNPhysicalColumns());
    EXPECT_EQ(1u, reader->GetDescriptor()->GetNFields()); // The zero field
    EXPECT_EQ(0u, reader->GetDescriptor()->GetNClusters());
 }

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -42,7 +42,7 @@ TEST(RPageStorage, ReadSealedPages)
    RPageSourceFile source("myNTuple", fileGuard.GetPath(), RNTupleReadOptions());
    source.Attach();
    auto columnId =
-      source.GetSharedDescriptorGuard()->FindColumnId(source.GetSharedDescriptorGuard()->FindFieldId("pt"), 0);
+      source.GetSharedDescriptorGuard()->FindPhysicalColumnId(source.GetSharedDescriptorGuard()->FindFieldId("pt"), 0);
 
    // Check first cluster consisting of a single entry
    RClusterIndex index(source.GetSharedDescriptorGuard()->FindClusterId(columnId, 0), 0);

--- a/tree/ntuple/v7/test/ntuple_project.cxx
+++ b/tree/ntuple/v7/test/ntuple_project.cxx
@@ -1,0 +1,49 @@
+#include "ntuple_test.hxx"
+
+TEST(RNTupleProjection, Basics)
+{
+   auto model = RNTupleModel::Create();
+   model->MakeField<float>("met", 0.0);
+   //
+   //   auto hitModel = RNTupleModel::Create();
+   //   hitModel->MakeField<float>("x", 0.0);
+   //   hitModel->MakeField<float>("y", 0.0);
+   //
+   //   auto trackModel = RNTupleModel::Create();
+   //   trackModel->MakeField<float>("energy", 0.0);
+   //
+   //   trackModel->MakeCollection("hits", std::move(hitModel));
+   //   model->MakeCollection("tracks", std::move(trackModel));
+   //
+   auto f1 = RFieldBase::Create("missingE", "std::vector<float>").Unwrap();
+   model->AddProjectedField(std::move(f1), [](const RFieldBase &) { return ""; });
+   //   // No such parent field
+   //   EXPECT_THROW(model->AddProjectedField(std::move(f1), "na", [](const RFieldBase &){return "";}),
+   //                RException);
+   //
+   //   // Top level field clash
+   //   auto f2 = RFieldBase::Create("met", "float").Unwrap();
+   //   EXPECT_THROW(model->AddProjectedField(std::move(f2), "", [](const RFieldBase &){return "";}),
+   //                RException);
+   //
+   //   // Sub field name clash
+   //   auto f3 = RFieldBase::Create("x", "float").Unwrap();
+   //   EXPECT_THROW(model->AddProjectedField(std::move(f3), "tracks.hits", [](const RFieldBase &){return "";}),
+   //                RException);
+   //
+   //   auto f4 = RFieldBase::Create("missingE", "float").Unwrap();
+   //   model->AddProjectedField(std::move(f4), "", [](const RFieldBase &){return "";});
+   //
+   //   // Projection name clash
+   //   auto f5 = RFieldBase::Create("missingE", "float").Unwrap();
+   //   EXPECT_THROW(model->AddProjectedField(std::move(f5), "", [](const RFieldBase &){return "";}),
+   //                RException);
+   //
+   //   auto f6 = RFieldBase::Create("X_coord", "float").Unwrap();
+   //   model->AddProjectedField(std::move(f6), "tracks.hits", [](const RFieldBase &){return "";});
+   //
+   //   // Projection name clash
+   //   auto f7 = RFieldBase::Create("X_coord", "float").Unwrap();
+   //   EXPECT_THROW(model->AddProjectedField(std::move(f7), "tracks.hits", [](const RFieldBase &){return "";}),
+   //                RException);
+}

--- a/tree/ntuple/v7/test/ntuple_project.cxx
+++ b/tree/ntuple/v7/test/ntuple_project.cxx
@@ -6,9 +6,19 @@ TEST(RNTupleProjection, Basics)
 
    auto model = RNTupleModel::Create();
    model->MakeField<float>("met", 42.0);
+   auto fvec = model->MakeField<std::vector<float>>("vec");
+   fvec->emplace_back(1.0);
+   fvec->emplace_back(2.0);
 
    auto f1 = RFieldBase::Create("missingE", "float").Unwrap();
    model->AddProjectedField(std::move(f1), [](const std::string &) { return "met"; });
+   auto f2 = RFieldBase::Create("aliasVec", "std::vector<float>").Unwrap();
+   model->AddProjectedField(std::move(f2), [](const std::string &fieldName) {
+      if (fieldName == "aliasVec")
+         return "vec";
+      else
+         return "vec._0";
+   });
 
    {
       auto writer = RNTupleWriter::Recreate(std::move(model), "A", fileGuard.GetPath());
@@ -17,7 +27,94 @@ TEST(RNTupleProjection, Basics)
 
    auto reader = RNTupleReader::Open("A", fileGuard.GetPath());
    auto viewMissingE = reader->GetView<float>("missingE");
+   auto viewAliasVec = reader->GetView<std::vector<float>>("aliasVec");
    EXPECT_FLOAT_EQ(42.0, viewMissingE(0));
+   EXPECT_EQ(2U, viewAliasVec(0).size());
+   EXPECT_FLOAT_EQ(1.0, viewAliasVec(0).at(0));
+   EXPECT_FLOAT_EQ(2.0, viewAliasVec(0).at(1));
+}
+
+TEST(RNTupleProjection, CatchInvalidMappings)
+{
+   FileRaii fileGuard("test_ntuple_projection_catch_invalid_mappings.root");
+
+   auto model = RNTupleModel::Create();
+   model->MakeField<float>("met", 42.0);
+   model->MakeField<std::vector<float>>("vec");
+   model->MakeField<std::variant<int, float>>("variant");
+   model->MakeField<std::vector<std::vector<float>>>("nnlo");
+
+   auto f1 = RFieldBase::Create("fail", "float").Unwrap();
+   try {
+      model->AddProjectedField(std::move(f1), [](const std::string &) { return "na"; }).ThrowOnError();
+      FAIL() << "mapping to unknown field should throw";
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("no such field"));
+   }
+
+   auto f2 = RFieldBase::Create("fail", "std::vector<float>").Unwrap();
+   try {
+      model
+         ->AddProjectedField(std::move(f2),
+                             [](const std::string &name) {
+                                if (name == "fail")
+                                   return "vec";
+                                else
+                                   return "na";
+                             })
+         .ThrowOnError();
+      FAIL() << "mapping to unknown field should throw";
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("no such field"));
+   }
+
+   auto f3 = RFieldBase::Create("fail", "std::vector<float>").Unwrap();
+   try {
+      model->AddProjectedField(std::move(f3), [](const std::string &) { return "met"; }).ThrowOnError();
+      FAIL() << "mapping with structural mismatch should throw";
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("field mapping structural mismatch"));
+   }
+
+   auto f4 = RFieldBase::Create("fail", "int").Unwrap();
+   try {
+      model->AddProjectedField(std::move(f4), [](const std::string &) { return "met"; }).ThrowOnError();
+      FAIL() << "mapping without matching type should throw";
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("field mapping type mismatch"));
+   }
+
+   auto f5 = RFieldBase::Create("fail", "std::variant<int, float>").Unwrap();
+   try {
+      model
+         ->AddProjectedField(std::move(f5),
+                             [](const std::string &fieldName) {
+                                if (fieldName == "fail")
+                                   return "variant";
+                                if (fieldName == "fail._0")
+                                   return "variant._0";
+                                return "variant._1";
+                             })
+         .ThrowOnError();
+      FAIL() << "mapping of variant should throw";
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("unsupported field mapping "));
+   }
+
+   auto f6 = RFieldBase::Create("fail", "std::vector<float>").Unwrap();
+   try {
+      model
+         ->AddProjectedField(std::move(f6),
+                             [](const std::string &fieldName) {
+                                if (fieldName == "fail")
+                                   return "nnlo._0";
+                                return "nnlo._0._0";
+                             })
+         .ThrowOnError();
+      FAIL() << "mapping scrambling the source structure should throw";
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("field mapping structure mismatch"));
+   }
 }
 
 TEST(RNTupleProjection, CatchReaderWithProjectedFields)

--- a/tree/ntuple/v7/test/ntuple_project.cxx
+++ b/tree/ntuple/v7/test/ntuple_project.cxx
@@ -2,48 +2,44 @@
 
 TEST(RNTupleProjection, Basics)
 {
+   FileRaii fileGuard("test_ntuple_projection_basics.root");
+
    auto model = RNTupleModel::Create();
-   model->MakeField<float>("met", 0.0);
-   //
-   //   auto hitModel = RNTupleModel::Create();
-   //   hitModel->MakeField<float>("x", 0.0);
-   //   hitModel->MakeField<float>("y", 0.0);
-   //
-   //   auto trackModel = RNTupleModel::Create();
-   //   trackModel->MakeField<float>("energy", 0.0);
-   //
-   //   trackModel->MakeCollection("hits", std::move(hitModel));
-   //   model->MakeCollection("tracks", std::move(trackModel));
-   //
-   auto f1 = RFieldBase::Create("missingE", "std::vector<float>").Unwrap();
-   model->AddProjectedField(std::move(f1), [](const RFieldBase &) { return ""; });
-   //   // No such parent field
-   //   EXPECT_THROW(model->AddProjectedField(std::move(f1), "na", [](const RFieldBase &){return "";}),
-   //                RException);
-   //
-   //   // Top level field clash
-   //   auto f2 = RFieldBase::Create("met", "float").Unwrap();
-   //   EXPECT_THROW(model->AddProjectedField(std::move(f2), "", [](const RFieldBase &){return "";}),
-   //                RException);
-   //
-   //   // Sub field name clash
-   //   auto f3 = RFieldBase::Create("x", "float").Unwrap();
-   //   EXPECT_THROW(model->AddProjectedField(std::move(f3), "tracks.hits", [](const RFieldBase &){return "";}),
-   //                RException);
-   //
-   //   auto f4 = RFieldBase::Create("missingE", "float").Unwrap();
-   //   model->AddProjectedField(std::move(f4), "", [](const RFieldBase &){return "";});
-   //
-   //   // Projection name clash
-   //   auto f5 = RFieldBase::Create("missingE", "float").Unwrap();
-   //   EXPECT_THROW(model->AddProjectedField(std::move(f5), "", [](const RFieldBase &){return "";}),
-   //                RException);
-   //
-   //   auto f6 = RFieldBase::Create("X_coord", "float").Unwrap();
-   //   model->AddProjectedField(std::move(f6), "tracks.hits", [](const RFieldBase &){return "";});
-   //
-   //   // Projection name clash
-   //   auto f7 = RFieldBase::Create("X_coord", "float").Unwrap();
-   //   EXPECT_THROW(model->AddProjectedField(std::move(f7), "tracks.hits", [](const RFieldBase &){return "";}),
-   //                RException);
+   model->MakeField<float>("met", 42.0);
+
+   auto f1 = RFieldBase::Create("missingE", "float").Unwrap();
+   model->AddProjectedField(std::move(f1), [](const std::string &) { return "met"; });
+
+   {
+      auto writer = RNTupleWriter::Recreate(std::move(model), "A", fileGuard.GetPath());
+      writer->Fill();
+   }
+
+   auto reader = RNTupleReader::Open("A", fileGuard.GetPath());
+   auto viewMissingE = reader->GetView<float>("missingE");
+   EXPECT_FLOAT_EQ(42.0, viewMissingE(0));
+}
+
+TEST(RNTupleProjection, CatchReaderWithProjectedFields)
+{
+   FileRaii fileGuard("test_ntuple_projection_catch_reader_with_projected_fields.root");
+
+   auto model = RNTupleModel::Create();
+   model->MakeField<float>("met", 42.0);
+
+   auto f1 = RFieldBase::Create("missingE", "float").Unwrap();
+   model->AddProjectedField(std::move(f1), [](const std::string &) { return "met"; });
+
+   auto modelRead = model->Clone();
+
+   {
+      auto writer = RNTupleWriter::Recreate(std::move(model), "A", fileGuard.GetPath());
+   }
+
+   try {
+      auto reader = RNTupleReader::Open(std::move(modelRead), "A", fileGuard.GetPath());
+      FAIL() << "creating a reader with a model with projected fields should throw";
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("model has projected fields"));
+   }
 }

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -500,9 +500,9 @@ TEST(RNTuple, SerializeHeader)
    builder.AddFieldLink(0, 42);
    builder.AddFieldLink(0, 137);
    builder.AddFieldLink(137, 13);
-   builder.AddColumn(23, 42, RColumnModel(EColumnType::kReal32, false), 0);
-   builder.AddColumn(17, 137, RColumnModel(EColumnType::kIndex, true), 0);
-   builder.AddColumn(40, 137, RColumnModel(EColumnType::kByte, true), 1);
+   builder.AddColumn(23, 23, 42, RColumnModel(EColumnType::kReal32, false), 0);
+   builder.AddColumn(17, 17, 137, RColumnModel(EColumnType::kIndex, true), 0);
+   builder.AddColumn(40, 40, 137, RColumnModel(EColumnType::kByte, true), 1);
 
    auto desc = builder.MoveDescriptor();
    auto context = RNTupleSerializer::SerializeHeaderV1(nullptr, desc);
@@ -531,7 +531,7 @@ TEST(RNTuple, SerializeFooter)
       .MakeDescriptor()
       .Unwrap());
    builder.AddFieldLink(0, 42);
-   builder.AddColumn(17, 42, RColumnModel(EColumnType::kIndex, true), 0);
+   builder.AddColumn(17, 17, 42, RColumnModel(EColumnType::kIndex, true), 0);
 
    ROOT::Experimental::RClusterDescriptor::RColumnRange columnRange;
    ROOT::Experimental::RClusterDescriptor::RPageRange::RPageInfo pageInfo;

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -486,6 +486,12 @@ TEST(RNTuple, SerializeHeader)
       .MakeDescriptor()
       .Unwrap());
    builder.AddField(RFieldDescriptorBuilder()
+                       .FieldId(24)
+                       .FieldName("ptAlias")
+                       .Structure(ENTupleStructure::kLeaf)
+                       .MakeDescriptor()
+                       .Unwrap());
+   builder.AddField(RFieldDescriptorBuilder()
       .FieldId(137)
       .FieldName("jet")
       .Structure(ENTupleStructure::kRecord)
@@ -498,9 +504,11 @@ TEST(RNTuple, SerializeHeader)
       .MakeDescriptor()
       .Unwrap());
    builder.AddFieldLink(0, 42);
+   builder.AddFieldLink(0, 24);
    builder.AddFieldLink(0, 137);
    builder.AddFieldLink(137, 13);
    builder.AddColumn(23, 23, 42, RColumnModel(EColumnType::kReal32, false), 0);
+   builder.AddColumn(100, 23, 24, RColumnModel(EColumnType::kReal32, false), 0);
    builder.AddColumn(17, 17, 137, RColumnModel(EColumnType::kIndex, true), 0);
    builder.AddColumn(40, 40, 137, RColumnModel(EColumnType::kByte, true), 1);
 
@@ -511,6 +519,13 @@ TEST(RNTuple, SerializeHeader)
    context = RNTupleSerializer::SerializeHeaderV1(buffer.get(), desc);
 
    RNTupleSerializer::DeserializeHeaderV1(buffer.get(), context.GetHeaderSize(), builder);
+
+   desc = builder.MoveDescriptor();
+   auto ptAliasFieldId = desc.FindFieldId("ptAlias");
+   auto colId = desc.FindLogicalColumnId(ptAliasFieldId, 0);
+   EXPECT_TRUE(desc.GetColumnDescriptor(colId).IsAliasColumn());
+   auto ptFieldId = desc.FindFieldId("pt");
+   EXPECT_EQ(desc.FindLogicalColumnId(ptFieldId, 0), desc.GetColumnDescriptor(colId).GetPhysicalId());
 }
 
 

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -537,7 +537,7 @@ TEST(RNTuple, SerializeFooter)
    ROOT::Experimental::RClusterDescriptor::RPageRange::RPageInfo pageInfo;
    RClusterDescriptorBuilder clusterBuilder(84, 0, 100);
    ROOT::Experimental::RClusterDescriptor::RPageRange pageRange;
-   pageRange.fColumnId = 17;
+   pageRange.fPhysicalColumnId = 17;
    pageInfo.fNElements = 100;
    pageInfo.fLocator.fPosition = 7000U;
    pageRange.fPageInfos.emplace_back(pageInfo);

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -40,7 +40,7 @@ protected:
    RPage ReservePage(ColumnHandle_t columnHandle, std::size_t nElements) final
    {
       auto elementSize = columnHandle.fColumn->GetElement()->GetSize();
-      return fPageAllocator.NewPage(columnHandle.fId, elementSize, nElements);
+      return fPageAllocator.NewPage(columnHandle.fPhysicalId, elementSize, nElements);
    }
    void ReleasePage(RPage &page) final { fPageAllocator.DeletePage(page); }
 

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -59,6 +59,7 @@ using RColumnModel = ROOT::Experimental::RColumnModel;
 using RClusterIndex = ROOT::Experimental::RClusterIndex;
 using RClusterDescriptorBuilder = ROOT::Experimental::RClusterDescriptorBuilder;
 using RClusterGroupDescriptorBuilder = ROOT::Experimental::RClusterGroupDescriptorBuilder;
+using RColumnDescriptorBuilder = ROOT::Experimental::RColumnDescriptorBuilder;
 using RFieldDescriptorBuilder = ROOT::Experimental::RFieldDescriptorBuilder;
 using RException = ROOT::Experimental::RException;
 template <class T>

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -267,6 +267,18 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSc
       }
       c.fFieldName = "_collection" + std::to_string(iLeafCountCollection);
       c.fCollectionWriter = fModel->MakeCollection(c.fFieldName, std::move(c.fCollectionModel));
+      // Add projected fields for all leaf count arrays
+      for (auto idx : c.fImportFieldIndexes) {
+         const auto name = fImportFields[idx].fField->GetName();
+         auto projectedField =
+            Detail::RFieldBase::Create(name, "ROOT::RVec<" + fImportFields[idx].fField->GetType() + ">").Unwrap();
+         fModel->AddProjectedField(std::move(projectedField), [&name, &c](const std::string &fieldName) {
+            if (fieldName == name)
+               return c.fFieldName;
+            else
+               return c.fFieldName + "." + name;
+         });
+      }
       iLeafCountCollection++;
    }
 

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -303,6 +303,9 @@ TEST(RNTupleImporter, LeafCountArray)
    auto viewJetEta = viewJets.GetView<float>("jet_eta");
    auto viewMuons = reader->GetViewCollection("_collection1");
    auto viewMuonPt = viewMuons.GetView<float>("muon_pt");
+   auto viewProjectedJetPt = reader->GetView<ROOT::RVec<float>>("jet_pt");
+   auto viewProjectedJetEta = reader->GetView<ROOT::RVec<float>>("jet_eta");
+   auto viewProjectedMuonPt = reader->GetView<ROOT::RVec<float>>("muon_pt");
 
    // Entry 0: 1 jet, 1 muon
    EXPECT_EQ(1, viewJets(0));
@@ -310,11 +313,21 @@ TEST(RNTupleImporter, LeafCountArray)
    EXPECT_FLOAT_EQ(2.0, viewJetEta(0));
    EXPECT_EQ(1, viewMuons(0));
    EXPECT_FLOAT_EQ(10.0, viewMuonPt(0));
+   EXPECT_EQ(1U, viewProjectedJetPt(0).size());
+   EXPECT_FLOAT_EQ(1.0, viewProjectedJetPt(0).at(0));
+   EXPECT_EQ(1U, viewProjectedJetEta(0).size());
+   EXPECT_FLOAT_EQ(2.0, viewProjectedJetEta(0).at(0));
+   EXPECT_EQ(1U, viewProjectedMuonPt(0).size());
+   EXPECT_FLOAT_EQ(10.0, viewProjectedMuonPt(0).at(0));
 
    // Entry 1: 0 jets, 1 muon
    EXPECT_EQ(0, viewJets(1));
    EXPECT_EQ(1, viewMuons(1));
    EXPECT_FLOAT_EQ(11.0, viewMuonPt(1));
+   EXPECT_EQ(0U, viewProjectedJetPt(1).size());
+   EXPECT_EQ(0U, viewProjectedJetEta(1).size());
+   EXPECT_EQ(1U, viewProjectedMuonPt(1).size());
+   EXPECT_FLOAT_EQ(11.0, viewProjectedMuonPt(1).at(0));
 
    // Entry 2: 2 jets, 1 muon
    EXPECT_EQ(2, viewJets(2));
@@ -324,6 +337,14 @@ TEST(RNTupleImporter, LeafCountArray)
    EXPECT_FLOAT_EQ(6.0, viewJetEta(2));
    EXPECT_EQ(1, viewMuons(2));
    EXPECT_FLOAT_EQ(12.0, viewMuonPt(2));
+   EXPECT_EQ(2U, viewProjectedJetPt(2).size());
+   EXPECT_FLOAT_EQ(3.0, viewProjectedJetPt(2).at(0));
+   EXPECT_FLOAT_EQ(5.0, viewProjectedJetPt(2).at(1));
+   EXPECT_EQ(2U, viewProjectedJetEta(2).size());
+   EXPECT_FLOAT_EQ(4.0, viewProjectedJetEta(2).at(0));
+   EXPECT_FLOAT_EQ(6.0, viewProjectedJetEta(2).at(1));
+   EXPECT_EQ(1U, viewProjectedMuonPt(2).size());
+   EXPECT_FLOAT_EQ(12.0, viewProjectedMuonPt(2).at(0));
 }
 
 TEST(RNTupleImporter, STL)

--- a/tutorials/v7/ntuple/ntpl008_import.C
+++ b/tutorials/v7/ntuple/ntpl008_import.C
@@ -19,6 +19,7 @@
 R__LOAD_LIBRARY(ROOTNTupleUtil)
 
 #include <ROOT/RNTuple.hxx>
+#include <ROOT/RNTupleDS.hxx>
 #include <ROOT/RNTupleImporter.hxx>
 
 #include <TFile.h>
@@ -56,4 +57,7 @@ void ntpl008_import()
    auto ntpl = file->Get<RNTuple>("Events");
    auto reader = RNTupleReader::Open(ntpl);
    reader->PrintInfo();
+
+   auto df = ROOT::RDF::Experimental::FromRNTuple("Events", kNTupleFileName);
+   df.Histo1D({"Jet_pt", "Jet_pt", 100, 0, 0}, "Jet_pt")->DrawCopy();
 }


### PR DESCRIPTION
Projected fields are fields that use existing columns to create alternative type representations of the data. Projected fields are linked to alias columns. We currently support a limited set of projections, namely only for leafs, collections, and records with a matching structure. The first application is for importing leaf count branches. The branches are physically stored in untyped collections and the projected as RVecs to their original names.  E.g., _collection0.jet_pt [`float`] --> jet_pt [`RVec<float>`].

On the descriptor level, the PR introduces the separation between physical and logical column IDs.

A follow-up PR will take care of projecting a collection offset column to the the count leaf branch (e.g., `njets`).