### PR TITLE
Resolve issue when dictionary with std::tuple is unloaded.

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -4005,9 +4005,9 @@ void TCling::SetClassInfo(TClass* cl, Bool_t reload)
    // details and just overlay a 'simpler'/'simplistic' version that is easy
    // for the I/O to understand and handle.
    if (strncmp(cl->GetName(),"tuple<",strlen("tuple<"))==0) {
-
-      name = AlternateTuple(cl->GetName(), fInterpreter->getLookupHelper());
-      if (name.empty()) {
+      if (!reload)
+         name = AlternateTuple(cl->GetName(), fInterpreter->getLookupHelper());
+      if (reload || name.empty()) {
          // We could not generate the alternate
          SetWithoutClassInfoState(cl);
          return;

--- a/core/metacling/src/TClingClassInfo.cxx
+++ b/core/metacling/src/TClingClassInfo.cxx
@@ -1262,7 +1262,7 @@ long TClingClassInfo::Property() const
 
    const clang::DeclContext *ctxt = GetDecl()->getDeclContext();
    clang::NamespaceDecl *std_ns =fInterp->getSema().getStdNamespace();
-   while (! ctxt->isTranslationUnit())  {
+   while (ctxt && ! ctxt->isTranslationUnit())  {
       if (ctxt->Equals(std_ns)) {
          property |= kIsDefinedInStd;
          break;


### PR DESCRIPTION
This fixes #12358.

When unloading a 'compiled' TClass, TClass sets the state of the TClass to the most information possible.  This usually means setting the ClassInfo if the interpreter information is still known about the class.  In the case of `std::tuple` is order to do that we need to generate code that depends on other types (that may also be unloaded), so skip that steps (which lead to 'compilation error' from the interpreter in the report cases (and a crash due to a couple of others issues solved also in this PR).