### PR TITLE
[RF][HS3] Migrate remaining relevant fileds from dicts to lists

### DIFF
--- a/etc/RooFitHS3_wsexportkeys.json
+++ b/etc/RooFitHS3_wsexportkeys.json
@@ -20,9 +20,9 @@
             "x": "x",
             "c": "c"
         }
-    },    
+    },
     "RooProduct": {
-        "type": "prod",
+        "type": "product",
         "proxies": {
             "compRSet": "factors",
             "compCSet": "factors"

--- a/etc/RooFitHS3_wsfactoryexpressions.json
+++ b/etc/RooFitHS3_wsfactoryexpressions.json
@@ -13,7 +13,7 @@
             "x",
             "c"
         ]
-    },    
+    },
     "poisson_dist": {
         "class": "RooPoisson",
         "arguments": [
@@ -21,8 +21,14 @@
             "mean"
         ]
     },
-    "prod": {
+    "product": {
         "class": "RooProduct",
+        "arguments": [
+            "factors"
+        ]
+    },
+    "product_dist": {
+        "class": "RooProdPdf",
         "arguments": [
             "factors"
         ]
@@ -41,7 +47,7 @@
         "arguments": [
             "summands"
         ]
-    },    
+    },
     "paramhist": {
         "class": "ParamHistFunc",
         "arguments": [
@@ -72,7 +78,7 @@
             "m0",
             "sigma",
             "alpha",
-	    "n"
+            "n"
         ]
     },
     "bifurkated_gaussian_dist": {
@@ -81,7 +87,7 @@
             "x",
             "mean",
             "sigmaL",
-            "sigmaR"	    
+            "sigmaR"
         ]
     }
 }

--- a/roofit/hs3/src/Domains.cxx
+++ b/roofit/hs3/src/Domains.cxx
@@ -72,7 +72,7 @@ void Domains::ProductDomain::writeVariable(RooRealVar &var) const
 void Domains::ProductDomain::readJSON(RooFit::Detail::JSONNode const &node)
 {
    // In the future, throw an exception if the type is not product domain
-   auto const &variablesNode = node["variables"];
+   auto const &variablesNode = node["axes"];
    for (size_t i = 0; i < variablesNode.num_children(); ++i) {
       auto const &varNode = variablesNode[i];
       auto &elem = _map[varNode["name"].val()];
@@ -92,7 +92,7 @@ void Domains::ProductDomain::writeJSON(RooFit::Detail::JSONNode &node) const
    node.set_map();
    node["type"] << "product_domain";
 
-   auto &variablesNode = node["variables"];
+   auto &variablesNode = node["axes"];
    variablesNode.set_seq();
 
    for (auto const &item : _map) {

--- a/roofit/hs3/src/JSONFactories_HistFactory.cxx
+++ b/roofit/hs3/src/JSONFactories_HistFactory.cxx
@@ -449,7 +449,7 @@ public:
       std::vector<std::string> funcnames;
       std::vector<std::string> coefnames;
       RooArgSet observables;
-      if (p.has_child("variables")) {
+      if (p.has_child("axes")) {
          RooJSONFactoryWSTool::getObservables(ws, p, name, observables);
          scope.setObservables(observables);
       }

--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -128,16 +128,6 @@ public:
    }
 };
 
-class RooProdPdfFactory : public RooFit::JSONIO::Importer {
-public:
-   bool importPdf(RooJSONFactoryWSTool *tool, const JSONNode &p) const override
-   {
-      std::string name(RooJSONFactoryWSTool::name(p));
-      tool->wsEmplace<RooProdPdf>(name, name, tool->requestArgSet<RooAbsPdf>(p, "pdfs"));
-      return true;
-   }
-};
-
 class RooAddPdfFactory : public RooFit::JSONIO::Importer {
 public:
    bool importPdf(RooJSONFactoryWSTool *tool, const JSONNode &p) const override
@@ -429,22 +419,6 @@ public:
    }
 };
 
-class RooProdPdfStreamer : public RooFit::JSONIO::Exporter {
-public:
-   std::string const &key() const override
-   {
-      static const std::string keystring = "product_dist";
-      return keystring;
-   }
-   bool exportObject(RooJSONFactoryWSTool *, const RooAbsArg *func, JSONNode &elem) const override
-   {
-      const RooProdPdf *pdf = static_cast<const RooProdPdf *>(func);
-      elem["type"] << key();
-      elem["pdfs"].fill_seq(pdf->pdfList(), [](auto const &f) { return f->GetName(); });
-      return true;
-   }
-};
-
 class RooGenericPdfStreamer : public RooFit::JSONIO::Exporter {
 public:
    std::string const &key() const override
@@ -570,7 +544,6 @@ public:
 STATIC_EXECUTE([]() {
    using namespace RooFit::JSONIO;
 
-   registerImporter<RooProdPdfFactory>("product_dist", false);
    registerImporter<RooGenericPdfFactory>("generic_dist", false);
    registerImporter<RooFormulaVarFactory>("generic_function", false);
    registerImporter<RooBinSamplingPdfFactory>("binsampling", false);
@@ -584,7 +557,6 @@ STATIC_EXECUTE([]() {
    registerImporter<RooMultiVarGaussianFactory>("multinormal_dist", false);
 
    registerExporter<RooBinWidthFunctionStreamer>(RooBinWidthFunction::Class(), false);
-   registerExporter<RooProdPdfStreamer>(RooProdPdf::Class(), false);
    registerExporter<RooBinSamplingPdfStreamer>(RooBinSamplingPdf::Class(), false);
    registerExporter<RooHistFuncStreamer>(RooHistFunc::Class(), false);
    registerExporter<RooHistPdfStreamer>(RooHistPdf::Class(), false);

--- a/roofit/jsoninterface/inc/RooFit/Detail/JSONInterface.h
+++ b/roofit/jsoninterface/inc/RooFit/Detail/JSONInterface.h
@@ -93,6 +93,7 @@ public:
    virtual bool is_seq() const = 0;
    virtual void set_map() = 0;
    virtual void set_seq() = 0;
+   virtual void clear() = 0;
 
    virtual std::string key() const = 0;
    virtual std::string val() const = 0;

--- a/roofit/jsoninterface/src/JSONParser.cxx
+++ b/roofit/jsoninterface/src/JSONParser.cxx
@@ -239,6 +239,11 @@ void TJSONTree::Node::set_seq()
    }
 }
 
+void TJSONTree::Node::clear()
+{
+   node->get().clear();
+}
+
 std::string TJSONTree::Node::key() const
 {
    return node->key();

--- a/roofit/jsoninterface/src/JSONParser.h
+++ b/roofit/jsoninterface/src/JSONParser.h
@@ -56,6 +56,7 @@ public:
       bool is_seq() const override;
       void set_map() override;
       void set_seq() override;
+      void clear() override;
       std::string key() const override;
       std::string val() const override;
       int val_int() const override;

--- a/roofit/jsoninterface/src/RYMLParser.cxx
+++ b/roofit/jsoninterface/src/RYMLParser.cxx
@@ -121,6 +121,11 @@ void TRYMLTree::Node::set_seq()
    node->get() |= c4::yml::SEQ;
 }
 
+void TRYMLTree::Node::clear()
+{
+   throw std::logic_error("Function not yet implemented");
+}
+
 TRYMLTree::TRYMLTree(std::istream &is)
    : tree(std::make_unique<Impl>(is)){
         // constructor taking an istream (for reading)

--- a/roofit/jsoninterface/src/RYMLParser.h
+++ b/roofit/jsoninterface/src/RYMLParser.h
@@ -53,6 +53,7 @@ public:
       bool is_seq() const override;
       void set_map() override;
       void set_seq() override;
+      void clear() override;
       std::string key() const override;
       std::string val() const override;
       bool has_key() const override;

--- a/tutorials/roofit/rf515_hfJSON.json
+++ b/tutorials/roofit/rf515_hfJSON.json
@@ -137,9 +137,12 @@
     "parameter_points": [
         {
             "name": "default_values",
-            "mu": {
-                "value": 1
-            }
+            "parameters": [
+                {
+                    "name": "mu",
+                    "value": 1
+                }
+            ]
         }
     ],
     "data": [

--- a/tutorials/roofit/rf515_hfJSON.json
+++ b/tutorials/roofit/rf515_hfJSON.json
@@ -33,13 +33,14 @@
                 {
                     "data": {
                         "contents": [20, 10],
-                        "variables": {
-                            "obs_x_channel1": {
+                        "axes": [
+                            {
+                                "name": "obs_x_channel1",
                                 "max": 2.0,
                                 "min": 1.0,
                                 "nbins": 2
                             }
-                        }
+                        ]
                     },
                     "modifiers": [
                         {
@@ -61,13 +62,14 @@
                     "data": {
                         "contents": [100, 0],
                         "errors": [5, 0],
-                        "variables": {
-                            "obs_x_channel1": {
+                        "axes": [
+                            {
+                                "name": "obs_x_channel1",
                                 "max": 2.0,
                                 "min": 1.0,
                                 "nbins": 2
                             }
-                        }
+                        ]
                     },
                     "modifiers": [
                         {
@@ -89,13 +91,14 @@
                     "data": {
                         "contents": [0, 100],
                         "errors": [0, 10],
-                        "variables": {
-                            "obs_x_channel1": {
+                        "axes": [
+                            {
+                                "name": "obs_x_channel1",
                                 "max": 2.0,
                                 "min": 1.0,
                                 "nbins": 2
                             }
-                        }
+                        ]
                     },
                     "modifiers": [
                         {
@@ -125,7 +128,7 @@
         {
             "name": "default_domain",
             "type": "product_domain",
-            "variables": [
+            "axes": [
                 {
                     "max": 5.0,
                     "min": -3.0,
@@ -148,13 +151,14 @@
     "data": [
         {
             "name": "observed_channel1",
-            "variables": {
-                "obs_x_channel1": {
+            "axes": [
+                {
+                    "name": "obs_x_channel1",
                     "nbins": 2,
                     "min": 1,
                     "max": 2
                 }
-            },
+            ],
             "contents": [122, 112]
         }
     ]


### PR DESCRIPTION
This is a follow-up on #12467, where  only the top-level fields got migrated from dicts to lists.

This PR migrates the remaining sub-fields that also should be lists according to the HS3 specification.

Also, some other improvements and fixes explained in the commit descriptions are applied.

