### PR TITLE
[ntuple] Implement foundations for late model extension (1/2)

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -409,7 +409,7 @@ The footer envelope has the following structure:
 
 The header checksum can be used to cross-check that header and footer belong together.
 
-The schema extension record frame contains an additional schema description that is incremental with respect to the schema contained in the header (see Section Header Envelope).
+The schema extension record frame contains an additional schema description that is incremental with respect to the schema contained in the header (see Section Header Envelope). To allow for backward compatibility the record frame might be empty.
 The interpretation of the information contained therein should be identical as if it was found directly at the end of the header.
 This is necessary when fields have been added during writing.
 

--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -227,7 +227,7 @@ The header consists of the following elements:
  - List frame: list of alias column record frames
  - List frame: list of extra type information
 
-The last four list frames containing information about fields and columns are collectively referred to as _Schema description_.
+The last four list frames containing information about fields and columns are collectively referred to as _schema description_.
 The release candidate tag is used to mark unstable implementations of the file format.
 Production code sets the tag to zero.
 
@@ -409,7 +409,8 @@ The footer envelope has the following structure:
 
 The header checksum can be used to cross-check that header and footer belong together.
 
-The schema extension record frame contains an additional schema description that is incremental with respect to the schema contained in the header (see Section Header Envelope). To allow for backward compatibility the record frame might be empty.
+The schema extension record frame contains an additional schema description that is incremental with respect to the schema contained in the header (see Section Header Envelope).
+In general, a schema extension is optional and thus this record frame might be empty.
 The interpretation of the information contained therein should be identical as if it was found directly at the end of the header.
 This is necessary when fields have been added during writing.
 

--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -227,6 +227,7 @@ The header consists of the following elements:
  - List frame: list of alias column record frames
  - List frame: list of extra type information
 
+The last four list frames containing information about fields and columns are collectively referred to as _Schema description_.
 The release candidate tag is used to mark unstable implementations of the file format.
 Production code sets the tag to zero.
 
@@ -400,7 +401,7 @@ The footer envelope has the following structure:
 
 - Feature flags
 - Header checksum (CRC32)
-- List frame of extension header envelope links
+- Schema extension record frame
 - List frame of column group record frames
 - List frame of cluster summary record frames
 - List frame of cluster group record frames
@@ -408,8 +409,9 @@ The footer envelope has the following structure:
 
 The header checksum can be used to cross-check that header and footer belong together.
 
-The extension headers are just additional headers with an empty name and description.
-They are necessary when fields have been backfilled during writing.
+The schema extension record frame contains an additional schema description that is incremental with respect to the schema contained in the header (see Section Header Envelope).
+The interpretation of the information contained therein should be identical as if it was found directly at the end of the header.
+This is necessary when fields have been added during writing.
 
 The ntuple meta-data can be split over multiple meta-data envelopes (see below).
 

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -440,6 +440,30 @@ public:
    const Detail::RNTupleMetrics &GetMetrics() const { return fMetrics; }
 
    const RNTupleModel *GetModel() const { return fModel.get(); }
+
+   /// Get a `RNTupleModel::RIncrementalUpdater` that provides limited support for incremental updates to the underlying
+   /// model, e.g. addition of new fields.
+   ///
+   /// **Example: add a new field after the model has been used to construct a `RNTupleWriter` object**
+   /// ~~~ {.cpp}
+   /// #include <ROOT/RNTuple.hxx>
+   /// using ROOT::Experimental::RNTupleModel;
+   /// using ROOT::Experimental::RNTupleWriter;
+   ///
+   /// auto model = RNTupleModel::Create();
+   /// auto fldFloat = model->MakeField<float>("fldFloat");
+   /// auto ntuple = RNTupleWriter::Recreate(std::move(model), "myNTuple", "some/file.root");
+   /// auto updater = ntuple->GetIncrementalModelUpdater();
+   /// updater->BeginUpdate();
+   /// updater->AddField(std::make_unique<RField<float>>("pt"));
+   /// updater->CommitUpdate();
+   ///
+   /// // ...
+   /// ~~~
+   std::unique_ptr<RNTupleModel::RIncrementalUpdater> GetIncrementalModelUpdater()
+   {
+      return std::unique_ptr<RNTupleModel::RIncrementalUpdater>(new RNTupleModel::RIncrementalUpdater(*this));
+   }
 };
 
 // clang-format off

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -366,7 +366,7 @@ triggered by Flush() or by destructing the ntuple.  On I/O errors, an exception 
 */
 // clang-format on
 class RNTupleWriter {
-   friend RNTupleModel::RIncrementalUpdater;
+   friend RNTupleModel::RUpdater;
 
 private:
    /// The page sink's parallel page compression scheduler if IMT is on.
@@ -441,7 +441,7 @@ public:
 
    const RNTupleModel *GetModel() const { return fModel.get(); }
 
-   /// Get a `RNTupleModel::RIncrementalUpdater` that provides limited support for incremental updates to the underlying
+   /// Get a `RNTupleModel::RUpdater` that provides limited support for incremental updates to the underlying
    /// model, e.g. addition of new fields.
    ///
    /// **Example: add a new field after the model has been used to construct a `RNTupleWriter` object**
@@ -453,16 +453,16 @@ public:
    /// auto model = RNTupleModel::Create();
    /// auto fldFloat = model->MakeField<float>("fldFloat");
    /// auto ntuple = RNTupleWriter::Recreate(std::move(model), "myNTuple", "some/file.root");
-   /// auto updater = ntuple->GetIncrementalModelUpdater();
+   /// auto updater = ntuple->GetModelUpdater();
    /// updater->BeginUpdate();
    /// updater->AddField(std::make_unique<RField<float>>("pt"));
    /// updater->CommitUpdate();
    ///
    /// // ...
    /// ~~~
-   std::unique_ptr<RNTupleModel::RIncrementalUpdater> GetIncrementalModelUpdater()
+   std::unique_ptr<RNTupleModel::RUpdater> GetModelUpdater()
    {
-      return std::unique_ptr<RNTupleModel::RIncrementalUpdater>(new RNTupleModel::RIncrementalUpdater(*this));
+      return std::unique_ptr<RNTupleModel::RUpdater>(new RNTupleModel::RUpdater(*this));
    }
 };
 

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -366,6 +366,8 @@ triggered by Flush() or by destructing the ntuple.  On I/O errors, an exception 
 */
 // clang-format on
 class RNTupleWriter {
+   friend RNTupleModel::RIncrementalUpdater;
+
 private:
    /// The page sink's parallel page compression scheduler if IMT is on.
    /// Needs to be destructed after the page sink is destructed and so declared before.

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -453,14 +453,14 @@ public:
    /// auto model = RNTupleModel::Create();
    /// auto fldFloat = model->MakeField<float>("fldFloat");
    /// auto ntuple = RNTupleWriter::Recreate(std::move(model), "myNTuple", "some/file.root");
-   /// auto updater = ntuple->GetModelUpdater();
+   /// auto updater = ntuple->CreateModelUpdater();
    /// updater->BeginUpdate();
    /// updater->AddField(std::make_unique<RField<float>>("pt"));
    /// updater->CommitUpdate();
    ///
    /// // ...
    /// ~~~
-   std::unique_ptr<RNTupleModel::RUpdater> GetModelUpdater()
+   std::unique_ptr<RNTupleModel::RUpdater> CreateModelUpdater()
    {
       return std::unique_ptr<RNTupleModel::RUpdater>(new RNTupleModel::RUpdater(*this));
    }

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -452,8 +452,8 @@ public:
    ///
    /// auto model = RNTupleModel::Create();
    /// auto fldFloat = model->MakeField<float>("fldFloat");
-   /// auto ntuple = RNTupleWriter::Recreate(std::move(model), "myNTuple", "some/file.root");
-   /// auto updater = ntuple->CreateModelUpdater();
+   /// auto writer = RNTupleWriter::Recreate(std::move(model), "myNTuple", "some/file.root");
+   /// auto updater = writer->CreateModelUpdater();
    /// updater->BeginUpdate();
    /// updater->AddField(std::make_unique<RField<float>>("pt"));
    /// updater->CommitUpdate();

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -396,6 +396,13 @@ public:
    class RFieldDescriptorIterable;
 
 private:
+   // clang-format off
+   /**
+   \class ROOT::Experimental::RNTupleDescriptor::RHeaderExtension
+   \ingroup NTuple
+   \brief Summarizes information about fields and the corresponding columns that were added after the header has been serialized
+   */
+   // clang-format on
    class RHeaderExtension {
       friend class RNTupleDescriptorBuilder;
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -392,9 +392,6 @@ writte struct. This allows for forward and backward compatibility when the meta-
 class RNTupleDescriptor {
    friend class RNTupleDescriptorBuilder;
 
-public:
-   class RFieldDescriptorIterable;
-
 private:
    // clang-format off
    /**
@@ -426,8 +423,8 @@ private:
       std::size_t GetNFields() const { return fFields.size(); }
       std::size_t GetNLogicalColumns() const { return fNLogicalColumns; }
       std::size_t GetNPhysicalColumns() const { return fNPhysicalColumns; }
-      /// Return an iterator over the top-level fields defined in the extension header
-      RFieldDescriptorIterable GetTopLevelFields(const RNTupleDescriptor &desc) const;
+      /// Return a vector containing the IDs of the top-level fields defined in the extension header
+      std::vector<DescriptorId_t> GetTopLevelFields(const RNTupleDescriptor &desc) const;
    };
 
    /// The ntuple name needs to be unique in a given storage location (file)
@@ -518,19 +515,12 @@ public:
    */
    // clang-format on
    class RFieldDescriptorIterable {
-      friend class RNTupleDescriptor;
-
    private:
       /// The associated NTuple for this range.
       const RNTupleDescriptor& fNTuple;
       /// The descriptor ids of the child fields. These may be sorted using
       /// a comparison function.
       std::vector<DescriptorId_t> fFieldChildren = {};
-
-      RFieldDescriptorIterable(const RNTupleDescriptor &ntuple, std::vector<DescriptorId_t> &&fields)
-         : fNTuple(ntuple), fFieldChildren(fields)
-      {
-      }
 
    public:
       class RIterator {

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -443,11 +443,11 @@ public:
       std::uint64_t fNLogicalColumns = 0;
       std::uint64_t fNPhysicalColumns = 0;
 
-      void AddField(const RFieldDescriptor &fieldDesc) { fFields.push_back(fieldDesc.GetId()); }
-      void AddColumn(const RColumnDescriptor &columnDesc)
+      void AddFieldId(DescriptorId_t id) { fFields.push_back(id); }
+      void AddColumn(bool isAliasColumn)
       {
          fNLogicalColumns++;
-         if (!columnDesc.IsAliasColumn())
+         if (!isAliasColumn)
             fNPhysicalColumns++;
       }
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -35,6 +35,30 @@ namespace ROOT {
 namespace Experimental {
 
 class RCollectionNTupleWriter;
+class RNTupleModel;
+
+namespace Detail {
+
+// clang-format off
+/**
+\class ROOT::Experimental::Detail::RNTupleModelChangeset
+\ingroup NTuple
+\brief The incremental changes to a `RNTupleModel`
+
+Represents a set of alterations to a `RNTupleModel` that happened after the model is used to initialize a `RPageSink`
+instance. This object can be used to communicate metadata updates to a `RPageSink`.
+*/
+// clang-format on
+struct RNTupleModelChangeset {
+   RNTupleModel &fModel;
+   std::vector<RFieldBase *> fAddedFields;
+   std::vector<RFieldBase *> fAddedProjectedFields;
+
+   RNTupleModelChangeset(RNTupleModel &model) : fModel(model) {}
+   bool IsEmpty() const { return fAddedFields.empty() && fAddedProjectedFields.empty(); }
+};
+
+} // namespace Detail
 
 // clang-format off
 /**

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -138,15 +138,12 @@ public:
    ///
    /// See `RNTupleWriter::GetModelUpdater()` for an example.
    class RUpdater {
-      friend class RNTupleWriter;
-
    private:
       RNTupleWriter &fWriter;
       Detail::RNTupleModelChangeset fOpenChangeset;
 
-      RUpdater(RNTupleWriter &writer);
-
    public:
+      explicit RUpdater(RNTupleWriter &writer);
       ~RUpdater() { CommitUpdate(); }
       /// Begin a new set of alterations to the underlying model. As a side effect, all `REntry` instances related to
       /// the model are invalidated.

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -302,7 +302,7 @@ public:
    const RProjectedFields &GetProjectedFields() const { return *fProjectedFields; }
 
    void Freeze();
-   void Unfreeze() { fModelId = 0; }
+   void Unfreeze();
    bool IsFrozen() const { return fModelId != 0; }
    std::uint64_t GetModelId() const { return fModelId; }
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -53,7 +53,9 @@ You will not normally use this directly; see `RNTupleModel::RIncrementalUpdater`
 // clang-format on
 struct RNTupleModelChangeset {
    RNTupleModel &fModel;
+   /// Points to the fields in fModel that were added as part of an updater transaction
    std::vector<RFieldBase *> fAddedFields;
+   /// Points to the projected fields in fModel that were added as part of an updater transaction
    std::vector<RFieldBase *> fAddedProjectedFields;
 
    RNTupleModelChangeset(RNTupleModel &model) : fModel(model) {}
@@ -130,7 +132,7 @@ public:
       bool IsEmpty() const { return fFieldZero->begin() == fFieldZero->end(); }
    };
 
-   /// A model is usually immutable after giving up on it, e.g. to construct a `RNTupleWriter`. However, for the rare
+   /// A model is usually immutable after passing it to an `RNTupleWriter`. However, for the rare
    /// cases that require changing the model after the fact, `RIncrementalUpdater` provides limited support for
    /// incremental updates, e.g. addition of new fields.
    ///

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -48,7 +48,7 @@ namespace Detail {
 
 Represents a set of alterations to a `RNTupleModel` that happened after the model is used to initialize a `RPageSink`
 instance. This object can be used to communicate metadata updates to a `RPageSink`.
-You will not normally use this directly; see `RNTupleModel::RIncrementalUpdater` instead.
+You will not normally use this directly; see `RNTupleModel::RUpdater` instead.
 */
 // clang-format on
 struct RNTupleModelChangeset {
@@ -133,21 +133,21 @@ public:
    };
 
    /// A model is usually immutable after passing it to an `RNTupleWriter`. However, for the rare
-   /// cases that require changing the model after the fact, `RIncrementalUpdater` provides limited support for
+   /// cases that require changing the model after the fact, `RUpdater` provides limited support for
    /// incremental updates, e.g. addition of new fields.
    ///
-   /// See `RNTupleWriter::GetIncrementalModelUpdater()` for an example.
-   class RIncrementalUpdater {
+   /// See `RNTupleWriter::GetModelUpdater()` for an example.
+   class RUpdater {
       friend class RNTupleWriter;
 
    private:
       RNTupleWriter &fWriter;
       Detail::RNTupleModelChangeset fOpenChangeset;
 
-      RIncrementalUpdater(RNTupleWriter &writer);
+      RUpdater(RNTupleWriter &writer);
 
    public:
-      ~RIncrementalUpdater() { CommitUpdate(); }
+      ~RUpdater() { CommitUpdate(); }
       /// Begin a new set of alterations to the underlying model. As a side effect, all `REntry` instances related to
       /// the model are invalidated.
       void BeginUpdate();

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -136,7 +136,7 @@ public:
    /// cases that require changing the model after the fact, `RUpdater` provides limited support for
    /// incremental updates, e.g. addition of new fields.
    ///
-   /// See `RNTupleWriter::GetModelUpdater()` for an example.
+   /// See `RNTupleWriter::CreateModelUpdater()` for an example.
    class RUpdater {
    private:
       RNTupleWriter &fWriter;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
@@ -212,6 +212,13 @@ public:
    static RResult<std::uint32_t> DeserializeClusterGroup(const void *buffer, std::uint32_t bufSize,
                                                          RClusterGroup &clusterGroup);
 
+   /// Serialize the schema description in `desc` into `buffer`. If `forHeaderExtension` is true, serialize only the
+   /// fields and columns tagged as part of the header extension (see `RNTupleDescriptorBuilder::BeginHeaderExtension`).
+   static std::uint32_t SerializeSchemaDescription(void *buffer, const RNTupleDescriptor &desc, RContext &context,
+                                                   bool forHeaderExtension = false);
+   static RResult<std::uint32_t>
+   DeserializeSchemaDescription(const void *buffer, std::uint32_t bufSize, RNTupleDescriptorBuilder &descBuilder);
+
    static RContext SerializeHeaderV1(void *buffer, const RNTupleDescriptor &desc);
    static std::uint32_t SerializePageListV1(void *buffer,
                                             const RNTupleDescriptor &desc,

--- a/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
@@ -106,15 +106,17 @@ public:
       std::uint32_t GetHeaderCRC32() const { return fHeaderCrc32; }
       DescriptorId_t MapFieldId(DescriptorId_t memId) {
          auto onDiskId = fOnDisk2MemFieldIDs.size();
-         fMem2OnDiskFieldIDs[memId] = onDiskId;
-         fOnDisk2MemFieldIDs.push_back(memId);
-         return onDiskId;
+         const auto &p = fMem2OnDiskFieldIDs.try_emplace(memId, onDiskId);
+         if (p.second)
+            fOnDisk2MemFieldIDs.push_back(memId);
+         return (*p.first).second;
       }
       DescriptorId_t MapColumnId(DescriptorId_t memId) {
          auto onDiskId = fOnDisk2MemColumnIDs.size();
-         fMem2OnDiskColumnIDs[memId] = onDiskId;
-         fOnDisk2MemColumnIDs.push_back(memId);
-         return onDiskId;
+         const auto &p = fMem2OnDiskColumnIDs.try_emplace(memId, onDiskId);
+         if (p.second)
+            fOnDisk2MemColumnIDs.push_back(memId);
+         return (*p.first).second;
       }
       DescriptorId_t MapClusterId(DescriptorId_t memId) {
          auto onDiskId = fOnDisk2MemClusterIDs.size();

--- a/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
@@ -135,9 +135,10 @@ public:
          fOnDisk2MemClusterGroupIDs.push_back(memId);
          return onDiskId;
       }
-      /// Ensure that columns added after header serialization have an on-disk column ID; this is required to ensure
-      /// consistency between page lists and the schema extension in the footer
-      void MapLateAddedColumns(const RNTupleDescriptor &desc);
+      /// Map in-memory field and column IDs to their on-disk counterparts. This function is unconditionally called
+      /// during header serialization.  This function must be manually called after an incremental schema update as page
+      /// list serialization requires all columns to be mapped.
+      void MapSchema(const RNTupleDescriptor &desc, bool forHeaderExtension);
       DescriptorId_t GetOnDiskFieldId(DescriptorId_t memId) const { return fMem2OnDiskFieldIDs.at(memId); }
       DescriptorId_t GetOnDiskColumnId(DescriptorId_t memId) const { return fMem2OnDiskColumnIDs.at(memId); }
       DescriptorId_t GetOnDiskClusterId(DescriptorId_t memId) const { return fMem2OnDiskClusterIDs.at(memId); }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
@@ -104,6 +104,8 @@ public:
       std::uint32_t GetHeaderSize() const { return fHeaderSize; }
       void SetHeaderCRC32(std::uint32_t crc32) { fHeaderCrc32 = crc32; }
       std::uint32_t GetHeaderCRC32() const { return fHeaderCrc32; }
+      /// Map an in-memory field ID to its on-disk counterpart. It is allowed to call this function multiple times for
+      /// the same `memId`, in which case the return value is the on-disk ID assigned on the first call.
       DescriptorId_t MapFieldId(DescriptorId_t memId) {
          auto onDiskId = fOnDisk2MemFieldIDs.size();
          const auto &p = fMem2OnDiskFieldIDs.try_emplace(memId, onDiskId);
@@ -111,6 +113,8 @@ public:
             fOnDisk2MemFieldIDs.push_back(memId);
          return (*p.first).second;
       }
+      /// Map an in-memory column ID to its on-disk counterpart. It is allowed to call this function multiple times for
+      /// the same `memId`, in which case the return value is the on-disk ID assigned on the first call.
       DescriptorId_t MapColumnId(DescriptorId_t memId) {
          auto onDiskId = fOnDisk2MemColumnIDs.size();
          const auto &p = fMem2OnDiskColumnIDs.try_emplace(memId, onDiskId);

--- a/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
@@ -98,6 +98,7 @@ public:
       std::vector<DescriptorId_t> fOnDisk2MemColumnIDs;
       std::vector<DescriptorId_t> fOnDisk2MemClusterIDs;
       std::vector<DescriptorId_t> fOnDisk2MemClusterGroupIDs;
+      std::size_t fHeaderExtensionOffset = -1U;
 
    public:
       void SetHeaderSize(std::uint32_t size) { fHeaderSize = size; }
@@ -139,6 +140,7 @@ public:
       /// during header serialization.  This function must be manually called after an incremental schema update as page
       /// list serialization requires all columns to be mapped.
       void MapSchema(const RNTupleDescriptor &desc, bool forHeaderExtension);
+
       DescriptorId_t GetOnDiskFieldId(DescriptorId_t memId) const { return fMem2OnDiskFieldIDs.at(memId); }
       DescriptorId_t GetOnDiskColumnId(DescriptorId_t memId) const { return fMem2OnDiskColumnIDs.at(memId); }
       DescriptorId_t GetOnDiskClusterId(DescriptorId_t memId) const { return fMem2OnDiskClusterIDs.at(memId); }
@@ -153,6 +155,14 @@ public:
       {
          return fOnDisk2MemClusterGroupIDs[onDiskId];
       }
+
+      /// Return a vector containing the in-memory field ID for each on-disk counterpart, in order, i.e. the `i`-th
+      /// value corresponds to the in-memory field ID for `i`-th on-disk ID
+      const std::vector<DescriptorId_t> &GetOnDiskFieldList() const { return fOnDisk2MemFieldIDs; }
+      /// Mark the first on-disk field ID that is part of the schema extension
+      void BeginHeaderExtension() { fHeaderExtensionOffset = fOnDisk2MemFieldIDs.size(); }
+      /// Return the offset of the first element in `fOnDisk2MemFieldIDs` that is part of the schema extension
+      std::size_t GetHeaderExtensionOffset() const { return fHeaderExtensionOffset; }
    };
 
    /// Writes a CRC32 checksum of the byte range given by data and length.

--- a/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
@@ -131,6 +131,9 @@ public:
          fOnDisk2MemClusterGroupIDs.push_back(memId);
          return onDiskId;
       }
+      /// Ensure that columns added after header serialization have an on-disk column ID; this is required to ensure
+      /// consistency between page lists and the schema extension in the footer
+      void MapLateAddedColumns(const RNTupleDescriptor &desc);
       DescriptorId_t GetOnDiskFieldId(DescriptorId_t memId) const { return fMem2OnDiskFieldIDs.at(memId); }
       DescriptorId_t GetOnDiskColumnId(DescriptorId_t memId) const { return fMem2OnDiskColumnIDs.at(memId); }
       DescriptorId_t GetOnDiskClusterId(DescriptorId_t memId) const { return fMem2OnDiskClusterIDs.at(memId); }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
@@ -224,7 +224,7 @@ public:
                                             const RNTupleDescriptor &desc,
                                             std::span<DescriptorId_t> physClusterIDs,
                                             const RContext &context);
-   static std::uint32_t SerializeFooterV1(void *buffer, const RNTupleDescriptor &desc, const RContext &context);
+   static std::uint32_t SerializeFooterV1(void *buffer, const RNTupleDescriptor &desc, RContext &context);
 
    static RResult<void> DeserializeHeaderV1(const void *buffer,
                                             std::uint32_t bufSize,

--- a/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
@@ -234,7 +234,7 @@ public:
 
    /// Serialize the schema description in `desc` into `buffer`. If `forHeaderExtension` is true, serialize only the
    /// fields and columns tagged as part of the header extension (see `RNTupleDescriptorBuilder::BeginHeaderExtension`).
-   static std::uint32_t SerializeSchemaDescription(void *buffer, const RNTupleDescriptor &desc, RContext &context,
+   static std::uint32_t SerializeSchemaDescription(void *buffer, const RNTupleDescriptor &desc, const RContext &context,
                                                    bool forHeaderExtension = false);
    static RResult<std::uint32_t>
    DeserializeSchemaDescription(const void *buffer, std::uint32_t bufSize, RNTupleDescriptorBuilder &descBuilder);
@@ -244,7 +244,7 @@ public:
                                             const RNTupleDescriptor &desc,
                                             std::span<DescriptorId_t> physClusterIDs,
                                             const RContext &context);
-   static std::uint32_t SerializeFooterV1(void *buffer, const RNTupleDescriptor &desc, RContext &context);
+   static std::uint32_t SerializeFooterV1(void *buffer, const RNTupleDescriptor &desc, const RContext &context);
 
    static RResult<void> DeserializeHeaderV1(const void *buffer,
                                             std::uint32_t bufSize,

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -142,7 +142,7 @@ public:
    RPageSinkBuf& operator=(RPageSinkBuf&&) = default;
    ~RPageSinkBuf() override = default;
 
-   void UpdateDescriptor(const RNTupleModelChangeset &changeset) final;
+   void UpdateSchema(const RNTupleModelChangeset &changeset) final;
    RPage ReservePage(ColumnHandle_t columnHandle, std::size_t nElements) final;
    void ReleasePage(RPage &page) final;
 

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -142,6 +142,7 @@ public:
    RPageSinkBuf& operator=(RPageSinkBuf&&) = default;
    ~RPageSinkBuf() override = default;
 
+   void UpdateDescriptor(const RNTupleModelChangeset &changeset) final;
    RPage ReservePage(ColumnHandle_t columnHandle, std::size_t nElements) final;
    void ReleasePage(RPage &page) final;
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -47,6 +47,7 @@ class RColumn;
 class RColumnElementBase;
 class RNTupleCompressor;
 class RNTupleDecompressor;
+class RNTupleModelChangeset;
 class RPagePool;
 class RFieldBase;
 
@@ -265,6 +266,10 @@ public:
    /// To do so, Create() calls CreateImpl() after updating the descriptor.
    /// Create() associates column handles to the columns referenced by the model
    void Create(RNTupleModel &model);
+   /// Incorporate incremental changes to the model into the ntuple descriptor. This happens, e.g. if new fields were
+   /// added after the initial call to `RPageSink::Create(RNTupleModel &)`
+   virtual void UpdateDescriptor(const RNTupleModelChangeset &changeset);
+
    /// Write a page to the storage. The column must have been added before.
    void CommitPage(ColumnHandle_t columnHandle, const RPage &page);
    /// Write a preprocessed page to storage. The column must have been added before.

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -268,7 +268,7 @@ public:
    void Create(RNTupleModel &model);
    /// Incorporate incremental changes to the model into the ntuple descriptor. This happens, e.g. if new fields were
    /// added after the initial call to `RPageSink::Create(RNTupleModel &)`
-   virtual void UpdateDescriptor(const RNTupleModelChangeset &changeset);
+   virtual void UpdateSchema(const RNTupleModelChangeset &changeset);
 
    /// Write a page to the storage. The column must have been added before.
    void CommitPage(ColumnHandle_t columnHandle, const RPage &page);

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -591,7 +591,7 @@ ROOT::Experimental::RFieldDescriptorBuilder::MakeDescriptor() const {
 void ROOT::Experimental::RNTupleDescriptorBuilder::AddField(const RFieldDescriptor& fieldDesc) {
    fDescriptor.fFieldDescriptors.emplace(fieldDesc.GetId(), fieldDesc.Clone());
    if (fDescriptor.fHeaderExtension)
-      fDescriptor.fHeaderExtension->AddField(fieldDesc);
+      fDescriptor.fHeaderExtension->AddFieldId(fieldDesc.GetId());
 }
 
 ROOT::Experimental::RResult<void>
@@ -633,7 +633,7 @@ void ROOT::Experimental::RNTupleDescriptorBuilder::AddColumn(DescriptorId_t logi
    if (!c.IsAliasColumn())
       fDescriptor.fNPhysicalColumns++;
    if (fDescriptor.fHeaderExtension)
-      fDescriptor.fHeaderExtension->AddColumn(c);
+      fDescriptor.fHeaderExtension->AddColumn(/*isAliasColumn=*/c.IsAliasColumn());
    fDescriptor.fColumnDescriptors.emplace(logicalId, std::move(c));
 }
 
@@ -664,7 +664,7 @@ ROOT::Experimental::RNTupleDescriptorBuilder::AddColumn(RColumnDescriptor &&colu
       fDescriptor.fNPhysicalColumns++;
    fDescriptor.fColumnDescriptors.emplace(logicalId, std::move(columnDesc));
    if (fDescriptor.fHeaderExtension)
-      fDescriptor.fHeaderExtension->AddColumn(columnDesc);
+      fDescriptor.fHeaderExtension->AddColumn(/*isAliasColumn=*/columnDesc.IsAliasColumn());
 
    return RResult<void>::Success();
 }

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -321,7 +321,7 @@ ROOT::Experimental::RNTupleDescriptor::FindPrevClusterId(DescriptorId_t clusterI
    return kInvalidDescriptorId;
 }
 
-ROOT::Experimental::RNTupleDescriptor::RFieldDescriptorIterable
+std::vector<ROOT::Experimental::DescriptorId_t>
 ROOT::Experimental::RNTupleDescriptor::RHeaderExtension::GetTopLevelFields(const RNTupleDescriptor &desc) const
 {
    std::vector<DescriptorId_t> fields{fFields.begin(), fFields.end()};
@@ -332,7 +332,7 @@ ROOT::Experimental::RNTupleDescriptor::RHeaderExtension::GetTopLevelFields(const
                                   return desc.GetFieldDescriptor(fieldId).GetParentId() != fieldZeroId;
                                }),
                 fields.end());
-   return RFieldDescriptorIterable(desc, std::move(fields));
+   return fields;
 }
 
 ROOT::Experimental::RResult<void>

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -324,14 +324,13 @@ ROOT::Experimental::RNTupleDescriptor::FindPrevClusterId(DescriptorId_t clusterI
 std::vector<ROOT::Experimental::DescriptorId_t>
 ROOT::Experimental::RNTupleDescriptor::RHeaderExtension::GetTopLevelFields(const RNTupleDescriptor &desc) const
 {
-   std::vector<DescriptorId_t> fields{fFields.begin(), fFields.end()};
-   // leave top-level fields only
    auto fieldZeroId = desc.GetFieldZeroId();
-   fields.erase(std::remove_if(fields.begin(), fields.end(),
-                               [&](DescriptorId_t fieldId) {
-                                  return desc.GetFieldDescriptor(fieldId).GetParentId() != fieldZeroId;
-                               }),
-                fields.end());
+
+   std::vector<DescriptorId_t> fields;
+   for (const DescriptorId_t fieldId : fFields) {
+      if (desc.GetFieldDescriptor(fieldId).GetParentId() == fieldZeroId)
+         fields.emplace_back(fieldId);
+   }
    return fields;
 }
 

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -128,19 +128,19 @@ ROOT::Experimental::RNTupleModel::RProjectedFields::Clone(const RNTupleModel *ne
    return clone;
 }
 
-ROOT::Experimental::RNTupleModel::RIncrementalUpdater::RIncrementalUpdater(RNTupleWriter &writer)
+ROOT::Experimental::RNTupleModel::RUpdater::RUpdater(RNTupleWriter &writer)
    : fWriter(writer), fOpenChangeset(*fWriter.fModel)
 {
 }
 
-void ROOT::Experimental::RNTupleModel::RIncrementalUpdater::BeginUpdate()
+void ROOT::Experimental::RNTupleModel::RUpdater::BeginUpdate()
 {
    if (fWriter.fNEntries > 0)
       throw RException(R__FAIL("invalid attempt to alter model (fWriter.fNEntries > 0)"));
    fOpenChangeset.fModel.Unfreeze();
 }
 
-void ROOT::Experimental::RNTupleModel::RIncrementalUpdater::CommitUpdate()
+void ROOT::Experimental::RNTupleModel::RUpdater::CommitUpdate()
 {
    fOpenChangeset.fModel.Freeze();
    if (fOpenChangeset.IsEmpty())
@@ -151,15 +151,16 @@ void ROOT::Experimental::RNTupleModel::RIncrementalUpdater::CommitUpdate()
    fWriter.fSink->UpdateDescriptor(toCommit);
 }
 
-void ROOT::Experimental::RNTupleModel::RIncrementalUpdater::AddField(std::unique_ptr<Detail::RFieldBase> field)
+void ROOT::Experimental::RNTupleModel::RUpdater::AddField(std::unique_ptr<Detail::RFieldBase> field)
 {
    auto fieldp = field.get();
    fOpenChangeset.fModel.AddField(std::move(field));
    fOpenChangeset.fAddedFields.emplace_back(fieldp);
 }
 
-ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleModel::RIncrementalUpdater::AddProjectedField(
-   std::unique_ptr<Detail::RFieldBase> field, std::function<std::string(const std::string &)> mapping)
+ROOT::Experimental::RResult<void>
+ROOT::Experimental::RNTupleModel::RUpdater::AddProjectedField(std::unique_ptr<Detail::RFieldBase> field,
+                                                              std::function<std::string(const std::string &)> mapping)
 {
    auto fieldp = field.get();
    auto result = fOpenChangeset.fModel.AddProjectedField(std::move(field), mapping);

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -148,7 +148,7 @@ void ROOT::Experimental::RNTupleModel::RUpdater::CommitUpdate()
    Detail::RNTupleModelChangeset toCommit{fOpenChangeset.fModel};
    std::swap(fOpenChangeset.fAddedFields, toCommit.fAddedFields);
    std::swap(fOpenChangeset.fAddedProjectedFields, toCommit.fAddedProjectedFields);
-   fWriter.fSink->UpdateDescriptor(toCommit);
+   fWriter.fSink->UpdateSchema(toCommit);
 }
 
 void ROOT::Experimental::RNTupleModel::RUpdater::AddField(std::unique_ptr<Detail::RFieldBase> field)

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -163,7 +163,8 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleModel::RIncremental
 {
    auto fieldp = field.get();
    auto result = fOpenChangeset.fModel.AddProjectedField(std::move(field), mapping);
-   fOpenChangeset.fAddedProjectedFields.emplace_back(fieldp);
+   if (result)
+      fOpenChangeset.fAddedProjectedFields.emplace_back(fieldp);
    return R__FORWARD_RESULT(result);
 }
 

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -342,6 +342,13 @@ std::unique_ptr<ROOT::Experimental::REntry> ROOT::Experimental::RNTupleModel::Cr
    return entry;
 }
 
+void ROOT::Experimental::RNTupleModel::Unfreeze()
+{
+   if (!IsFrozen())
+      throw RException(R__FAIL("invalid attempt to unfreeze an unfrozen model"));
+   fModelId = 0;
+}
+
 void ROOT::Experimental::RNTupleModel::Freeze()
 {
    if (IsFrozen())

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -1421,10 +1421,12 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::Internal::RNTupleSerialize
    if (!result)
       return R__FORWARD_ERROR(result);
    bytes += result.Unwrap();
-   descBuilder.BeginHeaderExtension();
-   result = DeserializeSchemaDescription(bytes, fnFrameSizeLeft(), descBuilder);
-   if (!result)
-      return R__FORWARD_ERROR(result);
+   if (fnFrameSizeLeft() > 0) {
+      descBuilder.BeginHeaderExtension();
+      result = DeserializeSchemaDescription(bytes, fnFrameSizeLeft(), descBuilder);
+      if (!result)
+         return R__FORWARD_ERROR(result);
+   }
    bytes = frame + frameSize;
 
    std::uint32_t nColumnGroups;

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -1006,9 +1006,7 @@ void ROOT::Experimental::Internal::RNTupleSerializer::RContext::MapLateAddedColu
    };
 
    if (auto xHeader = desc.GetHeaderExtension()) {
-      std::vector<DescriptorId_t> fieldIDs;
-      for (const auto &field : xHeader->GetTopLevelFields(desc))
-         fieldIDs.emplace_back(field.GetId());
+      auto fieldIDs = xHeader->GetTopLevelFields(desc);
       mapColumns(fieldIDs, /*forAliasColumns=*/false);
       mapColumns(fieldIDs, /*forAliasColumns=*/true);
    }
@@ -1029,8 +1027,7 @@ ROOT::Experimental::Internal::RNTupleSerializer::SerializeSchemaDescription(void
          nFields = xHeader->GetNFields();
          nColumns = xHeader->GetNPhysicalColumns();
          nAliasColumns = xHeader->GetNLogicalColumns() - xHeader->GetNPhysicalColumns();
-         for (const auto &field : xHeader->GetTopLevelFields(desc))
-            subtrees.emplace_back(field.GetId());
+         subtrees = xHeader->GetTopLevelFields(desc);
       }
    } else {
       nFields = desc.GetNFields() - 1;

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -1021,7 +1021,6 @@ std::uint32_t ROOT::Experimental::Internal::RNTupleSerializer::SerializeSchemaDe
    void** where = (buffer == nullptr) ? &buffer : reinterpret_cast<void**>(&pos);
 
    std::size_t nFields = 0, nColumns = 0, nAliasColumns = 0, fieldListOffset = 0;
-   std::vector<DescriptorId_t> subtrees;
    if (forHeaderExtension) {
       if (auto xHeader = desc.GetHeaderExtension()) {
          nFields = xHeader->GetNFields();

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -1175,7 +1175,7 @@ ROOT::Experimental::Internal::RNTupleSerializer::DeserializeSchemaDescription(co
       R__LOG_WARNING(NTupleLog()) << "Extra type information is still unsupported! ";
    bytes = frame + frameSize;
 
-   return bytes - reinterpret_cast<const unsigned char *>(buffer);
+   return bytes - base;
 }
 
 ROOT::Experimental::Internal::RNTupleSerializer::RContext

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -68,7 +68,7 @@ std::uint32_t SerializeFieldV1(const ROOT::Experimental::RFieldDescriptor &field
 std::uint32_t SerializeFieldList(const ROOT::Experimental::RNTupleDescriptor &desc,
                                  std::span<const ROOT::Experimental::DescriptorId_t> fieldList,
                                  std::size_t firstOnDiskId,
-                                 ROOT::Experimental::Internal::RNTupleSerializer::RContext &context, void *buffer)
+                                 const ROOT::Experimental::Internal::RNTupleSerializer::RContext &context, void *buffer)
 {
    auto base = reinterpret_cast<unsigned char *>(buffer);
    auto pos = base;
@@ -160,7 +160,8 @@ RResult<std::uint32_t> DeserializeFieldV1(
 
 std::uint32_t SerializeColumnListV1(const ROOT::Experimental::RNTupleDescriptor &desc,
                                     std::span<const ROOT::Experimental::DescriptorId_t> fieldList,
-                                    ROOT::Experimental::Internal::RNTupleSerializer::RContext &context, void *buffer)
+                                    const ROOT::Experimental::Internal::RNTupleSerializer::RContext &context,
+                                    void *buffer)
 {
    using RColumnElementBase = ROOT::Experimental::Detail::RColumnElementBase;
 
@@ -277,7 +278,8 @@ void DeserializeLocatorPayloadObject64(const unsigned char *buffer, ROOT::Experi
 
 std::uint32_t SerializeAliasColumnList(const ROOT::Experimental::RNTupleDescriptor &desc,
                                        std::span<const ROOT::Experimental::DescriptorId_t> fieldList,
-                                       ROOT::Experimental::Internal::RNTupleSerializer::RContext &context, void *buffer)
+                                       const ROOT::Experimental::Internal::RNTupleSerializer::RContext &context,
+                                       void *buffer)
 {
    auto base = reinterpret_cast<unsigned char *>(buffer);
    auto pos = base;
@@ -1009,9 +1011,10 @@ void ROOT::Experimental::Internal::RNTupleSerializer::RContext::MapSchema(const 
       BeginHeaderExtension();
 }
 
-std::uint32_t
-ROOT::Experimental::Internal::RNTupleSerializer::SerializeSchemaDescription(void *buffer, const RNTupleDescriptor &desc,
-                                                                            RContext &context, bool forHeaderExtension)
+std::uint32_t ROOT::Experimental::Internal::RNTupleSerializer::SerializeSchemaDescription(void *buffer,
+                                                                                          const RNTupleDescriptor &desc,
+                                                                                          const RContext &context,
+                                                                                          bool forHeaderExtension)
 {
    auto base = reinterpret_cast<unsigned char *>(buffer);
    auto pos = base;
@@ -1252,7 +1255,7 @@ std::uint32_t ROOT::Experimental::Internal::RNTupleSerializer::SerializePageList
 std::uint32_t
 ROOT::Experimental::Internal::RNTupleSerializer::SerializeFooterV1(void *buffer,
                                                                    const ROOT::Experimental::RNTupleDescriptor &desc,
-                                                                   RContext &context)
+                                                                   const RContext &context)
 {
    auto base = reinterpret_cast<unsigned char *>(buffer);
    auto pos = base;

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -206,7 +206,7 @@ std::uint32_t SerializeColumnListV1(const ROOT::Experimental::RNTupleDescriptor 
       }
 
       for (const auto &f : desc.GetFieldIterable(parentId))
-         idQueue.push_back(f.GetId());
+         idQueue.push_front(f.GetId());
    }
 
    return pos - base;
@@ -319,7 +319,7 @@ std::uint32_t SerializeAliasColumnList(const ROOT::Experimental::RNTupleDescript
       }
 
       for (const auto &f : desc.GetFieldIterable(parentId))
-         idQueue.push_back(f.GetId());
+         idQueue.push_front(f.GetId());
    }
 
    return pos - base;
@@ -1001,7 +1001,7 @@ void ROOT::Experimental::Internal::RNTupleSerializer::RContext::MapLateAddedColu
                MapColumnId(c.GetLogicalId());
          }
          for (const auto &f : desc.GetFieldIterable(parentId))
-            idQueue.push_back(f.GetId());
+            idQueue.push_front(f.GetId());
       }
    };
 

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -50,6 +50,7 @@ void ROOT::Experimental::Detail::RPageSinkBuf::UpdateDescriptor(const RNTupleMod
       return;
 
    // The buffered page sink maintains a copy of the RNTupleModel for the inner sink; replicate the changes there
+   // TODO(jalopezg): we should be able, in general, to simplify the buffered sink.
    auto cloneAddField = [&](const RFieldBase *field) {
       auto cloned = field->Clone(field->GetName());
       auto p = &(*cloned);

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -41,9 +41,9 @@ void ROOT::Experimental::Detail::RPageSinkBuf::CreateImpl(const RNTupleModel &mo
    fInnerSink->Create(*fInnerModel);
 }
 
-void ROOT::Experimental::Detail::RPageSinkBuf::UpdateDescriptor(const RNTupleModelChangeset &changeset)
+void ROOT::Experimental::Detail::RPageSinkBuf::UpdateSchema(const RNTupleModelChangeset &changeset)
 {
-   RPageSink::UpdateDescriptor(changeset);
+   RPageSink::UpdateSchema(changeset);
    bool isIncremental = !fBufferedColumns.empty();
    fBufferedColumns.resize(fDescriptorBuilder.GetDescriptor().GetNPhysicalColumns());
    if (!isIncremental)
@@ -76,7 +76,7 @@ void ROOT::Experimental::Detail::RPageSinkBuf::UpdateDescriptor(const RNTupleMod
    std::transform(changeset.fAddedProjectedFields.cbegin(), changeset.fAddedProjectedFields.cend(),
                   std::back_inserter(innerChangeset.fAddedProjectedFields), cloneAddProjectedField);
    fInnerModel->Freeze();
-   fInnerSink->UpdateDescriptor(innerChangeset);
+   fInnerSink->UpdateSchema(innerChangeset);
 }
 
 ROOT::Experimental::RNTupleLocator

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -355,6 +355,11 @@ void ROOT::Experimental::Detail::RPageSink::UpdateDescriptor(const RNTupleModelC
       pageRange.fPhysicalColumnId = i;
       fOpenPageRanges.emplace_back(std::move(pageRange));
    }
+
+   // Mapping of memory to on-disk column IDs usually happens during serialization of the schema description. If the
+   // header was already serialized, this has to be done manually as it is required for page list serialization.
+   if (fSerializationContext.GetHeaderSize() > 0)
+      fSerializationContext.MapLateAddedColumns(descriptor);
 }
 
 void ROOT::Experimental::Detail::RPageSink::Create(RNTupleModel &model)

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -309,7 +309,7 @@ ROOT::Experimental::Detail::RPageSink::AddColumn(DescriptorId_t fieldId, const R
    return ColumnHandle_t{columnId, &column};
 }
 
-void ROOT::Experimental::Detail::RPageSink::UpdateDescriptor(const RNTupleModelChangeset &changeset)
+void ROOT::Experimental::Detail::RPageSink::UpdateSchema(const RNTupleModelChangeset &changeset)
 {
    const auto &descriptor = fDescriptorBuilder.GetDescriptor();
    auto addField = [&](RFieldBase &f) {
@@ -377,7 +377,7 @@ void ROOT::Experimental::Detail::RPageSink::Create(RNTupleModel &model)
       initialChangeset.fAddedFields.emplace_back(f);
    for (auto f : model.GetProjectedFields().GetFieldZero()->GetSubFields())
       initialChangeset.fAddedProjectedFields.emplace_back(f);
-   UpdateDescriptor(initialChangeset);
+   UpdateSchema(initialChangeset);
 
    fSerializationContext = Internal::RNTupleSerializer::SerializeHeaderV1(nullptr, descriptor);
    auto buffer = std::make_unique<unsigned char[]>(fSerializationContext.GetHeaderSize());

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -356,10 +356,10 @@ void ROOT::Experimental::Detail::RPageSink::UpdateSchema(const RNTupleModelChang
       fOpenPageRanges.emplace_back(std::move(pageRange));
    }
 
-   // Mapping of memory to on-disk column IDs usually happens during serialization of the schema description. If the
+   // Mapping of memory to on-disk column IDs usually happens during serialization of the ntuple header. If the
    // header was already serialized, this has to be done manually as it is required for page list serialization.
    if (fSerializationContext.GetHeaderSize() > 0)
-      fSerializationContext.MapLateAddedColumns(descriptor);
+      fSerializationContext.MapSchema(descriptor, /*forHeaderExtension=*/true);
 }
 
 void ROOT::Experimental::Detail::RPageSink::Create(RNTupleModel &model)

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -309,37 +309,42 @@ ROOT::Experimental::Detail::RPageSink::AddColumn(DescriptorId_t fieldId, const R
    return ColumnHandle_t{columnId, &column};
 }
 
-void ROOT::Experimental::Detail::RPageSink::Create(RNTupleModel &model)
+void ROOT::Experimental::Detail::RPageSink::UpdateDescriptor(const RNTupleModelChangeset &changeset)
 {
-   fDescriptorBuilder.SetNTuple(fNTupleName, model.GetDescription());
    const auto &descriptor = fDescriptorBuilder.GetDescriptor();
-
-   auto &fieldZero = *model.GetFieldZero();
-   fDescriptorBuilder.AddField(RFieldDescriptorBuilder::FromField(fieldZero).FieldId(0).MakeDescriptor().Unwrap());
-   fieldZero.SetOnDiskId(0);
-   for (auto &f : fieldZero) {
+   auto addField = [&](RFieldBase &f) {
       auto fieldId = descriptor.GetNFields();
       fDescriptorBuilder.AddField(RFieldDescriptorBuilder::FromField(f).FieldId(fieldId).MakeDescriptor().Unwrap());
       fDescriptorBuilder.AddFieldLink(f.GetParent()->GetOnDiskId(), fieldId);
       f.SetOnDiskId(fieldId);
       f.ConnectPageSink(*this); // issues in turn one or several calls to AddColumn()
-   }
-
-   model.GetProjectedFields().GetFieldZero()->SetOnDiskId(0);
-   for (auto &f : *model.GetProjectedFields().GetFieldZero()) {
+   };
+   auto addProjectedField = [&](RFieldBase &f) {
       auto fieldId = descriptor.GetNFields();
       fDescriptorBuilder.AddField(RFieldDescriptorBuilder::FromField(f).FieldId(fieldId).MakeDescriptor().Unwrap());
       fDescriptorBuilder.AddFieldLink(f.GetParent()->GetOnDiskId(), fieldId);
       f.SetOnDiskId(fieldId);
-      auto sourceFieldId = model.GetProjectedFields().GetSourceField(&f)->GetOnDiskId();
+      auto sourceFieldId = changeset.fModel.GetProjectedFields().GetSourceField(&f)->GetOnDiskId();
       for (const auto &source : descriptor.GetColumnIterable(sourceFieldId)) {
          auto targetId = descriptor.GetNLogicalColumns();
          fDescriptorBuilder.AddColumn(targetId, source.GetLogicalId(), fieldId, source.GetModel(), source.GetIndex());
       }
+   };
+
+   const auto nColumnsBeforeUpdate = descriptor.GetNPhysicalColumns();
+   for (auto f : changeset.fAddedFields) {
+      addField(*f);
+      for (auto &descendant : *f)
+         addField(descendant);
+   }
+   for (auto f : changeset.fAddedProjectedFields) {
+      addProjectedField(*f);
+      for (auto &descendant : *f)
+         addProjectedField(descendant);
    }
 
-   auto nColumns = descriptor.GetNPhysicalColumns();
-   for (DescriptorId_t i = 0; i < nColumns; ++i) {
+   const auto nColumns = descriptor.GetNPhysicalColumns();
+   for (DescriptorId_t i = nColumnsBeforeUpdate; i < nColumns; ++i) {
       RClusterDescriptor::RColumnRange columnRange;
       columnRange.fPhysicalColumnId = i;
       columnRange.fFirstElementIndex = 0;
@@ -350,14 +355,32 @@ void ROOT::Experimental::Detail::RPageSink::Create(RNTupleModel &model)
       pageRange.fPhysicalColumnId = i;
       fOpenPageRanges.emplace_back(std::move(pageRange));
    }
+}
+
+void ROOT::Experimental::Detail::RPageSink::Create(RNTupleModel &model)
+{
+   fDescriptorBuilder.SetNTuple(fNTupleName, model.GetDescription());
+   const auto &descriptor = fDescriptorBuilder.GetDescriptor();
+
+   auto &fieldZero = *model.GetFieldZero();
+   fDescriptorBuilder.AddField(RFieldDescriptorBuilder::FromField(fieldZero).FieldId(0).MakeDescriptor().Unwrap());
+   fieldZero.SetOnDiskId(0);
+   model.GetProjectedFields().GetFieldZero()->SetOnDiskId(0);
+
+   RNTupleModelChangeset initialChangeset{model};
+   for (auto f : fieldZero.GetSubFields())
+      initialChangeset.fAddedFields.emplace_back(f);
+   for (auto f : model.GetProjectedFields().GetFieldZero()->GetSubFields())
+      initialChangeset.fAddedProjectedFields.emplace_back(f);
+   UpdateDescriptor(initialChangeset);
 
    fSerializationContext = Internal::RNTupleSerializer::SerializeHeaderV1(nullptr, descriptor);
    auto buffer = std::make_unique<unsigned char[]>(fSerializationContext.GetHeaderSize());
    fSerializationContext = Internal::RNTupleSerializer::SerializeHeaderV1(buffer.get(), descriptor);
-
    CreateImpl(model, buffer.get(), fSerializationContext.GetHeaderSize());
-}
 
+   fDescriptorBuilder.BeginHeaderExtension();
+}
 
 void ROOT::Experimental::Detail::RPageSink::CommitPage(ColumnHandle_t columnHandle, const RPage &page)
 {

--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -35,6 +35,7 @@ ROOT_ADD_GTEST(ntuple_pages ntuple_pages.cxx LIBRARIES ROOTDataFrame ROOTNTuple 
 ROOT_ADD_GTEST(ntuple_print ntuple_print.cxx LIBRARIES ROOTDataFrame ROOTNTuple MathCore CustomStruct)
 ROOT_ADD_GTEST(ntuple_project ntuple_project.cxx LIBRARIES ROOTDataFrame ROOTNTuple)
 ROOT_ADD_GTEST(ntuple_rdf ntuple_rdf.cxx LIBRARIES ROOTDataFrame ROOTNTuple MathCore CustomStruct)
+ROOT_ADD_GTEST(ntuple_schemaext ntuple_schemaext.cxx LIBRARIES ROOTDataFrame ROOTNTuple CustomStruct)
 ROOT_ADD_GTEST(ntuple_serialize ntuple_serialize.cxx LIBRARIES ROOTDataFrame ROOTNTuple MathCore CustomStruct)
 if(NOT MSVC OR ${LLVM_VERSION} VERSION_LESS 13.0.0 OR llvm13_broken_tests)
   ROOT_ADD_GTEST(ntuple_types ntuple_types.cxx LIBRARIES ROOTDataFrame ROOTNTuple MathCore CustomStruct)

--- a/tree/ntuple/v7/test/ntuple_descriptor.cxx
+++ b/tree/ntuple/v7/test/ntuple_descriptor.cxx
@@ -211,23 +211,39 @@ TEST(RFieldDescriptorBuilder, HeaderExtension)
                             .MakeDescriptor()
                             .Unwrap());
    descBuilder.AddFieldLink(0, 4);
+   descBuilder.AddField(RFieldDescriptorBuilder()
+                           .FieldId(5)
+                           .FieldName("projected")
+                           .TypeName("int64_t")
+                           .Structure(ENTupleStructure::kLeaf)
+                           .MakeDescriptor()
+                           .Unwrap());
+   descBuilder.AddColumn(RColumnDescriptorBuilder()
+                            .LogicalColumnId(3)
+                            .PhysicalColumnId(1)
+                            .Model(RColumnModel{EColumnType::kInt64, false})
+                            .FieldId(5)
+                            .Index(0)
+                            .MakeDescriptor()
+                            .Unwrap());
+   descBuilder.AddFieldLink(0, 5);
 
    auto desc = descBuilder.MoveDescriptor();
-   ASSERT_EQ(desc.GetNFields(), 5);
-   ASSERT_EQ(desc.GetNLogicalColumns(), 3);
+   ASSERT_EQ(desc.GetNFields(), 6);
+   ASSERT_EQ(desc.GetNLogicalColumns(), 4);
    ASSERT_EQ(desc.GetNPhysicalColumns(), 3);
    {
-      std::string_view child_names[] = {"i32", "topLevel1", "topLevel2"};
+      std::string_view child_names[] = {"i32", "topLevel1", "topLevel2", "projected"};
       unsigned i = 0;
       for (auto &child_field : desc.GetTopLevelFields())
          EXPECT_EQ(child_field.GetFieldName(), child_names[i++]);
    }
    auto xHeader = desc.GetHeaderExtension();
-   EXPECT_EQ(xHeader->GetNFields(), 3);
-   EXPECT_EQ(xHeader->GetNLogicalColumns(), 2);
+   EXPECT_EQ(xHeader->GetNFields(), 4);
+   EXPECT_EQ(xHeader->GetNLogicalColumns(), 3);
    EXPECT_EQ(xHeader->GetNPhysicalColumns(), 2);
    {
-      std::string_view child_names[] = {"topLevel1", "topLevel2"};
+      std::string_view child_names[] = {"topLevel1", "topLevel2", "projected"};
       unsigned i = 0;
       for (auto child_field : xHeader->GetTopLevelFields(desc))
          EXPECT_EQ(desc.GetFieldDescriptor(child_field).GetFieldName(), child_names[i++]);

--- a/tree/ntuple/v7/test/ntuple_descriptor.cxx
+++ b/tree/ntuple/v7/test/ntuple_descriptor.cxx
@@ -229,8 +229,8 @@ TEST(RFieldDescriptorBuilder, HeaderExtension)
    {
       std::string_view child_names[] = {"topLevel1", "topLevel2"};
       unsigned i = 0;
-      for (auto &child_field : xHeader->GetTopLevelFields(desc))
-         EXPECT_EQ(child_field.GetFieldName(), child_names[i++]);
+      for (auto child_field : xHeader->GetTopLevelFields(desc))
+         EXPECT_EQ(desc.GetFieldDescriptor(child_field).GetFieldName(), child_names[i++]);
    }
 }
 

--- a/tree/ntuple/v7/test/ntuple_descriptor.cxx
+++ b/tree/ntuple/v7/test/ntuple_descriptor.cxx
@@ -146,6 +146,94 @@ TEST(RNTupleDescriptorBuilder, CatchInvalidDescriptors)
    descBuilder.EnsureValidDescriptor();
 }
 
+TEST(RFieldDescriptorBuilder, HeaderExtension)
+{
+   RNTupleDescriptorBuilder descBuilder;
+   descBuilder.AddField(
+      RFieldDescriptorBuilder().FieldId(0).Structure(ENTupleStructure::kRecord).MakeDescriptor().Unwrap());
+   descBuilder.AddField(RFieldDescriptorBuilder()
+                           .FieldId(1)
+                           .FieldName("i32")
+                           .TypeName("int32_t")
+                           .Structure(ENTupleStructure::kLeaf)
+                           .MakeDescriptor()
+                           .Unwrap());
+   descBuilder.AddColumn(RColumnDescriptorBuilder()
+                            .LogicalColumnId(0)
+                            .PhysicalColumnId(0)
+                            .Model(RColumnModel{EColumnType::kInt32, false})
+                            .FieldId(1)
+                            .Index(0)
+                            .MakeDescriptor()
+                            .Unwrap());
+   descBuilder.AddFieldLink(0, 1);
+
+   EXPECT_TRUE(descBuilder.GetDescriptor().GetHeaderExtension() == nullptr);
+   descBuilder.BeginHeaderExtension();
+   EXPECT_TRUE(descBuilder.GetDescriptor().GetHeaderExtension() != nullptr);
+
+   descBuilder.AddField(RFieldDescriptorBuilder()
+                           .FieldId(2)
+                           .FieldName("topLevel1")
+                           .Structure(ENTupleStructure::kRecord)
+                           .MakeDescriptor()
+                           .Unwrap());
+   descBuilder.AddField(RFieldDescriptorBuilder()
+                           .FieldId(3)
+                           .FieldName("i64")
+                           .TypeName("int64_t")
+                           .Structure(ENTupleStructure::kLeaf)
+                           .MakeDescriptor()
+                           .Unwrap());
+   descBuilder.AddColumn(RColumnDescriptorBuilder()
+                            .LogicalColumnId(1)
+                            .PhysicalColumnId(1)
+                            .Model(RColumnModel{EColumnType::kInt64, false})
+                            .FieldId(3)
+                            .Index(0)
+                            .MakeDescriptor()
+                            .Unwrap());
+   descBuilder.AddFieldLink(2, 3);
+   descBuilder.AddFieldLink(0, 2);
+   descBuilder.AddField(RFieldDescriptorBuilder()
+                           .FieldId(4)
+                           .FieldName("topLevel2")
+                           .TypeName("bool")
+                           .Structure(ENTupleStructure::kLeaf)
+                           .MakeDescriptor()
+                           .Unwrap());
+   descBuilder.AddColumn(RColumnDescriptorBuilder()
+                            .LogicalColumnId(2)
+                            .PhysicalColumnId(2)
+                            .Model(RColumnModel{EColumnType::kBit, false})
+                            .FieldId(4)
+                            .Index(0)
+                            .MakeDescriptor()
+                            .Unwrap());
+   descBuilder.AddFieldLink(0, 4);
+
+   auto desc = descBuilder.MoveDescriptor();
+   ASSERT_EQ(desc.GetNFields(), 5);
+   ASSERT_EQ(desc.GetNLogicalColumns(), 3);
+   ASSERT_EQ(desc.GetNPhysicalColumns(), 3);
+   {
+      std::string_view child_names[] = {"i32", "topLevel1", "topLevel2"};
+      unsigned i = 0;
+      for (auto &child_field : desc.GetTopLevelFields())
+         EXPECT_EQ(child_field.GetFieldName(), child_names[i++]);
+   }
+   auto xHeader = desc.GetHeaderExtension();
+   EXPECT_EQ(xHeader->GetNFields(), 3);
+   EXPECT_EQ(xHeader->GetNLogicalColumns(), 2);
+   EXPECT_EQ(xHeader->GetNPhysicalColumns(), 2);
+   {
+      std::string_view child_names[] = {"topLevel1", "topLevel2"};
+      unsigned i = 0;
+      for (auto &child_field : xHeader->GetTopLevelFields(desc))
+         EXPECT_EQ(child_field.GetFieldName(), child_names[i++]);
+   }
+}
+
 TEST(RNTupleDescriptor, QualifiedFieldName)
 {
    auto model = RNTupleModel::Create();

--- a/tree/ntuple/v7/test/ntuple_schemaext.cxx
+++ b/tree/ntuple/v7/test/ntuple_schemaext.cxx
@@ -1,0 +1,200 @@
+#include "ntuple_test.hxx"
+
+TEST(RNTuple, SchemaExtensionSimple)
+{
+   FileRaii fileGuard("test_ntuple_schemaext_simple.root");
+   std::array<double, 2> refArray{1.0, 24.0};
+   {
+      auto model = RNTupleModel::Create();
+      auto fieldPt = model->MakeField<float>("pt", 42.0);
+
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "myNTuple", fileGuard.GetPath());
+      auto modelUpdater = ntuple->GetIncrementalModelUpdater();
+      modelUpdater->BeginUpdate();
+      std::array<double, 2> fieldArray = refArray;
+      modelUpdater->AddField<std::array<double, 2>>("array", &fieldArray);
+      modelUpdater->CommitUpdate();
+
+      ntuple->Fill();
+      *fieldPt = 12.0;
+      fieldArray[1] = 1337.0;
+      ntuple->Fill();
+   }
+
+   auto ntuple = RNTupleReader::Open("myNTuple", fileGuard.GetPath());
+   EXPECT_EQ(2U, ntuple->GetNEntries());
+   EXPECT_EQ(4U, ntuple->GetDescriptor()->GetNFields());
+
+   auto pt = ntuple->GetView<float>("pt");
+   auto array = ntuple->GetView<std::array<double, 2>>("array");
+   EXPECT_EQ(42.0, pt(0));
+   EXPECT_EQ(12.0, pt(1));
+   EXPECT_EQ(refArray, array(0));
+   EXPECT_EQ(1337.0, array(1)[1]);
+}
+
+TEST(RNTuple, SchemaExtensionInvalidUse)
+{
+   FileRaii fileGuard("test_ntuple_schemaext_invalid.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto fieldPt = model->MakeField<float>("pt", 42.0);
+
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "myNTuple", fileGuard.GetPath());
+      auto entry = ntuple->GetModel()->CreateEntry();
+
+      auto modelUpdater = ntuple->GetIncrementalModelUpdater();
+      modelUpdater->BeginUpdate();
+      double d;
+      modelUpdater->AddField<double>("d", &d);
+      // Cannot fill if the model is not frozen
+      EXPECT_THROW(ntuple->Fill(), ROOT::Experimental::RException);
+      // Trying to create an entry should throw if model is not frozen
+      EXPECT_THROW((void)ntuple->GetModel()->CreateEntry(), ROOT::Experimental::RException);
+      modelUpdater->CommitUpdate();
+
+      // Using an entry that does not match the model should throw
+      EXPECT_THROW(ntuple->Fill(*entry), ROOT::Experimental::RException);
+
+      ntuple->Fill();
+      auto entry2 = ntuple->GetModel()->CreateEntry();
+      ntuple->Fill(*entry2);
+
+      // Trying to update the schema after the first `Fill()` call should throw
+      EXPECT_THROW(modelUpdater->BeginUpdate(), ROOT::Experimental::RException);
+
+      ntuple->Fill();
+   }
+
+   auto ntuple = RNTupleReader::Open("myNTuple", fileGuard.GetPath());
+   EXPECT_EQ(3U, ntuple->GetNEntries());
+   EXPECT_EQ(3U, ntuple->GetDescriptor()->GetNFields());
+}
+
+TEST(RNTuple, SchemaExtensionMultiple)
+{
+   FileRaii fileGuard("test_ntuple_schemaext_multiple.root");
+   std::vector<std::uint32_t> refVec{0x00, 0xff, 0x55, 0xaa};
+   {
+      auto model = RNTupleModel::Create();
+      auto fieldPt = model->MakeField<float>("pt", 42.0);
+
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "myNTuple", fileGuard.GetPath());
+      auto modelUpdater = ntuple->GetIncrementalModelUpdater();
+      modelUpdater->BeginUpdate();
+      std::vector<std::uint32_t> fieldVec;
+      modelUpdater->AddField<std::vector<std::uint32_t>>("vec", &fieldVec);
+      modelUpdater->CommitUpdate();
+
+      modelUpdater->BeginUpdate();
+      float fieldFloat = 10.0;
+      modelUpdater->AddField<float>("f", &fieldFloat);
+      modelUpdater->CommitUpdate();
+
+      modelUpdater->BeginUpdate();
+      std::uint8_t u8 = 0x7f;
+      modelUpdater->AddField<std::uint8_t>("u8", &u8);
+      modelUpdater->CommitUpdate();
+
+      ntuple->Fill();
+      *fieldPt = 12.0;
+      fieldFloat = 1.0;
+      fieldVec = refVec;
+      u8 = 0xaa;
+      ntuple->Fill();
+   }
+
+   auto ntuple = RNTupleReader::Open("myNTuple", fileGuard.GetPath());
+   EXPECT_EQ(2U, ntuple->GetNEntries());
+   EXPECT_EQ(6U, ntuple->GetDescriptor()->GetNFields());
+
+   auto pt = ntuple->GetView<float>("pt");
+   auto vec = ntuple->GetView<std::vector<std::uint32_t>>("vec");
+   auto f = ntuple->GetView<float>("f");
+   auto u8 = ntuple->GetView<std::uint8_t>("u8");
+   EXPECT_EQ(42.0, pt(0));
+   EXPECT_EQ(12.0, pt(1));
+   EXPECT_EQ(std::vector<std::uint32_t>{}, vec(0));
+   EXPECT_EQ(refVec, vec(1));
+   EXPECT_EQ(10.0, f(0));
+   EXPECT_EQ(1.0, f(1));
+   EXPECT_EQ(0x7f, u8(0));
+   EXPECT_EQ(0xaa, u8(1));
+}
+
+// Based on the RealWorld1 test in `ntuple_extended.cxx`, but here some fields are added after the fact
+TEST(RNTuple, SchemaExtensionRealWorld1)
+{
+   ROOT::EnableImplicitMT();
+   FileRaii fileGuard("test_ntuple_schemaext_realworld1.root");
+
+   // See https://github.com/olifre/root-io-bench/blob/master/benchmark.cpp
+   auto modelWrite = RNTupleModel::Create();
+   auto wrEvent = modelWrite->MakeField<std::uint32_t>("event");
+   auto wrSignal = modelWrite->MakeField<bool>("signal");
+   auto wrTimes = modelWrite->MakeField<std::vector<double>>("times");
+
+   TRandom3 rnd(42);
+   double chksumWrite = 0.0;
+   {
+      auto ntuple = RNTupleWriter::Recreate(std::move(modelWrite), "myNTuple", fileGuard.GetPath());
+
+      auto modelUpdater = ntuple->GetIncrementalModelUpdater();
+      modelUpdater->BeginUpdate();
+      std::vector<std::uint32_t> fieldVec;
+      double wrEnergy;
+      std::vector<std::uint32_t> wrIndices;
+      modelUpdater->AddField<double>("energy", &wrEnergy);
+      modelUpdater->AddField<std::vector<std::uint32_t>>("indices", &wrIndices);
+      modelUpdater->CommitUpdate();
+
+      constexpr unsigned int nEvents = 60000;
+      for (unsigned int i = 0; i < nEvents; ++i) {
+         *wrEvent = i;
+         wrEnergy = rnd.Rndm() * 1000.;
+         *wrSignal = i % 2;
+
+         chksumWrite += double(*wrEvent);
+         chksumWrite += double(*wrSignal);
+         chksumWrite += wrEnergy;
+
+         auto nTimes = 1 + floor(rnd.Rndm() * 1000.);
+         wrTimes->resize(nTimes);
+         for (unsigned int n = 0; n < nTimes; ++n) {
+            wrTimes->at(n) = 1 + rnd.Rndm() * 1000. - 500.;
+            chksumWrite += wrTimes->at(n);
+         }
+
+         auto nIndices = 1 + floor(rnd.Rndm() * 1000.);
+         wrIndices.resize(nIndices);
+         for (unsigned int n = 0; n < nIndices; ++n) {
+            wrIndices.at(n) = 1 + floor(rnd.Rndm() * 1000.);
+            chksumWrite += double(wrIndices.at(n));
+         }
+
+         ntuple->Fill();
+      }
+   }
+
+   auto modelRead = RNTupleModel::Create();
+   auto rdEvent = modelRead->MakeField<std::uint32_t>("event");
+   auto rdSignal = modelRead->MakeField<bool>("signal");
+   auto rdEnergy = modelRead->MakeField<double>("energy");
+   auto rdTimes = modelRead->MakeField<std::vector<double>>("times");
+   auto rdIndices = modelRead->MakeField<std::vector<std::uint32_t>>("indices");
+
+   double chksumRead = 0.0;
+   auto ntuple = RNTupleReader::Open(std::move(modelRead), "myNTuple", fileGuard.GetPath());
+   for (auto entryId : *ntuple) {
+      ntuple->LoadEntry(entryId);
+      chksumRead += double(*rdEvent) + double(*rdSignal) + *rdEnergy;
+      for (auto t : *rdTimes)
+         chksumRead += t;
+      for (auto ind : *rdIndices)
+         chksumRead += double(ind);
+   }
+
+   // The floating point arithmetic should have been executed in the same order for reading and writing,
+   // thus we expect the checksums to be bitwise identical
+   EXPECT_EQ(chksumRead, chksumWrite);
+}

--- a/tree/ntuple/v7/test/ntuple_schemaext.cxx
+++ b/tree/ntuple/v7/test/ntuple_schemaext.cxx
@@ -9,7 +9,7 @@ TEST(RNTuple, SchemaExtensionSimple)
       auto fieldPt = model->MakeField<float>("pt", 42.0);
 
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "myNTuple", fileGuard.GetPath());
-      auto modelUpdater = ntuple->GetModelUpdater();
+      auto modelUpdater = ntuple->CreateModelUpdater();
       modelUpdater->BeginUpdate();
       std::array<double, 2> fieldArray = refArray;
       modelUpdater->AddField<std::array<double, 2>>("array", &fieldArray);
@@ -43,7 +43,7 @@ TEST(RNTuple, SchemaExtensionInvalidUse)
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "myNTuple", fileGuard.GetPath());
       auto entry = ntuple->GetModel()->CreateEntry();
 
-      auto modelUpdater = ntuple->GetModelUpdater();
+      auto modelUpdater = ntuple->CreateModelUpdater();
       modelUpdater->BeginUpdate();
       double d;
       modelUpdater->AddField<double>("d", &d);
@@ -80,7 +80,7 @@ TEST(RNTuple, SchemaExtensionMultiple)
       auto fieldPt = model->MakeField<float>("pt", 42.0);
 
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "myNTuple", fileGuard.GetPath());
-      auto modelUpdater = ntuple->GetModelUpdater();
+      auto modelUpdater = ntuple->CreateModelUpdater();
       modelUpdater->BeginUpdate();
       std::vector<std::uint32_t> fieldVec;
       modelUpdater->AddField<std::vector<std::uint32_t>>("vec", &fieldVec);
@@ -131,7 +131,7 @@ TEST(RNTuple, SchemaExtensionProject)
       auto fieldPt = model->MakeField<float>("pt", 42.0);
 
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "myNTuple", fileGuard.GetPath());
-      auto modelUpdater = ntuple->GetModelUpdater();
+      auto modelUpdater = ntuple->CreateModelUpdater();
       modelUpdater->BeginUpdate();
       std::vector<std::uint32_t> fieldVec;
       modelUpdater->AddField<std::vector<std::uint32_t>>("vec", &fieldVec);
@@ -182,7 +182,7 @@ TEST(RNTuple, SchemaExtensionRealWorld1)
    {
       auto ntuple = RNTupleWriter::Recreate(std::move(modelWrite), "myNTuple", fileGuard.GetPath());
 
-      auto modelUpdater = ntuple->GetModelUpdater();
+      auto modelUpdater = ntuple->CreateModelUpdater();
       modelUpdater->BeginUpdate();
       std::vector<std::uint32_t> fieldVec;
       double wrEnergy;

--- a/tree/ntuple/v7/test/ntuple_schemaext.cxx
+++ b/tree/ntuple/v7/test/ntuple_schemaext.cxx
@@ -9,7 +9,7 @@ TEST(RNTuple, SchemaExtensionSimple)
       auto fieldPt = model->MakeField<float>("pt", 42.0);
 
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "myNTuple", fileGuard.GetPath());
-      auto modelUpdater = ntuple->GetIncrementalModelUpdater();
+      auto modelUpdater = ntuple->GetModelUpdater();
       modelUpdater->BeginUpdate();
       std::array<double, 2> fieldArray = refArray;
       modelUpdater->AddField<std::array<double, 2>>("array", &fieldArray);
@@ -43,7 +43,7 @@ TEST(RNTuple, SchemaExtensionInvalidUse)
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "myNTuple", fileGuard.GetPath());
       auto entry = ntuple->GetModel()->CreateEntry();
 
-      auto modelUpdater = ntuple->GetIncrementalModelUpdater();
+      auto modelUpdater = ntuple->GetModelUpdater();
       modelUpdater->BeginUpdate();
       double d;
       modelUpdater->AddField<double>("d", &d);
@@ -80,7 +80,7 @@ TEST(RNTuple, SchemaExtensionMultiple)
       auto fieldPt = model->MakeField<float>("pt", 42.0);
 
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "myNTuple", fileGuard.GetPath());
-      auto modelUpdater = ntuple->GetIncrementalModelUpdater();
+      auto modelUpdater = ntuple->GetModelUpdater();
       modelUpdater->BeginUpdate();
       std::vector<std::uint32_t> fieldVec;
       modelUpdater->AddField<std::vector<std::uint32_t>>("vec", &fieldVec);
@@ -131,7 +131,7 @@ TEST(RNTuple, SchemaExtensionProject)
       auto fieldPt = model->MakeField<float>("pt", 42.0);
 
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "myNTuple", fileGuard.GetPath());
-      auto modelUpdater = ntuple->GetIncrementalModelUpdater();
+      auto modelUpdater = ntuple->GetModelUpdater();
       modelUpdater->BeginUpdate();
       std::vector<std::uint32_t> fieldVec;
       modelUpdater->AddField<std::vector<std::uint32_t>>("vec", &fieldVec);
@@ -182,7 +182,7 @@ TEST(RNTuple, SchemaExtensionRealWorld1)
    {
       auto ntuple = RNTupleWriter::Recreate(std::move(modelWrite), "myNTuple", fileGuard.GetPath());
 
-      auto modelUpdater = ntuple->GetIncrementalModelUpdater();
+      auto modelUpdater = ntuple->GetModelUpdater();
       modelUpdater->BeginUpdate();
       std::vector<std::uint32_t> fieldVec;
       double wrEnergy;

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -675,6 +675,8 @@ TEST(RNTuple, SerializeFooterXHeader)
    builder.AddFieldLink(0, 45);
    builder.AddColumn(18, 18, 44, RColumnModel(EColumnType::kReal32, true), 0);
    builder.AddColumn(19, 19, 45, RColumnModel(EColumnType::kInt64, true), 0);
+   // Make sure late-added fields and the corresponding columns get an on-disk ID
+   context.MapSchema(builder.GetDescriptor(), /*forHeaderExtension=*/true);
 
    auto desc = builder.MoveDescriptor();
    auto sizeFooter = RNTupleSerializer::SerializeFooterV1(nullptr, desc, context);
@@ -697,6 +699,6 @@ TEST(RNTuple, SerializeFooterXHeader)
    EXPECT_EQ(2u, xHeader->GetNPhysicalColumns());
    auto fldIdStruct = desc.FindFieldId("struct");
    EXPECT_EQ(1, fldIdStruct);
-   EXPECT_EQ(2, desc.FindFieldId("i64"));
-   EXPECT_EQ(3, desc.FindFieldId("f", fldIdStruct));
+   EXPECT_EQ(2, desc.FindFieldId("f", fldIdStruct));
+   EXPECT_EQ(3, desc.FindFieldId("i64"));
 }

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -675,6 +675,17 @@ TEST(RNTuple, SerializeFooterXHeader)
    builder.AddFieldLink(0, 45);
    builder.AddColumn(18, 18, 44, RColumnModel(EColumnType::kReal32, true), 0);
    builder.AddColumn(19, 19, 45, RColumnModel(EColumnType::kInt64, true), 0);
+
+   builder.AddField(RFieldDescriptorBuilder()
+                       .FieldId(46)
+                       .FieldName("projected")
+                       .TypeName("float")
+                       .Structure(ENTupleStructure::kLeaf)
+                       .MakeDescriptor()
+                       .Unwrap());
+   builder.AddFieldLink(0, 46);
+   builder.AddColumn(20, 18, 46, RColumnModel(EColumnType::kReal32, true), 0);
+
    // Make sure late-added fields and the corresponding columns get an on-disk ID
    context.MapSchema(builder.GetDescriptor(), /*forHeaderExtension=*/true);
 
@@ -689,16 +700,17 @@ TEST(RNTuple, SerializeFooterXHeader)
 
    desc = builder.MoveDescriptor();
 
-   EXPECT_EQ(5u, desc.GetNFields());
-   EXPECT_EQ(3u, desc.GetNLogicalColumns());
+   EXPECT_EQ(6u, desc.GetNFields());
+   EXPECT_EQ(4u, desc.GetNLogicalColumns());
    EXPECT_EQ(3u, desc.GetNPhysicalColumns());
    auto xHeader = desc.GetHeaderExtension();
    EXPECT_TRUE(xHeader != nullptr);
-   EXPECT_EQ(3u, xHeader->GetNFields());
-   EXPECT_EQ(2u, xHeader->GetNLogicalColumns());
+   EXPECT_EQ(4u, xHeader->GetNFields());
+   EXPECT_EQ(3u, xHeader->GetNLogicalColumns());
    EXPECT_EQ(2u, xHeader->GetNPhysicalColumns());
    auto fldIdStruct = desc.FindFieldId("struct");
    EXPECT_EQ(1, fldIdStruct);
    EXPECT_EQ(2, desc.FindFieldId("f", fldIdStruct));
    EXPECT_EQ(3, desc.FindFieldId("i64"));
+   EXPECT_EQ(4, desc.FindFieldId("projected"));
 }


### PR DESCRIPTION
This pull request implements the foundations for late model extension, i.e. extending the ntuple model with new fields after the initial schema has been fixed.
Per this PR, we only allow extending the model before the first entry is filled.  This restriction will be removed in a follow-up PR.

**NOTE:** after the changes in this PR, all the currently existing ntuple files remain readable.

The user-facing API is based on a new class `RNTupleModel::RUpdater` that can be used as follows:
```c++
auto model = RNTupleModel::Create();
auto field1 = model->MakeField<float>("field1", 42.0);

auto ntuple = RNTupleWriter::Recreate(std::move(model), "myNTuple", "some/file.root");
auto modelUpdater = ntuple->CreateModelUpdater();
modelUpdater->BeginUpdate();
float field2 = 10.0;
modelUpdater->AddField<float>("field2", &field2);
modelUpdater->CommitUpdate();
// possibly more calls to `BeginUpdate()`/`CommitUpdate()` here...

*field2 = 42.0;
ntuple->Fill();
```

## Changes or fixes:
- Changes required to `RNTupleDescriptor`: in particular, _(i)_ `RNTupleDescriptorBuilder::BeginHeaderExtension()` marks the beginning of the header extension; and _(ii)_ extension header information, including an iterator over the top-level fields may be obtained via `RNTupleDescriptor::GetHeaderExtension()`.
- Serialize/deserialize an incremental schema description, i.e. schema extension, as part of the footer envelope.  This changes the layout of the footer as explained in the [updated binary format specification](https://github.com/jalopezg-git/root/blob/2ed0dd65698c937f0c06017172c6fbcdfbbb9636/tree/ntuple/v7/doc/specifications.md).
**NOTE:** another change required in the serialization code is the use depth-first serialization of columns instead.  Rationale: given that
  1. New columns may appear during write as a result of schema extension; and
  2. On-disk IDs for those columns have to be assigned before serializing the next page list,

  we have to ensure that these columns get the same ID both when they are seen for the first time (in page lists) and by the time the description for the schema extension is serialized.
  This change only affects how the schema is serialized and does not change deserialization, i.e. the change is backwards compatible.
- `RPageSink::UpdateSchema(const RNTupleModelChangeset &)` allows incremental updates to the ntuple descriptor kept internally in the `RPageSink`, which is required, e.g. if new fields were added after the initial call to `RPageSink::Create(RNTupleModel &)`.
- Per the current state of affairs in `RPageSinkBuf`, some adjustments are also needed to keep `fInnerModel` in sync.
- Add class `RNTupleModel::RUpdater`, which provides limited support for incremental updates, e.g. addition of new fields.
- Add `RNTupleWriter::CreateModelUpdater()` that returns a usable `RUpdater` object.

## Checklist:
- [X] tested changes locally
- [X] updated the docs (if necessary)
- [ ] Update to format version to RC 2 -- to be done after merging both parts + split encoding