### PR TITLE
[RF] Improve code in `MinuitFcnGrad`

### DIFF
--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cxx
@@ -100,7 +100,7 @@ TEST_P(LikelihoodGradientJobTest, Gaussian1D)
    std::unique_ptr<RooAbsReal> nll;
    std::unique_ptr<RooArgSet> values;
    RooAbsPdf *pdf;
-   RooDataSet *data;
+   std::unique_ptr<RooDataSet> data;
    std::tie(nll, pdf, data, values) = generate_1D_gaussian_pdf_nll(w, 10000);
    RooRealVar *mu = w.var("mu");
 
@@ -125,8 +125,8 @@ TEST_P(LikelihoodGradientJobTest, Gaussian1D)
    values->assign(savedValues);
 
    RooFit::MultiProcess::Config::setDefaultNWorkers(NWorkers);
-   auto unbinned_l = std::make_shared<RooFit::TestStatistics::RooUnbinnedL>(pdf, data);
-   RooFit::TestStatistics::RooRealL likelihood("likelihood", "likelihood", unbinned_l);
+   RooFit::TestStatistics::RooRealL likelihood("likelihood", "likelihood",
+                                               std::make_unique<RooFit::TestStatistics::RooUnbinnedL>(pdf, data.get()));
 
    // Convert to RooRealL to enter into minimizer
    RooMinimizer::Config cfg1;
@@ -166,7 +166,7 @@ TEST(LikelihoodGradientJob, RepeatMigrad)
    std::unique_ptr<RooAbsReal> nll;
    std::unique_ptr<RooArgSet> values;
    RooAbsPdf *pdf;
-   RooDataSet *data;
+   std::unique_ptr<RooDataSet> data;
    std::tie(nll, pdf, data, values) = generate_1D_gaussian_pdf_nll(w, 10000);
 
    RooArgSet savedValues;
@@ -175,8 +175,8 @@ TEST(LikelihoodGradientJob, RepeatMigrad)
    // --------
 
    RooFit::MultiProcess::Config::setDefaultNWorkers(NWorkers);
-   auto unbinned_l = std::make_shared<RooFit::TestStatistics::RooUnbinnedL>(pdf, data);
-   RooFit::TestStatistics::RooRealL likelihood("likelihood", "likelihood", unbinned_l);
+   RooFit::TestStatistics::RooRealL likelihood("likelihood", "likelihood",
+                                               std::make_unique<RooFit::TestStatistics::RooUnbinnedL>(pdf, data.get()));
    RooMinimizer::Config cfg;
    cfg.parallelize = -1;
    RooMinimizer m1(likelihood, cfg);
@@ -212,7 +212,7 @@ TEST_P(LikelihoodGradientJobTest, GaussianND)
    std::unique_ptr<RooAbsReal> nll;
    std::unique_ptr<RooArgSet> values;
    RooAbsPdf *pdf;
-   RooDataSet *data;
+   std::unique_ptr<RooDataSet> data;
    std::tie(nll, pdf, data, values) = generate_ND_gaussian_pdf_nll(w, N, 1000);
 
    RooArgSet savedValues;
@@ -252,8 +252,8 @@ TEST_P(LikelihoodGradientJobTest, GaussianND)
    // --------
 
    RooFit::MultiProcess::Config::setDefaultNWorkers(NWorkers);
-   auto unbinned_l = std::make_shared<RooFit::TestStatistics::RooUnbinnedL>(pdf, data);
-   RooFit::TestStatistics::RooRealL likelihood("likelihood", "likelihood", unbinned_l);
+   RooFit::TestStatistics::RooRealL likelihood("likelihood", "likelihood",
+                                               std::make_unique<RooFit::TestStatistics::RooUnbinnedL>(pdf, data.get()));
    RooMinimizer::Config cfg1;
    cfg1.parallelize = -1;
    RooMinimizer m1(likelihood, cfg1);
@@ -362,10 +362,11 @@ TEST(SimBinnedConstrainedTestBasic, BasicParameters)
 
    const double nll0 = nll->getVal();
 
-   std::shared_ptr<RooFit::TestStatistics::RooAbsL> likelihood = RooFit::TestStatistics::buildLikelihood(
-      pdf, data, RooFit::TestStatistics::GlobalObservables({*w.var("alpha_bkg_obs_A"), *w.var("alpha_bkg_obs_B")}));
-   auto clean_flags = std::make_shared<RooFit::TestStatistics::WrapperCalculationCleanFlags>();
-   auto nll_ts = LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags);
+   auto nll_ts = LikelihoodWrapper::create(
+      RooFit::TestStatistics::LikelihoodMode::serial,
+      RooFit::TestStatistics::buildLikelihood(
+         pdf, data, RooFit::TestStatistics::GlobalObservables({*w.var("alpha_bkg_obs_A"), *w.var("alpha_bkg_obs_B")})),
+      std::make_unique<RooFit::TestStatistics::WrapperCalculationCleanFlags>());
 
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
@@ -493,7 +494,7 @@ TEST_P(LikelihoodGradientJobTest, Gaussian1DAlsoWithLikelihoodJob)
    std::unique_ptr<RooAbsReal> nll;
    std::unique_ptr<RooArgSet> values;
    RooAbsPdf *pdf;
-   RooDataSet *data;
+   std::unique_ptr<RooDataSet> data;
    std::tie(nll, pdf, data, values) = generate_1D_gaussian_pdf_nll(w, 10000);
    RooRealVar *mu = w.var("mu");
 
@@ -519,8 +520,8 @@ TEST_P(LikelihoodGradientJobTest, Gaussian1DAlsoWithLikelihoodJob)
    values->assign(savedValues);
 
    RooFit::MultiProcess::Config::setDefaultNWorkers(NWorkers);
-   auto unbinned_l = std::make_shared<RooFit::TestStatistics::RooUnbinnedL>(pdf, data);
-   RooFit::TestStatistics::RooRealL likelihood("likelihood", "likelihood", unbinned_l);
+   RooFit::TestStatistics::RooRealL likelihood("likelihood", "likelihood",
+                                               std::make_unique<RooFit::TestStatistics::RooUnbinnedL>(pdf, data.get()));
    RooMinimizer::Config cfg;
    cfg.parallelize = -1;
    cfg.enableParallelDescent = true;

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodJob.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodJob.cxx
@@ -70,7 +70,7 @@ protected:
    void SetUp() override
    {
       RooRandom::randomGenerator()->SetSeed(seed);
-      clean_flags = std::make_shared<RooFit::TestStatistics::WrapperCalculationCleanFlags>();
+      clean_flags = std::make_unique<RooFit::TestStatistics::WrapperCalculationCleanFlags>();
    }
 
    std::size_t seed = 23;
@@ -78,7 +78,7 @@ protected:
    std::unique_ptr<RooAbsReal> nll;
    std::unique_ptr<RooArgSet> values;
    RooAbsPdf *pdf;
-   RooAbsData *data;
+   std::unique_ptr<RooAbsData> data;
    std::shared_ptr<RooFit::TestStatistics::RooAbsL> likelihood;
    std::shared_ptr<RooFit::TestStatistics::WrapperCalculationCleanFlags> clean_flags;
 };
@@ -94,8 +94,8 @@ protected:
       w.factory("Uniform::u(x)");
 
       // Generate template histograms
-      RooDataHist *h_sig = w.pdf("g")->generateBinned(*w.var("x"), 1000);
-      RooDataHist *h_bkg = w.pdf("u")->generateBinned(*w.var("x"), 1000);
+      std::unique_ptr<RooDataHist> h_sig{w.pdf("g")->generateBinned(*w.var("x"), 1000)};
+      std::unique_ptr<RooDataHist> h_bkg{w.pdf("u")->generateBinned(*w.var("x"), 1000)};
 
       w.import(*h_sig, RooFit::Rename("h_sig"));
       w.import(*h_bkg, RooFit::Rename("h_bkg"));
@@ -112,7 +112,7 @@ protected:
 TEST_F(LikelihoodJobTest, UnbinnedGaussian1D)
 {
    std::tie(nll, pdf, data, values) = generate_1D_gaussian_pdf_nll(w, 10000);
-   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data);
+   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
    auto nll_ts =
       LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::multiprocess, likelihood, clean_flags);
 
@@ -127,7 +127,7 @@ TEST_F(LikelihoodJobTest, UnbinnedGaussian1D)
 TEST_F(LikelihoodJobTest, UnbinnedGaussian1DTwice)
 {
    std::tie(nll, pdf, data, values) = generate_1D_gaussian_pdf_nll(w, 10000);
-   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data);
+   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
    auto nll_ts =
       LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::multiprocess, likelihood, clean_flags);
 
@@ -146,7 +146,7 @@ TEST_F(LikelihoodJobTest, UnbinnedGaussianND)
    unsigned int N = 4;
 
    std::tie(nll, pdf, data, values) = generate_ND_gaussian_pdf_nll(w, N, 1000);
-   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data);
+   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
    auto nll_ts =
       LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::multiprocess, likelihood, clean_flags);
 
@@ -161,11 +161,11 @@ TEST_F(LikelihoodJobTest, UnbinnedGaussianND)
 
 TEST_F(LikelihoodJobBinnedDatasetTest, UnbinnedPdf)
 {
-   data = pdf->generateBinned(*w.var("x"));
+   data = std::unique_ptr<RooDataHist>{pdf->generateBinned(*w.var("x"))};
 
    nll.reset(pdf->createNLL(*data));
 
-   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data);
+   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
    auto nll_ts =
       LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::multiprocess, likelihood, clean_flags);
 
@@ -180,7 +180,7 @@ TEST_F(LikelihoodJobBinnedDatasetTest, UnbinnedPdf)
 TEST_F(LikelihoodJobBinnedDatasetTest, BinnedManualNLL)
 {
    pdf->setAttribute("BinnedLikelihood");
-   data = pdf->generateBinned(*w.var("x"));
+   data = std::unique_ptr<RooDataHist>{pdf->generateBinned(*w.var("x"))};
 
    // manually create NLL, ripping all relevant parts from RooAbsPdf::createNLL, except here we also set binnedL = true
    RooArgSet projDeps;
@@ -191,7 +191,7 @@ TEST_F(LikelihoodJobBinnedDatasetTest, BinnedManualNLL)
    int extended = 2;
    RooNLLVar nll_manual("nlletje", "-log(likelihood)", *pdf, *data, projDeps, extended, nll_config);
 
-   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data);
+   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
    auto nll_ts =
       LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::multiprocess, likelihood, clean_flags);
 
@@ -235,11 +235,11 @@ TEST_F(LikelihoodJobTest, SimBinned)
 
    // Construct dataset
    pdf = w.pdf("model");
-   data = pdf->generate(RooArgSet(*w.var("x"), *w.cat("index")), RooFit::AllBinned());
+   data = std::unique_ptr<RooDataSet>{pdf->generate({*w.var("x"), *w.cat("index")}, RooFit::AllBinned())};
 
    nll.reset(pdf->createNLL(*data));
 
-   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data);
+   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
    auto nll_ts =
       LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::multiprocess, likelihood, clean_flags);
 
@@ -279,7 +279,7 @@ TEST_F(LikelihoodJobTest, BinnedConstrained)
 
    pdf = w.pdf("model");
    // Construct dataset from physics pdf
-   data = w.pdf("model_phys")->generateBinned(*w.var("x"));
+   data = std::unique_ptr<RooDataHist>{w.pdf("model_phys")->generateBinned(*w.var("x"))};
 
    nll.reset(pdf->createNLL(*data, RooFit::GlobalObservables(*w.var("alpha_bkg_obs"))));
 
@@ -288,7 +288,7 @@ TEST_F(LikelihoodJobTest, BinnedConstrained)
    auto nll0 = nll->getVal();
 
    likelihood = RooFit::TestStatistics::buildLikelihood(
-      pdf, data, RooFit::TestStatistics::GlobalObservables(RooArgSet(*w.var("alpha_bkg_obs"))));
+      pdf, data.get(), RooFit::TestStatistics::GlobalObservables(RooArgSet(*w.var("alpha_bkg_obs"))));
    auto nll_ts =
       LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::multiprocess, likelihood, clean_flags);
 
@@ -308,15 +308,15 @@ TEST_F(LikelihoodJobTest, SimUnbinned)
 
    pdf = w.pdf("model");
    // Construct dataset from physics pdf
-   data = pdf->generate(RooArgSet(*w.var("x"), *w.cat("index")));
+   data = std::unique_ptr<RooDataSet>{pdf->generate({*w.var("x"), *w.cat("index")})};
 
-   nll.reset(pdf->createNLL(*data));
+   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data)};
 
    // --------
 
    auto nll0 = nll->getVal();
 
-   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data);
+   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
    auto nll_ts =
       LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::multiprocess, likelihood, clean_flags);
 
@@ -341,14 +341,14 @@ TEST_F(LikelihoodJobTest, SimUnbinnedNonExtended)
    w.cat("index")->setLabel("B");
    dB->addColumn(*w.cat("index"));
 
-   data = (RooDataSet *)dA->Clone();
-   dynamic_cast<RooDataSet *>(data)->append(*dB);
+   data = std::unique_ptr<RooDataSet>{static_cast<RooDataSet *>(dA->Clone())};
+   static_cast<RooDataSet &>(*data).append(*dB);
 
    pdf = w.pdf("model");
 
    nll.reset(pdf->createNLL(*data));
 
-   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data);
+   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
    auto nll_ts =
       LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::multiprocess, likelihood, clean_flags);
 
@@ -403,7 +403,7 @@ protected:
 
       pdf = w.pdf("model");
       // Construct dataset from physics pdf
-      data = pdf->generate(RooArgSet(*w.var("x"), *w.cat("index")), RooFit::AllBinned());
+      data = std::unique_ptr<RooDataSet>{pdf->generate({*w.var("x"), *w.cat("index")}, RooFit::AllBinned())};
    }
 };
 
@@ -418,7 +418,8 @@ TEST_F(LikelihoodJobSimBinnedConstrainedTest, BasicParameters)
    auto nll0 = nll->getVal();
 
    likelihood = RooFit::TestStatistics::buildLikelihood(
-      pdf, data, RooFit::TestStatistics::GlobalObservables({*w.var("alpha_bkg_obs_A"), *w.var("alpha_bkg_obs_B")}));
+      pdf, data.get(),
+      RooFit::TestStatistics::GlobalObservables({*w.var("alpha_bkg_obs_A"), *w.var("alpha_bkg_obs_B")}));
    auto nll_ts =
       LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::multiprocess, likelihood, clean_flags);
 
@@ -439,7 +440,7 @@ TEST_F(LikelihoodJobSimBinnedConstrainedTest, ConstrainedAndOffset)
    auto nll0 = nll->getVal();
 
    likelihood = RooFit::TestStatistics::buildLikelihood(
-      pdf, data, RooFit::TestStatistics::ConstrainedParameters(RooArgSet(*w.var("alpha_bkg_obs_A"))),
+      pdf, data.get(), RooFit::TestStatistics::ConstrainedParameters(RooArgSet(*w.var("alpha_bkg_obs_A"))),
       RooFit::TestStatistics::GlobalObservables(RooArgSet(*w.var("alpha_bkg_obs_B"))));
    auto nll_ts =
       LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::multiprocess, likelihood, clean_flags);
@@ -479,7 +480,7 @@ TEST_F(LikelihoodJobTest, BatchedUnbinnedGaussianND)
    // and then this line can be deleted.
    pdf->fixAddCoefNormalization(*data->get(), false);
 
-   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data);
+   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
    dynamic_cast<RooFit::TestStatistics::RooUnbinnedL *>(likelihood.get())->setUseBatchedEvaluations(true);
    auto nll_ts =
       LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::multiprocess, likelihood, clean_flags);
@@ -506,7 +507,7 @@ TEST_P(LikelihoodJobSplitStrategies, SimBinnedConstrainedAndOffset)
    auto nll0 = nll->getVal();
 
    likelihood = RooFit::TestStatistics::buildLikelihood(
-      pdf, data, RooFit::TestStatistics::ConstrainedParameters(RooArgSet(*w.var("alpha_bkg_obs_A"))),
+      pdf, data.get(), RooFit::TestStatistics::ConstrainedParameters(RooArgSet(*w.var("alpha_bkg_obs_A"))),
       RooFit::TestStatistics::GlobalObservables(RooArgSet(*w.var("alpha_bkg_obs_B"))));
 
    RooFit::MultiProcess::Config::LikelihoodJob::defaultNEventTasks = std::get<0>(GetParam());

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodSerial.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodSerial.cxx
@@ -60,7 +60,7 @@ protected:
    void SetUp() override
    {
       RooRandom::randomGenerator()->SetSeed(seed);
-      clean_flags = std::make_shared<RooFit::TestStatistics::WrapperCalculationCleanFlags>();
+      clean_flags = std::make_unique<RooFit::TestStatistics::WrapperCalculationCleanFlags>();
    }
 
    std::size_t seed = 23;
@@ -68,7 +68,7 @@ protected:
    std::unique_ptr<RooAbsReal> nll;
    std::unique_ptr<RooArgSet> values;
    RooAbsPdf *pdf;
-   RooAbsData *data;
+   std::unique_ptr<RooAbsData> data;
    std::shared_ptr<RooFit::TestStatistics::RooAbsL> likelihood;
    std::shared_ptr<RooFit::TestStatistics::WrapperCalculationCleanFlags> clean_flags;
 };
@@ -102,7 +102,7 @@ protected:
 TEST_F(LikelihoodSerialTest, UnbinnedGaussian1D)
 {
    std::tie(nll, pdf, data, values) = generate_1D_gaussian_pdf_nll(w, 10000);
-   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data);
+   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
    auto nll_ts = LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags);
 
    auto nll0 = nll->getVal();
@@ -118,7 +118,7 @@ TEST_F(LikelihoodSerialTest, UnbinnedGaussianND)
    unsigned int N = 4;
 
    std::tie(nll, pdf, data, values) = generate_ND_gaussian_pdf_nll(w, N, 1000);
-   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data);
+   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
    auto nll_ts = LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags);
 
    auto nll0 = nll->getVal();
@@ -131,11 +131,11 @@ TEST_F(LikelihoodSerialTest, UnbinnedGaussianND)
 
 TEST_F(LikelihoodSerialBinnedDatasetTest, UnbinnedPdf)
 {
-   data = pdf->generateBinned(*w.var("x"));
+   data = std::unique_ptr<RooDataHist>{pdf->generateBinned(*w.var("x"))};
 
    nll.reset(pdf->createNLL(*data));
 
-   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data);
+   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
    auto nll_ts = LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags);
 
    auto nll0 = nll->getVal();
@@ -149,7 +149,7 @@ TEST_F(LikelihoodSerialBinnedDatasetTest, UnbinnedPdf)
 TEST_F(LikelihoodSerialBinnedDatasetTest, BinnedManualNLL)
 {
    pdf->setAttribute("BinnedLikelihood");
-   data = pdf->generateBinned(*w.var("x"));
+   data = std::unique_ptr<RooDataHist>{pdf->generateBinned(*w.var("x"))};
 
    // manually create NLL, ripping all relevant parts from RooAbsPdf::createNLL, except here we also set binnedL = true
    RooArgSet projDeps;
@@ -160,7 +160,7 @@ TEST_F(LikelihoodSerialBinnedDatasetTest, BinnedManualNLL)
    int extended = 2;
    RooNLLVar nll_manual("nlletje", "-log(likelihood)", *pdf, *data, projDeps, extended, nll_config);
 
-   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data);
+   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
    auto nll_ts = LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags);
 
    auto nll0 = nll_manual.getVal();
@@ -203,11 +203,11 @@ TEST_F(LikelihoodSerialTest, SimBinned)
 
    // Construct dataset
    pdf = w.pdf("model");
-   data = pdf->generate(RooArgSet(*w.var("x"), *w.cat("index")), RooFit::AllBinned());
+   data = std::unique_ptr<RooDataSet>{pdf->generate({*w.var("x"), *w.cat("index")}, RooFit::AllBinned())};
 
    nll.reset(pdf->createNLL(*data));
 
-   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data);
+   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
    auto nll_ts = LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags);
 
    auto nll0 = nll->getVal();
@@ -246,7 +246,7 @@ TEST_F(LikelihoodSerialTest, BinnedConstrained)
 
    pdf = w.pdf("model");
    // Construct dataset from physics pdf
-   data = w.pdf("model_phys")->generateBinned(*w.var("x"));
+   data = std::unique_ptr<RooDataHist>{w.pdf("model_phys")->generateBinned(*w.var("x"))};
 
    nll.reset(pdf->createNLL(*data, RooFit::GlobalObservables(*w.var("alpha_bkg_obs"))));
 
@@ -255,7 +255,7 @@ TEST_F(LikelihoodSerialTest, BinnedConstrained)
    auto nll0 = nll->getVal();
 
    likelihood = RooFit::TestStatistics::buildLikelihood(
-      pdf, data, RooFit::TestStatistics::GlobalObservables(RooArgSet(*w.var("alpha_bkg_obs"))));
+      pdf, data.get(), RooFit::TestStatistics::GlobalObservables(RooArgSet(*w.var("alpha_bkg_obs"))));
    auto nll_ts = LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags);
 
    nll_ts->evaluate();
@@ -274,7 +274,7 @@ TEST_F(LikelihoodSerialTest, SimUnbinned)
 
    pdf = w.pdf("model");
    // Construct dataset from physics pdf
-   data = pdf->generate(RooArgSet(*w.var("x"), *w.cat("index")));
+   data = std::unique_ptr<RooDataSet>{pdf->generate({*w.var("x"), *w.cat("index")})};
 
    nll.reset(pdf->createNLL(*data));
 
@@ -282,7 +282,7 @@ TEST_F(LikelihoodSerialTest, SimUnbinned)
 
    auto nll0 = nll->getVal();
 
-   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data);
+   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
    auto nll_ts = LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags);
 
    nll_ts->evaluate();
@@ -306,14 +306,14 @@ TEST_F(LikelihoodSerialTest, SimUnbinnedNonExtended)
    w.cat("index")->setLabel("B");
    dB->addColumn(*w.cat("index"));
 
-   data = (RooDataSet *)dA->Clone();
-   dynamic_cast<RooDataSet *>(data)->append(*dB);
+   data = std::unique_ptr<RooDataSet>{static_cast<RooDataSet *>(dA->Clone())};
+   static_cast<RooDataSet &>(*data).append(*dB);
 
    pdf = w.pdf("model");
 
    nll.reset(pdf->createNLL(*data));
 
-   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data);
+   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
    auto nll_ts = LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags);
 
    auto nll0 = nll->getVal();
@@ -367,7 +367,7 @@ protected:
 
       pdf = w.pdf("model");
       // Construct dataset from physics pdf
-      data = pdf->generate(RooArgSet(*w.var("x"), *w.cat("index")), RooFit::AllBinned());
+      data = std::unique_ptr<RooDataSet>{pdf->generate({*w.var("x"), *w.cat("index")}, RooFit::AllBinned())};
    }
 };
 
@@ -382,7 +382,8 @@ TEST_F(LikelihoodSerialSimBinnedConstrainedTest, BasicParameters)
    auto nll0 = nll->getVal();
 
    likelihood = RooFit::TestStatistics::buildLikelihood(
-      pdf, data, RooFit::TestStatistics::GlobalObservables({*w.var("alpha_bkg_obs_A"), *w.var("alpha_bkg_obs_B")}));
+      pdf, data.get(),
+      RooFit::TestStatistics::GlobalObservables({*w.var("alpha_bkg_obs_A"), *w.var("alpha_bkg_obs_B")}));
    auto nll_ts = LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags);
 
    nll_ts->evaluate();
@@ -402,7 +403,7 @@ TEST_F(LikelihoodSerialSimBinnedConstrainedTest, ConstrainedAndOffset)
    auto nll0 = nll->getVal();
 
    likelihood = RooFit::TestStatistics::buildLikelihood(
-      pdf, data, RooFit::TestStatistics::ConstrainedParameters(RooArgSet(*w.var("alpha_bkg_obs_A"))),
+      pdf, data.get(), RooFit::TestStatistics::ConstrainedParameters(RooArgSet(*w.var("alpha_bkg_obs_A"))),
       RooFit::TestStatistics::GlobalObservables(RooArgSet(*w.var("alpha_bkg_obs_B"))));
    auto nll_ts = LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags);
    nll_ts->enableOffsetting(true);
@@ -441,7 +442,7 @@ TEST_F(LikelihoodSerialTest, BatchedUnbinnedGaussianND)
    // and then this line can be deleted.
    pdf->fixAddCoefNormalization(*data->get(), false);
 
-   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data);
+   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
    dynamic_cast<RooFit::TestStatistics::RooUnbinnedL *>(likelihood.get())->setUseBatchedEvaluations(true);
    auto nll_ts = LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags);
 

--- a/roofit/roofitcore/test/TestStatistics/testRooAbsL.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testRooAbsL.cxx
@@ -60,7 +60,7 @@ protected:
    void SetUp() override
    {
       RooRandom::randomGenerator()->SetSeed(seed);
-      clean_flags = std::make_shared<RooFit::TestStatistics::WrapperCalculationCleanFlags>();
+      clean_flags = std::make_unique<RooFit::TestStatistics::WrapperCalculationCleanFlags>();
    }
 
    std::size_t seed = 23;
@@ -68,7 +68,7 @@ protected:
    std::unique_ptr<RooAbsReal> nll;
    std::unique_ptr<RooArgSet> values;
    RooAbsPdf *pdf;
-   RooAbsData *data;
+   std::unique_ptr<RooAbsData> data;
    std::shared_ptr<RooFit::TestStatistics::RooAbsL> likelihood;
    std::shared_ptr<RooFit::TestStatistics::WrapperCalculationCleanFlags> clean_flags;
 };
@@ -84,8 +84,8 @@ protected:
       w.factory("Uniform::u(x)");
 
       // Generate template histograms
-      RooDataHist *h_sig = w.pdf("g")->generateBinned(*w.var("x"), 1000);
-      RooDataHist *h_bkg = w.pdf("u")->generateBinned(*w.var("x"), 1000);
+      std::unique_ptr<RooDataHist> h_sig{w.pdf("g")->generateBinned(*w.var("x"), 1000)};
+      std::unique_ptr<RooDataHist> h_bkg{w.pdf("u")->generateBinned(*w.var("x"), 1000)};
 
       w.import(*h_sig, RooFit::Rename("h_sig"));
       w.import(*h_bkg, RooFit::Rename("h_bkg"));
@@ -142,7 +142,7 @@ protected:
 
       pdf = w.pdf("model");
       // Construct dataset from physics pdf
-      data = pdf->generate(RooArgSet(*w.var("x"), *w.cat("index")), RooFit::AllBinned());
+      data = std::unique_ptr<RooDataSet>{pdf->generate({*w.var("x"), *w.cat("index")}, RooFit::AllBinned())};
    }
 };
 
@@ -153,7 +153,7 @@ protected:
 TEST_F(RooAbsLTest, UnbinnedLikelihoodIntrospection)
 {
    std::tie(nll, pdf, data, values) = generate_1D_gaussian_pdf_nll(w, 10000);
-   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data);
+   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
 
    EXPECT_STREQ("RooUnbinnedL", (likelihood->GetClassName()).c_str());
    EXPECT_STREQ("RooUnbinnedL::g", (likelihood->GetInfo()).c_str());
@@ -162,8 +162,8 @@ TEST_F(RooAbsLTest, UnbinnedLikelihoodIntrospection)
 TEST_F(BinnedDatasetTest, BinnedLikelihoodIntrospection)
 {
    pdf->setAttribute("BinnedLikelihood");
-   data = pdf->generateBinned(*w.var("x"));
-   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data);
+   data = std::unique_ptr<RooDataHist>{pdf->generateBinned(*w.var("x"))};
+   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
 
    EXPECT_STREQ("RooBinnedL", (likelihood->GetClassName()).c_str());
    EXPECT_STREQ("RooBinnedL::model", (likelihood->GetInfo()).c_str());
@@ -177,9 +177,9 @@ TEST_F(RooAbsLTest, SumLikelihoodIntrospection)
 
    pdf = w.pdf("model");
    // Construct dataset from physics pdf
-   data = pdf->generate(RooArgSet(*w.var("x"), *w.cat("index")));
+   data = std::unique_ptr<RooDataSet>{pdf->generate({*w.var("x"), *w.cat("index")})};
 
-   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data);
+   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
 
    EXPECT_STREQ("RooSumL", (likelihood->GetClassName()).c_str());
    EXPECT_STREQ("RooSumL::model", (likelihood->GetInfo()).c_str());
@@ -189,13 +189,14 @@ TEST_F(SimBinnedConstrainedTest, SumSubsidiaryLikelihoodIntrospection)
 {
 
    likelihood = RooFit::TestStatistics::buildLikelihood(
-      pdf, data, RooFit::TestStatistics::GlobalObservables({*w.var("alpha_bkg_obs_A"), *w.var("alpha_bkg_obs_B")}));
+      pdf, data.get(),
+      RooFit::TestStatistics::GlobalObservables({*w.var("alpha_bkg_obs_A"), *w.var("alpha_bkg_obs_B")}));
 
    EXPECT_STREQ("RooSumL", (likelihood->GetClassName()).c_str());
    EXPECT_STREQ("RooSumL::model", (likelihood->GetInfo()).c_str());
 
    // Is RooSumL so we can cast to this type to use its further functionality
-   RooFit::TestStatistics::RooSumL *sum_likelihood = dynamic_cast<RooFit::TestStatistics::RooSumL *>(likelihood.get());
+   auto sum_likelihood = static_cast<RooFit::TestStatistics::RooSumL *>(likelihood.get());
 
    EXPECT_STREQ("RooUnbinnedL", (sum_likelihood->GetComponents()[0]->GetClassName()).c_str());
    EXPECT_STREQ("RooUnbinnedL::model_A", (sum_likelihood->GetComponents()[0]->GetInfo()).c_str());
@@ -210,8 +211,8 @@ TEST_F(BinnedDatasetTest, EventSections)
    // Test whether the summed total of multiple sections gives the same result
    // as an evaluation with a single section over the whole event range.
    pdf->setAttribute("BinnedLikelihood");
-   data = pdf->generateBinned(*w.var("x"));
-   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data);
+   data = std::unique_ptr<RooDataHist>{pdf->generateBinned(*w.var("x"))};
+   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
 
    auto whole = likelihood->evaluatePartition({0, 1}, 0, 0);
    auto part1 = likelihood->evaluatePartition({0, 0.5}, 0, 0);
@@ -224,7 +225,8 @@ TEST_F(SimBinnedConstrainedTest, EventSections)
    // Test whether the summed total of multiple sections gives the same result
    // as an evaluation with a single section over the whole event range.
    likelihood = RooFit::TestStatistics::buildLikelihood(
-      pdf, data, RooFit::TestStatistics::GlobalObservables({*w.var("alpha_bkg_obs_A"), *w.var("alpha_bkg_obs_B")}));
+      pdf, data.get(),
+      RooFit::TestStatistics::GlobalObservables({*w.var("alpha_bkg_obs_A"), *w.var("alpha_bkg_obs_B")}));
 
    auto whole = likelihood->evaluatePartition({0, 1}, 0, likelihood->getNComponents());
    auto part1 = likelihood->evaluatePartition({0, 0.5}, 0, likelihood->getNComponents());
@@ -246,7 +248,7 @@ TEST_F(RooAbsLTest, SubEventSections)
    // must contain two events, but which section?), or 11 (one must be empty,
    // but which one?).
    std::tie(nll, pdf, data, values) = generate_1D_gaussian_pdf_nll(w, 10);
-   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data);
+   likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
 
    auto whole = likelihood->evaluatePartition({0, 1}, 0, likelihood->getNComponents());
    ROOT::Math::KahanSum<double> nine_parts, eleven_parts, twenty_parts;
@@ -278,7 +280,8 @@ TEST_F(SimBinnedConstrainedTest, SubEventSections)
    // complex likelihood has an extended term and a subsidiary component
    // which also depend on section so will also be checked here.
    likelihood = RooFit::TestStatistics::buildLikelihood(
-      pdf, data, RooFit::TestStatistics::GlobalObservables({*w.var("alpha_bkg_obs_A"), *w.var("alpha_bkg_obs_B")}));
+      pdf, data.get(),
+      RooFit::TestStatistics::GlobalObservables({*w.var("alpha_bkg_obs_A"), *w.var("alpha_bkg_obs_B")}));
 
    auto whole = likelihood->evaluatePartition({0, 1}, 0, likelihood->getNComponents());
 

--- a/roofit/roofitcore/test/TestStatistics/testRooRealL.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testRooRealL.cxx
@@ -57,7 +57,7 @@ TEST_P(RooRealL, getVal)
    auto nominal_result = nll->getVal();
 
    RooFit::TestStatistics::RooRealL nll_new("nll_new", "new style NLL",
-                                            std::make_shared<RooFit::TestStatistics::RooUnbinnedL>(pdf, data.get()));
+                                            std::make_unique<RooFit::TestStatistics::RooUnbinnedL>(pdf, data.get()));
 
    auto mp_result = nll_new.getVal();
 
@@ -212,7 +212,7 @@ TEST_P(RooRealL, setVal)
    std::unique_ptr<RooAbsReal> nll{pdf->createNLL(*data)};
 
    RooFit::TestStatistics::RooRealL nll_new("nll_new", "new style NLL",
-                                            std::make_shared<RooFit::TestStatistics::RooUnbinnedL>(pdf, data.get()));
+                                            std::make_unique<RooFit::TestStatistics::RooUnbinnedL>(pdf, data.get()));
 
    // calculate first results
    auto nominal_result1 = nll->getVal();
@@ -266,7 +266,7 @@ TEST_P(RealLVsMPFE, getVal)
    auto mpfe_result = nll_mpfe->getVal();
 
    RooFit::TestStatistics::RooRealL nll_new("nll_new", "new style NLL",
-                                            std::make_shared<RooFit::TestStatistics::RooUnbinnedL>(pdf, data.get()));
+                                            std::make_unique<RooFit::TestStatistics::RooUnbinnedL>(pdf, data.get()));
 
    auto mp_result = nll_new.getVal();
 
@@ -304,7 +304,7 @@ TEST_P(RealLVsMPFE, minimize)
 
    std::unique_ptr<RooAbsReal> nll_mpfe{pdf->createNLL(*data)};
    RooFit::TestStatistics::RooRealL nll_new("nll_new", "new style NLL",
-                                            std::make_shared<RooFit::TestStatistics::RooUnbinnedL>(pdf, data.get()));
+                                            std::make_unique<RooFit::TestStatistics::RooUnbinnedL>(pdf, data.get()));
 
    // save initial values for the start of all minimizations
    RooArgSet values{*mu, *pdf};


### PR DESCRIPTION
* Since the `RooAbsMinimizeFcn` implementations don't need to be copied
  anymore, we can use `std::unique_ptr` instead of `shared_ptr` for
  clear ownership and less overhead

* Name variables to be consistent with RooFit style

* Streamline `public` and `private` scopes

* Avoid code duplication with new private member function that applies a
  specific call to both the regular likelihood and the likelihood in the
  gradient

* Additional commit fixes memory leaks of toy datasets in `TestStatistics` tests

