### PR TITLE
[RF] Fix problems with dataset generation from a nested `RooSimultaneous` with proto data

### DIFF
--- a/roofit/roofitcore/inc/RooSimultaneous.h
+++ b/roofit/roofitcore/inc/RooSimultaneous.h
@@ -100,6 +100,9 @@ protected:
 
   void selectNormalization(const RooArgSet* depSet=nullptr, bool force=false) override ;
   void selectNormalizationRange(const char* rangeName=nullptr, bool force=false) override ;
+
+  RooArgSet const& flattenedCatList() const;
+
   mutable RooSetProxy _plotCoefNormSet ;
   const TNamed* _plotCoefNormRange = nullptr;
 
@@ -118,6 +121,8 @@ protected:
   RooCategoryProxy _indexCat ; ///< Index category
   TList    _pdfProxyList ;     ///< List of PDF proxies (named after applicable category state)
   Int_t    _numPdf = 0;        ///< Number of registered PDFs
+private:
+  mutable std::unique_ptr<RooArgSet> _indexCatSet ; ///<! Index category wrapped in a RooArgSet if needed internally
 
   ClassDefOverride(RooSimultaneous,3)  // Simultaneous operator p.d.f, functions like C++  'switch()' on input p.d.fs operating on index category5A
 };

--- a/roofit/roofitcore/inc/RooSimultaneous.h
+++ b/roofit/roofitcore/inc/RooSimultaneous.h
@@ -96,7 +96,7 @@ protected:
   void selectNormalization(const RooArgSet* depSet=nullptr, bool force=false) override ;
   void selectNormalizationRange(const char* rangeName=nullptr, bool force=false) override ;
   mutable RooSetProxy _plotCoefNormSet ;
-  const TNamed* _plotCoefNormRange ;
+  const TNamed* _plotCoefNormRange = nullptr;
 
   class CacheElem : public RooAbsCacheElement {
   public:
@@ -116,7 +116,7 @@ protected:
 
   RooCategoryProxy _indexCat ; ///< Index category
   TList    _pdfProxyList ;     ///< List of PDF proxies (named after applicable category state)
-  Int_t    _numPdf ;           ///< Number of registered PDFs
+  Int_t    _numPdf = 0;        ///< Number of registered PDFs
 
   ClassDefOverride(RooSimultaneous,3)  // Simultaneous operator p.d.f, functions like C++  'switch()' on input p.d.fs operating on index category5A
 };

--- a/roofit/roofitcore/inc/RooSimultaneous.h
+++ b/roofit/roofitcore/inc/RooSimultaneous.h
@@ -89,6 +89,11 @@ public:
                                  std::map<std::string, double> const& precisions,
                                  bool useCategoryNames=false);
 
+  RooAbsGenContext* autoGenContext(const RooArgSet &vars, const RooDataSet* prototype=nullptr, const RooArgSet* auxProto=nullptr,
+                  bool verbose=false, bool autoBinned=true, const char* binnedTag="") const override ;
+  RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype=nullptr,
+                                  const RooArgSet* auxProto=nullptr, bool verbose= false) const override ;
+
 protected:
 
   void initialize(RooAbsCategoryLValue& inIndexCat, std::map<std::string,RooAbsPdf*> pdfMap) ;
@@ -109,10 +114,6 @@ protected:
 
   friend class RooSimGenContext ;
   friend class RooSimSplitGenContext ;
-  RooAbsGenContext* autoGenContext(const RooArgSet &vars, const RooDataSet* prototype=nullptr, const RooArgSet* auxProto=nullptr,
-                  bool verbose=false, bool autoBinned=true, const char* binnedTag="") const override ;
-  RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype=nullptr,
-                                  const RooArgSet* auxProto=nullptr, bool verbose= false) const override ;
 
   RooCategoryProxy _indexCat ; ///< Index category
   TList    _pdfProxyList ;     ///< List of PDF proxies (named after applicable category state)

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -1061,9 +1061,12 @@ bool RooAbsArg::redirectServers(const RooAbsCollection& newSetOrig, bool mustRep
 
     if (!newServer) {
       if (mustReplaceAll) {
-        coutE(LinkStateMgmt) << "RooAbsArg::redirectServers(" << (void*)this << "," << GetName() << "): server " << oldServer->GetName()
-                    << " (" << (void*)oldServer << ") not redirected" << (nameChange?"[nameChange]":"") << endl ;
-        ret = true ;
+        std::stringstream ss;
+        ss << "RooAbsArg::redirectServers(" << (void*)this << "," << GetName() << "): server " << oldServer->GetName()
+           << " (" << (void*)oldServer << ") not redirected" << (nameChange?"[nameChange]":"");
+        const std::string errorMsg = ss.str();
+        coutE(LinkStateMgmt) << errorMsg << std::endl;
+        throw std::runtime_error(errorMsg);
       }
       continue ;
     }

--- a/roofit/roofitcore/src/RooSimGenContext.cxx
+++ b/roofit/roofitcore/src/RooSimGenContext.cxx
@@ -156,7 +156,7 @@ RooSimGenContext::~RooSimGenContext()
 void RooSimGenContext::attach(const RooArgSet& args)
 {
   if (_idxCat->isDerived()) {
-    _idxCat->recursiveRedirectServers(args,true) ;
+    _idxCat->recursiveRedirectServers(args) ;
   }
 
   // Forward initGenerator call to all components
@@ -174,7 +174,7 @@ void RooSimGenContext::initGenerator(const RooArgSet &theEvent)
 {
   // Attach the index category clone to the event
   if (_idxCat->isDerived()) {
-    _idxCat->recursiveRedirectServers(theEvent,true) ;
+    _idxCat->recursiveRedirectServers(theEvent) ;
   } else {
     _idxCat = (RooAbsCategoryLValue*) theEvent.find(_idxCat->GetName()) ;
   }

--- a/roofit/roofitcore/src/RooSimGenContext.cxx
+++ b/roofit/roofitcore/src/RooSimGenContext.cxx
@@ -67,37 +67,16 @@ RooSimGenContext::RooSimGenContext(const RooSimultaneous &model, const RooArgSet
   RooArgSet allPdfVars(pdfVars) ;
   if (prototype) allPdfVars.add(*prototype->get(),true) ;
 
-  if (!idxCat.isDerived()) {
-    pdfVars.remove(idxCat,true,true) ;
-    bool doGenIdx = allPdfVars.find(idxCat.GetName())?true:false ;
+  RooArgSet catsAmongAllVars;
+  allPdfVars.selectCommon(model.flattenedCatList(), catsAmongAllVars);
 
-    if (!doGenIdx) {
+  if(catsAmongAllVars.size() != model.flattenedCatList().size()) {
       oocoutE(_pdf,Generation) << "RooSimGenContext::ctor(" << GetName() << ") ERROR: This context must"
-                << " generate the index category" << endl ;
+                << " generate all components of the index category" << endl ;
       _isValid = false ;
       _numPdf = 0 ;
       _haveIdxProto = false ;
       return ;
-    }
-  } else {
-    bool anyServer(false), allServers(true) ;
-    for(RooAbsArg* server : idxCat.servers()) {
-      if (vars.find(server->GetName())) {
-   anyServer=true ;
-   pdfVars.remove(*server,true,true) ;
-      } else {
-   allServers=false ;
-      }
-    }
-
-    if (anyServer && !allServers) {
-      oocoutE(_pdf,Generation) << "RooSimGenContext::ctor(" << GetName() << ") ERROR: This context must"
-                << " generate all components of a derived index category" << endl ;
-      _isValid = false ;
-      _numPdf = 0 ;
-      _haveIdxProto = false ;
-      return ;
-    }
   }
 
   // We must either have the prototype or extended likelihood to determined

--- a/roofit/roofitcore/src/RooSimGenContext.cxx
+++ b/roofit/roofitcore/src/RooSimGenContext.cxx
@@ -61,15 +61,15 @@ RooSimGenContext::RooSimGenContext(const RooSimultaneous &model, const RooArgSet
   RooAbsGenContext(model,vars,prototype,auxProto,verbose), _pdf(&model), _protoData(0)
 {
   // Determine if we are requested to generate the index category
-  RooAbsCategory *idxCat = (RooAbsCategory*) model._indexCat.absArg() ;
+  RooAbsCategoryLValue const& idxCat = model.indexCat();
   RooArgSet pdfVars(vars) ;
 
   RooArgSet allPdfVars(pdfVars) ;
   if (prototype) allPdfVars.add(*prototype->get(),true) ;
 
-  if (!idxCat->isDerived()) {
-    pdfVars.remove(*idxCat,true,true) ;
-    bool doGenIdx = allPdfVars.find(idxCat->GetName())?true:false ;
+  if (!idxCat.isDerived()) {
+    pdfVars.remove(idxCat,true,true) ;
+    bool doGenIdx = allPdfVars.find(idxCat.GetName())?true:false ;
 
     if (!doGenIdx) {
       oocoutE(_pdf,Generation) << "RooSimGenContext::ctor(" << GetName() << ") ERROR: This context must"
@@ -81,7 +81,7 @@ RooSimGenContext::RooSimGenContext(const RooSimultaneous &model, const RooArgSet
     }
   } else {
     bool anyServer(false), allServers(true) ;
-    for(RooAbsArg* server : idxCat->servers()) {
+    for(RooAbsArg* server : idxCat.servers()) {
       if (vars.find(server->GetName())) {
    anyServer=true ;
    pdfVars.remove(*server,true,true) ;
@@ -103,7 +103,7 @@ RooSimGenContext::RooSimGenContext(const RooSimultaneous &model, const RooArgSet
   // We must either have the prototype or extended likelihood to determined
   // the relative fractions of the components
   _haveIdxProto = prototype ? true : false ;
-  _idxCatName = idxCat->GetName() ;
+  _idxCatName = idxCat.GetName() ;
   if (!_haveIdxProto && !model.canBeExtended()) {
     oocoutE(_pdf,Generation) << "RooSimGenContext::ctor(" << GetName() << ") ERROR: Need either extended mode"
               << " or prototype data to calculate number of events per category" << endl ;
@@ -129,7 +129,7 @@ RooSimGenContext::RooSimGenContext(const RooSimultaneous &model, const RooArgSet
     // Name the context after the associated state and add to list
     cx->SetName(proxy->name()) ;
     _gcList.push_back(cx) ;
-    _gcIndex.push_back(idxCat->lookupIndex(proxy->name()));
+    _gcIndex.push_back(idxCat.lookupIndex(proxy->name()));
 
     // Fill fraction threshold array
     _fracThresh[i] = _fracThresh[i-1] + (_haveIdxProto?0:pdf->expectedEvents(&allPdfVars)) ;
@@ -145,13 +145,13 @@ RooSimGenContext::RooSimGenContext(const RooSimultaneous &model, const RooArgSet
 
   // Clone the index category
   _idxCatSet = new RooArgSet;
-  RooArgSet(model._indexCat.arg()).snapshot(*_idxCatSet, true);
+  RooArgSet(model.indexCat()).snapshot(*_idxCatSet, true);
   if (!_idxCatSet) {
     oocoutE(_pdf,Generation) << "RooSimGenContext::RooSimGenContext(" << GetName() << ") Couldn't deep-clone index category, abort," << endl ;
     throw std::string("RooSimGenContext::RooSimGenContext() Couldn't deep-clone index category, abort") ;
   }
 
-  _idxCat = (RooAbsCategoryLValue*) _idxCatSet->find(model._indexCat.arg().GetName()) ;
+  _idxCat = static_cast<RooAbsCategoryLValue*>(_idxCatSet->find(model.indexCat().GetName()));
 }
 
 

--- a/roofit/roofitcore/src/RooSimSplitGenContext.cxx
+++ b/roofit/roofitcore/src/RooSimSplitGenContext.cxx
@@ -141,7 +141,7 @@ RooSimSplitGenContext::~RooSimSplitGenContext()
 void RooSimSplitGenContext::attach(const RooArgSet& args)
 {
   if (_idxCat->isDerived()) {
-    _idxCat->recursiveRedirectServers(args,true) ;
+    _idxCat->recursiveRedirectServers(args) ;
   }
 
   // Forward initGenerator call to all components
@@ -159,7 +159,7 @@ void RooSimSplitGenContext::initGenerator(const RooArgSet &theEvent)
 {
   // Attach the index category clone to the event
   if (_idxCat->isDerived()) {
-    _idxCat->recursiveRedirectServers(theEvent,true) ;
+    _idxCat->recursiveRedirectServers(theEvent) ;
   } else {
     _idxCat = (RooAbsCategoryLValue*) theEvent.find(_idxCat->GetName()) ;
   }

--- a/roofit/roofitcore/src/RooSimSplitGenContext.cxx
+++ b/roofit/roofitcore/src/RooSimSplitGenContext.cxx
@@ -58,37 +58,16 @@ RooSimSplitGenContext::RooSimSplitGenContext(const RooSimultaneous &model, const
 
   RooArgSet allPdfVars(pdfVars) ;
 
-  if (!idxCat.isDerived()) {
-    pdfVars.remove(idxCat,true,true) ;
-    bool doGenIdx = allPdfVars.find(idxCat.GetName())?true:false ;
+  RooArgSet catsAmongAllVars;
+  allPdfVars.selectCommon(model.flattenedCatList(), catsAmongAllVars);
 
-    if (!doGenIdx) {
+  if(catsAmongAllVars.size() != model.flattenedCatList().size()) {
       oocoutE(_pdf,Generation) << "RooSimSplitGenContext::ctor(" << GetName() << ") ERROR: This context must"
-                << " generate the index category" << endl ;
+                << " generate all components of the index category" << endl ;
       _isValid = false ;
       _numPdf = 0 ;
       // coverity[UNINIT_CTOR]
       return ;
-    }
-  } else {
-    bool anyServer(false), allServers(true) ;
-    for(RooAbsArg* server : idxCat.servers()) {
-      if (vars.find(server->GetName())) {
-   anyServer=true ;
-   pdfVars.remove(*server,true,true) ;
-      } else {
-   allServers=false ;
-      }
-    }
-
-    if (anyServer && !allServers) {
-      oocoutE(_pdf,Generation) << "RooSimSplitGenContext::ctor(" << GetName() << ") ERROR: This context must"
-                << " generate all components of a derived index category" << endl ;
-      _isValid = false ;
-      _numPdf = 0 ;
-      // coverity[UNINIT_CTOR]
-      return ;
-    }
   }
 
   // We must extended likelihood to determine the relative fractions of the components

--- a/roofit/roofitcore/src/RooSimSplitGenContext.cxx
+++ b/roofit/roofitcore/src/RooSimSplitGenContext.cxx
@@ -53,14 +53,14 @@ RooSimSplitGenContext::RooSimSplitGenContext(const RooSimultaneous &model, const
   RooAbsGenContext(model,vars,0,0,verbose), _pdf(&model)
 {
   // Determine if we are requested to generate the index category
-  RooAbsCategory *idxCat = (RooAbsCategory*) model._indexCat.absArg() ;
+  RooAbsCategoryLValue const& idxCat = model.indexCat();
   RooArgSet pdfVars(vars) ;
 
   RooArgSet allPdfVars(pdfVars) ;
 
-  if (!idxCat->isDerived()) {
-    pdfVars.remove(*idxCat,true,true) ;
-    bool doGenIdx = allPdfVars.find(idxCat->GetName())?true:false ;
+  if (!idxCat.isDerived()) {
+    pdfVars.remove(idxCat,true,true) ;
+    bool doGenIdx = allPdfVars.find(idxCat.GetName())?true:false ;
 
     if (!doGenIdx) {
       oocoutE(_pdf,Generation) << "RooSimSplitGenContext::ctor(" << GetName() << ") ERROR: This context must"
@@ -72,7 +72,7 @@ RooSimSplitGenContext::RooSimSplitGenContext(const RooSimultaneous &model, const
     }
   } else {
     bool anyServer(false), allServers(true) ;
-    for(RooAbsArg* server : idxCat->servers()) {
+    for(RooAbsArg* server : idxCat.servers()) {
       if (vars.find(server->GetName())) {
    anyServer=true ;
    pdfVars.remove(*server,true,true) ;
@@ -92,7 +92,7 @@ RooSimSplitGenContext::RooSimSplitGenContext(const RooSimultaneous &model, const
   }
 
   // We must extended likelihood to determine the relative fractions of the components
-  _idxCatName = idxCat->GetName() ;
+  _idxCatName = idxCat.GetName() ;
   if (!model.canBeExtended()) {
     oocoutE(_pdf,Generation) << "RooSimSplitGenContext::RooSimSplitGenContext(" << GetName() << "): All components of the simultaneous PDF "
               << "must be extended PDFs. Otherwise, it is impossible to calculate the number of events to be generated per component." << endl ;
@@ -118,7 +118,7 @@ RooSimSplitGenContext::RooSimSplitGenContext(const RooSimultaneous &model, const
     RooAbsGenContext* cx = pdf->autoGenContext(*compVars,0,0,verbose,autoBinned,binnedTag) ;
     delete compVars ;
 
-    const auto state = idxCat->lookupIndex(proxy->name());
+    const auto state = idxCat.lookupIndex(proxy->name());
 
     cx->SetName(proxy->name()) ;
     _gcList.push_back(cx) ;
@@ -134,11 +134,11 @@ RooSimSplitGenContext::RooSimSplitGenContext(const RooSimultaneous &model, const
   }
 
   // Clone the index category
-  if(RooArgSet(model._indexCat.arg()).snapshot(_idxCatSet, true)) {
+  if(RooArgSet(model.indexCat()).snapshot(_idxCatSet, true)) {
     oocoutE(_pdf,Generation) << "RooSimSplitGenContext::RooSimSplitGenContext(" << GetName() << ") Couldn't deep-clone index category, abort," << endl ;
     throw std::string("RooSimSplitGenContext::RooSimSplitGenContext() Couldn't deep-clone index category, abort") ;
   }
-  _idxCat = (RooAbsCategoryLValue*) _idxCatSet.find(model._indexCat.arg().GetName()) ;
+  _idxCat = static_cast<RooAbsCategoryLValue*>(_idxCatSet.find(model.indexCat().GetName()));
 }
 
 

--- a/roofit/roofitcore/src/RooSimultaneous.cxx
+++ b/roofit/roofitcore/src/RooSimultaneous.cxx
@@ -1000,21 +1000,21 @@ RooAbsGenContext* RooSimultaneous::genContext(const RooArgSet &vars, const RooDa
     // Generating index category: return special sim-context
     return new RooSimGenContext(*this,vars,prototype,auxProto,verbose) ;
 
-  } else if (_indexCat.arg().isDerived()) {
-    // Generating dependents of a derived index category
+  } else if (auto superIndexCat = dynamic_cast<RooSuperCategory const*>(&_indexCat.arg())) {
+    // Generating dependents of a RooSuperCategory index category.
+    // Note that the index category of a RooSimultaneous can only be of type
+    // RooCategory or RooSuperCategory, because these are the only classes that
+    // inherit from RooAbsCategoryLValue.
 
     // Determine if we none,any or all servers
-    bool anyServer(false), allServers(true) ;
+    bool anyServer = false;
+    bool allServers = true;
     if (prototype) {
-      for(RooAbsArg * server : _indexCat.arg().servers()) {
-   if (prototype->get()->find(server->GetName())) {
-     anyServer=true ;
-   } else {
-     allServers=false ;
-   }
-      }
-    } else {
-      allServers=true ;
+      RooArgSet common;
+      RooArgSet const& inputCats = superIndexCat->inputCatList();
+      prototype->get()->selectCommon(inputCats, common);
+      anyServer = !common.empty();
+      allServers = common.size() == inputCats.size();
     }
 
     if (allServers) {

--- a/roofit/roofitcore/src/RooSimultaneous.cxx
+++ b/roofit/roofitcore/src/RooSimultaneous.cxx
@@ -91,10 +91,8 @@ RooSimultaneous::RooSimultaneous(const char *name, const char *title,
              RooAbsCategoryLValue& inIndexCat) :
   RooAbsPdf(name,title),
   _plotCoefNormSet("!plotCoefNormSet","plotCoefNormSet",this,false,false),
-  _plotCoefNormRange(0),
   _partIntMgr(this,10),
-  _indexCat("indexCat","Index category",this,inIndexCat),
-  _numPdf(0)
+  _indexCat("indexCat","Index category",this,inIndexCat)
 {
 }
 
@@ -112,12 +110,7 @@ RooSimultaneous::RooSimultaneous(const char *name, const char *title,
 
 RooSimultaneous::RooSimultaneous(const char *name, const char *title,
              const RooArgList& inPdfList, RooAbsCategoryLValue& inIndexCat) :
-  RooAbsPdf(name,title),
-  _plotCoefNormSet("!plotCoefNormSet","plotCoefNormSet",this,false,false),
-  _plotCoefNormRange(0),
-  _partIntMgr(this,10),
-  _indexCat("indexCat","Index category",this,inIndexCat),
-  _numPdf(0)
+  RooSimultaneous(name,title,inIndexCat)
 {
   if (inPdfList.size() != inIndexCat.size()) {
     coutE(InputArguments) << "RooSimultaneous::ctor(" << GetName()
@@ -141,12 +134,7 @@ RooSimultaneous::RooSimultaneous(const char *name, const char *title,
 
 RooSimultaneous::RooSimultaneous(const char *name, const char *title,
              map<string,RooAbsPdf*> pdfMap, RooAbsCategoryLValue& inIndexCat) :
-  RooAbsPdf(name,title),
-  _plotCoefNormSet("!plotCoefNormSet","plotCoefNormSet",this,false,false),
-  _plotCoefNormRange(0),
-  _partIntMgr(this,10),
-  _indexCat("indexCat","Index category",this,inIndexCat),
-  _numPdf(0)
+  RooSimultaneous(name,title,inIndexCat)
 {
   initialize(inIndexCat,pdfMap) ;
 }
@@ -161,7 +149,7 @@ namespace RooSimultaneousAux {
     RooAbsPdf* pdf ;
     RooSimultaneous* simPdf ;
     const RooAbsCategoryLValue* subIndex ;
-    RooArgSet* subIndexComps ;
+    std::unique_ptr<RooArgSet> subIndexComps;
   } ;
 }
 
@@ -169,8 +157,8 @@ void RooSimultaneous::initialize(RooAbsCategoryLValue& inIndexCat, std::map<std:
 {
   // First see if there are any RooSimultaneous input components
   bool simComps(false) ;
-  for (map<string,RooAbsPdf*>::iterator iter=pdfMap.begin() ; iter!=pdfMap.end() ; ++iter) {
-    if (dynamic_cast<RooSimultaneous*>(iter->second)) {
+  for (auto const& item : pdfMap) {
+    if (dynamic_cast<RooSimultaneous*>(item.second)) {
       simComps = true ;
       break ;
     }
@@ -179,8 +167,8 @@ void RooSimultaneous::initialize(RooAbsCategoryLValue& inIndexCat, std::map<std:
   // If there are no simultaneous component p.d.f. do simple processing through addPdf()
   if (!simComps) {
     bool failure = false;
-    for (map<string,RooAbsPdf*>::iterator iter=pdfMap.begin() ; iter!=pdfMap.end() ; ++iter) {
-      failure |= addPdf(*iter->second,iter->first.c_str()) ;
+    for (auto const& item : pdfMap) {
+      failure |= addPdf(*item.second,item.first.c_str()) ;
     }
 
     if (failure) {
@@ -197,42 +185,42 @@ void RooSimultaneous::initialize(RooAbsCategoryLValue& inIndexCat, std::map<std:
 
 
   RooArgSet allAuxCats ;
-  map<string,RooSimultaneousAux::CompInfo> compMap ;
-  for (map<string,RooAbsPdf*>::iterator iter=pdfMap.begin() ; iter!=pdfMap.end() ; ++iter) {
+  std::map<string,RooSimultaneousAux::CompInfo> compMap ;
+  for (auto const& item : pdfMap) {
     RooSimultaneousAux::CompInfo ci ;
-    ci.pdf = iter->second ;
-    RooSimultaneous* simComp = dynamic_cast<RooSimultaneous*>(iter->second) ;
+    ci.pdf = item.second ;
+    RooSimultaneous* simComp = dynamic_cast<RooSimultaneous*>(item.second) ;
     if (simComp) {
       ci.simPdf = simComp ;
       ci.subIndex = &simComp->indexCat() ;
-      ci.subIndexComps = simComp->indexCat().isFundamental() ? new RooArgSet(simComp->indexCat()) : simComp->indexCat().getVariables() ;
-      allAuxCats.add(*(ci.subIndexComps),true) ;
+      ci.subIndexComps = simComp->indexCat().isFundamental()
+          ? std::make_unique<RooArgSet>(simComp->indexCat())
+          : std::unique_ptr<RooArgSet>(simComp->indexCat().getVariables());
+      allAuxCats.add(*ci.subIndexComps,true) ;
     } else {
-      ci.simPdf = 0 ;
-      ci.subIndex = 0 ;
-      ci.subIndexComps = 0 ;
+      ci.simPdf = nullptr;
+      ci.subIndex = nullptr;
     }
-    compMap[iter->first] = ci ;
+    compMap[item.first] = std::move(ci);
   }
 
   // Construct the 'superIndex' from the nominal index category and all auxiliary components
   RooArgSet allCats(inIndexCat) ;
   allCats.add(allAuxCats) ;
   string siname = Form("%s_index",GetName()) ;
-  RooSuperCategory* superIndex = new RooSuperCategory(siname.c_str(),siname.c_str(),allCats) ;
+  auto superIndex = std::make_unique<RooSuperCategory>(siname.c_str(),siname.c_str(),allCats) ;
   bool failure = false;
 
   // Now process each of original pdf/state map entries
-  for (map<string,RooSimultaneousAux::CompInfo>::iterator citer = compMap.begin() ; citer != compMap.end() ; ++citer) {
+  for (auto const& citem : compMap) {
 
     RooArgSet repliCats(allAuxCats) ;
-    if (citer->second.subIndexComps) {
-      repliCats.remove(*citer->second.subIndexComps) ;
-      delete citer->second.subIndexComps ;
+    if (citem.second.subIndexComps) {
+      repliCats.remove(*citem.second.subIndexComps) ;
     }
-    inIndexCat.setLabel(citer->first.c_str()) ;
+    inIndexCat.setLabel(citem.first.c_str()) ;
 
-    if (!citer->second.simPdf) {
+    if (!citem.second.simPdf) {
 
       // Entry is a plain p.d.f. assign it to every state permutation of the repliCats set
       RooSuperCategory repliSuperCat("tmp","tmp",repliCats) ;
@@ -243,9 +231,9 @@ void RooSimultaneous::initialize(RooAbsCategoryLValue& inIndexCat, std::map<std:
         repliSuperCat.setLabel(nameIdx.first) ;
         // Retrieve corresponding label of superIndex
         string superLabel = superIndex->getCurrentLabel() ;
-        failure |= addPdf(*citer->second.pdf,superLabel.c_str()) ;
+        failure |= addPdf(*citem.second.pdf,superLabel.c_str()) ;
         cxcoutD(InputArguments) << "RooSimultaneous::initialize(" << GetName()
-                << ") assigning pdf " << citer->second.pdf->GetName() << " to super label " << superLabel << endl ;
+                << ") assigning pdf " << citem.second.pdf->GetName() << " to super label " << superLabel << endl ;
       }
     } else {
 
@@ -255,19 +243,19 @@ void RooSimultaneous::initialize(RooAbsCategoryLValue& inIndexCat, std::map<std:
 
         // Case 1 -- No replication of components of RooSim component are required
 
-        for (const auto& type : *citer->second.subIndex) {
-          const_cast<RooAbsCategoryLValue*>(citer->second.subIndex)->setLabel(type.first.c_str());
+        for (const auto& type : *citem.second.subIndex) {
+          const_cast<RooAbsCategoryLValue*>(citem.second.subIndex)->setLabel(type.first.c_str());
           string superLabel = superIndex->getCurrentLabel() ;
-          RooAbsPdf* compPdf = citer->second.simPdf->getPdf(type.first.c_str());
+          RooAbsPdf* compPdf = citem.second.simPdf->getPdf(type.first.c_str());
           if (compPdf) {
             failure |= addPdf(*compPdf,superLabel.c_str()) ;
             cxcoutD(InputArguments) << "RooSimultaneous::initialize(" << GetName()
-                    << ") assigning pdf " << compPdf->GetName() << "(member of " << citer->second.pdf->GetName()
+                    << ") assigning pdf " << compPdf->GetName() << "(member of " << citem.second.pdf->GetName()
                     << ") to super label " << superLabel << endl ;
           } else {
             coutW(InputArguments) << "RooSimultaneous::initialize(" << GetName() << ") WARNING: No p.d.f. associated with label "
-                << type.second << " for component RooSimultaneous p.d.f " << citer->second.pdf->GetName()
-                << "which is associated with master index label " << citer->first << endl ;
+                << type.second << " for component RooSimultaneous p.d.f " << citem.second.pdf->GetName()
+                << "which is associated with master index label " << citem.first << endl ;
           }
         }
 
@@ -278,22 +266,22 @@ void RooSimultaneous::initialize(RooAbsCategoryLValue& inIndexCat, std::map<std:
         // Make replication supercat
         RooSuperCategory repliSuperCat("tmp","tmp",repliCats) ;
 
-        for (const auto& stype : *citer->second.subIndex) {
-          const_cast<RooAbsCategoryLValue*>(citer->second.subIndex)->setLabel(stype.first.c_str());
+        for (const auto& stype : *citem.second.subIndex) {
+          const_cast<RooAbsCategoryLValue*>(citem.second.subIndex)->setLabel(stype.first.c_str());
 
           for (const auto& nameIdx : repliSuperCat) {
             repliSuperCat.setLabel(nameIdx.first) ;
             const string superLabel = superIndex->getCurrentLabel() ;
-            RooAbsPdf* compPdf = citer->second.simPdf->getPdf(stype.first.c_str());
+            RooAbsPdf* compPdf = citem.second.simPdf->getPdf(stype.first.c_str());
             if (compPdf) {
               failure |= addPdf(*compPdf,superLabel.c_str()) ;
               cxcoutD(InputArguments) << "RooSimultaneous::initialize(" << GetName()
-                      << ") assigning pdf " << compPdf->GetName() << "(member of " << citer->second.pdf->GetName()
+                      << ") assigning pdf " << compPdf->GetName() << "(member of " << citem.second.pdf->GetName()
                       << ") to super label " << superLabel << endl ;
             } else {
               coutW(InputArguments) << "RooSimultaneous::initialize(" << GetName() << ") WARNING: No p.d.f. associated with label "
-                  << stype.second << " for component RooSimultaneous p.d.f " << citer->second.pdf->GetName()
-                  << "which is associated with master index label " << citer->first << endl ;
+                  << stype.second << " for component RooSimultaneous p.d.f " << citem.second.pdf->GetName()
+                  << "which is associated with master index label " << citem.first << endl ;
             }
           }
         }
@@ -307,7 +295,7 @@ void RooSimultaneous::initialize(RooAbsCategoryLValue& inIndexCat, std::map<std:
 
   // Change original master index to super index and take ownership of it
   _indexCat.setArg(*superIndex) ;
-  addOwnedComponents(*superIndex) ;
+  addOwnedComponents(std::move(superIndex));
 
 }
 
@@ -619,7 +607,7 @@ RooPlot* RooSimultaneous::plotOn(RooPlot *frame, RooLinkedList& cmdList) const
 
     // Make the master slice set if it doesnt exist
     if (!sliceSet) {
-      sliceSet.reset(new RooArgSet);
+      sliceSet = std::make_unique<RooArgSet>();
     }
 
     // Prepare comma separated label list for parsing
@@ -812,8 +800,7 @@ RooPlot* RooSimultaneous::plotOn(RooPlot *frame, RooLinkedList& cmdList) const
     if (skip) continue ;
 
     // Instantiate a RRV holding this pdfs weight fraction
-    RooRealVar *wgtVar = new RooRealVar(proxy->name(),"coef",wTable->getFrac(proxy->name())) ;
-    wgtCompList.addOwned(*wgtVar) ;
+    wgtCompList.addOwned(std::make_unique<RooRealVar>(proxy->name(),"coef",wTable->getFrac(proxy->name())));
     sumWeight += wTable->getFrac(proxy->name()) ;
 
     // Add the PDF to list list
@@ -834,7 +821,7 @@ RooPlot* RooSimultaneous::plotOn(RooPlot *frame, RooLinkedList& cmdList) const
 
     // Construct cut string to only select projection data event that match the current slice
     TString cutString ;
-    if (idxCompSliceSet->getSize()>0) {
+    if (!idxCompSliceSet->empty()) {
       bool first(true) ;
       for (const auto idxSliceCompArg : *idxCompSliceSet) {
         const auto idxSliceComp = static_cast<RooAbsCategory*>(idxSliceCompArg);
@@ -869,7 +856,7 @@ RooPlot* RooSimultaneous::plotOn(RooPlot *frame, RooLinkedList& cmdList) const
   }
 
 
-  if (_indexCat.arg().isDerived() && idxCompSliceSet->getSize()>0) {
+  if (_indexCat.arg().isDerived() && !idxCompSliceSet->empty()) {
     coutI(Plotting) << "RooSimultaneous::plotOn(" << GetName() << ") plot on " << frame->getPlotVar()->GetName()
           << " represents a slice in index category components " << *idxCompSliceSet << endl ;
 
@@ -898,7 +885,7 @@ RooPlot* RooSimultaneous::plotOn(RooPlot *frame, RooLinkedList& cmdList) const
   cmdList2.Add(&tmp2) ;
 
   RooPlot* frame2 ;
-  if (projSetTmp.getSize()>0) {
+  if (!projSetTmp.empty()) {
     // Plot temporary function
     RooCmdArg tmp3 = RooFit::Project(projSetTmp) ;
     cmdList2.Add(&tmp3) ;


### PR DESCRIPTION
When generating such a pdf from prototype data, the prototype needs to
contain all the subcategories of the super-category, and it does so by
checking the super-category servers. However, recently
`RooSuperCategory` was changed to contain a `RooMultiCategory`
internally, and the only reported direct server is the internal
multi-category. This leads to a wrong generation (the prototype data is
ignored, the gen context refers to the current labels).

The solution that this commit suggests is to use
`RooSuperCategory::inputCatList()` to inspect the internal categories
instead of using the client-server interface. Actually, the
client-server interface is not meant to be used for inspection like
that, just for general dependency management in the evaluation.

Closes https://github.com/root-project/root/issues/12020.