### PR TITLE
[llvm] Override llvm-visibility-default:

### DIFF
--- a/interpreter/llvm/src/include/llvm/Support/Compiler.h
+++ b/interpreter/llvm/src/include/llvm/Support/Compiler.h
@@ -126,7 +126,8 @@
 #if (__has_attribute(visibility) || LLVM_GNUC_PREREQ(4, 0, 0)) &&              \
     !defined(__MINGW32__) && !defined(__CYGWIN__) && !defined(_WIN32)
 #define LLVM_LIBRARY_VISIBILITY __attribute__ ((visibility("hidden")))
-#define LLVM_EXTERNAL_VISIBILITY __attribute__ ((visibility("default")))
+//#define LLVM_EXTERNAL_VISIBILITY __attribute__ ((visibility("default")))
+#define LLVM_EXTERNAL_VISIBILITY
 #else
 #define LLVM_LIBRARY_VISIBILITY
 #define LLVM_EXTERNAL_VISIBILITY


### PR DESCRIPTION
We really need these symbols to be hidden. Solves
https://github.com/root-project/root/issues/12170

```
Unable to find target for this triple (no targets are registered) *** Break *** abort
```
where the llvm of PyTorch ends up using the RegisterTarget function of the llvm of cling.


