### PR TITLE
Use gStyle attributes for candle and violin

### DIFF
--- a/core/base/inc/TStyle.h
+++ b/core/base/inc/TStyle.h
@@ -137,6 +137,10 @@ private:
    Double_t      fTimeOffset;        ///< Time offset to the beginning of an axis
    Bool_t        fIsReading;         ///<! Set to FALSE when userclass::UseCurrentStyle is called by the style manager
    Float_t       fImageScaling;      ///< Image scaling to produce high definition bitmap images
+   Double_t      fCandleWhiskerRange;///< Candle plot, the fraction which is covered by the whiskers (0 < x < 1), default 1
+   Double_t      fCandleBoxRange;    ///< Candle plot, The fraction which is covered by the box (0 < x < 1), default 0.5
+   Bool_t        fCandleScaled;      ///< Candle plot, shall the box-width be scaled to each other by the integral of a box?
+   Bool_t        fViolinScaled;      ///< Violin plot, shall the violin or histos be scaled to each other by the maximum height?
 
 public:
    enum EPaperSize { kA4, kUSLetter };
@@ -279,6 +283,10 @@ public:
    Int_t            GetJoinLinePS() const {return fJoinLinePS;} ///< Returns the line join method used for PostScript, PDF and SVG output. See `TPostScript::SetLineJoin` for details.
    Int_t            GetCapLinePS()  const {return fCapLinePS;}  ///< Returns the line cap method used for PostScript, PDF and SVG output. See `TPostScript::SetLineCap` for details.
    Float_t          GetLineScalePS() const {return fLineScalePS;}
+   Double_t         GetCandleWhiskerRange() const {return fCandleWhiskerRange;}
+   Double_t         GetCandleBoxRange() const {return fCandleBoxRange;}
+   Bool_t           GetCandleScaled() const {return fCandleScaled;}
+   Bool_t           GetViolinScaled() const {return fViolinScaled;}
 
    Bool_t           IsReading() const {return fIsReading;}
    void             Paint(Option_t *option="") override;
@@ -404,10 +412,15 @@ public:
    void             SetIsReading(Bool_t reading=kTRUE);
    void             SetPalette(Int_t ncolors = kBird, Int_t *colors = nullptr, Float_t alpha = 1.);
    void             SetPalette(TString fileName, Float_t alpha = 1.);
+   void             SetCandleWhiskerRange(Double_t wRange=1.0);
+   void             SetCandleBoxRange(Double_t bRange=0.5);
+   void             SetCandleScaled(Bool_t on=kFALSE) {fCandleScaled=on;}
+   void             SetViolinScaled(Bool_t on=kTRUE) {fViolinScaled=on;}
+
    void             SavePrimitive(std::ostream &out, Option_t * = "") override;
    void             SaveSource(const char *filename, Option_t *option = nullptr);
 
-   ClassDefOverride(TStyle, 19);  //A collection of all graphics attributes
+   ClassDefOverride(TStyle, 20);  //A collection of all graphics attributes
 };
 
 

--- a/core/base/src/TStyle.cxx
+++ b/core/base/src/TStyle.cxx
@@ -796,6 +796,11 @@ void TStyle::Reset(Option_t *opt)
 
    fTimeOffset = 788918400; // UTC time at 01/01/95
 
+   fCandleWhiskerRange  = 1.0;
+   fCandleBoxRange      = 0.5;
+   fCandleScaled = kFALSE;
+   fViolinScaled = kTRUE;
+
    TString style_name = opt;
 
    if (strcmp(style_name,"Modern") == 0) {
@@ -1819,6 +1824,41 @@ void TStyle::SetTimeOffset(Double_t toffset)
 void TStyle::SetStripDecimals(Bool_t strip)
 {
    fStripDecimals = strip;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// By setting whisker-range for candle plot, one can force
+/// the whiskers to cover the fraction of the distribution.
+/// Set wRange between 0 and 1. Default is 1
+/// gStyle->SetCandleWhiskerRange(0.95) will set all candle-charts to cover 95% of
+/// the distribution with the whiskers.
+/// Can only be used with the standard-whisker definition
+
+void TStyle::SetCandleWhiskerRange(Double_t wRange)
+{
+   if (wRange < 0)
+      fCandleWhiskerRange = 0;
+   else if (wRange > 1)
+      fCandleWhiskerRange = 1;
+   else
+      fCandleWhiskerRange = wRange;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// By setting box-range for candle plot, one can force the
+/// box of the candle-chart to cover that given fraction of the distribution.
+/// Set bRange between 0 and 1. Default is 0.5
+/// gStyle->SetCandleBoxRange(0.68) will set all candle-charts to cover 68% of the
+/// distribution by the box
+
+void TStyle::SetCandleBoxRange(Double_t bRange)
+{
+   if (bRange < 0)
+      fCandleBoxRange = 0;
+   else if (bRange > 1)
+      fCandleBoxRange = 1;
+   else
+      fCandleBoxRange = bRange;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/graf/inc/TCandle.h
+++ b/graf2d/graf/inc/TCandle.h
@@ -16,6 +16,7 @@
 #include "TAttLine.h"
 #include "TAttFill.h"
 #include "TAttMarker.h"
+#include "TString.h"
 
 #include "TMath.h"
 
@@ -79,7 +80,7 @@ protected:
    int  fNHistoPoints;
 
    CandleOption fOption;                  ///< Setting the style of the candle
-   char fOptionStr[128];                  ///< String to draw the candle
+   TString fOptionStr;                    ///< String to draw the candle
    int fLogX;                             ///< make the candle appear logx-like
    int fLogY;                             ///< make the candle appear logy-like
    int fLogZ;                             ///< make the candle appear logz-like
@@ -95,7 +96,7 @@ protected:
 
    void Calculate();
 
-   int  GetCandleOption(const int pos) {return (fOption/(long)TMath::Power(10,pos))%10;}
+   int  GetCandleOption(const int pos) const {return (fOption/(long)TMath::Power(10,pos))%10;}
 
    void PaintBox(Int_t nPoints, Double_t *x, Double_t *y, Bool_t swapXY);
    void PaintLine(Double_t x1, Double_t y1, Double_t x2, Double_t y2, Bool_t swapXY);
@@ -114,8 +115,8 @@ public:
    Double_t       GetQ1() const {return fBoxUp;}
    Double_t       GetQ2() const {return fMedian;}
    Double_t       GetQ3() const {return fBoxDown;}
-   Bool_t         IsHorizontal() {return (IsOption(kHorizontal)); }
-   Bool_t         IsVertical() {return (!IsOption(kHorizontal)); }
+   Bool_t         IsHorizontal() const {return IsOption(kHorizontal); }
+   Bool_t         IsVertical() const {return !IsOption(kHorizontal); }
    Bool_t         IsCandleScaled();
    Bool_t         IsViolinScaled();
 
@@ -137,9 +138,9 @@ public:
    virtual void   SetQ3(Double_t q3) { fBoxDown = q3; }
 
    int            ParseOption(char *optin);
-   const char    *GetDrawOption() { return fOptionStr; }
-   long           GetOption() { return fOption; }
-   bool           IsOption(CandleOption opt);
+   const char    *GetDrawOption() const { return fOptionStr.Data(); }
+   long           GetOption() const { return fOption; }
+   bool           IsOption(CandleOption opt) const;
    static void    SetWhiskerRange(const Double_t wRange);
    static void    SetBoxRange(const Double_t bRange);
    static void    SetScaledCandle(const Bool_t cScale = true);

--- a/graf2d/graf/inc/TCandle.h
+++ b/graf2d/graf/inc/TCandle.h
@@ -88,12 +88,6 @@ protected:
    Double_t fAxisMin;                     ///< The Minimum which is visible by the axis (used by zero indicator)
    Double_t fAxisMax;                     ///< The Maximum which is visible by the axis (used by zero indicator)
 
-   static Double_t fWhiskerRange;         ///< The fraction which is covered by the whiskers (0 < x < 1), default 1
-   static Double_t fBoxRange;             ///< The fraction which is covered by the box (0 < x < 1), default 0.5
-
-   static Bool_t fScaledCandle;           ///< shall the box-width be scaled to each other by the integral of a box?
-   static Bool_t fScaledViolin;           ///< shall the violin or histos be scaled to each other by the maximum height?
-
    void Calculate();
 
    int  GetCandleOption(const int pos) const {return (fOption/(long)TMath::Power(10,pos))%10;}
@@ -117,8 +111,8 @@ public:
    Double_t       GetQ3() const {return fBoxDown;}
    Bool_t         IsHorizontal() const {return IsOption(kHorizontal); }
    Bool_t         IsVertical() const {return !IsOption(kHorizontal); }
-   Bool_t         IsCandleScaled();
-   Bool_t         IsViolinScaled();
+   Bool_t         IsCandleScaled() const;
+   Bool_t         IsViolinScaled() const;
 
    void           SetOption(CandleOption opt) { fOption = opt; }
    void           SetLog(int x, int y, int z) { fLogX = x; fLogY = y; fLogZ = z;}

--- a/graf2d/graf/src/TCandle.cxx
+++ b/graf2d/graf/src/TCandle.cxx
@@ -16,12 +16,8 @@
 #include "TVirtualPad.h"
 #include "TH2D.h"
 #include "TRandom2.h"
+#include "TStyle.h"
 #include "strlcpy.h"
-
-Double_t TCandle::fWhiskerRange  = 1.0;
-Double_t TCandle::fBoxRange      = 0.5;
-Bool_t TCandle::fScaledCandle = false;
-Bool_t TCandle::fScaledViolin = true;
 
 ClassImp(TCandle);
 
@@ -176,54 +172,59 @@ TCandle::TCandle(const Double_t candlePos, const Double_t candleWidth, TH1D *pro
 ////////////////////////////////////////////////////////////////////////////////
 /// TCandle default destructor.
 
-TCandle::~TCandle() {
+TCandle::~TCandle()
+{
    if (fIsRaw && fProj) delete fProj;
 }
 
-Bool_t TCandle::IsCandleScaled()
-{
-   return fScaledCandle;
-}
+////////////////////////////////////////////////////////////////////////////////
+/// Returns true if candle plot should be scaled
 
-Bool_t TCandle::IsViolinScaled()
+Bool_t TCandle::IsCandleScaled() const
 {
-   return fScaledViolin;
+   return gStyle->GetCandleScaled();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Static function to set fWhiskerRange, by setting whisker-range, one can force
+/// Returns true if violin plot should be scaled
+
+Bool_t TCandle::IsViolinScaled() const
+{
+   return gStyle->GetViolinScaled();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Static function to set WhiskerRange, by setting whisker-range, one can force
 /// the whiskers to cover the fraction of the distribution.
 /// Set wRange between 0 and 1. Default is 1
 /// TCandle::SetWhiskerRange(0.95) will set all candle-charts to cover 95% of
 /// the distribution with the whiskers.
 /// Can only be used with the standard-whisker definition
 
-void TCandle::SetWhiskerRange(const Double_t wRange) {
-   if (wRange < 0) fWhiskerRange = 0;
-   else if (wRange > 1) fWhiskerRange = 1;
-   else fWhiskerRange = wRange;
-
+void TCandle::SetWhiskerRange(const Double_t wRange)
+{
+   gStyle->SetCandleWhiskerRange(wRange);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Static function to set fBoxRange, by setting whisker-range, one can force the
+/// Static function to set BoxRange, by setting box-range, one can force the
 /// box of the candle-chart to cover that given fraction of the distribution.
 /// Set bRange between 0 and 1. Default is 0.5
 /// TCandle::SetBoxRange(0.68) will set all candle-charts to cover 68% of the
 /// distribution by the box
 
-void TCandle::SetBoxRange(const Double_t bRange) {
-   if (bRange < 0) fBoxRange = 0;
-   else if (bRange > 1) fBoxRange = 1;
-   else fBoxRange = bRange;
+void TCandle::SetBoxRange(const Double_t bRange)
+{
+   gStyle->SetCandleBoxRange(bRange);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Static function to set scaling between candles-withs. A candle containing
-/// 100 entries with be two times wider than a candle containing 50 entries
+/// 100 entries will be two times wider than a candle containing 50 entries
 
-void TCandle::SetScaledCandle(const Bool_t cScale) {
-   fScaledCandle = cScale;
+void TCandle::SetScaledCandle(const Bool_t cScale)
+{
+   gStyle->SetCandleScaled(cScale);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -231,8 +232,9 @@ void TCandle::SetScaledCandle(const Bool_t cScale) {
 /// with a maximum bin content to 100 will be two times as high as a violin with
 /// a maximum bin content of 50
 
-void TCandle::SetScaledViolin(const Bool_t vScale) {
-   fScaledViolin = vScale;
+void TCandle::SetScaledViolin(const Bool_t vScale)
+{
+   gStyle->SetViolinScaled(vScale);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -391,20 +393,24 @@ void TCandle::Calculate() {
    // Determining the quantiles
    Double_t prob[5];
 
-   if (fWhiskerRange >= 1) {
+   Double_t wRange = gStyle->GetCandleWhiskerRange();
+   Double_t bRange = gStyle->GetCandleBoxRange();
+
+
+   if (wRange >= 1) {
       prob[0] = 1e-15;
       prob[4] = 1-1e-15;
    } else {
-      prob[0] = 0.5 - fWhiskerRange/2.;
-      prob[4] = 0.5 + fWhiskerRange/2.;
+      prob[0] = 0.5 - wRange/2.;
+      prob[4] = 0.5 + wRange/2.;
    }
 
-   if (fBoxRange >= 1) {
+   if (bRange >= 1) {
       prob[1] = 1E-14;
       prob[3] = 1-1E-14;
    } else {
-      prob[1] = 0.5 - fBoxRange/2.;
-      prob[3] = 0.5 + fBoxRange/2.;
+      prob[1] = 0.5 - bRange/2.;
+      prob[3] = 0.5 + bRange/2.;
    }
 
    prob[2] = 0.5;

--- a/graf2d/graf/src/TCandle.cxx
+++ b/graf2d/graf/src/TCandle.cxx
@@ -138,7 +138,6 @@ TCandle::TCandle(const Double_t candlePos, const Double_t candleWidth, Long64_t 
    fNHistoPoints  = 0;
    fAxisMin       = 0.;
    fAxisMax       = 0.;
-   snprintf(fOptionStr, sizeof(fOptionStr), " ");
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -172,7 +171,6 @@ TCandle::TCandle(const Double_t candlePos, const Double_t candleWidth, TH1D *pro
    fNHistoPoints  = 0;
    fAxisMin       = 0.;
    fAxisMax       = 0.;
-   snprintf(fOptionStr, sizeof(fOptionStr), " ");
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -295,17 +293,17 @@ int TCandle::ParseOption(char * opt) {
             if (wasHorizontal && !IsHorizontal()) {fOption = (CandleOption)(fOption + kHorizontal);}
             memcpy(brOpen,"                ",brClose-brOpen+1); //Cleanup
 
-            snprintf(fOptionStr, sizeof(fOptionStr), "CANDLE%c(%ld)",direction,(long)fOption);
+            fOptionStr.Form("CANDLE%c(%ld)", direction, (long)fOption);
          } else {
             fOption = (CandleOption)(fOption + fallbackCandle);
          }
       } else {
-         snprintf(fOptionStr, sizeof(fOptionStr), "CANDLE%c%c",direction,preset);
+         fOptionStr.Form("CANDLE%c%c",direction,preset);
       }
       //Handle option "CANDLE" ,"CANDLEX" or "CANDLEY" to behave like "CANDLEX1" or "CANDLEY1"
       if (!useIndivOption && !fOption ) {
          fOption = fallbackCandle;
-         snprintf(fOptionStr, sizeof(fOptionStr), "CANDLE%c2",direction);
+         fOptionStr.Form("CANDLE%c2",direction);
       }
    }
 
@@ -352,17 +350,17 @@ int TCandle::ParseOption(char * opt) {
             if (wasHorizontal && !IsHorizontal()) {fOption = (CandleOption)(fOption + kHorizontal);}
             memcpy(brOpen,"                ",brClose-brOpen+1); //Cleanup
 
-            snprintf(fOptionStr, sizeof(fOptionStr), "VIOLIN%c(%ld)",direction,(long)fOption);
+            fOptionStr.Form("VIOLIN%c(%ld)", direction, (long)fOption);
          } else {
             fOption = (CandleOption)(fOption + fallbackCandle);
          }
       } else {
-         snprintf(fOptionStr, sizeof(fOptionStr), "VIOLIN%c%c",direction,preset);
+         fOptionStr.Form("VIOLIN%c%c", direction, preset);
       }
       //Handle option "VIOLIN" ,"VIOLINX" or "VIOLINY" to behave like "VIOLINX1" or "VIOLINY1"
       if (!useIndivOption && !fOption ) {
          fOption = fallbackCandle;
-         snprintf(fOptionStr, sizeof(fOptionStr), "VIOLIN%c1",direction);
+         fOptionStr.Form("VIOLIN%c1", direction);
       }
    }
 
@@ -834,7 +832,7 @@ void TCandle::Paint(Option_t *)
 ////////////////////////////////////////////////////////////////////////////////
 /// Return true is this option is activated in fOption
 
-bool TCandle::IsOption(CandleOption opt) {
+bool TCandle::IsOption(CandleOption opt) const {
    long myOpt = 9;
    int pos = 0;
    for (pos = 0; pos < 16; pos++) {
@@ -844,7 +842,7 @@ bool TCandle::IsOption(CandleOption opt) {
    myOpt /= 9;
    int thisOpt = GetCandleOption(pos);
 
-   return ((thisOpt * myOpt) == opt);
+   return (thisOpt * myOpt) == opt;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/js/build/jsroot.js
+++ b/js/build/jsroot.js
@@ -366,7 +366,11 @@ let gStyle = {
    fLegendTextSize: 0,
    fLegendFillColor: 0,
    fHatchesLineWidth: 1,
-   fHatchesSpacing: 1
+   fHatchesSpacing: 1,
+   fCandleWhiskerRange: 1.0,
+   fCandleBoxRange: 0.5,
+   fCandleScaled: false,
+   fViolinScaled: true
 };
 
 /** @summary Method returns current document in use
@@ -78194,17 +78198,19 @@ let TH2Painter$2 = class TH2Painter extends THistPainter {
       let histo = this.getHisto(),
           handle = this.prepareDraw(),
           pmain = this.getFramePainter(), // used for axis values conversions
+          cp = this.getCanvPainter(),
           funcs = pmain.getGrFuncs(this.options.second_x, this.options.second_y),
           bars = '', lines = '', dashed_lines = '',
           hists = '', hlines = '',
           markers = '', cmarkers = '', attrcmarkers = null,
           xx, proj, swapXY = isOption(kHorizontal),
-          scaledViolin = true, scaledCandle = false,
+          scaledViolin = gStyle.fViolinScaled,
+          scaledCandle = gStyle.fCandleScaled,
           maxContent = 0, maxIntegral = 0;
 
       if (this.options.Scaled !== null)
          scaledViolin = scaledCandle = this.options.Scaled;
-      else if (histo.fTitle.indexOf('unscaled') >= 0)
+      else if (cp?.online_canvas) ; else if(histo.fTitle.indexOf('unscaled') >= 0)
          scaledViolin = scaledCandle = false;
       else if (histo.fTitle.indexOf('scaled') >= 0)
          scaledViolin = scaledCandle = true;
@@ -78250,12 +78256,12 @@ let TH2Painter$2 = class TH2Painter extends THistPainter {
       handle.candle = []; // array of drawn points
 
       // Determining the quantiles
-      const fBoxRange = 0.5, // for now constants, later can be made configurable
-            prob = [ 1e-15 ,
-                    0.5 - fBoxRange/2.,
-                    0.5,
-                    0.5 + fBoxRange/2.,
-                    1-1e-15 ];
+      const wRange = gStyle.fCandleWhiskerRange, bRange = gStyle.fCandleBoxRange,
+            prob = [ (wRange >= 1) ? 1e-15 : 0.5 - wRange/2.,
+                     (bRange >= 1) ? 1E-14 : 0.5 - bRange/2.,
+                     0.5,
+                     (bRange >= 1) ? 1-1E-14 : 0.5 + bRange/2.,
+                     (wRange >= 1) ? 1-1e-15 : 0.5 + wRange/2. ];
 
       const produceCandlePoint = (bin_indx, grx_left, grx_right, xindx1, xindx2) => {
          let res = extractQuantiles(xx, proj, prob);

--- a/js/changes.md
+++ b/js/changes.md
@@ -9,6 +9,7 @@
 6. Implement reverse axis on lego plots
 7. Add interactivity (moving, context menu) for TLine, TBox, TText, TLatex
 8. Support more kinds of log scales - ln and logN where N is any positive integer
+9. Use new gStyle attributes for candle and violin plots
 
 
 ## Changes in 7.3.0

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -361,7 +361,11 @@ let gStyle = {
    fLegendTextSize: 0,
    fLegendFillColor: 0,
    fHatchesLineWidth: 1,
-   fHatchesSpacing: 1
+   fHatchesSpacing: 1,
+   fCandleWhiskerRange: 1.0,
+   fCandleBoxRange: 0.5,
+   fCandleScaled: false,
+   fViolinScaled: true
 };
 
 /** @summary Method returns current document in use

--- a/js/modules/hist2d/TH2Painter.mjs
+++ b/js/modules/hist2d/TH2Painter.mjs
@@ -1562,17 +1562,21 @@ class TH2Painter extends THistPainter {
       let histo = this.getHisto(),
           handle = this.prepareDraw(),
           pmain = this.getFramePainter(), // used for axis values conversions
+          cp = this.getCanvPainter(),
           funcs = pmain.getGrFuncs(this.options.second_x, this.options.second_y),
           bars = '', lines = '', dashed_lines = '',
           hists = '', hlines = '',
           markers = '', cmarkers = '', attrcmarkers = null,
           xx, proj, swapXY = isOption(kHorizontal),
-          scaledViolin = true, scaledCandle = false,
+          scaledViolin = gStyle.fViolinScaled,
+          scaledCandle = gStyle.fCandleScaled,
           maxContent = 0, maxIntegral = 0;
 
       if (this.options.Scaled !== null)
          scaledViolin = scaledCandle = this.options.Scaled;
-      else if (histo.fTitle.indexOf('unscaled') >= 0)
+      else if (cp?.online_canvas) {
+         // console.log('ignore hist title in online canvas');
+      } else if(histo.fTitle.indexOf('unscaled') >= 0)
          scaledViolin = scaledCandle = false;
       else if (histo.fTitle.indexOf('scaled') >= 0)
          scaledViolin = scaledCandle = true;
@@ -1618,12 +1622,12 @@ class TH2Painter extends THistPainter {
       handle.candle = []; // array of drawn points
 
       // Determining the quantiles
-      const fWhiskerRange = 1.0, fBoxRange = 0.5, // for now constants, later can be made configurable
-            prob = [ (fWhiskerRange >= 1) ? 1e-15 : 0.5 - fWhiskerRange/2.,
-                    (fBoxRange >= 1) ? 1E-14 : 0.5 - fBoxRange/2.,
-                    0.5,
-                    (fBoxRange >= 1) ? 1-1E-14 : 0.5 + fBoxRange/2.,
-                    (fWhiskerRange >= 1) ? 1-1e-15 : 0.5 + fWhiskerRange/2.];
+      const wRange = gStyle.fCandleWhiskerRange, bRange = gStyle.fCandleBoxRange,
+            prob = [ (wRange >= 1) ? 1e-15 : 0.5 - wRange/2.,
+                     (bRange >= 1) ? 1E-14 : 0.5 - bRange/2.,
+                     0.5,
+                     (bRange >= 1) ? 1-1E-14 : 0.5 + bRange/2.,
+                     (wRange >= 1) ? 1-1e-15 : 0.5 + wRange/2. ];
 
       const produceCandlePoint = (bin_indx, grx_left, grx_right, xindx1, xindx2) => {
          let res = extractQuantiles(xx, proj, prob);

--- a/tutorials/hist/candlescaled.C
+++ b/tutorials/hist/candlescaled.C
@@ -13,20 +13,15 @@ void candlescaled()
 {
    TCanvas *c1 = new TCanvas("c1","TCandle Scaled",800,600);
    c1->Divide(2,2);
-   TRandom *rng = new TRandom();
    TH2I *h1 = new TH2I("h1","GausXY",20,-5,5,100,-5,5);
    TH2I *h3 = new TH2I("h3","GausXY",100,-5,5,20,-5,5);
 
-   float myRand1;
-   float myRand2;
-
    for (int j = 0; j < 100000; j++) {
-      myRand1 = rng->Gaus(0,1);
-      myRand2 = rng->Gaus(0,1);
+      auto myRand1 = gRandom->Gaus(0,1);
+      auto myRand2 = gRandom->Gaus(0,1);
       h1->Fill(myRand1, myRand2);
       h3->Fill(myRand1, myRand2);
    }
-
 
    c1->cd(1);
 
@@ -39,7 +34,7 @@ void candlescaled()
    h3->SetTitle("CandleY scaled");
    h3->DrawCopy("candleY2");
 
-   TCandle::SetScaledViolin(true); /* This is a global option for all existing violin, default is true */
+   TCandle::SetScaledViolin(false); /* This is a global option for all existing violin, default is true */
    TH2I *h2 = (TH2I*)h1->Clone();
    h2->SetFillStyle(0);
    h2->SetFillColor(kGray+2);
@@ -55,6 +50,4 @@ void candlescaled()
    c1->cd(4);
    h4->SetTitle("ViolinY unscaled");
    h4->DrawCopy("ViolinY");
-
-
 }


### PR DESCRIPTION
* Introduce new `TStyle` attributes
* Keep old `TCandle` static methods - just redirect them to gStyle
* Fix `candlescaled.C` tutorial - was drawing scaled violin, but title was saying un-scaled
* Adjust JSROOT to support new attributes

With these changes TWebCanvas will correctly display histogram from `candlescaled.C` tutorial