### PR TITLE
[ntuple] Add column- and field-related RNTupleInspector functionality

### DIFF
--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -59,6 +59,7 @@ class RNTupleInspector {
 private:
    std::unique_ptr<TFile> fSourceFile;
    std::unique_ptr<ROOT::Experimental::Detail::RPageSource> fPageSource;
+   std::unique_ptr<ROOT::Experimental::RNTupleDescriptor> fDescriptor;
    int fCompressionSettings;
    std::uint64_t fCompressedSize;
    std::uint64_t fUncompressedSize;
@@ -80,6 +81,12 @@ public:
    Create(std::unique_ptr<ROOT::Experimental::Detail::RPageSource> pageSource);
    static RResult<std::unique_ptr<RNTupleInspector>> Create(RNTuple *sourceNTuple);
    static RResult<std::unique_ptr<RNTupleInspector>> Create(std::string_view ntupleName, std::string_view storage);
+
+   /// Get the descriptor for the RNTuple being inspected.
+   /// Not that this contains a static copy of the descriptor at the time of
+   /// creation of the inspector. This means that if the inspected RNTuple changes,
+   /// these changes will not be propagated to the RNTupleInspector object!
+   RNTupleDescriptor *GetDescriptor();
 
    /// Get the name of the RNTuple being inspected.
    std::string GetName();

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -63,23 +63,18 @@ public:
    private:
       const RColumnDescriptor &fColumnDescriptor;
       std::uint64_t fOnDiskSize = 0;
-      std::uint64_t fInMemorySize = 0;
       std::uint32_t fElementSize = 0;
       std::uint64_t fNElements = 0;
 
    public:
-      RColumnInfo(const RColumnDescriptor &colDesc, std::uint64_t onDiskSize, std::uint64_t inMemSize,
-                  std::uint32_t elemSize, std::uint64_t nElems)
-         : fColumnDescriptor(colDesc),
-           fOnDiskSize(onDiskSize),
-           fInMemorySize(inMemSize),
-           fElementSize(elemSize),
-           fNElements(nElems){};
+      RColumnInfo(const RColumnDescriptor &colDesc, std::uint64_t onDiskSize, std::uint32_t elemSize,
+                  std::uint64_t nElems)
+         : fColumnDescriptor(colDesc), fOnDiskSize(onDiskSize), fElementSize(elemSize), fNElements(nElems){};
       ~RColumnInfo() = default;
 
       const RColumnDescriptor &GetDescriptor() const { return fColumnDescriptor; }
       std::uint64_t GetOnDiskSize() const { return fOnDiskSize; }
-      std::uint64_t GetInMemorySize() const { return fInMemorySize; }
+      std::uint64_t GetInMemorySize() const { return fElementSize * fNElements; }
       std::uint64_t GetElementSize() const { return fElementSize; }
       std::uint64_t GetNElements() const { return fNElements; }
       EColumnType GetType() const { return fColumnDescriptor.GetModel().GetType(); }

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -66,7 +66,7 @@ private:
    RNTupleInspector(std::unique_ptr<ROOT::Experimental::Detail::RPageSource> pageSource)
       : fPageSource(std::move(pageSource)){};
 
-   void CollectSizeData();
+   std::vector<DescriptorId_t> GetColumnsForField(DescriptorId_t fieldId);
 
 public:
    RNTupleInspector(const RNTupleInspector &other) = delete;
@@ -100,6 +100,29 @@ public:
 
    /// Get the compression factor of the RNTuple being inspected.
    float GetCompressionFactor();
+
+   /// Get the amount of fields of a given type or class present in the RNTuple.
+   int GetFieldTypeFrequency(std::string className);
+
+   /// Get the amount of columns of a given type present in the RNTuple.
+   int GetColumnTypeFrequency(EColumnType colType);
+
+   /// Get the on-disk, compressed size of a given column.
+   std::uint64_t GetCompressedColumnSize(DescriptorId_t logicalId);
+
+   /// Get the total, uncompressed size of a given column.
+   std::uint64_t GetUncompressedColumnSize(DescriptorId_t logicalId);
+
+   /// Get the on-disk, compressed size of a given field.
+   std::uint64_t GetCompressedFieldSize(DescriptorId_t fieldId);
+   std::uint64_t GetCompressedFieldSize(std::string fieldName);
+
+   /// Get the total, uncompressed size of a given field.
+   std::uint64_t GetUncompressedFieldSize(DescriptorId_t fieldId);
+   std::uint64_t GetUncompressedFieldSize(std::string fieldName);
+
+   /// Get the type of a given column.
+   EColumnType GetColumnType(DescriptorId_t logicalId);
 };
 } // namespace Experimental
 } // namespace ROOT

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -59,42 +59,45 @@ std::cout << "The compression factor is " << std::fixed << std::setprecision(2)
 class RNTupleInspector {
 public:
    class RColumnInfo {
-      friend class RNTupleInspector;
-
    private:
-      const RColumnDescriptor *fColumnDescriptor;
+      const RColumnDescriptor &fColumnDescriptor;
       std::uint64_t fOnDiskSize = 0;
       std::uint64_t fInMemorySize = 0;
       std::uint32_t fElementSize = 0;
       std::uint64_t fNElements = 0;
 
    public:
-      RColumnInfo() = default;
+      RColumnInfo(const RColumnDescriptor &colDesc, std::uint64_t onDiskSize, std::uint64_t inMemSize,
+                  std::uint32_t elemSize, std::uint64_t nElems)
+         : fColumnDescriptor(colDesc),
+           fOnDiskSize(onDiskSize),
+           fInMemorySize(inMemSize),
+           fElementSize(elemSize),
+           fNElements(nElems){};
       ~RColumnInfo() = default;
 
-      const RColumnDescriptor *GetDescriptor();
-      std::uint64_t GetOnDiskSize();
-      std::uint64_t GetInMemorySize();
-      std::uint64_t GetElementSize();
-      std::uint64_t GetNElements();
-      EColumnType GetType();
+      const RColumnDescriptor &GetDescriptor() { return fColumnDescriptor; }
+      std::uint64_t GetOnDiskSize() { return fOnDiskSize; }
+      std::uint64_t GetInMemorySize() { return fInMemorySize; }
+      std::uint64_t GetElementSize() { return fElementSize; }
+      std::uint64_t GetNElements() { return fNElements; }
+      EColumnType GetType() { return fColumnDescriptor.GetModel().GetType(); }
    };
 
    class RFieldInfo {
-      friend class RNTupleInspector;
-
    private:
-      const RFieldDescriptor *fFieldDescriptor;
+      const RFieldDescriptor &fFieldDescriptor;
       std::uint64_t fOnDiskSize = 0;
       std::uint64_t fInMemorySize = 0;
 
    public:
-      RFieldInfo() = default;
+      RFieldInfo(const RFieldDescriptor &fieldDesc, std::uint64_t onDiskSize, std::uint64_t inMemSize)
+         : fFieldDescriptor(fieldDesc), fOnDiskSize(onDiskSize), fInMemorySize(inMemSize){};
       ~RFieldInfo() = default;
 
-      const RFieldDescriptor *GetDescriptor();
-      std::uint64_t GetOnDiskSize();
-      std::uint64_t GetInMemorySize();
+      const RFieldDescriptor &GetDescriptor() { return fFieldDescriptor; }
+      std::uint64_t GetOnDiskSize() { return fOnDiskSize; }
+      std::uint64_t GetInMemorySize() { return fInMemorySize; }
    };
 
 private:
@@ -139,9 +142,6 @@ public:
    static std::unique_ptr<RNTupleInspector> Create(std::string_view ntupleName, std::string_view storage);
 
    /// Get the descriptor for the RNTuple being inspected.
-   /// Not that this contains a static copy of the descriptor at the time of
-   /// creation of the inspector. This means that if the inspected RNTuple changes,
-   /// these changes will not be propagated to the RNTupleInspector object!
    RNTupleDescriptor *GetDescriptor();
 
    /// Get the compression settings of the RNTuple being inspected.
@@ -158,13 +158,14 @@ public:
    /// Get the compression factor of the RNTuple being inspected.
    float GetCompressionFactor();
 
-   RColumnInfo GetColumnInfo(DescriptorId_t physicalColumnId);
+   const RColumnInfo &GetColumnInfo(DescriptorId_t physicalColumnId);
 
-   RFieldInfo GetFieldInfo(DescriptorId_t fieldId);
-   RFieldInfo GetFieldInfo(const std::string fieldName);
+   const RFieldInfo &GetFieldInfo(DescriptorId_t fieldId);
+   const RFieldInfo &GetFieldInfo(std::string_view fieldName);
 
    /// Get the number of fields of a given type or class present in the RNTuple.
-   int GetFieldTypeCount(const std::string typeName, bool includeSubFields = true);
+   /// TODO: Add regex support.
+   int GetFieldTypeCount(std::string_view typeName, bool includeSubFields = true);
 
    /// Get the number of columns of a given type present in the RNTuple.
    int GetColumnTypeCount(EColumnType colType);

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -142,21 +142,21 @@ public:
    static std::unique_ptr<RNTupleInspector> Create(std::string_view ntupleName, std::string_view storage);
 
    /// Get the descriptor for the RNTuple being inspected.
-   RNTupleDescriptor *GetDescriptor();
+   RNTupleDescriptor *GetDescriptor() { return fDescriptor.get(); }
 
    /// Get the compression settings of the RNTuple being inspected.
-   int GetCompressionSettings();
+   int GetCompressionSettings() { return fCompressionSettings; }
 
    /// Get the on-disk, compressed size of the RNTuple being inspected, in bytes.
    /// Does **not** include the size of the header and footer.
-   std::uint64_t GetOnDiskSize();
+   std::uint64_t GetOnDiskSize() { return fOnDiskSize; }
 
    /// Get the total, in-memory size of the RNTuple being inspected, in bytes.
    /// Does **not** include the size of the header and footer.
-   std::uint64_t GetInMemorySize();
+   std::uint64_t GetInMemorySize() { return fInMemorySize; }
 
    /// Get the compression factor of the RNTuple being inspected.
-   float GetCompressionFactor();
+   float GetCompressionFactor() { return (float)fInMemorySize / (float)fOnDiskSize; }
 
    const RColumnInfo &GetColumnInfo(DescriptorId_t physicalColumnId);
 

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -120,7 +120,7 @@ private:
    /// Recursively gather field-level information and store it in `fFieldTreeInfo`.
    ///
    /// This method is called when the `RNTupleInspector` is initially created.
-   RFieldTreeInfo CollectFieldInfo(DescriptorId_t fieldId);
+   RFieldTreeInfo CollectFieldTreeInfo(DescriptorId_t fieldId);
 
    /// Get the IDs of the columns that make up the given field, including its sub-fields.
    std::vector<DescriptorId_t> GetColumnsForFieldTree(DescriptorId_t fieldId) const;

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -106,7 +106,7 @@ private:
    std::uint64_t fInMemorySize = 0;
 
    std::map<int, RColumnInfo> fColumnInfo;
-   std::map<int, RFieldTreeInfo> fFieldInfo;
+   std::map<int, RFieldTreeInfo> fFieldTreeInfo;
 
    RNTupleInspector(std::unique_ptr<Detail::RPageSource> pageSource);
 
@@ -156,8 +156,8 @@ public:
 
    const RColumnInfo &GetColumnInfo(DescriptorId_t physicalColumnId) const;
 
-   const RFieldTreeInfo &GetFieldInfo(DescriptorId_t fieldId) const;
-   const RFieldTreeInfo &GetFieldInfo(std::string_view fieldName) const;
+   const RFieldTreeInfo &GetFieldTreeInfo(DescriptorId_t fieldId) const;
+   const RFieldTreeInfo &GetFieldTreeInfo(std::string_view fieldName) const;
 
    /// Get the number of fields of a given type or class present in the RNTuple.
    /// TODO: Add regex support.

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -161,10 +161,10 @@ public:
 
    /// Get the number of fields of a given type or class present in the RNTuple.
    /// TODO: Add regex support.
-   int GetFieldTypeCount(std::string_view typeName, bool includeSubFields = true) const;
+   size_t GetFieldTypeCount(std::string_view typeName, bool includeSubFields = true) const;
 
    /// Get the number of columns of a given type present in the RNTuple.
-   int GetColumnTypeCount(EColumnType colType) const;
+   size_t GetColumnTypeCount(EColumnType colType) const;
 };
 } // namespace Experimental
 } // namespace ROOT

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -108,8 +108,8 @@ private:
    std::uint64_t fOnDiskSize = 0;
    std::uint64_t fInMemorySize = 0;
 
-   std::vector<RColumnInfo> fColumnInfo;
-   std::vector<RFieldInfo> fFieldInfo;
+   std::map<int, RColumnInfo> fColumnInfo;
+   std::map<int, RFieldInfo> fFieldInfo;
 
    RNTupleInspector(std::unique_ptr<Detail::RPageSource> pageSource);
 

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -24,13 +24,14 @@
 
 #include <cstdlib>
 #include <memory>
+#include <vector>
 
 namespace ROOT {
 namespace Experimental {
 
 // clang-format off
 /**
-\class ROOT::Experimental::Detail::RNTupleInspector
+\class ROOT::Experimental::RNTupleInspector
 \ingroup NTuple
 \brief Inspect a given RNTuple
 

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -122,10 +122,10 @@ private:
    /// This method is called when the `RNTupleInspector` is initially created.
    void CollectColumnInfo();
 
-   /// Gather field-level information and store it in `fFieldTreeInfo`.
+   /// Recursively gather field-level information and store it in `fFieldTreeInfo`.
    ///
    /// This method is called when the `RNTupleInspector` is initially created.
-   void CollectFieldInfo();
+   RFieldTreeInfo CollectFieldInfo(DescriptorId_t fieldId);
 
    /// Get the IDs of the columns that make up the given field, including its sub-fields.
    std::vector<DescriptorId_t> GetColumnsForFieldTree(DescriptorId_t fieldId) const;

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -92,11 +92,11 @@ public:
 
    /// Get the on-disk, compressed size of the RNTuple being inspected, in bytes.
    /// Does **not** include the size of the header and footer.
-   std::uint64_t GetCompressedSize();
+   std::uint64_t GetOnDiskSize();
 
-   /// Get the total, uncompressed size of the RNTuple being inspected, in bytes.
+   /// Get the total, in-memory size of the RNTuple being inspected, in bytes.
    /// Does **not** include the size of the header and footer.
-   std::uint64_t GetUncompressedSize();
+   std::uint64_t GetInMemorySize();
 
    /// Get the compression factor of the RNTuple being inspected.
    float GetCompressionFactor();
@@ -108,18 +108,18 @@ public:
    int GetColumnTypeFrequency(EColumnType colType);
 
    /// Get the on-disk, compressed size of a given column.
-   std::uint64_t GetCompressedColumnSize(DescriptorId_t logicalId);
+   std::uint64_t GetOnDiskColumnSize(DescriptorId_t logicalId);
 
-   /// Get the total, uncompressed size of a given column.
-   std::uint64_t GetUncompressedColumnSize(DescriptorId_t logicalId);
+   /// Get the total, in-memory size of a given column.
+   std::uint64_t GetInMemoryColumnSize(DescriptorId_t logicalId);
 
    /// Get the on-disk, compressed size of a given field.
-   std::uint64_t GetCompressedFieldSize(DescriptorId_t fieldId);
-   std::uint64_t GetCompressedFieldSize(std::string fieldName);
+   std::uint64_t GetOnDiskFieldSize(DescriptorId_t fieldId);
+   std::uint64_t GetOnDiskFieldSize(std::string fieldName);
 
-   /// Get the total, uncompressed size of a given field.
-   std::uint64_t GetUncompressedFieldSize(DescriptorId_t fieldId);
-   std::uint64_t GetUncompressedFieldSize(std::string fieldName);
+   /// Get the total, in-memory size of a given field.
+   std::uint64_t GetInMemoryFieldSize(DescriptorId_t fieldId);
+   std::uint64_t GetInMemoryFieldSize(std::string fieldName);
 
    /// Get the type of a given column.
    EColumnType GetColumnType(DescriptorId_t logicalId);

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -98,7 +98,7 @@ ROOT::Experimental::RNTupleInspector::RFieldTreeInfo ROOT::Experimental::RNTuple
    }
 
    auto fieldInfo = RFieldTreeInfo(fDescriptor->GetFieldDescriptor(fieldId), onDiskSize, inMemSize);
-   fFieldInfo.emplace(fieldId, fieldInfo);
+   fFieldTreeInfo.emplace(fieldId, fieldInfo);
    return fieldInfo;
 }
 
@@ -178,7 +178,7 @@ int ROOT::Experimental::RNTupleInspector::GetFieldTypeCount(std::string_view typ
 {
    int typeCount = 0;
 
-   for (auto &[fldId, fldInfo] : fFieldInfo) {
+   for (auto &[fldId, fldInfo] : fFieldTreeInfo) {
       if (!includeSubFields && fldInfo.GetDescriptor().GetParentId() != fDescriptor->GetFieldZeroId()) {
          continue;
       }
@@ -215,17 +215,17 @@ ROOT::Experimental::RNTupleInspector::GetColumnInfo(DescriptorId_t physicalColum
 }
 
 const ROOT::Experimental::RNTupleInspector::RFieldTreeInfo &
-ROOT::Experimental::RNTupleInspector::GetFieldInfo(DescriptorId_t fieldId) const
+ROOT::Experimental::RNTupleInspector::GetFieldTreeInfo(DescriptorId_t fieldId) const
 {
    if (fieldId >= fDescriptor->GetNFields()) {
       throw RException(R__FAIL("No field with ID " + std::to_string(fieldId) + " present"));
    }
 
-   return fFieldInfo.at(fieldId);
+   return fFieldTreeInfo.at(fieldId);
 }
 
 const ROOT::Experimental::RNTupleInspector::RFieldTreeInfo &
-ROOT::Experimental::RNTupleInspector::GetFieldInfo(std::string_view fieldName) const
+ROOT::Experimental::RNTupleInspector::GetFieldTreeInfo(std::string_view fieldName) const
 {
    DescriptorId_t fieldId = fDescriptor->FindFieldId(fieldName);
 
@@ -233,5 +233,5 @@ ROOT::Experimental::RNTupleInspector::GetFieldInfo(std::string_view fieldName) c
       throw RException(R__FAIL("Could not find field `" + std::string(fieldName) + "`"));
    }
 
-   return GetFieldInfo(fieldId);
+   return GetFieldTreeInfo(fieldId);
 }

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -50,7 +50,6 @@ void ROOT::Experimental::RNTupleInspector::CollectColumnInfo()
       std::uint32_t elemSize = ROOT::Experimental::Detail::RColumnElementBase::Generate(colType)->GetSize();
       std::uint64_t nElems = 0;
       std::uint64_t onDiskSize = 0;
-      std::uint64_t inMemSize = 0;
 
       for (const auto &clusterDescriptor : fDescriptor->GetClusterIterable()) {
          if (!clusterDescriptor.ContainsColumn(colId)) {
@@ -70,13 +69,12 @@ void ROOT::Experimental::RNTupleInspector::CollectColumnInfo()
 
          for (const auto &page : pageRange.fPageInfos) {
             onDiskSize += page.fLocator.fBytesOnStorage;
-            inMemSize += page.fNElements * elemSize;
             fOnDiskSize += page.fLocator.fBytesOnStorage;
             fInMemorySize += page.fNElements * elemSize;
          }
       }
 
-      fColumnInfo.emplace(colId, RColumnInfo(colDesc, onDiskSize, inMemSize, elemSize, nElems));
+      fColumnInfo.emplace(colId, RColumnInfo(colDesc, onDiskSize, elemSize, nElems));
    }
 }
 

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -78,7 +78,9 @@ void ROOT::Experimental::RNTupleInspector::CollectColumnInfo()
    }
 }
 
-ROOT::Experimental::RNTupleInspector::RFieldTreeInfo ROOT::Experimental::RNTupleInspector::CollectFieldInfo(DescriptorId_t fieldId) {
+ROOT::Experimental::RNTupleInspector::RFieldTreeInfo
+ROOT::Experimental::RNTupleInspector::CollectFieldTreeInfo(DescriptorId_t fieldId)
+{
    std::uint64_t onDiskSize = 0;
    std::uint64_t inMemSize = 0;
 
@@ -91,7 +93,7 @@ ROOT::Experimental::RNTupleInspector::RFieldTreeInfo ROOT::Experimental::RNTuple
    for (const auto &subFieldDescriptor : fDescriptor->GetFieldIterable(fieldId)) {
       DescriptorId_t subFieldId = subFieldDescriptor.GetId();
 
-      auto subFieldInfo = CollectFieldInfo(subFieldId);
+      auto subFieldInfo = CollectFieldTreeInfo(subFieldId);
 
       onDiskSize += subFieldInfo.GetOnDiskSize();
       inMemSize += subFieldInfo.GetInMemorySize();
@@ -134,7 +136,7 @@ ROOT::Experimental::RNTupleInspector::Create(std::unique_ptr<ROOT::Experimental:
    auto inspector = std::unique_ptr<RNTupleInspector>(new RNTupleInspector(std::move(pageSource)));
 
    inspector->CollectColumnInfo();
-   inspector->CollectFieldInfo(inspector->GetDescriptor()->GetFieldZeroId());
+   inspector->CollectFieldTreeInfo(inspector->GetDescriptor()->GetFieldZeroId());
 
    return inspector;
 }
@@ -169,7 +171,7 @@ ROOT::Experimental::RNTupleInspector::Create(std::string_view ntupleName, std::s
    inspector->fSourceFile = std::move(sourceFile);
 
    inspector->CollectColumnInfo();
-   inspector->CollectFieldInfo(inspector->GetDescriptor()->GetFieldZeroId());
+   inspector->CollectFieldTreeInfo(inspector->GetDescriptor()->GetFieldZeroId());
 
    return inspector;
 }

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -38,6 +38,9 @@ ROOT::Experimental::RNTupleInspector::RNTupleInspector(
 
 void ROOT::Experimental::RNTupleInspector::CollectColumnInfo()
 {
+   fOnDiskSize = 0;
+   fInMemorySize = 0;
+
    for (DescriptorId_t colId = 0; colId < fDescriptor->GetNPhysicalColumns(); ++colId) {
       const RColumnDescriptor &colDesc = fDescriptor->GetColumnDescriptor(colId);
 
@@ -68,8 +71,8 @@ void ROOT::Experimental::RNTupleInspector::CollectColumnInfo()
          for (const auto &page : pageRange.fPageInfos) {
             onDiskSize += page.fLocator.fBytesOnStorage;
             inMemSize += page.fNElements * elemSize;
-            fOnDiskSize += onDiskSize;
-            fInMemorySize += inMemSize;
+            fOnDiskSize += page.fLocator.fBytesOnStorage;
+            fInMemorySize += page.fNElements * elemSize;
          }
       }
 

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -187,12 +187,12 @@ int ROOT::Experimental::RNTupleInspector::GetCompressionSettings()
    return fCompressionSettings;
 }
 
-std::uint64_t ROOT::Experimental::RNTupleInspector::GetCompressedSize()
+std::uint64_t ROOT::Experimental::RNTupleInspector::GetOnDiskSize()
 {
    return fCompressedSize;
 }
 
-std::uint64_t ROOT::Experimental::RNTupleInspector::GetUncompressedSize()
+std::uint64_t ROOT::Experimental::RNTupleInspector::GetInMemorySize()
 {
    return fUncompressedSize;
 }
@@ -232,8 +232,7 @@ int ROOT::Experimental::RNTupleInspector::GetColumnTypeFrequency(ROOT::Experimen
    return typeFrequency;
 }
 
-std::uint64_t
-ROOT::Experimental::RNTupleInspector::GetCompressedColumnSize(ROOT::Experimental::DescriptorId_t logicalId)
+std::uint64_t ROOT::Experimental::RNTupleInspector::GetOnDiskColumnSize(ROOT::Experimental::DescriptorId_t logicalId)
 {
    if (fColumnInfo.empty()) {
       CollectColumnData();
@@ -251,8 +250,7 @@ ROOT::Experimental::RNTupleInspector::GetCompressedColumnSize(ROOT::Experimental
    return fColumnInfo.at(physicalId).fCompressedSize;
 }
 
-std::uint64_t
-ROOT::Experimental::RNTupleInspector::GetUncompressedColumnSize(ROOT::Experimental::DescriptorId_t logicalId)
+std::uint64_t ROOT::Experimental::RNTupleInspector::GetInMemoryColumnSize(ROOT::Experimental::DescriptorId_t logicalId)
 {
    if (fColumnInfo.empty()) {
       CollectColumnData();
@@ -269,18 +267,18 @@ ROOT::Experimental::RNTupleInspector::GetUncompressedColumnSize(ROOT::Experiment
    return fColumnInfo.at(physicalId).fUncompressedSize;
 }
 
-std::uint64_t ROOT::Experimental::RNTupleInspector::GetCompressedFieldSize(ROOT::Experimental::DescriptorId_t fieldId)
+std::uint64_t ROOT::Experimental::RNTupleInspector::GetOnDiskFieldSize(ROOT::Experimental::DescriptorId_t fieldId)
 {
    std::uint64_t fieldSize = 0;
 
    for (const auto colId : GetColumnsForField(fieldId)) {
-      fieldSize += GetCompressedColumnSize(colId);
+      fieldSize += GetOnDiskColumnSize(colId);
    }
 
    return fieldSize;
 }
 
-std::uint64_t ROOT::Experimental::RNTupleInspector::GetCompressedFieldSize(std::string fieldName)
+std::uint64_t ROOT::Experimental::RNTupleInspector::GetOnDiskFieldSize(std::string fieldName)
 {
    auto descriptorGuard = fPageSource->GetSharedDescriptorGuard();
 
@@ -291,21 +289,21 @@ std::uint64_t ROOT::Experimental::RNTupleInspector::GetCompressedFieldSize(std::
       return -1;
    }
 
-   return GetCompressedFieldSize(fieldId);
+   return GetOnDiskFieldSize(fieldId);
 }
 
-std::uint64_t ROOT::Experimental::RNTupleInspector::GetUncompressedFieldSize(ROOT::Experimental::DescriptorId_t fieldId)
+std::uint64_t ROOT::Experimental::RNTupleInspector::GetInMemoryFieldSize(ROOT::Experimental::DescriptorId_t fieldId)
 {
    std::uint64_t fieldSize = 0;
 
    for (const auto colId : GetColumnsForField(fieldId)) {
-      fieldSize += GetUncompressedColumnSize(colId);
+      fieldSize += GetInMemoryColumnSize(colId);
    }
 
    return fieldSize;
 }
 
-std::uint64_t ROOT::Experimental::RNTupleInspector::GetUncompressedFieldSize(std::string fieldName)
+std::uint64_t ROOT::Experimental::RNTupleInspector::GetInMemoryFieldSize(std::string fieldName)
 {
    auto descriptorGuard = fPageSource->GetSharedDescriptorGuard();
 
@@ -316,7 +314,7 @@ std::uint64_t ROOT::Experimental::RNTupleInspector::GetUncompressedFieldSize(std
       return -1;
    }
 
-   return GetUncompressedFieldSize(fieldId);
+   return GetInMemoryFieldSize(fieldId);
 }
 
 ROOT::Experimental::EColumnType

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -41,8 +41,8 @@ void ROOT::Experimental::RNTupleInspector::CollectColumnInfo()
    fOnDiskSize = 0;
    fInMemorySize = 0;
 
-   for (DescriptorId_t colId = 0; colId < fDescriptor->GetNPhysicalColumns(); ++colId) {
-      const RColumnDescriptor &colDesc = fDescriptor->GetColumnDescriptor(colId);
+   for (const auto &colDesc : fDescriptor->GetColumnIterable()) {
+      auto colId = colDesc.GetPhysicalId();
 
       // We generate the default memory representation for the given column type in order
       // to report the size _in memory_ of column elements.

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -76,7 +76,7 @@ void ROOT::Experimental::RNTupleInspector::CollectColumnInfo()
          }
       }
 
-      fColumnInfo.emplace_back(RColumnInfo(colDesc, onDiskSize, inMemSize, elemSize, nElems));
+      fColumnInfo.emplace(colId, RColumnInfo(colDesc, onDiskSize, inMemSize, elemSize, nElems));
    }
 }
 
@@ -89,17 +89,18 @@ void ROOT::Experimental::RNTupleInspector::CollectFieldInfo()
       fieldIdQueue.pop_front();
 
       for (const auto &fieldDescriptor : fDescriptor->GetFieldIterable(currId)) {
+         DescriptorId_t fieldId = fieldDescriptor.GetId();
          std::uint64_t onDiskSize = 0;
          std::uint64_t inMemSize = 0;
 
-         for (const auto colId : GetColumnsForFieldTree(fieldDescriptor.GetId())) {
+         for (const auto colId : GetColumnsForFieldTree(fieldId)) {
             auto colInfo = GetColumnInfo(colId);
             onDiskSize += colInfo.GetOnDiskSize();
             inMemSize += colInfo.GetInMemorySize();
          }
 
-         fFieldInfo.emplace_back(RFieldInfo(fieldDescriptor, onDiskSize, inMemSize));
-         fieldIdQueue.push_back(fieldDescriptor.GetId());
+         fFieldInfo.emplace(fieldId, RFieldInfo(fieldDescriptor, onDiskSize, inMemSize));
+         fieldIdQueue.push_back(fieldId);
       }
    }
 }
@@ -182,7 +183,7 @@ int ROOT::Experimental::RNTupleInspector::GetFieldTypeCount(std::string_view typ
 
    int typeCount = 0;
 
-   for (auto &fldInfo : fFieldInfo) {
+   for (auto &[fldId, fldInfo] : fFieldInfo) {
       if (!includeSubFields && fldInfo.GetDescriptor().GetParentId() != fDescriptor->GetFieldZeroId()) {
          continue;
       }
@@ -199,7 +200,7 @@ int ROOT::Experimental::RNTupleInspector::GetColumnTypeCount(ROOT::Experimental:
 {
    int typeCount = 0;
 
-   for (auto &colInfo : fColumnInfo) {
+   for (auto &[colId, colInfo] : fColumnInfo) {
       if (colInfo.GetType() == colType) {
          ++typeCount;
       }

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -57,19 +57,13 @@ void ROOT::Experimental::RNTupleInspector::CollectNTupleData()
 void ROOT::Experimental::RNTupleInspector::CollectColumnData()
 {
    for (DescriptorId_t colId = 0; colId < fDescriptor->GetNPhysicalColumns(); ++colId) {
-      const ROOT::Experimental::RColumnDescriptor &colDescriptor = fDescriptor->GetColumnDescriptor(colId);
-
       RColumnInfo info;
-      info.fPhysicalColumnId = colId;
-      info.fLogicalColumnId = colDescriptor.GetLogicalId();
-      info.fFieldId = colDescriptor.GetFieldId();
-      info.fIndex = colDescriptor.GetIndex();
-      info.fType = colDescriptor.GetModel().GetType();
+      info.fColumnDescriptor = &(fDescriptor->GetColumnDescriptor(colId));
+      info.fType = info.fColumnDescriptor->GetModel().GetType();
 
       // We generate the default memory representation for the given column type in order
       // to report the size _in memory_ of column elements.
-      uint64_t elemSize =
-         ROOT::Experimental::Detail::RColumnElementBase::Generate(colDescriptor.GetModel().GetType())->GetSize();
+      uint64_t elemSize = ROOT::Experimental::Detail::RColumnElementBase::Generate(info.fType)->GetSize();
       info.fElementSize = elemSize;
 
       for (const auto &clusterDescriptor : fDescriptor->GetClusterIterable()) {

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -141,7 +141,7 @@ std::unique_ptr<ROOT::Experimental::RNTupleInspector>
 ROOT::Experimental::RNTupleInspector::Create(ROOT::Experimental::RNTuple *sourceNTuple)
 {
    if (!sourceNTuple) {
-      return R__FAIL("provided RNTuple is null");
+      throw RException(R__FAIL("provided RNTuple is null"));
    }
 
    std::unique_ptr<ROOT::Experimental::Detail::RPageSource> pageSource = sourceNTuple->MakePageSource();
@@ -149,17 +149,17 @@ ROOT::Experimental::RNTupleInspector::Create(ROOT::Experimental::RNTuple *source
    return ROOT::Experimental::RNTupleInspector::Create(std::move(pageSource));
 }
 
-ROOT::Experimental::RResult<std::unique_ptr<ROOT::Experimental::RNTupleInspector>>
+std::unique_ptr<ROOT::Experimental::RNTupleInspector>
 ROOT::Experimental::RNTupleInspector::Create(std::string_view ntupleName, std::string_view sourceFileName)
 {
    auto sourceFile = std::unique_ptr<TFile>(TFile::Open(std::string(sourceFileName).c_str()));
    if (!sourceFile || sourceFile->IsZombie()) {
-      return R__FAIL("cannot open source file " + std::string(sourceFileName));
+      throw RException(R__FAIL("cannot open source file " + std::string(sourceFileName)));
    }
    auto ntuple = std::unique_ptr<ROOT::Experimental::RNTuple>(
       sourceFile->Get<ROOT::Experimental::RNTuple>(std::string(ntupleName).c_str()));
    if (!ntuple) {
-      return R__FAIL("cannot read RNTuple " + std::string(ntupleName) + " from " + std::string(sourceFileName));
+      throw RException(R__FAIL("cannot read RNTuple " + std::string(ntupleName) + " from " + std::string(sourceFileName)));
    }
 
    auto inspector = std::unique_ptr<RNTupleInspector>(new RNTupleInspector(ntuple->MakePageSource()));

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -162,40 +162,16 @@ ROOT::Experimental::RNTupleInspector::Create(std::string_view ntupleName, std::s
    auto ntuple = std::unique_ptr<ROOT::Experimental::RNTuple>(
       sourceFile->Get<ROOT::Experimental::RNTuple>(std::string(ntupleName).c_str()));
    if (!ntuple) {
-      throw RException(R__FAIL("cannot read RNTuple " + std::string(ntupleName) + " from " + std::string(sourceFileName)));
+      throw RException(
+         R__FAIL("cannot read RNTuple " + std::string(ntupleName) + " from " + std::string(sourceFileName)));
    }
 
    auto inspector = std::unique_ptr<RNTupleInspector>(new RNTupleInspector(ntuple->MakePageSource()));
    inspector->fSourceFile = std::move(sourceFile);
 
-   inspector->CollectSizeData();
+   inspector->CollectColumnInfo();
 
    return inspector;
-}
-
-ROOT::Experimental::RNTupleDescriptor *ROOT::Experimental::RNTupleInspector::GetDescriptor()
-{
-   return fDescriptor.get();
-}
-
-int ROOT::Experimental::RNTupleInspector::GetCompressionSettings()
-{
-   return fCompressionSettings;
-}
-
-std::uint64_t ROOT::Experimental::RNTupleInspector::GetOnDiskSize()
-{
-   return fOnDiskSize;
-}
-
-std::uint64_t ROOT::Experimental::RNTupleInspector::GetInMemorySize()
-{
-   return fInMemorySize;
-}
-
-float ROOT::Experimental::RNTupleInspector::GetCompressionFactor()
-{
-   return (float)fInMemorySize / (float)fOnDiskSize;
 }
 
 int ROOT::Experimental::RNTupleInspector::GetFieldTypeCount(std::string_view typeName, bool includeSubFields)

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -21,11 +21,11 @@
 
 #include <TFile.h>
 
-#include <cstring>
-#include <iostream>
 #include <algorithm>
+#include <cstring>
 #include <deque>
 #include <exception>
+#include <iostream>
 
 ROOT::Experimental::RNTupleInspector::RNTupleInspector(
    std::unique_ptr<ROOT::Experimental::Detail::RPageSource> pageSource)
@@ -176,9 +176,9 @@ ROOT::Experimental::RNTupleInspector::Create(std::string_view ntupleName, std::s
    return inspector;
 }
 
-int ROOT::Experimental::RNTupleInspector::GetFieldTypeCount(std::string_view typeName, bool includeSubFields) const
+size_t ROOT::Experimental::RNTupleInspector::GetFieldTypeCount(std::string_view typeName, bool includeSubFields) const
 {
-   int typeCount = 0;
+   size_t typeCount = 0;
 
    for (auto &[fldId, fldInfo] : fFieldTreeInfo) {
       if (!includeSubFields && fldInfo.GetDescriptor().GetParentId() != fDescriptor->GetFieldZeroId()) {
@@ -193,9 +193,9 @@ int ROOT::Experimental::RNTupleInspector::GetFieldTypeCount(std::string_view typ
    return typeCount;
 }
 
-int ROOT::Experimental::RNTupleInspector::GetColumnTypeCount(ROOT::Experimental::EColumnType colType) const
+size_t ROOT::Experimental::RNTupleInspector::GetColumnTypeCount(ROOT::Experimental::EColumnType colType) const
 {
-   int typeCount = 0;
+   size_t typeCount = 0;
 
    for (auto &[colId, colInfo] : fColumnInfo) {
       if (colInfo.GetType() == colType) {

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -273,7 +273,7 @@ TEST(RNTupleInspector, ColumnTypeCount)
    auto ntuple = file->Get<RNTuple>("ntuple");
    auto inspector = RNTupleInspector::Create(ntuple);
 
-   EXPECT_EQ(2, inspector->GetColumnTypeCount(ROOT::Experimental::EColumnType::kIndex32));
+   EXPECT_EQ(2, inspector->GetColumnTypeCount(ROOT::Experimental::EColumnType::kSplitIndex32));
    EXPECT_EQ(4, inspector->GetColumnTypeCount(ROOT::Experimental::EColumnType::kSplitReal32));
    EXPECT_EQ(3, inspector->GetColumnTypeCount(ROOT::Experimental::EColumnType::kSplitInt32));
 }

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -109,11 +109,11 @@ TEST(RNTupleInspector, SizeUncompressedSimple)
    auto ntuple = file->Get<RNTuple>("ntuple");
    auto inspector = RNTupleInspector::Create(ntuple);
 
-   EXPECT_EQ(sizeof(int32_t) * 5, inspector->GetUncompressedSize());
+   EXPECT_EQ(sizeof(int32_t) * 5, inspector->GetInMemorySize());
 
    // N.B. This property only holds for ntuples without Index fields, due to
    // the 64-bit in-memory vs. 32-bit on-disk optimization.
-   EXPECT_EQ(inspector->GetCompressedSize(), inspector->GetUncompressedSize());
+   EXPECT_EQ(inspector->GetOnDiskSize(), inspector->GetInMemorySize());
 }
 
 TEST(RNTupleInspector, SizeUncompressedComplex)
@@ -147,7 +147,7 @@ TEST(RNTupleInspector, SizeUncompressedComplex)
 
    // We need to add another 4 bytes per index column per event, due to the 64-bit
    // in-memory vs. 32-bit on-disk optimization.
-   EXPECT_EQ(inspector->GetCompressedSize() + 4 * nIndexCols * nEntries, inspector->GetUncompressedSize());
+   EXPECT_EQ(inspector->GetOnDiskSize() + 4 * nIndexCols * nEntries, inspector->GetInMemorySize());
 }
 
 TEST(RNTupleInspector, SizeCompressedInt)
@@ -171,9 +171,9 @@ TEST(RNTupleInspector, SizeCompressedInt)
    auto ntuple = file->Get<RNTuple>("ntuple");
    auto inspector = RNTupleInspector::Create(ntuple);
 
-   EXPECT_EQ(sizeof(int32_t) * 50, inspector->GetUncompressedSize());
-   EXPECT_GT(inspector->GetCompressedSize(), 0);
-   EXPECT_LT(inspector->GetCompressedSize(), inspector->GetUncompressedSize());
+   EXPECT_EQ(sizeof(int32_t) * 50, inspector->GetInMemorySize());
+   EXPECT_GT(inspector->GetOnDiskSize(), 0);
+   EXPECT_LT(inspector->GetOnDiskSize(), inspector->GetInMemorySize());
    EXPECT_GT(inspector->GetCompressionFactor(), 1);
 }
 
@@ -200,8 +200,8 @@ TEST(RNTupleInspector, SizeCompressedComplex)
    auto ntuple = file->Get<RNTuple>("ntuple");
    auto inspector = RNTupleInspector::Create(ntuple);
 
-   EXPECT_GT(inspector->GetCompressedSize(), 0);
-   EXPECT_LT(inspector->GetCompressedSize(), inspector->GetUncompressedSize());
+   EXPECT_GT(inspector->GetOnDiskSize(), 0);
+   EXPECT_LT(inspector->GetOnDiskSize(), inspector->GetInMemorySize());
    EXPECT_GT(inspector->GetCompressionFactor(), 1);
 }
 
@@ -217,8 +217,8 @@ TEST(RNTupleInspector, SizeEmpty)
    auto ntuple = file->Get<RNTuple>("ntuple");
    auto inspector = RNTupleInspector::Create(ntuple);
 
-   EXPECT_EQ(0, inspector->GetCompressedSize());
-   EXPECT_EQ(0, inspector->GetUncompressedSize());
+   EXPECT_EQ(0, inspector->GetOnDiskSize());
+   EXPECT_EQ(0, inspector->GetInMemorySize());
 }
 
 TEST(RNTupleInspector, FieldTypeFrequency)
@@ -296,13 +296,13 @@ TEST(RNTupleInspector, ColumnSize)
    auto reader = RNTupleReader::Open(ntuple);
 
    for (std::size_t i = 0; i < reader->GetDescriptor()->GetNLogicalColumns(); ++i) {
-      EXPECT_GT(inspector->GetCompressedColumnSize(i), 0);
-      EXPECT_GT(inspector->GetUncompressedColumnSize(i), 0);
-      EXPECT_LT(inspector->GetCompressedColumnSize(i), inspector->GetUncompressedColumnSize(i));
+      EXPECT_GT(inspector->GetOnDiskColumnSize(i), 0);
+      EXPECT_GT(inspector->GetInMemoryColumnSize(i), 0);
+      EXPECT_LT(inspector->GetOnDiskColumnSize(i), inspector->GetInMemoryColumnSize(i));
    }
 
-   EXPECT_EQ(inspector->GetCompressedColumnSize(-42), -1);
-   EXPECT_EQ(inspector->GetUncompressedColumnSize(-42), -1);
+   EXPECT_EQ(inspector->GetOnDiskColumnSize(-42), -1);
+   EXPECT_EQ(inspector->GetInMemoryColumnSize(-42), -1);
 }
 
 TEST(RNTupleInspector, FieldSize)
@@ -330,12 +330,12 @@ TEST(RNTupleInspector, FieldSize)
    auto ntuple = file->Get<RNTuple>("ntuple");
    auto inspector = RNTupleInspector::Create(ntuple);
 
-   EXPECT_GT(inspector->GetCompressedFieldSize("object"), 0);
-   EXPECT_EQ(inspector->GetUncompressedFieldSize("object"), inspector->GetUncompressedSize());
-   EXPECT_LT(inspector->GetCompressedFieldSize("object"), inspector->GetUncompressedFieldSize("object"));
+   EXPECT_GT(inspector->GetOnDiskFieldSize("object"), 0);
+   EXPECT_EQ(inspector->GetInMemoryFieldSize("object"), inspector->GetInMemorySize());
+   EXPECT_LT(inspector->GetOnDiskFieldSize("object"), inspector->GetInMemoryFieldSize("object"));
 
-   EXPECT_EQ(inspector->GetCompressedFieldSize("invalid_field"), -1);
-   EXPECT_EQ(inspector->GetUncompressedFieldSize("invalid_field"), -1);
+   EXPECT_EQ(inspector->GetOnDiskFieldSize("invalid_field"), -1);
+   EXPECT_EQ(inspector->GetInMemoryFieldSize("invalid_field"), -1);
 }
 
 TEST(RNTupleInspector, ColumnType)

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -360,7 +360,7 @@ TEST(RNTupleInspector, FieldInfoCompressed)
    auto ntuple = file->Get<RNTuple>("ntuple");
    auto inspector = RNTupleInspector::Create(ntuple);
 
-   auto topFieldInfo = inspector->GetFieldInfo("object");
+   auto topFieldInfo = inspector->GetFieldTreeInfo("object");
 
    EXPECT_GT(topFieldInfo.GetOnDiskSize(), 0);
    EXPECT_EQ(topFieldInfo.GetInMemorySize(), inspector->GetInMemorySize());
@@ -370,7 +370,7 @@ TEST(RNTupleInspector, FieldInfoCompressed)
    std::uint64_t subFieldInMemorySize = 0;
 
    for (const auto &subField : inspector->GetDescriptor()->GetFieldIterable(topFieldInfo.GetDescriptor().GetId())) {
-      auto subFieldInfo = inspector->GetFieldInfo(subField.GetId());
+      auto subFieldInfo = inspector->GetFieldTreeInfo(subField.GetId());
       subFieldOnDiskSize += subFieldInfo.GetOnDiskSize();
       subFieldInMemorySize += subFieldInfo.GetInMemorySize();
    }
@@ -378,8 +378,8 @@ TEST(RNTupleInspector, FieldInfoCompressed)
    EXPECT_EQ(topFieldInfo.GetOnDiskSize(), subFieldOnDiskSize);
    EXPECT_EQ(topFieldInfo.GetInMemorySize(), subFieldInMemorySize);
 
-   EXPECT_THROW(inspector->GetFieldInfo("invalid_field"), ROOT::Experimental::RException);
-   EXPECT_THROW(inspector->GetFieldInfo(inspector->GetDescriptor()->GetNFields()), ROOT::Experimental::RException);
+   EXPECT_THROW(inspector->GetFieldTreeInfo("invalid_field"), ROOT::Experimental::RException);
+   EXPECT_THROW(inspector->GetFieldTreeInfo(inspector->GetDescriptor()->GetNFields()), ROOT::Experimental::RException);
 }
 
 TEST(RNTupleInspector, FieldInfoUncompressed)
@@ -407,7 +407,7 @@ TEST(RNTupleInspector, FieldInfoUncompressed)
    auto ntuple = file->Get<RNTuple>("ntuple");
    auto inspector = RNTupleInspector::Create(ntuple);
 
-   auto topFieldInfo = inspector->GetFieldInfo("object");
+   auto topFieldInfo = inspector->GetFieldTreeInfo("object");
 
    EXPECT_EQ(topFieldInfo.GetOnDiskSize(), topFieldInfo.GetInMemorySize());
 
@@ -415,7 +415,7 @@ TEST(RNTupleInspector, FieldInfoUncompressed)
    std::uint64_t subFieldInMemorySize = 0;
 
    for (const auto &subField : inspector->GetDescriptor()->GetFieldIterable(topFieldInfo.GetDescriptor().GetId())) {
-      auto subFieldInfo = inspector->GetFieldInfo(subField.GetId());
+      auto subFieldInfo = inspector->GetFieldTreeInfo(subField.GetId());
       subFieldOnDiskSize += subFieldInfo.GetOnDiskSize();
       subFieldInMemorySize += subFieldInfo.GetInMemorySize();
    }

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -3,6 +3,7 @@
 
 #include <TFile.h>
 
+#include "CustomStructUtil.hxx"
 #include "ntupleutil_test.hxx"
 
 using ROOT::Experimental::RNTuple;
@@ -60,17 +61,17 @@ TEST(RNTupleInspector, NEntries)
 
    std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
    auto ntuple = file->Get<RNTuple>("ntuple");
-   auto inspector = RNTupleInspector::Create(ntuple).Unwrap();
+   auto inspector = RNTupleInspector::Create(ntuple);
 
    EXPECT_EQ(inspector->GetNEntries(), 50);
 }
 
 TEST(RNTupleInspector, CompressionSettings)
 {
-   FileRaii fileGuard("test_ntuple_inspector_size_single_int_field.root");
+   FileRaii fileGuard("test_ntuple_inspector_compression_settings.root");
    {
       auto model = RNTupleModel::Create();
-      auto nFldInt = model->MakeField<std::int32_t>("i");
+      auto nFldInt = model->MakeField<std::int32_t>("int");
 
       auto writeOptions = RNTupleWriteOptions();
       writeOptions.SetCompression(505);
@@ -82,40 +83,79 @@ TEST(RNTupleInspector, CompressionSettings)
 
    std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
    auto ntuple = file->Get<RNTuple>("ntuple");
-   auto inspector = RNTupleInspector::Create(ntuple).Unwrap();
+   auto inspector = RNTupleInspector::Create(ntuple);
 
    EXPECT_EQ(505, inspector->GetCompressionSettings());
 }
 
-TEST(RNTupleInspector, SizeUncompressed)
+TEST(RNTupleInspector, SizeUncompressedSimple)
 {
-   FileRaii fileGuard("test_ntuple_inspector_size_uncompressed.root");
+   FileRaii fileGuard("test_ntuple_inspector_size_uncompressed_complex.root");
    {
       auto model = RNTupleModel::Create();
-      auto nFldInt = model->MakeField<std::int32_t>("i");
+      auto nFldInt = model->MakeField<std::int32_t>("int");
 
       auto writeOptions = RNTupleWriteOptions();
       writeOptions.SetCompression(0);
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
 
-      *nFldInt = 42;
+      for (int i = 0; i < 5; i++) {
+         *nFldInt = 1;
+         ntuple->Fill();
+      }
+   }
+
+   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
+   auto ntuple = file->Get<RNTuple>("ntuple");
+   auto inspector = RNTupleInspector::Create(ntuple);
+
+   EXPECT_EQ(sizeof(int32_t) * 5, inspector->GetUncompressedSize());
+
+   // N.B. This property only holds for ntuples without Index fields, due to
+   // the 64-bit in-memory vs. 32-bit on-disk optimization.
+   EXPECT_EQ(inspector->GetCompressedSize(), inspector->GetUncompressedSize());
+}
+
+TEST(RNTupleInspector, SizeUncompressedComplex)
+{
+   FileRaii fileGuard("test_ntuple_inspector_size_uncompressed_complex.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto nFldObject = model->MakeField<ComplexStructUtil>("object");
+
+      auto writeOptions = RNTupleWriteOptions();
+      writeOptions.SetCompression(0);
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
+
+      nFldObject->Init1();
+      ntuple->Fill();
+      nFldObject->Init2();
+      ntuple->Fill();
+      nFldObject->Init3();
       ntuple->Fill();
    }
 
    std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
    auto ntuple = file->Get<RNTuple>("ntuple");
-   auto inspector = RNTupleInspector::Create(ntuple).Unwrap();
+   auto inspector = RNTupleInspector::Create(ntuple);
 
-   EXPECT_EQ(sizeof(int32_t), inspector->GetUncompressedSize());
-   EXPECT_EQ(inspector->GetCompressedSize(), inspector->GetUncompressedSize());
+   int nIndexCols = inspector->GetColumnTypeFrequency(ROOT::Experimental::EColumnType::kIndex32);
+   int nEntries = inspector->GetNEntries();
+
+   EXPECT_EQ(2, nIndexCols);
+   EXPECT_EQ(3, nEntries);
+
+   // We need to add another 4 bytes per index column per event, due to the 64-bit
+   // in-memory vs. 32-bit on-disk optimization.
+   EXPECT_EQ(inspector->GetCompressedSize() + 4 * nIndexCols * nEntries, inspector->GetUncompressedSize());
 }
 
-TEST(RNTupleInspector, SizeCompressed)
+TEST(RNTupleInspector, SizeCompressedInt)
 {
-   FileRaii fileGuard("test_ntuple_inspector_size_uncompressed.root");
+   FileRaii fileGuard("test_ntuple_inspector_size_compressed_int.root");
    {
       auto model = RNTupleModel::Create();
-      auto nFldInt = model->MakeField<std::int32_t>("i");
+      auto nFldInt = model->MakeField<std::int32_t>("int");
 
       auto writeOptions = RNTupleWriteOptions();
       writeOptions.SetCompression(505);
@@ -129,9 +169,40 @@ TEST(RNTupleInspector, SizeCompressed)
 
    std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
    auto ntuple = file->Get<RNTuple>("ntuple");
-   auto inspector = RNTupleInspector::Create(ntuple).Unwrap();
+   auto inspector = RNTupleInspector::Create(ntuple);
 
-   EXPECT_NE(inspector->GetCompressedSize(), inspector->GetUncompressedSize());
+   EXPECT_EQ(sizeof(int32_t) * 50, inspector->GetUncompressedSize());
+   EXPECT_GT(inspector->GetCompressedSize(), 0);
+   EXPECT_LT(inspector->GetCompressedSize(), inspector->GetUncompressedSize());
+   EXPECT_GT(inspector->GetCompressionFactor(), 1);
+}
+
+TEST(RNTupleInspector, SizeCompressedComplex)
+{
+   FileRaii fileGuard("test_ntuple_inspector_size_compressed_complex.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto nFldObject = model->MakeField<ComplexStructUtil>("object");
+
+      auto writeOptions = RNTupleWriteOptions();
+      writeOptions.SetCompression(505);
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
+
+      nFldObject->Init1();
+      ntuple->Fill();
+      nFldObject->Init2();
+      ntuple->Fill();
+      nFldObject->Init3();
+      ntuple->Fill();
+   }
+
+   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
+   auto ntuple = file->Get<RNTuple>("ntuple");
+   auto inspector = RNTupleInspector::Create(ntuple);
+
+   EXPECT_GT(inspector->GetCompressedSize(), 0);
+   EXPECT_LT(inspector->GetCompressedSize(), inspector->GetUncompressedSize());
+   EXPECT_GT(inspector->GetCompressionFactor(), 1);
 }
 
 TEST(RNTupleInspector, SizeEmpty)
@@ -144,34 +215,146 @@ TEST(RNTupleInspector, SizeEmpty)
 
    std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
    auto ntuple = file->Get<RNTuple>("ntuple");
-   auto inspector = RNTupleInspector::Create(ntuple).Unwrap();
+   auto inspector = RNTupleInspector::Create(ntuple);
 
    EXPECT_EQ(0, inspector->GetCompressedSize());
    EXPECT_EQ(0, inspector->GetUncompressedSize());
 }
 
-TEST(RNTupleInspector, SingleIntFieldCompression)
+TEST(RNTupleInspector, FieldTypeFrequency)
 {
-   FileRaii fileGuard("test_ntuple_inspector_size_single_int_field.root");
+   FileRaii fileGuard("test_ntuple_inspector_field_type_frequency.root");
    {
       auto model = RNTupleModel::Create();
-      auto nFldInt = model->MakeField<std::int32_t>("i");
+      auto nFldObject = model->MakeField<ComplexStructUtil>("object");
+      auto nFldInt1 = model->MakeField<std::int32_t>("int1");
+      auto nFldInt2 = model->MakeField<std::int32_t>("int2");
+      auto nFldInt3 = model->MakeField<std::int32_t>("int3");
+      auto nFldString1 = model->MakeField<std::string>("string1");
+      auto nFldString2 = model->MakeField<std::string>("string2");
+
+      auto writeOptions = RNTupleWriteOptions();
+      writeOptions.SetCompression(505);
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
+   }
+
+   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
+   auto ntuple = file->Get<RNTuple>("ntuple");
+   auto inspector = RNTupleInspector::Create(ntuple);
+
+   EXPECT_EQ(3, inspector->GetFieldTypeFrequency("std::int32_t"));
+   EXPECT_EQ(2, inspector->GetFieldTypeFrequency("std::string"));
+   EXPECT_EQ(1, inspector->GetFieldTypeFrequency("ComplexStructUtil"));
+   EXPECT_EQ(0, inspector->GetFieldTypeFrequency("std::vector<float>"));
+}
+
+TEST(RNTupleInspector, ColumnTypeFrequency)
+{
+   FileRaii fileGuard("test_ntuple_inspector_column_type_frequency.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto nFldObject = model->MakeField<ComplexStructUtil>("object");
+
+      auto writeOptions = RNTupleWriteOptions();
+      writeOptions.SetCompression(505);
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
+   }
+
+   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
+   auto ntuple = file->Get<RNTuple>("ntuple");
+   auto inspector = RNTupleInspector::Create(ntuple);
+
+   EXPECT_EQ(2, inspector->GetColumnTypeFrequency(ROOT::Experimental::EColumnType::kIndex32));
+   EXPECT_EQ(4, inspector->GetColumnTypeFrequency(ROOT::Experimental::EColumnType::kSplitReal32));
+   EXPECT_EQ(3, inspector->GetColumnTypeFrequency(ROOT::Experimental::EColumnType::kSplitInt32));
+}
+
+TEST(RNTupleInspector, ColumnSize)
+{
+   FileRaii fileGuard("test_ntuple_inspector_column_size.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto nFldObject = model->MakeField<ComplexStructUtil>("object");
 
       auto writeOptions = RNTupleWriteOptions();
       writeOptions.SetCompression(505);
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
 
-      for (int32_t i = 0; i < 50; ++i) {
-         *nFldInt = i;
+      for (int i = 0; i < 25; ++i) {
+         nFldObject->Init1();
+         ntuple->Fill();
+         nFldObject->Init2();
+         ntuple->Fill();
+         nFldObject->Init3();
          ntuple->Fill();
       }
    }
 
    std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
    auto ntuple = file->Get<RNTuple>("ntuple");
-   auto inspector = RNTupleInspector::Create(ntuple).Unwrap();
+   auto inspector = RNTupleInspector::Create(ntuple);
+   auto reader = RNTupleReader::Open(ntuple);
 
-   EXPECT_LT(0, inspector->GetCompressedSize());
-   EXPECT_LT(inspector->GetCompressedSize(), inspector->GetUncompressedSize());
-   EXPECT_GT(inspector->GetCompressionFactor(), 1);
+   for (std::size_t i = 0; i < reader->GetDescriptor()->GetNLogicalColumns(); ++i) {
+      EXPECT_GT(inspector->GetCompressedColumnSize(i), 0);
+      EXPECT_GT(inspector->GetUncompressedColumnSize(i), 0);
+      EXPECT_LT(inspector->GetCompressedColumnSize(i), inspector->GetUncompressedColumnSize(i));
+   }
+
+   EXPECT_EQ(inspector->GetCompressedColumnSize(-42), -1);
+   EXPECT_EQ(inspector->GetUncompressedColumnSize(-42), -1);
+}
+
+TEST(RNTupleInspector, FieldSize)
+{
+   FileRaii fileGuard("test_ntuple_inspector_field_size.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto nFldObject = model->MakeField<ComplexStructUtil>("object");
+
+      auto writeOptions = RNTupleWriteOptions();
+      writeOptions.SetCompression(505);
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
+
+      for (int i = 0; i < 25; ++i) {
+         nFldObject->Init1();
+         ntuple->Fill();
+         nFldObject->Init2();
+         ntuple->Fill();
+         nFldObject->Init3();
+         ntuple->Fill();
+      }
+   }
+
+   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
+   auto ntuple = file->Get<RNTuple>("ntuple");
+   auto inspector = RNTupleInspector::Create(ntuple);
+
+   EXPECT_GT(inspector->GetCompressedFieldSize("object"), 0);
+   EXPECT_EQ(inspector->GetUncompressedFieldSize("object"), inspector->GetUncompressedSize());
+   EXPECT_LT(inspector->GetCompressedFieldSize("object"), inspector->GetUncompressedFieldSize("object"));
+
+   EXPECT_EQ(inspector->GetCompressedFieldSize("invalid_field"), -1);
+   EXPECT_EQ(inspector->GetUncompressedFieldSize("invalid_field"), -1);
+}
+
+TEST(RNTupleInspector, ColumnType)
+{
+   FileRaii fileGuard("test_ntuple_inspector_field_size.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto nFldObject = model->MakeField<ComplexStructUtil>("object");
+
+      auto writeOptions = RNTupleWriteOptions();
+      writeOptions.SetCompression(505);
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
+   }
+
+   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
+   auto ntuple = file->Get<RNTuple>("ntuple");
+   auto inspector = RNTupleInspector::Create(ntuple);
+
+   EXPECT_EQ(inspector->GetColumnType(0), ROOT::Experimental::EColumnType::kSplitReal32);
+   EXPECT_EQ(inspector->GetColumnType(1), ROOT::Experimental::EColumnType::kIndex32);
+   EXPECT_EQ(inspector->GetColumnType(2), ROOT::Experimental::EColumnType::kSplitInt32);
 }


### PR DESCRIPTION
This PR adds some (mostly size and compression-related) methods to the `RNTupleInspector` utility class. There are some small TODOs left, but I first wanted to collect some feedback.

- [x] tested changes locally
- [x] updated the docs (if necessary)
- [x] add support for all field structures in `GetColumnsForField`
- [x] decide on when to collect the (size) data: on creation of the `RNTupleInspector` object (how it is done now), or in a more on-the-fly approach


