### PR TITLE
Use FILTER instead of REMOVE_ITEM since GLOB returns absolute paths

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -30,7 +30,7 @@ ROOT_EXECUTABLE(rmkdepend
 if(NOT MSVC AND _BUILD_TYPE_UPPER MATCHES "DEBUG|RELWITHDEBINFO")
   file(GLOB PRETTY_PRINTERS "gdbPrinters/*.so-gdb.py")
   if(NOT roofit)
-    list(REMOVE_ITEM PRETTY_PRINTERS gdbPrinters/libRooFitCore.so-gdb.py)
+    list(FILTER PRETTY_PRINTERS EXCLUDE REGEX libRooFitCore.so-gdb.py)
   endif()
   set(PRETTY_PRINTER_DESTS)
   foreach(PRETTY_PRINTER ${PRETTY_PRINTERS})


### PR DESCRIPTION
# This Pull request:

Use FILTER instead of REMOVE_ITEM since GLOB returns absolute paths

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
