### PR TITLE
Don't install roofit files when roofit is disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -591,7 +591,14 @@ if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_INSTALL_PREFIX)
   else()
     install(DIRECTORY README DESTINATION ${CMAKE_INSTALL_DOCDIR})
   endif()
+  set(ETC_PATT_EXCL)
+  if(NOT roofit)
+    list(APPEND ETC_PATT_EXCL PATTERN HistFactorySchema.dtd EXCLUDE)
+    list(APPEND ETC_PATT_EXCL PATTERN RooFitHS3_wsexportkeys.json EXCLUDE)
+    list(APPEND ETC_PATT_EXCL PATTERN RooFitHS3_wsfactoryexpressions.json EXCLUDE)
+  endif()
   install(DIRECTORY etc/ DESTINATION ${CMAKE_INSTALL_SYSCONFDIR} USE_SOURCE_PERMISSIONS
+                         ${ETC_PATT_EXCL}
                          PATTERN "system.rootrc" EXCLUDE
                          PATTERN "system.rootauthrc" EXCLUDE
                          PATTERN "system.rootdaemonrc" EXCLUDE
@@ -612,8 +619,11 @@ if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_INSTALL_PREFIX)
      set(MAN_PATT_EXCL PATTERN xproofd.1 EXCLUDE)
   endif()
   if(NOT fortran OR NOT CMAKE_Fortran_COMPILER)
-    set(MAN_PATT_EXCL ${MAN_PATT_EXCL} PATTERN h2root.1 EXCLUDE)
-    set(MAN_PATT_EXCL ${MAN_PATT_EXCL} PATTERN g2root.1 EXCLUDE)
+    list(APPEND MAN_PATT_EXCL PATTERN h2root.1 EXCLUDE)
+    list(APPEND MAN_PATT_EXCL PATTERN g2root.1 EXCLUDE)
+  endif()
+  if(NOT roofit)
+    list(APPEND MAN_PATT_EXCL PATTERN prepareHistFactory.1 EXCLUDE)
   endif()
   install(DIRECTORY man/    DESTINATION ${CMAKE_INSTALL_MANDIR} ${MAN_PATT_EXCL})
   install(DIRECTORY tutorials/ DESTINATION ${CMAKE_INSTALL_TUTDIR} COMPONENT tests)

--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -29,6 +29,9 @@ ROOT_EXECUTABLE(rmkdepend
 
 if(NOT MSVC AND _BUILD_TYPE_UPPER MATCHES "DEBUG|RELWITHDEBINFO")
   file(GLOB PRETTY_PRINTERS "gdbPrinters/*.so-gdb.py")
+  if(NOT roofit)
+    list(REMOVE_ITEM PRETTY_PRINTERS gdbPrinters/libRooFitCore.so-gdb.py)
+  endif()
   set(PRETTY_PRINTER_DESTS)
   foreach(PRETTY_PRINTER ${PRETTY_PRINTERS})
     get_filename_component(PRETTY_PRINTER_DEST ${PRETTY_PRINTER} NAME)

--- a/core/base/CMakeLists.txt
+++ b/core/base/CMakeLists.txt
@@ -224,7 +224,9 @@ if(NOT MSVC)
 #---addRootC++CmdMan-------------------------------------------------------------------------
 generateManual(rootMan ${CMAKE_CURRENT_SOURCE_DIR}/src/root-argparse.py ${CMAKE_BINARY_DIR}/man/root.1)
 generateManual(haddMan ${CMAKE_SOURCE_DIR}/main/src/hadd-argparse.py ${CMAKE_BINARY_DIR}/man/hadd.1)
+if (roofit)
 generateManual(hist2workspaceMan ${CMAKE_SOURCE_DIR}/roofit/histfactory/src/hist2workspace-argparse.py ${CMAKE_BINARY_DIR}/man/hist2workspace.1)
+endif()
 generateManual(rootclingMan ${CMAKE_SOURCE_DIR}/core/dictgen/src/rootcling-argparse.py ${CMAKE_BINARY_DIR}/man/rootcling.1)
 
 #---addRootPyCmdMan---------------------------------------------------------------------------


### PR DESCRIPTION
# This Pull request:

When roofit is disabled, some roofit related files are still installed.

## Changes or fixes:

This PR makes the installation of those files conditional.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
