### PR TITLE
[VecOps] Avoid -ffast-math

### DIFF
--- a/math/vecops/CMakeLists.txt
+++ b/math/vecops/CMakeLists.txt
@@ -33,13 +33,6 @@ elseif(vdt)
   target_link_libraries(ROOTVecOps PUBLIC ${VDT_LIBRARIES})
 endif()
 
-if(MSVC)
-  target_compile_options(ROOTVecOps PRIVATE -O2 /fp:fast)
-  target_compile_definitions(ROOTVecOps PRIVATE _USE_MATH_DEFINES)
-else()
-  target_compile_options(ROOTVecOps PRIVATE -O3 -ffast-math)
-endif()
-
 include(CheckCXXSymbolExists)
 check_symbol_exists(m __sqrt_finite HAVE_FINITE_MATH)
 if(NOT HAVE_FINITE_MATH AND NOT MSVC)


### PR DESCRIPTION
The performance gains are unclear and the option can harm users linking against the library with gcc<13, see also https://gcc.gnu.org/bugzilla/show_bug.cgi?id=55522 .

EDIT: relevant forum conversation: https://root-forum.cern.ch/t/rootvecops-enables-ffast-math/53422 