### PR TITLE
[v626][RF] Backports of RooFit PRs to `v6-26-00-patches`: Part 27

### DIFF
--- a/roofit/roofitcore/inc/RooWorkspace.h
+++ b/roofit/roofitcore/inc/RooWorkspace.h
@@ -94,7 +94,7 @@ public:
   const RooArgSet* getSnapshot(const char* name) const ;
 
   // Retrieve list of parameter snapshots
-  RooLinkedList getSnapshots(){ return this->_snapshots; }
+  RooLinkedList const& getSnapshots() const { return _snapshots; }
 
   void merge(const RooWorkspace& /*other*/) {} ;
 

--- a/roofit/roofitcore/src/RooAbsCategoryLValue.cxx
+++ b/roofit/roofitcore/src/RooAbsCategoryLValue.cxx
@@ -183,7 +183,7 @@ void RooAbsCategoryLValue::setBin(Int_t ibin, const char* rangeName)
     return ;
   }
 
-  if (rangeName) {
+  if (rangeName && getBinningPtr(rangeName)) {
     coutF(InputArguments) << "RooAbsCategoryLValue::setBin(" << GetName() << ") ERROR: ranges not implemented"
         " for setting bins in categories." << std::endl;
     throw std::logic_error("Ranges not implemented for setting bins in categories.");

--- a/roofit/roostats/src/RooStatsUtils.cxx
+++ b/roofit/roostats/src/RooStatsUtils.cxx
@@ -395,12 +395,8 @@ namespace RooStats {
   
       // Copy snapshots
       if (copySnapshots) {
-        RooFIter itr(oldWS->getSnapshots().fwdIterator());
-        RooArgSet *snap;
-        while ((snap = (RooArgSet *)itr.next())) {
-          RooArgSet *snapClone = (RooArgSet *)snap->snapshot();
-          snapClone->setName(snap->GetName());
-          newWS->getSnapshots().Add(snapClone);
+        for (auto* snap : static_range_cast<RooArgSet const*>(oldWS->getSnapshots())) {
+          newWS->saveSnapshot(snap->GetName(), *snap, /*importValuesdf*/true);
         }
       }
   


### PR DESCRIPTION
This is a backport of all the relevant bugfix RooFit PRs that were recently merged to master to v6-26-00-patches (in the right order, to not have the commit history diverge too much).

1. https://github.com/root-project/root/pull/12119
2. https://github.com/root-project/root/pull/12305
    Only the first commit that is not code modernization.

Related to https://github.com/root-project/root/issues/11534.

