### PR TITLE
[CI] skip root-ci on forks

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -65,6 +65,7 @@ env:
 
 jobs:
   build-linux:
+    if: github.repository_owner == 'root-project'
     permissions:
       contents: read
 


### PR DESCRIPTION
# This Pull request:

Makes `root-ci` get skipped on forks of the repository
