### PR TITLE
Do not remove -Wp, before -D and -U when recording used compiler flags

### DIFF
--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -729,7 +729,7 @@ if (cxxmodules)
 endif()
 
 string(REGEX REPLACE "(^|[ ]*)-W[^ ]*" "" __fflags "${CMAKE_Fortran_FLAGS}")
-string(REGEX MATCHALL "-(D|U)[^ ]*" __defs "${CMAKE_CXX_FLAGS}")
+string(REGEX MATCHALL "(-Wp,)?-(D|U)[^ ]*" __defs "${CMAKE_CXX_FLAGS}")
 set(ROOT_COMPILER_FLAG_HINTS "#
 set(ROOT_DEFINITIONS \"${__defs}\")
 set(ROOT_CXX_FLAGS \"${__cxxflags}\")


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

This breaks the pattern used when undefining and then defining a variable in the same flag:
```
$ echo | g++ -Wp,-UVAR,-DVAR=1 -c -x c++ -
```
Here -Wp,-UVAR,-DVAR=1 will first undefine VAR and then define it to 1

If the -Wp, is dropped, this fails:
```
$ echo | g++ -UVAR,-DVAR=1 -c -x c++ -
<command-line>: warning: extra tokens at end of #undef directive
```
Now it will only undefine VAR, but not define it. I.e.

instead of
```
 #undef VAR
 #define VAR 1
```
you get
```
 #undef VAR,-DVAR=1
```
which explains the rather cryptic warning about extra token after #undef.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes  https://bugzilla.redhat.com/show_bug.cgi?id=2177136
