### PR TITLE
Remove `TDirectory::EncodeNameCycle()`, enable `R__DEPRECATED(6,32`

### DIFF
--- a/core/base/inc/TDirectory.h
+++ b/core/base/inc/TDirectory.h
@@ -304,7 +304,6 @@ public:
 
    static Bool_t       Cd(const char *path);
    static void         DecodeNameCycle(const char *namecycle, char *name, Short_t &cycle, const size_t namesize = 0);
-   static void         EncodeNameCycle(char *buffer, const char *name, Short_t cycle);
 
    ClassDefOverride(TDirectory,5)  //Describe directory structure in memory
 };

--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -1281,18 +1281,6 @@ void TDirectory::SetName(const char* newname)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Encode the name and cycle into buffer like: "aap;2".
-/// @note if `cycle` is 9999, its value will not appear in the output and `name` will be used verbatim.
-
-void TDirectory::EncodeNameCycle(char *buffer, const char *name, Short_t cycle)
-{
-   if (cycle == 9999)
-      strcpy(buffer, name);
-   else
-      sprintf(buffer, "%s;%d", name, cycle);
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Decode a namecycle "aap;2" into name "aap" and cycle "2". Destination
 /// buffer size for name (including string terminator) should be specified in
 /// namesize.

--- a/core/foundation/inc/ROOT/RConfig.hxx
+++ b/core/foundation/inc/ROOT/RConfig.hxx
@@ -495,12 +495,12 @@
 #define _R_DEPRECATED_REMOVE_NOW(REASON) __attribute__((REMOVE_THIS_NOW))
 #endif
 
-/* USE AS `R__DEPRECATED(6,30, "Not threadsafe; use TFoo::Bar().")`
-   To be removed by 6.30 */
-#if ROOT_VERSION_CODE <= ROOT_VERSION(6,29,0)
-# define _R__DEPRECATED_630(REASON) _R__DEPRECATED_LATER(REASON)
+/* USE AS `R__DEPRECATED(6,32, "Not threadsafe; use TFoo::Bar().")`
+   To be removed by 6.32 */
+#if ROOT_VERSION_CODE <= ROOT_VERSION(6,31,0)
+# define _R__DEPRECATED_632(REASON) _R__DEPRECATED_LATER(REASON)
 #else
-# define _R__DEPRECATED_630(REASON) _R_DEPRECATED_REMOVE_NOW(REASON)
+# define _R__DEPRECATED_632(REASON) _R_DEPRECATED_REMOVE_NOW(REASON)
 #endif
 
 /* USE AS `R__DEPRECATED(7,00, "Not threadsafe; use TFoo::Bar().")`


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

