### PR TITLE
[ntuple] Fix loading of class for split collections

### DIFF
--- a/tree/ntupleutil/v7/test/CustomStructUtilLinkDef.h
+++ b/tree/ntupleutil/v7/test/CustomStructUtilLinkDef.h
@@ -9,5 +9,6 @@
 #pragma link C++ class HitUtil + ;
 #pragma link C++ class TrackUtil + ;
 #pragma link C++ class ComplexStructUtil + ;
+#pragma link C++ class std::vector < BaseUtil> + ;
 
 #endif


### PR DESCRIPTION
This PR fixes the incorrect fetching of the type for branches containing split collections of user-defined classes.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)


