### PR TITLE
Change `clang-format` style to have line breaks in c'tor initializer

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -38,7 +38,7 @@ BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
 ColumnLimit:     120
 CommentPragmas:  '^ IWYU pragma:'
-ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 3
 ContinuationIndentWidth: 3
 Cpp11BracedListStyle: true


### PR DESCRIPTION
Backport of #12102 , in case we want it for 6.28 too since we'll still be making some changes there.