### PR TITLE
Fix compilation error in rbrowsable

### DIFF
--- a/gui/browsable/src/TDirectoryElement.cxx
+++ b/gui/browsable/src/TDirectoryElement.cxx
@@ -181,14 +181,6 @@ public:
    /** Returns full information for current element */
    std::shared_ptr<RElement> GetElement() override;
 
-   std::string GetContent(const std::string &kind) override
-   {
-      if (GetContentKind(kind) == kFileName)
-         return fFileName;
-
-      return ""s;
-   }
-
 };
 
 // ===============================================================================================================
@@ -433,6 +425,14 @@ public:
          return true;
       }
       return false;
+   }
+
+   std::string GetContent(const std::string &kind) override
+   {
+      if (GetContentKind(kind) == kFileName)
+         return fFileName;
+
+      return ""s;
    }
 
 };


### PR DESCRIPTION
Move GetContent method to TDirectoryElement where it should be.

Fixes #12110 