### PR TITLE
[RF] Rewrite `RooProdPdf.TestGetPartIntList` unit test

### DIFF
--- a/roofit/roofitcore/inc/RooProdPdf.h
+++ b/roofit/roofitcore/inc/RooProdPdf.h
@@ -96,8 +96,6 @@ public:
 
   RooArgSet* findPdfNSet(RooAbsPdf const& pdf) const ;
 
-  void writeCacheToStream(std::ostream& os, RooArgSet const* nset) const;
-
   std::unique_ptr<RooAbsArg> compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileContext & ctx) const override;
 
 private:

--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -2324,10 +2324,6 @@ void RooProdPdf::CacheElem::writeToStream(std::ostream& os) const {
   }
 }
 
-void RooProdPdf::writeCacheToStream(std::ostream& os, RooArgSet const* nset) const {
-  getCacheElem(nset)->writeToStream(os);
-}
-
 std::unique_ptr<RooArgSet> RooProdPdf::fillNormSetForServer(RooArgSet const &normSet, RooAbsArg const &server) const
 {
    if (normSet.empty())


### PR DESCRIPTION
In the ROOT 6.26 development cycle, the RooProdPdf was partially rewritten in moden C++ with less manual memory allocation to improve performance (PR #7907).

In that PR, a unit test that verifies the RooProdPdf can correctly deal with factorizing PDFs was implemented. However, that test used an arbitrary PDF where the correct factorization was checked in a rather crude way: check by hashing the content of the RooProdPdf cache element for a given normalization set that said PR doesn't change any behavior (the reference hash was hardcoded in the unit test).

This commit suggests a better alternative for the unit test, checking for a multidimensional product pdf of factorizing uniform pdfs that the pdf values for differenc normalization sets is as expected. This should cover the same functionality and is less fragile and implementation dependend than hashing the cache elements.

This closes GitHub issue #12430, as the rewritten test is not affected anymore by the problem reported in that issue.

The commit also removed the `RooProdPdf::writeCacheToStream()` function that was an implementation detail of the old unit test.