### PR TITLE
[RF] Add support for differentiating Gaussian integrals using AD.

### DIFF
--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -20,6 +20,7 @@ endif()
 
 ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
   HEADERS
+    RooFit/Detail/AnalyticalIntegrals.h
     RooFit/Detail/DataMap.h
     RooFit/Detail/NormalizationHelpers.h
     RooFit/Floats.h

--- a/roofit/roofitcore/inc/RooFit/Detail/AnalyticalIntegrals.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/AnalyticalIntegrals.h
@@ -1,0 +1,72 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   Jonas Rembser, CERN 2023
+ *   Garima Singh, CERN 2023
+ *
+ * Copyright (c) 2023, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#ifndef RooFit_Detail_AnalyticalIntegrals_h
+#define RooFit_Detail_AnalyticalIntegrals_h
+
+#include <TMath.h>
+
+namespace RooFit {
+
+namespace Detail {
+
+namespace AnalyticalIntegrals {
+
+/// @brief Function to calculate the integral of an un-normalized RooGaussian over x. To calculate the integral over
+/// mean, just interchange the respective values of x and mean.
+/// @param xMin Minimum value of variable to integrate wrt.
+/// @param xMax Maximum value of of variable to integrate wrt.
+/// @param mean Mean.
+/// @param sigma Sigma.
+/// @return The integral of an un-normalized RooGaussian over the value in x.
+inline double gaussianIntegral(double xMin, double xMax, double mean, double sigma)
+{
+   // The normalisation constant 1./sqrt(2*pi*sigma^2) is left out in evaluate().
+   // Therefore, the integral is scaled up by that amount to make RooFit normalise
+   // correctly.
+   double resultScale = std::sqrt(TMath::TwoPi()) * sigma;
+
+   // Here everything is scaled and shifted into a standard normal distribution:
+   double xscale = TMath::Sqrt2() * sigma;
+   double scaledMin = 0.;
+   double scaledMax = 0.;
+   scaledMin = (xMin - mean) / xscale;
+   scaledMax = (xMax - mean) / xscale;
+
+   // Here we go for maximum precision: We compute all integrals in the UPPER
+   // tail of the Gaussian, because erfc has the highest precision there.
+   // Therefore, the different cases for range limits in the negative hemisphere are mapped onto
+   // the equivalent points in the upper hemisphere using erfc(-x) = 2. - erfc(x)
+   double ecmin = TMath::Erfc(std::abs(scaledMin));
+   double ecmax = TMath::Erfc(std::abs(scaledMax));
+
+   double cond = 0.0;
+   // Don't put this "prd" inside the "if" because clad will not be able to differentiate the code correctly (as of
+   // v1.1)!
+   double prd = scaledMin * scaledMax;
+   if (prd < 0.0)
+      cond = 2.0 - (ecmin + ecmax);
+   else if (scaledMax <= 0.0)
+      cond = ecmax - ecmin;
+   else
+      cond = ecmin - ecmax;
+   return resultScale * 0.5 * cond;
+}
+
+} // namespace AnalyticalIntegrals
+
+} // namespace Detail
+
+} // namespace RooFit
+
+#endif

--- a/roofit/roofitcore/test/testRooFuncWrapper.cxx
+++ b/roofit/roofitcore/test/testRooFuncWrapper.cxx
@@ -232,8 +232,9 @@ std::string integralCode(RooRealIntegral const &integral)
    if (code == 1) {
       auto gauss = dynamic_cast<RooGaussian const *>(&integral.integrand());
       RooRealVar const &x = static_cast<RooRealVar const &>(gauss->getX());
-      ss << "GaussianEvalIntegralOverX(" << valToString(x.getMin(range)) << "," << valToString(x.getMax()) << ", "
-         << valName(gauss->getMean()) << ", " << valName(gauss->getSigma()) << ")";
+      RooRealVar const &mean = static_cast<RooRealVar const &>(gauss->getMean());
+      ss << "RooFit::Detail::AnalyticalIntegrals::gaussianIntegral(" << valToString(x.getMin(range)) << ", "
+         << valToString(x.getMax(range)) << ", " << valName(mean) << ", " << valName(gauss->getSigma()) << ")";
    }
    return ss.str();
 }
@@ -300,17 +301,10 @@ TEST(RooFuncWrapper, GaussianNormalized)
    "   const double arg = x - mean;"
    "   return std::exp(-0.5 * arg * arg / (sigma * sigma));"
    "}"
-   ""
-   "double GaussianEvalIntegralOverX(double /*xMin*/, double /*xMax*/, double mean, double sigma)"
-   "{"
-       // With clad, we can't use std::erfc yet, so we hardcode integration over infinity"
-   "   return std::sqrt(TMath::TwoPi()) * sigma;"
-   "}"
    );
    // clang-format on
 
-   auto inf = std::numeric_limits<double>::infinity();
-   RooRealVar x("x", "x", 0, -inf, inf);
+   RooRealVar x("x", "x", 0, -10, 10);
    RooRealVar mu("mu", "mu", 0, -10, 10);
    RooRealVar sigma("sigma", "sigma", 2.0, 0.01, 10);
    RooGaussian gauss{"gauss", "gauss", x, mu, sigma};


### PR DESCRIPTION
This commits adds support for including analytical integrals into the mock code-squashing test by introducing a private header that stores the stateless implementation details.

