### PR TITLE
[ntuple] RCollectionClassField: restore missing calls to `PushProxy()`

### DIFF
--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1266,6 +1266,7 @@ std::size_t ROOT::Experimental::RCollectionClassField::AppendImpl(const Detail::
 {
    std::size_t nbytes = 0;
    unsigned count = 0;
+   TVirtualCollectionProxy::TPushPop RAII(fProxy.get(), value.GetRawPtr());
    for (auto ptr : RCollectionIterableOnce{value.GetRawPtr(), fIFuncsRead, fProxy.get()}) {
       auto itemValue = fSubFields[0]->CaptureValue(ptr);
       nbytes += fSubFields[0]->Append(itemValue);
@@ -1324,6 +1325,7 @@ ROOT::Experimental::Detail::RFieldValue ROOT::Experimental::RCollectionClassFiel
 void ROOT::Experimental::RCollectionClassField::DestroyValue(const Detail::RFieldValue &value, bool dtorOnly)
 {
    if (fProperties & TVirtualCollectionProxy::kNeedDelete) {
+      TVirtualCollectionProxy::TPushPop RAII(fProxy.get(), value.GetRawPtr());
       for (auto ptr : RCollectionIterableOnce{value.GetRawPtr(), fIFuncsWrite, fProxy.get()}) {
          auto itemValue = fSubFields[0]->CaptureValue(ptr);
          fSubFields[0]->DestroyValue(itemValue, true /* dtorOnly */);
@@ -1343,6 +1345,7 @@ std::vector<ROOT::Experimental::Detail::RFieldValue>
 ROOT::Experimental::RCollectionClassField::SplitValue(const Detail::RFieldValue &value) const
 {
    std::vector<Detail::RFieldValue> result;
+   TVirtualCollectionProxy::TPushPop RAII(fProxy.get(), value.GetRawPtr());
    for (auto ptr : RCollectionIterableOnce{value.GetRawPtr(), fIFuncsRead, fProxy.get()}) {
       result.emplace_back(fSubFields[0]->CaptureValue(ptr));
    }


### PR DESCRIPTION
After merging #12380, @Nowakus noticed issues when trying to fill entries for a model that includes the ATLAS' `DataVector<T>` type.
This is because a proxied collection, notably those deriving from `TGenCollectionProxy`, apparently rely on an active object also for using iterators. This PR should fix the error below.
```
TGenCollectionProxy    FATAL Size> Logic error - no proxy object set.
```

## Checklist:
- [X] tested changes locally