### PR TITLE
Restore text alignment

### DIFF
--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -89,8 +89,8 @@ It is strongly recommended to persistify those as objects rather than lists of l
   assumed of type F by default. The list of currently supported
   types is given below:
    - `C` : a character string terminated by the 0 character
-///        - `B` : an 8 bit signed integer (`Char_t`); Treated as a character when in an array.
-///        - `b` : an 8 bit unsigned integer (`UChar_t`)
+   - `B` : an 8 bit signed integer (`Char_t`); Treated as a character when in an array.
+   - `b` : an 8 bit unsigned integer (`UChar_t`)
    - `S` : a 16 bit signed integer (`Short_t`)
    - `s` : a 16 bit unsigned integer (`UShort_t`)
    - `I` : a 32 bit signed integer (`Int_t`)
@@ -1939,8 +1939,8 @@ Int_t TTree::Branch(const char* foldername, Int_t bufsize /* = 32000 */, Int_t s
 ///      variable. If the first variable does not have a type, it is assumed
 ///      of type F by default. The list of currently supported types is given below:
 ///         - `C` : a character string terminated by the 0 character
-///        - `B` : an 8 bit signed integer (`Char_t`); Treated as a character when in an array.
-///        - `b` : an 8 bit unsigned integer (`UChar_t`)
+///         - `B` : an 8 bit signed integer (`Char_t`); Treated as a character when in an array.
+///         - `b` : an 8 bit unsigned integer (`UChar_t`)
 ///         - `S` : a 16 bit signed integer (`Short_t`)
 ///         - `s` : a 16 bit unsigned integer (`UShort_t`)
 ///         - `I` : a 32 bit signed integer (`Int_t`)


### PR DESCRIPTION
# This Pull request:

Recent changes introduced some weird alignment of text in the comments.

## Changes or fixes:

This PR restores the alignment.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

