### PR TITLE
Fix TEfficiency::Fit  for 2D or 3D fits 

### DIFF
--- a/hist/hist/src/TEfficiency.cxx
+++ b/hist/hist/src/TEfficiency.cxx
@@ -2373,7 +2373,8 @@ TFitResultPtr TEfficiency::Fit(TF1* f1,Option_t* opt)
    TFitResultPtr result = Fitter.Fit(f1,option.Data());
 
    //create copy which is appended to the list
-   TF1* pFunc = new TF1(*f1);
+   auto pFunc = static_cast<TF1*>(f1->IsA()->New());
+   f1->Copy(*pFunc);
 
    if(bDeleteOld) {
       TIter next(fFunctions);


### PR DESCRIPTION
This Pull request fixes a crash occurring in 6.26 (and older versions) when fitting Efficiency with 2D or 3D functions. 

The crash is caused by copying the TF2 using the copy constructor of TF1. 
It is not happening in 6.28 due to a fix in the Copy function of the TFx classes (see #10942)


