### PR TITLE
Add a missing %PATH% on Windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -540,7 +540,7 @@ add_custom_target(hsimple ALL DEPENDS tutorials/hsimple.root)
 add_dependencies(hsimple onepcm)
 if(WIN32)
   add_custom_command(OUTPUT tutorials/hsimple.root
-                     COMMAND set PATH=${CMAKE_RUNTIME_OUTPUT_DIRECTORY} &&
+                     COMMAND set PATH=${CMAKE_RUNTIME_OUTPUT_DIRECTORY};%PATH% &&
                              set ROOTIGNOREPREFIX=1 && set ROOT_HIST=0 &&
                              $<TARGET_FILE:root.exe> -l -q -b -n -x hsimple.C -e return
                      WORKING_DIRECTORY tutorials


### PR DESCRIPTION
Final fix for the issue reported on the Forum with Miniconda and Python 10 https://root-forum.cern.ch/t/windows-10-root-6-28-build-with-miniconda-python-3-10-crashed/53554/11