### PR TITLE
[webwindow] use `window.resizeTo` function for changing web browser size

### DIFF
--- a/gui/canvaspainter/src/RCanvasPainter.cxx
+++ b/gui/canvaspainter/src/RCanvasPainter.cxx
@@ -580,8 +580,13 @@ void RCanvasPainter::ProcessData(unsigned connid, const std::string &arg)
       } else {
          R__LOG_ERROR(CanvasPainerLog()) << "Fail to parse RDrawableRequest";
       }
+   } else if (check_header("RESIZED:")) {
+      auto sz = TBufferJSON::FromJSON<std::vector<int>>(cdata);
+      if (sz && sz->size() == 2) {
+         fCanvas.SetWidth(sz->at(0));
+         fCanvas.SetHeight(sz->at(1));
+      }
    } else if (check_header("CLEAR")) {
-
       fCanvas.Wipe();
       fCanvas.Modified();
    } else {

--- a/gui/webdisplay/inc/ROOT/RWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindow.hxx
@@ -150,8 +150,8 @@ private:
    std::thread fWindowThrd;                         ///<! special thread for that window
    std::queue<QueueEntry> fInputQueue;              ///<! input queue for all callbacks
    std::mutex fInputQueueMutex;                     ///<! mutex to protect input queue
-   unsigned fWidth{0};                              ///<! initial window width when displayed
-   unsigned fHeight{0};                             ///<! initial window height when displayed
+   unsigned fWidth{0}, fHeight{0};                  ///<! initial window width and height when displayed, zeros are ignored
+   int fX{-1}, fY{-1};                              ///<! initial window position, -1 ignored
    float fOperationTmout{50.};                      ///<! timeout in seconds to perform synchronous operation, default 50s
    std::string fClientVersion;                      ///<! configured client version, used as prefix in scripts URL
    std::string fProtocolFileName;                   ///<! local file where communication protocol will be written
@@ -241,6 +241,13 @@ public:
       fHeight = height;
    }
 
+   /// Set window position. Will be applied if supported by used web display (like CEF or Chromium)
+   void SetPosition(unsigned x, unsigned y)
+   {
+      fX = x;
+      fY = y;
+   }
+
    /////////////////////////////////////////////////////////////////////////
    /// returns configured window width (0 - default)
    /// actual window width can be different
@@ -249,6 +256,14 @@ public:
    /////////////////////////////////////////////////////////////////////////
    /// returns configured window height (0 - default)
    unsigned GetHeight() const { return fHeight; }
+
+   /////////////////////////////////////////////////////////////////////////
+   /// returns configured window X position (-1 - default)
+   int GetX() const { return fX; }
+
+   /////////////////////////////////////////////////////////////////////////
+   /// returns configured window Y position (-1 - default)
+   int GetY() const { return fY; }
 
    void SetConnLimit(unsigned lmt = 0);
 

--- a/gui/webdisplay/src/RWebWindowWSHandler.hxx
+++ b/gui/webdisplay/src/RWebWindowWSHandler.hxx
@@ -92,6 +92,8 @@ protected:
          more_args.append("credits: "s + std::to_string(credits) + ","s);
       if ((fWindow.GetWidth() > 0) && (fWindow.GetHeight() > 0))
          more_args.append("winW:"s + std::to_string(fWindow.GetWidth()) + ",winH:"s + std::to_string(fWindow.GetHeight()) + ","s);
+      if ((fWindow.GetX() >= 0) && (fWindow.GetY() >= 0))
+         more_args.append("winX:"s + std::to_string(fWindow.GetX()) + ",winY:"s + std::to_string(fWindow.GetY()) + ","s);
       auto user_args = fWindow.GetUserArgs();
       if (!user_args.empty())
          more_args.append("user_args: "s + user_args + ","s);

--- a/gui/webdisplay/src/RWebWindowWSHandler.hxx
+++ b/gui/webdisplay/src/RWebWindowWSHandler.hxx
@@ -90,6 +90,8 @@ protected:
       int credits = gEnv->GetValue("WebGui.ConnCredits", 10);
       if ((credits > 0) && (credits != 10))
          more_args.append("credits: "s + std::to_string(credits) + ","s);
+      if ((fWindow.GetWidth() > 0) && (fWindow.GetHeight() > 0))
+         more_args.append("winW:"s + std::to_string(fWindow.GetWidth()) + ",winH:"s + std::to_string(fWindow.GetHeight()) + ","s);
       auto user_args = fWindow.GetUserArgs();
       if (!user_args.empty())
          more_args.append("user_args: "s + user_args + ","s);

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -636,6 +636,10 @@ unsigned RWebWindowsManager::ShowWindow(RWebWindow &win, const RWebDisplayArgs &
       args.SetWidth(win.GetWidth());
    if (args.GetHeight() <= 0)
       args.SetHeight(win.GetHeight());
+   if (args.GetX() < 0)
+      args.SetX(win.GetX());
+   if (args.GetY() < 0)
+      args.SetY(win.GetY());
 
    bool normal_http = !args.IsLocalDisplay();
    if (!normal_http && (gEnv->GetValue("WebGui.ForceHttp", 0) == 1))

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -1460,7 +1460,13 @@ Bool_t TWebCanvas::ProcessData(unsigned connid, const std::string &arg)
          if (objlnk)
             objlnk->SetOption(arr->at(1).c_str());
       }
-
+   } else if (arg.compare(0, 8, "RESIZED:") == 0) {
+      auto arr = TBufferJSON::FromJSON<std::vector<int>>(arg.substr(8));
+      if (arr && arr->size() == 2) {
+         // set members directly to avoid redrawing of the client again
+         Canvas()->fCw = arr->at(0);
+         Canvas()->fCh = arr->at(1);
+      }
    } else if (arg == "INTERRUPT"s) {
       gROOT->SetInterrupt();
    } else {

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -5,7 +5,7 @@ let version_id = 'dev';
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-let version_date = '14/02/2023';
+let version_date = '15/02/2023';
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}

--- a/js/modules/gpad/RCanvasPainter.mjs
+++ b/js/modules/gpad/RCanvasPainter.mjs
@@ -2,7 +2,7 @@ import { settings, create, parse, toJSON, loadScript, registerMethods, isBatchMo
 import { select as d3_select, rgb as d3_rgb } from '../d3.mjs';
 import { closeCurrentWindow, showProgress, loadOpenui5, ToolbarIcons, getColorExec } from '../gui/utils.mjs';
 import { GridDisplay, getHPainter } from '../gui/display.mjs';
-import { makeTranslate } from '../base/BasePainter.mjs';
+import { makeTranslate, getElementRect } from '../base/BasePainter.mjs';
 import { selectActivePad, cleanup, resize, EAxisBits } from '../base/ObjectPainter.mjs';
 import { RObjectPainter } from '../base/RObjectPainter.mjs';
 import { RAxisPainter } from './RAxisPainter.mjs';
@@ -612,6 +612,30 @@ class RCanvasPainter extends RPadPainter {
       console.error('RCanvasPainter.produceJSON not yet implemented');
       return '';
    }
+
+   /** @summary resize browser window  */
+   resizeBrowser(canvW, canvH) {
+      if (!isFunc(window?.resizeTo) || !canvW || !canvH || isBatchMode() || this.embed_canvas || this.batch_mode)
+         return;
+
+      let cW = this.getPadWidth(), cH = this.getPadHeight();
+      if (!cW || !cH) {
+         let dom = this.selectDom('origin');
+         if (dom.empty()) return;
+         let rect = getElementRect(dom);
+         cW = rect.width;
+         cH = rect.height;
+         if (!cW || !cH) return;
+      }
+
+      let fullW = window.innerWidth - cW + canvW,
+          fullH = window.innerHeight - cH + canvH;
+      if ((fullW > 0) && (fullH > 0) && ((cW != canvW) || (cH != canvH))) {
+          window.resizeTo(fullW, fullH);
+          return true;
+      }
+   }
+
 
    /** @summary draw RCanvas object */
    static async draw(dom, can /*, opt */) {

--- a/js/modules/gpad/TCanvasPainter.mjs
+++ b/js/modules/gpad/TCanvasPainter.mjs
@@ -2,6 +2,7 @@ import { BIT, settings, create, parse, toJSON, loadScript, isBatchMode, isFunc, 
 import { select as d3_select } from '../d3.mjs';
 import { closeCurrentWindow, showProgress, loadOpenui5, ToolbarIcons, getColorExec } from '../gui/utils.mjs';
 import { GridDisplay, getHPainter } from '../gui/display.mjs';
+import { getElementRect } from '../base/BasePainter.mjs';
 import { cleanup, resize, selectActivePad, EAxisBits } from '../base/ObjectPainter.mjs';
 import { TAxisPainter } from './TAxisPainter.mjs';
 import { TFramePainter } from './TFramePainter.mjs';
@@ -685,6 +686,29 @@ class TCanvasPainter extends TPadPainter {
          canv.fPrimitives.Clear();
 
       return res;
+   }
+
+   /** @summary resize browser window to get requested canvas sizes */
+   resizeBrowser(canvW, canvH) {
+      if (!isFunc(window?.resizeTo) || !canvW || !canvH || isBatchMode() || this.embed_canvas || this.batch_mode)
+         return;
+
+      let cW = this.getPadWidth(), cH = this.getPadHeight();
+      if (!cW || !cH) {
+         let dom = this.selectDom('origin');
+         if (dom.empty()) return;
+         let rect = getElementRect(dom);
+         cW = rect.width;
+         cH = rect.height;
+         if (!cW || !cH) return;
+      }
+
+      let fullW = window.innerWidth - cW + canvW,
+          fullH = window.innerHeight - cH + canvH;
+      if ((fullW > 0) && (fullH > 0) && ((cW != canvW) || (cH != canvH))) {
+          window.resizeTo(fullW, fullH);
+          return true;
+      }
    }
 
    /** @summary draw TCanvas */

--- a/js/modules/webwindow.mjs
+++ b/js/modules/webwindow.mjs
@@ -704,6 +704,12 @@ async function connectWebWindow(arg) {
          arg.socket_kind = 'websocket';
    }
 
+   if (arg.winW && arg.winH && !isBatchMode() && isFunc(window?.resizeTo))
+      window.resizeTo(arg.winW, arg.winH);
+
+   if (arg.winX && arg.winY && !isBatchMode() && isFunc(window?.moveTo))
+      window.moveTo(arg.winX, arg.winY);
+
    // only for debug purposes
    // arg.socket_kind = 'longpoll';
 

--- a/ui5/canv/controller/Canvas.controller.js
+++ b/ui5/canv/controller/Canvas.controller.js
@@ -67,6 +67,8 @@ sap.ui.define([
 
             if (cp.v7canvas) model.setProperty("/isRoot6", false);
 
+            cp.enforceCanvasSize = !cp.embed_canvas && cp.online_canvas;
+
             model.setProperty("/canResize", !cp.embed_canvas && cp.online_canvas);
 
             let ws = cp._websocket || cp._window_handle;
@@ -113,6 +115,8 @@ sap.ui.define([
 
          return this.showGed(true).then(() => {
             canvp.selectObjectPainter(painter);
+
+            canvp.enforceCanvasSize = true;
 
             if (typeof canvp.processChanges == 'function')
                canvp.processChanges("sbits", canvp);
@@ -300,7 +304,10 @@ sap.ui.define([
          let ged = this.getLeftController("Ged"),
              p = this.getCanvasPainter();
          if (p) p.registerForPadEvents(null);
-         if (ged) ged.cleanupGed();
+         if (ged) {
+            ged.cleanupGed();
+            if (p) p.enforceCanvasSize = true;
+         }
          if (typeof p?.processChanges == 'function')
             p.processChanges('sbits', p);
       },
@@ -336,10 +343,11 @@ sap.ui.define([
             split.removeContentArea(split.getContentAreas()[0]);
          }
 
+         let canvp = this.getCanvasPainter();
+         if (canvp) canvp.enforceCanvasSize = true;
+
          if (!panel_name)
             return Promise.resolve(null);
-
-         let canvp = this.getCanvasPainter();
 
          let viewName = panel_name;
 
@@ -482,7 +490,10 @@ sap.ui.define([
          this.getView().getModel().setProperty("/StatusIcon", chk_icon(new_state));
 
          let canvp = this.getCanvasPainter();
-         if (canvp) canvp.processChanges("sbits", canvp);
+         if (canvp) {
+            canvp.enforceCanvasSize = true;
+            canvp.processChanges("sbits", canvp);
+         }
       },
 
       toggleToolBar(new_state) {

--- a/ui5/canv/controller/Canvas.controller.js
+++ b/ui5/canv/controller/Canvas.controller.js
@@ -32,7 +32,7 @@ sap.ui.define([
                                      ToolbarIcon: chk_icon(false),
                                      TooltipIcon: chk_icon(true),
                                      StatusLbl1: "", StatusLbl2: "", StatusLbl3: "", StatusLbl4: "",
-                                     Standalone: true, isRoot6: true });
+                                     Standalone: true, isRoot6: true, canResize: true });
          this.getView().setModel(model);
 
          let cp = this.getView().getViewData()?.canvas_painter;
@@ -66,6 +66,8 @@ sap.ui.define([
             cp.showUI5Panel = this.showLeftArea.bind(this);
 
             if (cp.v7canvas) model.setProperty("/isRoot6", false);
+
+            model.setProperty("/canResize", !cp.embed_canvas && cp.online_canvas);
 
             let ws = cp._websocket || cp._window_handle;
             if (!cp.embed_canvas && ws?.addReloadKeyHandler)
@@ -561,6 +563,11 @@ sap.ui.define([
                break;
             case 'Clear canvas':
                cp.sendWebsocket('CLEAR:' + cp.snapid);
+               break;
+            default:
+               let sz = name.split('x');
+               if (cp.resizeBrowser && (sz?.length == 2))
+                  cp.resizeBrowser(Number.parseInt(sz[0]), Number.parseInt(sz[1]));
                break;
          }
       },

--- a/ui5/canv/view/Canvas.view.xml
+++ b/ui5/canv/view/Canvas.view.xml
@@ -41,6 +41,15 @@
                      <items>
                         <MenuItem text="Style" enabled="false"/>
                         <MenuItem text="Divide" enabled="{/isRoot6}"/>
+                        <MenuItem text="Resize" enabled="{/canResize}">
+                           <items>
+                              <MenuItem text="700 x 500" tooltip="Resize draw canvas area"/>
+                              <MenuItem text="500 x 500" tooltip="Resize draw canvas area"/>
+                              <MenuItem text="1200 x 800" tooltip="Resize draw canvas area"/>
+                              <MenuItem text="900 x 900" tooltip="Resize draw canvas area"/>
+                              <MenuItem text="1600 x 1200" tooltip="Resize draw canvas area"/>
+                           </items>
+                        </MenuItem>
                         <MenuItem text="Clear pad" startsSection="true"/>
                         <MenuItem text="Clear canvas"/>
                      </items>


### PR DESCRIPTION
In Chrome browser one can change window size from JavaScript using `window.resizeTo` method
This solves problem when different `RWebWindow` instances with different sizes need to be used - 
like in `tutorials/geom/geodemo.C`.

Introduce also X and Y coordinate for `RWebWindow`, use `window.moveTo` to move browser to specified position.

Use this features for `TWebCanvas` to preserve/enforce configured canvas size.

Let change canvas size via context menu.