### PR TITLE
[ntuple,v6-28] RPageSinkBuf: add missing call to ReleasePage()

### DIFF
--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -106,8 +106,11 @@ ROOT::Experimental::Detail::RPageSinkBuf::CommitClusterImpl(ROOT::Experimental::
       }
       fInnerSink->CommitSealedPageV(toCommit);
 
-      for (auto &bufColumn : fBufferedColumns)
-         bufColumn.DrainBufferedPages();
+      for (auto &bufColumn : fBufferedColumns) {
+         auto drained = bufColumn.DrainBufferedPages();
+         for (auto &bufPage : std::get<std::deque<RColumnBuf::RPageZipItem>>(drained))
+            ReleasePage(bufPage.fPage);
+      }
       return fInnerSink->CommitCluster(nEntries);
    }
 


### PR DESCRIPTION
This pull request is a backport of https://github.com/root-project/root/pull/12298 to the `v6-28-00-patches` branch.

This fixes an unfortunate memory leak we introduced in https://github.com/root-project/root/pull/10775.