### PR TITLE
[RF] Improve importing other `RooAbsData` when creating a `RooDataSet`

### DIFF
--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -142,7 +142,6 @@ private:
    const RooFit::Detail::JSONNode &irootnode() const;
 
    std::map<std::string, std::unique_ptr<RooAbsData>> loadData(const RooFit::Detail::JSONNode &n);
-   RooRealVar *getWeightVar(const char *name);
    static RooRealVar *createObservable(RooWorkspace &ws, const std::string &name, const RooJSONFactoryWSTool::Var &var);
 
    class MissingRootnodeError : public std::exception {

--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -142,7 +142,6 @@ private:
    const RooFit::Detail::JSONNode &irootnode() const;
 
    std::map<std::string, std::unique_ptr<RooAbsData>> loadData(const RooFit::Detail::JSONNode &n);
-   std::unique_ptr<RooDataSet> unbinned(RooDataHist const &hist);
    RooRealVar *getWeightVar(const char *name);
    static RooRealVar *createObservable(RooWorkspace &ws, const std::string &name, const RooJSONFactoryWSTool::Var &var);
 

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -778,19 +778,6 @@ void RooJSONFactoryWSTool::importFunction(const JSONNode &p, bool isPdf)
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
-// generating a weight variable
-
-RooRealVar *RooJSONFactoryWSTool::getWeightVar(const char *weightName)
-{
-   RooRealVar *weightVar = _workspace.var(weightName);
-   if (!weightVar) {
-      _workspace.factory(std::string(weightName) + "[0.,0.,10000000]");
-   }
-   weightVar = _workspace.var(weightName);
-   return weightVar;
-}
-
-///////////////////////////////////////////////////////////////////////////////////////////////////////
 // importing data
 std::map<std::string, std::unique_ptr<RooAbsData>> RooJSONFactoryWSTool::loadData(const JSONNode &n)
 {
@@ -816,9 +803,7 @@ std::map<std::string, std::unique_ptr<RooAbsData>> RooJSONFactoryWSTool::loadDat
          RooArgSet vars;
          this->getObservables(_workspace, p, name, vars);
          RooArgList varlist(vars);
-         RooRealVar *weightVar = this->getWeightVar("weight");
-         vars.add(*weightVar, true);
-         auto data = std::make_unique<RooDataSet>(name, name, vars, RooFit::WeightVar(*weightVar));
+         auto data = std::make_unique<RooDataSet>(name, name, vars, RooFit::WeightVar());
          auto &coords = p["coordinates"];
          auto &weights = p["weights"];
          if (coords.num_children() != weights.num_children()) {
@@ -853,14 +838,11 @@ std::map<std::string, std::unique_ptr<RooAbsData>> RooJSONFactoryWSTool::loadDat
             logInputArgumentsError(std::move(ss));
          } else {
             RooArgSet allVars;
-            allVars.add(*channelCat, true);
             for (const auto &subd : subMap) {
                allVars.add(*subd.second->get(), true);
             }
-            RooRealVar *weightVar = this->getWeightVar("weight");
-            allVars.add(*weightVar, true);
             dataMap[name] = std::make_unique<RooDataSet>(name, name, allVars, RooFit::Index(*channelCat),
-                                                         RooFit::Import(subMap), RooFit::WeightVar(*weightVar));
+                                                         RooFit::Import(subMap));
          }
       } else {
          std::stringstream ss;

--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -322,6 +322,8 @@ protected:
 
   StorageType storageType;
 
+  void initializeVars(RooArgSet const& vars);
+
   double corrcov(const RooRealVar& x, const RooRealVar& y, const char* cutSpec, const char* cutRange, bool corr) const  ;
   TMatrixDSym* corrcovMatrix(const RooArgList& vars, const char* cutSpec, const char* cutRange, bool corr) const  ;
 

--- a/roofit/roofitcore/inc/RooDataSet.h
+++ b/roofit/roofitcore/inc/RooDataSet.h
@@ -176,7 +176,7 @@ protected:
 
 private:
 
-  void loadValuesFromSlices(RooCategory &indexCat, std::map<std::string, RooDataSet *> const &slices,
+  void loadValuesFromSlices(RooCategory &indexCat, std::map<std::string, RooAbsData *> const &slices,
                             const char *rangeName, RooFormulaVar const *cutVar, const char *cutSpec);
 
 #ifdef USEMEMPOOLFORDATASET

--- a/roofit/roofitcore/inc/RooDataSet.h
+++ b/roofit/roofitcore/inc/RooDataSet.h
@@ -16,10 +16,12 @@
 #ifndef ROO_DATA_SET
 #define ROO_DATA_SET
 
-class TDirectory;
 class RooAbsRealLValue;
-class RooRealVar;
+class RooCategory;
 class RooDataHist;
+class RooRealVar;
+
+class TDirectory;
 
 #include "RooAbsData.h"
 #include "RooDirItem.h"
@@ -173,6 +175,10 @@ protected:
   RooRealVar* _wgtVar ;    ///< Pointer to weight variable (if set)
 
 private:
+
+  void loadValuesFromSlices(RooCategory &indexCat, std::map<std::string, RooDataSet *> const &slices,
+                            const char *rangeName, RooFormulaVar const *cutVar, const char *cutSpec);
+
 #ifdef USEMEMPOOLFORDATASET
   typedef MemPoolForRooSets<RooDataSet, 5*150> MemPool; ///< 150 = about 100kb
   static MemPool * memPool();

--- a/roofit/roofitcore/inc/RooGlobalFunc.h
+++ b/roofit/roofitcore/inc/RooGlobalFunc.h
@@ -167,7 +167,7 @@ RooCmdArg Import(const std::map<std::string,RooDataHist*>&) ;
 RooCmdArg Import(TH1& histo, bool importDensity=false) ;
 
 // RooDataSet::ctor arguments
-RooCmdArg WeightVar(const char* name, bool reinterpretAsWeight=false) ;
+RooCmdArg WeightVar(const char* name="weight", bool reinterpretAsWeight=false) ;
 RooCmdArg WeightVar(const RooRealVar& arg, bool reinterpretAsWeight=false) ;
 RooCmdArg Import(const char* state, RooAbsData& data) ;
 RooCmdArg Import(const std::map<std::string,RooDataSet*>& ) ;

--- a/roofit/roofitcore/inc/RooGlobalFunc.h
+++ b/roofit/roofitcore/inc/RooGlobalFunc.h
@@ -169,8 +169,18 @@ RooCmdArg Import(TH1& histo, bool importDensity=false) ;
 // RooDataSet::ctor arguments
 RooCmdArg WeightVar(const char* name, bool reinterpretAsWeight=false) ;
 RooCmdArg WeightVar(const RooRealVar& arg, bool reinterpretAsWeight=false) ;
-RooCmdArg Import(const char* state, RooDataSet& data) ;
+RooCmdArg Import(const char* state, RooAbsData& data) ;
 RooCmdArg Import(const std::map<std::string,RooDataSet*>& ) ;
+template<class DataPtr_t>
+RooCmdArg Import(std::map<std::string,DataPtr_t> const& map) {
+    RooCmdArg container("ImportDataSliceMany",0,0,0,0,0,0,0,0) ;
+    for (auto const& item : map) {
+      container.addArg(Import(item.first.c_str(), *item.second)) ;
+    }
+    container.setProcessRecArgs(true,false) ;
+    return container ;
+}
+
 RooCmdArg Link(const char* state, RooAbsData& data) ;
 RooCmdArg Link(const std::map<std::string,RooAbsData*>&) ;
 RooCmdArg Import(RooDataSet& data) ;

--- a/roofit/roofitcore/inc/RooGlobalFunc.h
+++ b/roofit/roofitcore/inc/RooGlobalFunc.h
@@ -183,7 +183,7 @@ RooCmdArg Import(std::map<std::string,DataPtr_t> const& map) {
 
 RooCmdArg Link(const char* state, RooAbsData& data) ;
 RooCmdArg Link(const std::map<std::string,RooAbsData*>&) ;
-RooCmdArg Import(RooDataSet& data) ;
+RooCmdArg Import(RooAbsData& data) ;
 RooCmdArg Import(TTree& tree) ;
 RooCmdArg ImportFromFile(const char* fname, const char* tname) ;
 RooCmdArg StoreError(const RooArgSet& aset) ;

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1695,13 +1695,9 @@ RooFitResult* RooAbsPdf::fitTo(RooAbsData& data, const RooLinkedList& cmdList)
     }
     else {
       size_t step = data.numEntries()/nEvents;
-      RooArgSet tinyVars(*data.get());
-      RooRealVar weight("weight","weight",1);
 
-      if (data.isWeighted()) tinyVars.add(weight);
-
-      RooDataSet tiny("tiny", "tiny", tinyVars,
-          data.isWeighted() ? RooFit::WeightVar(weight) : RooCmdArg());
+      RooDataSet tiny("tiny", "tiny", *data.get(),
+          data.isWeighted() ? RooFit::WeightVar() : RooCmdArg());
 
       for (int i=0; i<data.numEntries(); i+=step)
       {

--- a/roofit/roofitcore/src/RooBinnedGenContext.cxx
+++ b/roofit/roofitcore/src/RooBinnedGenContext.cxx
@@ -155,10 +155,7 @@ RooDataSet *RooBinnedGenContext::generate(double nEvt, bool /*skipInit*/, bool e
   _pdf->fillDataHist(_hist,_vars,1,true) ;
 
   // Output container
-  RooRealVar weight("weight","weight",0,1e9) ;
-  RooArgSet tmp(*_vars) ;
-  tmp.add(weight) ;
-  RooDataSet* wudata = new RooDataSet("wu","wu",tmp,RooFit::WeightVar("weight")) ;
+  RooDataSet* wudata = new RooDataSet("wu","wu",*_vars,RooFit::WeightVar()) ;
 
   vector<int> histOut(_hist->numEntries()) ;
   double histMax(-1) ;

--- a/roofit/roofitcore/src/RooGlobalFunc.cxx
+++ b/roofit/roofitcore/src/RooGlobalFunc.cxx
@@ -170,7 +170,7 @@ namespace RooFit {
   RooCmdArg WeightVar(const char* name, bool reinterpretAsWeight) { return RooCmdArg("WeightVarName",reinterpretAsWeight,0,0,0,name,0,0,0) ; }
   RooCmdArg WeightVar(const RooRealVar& arg, bool reinterpretAsWeight)  { return RooCmdArg("WeightVar",reinterpretAsWeight,0,0,0,0,0,&arg,0) ; }
   RooCmdArg Link(const char* state, RooAbsData& data)   { return RooCmdArg("LinkDataSlice",0,0,0,0,state,0,&data,0) ;}
-  RooCmdArg Import(const char* state, RooDataSet& data) { return RooCmdArg("ImportDataSlice",0,0,0,0,state,0,&data,0) ; }
+  RooCmdArg Import(const char* state, RooAbsData& data) { return RooCmdArg("ImportDataSlice",0,0,0,0,state,0,&data,0) ; }
   RooCmdArg Import(RooDataSet& data)                    { return RooCmdArg("ImportData",0,0,0,0,0,0,&data,0) ; }
   RooCmdArg Import(TTree& tree)                         { return RooCmdArg("ImportTree",0,0,0,0,0,0,reinterpret_cast<TObject*>(&tree),0) ; }
   RooCmdArg ImportFromFile(const char* fname, const char* tname){ return RooCmdArg("ImportFromFile",0,0,0,0,fname,tname,0,0) ; }

--- a/roofit/roofitcore/src/RooGlobalFunc.cxx
+++ b/roofit/roofitcore/src/RooGlobalFunc.cxx
@@ -171,7 +171,7 @@ namespace RooFit {
   RooCmdArg WeightVar(const RooRealVar& arg, bool reinterpretAsWeight)  { return RooCmdArg("WeightVar",reinterpretAsWeight,0,0,0,0,0,&arg,0) ; }
   RooCmdArg Link(const char* state, RooAbsData& data)   { return RooCmdArg("LinkDataSlice",0,0,0,0,state,0,&data,0) ;}
   RooCmdArg Import(const char* state, RooAbsData& data) { return RooCmdArg("ImportDataSlice",0,0,0,0,state,0,&data,0) ; }
-  RooCmdArg Import(RooDataSet& data)                    { return RooCmdArg("ImportData",0,0,0,0,0,0,&data,0) ; }
+  RooCmdArg Import(RooAbsData& data)                    { return RooCmdArg("ImportData",0,0,0,0,0,0,&data,0) ; }
   RooCmdArg Import(TTree& tree)                         { return RooCmdArg("ImportTree",0,0,0,0,0,0,reinterpret_cast<TObject*>(&tree),0) ; }
   RooCmdArg ImportFromFile(const char* fname, const char* tname){ return RooCmdArg("ImportFromFile",0,0,0,0,fname,tname,0,0) ; }
   RooCmdArg StoreError(const RooArgSet& aset)           { return RooCmdArg("StoreError",0,0,0,0,0,0,0,0,0,0,&aset) ; }

--- a/roofit/roofitcore/src/RooVectorDataStore.cxx
+++ b/roofit/roofitcore/src/RooVectorDataStore.cxx
@@ -575,7 +575,7 @@ void RooVectorDataStore::loadValues(const RooAbsDataStore *ads, const RooFormula
       continue ;
     }
 
-    _varsww.assignValueOnly(*otherVarsww) ;
+    _varsww.assign(*otherVarsww) ;
 
     fill() ;
   }

--- a/roofit/roofitcore/test/testRooBinSamplingPdf.cxx
+++ b/roofit/roofitcore/test/testRooBinSamplingPdf.cxx
@@ -47,11 +47,7 @@ TEST_P(ParamTest, LinearPdfCrossCheck)
 
    RooGenericPdf pdf("lin", "x", {x});
    std::unique_ptr<RooDataHist> dataH(pdf.generateBinned(x, 10000));
-   RooDataSet data("data", "data", x, RooFit::WeightVar());
-   for (int i = 0; i < dataH->numEntries(); ++i) {
-      auto coords = dataH->get(i);
-      data.add(*coords, dataH->weight());
-   }
+   RooDataSet data("data", "data", x, RooFit::Import(*dataH));
 
    std::unique_ptr<RooAbsReal> nll1(pdf.createNLL(data));
    std::unique_ptr<RooAbsReal> nll2(pdf.createNLL(data, IntegrateBins(1.E-3)));
@@ -77,11 +73,7 @@ TEST_P(ParamTest, LinearPdfSubRangeCrossCheck)
 
    RooGenericPdf pdf("lin", "x", {x});
    std::unique_ptr<RooDataHist> dataH(pdf.generateBinned(x, 10000));
-   RooDataSet data("data", "data", x, RooFit::WeightVar());
-   for (int i = 0; i < dataH->numEntries(); ++i) {
-      auto coords = dataH->get(i);
-      data.add(*coords, dataH->weight());
-   }
+   RooDataSet data("data", "data", x, RooFit::Import(*dataH));
 
    std::unique_ptr<RooAbsReal> nll1(pdf.createNLL(data, Range("range")));
    std::unique_ptr<RooAbsReal> nll2(pdf.createNLL(data, Range("range"), IntegrateBins(1.E-3)));

--- a/roofit/roofitcore/test/testRooBinSamplingPdf.cxx
+++ b/roofit/roofitcore/test/testRooBinSamplingPdf.cxx
@@ -47,8 +47,7 @@ TEST_P(ParamTest, LinearPdfCrossCheck)
 
    RooGenericPdf pdf("lin", "x", {x});
    std::unique_ptr<RooDataHist> dataH(pdf.generateBinned(x, 10000));
-   RooRealVar w("w", "weight", 0., 0., 10000.);
-   RooDataSet data("data", "data", {x, w}, RooFit::WeightVar(w));
+   RooDataSet data("data", "data", x, RooFit::WeightVar());
    for (int i = 0; i < dataH->numEntries(); ++i) {
       auto coords = dataH->get(i);
       data.add(*coords, dataH->weight());
@@ -78,8 +77,7 @@ TEST_P(ParamTest, LinearPdfSubRangeCrossCheck)
 
    RooGenericPdf pdf("lin", "x", {x});
    std::unique_ptr<RooDataHist> dataH(pdf.generateBinned(x, 10000));
-   RooRealVar w("w", "weight", 0., 0., 10000.);
-   RooDataSet data("data", "data", {x, w}, RooFit::WeightVar(w));
+   RooDataSet data("data", "data", x, RooFit::WeightVar());
    for (int i = 0; i < dataH->numEntries(); ++i) {
       auto coords = dataH->get(i);
       data.add(*coords, dataH->weight());

--- a/roofit/roofitcore/test/testRooDataSet.cxx
+++ b/roofit/roofitcore/test/testRooDataSet.cxx
@@ -354,3 +354,26 @@ TEST(RooDataSet, ReduceWithSelectVarsAndCutRange)
 
    EXPECT_EQ(reduced->numEntries(), 1);
 }
+
+// Test that importing a RooDataHist to a RooDataSet works and that it gives
+// the right weight() and weightSquared().
+TEST(RooDataSet, ImportDataHist)
+{
+   RooRealVar x{"x", "x", 0, 3};
+   x.setBins(3);
+
+   RooDataHist dh{"dh", "dh", x};
+
+   dh.set(0, 10, 5);
+   dh.set(1, 20, 15);
+   dh.set(2, 30, 20);
+
+   RooDataSet ds{"ds", "ds", x, RooFit::Import(dh)};
+
+   for (int i = 0; i < x.numBins(); ++i) {
+      dh.get(i);
+      ds.get(i);
+      EXPECT_FLOAT_EQ(ds.weight(), dh.weight()) << "weight() is off in bin " << i;
+      EXPECT_FLOAT_EQ(ds.weightSquared(), dh.weightSquared()) << "weightSquared() is off in bin " << i;
+   }
+}

--- a/roofit/roofitcore/test/testTestStatistics.cxx
+++ b/roofit/roofitcore/test/testTestStatistics.cxx
@@ -51,16 +51,6 @@ std::unique_ptr<RooDataHist> generateBinnedAsimov(RooAbsPdf const &pdf, RooRealV
    return dataH;
 }
 
-std::unique_ptr<RooDataSet> dataHistToDataSet(RooDataHist const &dataH)
-{
-   auto data = std::make_unique<RooDataSet>("data", "data", *dataH.get(), RooFit::WeightVar());
-   for (int i = 0; i < dataH.numEntries(); ++i) {
-      auto coords = dataH.get(i);
-      data->add(*coords, dataH.weight());
-   }
-   return data;
-}
-
 } // namespace
 
 class TestStatisticTest : public testing::TestWithParam<std::tuple<std::string>> {
@@ -97,7 +87,7 @@ TEST_P(TestStatisticTest, IntegrateBins)
    using namespace RooFit;
 
    std::unique_ptr<RooDataHist> dataH(generateBinnedAsimov(pdf, x, 10000));
-   std::unique_ptr<RooDataSet> dataS = dataHistToDataSet(*dataH);
+   auto dataS = std::make_unique<RooDataSet>("data", "data", x, Import(*dataH));
 
    std::unique_ptr<RooPlot> frame(x.frame());
    dataH->plotOn(frame.get(), MarkerColor(kRed));
@@ -146,7 +136,7 @@ TEST_P(TestStatisticTest, IntegrateBins_SubRange)
    using namespace RooFit;
 
    std::unique_ptr<RooDataHist> dataH(generateBinnedAsimov(pdf, x, 10000));
-   std::unique_ptr<RooDataSet> dataS = dataHistToDataSet(*dataH);
+   auto dataS = std::make_unique<RooDataSet>("data", "data", x, Import(*dataH));
 
    std::unique_ptr<RooPlot> frame(x.frame());
    dataH->plotOn(frame.get(), MarkerColor(kRed));
@@ -198,7 +188,7 @@ TEST_P(TestStatisticTest, IntegrateBins_CustomBinning)
    using namespace RooFit;
 
    std::unique_ptr<RooDataHist> dataH(generateBinnedAsimov(pdf, x, 50000));
-   std::unique_ptr<RooDataSet> dataS = dataHistToDataSet(*dataH);
+   auto dataS = std::make_unique<RooDataSet>("data", "data", x, Import(*dataH));
 
    std::unique_ptr<RooPlot> frame(x.frame());
    dataH->plotOn(frame.get(), Name("dataHist"), MarkerColor(kRed));

--- a/roofit/roofitcore/test/testTestStatistics.cxx
+++ b/roofit/roofitcore/test/testTestStatistics.cxx
@@ -53,8 +53,7 @@ std::unique_ptr<RooDataHist> generateBinnedAsimov(RooAbsPdf const &pdf, RooRealV
 
 std::unique_ptr<RooDataSet> dataHistToDataSet(RooDataHist const &dataH)
 {
-   RooRealVar w("w", "weight", 0., 0., dataH.sumEntries());
-   auto data = std::make_unique<RooDataSet>("data", "data", RooArgSet{*dataH.get(), w}, RooFit::WeightVar(w));
+   auto data = std::make_unique<RooDataSet>("data", "data", *dataH.get(), RooFit::WeightVar());
    for (int i = 0; i < dataH.numEntries(); ++i) {
       auto coords = dataH.get(i);
       data->add(*coords, dataH.weight());

--- a/roofit/roostats/src/DetailedOutputAggregator.cxx
+++ b/roofit/roostats/src/DetailedOutputAggregator.cxx
@@ -127,8 +127,7 @@ namespace RooStats {
    void DetailedOutputAggregator::CommitSet(double weight) {
       if (fResult == nullptr) {
          // Store dataset as a tree - problem with VectorStore and StoreError (bug #94908)
-         RooRealVar wgt("weight","weight",1.0);
-         fResult = new RooDataSet("", "", RooArgSet(*fBuiltSet,wgt), RooFit::WeightVar(wgt));
+         fResult = new RooDataSet("", "", *fBuiltSet, RooFit::WeightVar());
       }
       fResult->add(RooArgSet(*fBuiltSet), weight);
 
@@ -153,8 +152,7 @@ namespace RooStats {
          fResult = nullptr;   // we no longer own the dataset
          temp->SetNameTitle( name.Data(), title.Data() );
       }else{
-         RooRealVar wgt("weight","weight",1.0);
-         temp = new RooDataSet(name.Data(), title.Data(), RooArgSet(wgt), RooFit::WeightVar(wgt));
+         temp = new RooDataSet(name.Data(), title.Data(), {}, RooFit::WeightVar());
       }
       delete fBuiltSet;
       fBuiltSet = nullptr;


### PR DESCRIPTION
Several improvements to the [`RooDataSet` constructor](https://root.cern.ch/doc/master/classRooDataSet.html#a6a2302f27e1b016a0351f6e0a0329fa2) that takes command arguments to import other data:

1. Automatically create weight variable when importing multiple data slices (closes #11487)
2. Support importing also RooDataHists (also as slices for combined datasets), and filling the weight errors correctly to match the `weightSquared()`
3. Create the weight variable on the fly if it was specified by name in `WeightVar()` but is not in the list of variables
4. Have a default argument for `WeightVar(="weight")`, because that's usually the name anyway
5. Fix `RooVectorDataStore::loadValues()` for loading values from another vector data store: so far it used `assignValueOnly` to copy the values over, but the values might have errors, like for example in the case of importing a RooDataHist. That's why the regular `RooAbsCollection::assign()` is used now.

All of these changes result in several code simplifications in the cases where RooDataSets are imported from other data, and fixes the bugs that might have been because the `weightSqaured()` was usually not transferred correctly.