### PR TITLE
[RF] Make RooFitResult set methods public 

### DIFF
--- a/roofit/roofitcore/inc/RooFitResult.h
+++ b/roofit/roofitcore/inc/RooFitResult.h
@@ -157,10 +157,8 @@ public:
   void SetName(const char *name) override ;
   void SetNameTitle(const char *name, const char* title) override ;
 
-protected:
 
-  friend class RooAbsPdf ;
-  friend class RooMinimizer ;
+
   void setCovarianceMatrix(TMatrixDSym& V) ;
   void setConstParList(const RooArgList& list) ;
   void setInitParList(const RooArgList& list) ;
@@ -170,12 +168,14 @@ protected:
   inline void setStatus(Int_t val) { _status = val ; }
   inline void setCovQual(Int_t val) { _covQual = val ; }
   inline void setNumInvalidNLL(Int_t val) { _numBadNLL=val ; }
-  void fillCorrMatrix() ;
+  void setStatusHistory(std::vector<std::pair<std::string,int> >& hist) { _statusHistory = hist ; }
   void fillCorrMatrix(const std::vector<double>& globalCC, const TMatrixDSym& corrs, const TMatrixDSym& covs) ;
+
+protected:
+
+  void fillCorrMatrix() ;
   void fillLegacyCorrMatrix() const ;
   void fillPrefitCorrMatrix();
-  void setStatusHistory(std::vector<std::pair<std::string,int> >& hist) { _statusHistory = hist ; }
-
   double correlation(Int_t row, Int_t col) const;
   double covariance(Int_t row, Int_t col) const;
 

--- a/roofit/xroofit/src/xRooFit.cxx
+++ b/roofit/xroofit/src/xRooFit.cxx
@@ -16,7 +16,7 @@
 #define protected public
 #endif
 #include "RooFitResult.h"
-#if ROOT_VERSION_CODE < ROOT_VERSION(6, 27, 00)
+#ifdef protected
 #undef protected
 #endif
 
@@ -506,8 +506,6 @@ xRooFit::minimize(RooAbsReal &nll, const std::shared_ptr<ROOT::Fit::FitConfig> &
    auto myFitConfig = _fitConfig ? _fitConfig : createFitConfig();
    auto &fitConfig = *myFitConfig;
 
-   bool save = true;
-
    auto _nll = &nll;
 
    TString resultTitle = nll.getStringAttribute("fitresultTitle");
@@ -720,10 +718,10 @@ xRooFit::minimize(RooAbsReal &nll, const std::shared_ptr<ROOT::Fit::FitConfig> &
                      ->Result()
                      .Status(); // note: Minuit failure is status code 4, minuit2 that is edm above max
          minim = _minimizer.fitter()->Config().MinimizerType(); // may have changed value
-         statusHistory.push_back(std::make_pair(
+         statusHistory.emplace_back(
             _minimizer.fitter()->Config().MinimizerType() + _minimizer.fitter()->Config().MinimizerAlgoType() +
                std::to_string(_minimizer.fitter()->Config().MinimizerOptions().Strategy()),
-            status));
+            status);
          if (status % 1000 == 0)
             break; // fit was good
 
@@ -1122,8 +1120,9 @@ int xRooFit::minos(RooAbsReal &nll, const RooFitResult &ufit, const char *parNam
    par->setConstant(isConst);
 
    std::vector<std::pair<std::string, int>> statusHistory;
-   for (int i = 0; i < ufit.numStatusHistory(); i++)
+   for (unsigned int i = 0; i < ufit.numStatusHistory(); i++) {
       statusHistory.emplace_back(ufit.statusLabelHistory(i), ufit.statusCodeHistory(i));
+   }
    statusHistory.emplace_back(TString::Format("xMINOS_%s", parName), status);
    const_cast<RooFitResult &>(ufit).setStatusHistory(statusHistory);
    const_cast<RooFitResult &>(ufit).setStatus(ufit.status() + status);

--- a/roofit/xroofit/src/xRooFit.cxx
+++ b/roofit/xroofit/src/xRooFit.cxx
@@ -10,9 +10,15 @@
  * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
  */
 
+#include "RVersion.h"
+
+#if ROOT_VERSION_CODE < ROOT_VERSION(6, 27, 00)
 #define protected public
+#endif
 #include "RooFitResult.h"
+#if ROOT_VERSION_CODE < ROOT_VERSION(6, 27, 00)
 #undef protected
+#endif
 
 #include "xRooFit/xRooFit.h"
 
@@ -33,11 +39,7 @@
 
 #include "RooStats/AsymptoticCalculator.h"
 #include "Math/GenAlgoOptions.h"
-
-#define private public
 #include "RooMinimizer.h"
-#undef private
-
 #include "coutCapture.h"
 
 #include "TCanvas.h"
@@ -661,7 +663,7 @@ xRooFit::minimize(RooAbsReal &nll, const std::shared_ptr<ROOT::Fit::FitConfig> &
       bool restore = !_minimizer.fitter()->Config().UpdateAfterFit();
       _minimizer.fitter()->Config().SetUpdateAfterFit(true); // note: seems to always take effect
 
-      std::vector<TString> algNames;
+      std::vector<std::pair<std::string, int>> statusHistory;
 
       // gCurrentSampler = this;
       // gOldHandlerr = signal(SIGINT,toyInterruptHandlerr);
@@ -717,17 +719,15 @@ xRooFit::minimize(RooAbsReal &nll, const std::shared_ptr<ROOT::Fit::FitConfig> &
          status = _minimizer.fitter()
                      ->Result()
                      .Status(); // note: Minuit failure is status code 4, minuit2 that is edm above max
-         _minimizer._statusHistory.back().second = _minimizer.fitter()->Result().Status();
          minim = _minimizer.fitter()->Config().MinimizerType(); // may have changed value
-         if (save)
-            algNames.push_back(_minimizer.fitter()->Config().MinimizerType() +
-                               _minimizer.fitter()->Config().MinimizerAlgoType() +
-                               std::to_string(_minimizer.fitter()->Config().MinimizerOptions().Strategy()));
-         // int status = _minimizer->migrad();
+         statusHistory.push_back(std::make_pair(
+            _minimizer.fitter()->Config().MinimizerType() + _minimizer.fitter()->Config().MinimizerAlgoType() +
+               std::to_string(_minimizer.fitter()->Config().MinimizerOptions().Strategy()),
+            status));
          if (status % 1000 == 0)
             break; // fit was good
 
-         if (_minimizer.fitter()->Result().Status() == 4 && minim != "Minuit") {
+         if (status == 4 && minim != "Minuit") {
             if (printLevel >= -1)
                Warning("fitTo", "%s Hit max function calls of %d", fitName.Data(),
                        _minimizer.fitter()->Config().MinimizerOptions().MaxFunctionCalls());
@@ -818,15 +818,10 @@ xRooFit::minimize(RooAbsReal &nll, const std::shared_ptr<ROOT::Fit::FitConfig> &
       // signal(SIGINT,gOldHandlerr);
       out = _minimizer.save(fitName, resultTitle);
 
-      if (save) {
-         // modify the statusHistory to use the algnames instead ..
-         int i = 0;
-         for (auto &ss : algNames) {
-            out->_statusHistory[i++].first = ss;
-         }
-      }
+      out->setStatusHistory(statusHistory);
 
-      out->_constPars->addClone(fUserPars, true);
+      // userPars wont have been added to the RooFitResult by RooMinimizer
+      const_cast<RooArgList &>(out->constPars()).addClone(fUserPars, true);
 
       if (boundaryCheck) {
          // check if any of the parameters are at their limits (potentially a problem with fit)
@@ -849,7 +844,7 @@ xRooFit::minimize(RooAbsReal &nll, const std::shared_ptr<ROOT::Fit::FitConfig> &
                v->setVal(v->getMin());
                double boundary_nll = _nll->getVal();
                if (boundary_nll <= out->minNll()) {
-                  ((RooRealVar *)out->_finalPars->find(v->GetName()))->setVal(v->getMin());
+                  static_cast<RooRealVar *>(out->floatParsFinal().find(v->GetName()))->setVal(v->getMin());
                   out->setMinNLL(boundary_nll);
                   // Info("fit","Corrected %s onto minimum @ %g",v->GetName(),v->getMin());
                } else {
@@ -881,8 +876,9 @@ xRooFit::minimize(RooAbsReal &nll, const std::shared_ptr<ROOT::Fit::FitConfig> &
          }
 
          // store the limit check result
-         out->_statusHistory.push_back(std::make_pair("BOUNDCHK", limit_status));
-         out->_status += limit_status;
+         statusHistory.emplace_back("BOUNDCHK", limit_status);
+         out->setStatusHistory(statusHistory);
+         out->setStatus(out->status() + limit_status);
       }
 
       //        // automatic parameter range adjustment based on errors
@@ -941,7 +937,7 @@ xRooFit::minimize(RooAbsReal &nll, const std::shared_ptr<ROOT::Fit::FitConfig> &
    }
    if (out && !logs.empty()) {
       // save logs to StringVar in constPars list
-      out->_constPars->addClone(RooStringVar(".log", "log", logs.c_str()));
+      const_cast<RooArgList &>(out->constPars()).addOwned(*new RooStringVar(".log", "log", logs.c_str()));
    }
 
    if (out && cacheDir && cacheDir->IsWritable()) {
@@ -961,7 +957,8 @@ xRooFit::minimize(RooAbsReal &nll, const std::shared_ptr<ROOT::Fit::FitConfig> &
             dir->WriteObject(&fitConfig, configName.data());
          }
          // add the fitConfig name into the fit result before writing, so can retrieve in future
-         out->_constPars->addClone(RooStringVar(".fitConfigName", "fitConfigName", configName.c_str()));
+         const_cast<RooArgList &>(out->constPars())
+            .addOwned(*new RooStringVar(".fitConfigName", "fitConfigName", configName.c_str()));
 
          dir->WriteObject(out, out->GetName());
       }
@@ -1124,9 +1121,12 @@ int xRooFit::minos(RooAbsReal &nll, const RooFitResult &ufit, const char *parNam
    fitConfig.SetMinosErrors(mErrs);
    par->setConstant(isConst);
 
-   const_cast<RooFitResult &>(ufit)._statusHistory.push_back(
-      std::make_pair(std::string(TString::Format("xMINOS_%s", parName)), status));
-   const_cast<RooFitResult &>(ufit)._status += status;
+   std::vector<std::pair<std::string, int>> statusHistory;
+   for (int i = 0; i < ufit.numStatusHistory(); i++)
+      statusHistory.emplace_back(ufit.statusLabelHistory(i), ufit.statusCodeHistory(i));
+   statusHistory.emplace_back(TString::Format("xMINOS_%s", parName), status);
+   const_cast<RooFitResult &>(ufit).setStatusHistory(statusHistory);
+   const_cast<RooFitResult &>(ufit).setStatus(ufit.status() + status);
 
    return status;
 }
@@ -1248,8 +1248,8 @@ xRooFit::hypoTest(RooWorkspace &w, int nToysNull, int /*nToysAlt*/, const xRooFi
             Info("hypoTest", "No altVal found - to specify setStringAttribute(\"altVal\",\"<value>\") on POI or set "
                              "the physical range");
       }
-      bool doCLs =
-         !std::isnan(altVal) && std::abs(mu->getMin("hypoPoints")) > altVal && std::abs(mu->getMax("hypoPoints")) > altVal;
+      bool doCLs = !std::isnan(altVal) && std::abs(mu->getMin("hypoPoints")) > altVal &&
+                   std::abs(mu->getMax("hypoPoints")) > altVal;
 
       const char *sCL = (doCLs) ? "CLs" : "null";
       Info("hypoTest", "%s testing active", sCL);


### PR DESCRIPTION
This allows non-friends to construct RooFitResults, which allows for the removal of protected->public override in xRooFit for this class.

