### PR TITLE
Check if a callfunc returns void before setting the return result.

### DIFF
--- a/core/metacling/src/TClingCallFunc.cxx
+++ b/core/metacling/src/TClingCallFunc.cxx
@@ -1820,8 +1820,7 @@ T TClingCallFunc::ExecT(void *address)
    }
    cling::Value ret;
    exec_with_valref_return(address, &ret);
-   if (!ret.isValid()) {
-      // Sometimes we are called on a function returning void!
+   if (ret.isVoid()) {
       return 0;
    }
 

--- a/core/metacling/test/TClingCallFuncTests.cxx
+++ b/core/metacling/test/TClingCallFuncTests.cxx
@@ -36,7 +36,22 @@ public:
     return gInterpreter->CallFunc_GetWrapperCode(fmc);
   }
 
+  CallFunc_t * GetCF() const { return fmc; }
 };
+
+// root-project/root#11930
+TEST(TClingCallFunc, Void)
+{
+   gInterpreter->Declare(R"cpp(
+                           void ExecVoid() { }
+                           )cpp");
+
+   CallFuncRAII CfRAII("");
+   CfRAII.SetProtoAndGetWrapper("ExecVoid", "");
+
+   // Should not crash
+   gInterpreter->CallFunc_ExecInt(CfRAII.GetCF(), /*address*/0);
+}
 
 TEST(TClingCallFunc, FunctionWrapper)
 {


### PR DESCRIPTION
This fixes root-project/root#11930

