### PR TITLE
[build] Add Python executable to root-config

### DIFF
--- a/README/ReleaseNotes/v630/index.md
+++ b/README/ReleaseNotes/v630/index.md
@@ -127,4 +127,5 @@ ROOT::Math::Functor func4{functor, static_cast<unsigned int>(functor.nObs())};
 
 ## Build, Configuration and Testing Infrastructure
 
-
+* `root-config` can also print the path to the Python executable used when building ROOT. Options `--python-executable`,
+  `--python2-executable`, `--python3-executable` are now supported by the utility.

--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -678,6 +678,12 @@ if(PYTHON_VERSION_STRING_Development_Other)
    set(python${PYTHON_VERSION_MAJOR_Development_Other}vers ${PYTHON_VERSION_STRING_Development_Other})
 endif()
 
+set(rootconfigpythonexecutable ${PYTHON_EXECUTABLE_Development_Main})
+set(rootconfigpython${PYTHON_VERSION_MAJOR_Development_Main}executable ${PYTHON_EXECUTABLE_Development_Main})
+if(PYTHON_EXECUTABLE_Development_Other)
+  set(rootconfigpython${PYTHON_VERSION_MAJOR_Development_Other}executable ${PYTHON_EXECUTABLE_Development_Other})
+endif()
+
 #---RConfigure.h---------------------------------------------------------------------------------------------
 try_compile(has__cplusplus "${CMAKE_BINARY_DIR}" SOURCES "${CMAKE_SOURCE_DIR}/config/__cplusplus.cxx"
             OUTPUT_VARIABLE __cplusplus_PPout)

--- a/config/root-config.bat.in
+++ b/config/root-config.bat.in
@@ -137,6 +137,15 @@ for %%w in (%*) do (
    if "!arg!"=="--python3-version" (
       set out=!$out! @python3vers@
    )
+   if "!arg!"=="--python-executable" (
+      set out=!out! @rootconfigpythonexecutable@
+   )
+   if "!arg!"=="--python2-executable" (
+      set out=!$out! @rootconfigpython2executable@
+   )
+   if "!arg!"=="--python3-executable" (
+      set out=!$out! @rootconfigpython3executable@
+   )
    if "!arg!"=="--cflags" (
       set out=!out! !cxxflags! -I!incdir!
    )

--- a/config/root-config.in
+++ b/config/root-config.in
@@ -575,6 +575,15 @@ while test $# -gt 0; do
     --python3-version)
       out="$out @python3vers@"
       ;;
+    --python-executable)
+      out="$out @rootconfigpythonexecutable@"
+      ;;
+    --python2-executable)
+      out="$out @rootconfigpython2executable@"
+      ;;
+    --python3-executable)
+      out="$out @rootconfigpython3executable@"
+      ;;
     --cflags)
       ### Output the compiler flags
       if test "${incdir}" != "/usr/include"; then
@@ -848,6 +857,9 @@ while test $# -gt 0; do
       echo "  --python-version      Print the Python version used by ROOT"
       echo "  --python2-version     Print the Python2 version used by PyROOT"
       echo "  --python3-version     Print the Python3 version used by PyROOT"
+      echo "  --python-executable   Print the Python executable used by ROOT"
+      echo "  --python2-executable  Print the Python2 executable used by ROOT"
+      echo "  --python3-executable  Print the Python3 executable used by ROOT"
       echo "  --ncpu                Print number of available (hyperthreaded) cores"
       echo "  --cc                  Print alternative C compiler specified when ROOT was built"
       echo "  --cxx                 Print alternative C++ compiler specified when ROOT was built"


### PR DESCRIPTION
To allow
```
vpadulan@fedora [~/programs/rootproject/rootinstall]: root-config --python-executable
/usr/bin/python3.10
vpadulan@fedora [~/programs/rootproject/rootinstall]: root-config --python3-executable
/usr/bin/python3.10
vpadulan@fedora [~/programs/rootproject/rootinstall]: root-config --python2-executable
/usr/bin/python2.7
vpadulan@fedora [~/programs/rootproject/rootinstall]: `root-config --python2-executable` -c "import ROOT; print(ROOT.__version__)"
6.29/01
vpadulan@fedora [~/programs/rootproject/rootinstall]: `root-config --python-executable` -c "import ROOT; print(ROOT.__version__)"
6.29/01
```