### PR TITLE
[RF] Improve implementation of `RooAbsArg::redirectServers()`

### DIFF
--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -266,7 +266,9 @@ public:
 
   void addServer(RooAbsArg& server, bool valueProp=true, bool shapeProp=false, std::size_t refCount = 1);
   void addServerList(RooAbsCollection& serverList, bool valueProp=true, bool shapeProp=false) ;
-  void replaceServer(RooAbsArg& oldServer, RooAbsArg& newServer, bool valueProp, bool shapeProp) ;
+  void
+  R__SUGGEST_ALTERNATIVE("This interface is unsafe! Use RooAbsArg::redirectServers()")
+  replaceServer(RooAbsArg& oldServer, RooAbsArg& newServer, bool valueProp, bool shapeProp) ;
   void changeServer(RooAbsArg& server, bool valueProp, bool shapeProp) ;
   void removeServer(RooAbsArg& server, bool force=false) ;
   RooAbsArg *findNewServer(const RooAbsCollection &newSet, bool nameChange) const;

--- a/roofit/roofitcore/src/RooGenProdProj.cxx
+++ b/roofit/roofitcore/src/RooGenProdProj.cxx
@@ -110,11 +110,6 @@ RooGenProdProj::RooGenProdProj(const RooGenProdProj& other, const char* name) :
   _compSetD("compSetD","Set of integral components owned by denominator",this),
   _intList("intList","List of integrals",this)
 {
-  // Explicitly remove all server links at this point
-  for(RooAbsArg * server : servers()) {
-    removeServer(*server,true) ;
-  }
-
   // Copy constructor
   _compSetOwnedN = new RooArgSet;
   other._compSetN.snapshot(*_compSetOwnedN);


### PR DESCRIPTION
The `RooAbsArg::replaceServer()` function is quite dangerous to use,
because it leaves your RooFit objects in an invalid state. See for
example this code:

```c++
   RooRealVar x("x", "x", -10, 10);
   RooRealVar mean("mean", "mean of gaussian", 1, -10, 10);
   RooRealVar sigma("sigma", "width of gaussian", 1, 0.1, 10);

   RooGaussian gauss("gauss", "gaussian PDF", x, mean, sigma);

   RooRealVar mean2(mean);

   gauss.replaceServer(mean, mean2, true, false);
   gauss.Print("v");

   std::cout << "x    : " << &gauss.getX() << std::endl;
   std::cout << "mean : " << &gauss.getMean() << std::endl;
   std::cout << "sigma: " << &gauss.getSigma() << std::endl;
```

Here, the proxy for `mean` will still point to the original `mean`, but
the server was redirected to the copy `mean2`. This is dangerous, and
desyncing of the proxy and server list are actually the underlying
reason for a set of RooFit problems.

The safter `RooAbsArg::redirectServers()` should always be used,
becauese that one is also updating the proxies. Therefore, the
`replaceServer()` interface is now marked as dangerous everywhere
possible: in a printout when you use it, in the docs, and with the
`R__SUGGEST_ALTERNATIVE` macro.

Internally, the `replaceServer()` was also used in `redirectServers()`.
But this was also causing problems: `replaceServer()` always adds the
new server at the end of the server list, which means the list gets
reordered. This can confuse usercode that rely on the server list being
ordered (yes, that's not a good idea anyway, but there are many codes
that do this). This reordering can also be seein in the example code
above.

Therefore, the `redirectServers()` function is now rewritten to replace
the server without changing its position in the server list. This also
means that the original server list doesn't need to be copied, as not
iterators are invalidated.

Furthermore, the `redirectServers()` is more optimized now. Before, it
redundantly figured out whether a server was a value and/or shape
server. Now, this is figured out only once when removing the original
server from the client.

In summary: this PR makes RooFit code safer and faster by changing
`RooAbsArg::redirectServers()`.