### PR TITLE
Veto tests using clad when clad is disabled

### DIFF
--- a/math/minuit2/test/CMakeLists.txt
+++ b/math/minuit2/test/CMakeLists.txt
@@ -11,10 +11,10 @@ if(NOT DEFINED ROOT_SOURCE_DIR)
    include(${ROOT_USE_FILE})
 endif()
 
-set(TestSource
-      testMinimizer.cxx
-      testADMinim.cxx
-)
+set(TestSource testMinimizer.cxx)
+if (clad)
+  list(APPEND TestSource testADMinim.cxx)
+endif()
 
 set(TestSourceMnTutorial
     MnTutorial/Quad1FMain.cxx

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -65,14 +65,16 @@ endfunction()
 
 #---Tutorials disabled depending on the build components-------------
 if(NOT ROOT_minuit2_FOUND)
-  set(minuit2_veto fit/fit2dHist.C fit/fit2dHist.C
-                   fit/fitCircle.C fit/minuit2FitBench2D.C
+  set(minuit2_veto fit/fit2dHist.C fit/fitCircle.C
                    fit/minuit2FitBench2D.C fit/minuit2FitBench.C
-                   fit/minuit2FitBench.C fit/minuit2GausFit.C
                    fit/minuit2GausFit.C fit/NumericalMinimization.C
                    fit/combinedFit.C fit/TestBinomial.C
                    fit/fitNormSum.C fit/vectorizedFit.C
                    tutorials/roostats/rs_bernsteinCorrection.C)
+endif()
+
+if(NOT clad)
+  set(clad_veto fit/minuit2GausFit.C)
 endif()
 
 if (NOT dataframe)
@@ -457,6 +459,7 @@ set(all_veto hsimple.C
              ${spectrum_veto}
              ${dataframe_veto}
              ${macm1_veto}
+             ${clad_veto}
              )
 
 file(GLOB_RECURSE tutorials RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.C)


### PR DESCRIPTION
# This Pull request:

Then clad is disabled, some tests that use it are still run causing test failures.

## Changes or fixes:

This PR vetos thos tests.
(Also removed duplicates in minuit2 veto.)

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
