### PR TITLE
[RF] Fix signature of `RooWorkspace::getSnapshots()`

### DIFF
--- a/roofit/roofitcore/inc/RooWorkspace.h
+++ b/roofit/roofitcore/inc/RooWorkspace.h
@@ -95,7 +95,7 @@ public:
   const RooArgSet* getSnapshot(const char* name) const ;
 
   // Retrieve list of parameter snapshots
-  RooLinkedList getSnapshots(){ return _snapshots; }
+  RooLinkedList const& getSnapshots() const { return _snapshots; }
 
   void merge(const RooWorkspace& /*other*/) {} ;
 

--- a/roofit/roostats/src/RooStatsUtils.cxx
+++ b/roofit/roostats/src/RooStatsUtils.cxx
@@ -384,11 +384,8 @@ namespace RooStats {
 
       // Copy snapshots
       if (copySnapshots) {
-        for (auto *snap : oldWS->getSnapshots()) {
-          RooArgSet *snapClone = new RooArgSet;
-          static_cast<RooArgSet *>(snap)->snapshot(*snapClone);
-          snapClone->setName(snap->GetName());
-          newWS->getSnapshots().Add(snapClone);
+        for (auto* snap : static_range_cast<RooArgSet const*>(oldWS->getSnapshots())) {
+          newWS->saveSnapshot(snap->GetName(), *snap, /*importValuesdf*/true);
         }
       }
 


### PR DESCRIPTION
For ROOT 6.26, the `RooWorkspace::getSnapshots()` method was introduced in commit 460a58cb28.

However, the signature was not what it should have been: it returned a copy of the snaphot list instead of a `const` reference.

This is fixed now, which also uncovered a bug in some RooStats code where the snapshots are supposed to be transferred from one workspace to another, but they were just appended to the new list that was returned by `getSnapshots()`, so whe whole code had no effect.

This is fixed now by correctly using `RooWorkspace::saveSnapshot()`.