### PR TITLE
CMake: use CLING_BINARY_DIR instead of LLVM_BINARY_DIR to configure ClingConfig.cmake

### DIFF
--- a/interpreter/cling/cmake/modules/CMakeLists.txt
+++ b/interpreter/cling/cmake/modules/CMakeLists.txt
@@ -2,7 +2,7 @@
 # link against them. LLVM calls its version of this file LLVMExports.cmake, but
 # the usual CMake convention seems to be ${Project}Targets.cmake.
 set(CLING_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/cling)
-set(cling_cmake_builddir "${LLVM_BINARY_DIR}/${CLING_INSTALL_PACKAGE_DIR}")
+set(cling_cmake_builddir "${CLING_BINARY_DIR}/${CLING_INSTALL_PACKAGE_DIR}")
 
 # Keep this in sync with llvm/cmake/CMakeLists.txt!
 set(LLVM_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm)


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Potential fix for #12151. Needs input from @vgvassilev for why `cling_cmake_builddir` was changed in 2b283ccf3a624f70dab3e8783d361d25c13e2c65.

I did not test this for the non-builtin case and I can't confirm this works fully since testing it is blocked by #12152.

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #11920.

