### PR TITLE
[RF] The testRooAbsL test compares two doubles and fails due to rounding errors

### DIFF
--- a/roofit/roofitcore/test/TestStatistics/testRooAbsL.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testRooAbsL.cxx
@@ -293,7 +293,11 @@ TEST_F(SimBinnedConstrainedTest, SubEventSections)
          {static_cast<double>(ix) / N_events_total, static_cast<double>(ix + 1) / N_events_total}, 0,
          likelihood->getNComponents());
    }
-   EXPECT_EQ(whole.Sum(), N_events_total_parts.Sum());
+   // We cannot EXPECT_EQ in this test, because we compare actually different
+   // calculations. The multiple additions and FMA operations involved in the
+   // calculation of the multiple parts introduces different rounding errors
+   // on the CPU level than the single calculation over all events at once.
+   EXPECT_DOUBLE_EQ(whole.Sum(), N_events_total_parts.Sum());
 
    // now let's do it again over a number of sections 3 times the number of events
    ROOT::Math::KahanSum<double> thrice_N_events_total_parts;
@@ -303,5 +307,5 @@ TEST_F(SimBinnedConstrainedTest, SubEventSections)
          {static_cast<double>(ix) / (3 * N_events_total), static_cast<double>(ix + 1) / (3 * N_events_total)}, 0,
          likelihood->getNComponents());
    }
-   EXPECT_EQ(whole.Sum(), thrice_N_events_total_parts.Sum());
+   EXPECT_DOUBLE_EQ(whole.Sum(), thrice_N_events_total_parts.Sum());
 }


### PR DESCRIPTION
# This Pull request:

The testRooAbsL test compares two doubles and fails due to rounding errors.
The failure happens on ppc64le and aarch64.

## Changes or fixes:

This PR changes EXPECT_EQ to EXPECT_DOUBLE_EQ in the affected test.
~~~
[ RUN      ] SimBinnedConstrainedTest.SubEventSections
/builddir/build/BUILD/root-6.28.00/roofit/roofitcore/test/TestStatistics/testRooAbsL.cxx:293: Failure
Expected equality of these values:
  whole.Sum()
    Which is: -1263.796050661927
  N_events_total_parts.Sum()
    Which is: -1263.7960506619268
/builddir/build/BUILD/root-6.28.00/roofit/roofitcore/test/TestStatistics/testRooAbsL.cxx:303: Failure
Expected equality of these values:
  whole.Sum()
    Which is: -1263.796050661927
  thrice_N_events_total_parts.Sum()
    Which is: -1263.7960506619268
[  FAILED  ] SimBinnedConstrainedTest.SubEventSections (199 ms)
~~~

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
