### PR TITLE
[ntuple] Fix tutorial `ntpl008_import.C`

### DIFF
--- a/tutorials/v7/ntuple/ntpl008_import.C
+++ b/tutorials/v7/ntuple/ntpl008_import.C
@@ -36,6 +36,10 @@ constexpr char const *kNTupleFileName = "ntpl008_import.root";
 
 void ntpl008_import()
 {
+   // RNTupleImporter appends keys to the output file; make sure a second run of the tutorial does not fail
+   // with `Key 'Events' already exists in file ntpl008_import.root` by removing the output file.
+   gSystem->Unlink(kNTupleFileName);
+
    // Use multiple threads to compress RNTuple data
    ROOT::EnableImplicitMT();
 


### PR DESCRIPTION
RNTupleImporter appends keys to the output file; make sure a second run of the tutorial does not fail with
```
terminate called after throwing an instance of 'ROOT::Experimental::RException'
  what():  Key 'Events' already exists in file ntpl008_import.root
```
by removing the output file.

This PR fixes #11987.