### PR TITLE
[cling] Set DataLayout from our TargetMachine

### DIFF
--- a/interpreter/cling/lib/Interpreter/IncrementalJIT.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalJIT.cpp
@@ -499,6 +499,7 @@ IncrementalJIT::IncrementalJIT(
   ErrorAsOutParameter _(&Err);
 
   LLJITBuilder Builder;
+  Builder.setDataLayout(m_TM->createDataLayout());
   Builder.setExecutorProcessControl(std::move(EPC));
 
   // Create ObjectLinkingLayer with our own MemoryManager.


### PR DESCRIPTION
Otherwise `LLJIT`'s constructor will ask the `LLJITBuilder`'s `JTMB` to create a `DataLayout`. As we don't propagate the `JTMB` (yet -- we probably should!), this will be wrong if target features influence the `DataLayout`.

This should fix #12293.