### PR TITLE
[RF] LikelihoodJob improved precision

### DIFF
--- a/roofit/multiprocess/src/Job.cxx
+++ b/roofit/multiprocess/src/Job.cxx
@@ -92,7 +92,9 @@ namespace MultiProcess {
 
 Job::Job() : id_(JobManager::add_job_object(this)) {}
 
-Job::Job(const Job &other) : id_(JobManager::add_job_object(this)), _manager(other._manager) {}
+Job::Job(const Job &other) : id_(JobManager::add_job_object(this)), state_id_(other.state_id_), _manager(other._manager)
+{
+}
 
 Job::~Job()
 {

--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -147,6 +147,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     RooFit/TestStatistics/RooSumL.h
     RooFit/TestStatistics/RooUnbinnedL.h
     RooFit/TestStatistics/buildLikelihood.h
+    RooFit/TestStatistics/SharedOffset.h
     RooFitLegacy/RooCatTypeLegacy.h
     RooFitLegacy/RooCategorySharedProperties.h
     RooFitLegacy/RooTreeData.h
@@ -455,6 +456,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     src/TestStatistics/RooSumL.cxx
     src/TestStatistics/RooUnbinnedL.cxx
     src/TestStatistics/buildLikelihood.cxx
+    src/TestStatistics/SharedOffset.cxx
     ${LegacyEvalBackendSources}
     ${RooFitMPTestStatisticsSources}
   DICTIONARY_OPTIONS

--- a/roofit/roofitcore/inc/RooFit/TestStatistics/LikelihoodGradientWrapper.h
+++ b/roofit/roofitcore/inc/RooFit/TestStatistics/LikelihoodGradientWrapper.h
@@ -13,9 +13,12 @@
 #ifndef ROOT_ROOFIT_TESTSTATISTICS_LikelihoodGradientWrapper
 #define ROOT_ROOFIT_TESTSTATISTICS_LikelihoodGradientWrapper
 
+#include "RooFit/TestStatistics/SharedOffset.h"
+
 #include <Fit/ParameterSettings.h>
 #include <Math/IFunctionfwd.h>
 #include "Math/MinimizerOptions.h"
+#include "Math/Util.h"
 
 #include <vector>
 #include <memory> // shared_ptr
@@ -33,16 +36,20 @@ struct WrapperCalculationCleanFlags;
 enum class LikelihoodGradientMode { multiprocess };
 
 class LikelihoodGradientWrapper {
-public:
+protected:
    LikelihoodGradientWrapper(std::shared_ptr<RooAbsL> likelihood,
                              std::shared_ptr<WrapperCalculationCleanFlags> calculation_is_clean, std::size_t N_dim,
-                             RooMinimizer *minimizer);
+                             RooMinimizer *minimizer, SharedOffset offset);
+
+public:
    virtual ~LikelihoodGradientWrapper() = default;
-   virtual LikelihoodGradientWrapper *clone() const = 0;
+   LikelihoodGradientWrapper(const LikelihoodGradientWrapper &) = delete;
+   LikelihoodGradientWrapper &operator=(const LikelihoodGradientWrapper &) = delete;
 
    static std::unique_ptr<LikelihoodGradientWrapper>
    create(LikelihoodGradientMode likelihoodGradientMode, std::shared_ptr<RooAbsL> likelihood,
-          std::shared_ptr<WrapperCalculationCleanFlags> calculationIsClean, std::size_t nDim, RooMinimizer *minimizer);
+          std::shared_ptr<WrapperCalculationCleanFlags> calculationIsClean, std::size_t nDim, RooMinimizer *minimizer,
+          SharedOffset offset);
 
    virtual void fillGradient(double *grad) = 0;
    virtual void
@@ -82,6 +89,7 @@ protected:
    std::shared_ptr<RooAbsL> likelihood_;
    RooMinimizer *minimizer_;
    std::shared_ptr<WrapperCalculationCleanFlags> calculation_is_clean_;
+   SharedOffset shared_offset_;
 };
 
 } // namespace TestStatistics

--- a/roofit/roofitcore/inc/RooFit/TestStatistics/SharedOffset.h
+++ b/roofit/roofitcore/inc/RooFit/TestStatistics/SharedOffset.h
@@ -1,0 +1,36 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2024, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#ifndef ROOT_ROOFIT_TESTSTATISTICS_SHAREDOFFSET_H
+#define ROOT_ROOFIT_TESTSTATISTICS_SHAREDOFFSET_H
+
+#include <Math/Util.h>
+#include <vector>
+#include <memory> // shared_ptr
+
+class SharedOffset {
+public:
+   SharedOffset();
+   using OffsetVec = std::vector<ROOT::Math::KahanSum<double>>;
+
+   void clear();
+   void swap(const std::vector<std::size_t> &component_keys);
+
+   inline OffsetVec &offsets() { return *offsets_; };
+   inline OffsetVec &offsets_save() { return *offsets_save_; };
+
+private:
+   std::shared_ptr<OffsetVec> offsets_;
+   std::shared_ptr<OffsetVec> offsets_save_;
+};
+
+#endif // ROOT_ROOFIT_TESTSTATISTICS_SHAREDOFFSET_H

--- a/roofit/roofitcore/src/TestStatistics/LikelihoodGradientJob.cxx
+++ b/roofit/roofitcore/src/TestStatistics/LikelihoodGradientJob.cxx
@@ -27,27 +27,14 @@ namespace TestStatistics {
 
 LikelihoodGradientJob::LikelihoodGradientJob(std::shared_ptr<RooAbsL> likelihood,
                                              std::shared_ptr<WrapperCalculationCleanFlags> calculation_is_clean,
-                                             std::size_t N_dim, RooMinimizer *minimizer)
-   : LikelihoodGradientWrapper(std::move(likelihood), std::move(calculation_is_clean), N_dim, minimizer),
+                                             std::size_t N_dim, RooMinimizer *minimizer, SharedOffset offset)
+   : LikelihoodGradientWrapper(std::move(likelihood), std::move(calculation_is_clean), N_dim, minimizer,
+                               std::move(offset)),
      grad_(N_dim),
      N_tasks_(N_dim)
 {
-   // Note to future maintainers: take care when storing the minimizer_fcn pointer. The
-   // RooAbsMinimizerFcn subclasses may get cloned inside MINUIT, which means the pointer
-   // should also somehow be updated in this class.
-
    minuit_internal_x_.reserve(N_dim);
-}
-
-LikelihoodGradientJob::LikelihoodGradientJob(const LikelihoodGradientJob &other)
-   : MultiProcess::Job(other), LikelihoodGradientWrapper(other), grad_(other.grad_), gradf_(other.gradf_),
-     N_tasks_(other.N_tasks_), minuit_internal_x_(other.minuit_internal_x_)
-{
-}
-
-LikelihoodGradientJob *LikelihoodGradientJob::clone() const
-{
-   return new LikelihoodGradientJob(*this);
+   offsets_previous_ = shared_offset_.offsets();
 }
 
 void LikelihoodGradientJob::synchronizeParameterSettings(
@@ -135,8 +122,17 @@ void LikelihoodGradientJob::update_workers_state()
    zmq::message_t gradient_message(grad_.begin(), grad_.end());
    zmq::message_t minuit_internal_x_message(minuit_internal_x_.begin(), minuit_internal_x_.end());
    ++state_id_;
-   get_manager()->messenger().publish_from_master_to_workers(id_, state_id_, isCalculating_, std::move(gradient_message),
-                                                             std::move(minuit_internal_x_message));
+
+   if (shared_offset_.offsets() != offsets_previous_) {
+      zmq::message_t offsets_message(shared_offset_.offsets().begin(), shared_offset_.offsets().end());
+      get_manager()->messenger().publish_from_master_to_workers(
+         id_, state_id_, isCalculating_, std::move(gradient_message), std::move(minuit_internal_x_message),
+         std::move(offsets_message));
+      offsets_previous_ = shared_offset_.offsets();
+   } else {
+      get_manager()->messenger().publish_from_master_to_workers(
+         id_, state_id_, isCalculating_, std::move(gradient_message), std::move(minuit_internal_x_message));
+   }
 }
 
 void LikelihoodGradientJob::update_workers_state_isCalculating()
@@ -162,12 +158,24 @@ void LikelihoodGradientJob::update_state()
       std::copy(gradient_message_begin, gradient_message_end, grad_.begin());
 
       auto minuit_internal_x_message = get_manager()->messenger().receive_from_master_on_worker<zmq::message_t>(&more);
-      assert(!more);
       auto minuit_internal_x_message_begin = minuit_internal_x_message.data<double>();
       auto minuit_internal_x_message_end =
          minuit_internal_x_message_begin + minuit_internal_x_message.size() / sizeof(double);
       std::copy(minuit_internal_x_message_begin, minuit_internal_x_message_end, minuit_internal_x_.begin());
 
+      if (more) {
+         // offsets also incoming
+         auto offsets_message = get_manager()->messenger().receive_from_master_on_worker<zmq::message_t>(&more);
+         assert(!more);
+         auto offsets_message_begin = offsets_message.data<ROOT::Math::KahanSum<double>>();
+         std::size_t N_offsets = offsets_message.size() / sizeof(ROOT::Math::KahanSum<double>);
+         shared_offset_.offsets().reserve(N_offsets);
+         auto offsets_message_end = offsets_message_begin + N_offsets;
+         std::copy(offsets_message_begin, offsets_message_end, shared_offset_.offsets().begin());
+      }
+
+      // note: the next call must stay after the (possible) update of the offset, because it
+      // calls the likelihood function, so the offset must be correct at this point
       gradf_.SetupDifferentiate(minimizer_->getMultiGenFcn(), minuit_internal_x_.data(),
                                 minimizer_->fitter()->Config().ParamsSettings());
    }
@@ -229,9 +237,13 @@ void LikelihoodGradientJob::fillGradientWithPrevResult(double *grad, double *pre
       }
 
       if (!calculation_is_clean_->gradient) {
-         if (RooFit::MultiProcess::Config::getTimingAnalysis()) RooFit::MultiProcess::ProcessTimer::start_timer("master:gradient");
+         if (RooFit::MultiProcess::Config::getTimingAnalysis()) {
+            RooFit::MultiProcess::ProcessTimer::start_timer("master:gradient");
+         }
          calculate_all();
-         if (RooFit::MultiProcess::Config::getTimingAnalysis()) RooFit::MultiProcess::ProcessTimer::end_timer("master:gradient");
+         if (RooFit::MultiProcess::Config::getTimingAnalysis()) {
+            RooFit::MultiProcess::ProcessTimer::end_timer("master:gradient");
+         }
       }
 
       // put the results from _grad into *grad

--- a/roofit/roofitcore/src/TestStatistics/LikelihoodGradientJob.h
+++ b/roofit/roofitcore/src/TestStatistics/LikelihoodGradientJob.h
@@ -29,9 +29,7 @@ class LikelihoodGradientJob : public MultiProcess::Job, public LikelihoodGradien
 public:
    LikelihoodGradientJob(std::shared_ptr<RooAbsL> likelihood,
                          std::shared_ptr<WrapperCalculationCleanFlags> calculation_is_clean, std::size_t N_dim,
-                         RooMinimizer *minimizer);
-   LikelihoodGradientJob *clone() const override;
-   LikelihoodGradientJob(const LikelihoodGradientJob &other);
+                         RooMinimizer *minimizer, SharedOffset offset);
 
    void fillGradient(double *grad) override;
    void fillGradientWithPrevResult(double *grad, double *previous_grad, double *previous_g2,
@@ -87,6 +85,8 @@ private:
    std::vector<double> minuit_internal_x_;
 
    mutable bool isCalculating_ = false;
+
+   SharedOffset::OffsetVec offsets_previous_;
 };
 
 } // namespace TestStatistics

--- a/roofit/roofitcore/src/TestStatistics/LikelihoodJob.cxx
+++ b/roofit/roofitcore/src/TestStatistics/LikelihoodJob.cxx
@@ -12,6 +12,7 @@
 
 #include "LikelihoodJob.h"
 
+#include "LikelihoodSerial.h"
 #include "RooFit/MultiProcess/JobManager.h"
 #include "RooFit/MultiProcess/ProcessManager.h"
 #include "RooFit/MultiProcess/Queue.h"
@@ -28,34 +29,15 @@
 namespace RooFit {
 namespace TestStatistics {
 
-LikelihoodJob::LikelihoodJob(
-   std::shared_ptr<RooAbsL> likelihood,
-   std::shared_ptr<WrapperCalculationCleanFlags> calculation_is_clean)
-   : LikelihoodWrapper(std::move(likelihood), std::move(calculation_is_clean)),
+LikelihoodJob::LikelihoodJob(std::shared_ptr<RooAbsL> likelihood,
+                             std::shared_ptr<WrapperCalculationCleanFlags> calculation_is_clean, SharedOffset offset)
+   : LikelihoodWrapper(std::move(likelihood), std::move(calculation_is_clean), std::move(offset)),
      n_event_tasks_(MultiProcess::Config::LikelihoodJob::defaultNEventTasks),
-     n_component_tasks_(MultiProcess::Config::LikelihoodJob::defaultNComponentTasks)
+     n_component_tasks_(MultiProcess::Config::LikelihoodJob::defaultNComponentTasks),
+     likelihood_serial_(likelihood_, calculation_is_clean_, shared_offset_)
 {
    init_vars();
-   // determine likelihood type
-   if (dynamic_cast<RooUnbinnedL *>(likelihood_.get()) != nullptr) {
-      likelihood_type_ = LikelihoodType::unbinned;
-   } else if (dynamic_cast<RooBinnedL *>(likelihood_.get()) != nullptr) {
-      likelihood_type_ = LikelihoodType::binned;
-   } else if (dynamic_cast<RooSumL *>(likelihood_.get()) != nullptr) {
-      likelihood_type_ = LikelihoodType::sum;
-   } else if (dynamic_cast<RooSubsidiaryL *>(likelihood_.get()) != nullptr) {
-      likelihood_type_ = LikelihoodType::subsidiary;
-   } else {
-      throw std::logic_error("in LikelihoodJob constructor: likelihood is not of a valid subclass!");
-   }
-   // Note to future maintainers: take care when storing the minimizer_fcn pointer. The
-   // RooAbsMinimizerFcn subclasses may get cloned inside MINUIT, which means the pointer
-   // should also somehow be updated in this class.
-}
-
-LikelihoodJob *LikelihoodJob::clone() const
-{
-   return new LikelihoodJob(*this);
+   offsets_previous_ = shared_offset_.offsets();
 }
 
 // This is a separate function (instead of just in ctor) for historical reasons.
@@ -84,11 +66,16 @@ void LikelihoodJob::init_vars()
 void LikelihoodJob::update_state()
 {
    if (get_manager()->process_manager().is_worker()) {
-      auto mode = get_manager()->messenger().receive_from_master_on_worker<update_state_mode>();
+      bool more;
+
+      auto mode = get_manager()->messenger().receive_from_master_on_worker<update_state_mode>(&more);
+      assert(more);
+
       switch (mode) {
       case update_state_mode::parameters: {
-         state_id_ = get_manager()->messenger().receive_from_master_on_worker<RooFit::MultiProcess::State>();
-         auto message = get_manager()->messenger().receive_from_master_on_worker<zmq::message_t>();
+         state_id_ = get_manager()->messenger().receive_from_master_on_worker<RooFit::MultiProcess::State>(&more);
+         assert(more);
+         auto message = get_manager()->messenger().receive_from_master_on_worker<zmq::message_t>(&more);
          auto message_begin = message.data<update_state_t>();
          auto message_end = message_begin + message.size() / sizeof(update_state_t);
          std::vector<update_state_t> to_update(message_begin, message_end);
@@ -99,10 +86,23 @@ void LikelihoodJob::update_state()
                rvar->setConstant(static_cast<bool>(item.is_constant));
             }
          }
+
+         if (more) {
+            // offsets also incoming
+            auto offsets_message = get_manager()->messenger().receive_from_master_on_worker<zmq::message_t>(&more);
+            assert(!more);
+            auto offsets_message_begin = offsets_message.data<ROOT::Math::KahanSum<double>>();
+            std::size_t N_offsets = offsets_message.size() / sizeof(ROOT::Math::KahanSum<double>);
+            shared_offset_.offsets().reserve(N_offsets);
+            auto offsets_message_end = offsets_message_begin + N_offsets;
+            std::copy(offsets_message_begin, offsets_message_end, shared_offset_.offsets().begin());
+         }
+
          break;
       }
       case update_state_mode::offsetting: {
-         LikelihoodWrapper::enableOffsetting(get_manager()->messenger().receive_from_master_on_worker<bool>());
+         LikelihoodWrapper::enableOffsetting(get_manager()->messenger().receive_from_master_on_worker<bool>(&more));
+         assert(!more);
          break;
       }
       }
@@ -121,7 +121,6 @@ std::size_t LikelihoodJob::getNEventTasks()
    }
    return val;
 }
-
 
 std::size_t LikelihoodJob::getNComponentTasks()
 {
@@ -163,12 +162,21 @@ void LikelihoodJob::updateWorkersParameters()
             }
          }
       }
-      if (!to_update.empty()) {
+      bool update_offsets = isOffsetting() && shared_offset_.offsets() != offsets_previous_;
+      if (!to_update.empty() || update_offsets) {
          ++state_id_;
          zmq::message_t message(to_update.begin(), to_update.end());
          // always send Job id first! This is used in worker_loop to route the
          // update_state call to the correct Job.
-         get_manager()->messenger().publish_from_master_to_workers(id_, update_state_mode::parameters, state_id_, std::move(message));
+         if (update_offsets) {
+            zmq::message_t offsets_message(shared_offset_.offsets().begin(), shared_offset_.offsets().end());
+            get_manager()->messenger().publish_from_master_to_workers(id_, update_state_mode::parameters, state_id_,
+                                                                      std::move(message), std::move(offsets_message));
+            offsets_previous_ = shared_offset_.offsets();
+         } else {
+            get_manager()->messenger().publish_from_master_to_workers(id_, update_state_mode::parameters, state_id_,
+                                                                      std::move(message));
+         }
       }
    }
 }
@@ -181,6 +189,13 @@ void LikelihoodJob::updateWorkersOffsetting()
 void LikelihoodJob::evaluate()
 {
    if (get_manager()->process_manager().is_master()) {
+      // evaluate the serial likelihood to set the offsets
+      if (do_offset_ && shared_offset_.offsets().empty()) {
+         likelihood_serial_.evaluate();
+         // note: we don't need to get the offsets from the serial likelihood, because they are already coupled through
+         // the shared_ptr
+      }
+
       // update parameters that changed since last calculation (or creation if first time)
       updateWorkersParameters();
 
@@ -194,12 +209,14 @@ void LikelihoodJob::evaluate()
       // wait for task results back from workers to master
       gather_worker_results();
 
-      result_ = ROOT::Math::KahanSum<double>{0.};
-//      printf("Master evaluate: ");
-      for (auto const &item : results_) {
-         result_ += item;
+      // Note: initializing result_ to results_[0] instead of zero-initializing it makes
+      // a difference due to Kahan sum precision. This way, a single-worker run gives
+      // the same result as a run with serial likelihood. Adding the terms to a zero
+      // initial sum can cancel the carry in some cases, causing divergent values.
+      result_ = results_[0];
+      for (auto item_it = results_.cbegin() + 1; item_it != results_.cend(); ++item_it) {
+         result_ += *item_it;
       }
-      result_ = applyOffsetting(result_);
       results_.clear();
    }
 }
@@ -248,6 +265,17 @@ void LikelihoodJob::evaluate_task(std::size_t task)
    case LikelihoodType::unbinned:
    case LikelihoodType::binned: {
       result_ = likelihood_->evaluatePartition({section_first, section_last}, 0, 0);
+      if (do_offset_ && section_last == 1) {
+         // we only subtract at the end of event sections, otherwise the offset is subtracted for each event split
+         result_ -= shared_offset_.offsets()[0];
+      }
+      break;
+   }
+   case LikelihoodType::subsidiary: {
+      result_ = likelihood_->evaluatePartition({0, 1}, 0, 0);
+      if (do_offset_ && offsetting_mode_ == OffsettingMode::full) {
+         result_ -= shared_offset_.offsets()[0];
+      }
       break;
    }
    case LikelihoodType::sum: {
@@ -262,13 +290,19 @@ void LikelihoodJob::evaluate_task(std::size_t task)
             components_last = likelihood_->getNComponents() * (component_task + 1) / getNComponentTasks();
          }
       }
-      result_ = likelihood_->evaluatePartition({section_first, section_last}, components_first, components_last);
-      break;
-   }
 
-   default: {
-      throw std::logic_error(
-         "in LikelihoodJob::evaluate_task: likelihood types other than binned and unbinned not yet implemented!");
+      result_ = ROOT::Math::KahanSum<double>();
+      for (std::size_t comp_ix = components_first; comp_ix < components_last; ++comp_ix) {
+         auto component_result = likelihood_->evaluatePartition({section_first, section_last}, comp_ix, comp_ix + 1);
+         if (do_offset_ && section_last == 1 &&
+             shared_offset_.offsets()[comp_ix] != ROOT::Math::KahanSum<double>(0, 0)) {
+            // we only subtract at the end of event sections, otherwise the offset is subtracted for each event split
+            result_ += (component_result - shared_offset_.offsets()[comp_ix]);
+         } else {
+            result_ += component_result;
+         }
+      }
+
       break;
    }
    }
@@ -276,9 +310,15 @@ void LikelihoodJob::evaluate_task(std::size_t task)
 
 void LikelihoodJob::enableOffsetting(bool flag)
 {
+   likelihood_serial_.enableOffsetting(flag);
    LikelihoodWrapper::enableOffsetting(flag);
    if (RooFit::MultiProcess::JobManager::is_instantiated()) {
-      printf("WARNING: when calling MinuitFcnGrad::setOffsetting after the run has already been started the MinuitFcnGrad::likelihood_in_gradient object (a LikelihoodSerial) on the workers can no longer be updated! This function (LikelihoodJob::enableOffsetting) can in principle be used outside of MinuitFcnGrad, but be aware of this limitation. To do a minimization with a different offsetting setting, please delete all RooFit::MultiProcess based objects so that the forked processes are killed and then set up a new RooMinimizer.\n");
+      printf("WARNING: when calling MinuitFcnGrad::setOffsetting after the run has already been started the "
+             "MinuitFcnGrad::likelihood_in_gradient object (a LikelihoodSerial) on the workers can no longer be "
+             "updated! This function (LikelihoodJob::enableOffsetting) can in principle be used outside of "
+             "MinuitFcnGrad, but be aware of this limitation. To do a minimization with a different offsetting "
+             "setting, please delete all RooFit::MultiProcess based objects so that the forked processes are killed "
+             "and then set up a new RooMinimizer.\n");
       updateWorkersOffsetting();
    }
 }

--- a/roofit/roofitcore/src/TestStatistics/LikelihoodJob.h
+++ b/roofit/roofitcore/src/TestStatistics/LikelihoodJob.h
@@ -16,6 +16,7 @@
 #include "RooFit/MultiProcess/Job.h"
 #include "RooFit/MultiProcess/types.h"
 #include "RooFit/TestStatistics/LikelihoodWrapper.h"
+#include "LikelihoodSerial.h"
 #include "RooArgList.h"
 
 #include "Math/MinimizerOptions.h"
@@ -25,11 +26,12 @@
 namespace RooFit {
 namespace TestStatistics {
 
+class LikelihoodSerial;
+
 class LikelihoodJob : public MultiProcess::Job, public LikelihoodWrapper {
 public:
    LikelihoodJob(std::shared_ptr<RooAbsL> _likelihood,
-                 std::shared_ptr<WrapperCalculationCleanFlags> calculation_is_clean /*, RooMinimizer *minimizer*/);
-   LikelihoodJob *clone() const override;
+                 std::shared_ptr<WrapperCalculationCleanFlags> calculation_is_clean, SharedOffset offset);
 
    void init_vars();
 
@@ -69,7 +71,6 @@ private:
    RooArgList vars_;      // Variables
    RooArgList save_vars_; // Copy of variables
 
-   LikelihoodType likelihood_type_;
    std::size_t n_tasks_at_workers_ = 0;
 
    // warning: don't use the following values directly, use the getters instead!
@@ -77,6 +78,9 @@ private:
    std::size_t n_component_tasks_;
    std::size_t getNEventTasks();
    std::size_t getNComponentTasks();
+
+   SharedOffset::OffsetVec offsets_previous_;
+   LikelihoodSerial likelihood_serial_;
 };
 
 std::ostream &operator<<(std::ostream &out, const LikelihoodJob::update_state_mode value);
@@ -84,4 +88,4 @@ std::ostream &operator<<(std::ostream &out, const LikelihoodJob::update_state_mo
 } // namespace TestStatistics
 } // namespace RooFit
 
-#endif // ROOT_ROOFIT_LikelihoodJob
+#endif // ROOT_ROOFIT_TESTSTATISTICS_LikelihoodJob

--- a/roofit/roofitcore/src/TestStatistics/LikelihoodSerial.cxx
+++ b/roofit/roofitcore/src/TestStatistics/LikelihoodSerial.cxx
@@ -13,10 +13,6 @@
 #include "LikelihoodSerial.h"
 
 #include <RooFit/TestStatistics/RooAbsL.h>
-#include <RooFit/TestStatistics/RooUnbinnedL.h>
-#include <RooFit/TestStatistics/RooBinnedL.h>
-#include <RooFit/TestStatistics/RooSubsidiaryL.h>
-#include <RooFit/TestStatistics/RooSumL.h>
 #include "RooRealVar.h"
 
 namespace RooFit {
@@ -32,25 +28,12 @@ namespace TestStatistics {
  * likelihood object, or to use a higher level entry point like RooAbsPdf::fitTo() or RooAbsPdf::createNLL().
  */
 
-LikelihoodSerial::LikelihoodSerial(std::shared_ptr<RooAbsL> likelihood, std::shared_ptr<WrapperCalculationCleanFlags> calculation_is_clean)
-   : LikelihoodWrapper(std::move(likelihood), std::move(calculation_is_clean))
+LikelihoodSerial::LikelihoodSerial(std::shared_ptr<RooAbsL> likelihood,
+                                   std::shared_ptr<WrapperCalculationCleanFlags> calculation_is_clean,
+                                   SharedOffset offset)
+   : LikelihoodWrapper(std::move(likelihood), std::move(calculation_is_clean), std::move(offset))
 {
    initVars();
-   // determine likelihood type
-   if (dynamic_cast<RooUnbinnedL *>(likelihood_.get()) != nullptr) {
-      likelihood_type = LikelihoodType::unbinned;
-   } else if (dynamic_cast<RooBinnedL *>(likelihood_.get()) != nullptr) {
-      likelihood_type = LikelihoodType::binned;
-   } else if (dynamic_cast<RooSumL *>(likelihood_.get()) != nullptr) {
-      likelihood_type = LikelihoodType::sum;
-   } else if (dynamic_cast<RooSubsidiaryL *>(likelihood_.get()) != nullptr) {
-      likelihood_type = LikelihoodType::subsidiary;
-   } else {
-      throw std::logic_error("in LikelihoodSerial constructor: _likelihood is not of a valid subclass!");
-   }
-   // Note to future maintainers: take care when storing the minimizer_fcn pointer. The
-   // RooAbsMinimizerFcn subclasses may get cloned inside MINUIT, which means the pointer
-   // should also somehow be updated in this class.
 }
 
 /// \brief Helper function for the constructor.
@@ -76,24 +59,42 @@ void LikelihoodSerial::initVars()
    _saveVars.addClone(varList);
 }
 
-void LikelihoodSerial::evaluate() {
-   switch (likelihood_type) {
+void LikelihoodSerial::evaluate()
+{
+   if (do_offset_ && shared_offset_.offsets().empty()) {
+      calculate_offsets();
+   }
+
+   switch (likelihood_type_) {
    case LikelihoodType::unbinned:
    case LikelihoodType::binned: {
       result = likelihood_->evaluatePartition({0, 1}, 0, 0);
+      if (do_offset_) {
+         result -= shared_offset_.offsets()[0];
+      }
+      break;
+   }
+   case LikelihoodType::subsidiary: {
+      result = likelihood_->evaluatePartition({0, 1}, 0, 0);
+      if (do_offset_ && offsetting_mode_ == OffsettingMode::full) {
+         result -= shared_offset_.offsets()[0];
+      }
       break;
    }
    case LikelihoodType::sum: {
-      result = likelihood_->evaluatePartition({0, 1}, 0, likelihood_->getNComponents());
-      break;
-   }
-   default: {
-      throw std::logic_error("in LikelihoodSerial::evaluate_task: likelihood types other than binned, unbinned and simultaneous not yet implemented!");
-      break;
-   }
-   }
+      result = ROOT::Math::KahanSum<double>();
+      for (std::size_t comp_ix = 0; comp_ix < likelihood_->getNComponents(); ++comp_ix) {
+         auto component_result = likelihood_->evaluatePartition({0, 1}, comp_ix, comp_ix + 1);
 
-   result = applyOffsetting(result);
+         if (do_offset_ && shared_offset_.offsets()[comp_ix] != ROOT::Math::KahanSum<double>(0, 0)) {
+            result += (component_result - shared_offset_.offsets()[comp_ix]);
+         } else {
+            result += component_result;
+         }
+      }
+      break;
+   }
+   }
 }
 
 } // namespace TestStatistics

--- a/roofit/roofitcore/src/TestStatistics/LikelihoodSerial.h
+++ b/roofit/roofitcore/src/TestStatistics/LikelihoodSerial.h
@@ -18,16 +18,13 @@
 
 #include "Math/MinimizerOptions.h"
 
-#include <map>
-
 namespace RooFit {
 namespace TestStatistics {
 
 class LikelihoodSerial : public LikelihoodWrapper {
 public:
-   LikelihoodSerial(std::shared_ptr<RooAbsL> likelihood,
-                    std::shared_ptr<WrapperCalculationCleanFlags> calculation_is_clean);
-   inline LikelihoodSerial *clone() const override { return new LikelihoodSerial(*this); }
+   LikelihoodSerial(std::shared_ptr<RooAbsL> _likelihood,
+                    std::shared_ptr<WrapperCalculationCleanFlags> calculation_is_clean, SharedOffset offset);
 
    void initVars();
 
@@ -39,8 +36,6 @@ private:
 
    RooArgList _vars;     ///< Variables
    RooArgList _saveVars; ///< Copy of variables
-
-   LikelihoodType likelihood_type;
 };
 
 } // namespace TestStatistics

--- a/roofit/roofitcore/src/TestStatistics/MinuitFcnGrad.h
+++ b/roofit/roofitcore/src/TestStatistics/MinuitFcnGrad.h
@@ -61,6 +61,9 @@ public:
    inline void setOffsetting(bool flag) override
    {
       applyToLikelihood([&](auto &l) { l.enableOffsetting(flag); });
+      if (!flag) {
+         offsets_reset_ = true;
+      }
    }
 
 private:
@@ -76,8 +79,9 @@ private:
    }
 
    // members
-   std::unique_ptr<LikelihoodWrapper> _likelihood;
-   std::unique_ptr<LikelihoodWrapper> _likelihoodInGradient;
+   // the likelihoods are shared_ptrs because they may point to the same object
+   std::shared_ptr<LikelihoodWrapper> _likelihood;
+   std::shared_ptr<LikelihoodWrapper> _likelihoodInGradient;
    std::unique_ptr<LikelihoodGradientWrapper> _gradient;
    mutable bool _calculatingGradient = false;
 
@@ -85,6 +89,10 @@ private:
 
    mutable std::vector<double> _minuitInternalX;
    mutable std::vector<double> _minuitExternalX;
+   // offsets_reset_ should be reset also when applyWeightSquared is activated in LikelihoodWrappers;
+   // currently setting this is not supported, so it doesn't happen.
+   mutable bool offsets_reset_ = false;
+   void syncOffsets() const;
 
    std::unique_ptr<ROOT::Math::IMultiGradFunction> _multiGenFcn;
 

--- a/roofit/roofitcore/src/TestStatistics/SharedOffset.cxx
+++ b/roofit/roofitcore/src/TestStatistics/SharedOffset.cxx
@@ -1,0 +1,33 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2024, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#include "RooFit/TestStatistics/SharedOffset.h"
+
+SharedOffset::SharedOffset() : offsets_(std::make_shared<OffsetVec>()), offsets_save_(std::make_shared<OffsetVec>()) {}
+
+void SharedOffset::clear()
+{
+   offsets_->clear();
+   offsets_save_->clear();
+}
+
+/// When calculating an unbinned likelihood with square weights applied, a different offset
+/// is necessary. Similar situations may ask for a separate offset as well. This function
+/// switches between the two sets of offset values for the given component keys.
+/// \note Currently we do not recalculate the offset value, so in practice swapped offsets
+///       are zero.
+void SharedOffset::swap(const std::vector<std::size_t> &component_keys)
+{
+   for (auto key : component_keys) {
+      std::swap((*offsets_)[key], (*offsets_save_)[key]);
+   }
+}

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cxx
@@ -13,6 +13,7 @@
  */
 
 #include "RooFit/TestStatistics/LikelihoodGradientWrapper.h"
+#include "RooFit/TestStatistics/SharedOffset.h"
 
 #include "RooRandom.h"
 #include "RooWorkspace.h"
@@ -27,6 +28,8 @@
 #include "RooFit/TestStatistics/buildLikelihood.h"
 #include "RooFit/MultiProcess/JobManager.h"
 #include "RooFit/MultiProcess/Config.h"
+
+#include <ROOT/TestSupport.hxx>
 
 #include "Math/Minimizer.h"
 
@@ -78,7 +81,7 @@ int main(int argc, char **argv)
    return RUN_ALL_TESTS();
 }
 
-class LikelihoodGradientJobTest : public ::testing::TestWithParam<std::tuple<std::size_t, std::size_t>> {};
+class LikelihoodGradientJobTest : public ::testing::TestWithParam<std::tuple<std::size_t, std::size_t, bool>> {};
 
 TEST_P(LikelihoodGradientJobTest, Gaussian1D)
 {
@@ -87,6 +90,15 @@ TEST_P(LikelihoodGradientJobTest, Gaussian1D)
    // parameters
    std::size_t NWorkers = std::get<0>(GetParam());
    std::size_t seed = std::get<1>(GetParam());
+   bool offsetting = std::get<2>(GetParam());
+
+   // in the 1D Gaussian tests, we suppress the positive definiteness
+   // warnings coming from Minuit2 with offsetting; they are errors both
+   // in serial RooFit and in the MultiProcess-enabled back-end
+   ROOT::TestSupport::CheckDiagsRAII checkDiag;
+   if (offsetting) {
+      checkDiag.requiredDiag(kError, "Minuit2", "VariableMetricBuilder Initial matrix not pos.def.");
+   }
 
    RooRandom::randomGenerator()->SetSeed(seed);
 
@@ -108,6 +120,7 @@ TEST_P(LikelihoodGradientJobTest, Gaussian1D)
 
    m0.setStrategy(0);
    m0.setPrintLevel(-1);
+   m0.setOffsetting(offsetting);
 
    m0.minimize("Minuit2", "migrad");
 
@@ -130,6 +143,7 @@ TEST_P(LikelihoodGradientJobTest, Gaussian1D)
 
    m1.setStrategy(0);
    m1.setPrintLevel(-1);
+   m1.setOffsetting(offsetting);
 
    m1.minimize("Minuit2", "migrad");
 
@@ -197,6 +211,7 @@ TEST_P(LikelihoodGradientJobTest, GaussianND)
    // parameters
    std::size_t NWorkers = std::get<0>(GetParam());
    std::size_t seed = std::get<1>(GetParam());
+   bool offsetting = std::get<2>(GetParam());
 
    unsigned int N = 4;
 
@@ -219,6 +234,7 @@ TEST_P(LikelihoodGradientJobTest, GaussianND)
 
    m0.setStrategy(0);
    m0.setPrintLevel(-1);
+   m0.setOffsetting(offsetting);
 
    m0.minimize("Minuit2", "migrad");
 
@@ -255,6 +271,7 @@ TEST_P(LikelihoodGradientJobTest, GaussianND)
 
    m1.setStrategy(0);
    m1.setPrintLevel(-1);
+   m1.setOffsetting(offsetting);
 
    m1.minimize("Minuit2", "migrad");
 
@@ -286,8 +303,15 @@ TEST_P(LikelihoodGradientJobTest, GaussianND)
 }
 
 INSTANTIATE_TEST_SUITE_P(NworkersSeed, LikelihoodGradientJobTest,
-                         ::testing::Combine(::testing::Values(1, 2, 3), // number of workers
-                                            ::testing::Values(2, 3)));  // random seed
+                         ::testing::Combine(::testing::Values(1, 2, 3),      // number of workers
+                                            ::testing::Values(2, 3),         // random seed
+                                            ::testing::Values(false, true)), //
+                         [](testing::TestParamInfo<LikelihoodGradientJobTest::ParamType> const &paramInfo) {
+                            std::stringstream ss;
+                            ss << std::get<0>(paramInfo.param) << "workers_seed" << std::get<1>(paramInfo.param)
+                               << (std::get<2>(paramInfo.param) ? "_WithOffsetting" : "_WithoutOffsetting");
+                            return ss.str();
+                         });
 
 std::unique_ptr<RooWorkspace> makeSimBinnedConstrainedWorkspace()
 {
@@ -357,11 +381,14 @@ TEST(SimBinnedConstrainedTestBasic, BasicParameters)
 
    const double nll0 = nll->getVal();
 
+   // dummy offsets (normally they are shared with other objects):
+   SharedOffset shared_offset;
    auto nll_ts = LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial,
                                            RooFit::TestStatistics::NLLFactory{*pdf, *data}
                                               .GlobalObservables({*w.var("alpha_bkg_obs_A"), *w.var("alpha_bkg_obs_B")})
                                               .build(),
-                                           std::make_unique<RooFit::TestStatistics::WrapperCalculationCleanFlags>());
+                                           std::make_unique<RooFit::TestStatistics::WrapperCalculationCleanFlags>(),
+                                           shared_offset);
 
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
@@ -377,6 +404,12 @@ TEST_P(SimBinnedConstrainedTest, ConstrainedAndOffset)
 
    // parameters
    const bool parallelLikelihood = std::get<0>(GetParam());
+   // This is a simultaneous fit, so its likelihood has multiple components. In that case, splitting over
+   // components is always preferable, since it is more precise, due to component offsets matching
+   // the (-log) function values better.
+   RooFit::MultiProcess::Config::LikelihoodJob::defaultNEventTasks = 1;
+   RooFit::MultiProcess::Config::LikelihoodJob::defaultNComponentTasks =
+      99999; // just a high number, so every component is a task
 
    std::unique_ptr<RooWorkspace> wPtr = makeSimBinnedConstrainedWorkspace();
    auto &w = *wPtr;
@@ -385,7 +418,7 @@ TEST_P(SimBinnedConstrainedTest, ConstrainedAndOffset)
    RooAbsData *data = w.data("data");
 
    // do a minimization, but now using GradMinimizer and its MP version
-   std::unique_ptr<RooAbsReal> nll{pdf->createNLL(*data, Constrain(*w.var("alpha_bkg_obs_A")),
+   std::unique_ptr<RooAbsReal> nll{pdf->createNLL(*data, Constrain(*w.var("alpha_bkg_A")),
                                                   GlobalObservables(*w.var("alpha_bkg_obs_B")), Offset(true))};
 
    // parameters
@@ -418,7 +451,7 @@ TEST_P(SimBinnedConstrainedTest, ConstrainedAndOffset)
    RooFit::MultiProcess::Config::setDefaultNWorkers(NWorkers);
 
    std::unique_ptr<RooAbsReal> likelihoodAbsReal{pdf->createNLL(
-      *data, Constrain(*w.var("alpha_bkg_obs_A")), GlobalObservables(*w.var("alpha_bkg_obs_B")), ModularL(true))};
+      *data, Constrain(*w.var("alpha_bkg_A")), GlobalObservables(*w.var("alpha_bkg_obs_B")), ModularL(true))};
 
    RooMinimizer::Config cfg1;
    cfg1.parallelize = -1;
@@ -441,30 +474,19 @@ TEST_P(SimBinnedConstrainedTest, ConstrainedAndOffset)
    ValAndError alpha_bkg_B_GradientJob = getValAndError(parsFinal_GradientJob, "alpha_bkg_B");
    ValAndError mu_sig_GradientJob = getValAndError(parsFinal_GradientJob, "mu_sig");
 
-   // Because offsetting is handled differently in the TestStatistics classes
-   // compared to the way it was done in the object returned from
-   // RooAbsPdf::createNLL (a RooAddition of an offset RooNLLVar and a
-   // non-offset RooConstraintSum, whereas RooSumL applies the offset to the
-   // total sum of its binned, unbinned and constraint components),
-   // we cannot always expect exactly equal results for fits with likelihood
-   // offsetting enabled. See also the LikelihoodSerialSimBinnedConstrainedTest.
-   // ConstrainedAndOffset test case in testLikelihoodSerial and other tests
-   // below with offsetting. We do test whether they are near, because any
-   // changes that cause further divergence should be carefully considered.
-   // Note that we also omit the edm checks for these test cases. They will
-   // always (by default) be below 1e-3 for successful fits (by definition),
-   // so it tests nothing specific about the likelihood classes, it's just a
-   // postcondition of the Minuit fit.
-#define EXPECT_NEAR_REL(a, b, c) EXPECT_NEAR(a, b, std::abs(a *c))
-#define EXPECT_NEAR_REL_INCL_ERROR(a, b, c)       \
-   EXPECT_NEAR(a.val, b.val, std::abs(a.val *c)); \
-   EXPECT_NEAR(a.error, b.error, std::abs(a.error *c))
-   EXPECT_NEAR_REL(minNll_nominal, minNll_GradientJob, 1e-6);
-   EXPECT_NEAR_REL_INCL_ERROR(alpha_bkg_A_nominal, alpha_bkg_A_GradientJob, 1e-6);
-   EXPECT_NEAR_REL_INCL_ERROR(alpha_bkg_B_nominal, alpha_bkg_B_GradientJob, 1e-6);
-   EXPECT_NEAR_REL_INCL_ERROR(mu_sig_nominal, mu_sig_GradientJob, 1e-6);
-#undef EXPECT_NEAR_REL
-#undef EXPECT_NEAR_REL_INCL_ERROR
+   EXPECT_FLOAT_EQ(minNll_nominal, minNll_GradientJob);
+   EXPECT_FLOAT_EQ(alpha_bkg_A_nominal.val, alpha_bkg_A_GradientJob.val);
+   EXPECT_FLOAT_EQ(alpha_bkg_A_nominal.error, alpha_bkg_A_GradientJob.error);
+   EXPECT_FLOAT_EQ(alpha_bkg_B_nominal.val, alpha_bkg_B_GradientJob.val);
+   EXPECT_FLOAT_EQ(alpha_bkg_B_nominal.error, alpha_bkg_B_GradientJob.error);
+   EXPECT_FLOAT_EQ(mu_sig_nominal.val, mu_sig_GradientJob.val);
+   EXPECT_FLOAT_EQ(mu_sig_nominal.error, mu_sig_GradientJob.error);
+
+   // reset static variables to automatic
+   RooFit::MultiProcess::Config::LikelihoodJob::defaultNEventTasks =
+      RooFit::MultiProcess::Config::LikelihoodJob::automaticNEventTasks;
+   RooFit::MultiProcess::Config::LikelihoodJob::defaultNComponentTasks =
+      RooFit::MultiProcess::Config::LikelihoodJob::automaticNComponentTasks;
 }
 
 INSTANTIATE_TEST_SUITE_P(LikelihoodGradientJob, SimBinnedConstrainedTest, testing::Values(false, true),
@@ -481,6 +503,15 @@ TEST_P(LikelihoodGradientJobTest, Gaussian1DAlsoWithLikelihoodJob)
    // parameters
    std::size_t NWorkers = std::get<0>(GetParam());
    std::size_t seed = std::get<1>(GetParam());
+   bool offsetting = std::get<2>(GetParam());
+
+   // in the 1D Gaussian tests, we suppress the positive definiteness
+   // warnings coming from Minuit2 with offsetting; they are errors both
+   // in serial RooFit and in the MultiProcess-enabled back-end
+   ROOT::TestSupport::CheckDiagsRAII checkDiag;
+   if (offsetting) {
+      checkDiag.requiredDiag(kError, "Minuit2", "VariableMetricBuilder Initial matrix not pos.def.");
+   }
 
    RooRandom::randomGenerator()->SetSeed(seed);
 
@@ -503,6 +534,7 @@ TEST_P(LikelihoodGradientJobTest, Gaussian1DAlsoWithLikelihoodJob)
    m0.setStrategy(0);
    m0.setPrintLevel(-1);
    m0.setVerbose(false);
+   m0.setOffsetting(offsetting);
 
    m0.minimize("Minuit2", "migrad");
 
@@ -523,6 +555,7 @@ TEST_P(LikelihoodGradientJobTest, Gaussian1DAlsoWithLikelihoodJob)
    RooMinimizer m1(likelihood, cfg);
    m1.setStrategy(0);
    m1.setPrintLevel(-1);
+   m1.setOffsetting(offsetting);
 
    m1.setVerbose(false);
 
@@ -534,8 +567,25 @@ TEST_P(LikelihoodGradientJobTest, Gaussian1DAlsoWithLikelihoodJob)
    double mu1 = mu->getVal();
    double muerr1 = mu->getError();
 
-   EXPECT_FLOAT_EQ(minNll0, minNll1);
-   EXPECT_FLOAT_EQ(mu0, mu1);
-   EXPECT_FLOAT_EQ(muerr0, muerr1);
-   EXPECT_NEAR(edm0, edm1, 1e-5);
+   if (NWorkers > 1 && offsetting) {
+      // Note: we cannot expect exact equal results here in most cases when using
+      // event-based splitting (which is currently the default; THIS MAY CHANGE!).
+      // See LikelihoodJobTest, UnbinnedGaussian1DSelectedParameterValues for an
+      // example of where slight bit-wise differences can pop up in fits like this
+      // due to minor bit-wise errors in Kahan summation due to different split
+      // ups over the event range. We do expect pretty close results, though,
+      // because this fit only has 4 iterations and bit-wise differences should
+      // not add up too much.
+#define EXPECT_NEAR_REL(a, b, c) EXPECT_NEAR(a, b, std::abs(a *c))
+      EXPECT_NEAR_REL(minNll0, minNll1, 1e-7);
+      EXPECT_NEAR_REL(mu0, mu1, 1e-7);
+      EXPECT_NEAR_REL(muerr0, muerr1, 1e-7);
+      EXPECT_NEAR(edm0, edm1, 1e-3);
+   } else {
+      EXPECT_NEAR_REL(minNll0, minNll1, 1e-10);
+      EXPECT_NEAR_REL(mu0, mu1, 1e-10);
+      EXPECT_NEAR_REL(muerr0, muerr1, 1e-10);
+      EXPECT_NEAR(edm0, edm1, 1e-5);
+   }
 }
+#undef EXPECT_NEAR_REL

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodSerial.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodSerial.cxx
@@ -105,7 +105,10 @@ TEST_F(LikelihoodSerialTest, UnbinnedGaussian1D)
 {
    std::tie(nll, pdf, data, values) = generate_1D_gaussian_pdf_nll(w, 10000);
    likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
-   auto nll_ts = LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags);
+   // dummy offsets (normally they are shared with other objects):
+   SharedOffset offset;
+   auto nll_ts =
+      LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags, offset);
 
    auto nll0 = nll->getVal();
 
@@ -122,7 +125,10 @@ TEST_F(LikelihoodSerialTest, UnbinnedGaussianND)
 
    std::tie(nll, pdf, data, values) = generate_ND_gaussian_pdf_nll(w, N, 1000, RooFit::EvalBackend::Legacy());
    likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
-   auto nll_ts = LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags);
+   // dummy offsets (normally they are shared with other objects):
+   SharedOffset offset;
+   auto nll_ts =
+      LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags, offset);
 
    auto nll0 = nll->getVal();
 
@@ -140,7 +146,10 @@ TEST_F(LikelihoodSerialBinnedDatasetTest, UnbinnedPdf)
    nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data)};
 
    likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
-   auto nll_ts = LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags);
+   // dummy offsets (normally they are shared with other objects):
+   SharedOffset offset;
+   auto nll_ts =
+      LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags, offset);
 
    auto nll0 = nll->getVal();
 
@@ -166,7 +175,10 @@ TEST_F(LikelihoodSerialBinnedDatasetTest, BinnedManualNLL)
    RooNLLVar nll_manual("nlletje", "-log(likelihood)", *pdf, *data, projDeps, extended, nll_config);
 
    likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
-   auto nll_ts = LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags);
+   // dummy offsets (normally they are shared with other objects):
+   SharedOffset offset;
+   auto nll_ts =
+      LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags, offset);
 
    auto nll0 = nll_manual.getVal();
 
@@ -214,7 +226,10 @@ TEST_F(LikelihoodSerialTest, SimBinned)
    nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data)};
 
    likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
-   auto nll_ts = LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags);
+   // dummy offsets (normally they are shared with other objects):
+   SharedOffset offset;
+   auto nll_ts =
+      LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags, offset);
 
    auto nll0 = nll->getVal();
 
@@ -261,7 +276,10 @@ TEST_F(LikelihoodSerialTest, BinnedConstrained)
    auto nll0 = nll->getVal();
 
    likelihood = RooFit::TestStatistics::NLLFactory{*pdf, *data}.GlobalObservables(*w.var("alpha_bkg_obs")).build();
-   auto nll_ts = LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags);
+   // dummy offsets (normally they are shared with other objects):
+   SharedOffset offset;
+   auto nll_ts =
+      LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags, offset);
 
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
@@ -288,7 +306,10 @@ TEST_F(LikelihoodSerialTest, SimUnbinned)
    auto nll0 = nll->getVal();
 
    likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
-   auto nll_ts = LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags);
+   // dummy offsets (normally they are shared with other objects):
+   SharedOffset offset;
+   auto nll_ts =
+      LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags, offset);
 
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
@@ -319,7 +340,10 @@ TEST_F(LikelihoodSerialTest, SimUnbinnedNonExtended)
    nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data)};
 
    likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
-   auto nll_ts = LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags);
+   // dummy offsets (normally they are shared with other objects):
+   SharedOffset offset;
+   auto nll_ts =
+      LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags, offset);
 
    auto nll0 = nll->getVal();
 
@@ -389,7 +413,10 @@ TEST_F(LikelihoodSerialSimBinnedConstrainedTest, BasicParameters)
    likelihood = RooFit::TestStatistics::NLLFactory{*pdf, *data}
                    .GlobalObservables({*w.var("alpha_bkg_obs_A"), *w.var("alpha_bkg_obs_B")})
                    .build();
-   auto nll_ts = LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags);
+   // dummy offsets (normally they are shared with other objects):
+   SharedOffset offset;
+   auto nll_ts =
+      LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags, offset);
 
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
@@ -406,7 +433,7 @@ TEST_F(LikelihoodSerialSimBinnedConstrainedTest, ConstrainedAndOffset)
    // the multiprocess test statistics classes were designed to give values
    // that are bit-by-bit identical with the old test statistics based on
    // RooAbsTestStatistic.
-   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data, RooFit::Constrain(RooArgSet(*w.var("alpha_bkg_obs_A"))),
+   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data, RooFit::Constrain(RooArgSet(*w.var("alpha_bkg_A"))),
                                                     RooFit::GlobalObservables(RooArgSet(*w.var("alpha_bkg_obs_B"))),
                                                     RooFit::Offset(true), RooFit::EvalBackend::Legacy())};
 
@@ -415,10 +442,13 @@ TEST_F(LikelihoodSerialSimBinnedConstrainedTest, ConstrainedAndOffset)
    auto nll0 = nll->getVal();
 
    likelihood = RooFit::TestStatistics::NLLFactory{*pdf, *data}
-                   .ConstrainedParameters(*w.var("alpha_bkg_obs_A"))
+                   .ConstrainedParameters(*w.var("alpha_bkg_A"))
                    .GlobalObservables(*w.var("alpha_bkg_obs_B"))
                    .build();
-   auto nll_ts = LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags);
+   // dummy offsets (normally they are shared with other objects):
+   SharedOffset offset;
+   auto nll_ts =
+      LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags, offset);
    nll_ts->enableOffsetting(true);
 
    nll_ts->evaluate();
@@ -427,10 +457,15 @@ TEST_F(LikelihoodSerialSimBinnedConstrainedTest, ConstrainedAndOffset)
    // value. RooRealL will also give the non-offset value, so that can be directly compared to the RooNLLVar::getVal
    // result (the nll0 vs nll2 comparison below). To compare to the raw RooAbsL/Wrapper value nll1, however, we need to
    // manually add the offset.
-   ROOT::Math::KahanSum<double> nll1 = nll_ts->getResult() + nll_ts->offset();
+   ROOT::Math::KahanSum<double> nll1 = nll_ts->getResult();
+   ROOT::Math::KahanSum<double> nll_ts_offset;
+   for (auto &offset_comp : offset.offsets()) {
+      nll1 += offset_comp;
+      nll_ts_offset += offset_comp;
+   }
 
-   EXPECT_DOUBLE_EQ(nll0, nll1.Sum());
-   EXPECT_FALSE(nll_ts->offset().Sum() == 0);
+   EXPECT_EQ(nll0, nll1.Sum());
+   EXPECT_FALSE(nll_ts_offset.Sum() == 0);
 
    // also check against RooRealL value
    RooFit::TestStatistics::RooRealL nll_real("real_nll", "RooRealL version", likelihood);
@@ -438,7 +473,7 @@ TEST_F(LikelihoodSerialSimBinnedConstrainedTest, ConstrainedAndOffset)
    auto nll2 = nll_real.getVal();
 
    EXPECT_EQ(nll0, nll2);
-   EXPECT_DOUBLE_EQ(nll1.Sum(), nll2);
+   EXPECT_EQ(nll1.Sum(), nll2);
 }
 #endif // ROOFIT_LEGACY_EVAL_BACKEND
 
@@ -452,7 +487,10 @@ TEST_F(LikelihoodSerialTest, BatchedUnbinnedGaussianND)
    auto nll0 = nll->getVal();
 
    likelihood = RooFit::TestStatistics::NLLFactory{*pdf, *data}.EvalBackend(backend).build();
-   auto nll_ts = LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags);
+   // dummy offsets (normally they are shared with other objects):
+   SharedOffset offset;
+   auto nll_ts =
+      LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags, offset);
 
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Triggered by a failure to run an ATLAS Higgs combination fit using the MultiProcess-parallelized LikelihoodJob, this PR changes the way offsetting is handled in the TestStatistics::LikelihoodWrapper family of classes. This in turn improves precision of evaluations, making many parallelized likelihood evaluations now bit-wise exactly equal to non-parallel evaluations. This allows us to better debug the Higgs fit. After this PR, the public Higgs workspace used in rootbench can be fit with LikelihoodJob enabled.

In detail, this PR changes the following:

- Increased precision:
    * Per-component offsets: instead of one offset for the total LikelihoodWrapper, we switched to a vector of offsets: one for each likelihood component. This makes a difference only for RooSumL fits, i.e. simultaneous PDF fits or fits with constraint or global observable terms. This brings the results of these fits closer to the old-style RooNLLVar fits, because those also use per-component offsets (per-RooNLLVar in a RooAddition to be exact).
    * In LikelihoodJob::evaluate, the result_ KahanSum is no longer initialized to zero, but is initialized to the first value in the results_ array, both sum and carry term. This sometimes makes a difference: adding a term with a small but non-zero carry term to an existing sum with a zero sum and zero carry term can make the small non-zero carry term disappear.
    * Due to these changes and the earlier KahanSum updates, we were able to tighten the tolerance of tests in testLikelihoodSerial, testLikelihoodJob and testLikelihoodGradientJob, with many tests now passing EXPECT_EQ.
    * testLikelihoodGradientJob adds offsetting to the parameterized test matrices of the LikelihoodGradientJobTest cases to test all the above (and below) changes.

- Offset synchronization:
    * LikelihoodWrapper and LikelihoodGradientWrapper now store a shared_ptr to the offsets instead of raw offsets. At construction time within a MinuitFcnGrad, they get passed the same single offset object so that it is always kept synced between the different likelihood calculators. If it isn't synced and the likelihood gets different offsets at different times, the minimizer understandably gets very confused. This was the case before this commit, which was, in fact, a bug.
    * For LikelihoodJob and LikelihoodGradientJob, the offsets are also synchronized to all workers via update_state. For this, we simply check before evaluation whether offsets have changed since the previous evaluation and if so they are sent over the MultiProcess::Messenger. Note that while the LikelihoodGradientJob doesn't itself use the offset (it doesn't calculate the likelihood), it must still synchronize offsets, because during the gradient calculation the LikelihoodSerial objects on the workers are used to calculate the likelihoods there, so for them the offsets must be up to date.
    * The LikelihoodJob contains a LikelihoodSerial member as well now. This allows the LikelihoodJob to trigger calculating the offsets on the master process before sending them to the workers.
    * LikelihoodWrapper has some added private helper functions for managing offsets.

- Other miscellaneous changes:
    * LikelihoodWrapper::setApplyWeightSquared was implemented properly for RooSumL likelihoods as well, passing along the call to component RooUnbinnedLs. Note, however, that it is currently not reachable for users because there is no interface to pass this along from the RooMinimizer, which contains the MinuitFcnGrad, which contains the LikelihoodWrapper. A comment in MinuitFcnGrad.h refers to this, reminding future devs to also flip offsets_reset_ when (un)setting squared weights.
    * LikelihoodWrapper now holds the likelihood_type. This cleans up some code duplication in LikelihoodSerial and LikelihoodJob, which previously used the type only in their ctors, and avoids dynamic_casts later, e.g. on when calculating offsets.
    * A RooSubsidiaryL can now also be computed with LikelihoodSerial and LikelihoodJob; this case was still missing in their evaluation functions.
    * The LikelihoodSerial, LikelihoodJob and LikelihoodGradientJob "ConstrainedAndOffset" test cases used the wrong argument for the constrained parameter. These are now corrected from alpha_bkg_obs_A to become alpha_bkg_A.
    * In LikelihoodJobTest, the added test case "UnbinnedGaussian1DSelectedParameterValues" shows where splitting over events can lead to bit-wise differences. This test will be useful in the future if further precision enhancements are made.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)