### PR TITLE
[RF] Add clad derivative support to RooFuncWrapper

### DIFF
--- a/roofit/batchcompute/inc/RooSpan.h
+++ b/roofit/batchcompute/inc/RooSpan.h
@@ -73,11 +73,7 @@ public:
 
 
   /// Construct from start pointer and size.
-  constexpr RooSpan(typename std::span<T>::pointer beginIn,
-      typename std::span<T>::size_type sizeIn) :
-  _span{beginIn, sizeIn}
-  { }
-
+  constexpr RooSpan(typename std::span<T>::pointer beginIn, std::size_t sizeIn) : _span{beginIn, sizeIn} {}
 
   constexpr RooSpan(const std::vector<typename std::remove_cv<T>::type>& vec) noexcept :
   _span{vec}
@@ -108,18 +104,21 @@ public:
   }
 
 #ifdef NDEBUG
-  constexpr typename std::span<T>::reference operator[](typename std::span<T>::size_type i) const noexcept {
-    return _span[i];
+  constexpr typename std::span<T>::reference operator[](std::size_t i) const noexcept
+  {
+     return _span[i];
   }
 #else
-  typename std::span<T>::reference operator[](typename std::span<T>::size_type i) const noexcept {
-    assert(i < _span.size());
-    return _span[i];
+  typename std::span<T>::reference operator[](std::size_t i) const noexcept
+  {
+     assert(i < _span.size());
+     return _span[i];
   }
 #endif
 
-  constexpr typename std::span<T>::size_type size() const noexcept {
-    return _span.size();
+  constexpr std::size_t size() const noexcept
+  {
+     return _span.size();
   }
 
   constexpr bool empty() const noexcept {

--- a/roofit/roofitcore/inc/RooFuncWrapper.h
+++ b/roofit/roofitcore/inc/RooFuncWrapper.h
@@ -27,22 +27,51 @@
 /// @brief  A wrapper class to store a C++ function of type 'double (*)(double* )'.
 /// The parameters can be accessed as x[<relative position of param in paramSet>] in the function body.
 /// @tparam Func Function pointer to the generated function.
-template <typename Func = double (*)(double *)>
+template <typename Func = double (*)(double *), typename Grad = void (*)(double *, double *)>
 class RooFuncWrapper final : public RooAbsReal {
 public:
    RooFuncWrapper(const char *name, const char *title, std::string const &funcBody, RooArgSet const &paramSet)
       : RooAbsReal{name, title}, _params{"!params", "List of parameters", this}
    {
       std::string funcName = name;
-      std::string bodyWithSig = "double " + funcName + "(double* x) {" + funcBody + "}";
-      bool comp = gInterpreter->Declare(bodyWithSig.c_str());
+      std::string gradName = funcName + "_grad";
+      std::string requestName = funcName + "_req";
+      std::string wrapperName = funcName + "_derivativeWrapper";
+
+      gInterpreter->Declare("#pragma cling optimize(2)");
+
+      // Declare the function
+      std::stringstream bodyWithSigStrm;
+      bodyWithSigStrm << "double " << funcName << "(double* x) {" << funcBody << "}";
+      bool comp = gInterpreter->Declare(bodyWithSigStrm.str().c_str());
       if (!comp) {
          std::stringstream errorMsg;
          errorMsg << "Function " << funcName << " could not be compiled. See above for details.";
          coutE(InputArguments) << errorMsg.str() << std::endl;
          throw std::runtime_error(errorMsg.str().c_str());
       }
-      _func = (Func)gInterpreter->ProcessLine((funcName + ";").c_str());
+      _func = reinterpret_cast<Func>(gInterpreter->ProcessLine((funcName + ";").c_str()));
+
+      // Calculate gradient
+      gInterpreter->ProcessLine("#include <Math/CladDerivator.h>");
+      // disable clang-format for making the following code unreadable.
+      // clang-format off
+      std::stringstream requestFuncStrm;
+      requestFuncStrm << "#pragma clad ON\n"
+                         "void " << requestName << "() {\n"
+                         "  clad::gradient(" << funcName << ");\n"
+                         "}\n"
+                         "#pragma clad OFF";
+      // clang-format on
+      comp = gInterpreter->Declare(requestFuncStrm.str().c_str());
+      if (!comp) {
+         std::stringstream errorMsg;
+         errorMsg << "Function " << funcName << " could not be be differentiated. See above for details.";
+         coutE(InputArguments) << errorMsg.str() << std::endl;
+         throw std::runtime_error(errorMsg.str().c_str());
+      }
+
+      // Extract parameters
       for (auto *param : paramSet) {
          if (!dynamic_cast<RooAbsReal *>(param)) {
             std::stringstream errorMsg;
@@ -53,6 +82,19 @@ public:
          }
          _params.add(*param);
       }
+      _gradientVarBuffer.reserve(_params.size());
+
+      // Build a wrapper over the derivative to hide clad specific types such as 'array_ref'.
+      // disable clang-format for making the following code unreadable.
+      // clang-format off
+      std::stringstream dWrapperStrm;
+      dWrapperStrm << "void " << wrapperName << "(double* in, double* out) {\n"
+                      "  clad::array_ref<double> cladOut(out, " << _params.size() << ");\n"
+                      "  " << gradName << "(in, cladOut);\n"
+                      "}";
+      // clang-format on
+      gInterpreter->Declare(dWrapperStrm.str().c_str());
+      _grad = reinterpret_cast<Grad>(gInterpreter->ProcessLine((wrapperName + ";").c_str()));
    }
 
    RooFuncWrapper(const RooFuncWrapper &other, const char *name = nullptr)
@@ -64,20 +106,32 @@ public:
 
    double defaultErrorLevel() const override { return 0.5; }
 
+   void getGradient(double *out) const
+   {
+      updateGradientVarBuffer();
+
+      _grad(_gradientVarBuffer.data(), out);
+   }
+
 protected:
+   void updateGradientVarBuffer() const
+   {
+      std::transform(_params.begin(), _params.end(), _gradientVarBuffer.begin(),
+                     [](RooAbsArg *obj) { return static_cast<RooAbsReal *>(obj)->getValV(); });
+   }
+
    double evaluate() const override
    {
-      std::vector<double> paramVals;
-      paramVals.reserve(_params.size());
-      std::transform(_params.begin(), _params.end(), std::back_inserter(paramVals),
-                     [](RooAbsArg *obj) { return static_cast<RooAbsReal *>(obj)->getValV(); });
+      updateGradientVarBuffer();
 
-      return _func(paramVals.data());
+      return _func(_gradientVarBuffer.data());
    }
 
 private:
    RooListProxy _params;
    Func _func;
+   Grad _grad;
+   mutable std::vector<double> _gradientVarBuffer;
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooHelpers.h
+++ b/roofit/roofitcore/inc/RooHelpers.h
@@ -157,6 +157,8 @@ struct BinnedLOutput {
 
 BinnedLOutput getBinnedL(RooAbsPdf &pdf);
 
+void getSortedComputationGraph(RooAbsReal const &func, RooArgSet &out);
+
 }
 
 #endif /* ROOFIT_ROOFITCORE_INC_ROOHELPERS_H_ */

--- a/roofit/roofitcore/src/RooFitDriver.cxx
+++ b/roofit/roofitcore/src/RooFitDriver.cxx
@@ -126,17 +126,8 @@ RooFitDriver::RooFitDriver(const RooAbsReal &absReal, RooFit::BatchModeOption ba
    // Some checks and logging of used architectures
    RooFit::BatchModeHelpers::logArchitectureInfo(_batchMode);
 
-   // Get the set of nodes in the computation graph. Do the detour via
-   // RooArgList to avoid deduplication done after adding each element.
-   RooArgList serverList;
-   topNode().treeNodeServerList(&serverList, nullptr, true, true, false, true);
-   // If we fill the servers in reverse order, they are approximately in
-   // topological order so we save a bit of work in sortTopologically().
    RooArgSet serverSet;
-   serverSet.add(serverList.rbegin(), serverList.rend(), /*silent=*/true);
-   // Sort nodes topologically: the servers of any node will be before that
-   // node in the collection.
-   serverSet.sortTopologically();
+   RooHelpers::getSortedComputationGraph(topNode(), serverSet);
 
    _dataMapCPU.resize(serverSet.size());
    _dataMapCUDA.resize(serverSet.size());

--- a/roofit/roofitcore/src/RooHelpers.cxx
+++ b/roofit/roofitcore/src/RooHelpers.cxx
@@ -295,4 +295,19 @@ BinnedLOutput getBinnedL(RooAbsPdf &pdf)
    return {nullptr, false};
 }
 
+/// Get the topologically-sorted list of all nodes in the computation graph.
+void getSortedComputationGraph(RooAbsReal const &func, RooArgSet &out)
+{
+   // Get the set of nodes in the computation graph. Do the detour via
+   // RooArgList to avoid deduplication done after adding each element.
+   RooArgList serverList;
+   func.treeNodeServerList(&serverList, nullptr, true, true, false, true);
+   // If we fill the servers in reverse order, they are approximately in
+   // topological order so we save a bit of work in sortTopologically().
+   out.add(serverList.rbegin(), serverList.rend(), /*silent=*/true);
+   // Sort nodes topologically: the servers of any node will be before that
+   // node in the collection.
+   out.sortTopologically();
+}
+
 }


### PR DESCRIPTION
This PR uses clad to calculate the AD-based derivatives for the C/C++ functions wrapped by the RooFuncWrapper class and introduces the 'getGradient' interface to get these derivatives from the generated gradient function. It also replaces a `std::span` templated type with `std::size` to avoid conflicts with system headers.