### PR TITLE
[hist] Improve TEfficiency::Fit and handling of binned likelihood fits in FitResult

### DIFF
--- a/hist/hist/src/TBinomialEfficiencyFitter.cxx
+++ b/hist/hist/src/TBinomialEfficiencyFitter.cxx
@@ -282,28 +282,33 @@ TFitResultPtr TBinomialEfficiencyFitter::Fit(TF1 *f1, Option_t* option)
 
    // perform the actual fit
 
-   fFitDone = kTRUE;
+   // set the fit to be a binned likelihood fit
+   // so use as chi2 for goodness of fit Baker&Cousins LR
+   fFitter->SetFitType(3);
    Bool_t status = fFitter->FitFCN();
    if ( !status && !quiet)
       Warning("Fit","Abnormal termination of minimization.");
 
+   fFitDone = kTRUE;
+
+   // set the number of fitted points
+   // number of fit points is set in ComputeFCN in the TF1 object
+   fFitter->SetNumberOfFitPoints(f1->GetNumberFitPoints());
 
    //Store fit results in fitFunction
    const ROOT::Fit::FitResult & fitResult = fFitter->Result();
    if (!fitResult.IsEmpty() ) {
-      // set in f1 the result of the fit
       f1->SetNDF(fitResult.Ndf() );
-
-      //f1->SetNumberFitPoints(...);  // this is set in ComputeFCN
+      f1->SetChisquare(fitResult.Chi2());
 
       f1->SetParameters( &(fitResult.Parameters().front()) );
       if ( int( fitResult.Errors().size()) >= f1->GetNpar() )
          f1->SetParErrors( &(fitResult.Errors().front()) );
 
-      f1->SetChisquare(2.*fitResult.MinFcnValue());    // store goodness of fit (Baker&Cousins)
-      f1->SetNDF(f1->GetNumberFitPoints()- fitResult.NFreeParameters());
-      Info("result"," chi2 %f ndf %d ",2.*fitResult.MinFcnValue(), fitResult.Ndf() );
-
+      if (!quiet) {
+         Info("Fit","Successful Result from Binomial Efficiency fitter of function %s",f1->GetName());
+         fitResult.Print(std::cout);
+      }
    }
    // create a new result class if needed
    if (saveResult) {

--- a/math/mathcore/inc/Fit/FitResult.h
+++ b/math/mathcore/inc/Fit/FitResult.h
@@ -76,7 +76,7 @@ public:
       Run also Minos if requested from the configuration
     */
    void FillResult(const std::shared_ptr<ROOT::Math::Minimizer> & min, const FitConfig & fconfig,  const std::shared_ptr<IModelFunction> & f,
-              bool isValid, unsigned int sizeOfData = 0, bool binFit = true, const ROOT::Math::IMultiGenFunction *chi2func = nullptr, unsigned int ncalls = 0);
+              bool isValid, unsigned int sizeOfData = 0, int fitType = 1, const ROOT::Math::IMultiGenFunction *chi2func = nullptr, unsigned int ncalls = 0);
 
 
    /**
@@ -187,6 +187,12 @@ public:
 
    /// set the Minos errors for parameter i (called by the Fitter class when running Minos)
    void SetMinosError(unsigned int i, double elow, double eup);
+
+   /// Set the chi2 and the ndf
+   /// This function should be called when using an external FCN for fitting
+   /// and one provides the chi2 and the number of fitting data points) to store
+   /// and have them printed in the FitResult class
+   void SetChi2AndNdf(double chi2, unsigned int npoints);
 
    /// query if parameter i has the Minos error
    bool HasMinosError(unsigned int i) const;

--- a/math/mathcore/inc/Fit/Fitter.h
+++ b/math/mathcore/inc/Fit/Fitter.h
@@ -462,6 +462,21 @@ public:
    */
    bool ApplyWeightCorrection(const ROOT::Math::IMultiGenFunction & loglw2, bool minimizeW2L=false);
 
+   /// Set number of fit points when using an external FCN function
+   /// This function can be called after Fit to set the correct number of Ndf in FitResult
+   void SetNumberOfFitPoints(unsigned int npoints) {
+      if (fExtObjFunction) fDataSize = npoints;
+      if (!fResult->IsEmpty()) fResult->SetChi2AndNdf(-1,npoints);
+   }
+
+   /// Set the type of fit when using an external FCN
+   /// possible types are : 1 (least-square), 2 (unbinned-likelihood), 3 (binned-likelihood)
+   /// Note that in case of binned likelihood fit the chi2 will be computed as 2 * MinFCN()
+   /// Note this function should be called before fitting to have effect on th FitResult
+   void SetFitType(int type) {
+      if (fExtObjFunction) fFitType = type;
+   }
+
 
 protected:
 
@@ -533,7 +548,7 @@ private:
                             ///< in case of false the fit is unbinned or undefined)
                             ///< flag it is used to compute chi2 for binned likelihood fit
 
-   int fFitType = 0;   ///< type of fit   (0 undefined, 1 least square, 2 likelihood)
+   int fFitType = 0;   ///< type of fit   (0 undefined, 1 least square, 2 likelihood, 3 binned likelihood)
 
    int fDataSize = 0;  ///< size of data sets (need for Fumili or LM fitters)
 

--- a/math/mathcore/src/Fitter.cxx
+++ b/math/mathcore/src/Fitter.cxx
@@ -803,7 +803,7 @@ bool Fitter::DoMinimization(const ROOT::Math::IMultiGenFunction * chi2func) {
 
    if (!fResult) fResult = std::make_shared<FitResult>();
 
-   fResult->FillResult(fMinimizer,fConfig, fFunc, isValid, fDataSize, fBinFit, chi2func );
+   fResult->FillResult(fMinimizer,fConfig, fFunc, isValid, fDataSize, fFitType, chi2func );
 
    // if requested run Minos after minimization
    if (isValid && fConfig.MinosErrors()) {


### PR DESCRIPTION
- Fix also the copying of the TF1 object after fitting. Use IsA()->New() instead of copy constructor which will not work correctly for TF2 and TF3 objects
- Improve the binomial fit used by TEfficiency::Fit by setting the correct chi2 and number of degree of freedom.
For this, add a function in the Fitter class to set number of fit points and to set the fit type flag. When the fit type is a binned likelihood fit use in FitResult as chi2 value to report 2 * NLL

