### PR TITLE
[DF] Removing failing test with shorter friends

### DIFF
--- a/tree/dataframe/test/dataframe_datasetspec.cxx
+++ b/tree/dataframe/test/dataframe_datasetspec.cxx
@@ -378,14 +378,6 @@ TEST_P(RDatasetSpecTest, Friends)
       if (i > 0) {
          EXPECT_VEC_SEQ_EQ(*res["friend_glob_" + data[i].name + "x"],
                            ROOT::TSeq<ULong64_t>(data[i].groupStart, data[i].groupStart + 24));
-      } else {
-         if (GetParam()) { // MT case
-            auto sol = *res["friend_glob_" + data[i].name + "x"];
-            ASSERT_EQ(sol.size(), 24u);
-            for (auto j = 0u; j < sol.size(); ++j)
-               EXPECT_EQ(sol[j], j > 8 ? j - 9 : 0u);
-         }
-         // sigle-threaded case with shorter friend behaves unexpectedly!
       }
    }
 }


### PR DESCRIPTION
According to https://github.com/root-project/root/issues/9137, we get bogus data if a friend is shorter than the main tree. The `datasetspec` test acknowledges this, but still checks the results in the MT case. This miraculously seems to work most of the time, but we sometimes see failures in the nightlies, especially on macOS, so remove it.