### PR TITLE
[ntuple] improve unit testing of split encodings

### DIFF
--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -1,7 +1,41 @@
 #include "ntuple_test.hxx"
 
 #include <array>
+#include <cmath>
+#include <cstring> // for memcmp
 #include <limits>
+#include <type_traits>
+#include <utility>
+
+template <typename PodT, ROOT::Experimental::EColumnType ColumnT>
+struct Helper {
+   using Pod_t = PodT;
+   static constexpr ROOT::Experimental::EColumnType kColumnType = ColumnT;
+};
+
+template <typename HelperT>
+class PackingInt : public ::testing::Test {
+public:
+   using Helper_t = HelperT;
+};
+
+template <typename HelperT>
+class PackingReal : public ::testing::Test {
+public:
+   using Helper_t = HelperT;
+};
+
+using PackingIntTypes = ::testing::Types<Helper<std::int64_t, ROOT::Experimental::EColumnType::kSplitInt64>,
+                                         Helper<std::uint64_t, ROOT::Experimental::EColumnType::kSplitInt64>,
+                                         Helper<std::int32_t, ROOT::Experimental::EColumnType::kSplitInt32>,
+                                         Helper<std::uint32_t, ROOT::Experimental::EColumnType::kSplitInt32>,
+                                         Helper<std::int16_t, ROOT::Experimental::EColumnType::kSplitInt16>,
+                                         Helper<std::uint16_t, ROOT::Experimental::EColumnType::kSplitInt16>>;
+TYPED_TEST_CASE(PackingInt, PackingIntTypes);
+
+using PackingRealTypes = ::testing::Types<Helper<double, ROOT::Experimental::EColumnType::kSplitReal64>,
+                                          Helper<float, ROOT::Experimental::EColumnType::kSplitReal32>>;
+TYPED_TEST_CASE(PackingReal, PackingRealTypes);
 
 TEST(Packing, Bitfield)
 {
@@ -54,24 +88,127 @@ TEST(Packing, RColumnSwitch)
    EXPECT_EQ(0x55, s2.GetTag());
 }
 
-TEST(Packing, SplitReal64)
+TYPED_TEST(PackingReal, SplitReal)
 {
-   ROOT::Experimental::Detail::RColumnElement<double, ROOT::Experimental::EColumnType::kSplitReal64> element(nullptr);
+   using Pod_t = typename TestFixture::Helper_t::Pod_t;
+
+   ROOT::Experimental::Detail::RColumnElement<Pod_t, TestFixture::Helper_t::kColumnType> element(nullptr);
    element.Pack(nullptr, nullptr, 0);
    element.Unpack(nullptr, nullptr, 0);
 
-   std::array<double, 7> mem{0.0,
-                             42.0,
-                             std::numeric_limits<double>::min(),
-                             std::numeric_limits<double>::max(),
-                             std::numeric_limits<double>::lowest(),
-                             std::numeric_limits<double>::infinity(),
-                             std::numeric_limits<double>::denorm_min()};
-   std::array<double, 7> packed;
-   std::array<double, 7> cmp;
+   std::array<Pod_t, 7> mem{0.0,
+                            42.0,
+                            std::numeric_limits<Pod_t>::min(),
+                            std::numeric_limits<Pod_t>::max(),
+                            std::numeric_limits<Pod_t>::lowest(),
+                            std::numeric_limits<Pod_t>::infinity(),
+                            std::numeric_limits<Pod_t>::denorm_min()};
+   std::array<Pod_t, 7> packed;
+   std::array<Pod_t, 7> cmp;
 
    element.Pack(packed.data(), mem.data(), 7);
    element.Unpack(cmp.data(), packed.data(), 7);
 
    EXPECT_EQ(mem, cmp);
+}
+
+TYPED_TEST(PackingInt, SplitInt)
+{
+   using Pod_t = typename TestFixture::Helper_t::Pod_t;
+
+   ROOT::Experimental::Detail::RColumnElement<Pod_t, TestFixture::Helper_t::kColumnType> element(nullptr);
+   element.Pack(nullptr, nullptr, 0);
+   element.Unpack(nullptr, nullptr, 0);
+
+   std::array<Pod_t, 5> mem{0, std::is_signed_v<Pod_t> ? -42 : 1, 42, std::numeric_limits<Pod_t>::min(),
+                            std::numeric_limits<Pod_t>::max()};
+   std::array<Pod_t, 5> packed;
+   std::array<Pod_t, 5> cmp;
+
+   element.Pack(packed.data(), mem.data(), 5);
+   element.Unpack(cmp.data(), packed.data(), 5);
+
+   EXPECT_EQ(mem, cmp);
+}
+
+namespace {
+
+template <typename PodT, ROOT::Experimental::EColumnType ColumnT>
+static void AddField(RNTupleModel &model, const std::string &fieldName)
+{
+   auto fld = std::make_unique<RField<PodT>>(fieldName);
+   fld->SetColumnRepresentative({ColumnT});
+   model.AddField(std::move(fld));
+}
+
+} // anonymous namespace
+
+TEST(Packing, OnDiskEncoding)
+{
+   FileRaii fileGuard("test_ntuple_packing_ondiskencoding.root");
+
+   constexpr std::size_t kPageSize = 16; // minimum page size for two 8 byte elements
+
+   auto model = RNTupleModel::Create();
+
+   AddField<std::int16_t, ROOT::Experimental::EColumnType::kSplitInt16>(*model, "int16");
+   AddField<std::int32_t, ROOT::Experimental::EColumnType::kSplitInt32>(*model, "int32");
+   AddField<std::int64_t, ROOT::Experimental::EColumnType::kSplitInt64>(*model, "int64");
+   AddField<float, ROOT::Experimental::EColumnType::kSplitReal32>(*model, "float");
+   AddField<double, ROOT::Experimental::EColumnType::kSplitReal64>(*model, "double");
+   {
+      RNTupleWriteOptions options;
+      options.SetCompression(0);
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), options);
+      auto e = writer->CreateEntry();
+
+      *e->Get<std::int16_t>("int16") = 1;
+      *e->Get<std::int32_t>("int32") = 0x00010203;
+      *e->Get<std::int64_t>("int64") = 0x0001020304050607L;
+      *e->Get<float>("float") = std::nextafterf(1.f, 2.f); // 0 01111111 00000000000000000000001 == 0x3f800001
+      *e->Get<double>("double") = std::nextafter(1., 2.);  // 0x3ff0 0000 0000 0001
+
+      writer->Fill(*e);
+
+      *e->Get<std::int16_t>("int16") = -2;
+      *e->Get<std::int32_t>("int32") = 0x04050607;
+      *e->Get<std::int64_t>("int64") = 0x08090a0b0c0d0e0fL;
+      *e->Get<float>("float") = std::nextafterf(1.f, 0.f);            // 0 01111110 11111111111111111111111 = 0x3f7fffff
+      *e->Get<double>("double") = std::numeric_limits<double>::max(); // 0x7fef ffff ffff ffff
+
+      writer->Fill(*e);
+   }
+
+   auto source = RPageSource::Create("ntuple", fileGuard.GetPath());
+   source->Attach();
+
+   char buf[2 * kPageSize];
+   RPageStorage::RSealedPage sealedPage(buf, 2 * kPageSize, 0);
+
+   auto fnGetColumnId = [&source](const std::string &fieldName) {
+      auto descGuard = source->GetSharedDescriptorGuard();
+      return descGuard->FindPhysicalColumnId(descGuard->FindFieldId(fieldName), 0);
+   };
+
+   source->LoadSealedPage(fnGetColumnId("int16"), RClusterIndex(0, 0), sealedPage);
+   unsigned char expInt16[] = {0x01, 0xFE, 0x00, 0xFF};
+   EXPECT_EQ(memcmp(sealedPage.fBuffer, expInt16, sizeof(expInt16)), 0);
+
+   source->LoadSealedPage(fnGetColumnId("int32"), RClusterIndex(0, 0), sealedPage);
+   unsigned char expInt32[] = {0x03, 0x07, 0x02, 0x06, 0x01, 0x05, 0x00, 0x04};
+   EXPECT_EQ(memcmp(sealedPage.fBuffer, expInt32, sizeof(expInt32)), 0);
+
+   source->LoadSealedPage(fnGetColumnId("int64"), RClusterIndex(0, 0), sealedPage);
+   unsigned char expInt64[] = {0x07, 0x0f, 0x06, 0x0e, 0x05, 0x0d, 0x04, 0x0c,
+                               0x03, 0x0b, 0x02, 0x0a, 0x01, 0x09, 0x00, 0x08};
+   EXPECT_EQ(memcmp(sealedPage.fBuffer, expInt64, sizeof(expInt64)), 0);
+
+   source->LoadSealedPage(fnGetColumnId("float"), RClusterIndex(0, 0), sealedPage);
+   unsigned char expFloat[] = {0x01, 0xff, 0x00, 0xff, 0x80, 0x7f, 0x3f, 0x3f};
+   EXPECT_EQ(memcmp(sealedPage.fBuffer, expFloat, sizeof(expFloat)), 0);
+
+   source->LoadSealedPage(fnGetColumnId("double"), RClusterIndex(0, 0), sealedPage);
+   unsigned char expDouble[] = {0x01, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff,
+                                0x00, 0xff, 0x00, 0xff, 0xf0, 0xef, 0x3f, 0x7f};
+   EXPECT_EQ(memcmp(sealedPage.fBuffer, expDouble, sizeof(expDouble)), 0);
 }


### PR DESCRIPTION
As suggested by @pcanal in #12220, adds unit tests to verify the on-disk encoding of split encoded columns