### PR TITLE
[ntuple] Add Inspector skeleton

### DIFF
--- a/tree/ntupleutil/CMakeLists.txt
+++ b/tree/ntupleutil/CMakeLists.txt
@@ -16,8 +16,10 @@ endif()
 ROOT_STANDARD_LIBRARY_PACKAGE(ROOTNTupleUtil
 HEADERS
   ROOT/RNTupleImporter.hxx
+  ROOT/RNTupleInspector.hxx
 SOURCES
   v7/src/RNTupleImporter.cxx
+  v7/src/RNTupleInspector.cxx
 LINKDEF
   LinkDef.h
 DEPENDENCIES

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -6,7 +6,7 @@
 /// is welcome!
 
 /*************************************************************************
- * Copyright (C) 1995-2022, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -55,13 +55,13 @@ std::cout << "The compression factor is " << std::fixed << std::setprecision(2)
 // clang-format on
 class RNTupleInspector {
 private:
-   std::shared_ptr<ROOT::Experimental::Detail::RPageSource> fPageSource;
+   std::unique_ptr<ROOT::Experimental::Detail::RPageSource> fPageSource;
    int fCompressionSettings;
    std::uint64_t fCompressedSize;
    std::uint64_t fUncompressedSize;
    float fCompressionFactor;
 
-   RNTupleInspector(std::shared_ptr<ROOT::Experimental::Detail::RPageSource> pageSource) : fPageSource(pageSource) {};
+   RNTupleInspector(std::unique_ptr<ROOT::Experimental::Detail::RPageSource> pageSource) : fPageSource(std::move(pageSource)) {};
 
    void CollectSizeData();
 
@@ -73,7 +73,7 @@ public:
    ~RNTupleInspector() = default;
 
    /// Creates a new inspector for a given RNTuple.
-   static RResult<std::unique_ptr<RNTupleInspector>> Create(std::shared_ptr<ROOT::Experimental::Detail::RPageSource> pageSource);
+   static RResult<std::unique_ptr<RNTupleInspector>> Create(std::unique_ptr<ROOT::Experimental::Detail::RPageSource> pageSource);
    static RResult<std::unique_ptr<RNTupleInspector>> Create(RNTuple *sourceNTuple);
 
    /// Get the name of the RNTuple being inspected.

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -1,0 +1,79 @@
+/// \file ROOT/RNTuplerInspector.hxx
+/// \ingroup NTuple ROOT7
+/// \author Florine de Geus <florine.willemijn.de.geus@cern.ch>
+/// \date 2023-01-09
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2022, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_RNTupleInspector
+#define ROOT7_RNTupleInspector
+
+#include <ROOT/RError.hxx>
+#include <ROOT/RNTuple.hxx>
+#include <ROOT/RNTupleDescriptor.hxx>
+
+#include <cstdlib>
+#include <memory>
+
+namespace ROOT {
+namespace Experimental {
+
+// clang-format off
+/**
+\class ROOT::Experimental::Detail::RNTupleInspector
+\ingroup NTuple
+\brief Inspect a given RNTuple
+*/
+// clang-format on
+class RNTupleInspector {
+private:
+   RNTupleInspector() = default;
+
+   const RNTupleDescriptor *fSourceNTupleDescriptor;
+   int fCompressionSettings;
+   std::uint64_t fCompressedSize;
+   std::uint64_t fUncompressedSize;
+   float fCompressionFactor;
+
+   void CollectSizeData();
+
+public:
+   RNTupleInspector(const RNTupleInspector &other) = delete;
+   RNTupleInspector &operator=(const RNTupleInspector &other) = delete;
+   RNTupleInspector(RNTupleInspector &&other) = delete;
+   RNTupleInspector &operator=(RNTupleInspector &&other) = delete;
+   ~RNTupleInspector() = default;
+
+   /// Creates a new inspector for a given RNTuple.
+   static RResult<std::unique_ptr<RNTupleInspector>> Create(std::unique_ptr<RNTupleReader> &sourceNTupleReader);
+   static RResult<std::unique_ptr<RNTupleInspector>> Create(RNTuple *sourceNTuple);
+
+   /// Get the name of the RNTuple being inspected.
+   std::string GetName();
+
+   /// Get the compression settings of the RNTuple being inspected.
+   int GetCompressionSettings();
+
+   /// Get the on-disk, compressed size of the RNTuple being inspected, in bytes.
+   /// Does **not** include the size of the header and footer.
+   std::uint64_t GetCompressedSize();
+
+   /// Get the total, uncompressed size of the RNTuple being inspected, in bytes.
+   /// Does **not** include the size of the header and footer.
+   std::uint64_t GetUncompressedSize();
+
+   /// Get the compression factor of the RNTuple being inspected.
+   float GetCompressionFactor();
+};
+} // namespace Experimental
+} // namespace ROOT
+
+#endif // ROOT7_RNTupleInspector

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -31,6 +31,25 @@ namespace Experimental {
 \class ROOT::Experimental::Detail::RNTupleInspector
 \ingroup NTuple
 \brief Inspect a given RNTuple
+
+Example usage:
+
+~~~ {.cpp}
+#include <ROOT/RNTuple.hxx>
+#include <ROOT/RNTupleInspector.hxx>
+
+#include <iostream>
+
+using ROOT::Experimental::RNTupleReader;
+using ROOT::Experimental::RNTupleInspector;
+
+auto rntuple = RNTupleReader::Open("NTupleName", "data.rntuple");
+auto inspector = RNTupleInspector::Create(rntuple).Unwrap();
+
+std::cout << "The compression factor is " << std::fixed << std::setprecision(2)
+                                          << inspector->GetCompressionFactor()
+                                          << std::endl;
+~~~
 */
 // clang-format on
 class RNTupleInspector {

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -54,13 +54,13 @@ std::cout << "The compression factor is " << std::fixed << std::setprecision(2)
 // clang-format on
 class RNTupleInspector {
 private:
-   RNTupleInspector() = default;
-
-   const RNTupleDescriptor *fSourceNTupleDescriptor;
+   std::shared_ptr<ROOT::Experimental::Detail::RPageSource> fPageSource;
    int fCompressionSettings;
    std::uint64_t fCompressedSize;
    std::uint64_t fUncompressedSize;
    float fCompressionFactor;
+
+   RNTupleInspector(std::shared_ptr<ROOT::Experimental::Detail::RPageSource> pageSource) : fPageSource(pageSource) {};
 
    void CollectSizeData();
 
@@ -72,7 +72,7 @@ public:
    ~RNTupleInspector() = default;
 
    /// Creates a new inspector for a given RNTuple.
-   static RResult<std::unique_ptr<RNTupleInspector>> Create(std::unique_ptr<RNTupleReader> &sourceNTupleReader);
+   static RResult<std::unique_ptr<RNTupleInspector>> Create(std::shared_ptr<ROOT::Experimental::Detail::RPageSource> pageSource);
    static RResult<std::unique_ptr<RNTupleInspector>> Create(RNTuple *sourceNTuple);
 
    /// Get the name of the RNTuple being inspected.

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -40,10 +40,11 @@ Example usage:
 
 #include <iostream>
 
-using ROOT::Experimental::RNTupleReader;
+using ROOT::Experimental::RNTuple;
 using ROOT::Experimental::RNTupleInspector;
 
-auto rntuple = RNTupleReader::Open("NTupleName", "data.rntuple");
+auto file = TFile::Open("data.rntuple");
+auto rntuple = file->Get<RNTuple>("NTupleName");
 auto inspector = RNTupleInspector::Create(rntuple).Unwrap();
 
 std::cout << "The compression factor is " << std::fixed << std::setprecision(2)

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -6,7 +6,7 @@
 /// is welcome!
 
 /*************************************************************************
- * Copyright (C) 1995-2022, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -53,9 +53,9 @@ void ROOT::Experimental::RNTupleInspector::CollectSizeData()
 }
 
 ROOT::Experimental::RResult<std::unique_ptr<ROOT::Experimental::RNTupleInspector>>
-ROOT::Experimental::RNTupleInspector::Create(std::shared_ptr<ROOT::Experimental::Detail::RPageSource> pageSource)
+ROOT::Experimental::RNTupleInspector::Create(std::unique_ptr<ROOT::Experimental::Detail::RPageSource> pageSource)
 {
-   auto inspector = std::unique_ptr<RNTupleInspector>(new RNTupleInspector(pageSource));
+   auto inspector = std::unique_ptr<RNTupleInspector>(new RNTupleInspector(std::move(pageSource)));
 
    inspector->CollectSizeData();
 
@@ -65,9 +65,9 @@ ROOT::Experimental::RNTupleInspector::Create(std::shared_ptr<ROOT::Experimental:
 ROOT::Experimental::RResult<std::unique_ptr<ROOT::Experimental::RNTupleInspector>>
 ROOT::Experimental::RNTupleInspector::Create(ROOT::Experimental::RNTuple *sourceNTuple)
 {
-   std::shared_ptr<ROOT::Experimental::Detail::RPageSource> pageSource = sourceNTuple->MakePageSource();
+   std::unique_ptr<ROOT::Experimental::Detail::RPageSource> pageSource = sourceNTuple->MakePageSource();
 
-   return ROOT::Experimental::RNTupleInspector::Create(pageSource);
+   return ROOT::Experimental::RNTupleInspector::Create(std::move(pageSource));
 }
 
 std::string ROOT::Experimental::RNTupleInspector::GetName()

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -37,7 +37,7 @@ void ROOT::Experimental::RNTupleInspector::CollectSizeData()
       }
    }
 
-   for (uint64_t colId = 0; colId < descriptorGuard->GetNColumns(); ++colId) {
+   for (uint64_t colId = 0; colId < descriptorGuard->GetNPhysicalColumns(); ++colId) {
       const ROOT::Experimental::RColumnDescriptor &colDescriptor = descriptorGuard->GetColumnDescriptor(colId);
 
       uint64_t elemSize =

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -1,0 +1,103 @@
+/// \file RNTupleInspector.cxx
+/// \ingroup NTuple ROOT7
+/// \author Florine de Geus <florine.willemijn.de.geus@cern.ch>
+/// \date 2023-01-09
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2022, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include <ROOT/RError.hxx>
+#include <ROOT/RNTuple.hxx>
+#include <ROOT/RNTupleDescriptor.hxx>
+#include <ROOT/RNTupleInspector.hxx>
+#include <ROOT/RError.hxx>
+
+#include <cstring>
+
+void ROOT::Experimental::RNTupleInspector::CollectSizeData()
+{
+   int compressionSettings = -1;
+   std::uint64_t compressedSize = 0;
+   std::uint64_t uncompressedSize = 0;
+
+   for (const auto &clusterDescriptor : fSourceNTupleDescriptor->GetClusterIterable()) {
+      compressedSize += clusterDescriptor.GetBytesOnStorage();
+
+      if (compressionSettings == -1) {
+         compressionSettings = clusterDescriptor.GetColumnRange(0).fCompressionSettings;
+      }
+   }
+
+   for (uint64_t colId = 0; colId < fSourceNTupleDescriptor->GetNColumns(); ++colId) {
+      const ROOT::Experimental::RColumnDescriptor &colDescriptor = fSourceNTupleDescriptor->GetColumnDescriptor(colId);
+
+      uint64_t elemSize =
+         ROOT::Experimental::Detail::RColumnElementBase::Generate(colDescriptor.GetModel().GetType())->GetSize();
+
+      uint64_t nElems = fSourceNTupleDescriptor->GetNElements(colId);
+      uncompressedSize += nElems * elemSize;
+   }
+
+   fCompressionSettings = compressionSettings;
+   fCompressedSize = compressedSize;
+   fUncompressedSize = uncompressedSize;
+}
+
+ROOT::Experimental::RResult<std::unique_ptr<ROOT::Experimental::RNTupleInspector>>
+ROOT::Experimental::RNTupleInspector::Create(std::unique_ptr<RNTupleReader> &sourceNTupleReader)
+{
+   auto inspector = std::unique_ptr<RNTupleInspector>(new RNTupleInspector());
+
+   inspector->fSourceNTupleDescriptor = sourceNTupleReader->GetDescriptor();
+
+   if (!inspector->fSourceNTupleDescriptor) {
+      return R__FAIL("cannot get descriptor for provided RNTuple");
+   }
+
+   inspector->CollectSizeData();
+   return inspector;
+}
+
+ROOT::Experimental::RResult<std::unique_ptr<ROOT::Experimental::RNTupleInspector>>
+ROOT::Experimental::RNTupleInspector::Create(ROOT::Experimental::RNTuple *sourceNTuple)
+{
+   auto reader = ROOT::Experimental::RNTupleReader::Open(sourceNTuple);
+
+   if (!reader) {
+      return R__FAIL("cannot get reader for provided RNTuple");
+   }
+
+   return ROOT::Experimental::RNTupleInspector::Create(reader);
+}
+
+std::string ROOT::Experimental::RNTupleInspector::GetName()
+{
+   return fSourceNTupleDescriptor->GetName();
+}
+
+int ROOT::Experimental::RNTupleInspector::GetCompressionSettings()
+{
+   return fCompressionSettings;
+}
+
+std::uint64_t ROOT::Experimental::RNTupleInspector::GetCompressedSize()
+{
+   return fCompressedSize;
+}
+
+std::uint64_t ROOT::Experimental::RNTupleInspector::GetUncompressedSize()
+{
+   return fUncompressedSize;
+}
+
+float ROOT::Experimental::RNTupleInspector::GetCompressionFactor()
+{
+   return (float)fUncompressedSize / (float)fCompressedSize;
+}

--- a/tree/ntupleutil/v7/test/CMakeLists.txt
+++ b/tree/ntupleutil/v7/test/CMakeLists.txt
@@ -20,3 +20,4 @@ if(MSVC)
 endif()
 
 ROOT_ADD_GTEST(ntuple_importer ntuple_importer.cxx LIBRARIES ROOTNTupleUtil CustomStructUtil)
+ROOT_ADD_GTEST(ntuple_inspector ntuple_inspector.cxx LIBRARIES ROOTNTupleUtil)

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -1,4 +1,19 @@
+#include <ROOT/RNTupleImporter.hxx>
+
+#include <TFile.h>
+#include <TTree.h>
+
+#include <cstdio>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "CustomStructUtil.hxx"
 #include "ntupleutil_test.hxx"
+
+using ROOT::Experimental::RNTupleImporter;
+using ROOT::Experimental::RNTupleReader;
 
 TEST(RNTupleImporter, Empty)
 {

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -1,42 +1,4 @@
-#include "gtest/gtest.h"
-
-#include <ROOT/RNTuple.hxx>
-#include <ROOT/RNTupleImporter.hxx>
-
-#include <TFile.h>
-#include <TTree.h>
-
-#include <cstdio>
-#include <string>
-#include <tuple>
-#include <vector>
-#include <utility>
-
-#include "CustomStructUtil.hxx"
-
-using ROOT::Experimental::RNTupleImporter;
-using ROOT::Experimental::RNTupleReader;
-
-/**
- * An RAII wrapper around an open temporary file on disk. It cleans up the guarded file when the wrapper object
- * goes out of scope.
- */
-class FileRaii {
-private:
-   static constexpr bool kDebug = false; // if true, don't delete the file on destruction
-   std::string fPath;
-
-public:
-   explicit FileRaii(const std::string &path) : fPath(path) {}
-   FileRaii(const FileRaii &) = delete;
-   FileRaii &operator=(const FileRaii &) = delete;
-   ~FileRaii()
-   {
-      if (!kDebug)
-         std::remove(fPath.c_str());
-   }
-   std::string GetPath() const { return fPath; }
-};
+#include "ntupleutil_test.hxx"
 
 TEST(RNTupleImporter, Empty)
 {

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -1,46 +1,4 @@
-#include "gtest/gtest.h"
-
-#include <ROOT/RNTuple.hxx>
-#include <ROOT/RNTupleInspector.hxx>
-#include <ROOT/RNTupleModel.hxx>
-#include <ROOT/RNTupleOptions.hxx>
-
-#include <TFile.h>
-
-#include <cstdio>
-#include <string>
-#include <tuple>
-#include <utility>
-#include <vector>
-
-#include "CustomStructUtil.hxx"
-
-using ROOT::Experimental::RNTupleInspector;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleReader;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
-
-/**
- * An RAII wrapper around an open temporary file on disk. It cleans up the
- * guarded file when the wrapper object goes out of scope.
- */
-class FileRaii {
-private:
-   static constexpr bool kDebug = false; // if true, don't delete the file on destruction
-   std::string fPath;
-
-public:
-   explicit FileRaii(const std::string &path) : fPath(path) {}
-   FileRaii(const FileRaii &) = delete;
-   FileRaii &operator=(const FileRaii &) = delete;
-   ~FileRaii()
-   {
-      if (!kDebug)
-         std::remove(fPath.c_str());
-   }
-   std::string GetPath() const { return fPath; }
-};
+#include "ntupleutil_test.hxx"
 
 TEST(RNTupleInspector, Name)
 {

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -3,11 +3,6 @@
 
 #include <TFile.h>
 
-// #include <cstdio>
-// #include <string>
-// #include <tuple>
-// #include <utility>
-
 #include "ntupleutil_test.hxx"
 
 using ROOT::Experimental::RNTuple;

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -2,16 +2,15 @@
 #include <ROOT/RNTupleOptions.hxx>
 
 #include <TFile.h>
-#include <TTree.h>
 
-#include <cstdio>
-#include <string>
-#include <tuple>
-#include <utility>
-#include <vector>
+// #include <cstdio>
+// #include <string>
+// #include <tuple>
+// #include <utility>
 
 #include "ntupleutil_test.hxx"
 
+using ROOT::Experimental::RNTuple;
 using ROOT::Experimental::RNTupleInspector;
 using ROOT::Experimental::RNTupleModel;
 using ROOT::Experimental::RNTupleReader;
@@ -26,8 +25,10 @@ TEST(RNTupleInspector, Name)
       RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
    }
 
-   auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
+   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
+   auto ntuple = file->Get<RNTuple>("ntuple");
    auto inspector = RNTupleInspector::Create(ntuple).Unwrap();
+
    EXPECT_EQ("ntuple", inspector->GetName());
 }
 
@@ -46,9 +47,10 @@ TEST(RNTupleInspector, CompressionSettings)
       ntuple->Fill();
    }
 
-   auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
-
+   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
+   auto ntuple = file->Get<RNTuple>("ntuple");
    auto inspector = RNTupleInspector::Create(ntuple).Unwrap();
+
    EXPECT_EQ(505, inspector->GetCompressionSettings());
 }
 
@@ -67,9 +69,10 @@ TEST(RNTupleInspector, SizeUncompressed)
       ntuple->Fill();
    }
 
-   auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
-
+   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
+   auto ntuple = file->Get<RNTuple>("ntuple");
    auto inspector = RNTupleInspector::Create(ntuple).Unwrap();
+
    EXPECT_EQ(sizeof(int32_t), inspector->GetUncompressedSize());
    EXPECT_EQ(inspector->GetCompressedSize(), inspector->GetUncompressedSize());
 }
@@ -91,9 +94,10 @@ TEST(RNTupleInspector, SizeCompressed)
       }
    }
 
-   auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
-
+   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
+   auto ntuple = file->Get<RNTuple>("ntuple");
    auto inspector = RNTupleInspector::Create(ntuple).Unwrap();
+
    EXPECT_NE(inspector->GetCompressedSize(), inspector->GetUncompressedSize());
 }
 
@@ -105,9 +109,10 @@ TEST(RNTupleInspector, SizeEmpty)
       RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
    }
 
-   auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
-
+   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
+   auto ntuple = file->Get<RNTuple>("ntuple");
    auto inspector = RNTupleInspector::Create(ntuple).Unwrap();
+
    EXPECT_EQ(0, inspector->GetCompressedSize());
    EXPECT_EQ(0, inspector->GetUncompressedSize());
 }
@@ -129,9 +134,10 @@ TEST(RNTupleInspector, SingleIntFieldCompression)
       }
    }
 
-   auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
-
+   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
+   auto ntuple = file->Get<RNTuple>("ntuple");
    auto inspector = RNTupleInspector::Create(ntuple).Unwrap();
+
    EXPECT_LT(0, inspector->GetCompressedSize());
    EXPECT_LT(inspector->GetCompressedSize(), inspector->GetUncompressedSize());
    EXPECT_GT(inspector->GetCompressionFactor(), 1);

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -1,4 +1,22 @@
+#include <ROOT/RNTupleInspector.hxx>
+#include <ROOT/RNTupleOptions.hxx>
+
+#include <TFile.h>
+#include <TTree.h>
+
+#include <cstdio>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
 #include "ntupleutil_test.hxx"
+
+using ROOT::Experimental::RNTupleInspector;
+using ROOT::Experimental::RNTupleModel;
+using ROOT::Experimental::RNTupleReader;
+using ROOT::Experimental::RNTupleWriteOptions;
+using ROOT::Experimental::RNTupleWriter;
 
 TEST(RNTupleInspector, Name)
 {

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -1,0 +1,162 @@
+#include "gtest/gtest.h"
+
+#include <ROOT/RNTuple.hxx>
+#include <ROOT/RNTupleInspector.hxx>
+#include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RNTupleOptions.hxx>
+
+#include <TFile.h>
+
+#include <cstdio>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "CustomStructUtil.hxx"
+
+using ROOT::Experimental::RNTupleInspector;
+using ROOT::Experimental::RNTupleModel;
+using ROOT::Experimental::RNTupleReader;
+using ROOT::Experimental::RNTupleWriteOptions;
+using ROOT::Experimental::RNTupleWriter;
+
+/**
+ * An RAII wrapper around an open temporary file on disk. It cleans up the
+ * guarded file when the wrapper object goes out of scope.
+ */
+class FileRaii {
+private:
+   static constexpr bool kDebug = false; // if true, don't delete the file on destruction
+   std::string fPath;
+
+public:
+   explicit FileRaii(const std::string &path) : fPath(path) {}
+   FileRaii(const FileRaii &) = delete;
+   FileRaii &operator=(const FileRaii &) = delete;
+   ~FileRaii()
+   {
+      if (!kDebug)
+         std::remove(fPath.c_str());
+   }
+   std::string GetPath() const { return fPath; }
+};
+
+TEST(RNTupleInspector, Name)
+{
+   FileRaii fileGuard("test_ntuple_inspector_name.root");
+   {
+      auto model = RNTupleModel::Create();
+      RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
+   }
+
+   auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
+   auto inspector = RNTupleInspector::Create(ntuple).Unwrap();
+   EXPECT_EQ("ntuple", inspector->GetName());
+}
+
+TEST(RNTupleInspector, CompressionSettings)
+{
+   FileRaii fileGuard("test_ntuple_inspector_size_single_int_field.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto nFldInt = model->MakeField<std::int32_t>("i");
+
+      auto writeOptions = RNTupleWriteOptions();
+      writeOptions.SetCompression(505);
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
+
+      *nFldInt = 42;
+      ntuple->Fill();
+   }
+
+   auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
+
+   auto inspector = RNTupleInspector::Create(ntuple).Unwrap();
+   EXPECT_EQ(505, inspector->GetCompressionSettings());
+}
+
+TEST(RNTupleInspector, SizeUncompressed)
+{
+   FileRaii fileGuard("test_ntuple_inspector_size_uncompressed.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto nFldInt = model->MakeField<std::int32_t>("i");
+
+      auto writeOptions = RNTupleWriteOptions();
+      writeOptions.SetCompression(0);
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
+
+      *nFldInt = 42;
+      ntuple->Fill();
+   }
+
+   auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
+
+   auto inspector = RNTupleInspector::Create(ntuple).Unwrap();
+   EXPECT_EQ(sizeof(int32_t), inspector->GetUncompressedSize());
+   EXPECT_EQ(inspector->GetCompressedSize(), inspector->GetUncompressedSize());
+}
+
+TEST(RNTupleInspector, SizeCompressed)
+{
+   FileRaii fileGuard("test_ntuple_inspector_size_uncompressed.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto nFldInt = model->MakeField<std::int32_t>("i");
+
+      auto writeOptions = RNTupleWriteOptions();
+      writeOptions.SetCompression(505);
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
+
+      for (int32_t i = 0; i < 50; ++i) {
+         *nFldInt = i;
+         ntuple->Fill();
+      }
+   }
+
+   auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
+
+   auto inspector = RNTupleInspector::Create(ntuple).Unwrap();
+   EXPECT_NE(inspector->GetCompressedSize(), inspector->GetUncompressedSize());
+}
+
+TEST(RNTupleInspector, SizeEmpty)
+{
+   FileRaii fileGuard("test_ntuple_inspector_size_empty.root");
+   {
+      auto model = RNTupleModel::Create();
+      RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
+   }
+
+   auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
+
+   auto inspector = RNTupleInspector::Create(ntuple).Unwrap();
+   EXPECT_EQ(0, inspector->GetCompressedSize());
+   EXPECT_EQ(0, inspector->GetUncompressedSize());
+}
+
+TEST(RNTupleInspector, SingleIntFieldCompression)
+{
+   FileRaii fileGuard("test_ntuple_inspector_size_single_int_field.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto nFldInt = model->MakeField<std::int32_t>("i");
+
+      auto writeOptions = RNTupleWriteOptions();
+      writeOptions.SetCompression(505);
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
+
+      for (int32_t i = 0; i < 50; ++i) {
+         *nFldInt = i;
+         ntuple->Fill();
+      }
+   }
+
+   auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
+
+   auto inspector = RNTupleInspector::Create(ntuple).Unwrap();
+   EXPECT_EQ(200, inspector->GetUncompressedSize());
+   EXPECT_EQ(95, inspector->GetCompressedSize());
+   EXPECT_NEAR(2.11, inspector->GetCompressionFactor(), 1e-2);
+}

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -132,7 +132,7 @@ TEST(RNTupleInspector, SingleIntFieldCompression)
    auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
 
    auto inspector = RNTupleInspector::Create(ntuple).Unwrap();
-   EXPECT_EQ(200, inspector->GetUncompressedSize());
-   EXPECT_EQ(95, inspector->GetCompressedSize());
-   EXPECT_NEAR(2.11, inspector->GetCompressionFactor(), 1e-2);
+   EXPECT_LT(0, inspector->GetCompressedSize());
+   EXPECT_LT(inspector->GetCompressedSize(), inspector->GetUncompressedSize());
+   EXPECT_GT(inspector->GetCompressionFactor(), 1);
 }

--- a/tree/ntupleutil/v7/test/ntupleutil_test.hxx
+++ b/tree/ntupleutil/v7/test/ntupleutil_test.hxx
@@ -1,0 +1,51 @@
+#ifndef ROOT7_RNTupleUtil_Test
+#define ROOT7_RNTupleUtil_Test
+
+#include "gtest/gtest.h"
+
+#include <ROOT/RNTuple.hxx>
+#include <ROOT/RNTupleImporter.hxx>
+#include <ROOT/RNTupleInspector.hxx>
+#include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RNTupleOptions.hxx>
+
+#include <TFile.h>
+#include <TTree.h>
+
+#include <cstdio>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "CustomStructUtil.hxx"
+
+using ROOT::Experimental::RNTupleImporter;
+using ROOT::Experimental::RNTupleInspector;
+using ROOT::Experimental::RNTupleModel;
+using ROOT::Experimental::RNTupleReader;
+using ROOT::Experimental::RNTupleWriteOptions;
+using ROOT::Experimental::RNTupleWriter;
+
+/**
+ * An RAII wrapper around an open temporary file on disk. It cleans up the
+ * guarded file when the wrapper object goes out of scope.
+ */
+class FileRaii {
+private:
+   static constexpr bool kDebug = false; // if true, don't delete the file on destruction
+   std::string fPath;
+
+public:
+   explicit FileRaii(const std::string &path) : fPath(path) {}
+   FileRaii(const FileRaii &) = delete;
+   FileRaii &operator=(const FileRaii &) = delete;
+   ~FileRaii()
+   {
+      if (!kDebug)
+         std::remove(fPath.c_str());
+   }
+   std::string GetPath() const { return fPath; }
+};
+
+#endif // ROOT7_RNTupleUtil_Test

--- a/tree/ntupleutil/v7/test/ntupleutil_test.hxx
+++ b/tree/ntupleutil/v7/test/ntupleutil_test.hxx
@@ -4,28 +4,8 @@
 #include "gtest/gtest.h"
 
 #include <ROOT/RNTuple.hxx>
-#include <ROOT/RNTupleImporter.hxx>
-#include <ROOT/RNTupleInspector.hxx>
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RNTupleOptions.hxx>
-
-#include <TFile.h>
-#include <TTree.h>
-
-#include <cstdio>
-#include <string>
-#include <tuple>
-#include <utility>
-#include <vector>
-
-#include "CustomStructUtil.hxx"
-
-using ROOT::Experimental::RNTupleImporter;
-using ROOT::Experimental::RNTupleInspector;
-using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleReader;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
 
 /**
  * An RAII wrapper around an open temporary file on disk. It cleans up the


### PR DESCRIPTION
This PR adds the RNTupleInspector class to the RNTuple utility package and can be used for (static) inspection of RNTuples. It currently provides basic information on the size and compression of a given RNTuple.

Next steps will adding functionality for for getting size and compression data on a per-column and per-type basis, and to provide a way to visualize this information.

## Checklist:

-[x] Add unit tests
-[x] Add usage documentation
