### PR TITLE
Allow splitting of TTime objects

### DIFF
--- a/core/base/inc/LinkDef2.h
+++ b/core/base/inc/LinkDef2.h
@@ -130,7 +130,7 @@
 #pragma link C++ class MemInfo_t+;
 #pragma link C++ class ProcInfo_t+;
 #pragma link C++ class TTask+;
-#pragma link C++ class TTime;
+#pragma link C++ class TTime+;
 #pragma link C++ class TTimer;
 #pragma link C++ class TQObject-;
 #pragma link C++ class TQObjSender;


### PR DESCRIPTION
This fixes #12498.

TTime objects were not (anymore) split because TTime is still using the automatically generated but streamer-function based I/O. (The splitting stopped when `TTree` was upgraded to respect custom streamers).

