### PR TITLE
[RF] Deprecate `RooCFunction*Binding` classes

### DIFF
--- a/README/ReleaseNotes/v632/index.md
+++ b/README/ReleaseNotes/v632/index.md
@@ -40,9 +40,7 @@ The following people have contributed to this new version:
 
 ## Deprecation and Removal
 - The RooFit legacy iterators are deprecated and will be removed in ROOT 6.34 (see section "RooFit libraries")
-- Some memory-unsafe RooFit interfaces were removed
-- Some redundant **RooDataSet** constructors are deprecated and will be removed in ROOT 6.34.
-  Please use the RooDataSet constructors that take RooFit command arguments instead
+- The `RooCFunction*Binding` classes and the associated `RooFit::bindFunction()` and `RooFit::bindPdf()` functions are deprecated and will be removed in ROOT 6.34. Their functionality is redundant with the `RooFormulaVar` and `RooGenericPdf` that should be used instead.
 
 ## Core Libraries
 

--- a/roofit/roofit/inc/RooCFunction1Binding.h
+++ b/roofit/roofit/inc/RooCFunction1Binding.h
@@ -21,6 +21,8 @@
 #include "TBuffer.h"
 #include "TString.h"
 
+#include <ROOT/RConfig.hxx> // R__DEPRECATED
+
 #include <string>
 #include <map>
 #include <vector>
@@ -31,9 +33,13 @@ namespace RooFit {
 typedef double (*CFUNCD1D)(double) ;
 typedef double (*CFUNCD1I)(Int_t) ;
 
+R__DEPRECATED(6, 34, "Use RooFormulaVar instead.")
 RooAbsReal* bindFunction(const char* name,CFUNCD1D func,RooAbsReal& x) ;
+R__DEPRECATED(6, 34, "Use RooFormulaVar instead.")
 RooAbsReal* bindFunction(const char* name,CFUNCD1I func,RooAbsReal& x) ;
+R__DEPRECATED(6, 34, "Use RooGenericPdf instead.")
 RooAbsPdf*  bindPdf(const char* name,CFUNCD1D func,RooAbsReal& x) ;
+R__DEPRECATED(6, 34, "Use RooGenericPdf instead.")
 RooAbsPdf*  bindPdf(const char* name,CFUNCD1I func,RooAbsReal& x) ;
 
 }

--- a/roofit/roofit/inc/RooCFunction2Binding.h
+++ b/roofit/roofit/inc/RooCFunction2Binding.h
@@ -21,6 +21,8 @@
 #include "TBuffer.h"
 #include "TString.h"
 
+#include <ROOT/RConfig.hxx> // R__DEPRECATED
+
 #include <string>
 #include <map>
 #include <vector>
@@ -34,15 +36,25 @@ typedef double (*CFUNCD2DI)(double,Int_t) ;
 typedef double (*CFUNCD2II)(Int_t,Int_t) ;
 
 
+R__DEPRECATED(6, 34, "Use RooFormulaVar instead.")
 RooAbsReal* bindFunction(const char* name,CFUNCD2DD func,RooAbsReal& x, RooAbsReal& y) ;
+R__DEPRECATED(6, 34, "Use RooFormulaVar instead.")
 RooAbsReal* bindFunction(const char* name,CFUNCD2ID func,RooAbsReal& x, RooAbsReal& y) ;
+R__DEPRECATED(6, 34, "Use RooFormulaVar instead.")
 RooAbsReal* bindFunction(const char* name,CFUNCD2UD func,RooAbsReal& x, RooAbsReal& y) ;
+R__DEPRECATED(6, 34, "Use RooFormulaVar instead.")
 RooAbsReal* bindFunction(const char* name,CFUNCD2DI func,RooAbsReal& x, RooAbsReal& y) ;
+R__DEPRECATED(6, 34, "Use RooFormulaVar instead.")
 RooAbsReal* bindFunction(const char* name,CFUNCD2II func,RooAbsReal& x, RooAbsReal& y) ;
+R__DEPRECATED(6, 34, "Use RooGenericPdf instead.")
 RooAbsPdf* bindPdf(const char* name,CFUNCD2DD func,RooAbsReal& x, RooAbsReal& y) ;
+R__DEPRECATED(6, 34, "Use RooGenericPdf instead.")
 RooAbsPdf* bindPdf(const char* name,CFUNCD2ID func,RooAbsReal& x, RooAbsReal& y) ;
+R__DEPRECATED(6, 34, "Use RooGenericPdf instead.")
 RooAbsPdf* bindPdf(const char* name,CFUNCD2UD func,RooAbsReal& x, RooAbsReal& y) ;
+R__DEPRECATED(6, 34, "Use RooGenericPdf instead.")
 RooAbsPdf* bindPdf(const char* name,CFUNCD2DI func,RooAbsReal& x, RooAbsReal& y) ;
+R__DEPRECATED(6, 34, "Use RooGenericPdf instead.")
 RooAbsPdf* bindPdf(const char* name,CFUNCD2II func,RooAbsReal& x, RooAbsReal& y) ;
 
 }

--- a/roofit/roofit/inc/RooCFunction3Binding.h
+++ b/roofit/roofit/inc/RooCFunction3Binding.h
@@ -20,6 +20,8 @@
 #include "TBuffer.h"
 #include "TString.h"
 
+#include <ROOT/RConfig.hxx> // R__DEPRECATED
+
 #include <string>
 #include <map>
 #include <vector>
@@ -34,17 +36,29 @@ typedef double (*CFUNCD3UDU)(UInt_t,double,UInt_t) ;
 typedef double (*CFUNCD3UDD)(UInt_t,double,double) ;
 typedef double (*CFUNCD3UUD)(UInt_t,UInt_t,double) ;
 
+R__DEPRECATED(6, 34, "Use RooFormulaVar instead.")
 RooAbsReal* bindFunction(const char* name,CFUNCD3DDD func,RooAbsReal& x, RooAbsReal& y, RooAbsReal& z) ;
+R__DEPRECATED(6, 34, "Use RooFormulaVar instead.")
 RooAbsReal* bindFunction(const char* name,CFUNCD3DDB func,RooAbsReal& x, RooAbsReal& y, RooAbsReal& z) ;
+R__DEPRECATED(6, 34, "Use RooFormulaVar instead.")
 RooAbsReal* bindFunction(const char* name,CFUNCD3DII func,RooAbsReal& x, RooAbsReal& y, RooAbsReal& z) ;
+R__DEPRECATED(6, 34, "Use RooFormulaVar instead.")
 RooAbsReal* bindFunction(const char* name,CFUNCD3UDU func,RooAbsReal& x, RooAbsReal& y, RooAbsReal& z) ;
+R__DEPRECATED(6, 34, "Use RooFormulaVar instead.")
 RooAbsReal* bindFunction(const char* name,CFUNCD3UDD func,RooAbsReal& x, RooAbsReal& y, RooAbsReal& z) ;
+R__DEPRECATED(6, 34, "Use RooFormulaVar instead.")
 RooAbsReal* bindFunction(const char* name,CFUNCD3UUD func,RooAbsReal& x, RooAbsReal& y, RooAbsReal& z) ;
+R__DEPRECATED(6, 34, "Use RooGenericPdf instead.")
 RooAbsPdf* bindPdf(const char* name,CFUNCD3DDD func,RooAbsReal& x, RooAbsReal& y, RooAbsReal& z) ;
+R__DEPRECATED(6, 34, "Use RooGenericPdf instead.")
 RooAbsPdf* bindPdf(const char* name,CFUNCD3DDB func,RooAbsReal& x, RooAbsReal& y, RooAbsReal& z) ;
+R__DEPRECATED(6, 34, "Use RooGenericPdf instead.")
 RooAbsPdf* bindPdf(const char* name,CFUNCD3DII func,RooAbsReal& x, RooAbsReal& y, RooAbsReal& z) ;
+R__DEPRECATED(6, 34, "Use RooGenericPdf instead.")
 RooAbsPdf* bindPdf(const char* name,CFUNCD3UDU func,RooAbsReal& x, RooAbsReal& y, RooAbsReal& z) ;
+R__DEPRECATED(6, 34, "Use RooGenericPdf instead.")
 RooAbsPdf* bindPdf(const char* name,CFUNCD3UDD func,RooAbsReal& x, RooAbsReal& y, RooAbsReal& z) ;
+R__DEPRECATED(6, 34, "Use RooGenericPdf instead.")
 RooAbsPdf* bindPdf(const char* name,CFUNCD3UUD func,RooAbsReal& x, RooAbsReal& y, RooAbsReal& z) ;
 
 }

--- a/roofit/roofit/inc/RooCFunction4Binding.h
+++ b/roofit/roofit/inc/RooCFunction4Binding.h
@@ -21,6 +21,8 @@
 #include "TBuffer.h"
 #include "TString.h"
 
+#include <ROOT/RConfig.hxx> // R__DEPRECATED
+
 #include <string>
 #include <map>
 #include <vector>
@@ -31,11 +33,17 @@ typedef double (*CFUNCD4DDDD)(double,double,double,double) ;
 typedef double (*CFUNCD4DDDI)(double,double,double,Int_t) ;
 typedef double (*CFUNCD4DDDB)(double,double,double,bool) ;
 
+R__DEPRECATED(6, 34, "Use RooFormulaVar instead.")
 RooAbsReal* bindFunction(const char* name,CFUNCD4DDDD func,RooAbsReal& x, RooAbsReal& y, RooAbsReal& z, RooAbsReal& w) ;
+R__DEPRECATED(6, 34, "Use RooFormulaVar instead.")
 RooAbsReal* bindFunction(const char* name,CFUNCD4DDDI func,RooAbsReal& x, RooAbsReal& y, RooAbsReal& z, RooAbsReal& w) ;
+R__DEPRECATED(6, 34, "Use RooFormulaVar instead.")
 RooAbsReal* bindFunction(const char* name,CFUNCD4DDDB func,RooAbsReal& x, RooAbsReal& y, RooAbsReal& z, RooAbsReal& w) ;
+R__DEPRECATED(6, 34, "Use RooGenericPdf instead.")
 RooAbsPdf* bindPdf(const char* name,CFUNCD4DDDD func,RooAbsReal& x, RooAbsReal& y, RooAbsReal& z, RooAbsReal& w) ;
+R__DEPRECATED(6, 34, "Use RooGenericPdf instead.")
 RooAbsPdf* bindPdf(const char* name,CFUNCD4DDDI func,RooAbsReal& x, RooAbsReal& y, RooAbsReal& z, RooAbsReal& w) ;
+R__DEPRECATED(6, 34, "Use RooGenericPdf instead.")
 RooAbsPdf* bindPdf(const char* name,CFUNCD4DDDB func,RooAbsReal& x, RooAbsReal& y, RooAbsReal& z, RooAbsReal& w) ;
 
 }

--- a/roofit/roofitcore/test/stressRooFit_tests.h
+++ b/roofit/roofitcore/test/stressRooFit_tests.h
@@ -369,11 +369,11 @@ public:
 
       // Bind one-dimensional TMath::Erf function as RooAbsReal function
       RooRealVar x("x", "x", -3, 3);
-      std::unique_ptr<RooAbsReal> erf{bindFunction("erf", TMath::Erf, x)};
+      RooFormulaVar errorFunc{"erf", "TMath::Erf(x)", {x}};
 
       // Plot erf on frame
       RooPlot *frame1 = x.frame(Title("TMath::Erf bound as RooFit function"));
-      erf->plotOn(frame1);
+      errorFunc.plotOn(frame1);
 
       // B i n d   R O O T : : M a t h : : b e t a _ p d f   C   f u n c t i o n
       // -----------------------------------------------------------------------
@@ -384,16 +384,16 @@ public:
       RooRealVar x2("x2", "x2", 0.001, 0.999);
       RooRealVar a("a", "a", 5, 0, 10);
       RooRealVar b("b", "b", 2, 0, 10);
-      std::unique_ptr<RooAbsPdf> beta{bindPdf("beta", ROOT::Math::beta_pdf, x2, a, b)};
+      RooGenericPdf beta{"beta", "ROOT::Math::beta_pdf(x2, a, b)", {x2, a, b}};
 
       // Generate some events and fit
-      std::unique_ptr<RooDataSet> data{beta->generate(x2, 10000)};
-      beta->fitTo(*data);
+      std::unique_ptr<RooDataSet> data{beta.generate(x2, 10000)};
+      beta.fitTo(*data);
 
       // Plot data and pdf on frame
       RooPlot *frame2 = x2.frame(Title("ROOT::Math::Beta bound as RooFit pdf"));
       data->plotOn(frame2);
-      beta->plotOn(frame2);
+      beta.plotOn(frame2);
 
       // B i n d   R O O T   T F 1   a s   R o o F i t   f u n c t i o n
       // ---------------------------------------------------------------

--- a/roofit/roostats/test/stressRooStats_tests.h
+++ b/roofit/roostats/test/stressRooStats_tests.h
@@ -32,7 +32,6 @@
 #include <TMath.h>
 
 // RooFit headers
-#include <RooCFunction1Binding.h>
 #include <RooDataSet.h>
 #include <RooGlobalFunc.h>
 #include <RooPlot.h>
@@ -498,8 +497,6 @@ class TestBayesianCalculator1 : public RooUnitTest {
 private:
    Int_t fObsValue;
    double fConfidenceLevel;
-   static double priorInv(double mean) { return 1.0 / mean; }
-   static double priorInvSqrt(double mean) { return 1.0 / sqrt(mean); }
 
 public:
    TestBayesianCalculator1(TFile *refFile, bool writeRef, Int_t verbose, Int_t obsValue = 3,
@@ -577,9 +574,8 @@ public:
 
          // create prior pdfs
          ws.factory("Uniform::prior(mean)");
-         ws.import(RooCFunction1PdfBinding<double, double>("priorInv", "priorInv", &priorInv, *ws.var("mean")));
-         ws.import(
-            RooCFunction1PdfBinding<double, double>("priorInvSqrt", "priorInvSqrt", priorInvSqrt, *ws.var("mean")));
+         ws.factory("EXPR::priorInv('1./mean', mean)");
+         ws.factory("EXPR::priorInvSqrt('1./std::sqrt(mean)', mean)");
          ws.factory(TString::Format("Gamma::priorGamma(mean, %lf, %lf, 0)", gammaShape, gammaRate).Data());
 
          // build argument sets and data set

--- a/tutorials/roofit/rf105_funcbinding.C
+++ b/tutorials/roofit/rf105_funcbinding.C
@@ -13,6 +13,9 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
+#include "RooFormulaVar.h"
+#include "RooGenericPdf.h"
+
 #include "TCanvas.h"
 #include "TAxis.h"
 #include "RooPlot.h"
@@ -31,14 +34,14 @@ void rf105_funcbinding()
 
    // Bind one-dimensional TMath::Erf function as RooAbsReal function
    RooRealVar x("x", "x", -3, 3);
-   RooAbsReal *errorFunc = bindFunction("erf", TMath::Erf, x);
+   RooFormulaVar errorFunc{"erf", "TMath::Erf(x)", {x}};
 
    // Print erf definition
-   errorFunc->Print();
+   errorFunc.Print();
 
    // Plot erf on frame
    RooPlot *frame1 = x.frame(Title("TMath::Erf bound as RooFit function"));
-   errorFunc->plotOn(frame1);
+   errorFunc.plotOn(frame1);
 
    // B i n d   R O O T : : M a t h : : b e t a _ p d f   C   f u n c t i o n
    // -----------------------------------------------------------------------
@@ -47,19 +50,19 @@ void rf105_funcbinding()
    RooRealVar x2("x2", "x2", 0, 0.999);
    RooRealVar a("a", "a", 5, 0, 10);
    RooRealVar b("b", "b", 2, 0, 10);
-   RooAbsPdf *beta = bindPdf("beta", ROOT::Math::beta_pdf, x2, a, b);
+   RooGenericPdf beta{"beta", "ROOT::Math::beta_pdf(x2, a, b)", {x2, a, b}};
 
    // Perf beta definition
-   beta->Print();
+   beta.Print();
 
    // Generate some events and fit
-   std::unique_ptr<RooDataSet> data{beta->generate(x2, 10000)};
-   beta->fitTo(*data, PrintLevel(-1));
+   std::unique_ptr<RooDataSet> data{beta.generate(x2, 10000)};
+   beta.fitTo(*data, PrintLevel(-1));
 
    // Plot data and pdf on frame
    RooPlot *frame2 = x2.frame(Title("ROOT::Math::Beta bound as RooFit pdf"));
    data->plotOn(frame2);
-   beta->plotOn(frame2);
+   beta.plotOn(frame2);
 
    // B i n d   R O O T   T F 1   a s   R o o F i t   f u n c t i o n
    // ---------------------------------------------------------------

--- a/tutorials/roofit/rf105_funcbinding.py
+++ b/tutorials/roofit/rf105_funcbinding.py
@@ -19,7 +19,7 @@ import ROOT
 
 # Bind one-dimensional ROOT.TMath.Erf function as ROOT.RooAbsReal function
 x = ROOT.RooRealVar("x", "x", -3, 3)
-erf = ROOT.RooFit.bindFunction("erf", ROOT.TMath.Erf, x)
+erf = ROOT.RooFormulaVar("erf", "TMath::Erf(x)", [x])
 
 # Print erf definition
 erf.Print()
@@ -35,7 +35,7 @@ erf.plotOn(frame1)
 x2 = ROOT.RooRealVar("x2", "x2", 0, 0.999)
 a = ROOT.RooRealVar("a", "a", 5, 0, 10)
 b = ROOT.RooRealVar("b", "b", 2, 0, 10)
-beta = ROOT.RooFit.bindPdf("beta", ROOT.Math.beta_pdf, x2, a, b)
+beta = ROOT.RooGenericPdf("beta", "ROOT::Math::beta_pdf(x2, a, b)", [x2, a, b])
 
 # Perf beta definition
 beta.Print()


### PR DESCRIPTION
The `RooCFunction*Binding` classes and the associated `RooFit::bindFunction()` and `RooFit::bindPdf()` functions are deprecated and will be removed in ROOT 6.32. Their functionality is redundant with the `RooFormulaVar` and `RooGenericPdf` that should be used instead.

This is another deprecation done in the spirit of avoiding duplicate interfaces and user confusion.