### PR TITLE
[RF] Fixes and improvements to `RooTruthModel` and related tutorials

### DIFF
--- a/roofit/batchcompute/inc/RooBatchCompute.h
+++ b/roofit/batchcompute/inc/RooBatchCompute.h
@@ -47,10 +47,12 @@ enum Computer {
    CBShape,
    Chebychev,
    ChiSquare,
+   DeltaFunction,
    DstD0BG,
    Exponential,
    Gamma,
    Gaussian,
+   Identity,
    Johnson,
    Landau,
    Lognormal,
@@ -60,6 +62,13 @@ enum Computer {
    Polynomial,
    ProdPdf,
    Ratio,
+   TruthModelExpBasis,
+   TruthModelSinBasis,
+   TruthModelCosBasis,
+   TruthModelLinBasis,
+   TruthModelQuadBasis,
+   TruthModelSinhBasis,
+   TruthModelCoshBasis,
    Voigtian
 };
 

--- a/roofit/batchcompute/inc/RooVDTHeaders.h
+++ b/roofit/batchcompute/inc/RooVDTHeaders.h
@@ -25,44 +25,72 @@
 #include "RConfigure.h"
 
 #if defined(R__HAS_VDT) && !defined(__CUDACC__)
-#include "vdt/exp.h"
-#include "vdt/log.h"
-#include "vdt/sqrt.h"
+#include <vdt/cos.h>
+#include <vdt/exp.h>
+#include <vdt/log.h>
+#include <vdt/sin.h>
+#include <vdt/sqrt.h>
 
-namespace RooBatchCompute{
+namespace RooBatchCompute {
 
-inline double fast_exp(double x) {
-  return vdt::fast_exp(x);
+inline double fast_exp(double x)
+{
+   return vdt::fast_exp(x);
 }
 
-inline double fast_log(double x) {
-  return vdt::fast_log(x);
+inline double fast_sin(double x)
+{
+   return vdt::fast_sin(x);
 }
 
-inline double fast_isqrt(double x) {
-  return vdt::fast_isqrt(x);
+inline double fast_cos(double x)
+{
+   return vdt::fast_cos(x);
 }
 
+inline double fast_log(double x)
+{
+   return vdt::fast_log(x);
 }
+
+inline double fast_isqrt(double x)
+{
+   return vdt::fast_isqrt(x);
+}
+
+} // namespace RooBatchCompute
 
 #else
 #include <cmath>
 
-namespace RooBatchCompute{
+namespace RooBatchCompute {
 
-__roodevice__ inline double fast_exp(double x) {
-  return std::exp(x);
+__roodevice__ inline double fast_exp(double x)
+{
+   return std::exp(x);
 }
 
-__roodevice__ inline double fast_log(double x) {
-  return std::log(x);
+__roodevice__ inline double fast_sin(double x)
+{
+   return std::sin(x);
 }
 
-__roodevice__ inline double fast_isqrt(double x) {
-  return 1/std::sqrt(x);
+__roodevice__ inline double fast_cos(double x)
+{
+   return std::cos(x);
 }
 
+__roodevice__ inline double fast_log(double x)
+{
+   return std::log(x);
 }
+
+__roodevice__ inline double fast_isqrt(double x)
+{
+   return 1. / std::sqrt(x);
+}
+
+} // namespace RooBatchCompute
 
 #endif // defined(R__HAS_VDT) && !defined(__CUDACC__)
 

--- a/roofit/batchcompute/src/ComputeFunctions.cxx
+++ b/roofit/batchcompute/src/ComputeFunctions.cxx
@@ -288,6 +288,13 @@ __rooglobal__ void computeChiSquare(BatchesHandle batches)
    }
 }
 
+__rooglobal__ void computeDeltaFunction(BatchesHandle batches)
+{
+   for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
+      batches._output[i] = 0.0 + (batches[0][i] == 1.0);
+   }
+}
+
 __rooglobal__ void computeDstD0BG(BatchesHandle batches)
 {
    Batch DM = batches[0], DM0 = batches[1], C = batches[2], A = batches[3], B = batches[4];
@@ -341,6 +348,13 @@ __rooglobal__ void computeGaussian(BatchesHandle batches)
       const double arg = x[i] - mean[i];
       const double halfBySigmaSq = -0.5 / (sigma[i] * sigma[i]);
       batches._output[i] = fast_exp(arg * arg * halfBySigmaSq);
+   }
+}
+
+__rooglobal__ void computeIdentity(BatchesHandle batches)
+{
+   for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
+      batches._output[i] = batches[0][i];
    }
 }
 
@@ -574,17 +588,116 @@ __rooglobal__ void computePolynomial(BatchesHandle batches)
 __rooglobal__ void computeProdPdf(BatchesHandle batches)
 {
    const int nPdfs = batches.extraArg(0);
-   for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
+   for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
       batches._output[i] = 1.;
-   for (int pdf = 0; pdf < nPdfs; pdf++)
-      for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
+   }
+   for (int pdf = 0; pdf < nPdfs; pdf++) {
+      for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
          batches._output[i] *= batches[pdf][i];
+      }
+   }
 }
 
 __rooglobal__ void computeRatio(BatchesHandle batches)
 {
-   for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
+   for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
       batches._output[i] = batches[0][i] / batches[1][i];
+   }
+}
+
+__rooglobal__ void computeTruthModelExpBasis(BatchesHandle batches)
+{
+
+   const bool isMinus = batches.extraArg(0) < 0.0;
+   const bool isPlus = batches.extraArg(0) > 0.0;
+   for (std::size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
+      double x = batches[0][i];
+      // Enforce sign compatibility
+      const bool isOutOfSign = (isMinus && x > 0.0) || (isPlus && x < 0.0);
+      batches._output[i] = isOutOfSign ? 0.0 : fast_exp(-std::abs(x) / batches[1][i]);
+   }
+}
+
+__rooglobal__ void computeTruthModelSinBasis(BatchesHandle batches)
+{
+   const bool isMinus = batches.extraArg(0) < 0.0;
+   const bool isPlus = batches.extraArg(0) > 0.0;
+   for (std::size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
+      double x = batches[0][i];
+      // Enforce sign compatibility
+      const bool isOutOfSign = (isMinus && x > 0.0) || (isPlus && x < 0.0);
+      batches._output[i] = isOutOfSign ? 0.0 : fast_exp(-std::abs(x) / batches[1][i]) * fast_sin(x * batches[2][i]);
+   }
+}
+
+__rooglobal__ void computeTruthModelCosBasis(BatchesHandle batches)
+{
+   const bool isMinus = batches.extraArg(0) < 0.0;
+   const bool isPlus = batches.extraArg(0) > 0.0;
+   for (std::size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
+      double x = batches[0][i];
+      // Enforce sign compatibility
+      const bool isOutOfSign = (isMinus && x > 0.0) || (isPlus && x < 0.0);
+      batches._output[i] = isOutOfSign ? 0.0 : fast_exp(-std::abs(x) / batches[1][i]) * fast_cos(x * batches[2][i]);
+   }
+}
+
+__rooglobal__ void computeTruthModelLinBasis(BatchesHandle batches)
+{
+   const bool isMinus = batches.extraArg(0) < 0.0;
+   const bool isPlus = batches.extraArg(0) > 0.0;
+   for (std::size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
+      double x = batches[0][i];
+      // Enforce sign compatibility
+      const bool isOutOfSign = (isMinus && x > 0.0) || (isPlus && x < 0.0);
+      if (isOutOfSign) {
+         batches._output[i] = 0.0;
+      } else {
+         const double tscaled = std::abs(x) / batches[1][i];
+         batches._output[i] = fast_exp(-tscaled) * tscaled;
+      }
+   }
+}
+
+__rooglobal__ void computeTruthModelQuadBasis(BatchesHandle batches)
+{
+   const bool isMinus = batches.extraArg(0) < 0.0;
+   const bool isPlus = batches.extraArg(0) > 0.0;
+   for (std::size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
+      double x = batches[0][i];
+      // Enforce sign compatibility
+      const bool isOutOfSign = (isMinus && x > 0.0) || (isPlus && x < 0.0);
+      if (isOutOfSign) {
+         batches._output[i] = 0.0;
+      } else {
+         const double tscaled = std::abs(x) / batches[1][i];
+         batches._output[i] = fast_exp(-tscaled) * tscaled * tscaled;
+      }
+   }
+}
+
+__rooglobal__ void computeTruthModelSinhBasis(BatchesHandle batches)
+{
+   const bool isMinus = batches.extraArg(0) < 0.0;
+   const bool isPlus = batches.extraArg(0) > 0.0;
+   for (std::size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
+      double x = batches[0][i];
+      // Enforce sign compatibility
+      const bool isOutOfSign = (isMinus && x > 0.0) || (isPlus && x < 0.0);
+      batches._output[i] = isOutOfSign ? 0.0 : fast_exp(-std::abs(x) / batches[1][i]) * sinh(x * batches[2][i] * 0.5);
+   }
+}
+
+__rooglobal__ void computeTruthModelCoshBasis(BatchesHandle batches)
+{
+   const bool isMinus = batches.extraArg(0) < 0.0;
+   const bool isPlus = batches.extraArg(0) > 0.0;
+   for (std::size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
+      double x = batches[0][i];
+      // Enforce sign compatibility
+      const bool isOutOfSign = (isMinus && x > 0.0) || (isPlus && x < 0.0);
+      batches._output[i] = isOutOfSign ? 0.0 : fast_exp(-std::abs(x) / batches[1][i]) * cosh(x * batches[2][i] * .5);
+   }
 }
 
 __rooglobal__ void computeVoigtian(BatchesHandle batches)
@@ -603,7 +716,7 @@ __rooglobal__ void computeVoigtian(BatchesHandle batches)
          batches._output[i] = invSqrt2 / S[i];
    }
 
-   for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
+   for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
       if (S[i] != 0.0 && W[i] != 0.0) {
          if (batches._output[i] < 0)
             batches._output[i] = -batches._output[i];
@@ -611,19 +724,45 @@ __rooglobal__ void computeVoigtian(BatchesHandle batches)
          std::complex<double> z(batches._output[i] * (X[i] - M[i]), factor * batches._output[i] * W[i]);
          batches._output[i] *= faddeeva_impl::faddeeva(z).real();
       }
+   }
 }
 
 /// Returns a std::vector of pointers to the compute functions in this file.
 std::vector<void (*)(BatchesHandle)> getFunctions()
 {
-   return {computeAddPdf,      computeArgusBG,    computeBMixDecay,
-           computeBernstein,   computeBifurGauss, computeBreitWigner,
-           computeBukin,       computeCBShape,    computeChebychev,
-           computeChiSquare,   computeDstD0BG,    computeExponential,
-           computeGamma,       computeGaussian,   computeJohnson,
-           computeLandau,      computeLognormal,  computeNegativeLogarithms,
-           computeNovosibirsk, computePoisson,    computePolynomial,
-           computeProdPdf,     computeRatio,      computeVoigtian};
+   return {computeAddPdf,
+           computeArgusBG,
+           computeBMixDecay,
+           computeBernstein,
+           computeBifurGauss,
+           computeBreitWigner,
+           computeBukin,
+           computeCBShape,
+           computeChebychev,
+           computeChiSquare,
+           computeDeltaFunction,
+           computeDstD0BG,
+           computeExponential,
+           computeGamma,
+           computeGaussian,
+           computeIdentity,
+           computeJohnson,
+           computeLandau,
+           computeLognormal,
+           computeNegativeLogarithms,
+           computeNovosibirsk,
+           computePoisson,
+           computePolynomial,
+           computeProdPdf,
+           computeRatio,
+           computeTruthModelExpBasis,
+           computeTruthModelSinBasis,
+           computeTruthModelCosBasis,
+           computeTruthModelLinBasis,
+           computeTruthModelQuadBasis,
+           computeTruthModelSinhBasis,
+           computeTruthModelCoshBasis,
+           computeVoigtian};
 }
 } // End namespace RF_ARCH
 } // End namespace RooBatchCompute

--- a/roofit/roofitcore/inc/RooTruthModel.h
+++ b/roofit/roofitcore/inc/RooTruthModel.h
@@ -53,6 +53,9 @@ public:
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
   double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
 
+  void computeBatch(cudaStream_t*, double* output, size_t size, RooFit::Detail::DataMap const&) const override;
+  inline bool canComputeBatchWithCuda() const override { return true; }
+
 protected:
   double evaluate() const override ;
   void changeBasis(RooFormulaVar* basis) override ;

--- a/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
@@ -313,8 +313,8 @@ bool RooAbsAnaConvPdf::isDirectGenSafe(const RooAbsArg& arg) const
 
 RooAbsRealLValue* RooAbsAnaConvPdf::convVar()
 {
-  RooResolutionModel* conv = (RooResolutionModel*) _convSet.at(0) ;
-  if (!conv) return 0 ;
+  auto* conv = static_cast<RooResolutionModel*>(_convSet.at(0));
+  if (!conv) return nullptr;
   return &conv->convVar() ;
 }
 
@@ -488,7 +488,7 @@ double RooAbsAnaConvPdf::analyticalIntegralWN(Int_t code, const RooArgSet* normS
     double integral(0) ;
     const TNamed *_rangeName = RooNameReg::ptr(rangeName);
     for (auto convArg : _convSet) {
-      auto conv = static_cast<RooResolutionModel*>(convArg);
+      auto conv = static_cast<RooAbsPdf*>(convArg);
       double coef = getCoefNorm(index++,intCoefSet,_rangeName) ;
       //cout << "coefInt[" << index << "] = " << coef << " " ; intCoefSet->Print("1") ;
       if (coef!=0) {
@@ -506,7 +506,7 @@ double RooAbsAnaConvPdf::analyticalIntegralWN(Int_t code, const RooArgSet* normS
     double norm(0) ;
     const TNamed *_rangeName = RooNameReg::ptr(rangeName);
     for (auto convArg : _convSet) {
-      auto conv = static_cast<RooResolutionModel*>(convArg);
+      auto conv = static_cast<RooAbsPdf*>(convArg);
 
       double coefInt = getCoefNorm(index,intCoefSet,_rangeName) ;
       //cout << "coefInt[" << index << "] = " << coefInt << "*" << term << " " << (intCoefSet?*intCoefSet:RooArgSet()) << endl ;
@@ -657,7 +657,7 @@ void RooAbsAnaConvPdf::printMultiline(ostream& os, Int_t contents, bool verbose,
   RooAbsPdf::printMultiline(os,contents,verbose,indent);
 
   os << indent << "--- RooAbsAnaConvPdf ---" << endl;
-  for (auto * conv : static_range_cast<RooResolutionModel*>(_convSet)) {
+  for (RooAbsArg * conv : _convSet) {
     conv->printMultiline(os,contents,verbose,indent) ;
   }
 }

--- a/roofit/roofitcore/src/RooTruthModel.cxx
+++ b/roofit/roofitcore/src/RooTruthModel.cxx
@@ -78,28 +78,33 @@ RooTruthModel::~RooTruthModel()
 
 Int_t RooTruthModel::basisCode(const char* name) const
 {
-  // Check for optimized basis functions
-  if (!TString("exp(-@0/@1)").CompareTo(name)) return expBasisPlus ;
-  if (!TString("exp(@0/@1)").CompareTo(name)) return expBasisMinus ;
-  if (!TString("exp(-abs(@0)/@1)").CompareTo(name)) return expBasisSum ;
-  if (!TString("exp(-@0/@1)*sin(@0*@2)").CompareTo(name)) return sinBasisPlus ;
-  if (!TString("exp(@0/@1)*sin(@0*@2)").CompareTo(name)) return sinBasisMinus ;
-  if (!TString("exp(-abs(@0)/@1)*sin(@0*@2)").CompareTo(name)) return sinBasisSum ;
-  if (!TString("exp(-@0/@1)*cos(@0*@2)").CompareTo(name)) return cosBasisPlus ;
-  if (!TString("exp(@0/@1)*cos(@0*@2)").CompareTo(name)) return cosBasisMinus ;
-  if (!TString("exp(-abs(@0)/@1)*cos(@0*@2)").CompareTo(name)) return cosBasisSum ;
-  if (!TString("(@0/@1)*exp(-@0/@1)").CompareTo(name)) return linBasisPlus ;
-  if (!TString("(@0/@1)*(@0/@1)*exp(-@0/@1)").CompareTo(name)) return quadBasisPlus ;
-  if (!TString("exp(-@0/@1)*cosh(@0*@2/2)").CompareTo(name)) return coshBasisPlus;
-  if (!TString("exp(@0/@1)*cosh(@0*@2/2)").CompareTo(name)) return coshBasisMinus;
-  if (!TString("exp(-abs(@0)/@1)*cosh(@0*@2/2)").CompareTo(name)) return coshBasisSum;
-  if (!TString("exp(-@0/@1)*sinh(@0*@2/2)").CompareTo(name)) return sinhBasisPlus;
-  if (!TString("exp(@0/@1)*sinh(@0*@2/2)").CompareTo(name)) return sinhBasisMinus;
-  if (!TString("exp(-abs(@0)/@1)*sinh(@0*@2/2)").CompareTo(name)) return sinhBasisSum;
+   std::string str = name;
 
-  // Truth model is delta function, i.e. convolution integral
-  // is basis function, therefore we can handle any basis function
-  return genericBasis ;
+   // Remove whitespaces from the input string
+   str.erase(remove(str.begin(),str.end(),' '),str.end());
+
+   // Check for optimized basis functions
+   if (str == "exp(-@0/@1)") return expBasisPlus ;
+   if (str == "exp(@0/@1)") return expBasisMinus ;
+   if (str == "exp(-abs(@0)/@1)") return expBasisSum ;
+   if (str == "exp(-@0/@1)*sin(@0*@2)") return sinBasisPlus ;
+   if (str == "exp(@0/@1)*sin(@0*@2)") return sinBasisMinus ;
+   if (str == "exp(-abs(@0)/@1)*sin(@0*@2)") return sinBasisSum ;
+   if (str == "exp(-@0/@1)*cos(@0*@2)") return cosBasisPlus ;
+   if (str == "exp(@0/@1)*cos(@0*@2)") return cosBasisMinus ;
+   if (str == "exp(-abs(@0)/@1)*cos(@0*@2)") return cosBasisSum ;
+   if (str == "(@0/@1)*exp(-@0/@1)") return linBasisPlus ;
+   if (str == "(@0/@1)*(@0/@1)*exp(-@0/@1)") return quadBasisPlus ;
+   if (str == "exp(-@0/@1)*cosh(@0*@2/2)") return coshBasisPlus;
+   if (str == "exp(@0/@1)*cosh(@0*@2/2)") return coshBasisMinus;
+   if (str == "exp(-abs(@0)/@1)*cosh(@0*@2/2)") return coshBasisSum;
+   if (str == "exp(-@0/@1)*sinh(@0*@2/2)") return sinhBasisPlus;
+   if (str == "exp(@0/@1)*sinh(@0*@2/2)") return sinhBasisMinus;
+   if (str == "exp(-abs(@0)/@1)*sinh(@0*@2/2)") return sinhBasisSum;
+
+   // Truth model is delta function, i.e. convolution integral is basis
+   // function, therefore we can handle any basis function
+   return genericBasis ;
 }
 
 

--- a/roofit/roofitcore/src/RooTruthModel.cxx
+++ b/roofit/roofitcore/src/RooTruthModel.cxx
@@ -104,31 +104,45 @@ Int_t RooTruthModel::basisCode(const char* name) const
 
 
 
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Changes associated bases function to 'inBasis'
 
 void RooTruthModel::changeBasis(RooFormulaVar* inBasis)
 {
-  // Process change basis function. Since we actually
-  // evaluate the basis function object, we need to
-  // adjust our client-server links to the basis function here
+   // Remove client-server link to old basis
+   if (_basis) {
+      if (_basisCode == genericBasis) {
+         // In the case of a generic basis, we evaluate it directly, so the
+         // basis was a direct server.
+         removeServer(*_basis);
+      } else {
+         for (RooAbsArg *basisServer : _basis->servers()) {
+            removeServer(*basisServer);
+         }
+      }
 
-  // Remove client-server link to old basis
-  if (_basis) {
-    removeServer(*_basis) ;
-  }
+      if (_ownBasis) {
+         delete _basis;
+      }
+   }
+   _ownBasis = false;
 
-  // Change basis pointer and update client-server link
-  _basis = inBasis ;
-  if (_basis) {
-    addServer(*_basis,true,false) ;
-  }
+   _basisCode = inBasis ? basisCode(inBasis->GetTitle()) : 0;
 
-  _basisCode = inBasis?basisCode(inBasis->GetTitle()):0 ;
+   // Change basis pointer and update client-server link
+   _basis = inBasis;
+   if (_basis) {
+      if (_basisCode == genericBasis) {
+         // Since we actually evaluate the basis function object, we need to
+         // adjust our client-server links to the basis function here
+         addServer(*_basis, true, false);
+      } else {
+         for (RooAbsArg *basisServer : _basis->servers()) {
+            addServer(*basisServer, true, false);
+         }
+      }
+   }
 }
-
-
 
 
 

--- a/roofit/roofitcore/src/RooTruthModel.cxx
+++ b/roofit/roofitcore/src/RooTruthModel.cxx
@@ -358,9 +358,8 @@ RooAbsGenContext* RooTruthModel::modelGenContext
 (const RooAbsAnaConvPdf& convPdf, const RooArgSet &vars, const RooDataSet *prototype,
  const RooArgSet* auxProto, bool verbose) const
 {
-  RooArgSet forceDirect(convVar()) ;
-  return new RooGenContext(dynamic_cast<const RooAbsPdf&>(convPdf), vars, prototype,
-                           auxProto, verbose, &forceDirect) ;
+   RooArgSet forceDirect(convVar()) ;
+   return new RooGenContext(convPdf, vars, prototype, auxProto, verbose, &forceDirect);
 }
 
 

--- a/test/stressRooFit_tests.h
+++ b/test/stressRooFit_tests.h
@@ -4638,22 +4638,18 @@ public:
   RooRealVar t("t","time",-1.,15.);
   RooRealVar cosa("cosa","cos(alpha)",-1.,1.);
 
-  // Use RooTruthModel to obtain compiled implementation of sinh/cosh modulated decay functions
-  RooRealVar tau("tau","#tau",1.5);
+  RooRealVar tau("tau", "#tau", 1.5);
   RooRealVar deltaGamma("deltaGamma","deltaGamma", 0.3);
-  RooTruthModel tm("tm","tm",t) ;
-  RooFormulaVar coshGBasis("coshGBasis","exp(-@0/ @1)*cosh(@0*@2/2)",RooArgList(t,tau,deltaGamma));
-  RooFormulaVar sinhGBasis("sinhGBasis","exp(-@0/ @1)*sinh(@0*@2/2)",RooArgList(t,tau,deltaGamma));
-  std::unique_ptr<RooAbsReal> coshGConv{tm.convolution(&coshGBasis,&t)};
-  std::unique_ptr<RooAbsReal> sinhGConv{tm.convolution(&sinhGBasis,&t)};
+  RooFormulaVar coshG("coshGBasis","exp(-@0/ @1)*cosh(@0*@2/2)", {t,tau,deltaGamma});
+  RooFormulaVar sinhG("sinhGBasis","exp(-@0/ @1)*sinh(@0*@2/2)", {t,tau,deltaGamma});
 
   // Construct polynomial amplitudes in cos(a)
   RooPolyVar poly1("poly1","poly1",cosa,RooArgList(0.5, 0.2, 0.2),0);
   RooPolyVar poly2("poly2","poly2",cosa,RooArgList(1.0, -0.2, 3.0),0);
 
   // Construct 2D amplitude as uncorrelated product of amp(t)*amp(cosa)
-  RooProduct  ampl1("ampl1","amplitude 1",RooArgSet(poly1,*coshGConv));
-  RooProduct  ampl2("ampl2","amplitude 2",RooArgSet(poly2,*sinhGConv));
+  RooProduct  ampl1("ampl1","amplitude 1", {poly1, coshG});
+  RooProduct  ampl2("ampl2","amplitude 2", {poly2, sinhG});
 
 
 

--- a/tutorials/roofit/rf704_amplitudefit.C
+++ b/tutorials/roofit/rf704_amplitudefit.C
@@ -13,7 +13,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooTruthModel.h"
 #include "RooFormulaVar.h"
 #include "RooRealSumPdf.h"
 #include "RooPolyVar.h"
@@ -33,22 +32,18 @@ void rf704_amplitudefit()
    RooRealVar t("t", "time", -1., 15.);
    RooRealVar cosa("cosa", "cos(alpha)", -1., 1.);
 
-   // Use RooTruthModel to obtain compiled implementation of sinh/cosh modulated decay functions
    RooRealVar tau("tau", "#tau", 1.5);
    RooRealVar deltaGamma("deltaGamma", "deltaGamma", 0.3);
-   RooTruthModel truthModel("tm", "tm", t);
-   RooFormulaVar coshGBasis("coshGBasis", "exp(-@0/ @1)*cosh(@0*@2/2)", RooArgList(t, tau, deltaGamma));
-   RooFormulaVar sinhGBasis("sinhGBasis", "exp(-@0/ @1)*sinh(@0*@2/2)", RooArgList(t, tau, deltaGamma));
-   RooAbsReal *coshGConv = truthModel.convolution(&coshGBasis, &t);
-   RooAbsReal *sinhGConv = truthModel.convolution(&sinhGBasis, &t);
+   RooFormulaVar coshG("coshGBasis", "exp(-@0/ @1)*cosh(@0*@2/2)", {t, tau, deltaGamma});
+   RooFormulaVar sinhG("sinhGBasis", "exp(-@0/ @1)*sinh(@0*@2/2)", {t, tau, deltaGamma});
 
    // Construct polynomial amplitudes in cos(a)
-   RooPolyVar poly1("poly1", "poly1", cosa, RooArgList(0.5, 0.2, 0.2), 0);
-   RooPolyVar poly2("poly2", "poly2", cosa, RooArgList(1.0, -0.2, 3.0), 0);
+   RooPolyVar poly1("poly1", "poly1", cosa, RooArgList{0.5, 0.2, 0.2}, 0);
+   RooPolyVar poly2("poly2", "poly2", cosa, RooArgList{1.0, -0.2, 3.0}, 0);
 
    // Construct 2D amplitude as uncorrelated product of amp(t)*amp(cosa)
-   RooProduct ampl1("ampl1", "amplitude 1", RooArgSet(poly1, *coshGConv));
-   RooProduct ampl2("ampl2", "amplitude 2", RooArgSet(poly2, *sinhGConv));
+   RooProduct ampl1("ampl1", "amplitude 1", {poly1, coshG});
+   RooProduct ampl2("ampl2", "amplitude 2", {poly2, sinhG});
 
    // C o n s t r u c t   a m p l i t u d e   s u m   p d f
    // -----------------------------------------------------

--- a/tutorials/roofit/rf704_amplitudefit.py
+++ b/tutorials/roofit/rf704_amplitudefit.py
@@ -18,23 +18,18 @@ import ROOT
 t = ROOT.RooRealVar("t", "time", -1.0, 15.0)
 cosa = ROOT.RooRealVar("cosa", "cos(alpha)", -1.0, 1.0)
 
-# Use ROOT.RooTruthModel to obtain compiled implementation of sinh/cosh
-# modulated decay functions
 tau = ROOT.RooRealVar("tau", "#tau", 1.5)
 deltaGamma = ROOT.RooRealVar("deltaGamma", "deltaGamma", 0.3)
-tm = ROOT.RooTruthModel("tm", "tm", t)
-coshGBasis = ROOT.RooFormulaVar("coshGBasis", "exp(-@0/ @1)*cosh(@0*@2/2)", [t, tau, deltaGamma])
-sinhGBasis = ROOT.RooFormulaVar("sinhGBasis", "exp(-@0/ @1)*sinh(@0*@2/2)", [t, tau, deltaGamma])
-coshGConv = tm.convolution(coshGBasis, t)
-sinhGConv = tm.convolution(sinhGBasis, t)
+coshG = ROOT.RooFormulaVar("coshGBasis", "exp(-@0/ @1)*cosh(@0*@2/2)", [t, tau, deltaGamma])
+sinhG = ROOT.RooFormulaVar("sinhGBasis", "exp(-@0/ @1)*sinh(@0*@2/2)", [t, tau, deltaGamma])
 
 # Construct polynomial amplitudes in cos(a)
 poly1 = ROOT.RooPolyVar("poly1", "poly1", cosa, [0.5, 0.2, 0.2], 0)
 poly2 = ROOT.RooPolyVar("poly2", "poly2", cosa, [1.0, -0.2, 3.0], 0)
 
 # Construct 2D amplitude as uncorrelated product of amp(t)*amp(cosa)
-ampl1 = ROOT.RooProduct("ampl1", "amplitude 1", [poly1, coshGConv])
-ampl2 = ROOT.RooProduct("ampl2", "amplitude 2", [poly2, sinhGConv])
+ampl1 = ROOT.RooProduct("ampl1", "amplitude 1", [poly1, coshG])
+ampl2 = ROOT.RooProduct("ampl2", "amplitude 2", [poly2, sinhG])
 
 # Construct amplitude sum pdf
 # -----------------------------------------------------


### PR DESCRIPTION
1. Don't use RooTruthModel in `rf704_aplitudefit` tutorial
2. Register correct servers in RooTruthModel
3. Ignore whitespaces diffs in RooTruthModel basis code matching
4. Change some casts that were too specialized
5. Implement RooTruthModel in RooBatchCompute library

More detail in the commit descriptions.