### PR TITLE
[ntuple] Add support for std::bitset<N>

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -648,6 +648,12 @@ The child fileds are named `_0` and `_1`.
 A tuple is stored using an empty mother field with $n$ subfields of type `T1`, `T2`, ..., `Tn`. All types must have RNTuple I/O support.
 The child fileds are named `_0`, `_1`, ...
 
+#### std::bitset<N>
+
+A bitset is stored as a repetitive leaf field with an attached `Bit` column.
+The bitset size `N` is stored as repetition parameter in the field meta-data.
+Within the repetition blocks, bits are stored in little-endian order, i.e. the least significant bits come first.
+
 ### User-defined classes
 
 User-defined classes might behave either as a record or as a collection of elements of a given type.

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -31,6 +31,7 @@
 
 #include <algorithm>
 #include <array>
+#include <bitset>
 #include <cstddef>
 #include <functional>
 #include <iostream>
@@ -712,6 +713,47 @@ public:
    size_t GetValueSize() const final { return fItemSize * fArrayLength; }
    size_t GetAlignment() const final { return fSubFields[0]->GetAlignment(); }
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+};
+
+/// The generic field an std::bitset<N>. All compilers we care about store the bits in an array of unsigned long.
+/// TODO(jblomer): reading and writing efficiency should be improved; currently it is one bit at a time
+/// with an array of bools on the page level.
+class RBitsetField : public Detail::RFieldBase {
+protected:
+   std::size_t fN;
+
+protected:
+   std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final
+   {
+      return std::make_unique<RBitsetField>(newName, fN);
+   }
+   const RColumnRepresentations &GetColumnRepresentations() const final;
+   void GenerateColumnsImpl() final;
+   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+   std::size_t AppendImpl(const Detail::RFieldValue &value) final;
+   void ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue *value) final;
+
+public:
+   RBitsetField(std::string_view fieldName, std::size_t N);
+   RBitsetField(RBitsetField &&other) = default;
+   RBitsetField &operator=(RBitsetField &&other) = default;
+   ~RBitsetField() override = default;
+
+   using Detail::RFieldBase::GenerateValue;
+   Detail::RFieldValue GenerateValue(void *where) final
+   {
+      memset(where, 0, GetValueSize());
+      return Detail::RFieldValue(true /* captureFlag */, this, where);
+   }
+   Detail::RFieldValue CaptureValue(void *where) final
+   {
+      return Detail::RFieldValue(true /* captureFlag */, this, where);
+   }
+   size_t GetValueSize() const final { return (fN + sizeof(unsigned long) * 8 - 1) / 8; }
+   size_t GetAlignment() const final { return alignof(unsigned long); }
+   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+
+   std::size_t GetN() const { return fN; }
 };
 
 /// The generic field for std::variant types
@@ -2113,6 +2155,24 @@ public:
       reinterpret_cast<ContainerT *>(value.GetRawPtr())->~tuple();
       if (!dtorOnly)
          free(reinterpret_cast<ContainerT *>(value.GetRawPtr()));
+   }
+};
+
+template <std::size_t N>
+class RField<std::bitset<N>> : public RBitsetField {
+public:
+   static std::string TypeName() { return "std::bitset<" + std::to_string(N) + ">"; }
+   explicit RField(std::string_view name) : RBitsetField(name, N) {}
+   RField(RField &&other) = default;
+   RField &operator=(RField &&other) = default;
+   ~RField() override = default;
+
+   using Detail::RFieldBase::GenerateValue;
+   template <typename... ArgsT>
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where, ArgsT &&...args)
+   {
+      return Detail::RFieldValue(Detail::RColumnElement<std::bitset<N>>(static_cast<float *>(where)), this,
+                                 static_cast<std::bitset<N> *>(where), std::forward<ArgsT>(args)...);
    }
 };
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -753,7 +753,7 @@ public:
    {
       return Detail::RFieldValue(true /* captureFlag */, this, where);
    }
-   size_t GetValueSize() const final { return kWordSize * (fN + kBitsPerWord - 1) / kBitsPerWord; }
+   size_t GetValueSize() const final { return kWordSize * ((fN + kBitsPerWord - 1) / kBitsPerWord); }
    size_t GetAlignment() const final { return alignof(Word_t); }
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -719,6 +719,10 @@ public:
 /// TODO(jblomer): reading and writing efficiency should be improved; currently it is one bit at a time
 /// with an array of bools on the page level.
 class RBitsetField : public Detail::RFieldBase {
+   using Word_t = unsigned long;
+   static constexpr std::size_t kWordSize = sizeof(Word_t);
+   static constexpr std::size_t kBitsPerWord = kWordSize * 8;
+
 protected:
    std::size_t fN;
 
@@ -749,10 +753,11 @@ public:
    {
       return Detail::RFieldValue(true /* captureFlag */, this, where);
    }
-   size_t GetValueSize() const final { return (fN + sizeof(unsigned long) * 8 - 1) / 8; }
-   size_t GetAlignment() const final { return alignof(unsigned long); }
+   size_t GetValueSize() const final { return kWordSize * (fN + kBitsPerWord - 1) / kBitsPerWord; }
+   size_t GetAlignment() const final { return alignof(Word_t); }
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 
+   /// Get the number of bits in the bitset, i.e. the N in std::bitset<N>
    std::size_t GetN() const { return fN; }
 };
 

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -46,6 +46,7 @@ public:
    virtual void VisitField(const Detail::RFieldBase &field) = 0;
    virtual void VisitFieldZero(const RFieldZero &field) { VisitField(field); }
    virtual void VisitArrayField(const RArrayField &field) { VisitField(field); }
+   virtual void VisitBitsetField(const RBitsetField &field) { VisitField(field); }
    virtual void VisitBoolField(const RField<bool> &field) { VisitField(field); }
    virtual void VisitClassField(const RClassField &field) { VisitField(field); }
    virtual void VisitCollectionClassField(const RCollectionClassField &field) { VisitField(field); }
@@ -216,6 +217,7 @@ public:
    void VisitVectorField(const RVectorField &field) final;
    void VisitVectorBoolField(const RField<std::vector<bool>> &field) final;
    void VisitRVecField(const RRVecField &field) final;
+   void VisitBitsetField(const RBitsetField &field) final;
 };
 
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -155,11 +155,16 @@ std::string GetNormalizedType(const std::string &typeName) {
    if (translatedType != typeTranslationMap.end())
       normalizedType = translatedType->second;
 
-   if (normalizedType.substr(0, 7) == "vector<") normalizedType = "std::" + normalizedType;
-   if (normalizedType.substr(0, 6) == "array<") normalizedType = "std::" + normalizedType;
-   if (normalizedType.substr(0, 8) == "variant<") normalizedType = "std::" + normalizedType;
-   if (normalizedType.substr(0, 5) == "pair<") normalizedType = "std::" + normalizedType;
-   if (normalizedType.substr(0, 6) == "tuple<") normalizedType = "std::" + normalizedType;
+   if (normalizedType.substr(0, 7) == "vector<")
+      normalizedType = "std::" + normalizedType;
+   if (normalizedType.substr(0, 6) == "array<")
+      normalizedType = "std::" + normalizedType;
+   if (normalizedType.substr(0, 8) == "variant<")
+      normalizedType = "std::" + normalizedType;
+   if (normalizedType.substr(0, 5) == "pair<")
+      normalizedType = "std::" + normalizedType;
+   if (normalizedType.substr(0, 6) == "tuple<")
+      normalizedType = "std::" + normalizedType;
    if (normalizedType.substr(0, 7) == "bitset<")
       normalizedType = "std::" + normalizedType;
 
@@ -2100,14 +2105,13 @@ void ROOT::Experimental::RBitsetField::GenerateColumnsImpl(const RNTupleDescript
 
 std::size_t ROOT::Experimental::RBitsetField::AppendImpl(const Detail::RFieldValue &value)
 {
-   constexpr auto nBitsULong = sizeof(unsigned long) * 8;
-   const auto *asULongArray = value.Get<unsigned long>();
+   const auto *asULongArray = value.Get<Word_t>();
    bool elementValue;
    Detail::RColumnElement<bool> element(&elementValue);
    std::size_t i = 0;
-   for (std::size_t word = 0; word < (fN + nBitsULong - 1) / nBitsULong; ++word) {
-      for (std::size_t mask = 0; (mask < nBitsULong) && (i < fN); ++mask, ++i) {
-         elementValue = (asULongArray[word] & (static_cast<unsigned long>(1) << mask)) != 0;
+   for (std::size_t word = 0; word < (fN + kBitsPerWord - 1) / kBitsPerWord; ++word) {
+      for (std::size_t mask = 0; (mask < kBitsPerWord) && (i < fN); ++mask, ++i) {
+         elementValue = (asULongArray[word] & (static_cast<Word_t>(1) << mask)) != 0;
          fColumns[0]->Append(element);
       }
    }
@@ -2116,15 +2120,14 @@ std::size_t ROOT::Experimental::RBitsetField::AppendImpl(const Detail::RFieldVal
 
 void ROOT::Experimental::RBitsetField::ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue *value)
 {
-   constexpr auto nBitsULong = sizeof(unsigned long) * 8;
-   auto *asULongArray = value->Get<unsigned long>();
+   auto *asULongArray = value->Get<Word_t>();
    bool elementValue;
    Detail::RColumnElement<bool> element(&elementValue);
    for (std::size_t i = 0; i < fN; ++i) {
       fColumns[0]->Read(globalIndex * fN + i, &element);
-      unsigned long mask = static_cast<unsigned long>(1) << (i % nBitsULong);
-      unsigned long bit = static_cast<unsigned long>(elementValue) << (i % nBitsULong);
-      asULongArray[i / nBitsULong] = (asULongArray[i / nBitsULong] & ~mask) | bit;
+      Word_t mask = static_cast<Word_t>(1) << (i % kBitsPerWord);
+      Word_t bit = static_cast<Word_t>(elementValue) << (i % kBitsPerWord);
+      asULongArray[i / kBitsPerWord] = (asULongArray[i / kBitsPerWord] & ~mask) | bit;
    }
 }
 

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -261,6 +261,25 @@ void ROOT::Experimental::RPrintValueVisitor::VisitCardinalityField(const RField<
    fOutput << static_cast<std::size_t>(*fValue.Get<RNTupleCardinality>());
 }
 
+void ROOT::Experimental::RPrintValueVisitor::VisitBitsetField(const RBitsetField &field)
+{
+   constexpr auto nBitsULong = sizeof(unsigned long) * 8;
+   const auto *asULongArray = fValue.Get<unsigned long>();
+
+   PrintIndent();
+   PrintName(field);
+   fOutput << "\"";
+   std::size_t i = 0;
+   std::string str;
+   for (std::size_t word = 0; word < (field.GetN() + nBitsULong - 1) / nBitsULong; ++word) {
+      for (std::size_t mask = 0; (mask < nBitsULong) && (i < field.GetN()); ++mask, ++i) {
+         bool isSet = (asULongArray[word] & (static_cast<unsigned long>(1) << mask)) != 0;
+         str = std::to_string(isSet) + str;
+      }
+   }
+   fOutput << str << "\"";
+}
+
 void ROOT::Experimental::RPrintValueVisitor::VisitArrayField(const RArrayField &field)
 {
    PrintCollection(field);

--- a/tree/ntuple/v7/test/ntuple_show.cxx
+++ b/tree/ntuple/v7/test/ntuple_show.cxx
@@ -41,6 +41,7 @@ TEST(RNTupleShow, BasicTypes)
       auto fieldstring = model->MakeField<std::string>("string");
       auto fieldbool = model->MakeField<bool>("boolean");
       auto fieldchar = model->MakeField<uint8_t>("uint8");
+      auto fieldbitset = model->MakeField<std::bitset<65>>("bitset");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, rootFileName);
 
       *fieldPt = 5.0f;
@@ -51,6 +52,7 @@ TEST(RNTupleShow, BasicTypes)
       *fieldstring = "TestString";
       *fieldbool = true;
       *fieldchar = 97;
+      *fieldbitset = std::bitset<65>("10000000000000000000000000000010000000000000000000000000000010010");
       ntuple->Fill();
 
       *fieldPt = 8.5f;
@@ -61,6 +63,7 @@ TEST(RNTupleShow, BasicTypes)
       *fieldstring = "TestString2";
       *fieldbool = false;
       *fieldchar = 98;
+      fieldbitset->flip();
       ntuple->Fill();
    }
 
@@ -78,7 +81,8 @@ TEST(RNTupleShow, BasicTypes)
       + "  \"uint64\": 44444444444,\n"
       + "  \"string\": \"TestString\",\n"
       + "  \"boolean\": true,\n"
-      + "  \"uint8\": 97\n"
+      + "  \"uint8\": 97,\n"
+      + "  \"bitset\": \"10000000000000000000000000000010000000000000000000000000000010010\"\n"
       + "}\n" };
    // clang-format on
    EXPECT_EQ(fString, os.str());
@@ -95,7 +99,8 @@ TEST(RNTupleShow, BasicTypes)
       + "  \"uint64\": 2299994967294,\n"
       + "  \"string\": \"TestString2\",\n"
       + "  \"boolean\": false,\n"
-      + "  \"uint8\": 98\n"
+      + "  \"uint8\": 98,\n"
+      + "  \"bitset\": \"01111111111111111111111111111101111111111111111111111111111101101\"\n"
       + "}\n" };
    // clang-format on
    EXPECT_EQ(fString1, os1.str());

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -467,6 +467,7 @@ TEST(RNTuple, Bitset)
 
    auto f1 = model->MakeField<std::bitset<66>>("f1");
    EXPECT_EQ(std::string("std::bitset<66>"), model->GetField("f1")->GetType());
+   EXPECT_EQ(sizeof(std::bitset<66>), model->GetField("f1")->GetValueSize());
    auto f2 = model->MakeField<std::bitset<8>>("f2", "10101010");
 
    {


### PR DESCRIPTION
Adds a type-erased `RBitsetField` and a templated `RField<std::bitset<N>>`. Compilers implement bitsets as arrays of `unsigned long`. On disk, bitsets get stored as `Bit` column. Bit sets occur in the CMS EDM.

