### PR TITLE
[rntpl] Do not rely on transient include; unused member.

### DIFF
--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -31,6 +31,7 @@
 #include <TDataMember.h>
 #include <TError.h>
 #include <TList.h>
+#include <TObjArray.h>
 #include <TObjString.h>
 #include <TRealData.h>
 #include <TSchemaRule.h>

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -59,7 +59,6 @@ private:
    int fCompressionSettings;
    std::uint64_t fCompressedSize;
    std::uint64_t fUncompressedSize;
-   float fCompressionFactor;
 
    RNTupleInspector(std::unique_ptr<ROOT::Experimental::Detail::RPageSource> pageSource) : fPageSource(std::move(pageSource)) {};
 


### PR DESCRIPTION
Visible with `-Ddev=On` on macOS