### PR TITLE
[ntuple] Avoid warning about possibly uninitialized variable

### DIFF
--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -241,7 +241,7 @@ void ROOT::Experimental::Detail::RColumnElement<std::int64_t, ROOT::Experimental
    char *int32SplitArray = reinterpret_cast<char *>(src);
    std::int64_t *int64Array = reinterpret_cast<std::int64_t *>(dst);
    for (std::size_t i = 0; i < count; ++i) {
-      std::int32_t v;
+      std::int32_t v = 0;
       for (std::size_t b = 0; b < 4; ++b) {
          reinterpret_cast<char *>(&v)[b] = int32SplitArray[b * count + i];
       }


### PR DESCRIPTION
Clang 15 warns that the variable v may be used uninitialized because it does not understand the pointer hackery to read individual bytes.