### PR TITLE
[ntuple] Add direct importing of TTree objects

### DIFF
--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -232,8 +232,7 @@ private:
    std::unique_ptr<RNTupleModel> fModel;
    std::unique_ptr<REntry> fEntry;
 
-   static RResult<std::unique_ptr<RNTupleImporter>>
-   InitDestination(std::unique_ptr<RNTupleImporter> importer, std::string_view destFileName);
+   ROOT::Experimental::RResult<void> InitDestination(std::string_view destFileName);
 
    void ResetSchema();
    /// Sets up the connection from TTree branches to RNTuple fields, including initialization of the memory

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -208,6 +208,7 @@ private:
 
    RNTupleImporter() = default;
 
+   std::unique_ptr<TFile> fSourceFile;
    std::unique_ptr<TTree> fSourceTree;
 
    std::string fDestFileName;
@@ -230,6 +231,8 @@ private:
    std::vector<std::unique_ptr<RImportTransformation>> fImportTransformations;
    std::unique_ptr<RNTupleModel> fModel;
    std::unique_ptr<REntry> fEntry;
+
+   ROOT::Experimental::RResult<void> SetupDestination(std::string_view destFileName);
 
    void ResetSchema();
    /// Sets up the connection from TTree branches to RNTuple fields, including initialization of the memory

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -210,6 +210,7 @@ private:
 
    std::unique_ptr<TFile> fSourceFile;
    std::unique_ptr<TTree> fSourceTree;
+   TTree *fSourceTreePtr;
 
    std::string fDestFileName;
    std::string fNTupleName;

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -208,7 +208,6 @@ private:
 
    RNTupleImporter() = default;
 
-   std::unique_ptr<TFile> fSourceFile;
    std::unique_ptr<TTree> fSourceTree;
 
    std::string fDestFileName;
@@ -247,7 +246,10 @@ public:
 
    /// Opens the input file for reading and the output file for writing (update).
    static RResult<std::unique_ptr<RNTupleImporter>>
-   Create(std::string_view sourceFile, std::string_view treeName, std::string_view destFile);
+   Create(std::string_view sourceFileName, std::string_view treeName, std::string_view destFileName);
+
+   /// Directly uses the provided tree and opens the output file for writing (update).
+   static RResult<std::unique_ptr<RNTupleImporter>> Create(TTree *sourceTree, std::string_view destFileName);
 
    RNTupleWriteOptions GetWriteOptions() const { return fWriteOptions; }
    void SetWriteOptions(RNTupleWriteOptions options) { fWriteOptions = options; }

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -209,8 +209,7 @@ private:
    RNTupleImporter() = default;
 
    std::unique_ptr<TFile> fSourceFile;
-   std::unique_ptr<TTree> fSourceTree;
-   TTree *fSourceTreePtr;
+   TTree *fSourceTree;
 
    std::string fDestFileName;
    std::string fNTupleName;

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -233,7 +233,8 @@ private:
    std::unique_ptr<RNTupleModel> fModel;
    std::unique_ptr<REntry> fEntry;
 
-   ROOT::Experimental::RResult<void> SetupDestination(std::string_view destFileName);
+   static RResult<std::unique_ptr<RNTupleImporter>>
+   InitDestination(std::unique_ptr<RNTupleImporter> importer, std::string_view destFileName);
 
    void ResetSchema();
    /// Sets up the connection from TTree branches to RNTuple fields, including initialization of the memory

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -98,7 +98,10 @@ ROOT::Experimental::RNTupleImporter::Create(std::string_view sourceFileName, std
 
    // If we have IMT enabled, its best use is for parallel page compression
    importer->fSourceTree->SetImplicitMT(false);
-   importer->InitDestination(destFileName);
+   auto result = importer->InitDestination(destFileName);
+
+   if (!result)
+      return R__FORWARD_ERROR(result);
 
    return importer;
 }
@@ -112,7 +115,10 @@ ROOT::Experimental::RNTupleImporter::Create(TTree *sourceTree, std::string_view 
 
    // If we have IMT enabled, its best use is for parallel page compression
    importer->fSourceTree->SetImplicitMT(false);
-   importer->InitDestination(destFileName);
+   auto result = importer->InitDestination(destFileName);
+
+   if (!result)
+      return R__FORWARD_ERROR(result);
 
    return importer;
 }

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -90,14 +90,14 @@ ROOT::Experimental::RNTupleImporter::Create(std::string_view sourceFileName, std
    if (!importer->fSourceFile || importer->fSourceFile->IsZombie()) {
       return R__FAIL("cannot open source file " + std::string(sourceFileName));
    }
-   importer->fSourceTree = std::unique_ptr<TTree>(importer->fSourceFile->Get<TTree>(std::string(treeName).c_str()));
+
+   importer->fSourceTree = importer->fSourceFile->Get<TTree>(std::string(treeName).c_str());
    if (!importer->fSourceTree) {
       return R__FAIL("cannot read TTree " + std::string(treeName) + " from " + std::string(sourceFileName));
    }
-   importer->fSourceTreePtr = importer->fSourceTree.get();
-   // If we have IMT enabled, its best use is for parallel page compression
-   importer->fSourceTreePtr->SetImplicitMT(false);
 
+   // If we have IMT enabled, its best use is for parallel page compression
+   importer->fSourceTree->SetImplicitMT(false);
    importer = InitDestination(std::move(importer), destFileName).Unwrap();
 
    return importer;
@@ -108,11 +108,10 @@ ROOT::Experimental::RNTupleImporter::Create(TTree *sourceTree, std::string_view 
 {
    auto importer = std::unique_ptr<RNTupleImporter>(new RNTupleImporter());
    importer->fNTupleName = sourceTree->GetName();
-   importer->fSourceTreePtr = sourceTree;
+   importer->fSourceTree = sourceTree;
 
    // If we have IMT enabled, its best use is for parallel page compression
-   importer->fSourceTreePtr->SetImplicitMT(false);
-
+   importer->fSourceTree->SetImplicitMT(false);
    importer = InitDestination(std::move(importer), destFileName).Unwrap();
 
    return importer;
@@ -156,7 +155,7 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSc
    // Browse through all branches and their leaves, create corresponding fields and prepare the memory buffers for
    // reading and writing. Usually, reading and writing share the same memory buffer, i.e. the object is read from TTree
    // and written as-is to the RNTuple. There are exceptions, e.g. for leaf count arrays and C strings.
-   for (auto b : TRangeDynCast<TBranch>(*fSourceTreePtr->GetListOfBranches())) {
+   for (auto b : TRangeDynCast<TBranch>(*fSourceTree->GetListOfBranches())) {
       assert(b);
       const auto firstLeaf = static_cast<TLeaf *>(b->GetListOfLeaves()->First());
       assert(firstLeaf);
@@ -184,7 +183,7 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSc
          c.fMaxLength = firstLeaf->GetMaximum();
          c.fCountVal = std::make_unique<Int_t>(); // count leafs are integers
          // Casting to void * makes it work for both Int_t and UInt_t
-         fSourceTreePtr->SetBranchAddress(b->GetName(), static_cast<void *>(c.fCountVal.get()));
+         fSourceTree->SetBranchAddress(b->GetName(), static_cast<void *>(c.fCountVal.get()));
          fLeafCountCollections.emplace(firstLeaf->GetName(), std::move(c));
          continue;
       }
@@ -280,9 +279,9 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSc
                            std::string(b->GetName()));
          }
          auto ptrBuf = reinterpret_cast<void **>(ib.fBranchBuffer.get());
-         fSourceTreePtr->SetBranchAddress(b->GetName(), ptrBuf, klass, EDataType::kOther_t, true /* isptr*/);
+         fSourceTree->SetBranchAddress(b->GetName(), ptrBuf, klass, EDataType::kOther_t, true /* isptr*/);
       } else {
-         fSourceTreePtr->SetBranchAddress(b->GetName(), reinterpret_cast<void *>(ib.fBranchBuffer.get()));
+         fSourceTree->SetBranchAddress(b->GetName(), reinterpret_cast<void *>(ib.fBranchBuffer.get()));
       }
 
       // If the TTree branch type and the RNTuple field type match, use the branch read buffer as RNTuple write buffer
@@ -368,7 +367,7 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::Import()
    }
 
    for (decltype(nEntries) i = 0; i < nEntries; ++i) {
-      fSourceTreePtr->GetEntry(i);
+      fSourceTree->GetEntry(i);
 
       for (const auto &[_, c] : fLeafCountCollections) {
          for (Int_t l = 0; l < *c.fCountVal; ++l) {

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -98,7 +98,7 @@ ROOT::Experimental::RNTupleImporter::Create(std::string_view sourceFileName, std
 
    // If we have IMT enabled, its best use is for parallel page compression
    importer->fSourceTree->SetImplicitMT(false);
-   importer = InitDestination(std::move(importer), destFileName).Unwrap();
+   importer->InitDestination(destFileName);
 
    return importer;
 }
@@ -112,23 +112,21 @@ ROOT::Experimental::RNTupleImporter::Create(TTree *sourceTree, std::string_view 
 
    // If we have IMT enabled, its best use is for parallel page compression
    importer->fSourceTree->SetImplicitMT(false);
-   importer = InitDestination(std::move(importer), destFileName).Unwrap();
+   importer->InitDestination(destFileName);
 
    return importer;
 }
 
-ROOT::Experimental::RResult<std::unique_ptr<ROOT::Experimental::RNTupleImporter>>
-ROOT::Experimental::RNTupleImporter::InitDestination(std::unique_ptr<RNTupleImporter> importer,
-                                                     std::string_view destFileName)
+ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::InitDestination(std::string_view destFileName)
 {
-   importer->fDestFileName = destFileName;
-   importer->fWriteOptions.SetCompression(kDefaultCompressionSettings);
-   importer->fDestFile = std::unique_ptr<TFile>(TFile::Open(importer->fDestFileName.c_str(), "UPDATE"));
-   if (!importer->fDestFile || importer->fDestFile->IsZombie()) {
-      return R__FAIL("cannot open dest file " + std::string(importer->fDestFileName));
+   fDestFileName = destFileName;
+   fWriteOptions.SetCompression(kDefaultCompressionSettings);
+   fDestFile = std::unique_ptr<TFile>(TFile::Open(fDestFileName.c_str(), "UPDATE"));
+   if (!fDestFile || fDestFile->IsZombie()) {
+      return R__FAIL("cannot open dest file " + std::string(fDestFileName));
    }
 
-   return importer;
+   return RResult<void>::Success();
 }
 
 void ROOT::Experimental::RNTupleImporter::ReportSchema()

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -81,23 +81,43 @@ ROOT::Experimental::RNTupleImporter::RLeafArrayTransformation::Transform(const R
 }
 
 ROOT::Experimental::RResult<std::unique_ptr<ROOT::Experimental::RNTupleImporter>>
-ROOT::Experimental::RNTupleImporter::Create(std::string_view sourceFile, std::string_view treeName,
-                                            std::string_view destFile)
+ROOT::Experimental::RNTupleImporter::Create(std::string_view sourceFileName, std::string_view treeName,
+                                            std::string_view destFileName)
 {
    auto importer = std::unique_ptr<RNTupleImporter>(new RNTupleImporter());
    importer->fNTupleName = treeName;
-   importer->fSourceFile = std::unique_ptr<TFile>(TFile::Open(std::string(sourceFile).c_str()));
-   if (!importer->fSourceFile || importer->fSourceFile->IsZombie()) {
-      return R__FAIL("cannot open source file " + std::string(sourceFile));
+   auto sourceFile = TFile::Open(std::string(sourceFileName).c_str());
+   if (!sourceFile || sourceFile->IsZombie()) {
+      return R__FAIL("cannot open source file " + std::string(sourceFileName));
    }
-   importer->fSourceTree = std::unique_ptr<TTree>(importer->fSourceFile->Get<TTree>(std::string(treeName).c_str()));
+   importer->fSourceTree = std::unique_ptr<TTree>(sourceFile->Get<TTree>(std::string(treeName).c_str()));
    if (!importer->fSourceTree) {
-      return R__FAIL("cannot read TTree " + std::string(treeName) + " from " + std::string(sourceFile));
+      return R__FAIL("cannot read TTree " + std::string(treeName) + " from " + std::string(sourceFileName));
    }
    // If we have IMT enabled, its best use is for parallel page compression
    importer->fSourceTree->SetImplicitMT(false);
 
-   importer->fDestFileName = destFile;
+   importer->fDestFileName = destFileName;
+   importer->fWriteOptions.SetCompression(kDefaultCompressionSettings);
+   importer->fDestFile = std::unique_ptr<TFile>(TFile::Open(importer->fDestFileName.c_str(), "UPDATE"));
+   if (!importer->fDestFile || importer->fDestFile->IsZombie()) {
+      return R__FAIL("cannot open dest file " + std::string(importer->fDestFileName));
+   }
+
+   return importer;
+}
+
+ROOT::Experimental::RResult<std::unique_ptr<ROOT::Experimental::RNTupleImporter>>
+ROOT::Experimental::RNTupleImporter::Create(TTree *sourceTree, std::string_view destFileName)
+{
+   auto importer = std::unique_ptr<RNTupleImporter>(new RNTupleImporter());
+   importer->fNTupleName = sourceTree->GetName();
+   importer->fSourceTree = std::unique_ptr<TTree>(sourceTree);
+
+   // If we have IMT enabled, its best use is for parallel page compression
+   importer->fSourceTree->SetImplicitMT(false);
+
+   importer->fDestFileName = destFileName;
    importer->fWriteOptions.SetCompression(kDefaultCompressionSettings);
    importer->fDestFile = std::unique_ptr<TFile>(TFile::Open(importer->fDestFileName.c_str(), "UPDATE"));
    if (!importer->fDestFile || importer->fDestFile->IsZombie()) {

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -98,7 +98,7 @@ ROOT::Experimental::RNTupleImporter::Create(std::string_view sourceFileName, std
    // If we have IMT enabled, its best use is for parallel page compression
    importer->fSourceTreePtr->SetImplicitMT(false);
 
-   importer->SetupDestination(destFileName);
+   importer = InitDestination(std::move(importer), destFileName).Unwrap();
 
    return importer;
 }
@@ -113,21 +113,23 @@ ROOT::Experimental::RNTupleImporter::Create(TTree *sourceTree, std::string_view 
    // If we have IMT enabled, its best use is for parallel page compression
    importer->fSourceTreePtr->SetImplicitMT(false);
 
-   importer->SetupDestination(destFileName);
+   importer = InitDestination(std::move(importer), destFileName).Unwrap();
 
    return importer;
 }
 
-ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::SetupDestination(std::string_view destFileName)
+ROOT::Experimental::RResult<std::unique_ptr<ROOT::Experimental::RNTupleImporter>>
+ROOT::Experimental::RNTupleImporter::InitDestination(std::unique_ptr<RNTupleImporter> importer,
+                                                     std::string_view destFileName)
 {
-   fDestFileName = destFileName;
-   fWriteOptions.SetCompression(kDefaultCompressionSettings);
-   fDestFile = std::unique_ptr<TFile>(TFile::Open(fDestFileName.c_str(), "UPDATE"));
-   if (!fDestFile || fDestFile->IsZombie()) {
-      return R__FAIL("cannot open dest file " + std::string(fDestFileName));
+   importer->fDestFileName = destFileName;
+   importer->fWriteOptions.SetCompression(kDefaultCompressionSettings);
+   importer->fDestFile = std::unique_ptr<TFile>(TFile::Open(importer->fDestFileName.c_str(), "UPDATE"));
+   if (!importer->fDestFile || importer->fDestFile->IsZombie()) {
+      return R__FAIL("cannot open dest file " + std::string(importer->fDestFileName));
    }
 
-   return RResult<void>::Success();
+   return importer;
 }
 
 void ROOT::Experimental::RNTupleImporter::ReportSchema()

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -92,7 +92,12 @@ TEST(RNTupleImporter, CreateFromChain)
    importer->Import();
 
    auto reader = RNTupleReader::Open("ntuple", fileGuard1.GetPath());
+   auto viewA = reader->GetView<std::int32_t>("a");
+
    EXPECT_EQ(2U, reader->GetNEntries());
+   EXPECT_EQ(42, viewA(0));
+   EXPECT_EQ(43, viewA(1));
+
    EXPECT_THROW(importer->Import(), ROOT::Experimental::RException);
 }
 

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -34,6 +34,28 @@ TEST(RNTupleImporter, Empty)
    EXPECT_THROW(importer->Import(), ROOT::Experimental::RException);
 }
 
+TEST(RNTupleImporter, CreateFromTree)
+{
+   FileRaii fileGuard("test_ntuple_importer_empty.root");
+   {
+      std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
+      auto tree = std::make_unique<TTree>("tree", "");
+      tree->Write();
+   }
+
+   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
+   auto tree = file->Get<TTree>("tree");
+
+   auto importer = RNTupleImporter::Create(tree, fileGuard.GetPath()).Unwrap();
+   importer->SetIsQuiet(true);
+   EXPECT_THROW(importer->Import(), ROOT::Experimental::RException);
+   importer->SetNTupleName("ntuple");
+   importer->Import();
+   auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
+   EXPECT_EQ(0U, reader->GetNEntries());
+   EXPECT_THROW(importer->Import(), ROOT::Experimental::RException);
+}
+
 TEST(RNTupleImporter, Simple)
 {
    FileRaii fileGuard("test_ntuple_importer_simple.root");


### PR DESCRIPTION
This PR adds an extra factory function for creating an `RNTupleImporter` by directly providing a pointer to the `TTree` to import, rather than the tree name and file name. With this, it should also become possible to import `TChain`s down the road, but this will require another PR.

- [x] tested changes locally
- [x] updated the docs (if necessary)

