### PR TITLE
Revert "[clang] Mark ContentCache as invalid if !Buffer:"

### DIFF
--- a/interpreter/llvm/src/tools/clang/include/clang/Basic/SourceManager.h
+++ b/interpreter/llvm/src/tools/clang/include/clang/Basic/SourceManager.h
@@ -243,7 +243,7 @@ public:
 
   /// Set the buffer.
   void setBuffer(std::unique_ptr<llvm::MemoryBuffer> B) {
-    IsBufferInvalid = !B;
+    IsBufferInvalid = false;
     Buffer = std::move(B);
   }
 


### PR DESCRIPTION
This reverts commit 8deb57c04a5ceea96533d095092fcd4f71d1df94 and fixes the Cling test `CodeUnloading/Macros.C` that was previously failing with complaints that the unloaded and then re-included `Macros.h` header had no lines 18 and 19.