### PR TITLE
Fix gcc13 warning in TPaveText

### DIFF
--- a/graf2d/graf/src/TPaveText.cxx
+++ b/graf2d/graf/src/TPaveText.cxx
@@ -682,6 +682,9 @@ void TPaveText::SaveLines(std::ostream &out, const char *name, Bool_t saved)
    Int_t nlines = GetSize();
    if (nlines == 0) return;
 
+   if (!name || !*name)
+      name = "pt";
+
    // Iterate over all lines
    char quote = '"';
    TIter next(fLines);


### PR DESCRIPTION
gcc13 complains that `name` can be null.
