### PR TITLE
Do not record kIsOnHeap nor kNotDeleted

### DIFF
--- a/core/base/src/TObject.cxx
+++ b/core/base/src/TObject.cxx
@@ -886,8 +886,9 @@ void TObject::Streamer(TBuffer &R__b)
    if (R__b.IsReading()) {
       R__b.SkipVersion(); // Version_t R__v = R__b.ReadVersion(); if (R__v) { }
       R__b >> fUniqueID;
+      const UInt_t isonheap = fBits & kIsOnHeap; // Record how this instance was actually allocated.
       R__b >> fBits;
-      fBits |= kIsOnHeap;  // by definition de-serialized object is on heap
+      fBits |= isonheap | kNotDeleted;  // by definition de-serialized object are not yet deleted.
       if (TestBit(kIsReferenced)) {
          //if the object is referenced, we must read its old address
          //and store it in the ProcessID map in gROOT

--- a/core/base/src/TObject.cxx
+++ b/core/base/src/TObject.cxx
@@ -909,12 +909,12 @@ void TObject::Streamer(TBuffer &R__b)
       R__b.WriteVersion(TObject::IsA());
       if (!TestBit(kIsReferenced)) {
          R__b << fUniqueID;
-         R__b << fBits;
+         R__b << (fBits & (~kIsOnHeap & ~kNotDeleted));
       } else {
          //if the object is referenced, we must save its address/file_pid
          UInt_t uid = fUniqueID & 0xffffff;
          R__b << uid;
-         R__b << fBits;
+         R__b << (fBits & (~kIsOnHeap & ~kNotDeleted));
          TProcessID *pid = TProcessID::GetProcessWithUID(fUniqueID,this);
          //add uid to the TRefTable if there is one
          TRefTable *table = TRefTable::GetRefTable();

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -237,7 +237,9 @@ namespace TStreamerInfoActions
       UInt_t *x = (UInt_t*)( ((char*)addr) + config->fOffset );
       // Idea: Implement buf.ReadBasic/Primitive to avoid the return value
       // Idea: This code really belongs inside TBuffer[File]
+      const UInt_t isonheap = *x & TObject::kIsOnHeap; // Record how this instance was actually allocated.
       buf >> *x;
+      *x |= isonheap | TObject::kNotDeleted;  // by definition de-serialized object are not yet deleted.
 
       if ((*x & kIsReferenced) != 0) {
          HandleReferencedTObject(buf,addr,config);

--- a/io/io/src/TStreamerInfoReadBuffer.cxx
+++ b/io/io/src/TStreamerInfoReadBuffer.cxx
@@ -609,6 +609,7 @@ Int_t TStreamerInfo::ReadBufferConv(TBuffer &b, const T &arr,  const TCompInfo *
          DOLOOP {
             UInt_t u;
             b >> u;
+            u |= kNotDeleted;  // by definition de-serialized object are not yet deleted.
             if ((u & kIsReferenced) != 0) {
                UShort_t pidf;
                b >> pidf;
@@ -1019,7 +1020,10 @@ Int_t TStreamerInfo::ReadBuffer(TBuffer &b, const T &arr,
          // special case for TObject::fBits in case of a referenced object
          case TStreamerInfo::kBits: {
             DOLOOP {
-               UInt_t *x=(UInt_t*)(arr[k]+ioffset); b >> *x;
+               UInt_t *x=(UInt_t*)(arr[k]+ioffset);
+               const UInt_t isonheap = *x & TObject::kIsOnHeap; // Record how this instance was actually allocated.
+               b >> *x;
+               *x |= isonheap | TObject::kNotDeleted;  // by definition de-serialized object are not yet deleted.
                if ((*x & kIsReferenced) != 0) {
                   UShort_t pidf;
                   b >> pidf;

--- a/io/io/src/TStreamerInfoWriteBuffer.cxx
+++ b/io/io/src/TStreamerInfoWriteBuffer.cxx
@@ -404,7 +404,7 @@ Int_t TStreamerInfo::WriteBufferAux(TBuffer &b, const T &arr,
 
          // special case for TObject::fBits in case of a referenced object
          case TStreamerInfo::kBits: { DOLOOP {
-            UInt_t *x=(UInt_t*)(arr[k]+ioffset); b << *x;
+            UInt_t *x=(UInt_t*)(arr[k]+ioffset); b << (*x & (~kIsOnHeap & ~kNotDeleted));
             if ((*x & kIsReferenced) != 0) {
                TObject *obj = (TObject*)(arr[k]+eoffset);
                TProcessID *pid = TProcessID::GetProcessWithUID(obj->GetUniqueID(),obj);

--- a/test/stress.cxx
+++ b/test/stress.cxx
@@ -402,9 +402,9 @@ void stress3()
    Float_t comp = f.GetCompressionFactor();
    Bool_t OK = kTRUE;
 #ifdef R__HAS_CLOUDFLARE_ZLIB
-   constexpr Long64_t lastgood = 52290;
+   constexpr Long64_t lastgood = 52264;
 #else
-   constexpr Long64_t lastgood = 52116;
+   constexpr Long64_t lastgood = 52090;
 #endif
    constexpr Long64_t tolerance = 150;
 #ifdef R__HAS_DEFAULT_LZ4


### PR DESCRIPTION
Rather than reading from the file the value of kIsOnHeap, preserve the value that was
calculated at object creation time (i.e. in the current execution).  For example, for
an embedded object (inside an object created on the heap or stack), the bit always
need to be off (i.e. it can never be explicitly deleted)# This Pull request:

When reading back the "heap status" is determine by how the
read-into object was allocated, so there is no need to record
that information.

When reading back, the kNotDeleted is always on, (and should
always be on when writing :) ), so there is no need to record it.

Recording '0' for both allow for (slightly) better compression.

Fix https://github.com/root-project/root/issues/12438
