### PR TITLE
[TMVA] Resize method for RTensor

### DIFF
--- a/tmva/tmva/inc/TMVA/RTensor.hxx
+++ b/tmva/tmva/inc/TMVA/RTensor.hxx
@@ -257,6 +257,7 @@ public:
    RTensor<Value_t, Container_t> Squeeze() const;
    RTensor<Value_t, Container_t> ExpandDims(int idx) const;
    RTensor<Value_t, Container_t> Reshape(const Shape_t &shape) const;
+   RTensor<Value_t, Container_t> Resize(const Shape_t &shape);
    RTensor<Value_t, Container_t> Slice(const Slice_t &slice);
 
    // Iterator class
@@ -483,6 +484,23 @@ inline RTensor<Value_t, Container_t> RTensor<Value_t, Container_t>::Reshape(cons
    // Create copy, replace and return
    RTensor<Value_t, Container_t> x(*this);
    x.ReshapeInplace(shape);
+   return x;
+}
+
+/// \brief Resize tensor
+/// \param[in] shape Shape vector
+/// \returns New RTensor
+/// Resize tensor into new shape
+template <typename Value_t, typename Container_t>
+inline RTensor<Value_t, Container_t> RTensor<Value_t, Container_t>::Resize(const Shape_t &shape)
+{
+   // Create new tensor with the specified shape
+   RTensor <Value_t, Container_t> x(shape, fLayout);
+   
+   // Copying contents from previous tensor
+   size_t n = (x.GetSize()>fSize) ? fSize : x.GetSize();
+   std::copy(this->GetData(), this->GetData() + n, x.GetData() );
+
    return x;
 }
 

--- a/tmva/tmva/test/rtensor.cxx
+++ b/tmva/tmva/test/rtensor.cxx
@@ -74,6 +74,36 @@ TEST(RTensor, Reshape)
    EXPECT_EQ(s3[0], 6u);
 }
 
+TEST(RTensor, Resize)
+{
+   float rtdata[3] = {0, 1, 2};
+   RTensor<float> x(rtdata, {1, 3});
+   const auto s = x.GetShape();
+   EXPECT_EQ(s.size(), 2u);
+   EXPECT_EQ(s[0], 1u);
+   EXPECT_EQ(s[1], 3u);
+
+   float count = 0;
+   for(size_t i = 0; i<3; ++i){
+         EXPECT_EQ(x(0,i), count);
+         ++count;
+   }
+
+   auto x2 = x.Resize({3, 2});
+   const auto s2 = x2.GetShape();
+   EXPECT_EQ(s2.size(), 2u);
+   EXPECT_EQ(s2[0], 3u);
+   EXPECT_EQ(s2[1], 2u);
+
+   count = -1;
+   for(size_t i = 0; i<3; ++i){
+      for(size_t j = 0; j<2; ++j){
+         count = ((i == 1 && j == 1) || (i == 2) ? 0 : count+1);
+         EXPECT_EQ(x2(i,j), count);
+      }
+   }
+}
+
 TEST(RTensor, ExpandDims)
 {
    RTensor<int> x({2, 3});


### PR DESCRIPTION
This PR adds the Resize method in RTensor. The function operates similarly to that of NumPy's [`resize()`](https://numpy.org/doc/stable/reference/generated/numpy.resize.html) method.