### PR TITLE
v628: Reenable the cleanup of gDirectory in other threads upon file deletion.

### DIFF
--- a/bindings/jupyroot/python/JupyROOT/helpers/cppcompleter.py
+++ b/bindings/jupyroot/python/JupyROOT/helpers/cppcompleter.py
@@ -75,6 +75,7 @@ class CppCompleter(object):
     ...     print(suggestion)
     TROOT::IsA
     TROOT::IsBatch
+    TROOT::IsBuilt
     TROOT::IsDestructed
     TROOT::IsEqual
     TROOT::IsEscaped

--- a/core/base/inc/TDirectory.h
+++ b/core/base/inc/TDirectory.h
@@ -324,7 +324,6 @@ public:
    ClassDefOverride(TDirectory,5)  //Describe directory structure in memory
 };
 
-#ifndef __CINT__
 namespace ROOT {
 namespace Internal {
    struct TDirectoryAtomicAdapter {
@@ -374,10 +373,5 @@ namespace Internal {
 } // Internal
 } // ROOT
 #define gDirectory (ROOT::Internal::TDirectoryAtomicAdapter{})
-
-#elif defined(__MAKECINT__)
-// To properly handle the use of gDirectory in header files (in static declarations)
-R__EXTERN TDirectory *gDirectory;
-#endif
 
 #endif

--- a/core/base/inc/TDirectory.h
+++ b/core/base/inc/TDirectory.h
@@ -107,8 +107,9 @@ can be replaced with the simpler and exception safe:
       // or in the process of being deleted by another thread while this constructor runs.
       TContext(TDirectory *previous, TDirectory *newCurrent) : fDirectory(previous)
       {
-         // Store the user given directory so we can restore it
-         // later and cd to the new directory.
+         // Store the value of `previous` as the directory to return to when
+         // this object is destructed.
+         // Then cd to the `newCurrent` directory.
          if (fDirectory)
             (*fDirectory).RegisterContext(this);
          if (newCurrent)

--- a/core/base/inc/TDirectory.h
+++ b/core/base/inc/TDirectory.h
@@ -203,7 +203,8 @@ public:
    virtual void        Close(Option_t *option="");
    static std::atomic<TDirectory*> &CurrentDirectory();  // Return the current directory for this thread.
            void        Copy(TObject &) const override { MayNotUse("Copy(TObject &)"); }
-   virtual Bool_t      cd(const char *path = nullptr);
+   virtual Bool_t      cd();
+   virtual Bool_t      cd(const char *path);
    virtual void        DeleteAll(Option_t *option="");
            void        Delete(const char *namecycle="") override;
            void        Draw(Option_t *option="") override;

--- a/core/base/inc/TROOT.h
+++ b/core/base/inc/TROOT.h
@@ -257,7 +257,7 @@ public:
    TCollection      *GetListOfFunctionTemplates();
    TList            *GetListOfBrowsables() const { return fBrowsables; }
    TDataType        *GetType(const char *name, Bool_t load = kFALSE) const;
-   TFile            *GetFile() const override { if (gDirectory != this) return gDirectory->GetFile(); else return nullptr;}
+   TFile            *GetFile() const override { if (gDirectory && gDirectory != this) return gDirectory->GetFile(); else return nullptr;}
    TFile            *GetFile(const char *name) const;
    TFunctionTemplate*GetFunctionTemplate(const char *name);
    TStyle           *GetStyle(const char *name) const;

--- a/core/base/inc/TThreadSlots.h
+++ b/core/base/inc/TThreadSlots.h
@@ -28,7 +28,9 @@ namespace ROOT {
       // Slot reserved by ROOT's packages.
       kPadThreadSlot       = 20,
       kClassThreadSlot     = 21,
-      kDirectoryThreadSlot = 22,
+      /* This no longer used.
+         kDirectoryThreadSlot = 22,
+      */
       kFileThreadSlot      = 23,
       kPerfStatsThreadSlot = 24,
 

--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -537,7 +537,8 @@ TDirectory *TDirectory::GetDirectory(const char *apath,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Change current directory to "this" directory.
+/// Change current directory to "this" directory or to the directory described
+/// by the path if given one.
 ///
 /// Using path one can change the current directory to "path". The absolute path
 /// syntax is: `file.root:/dir1/dir2`
@@ -554,7 +555,8 @@ Bool_t TDirectory::cd(const char *path)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Change current directory to "this" directory.
+/// Change current directory to "this" directory or to the directory described
+/// by the path if given one.
 ///
 /// Using path one can
 /// change the current directory to "path". The absolute path syntax is:
@@ -603,6 +605,7 @@ Bool_t TDirectory::Cd(const char *path)
 /// `file.root:/dir1/dir2`
 /// where file.root is the file and `/dir1/dir2` the desired subdirectory
 /// in the file.
+/// Relative syntax is relative to the current directory `gDirectory`, e.g.: `../aa`.
 ///
 /// Returns kFALSE in case path does not exist.
 

--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -400,15 +400,12 @@ std::shared_ptr<TDirectory::TGDirectory> &TDirectory::GetSharedLocalCurrentDirec
 {
    using shared_ptr_type = std::shared_ptr<TDirectory::TGDirectory>;
 
-   // NOTE: Maybe we could replace the call to gThreadTsd simply a single
-   // thread local:
+   // Note in previous implementation every time gDirectory was lookup in
+   // a thread, if it was set to nullptr it would be reset to gROOT.  This
+   // was unexpected and this routine is not re-introducing this issue.
    thread_local shared_ptr_type currentDirectory =
       std::make_shared<TDirectory::TGDirectory>(ROOT::Internal::gROOTLocal);
 
-   // Reproduce inadvertent feature of Thread::GetTls when we were using it
-   // for TDirectory.
-   if (!currentDirectory->fCurrent)
-      currentDirectory->fCurrent = gROOT;
    return currentDirectory;
 }
 

--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -268,7 +268,12 @@ void TDirectory::CleanTargets()
          const auto ctxt = fContext;
          ctxt->fDirectoryWait = true;
 
-         ctxt->fDirectory = nullptr;
+         // If fDirectory is assigned to gROOT but we do not unregister ctxt
+         // (and/or stop unregister for gROOT) then ~TContext will call Unregister on gROOT.
+         // Then unregister of this ctxt and its Previous context can actually be run
+         // in parallel (this takes the gROOT lock, Previous takes the lock of fDirectory)
+         // and thus step on each other.
+         ctxt->fDirectory = nullptr; // Can not be gROOT
 
          if (ctxt->fActiveDestructor) {
             extraWait.push_back(fContext);

--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -1322,7 +1322,7 @@ void TDirectory::RegisterGDirectory(std::atomic<TDirectory*> *globalptr)
 {
    ROOT::Internal::TSpinLockGuard slg(fSpinLock);
 
-   if (std::find(fGDirectories.begin(), fGDirectories.end(), globalptr) != fGDirectories.end())
+   if (std::find(fGDirectories.begin(), fGDirectories.end(), globalptr) == fGDirectories.end())
       fGDirectories.push_back(globalptr);
    // globalptr->load()->fGDirectories will still contain globalptr, but we cannot
    // know whether globalptr->load() has been deleted by another thread in the meantime.

--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -537,6 +537,18 @@ TDirectory *TDirectory::GetDirectory(const char *apath,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Change current directory to "this" directory.
+///
+/// Returns kTRUE in case of success.
+
+Bool_t TDirectory::cd()
+{
+   auto &global = RegisterGDirectory(nullptr);
+   global = this;
+   return kTRUE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Change current directory to "this" directory or to the directory described
 /// by the path if given one.
 ///
@@ -570,15 +582,10 @@ Bool_t TDirectory::cd(const char *path)
 
 Bool_t TDirectory::cd1(const char *apath)
 {
-   Int_t nch = 0;
-   if (apath) nch = strlen(apath);
-   if (!nch) {
-      auto &global = RegisterGDirectory(nullptr);
-      global = this;
-      return kTRUE;
-   }
+   if (!apath || !apath[0])
+      return this->cd();
 
-   TDirectory *where = GetDirectory(apath,kTRUE,"cd");
+   TDirectory *where = GetDirectory(apath, kTRUE, "cd");
    if (where) {
       where->cd();
       return kTRUE;
@@ -612,11 +619,10 @@ Bool_t TDirectory::Cd(const char *path)
 Bool_t TDirectory::Cd1(const char *apath)
 {
    // null path is always true (i.e. stay in the current directory)
-   Int_t nch = 0;
-   if (apath) nch = strlen(apath);
-   if (!nch) return kTRUE;
+   if (!apath || !apath[0])
+      return kTRUE;
 
-   TDirectory *where = gDirectory->GetDirectory(apath,kTRUE,"Cd");
+   TDirectory *where = gDirectory->GetDirectory(apath, kTRUE, "Cd");
    if (where) {
       where->cd();
       return kTRUE;
@@ -630,7 +636,6 @@ Bool_t TDirectory::Cd1(const char *apath)
 void TDirectory::Clear(Option_t *)
 {
    if (fList) fList->Clear();
-
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -278,10 +278,11 @@ void TDirectory::CleanTargets()
          fContext = next;
       }
 
-      for(auto ptr : fGDirectories) {
-         if (ptr.fCurrent->load() == this) {
-            ROOT::Internal::TSpinLockGuard(*(ptr.fLock));
-            (*ptr.fCurrent) = nullptr;
+      for (auto &ptr : fGDirectories) {
+         if (ptr->fCurrent.load() == this) {
+            ROOT::Internal::TSpinLockGuard(ptr->fLock);
+            auto This = this;
+            ptr->fCurrent.compare_exchange_strong(This, nullptr);
          }
       }
    }
@@ -393,15 +394,30 @@ TObject *TDirectory::CloneObject(const TObject *obj, Bool_t autoadd /* = kTRUE *
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Return the (address of) a shared pointer to the struct holding the
+/// actual thread local gDirectory pointer and the atomic_flag for its lock.
+std::shared_ptr<TDirectory::TGDirectory> &TDirectory::GetSharedLocalCurrentDirectory()
+{
+   using shared_ptr_type = std::shared_ptr<TDirectory::TGDirectory>;
+
+   // NOTE: Maybe we could replace the call to gThreadTsd simply a single
+   // thread local:
+   thread_local shared_ptr_type currentDirectory =
+      std::make_shared<TDirectory::TGDirectory>(ROOT::Internal::gROOTLocal);
+
+   // Reproduce inadvertent feature of Thread::GetTls when we were using it
+   // for TDirectory.
+   if (!currentDirectory->fCurrent)
+      currentDirectory->fCurrent = gROOT;
+   return currentDirectory;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Return the current directory for the current thread.
 
 std::atomic<TDirectory*> &TDirectory::CurrentDirectory()
 {
-   static std::atomic<TDirectory*> currentDirectory{nullptr};
-   if (!gThreadTsd)
-      return currentDirectory;
-   else
-      return *(std::atomic<TDirectory*>*)(*gThreadTsd)(&currentDirectory,ROOT::kDirectoryThreadSlot);
+   return GetSharedLocalCurrentDirectory()->fCurrent;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -535,8 +551,7 @@ Bool_t TDirectory::cd1(const char *apath)
    Int_t nch = 0;
    if (apath) nch = strlen(apath);
    if (!nch) {
-      auto &global = CurrentDirectory();
-      RegisterGDirectory(&global);
+      auto &global = RegisterGDirectory(nullptr);
       global = this;
       return kTRUE;
    }
@@ -1346,14 +1361,19 @@ void TDirectory::RegisterContext(TContext *ctxt) {
 ////////////////////////////////////////////////////////////////////////////////
 /// Register a std::atomic<TDirectory*> that will soon be pointing to this TDirectory object
 
-void TDirectory::RegisterGDirectory(std::atomic<TDirectory*> *globalptr)
+std::atomic<TDirectory*> &TDirectory::RegisterGDirectory(std::atomic<TDirectory*> *)
 {
-   ROOT::Internal::TSpinLockGuard slg(fSpinLock);
 
-   if (std::find(fGDirectories.begin(), fGDirectories.end(), globalptr) == fGDirectories.end())
-      fGDirectories.emplace_back(GetCurrentDirectoryLock(), (std::atomic<TDirectory *> *)globalptr);
+   auto &thread_local_gdirectory = GetSharedLocalCurrentDirectory();
+
+   ROOT::Internal::TSpinLockGuard slg(fSpinLock);
+   if (std::find(fGDirectories.begin(), fGDirectories.end(), thread_local_gdirectory) == fGDirectories.end()) {
+      fGDirectories.emplace_back(thread_local_gdirectory);
+   }
+   // FIXME:
    // globalptr->load()->fGDirectories will still contain globalptr, but we cannot
    // know whether globalptr->load() has been deleted by another thread in the meantime.
+   return thread_local_gdirectory->fCurrent;
 }
 
 

--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -318,11 +318,6 @@ void TDirectory::CleanTargets()
       context->fDirectoryWait = false;
    }
 
-   // Deal with the gROOT case; gROOT does not register the local gDirectories
-   // it is assigned to so the loop over fGDirectories has not done anything.
-   if (this == ROOT::Internal::gROOTLocal && gDirectory == this)
-      gDirectory = nullptr;
-
    // Wait until all register attempts are done.
    while(fContextPeg) {}
 
@@ -1392,8 +1387,6 @@ void TDirectory::RegisterContext(TContext *ctxt) {
 
 void TDirectory::RegisterGDirectory(TDirectory::SharedGDirectory_t &gdirectory_ptr)
 {
-   if (this == ROOT::Internal::gROOTLocal)
-      return;
    ROOT::Internal::TSpinLockGuard slg(fSpinLock);
    if (std::find(fGDirectories.begin(), fGDirectories.end(), gdirectory_ptr) == fGDirectories.end()) {
       fGDirectories.emplace_back(gdirectory_ptr);

--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -1372,7 +1372,7 @@ void TDirectory::TContext::RegisterCurrentDirectory()
 void TDirectory::RegisterContext(TContext *ctxt) {
    ROOT::Internal::TSpinLockGuard slg(fSpinLock);
 
-   if (!IsBuilt())
+   if (!IsBuilt() || this == ROOT::Internal::gROOTLocal)
       return;
    if (fContext) {
       TContext *current = fContext;
@@ -1391,6 +1391,8 @@ void TDirectory::RegisterContext(TContext *ctxt) {
 
 void TDirectory::RegisterGDirectory(TDirectory::SharedGDirectory_t &gdirectory_ptr)
 {
+   if (this == ROOT::Internal::gROOTLocal)
+      return;
    ROOT::Internal::TSpinLockGuard slg(fSpinLock);
    if (std::find(fGDirectories.begin(), fGDirectories.end(), gdirectory_ptr) == fGDirectories.end()) {
       fGDirectories.emplace_back(gdirectory_ptr);
@@ -1421,7 +1423,7 @@ void TDirectory::UnregisterContext(TContext *ctxt) {
    ROOT::Internal::TSpinLockGuard slg(fSpinLock);
 
    // Another thread already unregistered the TContext.
-   if (ctxt->fDirectory == nullptr)
+   if (ctxt->fDirectory == nullptr || ctxt->fDirectory == ROOT::Internal::gROOTLocal)
       return;
 
    if (ctxt==fContext) {

--- a/core/thread/src/TThread.cxx
+++ b/core/thread/src/TThread.cxx
@@ -912,14 +912,6 @@ void **TThread::Tsd(void *dflt, Int_t k)
 void **TThread::GetTls(Int_t k) {
    TTHREAD_TLS_ARRAY(void*, ROOT::kMaxThreadSlot, tls);
 
-   // In order for the thread 'gDirectory' value to be properly
-   // initialized we set it now (otherwise it defaults
-   // to zero which is 'unexpected')
-   // We initialize it to gROOT rather than gDirectory, since
-   // TFile are currently expected to not be shared by two threads.
-   if (k == ROOT::kDirectoryThreadSlot && tls[k] == nullptr)
-      tls[k] = gROOT;
-
    return &(tls[k]);
 }
 

--- a/io/io/inc/TDirectoryFile.h
+++ b/io/io/inc/TDirectoryFile.h
@@ -69,7 +69,8 @@ public:
           TObject    *CloneObject(const TObject *obj, Bool_t autoadd = kTRUE) override;
           void        Close(Option_t *option="") override;
           void        Copy(TObject &) const override { MayNotUse("Copy(TObject &)"); }
-          Bool_t      cd(const char *path = nullptr) override;
+          Bool_t      cd() override;
+          Bool_t      cd(const char *path) override;
           void        Delete(const char *namecycle="") override;
           void        FillBuffer(char *&buffer) override;
           TKey       *FindKey(const char *keyname) const override;

--- a/io/io/src/TDirectoryFile.cxx
+++ b/io/io/src/TDirectoryFile.cxx
@@ -329,7 +329,19 @@ void TDirectoryFile::BuildDirectoryFile(TFile* motherFile, TDirectory* motherDir
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Change current directory to "this" directory.
-/// Using path one can
+///
+/// Returns kTRUE in case of success.
+
+Bool_t TDirectoryFile::cd()
+{
+   Bool_t ok = TDirectory::cd();
+   if (ok)
+      TFile::CurrentFile() = fFile;
+   return ok;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Change current directory the directory described by the path if given one.
 /// change the current directory to "path". The absolute path syntax is:
 ///
 ///     file.root:/dir1/dir2
@@ -341,7 +353,8 @@ void TDirectoryFile::BuildDirectoryFile(TFile* motherFile, TDirectory* motherDir
 Bool_t TDirectoryFile::cd(const char *path)
 {
    Bool_t ok = TDirectory::cd(path);
-   if (ok) TFile::CurrentFile() = fFile;
+   if (ok)
+      TFile::CurrentFile() = fFile;
    return ok;
 }
 


### PR DESCRIPTION
This fixes #11907

Inadvertently a previous commit (79a669b) disabled the ability to cleanup the thread local gDirectory in other
threads when the TFile they pointed to is deleted.

Also fix a set of rare race conditions:

    Fix race condition between RegisterContext and gDirectory cleanup.

    Description of the race conditions:

    (1) thread one create TFile, gDirectory now points to that file.
    (2) thread two delete TFile, the destructor calls CleanTargets which has 4 distinct phase
    (a) take the TFile spin lock and update all the TContext that points to the file
    (b) still hold the spin lock, clean the other thread's directory.
    (c) deal with the TContext that were being destructed at the same time
    (d) update the local gDirectory

    If between (2)(a) and (2)(b), thread (1) starts the creation of a TContext, and
    is held at the start of RegisterContext after thread 2 release the spin lock,
    thread 1 might awaken only after the TFile object has been deleted and thus
    RegisterContext would access delete memory.

    If during the destruction of the TFile by thread 2, thread (1) starts the
    creation of a TContext, but is suspended right before the start of RegisterContext,
    when it comes back it will use deleted memory to try to acquire the spin lock.

