### PR TITLE
[v6-24][PyROOT] Py_TYPE is changed to an inline static function in Py3.11

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPConstructor.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPConstructor.cxx
@@ -122,7 +122,7 @@ PyObject* CPyCppyy::CPPConstructor::Call(
             if (pyclass) {
                 self->SetSmart((PyObject*)Py_TYPE(self));
                 Py_DECREF((PyObject*)Py_TYPE(self));
-                Py_TYPE(self) = (PyTypeObject*)pyclass;
+                Py_SET_TYPE(self, (PyTypeObject*)pyclass);
             }
         }
 

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyy.h
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyy.h
@@ -304,6 +304,13 @@ inline Py_ssize_t PyNumber_AsSsize_t(PyObject* obj, PyObject*) {
 #define CPyCppyy_PyCFunction_Call PyCFunction_Call
 #endif
 
+// Py_TYPE is changed to an inline static function in 3.11
+#if PY_VERSION_HEX < 0x030900A4 && !defined(Py_SET_TYPE)
+static inline
+void _Py_SET_TYPE(PyObject *ob, PyTypeObject *type) { ob->ob_type = type; }
+#define Py_SET_TYPE(ob, type) _Py_SET_TYPE((PyObject*)(ob), type)
+#endif
+
 // C++ version of the cppyy API
 #include "Cppyy.h"
 


### PR DESCRIPTION
As mentioned in the Python docs:
https://docs.python.org/3.11/whatsnew/3.11.html

Already available upstream in:
https://github.com/wlav/CPyCppyy/commit/a8f41df0618f40ecc9a2a0b5a51fd12ddf2e6673
