### PR TITLE
[RF] Enable analytic integration of RooHistPdfs with RooLinearVars

### DIFF
--- a/roofit/roofitcore/inc/RooHistFunc.h
+++ b/roofit/roofitcore/inc/RooHistFunc.h
@@ -74,6 +74,8 @@ public:
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
   double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
 
+  bool forceAnalyticalInt(const RooAbsArg& dep) const override;
+
   /// Set use of special boundary conditions for c.d.f.s
   void setCdfBoundaries(bool flag) {
     _cdfBoundaries = flag ;

--- a/roofit/roofitcore/inc/RooHistPdf.h
+++ b/roofit/roofitcore/inc/RooHistPdf.h
@@ -65,6 +65,8 @@ public:
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
   double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
 
+  bool forceAnalyticalInt(const RooAbsArg& dep) const override;
+
   void setCdfBoundaries(bool flag) {
     // Set use of special boundary conditions for c.d.f.s
     _cdfBoundaries = flag ;
@@ -119,17 +121,19 @@ private:
 
   friend class RooHistFunc;
 
+  static bool forceAnalyticalInt(RooArgSet const& pdfObsList, RooAbsArg const& dep);
+
   static Int_t getAnalyticalIntegral(RooArgSet& allVars,
                                      RooArgSet& analVars,
                                      const char* rangeName,
                                      RooArgSet const& histObsList,
-                                     RooSetProxy const& pdfObsList,
+                                     RooArgSet const& pdfObsList,
                                      Int_t intOrder) ;
 
   static double analyticalIntegral(Int_t code,
                                    const char* rangeName,
                                    RooArgSet const& histObsList,
-                                   RooSetProxy const& pdfObsList,
+                                   RooArgSet const& pdfObsList,
                                    RooDataHist& dataHist,
                                    bool histFuncMode) ;
 

--- a/roofit/roofitcore/src/RooHistFunc.cxx
+++ b/roofit/roofitcore/src/RooHistFunc.cxx
@@ -314,6 +314,11 @@ double RooHistFunc::analyticalIntegral(Int_t code, const char* rangeName) const
     return RooHistPdf::analyticalIntegral(code, rangeName, _histObsList, _depList, *_dataHist, true);
 }
 
+bool RooHistFunc::forceAnalyticalInt(const RooAbsArg& dep) const
+{
+   return RooHistPdf::forceAnalyticalInt(_depList, dep);
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return sampling hint for making curves of (projections) of this function

--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -61,6 +61,7 @@ ROOT_ADD_GTEST(testGlobalObservables testGlobalObservables.cxx LIBRARIES RooFitC
 ROOT_ADD_GTEST(testRooPolyFunc testRooPolyFunc.cxx LIBRARIES Gpad RooFitCore)
 ROOT_ADD_GTEST(testSumW2Error testSumW2Error.cxx LIBRARIES Gpad RooFitCore)
 ROOT_ADD_GTEST(testRooHist testRooHist.cxx LIBRARIES RooFitCore)
+ROOT_ADD_GTEST(testRooHistPdf testRooHistPdf.cxx LIBRARIES RooFitCore)
 if (roofit_multiprocess)
   ROOT_ADD_GTEST(testTestStatisticsPlot TestStatistics/testPlot.cxx LIBRARIES RooFitMultiProcess RooFitCore RooFit
                    COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/TestStatistics/TestStatistics_ref.root)

--- a/roofit/roofitcore/test/testRooHistPdf.cxx
+++ b/roofit/roofitcore/test/testRooHistPdf.cxx
@@ -1,0 +1,34 @@
+// Tests for the RooHistPdf
+// Authors: Jonas Rembser, CERN 03/2023
+
+#include <RooDataHist.h>
+#include <RooHistPdf.h>
+#include <RooLinearVar.h>
+#include <RooRealIntegral.h>
+#include <RooRealVar.h>
+
+#include <gtest/gtest.h>
+
+// Verify that RooFit correctly uses analytic integration when having a
+// RooLinearVar as the observable of a RooHistPdf.
+TEST(RooHistPdf, AnalyticIntWithRooLinearVar)
+{
+    RooRealVar x{"x", "x", 0, -10, 10};
+    x.setBins(10);
+
+    RooDataHist dataHist("dataHist", "dataHist", x);
+    for(int i = 0; i < x.numBins(); ++i) {
+       dataHist.set(i, 10.0, 0.0);
+    }
+
+    RooRealVar shift{"shift", "shift", 2.0, -10, 10};
+    RooRealVar slope{"slope", "slope", 1.0};
+    RooLinearVar xShifted{"x_shifted", "x_shifted", x, slope, shift};
+
+    RooHistPdf pdf{"pdf", "pdf", xShifted, x, dataHist};
+
+    RooRealIntegral integ{"integ", "integ", pdf, x};
+
+    EXPECT_DOUBLE_EQ(integ.getVal(), 90.);
+    EXPECT_EQ(integ.anaIntVars().size(), 1);
+}


### PR DESCRIPTION
The RooHistPdf and RooHistFunc should be able to do analytic integration if the input is a linear transformation of a variable using RooLinearVar.

This makes the fits faster where one wants to shift a template on the x-axis, which is for example talked about in this forum post: https://root-forum.cern.ch/t/roofit-pdf-normalization-integration/53905