### PR TITLE
Fix GL viewer camera center picking for retina displays.

### DIFF
--- a/graf3d/gl/src/TGLEventHandler.cxx
+++ b/graf3d/gl/src/TGLEventHandler.cxx
@@ -509,7 +509,8 @@ Bool_t TGLEventHandler::HandleButton(Event_t * event)
          fGLViewer->RequestSelect(event->fX, event->fY);
          if (fGLViewer->fSelRec.GetN() > 0)
          {
-            TGLVector3 v(event->fX, event->fY, 0.5*fGLViewer->fSelRec.GetMinZ());
+            auto scaling = TGLUtil::GetScreenScalingFactor();
+            TGLVector3 v(scaling * event->fX, scaling * event->fY, 0.5*fGLViewer->fSelRec.GetMinZ());
             fGLViewer->CurrentCamera().WindowToViewport(v);
             v = fGLViewer->CurrentCamera().ViewportToWorld(v);
             if (fGLViewer->GetPushAction() == TGLViewer::kPushCamCenter)


### PR DESCRIPTION
# This Pull request:
Corrects camera center picking feature in GL-based geometry display. The bug is described in #12035 

## Changes or fixes:
Applies the screen scaling factor for camera center picked screen coordinates. Fixes the bug reported in this forum [subject](https://root-forum.cern.ch/t/mouse-position-shifts-in-geometry-display/52937/4)

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #12035  

