### PR TITLE
[ntuple] Re-expose field type of RNTupleView

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -161,6 +161,8 @@ private:
    Detail::RFieldValue fValue;
 
 public:
+   using FieldTypeT = T;
+
    RNTupleView(DescriptorId_t fieldId, Detail::RPageSource *pageSource)
       : fField(pageSource->GetSharedDescriptorGuard()->GetFieldDescriptor(fieldId).GetFieldName()),
         fValue(fField.GenerateValue())


### PR DESCRIPTION
This PR re-exposed the field type of an `RNTupleView` which otherwise must be matched out from the template signature (e.g. via `boost::mp11::mp_first).