### PR TITLE
[RF] Make it possible to switch to `ryml` backend after building ROOT

### DIFF
--- a/.github/workflows/rootci-installers/buildconfig/global.txt
+++ b/.github/workflows/rootci-installers/buildconfig/global.txt
@@ -86,7 +86,6 @@ qt5web=OFF
 qt6web=OFF
 r=OFF
 roofit=ON
-roofit_hs3_ryml=OFF
 roofit_multiprocess=OFF
 root7=ON
 rootbench=OFF

--- a/.github/workflows/rootci-installers/buildconfig/mac12.txt
+++ b/.github/workflows/rootci-installers/buildconfig/mac12.txt
@@ -86,7 +86,6 @@ qt5web=OFF
 qt6web=OFF
 r=OFF
 roofit=OFF
-roofit_hs3_ryml=OFF
 roofit_multiprocess=OFF
 root7=OFF
 rootbench=OFF

--- a/.github/workflows/rootci-installers/buildconfig/ubuntu18.txt
+++ b/.github/workflows/rootci-installers/buildconfig/ubuntu18.txt
@@ -79,7 +79,6 @@ qt5web=On
 qt6web=Off
 r=On
 roofit=On
-roofit_hs3_ryml=Off
 roofit_multiprocess=On
 roottest=ON
 runtime_cxxmodules=Off

--- a/.github/workflows/rootci-installers/buildconfig/ubuntu20.txt
+++ b/.github/workflows/rootci-installers/buildconfig/ubuntu20.txt
@@ -78,7 +78,6 @@ qt5web=On
 qt6web=Off
 r=On
 roofit=On
-roofit_hs3_ryml=Off
 roofit_multiprocess=On
 roottest=ON
 runtime_cxxmodules=Off

--- a/.github/workflows/rootci-installers/buildconfig/windows.txt
+++ b/.github/workflows/rootci-installers/buildconfig/windows.txt
@@ -86,7 +86,6 @@ qt5web=OFF
 qt6web=OFF
 r=OFF
 roofit=OFF
-roofit_hs3_ryml=OFF
 roofit_multiprocess=OFF
 root7=OFF
 rootbench=OFF

--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -166,7 +166,6 @@ ROOT_BUILD_OPTION(qt6web OFF "Enable support for Qt6 web-based display (requires
 ROOT_BUILD_OPTION(r OFF "Enable support for R bindings (requires R, Rcpp, and RInside)")
 ROOT_BUILD_OPTION(roofit ON "Build the advanced fitting package RooFit, and RooStats for statistical tests. If xml is available, also build HistFactory.")
 ROOT_BUILD_OPTION(roofit_multiprocess OFF "Build RooFit::MultiProcess and multi-process RooFit::TestStatistics classes (requires ZeroMQ with zmq_ppoll and cppzmq).")
-ROOT_BUILD_OPTION(roofit_hs3_ryml OFF "Try to find RapidYML on the system and use it for RooFit JSON/YAML convertes")
 ROOT_BUILD_OPTION(webgui ON "Build Web-based UI components of ROOT (requires C++17 standard or higher)")
 ROOT_BUILD_OPTION(root7 ON "Build ROOT 7 components of ROOT (requires C++17 standard or higher)")
 ROOT_BUILD_OPTION(rpath ON "Link libraries with built-in RPATH (run-time search path)")

--- a/roofit/hs3/src/HistFactoryJSONTool.cxx
+++ b/roofit/hs3/src/HistFactoryJSONTool.cxx
@@ -233,21 +233,14 @@ void RooStats::HistFactory::JSONTool::PrintJSON(std::string const &filename)
    this->PrintJSON(out);
 }
 
-#ifdef ROOFIT_HS3_WITH_RYML
 void RooStats::HistFactory::JSONTool::PrintYAML(std::ostream &os)
 {
-   TRYMLTree p;
-   auto &n = p.rootnode();
+   std::unique_ptr<RooFit::Detail::JSONTree> tree = RooJSONFactoryWSTool::createNewJSONTree();
+   auto &n = tree->rootnode();
    n.set_map();
    exportMeasurement(_measurement, n);
    n.writeYML(os);
 }
-#else
-void RooStats::HistFactory::JSONTool::PrintYAML(std::ostream & /*os*/)
-{
-   std::cerr << "YAML export only support with rapidyaml!" << std::endl;
-}
-#endif
 
 void RooStats::HistFactory::JSONTool::PrintYAML(std::string const &filename)
 {

--- a/roofit/jsoninterface/CMakeLists.txt
+++ b/roofit/jsoninterface/CMakeLists.txt
@@ -9,22 +9,18 @@
 # @author Jonas Rembser, CERN
 ############################################################################
 
-if(roofit_hs3_ryml)
-  # If RapidYAML can be found on the system, we will use RapidYAML instead of
-  # nlohmann-json. Like this we can also convert to yaml.
+# If RapidYAML can be found on the system, we will also compile the RapidYAML backend besides the
+# nlohmann-json backend. Like this we can also convert to yaml.
 
-  message(STATUS "Looking for RapidYAML (used by RooFit)")
-  find_package(ryml)
-  if(${RYML_FOUND})
-    message(STATUS "RapidYAML found, compiling RooFit JSON Interface with RapidYAML parser")
-    set(ParserSource src/RYMLParser.cxx)
-    add_compile_definitions(ROOFIT_WITH_RYML)
-  else()
-    set(ParserSource src/JSONParser.cxx)
-    message(STATUS "RapidYAML not found, compiling RooFit with nlohmann-json parser")
-  endif()
+message(STATUS "Looking for RapidYAML (used by RooFit)")
+find_package(ryml)
+if(${RYML_FOUND})
+  message(STATUS "RapidYAML found, compiling also RooFit JSON Interface with RapidYAML parser")
+  set(ParserSources src/JSONParser.cxx src/RYMLParser.cxx)
+  add_compile_definitions(ROOFIT_WITH_RYML)
 else()
-  set(ParserSource src/JSONParser.cxx)
+  set(ParserSources src/JSONParser.cxx)
+  message(STATUS "RapidYAML not found, only compiling RooFit with nlohmann-json parser")
 endif()
 
 ROOT_STANDARD_LIBRARY_PACKAGE(RooFitJSONInterface
@@ -32,21 +28,21 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitJSONInterface
     RooFit/Detail/JSONInterface.h
   SOURCES
     src/JSONInterface.cxx
-    ${ParserSource}
+    ${ParserSources}
   DICTIONARY_OPTIONS
     "-writeEmptyRootPCM"
   LIBRARIES
     Core
 )
 
-if((roofit_hs3_ryml) AND (${RYML_FOUND}))
+if(${RYML_FOUND})
   target_include_directories(RooFitJSONInterface PRIVATE ${RYML_INCLUDE_DIRS})
   target_link_libraries(RooFitJSONInterface PRIVATE -lc4core -lryml)
   target_link_directories(RooFitJSONInterface PRIVATE ${RYML_LIB_DIR})
+endif()
+
+if(builtin_nlohmannjson)
+  target_include_directories(RooFitJSONInterface PRIVATE ${CMAKE_SOURCE_DIR}/builtins)
 else()
-  if(builtin_nlohmannjson)
-    target_include_directories(RooFitJSONInterface PRIVATE ${CMAKE_SOURCE_DIR}/builtins)
-  else()
-    target_link_libraries(RooFitJSONInterface PUBLIC nlohmann_json::nlohmann_json)
-  endif()
+  target_link_libraries(RooFitJSONInterface PUBLIC nlohmann_json::nlohmann_json)
 endif()

--- a/roofit/jsoninterface/inc/RooFit/Detail/JSONInterface.h
+++ b/roofit/jsoninterface/inc/RooFit/Detail/JSONInterface.h
@@ -133,6 +133,17 @@ public:
 
    static std::unique_ptr<JSONTree> create();
    static std::unique_ptr<JSONTree> create(std::istream &is);
+
+   static std::string getBackend();
+   static void setBackend(std::string const &name);
+
+   static bool hasBackend(std::string const &name);
+
+private:
+   // Internally, we store the backend type with an enum to be more memory efficient.
+   enum class Backend { NlohmannJson, Ryml };
+
+   static Backend &getBackendEnum();
 };
 
 std::ostream &operator<<(std::ostream &os, RooFit::Detail::JSONNode const &s);

--- a/roofit/jsoninterface/src/JSONInterface.cxx
+++ b/roofit/jsoninterface/src/JSONInterface.cxx
@@ -12,12 +12,9 @@
 
 #include <RooFit/Detail/JSONInterface.h>
 
+#include "JSONParser.h"
 #ifdef ROOFIT_WITH_RYML
 #include "RYMLParser.h"
-using Tree_t = TRYMLTree;
-#else
-#include "JSONParser.h"
-using Tree_t = TJSONTree;
 #endif
 
 namespace {
@@ -97,12 +94,69 @@ std::string JSONNode::val_t<std::string>() const
 
 std::unique_ptr<JSONTree> JSONTree::create()
 {
-   return std::make_unique<Tree_t>();
+   if (getBackendEnum() == Backend::Ryml) {
+#ifdef ROOFIT_WITH_RYML
+      return std::make_unique<TRYMLTree>();
+#else
+      throw std::runtime_error(
+         "Requesting JSON tree with rapidyaml backend, but rapidyaml could not be found by ROOT when it was compiled.");
+#endif
+   }
+   return std::make_unique<TJSONTree>();
 }
 
 std::unique_ptr<JSONTree> JSONTree::create(std::istream &is)
 {
-   return std::make_unique<Tree_t>(is);
+   if (getBackendEnum() == Backend::Ryml) {
+#ifdef ROOFIT_WITH_RYML
+      return std::make_unique<TRYMLTree>(is);
+#else
+      throw std::runtime_error(
+         "Requesting JSON tree with rapidyaml backend, but rapidyaml could not be found by ROOT when it was compiled.");
+#endif
+   }
+   return std::make_unique<TJSONTree>(is);
+}
+
+/// Check if ROOT was compiled with support for a certain JSON backend library.
+/// \param[in] name Name of the backend.
+bool JSONTree::hasBackend(std::string const &name)
+{
+   if (name == "rapidyaml") {
+#ifdef ROOFIT_WITH_RYML
+      return true;
+#else
+      return false;
+#endif
+   }
+   if (name == "nlohmann-json")
+      return true;
+   return false;
+}
+
+JSONTree::Backend &JSONTree::getBackendEnum()
+{
+   static Backend backend = Backend::NlohmannJson;
+   return backend;
+}
+
+/// Returns the name of the library that serves as the backend for the JSON
+/// interface, which is either `"nlohmann-json"` or `"rapidyaml"`.
+/// \return Backend name as a string.
+std::string JSONTree::getBackend()
+{
+   return getBackendEnum() == Backend::Ryml ? "rapidyaml" : "nlohmann-json";
+}
+
+/// Set the library that serves as the backend for the JSON interface. Note that the `"rapidyaml"` backend is only
+/// supported if rapidyaml was found on the system when ROOT was compiled. \param[in] name Name of the backend, can be
+/// either `"nlohmann-json"` or `"rapidyaml"`.
+void JSONTree::setBackend(std::string const &name)
+{
+   if (name == "rapidyaml")
+      getBackendEnum() = Backend::Ryml;
+   if (name == "nlohmann-json")
+      getBackendEnum() = Backend::NlohmannJson;
 }
 
 } // namespace Detail


### PR DESCRIPTION
ROOT introduced a build flag in 6.26.00 that allowed you to build it using the `ryml` library instead of nlohmann-json as the backend for the JSON IO.

But that was not particularly great. The `ryml` backend code is at risk of rotting, because to try and test it one needs a special ROOT build.

It would be much better to just build both backends if `ryml` is installed on the system, and have a mechanism for developers to try this other backend. This is implemented in this commit.