### PR TITLE
[RF] Add initial minimizer interface for RooFuncWrapper

### DIFF
--- a/roofit/roofitcore/inc/RooFuncWrapper.h
+++ b/roofit/roofitcore/inc/RooFuncWrapper.h
@@ -16,6 +16,8 @@
 #include "RooAbsReal.h"
 #include "RooListProxy.h"
 
+#include "Math/Functor.h"
+
 #include <memory>
 #include <string>
 
@@ -36,6 +38,12 @@ public:
 
    void getGradient(double *out) const;
 
+   void gradient(const double *x, double *g) const;
+
+   const ROOT::Math::GradFunctor &getGradFunctor() const { return _gradFunctor; }
+
+   const ROOT::Math::Functor &getFunctor() const { return _funcFunctor; }
+
 protected:
    void updateGradientVarBuffer() const;
 
@@ -45,9 +53,13 @@ private:
    using Func = double (*)(double *, double *);
    using Grad = void (*)(double *, double *, double *);
 
+   double doEval(const double *x) const;
+
    RooListProxy _params;
    Func _func;
+   ROOT::Math::Functor _funcFunctor;
    Grad _grad;
+   ROOT::Math::GradFunctor _gradFunctor;
    mutable std::vector<double> _gradientVarBuffer;
    mutable std::vector<double> _observables;
 };


### PR DESCRIPTION
This commit adds a ROOT::Math::Functor based interface to the minimizer for RooFuncWrapper. A functor based approach allows for the wrapper to choose between using AD/analytical and numerical derivatives easily.