### PR TITLE
Add missing TH1K::RetrieveBinContent

### DIFF
--- a/hist/hist/inc/TH1K.h
+++ b/hist/hist/inc/TH1K.h
@@ -32,6 +32,9 @@ protected:
    Int_t fNIn;
    Int_t fKOrd;   //!
    Int_t fKCur;   //!
+
+   Double_t RetrieveBinContent(Int_t bin) const override { return GetBinContent(bin); }
+
 public:
    TH1K();
    TH1K(const char *name,const char *title,Int_t nbinsx,Double_t xlow,Double_t xup,Int_t k=0);


### PR DESCRIPTION
Makes lot of warnings when drawing TH1K like in `tutorials/hist/hksimple.C` - any zoom operation makes:
```
Warning in <TH1K::RetrieveBinContent>: this method must be overridden!
```

