### PR TITLE
6.28: [cmake] Disable llvm-assertions for ROOT=RelWithDebInfo:

### DIFF
--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -193,7 +193,7 @@ if(builtin_llvm)
   message(STATUS "Building LLVM in '${LLVM_BUILD_TYPE}' mode.")
 
   if(NOT DEFINED LLVM_ENABLE_ASSERTIONS)
-    if(CMAKE_BUILD_TYPE MATCHES "(Debug|RelWithDebInfo)"
+    if(CMAKE_BUILD_TYPE MATCHES "Debug"
      OR LLVM_BUILD_TYPE MATCHES "(Debug|RelWithDebInfo)")
       set(LLVM_ENABLE_ASSERTIONS TRUE)
     else()


### PR DESCRIPTION
`verifyPreservedAnalysis()` is super slow these days. It gets run when assertions are one (!NDEBUG). Turn this off unless told to build a Debug build of ROOT (where time does not matter, and is expected to not be representative for reality) or where LLVM_BUILD_TYPE is turning asserts on.

(cherry picked from commit 92c90e8deff323fd2eab700e384dd3944b754471)

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

