### PR TITLE
[cmake] Do not duplicate foundation etc headers in Core.pcm:

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -237,6 +237,11 @@ if (runtime_cxxmodules)
   list(APPEND core_implicit_modules "-mByproduct" "ROOT_Rtypes")
 endif(runtime_cxxmodules)
 
+# These are already part of other modules
+list(REMOVE_ITEM Clib_dict_headers strlcpy.h snprintf.h)
+list(REMOVE_ITEM Foundation_dict_headers ESTLType.h TClassEdit.h ThreadLocalStorage.h ROOT/RStringView.hxx)
+list(REMOVE_ITEM Meta_dict_headers TIsAProxy.h TVirtualIsAProxy.h)
+
 ROOT_GENERATE_DICTIONARY(G__Core
   ${Core_dict_headers}
   ${Clib_dict_headers}


### PR DESCRIPTION
This circumvents the warnings:

```
[2751/6001] Generating G__Core.cxx, ../lib/Core.pcm
Warning in <CheckModuleValid>: after creating module "Core" the following headers are not part of that module:
  strlcpy.h (already part of top-level module "ROOT_Foundation_C")
  snprintf.h (already part of top-level module "ROOT_Foundation_C")
  ESTLType.h (already part of top-level module "ROOT_Foundation_Stage1_NoRTTI")
  TClassEdit.h (already part of top-level module "ROOT_Foundation_Stage1_NoRTTI")
  ThreadLocalStorage.h (already part of top-level module "ROOT_Foundation_C")
  ROOT/RStringView.hxx (already part of top-level module "ROOT_Foundation_Stage1_NoRTTI")
  TIsAProxy.h (already part of top-level module "ROOT_Foundation_Stage1_NoRTTI")
  TVirtualIsAProxy.h (already part of top-level module "ROOT_Foundation_Stage1_NoRTTI")
```
