### PR TITLE
[ntuple] Add support for float, double, Int split encodings

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -599,6 +599,7 @@ The following fundamental types are stored as `leaf` fields with a single column
 | double                           | SplitReal64            | Real64                |
 
 Possibly available `const` and `volatile` qualifiers of the C++ types are ignored for serialization.
+If the ntuple is stored uncompressed, the default changes from split encoding to non-split encoding where applicable.
 
 ### STL Types and Collections
 
@@ -628,7 +629,7 @@ They are stored as two fields:
 Fixed-sized arrays are stored as two fields:
   - A repetitive field of type `std::array<T, N>` with no attached columns. The array size `N` is stored in the field meta-data.
   - Child field of type `T`, which must be a type with RNTuple I/O support.
-  
+
 Multi-dimensional arrays of the form `T[N][M]...` are currently not supported.
 
 #### std::variant<T1, T2, ..., Tn>

--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -641,6 +641,20 @@ public:
    void Unpack(void *dst, void *src, std::size_t count) const final;
 };
 
+template <>
+class RColumnElement<std::int64_t, EColumnType::kSplitInt32> : public RColumnElementBase {
+public:
+   static constexpr bool kIsMappable = false;
+   static constexpr std::size_t kSize = sizeof(std::int64_t);
+   static constexpr std::size_t kBitsOnStorage = 32;
+   explicit RColumnElement(std::int64_t *value) : RColumnElementBase(value, kSize) {}
+   bool IsMappable() const final { return kIsMappable; }
+   std::size_t GetBitsOnStorage() const final { return kBitsOnStorage; }
+
+   void Pack(void *dst, void *src, std::size_t count) const final;
+   void Unpack(void *dst, void *src, std::size_t count) const final;
+};
+
 template <typename CppT>
 std::unique_ptr<RColumnElementBase> RColumnElementBase::Generate(EColumnType type)
 {

--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -488,6 +488,26 @@ public:
 };
 
 template <>
+class RColumnElement<std::int32_t, EColumnType::kSplitInt32> : public RColumnElementSplitLE<std::int32_t> {
+public:
+   static constexpr std::size_t kSize = sizeof(std::int32_t);
+   static constexpr std::size_t kBitsOnStorage = kSize * 8;
+   explicit RColumnElement(std::int32_t *value) : RColumnElementSplitLE(value, kSize) {}
+   bool IsMappable() const final { return kIsMappable; }
+   std::size_t GetBitsOnStorage() const final { return kBitsOnStorage; }
+};
+
+template <>
+class RColumnElement<std::uint32_t, EColumnType::kSplitInt32> : public RColumnElementSplitLE<std::uint32_t> {
+public:
+   static constexpr std::size_t kSize = sizeof(std::uint32_t);
+   static constexpr std::size_t kBitsOnStorage = kSize * 8;
+   explicit RColumnElement(std::uint32_t *value) : RColumnElementSplitLE(value, kSize) {}
+   bool IsMappable() const final { return kIsMappable; }
+   std::size_t GetBitsOnStorage() const final { return kBitsOnStorage; }
+};
+
+template <>
 class RColumnElement<std::int64_t, EColumnType::kInt64> : public RColumnElementLE<std::int64_t> {
 public:
    static constexpr std::size_t kSize = sizeof(std::int64_t);
@@ -619,6 +639,7 @@ std::unique_ptr<RColumnElementBase> RColumnElementBase::Generate(EColumnType typ
    case EColumnType::kSplitReal64: return std::make_unique<RColumnElement<CppT, EColumnType::kSplitReal64>>(nullptr);
    case EColumnType::kSplitReal32: return std::make_unique<RColumnElement<CppT, EColumnType::kSplitReal32>>(nullptr);
    case EColumnType::kSplitInt64: return std::make_unique<RColumnElement<CppT, EColumnType::kSplitInt64>>(nullptr);
+   case EColumnType::kSplitInt32: return std::make_unique<RColumnElement<CppT, EColumnType::kSplitInt32>>(nullptr);
    default: R__ASSERT(false);
    }
    // never here

--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -508,6 +508,26 @@ public:
 };
 
 template <>
+class RColumnElement<std::int64_t, EColumnType::kSplitInt64> : public RColumnElementSplitLE<std::int64_t> {
+public:
+   static constexpr std::size_t kSize = sizeof(std::int64_t);
+   static constexpr std::size_t kBitsOnStorage = kSize * 8;
+   explicit RColumnElement(std::int64_t *value) : RColumnElementSplitLE(value, kSize) {}
+   bool IsMappable() const final { return kIsMappable; }
+   std::size_t GetBitsOnStorage() const final { return kBitsOnStorage; }
+};
+
+template <>
+class RColumnElement<std::uint64_t, EColumnType::kSplitInt64> : public RColumnElementSplitLE<std::uint64_t> {
+public:
+   static constexpr std::size_t kSize = sizeof(std::uint64_t);
+   static constexpr std::size_t kBitsOnStorage = kSize * 8;
+   explicit RColumnElement(std::uint64_t *value) : RColumnElementSplitLE(value, kSize) {}
+   bool IsMappable() const final { return kIsMappable; }
+   std::size_t GetBitsOnStorage() const final { return kBitsOnStorage; }
+};
+
+template <>
 class RColumnElement<ClusterSize_t, EColumnType::kIndex> : public RColumnElementLE<ClusterSize_t::ValueType> {
 public:
    static constexpr std::size_t kSize = sizeof(ROOT::Experimental::ClusterSize_t);
@@ -585,19 +605,20 @@ template <typename CppT>
 std::unique_ptr<RColumnElementBase> RColumnElementBase::Generate(EColumnType type)
 {
    switch (type) {
-   case EColumnType::kReal32: return std::make_unique<RColumnElement<CppT, EColumnType::kReal32>>(nullptr);
-   case EColumnType::kSplitReal32: return std::make_unique<RColumnElement<CppT, EColumnType::kSplitReal32>>(nullptr);
-   case EColumnType::kReal64: return std::make_unique<RColumnElement<CppT, EColumnType::kReal64>>(nullptr);
-   case EColumnType::kSplitReal64: return std::make_unique<RColumnElement<CppT, EColumnType::kSplitReal64>>(nullptr);
-   case EColumnType::kChar: return std::make_unique<RColumnElement<CppT, EColumnType::kChar>>(nullptr);
-   case EColumnType::kByte: return std::make_unique<RColumnElement<CppT, EColumnType::kByte>>(nullptr);
-   case EColumnType::kInt8: return std::make_unique<RColumnElement<CppT, EColumnType::kInt8>>(nullptr);
-   case EColumnType::kInt16: return std::make_unique<RColumnElement<CppT, EColumnType::kInt16>>(nullptr);
-   case EColumnType::kInt32: return std::make_unique<RColumnElement<CppT, EColumnType::kInt32>>(nullptr);
-   case EColumnType::kInt64: return std::make_unique<RColumnElement<CppT, EColumnType::kInt64>>(nullptr);
-   case EColumnType::kBit: return std::make_unique<RColumnElement<CppT, EColumnType::kBit>>(nullptr);
    case EColumnType::kIndex: return std::make_unique<RColumnElement<CppT, EColumnType::kIndex>>(nullptr);
    case EColumnType::kSwitch: return std::make_unique<RColumnElement<CppT, EColumnType::kSwitch>>(nullptr);
+   case EColumnType::kByte: return std::make_unique<RColumnElement<CppT, EColumnType::kByte>>(nullptr);
+   case EColumnType::kChar: return std::make_unique<RColumnElement<CppT, EColumnType::kChar>>(nullptr);
+   case EColumnType::kBit: return std::make_unique<RColumnElement<CppT, EColumnType::kBit>>(nullptr);
+   case EColumnType::kReal64: return std::make_unique<RColumnElement<CppT, EColumnType::kReal64>>(nullptr);
+   case EColumnType::kReal32: return std::make_unique<RColumnElement<CppT, EColumnType::kReal32>>(nullptr);
+   case EColumnType::kInt64: return std::make_unique<RColumnElement<CppT, EColumnType::kInt64>>(nullptr);
+   case EColumnType::kInt32: return std::make_unique<RColumnElement<CppT, EColumnType::kInt32>>(nullptr);
+   case EColumnType::kInt16: return std::make_unique<RColumnElement<CppT, EColumnType::kInt16>>(nullptr);
+   case EColumnType::kInt8: return std::make_unique<RColumnElement<CppT, EColumnType::kInt8>>(nullptr);
+   case EColumnType::kSplitReal64: return std::make_unique<RColumnElement<CppT, EColumnType::kSplitReal64>>(nullptr);
+   case EColumnType::kSplitReal32: return std::make_unique<RColumnElement<CppT, EColumnType::kSplitReal32>>(nullptr);
+   case EColumnType::kSplitInt64: return std::make_unique<RColumnElement<CppT, EColumnType::kSplitInt64>>(nullptr);
    default: R__ASSERT(false);
    }
    // never here

--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -468,6 +468,26 @@ public:
 };
 
 template <>
+class RColumnElement<std::int16_t, EColumnType::kSplitInt16> : public RColumnElementSplitLE<std::int16_t> {
+public:
+   static constexpr std::size_t kSize = sizeof(std::int16_t);
+   static constexpr std::size_t kBitsOnStorage = kSize * 8;
+   explicit RColumnElement(std::int16_t *value) : RColumnElementSplitLE(value, kSize) {}
+   bool IsMappable() const final { return kIsMappable; }
+   std::size_t GetBitsOnStorage() const final { return kBitsOnStorage; }
+};
+
+template <>
+class RColumnElement<std::uint16_t, EColumnType::kSplitInt16> : public RColumnElementSplitLE<std::uint16_t> {
+public:
+   static constexpr std::size_t kSize = sizeof(std::uint16_t);
+   static constexpr std::size_t kBitsOnStorage = kSize * 8;
+   explicit RColumnElement(std::uint16_t *value) : RColumnElementSplitLE(value, kSize) {}
+   bool IsMappable() const final { return kIsMappable; }
+   std::size_t GetBitsOnStorage() const final { return kBitsOnStorage; }
+};
+
+template <>
 class RColumnElement<std::int32_t, EColumnType::kInt32> : public RColumnElementLE<std::int32_t> {
 public:
    static constexpr std::size_t kSize = sizeof(std::int32_t);
@@ -640,6 +660,7 @@ std::unique_ptr<RColumnElementBase> RColumnElementBase::Generate(EColumnType typ
    case EColumnType::kSplitReal32: return std::make_unique<RColumnElement<CppT, EColumnType::kSplitReal32>>(nullptr);
    case EColumnType::kSplitInt64: return std::make_unique<RColumnElement<CppT, EColumnType::kSplitInt64>>(nullptr);
    case EColumnType::kSplitInt32: return std::make_unique<RColumnElement<CppT, EColumnType::kSplitInt32>>(nullptr);
+   case EColumnType::kSplitInt16: return std::make_unique<RColumnElement<CppT, EColumnType::kSplitInt16>>(nullptr);
    default: R__ASSERT(false);
    }
    // never here

--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -374,6 +374,16 @@ public:
 };
 
 template <>
+class RColumnElement<float, EColumnType::kSplitReal32> : public RColumnElementSplitLE<float> {
+public:
+   static constexpr std::size_t kSize = sizeof(float);
+   static constexpr std::size_t kBitsOnStorage = kSize * 8;
+   explicit RColumnElement(float *value) : RColumnElementSplitLE(value, kSize) {}
+   bool IsMappable() const final { return kIsMappable; }
+   std::size_t GetBitsOnStorage() const final { return kBitsOnStorage; }
+};
+
+template <>
 class RColumnElement<double, EColumnType::kReal64> : public RColumnElementLE<double> {
 public:
    static constexpr std::size_t kSize = sizeof(double);
@@ -576,6 +586,7 @@ std::unique_ptr<RColumnElementBase> RColumnElementBase::Generate(EColumnType typ
 {
    switch (type) {
    case EColumnType::kReal32: return std::make_unique<RColumnElement<CppT, EColumnType::kReal32>>(nullptr);
+   case EColumnType::kSplitReal32: return std::make_unique<RColumnElement<CppT, EColumnType::kSplitReal32>>(nullptr);
    case EColumnType::kReal64: return std::make_unique<RColumnElement<CppT, EColumnType::kReal64>>(nullptr);
    case EColumnType::kSplitReal64: return std::make_unique<RColumnElement<CppT, EColumnType::kSplitReal64>>(nullptr);
    case EColumnType::kChar: return std::make_unique<RColumnElement<CppT, EColumnType::kChar>>(nullptr);

--- a/tree/ntuple/v7/inc/ROOT/RColumnModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnModel.hxx
@@ -53,6 +53,7 @@ enum class EColumnType {
    kReal64,
    kSplitReal64,
    kReal32,
+   kSplitReal32,
    kReal16,
    kInt64,
    kInt32,

--- a/tree/ntuple/v7/inc/ROOT/RColumnModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnModel.hxx
@@ -60,6 +60,7 @@ enum class EColumnType {
    kSplitReal64,
    kSplitReal32,
    kSplitInt64,
+   kSplitInt32,
    kMax,
 };
 

--- a/tree/ntuple/v7/inc/ROOT/RColumnModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnModel.hxx
@@ -51,14 +51,15 @@ enum class EColumnType {
    kChar,
    kBit,
    kReal64,
-   kSplitReal64,
    kReal32,
-   kSplitReal32,
    kReal16,
    kInt64,
    kInt32,
    kInt16,
    kInt8,
+   kSplitReal64,
+   kSplitReal32,
+   kSplitInt64,
    kMax,
 };
 

--- a/tree/ntuple/v7/inc/ROOT/RColumnModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnModel.hxx
@@ -61,6 +61,7 @@ enum class EColumnType {
    kSplitReal32,
    kSplitInt64,
    kSplitInt32,
+   kSplitInt16,
    kMax,
 };
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -139,6 +139,12 @@ private:
    /// Free text set by the user
    std::string fDescription;
 
+   void InvokeReadCallbacks(RFieldValue &value)
+   {
+      for (const auto &func : fReadCallbacks)
+         func(value);
+   }
+
 protected:
    /// Collections and classes own sub fields
    std::vector<std::unique_ptr<RFieldBase>> fSubFields;
@@ -193,13 +199,8 @@ protected:
    /// Called by `ConnectPageSource()` only once connected; derived classes may override this
    /// as appropriate
    virtual void OnConnectPageSource() {}
-
-private:
-   void InvokeReadCallbacks(RFieldValue &value)
-   {
-      for (const auto &func : fReadCallbacks)
-         func(value);
-   }
+   /// Called by `ConnectPageSink()` before the columns are generated. Used to fix column encoding.
+   virtual void OnConnectPageSink() {}
 
 public:
    /// Iterates over the sub tree of fields in depth-first search order

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -345,6 +345,8 @@ public:
    /// Otherwise, or if the provided representation is not in the list of GetColumnRepresentations,
    /// an exception is thrown
    void SetColumnRepresentative(const ColumnRepresentation_t &representative);
+   /// Whether or not an explicit column representative was set
+   bool HasDefaultColumnRepresentative() const { return fColumnRepresentative == nullptr; }
 
    /// Fields and their columns live in the void until connected to a physical page storage.  Only once connected, data
    /// can be read or written.  In order to find the field in the page storage, the field's on-disk ID has to be set.

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -199,8 +199,6 @@ protected:
    /// Called by `ConnectPageSource()` only once connected; derived classes may override this
    /// as appropriate
    virtual void OnConnectPageSource() {}
-   /// Called by `ConnectPageSink()` before the columns are generated. Used to fix column encoding.
-   virtual void OnConnectPageSink() {}
 
 public:
    /// Iterates over the sub tree of fields in depth-first search order

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -242,9 +242,6 @@ protected:
    /// GetMetrics() member function.
    void EnableDefaultMetrics(const std::string &prefix);
 
-   /// Fix-up default encoding: if the ntuple is uncompressed, the default encoding should be non-split
-   void FixUpColumnRepresentative(RFieldBase &field);
-
 public:
    RPageSink(std::string_view ntupleName, const RNTupleWriteOptions &options);
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -242,6 +242,9 @@ protected:
    /// GetMetrics() member function.
    void EnableDefaultMetrics(const std::string &prefix);
 
+   /// Fix-up default encoding: if the ntuple is uncompressed, the default encoding should be non-split
+   void FixUpColumnRepresentative(RFieldBase &field);
+
 public:
    RPageSink(std::string_view ntupleName, const RNTupleWriteOptions &options);
 

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -28,19 +28,20 @@ std::unique_ptr<ROOT::Experimental::Detail::RColumnElementBase>
 ROOT::Experimental::Detail::RColumnElementBase::Generate<void>(EColumnType type)
 {
    switch (type) {
-   case EColumnType::kReal32: return std::make_unique<RColumnElement<float, EColumnType::kReal32>>(nullptr);
-   case EColumnType::kSplitReal32: return std::make_unique<RColumnElement<float, EColumnType::kSplitReal32>>(nullptr);
-   case EColumnType::kReal64: return std::make_unique<RColumnElement<double, EColumnType::kReal64>>(nullptr);
-   case EColumnType::kSplitReal64: return std::make_unique<RColumnElement<double, EColumnType::kSplitReal64>>(nullptr);
-   case EColumnType::kChar: return std::make_unique<RColumnElement<char, EColumnType::kChar>>(nullptr);
-   case EColumnType::kByte: return std::make_unique<RColumnElement<std::uint8_t, EColumnType::kByte>>(nullptr);
-   case EColumnType::kInt8: return std::make_unique<RColumnElement<std::int8_t, EColumnType::kInt8>>(nullptr);
-   case EColumnType::kInt16: return std::make_unique<RColumnElement<std::int16_t, EColumnType::kInt16>>(nullptr);
-   case EColumnType::kInt32: return std::make_unique<RColumnElement<std::int32_t, EColumnType::kInt32>>(nullptr);
-   case EColumnType::kInt64: return std::make_unique<RColumnElement<std::int64_t, EColumnType::kInt64>>(nullptr);
-   case EColumnType::kBit: return std::make_unique<RColumnElement<bool, EColumnType::kBit>>(nullptr);
    case EColumnType::kIndex: return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kIndex>>(nullptr);
    case EColumnType::kSwitch: return std::make_unique<RColumnElement<RColumnSwitch, EColumnType::kSwitch>>(nullptr);
+   case EColumnType::kByte: return std::make_unique<RColumnElement<std::uint8_t, EColumnType::kByte>>(nullptr);
+   case EColumnType::kChar: return std::make_unique<RColumnElement<char, EColumnType::kChar>>(nullptr);
+   case EColumnType::kBit: return std::make_unique<RColumnElement<bool, EColumnType::kBit>>(nullptr);
+   case EColumnType::kReal64: return std::make_unique<RColumnElement<double, EColumnType::kReal64>>(nullptr);
+   case EColumnType::kReal32: return std::make_unique<RColumnElement<float, EColumnType::kReal32>>(nullptr);
+   case EColumnType::kInt64: return std::make_unique<RColumnElement<std::int64_t, EColumnType::kInt64>>(nullptr);
+   case EColumnType::kInt32: return std::make_unique<RColumnElement<std::int32_t, EColumnType::kInt32>>(nullptr);
+   case EColumnType::kInt16: return std::make_unique<RColumnElement<std::int16_t, EColumnType::kInt16>>(nullptr);
+   case EColumnType::kInt8: return std::make_unique<RColumnElement<std::int8_t, EColumnType::kInt8>>(nullptr);
+   case EColumnType::kSplitReal64: return std::make_unique<RColumnElement<double, EColumnType::kSplitReal64>>(nullptr);
+   case EColumnType::kSplitReal32: return std::make_unique<RColumnElement<float, EColumnType::kSplitReal32>>(nullptr);
+   case EColumnType::kSplitInt64: return std::make_unique<RColumnElement<float, EColumnType::kSplitInt64>>(nullptr);
    default: R__ASSERT(false);
    }
    // never here
@@ -52,19 +53,20 @@ ROOT::Experimental::Detail::RColumnElementBase::Generate<void>(EColumnType type)
 
 std::size_t ROOT::Experimental::Detail::RColumnElementBase::GetBitsOnStorage(EColumnType type) {
    switch (type) {
-   case EColumnType::kReal32: return 32;
-   case EColumnType::kSplitReal32: return 32;
-   case EColumnType::kReal64: return 64;
-   case EColumnType::kSplitReal64: return 64;
-   case EColumnType::kChar: return 8;
-   case EColumnType::kByte: return 8;
-   case EColumnType::kInt8: return 8;
-   case EColumnType::kInt16: return 16;
-   case EColumnType::kInt32: return 32;
-   case EColumnType::kInt64: return 64;
-   case EColumnType::kBit: return 1;
    case EColumnType::kIndex: return 32;
    case EColumnType::kSwitch: return 64;
+   case EColumnType::kByte: return 8;
+   case EColumnType::kChar: return 8;
+   case EColumnType::kBit: return 1;
+   case EColumnType::kReal64: return 64;
+   case EColumnType::kReal32: return 32;
+   case EColumnType::kInt64: return 64;
+   case EColumnType::kInt32: return 32;
+   case EColumnType::kInt16: return 16;
+   case EColumnType::kInt8: return 8;
+   case EColumnType::kSplitReal64: return 64;
+   case EColumnType::kSplitReal32: return 32;
+   case EColumnType::kSplitInt64: return 64;
    default: R__ASSERT(false);
    }
    // never here
@@ -73,19 +75,20 @@ std::size_t ROOT::Experimental::Detail::RColumnElementBase::GetBitsOnStorage(ECo
 
 std::string ROOT::Experimental::Detail::RColumnElementBase::GetTypeName(EColumnType type) {
    switch (type) {
-   case EColumnType::kReal32: return "Real32";
-   case EColumnType::kSplitReal32: return "SplitReal32";
-   case EColumnType::kReal64: return "Real64";
-   case EColumnType::kSplitReal64: return "SplitReal64";
-   case EColumnType::kChar: return "Char";
-   case EColumnType::kByte: return "Byte";
-   case EColumnType::kInt8: return "Int8";
-   case EColumnType::kInt16: return "Int16";
-   case EColumnType::kInt32: return "Int32";
-   case EColumnType::kInt64: return "Int64";
-   case EColumnType::kBit: return "Bit";
    case EColumnType::kIndex: return "Index";
    case EColumnType::kSwitch: return "Switch";
+   case EColumnType::kByte: return "Byte";
+   case EColumnType::kChar: return "Char";
+   case EColumnType::kBit: return "Bit";
+   case EColumnType::kReal64: return "Real64";
+   case EColumnType::kReal32: return "Real32";
+   case EColumnType::kInt64: return "Int64";
+   case EColumnType::kInt32: return "Int32";
+   case EColumnType::kInt16: return "Int16";
+   case EColumnType::kInt8: return "Int8";
+   case EColumnType::kSplitReal64: return "SplitReal64";
+   case EColumnType::kSplitReal32: return "SplitReal32";
+   case EColumnType::kSplitInt64: return "kSplitInt64";
    default: return "UNKNOWN";
    }
 }

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -28,31 +28,20 @@ std::unique_ptr<ROOT::Experimental::Detail::RColumnElementBase>
 ROOT::Experimental::Detail::RColumnElementBase::Generate<void>(EColumnType type)
 {
    switch (type) {
-   case EColumnType::kReal32:
-      return std::make_unique<RColumnElement<float, EColumnType::kReal32>>(nullptr);
-   case EColumnType::kReal64:
-      return std::make_unique<RColumnElement<double, EColumnType::kReal64>>(nullptr);
+   case EColumnType::kReal32: return std::make_unique<RColumnElement<float, EColumnType::kReal32>>(nullptr);
+   case EColumnType::kSplitReal32: return std::make_unique<RColumnElement<float, EColumnType::kSplitReal32>>(nullptr);
+   case EColumnType::kReal64: return std::make_unique<RColumnElement<double, EColumnType::kReal64>>(nullptr);
    case EColumnType::kSplitReal64: return std::make_unique<RColumnElement<double, EColumnType::kSplitReal64>>(nullptr);
-   case EColumnType::kChar:
-      return std::make_unique<RColumnElement<char, EColumnType::kChar>>(nullptr);
-   case EColumnType::kByte:
-      return std::make_unique<RColumnElement<std::uint8_t, EColumnType::kByte>>(nullptr);
-   case EColumnType::kInt8:
-      return std::make_unique<RColumnElement<std::int8_t, EColumnType::kInt8>>(nullptr);
-   case EColumnType::kInt16:
-      return std::make_unique<RColumnElement<std::int16_t, EColumnType::kInt16>>(nullptr);
-   case EColumnType::kInt32:
-      return std::make_unique<RColumnElement<std::int32_t, EColumnType::kInt32>>(nullptr);
-   case EColumnType::kInt64:
-      return std::make_unique<RColumnElement<std::int64_t, EColumnType::kInt64>>(nullptr);
-   case EColumnType::kBit:
-      return std::make_unique<RColumnElement<bool, EColumnType::kBit>>(nullptr);
-   case EColumnType::kIndex:
-      return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kIndex>>(nullptr);
-   case EColumnType::kSwitch:
-      return std::make_unique<RColumnElement<RColumnSwitch, EColumnType::kSwitch>>(nullptr);
-   default:
-      R__ASSERT(false);
+   case EColumnType::kChar: return std::make_unique<RColumnElement<char, EColumnType::kChar>>(nullptr);
+   case EColumnType::kByte: return std::make_unique<RColumnElement<std::uint8_t, EColumnType::kByte>>(nullptr);
+   case EColumnType::kInt8: return std::make_unique<RColumnElement<std::int8_t, EColumnType::kInt8>>(nullptr);
+   case EColumnType::kInt16: return std::make_unique<RColumnElement<std::int16_t, EColumnType::kInt16>>(nullptr);
+   case EColumnType::kInt32: return std::make_unique<RColumnElement<std::int32_t, EColumnType::kInt32>>(nullptr);
+   case EColumnType::kInt64: return std::make_unique<RColumnElement<std::int64_t, EColumnType::kInt64>>(nullptr);
+   case EColumnType::kBit: return std::make_unique<RColumnElement<bool, EColumnType::kBit>>(nullptr);
+   case EColumnType::kIndex: return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kIndex>>(nullptr);
+   case EColumnType::kSwitch: return std::make_unique<RColumnElement<RColumnSwitch, EColumnType::kSwitch>>(nullptr);
+   default: R__ASSERT(false);
    }
    // never here
    return nullptr;
@@ -63,31 +52,20 @@ ROOT::Experimental::Detail::RColumnElementBase::Generate<void>(EColumnType type)
 
 std::size_t ROOT::Experimental::Detail::RColumnElementBase::GetBitsOnStorage(EColumnType type) {
    switch (type) {
-   case EColumnType::kReal32:
-      return 32;
-   case EColumnType::kReal64:
-      return 64;
+   case EColumnType::kReal32: return 32;
+   case EColumnType::kSplitReal32: return 32;
+   case EColumnType::kReal64: return 64;
    case EColumnType::kSplitReal64: return 64;
-   case EColumnType::kChar:
-      return 8;
-   case EColumnType::kByte:
-      return 8;
-   case EColumnType::kInt8:
-      return 8;
-   case EColumnType::kInt16:
-      return 16;
-   case EColumnType::kInt32:
-      return 32;
-   case EColumnType::kInt64:
-      return 64;
-   case EColumnType::kBit:
-      return 1;
-   case EColumnType::kIndex:
-      return 32;
-   case EColumnType::kSwitch:
-      return 64;
-   default:
-      R__ASSERT(false);
+   case EColumnType::kChar: return 8;
+   case EColumnType::kByte: return 8;
+   case EColumnType::kInt8: return 8;
+   case EColumnType::kInt16: return 16;
+   case EColumnType::kInt32: return 32;
+   case EColumnType::kInt64: return 64;
+   case EColumnType::kBit: return 1;
+   case EColumnType::kIndex: return 32;
+   case EColumnType::kSwitch: return 64;
+   default: R__ASSERT(false);
    }
    // never here
    return 0;
@@ -95,31 +73,20 @@ std::size_t ROOT::Experimental::Detail::RColumnElementBase::GetBitsOnStorage(ECo
 
 std::string ROOT::Experimental::Detail::RColumnElementBase::GetTypeName(EColumnType type) {
    switch (type) {
-   case EColumnType::kReal32:
-      return "Real32";
-   case EColumnType::kReal64:
-      return "Real64";
+   case EColumnType::kReal32: return "Real32";
+   case EColumnType::kSplitReal32: return "SplitReal32";
+   case EColumnType::kReal64: return "Real64";
    case EColumnType::kSplitReal64: return "SplitReal64";
-   case EColumnType::kChar:
-      return "Char";
-   case EColumnType::kByte:
-      return "Byte";
-   case EColumnType::kInt8:
-      return "Int8";
-   case EColumnType::kInt16:
-      return "Int16";
-   case EColumnType::kInt32:
-      return "Int32";
-   case EColumnType::kInt64:
-      return "Int64";
-   case EColumnType::kBit:
-      return "Bit";
-   case EColumnType::kIndex:
-      return "Index";
-   case EColumnType::kSwitch:
-      return "Switch";
-   default:
-      return "UNKNOWN";
+   case EColumnType::kChar: return "Char";
+   case EColumnType::kByte: return "Byte";
+   case EColumnType::kInt8: return "Int8";
+   case EColumnType::kInt16: return "Int16";
+   case EColumnType::kInt32: return "Int32";
+   case EColumnType::kInt64: return "Int64";
+   case EColumnType::kBit: return "Bit";
+   case EColumnType::kIndex: return "Index";
+   case EColumnType::kSwitch: return "Switch";
+   default: return "UNKNOWN";
    }
 }
 

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -95,9 +95,9 @@ std::string ROOT::Experimental::Detail::RColumnElementBase::GetTypeName(EColumnT
    case EColumnType::kInt8: return "Int8";
    case EColumnType::kSplitReal64: return "SplitReal64";
    case EColumnType::kSplitReal32: return "SplitReal32";
-   case EColumnType::kSplitInt64: return "kSplitInt64";
-   case EColumnType::kSplitInt32: return "kSplitInt32";
-   case EColumnType::kSplitInt16: return "kSplitInt16";
+   case EColumnType::kSplitInt64: return "SplitInt64";
+   case EColumnType::kSplitInt32: return "SplitInt32";
+   case EColumnType::kSplitInt16: return "SplitInt16";
    default: return "UNKNOWN";
    }
 }

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -194,3 +194,36 @@ void ROOT::Experimental::Detail::RColumnElement<std::int64_t, ROOT::Experimental
 #endif
    }
 }
+
+void ROOT::Experimental::Detail::RColumnElement<std::int64_t, ROOT::Experimental::EColumnType::kSplitInt32>::Pack(
+   void *dst, void *src, std::size_t count) const
+{
+   std::int64_t *int64Array = reinterpret_cast<std::int64_t *>(src);
+   char *int32SplitArray = reinterpret_cast<char *>(dst);
+   for (std::size_t i = 0; i < count; ++i) {
+      std::int32_t v = int64Array[i];
+#if R__LITTLE_ENDIAN == 0
+      v = RByteSwap<4>::bswap(v);
+#endif
+      for (std::size_t b = 0; b < 4; ++b) {
+         int32SplitArray[b * count + i] = reinterpret_cast<char *>(&v)[b];
+      }
+   }
+}
+
+void ROOT::Experimental::Detail::RColumnElement<std::int64_t, ROOT::Experimental::EColumnType::kSplitInt32>::Unpack(
+   void *dst, void *src, std::size_t count) const
+{
+   char *int32SplitArray = reinterpret_cast<char *>(src);
+   std::int64_t *int64Array = reinterpret_cast<std::int64_t *>(dst);
+   for (std::size_t i = 0; i < count; ++i) {
+      std::int32_t v;
+      for (std::size_t b = 0; b < 4; ++b) {
+         reinterpret_cast<char *>(&v)[b] = int32SplitArray[b * count + i];
+      }
+#if R__LITTLE_ENDIAN == 0
+      v = RByteSwap<4>::bswap(v);
+#endif
+      int64Array[i] = v;
+   }
+}

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -45,6 +45,8 @@ ROOT::Experimental::Detail::RColumnElementBase::Generate<void>(EColumnType type)
       return std::make_unique<RColumnElement<std::int64_t, EColumnType::kSplitInt64>>(nullptr);
    case EColumnType::kSplitInt32:
       return std::make_unique<RColumnElement<std::int32_t, EColumnType::kSplitInt32>>(nullptr);
+   case EColumnType::kSplitInt16:
+      return std::make_unique<RColumnElement<std::int16_t, EColumnType::kSplitInt16>>(nullptr);
    default: R__ASSERT(false);
    }
    // never here
@@ -71,6 +73,7 @@ std::size_t ROOT::Experimental::Detail::RColumnElementBase::GetBitsOnStorage(ECo
    case EColumnType::kSplitReal32: return 32;
    case EColumnType::kSplitInt64: return 64;
    case EColumnType::kSplitInt32: return 32;
+   case EColumnType::kSplitInt16: return 16;
    default: R__ASSERT(false);
    }
    // never here
@@ -94,6 +97,7 @@ std::string ROOT::Experimental::Detail::RColumnElementBase::GetTypeName(EColumnT
    case EColumnType::kSplitReal32: return "SplitReal32";
    case EColumnType::kSplitInt64: return "kSplitInt64";
    case EColumnType::kSplitInt32: return "kSplitInt32";
+   case EColumnType::kSplitInt16: return "kSplitInt16";
    default: return "UNKNOWN";
    }
 }

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -41,7 +41,10 @@ ROOT::Experimental::Detail::RColumnElementBase::Generate<void>(EColumnType type)
    case EColumnType::kInt8: return std::make_unique<RColumnElement<std::int8_t, EColumnType::kInt8>>(nullptr);
    case EColumnType::kSplitReal64: return std::make_unique<RColumnElement<double, EColumnType::kSplitReal64>>(nullptr);
    case EColumnType::kSplitReal32: return std::make_unique<RColumnElement<float, EColumnType::kSplitReal32>>(nullptr);
-   case EColumnType::kSplitInt64: return std::make_unique<RColumnElement<float, EColumnType::kSplitInt64>>(nullptr);
+   case EColumnType::kSplitInt64:
+      return std::make_unique<RColumnElement<std::int64_t, EColumnType::kSplitInt64>>(nullptr);
+   case EColumnType::kSplitInt32:
+      return std::make_unique<RColumnElement<std::int32_t, EColumnType::kSplitInt32>>(nullptr);
    default: R__ASSERT(false);
    }
    // never here
@@ -67,6 +70,7 @@ std::size_t ROOT::Experimental::Detail::RColumnElementBase::GetBitsOnStorage(ECo
    case EColumnType::kSplitReal64: return 64;
    case EColumnType::kSplitReal32: return 32;
    case EColumnType::kSplitInt64: return 64;
+   case EColumnType::kSplitInt32: return 32;
    default: R__ASSERT(false);
    }
    // never here
@@ -89,6 +93,7 @@ std::string ROOT::Experimental::Detail::RColumnElementBase::GetTypeName(EColumnT
    case EColumnType::kSplitReal64: return "SplitReal64";
    case EColumnType::kSplitReal32: return "SplitReal32";
    case EColumnType::kSplitInt64: return "kSplitInt64";
+   case EColumnType::kSplitInt32: return "kSplitInt32";
    default: return "UNKNOWN";
    }
 }

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -820,7 +820,7 @@ void ROOT::Experimental::RField<std::uint16_t>::AcceptVisitor(Detail::RFieldVisi
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<std::int32_t>::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kInt32}}, {{}});
+   static RColumnRepresentations representations({{EColumnType::kInt32}, {EColumnType::kSplitInt32}}, {{}});
    return representations;
 }
 
@@ -845,7 +845,7 @@ void ROOT::Experimental::RField<std::int32_t>::AcceptVisitor(Detail::RFieldVisit
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<std::uint32_t>::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kInt32}}, {{}});
+   static RColumnRepresentations representations({{EColumnType::kInt32}, {EColumnType::kSplitInt32}}, {{}});
    return representations;
 }
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -474,6 +474,23 @@ void ROOT::Experimental::Detail::RFieldBase::RemoveReadCallback(size_t idx)
 void ROOT::Experimental::Detail::RFieldBase::ConnectPageSink(RPageSink &pageSink)
 {
    R__ASSERT(fColumns.empty());
+
+   /// Fix-up default encoding: if the ntuple is uncompressed, the default encoding should be non-split
+   if ((pageSink.GetWriteOptions().GetCompression() == 0) && HasDefaultColumnRepresentative()) {
+      const auto &rep = GetColumnRepresentative();
+      if (rep == ColumnRepresentation_t({EColumnType::kSplitReal64})) {
+         SetColumnRepresentative({EColumnType::kReal64});
+      } else if (rep == ColumnRepresentation_t({EColumnType::kSplitReal32})) {
+         SetColumnRepresentative({EColumnType::kReal32});
+      } else if (rep == ColumnRepresentation_t({EColumnType::kSplitInt64})) {
+         SetColumnRepresentative({EColumnType::kInt64});
+      } else if (rep == ColumnRepresentation_t({EColumnType::kSplitInt32})) {
+         SetColumnRepresentative({EColumnType::kInt32});
+      } else if (rep == ColumnRepresentation_t({EColumnType::kSplitInt16})) {
+         SetColumnRepresentative({EColumnType::kInt16});
+      }
+   }
+
    GenerateColumnsImpl();
    if (!fColumns.empty())
       fPrincipalColumn = fColumns[0].get();

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -719,7 +719,7 @@ void ROOT::Experimental::RField<bool>::AcceptVisitor(Detail::RFieldVisitor &visi
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<float>::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kReal32}}, {{}});
+   static RColumnRepresentations representations({{EColumnType::kReal32}, {EColumnType::kSplitReal32}}, {{}});
    return representations;
 }
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -896,7 +896,7 @@ const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<std::int64_t>::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations({{EColumnType::kSplitInt64}, {EColumnType::kInt64}},
-                                                 {{EColumnType::kInt32}});
+                                                 {{EColumnType::kInt32}, {EColumnType::kSplitInt32}});
    return representations;
 }
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -719,7 +719,7 @@ void ROOT::Experimental::RField<bool>::AcceptVisitor(Detail::RFieldVisitor &visi
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<float>::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kReal32}, {EColumnType::kSplitReal32}}, {{}});
+   static RColumnRepresentations representations({{EColumnType::kSplitReal32}, {EColumnType::kReal32}}, {{}});
    return representations;
 }
 
@@ -745,7 +745,7 @@ void ROOT::Experimental::RField<float>::AcceptVisitor(Detail::RFieldVisitor &vis
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<double>::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kReal64}, {EColumnType::kSplitReal64}}, {{}});
+   static RColumnRepresentations representations({{EColumnType::kSplitReal64}, {EColumnType::kReal64}}, {{}});
    return representations;
 }
 
@@ -770,7 +770,7 @@ void ROOT::Experimental::RField<double>::AcceptVisitor(Detail::RFieldVisitor &vi
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<std::int16_t>::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kInt16}, {EColumnType::kSplitInt16}}, {{}});
+   static RColumnRepresentations representations({{EColumnType::kSplitInt16}, {EColumnType::kInt16}}, {{}});
    return representations;
 }
 
@@ -795,7 +795,7 @@ void ROOT::Experimental::RField<std::int16_t>::AcceptVisitor(Detail::RFieldVisit
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<std::uint16_t>::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kInt16}, {EColumnType::kSplitInt16}}, {{}});
+   static RColumnRepresentations representations({{EColumnType::kSplitInt16}, {EColumnType::kInt16}}, {{}});
    return representations;
 }
 
@@ -820,7 +820,7 @@ void ROOT::Experimental::RField<std::uint16_t>::AcceptVisitor(Detail::RFieldVisi
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<std::int32_t>::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kInt32}, {EColumnType::kSplitInt32}}, {{}});
+   static RColumnRepresentations representations({{EColumnType::kSplitInt32}, {EColumnType::kInt32}}, {{}});
    return representations;
 }
 
@@ -845,7 +845,7 @@ void ROOT::Experimental::RField<std::int32_t>::AcceptVisitor(Detail::RFieldVisit
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<std::uint32_t>::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kInt32}, {EColumnType::kSplitInt32}}, {{}});
+   static RColumnRepresentations representations({{EColumnType::kSplitInt32}, {EColumnType::kInt32}}, {{}});
    return representations;
 }
 
@@ -870,7 +870,7 @@ void ROOT::Experimental::RField<std::uint32_t>::AcceptVisitor(Detail::RFieldVisi
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<std::uint64_t>::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kInt64}, {EColumnType::kSplitInt64}}, {{}});
+   static RColumnRepresentations representations({{EColumnType::kSplitInt64}, {EColumnType::kInt64}}, {{}});
    return representations;
 }
 
@@ -895,7 +895,7 @@ void ROOT::Experimental::RField<std::uint64_t>::AcceptVisitor(Detail::RFieldVisi
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<std::int64_t>::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kInt64}, {EColumnType::kSplitInt64}},
+   static RColumnRepresentations representations({{EColumnType::kSplitInt64}, {EColumnType::kInt64}},
                                                  {{EColumnType::kInt32}});
    return representations;
 }

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -870,7 +870,7 @@ void ROOT::Experimental::RField<std::uint32_t>::AcceptVisitor(Detail::RFieldVisi
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<std::uint64_t>::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kInt64}}, {{}});
+   static RColumnRepresentations representations({{EColumnType::kInt64}, {EColumnType::kSplitInt64}}, {{}});
    return representations;
 }
 
@@ -895,7 +895,8 @@ void ROOT::Experimental::RField<std::uint64_t>::AcceptVisitor(Detail::RFieldVisi
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<std::int64_t>::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kInt64}}, {{EColumnType::kInt32}});
+   static RColumnRepresentations representations({{EColumnType::kInt64}, {EColumnType::kSplitInt64}},
+                                                 {{EColumnType::kInt32}});
    return representations;
 }
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -770,7 +770,7 @@ void ROOT::Experimental::RField<double>::AcceptVisitor(Detail::RFieldVisitor &vi
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<std::int16_t>::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kInt16}}, {{}});
+   static RColumnRepresentations representations({{EColumnType::kInt16}, {EColumnType::kSplitInt16}}, {{}});
    return representations;
 }
 
@@ -795,7 +795,7 @@ void ROOT::Experimental::RField<std::int16_t>::AcceptVisitor(Detail::RFieldVisit
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<std::uint16_t>::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kInt16}}, {{}});
+   static RColumnRepresentations representations({{EColumnType::kInt16}, {EColumnType::kSplitInt16}}, {{}});
    return representations;
 }
 

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -523,6 +523,7 @@ std::uint16_t ROOT::Experimental::Internal::RNTupleSerializer::SerializeColumnTy
    case EColumnType::kSplitReal64: return SerializeUInt16(0x10, buffer);
    case EColumnType::kSplitReal32: return SerializeUInt16(0x11, buffer);
    case EColumnType::kSplitInt64: return SerializeUInt16(0x13, buffer);
+   case EColumnType::kSplitInt32: return SerializeUInt16(0x14, buffer);
    default: throw RException(R__FAIL("ROOT bug: unexpected column type"));
    }
 }
@@ -550,6 +551,7 @@ RResult<std::uint16_t> ROOT::Experimental::Internal::RNTupleSerializer::Deserial
    case 0x10: type = EColumnType::kSplitReal64; break;
    case 0x11: type = EColumnType::kSplitReal32; break;
    case 0x13: type = EColumnType::kSplitInt64; break;
+   case 0x14: type = EColumnType::kSplitInt32; break;
    default: return R__FAIL("unexpected on-disk column type");
    }
    return result;

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -508,33 +508,21 @@ std::uint16_t ROOT::Experimental::Internal::RNTupleSerializer::SerializeColumnTy
 {
    using EColumnType = ROOT::Experimental::EColumnType;
    switch (type) {
-      case EColumnType::kIndex:
-         return SerializeUInt16(0x02, buffer);
-      case EColumnType::kSwitch:
-         return SerializeUInt16(0x03, buffer);
-      case EColumnType::kByte:
-         return SerializeUInt16(0x04, buffer);
-      case EColumnType::kChar:
-         return SerializeUInt16(0x05, buffer);
-      case EColumnType::kBit:
-         return SerializeUInt16(0x06, buffer);
-      case EColumnType::kReal64:
-         return SerializeUInt16(0x07, buffer);
-      case EColumnType::kReal32:
-         return SerializeUInt16(0x08, buffer);
-      case EColumnType::kReal16:
-         return SerializeUInt16(0x09, buffer);
-      case EColumnType::kInt64:
-         return SerializeUInt16(0x0A, buffer);
-      case EColumnType::kInt32:
-         return SerializeUInt16(0x0B, buffer);
-      case EColumnType::kInt16:
-         return SerializeUInt16(0x0C, buffer);
-      case EColumnType::kInt8:
-         return SerializeUInt16(0x0D, buffer);
-      case EColumnType::kSplitReal64: return SerializeUInt16(0x10, buffer);
-      default:
-         throw RException(R__FAIL("ROOT bug: unexpected column type"));
+   case EColumnType::kIndex: return SerializeUInt16(0x02, buffer);
+   case EColumnType::kSwitch: return SerializeUInt16(0x03, buffer);
+   case EColumnType::kByte: return SerializeUInt16(0x04, buffer);
+   case EColumnType::kChar: return SerializeUInt16(0x05, buffer);
+   case EColumnType::kBit: return SerializeUInt16(0x06, buffer);
+   case EColumnType::kReal64: return SerializeUInt16(0x07, buffer);
+   case EColumnType::kReal32: return SerializeUInt16(0x08, buffer);
+   case EColumnType::kReal16: return SerializeUInt16(0x09, buffer);
+   case EColumnType::kInt64: return SerializeUInt16(0x0A, buffer);
+   case EColumnType::kInt32: return SerializeUInt16(0x0B, buffer);
+   case EColumnType::kInt16: return SerializeUInt16(0x0C, buffer);
+   case EColumnType::kInt8: return SerializeUInt16(0x0D, buffer);
+   case EColumnType::kSplitReal64: return SerializeUInt16(0x10, buffer);
+   case EColumnType::kSplitReal32: return SerializeUInt16(0x11, buffer);
+   default: throw RException(R__FAIL("ROOT bug: unexpected column type"));
    }
 }
 
@@ -546,45 +534,21 @@ RResult<std::uint16_t> ROOT::Experimental::Internal::RNTupleSerializer::Deserial
    std::uint16_t onDiskType;
    auto result = DeserializeUInt16(buffer, onDiskType);
    switch (onDiskType) {
-      case 0x02:
-         type = EColumnType::kIndex;
-         break;
-      case 0x03:
-         type = EColumnType::kSwitch;
-         break;
-      case 0x04:
-         type = EColumnType::kByte;
-         break;
-      case 0x05:
-         type = EColumnType::kChar;
-         break;
-      case 0x06:
-         type = EColumnType::kBit;
-         break;
-      case 0x07:
-         type = EColumnType::kReal64;
-         break;
-      case 0x08:
-         type = EColumnType::kReal32;
-         break;
-      case 0x09:
-         type = EColumnType::kReal16;
-         break;
-      case 0x0A:
-         type = EColumnType::kInt64;
-         break;
-      case 0x0B:
-         type = EColumnType::kInt32;
-         break;
-      case 0x0C:
-         type = EColumnType::kInt16;
-         break;
-      case 0x0D:
-         type = EColumnType::kInt8;
-         break;
-      case 0x10: type = EColumnType::kSplitReal64; break;
-      default:
-         return R__FAIL("unexpected on-disk column type");
+   case 0x02: type = EColumnType::kIndex; break;
+   case 0x03: type = EColumnType::kSwitch; break;
+   case 0x04: type = EColumnType::kByte; break;
+   case 0x05: type = EColumnType::kChar; break;
+   case 0x06: type = EColumnType::kBit; break;
+   case 0x07: type = EColumnType::kReal64; break;
+   case 0x08: type = EColumnType::kReal32; break;
+   case 0x09: type = EColumnType::kReal16; break;
+   case 0x0A: type = EColumnType::kInt64; break;
+   case 0x0B: type = EColumnType::kInt32; break;
+   case 0x0C: type = EColumnType::kInt16; break;
+   case 0x0D: type = EColumnType::kInt8; break;
+   case 0x10: type = EColumnType::kSplitReal64; break;
+   case 0x11: type = EColumnType::kSplitReal32; break;
+   default: return R__FAIL("unexpected on-disk column type");
    }
    return result;
 }

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -524,6 +524,7 @@ std::uint16_t ROOT::Experimental::Internal::RNTupleSerializer::SerializeColumnTy
    case EColumnType::kSplitReal32: return SerializeUInt16(0x11, buffer);
    case EColumnType::kSplitInt64: return SerializeUInt16(0x13, buffer);
    case EColumnType::kSplitInt32: return SerializeUInt16(0x14, buffer);
+   case EColumnType::kSplitInt16: return SerializeUInt16(0x15, buffer);
    default: throw RException(R__FAIL("ROOT bug: unexpected column type"));
    }
 }
@@ -552,6 +553,7 @@ RResult<std::uint16_t> ROOT::Experimental::Internal::RNTupleSerializer::Deserial
    case 0x11: type = EColumnType::kSplitReal32; break;
    case 0x13: type = EColumnType::kSplitInt64; break;
    case 0x14: type = EColumnType::kSplitInt32; break;
+   case 0x15: type = EColumnType::kSplitInt16; break;
    default: return R__FAIL("unexpected on-disk column type");
    }
    return result;

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -522,6 +522,7 @@ std::uint16_t ROOT::Experimental::Internal::RNTupleSerializer::SerializeColumnTy
    case EColumnType::kInt8: return SerializeUInt16(0x0D, buffer);
    case EColumnType::kSplitReal64: return SerializeUInt16(0x10, buffer);
    case EColumnType::kSplitReal32: return SerializeUInt16(0x11, buffer);
+   case EColumnType::kSplitInt64: return SerializeUInt16(0x13, buffer);
    default: throw RException(R__FAIL("ROOT bug: unexpected column type"));
    }
 }
@@ -548,6 +549,7 @@ RResult<std::uint16_t> ROOT::Experimental::Internal::RNTupleSerializer::Deserial
    case 0x0D: type = EColumnType::kInt8; break;
    case 0x10: type = EColumnType::kSplitReal64; break;
    case 0x11: type = EColumnType::kSplitReal32; break;
+   case 0x13: type = EColumnType::kSplitInt64; break;
    default: return R__FAIL("unexpected on-disk column type");
    }
    return result;

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -309,26 +309,6 @@ ROOT::Experimental::Detail::RPageSink::AddColumn(DescriptorId_t fieldId, const R
    return ColumnHandle_t{columnId, &column};
 }
 
-void ROOT::Experimental::Detail::RPageSink::FixUpColumnRepresentative(RFieldBase &field)
-{
-   if (GetWriteOptions().GetCompression() != 0)
-      return;
-   if (!field.HasDefaultColumnRepresentative())
-      return;
-   const auto &rep = field.GetColumnRepresentative();
-   if (rep == RFieldBase::ColumnRepresentation_t({EColumnType::kSplitReal64})) {
-      field.SetColumnRepresentative({EColumnType::kReal64});
-   } else if (rep == RFieldBase::ColumnRepresentation_t({EColumnType::kSplitReal32})) {
-      field.SetColumnRepresentative({EColumnType::kReal32});
-   } else if (rep == RFieldBase::ColumnRepresentation_t({EColumnType::kSplitInt64})) {
-      field.SetColumnRepresentative({EColumnType::kInt64});
-   } else if (rep == RFieldBase::ColumnRepresentation_t({EColumnType::kSplitInt32})) {
-      field.SetColumnRepresentative({EColumnType::kInt32});
-   } else if (rep == RFieldBase::ColumnRepresentation_t({EColumnType::kSplitInt16})) {
-      field.SetColumnRepresentative({EColumnType::kInt16});
-   }
-}
-
 void ROOT::Experimental::Detail::RPageSink::Create(RNTupleModel &model)
 {
    fDescriptorBuilder.SetNTuple(fNTupleName, model.GetDescription());
@@ -338,7 +318,6 @@ void ROOT::Experimental::Detail::RPageSink::Create(RNTupleModel &model)
    fDescriptorBuilder.AddField(RFieldDescriptorBuilder::FromField(fieldZero).FieldId(0).MakeDescriptor().Unwrap());
    fieldZero.SetOnDiskId(0);
    for (auto &f : fieldZero) {
-      FixUpColumnRepresentative(f);
       auto fieldId = descriptor.GetNFields();
       fDescriptorBuilder.AddField(RFieldDescriptorBuilder::FromField(f).FieldId(fieldId).MakeDescriptor().Unwrap());
       fDescriptorBuilder.AddFieldLink(f.GetParent()->GetOnDiskId(), fieldId);

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -224,6 +224,62 @@ TEST(RColumnElementEndian, UInt64)
    EXPECT_EQ(0, memcmp(buf2.get(), "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f", 16));
 }
 
+TEST(RColumnElementEndian, Int32)
+{
+   ROOT::Experimental::Detail::RColumnElement<std::int32_t, EColumnType::kInt32> element(nullptr);
+   EXPECT_EQ(element.IsMappable(), false);
+
+   RPageSinkMock sink1(element);
+   unsigned char buf1[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+                           0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f};
+   RPage page1(0, buf1, 4, 4);
+   page1.GrowUnchecked(4);
+   sink1.CommitPageImpl(RPageStorage::ColumnHandle_t{}, page1);
+
+   EXPECT_EQ(
+      0, memcmp(sink1.GetPages()[0].fBuffer, "\x03\x02\x01\x00\x07\x06\x05\x04\x0b\x0a\x09\x08\x0f\x0e\x0d\x0c", 16));
+
+   RPageSourceMock source1(sink1.GetPages(), element);
+   auto page2 = source1.PopulatePage(RPageStorage::ColumnHandle_t{}, NTupleSize_t{0});
+   std::unique_ptr<unsigned char[]> buf2(static_cast<unsigned char *>(page2.GetBuffer())); // adopt buffer
+   EXPECT_EQ(0, memcmp(buf2.get(), "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f", 16));
+
+   ROOT::Experimental::Detail::RColumnElement<int32_t, EColumnType::kSplitInt32> splitElement(nullptr);
+   RPageSinkMock sink2(splitElement);
+   RPage page3(0, buf1, 4, 4);
+   page3.GrowUnchecked(4);
+   sink2.CommitPageImpl(RPageStorage::ColumnHandle_t{}, page3);
+
+   EXPECT_EQ(
+      0, memcmp(sink2.GetPages()[0].fBuffer, "\x03\x07\x0b\x0f\x02\x06\x0a\x0e\x01\x05\x09\x0d\x00\x04\x08\x0c", 16));
+
+   RPageSourceMock source2(sink2.GetPages(), splitElement);
+   auto page4 = source2.PopulatePage(RPageStorage::ColumnHandle_t{}, NTupleSize_t{0});
+   std::unique_ptr<unsigned char[]> buf3(static_cast<unsigned char *>(page4.GetBuffer())); // adopt buffer
+   EXPECT_EQ(0, memcmp(buf3.get(), "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f", 16));
+}
+
+TEST(RColumnElementEndian, UInt32)
+{
+   ROOT::Experimental::Detail::RColumnElement<std::uint32_t, EColumnType::kInt32> element(nullptr);
+   EXPECT_EQ(element.IsMappable(), false);
+
+   RPageSinkMock sink(element);
+   unsigned char buf1[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+                           0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f};
+   RPage page1(0, buf1, 4, 4);
+   page1.GrowUnchecked(4);
+   sink.CommitPageImpl(RPageStorage::ColumnHandle_t{}, page1);
+
+   EXPECT_EQ(
+      0, memcmp(sink.GetPages()[0].fBuffer, "\x03\x02\x01\x00\x07\x06\x05\x04\x0b\x0a\x09\x08\x0f\x0e\x0d\x0c", 16));
+
+   RPageSourceMock source(sink.GetPages(), element);
+   auto page2 = source.PopulatePage(RPageStorage::ColumnHandle_t{}, NTupleSize_t{0});
+   std::unique_ptr<unsigned char[]> buf2(static_cast<unsigned char *>(page2.GetBuffer())); // adopt buffer
+   EXPECT_EQ(0, memcmp(buf2.get(), "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f", 16));
+}
+
 TEST(RColumnElementEndian, Int16)
 {
    ROOT::Experimental::Detail::RColumnElement<std::int16_t, EColumnType::kInt16> element(nullptr);
@@ -259,48 +315,6 @@ TEST(RColumnElementEndian, UInt16)
 
    EXPECT_EQ(
       0, memcmp(sink.GetPages()[0].fBuffer, "\x01\x00\x03\x02\x05\x04\x07\x06\x09\x08\x0b\x0a\x0d\x0c\x0f\x0e", 16));
-
-   RPageSourceMock source(sink.GetPages(), element);
-   auto page2 = source.PopulatePage(RPageStorage::ColumnHandle_t{}, NTupleSize_t{0});
-   std::unique_ptr<unsigned char[]> buf2(static_cast<unsigned char *>(page2.GetBuffer())); // adopt buffer
-   EXPECT_EQ(0, memcmp(buf2.get(), "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f", 16));
-}
-
-TEST(RColumnElementEndian, Int32)
-{
-   ROOT::Experimental::Detail::RColumnElement<std::int32_t, EColumnType::kInt32> element(nullptr);
-   EXPECT_EQ(element.IsMappable(), false);
-
-   RPageSinkMock sink(element);
-   unsigned char buf1[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
-                           0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f};
-   RPage page1(0, buf1, 4, 4);
-   page1.GrowUnchecked(4);
-   sink.CommitPageImpl(RPageStorage::ColumnHandle_t{}, page1);
-
-   EXPECT_EQ(
-      0, memcmp(sink.GetPages()[0].fBuffer, "\x03\x02\x01\x00\x07\x06\x05\x04\x0b\x0a\x09\x08\x0f\x0e\x0d\x0c", 16));
-
-   RPageSourceMock source(sink.GetPages(), element);
-   auto page2 = source.PopulatePage(RPageStorage::ColumnHandle_t{}, NTupleSize_t{0});
-   std::unique_ptr<unsigned char[]> buf2(static_cast<unsigned char *>(page2.GetBuffer())); // adopt buffer
-   EXPECT_EQ(0, memcmp(buf2.get(), "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f", 16));
-}
-
-TEST(RColumnElementEndian, UInt32)
-{
-   ROOT::Experimental::Detail::RColumnElement<std::uint32_t, EColumnType::kInt32> element(nullptr);
-   EXPECT_EQ(element.IsMappable(), false);
-
-   RPageSinkMock sink(element);
-   unsigned char buf1[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
-                           0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f};
-   RPage page1(0, buf1, 4, 4);
-   page1.GrowUnchecked(4);
-   sink.CommitPageImpl(RPageStorage::ColumnHandle_t{}, page1);
-
-   EXPECT_EQ(
-      0, memcmp(sink.GetPages()[0].fBuffer, "\x03\x02\x01\x00\x07\x06\x05\x04\x0b\x0a\x09\x08\x0f\x0e\x0d\x0c", 16));
 
    RPageSourceMock source(sink.GetPages(), element);
    auto page2 = source.PopulatePage(RPageStorage::ColumnHandle_t{}, NTupleSize_t{0});

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -98,6 +98,41 @@ public:
 };
 } // anonymous namespace
 
+TEST(RColumnElementEndian, Double)
+{
+   ROOT::Experimental::Detail::RColumnElement<double, EColumnType::kReal64> element(nullptr);
+   EXPECT_EQ(element.IsMappable(), false);
+
+   RPageSinkMock sink1(element);
+   unsigned char buf1[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+                           0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f};
+   RPage page1(0, buf1, 8, 2);
+   page1.GrowUnchecked(2);
+   sink1.CommitPageImpl(RPageStorage::ColumnHandle_t{}, page1);
+
+   EXPECT_EQ(
+      0, memcmp(sink1.GetPages()[0].fBuffer, "\x07\x06\x05\x04\x03\x02\x01\x00\x0f\x0e\x0d\x0c\x0b\x0a\x09\x08", 16));
+
+   RPageSourceMock source1(sink1.GetPages(), element);
+   auto page2 = source1.PopulatePage(RPageStorage::ColumnHandle_t{}, NTupleSize_t{0});
+   std::unique_ptr<unsigned char[]> buf2(static_cast<unsigned char *>(page2.GetBuffer())); // adopt buffer
+   EXPECT_EQ(0, memcmp(buf2.get(), "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f", 16));
+
+   ROOT::Experimental::Detail::RColumnElement<double, EColumnType::kSplitReal64> splitElement(nullptr);
+   RPageSinkMock sink2(splitElement);
+   RPage page3(0, buf1, 8, 2);
+   page3.GrowUnchecked(2);
+   sink2.CommitPageImpl(RPageStorage::ColumnHandle_t{}, page3);
+
+   EXPECT_EQ(
+      0, memcmp(sink2.GetPages()[0].fBuffer, "\x07\x0f\x06\x0e\x05\x0d\x04\x0c\x03\x0b\x02\x0a\x01\x09\x00\x08", 16));
+
+   RPageSourceMock source2(sink2.GetPages(), splitElement);
+   auto page4 = source2.PopulatePage(RPageStorage::ColumnHandle_t{}, NTupleSize_t{0});
+   std::unique_ptr<unsigned char[]> buf3(static_cast<unsigned char *>(page4.GetBuffer())); // adopt buffer
+   EXPECT_EQ(0, memcmp(buf3.get(), "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f", 16));
+}
+
 TEST(RColumnElementEndian, Float)
 {
    ROOT::Experimental::Detail::RColumnElement<float, EColumnType::kReal32> element(nullptr);
@@ -133,9 +168,9 @@ TEST(RColumnElementEndian, Float)
    EXPECT_EQ(0, memcmp(buf3.get(), "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f", 16));
 }
 
-TEST(RColumnElementEndian, Double)
+TEST(RColumnElementEndian, Int64)
 {
-   ROOT::Experimental::Detail::RColumnElement<double, EColumnType::kReal64> element(nullptr);
+   ROOT::Experimental::Detail::RColumnElement<std::int64_t, EColumnType::kInt64> element(nullptr);
    EXPECT_EQ(element.IsMappable(), false);
 
    RPageSinkMock sink1(element);
@@ -153,7 +188,7 @@ TEST(RColumnElementEndian, Double)
    std::unique_ptr<unsigned char[]> buf2(static_cast<unsigned char *>(page2.GetBuffer())); // adopt buffer
    EXPECT_EQ(0, memcmp(buf2.get(), "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f", 16));
 
-   ROOT::Experimental::Detail::RColumnElement<double, EColumnType::kSplitReal64> splitElement(nullptr);
+   ROOT::Experimental::Detail::RColumnElement<std::int64_t, EColumnType::kSplitInt64> splitElement(nullptr);
    RPageSinkMock sink2(splitElement);
    RPage page3(0, buf1, 8, 2);
    page3.GrowUnchecked(2);
@@ -166,6 +201,27 @@ TEST(RColumnElementEndian, Double)
    auto page4 = source2.PopulatePage(RPageStorage::ColumnHandle_t{}, NTupleSize_t{0});
    std::unique_ptr<unsigned char[]> buf3(static_cast<unsigned char *>(page4.GetBuffer())); // adopt buffer
    EXPECT_EQ(0, memcmp(buf3.get(), "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f", 16));
+}
+
+TEST(RColumnElementEndian, UInt64)
+{
+   ROOT::Experimental::Detail::RColumnElement<std::uint64_t, EColumnType::kInt64> element(nullptr);
+   EXPECT_EQ(element.IsMappable(), false);
+
+   RPageSinkMock sink(element);
+   unsigned char buf1[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+                           0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f};
+   RPage page1(0, buf1, 8, 2);
+   page1.GrowUnchecked(2);
+   sink.CommitPageImpl(RPageStorage::ColumnHandle_t{}, page1);
+
+   EXPECT_EQ(
+      0, memcmp(sink.GetPages()[0].fBuffer, "\x07\x06\x05\x04\x03\x02\x01\x00\x0f\x0e\x0d\x0c\x0b\x0a\x09\x08", 16));
+
+   RPageSourceMock source(sink.GetPages(), element);
+   auto page2 = source.PopulatePage(RPageStorage::ColumnHandle_t{}, NTupleSize_t{0});
+   std::unique_ptr<unsigned char[]> buf2(static_cast<unsigned char *>(page2.GetBuffer())); // adopt buffer
+   EXPECT_EQ(0, memcmp(buf2.get(), "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f", 16));
 }
 
 TEST(RColumnElementEndian, Int16)
@@ -245,48 +301,6 @@ TEST(RColumnElementEndian, UInt32)
 
    EXPECT_EQ(
       0, memcmp(sink.GetPages()[0].fBuffer, "\x03\x02\x01\x00\x07\x06\x05\x04\x0b\x0a\x09\x08\x0f\x0e\x0d\x0c", 16));
-
-   RPageSourceMock source(sink.GetPages(), element);
-   auto page2 = source.PopulatePage(RPageStorage::ColumnHandle_t{}, NTupleSize_t{0});
-   std::unique_ptr<unsigned char[]> buf2(static_cast<unsigned char *>(page2.GetBuffer())); // adopt buffer
-   EXPECT_EQ(0, memcmp(buf2.get(), "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f", 16));
-}
-
-TEST(RColumnElementEndian, Int64)
-{
-   ROOT::Experimental::Detail::RColumnElement<std::int64_t, EColumnType::kInt64> element(nullptr);
-   EXPECT_EQ(element.IsMappable(), false);
-
-   RPageSinkMock sink(element);
-   unsigned char buf1[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
-                           0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f};
-   RPage page1(0, buf1, 8, 2);
-   page1.GrowUnchecked(2);
-   sink.CommitPageImpl(RPageStorage::ColumnHandle_t{}, page1);
-
-   EXPECT_EQ(
-      0, memcmp(sink.GetPages()[0].fBuffer, "\x07\x06\x05\x04\x03\x02\x01\x00\x0f\x0e\x0d\x0c\x0b\x0a\x09\x08", 16));
-
-   RPageSourceMock source(sink.GetPages(), element);
-   auto page2 = source.PopulatePage(RPageStorage::ColumnHandle_t{}, NTupleSize_t{0});
-   std::unique_ptr<unsigned char[]> buf2(static_cast<unsigned char *>(page2.GetBuffer())); // adopt buffer
-   EXPECT_EQ(0, memcmp(buf2.get(), "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f", 16));
-}
-
-TEST(RColumnElementEndian, UInt64)
-{
-   ROOT::Experimental::Detail::RColumnElement<std::uint64_t, EColumnType::kInt64> element(nullptr);
-   EXPECT_EQ(element.IsMappable(), false);
-
-   RPageSinkMock sink(element);
-   unsigned char buf1[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
-                           0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f};
-   RPage page1(0, buf1, 8, 2);
-   page1.GrowUnchecked(2);
-   sink.CommitPageImpl(RPageStorage::ColumnHandle_t{}, page1);
-
-   EXPECT_EQ(
-      0, memcmp(sink.GetPages()[0].fBuffer, "\x07\x06\x05\x04\x03\x02\x01\x00\x0f\x0e\x0d\x0c\x0b\x0a\x09\x08", 16));
 
    RPageSourceMock source(sink.GetPages(), element);
    auto page2 = source.PopulatePage(RPageStorage::ColumnHandle_t{}, NTupleSize_t{0});

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -285,20 +285,34 @@ TEST(RColumnElementEndian, Int16)
    ROOT::Experimental::Detail::RColumnElement<std::int16_t, EColumnType::kInt16> element(nullptr);
    EXPECT_EQ(element.IsMappable(), false);
 
-   RPageSinkMock sink(element);
+   RPageSinkMock sink1(element);
    unsigned char buf1[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
                            0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f};
    RPage page1(0, buf1, 2, 8);
    page1.GrowUnchecked(8);
-   sink.CommitPageImpl(RPageStorage::ColumnHandle_t{}, page1);
+   sink1.CommitPageImpl(RPageStorage::ColumnHandle_t{}, page1);
 
    EXPECT_EQ(
-      0, memcmp(sink.GetPages()[0].fBuffer, "\x01\x00\x03\x02\x05\x04\x07\x06\x09\x08\x0b\x0a\x0d\x0c\x0f\x0e", 16));
+      0, memcmp(sink1.GetPages()[0].fBuffer, "\x01\x00\x03\x02\x05\x04\x07\x06\x09\x08\x0b\x0a\x0d\x0c\x0f\x0e", 16));
 
-   RPageSourceMock source(sink.GetPages(), element);
-   auto page2 = source.PopulatePage(RPageStorage::ColumnHandle_t{}, NTupleSize_t{0});
+   RPageSourceMock source1(sink1.GetPages(), element);
+   auto page2 = source1.PopulatePage(RPageStorage::ColumnHandle_t{}, NTupleSize_t{0});
    std::unique_ptr<unsigned char[]> buf2(static_cast<unsigned char *>(page2.GetBuffer())); // adopt buffer
    EXPECT_EQ(0, memcmp(buf2.get(), "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f", 16));
+
+   ROOT::Experimental::Detail::RColumnElement<int16_t, EColumnType::kSplitInt16> splitElement(nullptr);
+   RPageSinkMock sink2(splitElement);
+   RPage page3(0, buf1, 2, 8);
+   page3.GrowUnchecked(8);
+   sink2.CommitPageImpl(RPageStorage::ColumnHandle_t{}, page3);
+
+   EXPECT_EQ(
+      0, memcmp(sink2.GetPages()[0].fBuffer, "\x01\x03\x05\x07\x09\x0b\x0d\x0f\x00\x02\x04\x06\x08\x0a\x0c\x0e", 16));
+
+   RPageSourceMock source2(sink2.GetPages(), splitElement);
+   auto page4 = source2.PopulatePage(RPageStorage::ColumnHandle_t{}, NTupleSize_t{0});
+   std::unique_ptr<unsigned char[]> buf3(static_cast<unsigned char *>(page4.GetBuffer())); // adopt buffer
+   EXPECT_EQ(0, memcmp(buf3.get(), "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f", 16));
 }
 
 TEST(RColumnElementEndian, UInt16)

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -29,8 +29,7 @@ TEST(RPageStorage, ReadSealedPages)
    {
       RNTupleWriteOptions options;
       options.SetCompression(0);
-      RNTupleWriter ntuple(std::move(model),
-         std::make_unique<RPageSinkFile>("myNTuple", fileGuard.GetPath(), RNTupleWriteOptions()));
+      RNTupleWriter ntuple(std::move(model), std::make_unique<RPageSinkFile>("myNTuple", fileGuard.GetPath(), options));
       ntuple.Fill();
       ntuple.CommitCluster();
       for (unsigned i = 0; i < 100000; ++i) {

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -4,6 +4,7 @@
 #include "TInterpreter.h"
 
 #include <cstring>
+#include <limits>
 
 TEST(RNTuple, TypeName) {
    EXPECT_STREQ("float", ROOT::Experimental::RField<float>::TypeName().c_str());
@@ -205,10 +206,60 @@ TEST(RNTuple, StdTuple)
    }
 }
 
-TEST(RNTuple, Int64_t)
+TEST(RNTuple, Int64)
 {
-   auto field = RField<std::int64_t>("myInt64");
-   auto otherField = RFieldBase::Create("test", "std::int64_t").Unwrap();
+   auto field = RFieldBase::Create("test", "std::int64_t").Unwrap();
+   auto otherField = RFieldBase::Create("test", "std::uint64_t").Unwrap();
+
+   FileRaii fileGuard("test_ntuple_int64.root");
+
+   auto model = RNTupleModel::Create();
+
+   auto f1 = std::make_unique<RField<std::int64_t>>("i1");
+   f1->SetColumnRepresentative({ROOT::Experimental::EColumnType::kInt64});
+   model->AddField(std::move(f1));
+
+   auto f2 = std::make_unique<RField<std::int64_t>>("i2");
+   f2->SetColumnRepresentative({ROOT::Experimental::EColumnType::kSplitInt64});
+   model->AddField(std::move(f2));
+
+   auto f3 = std::make_unique<RField<std::uint64_t>>("i3");
+   f3->SetColumnRepresentative({ROOT::Experimental::EColumnType::kInt64});
+   model->AddField(std::move(f3));
+
+   auto f4 = std::make_unique<RField<std::uint64_t>>("i4");
+   f4->SetColumnRepresentative({ROOT::Experimental::EColumnType::kSplitInt64});
+   model->AddField(std::move(f4));
+
+   {
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
+      auto e = writer->CreateEntry();
+      *e->Get<std::int64_t>("i1") = std::numeric_limits<std::int64_t>::max() - 137;
+      *e->Get<std::int64_t>("i2") = std::numeric_limits<std::int64_t>::max() - 138;
+      *e->Get<std::uint64_t>("i3") = std::numeric_limits<std::uint64_t>::max() - 42;
+      *e->Get<std::uint64_t>("i4") = std::numeric_limits<std::uint64_t>::max() - 43;
+      writer->Fill(*e);
+   }
+
+   auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
+   const auto *desc = reader->GetDescriptor();
+   EXPECT_EQ(ROOT::Experimental::EColumnType::kInt64,
+             (*desc->GetColumnIterable(desc->FindFieldId("i1")).begin()).GetModel().GetType());
+   EXPECT_EQ(ROOT::Experimental::EColumnType::kSplitInt64,
+             (*desc->GetColumnIterable(desc->FindFieldId("i2")).begin()).GetModel().GetType());
+   EXPECT_EQ(ROOT::Experimental::EColumnType::kInt64,
+             (*desc->GetColumnIterable(desc->FindFieldId("i3")).begin()).GetModel().GetType());
+   EXPECT_EQ(ROOT::Experimental::EColumnType::kSplitInt64,
+             (*desc->GetColumnIterable(desc->FindFieldId("i4")).begin()).GetModel().GetType());
+   reader->LoadEntry(0);
+   EXPECT_EQ(std::numeric_limits<std::int64_t>::max() - 137,
+             *reader->GetModel()->GetDefaultEntry()->Get<std::int64_t>("i1"));
+   EXPECT_EQ(std::numeric_limits<std::int64_t>::max() - 138,
+             *reader->GetModel()->GetDefaultEntry()->Get<std::int64_t>("i2"));
+   EXPECT_EQ(std::numeric_limits<std::uint64_t>::max() - 42,
+             *reader->GetModel()->GetDefaultEntry()->Get<std::uint64_t>("i3"));
+   EXPECT_EQ(std::numeric_limits<std::uint64_t>::max() - 43,
+             *reader->GetModel()->GetDefaultEntry()->Get<std::uint64_t>("i4"));
 }
 
 TEST(RNTuple, Char)
@@ -239,39 +290,6 @@ TEST(RNTuple, UInt16_t)
    auto field = RField<std::uint16_t>("myUint16");
    auto otherField = RFieldBase::Create("test", "std::uint16_t").Unwrap();
    ASSERT_EQ("std::uint16_t", RFieldBase::Create("myUShort", "UShort_t").Unwrap()->GetType());
-}
-
-TEST(RNTuple, Float)
-{
-   FileRaii fileGuard("test_ntuple_float.root");
-
-   auto model = RNTupleModel::Create();
-
-   auto f1 = std::make_unique<RField<float>>("f1");
-   f1->SetColumnRepresentative({ROOT::Experimental::EColumnType::kReal32});
-   model->AddField(std::move(f1));
-
-   auto f2 = std::make_unique<RField<float>>("f2");
-   f2->SetColumnRepresentative({ROOT::Experimental::EColumnType::kSplitReal32});
-   model->AddField(std::move(f2));
-
-   {
-      auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
-      auto e = writer->CreateEntry();
-      *e->Get<float>("f1") = 1.0;
-      *e->Get<float>("f2") = 2.0;
-      writer->Fill(*e);
-   }
-
-   auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
-   const auto *desc = reader->GetDescriptor();
-   EXPECT_EQ(ROOT::Experimental::EColumnType::kReal32,
-             (*desc->GetColumnIterable(desc->FindFieldId("f1")).begin()).GetModel().GetType());
-   EXPECT_EQ(ROOT::Experimental::EColumnType::kSplitReal32,
-             (*desc->GetColumnIterable(desc->FindFieldId("f2")).begin()).GetModel().GetType());
-   reader->LoadEntry(0);
-   EXPECT_FLOAT_EQ(1.0, *reader->GetModel()->GetDefaultEntry()->Get<float>("f1"));
-   EXPECT_FLOAT_EQ(2.0, *reader->GetModel()->GetDefaultEntry()->Get<float>("f2"));
 }
 
 TEST(RNTuple, Double)
@@ -305,6 +323,39 @@ TEST(RNTuple, Double)
    reader->LoadEntry(0);
    EXPECT_DOUBLE_EQ(1.0, *reader->GetModel()->GetDefaultEntry()->Get<double>("d1"));
    EXPECT_DOUBLE_EQ(2.0, *reader->GetModel()->GetDefaultEntry()->Get<double>("d2"));
+}
+
+TEST(RNTuple, Float)
+{
+   FileRaii fileGuard("test_ntuple_float.root");
+
+   auto model = RNTupleModel::Create();
+
+   auto f1 = std::make_unique<RField<float>>("f1");
+   f1->SetColumnRepresentative({ROOT::Experimental::EColumnType::kReal32});
+   model->AddField(std::move(f1));
+
+   auto f2 = std::make_unique<RField<float>>("f2");
+   f2->SetColumnRepresentative({ROOT::Experimental::EColumnType::kSplitReal32});
+   model->AddField(std::move(f2));
+
+   {
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
+      auto e = writer->CreateEntry();
+      *e->Get<float>("f1") = 1.0;
+      *e->Get<float>("f2") = 2.0;
+      writer->Fill(*e);
+   }
+
+   auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
+   const auto *desc = reader->GetDescriptor();
+   EXPECT_EQ(ROOT::Experimental::EColumnType::kReal32,
+             (*desc->GetColumnIterable(desc->FindFieldId("f1")).begin()).GetModel().GetType());
+   EXPECT_EQ(ROOT::Experimental::EColumnType::kSplitReal32,
+             (*desc->GetColumnIterable(desc->FindFieldId("f2")).begin()).GetModel().GetType());
+   reader->LoadEntry(0);
+   EXPECT_FLOAT_EQ(1.0, *reader->GetModel()->GetDefaultEntry()->Get<float>("f1"));
+   EXPECT_FLOAT_EQ(2.0, *reader->GetModel()->GetDefaultEntry()->Get<float>("f2"));
 }
 
 TEST(RNTuple, UnsupportedStdTypes)

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -318,6 +318,64 @@ TEST(RNTuple, Int32)
              *reader->GetModel()->GetDefaultEntry()->Get<std::uint32_t>("i4"));
 }
 
+TEST(RNTuple, Int16)
+{
+   auto field = RFieldBase::Create("test", "std::int16_t").Unwrap();
+   auto otherField = RFieldBase::Create("test", "std::uint16_t").Unwrap();
+   ASSERT_EQ("std::int16_t", RFieldBase::Create("myShort", "Short_t").Unwrap()->GetType());
+   ASSERT_EQ("std::uint16_t", RFieldBase::Create("myUShort", "UShort_t").Unwrap()->GetType());
+
+   FileRaii fileGuard("test_ntuple_int16.root");
+
+   auto model = RNTupleModel::Create();
+
+   auto f1 = std::make_unique<RField<std::int16_t>>("i1");
+   f1->SetColumnRepresentative({ROOT::Experimental::EColumnType::kInt16});
+   model->AddField(std::move(f1));
+
+   auto f2 = std::make_unique<RField<std::int16_t>>("i2");
+   f2->SetColumnRepresentative({ROOT::Experimental::EColumnType::kSplitInt16});
+   model->AddField(std::move(f2));
+
+   auto f3 = std::make_unique<RField<std::uint16_t>>("i3");
+   f3->SetColumnRepresentative({ROOT::Experimental::EColumnType::kInt16});
+   model->AddField(std::move(f3));
+
+   auto f4 = std::make_unique<RField<std::uint16_t>>("i4");
+   f4->SetColumnRepresentative({ROOT::Experimental::EColumnType::kSplitInt16});
+   model->AddField(std::move(f4));
+
+   {
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
+      auto e = writer->CreateEntry();
+      *e->Get<std::int16_t>("i1") = std::numeric_limits<std::int16_t>::max() - 137;
+      *e->Get<std::int16_t>("i2") = std::numeric_limits<std::int16_t>::max() - 138;
+      *e->Get<std::uint16_t>("i3") = std::numeric_limits<std::uint16_t>::max() - 42;
+      *e->Get<std::uint16_t>("i4") = std::numeric_limits<std::uint16_t>::max() - 43;
+      writer->Fill(*e);
+   }
+
+   auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
+   const auto *desc = reader->GetDescriptor();
+   EXPECT_EQ(ROOT::Experimental::EColumnType::kInt16,
+             (*desc->GetColumnIterable(desc->FindFieldId("i1")).begin()).GetModel().GetType());
+   EXPECT_EQ(ROOT::Experimental::EColumnType::kSplitInt16,
+             (*desc->GetColumnIterable(desc->FindFieldId("i2")).begin()).GetModel().GetType());
+   EXPECT_EQ(ROOT::Experimental::EColumnType::kInt16,
+             (*desc->GetColumnIterable(desc->FindFieldId("i3")).begin()).GetModel().GetType());
+   EXPECT_EQ(ROOT::Experimental::EColumnType::kSplitInt16,
+             (*desc->GetColumnIterable(desc->FindFieldId("i4")).begin()).GetModel().GetType());
+   reader->LoadEntry(0);
+   EXPECT_EQ(std::numeric_limits<std::int16_t>::max() - 137,
+             *reader->GetModel()->GetDefaultEntry()->Get<std::int16_t>("i1"));
+   EXPECT_EQ(std::numeric_limits<std::int16_t>::max() - 138,
+             *reader->GetModel()->GetDefaultEntry()->Get<std::int16_t>("i2"));
+   EXPECT_EQ(std::numeric_limits<std::uint16_t>::max() - 42,
+             *reader->GetModel()->GetDefaultEntry()->Get<std::uint16_t>("i3"));
+   EXPECT_EQ(std::numeric_limits<std::uint16_t>::max() - 43,
+             *reader->GetModel()->GetDefaultEntry()->Get<std::uint16_t>("i4"));
+}
+
 TEST(RNTuple, Char)
 {
    auto charField = RField<char>("myChar");
@@ -332,20 +390,6 @@ TEST(RNTuple, Int8_t)
 {
    auto field = RField<std::int8_t>("myInt8");
    auto otherField = RFieldBase::Create("test", "std::int8_t").Unwrap();
-}
-
-TEST(RNTuple, Int16_t)
-{
-   auto field = RField<std::int16_t>("myInt16");
-   auto otherField = RFieldBase::Create("test", "std::int16_t").Unwrap();
-   ASSERT_EQ("std::int16_t", RFieldBase::Create("myShort", "Short_t").Unwrap()->GetType());
-}
-
-TEST(RNTuple, UInt16_t)
-{
-   auto field = RField<std::uint16_t>("myUint16");
-   auto otherField = RFieldBase::Create("test", "std::uint16_t").Unwrap();
-   ASSERT_EQ("std::uint16_t", RFieldBase::Create("myUShort", "UShort_t").Unwrap()->GetType());
 }
 
 TEST(RNTuple, Double)


### PR DESCRIPTION
As a follow up of #12133, this PR adds support for the column types
  - kSplitReal64
  - kSplitReal32
  - kSplitInt64
  - kSplitInt32
  - kSplitInt16

It makes the split encoding the default unless the ntuple is stored uncompressed.

A follow-up PR will take care of kSplitIndex[32|64].