### PR TITLE
[ntuple] Avoid gtest warnings about deprecated `TYPED_TEST_CASE`

### DIFF
--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -31,11 +31,11 @@ using PackingIntTypes = ::testing::Types<Helper<std::int64_t, ROOT::Experimental
                                          Helper<std::uint32_t, ROOT::Experimental::EColumnType::kSplitInt32>,
                                          Helper<std::int16_t, ROOT::Experimental::EColumnType::kSplitInt16>,
                                          Helper<std::uint16_t, ROOT::Experimental::EColumnType::kSplitInt16>>;
-TYPED_TEST_CASE(PackingInt, PackingIntTypes);
+TYPED_TEST_SUITE(PackingInt, PackingIntTypes);
 
 using PackingRealTypes = ::testing::Types<Helper<double, ROOT::Experimental::EColumnType::kSplitReal64>,
                                           Helper<float, ROOT::Experimental::EColumnType::kSplitReal32>>;
-TYPED_TEST_CASE(PackingReal, PackingRealTypes);
+TYPED_TEST_SUITE(PackingReal, PackingRealTypes);
 
 TEST(Packing, Bitfield)
 {

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -34,6 +34,11 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+// Backward compatibility for gtest version < 1.10.0
+#ifndef TYPED_TEST_SUITE
+#define TYPED_TEST_SUITE TYPED_TEST_CASE
+#endif
+
 #include "CustomStruct.hxx"
 
 #include <array>


### PR DESCRIPTION
Use the replacement `TYPED_TEST_SUITE`, and have a compatibility define for gtest version < 1.10.0.