### PR TITLE
Fix issue of multiple declaration of same objects in the saved C macros

### DIFF
--- a/graf2d/gpad/src/TCanvas.cxx
+++ b/graf2d/gpad/src/TCanvas.cxx
@@ -1807,7 +1807,7 @@ void TCanvas::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 /// The precision can be changed (via system.rootrc) by changing the value
 /// of the environment variable "Canvas.SavePrecision"
 
-void TCanvas::SaveSource(const char *filename, Option_t *option)
+void TCanvas::SaveSource(const char *filename, Option_t * /*option*/)
 {
    //    reset bit TClass::kClassSaved for all classes
    TIter next(gROOT->GetListOfClasses());

--- a/graf2d/gpad/src/TCanvas.cxx
+++ b/graf2d/gpad/src/TCanvas.cxx
@@ -1926,7 +1926,8 @@ void TCanvas::SaveSource(const char *filename, Option_t *option)
    //   Now recursively scan all pads of this canvas
    cd();
    if (invalid) SetName("c1");
-   TPad::SavePrimitive(out,option);
+   TPad::SavePrimitive(out,"toplevel");
+
    //   Write canvas options related to pad editor
    out<<"   "<<GetName()<<"->SetSelected("<<GetName()<<");"<<std::endl;
    if (GetShowToolBar()) {

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -5868,8 +5868,12 @@ void TPad::SavePrimitive(std::ostream &out, Option_t * option /*= ""*/)
          if (!strcmp(obj->GetName(),"Graph"))
             ((TGraph*)obj)->SetName(TString::Format("Graph%d",grnum++).Data());
       obj->SavePrimitive(out, (Option_t *)next.GetOption());
-      if (obj->InheritsFrom(TPad::Class()) and !opt.Contains("toplevel"))
-         out<<"   "<<pname<<"->cd();"<<std::endl;
+      if (obj->InheritsFrom(TPad::Class())) {
+         if (opt.Contains("toplevel"))
+            out<<"   "<<pname<<"->cd();"<<std::endl;
+         else
+            out<<"   "<<cname<<"->cd();"<<std::endl;
+      }
    }
    out<<"   "<<cname<<"->Modified();"<<std::endl;
 }

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -5697,30 +5697,25 @@ void TPad::SavePrimitive(std::ostream &out, Option_t * option /*= ""*/)
 
    char quote = '"';
 
-   static Int_t pcounter = 0;
    TString padName = GetName();
+
+   // check for space in the pad name
+   auto p = padName.Index(" ");
+   if (p != kNPOS) padName.Resize(p);
 
    TString opt = option;
    if (!opt.Contains("toplevel")) {
-      pcounter++;
-      padName += "__";
-      padName += pcounter;
-      padName = gInterpreter-> MapCppName(padName);
+      static Int_t pcounter = 0;
+      padName += TString::Format("__%d", pcounter++);
+      padName = gInterpreter->MapCppName(padName);
    }
-   const char *pname = padName.Data();
-   if (!strlen(pname)) pname = "unnamed";
 
-   char lcname[100];
+   const char *pname = padName.Data();
    const char *cname = padName.Data();
-   size_t nch = strlen(cname);
-   if (nch < sizeof(lcname)) {
-      strlcpy(lcname, cname, sizeof(lcname));
-      for(size_t k = 0; k < nch; k++)
-         if (lcname[k] == ' ')
-            lcname[k] = 0;
-      if (lcname[0] != 0)
-         cname = lcname;
-      else if (this == gPad->GetCanvas())
+
+   if (padName.Length() == 0) {
+      pname = "unnamed";
+      if (this == gPad->GetCanvas())
          cname = "c1";
       else
          cname = "pad";
@@ -5731,8 +5726,7 @@ void TPad::SavePrimitive(std::ostream &out, Option_t * option /*= ""*/)
       out <<"  "<<std::endl;
       out <<"// ------------>Primitives in pad: "<<GetName()<<std::endl;
 
-      out<<"   TPad *"<<cname<<" = new TPad("<<quote<<pname<<quote<<", "<<quote<<GetTitle()
-      <<quote
+      out<<"   TPad *"<<cname<<" = new TPad("<<quote<<GetName()<<quote<<", "<<quote<<GetTitle()<<quote
       <<","<<fXlowNDC
       <<","<<fYlowNDC
       <<","<<fXlowNDC+fWNDC


### PR DESCRIPTION
# This Pull request:

`TRatioPlot` defines three pads named `upper_pad`, `lower_pad` and `top_pad`. If single canvas contains two or more `TRatioPlot`s, the saved C macro declares same object variable names resulting in runtime error. This fix adds counter suffix to pads (like for histograms) resulting in unique pad names.

## Changes or fixes:

Modifications to `SavePrimitive` members of `TPad` and `TCanvas` to count instances and renumerate written object variable names.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

### Example

Consider MWE
```c++
{
    TH1I * h1 = new TH1I("h1", "h1", 10, -5, 5);
    TH1I * h2 = new TH1I("h2", "h2", 10, -5, 5);

    h1->FillRandom("gaus", 1000);
    h2->FillRandom("gaus", 1000);

    TCanvas * can = new TCanvas("c_pads_test", "c_pads_test", 800, 400);

    can->cd(0);
    TPad * p1 = new TPad("p1", "p1", 0, 0.3, 0.5, 1.0);
    p1->Draw();
    p1->cd();
    TRatioPlot ratio1(h1, h2);
    ratio1.Draw();

    can->cd(0);
    TPad * p2 = new TPad("p2", "p2", 0.5, 0.3, 1.0, 1.0);
    p2->Draw();
    p2->cd();
    TRatioPlot ratio2(h2, h1);
    ratio2.Draw();

    can->cd(0);
    TPad * p3 = new TPad("p3", "p3", 0.0, 0.0, 1.0, 0.3);
    p3->Draw();
    p3->cd();
    h1->Draw();
    h2->Draw("same");

    can->Draw();

    can->SaveAs(".C");
}
```
Run the macro and then try to run resulting `c_pads_test.C`. The output will be:

```
Processing c_pads_test.C...
In file included from input_line_10:1:
/home/rlalik/c_pads_test.C:229:10: error: redefinition of 'upper_pad'
   TPad *upper_pad = new TPad("upper_pad", "",0.0035,0.3,0.9965,0.9975);
         ^
/home/rlalik/c_pads_test.C:27:10: note: previous definition is here
   TPad *upper_pad = new TPad("upper_pad", "",0.0035,0.3,0.9965,0.9975);
         ^
/home/rlalik/c_pads_test.C:303:10: error: redefinition of 'lower_pad'
   TPad *lower_pad = new TPad("lower_pad", "",0.0035,0.0025,0.9965,0.3);
         ^
/home/rlalik/c_pads_test.C:103:10: note: previous definition is here
   TPad *lower_pad = new TPad("lower_pad", "",0.0035,0.0025,0.9965,0.3);
         ^
/home/rlalik/c_pads_test.C:359:10: error: redefinition of 'top_pad'
   TPad *top_pad = new TPad("top_pad", "",0.0035,0.0025,0.9965,0.9975);
         ^
/home/rlalik/c_pads_test.C:159:10: note: previous definition is here
   TPad *top_pad = new TPad("top_pad", "",0.0035,0.0025,0.9965,0.9975);
         ^
root [1] 
```
Proposed changes fix this.