### PR TITLE
[c++20] Add spaceship operator <=> in TString

### DIFF
--- a/core/base/inc/TString.h
+++ b/core/base/inc/TString.h
@@ -171,8 +171,9 @@ friend Bool_t  operator==(const TString &s1, const TString &s2);
 friend Bool_t  operator==(const TString &s1, const char *s2);
 #ifdef __cpp_lib_three_way_comparison
 friend std::strong_ordering operator<=>(const TString &s1, const TString &s2) {
-   if (s1 == s2) return std::strong_ordering::equal;
-   else if (s1 < s2) return std::strong_ordering::less;
+   const int cmp = s1.CompareTo(s2);
+   if (cmp == 0) return std::strong_ordering::equal;
+   if (cmp < 0) return std::strong_ordering::less;
    return std::strong_ordering::greater;
 }
 #endif

--- a/core/base/inc/TString.h
+++ b/core/base/inc/TString.h
@@ -59,9 +59,6 @@ Bool_t  operator==(const TString &s1, const char *s2);
 Bool_t  operator==(const TSubString &s1, const TSubString &s2);
 Bool_t  operator==(const TSubString &s1, const TString &s2);
 Bool_t  operator==(const TSubString &s1, const char *s2);
-#ifdef __cpp_lib_three_way_comparison
-std::strong_ordering operator<=>(const TString &s1, const TString &s2);
-#endif
 /*
 template<class T>
 struct is_signed_numeral : std::integral_constant<bool,
@@ -173,7 +170,11 @@ operator+(T f, const TString &s);
 friend Bool_t  operator==(const TString &s1, const TString &s2);
 friend Bool_t  operator==(const TString &s1, const char *s2);
 #ifdef __cpp_lib_three_way_comparison
-friend std::strong_ordering operator<=>(const TString &s1, const TString &s2);
+friend std::strong_ordering operator<=>(const TString &s1, const TString &s2) {
+   if (s1 == s2) return std::strong_ordering::equal;
+   else if (s1 < s2) return std::strong_ordering::less;
+   return std::strong_ordering::greater;
+}
 #endif
 
 private:
@@ -854,15 +855,6 @@ inline Bool_t operator==(const char *s1, const std::string_view &s2)
 inline Bool_t operator==(const std::string_view &s1, const char *s2)
 {
   return s1 == std::string_view(s2);
-}
-#endif
-
-#ifdef __cpp_lib_three_way_comparison
-inline std::strong_ordering operator<=>(const TString &s1, const TString &s2)
-{
-   if (s1 == s2) return std::strong_ordering::equal;
-   else if (s1 < s2) return std::strong_ordering::less;
-   return std::strong_ordering::greater;
 }
 #endif
 

--- a/core/base/inc/TString.h
+++ b/core/base/inc/TString.h
@@ -56,6 +56,9 @@ Bool_t  operator==(const TString &s1, const char *s2);
 Bool_t  operator==(const TSubString &s1, const TSubString &s2);
 Bool_t  operator==(const TSubString &s1, const TString &s2);
 Bool_t  operator==(const TSubString &s1, const char *s2);
+#if (__cplusplus >= 202002L)
+std::strong_ordering operator<=>(const TString &s1, const TString &s2);
+#endif
 /*
 template<class T>
 struct is_signed_numeral : std::integral_constant<bool,
@@ -166,6 +169,9 @@ operator+(T f, const TString &s);
 
 friend Bool_t  operator==(const TString &s1, const TString &s2);
 friend Bool_t  operator==(const TString &s1, const char *s2);
+#if (__cplusplus >= 202002L)
+friend std::strong_ordering operator<=>(const TString &s1, const TString &s2);
+#endif
 
 private:
 #ifdef R__BYTESWAP
@@ -845,6 +851,15 @@ inline Bool_t operator==(const char *s1, const std::string_view &s2)
 inline Bool_t operator==(const std::string_view &s1, const char *s2)
 {
   return s1 == std::string_view(s2);
+}
+#endif
+
+#if (__cplusplus >= 202002L)
+inline std::strong_ordering operator<=>(const TString &s1, const TString &s2)
+{
+   if (s1 == s2) return std::strong_ordering::equal;
+   else if (s1 < s2) return std::strong_ordering::less;
+   return std::strong_ordering::greater;
 }
 #endif
 

--- a/core/base/inc/TString.h
+++ b/core/base/inc/TString.h
@@ -56,7 +56,7 @@ Bool_t  operator==(const TString &s1, const char *s2);
 Bool_t  operator==(const TSubString &s1, const TSubString &s2);
 Bool_t  operator==(const TSubString &s1, const TString &s2);
 Bool_t  operator==(const TSubString &s1, const char *s2);
-#if (__cplusplus >= 202002L)
+#ifdef __cpp_impl_three_way_comparison
 std::strong_ordering operator<=>(const TString &s1, const TString &s2);
 #endif
 /*
@@ -169,7 +169,7 @@ operator+(T f, const TString &s);
 
 friend Bool_t  operator==(const TString &s1, const TString &s2);
 friend Bool_t  operator==(const TString &s1, const char *s2);
-#if (__cplusplus >= 202002L)
+#ifdef __cpp_impl_three_way_comparison
 friend std::strong_ordering operator<=>(const TString &s1, const TString &s2);
 #endif
 
@@ -854,7 +854,7 @@ inline Bool_t operator==(const std::string_view &s1, const char *s2)
 }
 #endif
 
-#if (__cplusplus >= 202002L)
+#ifdef __cpp_impl_three_way_comparison
 inline std::strong_ordering operator<=>(const TString &s1, const TString &s2)
 {
    if (s1 == s2) return std::strong_ordering::equal;

--- a/core/base/inc/TString.h
+++ b/core/base/inc/TString.h
@@ -35,7 +35,7 @@
 #include <cstdio>
 #include <cstring>
 #include <string>
-#if __has_include(<compare>)
+#if (__cplusplus >= 202002L)
 #  include <compare>
 #endif
 

--- a/core/base/inc/TString.h
+++ b/core/base/inc/TString.h
@@ -35,6 +35,9 @@
 #include <cstdio>
 #include <cstring>
 #include <string>
+#if __has_include(<compare>)
+#  include <compare>
+#endif
 
 class TRegexp;
 class TPRegexp;
@@ -56,7 +59,7 @@ Bool_t  operator==(const TString &s1, const char *s2);
 Bool_t  operator==(const TSubString &s1, const TSubString &s2);
 Bool_t  operator==(const TSubString &s1, const TString &s2);
 Bool_t  operator==(const TSubString &s1, const char *s2);
-#ifdef __cpp_impl_three_way_comparison
+#ifdef __cpp_lib_three_way_comparison
 std::strong_ordering operator<=>(const TString &s1, const TString &s2);
 #endif
 /*
@@ -169,7 +172,7 @@ operator+(T f, const TString &s);
 
 friend Bool_t  operator==(const TString &s1, const TString &s2);
 friend Bool_t  operator==(const TString &s1, const char *s2);
-#ifdef __cpp_impl_three_way_comparison
+#ifdef __cpp_lib_three_way_comparison
 friend std::strong_ordering operator<=>(const TString &s1, const TString &s2);
 #endif
 
@@ -854,7 +857,7 @@ inline Bool_t operator==(const std::string_view &s1, const char *s2)
 }
 #endif
 
-#ifdef __cpp_impl_three_way_comparison
+#ifdef __cpp_lib_three_way_comparison
 inline std::strong_ordering operator<=>(const TString &s1, const TString &s2)
 {
    if (s1 == s2) return std::strong_ordering::equal;


### PR DESCRIPTION
In the following code (from `TFormula.cxx`):
```
   map< std::pair<TString,Int_t>, pair<TString,TString> > functions;
   pair<TString, Int_t> key = make_pair(funName, dim);
   if (functions.find(key) == functions.end()) {
```
`functions.find(key)` always returns `functions.end()`. Adding the spaceship operator `<=>` in TString fixes the issue. This fixes also many failing tests with `std:c++20`
