### PR TITLE
[RF] RooProduct schema-evolved i/o bug fix

### DIFF
--- a/roofit/roofitcore/src/RooGenProdProj.cxx
+++ b/roofit/roofitcore/src/RooGenProdProj.cxx
@@ -116,7 +116,7 @@ RooGenProdProj::RooGenProdProj(const RooGenProdProj& other, const char* name) :
   _compSetN.add(*_compSetOwnedN) ;
 
   _compSetOwnedD = new RooArgSet;
-  other._compSetD.snapshot(*_compSetOwnedN);
+  other._compSetD.snapshot(*_compSetOwnedD);
   _compSetD.add(*_compSetOwnedD) ;
 
   for (RooAbsArg * arg : *_compSetOwnedN) {

--- a/roofit/roofitcore/src/RooProduct.cxx
+++ b/roofit/roofitcore/src/RooProduct.cxx
@@ -535,10 +535,12 @@ void RooProduct::ioStreamerPass2() {
   RooAbsProxy * p0 = getProxy(0);
   if(p0 == nullptr) {
     _proxyList.AddAt(&_compRSet, 0);
+    p0 = &_compRSet;
   }
   RooAbsProxy * p1 = getProxy(1);
   if(p1 == nullptr) {
     _proxyList.AddAt(&_compCSet, 1);
+    p1 = &_compCSet;
   }
 
   // If the proxies in the proxy list still don't correspond to _compRSet and
@@ -566,7 +568,7 @@ void RooProduct::ioStreamerPass2() {
   };
 
   expectProxyIs(0, p0, &_compRSet, "_compRSet");
-  expectProxyIs(1, p1, &_compCSet, "_compSSet");
+  expectProxyIs(1, p1, &_compCSet, "_compCSet");
 }
 
 


### PR DESCRIPTION
handle case where p0 or p1 are null -> ensure not null by time expectProxyIs is called
