### PR TITLE
[ntuple] Show all fields unless a model is specified

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -68,9 +68,6 @@ enum class ENTupleInfo {
 enum class ENTupleShowFormat {
    kCurrentModelJSON, // prints a single entry/row with the current active model in JSON format.
    kCompleteJSON,  // prints a single entry/row with all the fields in JSON format.
-   kCompleteUnlessCurrentJSON, // prints a single entry/row with all the fields in JSON format,
-                               // unless a model is active in which case it only loads the fields
-                               // in that model.
 };
 
 
@@ -251,7 +248,7 @@ public:
    /// Shows the values of the i-th entry/row, starting with 0 for the first entry. By default,
    /// prints the output in JSON format.
    /// Uses the visitor pattern to traverse through each field of the given entry.
-   void Show(NTupleSize_t index, const ENTupleShowFormat format = ENTupleShowFormat::kCompleteUnlessCurrentJSON,
+   void Show(NTupleSize_t index, const ENTupleShowFormat format = ENTupleShowFormat::kCurrentModelJSON,
              std::ostream &output = std::cout);
 
    /// Analogous to Fill(), fills the default entry of the model. Returns false at the end of the ntuple.

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -68,6 +68,9 @@ enum class ENTupleInfo {
 enum class ENTupleShowFormat {
    kCurrentModelJSON, // prints a single entry/row with the current active model in JSON format.
    kCompleteJSON,  // prints a single entry/row with all the fields in JSON format.
+   kCompleteUnlessCurrentJSON, // prints a single entry/row with all the fields in JSON format,
+                               // unless a model is active in which case it only loads the fields
+                               // in that model.
 };
 
 
@@ -248,7 +251,7 @@ public:
    /// Shows the values of the i-th entry/row, starting with 0 for the first entry. By default,
    /// prints the output in JSON format.
    /// Uses the visitor pattern to traverse through each field of the given entry.
-   void Show(NTupleSize_t index, const ENTupleShowFormat format = ENTupleShowFormat::kCurrentModelJSON,
+   void Show(NTupleSize_t index, const ENTupleShowFormat format = ENTupleShowFormat::kCompleteUnlessCurrentJSON,
              std::ostream &output = std::cout);
 
    /// Analogous to Fill(), fills the default entry of the model. Returns false at the end of the ntuple.

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -243,16 +243,10 @@ void ROOT::Experimental::RNTupleReader::Show(NTupleSize_t index, const ENTupleSh
       reader = GetDisplayReader();
       entry = reader->GetModel()->GetDefaultEntry();
       // Fall through
-   case ENTupleShowFormat::kCompleteUnlessCurrentJSON:
+   case ENTupleShowFormat::kCurrentModelJSON:
       if (!entry) {
          reader = GetDisplayReader();
          entry = reader->GetModel()->GetDefaultEntry();
-      }
-      // Fall through
-   case ENTupleShowFormat::kCurrentModelJSON:
-      if (!entry) {
-         output << "{}" << std::endl;
-         break;
       }
 
       reader->LoadEntry(index);

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -233,10 +233,7 @@ ROOT::Experimental::RNTupleReader *ROOT::Experimental::RNTupleReader::GetDisplay
 void ROOT::Experimental::RNTupleReader::Show(NTupleSize_t index, const ENTupleShowFormat format, std::ostream &output)
 {
    RNTupleReader *reader = this;
-   REntry *entry = nullptr;
-   // Don't accidentally trigger loading of the entire model
-   if (fModel)
-      entry = fModel->GetDefaultEntry();
+   REntry *entry = GetModel()->GetDefaultEntry();
 
    switch (format) {
    case ENTupleShowFormat::kCompleteJSON:
@@ -244,11 +241,6 @@ void ROOT::Experimental::RNTupleReader::Show(NTupleSize_t index, const ENTupleSh
       entry = reader->GetModel()->GetDefaultEntry();
       // Fall through
    case ENTupleShowFormat::kCurrentModelJSON:
-      if (!entry) {
-         reader = GetDisplayReader();
-         entry = reader->GetModel()->GetDefaultEntry();
-      }
-
       reader->LoadEntry(index);
       output << "{";
       for (auto iValue = entry->begin(); iValue != entry->end();) {

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -40,7 +40,6 @@
 #include <unordered_map>
 #include <utility>
 
-
 #ifdef R__USE_IMT
 ROOT::Experimental::RNTupleImtTaskScheduler::RNTupleImtTaskScheduler()
 {
@@ -52,12 +51,10 @@ void ROOT::Experimental::RNTupleImtTaskScheduler::Reset()
    fTaskGroup = std::make_unique<TTaskGroup>();
 }
 
-
 void ROOT::Experimental::RNTupleImtTaskScheduler::AddTask(const std::function<void(void)> &taskFunc)
 {
    fTaskGroup->Run(taskFunc);
 }
-
 
 void ROOT::Experimental::RNTupleImtTaskScheduler::Wait()
 {
@@ -65,11 +62,10 @@ void ROOT::Experimental::RNTupleImtTaskScheduler::Wait()
 }
 #endif
 
-
 //------------------------------------------------------------------------------
 
-
-void ROOT::Experimental::RNTupleReader::ConnectModel(const RNTupleModel &model) {
+void ROOT::Experimental::RNTupleReader::ConnectModel(const RNTupleModel &model)
+{
    // We must not use the descriptor guard to prevent recursive locking in field.ConnectPageSource
    model.GetFieldZero()->SetOnDiskId(fSource->GetSharedDescriptorGuard()->GetFieldZeroId());
    for (auto &field : *model.GetFieldZero()) {
@@ -95,12 +91,9 @@ void ROOT::Experimental::RNTupleReader::InitPageSource()
    fMetrics.ObserveMetrics(fSource->GetMetrics());
 }
 
-ROOT::Experimental::RNTupleReader::RNTupleReader(
-   std::unique_ptr<ROOT::Experimental::RNTupleModel> model,
-   std::unique_ptr<ROOT::Experimental::Detail::RPageSource> source)
-   : fSource(std::move(source))
-   , fModel(std::move(model))
-   , fMetrics("RNTupleReader")
+ROOT::Experimental::RNTupleReader::RNTupleReader(std::unique_ptr<ROOT::Experimental::RNTupleModel> model,
+                                                 std::unique_ptr<ROOT::Experimental::Detail::RPageSource> source)
+   : fSource(std::move(source)), fModel(std::move(model)), fMetrics("RNTupleReader")
 {
    if (!fSource) {
       throw RException(R__FAIL("null source"));
@@ -117,9 +110,7 @@ ROOT::Experimental::RNTupleReader::RNTupleReader(
 }
 
 ROOT::Experimental::RNTupleReader::RNTupleReader(std::unique_ptr<ROOT::Experimental::Detail::RPageSource> source)
-   : fSource(std::move(source))
-   , fModel(nullptr)
-   , fMetrics("RNTupleReader")
+   : fSource(std::move(source)), fModel(nullptr), fMetrics("RNTupleReader")
 {
    if (!fSource) {
       throw RException(R__FAIL("null source"));
@@ -129,19 +120,16 @@ ROOT::Experimental::RNTupleReader::RNTupleReader(std::unique_ptr<ROOT::Experimen
 
 ROOT::Experimental::RNTupleReader::~RNTupleReader() = default;
 
-std::unique_ptr<ROOT::Experimental::RNTupleReader> ROOT::Experimental::RNTupleReader::Open(
-   std::unique_ptr<RNTupleModel> model,
-   std::string_view ntupleName,
-   std::string_view storage,
-   const RNTupleReadOptions &options)
+std::unique_ptr<ROOT::Experimental::RNTupleReader>
+ROOT::Experimental::RNTupleReader::Open(std::unique_ptr<RNTupleModel> model, std::string_view ntupleName,
+                                        std::string_view storage, const RNTupleReadOptions &options)
 {
    return std::make_unique<RNTupleReader>(std::move(model), Detail::RPageSource::Create(ntupleName, storage, options));
 }
 
-std::unique_ptr<ROOT::Experimental::RNTupleReader> ROOT::Experimental::RNTupleReader::Open(
-   std::string_view ntupleName,
-   std::string_view storage,
-   const RNTupleReadOptions &options)
+std::unique_ptr<ROOT::Experimental::RNTupleReader>
+ROOT::Experimental::RNTupleReader::Open(std::string_view ntupleName, std::string_view storage,
+                                        const RNTupleReadOptions &options)
 {
    return std::make_unique<RNTupleReader>(Detail::RPageSource::Create(ntupleName, storage, options));
 }
@@ -152,8 +140,8 @@ ROOT::Experimental::RNTupleReader::Open(ROOT::Experimental::RNTuple *ntuple, con
    return std::make_unique<RNTupleReader>(ntuple->MakePageSource(options));
 }
 
-std::unique_ptr<ROOT::Experimental::RNTupleReader> ROOT::Experimental::RNTupleReader::OpenFriends(
-   std::span<ROpenSpec> ntuples)
+std::unique_ptr<ROOT::Experimental::RNTupleReader>
+ROOT::Experimental::RNTupleReader::OpenFriends(std::span<ROpenSpec> ntuples)
 {
    std::vector<std::unique_ptr<Detail::RPageSource>> sources;
    for (const auto &n : ntuples) {
@@ -173,7 +161,8 @@ ROOT::Experimental::RNTupleModel *ROOT::Experimental::RNTupleReader::GetModel()
 
 void ROOT::Experimental::RNTupleReader::PrintInfo(const ENTupleInfo what, std::ostream &output)
 {
-   // TODO(lesimon): In a later version, these variables may be defined by the user or the ideal width may be read out from the terminal.
+   // TODO(lesimon): In a later version, these variables may be defined by the user or the ideal width may be read out
+   // from the terminal.
    char frameSymbol = '*';
    int width = 80;
    /*
@@ -192,15 +181,17 @@ void ROOT::Experimental::RNTupleReader::PrintInfo(const ENTupleInfo what, std::o
          fullModel = descriptorGuard->GenerateModel();
       }
 
-      for (int i = 0; i < (width/2 + width%2 - 4); ++i)
-            output << frameSymbol;
+      for (int i = 0; i < (width / 2 + width % 2 - 4); ++i)
+         output << frameSymbol;
       output << " NTUPLE ";
-      for (int i = 0; i < (width/2 - 4); ++i)
+      for (int i = 0; i < (width / 2 - 4); ++i)
          output << frameSymbol;
       output << std::endl;
       // FitString defined in RFieldVisitor.cxx
-      output << frameSymbol << " N-Tuple : " << RNTupleFormatter::FitString(name, width-13) << frameSymbol << std::endl; // prints line with name of ntuple
-      output << frameSymbol << " Entries : " << RNTupleFormatter::FitString(std::to_string(GetNEntries()), width - 13) << frameSymbol << std::endl;  // prints line with number of entries
+      output << frameSymbol << " N-Tuple : " << RNTupleFormatter::FitString(name, width - 13) << frameSymbol
+             << std::endl; // prints line with name of ntuple
+      output << frameSymbol << " Entries : " << RNTupleFormatter::FitString(std::to_string(GetNEntries()), width - 13)
+             << frameSymbol << std::endl; // prints line with number of entries
 
       // Traverses through all fields to gather information needed for printing.
       RPrepareVisitor prepVisitor;
@@ -225,15 +216,12 @@ void ROOT::Experimental::RNTupleReader::PrintInfo(const ENTupleInfo what, std::o
       break;
    }
    case ENTupleInfo::kStorageDetails: fSource->GetSharedDescriptorGuard()->PrintInfo(output); break;
-   case ENTupleInfo::kMetrics:
-      fMetrics.Print(output);
-      break;
+   case ENTupleInfo::kMetrics: fMetrics.Print(output); break;
    default:
       // Unhandled case, internal error
       R__ASSERT(false);
    }
 }
-
 
 ROOT::Experimental::RNTupleReader *ROOT::Experimental::RNTupleReader::GetDisplayReader()
 {
@@ -241,7 +229,6 @@ ROOT::Experimental::RNTupleReader *ROOT::Experimental::RNTupleReader::GetDisplay
       fDisplayReader = Clone();
    return fDisplayReader.get();
 }
-
 
 void ROOT::Experimental::RNTupleReader::Show(NTupleSize_t index, const ENTupleShowFormat format, std::ostream &output)
 {
@@ -251,10 +238,16 @@ void ROOT::Experimental::RNTupleReader::Show(NTupleSize_t index, const ENTupleSh
    if (fModel)
       entry = fModel->GetDefaultEntry();
 
-   switch(format) {
+   switch (format) {
    case ENTupleShowFormat::kCompleteJSON:
       reader = GetDisplayReader();
       entry = reader->GetModel()->GetDefaultEntry();
+      // Fall through
+   case ENTupleShowFormat::kCompleteUnlessCurrentJSON:
+      if (!entry) {
+         reader = GetDisplayReader();
+         entry = reader->GetModel()->GetDefaultEntry();
+      }
       // Fall through
    case ENTupleShowFormat::kCurrentModelJSON:
       if (!entry) {
@@ -264,7 +257,7 @@ void ROOT::Experimental::RNTupleReader::Show(NTupleSize_t index, const ENTupleSh
 
       reader->LoadEntry(index);
       output << "{";
-      for (auto iValue = entry->begin(); iValue != entry->end(); ) {
+      for (auto iValue = entry->begin(); iValue != entry->end();) {
          output << std::endl;
          RPrintValueVisitor visitor(*iValue, output, 1 /* level */);
          iValue->GetField()->AcceptVisitor(visitor);
@@ -294,13 +287,9 @@ const ROOT::Experimental::RNTupleDescriptor *ROOT::Experimental::RNTupleReader::
 
 //------------------------------------------------------------------------------
 
-
-ROOT::Experimental::RNTupleWriter::RNTupleWriter(
-   std::unique_ptr<ROOT::Experimental::RNTupleModel> model,
-   std::unique_ptr<ROOT::Experimental::Detail::RPageSink> sink)
-   : fSink(std::move(sink))
-   , fModel(std::move(model))
-   , fMetrics("RNTupleWriter")
+ROOT::Experimental::RNTupleWriter::RNTupleWriter(std::unique_ptr<ROOT::Experimental::RNTupleModel> model,
+                                                 std::unique_ptr<ROOT::Experimental::Detail::RPageSink> sink)
+   : fSink(std::move(sink)), fModel(std::move(model)), fMetrics("RNTupleWriter")
 {
    if (!fModel) {
       throw RException(R__FAIL("null model"));
@@ -331,20 +320,16 @@ ROOT::Experimental::RNTupleWriter::~RNTupleWriter()
    fSink->CommitDataset();
 }
 
-std::unique_ptr<ROOT::Experimental::RNTupleWriter> ROOT::Experimental::RNTupleWriter::Recreate(
-   std::unique_ptr<RNTupleModel> model,
-   std::string_view ntupleName,
-   std::string_view storage,
-   const RNTupleWriteOptions &options)
+std::unique_ptr<ROOT::Experimental::RNTupleWriter>
+ROOT::Experimental::RNTupleWriter::Recreate(std::unique_ptr<RNTupleModel> model, std::string_view ntupleName,
+                                            std::string_view storage, const RNTupleWriteOptions &options)
 {
    return std::make_unique<RNTupleWriter>(std::move(model), Detail::RPageSink::Create(ntupleName, storage, options));
 }
 
-std::unique_ptr<ROOT::Experimental::RNTupleWriter> ROOT::Experimental::RNTupleWriter::Append(
-   std::unique_ptr<RNTupleModel> model,
-   std::string_view ntupleName,
-   TFile &file,
-   const RNTupleWriteOptions &options)
+std::unique_ptr<ROOT::Experimental::RNTupleWriter>
+ROOT::Experimental::RNTupleWriter::Append(std::unique_ptr<RNTupleModel> model, std::string_view ntupleName, TFile &file,
+                                          const RNTupleWriteOptions &options)
 {
    auto sink = std::make_unique<Detail::RPageSinkFile>(ntupleName, file, options);
    if (options.GetUseBufferedWrite()) {
@@ -369,7 +354,7 @@ void ROOT::Experimental::RNTupleWriter::CommitCluster(bool commitClusterGroup)
          CommitClusterGroup();
       return;
    }
-   for (auto& field : *fModel->GetFieldZero()) {
+   for (auto &field : *fModel->GetFieldZero()) {
       field.Flush();
       field.CommitCluster();
    }
@@ -377,8 +362,8 @@ void ROOT::Experimental::RNTupleWriter::CommitCluster(bool commitClusterGroup)
    fNBytesFilled += fUnzippedClusterSize;
 
    // Cap the compression factor at 1000 to prevent overflow of fUnzippedClusterSizeEst
-   const float compressionFactor = std::min(1000.f,
-      static_cast<float>(fNBytesFilled) / static_cast<float>(fNBytesCommitted));
+   const float compressionFactor =
+      std::min(1000.f, static_cast<float>(fNBytesFilled) / static_cast<float>(fNBytesCommitted));
    fUnzippedClusterSizeEst =
       compressionFactor * static_cast<float>(fSink->GetWriteOptions().GetApproxZippedClusterSize());
 
@@ -389,9 +374,7 @@ void ROOT::Experimental::RNTupleWriter::CommitCluster(bool commitClusterGroup)
       CommitClusterGroup();
 }
 
-
 //------------------------------------------------------------------------------
-
 
 ROOT::Experimental::RCollectionNTupleWriter::RCollectionNTupleWriter(std::unique_ptr<REntry> defaultEntry)
    : fOffset(0), fDefaultEntry(std::move(defaultEntry))

--- a/tree/ntuple/v7/test/ntuple_show.cxx
+++ b/tree/ntuple/v7/test/ntuple_show.cxx
@@ -556,4 +556,15 @@ TEST(RNTupleShow, CompleteOrCurrentModel)
       + "}\n"};
    // clang-format on
    EXPECT_EQ(expected2, os2.str());
+
+   std::ostringstream os3;
+   ntuple2->Show(0, ROOT::Experimental::ENTupleShowFormat::kCompleteJSON, os3);
+   // clang-format off
+   std::string expected3{std::string("")
+      + "{\n"
+      + "  \"int\": 42,\n"
+      + "  \"float\": 3.14\n"
+      + "}\n"};
+   // clang-format on
+   EXPECT_EQ(expected3, os3.str());
 }

--- a/tree/ntuple/v7/test/ntuple_show.cxx
+++ b/tree/ntuple/v7/test/ntuple_show.cxx
@@ -450,12 +450,12 @@ TEST(RNTupleShow, CompleteOrCurrentModel)
    auto ntuple2 = RNTupleReader::Open(std::move(model), "f", fileGuard.GetPath());
 
    std::ostringstream os1;
-   ntuple1->Show(0, ROOT::Experimental::ENTupleShowFormat::kCompleteUnlessCurrentJSON, os1);
+   ntuple1->Show(0, ROOT::Experimental::ENTupleShowFormat::kCurrentModelJSON, os1);
    std::string expected1{"{\n  \"int\": 42,\n  \"float\": 3.14\n}\n"};
    EXPECT_EQ(expected1, os1.str());
 
    std::ostringstream os2;
-   ntuple2->Show(0, ROOT::Experimental::ENTupleShowFormat::kCompleteUnlessCurrentJSON, os2);
+   ntuple2->Show(0, ROOT::Experimental::ENTupleShowFormat::kCurrentModelJSON, os2);
    std::string expected2{"{\n  \"int\": 42\n}\n"};
    EXPECT_EQ(expected2, os2.str());
 }

--- a/tree/ntuple/v7/test/ntuple_show.cxx
+++ b/tree/ntuple/v7/test/ntuple_show.cxx
@@ -26,7 +26,6 @@ TEST(RNTupleShow, Empty)
    EXPECT_EQ(fString1, os1.str());
 }
 
-
 TEST(RNTupleShow, BasicTypes)
 {
    std::string rootFileName{"test_ntuple_show_basictypes.root"};
@@ -69,32 +68,16 @@ TEST(RNTupleShow, BasicTypes)
 
    std::ostringstream os;
    ntuple2->Show(0, ROOT::Experimental::ENTupleShowFormat::kCompleteJSON, os);
-   std::string fString{ std::string("")
-      + "{\n"
-      + "  \"pt\": 5,\n"
-      + "  \"db\": 9.99,\n"
-      + "  \"int\": -4,\n"
-      + "  \"uint\": 3,\n"
-      + "  \"uint64\": 44444444444,\n"
-      + "  \"string\": \"TestString\",\n"
-      + "  \"boolean\": true,\n"
-      + "  \"uint8\": 97\n"
-      + "}\n" };
+   std::string fString{std::string("") + "{\n" + "  \"pt\": 5,\n" + "  \"db\": 9.99,\n" + "  \"int\": -4,\n" +
+                       "  \"uint\": 3,\n" + "  \"uint64\": 44444444444,\n" + "  \"string\": \"TestString\",\n" +
+                       "  \"boolean\": true,\n" + "  \"uint8\": 97\n" + "}\n"};
    EXPECT_EQ(fString, os.str());
 
    std::ostringstream os1;
    ntuple2->Show(1, ROOT::Experimental::ENTupleShowFormat::kCompleteJSON, os1);
-   std::string fString1{ std::string("")
-      + "{\n"
-      + "  \"pt\": 8.5,\n"
-      + "  \"db\": 9.998,\n"
-      + "  \"int\": -94,\n"
-      + "  \"uint\": 4294967266,\n"
-      + "  \"uint64\": 2299994967294,\n"
-      + "  \"string\": \"TestString2\",\n"
-      + "  \"boolean\": false,\n"
-      + "  \"uint8\": 98\n"
-      + "}\n" };
+   std::string fString1{std::string("") + "{\n" + "  \"pt\": 8.5,\n" + "  \"db\": 9.998,\n" + "  \"int\": -94,\n" +
+                        "  \"uint\": 4294967266,\n" + "  \"uint64\": 2299994967294,\n" +
+                        "  \"string\": \"TestString2\",\n" + "  \"boolean\": false,\n" + "  \"uint8\": 98\n" + "}\n"};
    EXPECT_EQ(fString1, os1.str());
 
    // TODO(jblomer): this should fail to an exception instead
@@ -115,7 +98,8 @@ TEST(RNTupleShow, Vectors)
 
       *fieldIntVec = std::vector<int>{4, 5, 6};
       *fieldFloatVecVec = std::vector<std::vector<float>>{std::vector<float>{0.1, 0.2}, std::vector<float>{1.1, 1.2}};
-      *fieldBoolVecVec = std::vector<std::vector<bool>>{std::vector<bool>{false, true, false}, std::vector<bool>{false, true}, std::vector<bool>{true, false, false }};
+      *fieldBoolVecVec = std::vector<std::vector<bool>>{
+         std::vector<bool>{false, true, false}, std::vector<bool>{false, true}, std::vector<bool>{true, false, false}};
       ntuple->Fill();
 
       fieldIntVec->emplace_back(7);
@@ -131,22 +115,17 @@ TEST(RNTupleShow, Vectors)
 
    std::ostringstream os;
    ntuple2->Show(0, ROOT::Experimental::ENTupleShowFormat::kCurrentModelJSON, os);
-   std::string fString{ std::string("")
-      + "{\n"
-      + "  \"intVec\": [4, 5, 6],\n"
-      + "  \"floatVecVec\": [[0.1, 0.2], [1.1, 1.2]],\n"
-      + "  \"booleanVecVec\": [[false, true, false], [false, true], [true, false, false]]\n"
-      + "}\n" };
+   std::string fString{std::string("") + "{\n" + "  \"intVec\": [4, 5, 6],\n" +
+                       "  \"floatVecVec\": [[0.1, 0.2], [1.1, 1.2]],\n" +
+                       "  \"booleanVecVec\": [[false, true, false], [false, true], [true, false, false]]\n" + "}\n"};
    EXPECT_EQ(fString, os.str());
 
    std::ostringstream os1;
    ntuple2->Show(1, ROOT::Experimental::ENTupleShowFormat::kCurrentModelJSON, os1);
-   std::string fString1{ std::string("")
-      + "{\n"
-      + "  \"intVec\": [4, 5, 6, 7],\n"
-      + "  \"floatVecVec\": [[0.1, 0.2], [1.1, 1.2], [2.2, 2.3]],\n"
-      + "  \"booleanVecVec\": [[false, true, false], [false, true], [true, false, false], [false, true]]\n"
-      + "}\n" };
+   std::string fString1{
+      std::string("") + "{\n" + "  \"intVec\": [4, 5, 6, 7],\n" +
+      "  \"floatVecVec\": [[0.1, 0.2], [1.1, 1.2], [2.2, 2.3]],\n" +
+      "  \"booleanVecVec\": [[false, true, false], [false, true], [true, false, false], [false, true]]\n" + "}\n"};
    EXPECT_EQ(fString1, os1.str());
 }
 
@@ -167,18 +146,22 @@ TEST(RNTupleShow, Arrays)
 
       *Intarrayfield = {1, 3};
       *Floatarrayfield = {3.5f, 4.6f, 5.7f};
-      *Vecarrayfield = {std::vector<double>{1, 2}, std::vector<double>{4, 5}, std::vector<double>{7, 8, 9}, std::vector<double>{11} };
+      *Vecarrayfield = {std::vector<double>{1, 2}, std::vector<double>{4, 5}, std::vector<double>{7, 8, 9},
+                        std::vector<double>{11}};
       *StringArray = {"First", "Second"};
-      *arrayOfArray = { std::array<bool,2>{ true, false }, std::array<bool,2>{ false, true }, std::array<bool,2>{ false, false } };
-      *arrayVecfield = { std::array<float, 2>{ 0, 1 }, std::array<float, 2>{ 2, 3 }, std::array<float, 2>{ 4, 5 } };
+      *arrayOfArray = {std::array<bool, 2>{true, false}, std::array<bool, 2>{false, true},
+                       std::array<bool, 2>{false, false}};
+      *arrayVecfield = {std::array<float, 2>{0, 1}, std::array<float, 2>{2, 3}, std::array<float, 2>{4, 5}};
       ntuple->Fill();
 
       *Intarrayfield = {2, 5};
       *Floatarrayfield = {2.3f, 5.7f, 11.13f};
-      *Vecarrayfield = {std::vector<double>{17, 19}, std::vector<double>{23, 29}, std::vector<double>{31, 37, 41}, std::vector<double>{43} };
+      *Vecarrayfield = {std::vector<double>{17, 19}, std::vector<double>{23, 29}, std::vector<double>{31, 37, 41},
+                        std::vector<double>{43}};
       *StringArray = {"Third", "Fourth"};
-      *arrayOfArray = { std::array<bool,2>{ true, true }, std::array<bool,2>{ false, true }, std::array<bool,2>{ true, true } };
-      *arrayVecfield = { std::array<float, 2>{ 6, 7 }, std::array<float, 2>{ 8, 9 } };
+      *arrayOfArray = {std::array<bool, 2>{true, true}, std::array<bool, 2>{false, true},
+                       std::array<bool, 2>{true, true}};
+      *arrayVecfield = {std::array<float, 2>{6, 7}, std::array<float, 2>{8, 9}};
       ntuple->Fill();
    }
    auto model2 = RNTupleModel::Create();
@@ -192,28 +175,21 @@ TEST(RNTupleShow, Arrays)
 
    std::ostringstream os;
    ntuple2->Show(0, ROOT::Experimental::ENTupleShowFormat::kCurrentModelJSON, os);
-   std::string fString{ std::string("")
-      + "{\n"
-      + "  \"IntArray\": [1, 3],\n"
-      + "  \"FloatArray\": [3.5, 4.6, 5.7],\n"
-      + "  \"ArrayOfVec\": [[1, 2], [4, 5], [7, 8, 9], [11]],\n"
-      + "  \"stringArray\": [\"First\", \"Second\"],\n"
-      + "  \"ArrayOfArray\": [[true, false], [false, true], [false, false]],\n"
-      + "  \"VecOfArray\": [[0, 1], [2, 3], [4, 5]]\n"
-      + "}\n"};
+   std::string fString{std::string("") + "{\n" + "  \"IntArray\": [1, 3],\n" + "  \"FloatArray\": [3.5, 4.6, 5.7],\n" +
+                       "  \"ArrayOfVec\": [[1, 2], [4, 5], [7, 8, 9], [11]],\n" +
+                       "  \"stringArray\": [\"First\", \"Second\"],\n" +
+                       "  \"ArrayOfArray\": [[true, false], [false, true], [false, false]],\n" +
+                       "  \"VecOfArray\": [[0, 1], [2, 3], [4, 5]]\n" + "}\n"};
    EXPECT_EQ(fString, os.str());
 
    std::ostringstream os1;
    ntuple2->Show(1, ROOT::Experimental::ENTupleShowFormat::kCurrentModelJSON, os1);
-   std::string fString1{ std::string("")
-      + "{\n"
-      + "  \"IntArray\": [2, 5],\n"
-      + "  \"FloatArray\": [2.3, 5.7, 11.13],\n"
-      + "  \"ArrayOfVec\": [[17, 19], [23, 29], [31, 37, 41], [43]],\n"
-      + "  \"stringArray\": [\"Third\", \"Fourth\"],\n"
-      + "  \"ArrayOfArray\": [[true, true], [false, true], [true, true]],\n"
-      + "  \"VecOfArray\": [[6, 7], [8, 9]]\n"
-      + "}\n"};
+   std::string fString1{std::string("") + "{\n" + "  \"IntArray\": [2, 5],\n" +
+                        "  \"FloatArray\": [2.3, 5.7, 11.13],\n" +
+                        "  \"ArrayOfVec\": [[17, 19], [23, 29], [31, 37, 41], [43]],\n" +
+                        "  \"stringArray\": [\"Third\", \"Fourth\"],\n" +
+                        "  \"ArrayOfArray\": [[true, true], [false, true], [true, true]],\n" +
+                        "  \"VecOfArray\": [[6, 7], [8, 9]]\n" + "}\n"};
    EXPECT_EQ(fString1, os1.str());
 }
 
@@ -230,16 +206,21 @@ TEST(RNTupleShow, Objects)
       auto derivedAfield = model->MakeField<DerivedA>("DerivedA");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, rootFileName);
 
-      *customStructfield = CustomStruct{4.1f, std::vector<float>{0.1f, 0.2f, 0.3f}, std::vector<std::vector<float>>{{1.1f, 1.2f, 1.3f}, {2.1f, 2.2f, 2.3f}}, "Example1String"};
+      *customStructfield =
+         CustomStruct{4.1f, std::vector<float>{0.1f, 0.2f, 0.3f},
+                      std::vector<std::vector<float>>{{1.1f, 1.2f, 1.3f}, {2.1f, 2.2f, 2.3f}}, "Example1String"};
       *customStructVec = {
-         CustomStruct{4.2f, std::vector<float>{0.1f, 0.2f, 0.3f}, std::vector<std::vector<float>>{{1.1f, 1.3f}, {2.1f, 2.2f, 2.3f}}, "Example2String"},
-         CustomStruct{4.3f, std::vector<float>{0.1f, 0.2f, 0.3f}, std::vector<std::vector<float>>{{1.1f, 1.2f, 1.3f}, {2.1f, 2.3f}}, "Example3String"},
-         CustomStruct{4.4f, std::vector<float>{0.1f, 0.3f}, std::vector<std::vector<float>>{{1.1f, 1.2f, 1.3f}, {2.1f, 2.2f, 2.3f}}, "Example4String"}
-      };
+         CustomStruct{4.2f, std::vector<float>{0.1f, 0.2f, 0.3f},
+                      std::vector<std::vector<float>>{{1.1f, 1.3f}, {2.1f, 2.2f, 2.3f}}, "Example2String"},
+         CustomStruct{4.3f, std::vector<float>{0.1f, 0.2f, 0.3f},
+                      std::vector<std::vector<float>>{{1.1f, 1.2f, 1.3f}, {2.1f, 2.3f}}, "Example3String"},
+         CustomStruct{4.4f, std::vector<float>{0.1f, 0.3f},
+                      std::vector<std::vector<float>>{{1.1f, 1.2f, 1.3f}, {2.1f, 2.2f, 2.3f}}, "Example4String"}};
       *customStructArray = {
-      CustomStruct{4.5f, std::vector<float>{0.1f, 0.2f, 0.3f}, std::vector<std::vector<float>>{{1.1f, 1.3f}, {2.1f, 2.2f, 2.3f}}, "AnotherString1"},
-      CustomStruct{4.6f, std::vector<float>{0.1f, 0.2f, 0.3f}, std::vector<std::vector<float>>{{1.1f, 1.2f, 1.3f}, {2.1f, 2.3f}}, "AnotherString2"}
-      };
+         CustomStruct{4.5f, std::vector<float>{0.1f, 0.2f, 0.3f},
+                      std::vector<std::vector<float>>{{1.1f, 1.3f}, {2.1f, 2.2f, 2.3f}}, "AnotherString1"},
+         CustomStruct{4.6f, std::vector<float>{0.1f, 0.2f, 0.3f},
+                      std::vector<std::vector<float>>{{1.1f, 1.2f, 1.3f}, {2.1f, 2.3f}}, "AnotherString2"}};
       *derivedAfield = {};
       ntuple->Fill();
    }
@@ -252,36 +233,21 @@ TEST(RNTupleShow, Objects)
 
    std::ostringstream os;
    ntuple2->Show(0, ROOT::Experimental::ENTupleShowFormat::kCurrentModelJSON, os);
-   std::string fString{ std::string("")
-      + "{\n"
-      + "  \"CustomStruct\": {\n"
-      + "    \"a\": 4.1,\n"
-      + "    \"v1\": [0.1, 0.2, 0.3],\n"
-      + "    \"v2\": [[1.1, 1.2, 1.3], [2.1, 2.2, 2.3]],\n"
-      + "    \"s\": \"Example1String\"\n"
-      + "  },\n"
-      + "  \"CustomStructVec\": [{\"a\": 4.2, \"v1\": [0.1, 0.2, 0.3], \"v2\": [[1.1, 1.3], [2.1, 2.2, 2.3]], "
-      +      "\"s\": \"Example2String\"}, {\"a\": 4.3, \"v1\": [0.1, 0.2, 0.3], "
-      +      "\"v2\": [[1.1, 1.2, 1.3], [2.1, 2.3]], \"s\": \"Example3String\"}, "
-      +      "{\"a\": 4.4, \"v1\": [0.1, 0.3], \"v2\": [[1.1, 1.2, 1.3], [2.1, 2.2, 2.3]], "
-      +      "\"s\": \"Example4String\"}],\n"
-      + "  \"CustomStructArray\": [{\"a\": 4.5, \"v1\": [0.1, 0.2, 0.3], \"v2\": [[1.1, 1.3], [2.1, 2.2, 2.3]], "
-      +      "\"s\": \"AnotherString1\"}, {\"a\": 4.6, \"v1\": [0.1, 0.2, 0.3], "
-      +      "\"v2\": [[1.1, 1.2, 1.3], [2.1, 2.3]], \"s\": \"AnotherString2\"}],\n"
-      + "  \"DerivedA\": {\n"
-      + "    \":_0\": {\n"
-      + "      \"a\": 0,\n"
-      + "      \"v1\": [],\n"
-      + "      \"v2\": [],\n"
-      + "      \"s\": \"\"\n"
-      + "    },\n"
-      + "    \"a_v\": [],\n"
-      + "    \"a_s\": \"\"\n"
-      + "  }\n"
-      + "}\n" };
+   std::string fString{
+      std::string("") + "{\n" + "  \"CustomStruct\": {\n" + "    \"a\": 4.1,\n" + "    \"v1\": [0.1, 0.2, 0.3],\n" +
+      "    \"v2\": [[1.1, 1.2, 1.3], [2.1, 2.2, 2.3]],\n" + "    \"s\": \"Example1String\"\n" + "  },\n" +
+      "  \"CustomStructVec\": [{\"a\": 4.2, \"v1\": [0.1, 0.2, 0.3], \"v2\": [[1.1, 1.3], [2.1, 2.2, 2.3]], " +
+      "\"s\": \"Example2String\"}, {\"a\": 4.3, \"v1\": [0.1, 0.2, 0.3], " +
+      "\"v2\": [[1.1, 1.2, 1.3], [2.1, 2.3]], \"s\": \"Example3String\"}, " +
+      "{\"a\": 4.4, \"v1\": [0.1, 0.3], \"v2\": [[1.1, 1.2, 1.3], [2.1, 2.2, 2.3]], " +
+      "\"s\": \"Example4String\"}],\n" +
+      "  \"CustomStructArray\": [{\"a\": 4.5, \"v1\": [0.1, 0.2, 0.3], \"v2\": [[1.1, 1.3], [2.1, 2.2, 2.3]], " +
+      "\"s\": \"AnotherString1\"}, {\"a\": 4.6, \"v1\": [0.1, 0.2, 0.3], " +
+      "\"v2\": [[1.1, 1.2, 1.3], [2.1, 2.3]], \"s\": \"AnotherString2\"}],\n" + "  \"DerivedA\": {\n" +
+      "    \":_0\": {\n" + "      \"a\": 0,\n" + "      \"v1\": [],\n" + "      \"v2\": [],\n" + "      \"s\": \"\"\n" +
+      "    },\n" + "    \"a_v\": [],\n" + "    \"a_s\": \"\"\n" + "  }\n" + "}\n"};
    EXPECT_EQ(fString, os.str());
 }
-
 
 TEST(RNTupleShow, Collections)
 {
@@ -302,29 +268,28 @@ TEST(RNTupleShow, Collections)
       *float_field = 20.0;
       collection->Fill();
       ntuple->Fill();
-    }
+   }
 
    auto ntuple = RNTupleReader::Open(ntupleName, rootFileName);
    std::ostringstream osData;
    ntuple->Show(0, ROOT::Experimental::ENTupleShowFormat::kCompleteJSON, osData);
-   std::string outputData{ std::string("")
-      + "{\n"
-      + "  \"collection\": [{\"myInt\": 0, \"myFloat\": 10}, {\"myInt\": 1, \"myFloat\": 20}]\n"
-      + "}\n" };
+   std::string outputData{std::string("") + "{\n" +
+                          "  \"collection\": [{\"myInt\": 0, \"myFloat\": 10}, {\"myInt\": 1, \"myFloat\": 20}]\n" +
+                          "}\n"};
    EXPECT_EQ(outputData, osData.str());
 
    std::ostringstream osFields;
    ntuple->PrintInfo(ROOT::Experimental::ENTupleInfo::kSummary, osFields);
-   std::string outputFields{ std::string("")
-      + "************************************ NTUPLE ************************************\n"
-      + "* N-Tuple : Collections                                                        *\n"
-      + "* Entries : 1                                                                  *\n"
-      + "********************************************************************************\n"
-      + "* Field 1           : collection (std::vector<>)                               *\n"
-      + "*   Field 1.1       : _0                                                       *\n"
-      + "*     Field 1.1.1   : myInt (std::int32_t)                                     *\n"
-      + "*     Field 1.1.2   : myFloat (float)                                          *\n"
-      + "********************************************************************************\n" };
+   std::string outputFields{std::string("") +
+                            "************************************ NTUPLE ************************************\n" +
+                            "* N-Tuple : Collections                                                        *\n" +
+                            "* Entries : 1                                                                  *\n" +
+                            "********************************************************************************\n" +
+                            "* Field 1           : collection (std::vector<>)                               *\n" +
+                            "*   Field 1.1       : _0                                                       *\n" +
+                            "*     Field 1.1.1   : myInt (std::int32_t)                                     *\n" +
+                            "*     Field 1.1.2   : myFloat (float)                                          *\n" +
+                            "********************************************************************************\n"};
    EXPECT_EQ(outputFields, osFields.str());
 }
 
@@ -462,4 +427,35 @@ TEST(RNTupleShow, CollectionProxy)
       std::string expected{"{\n  \"proxyF\": [42, 24],\n  \"vecProxyF\": [[1, 2], [1, 2]]\n}\n"};
       EXPECT_EQ(os.str(), expected);
    }
+}
+
+TEST(RNTupleShow, CompleteOrCurrentModel)
+{
+   FileRaii fileGuard("test_ntuple_show_completeorcurrentmodel.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto fldInt = model->MakeField<int>("int");
+      auto fldFloat = model->MakeField<float>("float");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "f", fileGuard.GetPath());
+
+      *fldInt = 42;
+      *fldFloat = 3.14;
+      *fldFloat = ntuple->Fill();
+   }
+
+   auto ntuple1 = RNTupleReader::Open("f", fileGuard.GetPath());
+
+   auto model = RNTupleModel::Create();
+   auto fldInt = model->MakeField<int>("int");
+   auto ntuple2 = RNTupleReader::Open(std::move(model), "f", fileGuard.GetPath());
+
+   std::ostringstream os1;
+   ntuple1->Show(0, ROOT::Experimental::ENTupleShowFormat::kCompleteUnlessCurrentJSON, os1);
+   std::string expected1{"{\n  \"int\": 42,\n  \"float\": 3.14\n}\n"};
+   EXPECT_EQ(expected1, os1.str());
+
+   std::ostringstream os2;
+   ntuple2->Show(0, ROOT::Experimental::ENTupleShowFormat::kCompleteUnlessCurrentJSON, os2);
+   std::string expected2{"{\n  \"int\": 42\n}\n"};
+   EXPECT_EQ(expected2, os2.str());
 }

--- a/tree/ntuple/v7/test/ntuple_show.cxx
+++ b/tree/ntuple/v7/test/ntuple_show.cxx
@@ -68,16 +68,36 @@ TEST(RNTupleShow, BasicTypes)
 
    std::ostringstream os;
    ntuple2->Show(0, ROOT::Experimental::ENTupleShowFormat::kCompleteJSON, os);
-   std::string fString{std::string("") + "{\n" + "  \"pt\": 5,\n" + "  \"db\": 9.99,\n" + "  \"int\": -4,\n" +
-                       "  \"uint\": 3,\n" + "  \"uint64\": 44444444444,\n" + "  \"string\": \"TestString\",\n" +
-                       "  \"boolean\": true,\n" + "  \"uint8\": 97\n" + "}\n"};
+   // clang-format off
+   std::string fString{ std::string("")
+      + "{\n"
+      + "  \"pt\": 5,\n"
+      + "  \"db\": 9.99,\n"
+      + "  \"int\": -4,\n"
+      + "  \"uint\": 3,\n"
+      + "  \"uint64\": 44444444444,\n"
+      + "  \"string\": \"TestString\",\n"
+      + "  \"boolean\": true,\n"
+      + "  \"uint8\": 97\n"
+      + "}\n" };
+   // clang-format on
    EXPECT_EQ(fString, os.str());
 
    std::ostringstream os1;
    ntuple2->Show(1, ROOT::Experimental::ENTupleShowFormat::kCompleteJSON, os1);
-   std::string fString1{std::string("") + "{\n" + "  \"pt\": 8.5,\n" + "  \"db\": 9.998,\n" + "  \"int\": -94,\n" +
-                        "  \"uint\": 4294967266,\n" + "  \"uint64\": 2299994967294,\n" +
-                        "  \"string\": \"TestString2\",\n" + "  \"boolean\": false,\n" + "  \"uint8\": 98\n" + "}\n"};
+   // clang-format off
+   std::string fString1{ std::string("")
+      + "{\n"
+      + "  \"pt\": 8.5,\n"
+      + "  \"db\": 9.998,\n"
+      + "  \"int\": -94,\n"
+      + "  \"uint\": 4294967266,\n"
+      + "  \"uint64\": 2299994967294,\n"
+      + "  \"string\": \"TestString2\",\n"
+      + "  \"boolean\": false,\n"
+      + "  \"uint8\": 98\n"
+      + "}\n" };
+   // clang-format on
    EXPECT_EQ(fString1, os1.str());
 
    // TODO(jblomer): this should fail to an exception instead
@@ -115,17 +135,26 @@ TEST(RNTupleShow, Vectors)
 
    std::ostringstream os;
    ntuple2->Show(0, ROOT::Experimental::ENTupleShowFormat::kCurrentModelJSON, os);
-   std::string fString{std::string("") + "{\n" + "  \"intVec\": [4, 5, 6],\n" +
-                       "  \"floatVecVec\": [[0.1, 0.2], [1.1, 1.2]],\n" +
-                       "  \"booleanVecVec\": [[false, true, false], [false, true], [true, false, false]]\n" + "}\n"};
+   // clang-format off
+   std::string fString{ std::string("")
+      + "{\n"
+      + "  \"intVec\": [4, 5, 6],\n"
+      + "  \"floatVecVec\": [[0.1, 0.2], [1.1, 1.2]],\n"
+      + "  \"booleanVecVec\": [[false, true, false], [false, true], [true, false, false]]\n"
+      + "}\n" };
+   // clang-format on
    EXPECT_EQ(fString, os.str());
 
    std::ostringstream os1;
    ntuple2->Show(1, ROOT::Experimental::ENTupleShowFormat::kCurrentModelJSON, os1);
-   std::string fString1{
-      std::string("") + "{\n" + "  \"intVec\": [4, 5, 6, 7],\n" +
-      "  \"floatVecVec\": [[0.1, 0.2], [1.1, 1.2], [2.2, 2.3]],\n" +
-      "  \"booleanVecVec\": [[false, true, false], [false, true], [true, false, false], [false, true]]\n" + "}\n"};
+   // clang-format off
+   std::string fString1{ std::string("")
+      + "{\n"
+      + "  \"intVec\": [4, 5, 6, 7],\n"
+      + "  \"floatVecVec\": [[0.1, 0.2], [1.1, 1.2], [2.2, 2.3]],\n"
+      + "  \"booleanVecVec\": [[false, true, false], [false, true], [true, false, false], [false, true]]\n"
+      + "}\n" };
+   // clang-format on
    EXPECT_EQ(fString1, os1.str());
 }
 
@@ -175,21 +204,32 @@ TEST(RNTupleShow, Arrays)
 
    std::ostringstream os;
    ntuple2->Show(0, ROOT::Experimental::ENTupleShowFormat::kCurrentModelJSON, os);
-   std::string fString{std::string("") + "{\n" + "  \"IntArray\": [1, 3],\n" + "  \"FloatArray\": [3.5, 4.6, 5.7],\n" +
-                       "  \"ArrayOfVec\": [[1, 2], [4, 5], [7, 8, 9], [11]],\n" +
-                       "  \"stringArray\": [\"First\", \"Second\"],\n" +
-                       "  \"ArrayOfArray\": [[true, false], [false, true], [false, false]],\n" +
-                       "  \"VecOfArray\": [[0, 1], [2, 3], [4, 5]]\n" + "}\n"};
+   // clang-format off
+   std::string fString{ std::string("")
+      + "{\n"
+      + "  \"IntArray\": [1, 3],\n"
+      + "  \"FloatArray\": [3.5, 4.6, 5.7],\n"
+      + "  \"ArrayOfVec\": [[1, 2], [4, 5], [7, 8, 9], [11]],\n"
+      + "  \"stringArray\": [\"First\", \"Second\"],\n"
+      + "  \"ArrayOfArray\": [[true, false], [false, true], [false, false]],\n"
+      + "  \"VecOfArray\": [[0, 1], [2, 3], [4, 5]]\n"
+      + "}\n"};
+   // clang-format on
    EXPECT_EQ(fString, os.str());
 
    std::ostringstream os1;
    ntuple2->Show(1, ROOT::Experimental::ENTupleShowFormat::kCurrentModelJSON, os1);
-   std::string fString1{std::string("") + "{\n" + "  \"IntArray\": [2, 5],\n" +
-                        "  \"FloatArray\": [2.3, 5.7, 11.13],\n" +
-                        "  \"ArrayOfVec\": [[17, 19], [23, 29], [31, 37, 41], [43]],\n" +
-                        "  \"stringArray\": [\"Third\", \"Fourth\"],\n" +
-                        "  \"ArrayOfArray\": [[true, true], [false, true], [true, true]],\n" +
-                        "  \"VecOfArray\": [[6, 7], [8, 9]]\n" + "}\n"};
+   // clang-format off
+   std::string fString1{ std::string("")
+      + "{\n"
+      + "  \"IntArray\": [2, 5],\n"
+      + "  \"FloatArray\": [2.3, 5.7, 11.13],\n"
+      + "  \"ArrayOfVec\": [[17, 19], [23, 29], [31, 37, 41], [43]],\n"
+      + "  \"stringArray\": [\"Third\", \"Fourth\"],\n"
+      + "  \"ArrayOfArray\": [[true, true], [false, true], [true, true]],\n"
+      + "  \"VecOfArray\": [[6, 7], [8, 9]]\n"
+      + "}\n"};
+   // clang-format on
    EXPECT_EQ(fString1, os1.str());
 }
 
@@ -233,19 +273,35 @@ TEST(RNTupleShow, Objects)
 
    std::ostringstream os;
    ntuple2->Show(0, ROOT::Experimental::ENTupleShowFormat::kCurrentModelJSON, os);
-   std::string fString{
-      std::string("") + "{\n" + "  \"CustomStruct\": {\n" + "    \"a\": 4.1,\n" + "    \"v1\": [0.1, 0.2, 0.3],\n" +
-      "    \"v2\": [[1.1, 1.2, 1.3], [2.1, 2.2, 2.3]],\n" + "    \"s\": \"Example1String\"\n" + "  },\n" +
-      "  \"CustomStructVec\": [{\"a\": 4.2, \"v1\": [0.1, 0.2, 0.3], \"v2\": [[1.1, 1.3], [2.1, 2.2, 2.3]], " +
-      "\"s\": \"Example2String\"}, {\"a\": 4.3, \"v1\": [0.1, 0.2, 0.3], " +
-      "\"v2\": [[1.1, 1.2, 1.3], [2.1, 2.3]], \"s\": \"Example3String\"}, " +
-      "{\"a\": 4.4, \"v1\": [0.1, 0.3], \"v2\": [[1.1, 1.2, 1.3], [2.1, 2.2, 2.3]], " +
-      "\"s\": \"Example4String\"}],\n" +
-      "  \"CustomStructArray\": [{\"a\": 4.5, \"v1\": [0.1, 0.2, 0.3], \"v2\": [[1.1, 1.3], [2.1, 2.2, 2.3]], " +
-      "\"s\": \"AnotherString1\"}, {\"a\": 4.6, \"v1\": [0.1, 0.2, 0.3], " +
-      "\"v2\": [[1.1, 1.2, 1.3], [2.1, 2.3]], \"s\": \"AnotherString2\"}],\n" + "  \"DerivedA\": {\n" +
-      "    \":_0\": {\n" + "      \"a\": 0,\n" + "      \"v1\": [],\n" + "      \"v2\": [],\n" + "      \"s\": \"\"\n" +
-      "    },\n" + "    \"a_v\": [],\n" + "    \"a_s\": \"\"\n" + "  }\n" + "}\n"};
+   // clang-format off
+   std::string fString{ std::string("")
+      + "{\n"
+      + "  \"CustomStruct\": {\n"
+      + "    \"a\": 4.1,\n"
+      + "    \"v1\": [0.1, 0.2, 0.3],\n"
+      + "    \"v2\": [[1.1, 1.2, 1.3], [2.1, 2.2, 2.3]],\n"
+      + "    \"s\": \"Example1String\"\n"
+      + "  },\n"
+      + "  \"CustomStructVec\": [{\"a\": 4.2, \"v1\": [0.1, 0.2, 0.3], \"v2\": [[1.1, 1.3], [2.1, 2.2, 2.3]], "
+      +      "\"s\": \"Example2String\"}, {\"a\": 4.3, \"v1\": [0.1, 0.2, 0.3], "
+      +      "\"v2\": [[1.1, 1.2, 1.3], [2.1, 2.3]], \"s\": \"Example3String\"}, "
+      +      "{\"a\": 4.4, \"v1\": [0.1, 0.3], \"v2\": [[1.1, 1.2, 1.3], [2.1, 2.2, 2.3]], "
+      +      "\"s\": \"Example4String\"}],\n"
+      + "  \"CustomStructArray\": [{\"a\": 4.5, \"v1\": [0.1, 0.2, 0.3], \"v2\": [[1.1, 1.3], [2.1, 2.2, 2.3]], "
+      +      "\"s\": \"AnotherString1\"}, {\"a\": 4.6, \"v1\": [0.1, 0.2, 0.3], "
+      +      "\"v2\": [[1.1, 1.2, 1.3], [2.1, 2.3]], \"s\": \"AnotherString2\"}],\n"
+      + "  \"DerivedA\": {\n"
+      + "    \":_0\": {\n"
+      + "      \"a\": 0,\n"
+      + "      \"v1\": [],\n"
+      + "      \"v2\": [],\n"
+      + "      \"s\": \"\"\n"
+      + "    },\n"
+      + "    \"a_v\": [],\n"
+      + "    \"a_s\": \"\"\n"
+      + "  }\n"
+      + "}\n" };
+   // clang-format on
    EXPECT_EQ(fString, os.str());
 }
 
@@ -273,23 +329,28 @@ TEST(RNTupleShow, Collections)
    auto ntuple = RNTupleReader::Open(ntupleName, rootFileName);
    std::ostringstream osData;
    ntuple->Show(0, ROOT::Experimental::ENTupleShowFormat::kCompleteJSON, osData);
-   std::string outputData{std::string("") + "{\n" +
-                          "  \"collection\": [{\"myInt\": 0, \"myFloat\": 10}, {\"myInt\": 1, \"myFloat\": 20}]\n" +
-                          "}\n"};
+   // clang-format off
+   std::string outputData{ std::string("")
+      + "{\n"
+      + "  \"collection\": [{\"myInt\": 0, \"myFloat\": 10}, {\"myInt\": 1, \"myFloat\": 20}]\n"
+      + "}\n" };
+   // clang-format on
    EXPECT_EQ(outputData, osData.str());
 
    std::ostringstream osFields;
    ntuple->PrintInfo(ROOT::Experimental::ENTupleInfo::kSummary, osFields);
-   std::string outputFields{std::string("") +
-                            "************************************ NTUPLE ************************************\n" +
-                            "* N-Tuple : Collections                                                        *\n" +
-                            "* Entries : 1                                                                  *\n" +
-                            "********************************************************************************\n" +
-                            "* Field 1           : collection (std::vector<>)                               *\n" +
-                            "*   Field 1.1       : _0                                                       *\n" +
-                            "*     Field 1.1.1   : myInt (std::int32_t)                                     *\n" +
-                            "*     Field 1.1.2   : myFloat (float)                                          *\n" +
-                            "********************************************************************************\n"};
+   // clang-format off
+   std::string outputFields{ std::string("")
+      + "************************************ NTUPLE ************************************\n"
+      + "* N-Tuple : Collections                                                        *\n"
+      + "* Entries : 1                                                                  *\n"
+      + "********************************************************************************\n"
+      + "* Field 1           : collection (std::vector<>)                               *\n"
+      + "*   Field 1.1       : _0                                                       *\n"
+      + "*     Field 1.1.1   : myInt (std::int32_t)                                     *\n"
+      + "*     Field 1.1.2   : myFloat (float)                                          *\n"
+      + "********************************************************************************\n" };
+   // clang-format on
    EXPECT_EQ(outputFields, osFields.str());
 }
 
@@ -323,18 +384,30 @@ TEST(RNTupleShow, RVec)
 
    std::ostringstream os;
    r->Show(0, ROOT::Experimental::ENTupleShowFormat::kCurrentModelJSON, os);
-   std::string expected =
-      "{\n  \"intVec\": [1, 2, 3],\n  \"floatVecVec\": [[0.1, 0.2], [1.1, 1.2]],\n  \"customStructVec\": [{\"a\": 0, "
-      "\"v1\": [], \"v2\": [], \"s\": \"\"}, {\"a\": 1, \"v1\": [2, 3], \"v2\": [[4], [5]], \"s\": \"foo\"}]\n}\n";
-   EXPECT_EQ(os.str(), expected);
+   // clang-format off
+   std::string expected1{std::string("")
+      + "{\n"
+      + "  \"intVec\": [1, 2, 3],\n"
+      + "  \"floatVecVec\": [[0.1, 0.2], [1.1, 1.2]],\n"
+      + "  \"customStructVec\": [{\"a\": 0, \"v1\": [], \"v2\": [], \"s\": \"\"},"
+      + " {\"a\": 1, \"v1\": [2, 3], \"v2\": [[4], [5]], \"s\": \"foo\"}]\n"
+      + "}\n"};
+   // clang-format on
+   EXPECT_EQ(os.str(), expected1);
 
    std::ostringstream os2;
    r->Show(1, ROOT::Experimental::ENTupleShowFormat::kCurrentModelJSON, os2);
-   expected =
-      "{\n  \"intVec\": [1, 2, 3, 4],\n  \"floatVecVec\": [[0.1, 0.2], [1.1, 1.2], [2.1, 2.2]],\n  "
-      "\"customStructVec\": [{\"a\": 0, \"v1\": [], \"v2\": [], \"s\": \"\"}, {\"a\": 1, \"v1\": [2, 3], \"v2\": [[4], "
-      "[5]], \"s\": \"foo\"}, {\"a\": 6, \"v1\": [7, 8], \"v2\": [[9], [10]], \"s\": \"bar\"}]\n}\n";
-   EXPECT_EQ(os2.str(), expected);
+   // clang-format off
+   std::string expected2{std::string("")
+      + "{\n"
+      + "  \"intVec\": [1, 2, 3, 4],\n"
+      + "  \"floatVecVec\": [[0.1, 0.2], [1.1, 1.2], [2.1, 2.2]],\n"
+      + "  \"customStructVec\": [{\"a\": 0, \"v1\": [], \"v2\": [], \"s\": \"\"},"
+      + " {\"a\": 1, \"v1\": [2, 3], \"v2\": [[4], [5]], \"s\": \"foo\"},"
+      + " {\"a\": 6, \"v1\": [7, 8], \"v2\": [[9], [10]], \"s\": \"bar\"}]\n"
+      + "}\n"};
+   // clang-format on
+   EXPECT_EQ(os2.str(), expected2);
 }
 
 TEST(RNTupleShow, RVecTypeErased)
@@ -378,21 +451,29 @@ TEST(RNTupleShow, RVecTypeErased)
 
    std::ostringstream os;
    ntuple->Show(0, ROOT::Experimental::ENTupleShowFormat::kCompleteJSON, os);
-   std::string fString{std::string("") + "{\n" + "  \"intVec\": [1, 2, 3],\n" +
-                       "  \"floatVecVec\": [[0.1, 0.2], [1.1, 1.2]],\n" +
-                       "  \"customStructVec\": [{\"a\": 0, \"v1\": [], \"v2\": [], \"s\": \"\"}, {\"a\": 1, \"v1\": "
-                       "[2, 3], \"v2\": [[4], [5]], \"s\": \"foo\"}]\n" +
-                       "}\n"};
+   // clang-format off
+   std::string fString{std::string("")
+      + "{\n"
+      + "  \"intVec\": [1, 2, 3],\n"
+      + "  \"floatVecVec\": [[0.1, 0.2], [1.1, 1.2]],\n"
+      + "  \"customStructVec\": [{\"a\": 0, \"v1\": [], \"v2\": [], \"s\": \"\"},"
+      + " {\"a\": 1, \"v1\": [2, 3], \"v2\": [[4], [5]], \"s\": \"foo\"}]\n"
+      + "}\n"};
+   // clang-format on
    EXPECT_EQ(fString, os.str());
 
    std::ostringstream os1;
    ntuple->Show(1, ROOT::Experimental::ENTupleShowFormat::kCompleteJSON, os1);
-   std::string fString1{
-      std::string("") + "{\n" + "  \"intVec\": [1, 2, 3, 4],\n" +
-      "  \"floatVecVec\": [[0.1, 0.2], [1.1, 1.2], [2.1, 2.2]],\n" +
-      "  \"customStructVec\": [{\"a\": 0, \"v1\": [], \"v2\": [], \"s\": \"\"}, {\"a\": 1, \"v1\": [2, 3], \"v2\": "
-      "[[4], [5]], \"s\": \"foo\"}, {\"a\": 6, \"v1\": [7, 8], \"v2\": [[9], [10]], \"s\": \"bar\"}]\n" +
-      "}\n"};
+   // clang-format off
+   std::string fString1{std::string("")
+      + "{\n"
+      + "  \"intVec\": [1, 2, 3, 4],\n"
+      + "  \"floatVecVec\": [[0.1, 0.2], [1.1, 1.2], [2.1, 2.2]],\n"
+      + "  \"customStructVec\": [{\"a\": 0, \"v1\": [], \"v2\": [], \"s\": \"\"},"
+      + " {\"a\": 1, \"v1\": [2, 3], \"v2\": [[4], [5]], \"s\": \"foo\"},"
+      + " {\"a\": 6, \"v1\": [7, 8], \"v2\": [[9], [10]], \"s\": \"bar\"}]\n"
+      + "}\n"};
+   // clang-format off
    EXPECT_EQ(fString1, os1.str());
 }
 
@@ -424,7 +505,13 @@ TEST(RNTupleShow, CollectionProxy)
 
       std::ostringstream os;
       ntuple->Show(0, ROOT::Experimental::ENTupleShowFormat::kCompleteJSON, os);
-      std::string expected{"{\n  \"proxyF\": [42, 24],\n  \"vecProxyF\": [[1, 2], [1, 2]]\n}\n"};
+      // clang-format off
+      std::string expected{std::string("")
+         + "{\n"
+         + "  \"proxyF\": [42, 24],\n"
+         + "  \"vecProxyF\": [[1, 2], [1, 2]]\n"
+         + "}\n"};
+      // clang-format on
       EXPECT_EQ(os.str(), expected);
    }
 }
@@ -451,11 +538,22 @@ TEST(RNTupleShow, CompleteOrCurrentModel)
 
    std::ostringstream os1;
    ntuple1->Show(0, ROOT::Experimental::ENTupleShowFormat::kCurrentModelJSON, os1);
-   std::string expected1{"{\n  \"int\": 42,\n  \"float\": 3.14\n}\n"};
+   // clang-format off
+   std::string expected1{std::string("")
+      + "{\n"
+      + "  \"int\": 42,\n"
+      + "  \"float\": 3.14\n"
+      + "}\n"};
+   // clang-format on
    EXPECT_EQ(expected1, os1.str());
 
    std::ostringstream os2;
    ntuple2->Show(0, ROOT::Experimental::ENTupleShowFormat::kCurrentModelJSON, os2);
-   std::string expected2{"{\n  \"int\": 42\n}\n"};
+   // clang-format off
+   std::string expected2{std::string("")
+      + "{\n"
+      + "  \"int\": 42\n"
+      + "}\n"};
+   // clang-format on
    EXPECT_EQ(expected2, os2.str());
 }


### PR DESCRIPTION
This PR introduces a new format option for `RNTupleReader::Show()` that shows all fields if no model is specified, and only the fields present in the model if there is one. It also changes the default show format to this option.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)


