### PR TITLE
[RF] Iron out inconsistencies in treatment of global observables

### DIFF
--- a/roofit/roofitcore/src/FitHelpers.cxx
+++ b/roofit/roofitcore/src/FitHelpers.cxx
@@ -324,9 +324,6 @@ std::unique_ptr<RooAbsReal> createNLLNew(RooAbsPdf &pdf, RooAbsData &data, std::
                                          double integrateOverBinsPrecision, RooFit::OffsetMode offset)
 {
    if (constraints) {
-      // Redirect the global observables to the ones from the dataset if applicable.
-      constraints->setData(data, false);
-
       // The computation graph for the constraints is very small, no need to do
       // the tracking of clean and dirty nodes here.
       constraints->setOperMode(RooAbsArg::ADirty);

--- a/roofit/roofitcore/src/RooEvaluatorWrapper.h
+++ b/roofit/roofitcore/src/RooEvaluatorWrapper.h
@@ -22,6 +22,7 @@
 #include <RooRealProxy.h>
 #include <RooFit/Evaluator.h>
 
+#include "RooFit/Detail/BatchModeDataHelpers.h"
 #include "RooFit/Detail/Buffers.h"
 
 #include <chrono>
@@ -72,6 +73,7 @@ private:
    RooSimultaneous const *_simPdf = nullptr;
    const bool _takeGlobalObservablesFromData;
    std::stack<std::vector<double>> _vectorBuffers; // used for preserving resources
+   std::map<RooFit::Detail::DataKey, std::span<const double>> _dataSpans;
 };
 
 #endif

--- a/roofit/roofitcore/src/RooFit/Evaluator.cxx
+++ b/roofit/roofitcore/src/RooFit/Evaluator.cxx
@@ -666,7 +666,7 @@ RooArgSet Evaluator::getParameters() const
 {
    RooArgSet parameters;
    for (auto &nodeInfo : _nodes) {
-      if (!nodeInfo.fromArrayInput && nodeInfo.isVariable) {
+      if (nodeInfo.isVariable) {
          parameters.add(*nodeInfo.absArg);
       }
    }


### PR DESCRIPTION
Iron out some inconsistencies in the treatment of global observables with the new CPU evaluation backend.

To check that everything works now, all the tests in `testGlobalObservables` are now done with both the old legacy backend and the new CPU evaluation backend.

More detail in the commit descriptions.