### PR TITLE
[core] Improve readbility of unit-test-support messages.

### DIFF
--- a/core/testsupport/inc/ROOT/TestSupport.hxx
+++ b/core/testsupport/inc/ROOT/TestSupport.hxx
@@ -111,15 +111,6 @@ class CheckDiagsRAII {
       }
 
    private:
-      struct Diag_t {
-         int severity;
-         std::string location;
-         std::string message;
-         bool matchFullString = true;
-         bool optional = false;
-         int receivedCount = -1;
-      };
-
       /// Message handler that hands over all diagnostics to the currently active instance.
       static void callback(int severity, bool abort, const char * location, const char * msg) {
          if (sActiveInstance) {
@@ -136,9 +127,17 @@ class CheckDiagsRAII {
       }
 
       /// Check all received diags against list of expected ones.
-      void checkDiag(int severity, const char * location, const char * msg);
-      /// Print the diags in `diags` to the terminal.
-      void printDiags(std::vector<Diag_t> const & diags) const;
+      void checkDiag(int severity, const char *location, const char *msg);
+
+      struct Diag_t {
+         int severity;
+         std::string location;
+         std::string message;
+         bool matchFullString = true;
+         bool optional = false;
+         int receivedCount = -1;
+      };
+      friend std::ostream &operator<<(std::ostream &stream, Diag_t const &diag);
 
       std::vector<Diag_t> fExpectedDiags;
       std::vector<Diag_t> fUnexpectedDiags;


### PR DESCRIPTION
ROOT::TestSupport checks info/warning/error messages during unit tests. Previously, it would generate one global failure irrespective of how many messages have been received, or how many were missing. It would then list all messages that are being checked, irrespective of whether they were received or not.

Now, each missing or unexpected message generates a dedicated test failure.

## Before
```
../../../root-src/core/testsupport/src/TestSupport.cxx:93: Failure
Failed
ROOT::TestSupport::CheckDiagsRAII: Unexpected diagnostic messages received.
../../../root-src/core/testsupport/src/TestSupport.cxx:96: Failure
Failed
ROOT::TestSupport::CheckDiagsRAII: Diagnostic message missing.
-------------------------
Pre-registered messages:
    kError	1x received	(required, subMatch)	'prepareMethod' msg='Can't compile function TFormula'
    kError	0x received	(required, fullMatch)	'TFormula::InputFormulaIntoCling' msg='Error compiling formula expression in Cling____'
    kError	1x received	(required, subMatch)	'TFormula::ProcessFormula' msg=' is invalid'
    kError	1x received	(required, subMatch)	'TFormula::ProcessFormula' msg='has not been matched in the formula expression'
    kError	2x received	(required, subMatch)	'cling' msg='undeclared identifier'
Unexpected messages received:
    kError	'TFormula::InputFormulaIntoCling' msg='Error compiling formula expression in Cling'
-------------------------
```

## After
```
../../../root-src/core/testsupport/src/TestSupport.cxx:96: Failure
Failed
ROOT::TestSupport::CheckDiagsRAII: Expected diagnostic message missing:
     severity: kError
     received: 0 times (required, fullMatch)	
       origin: "TFormula::InputFormulaIntoCling"
      message: Error compiling formula expression in Cling____

../../../root-src/core/testsupport/src/TestSupport.cxx:101: Failure
Failed
ROOT::TestSupport::CheckDiagsRAII: Unexpected diagnostic message:
     severity: kError
       origin: "TFormula::InputFormulaIntoCling"
      message: Error compiling formula expression in Cling
```