### PR TITLE
[RF] Small fixes to debug printout in RooRealIntegral and RooEffGenContext

### DIFF
--- a/roofit/roofitcore/inc/RooEffGenContext.h
+++ b/roofit/roofitcore/inc/RooEffGenContext.h
@@ -27,6 +27,8 @@ public:
                     const RooArgSet *forceDirect = nullptr);
    ~RooEffGenContext() override;
 
+   void printMultiline(std::ostream &os, Int_t content, bool verbose = false, TString indent = "") const override;
+
 protected:
    void initGenerator(const RooArgSet &theEvent) override;
    void generateEvent(RooArgSet &theEvent, Int_t remaining) override;

--- a/roofit/roofitcore/inc/RooEffGenContext.h
+++ b/roofit/roofitcore/inc/RooEffGenContext.h
@@ -22,22 +22,21 @@ class RooAbsReal;
 
 class RooEffGenContext : public RooAbsGenContext {
 public:
-  RooEffGenContext(const RooAbsPdf &model,
-                   const RooAbsPdf &pdf,const RooAbsReal& eff,
-                   const RooArgSet &vars, const RooDataSet *prototype= nullptr,
-                   const RooArgSet* auxProto=nullptr, bool verbose=false, const RooArgSet* forceDirect=nullptr);
-  ~RooEffGenContext() override;
+   RooEffGenContext(const RooAbsPdf &model, const RooAbsPdf &pdf, const RooAbsReal &eff, const RooArgSet &vars,
+                    const RooDataSet *prototype = nullptr, const RooArgSet *auxProto = nullptr, bool verbose = false,
+                    const RooArgSet *forceDirect = nullptr);
+   ~RooEffGenContext() override;
 
 protected:
-  void initGenerator(const RooArgSet &theEvent) override;
-  void generateEvent(RooArgSet &theEvent, Int_t remaining) override;
+   void initGenerator(const RooArgSet &theEvent) override;
+   void generateEvent(RooArgSet &theEvent, Int_t remaining) override;
 
 private:
-   RooArgSet _cloneSet;            ///< Internal clone of p.d.f.
-   RooAbsReal* _eff;               ///< Pointer to efficiency function
-   RooAbsGenContext* _generator;   ///< Generator context for p.d.f
-   RooArgSet _vars;               ///< Vars to generate
-   double _maxEff;                 ///< Maximum of efficiency in vars
+   RooArgSet _cloneSet;          ///< Internal clone of p.d.f.
+   RooAbsReal *_eff;             ///< Pointer to efficiency function
+   RooAbsGenContext *_generator; ///< Generator context for p.d.f
+   RooArgSet _vars;              ///< Vars to generate
+   double _maxEff;               ///< Maximum of efficiency in vars
 
    ClassDefOverride(RooEffGenContext, 0); // Context for generating a dataset from a PDF
 };

--- a/roofit/roofitcore/src/RooEffGenContext.cxx
+++ b/roofit/roofitcore/src/RooEffGenContext.cxx
@@ -12,7 +12,6 @@
  * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
  *****************************************************************************/
 
-
 /**
 \file RooEffGenContext.cxx
 \class RooEffGenContext
@@ -38,16 +37,14 @@ ClassImp(RooEffGenContext);
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor of generator context for RooEffProd products
 
-RooEffGenContext::RooEffGenContext(const RooAbsPdf &model,
-                                   const RooAbsPdf& pdf, const RooAbsReal& eff,
-                                   const RooArgSet &vars,
-                                   const RooDataSet *prototype, const RooArgSet* auxProto,
-                                   bool verbose, const RooArgSet* /*forceDirect*/) :
-   RooAbsGenContext(model, vars, prototype, auxProto, verbose), _maxEff(0.)
+RooEffGenContext::RooEffGenContext(const RooAbsPdf &model, const RooAbsPdf &pdf, const RooAbsReal &eff,
+                                   const RooArgSet &vars, const RooDataSet *prototype, const RooArgSet *auxProto,
+                                   bool verbose, const RooArgSet * /*forceDirect*/)
+   : RooAbsGenContext(model, vars, prototype, auxProto, verbose), _maxEff(0.)
 {
-   RooArgSet x(eff,eff.GetName());
+   RooArgSet x(eff, eff.GetName());
    x.snapshot(_cloneSet, true);
-   _eff = dynamic_cast<RooAbsReal*>(_cloneSet.find(eff.GetName()));
+   _eff = dynamic_cast<RooAbsReal *>(_cloneSet.find(eff.GetName()));
    _generator = pdf.genContext(vars, prototype, auxProto, verbose);
    vars.snapshot(_vars, true);
 }
@@ -71,9 +68,9 @@ void RooEffGenContext::initGenerator(const RooArgSet &theEvent)
    // Check if PDF supports maximum finding
    Int_t code = _eff->getMaxVal(_vars);
    if (!code) {
-     _maxEff = 1.;
+      _maxEff = 1.;
    } else {
-     _maxEff = _eff->maxVal(code);
+      _maxEff = _eff->maxVal(code);
    }
 }
 
@@ -89,7 +86,7 @@ void RooEffGenContext::generateEvent(RooArgSet &theEvent, Int_t remaining)
       double val = _eff->getVal();
       if (val > _maxEff && !_eff->getMaxVal(_vars)) {
          coutE(Generation) << ClassName() << "::" << GetName()
-              << ":generateEvent: value of efficiency is larger than assumed maximum of 1."  << std::endl;
+                           << ":generateEvent: value of efficiency is larger than assumed maximum of 1." << std::endl;
          continue;
       }
       if (val > RooRandom::uniform() * _maxEff) {

--- a/roofit/roofitcore/src/RooEffGenContext.cxx
+++ b/roofit/roofitcore/src/RooEffGenContext.cxx
@@ -94,3 +94,20 @@ void RooEffGenContext::generateEvent(RooArgSet &theEvent, Int_t remaining)
       }
    }
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// Detailed printing interface
+
+void RooEffGenContext::printMultiline(ostream &os, Int_t content, bool verbose, TString indent) const
+{
+   RooAbsGenContext::printMultiline(os, content, verbose, indent);
+   os << indent << "--- RooEffGenContext ---" << endl;
+   os << indent << "Using EFF ";
+   _eff->printStream(os, kName | kArgs | kClassName, kSingleLine, indent);
+   os << indent << "PDF generator" << endl;
+
+   TString indent2(indent);
+   indent2.Append("    ");
+
+   _generator->printMultiline(os, content, verbose, indent2);
+}

--- a/roofit/roofitcore/src/RooRealIntegral.cxx
+++ b/roofit/roofitcore/src/RooRealIntegral.cxx
@@ -945,7 +945,7 @@ double RooRealIntegral::evaluate() const
 
   if (dologD(Tracing)) {
     cxcoutD(Tracing) << "RooRealIntegral::evaluate(" << GetName() << ") anaInt = " << _anaList << " numInt = " << _intList << _sumList << " mode = " ;
-    switch(_mode) {
+    switch(_intOperMode) {
     case Hybrid: ccoutD(Tracing) << "Hybrid" ; break ;
     case Analytic: ccoutD(Tracing) << "Analytic" ; break ;
     case PassThrough: ccoutD(Tracing) << "PassThrough" ; break ;


### PR DESCRIPTION
# This Pull request:
Fixes some small issues with debug printout during integration or generation

## Changes or fixes:
The first commit changes the debug printout in `RooRealIntegral::evaluate`. `_mode` here is the analytical integral code, `_intOperMode` is the variable that can be `Hybrid`, `Analytic` or `PassThrough` (like in the switch-case above).

The second commit adds `printMultiline` to `RooEffGenContext`. This is used when requesting verbose printout during dataset generation, which is supposed to recursively print all gen contexts. Before this change, having a `RooEffProd` inside the model stopped the recursive printout.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

