### PR TITLE
[RF] Fix IO and memory problems in RooMomentMorph(Func)ND

### DIFF
--- a/roofit/roofit/inc/RooMomentMorphFuncND.h
+++ b/roofit/roofit/inc/RooMomentMorphFuncND.h
@@ -48,7 +48,7 @@ public:
          _grid.push_back(binning_y.clone());
          _grid.push_back(binning_z.clone());
       };
-      Grid2(const std::vector<RooAbsBinning *> binnings)
+      Grid2(std::vector<RooAbsBinning *> const &binnings)
       {
          for (unsigned int i = 0; i < binnings.size(); i++) {
             _grid.push_back(binnings[i]->clone());
@@ -129,16 +129,16 @@ protected:
    friend class CacheElem;
    friend class Grid2;
 
-   mutable RooObjCacheManager _cacheMgr; ///<! Transient cache manager
-   mutable RooArgSet *_curNormSet;
+   mutable RooObjCacheManager _cacheMgr;     ///<! Transient cache manager
+   mutable RooArgSet *_curNormSet = nullptr; ///<! Transient cache manager
 
    RooListProxy _parList;
    RooSetProxy _obsList;
    mutable Grid2 _referenceGrid;
    RooListProxy _pdfList;
 
-   mutable TMatrixD *_M;
-   mutable TMatrixD *_MSqr;
+   mutable std::unique_ptr<TMatrixD> _M;
+   mutable std::unique_ptr<TMatrixD> _MSqr;
    mutable std::vector<std::vector<double>> _squareVec;
    mutable std::vector<int> _squareIdx;
 
@@ -147,7 +147,7 @@ protected:
 
    inline int sij(const int &i, const int &j) const { return (i * _obsList.getSize() + j); }
 
-   ClassDefOverride(RooMomentMorphFuncND, 2);
+   ClassDefOverride(RooMomentMorphFuncND, 3);
 };
 
 #endif

--- a/roofit/roofit/inc/RooMomentMorphND.h
+++ b/roofit/roofit/inc/RooMomentMorphND.h
@@ -48,7 +48,7 @@ public:
          _grid.push_back(binning_y.clone());
          _grid.push_back(binning_z.clone());
       };
-      Grid2(const std::vector<RooAbsBinning *> binnings)
+      Grid2(std::vector<RooAbsBinning *> const &binnings)
       {
          for (unsigned int i = 0; i < binnings.size(); i++) {
             _grid.push_back(binnings[i]->clone());
@@ -127,16 +127,16 @@ protected:
    friend class CacheElem;
    friend class Grid2;
 
-   mutable RooObjCacheManager _cacheMgr; ///<! Transient cache manager
-   mutable RooArgSet *_curNormSet;
+   mutable RooObjCacheManager _cacheMgr;     ///<! Transient cache manager
+   mutable RooArgSet *_curNormSet = nullptr; ///<! Transient cache manager
 
    RooListProxy _parList;
    RooSetProxy _obsList;
    mutable Grid2 _referenceGrid;
    RooListProxy _pdfList;
 
-   mutable TMatrixD *_M;
-   mutable TMatrixD *_MSqr;
+   mutable std::unique_ptr<TMatrixD> _M;
+   mutable std::unique_ptr<TMatrixD> _MSqr;
    mutable std::vector<std::vector<double>> _squareVec;
    mutable std::vector<int> _squareIdx;
 
@@ -145,7 +145,7 @@ protected:
 
    inline int sij(const int &i, const int &j) const { return (i * _obsList.getSize() + j); }
 
-   ClassDefOverride(RooMomentMorphND, 2);
+   ClassDefOverride(RooMomentMorphND, 3);
 };
 
 #endif

--- a/roofit/roofit/src/RooMomentMorphFuncND.cxx
+++ b/roofit/roofit/src/RooMomentMorphFuncND.cxx
@@ -38,8 +38,7 @@ ClassImp(RooMomentMorphFuncND::Grid2);
 
 //_____________________________________________________________________________
 RooMomentMorphFuncND::RooMomentMorphFuncND()
-   : _cacheMgr(this, 10, true, true), _curNormSet(0), _M(0), _MSqr(0), _setting(RooMomentMorphFuncND::Linear),
-     _useHorizMorph(true)
+   : _cacheMgr(this, 10, true, true), _setting(RooMomentMorphFuncND::Linear), _useHorizMorph(true)
 {
    TRACE_CREATE;
 }
@@ -157,10 +156,10 @@ RooMomentMorphFuncND::RooMomentMorphFuncND(const char *name, const char *title, 
 
 //_____________________________________________________________________________
 RooMomentMorphFuncND::RooMomentMorphFuncND(const RooMomentMorphFuncND &other, const char *name)
-   : RooMomentMorphFuncND::Base_t(other, name), _cacheMgr(other._cacheMgr, this), _curNormSet(0),
+   : RooMomentMorphFuncND::Base_t(other, name), _cacheMgr(other._cacheMgr, this),
      _parList("parList", this, other._parList), _obsList("obsList", this, other._obsList),
-     _referenceGrid(other._referenceGrid), _pdfList("pdfList", this, other._pdfList), _M(0), _MSqr(0),
-     _setting(other._setting), _useHorizMorph(other._useHorizMorph)
+     _referenceGrid(other._referenceGrid), _pdfList("pdfList", this, other._pdfList), _setting(other._setting),
+     _useHorizMorph(other._useHorizMorph)
 {
    // general initialization
    initialize();
@@ -171,11 +170,6 @@ RooMomentMorphFuncND::RooMomentMorphFuncND(const RooMomentMorphFuncND &other, co
 //_____________________________________________________________________________
 RooMomentMorphFuncND::~RooMomentMorphFuncND()
 {
-   if (_M)
-      delete _M;
-   if (_MSqr)
-      delete _MSqr;
-
    TRACE_DESTROY;
 }
 
@@ -232,8 +226,8 @@ void RooMomentMorphFuncND::initialize()
    }
 
    // Transformation matrix for NonLinear settings
-   _M = new TMatrixD(nPdf, nPdf);
-   _MSqr = new TMatrixD(depth, depth);
+   _M = std::make_unique<TMatrixD>(nPdf, nPdf);
+   _MSqr = std::make_unique<TMatrixD>(depth, depth);
    if (_setting == NonLinear || _setting == NonLinearPosFractions || _setting == NonLinearLinFractions) {
       TMatrixD M(nPdf, nPdf);
 
@@ -289,7 +283,12 @@ RooMomentMorphFuncND::Grid2::Grid2(const RooMomentMorphFuncND::Grid2 &other)
 }
 
 //_____________________________________________________________________________
-RooMomentMorphFuncND::Grid2::~Grid2() {}
+RooMomentMorphFuncND::Grid2::~Grid2()
+{
+   for (RooAbsBinning *binning : _grid) {
+      delete binning;
+   }
+}
 
 //_____________________________________________________________________________
 void RooMomentMorphFuncND::Grid2::addPdf(const RooMomentMorphFuncND::Base_t &pdf, int bin_x)

--- a/roofit/roofit/src/RooMomentMorphND.cxx
+++ b/roofit/roofit/src/RooMomentMorphND.cxx
@@ -37,8 +37,7 @@ ClassImp(RooMomentMorphND);
 
 //_____________________________________________________________________________
 RooMomentMorphND::RooMomentMorphND()
-   : _cacheMgr(this, 10, true, true), _curNormSet(0), _M(0), _MSqr(0), _setting(RooMomentMorphND::Linear),
-     _useHorizMorph(true)
+   : _cacheMgr(this, 10, true, true), _setting(RooMomentMorphND::Linear), _useHorizMorph(true)
 {
    TRACE_CREATE;
 }
@@ -154,10 +153,9 @@ RooMomentMorphND::RooMomentMorphND(const char *name, const char *title, RooAbsRe
 
 //_____________________________________________________________________________
 RooMomentMorphND::RooMomentMorphND(const RooMomentMorphND &other, const char *name)
-   : RooMomentMorphND::Base_t(other, name), _cacheMgr(other._cacheMgr, this), _curNormSet(0),
-     _parList("parList", this, other._parList), _obsList("obsList", this, other._obsList),
-     _referenceGrid(other._referenceGrid), _pdfList("pdfList", this, other._pdfList), _M(0), _MSqr(0),
-     _setting(other._setting), _useHorizMorph(other._useHorizMorph)
+   : RooMomentMorphND::Base_t(other, name), _cacheMgr(other._cacheMgr, this), _parList("parList", this, other._parList),
+     _obsList("obsList", this, other._obsList), _referenceGrid(other._referenceGrid),
+     _pdfList("pdfList", this, other._pdfList), _setting(other._setting), _useHorizMorph(other._useHorizMorph)
 {
    // general initialization
    initialize();
@@ -168,11 +166,6 @@ RooMomentMorphND::RooMomentMorphND(const RooMomentMorphND &other, const char *na
 //_____________________________________________________________________________
 RooMomentMorphND::~RooMomentMorphND()
 {
-   if (_M)
-      delete _M;
-   if (_MSqr)
-      delete _MSqr;
-
    TRACE_DESTROY;
 }
 
@@ -229,8 +222,8 @@ void RooMomentMorphND::initialize()
    }
 
    // Transformation matrix for NonLinear settings
-   _M = new TMatrixD(nPdf, nPdf);
-   _MSqr = new TMatrixD(depth, depth);
+   _M = std::make_unique<TMatrixD>(nPdf, nPdf);
+   _MSqr = std::make_unique<TMatrixD>(depth, depth);
    if (_setting == NonLinear || _setting == NonLinearPosFractions || _setting == NonLinearLinFractions) {
       TMatrixD M(nPdf, nPdf);
 
@@ -286,7 +279,12 @@ RooMomentMorphND::Grid2::Grid2(const RooMomentMorphND::Grid2 &other)
 }
 
 //_____________________________________________________________________________
-RooMomentMorphND::Grid2::~Grid2() {}
+RooMomentMorphND::Grid2::~Grid2()
+{
+   for (RooAbsBinning *binning : _grid) {
+      delete binning;
+   }
+}
 
 //_____________________________________________________________________________
 void RooMomentMorphND::Grid2::addPdf(const RooMomentMorphND::Base_t &pdf, int bin_x)


### PR DESCRIPTION
The member that points to the last normalization set should not take part in IO.

Also, a memory leak is fixed and some code is modernized by using `std::unique_ptr`.