### PR TITLE
[meta] GetClass better handling of typedef autoloading.

### DIFF
--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -3102,6 +3102,17 @@ TClass *TClass::GetClass(const char *name, Bool_t load, Bool_t silent, size_t hi
       loadedcl = LoadClassDefault(normalizedName.c_str(),silent);
    } else {
       if (gInterpreter->AutoLoad(normalizedName.c_str(),kTRUE)) {
+         // At this point more infomration has been loaded.  This
+         // information might be pertinent ot the normalization of the name.
+         // For example it might contain or be a typedef for which we don't
+         // have a forward declaration (eg. typedef to instance of class
+         // template with default paramters).  So let's redo the normalization
+         // as the new information (eg typedef in TROOT::GetListOfTypes) might
+         // lead to a different value.
+         {
+            TInterpreter::SuspendAutoLoadingRAII autoloadOff(gInterpreter);
+            TClassEdit::GetNormalizedName(normalizedName, name);
+         }
          loadedcl = LoadClassDefault(normalizedName.c_str(),silent);
       }
       auto e = TEnum::GetEnum(normalizedName.c_str(), TEnum::kNone);


### PR DESCRIPTION
Handle the case where a typedef as a dictionary entry and thus an autoload entry (rootmap case) and this typedef point to an instance a class template with a default paramter.  In this case we do not have a (forward) declaration of the typedef in the rootmap file (because we can't have a forward declaration of the class template).  In those case our only source of information is in the list of type which is loaded as part of the dictionary for the typedef.  If in addition the dictionary for the target of the typedef is in another library we actually need to load that library based on the resolved name of the typedef).

This fixes #12378


