### PR TITLE
[RF] Add observables as another parameter in RooFuncWrapper.

### DIFF
--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -344,6 +344,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     src/RooFormulaVar.cxx
     src/RooFracRemainder.cxx
     src/RooFunctor.cxx
+    src/RooFuncWrapper.cxx
     src/RooGenContext.cxx
     src/RooGenericPdf.cxx
     src/RooGenFitStudy.cxx

--- a/roofit/roofitcore/inc/RooFuncWrapper.h
+++ b/roofit/roofitcore/inc/RooFuncWrapper.h
@@ -13,140 +13,38 @@
 #ifndef RooFit_RooFuncWrapper_h
 #define RooFit_RooFuncWrapper_h
 
-#include "TROOT.h"
-#include "TSystem.h"
-#include "RooAbsData.h"
 #include "RooAbsReal.h"
-#include "RooGlobalFunc.h"
-#include "RooMsgService.h"
-#include "RooRealVar.h"
 #include "RooListProxy.h"
 
 #include <memory>
 #include <string>
 
-/// @brief  A wrapper class to store a C++ function of type 'double (*)(double* )'.
+/// @brief  A wrapper class to store a C++ function of type 'double (*)(double*, double*)'.
 /// The parameters can be accessed as params[<relative position of param in paramSet>] in the function body.
 /// The observables can be accessed as obs[i * num_entries + j], where i represents the observable position and j
 /// represents the data entry.
-/// @tparam Func Function pointer to the generated function.
-template <typename Func = double (*)(double *, double *), typename Grad = void (*)(double *, double *, double *)>
 class RooFuncWrapper final : public RooAbsReal {
 public:
    RooFuncWrapper(const char *name, const char *title, std::string const &funcBody, RooArgSet const &paramSet,
-                  RooArgSet const &ObsSet, const RooAbsData *data = nullptr)
-      : RooAbsReal{name, title}, _params{"!params", "List of parameters", this}
-   {
-      std::string funcName = name;
-      std::string gradName = funcName + "_grad_0";
-      std::string requestName = funcName + "_req";
-      std::string wrapperName = funcName + "_derivativeWrapper";
+                  RooArgSet const &ObsSet, const RooAbsData *data = nullptr);
 
-      // Declare the function
-      std::stringstream bodyWithSigStrm;
-      bodyWithSigStrm << "double " << funcName << "(double* params, double* obs) {" << funcBody << "}";
-      bool comp = gInterpreter->Declare(bodyWithSigStrm.str().c_str());
-      if (!comp) {
-         std::stringstream errorMsg;
-         errorMsg << "Function " << funcName << " could not be compiled. See above for details.";
-         coutE(InputArguments) << errorMsg.str() << std::endl;
-         throw std::runtime_error(errorMsg.str().c_str());
-      }
-      _func = reinterpret_cast<Func>(gInterpreter->ProcessLine((funcName + ";").c_str()));
-
-      // Calculate gradient
-      gInterpreter->ProcessLine("#include <Math/CladDerivator.h>");
-      // disable clang-format for making the following code unreadable.
-      // clang-format off
-      std::stringstream requestFuncStrm;
-      requestFuncStrm << "#pragma clad ON\n"
-                         "void " << requestName << "() {\n"
-                         "  clad::gradient(" << funcName << ", \"params\");\n"
-                         "}\n"
-                         "#pragma clad OFF";
-      // clang-format on
-      comp = gInterpreter->Declare(requestFuncStrm.str().c_str());
-      if (!comp) {
-         std::stringstream errorMsg;
-         errorMsg << "Function " << funcName << " could not be be differentiated. See above for details.";
-         coutE(InputArguments) << errorMsg.str() << std::endl;
-         throw std::runtime_error(errorMsg.str().c_str());
-      }
-
-      // Extract parameters
-      for (auto *param : paramSet) {
-         if (!dynamic_cast<RooAbsReal *>(param)) {
-            std::stringstream errorMsg;
-            errorMsg << "In creation of function " << funcName
-                     << " wrapper: input param expected to be of type RooAbsReal.";
-            coutE(InputArguments) << errorMsg.str() << std::endl;
-            throw std::runtime_error(errorMsg.str().c_str());
-         }
-         _params.add(*param);
-      }
-      _gradientVarBuffer.reserve(_params.size());
-
-      // Extract observables
-      if (!ObsSet.empty()) {
-         auto dataSpans = data->getBatches(0, data->numEntries());
-         _observables.reserve(_observables.size() * data->numEntries());
-         for (auto *obs : static_range_cast<RooRealVar *>(ObsSet)) {
-            RooSpan<const double> span{dataSpans.at(obs)};
-            for (int i = 0; i < data->numEntries(); ++i) {
-               _observables.push_back(span[i]);
-            }
-         }
-      }
-
-      // Build a wrapper over the derivative to hide clad specific types such as 'array_ref'.
-      // disable clang-format for making the following code unreadable.
-      // clang-format off
-      std::stringstream dWrapperStrm;
-      dWrapperStrm << "void " << wrapperName << "(double* params, double* obs, double* out) {\n"
-                      "  clad::array_ref<double> cladOut(out, " << _params.size() << ");\n"
-                      "  " << gradName << "(params, obs, cladOut);\n"
-                      "}";
-      // clang-format on
-      gInterpreter->Declare(dWrapperStrm.str().c_str());
-      _grad = reinterpret_cast<Grad>(gInterpreter->ProcessLine((wrapperName + ";").c_str()));
-   }
-
-   RooFuncWrapper(const RooFuncWrapper &other, const char *name = nullptr)
-      : RooAbsReal(other, name),
-        _params("!params", this, other._params),
-        _func(other._func),
-        _grad(other._grad),
-        _gradientVarBuffer(other._gradientVarBuffer),
-        _observables(other._observables)
-   {
-   }
+   RooFuncWrapper(const RooFuncWrapper &other, const char *name = nullptr);
 
    TObject *clone(const char *newname) const override { return new RooFuncWrapper(*this, newname); }
 
    double defaultErrorLevel() const override { return 0.5; }
 
-   void getGradient(double *out) const
-   {
-      updateGradientVarBuffer();
-
-      _grad(_gradientVarBuffer.data(), _observables.data(), out);
-   }
+   void getGradient(double *out) const;
 
 protected:
-   void updateGradientVarBuffer() const
-   {
-      std::transform(_params.begin(), _params.end(), _gradientVarBuffer.begin(),
-                     [](RooAbsArg *obj) { return static_cast<RooAbsReal *>(obj)->getVal(); });
-   }
+   void updateGradientVarBuffer() const;
 
-   double evaluate() const override
-   {
-      updateGradientVarBuffer();
-
-      return _func(_gradientVarBuffer.data(), _observables.data());
-   }
+   double evaluate() const override;
 
 private:
+   using Func = double (*)(double *, double *);
+   using Grad = void (*)(double *, double *, double *);
+
    RooListProxy _params;
    Func _func;
    Grad _grad;

--- a/roofit/roofitcore/src/RooFuncWrapper.cxx
+++ b/roofit/roofitcore/src/RooFuncWrapper.cxx
@@ -1,0 +1,128 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   Garima Singh, CERN 2022
+ *
+ * Copyright (c) 2022, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#include "RooFuncWrapper.h"
+
+#include "TROOT.h"
+#include "TSystem.h"
+#include "RooAbsData.h"
+#include "RooGlobalFunc.h"
+#include "RooMsgService.h"
+#include "RooRealVar.h"
+
+RooFuncWrapper::RooFuncWrapper(const char *name, const char *title, std::string const &funcBody,
+                               RooArgSet const &paramSet, RooArgSet const &ObsSet, const RooAbsData *data /*=nullptr*/)
+   : RooAbsReal{name, title}, _params{"!params", "List of parameters", this}
+{
+   std::string funcName = name;
+   std::string gradName = funcName + "_grad_0";
+   std::string requestName = funcName + "_req";
+   std::string wrapperName = funcName + "_derivativeWrapper";
+
+   // Declare the function
+   std::stringstream bodyWithSigStrm;
+   bodyWithSigStrm << "double " << funcName << "(double* params, double* obs) {" << funcBody << "}";
+   bool comp = gInterpreter->Declare(bodyWithSigStrm.str().c_str());
+   if (!comp) {
+      std::stringstream errorMsg;
+      errorMsg << "Function " << funcName << " could not be compiled. See above for details.";
+      coutE(InputArguments) << errorMsg.str() << std::endl;
+      throw std::runtime_error(errorMsg.str().c_str());
+   }
+   _func = reinterpret_cast<Func>(gInterpreter->ProcessLine((funcName + ";").c_str()));
+
+   // Calculate gradient
+   gInterpreter->ProcessLine("#include <Math/CladDerivator.h>");
+   // disable clang-format for making the following code unreadable.
+   // clang-format off
+      std::stringstream requestFuncStrm;
+      requestFuncStrm << "#pragma clad ON\n"
+                         "void " << requestName << "() {\n"
+                         "  clad::gradient(" << funcName << ", \"params\");\n"
+                         "}\n"
+                         "#pragma clad OFF";
+   // clang-format on
+   comp = gInterpreter->Declare(requestFuncStrm.str().c_str());
+   if (!comp) {
+      std::stringstream errorMsg;
+      errorMsg << "Function " << funcName << " could not be be differentiated. See above for details.";
+      coutE(InputArguments) << errorMsg.str() << std::endl;
+      throw std::runtime_error(errorMsg.str().c_str());
+   }
+
+   // Extract parameters
+   for (auto *param : paramSet) {
+      if (!dynamic_cast<RooAbsReal *>(param)) {
+         std::stringstream errorMsg;
+         errorMsg << "In creation of function " << funcName
+                  << " wrapper: input param expected to be of type RooAbsReal.";
+         coutE(InputArguments) << errorMsg.str() << std::endl;
+         throw std::runtime_error(errorMsg.str().c_str());
+      }
+      _params.add(*param);
+   }
+   _gradientVarBuffer.reserve(_params.size());
+
+   // Extract observables
+   if (!ObsSet.empty()) {
+      auto dataSpans = data->getBatches(0, data->numEntries());
+      _observables.reserve(_observables.size() * data->numEntries());
+      for (auto *obs : static_range_cast<RooRealVar *>(ObsSet)) {
+         RooSpan<const double> span{dataSpans.at(obs)};
+         for (int i = 0; i < data->numEntries(); ++i) {
+            _observables.push_back(span[i]);
+         }
+      }
+   }
+
+   // Build a wrapper over the derivative to hide clad specific types such as 'array_ref'.
+   // disable clang-format for making the following code unreadable.
+   // clang-format off
+      std::stringstream dWrapperStrm;
+      dWrapperStrm << "void " << wrapperName << "(double* params, double* obs, double* out) {\n"
+                      "  clad::array_ref<double> cladOut(out, " << _params.size() << ");\n"
+                      "  " << gradName << "(params, obs, cladOut);\n"
+                      "}";
+   // clang-format on
+   gInterpreter->Declare(dWrapperStrm.str().c_str());
+   _grad = reinterpret_cast<Grad>(gInterpreter->ProcessLine((wrapperName + ";").c_str()));
+}
+
+RooFuncWrapper::RooFuncWrapper(const RooFuncWrapper &other, const char *name /*=nullptr*/)
+   : RooAbsReal(other, name),
+     _params("!params", this, other._params),
+     _func(other._func),
+     _grad(other._grad),
+     _gradientVarBuffer(other._gradientVarBuffer),
+     _observables(other._observables)
+{
+}
+
+void RooFuncWrapper::getGradient(double *out) const
+{
+   updateGradientVarBuffer();
+
+   _grad(_gradientVarBuffer.data(), _observables.data(), out);
+}
+
+void RooFuncWrapper::updateGradientVarBuffer() const
+{
+   std::transform(_params.begin(), _params.end(), _gradientVarBuffer.begin(),
+                  [](RooAbsArg *obj) { return static_cast<RooAbsReal *>(obj)->getVal(); });
+}
+
+double RooFuncWrapper::evaluate() const
+{
+   updateGradientVarBuffer();
+
+   return _func(_gradientVarBuffer.data(), _observables.data());
+}

--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -24,7 +24,6 @@ ROOT_ADD_GTEST(testRooAbsCollection testRooAbsCollection.cxx LIBRARIES RooFitCor
 ROOT_ADD_GTEST(testRooDataSet testRooDataSet.cxx LIBRARIES Tree RooFitCore)
 ROOT_ADD_GTEST(testRooFormula testRooFormula.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testRooProdPdf testRooProdPdf.cxx LIBRARIES RooFitCore)
-ROOT_ADD_GTEST(testRooFuncWrapper testRooFuncWrapper.cxx LIBRARIES RooFitCore RooFit)
 ROOT_ADD_GTEST(testProxiesAndCategories testProxiesAndCategories.cxx
   LIBRARIES RooFitCore
   COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/testProxiesAndCategories_1.root
@@ -46,6 +45,8 @@ if(NOT MSVC OR win_broken_tests)
   # unknown file: error: SEH exception with code 0xc0000005 thrown in the test body.
   # According to the internet, this has to do with gtest, so it's not a RooFit problem
   ROOT_ADD_GTEST(testRooRealIntegral testRooRealIntegral.cxx LIBRARIES RooFitCore)
+  # Test disabled on windows due to an issue with cling symbols.
+  ROOT_ADD_GTEST(testRooFuncWrapper testRooFuncWrapper.cxx LIBRARIES RooFitCore RooFit)
 
   ROOT_ADD_GTEST(testTestStatistics testTestStatistics.cxx LIBRARIES RooFitCore)
 endif()

--- a/roofit/roofitcore/test/testRooFuncWrapper.cxx
+++ b/roofit/roofitcore/test/testRooFuncWrapper.cxx
@@ -60,7 +60,7 @@ TEST(RooFuncWrapper, GaussianNormalizedHardcoded)
                       "const double sig = params[2];"
                       "double out = std::exp(-0.5 * arg * arg / (sig * sig));"
                       "return 1. / (std::sqrt(TMath::TwoPi()) * sig) * out;";
-   RooFuncWrapper<> gaussFunc("myGauss1", "myGauss1", func, {x, mu, sigma}, {});
+   RooFuncWrapper gaussFunc("myGauss1", "myGauss1", func, {x, mu, sigma}, {});
 
    // Check if functions results are the same even after changing parameters.
    EXPECT_NEAR(gauss.getVal(normSet), gaussFunc.getVal(), 1e-8);
@@ -119,7 +119,7 @@ TEST(RooFuncWrapper, NllWithObservables)
             "}"
             "return nllSum;";
    // clang-format on
-   RooFuncWrapper<> nllFunc("myNLL", "myNLL", func.str(), parameters, observables, data.get());
+   RooFuncWrapper nllFunc("myNLL", "myNLL", func.str(), parameters, observables, data.get());
 
    // Check if functions results are the same even after changing parameters.
    EXPECT_NEAR(nllRef->getVal(normSet), nllFunc.getVal(), 1e-8);
@@ -272,7 +272,7 @@ TEST(DISABLED_RooFuncWrapper, GaussianNormalized)
    // generation might work like in the end
    std::string func = generateCode(*pdf, paramsGauss);
 
-   RooFuncWrapper<> gaussFunc("myGauss2", "myGauss2", func, paramsGauss, {});
+   RooFuncWrapper gaussFunc("myGauss2", "myGauss2", func, paramsGauss, {});
 
    // Check if functions results are the same even after changing parameters.
    EXPECT_NEAR(pdf->getVal(normSet), gaussFunc.getVal(), 1e-8);


### PR DESCRIPTION
This commit separates the parameters and observables passed to RooFuncWrapper. Now, the wrapper function accepts two different arrays and only calculates the gradient of the underlying func wrt. the parameter array.
