### PR TITLE
[ntuple] Add column/field-level methods to RNTupleInspector

### DIFF
--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -108,11 +108,11 @@ public:
 
    /// Get the on-disk, compressed size of the RNTuple being inspected, in bytes.
    /// Does **not** include the size of the header and footer.
-   std::uint64_t GetCompressedSize();
+   std::uint64_t GetOnDiskSize();
 
-   /// Get the total, uncompressed size of the RNTuple being inspected, in bytes.
+   /// Get the total, in-memory size of the RNTuple being inspected, in bytes.
    /// Does **not** include the size of the header and footer.
-   std::uint64_t GetUncompressedSize();
+   std::uint64_t GetInMemorySize();
 
    /// Get the compression factor of the RNTuple being inspected.
    float GetCompressionFactor();
@@ -124,18 +124,18 @@ public:
    int GetColumnTypeFrequency(EColumnType colType);
 
    /// Get the on-disk, compressed size of a given column.
-   std::uint64_t GetCompressedColumnSize(DescriptorId_t logicalId);
+   std::uint64_t GetOnDiskColumnSize(DescriptorId_t logicalId);
 
-   /// Get the total, uncompressed size of a given column.
-   std::uint64_t GetUncompressedColumnSize(DescriptorId_t logicalId);
+   /// Get the total, in-memory size of a given column.
+   std::uint64_t GetInMemoryColumnSize(DescriptorId_t logicalId);
 
    /// Get the on-disk, compressed size of a given field.
-   std::uint64_t GetCompressedFieldSize(DescriptorId_t fieldId);
-   std::uint64_t GetCompressedFieldSize(std::string fieldName);
+   std::uint64_t GetOnDiskFieldSize(DescriptorId_t fieldId);
+   std::uint64_t GetOnDiskFieldSize(std::string fieldName);
 
-   /// Get the total, uncompressed size of a given field.
-   std::uint64_t GetUncompressedFieldSize(DescriptorId_t fieldId);
-   std::uint64_t GetUncompressedFieldSize(std::string fieldName);
+   /// Get the total, in-memory size of a given field.
+   std::uint64_t GetInMemoryFieldSize(DescriptorId_t fieldId);
+   std::uint64_t GetInMemoryFieldSize(std::string fieldName);
 
    /// Get the type of a given column.
    EColumnType GetColumnType(DescriptorId_t logicalId);

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -20,10 +20,11 @@
 #include <ROOT/RError.hxx>
 
 #include <cstring>
+#include <iostream>
+#include <algorithm>
 
-void ROOT::Experimental::RNTupleInspector::CollectSizeData()
+void ROOT::Experimental::RNTupleInspector::CollectNTupleData()
 {
-   fPageSource->Attach();
    auto descriptorGuard = fPageSource->GetSharedDescriptorGuard();
    int compressionSettings = -1;
    std::uint64_t compressedSize = 0;
@@ -52,17 +53,88 @@ void ROOT::Experimental::RNTupleInspector::CollectSizeData()
    fUncompressedSize = uncompressedSize;
 }
 
-ROOT::Experimental::RResult<std::unique_ptr<ROOT::Experimental::RNTupleInspector>>
+void ROOT::Experimental::RNTupleInspector::CollectColumnData()
+{
+   auto descriptorGuard = fPageSource->GetSharedDescriptorGuard();
+
+   for (DescriptorId_t colId = 0; colId < descriptorGuard->GetNPhysicalColumns(); ++colId) {
+      const ROOT::Experimental::RColumnDescriptor &colDescriptor = descriptorGuard->GetColumnDescriptor(colId);
+
+      RColumnInfo info;
+      info.fPhysicalColumnId = colId;
+      info.fLogicalColumnId = colDescriptor.GetLogicalId();
+      info.fFieldId = colDescriptor.GetFieldId();
+      info.fIndex = colDescriptor.GetIndex();
+      info.fType = colDescriptor.GetModel().GetType();
+
+      // We generate the default memory representation for the given column type in order
+      // to report the size _in memory_ of column elements.
+      uint64_t elemSize =
+         ROOT::Experimental::Detail::RColumnElementBase::Generate(colDescriptor.GetModel().GetType())->GetSize();
+      info.fElementSize = elemSize;
+
+      for (const auto &clusterDescriptor : descriptorGuard->GetClusterIterable()) {
+         auto columnRange = clusterDescriptor.GetColumnRange(colId);
+         info.fNElements += columnRange.fNElements;
+
+         const auto &pageRange = clusterDescriptor.GetPageRange(colId);
+
+         for (const auto &page : pageRange.fPageInfos) {
+            info.fCompressedSize += page.fLocator.fBytesOnStorage;
+            info.fUncompressedSize += page.fNElements * elemSize;
+         }
+      }
+
+      fColumnInfo.emplace_back(info);
+   }
+}
+
+std::vector<ROOT::Experimental::DescriptorId_t>
+ROOT::Experimental::RNTupleInspector::GetColumnsForField(ROOT::Experimental::DescriptorId_t fieldId)
+{
+   auto descriptorGuard = fPageSource->GetSharedDescriptorGuard();
+
+   const RFieldDescriptor &fieldDescriptor = descriptorGuard->GetFieldDescriptor(fieldId);
+   std::vector<ROOT::Experimental::DescriptorId_t> colIds;
+
+   switch (fieldDescriptor.GetStructure()) {
+   case kLeaf:
+      for (const auto &col : descriptorGuard->GetColumnIterable(fieldDescriptor)) {
+         colIds.emplace_back(col.GetPhysicalId());
+      }
+      break;
+   case kCollection:
+      for (const auto &col : descriptorGuard->GetColumnIterable(fieldDescriptor)) {
+         colIds.emplace_back(col.GetPhysicalId());
+      }
+   case kRecord:
+      for (const auto &fld : descriptorGuard->GetFieldIterable(fieldId)) {
+         auto rColIds = GetColumnsForField(fld.GetId());
+         colIds.insert(colIds.end(), rColIds.begin(), rColIds.end());
+      }
+      break;
+   default:
+      // TODO fdegeus
+      std::cerr << "structure type " << fieldDescriptor.GetStructure() << " not supported yet" << std::endl;
+   }
+
+   return colIds;
+}
+
+//------------------------------------------------------------------------------
+
+std::unique_ptr<ROOT::Experimental::RNTupleInspector>
 ROOT::Experimental::RNTupleInspector::Create(std::unique_ptr<ROOT::Experimental::Detail::RPageSource> pageSource)
 {
    auto inspector = std::unique_ptr<RNTupleInspector>(new RNTupleInspector(std::move(pageSource)));
 
-   inspector->CollectSizeData();
+   // TODO Memoize instead of calling everything in the constructor?
+   inspector->CollectNTupleData();
 
    return inspector;
 }
 
-ROOT::Experimental::RResult<std::unique_ptr<ROOT::Experimental::RNTupleInspector>>
+std::unique_ptr<ROOT::Experimental::RNTupleInspector>
 ROOT::Experimental::RNTupleInspector::Create(ROOT::Experimental::RNTuple *sourceNTuple)
 {
    std::unique_ptr<ROOT::Experimental::Detail::RPageSource> pageSource = sourceNTuple->MakePageSource();
@@ -72,7 +144,6 @@ ROOT::Experimental::RNTupleInspector::Create(ROOT::Experimental::RNTuple *source
 
 std::string ROOT::Experimental::RNTupleInspector::GetName()
 {
-   fPageSource->Attach();
    auto descriptorGuard = fPageSource->GetSharedDescriptorGuard();
    return descriptorGuard->GetName();
 }
@@ -102,4 +173,133 @@ std::uint64_t ROOT::Experimental::RNTupleInspector::GetUncompressedSize()
 float ROOT::Experimental::RNTupleInspector::GetCompressionFactor()
 {
    return (float)fUncompressedSize / (float)fCompressedSize;
+}
+
+int ROOT::Experimental::RNTupleInspector::GetFieldTypeFrequency(std::string className)
+{
+   if (fFieldTypeFrequencies.empty()) {
+      auto descriptorGuard = fPageSource->GetSharedDescriptorGuard();
+
+      for (const auto &fieldDescriptor : descriptorGuard->GetTopLevelFields()) {
+         fFieldTypeFrequencies[fieldDescriptor.GetTypeName()]++;
+      }
+   }
+
+   return fFieldTypeFrequencies[className];
+}
+
+int ROOT::Experimental::RNTupleInspector::GetColumnTypeFrequency(ROOT::Experimental::EColumnType colType)
+{
+   if (fColumnInfo.empty()) {
+      CollectColumnData();
+   }
+
+   int typeFrequency = 0;
+
+   for (auto const &colInfo : fColumnInfo) {
+      if (colInfo.fType == colType) {
+         ++typeFrequency;
+      }
+   }
+
+   return typeFrequency;
+}
+
+std::uint64_t
+ROOT::Experimental::RNTupleInspector::GetCompressedColumnSize(ROOT::Experimental::DescriptorId_t logicalId)
+{
+   if (fColumnInfo.empty()) {
+      CollectColumnData();
+   }
+
+   auto descriptorGuard = fPageSource->GetSharedDescriptorGuard();
+
+   if (logicalId > descriptorGuard->GetNLogicalColumns()) {
+      std::cerr << "no column with id " << logicalId << " present" << std::endl;
+      return -1;
+   }
+
+   ROOT::Experimental::DescriptorId_t physicalId = descriptorGuard->GetColumnDescriptor(logicalId).GetPhysicalId();
+
+   return fColumnInfo.at(physicalId).fCompressedSize;
+}
+
+std::uint64_t
+ROOT::Experimental::RNTupleInspector::GetUncompressedColumnSize(ROOT::Experimental::DescriptorId_t logicalId)
+{
+   if (fColumnInfo.empty()) {
+      CollectColumnData();
+   }
+
+   auto descriptorGuard = fPageSource->GetSharedDescriptorGuard();
+
+   if (logicalId > descriptorGuard->GetNLogicalColumns()) {
+      std::cerr << "no column with id " << logicalId << " present" << std::endl;
+      return -1;
+   }
+
+   ROOT::Experimental::DescriptorId_t physicalId = descriptorGuard->GetColumnDescriptor(logicalId).GetPhysicalId();
+   return fColumnInfo.at(physicalId).fUncompressedSize;
+}
+
+std::uint64_t ROOT::Experimental::RNTupleInspector::GetCompressedFieldSize(ROOT::Experimental::DescriptorId_t fieldId)
+{
+   std::uint64_t fieldSize = 0;
+
+   for (const auto colId : GetColumnsForField(fieldId)) {
+      fieldSize += GetCompressedColumnSize(colId);
+   }
+
+   return fieldSize;
+}
+
+std::uint64_t ROOT::Experimental::RNTupleInspector::GetCompressedFieldSize(std::string fieldName)
+{
+   auto descriptorGuard = fPageSource->GetSharedDescriptorGuard();
+
+   ROOT::Experimental::DescriptorId_t fieldId = descriptorGuard->FindFieldId(fieldName);
+
+   if (fieldId == kInvalidDescriptorId) {
+      std::cerr << "could not find field \"" + fieldName + "\"." << std::endl;
+      return -1;
+   }
+
+   return GetCompressedFieldSize(fieldId);
+}
+
+std::uint64_t ROOT::Experimental::RNTupleInspector::GetUncompressedFieldSize(ROOT::Experimental::DescriptorId_t fieldId)
+{
+   std::uint64_t fieldSize = 0;
+
+   for (const auto colId : GetColumnsForField(fieldId)) {
+      fieldSize += GetUncompressedColumnSize(colId);
+   }
+
+   return fieldSize;
+}
+
+std::uint64_t ROOT::Experimental::RNTupleInspector::GetUncompressedFieldSize(std::string fieldName)
+{
+   auto descriptorGuard = fPageSource->GetSharedDescriptorGuard();
+
+   ROOT::Experimental::DescriptorId_t fieldId = descriptorGuard->FindFieldId(fieldName);
+
+   if (fieldId == kInvalidDescriptorId) {
+      std::cerr << "could not find field \"" + fieldName + "\"." << std::endl;
+      return -1;
+   }
+
+   return GetUncompressedFieldSize(fieldId);
+}
+
+ROOT::Experimental::EColumnType
+ROOT::Experimental::RNTupleInspector::GetColumnType(ROOT::Experimental::DescriptorId_t logicalId)
+{
+   if (fColumnInfo.empty()) {
+      CollectColumnData();
+   }
+
+   auto descriptorGuard = fPageSource->GetSharedDescriptorGuard();
+
+   return descriptorGuard->GetColumnDescriptor(logicalId).GetModel().GetType();
 }

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -160,12 +160,12 @@ int ROOT::Experimental::RNTupleInspector::GetCompressionSettings()
    return fCompressionSettings;
 }
 
-std::uint64_t ROOT::Experimental::RNTupleInspector::GetCompressedSize()
+std::uint64_t ROOT::Experimental::RNTupleInspector::GetOnDiskSize()
 {
    return fCompressedSize;
 }
 
-std::uint64_t ROOT::Experimental::RNTupleInspector::GetUncompressedSize()
+std::uint64_t ROOT::Experimental::RNTupleInspector::GetInMemorySize()
 {
    return fUncompressedSize;
 }
@@ -205,8 +205,7 @@ int ROOT::Experimental::RNTupleInspector::GetColumnTypeFrequency(ROOT::Experimen
    return typeFrequency;
 }
 
-std::uint64_t
-ROOT::Experimental::RNTupleInspector::GetCompressedColumnSize(ROOT::Experimental::DescriptorId_t logicalId)
+std::uint64_t ROOT::Experimental::RNTupleInspector::GetOnDiskColumnSize(ROOT::Experimental::DescriptorId_t logicalId)
 {
    if (fColumnInfo.empty()) {
       CollectColumnData();
@@ -224,8 +223,7 @@ ROOT::Experimental::RNTupleInspector::GetCompressedColumnSize(ROOT::Experimental
    return fColumnInfo.at(physicalId).fCompressedSize;
 }
 
-std::uint64_t
-ROOT::Experimental::RNTupleInspector::GetUncompressedColumnSize(ROOT::Experimental::DescriptorId_t logicalId)
+std::uint64_t ROOT::Experimental::RNTupleInspector::GetInMemoryColumnSize(ROOT::Experimental::DescriptorId_t logicalId)
 {
    if (fColumnInfo.empty()) {
       CollectColumnData();
@@ -242,18 +240,18 @@ ROOT::Experimental::RNTupleInspector::GetUncompressedColumnSize(ROOT::Experiment
    return fColumnInfo.at(physicalId).fUncompressedSize;
 }
 
-std::uint64_t ROOT::Experimental::RNTupleInspector::GetCompressedFieldSize(ROOT::Experimental::DescriptorId_t fieldId)
+std::uint64_t ROOT::Experimental::RNTupleInspector::GetOnDiskFieldSize(ROOT::Experimental::DescriptorId_t fieldId)
 {
    std::uint64_t fieldSize = 0;
 
    for (const auto colId : GetColumnsForField(fieldId)) {
-      fieldSize += GetCompressedColumnSize(colId);
+      fieldSize += GetOnDiskColumnSize(colId);
    }
 
    return fieldSize;
 }
 
-std::uint64_t ROOT::Experimental::RNTupleInspector::GetCompressedFieldSize(std::string fieldName)
+std::uint64_t ROOT::Experimental::RNTupleInspector::GetOnDiskFieldSize(std::string fieldName)
 {
    auto descriptorGuard = fPageSource->GetSharedDescriptorGuard();
 
@@ -264,21 +262,21 @@ std::uint64_t ROOT::Experimental::RNTupleInspector::GetCompressedFieldSize(std::
       return -1;
    }
 
-   return GetCompressedFieldSize(fieldId);
+   return GetOnDiskFieldSize(fieldId);
 }
 
-std::uint64_t ROOT::Experimental::RNTupleInspector::GetUncompressedFieldSize(ROOT::Experimental::DescriptorId_t fieldId)
+std::uint64_t ROOT::Experimental::RNTupleInspector::GetInMemoryFieldSize(ROOT::Experimental::DescriptorId_t fieldId)
 {
    std::uint64_t fieldSize = 0;
 
    for (const auto colId : GetColumnsForField(fieldId)) {
-      fieldSize += GetUncompressedColumnSize(colId);
+      fieldSize += GetInMemoryColumnSize(colId);
    }
 
    return fieldSize;
 }
 
-std::uint64_t ROOT::Experimental::RNTupleInspector::GetUncompressedFieldSize(std::string fieldName)
+std::uint64_t ROOT::Experimental::RNTupleInspector::GetInMemoryFieldSize(std::string fieldName)
 {
    auto descriptorGuard = fPageSource->GetSharedDescriptorGuard();
 
@@ -289,7 +287,7 @@ std::uint64_t ROOT::Experimental::RNTupleInspector::GetUncompressedFieldSize(std
       return -1;
    }
 
-   return GetUncompressedFieldSize(fieldId);
+   return GetInMemoryFieldSize(fieldId);
 }
 
 ROOT::Experimental::EColumnType

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -93,11 +93,11 @@ TEST(RNTupleInspector, SizeUncompressedSimple)
    auto ntuple = file->Get<RNTuple>("ntuple");
    auto inspector = RNTupleInspector::Create(ntuple);
 
-   EXPECT_EQ(sizeof(int32_t) * 5, inspector->GetUncompressedSize());
+   EXPECT_EQ(sizeof(int32_t) * 5, inspector->GetInMemorySize());
 
    // N.B. This property only holds for ntuples without Index fields, due to
    // the 64-bit in-memory vs. 32-bit on-disk optimization.
-   EXPECT_EQ(inspector->GetCompressedSize(), inspector->GetUncompressedSize());
+   EXPECT_EQ(inspector->GetOnDiskSize(), inspector->GetInMemorySize());
 }
 
 TEST(RNTupleInspector, SizeUncompressedComplex)
@@ -131,7 +131,7 @@ TEST(RNTupleInspector, SizeUncompressedComplex)
 
    // We need to add another 4 bytes per index column per event, due to the 64-bit
    // in-memory vs. 32-bit on-disk optimization.
-   EXPECT_EQ(inspector->GetCompressedSize() + 4 * nIndexCols * nEntries, inspector->GetUncompressedSize());
+   EXPECT_EQ(inspector->GetOnDiskSize() + 4 * nIndexCols * nEntries, inspector->GetInMemorySize());
 }
 
 TEST(RNTupleInspector, SizeCompressedInt)
@@ -155,9 +155,9 @@ TEST(RNTupleInspector, SizeCompressedInt)
    auto ntuple = file->Get<RNTuple>("ntuple");
    auto inspector = RNTupleInspector::Create(ntuple);
 
-   EXPECT_EQ(sizeof(int32_t) * 50, inspector->GetUncompressedSize());
-   EXPECT_GT(inspector->GetCompressedSize(), 0);
-   EXPECT_LT(inspector->GetCompressedSize(), inspector->GetUncompressedSize());
+   EXPECT_EQ(sizeof(int32_t) * 50, inspector->GetInMemorySize());
+   EXPECT_GT(inspector->GetOnDiskSize(), 0);
+   EXPECT_LT(inspector->GetOnDiskSize(), inspector->GetInMemorySize());
    EXPECT_GT(inspector->GetCompressionFactor(), 1);
 }
 
@@ -184,8 +184,8 @@ TEST(RNTupleInspector, SizeCompressedComplex)
    auto ntuple = file->Get<RNTuple>("ntuple");
    auto inspector = RNTupleInspector::Create(ntuple);
 
-   EXPECT_GT(inspector->GetCompressedSize(), 0);
-   EXPECT_LT(inspector->GetCompressedSize(), inspector->GetUncompressedSize());
+   EXPECT_GT(inspector->GetOnDiskSize(), 0);
+   EXPECT_LT(inspector->GetOnDiskSize(), inspector->GetInMemorySize());
    EXPECT_GT(inspector->GetCompressionFactor(), 1);
 }
 
@@ -201,8 +201,8 @@ TEST(RNTupleInspector, SizeEmpty)
    auto ntuple = file->Get<RNTuple>("ntuple");
    auto inspector = RNTupleInspector::Create(ntuple);
 
-   EXPECT_EQ(0, inspector->GetCompressedSize());
-   EXPECT_EQ(0, inspector->GetUncompressedSize());
+   EXPECT_EQ(0, inspector->GetOnDiskSize());
+   EXPECT_EQ(0, inspector->GetInMemorySize());
 }
 
 TEST(RNTupleInspector, FieldTypeFrequency)
@@ -280,13 +280,13 @@ TEST(RNTupleInspector, ColumnSize)
    auto reader = RNTupleReader::Open(ntuple);
 
    for (std::size_t i = 0; i < reader->GetDescriptor()->GetNLogicalColumns(); ++i) {
-      EXPECT_GT(inspector->GetCompressedColumnSize(i), 0);
-      EXPECT_GT(inspector->GetUncompressedColumnSize(i), 0);
-      EXPECT_LT(inspector->GetCompressedColumnSize(i), inspector->GetUncompressedColumnSize(i));
+      EXPECT_GT(inspector->GetOnDiskColumnSize(i), 0);
+      EXPECT_GT(inspector->GetInMemoryColumnSize(i), 0);
+      EXPECT_LT(inspector->GetOnDiskColumnSize(i), inspector->GetInMemoryColumnSize(i));
    }
 
-   EXPECT_EQ(inspector->GetCompressedColumnSize(-42), -1);
-   EXPECT_EQ(inspector->GetUncompressedColumnSize(-42), -1);
+   EXPECT_EQ(inspector->GetOnDiskColumnSize(-42), -1);
+   EXPECT_EQ(inspector->GetInMemoryColumnSize(-42), -1);
 }
 
 TEST(RNTupleInspector, FieldSize)
@@ -314,12 +314,12 @@ TEST(RNTupleInspector, FieldSize)
    auto ntuple = file->Get<RNTuple>("ntuple");
    auto inspector = RNTupleInspector::Create(ntuple);
 
-   EXPECT_GT(inspector->GetCompressedFieldSize("object"), 0);
-   EXPECT_EQ(inspector->GetUncompressedFieldSize("object"), inspector->GetUncompressedSize());
-   EXPECT_LT(inspector->GetCompressedFieldSize("object"), inspector->GetUncompressedFieldSize("object"));
+   EXPECT_GT(inspector->GetOnDiskFieldSize("object"), 0);
+   EXPECT_EQ(inspector->GetInMemoryFieldSize("object"), inspector->GetInMemorySize());
+   EXPECT_LT(inspector->GetOnDiskFieldSize("object"), inspector->GetInMemoryFieldSize("object"));
 
-   EXPECT_EQ(inspector->GetCompressedFieldSize("invalid_field"), -1);
-   EXPECT_EQ(inspector->GetUncompressedFieldSize("invalid_field"), -1);
+   EXPECT_EQ(inspector->GetOnDiskFieldSize("invalid_field"), -1);
+   EXPECT_EQ(inspector->GetInMemoryFieldSize("invalid_field"), -1);
 }
 
 TEST(RNTupleInspector, ColumnType)

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -3,6 +3,7 @@
 
 #include <TFile.h>
 
+#include "CustomStructUtil.hxx"
 #include "ntupleutil_test.hxx"
 
 using ROOT::Experimental::RNTuple;
@@ -22,7 +23,7 @@ TEST(RNTupleInspector, Name)
 
    std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
    auto ntuple = file->Get<RNTuple>("ntuple");
-   auto inspector = RNTupleInspector::Create(ntuple).Unwrap();
+   auto inspector = RNTupleInspector::Create(ntuple);
 
    EXPECT_EQ("ntuple", inspector->GetName());
 }
@@ -44,17 +45,17 @@ TEST(RNTupleInspector, NEntries)
 
    std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
    auto ntuple = file->Get<RNTuple>("ntuple");
-   auto inspector = RNTupleInspector::Create(ntuple).Unwrap();
+   auto inspector = RNTupleInspector::Create(ntuple);
 
    EXPECT_EQ(inspector->GetNEntries(), 50);
 }
 
 TEST(RNTupleInspector, CompressionSettings)
 {
-   FileRaii fileGuard("test_ntuple_inspector_size_single_int_field.root");
+   FileRaii fileGuard("test_ntuple_inspector_compression_settings.root");
    {
       auto model = RNTupleModel::Create();
-      auto nFldInt = model->MakeField<std::int32_t>("i");
+      auto nFldInt = model->MakeField<std::int32_t>("int");
 
       auto writeOptions = RNTupleWriteOptions();
       writeOptions.SetCompression(505);
@@ -66,40 +67,79 @@ TEST(RNTupleInspector, CompressionSettings)
 
    std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
    auto ntuple = file->Get<RNTuple>("ntuple");
-   auto inspector = RNTupleInspector::Create(ntuple).Unwrap();
+   auto inspector = RNTupleInspector::Create(ntuple);
 
    EXPECT_EQ(505, inspector->GetCompressionSettings());
 }
 
-TEST(RNTupleInspector, SizeUncompressed)
+TEST(RNTupleInspector, SizeUncompressedSimple)
 {
-   FileRaii fileGuard("test_ntuple_inspector_size_uncompressed.root");
+   FileRaii fileGuard("test_ntuple_inspector_size_uncompressed_complex.root");
    {
       auto model = RNTupleModel::Create();
-      auto nFldInt = model->MakeField<std::int32_t>("i");
+      auto nFldInt = model->MakeField<std::int32_t>("int");
 
       auto writeOptions = RNTupleWriteOptions();
       writeOptions.SetCompression(0);
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
 
-      *nFldInt = 42;
+      for (int i = 0; i < 5; i++) {
+         *nFldInt = 1;
+         ntuple->Fill();
+      }
+   }
+
+   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
+   auto ntuple = file->Get<RNTuple>("ntuple");
+   auto inspector = RNTupleInspector::Create(ntuple);
+
+   EXPECT_EQ(sizeof(int32_t) * 5, inspector->GetUncompressedSize());
+
+   // N.B. This property only holds for ntuples without Index fields, due to
+   // the 64-bit in-memory vs. 32-bit on-disk optimization.
+   EXPECT_EQ(inspector->GetCompressedSize(), inspector->GetUncompressedSize());
+}
+
+TEST(RNTupleInspector, SizeUncompressedComplex)
+{
+   FileRaii fileGuard("test_ntuple_inspector_size_uncompressed_complex.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto nFldObject = model->MakeField<ComplexStructUtil>("object");
+
+      auto writeOptions = RNTupleWriteOptions();
+      writeOptions.SetCompression(0);
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
+
+      nFldObject->Init1();
+      ntuple->Fill();
+      nFldObject->Init2();
+      ntuple->Fill();
+      nFldObject->Init3();
       ntuple->Fill();
    }
 
    std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
    auto ntuple = file->Get<RNTuple>("ntuple");
-   auto inspector = RNTupleInspector::Create(ntuple).Unwrap();
+   auto inspector = RNTupleInspector::Create(ntuple);
 
-   EXPECT_EQ(sizeof(int32_t), inspector->GetUncompressedSize());
-   EXPECT_EQ(inspector->GetCompressedSize(), inspector->GetUncompressedSize());
+   int nIndexCols = inspector->GetColumnTypeFrequency(ROOT::Experimental::EColumnType::kIndex32);
+   int nEntries = inspector->GetNEntries();
+
+   EXPECT_EQ(2, nIndexCols);
+   EXPECT_EQ(3, nEntries);
+
+   // We need to add another 4 bytes per index column per event, due to the 64-bit
+   // in-memory vs. 32-bit on-disk optimization.
+   EXPECT_EQ(inspector->GetCompressedSize() + 4 * nIndexCols * nEntries, inspector->GetUncompressedSize());
 }
 
-TEST(RNTupleInspector, SizeCompressed)
+TEST(RNTupleInspector, SizeCompressedInt)
 {
-   FileRaii fileGuard("test_ntuple_inspector_size_uncompressed.root");
+   FileRaii fileGuard("test_ntuple_inspector_size_compressed_int.root");
    {
       auto model = RNTupleModel::Create();
-      auto nFldInt = model->MakeField<std::int32_t>("i");
+      auto nFldInt = model->MakeField<std::int32_t>("int");
 
       auto writeOptions = RNTupleWriteOptions();
       writeOptions.SetCompression(505);
@@ -113,9 +153,40 @@ TEST(RNTupleInspector, SizeCompressed)
 
    std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
    auto ntuple = file->Get<RNTuple>("ntuple");
-   auto inspector = RNTupleInspector::Create(ntuple).Unwrap();
+   auto inspector = RNTupleInspector::Create(ntuple);
 
-   EXPECT_NE(inspector->GetCompressedSize(), inspector->GetUncompressedSize());
+   EXPECT_EQ(sizeof(int32_t) * 50, inspector->GetUncompressedSize());
+   EXPECT_GT(inspector->GetCompressedSize(), 0);
+   EXPECT_LT(inspector->GetCompressedSize(), inspector->GetUncompressedSize());
+   EXPECT_GT(inspector->GetCompressionFactor(), 1);
+}
+
+TEST(RNTupleInspector, SizeCompressedComplex)
+{
+   FileRaii fileGuard("test_ntuple_inspector_size_compressed_complex.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto nFldObject = model->MakeField<ComplexStructUtil>("object");
+
+      auto writeOptions = RNTupleWriteOptions();
+      writeOptions.SetCompression(505);
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
+
+      nFldObject->Init1();
+      ntuple->Fill();
+      nFldObject->Init2();
+      ntuple->Fill();
+      nFldObject->Init3();
+      ntuple->Fill();
+   }
+
+   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
+   auto ntuple = file->Get<RNTuple>("ntuple");
+   auto inspector = RNTupleInspector::Create(ntuple);
+
+   EXPECT_GT(inspector->GetCompressedSize(), 0);
+   EXPECT_LT(inspector->GetCompressedSize(), inspector->GetUncompressedSize());
+   EXPECT_GT(inspector->GetCompressionFactor(), 1);
 }
 
 TEST(RNTupleInspector, SizeEmpty)
@@ -128,34 +199,146 @@ TEST(RNTupleInspector, SizeEmpty)
 
    std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
    auto ntuple = file->Get<RNTuple>("ntuple");
-   auto inspector = RNTupleInspector::Create(ntuple).Unwrap();
+   auto inspector = RNTupleInspector::Create(ntuple);
 
    EXPECT_EQ(0, inspector->GetCompressedSize());
    EXPECT_EQ(0, inspector->GetUncompressedSize());
 }
 
-TEST(RNTupleInspector, SingleIntFieldCompression)
+TEST(RNTupleInspector, FieldTypeFrequency)
 {
-   FileRaii fileGuard("test_ntuple_inspector_size_single_int_field.root");
+   FileRaii fileGuard("test_ntuple_inspector_field_type_frequency.root");
    {
       auto model = RNTupleModel::Create();
-      auto nFldInt = model->MakeField<std::int32_t>("i");
+      auto nFldObject = model->MakeField<ComplexStructUtil>("object");
+      auto nFldInt1 = model->MakeField<std::int32_t>("int1");
+      auto nFldInt2 = model->MakeField<std::int32_t>("int2");
+      auto nFldInt3 = model->MakeField<std::int32_t>("int3");
+      auto nFldString1 = model->MakeField<std::string>("string1");
+      auto nFldString2 = model->MakeField<std::string>("string2");
+
+      auto writeOptions = RNTupleWriteOptions();
+      writeOptions.SetCompression(505);
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
+   }
+
+   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
+   auto ntuple = file->Get<RNTuple>("ntuple");
+   auto inspector = RNTupleInspector::Create(ntuple);
+
+   EXPECT_EQ(3, inspector->GetFieldTypeFrequency("std::int32_t"));
+   EXPECT_EQ(2, inspector->GetFieldTypeFrequency("std::string"));
+   EXPECT_EQ(1, inspector->GetFieldTypeFrequency("ComplexStructUtil"));
+   EXPECT_EQ(0, inspector->GetFieldTypeFrequency("std::vector<float>"));
+}
+
+TEST(RNTupleInspector, ColumnTypeFrequency)
+{
+   FileRaii fileGuard("test_ntuple_inspector_column_type_frequency.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto nFldObject = model->MakeField<ComplexStructUtil>("object");
+
+      auto writeOptions = RNTupleWriteOptions();
+      writeOptions.SetCompression(505);
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
+   }
+
+   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
+   auto ntuple = file->Get<RNTuple>("ntuple");
+   auto inspector = RNTupleInspector::Create(ntuple);
+
+   EXPECT_EQ(2, inspector->GetColumnTypeFrequency(ROOT::Experimental::EColumnType::kIndex32));
+   EXPECT_EQ(4, inspector->GetColumnTypeFrequency(ROOT::Experimental::EColumnType::kSplitReal32));
+   EXPECT_EQ(3, inspector->GetColumnTypeFrequency(ROOT::Experimental::EColumnType::kSplitInt32));
+}
+
+TEST(RNTupleInspector, ColumnSize)
+{
+   FileRaii fileGuard("test_ntuple_inspector_column_size.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto nFldObject = model->MakeField<ComplexStructUtil>("object");
 
       auto writeOptions = RNTupleWriteOptions();
       writeOptions.SetCompression(505);
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
 
-      for (int32_t i = 0; i < 50; ++i) {
-         *nFldInt = i;
+      for (int i = 0; i < 25; ++i) {
+         nFldObject->Init1();
+         ntuple->Fill();
+         nFldObject->Init2();
+         ntuple->Fill();
+         nFldObject->Init3();
          ntuple->Fill();
       }
    }
 
    std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
    auto ntuple = file->Get<RNTuple>("ntuple");
-   auto inspector = RNTupleInspector::Create(ntuple).Unwrap();
+   auto inspector = RNTupleInspector::Create(ntuple);
+   auto reader = RNTupleReader::Open(ntuple);
 
-   EXPECT_LT(0, inspector->GetCompressedSize());
-   EXPECT_LT(inspector->GetCompressedSize(), inspector->GetUncompressedSize());
-   EXPECT_GT(inspector->GetCompressionFactor(), 1);
+   for (std::size_t i = 0; i < reader->GetDescriptor()->GetNLogicalColumns(); ++i) {
+      EXPECT_GT(inspector->GetCompressedColumnSize(i), 0);
+      EXPECT_GT(inspector->GetUncompressedColumnSize(i), 0);
+      EXPECT_LT(inspector->GetCompressedColumnSize(i), inspector->GetUncompressedColumnSize(i));
+   }
+
+   EXPECT_EQ(inspector->GetCompressedColumnSize(-42), -1);
+   EXPECT_EQ(inspector->GetUncompressedColumnSize(-42), -1);
+}
+
+TEST(RNTupleInspector, FieldSize)
+{
+   FileRaii fileGuard("test_ntuple_inspector_field_size.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto nFldObject = model->MakeField<ComplexStructUtil>("object");
+
+      auto writeOptions = RNTupleWriteOptions();
+      writeOptions.SetCompression(505);
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
+
+      for (int i = 0; i < 25; ++i) {
+         nFldObject->Init1();
+         ntuple->Fill();
+         nFldObject->Init2();
+         ntuple->Fill();
+         nFldObject->Init3();
+         ntuple->Fill();
+      }
+   }
+
+   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
+   auto ntuple = file->Get<RNTuple>("ntuple");
+   auto inspector = RNTupleInspector::Create(ntuple);
+
+   EXPECT_GT(inspector->GetCompressedFieldSize("object"), 0);
+   EXPECT_EQ(inspector->GetUncompressedFieldSize("object"), inspector->GetUncompressedSize());
+   EXPECT_LT(inspector->GetCompressedFieldSize("object"), inspector->GetUncompressedFieldSize("object"));
+
+   EXPECT_EQ(inspector->GetCompressedFieldSize("invalid_field"), -1);
+   EXPECT_EQ(inspector->GetUncompressedFieldSize("invalid_field"), -1);
+}
+
+TEST(RNTupleInspector, ColumnType)
+{
+   FileRaii fileGuard("test_ntuple_inspector_field_size.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto nFldObject = model->MakeField<ComplexStructUtil>("object");
+
+      auto writeOptions = RNTupleWriteOptions();
+      writeOptions.SetCompression(505);
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
+   }
+
+   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
+   auto ntuple = file->Get<RNTuple>("ntuple");
+   auto inspector = RNTupleInspector::Create(ntuple);
+
+   EXPECT_EQ(inspector->GetColumnType(0), ROOT::Experimental::EColumnType::kSplitReal32);
+   EXPECT_EQ(inspector->GetColumnType(1), ROOT::Experimental::EColumnType::kIndex32);
+   EXPECT_EQ(inspector->GetColumnType(2), ROOT::Experimental::EColumnType::kSplitInt32);
 }


### PR DESCRIPTION
This PR adds some (mostly size and compression-related) methods to the `RNTupleInspector` utility class. There are some small TODOs left, but I first wanted to collect some feedback.

- [x] tested changes locally
- [x] updated the docs (if necessary)
- [ ] add support for all field structures in `GetColumnsForField`
- [ ] decide on when to collect the (size) data: on creation of the `RNTupleInspector` object (how it is done now), or in a more on-the-fly approach


