### PR TITLE
[RF] Replace `RooAbsReal::_lastNSet` pointer with ID of last normSet

### DIFF
--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -604,7 +604,7 @@ protected:
   };
 
 
-  mutable RooArgSet* _lastNSet = nullptr; ///<!
+  mutable RooFit::UniqueId<RooArgSet>::Value_t _lastNormSetId = RooFit::UniqueId<RooArgSet>::nullval; ///<!
   static bool _hideOffset ;    ///< Offset hiding flag
 
   ClassDefOverride(RooAbsReal,3) // Abstract real-valued variable

--- a/roofit/roofitcore/inc/RooFormulaVar.h
+++ b/roofit/roofitcore/inc/RooFormulaVar.h
@@ -72,7 +72,6 @@ public:
 
   // Function evaluation
   double evaluate() const override ;
-  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const override;
   inline void computeBatch(cudaStream_t* stream, double* output, size_t nEvents, RooFit::Detail::DataMap const& dataMap) const override
   {
     formula().computeBatch(stream, output, nEvents, dataMap);

--- a/roofit/roofitcore/inc/RooGenericPdf.h
+++ b/roofit/roofitcore/inc/RooGenericPdf.h
@@ -52,7 +52,6 @@ protected:
   // Function evaluation
   RooListProxy _actualVars ;
   double evaluate() const override ;
-  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& inputData, const RooArgSet* normSet) const override;
   void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooFit::Detail::DataMap const&) const override;
 
   bool setFormula(const char* formula) ;

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -227,9 +227,9 @@ TString RooAbsReal::getTitle(bool appendUnit) const
 
 double RooAbsReal::getValV(const RooArgSet* nset) const
 {
-  if (nset && nset!=_lastNSet) {
-    ((RooAbsReal*) this)->setProxyNormSet(nset) ;
-    _lastNSet = (RooArgSet*) nset ;
+  if (nset && nset->uniqueId().value() != _lastNormSetId) {
+    const_cast<RooAbsReal*>(this)->setProxyNormSet(nset);
+    _lastNormSetId = nset->uniqueId().value();
   }
 
   if (isValueDirtyAndClear()) {
@@ -263,8 +263,6 @@ RooSpan<const double> RooAbsReal::getValues(RooBatchCompute::RunContext& evalDat
   if (item != evalData.spans.end()) {
     return item->second;
   }
-
-  normSet = normSet ? normSet : _lastNSet;
 
   std::map<RooFit::Detail::DataKey, RooSpan<const double>> dataSpans;
   for (auto const &evalDataItem : evalData.spans) {
@@ -4845,7 +4843,7 @@ void RooAbsReal::checkBatchComputation(const RooBatchCompute::RunContext& evalDa
 bool RooAbsReal::redirectServersHook(const RooAbsCollection & newServerList, bool mustReplaceAll,
                                     bool nameChange, bool isRecursiveStep)
 {
-  _lastNSet = nullptr ;
+  _lastNormSetId = RooFit::UniqueId<RooArgSet>::nullval;
   return RooAbsArg::redirectServersHook(newServerList, mustReplaceAll, nameChange, isRecursiveStep);
 }
 

--- a/roofit/roofitcore/src/RooFormulaVar.cxx
+++ b/roofit/roofitcore/src/RooFormulaVar.cxx
@@ -152,24 +152,6 @@ double RooFormulaVar::evaluate() const
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Evaluate the formula for all entries of our servers found in `inputData`.
-RooSpan<double> RooFormulaVar::evaluateSpan(RooBatchCompute::RunContext& inputData, const RooArgSet* normSet) const {
-  if (normSet != _lastNSet) {
-    // TODO: Remove dependence on _lastNSet
-    // See also comment in RooAbsReal::getValBatch().
-    std::cerr << "Formula " << GetName() << " " << GetTitle() << "\n\tBeing evaluated with normSet " << normSet << "\n";
-    normSet->Print("V");
-    std::cerr << "\tHowever, _lastNSet = " << _lastNSet << "\n";
-    if (_lastNSet) _lastNSet->Print("V");
-
-    throw std::logic_error("Got conflicting norm sets. This shouldn't happen.");
-  }
-
-  return formula().evaluateSpan(this, inputData, normSet);
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
 /// Propagate server change information to embedded RooFormula object
 
 bool RooFormulaVar::redirectServersHook(const RooAbsCollection& newServerList, bool mustReplaceAll, bool nameChange, bool isRecursive)

--- a/roofit/roofitcore/src/RooGenericPdf.cxx
+++ b/roofit/roofitcore/src/RooGenericPdf.cxx
@@ -124,18 +124,6 @@ double RooGenericPdf::evaluate() const
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Evaluate this formula for values found in inputData.
-RooSpan<double> RooGenericPdf::evaluateSpan(RooBatchCompute::RunContext& inputData, const RooArgSet* normSet) const {
-  if (normSet != nullptr && normSet != _normSet)
-    throw std::logic_error("Got conflicting normSets");
-
-  auto results = formula().evaluateSpan(this, inputData, _normSet);
-  inputData.spans[this] = results;
-
-  return results;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 void RooGenericPdf::computeBatch(cudaStream_t* stream, double* output, size_t nEvents, RooFit::Detail::DataMap const& dataMap) const
 {
   formula().computeBatch(stream, output, nEvents, dataMap);

--- a/roofit/roofitcore/src/RooRealIntegral.cxx
+++ b/roofit/roofitcore/src/RooRealIntegral.cxx
@@ -820,9 +820,9 @@ double RooRealIntegral::getValV(const RooArgSet* nset) const
 //     return _value ;
 //   }
 
-  if (nset && nset!=_lastNSet) {
-    ((RooAbsReal*) this)->setProxyNormSet(nset) ;
-    _lastNSet = (RooArgSet*) nset ;
+  if (nset && nset->uniqueId().value() != _lastNormSetId) {
+    const_cast<RooRealIntegral*>(this)->setProxyNormSet(nset);
+    _lastNormSetId = nset->uniqueId().value();
   }
 
   if (isValueOrShapeDirtyAndClear()) {


### PR DESCRIPTION
The last normalization set should not be stored by pointer because this
can result is false positives when comparing normalization sets by
pointer: a new normalization set might have the same address as the
previous one.

