### PR TITLE
[PyROOT] Only build RooFit and TMVA pythonizations if needed

### DIFF
--- a/bindings/pyroot/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/CMakeLists.txt
@@ -25,6 +25,48 @@ if(dataframe)
         inc/RNumpyDS.hxx)
 endif()
 
+if(roofit)
+    list(APPEND PYROOT_EXTRA_PY2_PY3_SOURCE
+        ROOT/_pythonization/_roofit/__init__.py
+        ROOT/_pythonization/_roofit/_rooabscollection.py
+        ROOT/_pythonization/_roofit/_rooabsdata.py
+        ROOT/_pythonization/_roofit/_rooabspdf.py
+        ROOT/_pythonization/_roofit/_rooabsreallvalue.py
+        ROOT/_pythonization/_roofit/_rooabsreal.py
+        ROOT/_pythonization/_roofit/_rooarglist.py
+        ROOT/_pythonization/_roofit/_rooargset.py
+        ROOT/_pythonization/_roofit/_roocategory.py
+        ROOT/_pythonization/_roofit/_roochi2var.py
+        ROOT/_pythonization/_roofit/_roodatahist.py
+        ROOT/_pythonization/_roofit/_roodataset.py
+        ROOT/_pythonization/_roofit/_roodecays.py
+        ROOT/_pythonization/_roofit/_roogenfitstudy.py
+        ROOT/_pythonization/_roofit/_rooglobalfunc.py
+        ROOT/_pythonization/_roofit/_roojsonfactorywstool.py
+        ROOT/_pythonization/_roofit/_roomcstudy.py
+        ROOT/_pythonization/_roofit/_roomsgservice.py
+        ROOT/_pythonization/_roofit/_roonllvar.py
+        ROOT/_pythonization/_roofit/_rooprodpdf.py
+        ROOT/_pythonization/_roofit/_roorealvar.py
+        ROOT/_pythonization/_roofit/_roosimultaneous.py
+        ROOT/_pythonization/_roofit/_roosimwstool.py
+        ROOT/_pythonization/_roofit/_roovectordatastore.py
+        ROOT/_pythonization/_roofit/_rooworkspace.py
+        ROOT/_pythonization/_roofit/_utils.py)
+endif()
+
+if(tmva)
+    list(APPEND PYROOT_EXTRA_PY2_PY3_SOURCE
+        ROOT/_pythonization/_tmva/_crossvalidation.py
+        ROOT/_pythonization/_tmva/_dataloader.py
+        ROOT/_pythonization/_tmva/_factory.py
+        ROOT/_pythonization/_tmva/__init__.py
+        ROOT/_pythonization/_tmva/_rbdt.py
+        ROOT/_pythonization/_tmva/_rtensor.py
+        ROOT/_pythonization/_tmva/_tree_inference.py
+        ROOT/_pythonization/_tmva/_utils.py)
+endif()
+
 list(APPEND PYROOT_EXTRA_HEADERS
      inc/TPyDispatcher.h)
 
@@ -39,32 +81,6 @@ set(py2_py3_sources
   ROOT/_pythonization/_generic.py
   ROOT/_pythonization/__init__.py
   ROOT/_pythonization/_pyz_utils.py
-  ROOT/_pythonization/_roofit/__init__.py
-  ROOT/_pythonization/_roofit/_rooabscollection.py
-  ROOT/_pythonization/_roofit/_rooabsdata.py
-  ROOT/_pythonization/_roofit/_rooabspdf.py
-  ROOT/_pythonization/_roofit/_rooabsreallvalue.py
-  ROOT/_pythonization/_roofit/_rooabsreal.py
-  ROOT/_pythonization/_roofit/_rooarglist.py
-  ROOT/_pythonization/_roofit/_rooargset.py
-  ROOT/_pythonization/_roofit/_roocategory.py
-  ROOT/_pythonization/_roofit/_roochi2var.py
-  ROOT/_pythonization/_roofit/_roodatahist.py
-  ROOT/_pythonization/_roofit/_roodataset.py
-  ROOT/_pythonization/_roofit/_roodecays.py
-  ROOT/_pythonization/_roofit/_roogenfitstudy.py
-  ROOT/_pythonization/_roofit/_rooglobalfunc.py
-  ROOT/_pythonization/_roofit/_roojsonfactorywstool.py
-  ROOT/_pythonization/_roofit/_roomcstudy.py
-  ROOT/_pythonization/_roofit/_roomsgservice.py
-  ROOT/_pythonization/_roofit/_roonllvar.py
-  ROOT/_pythonization/_roofit/_rooprodpdf.py
-  ROOT/_pythonization/_roofit/_roorealvar.py
-  ROOT/_pythonization/_roofit/_roosimultaneous.py
-  ROOT/_pythonization/_roofit/_roosimwstool.py
-  ROOT/_pythonization/_roofit/_roovectordatastore.py
-  ROOT/_pythonization/_roofit/_rooworkspace.py
-  ROOT/_pythonization/_roofit/_utils.py
   ROOT/_pythonization/_rvec.py
   ROOT/_pythonization/_stl_vector.py
   ROOT/_pythonization/_tarray.py
@@ -79,14 +95,6 @@ set(py2_py3_sources
   ROOT/_pythonization/_tgraph.py
   ROOT/_pythonization/_th1.py
   ROOT/_pythonization/_titer.py
-  ROOT/_pythonization/_tmva/_crossvalidation.py
-  ROOT/_pythonization/_tmva/_dataloader.py
-  ROOT/_pythonization/_tmva/_factory.py
-  ROOT/_pythonization/_tmva/__init__.py
-  ROOT/_pythonization/_tmva/_rbdt.py
-  ROOT/_pythonization/_tmva/_rtensor.py
-  ROOT/_pythonization/_tmva/_tree_inference.py
-  ROOT/_pythonization/_tmva/_utils.py
   ROOT/_pythonization/_tobject.py
   ROOT/_pythonization/_tobjstring.py
   ROOT/_pythonization/_tseqcollection.py


### PR DESCRIPTION
Like this, we are polluting the build and install directories less with unneeded files and it also speeds up the build process a bit if RooFit and/or TMVA are disabled. Their pythonization files don't need to be compiled to `.pyc` files.