### PR TITLE
Don't cast a TDirectory pointer argument to a Long_t (even if its value is 0)

### DIFF
--- a/tree/tree/src/TSelectorList.cxx
+++ b/tree/tree/src/TSelectorList.cxx
@@ -40,7 +40,7 @@ Bool_t TSelectorList::UnsetDirectory(TObject *obj)
    if (!callEnv.IsValid())
       return kFALSE;
 
-   callEnv.SetParam((Longptr_t) 0);
+   callEnv.SetParam((Longptr_t) nullptr);
    callEnv.Execute(obj);
 
    return kTRUE;

--- a/tree/tree/src/TSelectorList.cxx
+++ b/tree/tree/src/TSelectorList.cxx
@@ -40,7 +40,7 @@ Bool_t TSelectorList::UnsetDirectory(TObject *obj)
    if (!callEnv.IsValid())
       return kFALSE;
 
-   callEnv.SetParam((Long_t) 0);
+   callEnv.SetParam((Longptr_t) 0);
    callEnv.Execute(obj);
 
    return kTRUE;


### PR DESCRIPTION
Should fix the failure of tutorial/tree/run_h1analysis.C on Win64