### PR TITLE
[ntuple] Remove unneeded `RColumnElementBase::Generate<void>` instatiation

### DIFF
--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -58,9 +58,6 @@ ROOT::Experimental::Detail::RColumnElementBase::Generate<void>(EColumnType type)
    return nullptr;
 }
 
-template std::unique_ptr<ROOT::Experimental::Detail::RColumnElementBase>
-ROOT::Experimental::Detail::RColumnElementBase::Generate<void>(EColumnType type);
-
 std::size_t ROOT::Experimental::Detail::RColumnElementBase::GetBitsOnStorage(EColumnType type) {
    switch (type) {
    case EColumnType::kReal32:


### PR DESCRIPTION
Apparently, this is not required as the symbol is always emitted; removing as it also triggers the `clang` warning below
```
/home/jhahnfel/ROOT/src/tree/ntuple/v7/src/RColumnElement.cxx:62:49: warning: explicit instantiation of 'Generate<void>' that occurs after an explicit specialization has no effect [-Winstantiation-after-specialization]
ROOT::Experimental::Detail::RColumnElementBase::Generate<void>(EColumnType type);
                                                ^
/home/jhahnfel/ROOT/src/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx:597:57: note: previous template specialization is here
std::unique_ptr<RColumnElementBase> RColumnElementBase::Generate<void>(EColumnType type);
                                                        ^
1 warning generated.
```

Thanks for reporting @hahnjo!