### PR TITLE
Add option to change exponent offset for z-axis (within GAxis)

### DIFF
--- a/graf2d/graf/inc/TGaxis.h
+++ b/graf2d/graf/inc/TGaxis.h
@@ -50,6 +50,8 @@ protected:
    static Float_t fXAxisExpYOffset; ///<! Exponent Y offset for the X axis
    static Float_t fYAxisExpXOffset; ///<! Exponent X offset for the Y axis
    static Float_t fYAxisExpYOffset; ///<! Exponent Y offset for the Y axis
+   static Float_t fZAxisExpXOffset; ///<! Exponent X offset for the Z axis
+   static Float_t fZAxisExpYOffset; ///<! Exponent Y offset for the Z axis
 
    TGaxis(const TGaxis&);
    TGaxis& operator=(const TGaxis&);
@@ -130,7 +132,7 @@ public:
    void                SetTitleColor(Int_t titlecolor) {SetTextColor(titlecolor);} // *MENU*
    void                SetWmin(Double_t wmin) {fWmin = wmin;}
    void                SetWmax(Double_t wmax) {fWmax = wmax;}
-   static void         SetExponentOffset(Float_t xoff=0., Float_t yoff=0., Option_t *axis="xy");
+   static void         SetExponentOffset(Float_t xoff=0., Float_t yoff=0., Option_t *axis="xyz");
 
    ClassDefOverride(TGaxis,6)  //Graphics axis
 };

--- a/graf2d/graf/src/TGaxis.cxx
+++ b/graf2d/graf/src/TGaxis.cxx
@@ -37,10 +37,14 @@
 #include "snprintf.h"
 
 Int_t   TGaxis::fgMaxDigits = 5;
+
 Float_t TGaxis::fXAxisExpXOffset = 0.;
 Float_t TGaxis::fXAxisExpYOffset = 0.;
 Float_t TGaxis::fYAxisExpXOffset = 0.;
 Float_t TGaxis::fYAxisExpYOffset = 0.;
+Float_t TGaxis::fZAxisExpXOffset = 0.;
+Float_t TGaxis::fZAxisExpYOffset = 0.;
+
 const Int_t kHori = BIT(9);
 
 ClassImp(TGaxis);
@@ -2146,6 +2150,11 @@ L110:
                   xx = xx + fYAxisExpXOffset;
                   yy = yy + fYAxisExpYOffset;
                }
+               if (fAxis && !strcmp(fAxis->GetName(),"zaxis")) {
+                  xx = xx + fZAxisExpXOffset;
+                  yy = yy + fZAxisExpYOffset;
+               }
+
                typolabel = label;
                typolabel.ReplaceAll("-", "#minus");
                textaxis.PaintLatex(gPad->GetX1() + xx*(gPad->GetX2() - gPad->GetX1()),
@@ -2936,6 +2945,11 @@ void TGaxis::SetExponentOffset(Float_t xoff, Float_t yoff, Option_t *axis)
       fYAxisExpXOffset = xoff;
       fYAxisExpYOffset = yoff;
    }
+   if (opt.Contains("z")) {
+      fZAxisExpXOffset = xoff;
+      fZAxisExpYOffset = yoff;
+   }
+
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/graf/src/TGaxis.cxx
+++ b/graf2d/graf/src/TGaxis.cxx
@@ -37,7 +37,6 @@
 #include "snprintf.h"
 
 Int_t   TGaxis::fgMaxDigits = 5;
-
 Float_t TGaxis::fXAxisExpXOffset = 0.;
 Float_t TGaxis::fXAxisExpYOffset = 0.;
 Float_t TGaxis::fYAxisExpXOffset = 0.;
@@ -2154,7 +2153,6 @@ L110:
                   xx = xx + fZAxisExpXOffset;
                   yy = yy + fZAxisExpYOffset;
                }
-
                typolabel = label;
                typolabel.ReplaceAll("-", "#minus");
                textaxis.PaintLatex(gPad->GetX1() + xx*(gPad->GetX2() - gPad->GetX1()),
@@ -2949,7 +2947,6 @@ void TGaxis::SetExponentOffset(Float_t xoff, Float_t yoff, Option_t *axis)
       fZAxisExpXOffset = xoff;
       fZAxisExpYOffset = yoff;
    }
-
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
Add option to change exponent offset for z-axis (within GAxis) 

## Checklist:

- [X] tested changes locally
- [X] updated the docs (if necessary) (technically the doc already even says "xz", though the "z" was not being used)

This PR fixes # 
Often times when drawing 2D histograms (with the SURF option), the 10^n exponent on the z-axis will intersect the "height" lines drawn for the z-axis. To fix this, I've added the option to "translate" the exponent label (shifting x, y) for the z-axis, which was previously only possible to do with x and y-axes. 

Here is the 10^n exponent intersecting with the height-lines:
![before_offset](https://user-images.githubusercontent.com/32146461/225423544-92800949-b355-4382-83a6-1a2e2595d1d6.png)

Here is the 10^n exponent shifted upwards in y very slightly to avoid this intersection:
![after_offset](https://user-images.githubusercontent.com/32146461/225423842-b27bdd15-c62e-4a20-83b4-1202fa75c767.png)

