### PR TITLE
Revert recent C++20 related modulemap commits

### DIFF
--- a/interpreter/cling/include/cling/std.modulemap
+++ b/interpreter/cling/include/cling/std.modulemap
@@ -459,10 +459,6 @@ module "std" [system] {
     export *
     header "bits/stl_iterator.h"
   }
-  module "bits/stl_iterator_base_funcs.h" {
-    export *
-    header "bits/stl_iterator_base_funcs.h"
-  }
   module "bits/stl_iterator_base_types.h" {
     export *
     export bits_stl_algobase_h

--- a/interpreter/cling/include/cling/std.modulemap
+++ b/interpreter/cling/include/cling/std.modulemap
@@ -429,11 +429,6 @@ module "std" [system] {
     export *
     header "bits/basic_ios.h"
   }
-  module "bits/chrono.h" {
-    requires cplusplus20
-    export *
-    header "bits/chrono.h"
-  }
   module "bits/cpp_type_traits.h" {
     export *
     header "bits/cpp_type_traits.h"
@@ -466,10 +461,9 @@ module "std" [system] {
   }
   module "bits/stl_iterator_base_funcs.h" {
     export *
-    export bits_stl_iterator_base_types_h
     header "bits/stl_iterator_base_funcs.h"
   }
-  module "bits_stl_iterator_base_types_h" {
+  module "bits/stl_iterator_base_types.h" {
     export *
     export bits_stl_algobase_h
     header "bits/stl_iterator_base_types.h"
@@ -491,30 +485,18 @@ module "std" [system] {
     requires cplusplus20
     export *
     export utility
-    export bits_stl_algo_h
     header "bits/ranges_algo.h"
   }
-   module "bits/ranges_algobase.h" {
+  module "bits/ranges_algobase.h" {
     requires cplusplus20
     export *
-    export initializer_list
     header "bits/ranges_algobase.h"
   }
-  explicit module "bits_ranges_base_h" {
+  module "bits/ranges_base.h" {
     requires cplusplus20
     export *
     export bits_stl_iterator_h
-    export initializer_list
     header "bits/ranges_base.h"
-  }
-  module "bits_stl_algo_h" {
-    export *
-    header "bits/stl_algo.h"
-  }
-  module "bits/stl_construct.h" {
-    export *
-    export bits_stl_iterator_base_types_h
-    header "bits/stl_construct.h"
   }
   module "bits/uniform_int_dist.h" {
     export *


### PR DESCRIPTION
It causes build failures on GCC 12.2.1 / c++17 with

```
[ 70%] Generating G__Core.cxx, ../lib/Core.pcm
In file included from input_line_7:111:
/home/linev/build/webgui/include/ROOT/RDirectoryEntry.hxx:31:33: error: missing '#include <bits/chrono.h>'; 'system_clock' must be declared before it is used
   using clock_t = std::chrono::system_clock;
                                ^
/usr/include/c++/12/bits/chrono.h:1110:12: note: declaration here is not visible
    struct system_clock
           ^
In module 'std' imported from input_line_1:1:
/usr/include/c++/12/bits/move.h:204:11: error: missing '#include <bits/chrono.h>'; 'time_point' must be defined before it is used
      _Tp __tmp = _GLIBCXX_MOVE(__a);
          ^
/home/linev/build/webgui/include/ROOT/RDirectoryEntry.hxx:89:4: note: in instantiation of function template specialization 'std::swap<std::chrono::time_point<std::chrono::system_clock, std::chrono::duration<long, std::ratio<1, 1000000000>>>>' requested here
   swap(fDate, other.fDate);
   ^
/usr/include/c++/12/bits/chrono.h:856:14: note: definition here is not reachable
      struct time_point
```# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

