### PR TITLE
Revert LLVM patch for win32

### DIFF
--- a/core/clingutils/res/TClingUtils.h
+++ b/core/clingutils/res/TClingUtils.h
@@ -575,10 +575,10 @@ static inline std::string DemangleNameForDlsym(const std::string& name)
 {
    std::string nameForDlsym = name;
 
-#ifdef R__MACOSX
+#if defined(R__MACOSX) || defined(R__WIN32)
    // The JIT gives us a mangled name which has an additional leading underscore
-   // macOS, for instance __ZN8TRandom34RndmEv. However, dlsym requires us to
-   // remove it.
+   // on macOS and Windows, for instance __ZN8TRandom34RndmEv. However, dlsym
+   // requires us to remove it.
    // FIXME: get this information from the DataLayout via getGlobalPrefix()!
    if (nameForDlsym[0] == '_')
       nameForDlsym.erase(0, 1);

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -7148,18 +7148,12 @@ static std::string GetSharedLibImmediateDepsSlow(std::string lib,
             continue;
       }
 
-// FIXME: this might really depend on MachO library format instead of R__MACOSX.
-#ifdef R__MACOSX
-      // MacOS symbols sometimes have an extra "_", see
-      // https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/dlsym.3.html
-      if (skipLoadedLibs && SymName[0] == '_'
-            && llvm::sys::DynamicLibrary::SearchForAddressOfSymbol(SymName.drop_front().str()))
-         continue;
-#endif
-
       // If we can find the address of the symbol, we have loaded it. Skip.
-      if (skipLoadedLibs && llvm::sys::DynamicLibrary::SearchForAddressOfSymbol(SymName.str()))
-         continue;
+      if (skipLoadedLibs) {
+         std::string SymNameForDlsym = ROOT::TMetaUtils::DemangleNameForDlsym(SymName.str());
+         if (llvm::sys::DynamicLibrary::SearchForAddressOfSymbol(SymNameForDlsym))
+            continue;
+      }
 
       R__LOCKGUARD(gInterpreterMutex);
       std::string found = interp->getDynamicLibraryManager()->searchLibrariesForSymbol(SymName, /*searchSystem*/false);

--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -1389,10 +1389,6 @@ namespace {
     }
 
     llvm::Triple TheTriple(llvm::sys::getProcessTriple());
-#ifdef _WIN32
-    // COFF format currently needs a few changes in LLVM to function properly.
-    TheTriple.setObjectFormat(llvm::Triple::COFF);
-#endif
     clang::driver::Driver Drvr(argv[0], TheTriple.getTriple(), *Diags);
     //Drvr.setWarnMissingInput(false);
     Drvr.setCheckInputsExist(false); // think foo.C(12)

--- a/interpreter/cling/lib/Interpreter/IncrementalJIT.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalJIT.cpp
@@ -262,8 +262,6 @@ Error RTDynamicLibrarySearchGenerator::tryToGenerate(
     JITDylibLookupFlags JDLookupFlags, const SymbolLookupSet &Symbols) {
   orc::SymbolMap NewSymbols;
 
-  bool HasGlobalPrefix = (GlobalPrefix != '\0');
-
   for (auto &KV : Symbols) {
     auto &Name = KV.first;
 
@@ -273,11 +271,10 @@ Error RTDynamicLibrarySearchGenerator::tryToGenerate(
     if (Allow && !Allow(Name))
       continue;
 
-    if (HasGlobalPrefix && (*Name).front() != GlobalPrefix)
-      continue;
+    bool StripGlobalPrefix = (GlobalPrefix != '\0' && (*Name).front() == GlobalPrefix);
 
-    std::string Tmp((*Name).data() + HasGlobalPrefix,
-                    (*Name).size() - HasGlobalPrefix);
+    std::string Tmp((*Name).data() + StripGlobalPrefix,
+                    (*Name).size() - StripGlobalPrefix);
     if (void *Addr = Dylib.getAddressOfSymbol(Tmp.c_str())) {
       NewSymbols[Name] = JITEvaluatedSymbol(
           static_cast<JITTargetAddress>(reinterpret_cast<uintptr_t>(Addr)),

--- a/interpreter/llvm/src/include/llvm/IR/DataLayout.h
+++ b/interpreter/llvm/src/include/llvm/IR/DataLayout.h
@@ -319,9 +319,9 @@ public:
     case MM_Mips:
     case MM_WinCOFF:
     case MM_XCOFF:
-    case MM_WinCOFFX86:
       return '\0';
     case MM_MachO:
+    case MM_WinCOFFX86:
       return '_';
     }
     llvm_unreachable("invalid mangling mode");


### PR DESCRIPTION
The issue was the in-process lookup of C++ symbols failed with a `GlobalPrefix`.