### PR TITLE
[ci] Add test summary to pull requests

### DIFF
--- a/.github/workflows/root-ci-config/build_root.py
+++ b/.github/workflows/root-ci-config/build_root.py
@@ -196,7 +196,7 @@ def test(workdir: str, shell_log: str, extra_ctest_flags: str):
 
     result, shell_log = subprocess_with_log(f"""
         cd '{workdir}/build'
-        ctest -j{os.cpu_count()} {extra_ctest_flags}
+        ctest -j{os.cpu_count()} --output-junit TestResults.xml {extra_ctest_flags}
     """, shell_log)
     
     if result != 0:

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -1,5 +1,5 @@
 
-name: 'Rebase and Build'
+name: 'ROOT CI'
 
 on:
   schedule:

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -145,3 +145,19 @@ jobs:
                     --base_ref       ${{ github.ref_name }}
                     --repository     ${{ github.server_url }}/${{ github.repository }}
               "
+        
+      - name: Upload test results
+        uses: actions/upload-artifact@v3
+        with:
+          name:  Test Results ${{ matrix.image }} ${{ matrix.config }}
+          path: /tmp/workspace/build/TestResults.xml
+
+  event_file:
+    name: "Upload Event Payload"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Upload
+      uses: actions/upload-artifact@v3
+      with:
+        name: Event File
+        path: ${{ github.event_path }}

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -79,7 +79,7 @@ jobs:
 
     container:
       image: registry.cern.ch/root-ci/${{ matrix.image }}:buildready
-      options: '--security-opt label=disable'
+      options: '--security-opt label=disable --rm'
       env:
         OS_APPLICATION_CREDENTIAL_ID: '7f5b64a265244623a3a933308569bdba'
         OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}

--- a/.github/workflows/test-result-comment.yml
+++ b/.github/workflows/test-result-comment.yml
@@ -1,0 +1,47 @@
+
+name: Test Summary PR comment
+
+on:
+  workflow_run:
+    # do NOT use quotes: https://stackoverflow.com/a/72551795/17876693
+    workflows: [ROOT CI]
+    types:
+      - completed
+permissions: {}
+
+jobs:
+  comment-test-results:
+    name: Publish Test Results
+
+    if: github.event.workflow_run.event == 'pull_request'
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      checks: write
+      pull-requests: write
+      actions: read
+
+    steps:
+      - name: Download and Extract Artifacts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+           mkdir -p artifacts && cd artifacts
+
+           artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+
+           gh api --paginate "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+           do
+             IFS=$'\t' read name url <<< "$artifact"
+             gh api $url > "$name.zip"
+             unzip -d "$name" "$name.zip"
+           done
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/Event File/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: "artifacts/**/*.xml"


### PR DESCRIPTION
# This Pull request:
- (https://github.com/root-project/root/issues/12186) Adds test summaries to builds. Writes comments on pull-requests: [example](https://github.com/olemorud/root/pull/9)
- Adds the `--rm` flag to containers as a temporary fix for the disk space problem (puppet fix coming soon)

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

[skip-ci] 