### PR TITLE
[tree][DF] Backport fix for globbing with `?#` treename token (v6.28)

### DIFF
--- a/tree/dataframe/src/RDatasetGroup.cxx
+++ b/tree/dataframe/src/RDatasetGroup.cxx
@@ -39,7 +39,7 @@ RDatasetGroup::RDatasetGroup(const std::string &groupName,
 
    TChain chain;
    for (const auto &p : treeAndFileNameGlobs) {
-      const auto fullpath = p.second + "/" + p.first;
+      const auto fullpath = p.second + "?#" + p.first;
       chain.Add(fullpath.c_str());
    }
    const auto &expandedNames = chain.GetListOfFiles();
@@ -59,7 +59,7 @@ RDatasetGroup::RDatasetGroup(const std::string &groupName, const std::vector<std
       throw std::logic_error("Mismatch between number of trees and file globs.");
    TChain chain;
    for (auto i = 0u; i < fileNameGlobs.size(); ++i) {
-      const auto fullpath = fileNameGlobs[i] + "/" + (treeNames.size() == 1u ? treeNames[0] : treeNames[i]);
+      const auto fullpath = fileNameGlobs[i] + "?#" + (treeNames.size() == 1u ? treeNames[0] : treeNames[i]);
       chain.Add(fullpath.c_str());
    }
    const auto &expandedNames = chain.GetListOfFiles();

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -376,9 +376,15 @@ RLoopManager::RLoopManager(ROOT::RDF::Experimental::RDatasetSpec &&spec)
       const auto &trees = group.GetTreeNames();
       const auto &files = group.GetFileNameGlobs();
       for (auto i = 0u; i < files.size(); ++i) {
-         const auto fullpath = files[i] + "/" + trees[i]; // TODO: use ?# once #11483 is solved
+         // We need to use `<filename>?#<treename>` as an argument to TChain::Add
+         // (see https://github.com/root-project/root/pull/8820 for why)
+         const auto fullpath = files[i] + "?#" + trees[i];
          chain->Add(fullpath.c_str());
-         fDatasetGroupMap[fullpath] = &group;
+         // ...but instead we use `<filename>/<treename>` as a sample ID (cannot
+         // change this easily because of backward compatibility: the sample ID
+         // is exposed to users via RSampleInfo and DefinePerSample).
+         const auto sampleId = files[i] + '/' + trees[i];
+         fDatasetGroupMap.insert({sampleId, &group});
       }
    }
 
@@ -408,10 +414,11 @@ RLoopManager::RLoopManager(ROOT::RDF::Experimental::RDatasetSpec &&spec)
          }
       } else {
          // Otherwise, the new friend chain needs to be built using the nomenclature
-         // "filename/treename" as argument to `TChain::Add`
-         for (auto j = 0u; j < nFileNames; ++j) {
-            frChain->Add((thisFriendFiles[j] + "/" + thisFriendChainSubNames[j]).c_str());
-         }
+         // "filename#?treename" as argument to `TChain::Add`.
+         // See https://github.com/root-project/root/pull/8820 for why "filename#?treename"
+         // is better than "filename#?treename".
+         for (auto j = 0u; j < nFileNames; ++j)
+            frChain->Add((thisFriendFiles[j] + "?#" + thisFriendChainSubNames[j]).c_str());
       }
 
       // Make it friends with the main chain

--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -400,9 +400,22 @@ Int_t TChain::Add(const char* name, Long64_t nentries /* = TTree::kMaxEntries */
       l.Sort();
       TIter next(&l);
       TObjString *obj;
+      const TString hashMarkTreeName{"#" + treename};
       while ((obj = (TObjString*)next())) {
          file = obj->GetName();
-         nf += AddFile(TString::Format("%s/%s%s",directory.Data(),file,suffix.Data()),nentries);
+         if (suffix == hashMarkTreeName) {
+            // See https://github.com/root-project/root/issues/11483
+            // In case the input parameter 'name' contains both a glob and the
+            // '?#' token to identify the tree name, the call to
+            // `ParseTreeFileName` will produce a 'suffix' string of the form
+            // '#treename'. Passing this to the `AddFile` call produces a bogus
+            // file name that TChain won't be able to open afterwards. Thus,
+            // we do not pass the 'suffix' as part of the file name, instead we
+            // directly pass 'treename' to `AddFile`.
+            nf += AddFile(TString::Format("%s/%s", directory.Data(), file), nentries, treename);
+         } else {
+            nf += AddFile(TString::Format("%s/%s%s", directory.Data(), file, suffix.Data()), nentries);
+         }
       }
       l.Delete();
    }


### PR DESCRIPTION
Fixes https://github.com/root-project/root/issues/11483 .