### PR TITLE
[6.28] Use non-deprecated API to initialize Python interpreter

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/API.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/API.cxx
@@ -49,7 +49,14 @@ static bool Initialize()
 #if PY_VERSION_HEX < 0x03020000
         PyEval_InitThreads();
 #endif
+#if PY_VERSION_HEX < 0x03080000
         Py_Initialize();
+#else
+        PyConfig config;
+        PyConfig_InitPythonConfig(&config);
+        PyConfig_SetString(&config, &config.program_name, L"cppyy");
+        Py_InitializeFromConfig(&config);
+#endif
 #if PY_VERSION_HEX >= 0x03020000
 #if PY_VERSION_HEX < 0x03090000
 	PyEval_InitThreads();
@@ -66,11 +73,12 @@ static bool Initialize()
    // set the command line arguments on python's sys.argv
 #if PY_VERSION_HEX < 0x03000000
         char* argv[] = {const_cast<char*>("cppyy")};
-#else
+#elif PY_VERSION_HEX < 0x03080000
         wchar_t* argv[] = {const_cast<wchar_t*>(L"cppyy")};
 #endif
+#if PY_VERSION_HEX < 0x03080000
         PySys_SetArgv(sizeof(argv)/sizeof(argv[0]), argv);
-
+#endif
     // force loading of the cppyy module
         PyRun_SimpleString(const_cast<char*>("import cppyy"));
     }

--- a/bindings/pyroot/cppyy/patches/PyROOT-Use-non-deprecated-API-to-initialize-Python.patch
+++ b/bindings/pyroot/cppyy/patches/PyROOT-Use-non-deprecated-API-to-initialize-Python.patch
@@ -1,0 +1,48 @@
+From 202d3c2f2eda6026d7b762612093368fb61b3061 Mon Sep 17 00:00:00 2001
+From: Vincenzo Eduardo Padulano <v.e.padulano@gmail.com>
+Date: Tue, 31 Jan 2023 19:18:16 +0100
+Subject: [PATCH] [PyROOT] Use non-deprecated API to initialize Python
+ interpreter
+
+Taken from part of https://github.com/wlav/CPyCppyy/commit/64fd89050a66bf8cb119f236cadd365efa07b005
+---
+ bindings/pyroot/cppyy/CPyCppyy/src/API.cxx | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/bindings/pyroot/cppyy/CPyCppyy/src/API.cxx b/bindings/pyroot/cppyy/CPyCppyy/src/API.cxx
+index 0cc4c8247b..24959b61c3 100644
+--- a/bindings/pyroot/cppyy/CPyCppyy/src/API.cxx
++++ b/bindings/pyroot/cppyy/CPyCppyy/src/API.cxx
+@@ -49,7 +49,14 @@ static bool Initialize()
+ #if PY_VERSION_HEX < 0x03020000
+         PyEval_InitThreads();
+ #endif
++#if PY_VERSION_HEX < 0x03080000
+         Py_Initialize();
++#else
++        PyConfig config;
++        PyConfig_InitPythonConfig(&config);
++        PyConfig_SetString(&config, &config.program_name, L"cppyy");
++        Py_InitializeFromConfig(&config);
++#endif
+ #if PY_VERSION_HEX >= 0x03020000
+ #if PY_VERSION_HEX < 0x03090000
+ 	PyEval_InitThreads();
+@@ -66,11 +73,12 @@ static bool Initialize()
+    // set the command line arguments on python's sys.argv
+ #if PY_VERSION_HEX < 0x03000000
+         char* argv[] = {const_cast<char*>("cppyy")};
+-#else
++#elif PY_VERSION_HEX < 0x03080000
+         wchar_t* argv[] = {const_cast<wchar_t*>(L"cppyy")};
+ #endif
++#if PY_VERSION_HEX < 0x03080000
+         PySys_SetArgv(sizeof(argv)/sizeof(argv[0]), argv);
+-
++#endif
+     // force loading of the cppyy module
+         PyRun_SimpleString(const_cast<char*>("import cppyy"));
+     }
+-- 
+2.39.0
+


### PR DESCRIPTION
Backport of #12189 