### PR TITLE
[cling] Disable outline-atomics on AArch64

### DIFF
--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -1254,6 +1254,13 @@ namespace {
 #if __APPLE__ && __arm64__
     argvCompile.push_back("--target=arm64-apple-darwin20.3.0");
 #endif
+#if __aarch64__
+    // Disable outline-atomics on AArch64; the routines __aarch64_* are defined
+    // in the static library libgcc.a and not necessarily included in libCling
+    // or otherwise present in the process, so the interpreter has a hard time
+    // finding them.
+    argvCompile.push_back("-mno-outline-atomics");
+#endif
 
     // Variables for storing the memory of the C-string arguments.
     // FIXME: We shouldn't use C-strings in the first place, but just use


### PR DESCRIPTION
The routines `__aarch64_*` are defined in the static library libgcc.a and not necessarily included in libCling or otherwise present in the process, so the interpreter has a hard time finding them.

Fixes #12294