### PR TITLE
New constructors for TAxis, THnSparse and friends.

### DIFF
--- a/hist/hist/inc/TAxis.h
+++ b/hist/hist/inc/TAxis.h
@@ -41,9 +41,9 @@ private:
    UShort_t     fBits2;         ///<  Second bit status word
    Bool_t       fTimeDisplay;   ///<  On/off displaying time values instead of numerics
    TString      fTimeFormat;    ///<  Date&time format, ex: 09/12/99 12:34:00
-   TObject     *fParent;        ///<! Object owning this axis
-   THashList   *fLabels;        ///<  List of labels
-   TList       *fModLabs;       ///<  List of modified labels
+   TObject     *fParent = nullptr;  ///<! Object owning this axis
+   THashList   *fLabels = nullptr;  ///<  List of labels
+   TList       *fModLabs = nullptr; ///<  List of modified labels
 
    /// TAxis extra status bits (stored in fBits2)
    enum {
@@ -80,8 +80,7 @@ public:
    TAxis();
    TAxis(Int_t nbins, Double_t xmin, Double_t xmax);
    TAxis(Int_t nbins, const Double_t *xbins);
-   TAxis(const std::vector<double>& bins);
-   TAxis(std::vector<double>&& bins);
+   TAxis(std::vector<double> const &bins);
    TAxis(const TAxis &axis);
    ~TAxis() override;
    TAxis& operator=(const TAxis&);

--- a/hist/hist/inc/TAxis.h
+++ b/hist/hist/inc/TAxis.h
@@ -24,6 +24,7 @@
 #include "TNamed.h"
 #include "TAttAxis.h"
 #include "TArrayD.h"
+#include <vector>
 
 class THashList;
 class TAxisModLab;
@@ -79,6 +80,8 @@ public:
    TAxis();
    TAxis(Int_t nbins, Double_t xmin, Double_t xmax);
    TAxis(Int_t nbins, const Double_t *xbins);
+   TAxis(const std::vector<double>& bins);
+   TAxis(std::vector<double>&& bins);
    TAxis(const TAxis &axis);
    ~TAxis() override;
    TAxis& operator=(const TAxis&);

--- a/hist/hist/inc/THnBase.h
+++ b/hist/hist/inc/THnBase.h
@@ -65,8 +65,6 @@ protected:
     THnBase(const char *name, const char *title, Int_t dim, const Int_t *nbins, const Double_t *xmin,
             const Double_t *xmax);
 
-    THnBase(const char* name, const char* title, const std::vector<TAxis*>& axes);
-
     THnBase(const char* name, const char* title, const std::vector<TAxis>& axes);
 
     THnBase(const char *name, const char *title, Int_t dim, const Int_t *nbins,

--- a/hist/hist/inc/THnBase.h
+++ b/hist/hist/inc/THnBase.h
@@ -25,6 +25,8 @@
 #include "TFitResultPtr.h"
 #include "TObjArray.h"
 #include "TArrayD.h"
+#include <vector>
+
 
 class TAxis;
 class TH1;
@@ -62,6 +64,10 @@ protected:
 
     THnBase(const char *name, const char *title, Int_t dim, const Int_t *nbins, const Double_t *xmin,
             const Double_t *xmax);
+
+    THnBase(const char* name, const char* title, const std::vector<TAxis*>& axes);
+
+    THnBase(const char* name, const char* title, const std::vector<TAxis>& axes);
 
     THnBase(const char *name, const char *title, Int_t dim, const Int_t *nbins,
             const std::vector<std::vector<double>> &xbins);

--- a/hist/hist/inc/THnSparse.h
+++ b/hist/hist/inc/THnSparse.h
@@ -52,6 +52,13 @@ class THnSparse: public THnBase {
    THnSparse(const char* name, const char* title, Int_t dim,
              const Int_t* nbins, const Double_t* xmin, const Double_t* xmax,
              Int_t chunksize);
+   THnSparse(const char* name, const char* title,
+             const std::vector<TAxis*>& axes,
+             Int_t chunksize);
+   THnSparse(const char* name, const char* title,
+             const std::vector<TAxis>& axes,
+             Int_t chunksize);
+
    THnSparseCompactBinCoord* GetCompactCoord() const;
    THnSparseArrayChunk* GetChunk(Int_t idx) const {
       return (THnSparseArrayChunk*) fBinContent[idx]; }
@@ -211,6 +218,15 @@ class THnSparseT: public THnSparse {
               const Int_t* nbins, const Double_t* xmin = nullptr,
               const Double_t* xmax = nullptr, Int_t chunksize = 1024 * 16):
       THnSparse(name, title, dim, nbins, xmin, xmax, chunksize) {}
+   THnSparseT(const char* name, const char* title,
+              std::vector<TAxis*> axes,
+              Int_t chunksize = 1024 * 16):
+     THnSparse(name, title, axes, chunksize) {}
+   THnSparseT(const char* name, const char* title,
+             std::vector<TAxis> axes,
+             Int_t chunksize = 1024 * 16):
+     THnSparse(name, title, axes, chunksize) {}
+
 
    TArray* GenerateArray() const override { return new CONT(GetChunkSize()); }
  private:

--- a/hist/hist/inc/THnSparse.h
+++ b/hist/hist/inc/THnSparse.h
@@ -48,17 +48,6 @@ class THnSparse: public THnBase {
 
  protected:
 
-   THnSparse();
-   THnSparse(const char* name, const char* title, Int_t dim,
-             const Int_t* nbins, const Double_t* xmin, const Double_t* xmax,
-             Int_t chunksize);
-   THnSparse(const char* name, const char* title,
-             const std::vector<TAxis*>& axes,
-             Int_t chunksize);
-   THnSparse(const char* name, const char* title,
-             const std::vector<TAxis>& axes,
-             Int_t chunksize);
-
    THnSparseCompactBinCoord* GetCompactCoord() const;
    THnSparseArrayChunk* GetChunk(Int_t idx) const {
       return (THnSparseArrayChunk*) fBinContent[idx]; }
@@ -79,6 +68,15 @@ class THnSparse: public THnBase {
    void InitStorage(Int_t* nbins, Int_t chunkSize) override;
 
  public:
+
+   THnSparse();
+   THnSparse(const char* name, const char* title, Int_t dim,
+             const Int_t* nbins, const Double_t* xmin = nullptr, const Double_t* xmax = nullptr,
+             Int_t chunksize = 1024 * 16);
+   THnSparse(const char* name, const char* title,
+             const std::vector<TAxis>& axes,
+             Int_t chunksize = 1024 * 16);
+
    ~THnSparse() override;
 
    static THnSparse* CreateSparse(const char* name, const char* title,
@@ -213,20 +211,7 @@ class THnSparse: public THnBase {
 template <class CONT>
 class THnSparseT: public THnSparse {
  public:
-   THnSparseT() {}
-   THnSparseT(const char* name, const char* title, Int_t dim,
-              const Int_t* nbins, const Double_t* xmin = nullptr,
-              const Double_t* xmax = nullptr, Int_t chunksize = 1024 * 16):
-      THnSparse(name, title, dim, nbins, xmin, xmax, chunksize) {}
-   THnSparseT(const char* name, const char* title,
-              std::vector<TAxis*> axes,
-              Int_t chunksize = 1024 * 16):
-     THnSparse(name, title, axes, chunksize) {}
-   THnSparseT(const char* name, const char* title,
-             std::vector<TAxis> axes,
-             Int_t chunksize = 1024 * 16):
-     THnSparse(name, title, axes, chunksize) {}
-
+   using THnSparse::THnSparse;
 
    TArray* GenerateArray() const override { return new CONT(GetChunkSize()); }
  private:

--- a/hist/hist/src/TAxis.cxx
+++ b/hist/hist/src/TAxis.cxx
@@ -54,9 +54,6 @@ TAxis::TAxis()
    fXmax    = 1;
    fFirst   = 0;
    fLast    = 0;
-   fParent  = nullptr;
-   fLabels  = nullptr;
-   fModLabs = nullptr;
    fBits2   = 0;
    fTimeDisplay = false;
 }
@@ -66,9 +63,6 @@ TAxis::TAxis()
 
 TAxis::TAxis(Int_t nbins,Double_t xlow,Double_t xup)
 {
-   fParent  = nullptr;
-   fLabels  = nullptr;
-   fModLabs = nullptr;
    Set(nbins,xlow,xup);
 }
 
@@ -77,17 +71,10 @@ TAxis::TAxis(Int_t nbins,Double_t xlow,Double_t xup)
 
 TAxis::TAxis(Int_t nbins,const Double_t *xbins)
 {
-   fParent  = nullptr;
-   fLabels  = nullptr;
-   fModLabs = nullptr;
    Set(nbins,xbins);
 }
 
-TAxis::TAxis(const std::vector<double>& bins):
-  TAxis(bins.size()-1, bins.data())
-{}
-
-TAxis::TAxis(std::vector<double>&& bins):
+TAxis::TAxis(std::vector<double> const &bins):
   TAxis(bins.size()-1, bins.data())
 {}
 

--- a/hist/hist/src/TAxis.cxx
+++ b/hist/hist/src/TAxis.cxx
@@ -83,6 +83,14 @@ TAxis::TAxis(Int_t nbins,const Double_t *xbins)
    Set(nbins,xbins);
 }
 
+TAxis::TAxis(const std::vector<double>& bins):
+  TAxis(bins.size()-1, bins.data())
+{}
+
+TAxis::TAxis(std::vector<double>&& bins):
+  TAxis(bins.size()-1, bins.data())
+{}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Destructor.
 

--- a/hist/hist/src/THnBase.cxx
+++ b/hist/hist/src/THnBase.cxx
@@ -64,6 +64,31 @@ fIntegral(0), fIntegralStatus(kNoInt)
    fAxes.SetOwner();
 }
 
+THnBase::THnBase(const char* name, const char* title, const std::vector<TAxis*>& axes):
+  TNamed(name, title), fNdimensions(axes.size()), fAxes(axes.size()), fBrowsables(axes.size()),
+  fEntries(0), fTsumw(0), fTsumw2(-1.), fTsumwx(axes.size()), fTsumwx2(axes.size()),
+  fIntegral(0), fIntegralStatus(kNoInt)
+{
+  size_t i{};
+  for (auto& a: axes)
+    fAxes.AddAtAndExpand(a->Clone(), i++);
+  // Assuming SetTitle is done by TNamed.
+  fAxes.SetOwner();
+}
+
+THnBase::THnBase(const char* name, const char* title, const std::vector<TAxis>& axes):
+  TNamed(name, title), fNdimensions(axes.size()), fAxes(axes.size()), fBrowsables(axes.size()),
+  fEntries(0), fTsumw(0), fTsumw2(-1.), fTsumwx(axes.size()), fTsumwx2(axes.size()),
+  fIntegral(0), fIntegralStatus(kNoInt)
+{
+  size_t i{};
+  for (auto& a: axes)
+    fAxes.AddAtAndExpand(a.Clone(), i++);
+  // Assuming SetTitle is done by TNamed.
+  fAxes.SetOwner();
+}
+
+
 THnBase::THnBase(const char *name, const char *title, Int_t dim, const Int_t *nbins,
                  const std::vector<std::vector<double>> &xbins)
    : TNamed(name, title), fNdimensions(dim), fAxes(dim), fBrowsables(dim), fEntries(0), fTsumw(0), fTsumw2(-1.),

--- a/hist/hist/src/THnBase.cxx
+++ b/hist/hist/src/THnBase.cxx
@@ -64,18 +64,6 @@ fIntegral(0), fIntegralStatus(kNoInt)
    fAxes.SetOwner();
 }
 
-THnBase::THnBase(const char* name, const char* title, const std::vector<TAxis*>& axes):
-  TNamed(name, title), fNdimensions(axes.size()), fAxes(axes.size()), fBrowsables(axes.size()),
-  fEntries(0), fTsumw(0), fTsumw2(-1.), fTsumwx(axes.size()), fTsumwx2(axes.size()),
-  fIntegral(0), fIntegralStatus(kNoInt)
-{
-  size_t i{};
-  for (auto& a: axes)
-    fAxes.AddAtAndExpand(a->Clone(), i++);
-  // Assuming SetTitle is done by TNamed.
-  fAxes.SetOwner();
-}
-
 THnBase::THnBase(const char* name, const char* title, const std::vector<TAxis>& axes):
   TNamed(name, title), fNdimensions(axes.size()), fAxes(axes.size()), fBrowsables(axes.size()),
   fEntries(0), fTsumw(0), fTsumw2(-1.), fTsumwx(axes.size()), fTsumwx2(axes.size()),

--- a/hist/hist/src/THnSparse.cxx
+++ b/hist/hist/src/THnSparse.cxx
@@ -611,6 +611,46 @@ THnSparse::THnSparse(const char* name, const char* title, Int_t dim,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Construct a THnSparse with chunksize as the size of the chunks.
+/// "axes" is a vector of TAxis*, its size sets the number of dimensions.
+
+THnSparse::THnSparse(const char* name, const char* title,
+                     const std::vector<TAxis*>& axes,
+                     Int_t chunksize):
+   THnBase(name, title, axes),
+   fChunkSize(chunksize), fFilledBins(0), fCompactCoord(nullptr)
+{
+  const size_t dim=axes.size();
+  auto nbins=new Int_t[dim];
+  for (size_t i=0; i<dim; i++)
+    nbins[i]=axes.at(i)->GetNbins();
+  fCompactCoord = new THnSparseCompactBinCoord(dim, nbins);
+  fBinContent.SetOwner();
+  delete[] nbins;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Construct a THnSparse with chunksize as the size of the chunks.
+/// "axes" is a vector of TAxis, its size sets the number of dimensions.
+/// This method is convenient for passing the Axes on the fly:
+/// auto h0= new THnSparseI{"h0", "", {{100, -50., 50.}, {50, -1000., 1000.}}};
+
+THnSparse::THnSparse(const char* name, const char* title,
+                     const std::vector<TAxis>& axes,
+                     Int_t chunksize):
+THnBase(name, title, axes),
+  fChunkSize(chunksize), fFilledBins(0), fCompactCoord(nullptr)
+{
+  const size_t dim=axes.size();
+  auto nbins=new Int_t[dim];
+  for (size_t i=0; i<dim; i++)
+    nbins[i]=axes.at(i).GetNbins();
+  fCompactCoord = new THnSparseCompactBinCoord(dim, nbins);
+  fBinContent.SetOwner();
+  delete[] nbins;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Destruct a THnSparse
 
 THnSparse::~THnSparse() {

--- a/hist/hist/src/THnSparse.cxx
+++ b/hist/hist/src/THnSparse.cxx
@@ -612,25 +612,6 @@ THnSparse::THnSparse(const char* name, const char* title, Int_t dim,
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Construct a THnSparse with chunksize as the size of the chunks.
-/// "axes" is a vector of TAxis*, its size sets the number of dimensions.
-
-THnSparse::THnSparse(const char* name, const char* title,
-                     const std::vector<TAxis*>& axes,
-                     Int_t chunksize):
-   THnBase(name, title, axes),
-   fChunkSize(chunksize), fFilledBins(0), fCompactCoord(nullptr)
-{
-  const size_t dim=axes.size();
-  auto nbins=new Int_t[dim];
-  for (size_t i=0; i<dim; i++)
-    nbins[i]=axes.at(i)->GetNbins();
-  fCompactCoord = new THnSparseCompactBinCoord(dim, nbins);
-  fBinContent.SetOwner();
-  delete[] nbins;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Construct a THnSparse with chunksize as the size of the chunks.
 /// "axes" is a vector of TAxis, its size sets the number of dimensions.
 /// This method is convenient for passing the Axes on the fly:
 /// auto h0= new THnSparseI{"h0", "", {{100, -50., 50.}, {50, -1000., 1000.}}};


### PR DESCRIPTION
## Changes or fixes:

With ROOT6 understanding STL containers, there is no reason to pass arrays as two parameters ``(int size, some_t* array)``. 

A TAxis with custom bins can now be constructed from a ``std::vector<double>``, which will be convenient later. 

A THnSparseT can now be constructed from either a ``std::vector<TAxis*>`` (more in the spirit "always use pointers" of ROOT) or ``std::vector<TAxis>`` (which allows neatly filling the vector from a initializer list, but does not allow the reuse of one TAxis object in different vectors, not that I personally care). 

Both forms will allow providing some TAxis in the (bins, min, max) scheme and other axes as an explicit list, which previous constructors did not support. (I have not yet tested such histograms much yet.)

One might discuss marking the new TAxis constructor explicit to prevent implicit conversion of ``std::vector<double>``. 

## Checklist:
- [x] tested changes locally (compiles, GetAxis results look like what I expected.)
- [X] updated the docs (if necessary) (Only the /// Comment in some constructors)

Excerpt from [test2.txt](https://github.com/root-project/root/files/10451814/test2.txt)
```
  // old:
  std::vector<double> xv{0, 1, 2, 3, 4, 5};
  TAxis a0 {int(xv.size()-1), xv.data()};
  // new: construct axis from std::vector<double> bin list
  TAxis a1 {{0, 1, 2, 3, 4, 5}}; 
  ...
  //THnSparseX by std::vector<TAxis>:
  THnSparseD h{"test", "test",
               // std::vector<TAxis>
               {{100, 0., 20.},                // TAxis by bins, min, max
                {int(xv.size()-1), xv.data()}, // TAxis by bins, double*
                {{7, 8, 9, 10, 11}} }};        // TAxis by new constructor
```
Excerpt from [out.txt](https://github.com/root-project/root/files/10451816/out.txt):
```
THnSparseT<TArrayD> (*0x7ffd225ee5a0): "test" "test"
  3 dimensions, 1 entries in 1 filled bins
  axis 0: 100 bins from 0 to 20 (uniform bin widths)
  axis 1: 5 bins from 0 to 5 (custom bin widths)
  axis 2: 4 bins from 7 to 11 (custom bin widths)
```
