### PR TITLE
[ntuple] Improve I/O and unzip queue management in `RClusterPool`

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RClusterPool.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RClusterPool.hxx
@@ -20,10 +20,10 @@
 #include <ROOT/RNTupleUtil.hxx>
 
 #include <condition_variable>
+#include <deque>
 #include <memory>
 #include <mutex>
 #include <future>
-#include <queue>
 #include <thread>
 #include <set>
 #include <vector>
@@ -109,13 +109,13 @@ private:
    /// Signals a non-empty I/O work queue
    std::condition_variable fCvHasReadWork;
    /// The communication channel to the I/O thread
-   std::queue<RReadItem> fReadQueue;
+   std::deque<RReadItem> fReadQueue;
    /// The lock associated with the fCvHasUnzipWork conditional variable
    std::mutex fLockUnzipQueue;
    /// Signals non-empty unzip work queue
    std::condition_variable fCvHasUnzipWork;
    /// The communication channel between the I/O thread and the unzip thread
-   std::queue<RUnzipItem> fUnzipQueue;
+   std::deque<RUnzipItem> fUnzipQueue;
 
    /// The I/O thread calls RPageSource::LoadClusters() asynchronously.  The thread is mostly waiting for the
    /// data to arrive (blocked by the kernel) and therefore can safely run in addition to the application

--- a/tree/ntuple/v7/src/RClusterPool.cxx
+++ b/tree/ntuple/v7/src/RClusterPool.cxx
@@ -117,9 +117,14 @@ void ROOT::Experimental::Detail::RClusterPool::ExecReadClusters()
       while (!readItems.empty()) {
          std::vector<RCluster::RKey> clusterKeys;
          std::int64_t bunchId = -1;
-         for (auto &item : readItems) {
-            if (item.fClusterKey.fClusterId == kInvalidDescriptorId)
+         for (unsigned i = 0; i < readItems.size(); ++i) {
+            const auto &item = readItems[i];
+            // `kInvalidDescriptorId` is used as a marker for thread cancellation. Such item causes the
+            // thread to terminate; thus, it must appear last in the queue.
+            if (R__unlikely(item.fClusterKey.fClusterId == kInvalidDescriptorId)) {
+               R__ASSERT(i == (readItems.size() - 1));
                return;
+            }
             if ((bunchId >= 0) && (item.fBunchId != bunchId))
                break;
             bunchId = item.fBunchId;


### PR DESCRIPTION
This pull request slighly improves RClusterPool to reduce contention (due to `fLockXxxQueue` being held) in I/O and unzip
threads.

To this end, each thread keeps its local buffer of elements to be processed.  On wakeup, the local copy is swapped with `fXxxQueue`, which not only reduces contention but also reduces the overall number of allocations, as the internal storage of both copies is reused.  The local copy should be cleared before the `std::swap()` in the next iteration.

Also, the unzip thread is just notified once after all the elements are pushed into the queue.

## Checklist:
- [X] tested changes locally