### PR TITLE
[cling] Support noexcept cxa_atexit (libc++):

### DIFF
--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -463,8 +463,8 @@ namespace cling {
     const char* Attr = "";
 #endif
 
-#if defined(__GLIBCXX__)
-    const char* cxa_atexit_is_noexcept = LangOpts.CPlusPlus ? " noexcept" : "";
+#if defined(__GLIBCXX__ || _LIBCPP_VERSION)
+    const char* cxa_atexit_is_noexcept = noexcept(__cxa_atexit) ? " noexcept" : "";
 #else
     const char* cxa_atexit_is_noexcept = "";
 #endif


### PR DESCRIPTION
Also libc++ has a noexcept __cxa_atexit, see https://root-forum.cern.ch/t/libc-issue-on-linux/52433 . Simple ask the compiler.
