### PR TITLE
TH3 palette title was equal to the z-axis title

### DIFF
--- a/hist/histpainter/src/TPaletteAxis.cxx
+++ b/hist/histpainter/src/TPaletteAxis.cxx
@@ -446,6 +446,8 @@ void TPaletteAxis::Paint(Option_t *)
    Int_t theColor, color;
    // import Attributes already here since we might need them for CJUST
    if (fH->GetDimension() == 2) fAxis.ImportAxisAttributes(fH->GetZaxis());
+   // for 3D histograms there is no palette's title
+   if (fH->GetDimension() >  2) fAxis.SetTitle("");
    // case option "CJUST": put labels directly at color boundaries
    TLatex *label = nullptr;
    TLine *line = nullptr;


### PR DESCRIPTION
The TH3 Palette title was wrongly equal to the za-xis title.
this was found here:
https://root-forum.cern.ch/t/z-bad-label-for-palette-axis-in-th3d/53317/4

