### PR TITLE
[ntuple,daos] Cast variable to preclude warning in 32-bit

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -115,8 +115,8 @@ struct RDaosContainerNTupleLocator {
    static ntuple_index_t Hash(const std::string &ntupleName)
    {
       // Convert string to numeric representation via `std::hash`.
-      std::size_t h = std::hash<std::string>{}(ntupleName);
-      // Fold `std::size_t` bits into 32-bit using `boost::hash_combine()` algorithm and magic number.
+      uint64_t h = std::hash<std::string>{}(ntupleName);
+      // Fold the hash into 32-bit using `boost::hash_combine()` algorithm and magic number.
       auto seed = static_cast<uint32_t>(h >> 32);
       seed ^= static_cast<uint32_t>(h & 0xffffffff) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
       auto hash = static_cast<ntuple_index_t>(seed);


### PR DESCRIPTION
This pull request replaces a variable's type from `size_t` to `uint64_t` to avoid warnings on 32-bit platforms.

The variable is the output of a hashing function and undergoes shifting by 32 bits as the seeding step of a hash combination between the two-halves of a 64-bit value.

The change has no functional impact. It prevents the following compilation warning in 32-bit systems:

```
In file included from /path/to/src/RPageStorageDaos.cxx:29:
/path/to/src/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx: In static member function ‘static ROOT::Experimental::Detail::ntuple_index_t ROOT::Experimental::Detail::RDaosContainerNTupleLocator::Hash(const string&)’:
/path/to/src/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx:120:43: warning: right shift count >= width of type [-Wshift-count-overflow]
  120 |       auto seed = static_cast<uint32_t>(h >> 32);
```

## Checklist:

- [x] tested changes locally

