### PR TITLE
Fit params were converted to float.

### DIFF
--- a/hist/histpainter/src/TGraphPainter.cxx
+++ b/hist/histpainter/src/TGraphPainter.cxx
@@ -4634,11 +4634,11 @@ void TGraphPainter::PaintStats(TGraph *theGraph, TF1 *fit)
    char textstats[50];
    Int_t ndf = fit->GetNDF();
    snprintf(textstats,50,"#chi^{2} / ndf = %s%s / %d","%",stats->GetFitFormat(),ndf);
-   snprintf(t,64,textstats,(Float_t)fit->GetChisquare());
+   snprintf(t,64,textstats,fit->GetChisquare());
    if (print_fchi2) stats->AddText(t);
    if (print_fprob) {
       snprintf(textstats,50,"Prob  = %s%s","%",stats->GetFitFormat());
-      snprintf(t,64,textstats,(Float_t)TMath::Prob(fit->GetChisquare(),ndf));
+      snprintf(t,64,textstats,TMath::Prob(fit->GetChisquare(),ndf));
       stats->AddText(t);
    }
    if (print_fval || print_ferrors) {
@@ -4648,11 +4648,11 @@ void TGraphPainter::PaintStats(TGraph *theGraph, TF1 *fit)
          if (print_fval < 2 && parmin*parmax != 0 && parmin >= parmax) continue;
          if (print_ferrors) {
             snprintf(textstats,50,"%-8s = %s%s #pm %s%s ",fit->GetParName(ipar),"%",stats->GetFitFormat(),"%",stats->GetFitFormat());
-            snprintf(t,64,textstats,(Float_t)fit->GetParameter(ipar)
-                            ,(Float_t)fit->GetParError(ipar));
+            snprintf(t,64,textstats,fit->GetParameter(ipar)
+                            ,fit->GetParError(ipar));
          } else {
             snprintf(textstats,50,"%-8s = %s%s ",fit->GetParName(ipar),"%",stats->GetFitFormat());
-            snprintf(t,64,textstats,(Float_t)fit->GetParameter(ipar));
+            snprintf(t,64,textstats,fit->GetParameter(ipar));
          }
          t[63] = 0;
          stats->AddText(t);

--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -8708,11 +8708,11 @@ void THistPainter::PaintStat(Int_t dostat, TF1 *fit)
    if (fit) {
       Int_t ndf = fit->GetNDF();
       tf.Form("#chi^{2} / ndf = %s%s / %d","%",stats->GetFitFormat(),ndf);
-      tt.Form(tf.Data(),(Float_t)fit->GetChisquare());
+      tt.Form(tf.Data(),fit->GetChisquare());
       if (print_fchi2) stats->AddText(tt.Data());
       if (print_fprob) {
          tf.Form("Prob  = %s%s","%",stats->GetFitFormat());
-         tt.Form(tf.Data(),(Float_t)TMath::Prob(fit->GetChisquare(),ndf));
+         tt.Form(tf.Data(),TMath::Prob(fit->GetChisquare(),ndf));
          stats->AddText(tt.Data());
       }
       if (print_fval || print_ferrors) {
@@ -8723,11 +8723,11 @@ void THistPainter::PaintStat(Int_t dostat, TF1 *fit)
             if (print_ferrors) {
                tf.Form("%-8s = %s%s #pm %s ", fit->GetParName(ipar), "%",stats->GetFitFormat(),
                        GetBestFormat(fit->GetParameter(ipar), fit->GetParError(ipar), stats->GetFitFormat()));
-               tt.Form(tf.Data(),(Float_t)fit->GetParameter(ipar)
-                               ,(Float_t)fit->GetParError(ipar));
+               tt.Form(tf.Data(),fit->GetParameter(ipar)
+                               ,fit->GetParError(ipar));
             } else {
                tf.Form("%-8s = %s%s ",fit->GetParName(ipar), "%",stats->GetFitFormat());
-               tt.Form(tf.Data(),(Float_t)fit->GetParameter(ipar));
+               tt.Form(tf.Data(),fit->GetParameter(ipar));
             }
             stats->AddText(tt.Data());
          }
@@ -8937,12 +8937,12 @@ void THistPainter::PaintStat2(Int_t dostat, TF1 *fit)
    // Draw Fit parameters
    if (fit) {
       Int_t ndf = fit->GetNDF();
-      tt.Form("#chi^{2} / ndf = %6.4g / %d",(Float_t)fit->GetChisquare(),ndf);
+      tt.Form("#chi^{2} / ndf = %6.4g / %d",fit->GetChisquare(),ndf);
       stats->AddText(tt.Data());
       for (Int_t ipar=0;ipar<fit->GetNpar();ipar++) {
          tt.Form("%-8s = %5.4g #pm %5.4g ",fit->GetParName(ipar)
-                                   ,(Float_t)fit->GetParameter(ipar)
-                                   ,(Float_t)fit->GetParError(ipar));
+                                   ,fit->GetParameter(ipar)
+                                   ,fit->GetParError(ipar));
          stats->AddText(tt.Data());
       }
    }
@@ -9151,12 +9151,12 @@ void THistPainter::PaintStat3(Int_t dostat, TF1 *fit)
    // Draw Fit parameters
    if (fit) {
       Int_t ndf = fit->GetNDF();
-      tt.Form("#chi^{2} / ndf = %6.4g / %d",(Float_t)fit->GetChisquare(),ndf);
+      tt.Form("#chi^{2} / ndf = %6.4g / %d",fit->GetChisquare(),ndf);
       stats->AddText(tt.Data());
       for (Int_t ipar=0;ipar<fit->GetNpar();ipar++) {
          tt.Form("%-8s = %5.4g #pm %5.4g ",fit->GetParName(ipar)
-                                   ,(Float_t)fit->GetParameter(ipar)
-                                   ,(Float_t)fit->GetParError(ipar));
+                                   ,fit->GetParameter(ipar)
+                                   ,fit->GetParError(ipar));
          stats->AddText(tt.Data());
       }
    }


### PR DESCRIPTION
Fit params were concerted to float in stats display.
The problem was seen here: https://root-forum.cern.ch/t/root-gstyle-setoptfit-1111/54071/30

