### PR TITLE
[v628][RF] Backports of RooFit PRs to `v6-28-00-patches`: Part 3

### DIFF
--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -311,7 +311,7 @@ inline bool checkRegularBins(const TAxis &ax)
    double w = ax.GetXmax() - ax.GetXmin();
    double bw = w / ax.GetNbins();
    for (int i = 0; i <= ax.GetNbins(); ++i) {
-      if (fabs(ax.GetBinUpEdge(i) - (ax.GetXmin() + (bw * i))) > w * 1e-6)
+      if (std::abs(ax.GetBinUpEdge(i) - (ax.GetXmin() + (bw * i))) > w * 1e-6)
          return false;
    }
    return true;

--- a/roofit/multiprocess/test/utils.h
+++ b/roofit/multiprocess/test/utils.h
@@ -53,7 +53,7 @@ generate_ND_gaussian_pdf_nll(RooWorkspace &w, unsigned int n, unsigned long N_ev
    double mean[n], sigma[n];
    for (unsigned ix = 0; ix < n; ++ix) {
       mean[ix] = RooRandom::randomGenerator()->Gaus(0, 2);
-      sigma[ix] = 0.1 + abs(RooRandom::randomGenerator()->Gaus(0, 2));
+      sigma[ix] = 0.1 + std::abs(RooRandom::randomGenerator()->Gaus(0, 2));
    }
 
    // create gaussians and also the observables and parameters they depend on
@@ -126,7 +126,7 @@ generate_ND_gaussian_pdf_nll(RooWorkspace &w, unsigned int n, unsigned long N_ev
          std::ostringstream os;
          os << "s" << ix;
          dynamic_cast<RooRealVar *>(w.arg(os.str().c_str()))
-            ->setVal(0.1 + abs(RooRandom::randomGenerator()->Gaus(0, 2)));
+            ->setVal(0.1 + std::abs(RooRandom::randomGenerator()->Gaus(0, 2)));
       }
    }
 

--- a/roofit/roofit/src/RooBCPEffDecay.cxx
+++ b/roofit/roofit/src/RooBCPEffDecay.cxx
@@ -225,7 +225,7 @@ void RooBCPEffDecay::generateEvent(Int_t code)
     // Accept event if T is in generated range
     double maxDil = 1.0 ;
     double al2 = _absLambda*_absLambda ;
-    double maxAcceptProb = (1+al2) + fabs(maxDil*_CPeigenval*_absLambda*_argLambda) + fabs(maxDil*(1-al2)/2);
+    double maxAcceptProb = (1+al2) + std::abs(maxDil*_CPeigenval*_absLambda*_argLambda) + std::abs(maxDil*(1-al2)/2);
     double acceptProb    = (1+al2)/2*(1-_tag*_delMistag)
                            - (_tag*(1-2*_avgMistag))*(_CPeigenval*_absLambda*_argLambda)*sin(_dm*tval)
                            - (_tag*(1-2*_avgMistag))*(1-al2)/2*cos(_dm*tval);

--- a/roofit/roofit/src/RooBCPGenDecay.cxx
+++ b/roofit/roofit/src/RooBCPGenDecay.cxx
@@ -224,7 +224,7 @@ void RooBCPGenDecay::generateEvent(Int_t code)
     // Accept event if T is in generated range
     double maxDil = 1.0 ;
 // 2 in next line is conservative and inefficient - allows for delMistag=1!
-    double maxAcceptProb = 2 + fabs(maxDil*_avgS) + fabs(maxDil*_avgC);
+    double maxAcceptProb = 2 + std::abs(maxDil*_avgS) + std::abs(maxDil*_avgC);
     double acceptProb    = (1-_tag*_delMistag + _mu*_tag*(1. - 2.*_avgMistag))
                            + (_tag*(1-2*_avgMistag) + _mu*(1. - _tag*_delMistag))*_avgS*sin(_dm*tval)
                            - (_tag*(1-2*_avgMistag) + _mu*(1. - _tag*_delMistag))*_avgC*cos(_dm*tval);

--- a/roofit/roofit/src/RooBDecay.cxx
+++ b/roofit/roofit/src/RooBDecay.cxx
@@ -223,7 +223,7 @@ void RooBDecay::generateEvent(Int_t code)
 
     double dgt = _dgamma*t/2;
     double dmt = _dm*t;
-    double ft = fabs(t);
+    double ft = std::abs(t);
     double f = exp(-ft/_tau)*(_f0*cosh(dgt)+_f1*sinh(dgt)+_f2*cos(dmt)+_f3*sin(dmt));
     if(f < 0) {
       cout << "RooBDecay::generateEvent(" << GetName() << ") ERROR: PDF value less than zero" << endl;

--- a/roofit/roofit/src/RooBukinPdf.cxx
+++ b/roofit/roofit/src/RooBukinPdf.cxx
@@ -96,7 +96,7 @@ double RooBukinPdf::evaluate() const
   r4=sqrt(xi*xi+1);
   r1=xi/r4;
 
-  if(fabs(xi) > exp(-6.)){
+  if(std::abs(xi) > exp(-6.)){
     r5=xi/log(r4+xi);
   }
   else
@@ -113,7 +113,7 @@ double RooBukinPdf::evaluate() const
 
   //--- Center
   else if(x < x2) {
-    if(fabs(xi) > exp(-6.)) {
+    if(std::abs(xi) > exp(-6.)) {
       r2=log(1 + 4 * xi * r4 * (x-Xp)/hp)/log(1+2*xi*(xi-r4));
       r2=-r3*r2*r2;
     }
@@ -128,7 +128,7 @@ double RooBukinPdf::evaluate() const
     r2=rho2*(x-x2)*(x-x2)/(Xp-x2)/(Xp-x2)-r3 - 4 * r3 * (x-x2)/hp * r5 * r4/(r4+xi)/(r4+xi);
   }
 
-  if(fabs(r2) > 100){
+  if(std::abs(r2) > 100){
     fit_result = 0;
   }
   else{

--- a/roofit/roofit/src/RooCBShape.cxx
+++ b/roofit/roofit/src/RooCBShape.cxx
@@ -76,7 +76,7 @@ double RooCBShape::evaluate() const {
   double t = (m-m0)/sigma;
   if (alpha < 0) t = -t;
 
-  double absAlpha = fabs((double)alpha);
+  double absAlpha = std::abs((double)alpha);
 
   if (t >= -absAlpha) {
     return exp(-0.5*t*t);
@@ -119,10 +119,10 @@ double RooCBShape::analyticalIntegral(Int_t code, const char* rangeName) const
   double result = 0.0;
   bool useLog = false;
 
-  if( fabs(n-1.0) < 1.0e-05 )
+  if( std::abs(n-1.0) < 1.0e-05 )
     useLog = true;
 
-  double sig = fabs((double)sigma);
+  double sig = std::abs((double)sigma);
 
   double tmin = (m.min(rangeName)-m0)/sig;
   double tmax = (m.max(rangeName)-m0)/sig;
@@ -133,7 +133,7 @@ double RooCBShape::analyticalIntegral(Int_t code, const char* rangeName) const
     tmax = -tmp;
   }
 
-  double absAlpha = fabs((double)alpha);
+  double absAlpha = std::abs((double)alpha);
 
   if( tmin >= -absAlpha ) {
     result += sig*sqrtPiOver2*(   ApproxErf(tmax/sqrt2)

--- a/roofit/roofit/src/RooGExpModel.cxx
+++ b/roofit/roofit/src/RooGExpModel.cxx
@@ -211,7 +211,7 @@ namespace {
 double logErfC(double xx)
 {
   double t,z,ans;
-  z=fabs(xx);
+  z=std::abs(xx);
   t=1.0/(1.0+0.5*z);
 
   if(xx >= 0.0)
@@ -469,10 +469,10 @@ double RooGExpModel::calcDecayConv(double sign, double tau, double sig, double r
   sign *= fsign ;  // modified FMV,08/13/03
 
   double cFly;
-  if ((sign<0)&&(fabs(tau-rtau)<tau/260)) {
+  if ((sign<0)&&(std::abs(tau-rtau)<tau/260)) {
 
     double MeanTau=0.5*(tau+rtau);
-    if (fabs(xp/MeanTau)>300) {
+    if (std::abs(xp/MeanTau)>300) {
       return 0 ;
     }
 
@@ -848,7 +848,7 @@ double RooGExpModel::calcSinConvNorm(double sign, double tau, double sig, double
   double term2 = evalCerfInt(-fsign, rtau, fsign*umin2, fsign*umax2, c2)*fsign*sign;
 
   // WVE Handle 0/0 numeric divergence
-  if (fabs(tau-rtau)<1e-10 && fabs(term1+term2)<1e-10) {
+  if (std::abs(tau-rtau)<1e-10 && std::abs(term1+term2)<1e-10) {
     cout << "epsilon method" << endl ;
     static double epsilon = 1e-4 ;
     return calcSinConvNorm(sign,tau+epsilon,sig,rtau-epsilon,fsign,rangeName) ;

--- a/roofit/roofit/src/RooIntegralMorph.cxx
+++ b/roofit/roofit/src/RooIntegralMorph.cxx
@@ -389,7 +389,7 @@ void RooIntegralMorph::MorphCacheElem::calculate(TIterator* dIter)
     // Calculate additional offset to apply if bin ixlo does not have X value calculated at bin center
     double xBinC = xmin + (i+0.5)*binw ;
     double xOffset = xBinC-_calcX[i] ;
-    if (fabs(xOffset/binw)>1e-3) {
+    if (std::abs(xOffset/binw)>1e-3) {
       double slope = (_yatX[i+1]-_yatX[i-1])/(_calcX[i+1]-_calcX[i-1]) ;
       double newY = _yatX[i] + slope*xOffset ;
       //cout << "bin " << i << " needs to be re-centered " << xOffset/binw << " slope = " << slope << " origY = " << _yatX[i] << " newY = " << newY << endl ;
@@ -481,7 +481,7 @@ void RooIntegralMorph::MorphCacheElem::fillGap(Int_t ixlo, Int_t ixhi, double sp
 
 
   // Policy: If centration quality is better than 1% OR better than 1/10 of a bin, fill interval with linear interpolation
-  if (fabs(cq)<0.01 || fabs(cq*(ixhi-ixlo))<0.1 || ymid<_ycutoff ) {
+  if (std::abs(cq)<0.01 || std::abs(cq*(ixhi-ixlo))<0.1 || ymid<_ycutoff ) {
 
     // Fill remaining gaps on either side with linear interpolation
     if (iX-ixlo>1) {
@@ -584,7 +584,7 @@ void RooIntegralMorph::MorphCacheElem::findRange()
 
     // Terminate if value of X no longer moves by >0.1 bin size
     double X = _alpha->getVal()*x1 + (1-_alpha->getVal())*x2 ;
-    if (fabs(X-Xlast)/(xmax-xmin)<0.0001) {
+    if (std::abs(X-Xlast)/(xmax-xmin)<0.0001) {
       break ;
     }
     Xlast=X ;
@@ -621,7 +621,7 @@ void RooIntegralMorph::MorphCacheElem::findRange()
 
     // Terminate if value of X no longer moves by >0.1 bin size
     double X = _alpha->getVal()*x1 + (1-_alpha->getVal())*x2 ;
-    if (fabs(X-Xlast)/(xmax-xmin)<0.0001) {
+    if (std::abs(X-Xlast)/(xmax-xmin)<0.0001) {
       break ;
     }
     Xlast=X ;

--- a/roofit/roofit/src/RooLagrangianMorphFunc.cxx
+++ b/roofit/roofit/src/RooLagrangianMorphFunc.cxx
@@ -317,7 +317,7 @@ inline double invertMatrix(const Matrix &matrix, Matrix &inverse)
    // sanitize numeric problems
    for (size_t i = 0; i < n; ++i)
       for (size_t j = 0; j < n; ++j)
-         if (fabs(inverse(i, j)) < 1e-9)
+         if (std::abs(inverse(i, j)) < 1e-9)
             inverse(i, j) = 0;
    return condition;
 }
@@ -1060,8 +1060,8 @@ inline void inverseSanity(const Matrix &matrix, const Matrix &inverse, double &u
          if (inverse(i, j) > largestWeight) {
             largestWeight = (double)inverse(i, j);
          }
-         if (fabs(unity(i, j) - static_cast<int>(i == j)) > unityDeviation) {
-            unityDeviation = fabs((double)unity(i, j)) - static_cast<int>(i == j);
+         if (std::abs(unity(i, j) - static_cast<int>(i == j)) > unityDeviation) {
+            unityDeviation = std::abs((double)unity(i, j)) - static_cast<int>(i == j);
          }
       }
    }

--- a/roofit/roofit/src/RooNDKeysPdf.cxx
+++ b/roofit/roofit/src/RooNDKeysPdf.cxx
@@ -1242,9 +1242,9 @@ double RooNDKeysPdf::analyticalIntegral(Int_t code, const char* rangeName) const
      chi[j] = (bi->xVarHi[j]-x[j])/weight[j];
 
    if (chi[j]>0) // inVarRange
-     prob *= (0.5 + TMath::Erf(fabs(chi[j])/sqrt(2.))/2.);
+     prob *= (0.5 + TMath::Erf(std::abs(chi[j])/sqrt(2.))/2.);
    else // outside Var range
-     prob *= (0.5 - TMath::Erf(fabs(chi[j])/sqrt(2.))/2.);
+     prob *= (0.5 - TMath::Erf(std::abs(chi[j])/sqrt(2.))/2.);
       }
 
       norm += prob * _wMap.at(_idx[bi->sIdcs[i]]);

--- a/roofit/roofit/test/testRooBernstein.cxx
+++ b/roofit/roofit/test/testRooBernstein.cxx
@@ -55,8 +55,8 @@ void IntegrationChecker(double a0, double a1, double a2, double a3)
   auto numInt_full = bern.createIntegral(x, "FULL");
 
   // closure
-  EXPECT_LT(fabs(int_full->getVal() - int_range1->getVal() - int_range2->getVal() - int_range3->getVal()), 1e-10);
-  EXPECT_LT(fabs(numInt_full->getVal() - numInt_range1->getVal() - numInt_range2->getVal() - numInt_range3->getVal()), 1e-10);
+  EXPECT_LT(std::abs(int_full->getVal() - int_range1->getVal() - int_range2->getVal() - int_range3->getVal()), 1e-10);
+  EXPECT_LT(std::abs(numInt_full->getVal() - numInt_range1->getVal() - numInt_range2->getVal() - numInt_range3->getVal()), 1e-10);
 
   // comparision with polynomial
   double accAnaVsNum = 1.;

--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -299,9 +299,9 @@ public:
   static void verboseEval(Int_t stat) ;
   static int verboseEval() ;
 
-  double extendedTerm(double sumEntries, double expected, double sumEntriesW2=0.0) const;
-  double extendedTerm(double sumEntries, RooArgSet const* nset, double sumEntriesW2=0.0) const;
-  double extendedTerm(RooAbsData const& data, bool weightSquared) const;
+  double extendedTerm(double sumEntries, double expected, double sumEntriesW2=0.0, bool doOffset=false) const;
+  double extendedTerm(double sumEntries, RooArgSet const* nset, double sumEntriesW2=0.0, bool doOffset=false) const;
+  double extendedTerm(RooAbsData const& data, bool weightSquared, bool doOffset=false) const;
 
   void setNormRange(const char* rangeName) ;
   const char* normRange() const {

--- a/roofit/roofitcore/inc/RooGlobalFunc.h
+++ b/roofit/roofitcore/inc/RooGlobalFunc.h
@@ -70,7 +70,7 @@ enum class BatchModeOption { Off, Cpu, Cuda, Old };
 
 /// For setting the offset mode with the Offset() command argument to
 /// RooAbsPdf::fitTo()
-enum class OffsetMode { Off, Initial, Bin };
+enum class OffsetMode { None, Initial, Bin };
 
 namespace Experimental {
 

--- a/roofit/roofitcore/inc/RooNLLVar.h
+++ b/roofit/roofitcore/inc/RooNLLVar.h
@@ -61,8 +61,8 @@ public:
     _batchEvaluations = on;
   }
 
-  void templateRatioOffset(bool on = true) {
-    _templateRatioOffset = on;
+  void enableBinOffsetting(bool on = true) {
+    _doBinOffset = on;
   }
 
   using ComputeResult = std::pair<ROOT::Math::KahanSum<double>, double>;
@@ -73,7 +73,7 @@ public:
                                                  std::size_t firstEvent, std::size_t lastEvent);
   static RooNLLVar::ComputeResult computeScalarFunc(const RooAbsPdf *pdfClone, RooAbsData *dataClone, RooArgSet *normSet,
                                                 bool weightSq, std::size_t stepSize, std::size_t firstEvent,
-                                                std::size_t lastEvent, bool templateRatioOffset=false);
+                                                std::size_t lastEvent, bool doBinOffset=false);
 
 protected:
 
@@ -88,7 +88,7 @@ private:
 
   bool _extended{false};
   bool _batchEvaluations{false};
-  bool _templateRatioOffset{false};
+  bool _doBinOffset{false};
   bool _weightSq{false}; ///< Apply weights squared?
   mutable bool _first{true}; ///<!
   ROOT::Math::KahanSum<double> _offsetSaveW2{0.0}; ///<!

--- a/roofit/roofitcore/inc/RooPlot.h
+++ b/roofit/roofitcore/inc/RooPlot.h
@@ -204,6 +204,8 @@ public:
 
   static void fillItemsFromTList(Items & items, TList const& tlist);
 
+  void createInternalPlotVarClone();
+
 protected:
 
   RooPlot(const RooPlot& other) = delete; // cannot be copied

--- a/roofit/roofitcore/src/RooAbsCategory.cxx
+++ b/roofit/roofitcore/src/RooAbsCategory.cxx
@@ -665,7 +665,7 @@ bool RooAbsCategory::isSignType(bool mustHaveZero) const
   if (mustHaveZero && theStateNames.size() != 3) return false;
 
   for (const auto& type : theStateNames) {
-    if (abs(type.second)>1)
+    if (std::abs(type.second)>1)
       return false;
   }
 

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -2503,7 +2503,7 @@ RooDataHist *RooAbsPdf::generateBinned(const RooArgSet &whatVars, double nEvents
     // Second pass for regular mode - Trim/Extend dataset to exact number of entries
 
     // Calculate difference between what is generated so far and what is requested
-    Int_t nEvtExtra = abs(Int_t(nEvents)-histOutSum) ;
+    Int_t nEvtExtra = std::abs(Int_t(nEvents)-histOutSum) ;
     Int_t wgt = (histOutSum>nEvents) ? -1 : 1 ;
 
     // Perform simple binned accept/reject procedure to get to exact event count

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -4844,7 +4844,7 @@ void RooAbsReal::checkBatchComputation(const RooBatchCompute::RunContext& evalDa
   const double batchVal = batch.size() == 1 ? batch[0] : batch[evtNo];
   const double relDiff = value != 0. ? (value - batchVal)/value : value - batchVal;
 
-  if (fabs(relDiff) > relAccuracy && fabs(value) > 1.E-300) {
+  if (std::abs(relDiff) > relAccuracy && std::abs(value) > 1.E-300) {
     FormatPdfTree formatter;
     formatter << "--> (Batch computation wrong:)\n";
     printStream(formatter.stream(), kName | kClassName | kArgs | kExtras | kAddress, kInline);

--- a/roofit/roofitcore/src/RooAbsRealLValue.cxx
+++ b/roofit/roofitcore/src/RooAbsRealLValue.cxx
@@ -493,7 +493,7 @@ bool RooAbsRealLValue::fitRangeOKForPlotting() const
 bool RooAbsRealLValue::inRange(const char* name) const
 {
   const double val = getVal() ;
-  const double epsilon = 1e-8 * fabs(val) ;
+  const double epsilon = 1e-8 * std::abs(val) ;
   if (!name || name[0] == '\0') {
     const auto minMax = getRange(nullptr);
     return minMax.first - epsilon <= val && val <= minMax.second + epsilon;

--- a/roofit/roofitcore/src/RooBinnedGenContext.cxx
+++ b/roofit/roofitcore/src/RooBinnedGenContext.cxx
@@ -196,7 +196,7 @@ RooDataSet *RooBinnedGenContext::generate(double nEvt, bool /*skipInit*/, bool e
     // Second pass for regular mode - Trim/Extend dataset to exact number of entries
 
     // Calculate difference between what is generated so far and what is requested
-    Int_t nEvtExtra = abs(Int_t(nEvents)-histOutSum) ;
+    Int_t nEvtExtra = std::abs(Int_t(nEvents)-histOutSum) ;
     Int_t wgt = (histOutSum>nEvents) ? -1 : 1 ;
 
     // Perform simple binned accept/reject procedure to get to exact event count

--- a/roofit/roofitcore/src/RooBrentRootFinder.cxx
+++ b/roofit/roofitcore/src/RooBrentRootFinder.cxx
@@ -80,7 +80,7 @@ bool RooBrentRootFinder::findRoot(double &result, double xlo, double xhi, double
       e = b - a;
     }
 
-    if (fabs (fc) < fabs (fb)) {
+    if (std::abs(fc) < std::abs(fb)) {
       ac_equal = true;
       a = b;
       b = c;
@@ -90,18 +90,18 @@ bool RooBrentRootFinder::findRoot(double &result, double xlo, double xhi, double
       fc = fa;
     }
 
-    double tol = 0.5 * _tol * fabs(b);
+    double tol = 0.5 * _tol * std::abs(b);
     double m = 0.5 * (c - b);
 
 
-    if (fb == 0 || fabs(m) <= tol) {
+    if (fb == 0 || std::abs(m) <= tol) {
       //cout << "RooBrentRootFinder: iter = " << iter << " m = " << m << " tol = " << tol << endl ;
       result= b;
       _function->restoreXVec() ;
       return true;
     }
 
-    if (fabs (e) < tol || fabs (fa) <= fabs (fb)) {
+    if (std::abs(e) < tol || std::abs(fa) <= std::abs(fb)) {
       // Bounds decreasing too slowly: use bisection
       d = m;
       e = m;
@@ -129,8 +129,8 @@ bool RooBrentRootFinder::findRoot(double &result, double xlo, double xhi, double
    p = -p;
       }
 
-      double min1= 3 * m * q - fabs (tol * q);
-      double min2= fabs (e * q);
+      double min1= 3 * m * q - std::abs(tol * q);
+      double min2= std::abs(e * q);
       if (2 * p < (min1 < min2 ? min1 : min2)) {
    // Accept the interpolation
    e = d;
@@ -146,7 +146,7 @@ bool RooBrentRootFinder::findRoot(double &result, double xlo, double xhi, double
     a = b;
     fa = fb;
     // Evaluate new trial root
-    if (fabs (d) > tol) {
+    if (std::abs(d) > tol) {
       b += d;
     }
     else {

--- a/roofit/roofitcore/src/RooCurve.cxx
+++ b/roofit/roofitcore/src/RooCurve.cxx
@@ -424,7 +424,7 @@ void RooCurve::addRange(const RooAbsFunc& func, double x1, double x2,
          Int_t numee, bool doEEVal, double eeVal)
 {
   // Explicitly skip empty ranges to eliminate point duplication
-  if (fabs(x2-x1)<1e-20) {
+  if (std::abs(x2-x1)<1e-20) {
     return ;
   }
 
@@ -449,7 +449,7 @@ void RooCurve::addRange(const RooAbsFunc& func, double x1, double x2,
 
   // test if the midpoint is sufficiently close to a straight line across this interval
   double dy= ymid - 0.5*(y1+y2);
-  if((xmid - x1 >= minDx) && fabs(dy)>0 && fabs(dy) >= minDy) {
+  if((xmid - x1 >= minDx) && std::abs(dy)>0 && std::abs(dy) >= minDy) {
     // fill in each subrange
     addRange(func,x1,xmid,y1,ymid,minDy,minDx,numee,doEEVal,eeVal);
     addRange(func,xmid,x2,ymid,y2,minDy,minDx,numee,doEEVal,eeVal);
@@ -671,8 +671,8 @@ Int_t RooCurve::findPoint(double xvalue, double tolerance) const
   Int_t ibest(-1) ;
   for (i=0 ; i<n ; i++) {
     GetPoint(i,x,y);
-    if (fabs(xvalue-x)<delta) {
-      delta = fabs(xvalue-x) ;
+    if (std::abs(xvalue-x)<delta) {
+      delta = std::abs(xvalue-x) ;
       ibest = i ;
     }
   }
@@ -697,7 +697,7 @@ double RooCurve::interpolate(double xvalue, double tolerance) const
   const_cast<RooCurve*>(this)->GetPoint(ibest,xbest,ybest) ;
 
   // Handle trivial case of being dead on
-  if (fabs(xbest-xvalue)<tolerance) {
+  if (std::abs(xbest-xvalue)<tolerance) {
     return ybest ;
   }
 
@@ -897,7 +897,7 @@ bool RooCurve::isIdentical(const RooCurve& other, double tol, bool verbose) cons
   bool ret(true) ;
   for(Int_t i= 2; i < n-2; i++) {
     double yTest = interpolate(other.fX[i],1e-10) ;
-    double rdy = fabs(yTest-other.fY[i])/Yrange ;
+    double rdy = std::abs(yTest-other.fY[i])/Yrange ;
     if (rdy>tol) {
       ret = false;
       if(!verbose) continue;

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -684,7 +684,7 @@ void RooDataHist::_adjustBinning(RooRealVar &theirVar, const TAxis &axis,
 
     theirVar.setBinning(xbins);
 
-    if (true || fabs(xloAdj - xlo) > tolerance || fabs(xhiAdj - xhi) > tolerance) {
+    if (true || std::abs(xloAdj - xlo) > tolerance || std::abs(xhiAdj - xhi) > tolerance) {
        coutI(DataHandling) << "RooDataHist::adjustBinning(" << ownName << "): fit range of variable " << ourVarName
                            << " expanded to nearest bin boundaries: [" << xlo << "," << xhi << "] --> [" << xloAdj
                            << "," << xhiAdj << "]"
@@ -708,7 +708,7 @@ void RooDataHist::_adjustBinning(RooRealVar &theirVar, const TAxis &axis,
     xbins.setRange(xloAdj, xhiAdj);
     theirVar.setRange(xloAdj, xhiAdj);
 
-    if (fabs(xloAdj - xlo) > tolerance || fabs(xhiAdj - xhi) > tolerance) {
+    if (std::abs(xloAdj - xlo) > tolerance || std::abs(xhiAdj - xhi) > tolerance) {
        coutI(DataHandling) << "RooDataHist::adjustBinning(" << ownName << "): fit range of variable " << ourVarName
                            << " expanded to nearest bin boundaries: [" << xlo << "," << xhi << "] --> [" << xloAdj
                            << "," << xhiAdj << "]"
@@ -2228,7 +2228,7 @@ bool RooDataHist::isNonPoissonWeighted() const
   for (Int_t i=0; i < _arrSize; ++i) {
     const double wgt = _wgt[i];
     double intpart;
-    if (fabs(std::modf(wgt, &intpart)) > 1.E-10)
+    if (std::abs(std::modf(wgt, &intpart)) > 1.E-10)
       return true;
   }
 

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -1094,7 +1094,7 @@ bool RooDataSet::isNonPoissonWeighted() const
   // Now examine individual weights
   for (int i=0 ; i<numEntries() ; i++) {
     get(i) ;
-    if (fabs(weight()-Int_t(weight()))>1e-10) return true ;
+    if (std::abs(weight()-Int_t(weight()))>1e-10) return true ;
   }
   // If sum of weights is less than number of events there are negative (integer) weights
   if (sumEntries()<numEntries()) return true ;
@@ -1147,7 +1147,7 @@ void RooDataSet::add(const RooArgSet& data, double wgt, double wgtError)
 
   if (_wgtVar && _doWeightErrorCheck
       && wgtError != 0.
-      && fabs(wgt*wgt - wgtError)/wgtError > 1.E-15 //Exception for standard wgt^2 errors, which need not be stored.
+      && std::abs(wgt*wgt - wgtError)/wgtError > 1.E-15 //Exception for standard wgt^2 errors, which need not be stored.
       && _errorMsgCount < 5 && !_wgtVar->getAttribute("StoreError")) {
     coutE(DataHandling) << "An event weight error was passed to the RooDataSet '" << GetName()
         << "', but the weight variable '" << _wgtVar->GetName()

--- a/roofit/roofitcore/src/RooExpensiveObjectCache.cxx
+++ b/roofit/roofitcore/src/RooExpensiveObjectCache.cxx
@@ -237,7 +237,7 @@ bool RooExpensiveObjectCache::ExpensiveObject::matches(TClass* tc, const RooArgS
   for(RooAbsArg * arg : params) {
     RooAbsReal* real = dynamic_cast<RooAbsReal*>(arg) ;
     if (real) {
-      if (fabs(real->getVal()-_realRefParams[real->GetName()])>1e-12) {
+      if (std::abs(real->getVal()-_realRefParams[real->GetName()])>1e-12) {
    return false ;
       }
     } else {

--- a/roofit/roofitcore/src/RooFitResult.cxx
+++ b/roofit/roofitcore/src/RooFitResult.cxx
@@ -850,7 +850,7 @@ bool RooFitResult::isIdentical(const RooFitResult& other, double tol, double tol
   bool ret = isIdenticalNoCov(other, tol, 1e-3 /* synced with default parameter*/, verbose);
 
   auto deviationCorr = [tolCorr](const double left, const double right){
-    return fabs(left - right) >= tolCorr;
+    return std::abs(left - right) >= tolCorr;
   };
 
   // Only examine correlations for cases with >1 floating parameter

--- a/roofit/roofitcore/src/RooGlobalFunc.cxx
+++ b/roofit/roofitcore/src/RooGlobalFunc.cxx
@@ -282,8 +282,8 @@ namespace RooFit {
   RooCmdArg Offset(std::string const& mode) {
       std::string lower = mode;
       std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c){ return std::tolower(c); });
-      OffsetMode modeVal = OffsetMode::Off;
-      if(lower == "off") modeVal = OffsetMode::Off;
+      OffsetMode modeVal = OffsetMode::None;
+      if(lower == "none") modeVal = OffsetMode::None;
       else if(lower == "initial") modeVal = OffsetMode::Initial;
       else if(lower == "bin") modeVal = OffsetMode::Bin;
       return RooCmdArg("OffsetLikelihood", static_cast<int>(modeVal));

--- a/roofit/roofitcore/src/RooHistFunc.cxx
+++ b/roofit/roofitcore/src/RooHistFunc.cxx
@@ -481,12 +481,12 @@ bool RooHistFunc::importWorkspaceHook(RooWorkspace& ws)
 
 bool RooHistFunc::areIdentical(const RooDataHist& dh1, const RooDataHist& dh2)
 {
-  if (fabs(dh1.sumEntries()-dh2.sumEntries())>1e-8) return false ;
+  if (std::abs(dh1.sumEntries()-dh2.sumEntries())>1e-8) return false ;
   if (dh1.numEntries() != dh2.numEntries()) return false ;
   for (int i=0 ; i < dh1.numEntries() ; i++) {
     dh1.get(i) ;
     dh2.get(i) ;
-    if (fabs(dh1.weight()-dh2.weight())>1e-8) return false ;
+    if (std::abs(dh1.weight()-dh2.weight())>1e-8) return false ;
   }
   using RooHelpers::getColonSeparatedNameString;
   if (getColonSeparatedNameString(*dh1.get()) != getColonSeparatedNameString(*dh2.get())) return false ;

--- a/roofit/roofitcore/src/RooHistPdf.cxx
+++ b/roofit/roofitcore/src/RooHistPdf.cxx
@@ -520,12 +520,12 @@ double RooHistPdf::maxVal(Int_t code) const
 
 bool RooHistPdf::areIdentical(const RooDataHist& dh1, const RooDataHist& dh2)
 {
-  if (fabs(dh1.sumEntries()-dh2.sumEntries())>1e-8) return false ;
+  if (std::abs(dh1.sumEntries()-dh2.sumEntries())>1e-8) return false ;
   if (dh1.numEntries() != dh2.numEntries()) return false ;
   for (int i=0 ; i < dh1.numEntries() ; i++) {
     dh1.get(i) ;
     dh2.get(i) ;
-    if (fabs(dh1.weight()-dh2.weight())>1e-8) return false ;
+    if (std::abs(dh1.weight()-dh2.weight())>1e-8) return false ;
   }
   return true ;
 }

--- a/roofit/roofitcore/src/RooIntegrator1D.cxx
+++ b/roofit/roofitcore/src/RooIntegrator1D.cxx
@@ -298,10 +298,10 @@ double RooIntegrator1D::integral(const double *yvec)
         _extrapError = _s[j]-_s[j-1] ;
       }
 
-      if(fabs(_extrapError) <= _epsRel*fabs(_extrapValue)) {
+      if(std::abs(_extrapError) <= _epsRel*std::abs(_extrapValue)) {
         return _extrapValue;
       }
-      if(fabs(_extrapError) <= _epsAbs) {
+      if(std::abs(_extrapError) <= _epsAbs) {
         return _extrapValue ;
       }
 
@@ -395,9 +395,9 @@ void RooIntegrator1D::extrapolate(Int_t n)
   Int_t i,m,ns=1;
   double den,dif,dift,ho,hp,w;
 
-  dif=fabs(xa[1]);
+  dif=std::abs(xa[1]);
   for (i= 1; i <= _nPoints; i++) {
-    if ((dift=fabs(xa[i])) < dif) {
+    if ((dift=std::abs(xa[i])) < dif) {
       ns=i;
       dif=dift;
     }

--- a/roofit/roofitcore/src/RooMCStudy.cxx
+++ b/roofit/roofitcore/src/RooMCStudy.cxx
@@ -1007,7 +1007,12 @@ RooPlot* RooMCStudy::plotError(const RooRealVar& param, const RooCmdArg& arg1, c
 
   std::unique_ptr<RooErrorVar> evar{param.errorVar()};
   std::unique_ptr<RooRealVar> evar_rrv{static_cast<RooRealVar*>(evar->createFundamental())};
-  return plotParam(*evar_rrv,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8);
+  RooPlot* frame = plotParam(*evar_rrv,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8) ;
+
+  // To make sure the frame has no dangling pointer to evar_rrv.
+  frame->createInternalPlotVarClone();
+
+  return frame ;
 }
 
 namespace {
@@ -1132,6 +1137,9 @@ RooPlot* RooMCStudy::plotPull(const RooRealVar& param, const RooCmdArg& arg1, co
     if (fitGauss) {
       fitGaussToPulls(*frame, *_fitParData);
     }
+
+    // To make sure the frame has no dangling pointer to pvar.
+    frame->createInternalPlotVarClone();
   }
   return frame;
 }

--- a/roofit/roofitcore/src/RooMath.cxx
+++ b/roofit/roofitcore/src/RooMath.cxx
@@ -87,9 +87,9 @@ double RooMath::interpolate(double ya[], Int_t n, double x)
    double den, dif, dift /*,ho,hp,w*/, y, dy;
    double c[20], d[20];
 
-   dif = fabs(x);
+   dif = std::abs(x);
    for (i = 1; i <= n; i++) {
-      if ((dift = fabs(x - itod[i - 1])) < dif) {
+      if ((dift = std::abs(x - itod[i - 1])) < dif) {
          ns = i;
          dif = dift;
       }
@@ -121,9 +121,9 @@ double RooMath::interpolate(double xa[], double ya[], Int_t n, double x)
    double den, dif, dift, ho, hp, w, y, dy;
    double c[20], d[20];
 
-   dif = fabs(x - xa[0]);
+   dif = std::abs(x - xa[0]);
    for (i = 1; i <= n; i++) {
-      if ((dift = fabs(x - xa[i - 1])) < dif) {
+      if ((dift = std::abs(x - xa[i - 1])) < dif) {
          ns = i;
          dif = dift;
       }

--- a/roofit/roofitcore/src/RooMultiVarGaussian.cxx
+++ b/roofit/roofitcore/src/RooMultiVarGaussian.cxx
@@ -287,7 +287,7 @@ Int_t RooMultiVarGaussian::getAnalyticalIntegral(RooArgSet& allVarsIn, RooArgSet
 double RooMultiVarGaussian::analyticalIntegral(Int_t code, const char* /*rangeName*/) const
 {
   if (code==-1) {
-    return pow(2*3.14159268,_x.getSize()/2.)*sqrt(fabs(_det)) ;
+    return pow(2*3.14159268,_x.getSize()/2.)*sqrt(std::abs(_det)) ;
   }
 
   // Handle partial integrals here
@@ -303,7 +303,7 @@ double RooMultiVarGaussian::analyticalIntegral(Int_t code, const char* /*rangeNa
   }
 
   // Calculate partial integral
-  double ret = pow(2*3.14159268,aid.nint/2.)/sqrt(fabs(aid.S22det))*exp(-0.5*u*(aid.S22bar*u)) ;
+  double ret = pow(2*3.14159268,aid.nint/2.)/sqrt(std::abs(aid.S22det))*exp(-0.5*u*(aid.S22bar*u)) ;
 
   return ret ;
 }

--- a/roofit/roofitcore/src/RooNLLVar.cxx
+++ b/roofit/roofitcore/src/RooNLLVar.cxx
@@ -311,7 +311,7 @@ double RooNLLVar::evaluatePartition(std::size_t firstEvent, std::size_t lastEven
 
     // include the extended maximum likelihood term, if requested
     if(_extended && _setNum==_extSet) {
-      result += pdfClone->extendedTerm(*_dataClone, _weightSq);
+      result += pdfClone->extendedTerm(*_dataClone, _weightSq, _templateRatioOffset);
     }
   } //unbinned PDF
 

--- a/roofit/roofitcore/src/RooNLLVarNew.cxx
+++ b/roofit/roofitcore/src/RooNLLVarNew.cxx
@@ -62,6 +62,11 @@ RooArgSet getObs(RooAbsArg const &arg, RooArgSet const &observables)
    return out;
 }
 
+RooRealVar *dummyVar(const char *name)
+{
+   return new RooRealVar(name, name, 1.0);
+}
+
 } // namespace
 
 /** Construct a RooNLLVarNew
@@ -74,39 +79,18 @@ RooArgSet getObs(RooAbsArg const &arg, RooArgSet const &observables)
 RooNLLVarNew::RooNLLVarNew(const char *name, const char *title, RooAbsPdf &pdf, RooArgSet const &observables,
                            bool isExtended, RooFit::OffsetMode offsetMode, bool binnedL)
    : RooAbsReal(name, title), _pdf{"pdf", "pdf", this, pdf}, _observables{getObs(pdf, observables)},
-     _isExtended{isExtended}, _binnedL{binnedL},
-     _weightVar{"weightVar", "weightVar", this, *new RooRealVar(weightVarName, weightVarName, 1.0), true, false, true},
-     _weightSquaredVar{weightVarNameSumW2,
-                       weightVarNameSumW2,
-                       this,
-                       *new RooRealVar("weightSquardVar", "weightSquaredVar", 1.0),
-                       true,
-                       false,
-                       true}
+     _isExtended{isExtended}, _binnedL{binnedL}, _weightVar{"weightVar", "weightVar", this, *dummyVar(weightVarName),
+                                                            true,        false,       true},
+     _weightSquaredVar{weightVarNameSumW2, weightVarNameSumW2, this, *dummyVar("weightSquardVar"), true, false, true},
+     _binVolumeVar{"binVolumeVar", "binVolumeVar", this, *dummyVar("_bin_volume"), true, false, true}
 {
    if (_binnedL) {
-      if (_observables.size() != 1) {
-         throw std::runtime_error("BinnedPdf optimization only works with a 1D pdf.");
-      } else {
-         auto *var = static_cast<RooRealVar *>(_observables.first());
-         std::list<double> *boundaries = pdf.binBoundaries(*var, var->getMin(), var->getMax());
-         std::list<double>::iterator biter = boundaries->begin();
-         _binw.resize(boundaries->size() - 1);
-         double lastBound = (*biter);
-         ++biter;
-         int ibin = 0;
-         while (biter != boundaries->end()) {
-            _binw[ibin] = (*biter) - lastBound;
-            lastBound = (*biter);
-            ibin++;
-            ++biter;
-         }
-      }
+      fillBinWidthsFromPdfBoundaries(pdf);
    }
 
    resetWeightVarNames();
    enableOffsetting(offsetMode == RooFit::OffsetMode::Initial);
-   // TODO: implement template offsetting mode as well
+   enableBinOffsetting(offsetMode == RooFit::OffsetMode::Bin);
 }
 
 RooNLLVarNew::RooNLLVarNew(const RooNLLVarNew &other, const char *name)
@@ -116,6 +100,32 @@ RooNLLVarNew::RooNLLVarNew(const RooNLLVarNew &other, const char *name)
      _weightVar{"weightVar", this, other._weightVar}, _weightSquaredVar{"weightSquaredVar", this,
                                                                         other._weightSquaredVar}
 {
+}
+
+void RooNLLVarNew::fillBinWidthsFromPdfBoundaries(RooAbsReal const &pdf)
+{
+   // Check if the bin widths were already filled
+   if (!_binw.empty()) {
+      return;
+   }
+
+   if (_observables.size() != 1) {
+      throw std::runtime_error("BinnedPdf optimization only works with a 1D pdf.");
+   } else {
+      auto *var = static_cast<RooRealVar *>(_observables.first());
+      std::list<double> *boundaries = pdf.binBoundaries(*var, var->getMin(), var->getMax());
+      std::list<double>::iterator biter = boundaries->begin();
+      _binw.resize(boundaries->size() - 1);
+      double lastBound = (*biter);
+      ++biter;
+      int ibin = 0;
+      while (biter != boundaries->end()) {
+         _binw[ibin] = (*biter) - lastBound;
+         lastBound = (*biter);
+         ibin++;
+         ++biter;
+      }
+   }
 }
 
 /** Compute multiple negative logs of propabilities
@@ -130,9 +140,10 @@ void RooNLLVarNew::computeBatch(cudaStream_t * /*stream*/, double *output, size_
 {
    std::size_t nEvents = dataMap.at(_pdf).size();
 
-   auto weights = dataMap.at(_weightVar);
-   auto weightsSumW2 = dataMap.at(_weightSquaredVar);
-   auto weightSpan = _weightSquared ? weightsSumW2 : weights;
+   RooSpan<const double> weights = dataMap.at(_weightVar);
+   RooSpan<const double> weightsSumW2 = dataMap.at(_weightSquaredVar);
+   RooSpan<const double> weightSpan = _weightSquared ? weightsSumW2 : weights;
+   RooSpan<const double> binVolumes = _doBinOffset ? dataMap.at(_binVolumeVar) : RooSpan<const double>{};
 
    if (_binnedL) {
       ROOT::Math::KahanSum<double> result{0.0};
@@ -175,6 +186,7 @@ void RooNLLVarNew::computeBatch(cudaStream_t * /*stream*/, double *output, size_
    (*_pdf).getLogProbabilities(probas, _logProbasBuffer.data());
 
    _sumWeight = weights.size() == 1 ? weights[0] * nEvents : kahanSum(weights);
+   const double logSumW = std::log(_sumWeight);
 
    if (_isExtended && _weightSquared && _sumWeight2 == 0.0) {
       _sumWeight2 = weights.size() == 1 ? weightsSumW2[0] * nEvents : kahanSum(weightsSumW2);
@@ -186,10 +198,17 @@ void RooNLLVarNew::computeBatch(cudaStream_t * /*stream*/, double *output, size_
    for (std::size_t i = 0; i < nEvents; ++i) {
 
       double eventWeight = weightSpan.size() > 1 ? weightSpan[i] : weightSpan[0];
+
       if (0. == eventWeight * eventWeight)
          continue;
 
-      const double term = -eventWeight * _logProbasBuffer[i];
+      double term = _logProbasBuffer[i];
+
+      if (_doBinOffset) {
+         term -= std::log(weights[i]) - std::log(binVolumes[i]) - logSumW;
+      }
+
+      term *= -eventWeight;
 
       kahanProb.Add(term);
       packedNaN.accumulate(term);
@@ -202,7 +221,7 @@ void RooNLLVarNew::computeBatch(cudaStream_t * /*stream*/, double *output, size_
 
    if (_isExtended) {
       double expected = _pdf->expectedEvents(&_observables);
-      kahanProb += _pdf->extendedTerm(_sumWeight, expected, _weightSquared ? _sumWeight2 : 0.0);
+      kahanProb += _pdf->extendedTerm(_sumWeight, expected, _weightSquared ? _sumWeight2 : 0.0, _doBinOffset);
    }
 
    output[0] = finalizeResult(std::move(kahanProb), _sumWeight);
@@ -212,7 +231,7 @@ void RooNLLVarNew::getParametersHook(const RooArgSet * /*nset*/, RooArgSet *para
 {
    // strip away the observables and weights
    params->remove(_observables, true, true);
-   params->remove(RooArgList{*_weightVar, *_weightSquaredVar}, true, true);
+   params->remove(RooArgList{*_weightVar, *_weightSquaredVar, *_binVolumeVar}, true, true);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooNLLVarNew.h
+++ b/roofit/roofitcore/src/RooNLLVarNew.h
@@ -56,12 +56,15 @@ public:
 
    void enableOffsetting(bool) override;
 
+   void enableBinOffsetting(bool on = true) { _doBinOffset = on; }
+
    void setSimCount(int simCount) { _simCount = simCount; }
 
 private:
    double evaluate() const override { return _value; }
    void resetWeightVarNames();
    double finalizeResult(ROOT::Math::KahanSum<double> &&result, double weightSum) const;
+   void fillBinWidthsFromPdfBoundaries(RooAbsReal const &pdf);
 
    RooTemplateProxy<RooAbsPdf> _pdf;
    RooArgSet _observables;
@@ -71,13 +74,15 @@ private:
    bool _weightSquared = false;
    bool _binnedL = false;
    bool _doOffset = false;
+   bool _doBinOffset = false;
    int _simCount = 1;
    std::string _prefix;
    RooTemplateProxy<RooAbsReal> _weightVar;
    RooTemplateProxy<RooAbsReal> _weightSquaredVar;
-   mutable std::vector<double> _binw;                  ///<!
-   mutable std::vector<double> _logProbasBuffer;       ///<!
-   mutable ROOT::Math::KahanSum<double> _offset {0.}; ///<! Offset as KahanSum to avoid loss of precision
+   RooTemplateProxy<RooAbsReal> _binVolumeVar;
+   std::vector<double> _binw;
+   mutable std::vector<double> _logProbasBuffer;     ///<!
+   mutable ROOT::Math::KahanSum<double> _offset{0.}; ///<! Offset as KahanSum to avoid loss of precision
 
 }; // end class RooNLLVar
 

--- a/roofit/roofitcore/src/RooNumIntConfig.cxx
+++ b/roofit/roofitcore/src/RooNumIntConfig.cxx
@@ -223,7 +223,7 @@ const RooArgSet& RooNumIntConfig::getConfigSection(const char* name) const
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Set absolute convergence criteria (convergence if abs(Err)<newEpsAbs)
+/// Set absolute convergence criteria (convergence if std::abs(Err)<newEpsAbs)
 
 void RooNumIntConfig::setEpsAbs(double newEpsAbs)
 {
@@ -253,7 +253,7 @@ RooPrintable::StyleOption RooNumIntConfig::defaultPrintStyle(Option_t* opt) cons
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Set relative convergence criteria (convergence if abs(Err)/abs(Int)<newEpsRel)
+/// Set relative convergence criteria (convergence if std::abs(Err)/abs(Int)<newEpsRel)
 
 void RooNumIntConfig::setEpsRel(double newEpsRel)
 {

--- a/roofit/roofitcore/src/RooNumRunningInt.cxx
+++ b/roofit/roofitcore/src/RooNumRunningInt.cxx
@@ -213,7 +213,7 @@ void RooNumRunningInt::RICacheElem::addRange(Int_t ixlo, Int_t ixhi, Int_t nbins
   double yInt = _ay[ixlo] + (_ay[ixhi]-_ay[ixlo])*(ixmid-ixlo)/(ixhi-ixlo) ;
 
   // If relative deviation is greater than tolerance divide and iterate
-  if (fabs(yInt-_ay[ixmid])*(_ax[nbins-1]-_ax[0])>1e-6) {
+  if (std::abs(yInt-_ay[ixmid])*(_ax[nbins-1]-_ax[0])>1e-6) {
     addRange(ixlo,ixmid,nbins) ;
     addRange(ixmid,ixhi,nbins) ;
   } else {

--- a/roofit/roofitcore/src/RooPlot.cxx
+++ b/roofit/roofitcore/src/RooPlot.cxx
@@ -582,7 +582,7 @@ void RooPlot::updateFitRangeNorm(const RooPlotable* rp, bool refreshNorm)
     if (dynamic_cast<const RooHist*>(rp)) corFac = _normBinWidth/rp->getFitRangeBinW() ;
 
 
-    if (fabs(rp->getFitRangeNEvt()/corFac-_normNumEvts)>1e-6) {
+    if (std::abs(rp->getFitRangeNEvt()/corFac-_normNumEvts)>1e-6) {
       coutI(Plotting) << "RooPlot::updateFitRangeNorm: New event count of " << rp->getFitRangeNEvt()/corFac
             << " will supercede previous event count of " << _normNumEvts << " for normalization of PDF projections" << endl ;
     }

--- a/roofit/roofitcore/src/RooPlot.cxx
+++ b/roofit/roofitcore/src/RooPlot.cxx
@@ -1437,3 +1437,17 @@ void RooPlot::fillItemsFromTList(RooPlot::Items & items, TList const& tlist) {
     items.emplace_back(obj, obj->GetOption());
   }
 }
+
+/// Replaces the pointer to the plot variable with a pointer to a clone of the
+/// plot variable that is owned by this RooPlot. The RooPlot references the
+/// plotted variable by non-owning pointer by default since ROOT 6.28, which
+/// resulted in a big speedup when plotting complicated pdfs that are expensive
+/// to clone. However, going back to an owned clone is useful in rare cases.
+/// For example in the RooUnitTest, where the registered plots need to live
+/// longer than the scope of the unit test.
+void RooPlot::createInternalPlotVarClone() {
+  // If the plot variable is already cloned, we don't need to do anything.
+  if(_plotVarSet) return;
+  _plotVarSet = static_cast<RooArgSet*>(RooArgSet(*_plotVar).snapshot());
+  _plotVar = static_cast<RooAbsRealLValue*>(_plotVarSet->find(_plotVar->GetName()));
+}

--- a/roofit/roofitcore/src/RooRealIntegral.cxx
+++ b/roofit/roofitcore/src/RooRealIntegral.cxx
@@ -971,9 +971,9 @@ double RooRealIntegral::jacobianProduct() const
     jacProd *= arg->jacobian() ;
   }
 
-  // Take fabs() here: if jacobian is negative, min and max are swapped and analytical integral
+  // Take std::abs() here: if jacobian is negative, min and max are swapped and analytical integral
   // will be positive, so must multiply with positive jacobian.
-  return fabs(jacProd) ;
+  return std::abs(jacProd) ;
 }
 
 

--- a/roofit/roofitcore/src/RooRealVar.cxx
+++ b/roofit/roofitcore/src/RooRealVar.cxx
@@ -945,13 +945,13 @@ TString *RooRealVar::format(Int_t sigDigits, const char *options) const
   if(sigDigits < 1) sigDigits= 1;
   Int_t leadingDigitVal = 0;
   if (useErrorForPrecision) {
-    leadingDigitVal = (Int_t)floor(log10(fabs(_error+1e-10)));
+    leadingDigitVal = (Int_t)floor(log10(std::abs(_error+1e-10)));
     if (_value==0&&_error==0) leadingDigitVal=0 ;
   } else {
-    leadingDigitVal = (Int_t)floor(log10(fabs(_value+1e-10)));
+    leadingDigitVal = (Int_t)floor(log10(std::abs(_value+1e-10)));
     if (_value==0) leadingDigitVal=0 ;
   }
-  Int_t leadingDigitErr= (Int_t)floor(log10(fabs(_error+1e-10)));
+  Int_t leadingDigitErr= (Int_t)floor(log10(std::abs(_error+1e-10)));
   Int_t whereVal= leadingDigitVal - sigDigits + 1;
   Int_t whereErr= leadingDigitErr - sigDigits + 1;
   char fmtVal[16], fmtErr[16];

--- a/roofit/roofitcore/src/RooTruthModel.cxx
+++ b/roofit/roofitcore/src/RooTruthModel.cxx
@@ -162,32 +162,32 @@ double RooTruthModel::evaluate() const
   // Return desired basis function
   switch(basisType) {
   case expBasis: {
-    //cout << " RooTruthModel::eval(" << GetName() << ") expBasis mode ret = " << exp(-fabs((double)x)/tau) << " tau = " << tau << endl ;
-    return exp(-fabs((double)x)/tau) ;
+    //cout << " RooTruthModel::eval(" << GetName() << ") expBasis mode ret = " << exp(-std::abs((double)x)/tau) << " tau = " << tau << endl ;
+    return exp(-std::abs((double)x)/tau) ;
   }
   case sinBasis: {
     double dm = ((RooAbsReal*)basis().getParameter(2))->getVal() ;
-    return exp(-fabs((double)x)/tau)*sin(x*dm) ;
+    return exp(-std::abs((double)x)/tau)*sin(x*dm) ;
   }
   case cosBasis: {
     double dm = ((RooAbsReal*)basis().getParameter(2))->getVal() ;
-    return exp(-fabs((double)x)/tau)*cos(x*dm) ;
+    return exp(-std::abs((double)x)/tau)*cos(x*dm) ;
   }
   case linBasis: {
-    double tscaled = fabs((double)x)/tau;
+    double tscaled = std::abs((double)x)/tau;
     return exp(-tscaled)*tscaled ;
   }
   case quadBasis: {
-    double tscaled = fabs((double)x)/tau;
+    double tscaled = std::abs((double)x)/tau;
     return exp(-tscaled)*tscaled*tscaled;
   }
   case sinhBasis: {
     double dg = ((RooAbsReal*)basis().getParameter(2))->getVal() ;
-    return exp(-fabs((double)x)/tau)*sinh(x*dg/2) ;
+    return exp(-std::abs((double)x)/tau)*sinh(x*dg/2) ;
   }
   case coshBasis: {
     double dg = ((RooAbsReal*)basis().getParameter(2))->getVal() ;
-    return exp(-fabs((double)x)/tau)*cosh(x*dg/2) ;
+    return exp(-std::abs((double)x)/tau)*cosh(x*dg/2) ;
   }
   default:
     R__ASSERT(0) ;

--- a/roofit/roofitcore/src/RooUnitTest.cxx
+++ b/roofit/roofitcore/src/RooUnitTest.cxx
@@ -28,7 +28,7 @@ Object          | function
 ----------------|------------
    RooPlot      | regPlot()
    RooFitResult | regResult()
-   double     | regValue()
+   double       | regValue()
    RooTable     | regTable()
    TH1/2/3      | regTH()
    RooWorkspace | regWS()
@@ -79,7 +79,13 @@ void RooUnitTest::regPlot(RooPlot* frame, const char* refName)
   if (_refFile) {
     string refNameStr(refName) ;
     frame->SetName(refName) ;
-    _regPlots.push_back(make_pair(frame,refNameStr)) ;
+    // Since ROOT 6.28, the RooPlot doesn't clone the plot variable by default
+    // anymore. This is a problem for registering the RooPlots, because they
+    // need to survive without dangling pointers even after the RooUnitTest is
+    // done. For that reason, we ask the RooPlot to create an internal plot
+    // variable clone for itself.
+    frame->createInternalPlotVarClone();
+    _regPlots.emplace_back(frame,refNameStr);
   } else {
     delete frame ;
   }

--- a/roofit/roofitcore/src/RooUnitTest.cxx
+++ b/roofit/roofitcore/src/RooUnitTest.cxx
@@ -197,7 +197,7 @@ bool RooUnitTest::areTHidentical(TH1* htest, TH1* href)
     }
 
     for (Int_t i=0 ; i<ntest ; i++) {
-      if (fabs(htest->GetBinContent(i)-href->GetBinContent(i))>htol()) {
+      if (std::abs(htest->GetBinContent(i)-href->GetBinContent(i))>htol()) {
         if(_verb >= 0) std::cout << "htest[" << i << "] = " << htest->GetBinContent(i) << " href[" << i << "] = " << href->GetBinContent(i) << endl;
       }
     }
@@ -398,7 +398,7 @@ bool RooUnitTest::runCompTests()
    cout << "comparing value " << iter3->first << " to benchmark " << iter3->second << " = " << (double)(*ref) << endl ;
       }
 
-      if (fabs(iter3->first - (double)(*ref))>vtol() ) {
+      if (std::abs(iter3->first - (double)(*ref))>vtol() ) {
         if(_verb >= 0) cout << "RooUnitTest ERROR: comparison of value " << iter3->first <<   " fails comparison with reference " << ref->GetName() << endl ;
         ret = false ;
       }

--- a/roofit/roofitcore/src/TestStatistics/RooBinnedL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooBinnedL.cxx
@@ -120,7 +120,7 @@ RooBinnedL::evaluatePartition(Section bins, std::size_t /*components_begin*/, st
          oocoutI(nullptr, Minimization)
             << "Observed " << N << " events in bin " << i << " with zero event yield" << std::endl;
 
-      } else if (fabs(mu) < 1e-10 && fabs(N) < 1e-10) {
+      } else if (std::abs(mu) < 1e-10 && std::abs(N) < 1e-10) {
 
          // Special handling of this case since log(Poisson(0,0)=0 but can't be calculated with usual log-formula
          // since log(mu)=0. No update of result is required since term=0.

--- a/roofit/roofitcore/test/testRooAbsPdf.cxx
+++ b/roofit/roofitcore/test/testRooAbsPdf.cxx
@@ -93,7 +93,7 @@ TEST(RooAbsPdf, ConditionalFitBatchMode)
       for (int i = 0; i < 10000; i++) {
          double tmpy = gRandom->Gaus(3, 2);
          double tmpx = gRandom->Poisson(tmpy);
-         if (fabs(tmpy) > 1 && std::abs(tmpy) < 5 && std::abs(tmpx) < 10) {
+         if (std::abs(tmpy) > 1 && std::abs(tmpy) < 5 && std::abs(tmpx) < 10) {
             x = tmpx;
             y = tmpy;
             d->add(coord);

--- a/roofit/roofitcore/test/testRooDataHist.cxx
+++ b/roofit/roofitcore/test/testRooDataHist.cxx
@@ -760,30 +760,12 @@ TEST_P(WeightsTest, VectorizedWeights)
 }
 
 INSTANTIATE_TEST_SUITE_P(RooDataHist, WeightsTest,
-                         testing::Values(WeightsTest::ParamType{0, false, false, false},
-                                         WeightsTest::ParamType{1, false, false, false},
-                                         WeightsTest::ParamType{2, false, false, false},
-                                         WeightsTest::ParamType{0, false, true, false},
-                                         WeightsTest::ParamType{1, false, true, false},
-                                         WeightsTest::ParamType{2, false, true, false},
-                                         WeightsTest::ParamType{0, true, false, false},
-                                         WeightsTest::ParamType{1, true, false, false},
-                                         WeightsTest::ParamType{2, true, false, false},
-                                         WeightsTest::ParamType{0, true, true, false},
-                                         WeightsTest::ParamType{1, true, true, false},
-                                         WeightsTest::ParamType{2, true, true, false},
-                                         WeightsTest::ParamType{0, false, false, true},
-                                         WeightsTest::ParamType{1, false, false, true},
-                                         WeightsTest::ParamType{2, false, false, true},
-                                         WeightsTest::ParamType{0, false, true, true},
-                                         WeightsTest::ParamType{1, false, true, true},
-                                         WeightsTest::ParamType{2, false, true, true},
-                                         WeightsTest::ParamType{0, true, false, true},
-                                         WeightsTest::ParamType{1, true, false, true},
-                                         WeightsTest::ParamType{2, true, false, true},
-                                         WeightsTest::ParamType{0, true, true, true},
-                                         WeightsTest::ParamType{1, true, true, true},
-                                         WeightsTest::ParamType{2, true, true, true}),
+                         testing::Combine(
+                            testing::Values(0, 1, 2), // interpolation order
+                            testing::Values(false, true), // RooHistPdf or RooHistFunc?
+                            testing::Values(false, true), // CDF boundary mode
+                            testing::Values(false, true) // uniform bins or not
+                         ),
                          [](testing::TestParamInfo<WeightsTest::ParamType> const &paramInfo) {
                             std::stringstream ss;
                             ss << (std::get<1>(paramInfo.param) ? "RooHistFunc" : "RooHistPdf");

--- a/roofit/roofitcore/test/testRooProdPdf.cxx
+++ b/roofit/roofitcore/test/testRooProdPdf.cxx
@@ -55,7 +55,7 @@ TEST_P(TestProdPdf, CachingOpt)
 
    using namespace RooFit;
    prod.fitTo(*datap, Optimize(_optimize), PrintLevel(-1), BatchMode(_batchMode));
-   EXPECT_LT(fabs(b.getVal() - bTruth), b.getError() * 2.5) // 2.5-sigma compatibility check
+   EXPECT_LT(std::abs(b.getVal() - bTruth), b.getError() * 2.5) // 2.5-sigma compatibility check
       << "b=" << b.getVal() << " +- " << b.getError() << " doesn't match truth value with O" << _optimize << ".";
 }
 

--- a/roofit/roofitcore/test/testRooWrapperPdf.cxx
+++ b/roofit/roofitcore/test/testRooWrapperPdf.cxx
@@ -65,7 +65,7 @@ TEST(RooWrapperPdf, GenerateAndFit) {
   auto result = polPdf.fitTo(*data, RooFit::Save(), RooFit::PrintLevel(-1));
 
   EXPECT_EQ(result->status(), 0) << "Fit converged.";
-  EXPECT_LT(fabs(a2.getVal()-0.01), a2.getError());
+  EXPECT_LT(std::abs(a2.getVal()-0.01), a2.getError());
 
 //  auto frame = x.frame();
 //  data->plotOn(frame);

--- a/roofit/roofitcore/test/testTestStatistics.cxx
+++ b/roofit/roofitcore/test/testTestStatistics.cxx
@@ -16,284 +16,272 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <cmath>
 
 const bool batchMode = true;
 
-TEST(RooNLLVar, IntegrateBins) {
-  RooRandom::randomGenerator()->SetSeed(1337ul);
+TEST(RooNLLVar, IntegrateBins)
+{
+   RooRandom::randomGenerator()->SetSeed(1337ul);
 
-  RooRealVar x("x", "x", 0.1, 5.1);
-  x.setBins(10);
+   RooRealVar x("x", "x", 0.1, 5.1);
+   x.setBins(10);
 
-  RooRealVar a("a", "a", -0.3, -5., 5.);
-  RooArgSet targetValues;
-  RooArgSet(a).snapshot(targetValues);
+   RooRealVar a("a", "a", -0.3, -5., 5.);
+   RooArgSet targetValues;
+   RooArgSet(a).snapshot(targetValues);
 
-  RooGenericPdf pdf("pow", "std::pow(x, a)", RooArgSet(x, a));
-  std::unique_ptr<RooDataHist> dataH(pdf.generateBinned(x,  10000));
-  RooRealVar w("w", "weight", 0., 0., 10000.);
-  RooDataSet data("data", "data", RooArgSet(x, w), RooFit::WeightVar(w));
-  for (int i=0; i < dataH->numEntries(); ++i) {
-    auto coords = dataH->get(i);
-    data.add(*coords, dataH->weight());
-  }
+   RooGenericPdf pdf("pow", "std::pow(x, a)", {x, a});
+   std::unique_ptr<RooDataHist> dataH(pdf.generateBinned(x, 10000));
+   RooRealVar w("w", "weight", 0., 0., 10000.);
+   RooDataSet data("data", "data", {x, w}, RooFit::WeightVar(w));
+   for (int i = 0; i < dataH->numEntries(); ++i) {
+      auto coords = dataH->get(i);
+      data.add(*coords, dataH->weight());
+   }
 
-  std::unique_ptr<RooPlot> frame( x.frame() );
-  dataH->plotOn(frame.get(), RooFit::MarkerColor(kRed));
-  data.plotOn(frame.get(), RooFit::Name("data"));
+   std::unique_ptr<RooPlot> frame(x.frame());
+   dataH->plotOn(frame.get(), RooFit::MarkerColor(kRed));
+   data.plotOn(frame.get(), RooFit::Name("data"));
 
+   a.setVal(3.);
+   std::unique_ptr<RooFitResult> fit1(pdf.fitTo(data, RooFit::Save(), RooFit::PrintLevel(-1)));
+   pdf.plotOn(frame.get(), RooFit::LineColor(kRed), RooFit::Name("standard"));
 
-  a.setVal(3.);
-  std::unique_ptr<RooFitResult> fit1( pdf.fitTo(data, RooFit::Save(), RooFit::PrintLevel(-1)) );
-  pdf.plotOn(frame.get(), RooFit::LineColor(kRed), RooFit::Name("standard"));
+   a.setVal(3.);
+   std::unique_ptr<RooFitResult> fit2(pdf.fitTo(data, RooFit::Save(), RooFit::PrintLevel(-1),
+                                                RooFit::BatchMode(batchMode), RooFit::IntegrateBins(1.E-3)));
+   pdf.plotOn(frame.get(), RooFit::LineColor(kBlue), RooFit::Name("highRes"));
 
-  a.setVal(3.);
-  std::unique_ptr<RooFitResult> fit2( pdf.fitTo(data, RooFit::Save(), RooFit::PrintLevel(-1),
-      RooFit::BatchMode(batchMode),
-      RooFit::IntegrateBins(1.E-3)) );
-  pdf.plotOn(frame.get(), RooFit::LineColor(kBlue), RooFit::Name("highRes"));
+   auto getVal = [](const char *name, const RooArgSet &set) {
+      return dynamic_cast<const RooRealVar &>(set[name]).getVal();
+   };
+   auto getErr = [](const char *name, const RooArgSet &set) {
+      return dynamic_cast<const RooRealVar &>(set[name]).getError();
+   };
 
-
-  auto getVal = [](const char* name, const RooArgSet& set) {
-    return dynamic_cast<const RooRealVar&>(set[name]).getVal();
-  };
-  auto getErr = [](const char* name, const RooArgSet& set) {
-    return dynamic_cast<const RooRealVar&>(set[name]).getError();
-  };
-
-  EXPECT_GT(std::abs(getVal("a", targetValues) - getVal("a", fit1->floatParsFinal())), 1. * getErr("a", fit1->floatParsFinal()))
+   EXPECT_GT(std::abs(getVal("a", targetValues) - getVal("a", fit1->floatParsFinal())),
+             1. * getErr("a", fit1->floatParsFinal()))
       << "Expecting a bias when sampling PDF in bin centre.";
 
-  EXPECT_NEAR(getVal("a", targetValues), getVal("a", fit2->floatParsFinal()), 1. * getErr("a", fit2->floatParsFinal()))
+   EXPECT_NEAR(getVal("a", targetValues), getVal("a", fit2->floatParsFinal()), 1. * getErr("a", fit2->floatParsFinal()))
       << "Expect reduced bias with high-resolution sampling.";
 
-  EXPECT_GT(frame->chiSquare("standard", "data", 1) * 0.9, frame->chiSquare("highRes",  "data", 1))
-      << "Expect chi2/ndf at least 10% better.";
-}
-
-
-/// Prepare a RooDataSet that looks like the one that HistFactory uses:
-/// It pretends to be an unbinned dataset, but instead of single events,
-/// events are aggregated in the bin centres using weights.
-TEST(RooNLLVar, IntegrateBins_SubRange) {
-  RooRandom::randomGenerator()->SetSeed(1337ul);
-
-  RooRealVar x("x", "x", 0.1, 5.1);
-  x.setBins(10);
-  x.setRange("range", 0.1, 4.1);
-  x.setBins(8, "range"); // consistent binning
-
-  RooRealVar a("a", "a", -0.3, -5., 5.);
-  RooArgSet targetValues;
-  RooArgSet(a).snapshot(targetValues);
-
-  RooGenericPdf pdf("pow", "std::pow(x, a)", RooArgSet(x, a));
-  std::unique_ptr<RooDataHist> dataH(pdf.generateBinned(x,  10000));
-  RooRealVar w("w", "weight", 0., 0., 10000.);
-  RooDataSet data("data", "data", RooArgSet(x, w), RooFit::WeightVar(w));
-  for (int i=0; i < dataH->numEntries(); ++i) {
-    auto coords = dataH->get(i);
-    data.add(*coords, dataH->weight());
-  }
-
-  std::unique_ptr<RooPlot> frame( x.frame() );
-  dataH->plotOn(frame.get(), RooFit::MarkerColor(kRed));
-  data.plotOn(frame.get(), RooFit::Name("data"));
-
-
-  a.setVal(3.);
-  std::unique_ptr<RooFitResult> fit1( pdf.fitTo(data, RooFit::Save(), RooFit::PrintLevel(-1),
-      RooFit::Optimize(0),
-      RooFit::Range("range"),
-      RooFit::BatchMode(batchMode))  );
-  pdf.plotOn(frame.get(), RooFit::LineColor(kRed), RooFit::Name("standard"));
-
-  a.setVal(3.);
-  std::unique_ptr<RooFitResult> fit2( pdf.fitTo(data, RooFit::Save(), RooFit::PrintLevel(-1),
-      RooFit::Optimize(0),
-      RooFit::Range("range"),
-      RooFit::BatchMode(batchMode),
-      RooFit::IntegrateBins(1.E-3)) );
-  pdf.plotOn(frame.get(), RooFit::LineColor(kBlue), RooFit::Name("highRes"));
-
-
-  auto getVal = [](const char* name, const RooArgSet& set) {
-    return dynamic_cast<const RooRealVar&>(set[name]).getVal();
-  };
-  auto getErr = [](const char* name, const RooArgSet& set) {
-    return dynamic_cast<const RooRealVar&>(set[name]).getError();
-  };
-
-  EXPECT_GT(std::abs(getVal("a", targetValues) - getVal("a", fit1->floatParsFinal())), 1. * getErr("a", fit1->floatParsFinal()))
-      << "Expecting a bias when sampling PDF in bin centre.";
-
-  EXPECT_NEAR(getVal("a", targetValues), getVal("a", fit2->floatParsFinal()), 1. * getErr("a", fit2->floatParsFinal()))
-      << "Expect reduced bias with high-resolution sampling.";
-
-  EXPECT_GT(frame->chiSquare("standard", "data", 1) * 0.9, frame->chiSquare("highRes",  "data", 1))
+   EXPECT_GT(frame->chiSquare("standard", "data", 1) * 0.9, frame->chiSquare("highRes", "data", 1))
       << "Expect chi2/ndf at least 10% better.";
 }
 
 /// Prepare a RooDataSet that looks like the one that HistFactory uses:
 /// It pretends to be an unbinned dataset, but instead of single events,
 /// events are aggregated in the bin centres using weights.
-TEST(RooNLLVar, IntegrateBins_CustomBinning) {
-  RooRandom::randomGenerator()->SetSeed(1337ul);
+TEST(RooNLLVar, IntegrateBins_SubRange)
+{
+   RooRandom::randomGenerator()->SetSeed(1337ul);
 
-  RooRealVar x("x", "x", 1., 5.);
-  RooBinning binning(1., 5.);
-  binning.addBoundary(1.5);
-  binning.addBoundary(2.0);
-  binning.addBoundary(3.);
-  binning.addBoundary(4.);
-  x.setBinning(binning);
+   RooRealVar x("x", "x", 0.1, 5.1);
+   x.setBins(10);
+   x.setRange("range", 0.1, 4.1);
+   x.setBins(8, "range"); // consistent binning
 
-  RooRealVar a("a", "a", -0.3, -5., 5.);
-  RooArgSet targetValues;
-  RooArgSet(a).snapshot(targetValues);
+   RooRealVar a("a", "a", -0.3, -5., 5.);
+   RooArgSet targetValues;
+   RooArgSet(a).snapshot(targetValues);
 
-  RooGenericPdf pdf("pow", "std::pow(x, a)", RooArgSet(x, a));
-  std::unique_ptr<RooDataHist> dataH(pdf.generateBinned(x,  50000));
-  RooRealVar w("w", "weight", 0., 0., 1000000.);
-  RooDataSet data("data", "data", RooArgSet(x, w), RooFit::WeightVar(w));
-  for (int i=0; i < dataH->numEntries(); ++i) {
-    auto coords = dataH->get(i);
-    data.add(*coords, dataH->weight());
-  }
+   RooGenericPdf pdf("pow", "std::pow(x, a)", {x, a});
+   std::unique_ptr<RooDataHist> dataH(pdf.generateBinned(x, 10000));
+   RooRealVar w("w", "weight", 0., 0., 10000.);
+   RooDataSet data("data", "data", {x, w}, RooFit::WeightVar(w));
+   for (int i = 0; i < dataH->numEntries(); ++i) {
+      auto coords = dataH->get(i);
+      data.add(*coords, dataH->weight());
+   }
 
-  std::unique_ptr<RooPlot> frame( x.frame() );
-  dataH->plotOn(frame.get(), RooFit::Name("dataHist"), RooFit::MarkerColor(kRed));
-  data.plotOn(frame.get(), RooFit::Name("data"));
+   std::unique_ptr<RooPlot> frame(x.frame());
+   dataH->plotOn(frame.get(), RooFit::MarkerColor(kRed));
+   data.plotOn(frame.get(), RooFit::Name("data"));
 
+   a.setVal(3.);
+   std::unique_ptr<RooFitResult> fit1(pdf.fitTo(data, RooFit::Save(), RooFit::PrintLevel(-1), RooFit::Optimize(0),
+                                                RooFit::Range("range"), RooFit::BatchMode(batchMode)));
+   pdf.plotOn(frame.get(), RooFit::LineColor(kRed), RooFit::Name("standard"));
 
-  a.setVal(3.);
-  std::unique_ptr<RooFitResult> fit1( pdf.fitTo(data, RooFit::Save(), RooFit::PrintLevel(-1),
-      RooFit::Optimize(0)) );
-  pdf.plotOn(frame.get(), RooFit::LineColor(kRed), RooFit::Name("standard"));
+   a.setVal(3.);
+   std::unique_ptr<RooFitResult> fit2(pdf.fitTo(data, RooFit::Save(), RooFit::PrintLevel(-1), RooFit::Optimize(0),
+                                                RooFit::Range("range"), RooFit::BatchMode(batchMode),
+                                                RooFit::IntegrateBins(1.E-3)));
+   pdf.plotOn(frame.get(), RooFit::LineColor(kBlue), RooFit::Name("highRes"));
 
-  a.setVal(3.);
-  std::unique_ptr<RooFitResult> fit2( pdf.fitTo(data, RooFit::Save(), RooFit::PrintLevel(-1),
-      RooFit::Optimize(0),
-      RooFit::BatchMode(batchMode),
-      RooFit::IntegrateBins(1.E-3)) );
-  pdf.plotOn(frame.get(), RooFit::LineColor(kBlue), RooFit::Name("highRes"));
+   auto getVal = [](const char *name, const RooArgSet &set) {
+      return dynamic_cast<const RooRealVar &>(set[name]).getVal();
+   };
+   auto getErr = [](const char *name, const RooArgSet &set) {
+      return dynamic_cast<const RooRealVar &>(set[name]).getError();
+   };
 
-
-  auto getVal = [](const char* name, const RooArgSet& set) {
-    return dynamic_cast<const RooRealVar&>(set[name]).getVal();
-  };
-  auto getErr = [](const char* name, const RooArgSet& set) {
-    return dynamic_cast<const RooRealVar&>(set[name]).getError();
-  };
-
-  EXPECT_GT(std::abs(getVal("a", targetValues) - getVal("a", fit1->floatParsFinal())), 1. * getErr("a", fit1->floatParsFinal()))
+   EXPECT_GT(std::abs(getVal("a", targetValues) - getVal("a", fit1->floatParsFinal())),
+             1. * getErr("a", fit1->floatParsFinal()))
       << "Expecting a bias when sampling PDF in bin centre.";
 
-  EXPECT_NEAR(getVal("a", targetValues), getVal("a", fit2->floatParsFinal()), 1. * getErr("a", fit2->floatParsFinal()))
+   EXPECT_NEAR(getVal("a", targetValues), getVal("a", fit2->floatParsFinal()), 1. * getErr("a", fit2->floatParsFinal()))
       << "Expect reduced bias with high-resolution sampling.";
 
-  // Note: We cannot compare with the unbinned dataset here, because when it's plotted, it's filled into a
-  // histogram with uniform binning. It therefore creates a jumpy distribution. When comparing with the original
-  // data hist, we don't get those jumps.
-  EXPECT_GT(frame->chiSquare("standard", "dataHist", 1) * 0.9, frame->chiSquare("highRes",  "dataHist", 1))
+   EXPECT_GT(frame->chiSquare("standard", "data", 1) * 0.9, frame->chiSquare("highRes", "data", 1))
       << "Expect chi2/ndf at least 10% better.";
 }
 
+/// Prepare a RooDataSet that looks like the one that HistFactory uses:
+/// It pretends to be an unbinned dataset, but instead of single events,
+/// events are aggregated in the bin centres using weights.
+TEST(RooNLLVar, IntegrateBins_CustomBinning)
+{
+   RooRandom::randomGenerator()->SetSeed(1337ul);
+
+   RooRealVar x("x", "x", 1., 5.);
+   RooBinning binning(1., 5.);
+   binning.addBoundary(1.5);
+   binning.addBoundary(2.0);
+   binning.addBoundary(3.);
+   binning.addBoundary(4.);
+   x.setBinning(binning);
+
+   RooRealVar a("a", "a", -0.3, -5., 5.);
+   RooArgSet targetValues;
+   RooArgSet(a).snapshot(targetValues);
+
+   RooGenericPdf pdf("pow", "std::pow(x, a)", {x, a});
+   std::unique_ptr<RooDataHist> dataH(pdf.generateBinned(x, 50000));
+   RooRealVar w("w", "weight", 0., 0., 1000000.);
+   RooDataSet data("data", "data", {x, w}, RooFit::WeightVar(w));
+   for (int i = 0; i < dataH->numEntries(); ++i) {
+      auto coords = dataH->get(i);
+      data.add(*coords, dataH->weight());
+   }
+
+   std::unique_ptr<RooPlot> frame(x.frame());
+   dataH->plotOn(frame.get(), RooFit::Name("dataHist"), RooFit::MarkerColor(kRed));
+   data.plotOn(frame.get(), RooFit::Name("data"));
+
+   a.setVal(3.);
+   std::unique_ptr<RooFitResult> fit1(pdf.fitTo(data, RooFit::Save(), RooFit::PrintLevel(-1), RooFit::Optimize(0)));
+   pdf.plotOn(frame.get(), RooFit::LineColor(kRed), RooFit::Name("standard"));
+
+   a.setVal(3.);
+   std::unique_ptr<RooFitResult> fit2(pdf.fitTo(data, RooFit::Save(), RooFit::PrintLevel(-1), RooFit::Optimize(0),
+                                                RooFit::BatchMode(batchMode), RooFit::IntegrateBins(1.E-3)));
+   pdf.plotOn(frame.get(), RooFit::LineColor(kBlue), RooFit::Name("highRes"));
+
+   auto getVal = [](const char *name, const RooArgSet &set) {
+      return dynamic_cast<const RooRealVar &>(set[name]).getVal();
+   };
+   auto getErr = [](const char *name, const RooArgSet &set) {
+      return dynamic_cast<const RooRealVar &>(set[name]).getError();
+   };
+
+   EXPECT_GT(std::abs(getVal("a", targetValues) - getVal("a", fit1->floatParsFinal())),
+             1. * getErr("a", fit1->floatParsFinal()))
+      << "Expecting a bias when sampling PDF in bin centre.";
+
+   EXPECT_NEAR(getVal("a", targetValues), getVal("a", fit2->floatParsFinal()), 1. * getErr("a", fit2->floatParsFinal()))
+      << "Expect reduced bias with high-resolution sampling.";
+
+   // Note: We cannot compare with the unbinned dataset here, because when it's plotted, it's filled into a
+   // histogram with uniform binning. It therefore creates a jumpy distribution. When comparing with the original
+   // data hist, we don't get those jumps.
+   EXPECT_GT(frame->chiSquare("standard", "dataHist", 1) * 0.9, frame->chiSquare("highRes", "dataHist", 1))
+      << "Expect chi2/ndf at least 10% better.";
+}
 
 /// Test the same, but now with RooDataHist. Here, the feature should switch on automatically.
-TEST(RooNLLVar, IntegrateBins_RooDataHist) {
-  RooRealVar x("x", "x", 0.1, 5.);
-  x.setBins(10);
+TEST(RooNLLVar, IntegrateBins_RooDataHist)
+{
+   RooRealVar x("x", "x", 0.1, 5.);
+   x.setBins(10);
 
-  RooRealVar a("a", "a", -0.3, -5., 5.);
-  RooArgSet targetValues;
-  RooArgSet(a).snapshot(targetValues);
+   RooRealVar a("a", "a", -0.3, -5., 5.);
+   RooArgSet targetValues;
+   RooArgSet(a).snapshot(targetValues);
 
-  RooGenericPdf pdf("pow", "std::pow(x, a)", RooArgSet(x, a));
-  std::unique_ptr<RooDataHist> data(pdf.generateBinned(x,  10000));
+   RooGenericPdf pdf("pow", "std::pow(x, a)", {x, a});
+   std::unique_ptr<RooDataHist> data(pdf.generateBinned(x, 10000));
 
-  std::unique_ptr<RooPlot> frame( x.frame() );
-  data->plotOn(frame.get(), RooFit::Name("data"));
+   std::unique_ptr<RooPlot> frame(x.frame());
+   data->plotOn(frame.get(), RooFit::Name("data"));
 
+   a.setVal(3.);
+   std::unique_ptr<RooFitResult> fit1(pdf.fitTo(*data, RooFit::Save(), RooFit::PrintLevel(-1),
+                                                RooFit::BatchMode(batchMode),
+                                                RooFit::IntegrateBins(-1.) // Disable forcefully
+                                                ));
+   pdf.plotOn(frame.get(), RooFit::LineColor(kRed), RooFit::Name("standard"));
 
-  a.setVal(3.);
-  std::unique_ptr<RooFitResult> fit1( pdf.fitTo(*data, RooFit::Save(), RooFit::PrintLevel(-1),
-      RooFit::BatchMode(batchMode),
-      RooFit::IntegrateBins(-1.) // Disable forcefully
-      ) );
-  pdf.plotOn(frame.get(), RooFit::LineColor(kRed), RooFit::Name("standard"));
+   a.setVal(3.);
+   std::unique_ptr<RooFitResult> fit2(pdf.fitTo(*data, RooFit::Save(), RooFit::PrintLevel(-1),
+                                                RooFit::BatchMode(batchMode),
+                                                RooFit::IntegrateBins(0.) // Auto-enable for all RooDataHists.
+                                                ));
+   pdf.plotOn(frame.get(), RooFit::LineColor(kBlue), RooFit::Name("highRes"));
 
-  a.setVal(3.);
-  std::unique_ptr<RooFitResult> fit2( pdf.fitTo(*data, RooFit::Save(), RooFit::PrintLevel(-1),
-      RooFit::BatchMode(batchMode),
-      RooFit::IntegrateBins(0.) // Auto-enable for all RooDataHists.
-      ) );
-  pdf.plotOn(frame.get(), RooFit::LineColor(kBlue), RooFit::Name("highRes"));
+   auto getVal = [](const char *name, const RooArgSet &set) {
+      return dynamic_cast<const RooRealVar &>(set[name]).getVal();
+   };
+   auto getErr = [](const char *name, const RooArgSet &set) {
+      return dynamic_cast<const RooRealVar &>(set[name]).getError();
+   };
 
-
-  auto getVal = [](const char* name, const RooArgSet& set) {
-    return dynamic_cast<const RooRealVar&>(set[name]).getVal();
-  };
-  auto getErr = [](const char* name, const RooArgSet& set) {
-    return dynamic_cast<const RooRealVar&>(set[name]).getError();
-  };
-
-  EXPECT_GT(std::abs(getVal("a", targetValues) - getVal("a", fit1->floatParsFinal())), 1. * getErr("a", fit1->floatParsFinal()))
+   EXPECT_GT(std::abs(getVal("a", targetValues) - getVal("a", fit1->floatParsFinal())),
+             1. * getErr("a", fit1->floatParsFinal()))
       << "Expecting a bias when sampling PDF in bin centre.";
 
-  EXPECT_NEAR(getVal("a", targetValues), getVal("a", fit2->floatParsFinal()), 1. * getErr("a", fit2->floatParsFinal()))
+   EXPECT_NEAR(getVal("a", targetValues), getVal("a", fit2->floatParsFinal()), 1. * getErr("a", fit2->floatParsFinal()))
       << "Expect reduced bias with high-resolution sampling.";
 
-  EXPECT_GT(frame->chiSquare("standard", "data", 1) * 0.9, frame->chiSquare("highRes",  "data", 1))
+   EXPECT_GT(frame->chiSquare("standard", "data", 1) * 0.9, frame->chiSquare("highRes", "data", 1))
       << "Expect chi2/ndf at least 10% better.";
 }
 
+TEST(RooChi2Var, IntegrateBins)
+{
+   RooRandom::randomGenerator()->SetSeed(1337ul);
 
-TEST(RooChi2Var, IntegrateBins) {
-  RooRandom::randomGenerator()->SetSeed(1337ul);
+   RooRealVar x("x", "x", 0.1, 5.1);
+   x.setBins(10);
 
-  RooRealVar x("x", "x", 0.1, 5.1);
-  x.setBins(10);
+   RooRealVar a("a", "a", -0.3, -5., 5.);
+   RooArgSet targetValues;
+   RooArgSet(a).snapshot(targetValues);
 
-  RooRealVar a("a", "a", -0.3, -5., 5.);
-  RooArgSet targetValues;
-  RooArgSet(a).snapshot(targetValues);
+   RooGenericPdf pdf("pow", "std::pow(x, a)", {x, a});
+   std::unique_ptr<RooDataHist> dataH(pdf.generateBinned(x, 10000));
 
-  RooGenericPdf pdf("pow", "std::pow(x, a)", RooArgSet(x, a));
-  std::unique_ptr<RooDataHist> dataH(pdf.generateBinned(x,  10000));
+   std::unique_ptr<RooPlot> frame(x.frame());
+   dataH->plotOn(frame.get(), RooFit::MarkerColor(kRed));
 
-  std::unique_ptr<RooPlot> frame( x.frame() );
-  dataH->plotOn(frame.get(), RooFit::MarkerColor(kRed));
+   a.setVal(3.);
+   std::unique_ptr<RooFitResult> fit1(pdf.chi2FitTo(*dataH, RooFit::Save(), RooFit::PrintLevel(-1)));
+   pdf.plotOn(frame.get(), RooFit::LineColor(kRed), RooFit::Name("standard"));
 
+   a.setVal(3.);
+   std::unique_ptr<RooFitResult> fit2(pdf.chi2FitTo(*dataH, RooFit::Save(), RooFit::PrintLevel(-1),
+                                                    RooFit::BatchMode(batchMode), RooFit::IntegrateBins(1.E-3)));
+   pdf.plotOn(frame.get(), RooFit::LineColor(kBlue), RooFit::Name("highRes"));
 
-  a.setVal(3.);
-  std::unique_ptr<RooFitResult> fit1( pdf.chi2FitTo(*dataH, RooFit::Save(), RooFit::PrintLevel(-1)) );
-  pdf.plotOn(frame.get(), RooFit::LineColor(kRed), RooFit::Name("standard"));
+   auto getVal = [](const char *name, const RooArgSet &set) {
+      return dynamic_cast<const RooRealVar &>(set[name]).getVal();
+   };
+   auto getErr = [](const char *name, const RooArgSet &set) {
+      return dynamic_cast<const RooRealVar &>(set[name]).getError();
+   };
 
-  a.setVal(3.);
-  std::unique_ptr<RooFitResult> fit2( pdf.chi2FitTo(*dataH, RooFit::Save(), RooFit::PrintLevel(-1),
-      RooFit::BatchMode(batchMode),
-      RooFit::IntegrateBins(1.E-3)) );
-  pdf.plotOn(frame.get(), RooFit::LineColor(kBlue), RooFit::Name("highRes"));
-
-
-  auto getVal = [](const char* name, const RooArgSet& set) {
-    return dynamic_cast<const RooRealVar&>(set[name]).getVal();
-  };
-  auto getErr = [](const char* name, const RooArgSet& set) {
-    return dynamic_cast<const RooRealVar&>(set[name]).getError();
-  };
-
-  EXPECT_GT(std::abs(getVal("a", targetValues) - getVal("a", fit1->floatParsFinal())), 1. * getErr("a", fit1->floatParsFinal()))
+   EXPECT_GT(std::abs(getVal("a", targetValues) - getVal("a", fit1->floatParsFinal())),
+             1. * getErr("a", fit1->floatParsFinal()))
       << "Expecting a bias when sampling PDF in bin centre.";
 
-  EXPECT_NEAR(getVal("a", targetValues), getVal("a", fit2->floatParsFinal()), 1. * getErr("a", fit2->floatParsFinal()))
+   EXPECT_NEAR(getVal("a", targetValues), getVal("a", fit2->floatParsFinal()), 1. * getErr("a", fit2->floatParsFinal()))
       << "Expect reduced bias with high-resolution sampling.";
 
-  EXPECT_GT(frame->chiSquare("standard", nullptr, 1) * 0.9, frame->chiSquare("highRes", nullptr, 1))
+   EXPECT_GT(frame->chiSquare("standard", nullptr, 1) * 0.9, frame->chiSquare("highRes", nullptr, 1))
       << "Expect chi2/ndf at least 10% better.";
 }
-
 
 /// Verifies that a ranged RooNLLVar has still the correct value when copied,
 /// as it happens when it is plotted Covers JIRA ticket ROOT-9752.
@@ -302,8 +290,8 @@ TEST(RooNLLVar, CopyRangedNLL)
    RooWorkspace ws;
    ws.factory("Gaussian::model(x[0, 10], mean[5, 0, 10], sigma[0.5, 0.01, 5.0])");
 
-   RooRealVar& x = *ws.var("x");
-   RooAbsPdf& model = *ws.pdf("model");
+   RooRealVar &x = *ws.var("x");
+   RooAbsPdf &model = *ws.pdf("model");
 
    x.setRange("fitrange", 0, 10);
 
@@ -312,7 +300,8 @@ TEST(RooNLLVar, CopyRangedNLL)
    // This bug is related to the implementation details of the old test statistics, so BatchMode is forced to be off
    using namespace RooFit;
    std::unique_ptr<RooNLLVar> nll{static_cast<RooNLLVar *>(model.createNLL(*ds, BatchMode("off")))};
-   std::unique_ptr<RooNLLVar> nllrange{static_cast<RooNLLVar *>(model.createNLL(*ds, Range("fitrange"), BatchMode("off")))};
+   std::unique_ptr<RooNLLVar> nllrange{
+      static_cast<RooNLLVar *>(model.createNLL(*ds, Range("fitrange"), BatchMode("off")))};
 
    auto nllClone = std::make_unique<RooNLLVar>(*nll);
    auto nllrangeClone = std::make_unique<RooNLLVar>(*nllrange);

--- a/roofit/roofitcore/test/testTestStatistics.cxx
+++ b/roofit/roofitcore/test/testTestStatistics.cxx
@@ -114,16 +114,17 @@ TEST(RooNLLVar, IntegrateBins_SubRange)
    dataH->plotOn(frame.get(), RooFit::MarkerColor(kRed));
    data.plotOn(frame.get(), RooFit::Name("data"));
 
-   a.setVal(3.);
-   std::unique_ptr<RooFitResult> fit1(pdf.fitTo(data, RooFit::Save(), RooFit::PrintLevel(-1), RooFit::Optimize(0),
-                                                RooFit::Range("range"), RooFit::BatchMode(batchMode)));
-   pdf.plotOn(frame.get(), RooFit::LineColor(kRed), RooFit::Name("standard"));
+   using namespace RooFit;
 
    a.setVal(3.);
-   std::unique_ptr<RooFitResult> fit2(pdf.fitTo(data, RooFit::Save(), RooFit::PrintLevel(-1), RooFit::Optimize(0),
-                                                RooFit::Range("range"), RooFit::BatchMode(batchMode),
-                                                RooFit::IntegrateBins(1.E-3)));
-   pdf.plotOn(frame.get(), RooFit::LineColor(kBlue), RooFit::Name("highRes"));
+   std::unique_ptr<RooFitResult> fit1(
+      pdf.fitTo(data, Save(), PrintLevel(-1), Optimize(0), Range("range"), BatchMode(batchMode)));
+   pdf.plotOn(frame.get(), LineColor(kRed), Name("standard"), Range("range"), NormRange("range"));
+
+   a.setVal(3.);
+   std::unique_ptr<RooFitResult> fit2(
+      pdf.fitTo(data, Save(), PrintLevel(-1), Optimize(0), Range("range"), BatchMode(batchMode), IntegrateBins(1.E-3)));
+   pdf.plotOn(frame.get(), LineColor(kBlue), Name("highRes"), Range("range"), NormRange("range"));
 
    EXPECT_GT(std::abs(getVal("a", targetValues) - getVal("a", fit1->floatParsFinal())),
              1. * getErr("a", fit1->floatParsFinal()))

--- a/roofit/roofitcore/test/testTestStatistics.cxx
+++ b/roofit/roofitcore/test/testTestStatistics.cxx
@@ -61,7 +61,7 @@ TEST(RooNLLVar, IntegrateBins) {
     return dynamic_cast<const RooRealVar&>(set[name]).getError();
   };
 
-  EXPECT_GT(fabs(getVal("a", targetValues) - getVal("a", fit1->floatParsFinal())), 1. * getErr("a", fit1->floatParsFinal()))
+  EXPECT_GT(std::abs(getVal("a", targetValues) - getVal("a", fit1->floatParsFinal())), 1. * getErr("a", fit1->floatParsFinal()))
       << "Expecting a bias when sampling PDF in bin centre.";
 
   EXPECT_NEAR(getVal("a", targetValues), getVal("a", fit2->floatParsFinal()), 1. * getErr("a", fit2->floatParsFinal()))
@@ -124,7 +124,7 @@ TEST(RooNLLVar, IntegrateBins_SubRange) {
     return dynamic_cast<const RooRealVar&>(set[name]).getError();
   };
 
-  EXPECT_GT(fabs(getVal("a", targetValues) - getVal("a", fit1->floatParsFinal())), 1. * getErr("a", fit1->floatParsFinal()))
+  EXPECT_GT(std::abs(getVal("a", targetValues) - getVal("a", fit1->floatParsFinal())), 1. * getErr("a", fit1->floatParsFinal()))
       << "Expecting a bias when sampling PDF in bin centre.";
 
   EXPECT_NEAR(getVal("a", targetValues), getVal("a", fit2->floatParsFinal()), 1. * getErr("a", fit2->floatParsFinal()))
@@ -186,7 +186,7 @@ TEST(RooNLLVar, IntegrateBins_CustomBinning) {
     return dynamic_cast<const RooRealVar&>(set[name]).getError();
   };
 
-  EXPECT_GT(fabs(getVal("a", targetValues) - getVal("a", fit1->floatParsFinal())), 1. * getErr("a", fit1->floatParsFinal()))
+  EXPECT_GT(std::abs(getVal("a", targetValues) - getVal("a", fit1->floatParsFinal())), 1. * getErr("a", fit1->floatParsFinal()))
       << "Expecting a bias when sampling PDF in bin centre.";
 
   EXPECT_NEAR(getVal("a", targetValues), getVal("a", fit2->floatParsFinal()), 1. * getErr("a", fit2->floatParsFinal()))
@@ -238,7 +238,7 @@ TEST(RooNLLVar, IntegrateBins_RooDataHist) {
     return dynamic_cast<const RooRealVar&>(set[name]).getError();
   };
 
-  EXPECT_GT(fabs(getVal("a", targetValues) - getVal("a", fit1->floatParsFinal())), 1. * getErr("a", fit1->floatParsFinal()))
+  EXPECT_GT(std::abs(getVal("a", targetValues) - getVal("a", fit1->floatParsFinal())), 1. * getErr("a", fit1->floatParsFinal()))
       << "Expecting a bias when sampling PDF in bin centre.";
 
   EXPECT_NEAR(getVal("a", targetValues), getVal("a", fit2->floatParsFinal()), 1. * getErr("a", fit2->floatParsFinal()))
@@ -284,7 +284,7 @@ TEST(RooChi2Var, IntegrateBins) {
     return dynamic_cast<const RooRealVar&>(set[name]).getError();
   };
 
-  EXPECT_GT(fabs(getVal("a", targetValues) - getVal("a", fit1->floatParsFinal())), 1. * getErr("a", fit1->floatParsFinal()))
+  EXPECT_GT(std::abs(getVal("a", targetValues) - getVal("a", fit1->floatParsFinal())), 1. * getErr("a", fit1->floatParsFinal()))
       << "Expecting a bias when sampling PDF in bin centre.";
 
   EXPECT_NEAR(getVal("a", targetValues), getVal("a", fit2->floatParsFinal()), 1. * getErr("a", fit2->floatParsFinal()))

--- a/roofit/roofitcore/test/test_lib.h
+++ b/roofit/roofitcore/test/test_lib.h
@@ -65,7 +65,7 @@ generate_ND_gaussian_pdf_nll(RooWorkspace &w, unsigned int n, unsigned long N_ev
   std::vector<double> mean(n), sigma(n);
   for (unsigned ix = 0; ix < n; ++ix) {
     mean[ix] = RooRandom::randomGenerator()->Gaus(0, 2);
-    sigma[ix] = 0.1 + abs(RooRandom::randomGenerator()->Gaus(0, 2));
+    sigma[ix] = 0.1 + std::abs(RooRandom::randomGenerator()->Gaus(0, 2));
   }
 
   // create gaussians and also the observables and parameters they depend on
@@ -138,7 +138,7 @@ generate_ND_gaussian_pdf_nll(RooWorkspace &w, unsigned int n, unsigned long N_ev
     {
       std::ostringstream os;
       os << "s" << ix;
-      dynamic_cast<RooRealVar *>(w.arg(os.str().c_str()))->setVal(0.1 + abs(RooRandom::randomGenerator()->Gaus(0, 2)));
+      dynamic_cast<RooRealVar *>(w.arg(os.str().c_str()))->setVal(0.1 + std::abs(RooRandom::randomGenerator()->Gaus(0, 2)));
     }
   }
 

--- a/roofit/roofitmore/src/RooAdaptiveGaussKronrodIntegrator1D.cxx
+++ b/roofit/roofitmore/src/RooAdaptiveGaussKronrodIntegrator1D.cxx
@@ -731,9 +731,9 @@ subinterval_too_small (double a1, double a2, double b2)
   const double e = GSL_DBL_EPSILON;
   const double u = GSL_DBL_MIN;
 
-  double tmp = (1 + 100 * e) * (fabs (a2) + 1000 * u);
+  double tmp = (1 + 100 * e) * (std::abs(a2) + 1000 * u);
 
-  int status = fabs (a1) <= tmp && fabs (b2) <= tmp;
+  int status = std::abs(a1) <= tmp && std::abs(b2) <= tmp;
 
   return status;
 }
@@ -841,7 +841,7 @@ qag (const gsl_function * f,
 
   /* Test on accuracy */
 
-  tolerance = GSL_MAX_DBL (epsabs, epsrel * fabs (result0));
+  tolerance = GSL_MAX_DBL (epsabs, epsrel * std::abs(result0));
 
   /* need IEEE rounding here to match original quadpack behavior */
 
@@ -906,7 +906,7 @@ qag (const gsl_function * f,
         {
           double delta = r_i - area12;
 
-          if (fabs (delta) <= 1.0e-5 * fabs (area12) && error12 >= 0.99 * e_i)
+          if (std::abs(delta) <= 1.0e-5 * std::abs(area12) && error12 >= 0.99 * e_i)
             {
               roundoff_type1++;
             }
@@ -916,7 +916,7 @@ qag (const gsl_function * f,
             }
         }
 
-      tolerance = GSL_MAX_DBL (epsabs, epsrel * fabs (area));
+      tolerance = GSL_MAX_DBL (epsabs, epsrel * std::abs(area));
 
       if (errsum > tolerance)
         {
@@ -975,7 +975,7 @@ static double rescale_error (double err, const double result_abs, const double r
 static double
 rescale_error (double err, const double result_abs, const double result_asc)
 {
-  err = fabs(err) ;
+  err = std::abs(err) ;
 
   if (result_asc != 0 && err != 0)
       {
@@ -1015,13 +1015,13 @@ gsl_integration_qk (const int n,
 
   const double center = 0.5 * (a + b);
   const double half_length = 0.5 * (b - a);
-  const double abs_half_length = fabs (half_length);
+  const double abs_half_length = std::abs(half_length);
   const double f_center = GSL_FN_EVAL (f, center);
 
   double result_gauss = 0;
   double result_kronrod = f_center * wgk[n - 1];
 
-  double result_abs = fabs (result_kronrod);
+  double result_abs = std::abs(result_kronrod);
   double result_asc = 0;
   double mean = 0, err = 0;
 
@@ -1043,7 +1043,7 @@ gsl_integration_qk (const int n,
       fv2[jtw] = fval2;
       result_gauss += wg[j] * fsum;
       result_kronrod += wgk[jtw] * fsum;
-      result_abs += wgk[jtw] * (fabs (fval1) + fabs (fval2));
+      result_abs += wgk[jtw] * (std::abs(fval1) + std::abs(fval2));
     }
 
   for (j = 0; j < n / 2; j++)
@@ -1055,16 +1055,16 @@ gsl_integration_qk (const int n,
       fv1[jtwm1] = fval1;
       fv2[jtwm1] = fval2;
       result_kronrod += wgk[jtwm1] * (fval1 + fval2);
-      result_abs += wgk[jtwm1] * (fabs (fval1) + fabs (fval2));
+      result_abs += wgk[jtwm1] * (std::abs(fval1) + std::abs(fval2));
     };
 
   mean = result_kronrod * 0.5;
 
-  result_asc = wgk[n - 1] * fabs (f_center - mean);
+  result_asc = wgk[n - 1] * std::abs(f_center - mean);
 
   for (j = 0; j < n - 1; j++)
     {
-      result_asc += wgk[j] * (fabs (fv1[j] - mean) + fabs (fv2[j] - mean));
+      result_asc += wgk[j] * (std::abs(fv1[j] - mean) + std::abs(fv2[j] - mean));
     }
 
   /* scale by the width of the integration region */
@@ -1790,7 +1790,7 @@ qelg (struct extrapolation_table *table, double *result, double *abserr)
   const double current = epstab[n];
 
   double absolute = GSL_DBL_MAX;
-  double relative = 5 * GSL_DBL_EPSILON * fabs (current);
+  double relative = 5 * GSL_DBL_EPSILON * std::abs(current);
 
   const size_t newelm = n / 2;
   const size_t n_orig = n;
@@ -1819,13 +1819,13 @@ qelg (struct extrapolation_table *table, double *result, double *abserr)
       double e1 = epstab[n - 2 * i - 1];
       double e2 = res;
 
-      double e1abs = fabs (e1);
+      double e1abs = std::abs(e1);
       double delta2 = e2 - e1;
-      double err2 = fabs (delta2);
-      double tol2 = GSL_MAX_DBL (fabs (e2), e1abs) * GSL_DBL_EPSILON;
+      double err2 = std::abs(delta2);
+      double tol2 = GSL_MAX_DBL (std::abs(e2), e1abs) * GSL_DBL_EPSILON;
       double delta3 = e1 - e0;
-      double err3 = fabs (delta3);
-      double tol3 = GSL_MAX_DBL (e1abs, fabs (e0)) * GSL_DBL_EPSILON;
+      double err3 = std::abs(delta3);
+      double tol3 = GSL_MAX_DBL (e1abs, std::abs(e0)) * GSL_DBL_EPSILON;
 
       double e3, delta1, err1, tol1, ss;
 
@@ -1836,7 +1836,7 @@ qelg (struct extrapolation_table *table, double *result, double *abserr)
 
           *result = res;
           absolute = err2 + err3;
-          relative = 5 * GSL_DBL_EPSILON * fabs (res);
+          relative = 5 * GSL_DBL_EPSILON * std::abs(res);
           *abserr = GSL_MAX_DBL (absolute, relative);
           return;
         }
@@ -1844,8 +1844,8 @@ qelg (struct extrapolation_table *table, double *result, double *abserr)
       e3 = epstab[n - 2 * i];
       epstab[n - 2 * i] = e1;
       delta1 = e1 - e3;
-      err1 = fabs (delta1);
-      tol1 = GSL_MAX_DBL (e1abs, fabs (e3)) * GSL_DBL_EPSILON;
+      err1 = std::abs(delta1);
+      tol1 = GSL_MAX_DBL (e1abs, std::abs(e3)) * GSL_DBL_EPSILON;
 
       /* If two elements are very close to each other, omit a part of
          the table by adjusting the value of n */
@@ -1862,7 +1862,7 @@ qelg (struct extrapolation_table *table, double *result, double *abserr)
          eventually omit a part of the table by adjusting the value of
          n. */
 
-      if (fabs (ss * e1) <= 0.0001)
+      if (std::abs(ss * e1) <= 0.0001)
         {
           n_final = 2 * i;
           break;
@@ -1875,7 +1875,7 @@ qelg (struct extrapolation_table *table, double *result, double *abserr)
       epstab[n - 2 * i] = res;
 
       {
-        const double error = err2 + fabs (res - e2) + err3;
+        const double error = err2 + std::abs(res - e2) + err3;
 
         if (error <= *abserr)
           {
@@ -1928,8 +1928,8 @@ qelg (struct extrapolation_table *table, double *result, double *abserr)
     }
   else
     {                           /* Compute error estimate */
-      *abserr = (fabs (*result - res3la[2]) + fabs (*result - res3la[1])
-                 + fabs (*result - res3la[0]));
+      *abserr = (std::abs(*result - res3la[2]) + std::abs(*result - res3la[1])
+                 + std::abs(*result - res3la[0]));
 
       res3la[0] = res3la[1];
       res3la[1] = res3la[2];
@@ -1944,7 +1944,7 @@ qelg (struct extrapolation_table *table, double *result, double *abserr)
 
   table->nres = nres_orig + 1;
 
-  *abserr = GSL_MAX_DBL (*abserr, 5 * GSL_DBL_EPSILON * fabs (*result));
+  *abserr = GSL_MAX_DBL (*abserr, 5 * GSL_DBL_EPSILON * std::abs(*result));
 
   return;
 }
@@ -1960,7 +1960,7 @@ test_positivity (double result, double resabs);
 static inline int
 test_positivity (double result, double resabs)
 {
-  int status = (fabs (result) >= (1 - 50 * GSL_DBL_EPSILON) * resabs);
+  int status = (std::abs(result) >= (1 - 50 * GSL_DBL_EPSILON) * resabs);
 
   return status;
 }
@@ -2180,7 +2180,7 @@ qags (const gsl_function * f,
 
   set_initial_result (workspace, result0, abserr0);
 
-  tolerance = GSL_MAX_DBL (epsabs, epsrel * fabs (result0));
+  tolerance = GSL_MAX_DBL (epsabs, epsrel * std::abs(result0));
 
   if (abserr0 <= 100 * GSL_DBL_EPSILON * resabs0 && abserr0 > tolerance)
     {
@@ -2261,13 +2261,13 @@ qags (const gsl_function * f,
       errsum = errsum + error12 - e_i;
       area = area + area12 - r_i;
 
-      tolerance = GSL_MAX_DBL (epsabs, epsrel * fabs (area));
+      tolerance = GSL_MAX_DBL (epsabs, epsrel * std::abs(area));
 
       if (resasc1 != error1 && resasc2 != error2)
         {
           double delta = r_i - area12;
 
-          if (fabs (delta) <= 1.0e-5 * fabs (area12) && error12 >= 0.99 * e_i)
+          if (std::abs(delta) <= 1.0e-5 * std::abs(area12) && error12 >= 0.99 * e_i)
             {
               if (!extrapolate)
                 {
@@ -2381,7 +2381,7 @@ qags (const gsl_function * f,
           err_ext = abseps;
           res_ext = reseps;
           correc = error_over_large_intervals;
-          ertest = GSL_MAX_DBL (epsabs, epsrel * fabs (reseps));
+          ertest = GSL_MAX_DBL (epsabs, epsrel * std::abs(reseps));
           if (err_ext <= ertest)
             break;
         }
@@ -2425,7 +2425,7 @@ qags (const gsl_function * f,
 
       if (res_ext != 0.0 && area != 0.0)
         {
-          if (err_ext / fabs (res_ext) > errsum / fabs (area))
+          if (err_ext / std::abs(res_ext) > errsum / std::abs(area))
             goto compute_result;
         }
       else if (err_ext > errsum)
@@ -2441,7 +2441,7 @@ qags (const gsl_function * f,
   /*  Test on divergence. */
 
   {
-    double max_area = GSL_MAX_DBL (fabs (res_ext), fabs (area));
+    double max_area = GSL_MAX_DBL (std::abs(res_ext), std::abs(area));
 
     if (!positive_integrand && max_area < 0.01 * resabs0)
       goto return_error;
@@ -2450,7 +2450,7 @@ qags (const gsl_function * f,
   {
     double ratio = res_ext / area;
 
-    if (ratio < 0.01 || ratio > 100.0 || errsum > fabs (area))
+    if (ratio < 0.01 || ratio > 100.0 || errsum > std::abs(area))
       error_type = 6;
   }
 

--- a/roofit/roofitmore/src/RooGaussKronrodIntegrator1D.cxx
+++ b/roofit/roofitmore/src/RooGaussKronrodIntegrator1D.cxx
@@ -281,7 +281,7 @@ static double rescale_error (double err, const double result_abs, const double r
 static double
 rescale_error (double err, const double result_abs, const double result_asc)
 {
-  err = fabs(err) ;
+  err = std::abs(err) ;
 
   if (result_asc != 0 && err != 0)
       {
@@ -496,11 +496,11 @@ gsl_integration_qng (const gsl_function *f,
   double savfun[21];  /* array of function values which have been computed */
   double res10, res21, res43, res87;    /* 10, 21, 43 and 87 point results */
   double result_kronrod, err ;
-  double resabs; /* approximation to the integral of abs(f) */
-  double resasc; /* approximation to the integral of abs(f-i/(b-a)) */
+  double resabs; /* approximation to the integral of std::abs(f) */
+  double resasc; /* approximation to the integral of std::abs(f-i/(b-a)) */
 
   const double half_length =  0.5 * (b - a);
-  const double abs_half_length = fabs (half_length);
+  const double abs_half_length = std::abs(half_length);
   const double center = 0.5 * (b + a);
   const double f_center = GSL_FN_EVAL(f, center);
 
@@ -519,7 +519,7 @@ gsl_integration_qng (const gsl_function *f,
 
   res10 = 0;
   res21 = w21b[5] * f_center;
-  resabs = w21b[5] * fabs (f_center);
+  resabs = w21b[5] * std::abs(f_center);
 
   for (k = 0; k < 5; k++)
     {
@@ -529,7 +529,7 @@ gsl_integration_qng (const gsl_function *f,
       const double fval = fval1 + fval2;
       res10 += w10[k] * fval;
       res21 += w21a[k] * fval;
-      resabs += w21a[k] * (fabs (fval1) + fabs (fval2));
+      resabs += w21a[k] * (std::abs(fval1) + std::abs(fval2));
       savfun[k] = fval;
       fv1[k] = fval1;
       fv2[k] = fval2;
@@ -542,7 +542,7 @@ gsl_integration_qng (const gsl_function *f,
       const double fval2 = GSL_FN_EVAL(f, center - abscissa);
       const double fval = fval1 + fval2;
       res21 += w21b[k] * fval;
-      resabs += w21b[k] * (fabs (fval1) + fabs (fval2));
+      resabs += w21b[k] * (std::abs(fval1) + std::abs(fval2));
       savfun[k + 5] = fval;
       fv3[k] = fval1;
       fv4[k] = fval2;
@@ -553,13 +553,13 @@ gsl_integration_qng (const gsl_function *f,
   {
     const double mean = 0.5 * res21;
 
-    resasc = w21b[5] * fabs (f_center - mean);
+    resasc = w21b[5] * std::abs(f_center - mean);
 
     for (k = 0; k < 5; k++)
       {
         resasc +=
-          (w21a[k] * (fabs (fv1[k] - mean) + fabs (fv2[k] - mean))
-          + w21b[k] * (fabs (fv3[k] - mean) + fabs (fv4[k] - mean)));
+          (w21a[k] * (std::abs(fv1[k] - mean) + std::abs(fv2[k] - mean))
+          + w21b[k] * (std::abs(fv3[k] - mean) + std::abs(fv4[k] - mean)));
       }
     resasc *= abs_half_length ;
   }
@@ -570,7 +570,7 @@ gsl_integration_qng (const gsl_function *f,
 
   /*   test for convergence. */
 
-  if (err < epsabs || err < epsrel * fabs (result_kronrod))
+  if (err < epsabs || err < epsrel * std::abs(result_kronrod))
     {
       * result = result_kronrod ;
       * abserr = err ;
@@ -601,7 +601,7 @@ gsl_integration_qng (const gsl_function *f,
   result_kronrod = res43 * half_length;
   err = rescale_error ((res43 - res21) * half_length, resabs, resasc);
 
-  if (err < epsabs || err < epsrel * fabs (result_kronrod))
+  if (err < epsabs || err < epsrel * std::abs(result_kronrod))
     {
       * result = result_kronrod ;
       * abserr = err ;
@@ -631,7 +631,7 @@ gsl_integration_qng (const gsl_function *f,
 
   err = rescale_error ((res87 - res43) * half_length, resabs, resasc);
 
-  if (err < epsabs || err < epsrel * fabs (result_kronrod))
+  if (err < epsabs || err < epsrel * std::abs(result_kronrod))
     {
       * result = result_kronrod ;
       * abserr = err ;

--- a/roofit/roofitmore/src/RooHypatia2.cxx
+++ b/roofit/roofitmore/src/RooHypatia2.cxx
@@ -182,7 +182,7 @@ double low_x_LnBK(double nu, double x){
 }
 
 double besselK(double ni, double x) {
-  const double nu = std::fabs(ni);
+  const double nu = std::abs(ni);
   if ((x < 1.e-06 && nu > 0.) ||
       (x < 1.e-04 && nu > 0. && nu < 55.) ||
       (x < 0.1 && nu >= 55.) )
@@ -197,7 +197,7 @@ double besselK(double ni, double x) {
 }
 
 double LnBesselK(double ni, double x) {
-  const double nu = std::fabs(ni);
+  const double nu = std::abs(ni);
   if ((x < 1.e-06 && nu > 0.) ||
       (x < 1.e-04 && nu > 0. && nu < 55.) ||
       (x < 0.1 && nu >= 55.) )
@@ -219,7 +219,7 @@ double LogEval(double d, double l, double alpha, double beta, double delta) {
 
   return std::exp(logno + beta*d
       + (0.5-l)*(std::log(alpha)-0.5*std::log(thing))
-      + LnBesselK(l-0.5, alpha*std::sqrt(thing)) );// + std::log(std::fabs(beta)+0.0001) );
+      + LnBesselK(l-0.5, alpha*std::sqrt(thing)) );// + std::log(std::abs(beta)+0.0001) );
 
 }
 
@@ -243,7 +243,7 @@ double diff_eval(double d, double l, double alpha, double beta, double delta){
 
 /*
 double Gauss2F1(double a, double b, double c, double x){
-  if (fabs(x) <= 1.) {
+  if (std::abs(x) <= 1.) {
     return ROOT::Math::hyperg(a, b, c, x);
   } else {
     return ROOT::Math::hyperg(c-a, b, c, 1-1/(1-x))/std::pow(1-x, b);

--- a/roofit/roofitmore/src/RooLegendre.cxx
+++ b/roofit/roofitmore/src/RooLegendre.cxx
@@ -183,8 +183,8 @@ namespace {
   bool fullRange(const RooRealProxy& x ,const char* range)
   {
     return range == 0 || strlen(range) == 0
-        ? std::fabs(x.min() + 1.) < 1.e-8 && std::fabs(x.max() - 1.) < 1.e-8
-        : std::fabs(x.min(range) + 1.) < 1.e-8 && std::fabs(x.max(range) - 1.) < 1.e-8;
+        ? std::abs(x.min() + 1.) < 1.e-8 && std::abs(x.max() - 1.) < 1.e-8
+        : std::abs(x.min(range) + 1.) < 1.e-8 && std::abs(x.max(range) - 1.) < 1.e-8;
   }
 }
 

--- a/roofit/roofitmore/src/RooSpHarmonic.cxx
+++ b/roofit/roofitmore/src/RooSpHarmonic.cxx
@@ -125,13 +125,13 @@ namespace {
   {
     if (phi) {
       return range == 0 || strlen(range) == 0
-          ? std::fabs(x.max() - x.min() - TMath::TwoPi()) < 1.e-8
-          : std::fabs(x.max(range) - x.min(range) - TMath::TwoPi()) < 1.e-8;
+          ? std::abs(x.max() - x.min() - TMath::TwoPi()) < 1.e-8
+          : std::abs(x.max(range) - x.min(range) - TMath::TwoPi()) < 1.e-8;
     }
 
     return range == 0 || strlen(range) == 0
-        ? std::fabs(x.min() + 1.) < 1.e-8 && std::fabs(x.max() - 1.) < 1.e-8
-        : std::fabs(x.min(range) + 1.) < 1.e-8 && std::fabs(x.max(range) - 1.) < 1.e-8;
+        ? std::abs(x.min() + 1.) < 1.e-8 && std::abs(x.max() - 1.) < 1.e-8
+        : std::abs(x.min(range) + 1.) < 1.e-8 && std::abs(x.max(range) - 1.) < 1.e-8;
   }
 }
 

--- a/roofit/roostats/src/HybridPlot.cxx
+++ b/roofit/roostats/src/HybridPlot.cxx
@@ -331,7 +331,7 @@ double* HybridPlot::GetHistoPvals (TH1* histo, double percentage){
    for (it = extremes_map.begin();it != extremes_map.end();++it){
       a=it->first;
       b=it->second;
-      current_diff=std::fabs(histo->GetBinContent(a)-histo->GetBinContent(b));
+      current_diff=std::abs(histo->GetBinContent(a)-histo->GetBinContent(b));
       if (current_diff<diff){
          //std::cout << "a=" << a << " b=" << b << std::endl;
          diff=current_diff;

--- a/roofit/roostats/src/HypoTestInverter.cxx
+++ b/roofit/roostats/src/HypoTestInverter.cxx
@@ -560,7 +560,7 @@ HypoTestResult * HypoTestInverter::Eval(HypoTestCalculatorGeneric &hc, bool adap
       if (fCalcType == kHybrid) HypoTestWrapper<HybridCalculator>::SetToys((HybridCalculator*)&hc, fUseCLs ? fgNToys : 1, 4*fgNToys);
       if (fCalcType == kFrequentist) HypoTestWrapper<FrequentistCalculator>::SetToys((FrequentistCalculator*)&hc, fUseCLs ? fgNToys : 1, 4*fgNToys);
 
-   while (clsMidErr >= fgCLAccuracy && (clsTarget == -1 || fabs(clsMid-clsTarget) < 3*clsMidErr) ) {
+   while (clsMidErr >= fgCLAccuracy && (clsTarget == -1 || std::abs(clsMid-clsTarget) < 3*clsMidErr) ) {
       std::unique_ptr<HypoTestResult> more(hc.GetHypoTest());
 
       // if (flipPValues)
@@ -805,7 +805,7 @@ bool HypoTestInverter::RunLimit(double &limit, double &limitErr, double absAccur
         continue;
      }
      clsMax = std::make_pair( fResults->GetLastYValue(), fResults->GetLastYError() );
-     if (clsMax.first == 0 || clsMax.first + 3 * fabs(clsMax.second) < clsTarget ) break;
+     if (clsMax.first == 0 || clsMax.first + 3 * std::abs(clsMax.second) < clsTarget ) break;
      rMax += rMax;
      if (tries == 5) {
         oocoutE(nullptr,Eval) << "HypoTestInverter::RunLimit - Cannot determine upper limit of scan range. At " << r->GetName()
@@ -828,7 +828,7 @@ bool HypoTestInverter::RunLimit(double &limit, double &limitErr, double absAccur
      }
      clsMin = std::make_pair( fResults->GetLastYValue(), fResults->GetLastYError() );
   }
-  if (clsMin.first != 1 && clsMin.first - 3 * fabs(clsMin.second) < clsTarget) {
+  if (clsMin.first != 1 && clsMin.first - 3 * std::abs(clsMin.second) < clsTarget) {
      if (fUseCLs) {
         rMin = 0;
         clsMin = CLs_t(1,0); // this is always true for CLs
@@ -841,7 +841,7 @@ bool HypoTestInverter::RunLimit(double &limit, double &limitErr, double absAccur
              continue;
            }
            clsMin = std::make_pair( fResults->GetLastYValue(), fResults->GetLastYError() );
-           if (clsMin.first == 1 || clsMin.first - 3 * fabs(clsMin.second) > clsTarget) break;
+           if (clsMin.first == 1 || clsMin.first - 3 * std::abs(clsMin.second) > clsTarget) break;
            rMin += rMin;
            if (tries == 5) {
               oocoutE(nullptr,Eval) << "HypoTestInverter::RunLimit - Cannot determine lower limit of scan range. At " << r->GetName()
@@ -897,7 +897,7 @@ bool HypoTestInverter::RunLimit(double &limit, double &limitErr, double absAccur
      }
 
      // if sufficiently far away, drop one of the points
-     if (fabs(clsMid.first-clsTarget) >= 2*clsMid.second) {
+     if (std::abs(clsMid.first-clsTarget) >= 2*clsMid.second) {
        if ((clsMid.first>clsTarget) == (clsMax.first>clsTarget)) {
          rMax = limit; clsMax = clsMid;
        } else {
@@ -907,24 +907,24 @@ bool HypoTestInverter::RunLimit(double &limit, double &limitErr, double absAccur
        if (fVerbose > 0) std::cout << "Trying to move the interval edges closer" << std::endl;
        double rMinBound = rMin, rMaxBound = rMax;
        // try to reduce the size of the interval
-       while (clsMin.second == 0 || fabs(rMin-limit) > std::max(absAccuracy, relAccuracy * limit)) {
+       while (clsMin.second == 0 || std::abs(rMin-limit) > std::max(absAccuracy, relAccuracy * limit)) {
          rMin = 0.5*(rMin+limit);
          if (!RunOnePoint(rMin,true, clsTarget) ) {
            oocoutE(nullptr,Eval) << "HypoTestInverter::RunLimit - Hypo test failed at x=" << rMin << " when trying to find limit from below." << std::endl;
            return false;
          }
          clsMin = std::make_pair( fResults->GetLastYValue(), fResults->GetLastYError() );
-         if (fabs(clsMin.first-clsTarget) <= 2*clsMin.second) break;
+         if (std::abs(clsMin.first-clsTarget) <= 2*clsMin.second) break;
          rMinBound = rMin;
        }
-       while (clsMax.second == 0 || fabs(rMax-limit) > std::max(absAccuracy, relAccuracy * limit)) {
+       while (clsMax.second == 0 || std::abs(rMax-limit) > std::max(absAccuracy, relAccuracy * limit)) {
          rMax = 0.5*(rMax+limit);
          if (!RunOnePoint(rMax,true,clsTarget) ) {
            oocoutE(nullptr,Eval) << "HypoTestInverter::RunLimit - Hypo test failed at x=" << rMin << " when trying to find limit from above." << std::endl;
            return false;
          }
          clsMax = std::make_pair( fResults->GetLastYValue(), fResults->GetLastYError() );
-         if (fabs(clsMax.first-clsTarget) <= 2*clsMax.second) break;
+         if (std::abs(clsMax.first-clsTarget) <= 2*clsMax.second) break;
          rMaxBound = rMax;
        }
        expoFit.SetRange(rMinBound,rMaxBound);
@@ -942,7 +942,7 @@ bool HypoTestInverter::RunLimit(double &limit, double &limitErr, double absAccur
       expoFit.SetParameter(1,log(clsMax.first/clsMin.first)/(rMax-rMin));
       expoFit.SetParameter(2,limit);
       double rMinBound, rMaxBound; expoFit.GetRange(rMinBound, rMaxBound);
-      limitErr = std::max(fabs(rMinBound-limit), fabs(rMaxBound-limit));
+      limitErr = std::max(std::abs(rMinBound-limit), std::abs(rMaxBound-limit));
       int npoints = 0;
 
       HypoTestInverterPlot plot("plot","plot",fResults);

--- a/roofit/roostats/src/HypoTestInverterResult.cxx
+++ b/roofit/roostats/src/HypoTestInverterResult.cxx
@@ -892,7 +892,7 @@ int HypoTestInverterResult::FindClosestPointIndex(double target, int mode, doubl
      double smallestError = 2; // error must be < 1
      double bestValue = 2;
      for (int i=0; i<ArraySize(); i++) {
-        double dist = fabs(GetYValue(i)-target);
+        double dist = std::abs(GetYValue(i)-target);
         if ( dist <3 *GetYError(i) ) { // less than 1 sigma from target CL
            if (GetYError(i) < smallestError ) {
               smallestError = GetYError(i);
@@ -930,7 +930,7 @@ int HypoTestInverterResult::FindClosestPointIndex(double target, int mode, doubl
   if (mode == 2) return (GetXValue(indx[index1]) < GetXValue(indx[index2])) ? indx[index1] : indx[index2];
   if (mode == 3) return (GetXValue(indx[index1]) > GetXValue(indx[index2])) ? indx[index1] : indx[index2];
   // get smaller point of the two (mode == 1)
-  if (fabs(GetYValue(indx[index1])-target) <= fabs(GetYValue(indx[index2])-target) )
+  if (std::abs(GetYValue(indx[index1])-target) <= std::abs(GetYValue(indx[index2])-target) )
      return indx[index1];
   return indx[index2];
 
@@ -1063,7 +1063,7 @@ double HypoTestInverterResult::CalculateEstimatedError(double target, bool lower
      double errY = GetYError(index);
      if (errY >  0) {
         double m = fct.Derivative( GetXValue(index) );
-        theError = std::min(fabs( GetYError(index) / m), maxX-minX);
+        theError = std::min(std::abs( GetYError(index) / m), maxX-minX);
      }
   }
   else {

--- a/roofit/roostats/src/SPlot.cxx
+++ b/roofit/roostats/src/SPlot.cxx
@@ -684,7 +684,7 @@ void SPlot::AddSWeight( RooAbsPdf* pdf, const RooArgList &yieldsTmp,
 
      pdfvec[n]->setVal( pdfvalues[ievt][n] ) ;
 
-     if( !(fabs(nsum/dsum)>=0 ) )
+     if( !(std::abs(nsum/dsum)>=0 ) )
        {
          coutE(Contents) << "error: " << nsum/dsum << endl ;
          return;

--- a/roofit/xroofit/src/xRooFit.cxx
+++ b/roofit/xroofit/src/xRooFit.cxx
@@ -569,7 +569,7 @@ xRooFit::minimize(RooAbsReal &nll, const std::shared_ptr<ROOT::Fit::FitConfig> &
                            if (auto _p = dynamic_cast<RooAbsReal *>(cachedFit->constPars().find(p->GetName())); _p) {
                               // note: do not need global observable values to match (globals currently added to
                               // constPars list)
-                              if (!_p->getAttribute("global") && abs(_p->getVal() - v->getVal()) > 1e-12) {
+                              if (!_p->getAttribute("global") && std::abs(_p->getVal() - v->getVal()) > 1e-12) {
                                  match = false;
                                  break;
                               }
@@ -1004,12 +1004,12 @@ int xRooFit::minos(RooAbsReal &nll, const RooFitResult &ufit, const char *parNam
    auto findValue = [&](double val_guess, double N_sigma = 1, double precision = 0.002, int printLevel = 0) {
       double tmu;
       int nrItr = 0;
-      double sigma_guess = fabs((val_guess - val_best) / N_sigma);
+      double sigma_guess = std::abs((val_guess - val_best) / N_sigma);
       double val_pre =
          val_guess -
          10 * precision * sigma_guess; // this is just to set value st. guarantees will do at least one iteration
       bool lastOverflow = false, lastUnderflow = false;
-      while (fabs(val_pre - val_guess) > precision * sigma_guess) {
+      while (std::abs(val_pre - val_guess) > precision * sigma_guess) {
          val_pre = val_guess;
          if (val_guess > 0 && par->getMax() < val_guess)
             par->setMax(2 * val_guess);
@@ -1024,7 +1024,7 @@ int xRooFit::minos(RooAbsReal &nll, const RooFitResult &ufit, const char *parNam
          double nll_val = result->minNll();
          status += result->status() * 10;
          tmu = 2 * (nll_val - nll_min);
-         sigma_guess = fabs(val_guess - val_best) / sqrt(tmu);
+         sigma_guess = std::abs(val_guess - val_best) / sqrt(tmu);
 
          if (tmu <= 0) {
             // found an alternative or improved minima
@@ -1033,7 +1033,7 @@ int xRooFit::minos(RooAbsReal &nll, const RooFitResult &ufit, const char *parNam
             double new_guess = val_guess + (val_guess - val_best);
             val_best = val_guess;
             val_guess = new_guess;
-            sigma_guess = fabs((val_guess - val_best) / N_sigma);
+            sigma_guess = std::abs((val_guess - val_best) / N_sigma);
             val_pre = val_guess - 10 * precision * sigma_guess;
             status = (status / 10) * 10 + 1;
             continue;
@@ -1049,14 +1049,14 @@ int xRooFit::minos(RooAbsReal &nll, const RooFitResult &ufit, const char *parNam
             // cout << "NLL:            " << nll->GetName() << " = " << nll->getVal() << endl;
             // cout << "delta(NLL):     " << nll->getVal()-nll_min << endl;
             std::cout << "NLL min: " << nll_min << std::endl;
-            std::cout << "N_sigma*sigma(pre):   " << fabs(val_pre - val_best) << std::endl;
+            std::cout << "N_sigma*sigma(pre):   " << std::abs(val_pre - val_best) << std::endl;
             std::cout << "sigma(guess):   " << sigma_guess << std::endl;
             std::cout << "par(guess):     " << val_guess + corr << std::endl;
             std::cout << "true val:       " << val_best << std::endl;
             std::cout << "tmu:            " << tmu << std::endl;
             std::cout << "Precision:      " << sigma_guess * precision << std::endl;
             std::cout << "Correction:     " << (-corr < 0 ? " " : "") << -corr << std::endl;
-            std::cout << "N_sigma*sigma(guess): " << fabs(val_guess - val_best) << std::endl;
+            std::cout << "N_sigma*sigma(guess): " << std::abs(val_guess - val_best) << std::endl;
             std::cout << std::endl;
          }
          if (val_guess > par->getMax()) {
@@ -1249,7 +1249,7 @@ xRooFit::hypoTest(RooWorkspace &w, int nToysNull, int /*nToysAlt*/, const xRooFi
                              "the physical range");
       }
       bool doCLs =
-         !std::isnan(altVal) && abs(mu->getMin("hypoPoints")) > altVal && abs(mu->getMax("hypoPoints")) > altVal;
+         !std::isnan(altVal) && std::abs(mu->getMin("hypoPoints")) > altVal && std::abs(mu->getMax("hypoPoints")) > altVal;
 
       const char *sCL = (doCLs) ? "CLs" : "null";
       Info("hypoTest", "%s testing active", sCL);
@@ -1320,7 +1320,7 @@ xRooFit::hypoTest(RooWorkspace &w, int nToysNull, int /*nToysAlt*/, const xRooFi
          testPoint(mu->getMax("hypoPoints"));
          testPoint((mu->getMax("hypoPoints") + mu->getMin("hypoPoints")) / 2.);
 
-         while (abs(obs_pcls->GetPointY(obs_pcls->GetN() - 1) - (1. - CL)) > 0.01) {
+         while (std::abs(obs_pcls->GetPointY(obs_pcls->GetN() - 1) - (1. - CL)) > 0.01) {
             obs_pcls->Sort();
             double nextTest = getLimit(*obs_pcls);
             if (std::isnan(nextTest))
@@ -1328,7 +1328,7 @@ xRooFit::hypoTest(RooWorkspace &w, int nToysNull, int /*nToysAlt*/, const xRooFi
             testPoint(nextTest);
          }
          for (auto s : expSig) {
-            while (abs(exp_pcls[s].GetPointY(exp_pcls[s].GetN() - 1) - (1. - CL)) > 0.01) {
+            while (std::abs(exp_pcls[s].GetPointY(exp_pcls[s].GetN() - 1) - (1. - CL)) > 0.01) {
                exp_pcls[s].Sort();
                double nextTest = getLimit(exp_pcls[s]);
                if (std::isnan(nextTest))

--- a/roofit/xroofit/src/xRooHypoSpace.cxx
+++ b/roofit/xroofit/src/xRooHypoSpace.cxx
@@ -179,7 +179,7 @@ double round_to_digits(double value, int digits)
 {
    if (value == 0.0)
       return 0.0;
-   double factor = pow(10.0, digits - ceil(log10(fabs(value))));
+   double factor = pow(10.0, digits - ceil(log10(std::abs(value))));
    return std::round(value * factor) / factor;
 };
 double round_to_decimal(double value, int decimal_places)
@@ -195,7 +195,7 @@ std::pair<double, double> matchPrecision(const std::pair<double, double> &in)
    if (!std::isinf(out.second)) {
       auto tmp = out.second;
       out.second = round_to_digits(out.second, 2);
-      int expo = (out.second == 0) ? 0 : (int)std::floor(std::log10(std::fabs(out.second)));
+      int expo = (out.second == 0) ? 0 : (int)std::floor(std::log10(std::abs(out.second)));
       if (TString::Format("%e", out.second)(0) != '1') {
          out.second = round_to_digits(tmp, 1);
          out.first = (expo >= 0) ? round(out.first) : round_to_decimal(out.first, -expo);

--- a/roofit/xroofit/src/xRooNLLVar.cxx
+++ b/roofit/xroofit/src/xRooNLLVar.cxx
@@ -1527,16 +1527,16 @@ void xRooNLLVar::xRooHypoPoint::Draw(Option_t *opt)
 
    auto obs = pll();
    if (!std::isnan(obs.first)) {
-      _min = std::min(obs.first - abs(obs.first) * 0.1, _min);
-      _max = std::max(obs.first + abs(obs.first) * 0.1, _max);
+      _min = std::min(obs.first - std::abs(obs.first) * 0.1, _min);
+      _max = std::max(obs.first + std::abs(obs.first) * 0.1, _max);
    }
 
    auto asi = (fAsimov && fAsimov->fUfit && fAsimov->fNull_cfit) ? fAsimov->pll().first
                                                                  : std::numeric_limits<double>::quiet_NaN();
    if (!std::isnan(asi) && asi > 0 && fPllType != xRooFit::Asymptotics::Unknown) {
       // can calculate asymptotic distributions,
-      _min = std::min(asi - abs(asi), _min);
-      _max = std::max(asi + abs(asi), _max);
+      _min = std::min(asi - std::abs(asi), _min);
+      _max = std::max(asi + std::abs(asi), _max);
    }
    if (_min > 0)
       _min = 0;

--- a/roofit/xroofit/src/xRooNode.cxx
+++ b/roofit/xroofit/src/xRooNode.cxx
@@ -5775,9 +5775,9 @@ TH1 *xRooNode::BuildHistogram(RooAbsLValue *v, bool empty, bool errors, int binS
          if (x->hasError())
             h->SetBinError(1, x->getError());
          h->SetMaximum(x->hasMax() ? x->getMax()
-                                   : (h->GetBinContent(1) + std::max(abs(h->GetBinContent(1) * 0.1), 50.)));
+                                   : (h->GetBinContent(1) + std::max(std::abs(h->GetBinContent(1) * 0.1), 50.)));
          h->SetMinimum(x->hasMin() ? x->getMin()
-                                   : (h->GetBinContent(1) - std::max(abs(h->GetBinContent(1) * 0.1), 50.)));
+                                   : (h->GetBinContent(1) - std::max(std::abs(h->GetBinContent(1) * 0.1), 50.)));
          h->GetXaxis()->SetName(dynamic_cast<TObject *>(v)->GetName());
          return h;
       }

--- a/test/stressRooFit_tests.h
+++ b/test/stressRooFit_tests.h
@@ -1270,12 +1270,12 @@ public:
     RooExponential bkg2("bkg2","Background 2",x,alpha) ;
 
     // Sum the background components into a composite background p.d.f.
-    RooRealVar bkg1frac("sig1frac","fraction of component 1 in background",0.2,0.,1.) ;
-    RooAddPdf bkg("bkg","Signal",RooArgList(bkg1,bkg2),sig1frac) ;
+    RooRealVar bkg1frac("bkg1frac","fraction of component 1 in background",0.8,0.,1.) ;
+    RooAddPdf bkg("bkg", "Total background", {bkg1,bkg2}, bkg1frac);
 
     // Sum the composite signal and background
     RooRealVar bkgfrac("bkgfrac","fraction of background",0.5,0.,1.) ;
-    RooAddPdf  model("model","g1+g2+a",RooArgList(bkg,sig),bkgfrac) ;
+    RooAddPdf  model("model", "g1+g2+a", {bkg,sig}, bkgfrac);
 
 
 

--- a/tutorials/roofit/rf205_compplot.C
+++ b/tutorials/roofit/rf205_compplot.C
@@ -38,30 +38,30 @@ void rf205_compplot()
 
    // Sum the signal components into a composite signal pdf
    RooRealVar sig1frac("sig1frac", "fraction of component 1 in signal", 0.8, 0., 1.);
-   RooAddPdf sig("sig", "Signal", RooArgList(sig1, sig2), sig1frac);
+   RooAddPdf sig("sig", "Signal", {sig1, sig2}, sig1frac);
 
    // Build Chebychev polynomial pdf
    RooRealVar a0("a0", "a0", 0.5, 0., 1.);
    RooRealVar a1("a1", "a1", 0.2, 0., 1.);
-   RooChebychev bkg1("bkg1", "Background 1", x, RooArgSet(a0, a1));
+   RooChebychev bkg1("bkg1", "Background 1", x, {a0, a1});
 
    // Build exponential pdf
    RooRealVar alpha("alpha", "alpha", -1);
    RooExponential bkg2("bkg2", "Background 2", x, alpha);
 
    // Sum the background components into a composite background pdf
-   RooRealVar bkg1frac("sig1frac", "fraction of component 1 in background", 0.2, 0., 1.);
-   RooAddPdf bkg("bkg", "Signal", RooArgList(bkg1, bkg2), sig1frac);
+   RooRealVar bkg1frac("bkg1frac", "fraction of component 1 in background", 0.8, 0., 1.);
+   RooAddPdf bkg("bkg", "Total background", {bkg1, bkg2}, bkg1frac);
 
    // Sum the composite signal and background
    RooRealVar bkgfrac("bkgfrac", "fraction of background", 0.5, 0., 1.);
-   RooAddPdf model("model", "g1+g2+a", RooArgList(bkg, sig), bkgfrac);
+   RooAddPdf model("model", "g1+g2+a", {bkg, sig}, bkgfrac);
 
    // S e t u p   b a s i c   p l o t   w i t h   d a t a   a n d   f u l l   p d f
    // ------------------------------------------------------------------------------
 
    // Generate a data sample of 1000 events in x from model
-   RooDataSet *data = model.generate(x, 1000);
+   std::unique_ptr<RooDataSet> data{model.generate(x, 1000)};
 
    // Plot data and complete PDF overlaid
    RooPlot *xframe = x.frame(Title("Component plotting of pdf=(sig1+sig2)+(bkg1+bkg2)"));
@@ -83,7 +83,7 @@ void rf205_compplot()
    // Plot multiple background components specified by object reference
    // Note that specified components may occur at any level in object tree
    // (e.g bkg is component of 'model' and 'sig2' is component 'sig')
-   model.plotOn(xframe, Components(RooArgSet(bkg, sig2)), LineStyle(kDotted));
+   model.plotOn(xframe, Components(bkg, sig2), LineStyle(kDotted));
 
    // M a k e   c o m p o n e n t   b y   n a m e  /   r e g e x p
    // ------------------------------------------------------------

--- a/tutorials/roofit/rf205_compplot.py
+++ b/tutorials/roofit/rf205_compplot.py
@@ -38,8 +38,8 @@ alpha = ROOT.RooRealVar("alpha", "alpha", -1)
 bkg2 = ROOT.RooExponential("bkg2", "Background 2", x, alpha)
 
 # Sum the background components into a composite background pdf
-bkg1frac = ROOT.RooRealVar("sig1frac", "fraction of component 1 in background", 0.2, 0.0, 1.0)
-bkg = ROOT.RooAddPdf("bkg", "Signal", [bkg1, bkg2], [sig1frac])
+bkg1frac = ROOT.RooRealVar("bkg1frac", "fraction of component 1 in background", 0.8, 0.0, 1.0)
+bkg = ROOT.RooAddPdf("bkg", "Total background", [bkg1, bkg2], [bkg1frac])
 
 # Sum the composite signal and background
 bkgfrac = ROOT.RooRealVar("bkgfrac", "fraction of background", 0.5, 0.0, 1.0)


### PR DESCRIPTION
This is a backport of all the relevant RooFit PRs that were recently merged to master to v6-28-00-patches (in the right order, to not have the commit history diverge too much).

1. https://github.com/root-project/root/pull/11984
2. https://github.com/root-project/root/pull/11986
3. https://github.com/root-project/root/pull/11841
4. https://github.com/root-project/root/pull/11985
5. https://github.com/root-project/root/pull/11988

Related to https://github.com/root-project/root/issues/11856.