### PR TITLE
[ntuple] Improve support for classes with an associated collection proxy

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -503,6 +503,7 @@ private:
    };
 
    std::unique_ptr<TVirtualCollectionProxy> fProxy;
+   Int_t fProperties;
    /// Two sets of functions to operate on iterators, to be used depending on the access type
    RCollectionIterableOnce::RIteratorFuncs fIFuncsRead;
    RCollectionIterableOnce::RIteratorFuncs fIFuncsWrite;

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -462,8 +462,8 @@ private:
    private:
       class RIterator {
          const RCollectionIterableOnce &fOwner;
-         void *fIterator;
-         void *fElementPtr;
+         void *fIterator = nullptr;
+         void *fElementPtr = nullptr;
       public:
          using iterator_category = std::forward_iterator_tag;
          using iterator = RIterator;


### PR DESCRIPTION
This pull request improves the support for storage of collections that use `TVirtualCollectionProxy`, which was initially landed in #11525.  However, `TVirtualCollectionProxy` allows for traversing a collection using iterators, which should be faster than using `TVirtualCollectionProxy::At()`.  Also, this interface avoids (where possible) an additional copy during element insertion.

## Changes or fixes:
- Switches from using `TVirtualCollectionProxy::{Size,At}()` to the use of iterators.  After merging this PR, an implementation for the following functions is required instead: `TVirtualCollectionProxy::GetFunctionCreateIterators()`, `GetFunctionNext()`, and `GetFunctionDeleteTwoIterators`.

## Checklist:
- [X] tested changes locally
- [X] updated the docs (if necessary)

This PR fixes #11671.