### PR TITLE
[CI] load openstack credentials from file

### DIFF
--- a/.github/workflows/buildroot.yml
+++ b/.github/workflows/buildroot.yml
@@ -50,13 +50,6 @@ on:
         default: true
 
 env:
-  OS_APPLICATION_CREDENTIAL_ID: '7f5b64a265244623a3a933308569bdba'
-  OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
-  OS_AUTH_TYPE: 'v3applicationcredential'
-  OS_AUTH_URL: 'https://keystone.cern.ch/v3'
-  OS_IDENTITY_API_VERSION: 3
-  OS_INTERFACE: 'public'
-  OS_REGION_NAME: 'cern'
   PYTHONUNBUFFERED: true
 
 jobs:
@@ -72,15 +65,9 @@ jobs:
 
     container:
       image: ghcr.io/olemorud/${{ matrix.image }}:buildready
-      options: '--security-opt label=disable'
+      options: '--security-opt label=disable
+                -v /home/rootci/clouds.yaml:/etc/openstack/clouds.yaml:ro'
       env: # S3 storage
-        OS_APPLICATION_CREDENTIAL_ID: '7f5b64a265244623a3a933308569bdba'
-        OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
-        OS_AUTH_TYPE: 'v3applicationcredential'
-        OS_AUTH_URL: 'https://keystone.cern.ch/v3'
-        OS_IDENTITY_API_VERSION: 3
-        OS_INTERFACE: 'public'
-        OS_REGION_NAME: 'cern'
         PYTHONUNBUFFERED: true
     
     steps:

--- a/.github/workflows/rootci-installers/build_root.py
+++ b/.github/workflows/rootci-installers/build_root.py
@@ -108,7 +108,9 @@ def main():
     s3_prefix = f'{platform}/{base_ref}/{buildtype}/{option_hash}'
 
     print("\nEstablishing s3 connection")
-    connection = openstack.connect('envvars')
+
+    connection = openstack.connect(cloud=None) # Will look for /etc/openstack/clouds.yaml
+
     # without openstack we can't run test workflow, might as well give up here ¯\_(ツ)_/¯
     if not connection:
         die(msg="Could not connect to OpenStack")


### PR DESCRIPTION
[skip-ci]

# This Pull request:

Makes the CI load OpenStack object-store credentials from files on runners instead of using GitHub secrets.

When `pull_request` is a workflow trigger, the job can't access secrets, which means that the S3 secret token is unavailable. Adding S3 credentials to the runners themselves solves this issue.

The OpenStack credentials are defined [here](https://gitlab.cern.ch/ai/it-puppet-hostgroup-lcgapp/-/blob/rootci_test/code/manifests/build/root.pp#L43) (using [teigi](https://configdocs.web.cern.ch/secrets/adding.html))

If a malicious actor makes a PR with a job to print the credentials, or to upload a malicious artifact, it would still have to be approved by a maintainer.

A safer alternative is not allowing pull request jobs to upload artifacts at all but then we can't run tests in a separate job. It would also cause builds to take more time on average because the object storage will be less populated.


## Checklist:

- [x] tested changes locally

