### PR TITLE
[ntuple] Allow I/O customization rules with an empty target list

### DIFF
--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1003,7 +1003,8 @@ void ROOT::Experimental::RClassField::OnConnectPageSource()
    if (!ruleset)
       return;
    auto referencesNonTransientMembers = [klass = fClass](const ROOT::TSchemaRule *rule) {
-      R__ASSERT(rule->GetTarget() != nullptr);
+      if (rule->GetTarget() == nullptr)
+         return false;
       for (auto target : ROOT::Detail::TRangeStaticCast<TObjString>(*rule->GetTarget())) {
          const auto dataMember = klass->GetDataMember(target->GetString());
          if (!dataMember || dataMember->IsPersistent()) {


### PR DESCRIPTION
The `target` attribute in a rule specification is mandatory, but the list can be empty, in which case `TSchemaRule::GetTarget()` returns `nullptr`.

In particular, @Nowakus reported the following error for read rules associated with class `ElementLinkBase`, which happens to have an empty `target` list
```
Fatal: rule->GetTarget() != nullptr violated at line 1006 of
`/build/jenkins/workspace/lcg_nightly_pipeline/build/projects/ROOT-HEAD/src/ROOT/HEAD/tree/ntuple/v7/src/RField.cxx'
aborting
```
Therefore, in principle we should also allow these rules for now.

## Checklist:
- [X] tested changes locally
- [ ] updated the docs (if necessary)