### PR TITLE
[ntuple] Report the branch name when a class cannot be loaded

### DIFF
--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -240,7 +240,8 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSc
       if (isClass) {
          auto klass = TClass::GetClass(firstLeaf->GetTypeName());
          if (!klass)
-            return R__FAIL("unable to load class " + std::string(firstLeaf->GetTypeName()));
+            return R__FAIL("unable to load class " + std::string(firstLeaf->GetTypeName()) + " for branch " +
+                           std::string(b->GetName()));
          auto ptrBuf = reinterpret_cast<void **>(ib.fBranchBuffer.get());
          fSourceTree->SetBranchAddress(b->GetName(), ptrBuf, klass, EDataType::kOther_t, true /* isptr*/);
       } else {

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -239,9 +239,10 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSc
       ib.fBranchBuffer = std::make_unique<unsigned char[]>(branchBufferSize);
       if (isClass) {
          auto klass = TClass::GetClass(firstLeaf->GetTypeName());
-         if (!klass)
+         if (!klass) {
             return R__FAIL("unable to load class " + std::string(firstLeaf->GetTypeName()) + " for branch " +
                            std::string(b->GetName()));
+         }
          auto ptrBuf = reinterpret_cast<void **>(ib.fBranchBuffer.get());
          fSourceTree->SetBranchAddress(b->GetName(), ptrBuf, klass, EDataType::kOther_t, true /* isptr*/);
       } else {


### PR DESCRIPTION
This patch also reports the branch name when a class cannot be loaded by the importer to make debugging easier.
