### PR TITLE
[DF] Remove performance overhead in construction of RSampleInfo

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RDatasetSpec.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDatasetSpec.hxx
@@ -21,6 +21,11 @@
 #include <RtypesCore.h> // Long64_t
 
 namespace ROOT {
+namespace Detail {
+namespace RDF {
+class RLoopManager;
+}
+} // namespace Detail
 namespace RDF {
 namespace Experimental {
 
@@ -29,6 +34,8 @@ namespace Experimental {
 \brief A dataset specification for RDataFrame.
 */
 class RDatasetSpec {
+   friend class ::ROOT::Detail::RDF::RLoopManager; // for MoveOutDatasetGroups
+
 public:
    struct REntryRange {
       Long64_t fBegin{0};
@@ -43,6 +50,8 @@ private:
    ROOT::TreeUtils::RFriendInfo fFriendInfo;  ///< List of friends
    REntryRange fEntryRange; ///< Start (inclusive) and end (exclusive) entry for the dataset processing
 
+   std::vector<RDatasetGroup> MoveOutDatasetGroups();
+
 public:
    RDatasetSpec() = default;
 
@@ -53,10 +62,6 @@ public:
    const ROOT::TreeUtils::RFriendInfo &GetFriendInfo() const;
    Long64_t GetEntryRangeBegin() const;
    Long64_t GetEntryRangeEnd() const;
-
-   /// \cond HIDDEN_SYMBOLS
-   const std::vector<RDatasetGroup> &GetDatasetGroups() const;
-   /// \endcond
 
    RDatasetSpec &AddGroup(RDatasetGroup datasetGroup);
 

--- a/tree/dataframe/inc/ROOT/RDF/RSampleInfo.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RSampleInfo.hxx
@@ -36,11 +36,19 @@ class RSampleInfo {
    std::string fID;
    std::pair<ULong64_t, ULong64_t> fEntryRange;
 
-   ROOT::RDF::Experimental::RDatasetGroup fDatasetGroup{"", "", ""};
+   const ROOT::RDF::Experimental::RDatasetGroup *fDatasetGroup = nullptr; // non-owning
+
+   void ThrowIfNoDatasetGroup() const
+   {
+      if (fDatasetGroup == nullptr) {
+         const auto msg = "RSampleInfo: dataset group data was requested but no dataset groups are available.";
+         throw std::logic_error(msg);
+      }
+   }
 
 public:
    RSampleInfo(std::string_view id, std::pair<ULong64_t, ULong64_t> entryRange,
-               const ROOT::RDF::Experimental::RDatasetGroup &datasetGroup = {"", "", ""})
+               const ROOT::RDF::Experimental::RDatasetGroup *datasetGroup = nullptr)
       : fID(id), fEntryRange(entryRange), fDatasetGroup(datasetGroup)
    {
    }
@@ -51,15 +59,35 @@ public:
    RSampleInfo &operator=(RSampleInfo &&) = default;
    ~RSampleInfo() = default;
 
-   const std::string &GetGroupName() const { return fDatasetGroup.GetGroupName(); }
+   const std::string &GetGroupName() const
+   {
+      ThrowIfNoDatasetGroup();
+      return fDatasetGroup->GetGroupName();
+   }
 
-   unsigned int GetGroupId() const { return fDatasetGroup.GetGroupId(); }
+   unsigned int GetGroupId() const
+   {
+      ThrowIfNoDatasetGroup();
+      return fDatasetGroup->GetGroupId();
+   }
 
-   int GetI(const std::string &key) const { return fDatasetGroup.GetMetaData().GetI(key); }
+   int GetI(const std::string &key) const
+   {
+      ThrowIfNoDatasetGroup();
+      return fDatasetGroup->GetMetaData().GetI(key);
+   }
 
-   double GetD(const std::string &key) const { return fDatasetGroup.GetMetaData().GetD(key); }
+   double GetD(const std::string &key) const
+   {
+      ThrowIfNoDatasetGroup();
+      return fDatasetGroup->GetMetaData().GetD(key);
+   }
 
-   std::string GetS(const std::string &key) const { return fDatasetGroup.GetMetaData().GetS(key); }
+   std::string GetS(const std::string &key) const
+   {
+      ThrowIfNoDatasetGroup();
+      return fDatasetGroup->GetMetaData().GetS(key);
+   }
 
    /// Check whether the sample name contains the given substring.
    bool Contains(std::string_view substr) const

--- a/tree/dataframe/src/RDatasetGroup.cxx
+++ b/tree/dataframe/src/RDatasetGroup.cxx
@@ -33,6 +33,10 @@ RDatasetGroup::RDatasetGroup(const std::string &groupName,
                              const RMetaData &metaData)
    : fGroupName(groupName), fMetaData(metaData)
 {
+   // avoid constructing and destructing the helper TChain here if we don't need to
+   if (treeAndFileNameGlobs.empty())
+      return;
+
    TChain chain;
    for (const auto &p : treeAndFileNameGlobs) {
       const auto fullpath = p.second + "/" + p.first;

--- a/tree/dataframe/src/RDatasetSpec.cxx
+++ b/tree/dataframe/src/RDatasetSpec.cxx
@@ -81,9 +81,9 @@ Long64_t RDatasetSpec::GetEntryRangeEnd() const
    return fEntryRange.fEnd;
 }
 
-const std::vector<RDatasetGroup> &RDatasetSpec::GetDatasetGroups() const
+std::vector<RDatasetGroup> RDatasetSpec::MoveOutDatasetGroups()
 {
-   return fDatasetGroups;
+   return std::move(fDatasetGroups);
 }
 
 RDatasetSpec &RDatasetSpec::AddGroup(RDatasetGroup datasetGroup)

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -367,7 +367,7 @@ RLoopManager::RLoopManager(std::unique_ptr<RDataSource> ds, const ColumnNames_t 
 
 RLoopManager::RLoopManager(ROOT::RDF::Experimental::RDatasetSpec &&spec)
    : fBeginEntry(spec.GetEntryRangeBegin()), fEndEntry(spec.GetEntryRangeEnd()),
-     fDatasetGroups(spec.GetDatasetGroups()), fNSlots(RDFInternal::GetNSlots()),
+     fDatasetGroups(spec.MoveOutDatasetGroups()), fNSlots(RDFInternal::GetNSlots()),
      fLoopType(ROOT::IsImplicitMTEnabled() ? ELoopType::kROOTFilesMT : ELoopType::kROOTFiles),
      fNewSampleNotifier(fNSlots), fSampleInfos(fNSlots), fDatasetColumnReaders(fNSlots)
 {

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -711,7 +711,7 @@ void RLoopManager::UpdateSampleInfo(unsigned int slot, TTreeReader &r) {
    }
    const std::string &id = fname + "/" + treename;
    fSampleInfos[slot] =
-      fDatasetGroupMap.empty() ? RSampleInfo(id, range) : RSampleInfo(id, range, *fDatasetGroupMap[id]);
+      fDatasetGroupMap.empty() ? RSampleInfo(id, range) : RSampleInfo(id, range, fDatasetGroupMap[id]);
 }
 
 /// Initialize all nodes of the functional graph before running the event loop.


### PR DESCRIPTION
The important commit is [[DF] Make dataset group an optional data member of RSampleInfo](https://github.com/root-project/root/commit/ad6ecd8227786f363f48be207d45b0f86d6357e5): it short-circuits some logic so that we don't construct a RDatasetGroup object if we don't have to, and we copy pointers to RDatasetGroups instead of RDatasetGroup objects.

It also introduces a change in behavior: RDF now throws if a user asks for information about the dataset group but there is no group available. Before that commit it would return some arbitrary value for each of the properties (e.g. empty string, 0, ...).

This should fix the performance regression seen in some Grafana benchmarks on the evening of the 15th of December.