### PR TITLE
Fix gcc13 warning in TMVA Sofie includes

### DIFF
--- a/tmva/sofie/inc/TMVA/ROperator.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator.hxx
@@ -19,8 +19,8 @@ class ROperator{
 
 
 public:
-   virtual std::vector<std::string> GetBlasRoutines() { return {};}
-   virtual std::vector<std::string> GetStdLibs() { return {};}
+   virtual std::vector<std::string> GetBlasRoutines() { return {}; }
+   virtual std::vector<std::string> GetStdLibs() { return {}; }
    virtual std::vector<std::vector<size_t>> ShapeInference(std::vector<std::vector<size_t>>) = 0;
    virtual std::vector<ETensorType> TypeInference(std::vector<ETensorType>) = 0;
    virtual void Initialize(RModel&) = 0;
@@ -37,9 +37,9 @@ public:
    virtual ~ROperator(){}
 
 protected:
-   
+
    const std::string SP = "   ";    ///< space used to correctly indent the generated C++ code
-   bool fUseSession = false;        ///< flag to identify if using the session class 
+   bool fUseSession = false;        ///< flag to identify if using the session class
 };
 
 

--- a/tmva/sofie/inc/TMVA/ROperator_BasicBinary.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_BasicBinary.hxx
@@ -173,7 +173,7 @@ public:
 
    std::vector<std::string> GetStdLibs() override {
       if (Op == EBasicBinaryOperator::Pow) {
-         return {"cmath"};
+         return { std::string("cmath") };
       } else {
          return {};
       }

--- a/tmva/sofie/inc/TMVA/ROperator_BasicNary.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_BasicNary.hxx
@@ -102,14 +102,14 @@ public:
          fNInputs.push_back(UTILITY::Clean_name(name));
    }
 
-   // type of output given input 
+   // type of output given input
    std::vector<ETensorType> TypeInference(std::vector<ETensorType> input){
       return input;
    }
 
    // shape of output tensors given input tensors
    std::vector<std::vector<size_t>> ShapeInference(std::vector<std::vector<size_t>> input){
-      auto ret = std::vector<std::vector<size_t>>(1, input[0]); 
+      auto ret = std::vector<std::vector<size_t>>(1, input[0]);
       return ret;
    }
 
@@ -176,7 +176,7 @@ public:
       return out.str();
    }
 
-   std::vector<std::string> GetStdLibs() {return {"cmath"};}
+   std::vector<std::string> GetStdLibs() {return { std::string("cmath") }; }
 };
 
 }//SOFIE

--- a/tmva/sofie/inc/TMVA/ROperator_BatchNormalization.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_BatchNormalization.hxx
@@ -45,11 +45,11 @@ public:
 
    /* Constructor */
    ROperator_BatchNormalization( float epsilon, float momentum, std::size_t training_mode,
-   std::string nameX, std::string nameScale, std::string nameB, 
+   std::string nameX, std::string nameScale, std::string nameB,
    std::string nameMean, std::string nameVar, std::string nameY):
    fepsilon(epsilon), fmomentum(momentum), ftraining_mode(training_mode),
-   fNX(UTILITY::Clean_name(nameX)), fNScale(UTILITY::Clean_name(nameScale)), 
-   fNB(UTILITY::Clean_name(nameB)), fNMean(UTILITY::Clean_name(nameMean)), 
+   fNX(UTILITY::Clean_name(nameX)), fNScale(UTILITY::Clean_name(nameScale)),
+   fNB(UTILITY::Clean_name(nameB)), fNMean(UTILITY::Clean_name(nameMean)),
    fNVar(UTILITY::Clean_name(nameVar)), fNY(UTILITY::Clean_name(nameY))
    {
       if(std::is_same<T, float>::value){
@@ -60,7 +60,7 @@ public:
 		      std::runtime_error("TMVA SOFIE Encountered unsupported type parsing a BatchNormalization operator");
       }
    }
-	
+
 
    std::vector<ETensorType> TypeInference(std::vector<ETensorType> input) {
       ETensorType out = input[0];
@@ -79,7 +79,7 @@ public:
          }
       }
 
-      auto ret = input; 
+      auto ret = input;
       return ret;
    }
 
@@ -159,7 +159,7 @@ public:
             }
             //// new_var =1. / sqrt(input_var + fepsilon)
 		    for(size_t i=0; i<n; i++){
-		       new_var[i] = 1./sqrt(new_var[i] + fepsilon);	
+		       new_var[i] = 1./sqrt(new_var[i] + fepsilon);
 		    }
             std::vector<size_t> new_bias_shape = {batchSize,channels,height,width};
             std::shared_ptr<void> new_bias_ptr(new_bias, std::default_delete<float[]>());
@@ -201,7 +201,7 @@ public:
 
       //// blas saxpy (Y = -Bmean + Y)
       out << SP << "float "<<OpName<< "_alpha = -1;\n";
-      out << SP << "BLAS::saxpy_(&" << OpName << "_N, &" << OpName << "_alpha, " << "tensor_" << fNMean << ", &" << OpName << "_incx," 
+      out << SP << "BLAS::saxpy_(&" << OpName << "_N, &" << OpName << "_alpha, " << "tensor_" << fNMean << ", &" << OpName << "_incx,"
          << "tensor_" << fNY <<", &" << OpName << "_incy);\n\n ";
 
       //// Y *= scale*var
@@ -217,7 +217,7 @@ public:
       return out.str();
    }
 
-   std::vector<std::string> GetBlasRoutines() { return {"Copy", "Axpy"};}
+   std::vector<std::string> GetBlasRoutines() { return { std::string("Copy"), std::string("Axpy") }; }
 };
 
 }//SOFIE

--- a/tmva/sofie/inc/TMVA/ROperator_Conv.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Conv.hxx
@@ -85,11 +85,11 @@ public:
       return {out};
    }
 
-   // function returning output shape given input 
+   // function returning output shape given input
    std::vector<std::vector<size_t>> ShapeInference(std::vector<std::vector<size_t>> input) {
-      // shape of convolution input has to be (according to ONNX): N x C x H x W  
+      // shape of convolution input has to be (according to ONNX): N x C x H x W
       // Where N : batch size, C : input  channels, H : input height, W : input width
-   
+
       if (input.size() > 3 ) {
          throw
             std::runtime_error("TMVA SOFIE Conv Op Shape inference need 2 or 3 input tensors");
@@ -105,7 +105,7 @@ public:
          fAttrGroup = input[0][1] / input[1][1];
       }
 
-      // kernel shape  
+      // kernel shape
       size_t k1 = ((fAttrKernelShape.empty())? input[1][2] : fAttrKernelShape[0]);
       size_t k2 = (fDim > 1) ? ((fAttrKernelShape.empty()) ? input[1][3] : fAttrKernelShape[1]) : 1;
       size_t k3 = (fDim > 2) ? ((fAttrKernelShape.empty()) ? input[1][4] : fAttrKernelShape[2]) : 1;
@@ -118,12 +118,12 @@ public:
       if (fAttrDilations.empty()) {
          fAttrDilations = {1, 1, 1};
       }
-      fAttrDilations.resize(3); 
+      fAttrDilations.resize(3);
       if (fDim < 3) {
          fAttrDilations.resize(3, 1);
       }
       // Shape of the kernel
-      fAttrKernelShape = {k1 + (fAttrDilations[0] - 1) * (k1 - 1), 
+      fAttrKernelShape = {k1 + (fAttrDilations[0] - 1) * (k1 - 1),
                           k2 + (fAttrDilations[1] - 1) * (k2 - 1),
                           k3 + (fAttrDilations[2] - 1) * (k3 - 1)};
 
@@ -176,7 +176,7 @@ public:
 
       std::vector<std::vector<size_t>> ret({{ batch_size, output_channels, output1 }});
 
-      if (fDim == 1) 
+      if (fDim == 1)
          return ret;
 
       size_t pad2 = fAttrPads[1] + fAttrPads[i2];
@@ -231,7 +231,7 @@ public:
             // make bias shape equal to Y shape by adding 1
             if (fShapeB.size() < 1)
                throw std::runtime_error("TMVA SOFIE Conv op: Bias Tensor has empty shape");
-            // we assume bias tensor dimension is equal to number of filters that is the second dimension in 
+            // we assume bias tensor dimension is equal to number of filters that is the second dimension in
             // the output tensor
             if (fShapeB[0] != fShapeY[1])
                throw std::runtime_error("TMVA SOFIE Conv op: Bias Tensor has wrong shape: " +
@@ -249,7 +249,7 @@ public:
                fShapeB = model.GetTensorShape(fNB);
                fNB2 = fNB;   // use same name
             }
-            else {  
+            else {
                // In case of session add broadcasting code in Session constructor and in GenerateInitCode
                // we need to add a new intermediate tensor for broadcasted bias tensor
                fNB2 = fNB + "bcast";
@@ -293,11 +293,11 @@ public:
       out << "std::vector<" << fType << "> fVec_" << opName << "_f = std::vector<" << fType << ">("
           << fShapeW[0] * fShapeW[1] * kernelSize << ");\n";
       // output matrix of im2col
-      out << "std::vector<" << fType << "> fVec_" << opName << "_xcol = std::vector<" << fType << ">(" 
+      out << "std::vector<" << fType << "> fVec_" << opName << "_xcol = std::vector<" << fType << ">("
           << fShapeW[1] * kernelSize * outputChannelSize << ");\n";
       out << "\n";
 
-      return out.str(); 
+      return out.str();
    }
 
    std::string Generate(std::string OpName) {
@@ -325,12 +325,12 @@ public:
       // create first matrix with convolution kernels
       if (fUseSession)
          out << SP << fType << " * " << OpName << "_f = fVec_" << OpName << "_f.data();\n";
-      else 
+      else
          out << SP << fType << " " << OpName << "_f[" << fShapeW[0] * fShapeW[1] * fAttrKernelShape[0] * fAttrKernelShape[1] << "] = {0};\n";
 
       // vectorize the (dilated)convolution kernels into a matrix
       // no need to transpose the matrix
-      // to fix for 1d and 3d 
+      // to fix for 1d and 3d
 
       size_t id = (fDim > 2) ? fDim-3 : 2;
       size_t ih = (fDim > 1) ? fDim-2 : 1;
@@ -353,11 +353,11 @@ public:
       if (fDim > 1)
          out << SP << SP << SP << "for (std::size_t kh = 0; kh < " << kHeight << "; kh++) {\n";
       out << SP << SP << SP << SP << "for (std::size_t kw = 0; kw < " << kWidth << "; kw++) {\n";
-     
+
       out << SP << SP << SP << SP << SP << OpName <<  "_f[oc * "
-          << ocstrideDil << " + ic * " << icstrideDil; 
+          << ocstrideDil << " + ic * " << icstrideDil;
       if (fDim > 2) out << " + kd * " << dstrideDil;
-      if (fDim > 1) out << " + kh * " << hstrideDil; 
+      if (fDim > 1) out << " + kh * " << hstrideDil;
       out << " + kw * " << wstrideDil  << "  ] = tensor_" << fNW << "[oc * " << ocstride << " + ic * " << icstride;
       if (fDim > 2) out << " + kd * " << dstride;
       if (fDim > 1) out << " + kh * " << hstride;
@@ -385,11 +385,11 @@ public:
       }
       else {
          out << SP << fType << " " << OpName << "_xcol["
-             << fShapeX[1] * fAttrKernelShape[0] * fAttrKernelShape[1] * fAttrKernelShape[2] * oDepth * oHeight * oWidth 
+             << fShapeX[1] * fAttrKernelShape[0] * fAttrKernelShape[1] * fAttrKernelShape[2] * oDepth * oHeight * oWidth
              << "] = {0};\n";
       }
 
-      // Loop on batch size 
+      // Loop on batch size
       out << SP << "for (size_t n = 0; n < " << bsize << "; n++) {\n";
 
       // IM2COL: Unroll the input tensor
@@ -414,7 +414,7 @@ public:
             fAttrPads[0] = (fAttrPads[0] + fAttrPads[2]) / 2;
             fAttrPads[1] = (fAttrPads[1] + fAttrPads[3]) / 2;
          }
-      } 
+      }
       if (fDim == 3) {
          if (fAttrPads[0] != fAttrPads[3] || fAttrPads[1] != fAttrPads[4] || fAttrPads[2] != fAttrPads[5]) {
             std::cout << "TMVA SOFIE Operator Conv:  asymmetric padding not supported. Assume an average padding " << std::endl;
@@ -444,18 +444,18 @@ public:
                    << "," << fAttrStrides[0] << "," << fAttrStrides[1] << "," << fAttrDilations[0] << ","
                    << fAttrDilations[1];
             out << "," << OpName << "_xcol);\n\n ";
-         } else { 
+         } else {
             // 3d im2col
             out << SP << SP << "TMVA::Experimental::SOFIE::UTILITY::Im2col_3d<float>(tensor_" << fNX
                 << " + x_offset,"
-                //  channels, d, h, w, k_d, k_h, k_w, pad_d, pad_h, pad_w, stride_d, stride_h, stride_w, 
+                //  channels, d, h, w, k_d, k_h, k_w, pad_d, pad_h, pad_w, stride_d, stride_h, stride_w,
                 //  dilation_d, dilation_h, dilation_w,
                 //
-                << fShapeW[1] << "," << iDepth << "," << iHeight << "," << iWidth << "," 
-                << fAttrKernelShape[0] << "," << fAttrKernelShape[1] << "," << fAttrKernelShape[2] << "," 
-                << fAttrPads[0] << "," << fAttrPads[1] << "," << fAttrPads[2] << "," 
-                << fAttrStrides[0] << "," << fAttrStrides[1] << "," << fAttrStrides[2] << "," 
-                << fAttrDilations[0] << "," << fAttrDilations[1] << "," << fAttrDilations[2] << "," 
+                << fShapeW[1] << "," << iDepth << "," << iHeight << "," << iWidth << ","
+                << fAttrKernelShape[0] << "," << fAttrKernelShape[1] << "," << fAttrKernelShape[2] << ","
+                << fAttrPads[0] << "," << fAttrPads[1] << "," << fAttrPads[2] << ","
+                << fAttrStrides[0] << "," << fAttrStrides[1] << "," << fAttrStrides[2] << ","
+                << fAttrDilations[0] << "," << fAttrDilations[1] << "," << fAttrDilations[2] << ","
                 << OpName << "_xcol);\n\n ";
          }
          // BLAS
@@ -502,14 +502,14 @@ public:
                 << "," << fAttrPads[2] << "," << fAttrStrides[0] << "," << fAttrStrides[1] << "," << fAttrStrides[2]
                 << "," << fAttrDilations[0] << "," << fAttrDilations[1] << "," << fAttrDilations[2] << "," << OpName
                 << "_xcol);\n\n ";
-         } 
+         }
 
          // BLAS
          // n must be divided by the number of groups
          out << SP << SP << SP << OpName << "_n = " << fShapeW[0] / fAttrGroup << ";\n";
          // offset g must be  g * k * n
          out << SP << SP << SP << "size_t offset_f = g * "
-             << fShapeW[0] * fShapeW[1] * fAttrKernelShape[0] * fAttrKernelShape[1] * fAttrKernelShape[2] / fAttrGroup 
+             << fShapeW[0] * fShapeW[1] * fAttrKernelShape[0] * fAttrKernelShape[1] * fAttrKernelShape[2] / fAttrGroup
              << ";\n";
          out << SP << SP << "BLAS::sgemm_(&" << OpName << "_transA, &" << OpName << "_transB, &" << OpName << "_m, &"
              << OpName << "_n, &" << OpName << "_k, &" << OpName << "_alpha, " << OpName << "_xcol, &" << OpName
@@ -538,7 +538,7 @@ public:
 
    /*! \brief Returns the blas routines needed to compile the generated code
     */
-   std::vector<std::string> GetBlasRoutines() { return {"Gemm", "Axpy"};}
+   std::vector<std::string> GetBlasRoutines() { return { std::string("Gemm"), std::string("Axpy") }; }
 };
 
 } // namespace SOFIE

--- a/tmva/sofie/inc/TMVA/ROperator_ConvTranspose.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_ConvTranspose.hxx
@@ -119,7 +119,7 @@ public:
 
    /*! \brief Returns the blas routines needed to compile the generated code
     */
-   std::vector<std::string> GetBlasRoutines() override { return {"Gemm", "Axpy"};}
+   std::vector<std::string> GetBlasRoutines() override { return { std::string("Gemm"), std::string("Axpy") }; }
 };
 
 } // namespace SOFIE

--- a/tmva/sofie/inc/TMVA/ROperator_GRU.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_GRU.hxx
@@ -132,7 +132,7 @@ template <typename T> class ROperator_GRU final : public ROperator {
 
    /*! \brief Returns the blas routines needed to compile the generated code
     */
-   std::vector<std::string> GetBlasRoutines() { return {"Gemm", "Axpy"};}
+   std::vector<std::string> GetBlasRoutines() { return { std::string("Gemm"), std::string("Axpy") }; }
 };
 
 } // namespace SOFIE

--- a/tmva/sofie/inc/TMVA/ROperator_Gemm.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Gemm.hxx
@@ -227,7 +227,7 @@ namespace SOFIE{
 
          }
 
-         std::vector<std::string> GetBlasRoutines() { return {"Gemm", "Gemv"};}
+         std::vector<std::string> GetBlasRoutines() { return { std::string("Gemm"), std::string("Gemv") }; }
 
    };
 

--- a/tmva/sofie/inc/TMVA/ROperator_LSTM.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_LSTM.hxx
@@ -144,7 +144,7 @@ template <typename T> class ROperator_LSTM final : public ROperator {
 
    /*! \brief Returns the blas routines needed to compile the generated code
     */
-   std::vector<std::string> GetBlasRoutines() { return {"Gemm", "Axpy"};}
+   std::vector<std::string> GetBlasRoutines() { return { std::string("Gemm"), std::string("Axpy") }; }
 };
 
 } // namespace SOFIE

--- a/tmva/sofie/inc/TMVA/ROperator_LayerNormalization.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_LayerNormalization.hxx
@@ -313,9 +313,9 @@ public:
       return out.str();
    }
 
-   std::vector<std::string> GetBlasRoutines() override { return {"Axpy"}; }
+   std::vector<std::string> GetBlasRoutines() override { return { std::string("Axpy") }; }
 
-   std::vector<std::string> GetStdLibs() override { return {"cmath"}; }
+   std::vector<std::string> GetStdLibs() override { return { std::string("cmath") }; }
 };
 
 } // namespace SOFIE

--- a/tmva/sofie/inc/TMVA/ROperator_RNN.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_RNN.hxx
@@ -126,7 +126,7 @@ template <typename T> class ROperator_RNN final : public ROperator {
 
    /*! \brief Returns the blas routines needed to compile the generated code
     */
-   std::vector<std::string> GetBlasRoutines() { return {"Gemm", "Axpy"};}
+   std::vector<std::string> GetBlasRoutines() { return { std::string("Gemm"), std::string("Axpy") }; }
 };
 
 } // namespace SOFIE

--- a/tmva/sofie/inc/TMVA/ROperator_Selu.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Selu.hxx
@@ -60,7 +60,7 @@ public:
       return out.str();
    }
 
-   std::vector<std::string> GetStdLibs() { return {"cmath"};}
+   std::vector<std::string> GetStdLibs() { return { std::string("cmath") };}
 };
 
 }//SOFIE

--- a/tmva/sofie/inc/TMVA/ROperator_Sigmoid.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Sigmoid.hxx
@@ -60,7 +60,7 @@ public:
       return out.str();
    }
 
-   std::vector<std::string> GetStdLibs() { return {"cmath"};}
+   std::vector<std::string> GetStdLibs() { return { std::string("cmath") };}
 };
 
 }//SOFIE

--- a/tmva/sofie/inc/TMVA/ROperator_Tanh.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Tanh.hxx
@@ -60,7 +60,7 @@ public:
       return out.str();
    }
 
-   std::vector<std::string> GetStdLibs() { return {"cmath"};}
+   std::vector<std::string> GetStdLibs() { return { std::string("cmath") };}
 };
 
 }//SOFIE

--- a/tmva/sofie/src/RModel.cxx
+++ b/tmva/sofie/src/RModel.cxx
@@ -130,7 +130,8 @@ namespace SOFIE{
 
    void RModel::AddOperator(std::unique_ptr<ROperator> op, int order_execution){
       AddBlasRoutines(op->GetBlasRoutines());
-      for (auto& stdlib : op->GetStdLibs()) {
+      auto libs = op->GetStdLibs();
+      for (auto& stdlib : libs) {
          AddNeededStdLib(stdlib);
       }
       if (order_execution >= 0) {


### PR DESCRIPTION
Properly initialize `std::vector<std::string>`, gcc13 do not like to automatically convert array of const char* to it.
