### PR TITLE
Fixing a typo in the documentation: `SetOptStats --> SetOptStat`

### DIFF
--- a/hist/hist/src/TGraph.cxx
+++ b/hist/hist/src/TGraph.cxx
@@ -2407,7 +2407,7 @@ void TGraph::SetNameTitle(const char *name, const char *title)
 /// Set statistics option on/off.
 ///
 /// By default, the statistics box is drawn.
-/// The paint options can be selected via gStyle->SetOptStats.
+/// The paint options can be selected via gStyle->SetOptStat.
 /// This function sets/resets the kNoStats bit in the graph object.
 /// It has priority over the Style option.
 

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -8851,7 +8851,7 @@ void TH1::SetNameTitle(const char *name, const char *title)
 /// Set statistics option on/off.
 ///
 /// By default, the statistics box is drawn.
-/// The paint options can be selected via gStyle->SetOptStats.
+/// The paint options can be selected via gStyle->SetOptStat.
 /// This function sets/resets the kNoStats bit in the histogram object.
 /// It has priority over the Style option.
 


### PR DESCRIPTION
`SetOptStats` --> `SetOptStat`


