### PR TITLE
Avoid warnings when iterating over a TList in a range-based loop with `auto const&&`

### DIFF
--- a/core/cont/src/TList.cxx
+++ b/core/cont/src/TList.cxx
@@ -23,7 +23,7 @@ not forced by other constraints:
 
   1. (Preferred way) Using the C++ range-based `for` or `begin()` / `end()`:
 ~~~ {.cpp}
-         for(const auto&& obj: *GetListOfPrimitives())
+         for(TObject *obj: *GetListOfPrimitives())
             obj->Write();
 ~~~
   2. Using the R__FOR_EACH macro:

--- a/roofit/multiprocess/src/HeatmapAnalyzer.cxx
+++ b/roofit/multiprocess/src/HeatmapAnalyzer.cxx
@@ -47,9 +47,9 @@ namespace MultiProcess {
 HeatmapAnalyzer::HeatmapAnalyzer(std::string const &logs_dir)
 {
    TSystemDirectory dir(logs_dir.c_str(), logs_dir.c_str());
-   TList *duration_files = dir.GetListOfFiles();
+   std::unique_ptr<TList> durationFiles{dir.GetListOfFiles()};
 
-   for (const auto &&file : *duration_files) {
+   for (TObject *file : *durationFiles) {
       if (std::string(file->GetName()).find("p_") == std::string::npos)
          continue;
 
@@ -81,8 +81,6 @@ HeatmapAnalyzer::HeatmapAnalyzer(std::string const &logs_dir)
    }
 
    sortTaskNames(tasks_names_);
-
-   duration_files->Delete();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/multiprocess/src/HeatmapAnalyzer.cxx
+++ b/roofit/multiprocess/src/HeatmapAnalyzer.cxx
@@ -44,7 +44,7 @@ namespace MultiProcess {
 /// \param[in] logs_dir Directory where log files are stored in the format
 ///                     outputted by RooFit::MultiProcess::ProcessTimer.
 ///                     There can be other files in this directory as well.
-HeatmapAnalyzer::HeatmapAnalyzer(std::string const& logs_dir)
+HeatmapAnalyzer::HeatmapAnalyzer(std::string const &logs_dir)
 {
    TSystemDirectory dir(logs_dir.c_str(), logs_dir.c_str());
    TList *duration_files = dir.GetListOfFiles();
@@ -96,13 +96,14 @@ std::unique_ptr<TH2I> HeatmapAnalyzer::analyze(int analyzed_gradient)
    int gradient_start_t = gradients_["master:gradient"][analyzed_gradient * 2 - 2];
    int gradient_end_t = gradients_["master:gradient"][analyzed_gradient * 2 - 1];
 
-
-   std::unique_ptr<TH2I> total_matrix = std::make_unique<TH2I>("heatmap", "", eval_partitions_names_.size(), 0, 1, tasks_names_.size(), 0, 1);
+   std::unique_ptr<TH2I> total_matrix =
+      std::make_unique<TH2I>("heatmap", "", eval_partitions_names_.size(), 0, 1, tasks_names_.size(), 0, 1);
 
    // loop over all logfiles stored in durations_
    for (json &durations_json : durations_) {
       // partial heatmap is the heatmap that will be filled in for the current durations logfile
-      std::unique_ptr<TH2I> partial_matrix = std::make_unique<TH2I>("partial_heatmap", "", eval_partitions_names_.size(), 0, 1, tasks_names_.size(), 0, 1);
+      std::unique_ptr<TH2I> partial_matrix =
+         std::make_unique<TH2I>("partial_heatmap", "", eval_partitions_names_.size(), 0, 1, tasks_names_.size(), 0, 1);
 
       // remove unnecessary components (those that are out of range)
       for (auto &&el : durations_json.items()) {
@@ -135,8 +136,8 @@ std::unique_ptr<TH2I> HeatmapAnalyzer::analyze(int analyzed_gradient)
                find(eval_partitions_names_.begin(), eval_partitions_names_.end(), eval_partition_name) -
                eval_partitions_names_.begin() + 1;
             partial_matrix->SetBinContent(eval_partitions_idx, tasks_idx,
-                                         durations_json[eval_partition_name][idx + 1].get<int>() -
-                                            durations_json[eval_partition_name][idx].get<int>());
+                                          durations_json[eval_partition_name][idx + 1].get<int>() -
+                                             durations_json[eval_partition_name][idx].get<int>());
          }
       }
       // add all partial matrices to form one matrix with entire gradient evaluation information


### PR DESCRIPTION
The example for range-based iteration in `TList.cxx` uses a pattern that
can yield compiler warnings for some GCC versions:

```
warning: loop variable 'obj' is always a copy because the range of type 'TList' does not return a reference [-Wrange-loop-analysis]
```

To avoid spreading this pattern, this commit suggests to change the
example to explicitly use the `TObject *` type, which also makes the
example clearer.

One of the occurrences of this pattern in RooFit is also changed to `TObject *` to avoid a warning in the Ubuntu 18 nightlies:
https://lcgapp-services.cern.ch/root-jenkins/job/root-incremental-master/LABEL=ROOT-ubuntu1804-clangHEAD,SPEC=noimt/11389/parsed_console/log_content.html#WARNING1

A memory leak in the `HeatmapAnalyzer.cxx` is also fixed.