### PR TITLE
[ntuple] Add cardinality field

### DIFF
--- a/gui/browsable/src/RFieldProvider.hxx
+++ b/gui/browsable/src/RFieldProvider.hxx
@@ -162,6 +162,10 @@ class RFieldProvider : public RProvider {
       void VisitUInt32Field(const RField<std::uint32_t> &field) final { FillHistogram(field); }
       void VisitUInt64Field(const RField<std::uint64_t> &field) final { FillHistogram(field); }
       void VisitUInt8Field(const RField<std::uint8_t> &field) final { FillHistogram(field); }
+      void VisitCardinalityField(const RField<ROOT::Experimental::RNTupleCardinality> &field) final
+      {
+         FillHistogram(field);
+      }
    }; // class RDrawVisitor
 
 public:

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -49,70 +49,6 @@ namespace ROOT {
 namespace Experimental {
 namespace Internal {
 
-/// An artificial field that transforms an RNTuple column that contains the offset of collections into
-/// collection sizes. It is used to provide the "number of" RDF columns for collections, e.g.
-/// `R_rdf_sizeof_jets` for a collection named `jets`.
-///
-/// This field owns the collection offset field but instead of exposing the collection offsets it exposes
-/// the collection sizes (offset(N+1) - offset(N)).  For the time being, we offer this functionality only in RDataFrame.
-/// TODO(jblomer): consider providing a general set of useful virtual fields as part of RNTuple.
-class RRDFCardinalityField : public ROOT::Experimental::Detail::RFieldBase {
-protected:
-   std::unique_ptr<ROOT::Experimental::Detail::RFieldBase> CloneImpl(std::string_view /* newName */) const final
-   {
-      return std::make_unique<RRDFCardinalityField>();
-   }
-
-public:
-   static std::string TypeName() { return "std::size_t"; }
-   RRDFCardinalityField()
-      : ROOT::Experimental::Detail::RFieldBase("", TypeName(), ENTupleStructure::kLeaf, false /* isSimple */) {}
-   RRDFCardinalityField(RRDFCardinalityField &&other) = default;
-   RRDFCardinalityField &operator=(RRDFCardinalityField &&other) = default;
-   ~RRDFCardinalityField() = default;
-
-   // Field is only used for reading
-   void GenerateColumnsImpl() final { assert(false && "Cardinality fields must only be used for reading"); }
-
-   void GenerateColumnsImpl(const RNTupleDescriptor &) final
-   {
-      RColumnModel model(EColumnType::kIndex, true /* isSorted*/);
-      fColumns.emplace_back(std::unique_ptr<ROOT::Experimental::Detail::RColumn>(
-         ROOT::Experimental::Detail::RColumn::Create<ClusterSize_t, EColumnType::kIndex>(model, 0)));
-      fPrincipalColumn = fColumns[0].get();
-   }
-
-   ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where) final
-   {
-      return ROOT::Experimental::Detail::RFieldValue(this, static_cast<std::size_t *>(where));
-   }
-   ROOT::Experimental::Detail::RFieldValue CaptureValue(void *where) final
-   {
-      return ROOT::Experimental::Detail::RFieldValue(true /* captureFlag */, this, where);
-   }
-   size_t GetValueSize() const final { return sizeof(std::size_t); }
-
-   /// Get the number of elements of the collection identified by globalIndex
-   void
-   ReadGlobalImpl(ROOT::Experimental::NTupleSize_t globalIndex, ROOT::Experimental::Detail::RFieldValue *value) final
-   {
-      RClusterIndex collectionStart;
-      ClusterSize_t size;
-      fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &size);
-      *value->Get<std::size_t>() = size;
-   }
-
-   /// Get the number of elements of the collection identified by clusterIndex
-   void ReadInClusterImpl(const ROOT::Experimental::RClusterIndex &clusterIndex,
-                          ROOT::Experimental::Detail::RFieldValue *value) final
-   {
-      RClusterIndex collectionStart;
-      ClusterSize_t size;
-      fPrincipalColumn->GetCollectionInfo(clusterIndex, &collectionStart, &size);
-      *value->Get<std::size_t>() = size;
-   }
-};
-
 /// Every RDF column is represented by exactly one RNTuple field
 class RNTupleColumnReader : public ROOT::Detail::RDF::RColumnReaderBase {
    using RFieldBase = ROOT::Experimental::Detail::RFieldBase;
@@ -203,7 +139,7 @@ void RNTupleDS::AddField(const RNTupleDescriptor &desc, std::string_view colName
 
       if (fieldDesc.GetTypeName().empty()) {
          // Anonymous collection with one or several sub fields
-         auto cardinalityField = std::make_unique<ROOT::Experimental::Internal::RRDFCardinalityField>();
+         auto cardinalityField = std::make_unique<ROOT::Experimental::RField<RNTupleCardinality>>("");
          cardinalityField->SetOnDiskId(fieldId);
          fColumnNames.emplace_back("R_rdf_sizeof_" + std::string(colName));
          fColumnTypes.emplace_back(cardinalityField->GetType());
@@ -240,7 +176,7 @@ void RNTupleDS::AddField(const RNTupleDescriptor &desc, std::string_view colName
    std::unique_ptr<Detail::RFieldBase> cardinalityField;
    // Collections get the additional "number of" RDF column (e.g. "R_rdf_sizeof_tracks")
    if (!skeinIDs.empty()) {
-      cardinalityField = std::make_unique<ROOT::Experimental::Internal::RRDFCardinalityField>();
+      cardinalityField = std::make_unique<ROOT::Experimental::RField<RNTupleCardinality>>("");
       cardinalityField->SetOnDiskId(skeinIDs.back());
    }
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -912,7 +912,7 @@ protected:
    }
 
 public:
-   static std::string TypeName() { return "ROOT::Experimental::RNTupleCardinality"; }
+   static std::string TypeName() { return "std::size_t"; }
    explicit RField(std::string_view name)
       : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, false /* isSimple */)
    {
@@ -929,14 +929,14 @@ public:
    template <typename... ArgsT>
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where, ArgsT &&...args)
    {
-      return Detail::RFieldValue(this, static_cast<RNTupleCardinality *>(where), std::forward<ArgsT>(args)...);
+      return Detail::RFieldValue(this, static_cast<std::size_t *>(where), std::forward<ArgsT>(args)...);
    }
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where) final { return GenerateValue(where, 0); }
    Detail::RFieldValue CaptureValue(void *where) override
    {
       return Detail::RFieldValue(true /* captureFlag */, this, where);
    }
-   size_t GetValueSize() const final { return sizeof(RNTupleCardinality); }
+   size_t GetValueSize() const final { return sizeof(std::size_t); }
 
    /// Get the number of elements of the collection identified by globalIndex
    void ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue *value) final
@@ -944,7 +944,7 @@ public:
       RClusterIndex collectionStart;
       ClusterSize_t size;
       fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &size);
-      *value->Get<RNTupleCardinality>() = size;
+      *value->Get<std::size_t>() = size;
    }
 
    /// Get the number of elements of the collection identified by clusterIndex
@@ -953,7 +953,7 @@ public:
       RClusterIndex collectionStart;
       ClusterSize_t size;
       fPrincipalColumn->GetCollectionInfo(clusterIndex, &collectionStart, &size);
-      *value->Get<RNTupleCardinality>() = size;
+      *value->Get<std::size_t>() = size;
    }
 
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -912,7 +912,7 @@ protected:
    }
 
 public:
-   static std::string TypeName() { return "std::size_t"; }
+   static std::string TypeName() { return "ROOT::Experimental::RNTupleCardinality"; }
    explicit RField(std::string_view name)
       : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, false /* isSimple */)
    {
@@ -929,14 +929,14 @@ public:
    template <typename... ArgsT>
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where, ArgsT &&...args)
    {
-      return Detail::RFieldValue(this, static_cast<std::size_t *>(where), std::forward<ArgsT>(args)...);
+      return Detail::RFieldValue(this, static_cast<RNTupleCardinality *>(where), std::forward<ArgsT>(args)...);
    }
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where) final { return GenerateValue(where, 0); }
    Detail::RFieldValue CaptureValue(void *where) override
    {
       return Detail::RFieldValue(true /* captureFlag */, this, where);
    }
-   size_t GetValueSize() const final { return sizeof(std::size_t); }
+   size_t GetValueSize() const final { return sizeof(RNTupleCardinality); }
 
    /// Get the number of elements of the collection identified by globalIndex
    void ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue *value) final
@@ -944,7 +944,7 @@ public:
       RClusterIndex collectionStart;
       ClusterSize_t size;
       fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &size);
-      *value->Get<std::size_t>() = size;
+      *value->Get<RNTupleCardinality>() = size;
    }
 
    /// Get the number of elements of the collection identified by clusterIndex
@@ -953,7 +953,7 @@ public:
       RClusterIndex collectionStart;
       ClusterSize_t size;
       fPrincipalColumn->GetCollectionInfo(clusterIndex, &collectionStart, &size);
-      *value->Get<std::size_t>() = size;
+      *value->Get<RNTupleCardinality>() = size;
    }
 
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -908,7 +908,7 @@ class RField<RNTupleCardinality> : public Detail::RFieldBase {
 protected:
    std::unique_ptr<ROOT::Experimental::Detail::RFieldBase> CloneImpl(std::string_view newName) const final
    {
-      return std::make_unique<RField>(newName);
+      return std::make_unique<RField<RNTupleCardinality>>(newName);
    }
 
 public:

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -51,6 +51,7 @@ public:
    virtual void VisitCollectionClassField(const RCollectionClassField &field) { VisitField(field); }
    virtual void VisitRecordField(const RRecordField &field) { VisitField(field); }
    virtual void VisitClusterSizeField(const RField<ClusterSize_t> &field) { VisitField(field); }
+   virtual void VisitCardinalityField(const RField<RNTupleCardinality> &field) { VisitField(field); }
    virtual void VisitDoubleField(const RField<double> &field) { VisitField(field); }
    virtual void VisitFloatField(const RField<float> &field) { VisitField(field); }
    virtual void VisitCharField(const RField<char> &field) { VisitField(field); }
@@ -206,6 +207,7 @@ public:
    void VisitUInt16Field(const RField<std::uint16_t> &field) final;
    void VisitUInt32Field(const RField<std::uint32_t> &field) final;
    void VisitUInt64Field(const RField<std::uint64_t> &field) final;
+   void VisitCardinalityField(const RField<RNTupleCardinality> &field) final;
 
    void VisitArrayField(const RArrayField &field) final;
    void VisitClassField(const RClassField &field) final;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -63,6 +63,22 @@ struct RClusterSize {
 using ClusterSize_t = RClusterSize;
 constexpr ClusterSize_t kInvalidClusterIndex(std::uint32_t(-1));
 
+/// Helper type to present an offset column as array of collection sizes. See RField<RNTupleCardinality> for details.
+struct RNTupleCardinality {
+   using ValueType = std::size_t;
+
+   RNTupleCardinality() : fValue(0) {}
+   explicit constexpr RNTupleCardinality(ValueType value) : fValue(value) {}
+   RNTupleCardinality &operator=(const ValueType value)
+   {
+      fValue = value;
+      return *this;
+   }
+   operator ValueType() const { return fValue; }
+
+   ValueType fValue;
+};
+
 /// Holds the index and the tag of a kSwitch column
 class RColumnSwitch {
 private:

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -223,6 +223,8 @@ ROOT::Experimental::Detail::RFieldBase::Create(const std::string &fieldName, con
 
    if (normalizedType == "ROOT::Experimental::ClusterSize_t") {
       result = std::make_unique<RField<ClusterSize_t>>(fieldName);
+   } else if (normalizedType == "ROOT::Experimental::RNTupleCardinality") {
+      result = std::make_unique<RField<RNTupleCardinality>>(fieldName);
    } else if (normalizedType == "bool") {
       result = std::make_unique<RField<bool>>(fieldName);
    } else if (normalizedType == "char") {
@@ -544,6 +546,24 @@ void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::GenerateColu
 void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitClusterSizeField(*this);
+}
+
+//------------------------------------------------------------------------------
+
+void ROOT::Experimental::RField<ROOT::Experimental::RNTupleCardinality>::GenerateColumnsImpl(
+   const RNTupleDescriptor &desc)
+{
+   EnsureColumnType({EColumnType::kIndex}, 0, desc);
+   RColumnModel model(EColumnType::kIndex, true /* isSorted*/);
+   fColumns.emplace_back(std::unique_ptr<ROOT::Experimental::Detail::RColumn>(
+      ROOT::Experimental::Detail::RColumn::Create<ClusterSize_t, EColumnType::kIndex>(model, 0)));
+   fPrincipalColumn = fColumns[0].get();
+}
+
+void ROOT::Experimental::RField<ROOT::Experimental::RNTupleCardinality>::AcceptVisitor(
+   Detail::RFieldVisitor &visitor) const
+{
+   visitor.VisitCardinalityField(*this);
 }
 
 //------------------------------------------------------------------------------

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -254,6 +254,12 @@ void ROOT::Experimental::RPrintValueVisitor::VisitUInt64Field(const RField<std::
    fOutput << *fValue.Get<std::uint64_t>();
 }
 
+void ROOT::Experimental::RPrintValueVisitor::VisitCardinalityField(const RField<RNTupleCardinality> &field)
+{
+   PrintIndent();
+   PrintName(field);
+   fOutput << static_cast<std::size_t>(*fValue.Get<RNTupleCardinality>());
+}
 
 void ROOT::Experimental::RPrintValueVisitor::VisitArrayField(const RArrayField &field)
 {

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -29,10 +29,9 @@ ROOT::Experimental::RNTupleModel::RProjectedFields::EnsureValidMapping(const Det
                                                                        const FieldMap_t &fieldMap)
 {
    auto source = fieldMap.at(target);
-   const bool hasCompatibleStructure =
-      (source->GetStructure() == target->GetStructure()) ||
-      ((source->GetStructure() == ENTupleStructure::kCollection) &&
-       (typeid(*target) == typeid(ROOT::Experimental::RField<ROOT::Experimental::RNTupleCardinality>)));
+   const bool hasCompatibleStructure = (source->GetStructure() == target->GetStructure()) ||
+                                       ((source->GetStructure() == ENTupleStructure::kCollection) &&
+                                        (target->GetType() == "ROOT::Experimental::RNTupleCardinality"));
    if (!hasCompatibleStructure)
       return R__FAIL("field mapping structural mismatch: " + source->GetName() + " --> " + target->GetName());
    if (source->GetStructure() == ENTupleStructure::kLeaf) {

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -29,9 +29,13 @@ ROOT::Experimental::RNTupleModel::RProjectedFields::EnsureValidMapping(const Det
                                                                        const FieldMap_t &fieldMap)
 {
    auto source = fieldMap.at(target);
-   if (source->GetStructure() != target->GetStructure())
+   const bool hasCompatibleStructure =
+      (source->GetStructure() == target->GetStructure()) ||
+      ((source->GetStructure() == ENTupleStructure::kCollection) &&
+       (typeid(*target) == typeid(ROOT::Experimental::RField<ROOT::Experimental::RNTupleCardinality>)));
+   if (!hasCompatibleStructure)
       return R__FAIL("field mapping structural mismatch: " + source->GetName() + " --> " + target->GetName());
-   if (target->GetStructure() == ENTupleStructure::kLeaf) {
+   if (source->GetStructure() == ENTupleStructure::kLeaf) {
       if (target->GetType() != source->GetType())
          return R__FAIL("field mapping type mismatch: " + source->GetName() + " --> " + target->GetName());
    }

--- a/tree/ntuple/v7/test/ntuple_project.cxx
+++ b/tree/ntuple/v7/test/ntuple_project.cxx
@@ -19,6 +19,8 @@ TEST(RNTupleProjection, Basics)
       else
          return "vec._0";
    });
+   auto f3 = RFieldBase::Create("vecSize", "ROOT::Experimental::RNTupleCardinality").Unwrap();
+   model->AddProjectedField(std::move(f3), [](const std::string &) { return "vec"; });
 
    {
       auto writer = RNTupleWriter::Recreate(std::move(model), "A", fileGuard.GetPath());
@@ -28,10 +30,12 @@ TEST(RNTupleProjection, Basics)
    auto reader = RNTupleReader::Open("A", fileGuard.GetPath());
    auto viewMissingE = reader->GetView<float>("missingE");
    auto viewAliasVec = reader->GetView<std::vector<float>>("aliasVec");
+   auto viewVecSize = reader->GetView<ROOT::Experimental::RNTupleCardinality>("vecSize");
    EXPECT_FLOAT_EQ(42.0, viewMissingE(0));
    EXPECT_EQ(2U, viewAliasVec(0).size());
    EXPECT_FLOAT_EQ(1.0, viewAliasVec(0).at(0));
    EXPECT_FLOAT_EQ(2.0, viewAliasVec(0).at(1));
+   EXPECT_EQ(2U, viewVecSize(0));
 }
 
 TEST(RNTupleProjection, CatchInvalidMappings)

--- a/tree/ntuple/v7/test/rfield_vector.cxx
+++ b/tree/ntuple/v7/test/rfield_vector.cxx
@@ -83,12 +83,21 @@ TEST(RNTuple, InsideCollection)
    field->SetOnDiskId(idKlassVec);
    field->ConnectPageSource(*source);
 
+   auto fieldCardinality =
+      std::unique_ptr<RFieldBase>(RFieldBase::Create("", "ROOT::Experimental::RNTupleCardinality").Unwrap());
+   fieldCardinality->SetOnDiskId(idKlassVec);
+   fieldCardinality->ConnectPageSource(*source);
+
    auto value = field->GenerateValue();
    field->Read(0, &value);
    auto aVec = value.Get<std::vector<float>>();
    EXPECT_EQ(1U, aVec->size());
    EXPECT_EQ(42.0, (*aVec)[0]);
    field->DestroyValue(value);
+
+   auto valueCardinality = fieldCardinality->GenerateValue();
+   fieldCardinality->Read(0, &valueCardinality);
+   EXPECT_EQ(1U, *valueCardinality.Get<std::size_t>());
 
    // TODO: test reading of "klassVec.v1"
 }

--- a/tree/ntuple/v7/test/rfield_vector.cxx
+++ b/tree/ntuple/v7/test/rfield_vector.cxx
@@ -83,8 +83,7 @@ TEST(RNTuple, InsideCollection)
    field->SetOnDiskId(idKlassVec);
    field->ConnectPageSource(*source);
 
-   auto fieldCardinality =
-      std::unique_ptr<RFieldBase>(RFieldBase::Create("", "ROOT::Experimental::RNTupleCardinality").Unwrap());
+   auto fieldCardinality = RFieldBase::Create("", "ROOT::Experimental::RNTupleCardinality").Unwrap();
    fieldCardinality->SetOnDiskId(idKlassVec);
    fieldCardinality->ConnectPageSource(*source);
 
@@ -98,6 +97,7 @@ TEST(RNTuple, InsideCollection)
    auto valueCardinality = fieldCardinality->GenerateValue();
    fieldCardinality->Read(0, &valueCardinality);
    EXPECT_EQ(1U, *valueCardinality.Get<std::size_t>());
+   fieldCardinality->DestroyValue(valueCardinality);
 
    // TODO: test reading of "klassVec.v1"
 }

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -75,13 +75,12 @@ Most RNTuple fields have a type identical to the corresponding TTree input branc
       _collection0 (untyped collection)
       |- float jet_pt
       |- float jet_eta
-      std::uint64_t njets (projected from _collection0 without subfields)
+      std::size_t (RNTupleCardinality) njets (projected from _collection0 without subfields)
       ROOT::RVec<float> jet_pt (projected from _collection0.jet_pt)
       ROOT::RVec<float> jet_eta (projected from _collection0.jet_eta)
     These projections are meta-data only operations and don't involve duplicating the data.
 
 Current limitations of the importer:
-  - Adding projected fields where necessary is pending the implementation of the core functionality in RNTuple
   - Importing collection proxies is untested
   - No support for trees containing TObject (or derived classes) or TClonesArray collections
   - Due to RNTuple currently storing data fully split, "don't split" markers are ignored

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -303,8 +303,10 @@ TEST(RNTupleImporter, LeafCountArray)
    auto viewJetEta = viewJets.GetView<float>("jet_eta");
    auto viewMuons = reader->GetViewCollection("_collection1");
    auto viewMuonPt = viewMuons.GetView<float>("muon_pt");
+   auto viewProjectedNjets = reader->GetView<ROOT::Experimental::RNTupleCardinality>("njets");
    auto viewProjectedJetPt = reader->GetView<ROOT::RVec<float>>("jet_pt");
    auto viewProjectedJetEta = reader->GetView<ROOT::RVec<float>>("jet_eta");
+   auto viewProjectedNmuons = reader->GetView<ROOT::Experimental::RNTupleCardinality>("nmuons");
    auto viewProjectedMuonPt = reader->GetView<ROOT::RVec<float>>("muon_pt");
 
    // Entry 0: 1 jet, 1 muon
@@ -313,10 +315,12 @@ TEST(RNTupleImporter, LeafCountArray)
    EXPECT_FLOAT_EQ(2.0, viewJetEta(0));
    EXPECT_EQ(1, viewMuons(0));
    EXPECT_FLOAT_EQ(10.0, viewMuonPt(0));
+   EXPECT_EQ(1U, viewProjectedNjets(0));
    EXPECT_EQ(1U, viewProjectedJetPt(0).size());
    EXPECT_FLOAT_EQ(1.0, viewProjectedJetPt(0).at(0));
    EXPECT_EQ(1U, viewProjectedJetEta(0).size());
    EXPECT_FLOAT_EQ(2.0, viewProjectedJetEta(0).at(0));
+   EXPECT_EQ(1U, viewProjectedNmuons(0));
    EXPECT_EQ(1U, viewProjectedMuonPt(0).size());
    EXPECT_FLOAT_EQ(10.0, viewProjectedMuonPt(0).at(0));
 
@@ -324,8 +328,10 @@ TEST(RNTupleImporter, LeafCountArray)
    EXPECT_EQ(0, viewJets(1));
    EXPECT_EQ(1, viewMuons(1));
    EXPECT_FLOAT_EQ(11.0, viewMuonPt(1));
+   EXPECT_EQ(0U, viewProjectedNjets(1));
    EXPECT_EQ(0U, viewProjectedJetPt(1).size());
    EXPECT_EQ(0U, viewProjectedJetEta(1).size());
+   EXPECT_EQ(1U, viewProjectedNmuons(1));
    EXPECT_EQ(1U, viewProjectedMuonPt(1).size());
    EXPECT_FLOAT_EQ(11.0, viewProjectedMuonPt(1).at(0));
 
@@ -337,12 +343,14 @@ TEST(RNTupleImporter, LeafCountArray)
    EXPECT_FLOAT_EQ(6.0, viewJetEta(2));
    EXPECT_EQ(1, viewMuons(2));
    EXPECT_FLOAT_EQ(12.0, viewMuonPt(2));
+   EXPECT_EQ(2U, viewProjectedNjets(2));
    EXPECT_EQ(2U, viewProjectedJetPt(2).size());
    EXPECT_FLOAT_EQ(3.0, viewProjectedJetPt(2).at(0));
    EXPECT_FLOAT_EQ(5.0, viewProjectedJetPt(2).at(1));
    EXPECT_EQ(2U, viewProjectedJetEta(2).size());
    EXPECT_FLOAT_EQ(4.0, viewProjectedJetEta(2).at(0));
    EXPECT_FLOAT_EQ(6.0, viewProjectedJetEta(2).at(1));
+   EXPECT_EQ(1U, viewProjectedNmuons(2));
    EXPECT_EQ(1U, viewProjectedMuonPt(2).size());
    EXPECT_FLOAT_EQ(12.0, viewProjectedMuonPt(2).at(0));
 }


### PR DESCRIPTION
The cardinality field presents an offset column as vector sizes. It supports reading only. It is used in the importer to project the offset columns of untyped collections stemming from leaf count arrays to their count leaf names.