### PR TITLE
Fix rounding issue in TAxis::FindFixBin

### DIFF
--- a/hist/hist/src/TAxis.cxx
+++ b/hist/hist/src/TAxis.cxx
@@ -311,7 +311,7 @@ Int_t TAxis::FindBin(Double_t x)
       return FindFixBin(x);
    } else {
       if (!fXbins.fN) {        //*-* fix bins
-         bin = 1 + int (fNbins*(x-fXmin)/(fXmax-fXmin) );
+         bin = 1 + round( (double)fNbins*((x-fXmin)/(fXmax-fXmin)) );
       } else {                  //*-* variable bin sizes
          //for (bin =1; x >= fXbins.fArray[bin]; bin++);
          bin = 1 + TMath::BinarySearch(fXbins.fN,fXbins.fArray,x);
@@ -425,9 +425,8 @@ Int_t TAxis::FindFixBin(Double_t x) const
       bin = fNbins+1;
    } else {
       if (!fXbins.fN) {        //*-* fix bins
-         bin = 1 + int (fNbins*(x-fXmin)/(fXmax-fXmin) );
+         bin = 1 + round( (double)fNbins*((x-fXmin)/(fXmax-fXmin)) );
       } else {                  //*-* variable bin sizes
-//         for (bin =1; x >= fXbins.fArray[bin]; bin++);
          bin = 1 + TMath::BinarySearch(fXbins.fN,fXbins.fArray,x);
       }
    }


### PR DESCRIPTION
Fix a rounding problem in FndFixBin. the attached code show the problem. This was mentioned in the issue:  https://github.com/root-project/root/issues/11212

### Reproducer
```
void testProblem(){
   int   nb = 4;
   float x2 = 0.005;
   float x1 = 0.0;

   auto h1 = new TH1F("h1" ,"h1" ,nb ,x1 ,x2);
   auto h2 = new TH1F("h2" ,"h2" ,nb ,x1 ,x2);

   double xr1 = h1->GetXaxis()->GetBinLowEdge(2);

   h1->GetXaxis()->SetRangeUser(xr1, x2);

   h2->SetBinContent(1 ,1000);
   h2->SetBinContent(2 ,500);
   h2->SetBinContent(3 ,300);
   h2->SetBinContent(4 ,50);

   h1->SetBinContent(1 ,1000);
   h1->SetBinContent(2 ,500);
   h1->SetBinContent(3 ,300);
   h1->SetBinContent(4 ,50);
   h1->SetLineColor(kRed);

   auto c = new TCanvas;
   c->SetLogx();
   h1->Draw();
   h2->Draw("same"); //only 3 bins should be visible, the 2 histograms should overlap.
}
```
