### PR TITLE
Fix multiple hist drawing in log scale.

### DIFF
--- a/hist/histpainter/src/TGraphPainter.cxx
+++ b/hist/histpainter/src/TGraphPainter.cxx
@@ -1966,8 +1966,9 @@ void TGraphPainter::PaintGrapHist(TGraph *theGraph, Int_t npoints, const Double_
    if ((optionHist) || !chopt[0]) {
       if (!optionRot) {
          gxwork[0] = wmin;
-         gywork[0] = TMath::Min(TMath::Max((Double_t)0,gPad->GetUymin())
-                                           ,gPad->GetUymax());
+         if (!optionOne) gywork[0] = TMath::Min(TMath::Max((Double_t)0,gPad->GetUymin())
+                                               ,gPad->GetUymax());
+         else            gywork[0] = gPad->GetUymin();
          ywmin    = gywork[0];
          npt      = 2;
          for (i=first; i<=last;i++) {
@@ -2033,7 +2034,8 @@ void TGraphPainter::PaintGrapHist(TGraph *theGraph, Int_t npoints, const Double_
          }  //endfor (i=first; i<=last;i++)
       } else {
          gywork[0] = wmin;
-         gxwork[0] = TMath::Max((Double_t)0,gPad->GetUxmin());
+         if (!optionOne) gxwork[0] = TMath::Max((Double_t)0,gPad->GetUxmin());
+         else            gxwork[0] = gPad->GetUxmin();
          xwmin    = gxwork[0];
          npt      = 2;
          for (i=first; i<=last;i++) {

--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -6893,18 +6893,16 @@ void THistPainter::PaintHist(Option_t *)
 
    //         Code option for GrapHist
 
-   if (Hoption.Line) chopth[0] = 'L';
-   if (Hoption.Star) chopth[1] = '*';
-   if (Hoption.Mark) chopth[2] = 'P';
+   if (Hoption.Line)       chopth[0] = 'L';
+   if (Hoption.Star)       chopth[1] = '*';
+   if (Hoption.Mark)       chopth[2] = 'P';
    if (Hoption.Mark == 10) chopth[3] = '0';
    if (Hoption.Line || Hoption.Curve || Hoption.Hist || Hoption.Bar) {
       if (Hoption.Curve)    chopth[3] = 'C';
       if (Hoption.Hist > 0) chopth[4] = 'H';
       else if (Hoption.Bar) chopth[5] = 'B';
+      if (Hoption.Logy) chopth[6] = '1';
       if (fH->GetFillColor() && htype) {
-         if (Hoption.Logy) {
-            chopth[6] = '1';
-         }
          if (Hoption.Hist > 0 || Hoption.Curve || Hoption.Line) {
             chopth[7] = 'F';
          }


### PR DESCRIPTION
When two histograms created with different upper edges of the last bin are drawn in the same pad with a Log y-axis. The edge of the last bin should be drawn as the minimum y value of the pad, instead, it is always set to 1. This artifact is most noticeable when the histogram values are less than 1.

This occurred only when the histogram was drawn as a line, it was correct with a filled area. This patch uses the same algorithm for line drawing as fill area drawing. The problem was seen here: https://github.com/root-project/root/issues/12394

The following macro can be used as a reproducer:
```
{
   gStyle->SetOptStat(0);
   gStyle->SetOptTitle(0);

   auto C = new TCanvas();
   C->Divide(2,1);

   auto h15 = new TH1F("h15","h15", 3, 10, 15);
   auto h25 = new TH1F("h25","h25", 5, 0, 25);

   h15->Fill(11,.5);
   h15->Fill(12,1.);
   h15->Fill(14,.5);
   h15->SetLineWidth(3);

   h25->Fill(1,1);
   h25->Fill(6,2);
   h25->Fill(11,3);
   h25->Fill(16,2);
   h25->Fill(23,1);
   h25->SetLineColor(2);
   h25->SetLineWidth(3);
   h25->SetMinimum(.05);

   C->cd(1);
   h25->Draw("hist");
   h15->Draw("hist same");
   gPad->SetLogy(1);
   gPad->SetGridx(1);
   gPad->SetGridy(1);

   C->cd(2);
   h25->Draw("hist");
   h15->Draw("hist same");
   gPad->SetGridx(1);
   gPad->SetGridy(1);
}
```



