### PR TITLE
[tmva][pymva] Use correct python executable for the Keras and PyTorch  tests

### DIFF
--- a/tmva/pymva/test/testPyKerasClassification.C
+++ b/tmva/pymva/test/testPyKerasClassification.C
@@ -36,7 +36,7 @@ int testPyKerasClassification(){
        std::cout << "[ERROR] Failed to write python code to file" << std::endl;
        return 1;
    }
-   ret = gSystem->Exec("python generateKerasModelClassification.py");
+   ret = gSystem->Exec(TMVA::Python_Executable() + " generateKerasModelClassification.py");
    if(ret!=0){
        std::cout << "[ERROR] Failed to generate model using python" << std::endl;
        return 1;

--- a/tmva/pymva/test/testPyKerasMulticlass.C
+++ b/tmva/pymva/test/testPyKerasMulticlass.C
@@ -42,7 +42,7 @@ int testPyKerasMulticlass(){
        std::cout << "[ERROR] Failed to write python code to file" << std::endl;
        return 1;
    }
-   ret = gSystem->Exec("python generateKerasModelMulticlass.py");
+   ret = gSystem->Exec(TMVA::Python_Executable() + " generateKerasModelMulticlass.py");
    if(ret!=0){
        std::cout << "[ERROR] Failed to generate model using python" << std::endl;
        return 1;

--- a/tmva/pymva/test/testPyKerasRegression.C
+++ b/tmva/pymva/test/testPyKerasRegression.C
@@ -36,7 +36,7 @@ int testPyKerasRegression(){
        std::cout << "[ERROR] Failed to write python code to file" << std::endl;
        return 1;
    }
-   ret = gSystem->Exec("python generateKerasModelRegression.py");
+   ret = gSystem->Exec(TMVA::Python_Executable() + " generateKerasModelRegression.py");
    if(ret!=0){
        std::cout << "[ERROR] Failed to generate model using python" << std::endl;
        return 1;

--- a/tmva/pymva/test/testPyTorchMulticlass.C
+++ b/tmva/pymva/test/testPyTorchMulticlass.C
@@ -27,7 +27,7 @@ int testPyTorchMulticlass(){
    // Build model from python file
    std::cout << "Generate PyTorch model..." << std::endl;
    UInt_t ret;
-   ret = gSystem->Exec("python generatePyTorchModelMulticlass.py");
+   ret = gSystem->Exec(TMVA::Python_Executable() + " generatePyTorchModelMulticlass.py");
    if(ret!=0){
        std::cout << "[ERROR] Failed to generate model using python" << std::endl;
        return 1;

--- a/tmva/pymva/test/testPyTorchRegression.C
+++ b/tmva/pymva/test/testPyTorchRegression.C
@@ -21,7 +21,7 @@ int testPyTorchRegression(){
    // Build model from python file
    std::cout << "Generate PyTorch model..." << std::endl;
    UInt_t ret;
-   ret = gSystem->Exec("python generatePyTorchModelRegression.py");
+   ret = gSystem->Exec(TMVA::Python_Executable() + " generatePyTorchModelRegression.py");
    if(ret!=0){
        std::cout << "[ERROR] Failed to generate model using python" << std::endl;
        return 1;


### PR DESCRIPTION
This PR should fix the failures of some PyTorch tests caused by using Python2 instead of Python3