### PR TITLE
[RF] Add `cloneAndOwnDataHist()` method to RooHistFunc and RooHistPdf

### DIFF
--- a/roofit/roofitcore/inc/RooHistFunc.h
+++ b/roofit/roofitcore/inc/RooHistFunc.h
@@ -53,12 +53,7 @@ public:
 
   /// Replaces underlying RooDataHist with a clone, which is now owned, and returns the clone.
   /// If the underlying RooDataHist is already owned, then that is returned instead of being cloned.
-  RooDataHist* cloneAndOwnDataHist(const char* newname="") {
-     if (_ownedDataHist) return _ownedDataHist.get();
-     _ownedDataHist.reset(static_cast<RooDataHist*>(_dataHist->Clone(newname)));
-     _dataHist = _ownedDataHist.get();
-     return _dataHist;
-  }
+  RooDataHist* cloneAndOwnDataHist(const char* newname="");
 
   /// Get total bin volume spanned by this hist function.
   /// In 1-d, this is e.g. the range spanned on the x-axis.

--- a/roofit/roofitcore/inc/RooHistFunc.h
+++ b/roofit/roofitcore/inc/RooHistFunc.h
@@ -51,6 +51,15 @@ public:
     return *_dataHist ;
   }
 
+  /// Replaces underlying RooDataHist with a clone, which is now owned, and returns the clone.
+  /// If the underlying RooDataHist is already owned, then that is returned instead of being cloned.
+  RooDataHist* cloneAndOwnDataHist(const char* newname="") {
+     if (_ownedDataHist) return _ownedDataHist.get();
+     _ownedDataHist.reset(static_cast<RooDataHist*>(_dataHist->Clone(newname)));
+     _dataHist = _ownedDataHist.get();
+     return _dataHist;
+  }
+
   /// Get total bin volume spanned by this hist function.
   /// In 1-d, this is e.g. the range spanned on the x-axis.
   double totVolume() const;

--- a/roofit/roofitcore/inc/RooHistPdf.h
+++ b/roofit/roofitcore/inc/RooHistPdf.h
@@ -49,6 +49,15 @@ public:
     return *_dataHist ;
   }
 
+  /// Replaces underlying RooDataHist with a clone, which is now owned, and returns the clone.
+  /// If the underlying RooDataHist is already owned, then that is returned instead of being cloned.
+  RooDataHist* cloneAndOwnDataHist(const char* newname="") {
+     if (_ownedDataHist) return _ownedDataHist.get();
+     _ownedDataHist.reset(static_cast<RooDataHist*>(_dataHist->Clone(newname)));
+     _dataHist = _ownedDataHist.get();
+     return _dataHist;
+  }
+
   void setInterpolationOrder(Int_t order) {
     // Set histogram interpolation order
     _intOrder = order ;

--- a/roofit/roofitcore/inc/RooHistPdf.h
+++ b/roofit/roofitcore/inc/RooHistPdf.h
@@ -51,12 +51,7 @@ public:
 
   /// Replaces underlying RooDataHist with a clone, which is now owned, and returns the clone.
   /// If the underlying RooDataHist is already owned, then that is returned instead of being cloned.
-  RooDataHist* cloneAndOwnDataHist(const char* newname="") {
-     if (_ownedDataHist) return _ownedDataHist.get();
-     _ownedDataHist.reset(static_cast<RooDataHist*>(_dataHist->Clone(newname)));
-     _dataHist = _ownedDataHist.get();
-     return _dataHist;
-  }
+  RooDataHist* cloneAndOwnDataHist(const char* newname="");
 
   void setInterpolationOrder(Int_t order) {
     // Set histogram interpolation order

--- a/roofit/roofitcore/src/RooHistFunc.cxx
+++ b/roofit/roofitcore/src/RooHistFunc.cxx
@@ -258,6 +258,13 @@ double RooHistFunc::maxVal(Int_t code) const
   return max*1.05 ;
 }
 
+RooDataHist* RooHistFunc::cloneAndOwnDataHist(const char* newname) {
+   if (_ownedDataHist) return _ownedDataHist.get();
+   _ownedDataHist.reset(static_cast<RooDataHist*>(_dataHist->Clone(newname)));
+   _dataHist = _ownedDataHist.get();
+   return _dataHist;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Return the total volume spanned by the observables of the RooDataHist
 

--- a/roofit/roofitcore/src/RooHistPdf.cxx
+++ b/roofit/roofitcore/src/RooHistPdf.cxx
@@ -187,6 +187,12 @@ RooHistPdf::~RooHistPdf()
 
 }
 
+RooDataHist* RooHistPdf::cloneAndOwnDataHist(const char* newname) {
+   if (_ownedDataHist) return _ownedDataHist.get();
+   _ownedDataHist.reset(static_cast<RooDataHist*>(_dataHist->Clone(newname)));
+   _dataHist = _ownedDataHist.get();
+   return _dataHist;
+}
 
 void RooHistPdf::computeBatch(cudaStream_t*, double* output, size_t nEvents, RooFit::Detail::DataMap const& dataMap) const {
 


### PR DESCRIPTION
Explanation is in comments for new methods - allows underlying dataHist to be cloned if necessary to take ownership