### PR TITLE
Extra public accessor methods in root browser classes

### DIFF
--- a/gui/gui/inc/TGFileBrowser.h
+++ b/gui/gui/inc/TGFileBrowser.h
@@ -113,6 +113,9 @@ public:
    void        ToggleSort();
    void        Update();
 
+   TGListTree     *GetListTree() const { return fListTree; }
+   TGListTreeItem *GetRootDir() const { return fRootDir; }
+
    ClassDefOverride(TGFileBrowser, 0) // File browser.
 };
 

--- a/gui/gui/inc/TRootBrowser.h
+++ b/gui/gui/inc/TRootBrowser.h
@@ -146,6 +146,7 @@ public:
    void              HandleMenu(Int_t id);
    void              RecursiveReparent(TGPopupMenu *popup);
    void              RemoveTab(Int_t pos, Int_t subpos);
+   TBrowserImp      *GetActBrowser() const { return fActBrowser; }
    void              SetActBrowser(TBrowserImp *b) { fActBrowser = b; }
    void              ShowMenu(TGCompositeFrame *menu);
    void              StartEmbedding(Int_t pos = kRight, Int_t subpos = -1) override;


### PR DESCRIPTION
This is a small MR for the addition of a few extra public accessor methods for some parts of the root browser classes. These classes are using in the new, experiment, RooBrowser. Having public access to these data members will help with the future development of that feature, and I hope the methods added will be acceptable. 

Please Note: Will need pulling into the 6.28 branch!