### PR TITLE
[RF] Prevent accidental casting from `double` to `int` in xroofit

### DIFF
--- a/roofit/xroofit/src/xRooNode.cxx
+++ b/roofit/xroofit/src/xRooNode.cxx
@@ -5775,9 +5775,9 @@ TH1 *xRooNode::BuildHistogram(RooAbsLValue *v, bool empty, bool errors, int binS
          if (x->hasError())
             h->SetBinError(1, x->getError());
          h->SetMaximum(x->hasMax() ? x->getMax()
-                                   : (h->GetBinContent(1) + std::max(abs(h->GetBinContent(1) * 0.1), 50.)));
+                                   : (h->GetBinContent(1) + std::max(std::abs(h->GetBinContent(1) * 0.1), 50.)));
          h->SetMinimum(x->hasMin() ? x->getMin()
-                                   : (h->GetBinContent(1) - std::max(abs(h->GetBinContent(1) * 0.1), 50.)));
+                                   : (h->GetBinContent(1) - std::max(std::abs(h->GetBinContent(1) * 0.1), 50.)));
          h->GetXaxis()->SetName(dynamic_cast<TObject *>(v)->GetName());
          return h;
       }


### PR DESCRIPTION
On the Snap build of ROOT, the parameters were assumed to be int, double

Errors from build log, running Ubuntu 20.04 GCC9 C++17

```
/root/parts/root/src/roofit/xroofit/src/xRooNode.cxx:5778:105: note:   deduced conflicting types for parameter ‘const _Tp’ (‘int’ and ‘double’)
 5778 |                                    : (h->GetBinContent(1) + std::max(abs(h->GetBinContent(1) * 0.1), 50.)));
 ```
 
 This doesn't appear to occur in normal builds, but the guard code seems trivial enough to include and this may prevent compilation errors in other scenarios.

## Checklist:

- [Y] tested changes locally
- [Y] updated the docs (if necessary)

