### PR TITLE
[RF] Increase version number of `RooRealVar`

### DIFF
--- a/roofit/roofitcore/inc/RooRealVar.h
+++ b/roofit/roofitcore/inc/RooRealVar.h
@@ -172,10 +172,7 @@ public:
 
   std::size_t _valueResetCounter = 0; ///<! How many times the value of this variable was reset
 
-  ClassDefOverride(RooRealVar,8) // Real-valued variable
+  ClassDefOverride(RooRealVar,9); // Real-valued variable
 };
-
-
-
 
 #endif


### PR DESCRIPTION
In ecd98632, the class version of the `RooAbsArg` class was incremented.

As explained in #8791, there are sometimes warnings in the IO of derived classes if their version number is not increased as well.

Increasing the class version of RooRealVar indeed fixes this warning that one gets right now when reading old workspaces:

```
Warning in <TStreamerInfo::BuildCheck>:
   The StreamerInfo of class RooRealVar read from file toyws/WS-VHbb-STXS_mu_toy_new.root
   has the same version (=8) as the active class but a different checksum.
   You should update the version to ClassDef(RooRealVar,9).
   Do not try to write objects with the current class definition,
   the files will not be readable.

Warning in <TStreamerInfo::CompareContent>: The following data member of
the on-file layout version 8 of class 'RooRealVar' differs from
the in-memory layout version 8:
   RooAbsBinning _binning; //
vs
   unique_ptr<RooAbsBinning,default_delete<RooAbsBinning> > _binning;
```