### PR TITLE
Fix URL parsing in TChain for fragment parameters

### DIFF
--- a/tree/tree/inc/TChain.h
+++ b/tree/tree/inc/TChain.h
@@ -48,7 +48,8 @@ protected:
 private:
    TChain(const TChain&);            // not implemented
    TChain& operator=(const TChain&); // not implemented
-   void ParseTreeFilename(const char *name, TString &filename, TString &treename, TString &query, TString &suffix, Bool_t wildcards) const;
+   void
+   ParseTreeFilename(const char *name, TString &filename, TString &treename, TString &query, TString &suffix) const;
 
 protected:
    void InvalidateCurrentTree();

--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -362,7 +362,7 @@ Int_t TChain::Add(TChain* chain)
 Int_t TChain::Add(const char* name, Long64_t nentries /* = TTree::kMaxEntries */)
 {
    TString basename, treename, query, suffix;
-   ParseTreeFilename(name, basename, treename, query, suffix, kTRUE);
+   ParseTreeFilename(name, basename, treename, query, suffix);
 
    // case with one single file
    if (!basename.MaybeWildcard()) {
@@ -495,7 +495,7 @@ Int_t TChain::AddFile(const char* name, Long64_t nentries /* = TTree::kMaxEntrie
    if (tname && strlen(tname) > 0) treename = tname;
 
    TString basename, tn, query, suffix;
-   ParseTreeFilename(name, basename, tn, query, suffix, kFALSE);
+   ParseTreeFilename(name, basename, tn, query, suffix);
 
    if (!tn.IsNull()) {
       treename = tn.Data();
@@ -2143,12 +2143,6 @@ Long64_t TChain::Merge(TFile* file, Int_t basketsize, Option_t* option)
 /// pass the treename if the query field is empty.
 ///
 /// \param[in] name        is the original name
-/// \param[in] wildcards   indicates if the resulting filename will be treated for
-///                        wildcards. For backwards compatibility, with most protocols
-///                        this flag suppresses the search for the url fragment
-///                        identifier and limits the query identifier search to cases
-///                        where the tree name is given as a trailing slash-separated
-///                        string at the end of the file name.
 /// \param[out] filename   the url or filename to be opened or matched
 /// \param[out] treename   the treename, which may be found in a url fragment section
 ///                        as a trailing part of the name (deprecated).
@@ -2160,8 +2154,8 @@ Long64_t TChain::Merge(TFile* file, Int_t basketsize, Option_t* option)
 ///                        a fragment this will be empty.
 /// \param[out] suffix     the portion of name which was removed to from filename.
 
-void TChain::ParseTreeFilename(const char *name, TString &filename, TString &treename, TString &query, TString &suffix,
-                               Bool_t) const
+void TChain::ParseTreeFilename(const char *name, TString &filename, TString &treename, TString &query,
+                               TString &suffix) const
 {
    Ssiz_t pIdx = kNPOS;
    filename.Clear();

--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -2173,7 +2173,7 @@ void TChain::ParseTreeFilename(const char *name, TString &filename, TString &tre
       query.Form("?%s", url.GetOptions());
    // The treename can be passed as anchor
    const char *anchor = url.GetAnchor();
-   if (anchor && (strlen(anchor) > 0)) {
+   if (anchor && anchor[0] != '\0') {
       // Support "?#tree_name" and "?query#tree_name"
       // "#tree_name" (no '?' is for tar archives)
       // If the treename would contain a '=', treat the anchor as part of the query instead. This makes sure

--- a/tree/tree/test/TChainParsing.cxx
+++ b/tree/tree/test/TChainParsing.cxx
@@ -10,13 +10,18 @@
 
 TEST(TChainParsing, RemoteAdd)
 {
-   TChain c;
+   TChain c("defaultname");
    c.Add("root://some.domain/path/to/file.root/treename");
    c.Add("root://some.domain//path/to/file.root/treename");
    c.Add("root://some.domain/path/to/foo.something/file.root/treename");
    c.Add("root://some.domain/path/to/foo.root/file.root/treename"); // ROOT-9344
    c.Add("root://some.domain/path//to/file.root/treename"); // ROOT-10494
    c.Add("root://some.domain//path//to//file.root//treename");
+   c.Add("https://some.domain:8443/path/to/file.root.1?#treename");
+   c.Add("https://some.domain:8443/path/to/file.root.1#anchor");
+   c.Add("https://some.domain:8443/path/to/file.root.1?a=b&x=y&");
+   c.Add("https://some.domain:8443/path/to/file.root.1?a=b&x=y&#treename");
+   c.Add("https://some.domain:8443/path/to/file.root.1?a=b&x=y&#X=Y");
    const auto files = c.GetListOfFiles();
 
    EXPECT_STREQ(files->At(0)->GetTitle(), "root://some.domain/path/to/file.root");
@@ -36,6 +41,21 @@ TEST(TChainParsing, RemoteAdd)
 
    EXPECT_STREQ(files->At(5)->GetTitle(), "root://some.domain//path/to/file.root");
    EXPECT_STREQ(files->At(5)->GetName(), "treename");
+
+   EXPECT_STREQ(files->At(6)->GetTitle(), "https://some.domain:8443/path/to/file.root.1");
+   EXPECT_STREQ(files->At(6)->GetName(), "treename");
+
+   EXPECT_STREQ(files->At(7)->GetTitle(), "https://some.domain:8443/path/to/file.root.1#anchor");
+   EXPECT_STREQ(files->At(7)->GetName(), "defaultname");
+
+   EXPECT_STREQ(files->At(8)->GetTitle(), "https://some.domain:8443/path/to/file.root.1?a=b&x=y&");
+   EXPECT_STREQ(files->At(8)->GetName(), "defaultname");
+
+   EXPECT_STREQ(files->At(9)->GetTitle(), "https://some.domain:8443/path/to/file.root.1?a=b&x=y&");
+   EXPECT_STREQ(files->At(9)->GetName(), "treename");
+
+   EXPECT_STREQ(files->At(10)->GetTitle(), "https://some.domain:8443/path/to/file.root.1?a=b&x=y&#X=Y");
+   EXPECT_STREQ(files->At(10)->GetName(), "defaultname");
 }
 
 TEST(TChainParsing, LocalAdd)


### PR DESCRIPTION
Davix interprets certain parameters that are passed in the anchor part of the URL (after the `#`). The anchor, however, is also used by `TChain` to pass the treename. This patch looks at the anchor and if it contains an equal sign (`=`), it assumes that it is a parameter list for Davix and not a treename.

See also https://root-forum.cern.ch/t/problem-with-tchain-and-https-turls/53545/7