### PR TITLE
[v6-24][PyROOT] code.h must not be included directly in 3.11

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPOverload.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPOverload.cxx
@@ -1,10 +1,10 @@
 // Bindings
 #include "CPyCppyy.h"
 #include "structmember.h"    // from Python
-#if PY_VERSION_HEX >= 0x02050000
-#include "code.h"            // from Python
-#else
+#if PY_VERSION_HEX < 0x02050000
 #include "compile.h"         // from Python
+#elif PY_VERSION_HEX < 0x030b0000
+#include "code.h"            // from Python
 #endif
 #ifndef CO_NOFREE
 // python2.2 does not have CO_NOFREE defined


### PR DESCRIPTION
It has been moved to Include/cpython, and it is included by Python.h.

See:
https://docs.python.org/3.11/whatsnew/3.11.html
