### PR TITLE
[tree] Propagate TTreeIndex info through GetFriendInfo/MakeFriends 

### DIFF
--- a/tree/tree/inc/ROOT/RFriendInfo.hxx
+++ b/tree/tree/inc/ROOT/RFriendInfo.hxx
@@ -18,8 +18,12 @@
 #ifndef ROOT_RFRIENDINFO_H
 #define ROOT_RFRIENDINFO_H
 
+#include <ROOT/RStringView.hxx>
+#include <TVirtualIndex.h>
+
 #include <cstdint> // std::int64_t
 #include <limits>
+#include <memory>
 #include <string>
 #include <utility> // std::pair
 #include <vector>
@@ -28,6 +32,7 @@ class TTree;
 
 namespace ROOT {
 namespace TreeUtils {
+
 /**
 \struct ROOT::TreeUtils::RFriendInfo
 \brief Information about friend trees of a certain TTree or TChain object.
@@ -59,14 +64,32 @@ struct RFriendInfo {
     */
    std::vector<std::vector<std::int64_t>> fNEntriesPerTreePerFriend;
 
+   /**
+      Information on the friend's TTreeIndexes.
+   */
+   std::vector<std::unique_ptr<TVirtualIndex>> fTreeIndexInfos;
+
+   RFriendInfo() = default;
+   RFriendInfo(const RFriendInfo &);
+   RFriendInfo &operator=(const RFriendInfo &);
+   RFriendInfo(RFriendInfo &&) = default;
+   RFriendInfo &operator=(RFriendInfo &&) = default;
+   RFriendInfo(std::vector<std::pair<std::string, std::string>> friendNames,
+               std::vector<std::vector<std::string>> friendFileNames,
+               std::vector<std::vector<std::string>> friendChainSubNames,
+               std::vector<std::vector<std::int64_t>> nEntriesPerTreePerFriend,
+               std::vector<std::unique_ptr<TVirtualIndex>> treeIndexInfos);
+
    void AddFriend(const std::string &treeName, const std::string &fileNameGlob, const std::string &alias = "",
-                  std::int64_t nEntries = std::numeric_limits<std::int64_t>::max());
+                  std::int64_t nEntries = std::numeric_limits<std::int64_t>::max(), TVirtualIndex *indexInfo = nullptr);
 
    void AddFriend(const std::string &treeName, const std::vector<std::string> &fileNameGlobs,
-                  const std::string &alias = "", const std::vector<std::int64_t> &nEntriesVec = {});
+                  const std::string &alias = "", const std::vector<std::int64_t> &nEntriesVec = {},
+                  TVirtualIndex *indexInfo = nullptr);
 
    void AddFriend(const std::vector<std::pair<std::string, std::string>> &treeAndFileNameGlobs,
-                  const std::string &alias = "", const std::vector<std::int64_t> &nEntriesVec = {});
+                  const std::string &alias = "", const std::vector<std::int64_t> &nEntriesVec = {},
+                  TVirtualIndex *indexInfo = nullptr);
 };
 
 } // namespace TreeUtils

--- a/tree/tree/inc/TVirtualIndex.h
+++ b/tree/tree/inc/TVirtualIndex.h
@@ -45,7 +45,7 @@ public:
    virtual Long64_t       GetN()            const = 0;
    virtual TTree         *GetTree()         const {return fTree;}
    virtual void           UpdateFormulaLeaves(const TTree *parent) = 0;
-   virtual void           SetTree(const TTree *T) = 0;
+   virtual void           SetTree(TTree *T) = 0;
 
    ClassDefOverride(TVirtualIndex,1);  //Abstract interface for Tree Index
 };

--- a/tree/tree/src/RFriendInfo.cxx
+++ b/tree/tree/src/RFriendInfo.cxx
@@ -12,6 +12,38 @@
 namespace ROOT {
 namespace TreeUtils {
 
+RFriendInfo::RFriendInfo(const RFriendInfo &other)
+{
+   *this = other;
+}
+
+RFriendInfo &RFriendInfo::operator=(const RFriendInfo &other)
+{
+   fFriendNames = other.fFriendNames;
+   fFriendFileNames = other.fFriendFileNames;
+   fFriendChainSubNames = other.fFriendChainSubNames;
+   fNEntriesPerTreePerFriend = other.fNEntriesPerTreePerFriend;
+
+   for (const auto &idxInfo : other.fTreeIndexInfos)
+      fTreeIndexInfos.emplace_back(static_cast<TVirtualIndex *>(idxInfo ? idxInfo->Clone() : nullptr));
+
+   return *this;
+}
+
+/// Construct a RFriendInfo object from its components.
+RFriendInfo::RFriendInfo(std::vector<std::pair<std::string, std::string>> friendNames,
+                         std::vector<std::vector<std::string>> friendFileNames,
+                         std::vector<std::vector<std::string>> friendChainSubNames,
+                         std::vector<std::vector<std::int64_t>> nEntriesPerTreePerFriend,
+                         std::vector<std::unique_ptr<TVirtualIndex>> treeIndexInfos)
+   : fFriendNames(std::move(friendNames)),
+     fFriendFileNames(std::move(friendFileNames)),
+     fFriendChainSubNames(std::move(friendChainSubNames)),
+     fNEntriesPerTreePerFriend(std::move(nEntriesPerTreePerFriend)),
+     fTreeIndexInfos(std::move(treeIndexInfos))
+{
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// \brief Add information of a single friend.
 ///
@@ -19,13 +51,15 @@ namespace TreeUtils {
 /// \param[in] fileNameGlob Path to the file. Refer to TChain::Add for globbing rules.
 /// \param[in] alias Alias for this friend.
 /// \param[in] nEntries Number of entries for this friend.
+/// \param[in] indexInfo Tree index info for this friend.
 void RFriendInfo::AddFriend(const std::string &treeName, const std::string &fileNameGlob, const std::string &alias,
-                            std::int64_t nEntries)
+                            std::int64_t nEntries, TVirtualIndex *indexInfo)
 {
    fFriendNames.emplace_back(std::make_pair(treeName, alias));
    fFriendFileNames.emplace_back(std::vector<std::string>{fileNameGlob});
    fFriendChainSubNames.emplace_back();
    fNEntriesPerTreePerFriend.push_back(std::vector<std::int64_t>({nEntries}));
+   fTreeIndexInfos.emplace_back(static_cast<TVirtualIndex *>(indexInfo ? indexInfo->Clone() : nullptr));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -35,8 +69,10 @@ void RFriendInfo::AddFriend(const std::string &treeName, const std::string &file
 /// \param[in] fileNameGlobs Paths to the files. Refer to TChain::Add for globbing rules.
 /// \param[in] alias Alias for this friend.
 /// \param[in] nEntriesVec Number of entries for each file of this friend.
+/// \param[in] indexInfo Tree index info for this friend.
 void RFriendInfo::AddFriend(const std::string &treeName, const std::vector<std::string> &fileNameGlobs,
-                            const std::string &alias, const std::vector<std::int64_t> &nEntriesVec)
+                            const std::string &alias, const std::vector<std::int64_t> &nEntriesVec,
+                            TVirtualIndex *indexInfo)
 {
    fFriendNames.emplace_back(std::make_pair(treeName, alias));
    fFriendFileNames.emplace_back(fileNameGlobs);
@@ -44,6 +80,7 @@ void RFriendInfo::AddFriend(const std::string &treeName, const std::vector<std::
    fNEntriesPerTreePerFriend.push_back(
       nEntriesVec.empty() ? std::vector<int64_t>(fileNameGlobs.size(), std::numeric_limits<std::int64_t>::max())
                           : nEntriesVec);
+   fTreeIndexInfos.emplace_back(static_cast<TVirtualIndex *>(indexInfo ? indexInfo->Clone() : nullptr));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -52,8 +89,10 @@ void RFriendInfo::AddFriend(const std::string &treeName, const std::vector<std::
 /// \param[in] treeAndFileNameGlobs Pairs of (treename, filename). Refer to TChain::Add for globbing rules.
 /// \param[in] alias Alias for this friend.
 /// \param[in] nEntriesVec Number of entries for each file of this friend.
+/// \param[in] indexInfo Tree index info for this friend.
 void RFriendInfo::AddFriend(const std::vector<std::pair<std::string, std::string>> &treeAndFileNameGlobs,
-                            const std::string &alias, const std::vector<std::int64_t> &nEntriesVec)
+                            const std::string &alias, const std::vector<std::int64_t> &nEntriesVec,
+                            TVirtualIndex *indexInfo)
 {
    fFriendNames.emplace_back(std::make_pair("", alias));
 
@@ -76,6 +115,7 @@ void RFriendInfo::AddFriend(const std::vector<std::pair<std::string, std::string
    fNEntriesPerTreePerFriend.push_back(
       nEntriesVec.empty() ? std::vector<int64_t>(treeAndFileNameGlobs.size(), std::numeric_limits<std::int64_t>::max())
                           : nEntriesVec);
+   fTreeIndexInfos.emplace_back(static_cast<TVirtualIndex *>(indexInfo ? indexInfo->Clone() : nullptr));
 }
 
 } // namespace TreeUtils

--- a/tree/treeplayer/inc/TChainIndex.h
+++ b/tree/treeplayer/inc/TChainIndex.h
@@ -88,7 +88,7 @@ public:
    virtual Long64_t       GetN()            const {return fEntries.size();}
    virtual Bool_t         IsValidFor(const TTree *parent);
    virtual void           UpdateFormulaLeaves(const TTree *parent);
-   virtual void           SetTree(const TTree *T);
+   virtual void           SetTree(TTree *T);
 
    ClassDef(TChainIndex,1)  //A Tree Index with majorname and minorname.
 };

--- a/tree/treeplayer/inc/TTreeIndex.h
+++ b/tree/treeplayer/inc/TTreeIndex.h
@@ -68,7 +68,7 @@ public:
    virtual Bool_t         IsValidFor(const TTree *parent);
    virtual void           Print(Option_t *option="") const;
    virtual void           UpdateFormulaLeaves(const TTree *parent);
-   virtual void           SetTree(const TTree *T);
+   virtual void           SetTree(TTree *T);
 
    ClassDef(TTreeIndex,2);  //A Tree Index with majorname and minorname.
 };

--- a/tree/treeplayer/src/TChainIndex.cxx
+++ b/tree/treeplayer/src/TChainIndex.cxx
@@ -182,9 +182,11 @@ void TChainIndex::DeleteIndices()
 
 TChainIndex::~TChainIndex()
 {
-   DeleteIndices();
-   if (fTree && fTree->GetTreeIndex() == this)
-      fTree->SetTreeIndex(0);
+   if (fTree) {
+      DeleteIndices();
+      if (fTree->GetTreeIndex() == this)
+         fTree->SetTreeIndex(nullptr);
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/treeplayer/src/TChainIndex.cxx
+++ b/tree/treeplayer/src/TChainIndex.cxx
@@ -402,5 +402,6 @@ void TChainIndex::UpdateFormulaLeaves(const TTree *parent)
 void TChainIndex::SetTree(TTree *T)
 {
    R__ASSERT(fTree == 0 || fTree == T || T==0);
+   fTree = T;
 }
 

--- a/tree/treeplayer/src/TChainIndex.cxx
+++ b/tree/treeplayer/src/TChainIndex.cxx
@@ -399,7 +399,7 @@ void TChainIndex::UpdateFormulaLeaves(const TTree *parent)
 ////////////////////////////////////////////////////////////////////////////////
 /// See TTreeIndex::SetTree.
 
-void TChainIndex::SetTree(const TTree *T)
+void TChainIndex::SetTree(TTree *T)
 {
    R__ASSERT(fTree == 0 || fTree == T || T==0);
 }

--- a/tree/treeplayer/src/TTreeIndex.cxx
+++ b/tree/treeplayer/src/TTreeIndex.cxx
@@ -633,8 +633,8 @@ void TTreeIndex::UpdateFormulaLeaves(const TTree *parent)
 /// Because Trees in a TChain may have a different list of leaves, one
 /// must update the leaves numbers in the TTreeFormula used by the TreeIndex.
 
-void TTreeIndex::SetTree(const TTree *T)
+void TTreeIndex::SetTree(TTree *T)
 {
-   fTree = (TTree*)T;
+   fTree = T;
 }
 


### PR DESCRIPTION
This in turn fixes a problem with TTreeProcessorMT and multi-thread
RDataFrame "forgetting" about the TTreeIndexes associated with
input friend trees.

It fixes https://github.com/root-project/root/issues/12260,
"[DF] Bogus data read from indexed friend trees in multi-thread runs".

A test is added for this case as well.