### PR TITLE
Use consistent wording of the comments in the different TMVA classification tests to avoid confusion

### DIFF
--- a/tutorials/tmva/TMVA_CNN_Classification.py
+++ b/tutorials/tmva/TMVA_CNN_Classification.py
@@ -25,7 +25,6 @@
 
 import ROOT
 
-#switch off MT in OpenMP (BLAS)
 
 TMVA = ROOT.TMVA
 TFile = ROOT.TFile
@@ -144,7 +143,7 @@ if not useTMVACNN:
 
 writeOutputFile = True
 
-num_threads = 4  # use default threads
+num_threads = 4  # use max 4 threads
 max_epochs = 10  # maximum number of epochs used for training
 
 

--- a/tutorials/tmva/TMVA_RNN_Classification.C
+++ b/tutorials/tmva/TMVA_RNN_Classification.C
@@ -192,8 +192,10 @@ void TMVA_RNN_Classification(int nevts = 2000, int use_type = 1)
 #endif
 
 #ifdef R__USE_IMT
-   int num_threads = 4;   // use by default all threads
-   gSystem->Setenv("OMP_NUM_THREADS", "1"); // switch off MT in OpenBLAS
+   int num_threads = 4; // use max 4 threads
+   // switch off MT in OpenBLAS to avoid conflict with tbb
+   gSystem->Setenv("OMP_NUM_THREADS", "1");
+
    // do enable MT running
    if (num_threads >= 0) {
       ROOT::EnableImplicitMT(num_threads);

--- a/tutorials/tmva/TMVA_RNN_Classification.py
+++ b/tutorials/tmva/TMVA_RNN_Classification.py
@@ -26,7 +26,8 @@ num_threads = 4  # use max 4 threads
 # do enable MT running
 if "imt" in ROOT.gROOT.GetConfigFeatures():
     ROOT.EnableImplicitMT(num_threads)
-    ROOT.gSystem.Setenv("OMP_NUM_THREADS", "1")  # switch OFF MT in OpenBLAS
+    # switch off MT in OpenBLAS to avoid conflict with tbb
+    ROOT.gSystem.Setenv("OMP_NUM_THREADS", "1")
     print("Running with nthreads  = {}".format(ROOT.GetThreadPoolSize()))
 else:
     print("Running in serial mode since ROOT does not support MT")


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

After the recent update of the TMVA classification tests, some comments were not updated to reflect the changes, which is confusing. This PR makes the comments the same in all tests to reduce the conusion.
