### PR TITLE
[DF] Remove deprecated functions marked for removal in v6.30

### DIFF
--- a/README/ReleaseNotes/v630/index.md
+++ b/README/ReleaseNotes/v630/index.md
@@ -34,6 +34,7 @@ The following people have contributed to this new version:
  Wouter Verkerke, NIKHEF/Atlas,
 
 ## Deprecation and Removal
+- The RDataFrame factory functions `MakeCsvDataFrame`, `MakeArrowDataFrame`, `MakeNTupleDataFrame` and `MakeSqliteDataFrame` that were deprecated in v6.28 have been removed. Use `FromCSV`, `FromArrow`, `FromRNTuple` or `FromSqlite` instead.
 
 
 ## Core Libraries

--- a/tree/dataframe/inc/ROOT/RArrowDS.hxx
+++ b/tree/dataframe/inc/ROOT/RArrowDS.hxx
@@ -54,9 +54,6 @@ public:
 
 RDataFrame FromArrow(std::shared_ptr<arrow::Table> table, std::vector<std::string> const &columnNames);
 
-R__DEPRECATED(6, 30, "Use FromArrow instead.")
-RDataFrame MakeArrowDataFrame(std::shared_ptr<arrow::Table> table, std::vector<std::string> const &columnNames);
-
 } // namespace RDF
 
 } // namespace ROOT

--- a/tree/dataframe/inc/ROOT/RCsvDS.hxx
+++ b/tree/dataframe/inc/ROOT/RCsvDS.hxx
@@ -105,14 +105,6 @@ public:
 RDataFrame FromCSV(std::string_view fileName, bool readHeaders = true, char delimiter = ',',
                    Long64_t linesChunkSize = -1LL, std::unordered_map<std::string, char> &&colTypes = {});
 
-////////////////////////////////////////////////////////////////////////////////////////////////
-/// \brief Factory method to create a CSV RDataFrame.
-///
-/// Deprecated in favor of FromCSV().
-R__DEPRECATED(6, 30, "Use FromCSV instead.")
-RDataFrame MakeCsvDataFrame(std::string_view fileName, bool readHeaders = true, char delimiter = ',',
-                            Long64_t linesChunkSize = -1LL, std::unordered_map<std::string, char> &&colTypes = {});
-
 } // ns RDF
 
 } // ns ROOT

--- a/tree/dataframe/inc/ROOT/RNTupleDS.hxx
+++ b/tree/dataframe/inc/ROOT/RNTupleDS.hxx
@@ -93,11 +93,6 @@ protected:
    Record_t GetColumnReadersImpl(std::string_view name, const std::type_info &) final;
 };
 
-R__DEPRECATED(6, 30, "Use ROOT::RDF::Experimental::FromRNTuple instead.")
-RDataFrame MakeNTupleDataFrame(std::string_view ntupleName, std::string_view fileName);
-R__DEPRECATED(6, 30, "Use ROOT::RDF::Experimental::FromRNTuple instead.")
-RDataFrame MakeNTupleDataFrame(RNTuple *ntuple);
-
 } // ns Experimental
 
 namespace RDF {

--- a/tree/dataframe/inc/ROOT/RSqliteDS.hxx
+++ b/tree/dataframe/inc/ROOT/RSqliteDS.hxx
@@ -36,7 +36,7 @@ struct RSqliteDSDataSet;
 
 The RSqliteDS is able to feed an RDataFrame with data from a SQlite SELECT query. One can use it like
 
-    auto rdf = ROOT::RDF::MakeSqliteDataFrame("/path/to/file.sqlite", "select name from table");
+    auto rdf = ROOT::RDF::FromSqlite("/path/to/file.sqlite", "select name from table");
     auto h = rdf.Define("lName", "name.length()").Histo1D("lName");
 
 The data source has to provide column types for all the columns. Determining column types in SQlite is tricky

--- a/tree/dataframe/inc/ROOT/RSqliteDS.hxx
+++ b/tree/dataframe/inc/ROOT/RSqliteDS.hxx
@@ -114,9 +114,6 @@ protected:
 
 RDataFrame FromSqlite(std::string_view fileName, std::string_view query);
 
-R__DEPRECATED(6, 30, "Use FromSqlite instead.")
-RDataFrame MakeSqliteDataFrame(std::string_view fileName, std::string_view query);
-
 } // namespace RDF
 
 } // namespace ROOT

--- a/tree/dataframe/src/RArrowDS.cxx
+++ b/tree/dataframe/src/RArrowDS.cxx
@@ -609,14 +609,6 @@ RDataFrame FromArrow(std::shared_ptr<arrow::Table> table, std::vector<std::strin
    return tdf;
 }
 
-/// \brief Factory method to create a Apache Arrow RDataFrame.
-///
-/// Deprecated in favor of FromArrow().
-RDataFrame MakeArrowDataFrame(std::shared_ptr<arrow::Table> table, std::vector<std::string> const &columnNames)
-{
-   return FromArrow(table, columnNames);
-}
-
 } // namespace RDF
 
 } // namespace ROOT

--- a/tree/dataframe/src/RArrowDS.cxx
+++ b/tree/dataframe/src/RArrowDS.cxx
@@ -17,7 +17,7 @@ The RArrowDS implements a proxy RDataSource to be able to use Apache Arrow
 tables with RDataFrame.
 
 A RDataFrame that adapts an arrow::Table class can be constructed using the factory method
-ROOT::RDF::MakeArrowDataFrame, which accepts one parameter:
+ROOT::RDF::FromArrow, which accepts one parameter:
 1. An arrow::Table smart pointer.
 
 The types of the columns are derived from the types in the associated

--- a/tree/dataframe/src/RCsvDS.cxx
+++ b/tree/dataframe/src/RCsvDS.cxx
@@ -16,7 +16,7 @@
 The RCsvDS class implements a CSV file reader for RDataFrame.
 
 A RDataFrame that reads from a CSV file can be constructed using the factory method
-ROOT::RDF::MakeCsvDataFrame, which accepts five parameters:
+ROOT::RDF::FromCSV, which accepts five parameters:
 1. Path to the CSV file.
 2. Boolean that specifies whether the first row of the CSV file contains headers or
 not (optional, default `true`). If `false`, header names will be automatically generated as Col0, Col1, ..., ColN.

--- a/tree/dataframe/src/RCsvDS.cxx
+++ b/tree/dataframe/src/RCsvDS.cxx
@@ -561,12 +561,6 @@ RDataFrame FromCSV(std::string_view fileName, bool readHeaders, char delimiter, 
    return rdf;
 }
 
-RDataFrame MakeCsvDataFrame(std::string_view fileName, bool readHeaders, char delimiter, Long64_t linesChunkSize,
-                            std::unordered_map<std::string, char> &&colTypes)
-{
-   return FromCSV(fileName, readHeaders, delimiter, linesChunkSize, std::move(colTypes));
-}
-
 } // ns RDF
 
 } // ns ROOT

--- a/tree/dataframe/src/RDataFrame.cxx
+++ b/tree/dataframe/src/RDataFrame.cxx
@@ -308,7 +308,7 @@ This is useful to generate simple datasets on the fly: the contents of each even
 For data sources other than TTrees and TChains, RDataFrame objects are constructed using ad-hoc factory functions (see e.g. FromCSV(), FromSqlite(), FromArrow()):
 
 ~~~{.cpp}
-auto df = ROOT::RDF::MakeCsvDataFrame("input.csv");
+auto df = ROOT::RDF::FromCSV("input.csv");
 // use df as usual
 ~~~
 
@@ -1262,7 +1262,7 @@ RDataFrame calls into concrete RDataSource implementations to retrieve informati
 and to advance the readers to the desired data entry.
 Some predefined RDataSources are natively provided by ROOT such as the ROOT::RDF::RCsvDS which allows to read comma separated files:
 ~~~{.cpp}
-auto tdf = ROOT::RDF::MakeCsvDataFrame("MuRun2010B.csv");
+auto tdf = ROOT::RDF::FromCSV("MuRun2010B.csv");
 auto filteredEvents =
    tdf.Filter("Q1 * Q2 == -1")
       .Define("m", "sqrt(pow(E1 + E2, 2) - (pow(px1 + px2, 2) + pow(py1 + py2, 2) + pow(pz1 + pz2, 2)))");

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -368,13 +368,3 @@ ROOT::RDataFrame ROOT::RDF::Experimental::FromRNTuple(ROOT::Experimental::RNTupl
    ROOT::RDataFrame rdf(std::make_unique<ROOT::Experimental::RNTupleDS>(ntuple->MakePageSource()));
    return rdf;
 }
-
-ROOT::RDataFrame ROOT::Experimental::MakeNTupleDataFrame(std::string_view ntupleName, std::string_view fileName)
-{
-   return ROOT::RDF::Experimental::FromRNTuple(ntupleName, fileName);
-}
-
-ROOT::RDataFrame ROOT::Experimental::MakeNTupleDataFrame(RNTuple *ntuple)
-{
-   return ROOT::RDF::Experimental::FromRNTuple(ntuple);
-}

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -37,7 +37,7 @@
 * \ingroup dataframe
 * \brief The RDataSource implementation for RNTuple. It lets RDataFrame read RNTuple data.
 *
-* An RDataFrame that reads RNTuple data can be constructed using MakeNTupleDataFrame().
+* An RDataFrame that reads RNTuple data can be constructed using FromRNTuple().
 *
 * For each column containing an array or a collection, a corresponding column `#colname` is available to access
 * `colname.size()` without reading and deserializing the collection values.

--- a/tree/dataframe/src/RSqliteDS.cxx
+++ b/tree/dataframe/src/RSqliteDS.cxx
@@ -546,15 +546,6 @@ RDataFrame FromSqlite(std::string_view fileName, std::string_view query)
    return rdf;
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////
-/// \brief Factory method to create a SQlite RDataFrame.
-///
-/// Deprecated in favor of FromSqlite().
-RDataFrame MakeSqliteDataFrame(std::string_view fileName, std::string_view query)
-{
-   return FromSqlite(fileName, query);
-}
-
 ////////////////////////////////////////////////////////////////////////////
 /// Stores the result of the current active sqlite query row as a C++ value.
 bool RSqliteDS::SetEntry(unsigned int /* slot */, ULong64_t entry)


### PR DESCRIPTION
This pull request removes deprecated RDataFrame functions marked for removal in ROOT v6.30.  These changes fix the warnings reported by the CI on pull requests targeting `master`, e.g. 
```
.../build/include/ROOT/RCsvDS.hxx:112:1: warning: unknown attribute 'REMOVE_THIS_NOW' ignored [-Wunknown-attributes]
.../build/include/ROOT/RSqliteDS.hxx:117:1: warning: unknown attribute 'REMOVE_THIS_NOW' ignored [-Wunknown-attribute]
```

## Checklist:
- [X] tested changes locally
- [X] updated the docs (if necessary)

Sibling PR in roottest: https://github.com/root-project/roottest/pull/931