### PR TITLE
Set jblomer as code owner for ntupleutil

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,6 +41,7 @@ interpreter/cling/tools/packaging @vgvassilev
 /tree/dataframe/ @eguiraud
 /tree/readspeed/ @eguiraud
 /tree/ntuple/v7/ @jblomer
+/tree/ntupleutil/v7/ @jblomer
 
 # Projects that span over several code modules:
 /bindings/r/ @omazapa


### PR DESCRIPTION
This should set me as a default reviewer for changes in tree/ntupleutil