### PR TITLE
Graceful no DistRDF

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_facade.py
@@ -336,8 +336,11 @@ class ROOTFacade(types.ModuleType):
             ns.FromNumpy = MakeNumpyDataFrame
 
             if sys.version_info >= (3, 8):
-                # Inject Experimental.Distributed package into namespace RDF
-                ns.Experimental.Distributed = _create_rdf_experimental_distributed_module(ns.Experimental)
+                try:
+                    # Inject Experimental.Distributed package into namespace RDF if available
+                    ns.Experimental.Distributed = _create_rdf_experimental_distributed_module(ns.Experimental)
+                except ImportError:
+                    pass
         except:
             raise Exception('Failed to pythonize the namespace RDF')
         del type(self).RDF

--- a/bindings/pyroot/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_facade.py
@@ -335,7 +335,7 @@ class ROOTFacade(types.ModuleType):
             ns.MakeNumpyDataFrame = DeprecatedMakeNumpy
             ns.FromNumpy = MakeNumpyDataFrame
 
-            if sys.version_info >= (3, 7):
+            if sys.version_info >= (3, 8):
                 # Inject Experimental.Distributed package into namespace RDF
                 ns.Experimental.Distributed = _create_rdf_experimental_distributed_module(ns.Experimental)
         except:


### PR DESCRIPTION
# This Pull request:

Missing experimental add-on module ROOT.RDF.Experimental.Distributed (DistRDF) should not fail the loading of the rest of the ROOT.RDF namespace.

Also addresses a mismatch in the minimum Python version check in the code vs. cmake.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2173518
