### PR TITLE
[tree] Prefer Long64_t to int64_t for the number of TTree entries 

### DIFF
--- a/tree/tree/inc/ROOT/RFriendInfo.hxx
+++ b/tree/tree/inc/ROOT/RFriendInfo.hxx
@@ -21,6 +21,7 @@
 #include <string_view>
 #include <Rtypes.h> // Long64_t
 #include <TVirtualIndex.h>
+#include <TTree.h>
 
 #include <limits>
 #include <memory>
@@ -81,7 +82,7 @@ struct RFriendInfo {
                std::vector<std::unique_ptr<TVirtualIndex>> treeIndexInfos);
 
    void AddFriend(const std::string &treeName, const std::string &fileNameGlob, const std::string &alias = "",
-                  Long64_t nEntries = std::numeric_limits<Long64_t>::max(), TVirtualIndex *indexInfo = nullptr);
+                  Long64_t nEntries = TTree::kMaxEntries, TVirtualIndex *indexInfo = nullptr);
 
    void AddFriend(const std::string &treeName, const std::vector<std::string> &fileNameGlobs,
                   const std::string &alias = "", const std::vector<Long64_t> &nEntriesVec = {},

--- a/tree/tree/inc/ROOT/RFriendInfo.hxx
+++ b/tree/tree/inc/ROOT/RFriendInfo.hxx
@@ -19,9 +19,9 @@
 #define ROOT_RFRIENDINFO_H
 
 #include <string_view>
+#include <Rtypes.h> // Long64_t
 #include <TVirtualIndex.h>
 
-#include <cstdint> // std::int64_t
 #include <limits>
 #include <memory>
 #include <string>
@@ -62,7 +62,7 @@ struct RFriendInfo {
     * dimension of the vector tracks the n-th friend tree/chain, the inner
     * dimension tracks the number of entries of each tree in the current friend.
     */
-   std::vector<std::vector<std::int64_t>> fNEntriesPerTreePerFriend;
+   std::vector<std::vector<Long64_t>> fNEntriesPerTreePerFriend;
 
    /**
       Information on the friend's TTreeIndexes.
@@ -77,18 +77,18 @@ struct RFriendInfo {
    RFriendInfo(std::vector<std::pair<std::string, std::string>> friendNames,
                std::vector<std::vector<std::string>> friendFileNames,
                std::vector<std::vector<std::string>> friendChainSubNames,
-               std::vector<std::vector<std::int64_t>> nEntriesPerTreePerFriend,
+               std::vector<std::vector<Long64_t>> nEntriesPerTreePerFriend,
                std::vector<std::unique_ptr<TVirtualIndex>> treeIndexInfos);
 
    void AddFriend(const std::string &treeName, const std::string &fileNameGlob, const std::string &alias = "",
-                  std::int64_t nEntries = std::numeric_limits<std::int64_t>::max(), TVirtualIndex *indexInfo = nullptr);
+                  Long64_t nEntries = std::numeric_limits<Long64_t>::max(), TVirtualIndex *indexInfo = nullptr);
 
    void AddFriend(const std::string &treeName, const std::vector<std::string> &fileNameGlobs,
-                  const std::string &alias = "", const std::vector<std::int64_t> &nEntriesVec = {},
+                  const std::string &alias = "", const std::vector<Long64_t> &nEntriesVec = {},
                   TVirtualIndex *indexInfo = nullptr);
 
    void AddFriend(const std::vector<std::pair<std::string, std::string>> &treeAndFileNameGlobs,
-                  const std::string &alias = "", const std::vector<std::int64_t> &nEntriesVec = {},
+                  const std::string &alias = "", const std::vector<Long64_t> &nEntriesVec = {},
                   TVirtualIndex *indexInfo = nullptr);
 };
 

--- a/tree/tree/src/InternalTreeUtils.cxx
+++ b/tree/tree/src/InternalTreeUtils.cxx
@@ -211,7 +211,7 @@ ROOT::TreeUtils::RFriendInfo GetFriendInfo(const TTree &tree, bool retrieveEntri
       auto *treeIndex = frTree->GetTreeIndex();
       treeIndexes.emplace_back(static_cast<TVirtualIndex *>(treeIndex ? treeIndex->Clone() : nullptr));
 
-      // If the current tree is a TChain
+      // If the friend tree is a TChain
       if (auto frChain = dynamic_cast<const TChain *>(frTree)) {
          // Note that each TChainElement returned by TChain::GetListOfFiles has a name
          // equal to the tree name of this TChain and a title equal to the filename.
@@ -265,7 +265,7 @@ ROOT::TreeUtils::RFriendInfo GetFriendInfo(const TTree &tree, bool retrieveEntri
                nEntriesInThisFriend.emplace_back(maxEntries);
             }
          }
-      } else {
+      } else { // frTree is not a chain but a simple TTree
          // Get name of the tree
          const auto realName = GetTreeFullPaths(*frTree)[0];
          friendNames.emplace_back(std::make_pair(realName, alias));

--- a/tree/tree/src/InternalTreeUtils.cxx
+++ b/tree/tree/src/InternalTreeUtils.cxx
@@ -21,7 +21,6 @@
 #include "TTree.h"
 #include "TVirtualIndex.h"
 
-#include <cstdint> // std::uint64_t
 #include <limits>
 #include <utility> // std::pair
 #include <vector>
@@ -176,7 +175,7 @@ ROOT::TreeUtils::RFriendInfo GetFriendInfo(const TTree &tree, bool retrieveEntri
    std::vector<std::pair<std::string, std::string>> friendNames;
    std::vector<std::vector<std::string>> friendFileNames;
    std::vector<std::vector<std::string>> friendChainSubNames;
-   std::vector<std::vector<std::int64_t>> nEntriesPerTreePerFriend;
+   std::vector<std::vector<Long64_t>> nEntriesPerTreePerFriend;
    std::vector<std::unique_ptr<TVirtualIndex>> treeIndexes;
 
    // Reserve space for all friends

--- a/tree/tree/src/RFriendInfo.cxx
+++ b/tree/tree/src/RFriendInfo.cxx
@@ -34,7 +34,7 @@ RFriendInfo &RFriendInfo::operator=(const RFriendInfo &other)
 RFriendInfo::RFriendInfo(std::vector<std::pair<std::string, std::string>> friendNames,
                          std::vector<std::vector<std::string>> friendFileNames,
                          std::vector<std::vector<std::string>> friendChainSubNames,
-                         std::vector<std::vector<std::int64_t>> nEntriesPerTreePerFriend,
+                         std::vector<std::vector<Long64_t>> nEntriesPerTreePerFriend,
                          std::vector<std::unique_ptr<TVirtualIndex>> treeIndexInfos)
    : fFriendNames(std::move(friendNames)),
      fFriendFileNames(std::move(friendFileNames)),
@@ -53,12 +53,12 @@ RFriendInfo::RFriendInfo(std::vector<std::pair<std::string, std::string>> friend
 /// \param[in] nEntries Number of entries for this friend.
 /// \param[in] indexInfo Tree index info for this friend.
 void RFriendInfo::AddFriend(const std::string &treeName, const std::string &fileNameGlob, const std::string &alias,
-                            std::int64_t nEntries, TVirtualIndex *indexInfo)
+                            Long64_t nEntries, TVirtualIndex *indexInfo)
 {
    fFriendNames.emplace_back(std::make_pair(treeName, alias));
    fFriendFileNames.emplace_back(std::vector<std::string>{fileNameGlob});
    fFriendChainSubNames.emplace_back();
-   fNEntriesPerTreePerFriend.push_back(std::vector<std::int64_t>({nEntries}));
+   fNEntriesPerTreePerFriend.push_back(std::vector<Long64_t>({nEntries}));
    fTreeIndexInfos.emplace_back(static_cast<TVirtualIndex *>(indexInfo ? indexInfo->Clone() : nullptr));
 }
 
@@ -71,14 +71,14 @@ void RFriendInfo::AddFriend(const std::string &treeName, const std::string &file
 /// \param[in] nEntriesVec Number of entries for each file of this friend.
 /// \param[in] indexInfo Tree index info for this friend.
 void RFriendInfo::AddFriend(const std::string &treeName, const std::vector<std::string> &fileNameGlobs,
-                            const std::string &alias, const std::vector<std::int64_t> &nEntriesVec,
+                            const std::string &alias, const std::vector<Long64_t> &nEntriesVec,
                             TVirtualIndex *indexInfo)
 {
    fFriendNames.emplace_back(std::make_pair(treeName, alias));
    fFriendFileNames.emplace_back(fileNameGlobs);
    fFriendChainSubNames.emplace_back(std::vector<std::string>(fileNameGlobs.size(), treeName));
    fNEntriesPerTreePerFriend.push_back(
-      nEntriesVec.empty() ? std::vector<int64_t>(fileNameGlobs.size(), std::numeric_limits<std::int64_t>::max())
+      nEntriesVec.empty() ? std::vector<Long64_t>(fileNameGlobs.size(), std::numeric_limits<Long64_t>::max())
                           : nEntriesVec);
    fTreeIndexInfos.emplace_back(static_cast<TVirtualIndex *>(indexInfo ? indexInfo->Clone() : nullptr));
 }
@@ -91,7 +91,7 @@ void RFriendInfo::AddFriend(const std::string &treeName, const std::vector<std::
 /// \param[in] nEntriesVec Number of entries for each file of this friend.
 /// \param[in] indexInfo Tree index info for this friend.
 void RFriendInfo::AddFriend(const std::vector<std::pair<std::string, std::string>> &treeAndFileNameGlobs,
-                            const std::string &alias, const std::vector<std::int64_t> &nEntriesVec,
+                            const std::string &alias, const std::vector<Long64_t> &nEntriesVec,
                             TVirtualIndex *indexInfo)
 {
    fFriendNames.emplace_back(std::make_pair("", alias));
@@ -113,7 +113,7 @@ void RFriendInfo::AddFriend(const std::vector<std::pair<std::string, std::string
       *fNamesIt = names.second;
    }
    fNEntriesPerTreePerFriend.push_back(
-      nEntriesVec.empty() ? std::vector<int64_t>(treeAndFileNameGlobs.size(), std::numeric_limits<std::int64_t>::max())
+      nEntriesVec.empty() ? std::vector<Long64_t>(treeAndFileNameGlobs.size(), std::numeric_limits<Long64_t>::max())
                           : nEntriesVec);
    fTreeIndexInfos.emplace_back(static_cast<TVirtualIndex *>(indexInfo ? indexInfo->Clone() : nullptr));
 }

--- a/tree/tree/test/friendinfo.cxx
+++ b/tree/tree/test/friendinfo.cxx
@@ -262,7 +262,7 @@ TEST_P(RFriendInfoTest, MakeFriendsFromAddFriendOverload3)
    }
    if (retrieveEntries) {
       friendInfo.AddFriend(treeAndFileNames, /*alias*/ "",
-                           std::vector<int64_t>(friendTreeNames.size(), nEntriesInFriendTree));
+                           std::vector<Long64_t>(friendTreeNames.size(), nEntriesInFriendTree));
    } else {
       friendInfo.AddFriend(treeAndFileNames);
    }


### PR DESCRIPTION
For consistency with the rest of libTree.
