### PR TITLE
[ntuple] RPageSinkBuf: add missing call to `ReleasePage()`

### DIFF
--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -105,8 +105,11 @@ ROOT::Experimental::Detail::RPageSinkBuf::CommitClusterImpl(ROOT::Experimental::
       }
       fInnerSink->CommitSealedPageV(toCommit);
 
-      for (auto &bufColumn : fBufferedColumns)
-         bufColumn.DrainBufferedPages();
+      for (auto &bufColumn : fBufferedColumns) {
+         auto drained = bufColumn.DrainBufferedPages();
+         for (auto &bufPage : std::get<std::deque<RColumnBuf::RPageZipItem>>(drained))
+            ReleasePage(bufPage.fPage);
+      }
       return fInnerSink->CommitCluster(nEntries);
    }
 


### PR DESCRIPTION
Add missing call to `ReleasePage()` to free memory used for all the buffered pages after the vector write case (call to `CommitSealedPageV()`).
This fixes an unfortunate memory leak we introduced in https://github.com/root-project/root/pull/10775.

Thanks @glmiotto!

## Checklist:
- [X] tested changes locally