### PR TITLE
[RF] Avoid overhead of tracking evaluation error messages when not needed

### DIFF
--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -337,6 +337,22 @@ public:
   } ;
 
   enum ErrorLoggingMode { PrintErrors, CollectErrors, CountErrors, Ignore } ;
+
+  /// Context to temporarily change the error logging mode as long as the context is alive.
+  class EvalErrorContext {
+  public:
+     EvalErrorContext(ErrorLoggingMode m) : _old{evalErrorLoggingMode()} { setEvalErrorLoggingMode(m); }
+
+     EvalErrorContext(EvalErrorContext const&) = delete;
+     EvalErrorContext(EvalErrorContext &&) = delete;
+     EvalErrorContext& operator=(EvalErrorContext const&) = delete;
+     EvalErrorContext& operator=(EvalErrorContext &&) = delete;
+
+     ~EvalErrorContext() { setEvalErrorLoggingMode(_old); }
+  private:
+     ErrorLoggingMode _old;
+  };
+
   static ErrorLoggingMode evalErrorLoggingMode() ;
   static void setEvalErrorLoggingMode(ErrorLoggingMode m) ;
   void logEvalError(const char* message, const char* serverValueString=nullptr) const ;

--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -45,14 +45,14 @@ public:
    /// Config argument to RooMinimizer ctor
    struct Config {
       Config() {}
-      double recoverFromNaN = 10.;        // RooAbsMinimizerFcn config
-      int printEvalErrors = 10;           // RooAbsMinimizerFcn config
-      int doEEWall = 1;                   // RooAbsMinimizerFcn config
-      int offsetting = -1;                // RooAbsMinimizerFcn config
-      const char *logf = nullptr;         // RooAbsMinimizerFcn config
+      double recoverFromNaN = 10.; // RooAbsMinimizerFcn config
+      int printEvalErrors = 10;    // RooAbsMinimizerFcn config
+      int doEEWall = 1;            // RooAbsMinimizerFcn config
+      int offsetting = -1;         // RooAbsMinimizerFcn config
+      const char *logf = nullptr;  // RooAbsMinimizerFcn config
 
-      // RooAbsMinimizerFcn config that can only be set in ctor, 0 means no parallelization (default), 
-      // -1 is parallelization with the number of workers controlled by RooFit::MultiProcess which 
+      // RooAbsMinimizerFcn config that can only be set in ctor, 0 means no parallelization (default),
+      // -1 is parallelization with the number of workers controlled by RooFit::MultiProcess which
       // defaults to the number of available processors, n means parallelization with n CPU's
       int parallelize = 0;
 
@@ -64,10 +64,10 @@ public:
       // argument is ignored when parallelize is 0
       bool enableParallelDescent = false;
 
-      bool verbose = false;               // local config
-      bool profile = false;               // local config
-      bool timingAnalysis = false;            // local config
-      std::string minimizerType = "";     // local config
+      bool verbose = false;           // local config
+      bool profile = false;           // local config
+      bool timingAnalysis = false;    // local config
+      std::string minimizerType = ""; // local config
    private:
       int getDefaultWorkers();
    };

--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -152,6 +152,8 @@ public:
 private:
    friend class RooAbsMinimizerFcn;
 
+   std::unique_ptr<RooAbsReal::EvalErrorContext> makeEvalErrorContext() const;
+
    void addParamsToProcessTimer();
 
    void profileStart();

--- a/roofit/roofitcore/src/RooAbsMinimizerFcn.cxx
+++ b/roofit/roofitcore/src/RooAbsMinimizerFcn.cxx
@@ -460,7 +460,7 @@ void RooAbsMinimizerFcn::finishDoEval() const
 
 void RooAbsMinimizerFcn::setOptimizeConst(int flag)
 {
-   RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CollectErrors);
+   auto ctx = _context->makeEvalErrorContext();
 
    if (_optConst && !flag) {
       if (_context->getPrintLevel() > -1)
@@ -483,15 +483,13 @@ void RooAbsMinimizerFcn::setOptimizeConst(int flag)
          oocoutI(_context, Minimization) << "RooAbsMinimizerFcn::setOptimizeConst: const optimization wasn't active"
                                          << endl;
    }
-
-   RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::PrintErrors);
 }
 
 void RooAbsMinimizerFcn::optimizeConstantTerms(bool constStatChange, bool constValChange)
 {
-   if (constStatChange) {
+   auto ctx = _context->makeEvalErrorContext();
 
-      RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CollectErrors);
+   if (constStatChange) {
 
       oocoutI(_context, Minimization)
          << "RooAbsMinimizerFcn::optimizeConstantTerms: set of constant parameters changed, rerunning const optimizer"
@@ -503,8 +501,6 @@ void RooAbsMinimizerFcn::optimizeConstantTerms(bool constStatChange, bool constV
          << endl;
       setOptimizeConstOnFunction(RooAbsArg::ValueChange, true);
    }
-
-   RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::PrintErrors);
 }
 
 std::vector<double> RooAbsMinimizerFcn::getParameterValues() const

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -976,5 +976,9 @@ int RooMinimizer::Config::getDefaultWorkers()
 std::unique_ptr<RooAbsReal::EvalErrorContext> RooMinimizer::makeEvalErrorContext() const
 {
    RooAbsReal::clearEvalErrorLog();
-   return std::make_unique<RooAbsReal::EvalErrorContext>(RooAbsReal::CollectErrors);
+   // If evaluation error printing is disabled, we don't need to collect the
+   // errors and only need to count them. This significantly reduces the
+   // performance overhead when having evaluation errors.
+   auto m = _cfg.printEvalErrors < 0 ? RooAbsReal::CountErrors : RooAbsReal::CollectErrors;
+   return std::make_unique<RooAbsReal::EvalErrorContext>(m);
 }

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -115,9 +115,10 @@ RooMinimizer::RooMinimizer(RooAbsReal &function, Config const &cfg) : _cfg(cfg)
                                   << "also setting parallel gradient calculation mode." << std::endl;
             _cfg.enableParallelGradient = 1;
          }
-         // If _cfg.parallelize is larger than zero set the number of workers to that value. Otherwise do not do anything and let
-         // RooFit::MultiProcess handle the number of workers
-         if (_cfg.parallelize > 0) RooFit::MultiProcess::Config::setDefaultNWorkers(_cfg.parallelize);
+         // If _cfg.parallelize is larger than zero set the number of workers to that value. Otherwise do not do
+         // anything and let RooFit::MultiProcess handle the number of workers
+         if (_cfg.parallelize > 0)
+            RooFit::MultiProcess::Config::setDefaultNWorkers(_cfg.parallelize);
          RooFit::MultiProcess::Config::setTimingAnalysis(_cfg.timingAnalysis);
 
          _fcn = std::make_unique<RooFit::TestStatistics::MinuitFcnGrad>(
@@ -131,14 +132,14 @@ RooMinimizer::RooMinimizer(RooAbsReal &function, Config const &cfg) : _cfg(cfg)
             "please recompile with -Droofit_multiprocess=ON for parallel evaluation");
 #endif
       } else { // modular test statistic non parallel
-         coutW(InputArguments) << "Requested modular likelihood without gradient parallelization, some features such as offsetting "
-                               << "may not work yet. Non-modular likelihoods are more reliable without parallelization."
-                               << std::endl;
-         // The RooRealL that is used in the case where the modular likelihood is being passed to a RooMinimizerFcn does not have
-         // offsetting implemented. Therefore, offsetting will not work in this case. Other features might also not work since the
-         // RooRealL was not intended for minimization. Further development is required to make the MinuitFcnGrad also handle serial gradient
-         // minimization. The MinuitFcnGrad accepts a RooAbsL and has offsetting implemented, thus omitting the need for RooRealL
-         // minimization altogether.
+         coutW(InputArguments)
+            << "Requested modular likelihood without gradient parallelization, some features such as offsetting "
+            << "may not work yet. Non-modular likelihoods are more reliable without parallelization." << std::endl;
+         // The RooRealL that is used in the case where the modular likelihood is being passed to a RooMinimizerFcn does
+         // not have offsetting implemented. Therefore, offsetting will not work in this case. Other features might also
+         // not work since the RooRealL was not intended for minimization. Further development is required to make the
+         // MinuitFcnGrad also handle serial gradient minimization. The MinuitFcnGrad accepts a RooAbsL and has
+         // offsetting implemented, thus omitting the need for RooRealL minimization altogether.
          _fcn = std::make_unique<RooMinimizerFcn>(&function, this);
       }
    } else {
@@ -314,10 +315,9 @@ int RooMinimizer::minimize(const char *type, const char *alg)
 #ifdef R__HAS_ROOFIT_MULTIPROCESS
       addParamsToProcessTimer();
 #else
-      throw std::logic_error(
-            "ProcessTimer, but ROOT was not compiled with multiprocessing enabled, "
-            "please recompile with -Droofit_multiprocess=ON for logging with the "
-            "ProcessTimer.");
+      throw std::logic_error("ProcessTimer, but ROOT was not compiled with multiprocessing enabled, "
+                             "please recompile with -Droofit_multiprocess=ON for logging with the "
+                             "ProcessTimer.");
 #endif
    }
    _fcn->Synchronize(_theFitter->Config().ParamsSettings());
@@ -386,7 +386,6 @@ int RooMinimizer::hesse()
          _theFitter->Config().SetMinimizer(_cfg.minimizerType.c_str());
          bool ret = _theFitter->CalculateHessErrors();
          _status = ((ret) ? _theFitter->Result().Status() : -1);
-
       }
       profileStop();
       _fcn->BackProp(_theFitter->Result());
@@ -467,7 +466,6 @@ int RooMinimizer::minos(const RooArgSet &minosParamList)
             // to avoid that following minimization computes automatically the Minos errors
             _theFitter->Config().SetMinosErrors(false);
          }
-
       }
       profileStop();
       _fcn->BackProp(_theFitter->Result());
@@ -519,7 +517,6 @@ int RooMinimizer::simplex()
       _theFitter->Config().SetMinimizer(_cfg.minimizerType.c_str(), "simplex");
       bool ret = fitFcn();
       _status = ((ret) ? _theFitter->Result().Status() : -1);
-
    }
    profileStop();
    _fcn->BackProp(_theFitter->Result());
@@ -545,7 +542,6 @@ int RooMinimizer::improve()
       _theFitter->Config().SetMinimizer(_cfg.minimizerType.c_str(), "migradimproved");
       bool ret = fitFcn();
       _status = ((ret) ? _theFitter->Result().Status() : -1);
-
    }
    profileStop();
    _fcn->BackProp(_theFitter->Result());
@@ -757,15 +753,15 @@ RooPlot *RooMinimizer::contour(RooRealVar &var1, RooRealVar &var2, double n1, do
 void RooMinimizer::addParamsToProcessTimer()
 {
 #ifdef R__HAS_ROOFIT_MULTIPROCESS
-  // parameter indices for use in timing heat matrix
-  std::vector<std::string> parameter_names;
-  for (auto && parameter : *_fcn->GetFloatParamList()) {
-    parameter_names.push_back(parameter->GetName());
-    if (_cfg.verbose) {
-      coutI(Minimization) << "parameter name: " << parameter_names.back() << std::endl;
-    }
-  }
-  RooFit::MultiProcess::ProcessTimer::add_metadata(parameter_names);
+   // parameter indices for use in timing heat matrix
+   std::vector<std::string> parameter_names;
+   for (auto &&parameter : *_fcn->GetFloatParamList()) {
+      parameter_names.push_back(parameter->GetName());
+      if (_cfg.verbose) {
+         coutI(Minimization) << "parameter name: " << parameter_names.back() << std::endl;
+      }
+   }
+   RooFit::MultiProcess::ProcessTimer::add_metadata(parameter_names);
 #else
    coutI(Minimization) << "Not adding parameters to processtimer because multiprocessing "
                        << "is not enabled." << std::endl;


### PR DESCRIPTION
For the minimization, the RooMinimizer sets the error logging mode
temporarily to `CollectErrors`, which collects all error messages in
strings. This results in a HUGE overhead, which is completely
unnecessary if evaluation error printing is disabled. In that case, the
error evaluation mode should be set to counting only, which is what this
commit implements.

This speeds up fits with frequent evaluation errors a lot, for example
the `testNaNPacker` tests are sped up by 25x.
