### PR TITLE
[ntuple] Allow for storing fields in different column representations

### DIFF
--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -78,11 +78,11 @@ public:
    }
    // Field is only used for reading
    void GenerateColumnsImpl() final { assert(false && "Cardinality fields must only be used for reading"); }
-   void GenerateColumnsImpl(const RNTupleDescriptor &) final
+   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final
    {
-      RColumnModel model(EColumnType::kIndex, true /* isSorted*/);
-      fColumns.emplace_back(ROOT::Experimental::Detail::RColumn::Create<ClusterSize_t>(model, 0));
-      fPrincipalColumn = fColumns[0].get();
+      auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
+      fColumns.emplace_back(
+         ROOT::Experimental::Detail::RColumn::Create<ClusterSize_t>(RColumnModel(onDiskTypes[0]), 0));
    }
 
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where) final

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -71,9 +71,13 @@ public:
    RRDFCardinalityField &operator=(RRDFCardinalityField &&other) = default;
    ~RRDFCardinalityField() = default;
 
+   const RColumnRepresentations &GetColumnRepresentations() const final
+   {
+      static RColumnRepresentations representations({{EColumnType::kIndex}}, {{}});
+      return representations;
+   }
    // Field is only used for reading
    void GenerateColumnsImpl() final { assert(false && "Cardinality fields must only be used for reading"); }
-
    void GenerateColumnsImpl(const RNTupleDescriptor &) final
    {
       RColumnModel model(EColumnType::kIndex, true /* isSorted*/);

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -81,8 +81,7 @@ public:
    void GenerateColumnsImpl(const RNTupleDescriptor &) final
    {
       RColumnModel model(EColumnType::kIndex, true /* isSorted*/);
-      fColumns.emplace_back(std::unique_ptr<ROOT::Experimental::Detail::RColumn>(
-         ROOT::Experimental::Detail::RColumn::Create<ClusterSize_t, EColumnType::kIndex>(model, 0)));
+      fColumns.emplace_back(ROOT::Experimental::Detail::RColumn::Create<ClusterSize_t>(model, 0));
       fPrincipalColumn = fColumns[0].get();
    }
 

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -26,6 +26,7 @@
 #include <TError.h>
 
 #include <memory>
+#include <utility>
 
 namespace ROOT {
 namespace Experimental {
@@ -99,11 +100,11 @@ private:
    }
 
 public:
-   template <typename CppT, EColumnType ColumnT>
-   static RColumn *Create(const RColumnModel &model, std::uint32_t index) {
-      R__ASSERT(model.GetType() == ColumnT);
-      auto column = new RColumn(model, index);
-      column->fElement = std::unique_ptr<RColumnElementBase>(new RColumnElement<CppT, ColumnT>(nullptr));
+   template <typename CppT>
+   static std::unique_ptr<RColumn> Create(const RColumnModel &model, std::uint32_t index)
+   {
+      auto column = std::unique_ptr<RColumn>(new RColumn(model, index));
+      column->fElement = RColumnElementBase::Generate<CppT>(model.GetType());
       return column;
    }
 

--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -296,6 +296,20 @@ public:
 };
 
 template <>
+class RColumnElement<double, EColumnType::kSplitReal64> : public RColumnElementBase {
+public:
+   static constexpr bool kIsMappable = false;
+   static constexpr std::size_t kSize = sizeof(double);
+   static constexpr std::size_t kBitsOnStorage = kSize * 8;
+   explicit RColumnElement(double *value) : RColumnElementBase(value, kSize) {}
+   bool IsMappable() const final { return kIsMappable; }
+   std::size_t GetBitsOnStorage() const final { return kBitsOnStorage; }
+
+   void Pack(void *dst, void *src, std::size_t count) const final;
+   void Unpack(void *dst, void *src, std::size_t count) const final;
+};
+
+template <>
 class RColumnElement<std::int8_t, EColumnType::kInt8> : public RColumnElementBase {
 public:
    static constexpr bool kIsMappable = true;
@@ -479,6 +493,7 @@ std::unique_ptr<RColumnElementBase> RColumnElementBase::Generate(EColumnType typ
    switch (type) {
    case EColumnType::kReal32: return std::make_unique<RColumnElement<CppT, EColumnType::kReal32>>(nullptr);
    case EColumnType::kReal64: return std::make_unique<RColumnElement<CppT, EColumnType::kReal64>>(nullptr);
+   case EColumnType::kSplitReal64: return std::make_unique<RColumnElement<CppT, EColumnType::kSplitReal64>>(nullptr);
    case EColumnType::kChar: return std::make_unique<RColumnElement<CppT, EColumnType::kChar>>(nullptr);
    case EColumnType::kByte: return std::make_unique<RColumnElement<CppT, EColumnType::kByte>>(nullptr);
    case EColumnType::kInt8: return std::make_unique<RColumnElement<CppT, EColumnType::kInt8>>(nullptr);

--- a/tree/ntuple/v7/inc/ROOT/RColumnModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnModel.hxx
@@ -35,6 +35,7 @@ When changed, remember to update
   - RColumnElement::Generate()
   - RColumnElement::GetBitsOnStorage()
   - RColumnElement::GetTypeName()
+  - RColumnElement template specializations / packing & unpacking
   - RNTupleSerializer::[Des|S]erializeColumnType
 */
 // clang-format on
@@ -49,6 +50,7 @@ enum class EColumnType {
    kChar,
    kBit,
    kReal64,
+   kSplitReal64,
    kReal32,
    kReal16,
    kInt64,

--- a/tree/ntuple/v7/inc/ROOT/RColumnModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnModel.hxx
@@ -36,6 +36,7 @@ When changed, remember to update
   - RColumnElement::GetBitsOnStorage()
   - RColumnElement::GetTypeName()
   - RColumnElement template specializations / packing & unpacking
+  - If necessary, endianess handling for the packing + unit test in ntuple_endian
   - RNTupleSerializer::[Des|S]erializeColumnType
 */
 // clang-format on

--- a/tree/ntuple/v7/inc/ROOT/RColumnModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnModel.hxx
@@ -31,6 +31,11 @@ namespace Experimental {
 
 More complex types, such as classes, get translated into columns of such simple types by the RField.
 New types need to be accounted for in RColumnElementBase::Generate() and RColumnElementBase::GetBitsOnStorage(), too.
+When changed, remember to update
+  - RColumnElement::Generate()
+  - RColumnElement::GetBitsOnStorage()
+  - RColumnElement::GetTypeName()
+  - RNTupleSerializer::[Des|S]erializeColumnType
 */
 // clang-format on
 enum class EColumnType {

--- a/tree/ntuple/v7/inc/ROOT/RColumnModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnModel.hxx
@@ -62,7 +62,7 @@ enum class EColumnType {
 /**
 \class ROOT::Experimental::RColumnModel
 \ingroup NTuple
-\brief Holds the static meta-data of a column in a tree
+\brief Holds the static meta-data of an RNTuple column
 */
 // clang-format on
 class RColumnModel {
@@ -72,6 +72,7 @@ private:
 
 public:
    RColumnModel() : fType(EColumnType::kUnknown), fIsSorted(false) {}
+   explicit RColumnModel(EColumnType type) : fType(type), fIsSorted(type == EColumnType::kIndex) {}
    RColumnModel(EColumnType type, bool isSorted) : fType(type), fIsSorted(isSorted) {}
 
    EColumnType GetType() const { return fType; }

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -156,9 +156,9 @@ protected:
    std::vector<ReadCallback_t> fReadCallbacks;
    /// C++ type version cached from the descriptor after a call to `ConnectPageSource()`
    std::uint32_t fOnDiskTypeVersion = kInvalidTypeVersion;
-   /// If set, the column representation used for serialization; otherwise the default from
-   /// GetColumnRepresentations() is used
-   std::unique_ptr<ColumnRepresentation_t> fColumnRepresentative;
+   /// Points into the static vector GetColumnRepresentations().GetSerializationTypes() when SetColumnRepresentative
+   /// is called.  Otherwise GetColumnRepresentative returns the default representation.
+   const ColumnRepresentation_t *fColumnRepresentative = nullptr;
 
    /// Implementations in derived classes should return a static RColumnRepresentations object. The default
    /// implementation does not attach any columns to the field.
@@ -183,7 +183,7 @@ protected:
 
    /// Returns the on-disk column types found in the provided descriptor for fOnDiskId. Throws an exception if the types
    /// don't match any of the deserialization types from GetColumnRepresentations().
-   ColumnRepresentation_t EnsureCompatibleColumnTypes(const RNTupleDescriptor &desc) const;
+   const ColumnRepresentation_t &EnsureCompatibleColumnTypes(const RNTupleDescriptor &desc) const;
 
    /// Set a user-defined function to be called after reading a value, giving a chance to inspect and/or modify the
    /// value object.
@@ -340,7 +340,7 @@ public:
    void SetOnDiskId(DescriptorId_t id) { fOnDiskId = id; }
 
    /// Returns the fColumnRepresentative pointee or, if unset, the field's default representative
-   ColumnRepresentation_t GetColumnRepresentative() const;
+   const ColumnRepresentation_t &GetColumnRepresentative() const;
    /// Fixes a column representative. This can only be done _before_ connecting the field to a page sink.
    /// Otherwise, or if the provided representation is not in the list of GetColumnRepresentations,
    /// an exception is thrown

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -112,9 +112,9 @@ public:
 
       /// The first column list from fSerializationTypes is the default for writing.
       std::vector<EColumnType> GetSerializationDefault() const;
-      TypesList_t GetSerializeTypes() const { return fSerializationTypes; }
+      TypesList_t GetSerializationTypes() const { return fSerializationTypes; }
       /// Get the union of fSerializationTypes and fDeserializationExtraTypes
-      TypesList_t GetDeserializeTypes() const;
+      TypesList_t GetDeserializationTypes() const;
 
    private:
       TypesList_t fSerializationTypes;
@@ -158,7 +158,7 @@ protected:
    std::uint32_t fOnDiskTypeVersion = kInvalidTypeVersion;
    /// If set, the column representation used for serialization; otherwise the default from
    /// GetColumnRepresentations() is used
-   std::unique_ptr<std::vector<EColumnType>> fSerializationTypes;
+   std::unique_ptr<std::vector<EColumnType>> fColumnRepresentative;
 
    /// Implementations in derived classes should return a static RColumnRepresentations object. The default
    /// implementation does not attach any columns to the field.
@@ -339,12 +339,12 @@ public:
    DescriptorId_t GetOnDiskId() const { return fOnDiskId; }
    void SetOnDiskId(DescriptorId_t id) { fOnDiskId = id; }
 
-   /// Returns the fSerializationColumnTypes pointee or, if unset, the field's default representation
-   std::vector<EColumnType> GetSerializationColumnTypes() const;
-   /// Picks a column representation. This can only be done _before_ connecting the field to a page sink.
+   /// Returns the fColumnRepresentative pointee or, if unset, the field's default representative
+   std::vector<EColumnType> GetColumnRepresentative() const;
+   /// Fixes a column representative. This can only be done _before_ connecting the field to a page sink.
    /// Otherwise, or if the provided representation is not in the list of GetColumnRepresentations,
    /// an exception is thrown
-   void SetSerializationTypes(const std::vector<EColumnType> &representation);
+   void SetColumnRepresentative(const std::vector<EColumnType> &representative);
 
    /// Fields and their columns live in the void until connected to a physical page storage.  Only once connected, data
    /// can be read or written.  In order to find the field in the page storage, the field's on-disk ID has to be set.

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -155,6 +155,9 @@ protected:
    std::vector<ReadCallback_t> fReadCallbacks;
    /// C++ type version cached from the descriptor after a call to `ConnectPageSource()`
    std::uint32_t fOnDiskTypeVersion = kInvalidTypeVersion;
+   /// If set, the column representation used for serialization; otherwise the default from
+   /// GetColumnRepresentations() is used
+   std::unique_ptr<std::vector<EColumnType>> fSerializationColumnTypes;
 
    /// Implementations in derived classes should return a static RColumnRepresentations object. The default
    /// implementation does not attach any columns to the field.
@@ -177,10 +180,12 @@ protected:
       ReadGlobalImpl(fPrincipalColumn->GetGlobalIndex(clusterIndex), value);
    }
 
-   /// Throws an exception if the column given by fOnDiskId and the columnIndex in the provided descriptor
-   /// is not of one of the requested types.
-   ROOT::Experimental::EColumnType EnsureColumnType(const std::vector<EColumnType> &requestedTypes,
-                                                    unsigned int columnIndex, const RNTupleDescriptor &desc);
+   /// Returns the fSerializationColumnTypes pointee or, if unset, the field's default representation
+   std::vector<EColumnType> GetSerializationColumnTypes() const;
+
+   /// Returns the on-disk column types found in the provided descriptor for fOnDiskId. Throws an exception if the types
+   /// don't match any of the deserialization types from GetColumnRepresentations().
+   std::vector<ROOT::Experimental::EColumnType> EnsureCompatibleColumnTypes(const RNTupleDescriptor &desc) const;
 
    /// Set a user-defined function to be called after reading a value, giving a chance to inspect and/or modify the
    /// value object.

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -112,6 +112,7 @@ public:
 
       /// The first column list from fSerializationTypes is the default for writing.
       std::vector<EColumnType> GetSerializationDefault() const;
+      TypesList_t GetSerializeTypes() const { return fSerializationTypes; }
       /// Get the union of fSerializationTypes and fDeserializationExtraTypes
       TypesList_t GetDeserializeTypes() const;
 
@@ -157,7 +158,7 @@ protected:
    std::uint32_t fOnDiskTypeVersion = kInvalidTypeVersion;
    /// If set, the column representation used for serialization; otherwise the default from
    /// GetColumnRepresentations() is used
-   std::unique_ptr<std::vector<EColumnType>> fSerializationColumnTypes;
+   std::unique_ptr<std::vector<EColumnType>> fSerializationTypes;
 
    /// Implementations in derived classes should return a static RColumnRepresentations object. The default
    /// implementation does not attach any columns to the field.
@@ -179,9 +180,6 @@ protected:
    virtual void ReadInClusterImpl(const RClusterIndex &clusterIndex, RFieldValue *value) {
       ReadGlobalImpl(fPrincipalColumn->GetGlobalIndex(clusterIndex), value);
    }
-
-   /// Returns the fSerializationColumnTypes pointee or, if unset, the field's default representation
-   std::vector<EColumnType> GetSerializationColumnTypes() const;
 
    /// Returns the on-disk column types found in the provided descriptor for fOnDiskId. Throws an exception if the types
    /// don't match any of the deserialization types from GetColumnRepresentations().
@@ -340,6 +338,13 @@ public:
 
    DescriptorId_t GetOnDiskId() const { return fOnDiskId; }
    void SetOnDiskId(DescriptorId_t id) { fOnDiskId = id; }
+
+   /// Returns the fSerializationColumnTypes pointee or, if unset, the field's default representation
+   std::vector<EColumnType> GetSerializationColumnTypes() const;
+   /// Picks a column representation. This can only be done _before_ connecting the field to a page sink.
+   /// Otherwise, or if the provided representation is not in the list of GetColumnRepresentations,
+   /// an exception is thrown
+   void SetSerializationTypes(const std::vector<EColumnType> &representation);
 
    /// Fields and their columns live in the void until connected to a physical page storage.  Only once connected, data
    /// can be read or written.  In order to find the field in the page storage, the field's on-disk ID has to be set.

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -99,6 +99,8 @@ public:
    /// All column representations supported for writing also need to be supported for reading. In addition,
    /// fields can support extra column representations for reading only, e.g. a 64bit integer reading from a
    /// 32bit column.
+   /// The defined column representations must be supported by corresponding column packing/unpacking implementations,
+   /// i.e. for the example above, the unpacking of 32bit ints to 64bit pages must be implemented in RColumnElement.hxx
    class RColumnRepresentations {
    public:
       using TypesList_t = std::vector<std::vector<EColumnType>>;
@@ -265,6 +267,9 @@ public:
    virtual size_t GetValueSize() const = 0;
    /// For many types, the alignment requirement is equal to the size; otherwise override.
    virtual size_t GetAlignment() const { return GetValueSize(); }
+   /// Implementations in derived classes should return a static RColumnRepresentations object. The default
+   /// implementation does not attach any columns to the field.
+   virtual const RColumnRepresentations &GetColumnRepresentations() const;
    int GetTraits() const { return fTraits; }
    bool HasReadCallbacks() const { return !fReadCallbacks.empty(); }
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -156,6 +156,9 @@ protected:
    /// C++ type version cached from the descriptor after a call to `ConnectPageSource()`
    std::uint32_t fOnDiskTypeVersion = kInvalidTypeVersion;
 
+   /// Implementations in derived classes should return a static RColumnRepresentations object. The default
+   /// implementation does not attach any columns to the field.
+   virtual const RColumnRepresentations &GetColumnRepresentations() const;
    /// Creates the backing columns corresponsing to the field type for writing
    virtual void GenerateColumnsImpl() = 0;
    /// Creates the backing columns corresponsing to the field type for reading.
@@ -267,9 +270,6 @@ public:
    virtual size_t GetValueSize() const = 0;
    /// For many types, the alignment requirement is equal to the size; otherwise override.
    virtual size_t GetAlignment() const { return GetValueSize(); }
-   /// Implementations in derived classes should return a static RColumnRepresentations object. The default
-   /// implementation does not attach any columns to the field.
-   virtual const RColumnRepresentations &GetColumnRepresentations() const;
    int GetTraits() const { return fTraits; }
    bool HasReadCallbacks() const { return !fReadCallbacks.empty(); }
 
@@ -362,12 +362,12 @@ public:
 class RFieldZero : public Detail::RFieldBase {
 protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const override;
+   void GenerateColumnsImpl() final {}
+   void GenerateColumnsImpl(const RNTupleDescriptor &) final {}
 
 public:
    RFieldZero() : Detail::RFieldBase("", "", ENTupleStructure::kRecord, false /* isSimple */) { }
 
-   void GenerateColumnsImpl() final {}
-   void GenerateColumnsImpl(const RNTupleDescriptor &) final {}
    using Detail::RFieldBase::GenerateValue;
    Detail::RFieldValue GenerateValue(void*) override { return Detail::RFieldValue(); }
    Detail::RFieldValue CaptureValue(void*) final { return Detail::RFieldValue(); }
@@ -404,6 +404,8 @@ private:
 
 protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final;
+   void GenerateColumnsImpl() final {}
+   void GenerateColumnsImpl(const RNTupleDescriptor &) final {}
    std::size_t AppendImpl(const Detail::RFieldValue& value) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue *value) final;
    void ReadInClusterImpl(const RClusterIndex &clusterIndex, Detail::RFieldValue *value) final;
@@ -415,8 +417,6 @@ public:
    RClassField& operator =(RClassField&& other) = default;
    ~RClassField() override = default;
 
-   void GenerateColumnsImpl() final {}
-   void GenerateColumnsImpl(const RNTupleDescriptor &) final {}
    using Detail::RFieldBase::GenerateValue;
    Detail::RFieldValue GenerateValue(void* where) override;
    void DestroyValue(const Detail::RFieldValue& value, bool dtorOnly = false) final;
@@ -448,6 +448,9 @@ private:
 
 protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final;
+   const RColumnRepresentations &GetColumnRepresentations() const final;
+   void GenerateColumnsImpl() final;
+   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
    std::size_t AppendImpl(const Detail::RFieldValue &value) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue *value) final;
 
@@ -457,9 +460,6 @@ public:
    RCollectionClassField &operator=(RCollectionClassField &&other) = default;
    ~RCollectionClassField() override = default;
 
-   const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
    using Detail::RFieldBase::GenerateValue;
    Detail::RFieldValue GenerateValue(void *where) override;
    void DestroyValue(const Detail::RFieldValue &value, bool dtorOnly = false) final;
@@ -490,6 +490,8 @@ protected:
    std::size_t GetItemPadding(std::size_t baseOffset, std::size_t itemAlignment) const;
 
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const override;
+   void GenerateColumnsImpl() final {}
+   void GenerateColumnsImpl(const RNTupleDescriptor &) final {}
    std::size_t AppendImpl(const Detail::RFieldValue& value) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue *value) final;
    void ReadInClusterImpl(const RClusterIndex &clusterIndex, Detail::RFieldValue *value) final;
@@ -520,8 +522,6 @@ public:
    RRecordField& operator =(RRecordField&& other) = default;
    ~RRecordField() override = default;
 
-   void GenerateColumnsImpl() final {}
-   void GenerateColumnsImpl(const RNTupleDescriptor &) final {}
    using Detail::RFieldBase::GenerateValue;
    Detail::RFieldValue GenerateValue(void* where) override;
    void DestroyValue(const Detail::RFieldValue& value, bool dtorOnly = false) override;
@@ -540,6 +540,9 @@ private:
 
 protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final;
+   const RColumnRepresentations &GetColumnRepresentations() const final;
+   void GenerateColumnsImpl() final;
+   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
    std::size_t AppendImpl(const Detail::RFieldValue& value) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue *value) final;
 
@@ -549,9 +552,6 @@ public:
    RVectorField& operator =(RVectorField&& other) = default;
    ~RVectorField() override = default;
 
-   const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
    using Detail::RFieldBase::GenerateValue;
    Detail::RFieldValue GenerateValue(void* where) override;
    void DestroyValue(const Detail::RFieldValue& value, bool dtorOnly = false) final;
@@ -582,6 +582,9 @@ protected:
    std::size_t fValueSize;
 
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const override;
+   const RColumnRepresentations &GetColumnRepresentations() const final;
+   void GenerateColumnsImpl() final;
+   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
    std::size_t AppendImpl(const Detail::RFieldValue &value) override;
    void ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue *value) override;
 
@@ -593,9 +596,6 @@ public:
    RRVecField &operator=(RRVecField &) = delete;
    ~RRVecField() override = default;
 
-   const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
    using Detail::RFieldBase::GenerateValue;
    Detail::RFieldValue GenerateValue(void *where) override;
    void DestroyValue(const Detail::RFieldValue &value, bool dtorOnly = false) override;
@@ -623,6 +623,8 @@ private:
 
 protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final;
+   void GenerateColumnsImpl() final {}
+   void GenerateColumnsImpl(const RNTupleDescriptor &) final {}
    std::size_t AppendImpl(const Detail::RFieldValue& value) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue *value) final;
    void ReadInClusterImpl(const RClusterIndex &clusterIndex, Detail::RFieldValue *value) final;
@@ -633,8 +635,6 @@ public:
    RArrayField& operator =(RArrayField &&other) = default;
    ~RArrayField() override = default;
 
-   void GenerateColumnsImpl() final {}
-   void GenerateColumnsImpl(const RNTupleDescriptor &) final {}
    using Detail::RFieldBase::GenerateValue;
    Detail::RFieldValue GenerateValue(void *where) override;
    void DestroyValue(const Detail::RFieldValue &value, bool dtorOnly = false) final;
@@ -662,6 +662,9 @@ private:
 
 protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final;
+   const RColumnRepresentations &GetColumnRepresentations() const final;
+   void GenerateColumnsImpl() final;
+   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
    std::size_t AppendImpl(const Detail::RFieldValue& value) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue *value) final;
 
@@ -672,9 +675,6 @@ public:
    RVariantField& operator =(RVariantField &&other) = default;
    ~RVariantField() override = default;
 
-   const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
    using Detail::RFieldBase::GenerateValue;
    Detail::RFieldValue GenerateValue(void *where) override;
    void DestroyValue(const Detail::RFieldValue &value, bool dtorOnly = false) final;
@@ -796,8 +796,13 @@ class RCollectionField : public ROOT::Experimental::Detail::RFieldBase {
 private:
    /// Save the link to the collection ntuple in order to reset the offset counter when committing the cluster
    std::shared_ptr<RCollectionNTupleWriter> fCollectionNTuple;
+
 protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final;
+   const RColumnRepresentations &GetColumnRepresentations() const final;
+   void GenerateColumnsImpl() final;
+   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+
 public:
    static std::string TypeName() { return ""; }
    RCollectionField(std::string_view name,
@@ -806,10 +811,6 @@ public:
    RCollectionField(RCollectionField&& other) = default;
    RCollectionField& operator =(RCollectionField&& other) = default;
    ~RCollectionField() override = default;
-
-   const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
    using Detail::RFieldBase::GenerateValue;
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final {
@@ -881,6 +882,10 @@ protected:
       return std::make_unique<RField>(newName);
    }
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
+   void GenerateColumnsImpl() final;
+   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+
 public:
    static std::string TypeName() { return "ROOT::Experimental::ClusterSize_t"; }
    explicit RField(std::string_view name)
@@ -891,10 +896,6 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
-
-   const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
    ClusterSize_t *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<ClusterSize_t>(globalIndex);
@@ -945,6 +946,11 @@ protected:
       return std::make_unique<RField<RNTupleCardinality>>(newName);
    }
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
+   // Field is only used for reading
+   void GenerateColumnsImpl() final { throw RException(R__FAIL("Cardinality fields must only be used for reading")); }
+   void GenerateColumnsImpl(const RNTupleDescriptor &) final;
+
 public:
    static std::string TypeName() { return "ROOT::Experimental::RNTupleCardinality"; }
    explicit RField(std::string_view name)
@@ -954,11 +960,6 @@ public:
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
    ~RField() = default;
-
-   const RColumnRepresentations &GetColumnRepresentations() const final;
-   // Field is only used for reading
-   void GenerateColumnsImpl() final { throw RException(R__FAIL("Cardinality fields must only be used for reading")); }
-   void GenerateColumnsImpl(const RNTupleDescriptor &) final;
 
    using Detail::RFieldBase::GenerateValue;
    template <typename... ArgsT>
@@ -1001,6 +1002,10 @@ protected:
       return std::make_unique<RField>(newName);
    }
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
+   void GenerateColumnsImpl() final;
+   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+
 public:
    static std::string TypeName() { return "bool"; }
    explicit RField(std::string_view name)
@@ -1011,10 +1016,6 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
-
-   const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
    bool *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<bool>(globalIndex);
@@ -1053,6 +1054,10 @@ protected:
       return std::make_unique<RField>(newName);
    }
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
+   void GenerateColumnsImpl() final;
+   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+
 public:
    static std::string TypeName() { return "float"; }
    explicit RField(std::string_view name)
@@ -1063,10 +1068,6 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
-
-   const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
    float *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<float>(globalIndex);
@@ -1106,6 +1107,10 @@ protected:
       return std::make_unique<RField>(newName);
    }
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
+   void GenerateColumnsImpl() final;
+   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+
 public:
    static std::string TypeName() { return "double"; }
    explicit RField(std::string_view name)
@@ -1116,10 +1121,6 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
-
-   const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
    double *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<double>(globalIndex);
@@ -1158,6 +1159,10 @@ protected:
       return std::make_unique<RField>(newName);
    }
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
+   void GenerateColumnsImpl() final;
+   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+
 public:
    static std::string TypeName() { return "char"; }
    explicit RField(std::string_view name)
@@ -1168,10 +1173,6 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
-
-   const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
    char *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<char>(globalIndex);
@@ -1210,6 +1211,10 @@ protected:
       return std::make_unique<RField>(newName);
    }
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
+   void GenerateColumnsImpl() final;
+   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+
 public:
    static std::string TypeName() { return "std::int8_t"; }
    explicit RField(std::string_view name)
@@ -1220,10 +1225,6 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
-
-   const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
    std::int8_t *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<std::int8_t>(globalIndex);
@@ -1262,6 +1263,10 @@ protected:
       return std::make_unique<RField>(newName);
    }
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
+   void GenerateColumnsImpl() final;
+   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+
 public:
    static std::string TypeName() { return "std::uint8_t"; }
    explicit RField(std::string_view name)
@@ -1272,10 +1277,6 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
-
-   const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
    std::uint8_t *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<std::uint8_t>(globalIndex);
@@ -1314,6 +1315,10 @@ protected:
       return std::make_unique<RField>(newName);
    }
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
+   void GenerateColumnsImpl() final;
+   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+
 public:
    static std::string TypeName() { return "std::int16_t"; }
    explicit RField(std::string_view name)
@@ -1324,10 +1329,6 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
-
-   const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
    std::int16_t *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<std::int16_t>(globalIndex);
@@ -1366,6 +1367,10 @@ protected:
       return std::make_unique<RField>(newName);
    }
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
+   void GenerateColumnsImpl() final;
+   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+
 public:
    static std::string TypeName() { return "std::uint16_t"; }
    explicit RField(std::string_view name)
@@ -1376,10 +1381,6 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
-
-   const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
    std::uint16_t *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<std::uint16_t>(globalIndex);
@@ -1418,6 +1419,10 @@ protected:
       return std::make_unique<RField>(newName);
    }
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
+   void GenerateColumnsImpl() final;
+   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+
 public:
    static std::string TypeName() { return "std::int32_t"; }
    explicit RField(std::string_view name)
@@ -1428,10 +1433,6 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
-
-   const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
    std::int32_t *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<std::int32_t>(globalIndex);
@@ -1470,6 +1471,10 @@ protected:
       return std::make_unique<RField>(newName);
    }
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
+   void GenerateColumnsImpl() final;
+   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+
 public:
    static std::string TypeName() { return "std::uint32_t"; }
    explicit RField(std::string_view name)
@@ -1480,10 +1485,6 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
-
-   const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
    std::uint32_t *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<std::uint32_t>(globalIndex);
@@ -1522,6 +1523,10 @@ protected:
       return std::make_unique<RField>(newName);
    }
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
+   void GenerateColumnsImpl() final;
+   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+
 public:
    static std::string TypeName() { return "std::uint64_t"; }
    explicit RField(std::string_view name)
@@ -1532,10 +1537,6 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
-
-   const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
    std::uint64_t *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<std::uint64_t>(globalIndex);
@@ -1574,6 +1575,10 @@ protected:
       return std::make_unique<RField>(newName);
    }
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
+   void GenerateColumnsImpl() final;
+   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+
 public:
    static std::string TypeName() { return "std::int64_t"; }
    explicit RField(std::string_view name)
@@ -1584,10 +1589,6 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
-
-   const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
    std::int64_t *Map(NTupleSize_t globalIndex) {
       return fPrincipalColumn->Map<std::int64_t>(globalIndex);
@@ -1628,6 +1629,9 @@ private:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final {
       return std::make_unique<RField>(newName);
    }
+   const RColumnRepresentations &GetColumnRepresentations() const final;
+   void GenerateColumnsImpl() final;
+   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
    std::size_t AppendImpl(const ROOT::Experimental::Detail::RFieldValue& value) final;
    void ReadGlobalImpl(ROOT::Experimental::NTupleSize_t globalIndex,
                        ROOT::Experimental::Detail::RFieldValue *value) final;
@@ -1642,10 +1646,6 @@ public:
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
-
-   const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
    using Detail::RFieldBase::GenerateValue;
    template <typename... ArgsT>

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -95,6 +95,29 @@ public:
    /// Shorthand for types that are both trivially constructible and destructible
    static constexpr int kTraitTrivialType = kTraitTriviallyConstructible | kTraitTriviallyDestructible;
 
+   /// Some fields have multiple possible column representations, e.g. with or without split encoding.
+   /// All column representations supported for writing also need to be supported for reading. In addition,
+   /// fields can support extra column representations for reading only, e.g. a 64bit integer reading from a
+   /// 32bit column.
+   class RColumnRepresentations {
+   public:
+      using TypesList_t = std::vector<std::vector<EColumnType>>;
+      RColumnRepresentations() = default;
+      RColumnRepresentations(const TypesList_t &serializationTypes, const TypesList_t &deserializationExtraTypes)
+         : fSerializationTypes(serializationTypes), fDeserializationExtraTypes(deserializationExtraTypes)
+      {
+      }
+
+      /// The first column list from fSerializationTypes is the default for writing.
+      std::vector<EColumnType> GetSerializationDefault() const;
+      /// Get the union of fSerializationTypes and fDeserializationExtraTypes
+      TypesList_t GetDeserializeTypes() const;
+
+   private:
+      TypesList_t fSerializationTypes;
+      TypesList_t fDeserializationExtraTypes;
+   };
+
 private:
    /// The field name relative to its parent field
    std::string fName;

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -95,6 +95,8 @@ public:
    /// Shorthand for types that are both trivially constructible and destructible
    static constexpr int kTraitTrivialType = kTraitTriviallyConstructible | kTraitTriviallyDestructible;
 
+   using ColumnRepresentation_t = std::vector<EColumnType>;
+
    /// Some fields have multiple possible column representations, e.g. with or without split encoding.
    /// All column representations supported for writing also need to be supported for reading. In addition,
    /// fields can support extra column representations for reading only, e.g. a 64bit integer reading from a
@@ -103,7 +105,7 @@ public:
    /// i.e. for the example above, the unpacking of 32bit ints to 64bit pages must be implemented in RColumnElement.hxx
    class RColumnRepresentations {
    public:
-      using TypesList_t = std::vector<std::vector<EColumnType>>;
+      using TypesList_t = std::vector<ColumnRepresentation_t>;
       RColumnRepresentations() = default;
       RColumnRepresentations(const TypesList_t &serializationTypes, const TypesList_t &deserializationExtraTypes)
          : fSerializationTypes(serializationTypes), fDeserializationExtraTypes(deserializationExtraTypes)
@@ -111,7 +113,7 @@ public:
       }
 
       /// The first column list from fSerializationTypes is the default for writing.
-      std::vector<EColumnType> GetSerializationDefault() const;
+      ColumnRepresentation_t GetSerializationDefault() const;
       TypesList_t GetSerializationTypes() const { return fSerializationTypes; }
       /// Get the union of fSerializationTypes and fDeserializationExtraTypes
       TypesList_t GetDeserializationTypes() const;
@@ -158,7 +160,7 @@ protected:
    std::uint32_t fOnDiskTypeVersion = kInvalidTypeVersion;
    /// If set, the column representation used for serialization; otherwise the default from
    /// GetColumnRepresentations() is used
-   std::unique_ptr<std::vector<EColumnType>> fColumnRepresentative;
+   std::unique_ptr<ColumnRepresentation_t> fColumnRepresentative;
 
    /// Implementations in derived classes should return a static RColumnRepresentations object. The default
    /// implementation does not attach any columns to the field.
@@ -183,7 +185,7 @@ protected:
 
    /// Returns the on-disk column types found in the provided descriptor for fOnDiskId. Throws an exception if the types
    /// don't match any of the deserialization types from GetColumnRepresentations().
-   std::vector<ROOT::Experimental::EColumnType> EnsureCompatibleColumnTypes(const RNTupleDescriptor &desc) const;
+   ColumnRepresentation_t EnsureCompatibleColumnTypes(const RNTupleDescriptor &desc) const;
 
    /// Set a user-defined function to be called after reading a value, giving a chance to inspect and/or modify the
    /// value object.
@@ -340,11 +342,11 @@ public:
    void SetOnDiskId(DescriptorId_t id) { fOnDiskId = id; }
 
    /// Returns the fColumnRepresentative pointee or, if unset, the field's default representative
-   std::vector<EColumnType> GetColumnRepresentative() const;
+   ColumnRepresentation_t GetColumnRepresentative() const;
    /// Fixes a column representative. This can only be done _before_ connecting the field to a page sink.
    /// Otherwise, or if the provided representation is not in the list of GetColumnRepresentations,
    /// an exception is thrown
-   void SetColumnRepresentative(const std::vector<EColumnType> &representative);
+   void SetColumnRepresentative(const ColumnRepresentation_t &representative);
 
    /// Fields and their columns live in the void until connected to a physical page storage.  Only once connected, data
    /// can be read or written.  In order to find the field in the page storage, the field's on-disk ID has to be set.

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -106,21 +106,19 @@ public:
    class RColumnRepresentations {
    public:
       using TypesList_t = std::vector<ColumnRepresentation_t>;
-      RColumnRepresentations() = default;
-      RColumnRepresentations(const TypesList_t &serializationTypes, const TypesList_t &deserializationExtraTypes)
-         : fSerializationTypes(serializationTypes), fDeserializationExtraTypes(deserializationExtraTypes)
-      {
-      }
+      RColumnRepresentations();
+      RColumnRepresentations(const TypesList_t &serializationTypes, const TypesList_t &deserializationExtraTypes);
 
       /// The first column list from fSerializationTypes is the default for writing.
-      ColumnRepresentation_t GetSerializationDefault() const;
-      TypesList_t GetSerializationTypes() const { return fSerializationTypes; }
-      /// Get the union of fSerializationTypes and fDeserializationExtraTypes
-      TypesList_t GetDeserializationTypes() const;
+      const ColumnRepresentation_t &GetSerializationDefault() const { return fSerializationTypes[0]; }
+      const TypesList_t &GetSerializationTypes() const { return fSerializationTypes; }
+      const TypesList_t &GetDeserializationTypes() const { return fDeserializationTypes; }
 
    private:
       TypesList_t fSerializationTypes;
-      TypesList_t fDeserializationExtraTypes;
+      /// The union of the serialization types and the deserialization extra types.  Duplicates the serialization types
+      /// list but the benenfit is that GetDeserializationTypes does not need to compile the list.
+      TypesList_t fDeserializationTypes;
    };
 
 private:

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -415,8 +415,8 @@ public:
    RClassField& operator =(RClassField&& other) = default;
    ~RClassField() override = default;
 
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+   void GenerateColumnsImpl() final {}
+   void GenerateColumnsImpl(const RNTupleDescriptor &) final {}
    using Detail::RFieldBase::GenerateValue;
    Detail::RFieldValue GenerateValue(void* where) override;
    void DestroyValue(const Detail::RFieldValue& value, bool dtorOnly = false) final;
@@ -457,6 +457,7 @@ public:
    RCollectionClassField &operator=(RCollectionClassField &&other) = default;
    ~RCollectionClassField() override = default;
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
    using Detail::RFieldBase::GenerateValue;
@@ -548,6 +549,7 @@ public:
    RVectorField& operator =(RVectorField&& other) = default;
    ~RVectorField() override = default;
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
    using Detail::RFieldBase::GenerateValue;
@@ -591,6 +593,7 @@ public:
    RRVecField &operator=(RRVecField &) = delete;
    ~RRVecField() override = default;
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
    using Detail::RFieldBase::GenerateValue;
@@ -630,8 +633,8 @@ public:
    RArrayField& operator =(RArrayField &&other) = default;
    ~RArrayField() override = default;
 
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+   void GenerateColumnsImpl() final {}
+   void GenerateColumnsImpl(const RNTupleDescriptor &) final {}
    using Detail::RFieldBase::GenerateValue;
    Detail::RFieldValue GenerateValue(void *where) override;
    void DestroyValue(const Detail::RFieldValue &value, bool dtorOnly = false) final;
@@ -669,6 +672,7 @@ public:
    RVariantField& operator =(RVariantField &&other) = default;
    ~RVariantField() override = default;
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
    using Detail::RFieldBase::GenerateValue;
@@ -803,6 +807,7 @@ public:
    RCollectionField& operator =(RCollectionField&& other) = default;
    ~RCollectionField() override = default;
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
@@ -887,6 +892,7 @@ public:
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
@@ -949,6 +955,7 @@ public:
    RField &operator=(RField &&other) = default;
    ~RField() = default;
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
    // Field is only used for reading
    void GenerateColumnsImpl() final { throw RException(R__FAIL("Cardinality fields must only be used for reading")); }
    void GenerateColumnsImpl(const RNTupleDescriptor &) final;
@@ -1005,6 +1012,7 @@ public:
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
@@ -1056,6 +1064,7 @@ public:
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
@@ -1108,6 +1117,7 @@ public:
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
@@ -1159,6 +1169,7 @@ public:
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
@@ -1210,6 +1221,7 @@ public:
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
@@ -1261,6 +1273,7 @@ public:
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
@@ -1312,6 +1325,7 @@ public:
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
@@ -1363,6 +1377,7 @@ public:
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
@@ -1414,6 +1429,7 @@ public:
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
@@ -1465,6 +1481,7 @@ public:
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
@@ -1516,6 +1533,7 @@ public:
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
@@ -1567,6 +1585,7 @@ public:
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
@@ -1624,6 +1643,7 @@ public:
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
 
+   const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
@@ -1766,6 +1786,8 @@ protected:
    }
    std::size_t AppendImpl(const Detail::RFieldValue& value) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue *value) final;
+
+   const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -58,6 +58,9 @@ ROOT::Experimental::Detail::RColumnElementBase::Generate<void>(EColumnType type)
    return nullptr;
 }
 
+template std::unique_ptr<ROOT::Experimental::Detail::RColumnElementBase>
+ROOT::Experimental::Detail::RColumnElementBase::Generate<void>(EColumnType type);
+
 std::size_t ROOT::Experimental::Detail::RColumnElementBase::GetBitsOnStorage(EColumnType type) {
    switch (type) {
    case EColumnType::kReal32:

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -23,8 +23,10 @@
 #include <memory>
 #include <utility>
 
+template <>
 std::unique_ptr<ROOT::Experimental::Detail::RColumnElementBase>
-ROOT::Experimental::Detail::RColumnElementBase::Generate(EColumnType type) {
+ROOT::Experimental::Detail::RColumnElementBase::Generate<void>(EColumnType type)
+{
    switch (type) {
    case EColumnType::kReal32:
       return std::make_unique<RColumnElement<float, EColumnType::kReal32>>(nullptr);

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -152,40 +152,6 @@ void ROOT::Experimental::Detail::RColumnElement<
    }
 }
 
-void ROOT::Experimental::Detail::RColumnElement<double, ROOT::Experimental::EColumnType::kSplitReal64>::Pack(
-   void *dst, void *src, std::size_t count) const
-{
-   char *unsplitArray = reinterpret_cast<char *>(src);
-   char *splitArray = reinterpret_cast<char *>(dst);
-   for (std::size_t i = 0; i < count; ++i) {
-      splitArray[i] = unsplitArray[8 * i];
-      splitArray[count + i] = unsplitArray[8 * i + 1];
-      splitArray[2 * count + i] = unsplitArray[8 * i + 2];
-      splitArray[3 * count + i] = unsplitArray[8 * i + 3];
-      splitArray[4 * count + i] = unsplitArray[8 * i + 4];
-      splitArray[5 * count + i] = unsplitArray[8 * i + 5];
-      splitArray[6 * count + i] = unsplitArray[8 * i + 6];
-      splitArray[7 * count + i] = unsplitArray[8 * i + 7];
-   }
-}
-
-void ROOT::Experimental::Detail::RColumnElement<double, ROOT::Experimental::EColumnType::kSplitReal64>::Unpack(
-   void *dst, void *src, std::size_t count) const
-{
-   char *splitArray = reinterpret_cast<char *>(src);
-   char *unsplitArray = reinterpret_cast<char *>(dst);
-   for (std::size_t i = 0; i < count; ++i) {
-      unsplitArray[8 * i] = splitArray[i];
-      unsplitArray[8 * i + 1] = splitArray[count + i];
-      unsplitArray[8 * i + 2] = splitArray[2 * count + i];
-      unsplitArray[8 * i + 3] = splitArray[3 * count + i];
-      unsplitArray[8 * i + 4] = splitArray[4 * count + i];
-      unsplitArray[8 * i + 5] = splitArray[5 * count + i];
-      unsplitArray[8 * i + 6] = splitArray[6 * count + i];
-      unsplitArray[8 * i + 7] = splitArray[7 * count + i];
-   }
-}
-
 void ROOT::Experimental::Detail::RColumnElement<bool, ROOT::Experimental::EColumnType::kBit>::Pack(
   void *dst, void *src, std::size_t count) const
 {

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -554,6 +554,12 @@ void ROOT::Experimental::RFieldZero::AcceptVisitor(Detail::RFieldVisitor &visito
 
 //------------------------------------------------------------------------------
 
+const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
+ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::GetColumnRepresentations() const
+{
+   static RColumnRepresentations representations({{EColumnType::kIndex}}, {{}});
+   return representations;
+}
 
 void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::GenerateColumnsImpl()
 {
@@ -575,6 +581,13 @@ void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::AcceptVisito
 
 //------------------------------------------------------------------------------
 
+const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
+ROOT::Experimental::RField<ROOT::Experimental::RNTupleCardinality>::GetColumnRepresentations() const
+{
+   static RColumnRepresentations representations({{EColumnType::kIndex}}, {{}});
+   return representations;
+}
+
 void ROOT::Experimental::RField<ROOT::Experimental::RNTupleCardinality>::GenerateColumnsImpl(
    const RNTupleDescriptor &desc)
 {
@@ -592,6 +605,13 @@ void ROOT::Experimental::RField<ROOT::Experimental::RNTupleCardinality>::AcceptV
 }
 
 //------------------------------------------------------------------------------
+
+const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
+ROOT::Experimental::RField<char>::GetColumnRepresentations() const
+{
+   static RColumnRepresentations representations({{EColumnType::kChar}}, {{}});
+   return representations;
+}
 
 void ROOT::Experimental::RField<char>::GenerateColumnsImpl()
 {
@@ -613,6 +633,13 @@ void ROOT::Experimental::RField<char>::AcceptVisitor(Detail::RFieldVisitor &visi
 
 //------------------------------------------------------------------------------
 
+const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
+ROOT::Experimental::RField<std::int8_t>::GetColumnRepresentations() const
+{
+   static RColumnRepresentations representations({{EColumnType::kInt8}}, {{}});
+   return representations;
+}
+
 void ROOT::Experimental::RField<std::int8_t>::GenerateColumnsImpl()
 {
    RColumnModel model(EColumnType::kInt8, false /* isSorted*/);
@@ -632,6 +659,13 @@ void ROOT::Experimental::RField<std::int8_t>::AcceptVisitor(Detail::RFieldVisito
 }
 
 //------------------------------------------------------------------------------
+
+const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
+ROOT::Experimental::RField<std::uint8_t>::GetColumnRepresentations() const
+{
+   static RColumnRepresentations representations({{EColumnType::kInt8}}, {{}});
+   return representations;
+}
 
 void ROOT::Experimental::RField<std::uint8_t>::GenerateColumnsImpl()
 {
@@ -653,6 +687,12 @@ void ROOT::Experimental::RField<std::uint8_t>::AcceptVisitor(Detail::RFieldVisit
 
 //------------------------------------------------------------------------------
 
+const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
+ROOT::Experimental::RField<bool>::GetColumnRepresentations() const
+{
+   static RColumnRepresentations representations({{EColumnType::kBit}}, {{}});
+   return representations;
+}
 
 void ROOT::Experimental::RField<bool>::GenerateColumnsImpl()
 {
@@ -674,6 +714,12 @@ void ROOT::Experimental::RField<bool>::AcceptVisitor(Detail::RFieldVisitor &visi
 
 //------------------------------------------------------------------------------
 
+const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
+ROOT::Experimental::RField<float>::GetColumnRepresentations() const
+{
+   static RColumnRepresentations representations({{EColumnType::kReal32}}, {{}});
+   return representations;
+}
 
 void ROOT::Experimental::RField<float>::GenerateColumnsImpl()
 {
@@ -696,6 +742,13 @@ void ROOT::Experimental::RField<float>::AcceptVisitor(Detail::RFieldVisitor &vis
 
 //------------------------------------------------------------------------------
 
+const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
+ROOT::Experimental::RField<double>::GetColumnRepresentations() const
+{
+   static RColumnRepresentations representations({{EColumnType::kReal64}}, {{}});
+   return representations;
+}
+
 void ROOT::Experimental::RField<double>::GenerateColumnsImpl()
 {
    RColumnModel model(EColumnType::kReal64, false /* isSorted*/);
@@ -715,6 +768,13 @@ void ROOT::Experimental::RField<double>::AcceptVisitor(Detail::RFieldVisitor &vi
 }
 
 //------------------------------------------------------------------------------
+
+const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
+ROOT::Experimental::RField<std::int16_t>::GetColumnRepresentations() const
+{
+   static RColumnRepresentations representations({{EColumnType::kInt16}}, {{}});
+   return representations;
+}
 
 void ROOT::Experimental::RField<std::int16_t>::GenerateColumnsImpl()
 {
@@ -736,6 +796,13 @@ void ROOT::Experimental::RField<std::int16_t>::AcceptVisitor(Detail::RFieldVisit
 
 //------------------------------------------------------------------------------
 
+const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
+ROOT::Experimental::RField<std::uint16_t>::GetColumnRepresentations() const
+{
+   static RColumnRepresentations representations({{EColumnType::kInt16}}, {{}});
+   return representations;
+}
+
 void ROOT::Experimental::RField<std::uint16_t>::GenerateColumnsImpl()
 {
    RColumnModel model(EColumnType::kInt16, false /* isSorted*/);
@@ -755,6 +822,13 @@ void ROOT::Experimental::RField<std::uint16_t>::AcceptVisitor(Detail::RFieldVisi
 }
 
 //------------------------------------------------------------------------------
+
+const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
+ROOT::Experimental::RField<std::int32_t>::GetColumnRepresentations() const
+{
+   static RColumnRepresentations representations({{EColumnType::kInt32}}, {{}});
+   return representations;
+}
 
 void ROOT::Experimental::RField<std::int32_t>::GenerateColumnsImpl()
 {
@@ -776,6 +850,13 @@ void ROOT::Experimental::RField<std::int32_t>::AcceptVisitor(Detail::RFieldVisit
 
 //------------------------------------------------------------------------------
 
+const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
+ROOT::Experimental::RField<std::uint32_t>::GetColumnRepresentations() const
+{
+   static RColumnRepresentations representations({{EColumnType::kInt32}}, {{}});
+   return representations;
+}
+
 void ROOT::Experimental::RField<std::uint32_t>::GenerateColumnsImpl()
 {
    RColumnModel model(EColumnType::kInt32, false /* isSorted*/);
@@ -796,6 +877,13 @@ void ROOT::Experimental::RField<std::uint32_t>::AcceptVisitor(Detail::RFieldVisi
 
 //------------------------------------------------------------------------------
 
+const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
+ROOT::Experimental::RField<std::uint64_t>::GetColumnRepresentations() const
+{
+   static RColumnRepresentations representations({{EColumnType::kInt64}}, {{}});
+   return representations;
+}
+
 void ROOT::Experimental::RField<std::uint64_t>::GenerateColumnsImpl()
 {
    RColumnModel model(EColumnType::kInt64, false /* isSorted*/);
@@ -815,6 +903,13 @@ void ROOT::Experimental::RField<std::uint64_t>::AcceptVisitor(Detail::RFieldVisi
 }
 
 //------------------------------------------------------------------------------
+
+const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
+ROOT::Experimental::RField<std::int64_t>::GetColumnRepresentations() const
+{
+   static RColumnRepresentations representations({{EColumnType::kInt64}}, {{EColumnType::kInt32}});
+   return representations;
+}
 
 void ROOT::Experimental::RField<std::int64_t>::GenerateColumnsImpl()
 {
@@ -852,6 +947,13 @@ void ROOT::Experimental::RField<std::string>::GenerateColumnsImpl()
    RColumnModel modelChars(EColumnType::kChar, false /* isSorted*/);
    fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
       Detail::RColumn::Create<char, EColumnType::kChar>(modelChars, 1)));
+}
+
+const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
+ROOT::Experimental::RField<std::string>::GetColumnRepresentations() const
+{
+   static RColumnRepresentations representations({{EColumnType::kIndex, EColumnType::kChar}}, {{}});
+   return representations;
 }
 
 void ROOT::Experimental::RField<std::string>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -1045,14 +1147,6 @@ void ROOT::Experimental::RClassField::OnConnectPageSource()
    AddReadCallbacksFromIORules(rules, fClass);
 }
 
-void ROOT::Experimental::RClassField::GenerateColumnsImpl()
-{
-}
-
-void ROOT::Experimental::RClassField::GenerateColumnsImpl(const RNTupleDescriptor &)
-{
-}
-
 ROOT::Experimental::Detail::RFieldValue ROOT::Experimental::RClassField::GenerateValue(void* where)
 {
    return Detail::RFieldValue(true /* captureFlag */, this, fClass->New(where));
@@ -1205,6 +1299,13 @@ void ROOT::Experimental::RCollectionClassField::ReadGlobalImpl(NTupleSize_t glob
       collectionStart = collectionStart + count;
       nItemsLeft -= count;
    }
+}
+
+const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
+ROOT::Experimental::RCollectionClassField::GetColumnRepresentations() const
+{
+   static RColumnRepresentations representations({{EColumnType::kIndex}}, {{}});
+   return representations;
 }
 
 void ROOT::Experimental::RCollectionClassField::GenerateColumnsImpl()
@@ -1463,6 +1564,13 @@ void ROOT::Experimental::RVectorField::ReadGlobalImpl(NTupleSize_t globalIndex, 
    }
 }
 
+const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
+ROOT::Experimental::RVectorField::GetColumnRepresentations() const
+{
+   static RColumnRepresentations representations({{EColumnType::kIndex}}, {{}});
+   return representations;
+}
+
 void ROOT::Experimental::RVectorField::GenerateColumnsImpl()
 {
    RColumnModel modelIndex(EColumnType::kIndex, true /* isSorted*/);
@@ -1627,6 +1735,13 @@ void ROOT::Experimental::RRVecField::ReadGlobalImpl(NTupleSize_t globalIndex, De
       auto itemValue = fSubFields[0]->CaptureValue(begin + (i * fItemSize));
       fSubFields[0]->Read(collectionStart + i, &itemValue);
    }
+}
+
+const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
+ROOT::Experimental::RRVecField::GetColumnRepresentations() const
+{
+   static RColumnRepresentations representations({{EColumnType::kIndex}}, {{}});
+   return representations;
 }
 
 void ROOT::Experimental::RRVecField::GenerateColumnsImpl()
@@ -1811,6 +1926,13 @@ void ROOT::Experimental::RField<std::vector<bool>>::ReadGlobalImpl(NTupleSize_t 
    }
 }
 
+const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
+ROOT::Experimental::RField<std::vector<bool>>::GetColumnRepresentations() const
+{
+   static RColumnRepresentations representations({{EColumnType::kIndex}}, {{}});
+   return representations;
+}
+
 void ROOT::Experimental::RField<std::vector<bool>>::GenerateColumnsImpl()
 {
    RColumnModel modelIndex(EColumnType::kIndex, true /* isSorted*/);
@@ -1905,14 +2027,6 @@ void ROOT::Experimental::RArrayField::ReadInClusterImpl(const RClusterIndex &clu
       fSubFields[0]->Read(RClusterIndex(clusterIndex.GetClusterId(), clusterIndex.GetIndex() * fArrayLength + i),
                           &itemValue);
    }
-}
-
-void ROOT::Experimental::RArrayField::GenerateColumnsImpl()
-{
-}
-
-void ROOT::Experimental::RArrayField::GenerateColumnsImpl(const RNTupleDescriptor &)
-{
 }
 
 ROOT::Experimental::Detail::RFieldValue ROOT::Experimental::RArrayField::GenerateValue(void *where)
@@ -2045,6 +2159,13 @@ void ROOT::Experimental::RVariantField::ReadGlobalImpl(NTupleSize_t globalIndex,
    auto itemValue = fSubFields[tag - 1]->GenerateValue(value->GetRawPtr());
    fSubFields[tag - 1]->Read(variantIndex, &itemValue);
    SetTag(value->GetRawPtr(), tag);
+}
+
+const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
+ROOT::Experimental::RVariantField::GetColumnRepresentations() const
+{
+   static RColumnRepresentations representations({{EColumnType::kSwitch}}, {{}});
+   return representations;
 }
 
 void ROOT::Experimental::RVariantField::GenerateColumnsImpl()
@@ -2235,6 +2356,12 @@ ROOT::Experimental::RCollectionField::RCollectionField(
    SetDescription(collectionModel->GetDescription());
 }
 
+const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
+ROOT::Experimental::RCollectionField::GetColumnRepresentations() const
+{
+   static RColumnRepresentations representations({{EColumnType::kIndex}}, {{}});
+   return representations;
+}
 
 void ROOT::Experimental::RCollectionField::GenerateColumnsImpl()
 {

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -340,6 +340,13 @@ ROOT::Experimental::Detail::RFieldBase::EnsureValidFieldName(std::string_view fi
    return RResult<void>::Success();
 }
 
+const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
+ROOT::Experimental::Detail::RFieldBase::GetColumnRepresentations() const
+{
+   static RColumnRepresentations representations;
+   return representations;
+}
+
 std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>
 ROOT::Experimental::Detail::RFieldBase::Clone(std::string_view newName) const
 {

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -182,11 +182,11 @@ std::tuple<void **, std::int32_t *, std::int32_t *> GetRVecDataMembers(void *rve
 
 //------------------------------------------------------------------------------
 
-std::vector<ROOT::Experimental::EColumnType>
+ROOT::Experimental::Detail::RFieldBase::ColumnRepresentation_t
 ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations::GetSerializationDefault() const
 {
    if (fSerializationTypes.empty())
-      return std::vector<EColumnType>();
+      return ColumnRepresentation_t();
    return fSerializationTypes[0];
 }
 
@@ -354,7 +354,7 @@ ROOT::Experimental::Detail::RFieldBase::Clone(std::string_view newName) const
    clone->fOnDiskId = fOnDiskId;
    clone->fDescription = fDescription;
    clone->fColumnRepresentative =
-      fColumnRepresentative ? std::make_unique<std::vector<EColumnType>>(*fColumnRepresentative) : nullptr;
+      fColumnRepresentative ? std::make_unique<ColumnRepresentation_t>(*fColumnRepresentative) : nullptr;
    return clone;
 }
 
@@ -415,30 +415,31 @@ void ROOT::Experimental::Detail::RFieldBase::Flush() const
    }
 }
 
-std::vector<ROOT::Experimental::EColumnType> ROOT::Experimental::Detail::RFieldBase::GetColumnRepresentative() const
+ROOT::Experimental::Detail::RFieldBase::ColumnRepresentation_t
+ROOT::Experimental::Detail::RFieldBase::GetColumnRepresentative() const
 {
    if (fColumnRepresentative)
       return *fColumnRepresentative;
    return GetColumnRepresentations().GetSerializationDefault();
 }
 
-void ROOT::Experimental::Detail::RFieldBase::SetColumnRepresentative(const std::vector<EColumnType> &representative)
+void ROOT::Experimental::Detail::RFieldBase::SetColumnRepresentative(const ColumnRepresentation_t &representative)
 {
    if (!fColumns.empty())
       throw RException(R__FAIL("cannot set column representative once field is connected"));
    auto validTypes = GetColumnRepresentations().GetSerializationTypes();
    if (std::find(validTypes.begin(), validTypes.end(), representative) == std::end(validTypes))
       throw RException(R__FAIL("invalid column representative"));
-   fColumnRepresentative = std::make_unique<std::vector<EColumnType>>(representative);
+   fColumnRepresentative = std::make_unique<ColumnRepresentation_t>(representative);
 }
 
-std::vector<ROOT::Experimental::EColumnType>
+ROOT::Experimental::Detail::RFieldBase::ColumnRepresentation_t
 ROOT::Experimental::Detail::RFieldBase::EnsureCompatibleColumnTypes(const RNTupleDescriptor &desc) const
 {
    if (fOnDiskId == kInvalidDescriptorId)
       throw RException(R__FAIL("No on-disk column information for for field `" + GetQualifiedFieldName() + "`"));
 
-   std::vector<ROOT::Experimental::EColumnType> onDiskTypes;
+   ColumnRepresentation_t onDiskTypes;
    for (const auto &c : desc.GetColumnIterable(fOnDiskId)) {
       onDiskTypes.emplace_back(c.GetModel().GetType());
    }

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -191,7 +191,7 @@ ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations::GetSerialization
 }
 
 ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations::TypesList_t
-ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations::GetDeserializeTypes() const
+ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations::GetDeserializationTypes() const
 {
    TypesList_t result(fSerializationTypes);
    result.insert(result.end(), fDeserializationExtraTypes.begin(), fDeserializationExtraTypes.end());
@@ -413,21 +413,21 @@ void ROOT::Experimental::Detail::RFieldBase::Flush() const
    }
 }
 
-std::vector<ROOT::Experimental::EColumnType> ROOT::Experimental::Detail::RFieldBase::GetSerializationColumnTypes() const
+std::vector<ROOT::Experimental::EColumnType> ROOT::Experimental::Detail::RFieldBase::GetColumnRepresentative() const
 {
-   if (fSerializationTypes)
-      return *fSerializationTypes;
+   if (fColumnRepresentative)
+      return *fColumnRepresentative;
    return GetColumnRepresentations().GetSerializationDefault();
 }
 
-void ROOT::Experimental::Detail::RFieldBase::SetSerializationTypes(const std::vector<EColumnType> &representation)
+void ROOT::Experimental::Detail::RFieldBase::SetColumnRepresentative(const std::vector<EColumnType> &representative)
 {
    if (!fColumns.empty())
-      throw RException(R__FAIL("cannot set column representation once field is connected"));
-   auto validTypes = GetColumnRepresentations().GetSerializeTypes();
-   if (std::find(validTypes.begin(), validTypes.end(), representation) == std::end(validTypes))
-      throw RException(R__FAIL("invalid column representation"));
-   fSerializationTypes = std::make_unique<std::vector<EColumnType>>(representation);
+      throw RException(R__FAIL("cannot set column representative once field is connected"));
+   auto validTypes = GetColumnRepresentations().GetSerializationTypes();
+   if (std::find(validTypes.begin(), validTypes.end(), representative) == std::end(validTypes))
+      throw RException(R__FAIL("invalid column representative"));
+   fColumnRepresentative = std::make_unique<std::vector<EColumnType>>(representative);
 }
 
 std::vector<ROOT::Experimental::EColumnType>
@@ -440,7 +440,7 @@ ROOT::Experimental::Detail::RFieldBase::EnsureCompatibleColumnTypes(const RNTupl
    for (const auto &c : desc.GetColumnIterable(fOnDiskId)) {
       onDiskTypes.emplace_back(c.GetModel().GetType());
    }
-   for (const auto &t : GetColumnRepresentations().GetDeserializeTypes()) {
+   for (const auto &t : GetColumnRepresentations().GetDeserializationTypes()) {
       if (t == onDiskTypes)
          return onDiskTypes;
    }
@@ -482,6 +482,9 @@ void ROOT::Experimental::Detail::RFieldBase::ConnectPageSink(RPageSink &pageSink
 void ROOT::Experimental::Detail::RFieldBase::ConnectPageSource(RPageSource &pageSource)
 {
    R__ASSERT(fColumns.empty());
+   if (fColumnRepresentative)
+      throw RException(R__FAIL("fixed column representative only valid when connecting to a page sink"));
+
    {
       const auto descriptorGuard = pageSource.GetSharedDescriptorGuard();
       const RNTupleDescriptor &desc = descriptorGuard.GetRef();
@@ -572,7 +575,7 @@ ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::GetColumnRepresen
 
 void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::GenerateColumnsImpl()
 {
-   fColumns.emplace_back(Detail::RColumn::Create<ClusterSize_t>(RColumnModel(GetSerializationColumnTypes()[0]), 0));
+   fColumns.emplace_back(Detail::RColumn::Create<ClusterSize_t>(RColumnModel(GetColumnRepresentative()[0]), 0));
 }
 
 void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -619,7 +622,7 @@ ROOT::Experimental::RField<char>::GetColumnRepresentations() const
 
 void ROOT::Experimental::RField<char>::GenerateColumnsImpl()
 {
-   fColumns.emplace_back(Detail::RColumn::Create<char>(RColumnModel(GetSerializationColumnTypes()[0]), 0));
+   fColumns.emplace_back(Detail::RColumn::Create<char>(RColumnModel(GetColumnRepresentative()[0]), 0));
 }
 
 void ROOT::Experimental::RField<char>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -644,7 +647,7 @@ ROOT::Experimental::RField<std::int8_t>::GetColumnRepresentations() const
 
 void ROOT::Experimental::RField<std::int8_t>::GenerateColumnsImpl()
 {
-   fColumns.emplace_back(Detail::RColumn::Create<std::int8_t>(RColumnModel(GetSerializationColumnTypes()[0]), 0));
+   fColumns.emplace_back(Detail::RColumn::Create<std::int8_t>(RColumnModel(GetColumnRepresentative()[0]), 0));
 }
 
 void ROOT::Experimental::RField<std::int8_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -669,7 +672,7 @@ ROOT::Experimental::RField<std::uint8_t>::GetColumnRepresentations() const
 
 void ROOT::Experimental::RField<std::uint8_t>::GenerateColumnsImpl()
 {
-   fColumns.emplace_back(Detail::RColumn::Create<std::uint8_t>(RColumnModel(GetSerializationColumnTypes()[0]), 0));
+   fColumns.emplace_back(Detail::RColumn::Create<std::uint8_t>(RColumnModel(GetColumnRepresentative()[0]), 0));
 }
 
 void ROOT::Experimental::RField<std::uint8_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -694,7 +697,7 @@ ROOT::Experimental::RField<bool>::GetColumnRepresentations() const
 
 void ROOT::Experimental::RField<bool>::GenerateColumnsImpl()
 {
-   fColumns.emplace_back(Detail::RColumn::Create<bool>(RColumnModel(GetSerializationColumnTypes()[0]), 0));
+   fColumns.emplace_back(Detail::RColumn::Create<bool>(RColumnModel(GetColumnRepresentative()[0]), 0));
 }
 
 void ROOT::Experimental::RField<bool>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -719,7 +722,7 @@ ROOT::Experimental::RField<float>::GetColumnRepresentations() const
 
 void ROOT::Experimental::RField<float>::GenerateColumnsImpl()
 {
-   fColumns.emplace_back(Detail::RColumn::Create<float>(RColumnModel(GetSerializationColumnTypes()[0]), 0));
+   fColumns.emplace_back(Detail::RColumn::Create<float>(RColumnModel(GetColumnRepresentative()[0]), 0));
 }
 
 void ROOT::Experimental::RField<float>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -745,7 +748,7 @@ ROOT::Experimental::RField<double>::GetColumnRepresentations() const
 
 void ROOT::Experimental::RField<double>::GenerateColumnsImpl()
 {
-   fColumns.emplace_back(Detail::RColumn::Create<double>(RColumnModel(GetSerializationColumnTypes()[0]), 0));
+   fColumns.emplace_back(Detail::RColumn::Create<double>(RColumnModel(GetColumnRepresentative()[0]), 0));
 }
 
 void ROOT::Experimental::RField<double>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -770,7 +773,7 @@ ROOT::Experimental::RField<std::int16_t>::GetColumnRepresentations() const
 
 void ROOT::Experimental::RField<std::int16_t>::GenerateColumnsImpl()
 {
-   fColumns.emplace_back(Detail::RColumn::Create<std::int16_t>(RColumnModel(GetSerializationColumnTypes()[0]), 0));
+   fColumns.emplace_back(Detail::RColumn::Create<std::int16_t>(RColumnModel(GetColumnRepresentative()[0]), 0));
 }
 
 void ROOT::Experimental::RField<std::int16_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -795,7 +798,7 @@ ROOT::Experimental::RField<std::uint16_t>::GetColumnRepresentations() const
 
 void ROOT::Experimental::RField<std::uint16_t>::GenerateColumnsImpl()
 {
-   fColumns.emplace_back(Detail::RColumn::Create<std::uint16_t>(RColumnModel(GetSerializationColumnTypes()[0]), 0));
+   fColumns.emplace_back(Detail::RColumn::Create<std::uint16_t>(RColumnModel(GetColumnRepresentative()[0]), 0));
 }
 
 void ROOT::Experimental::RField<std::uint16_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -820,7 +823,7 @@ ROOT::Experimental::RField<std::int32_t>::GetColumnRepresentations() const
 
 void ROOT::Experimental::RField<std::int32_t>::GenerateColumnsImpl()
 {
-   fColumns.emplace_back(Detail::RColumn::Create<std::int32_t>(RColumnModel(GetSerializationColumnTypes()[0]), 0));
+   fColumns.emplace_back(Detail::RColumn::Create<std::int32_t>(RColumnModel(GetColumnRepresentative()[0]), 0));
 }
 
 void ROOT::Experimental::RField<std::int32_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -845,7 +848,7 @@ ROOT::Experimental::RField<std::uint32_t>::GetColumnRepresentations() const
 
 void ROOT::Experimental::RField<std::uint32_t>::GenerateColumnsImpl()
 {
-   fColumns.emplace_back(Detail::RColumn::Create<std::uint32_t>(RColumnModel(GetSerializationColumnTypes()[0]), 0));
+   fColumns.emplace_back(Detail::RColumn::Create<std::uint32_t>(RColumnModel(GetColumnRepresentative()[0]), 0));
 }
 
 void ROOT::Experimental::RField<std::uint32_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -870,7 +873,7 @@ ROOT::Experimental::RField<std::uint64_t>::GetColumnRepresentations() const
 
 void ROOT::Experimental::RField<std::uint64_t>::GenerateColumnsImpl()
 {
-   fColumns.emplace_back(Detail::RColumn::Create<std::uint64_t>(RColumnModel(GetSerializationColumnTypes()[0]), 0));
+   fColumns.emplace_back(Detail::RColumn::Create<std::uint64_t>(RColumnModel(GetColumnRepresentative()[0]), 0));
 }
 
 void ROOT::Experimental::RField<std::uint64_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -895,7 +898,7 @@ ROOT::Experimental::RField<std::int64_t>::GetColumnRepresentations() const
 
 void ROOT::Experimental::RField<std::int64_t>::GenerateColumnsImpl()
 {
-   fColumns.emplace_back(Detail::RColumn::Create<std::int64_t>(RColumnModel(GetSerializationColumnTypes()[0]), 0));
+   fColumns.emplace_back(Detail::RColumn::Create<std::int64_t>(RColumnModel(GetColumnRepresentative()[0]), 0));
 }
 
 void ROOT::Experimental::RField<std::int64_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -920,8 +923,8 @@ ROOT::Experimental::RField<std::string>::GetColumnRepresentations() const
 
 void ROOT::Experimental::RField<std::string>::GenerateColumnsImpl()
 {
-   fColumns.emplace_back(Detail::RColumn::Create<ClusterSize_t>(RColumnModel(GetSerializationColumnTypes()[0]), 0));
-   fColumns.emplace_back(Detail::RColumn::Create<char>(RColumnModel(GetSerializationColumnTypes()[1]), 1));
+   fColumns.emplace_back(Detail::RColumn::Create<ClusterSize_t>(RColumnModel(GetColumnRepresentative()[0]), 0));
+   fColumns.emplace_back(Detail::RColumn::Create<char>(RColumnModel(GetColumnRepresentative()[1]), 1));
 }
 
 void ROOT::Experimental::RField<std::string>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -1278,7 +1281,7 @@ ROOT::Experimental::RCollectionClassField::GetColumnRepresentations() const
 
 void ROOT::Experimental::RCollectionClassField::GenerateColumnsImpl()
 {
-   fColumns.emplace_back(Detail::RColumn::Create<ClusterSize_t>(RColumnModel(GetSerializationColumnTypes()[0]), 0));
+   fColumns.emplace_back(Detail::RColumn::Create<ClusterSize_t>(RColumnModel(GetColumnRepresentative()[0]), 0));
 }
 
 void ROOT::Experimental::RCollectionClassField::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -1539,7 +1542,7 @@ ROOT::Experimental::RVectorField::GetColumnRepresentations() const
 
 void ROOT::Experimental::RVectorField::GenerateColumnsImpl()
 {
-   fColumns.emplace_back(Detail::RColumn::Create<ClusterSize_t>(RColumnModel(GetSerializationColumnTypes()[0]), 0));
+   fColumns.emplace_back(Detail::RColumn::Create<ClusterSize_t>(RColumnModel(GetColumnRepresentative()[0]), 0));
 }
 
 void ROOT::Experimental::RVectorField::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -1710,7 +1713,7 @@ ROOT::Experimental::RRVecField::GetColumnRepresentations() const
 
 void ROOT::Experimental::RRVecField::GenerateColumnsImpl()
 {
-   fColumns.emplace_back(Detail::RColumn::Create<ClusterSize_t>(RColumnModel(GetSerializationColumnTypes()[0]), 0));
+   fColumns.emplace_back(Detail::RColumn::Create<ClusterSize_t>(RColumnModel(GetColumnRepresentative()[0]), 0));
 }
 
 void ROOT::Experimental::RRVecField::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -1897,7 +1900,7 @@ ROOT::Experimental::RField<std::vector<bool>>::GetColumnRepresentations() const
 
 void ROOT::Experimental::RField<std::vector<bool>>::GenerateColumnsImpl()
 {
-   fColumns.emplace_back(Detail::RColumn::Create<ClusterSize_t>(RColumnModel(GetSerializationColumnTypes()[0]), 0));
+   fColumns.emplace_back(Detail::RColumn::Create<ClusterSize_t>(RColumnModel(GetColumnRepresentative()[0]), 0));
 }
 
 void ROOT::Experimental::RField<std::vector<bool>>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -2130,7 +2133,7 @@ ROOT::Experimental::RVariantField::GetColumnRepresentations() const
 
 void ROOT::Experimental::RVariantField::GenerateColumnsImpl()
 {
-   fColumns.emplace_back(Detail::RColumn::Create<RColumnSwitch>(RColumnModel(GetSerializationColumnTypes()[0]), 0));
+   fColumns.emplace_back(Detail::RColumn::Create<RColumnSwitch>(RColumnModel(GetColumnRepresentative()[0]), 0));
 }
 
 void ROOT::Experimental::RVariantField::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -2323,7 +2326,7 @@ ROOT::Experimental::RCollectionField::GetColumnRepresentations() const
 
 void ROOT::Experimental::RCollectionField::GenerateColumnsImpl()
 {
-   fColumns.emplace_back(Detail::RColumn::Create<ClusterSize_t>(RColumnModel(GetSerializationColumnTypes()[0]), 0));
+   fColumns.emplace_back(Detail::RColumn::Create<ClusterSize_t>(RColumnModel(GetColumnRepresentative()[0]), 0));
 }
 
 void ROOT::Experimental::RCollectionField::GenerateColumnsImpl(const RNTupleDescriptor &desc)

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -415,9 +415,19 @@ void ROOT::Experimental::Detail::RFieldBase::Flush() const
 
 std::vector<ROOT::Experimental::EColumnType> ROOT::Experimental::Detail::RFieldBase::GetSerializationColumnTypes() const
 {
-   if (fSerializationColumnTypes)
-      return *fSerializationColumnTypes;
+   if (fSerializationTypes)
+      return *fSerializationTypes;
    return GetColumnRepresentations().GetSerializationDefault();
+}
+
+void ROOT::Experimental::Detail::RFieldBase::SetSerializationTypes(const std::vector<EColumnType> &representation)
+{
+   if (!fColumns.empty())
+      throw RException(R__FAIL("cannot set column representation once field is connected"));
+   auto validTypes = GetColumnRepresentations().GetSerializeTypes();
+   if (std::find(validTypes.begin(), validTypes.end(), representation) == std::end(validTypes))
+      throw RException(R__FAIL("invalid column representation"));
+   fSerializationTypes = std::make_unique<std::vector<EColumnType>>(representation);
 }
 
 std::vector<ROOT::Experimental::EColumnType>

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -564,8 +564,7 @@ ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::GetColumnRepresen
 void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::GenerateColumnsImpl()
 {
    RColumnModel model(EColumnType::kIndex, true /* isSorted*/);
-   fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
-      Detail::RColumn::Create<ClusterSize_t, EColumnType::kIndex>(model, 0)));
+   fColumns.emplace_back(Detail::RColumn::Create<ClusterSize_t>(model, 0));
 }
 
 void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -593,8 +592,7 @@ void ROOT::Experimental::RField<ROOT::Experimental::RNTupleCardinality>::Generat
 {
    EnsureColumnType({EColumnType::kIndex}, 0, desc);
    RColumnModel model(EColumnType::kIndex, true /* isSorted*/);
-   fColumns.emplace_back(std::unique_ptr<ROOT::Experimental::Detail::RColumn>(
-      ROOT::Experimental::Detail::RColumn::Create<ClusterSize_t, EColumnType::kIndex>(model, 0)));
+   fColumns.emplace_back(Detail::RColumn::Create<ClusterSize_t>(model, 0));
    fPrincipalColumn = fColumns[0].get();
 }
 
@@ -616,8 +614,7 @@ ROOT::Experimental::RField<char>::GetColumnRepresentations() const
 void ROOT::Experimental::RField<char>::GenerateColumnsImpl()
 {
    RColumnModel model(EColumnType::kChar, false /* isSorted*/);
-   fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(Detail::RColumn::Create<
-      char, EColumnType::kChar>(model, 0)));
+   fColumns.emplace_back(Detail::RColumn::Create<char>(model, 0));
 }
 
 void ROOT::Experimental::RField<char>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -643,8 +640,7 @@ ROOT::Experimental::RField<std::int8_t>::GetColumnRepresentations() const
 void ROOT::Experimental::RField<std::int8_t>::GenerateColumnsImpl()
 {
    RColumnModel model(EColumnType::kInt8, false /* isSorted*/);
-   fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(Detail::RColumn::Create<
-      std::int8_t, EColumnType::kInt8>(model, 0)));
+   fColumns.emplace_back(Detail::RColumn::Create<std::int8_t>(model, 0));
 }
 
 void ROOT::Experimental::RField<std::int8_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -670,8 +666,7 @@ ROOT::Experimental::RField<std::uint8_t>::GetColumnRepresentations() const
 void ROOT::Experimental::RField<std::uint8_t>::GenerateColumnsImpl()
 {
    RColumnModel model(EColumnType::kInt8, false /* isSorted*/);
-   fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(Detail::RColumn::Create<
-      std::uint8_t, EColumnType::kInt8>(model, 0)));
+   fColumns.emplace_back(Detail::RColumn::Create<std::uint8_t>(model, 0));
 }
 
 void ROOT::Experimental::RField<std::uint8_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -697,8 +692,7 @@ ROOT::Experimental::RField<bool>::GetColumnRepresentations() const
 void ROOT::Experimental::RField<bool>::GenerateColumnsImpl()
 {
    RColumnModel model(EColumnType::kBit, false /* isSorted*/);
-   fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
-      Detail::RColumn::Create<bool, EColumnType::kBit>(model, 0)));
+   fColumns.emplace_back(Detail::RColumn::Create<bool>(model, 0));
 }
 
 void ROOT::Experimental::RField<bool>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -724,8 +718,7 @@ ROOT::Experimental::RField<float>::GetColumnRepresentations() const
 void ROOT::Experimental::RField<float>::GenerateColumnsImpl()
 {
    RColumnModel model(EColumnType::kReal32, false /* isSorted*/);
-   fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
-      Detail::RColumn::Create<float, EColumnType::kReal32>(model, 0)));
+   fColumns.emplace_back(Detail::RColumn::Create<float>(model, 0));
 }
 
 void ROOT::Experimental::RField<float>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -752,8 +745,7 @@ ROOT::Experimental::RField<double>::GetColumnRepresentations() const
 void ROOT::Experimental::RField<double>::GenerateColumnsImpl()
 {
    RColumnModel model(EColumnType::kReal64, false /* isSorted*/);
-   fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
-      Detail::RColumn::Create<double, EColumnType::kReal64>(model, 0)));
+   fColumns.emplace_back(Detail::RColumn::Create<double>(model, 0));
 }
 
 void ROOT::Experimental::RField<double>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -779,8 +771,7 @@ ROOT::Experimental::RField<std::int16_t>::GetColumnRepresentations() const
 void ROOT::Experimental::RField<std::int16_t>::GenerateColumnsImpl()
 {
    RColumnModel model(EColumnType::kInt16, false /* isSorted*/);
-   fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(Detail::RColumn::Create<
-      std::int16_t, EColumnType::kInt16>(model, 0)));
+   fColumns.emplace_back(Detail::RColumn::Create<std::int16_t>(model, 0));
 }
 
 void ROOT::Experimental::RField<std::int16_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -806,8 +797,7 @@ ROOT::Experimental::RField<std::uint16_t>::GetColumnRepresentations() const
 void ROOT::Experimental::RField<std::uint16_t>::GenerateColumnsImpl()
 {
    RColumnModel model(EColumnType::kInt16, false /* isSorted*/);
-   fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(Detail::RColumn::Create<
-      std::uint16_t, EColumnType::kInt16>(model, 0)));
+   fColumns.emplace_back(Detail::RColumn::Create<std::uint16_t>(model, 0));
 }
 
 void ROOT::Experimental::RField<std::uint16_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -833,8 +823,7 @@ ROOT::Experimental::RField<std::int32_t>::GetColumnRepresentations() const
 void ROOT::Experimental::RField<std::int32_t>::GenerateColumnsImpl()
 {
    RColumnModel model(EColumnType::kInt32, false /* isSorted*/);
-   fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(Detail::RColumn::Create<
-      std::int32_t, EColumnType::kInt32>(model, 0)));
+   fColumns.emplace_back(Detail::RColumn::Create<std::int32_t>(model, 0));
 }
 
 void ROOT::Experimental::RField<std::int32_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -860,8 +849,7 @@ ROOT::Experimental::RField<std::uint32_t>::GetColumnRepresentations() const
 void ROOT::Experimental::RField<std::uint32_t>::GenerateColumnsImpl()
 {
    RColumnModel model(EColumnType::kInt32, false /* isSorted*/);
-   fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
-      Detail::RColumn::Create<std::uint32_t, EColumnType::kInt32>(model, 0)));
+   fColumns.emplace_back(Detail::RColumn::Create<std::uint32_t>(model, 0));
 }
 
 void ROOT::Experimental::RField<std::uint32_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -887,8 +875,7 @@ ROOT::Experimental::RField<std::uint64_t>::GetColumnRepresentations() const
 void ROOT::Experimental::RField<std::uint64_t>::GenerateColumnsImpl()
 {
    RColumnModel model(EColumnType::kInt64, false /* isSorted*/);
-   fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
-      Detail::RColumn::Create<std::uint64_t, EColumnType::kInt64>(model, 0)));
+   fColumns.emplace_back(Detail::RColumn::Create<std::uint64_t>(model, 0));
 }
 
 void ROOT::Experimental::RField<std::uint64_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -914,21 +901,14 @@ ROOT::Experimental::RField<std::int64_t>::GetColumnRepresentations() const
 void ROOT::Experimental::RField<std::int64_t>::GenerateColumnsImpl()
 {
    RColumnModel model(EColumnType::kInt64, false /* isSorted*/);
-   fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
-      Detail::RColumn::Create<std::int64_t, EColumnType::kInt64>(model, 0)));
+   fColumns.emplace_back(Detail::RColumn::Create<std::int64_t>(model, 0));
 }
 
 void ROOT::Experimental::RField<std::int64_t>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
 {
    auto type = EnsureColumnType({EColumnType::kInt64, EColumnType::kInt32}, 0, desc);
    RColumnModel model(type, false /* isSorted*/);
-   if (type == EColumnType::kInt64) {
-      fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
-         Detail::RColumn::Create<std::int64_t, EColumnType::kInt64>(model, 0)));
-   } else {
-      fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
-         Detail::RColumn::Create<std::int64_t, EColumnType::kInt32>(model, 0)));
-   }
+   fColumns.emplace_back(Detail::RColumn::Create<std::int64_t>(model, 0));
 }
 
 void ROOT::Experimental::RField<std::int64_t>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
@@ -941,12 +921,10 @@ void ROOT::Experimental::RField<std::int64_t>::AcceptVisitor(Detail::RFieldVisit
 void ROOT::Experimental::RField<std::string>::GenerateColumnsImpl()
 {
    RColumnModel modelIndex(EColumnType::kIndex, true /* isSorted*/);
-   fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
-      Detail::RColumn::Create<ClusterSize_t, EColumnType::kIndex>(modelIndex, 0)));
+   fColumns.emplace_back(Detail::RColumn::Create<ClusterSize_t>(modelIndex, 0));
 
    RColumnModel modelChars(EColumnType::kChar, false /* isSorted*/);
-   fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
-      Detail::RColumn::Create<char, EColumnType::kChar>(modelChars, 1)));
+   fColumns.emplace_back(Detail::RColumn::Create<char>(modelChars, 1));
 }
 
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
@@ -1311,8 +1289,7 @@ ROOT::Experimental::RCollectionClassField::GetColumnRepresentations() const
 void ROOT::Experimental::RCollectionClassField::GenerateColumnsImpl()
 {
    RColumnModel modelIndex(EColumnType::kIndex, true /* isSorted*/);
-   fColumns.emplace_back(
-      std::unique_ptr<Detail::RColumn>(Detail::RColumn::Create<ClusterSize_t, EColumnType::kIndex>(modelIndex, 0)));
+   fColumns.emplace_back(Detail::RColumn::Create<ClusterSize_t>(modelIndex, 0));
 }
 
 void ROOT::Experimental::RCollectionClassField::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -1574,8 +1551,7 @@ ROOT::Experimental::RVectorField::GetColumnRepresentations() const
 void ROOT::Experimental::RVectorField::GenerateColumnsImpl()
 {
    RColumnModel modelIndex(EColumnType::kIndex, true /* isSorted*/);
-   fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
-      Detail::RColumn::Create<ClusterSize_t, EColumnType::kIndex>(modelIndex, 0)));
+   fColumns.emplace_back(Detail::RColumn::Create<ClusterSize_t>(modelIndex, 0));
 }
 
 void ROOT::Experimental::RVectorField::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -1747,8 +1723,7 @@ ROOT::Experimental::RRVecField::GetColumnRepresentations() const
 void ROOT::Experimental::RRVecField::GenerateColumnsImpl()
 {
    RColumnModel modelIndex(EColumnType::kIndex, true /* isSorted*/);
-   fColumns.emplace_back(
-      std::unique_ptr<Detail::RColumn>(Detail::RColumn::Create<ClusterSize_t, EColumnType::kIndex>(modelIndex, 0)));
+   fColumns.emplace_back(Detail::RColumn::Create<ClusterSize_t>(modelIndex, 0));
 }
 
 void ROOT::Experimental::RRVecField::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -1936,8 +1911,7 @@ ROOT::Experimental::RField<std::vector<bool>>::GetColumnRepresentations() const
 void ROOT::Experimental::RField<std::vector<bool>>::GenerateColumnsImpl()
 {
    RColumnModel modelIndex(EColumnType::kIndex, true /* isSorted*/);
-   fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
-      Detail::RColumn::Create<ClusterSize_t, EColumnType::kIndex>(modelIndex, 0)));
+   fColumns.emplace_back(Detail::RColumn::Create<ClusterSize_t>(modelIndex, 0));
 }
 
 void ROOT::Experimental::RField<std::vector<bool>>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -2171,8 +2145,7 @@ ROOT::Experimental::RVariantField::GetColumnRepresentations() const
 void ROOT::Experimental::RVariantField::GenerateColumnsImpl()
 {
    RColumnModel modelSwitch(EColumnType::kSwitch, false);
-   fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
-      Detail::RColumn::Create<RColumnSwitch, EColumnType::kSwitch>(modelSwitch, 0)));
+   fColumns.emplace_back(Detail::RColumn::Create<RColumnSwitch>(modelSwitch, 0));
 }
 
 void ROOT::Experimental::RVariantField::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -2366,8 +2339,7 @@ ROOT::Experimental::RCollectionField::GetColumnRepresentations() const
 void ROOT::Experimental::RCollectionField::GenerateColumnsImpl()
 {
    RColumnModel modelIndex(EColumnType::kIndex, true /* isSorted*/);
-   fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
-      Detail::RColumn::Create<ClusterSize_t, EColumnType::kIndex>(modelIndex, 0)));
+   fColumns.emplace_back(Detail::RColumn::Create<ClusterSize_t>(modelIndex, 0));
 }
 
 void ROOT::Experimental::RCollectionField::GenerateColumnsImpl(const RNTupleDescriptor &desc)

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -182,20 +182,19 @@ std::tuple<void **, std::int32_t *, std::int32_t *> GetRVecDataMembers(void *rve
 
 //------------------------------------------------------------------------------
 
-ROOT::Experimental::Detail::RFieldBase::ColumnRepresentation_t
-ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations::GetSerializationDefault() const
+ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations::RColumnRepresentations()
 {
-   if (fSerializationTypes.empty())
-      return ColumnRepresentation_t();
-   return fSerializationTypes[0];
+   // A single representations with an empty set of columns
+   fSerializationTypes.emplace_back(ColumnRepresentation_t());
+   fDeserializationTypes.emplace_back(ColumnRepresentation_t());
 }
 
-ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations::TypesList_t
-ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations::GetDeserializationTypes() const
+ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations::RColumnRepresentations(
+   const TypesList_t &serializationTypes, const TypesList_t &deserializationExtraTypes)
+   : fSerializationTypes(serializationTypes), fDeserializationTypes(serializationTypes)
 {
-   TypesList_t result(fSerializationTypes);
-   result.insert(result.end(), fDeserializationExtraTypes.begin(), fDeserializationExtraTypes.end());
-   return result;
+   fDeserializationTypes.insert(fDeserializationTypes.end(),
+                                deserializationExtraTypes.begin(), deserializationExtraTypes.end());
 }
 
 //------------------------------------------------------------------------------

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -180,6 +180,23 @@ std::tuple<void **, std::int32_t *, std::int32_t *> GetRVecDataMembers(void *rve
 
 } // anonymous namespace
 
+//------------------------------------------------------------------------------
+
+std::vector<ROOT::Experimental::EColumnType>
+ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations::GetSerializationDefault() const
+{
+   if (fSerializationTypes.empty())
+      return std::vector<EColumnType>();
+   return fSerializationTypes[0];
+}
+
+ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations::TypesList_t
+ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations::GetDeserializeTypes() const
+{
+   TypesList_t result(fSerializationTypes);
+   result.insert(result.end(), fDeserializationExtraTypes.begin(), fDeserializationExtraTypes.end());
+   return result;
+}
 
 //------------------------------------------------------------------------------
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -353,6 +353,8 @@ ROOT::Experimental::Detail::RFieldBase::Clone(std::string_view newName) const
    auto clone = CloneImpl(newName);
    clone->fOnDiskId = fOnDiskId;
    clone->fDescription = fDescription;
+   clone->fColumnRepresentative =
+      fColumnRepresentative ? std::make_unique<std::vector<EColumnType>>(*fColumnRepresentative) : nullptr;
    return clone;
 }
 
@@ -742,7 +744,7 @@ void ROOT::Experimental::RField<float>::AcceptVisitor(Detail::RFieldVisitor &vis
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<double>::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kReal64}}, {{}});
+   static RColumnRepresentations representations({{EColumnType::kReal64}, {EColumnType::kSplitReal64}}, {{}});
    return representations;
 }
 

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -532,6 +532,7 @@ std::uint16_t ROOT::Experimental::Internal::RNTupleSerializer::SerializeColumnTy
          return SerializeUInt16(0x0C, buffer);
       case EColumnType::kInt8:
          return SerializeUInt16(0x0D, buffer);
+      case EColumnType::kSplitReal64: return SerializeUInt16(0x10, buffer);
       default:
          throw RException(R__FAIL("ROOT bug: unexpected column type"));
    }
@@ -581,6 +582,7 @@ RResult<std::uint16_t> ROOT::Experimental::Internal::RNTupleSerializer::Deserial
       case 0x0D:
          type = EColumnType::kInt8;
          break;
+      case 0x10: type = EColumnType::kSplitReal64; break;
       default:
          return R__FAIL("unexpected on-disk column type");
    }

--- a/tree/ntuple/v7/test/ntuple_cluster.cxx
+++ b/tree/ntuple/v7/test/ntuple_cluster.cxx
@@ -320,9 +320,8 @@ TEST(PageStorageFile, LoadClusters)
    EXPECT_EQ(0U, cluster->GetId());
    EXPECT_EQ(0U, cluster->GetNOnDiskPages());
 
-   auto column = std::unique_ptr<ROOT::Experimental::Detail::RColumn>(
-      ROOT::Experimental::Detail::RColumn::Create<float, ROOT::Experimental::EColumnType::kReal32>(
-         ROOT::Experimental::RColumnModel(ROOT::Experimental::EColumnType::kReal32, false), 0));
+   auto column = ROOT::Experimental::Detail::RColumn::Create<float>(
+      ROOT::Experimental::RColumnModel(ROOT::Experimental::EColumnType::kReal32, false), 0);
    column->Connect(ptId, &source);
    clusterKeys[0].fClusterId = 1;
    clusterKeys[0].fPhysicalColumnSet.insert(colId);

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -124,20 +124,34 @@ TEST(RColumnElementEndian, Double)
    ROOT::Experimental::Detail::RColumnElement<double, EColumnType::kReal64> element(nullptr);
    EXPECT_EQ(element.IsMappable(), false);
 
-   RPageSinkMock sink(element);
+   RPageSinkMock sink1(element);
    unsigned char buf1[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
                            0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f};
    RPage page1(0, buf1, 8, 2);
    page1.GrowUnchecked(2);
-   sink.CommitPageImpl(RPageStorage::ColumnHandle_t{}, page1);
+   sink1.CommitPageImpl(RPageStorage::ColumnHandle_t{}, page1);
 
    EXPECT_EQ(
-      0, memcmp(sink.GetPages()[0].fBuffer, "\x07\x06\x05\x04\x03\x02\x01\x00\x0f\x0e\x0d\x0c\x0b\x0a\x09\x08", 16));
+      0, memcmp(sink1.GetPages()[0].fBuffer, "\x07\x06\x05\x04\x03\x02\x01\x00\x0f\x0e\x0d\x0c\x0b\x0a\x09\x08", 16));
 
-   RPageSourceMock source(sink.GetPages(), element);
-   auto page2 = source.PopulatePage(RPageStorage::ColumnHandle_t{}, NTupleSize_t{0});
+   RPageSourceMock source1(sink1.GetPages(), element);
+   auto page2 = source1.PopulatePage(RPageStorage::ColumnHandle_t{}, NTupleSize_t{0});
    std::unique_ptr<unsigned char[]> buf2(static_cast<unsigned char *>(page2.GetBuffer())); // adopt buffer
    EXPECT_EQ(0, memcmp(buf2.get(), "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f", 16));
+
+   ROOT::Experimental::Detail::RColumnElement<double, EColumnType::kSplitReal64> splitElement(nullptr);
+   RPageSinkMock sink2(splitElement);
+   RPage page3(0, buf1, 8, 2);
+   page3.GrowUnchecked(2);
+   sink2.CommitPageImpl(RPageStorage::ColumnHandle_t{}, page3);
+
+   EXPECT_EQ(
+      0, memcmp(sink2.GetPages()[0].fBuffer, "\x07\x0f\x06\x0e\x05\x0d\x04\x0c\x03\x0b\x02\x0a\x01\x09\x00\x08", 16));
+
+   RPageSourceMock source2(sink2.GetPages(), splitElement);
+   auto page4 = source2.PopulatePage(RPageStorage::ColumnHandle_t{}, NTupleSize_t{0});
+   std::unique_ptr<unsigned char[]> buf3(static_cast<unsigned char *>(page4.GetBuffer())); // adopt buffer
+   EXPECT_EQ(0, memcmp(buf3.get(), "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f", 16));
 }
 
 TEST(RColumnElementEndian, Int16)

--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -1,5 +1,8 @@
 #include "ntuple_test.hxx"
 
+#include <array>
+#include <limits>
+
 TEST(Packing, Bitfield)
 {
    ROOT::Experimental::Detail::RColumnElement<bool, ROOT::Experimental::EColumnType::kBit> element(nullptr);
@@ -49,4 +52,26 @@ TEST(Packing, RColumnSwitch)
    element.Unpack(&s2, &out, 1);
    EXPECT_EQ(0xaa, s2.GetIndex());
    EXPECT_EQ(0x55, s2.GetTag());
+}
+
+TEST(Packing, SplitReal64)
+{
+   ROOT::Experimental::Detail::RColumnElement<double, ROOT::Experimental::EColumnType::kSplitReal64> element(nullptr);
+   element.Pack(nullptr, nullptr, 0);
+   element.Unpack(nullptr, nullptr, 0);
+
+   std::array<double, 7> mem{0.0,
+                             42.0,
+                             std::numeric_limits<double>::min(),
+                             std::numeric_limits<double>::max(),
+                             std::numeric_limits<double>::lowest(),
+                             std::numeric_limits<double>::infinity(),
+                             std::numeric_limits<double>::denorm_min()};
+   std::array<double, 7> packed;
+   std::array<double, 7> cmp;
+
+   element.Pack(packed.data(), mem.data(), 7);
+   element.Unpack(cmp.data(), packed.data(), 7);
+
+   EXPECT_EQ(mem, cmp);
 }

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -722,11 +722,10 @@ TEST(RNTuple, RColumnRepresentations)
    EXPECT_EQ(std::vector<EColumnType>(), colReps1.GetSerializationDefault());
    EXPECT_EQ(RColumnRepresentations::TypesList_t(), colReps1.GetDeserializationTypes());
 
-   // TODO(jblomer): replace kMax by kReal64Split
-   RColumnRepresentations colReps2({{EColumnType::kReal64}, {EColumnType::kMax}},
+   RColumnRepresentations colReps2({{EColumnType::kReal64}, {EColumnType::kSplitReal64}},
                                    {{EColumnType::kReal32}, {EColumnType::kReal16}});
    EXPECT_EQ(std::vector<EColumnType>({EColumnType::kReal64}), colReps2.GetSerializationDefault());
    EXPECT_EQ(RColumnRepresentations::TypesList_t(
-                {{EColumnType::kReal64}, {EColumnType::kMax}, {EColumnType::kReal32}, {EColumnType::kReal16}}),
+                {{EColumnType::kReal64}, {EColumnType::kSplitReal64}, {EColumnType::kReal32}, {EColumnType::kReal16}}),
              colReps2.GetDeserializationTypes());
 }

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -273,7 +273,8 @@ TEST(RNTuple, Casting)
       auto reader = RNTupleReader::Open(std::move(modelB), "ntuple", fileGuard.GetPath());
       FAIL() << "should not be able to cast int to float";
    } catch (const RException& err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("not convertible to the requested type"));
+      EXPECT_THAT(err.what(), testing::HasSubstr("On-disk column types"));
+      EXPECT_THAT(err.what(), testing::HasSubstr("cannot be matched"));
    }
 
    auto modelC = RNTupleModel::Create();
@@ -333,7 +334,7 @@ TEST(RNTuple, TClass)
          auto viewKlass = ntuple->GetView<DerivedA>("klass");
          FAIL() << "GetView<a_base_class_of_T> should throw";
       } catch (const RException& err) {
-         EXPECT_THAT(err.what(), testing::HasSubstr("Column missing: column #0 for field a"));
+         EXPECT_THAT(err.what(), testing::HasSubstr("No on-disk column information for for field `klass.:_0.a`"));
       }
    }
 }

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -262,6 +262,14 @@ TEST(RNTuple, Casting)
    FileRaii fileGuard("test_ntuple_casting.root");
    auto modelA = RNTupleModel::Create();
    modelA->MakeField<std::int32_t>("myInt", 42);
+   auto fld = ROOT::Experimental::Detail::RFieldBase::Create("field", "float").Unwrap();
+   fld->SetSerializationTypes({EColumnType::kReal32});
+   try {
+      fld->SetSerializationTypes({EColumnType::kBit});
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("invalid column representation"));
+   }
+   modelA->AddField(std::move(fld));
    {
       auto writer = RNTupleWriter::Recreate(std::move(modelA), "ntuple", fileGuard.GetPath());
       writer->Fill();

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -660,3 +660,19 @@ TEST(RNTuple, TClassReadRules)
       EXPECT_EQ("ROOT", viewKlass(i).s.str);
    }
 }
+
+TEST(RNTuple, RColumnRepresentations)
+{
+   using RColumnRepresentations = ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations;
+   RColumnRepresentations colReps1;
+   EXPECT_EQ(std::vector<EColumnType>(), colReps1.GetSerializationDefault());
+   EXPECT_EQ(RColumnRepresentations::TypesList_t(), colReps1.GetDeserializeTypes());
+
+   // TODO(jblomer): replace kMax by kReal64Split
+   RColumnRepresentations colReps2({{EColumnType::kReal64}, {EColumnType::kMax}},
+                                   {{EColumnType::kReal32}, {EColumnType::kReal16}});
+   EXPECT_EQ(std::vector<EColumnType>({EColumnType::kReal64}), colReps2.GetSerializationDefault());
+   EXPECT_EQ(RColumnRepresentations::TypesList_t(
+                {{EColumnType::kReal64}, {EColumnType::kMax}, {EColumnType::kReal32}, {EColumnType::kReal16}}),
+             colReps2.GetDeserializeTypes());
+}

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -719,12 +719,12 @@ TEST(RNTuple, RColumnRepresentations)
 {
    using RColumnRepresentations = ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations;
    RColumnRepresentations colReps1;
-   EXPECT_EQ(std::vector<EColumnType>(), colReps1.GetSerializationDefault());
+   EXPECT_EQ(RFieldBase::ColumnRepresentation_t(), colReps1.GetSerializationDefault());
    EXPECT_EQ(RColumnRepresentations::TypesList_t(), colReps1.GetDeserializationTypes());
 
    RColumnRepresentations colReps2({{EColumnType::kReal64}, {EColumnType::kSplitReal64}},
                                    {{EColumnType::kReal32}, {EColumnType::kReal16}});
-   EXPECT_EQ(std::vector<EColumnType>({EColumnType::kReal64}), colReps2.GetSerializationDefault());
+   EXPECT_EQ(RFieldBase::ColumnRepresentation_t({EColumnType::kReal64}), colReps2.GetSerializationDefault());
    EXPECT_EQ(RColumnRepresentations::TypesList_t(
                 {{EColumnType::kReal64}, {EColumnType::kSplitReal64}, {EColumnType::kReal32}, {EColumnType::kReal16}}),
              colReps2.GetDeserializationTypes());

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -720,7 +720,8 @@ TEST(RNTuple, RColumnRepresentations)
    using RColumnRepresentations = ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations;
    RColumnRepresentations colReps1;
    EXPECT_EQ(RFieldBase::ColumnRepresentation_t(), colReps1.GetSerializationDefault());
-   EXPECT_EQ(RColumnRepresentations::TypesList_t(), colReps1.GetDeserializationTypes());
+   EXPECT_EQ(RColumnRepresentations::TypesList_t{RFieldBase::ColumnRepresentation_t()},
+             colReps1.GetDeserializationTypes());
 
    RColumnRepresentations colReps2({{EColumnType::kReal64}, {EColumnType::kSplitReal64}},
                                    {{EColumnType::kReal32}, {EColumnType::kReal16}});


### PR DESCRIPTION
Add the concept of column representations to fields. Every fields can have a set of possible column representations for writing and additional column representations for reading. When reading, the column representation is fixed by the on-disk data. On writing, there is a default column representation but the user can pick a different one.

This provides the framework to store data in different encodings (e.g., split, unsplit) and to load data from "compatible columns", e.g. `kInt32` column into `std::int64` type.

As an example, the PR adds support for split and unsplit storage of `double`s. Follow-up PRs will complete the available encodings and select split encode as the default for writing.