### PR TITLE
[ntuple] Add GetNEntries to inspector

### DIFF
--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -78,6 +78,9 @@ public:
    /// Get the name of the RNTuple being inspected.
    std::string GetName();
 
+   /// Get the number of entries in the RNTuple being inspected.
+   std::uint64_t GetNEntries();
+
    /// Get the compression settings of the RNTuple being inspected.
    int GetCompressionSettings();
 

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -77,6 +77,13 @@ std::string ROOT::Experimental::RNTupleInspector::GetName()
    return descriptorGuard->GetName();
 }
 
+std::uint64_t ROOT::Experimental::RNTupleInspector::GetNEntries()
+{
+   fPageSource->Attach();
+   auto descriptorGuard = fPageSource->GetSharedDescriptorGuard();
+   return descriptorGuard->GetNEntries();
+}
+
 int ROOT::Experimental::RNTupleInspector::GetCompressionSettings()
 {
    return fCompressionSettings;

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -27,6 +27,28 @@ TEST(RNTupleInspector, Name)
    EXPECT_EQ("ntuple", inspector->GetName());
 }
 
+TEST(RNTupleInspector, NEntries)
+{
+   FileRaii fileGuard("test_ntuple_inspector_n_entries.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto nFldInt = model->MakeField<std::int32_t>("i");
+
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
+
+      for (int32_t i = 0; i < 50; ++i) {
+         *nFldInt = i;
+         ntuple->Fill();
+      }
+   }
+
+   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
+   auto ntuple = file->Get<RNTuple>("ntuple");
+   auto inspector = RNTupleInspector::Create(ntuple).Unwrap();
+
+   EXPECT_EQ(inspector->GetNEntries(), 50);
+}
+
 TEST(RNTupleInspector, CompressionSettings)
 {
    FileRaii fileGuard("test_ntuple_inspector_size_single_int_field.root");


### PR DESCRIPTION
This PR adds a `GetNEntries` method to the `RNTupleInspector` class, so that won't be necessary to have to do this via the `RNTupleReader` or `RNTupleDescriptor` directly.

