### PR TITLE
[webgui] no need to provide dummy disconnect handler in TWebControlBar

### DIFF
--- a/gui/webgui6/src/TWebControlBar.cxx
+++ b/gui/webgui6/src/TWebControlBar.cxx
@@ -131,9 +131,6 @@ void TWebControlBar::Show()
          // data
          [this](unsigned connid, const std::string &arg) {
             ProcessData(connid, arg);
-         },
-         // disconnect
-         [this](unsigned) {
          });
    }
 


### PR DESCRIPTION
Fix compiler warning

