### PR TITLE
v6.28: [base] Deprecate TDirectory::EncodeNameCycle():

### DIFF
--- a/core/base/inc/TDirectory.h
+++ b/core/base/inc/TDirectory.h
@@ -304,6 +304,7 @@ public:
 
    static Bool_t       Cd(const char *path);
    static void         DecodeNameCycle(const char *namecycle, char *name, Short_t &cycle, const size_t namesize = 0);
+   R__DEPRECATED(6,30, "Cannot be used safely, use `name + ';' + std::to_string(cycle)`")
    static void         EncodeNameCycle(char *buffer, const char *name, Short_t cycle);
 
    ClassDefOverride(TDirectory,5)  //Describe directory structure in memory

--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -1288,8 +1288,14 @@ void TDirectory::EncodeNameCycle(char *buffer, const char *name, Short_t cycle)
 {
    if (cycle == 9999)
       strcpy(buffer, name);
-   else
-      sprintf(buffer, "%s;%d", name, cycle);
+   else {
+      // sizeof(buffer) is unknown, this interface is broken.
+      // It's now also deprecated. Until it's removed, silence sprintf warning
+      // on macOS / Xcode / clang by using an equivalently bad snprintf without
+      // knowledge of sizeof(buffer):
+      size_t unsafeSize = strlen(name) + std::to_string(cycle).length() + 1;
+      snprintf(buffer, unsafeSize, "%s;%d", name, cycle);
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
It is broken by design, there is no way that this interface can
be used in a safe way. Just get rid of it.# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

