### PR TITLE
[RF] Fix splitting of RooDataSets with weight errors and avoid creating dummy weight variables

### DIFF
--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -1372,10 +1372,6 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
     ///////////////////////////
     // make data sets
     // THis works and is natural, but the memory size of the simultaneous dataset grows exponentially with channels
-    const char* weightName="weightVar";
-    proto->factory(TString::Format("%s[0,-1e10,1e10]",weightName));
-    proto->defineSet("obsAndWeight",TString::Format("%s,%s",weightName,observablesStr.c_str()));
-
     // New Asimov Generation: Use the code in the Asymptotic calculator
     // Need to get the ModelConfig...
     int asymcalcPrintLevel = 0;
@@ -1389,7 +1385,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
     if(TH1 const* mnominal = channel.GetData().GetHisto()) {
       // This works and is natural, but the memory size of the simultaneous
       // dataset grows exponentially with channels.
-      RooDataSet dataset{"obsData","",*proto->set("obsAndWeight"),weightName};
+      RooDataSet dataset{"obsData","",*proto->set("observables"), RooFit::WeightVar("weightVar")};
       ConfigureHistFactoryDataset( dataset, *mnominal, *proto, fObsNameVec );
       proto->import(dataset);
     } // End: Has non-null 'data' entry
@@ -1411,7 +1407,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
       }
 
       // THis works and is natural, but the memory size of the simultaneous dataset grows exponentially with channels
-      RooDataSet dataset{dataName.c_str(), "", *proto->set("obsAndWeight"), weightName};
+      RooDataSet dataset{dataName.c_str(), "", *proto->set("observables"), RooFit::WeightVar("weightVar")};
       ConfigureHistFactoryDataset( dataset, *mnominal, *proto, fObsNameVec );
       proto->import(dataset);
 
@@ -1449,7 +1445,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
 
       if(obsNameVec.size()==1) {
    double fval = mnominal.GetBinContent(i);
-   obsDataUnbinned.add( *proto.set("obsAndWeight"), fval );
+   obsDataUnbinned.add( *proto.set("observables"), fval );
       } else { // 2 or more dimensions
 
    for(int j=1; j<=ay->GetNbins(); ++j) {
@@ -1458,14 +1454,14 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
 
      if(obsNameVec.size()==2) {
        double fval = mnominal.GetBinContent(i,j);
-       obsDataUnbinned.add( *proto.set("obsAndWeight"), fval );
+       obsDataUnbinned.add( *proto.set("observables"), fval );
      } else { // 3 dimensions
 
        for(int k=1; k<=az->GetNbins(); ++k) {
          double zval = az->GetBinCenter(k);
          proto.var( obsNameVec[2] )->setVal( zval );
          double fval = mnominal.GetBinContent(i,j,k);
-         obsDataUnbinned.add( *proto.set("obsAndWeight"), fval );
+         obsDataUnbinned.add( *proto.set("observables"), fval );
        }
      }
    }

--- a/roofit/roofit/src/RooNDKeysPdf.cxx
+++ b/roofit/roofit/src/RooNDKeysPdf.cxx
@@ -1260,8 +1260,8 @@ double RooNDKeysPdf::analyticalIntegral(Int_t code, const char* rangeName) const
 
 RooDataSet* RooNDKeysPdf::createDatasetFromHist(const RooArgList &varList, const TH1 &hist) const
 {
+   RooArgSet varSet{varList};
    std::vector<RooRealVar *> varVec;
-   RooArgSet varsAndWeightSet;
 
    for (const auto var : varList) {
       if (!dynamic_cast<RooRealVar *>(var)) {
@@ -1269,13 +1269,8 @@ RooDataSet* RooNDKeysPdf::createDatasetFromHist(const RooArgList &varList, const
                                << var->GetName() << " is not of type RooRealVar. Skip." << endl;
          continue;
       }
-      varsAndWeightSet.add(*var);                       // used for dataset creation
       varVec.push_back(static_cast<RooRealVar *>(var)); // used for setting the variables.
    }
-
-   /// Add weight
-   RooRealVar weight("weight", "event weight", 0);
-   varsAndWeightSet.add(weight);
 
    /// determine histogram dimensionality
    unsigned int histndim(0);
@@ -1296,7 +1291,7 @@ RooDataSet* RooNDKeysPdf::createDatasetFromHist(const RooArgList &varList, const
    }
 
    /// dataset creation
-   RooDataSet *dataFromHist = new RooDataSet("datasetFromHist", "datasetFromHist", varsAndWeightSet, weight.GetName());
+   RooDataSet *dataFromHist = new RooDataSet("datasetFromHist", "datasetFromHist", varSet, RooFit::WeightVar());
 
    /// dataset filling
    for (int i = 1; i <= hist.GetXaxis()->GetNbins(); ++i) {
@@ -1307,8 +1302,7 @@ RooDataSet* RooNDKeysPdf::createDatasetFromHist(const RooArgList &varList, const
 
       if (varVec.size() == 1) {
          double fval = hist.GetBinContent(i);
-         weight.setVal(fval);
-         dataFromHist->add(varsAndWeightSet, fval);
+         dataFromHist->add(varSet, fval);
       } else { // 2 or more dimensions
 
          for (int j = 1; j <= hist.GetYaxis()->GetNbins(); ++j) {
@@ -1317,8 +1311,7 @@ RooDataSet* RooNDKeysPdf::createDatasetFromHist(const RooArgList &varList, const
 
             if (varVec.size() == 2) {
                double fval = hist.GetBinContent(i, j);
-               weight.setVal(fval);
-               dataFromHist->add(varsAndWeightSet, fval);
+               dataFromHist->add(varSet, fval);
             } else { // 3 dimensions
 
                for (int k = 1; k <= hist.GetZaxis()->GetNbins(); ++k) {
@@ -1326,8 +1319,7 @@ RooDataSet* RooNDKeysPdf::createDatasetFromHist(const RooArgList &varList, const
                   varVec[2]->setVal(zval);
 
                   double fval = hist.GetBinContent(i, j, k);
-                  weight.setVal(fval);
-                  dataFromHist->add(varsAndWeightSet, fval);
+                  dataFromHist->add(varSet, fval);
                }
             }
          }

--- a/roofit/roofit/test/testRooKeysPdf.cxx
+++ b/roofit/roofit/test/testRooKeysPdf.cxx
@@ -19,13 +19,12 @@ TEST(RooKeysPdf, WeightedDataset)
    // this validates that dataset weights are correctly dealt with.
 
    RooRealVar x("x", "x", 0, 20);
-   RooRealVar weight("weight", "weight", 0, 2000);
 
    const std::size_t nEvents0 = 100;
    const std::size_t nEvents1 = 400;
 
    RooDataSet data1{"data1", "data1", x};
-   RooDataSet data2{"data2", "data2", {x, weight}, "weight"};
+   RooDataSet data2{"data2", "data2", x, RooFit::WeightVar()};
 
    x.setVal(5);
    for (std::size_t i = 0; i < nEvents0; ++i) {

--- a/roofit/roofitcore/inc/RooDataSet.h
+++ b/roofit/roofitcore/inc/RooDataSet.h
@@ -66,11 +66,11 @@ public:
   // Constructors, factory methods etc.
   RooDataSet() ;
 
-  // Empty constructor
-  RooDataSet(RooStringView name, RooStringView title, const RooArgSet& vars, const char* wgtVarName=nullptr) ;
+  RooDataSet(RooStringView name, RooStringView title, const RooArgSet& vars, const char* wgtVarName)
+     R__SUGGEST_ALTERNATIVE("Use RooDataSet(name, title, vars, RooFit::WeightVar(wgtVarName)).");
 
   // Universal constructor
-  RooDataSet(RooStringView name, RooStringView title, const RooArgSet& vars, const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg(),
+  RooDataSet(RooStringView name, RooStringView title, const RooArgSet& vars, const RooCmdArg& arg1=RooCmdArg(), const RooCmdArg& arg2=RooCmdArg(),
              const RooCmdArg& arg3=RooCmdArg(), const RooCmdArg& arg4=RooCmdArg(),const RooCmdArg& arg5=RooCmdArg(),
              const RooCmdArg& arg6=RooCmdArg(),const RooCmdArg& arg7=RooCmdArg(),const RooCmdArg& arg8=RooCmdArg()) ;
 

--- a/roofit/roofitcore/inc/RooDataSet.h
+++ b/roofit/roofitcore/inc/RooDataSet.h
@@ -169,10 +169,8 @@ protected:
              const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
              std::size_t nStart, std::size_t nStop);
 
-  RooArgSet addWgtVar(const RooArgSet& origVars, const RooAbsArg* wgtVar) ;
-
-  RooArgSet _varsNoWgt ;   ///< Vars without weight variable
-  RooRealVar* _wgtVar ;    ///< Pointer to weight variable (if set)
+  RooArgSet _varsNoWgt;          ///< Vars without weight variable
+  RooRealVar *_wgtVar = nullptr; ///< Pointer to weight variable (if set)
 
 private:
 

--- a/roofit/roofitcore/src/RooAbsData.cxx
+++ b/roofit/roofitcore/src/RooAbsData.cxx
@@ -1554,15 +1554,14 @@ TList *splitImpl(RooAbsData const &data, const RooAbsCategory &cloneCat, bool cr
    }
 
    // Loop over dataset and copy event to matching subset
-   const bool propWeightSquared = data.isWeighted();
    for (Int_t i = 0; i < data.numEntries(); ++i) {
       const RooArgSet *row = data.get(i);
-      RooAbsData *subset = (RooAbsData *)dsetList->FindObject(cloneCat.getCurrentLabel());
+      auto subset = static_cast<RooAbsData *>(dsetList->FindObject(cloneCat.getCurrentLabel()));
       if (!subset) {
          subset = createEmptyData(cloneCat.getCurrentLabel());
          dsetList->Add(subset);
       }
-      subset->add(*row, data.weight(), propWeightSquared ? data.weightSquared() : 0.0);
+      subset->add(*row, data.weight(), data.weightError());
    }
 
    return dsetList;

--- a/roofit/roofitcore/src/RooAbsData.cxx
+++ b/roofit/roofitcore/src/RooAbsData.cxx
@@ -1536,12 +1536,7 @@ SplittingSetup initSplit(RooAbsData const &data, RooAbsCategory const &splitCat)
 
    // Add weight variable explicitly if dataset has weights, but no top-level weight
    // variable exists (can happen with composite datastores)
-   if (data.isWeighted() && !data.IsA()->InheritsFrom(RooDataHist::Class())) {
-      auto newweight = std::make_unique<RooRealVar>("weight", "weight", -1e9, 1e9);
-      setup.subsetVars.add(*newweight);
-      setup.addWeightVar = true;
-      setup.ownedSet.addOwned(std::move(newweight));
-   }
+   setup.addWeightVar = data.isWeighted();
 
    return setup;
 }
@@ -1554,8 +1549,7 @@ TList *splitImpl(RooAbsData const &data, const RooAbsCategory &cloneCat, bool cr
    // If createEmptyDataSets is true, prepopulate with empty sets corresponding to all states
    if (createEmptyDataSets) {
       for (const auto &nameIdx : cloneCat) {
-         RooAbsData *subset = createEmptyData(nameIdx.first.c_str());
-         dsetList->Add((RooAbsArg *)subset);
+         dsetList->Add(createEmptyData(nameIdx.first.c_str()));
       }
    }
 
@@ -1566,7 +1560,7 @@ TList *splitImpl(RooAbsData const &data, const RooAbsCategory &cloneCat, bool cr
       RooAbsData *subset = (RooAbsData *)dsetList->FindObject(cloneCat.getCurrentLabel());
       if (!subset) {
          subset = createEmptyData(cloneCat.getCurrentLabel());
-         dsetList->Add((RooAbsArg *)subset);
+         dsetList->Add(subset);
       }
       subset->add(*row, data.weight(), propWeightSquared ? data.weightSquared() : 0.0);
    }

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -579,17 +579,11 @@ RooDataSet::RooDataSet(RooStringView name, RooStringView title, const RooArgSet&
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor of an empty data set from a RooArgSet defining the dimensions
 /// of the data space.
+/// \deprecated Use the more explicit `RooDataSet(name, title, vars, RooFit::WeightVar(wgtVarName))`.
 
-RooDataSet::RooDataSet(RooStringView name, RooStringView title, const RooArgSet& vars, const char* wgtVarName) :
-  RooAbsData(name,title,vars)
+RooDataSet::RooDataSet(RooStringView name, RooStringView title, const RooArgSet& vars, const char* wgtVarName)
+  : RooDataSet(name,title,vars, RooFit::WeightVar(wgtVarName))
 {
-//   cout << "RooDataSet::ctor(" << this << ") storageType = " << ((defaultStorageType==Tree)?"Tree":"Vector") << endl ;
-  _dstore = defaultStorageType==Tree ? static_cast<std::unique_ptr<RooAbsDataStore>>(std::make_unique<RooTreeDataStore>(name,title,_vars,wgtVarName)) :
-                                       static_cast<std::unique_ptr<RooAbsDataStore>>(std::make_unique<RooVectorDataStore>(name,title,_vars,wgtVarName)) ;
-
-  appendToDir(this,true) ;
-  initialize(wgtVarName) ;
-  TRACE_CREATE;
 }
 
 
@@ -1886,9 +1880,9 @@ namespace {
   const char * cstr = "cstr";
   RooRealVar x{"x", "x", 1.0};
   RooArgSet vars{x};
-  RooDataSet d1(tstr, tstr, vars, nullptr);
-  RooDataSet d2(tstr, cstr, vars, nullptr);
-  RooDataSet d3(cstr, tstr, vars, nullptr);
+  RooDataSet d1(tstr, tstr, vars);
+  RooDataSet d2(tstr, cstr, vars);
+  RooDataSet d3(cstr, tstr, vars);
 
 } // namespace
 

--- a/roofit/roofitcore/src/RooGlobalFunc.cxx
+++ b/roofit/roofitcore/src/RooGlobalFunc.cxx
@@ -167,7 +167,10 @@ namespace RooFit {
 
 
   // RooDataSet::ctor arguments
-  RooCmdArg WeightVar(const char* name, bool reinterpretAsWeight) { return RooCmdArg("WeightVarName",reinterpretAsWeight,0,0,0,name,0,0,0) ; }
+  RooCmdArg WeightVar(const char* name, bool reinterpretAsWeight) {
+      if(name == nullptr) return RooCmdArg::none(); // Passing a nullptr name means no weight variable
+      return RooCmdArg("WeightVarName",reinterpretAsWeight,0,0,0,name,0,0,0) ;
+  }
   RooCmdArg WeightVar(const RooRealVar& arg, bool reinterpretAsWeight)  { return RooCmdArg("WeightVar",reinterpretAsWeight,0,0,0,0,0,&arg,0) ; }
   RooCmdArg Link(const char* state, RooAbsData& data)   { return RooCmdArg("LinkDataSlice",0,0,0,0,state,0,&data,0) ;}
   RooCmdArg Import(const char* state, RooAbsData& data) { return RooCmdArg("ImportDataSlice",0,0,0,0,state,0,&data,0) ; }

--- a/roofit/roofitcore/test/testSumW2Error.cxx
+++ b/roofit/roofitcore/test/testSumW2Error.cxx
@@ -35,8 +35,7 @@ TEST(SumW2Error, BatchMode)
    params.snapshot(initialParams);
 
    // these datasets will be filled with a weight that is not unity
-   RooRealVar weight("weight", "weight", 0.5, 0.0, 1.0);
-   RooDataSet dataSetWeighted("dataSetWeighted", "dataSetWeighted", {*dataSet->get(), weight}, "weight");
+   RooDataSet dataSetWeighted("dataSetWeighted", "dataSetWeighted", *dataSet->get(), RooFit::WeightVar());
 
    for (int i = 0; i < dataSet->numEntries(); ++i) {
       dataSetWeighted.add(*dataSet->get(i), 0.5);

--- a/roofit/roofitcore/test/testTestStatistics.cxx
+++ b/roofit/roofitcore/test/testTestStatistics.cxx
@@ -447,8 +447,7 @@ TEST_P(OffsetBinTest, CrossCheck)
    // it correctly.
    {
       // Create weighted dataset and hist to test SumW2 feature
-      RooRealVar weight("weight", "weight", 0.5, 0.0, 1.0);
-      auto dataW = std::make_unique<RooDataSet>("dataW", "dataW", RooArgSet{x, weight}, "weight");
+      auto dataW = std::make_unique<RooDataSet>("dataW", "dataW", x, RooFit::WeightVar());
       for (int i = 0; i < data->numEntries(); ++i) {
          dataW->add(*data->get(i), 0.5);
       }

--- a/roofit/roostats/inc/RooStats/MarkovChain.h
+++ b/roofit/roostats/inc/RooStats/MarkovChain.h
@@ -102,7 +102,7 @@ namespace RooStats {
 
       /// get a clone of the weight variable
       virtual RooRealVar* GetWeightVar() const
-      { return (RooRealVar*)fWeight->Clone(); }
+      { return static_cast<RooRealVar*>(fChain->weightVar()->Clone()); }
 
       ~MarkovChain() override
       {
@@ -116,9 +116,8 @@ namespace RooStats {
       RooArgSet * fDataEntry;
       RooDataSet* fChain;
       RooRealVar* fNLL;
-      RooRealVar* fWeight;
 
-      ClassDefOverride(MarkovChain,1);
+      ClassDefOverride(MarkovChain,2);
    };
 }
 

--- a/roofit/roostats/src/MarkovChain.cxx
+++ b/roofit/roostats/src/MarkovChain.cxx
@@ -49,7 +49,6 @@ MarkovChain::MarkovChain() :
    fDataEntry = nullptr;
    fChain = nullptr;
    fNLL = nullptr;
-   fWeight = nullptr;
 }
 
 MarkovChain::MarkovChain(RooArgSet& parameters) :
@@ -59,7 +58,6 @@ MarkovChain::MarkovChain(RooArgSet& parameters) :
    fDataEntry = nullptr;
    fChain = nullptr;
    fNLL = nullptr;
-   fWeight = nullptr;
    SetParameters(parameters);
 }
 
@@ -70,7 +68,6 @@ MarkovChain::MarkovChain(const char* name, const char* title,
    fDataEntry = nullptr;
    fChain = nullptr;
    fNLL = nullptr;
-   fWeight = nullptr;
    SetParameters(parameters);
 }
 
@@ -87,16 +84,13 @@ void MarkovChain::SetParameters(RooArgSet& parameters)
    // to see if that makes it possible to get values of variables without
    // doing string comparison
    RooRealVar nll(NLL_NAME, "-log Likelihood", 0);
-   RooRealVar weight(WEIGHT_NAME, "weight", 0);
 
    fDataEntry = new RooArgSet();
    fDataEntry->addClone(parameters);
    fDataEntry->addClone(nll);
-   fDataEntry->addClone(weight);
    fNLL = (RooRealVar*)fDataEntry->find(NLL_NAME);
-   fWeight = (RooRealVar*)fDataEntry->find(WEIGHT_NAME);
 
-   fChain = new RooDataSet(DATASET_NAME, "Markov Chain", *fDataEntry,WEIGHT_NAME);
+   fChain = new RooDataSet(DATASET_NAME, "Markov Chain", *fDataEntry, RooFit::WeightVar(WEIGHT_NAME));
 }
 
 void MarkovChain::Add(RooArgSet& entry, double nllValue, double weight)
@@ -106,7 +100,6 @@ void MarkovChain::Add(RooArgSet& entry, double nllValue, double weight)
    RooStats::SetParameters(&entry, fDataEntry);
    fNLL->setVal(nllValue);
    //kbelasco: this is stupid, but some things might require it, so be doubly sure
-   fWeight->setVal(weight);
    fChain->add(*fDataEntry, weight);
    //fChain->add(*fDataEntry);
 }
@@ -147,7 +140,6 @@ void MarkovChain::AddFast(RooArgSet& entry, double nllValue, double weight)
    RooStats::SetParameters(&entry, fDataEntry);
    fNLL->setVal(nllValue);
    //kbelasco: this is stupid, but some things might require it, so be doubly sure
-   fWeight->setVal(weight);
    fChain->addFast(*fDataEntry, weight);
    //fChain->addFast(*fDataEntry);
 }

--- a/roofit/roostats/src/ToyMCImportanceSampler.cxx
+++ b/roofit/roostats/src/ToyMCImportanceSampler.cxx
@@ -104,13 +104,7 @@ RooDataSet* ToyMCImportanceSampler::GetSamplingDistributionsSingleWorker(RooArgS
       }
 
       if( !fullResult ) {
-         RooArgSet columns( *result->get() );
-         RooRealVar weightVar ( "weight", "weight", 1.0 );
-         columns.add( weightVar );
-//       cout << endl << endl << "Reweighted data columns: " << endl;
-//       columns.Print("v");
-//       cout << endl;
-         fullResult = new RooDataSet( result->GetName(), result->GetTitle(), columns, "weight" );
+         fullResult = new RooDataSet( result->GetName(), result->GetTitle(), *result->get(), RooFit::WeightVar());
       }
 
       for( int j=0; j < result->numEntries(); j++ ) {


### PR DESCRIPTION
This pull request:

1. Closes #12453, where is was reported that weight errors are lost when splitting weighted datasets.
2. Avoids the associated errors printed when doing the JSON IO of combined RooDataSets (run the unit test `gtest-roofit-hs3-test-testHS3SimultaneousFit` with ROOT master to see them)
3. Avoids the creation of dummy weight variables when constructing RooDataSets in all of RooFit.

More detail in the commit descriptions.

