### PR TITLE
[rmkdepend] Work around GCC format truncation warning:

### DIFF
--- a/build/rmkdepend/include.c
+++ b/build/rmkdepend/include.c
@@ -299,11 +299,11 @@ struct inclist *inc_path(char *file, char *include, boolean dot) {
     */
    if (!found)
       for (pp = includedirs; *pp; pp++) {
-         if (strlen(*pp) + strlen(include) + 2 > sizeof(path)) {
+         int retlen = snprintf(path, BUFSIZ, "%s/%s", *pp, include);
+         if (retlen <= 0 || BUFSIZ <= retlen) {
             warning1("\t%s/%s too long\n", *pp, include);
             continue;
          }
-         snprintf(path, BUFSIZ, "%s/%s", *pp, include);
          remove_dotdot(path);
 #ifdef _WIN32
          if (stat(path, &st) == 0 && (st.st_mode & S_IFREG)) {

--- a/build/rmkdepend/include.c
+++ b/build/rmkdepend/include.c
@@ -300,7 +300,7 @@ struct inclist *inc_path(char *file, char *include, boolean dot) {
    if (!found)
       for (pp = includedirs; *pp; pp++) {
          int retlen = snprintf(path, BUFSIZ, "%s/%s", *pp, include);
-         if (retlen <= 0 || BUFSIZ <= retlen) {
+         if (retlen <= 0 || BUFSIZ < retlen) {
             warning1("\t%s/%s too long\n", *pp, include);
             continue;
          }


### PR DESCRIPTION
```
/home/vpadulan/programs/rootproject/rootsrc/build/rmkdepend/include.c:306:37: warning: ‘%s’ directive output may be truncated writing up to 8190 bytes into a region of size between 1 and 8191 [-Wformat-truncation=]
  306 |          snprintf(path, BUFSIZ, "%s/%s", *pp, include);
```
