### PR TITLE
[math] Do correctly the setting of fix  variables in TLinearMinimizer

### DIFF
--- a/math/mathcore/src/Fitter.cxx
+++ b/math/mathcore/src/Fitter.cxx
@@ -757,9 +757,7 @@ bool Fitter::DoInitMinimizer() {
                unsigned int nh = ndim * (ndim + 1) / 2;
                std::vector<double> h(nh);
                bool ret = fitGradFcn->Hessian(x.data(), h.data());
-               if (ret) {
-                  std::cout << "computing hessian " << x[0] << " -> " << h[0] << std::endl;
-               }
+               if (!ret) return false;
                for (unsigned int i = 0; i < ndim; i++) {
                   for (unsigned int j = 0; j <= i; j++) {
                      unsigned int index = j + i * (i + 1) / 2; // formula for j < i
@@ -768,7 +766,7 @@ bool Fitter::DoInitMinimizer() {
                         hess[ndim * j + i] = h[index];
                   }
                }
-               return ret;
+               return true;
             };
 
             fMinimizer->SetHessianFunction(hessFcn);

--- a/math/minuit/inc/TLinearMinimizer.h
+++ b/math/minuit/inc/TLinearMinimizer.h
@@ -68,8 +68,8 @@ public:
    /// set the function to minimize
    void SetFunction(const ROOT::Math::IMultiGradFunction & func) override;
 
-   /// set free variable (dummy impl. )
-   bool SetVariable(unsigned int , const std::string & , double , double ) override { return false; }
+   /// set free variable (dummy impl. since there is no need to set variables in the Linear Fitter)
+   bool SetVariable(unsigned int , const std::string & , double , double ) override { return true; }
 
    /// set fixed variable (override if minimizer supports them )
    bool SetFixedVariable(unsigned int /* ivar */, const std::string & /* name */, double /* val */) override;

--- a/math/minuit/src/TLinearMinimizer.cxx
+++ b/math/minuit/src/TLinearMinimizer.cxx
@@ -143,7 +143,7 @@ void TLinearMinimizer::SetFunction(const  ROOT::Math::IMultiGradFunction & objfu
    assert(modfunc != 0);
 
    fDim = chi2func->NDim(); // number of parameters
-   fNFree = fDim;
+   fNFree = fDim;  // in case of no fixed parameters
    // get the basis functions (derivatives of the modelfunc)
    TObjArray flist(fDim);
    flist.SetOwner(kFALSE);  // we do not want to own the list - it will be owned by the TLinearFitter class
@@ -196,6 +196,8 @@ bool TLinearMinimizer::Minimize() {
    // solving the linear equation. Use  TVirtualFitter::Eval.
 
    if (fFitter == 0 || fObjFunc == 0) return false;
+
+   fNFree = fFitter->GetNumberFreeParameters();
 
    int iret = 0;
    if (!fRobust)


### PR DESCRIPTION
This PR fixes a problem in fixing the parameter when using the linear fitter. 
This simple examples shows the problem (the fixed parameter is always the first one) instead of the second one
```
{
   auto h1 = new TH1D("h1","h1",20,0,10);
   h1->FillRandom("pol0");
   auto f1 = new TF1("f1","pol1");
   f1->FixParameter(1,0);
   h1->Fit(f1,"");
}
```
the bug is caused by `TLinearMinimizer::SetVariable` returning false instead of true. 

The PR fixes also the counting of the total number of free parameters


