### PR TITLE
Change `clang-format` style to have line breaks in c'tor initializer

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -38,7 +38,7 @@ BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
 ColumnLimit:     120
 CommentPragmas:  '^ IWYU pragma:'
-ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 3
 ContinuationIndentWidth: 3
 Cpp11BracedListStyle: true


### PR DESCRIPTION
We use the `clang-format` style of ROOT for all the new source files in RooFit, but some code looks pretty ugly. For example, here in the constructor of `RooNLLVarNer`:

```C++
RooNLLVarNew::RooNLLVarNew(const char *name, const char *title, RooAbsPdf &pdf, RooArgSet const &observables,
                           bool isExtended, RooFit::OffsetMode offsetMode, bool binnedL)
   : RooAbsReal(name, title), _pdf{"pdf", "pdf", this, pdf}, _observables{getObs(pdf, observables)},
     _isExtended{isExtended}, _binnedL{binnedL}, _weightVar{"weightVar", "weightVar", this, *dummyVar(weightVarName),
                                                            true,        false,       true}, ...
```

Really not great to have all the elements in the constructor initializer list in one line. It's hard to read, there are weird line breaks, and if you only change one member it looks like you have changed everything.

This commit suggests to have line breaks in the style instead, so from now on, it will look better:

```C++
RooNLLVarNew::RooNLLVarNew(const char *name, const char *title, RooAbsPdf &pdf, RooArgSet const &observables,
                            bool isExtended, RooFit::OffsetMode offsetMode, bool binnedL)                                                 true,        false,       true},
   : RooAbsReal(name, title),
     _pdf{"pdf", "pdf", this, pdf},
     _observables{getObs(pdf, observables)},
     _isExtended{isExtended},
     _binnedL{binnedL},
     _weightVar{"weightVar", "weightVar", this, *dummyVar(weightVarName), true, false, true},
    ...
```