### PR TITLE
Fix build with -Dbuiltin_gtest:BOOL=OFF on EPEL 8

### DIFF
--- a/roofit/roofitcore/test/testRooAbsPdf.cxx
+++ b/roofit/roofitcore/test/testRooAbsPdf.cxx
@@ -354,7 +354,7 @@ TEST(RooAbsPdf, NormSetChange)
    EXPECT_NE(v1, v2);
 }
 
-INSTANTIATE_TEST_SUITE_P(RooAbsPdf, FitTest, testing::Combine(testing::Values("Off", "Cpu")),
+INSTANTIATE_TEST_SUITE_P(RooAbsPdf, FitTest, testing::Values("Off", "Cpu"),
                          [](testing::TestParamInfo<FitTest::ParamType> const &paramInfo) {
                             std::stringstream ss;
                             ss << "BatchMode" << std::get<0>(paramInfo.param);

--- a/roofit/roofitcore/test/testRooBinSamplingPdf.cxx
+++ b/roofit/roofitcore/test/testRooBinSamplingPdf.cxx
@@ -13,6 +13,11 @@
 
 #include <gtest/gtest.h>
 
+// Backward compatibility for gtest version < 1.10.0
+#ifndef INSTANTIATE_TEST_SUITE_P
+#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
+#endif
+
 #include <memory>
 
 class ParamTest : public testing::TestWithParam<std::tuple<std::string>> {
@@ -123,7 +128,7 @@ TEST(RooBinSamplingPdf, CheckConsistentNormalization)
    EXPECT_FLOAT_EQ(int2->getVal(), int3->getVal());
 }
 
-INSTANTIATE_TEST_SUITE_P(RooBinSamplingPdf, ParamTest, testing::Combine(testing::Values("Off", "Cpu")),
+INSTANTIATE_TEST_SUITE_P(RooBinSamplingPdf, ParamTest, testing::Values("Off", "Cpu"),
                          [](testing::TestParamInfo<ParamTest::ParamType> const &paramInfo) {
                             std::stringstream ss;
                             ss << "BatchMode" << std::get<0>(paramInfo.param);

--- a/roofit/roofitcore/test/testRooProdPdf.cxx
+++ b/roofit/roofitcore/test/testRooProdPdf.cxx
@@ -16,6 +16,11 @@
 
 #include <gtest/gtest.h>
 
+// Backward compatibility for gtest version < 1.10.0
+#ifndef INSTANTIATE_TEST_SUITE_P
+#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
+#endif
+
 #include <memory>
 #include <sstream>
 #include <string>

--- a/roofit/roofitcore/test/testRooRealIntegral.cxx
+++ b/roofit/roofitcore/test/testRooRealIntegral.cxx
@@ -20,6 +20,11 @@
 
 #include <gtest/gtest.h>
 
+// Backward compatibility for gtest version < 1.10.0
+#ifndef INSTANTIATE_TEST_SUITE_P
+#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
+#endif
+
 #include <memory>
 
 namespace {

--- a/roofit/roofitcore/test/testTestStatistics.cxx
+++ b/roofit/roofitcore/test/testTestStatistics.cxx
@@ -490,7 +490,7 @@ TEST_P(OffsetBinTest, CrossCheck)
    EXPECT_NEAR(nllVal1, 0.0, 1e-8) << "NLL with bin offsetting is " << nllVal1 << ", and " << nllVal0 << " without it.";
 }
 
-INSTANTIATE_TEST_SUITE_P(RooNLLVar, TestStatisticTest, testing::Combine(testing::Values("Off", "Cpu")),
+INSTANTIATE_TEST_SUITE_P(RooNLLVar, TestStatisticTest, testing::Values("Off", "Cpu"),
                          [](testing::TestParamInfo<TestStatisticTest::ParamType> const &paramInfo) {
                             std::stringstream ss;
                             ss << "BatchMode" << std::get<0>(paramInfo.param);


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Some new tests need the backward compatibility tweaks to work with the system gtest on RHEL/EPEL 8.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

