### PR TITLE
[math] Replace TRef with array indices in `TFoamCell`

### DIFF
--- a/math/foam/inc/TFoam.h
+++ b/math/foam/inc/TFoam.h
@@ -43,7 +43,7 @@ protected:
 
    Int_t   fNoAct;            ///< Number of active cells
    Int_t   fLastCe;           ///< Index of the last cell
-   TFoamCell **fCells;        ///< [fNCells] Array of ALL cells
+   TFoamCell **fCells = nullptr; ///< [fNCells] Array of ALL cells
 
    TFoamMaxwt   *fMCMonit;    ///< Monitor of the MC weight for measuring MC efficiency
    Double_t   fMaxWtRej;      ///< Maximum weight in rejection for getting wt=1 events
@@ -138,6 +138,7 @@ public:
    // Inline
 private:
    Double_t Sqr(Double_t x) const { return x*x;}      // Square function
+   TFoamCell* getCell(std::size_t i) const;
 
    ClassDefOverride(TFoam,2);   // General purpose self-adapting Monte Carlo event generator
 };

--- a/math/foam/inc/TFoamCell.h
+++ b/math/foam/inc/TFoamCell.h
@@ -18,9 +18,21 @@ private:
    //--- linked tree organization ---
    Int_t    fSerial;                ///< Serial number
    Int_t    fStatus;                ///< Status (active, inactive)
-   TRef     fParent;                ///< Pointer to parent cell
-   TRef     fDaught0;               ///< Pointer to daughter 1
-   TRef     fDaught1;               ///< Pointer to daughter 2
+
+   // For backwards compatibility. The TFoam v1 and v2 classes use these
+   // members. Getting rid of them and doing a schema evolution rule for
+   // TFoamCell doesn't seem to work, because the TRefs can't be dereferenced
+   // at that point yet.
+   TRef fParent;    ///< Pointer to parent cell
+   TRef fDaught0;   ///< Pointer to daughter 1
+   TRef fDaught1;   ///< Pointer to daughter 2
+
+   Int_t fParentIdx = -1;    ///< Serial number of parent cell
+   Int_t fDaught0Idx = -1;   ///< Serial number of daughter 1
+   Int_t fDaught1Idx = -1;   ///< Serial number of daughter 2
+
+   // Note: the fCells member doesn't take part in IO because it will be filled by the TFoam object.
+   TFoamCell** fCells = nullptr;    ///<! Array of ALL cells, owned by the TFoam object
    //--- M.C. sampling and choice of the best edge ---
 private:
    Double_t fXdiv;                  ///< Factor for division
@@ -34,10 +46,10 @@ private:
 public:
    TFoamCell();                          // Default Constructor for ROOT streamers
    TFoamCell(Int_t);                     // User Constructor
-   TFoamCell(TFoamCell &);               // Copy Constructor
-   ~TFoamCell() override;                 // Destructor
+   TFoamCell(TFoamCell &);      // Copy Constructor
+   ~TFoamCell() override;                // Destructor
    void  Fill(Int_t, TFoamCell*, TFoamCell*, TFoamCell*);    // Assigns values of attributes
-   TFoamCell&  operator=(const TFoamCell&);       // Substitution operator (never used)
+   TFoamCell&  operator=(const TFoamCell&);   // Substitution operator (never used)
    //--------------- Geometry ----------------------------------
    Double_t  GetXdiv() const { return fXdiv;}          // Pointer to Xdiv
    Int_t     GetBest() const { return fBest;}          // Pointer to Best
@@ -57,16 +69,21 @@ public:
    //--------------- linked tree organization ------------------
    Int_t     GetStat() const { return fStatus;}        // Get Status
    void      SetStat(Int_t Stat){ fStatus=Stat;}       // Set Status
-   TFoamCell* GetPare() const { return (TFoamCell*) fParent.GetObject(); }  // Get Pointer to parent cell
-   TFoamCell* GetDau0() const { return (TFoamCell*) fDaught0.GetObject(); } // Get Pointer to 1-st daughter vertex
-   TFoamCell* GetDau1() const { return (TFoamCell*) fDaught1.GetObject(); } // Get Pointer to 2-nd daughter vertex
-   void      SetDau0(TFoamCell* Daug){ fDaught0 = Daug;}  // Set pointer to 1-st daughter
-   void      SetDau1(TFoamCell* Daug){ fDaught1 = Daug;}  // Set pointer to 2-nd daughter
+
+   // For backwards compatibility, fall back to the TRefs if the index is not set.
+   TFoamCell* GetPare() const { return fParentIdx >= 0 ? fCells[fParentIdx] : (TFoamCell*) fParent.GetObject(); }    // Get Pointer to parent cell
+   TFoamCell* GetDau0() const { return fDaught0Idx >= 0 ? fCells[fDaught0Idx] : (TFoamCell*) fDaught0.GetObject(); } // Get Pointer to 1-st daughter vertex
+   TFoamCell* GetDau1() const { return fDaught1Idx >= 0 ? fCells[fDaught1Idx] : (TFoamCell*) fDaught1.GetObject(); } // Get Pointer to 2-nd daughter vertex
+
+   void      SetDau0(TFoamCell* Daug){ fDaught0Idx = Daug ? Daug->fSerial : -1;}  // Set pointer to 1-st daughter
+   void      SetDau1(TFoamCell* Daug){ fDaught1Idx = Daug ? Daug->fSerial : -1;}  // Set pointer to 2-nd daughter
    void      SetSerial(Int_t Serial){ fSerial=Serial;}    // Set serial number
    Int_t     GetSerial() const { return fSerial;}         // Get serial number
+   void      SetCells(TFoamCell** cells) { fCells = cells;} // Set the pointer to the cells array
+   TFoamCell** GetCells() const { return fCells;}           // Return the pointer to the cells array
    //--- other ---
    void Print(Option_t *option) const override ;                   // Prints cell content
 
-   ClassDefOverride(TFoamCell,1)  //Single cell of FOAM
+   ClassDefOverride(TFoamCell,2)  //Single cell of FOAM
 };
 #endif

--- a/math/foam/inc/TFoamCell.h
+++ b/math/foam/inc/TFoamCell.h
@@ -46,10 +46,12 @@ private:
 public:
    TFoamCell();                          // Default Constructor for ROOT streamers
    TFoamCell(Int_t);                     // User Constructor
-   TFoamCell(TFoamCell &);      // Copy Constructor
+   TFoamCell(TFoamCell const&) = delete;      // Copy Constructor
+   TFoamCell(TFoamCell &&) = delete;
    ~TFoamCell() override;                // Destructor
    void  Fill(Int_t, TFoamCell*, TFoamCell*, TFoamCell*);    // Assigns values of attributes
-   TFoamCell&  operator=(const TFoamCell&);   // Substitution operator (never used)
+   TFoamCell&  operator=(const TFoamCell&) = delete;   // Substitution operator (never used)
+   TFoamCell&  operator=(TFoamCell &&) = delete;
    //--------------- Geometry ----------------------------------
    Double_t  GetXdiv() const { return fXdiv;}          // Pointer to Xdiv
    Int_t     GetBest() const { return fBest;}          // Pointer to Best

--- a/math/foam/src/TFoam.cxx
+++ b/math/foam/src/TFoam.cxx
@@ -85,7 +85,6 @@ S. Jadach, Computer Physics Communications 152 (2003) 55.
 #include <iomanip>
 #include <fstream>
 #include "TH1.h"
-#include "TRefArray.h"
 #include "TObjArray.h"
 #include "TMethodCall.h"
 #include "TRandom.h"
@@ -148,7 +147,7 @@ TFoam::TFoam() :
    fOptDrive(0), fChat(0), fOptRej(0),
    fNBin(0), fNSampl(0), fEvPerBin(0),
    fMaskDiv(0), fInhiDiv(0), fOptPRD(0), fXdivPRD(0),
-   fNoAct(0), fLastCe(0), fCells(0),
+   fNoAct(0), fLastCe(0),
    fMCMonit(0), fMaxWtRej(0), fPrimAcu(0),
    fHistEdg(0), fHistDbg(0), fHistWt(0),
    fMCvect(0), fMCwt(0), fRvec(0),
@@ -169,7 +168,7 @@ TFoam::TFoam(const Char_t* Name) :
    fOptDrive(0), fChat(0), fOptRej(0),
    fNBin(0), fNSampl(0), fEvPerBin(0),
    fMaskDiv(0), fInhiDiv(0), fOptPRD(0), fXdivPRD(0),
-   fNoAct(0), fLastCe(0), fCells(0),
+   fNoAct(0), fLastCe(0),
    fMCMonit(0), fMaxWtRej(0), fPrimAcu(0),
    fHistEdg(0), fHistDbg(0), fHistWt(0),
    fMCvect(0), fMCwt(0), fRvec(0),
@@ -190,7 +189,6 @@ TFoam::TFoam(const Char_t* Name) :
    fMaskDiv  = 0;             // Dynamic Mask for  cell division, h-cubic
    fInhiDiv  = 0;             // Flag allowing to inhibit cell division in certain projection/edge
    fXdivPRD  = 0;             // Lists of division values encoded in one vector per direction
-   fCells    = 0;
    fAlpha    = 0;
    fPrimAcu  = 0;
    fHistEdg  = 0;
@@ -231,7 +229,7 @@ TFoam::~TFoam()
 {
    Int_t i;
 
-   if(fCells!= 0) {
+   if(fCells!= nullptr) {
       for(i=0; i<fNCells; i++) delete fCells[i]; // TFoamCell*[]
       delete [] fCells;
    }
@@ -421,13 +419,13 @@ void TFoam::Initialize()
    fNevGen = 0.0;               // M.C. generation sum of 1d0
    fWtMax  = gVlow;               // M.C. generation maximum wt
    fWtMin  = gHigh;               // M.C. generation minimum wt
-   fMCresult=fCells[0]->GetIntg(); // M.C. Value of INTEGRAL,temporary assignment
-   fMCresult=fCells[0]->GetIntg(); // M.C. Value of INTEGRAL,temporary assignment
-   fMCerror =fCells[0]->GetIntg(); // M.C. Value of ERROR   ,temporary assignment
+   fMCresult= getCell(0)->GetIntg(); // M.C. Value of INTEGRAL,temporary assignment
+   fMCresult= getCell(0)->GetIntg(); // M.C. Value of INTEGRAL,temporary assignment
+   fMCerror = getCell(0)->GetIntg(); // M.C. Value of ERROR   ,temporary assignment
    fMCMonit = new TFoamMaxwt(5.0,1000);  // monitoring M.C. efficiency
    //
    if(fChat>0){
-      Double_t driver = fCells[0]->GetDriv();
+      Double_t driver = getCell(0)->GetDriv();
       BXOPE;
       BXTXT("***  TFoam::Initialize FINISHED!!!  ***");
       BX1I("    nCalls",fNCalls,  "Total number of function calls         ");
@@ -459,7 +457,7 @@ void TFoam::InitCells()
       fCells[i]= new TFoamCell(fDim); // Allocate BIG list of cells
       fCells[i]->SetSerial(i);
    }
-   if(fCells==0) Error("InitCells", "Cannot initialize CELLS \n"  );
+   if(fCells==nullptr) Error("InitCells", "Cannot initialize CELLS \n"  );
 
    /////////////////////////////////////////////////////////////////////////////
    //              Single Root Hypercube                                      //
@@ -468,7 +466,7 @@ void TFoam::InitCells()
 
    // Exploration of the root cell(s)
    for(Long_t iCell=0; iCell<=fLastCe; iCell++){
-      Explore( fCells[iCell] );               // Exploration of root cell(s)
+      Explore( getCell(iCell) );               // Exploration of root cell(s)
    }
 }
 
@@ -485,7 +483,7 @@ Int_t TFoam::CellFill(Int_t Status, TFoamCell *parent)
    fLastCe++;   // 0-th cell is the first
    if (Status==1) fNoAct++;
 
-   cell = fCells[fLastCe];
+   cell = getCell(fLastCe);
 
    cell->Fill(Status, parent, 0, 0);
 
@@ -870,7 +868,7 @@ void TFoam::Grow()
         Error("Grow", "Wrong iCell \n");
         break;
       }
-      newCell = fCells[iCell];
+      newCell = getCell(iCell);
 
       if(fLastCe !=0) {
          Int_t kEcho=10;
@@ -905,8 +903,8 @@ Long_t  TFoam::PeekMax()
 
    drivMax = gVlow;
    for(i=0; i<=fLastCe; i++) {//without root
-      if( fCells[i]->GetStat() == 1 ) {
-         driv =  TMath::Abs( fCells[i]->GetDriv());
+      if( getCell(i)->GetStat() == 1 ) {
+         driv =  TMath::Abs( getCell(i)->GetDriv());
          //std::cout<<"PeekMax: Driv = "<<driv<<std::endl;
          if(driv > drivMax) {
             drivMax = driv;
@@ -949,10 +947,10 @@ Int_t TFoam::Divide(TFoamCell *cell)
 
    Int_t d1 = CellFill(1,   cell);
    Int_t d2 = CellFill(1,   cell);
-   cell->SetDau0((fCells[d1]));
-   cell->SetDau1((fCells[d2]));
-   Explore( (fCells[d1]) );
-   Explore( (fCells[d2]) );
+   cell->SetDau0((getCell(d1)));
+   cell->SetDau1((getCell(d2)));
+   Explore( (getCell(d1)) );
+   Explore( (getCell(d2)) );
    return 1;
 } // TFoam_Divide
 
@@ -978,8 +976,8 @@ void TFoam::MakeActiveList()
 
    fPrime = 0.0;
    for(iCell=0; iCell<=fLastCe; iCell++) {
-      if (fCells[iCell]->GetStat()==1) {
-         fPrime += fCells[iCell]->GetPrim();
+      if (getCell(iCell)->GetStat()==1) {
+         fPrime += getCell(iCell)->GetPrim();
          fCellsAct.push_back(iCell);
       }
    }
@@ -992,7 +990,7 @@ void TFoam::MakeActiveList()
 
    sum =0.0;
    for(iCell=0; iCell<fNoAct; iCell++) {
-      sum = sum + ( fCells[fCellsAct[iCell]] )->GetPrim()/fPrime;
+      sum = sum + ( getCell(fCellsAct[iCell]) )->GetPrim()/fPrime;
       fPrimAcu[iCell]=sum;
    }
 
@@ -1108,9 +1106,9 @@ void TFoam::GenerCel2(TFoamCell *&pCell)
       }
    }
    if (fPrimAcu[lo]>random)
-      pCell = fCells[fCellsAct[lo]];
+      pCell = getCell(fCellsAct[lo]);
    else
-      pCell = fCells[fCellsAct[hi]];
+      pCell = getCell(fCellsAct[hi]);
 }       // TFoam::GenerCel2
 
 
@@ -1269,7 +1267,7 @@ void TFoam::Finalize(Double_t& IntNorm, Double_t& Errel)
       mCeff=0;
       if(wtMax>0.0) mCeff=aveWt/wtMax;
       mcEf2 = sigma/aveWt;
-      Double_t driver = fCells[0]->GetDriv();
+      Double_t driver = getCell(0)->GetDriv();
       //
       BXOPE;
       BXTXT("****************************************");
@@ -1386,7 +1384,7 @@ void TFoam::CheckAll(Int_t level)
    errors = 0; warnings = 0;
    if (level==1) std::cout << "///////////////////////////// FOAM_Checks /////////////////////////////////" << std::endl;
    for(iCell=1; iCell<=fLastCe; iCell++) {
-      cell = fCells[iCell];
+      cell = getCell(iCell);
       //  checking general rules
       if( ((cell->GetDau0()==0) && (cell->GetDau1()!=0) ) ||
          ((cell->GetDau1()==0) && (cell->GetDau0()!=0) ) ) {
@@ -1403,7 +1401,7 @@ void TFoam::CheckAll(Int_t level)
       }
 
       // checking parents
-      if( (cell->GetPare())!=fCells[0] ) { // not child of the root
+      if( (cell->GetPare())!=getCell(0) ) { // not child of the root
          if ( (cell != cell->GetPare()->GetDau0()) && (cell != cell->GetPare()->GetDau1()) ) {
             errors++;
             if (level==1) Error("CheckAll","ERROR: Cell's no %ld parent not pointing to this cell\n ",iCell);
@@ -1427,7 +1425,7 @@ void TFoam::CheckAll(Int_t level)
 
    // Check for empty cells
    for(iCell=0; iCell<=fLastCe; iCell++) {
-      cell = fCells[iCell];
+      cell = getCell(iCell);
       if( (cell->GetStat()==1) && (cell->GetDriv()==0) ) {
          warnings++;
          if(level==1) Warning("CheckAll", "Warning: Cell no. %ld is active but empty \n", iCell);
@@ -1451,9 +1449,9 @@ void TFoam::PrintCells(void)
 
    for(iCell=0; iCell<=fLastCe; iCell++) {
       std::cout<<"Cell["<<iCell<<"]={ ";
-      //std::cout<<"  "<< fCells[iCell]<<"  ";  // extra DEBUG
+      //std::cout<<"  "<< getCell(iCell)<<"  ";  // extra DEBUG
       std::cout<<std::endl;
-      fCells[iCell]->Print("1");
+      getCell(iCell)->Print("1");
       std::cout<<"}"<<std::endl;
    }
 }
@@ -1494,8 +1492,8 @@ void TFoam::RootPlot2dim(Char_t *filename)
       TFoamVect  cellPosi(fDim); TFoamVect  cellSize(fDim);
       outfile << "// =========== Rectangular cells  ==========="<< std::endl;
       for(iCell=1; iCell<=fLastCe; iCell++) {
-         if( fCells[iCell]->GetStat() == 1) {
-            fCells[iCell]->GetHcub(cellPosi,cellSize);
+         if( getCell(iCell)->GetStat() == 1) {
+            getCell(iCell)->GetHcub(cellPosi,cellSize);
             x1 = offs+lpag*(        cellPosi[0]); y1 = offs+lpag*(        cellPosi[1]);
             x2 = offs+lpag*(cellPosi[0]+cellSize[0]); y2 = offs+lpag*(cellPosi[1]+cellSize[1]);
             //     cell rectangle
@@ -1524,3 +1522,14 @@ void TFoam::LinkCells()
    return;
 }
 
+TFoamCell* TFoam::getCell(std::size_t i) const
+{
+  // Ensure that the fCells member of the cells is filled
+  if(fCells[i]->GetCells() == nullptr) {
+    for (Int_t j=0; j < fNCells; ++j) {
+      fCells[j]->SetCells(fCells);
+    }
+  }
+
+  return fCells[i];
+}

--- a/math/foam/src/TFoamCell.cxx
+++ b/math/foam/src/TFoamCell.cxx
@@ -61,6 +61,10 @@ TFoamCell::TFoamCell(TFoamCell &From): TObject(From)
    fParent      = From.fParent;
    fDaught0     = From.fDaught0;
    fDaught1     = From.fDaught1;
+   fParentIdx   = From.fParentIdx;
+   fDaught0Idx  = From.fDaught0Idx;
+   fDaught1Idx  = From.fDaught1Idx;
+   fCells       = From.fCells;
    fXdiv        = From.fXdiv;
    fBest        = From.fBest;
    fVolume      = From.fVolume;
@@ -87,6 +91,10 @@ TFoamCell& TFoamCell::operator=(const TFoamCell &From)
    fParent      = From.fParent;
    fDaught0     = From.fDaught0;
    fDaught1     = From.fDaught1;
+   fParentIdx   = From.fParentIdx;
+   fDaught0Idx  = From.fDaught0Idx;
+   fDaught1Idx  = From.fDaught1Idx;
+   fCells       = From.fCells;
    fXdiv        = From.fXdiv;
    fBest        = From.fBest;
    fVolume      = From.fVolume;
@@ -96,16 +104,15 @@ TFoamCell& TFoamCell::operator=(const TFoamCell &From)
    return *this;
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Fills in certain data into newly allocated cell
 
 void TFoamCell::Fill(Int_t Status, TFoamCell *Parent, TFoamCell *Daugh1, TFoamCell *Daugh2)
 {
    fStatus  = Status;
-   fParent  = Parent;
-   fDaught0 = Daugh1;
-   fDaught1 = Daugh2;
+   fParentIdx  = Parent ? Parent->fSerial : -1;
+   fDaught0Idx = Daugh1 ? Daugh1->fSerial : -1;
+   fDaught1Idx = Daugh2 ? Daugh2->fSerial : -1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/math/foam/src/TFoamCell.cxx
+++ b/math/foam/src/TFoamCell.cxx
@@ -23,9 +23,6 @@ ClassImp(TFoamCell);
 
 TFoamCell::TFoamCell()
 {
-   fParent  = 0;
-   fDaught0 = 0;
-   fDaught1 = 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -38,9 +35,6 @@ TFoamCell::TFoamCell(Int_t kDim)
       fDim     = kDim;
       fSerial   = 0;
       fStatus   = 1;
-      fParent   = 0;
-      fDaught0  = 0;
-      fDaught1  = 0;
       fXdiv     = 0.0;
       fBest     = 0;
       fVolume   = 0.0;
@@ -52,56 +46,10 @@ TFoamCell::TFoamCell(Int_t kDim)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Copy constructor (not tested!)
-
-TFoamCell::TFoamCell(TFoamCell &From): TObject(From)
-{
-   Error("TFoamCell", "+++++ NEVER USE Copy constructor for TFoamCell \n");
-   fStatus      = From.fStatus;
-   fParent      = From.fParent;
-   fDaught0     = From.fDaught0;
-   fDaught1     = From.fDaught1;
-   fParentIdx   = From.fParentIdx;
-   fDaught0Idx  = From.fDaught0Idx;
-   fDaught1Idx  = From.fDaught1Idx;
-   fCells       = From.fCells;
-   fXdiv        = From.fXdiv;
-   fBest        = From.fBest;
-   fVolume      = From.fVolume;
-   fIntegral    = From.fIntegral;
-   fDrive       = From.fDrive;
-   fPrimary     = From.fPrimary;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Destructor
 
 TFoamCell::~TFoamCell()
 {
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Substitution operator = (never used)
-
-TFoamCell& TFoamCell::operator=(const TFoamCell &From)
-{
-   Info("TFoamCell", "operator=\n ");
-   if (&From == this) return *this;
-   fStatus      = From.fStatus;
-   fParent      = From.fParent;
-   fDaught0     = From.fDaught0;
-   fDaught1     = From.fDaught1;
-   fParentIdx   = From.fParentIdx;
-   fDaught0Idx  = From.fDaught0Idx;
-   fDaught1Idx  = From.fDaught1Idx;
-   fCells       = From.fCells;
-   fXdiv        = From.fXdiv;
-   fBest        = From.fBest;
-   fVolume      = From.fVolume;
-   fIntegral    = From.fIntegral;
-   fDrive       = From.fDrive;
-   fPrimary     = From.fPrimary;
-   return *this;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This fixes a memory leak related to the usage of `TRef` in `TFoamCell`
that can be reproduced with the following code:

```C++
class MyTFoamBinding : public TFoamIntegrand {
public:
   double Density(Int_t ndim, double *) override { return 1.0; }
};

void reproTFoam()
{
   ProcInfo_t procinfo;
   const float toMB = 1.f / 1024.f;

   std::size_t nToys = 5000;

   TRandom3 rand{};

   for (std::size_t index_toy = 1; index_toy <= nToys; index_toy++) {

      if (index_toy % 500 == 0) {
         gSystem->GetProcInfo(&procinfo);
         std::cout << index_toy << ": " << procinfo.fMemResident * toMB
                   << "   " << procinfo.fMemVirtual * toMB << std::endl;
      }

      MyTFoamBinding binding{};
      TFoam tfoam{"TFOAM"};
      tfoam.SetkDim(1);
      tfoam.SetRho(&binding);
      tfoam.SetPseRan(&rand);

      tfoam.SetnCells(30);

      tfoam.SetnSampl(200);
      tfoam.SetPseRan(&rand);
      tfoam.SetChat(0);
      tfoam.Initialize();
   }
}
```

Before this commit, you will see a steady memory increase that is gone
after this commit.

This fixes the fundamental memory increase in RooFit toy studies,
reported for example in https://github.com/root-project/root/issues/8984.