### PR TITLE
[RF] Define infinity as `std::numeric_limits<double>::infinity()`

### DIFF
--- a/README/ReleaseNotes/v630/index.md
+++ b/README/ReleaseNotes/v630/index.md
@@ -51,6 +51,13 @@ The following people have contributed to this new version:
 
 ## Math Libraries
 
+### Behavior change of `TMath::AreEqualAbs()`
+
+The `TMath::AreEqualAbs()` compares two numbers for equality within a certain absolute range.
+So far, it would tell you that `inf != inf` if you define `inf` as `std::numeric_limits<double>::infinity()`, which is inconsistent with the regular `==` operator.
+
+This is unexpected, because one would expect that if two numbers are considered exactly equal, they would also be considered equal within any range. 
+Therefore, the behavior of `TMath::AreEqualAbs()` was changed to return always `true` if the `==` comparision would return `true`.
 
 ## RooFit Libraries
 
@@ -86,6 +93,14 @@ RooFunctor functor{pdf, observables, {}, normSet};
 ROOT::Math::Functor func4{functor, static_cast<unsigned int>(functor.nObs())};
 // Functor takes by reference, so the RooFunctor also needs to stay alive.
 ```
+
+### Define infinity as `std::numeric_limits<double>::infinity()`
+
+RooFit has its internal representation of infinity in `RooNumber::infinity()`, which was `1e30` before.
+
+Now, it is defined as `std::numeric_limits<double>::infinity()`, to be consistent with the C++ standard library and other code.
+
+This change also affects the `RooNumber::isInfinite()` function.
 
 ## 2D Graphics Libraries
 

--- a/math/mathcore/inc/TMath.h
+++ b/math/mathcore/inc/TMath.h
@@ -416,14 +416,16 @@ struct Limits {
    /// Comparing floating points.
    /// Returns `kTRUE` if the absolute difference between `af` and `bf` is less than `epsilon`.
    inline Bool_t AreEqualAbs(Double_t af, Double_t bf, Double_t epsilon) {
-      return TMath::Abs(af-bf) < epsilon ||
+      return af == bf || // shortcut for exact equality (necessary because otherwise (inf != inf))
+             TMath::Abs(af-bf) < epsilon ||
              TMath::Abs(af - bf) < Limits<Double_t>::Min(); // handle 0 < 0 case
 
    }
    /// Comparing floating points.
    /// Returns `kTRUE` if the relative difference between `af` and `bf` is less than `relPrec`.
    inline Bool_t AreEqualRel(Double_t af, Double_t bf, Double_t relPrec) {
-      return TMath::Abs(af - bf) <= 0.5 * relPrec * (TMath::Abs(af) + TMath::Abs(bf)) ||
+      return af == bf || // shortcut for exact equality (necessary because otherwise (inf != inf))
+             TMath::Abs(af - bf) <= 0.5 * relPrec * (TMath::Abs(af) + TMath::Abs(bf)) ||
              TMath::Abs(af - bf) < Limits<Double_t>::Min(); // handle denormals
    }
 

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -521,10 +521,10 @@ void RooJSONFactoryWSTool::exportVariable(const RooAbsArg *v, JSONNode &n)
       var["const"] << true;
    } else if (rrv) {
       var["value"] << rrv->getVal();
-      if (rrv->getMin() > -1e30) {
+      if (!RooNumber::isInfinite(rrv->getMin())) {
          var["min"] << rrv->getMin();
       }
-      if (rrv->getMax() < 1e30) {
+      if (!RooNumber::isInfinite(rrv->getMax())) {
          var["max"] << rrv->getMax();
       }
       if (rrv->isConstant()) {

--- a/roofit/roofitcore/inc/LinkDef.h
+++ b/roofit/roofitcore/inc/LinkDef.h
@@ -151,7 +151,6 @@
 #pragma link C++ class RooMultiCategory+ ;
 #pragma link off class RooNameReg+ ;
 #pragma link C++ class RooNLLVar+ ;
-#pragma link C++ class RooNumber+ ;
 #pragma link C++ class RooNumConvolution+ ;
 #pragma link C++ class RooNumConvPdf+ ;
 #pragma link C++ class RooNumIntConfig+ ;

--- a/roofit/roofitcore/inc/RooNumber.h
+++ b/roofit/roofitcore/inc/RooNumber.h
@@ -20,33 +20,32 @@
 
 class RooNumber {
 public:
+   virtual ~RooNumber(){};
 
-  virtual ~RooNumber() {} ;
+   static double infinity();
+   static Int_t isInfinite(double x);
 
-  static double infinity() ;
-  static Int_t isInfinite(double x) ;
+   /// Set the relative epsilon that is used by range checks in RooFit,
+   /// e.g., in RooAbsRealLValue::inRange().
+   inline static void setRangeEpsRel(double epsRel) { staticRangeEpsRel() = epsRel; }
+   /// Get the relative epsilon that is used by range checks in RooFit,
+   /// e.g., in RooAbsRealLValue::inRange().
+   inline static double rangeEpsRel() { return staticRangeEpsRel(); }
 
-  /// Set the relative epsilon that is used by range checks in RooFit,
-  /// e.g., in RooAbsRealLValue::inRange().
-  inline static void setRangeEpsRel(double epsRel) { staticRangeEpsRel() = epsRel; }
-  /// Get the relative epsilon that is used by range checks in RooFit,
-  /// e.g., in RooAbsRealLValue::inRange().
-  inline static double rangeEpsRel() { return staticRangeEpsRel(); }
+   /// Set the absolute epsilon that is used by range checks in RooFit,
+   /// e.g., in RooAbsRealLValue::inRange().
+   inline static void setRangeEpsAbs(double epsRel) { staticRangeEpsAbs() = epsRel; }
+   /// Get the absolute epsilon that is used by range checks in RooFit,
+   /// e.g., in RooAbsRealLValue::inRange().
+   inline static double rangeEpsAbs() { return staticRangeEpsAbs(); }
 
-  /// Set the absolute epsilon that is used by range checks in RooFit,
-  /// e.g., in RooAbsRealLValue::inRange().
-  inline static void setRangeEpsAbs(double epsRel) { staticRangeEpsAbs() = epsRel; }
-  /// Get the absolute epsilon that is used by range checks in RooFit,
-  /// e.g., in RooAbsRealLValue::inRange().
-  inline static double rangeEpsAbs() { return staticRangeEpsAbs(); }
+private:
+   static double &staticRangeEpsRel();
+   static double &staticRangeEpsAbs();
 
- private:
-  static double& staticRangeEpsRel() ;
-  static double& staticRangeEpsAbs() ;
+   static double _Infinity;
 
-  static double _Infinity ;
-
-  ClassDef(RooNumber,0) // wrapper class for portable numerics
+   ClassDef(RooNumber, 0) // wrapper class for portable numerics
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooNumber.h
+++ b/roofit/roofitcore/inc/RooNumber.h
@@ -16,14 +16,22 @@
 #ifndef ROO_NUMBER
 #define ROO_NUMBER
 
-#include "Rtypes.h"
+#include <limits>
 
 class RooNumber {
 public:
-   virtual ~RooNumber(){};
+   /// Return internal infinity representation.
+   constexpr static double infinity()
+   {
+      // In the future, it should better do this:
+      //    return std::numeric_limits<double>::infinity();
 
-   static double infinity();
-   static Int_t isInfinite(double x);
+      // This assumes a well behaved IEEE-754 floating point implementation.
+      // The next line may generate a compiler warning that can be ignored.
+      return 1.0e30; // 1./0.;
+   }
+   /// Return true if x is infinite by RooNumber internal specification.
+   constexpr static int isInfinite(double x) { return (x >= +infinity()) ? +1 : ((x <= -infinity()) ? -1 : 0); }
 
    /// Set the relative epsilon that is used by range checks in RooFit,
    /// e.g., in RooAbsRealLValue::inRange().
@@ -42,10 +50,6 @@ public:
 private:
    static double &staticRangeEpsRel();
    static double &staticRangeEpsAbs();
-
-   static double _Infinity;
-
-   ClassDef(RooNumber, 0) // wrapper class for portable numerics
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooNumber.h
+++ b/roofit/roofitcore/inc/RooNumber.h
@@ -21,15 +21,7 @@
 class RooNumber {
 public:
    /// Return internal infinity representation.
-   constexpr static double infinity()
-   {
-      // In the future, it should better do this:
-      //    return std::numeric_limits<double>::infinity();
-
-      // This assumes a well behaved IEEE-754 floating point implementation.
-      // The next line may generate a compiler warning that can be ignored.
-      return 1.0e30; // 1./0.;
-   }
+   constexpr static double infinity() { return std::numeric_limits<double>::infinity(); }
    /// Return true if x is infinite by RooNumber internal specification.
    constexpr static int isInfinite(double x) { return (x >= +infinity()) ? +1 : ((x <= -infinity()) ? -1 : 0); }
 

--- a/roofit/roofitcore/src/RooNumber.cxx
+++ b/roofit/roofitcore/src/RooNumber.cxx
@@ -32,42 +32,39 @@ ClassImp(RooNumber);
 #ifdef HAS_NUMERIC_LIMITS
 
 #include <numeric_limits.h>
-double RooNumber::_Infinity= numeric_limits<double>::infinity();
+double RooNumber::_Infinity = numeric_limits<double>::infinity();
 #else
 
 // This assumes a well behaved IEEE-754 floating point implementation.
 // The next line may generate a compiler warning that can be ignored.
-double RooNumber::_Infinity= 1.0e30 ;  //1./0.;
+double RooNumber::_Infinity = 1.0e30; // 1./0.;
 
 #endif
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return internal infinity representation
 
 double RooNumber::infinity()
 {
-  return _Infinity ;
+   return _Infinity;
 }
 
-
-double& RooNumber::staticRangeEpsRel() {
-  static double epsRel = 0.0;
-  return epsRel;
+double &RooNumber::staticRangeEpsRel()
+{
+   static double epsRel = 0.0;
+   return epsRel;
 }
 
-
-double& RooNumber::staticRangeEpsAbs() {
-  static double epsAbs = 0.0;
-  return epsAbs;
+double &RooNumber::staticRangeEpsAbs()
+{
+   static double epsAbs = 0.0;
+   return epsAbs;
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return true if x is infinite by RooNumBer internal specification
 
 Int_t RooNumber::isInfinite(double x)
 {
-  return (x >= +_Infinity) ? +1 : ((x <= -_Infinity) ? -1 : 0);
+   return (x >= +_Infinity) ? +1 : ((x <= -_Infinity) ? -1 : 0);
 }
-

--- a/roofit/roofitcore/src/RooNumber.cxx
+++ b/roofit/roofitcore/src/RooNumber.cxx
@@ -22,32 +22,7 @@
 Class RooNumber implements numeric constants used by RooFit
 **/
 
-#include "RooNumber.h"
-
-using namespace std;
-
-ClassImp(RooNumber);
-;
-
-#ifdef HAS_NUMERIC_LIMITS
-
-#include <numeric_limits.h>
-double RooNumber::_Infinity = numeric_limits<double>::infinity();
-#else
-
-// This assumes a well behaved IEEE-754 floating point implementation.
-// The next line may generate a compiler warning that can be ignored.
-double RooNumber::_Infinity = 1.0e30; // 1./0.;
-
-#endif
-
-////////////////////////////////////////////////////////////////////////////////
-/// Return internal infinity representation
-
-double RooNumber::infinity()
-{
-   return _Infinity;
-}
+#include <RooNumber.h>
 
 double &RooNumber::staticRangeEpsRel()
 {
@@ -59,12 +34,4 @@ double &RooNumber::staticRangeEpsAbs()
 {
    static double epsAbs = 0.0;
    return epsAbs;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Return true if x is infinite by RooNumBer internal specification
-
-Int_t RooNumber::isInfinite(double x)
-{
-   return (x >= +_Infinity) ? +1 : ((x <= -_Infinity) ? -1 : 0);
 }

--- a/roofit/roofitcore/src/RooTruthModel.cxx
+++ b/roofit/roofitcore/src/RooTruthModel.cxx
@@ -347,17 +347,21 @@ double RooTruthModel::analyticalIntegral(Int_t code, const char* rangeName) cons
   //cout << " calling RooTruthModel::analyticalIntegral with basisType " << basisType << endl;
 
   double tau = ((RooAbsReal*)basis().getParameter(1))->getVal() ;
+
+  const double xmin = x.min(rangeName);
+  const double xmax = x.max(rangeName);
+
   switch (basisType) {
   case expBasis:
     {
       // WVE fixed for ranges
       double result(0) ;
       if (tau==0) return 1 ;
-      if ((basisSign != Minus) && (x.max(rangeName)>0)) {
-   result += tau*(-exp(-x.max(rangeName)/tau) -  -exp(-max(0.,x.min(rangeName))/tau) ) ; // plus and both
+      if ((basisSign != Minus) && (xmax>0)) {
+   result += tau*(-exp(-xmax/tau) -  -exp(-max(0.,xmin)/tau) ) ; // plus and both
       }
-      if ((basisSign != Plus) && (x.min(rangeName)<0)) {
-   result -= tau*(-exp(-max(0.,x.min(rangeName))/tau)) - -tau*exp(-x.max(rangeName)/tau) ;   // minus and both
+      if ((basisSign != Plus) && (xmin<0)) {
+   result -= tau*(-exp(-max(0.,xmin)/tau)) - -tau*exp(-xmax/tau) ;   // minus and both
       }
 
       return result ;
@@ -367,8 +371,8 @@ double RooTruthModel::analyticalIntegral(Int_t code, const char* rangeName) cons
       double result(0) ;
       if (tau==0) return 0 ;
       double dm = ((RooAbsReal*)basis().getParameter(2))->getVal() ;
-      if (basisSign != Minus) result += exp(-x.max(rangeName)/tau)*(-1/tau*sin(dm*x.max(rangeName)) - dm*cos(dm*x.max(rangeName))) + dm;  // fixed FMV 08/29/03
-      if (basisSign != Plus)  result -= exp( x.min(rangeName)/tau)*(-1/tau*sin(dm*(-x.min(rangeName))) - dm*cos(dm*(-x.min(rangeName)))) + dm ;  // fixed FMV 08/29/03
+      if (basisSign != Minus) result += exp(-xmax/tau)*(-1/tau*sin(dm*xmax) - dm*cos(dm*xmax)) + dm;  // fixed FMV 08/29/03
+      if (basisSign != Plus)  result -= exp( xmin/tau)*(-1/tau*sin(dm*(-xmin)) - dm*cos(dm*(-xmin))) + dm ;  // fixed FMV 08/29/03
       return result / (1/(tau*tau) + dm*dm) ;
     }
   case cosBasis:
@@ -376,20 +380,20 @@ double RooTruthModel::analyticalIntegral(Int_t code, const char* rangeName) cons
       double result(0) ;
       if (tau==0) return 1 ;
       double dm = ((RooAbsReal*)basis().getParameter(2))->getVal() ;
-      if (basisSign != Minus) result += exp(-x.max(rangeName)/tau)*(-1/tau*cos(dm*x.max(rangeName)) + dm*sin(dm*x.max(rangeName))) + 1/tau ;
-      if (basisSign != Plus)  result += exp( x.min(rangeName)/tau)*(-1/tau*cos(dm*(-x.min(rangeName))) + dm*sin(dm*(-x.min(rangeName)))) + 1/tau ; // fixed FMV 08/29/03
+      if (basisSign != Minus) result += exp(-xmax/tau)*(-1/tau*cos(dm*xmax) + dm*sin(dm*xmax)) + 1/tau ;
+      if (basisSign != Plus)  result += exp( xmin/tau)*(-1/tau*cos(dm*(-xmin)) + dm*sin(dm*(-xmin))) + 1/tau ; // fixed FMV 08/29/03
       return result / (1/(tau*tau) + dm*dm) ;
     }
   case linBasis:
     {
       if (tau==0) return 0 ;
-      double t_max = x.max(rangeName)/tau ;
+      double t_max = xmax/tau ;
       return tau*( 1 - (1 + t_max)*exp(-t_max) ) ;
     }
   case quadBasis:
     {
       if (tau==0) return 0 ;
-      double t_max = x.max(rangeName)/tau ;
+      double t_max = xmax/tau ;
       return tau*( 2 - (2 + (2 + t_max)*t_max)*exp(-t_max) ) ;
     }
   case sinhBasis:
@@ -399,8 +403,8 @@ double RooTruthModel::analyticalIntegral(Int_t code, const char* rangeName) cons
       double dg = ((RooAbsReal*)basis().getParameter(2))->getVal() ;
       double taup = 2*tau/(2-tau*dg);
       double taum = 2*tau/(2+tau*dg);
-      if (basisSign != Minus) result += 0.5*( taup*(1-exp(-x.max(rangeName)/taup)) - taum*(1-exp(-x.max(rangeName)/taum)) ) ;
-      if (basisSign != Plus)  result -= 0.5*( taup*(1-exp( x.min(rangeName)/taup)) - taum*(1-exp( x.min(rangeName)/taum)) ) ;
+      if (basisSign != Minus) result += 0.5*( taup*(1-exp(-xmax/taup)) - taum*(1-exp(-xmax/taum)) ) ;
+      if (basisSign != Plus)  result -= 0.5*( taup*(1-exp( xmin/taup)) - taum*(1-exp( xmin/taum)) ) ;
       return result ;
     }
   case coshBasis:
@@ -410,8 +414,8 @@ double RooTruthModel::analyticalIntegral(Int_t code, const char* rangeName) cons
       double dg = ((RooAbsReal*)basis().getParameter(2))->getVal() ;
       double taup = 2*tau/(2-tau*dg);
       double taum = 2*tau/(2+tau*dg);
-      if (basisSign != Minus) result += 0.5*( taup*(1-exp(-x.max(rangeName)/taup)) + taum*(1-exp(-x.max(rangeName)/taum)) ) ;
-      if (basisSign != Plus)  result += 0.5*( taup*(1-exp( x.min(rangeName)/taup)) + taum*(1-exp( x.min(rangeName)/taum)) ) ;
+      if (basisSign != Minus) result += 0.5*( taup*(1-exp(-xmax/taup)) + taum*(1-exp(-xmax/taum)) ) ;
+      if (basisSign != Plus)  result += 0.5*( taup*(1-exp( xmin/taup)) + taum*(1-exp( xmin/taum)) ) ;
       return result ;
     }
   default:

--- a/roofit/roofitcore/src/RooTruthModel.cxx
+++ b/roofit/roofitcore/src/RooTruthModel.cxx
@@ -371,8 +371,22 @@ double RooTruthModel::analyticalIntegral(Int_t code, const char* rangeName) cons
       double result(0) ;
       if (tau==0) return 0 ;
       double dm = ((RooAbsReal*)basis().getParameter(2))->getVal() ;
-      if (basisSign != Minus) result += exp(-xmax/tau)*(-1/tau*sin(dm*xmax) - dm*cos(dm*xmax)) + dm;  // fixed FMV 08/29/03
-      if (basisSign != Plus)  result -= exp( xmin/tau)*(-1/tau*sin(dm*(-xmin)) - dm*cos(dm*(-xmin))) + dm ;  // fixed FMV 08/29/03
+      if (basisSign != Minus) {
+         double term = exp(-xmax/tau);
+         // We only multiply with the sine term if the coefficient is non zero,
+         // i.e. if xmax was not infinity. Otherwise, we are evaluating the
+         // sine of infinity, whic is NAN! Same applies to the other terms
+         // below.
+         if(term > 0.0) term *= -1/tau*sin(dm*xmax) - dm*cos(dm*xmax);
+         term += dm;
+         result += term;
+      }
+      if (basisSign != Plus) {
+         double term = exp(xmin/tau);
+         if (term > 0.0) term *= -1/tau*sin(dm*(-xmin)) - dm*cos(dm*(-xmin));
+         term += dm;
+         result -= term;
+      }
       return result / (1/(tau*tau) + dm*dm) ;
     }
   case cosBasis:
@@ -380,8 +394,18 @@ double RooTruthModel::analyticalIntegral(Int_t code, const char* rangeName) cons
       double result(0) ;
       if (tau==0) return 1 ;
       double dm = ((RooAbsReal*)basis().getParameter(2))->getVal() ;
-      if (basisSign != Minus) result += exp(-xmax/tau)*(-1/tau*cos(dm*xmax) + dm*sin(dm*xmax)) + 1/tau ;
-      if (basisSign != Plus)  result += exp( xmin/tau)*(-1/tau*cos(dm*(-xmin)) + dm*sin(dm*(-xmin))) + 1/tau ; // fixed FMV 08/29/03
+      if (basisSign != Minus) {
+         double term = exp(-xmax/tau);
+         if(term > 0.0) term *= -1/tau*cos(dm*xmax) + dm*sin(dm*xmax);
+         term += 1/tau;
+         result += term;
+      }
+      if (basisSign != Plus) {
+         double term = exp( xmin/tau);
+         if(term > 0.0) term *= -1/tau*cos(dm*(-xmin)) + dm*sin(dm*(-xmin));
+         term += 1/tau;
+         result += term;
+      }
       return result / (1/(tau*tau) + dm*dm) ;
     }
   case linBasis:


### PR DESCRIPTION
Changing the definition of infinity in RooFit from `1e30` to `std::numeric_limits<double>::infinity()`, and making some other changes that ensure no evaluation errors are logged with this new definition.

* Code-format RooNumber.h and RooNumber.cxx
* Inline infinity constant and checks in `RooNumber`
* Make `TMath::AreEqualAbs()` return `true` when comparing `inf`
* Define infinity as `std::numeric_limits<double>::infinity()`
* RooTruthModel: local `xmin` and `xmax` to make code more readable
* Avoid `sin` or `cos` of infinity in RooTruthModel integral code
* Note change of infinity definition in RooFit


More details in the commit descriptions.


With the increased use of inlined code and simpler comparisons in `RooNumber`, this is also speeding up RooFit.

