### PR TITLE
Fix remaining CI test failures [skip-ci]

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/fedora37.txt
+++ b/.github/workflows/root-ci-config/buildconfig/fedora37.txt
@@ -1,1 +1,2 @@
 tmva-pymva=Off
+test_distrdf_pyspark=OFF


### PR DESCRIPTION
Its Python 3.11 needs the upcoming Spark release, see https://github.com/apache/spark/pull/38987
