### PR TITLE
[CI] Add fine-grained matrix

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -70,13 +70,33 @@ jobs:
       contents: read
 
     strategy:
-      matrix:
-        image: ["fedora37", "centos8", "ubuntu18", "ubuntu20", "ubuntu22"]
-        config: ["Release"]
-        #, "Debug", "RelWithDebInfo"]
       fail-fast: false
+      matrix:
+        # Specify image + config + (optional) build option overrides
+        #
+        # Available images: https://github.com/root-project/root-ci-images
+        # Common configs: {Release,Debug,RelWithDebInfo)
+        # Build options: https://root.cern/install/build_from_source/#all-build-options
+        include:
+          - image: fedora37
+            config: Debug
+
+          - image: centos8
+            config: Release
+
+          - image: ubuntu20
+            config: Release
+
+          - image: ubuntu22
+            config: Release
+            overrides: ["testing=Off", "roottest=Off"]
+
+          - image: ubuntu22
+            config: Debug
+            overrides: ["DLLVM_BUILD_TYPE=Debug", "soversion=On"]
 
     runs-on: [self-hosted, linux, x64]
+    name: ${{ matrix.image }} ${{ matrix.config }} ${{ join( matrix.overrides, ', ' ) }}
 
     container:
       image: registry.cern.ch/root-ci/${{ matrix.image }}:buildready
@@ -104,6 +124,31 @@ jobs:
         run:  'printf "%s@%s\\n" "$(whoami)" "$(hostname)";
                ls -la
               '
+
+      - name: Apply option overrides from matrix for this job
+        if: ${{ matrix.overrides != NaN }}
+        env:
+          OVERRIDES: ${{ join( matrix.overrides, ' ') }}
+          FILE: .github/workflows/root-ci-config/buildconfig/${{ matrix.image }}.txt
+        shell: bash
+        run: |
+          set -x
+
+          echo '' >> "$FILE"
+
+          for ENTRY in $OVERRIDES; do
+              KEY=$( echo "$ENTRY" | cut -d '=' -f 1 )
+              
+              # Add entry to file if not exists, otherwise replace
+
+              if grep -q "$KEY=" "$FILE"; then
+                  sed -i "s/$KEY=.*\$/$ENTRY/" "$FILE"
+              else
+                  echo "$ENTRY" >> "$FILE"
+              fi
+          done
+
+          cat "$FILE" || true
 
       - name: Pull Request Build
         if:   github.event_name == 'pull_request' || github.event_name == 'pull_request_target'


### PR DESCRIPTION
# This Pull request:

Resolves #12297

Changes the matrix to do some jobs with different options, e.g. `DLLVM_BUILD_TYP=Debug` for one of the ubuntu22 builds. (can be changed).

Also rewrites the matrix to explicitly type each job, instead of doing a N x M jobs. I believe this syntax is easier to configure and makes implementation cleaner, as opposed to using nested lists to provide matrix options.

Example run (picture added in case it expires): https://github.com/olemorud/root/actions/runs/4284703493
![image](https://user-images.githubusercontent.com/82065181/221802381-3394775e-2b1b-45e9-8e3c-63ce0d44bd18.png)


## Checklist:

- [x] tested changes locally

