### PR TITLE
[RF] Remove `add(row, weight, weightError)` from RooAbsData interface

### DIFF
--- a/README/ReleaseNotes/v630/index.md
+++ b/README/ReleaseNotes/v630/index.md
@@ -58,7 +58,7 @@ that were deprecated in v6.02/00.
 The `TMath::AreEqualAbs()` compares two numbers for equality within a certain absolute range.
 So far, it would tell you that `inf != inf` if you define `inf` as `std::numeric_limits<double>::infinity()`, which is inconsistent with the regular `==` operator.
 
-This is unexpected, because one would expect that if two numbers are considered exactly equal, they would also be considered equal within any range. 
+This is unexpected, because one would expect that if two numbers are considered exactly equal, they would also be considered equal within any range.
 Therefore, the behavior of `TMath::AreEqualAbs()` was changed to return always `true` if the `==` comparision would return `true`.
 
 ## RooFit Libraries
@@ -103,6 +103,18 @@ RooFit has its internal representation of infinity in `RooNumber::infinity()`, w
 Now, it is defined as `std::numeric_limits<double>::infinity()`, to be consistent with the C++ standard library and other code.
 
 This change also affects the `RooNumber::isInfinite()` function.
+
+### Remove `add(row, weight, weightError)` from RooAbsData interface
+
+It was not good to have this signature in RooAbsData, because the
+implementations in the two derived classes RooDataHist and RooDataSet were
+inconsistent.
+
+The RooDataSet indeed took the weight error as the third argument, but
+the RooDataHist version instead took the sum of weights squared, which
+is equivalent to the squared weight error.
+
+Therefore, the virtual `RooAbsData::add(row, weight, weightError)` function was removed.
 
 ## 2D Graphics Libraries
 

--- a/roofit/roofitcore/inc/LinkDef.h
+++ b/roofit/roofitcore/inc/LinkDef.h
@@ -124,7 +124,6 @@
 #pragma link C++ class RooGenContext+ ;
 #pragma link C++ class RooGenericPdf+ ;
 #pragma link C++ class RooGenProdProj+ ;
-#pragma link C++ class RooHistError+ ;
 #pragma link C++ class RooHist+ ;
 #pragma link C++ class RooImproperIntegrator1D+ ;
 #pragma link C++ class RooIntegrator1D+ ;

--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -98,7 +98,7 @@ public:
   virtual bool changeObservableName(const char* from, const char* to) ;
 
   // Add one ore more rows of data
-  virtual void add(const RooArgSet& row, double weight=1, double weightError=0.0) = 0 ; // DERIVED
+  virtual void add(const RooArgSet& row, double weight=1) = 0 ; // DERIVED
   virtual void fill() ;
 
   // Load a given row of data

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -63,8 +63,8 @@ public:
   }
 
   /// Add `wgt` to the bin content enclosed by the coordinates passed in `row`.
-  virtual void add(const RooArgSet& row, double wgt=1.0) { add(row,wgt,-1.); }
-  void add(const RooArgSet& row, double weight, double sumw2) override ;
+  void add(const RooArgSet& row, double wgt=1.0) override { add(row,wgt,-1.); }
+  void add(const RooArgSet& row, double weight, double sumw2);
   void set(std::size_t binNumber, double weight, double wgtErr);
   void set(const RooArgSet& row, double weight, double wgtErr=-1.) ;
   void set(const RooArgSet& row, double weight, double wgtErrLo, double wgtErrHi) ;

--- a/roofit/roofitcore/inc/RooDataSet.h
+++ b/roofit/roofitcore/inc/RooDataSet.h
@@ -132,7 +132,8 @@ public:
   RooSpan<const double> getWeightBatch(std::size_t first, std::size_t len, bool sumW2) const override;
 
   /// Add one ore more rows of data
-  void add(const RooArgSet& row, double weight=1.0, double weightError=0.0) override;
+  void add(const RooArgSet& row, double weight, double weightError);
+  void add(const RooArgSet& row, double weight=1.0) override { add(row, weight, 0.0); }
   virtual void add(const RooArgSet& row, double weight, double weightErrorLo, double weightErrorHi);
 
   virtual void addFast(const RooArgSet& row, double weight=1.0, double weightError=0.0);

--- a/roofit/roofitcore/inc/RooHistError.h
+++ b/roofit/roofitcore/inc/RooHistError.h
@@ -131,7 +131,6 @@ private:
     Int_t _N1 ;
   } ;
 
-  ClassDef(RooHistError,1) // Utility class for calculating histogram errors
 };
 
 #endif

--- a/roofit/roofitcore/src/RooHistError.cxx
+++ b/roofit/roofitcore/src/RooHistError.cxx
@@ -34,10 +34,6 @@ a specified area of a Poisson or Binomail error distribution.
 
 using namespace std;
 
-ClassImp(RooHistError);
-  ;
-
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return a reference to a singleton object that is created the

--- a/roofit/roofitcore/test/testRooDataHist.cxx
+++ b/roofit/roofitcore/test/testRooDataHist.cxx
@@ -33,385 +33,373 @@
 /// although the boundaries match perfectly.
 TEST(RooDataHist, BinningRangeCheck_8163)
 {
-  RooHelpers::HijackMessageStream hijack(RooFit::INFO, RooFit::DataHandling, "dataHist");
+   RooHelpers::HijackMessageStream hijack(RooFit::INFO, RooFit::DataHandling, "dataHist");
 
-  RooRealVar x("x", "x", 0., 1.);
-  TH1D hist("hist", "", 10, 0., 1.);
+   RooRealVar x("x", "x", 0., 1.);
+   TH1D hist("hist", "", 10, 0., 1.);
 
-  RooDataHist dataHist("dataHist", "", RooArgList(x), &hist);
-  EXPECT_TRUE(hijack.str().empty()) << "Messages issued were: " << hijack.str();
+   RooDataHist dataHist("dataHist", "", RooArgList(x), &hist);
+   EXPECT_TRUE(hijack.str().empty()) << "Messages issued were: " << hijack.str();
 }
 
+double computePoissonUpper(double weight)
+{
+   double upperLimit = weight;
+   double CL;
+   do {
+      upperLimit += 0.001;
+      CL = 0.;
+      for (unsigned int i = 0; i <= (unsigned int)weight; ++i) {
+         CL += TMath::PoissonI(i, upperLimit);
+      }
+      //    std::cout << "Upper=" << upperLimit << "\tCL=" << CL << std::endl;
+   } while (CL > 0.16);
 
-
-double computePoissonUpper(double weight) {
-  double upperLimit = weight;
-  double CL;
-  do {
-    upperLimit += 0.001;
-    CL = 0.;
-    for (unsigned int i = 0; i <= (unsigned int)weight; ++i) {
-      CL += TMath::PoissonI(i, upperLimit);
-    }
-//    std::cout << "Upper=" << upperLimit << "\tCL=" << CL << std::endl;
-  } while (CL > 0.16);
-
-  return upperLimit;
+   return upperLimit;
 }
 
-double computePoissonLower(double weight) {
-  double lowerLimit = weight;
-  double CL;
-  do {
-    CL = 0.;
-    lowerLimit -= 0.001;
-    for (unsigned int i = 0; i < (unsigned int)weight; ++i) {
-      CL += TMath::PoissonI(i, lowerLimit);
-    }
-  } while (CL < 1. - 0.16);
+double computePoissonLower(double weight)
+{
+   double lowerLimit = weight;
+   double CL;
+   do {
+      CL = 0.;
+      lowerLimit -= 0.001;
+      for (unsigned int i = 0; i < (unsigned int)weight; ++i) {
+         CL += TMath::PoissonI(i, lowerLimit);
+      }
+   } while (CL < 1. - 0.16);
 
-  return lowerLimit;
+   return lowerLimit;
 }
 
 TEST(RooDataHist, UnWeightedEntries)
 {
-  RooRealVar x("x", "x", -10., 10.);
-  x.setBins(20);
-  RooRealVar w("w", "w", 0., 10.);
-  RooArgSet coordinates(x);
+   RooRealVar x("x", "x", -10., 10.);
+   x.setBins(20);
+   RooRealVar w("w", "w", 0., 10.);
+   RooArgSet coordinates(x);
 
-  constexpr double targetBinContent = 10.;
-  RooDataHist dataHist("dataHist", "", RooArgList(x));
-  for (unsigned int i=0; i < 200; ++i) {
-    x.setVal(-10. + 20./200. * i);
-    dataHist.add(coordinates);
-  }
+   constexpr double targetBinContent = 10.;
+   RooDataHist dataHist("dataHist", "", RooArgList(x));
+   for (unsigned int i = 0; i < 200; ++i) {
+      x.setVal(-10. + 20. / 200. * i);
+      dataHist.add(coordinates);
+   }
 
-  EXPECT_EQ(dataHist.numEntries(), 20);
-  ASSERT_EQ(dataHist.sumEntries(), 20 * targetBinContent);
+   EXPECT_EQ(dataHist.numEntries(), 20);
+   ASSERT_EQ(dataHist.sumEntries(), 20 * targetBinContent);
 
-  x.setVal(0.);
-  RooArgSet coordsAtZero;
-  dataHist.get(coordinates)->snapshot(coordsAtZero);
-  x.setVal(0.9);
-  RooArgSet coordsAtPoint9;
-  dataHist.get(coordinates)->snapshot(coordsAtPoint9);
-  EXPECT_EQ(static_cast<RooRealVar*>(coordsAtZero.find(x))->getVal(),
-            static_cast<RooRealVar*>(coordsAtPoint9.find(x))->getVal());
+   x.setVal(0.);
+   RooArgSet coordsAtZero;
+   dataHist.get(coordinates)->snapshot(coordsAtZero);
+   x.setVal(0.9);
+   RooArgSet coordsAtPoint9;
+   dataHist.get(coordinates)->snapshot(coordsAtPoint9);
+   EXPECT_EQ(static_cast<RooRealVar *>(coordsAtZero.find(x))->getVal(),
+             static_cast<RooRealVar *>(coordsAtPoint9.find(x))->getVal());
 
-  const double weight = dataHist.weight();
-  EXPECT_EQ(weight, targetBinContent);
+   const double weight = dataHist.weight();
+   EXPECT_EQ(weight, targetBinContent);
 
-  EXPECT_NEAR(dataHist.weightError(RooAbsData::Poisson),
-      sqrt(targetBinContent), 0.7); // TODO What is the actual value?
+   EXPECT_NEAR(dataHist.weightError(RooAbsData::Poisson), sqrt(targetBinContent),
+               0.7); // TODO What is the actual value?
 
-  {
-    double lo, hi;
-    dataHist.weightError(lo, hi, RooAbsData::Poisson);
-    EXPECT_LT(lo, hi);
-    EXPECT_NEAR(lo, weight - computePoissonLower(weight), 3.E-2);
-    EXPECT_NEAR(hi, computePoissonUpper(weight) - weight, 3.E-2);
-  }
+   {
+      double lo, hi;
+      dataHist.weightError(lo, hi, RooAbsData::Poisson);
+      EXPECT_LT(lo, hi);
+      EXPECT_NEAR(lo, weight - computePoissonLower(weight), 3.E-2);
+      EXPECT_NEAR(hi, computePoissonUpper(weight) - weight, 3.E-2);
+   }
 
-  EXPECT_NEAR(dataHist.weightError(RooAbsData::SumW2),
-      sqrt(targetBinContent), 1.E-14);
+   EXPECT_NEAR(dataHist.weightError(RooAbsData::SumW2), sqrt(targetBinContent), 1.E-14);
 
-  {
-    double lo, hi;
-    dataHist.weightError(lo, hi, RooAbsData::SumW2);
-    EXPECT_NEAR(lo, sqrt(targetBinContent), 1.E-14);
-    EXPECT_NEAR(lo, sqrt(targetBinContent), 1.E-14);
-    EXPECT_EQ(lo, hi);
-  }
+   {
+      double lo, hi;
+      dataHist.weightError(lo, hi, RooAbsData::SumW2);
+      EXPECT_NEAR(lo, sqrt(targetBinContent), 1.E-14);
+      EXPECT_NEAR(lo, sqrt(targetBinContent), 1.E-14);
+      EXPECT_EQ(lo, hi);
+   }
 
+   RooArgSet coordsAt10;
+   dataHist.get(10)->snapshot(coordsAt10);
+   const double weightBin10 = dataHist.weight();
 
-  RooArgSet coordsAt10;
-  dataHist.get(10)->snapshot(coordsAt10);
-  const double weightBin10 = dataHist.weight();
-
-  EXPECT_NEAR(static_cast<RooRealVar*>(coordsAt10.find(x))->getVal(), 0.5, 1.E-1);
-  EXPECT_EQ(weight, weightBin10);
+   EXPECT_NEAR(static_cast<RooRealVar *>(coordsAt10.find(x))->getVal(), 0.5, 1.E-1);
+   EXPECT_EQ(weight, weightBin10);
 }
-
 
 TEST(RooDataHist, WeightedEntries)
 {
-  RooRealVar x("x", "x", -10., 10.);
-  x.setBins(20);
-  RooRealVar w("w", "w", 0., 10.);
-  RooArgSet coordinates(x);
+   RooRealVar x("x", "x", -10., 10.);
+   x.setBins(20);
+   RooRealVar w("w", "w", 0., 10.);
+   RooArgSet coordinates(x);
 
-  constexpr double targetBinContent = 20.;
-  RooDataHist dataHist("dataHist", "", RooArgList(x));
-  for (unsigned int i=0; i < 200; ++i) {
-    x.setVal(-10. + 20./200. * i);
-    dataHist.add(coordinates, 2.);
-  }
+   constexpr double targetBinContent = 20.;
+   RooDataHist dataHist("dataHist", "", RooArgList(x));
+   for (unsigned int i = 0; i < 200; ++i) {
+      x.setVal(-10. + 20. / 200. * i);
+      dataHist.add(coordinates, 2.);
+   }
 
+   EXPECT_EQ(dataHist.numEntries(), 20);
+   EXPECT_EQ(dataHist.sumEntries(), 20 * targetBinContent);
 
-  EXPECT_EQ(dataHist.numEntries(), 20);
-  EXPECT_EQ(dataHist.sumEntries(), 20 * targetBinContent);
+   x.setVal(0.);
+   dataHist.get(coordinates);
+   const double weight = dataHist.weight();
+   ASSERT_EQ(weight, targetBinContent);
 
-  x.setVal(0.);
-  dataHist.get(coordinates);
-  const double weight = dataHist.weight();
-  ASSERT_EQ(weight, targetBinContent);
+   const double targetError = sqrt(10 * 4.);
 
+   EXPECT_NEAR(dataHist.weightError(RooAbsData::Poisson), targetError, 1.5); // TODO What is the actual value?
 
-  const double targetError = sqrt(10*4.);
+   {
+      double lo, hi;
+      dataHist.weightError(lo, hi, RooAbsData::Poisson);
+      EXPECT_LT(lo, hi);
+      EXPECT_NEAR(lo, weight - computePoissonLower(weight), 3.E-2);
+      EXPECT_NEAR(hi, computePoissonUpper(weight) - weight, 3.E-2);
+   }
 
-  EXPECT_NEAR(dataHist.weightError(RooAbsData::Poisson),
-      targetError, 1.5); // TODO What is the actual value?
+   EXPECT_NEAR(dataHist.weightError(RooAbsData::SumW2), targetError, 1.E-14);
 
-  {
-    double lo, hi;
-    dataHist.weightError(lo, hi, RooAbsData::Poisson);
-    EXPECT_LT(lo, hi);
-    EXPECT_NEAR(lo, weight - computePoissonLower(weight), 3.E-2);
-    EXPECT_NEAR(hi, computePoissonUpper(weight) - weight, 3.E-2);
-  }
+   {
+      double lo, hi;
+      dataHist.weightError(lo, hi, RooAbsData::SumW2);
+      EXPECT_NEAR(lo, targetError, 1.E-14);
+      EXPECT_NEAR(lo, targetError, 1.E-14);
+      EXPECT_EQ(lo, hi);
+   }
 
-  EXPECT_NEAR(dataHist.weightError(RooAbsData::SumW2),
-      targetError, 1.E-14);
+   RooArgSet coordsAt10;
+   dataHist.get(10)->snapshot(coordsAt10);
+   const double weightBin10 = dataHist.weight();
 
-  {
-    double lo, hi;
-    dataHist.weightError(lo, hi, RooAbsData::SumW2);
-    EXPECT_NEAR(lo, targetError, 1.E-14);
-    EXPECT_NEAR(lo, targetError, 1.E-14);
-    EXPECT_EQ(lo, hi);
-  }
-
-
-  RooArgSet coordsAt10;
-  dataHist.get(10)->snapshot(coordsAt10);
-  const double weightBin10 = dataHist.weight();
-
-  EXPECT_NEAR(static_cast<RooRealVar*>(coordsAt10.find(x))->getVal(), 0.5, 1.E-1);
-  EXPECT_EQ(weight, weightBin10);
+   EXPECT_NEAR(static_cast<RooRealVar *>(coordsAt10.find(x))->getVal(), 0.5, 1.E-1);
+   EXPECT_EQ(weight, weightBin10);
 }
 
-class RooDataHistIO : public testing::TestWithParam<const char*> {
+class RooDataHistIO : public testing::TestWithParam<const char *> {
 public:
-  void SetUp() override {
-    TFile file(GetParam(), "READ");
-    ASSERT_TRUE(file.IsOpen());
+   void SetUp() override
+   {
+      TFile file(GetParam(), "READ");
+      ASSERT_TRUE(file.IsOpen());
 
-    legacy = std::unique_ptr<RooDataHist>{file.Get<RooDataHist>("dataHist")};
-    ASSERT_NE(legacy, nullptr);
-  }
+      legacy = std::unique_ptr<RooDataHist>{file.Get<RooDataHist>("dataHist")};
+      ASSERT_NE(legacy, nullptr);
+   }
 
-  void TearDown() override {
-    legacy.reset();
-  }
+   void TearDown() override { legacy.reset(); }
 
 protected:
-  std::unique_ptr<RooDataHist> legacy;
+   std::unique_ptr<RooDataHist> legacy;
 };
 
-TEST_P(RooDataHistIO, ReadLegacy) {
+TEST_P(RooDataHistIO, ReadLegacy)
+{
 
-  RooDataHist& dataHist = *legacy;
+   RooDataHist &dataHist = *legacy;
 
-  constexpr double targetBinContent = 20.;
+   constexpr double targetBinContent = 20.;
 
-  RooArgSet legacyVals;
-  dataHist.get(10)->snapshot(legacyVals);
-  EXPECT_EQ(static_cast<RooAbsReal*>(legacyVals.find("x"))->getVal(),
-      static_cast<RooAbsReal*>(dataHist.get(10)->find("x"))->getVal());
+   RooArgSet legacyVals;
+   dataHist.get(10)->snapshot(legacyVals);
+   EXPECT_EQ(static_cast<RooAbsReal *>(legacyVals.find("x"))->getVal(),
+             static_cast<RooAbsReal *>(dataHist.get(10)->find("x"))->getVal());
 
+   EXPECT_EQ(dataHist.numEntries(), 20);
+   EXPECT_EQ(dataHist.sumEntries(), 20 * targetBinContent);
 
-  EXPECT_EQ(dataHist.numEntries(), 20);
-  EXPECT_EQ(dataHist.sumEntries(), 20 * targetBinContent);
+   static_cast<RooRealVar *>(legacyVals.find("x"))->setVal(0.);
+   dataHist.get(legacyVals); // trigger side effect for weight below.
+   const double weight = dataHist.weight();
+   ASSERT_EQ(weight, targetBinContent);
 
-  static_cast<RooRealVar*>(legacyVals.find("x"))->setVal(0.);
-  dataHist.get(legacyVals); // trigger side effect for weight below.
-  const double weight = dataHist.weight();
-  ASSERT_EQ(weight, targetBinContent);
+   const double targetError = sqrt(10 * 4.);
 
+   EXPECT_NEAR(dataHist.weightError(RooAbsData::Poisson), targetError, 1.5); // TODO What is the actual value?
 
-  const double targetError = sqrt(10*4.);
+   {
+      double lo, hi;
+      dataHist.weightError(lo, hi, RooAbsData::Poisson);
+      EXPECT_LT(lo, hi);
+      EXPECT_NEAR(lo, weight - computePoissonLower(weight), 3.E-2);
+      EXPECT_NEAR(hi, computePoissonUpper(weight) - weight, 3.E-2);
+   }
 
-  EXPECT_NEAR(dataHist.weightError(RooAbsData::Poisson), targetError, 1.5); // TODO What is the actual value?
+   EXPECT_NEAR(dataHist.weightError(RooAbsData::SumW2), targetError, 1.E-14);
 
-  {
-    double lo, hi;
-    dataHist.weightError(lo, hi, RooAbsData::Poisson);
-    EXPECT_LT(lo, hi);
-    EXPECT_NEAR(lo, weight - computePoissonLower(weight), 3.E-2);
-    EXPECT_NEAR(hi, computePoissonUpper(weight) - weight, 3.E-2);
-  }
+   {
+      double lo, hi;
+      dataHist.weightError(lo, hi, RooAbsData::SumW2);
+      EXPECT_NEAR(lo, targetError, 1.E-14);
+      EXPECT_NEAR(lo, targetError, 1.E-14);
+      EXPECT_EQ(lo, hi);
+   }
 
-  EXPECT_NEAR(dataHist.weightError(RooAbsData::SumW2),
-      targetError, 1.E-14);
+   RooArgSet coordsAt10;
+   dataHist.get(10)->snapshot(coordsAt10);
+   const double weightBin10 = dataHist.weight();
 
-  {
-    double lo, hi;
-    dataHist.weightError(lo, hi, RooAbsData::SumW2);
-    EXPECT_NEAR(lo, targetError, 1.E-14);
-    EXPECT_NEAR(lo, targetError, 1.E-14);
-    EXPECT_EQ(lo, hi);
-  }
-
-
-  RooArgSet coordsAt10;
-  dataHist.get(10)->snapshot(coordsAt10);
-  const double weightBin10 = dataHist.weight();
-
-  EXPECT_NEAR(static_cast<RooRealVar*>(coordsAt10.find("x"))->getVal(), 0.5, 1.E-1);
-  EXPECT_EQ(weight, weightBin10);
+   EXPECT_NEAR(static_cast<RooRealVar *>(coordsAt10.find("x"))->getVal(), 0.5, 1.E-1);
+   EXPECT_EQ(weight, weightBin10);
 }
-
 
 INSTANTIATE_TEST_SUITE_P(IO_SchemaEvol, RooDataHistIO,
-    testing::Values("dataHistv4_ref.root", "dataHistv5_ref.root", "dataHistv6_ref.root"));
+                         testing::Values("dataHistv4_ref.root", "dataHistv5_ref.root", "dataHistv6_ref.root"));
 
-
-void fillHist(TH2D* histo, double content) {
-  for (int i=0; i < histo->GetNbinsX()+2; ++i) {
-    for (int j=0; j < histo->GetNbinsY()+2; ++j) {
-      histo->SetBinContent(i, j, content + (i-1)*100 + (j-1));
-    }
-  }
+void fillHist(TH2D *histo, double content)
+{
+   for (int i = 0; i < histo->GetNbinsX() + 2; ++i) {
+      for (int j = 0; j < histo->GetNbinsY() + 2; ++j) {
+         histo->SetBinContent(i, j, content + (i - 1) * 100 + (j - 1));
+      }
+   }
 }
 
-TEST(RooDataHist, BatchDataAccess) {
-  RooRealVar x("x", "x", 0, -10, 10);
-  RooRealVar y("y", "y", 1, 0, 20);
+TEST(RooDataHist, BatchDataAccess)
+{
+   RooRealVar x("x", "x", 0, -10, 10);
+   RooRealVar y("y", "y", 1, 0, 20);
 
-  auto histo = std::make_unique<TH2D>("xyHist", "xyHist", 20, -10, 10, 10, 0, 10);
-  fillHist(histo.get(), 0.1);
+   auto histo = std::make_unique<TH2D>("xyHist", "xyHist", 20, -10, 10, 10, 0, 10);
+   fillHist(histo.get(), 0.1);
 
-  RooDataHist dataHist("dataHist", "Data histogram with batch access",
-      RooArgSet(x, y), RooFit::Import(*histo));
+   RooDataHist dataHist("dataHist", "Data histogram with batch access", RooArgSet(x, y), RooFit::Import(*histo));
 
-  const std::size_t numEntries = static_cast<std::size_t>(dataHist.numEntries());
-  ASSERT_EQ(numEntries, 200ul);
+   const std::size_t numEntries = static_cast<std::size_t>(dataHist.numEntries());
+   ASSERT_EQ(numEntries, 200ul);
 
-  const RooArgSet& vars = *dataHist.get();
-  auto xp = dynamic_cast<RooRealVar*>(vars[0ul]);
-  auto yp = dynamic_cast<RooRealVar*>(vars[1]);
-  ASSERT_STREQ(xp->GetName(), "x");
-  ASSERT_STREQ(yp->GetName(), "y");
+   const RooArgSet &vars = *dataHist.get();
+   auto xp = dynamic_cast<RooRealVar *>(vars[0ul]);
+   auto yp = dynamic_cast<RooRealVar *>(vars[1]);
+   ASSERT_STREQ(xp->GetName(), "x");
+   ASSERT_STREQ(yp->GetName(), "y");
 
-  auto evalData = dataHist.getBatches(0, numEntries);
+   auto evalData = dataHist.getBatches(0, numEntries);
 
-  auto xBatchShort = dataHist.getBatches(0, 100)[xp];
-  auto xBatch = evalData[xp];
-  auto yBatch = evalData[yp];
+   auto xBatchShort = dataHist.getBatches(0, 100)[xp];
+   auto xBatch = evalData[xp];
+   auto yBatch = evalData[yp];
 
-  ASSERT_FALSE(xBatchShort.empty());
-  ASSERT_FALSE(xBatch.empty());
-  ASSERT_FALSE(yBatch.empty());
+   ASSERT_FALSE(xBatchShort.empty());
+   ASSERT_FALSE(xBatch.empty());
+   ASSERT_FALSE(yBatch.empty());
 
-  EXPECT_EQ(xBatchShort.size(), 100ul);
-  EXPECT_EQ(xBatch.size(), numEntries);
-  EXPECT_EQ(yBatch.size(), numEntries);
+   EXPECT_EQ(xBatchShort.size(), 100ul);
+   EXPECT_EQ(xBatch.size(), numEntries);
+   EXPECT_EQ(yBatch.size(), numEntries);
 
-  EXPECT_EQ(xBatch[5 * 10], histo->GetXaxis()->GetBinCenter(5+1));
-  EXPECT_EQ(yBatch[5], histo->GetYaxis()->GetBinCenter(5+1));
+   EXPECT_EQ(xBatch[5 * 10], histo->GetXaxis()->GetBinCenter(5 + 1));
+   EXPECT_EQ(yBatch[5], histo->GetYaxis()->GetBinCenter(5 + 1));
 
-  auto weights = dataHist.getWeightBatch(0, numEntries);
-  ASSERT_FALSE(weights.empty());
-  ASSERT_EQ(weights.size(), numEntries);
-  EXPECT_EQ(weights[2], 0.1 + 2.);
-  EXPECT_EQ(weights[4*10 + 7], 0.1 + 400. + 7.);
+   auto weights = dataHist.getWeightBatch(0, numEntries);
+   ASSERT_FALSE(weights.empty());
+   ASSERT_EQ(weights.size(), numEntries);
+   EXPECT_EQ(weights[2], 0.1 + 2.);
+   EXPECT_EQ(weights[4 * 10 + 7], 0.1 + 400. + 7.);
 }
 
-
-void fillHist(TH1D* histo, double content) {
-  for (int i=0; i < histo->GetNbinsX()+2; ++i) {
-    histo->SetBinContent(i, content + i-1);
-  }
+void fillHist(TH1D *histo, double content)
+{
+   for (int i = 0; i < histo->GetNbinsX() + 2; ++i) {
+      histo->SetBinContent(i, content + i - 1);
+   }
 }
 
-TEST(RooDataHist, BatchDataAccessWithCategories) {
-  RooRealVar x("x", "x", 0, -10, 10);
-  RooCategory cat("cat", "category");
+TEST(RooDataHist, BatchDataAccessWithCategories)
+{
+   RooRealVar x("x", "x", 0, -10, 10);
+   RooCategory cat("cat", "category");
 
-  auto histoX = std::make_unique<TH1D>("xHist", "xHist", 20, -10., 10.);
-  auto histoY = std::make_unique<TH1D>("yHist", "yHist", 20, -10., 10.);
-  fillHist(histoX.get(), 0.2);
-  fillHist(histoY.get(), 0.3);
+   auto histoX = std::make_unique<TH1D>("xHist", "xHist", 20, -10., 10.);
+   auto histoY = std::make_unique<TH1D>("yHist", "yHist", 20, -10., 10.);
+   fillHist(histoX.get(), 0.2);
+   fillHist(histoY.get(), 0.3);
 
-  RooDataHist dataHist("dataHist", "Data histogram with batch access",
-      RooArgSet(x), RooFit::Index(cat), RooFit::Import("catX", *histoX), RooFit::Import("catY", *histoY));
+   RooDataHist dataHist("dataHist", "Data histogram with batch access", RooArgSet(x), RooFit::Index(cat),
+                        RooFit::Import("catX", *histoX), RooFit::Import("catY", *histoY));
 
-  const std::size_t numEntries = (std::size_t)dataHist.numEntries();
-  ASSERT_EQ(numEntries, 40ul);
+   const std::size_t numEntries = (std::size_t)dataHist.numEntries();
+   ASSERT_EQ(numEntries, 40ul);
 
-  const RooArgSet& vars = *dataHist.get();
-  auto catp = dynamic_cast<RooCategory*>(vars[0ul]);
-  auto xp = dynamic_cast<RooRealVar*>(vars[1]);
-  ASSERT_NE(catp, nullptr);
-  ASSERT_NE(xp, nullptr);
-  ASSERT_STREQ(catp->GetName(), "cat");
-  ASSERT_STREQ(xp->GetName(), "x");
+   const RooArgSet &vars = *dataHist.get();
+   auto catp = dynamic_cast<RooCategory *>(vars[0ul]);
+   auto xp = dynamic_cast<RooRealVar *>(vars[1]);
+   ASSERT_NE(catp, nullptr);
+   ASSERT_NE(xp, nullptr);
+   ASSERT_STREQ(catp->GetName(), "cat");
+   ASSERT_STREQ(xp->GetName(), "x");
 
-  auto xBatchShort = dataHist.getBatches(0, 10)[xp];
-  auto xBatch      = dataHist.getBatches(0, numEntries)[xp];
+   auto xBatchShort = dataHist.getBatches(0, 10)[xp];
+   auto xBatch = dataHist.getBatches(0, numEntries)[xp];
 
-  ASSERT_FALSE(xBatchShort.empty());
-  ASSERT_FALSE(xBatch.empty());
+   ASSERT_FALSE(xBatchShort.empty());
+   ASSERT_FALSE(xBatch.empty());
 
-  EXPECT_EQ(xBatchShort.size(), 10ul);
-  EXPECT_EQ(xBatch.size(), numEntries);
+   EXPECT_EQ(xBatchShort.size(), 10ul);
+   EXPECT_EQ(xBatch.size(), numEntries);
 
-  EXPECT_EQ(xBatch[15], histoX->GetXaxis()->GetBinCenter(15+1));
-  EXPECT_EQ(xBatch[35], histoX->GetXaxis()->GetBinCenter(15+1));
+   EXPECT_EQ(xBatch[15], histoX->GetXaxis()->GetBinCenter(15 + 1));
+   EXPECT_EQ(xBatch[35], histoX->GetXaxis()->GetBinCenter(15 + 1));
 
-  auto weights = dataHist.getWeightBatch(0, numEntries);
-  ASSERT_FALSE(weights.empty());
-  ASSERT_EQ(weights.size(), numEntries);
-  EXPECT_EQ(weights[2], 0.2 + 2.);
-  EXPECT_EQ(weights[23], 0.3 + 3.);
+   auto weights = dataHist.getWeightBatch(0, numEntries);
+   ASSERT_FALSE(weights.empty());
+   ASSERT_EQ(weights.size(), numEntries);
+   EXPECT_EQ(weights[2], 0.2 + 2.);
+   EXPECT_EQ(weights[23], 0.3 + 3.);
 }
 
+TEST(RooDataHist, BatchDataAccessWithCategoriesAndFitRange)
+{
+   RooRealVar x("x", "x", 0, -10, 10);
+   RooCategory cat("cat", "category");
+   x.setRange(-8., 5);
 
-TEST(RooDataHist, BatchDataAccessWithCategoriesAndFitRange) {
-  RooRealVar x("x", "x", 0, -10, 10);
-  RooCategory cat("cat", "category");
-  x.setRange(-8., 5);
+   auto histoX = std::make_unique<TH1D>("xHist", "xHist", 20, -10., 10.);
+   auto histoY = std::make_unique<TH1D>("yHist", "yHist", 20, -10., 10.);
+   fillHist(histoX.get(), 0.2);
+   fillHist(histoY.get(), 0.3);
 
-  auto histoX = std::make_unique<TH1D>("xHist", "xHist", 20, -10., 10.);
-  auto histoY = std::make_unique<TH1D>("yHist", "yHist", 20, -10., 10.);
-  fillHist(histoX.get(), 0.2);
-  fillHist(histoY.get(), 0.3);
+   RooDataHist dataHist("dataHist", "Data histogram with batch access", RooArgSet(x), RooFit::Index(cat),
+                        RooFit::Import("catX", *histoX), RooFit::Import("catY", *histoY));
 
-  RooDataHist dataHist("dataHist", "Data histogram with batch access",
-      RooArgSet(x), RooFit::Index(cat), RooFit::Import("catX", *histoX), RooFit::Import("catY", *histoY));
+   const std::size_t numEntries = (std::size_t)dataHist.numEntries();
+   ASSERT_EQ(numEntries, 26ul);
 
-  const std::size_t numEntries = (std::size_t)dataHist.numEntries();
-  ASSERT_EQ(numEntries, 26ul);
+   const RooArgSet &vars = *dataHist.get();
+   auto catp = dynamic_cast<RooCategory *>(vars[0ul]);
+   auto xp = dynamic_cast<RooRealVar *>(vars[1]);
+   ASSERT_NE(catp, nullptr);
+   ASSERT_NE(xp, nullptr);
+   ASSERT_STREQ(catp->GetName(), "cat");
+   ASSERT_STREQ(xp->GetName(), "x");
 
-  const RooArgSet& vars = *dataHist.get();
-  auto catp = dynamic_cast<RooCategory*>(vars[0ul]);
-  auto xp = dynamic_cast<RooRealVar*>(vars[1]);
-  ASSERT_NE(catp, nullptr);
-  ASSERT_NE(xp, nullptr);
-  ASSERT_STREQ(catp->GetName(), "cat");
-  ASSERT_STREQ(xp->GetName(), "x");
+   auto xBatchShort = dataHist.getBatches(0, 10)[xp];
+   auto xBatch = dataHist.getBatches(0, numEntries)[xp];
 
-  auto xBatchShort = dataHist.getBatches(0, 10)[xp];
-  auto xBatch      = dataHist.getBatches(0, numEntries)[xp];
+   ASSERT_FALSE(xBatchShort.empty());
+   ASSERT_FALSE(xBatch.empty());
 
-  ASSERT_FALSE(xBatchShort.empty());
-  ASSERT_FALSE(xBatch.empty());
+   EXPECT_EQ(xBatchShort.size(), 10ul);
+   EXPECT_EQ(xBatch.size(), numEntries);
 
-  EXPECT_EQ(xBatchShort.size(), 10ul);
-  EXPECT_EQ(xBatch.size(), numEntries);
+   EXPECT_TRUE(std::all_of(xBatch.begin(), xBatch.end(), [](double arg) { return -8. < arg && arg < 5.; }));
 
-  EXPECT_TRUE(std::all_of(xBatch.begin(), xBatch.end(), [](double arg){return -8. < arg && arg < 5.;}));
+   EXPECT_EQ(xBatch[0], -7.5);
+   EXPECT_EQ(xBatch[12], 4.5);
+   EXPECT_EQ(xBatch[13], -7.5);
+   EXPECT_EQ(xBatch[25], 4.5);
 
-  EXPECT_EQ(xBatch[ 0],  -7.5);
-  EXPECT_EQ(xBatch[12],  4.5);
-  EXPECT_EQ(xBatch[13], -7.5);
-  EXPECT_EQ(xBatch[25],  4.5);
-
-  auto weights = dataHist.getWeightBatch(0, numEntries);
-  ASSERT_FALSE(weights.empty());
-  ASSERT_EQ(weights.size(), numEntries);
-  EXPECT_TRUE(std::none_of(weights.begin(), weights.end(), [](double arg){return arg == 0.;}));
+   auto weights = dataHist.getWeightBatch(0, numEntries);
+   ASSERT_FALSE(weights.empty());
+   ASSERT_EQ(weights.size(), numEntries);
+   EXPECT_TRUE(std::none_of(weights.begin(), weights.end(), [](double arg) { return arg == 0.; }));
 }
 
 double integrate(RooAbsReal &absReal, const RooArgSet &iset, const RooArgSet &nset, const char *rangeName = 0)
@@ -591,7 +579,6 @@ TEST(RooDataHist, AnalyticalIntegration)
    EXPECT_FLOAT_EQ(integrate(hpdf2, y, bothXandY, "R2"), 3.8 / 4. * normYoverXY);
 }
 
-
 TEST(RooDataHist, Interpolation2DSimple)
 {
    TH2D hist{"hist", "hist", 2, 0, 2, 2, 0, 2};
@@ -601,16 +588,16 @@ TEST(RooDataHist, Interpolation2DSimple)
    double a1 = 3;
    double b1 = 4;
 
-   for(int i = 0; i < a0; ++i) {
+   for (int i = 0; i < a0; ++i) {
       hist.Fill(0.5, 0.5);
    }
-   for(int i = 0; i < b0; ++i) {
+   for (int i = 0; i < b0; ++i) {
       hist.Fill(1.5, 0.5);
    }
-   for(int i = 0; i < a1; ++i) {
+   for (int i = 0; i < a1; ++i) {
       hist.Fill(0.5, 1.5);
    }
-   for(int i = 0; i < b1; ++i) {
+   for (int i = 0; i < b1; ++i) {
       hist.Fill(1.5, 1.5);
    }
 
@@ -625,9 +612,7 @@ TEST(RooDataHist, Interpolation2DSimple)
       values.push_back((i * 2.0) / n);
    }
 
-   auto clamp = [](double v, double a, double b) {
-      return std::min(std::max(v, a), b);
-   };
+   auto clamp = [](double v, double a, double b) { return std::min(std::max(v, a), b); };
 
    auto getTrueWeight = [&]() {
       double xVal = x.getVal();
@@ -647,7 +632,6 @@ TEST(RooDataHist, Interpolation2DSimple)
       }
    }
 }
-
 
 /// GitHub issue #8015
 /// Take binning from input RooDataHists when building a combined RooDataHist.
@@ -670,19 +654,15 @@ TEST(RooDataHist, CombinedRooDataHistBinning)
    RooDataHist dh2("dh2", "dh1", x, &hh2);
 
    // Create combined RooDataHist via intermediate RooDataHists
-   RooDataHist dhComb1("dhComb1", "dhComb1", x, Index(c), Import("SampleA", dh1),
-                       Import("SampleB", dh2));
+   RooDataHist dhComb1("dhComb1", "dhComb1", x, Index(c), Import("SampleA", dh1), Import("SampleB", dh2));
 
    // Create combined RooDataHist directly from the TH1Ds
-   RooDataHist dhComb2{"dhComb2", "dhComb2", x, Index(c), Import("SampleA", hh1),
-                       Import("SampleB", hh2)};
+   RooDataHist dhComb2{"dhComb2", "dhComb2", x, Index(c), Import("SampleA", hh1), Import("SampleB", hh2)};
 
    // In both cases the number of bins should be 40 + 40 = 80
    EXPECT_EQ(dhComb1.numEntries(), 80);
    EXPECT_EQ(dhComb2.numEntries(), 80);
 }
-
-
 
 class WeightsTest : public testing::TestWithParam<std::tuple<int, bool, bool, bool>> {
    void SetUp() override
@@ -704,74 +684,72 @@ protected:
 
 TEST_P(WeightsTest, VectorizedWeights)
 {
-  // Change local message level to suppress unnecessary info
-  RooHelpers::LocalChangeMsgLevel chmsglvl1{RooFit::WARNING, 0u, RooFit::DataHandling, true};
-  RooHelpers::LocalChangeMsgLevel chmsglvl2{RooFit::WARNING, 0u, RooFit::Fitting, true};
+   // Change local message level to suppress unnecessary info
+   RooHelpers::LocalChangeMsgLevel chmsglvl1{RooFit::WARNING, 0u, RooFit::DataHandling, true};
+   RooHelpers::LocalChangeMsgLevel chmsglvl2{RooFit::WARNING, 0u, RooFit::Fitting, true};
 
-  const double xMin = -1;
-  const double xMax = 1;
-  const std::size_t nBins = 100;
+   const double xMin = -1;
+   const double xMax = 1;
+   const std::size_t nBins = 100;
 
-  TH1D h1;
-  if (_isUniform) {
-    h1 = TH1D("h1", "h1", nBins, xMin, xMax);
-  }
-  else {
-    std::vector<double> boundaries(nBins + 1);
-    for(std::size_t i = 0; i < boundaries.size(); ++i) {
-      boundaries[i] = ((xMax - xMin) / nBins) * i + xMin;
-    }
-    h1 = TH1D("h1", "h1", nBins, boundaries.data());
-  }
+   TH1D h1;
+   if (_isUniform) {
+      h1 = TH1D("h1", "h1", nBins, xMin, xMax);
+   } else {
+      std::vector<double> boundaries(nBins + 1);
+      for (std::size_t i = 0; i < boundaries.size(); ++i) {
+         boundaries[i] = ((xMax - xMin) / nBins) * i + xMin;
+      }
+      h1 = TH1D("h1", "h1", nBins, boundaries.data());
+   }
 
-  h1.FillRandom("gaus");
+   h1.FillRandom("gaus");
 
-  RooRealVar x("x", "x", 0, xMin, xMax);
-  RooDataHist dh{"dh", "dh", x, &h1};
+   RooRealVar x("x", "x", 0, xMin, xMax);
+   RooDataHist dh{"dh", "dh", x, &h1};
 
-  std::unique_ptr<RooAbsReal> absReal;
-  if (_correctForBinSize) {
-    auto histPdf = std::make_unique<RooHistPdf>("histPdf", "histPdf", x, dh, _interpolationOrder);
-    histPdf->setCdfBoundaries(_cdfBoundaries);
-    absReal = std::move(histPdf);
-  } else {
-    auto histFunc = std::make_unique<RooHistFunc>("histPdf", "histPdf", x, dh, _interpolationOrder);
-    histFunc->setCdfBoundaries(_cdfBoundaries);
-    absReal = std::move(histFunc);
-  }
+   std::unique_ptr<RooAbsReal> absReal;
+   if (_correctForBinSize) {
+      auto histPdf = std::make_unique<RooHistPdf>("histPdf", "histPdf", x, dh, _interpolationOrder);
+      histPdf->setCdfBoundaries(_cdfBoundaries);
+      absReal = std::move(histPdf);
+   } else {
+      auto histFunc = std::make_unique<RooHistFunc>("histPdf", "histPdf", x, dh, _interpolationOrder);
+      histFunc->setCdfBoundaries(_cdfBoundaries);
+      absReal = std::move(histFunc);
+   }
 
-  // Fill 10 000 random x values
-  std::size_t nVals = 10000;
-  std::vector<double> xVals(nVals);
-  RooDataSet data{"data", "data", x};
+   // Fill 10 000 random x values
+   std::size_t nVals = 10000;
+   std::vector<double> xVals(nVals);
+   RooDataSet data{"data", "data", x};
 
-  for (std::size_t i = 0; i < nVals; ++i) {
-    xVals[i] = xMin + RooRandom::uniform() * (xMax - xMin);
-    x.setVal(xVals[i]);
-    data.add(x);
-  }
+   for (std::size_t i = 0; i < nVals; ++i) {
+      xVals[i] = xMin + RooRandom::uniform() * (xMax - xMin);
+      x.setVal(xVals[i]);
+      data.add(x);
+   }
 
-  std::vector<double> weightsGetVal(nVals);
-  for (std::size_t i = 0; i < nVals; ++i) {
-    x.setVal(xVals[i]);
-    weightsGetVal[i] = absReal->getVal(x);
-  }
-  x.setVal(0.0);
+   std::vector<double> weightsGetVal(nVals);
+   for (std::size_t i = 0; i < nVals; ++i) {
+      x.setVal(xVals[i]);
+      weightsGetVal[i] = absReal->getVal(x);
+   }
+   x.setVal(0.0);
 
-  auto weightsGetValues = absReal->getValues(data);
+   auto weightsGetValues = absReal->getValues(data);
 
-  for (std::size_t i = 0; i < nVals; ++i) {
-    EXPECT_NEAR(weightsGetVal[i], weightsGetValues[i], 1e-6);
-  }
+   for (std::size_t i = 0; i < nVals; ++i) {
+      EXPECT_NEAR(weightsGetVal[i], weightsGetValues[i], 1e-6);
+   }
 }
 
 INSTANTIATE_TEST_SUITE_P(RooDataHist, WeightsTest,
-                         testing::Combine(
-                            testing::Values(0, 1, 2), // interpolation order
-                            testing::Values(false, true), // RooHistPdf or RooHistFunc?
-                            testing::Values(false, true), // CDF boundary mode
-                            testing::Values(false, true) // uniform bins or not
-                         ),
+                         testing::Combine(testing::Values(0, 1, 2),     // interpolation order
+                                          testing::Values(false, true), // RooHistPdf or RooHistFunc?
+                                          testing::Values(false, true), // CDF boundary mode
+                                          testing::Values(false, true)  // uniform bins or not
+                                          ),
                          [](testing::TestParamInfo<WeightsTest::ParamType> const &paramInfo) {
                             std::stringstream ss;
                             ss << (std::get<1>(paramInfo.param) ? "RooHistFunc" : "RooHistPdf");


### PR DESCRIPTION
It was not good to have this signature in RooAbsData, because the
implementations in RooDataHist and RooDataSet were inconsistent.

The RooDataSet indeed took the weight error as the third argument, but
the RooDataHist version instead took the sum of weights squared, which
is equivalent to the squared weight error.

That means using `RooAbsData::add(row, weight, weightError)` results in
different weight uncertainties depending on which data implementation
you use. This should not happen. It probably didn't happen to many
people, but I was affected by this when implementing
`RooAbsData::split()` (see https://github.com/root-project/root/pull/12459/commits/909d2564045d1cdb99865c4da6b7e79e463b548f).

The solution to this problem it to remove the `add(row, weight,
weightError)` from the virtual RooAbsData interface. The `add(row,
weight)` signature can stay, because this one is implemented
consistently in RooDataSet and RooDataHist.
