### PR TITLE
Add missing include to metacling test

### DIFF
--- a/core/metacling/test/TClingCallFuncTests.cxx
+++ b/core/metacling/test/TClingCallFuncTests.cxx
@@ -1,5 +1,6 @@
 #include "ROOT/TestSupport.hxx"
 #include "TInterpreter.h"
+#include "TCollection.h"
 
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"


### PR DESCRIPTION
Detected with -Ddev=ON cmake flags

