### PR TITLE
[ntuple] Add importing of entire `TFile`s

### DIFF
--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -217,6 +217,10 @@ private:
    std::unique_ptr<TFile> fDestFile;
    RNTupleWriteOptions fWriteOptions;
 
+   /// Whether non-TTree should be copied to the destination file, in case the importer is created by only specifying
+   /// the source file.
+   bool fCopyNonTrees;
+
    /// The maximum number of entries to import. When this value is -1 (default), import all entries.
    std::int64_t fMaxEntries = -1;
 
@@ -243,6 +247,8 @@ private:
 
    RResult<void> Import(TTree *sourceTree);
 
+   RResult<void> CopyNonTrees();
+
 public:
    RNTupleImporter(const RNTupleImporter &other) = delete;
    RNTupleImporter &operator=(const RNTupleImporter &other) = delete;
@@ -263,6 +269,7 @@ public:
    RNTupleWriteOptions GetWriteOptions() const { return fWriteOptions; }
    void SetWriteOptions(RNTupleWriteOptions options) { fWriteOptions = options; }
    void SetMaxEntries(std::uint64_t maxEntries) { fMaxEntries = maxEntries; }
+   void SetCopyNonTrees(bool copyNonTrees) { fCopyNonTrees = copyNonTrees; }
 
    /// Throws an exception in case multiple TTrees are imported simultaneously.
    ROOT::Experimental::RResult<void> SetNTupleName(std::string_view ntupleName);

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -212,7 +212,7 @@ private:
    std::vector<TTree *> fSourceTrees;
 
    /// Maps the name of the original TTree to the desired RNTuple name.
-   std::map<std::string_view, std::string> fNTupleNames;
+   std::map<std::string, std::string> fNTupleNames;
    std::string fDestFileName;
    std::unique_ptr<TFile> fDestFile;
    RNTupleWriteOptions fWriteOptions;
@@ -265,8 +265,8 @@ public:
    void SetMaxEntries(std::uint64_t maxEntries) { fMaxEntries = maxEntries; }
 
    /// Throws an exception in case multiple TTrees are imported simultaneously.
-   ROOT::Experimental::RResult<void> SetNTupleName(const std::string &ntupleName);
-   ROOT::Experimental::RResult<void> SetNTupleName(std::string_view treeName, const std::string &ntupleName);
+   ROOT::Experimental::RResult<void> SetNTupleName(std::string_view ntupleName);
+   ROOT::Experimental::RResult<void> SetNTupleName(std::string_view treeName, std::string_view ntupleName);
 
    /// Whether or not information and progress is printed to stdout.
    void SetIsQuiet(bool value) { fIsQuiet = value; }

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -264,6 +264,8 @@ public:
    void SetWriteOptions(RNTupleWriteOptions options) { fWriteOptions = options; }
    void SetMaxEntries(std::uint64_t maxEntries) { fMaxEntries = maxEntries; }
 
+   /// Throws an exception in case multiple TTrees are imported simultaneously.
+   ROOT::Experimental::RResult<void> SetNTupleName(const std::string &ntupleName);
    ROOT::Experimental::RResult<void> SetNTupleName(std::string_view treeName, const std::string &ntupleName);
 
    /// Whether or not information and progress is printed to stdout.

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -209,10 +209,11 @@ private:
    RNTupleImporter() = default;
 
    std::unique_ptr<TFile> fSourceFile;
-   TTree *fSourceTree;
+   std::vector<TTree *> fSourceTrees;
 
+   /// Maps the name of the original TTree to the desired RNTuple name.
+   std::map<std::string_view, std::string> fNTupleNames;
    std::string fDestFileName;
-   std::string fNTupleName;
    std::unique_ptr<TFile> fDestFile;
    RNTupleWriteOptions fWriteOptions;
 
@@ -237,8 +238,10 @@ private:
    void ResetSchema();
    /// Sets up the connection from TTree branches to RNTuple fields, including initialization of the memory
    /// buffers used for reading and writing.
-   RResult<void> PrepareSchema();
+   RResult<void> PrepareSchema(TTree *sourceTree);
    void ReportSchema();
+
+   RResult<void> Import(TTree *sourceTree);
 
 public:
    RNTupleImporter(const RNTupleImporter &other) = delete;
@@ -254,10 +257,14 @@ public:
    /// Directly uses the provided tree and opens the output file for writing (update).
    static RResult<std::unique_ptr<RNTupleImporter>> Create(TTree *sourceTree, std::string_view destFileName);
 
+   /// Imports all TTree objects present in `sourceFile` as RNTuple objects to `destFile`.
+   static RResult<std::unique_ptr<RNTupleImporter>> Create(std::string_view sourceFile, std::string_view destFile);
+
    RNTupleWriteOptions GetWriteOptions() const { return fWriteOptions; }
    void SetWriteOptions(RNTupleWriteOptions options) { fWriteOptions = options; }
-   void SetNTupleName(const std::string &name) { fNTupleName = name; }
-   void SetMaxEntries(std::uint64_t maxEntries) { fMaxEntries = maxEntries; };
+   void SetMaxEntries(std::uint64_t maxEntries) { fMaxEntries = maxEntries; }
+
+   ROOT::Experimental::RResult<void> SetNTupleName(std::string_view treeName, const std::string &ntupleName);
 
    /// Whether or not information and progress is printed to stdout.
    void SetIsQuiet(bool value) { fIsQuiet = value; }

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -507,9 +507,12 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::SetNTuple
 ROOT::Experimental::RResult<void>
 ROOT::Experimental::RNTupleImporter::SetNTupleName(std::string_view treeName, std::string_view ntupleName)
 {
-   if (fNTupleNames.find(std::string(treeName)) == fNTupleNames.end()) {
+   auto it = fNTupleNames.find(std::string(treeName));
+
+   if (it == fNTupleNames.end()) {
       return R__FAIL("Tree '" + std::string(treeName) + "' not present in " + std::string(fSourceFile->GetName()));
    }
-   fNTupleNames.at(std::string(treeName)) = ntupleName;
+
+   (*it).second = ntupleName;
    return RResult<void>::Success();
 }

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -121,10 +121,9 @@ ROOT::Experimental::RNTupleImporter::Create(std::string_view sourceFileName, std
    while (objLink) {
       auto key = (TKey *)objLink->GetObject();
       auto keyName = key->GetName();
-      // NOTE: Do we also want to support TNTuples?
-      bool isTree = strcmp(key->GetClassName(), "TTree") == 0;
-      // The actual current cycle number doesn't matter since TFile::Get will automatically get it from the tree name.
-      // We just need to make sure each tree is only added once.
+      bool isTree = TClass::GetClass(key->GetClassName())->GetBaseClass("TTree");
+      // The actual current cycle number doesn't matter since TFile::Get will automatically get it from
+      // the tree name. We just need to make sure each tree is only added once.
       bool isFirstOccurrence = key->GetCycle() == 1;
 
       // TODO: Copy/clone non-TTree objects to the destination file, if desired by the user.

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -123,9 +123,7 @@ ROOT::Experimental::RNTupleImporter::Create(std::string_view sourceFileName, std
       auto key = (TKey *)objLink->GetObject();
       auto keyName = key->GetName();
       bool isTree = TClass::GetClass(key->GetClassName())->GetBaseClass("TTree");
-      // The actual current cycle number doesn't matter since TFile::Get will automatically get it from
-      // the tree name. We just need to make sure each tree is only added once.
-      bool isFirstOccurrence = key->GetCycle() == 1;
+      bool isFirstOccurrence = importer->fNTupleNames.find(keyName) == importer->fNTupleNames.end();
 
       // TODO: Copy/clone non-TTree objects to the destination file, if desired by the user.
       if (isTree && isFirstOccurrence) {

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -459,13 +459,21 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::Import(TT
    return RResult<void>::Success();
 }
 
+ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::SetNTupleName(const std::string &ntupleName)
+{
+   if (fSourceTrees.size() > 1) {
+      return R__FAIL("Multiple trees are being imported, please specify the source tree name");
+   }
+   fNTupleNames.at(fSourceTrees.at(0)->GetName()) = ntupleName;
+   return RResult<void>::Success();
+}
+
 ROOT::Experimental::RResult<void>
 ROOT::Experimental::RNTupleImporter::SetNTupleName(std::string_view treeName, const std::string &ntupleName)
 {
    if (fNTupleNames.find(treeName) == fNTupleNames.end()) {
       return R__FAIL("Tree '" + std::string(treeName) + "' not present in " + std::string(fSourceFile->GetName()));
    }
-
-   fNTupleNames[treeName] = ntupleName;
+   fNTupleNames.at(treeName) = ntupleName;
    return RResult<void>::Success();
 }

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -86,7 +86,7 @@ ROOT::Experimental::RNTupleImporter::Create(std::string_view sourceFileName, std
                                             std::string_view destFileName)
 {
    auto importer = std::unique_ptr<RNTupleImporter>(new RNTupleImporter());
-   importer->fNTupleNames[treeName] = treeName;
+   importer->fNTupleNames[std::string(treeName)] = treeName;
    importer->fSourceFile = std::unique_ptr<TFile>(TFile::Open(std::string(sourceFileName).c_str()));
    if (!importer->fSourceFile || importer->fSourceFile->IsZombie()) {
       return R__FAIL("cannot open source file " + std::string(sourceFileName));
@@ -405,7 +405,7 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::Import()
 
 ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::Import(TTree *sourceTree)
 {
-   std::string ntupleName = fNTupleNames.at(std::string_view(sourceTree->GetName()));
+   std::string ntupleName = fNTupleNames.at(sourceTree->GetName());
    if (fDestFile->FindKey(ntupleName.c_str()) != nullptr)
       return R__FAIL("Key '" + ntupleName + "' already exists in file " + fDestFileName);
 
@@ -460,7 +460,7 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::Import(TT
    return RResult<void>::Success();
 }
 
-ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::SetNTupleName(const std::string &ntupleName)
+ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::SetNTupleName(std::string_view ntupleName)
 {
    if (fSourceTrees.size() > 1) {
       return R__FAIL("Multiple trees are being imported, please specify the source tree name");
@@ -470,11 +470,11 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::SetNTuple
 }
 
 ROOT::Experimental::RResult<void>
-ROOT::Experimental::RNTupleImporter::SetNTupleName(std::string_view treeName, const std::string &ntupleName)
+ROOT::Experimental::RNTupleImporter::SetNTupleName(std::string_view treeName, std::string_view ntupleName)
 {
-   if (fNTupleNames.find(treeName) == fNTupleNames.end()) {
+   if (fNTupleNames.find(std::string(treeName)) == fNTupleNames.end()) {
       return R__FAIL("Tree '" + std::string(treeName) + "' not present in " + std::string(fSourceFile->GetName()));
    }
-   fNTupleNames.at(treeName) = ntupleName;
+   fNTupleNames.at(std::string(treeName)) = ntupleName;
    return RResult<void>::Success();
 }

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -127,6 +127,7 @@ ROOT::Experimental::RNTupleImporter::Create(std::string_view sourceFileName, std
       // We just need to make sure each tree is only added once.
       bool isFirstOccurrence = key->GetCycle() == 1;
 
+      // TODO: Copy/clone non-TTree objects to the destination file, if desired by the user.
       if (isTree && isFirstOccurrence) {
          importer->fNTupleNames[keyName] = keyName;
 

--- a/tree/ntupleutil/v7/test/CMakeLists.txt
+++ b/tree/ntupleutil/v7/test/CMakeLists.txt
@@ -19,5 +19,5 @@ if(MSVC)
                                      ${CMAKE_CURRENT_BINARY_DIR}/libCustomStructUtil.dll)
 endif()
 
-ROOT_ADD_GTEST(ntuple_importer ntuple_importer.cxx LIBRARIES ROOTNTupleUtil CustomStructUtil)
+ROOT_ADD_GTEST(ntuple_importer ntuple_importer.cxx LIBRARIES ROOTNTupleUtil CustomStructUtil Hist)
 ROOT_ADD_GTEST(ntuple_inspector ntuple_inspector.cxx LIBRARIES ROOTNTupleUtil)

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -2,6 +2,7 @@
 
 #include <TFile.h>
 #include <TTree.h>
+#include <TNtuple.h>
 #include <TChain.h>
 #include <TH1.h>
 
@@ -633,6 +634,10 @@ TEST(RNTupleImporter, MultipleTrees)
       tree2->Fill();
       tree2->Write();
 
+      auto tntuple = std::make_unique<TNtuple>("tntuple", "", "c");
+      tntuple->Fill(3.14);
+      tntuple->Write();
+
       auto hist = std::make_unique<TH1F>("hist", "hist", 10, 5, 5);
       hist->Write();
    }
@@ -642,6 +647,7 @@ TEST(RNTupleImporter, MultipleTrees)
 
    importer->SetNTupleName("tree1", "ntuple1");
    importer->SetNTupleName("tree2", "ntuple2");
+   importer->SetNTupleName("tntuple", "ntuple3");
 
    // Bad weather, trying to set the name of a tree that does not exist should yield an exception.
    EXPECT_THROW(importer->SetNTupleName("tree3", "ntuple3"), ROOT::Experimental::RException);
@@ -660,6 +666,11 @@ TEST(RNTupleImporter, MultipleTrees)
    auto bView = reader2->GetView<int>("b");
    EXPECT_EQ(1U, reader2->GetNEntries());
    EXPECT_EQ(43, bView(0));
+
+   auto reader3 = RNTupleReader::Open("ntuple3", fileGuardNTuple.GetPath());
+   auto cView = reader3->GetView<float>("c");
+   EXPECT_EQ(1U, reader3->GetNEntries());
+   EXPECT_FLOAT_EQ(3.14, cView(0));
 
    // Non-TTree objects should not be imported.
    std::unique_ptr<TFile> file(TFile::Open(fileGuardNTuple.GetPath().c_str()));

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -36,68 +36,6 @@ TEST(RNTupleImporter, Empty)
    EXPECT_THROW(importer->Import(), ROOT::Experimental::RException);
 }
 
-TEST(RNTUpleImporter, SetNTupleNameSingle)
-{
-   FileRaii treeFileGuard("test_ntuple_importer_set_ntuple_name_single_tree.root");
-   FileRaii ntupleFileGuard("test_ntuple_importer_set_ntuple_name_single_ntuple.root");
-   {
-      std::unique_ptr<TFile> file(TFile::Open(treeFileGuard.GetPath().c_str(), "RECREATE"));
-
-      auto tree = std::make_unique<TTree>("tree", "");
-      tree->Write();
-   }
-
-   auto importer = RNTupleImporter::Create(treeFileGuard.GetPath(), "tree", ntupleFileGuard.GetPath()).Unwrap();
-
-   // Base case, we don't touch the name so it should be the same as the tree.
-   importer->SetIsQuiet(true);
-   importer->Import();
-   EXPECT_NO_THROW(RNTupleReader::Open("tree", ntupleFileGuard.GetPath()));
-
-   importer->SetNTupleName("ntuple");
-   importer->Import();
-   EXPECT_NO_THROW(RNTupleReader::Open("ntuple", ntupleFileGuard.GetPath()));
-
-   // Bad weather, trying to set the name of a tree that does not exist should yield an exception.
-   EXPECT_THROW(importer->SetNTupleName("treee", "ntuple"), ROOT::Experimental::RException);
-}
-
-TEST(RNTUpleImporter, SetNTupleNameMultiple)
-{
-   FileRaii treeFileGuard("test_ntuple_importer_set_ntuple_name_multiple_tree.root");
-   FileRaii ntupleFileGuard("test_ntuple_importer_set_ntuple_name_multiple_ntuple.root");
-   {
-      std::unique_ptr<TFile> file(TFile::Open(treeFileGuard.GetPath().c_str(), "RECREATE"));
-
-      auto tree1 = std::make_unique<TTree>("tree1", "");
-      tree1->Write();
-
-      auto tree2 = std::make_unique<TTree>("tree2", "");
-      tree2->Write();
-   }
-
-   auto importer = RNTupleImporter::Create(treeFileGuard.GetPath(), ntupleFileGuard.GetPath()).Unwrap();
-
-   // Base case, we don't touch the name so it should be the same as the tree.
-   importer->SetIsQuiet(true);
-   importer->Import();
-   EXPECT_NO_THROW(RNTupleReader::Open("tree1", ntupleFileGuard.GetPath()));
-   EXPECT_NO_THROW(RNTupleReader::Open("tree2", ntupleFileGuard.GetPath()));
-
-   // Good weather, the tree exists and the imported ntuple should have the desired name.
-   importer->SetNTupleName("tree1", "ntuple1");
-   importer->SetNTupleName("tree2", "ntuple2");
-   importer->Import();
-   EXPECT_NO_THROW(RNTupleReader::Open("ntuple1", ntupleFileGuard.GetPath()));
-   EXPECT_NO_THROW(RNTupleReader::Open("ntuple2", ntupleFileGuard.GetPath()));
-
-   // Bad weather, trying to set the name of a tree that does not exist should yield an exception.
-   EXPECT_THROW(importer->SetNTupleName("tree3", "ntuple3"), ROOT::Experimental::RException);
-
-   // Bad weather, trying to set the name without specifying the source tree.
-   EXPECT_THROW(importer->SetNTupleName("ntuple"), ROOT::Experimental::RException);
-}
-
 TEST(RNTupleImporter, CreateFromTree)
 {
    FileRaii fileGuard("test_ntuple_create_from_tree.root");
@@ -625,7 +563,7 @@ TEST(RNTupleImporter, CollectionProxyClass)
    }
 }
 
-TEST(RNTUpleImporter, MaxEntries)
+TEST(RNTupleImporter, MaxEntries)
 {
    FileRaii fileGuard("test_ntuple_importer_max_entries.root");
    {
@@ -677,7 +615,7 @@ TEST(RNTUpleImporter, MaxEntries)
    EXPECT_EQ(5U, reader->GetNEntries());
 }
 
-TEST(RNTUpleImporter, MultipleTrees)
+TEST(RNTupleImporter, MultipleTrees)
 {
    FileRaii fileGuardTree("test_ntuple_importer_multiple_trees_tree.root");
    FileRaii fileGuardNTuple("test_ntuple_importer_multiple_trees_ntuple.root");
@@ -704,6 +642,12 @@ TEST(RNTUpleImporter, MultipleTrees)
 
    importer->SetNTupleName("tree1", "ntuple1");
    importer->SetNTupleName("tree2", "ntuple2");
+
+   // Bad weather, trying to set the name of a tree that does not exist should yield an exception.
+   EXPECT_THROW(importer->SetNTupleName("tree3", "ntuple3"), ROOT::Experimental::RException);
+
+   // Bad weather, trying to set the name without specifying the source tree.
+   EXPECT_THROW(importer->SetNTupleName("ntuple"), ROOT::Experimental::RException);
 
    importer->Import();
 

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -689,8 +689,10 @@ TEST(RNTupleImporter, MultipleTrees)
    importerCopy->Import();
 
    std::unique_ptr<TFile> fileCopy(TFile::Open(fileGuardNTupleCopy.GetPath().c_str()));
-   // Check if th imported RNTuple is present...
+   // Check if the imported RNTuples are present...
    EXPECT_THAT(fileCopy->Get<ROOT::Experimental::RNTuple>("ntuple1"), testing::NotNull());
+   EXPECT_THAT(fileCopy->Get<ROOT::Experimental::RNTuple>("ntuple2"), testing::NotNull());
+   EXPECT_THAT(fileCopy->Get<ROOT::Experimental::RNTuple>("ntuple3"), testing::NotNull());
    // ...As well as the histogram from the original file.
    EXPECT_THAT(fileCopy->Get<TH1F>("hist"), testing::NotNull());
 }

--- a/tree/ntupleutil/v7/test/ntupleutil_test.hxx
+++ b/tree/ntupleutil/v7/test/ntupleutil_test.hxx
@@ -2,6 +2,7 @@
 #define ROOT7_RNTupleUtil_Test
 
 #include "gtest/gtest.h"
+#include "gmock/gmock.h"
 
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>


### PR DESCRIPTION
This PR introduces the possibility of converting all `TTree`s that are present in a `TFile` to `RNTuple`s at once. Concretely, it implements an additional factory method that requires only the source file path and the destination path. Because we now deal with multiple trees at the same time, `SetNTupleName` has been replaced by `SetNTupleNames`, which takes the name of the original tree and the name of the corresponding ntuple. Optionally, we could keep `SetNTupleName` as well in case there's only one tree and throw an exception when multiple trees are being imported at the same time.

The `Create` factory method could be expanded with an optional parameter that takes a list of tree names (or regexes) to import, in case it is not desired that every tree is imported.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

