### PR TITLE
[math] Add virtual HasGradient() to ROOT::Math function base classes and simplify them

### DIFF
--- a/hist/hist/inc/Math/WrappedTF1.h
+++ b/hist/hist/inc/Math/WrappedTF1.h
@@ -36,11 +36,11 @@ namespace ROOT {
 
          @ingroup CppFunctions
       */
-      class WrappedTF1 : public ROOT::Math::IParamGradFunction, public ROOT::Math::IGradientOneDim {
+      class WrappedTF1 : public ROOT::Math::IParamGradFunction, public ROOT::Math::IGradientFunctionOneDim {
 
       public:
 
-         typedef  ROOT::Math::IGradientOneDim     IGrad;
+         typedef  ROOT::Math::IGradientFunctionOneDim     IGrad;
          typedef  ROOT::Math::IParamGradFunction  BaseGradFunc;
          typedef  ROOT::Math::IParamGradFunction::BaseFunc BaseFunc;
 

--- a/math/fumili/inc/TFumiliMinimizer.h
+++ b/math/fumili/inc/TFumiliMinimizer.h
@@ -73,9 +73,6 @@ public:
    /// set the function to minimize
    void SetFunction(const ROOT::Math::IMultiGenFunction & func) override;
 
-   /// set the function to minimize
-   void SetFunction(const ROOT::Math::IMultiGradFunction & func) override;
-
    /// set free variable
    bool SetVariable(unsigned int ivar, const std::string & name, double val, double step) override;
 

--- a/math/fumili/src/TFumiliMinimizer.cxx
+++ b/math/fumili/src/TFumiliMinimizer.cxx
@@ -188,6 +188,27 @@ void TFumiliMinimizer::SetFunction(const  ROOT::Math::IMultiGenFunction & func) 
    fDim = func.NDim();
    fFumili->SetParNumber(fDim);
 
+   if(func.HasGradient()) {
+      // In this case the function derivatives are provided
+      // by the user via this interface and there not calculated by Fumili.
+
+      fDim = func.NDim();
+      fFumili->SetParNumber(fDim);
+
+      // for Fumili the fit method function interface is required
+      const ROOT::Math::FitMethodGradFunction * fcnfunc = dynamic_cast<const ROOT::Math::FitMethodGradFunction *>(&func);
+      if (!fcnfunc) {
+         Error("SetFunction","Wrong Fit method function type used for Fumili");
+         return;
+      }
+      // assign to the static pointer (NO Thread safety here)
+      fgFunc = 0;
+      fgGradFunc = const_cast<ROOT::Math::FitMethodGradFunction  *>(fcnfunc);
+      fFumili->SetFCN(&TFumiliMinimizer::Fcn);
+
+      return;
+   }
+
    // for Fumili the fit method function interface is required
    const ROOT::Math::FitMethodFunction * fcnfunc = dynamic_cast<const ROOT::Math::FitMethodFunction *>(&func);
    if (!fcnfunc) {
@@ -207,27 +228,6 @@ void TFumiliMinimizer::SetFunction(const  ROOT::Math::IMultiGenFunction & func) 
          fgFunc = new FumiliFunction<ROOT::Fit::Chi2FCN<ROOT::Math::FitMethodFunction::BaseFunction> >(fFumili,fcnfunc);
    }
 #endif
-
-}
-
-void TFumiliMinimizer::SetFunction(const  ROOT::Math::IMultiGradFunction & func) {
-   // Set the objective function to be minimized, by passing a function object implement the
-   // multi-dim gradient Function interface. In this case the function derivatives are provided
-   // by the user via this interface and there not calculated by Fumili.
-
-   fDim = func.NDim();
-   fFumili->SetParNumber(fDim);
-
-   // for Fumili the fit method function interface is required
-   const ROOT::Math::FitMethodGradFunction * fcnfunc = dynamic_cast<const ROOT::Math::FitMethodGradFunction *>(&func);
-   if (!fcnfunc) {
-      Error("SetFunction","Wrong Fit method function type used for Fumili");
-      return;
-   }
-   // assign to the static pointer (NO Thread safety here)
-   fgFunc = 0;
-   fgGradFunc = const_cast<ROOT::Math::FitMethodGradFunction  *>(fcnfunc);
-   fFumili->SetFCN(&TFumiliMinimizer::Fcn);
 
 }
 

--- a/math/mathcore/inc/Fit/Fitter.h
+++ b/math/mathcore/inc/Fit/Fitter.h
@@ -314,35 +314,10 @@ public:
    bool SetFCN(const ROOT::Math::FitMethodFunction & fcn, const double *params = nullptr);
 
    /**
-      Fit using the given FCN function representing a multi-dimensional gradient function
-      interface (ROOT::Math::IMultiGradFunction). In this case the minimizer will use the
-      gradient information provided by the function.
-      For the options same consideration as in the previous method
-    */
-   bool FitFCN(const ROOT::Math::IMultiGradFunction &fcn, const double *params = nullptr, unsigned int dataSize = 0, bool chi2fit = false);
-
-   /**
        Fit using a FitMethodGradFunction interface. Same as method above, but now extra information
        can be taken from the function class
    */
    bool FitFCN(const ROOT::Math::FitMethodGradFunction & fcn, const double *params = nullptr);
-
-   /**
-      Set the FCN function represented by a multi-dimensional gradient function interface
-      (ROOT::Math::IMultiGradFunction) and optionally the initial parameters
-      See also note above for the initial parameters for FitFCN
-    */
-   bool SetFCN(const ROOT::Math::IMultiGradFunction &fcn, const double *params = nullptr, unsigned int dataSize = 0, bool chi2fit = false);
-
-   /**
-      Set the FCN function represented by a multi-dimensional gradient function interface
-     (ROOT::Math::IMultiGradFunction) and optionally the initial parameters
-      See also note above for the initial parameters for FitFCN
-      With this interface we pass in addition a ModelFunction that will be attached to the FitResult and
-      used to compute confidence interval of the fit
-   */
-   bool SetFCN(const ROOT::Math::IMultiGradFunction &fcn, const IModelFunction &func, const double *params = nullptr,
-               unsigned int dataSize = 0, bool chi2fit = false);
 
    /**
        Set the objective function (FCN)  using a FitMethodGradFunction interface.

--- a/math/mathcore/inc/LinkDef2.h
+++ b/math/mathcore/inc/LinkDef2.h
@@ -104,7 +104,6 @@
 #pragma link C++ typedef ROOT::Math::IMultiGradFunction;
 
 #pragma link C++ class ROOT::Math::IBaseFunctionOneDim+;
-#pragma link C++ class ROOT::Math::IGradientOneDim+;
 #pragma link C++ class ROOT::Math::IGradientFunctionOneDim+;
 #pragma link C++ class ROOT::Math::IBaseParam+;
 
@@ -112,7 +111,6 @@
 #pragma link C++ class ROOT::Math::IParametricGradFunctionOneDim+;
 
 #pragma link C++ class ROOT::Math::IBaseFunctionMultiDim+;
-#pragma link C++ class ROOT::Math::IGradientMultiDim+;
 #pragma link C++ class ROOT::Math::IGradientFunctionMultiDim+;
 #pragma link C++ class ROOT::Math::IParametricFunctionMultiDim+;
 #pragma link C++ class ROOT::Math::IParametricGradFunctionMultiDim+;

--- a/math/mathcore/inc/Math/BasicMinimizer.h
+++ b/math/mathcore/inc/Math/BasicMinimizer.h
@@ -87,9 +87,6 @@ public:
    /// set the function to minimize
    void SetFunction(const ROOT::Math::IMultiGenFunction & func) override;
 
-   /// set gradient the function to minimize
-   void SetFunction(const ROOT::Math::IMultiGradFunction & func) override;
-
    /// set free variable
    bool SetVariable(unsigned int ivar, const std::string & name, double val, double step) override;
 

--- a/math/mathcore/inc/Math/IFunction.h
+++ b/math/mathcore/inc/Math/IFunction.h
@@ -31,7 +31,6 @@
 @ingroup MathCore
 */
 
-//typedefs and tags definitions
 #include "Math/IFunctionfwd.h"
 
 
@@ -66,60 +65,34 @@ namespace ROOT {
          typedef T BackendType;
          typedef  IBaseFunctionMultiDimTempl<T> BaseFunc;
 
+         virtual ~IBaseFunctionMultiDimTempl() = default;
 
-         IBaseFunctionMultiDimTempl() {}
-
-         /**
-            virtual destructor
-          */
-         virtual ~IBaseFunctionMultiDimTempl() {}
-
-         /**
-             Clone a function.
-             Each derived class must implement their version of the Clone method
-         */
+         /// Clone a function.
+         /// Each derived class must implement their version of the Clone method.
          virtual IBaseFunctionMultiDimTempl<T> *Clone() const = 0;
 
-         /**
-            Retrieve the dimension of the function
-          */
+         /// Retrieve the dimension of the function.
          virtual unsigned int NDim() const = 0;
 
-         /**
-             Evaluate the function at a point x[].
-             Use the pure virtual private method DoEval which must be implemented by the sub-classes
-         */
-         T operator()(const T *x) const
-         {
-            return DoEval(x);
-         }
+         /// Evaluate the function at a point x[].
+         /// Use the pure virtual private method DoEval which must be implemented by the sub-classes.
+         T operator()(const T *x) const { return DoEval(x); }
 
 #ifdef LATER
-         /**
-            Template method to evaluate the function using the begin of an iterator
-            User is responsible to provide correct size for the iterator
-         */
+         /// Template method to evaluate the function using the begin of an iterator.
+         /// User is responsible to provide correct size for the iterator.
          template <class Iterator>
-         T operator()(const Iterator it) const
-         {
-            return DoEval(&(*it));
-         }
+         T operator()(const Iterator it) const { return DoEval(&(*it)); }
 #endif
 
          // Indicate whether this class supports gradient calculations, i.e.,
          // if it inherits from ROOT::Math::IGradientFunctionMultiDim.
          virtual bool HasGradient() const { return false; }
 
-
       private:
 
-
-         /**
-            Implementation of the evaluation function. Must be implemented by derived classes
-         */
+         /// Implementation of the evaluation function. Must be implemented by derived classes.
          virtual T DoEval(const T *x) const = 0;
-
-
       };
 
 
@@ -142,56 +115,45 @@ namespace ROOT {
 
          typedef  IBaseFunctionOneDim BaseFunc;
 
-         IBaseFunctionOneDim() {}
+         virtual ~IBaseFunctionOneDim() = default;
 
-         /**
-            virtual destructor
-          */
-         virtual ~IBaseFunctionOneDim() {}
-
-         /**
-             Clone a function.
-             Each derived class will implement their version of the provate DoClone method
-         */
+         /// Clone a function.
+         /// Each derived class will implement their version of the provate DoClone method.
          virtual IBaseFunctionOneDim *Clone() const = 0;
 
-         /**
-             Evaluate the function at a point x
-             Use the  a pure virtual private method DoEval which must be implemented by sub-classes
-         */
-         double operator()(double x) const
-         {
-            return DoEval(x);
-         }
+         /// Evaluate the function at a point x.
+         /// Use the a pure virtual private method DoEval which must be implemented by sub-classes.
+         double operator()(double x) const { return DoEval(x); }
 
-         /**
-             Evaluate the function at a point x[].
-             Compatible method with multi-dimensional functions
-         */
-         double operator()(const double *x) const
-         {
-            return DoEval(*x);
-         }
+         /// Evaluate the function at a point x[].
+         /// Compatible method with multi-dimensional functions.
+         double operator()(const double *x) const { return DoEval(*x); }
 
          // Indicate whether this class supports gradient calculations, i.e.,
          // if it inherits from ROOT::Math::IGradientFunctionOneDim.
          virtual bool HasGradient() const { return false; }
 
-
       private:
-
-         // use private virtual inheritance
 
          /// implementation of the evaluation function. Must be implemented by derived classes
          virtual double DoEval(double x) const = 0;
-
       };
 
 
 //-------- GRAD  functions---------------------------
 
+
+
 //___________________________________________________________________________________
       /**
+         Interface (abstract class) for multi-dimensional functions providing a gradient calculation.
+         The method ROOT::Math::IFunction::Gradient calculates the full gradient vector,
+         ROOT::Math::IFunction::Derivative calculates the partial derivative for each coordinate and
+         ROOT::Math::Fdf calculates the gradient and the function value at the same time.
+         The pure private virtual method DoDerivative() must be implemented by the derived classes, while
+         Gradient and FdF are by default implemented using DoDerivative, butthey  can be overloaded by the
+         derived classes to improve the efficiency in the derivative calculation.
+
          Gradient interface (abstract class) defining the signature for calculating the gradient of a
          multi-dimensional function.
          Three methods are provided:
@@ -199,29 +161,53 @@ namespace ROOT {
          - Derivative(const double * x, int icoord) evaluate the partial derivative for the icoord coordinate
          - FdF(const double *x, double &f, double * g) evaluate at the same time gradient and function/
 
-         Concrete classes should derive from ROOT::Math::IGradientFunctionMultiDim and not from this class.
-
          @ingroup  GenFunc
-       */
+      */
 
       template <class T>
-      class IGradientMultiDimTempl {
+      class IGradientFunctionMultiDimTempl : virtual public IBaseFunctionMultiDimTempl<T> {
 
       public:
+         typedef IBaseFunctionMultiDimTempl<T> BaseFunc;
+         typedef IGradientFunctionMultiDimTempl<T> BaseGrad;
 
-         /// virtual destructor
-         virtual ~IGradientMultiDimTempl() {}
 
-         /**
-             Evaluate all the vector of function derivatives (gradient)  at a point x.
-             Derived classes must re-implement if it is more efficient than evaluating one at a time
-         */
-         virtual void Gradient(const T *x, T *grad) const = 0;
+         /// Evaluate all the vector of function derivatives (gradient)  at a point x.
+         /// Derived classes must re-implement it if more efficient than evaluating one at a time
+         virtual void Gradient(const T *x, T *grad) const
+         {
+            unsigned int ndim = NDim();
+            for (unsigned int icoord  = 0; icoord < ndim; ++icoord) {
+               grad[icoord] = Derivative(x, icoord);
+            }
+         }
 
-         /**
-            Return the partial derivative with respect to the passed coordinate
-         */
+         /// In some cases, the gradient algorithm will use information from the previous step, these can be passed
+         /// in with this overload. The `previous_*` arrays can also be used to return second derivative and step size
+         /// so that these can be passed forward again as well at the call site, if necessary.
+         virtual void GradientWithPrevResult(const T *x, T *grad, T *previous_grad, T *previous_g2, T *previous_gstep) const
+         {
+            unsigned int ndim = NDim();
+            for (unsigned int icoord  = 0; icoord < ndim; ++icoord) {
+               grad[icoord] = Derivative(x, icoord, previous_grad, previous_g2, previous_gstep);
+            }
+         }
+
+         using BaseFunc::NDim;
+
+         /// Optimized method to evaluate at the same time the function value and derivative at a point x.
+         /// Often both value and derivatives are needed and it is often more efficient to compute them at the same time.
+         /// Derived class should implement this method if performances play an important role and if it is faster to
+         /// evaluate value and derivative at the same time
+         virtual void FdF(const T *x, T &f, T *df) const
+         {
+            f = BaseFunc::operator()(x);
+            Gradient(x, df);
+         }
+
+         /// Return the partial derivative with respect to the passed coordinate.
          T Derivative(const T *x, unsigned int icoord = 0) const { return DoDerivative(x, icoord); }
+
          /// In some cases, the derivative algorithm will use information from the previous step, these can be passed
          /// in with this overload. The `previous_*` arrays can also be used to return second derivative and step size
          /// so that these can be passed forward again as well at the call site, if necessary.
@@ -231,22 +217,14 @@ namespace ROOT {
             return DoDerivativeWithPrevResult(x, icoord, previous_grad, previous_g2, previous_gstep);
          }
 
-         /**
-             Optimized method to evaluate at the same time the function value and derivative at a point x.
-             Often both value and derivatives are needed and it is often more efficient to compute them at the same time.
-             Derived class should implement this method if performances play an important role and if it is faster to
-             evaluate value and derivative at the same time
+         bool HasGradient() const { return true; }
 
-         */
-         virtual void FdF(const T *x, T &f, T *df) const = 0;
+         virtual bool returnsInMinuit2ParameterSpace() const { return false; }
 
       private:
-
-
-         /**
-            function to evaluate the derivative with respect each coordinate. To be implemented by the derived class
-         */
+         /// Function to evaluate the derivative with respect each coordinate. To be implemented by the derived class.
          virtual T DoDerivative(const T *x, unsigned int icoord) const = 0;
+
          /// In some cases, the derivative algorithm will use information from the previous step, these can be passed
          /// in with this overload. The `previous_*` arrays can also be used to return second derivative and step size
          /// so that these can be passed forward again as well at the call site, if necessary.
@@ -254,198 +232,61 @@ namespace ROOT {
                                               T * /*previous_g2*/, T * /*previous_gstep*/) const
          {
             return DoDerivative(x, icoord);
-         };
+         }
       };
 
-//___________________________________________________________________________________
-      /**
-         Specialized Gradient interface(abstract class)  for one dimensional functions
-         It provides a method to evaluate the derivative of the function, Derivative and a
-         method to evaluate at the same time the function and the derivative FdF
-
-         Concrete classes should derive from ROOT::Math::IGradientFunctionOneDim and not from this class.
-
-         @ingroup  GenFunc
-       */
-      class IGradientOneDim {
-
-      public:
-
-         /// virtual destructor
-         virtual ~IGradientOneDim() {}
-
-         /**
-            Return the derivative of the function at a point x
-            Use the private method DoDerivative
-         */
-         double Derivative(double x) const
-         {
-            return DoDerivative(x);
-         }
-
-
-         /**
-             Optimized method to evaluate at the same time the function value and derivative at a point x.
-             Often both value and derivatives are needed and it is often more efficient to compute them at the same time.
-             Derived class should implement this method if performances play an important role and if it is faster to
-             evaluate value and derivative at the same time
-
-         */
-         virtual void FdF(double x, double &f, double &df) const = 0;
-
-
-         /**
-            Compatibility method with multi-dimensional interface for partial derivative
-          */
-         double Derivative(const double *x) const
-         {
-            return DoDerivative(*x);
-         }
-
-         /**
-            Compatibility method with multi-dimensional interface for Gradient
-          */
-         void Gradient(const double *x, double *g) const
-         {
-            g[0] = DoDerivative(*x);
-         }
-
-         /**
-            Compatibility method with multi-dimensional interface for Gradient and function evaluation
-          */
-         void FdF(const double *x, double &f, double *df) const
-         {
-            FdF(*x, f, *df);
-         }
-
-
-
-      private:
-
-
-         /**
-            function to evaluate the derivative with respect each coordinate. To be implemented by the derived class
-         */
-         virtual  double  DoDerivative(double x) const = 0;
-
-      };
-
-//___________________________________________________________________________________
-      /**
-         Interface (abstract class) for multi-dimensional functions providing a gradient calculation.
-         It implements both the ROOT::Math::IBaseFunctionMultiDimTempl and
-         ROOT::Math::IGradientMultiDimTempl interfaces.
-         The method ROOT::Math::IFunction::Gradient calculates the full gradient vector,
-         ROOT::Math::IFunction::Derivative calculates the partial derivative for each coordinate and
-         ROOT::Math::Fdf calculates the gradient and the function value at the same time.
-         The pure private virtual method DoDerivative() must be implemented by the derived classes, while
-         Gradient and FdF are by default implemented using DoDerivative, butthey  can be overloaded by the
-         derived classes to improve the efficiency in the derivative calculation.
-
-         @ingroup  GenFunc
-      */
-
-      template <class T>
-      class IGradientFunctionMultiDimTempl : virtual public IBaseFunctionMultiDimTempl<T>,
-                                             public IGradientMultiDimTempl<T> {
-
-      public:
-         typedef IBaseFunctionMultiDimTempl<T> BaseFunc;
-         typedef IGradientMultiDimTempl<T> BaseGrad;
-
-         /**
-            Virtual Destructor (no operations)
-         */
-         virtual ~IGradientFunctionMultiDimTempl() {}
-
-         /**
-            Evaluate all the vector of function derivatives (gradient)  at a point x.
-            Derived classes must re-implement it if more efficient than evaluating one at a time
-         */
-         virtual void Gradient(const T *x, T *grad) const
-         {
-            unsigned int ndim = NDim();
-            for (unsigned int icoord  = 0; icoord < ndim; ++icoord)
-               grad[icoord] = BaseGrad::Derivative(x, icoord);
-         }
-
-         /// In some cases, the gradient algorithm will use information from the previous step, these can be passed
-         /// in with this overload. The `previous_*` arrays can also be used to return second derivative and step size
-         /// so that these can be passed forward again as well at the call site, if necessary.
-         virtual void GradientWithPrevResult(const T *x, T *grad, T *previous_grad, T *previous_g2, T *previous_gstep) const
-         {
-            unsigned int ndim = NDim();
-            for (unsigned int icoord  = 0; icoord < ndim; ++icoord)
-               grad[icoord] = BaseGrad::Derivative(x, icoord, previous_grad, previous_g2, previous_gstep);
-         }
-
-         using  BaseFunc::NDim;
-
-         /**
-            Optimized method to evaluate at the same time the function value and derivative at a point x.
-            Often both value and derivatives are needed and it is often more efficient to compute them at the same time.
-            Derived class should implement this method if performances play an important role and if it is faster to
-            evaluate value and derivative at the same time
-         */
-         virtual void FdF(const T *x, T &f, T *df) const
-         {
-            f = BaseFunc::operator()(x);
-            Gradient(x, df);
-         }
-
-         bool HasGradient() const { return true; }
-
-         virtual bool returnsInMinuit2ParameterSpace() const { return false; }
-      };
 
 //___________________________________________________________________________________
       /**
          Interface (abstract class) for one-dimensional functions providing a gradient calculation.
-         It implements both the ROOT::Math::IBaseFunctionOneDim and
-         ROOT::Math::IGradientOneDim interfaces.
          The method  ROOT::Math::IFunction::Derivative calculates the derivative  and
          ROOT::Math::Fdf calculates the derivative and the function values at the same time.
          The pure private virtual method DoDerivative() must be implemented by the derived classes, while
          FdF is by default implemented using DoDerivative, but it can be overloaded by the
          derived classes to improve the efficiency in the derivative calculation.
 
+         Specialized Gradient interface(abstract class)  for one dimensional functions
+         It provides a method to evaluate the derivative of the function, Derivative and a
+         method to evaluate at the same time the function and the derivative FdF
 
          @ingroup  GenFunc
       */
-      //template <>
-      class IGradientFunctionOneDim :
-         virtual public IBaseFunctionOneDim ,
-         public IGradientOneDim {
-
+      class IGradientFunctionOneDim : virtual public IBaseFunctionOneDim {
 
       public:
 
          typedef IBaseFunctionOneDim BaseFunc;
-         typedef IGradientOneDim BaseGrad;
+         typedef IGradientFunctionOneDim BaseGrad;
 
+         /// Return the derivative of the function at a point x
+         /// Use the private method DoDerivative
+         double Derivative(double x) const { return DoDerivative(x); }
 
-         /**
-             Virtual Destructor (no operations)
-         */
-         ~IGradientFunctionOneDim() override {}
+         /// Compatibility method with multi-dimensional interface for partial derivative.
+         double Derivative(const double *x) const { return DoDerivative(*x); }
 
+         /// Compatibility method with multi-dimensional interface for Gradient.
+         void Gradient(const double *x, double *g) const { g[0] = DoDerivative(*x); }
 
-         /**
-             Optimized method to evaluate at the same time the function value and derivative at a point x.
-              Often both value and derivatives are needed and it is often more efficient to compute them at the same time.
-             Derived class should implement this method if performances play an important role and if it is faster to
-             evaluate value and derivative at the same time
-
-         */
-         void FdF(double x, double &f, double &df) const override
+         /// Optimized method to evaluate at the same time the function value and derivative at a point x.
+         /// Often both value and derivatives are needed and it is often more efficient to compute them at the same time.
+         /// Derived class should implement this method if performances play an important role and if it is faster to
+         /// evaluate value and derivative at the same time.
+         virtual void FdF(double x, double &f, double &df) const
          {
             f = operator()(x);
             df = Derivative(x);
          }
 
+         /// Compatibility method with multi-dimensional interface for Gradient and function evaluation.
+         void FdF(const double *x, double &f, double *df) const { FdF(*x, f, *df); }
+
          bool HasGradient() const override { return true; }
 
+      private:
 
+         /// Function to evaluate the derivative with respect each coordinate. To be implemented by the derived class.
+         virtual  double  DoDerivative(double x) const = 0;
       };
 
 

--- a/math/mathcore/inc/Math/IFunction.h
+++ b/math/mathcore/inc/Math/IFunction.h
@@ -106,6 +106,10 @@ namespace ROOT {
          }
 #endif
 
+         // Indicate whether this class supports gradient calculations, i.e.,
+         // if it inherits from ROOT::Math::IGradientFunctionMultiDim.
+         virtual bool HasGradient() const { return false; }
+
 
       private:
 
@@ -169,6 +173,9 @@ namespace ROOT {
             return DoEval(*x);
          }
 
+         // Indicate whether this class supports gradient calculations, i.e.,
+         // if it inherits from ROOT::Math::IGradientFunctionOneDim.
+         virtual bool HasGradient() const { return false; }
 
 
       private:
@@ -386,6 +393,8 @@ namespace ROOT {
             Gradient(x, df);
          }
 
+         bool HasGradient() const { return true; }
+
          virtual bool returnsInMinuit2ParameterSpace() const { return false; }
       };
 
@@ -434,6 +443,7 @@ namespace ROOT {
             df = Derivative(x);
          }
 
+         bool HasGradient() const override { return true; }
 
 
       };

--- a/math/mathcore/inc/Math/Minimizer.h
+++ b/math/mathcore/inc/Math/Minimizer.h
@@ -119,12 +119,6 @@ public:
    /// set the function to minimize
    virtual void SetFunction(const ROOT::Math::IMultiGenFunction & func) = 0;
 
-   /// set a function to minimize using gradient
-   virtual void SetFunction(const ROOT::Math::IMultiGradFunction & func)
-   {
-      SetFunction(static_cast<const ::ROOT::Math::IMultiGenFunction &> (func));
-   }
-
    /// set the function implementing Hessian computation (re-implemented by Minimizer using it)
    virtual void SetHessianFunction(std::function<bool(const std::vector<double> &, double *)> ) {}
 

--- a/math/mathcore/src/BasicMinimizer.cxx
+++ b/math/mathcore/src/BasicMinimizer.cxx
@@ -243,13 +243,6 @@ void BasicMinimizer::SetFunction(const ROOT::Math::IMultiGenFunction & func) {
    fDim = fObjFunc->NDim();
 }
 
-void BasicMinimizer::SetFunction(const ROOT::Math::IMultiGradFunction & func) {
-   // set the gradient function to minimize after cloning it
-   fObjFunc = dynamic_cast<const ROOT::Math::IMultiGradFunction *>( func.Clone());
-   assert(fObjFunc != 0);
-   fDim = fObjFunc->NDim();
-}
-
 
 bool BasicMinimizer::CheckDimension() const {
    unsigned int npar = fValues.size();

--- a/math/mathcore/src/Fitter.cxx
+++ b/math/mathcore/src/Fitter.cxx
@@ -183,27 +183,12 @@ bool Fitter::SetFCN(const ROOT::Math::IMultiGenFunction &fcn, const IModelFuncti
    // set the objective function for the fit and a model function
    if (!SetFCN(fcn, params, dataSize, chi2fit) ) return false;
    // need to set fFunc afterwards because SetFCN could reset fFUnc
-   fFunc = std::shared_ptr<IModelFunction>(dynamic_cast<IModelFunction *>(func.Clone()));
-   return (fFunc != nullptr);
-}
-
-bool Fitter::SetFCN(const ROOT::Math::IMultiGradFunction &fcn, const double *params, unsigned int dataSize,
-                       bool chi2fit)
-{
-   // set the objective function for the fit
-   // if params is not NULL create the parameter settings
-   if (!SetFCN(static_cast<const ROOT::Math::IMultiGenFunction &>(fcn), params, dataSize, chi2fit))
-      return false;
-   fUseGradient = true;
-   return true;
-}
-
-bool Fitter::SetFCN(const ROOT::Math::IMultiGradFunction &fcn, const IModelFunction &func, const double *params,
-                    unsigned int dataSize, bool chi2fit)
-{
-   // set the objective function for the fit and a model function
-   if (!SetFCN(fcn, params, dataSize, chi2fit) ) return false;
-   fFunc = std::shared_ptr<IModelFunction>(dynamic_cast<IModelFunction *>(func.Clone()));
+   fFunc = std::unique_ptr<IModelFunction>(dynamic_cast<IModelFunction *>(func.Clone()));
+   if(fFunc) {
+      fUseGradient = fcn.HasGradient();
+      return true;
+   }
+   return false;
    return (fFunc != nullptr);
 }
 
@@ -235,15 +220,6 @@ bool Fitter::FitFCN(const BaseFunc &fcn, const double *params, unsigned int data
 {
    // fit a user provided FCN function
    // create fit parameter settings
-   if (!SetFCN(fcn, params, dataSize, chi2fit))
-      return false;
-   return FitFCN();
-}
-
-bool Fitter::FitFCN(const BaseGradFunc &fcn, const double *params, unsigned int dataSize, bool chi2fit)
-{
-   // fit a user provided FCN gradient function
-
    if (!SetFCN(fcn, params, dataSize, chi2fit))
       return false;
    return FitFCN();

--- a/math/mathmore/inc/Math/GSLMinimizer.h
+++ b/math/mathmore/inc/Math/GSLMinimizer.h
@@ -116,8 +116,6 @@ public:
    /// set the function to minimize
    void SetFunction(const ROOT::Math::IMultiGenFunction & func) override;
 
-   /// set the function to minimize
-   void SetFunction(const ROOT::Math::IMultiGradFunction & func) override { BasicMinimizer::SetFunction(func);}
 
    /// method to perform the minimization
     bool Minimize() override;

--- a/math/mathmore/inc/Math/GSLNLSMinimizer.h
+++ b/math/mathmore/inc/Math/GSLNLSMinimizer.h
@@ -91,9 +91,6 @@ public:
    /// set the function to minimize
    void SetFunction(const ROOT::Math::IMultiGenFunction & func) override;
 
-   /// set gradient the function to minimize
-   void SetFunction(const ROOT::Math::IMultiGradFunction & func) override;
-
 
    /// method to perform the minimization
     bool Minimize() override;

--- a/math/mathmore/inc/Math/Polynomial.h
+++ b/math/mathmore/inc/Math/Polynomial.h
@@ -62,7 +62,7 @@ namespace Math {
   */
 
 class Polynomial : public ParamFunction<IParamGradFunction>,
-                   public IGradientOneDim
+                   public IGradientFunctionOneDim
 {
 
 
@@ -138,7 +138,7 @@ public:
 
    /**
        Optimized method to evaluate at the same time the function value and derivative at a point x.
-       Implement the interface specified bby ROOT::Math::IGradientOneDim.
+       Implement the interface specified by ROOT::Math::IGradientOneDim.
        In the case of polynomial there is no advantage to compute both at the same time
    */
    void FdF (double x, double & f, double & df) const override {

--- a/math/mathmore/src/GSLNLSMinimizer.cxx
+++ b/math/mathmore/src/GSLNLSMinimizer.cxx
@@ -240,13 +240,7 @@ void GSLNLSMinimizer::SetFunction(const ROOT::Math::IMultiGenFunction & func) {
    // call base class method. It will clone the function and set number of dimensions
    BasicMinimizer::SetFunction(func);
    fNFree = NDim();
-   fUseGradFunction = false;
- }
-
-void GSLNLSMinimizer::SetFunction(const ROOT::Math::IMultiGradFunction & func ) {
-   // set the function to minimizer using gradient interface
-   BasicMinimizer::SetFunction(func);
-   fUseGradFunction = true;
+   fUseGradFunction = func.HasGradient();
 }
 
 

--- a/math/minuit/inc/TLinearMinimizer.h
+++ b/math/minuit/inc/TLinearMinimizer.h
@@ -65,9 +65,6 @@ public:
    /// set the fit model function
    void SetFunction(const ROOT::Math::IMultiGenFunction & func) override;
 
-   /// set the function to minimize
-   void SetFunction(const ROOT::Math::IMultiGradFunction & func) override;
-
    /// set free variable (dummy impl. since there is no need to set variables in the Linear Fitter)
    bool SetVariable(unsigned int , const std::string & , double , double ) override { return true; }
 

--- a/math/minuit/inc/TMinuitMinimizer.h
+++ b/math/minuit/inc/TMinuitMinimizer.h
@@ -85,9 +85,6 @@ public:
    /// set the function to minimize
    void SetFunction(const ROOT::Math::IMultiGenFunction & func) override;
 
-   /// set the function to minimize
-   void SetFunction(const ROOT::Math::IMultiGradFunction & func) override;
-
    /// set free variable
    bool SetVariable(unsigned int ivar, const std::string & name, double val, double step) override;
 

--- a/math/minuit/src/TLinearMinimizer.cxx
+++ b/math/minuit/src/TLinearMinimizer.cxx
@@ -118,21 +118,19 @@ TLinearMinimizer & TLinearMinimizer::operator = (const TLinearMinimizer &rhs)
 }
 
 
-void TLinearMinimizer::SetFunction(const  ROOT::Math::IMultiGenFunction & ) {
-   // Set function to be minimized. Flag an error since only support Gradient objective functions
-
-   Error("TLinearMinimizer::SetFunction(IMultiGenFunction)","Wrong type of function used for Linear fitter");
-}
-
-
-void TLinearMinimizer::SetFunction(const  ROOT::Math::IMultiGradFunction & objfunc) {
+void TLinearMinimizer::SetFunction(const  ROOT::Math::IMultiGenFunction & objfunc) {
    // Set the function to be minimized. The function must be a Chi2 gradient function
    // When performing a linear fit we need the basis functions, which are the partial derivatives with respect to the parameters of the model function.
+
+   if(!objfunc.HasGradient()) {
+      // Set function to be minimized. Flag an error since only support Gradient objective functions
+      Error("TLinearMinimizer::SetFunction(IMultiGenFunction)","Wrong type of function used for Linear fitter");
+   }
 
    typedef ROOT::Fit::Chi2FCN<ROOT::Math::IMultiGradFunction> Chi2Func;
    const Chi2Func * chi2func = dynamic_cast<const Chi2Func *>(&objfunc);
    if (chi2func ==0) {
-      Error("TLinearMinimizer::SetFunction(IMultiGradFunction)","Wrong type of function used for Linear fitter");
+      Error("TLinearMinimizer::SetFunction(IMultiGenFunction)","Wrong type of function used for Linear fitter");
       return;
    }
    fObjFunc = chi2func;

--- a/math/minuit/src/TMinuitMinimizer.cxx
+++ b/math/minuit/src/TMinuitMinimizer.cxx
@@ -218,33 +218,19 @@ void TMinuitMinimizer::SetFunction(const  ROOT::Math::IMultiGenFunction & func) 
    GetGlobalFuncPtr() = const_cast<ROOT::Math::IMultiGenFunction *>(&func);
    fMinuit->SetFCN(&TMinuitMinimizer::Fcn);
 
-   // switch off gradient calculations
    double arglist[1];
    int ierr = 0;
-   fMinuit->mnexcm("SET NOGrad",arglist,0,ierr);
-}
 
-void TMinuitMinimizer::SetFunction(const  ROOT::Math::IMultiGradFunction & func) {
-   // Set the objective function to be minimized, by passing a function object implement the
-   // multi-dim gradient Function interface. In this case the function derivatives are provided
-   // by the user via this interface and there not calculated by Minuit.
-
-   fDim = func.NDim();
-
-   // create TMinuit if needed
-   InitTMinuit(fDim);
-
-   // assign to the static pointer (NO Thread safety here)
-   GetGlobalFuncPtr() = const_cast<ROOT::Math::IMultiGradFunction *>(&func);
-   fMinuit->SetFCN(&TMinuitMinimizer::FcnGrad);
-
-   // set gradient
-   // by default do not check gradient calculation
-   // it cannot be done here, check can be done only after having defined the parameters
-   double arglist[1];
-   int ierr = 0;
-   arglist[0] = 1;
-   fMinuit->mnexcm("SET GRAD",arglist,1,ierr);
+   if(func.HasGradient()) {
+      // set gradient
+      // by default do not check gradient calculation
+      // it cannot be done here, check can be done only after having defined the parameters
+      arglist[0] = 1;
+      fMinuit->mnexcm("SET GRAD",arglist,1,ierr);
+   } else {
+      // switch off gradient calculations
+      fMinuit->mnexcm("SET NOGrad",arglist,0,ierr);
+   }
 }
 
 void TMinuitMinimizer::Fcn( int &, double * , double & f, double * x , int /* iflag */) {

--- a/math/minuit2/inc/Minuit2/Minuit2Minimizer.h
+++ b/math/minuit2/inc/Minuit2/Minuit2Minimizer.h
@@ -89,9 +89,6 @@ public:
    /// set the function to minimize
    void SetFunction(const ROOT::Math::IMultiGenFunction &func) override;
 
-   /// set the function to minimize using an interface with gradient computation capabilities
-   void SetFunction(const ROOT::Math::IMultiGradFunction &func) override;
-
    /// set the function implementing Hessian computation
    void SetHessianFunction(std::function<bool(const std::vector<double> &, double *)> hfunc) override;
 

--- a/roofit/roofitcore/src/RooAbsMinimizerFcn.h
+++ b/roofit/roofitcore/src/RooAbsMinimizerFcn.h
@@ -90,7 +90,6 @@ public:
 
    /// Enable or disable offsetting on the function to be minimized, which enhances numerical precision.
    virtual void setOffsetting(bool flag) = 0;
-   virtual bool fit(ROOT::Fit::Fitter &) const = 0;
    virtual ROOT::Math::IMultiGenFunction *getMultiGenFcn() = 0;
 
    RooMinimizer::Config const &cfg() const { return _context->_cfg; }

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -298,7 +298,7 @@ ROOT::Fit::Fitter const *RooMinimizer::fitter() const
 
 bool RooMinimizer::fitFcn() const
 {
-   return _fcn->fit(*_theFitter);
+   return _theFitter->FitFCN(*_fcn->getMultiGenFcn());
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooMinimizerFcn.h
+++ b/roofit/roofitcore/src/RooMinimizerFcn.h
@@ -50,7 +50,6 @@ public:
    void setOptimizeConstOnFunction(RooAbsArg::ConstOpCode opcode, bool doAlsoTrackingOpt) override;
 
    void setOffsetting(bool flag) override;
-   bool fit(ROOT::Fit::Fitter &fitter) const override { return fitter.FitFCN(*this); };
    ROOT::Math::IMultiGenFunction *getMultiGenFcn() override { return this; };
 
 private:

--- a/roofit/roofitcore/src/TestStatistics/MinuitFcnGrad.h
+++ b/roofit/roofitcore/src/TestStatistics/MinuitFcnGrad.h
@@ -52,7 +52,6 @@ public:
       }
    }
 
-   bool fit(ROOT::Fit::Fitter &fitter) const override { return fitter.FitFCN(*this); };
    ROOT::Math::IMultiGenFunction *getMultiGenFcn() override { return this; };
 
 private:


### PR DESCRIPTION
The fact that gradient computations are supported in a `ROOT::Math`
function wrapper was only transmitted by the static class type.

However, this is rather inconvenient:

1. If you forget to downcast your function to the gradient type, the
   provided gradient won't be used.

2. Many minimizer function signatures must be overloaded for both the
   function with and without gradients

3. In RooFit, this caused particular pain: depending on if an external
   gradient is provided, the function wrapper in the `RooMinimizer`
   needs to have a different base class, and the RooMinimizer needs to
   cast it correctly when fitting.

This commit suggests two new virtual functions:

* `IBaseFunctionMultiDimTempl::HasGradient()` for multi-dim functions

* `IBaseFunctionOneDim::HasGradient()` for 1D functions

Like this, the gradient support can be queried without dynamic casting
at runtime, simplifying lots of other code.