### PR TITLE
[ntuple,daos] Improve test suite with fixture class and teardown functionality

### DIFF
--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -53,12 +53,16 @@ ROOT_ADD_GTEST(ntuple_storage ntuple_storage.cxx LIBRARIES ROOTDataFrame ROOTNTu
 ROOT_ADD_GTEST(ntuple_extended ntuple_extended.cxx LIBRARIES ROOTDataFrame ROOTNTuple MathCore CustomStruct)
 
 if(daos OR daos_mock)
-  # UUID of the DAOS pool used for testing, if not provided (may be any for libdaos_mock).
+  # Label of the DAOS pool used for testing, if not provided (may be any for libdaos_mock).
   if(NOT daos_test_pool)
     set(daos_test_pool ntuple-daos-test-pool)
   endif()
-  set_property(SOURCE ntuple_storage_daos.cxx
-               APPEND PROPERTY COMPILE_DEFINITIONS R__DAOS_TEST_POOL="${daos_test_pool}")
 
   ROOT_ADD_GTEST(ntuple_storage_daos ntuple_storage_daos.cxx LIBRARIES ROOTDataFrame ROOTNTuple MathCore CustomStruct)
+  target_compile_definitions(ntuple_storage_daos PRIVATE R__DAOS_TEST_POOL="${daos_test_pool}")
+
+  if(daos_mock)
+    set_property(SOURCE ntuple_storage_daos.cxx
+            APPEND PROPERTY COMPILE_DEFINITIONS R__DAOS_TEST_MOCK=1)
+  endif()
 endif()

--- a/tree/ntuple/v7/test/ntuple_storage_daos.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage_daos.cxx
@@ -5,6 +5,8 @@
 
 class RPageStorageDaos : public ::testing::Test {
 public:
+   ROOT::TestSupport::CheckDiagsRAII fTestRootDiags;
+
    static constexpr const char fDaosContainerLabels[5][22] = {
       "test-basics", "test-extended", "test-options", "test-multiple-ntuples", "test-caged-pages",
    };
@@ -16,6 +18,16 @@ public:
    }
 
 protected:
+   void SetUp() override
+   {
+      // Initialized at the start of each test to expect diagnostic messages from TestSupport
+      fTestRootDiags.optionalDiag(kWarning, "in int daos_init()",
+                                  "This RNTuple build uses libdaos_mock. Use only for testing!");
+      fTestRootDiags.requiredDiag(kWarning, "ROOT::Experimental::Detail::RPageSinkDaos::RPageSinkDaos",
+                                  "The DAOS backend is experimental and still under development.", false);
+      fTestRootDiags.requiredDiag(kWarning, "[ROOT.NTuple]", "Pre-release format version: RC 1", false);
+   }
+
    static void TearDownTestSuite()
    {
 #ifndef R__DAOS_TEST_MOCK
@@ -29,12 +41,6 @@ protected:
 
 TEST_F(RPageStorageDaos, Basics)
 {
-   ROOT::TestSupport::CheckDiagsRAII diags;
-   diags.optionalDiag(kWarning, "in int daos_init()", "This RNTuple build uses libdaos_mock. Use only for testing!");
-   diags.requiredDiag(kWarning, "ROOT::Experimental::Detail::RPageSinkDaos::RPageSinkDaos",
-                      "The DAOS backend is experimental and still under development.", false);
-   diags.requiredDiag(kWarning, "[ROOT.NTuple]", "Pre-release format version: RC 1", false);
-
    std::string daosUri = GetDaosUri(0);
    const std::string_view ntupleName("ntuple");
    auto model = RNTupleModel::Create();

--- a/tree/ntuple/v7/test/ntuple_storage_daos.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage_daos.cxx
@@ -3,7 +3,20 @@
 #include "ROOT/TestSupport.hxx"
 #include <iostream>
 
-TEST(RPageStorageDaos, Basics)
+class RPageStorageDaos : public ::testing::Test {
+public:
+   static constexpr const char fDaosContainerLabels[5][22] = {
+      "test-basics", "test-extended", "test-options", "test-multiple-ntuples", "test-caged-pages",
+   };
+
+   [[nodiscard]] static std::string GetDaosUri(int testIndex)
+   {
+      static const std::string testPoolUriPrefix("daos://" R__DAOS_TEST_POOL "/");
+      return {testPoolUriPrefix + fDaosContainerLabels[testIndex]};
+   }
+};
+
+TEST_F(RPageStorageDaos, Basics)
 {
    ROOT::TestSupport::CheckDiagsRAII diags;
    diags.optionalDiag(kWarning, "in int daos_init()", "This RNTuple build uses libdaos_mock. Use only for testing!");
@@ -11,7 +24,7 @@ TEST(RPageStorageDaos, Basics)
                       "The DAOS backend is experimental and still under development.", false);
    diags.requiredDiag(kWarning, "[ROOT.NTuple]", "Pre-release format version: RC 1", false);
 
-   std::string daosUri("daos://" R__DAOS_TEST_POOL "/container-test-1");
+   std::string daosUri = GetDaosUri(0);
    const std::string_view ntupleName("ntuple");
    auto model = RNTupleModel::Create();
    auto wrPt = model->MakeField<float>("pt", 42.0);
@@ -41,9 +54,9 @@ TEST(RPageStorageDaos, Basics)
    EXPECT_EQ(12.0, *rdPt);
 }
 
-TEST(RPageStorageDaos, Extended)
+TEST_F(RPageStorageDaos, Extended)
 {
-   std::string daosUri("daos://" R__DAOS_TEST_POOL "/container-test-2");
+   std::string daosUri = GetDaosUri(1);
    const std::string_view ntupleName("ntuple");
    auto model = RNTupleModel::Create();
    auto wrVector = model->MakeField<std::vector<double>>("vector");
@@ -83,9 +96,9 @@ TEST(RPageStorageDaos, Extended)
    EXPECT_EQ(chksumRead, chksumWrite);
 }
 
-TEST(RPageStorageDaos, Options)
+TEST_F(RPageStorageDaos, Options)
 {
-   std::string daosUri("daos://" R__DAOS_TEST_POOL "/container-test-3");
+   std::string daosUri = GetDaosUri(2);
    const std::string_view ntupleName("ntuple");
    {
       auto model = RNTupleModel::Create();
@@ -121,9 +134,9 @@ TEST(RPageStorageDaos, Options)
    EXPECT_EQ(1U, source.GetNEntries());
 }
 
-TEST(RPageStorageDaos, MultipleNTuplesPerContainer)
+TEST_F(RPageStorageDaos, MultipleNTuplesPerContainer)
 {
-   std::string daosUri("daos://" R__DAOS_TEST_POOL "/container-test-4");
+   std::string daosUri = GetDaosUri(3);
    const std::string_view ntupleName1("ntuple1"), ntupleName2("ntuple2");
 
    RNTupleWriteOptionsDaos options;
@@ -175,9 +188,9 @@ TEST(RPageStorageDaos, MultipleNTuplesPerContainer)
    EXPECT_THROW(RNTupleReader::Open("ntuple3", daosUri), ROOT::Experimental::RException);
 }
 
-TEST(RPageStorageDaos, CagedPages)
+TEST_F(RPageStorageDaos, CagedPages)
 {
-   std::string daosUri("daos://" R__DAOS_TEST_POOL "/container-test-5");
+   std::string daosUri = GetDaosUri(4);
    const std::string_view ntupleName("ntuple");
    ROOT::EnableImplicitMT();
 

--- a/tree/ntuple/v7/test/ntuple_storage_daos.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage_daos.cxx
@@ -14,6 +14,17 @@ public:
       static const std::string testPoolUriPrefix("daos://" R__DAOS_TEST_POOL "/");
       return {testPoolUriPrefix + fDaosContainerLabels[testIndex]};
    }
+
+protected:
+   static void TearDownTestSuite()
+   {
+#ifndef R__DAOS_TEST_MOCK
+      const std::string sysCmd("daos cont destroy " R__DAOS_TEST_POOL " ");
+      for (const auto &label : fDaosContainerLabels) {
+         system((sysCmd + label).data());
+      }
+#endif
+   }
 };
 
 TEST_F(RPageStorageDaos, Basics)


### PR DESCRIPTION
This Pull request adds Google Test fixture functionality in the RNTuple DAOS test suite, enabling automatic storage cleanup when running unit tests with real DAOS clusters.

## Changes or fixes:

- Introduces a fixture class for the test suite and registers all five existing tests under it through the `TEST_F` macro. 
- Consolidates shared functionality in the fixture definition. Namely, pool and container label data and expected diagnostics messages from `ROOT::TestSupport`. 
- Uses the `TearDownTestSuite()` call to automatically destroy DAOS containers created for the unit tests when all of them are completed.
- Replaces some duplicated string literals that specify ntuples and models for variables.
- Introduces preproc definition `R__DAOS_TEST_MOCK` to CMake to bypass container destruction system call if using the mock library as underlying storage.

## Pending:

- One error message is not currently suppressed, as it is not emitted by ROOT's exception diagnostics: `client ERR  src/client/api/container.c:148 daos_cont_create_with_label() daos_cont_create label=test-multiple-ntuples failed, DER_EXIST(-1004): 'Entity already exists'`. This is the (normal) output of `RDaosContainer` attempting to create a container by default, and ignoring the error if it already exists in the DAOS pool.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

