### PR TITLE
[rootcling] Remove unused flags.

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -4230,10 +4230,6 @@ int RootClingMain(int argc,
 #endif
    clingArgs.push_back("-Xclang");
    clingArgs.push_back("-fmodules-embed-all-files");
-   clingArgs.push_back("-Xclang");
-   clingArgs.push_back("-main-file-name");
-   clingArgs.push_back("-Xclang");
-   clingArgs.push_back((dictname + ".h").c_str());
 
    ROOT::TMetaUtils::SetPathsForRelocatability(clingArgs);
 


### PR DESCRIPTION
These flags are used mostly when we generate debug information which we don't as rootcling is a syntax-only action.

