### PR TITLE
[graf] Additional options for `TPad::PlaceBox()` method

### DIFF
--- a/core/base/inc/TVirtualPad.h
+++ b/core/base/inc/TVirtualPad.h
@@ -255,7 +255,7 @@ public:
    virtual Int_t    IncrementPaletteColor(Int_t i, TString opt) = 0;
    virtual Int_t    NextPaletteColor() = 0;
 
-   virtual Bool_t   PlaceBox(TObject *o, Double_t w, Double_t h, Double_t &xl, Double_t &yb) = 0;
+   virtual Bool_t   PlaceBox(TObject *o, Double_t w, Double_t h, Double_t &xl, Double_t &yb, Option_t* opt = "lb") = 0;
 
    virtual TObject *CreateToolTip(const TBox *b, const char *text, Long_t delayms) = 0;
    virtual void     DeleteToolTip(TObject *tip) = 0;

--- a/graf2d/gpad/inc/TPad.h
+++ b/graf2d/gpad/inc/TPad.h
@@ -386,7 +386,7 @@ public:
    Int_t             NextPaletteColor() override;
 
    void              DrawCollideGrid();
-   Bool_t            PlaceBox(TObject *o, Double_t w, Double_t h, Double_t &xl, Double_t &yb) override;
+   Bool_t            PlaceBox(TObject *o, Double_t w, Double_t h, Double_t &xl, Double_t &yb, Option_t* option = "lb") override;
 
    virtual void      x3d(Option_t *type=""); // Depreciated
 


### PR DESCRIPTION
This is needed so that the new RooBrowser doesn't need to access the private collision grid of the TPad. These additional options allow the placement of the box with choice of priority over directions as well as option to place within the margins of the pad. 

Wanted for 6.28 release too!