### PR TITLE
[RF] New mechanism to implicitly convert numbers to RooFit arguments

### DIFF
--- a/roofit/roofit/inc/RooArgusBG.h
+++ b/roofit/roofit/inc/RooArgusBG.h
@@ -22,10 +22,16 @@
 class RooArgusBG : public RooAbsPdf {
 public:
   RooArgusBG() {} ;
+  // One of the original constructors without RooAbsReal::Ref for backwards compatibility.
+  inline RooArgusBG(const char *name, const char *title,
+        RooAbsReal& _m, RooAbsReal& _m0, RooAbsReal& _c, RooAbsReal& _p)
+      : RooArgusBG{name, title, RooAbsReal::Ref{_m}, RooAbsReal::Ref{_m0}, RooAbsReal::Ref{_c}, RooAbsReal::Ref{_p}} {}
+  // One of the original constructors without RooAbsReal::Ref for backwards compatibility.
+  inline RooArgusBG(const char *name, const char *title,
+        RooAbsReal& _m, RooAbsReal& _m0, RooAbsReal& _c)
+      : RooArgusBG{name, title, RooAbsReal::Ref{_m}, RooAbsReal::Ref{_m0}, RooAbsReal::Ref{_c}} {}
   RooArgusBG(const char *name, const char *title,
-        RooAbsReal& _m, RooAbsReal& _m0, RooAbsReal& _c);
-  RooArgusBG(const char *name, const char *title,
-        RooAbsReal& _m, RooAbsReal& _m0, RooAbsReal& _c, RooAbsReal& _p);
+        RooAbsReal::Ref _m, RooAbsReal::Ref _m0, RooAbsReal::Ref _c, RooAbsReal::Ref _p=0.5);
   RooArgusBG(const RooArgusBG& other,const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooArgusBG(*this,newname); }
   inline ~RooArgusBG() override { }

--- a/roofit/roofit/inc/RooGaussian.h
+++ b/roofit/roofit/inc/RooGaussian.h
@@ -24,8 +24,12 @@ class RooAbsReal;
 class RooGaussian : public RooAbsPdf {
 public:
   RooGaussian() { };
+  // Original constructor without RooAbsReal::Ref for backwards compatibility.
+  inline RooGaussian(const char *name, const char *title,
+         RooAbsReal& _x, RooAbsReal& _mean, RooAbsReal& _sigma)
+      : RooGaussian{name, title, RooAbsReal::Ref{_x}, RooAbsReal::Ref{_mean}, RooAbsReal::Ref{_sigma}} {}
   RooGaussian(const char *name, const char *title,
-         RooAbsReal& _x, RooAbsReal& _mean, RooAbsReal& _sigma);
+         RooAbsReal::Ref _x, RooAbsReal::Ref _mean, RooAbsReal::Ref _sigma);
   RooGaussian(const RooGaussian& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override {
     return new RooGaussian(*this,newname);

--- a/roofit/roofit/inc/RooLandau.h
+++ b/roofit/roofit/inc/RooLandau.h
@@ -24,7 +24,10 @@ class RooRealVar;
 class RooLandau : public RooAbsPdf {
 public:
   RooLandau() {} ;
-  RooLandau(const char *name, const char *title, RooAbsReal& _x, RooAbsReal& _mean, RooAbsReal& _sigma);
+  // Original constructor without RooAbsReal::Ref for backwards compatibility.
+  inline RooLandau(const char *name, const char *title, RooAbsReal& _x, RooAbsReal& _mean, RooAbsReal& _sigma)
+      : RooLandau{name, title, RooAbsReal::Ref{_x}, RooAbsReal::Ref{_mean}, RooAbsReal::Ref{_sigma}} {}
+  RooLandau(const char *name, const char *title, RooAbsReal::Ref _x, RooAbsReal::Ref _mean, RooAbsReal::Ref _sigma);
   RooLandau(const RooLandau& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooLandau(*this,newname); }
   inline ~RooLandau() override { }

--- a/roofit/roofit/inc/RooPoisson.h
+++ b/roofit/roofit/inc/RooPoisson.h
@@ -19,7 +19,10 @@
 class RooPoisson : public RooAbsPdf {
 public:
   RooPoisson() { _noRounding = false ;   } ;
-  RooPoisson(const char *name, const char *title, RooAbsReal& _x, RooAbsReal& _mean, bool noRounding=false);
+  // Original constructor without RooAbsReal::Ref for backwards compatibility.
+  inline RooPoisson(const char *name, const char *title, RooAbsReal& _x, RooAbsReal& _mean, bool noRounding=false)
+      : RooPoisson{name, title, RooAbsReal::Ref{_x}, RooAbsReal::Ref{_mean}, noRounding} {}
+  RooPoisson(const char *name, const char *title, RooAbsReal::Ref _x, RooAbsReal::Ref _mean, bool noRounding=false);
   RooPoisson(const RooPoisson& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooPoisson(*this,newname); }
   inline ~RooPoisson() override {  }

--- a/roofit/roofit/src/RooArgusBG.cxx
+++ b/roofit/roofit/src/RooArgusBG.cxx
@@ -42,20 +42,7 @@ ClassImp(RooArgusBG);
 /// Constructor.
 
 RooArgusBG::RooArgusBG(const char *name, const char *title,
-             RooAbsReal& _m, RooAbsReal& _m0, RooAbsReal& _c) :
-  RooAbsPdf(name, title),
-  m("m","Mass",this,_m),
-  m0("m0","Resonance mass",this,_m0),
-  c("c","Slope parameter",this,_c),
-  p("p","Power",this,(RooRealVar&)RooRealConstant::value(0.5))
-{
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor.
-
-RooArgusBG::RooArgusBG(const char *name, const char *title,
-             RooAbsReal& _m, RooAbsReal& _m0, RooAbsReal& _c, RooAbsReal& _p) :
+             RooAbsReal::Ref _m, RooAbsReal::Ref _m0, RooAbsReal::Ref _c, RooAbsReal::Ref _p) :
   RooAbsPdf(name, title),
   m("m","Mass",this,_m),
   m0("m0","Resonance mass",this,_m0),

--- a/roofit/roofit/src/RooGaussian.cxx
+++ b/roofit/roofit/src/RooGaussian.cxx
@@ -33,14 +33,14 @@ ClassImp(RooGaussian);
 ////////////////////////////////////////////////////////////////////////////////
 
 RooGaussian::RooGaussian(const char *name, const char *title,
-          RooAbsReal& _x, RooAbsReal& _mean,
-          RooAbsReal& _sigma) :
+          RooAbsReal::Ref _x, RooAbsReal::Ref _mean,
+          RooAbsReal::Ref _sigma) :
   RooAbsPdf(name,title),
   x("x","Observable",this,_x),
   mean("mean","Mean",this,_mean),
   sigma("sigma","Width",this,_sigma)
 {
-  RooHelpers::checkRangeOfParameters(this, {&_sigma}, 0);
+  RooHelpers::checkRangeOfParameters(this, {&static_cast<RooAbsReal&>(_sigma)}, 0);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooLandau.cxx
+++ b/roofit/roofit/src/RooLandau.cxx
@@ -33,13 +33,13 @@ ClassImp(RooLandau);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooLandau::RooLandau(const char *name, const char *title, RooAbsReal& _x, RooAbsReal& _mean, RooAbsReal& _sigma) :
+RooLandau::RooLandau(const char *name, const char *title, RooAbsReal::Ref _x, RooAbsReal::Ref _mean, RooAbsReal::Ref _sigma) :
   RooAbsPdf(name,title),
   x("x","Dependent",this,_x),
   mean("mean","Mean",this,_mean),
   sigma("sigma","Width",this,_sigma)
 {
-  RooHelpers::checkRangeOfParameters(this, {&_sigma}, 0.0);
+  RooHelpers::checkRangeOfParameters(this, {&static_cast<RooAbsReal&>(_sigma)}, 0.0);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooPoisson.cxx
+++ b/roofit/roofit/src/RooPoisson.cxx
@@ -26,8 +26,8 @@ ClassImp(RooPoisson);
 /// Constructor
 
 RooPoisson::RooPoisson(const char *name, const char *title,
-             RooAbsReal& _x,
-             RooAbsReal& _mean,
+             RooAbsReal::Ref _x,
+             RooAbsReal::Ref _mean,
              bool noRounding) :
   RooAbsPdf(name,title),
   x("x","x",this,_x),

--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -61,6 +61,21 @@ class RooAbsReal : public RooAbsArg {
 public:
   using value_type = double;
 
+  /// A RooAbsReal::Ref can be constructed from a `RooAbsReal&` or a `double`
+  /// that will be implicitly converted to a RooConstVar&. The RooAbsReal::Ref
+  /// can be used as a replacement for `RooAbsReal&`. With this type
+  /// definition, you can write RooFit interfaces that accept both RooAbsReal,
+  /// or simply a number that will be implicitly converted to a RooConstVar&.
+  class Ref {
+  public:
+     inline Ref(RooAbsReal &ref) : _ref{ref} {}
+     Ref(double val);
+     inline operator RooAbsReal &() const { return _ref; }
+
+  private:
+     RooAbsReal &_ref;
+  };
+
   // Constructors, assignment etc
   RooAbsReal() ;
   RooAbsReal(const char *name, const char *title, const char *unit= "") ;

--- a/roofit/roofitcore/inc/RooExtendPdf.h
+++ b/roofit/roofitcore/inc/RooExtendPdf.h
@@ -23,8 +23,11 @@ class RooExtendPdf : public RooAbsPdf {
 public:
 
   RooExtendPdf() ;
+  // Original constructor without RooAbsReal::Ref for backwards compatibility.
   RooExtendPdf(const char *name, const char *title, RooAbsPdf& pdf,
-          RooAbsReal& norm, const char* rangeName=nullptr) ;
+                      RooAbsReal& norm, const char* rangeName=nullptr);
+  RooExtendPdf(const char *name, const char *title, RooAbsPdf& pdf,
+          RooAbsReal::Ref norm, const char* rangeName=nullptr) ;
   RooExtendPdf(const RooExtendPdf& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooExtendPdf(*this,newname) ; }
   ~RooExtendPdf() override ;

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -38,6 +38,7 @@
 #include "RooArgList.h"
 #include "RooBinning.h"
 #include "RooPlot.h"
+#include "RooConstVar.h"
 #include "RooCurve.h"
 #include "RooHist.h"
 #include "RooRealVar.h"
@@ -4890,3 +4891,6 @@ void RooAbsReal::enableOffsetting(bool flag)
     }
   }
 }
+
+
+RooAbsReal::Ref::Ref(double val) : _ref{RooFit::RooConst(val)} {}

--- a/roofit/roofitcore/src/RooExtendPdf.cxx
+++ b/roofit/roofitcore/src/RooExtendPdf.cxx
@@ -57,6 +57,10 @@ RooExtendPdf::RooExtendPdf() : _rangeName(0)
   // Default constructor
 }
 
+RooExtendPdf::RooExtendPdf(const char *name, const char *title, RooAbsPdf& pdf,
+                    RooAbsReal& norm, const char* rangeName)
+    : RooExtendPdf{name, title, pdf, RooAbsReal::Ref{norm}, rangeName} {}
+
 /// Constructor. The ExtendPdf behaves identical to the supplied input pdf,
 /// but adds an extended likelihood term. expectedEvents() will return
 /// `norm` if `rangeName` remains empty. If `rangeName` is not empty,
@@ -69,7 +73,7 @@ RooExtendPdf::RooExtendPdf() : _rangeName(0)
 /// \param[in] rangeName  If given, the number of events denoted by `norm` is interpreted as
 /// the number of events in this range only
 RooExtendPdf::RooExtendPdf(const char *name, const char *title, RooAbsPdf& pdf,
-            RooAbsReal& norm, const char* rangeName) :
+            RooAbsReal::Ref norm, const char* rangeName) :
   RooAbsPdf(name,title),
   _pdf("pdf", "PDF", this, pdf),
   _n("n","Normalization",this,norm),

--- a/roofit/roofitcore/src/RooFactoryWSTool.cxx
+++ b/roofit/roofitcore/src/RooFactoryWSTool.cxx
@@ -380,7 +380,7 @@ RooAbsArg* RooFactoryWSTool::createArg(const char* className, const char* objNam
     Int_t i(0) ;
     list<string>::iterator ti = ca.first.begin() ; ++ti ; ++ti ;
     for (vector<string>::iterator ai = _args.begin() ; ai != _args.end() ; ++ai,++ti,++i) {
-      if ((*ti)=="RooAbsReal&" || (*ti)=="const RooAbsReal&") {
+      if ((*ti)=="RooAbsReal&" || (*ti)=="const RooAbsReal&" || (*ti)=="RooAbsReal::Ref") {
    RooFactoryWSTool::as_FUNC(i) ;
    cintExpr += Form(",RooFactoryWSTool::as_FUNC(%d)",i) ;
       } else if ((*ti)=="RooAbsArg&" || (*ti)=="const RooAbsArg&") {

--- a/test/stressRooFit_tests.h
+++ b/test/stressRooFit_tests.h
@@ -390,7 +390,7 @@ public:
     // ---------------------------------
 
     // Construct a separate gaussian g1(x,10,3) to generate a toy Gaussian dataset with mean 10 and width 3
-    RooGaussian g1("g1","g1",x,RooConst(10),RooConst(3)) ;
+    RooGaussian g1("g1","g1",x,10.0,3.0) ;
     std::unique_ptr<RooDataSet> data2{g1.generate(x,1000)};
 
 
@@ -631,7 +631,7 @@ public:
     // Create Gaussian
     RooRealVar sigma("sigma","sigma",3,0.1,10) ;
     RooRealVar mean("mean","mean",0,-10,10) ;
-    RooGaussian gauss("gauss","gauss",x,RooConst(0),sigma) ;
+    RooGaussian gauss("gauss","gauss",x,0.0,sigma) ;
 
     // Generate a sample of 1000 events with sigma=3
     std::unique_ptr<RooDataSet> data{gauss.generate(x,10000)};
@@ -714,7 +714,7 @@ public:
     RooRealVar x("x","x",-10,10) ;
 
     // Create p.d.f. gaussx(x,-2,3)
-    RooGaussian gx("gx","gx",x,RooConst(-2),RooConst(3)) ;
+    RooGaussian gx("gx","gx",x,-2.0,3.0) ;
 
 
     // R e t r i e v e   r a w  &   n o r m a l i z e d   v a l u e s   o f   R o o F i t   p . d . f . s
@@ -807,7 +807,7 @@ public:
     // ------------------------------------------------------------------
 
     RooRealVar x("x","x",-10,10) ;
-    RooLandau landau("landau","landau",x,RooConst(0),RooConst(0.1)) ;
+    RooLandau landau("landau","landau",x,0.0,0.1) ;
 
     // Disable analytic integration from demonstration purposes
     landau.forceNumInt(true);
@@ -1099,7 +1099,7 @@ public:
 
     // Construct gaussx(x,mx,1)
     RooRealVar mx("mx","mx",0,-10,10) ;
-    RooGaussian gx("gx","gx",x,mx,RooConst(1)) ;
+    RooGaussian gx("gx","gx",x,mx,1.0) ;
 
     // Construct px = 1 (flat in x)
     RooPolynomial px("px","px",x) ;
@@ -1902,7 +1902,7 @@ public:
   // -----------------------------------------------------------
 
   // Create gaussy(y,0,5)
-  RooGaussian gaussy("gaussy","Gaussian in y",y,RooConst(0),RooConst(3)) ;
+  RooGaussian gaussy("gaussy","Gaussian in y",y,0.0,3.0) ;
 
 
 
@@ -1986,7 +1986,7 @@ public:
   // ------------------------------------------------------------------------------------------------------
 
   // Use landau p.d.f to get somewhat realistic distribution with long tail
-  RooLandau pdfDtErr("pdfDtErr","pdfDtErr",dterr,RooConst(1),RooConst(0.25)) ;
+  RooLandau pdfDtErr("pdfDtErr","pdfDtErr",dterr,1.0,0.25) ;
   std::unique_ptr<RooDataSet> expDataDterr{pdfDtErr.generate(dterr,10000)};
 
 
@@ -2085,7 +2085,7 @@ public:
   // -----------------------------------------------------------------
 
   // Use landau p.d.f to get empirical distribution with long tail
-  RooLandau pdfDtErr("pdfDtErr","pdfDtErr",dterr,RooConst(1),RooConst(0.25)) ;
+  RooLandau pdfDtErr("pdfDtErr","pdfDtErr",dterr,1.0,0.25) ;
   std::unique_ptr<RooDataSet> expDataDterr{pdfDtErr.generate(dterr,10000)};
 
   // Construct a histogram pdf to describe the shape of the dtErr distribution
@@ -2164,8 +2164,8 @@ public:
   RooRealVar y("y","y",-10,10) ;
 
   // Create p.d.f. gaussx(x,-2,3), gaussy(y,2,2)
-  RooGaussian gx("gx","gx",x,RooConst(-2),RooConst(3)) ;
-  RooGaussian gy("gy","gy",y,RooConst(+2),RooConst(2)) ;
+  RooGaussian gx("gx","gx",x,-2.0,3.0) ;
+  RooGaussian gy("gy","gy",y,+2.0,2.0) ;
 
   // Create gxy = gx(x)*gy(y)
   RooProdPdf gxy("gxy","gxy",RooArgSet(gx,gy)) ;
@@ -2346,14 +2346,14 @@ public:
   RooRealVar z("z","z",-5,5) ;
 
   // Create signal pdf gauss(x)*gauss(y)*gauss(z)
-  RooGaussian gx("gx","gx",x,RooConst(0),RooConst(1)) ;
-  RooGaussian gy("gy","gy",y,RooConst(0),RooConst(1)) ;
-  RooGaussian gz("gz","gz",z,RooConst(0),RooConst(1)) ;
+  RooGaussian gx("gx","gx",x,0.0,1.0) ;
+  RooGaussian gy("gy","gy",y,0.0,1.0) ;
+  RooGaussian gz("gz","gz",z,0.0,1.0) ;
   RooProdPdf sig("sig","sig",RooArgSet(gx,gy,gz)) ;
 
   // Create background pdf poly(x)*poly(y)*poly(z)
-  RooPolynomial px("px","px",x,RooArgSet(RooConst(-0.1),RooConst(0.004))) ;
-  RooPolynomial py("py","py",y,RooArgSet(RooConst(0.1),RooConst(-0.004))) ;
+  RooPolynomial px("px","px",x,RooArgSet(-0.1,0.004)) ;
+  RooPolynomial py("py","py",y,RooArgSet(0.1,-0.004)) ;
   RooPolynomial pz("pz","pz",z) ;
   RooProdPdf bkg("bkg","bkg",RooArgSet(px,py,pz)) ;
 
@@ -2430,8 +2430,8 @@ public:
   RooRealVar mx("mx","mx",1,-10,10) ;
   RooRealVar my("my","my",1,-10,10) ;
 
-  RooGaussian gx("gx","gx",x,mx,RooConst(1)) ;
-  RooGaussian gy("gy","gy",y,my,RooConst(1)) ;
+  RooGaussian gx("gx","gx",x,mx,1.0) ;
+  RooGaussian gy("gy","gy",y,my,1.0) ;
 
   RooProdPdf sig("sig","sig",gx,gy) ;
 
@@ -2631,7 +2631,7 @@ public:
   std::unique_ptr<RooDataSet> dall{model.generate(t,10000)};
 
   // Generate a (fake) prototype dataset for acceptance limit values
-  std::unique_ptr<RooDataSet> tmp{RooGaussian("gmin","gmin",tmin,RooConst(0),RooConst(0.5)).generate(tmin,5000)};
+  std::unique_ptr<RooDataSet> tmp{RooGaussian("gmin","gmin",tmin,0.0,0.5).generate(tmin,5000)};
 
   // Generate dataset with t values that observe (t>tmin)
   std::unique_ptr<RooDataSet> dacc{model.generate(t,ProtoData(*tmp))};
@@ -2705,7 +2705,7 @@ public:
     RooGaussian gaussx("gaussx","Gaussian in x with shifting mean in y",x,fy,sigmax) ;
 
     // Create gaussy(y,0,2)
-    RooGaussian gaussy("gaussy","Gaussian in y",y,RooConst(0),RooConst(2)) ;
+    RooGaussian gaussy("gaussy","Gaussian in y",y,0.0,2.0) ;
 
     // Create gaussx(x,sx|y) * gaussy(y)
     RooProdPdf model("model","gaussx(x|y)*gaussy(y)",gaussy,Conditional(gaussx,x)) ;
@@ -2773,14 +2773,14 @@ public:
   RooRealVar z("z","z",-5,5) ;
 
   // Create signal pdf gauss(x)*gauss(y)*gauss(z)
-  RooGaussian gx("gx","gx",x,RooConst(0),RooConst(1)) ;
-  RooGaussian gy("gy","gy",y,RooConst(0),RooConst(1)) ;
-  RooGaussian gz("gz","gz",z,RooConst(0),RooConst(1)) ;
+  RooGaussian gx("gx","gx",x,0.0,1.0) ;
+  RooGaussian gy("gy","gy",y,0.0,1.0) ;
+  RooGaussian gz("gz","gz",z,0.0,1.0) ;
   RooProdPdf sig("sig","sig",RooArgSet(gx,gy,gz)) ;
 
   // Create background pdf poly(x)*poly(y)*poly(z)
-  RooPolynomial px("px","px",x,RooArgSet(RooConst(-0.1),RooConst(0.004))) ;
-  RooPolynomial py("py","py",y,RooArgSet(RooConst(0.1),RooConst(-0.004))) ;
+  RooPolynomial px("px","px",x,RooArgSet(-0.1,0.004)) ;
+  RooPolynomial py("py","py",y,RooArgSet(0.1,-0.004)) ;
   RooPolynomial pz("pz","pz",z) ;
   RooProdPdf bkg("bkg","bkg",RooArgSet(px,py,pz)) ;
 
@@ -3957,7 +3957,7 @@ public:
   // -----------------------------------------
 
   // Construct Gaussian constraint p.d.f on parameter f at 0.8 with resolution of 0.1
-  RooGaussian fconstraint("fconstraint","fconstraint",f,RooConst(0.8),RooConst(0.1)) ;
+  RooGaussian fconstraint("fconstraint","fconstraint",f,0.8,0.1) ;
 
 
 
@@ -3982,7 +3982,7 @@ public:
   // -------------------------------------------------------------------------------------------------------
 
   // Construct another Gaussian constraint p.d.f on parameter f at 0.8 with resolution of 0.1
-  RooGaussian fconstext("fconstext","fconstext",f,RooConst(0.2),RooConst(0.1)) ;
+  RooGaussian fconstext("fconstext","fconstext",f,0.2,0.1) ;
 
   // Fit with external constraint
   RooFitResult* r3 = model.fitTo(*d,ExternalConstraints(fconstext),Save(),BatchMode(_batchMode)) ;
@@ -4648,8 +4648,8 @@ public:
   std::unique_ptr<RooAbsReal> sinhGConv{tm.convolution(&sinhGBasis,&t)};
 
   // Construct polynomial amplitudes in cos(a)
-  RooPolyVar poly1("poly1","poly1",cosa,RooArgList(RooConst(0.5),RooConst(0.2),RooConst(0.2)),0);
-  RooPolyVar poly2("poly2","poly2",cosa,RooArgList(RooConst(1),RooConst(-0.2),RooConst(3)),0);
+  RooPolyVar poly1("poly1","poly1",cosa,RooArgList(0.5, 0.2, 0.2),0);
+  RooPolyVar poly2("poly2","poly2",cosa,RooArgList(1.0, -0.2, 3.0),0);
 
   // Construct 2D amplitude as uncorrelated product of amp(t)*amp(cosa)
   RooProduct  ampl1("ampl1","amplitude 1",RooArgSet(poly1,*coshGConv));
@@ -4740,10 +4740,10 @@ public:
 
   // Lower end point shape: a Gaussian
   RooRealVar g1mean("g1mean","g1mean",-10) ;
-  RooGaussian g1("g1","g1",x,g1mean,RooConst(2)) ;
+  RooGaussian g1("g1","g1",x,g1mean,2.0) ;
 
   // Upper end point shape: a Polynomial
-  RooPolynomial g2("g2","g2",x,RooArgSet(RooConst(-0.03),RooConst(-0.001))) ;
+  RooPolynomial g2("g2","g2",x,RooArgSet(-0.03,-0.001)) ;
 
 
 
@@ -4869,7 +4869,7 @@ public:
   // ---------------------------------------------
 
   RooRealVar x("x","x",0,20) ;
-  RooPolynomial p("p","p",x,RooArgList(RooConst(0.01),RooConst(-0.01),RooConst(0.0004))) ;
+  RooPolynomial p("p","p",x,RooArgList(0.01,-0.01,0.0004)) ;
 
 
 
@@ -4941,7 +4941,7 @@ public:
 
   // Create a toy pdf for sampling
   RooRealVar x("x","x",0,20) ;
-  RooPolynomial p("p","p",x,RooArgList(RooConst(0.01),RooConst(-0.01),RooConst(0.0004))) ;
+  RooPolynomial p("p","p",x,RooArgList(0.01,-0.01,0.0004)) ;
 
   // Sample 500 events from p
   std::unique_ptr<RooDataSet> data1{p.generate(x,200)};
@@ -4985,7 +4985,7 @@ public:
 
   // Construct a 2D toy pdf for sampleing
   RooRealVar y("y","y",0,20) ;
-  RooPolynomial py("py","py",y,RooArgList(RooConst(0.01),RooConst(0.01),RooConst(-0.0004))) ;
+  RooPolynomial py("py","py",y,RooArgList(0.01,0.01,-0.0004)) ;
   RooProdPdf pxy("pxy","pxy",RooArgSet(p,py)) ;
   std::unique_ptr<RooDataSet> data2{pxy.generate(RooArgSet(x,y),1000)};
 
@@ -5567,7 +5567,7 @@ public:
   RooAddPdf sum("sum","sum",RooArgSet(g,p),f) ;
 
   // Construct constraint on parameter f
-  RooGaussian fconstraint("fconstraint","fconstraint",f,RooConst(0.7),RooConst(0.1)) ;
+  RooGaussian fconstraint("fconstraint","fconstraint",f,0.7,0.1) ;
 
   // Multiply constraint with p.d.f
   RooProdPdf sumc("sumc","sum with constraint",RooArgSet(sum,fconstraint)) ;

--- a/tutorials/roofit/rf103_interprfuncs.C
+++ b/tutorials/roofit/rf103_interprfuncs.C
@@ -18,7 +18,6 @@
 #include "RooPlot.h"
 #include "RooFitResult.h"
 #include "RooGenericPdf.h"
-#include "RooConstVar.h"
 
 using namespace RooFit;
 
@@ -76,7 +75,7 @@ void rf103_interprfuncs()
    // ---------------------------------
 
    // Construct a separate gaussian g1(x,10,3) to generate a toy Gaussian dataset with mean 10 and width 3
-   RooGaussian g1("g1", "g1", x, RooConst(10), RooConst(3));
+   RooGaussian g1("g1", "g1", x, 10.0, 3.0);
    RooDataSet *data2 = g1.generate(x, 1000);
 
    // F i t   a n d   p l o t   t a i l o r e d   s t a n d a r d   p d f

--- a/tutorials/roofit/rf103_interprfuncs.py
+++ b/tutorials/roofit/rf103_interprfuncs.py
@@ -61,7 +61,7 @@ g2 = ROOT.RooGaussian("g2", "h2", x, mean, sigma)
 
 # Construct a separate gaussian g1(x,10,3) to generate a toy Gaussian
 # dataset with mean 10 and width 3
-g1 = ROOT.RooGaussian("g1", "g1", x, ROOT.RooFit.RooConst(10), ROOT.RooFit.RooConst(3))
+g1 = ROOT.RooGaussian("g1", "g1", x, 10, 3)
 data2 = g1.generate({x}, 1000)
 
 # Fit and plot tailored standard pdf

--- a/tutorials/roofit/rf109_chi2residpull.C
+++ b/tutorials/roofit/rf109_chi2residpull.C
@@ -14,7 +14,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "TCanvas.h"
 #include "TAxis.h"
 #include "RooPlot.h"
@@ -33,7 +32,7 @@ void rf109_chi2residpull()
    // Create Gaussian
    RooRealVar sigma("sigma", "sigma", 3, 0.1, 10);
    RooRealVar mean("mean", "mean", 0, -10, 10);
-   RooGaussian gauss("gauss", "gauss", x, RooConst(0), sigma);
+   RooGaussian gauss("gauss", "gauss", x, 0.0, sigma);
 
    // Generate a sample of 1000 events with sigma=3
    RooDataSet *data = gauss.generate(x, 10000);

--- a/tutorials/roofit/rf110_normintegration.C
+++ b/tutorials/roofit/rf110_normintegration.C
@@ -13,7 +13,6 @@
 
 #include "RooRealVar.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooAbsReal.h"
 #include "RooPlot.h"
 #include "TCanvas.h"
@@ -29,7 +28,7 @@ void rf110_normintegration()
    RooRealVar x("x", "x", -10, 10);
 
    // Create pdf gaussx(x,-2,3)
-   RooGaussian gx("gx", "gx", x, RooConst(-2), RooConst(3));
+   RooGaussian gx("gx", "gx", x, -2.0, 3.0);
 
    // R e t r i e v e   r a w  &   n o r m a l i z e d   v a l u e s   o f   R o o F i t   p . d . f . s
    // --------------------------------------------------------------------------------------------------

--- a/tutorials/roofit/rf110_normintegration.py
+++ b/tutorials/roofit/rf110_normintegration.py
@@ -19,7 +19,7 @@ import ROOT
 x = ROOT.RooRealVar("x", "x", -10, 10)
 
 # Create pdf gaussx(x,-2,3)
-gx = ROOT.RooGaussian("gx", "gx", x, ROOT.RooFit.RooConst(-2), ROOT.RooFit.RooConst(3))
+gx = ROOT.RooGaussian("gx", "gx", x, -2, 3)
 
 # Retrieve raw & normalized values of RooFit pdfs
 # --------------------------------------------------------------------------------------------------

--- a/tutorials/roofit/rf203_ranges.C
+++ b/tutorials/roofit/rf203_ranges.C
@@ -13,7 +13,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooPolynomial.h"
 #include "RooAddPdf.h"
 #include "RooFitResult.h"
@@ -33,7 +32,7 @@ void rf203_ranges()
 
    // Construct gaussx(x,mx,1)
    RooRealVar mx("mx", "mx", 0, -10, 10);
-   RooGaussian gx("gx", "gx", x, mx, RooConst(1));
+   RooGaussian gx("gx", "gx", x, mx, 1.0);
 
    // Construct px = 1 (flat in x)
    RooPolynomial px("px", "px", x);

--- a/tutorials/roofit/rf203_ranges.py
+++ b/tutorials/roofit/rf203_ranges.py
@@ -19,7 +19,7 @@ x = ROOT.RooRealVar("x", "x", -10, 10)
 
 # Construct gaussx(x,mx,1)
 mx = ROOT.RooRealVar("mx", "mx", 0, -10, 10)
-gx = ROOT.RooGaussian("gx", "gx", x, mx, ROOT.RooFit.RooConst(1))
+gx = ROOT.RooGaussian("gx", "gx", x, mx, 1.0)
 
 # px = 1 (flat in x)
 px = ROOT.RooPolynomial("px", "px", x)

--- a/tutorials/roofit/rf305_condcorrprod.C
+++ b/tutorials/roofit/rf305_condcorrprod.C
@@ -15,7 +15,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooPolyVar.h"
 #include "RooProdPdf.h"
 #include "RooPlot.h"
@@ -46,7 +45,7 @@ void rf305_condcorrprod()
    // -----------------------------------------------------------
 
    // Create gaussy(y,0,5)
-   RooGaussian gaussy("gaussy", "Gaussian in y", y, RooConst(0), RooConst(3));
+   RooGaussian gaussy("gaussy", "Gaussian in y", y, 0.0, 3.0);
 
    // C r e a t e   p r o d u c t   g x ( x | y ) * g y ( y )
    // -------------------------------------------------------

--- a/tutorials/roofit/rf305_condcorrprod.py
+++ b/tutorials/roofit/rf305_condcorrprod.py
@@ -32,7 +32,7 @@ gaussx = ROOT.RooGaussian("gaussx", "Gaussian in x with shifting mean in y", x, 
 # -----------------------------------------------------------
 
 # Create gaussy(y,0,5)
-gaussy = ROOT.RooGaussian("gaussy", "Gaussian in y", y, ROOT.RooFit.RooConst(0), ROOT.RooFit.RooConst(3))
+gaussy = ROOT.RooGaussian("gaussy", "Gaussian in y", y, 0.0, 3.0)
 
 # Create product gx(x|y)*gy(y)
 # -------------------------------------------------------

--- a/tutorials/roofit/rf306_condpereventerrors.C
+++ b/tutorials/roofit/rf306_condpereventerrors.C
@@ -14,7 +14,6 @@
 #include "RooDataSet.h"
 #include "RooGaussian.h"
 #include "RooGaussModel.h"
-#include "RooConstVar.h"
 #include "RooDecay.h"
 #include "RooLandau.h"
 #include "RooPlot.h"
@@ -45,7 +44,7 @@ void rf306_condpereventerrors()
    // ------------------------------------------------------------------------------------------------------
 
    // Use landau pdf to get somewhat realistic distribution with long tail
-   RooLandau pdfDtErr("pdfDtErr", "pdfDtErr", dterr, RooConst(1), RooConst(0.25));
+   RooLandau pdfDtErr("pdfDtErr", "pdfDtErr", dterr, 1.0, 0.25);
    RooDataSet *expDataDterr = pdfDtErr.generate(dterr, 10000);
 
    // S a m p l e   d a t a   f r o m   c o n d i t i o n a l   d e c a y _ g m ( d t | d t e r r )

--- a/tutorials/roofit/rf306_condpereventerrors.py
+++ b/tutorials/roofit/rf306_condpereventerrors.py
@@ -31,7 +31,7 @@ decay_gm = ROOT.RooDecay("decay_gm", "decay", dt, tau, gm, type="DoubleSided")
 # ------------------------------------------------------------------------------------------------------
 
 # Use landau pdf to get somewhat realistic distribution with long tail
-pdfDtErr = ROOT.RooLandau("pdfDtErr", "pdfDtErr", dterr, ROOT.RooFit.RooConst(1), ROOT.RooFit.RooConst(0.25))
+pdfDtErr = ROOT.RooLandau("pdfDtErr", "pdfDtErr", dterr, 1.0, 0.25)
 expDataDterr = pdfDtErr.generate({dterr}, 10000)
 
 # Sample data from conditional decay_gm(dt|dterr)

--- a/tutorials/roofit/rf307_fullpereventerrors.C
+++ b/tutorials/roofit/rf307_fullpereventerrors.C
@@ -12,7 +12,6 @@
 #include "RooDataSet.h"
 #include "RooGaussian.h"
 #include "RooGaussModel.h"
-#include "RooConstVar.h"
 #include "RooDecay.h"
 #include "RooLandau.h"
 #include "RooProdPdf.h"
@@ -45,7 +44,7 @@ void rf307_fullpereventerrors()
    // -----------------------------------------------------------------
 
    // Use landau pdf to get empirical distribution with long tail
-   RooLandau pdfDtErr("pdfDtErr", "pdfDtErr", dterr, RooConst(1), RooConst(0.25));
+   RooLandau pdfDtErr("pdfDtErr", "pdfDtErr", dterr, 1.0, 0.25);
    RooDataSet *expDataDterr = pdfDtErr.generate(dterr, 10000);
 
    // Construct a histogram pdf to describe the shape of the dtErr distribution

--- a/tutorials/roofit/rf307_fullpereventerrors.py
+++ b/tutorials/roofit/rf307_fullpereventerrors.py
@@ -31,7 +31,7 @@ decay_gm = ROOT.RooDecay("decay_gm", "decay", dt, tau, gm, type="DoubleSided")
 # -----------------------------------------------------------------
 
 # Use landau pdf to get empirical distribution with long tail
-pdfDtErr = ROOT.RooLandau("pdfDtErr", "pdfDtErr", dterr, ROOT.RooFit.RooConst(1), ROOT.RooFit.RooConst(0.25))
+pdfDtErr = ROOT.RooLandau("pdfDtErr", "pdfDtErr", dterr, 1.0, 0.25)
 expDataDterr = pdfDtErr.generate({dterr}, 10000)
 
 # Construct a histogram pdf to describe the shape of the dtErr distribution

--- a/tutorials/roofit/rf308_normintegration2d.C
+++ b/tutorials/roofit/rf308_normintegration2d.C
@@ -13,7 +13,6 @@
 
 #include "RooRealVar.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooProdPdf.h"
 #include "RooAbsReal.h"
 #include "RooPlot.h"
@@ -32,8 +31,8 @@ void rf308_normintegration2d()
    RooRealVar y("y", "y", -10, 10);
 
    // Create pdf gaussx(x,-2,3), gaussy(y,2,2)
-   RooGaussian gx("gx", "gx", x, RooConst(-2), RooConst(3));
-   RooGaussian gy("gy", "gy", y, RooConst(+2), RooConst(2));
+   RooGaussian gx("gx", "gx", x, -2.0, 3.0);
+   RooGaussian gy("gy", "gy", y, +2.0, 2.0);
 
    // Create gxy = gx(x)*gy(y)
    RooProdPdf gxy("gxy", "gxy", RooArgSet(gx, gy));

--- a/tutorials/roofit/rf308_normintegration2d.py
+++ b/tutorials/roofit/rf308_normintegration2d.py
@@ -20,8 +20,8 @@ x = ROOT.RooRealVar("x", "x", -10, 10)
 y = ROOT.RooRealVar("y", "y", -10, 10)
 
 # Create pdf gaussx(x,-2,3), gaussy(y,2,2)
-gx = ROOT.RooGaussian("gx", "gx", x, ROOT.RooFit.RooConst(-2), ROOT.RooFit.RooConst(3))
-gy = ROOT.RooGaussian("gy", "gy", y, ROOT.RooFit.RooConst(+2), ROOT.RooFit.RooConst(2))
+gx = ROOT.RooGaussian("gx", "gx", x, -2.0, 3.0)
+gy = ROOT.RooGaussian("gy", "gy", y, +2.0, 2.0)
 
 # gxy = gx(x)*gy(y)
 gxy = ROOT.RooProdPdf("gxy", "gxy", [gx, gy])

--- a/tutorials/roofit/rf309_ndimplot.C
+++ b/tutorials/roofit/rf309_ndimplot.C
@@ -12,7 +12,6 @@
 
 #include "RooRealVar.h"
 #include "RooDataSet.h"
-#include "RooConstVar.h"
 #include "RooGaussian.h"
 #include "RooProdPdf.h"
 #include "TCanvas.h"
@@ -62,7 +61,7 @@ void rf309_ndimplot()
    // Create observables
    RooRealVar z("z", "z", -5, 5);
 
-   RooGaussian gz("gz", "gz", z, RooConst(0), RooConst(2));
+   RooGaussian gz("gz", "gz", z, 0.0, 2.0);
    RooProdPdf model3("model3", "model3", RooArgSet(model, gz));
 
    RooDataSet *data3 = model3.generate(RooArgSet(x, y, z), 10000);

--- a/tutorials/roofit/rf309_ndimplot.py
+++ b/tutorials/roofit/rf309_ndimplot.py
@@ -48,7 +48,7 @@ hh_pdf.SetLineColor(ROOT.kBlue)
 # Create observables
 z = ROOT.RooRealVar("z", "z", -5, 5)
 
-gz = ROOT.RooGaussian("gz", "gz", z, ROOT.RooFit.RooConst(0), ROOT.RooFit.RooConst(2))
+gz = ROOT.RooGaussian("gz", "gz", z, 0.0, 2.0)
 model3 = ROOT.RooProdPdf("model3", "model3", [model, gz])
 
 data3 = model3.generate({x, y, z}, 10000)

--- a/tutorials/roofit/rf311_rangeplot.C
+++ b/tutorials/roofit/rf311_rangeplot.C
@@ -34,9 +34,9 @@ void rf311_rangeplot()
    RooRealVar z("z", "z", -5, 5);
 
    // Create signal pdf gauss(x)*gauss(y)*gauss(z)
-   RooGaussian gx("gx", "gx", x, RooConst(0), RooConst(1));
-   RooGaussian gy("gy", "gy", y, RooConst(0), RooConst(1));
-   RooGaussian gz("gz", "gz", z, RooConst(0), RooConst(1));
+   RooGaussian gx("gx", "gx", x, 0.0, 1.0);
+   RooGaussian gy("gy", "gy", y, 0.0, 1.0);
+   RooGaussian gz("gz", "gz", z, 0.0, 1.0);
    RooProdPdf sig("sig", "sig", RooArgSet(gx, gy, gz));
 
    // Create background pdf poly(x)*poly(y)*poly(z)

--- a/tutorials/roofit/rf311_rangeplot.py
+++ b/tutorials/roofit/rf311_rangeplot.py
@@ -19,9 +19,9 @@ y = ROOT.RooRealVar("y", "y", -5, 5)
 z = ROOT.RooRealVar("z", "z", -5, 5)
 
 # Create signal pdf gauss(x)*gauss(y)*gauss(z)
-gx = ROOT.RooGaussian("gx", "gx", x, ROOT.RooFit.RooConst(0), ROOT.RooFit.RooConst(1))
-gy = ROOT.RooGaussian("gy", "gy", y, ROOT.RooFit.RooConst(0), ROOT.RooFit.RooConst(1))
-gz = ROOT.RooGaussian("gz", "gz", z, ROOT.RooFit.RooConst(0), ROOT.RooFit.RooConst(1))
+gx = ROOT.RooGaussian("gx", "gx", x, 0.0, 1.0)
+gy = ROOT.RooGaussian("gy", "gy", y, 0.0, 1.0)
+gz = ROOT.RooGaussian("gz", "gz", z, 0.0, 1.0)
 sig = ROOT.RooProdPdf("sig", "sig", [gx, gy, gz])
 
 # Create background pdf poly(x)*poly(y)*poly(z)

--- a/tutorials/roofit/rf312_multirangefit.C
+++ b/tutorials/roofit/rf312_multirangefit.C
@@ -12,7 +12,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooProdPdf.h"
 #include "RooAddPdf.h"
 #include "RooPolynomial.h"
@@ -36,8 +35,8 @@ void rf312_multirangefit()
    RooRealVar mx("mx", "mx", 1, -10, 10);
    RooRealVar my("my", "my", 1, -10, 10);
 
-   RooGaussian gx("gx", "gx", x, mx, RooConst(1));
-   RooGaussian gy("gy", "gy", y, my, RooConst(1));
+   RooGaussian gx("gx", "gx", x, mx, 1.0);
+   RooGaussian gy("gy", "gy", y, my, 1.0);
 
    RooProdPdf sig("sig", "sig", gx, gy);
 

--- a/tutorials/roofit/rf312_multirangefit.py
+++ b/tutorials/roofit/rf312_multirangefit.py
@@ -22,8 +22,8 @@ y = ROOT.RooRealVar("y", "y", -10, 10)
 mx = ROOT.RooRealVar("mx", "mx", 1, -10, 10)
 my = ROOT.RooRealVar("my", "my", 1, -10, 10)
 
-gx = ROOT.RooGaussian("gx", "gx", x, mx, ROOT.RooFit.RooConst(1))
-gy = ROOT.RooGaussian("gy", "gy", y, my, ROOT.RooFit.RooConst(1))
+gx = ROOT.RooGaussian("gx", "gx", x, mx, 1.0)
+gy = ROOT.RooGaussian("gy", "gy", y, my, 1.0)
 
 sig = ROOT.RooProdPdf("sig", "sig", gx, gy)
 

--- a/tutorials/roofit/rf313_paramranges.C
+++ b/tutorials/roofit/rf313_paramranges.C
@@ -14,7 +14,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooPolynomial.h"
 #include "RooProdPdf.h"
 #include "TCanvas.h"
@@ -35,8 +34,8 @@ void rf313_paramranges()
 
    // Define 3 dimensional pdf
    RooRealVar z0("z0", "z0", -0.1, 1);
-   RooPolynomial px("px", "px", x, RooConst(0));
-   RooPolynomial py("py", "py", y, RooConst(0));
+   RooPolynomial px("px", "px", x, RooConst(0.0));
+   RooPolynomial py("py", "py", y, RooConst(0.0));
    RooPolynomial pz("pz", "pz", z, z0);
    RooProdPdf pxyz("pxyz", "pxyz", RooArgSet(px, py, pz));
 

--- a/tutorials/roofit/rf314_paramfitrange.C
+++ b/tutorials/roofit/rf314_paramfitrange.C
@@ -51,7 +51,7 @@ void rf314_paramfitrange()
    RooDataSet *dall = model.generate(t, 10000);
 
    // Generate a (fake) prototype dataset for acceptance limit values
-   RooDataSet *tmp = RooGaussian("gmin", "gmin", tmin, RooConst(0), RooConst(0.5)).generate(tmin, 5000);
+   RooDataSet *tmp = RooGaussian("gmin", "gmin", tmin, 0.0, 0.5).generate(tmin, 5000);
 
    // Generate dataset with t values that observe (t>tmin)
    RooDataSet *dacc = model.generate(t, ProtoData(*tmp));

--- a/tutorials/roofit/rf314_paramfitrange.py
+++ b/tutorials/roofit/rf314_paramfitrange.py
@@ -37,7 +37,7 @@ model = ROOT.RooExponential("model", "model", t, tau)
 dall = model.generate({t}, 10000)
 
 # Generate a (fake) prototype dataset for acceptance limit values
-tmp = ROOT.RooGaussian("gmin", "gmin", tmin, ROOT.RooFit.RooConst(0), ROOT.RooFit.RooConst(0.5)).generate({tmin}, 5000)
+tmp = ROOT.RooGaussian("gmin", "gmin", tmin, 0.0, 0.5).generate({tmin}, 5000)
 
 # Generate dataset with t values that observe (t>tmin)
 dacc = model.generate({t}, ProtoData=tmp)

--- a/tutorials/roofit/rf315_projectpdf.C
+++ b/tutorials/roofit/rf315_projectpdf.C
@@ -20,7 +20,6 @@
 #include "TAxis.h"
 #include "RooPlot.h"
 #include "RooNumIntConfig.h"
-#include "RooConstVar.h"
 using namespace RooFit;
 
 void rf315_projectpdf()
@@ -47,7 +46,7 @@ void rf315_projectpdf()
    RooGaussian gaussx("gaussx", "Gaussian in x with shifting mean in y", x, fy, sigmax);
 
    // Create gaussy(y,0,2)
-   RooGaussian gaussy("gaussy", "Gaussian in y", y, RooConst(0), RooConst(2));
+   RooGaussian gaussy("gaussy", "Gaussian in y", y, 0.0, 2.0);
 
    // Create gaussx(x,sx|y) * gaussy(y)
    RooProdPdf model("model", "gaussx(x|y)*gaussy(y)", gaussy, Conditional(gaussx, x));

--- a/tutorials/roofit/rf315_projectpdf.py
+++ b/tutorials/roofit/rf315_projectpdf.py
@@ -33,7 +33,7 @@ sigmax = ROOT.RooRealVar("sigmax", "width of gaussian", 0.5)
 gaussx = ROOT.RooGaussian("gaussx", "Gaussian in x with shifting mean in y", x, fy, sigmax)
 
 # Create gaussy(y,0,2)
-gaussy = ROOT.RooGaussian("gaussy", "Gaussian in y", y, ROOT.RooFit.RooConst(0), ROOT.RooFit.RooConst(2))
+gaussy = ROOT.RooGaussian("gaussy", "Gaussian in y", y, 0.0, 2.0)
 
 # Create gaussx(x,sx|y) * gaussy(y)
 model = ROOT.RooProdPdf(

--- a/tutorials/roofit/rf316_llratioplot.C
+++ b/tutorials/roofit/rf316_llratioplot.C
@@ -14,7 +14,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooPolynomial.h"
 #include "RooAddPdf.h"
 #include "RooProdPdf.h"
@@ -35,9 +34,9 @@ void rf316_llratioplot()
    RooRealVar z("z", "z", -5, 5);
 
    // Create signal pdf gauss(x)*gauss(y)*gauss(z)
-   RooGaussian gx("gx", "gx", x, RooConst(0), RooConst(1));
-   RooGaussian gy("gy", "gy", y, RooConst(0), RooConst(1));
-   RooGaussian gz("gz", "gz", z, RooConst(0), RooConst(1));
+   RooGaussian gx("gx", "gx", x, 0.0, 1.0);
+   RooGaussian gy("gy", "gy", y, 0.0, 1.0);
+   RooGaussian gz("gz", "gz", z, 0.0, 1.0);
    RooProdPdf sig("sig", "sig", RooArgSet(gx, gy, gz));
 
    // Create background pdf poly(x)*poly(y)*poly(z)

--- a/tutorials/roofit/rf316_llratioplot.py
+++ b/tutorials/roofit/rf316_llratioplot.py
@@ -21,9 +21,9 @@ y = ROOT.RooRealVar("y", "y", -5, 5)
 z = ROOT.RooRealVar("z", "z", -5, 5)
 
 # Create signal pdf gauss(x)*gauss(y)*gauss(z)
-gx = ROOT.RooGaussian("gx", "gx", x, ROOT.RooFit.RooConst(0), ROOT.RooFit.RooConst(1))
-gy = ROOT.RooGaussian("gy", "gy", y, ROOT.RooFit.RooConst(0), ROOT.RooFit.RooConst(1))
-gz = ROOT.RooGaussian("gz", "gz", z, ROOT.RooFit.RooConst(0), ROOT.RooFit.RooConst(1))
+gx = ROOT.RooGaussian("gx", "gx", x, 0.0, 1.0)
+gy = ROOT.RooGaussian("gy", "gy", y, 0.0, 1.0)
+gz = ROOT.RooGaussian("gz", "gz", z, 0.0, 1.0)
 sig = ROOT.RooProdPdf("sig", "sig", [gx, gy, gz])
 
 # Create background pdf poly(x)*poly(y)*poly(z)

--- a/tutorials/roofit/rf405_realtocatfuncs.C
+++ b/tutorials/roofit/rf405_realtocatfuncs.C
@@ -13,7 +13,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooCategory.h"
 #include "RooThresholdCategory.h"
 #include "RooBinningCategory.h"
@@ -32,7 +31,7 @@ void rf405_realtocatfuncs()
 
    // Define a dummy PDF in x
    RooRealVar x("x", "x", 0, 10);
-   RooArgusBG a("a", "argus(x)", x, RooConst(10), RooConst(-1));
+   RooArgusBG a("a", "argus(x)", x, 10.0, -1.0);
 
    // Generate a dummy dataset
    RooDataSet *data = a.generate(x, 10000);

--- a/tutorials/roofit/rf405_realtocatfuncs.py
+++ b/tutorials/roofit/rf405_realtocatfuncs.py
@@ -16,7 +16,7 @@ import ROOT
 
 # Define a dummy PDF in x
 x = ROOT.RooRealVar("x", "x", 0, 10)
-a = ROOT.RooArgusBG("a", "argus(x)", x, ROOT.RooFit.RooConst(10), ROOT.RooFit.RooConst(-1))
+a = ROOT.RooArgusBG("a", "argus(x)", x, 10.0, -1.0)
 
 # Generate a dummy dataset
 data = a.generate({x}, 10000)

--- a/tutorials/roofit/rf603_multicpu.C
+++ b/tutorials/roofit/rf603_multicpu.C
@@ -13,7 +13,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooPolynomial.h"
 #include "RooAddPdf.h"
 #include "RooProdPdf.h"
@@ -34,9 +33,9 @@ void rf603_multicpu()
    RooRealVar z("z", "z", -5, 5);
 
    // Create signal pdf gauss(x)*gauss(y)*gauss(z)
-   RooGaussian gx("gx", "gx", x, RooConst(0), RooConst(1));
-   RooGaussian gy("gy", "gy", y, RooConst(0), RooConst(1));
-   RooGaussian gz("gz", "gz", z, RooConst(0), RooConst(1));
+   RooGaussian gx("gx", "gx", x, 0.0, 1.0);
+   RooGaussian gy("gy", "gy", y, 0.0, 1.0);
+   RooGaussian gz("gz", "gz", z, 0.0, 1.0);
    RooProdPdf sig("sig", "sig", RooArgSet(gx, gy, gz));
 
    // Create background pdf poly(x)*poly(y)*poly(z)

--- a/tutorials/roofit/rf603_multicpu.py
+++ b/tutorials/roofit/rf603_multicpu.py
@@ -20,9 +20,9 @@ y = ROOT.RooRealVar("y", "y", -5, 5)
 z = ROOT.RooRealVar("z", "z", -5, 5)
 
 # Create signal pdf gauss(x)*gauss(y)*gauss(z)
-gx = ROOT.RooGaussian("gx", "gx", x, ROOT.RooFit.RooConst(0), ROOT.RooFit.RooConst(1))
-gy = ROOT.RooGaussian("gy", "gy", y, ROOT.RooFit.RooConst(0), ROOT.RooFit.RooConst(1))
-gz = ROOT.RooGaussian("gz", "gz", z, ROOT.RooFit.RooConst(0), ROOT.RooFit.RooConst(1))
+gx = ROOT.RooGaussian("gx", "gx", x, 0.0, 1.0)
+gy = ROOT.RooGaussian("gy", "gy", y, 0.0, 1.0)
+gz = ROOT.RooGaussian("gz", "gz", z, 0.0, 1.0)
 sig = ROOT.RooProdPdf("sig", "sig", [gx, gy, gz])
 
 # Create background pdf poly(x)*poly(y)*poly(z)

--- a/tutorials/roofit/rf604_constraints.C
+++ b/tutorials/roofit/rf604_constraints.C
@@ -12,7 +12,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooPolynomial.h"
 #include "RooAddPdf.h"
 #include "RooProdPdf.h"
@@ -50,7 +49,7 @@ void rf604_constraints()
    // -----------------------------------------
 
    // Construct Gaussian constraint pdf on parameter f at 0.8 with resolution of 0.1
-   RooGaussian fconstraint("fconstraint", "fconstraint", f, RooConst(0.8), RooConst(0.2));
+   RooGaussian fconstraint("fconstraint", "fconstraint", f, 0.8, 0.2);
 
    // M E T H O D   1   -   A d d   i n t e r n a l   c o n s t r a i n t   t o   m o d e l
    // -------------------------------------------------------------------------------------
@@ -71,7 +70,7 @@ void rf604_constraints()
    // -------------------------------------------------------------------------------------------------------
 
    // Construct another Gaussian constraint pdf on parameter f at 0.2 with resolution of 0.1
-   RooGaussian fconstext("fconstext", "fconstext", f, RooConst(0.2), RooConst(0.1));
+   RooGaussian fconstext("fconstext", "fconstext", f, 0.2, 0.1);
 
    // Fit with external constraint
    RooFitResult *r3 = model.fitTo(*d, ExternalConstraints(fconstext), Save(), PrintLevel(-1));

--- a/tutorials/roofit/rf604_constraints.py
+++ b/tutorials/roofit/rf604_constraints.py
@@ -37,7 +37,7 @@ d = model.generate({x}, 50)
 
 # Construct Gaussian constraint pdf on parameter f at 0.8 with
 # resolution of 0.1
-fconstraint = ROOT.RooGaussian("fconstraint", "fconstraint", f, ROOT.RooFit.RooConst(0.8), ROOT.RooFit.RooConst(0.1))
+fconstraint = ROOT.RooGaussian("fconstraint", "fconstraint", f, 0.8, 0.1)
 
 # Method 1 - add internal constraint to model
 # -------------------------------------------------------------------------------------
@@ -59,7 +59,7 @@ r2 = modelc.fitTo(d, Constrain={f}, Save=True, PrintLevel=-1)
 
 # Construct another Gaussian constraint pdf on parameter f at 0.8 with
 # resolution of 0.1
-fconstext = ROOT.RooGaussian("fconstext", "fconstext", f, ROOT.RooFit.RooConst(0.2), ROOT.RooFit.RooConst(0.1))
+fconstext = ROOT.RooGaussian("fconstext", "fconstext", f, 0.2, 0.1)
 
 # Fit with external constraint
 r3 = model.fitTo(d, ExternalConstraints={fconstext}, Save=True, PrintLevel=-1)

--- a/tutorials/roofit/rf613_global_observables.C
+++ b/tutorials/roofit/rf613_global_observables.C
@@ -57,7 +57,6 @@
 /// \author Jonas Rembser
 
 #include <RooArgSet.h>
-#include <RooConstVar.h>
 #include <RooDataSet.h>
 #include <RooFitResult.h>
 #include <RooGaussian.h>
@@ -89,7 +88,7 @@ void rf613_global_observables()
    // note: alternatively, one can create a constant with default limits using `RooRealVar("mu_obs", "mu_obs", 1.0)`
 
    // constraint pdf
-   RooGaussian constraint("constraint", "constraint", mu_obs, mu, RooConst(0.2));
+   RooGaussian constraint("constraint", "constraint", mu_obs, mu, 0.2);
 
    // full pdf including constraint pdf
    RooProdPdf model("model", "model", {gauss, constraint});

--- a/tutorials/roofit/rf613_global_observables.py
+++ b/tutorials/roofit/rf613_global_observables.py
@@ -80,7 +80,7 @@ mu_obs.setConstant()
 # note: alternatively, one can create a constant with default limits using `RooRealVar("mu_obs", "mu_obs", 1.0)`
 
 # constraint pdf
-constraint = ROOT.RooGaussian("constraint", "constraint", mu_obs, mu, ROOT.RooFit.RooConst(0.2))
+constraint = ROOT.RooGaussian("constraint", "constraint", mu_obs, mu, 0.2)
 
 # full pdf including constraint pdf
 model = ROOT.RooProdPdf("model", "model", [gauss, constraint])

--- a/tutorials/roofit/rf705_linearmorph.C
+++ b/tutorials/roofit/rf705_linearmorph.C
@@ -31,7 +31,7 @@ void rf705_linearmorph()
 
    // Lower end point shape: a Gaussian
    RooRealVar g1mean("g1mean", "g1mean", -10);
-   RooGaussian g1("g1", "g1", x, g1mean, RooConst(2));
+   RooGaussian g1("g1", "g1", x, g1mean, 2.0);
 
    // Upper end point shape: a Polynomial
    RooPolynomial g2("g2", "g2", x, RooArgSet(-0.03, -0.001));

--- a/tutorials/roofit/rf705_linearmorph.py
+++ b/tutorials/roofit/rf705_linearmorph.py
@@ -23,7 +23,7 @@ x = ROOT.RooRealVar("x", "x", -20, 20)
 
 # Lower end point shape: a Gaussian
 g1mean = ROOT.RooRealVar("g1mean", "g1mean", -10)
-g1 = ROOT.RooGaussian("g1", "g1", x, g1mean, ROOT.RooFit.RooConst(2))
+g1 = ROOT.RooGaussian("g1", "g1", x, g1mean, 2.0)
 
 # Upper end point shape: a Polynomial
 g2 = ROOT.RooPolynomial("g2", "g2", x, [-0.03, -0.001])

--- a/tutorials/roofit/rf804_mcstudy_constr.C
+++ b/tutorials/roofit/rf804_mcstudy_constr.C
@@ -13,7 +13,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooPolynomial.h"
 #include "RooAddPdf.h"
 #include "RooProdPdf.h"
@@ -45,7 +44,7 @@ void rf804_mcstudy_constr()
    RooAddPdf sum("sum", "sum", RooArgSet(g, p), f);
 
    // Construct constraint on parameter f
-   RooGaussian fconstraint("fconstraint", "fconstraint", f, RooConst(0.7), RooConst(0.1));
+   RooGaussian fconstraint("fconstraint", "fconstraint", f, 0.7, 0.1);
 
    // Multiply constraint with pdf
    RooProdPdf sumc("sumc", "sum with constraint", RooArgSet(sum, fconstraint));

--- a/tutorials/roofit/rf804_mcstudy_constr.py
+++ b/tutorials/roofit/rf804_mcstudy_constr.py
@@ -33,7 +33,7 @@ f = ROOT.RooRealVar("f", "f", 0.4, 0.0, 1.0)
 sum = ROOT.RooAddPdf("sum", "sum", [g, p], [f])
 
 # Construct constraint on parameter f
-fconstraint = ROOT.RooGaussian("fconstraint", "fconstraint", f, ROOT.RooFit.RooConst(0.7), ROOT.RooFit.RooConst(0.1))
+fconstraint = ROOT.RooGaussian("fconstraint", "fconstraint", f, 0.7, 0.1)
 
 # Multiply constraint with p.d.f
 sumc = ROOT.RooProdPdf("sumc", "sum with constraint", [sum, fconstraint])

--- a/tutorials/roofit/rf901_numintconfig.C
+++ b/tutorials/roofit/rf901_numintconfig.C
@@ -12,7 +12,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "TCanvas.h"
 #include "TAxis.h"
 #include "RooPlot.h"
@@ -49,7 +48,7 @@ void rf901_numintconfig()
    // ------------------------------------------------------------------
 
    RooRealVar x("x", "x", -10, 10);
-   RooLandau landau("landau", "landau", x, RooConst(0), RooConst(0.1));
+   RooLandau landau("landau", "landau", x, 0.0, 0.1);
 
    // Disable analytic integration from demonstration purposes
    landau.forceNumInt(true);

--- a/tutorials/roofit/rf901_numintconfig.py
+++ b/tutorials/roofit/rf901_numintconfig.py
@@ -37,7 +37,7 @@ ROOT.RooAbsReal.defaultIntegratorConfig().setEpsRel(1e-6)
 # ------------------------------------------------------------------
 
 x = ROOT.RooRealVar("x", "x", -10, 10)
-landau = ROOT.RooLandau("landau", "landau", x, ROOT.RooFit.RooConst(0), ROOT.RooFit.RooConst(0.1))
+landau = ROOT.RooLandau("landau", "landau", x, 0.0, 0.1)
 
 # Disable analytic integration from demonstration purposes
 landau.forceNumInt(True)


### PR DESCRIPTION
A new mechanism is suggested to enable function signatures that accept both references to RooFit arguments, or `double`s that will be implicitly converted to `RooConst&`.

The only thing that you need to do is to replace for example `RooAbsReal&` with `RooAbsReal::Ref` (or `RooAbsArg::Ref` if you want to use the RooAbsArg base class).

To test this mechanism, it is now supported for the `RooGaussian` and `RooExtendedPdf` and tested in the rf311 tutorial and corresponding `stressRooFit` unit test.