### PR TITLE
REve: Correction in streaming of REveGeoShape render data

### DIFF
--- a/graf3d/eve7/src/REveGeoShape.cxx
+++ b/graf3d/eve7/src/REveGeoShape.cxx
@@ -146,26 +146,18 @@ void REveGeoShape::BuildRenderData()
 {
    if (!fShape) return;
 
-   REveGeoPolyShape *egps = nullptr;
-   std::unique_ptr<REveGeoPolyShape> tmp_egps;
+   fRenderData = std::make_unique<REveRenderData>("makeEveGeoShape");
+   REveElement::BuildRenderData();
 
    if (fCompositeShape) {
-
-      egps = dynamic_cast<REveGeoPolyShape *>(fShape);
-
+      REveGeoPolyShape* egps = dynamic_cast<REveGeoPolyShape *>(fShape);
+      egps->FillRenderData(*fRenderData);
    } else {
-
-      tmp_egps = std::make_unique<REveGeoPolyShape>();
-
+      REveGeoManagerHolder gmgr(fgGeoManager);
+      std::unique_ptr<REveGeoPolyShape> tmp_egps = std::make_unique<REveGeoPolyShape>();
       tmp_egps->BuildFromShape(fShape, fNSegments);
-
-      egps = tmp_egps.get();
+      tmp_egps->FillRenderData(*fRenderData);
    }
-
-   fRenderData = std::make_unique<REveRenderData>("makeEveGeoShape");
-
-   REveElement::BuildRenderData();
-   egps->FillRenderData(*fRenderData);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf3d/eve7/src/REvePointSet.cxx
+++ b/graf3d/eve7/src/REvePointSet.cxx
@@ -574,6 +574,10 @@ void REvePointSetProjected::UpdateProjection()
    Int_t n = ps.GetSize();
    Reset(n);
    fSize = n;
+
+   if (n == 0)
+     return;
+
    const Float_t *o = & ps.RefPoint(0).fX;
          Float_t *p = & fPoints[0].fX;
    for (Int_t i = 0; i < n; ++i, o+=3, p+=3)


### PR DESCRIPTION
This PR fixes a possible crash in streaming REveGeoShape because local geo manger forgot to be set.
It also fixes crash in projecting empty point set.

