### PR TITLE
Plot markers using their actual size

### DIFF
--- a/graf2d/quartz/src/QuartzMarker.mm
+++ b/graf2d/quartz/src/QuartzMarker.mm
@@ -18,10 +18,11 @@ namespace Quartz {
 
 
 //______________________________________________________________________________
-void DrawMarkerDot(CGContextRef ctx, unsigned n, const TPoint *xy)
+void DrawMarkerDot(CGContextRef ctx, unsigned n, const TPoint *xy,
+                   Size_t markerSize)
 {
    for (unsigned i = 0; i < n; ++i)
-      CGContextFillRect(ctx, CGRectMake(xy[i].fX, xy[i].fY, 1.f, 1.f));
+      CGContextFillRect(ctx, CGRectMake(xy[i].fX, xy[i].fY, markerSize, markerSize));
 }
 
 
@@ -909,7 +910,7 @@ void DrawPolyMarker(CGContextRef ctx, unsigned nPoints, const TPoint *xy,
 {
    switch (markerStyle) {
    case kDot:
-      DrawMarkerDot(ctx, nPoints, xy);
+      DrawMarkerDot(ctx, nPoints, xy, markerSize);
       break;
    case kPlus:
       DrawMarkerPlus(ctx, nPoints, xy, markerSize);


### PR DESCRIPTION
The marker size in Quartz was using fixed value 1, ignoring that the size must be scaled for retina displays.

# This Pull request:
Propagates the scaled marker size to the CGContextFillRect method in charge of the actual drawing

## Changes or fixes:
Fixes (among others) the wrong ray-tracing output mentioned in #12035

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

