### PR TITLE
[math][minuit] Add missing SetErrorDef for the Minuit2 gradient function

### DIFF
--- a/math/minuit2/inc/Minuit2/FCNGradAdapter.h
+++ b/math/minuit2/inc/Minuit2/FCNGradAdapter.h
@@ -118,6 +118,8 @@ public:
    template<class Func>
    void SetHessianFunction(Func f) { fHessianFunc = f;}
 
+   void SetErrorDef(double up) override { fUp = up; }
+
 private:
    const Function &fFunc;
    double fUp;


### PR DESCRIPTION
SetErrorDef was not implemented for the FCNGradAdapter used to wrap the user functions in the Minuit interface. This causes that the current set ErrorDef was not used when minimizing but the one set when constructed the function.

This fixes issue #12338

