### PR TITLE
[DF][tree] Backport fix for MT RDF + TTreeIndex (v6.28)

### DIFF
--- a/bindings/experimental/distrdf/python/DistRDF/HeadNode.py
+++ b/bindings/experimental/distrdf/python/DistRDF/HeadNode.py
@@ -377,6 +377,15 @@ class TreeHeadNode(HeadNode):
         if isinstance(args[0], ROOT.TTree):
             # RDataFrame(tree, defaultBranches = {})
             self.tree = args[0]
+            # TTreeIndex is not supported in distributed RDataFrame
+            list_of_friends = self.tree.GetListOfFriends()
+            if list_of_friends and list_of_friends.GetEntries() > 0:
+                for friend_element in list_of_friends:
+                    if friend_element.GetTree().GetTreeIndex():
+                        raise ValueError(
+                            f"Friend tree '{friend_element.GetName()}' has a TTreeIndex. "
+                            "This is not supported in distributed mode."
+                        )
             # Retrieve information about friend trees when user passes a TTree
             # or TChain object.
             fi = ROOT.Internal.TreeUtils.GetFriendInfo(args[0])

--- a/bindings/experimental/distrdf/test/test_headnode.py
+++ b/bindings/experimental/distrdf/test/test_headnode.py
@@ -14,6 +14,47 @@ def create_dummy_headnode(*args):
     return get_headnode(None, None, *args)
 
 
+def fill_main_tree_and_indexed_friend(mainfile, auxfile):
+    idx = array("i", [0])
+    x = array("i", [0])
+    y = array("i", [0])
+
+    with ROOT.TFile(mainfile, "RECREATE") as f1:
+        main_tree = ROOT.TTree("mainTree", "mainTree")
+        main_tree.Branch("idx", idx, "idx/I")
+        main_tree.Branch("x", x, "x/I")
+
+        idx[0] = 1
+        x[0] = 1
+        main_tree.Fill()
+        idx[0] = 1
+        x[0] = 2
+        main_tree.Fill()
+        idx[0] = 1
+        x[0] = 3
+        main_tree.Fill()
+        idx[0] = 2
+        x[0] = 4
+        main_tree.Fill()
+        idx[0] = 2
+        x[0] = 5
+        main_tree.Fill()
+        f1.WriteObject(main_tree, "mainTree")
+
+    with ROOT.TFile(auxfile, "RECREATE") as f2:
+        aux_tree = ROOT.TTree("auxTree", "auxTree")
+        aux_tree.Branch("idx", idx, "idx/I")
+        aux_tree.Branch("y", y, "y/I")
+
+        idx[0] = 2
+        y[0] = 5
+        aux_tree.Fill()
+        idx[0] = 1
+        y[0] = 7
+        aux_tree.Fill()
+        f2.WriteObject(aux_tree, "auxTree")
+
+
 class DataFrameConstructorTests(unittest.TestCase):
     """Check various functionalities of the HeadNode class"""
 
@@ -162,6 +203,34 @@ class DataFrameConstructorTests(unittest.TestCase):
         self.assertIsInstance(hn_3.defaultbranches, type(rdf_branches))
         self.assertIsInstance(hn_2.defaultbranches, type(reqd_branches_vec))
         self.assertIsInstance(hn_4.defaultbranches, type(reqd_branches_vec))
+
+    def test_tree_with_friends_and_treeindex(self):
+        """TTreeIndex is not supported in distributed mode."""
+        # See https://github.com/root-project/root/issues/7541 and
+        # https://bugs.llvm.org/show_bug.cgi?id=49692 :
+        # llvm JIT fails to catch exceptions on M1, so we disable their testing
+        if platform.processor() != "arm" or platform.mac_ver()[0] == '':
+            main_file = "distrdf_indexed_friend_main.root"
+            aux_file = "distrdf_indexed_friend_aux.root"
+            fill_main_tree_and_indexed_friend(main_file, aux_file)
+
+            main_chain = ROOT.TChain("mainTree", "mainTree")
+            main_chain.Add(main_file)
+            aux_chain = ROOT.TChain("auxTree", "auxTree")
+            aux_chain.Add(aux_file)
+
+            aux_chain.BuildIndex("idx")
+            main_chain.AddFriend(aux_chain)
+
+            with self.assertRaises(ValueError) as context:
+                create_dummy_headnode(main_chain)
+
+            self.assertEqual(str(context.exception),
+                            "Friend tree 'auxTree' has a TTreeIndex. This is not supported in distributed mode.")
+
+            # Remove unnecessary .root files
+            os.remove(main_file)
+            os.remove(aux_file)
 
 
 class NumEntriesTest(unittest.TestCase):

--- a/tree/tree/inc/ROOT/InternalTreeUtils.hxx
+++ b/tree/tree/inc/ROOT/InternalTreeUtils.hxx
@@ -18,6 +18,7 @@
 #ifndef ROOT_INTERNAL_TREEUTILS_H
 #define ROOT_INTERNAL_TREEUTILS_H
 
+#include "TTree.h"
 #include "TChain.h"
 #include "TNotifyLink.h"
 #include "TObjArray.h"
@@ -27,8 +28,6 @@
 #include <string>
 #include <utility> // std::pair
 #include <vector>
-
-class TTree;
 
 namespace ROOT {
 namespace Internal {
@@ -41,7 +40,7 @@ namespace TreeUtils {
 
 std::vector<std::string> GetTopLevelBranchNames(TTree &t);
 std::vector<std::string> GetFileNamesFromTree(const TTree &tree);
-ROOT::TreeUtils::RFriendInfo GetFriendInfo(const TTree &tree);
+ROOT::TreeUtils::RFriendInfo GetFriendInfo(const TTree &tree, bool retrieveEntries = false);
 std::vector<std::string> GetTreeFullPaths(const TTree &tree);
 
 void ClearMustCleanupBits(TObjArray &arr);
@@ -77,6 +76,7 @@ public:
 };
 
 std::unique_ptr<TChain> MakeChainForMT(const std::string &name = "", const std::string &title = "");
+std::vector<std::unique_ptr<TChain>> MakeFriends(const ROOT::TreeUtils::RFriendInfo &finfo);
 
 } // namespace TreeUtils
 } // namespace Internal

--- a/tree/tree/inc/ROOT/RFriendInfo.hxx
+++ b/tree/tree/inc/ROOT/RFriendInfo.hxx
@@ -19,6 +19,7 @@
 #define ROOT_RFRIENDINFO_H
 
 #include <cstdint> // std::int64_t
+#include <limits>
 #include <string>
 #include <utility> // std::pair
 #include <vector>
@@ -58,13 +59,14 @@ struct RFriendInfo {
     */
    std::vector<std::vector<std::int64_t>> fNEntriesPerTreePerFriend;
 
-   void AddFriend(const std::string &treeName, const std::string &fileNameGlob, const std::string &alias = "");
+   void AddFriend(const std::string &treeName, const std::string &fileNameGlob, const std::string &alias = "",
+                  std::int64_t nEntries = std::numeric_limits<std::int64_t>::max());
 
-   void
-   AddFriend(const std::string &treeName, const std::vector<std::string> &fileNameGlobs, const std::string &alias = "");
+   void AddFriend(const std::string &treeName, const std::vector<std::string> &fileNameGlobs,
+                  const std::string &alias = "", const std::vector<std::int64_t> &nEntriesVec = {});
 
    void AddFriend(const std::vector<std::pair<std::string, std::string>> &treeAndFileNameGlobs,
-                  const std::string &alias = "");
+                  const std::string &alias = "", const std::vector<std::int64_t> &nEntriesVec = {});
 };
 
 } // namespace TreeUtils

--- a/tree/tree/inc/ROOT/RFriendInfo.hxx
+++ b/tree/tree/inc/ROOT/RFriendInfo.hxx
@@ -18,6 +18,7 @@
 #ifndef ROOT_RFRIENDINFO_H
 #define ROOT_RFRIENDINFO_H
 
+#include <cstdint> // std::int64_t
 #include <string>
 #include <utility> // std::pair
 #include <vector>
@@ -33,8 +34,10 @@ namespace TreeUtils {
 */
 struct RFriendInfo {
 
-   std::vector<std::pair<std::string, std::string>>
-      fFriendNames; ///< Pairs of names and aliases of friend trees/chains.
+   /**
+    * Pairs of names and aliases of each friend tree/chain.
+    */
+   std::vector<std::pair<std::string, std::string>> fFriendNames;
    /**
    Names of the files where each friend is stored. fFriendFileNames[i] is the
    list of files for friend with name fFriendNames[i].
@@ -48,6 +51,12 @@ struct RFriendInfo {
       vector.
    */
    std::vector<std::vector<std::string>> fFriendChainSubNames;
+   /**
+    * Number of entries contained in each tree of each friend. The outer
+    * dimension of the vector tracks the n-th friend tree/chain, the inner
+    * dimension tracks the number of entries of each tree in the current friend.
+    */
+   std::vector<std::vector<std::int64_t>> fNEntriesPerTreePerFriend;
 
    void AddFriend(const std::string &treeName, const std::string &fileNameGlob, const std::string &alias = "");
 

--- a/tree/tree/inc/ROOT/RFriendInfo.hxx
+++ b/tree/tree/inc/ROOT/RFriendInfo.hxx
@@ -18,8 +18,12 @@
 #ifndef ROOT_RFRIENDINFO_H
 #define ROOT_RFRIENDINFO_H
 
+#include <ROOT/RStringView.hxx>
+#include <TVirtualIndex.h>
+
 #include <cstdint> // std::int64_t
 #include <limits>
+#include <memory>
 #include <string>
 #include <utility> // std::pair
 #include <vector>
@@ -28,6 +32,7 @@ class TTree;
 
 namespace ROOT {
 namespace TreeUtils {
+
 /**
 \struct ROOT::TreeUtils::RFriendInfo
 \brief Information about friend trees of a certain TTree or TChain object.
@@ -59,14 +64,32 @@ struct RFriendInfo {
     */
    std::vector<std::vector<std::int64_t>> fNEntriesPerTreePerFriend;
 
+   /**
+      Information on the friend's TTreeIndexes.
+   */
+   std::vector<std::unique_ptr<TVirtualIndex>> fTreeIndexInfos;
+
+   RFriendInfo() = default;
+   RFriendInfo(const RFriendInfo &);
+   RFriendInfo &operator=(const RFriendInfo &);
+   RFriendInfo(RFriendInfo &&) = default;
+   RFriendInfo &operator=(RFriendInfo &&) = default;
+   RFriendInfo(std::vector<std::pair<std::string, std::string>> friendNames,
+               std::vector<std::vector<std::string>> friendFileNames,
+               std::vector<std::vector<std::string>> friendChainSubNames,
+               std::vector<std::vector<std::int64_t>> nEntriesPerTreePerFriend,
+               std::vector<std::unique_ptr<TVirtualIndex>> treeIndexInfos);
+
    void AddFriend(const std::string &treeName, const std::string &fileNameGlob, const std::string &alias = "",
-                  std::int64_t nEntries = std::numeric_limits<std::int64_t>::max());
+                  std::int64_t nEntries = std::numeric_limits<std::int64_t>::max(), TVirtualIndex *indexInfo = nullptr);
 
    void AddFriend(const std::string &treeName, const std::vector<std::string> &fileNameGlobs,
-                  const std::string &alias = "", const std::vector<std::int64_t> &nEntriesVec = {});
+                  const std::string &alias = "", const std::vector<std::int64_t> &nEntriesVec = {},
+                  TVirtualIndex *indexInfo = nullptr);
 
    void AddFriend(const std::vector<std::pair<std::string, std::string>> &treeAndFileNameGlobs,
-                  const std::string &alias = "", const std::vector<std::int64_t> &nEntriesVec = {});
+                  const std::string &alias = "", const std::vector<std::int64_t> &nEntriesVec = {},
+                  TVirtualIndex *indexInfo = nullptr);
 };
 
 } // namespace TreeUtils

--- a/tree/tree/inc/TVirtualIndex.h
+++ b/tree/tree/inc/TVirtualIndex.h
@@ -45,7 +45,7 @@ public:
    virtual Long64_t       GetN()            const = 0;
    virtual TTree         *GetTree()         const {return fTree;}
    virtual void           UpdateFormulaLeaves(const TTree *parent) = 0;
-   virtual void           SetTree(const TTree *T) = 0;
+   virtual void           SetTree(TTree *T) = 0;
 
    ClassDefOverride(TVirtualIndex,1);  //Abstract interface for Tree Index
 };

--- a/tree/tree/src/InternalTreeUtils.cxx
+++ b/tree/tree/src/InternalTreeUtils.cxx
@@ -222,9 +222,7 @@ ROOT::TreeUtils::RFriendInfo GetFriendInfo(const TTree &tree, bool retrieveEntri
          auto nFiles = chainFiles->GetEntries();
          fileNames.reserve(nFiles);
          chainSubNames.reserve(nFiles);
-         if (retrieveEntries) {
-            nEntriesInThisFriend.reserve(nFiles);
-         }
+         nEntriesInThisFriend.reserve(nFiles);
 
          // Retrieve the name of the chain and add a (name, alias) pair
          friendNames.emplace_back(std::make_pair(frChain->GetName(), alias));
@@ -248,6 +246,8 @@ ROOT::TreeUtils::RFriendInfo GetFriendInfo(const TTree &tree, bool retrieveEntri
                   throw std::runtime_error(std::string("GetFriendInfo: Could not retrieve TTree \"") + thisTreeName +
                                            "\" from file \"" + thisFileName + "\"");
                nEntriesInThisFriend.emplace_back(thisTree->GetEntries());
+            } else {
+               nEntriesInThisFriend.emplace_back(TTree::kMaxEntries);
             }
          }
       } else {
@@ -365,10 +365,7 @@ std::vector<std::unique_ptr<TChain>> MakeFriends(const ROOT::TreeUtils::RFriendI
       const auto &thisFriendName = finfo.fFriendNames[i].first;
       const auto &thisFriendFileNames = finfo.fFriendFileNames[i];
       const auto &thisFriendChainSubNames = finfo.fFriendChainSubNames[i];
-      const auto &thisFriendEntries =
-         finfo.fNEntriesPerTreePerFriend[i].empty()
-            ? std::vector<std::int64_t>(thisFriendFileNames.size(), std::numeric_limits<std::int64_t>::max())
-            : finfo.fNEntriesPerTreePerFriend[i];
+      const auto &thisFriendEntries = finfo.fNEntriesPerTreePerFriend[i];
 
       // Build a friend chain
       auto frChain = ROOT::Internal::TreeUtils::MakeChainForMT(thisFriendName);

--- a/tree/tree/src/RFriendInfo.cxx
+++ b/tree/tree/src/RFriendInfo.cxx
@@ -18,11 +18,14 @@ namespace TreeUtils {
 /// \param[in] treeName Name of the tree.
 /// \param[in] fileNameGlob Path to the file. Refer to TChain::Add for globbing rules.
 /// \param[in] alias Alias for this friend.
-void RFriendInfo::AddFriend(const std::string &treeName, const std::string &fileNameGlob, const std::string &alias)
+/// \param[in] nEntries Number of entries for this friend.
+void RFriendInfo::AddFriend(const std::string &treeName, const std::string &fileNameGlob, const std::string &alias,
+                            std::int64_t nEntries)
 {
    fFriendNames.emplace_back(std::make_pair(treeName, alias));
    fFriendFileNames.emplace_back(std::vector<std::string>{fileNameGlob});
    fFriendChainSubNames.emplace_back();
+   fNEntriesPerTreePerFriend.push_back(std::vector<std::int64_t>({nEntries}));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -31,12 +34,16 @@ void RFriendInfo::AddFriend(const std::string &treeName, const std::string &file
 /// \param[in] treeName Name of the tree.
 /// \param[in] fileNameGlobs Paths to the files. Refer to TChain::Add for globbing rules.
 /// \param[in] alias Alias for this friend.
+/// \param[in] nEntriesVec Number of entries for each file of this friend.
 void RFriendInfo::AddFriend(const std::string &treeName, const std::vector<std::string> &fileNameGlobs,
-                            const std::string &alias)
+                            const std::string &alias, const std::vector<std::int64_t> &nEntriesVec)
 {
    fFriendNames.emplace_back(std::make_pair(treeName, alias));
    fFriendFileNames.emplace_back(fileNameGlobs);
    fFriendChainSubNames.emplace_back(std::vector<std::string>(fileNameGlobs.size(), treeName));
+   fNEntriesPerTreePerFriend.push_back(
+      nEntriesVec.empty() ? std::vector<int64_t>(fileNameGlobs.size(), std::numeric_limits<std::int64_t>::max())
+                          : nEntriesVec);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -44,8 +51,9 @@ void RFriendInfo::AddFriend(const std::string &treeName, const std::vector<std::
 ///
 /// \param[in] treeAndFileNameGlobs Pairs of (treename, filename). Refer to TChain::Add for globbing rules.
 /// \param[in] alias Alias for this friend.
+/// \param[in] nEntriesVec Number of entries for each file of this friend.
 void RFriendInfo::AddFriend(const std::vector<std::pair<std::string, std::string>> &treeAndFileNameGlobs,
-                            const std::string &alias)
+                            const std::string &alias, const std::vector<std::int64_t> &nEntriesVec)
 {
    fFriendNames.emplace_back(std::make_pair("", alias));
 
@@ -65,6 +73,9 @@ void RFriendInfo::AddFriend(const std::vector<std::pair<std::string, std::string
       *fSubNamesIt = names.first;
       *fNamesIt = names.second;
    }
+   fNEntriesPerTreePerFriend.push_back(
+      nEntriesVec.empty() ? std::vector<int64_t>(treeAndFileNameGlobs.size(), std::numeric_limits<std::int64_t>::max())
+                          : nEntriesVec);
 }
 
 } // namespace TreeUtils

--- a/tree/tree/src/RFriendInfo.cxx
+++ b/tree/tree/src/RFriendInfo.cxx
@@ -12,6 +12,38 @@
 namespace ROOT {
 namespace TreeUtils {
 
+RFriendInfo::RFriendInfo(const RFriendInfo &other)
+{
+   *this = other;
+}
+
+RFriendInfo &RFriendInfo::operator=(const RFriendInfo &other)
+{
+   fFriendNames = other.fFriendNames;
+   fFriendFileNames = other.fFriendFileNames;
+   fFriendChainSubNames = other.fFriendChainSubNames;
+   fNEntriesPerTreePerFriend = other.fNEntriesPerTreePerFriend;
+
+   for (const auto &idxInfo : other.fTreeIndexInfos)
+      fTreeIndexInfos.emplace_back(static_cast<TVirtualIndex *>(idxInfo ? idxInfo->Clone() : nullptr));
+
+   return *this;
+}
+
+/// Construct a RFriendInfo object from its components.
+RFriendInfo::RFriendInfo(std::vector<std::pair<std::string, std::string>> friendNames,
+                         std::vector<std::vector<std::string>> friendFileNames,
+                         std::vector<std::vector<std::string>> friendChainSubNames,
+                         std::vector<std::vector<std::int64_t>> nEntriesPerTreePerFriend,
+                         std::vector<std::unique_ptr<TVirtualIndex>> treeIndexInfos)
+   : fFriendNames(std::move(friendNames)),
+     fFriendFileNames(std::move(friendFileNames)),
+     fFriendChainSubNames(std::move(friendChainSubNames)),
+     fNEntriesPerTreePerFriend(std::move(nEntriesPerTreePerFriend)),
+     fTreeIndexInfos(std::move(treeIndexInfos))
+{
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// \brief Add information of a single friend.
 ///
@@ -19,13 +51,15 @@ namespace TreeUtils {
 /// \param[in] fileNameGlob Path to the file. Refer to TChain::Add for globbing rules.
 /// \param[in] alias Alias for this friend.
 /// \param[in] nEntries Number of entries for this friend.
+/// \param[in] indexInfo Tree index info for this friend.
 void RFriendInfo::AddFriend(const std::string &treeName, const std::string &fileNameGlob, const std::string &alias,
-                            std::int64_t nEntries)
+                            std::int64_t nEntries, TVirtualIndex *indexInfo)
 {
    fFriendNames.emplace_back(std::make_pair(treeName, alias));
    fFriendFileNames.emplace_back(std::vector<std::string>{fileNameGlob});
    fFriendChainSubNames.emplace_back();
    fNEntriesPerTreePerFriend.push_back(std::vector<std::int64_t>({nEntries}));
+   fTreeIndexInfos.emplace_back(static_cast<TVirtualIndex *>(indexInfo ? indexInfo->Clone() : nullptr));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -35,8 +69,10 @@ void RFriendInfo::AddFriend(const std::string &treeName, const std::string &file
 /// \param[in] fileNameGlobs Paths to the files. Refer to TChain::Add for globbing rules.
 /// \param[in] alias Alias for this friend.
 /// \param[in] nEntriesVec Number of entries for each file of this friend.
+/// \param[in] indexInfo Tree index info for this friend.
 void RFriendInfo::AddFriend(const std::string &treeName, const std::vector<std::string> &fileNameGlobs,
-                            const std::string &alias, const std::vector<std::int64_t> &nEntriesVec)
+                            const std::string &alias, const std::vector<std::int64_t> &nEntriesVec,
+                            TVirtualIndex *indexInfo)
 {
    fFriendNames.emplace_back(std::make_pair(treeName, alias));
    fFriendFileNames.emplace_back(fileNameGlobs);
@@ -44,6 +80,7 @@ void RFriendInfo::AddFriend(const std::string &treeName, const std::vector<std::
    fNEntriesPerTreePerFriend.push_back(
       nEntriesVec.empty() ? std::vector<int64_t>(fileNameGlobs.size(), std::numeric_limits<std::int64_t>::max())
                           : nEntriesVec);
+   fTreeIndexInfos.emplace_back(static_cast<TVirtualIndex *>(indexInfo ? indexInfo->Clone() : nullptr));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -52,8 +89,10 @@ void RFriendInfo::AddFriend(const std::string &treeName, const std::vector<std::
 /// \param[in] treeAndFileNameGlobs Pairs of (treename, filename). Refer to TChain::Add for globbing rules.
 /// \param[in] alias Alias for this friend.
 /// \param[in] nEntriesVec Number of entries for each file of this friend.
+/// \param[in] indexInfo Tree index info for this friend.
 void RFriendInfo::AddFriend(const std::vector<std::pair<std::string, std::string>> &treeAndFileNameGlobs,
-                            const std::string &alias, const std::vector<std::int64_t> &nEntriesVec)
+                            const std::string &alias, const std::vector<std::int64_t> &nEntriesVec,
+                            TVirtualIndex *indexInfo)
 {
    fFriendNames.emplace_back(std::make_pair("", alias));
 
@@ -76,6 +115,7 @@ void RFriendInfo::AddFriend(const std::vector<std::pair<std::string, std::string
    fNEntriesPerTreePerFriend.push_back(
       nEntriesVec.empty() ? std::vector<int64_t>(treeAndFileNameGlobs.size(), std::numeric_limits<std::int64_t>::max())
                           : nEntriesVec);
+   fTreeIndexInfos.emplace_back(static_cast<TVirtualIndex *>(indexInfo ? indexInfo->Clone() : nullptr));
 }
 
 } // namespace TreeUtils

--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
@@ -62,8 +62,7 @@ class TTreeView {
    std::unique_ptr<TChain> fChain; ///< Chain on which to operate
 
    void MakeChain(const std::vector<std::string> &treeName, const std::vector<std::string> &fileNames,
-                  const ROOT::TreeUtils::RFriendInfo &friendInfo, const std::vector<Long64_t> &nEntries,
-                  const std::vector<std::vector<Long64_t>> &friendEntries);
+                  const ROOT::TreeUtils::RFriendInfo &friendInfo, const std::vector<Long64_t> &nEntries);
 
 public:
    TTreeView() = default;
@@ -72,8 +71,7 @@ public:
    std::unique_ptr<TTreeReader> GetTreeReader(Long64_t start, Long64_t end, const std::vector<std::string> &treeName,
                                               const std::vector<std::string> &fileNames,
                                               const ROOT::TreeUtils::RFriendInfo &friendInfo,
-                                              const TEntryList &entryList, const std::vector<Long64_t> &nEntries,
-                                              const std::vector<std::vector<Long64_t>> &friendEntries);
+                                              const TEntryList &entryList, const std::vector<Long64_t> &nEntries);
    void Reset();
 };
 } // End of namespace Internal
@@ -84,7 +82,7 @@ private:
    const std::vector<std::string> fTreeNames; ///< TTree names (always same size and ordering as fFileNames)
    /// User-defined selection of entry numbers to be processed, empty if none was provided
    TEntryList fEntryList;
-   const ROOT::TreeUtils::RFriendInfo fFriendInfo;
+   ROOT::TreeUtils::RFriendInfo fFriendInfo;
    ROOT::TThreadExecutor fPool; ///<! Thread pool for processing.
 
    /// Thread-local TreeViews

--- a/tree/treeplayer/inc/TChainIndex.h
+++ b/tree/treeplayer/inc/TChainIndex.h
@@ -88,7 +88,7 @@ public:
    virtual Long64_t       GetN()            const {return fEntries.size();}
    virtual Bool_t         IsValidFor(const TTree *parent);
    virtual void           UpdateFormulaLeaves(const TTree *parent);
-   virtual void           SetTree(const TTree *T);
+   virtual void           SetTree(TTree *T);
 
    ClassDef(TChainIndex,1)  //A Tree Index with majorname and minorname.
 };

--- a/tree/treeplayer/inc/TTreeIndex.h
+++ b/tree/treeplayer/inc/TTreeIndex.h
@@ -68,7 +68,7 @@ public:
    virtual Bool_t         IsValidFor(const TTree *parent);
    virtual void           Print(Option_t *option="") const;
    virtual void           UpdateFormulaLeaves(const TTree *parent);
-   virtual void           SetTree(const TTree *T);
+   virtual void           SetTree(TTree *T);
 
    ClassDef(TTreeIndex,2);  //A Tree Index with majorname and minorname.
 };

--- a/tree/treeplayer/src/TChainIndex.cxx
+++ b/tree/treeplayer/src/TChainIndex.cxx
@@ -182,9 +182,11 @@ void TChainIndex::DeleteIndices()
 
 TChainIndex::~TChainIndex()
 {
-   DeleteIndices();
-   if (fTree && fTree->GetTreeIndex() == this)
-      fTree->SetTreeIndex(0);
+   if (fTree) {
+      DeleteIndices();
+      if (fTree->GetTreeIndex() == this)
+         fTree->SetTreeIndex(nullptr);
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/treeplayer/src/TChainIndex.cxx
+++ b/tree/treeplayer/src/TChainIndex.cxx
@@ -402,5 +402,6 @@ void TChainIndex::UpdateFormulaLeaves(const TTree *parent)
 void TChainIndex::SetTree(TTree *T)
 {
    R__ASSERT(fTree == 0 || fTree == T || T==0);
+   fTree = T;
 }
 

--- a/tree/treeplayer/src/TChainIndex.cxx
+++ b/tree/treeplayer/src/TChainIndex.cxx
@@ -399,7 +399,7 @@ void TChainIndex::UpdateFormulaLeaves(const TTree *parent)
 ////////////////////////////////////////////////////////////////////////////////
 /// See TTreeIndex::SetTree.
 
-void TChainIndex::SetTree(const TTree *T)
+void TChainIndex::SetTree(TTree *T)
 {
    R__ASSERT(fTree == 0 || fTree == T || T==0);
 }

--- a/tree/treeplayer/src/TTreeIndex.cxx
+++ b/tree/treeplayer/src/TTreeIndex.cxx
@@ -633,8 +633,8 @@ void TTreeIndex::UpdateFormulaLeaves(const TTree *parent)
 /// Because Trees in a TChain may have a different list of leaves, one
 /// must update the leaves numbers in the TTreeFormula used by the TreeIndex.
 
-void TTreeIndex::SetTree(const TTree *T)
+void TTreeIndex::SetTree(TTree *T)
 {
-   fTree = (TTree*)T;
+   fTree = T;
 }
 


### PR DESCRIPTION
To avoid the largest merge conflicts this PR also backports some refactoring of RFriendInfo and TTreeProcessorMT.

Fixes #12260 .