### PR TITLE
[DF] Fix wrong data in CSV data source with user-defined column types (v6.28)

### DIFF
--- a/tree/dataframe/src/RCsvDS.cxx
+++ b/tree/dataframe/src/RCsvDS.cxx
@@ -224,9 +224,11 @@ void RCsvDS::InferColTypes(std::vector<std::string> &columns)
    const auto second_line = fCsvFile->GetFilePos();
 
    for (auto i = 0u; i < columns.size(); ++i) {
-
-      if (fColTypes.find(fHeaders[i]) != fColTypes.end())
-         continue; // type was manually specified, nothing to do
+      const auto userSpecifiedType = fColTypes.find(fHeaders[i]);
+      if (userSpecifiedType != fColTypes.end()) {
+         fColTypesList.push_back(userSpecifiedType->second);
+         continue;
+      }
 
       // read <=10 extra lines until a non-empty cell on this column is found, so that type is determined
       for (auto extraRowsRead = 0u; extraRowsRead < 10u && columns[i] == "nan"; ++extraRowsRead) {


### PR DESCRIPTION
When some column types were specified explicitly by the user, RCsvDS forgot to add that type to fColTypesList, which in turn caused RCsvDS::SetEntry to skip the proper loading of some column data.

This fixes #12520.