### PR TITLE
[ntuple] Avoid lambda capture of structured binding

### DIFF
--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -257,7 +257,10 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSc
    }
 
    int iLeafCountCollection = 0;
-   for (auto &[_, c] : fLeafCountCollections) {
+   for (auto &p : fLeafCountCollections) {
+      // We want to capture this variable, which is not possible with a
+      // structured binding in C++17. Explicitly defining a variable works.
+      auto &c = p.second;
       c.fCollectionModel->Freeze();
       c.fCollectionEntry = c.fCollectionModel->CreateBareEntry();
       for (auto idx : c.fImportFieldIndexes) {


### PR DESCRIPTION
Apparently this is ill-formed with C++17 and fails to compile with Clang version 14.