### PR TITLE
[RF] Clearly mark `RooFit::CloneData()` as deprecated

### DIFF
--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -936,7 +936,8 @@ double RooAbsPdf::extendedTerm(RooAbsData const& data, bool weightSquared, bool 
 /// <tr><td> `GlobalObservablesTag(const char* tagName)` <td> Define the set of normalization observables to be used for the constraint terms by
 ///                                                         a string attribute associated with pdf observables that match the given tagName.
 /// <tr><td> `Verbose(bool flag)`           <td> Controls RooFit informational messages in likelihood construction
-/// <tr><td> `CloneData(bool flag)`            <td> Use clone of dataset in NLL (default is true)
+/// <tr><td> `CloneData(bool flag)`            <td> Use clone of dataset in NLL (default is true).
+///                                                 \warning Deprecated option that is ignored. It is up to the implementation of the NLL creation method if the data is cloned or not.
 /// <tr><td> `Offset(std::string const& mode)` <td> Likelihood offsetting mode. Can be either:
 ///                                                 - `"none"` (default): no offsetting
 ///                                                 - `"initial"`: Offset likelihood by initial value (so that starting value of FCN in minuit is zero).

--- a/roofit/roofitcore/src/RooGlobalFunc.cxx
+++ b/roofit/roofitcore/src/RooGlobalFunc.cxx
@@ -275,7 +275,10 @@ namespace RooFit {
   RooCmdArg EvalErrorWall(bool flag)                   { return RooCmdArg("EvalErrorWall",flag,0,0,0,0,0,0,0) ; }
   RooCmdArg SumW2Error(bool flag)                      { return RooCmdArg("SumW2Error",flag,0,0,0,0,0,0,0) ; }
   RooCmdArg AsymptoticError(bool flag)                      { return RooCmdArg("AsymptoticError",flag,0,0,0,0,0,0,0) ; }
-  RooCmdArg CloneData(bool flag)                       { return RooCmdArg("CloneData",flag,0,0,0,0,0,0,0) ; }
+  RooCmdArg CloneData(bool flag)                       {
+      oocoutI(nullptr, InputArguments) << "The deprecated RooFit::CloneData(" << flag << ") option passed to createNLL() is ignored." << std::endl;
+      return RooCmdArg("CloneData",flag,0,0,0,0,0,0,0) ;
+  }
   RooCmdArg Integrate(bool flag)                       { return RooCmdArg("Integrate",flag,0,0,0,0,0,0,0) ; }
   RooCmdArg Minimizer(const char* type, const char* alg) { return RooCmdArg("Minimizer",0,0,0,0,type,alg,0,0) ; }
 


### PR DESCRIPTION
Marking the `CloneData()` argument for createNLL explicitly as deprecated and noting in the docs that it is ignored.

There is no reason to support it now. The new BatchMode doesn't clone the data anyway, the new test statistics with multiprocessing need to clone the data for each process anyway, and the old test statistics classes will be deprecated at some point.

Closes the following Jira ticket:
https://sft.its.cern.ch/jira/browse/ROOT-10372