### PR TITLE
RF] Use `double` and not `float` all the way in RooFit JSON IO 

### DIFF
--- a/roofit/hs3/src/HistFactoryJSONTool.cxx
+++ b/roofit/hs3/src/HistFactoryJSONTool.cxx
@@ -42,11 +42,7 @@ void exportSample(const RooStats::HistFactory::Sample &sample, JSONNode &s)
    }
 
    if (sample.GetNormFactorList().size() > 0) {
-      auto &normFactors = s["normFactors"];
-      normFactors.set_seq();
-      for (auto &sys : sample.GetNormFactorList()) {
-         normFactors.append_child() << sys.GetName();
-      }
+      s["normFactors"].fill_seq(sample.GetNormFactorList(), [](auto const &x) { return x.GetName(); });
    }
 
    if (sample.GetHistoSysList().size() > 0) {

--- a/roofit/hs3/src/JSONFactories_HistFactory.cxx
+++ b/roofit/hs3/src/JSONFactories_HistFactory.cxx
@@ -82,8 +82,8 @@ inline void stackError(const JSONNode &n, std::vector<double> &sumW, std::vector
    }
    const size_t nbins = n["counts"].num_children();
    for (size_t ibin = 0; ibin < nbins; ++ibin) {
-      double w = n["counts"][ibin].val_float();
-      double e = n["errors"][ibin].val_float();
+      double w = n["counts"][ibin].val_double();
+      double e = n["errors"][ibin].val_double();
       if (ibin < sumW.size())
          sumW[ibin] += w;
       else
@@ -246,8 +246,8 @@ bool importHistSample(RooWorkspace &ws, Scope const &scope, const JSONNode &p)
                                                            : "alpha_" + sysname);
             if (RooRealVar *par = ::getNP(ws, parname.c_str())) {
                nps.add(*par);
-               low.push_back(sys["low"].val_float());
-               high.push_back(sys["high"].val_float());
+               low.push_back(sys["low"].val_double());
+               high.push_back(sys["high"].val_double());
             } else {
                RooJSONFactoryWSTool::error("overall systematic '" + sysname + "' doesn't have a valid parameter!");
             }
@@ -428,7 +428,7 @@ public:
       std::string sysname(RooJSONFactoryWSTool::name(p));
       std::vector<double> vals;
       for (const auto &v : p["vals"].children()) {
-         vals.push_back(v.val_float());
+         vals.push_back(v.val_double());
       }
       RooArgList gammas;
       return createPHF(sysname, phfname, vals, w, constraints, observables, p["constraint"].val(), gammas, 0, 1000);
@@ -453,7 +453,7 @@ public:
       if (p.has_child("statError")) {
          auto &staterr = p["statError"];
          if (staterr.has_child("relThreshold"))
-            statErrorThreshold = staterr["relThreshold"].val_float();
+            statErrorThreshold = staterr["relThreshold"].val_double();
          if (staterr.has_child("constraint"))
             statErrorType = staterr["constraint"].val();
       }
@@ -668,7 +668,7 @@ public:
          RooJSONFactoryWSTool::error("no nominal variation of '" + name + "'");
       }
 
-      double nom(p["nom"].val_float());
+      double nom(p["nom"].val_double());
 
       RooArgList vars;
       for (const auto &d : p["vars"].children()) {

--- a/roofit/hs3/src/JSONFactories_HistFactory.cxx
+++ b/roofit/hs3/src/JSONFactories_HistFactory.cxx
@@ -955,8 +955,7 @@ public:
    }
 };
 
-STATIC_EXECUTE(
-
+STATIC_EXECUTE([]() {
    using namespace RooFit::JSONIO;
 
    registerImporter<RooRealSumPdfFactory>("histfactory", true);
@@ -965,7 +964,6 @@ STATIC_EXECUTE(
    registerExporter<FlexibleInterpVarStreamer>(RooStats::HistFactory::FlexibleInterpVar::Class(), true);
    registerExporter<PiecewiseInterpolationStreamer>(PiecewiseInterpolation::Class(), true);
    registerExporter<HistFactoryStreamer>(RooProdPdf::Class(), true);
-
-)
+});
 
 } // namespace

--- a/roofit/hs3/src/JSONFactories_HistFactory.cxx
+++ b/roofit/hs3/src/JSONFactories_HistFactory.cxx
@@ -560,18 +560,13 @@ public:
    }
    bool exportObject(RooJSONFactoryWSTool *, const RooAbsArg *func, JSONNode &elem) const override
    {
-      const RooStats::HistFactory::FlexibleInterpVar *fip =
-         static_cast<const RooStats::HistFactory::FlexibleInterpVar *>(func);
+      auto fip = static_cast<const RooStats::HistFactory::FlexibleInterpVar *>(func);
       elem["type"] << key();
-      auto &vars = elem["vars"];
-      elem["interpolationCodes"] << fip->interpolationCodes();
-      vars.set_seq();
-      for (const auto &v : fip->variables()) {
-         vars.append_child() << v->GetName();
-      }
+      elem["vars"].fill_seq(fip->variables(), [](auto const &item) { return item->GetName(); });
+      elem["interpolationCodes"].fill_seq(fip->interpolationCodes());
       elem["nom"] << fip->nominal();
-      elem["high"] << fip->high();
-      elem["low"] << fip->low();
+      elem["high"].fill_seq(fip->high());
+      elem["low"].fill_seq(fip->low());
       return true;
    }
 };
@@ -587,27 +582,13 @@ public:
    {
       const PiecewiseInterpolation *pip = static_cast<const PiecewiseInterpolation *>(func);
       elem["type"] << key();
-      elem["interpolationCodes"] << pip->interpolationCodes();
-      auto &vars = elem["vars"];
-      vars.set_seq();
-      for (const auto &v : pip->paramList()) {
-         vars.append_child() << v->GetName();
-      }
-
+      elem["interpolationCodes"].fill_seq(pip->interpolationCodes());
+      elem["vars"].fill_seq(pip->paramList(), [](auto const &item) { return item->GetName(); });
       auto &nom = elem["nom"];
       nom << pip->nominalHist()->GetName();
 
-      auto &high = elem["high"];
-      high.set_seq();
-      for (const auto &v : pip->highList()) {
-         high.append_child() << v->GetName();
-      }
-
-      auto &low = elem["low"];
-      low.set_seq();
-      for (const auto &v : pip->lowList()) {
-         low.append_child() << v->GetName();
-      }
+      elem["high"].fill_seq(pip->highList(), [](auto const &item) { return item->GetName(); });
+      elem["low"].fill_seq(pip->lowList(), [](auto const &item) { return item->GetName(); });
       return true;
    }
 };
@@ -823,11 +804,7 @@ public:
          auto &s = samples[samplename];
          s.set_map();
 
-         for (const auto &norm : norms) {
-            auto &nfs = s["normFactors"];
-            nfs.set_seq();
-            nfs.append_child() << norm->GetName();
-         }
+         s["normFactors"].fill_seq(norms, [](auto const &item) { return item->GetName(); });
 
          if (pip) {
             auto &systs = s["histogramSystematics"];

--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -526,8 +526,7 @@ public:
 // instantiate all importers and exporters
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 
-STATIC_EXECUTE(
-
+STATIC_EXECUTE([]() {
    using namespace RooFit::JSONIO;
 
    registerImporter<RooProdPdfFactory>("pdfprod", false);
@@ -551,6 +550,7 @@ STATIC_EXECUTE(
    registerExporter<RooGenericPdfStreamer>(RooGenericPdf::Class(), false);
    registerExporter<RooFormulaVarStreamer>(RooFormulaVar::Class(), false);
    registerExporter<RooRealSumPdfStreamer>(RooRealSumPdf::Class(), false);
-   registerExporter<RooRealSumFuncStreamer>(RooRealSumFunc::Class(), false);)
+   registerExporter<RooRealSumFuncStreamer>(RooRealSumFunc::Class(), false);
+});
 
 } // namespace

--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -536,7 +536,7 @@ STATIC_EXECUTE(
    registerImporter<RooBinSamplingPdfFactory>("binsampling", false);
    registerImporter<RooAddPdfFactory>("pdfsum", false);
    registerImporter<RooHistFuncFactory>("histogram", false);
-   registerImporter<RooHistFuncFactory>("histogramPdf", false);
+   registerImporter<RooHistPdfFactory>("histogramPdf", false);
    registerImporter<RooSimultaneousFactory>("simultaneous", false);
    registerImporter<RooBinWidthFunctionFactory>("binwidth", false);
    registerImporter<RooRealSumPdfFactory>("sumpdf", false);

--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -301,16 +301,8 @@ public:
    {
       const RooRealSumPdf *pdf = static_cast<const RooRealSumPdf *>(func);
       elem["type"] << key();
-      auto &samples = elem["samples"];
-      samples.set_seq();
-      auto &coefs = elem["coefficients"];
-      coefs.set_seq();
-      for (const auto &s : pdf->funcList()) {
-         samples.append_child() << s->GetName();
-      }
-      for (const auto &c : pdf->coefList()) {
-         coefs.append_child() << c->GetName();
-      }
+      elem["samples"].fill_seq(pdf->funcList(), [](auto const &item) { return item->GetName(); });
+      elem["coefficients"].fill_seq(pdf->coefList(), [](auto const &item) { return item->GetName(); });
       elem["extended"] << (pdf->extendMode() == RooAbsPdf::CanBeExtended);
       return true;
    }
@@ -327,16 +319,8 @@ public:
    {
       const RooRealSumFunc *pdf = static_cast<const RooRealSumFunc *>(func);
       elem["type"] << key();
-      auto &samples = elem["samples"];
-      samples.set_seq();
-      auto &coefs = elem["coefficients"];
-      coefs.set_seq();
-      for (const auto &s : pdf->funcList()) {
-         samples.append_child() << s->GetName();
-      }
-      for (const auto &c : pdf->coefList()) {
-         coefs.append_child() << c->GetName();
-      }
+      elem["samples"].fill_seq(pdf->funcList(), [](auto const &item) { return item->GetName(); });
+      elem["coefficients"].fill_seq(pdf->coefList(), [](auto const &item) { return item->GetName(); });
       return true;
    }
 };
@@ -482,10 +466,7 @@ public:
    {
       const RooProdPdf *pdf = static_cast<const RooProdPdf *>(func);
       elem["type"] << key();
-      auto &factors = elem["pdfs"];
-      for (const auto &f : pdf->pdfList()) {
-         factors.append_child() << f->GetName();
-      }
+      elem["pdfs"].fill_seq(pdf->pdfList(), [](auto const &f) { return f->GetName(); });
       return true;
    }
 };
@@ -502,10 +483,7 @@ public:
       const RooGenericPdf *pdf = static_cast<const RooGenericPdf *>(func);
       elem["type"] << key();
       elem["formula"] << pdf->expression();
-      auto &factors = elem["dependents"];
-      for (const auto &f : pdf->dependents()) {
-         factors.append_child() << f->GetName();
-      }
+      elem["dependents"].fill_seq(pdf->dependents(), [](auto const &f) { return f->GetName(); });
       return true;
    }
 };
@@ -539,10 +517,7 @@ public:
       const RooFormulaVar *var = static_cast<const RooFormulaVar *>(func);
       elem["type"] << key();
       elem["formula"] << var->expression();
-      auto &factors = elem["dependents"];
-      for (const auto &f : var->dependents()) {
-         factors.append_child() << f->GetName();
-      }
+      elem["dependents"].fill_seq(var->dependents(), [](auto const &f) { return f->GetName(); });
       return true;
    }
 };
@@ -555,7 +530,8 @@ STATIC_EXECUTE(
 
    using namespace RooFit::JSONIO;
 
-   registerImporter<RooProdPdfFactory>("pdfprod", false); registerImporter<RooGenericPdfFactory>("genericpdf", false);
+   registerImporter<RooProdPdfFactory>("pdfprod", false);
+   registerImporter<RooGenericPdfFactory>("genericpdf", false);
    registerImporter<RooFormulaVarFactory>("formulavar", false);
    registerImporter<RooBinSamplingPdfFactory>("binsampling", false);
    registerImporter<RooAddPdfFactory>("pdfsum", false);
@@ -575,7 +551,6 @@ STATIC_EXECUTE(
    registerExporter<RooGenericPdfStreamer>(RooGenericPdf::Class(), false);
    registerExporter<RooFormulaVarStreamer>(RooFormulaVar::Class(), false);
    registerExporter<RooRealSumPdfStreamer>(RooRealSumPdf::Class(), false);
-   registerExporter<RooRealSumFuncStreamer>(RooRealSumFunc::Class(), false);
-)
+   registerExporter<RooRealSumFuncStreamer>(RooRealSumFunc::Class(), false);)
 
 } // namespace

--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -217,7 +217,7 @@ public:
       if (!p.has_child("epsilon")) {
          RooJSONFactoryWSTool::error("no epsilon given in '" + name + "'");
       }
-      double epsilon(p["epsilon"].val_float());
+      double epsilon(p["epsilon"].val_double());
 
       RooBinSamplingPdf thepdf(name.c_str(), name.c_str(), *obs, *pdf, epsilon);
       tool->workspace()->import(thepdf, RooFit::RecycleConflictNodes(true), RooFit::Silence(true));

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -224,14 +224,14 @@ RooJSONFactoryWSTool::Var::Var(const JSONNode &val)
       if (!val.has_child("min"))
          this->min = 0;
       else
-         this->min = val["min"].val_float();
+         this->min = val["min"].val_double();
       if (!val.has_child("max"))
          this->max = 1;
       else
-         this->max = val["max"].val_float();
+         this->max = val["max"].val_double();
    } else if (val.is_seq()) {
       for (size_t i = 0; i < val.num_children(); ++i) {
-         this->bounds.push_back(val[i].val_float());
+         this->bounds.push_back(val[i].val_double());
       }
       this->nbins = this->bounds.size();
       this->min = this->bounds[0];
@@ -852,9 +852,9 @@ std::map<std::string, std::unique_ptr<RooAbsData>> RooJSONFactoryWSTool::loadDat
             }
             for (size_t j = 0; j < point.num_children(); ++j) {
                auto *v = static_cast<RooRealVar *>(varlist.at(j));
-               v->setVal(point[j].val_float());
+               v->setVal(point[j].val_double());
             }
-            data->add(vars, weights[i].val_float());
+            data->add(vars, weights[i].val_double());
          }
          dataMap[name] = std::move(data);
       } else if (p.has_child("index")) {
@@ -1045,7 +1045,7 @@ std::unique_ptr<RooDataHist> RooJSONFactoryWSTool::readBinnedData(RooWorkspace &
          RooRealVar *v = (RooRealVar *)(varlist.at(i));
          v->setBin(bins[ibin][i]);
       }
-      dh->add(varlist, counts[ibin].val_float());
+      dh->add(varlist, counts[ibin].val_double());
    }
    // re-enable dirty flag propagation
    for (size_t i = 0; i < varlist.size(); ++i) {
@@ -1182,17 +1182,17 @@ void RooJSONFactoryWSTool::importVariable(const JSONNode &p)
 void RooJSONFactoryWSTool::configureVariable(const JSONNode &p, RooRealVar &v)
 {
    if (p.has_child("value"))
-      v.setVal(p["value"].val_float());
+      v.setVal(p["value"].val_double());
    if (p.has_child("min"))
-      v.setMin(p["min"].val_float());
+      v.setMin(p["min"].val_double());
    if (p.has_child("max"))
-      v.setMax(p["max"].val_float());
+      v.setMax(p["max"].val_double());
    if (p.has_child("nbins"))
       v.setBins(p["nbins"].val_int());
    if (p.has_child("relErr"))
-      v.setError(v.getVal() * p["relErr"].val_float());
+      v.setError(v.getVal() * p["relErr"].val_double());
    if (p.has_child("err"))
-      v.setError(p["err"].val_float());
+      v.setError(p["err"].val_double());
    if (p.has_child("const"))
       v.setConstant(p["const"].val_bool());
    else

--- a/roofit/hs3/src/static_execute.h
+++ b/roofit/hs3/src/static_execute.h
@@ -15,7 +15,7 @@
 
 // Execute code on library loading by running code in the constructor of a
 // class that is a static class member of another class.
-#define STATIC_EXECUTE(MY_CODE)   \
+#define STATIC_EXECUTE(MY_FUNC)   \
    struct StaticExecutorWrapper { \
       struct Executor {           \
          template <class Func>    \
@@ -27,6 +27,6 @@
       static Executor executor;   \
    };                             \
                                   \
-   StaticExecutorWrapper::Executor StaticExecutorWrapper::executor{[]() { MY_CODE }};
+   StaticExecutorWrapper::Executor StaticExecutorWrapper::executor{MY_FUNC};
 
 #endif

--- a/roofit/jsoninterface/inc/RooFit/Detail/JSONInterface.h
+++ b/roofit/jsoninterface/inc/RooFit/Detail/JSONInterface.h
@@ -83,15 +83,6 @@ public:
    virtual JSONNode &operator<<(std::string const &s) = 0;
    virtual JSONNode &operator<<(int i) = 0;
    virtual JSONNode &operator<<(double d) = 0;
-   template <class T>
-   JSONNode &operator<<(const std::vector<T> &v)
-   {
-      this->set_seq();
-      for (const auto &e : v) {
-         this->append_child() << e;
-      };
-      return *this;
-   }
    virtual const JSONNode &operator>>(std::string &v) const = 0;
    virtual JSONNode &operator[](std::string const &k) = 0;
    virtual JSONNode &operator[](size_t pos) = 0;
@@ -123,6 +114,24 @@ public:
    virtual const_children_view children() const;
    virtual JSONNode &child(size_t pos) = 0;
    virtual const JSONNode &child(size_t pos) const = 0;
+
+   template <typename Collection>
+   void fill_seq(Collection const &coll)
+   {
+      set_seq();
+      for (auto const &item : coll) {
+         append_child() << item;
+      }
+   }
+
+   template <typename Collection, typename TransformationFunc>
+   void fill_seq(Collection const &coll, TransformationFunc func)
+   {
+      set_seq();
+      for (auto const &item : coll) {
+         append_child() << func(item);
+      }
+   }
 };
 
 class JSONTree {

--- a/roofit/jsoninterface/inc/RooFit/Detail/JSONInterface.h
+++ b/roofit/jsoninterface/inc/RooFit/Detail/JSONInterface.h
@@ -97,7 +97,7 @@ public:
    virtual std::string key() const = 0;
    virtual std::string val() const = 0;
    virtual int val_int() const { return atoi(this->val().c_str()); }
-   virtual float val_float() const { return atof(this->val().c_str()); }
+   virtual double val_double() const { return std::stod(this->val()); }
    virtual bool val_bool() const { return atoi(this->val().c_str()); }
    template <class T>
    T val_t() const;

--- a/roofit/jsoninterface/src/JSONInterface.cxx
+++ b/roofit/jsoninterface/src/JSONInterface.cxx
@@ -75,14 +75,9 @@ int JSONNode::val_t<int>() const
    return val_int();
 }
 template <>
-float JSONNode::val_t<float>() const
-{
-   return val_float();
-}
-template <>
 double JSONNode::val_t<double>() const
 {
-   return val_float();
+   return val_double();
 }
 template <>
 bool JSONNode::val_t<bool>() const

--- a/roofit/jsoninterface/src/JSONParser.cxx
+++ b/roofit/jsoninterface/src/JSONParser.cxx
@@ -251,7 +251,7 @@ std::string TJSONTree::Node::val() const
    case nlohmann::json::value_t::boolean: return node->get().get<bool>() ? "true" : "false";
    case nlohmann::json::value_t::number_integer: return std::to_string(node->get().get<int>());
    case nlohmann::json::value_t::number_unsigned: return std::to_string(node->get().get<unsigned int>());
-   case nlohmann::json::value_t::number_float: return std::to_string(node->get().get<float>());
+   case nlohmann::json::value_t::number_float: return std::to_string(node->get().get<double>());
    default:
       throw std::runtime_error(std::string("node " + node->key() + ": implicit string conversion for type " +
                                            node->get().type_name() + " not supported!"));
@@ -262,9 +262,9 @@ int TJSONTree::Node::val_int() const
 {
    return node->get().get<int>();
 }
-float TJSONTree::Node::val_float() const
+double TJSONTree::Node::val_double() const
 {
-   return node->get().get<float>();
+   return node->get().get<double>();
 }
 bool TJSONTree::Node::val_bool() const
 {

--- a/roofit/jsoninterface/src/JSONParser.h
+++ b/roofit/jsoninterface/src/JSONParser.h
@@ -59,7 +59,7 @@ public:
       std::string key() const override;
       std::string val() const override;
       int val_int() const override;
-      float val_float() const override;
+      double val_double() const override;
       bool val_bool() const override;
       bool has_key() const override;
       bool has_val() const override;

--- a/roofit/jsoninterface/src/RYMLParser.cxx
+++ b/roofit/jsoninterface/src/RYMLParser.cxx
@@ -171,7 +171,7 @@ TRYMLTree::Node &TRYMLTree::Node::operator<<(int i)
 
 TRYMLTree::Node &TRYMLTree::Node::operator<<(double d)
 {
-   // write an float to this node
+   // write a double to this node
    node->get() << d;
    return *this;
 }


### PR DESCRIPTION
RooFit uses doubles everywhere else, so if importing a model from JSON
should give the same biswise results as creating the model in the
workspace factory language, `double` needs to be used in the JSON
interface too.

There is also another commit  that fixes a typo, and another commit that adds an easy way to fill lists via the JSON interface in order to reduce the number of lines of code needed.