### PR TITLE
[RF] Add initial interface and implementation for code-squashing.

### DIFF
--- a/roofit/roofit/inc/RooGaussian.h
+++ b/roofit/roofit/inc/RooGaussian.h
@@ -51,6 +51,10 @@ public:
   /// Get the sigma parameter.
   RooAbsReal const& getSigma() const { return sigma.arg(); }
 
+  void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
+  std::string
+  buildCallToAnalyticIntegral(Int_t code, const char *rangeName, RooFit::Detail::CodeSquashContext &ctx) const override;
+
 protected:
 
   RooRealProxy x ;

--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -21,6 +21,8 @@ endif()
 ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
   HEADERS
     RooFit/Detail/AnalyticalIntegrals.h
+    RooFit/Detail/EvaluateFuncs.h
+    RooFit/Detail/CodeSquashContext.h
     RooFit/Detail/DataMap.h
     RooFit/Detail/NormalizationHelpers.h
     RooFit/Floats.h

--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -25,6 +25,7 @@
 #include "RooSpan.h"
 #include "RooBatchComputeTypes.h"
 #include "RooFit/Detail/DataMap.h"
+#include "RooFit/Detail/CodeSquashContext.h"
 
 class RooDataSet ;
 class RooPlot;
@@ -425,6 +426,10 @@ protected:
   const RooAbsReal *createPlotProjection(const RooArgSet &dependentVars, const RooArgSet *projectedVars,
                      RooArgSet *&cloneSet, const char* rangeName=nullptr, const RooArgSet* condObs=nullptr) const;
   virtual void computeBatch(cudaStream_t*, double* output, size_t size, RooFit::Detail::DataMap const&) const;
+
+  virtual void translate(RooFit::Detail::CodeSquashContext &ctx) const;
+  virtual std::string
+  buildCallToAnalyticIntegral(Int_t code, const char *rangeName, RooFit::Detail::CodeSquashContext &ctx) const;
 
  protected:
 

--- a/roofit/roofitcore/inc/RooAddition.h
+++ b/roofit/roofitcore/inc/RooAddition.h
@@ -56,6 +56,8 @@ public:
 
   void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooFit::Detail::DataMap const&) const override;
 
+  void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
+
 protected:
 
   RooArgList   _ownedList ;      ///< List of owned components

--- a/roofit/roofitcore/inc/RooConstVar.h
+++ b/roofit/roofitcore/inc/RooConstVar.h
@@ -54,6 +54,8 @@ public:
     _value = value;
   }
 
+  void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
+
 protected:
 
   double evaluate() const override {

--- a/roofit/roofitcore/inc/RooFit/Detail/CodeSquashContext.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/CodeSquashContext.h
@@ -1,0 +1,87 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   Garima Singh, CERN 2023
+ *   Jonas Rembser, CERN 2023
+ *
+ * Copyright (c) 2023, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#ifndef RooFit_Detail_CodeSquashContext_h
+#define RooFit_Detail_CodeSquashContext_h
+
+#include "RooAbsArg.h"
+
+#include <string>
+#include <unordered_map>
+
+namespace RooFit {
+
+namespace Detail {
+
+/// @brief A class to maintain the context for squashing of RooFit models into code.
+class CodeSquashContext {
+public:
+   /// @brief Adds (or overwrites) the string representing the result of a node.
+   /// @param key The node to add the result for.
+   /// @param value The new name to assign/overwrite.
+   inline void addResult(RooAbsArg const *key, std::string value) { _nodeNames[key->namePtr()] = value; }
+
+   /// @brief Gets the result for the given node using the node name.
+   /// @param key The node to get the result string for.
+   /// @return String representing the result of this node.
+   inline std::string const &getResult(RooAbsArg const *key) const { return _nodeNames.at(key->namePtr()); }
+
+   /// @brief Checks if the current node has a result string already assigned.
+   /// @param key The node to get the result string for.
+   /// @return True if the node was assigned a result string, false otherwise.
+   inline bool isResultAssigned(RooAbsArg const *key) const
+   {
+      return _nodeNames.find(key->namePtr()) != _nodeNames.end();
+   }
+
+   /// @brief Adds the given string to the string block that will be emitted at the top of the squashed function. Useful
+   /// for variable declarations.
+   /// @param str The string to add to the global scope.
+   inline void addToGlobalScope(std::string const &str) { _globalScope += str; }
+
+   /// @brief Assemble and return the final code with the return expression and global statements.
+   /// @param returnExpr The string representation of what the squashed function should return, usually the head node.
+   /// @return The final body of the function.
+   inline std::string assembleCode(std::string const &returnExpr)
+   {
+      return _globalScope + _code + "\n return " + returnExpr + ";\n";
+   }
+
+   /// @brief Since the squashed code represents all observables as a single flattened array, it is important
+   /// to keep track of the start index for a vector valued observable which can later be expanded to access the correct
+   /// element. For example, a vector valued variable x with 10 entries will be squashed to obs[start_idx + i].
+   /// @param key The node representing the vector valued observable.
+   /// @param idx The start index (or relative position of the observable in the set of all observables).
+   inline void addVecObs(RooAbsArg const *key, int idx) { _vecObsIndices[key->namePtr()] = idx; }
+
+   /// @brief Adds the input string to the squashed code body. If a class implements a translate function that wants to
+   /// emit something to the squashed code body, it must call this function with the code it wants to emit.
+   /// @param in String to add to the squashed code.
+   inline void addToCodeBody(std::string const &in) { _code += in; }
+
+private:
+   /// @brief Map of node names to their result strings.
+   std::unordered_map<const TNamed *, std::string> _nodeNames;
+   /// @brief Block of code that is placed before the rest of the function body.
+   std::string _globalScope;
+   /// @brief a map to keep track of the observable indices if they are non scalar.
+   std::unordered_map<const TNamed *, int> _vecObsIndices;
+   /// @brief Stores the squashed code body.
+   std::string _code;
+};
+
+} // namespace Detail
+
+} // namespace RooFit
+
+#endif

--- a/roofit/roofitcore/inc/RooFit/Detail/EvaluateFuncs.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/EvaluateFuncs.h
@@ -1,0 +1,39 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   Jonas Rembser, CERN 2023
+ *   Garima Singh, CERN 2023
+ *
+ * Copyright (c) 2023, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#ifndef RooFit_Detail_EvaluateFuncs_h
+#define RooFit_Detail_EvaluateFuncs_h
+
+#include <cmath>
+
+namespace RooFit {
+
+namespace Detail {
+
+namespace EvaluateFuncs {
+
+/// @brief Function to evaluate an un-normalized RooGaussian.
+inline double gaussEvaluate(double x, double mean, double sigma)
+{
+   const double arg = x - mean;
+   const double sig = sigma;
+   return std::exp(-0.5 * arg * arg / (sig * sig));
+}
+
+} // namespace EvaluateFuncs
+
+} // namespace Detail
+
+} // namespace RooFit
+
+#endif

--- a/roofit/roofitcore/inc/RooFuncWrapper.h
+++ b/roofit/roofitcore/inc/RooFuncWrapper.h
@@ -26,7 +26,10 @@
 class RooFuncWrapper final : public RooAbsReal {
 public:
    RooFuncWrapper(const char *name, const char *title, std::string const &funcBody, RooArgSet const &paramSet,
-                  RooArgSet const &ObsSet, const RooAbsData *data = nullptr);
+                  RooArgSet const &obsSet, const RooAbsData *data = nullptr);
+
+   RooFuncWrapper(const char *name, const char *title, RooAbsReal const &obj, RooArgSet const &normSet,
+                  const RooAbsData *data = nullptr);
 
    RooFuncWrapper(const RooFuncWrapper &other, const char *name = nullptr);
 
@@ -42,7 +45,17 @@ protected:
    double evaluate() const override;
 
 private:
+   std::string buildCode(RooAbsReal const &head, RooArgSet const & /* paramSet */, RooArgSet const &obsSet,
+                  const RooAbsData *data);
+
    void updateGradientVarBuffer() const;
+
+   void
+   loadParamsAndObs(std::string funcName, RooArgSet const &paramSet, RooArgSet const &obsSet, const RooAbsData *data);
+
+   void declareAndDiffFunction(std::string funcName, std::string const &funcBody);
+
+   void buildFuncAndGradFunctors();
 
    using Func = double (*)(double *, double *);
    using Grad = void (*)(double *, double *, double *);

--- a/roofit/roofitcore/inc/RooNumber.h
+++ b/roofit/roofitcore/inc/RooNumber.h
@@ -17,6 +17,7 @@
 #define ROO_NUMBER
 
 #include <limits>
+#include <string>
 
 class RooNumber {
 public:
@@ -38,6 +39,7 @@ public:
    /// Get the absolute epsilon that is used by range checks in RooFit,
    /// e.g., in RooAbsRealLValue::inRange().
    inline static double rangeEpsAbs() { return staticRangeEpsAbs(); }
+   static std::string toString(double x);
 
 private:
    static double &staticRangeEpsRel();

--- a/roofit/roofitcore/inc/RooProduct.h
+++ b/roofit/roofitcore/inc/RooProduct.h
@@ -63,6 +63,7 @@ public:
   CacheMode canNodeBeCached() const override { return RooAbsArg::NotAdvised ; } ;
   void setCacheAndTrackHints(RooArgSet&) override ;
 
+  void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
 protected:
 
   void ioStreamerPass2() override ;

--- a/roofit/roofitcore/inc/RooRealIntegral.h
+++ b/roofit/roofitcore/inc/RooRealIntegral.h
@@ -81,6 +81,7 @@ public:
   void setAllowComponentSelection(bool allow);
   bool getAllowComponentSelection() const;
 
+  void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
 protected:
 
   mutable bool _valid = false;

--- a/roofit/roofitcore/inc/RooRealVar.h
+++ b/roofit/roofitcore/inc/RooRealVar.h
@@ -136,6 +136,8 @@ public:
 
   static void cleanup() ;
 
+  void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
+
   protected:
 
   static bool _printScientific ;

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -4725,8 +4725,39 @@ void RooAbsReal::computeBatch(cudaStream_t*, double* output, size_t nEvents, Roo
   }
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// This function defines a translation for each RooAbsReal based object that can be used
+/// to express the class as simple C++ code. The function adds the code represented by
+/// each class as an std::string (that is later concatenated with code strings from translate calls)
+/// to form the C++ code that AD tools can understand. Any class that wants to support AD, has to
+/// implement this function.
+///
+/// \param[in] ctx An object to manage auxilary information for code-squashing. Also takes the
+/// code string that this class outputs into the squashed code through the 'addToCodeBody' function.
+void RooAbsReal::translate(RooFit::Detail::CodeSquashContext & /*ctx*/) const
+{
+   std::stringstream errorMsg;
+   errorMsg << "Translate function for class " << GetName() << " has not yet been implemented.";
+   coutE(Minimization) << errorMsg.str() << std::endl;
+   throw std::runtime_error(errorMsg.str().c_str());
+}
 
-
+////////////////////////////////////////////////////////////////////////////////
+/// This function defines the analytical integral translation for the class.
+///
+/// \param[in] code The code that decides the integrands.
+/// \param[in] rangeName Name of the normalization range.
+/// \param[in] ctx An object to manage auxilary information for code-squashing.
+///
+/// \returns The representative code string of the integral for the given object.
+std::string RooAbsReal::buildCallToAnalyticIntegral(Int_t /* code */, const char * /* rangeName */,
+                                                    RooFit::Detail::CodeSquashContext & /*ctx*/) const
+{
+   std::stringstream errorMsg;
+   errorMsg << "An analytical integral function for class " << GetName() << " has not yet been implemented.";
+   coutE(Minimization) << errorMsg.str() << std::endl;
+   throw std::runtime_error(errorMsg.str().c_str());
+}
 
 double RooAbsReal::_DEBUG_getVal(const RooArgSet* normalisationSet) const {
 

--- a/roofit/roofitcore/src/RooConstVar.cxx
+++ b/roofit/roofitcore/src/RooConstVar.cxx
@@ -24,6 +24,7 @@ RooConstVar represent a constant real-valued object
 
 #include "RooConstVar.h"
 #include "RunContext.h"
+#include "RooNumber.h"
 
 using namespace std;
 
@@ -71,3 +72,17 @@ void RooConstVar::writeToStream(ostream& os, bool /*compact*/) const
   os << _value ;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
+void RooConstVar::translate(RooFit::Detail::CodeSquashContext &ctx) const
+{
+   // Just return a stringy-fied version of the const value.
+   // Formats to the maximum precision.
+   constexpr auto max_precision{std::numeric_limits<double>::digits10 + 1};
+   std::stringstream ss;
+   ss.precision(max_precision);
+   // Just use toString to make sure we do not ouput 'inf'.
+   // This is really ugly for large numbers...
+   ss << std::fixed << RooNumber::toString(_value);
+   ctx.addResult(this, ss.str());
+}

--- a/roofit/roofitcore/src/RooFuncWrapper.cxx
+++ b/roofit/roofitcore/src/RooFuncWrapper.cxx
@@ -18,12 +18,87 @@
 #include "RooGlobalFunc.h"
 #include "RooMsgService.h"
 #include "RooRealVar.h"
+#include "RooHelpers.h"
+#include "RooFit/Detail/CodeSquashContext.h"
 
 RooFuncWrapper::RooFuncWrapper(const char *name, const char *title, std::string const &funcBody,
-                               RooArgSet const &paramSet, RooArgSet const &ObsSet, const RooAbsData *data /*=nullptr*/)
+                               RooArgSet const &paramSet, RooArgSet const &obsSet, const RooAbsData *data /*=nullptr*/)
    : RooAbsReal{name, title}, _params{"!params", "List of parameters", this}
 {
-   std::string funcName = name;
+   // Declare the function and create its derivative.
+   declareAndDiffFunction(name, funcBody);
+
+   // Load the parameters and observables.
+   loadParamsAndObs(name, paramSet, obsSet, data);
+}
+
+RooFuncWrapper::RooFuncWrapper(const char *name, const char *title, RooAbsReal const &obj, RooArgSet const &normSet,
+                               const RooAbsData *data /*=nullptr*/)
+   : RooAbsReal{name, title}, _params{"!params", "List of parameters", this}
+{
+   std::string func;
+
+   // Compile the computation graph for the norm set, such that we also get the
+   // integrals explicitly in the graph.
+   std::unique_ptr<RooAbsReal> pdf{RooFit::Detail::compileForNormSet(obj, normSet)};
+   // Get the parameters.
+   RooArgSet paramSet;
+   pdf->getParameters(data ? data->get() : nullptr, paramSet);
+   // Get the observable if we have a valid dataset.
+   RooArgSet obsSet;
+   if (data)
+      pdf->getObservables(data->get(), obsSet);
+
+   // Load the parameters and observables.
+   loadParamsAndObs(name, paramSet, obsSet, data);
+
+   func = buildCode(*pdf, paramSet, obsSet, data);
+
+   // Declare the function and create its derivative.
+   declareAndDiffFunction(name, func);
+}
+
+RooFuncWrapper::RooFuncWrapper(const RooFuncWrapper &other, const char *name /*=nullptr*/)
+   : RooAbsReal(other, name),
+     _params("!params", this, other._params),
+     _func(other._func),
+     _grad(other._grad),
+     _gradientVarBuffer(other._gradientVarBuffer),
+     _observables(other._observables)
+{
+}
+
+void RooFuncWrapper::loadParamsAndObs(std::string funcName, RooArgSet const &paramSet, RooArgSet const &obsSet,
+                                      const RooAbsData *data)
+{
+   // Extract parameters
+   for (auto *param : paramSet) {
+      if (!dynamic_cast<RooAbsReal *>(param)) {
+         std::stringstream errorMsg;
+         errorMsg << "In creation of function " << funcName
+                  << " wrapper: input param expected to be of type RooAbsReal.";
+         coutE(InputArguments) << errorMsg.str() << std::endl;
+         throw std::runtime_error(errorMsg.str().c_str());
+      }
+      _params.add(*param);
+   }
+   _gradientVarBuffer.reserve(_params.size());
+
+   // Extract observables
+   if (!obsSet.empty()) {
+      auto dataSpans = data->getBatches(0, data->numEntries());
+      _observables.reserve(_observables.size() * data->numEntries());
+      for (auto *obs : static_range_cast<RooRealVar *>(obsSet)) {
+         RooSpan<const double> span{dataSpans.at(obs)};
+         for (int i = 0; i < data->numEntries(); ++i) {
+            _observables.push_back(span[i]);
+         }
+      }
+   }
+}
+
+void RooFuncWrapper::declareAndDiffFunction(std::string funcName, std::string const &funcBody)
+{
    std::string gradName = funcName + "_grad_0";
    std::string requestName = funcName + "_req";
    std::string wrapperName = funcName + "_derivativeWrapper";
@@ -32,7 +107,7 @@ RooFuncWrapper::RooFuncWrapper(const char *name, const char *title, std::string 
 
    // Declare the function
    std::stringstream bodyWithSigStrm;
-   bodyWithSigStrm << "double " << funcName << "(double* params, double* obs) {" << funcBody << "}";
+   bodyWithSigStrm << "double " << funcName << "(double* params, double* obs) {\n" << funcBody << "\n}";
    bool comp = gInterpreter->Declare(bodyWithSigStrm.str().c_str());
    if (!comp) {
       std::stringstream errorMsg;
@@ -61,31 +136,6 @@ RooFuncWrapper::RooFuncWrapper(const char *name, const char *title, std::string 
       throw std::runtime_error(errorMsg.str().c_str());
    }
 
-   // Extract parameters
-   for (auto *param : paramSet) {
-      if (!dynamic_cast<RooAbsReal *>(param)) {
-         std::stringstream errorMsg;
-         errorMsg << "In creation of function " << funcName
-                  << " wrapper: input param expected to be of type RooAbsReal.";
-         coutE(InputArguments) << errorMsg.str() << std::endl;
-         throw std::runtime_error(errorMsg.str().c_str());
-      }
-      _params.add(*param);
-   }
-   _gradientVarBuffer.reserve(_params.size());
-
-   // Extract observables
-   if (!ObsSet.empty()) {
-      auto dataSpans = data->getBatches(0, data->numEntries());
-      _observables.reserve(_observables.size() * data->numEntries());
-      for (auto *obs : static_range_cast<RooRealVar *>(ObsSet)) {
-         RooSpan<const double> span{dataSpans.at(obs)};
-         for (int i = 0; i < data->numEntries(); ++i) {
-            _observables.push_back(span[i]);
-         }
-      }
-   }
-
    // Build a wrapper over the derivative to hide clad specific types such as 'array_ref'.
    // disable clang-format for making the following code unreadable.
    // clang-format off
@@ -97,16 +147,6 @@ RooFuncWrapper::RooFuncWrapper(const char *name, const char *title, std::string 
    // clang-format on
    gInterpreter->Declare(dWrapperStrm.str().c_str());
    _grad = reinterpret_cast<Grad>(gInterpreter->ProcessLine((wrapperName + ";").c_str()));
-}
-
-RooFuncWrapper::RooFuncWrapper(const RooFuncWrapper &other, const char *name /*=nullptr*/)
-   : RooAbsReal(other, name),
-     _params("!params", this, other._params),
-     _func(other._func),
-     _grad(other._grad),
-     _gradientVarBuffer(other._gradientVarBuffer),
-     _observables(other._observables)
-{
 }
 
 void RooFuncWrapper::getGradient(double *out) const
@@ -135,4 +175,54 @@ void RooFuncWrapper::gradient(const double *x, double *g) const
    std::fill(g, g + _params.size(), 0.0);
 
    _grad(const_cast<double *>(x), _observables.data(), g);
+}
+
+std::string RooFuncWrapper::buildCode(RooAbsReal const &head, RooArgSet const & /* paramSet */,
+                               RooArgSet const &obsSet, const RooAbsData *data)
+{
+   RooFit::Detail::CodeSquashContext ctx;
+
+   // First update the result variable of params in the compute graph to in[<position>].
+   int idx = 0;
+   for (RooAbsArg *param : _params) {
+      ctx.addResult(param, "params[" + std::to_string(idx) + "]");
+      idx++;
+   }
+
+   // Also update observables...
+   idx = 0;
+   if (!obsSet.empty()) {
+      auto dataSpans = data->getBatches(0, data->numEntries());
+      _observables.reserve(_observables.size() * data->numEntries());
+      for (auto *obs : static_range_cast<RooRealVar *>(obsSet)) {
+         RooSpan<const double> span{dataSpans.at(obs)};
+         // If the observable is a scalar, set its name to the start index.
+         // else, store the start index and later set the the name to obs[start_idx + curr_idx], here curr_idx is
+         // defined by a loop producing parent node.
+         if (data->numEntries() == 1)
+            ctx.addResult(obs, "obs[" + std::to_string(idx) + "]");
+         else
+            ctx.addVecObs(obs, idx);
+         idx += data->numEntries();
+      }
+   }
+
+   // This will not work for nodes that produce loops as we need to keep track of the subtree of the loop producing
+   // node. A better approach is to have 2 stacks and perform an iterative post order traversal on the graph/resolved
+   // tree.
+   RooArgSet nodes;
+   RooHelpers::getSortedComputationGraph(head, nodes);
+
+   for (RooAbsArg *node : nodes) {
+      RooAbsReal *curr = dynamic_cast<RooAbsReal *>(node);
+      if (!curr) {
+         std::stringstream errorMsg;
+         errorMsg << "Translate is only supported for RooAbsReal derived objects.";
+         oocoutE(nullptr, Minimization) << errorMsg.str() << std::endl;
+         throw std::runtime_error(errorMsg.str().c_str());
+      }
+      curr->translate(ctx);
+   }
+
+   return ctx.assembleCode(ctx.getResult(&head));
 }

--- a/roofit/roofitcore/src/RooNormalizedPdf.cxx
+++ b/roofit/roofitcore/src/RooNormalizedPdf.cxx
@@ -36,3 +36,9 @@ void RooNormalizedPdf::computeBatch(cudaStream_t * /*stream*/, double *output, s
       }
    }
 }
+
+void RooNormalizedPdf::translate(RooFit::Detail::CodeSquashContext &ctx) const
+{
+   // For now just return function/normalization integral.
+   ctx.addResult(this, ctx.getResult(&_pdf.arg()) + "/" + ctx.getResult(&_normIntegral.arg()));
+}

--- a/roofit/roofitcore/src/RooNormalizedPdf.h
+++ b/roofit/roofitcore/src/RooNormalizedPdf.h
@@ -58,6 +58,8 @@ public:
       return static_cast<RooAbsPdf &>(*_pdf).expectedEvents(&_normSet);
    }
 
+   void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
+
 protected:
    void computeBatch(cudaStream_t *, double *output, size_t size, RooFit::Detail::DataMap const &) const override;
    double evaluate() const override

--- a/roofit/roofitcore/src/RooNumber.cxx
+++ b/roofit/roofitcore/src/RooNumber.cxx
@@ -24,6 +24,19 @@ Class RooNumber implements numeric constants used by RooFit
 
 #include <RooNumber.h>
 
+/// @brief  Returns an std::to_string compatible number (i.e. rounds infinities back to the nearest representable
+/// value). This function is primarily used in the code-squashing for AD and as such encodes infinities to double's
+/// maximum value. We do this because 1, std::to_string cannot handle infinities correctly on some platforms
+/// (e.g. 32 bit debian) and 2, Clad (the AD tool) cannot handle differentiating std::numeric_limits::infinity directly.
+std::string RooNumber::toString(double x)
+{
+   int sign = isInfinite(x);
+   double out = x;
+   if (sign)
+      out = sign == 1 ? std::numeric_limits<double>::max() : std::numeric_limits<double>::min();
+   return std::to_string(out);
+}
+
 double &RooNumber::staticRangeEpsRel()
 {
    static double epsRel = 0.0;

--- a/roofit/roofitcore/src/RooProduct.cxx
+++ b/roofit/roofitcore/src/RooProduct.cxx
@@ -493,9 +493,19 @@ void RooProduct::setCacheAndTrackHints(RooArgSet& trackNodes)
   }
 }
 
+////////////////////////////////////////////////////////////////////////////////
 
-
-
+void RooProduct::translate(RooFit::Detail::CodeSquashContext &ctx) const
+{
+   std::string result;
+   // Build a (node1 * node2 * node3 * ...) like expression.
+   result = '(';
+   for (const auto item : _compRSet) {
+      result += ctx.getResult(item) + "*";
+   }
+   result.back() = ')';
+   ctx.addResult(this, result);
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Customized printing of arguments of a RooProduct to more intuitively reflect the contents of the

--- a/roofit/roofitcore/src/RooRealIntegral.cxx
+++ b/roofit/roofitcore/src/RooRealIntegral.cxx
@@ -1086,6 +1086,18 @@ void RooRealIntegral::setAllowComponentSelection(bool allow){
   _respectCompSelect = allow;
 }
 
+void RooRealIntegral::translate(RooFit::Detail::CodeSquashContext &ctx) const
+{
+   if (!_sumList.empty() || !_intList.empty()) {
+      std::stringstream errorMsg;
+      errorMsg << "Only analytical integrals are supported for AD for class" << _function.GetName();
+      coutE(Minimization) << errorMsg.str() << std::endl;
+      throw std::runtime_error(errorMsg.str().c_str());
+   }
+
+   ctx.addResult(this, _function.arg().buildCallToAnalyticIntegral(_mode, RooNameReg::str(_rangeName), ctx));
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Customized printing of arguments of a RooRealIntegral to more intuitively reflect the contents of the
 /// integration operation

--- a/roofit/roofitcore/src/RooRealVar.cxx
+++ b/roofit/roofitcore/src/RooRealVar.cxx
@@ -81,6 +81,14 @@ void RooRealVar::cleanup()
   }
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
+void RooRealVar::translate(RooFit::Detail::CodeSquashContext &ctx) const
+{
+   if (!ctx.isResultAssigned(this))
+      ctx.addResult(this, GetName());
+}
+
 /// Return a dummy object to use when properties are not initialised.
 RooRealVarSharedProperties& RooRealVar::_nullProp()
 {


### PR DESCRIPTION
This commit adds the initial implementation of the code-squashing approach for AD. Users can now squash their models into a single function that can then be used for evaluation, derivative calculation, minimization, etc., through the RooFuncWrapper.