### PR TITLE
[tmva] Speed up TMVA CNN and RNN tutorials

### DIFF
--- a/tutorials/tmva/TMVA_CNN_Classification.C
+++ b/tutorials/tmva/TMVA_CNN_Classification.C
@@ -107,7 +107,16 @@ void MakeImagesTree(int n, int nh, int nw)
    f.Close();
 }
 
-void TMVA_CNN_Classification(std::vector<bool> opt = {1, 1, 1, 1, 1})
+/// @brief Run the TMVA CNN Classification example
+/// @param nevts : number of signal/background events. Use by default a low value (1000)
+///                but increase to at least 5000 to get a good result
+/// @param opt :   vector of bool with method used (default all on if available). The order is:
+///                   - TMVA CNN
+///                   - Keras CNN
+///                   - TMVA DNN
+///                   - TMVA BDT
+///                   - PyTorch CNN
+void TMVA_CNN_Classification(int nevts = 1000, std::vector<bool> opt = {1, 1, 1, 1, 1})
 {
 
    bool useTMVACNN = (opt.size() > 0) ? opt[0] : false;
@@ -125,17 +134,17 @@ void TMVA_CNN_Classification(std::vector<bool> opt = {1, 1, 1, 1, 1})
 
    bool writeOutputFile = true;
 
-   int num_threads = 0;  // use default threads
+   int num_threads = 4;  // use by default 4 threads if value is not set before
+   // switch off MT in OpenBLAS to avoid conflict with tbb
+   gSystem->Setenv("OMP_NUM_THREADS", "1");
 
    TMVA::Tools::Instance();
 
    // do enable MT running
    if (num_threads >= 0) {
       ROOT::EnableImplicitMT(num_threads);
-      if (num_threads > 0) gSystem->Setenv("OMP_NUM_THREADS", TString::Format("%d",num_threads));
    }
-   else
-      gSystem->Setenv("OMP_NUM_THREADS", "1");
+
 
    std::cout << "Running with nthreads  = " << ROOT::GetThreadPoolSize() << std::endl;
 
@@ -161,7 +170,7 @@ void TMVA_CNN_Classification(std::vector<bool> opt = {1, 1, 1, 1, 1})
     The factory is the major TMVA object you have to interact with. Here is the list of parameters you need to pass
 
     - The first argument is the base of the name of all the output
-    weightfiles in the directory weight/ that will be created with the
+    weight files in the directory weight/ that will be created with the
     method parameters
 
     - The second argument is the output file for the training results
@@ -208,7 +217,7 @@ void TMVA_CNN_Classification(std::vector<bool> opt = {1, 1, 1, 1, 1})
 
    // if file does not exists create it
    if (!fileExist) {
-      MakeImagesTree(5000, 16, 16);
+      MakeImagesTree(nevts, 16, 16);
    }
 
    // TString inputFileName = "tmva_class_example.root";
@@ -289,7 +298,7 @@ void TMVA_CNN_Classification(std::vector<bool> opt = {1, 1, 1, 1, 1})
    // Boosted Decision Trees
    if (useTMVABDT) {
       factory.BookMethod(loader, TMVA::Types::kBDT, "BDT",
-                         "!V:NTrees=400:MinNodeSize=2.5%:MaxDepth=2:BoostType=AdaBoost:AdaBoostBeta=0.5:"
+                         "!V:NTrees=200:MinNodeSize=2.5%:MaxDepth=2:BoostType=AdaBoost:AdaBoostBeta=0.5:"
                          "UseBaggedBoost:BaggedSampleFraction=0.5:SeparationType=GiniIndex:nCuts=20");
    }
    /**

--- a/tutorials/tmva/TMVA_CNN_Classification.py
+++ b/tutorials/tmva/TMVA_CNN_Classification.py
@@ -25,6 +25,9 @@
 
 import ROOT
 
+#switch off MT in OpenMP (BLAS)
+ROOT.gSystem.Setenv("OMP_NUM_THREADS", "1")
+
 TMVA = ROOT.TMVA
 TFile = ROOT.TFile
 
@@ -105,6 +108,7 @@ def MakeImagesTree(n, nh, nw):
 hasGPU = ROOT.gSystem.GetFromPipe("root-config --has-tmva-gpu") == "yes"
 hasCPU = ROOT.gSystem.GetFromPipe("root-config --has-tmva-cpu") == "yes"
 
+nevt = 1000    # use a larger value to get better results
 opt = [1, 1, 1, 1, 1]
 useTMVACNN = opt[0] if len(opt) > 0  else False
 useKerasCNN = opt[1] if len(opt) > 1 else False
@@ -141,17 +145,13 @@ if not useTMVACNN:
 
 writeOutputFile = True
 
-num_threads = 0  # use default threads
+num_threads = 4  # use default threads
 max_epochs = 10  # maximum number of epochs used for training
 
 
 # do enable MT running
 if num_threads >= 0:
     ROOT.EnableImplicitMT(num_threads)
-    if (num_threads > 0) :
-        ROOT.gSystem.Setenv("OMP_NUM_THREADS", str(num_threads))
-else:
-    ROOT.gSystem.Setenv("OMP_NUM_THREADS", "1")
 
 print("Running with nthreads  = ", ROOT.GetThreadPoolSize())
 
@@ -218,7 +218,7 @@ inputFileName = "images_data_16x16.root"
 
 # if the input file does not exist create it
 if ROOT.gSystem.AccessPathName(inputFileName):
-    MakeImagesTree(5000, 16, 16)
+    MakeImagesTree(nevt, 16, 16)
 
 inputFile = TFile.Open(inputFileName)
 if inputFile is None:

--- a/tutorials/tmva/TMVA_RNN_Classification.C
+++ b/tutorials/tmva/TMVA_RNN_Classification.C
@@ -136,13 +136,14 @@ void MakeTimeData(int n, int ntime, int ndim )
    }
 }
 /// macro for performing a classification using a Recurrent Neural Network
+/// @param nevts = 2000  Number of events used. (increase for better classification results)
 /// @param use_type
 ///    use_type = 0    use Simple RNN network
 ///    use_type = 1    use LSTM network
 ///    use_type = 2    use GRU
 ///    use_type = 3    build 3 different networks with RNN, LSTM and GRU
 
-void TMVA_RNN_Classification(int use_type = 1)
+void TMVA_RNN_Classification(int nevts = 2000, int use_type = 1)
 {
 
    const int ninput = 30;
@@ -150,7 +151,7 @@ void TMVA_RNN_Classification(int use_type = 1)
    const int batchSize = 100;
    const int maxepochs = 20;
 
-   int nTotEvts = 10000; // total events to be generated for signal or background
+   int nTotEvts = nevts; // total events to be generated for signal or background
 
    bool useKeras = true;
 
@@ -190,14 +191,12 @@ void TMVA_RNN_Classification(int use_type = 1)
    useKeras = false;
 #endif
 
-   int num_threads = 0;   // use by default all threads
+   int num_threads = 4;   // use by default all threads
+   gSystem->Setenv("OMP_NUM_THREADS", "1"); // switch off MT in OpenBLAS
    // do enable MT running
    if (num_threads >= 0) {
       ROOT::EnableImplicitMT(num_threads);
-      if (num_threads > 0) gSystem->Setenv("OMP_NUM_THREADS", TString::Format("%d",num_threads));
    }
-   else
-      gSystem->Setenv("OMP_NUM_THREADS", "1");
 
    TMVA::Config::Instance();
 

--- a/tutorials/tmva/TMVA_RNN_Classification.py
+++ b/tutorials/tmva/TMVA_RNN_Classification.py
@@ -22,6 +22,16 @@
 
 import ROOT
 
+num_threads = 4  # use max 4 threads
+# do enable MT running
+if ROOT.gSystem.GetFromPipe("root-config --has-imt") == "yes":
+    ROOT.EnableImplicitMT(num_threads)
+    ROOT.gSystem.Setenv("OMP_NUM_THREADS", "1")  # switch OFF MT in OpenBLAS
+    print("Running with nthreads  = {}".format(ROOT.GetThreadPoolSize()))
+else:
+    print("Running in serail mode since ROOT does not support MT")
+
+
 TMVA = ROOT.TMVA
 TFile = ROOT.TFile
 
@@ -141,7 +151,7 @@ ntime = 10
 batchSize = 100
 maxepochs = 10
 
-nTotEvts = 10000  # total events to be generated for signal or background
+nTotEvts = 2000  # total events to be generated for signal or background
 
 useKeras = True
 
@@ -184,21 +194,7 @@ if ROOT.gSystem.GetFromPipe("root-config --has-tmva-pymva") == "yes":
 else:
     useKeras = False
 
-num_threads = 0  # use by default all threads
-# do enable MT running
-if ROOT.gSystem.GetFromPipe("root-config --has-imt") == "yes":
-    if num_threads >= 0:
-        ROOT.EnableImplicitMT(num_threads)
-        if num_threads > 0:
-            ROOT.gSystem.Setenv("OMP_NUM_THREADS", str(num_threads))
-    else:
-        ROOT.gSystem.Setenv("OMP_NUM_THREADS", "1")
 
-
-    print("Running with nthreads  = {}".format(ROOT.GetThreadPoolSize()))
-
-else:
-    print("Running in serail mode since ROOT does not support MT")
 
 inputFileName = "time_data_t10_d30.root"
 


### PR DESCRIPTION
Run tutorials with a maximum of 4 threads to avoid MT problems on some machines. Disable also OpenMP when running in MT in ROOT

Reduce also by a factor of 5 the number of input events

