### PR TITLE
[RF] Support `RooAbsCategoryLValue::setBin()` for non-existing ranges 

### DIFF
--- a/roofit/histfactory/src/ParamHistFunc.cxx
+++ b/roofit/histfactory/src/ParamHistFunc.cxx
@@ -700,7 +700,7 @@ std::list<double>* ParamHistFunc::plotSamplingHint(RooAbsRealLValue& obs, double
   RooAbsLValue* lvarg = &obs;
 
   // Retrieve position of all bin boundaries
-  const RooAbsBinning* binning = lvarg->getBinningPtr(0) ;
+  const RooAbsBinning* binning = lvarg->getBinningPtr(nullptr);
   double* boundaries = binning->array() ;
 
   std::list<double>* hint = new std::list<double> ;
@@ -735,7 +735,7 @@ std::list<double>* ParamHistFunc::binBoundaries(RooAbsRealLValue& obs, double xl
   RooAbsLValue* lvarg = &obs;
 
   // Retrieve position of all bin boundaries
-  const RooAbsBinning* binning = lvarg->getBinningPtr(0) ;
+  const RooAbsBinning* binning = lvarg->getBinningPtr(nullptr);
   double* boundaries = binning->array() ;
 
   std::list<double>* hint = new std::list<double> ;

--- a/roofit/roofit/inc/RooIntegralMorph.h
+++ b/roofit/roofit/inc/RooIntegralMorph.h
@@ -68,7 +68,7 @@ public:
     void interpolateGap(Int_t ixlo, Int_t ixhi) ;
 
     RooIntegralMorph* _self ; //
-    RooArgSet* _nset ;
+    std::unique_ptr<RooArgSet> _nset ;
     RooAbsPdf* _pdf1 ; // PDF1
     RooAbsPdf* _pdf2 ; // PDF2
     RooRealVar* _x   ; // X
@@ -77,8 +77,8 @@ public:
     RooAbsReal* _c2 ; // CDF of PDF 2
     RooAbsFunc* _cb1 ; // Binding of CDF1
     RooAbsFunc* _cb2 ; // Binding of CDF2
-    RooBrentRootFinder* _rf1 ; // ROOT finder on CDF1
-    RooBrentRootFinder* _rf2 ; // ROOT finder of CDF2 ;
+    std::unique_ptr<RooBrentRootFinder> _rf1; // ROOT finder on CDF1
+    std::unique_ptr<RooBrentRootFinder> _rf2; // ROOT finder of CDF2 ;
 
     std::vector<double> _yatX ; //
     std::vector<double> _calcX; //

--- a/roofit/roofit/src/RooIntegralMorph.cxx
+++ b/roofit/roofit/src/RooIntegralMorph.cxx
@@ -149,14 +149,14 @@ RooArgSet* RooIntegralMorph::actualObservables(const RooArgSet& /*nset*/) const
 
 RooArgSet* RooIntegralMorph::actualParameters(const RooArgSet& /*nset*/) const
 {
-  RooArgSet* par1 = pdf1.arg().getParameters(RooArgSet()) ;
-  RooArgSet* par2 = pdf2.arg().getParameters(RooArgSet()) ;
-  par1->add(*par2,true) ;
+  RooArgSet* par1 = pdf1.arg().getParameters(static_cast<RooArgSet*>(nullptr));
+  RooArgSet par2;
+  pdf2.arg().getParameters(nullptr, par2);
+  par1->add(par2,true) ;
   par1->remove(x.arg(),true,true) ;
   if (!_cacheAlpha) {
     par1->add(alpha.arg()) ;
   }
-  delete par2 ;
   return par1 ;
 }
 
@@ -185,26 +185,23 @@ void RooIntegralMorph::fillCacheObject(PdfCacheElem& cache) const
 
   if (!_cacheAlpha) {
 
-    TIterator* dIter = cache.hist()->sliceIterator((RooAbsArg&)x.arg(),RooArgSet()) ;
-    mcache.calculate(dIter) ;
-    delete dIter ;
+    std::unique_ptr<TIterator> dIter{cache.hist()->sliceIterator(const_cast<RooAbsReal&>(x.arg()),RooArgSet())};
+    mcache.calculate(dIter.get());
 
   } else {
-    TIterator* slIter = cache.hist()->sliceIterator((RooAbsArg&)alpha.arg(),RooArgSet()) ;
+    std::unique_ptr<TIterator> slIter{cache.hist()->sliceIterator(const_cast<RooAbsReal&>(alpha.arg()),RooArgSet())};
 
     double alphaSave = alpha ;
     RooArgSet alphaSet(alpha.arg()) ;
     coutP(Eval) << "RooIntegralMorph::fillCacheObject(" << GetName() << ") filling multi-dimensional cache" ;
     while(slIter->Next()) {
       alphaSet.assign(*cache.hist()->get()) ;
-      TIterator* dIter = cache.hist()->sliceIterator((RooAbsArg&)x.arg(),RooArgSet(alpha.arg())) ;
-      mcache.calculate(dIter) ;
+      std::unique_ptr<TIterator> dIter{cache.hist()->sliceIterator(const_cast<RooAbsReal&>(x.arg()),RooArgSet(alpha.arg()))};
+      mcache.calculate(dIter.get());
       ccoutP(Eval) << "." << flush;
-      delete dIter ;
     }
-    ccoutP(Eval) << endl ;
+    ccoutP(Eval) << std::endl;
 
-    delete slIter ;
     const_cast<RooIntegralMorph*>(this)->alpha = alphaSave ;
   }
 }
@@ -244,19 +241,19 @@ RooIntegralMorph::MorphCacheElem::MorphCacheElem(RooIntegralMorph& self, const R
 {
   // Mark in base class that normalization of cached pdf is invariant under pdf parameters
   _x = (RooRealVar*)self.x.absArg() ;
-  _nset = new RooArgSet(*_x) ;
+  _nset = std::make_unique<RooArgSet>(*_x);
 
   _alpha = (RooAbsReal*)self.alpha.absArg() ;
   _pdf1 = (RooAbsPdf*)(self.pdf1.absArg()) ;
   _pdf2 = (RooAbsPdf*)(self.pdf2.absArg()) ;
   _c1 = _pdf1->createCdf(*_x);
   _c2 = _pdf2->createCdf(*_x) ;
-  _cb1 = _c1->bindVars(*_x,_nset) ;
-  _cb2 = _c2->bindVars(*_x,_nset) ;
+  _cb1 = _c1->bindVars(*_x,_nset.get());
+  _cb2 = _c2->bindVars(*_x,_nset.get());
   _self = &self ;
 
-  _rf1 = new RooBrentRootFinder(*_cb1) ;
-  _rf2 = new RooBrentRootFinder(*_cb2) ;
+  _rf1 = std::make_unique<RooBrentRootFinder>(*_cb1);
+  _rf2 = std::make_unique<RooBrentRootFinder>(*_cb2);
   _ccounter = 0 ;
 
   _rf1->setTol(1e-12) ;
@@ -278,10 +275,6 @@ RooIntegralMorph::MorphCacheElem::MorphCacheElem(RooIntegralMorph& self, const R
 
 RooIntegralMorph::MorphCacheElem::~MorphCacheElem()
 {
-  delete _rf1 ;
-  delete _rf2 ;
-  // delete[] _yatX ;
-  // delete[] _calcX ;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -421,8 +414,10 @@ void RooIntegralMorph::MorphCacheElem::calculate(TIterator* dIter)
     _rf1->findRoot(x1,x1,xMax,y) ;
     _rf2->findRoot(x2,x2,xMax,y) ;
 
-    _x->setVal(x1) ; double f1x1 = _pdf1->getVal(_nset) ;
-    _x->setVal(x2) ; double f2x2 = _pdf2->getVal(_nset) ;
+    _x->setVal(x1);
+    double f1x1 = _pdf1->getVal(_nset.get());
+    _x->setVal(x2);
+    double f2x2 = _pdf2->getVal(_nset.get());
     double fbarX = f1x1*f2x2 / ( _alpha->getVal()*f2x2 + (1-_alpha->getVal())*f1x1 ) ;
 
     dIter->Next() ;

--- a/roofit/roofit/src/RooParamHistFunc.cxx
+++ b/roofit/roofit/src/RooParamHistFunc.cxx
@@ -171,7 +171,7 @@ list<double>* RooParamHistFunc::plotSamplingHint(RooAbsRealLValue& obs, double x
   }
 
   // Retrieve position of all bin boundaries
-  const RooAbsBinning* binning = lvarg->getBinningPtr(0) ;
+  const RooAbsBinning* binning = lvarg->getBinningPtr(nullptr);
   double* boundaries = binning->array() ;
 
   list<double>* hint = new list<double> ;
@@ -208,7 +208,7 @@ std::list<double>* RooParamHistFunc::binBoundaries(RooAbsRealLValue& obs, double
   }
 
   // Retrieve position of all bin boundaries
-  const RooAbsBinning* binning = lvarg->getBinningPtr(0) ;
+  const RooAbsBinning* binning = lvarg->getBinningPtr(nullptr);
   double* boundaries = binning->array() ;
 
   list<double>* hint = new list<double> ;

--- a/roofit/roofitcore/inc/RooAbsCategoryLValue.h
+++ b/roofit/roofitcore/inc/RooAbsCategoryLValue.h
@@ -16,11 +16,12 @@
 #ifndef ROO_ABS_CATEGORY_LVALUE
 #define ROO_ABS_CATEGORY_LVALUE
 
-#include "RooAbsCategory.h"
-#include "RooAbsLValue.h"
+#include <RooAbsCategory.h>
+#include <RooAbsLValue.h>
+
 #include <list>
 #include <string>
-#include <utility>
+#include <utility> // for std::pair
 
 class RooAbsCategoryLValue : public RooAbsCategory, public RooAbsLValue {
 public:
@@ -30,7 +31,7 @@ public:
   }
   RooAbsCategoryLValue(const char *name, const char *title);
   RooAbsCategoryLValue(const RooAbsCategoryLValue& other, const char* name=nullptr) ;
-  ~RooAbsCategoryLValue() override;
+  ~RooAbsCategoryLValue() override = default;
 
   // Value modifiers
   ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
@@ -335,11 +335,11 @@ double RooAbsAnaConvPdf::evaluate() const
     auto conv = static_cast<RooAbsPdf*>(convArg);
     double coef = coefficient(index++) ;
     if (coef!=0.) {
-      double c = conv->getVal(0) ;
+      double c = conv->getVal(nullptr);
       double r = coef ;
       cxcoutD(Eval) << "RooAbsAnaConvPdf::evaluate(" << GetName() << ") val += coef*conv [" << index-1 << "/"
           << _convSet.getSize() << "] coef = " << r << " conv = " << c << endl ;
-      result += conv->getVal(0)*coef ;
+      result += conv->getVal(nullptr)*coef ;
     } else {
       cxcoutD(Eval) << "RooAbsAnaConvPdf::evaluate(" << GetName() << ") [" << index-1 << "/" << _convSet.getSize() << "] coef = 0" << endl ;
     }

--- a/roofit/roofitcore/src/RooAbsCategoryLValue.cxx
+++ b/roofit/roofitcore/src/RooAbsCategoryLValue.cxx
@@ -28,13 +28,11 @@ of the value. RooAbsCategoryLValue may be derived, but its functional relation
 to other RooAbsArgs must be invertible.
 */
 
-#include "RooAbsCategoryLValue.h"
+#include <RooAbsCategoryLValue.h>
 
-#include "RooArgSet.h"
-#include "RooRandom.h"
-#include "RooMsgService.h"
+#include <RooRandom.h>
+#include <RooMsgService.h>
 
-using namespace std;
 
 ClassImp(RooAbsCategoryLValue);
 
@@ -57,15 +55,6 @@ RooAbsCategoryLValue::RooAbsCategoryLValue(const char *name, const char *title) 
 
 RooAbsCategoryLValue::RooAbsCategoryLValue(const RooAbsCategoryLValue& other, const char* name) :
   RooAbsCategory(other, name), RooAbsLValue(other)
-{
-}
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Destructor
-
-RooAbsCategoryLValue::~RooAbsCategoryLValue()
 {
 }
 
@@ -176,7 +165,7 @@ void RooAbsCategoryLValue::setBin(Int_t ibin, const char* rangeName)
   // Check validity of ibin
   if (ibin<0 || ibin>=numBins(rangeName)) {
     coutE(InputArguments) << "RooAbsCategoryLValue::setBin(" << GetName() << ") ERROR: bin index " << ibin
-           << " is out of range (0," << numBins(rangeName)-1 << ")" << endl ;
+           << " is out of range (0," << numBins(rangeName)-1 << ")" << std::endl;
     return ;
   }
 
@@ -187,11 +176,11 @@ void RooAbsCategoryLValue::setBin(Int_t ibin, const char* rangeName)
   }
 
   // Retrieve state corresponding to bin
-  const auto& type = getOrdinal(ibin);
-  assert(type.second != std::numeric_limits<value_type>::min());
+  value_type val = getOrdinal(ibin).second;
+  assert(val != std::numeric_limits<value_type>::min());
 
   // Set value to requested state
-  setIndex(type.second);
+  setIndex(val);
 }
 
 

--- a/roofit/roofitcore/src/RooAbsCategoryLValue.cxx
+++ b/roofit/roofitcore/src/RooAbsCategoryLValue.cxx
@@ -180,7 +180,7 @@ void RooAbsCategoryLValue::setBin(Int_t ibin, const char* rangeName)
     return ;
   }
 
-  if (rangeName) {
+  if (rangeName && getBinningPtr(rangeName)) {
     coutF(InputArguments) << "RooAbsCategoryLValue::setBin(" << GetName() << ") ERROR: ranges not implemented"
         " for setting bins in categories." << std::endl;
     throw std::logic_error("Ranges not implemented for setting bins in categories.");

--- a/roofit/roofitcore/src/RooAbsData.cxx
+++ b/roofit/roofitcore/src/RooAbsData.cxx
@@ -933,7 +933,7 @@ double RooAbsData::moment(const RooRealVar& var, double order, double offset, co
   // Setup RooFormulaVar for cutSpec if it is present
   std::unique_ptr<RooFormula> select;
   if (cutSpec) {
-    select.reset(new RooFormula("select",cutSpec,*get()));
+    select = std::make_unique<RooFormula>("select",cutSpec,*get());
   }
 
 

--- a/roofit/roofitcore/src/RooBinIntegrator.cxx
+++ b/roofit/roofitcore/src/RooBinIntegrator.cxx
@@ -96,8 +96,8 @@ RooBinIntegrator::RooBinIntegrator(const RooAbsFunc& function, int numBins):
   const bool useBatchMode = false;
 
   if (useBatchMode) {
-    _evalData.reset(new RooBatchCompute::RunContext());
-    _evalDataOrig.reset(new RooBatchCompute::RunContext());
+    _evalData = std::make_unique<RooBatchCompute::RunContext>();
+    _evalDataOrig = std::make_unique<RooBatchCompute::RunContext>();
   }
 
   for (UInt_t i=0 ; i<_function->getDimension() ; i++) {

--- a/roofit/roofitcore/src/RooBinSamplingPdf.cxx
+++ b/roofit/roofitcore/src/RooBinSamplingPdf.cxx
@@ -276,12 +276,12 @@ std::list<double>* RooBinSamplingPdf::plotSamplingHint(RooAbsRealLValue& obs, do
 /// \note When RooBinSamplingPdf is loaded from files, integrator options will fall back to the default values.
 std::unique_ptr<ROOT::Math::IntegratorOneDim>& RooBinSamplingPdf::integrator() const {
   if (!_integrator) {
-    _integrator.reset(new ROOT::Math::IntegratorOneDim(*this,
+    _integrator = std::make_unique<ROOT::Math::IntegratorOneDim>(*this,
         ROOT::Math::IntegrationOneDim::kADAPTIVE, // GSL Integrator. Will really get it only if MathMore enabled.
         -1., _relEpsilon, // Abs epsilon = default, rel epsilon set by us.
         0, // We don't limit the sub-intervals. Steer run time via _relEpsilon.
         2 // This should read ROOT::Math::Integration::kGAUSS21, but this is in MathMore, so we cannot include it here.
-        ));
+        );
   }
 
   return _integrator;

--- a/roofit/roofitcore/src/RooCategory.cxx
+++ b/roofit/roofitcore/src/RooCategory.cxx
@@ -103,7 +103,7 @@ std::map<std::string, std::weak_ptr<RooCategory::RangeMap_t>> RooCategory::_shar
 
 RooCategory::RooCategory()
 {
-  TRACE_CREATE
+  TRACE_CREATE;
 }
 
 
@@ -112,11 +112,11 @@ RooCategory::RooCategory()
 /// Constructor. Types must be defined using defineType() before variable can be used
 RooCategory::RooCategory(const char *name, const char *title) :
   RooAbsCategoryLValue(name,title),
-  _ranges(new RangeMap_t())
+  _ranges{std::make_unique<RangeMap_t>()}
 {
   setValueDirty() ;
   setShapeDirty() ;
-  TRACE_CREATE
+  TRACE_CREATE;
 }
 
 
@@ -127,7 +127,7 @@ RooCategory::RooCategory(const char *name, const char *title) :
 /// \param[in] allowedStates Map of allowed states. Pass e.g. `{ {"0Lep", 0}, {"1Lep:, 1} }`
 RooCategory::RooCategory(const char* name, const char* title, const std::map<std::string, int>& allowedStates) :
   RooAbsCategoryLValue(name,title),
-  _ranges(new RangeMap_t())
+  _ranges{std::make_unique<RangeMap_t>()}
 {
   defineTypes(allowedStates);
 }
@@ -141,7 +141,7 @@ RooCategory::RooCategory(const RooCategory& other, const char* name) :
   RooAbsCategoryLValue(other, name),
   _ranges(other._ranges)
 {
-  TRACE_CREATE
+  TRACE_CREATE;
 }
 
 
@@ -150,7 +150,7 @@ RooCategory::RooCategory(const RooCategory& other, const char* name) :
 
 RooCategory::~RooCategory()
 {
-  TRACE_DESTROY
+  TRACE_DESTROY;
 }
 
 
@@ -487,7 +487,7 @@ void RooCategory::installLegacySharedProp(const RooCategorySharedProperties* pro
     _ranges = std::move(existingObject);
   } else {
     // This range is unknown, make a new object
-    _ranges = std::make_shared<std::map<std::string, std::vector<value_type>>>();
+    _ranges = std::make_unique<std::map<std::string, std::vector<value_type>>>();
     auto& rangesMap = *_ranges;
 
     // Copy the data:
@@ -521,16 +521,12 @@ void RooCategory::installSharedRange(std::unique_ptr<RangeMap_t>&& rangeMap) {
     if (a.size() != b.size())
       return false;
 
-    auto vecsEqual = [](const std::vector<RooAbsCategory::value_type>& aa, const std::vector<RooAbsCategory::value_type>& bb) {
-      return aa.size() == bb.size() && std::equal(aa.begin(), aa.end(), bb.begin());
-    };
-
     for (const auto& itemA : a) {
       const auto itemB = b.find(itemA.first);
       if (itemB == b.end())
         return false;
 
-      if (!vecsEqual(itemA.second, itemB->second))
+      if (itemA.second != itemB->second)
         return false;
     }
 

--- a/roofit/roofitcore/src/RooCompositeDataStore.cxx
+++ b/roofit/roofitcore/src/RooCompositeDataStore.cxx
@@ -472,7 +472,7 @@ void RooCompositeDataStore::dump()
 /// (even if the weight is constant). Then, it returns a span.
 RooSpan<const double> RooCompositeDataStore::getWeightBatch(std::size_t first, std::size_t len) const {
   if (!_weightBuffer) {
-    _weightBuffer.reset(new std::vector<double>());
+    _weightBuffer = std::make_unique<std::vector<double>>();
     _weightBuffer->reserve(len);
 
     for (std::size_t i = 0; i < static_cast<std::size_t>(numEntries()); ++i) {

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -797,7 +797,7 @@ void RooDataHist::initialize(const char* binningName, bool fillTree)
     assert(lvarg);
     _lvvars.push_back(lvarg);
 
-    const RooAbsBinning* binning = lvarg->getBinningPtr(0);
+    const RooAbsBinning* binning = lvarg->getBinningPtr(nullptr);
     _lvbins.emplace_back(binning ? binning->clone() : nullptr);
   }
 

--- a/roofit/roofitcore/src/RooDataProjBinding.cxx
+++ b/roofit/roofitcore/src/RooDataProjBinding.cxx
@@ -161,17 +161,17 @@ RooSpan<const double> RooDataProjBinding::getValues(std::vector<RooSpan<const do
   assert(isValid());
 
   if (!_batchBuffer)
-    _batchBuffer.reset(new std::vector<double>());
+    _batchBuffer = std::make_unique<std::vector<double>>();
   _batchBuffer->resize(coordinates.front().size());
 
-  std::unique_ptr<double[]> xVec( new double[coordinates.size()] );
+  std::vector<double> xVec(coordinates.size());
 
   for (std::size_t i=0; i < coordinates.front().size(); ++i) {
     for (unsigned int dim=0; dim < coordinates.size(); ++dim) {
-      xVec.get()[dim] = coordinates[dim][i];
+      xVec[dim] = coordinates[dim][i];
     }
 
-    (*_batchBuffer)[i] = this->operator()(xVec.get());
+    (*_batchBuffer)[i] = this->operator()(xVec.data());
   }
 
   return {*_batchBuffer};

--- a/roofit/roofitcore/src/RooFormula.cxx
+++ b/roofit/roofitcore/src/RooFormula.cxx
@@ -232,13 +232,13 @@ RooFormula::RooFormula(const RooFormula& other, const char* name) :
   _origList.add(other._origList);
   _isCategory = findCategoryServers(_origList);
 
-  TFormula* newTF = nullptr;
+  std::unique_ptr<TFormula> newTF;
   if (other._tFormula) {
-    newTF = new TFormula(*other._tFormula);
+    newTF = std::make_unique<TFormula>(*other._tFormula);
     newTF->SetName(GetName());
   }
 
-  _tFormula.reset(newTF);
+  _tFormula = std::move(newTF);
 }
 
 

--- a/roofit/roofitcore/src/RooFormulaVar.cxx
+++ b/roofit/roofitcore/src/RooFormulaVar.cxx
@@ -77,9 +77,9 @@ RooFormulaVar::RooFormulaVar(const char *name, const char *title, const char* in
   _actualVars.add(dependents) ;
 
   if (_actualVars.empty()) {
-    _value = traceEval(0);
+    _value = traceEval(nullptr);
   } else {
-    _formula.reset(new RooFormula(GetName(), _formExpr, _actualVars, checkVariables));
+    _formula = std::make_unique<RooFormula>(GetName(), _formExpr, _actualVars, checkVariables);
     _formExpr = _formula->formulaString().c_str();
   }
 }
@@ -103,7 +103,7 @@ RooFormulaVar::RooFormulaVar(const char *name, const char *title, const RooArgLi
   if (_actualVars.empty()) {
     _value = traceEval(0);
   } else {
-    _formula.reset(new RooFormula(GetName(), _formExpr, _actualVars, checkVariables));
+    _formula = std::make_unique<RooFormula>(GetName(), _formExpr, _actualVars, checkVariables);
     _formExpr = _formula->formulaString().c_str();
   }
 }

--- a/roofit/roofitcore/src/RooHistFunc.cxx
+++ b/roofit/roofitcore/src/RooHistFunc.cxx
@@ -394,7 +394,7 @@ std::list<double>* RooHistFunc::binBoundaries(RooAbsRealLValue& obs, double xlo,
   }
 
   // Retrieve position of all bin boundaries
-  const RooAbsBinning* binning = lvarg->getBinningPtr(0) ;
+  const RooAbsBinning* binning = lvarg->getBinningPtr(nullptr);
   double* boundaries = binning->array() ;
 
   auto hint = new std::list<double> ;

--- a/roofit/roofitcore/src/RooHistPdf.cxx
+++ b/roofit/roofitcore/src/RooHistPdf.cxx
@@ -471,7 +471,7 @@ std::list<double>* RooHistPdf::binBoundaries(RooAbsRealLValue& obs, double xlo, 
   }
 
   // Retrieve position of all bin boundaries
-  const RooAbsBinning* binning = lvarg->getBinningPtr(0) ;
+  const RooAbsBinning* binning = lvarg->getBinningPtr(nullptr);
   double* boundaries = binning->array() ;
 
   auto hint = new std::list<double> ;

--- a/roofit/roofitcore/src/RooNLLVar.cxx
+++ b/roofit/roofitcore/src/RooNLLVar.cxx
@@ -377,7 +377,7 @@ RooNLLVar::ComputeResult RooNLLVar::computeBatchedFunc(const RooAbsPdf *pdfClone
   // Holding on to this struct in between function calls will make sure that the memory
   // is only allocated once.
   if (!evalData) {
-    evalData.reset(new RooBatchCompute::RunContext);
+    evalData = std::make_unique<RooBatchCompute::RunContext>();
   }
   evalData->clear();
   evalData->spans = dataClone->getBatches(firstEvent, nEvents);

--- a/roofit/roofitcore/src/RooRealAnalytic.cxx
+++ b/roofit/roofitcore/src/RooRealAnalytic.cxx
@@ -53,7 +53,7 @@ RooSpan<const double> RooRealAnalytic::getValues(std::vector<RooSpan<const doubl
   _ncall += coordinates.front().size();
 
   if (!_batchBuffer)
-    _batchBuffer.reset(new std::vector<double>());
+    _batchBuffer = std::make_unique<std::vector<double>>();
   _batchBuffer->resize(coordinates.front().size());
   RooSpan<double> results(*_batchBuffer);
 

--- a/roofit/roofitcore/src/RooRealBinding.cxx
+++ b/roofit/roofitcore/src/RooRealBinding.cxx
@@ -212,7 +212,7 @@ RooSpan<const double> RooRealBinding::getValues(std::vector<RooSpan<const double
 
   // Use _evalData to hold on to memory between integration calls
   if (!_evalData) {
-    _evalData.reset(new RooBatchCompute::RunContext());
+    _evalData = std::make_unique<RooBatchCompute::RunContext>();
   } else {
     _evalData->clear();
   }

--- a/roofit/roofitcore/src/RooRealVar.cxx
+++ b/roofit/roofitcore/src/RooRealVar.cxx
@@ -1227,7 +1227,7 @@ void RooRealVar::Streamer(TBuffer &R__b)
       R__b >> fitMin;
       R__b >> fitMax;
       R__b >> fitBins;
-      _binning.reset(new RooUniformBinning(fitMin,fitMax,fitBins));
+      _binning = std::make_unique<RooUniformBinning>(fitMin,fitMax,fitBins);
     }
     R__b >> _error;
     R__b >> _asymErrLo;

--- a/roofit/roofitcore/src/RooTreeDataStore.cxx
+++ b/roofit/roofitcore/src/RooTreeDataStore.cxx
@@ -1202,7 +1202,7 @@ RooSpan<const double> RooTreeDataStore::getWeightBatch(std::size_t first, std::s
   }
 
   if (!_weightBuffer) {
-    _weightBuffer.reset(new std::vector<double>());
+    _weightBuffer = std::make_unique<std::vector<double>>();
     _weightBuffer->reserve(len);
 
     for (std::size_t i = 0; i < GetEntries(); ++i) {

--- a/roofit/roostats/src/BayesianCalculator.cxx
+++ b/roofit/roostats/src/BayesianCalculator.cxx
@@ -383,7 +383,7 @@ public:
          fIntegratorOneDim->Options().Print(ooccoutD(nullptr,NumIntegration) );
       }
       else if (fXmin.size() > 1) { // multiDim case
-         fIntegratorMultiDim.reset(new ROOT::Math::IntegratorMultiDim(ROOT::Math::IntegratorMultiDim::GetType(integType) ) );
+         fIntegratorMultiDim = std::make_unique<ROOT::Math::IntegratorMultiDim>(ROOT::Math::IntegratorMultiDim::GetType(integType));
          fIntegratorMultiDim->SetFunction(fLikelihood, fXmin.size());
          ROOT::Math::IntegratorMultiDimOptions opt = fIntegratorMultiDim->Options();
          if (niter > 0) {

--- a/roofit/roostats/src/HypoTestInverter.cxx
+++ b/roofit/roostats/src/HypoTestInverter.cxx
@@ -355,9 +355,9 @@ HypoTestInverter::HypoTestInverter( RooAbsData& data, ModelConfig &sbModel, Mode
    fNBins(0), fXmin(1), fXmax(1),
    fNumErr(0)
 {
-   if(fCalcType==kFrequentist) fHC.reset(new FrequentistCalculator(data, bModel, sbModel));
-   if(fCalcType==kHybrid) fHC.reset( new HybridCalculator(data, bModel, sbModel)) ;
-   if(fCalcType==kAsymptotic) fHC.reset( new AsymptoticCalculator(data, bModel, sbModel));
+   if(fCalcType==kFrequentist) fHC = std::make_unique<FrequentistCalculator>(data, bModel, sbModel);
+   if(fCalcType==kHybrid) fHC = std::make_unique<HybridCalculator>(data, bModel, sbModel);
+   if(fCalcType==kAsymptotic) fHC = std::make_unique<AsymptoticCalculator>(data, bModel, sbModel);
    fCalculator0 = fHC.get();
    // get scanned variable
    if (!fScannedVariable) {
@@ -795,7 +795,7 @@ bool HypoTestInverter::RunLimit(double &limit, double &limitErr, double absAccur
 
   TF1 expoFit("expoFit","[0]*exp([1]*(x-[2]))", rMin, rMax);
 
-  fLimitPlot.reset(new TGraphErrors());
+  fLimitPlot = std::make_unique<TGraphErrors>();
 
   if (fVerbose > 0) std::cout << "Search for upper limit to the limit" << std::endl;
   for (int tries = 0; tries < 6; ++tries) {

--- a/roofit/roostats/src/HypoTestResult.cxx
+++ b/roofit/roostats/src/HypoTestResult.cxx
@@ -197,7 +197,7 @@ void HypoTestResult::Append(const HypoTestResult* other) {
    if( fFitInfo ) {
       if( other->GetFitInfo() ) fFitInfo->append( *other->GetFitInfo() );
    }else{
-      if( other->GetFitInfo() ) fFitInfo.reset(new RooDataSet( *other->GetFitInfo() ));
+      if( other->GetFitInfo() ) fFitInfo = std::make_unique<RooDataSet>( *other->GetFitInfo());
    }
 
    // if no data is present use the other HypoTestResult's data


### PR DESCRIPTION
In `RooAbsCategoryLValue::setBin()`, there is a check for passing a
named binning, because the function doesn't support named binnings.

However, if a binning with that name doesn't exist, it is fine to not
error out, because the default range is used.

This supports the fit in this forum post:
https://root-forum.cern.ch/t/roosimultaneous-and-roofftconvpdf/53606

There are also two additional commits with some code modernization as usual.

