### PR TITLE
[RF] Composition over inheritance in RooAbsMinimizerFcn implementations

### DIFF
--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -613,13 +613,9 @@ RooFitResult *RooMinimizer::save(const char *userName, const char *userTitle)
    fitRes->setConstParList(saveConstList);
    fitRes->setInitParList(saveFloatInitList);
 
-   // The fitter often clones the function. We therefore have to ask it for its copy.
-   const auto fitFcn = dynamic_cast<const RooAbsMinimizerFcn *>(_theFitter->GetFCN());
    double removeOffset = 0.;
-   if (fitFcn) {
-      fitRes->setNumInvalidNLL(fitFcn->GetNumInvalidNLL());
-      removeOffset = -fitFcn->getOffset();
-   }
+   fitRes->setNumInvalidNLL(_fcn->GetNumInvalidNLL());
+   removeOffset = -_fcn->getOffset();
 
    fitRes->setStatus(_status);
    fitRes->setCovQual(_theFitter->GetMinimizer()->CovMatrixStatus());

--- a/roofit/roofitcore/src/RooMinimizerFcn.h
+++ b/roofit/roofitcore/src/RooMinimizerFcn.h
@@ -34,15 +34,10 @@ using TMatrixDSym = TMatrixTSym<double>;
 // forward declaration
 class RooMinimizer;
 
-class RooMinimizerFcn : public RooAbsMinimizerFcn, public ROOT::Math::IBaseFunctionMultiDim {
+class RooMinimizerFcn : public RooAbsMinimizerFcn {
 
 public:
    RooMinimizerFcn(RooAbsReal *funct, RooMinimizer *context);
-   RooMinimizerFcn(const RooMinimizerFcn &other);
-   ~RooMinimizerFcn() override;
-
-   ROOT::Math::IBaseFunctionMultiDim *Clone() const override;
-   unsigned int NDim() const override { return getNDim(); }
 
    std::string getFunctionName() const override;
    std::string getFunctionTitle() const override;
@@ -50,12 +45,13 @@ public:
    void setOptimizeConstOnFunction(RooAbsArg::ConstOpCode opcode, bool doAlsoTrackingOpt) override;
 
    void setOffsetting(bool flag) override;
-   ROOT::Math::IMultiGenFunction *getMultiGenFcn() override { return this; };
+   ROOT::Math::IMultiGenFunction *getMultiGenFcn() override { return _multiGenFcn.get(); }
+
+   double operator()(const double *x) const;
 
 private:
-   double DoEval(const double *x) const override;
-
    RooAbsReal *_funct;
+   std::unique_ptr<ROOT::Math::IBaseFunctionMultiDim> _multiGenFcn;
 };
 
 #endif


### PR DESCRIPTION
This results in more modular code that is also safer: the `ROOT::Fit::Fitter` has no access to the RooAbsMinimizerFcn anymore, only to the member that is a lightweight adapter. This means the `RooAbsMinimizerFcn` also doesn't get cloned unexpectedly, so we don't need extra checks in the RooMinimizer to account for that!