### PR TITLE
[RF] Add a C/C++ function wrapper class in roofit.

### DIFF
--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -109,6 +109,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     RooFormulaVar.h
     RooFracRemainder.h
     RooFunctor.h
+    RooFuncWrapper.h
     RooGenContext.h
     RooGenericPdf.h
     RooGenFitStudy.h

--- a/roofit/roofitcore/inc/RooFuncWrapper.h
+++ b/roofit/roofitcore/inc/RooFuncWrapper.h
@@ -1,0 +1,83 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   Garima Singh, CERN 2022
+ *
+ * Copyright (c) 2022, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#ifndef RooFit_RooFuncWrapper_h
+#define RooFit_RooFuncWrapper_h
+
+#include "TROOT.h"
+#include "TSystem.h"
+#include "RooAbsReal.h"
+#include "RooGlobalFunc.h"
+#include "RooMsgService.h"
+#include "RooRealVar.h"
+#include "RooListProxy.h"
+
+#include <memory>
+#include <string>
+
+/// @brief  A wrapper class to store a C++ function of type 'double (*)(double* )'.
+/// The parameters can be accessed as x[<relative position of param in paramSet>] in the function body.
+/// @tparam Func Function pointer to the generated function.
+template <typename Func = double (*)(double *)>
+class RooFuncWrapper final : public RooAbsReal {
+public:
+   RooFuncWrapper(const char *name, const char *title, std::string const &funcBody, RooArgSet const &paramSet)
+      : RooAbsReal{name, title}, _params{"!params", "List of parameters", this}
+   {
+      std::string funcName = name;
+      std::string bodyWithSig = "double " + funcName + "(double* x) {" + funcBody + "}";
+      bool comp = gInterpreter->Declare(bodyWithSig.c_str());
+      if (!comp) {
+         std::stringstream errorMsg;
+         errorMsg << "Function " << funcName << " could not be compiled. See above for details.";
+         coutE(InputArguments) << errorMsg.str() << std::endl;
+         throw std::runtime_error(errorMsg.str().c_str());
+      }
+      _func = (Func)gInterpreter->ProcessLine((funcName + ";").c_str());
+      for (auto *param : paramSet) {
+         if (!dynamic_cast<RooAbsReal *>(param)) {
+            std::stringstream errorMsg;
+            errorMsg << "In creation of function " << funcName
+                     << " wrapper: input param expected to be of type RooAbsReal.";
+            coutE(InputArguments) << errorMsg.str() << std::endl;
+            throw std::runtime_error(errorMsg.str().c_str());
+         }
+         _params.add(*param);
+      }
+   }
+
+   RooFuncWrapper(const RooFuncWrapper &other, const char *name = nullptr)
+      : RooAbsReal(other, name), _params("!params", this, other._params), _func(other._func)
+   {
+   }
+
+   TObject *clone(const char *newname) const override { return new RooFuncWrapper(*this, newname); }
+
+   double defaultErrorLevel() const override { return 0.5; }
+
+protected:
+   double evaluate() const override
+   {
+      std::vector<double> paramVals;
+      paramVals.reserve(_params.size());
+      std::transform(_params.begin(), _params.end(), std::back_inserter(paramVals),
+                     [](RooAbsArg *obj) { return static_cast<RooAbsReal *>(obj)->getValV(); });
+
+      return _func(paramVals.data());
+   }
+
+private:
+   RooListProxy _params;
+   Func _func;
+};
+
+#endif

--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -24,6 +24,7 @@ ROOT_ADD_GTEST(testRooAbsCollection testRooAbsCollection.cxx LIBRARIES RooFitCor
 ROOT_ADD_GTEST(testRooDataSet testRooDataSet.cxx LIBRARIES Tree RooFitCore)
 ROOT_ADD_GTEST(testRooFormula testRooFormula.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testRooProdPdf testRooProdPdf.cxx LIBRARIES RooFitCore)
+ROOT_ADD_GTEST(testRooFuncWrapper testRooFuncWrapper.cxx LIBRARIES RooFitCore RooFit)
 ROOT_ADD_GTEST(testProxiesAndCategories testProxiesAndCategories.cxx
   LIBRARIES RooFitCore
   COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/testProxiesAndCategories_1.root

--- a/roofit/roofitcore/test/testRooFuncWrapper.cxx
+++ b/roofit/roofitcore/test/testRooFuncWrapper.cxx
@@ -1,0 +1,48 @@
+#include <RooRealVar.h>
+#include <RooWorkspace.h>
+#include <RooRealProxy.h>
+#include <RooGaussian.h>
+#include <RooFuncWrapper.h>
+#include <RooDataSet.h>
+#include <RooAbsPdf.h>
+#include <TROOT.h>
+#include <TSystem.h>
+#include <RooFitResult.h>
+#include <RooListProxy.h>
+#include <TMath.h>
+
+#include "gtest/gtest.h"
+
+TEST(RooFuncWrapper, GaussianNormalized)
+{
+   using namespace RooFit;
+
+   auto inf = std::numeric_limits<double>::infinity();
+   RooRealVar x("x", "x", 0, -inf, inf);
+   RooRealVar mu("mu", "mu", 0, -10, 10);
+   RooRealVar sigma("sigma", "sigma", 2.0, 0.01, 10);
+   RooGaussian gauss{"gauss", "gauss", x, mu, sigma};
+
+   RooArgSet normSet{x};
+   RooArgSet paramsGauss;
+   RooArgSet paramsMyGauss;
+
+   std::string func = "const double arg = x[0] - x[1];"
+                      "const double sig = x[2];"
+                      "double out = std::exp(-0.5 * arg * arg / (sig * sig));"
+                      "return 1. / (std::sqrt(TMath::TwoPi()) * sig) * out;";
+   RooFuncWrapper<> gaussFunc("myGauss", "myGauss", func, {x, mu, sigma});
+
+   // Check if functions results are the same even after changing parameters.
+   EXPECT_NEAR(gauss.getVal(normSet), gaussFunc.getVal(), 1e-8);
+
+   mu.setVal(1);
+   EXPECT_NEAR(gauss.getVal(normSet), gaussFunc.getVal(), 1e-8);
+
+   // Check if the parameter layout and size is the same.
+   gauss.getParameters(&normSet, paramsGauss);
+   gaussFunc.getParameters(&normSet, paramsMyGauss);
+
+   EXPECT_TRUE(paramsMyGauss.hasSameLayout(paramsGauss));
+   EXPECT_EQ(paramsMyGauss.size(), paramsGauss.size());
+}


### PR DESCRIPTION
This commit adds a C/C++ function wrapper class that takes in code as a string, declares it, and stores it as a function pointer. Currently, only functions of type `double (*)(double* )` are supported. This class will later be used to store a roofit model as code for automatic differentiation.

