### PR TITLE
[RF] Fix duplicate ownership problem in RooMomentMorph(Func)ND

### DIFF
--- a/roofit/roofit/src/RooMomentMorphFuncND.cxx
+++ b/roofit/roofit/src/RooMomentMorphFuncND.cxx
@@ -278,8 +278,11 @@ void RooMomentMorphFuncND::initialize()
 
 //_____________________________________________________________________________
 RooMomentMorphFuncND::Grid2::Grid2(const RooMomentMorphFuncND::Grid2 &other)
-   : _grid(other._grid), _pdfList(other._pdfList), _pdfMap(other._pdfMap), _nref(other._nref)
+   : _pdfList(other._pdfList), _pdfMap(other._pdfMap), _nref(other._nref)
 {
+   for (unsigned int i = 0; i < other._grid.size(); i++) {
+      _grid.push_back(other._grid[i]->clone());
+   }
 }
 
 //_____________________________________________________________________________

--- a/roofit/roofit/src/RooMomentMorphND.cxx
+++ b/roofit/roofit/src/RooMomentMorphND.cxx
@@ -274,8 +274,11 @@ void RooMomentMorphND::initialize()
 
 //_____________________________________________________________________________
 RooMomentMorphND::Grid2::Grid2(const RooMomentMorphND::Grid2 &other)
-   : _grid(other._grid), _pdfList(other._pdfList), _pdfMap(other._pdfMap), _nref(other._nref)
+   : _pdfList(other._pdfList), _pdfMap(other._pdfMap), _nref(other._nref)
 {
+   for (unsigned int i = 0; i < other._grid.size(); i++) {
+      _grid.push_back(other._grid[i]->clone());
+   }
 }
 
 //_____________________________________________________________________________


### PR DESCRIPTION
The commit 4c9c5d6b49 fixed the memory leaking of the `RooMomentMorph(Func)ND::Grid2::_grid` member by deleting it in the constructor, but it didn't consider that the copy constructor didn't make a clone of the `_grid`, ending up with double ownership.

Now, the copy constructor is also cloning the binnings, just like the regular constructor, and the double ownership is avoided.

Closes #12155.