### PR TITLE
Undesired behaviour with SetRangeUser & Draw->(“same”) & Log Scale

### DIFF
--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -45,6 +45,7 @@
 #include "TGaxis.h"
 #include "TColor.h"
 #include "TPainter3dAlgorithms.h"
+#include "TGraph2D.h"
 #include "TGraph2DPainter.h"
 #include "TGraphDelaunay2D.h"
 #include "TView.h"
@@ -7087,6 +7088,8 @@ Int_t THistPainter::PaintInit()
                if (obj->InheritsFrom(THStack::Class()))     { h1 = ((THStack*)(obj))->GetHistogram()    ; break; }
                if (obj->InheritsFrom(TGraph::Class()))      { h1 = ((TGraph*)(obj))->GetHistogram()     ; break; }
                if (obj->InheritsFrom(TMultiGraph::Class())) { h1 = ((TMultiGraph*)(obj))->GetHistogram(); break; }
+               if (obj->InheritsFrom(TGraph2D::Class()))    { h1 = ((TGraph2D*)(obj))->GetHistogram(); break; }
+               if (obj->InheritsFrom(TF1::Class()))         { h1 = ((TF1*)(obj))->GetHistogram(); break; }
             }
             if (h1) {
                Hparam.xlowedge = h1->GetXaxis()->GetBinLowEdge(h1->GetXaxis()->GetFirst());

--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -7079,7 +7079,13 @@ Int_t THistPainter::PaintInit()
       }
       if (Hparam.xlowedge <=0 ) {
          if (Hoption.Same) {
-            Hparam.xlowedge = TMath::Power(10, gPad->GetUxmin());
+            TH1 *h1;
+            TIter next(gPad->GetListOfPrimitives());
+            while ((h1 = (TH1 *)next())) {
+               if (!h1->InheritsFrom(TH1::Class())) continue;
+               Hparam.xlowedge = h1->GetXaxis()->GetBinLowEdge(h1->GetXaxis()->GetFirst());
+               break;
+            }
          } else {
             for (i=first; i<=last; i++) {
                Double_t binLow = fXaxis->GetBinLowEdge(i);

--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -7079,12 +7079,20 @@ Int_t THistPainter::PaintInit()
       }
       if (Hparam.xlowedge <=0 ) {
          if (Hoption.Same) {
-            TH1 *h1;
+            TH1* h1 = nullptr;
+            TObject *obj;
             TIter next(gPad->GetListOfPrimitives());
-            while ((h1 = (TH1 *)next())) {
-               if (!h1->InheritsFrom(TH1::Class())) continue;
+            while ((obj = (TObject *)next())) {
+               if (obj->InheritsFrom(TH1::Class()))         { h1 = (TH1*)(obj)                          ; break; }
+               if (obj->InheritsFrom(THStack::Class()))     { h1 = ((THStack*)(obj))->GetHistogram()    ; break; }
+               if (obj->InheritsFrom(TGraph::Class()))      { h1 = ((TGraph*)(obj))->GetHistogram()     ; break; }
+               if (obj->InheritsFrom(TMultiGraph::Class())) { h1 = ((TMultiGraph*)(obj))->GetHistogram(); break; }
+            }
+            if (h1) {
                Hparam.xlowedge = h1->GetXaxis()->GetBinLowEdge(h1->GetXaxis()->GetFirst());
-               break;
+            } else {
+               Error(where, "undefined user's coordinates. Cannot use option SAME");
+               return 0;
             }
          } else {
             for (i=first; i<=last; i++) {


### PR DESCRIPTION
Fix https://github.com/root-project/root/issues/11212

The fix proposed in this PR was not correct: https://github.com/root-project/root/pull/12401


### Reproducer
```
void testProblem(){
   int   nb = 4;
   float x2 = 0.005;
   float x1 = 0.0;

   auto h1 = new TH1F("h1" ,"h1" ,nb ,x1 ,x2);
   auto h2 = new TH1F("h2" ,"h2" ,nb ,x1 ,x2);

   double xr1 = h1->GetXaxis()->GetBinLowEdge(2);

   h1->GetXaxis()->SetRangeUser(xr1, x2);

   h2->SetBinContent(1 ,1000);
   h2->SetBinContent(2 ,500);
   h2->SetBinContent(3 ,300);
   h2->SetBinContent(4 ,50);

   h1->SetBinContent(1 ,1000);
   h1->SetBinContent(2 ,500);
   h1->SetBinContent(3 ,300);
   h1->SetBinContent(4 ,50);
   h1->SetLineColor(kRed);

   auto c = new TCanvas;
   c->SetLogx();
   h1->Draw();
   h2->Draw("same"); //only 3 bins should be visible, the 2 histograms should overlap.
}
```