### PR TITLE
Fixes in web canvas and JSROOT for 6.28 branch

### DIFF
--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -452,15 +452,17 @@ void TWebCanvas::CreatePadSnapshot(TPadWebSnapshot &paddata, TPad *pad, Long64_t
          }
 
          if (!stats && first_obj && (gStyle->GetOptStat() > 0) && CanCreateObject("TPaveStats")) {
-            stats  = new TPaveStats(
+            stats = new TPaveStats(
                            gStyle->GetStatX() - gStyle->GetStatW(),
                            gStyle->GetStatY() - gStyle->GetStatH(),
                            gStyle->GetStatX(),
                            gStyle->GetStatY(), "brNDC");
 
              stats->SetParent(hist);
-             stats->SetOptFit(gStyle->GetOptFit());
-             stats->SetOptStat(gStyle->GetOptStat());
+             // do not set optfit and optstat, they calling pad->Update,
+             // values correctly set already in TPaveStats constructor
+             // stats->SetOptFit(gStyle->GetOptFit());
+             // stats->SetOptStat(gStyle->GetOptStat());
              stats->SetFillColor(gStyle->GetStatColor());
              stats->SetFillStyle(gStyle->GetStatStyle());
              stats->SetBorderSize(gStyle->GetStatBorderSize());

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -373,7 +373,7 @@ void TWebCanvas::CreatePadSnapshot(TPadWebSnapshot &paddata, TPad *pad, Long64_t
       } else if (obj->InheritsFrom(TH1::Class())) {
          need_frame = true;
          has_histo = true;
-         if (!obj->TestBit(TH1::kNoTitle) && (strlen(obj->GetTitle()) > 0))
+         if (!obj->TestBit(TH1::kNoTitle) && !opt.Contains("SAME") && (strlen(obj->GetTitle()) > 0))
             need_title = obj->GetTitle();
       } else if (obj->InheritsFrom(TGraph::Class())) {
          if (opt.Contains("A")) {

--- a/js/changes.md
+++ b/js/changes.md
@@ -2,6 +2,8 @@
 
 ## Changes in 7.3.x
 1. Fix - TGeo update in the TWebCanvas
+2. Fix - several tutorials with three.js modules loading
+3. Fix - redraw pad when change text align attributes
 
 
 ## Changes in 7.3.0

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -5,7 +5,7 @@ let version_id = '7.3.x';
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-let version_date = '19/12/2022';
+let version_date = '7/02/2023';
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}

--- a/js/modules/draw/TRatioPlotPainter.mjs
+++ b/js/modules/draw/TRatioPlotPainter.mjs
@@ -65,9 +65,11 @@ class TRatioPlotPainter extends ObjectPainter {
             up_fp._ratio_painter = this;
 
             up_fp.zoom = function(xmin,xmax,ymin,ymax,zmin,zmax) {
-               this._ratio_painter.setGridsRange(xmin, xmax);
-               this._ratio_low_fp.o_zoom(xmin,xmax);
-               return this.o_zoom(xmin,xmax,ymin,ymax,zmin,zmax);
+               return this.o_zoom(xmin,xmax,ymin,ymax,zmin,zmax).then(res => {
+                  this._ratio_painter.setGridsRange(up_fp.scale_xmin, up_fp.scale_xmax);
+                  this._ratio_low_fp.o_zoom(up_fp.scale_xmin, up_fp.scale_xmax);
+                  return res;
+               });
             }
 
             up_fp.o_sizeChanged = up_fp.sizeChanged;

--- a/js/modules/gpad/RPadPainter.mjs
+++ b/js/modules/gpad/RPadPainter.mjs
@@ -379,6 +379,11 @@ class RPadPainter extends RObjectPainter {
       return true;
    }
 
+   /** @summary Draw item name on canvas, dummy for RPad
+     * @private */
+   drawItemNameOnCanvas() {
+   }
+
    /** @summary Enlarge pad draw element when possible */
    enlargePad(evnt) {
 

--- a/js/modules/gpad/TAxisPainter.mjs
+++ b/js/modules/gpad/TAxisPainter.mjs
@@ -948,7 +948,7 @@ class TAxisPainter extends ObjectPainter {
 
             if (center_lbls) {
                let gap = arg.gap_after || arg.gap_before;
-               pos = Math.round(pos - (this.vertical ? 0.5*gap : -0.5*gap));
+               pos = Math.round(pos - ((this.vertical != this.reverse) ? 0.5*gap : -0.5*gap));
                if ((pos < -5) || (pos > (this.vertical ? h : w) + 5)) continue;
             }
 

--- a/js/modules/gui/menu.mjs
+++ b/js/modules/gui/menu.mjs
@@ -387,7 +387,7 @@ class JSRootMenu {
          this.addchk(align[n] == obj.fTextAlign,
             align[n], align[n],
             // align[n].toString() + '_h:' + hnames[Math.floor(align[n]/10) - 1] + '_v:' + vnames[align[n]%10-1], align[n],
-            function(arg) { this.getObject().fTextAlign = parseInt(arg); this.interactiveRedraw(true, `exec:SetTextAlign(${arg})`); }.bind(painter));
+            function(arg) { this.getObject().fTextAlign = parseInt(arg); this.interactiveRedraw('pad', `exec:SetTextAlign(${arg})`); }.bind(painter));
       }
       this.add('endsub:');
 

--- a/js/modules/hist/TPavePainter.mjs
+++ b/js/modules/hist/TPavePainter.mjs
@@ -904,7 +904,7 @@ class TPavePainter extends ObjectPainter {
          menu.add('sub:SetOptStat', () => {
             menu.input('Enter OptStat', pave.fOptStat, 'int').then(fmt => {
                pave.fOptStat = fmt;
-               this.interactiveRedraw(true, `exec:SetOptStat(${fmt}`);
+               this.interactiveRedraw(true, `exec:SetOptStat(${fmt})`);
             });
          });
          function AddStatOpt(pos, name) {

--- a/js/modules/hist2d/TH1Painter.mjs
+++ b/js/modules/hist2d/TH1Painter.mjs
@@ -820,19 +820,21 @@ class TH1Painter extends THistPainter {
       if (funcs.swap_xy)
          [pnt_x, pnt_y, width, height] = [pnt_y, pnt_x, height, width];
 
+      let descent_order = funcs.swap_xy != pmain.x_handle.reverse;
+
       while (l < r-1) {
          let m = Math.round((l+r)*0.5), xx = GetBinGrX(m);
          if ((xx === null) || (xx < pnt_x - 0.5)) {
-            if (funcs.swap_xy) r = m; else l = m;
+            if (descent_order) r = m; else l = m;
          } else if (xx > pnt_x + 0.5) {
-            if (funcs.swap_xy) l = m; else r = m;
+            if (descent_order) l = m; else r = m;
          } else { l++; r--; }
       }
 
       findbin = r = l;
       grx1 = GetBinGrX(findbin);
 
-      if (pmain.swap_xy) {
+      if (descent_order) {
          while ((l > left) && (GetBinGrX(l-1) < grx1 + 2)) --l;
          while ((r < right) && (GetBinGrX(r+1) > grx1 - 2)) ++r;
       } else {

--- a/js/modules/hist2d/THistPainter.mjs
+++ b/js/modules/hist2d/THistPainter.mjs
@@ -551,7 +551,11 @@ class THistDrawOptions {
          if (this.y3dscale !== 1) res += '_Y3DSC' + Math.round(this.y3dscale * 100);
 
       } else {
-         if (this.Scat) {
+         if (this.Candle) {
+            res = 'CANDLE' + this.Candle;
+         } else if (this.Violin) {
+            res = 'VIOLIN' + this.Violin;
+         } else if (this.Scat) {
             res = 'SCAT';
          } else if (this.Color) {
             res = 'COL';


### PR DESCRIPTION
1. Do not create title for second histogram in web canvas
2. Preserve custom stats box
3. Properly handle violin and candle draw options
4. Labels position on reversed axes 