### PR TITLE
[ntuple] Bump in-memory representation of offsets to 64bit

### DIFF
--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -73,7 +73,7 @@ public:
 
    const RColumnRepresentations &GetColumnRepresentations() const final
    {
-      static RColumnRepresentations representations({{EColumnType::kIndex}}, {{}});
+      static RColumnRepresentations representations({{EColumnType::kIndex32}}, {{}});
       return representations;
    }
    // Field is only used for reading

--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -568,7 +568,7 @@ public:
 };
 
 template <>
-class RColumnElement<ClusterSize_t, EColumnType::kIndex> : public RColumnElementBase {
+class RColumnElement<ClusterSize_t, EColumnType::kIndex32> : public RColumnElementBase {
 public:
    static constexpr bool kIsMappable = false;
    static constexpr std::size_t kSize = sizeof(ClusterSize_t);
@@ -663,7 +663,7 @@ template <typename CppT>
 std::unique_ptr<RColumnElementBase> RColumnElementBase::Generate(EColumnType type)
 {
    switch (type) {
-   case EColumnType::kIndex: return std::make_unique<RColumnElement<CppT, EColumnType::kIndex>>(nullptr);
+   case EColumnType::kIndex32: return std::make_unique<RColumnElement<CppT, EColumnType::kIndex32>>(nullptr);
    case EColumnType::kSwitch: return std::make_unique<RColumnElement<CppT, EColumnType::kSwitch>>(nullptr);
    case EColumnType::kByte: return std::make_unique<RColumnElement<CppT, EColumnType::kByte>>(nullptr);
    case EColumnType::kChar: return std::make_unique<RColumnElement<CppT, EColumnType::kChar>>(nullptr);

--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -568,13 +568,17 @@ public:
 };
 
 template <>
-class RColumnElement<ClusterSize_t, EColumnType::kIndex> : public RColumnElementLE<ClusterSize_t::ValueType> {
+class RColumnElement<ClusterSize_t, EColumnType::kIndex> : public RColumnElementBase {
 public:
-   static constexpr std::size_t kSize = sizeof(ROOT::Experimental::ClusterSize_t);
-   static constexpr std::size_t kBitsOnStorage = kSize * 8;
-   explicit RColumnElement(ClusterSize_t *value) : RColumnElementLE(value, kSize) {}
+   static constexpr bool kIsMappable = false;
+   static constexpr std::size_t kSize = sizeof(ClusterSize_t);
+   static constexpr std::size_t kBitsOnStorage = 32;
+   explicit RColumnElement(ClusterSize_t *value) : RColumnElementBase(value, kSize) {}
    bool IsMappable() const final { return kIsMappable; }
    std::size_t GetBitsOnStorage() const final { return kBitsOnStorage; }
+
+   void Pack(void *dst, void *src, std::size_t count) const final;
+   void Unpack(void *dst, void *src, std::size_t count) const final;
 };
 
 template <>
@@ -582,7 +586,7 @@ class RColumnElement<RColumnSwitch, EColumnType::kSwitch> : public RColumnElemen
 public:
    static constexpr bool kIsMappable = false;
    static constexpr std::size_t kSize = sizeof(ROOT::Experimental::RColumnSwitch);
-   static constexpr std::size_t kBitsOnStorage = kSize * 8;
+   static constexpr std::size_t kBitsOnStorage = 64;
    explicit RColumnElement(RColumnSwitch *value) : RColumnElementBase(value, kSize) {}
    bool IsMappable() const final { return kIsMappable; }
    std::size_t GetBitsOnStorage() const final { return kBitsOnStorage; }

--- a/tree/ntuple/v7/inc/ROOT/RColumnModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnModel.hxx
@@ -43,9 +43,9 @@ When changed, remember to update
 enum class EColumnType {
    kUnknown = 0,
    // type for root columns of (nested) collections; 32bit integers that count relative to the current cluster
-   kIndex,
-   // 64 bit column that uses the lower 32bits as kIndex and the higher 32bits as a dispatch tag; used, e.g.,
-   // in order to serialize std::variant
+   kIndex32,
+   // 64 bit column that uses the lower 44 bits like kIndex64, higher 20 bits are a dispatch tag to a column ID;
+   // used to serialize std::variant.
    kSwitch,
    kByte,
    kChar,
@@ -79,7 +79,7 @@ private:
 
 public:
    RColumnModel() : fType(EColumnType::kUnknown), fIsSorted(false) {}
-   explicit RColumnModel(EColumnType type) : fType(type), fIsSorted(type == EColumnType::kIndex) {}
+   explicit RColumnModel(EColumnType type) : fType(type), fIsSorted(type == EColumnType::kIndex32) {}
    RColumnModel(EColumnType type, bool isSorted) : fType(type), fIsSorted(isSorted) {}
 
    EColumnType GetType() const { return fType; }

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -1635,7 +1635,7 @@ template <>
 class RField<std::string> : public Detail::RFieldBase {
 private:
    ClusterSize_t fIndex;
-   Detail::RColumnElement<ClusterSize_t, EColumnType::kIndex> fElemIndex;
+   Detail::RColumnElement<ClusterSize_t, EColumnType::kIndex32> fElemIndex;
 
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final {
       return std::make_unique<RField>(newName);
@@ -1853,7 +1853,7 @@ protected:
          auto itemValue = fSubFields[0]->CaptureValue(&typedValue->data()[i]);
          nbytes += fSubFields[0]->Append(itemValue);
       }
-      Detail::RColumnElement<ClusterSize_t, EColumnType::kIndex> elemIndex(&this->fNWritten);
+      Detail::RColumnElement<ClusterSize_t, EColumnType::kIndex32> elemIndex(&this->fNWritten);
       this->fNWritten += count;
       fColumns[0]->Append(elemIndex);
       return nbytes + sizeof(elemIndex);

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -207,7 +207,7 @@ public:
       DescriptorId_t fPhysicalColumnId = kInvalidDescriptorId;
       /// A 64bit element index
       NTupleSize_t fFirstElementIndex = kInvalidNTupleIndex;
-      /// A 32bit value for the number of column elements in the cluster
+      /// The number of column elements in the cluster
       ClusterSize_t fNElements = kInvalidClusterIndex;
       /// The usual format for ROOT compression settings (see Compression.h).
       /// The pages of a particular column in a particular cluster are all compressed with the same settings.
@@ -232,7 +232,7 @@ public:
       /// the page belongs
       struct RPageInfo {
          /// The sum of the elements of all the pages must match the corresponding fNElements field in fColumnRanges
-         ClusterSize_t fNElements = kInvalidClusterIndex;
+         std::uint32_t fNElements = std::uint32_t(-1);
          /// The meaning of fLocator depends on the storage backend.
          RNTupleLocator fLocator;
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -47,9 +47,9 @@ enum ENTupleStructure {
 /// Integer type long enough to hold the maximum number of entries in a column
 using NTupleSize_t = std::uint64_t;
 constexpr NTupleSize_t kInvalidNTupleIndex = std::uint64_t(-1);
-/// Wrap the 32bit integer in a struct in order to avoid template specialization clash with std::uint32_t
+/// Wrap the integer in a struct in order to avoid template specialization clash with std::uint32_t
 struct RClusterSize {
-   using ValueType = std::uint32_t;
+   using ValueType = std::uint64_t;
 
    RClusterSize() : fValue(0) {}
    explicit constexpr RClusterSize(ValueType value) : fValue(value) {}
@@ -61,7 +61,7 @@ struct RClusterSize {
    ValueType fValue;
 };
 using ClusterSize_t = RClusterSize;
-constexpr ClusterSize_t kInvalidClusterIndex(std::uint32_t(-1));
+constexpr ClusterSize_t kInvalidClusterIndex(std::uint64_t(-1));
 
 /// Helper type to present an offset column as array of collection sizes. See RField<RNTupleCardinality> for details.
 struct RNTupleCardinality {

--- a/tree/ntuple/v7/inc/ROOT/RPage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPage.hxx
@@ -59,10 +59,10 @@ public:
 private:
    ColumnId_t fColumnId;
    void *fBuffer;
-   ClusterSize_t::ValueType fElementSize;
-   ClusterSize_t::ValueType fNElements;
+   std::uint32_t fElementSize;
+   std::uint32_t fNElements;
    /// The capacity of the page in number of elements
-   ClusterSize_t::ValueType fMaxElements;
+   std::uint32_t fMaxElements;
    NTupleSize_t fRangeFirst;
    RClusterInfo fClusterInfo;
 
@@ -78,10 +78,10 @@ public:
 
    ColumnId_t GetColumnId() const { return fColumnId; }
    /// The space taken by column elements in the buffer
-   ClusterSize_t::ValueType GetNBytes() const { return fElementSize * fNElements; }
-   ClusterSize_t::ValueType GetElementSize() const { return fElementSize; }
-   ClusterSize_t::ValueType GetNElements() const { return fNElements; }
-   ClusterSize_t::ValueType GetMaxElements() const { return fMaxElements; }
+   std::uint32_t GetNBytes() const { return fElementSize * fNElements; }
+   std::uint32_t GetElementSize() const { return fElementSize; }
+   std::uint32_t GetNElements() const { return fNElements; }
+   std::uint32_t GetMaxElements() const { return fMaxElements; }
    NTupleSize_t GetGlobalRangeFirst() const { return fRangeFirst; }
    NTupleSize_t GetGlobalRangeLast() const { return fRangeFirst + NTupleSize_t(fNElements) - 1; }
    ClusterSize_t::ValueType GetClusterRangeFirst() const { return fRangeFirst - fClusterInfo.GetIndexOffset(); }

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -166,6 +166,34 @@ void ROOT::Experimental::Detail::RColumnElement<bool, ROOT::Experimental::EColum
 }
 
 
+void ROOT::Experimental::Detail::RColumnElement<
+   ROOT::Experimental::ClusterSize_t, ROOT::Experimental::EColumnType::kIndex>::Pack(
+   void *dst, void *src, std::size_t count) const
+{
+   std::int64_t *int64Array = reinterpret_cast<std::int64_t *>(src);
+   std::int32_t *int32Array = reinterpret_cast<std::int32_t *>(dst);
+   for (std::size_t i = 0; i < count; ++i) {
+      int32Array[i] = int64Array[i];
+#if R__LITTLE_ENDIAN == 0
+      int32Array[i] = RByteSwap<4>::bswap(int32Array[i]);
+#endif
+   }
+}
+
+void ROOT::Experimental::Detail::RColumnElement<
+   ROOT::Experimental::ClusterSize_t, ROOT::Experimental::EColumnType::kIndex>::Unpack(
+   void *dst, void *src, std::size_t count) const
+{
+   std::int32_t *int32Array = reinterpret_cast<std::int32_t *>(src);
+   std::int64_t *int64Array = reinterpret_cast<std::int64_t *>(dst);
+   for (std::size_t i = 0; i < count; ++i) {
+      int64Array[i] = int32Array[i];
+#if R__LITTLE_ENDIAN == 0
+      int64Array[i] = RByteSwap<8>::bswap(int64Array[i]);
+#endif
+   }
+}
+
 void ROOT::Experimental::Detail::RColumnElement<std::int64_t, ROOT::Experimental::EColumnType::kInt32>::Pack(
   void *dst, void *src, std::size_t count) const
 {

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -28,7 +28,7 @@ std::unique_ptr<ROOT::Experimental::Detail::RColumnElementBase>
 ROOT::Experimental::Detail::RColumnElementBase::Generate<void>(EColumnType type)
 {
    switch (type) {
-   case EColumnType::kIndex: return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kIndex>>(nullptr);
+   case EColumnType::kIndex32: return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kIndex32>>(nullptr);
    case EColumnType::kSwitch: return std::make_unique<RColumnElement<RColumnSwitch, EColumnType::kSwitch>>(nullptr);
    case EColumnType::kByte: return std::make_unique<RColumnElement<std::uint8_t, EColumnType::kByte>>(nullptr);
    case EColumnType::kChar: return std::make_unique<RColumnElement<char, EColumnType::kChar>>(nullptr);
@@ -55,7 +55,7 @@ ROOT::Experimental::Detail::RColumnElementBase::Generate<void>(EColumnType type)
 
 std::size_t ROOT::Experimental::Detail::RColumnElementBase::GetBitsOnStorage(EColumnType type) {
    switch (type) {
-   case EColumnType::kIndex: return 32;
+   case EColumnType::kIndex32: return 32;
    case EColumnType::kSwitch: return 64;
    case EColumnType::kByte: return 8;
    case EColumnType::kChar: return 8;
@@ -79,7 +79,7 @@ std::size_t ROOT::Experimental::Detail::RColumnElementBase::GetBitsOnStorage(ECo
 
 std::string ROOT::Experimental::Detail::RColumnElementBase::GetTypeName(EColumnType type) {
    switch (type) {
-   case EColumnType::kIndex: return "Index";
+   case EColumnType::kIndex32: return "Index";
    case EColumnType::kSwitch: return "Switch";
    case EColumnType::kByte: return "Byte";
    case EColumnType::kChar: return "Char";
@@ -167,7 +167,7 @@ void ROOT::Experimental::Detail::RColumnElement<bool, ROOT::Experimental::EColum
 
 
 void ROOT::Experimental::Detail::RColumnElement<
-   ROOT::Experimental::ClusterSize_t, ROOT::Experimental::EColumnType::kIndex>::Pack(
+   ROOT::Experimental::ClusterSize_t, ROOT::Experimental::EColumnType::kIndex32>::Pack(
    void *dst, void *src, std::size_t count) const
 {
    std::int64_t *int64Array = reinterpret_cast<std::int64_t *>(src);
@@ -181,7 +181,7 @@ void ROOT::Experimental::Detail::RColumnElement<
 }
 
 void ROOT::Experimental::Detail::RColumnElement<
-   ROOT::Experimental::ClusterSize_t, ROOT::Experimental::EColumnType::kIndex>::Unpack(
+   ROOT::Experimental::ClusterSize_t, ROOT::Experimental::EColumnType::kIndex32>::Unpack(
    void *dst, void *src, std::size_t count) const
 {
    std::int32_t *int32Array = reinterpret_cast<std::int32_t *>(src);

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -165,10 +165,9 @@ void ROOT::Experimental::Detail::RColumnElement<bool, ROOT::Experimental::EColum
    }
 }
 
-
 void ROOT::Experimental::Detail::RColumnElement<
-   ROOT::Experimental::ClusterSize_t, ROOT::Experimental::EColumnType::kIndex32>::Pack(
-   void *dst, void *src, std::size_t count) const
+   ROOT::Experimental::ClusterSize_t, ROOT::Experimental::EColumnType::kIndex32>::Pack(void *dst, void *src,
+                                                                                       std::size_t count) const
 {
    std::int64_t *int64Array = reinterpret_cast<std::int64_t *>(src);
    std::int32_t *int32Array = reinterpret_cast<std::int32_t *>(dst);
@@ -181,8 +180,8 @@ void ROOT::Experimental::Detail::RColumnElement<
 }
 
 void ROOT::Experimental::Detail::RColumnElement<
-   ROOT::Experimental::ClusterSize_t, ROOT::Experimental::EColumnType::kIndex32>::Unpack(
-   void *dst, void *src, std::size_t count) const
+   ROOT::Experimental::ClusterSize_t, ROOT::Experimental::EColumnType::kIndex32>::Unpack(void *dst, void *src,
+                                                                                         std::size_t count) const
 {
    std::int32_t *int32Array = reinterpret_cast<std::int32_t *>(src);
    std::int64_t *int64Array = reinterpret_cast<std::int64_t *>(dst);

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -589,7 +589,7 @@ void ROOT::Experimental::RFieldZero::AcceptVisitor(Detail::RFieldVisitor &visito
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kIndex}}, {{}});
+   static RColumnRepresentations representations({{EColumnType::kIndex32}}, {{}});
    return representations;
 }
 
@@ -614,7 +614,7 @@ void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::AcceptVisito
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<ROOT::Experimental::RNTupleCardinality>::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kIndex}}, {{}});
+   static RColumnRepresentations representations({{EColumnType::kIndex32}}, {{}});
    return representations;
 }
 
@@ -938,7 +938,7 @@ void ROOT::Experimental::RField<std::int64_t>::AcceptVisitor(Detail::RFieldVisit
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<std::string>::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kIndex, EColumnType::kChar}}, {{}});
+   static RColumnRepresentations representations({{EColumnType::kIndex32, EColumnType::kChar}}, {{}});
    return representations;
 }
 
@@ -1296,7 +1296,7 @@ void ROOT::Experimental::RCollectionClassField::ReadGlobalImpl(NTupleSize_t glob
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RCollectionClassField::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kIndex}}, {{}});
+   static RColumnRepresentations representations({{EColumnType::kIndex32}}, {{}});
    return representations;
 }
 
@@ -1557,7 +1557,7 @@ void ROOT::Experimental::RVectorField::ReadGlobalImpl(NTupleSize_t globalIndex, 
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RVectorField::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kIndex}}, {{}});
+   static RColumnRepresentations representations({{EColumnType::kIndex32}}, {{}});
    return representations;
 }
 
@@ -1728,7 +1728,7 @@ void ROOT::Experimental::RRVecField::ReadGlobalImpl(NTupleSize_t globalIndex, De
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RRVecField::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kIndex}}, {{}});
+   static RColumnRepresentations representations({{EColumnType::kIndex32}}, {{}});
    return representations;
 }
 
@@ -1915,7 +1915,7 @@ void ROOT::Experimental::RField<std::vector<bool>>::ReadGlobalImpl(NTupleSize_t 
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<std::vector<bool>>::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kIndex}}, {{}});
+   static RColumnRepresentations representations({{EColumnType::kIndex32}}, {{}});
    return representations;
 }
 
@@ -2341,7 +2341,7 @@ ROOT::Experimental::RCollectionField::RCollectionField(
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RCollectionField::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kIndex}}, {{}});
+   static RColumnRepresentations representations({{EColumnType::kIndex32}}, {{}});
    return representations;
 }
 

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -195,7 +195,7 @@ std::uint32_t SerializeColumnListV1(
          if (c.GetModel().GetIsSorted())
             flags |= RNTupleSerializer::kFlagSortAscColumn;
          // TODO(jblomer): fix for unsigned integer types
-         if (type == ROOT::Experimental::EColumnType::kIndex)
+         if (type == ROOT::Experimental::EColumnType::kIndex32)
             flags |= RNTupleSerializer::kFlagNonNegativeColumn;
          pos += RNTupleSerializer::SerializeUInt32(flags, *where);
 
@@ -228,7 +228,7 @@ RResult<std::uint32_t> DeserializeColumnV1(
    bytes += result.Unwrap();
 
    // Initialize properly for SerializeColumnType
-   EColumnType type{EColumnType::kIndex};
+   EColumnType type{EColumnType::kIndex32};
    std::uint16_t bitsOnStorage;
    std::uint32_t fieldId;
    std::uint32_t flags;
@@ -508,7 +508,7 @@ std::uint16_t ROOT::Experimental::Internal::RNTupleSerializer::SerializeColumnTy
 {
    using EColumnType = ROOT::Experimental::EColumnType;
    switch (type) {
-   case EColumnType::kIndex: return SerializeUInt16(0x02, buffer);
+   case EColumnType::kIndex32: return SerializeUInt16(0x02, buffer);
    case EColumnType::kSwitch: return SerializeUInt16(0x03, buffer);
    case EColumnType::kByte: return SerializeUInt16(0x04, buffer);
    case EColumnType::kChar: return SerializeUInt16(0x05, buffer);
@@ -537,7 +537,7 @@ RResult<std::uint16_t> ROOT::Experimental::Internal::RNTupleSerializer::Deserial
    std::uint16_t onDiskType;
    auto result = DeserializeUInt16(buffer, onDiskType);
    switch (onDiskType) {
-   case 0x02: type = EColumnType::kIndex; break;
+   case 0x02: type = EColumnType::kIndex32; break;
    case 0x03: type = EColumnType::kSwitch; break;
    case 0x04: type = EColumnType::kByte; break;
    case 0x05: type = EColumnType::kChar; break;

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -1474,7 +1474,7 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::Internal::RNTupleSerialize
             result = DeserializeLocator(bytes, fnInnerFrameSizeLeft(), locator);
             if (!result)
                return R__FORWARD_ERROR(result);
-            pageRange.fPageInfos.push_back({ClusterSize_t(nElements), locator});
+            pageRange.fPageInfos.push_back({nElements, locator});
             bytes += result.Unwrap();
          }
 

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -497,7 +497,7 @@ ROOT::Experimental::Detail::RPageSink::SealPage(const RPage &page,
 
    R__ASSERT(isAdoptedBuffer);
 
-   return RSealedPage{pageBuf, zippedBytes, page.GetNElements()};
+   return RSealedPage{pageBuf, static_cast<std::uint32_t>(zippedBytes), page.GetNElements()};
 }
 
 ROOT::Experimental::Detail::RPageStorage::RSealedPage

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -509,7 +509,7 @@ TEST(RNTuple, SerializeHeader)
    builder.AddFieldLink(137, 13);
    builder.AddColumn(23, 23, 42, RColumnModel(EColumnType::kReal32, false), 0);
    builder.AddColumn(100, 23, 24, RColumnModel(EColumnType::kReal32, false), 0);
-   builder.AddColumn(17, 17, 137, RColumnModel(EColumnType::kIndex, true), 0);
+   builder.AddColumn(17, 17, 137, RColumnModel(EColumnType::kIndex32, true), 0);
    builder.AddColumn(40, 40, 137, RColumnModel(EColumnType::kByte, true), 1);
 
    auto desc = builder.MoveDescriptor();
@@ -546,7 +546,7 @@ TEST(RNTuple, SerializeFooter)
       .MakeDescriptor()
       .Unwrap());
    builder.AddFieldLink(0, 42);
-   builder.AddColumn(17, 17, 42, RColumnModel(EColumnType::kIndex, true), 0);
+   builder.AddColumn(17, 17, 42, RColumnModel(EColumnType::kIndex32, true), 0);
 
    ROOT::Experimental::RClusterDescriptor::RColumnRange columnRange;
    ROOT::Experimental::RClusterDescriptor::RPageRange::RPageInfo pageInfo;


### PR DESCRIPTION
In preparation of adding support for the `SplitIndex[32|64]` and `Index64` column types, this PR bumps `RClusterSize_t` from 32bit to 64bit. On-disk representation stays as is, 32bit. This change makes sure that "big clusters" (>512MB) with 64bit offset columns will be properly supported.