### PR TITLE
[TMVA][SOFIE] Handling Dropout layer in SOFIE Keras Parser

### DIFF
--- a/tmva/pymva/src/RModelParser_Keras.cxx
+++ b/tmva/pymva/src/RModelParser_Keras.cxx
@@ -809,7 +809,7 @@ RModel Parse(std::string filename){
       fLayerType = PyStringAsString(GetValueFromDict(fLayer,"layerType"));
 
       // Ignoring the input layer for models built using Keras Functional API
-      if(fLayerType == "InputLayer")
+      if(fLayerType == "InputLayer" || fLayerType == "Dropout")
          continue;
 
       // Adding any required routines depending on the Layer types for generating

--- a/tmva/pymva/src/RModelParser_Keras.cxx
+++ b/tmva/pymva/src/RModelParser_Keras.cxx
@@ -54,6 +54,7 @@ std::unique_ptr<ROperator> MakeKerasBinary(PyObject *fLayer);       // For insta
 std::unique_ptr<ROperator> MakeKerasSoftmax(PyObject *fLayer);      // For instantiating ROperator for Keras Softmax Layer
 std::unique_ptr<ROperator> MakeKerasTanh(PyObject *fLayer);         // For instantiating ROperator for Keras Tanh Layer
 std::unique_ptr<ROperator> MakeKerasLeakyRelu(PyObject *fLayer);    // For instantiating ROperator for Keras LeakyRelu Layer
+std::unique_ptr<ROperator> MakeKerasDropout(PyObject *fLayer);      // For handling Keras Dropout layer by mimicking Identity operator
 
 
 // Declaring Internal function for Keras layers which have additional activation attribute
@@ -76,7 +77,7 @@ const KerasMethodMap mapKerasLayer = {
    {"Softmax", &MakeKerasSoftmax},
    {"tanh", &MakeKerasTanh},
    {"LeakyReLU", &MakeKerasLeakyRelu},
-   {"Dropout",  &MakeKerasDropout}
+   {"Dropout",  &MakeKerasDropout},
 
    // For activation layers
    {"ReLU", &MakeKerasReLU},
@@ -848,11 +849,8 @@ RModel Parse(std::string filename){
          rmodel.AddBlasRoutines({"Gemm", "Gemv"});
       else if (fLayerType == "BatchNormalization")
          rmodel.AddBlasRoutines({"Copy", "Axpy"});
-
       else if(fLayerType == "Conv1D" || fLayerType == "Conv2D" || fLayerType == "Conv3D")
          rmodel.AddBlasRoutines({"Gemm", "Axpy"});
-      
-      else if(fLayerType == "Dropout")
 
       INTERNAL::AddKerasLayer(rmodel,fLayer);
 

--- a/tmva/pymva/src/RModelParser_Keras.cxx
+++ b/tmva/pymva/src/RModelParser_Keras.cxx
@@ -54,7 +54,7 @@ std::unique_ptr<ROperator> MakeKerasBinary(PyObject *fLayer);       // For insta
 std::unique_ptr<ROperator> MakeKerasSoftmax(PyObject *fLayer);      // For instantiating ROperator for Keras Softmax Layer
 std::unique_ptr<ROperator> MakeKerasTanh(PyObject *fLayer);         // For instantiating ROperator for Keras Tanh Layer
 std::unique_ptr<ROperator> MakeKerasLeakyRelu(PyObject *fLayer);    // For instantiating ROperator for Keras LeakyRelu Layer
-std::unique_ptr<ROperator> MakeKerasDropout(PyObject *fLayer);      // For handling Keras Dropout layer by mimicking Identity operator
+std::unique_ptr<ROperator> MakeKerasIdentity(PyObject *fLayer);     // For instantiating ROperator for Keras Identity Layer
 
 
 // Declaring Internal function for Keras layers which have additional activation attribute
@@ -77,7 +77,8 @@ const KerasMethodMap mapKerasLayer = {
    {"Softmax", &MakeKerasSoftmax},
    {"tanh", &MakeKerasTanh},
    {"LeakyReLU", &MakeKerasLeakyRelu},
-   {"Dropout",  &MakeKerasDropout},
+   {"Identity",  &MakeKerasIdentity},
+   {"Dropout",  &MakeKerasIdentity},
 
    // For activation layers
    {"ReLU", &MakeKerasReLU},
@@ -702,14 +703,14 @@ std::unique_ptr<ROperator> MakeKerasBinary(PyObject* fLayer){
 }
 
 //////////////////////////////////////////////////////////////////////////////////
-/// \brief Prepares a ROperator object for Keras Dropout Layer
+/// \brief Prepares a ROperator object for Keras Identity and Dropout Layer
 ///
 /// \param[in] fLayer Python Keras layer as a Dictionary object
 /// \return Unique pointer to ROperator object
 ///
 /// Dropout will have no effect in inference, so instead an Identity operator
 /// is added to mimic its presence in the Keras model
-std::unique_ptr<ROperator> MakeKerasDropout(PyObject* fLayer)
+std::unique_ptr<ROperator> MakeKerasIdentity(PyObject* fLayer)
 {
       PyObject* fInputs=GetValueFromDict(fLayer,"layerInput");
       PyObject* fOutputs=GetValueFromDict(fLayer,"layerOutput");
@@ -724,8 +725,7 @@ std::unique_ptr<ROperator> MakeKerasDropout(PyObject* fLayer)
          op.reset(new ROperator_Identity<float>(fLayerInputName, fLayerOutputName));
          break;
          default:
-         throw std::runtime_error("TMVA::SOFIE - Unsupported - Identity Operator for mimicking Dropout" 
-                                  "does not yet support input type " + fLayerDType);
+         throw std::runtime_error("TMVA::SOFIE - Unsupported - Operator Identity does not yet support input type " + fLayerDType);
          }
    return op;
 }

--- a/tmva/sofie/inc/TMVA/ROperator_Identity.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Identity.hxx
@@ -53,7 +53,7 @@ public:
       std::stringstream out;
       out << "\n//------ IDENTITY\n";
       // just copy the tensor pointers
-      out << SP << SP << "tensor_" << fNY << " = tensor_" << fNX << ";\n";
+      out << SP << SP << "fTensor_" << fNY << ".assign(tensor_" << fNX << ", "<< fNX << "+" << "fTensor_" << fNY <<".size());\n";
       return out.str();
    }
 

--- a/tmva/sofie/inc/TMVA/ROperator_Identity.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Identity.hxx
@@ -53,7 +53,7 @@ public:
       std::stringstream out;
       out << "\n//------ IDENTITY\n";
       // just copy the tensor pointers
-      out << SP << SP << "fTensor_" << fNY << ".assign(tensor_" << fNX << ", "<< fNX << "+" << "fTensor_" << fNY <<".size());\n";
+      out << SP << SP << "tensor_" << fNY << " = tensor_" << fNX << ";\n";
       return out.str();
    }
 


### PR DESCRIPTION
This PR adds the handling of the Dropout layer in SOFIE Keras Parser. As dropout will not have any effect on inference, thus it should be mimicked as an identity operator while parsing and in the generated inference code. 