### PR TITLE
Revert "Do not install {Clang,Cling}Config.cmake in the project lib dir"

### DIFF
--- a/interpreter/cling/cmake/modules/CMakeLists.txt
+++ b/interpreter/cling/cmake/modules/CMakeLists.txt
@@ -2,7 +2,7 @@
 # link against them. LLVM calls its version of this file LLVMExports.cmake, but
 # the usual CMake convention seems to be ${Project}Targets.cmake.
 set(CLING_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/cling)
-set(cling_cmake_builddir "${LLVM_BINARY_DIR}/${CLING_INSTALL_PACKAGE_DIR}")
+set(cling_cmake_builddir "${CMAKE_BINARY_DIR}/${CLING_INSTALL_PACKAGE_DIR}")
 
 # Keep this in sync with llvm/cmake/CMakeLists.txt!
 set(LLVM_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm)

--- a/interpreter/llvm/src/tools/clang/cmake/modules/CMakeLists.txt
+++ b/interpreter/llvm/src/tools/clang/cmake/modules/CMakeLists.txt
@@ -4,7 +4,7 @@ include(LLVMDistributionSupport)
 # link against them. LLVM calls its version of this file LLVMExports.cmake, but
 # the usual CMake convention seems to be ${Project}Targets.cmake.
 set(CLANG_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/clang)
-set(clang_cmake_builddir "${CLANG_BINARY_DIR}/${CLANG_INSTALL_PACKAGE_DIR}")
+set(clang_cmake_builddir "${CMAKE_BINARY_DIR}/${CLANG_INSTALL_PACKAGE_DIR}")
 
 # Keep this in sync with llvm/cmake/CMakeLists.txt!
 set(LLVM_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm)


### PR DESCRIPTION
This reverts commit 2b283ccf3a624f70dab3e8783d361d25c13e2c65. It might not be needed, see https://github.com/root-project/root/pull/12153#issuecomment-1411591339

FYI @stephanlachnit 