### PR TITLE
[ntuple] Fix misuse of the `TVirtualCollectionProxy` iterator interface

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -475,11 +475,11 @@ private:
          RIterator(const RCollectionIterableOnce &owner) : fOwner(owner) {}
          RIterator(const RCollectionIterableOnce &owner, void *iter) : fOwner(owner), fIterator(iter)
          {
-            fElementPtr = fOwner.fIFuncs.fNext(&fIterator, &fOwner.fEnd);
+            fElementPtr = fOwner.fIFuncs.fNext(fIterator, fOwner.fEnd);
          }
          iterator operator++()
          {
-            fElementPtr = fOwner.fIFuncs.fNext(&fIterator, &fOwner.fEnd);
+            fElementPtr = fOwner.fIFuncs.fNext(fIterator, fOwner.fEnd);
             return *this;
          }
          pointer operator*() const { return fElementPtr; }
@@ -498,7 +498,7 @@ private:
       {
          fIFuncs.fCreateIterators(collection, &fBegin, &fEnd, proxy);
       }
-      ~RCollectionIterableOnce() { fIFuncs.fDeleteTwoIterators(&fBegin, &fEnd); }
+      ~RCollectionIterableOnce() { fIFuncs.fDeleteTwoIterators(fBegin, fEnd); }
 
       RIterator begin() { return RIterator(*this, fBegin); }
       RIterator end() { return RIterator(*this); }


### PR DESCRIPTION
This pull request fixes a misuse of the `TVirtualCollectionProxy` iterator interface.  Specifically the `Next()` and `DeleteTwoIterators()` functions take a pointer to the iterator itself (not a pointer-to-pointer).

The misuse was most likely due to the lack of proper documentation on the `TVirtualCollectionProxy` class.  The documentation for this class should be thus updated in a follow-up PR.

The issue was originally introduced in https://github.com/root-project/root/pull/12380 and first noticed by @Nowakus on March 13, when trying to write a `xAOD::DataVector<T>` into RNTuple.  This PR should fix the observed misbehavior.

## Checklist:
- [X] tested changes locally