### PR TITLE
Re-enable registration of thread-local gDirectory to gROOT.

### DIFF
--- a/core/base/inc/TDirectory.h
+++ b/core/base/inc/TDirectory.h
@@ -311,23 +311,31 @@ public:
 
 namespace ROOT {
 namespace Internal {
-   // The objects of type TDirectoryAtomicAdapter should only be used inside the
-   // thread that created them.  The intent is for this to be used (indirectly) solely as
-   // temporary objects.  For example:
-   //
-   // gDirectory = newvalue;
-   // gDirectory->ls();
-   // TDirectory *current = gDirectory;
-   //
-   // Note that:
-   //   auto dir = gDirectory;
-   // currently behaves "unexpectedly" as changing dir will change gDirectory:
-   //   dir = newvalue;
-   // leads to
-   //   gDirectory == newvalue
-   // To prevent this we would need a new mechanism such that the type
-   // used by 'auto' in that case is `TDirectory*` rather than the Internal
-   // type TDirectoryAtomicAdapter.
+   /// \brief Internal class used in the implementation of `gDirectory`
+   /// The objects of type `TDirectoryAtomicAdapter` should only be used inside the
+   /// thread that created them.  The intent is for those objects to be used indirectly
+   /// through the macro `gDirectory` and solely as temporary objects.
+   /// For example:
+   /// ```
+   ///   gDirectory = newvalue;
+   ///   gDirectory->ls();
+   ///   TDirectory *current = gDirectory;
+   /// ```
+   /// Note that:
+   /// ```
+   ///   auto dir = gDirectory;
+   /// ```
+   /// currently behaves "unexpectedly" as changing `dir` will also change `gDirectory`:
+   /// ```
+   ///   dir = newvalue;
+   /// ```
+   /// leads to
+   /// ```
+   ///   gDirectory == newvalue
+   /// ```
+   /// To prevent this we would need a new mechanism such that the type
+   /// used by `auto` in that case is `TDirectory*` rather than the `Internal`
+   /// type `TDirectoryAtomicAdapter`.
    struct TDirectoryAtomicAdapter {
       // The shared pointer's lifetime is that of the thread creating this object
       // (with the default constructor)

--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -318,11 +318,6 @@ void TDirectory::CleanTargets()
       context->fDirectoryWait = false;
    }
 
-   // Deal with the gROOT case; gROOT does not register the local gDirectories
-   // it is assigned to so the loop over fGDirectories has not done anything.
-   if (this == ROOT::Internal::gROOTLocal && gDirectory == this)
-      gDirectory = nullptr;
-
    // Wait until all register attempts are done.
    while(fContextPeg) {}
 
@@ -1392,8 +1387,6 @@ void TDirectory::RegisterContext(TContext *ctxt) {
 
 void TDirectory::RegisterGDirectory(TDirectory::SharedGDirectory_t &gdirectory_ptr)
 {
-   if (this == ROOT::Internal::gROOTLocal)
-      return;
    ROOT::Internal::TSpinLockGuard slg(fSpinLock);
    if (std::find(fGDirectories.begin(), fGDirectories.end(), gdirectory_ptr) == fGDirectories.end()) {
       fGDirectories.emplace_back(gdirectory_ptr);


### PR DESCRIPTION
    Registrering the thread-local gDirectory with the gROOT (which is special TDirectory) allows to keep the
    shared_pointer alive until gROOT is destructed.

    Technically we would only need to keep around the one associated with the main thread.  Thread local
    storage (and hence the original shared_ptr for the thread local gDirectory) is destructed
    (even for the thread local associated with the main thread) before the static storage is destructed.
    So prior to this commit, the main thread's gDirectory shared pointer was destructed before
    the start of the TROOT destructor and then TDirectory::CleanTargets when using explicitly
    'gDirectory' was reading deleted memory.

