### PR TITLE
[cling] Reuse existing weak symbols, also from JIT:

### DIFF
--- a/interpreter/cling/lib/Interpreter/BackendPasses.cpp
+++ b/interpreter/cling/lib/Interpreter/BackendPasses.cpp
@@ -298,13 +298,15 @@ namespace {
     bool runOnFunc(Function& Func) {
       if (Func.isDeclaration())
         return false; // no change.
-
+#ifndef _WIN32
+      // MSVC's stdlib gets symbol issues; i.e. apparently: JIT all or none.
       if (Func.getInstructionCount() < 50) {
         // This is a small function. Keep its definition to retain it for
         // inlining: the cost for JITting it is small, and the likelihood
         // that the call will be inlined is high.
         return false;
       }
+#endif
       if (shouldRemoveGlobalDefinition(Func)) {
         Func.deleteBody(); // make this a declaration
         return true; // a change!

--- a/interpreter/cling/lib/Interpreter/BackendPasses.cpp
+++ b/interpreter/cling/lib/Interpreter/BackendPasses.cpp
@@ -267,6 +267,15 @@ namespace {
 
       // GV is a definition.
 
+      if (auto *Func = dyn_cast<Function>(&GV))
+        if (Func->getInstructionCount() < 50) {
+          // This is a small function. Keep its definition to retain it for
+          // inlining: the cost for JITting it is small, and the likelihood
+          // that the call will be inlined is high.
+          return false;
+        }
+
+
       llvm::GlobalValue::LinkageTypes LT = GV.getLinkage();
       if (!GV.isDiscardableIfUnused(LT) || !GV.isWeakForLinker(LT))
         return false;

--- a/interpreter/cling/lib/Interpreter/BackendPasses.h
+++ b/interpreter/cling/lib/Interpreter/BackendPasses.h
@@ -44,12 +44,13 @@ namespace cling {
     std::array<std::unique_ptr<llvm::legacy::FunctionPassManager>, 4> m_FPM;
 
     llvm::TargetMachine& m_TM;
+    IncrementalJIT &m_JIT;
     const clang::CodeGenOptions &m_CGOpts;
 
     void CreatePasses(llvm::Module& M, int OptLevel);
 
   public:
-    BackendPasses(const clang::CodeGenOptions &CGOpts,
+    BackendPasses(const clang::CodeGenOptions &CGOpts, IncrementalJIT &JIT,
                   llvm::TargetMachine& TM);
     ~BackendPasses();
 

--- a/interpreter/cling/lib/Interpreter/IncrementalExecutor.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalExecutor.cpp
@@ -55,7 +55,7 @@ IncrementalExecutor::IncrementalExecutor(clang::DiagnosticsEngine& /*diags*/,
     llvm_unreachable("Propagate this error and exit gracefully");
   }
 
-  m_BackendPasses.reset(new BackendPasses(CI.getCodeGenOpts(), m_JIT->getTargetMachine()));
+  m_BackendPasses.reset(new BackendPasses(CI.getCodeGenOpts(), *m_JIT, m_JIT->getTargetMachine()));
 }
 
 IncrementalExecutor::~IncrementalExecutor() {}

--- a/interpreter/cling/lib/Interpreter/IncrementalJIT.h
+++ b/interpreter/cling/lib/Interpreter/IncrementalJIT.h
@@ -78,6 +78,10 @@ public:
   /// should include symbols from the host process (via dlsym) or not.
   void* getSymbolAddress(llvm::StringRef Name, bool IncludeHostSymbols);
 
+  /// @brief Check whether the JIT already has emitted or knows how to emit
+  /// a symbol based on its IR name (as coming from clang's mangler).
+  bool doesSymbolAlreadyExist(llvm::StringRef UnmangledName);
+
   /// Inject a symbol with a known address. Name is not linker mangled, i.e.
   /// as known by the IR.
   llvm::JITTargetAddress addOrReplaceDefinition(llvm::StringRef Name,


### PR DESCRIPTION
With the upgrade to llvm-13, the JIT lost the ability to re-use existing weak symbols that the JIT had already emitted, instead only looking at dlsym. This causes a significant increase in JITted symbols, and thus a significant slow-down of cling / its JIT.

This restores the old behavior, with an identical set of symbols that jet jitted.

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

