### PR TITLE
[dictgen] Do not complain about headers in byproducts:

### DIFF
--- a/build/rmkdepend/def.h
+++ b/build/rmkdepend/def.h
@@ -32,6 +32,9 @@ in this Software without prior written authorization from the X Consortium.
 #define _POSIX_SOURCE
 #endif
 #endif
+#if defined(__APPLE__) && !defined(_DARWIN_C_SOURCE)
+#define _DARWIN_C_SOURCE
+#endif
 #include <stdio.h>
 #ifndef X_NOT_STDC_ENV
 #include <string.h>

--- a/build/rmkdepend/include.c
+++ b/build/rmkdepend/include.c
@@ -303,7 +303,7 @@ struct inclist *inc_path(char *file, char *include, boolean dot) {
             warning1("\t%s/%s too long\n", *pp, include);
             continue;
          }
-         sprintf(path, "%s/%s", *pp, include);
+         snprintf(path, BUFSIZ, "%s/%s", *pp, include);
          remove_dotdot(path);
 #ifdef _WIN32
          if (stat(path, &st) == 0 && (st.st_mode & S_IFREG)) {


### PR DESCRIPTION
During ROOT's build of Core.pcm, byproduct modules are built.
rootcling was complaining about some headers not appearing in Core.pcm,
despite them ending up in the byproduct pcms.

Simply don't complain about headers not in the pcm if these headers
are actually in a byproduct. In the same vein, do not forcefully include
them in teh pcm, as they are already included in the byproduct which should
be sufficient.

This circumvents the warnings:

```
[2751/6001] Generating G__Core.cxx, ../lib/Core.pcm
Warning in <CheckModuleValid>: after creating module "Core" the following headers are not part of that module:
  strlcpy.h (already part of top-level module "ROOT_Foundation_C")
  snprintf.h (already part of top-level module "ROOT_Foundation_C")
  ESTLType.h (already part of top-level module "ROOT_Foundation_Stage1_NoRTTI")
  TClassEdit.h (already part of top-level module "ROOT_Foundation_Stage1_NoRTTI")
  ThreadLocalStorage.h (already part of top-level module "ROOT_Foundation_C")
  ROOT/RStringView.hxx (already part of top-level module "ROOT_Foundation_Stage1_NoRTTI")
  TIsAProxy.h (already part of top-level module "ROOT_Foundation_Stage1_NoRTTI")
  TVirtualIsAProxy.h (already part of top-level module "ROOT_Foundation_Stage1_NoRTTI")
```

(cherry picked from commit a12ef5c)# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

