### PR TITLE
[RF] HS3: updates to reflect the suggested changes in the RooFit JSON standard

### DIFF
--- a/roofit/hs3/CMakeLists.txt
+++ b/roofit/hs3/CMakeLists.txt
@@ -15,6 +15,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitHS3
     RooFitHS3/RooJSONFactoryWSTool.h
     RooFitHS3/HistFactoryJSONTool.h
   SOURCES
+    src/Domains.cxx
     src/JSONIO.cxx
     src/RooJSONFactoryWSTool.cxx
     src/HistFactoryJSONTool.cxx

--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -200,9 +200,11 @@ private:
 
    void exportAllObjects(RooFit::Detail::JSONNode &n);
    void exportDependants(const RooAbsArg *source);
-   void exportModelConfig(RooFit::Detail::JSONNode &node, RooAbsPdf const &pdf, RooStats::ModelConfig const *mc);
+   void exportTopLevelPdf(RooFit::Detail::JSONNode &node, RooAbsPdf const &pdf, std::string const &modelConfigName);
 
    void tagVariables(RooFit::Detail::JSONNode &rootnode, RooArgSet const *args, const char *tag);
+
+   void exportModelConfig(RooFit::Detail::JSONNode &n, RooStats::ModelConfig const &mc);
 
    // member variables
    const RooFit::Detail::JSONNode *_rootnode_input = nullptr;

--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -202,8 +202,6 @@ private:
    void exportDependants(const RooAbsArg *source);
    void exportTopLevelPdf(RooFit::Detail::JSONNode &node, RooAbsPdf const &pdf, std::string const &modelConfigName);
 
-   void tagVariables(RooFit::Detail::JSONNode &rootnode, RooArgSet const *args, const char *tag);
-
    void exportModelConfig(RooFit::Detail::JSONNode &n, RooStats::ModelConfig const &mc);
 
    // member variables

--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -40,6 +40,9 @@ class JSONNode;
 class JSONTree;
 } // namespace Detail
 } // namespace RooFit
+namespace RooStats {
+class ModelConfig;
+}
 
 class TH1;
 class TClass;
@@ -183,7 +186,6 @@ private:
    void importPdfs(const RooFit::Detail::JSONNode &n);
    void importVariables(const RooFit::Detail::JSONNode &n);
    void importVariable(const RooFit::Detail::JSONNode &n);
-   void configureVariable(const RooFit::Detail::JSONNode &p, RooRealVar &v);
    void importDependants(const RooFit::Detail::JSONNode &n);
 
    void configureToplevelPdf(const RooFit::Detail::JSONNode &n, RooAbsPdf &pdf);
@@ -197,6 +199,9 @@ private:
 
    void exportAllObjects(RooFit::Detail::JSONNode &n);
    void exportDependants(const RooAbsArg *source);
+   void exportModelConfig(RooFit::Detail::JSONNode &node, RooAbsPdf const &pdf, RooStats::ModelConfig const *mc);
+
+   void tagVariables(RooFit::Detail::JSONNode &rootnode, RooArgSet const *args, const char *tag);
 
    // member variables
    const RooFit::Detail::JSONNode *_rootnode_input = nullptr;

--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -135,6 +135,9 @@ public:
 
    static std::unique_ptr<RooFit::Detail::JSONTree> createNewJSONTree();
 
+   static RooFit::Detail::JSONNode &makeVariablesNode(RooFit::Detail::JSONNode &rootNode);
+   static RooFit::Detail::JSONNode const *getVariablesNode(RooFit::Detail::JSONNode const &rootNode);
+
 private:
    struct Config {
       static bool stripObservables;

--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -30,6 +30,11 @@ class RooRealVar;
 class RooWorkspace;
 
 namespace RooFit {
+namespace JSONIO {
+namespace Detail {
+class Domains;
+}
+} // namespace JSONIO
 namespace Detail {
 class JSONNode;
 class JSONTree;
@@ -48,7 +53,10 @@ public:
    template <class T>
    T *request(const std::string &objname, const std::string &requestAuthor);
 
-   RooJSONFactoryWSTool(RooWorkspace &ws) : _workspace{ws} {}
+   RooJSONFactoryWSTool(RooWorkspace &ws);
+
+   ~RooJSONFactoryWSTool();
+
    RooWorkspace *workspace() { return &_workspace; }
 
    static void error(const char *s) { throw std::runtime_error(s); }
@@ -194,5 +202,8 @@ private:
    const RooFit::Detail::JSONNode *_rootnode_input = nullptr;
    RooFit::Detail::JSONNode *_rootnode_output = nullptr;
    RooWorkspace &_workspace;
+
+   // objects to represent intermediate information
+   std::unique_ptr<RooFit::JSONIO::Detail::Domains> _domains;
 };
 #endif

--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -108,8 +108,8 @@ public:
                                const TH1 *errH = nullptr, bool writeObservables = true, bool writeErrors = true);
    static void writeObservables(const TH1 &h, RooFit::Detail::JSONNode &n, const std::vector<std::string> &varnames);
 
-   static std::unique_ptr<RooDataHist> readBinnedData(RooWorkspace &ws, const RooFit::Detail::JSONNode &n,
-                                                      const std::string &namecomp, RooArgList observables);
+   static std::unique_ptr<RooDataHist> readBinnedData(const RooFit::Detail::JSONNode &n, const std::string &namecomp);
+   static std::unique_ptr<RooDataHist> readBinnedData(const RooFit::Detail::JSONNode &n, const std::string &namecomp, RooArgList varlist);
 
    static void
    getObservables(RooWorkspace &ws, const RooFit::Detail::JSONNode &n, const std::string &obsnamecomp, RooArgSet &out);

--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -203,7 +203,7 @@ private:
 
    void exportAllObjects(RooFit::Detail::JSONNode &n);
    void exportDependants(const RooAbsArg *source);
-   void exportTopLevelPdf(RooFit::Detail::JSONNode &node, RooAbsPdf const &pdf, std::string const &modelConfigName);
+   void exportTopLevelPdf(RooAbsPdf const &pdf, std::string const &modelConfigName);
 
    void exportModelConfig(RooFit::Detail::JSONNode &n, RooStats::ModelConfig const &mc);
 

--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -109,7 +109,8 @@ public:
    static void writeObservables(const TH1 &h, RooFit::Detail::JSONNode &n, const std::vector<std::string> &varnames);
 
    static std::unique_ptr<RooDataHist> readBinnedData(const RooFit::Detail::JSONNode &n, const std::string &namecomp);
-   static std::unique_ptr<RooDataHist> readBinnedData(const RooFit::Detail::JSONNode &n, const std::string &namecomp, RooArgList varlist);
+   static std::unique_ptr<RooDataHist>
+   readBinnedData(const RooFit::Detail::JSONNode &n, const std::string &namecomp, RooArgList varlist);
 
    static void
    getObservables(RooWorkspace &ws, const RooFit::Detail::JSONNode &n, const std::string &obsnamecomp, RooArgSet &out);
@@ -153,6 +154,7 @@ private:
    const RooFit::Detail::JSONNode &irootnode() const;
 
    std::map<std::string, std::unique_ptr<RooAbsData>> loadData(const RooFit::Detail::JSONNode &n);
+   std::unique_ptr<RooDataSet> unbinned(RooDataHist const &hist);
    static RooRealVar *createObservable(RooWorkspace &ws, const std::string &name, const RooJSONFactoryWSTool::Var &var);
 
    class MissingRootnodeError : public std::exception {
@@ -187,8 +189,7 @@ private:
    void importVariables(const RooFit::Detail::JSONNode &n);
    void importVariable(const RooFit::Detail::JSONNode &n);
    void importDependants(const RooFit::Detail::JSONNode &n);
-
-   void configureToplevelPdf(const RooFit::Detail::JSONNode &n, RooAbsPdf &pdf);
+   void importAnalysis(const RooFit::Detail::JSONNode &analysisNode, const RooFit::Detail::JSONNode &likelihoodsNode);
 
    bool find(const RooFit::Detail::JSONNode &n, const std::string &elem);
    void append(RooFit::Detail::JSONNode &n, const std::string &elem);

--- a/roofit/hs3/src/Domains.cxx
+++ b/roofit/hs3/src/Domains.cxx
@@ -1,0 +1,113 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   Jonas Rembser, CERN, Jan 2023
+ *
+ * Copyright (c) 2023, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#include "Domains.h"
+
+#include <RooNumber.h>
+#include <RooRealVar.h>
+
+#include <RooFit/Detail/JSONInterface.h>
+
+namespace RooFit {
+namespace JSONIO {
+namespace Detail {
+
+void Domains::readVariable(const char *name, double min, double max)
+{
+   _map["default_domain"].readVariable(name, min, max);
+}
+void Domains::readVariable(RooRealVar const &var)
+{
+   readVariable(var.GetName(), var.getMin(), var.getMax());
+}
+void Domains::writeVariable(RooRealVar &var) const
+{
+   _map.at("default_domain").writeVariable(var);
+}
+
+void Domains::readJSON(RooFit::Detail::JSONNode const &node)
+{
+   _map["default_domain"].readJSON(node["default_domain"]);
+}
+void Domains::writeJSON(RooFit::Detail::JSONNode &node) const
+{
+   node.set_map();
+
+   for (auto const &domain : _map) {
+      domain.second.writeJSON(node[domain.first]);
+   }
+}
+void Domains::ProductDomain::readVariable(const char *name, double min, double max)
+{
+   auto &elem = _map[name];
+
+   if (!RooNumber::isInfinite(min)) {
+      elem.hasMin = true;
+      elem.min = min;
+   }
+   if (!RooNumber::isInfinite(max)) {
+      elem.hasMax = true;
+      elem.max = max;
+   }
+}
+void Domains::ProductDomain::writeVariable(RooRealVar &var) const
+{
+   auto found = _map.find(var.GetName());
+   if (found != _map.end()) {
+      auto const &elem = found->second;
+      if (elem.hasMin)
+         var.setMin(elem.min);
+      if (elem.hasMax)
+         var.setMax(elem.max);
+   }
+}
+void Domains::ProductDomain::readJSON(RooFit::Detail::JSONNode const &node)
+{
+   // In the future, throw an exception if the type is not product domain
+   auto const &variablesNode = node["variables"];
+   for (size_t i = 0; i < variablesNode.num_children(); ++i) {
+      auto const &varNode = variablesNode[i];
+      auto &elem = _map[varNode["name"].val()];
+
+      if (varNode.has_child("min")) {
+         elem.min = varNode["min"].val_double();
+         elem.hasMin = true;
+      }
+      if (varNode.has_child("max")) {
+         elem.max = varNode["max"].val_double();
+         elem.hasMax = true;
+      }
+   }
+}
+void Domains::ProductDomain::writeJSON(RooFit::Detail::JSONNode &node) const
+{
+   node.set_map();
+   node["type"] << "product_domain";
+
+   auto &variablesNode = node["variables"];
+   variablesNode.set_seq();
+
+   for (auto const &item : _map) {
+      auto const &elem = item.second;
+      RooFit::Detail::JSONNode &varnode = variablesNode.append_child();
+      varnode.set_map();
+      varnode["name"] << item.first;
+      if (elem.hasMin)
+         varnode["min"] << elem.min;
+      if (elem.hasMax)
+         varnode["max"] << elem.max;
+   }
+}
+
+} // namespace Detail
+} // namespace JSONIO
+} // namespace RooFit

--- a/roofit/hs3/src/Domains.h
+++ b/roofit/hs3/src/Domains.h
@@ -1,0 +1,69 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   Jonas Rembser, CERN, Jan 2023
+ *
+ * Copyright (c) 2023, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#ifndef RooFit_JSONIO_Detail_Domains_h
+#define RooFit_JSONIO_Detail_Domains_h
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+class RooRealVar;
+
+namespace RooFit {
+namespace Detail {
+class JSONNode;
+class JSONTree;
+} // namespace Detail
+} // namespace RooFit
+
+namespace RooFit {
+namespace JSONIO {
+namespace Detail {
+
+class Domains {
+public:
+   void readVariable(const char *name, double min, double max);
+   void readVariable(RooRealVar const &);
+   void writeVariable(RooRealVar &) const;
+
+   void readJSON(RooFit::Detail::JSONNode const &);
+   void writeJSON(RooFit::Detail::JSONNode &) const;
+
+private:
+   class ProductDomain {
+   public:
+      void readVariable(const char *name, double min, double max);
+      void writeVariable(RooRealVar &) const;
+
+      void readJSON(RooFit::Detail::JSONNode const &);
+      void writeJSON(RooFit::Detail::JSONNode &) const;
+
+   private:
+      struct ProductDomainElement {
+         bool hasMin = false;
+         bool hasMax = false;
+         double min = 0.0;
+         double max = 0.0;
+      };
+
+      std::unordered_map<std::string, ProductDomainElement> _map;
+   };
+
+   std::unordered_map<std::string, ProductDomain> _map;
+};
+
+} // namespace Detail
+} // namespace JSONIO
+} // namespace RooFit
+
+#endif

--- a/roofit/hs3/src/HistFactoryJSONTool.cxx
+++ b/roofit/hs3/src/HistFactoryJSONTool.cxx
@@ -215,9 +215,7 @@ void exportMeasurement(RooStats::HistFactory::Measurement &measurement, JSONNode
    // the data
    auto &datalist = n["observations"];
    datalist.set_map();
-   // auto &obsdata = datalist["obsData"];
-   // obsdata.set_map();
-   // obsdata["index"] << "channelCat";
+
    for (const auto &c : measurement.GetChannels()) {
       const std::vector<std::string> obsnames{"obs_x_" + c.GetName(), "obs_y_" + c.GetName(), "obs_z_" + c.GetName()};
 
@@ -225,8 +223,6 @@ void exportMeasurement(RooStats::HistFactory::Measurement &measurement, JSONNode
          analysisObservables.append_child() << obsnames[i];
       }
 
-      // auto &chdata = obsdata[c.GetName()];
-      // RooJSONFactoryWSTool::exportHistogram(*c.GetData().GetHisto(), chdata, obsnames);
       RooJSONFactoryWSTool::exportHistogram(*c.GetData().GetHisto(), datalist[std::string("obsData_") + c.GetName()],
                                             obsnames);
    }

--- a/roofit/hs3/src/HistFactoryJSONTool.cxx
+++ b/roofit/hs3/src/HistFactoryJSONTool.cxx
@@ -180,11 +180,10 @@ void exportMeasurement(RooStats::HistFactory::Measurement &measurement, JSONNode
    }
 
    // the variables
-   auto &varlist = n["variables"];
-   varlist.set_map();
-   for (const auto &c : measurement.GetChannels()) {
-      for (const auto &s : c.GetSamples()) {
-         for (const auto &norm : s.GetNormFactorList()) {
+   JSONNode &varlist = RooJSONFactoryWSTool::makeVariablesNode(n);
+   for (const auto &channel : measurement.GetChannels()) {
+      for (const auto &sample : channel.GetSamples()) {
+         for (const auto &norm : sample.GetNormFactorList()) {
             if (!varlist.has_child(norm.GetName())) {
                auto &v = varlist[norm.GetName()];
                v.set_map();
@@ -192,7 +191,7 @@ void exportMeasurement(RooStats::HistFactory::Measurement &measurement, JSONNode
                domains.readVariable(norm.GetName().c_str(), norm.GetLow(), norm.GetHigh());
             }
          }
-         for (const auto &sys : s.GetOverallSysList()) {
+         for (const auto &sys : sample.GetOverallSysList()) {
             std::string parname("alpha_");
             parname += sys.GetName();
             if (!varlist.has_child(parname)) {

--- a/roofit/hs3/src/HistFactoryJSONTool.cxx
+++ b/roofit/hs3/src/HistFactoryJSONTool.cxx
@@ -137,7 +137,7 @@ void exportMeasurement(RooStats::HistFactory::Measurement &measurement, JSONNode
       }
    }
 
-   auto &pdflist = n["pdfs"];
+   auto &pdflist = n["distributions"];
    pdflist.set_map();
 
    auto &likelihoodlist = n["likelihoods"];
@@ -214,7 +214,7 @@ void exportMeasurement(RooStats::HistFactory::Measurement &measurement, JSONNode
    }
 
    // the data
-   auto &datalist = n["data"];
+   auto &datalist = n["observations"];
    datalist.set_map();
    // auto &obsdata = datalist["obsData"];
    // obsdata.set_map();

--- a/roofit/hs3/src/HistFactoryJSONTool.cxx
+++ b/roofit/hs3/src/HistFactoryJSONTool.cxx
@@ -18,6 +18,8 @@
 #include "RooStats/HistFactory/Channel.h"
 #include "RooStats/HistFactory/Sample.h"
 
+#include "Domains.h"
+
 using RooFit::Detail::JSONNode;
 using RooFit::Detail::JSONTree;
 
@@ -91,7 +93,8 @@ void exportChannel(const RooStats::HistFactory::Channel &c, JSONNode &ch)
    }
 }
 
-void exportMeasurement(RooStats::HistFactory::Measurement &measurement, JSONNode &n)
+void exportMeasurement(RooStats::HistFactory::Measurement &measurement, JSONNode &n,
+                       RooFit::JSONIO::Detail::Domains &domains)
 {
    using namespace RooStats::HistFactory;
 
@@ -166,8 +169,7 @@ void exportMeasurement(RooStats::HistFactory::Measurement &measurement, JSONNode
                auto &v = varlist[norm.GetName()];
                v.set_map();
                v["value"] << norm.GetVal();
-               v["min"] << norm.GetLow();
-               v["max"] << norm.GetHigh();
+               domains.readVariable(norm.GetName().c_str(), norm.GetLow(), norm.GetHigh());
             }
          }
          for (const auto &sys : s.GetOverallSysList()) {
@@ -177,8 +179,7 @@ void exportMeasurement(RooStats::HistFactory::Measurement &measurement, JSONNode
                auto &v = varlist[parname];
                v.set_map();
                v["value"] << 0.;
-               v["min"] << -5.;
-               v["max"] << 5.;
+               domains.readVariable(parname.c_str(), -5., 5.);
             }
          }
       }
@@ -220,7 +221,9 @@ void RooStats::HistFactory::JSONTool::PrintJSON(std::ostream &os)
 {
    std::unique_ptr<RooFit::Detail::JSONTree> tree = RooJSONFactoryWSTool::createNewJSONTree();
    auto &n = tree->rootnode();
-   exportMeasurement(_measurement, n);
+   RooFit::JSONIO::Detail::Domains domains;
+   exportMeasurement(_measurement, n, domains);
+   domains.writeJSON(n["domains"]);
    n.writeJSON(os);
 }
 void RooStats::HistFactory::JSONTool::PrintJSON(std::string const &filename)
@@ -234,7 +237,9 @@ void RooStats::HistFactory::JSONTool::PrintYAML(std::ostream &os)
    std::unique_ptr<RooFit::Detail::JSONTree> tree = RooJSONFactoryWSTool::createNewJSONTree();
    auto &n = tree->rootnode();
    n.set_map();
-   exportMeasurement(_measurement, n);
+   RooFit::JSONIO::Detail::Domains domains;
+   exportMeasurement(_measurement, n, domains);
+   domains.writeJSON(n["domains"]);
    n.writeYML(os);
 }
 

--- a/roofit/hs3/src/JSONFactories_HistFactory.cxx
+++ b/roofit/hs3/src/JSONFactories_HistFactory.cxx
@@ -200,7 +200,7 @@ bool importHistSample(RooWorkspace &ws, Scope const &scope, const JSONNode &p)
       auto getBinnedData = [&](std::string const &binnedDataName) -> RooDataHist & {
          auto *dh = dynamic_cast<RooDataHist *>(ws.embeddedData(binnedDataName));
          if (!dh) {
-            auto dhForImport = RooJSONFactoryWSTool::readBinnedData(ws, p["data"], binnedDataName, varlist);
+            auto dhForImport = RooJSONFactoryWSTool::readBinnedData(p["data"], binnedDataName, varlist);
             ws.import(*dhForImport, RooFit::Silence(true), RooFit::Embedded());
             dh = static_cast<RooDataHist *>(ws.embeddedData(dhForImport->GetName()));
          }

--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -28,7 +28,6 @@
 #include <RooRealSumFunc.h>
 #include <RooRealSumPdf.h>
 #include <RooRealVar.h>
-#include <RooSimultaneous.h>
 #include <RooWorkspace.h>
 
 #include <TH1.h>
@@ -164,11 +163,6 @@ public:
       tool->workspace()->import(func, RooFit::RecycleConflictNodes(true), RooFit::Silence(true));
       return true;
    }
-};
-
-class RooSimultaneousFactory : public RooFit::JSONIO::Importer {
-public:
-   bool importPdf(RooJSONFactoryWSTool * /*tool*/, const JSONNode & /*p*/) const override { return true; }
 };
 
 class RooBinSamplingPdfFactory : public RooFit::JSONIO::Importer {
@@ -337,19 +331,6 @@ public:
       elem["type"] << key();
       elem["samples"].fill_seq(pdf->funcList(), [](auto const &item) { return item->GetName(); });
       elem["coefficients"].fill_seq(pdf->coefList(), [](auto const &item) { return item->GetName(); });
-      return true;
-   }
-};
-
-class RooSimultaneousStreamer : public RooFit::JSONIO::Exporter {
-public:
-   std::string const &key() const override
-   {
-      const static std::string keystring = "simultaneous";
-      return keystring;
-   }
-   bool exportObject(RooJSONFactoryWSTool *, const RooAbsArg * /*func*/, JSONNode & /*elem*/) const override
-   {
       return true;
    }
 };
@@ -561,7 +542,6 @@ STATIC_EXECUTE([]() {
    registerImporter<RooAddPdfFactory>("pdfsum", false);
    registerImporter<RooHistFuncFactory>("histogram", false);
    registerImporter<RooHistPdfFactory>("histogramPdf", false);
-   registerImporter<RooSimultaneousFactory>("simultaneous", false);
    registerImporter<RooBinWidthFunctionFactory>("binwidth", false);
    registerImporter<RooRealSumPdfFactory>("sumpdf", false);
    registerImporter<RooRealSumFuncFactory>("sumfunc", false);
@@ -569,7 +549,6 @@ STATIC_EXECUTE([]() {
 
    registerExporter<RooBinWidthFunctionStreamer>(RooBinWidthFunction::Class(), false);
    registerExporter<RooProdPdfStreamer>(RooProdPdf::Class(), false);
-   registerExporter<RooSimultaneousStreamer>(RooSimultaneous::Class(), false);
    registerExporter<RooBinSamplingPdfStreamer>(RooBinSamplingPdf::Class(), false);
    registerExporter<RooHistFuncStreamer>(RooHistFunc::Class(), false);
    registerExporter<RooHistPdfStreamer>(RooHistPdf::Class(), false);

--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -168,27 +168,7 @@ public:
 
 class RooSimultaneousFactory : public RooFit::JSONIO::Importer {
 public:
-   bool importPdf(RooJSONFactoryWSTool *tool, const JSONNode &p) const override
-   {
-      std::string name(RooJSONFactoryWSTool::name(p));
-      if (!p.has_child("channels")) {
-         RooJSONFactoryWSTool::error("no channel components of '" + name + "'");
-      }
-      std::map<std::string, RooAbsPdf *> components;
-      std::string indexname(p["index"].val());
-      RooCategory cat(indexname.c_str(), indexname.c_str());
-      for (const auto &comp : p["channels"].children()) {
-         std::string catname(RooJSONFactoryWSTool::name(comp));
-         RooJSONFactoryWSTool::log(RooFit::INFO) << "importing category " << catname << std::endl;
-         std::string pdfname(comp.has_val() ? comp.val() : RooJSONFactoryWSTool::name(comp));
-         RooAbsPdf *pdf = tool->request<RooAbsPdf>(pdfname, name);
-         components[catname] = pdf;
-         cat.defineType(catname.c_str());
-      }
-      RooSimultaneous simpdf(name.c_str(), name.c_str(), components, cat);
-      tool->workspace()->import(simpdf, RooFit::RecycleConflictNodes(true), RooFit::Silence(true));
-      return true;
-   }
+   bool importPdf(RooJSONFactoryWSTool * /*tool*/, const JSONNode & /*p*/) const override { return true; }
 };
 
 class RooBinSamplingPdfFactory : public RooFit::JSONIO::Importer {
@@ -368,21 +348,8 @@ public:
       const static std::string keystring = "simultaneous";
       return keystring;
    }
-   bool exportObject(RooJSONFactoryWSTool *, const RooAbsArg *func, JSONNode &elem) const override
+   bool exportObject(RooJSONFactoryWSTool *, const RooAbsArg * /*func*/, JSONNode & /*elem*/) const override
    {
-      const RooSimultaneous *sim = static_cast<const RooSimultaneous *>(func);
-      elem["type"] << key();
-      elem["index"] << sim->indexCat().GetName();
-      auto &channels = elem["channels"];
-      channels.set_map();
-      const auto &indexCat = sim->indexCat();
-      for (const auto &cat : indexCat) {
-         const auto catname = cat.first.c_str();
-         RooAbsPdf *pdf = sim->getPdf(catname);
-         if (!pdf)
-            RooJSONFactoryWSTool::error("no pdf found for category");
-         channels[catname] << pdf->GetName();
-      }
       return true;
    }
 };

--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -417,11 +417,9 @@ public:
       if (!p.has_child("data")) {
          RooJSONFactoryWSTool::error("function '" + name + "' is of histogram type, but does not define a 'data' key");
       }
-      RooArgSet varlist;
-      RooJSONFactoryWSTool::getObservables(ws, p["data"], name, varlist);
       RooDataHist *dh = dynamic_cast<RooDataHist *>(ws.embeddedData(name));
       if (!dh) {
-         auto dhForImport = RooJSONFactoryWSTool::readBinnedData(ws, p["data"], name, varlist);
+         auto dhForImport = RooJSONFactoryWSTool::readBinnedData(p["data"], name);
          ws.import(*dhForImport, RooFit::Silence(true), RooFit::Embedded());
          dh = static_cast<RooDataHist *>(ws.embeddedData(dhForImport->GetName()));
       }
@@ -459,11 +457,9 @@ public:
       if (!p.has_child("data")) {
          RooJSONFactoryWSTool::error("function '" + name + "' is of histogram type, but does not define a 'data' key");
       }
-      RooArgSet varlist;
-      tool->getObservables(*tool->workspace(), p["data"], name, varlist);
       RooDataHist *dh = dynamic_cast<RooDataHist *>(tool->workspace()->embeddedData(name));
       if (!dh) {
-         auto dhForImport = tool->readBinnedData(*tool->workspace(), p["data"], name, varlist);
+         auto dhForImport = tool->readBinnedData(p["data"], name);
          tool->workspace()->import(*dhForImport, RooFit::Silence(true), RooFit::Embedded());
          dh = static_cast<RooDataHist *>(tool->workspace()->embeddedData(dhForImport->GetName()));
       }

--- a/roofit/hs3/src/JSONIO.cxx
+++ b/roofit/hs3/src/JSONIO.cxx
@@ -133,43 +133,39 @@ void loadFactoryExpressions(const std::string &fname)
       std::cerr << "unable to read file '" << fname << "'" << std::endl;
       return;
    }
-   try {
-      std::unique_ptr<RooFit::Detail::JSONTree> tree = RooFit::Detail::JSONTree::create(infile);
-      const RooFit::Detail::JSONNode &n = tree->rootnode();
-      for (const auto &cl : n.children()) {
-         std::string key(RooJSONFactoryWSTool::name(cl));
-         if (!cl.has_child("class")) {
-            std::cerr << "error in file '" << fname << "' for entry '" << key << "': 'class' key is required!"
-                      << std::endl;
+
+   std::unique_ptr<RooFit::Detail::JSONTree> tree = RooFit::Detail::JSONTree::create(infile);
+   const RooFit::Detail::JSONNode &n = tree->rootnode();
+   for (const auto &cl : n.children()) {
+      std::string key(RooJSONFactoryWSTool::name(cl));
+      if (!cl.has_child("class")) {
+         std::cerr << "error in file '" << fname << "' for entry '" << key << "': 'class' key is required!"
+                   << std::endl;
+         continue;
+      }
+      std::string classname(cl["class"].val());
+      TClass *c = TClass::GetClass(classname.c_str());
+      if (!c) {
+         std::cerr << "unable to find class " << classname << ", skipping." << std::endl;
+      } else {
+         RooFit::JSONIO::ImportExpression ex;
+         ex.tclass = c;
+         if (!cl.has_child("arguments")) {
+            std::cerr << "class " << classname << " seems to have no arguments attached, skipping" << std::endl;
             continue;
          }
-         std::string classname(cl["class"].val());
-         TClass *c = TClass::GetClass(classname.c_str());
-         if (!c) {
-            std::cerr << "unable to find class " << classname << ", skipping." << std::endl;
+         for (const auto &arg : cl["arguments"].children()) {
+            ex.arguments.push_back(arg.val());
+         }
+         if (c->InheritsFrom(RooAbsPdf::Class())) {
+            pdfFactoryExpressions[key] = ex;
+         } else if (c->InheritsFrom(RooAbsReal::Class())) {
+            funcFactoryExpressions[key] = ex;
          } else {
-            RooFit::JSONIO::ImportExpression ex;
-            ex.tclass = c;
-            if (!cl.has_child("arguments")) {
-               std::cerr << "class " << classname << " seems to have no arguments attached, skipping" << std::endl;
-               continue;
-            }
-            for (const auto &arg : cl["arguments"].children()) {
-               ex.arguments.push_back(arg.val());
-            }
-            if (c->InheritsFrom(RooAbsPdf::Class())) {
-               pdfFactoryExpressions[key] = ex;
-            } else if (c->InheritsFrom(RooAbsReal::Class())) {
-               funcFactoryExpressions[key] = ex;
-            } else {
-               std::cerr << "class " << classname << " seems to not inherit from any suitable class, skipping"
-                         << std::endl;
-            }
+            std::cerr << "class " << classname << " seems to not inherit from any suitable class, skipping"
+                      << std::endl;
          }
       }
-   } catch (const std::exception &ex) {
-      std::cout << "caught" << std::endl;
-      std::cerr << "unable to load factory expressions: " << ex.what() << std::endl;
    }
 }
 
@@ -215,35 +211,32 @@ void loadExportKeys(const std::string &fname)
       std::cerr << "unable to read file '" << fname << "'" << std::endl;
       return;
    }
-   try {
-      std::unique_ptr<RooFit::Detail::JSONTree> tree = RooFit::Detail::JSONTree::create(infile);
-      const RooFit::Detail::JSONNode &n = tree->rootnode();
-      for (const auto &cl : n.children()) {
-         std::string classname(RooJSONFactoryWSTool::name(cl));
-         TClass *c = TClass::GetClass(classname.c_str());
-         if (!c) {
-            std::cerr << "unable to find class " << classname << ", skipping." << std::endl;
-         } else {
-            RooFit::JSONIO::ExportKeys ex;
-            if (!cl.has_child("type")) {
-               std::cerr << "class " << classname << "has not type key set, skipping" << std::endl;
-               continue;
-            }
-            if (!cl.has_child("proxies")) {
-               std::cerr << "class " << classname << "has no proxies identified, skipping" << std::endl;
-               continue;
-            }
-            ex.type = cl["type"].val();
-            for (const auto &k : cl["proxies"].children()) {
-               std::string key(RooJSONFactoryWSTool::name(k));
-               std::string val(k.val());
-               ex.proxies[key] = val;
-            }
-            exportKeys[c] = ex;
+
+   std::unique_ptr<RooFit::Detail::JSONTree> tree = RooFit::Detail::JSONTree::create(infile);
+   const RooFit::Detail::JSONNode &n = tree->rootnode();
+   for (const auto &cl : n.children()) {
+      std::string classname(RooJSONFactoryWSTool::name(cl));
+      TClass *c = TClass::GetClass(classname.c_str());
+      if (!c) {
+         std::cerr << "unable to find class " << classname << ", skipping." << std::endl;
+      } else {
+         RooFit::JSONIO::ExportKeys ex;
+         if (!cl.has_child("type")) {
+            std::cerr << "class " << classname << "has not type key set, skipping" << std::endl;
+            continue;
          }
+         if (!cl.has_child("proxies")) {
+            std::cerr << "class " << classname << "has no proxies identified, skipping" << std::endl;
+            continue;
+         }
+         ex.type = cl["type"].val();
+         for (const auto &k : cl["proxies"].children()) {
+            std::string key(RooJSONFactoryWSTool::name(k));
+            std::string val(k.val());
+            ex.proxies[key] = val;
+         }
+         exportKeys[c] = ex;
       }
-   } catch (const std::exception &ex) {
-      std::cerr << "unable to load export keys: " << ex.what() << std::endl;
    }
 }
 

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -597,7 +597,7 @@ JSONNode *RooJSONFactoryWSTool::exportObject(const RooAbsArg *func)
    auto &n = orootnode()[func->InheritsFrom(RooAbsPdf::Class()) ? "distributions" : "functions"];
    n.set_map();
 
-   const char* name = func->GetName();
+   const char *name = func->GetName();
 
    // if this element already exists, skip
    if (n.has_child(name))
@@ -611,22 +611,16 @@ JSONNode *RooJSONFactoryWSTool::exportObject(const RooAbsArg *func)
    auto it = exporters.find(cl);
    if (it != exporters.end()) { // check if we have a specific exporter available
       for (auto &exp : it->second) {
-         try {
-            auto &elem = n[name];
-            elem.set_map();
-            if (!exp->exportObject(this, func, elem)) {
-               continue;
-            }
-            if (exp->autoExportDependants()) {
-               RooJSONFactoryWSTool::exportDependants(func);
-            }
-            RooJSONFactoryWSTool::exportAttributes(func, elem);
-            return &elem;
-         } catch (const std::exception &ex) {
-            std::cerr << "error exporting " << func->ClassName() << " " << name << ": " << ex.what()
-                      << ". skipping." << std::endl;
-            return nullptr;
+         auto &elem = n[name];
+         elem.set_map();
+         if (!exp->exportObject(this, func, elem)) {
+            continue;
          }
+         if (exp->autoExportDependants()) {
+            RooJSONFactoryWSTool::exportDependants(func);
+         }
+         RooJSONFactoryWSTool::exportAttributes(func, elem);
+         return &elem;
       }
    }
 
@@ -790,13 +784,14 @@ void RooJSONFactoryWSTool::importFunction(const JSONNode &p, bool isPdf)
          ::importAttributes(func, p);
       }
    } catch (const RooJSONFactoryWSTool::DependencyMissingError &ex) {
-      throw;
+      throw ex;
    } catch (const RooJSONFactoryWSTool::MissingRootnodeError &ex) {
-      throw;
+      throw ex;
    } catch (const std::exception &ex) {
       std::stringstream ss;
       ss << "RooJSONFactoryWSTool(): error importing " << name << ": " << ex.what() << ". skipping." << std::endl;
       logInputArgumentsError(std::move(ss));
+      throw ex;
    }
 }
 
@@ -929,7 +924,7 @@ void RooJSONFactoryWSTool::exportData(RooAbsData *data, JSONNode &n)
       for (int i = 0; i < dh->numEntries(); ++i) {
          double w = dh->weight(i);
          // To make sure there are no unnecessary floating points in the JSON
-         if(int(w) == w) {
+         if (int(w) == w) {
             weights.append_child() << int(w);
          } else {
             weights.append_child() << w;
@@ -1250,7 +1245,7 @@ void RooJSONFactoryWSTool::exportAllObjects(JSONNode &n)
          exportModelConfig(n, *mcs.back());
       }
    }
-   for (RooAbsArg* pdf : _workspace.allPdfs()) {
+   for (RooAbsArg *pdf : _workspace.allPdfs()) {
 
       if (!pdf->hasClients() || pdf->getAttribute("toplevel")) {
          bool hasMC = false;

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -538,14 +538,16 @@ void RooJSONFactoryWSTool::append(JSONNode &n, const std::string &elem)
 void RooJSONFactoryWSTool::exportAttributes(const RooAbsArg *arg, JSONNode &n)
 {
    // export all string attributes of an object
-   if (arg->stringAttributes().size() > 0) {
-      auto &dict = n["dict"];
-      dict.set_map();
+   if (!arg->stringAttributes().empty()) {
       for (const auto &it : arg->stringAttributes()) {
+         // We don't want to span the JSON with the factory tags
+         if(it.first == "factory_tag") continue;
+         auto &dict = n["dict"];
+         dict.set_map();
          dict[it.first] << it.second;
       }
    }
-   if (arg->attributes().size() > 0) {
+   if (!arg->attributes().empty()) {
       auto &tags = n["tags"];
       for (const auto &it : arg->attributes()) {
          RooJSONFactoryWSTool::append(tags, it);

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -216,7 +216,7 @@ RooAbsReal *RooJSONFactoryWSTool::request<RooAbsReal>(const std::string &objname
    if (retval)
       return retval;
    if (isNumber(objname))
-      return dynamic_cast<RooAbsReal *>(_workspace.factory(objname));
+      return &RooFit::RooConst(std::stod(objname));
    if (irootnode().has_child("distributions")) {
       const JSONNode &pdfs = irootnode()["distributions"];
       if (pdfs.has_child(objname)) {
@@ -1287,8 +1287,9 @@ void RooJSONFactoryWSTool::exportAllObjects(JSONNode &n)
 
 void RooJSONFactoryWSTool::exportTopLevelPdf(JSONNode &node, RooAbsPdf const &pdf, std::string const &modelConfigName)
 {
-   auto * pdfNode = RooJSONFactoryWSTool::exportObject(&pdf);
-   if(!pdfNode) return;
+   auto *pdfNode = RooJSONFactoryWSTool::exportObject(&pdf);
+   if (!pdfNode)
+      return;
    if (!pdf.getAttribute("toplevel"))
       RooJSONFactoryWSTool::append((*pdfNode)["tags"], "toplevel");
    auto &dict = (*pdfNode)["dict"];

--- a/roofit/hs3/test/CMakeLists.txt
+++ b/roofit/hs3/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 ROOT_ADD_GTEST(testRooFitHS3 testRooFitHS3.cxx LIBRARIES RooFitCore RooFit RooFitHS3)
+ROOT_ADD_GTEST(testHS3SimultaneousFit testHS3SimultaneousFit.cxx LIBRARIES RooFitCore RooFit RooFitHS3 RooStats)
 ROOT_ADD_GTEST(testHS3HistFactory testHS3HistFactory.cxx LIBRARIES RooFit RooFitHS3 HistFactory
   COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/test_hs3_histfactory_json_input.root
 )

--- a/roofit/hs3/test/testHS3HistFactory.cxx
+++ b/roofit/hs3/test/testHS3HistFactory.cxx
@@ -105,11 +105,11 @@ TEST(TestHS3HistFactoryJSON, Closure)
 
    using namespace RooFit;
 
-   pdf->fitTo(*data, Strategy(1), Minos(*mc->GetParametersOfInterest()),
-              GlobalObservables(*mc->GetGlobalObservables()));
+   pdf->fitTo(*data, Strategy(1), Minos(*mc->GetParametersOfInterest()), GlobalObservables(*mc->GetGlobalObservables()),
+              PrintLevel(-1));
 
    pdfFromJson->fitTo(*dataFromJson, Strategy(1), Minos(*mcFromJson->GetParametersOfInterest()),
-                      GlobalObservables(*mcFromJson->GetGlobalObservables()));
+                      GlobalObservables(*mcFromJson->GetGlobalObservables()), PrintLevel(-1));
 
    const double muVal = ws->var("mu")->getVal();
    const double muJsonVal = wsFromJson->var("mu")->getVal();

--- a/roofit/hs3/test/testHS3SimultaneousFit.cxx
+++ b/roofit/hs3/test/testHS3SimultaneousFit.cxx
@@ -1,0 +1,139 @@
+// Test for the JSON IO of a full workspace with a multi-channel model and
+// data.
+// Author: Jonas Rembser, CERN 02/2023
+
+#include <RooFitHS3/JSONIO.h>
+#include <RooFitHS3/RooJSONFactoryWSTool.h>
+
+#include <RooCategory.h>
+#include <RooConstVar.h>
+#include <RooDataHist.h>
+#include <RooDataSet.h>
+#include <RooFitResult.h>
+#include <RooGlobalFunc.h>
+#include <RooProdPdf.h>
+#include <RooRealVar.h>
+#include <RooWorkspace.h>
+
+#include <RooStats/ModelConfig.h>
+
+#include <TROOT.h>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+/// Generating an unbinned dataset from a binned one.
+std::unique_ptr<RooDataSet> makeUnbinned(RooDataHist const &hist)
+{
+   RooArgSet obs(*hist.get());
+   RooRealVar weight{"weight", "weight", 1.0};
+   obs.add(weight, true);
+   auto data = std::make_unique<RooDataSet>(hist.GetName(), hist.GetTitle(), obs, RooFit::WeightVar(weight));
+   for (int i = 0; i < hist.numEntries(); ++i) {
+      data->add(*hist.get(i), hist.weight(i));
+   }
+   return data;
+}
+
+std::unique_ptr<RooFitResult> writeJSONAndFitModel(std::string &jsonStr)
+{
+   using namespace RooFit;
+
+   RooWorkspace ws{"workspace"};
+
+   // Build two channels for different observables where the distributions
+   // share one parameter: the mean for the signal.
+
+   // Channel 1: Gaussian signal and exponential background
+   ws.factory("Gaussian::sig_1(x_1[0, 10], mean[5.0, 0, 10], sigma_1[0.5, 0.1, 10.0])");
+   ws.factory("Exponential::bkg_1(x_1, c_1[-0.2, -100, -0.001])");
+   ws.factory("SUM::model_1(n_sig_1[10000, 0, 10000000] * sig_1, nbkg_2[100000, 0, 10000000] * bkg_1)");
+
+   // Channel 2: Crystal ball signal and polynomial background
+   ws.factory("CBShape::sig_2(x_2[0, 10], mean[5.0, 0, 10], sigma_2[0.8, 0.1, 10.0], alpha[0.9, 0.1, 10.0], "
+              "ncb[1.0, 0.1, 10.0])");
+   ws.factory("Polynomial::bkg_2(x_2, {a_0[3.0, -10, 10], a_1[-0.3, -10, 10], a_2[0.01, -10, 10]}, 0)");
+   ws.factory("SUM::model_2(n_sig_2[30000, 0, 10000000] * sig_2, nbkg_2[100000, 0, 10000000] * bkg_2)");
+
+   // Simultaneous PDF and model config
+   ws.factory("SIMUL::simPdf(channelCat[channel_1=0, channel_2=1], channel_1=model_1, channel_2=model_2)");
+
+   RooStats::ModelConfig modelConfig{"ModelConfig"};
+
+   modelConfig.SetWS(ws);
+   modelConfig.SetPdf("simPdf");
+   modelConfig.SetParametersOfInterest("mean");
+   modelConfig.SetObservables("x_1,x_2");
+
+   ws.import(modelConfig);
+
+   modelConfig.Print();
+
+   RooRealVar &x1 = *ws.var("x_1");
+   RooRealVar &x2 = *ws.var("x_2");
+   x1.setBins(20);
+   x2.setBins(20);
+
+   RooAbsPdf &model_1 = *ws.pdf("model_1");
+   RooAbsPdf &model_2 = *ws.pdf("model_2");
+
+   std::unique_ptr<RooDataHist> data1{model_1.generateBinned(x1)};
+   std::unique_ptr<RooDataHist> data2{model_2.generateBinned(x2)};
+
+   data1->SetName("obsData_channel_1");
+   data2->SetName("obsData_channel_2");
+
+   ws.import(*data1);
+   ws.import(*data2);
+
+   RooJSONFactoryWSTool tool{ws};
+
+   // Export before fitting to keep the prefit values
+   jsonStr = tool.exportJSONtoString();
+
+   RooRealVar weight{"weight", "weight", 1.0};
+   RooDataSet obsData{"obsData",
+                      "obsData",
+                      {x1, x2, weight},
+                      Index(*ws.cat("channelCat")),
+                      Import({{"channel_1", makeUnbinned(*data1).get()}, {"channel_2", makeUnbinned(*data2).get()}}),
+                      WeightVar(weight)};
+
+   return std::unique_ptr<RooFitResult>{ws.pdf("simPdf")->fitTo(obsData, Save(), PrintLevel(-1), PrintEvalErrors(-1))};
+}
+
+std::unique_ptr<RooFitResult> readJSONAndFitModel(std::string const &jsonStr)
+{
+   using namespace RooFit;
+
+   RooWorkspace ws{"workspace"};
+   RooJSONFactoryWSTool tool{ws};
+
+   tool.importJSONfromString(jsonStr);
+
+   auto &pdf = *ws.pdf("simPdf");
+
+   return std::unique_ptr<RooFitResult>{pdf.fitTo(*ws.data("obsData"), Save(), PrintLevel(-1), PrintEvalErrors(-1))};
+}
+
+} // namespace
+
+TEST(RooFitHS3, SimultaneousFit)
+{
+   using namespace RooFit;
+
+   auto etcDir = std::string(TROOT::GetEtcDir());
+   RooFit::JSONIO::loadExportKeys(etcDir + "/RooFitHS3_wsexportkeys.json");
+   RooFit::JSONIO::loadFactoryExpressions(etcDir + "/RooFitHS3_wsfactoryexpressions.json");
+
+   std::string jsonStr;
+
+   std::unique_ptr<RooFitResult> res1 = writeJSONAndFitModel(jsonStr);
+   std::unique_ptr<RooFitResult> res2 = readJSONAndFitModel(jsonStr);
+
+   // todo: also check the modelconfig for equality
+
+   // The precision is not great, needs to be understood why it is not exactly the same
+   EXPECT_TRUE(res2->isIdentical(*res1, 1e-3, 1e-3));
+}

--- a/roofit/hs3/test/testHS3SimultaneousFit.cxx
+++ b/roofit/hs3/test/testHS3SimultaneousFit.cxx
@@ -53,7 +53,7 @@ std::unique_ptr<RooFitResult> writeJSONAndFitModel(std::string &jsonStr)
    // Channel 2: Crystal ball signal and polynomial background
    ws.factory("CBShape::sig_2(x_2[0, 10], mean[5.0, 0, 10], sigma_2[0.8, 0.1, 10.0], alpha[0.9, 0.1, 10.0], "
               "ncb[1.0, 0.1, 10.0])");
-   ws.factory("Polynomial::bkg_2(x_2, {a_0[3.0, -10, 10], a_1[-0.3, -10, 10], a_2[0.01, -10, 10]}, 0)");
+   ws.factory("Polynomial::bkg_2(x_2, {3.0, a_1[-0.3, -10, 10], a_2[0.01, -10, 10]}, 0)");
    ws.factory("SUM::model_2(n_sig_2[30000, 0, 10000000] * sig_2, nbkg_2[100000, 0, 10000000] * bkg_2)");
 
    // Simultaneous PDF and model config

--- a/tutorials/roofit/rf515_hfJSON.json
+++ b/tutorials/roofit/rf515_hfJSON.json
@@ -20,7 +20,7 @@
             "obs": "observed_channel1"
         }
     },
-    "pdfs": {
+    "distributions": {
         "model_channel1": {
             "type": "histfactory",
             "observables": {
@@ -103,7 +103,7 @@
             ]
         }
     },
-    "data": {
+    "observations": {
         "observed_channel1": {
             "observables": {
                 "obs_x_channel1": {

--- a/tutorials/roofit/rf515_hfJSON.json
+++ b/tutorials/roofit/rf515_hfJSON.json
@@ -93,14 +93,23 @@
             }
         }
     },
-    "variables": {
-        "mu": {
-            "value": 1,
-            "min": -3,
-            "max": 5,
-            "tags": [
-                "poi"
+    "domains": {
+        "default_domain": {
+            "type": "product_domain",
+            "variables": [
+                {
+                    "max": 5.0,
+                    "min": -3.0,
+                    "name": "mu"
+                }
             ]
+        }
+    },
+    "estimates": {
+        "default_values": {
+            "mu": {
+                "value": 1
+            }
         }
     },
     "observations": {

--- a/tutorials/roofit/rf515_hfJSON.json
+++ b/tutorials/roofit/rf515_hfJSON.json
@@ -1,18 +1,26 @@
 {
-    "pdfs": {
+    "analyses": {
         "main": {
-            "dict": {
-                "InterpolationScheme": ""
-            },
-            "index": "channelCat",
-            "type": "simultaneous",
-            "tags": [
-                "toplevel"
+            "likelihoods": [
+                "channel1"
             ],
-            "channels": {
-                "channel1" : "model_channel1"
-            }
-        },
+            "pois": [
+                "mu"
+            ],
+            "observables": [
+                "obs_x_channel1"
+            ],
+            "InterpolationScheme": "",
+            "combinedObservationName": "observed"
+        }
+    },
+    "likelihoods": {
+        "channel1": {
+            "dist": "model_channel1",
+            "obs": "observed_channel1"
+        }
+    },
+    "pdfs": {
         "model_channel1": {
             "type": "histfactory",
             "observables": {
@@ -96,21 +104,18 @@
         }
     },
     "data": {
-        "observed": {
-            "index": "channelCat",
-            "channel1": {
-                "observables": {
-                    "obs_x_channel1": {
-                        "nbins": 2,
-                        "min": 1,
-                        "max": 2
-                    }
-                },
-                "counts": [
-                    122,
-                    112
-                ]
-            }
+        "observed_channel1": {
+            "observables": {
+                "obs_x_channel1": {
+                    "nbins": 2,
+                    "min": 1,
+                    "max": 2
+                }
+            },
+            "counts": [
+                122,
+                112
+            ]
         }
     }
 }


### PR DESCRIPTION
* Use proper infinity checks in RooFit HS3
* New `domains` section in JSON to store variable ranges
* Some refactoring of RooFit HS3
* Decouple `RooDataHist` reading from rest of workspace in RooFitHS3
* Add likelihoods and analyses fields for HS3 v2
* Complete also the reading of likelihoods and analysis fields
* Rename fields in JSON file to match new standard

More description in the commit descriptions.
