### PR TITLE
[math] Fix Delaunay 2D interpolation

### DIFF
--- a/math/mathcore/src/Delaunay2D.cxx
+++ b/math/mathcore/src/Delaunay2D.cxx
@@ -16,14 +16,15 @@
 
 //#include <thread>
 
-// in case we do not use CGAL
+// use the triangle library if we do not use CGAL
 #ifndef HAS_CGAL
-// use the triangle library
 #include "triangle.h"
 #endif
 
 #include <algorithm>
 #include <stdlib.h>
+
+#include <iostream>
 
 namespace ROOT {
 
@@ -60,11 +61,7 @@ void Delaunay2D::SetInputPoints(int n, const double * x, const double * y, const
                            double xmin, double xmax, double ymin, double ymax) {
 
 
-#ifdef THREAD_SAFE
-   fInit         = Initialization::UNINITIALIZED;
-#else
    fInit         = kFALSE;
-#endif
 
    if (n == 0 || !x || !y || !z ) return;
 
@@ -128,9 +125,8 @@ double Delaunay2D::Interpolate(double x, double y)
    yy = Linear_transform(y, fOffsetY, fScaleFactorY); //yy = yTransformer(y);
    double zz = DoInterpolateNormalized(xx, yy);
 
-   // Wrong zeros may appear when points sit on a regular grid.
-   // The following line try to avoid this problem.
-   if (zz==0) zz = DoInterpolateNormalized(xx+0.0001, yy);
+   // the case of points on a regular grid (i.e. points on triangle edges) it is now handles in
+   // DoInterpolateNormalized
 
    return zz;
 }
@@ -139,119 +135,32 @@ double Delaunay2D::Interpolate(double x, double y)
 void Delaunay2D::FindAllTriangles()
 {
 
-#ifdef THREAD_SAFE
-   //treat the common case first
-   if(fInit.load(std::memory_order::memory_order_relaxed) == Initialization::INITIALIZED)
+   if (fInit)
       return;
+   else
+      fInit = kTRUE;
 
-   Initialization cState = Initialization::UNINITIALIZED;
-   if(fInit.compare_exchange_strong(cState, Initialization::INITIALIZING,
-                                    std::memory_order::memory_order_release, std::memory_order::memory_order_relaxed))
-   {
-      // the value of fInit was indeed UNINIT, we replaced it atomically with initializing
-      // performing the initialzing now
-#else
-      if (fInit) return; else fInit = kTRUE;
-#endif
+   // Function used internally only. It creates the data structures needed to
+   // compute the Delaunay triangles.
 
-      // Function used internally only. It creates the data structures needed to
-      // compute the Delaunay triangles.
+   // Offset fX and fY so they average zero, and scale so the average
+   // of the X and Y ranges is one. The normalized version of fX and fY used
+   // in Interpolate.
 
-      // Offset fX and fY so they average zero, and scale so the average
-      // of the X and Y ranges is one. The normalized version of fX and fY used
-      // in Interpolate.
+   DoNormalizePoints(); // call backend specific point normalization
 
-      DoNormalizePoints(); // call backend specific point normalization
+   DoFindTriangles(); // call backend specific triangle finding
 
-      DoFindTriangles(); // call backend specific triangle finding
-
-      fNdt = fTriangles.size();
-
-#ifdef THREAD_SAFE
-      fInit = Initialization::INITIALIZED;
-   } else while(cState != Initialization::INITIALIZED) {
-         //the value of fInit was NOT UNINIT, so we have to spin until we reach INITIALEZED
-         cState = fInit.load(std::memory_order::memory_order_relaxed);
-      }
-#endif
-
+   fNdt = fTriangles.size();
 }
-
 
 // backend specific implementations
 
-#ifdef HAS_CGAL
-/// CGAL implementation of normalize points
-void Delaunay2D::DonormalizePoints() {
-   for (Int_t n = 0; n < fNpoints; n++) {
-      //Point p(xTransformer(fX[n]), yTransformer(fY[n]));
-      Point p(linear_transform(fX[n], fOffsetX, fScaleFactorX),
-              linear_transform(fY[n], fOffsetY, fScaleFactorY));
+#ifndef HAS_CGAL
 
-      fNormalizedPoints.insert(std::make_pair(p, n));
-   }
-}
+// Triangle implementation (default case)
 
-/// CGAL implementation for finding triangles
-void Delaunay2D::DoFindTriangles() {
-   fCGALdelaunay.insert(fNormalizedPoints.begin(), fNormalizedPoints.end());
-
-   std::transform(fCGALdelaunay.finite_faces_begin(),
-                  fCGALdelaunay.finite_faces_end(), std::back_inserter(fTriangles),
-                  [] (const Delaunay::Face face) -> Triangle {
-
-                     Triangle tri;
-
-                     auto transform = [&] (const unsigned int i) {
-                        tri.x[i] = face.vertex(i)->point().x();
-                        tri.y[i] = face.vertex(i)->point().y();
-                        tri.idx[i] = face.vertex(i)->info();
-                     };
-
-                     transform(0);
-                     transform(1);
-                     transform(2);
-
-                     return tri;
-
-                  });
-}
-
-/// CGAL implementation for interpolation
-double Delaunay2D::DoInterpolateNormalized(double xx, double yy)
-{
-   // Finds the Delaunay triangle that the point (xi,yi) sits in (if any) and
-   // calculate a z-value for it by linearly interpolating the z-values that
-   // make up that triangle.
-
-   // initialise the Delaunay algorithm if needed
-    FindAllTriangles();
-
-   //coordinate computation
-   Point p(xx, yy);
-
-   std::vector<std::pair<Point, Coord_type> > coords;
-   auto nn = CGAL::natural_neighbor_coordinates_2(fCGALdelaunay, p,
-                                                  std::back_inserter(coords));
-
-   //std::cout << std::this_thread::get_id() << ": Found " << coords.size() << " points" << std::endl;
-
-   if(!nn.third) //neighbor finding was NOT successfull, return standard value
-      return fZout;
-
-   //printf("found neighbors %u\n", coords.size());
-
-   Coord_type res = CGAL::linear_interpolation(coords.begin(), coords.end(),
-                                               nn.second, Value_access(fNormalizedPoints, fZ));
-
-   //std::cout << std::this_thread::get_id() << ": Result " << res << std::endl;
-
-   return res;
-}
-
-#else // HAS_CGAL
-
-/// Triangle implementation for normalizing the points
+/// Triangle implementation for points normalization
 void Delaunay2D::DoNormalizePoints() {
    for (Int_t n = 0; n < fNpoints; n++) {
       fXN.push_back(Linear_transform(fX[n], fOffsetX, fScaleFactorX));
@@ -387,84 +296,132 @@ void Delaunay2D::DoFindTriangles() {
 /// Finds the Delaunay triangle that the point (xi,yi) sits in (if any) and
 /// calculate a z-value for it by linearly interpolating the z-values that
 /// make up that triangle.
+/// Relay that all the triangles have been found before
+/// see comment in class description (in Delaunay2D.h) for implementation details:
+/// finding barycentric cordinates and computing the interpolation
 double Delaunay2D::DoInterpolateNormalized(double xx, double yy)
 {
 
-   // relay that ll the triangles have been found
-   ///  FindAllTriangles();
+   // compute barycentric coordinates of a point P(xx,yy,zz)
+   auto bayCoords = [&](const unsigned int t) -> std::tuple<double, double, double> {
+      double la = ((fTriangles[t].y[1] - fTriangles[t].y[2]) * (xx - fTriangles[t].x[2]) +
+                   (fTriangles[t].x[2] - fTriangles[t].x[1]) * (yy - fTriangles[t].y[2])) *
+                  fTriangles[t].invDenom;
+      double lb = ((fTriangles[t].y[2] - fTriangles[t].y[0]) * (xx - fTriangles[t].x[2]) +
+                   (fTriangles[t].x[0] - fTriangles[t].x[2]) * (yy - fTriangles[t].y[2])) *
+                  fTriangles[t].invDenom;
 
-    //see comment in header for CGAL fallback section
-    auto bayCoords = [&] (const unsigned int t) -> std::tuple<double, double, double> {
-       double la = ( (fTriangles[t].y[1] - fTriangles[t].y[2])*(xx - fTriangles[t].x[2])
-                    + (fTriangles[t].x[2] - fTriangles[t].x[1])*(yy - fTriangles[t].y[2]) ) * fTriangles[t].invDenom;
-       double lb = ( (fTriangles[t].y[2] - fTriangles[t].y[0])*(xx - fTriangles[t].x[2])
-                    + (fTriangles[t].x[0] - fTriangles[t].x[2])*(yy - fTriangles[t].y[2]) ) * fTriangles[t].invDenom;
+      return std::make_tuple(la, lb, (1 - la - lb));
+   };
 
-       return std::make_tuple(la, lb, (1 - la - lb));
-    };
-
-    auto inTriangle = [] (const std::tuple<double, double, double> & coords) -> bool {
-       return std::get<0>(coords) >= 0 && std::get<1>(coords) >= 0 && std::get<2>(coords) >= 0;
-    };
+   // function to test if a point with barycentric coordinates (a,b,c) is inside the triangle
+   // If the point is outside one or more of the coordinate are negative.
+   // If the point is on a triangle edge, one of the coordinate (the one not part of the edge) is zero.
+   // Due to numerical error, it can happen that if the point is at the edge the result is a small negative value.
+   // Use then a tolerance (of - eps) to still consider the point within the triangle
+   auto inTriangle = [](const std::tuple<double, double, double> &coords) -> bool {
+      constexpr double eps = -4 * std::numeric_limits<double>::epsilon();
+      return std::get<0>(coords) > eps && std::get<1>(coords) > eps && std::get<2>(coords) > eps;
+   };
 
    int cX = CellX(xx);
    int cY = CellY(yy);
 
-   if(cX < 0 || cX > fNCells || cY < 0 || cY > fNCells)
-      return fZout; //TODO some more fancy interpolation here
+   if (cX < 0 || cX > fNCells || cY < 0 || cY > fNCells)
+      return fZout; // TODO some more fancy interpolation here
 
-    for(unsigned int t : fCells[Cell(cX, cY)]){
-       auto coords = bayCoords(t);
+   for (unsigned int t : fCells[Cell(cX, cY)]) {
 
-       if(inTriangle(coords)){
-          //we found the triangle -> interpolate using the barycentric interpolation
-          return std::get<0>(coords) * fZ[fTriangles[t].idx[0]]
-                 + std::get<1>(coords) * fZ[fTriangles[t].idx[1]]
-               + std::get<2>(coords) * fZ[fTriangles[t].idx[2]];
+      auto coords = bayCoords(t);
 
-       }
-    }
+      // std::cout << "result of bayCoords " << std::get<0>(coords) <<
+      //     "  " << std::get<1>(coords)  << "   " << std::get<2>(coords) << std::endl;
 
-    //debugging
+      if (inTriangle(coords)) {
 
-    /*
-    for(unsigned int t = 0; t < fNdt; ++t) {
-       auto coords = bayCoords(t);
+         // we found the triangle -> interpolate using the barycentric interpolation
 
-       if(inTriangle(coords)){
+         return std::get<0>(coords) * fZ[fTriangles[t].idx[0]] + std::get<1>(coords) * fZ[fTriangles[t].idx[1]] +
+                std::get<2>(coords) * fZ[fTriangles[t].idx[2]];
+      }
+   }
 
-          //brute force found a triangle -> grid not
-          printf("Found triangle %u for (%f,%f) -> (%u,%u)\n", t, xx,yy, cX, cY);
-          printf("Triangles in grid cell: ");
-          for(unsigned int x : fCells[Cell(cX, cY)])
-             printf("%u ", x);
-          printf("\n");
+   // printf("Could not find a triangle for point (%f,%f)\n", xx, yy);
 
-          printf("Triangle %u is in cells: ", t);
-          for(unsigned int i = 0; i <= fNCells; ++i)
-             for(unsigned int j = 0; j <= fNCells; ++j)
-                if(fCells[Cell(i,j)].count(t))
-                   printf("(%u,%u) ", i, j);
-          printf("\n");
-          for(unsigned int i = 0; i < 3; ++i)
-             printf("\tpoint %u (%u): (%f,%f) -> (%u,%u)\n", i, fTriangles[t].idx[i], fTriangles[t].x[i], fTriangles[t].y[i], CellX(fTriangles[t].x[i]), CellY(fTriangles[t].y[i]));
-
-          //we found the triangle -> interpolate using the barycentric interpolation
-          return std::get<0>(coords) * fZ[fTriangles[t].idx[0]]
-                 + std::get<1>(coords) * fZ[fTriangles[t].idx[1]]
-                 + std::get<2>(coords) * fZ[fTriangles[t].idx[2]];
-
-       }
-    }
-
-    printf("Could not find a triangle for point (%f,%f)\n", xx, yy);
-    */
-
-    //no triangle found return standard value
+   // no triangle found return standard value
    return fZout;
 }
-#endif //HAS_CGAL
+
+#else //HAS_CGAL: case of using GCAL
+
+/// CGAL implementation of normalize points
+void Delaunay2D::DonormalizePoints() {
+   for (Int_t n = 0; n < fNpoints; n++) {
+      //Point p(xTransformer(fX[n]), yTransformer(fY[n]));
+      Point p(linear_transform(fX[n], fOffsetX, fScaleFactorX),
+              linear_transform(fY[n], fOffsetY, fScaleFactorY));
+
+      fNormalizedPoints.insert(std::make_pair(p, n));
+   }
+}
+
+/// CGAL implementation for finding triangles
+void Delaunay2D::DoFindTriangles() {
+   fCGALdelaunay.insert(fNormalizedPoints.begin(), fNormalizedPoints.end());
+
+   std::transform(fCGALdelaunay.finite_faces_begin(),
+                  fCGALdelaunay.finite_faces_end(), std::back_inserter(fTriangles),
+                  [] (const Delaunay::Face face) -> Triangle {
+
+                     Triangle tri;
+
+                     auto transform = [&] (const unsigned int i) {
+                        tri.x[i] = face.vertex(i)->point().x();
+                        tri.y[i] = face.vertex(i)->point().y();
+                        tri.idx[i] = face.vertex(i)->info();
+                     };
+
+                     transform(0);
+                     transform(1);
+                     transform(2);
+
+                     return tri;
+
+                  });
+}
+
+/// CGAL implementation for interpolation
+double Delaunay2D::DoInterpolateNormalized(double xx, double yy)
+{
+   // Finds the Delaunay triangle that the point (xi,yi) sits in (if any) and
+   // calculate a z-value for it by linearly interpolating the z-values that
+   // make up that triangle.
+
+   // initialise the Delaunay algorithm if needed
+    FindAllTriangles();
+
+   //coordinate computation
+   Point p(xx, yy);
+
+   std::vector<std::pair<Point, Coord_type> > coords;
+   auto nn = CGAL::natural_neighbor_coordinates_2(fCGALdelaunay, p,
+                                                  std::back_inserter(coords));
+
+   //std::cout << std::this_thread::get_id() << ": Found " << coords.size() << " points" << std::endl;
+
+   if(!nn.third) //neighbor finding was NOT successfull, return standard value
+      return fZout;
+
+   //printf("found neighbors %u\n", coords.size());
+
+   Coord_type res = CGAL::linear_interpolation(coords.begin(), coords.end(),
+                                               nn.second, Value_access(fNormalizedPoints, fZ));
+
+   //std::cout << std::this_thread::get_id() << ": Result " << res << std::endl;
+
+   return res;
+}
+#endif // HAS_GCAL
 
 } // namespace Math
 } // namespace ROOT
-

--- a/math/mathcore/test/CMakeLists.txt
+++ b/math/mathcore/test/CMakeLists.txt
@@ -97,8 +97,8 @@ endif()
 
 ROOT_ADD_GTEST(testRootFinder testRootFinder.cxx  LIBRARIES ${Libraries})
 
-ROOT_ADD_GTEST(testKahan testKahan.cxx
-      LIBRARIES Core MathCore)
+ROOT_ADD_GTEST(testKahan testKahan.cxx LIBRARIES Core MathCore)
+ROOT_ADD_GTEST(testDelaunay2D testDelaunay2D.cxx LIBRARIES Core MathCore)
 
 if(clad)
   ROOT_ADD_GTEST(CladDerivatorTests CladDerivatorTests.cxx LIBRARIES Core MathCore)

--- a/math/mathcore/test/testDelaunay2D.cxx
+++ b/math/mathcore/test/testDelaunay2D.cxx
@@ -1,0 +1,64 @@
+// @(#)root/mathcore:$Id$
+// Author: Lorenzo Moneta March 2023
+
+
+
+#include "Math/Delaunay2D.h"
+
+#include "gtest/gtest.h"
+
+// test Delauney interpolation on edges of a triangle
+// some of these tests failed when using the older version
+// see issue #
+
+TEST(Delaunay2D,interpolation_at_edges)
+{
+   // give point making three triangles
+   // points are taken from
+
+   //triangle1 is { P0,P1,P4}, tr2 is { P1,P2,P4}, tr3 is {P2,P3,P4}
+
+   double x[] = { 750, 1000, 1000, 900, 750 };
+   double y[] = { 400, 400, 500, 600, 500};
+   double z[] = {100,100,500,600,250};
+
+   // need to provide some min/max value to have a numerical error in
+   // computation of  barycentric coordinates
+
+   ROOT::Math::Delaunay2D d(5,x,y,z,170.,1000.,15.,600.);
+
+   // interpolate on horizontal edge between tr2 and tr3 (line P2-P4)
+   //This was giving an error
+   // result should be linear interp betwen P4(x=750,z=250) and P2(x=1000,z=500)
+   EXPECT_DOUBLE_EQ( d.Interpolate(760,500),  260.);
+   EXPECT_DOUBLE_EQ( d.Interpolate(780,500),  280.);
+   EXPECT_DOUBLE_EQ( d.Interpolate(800,500),  300.);
+   EXPECT_DOUBLE_EQ( d.Interpolate(900,500),  400.);
+
+   // interpolate on vertical edge (p0,p4), same x different y
+   // DeltaY = 100 deltaZ = 150
+   EXPECT_DOUBLE_EQ( d.Interpolate(750,420),  130.);
+   EXPECT_DOUBLE_EQ( d.Interpolate(750,450),  175.);
+   EXPECT_DOUBLE_EQ( d.Interpolate(750,490),  235);
+
+   // interpolate now on diagonal edge (P1,P4)
+   EXPECT_DOUBLE_EQ( d.Interpolate(800,480),  220.);
+   EXPECT_DOUBLE_EQ( d.Interpolate(900,440),  160.);
+   EXPECT_DOUBLE_EQ( d.Interpolate(950,420),  130.);
+
+   // interpolate on vertices
+   EXPECT_DOUBLE_EQ( d.Interpolate(750,400),  z[0]);
+   EXPECT_DOUBLE_EQ( d.Interpolate(1000,400),  z[1]);
+   EXPECT_DOUBLE_EQ( d.Interpolate(1000,500), z[2]);
+   EXPECT_DOUBLE_EQ( d.Interpolate(900,600),  z[3]);
+   EXPECT_DOUBLE_EQ( d.Interpolate(750,500),  z[4]);
+
+   // interpolate outside triangles
+   // small underflow in x and y
+   EXPECT_DOUBLE_EQ( d.Interpolate(750-0.0001,450),  0.);
+   EXPECT_DOUBLE_EQ( d.Interpolate(800,400-0.0001),  0.);
+   EXPECT_DOUBLE_EQ( d.Interpolate(1001,500),  0.);
+
+}
+
+


### PR DESCRIPTION
 Fix Delaunay 2D interpolation when the interpolated points are on at tringle's edges.
    
This is often the case when interpolating points laying in a grid, see https://root-forum.cern.ch/t/tgraph2d-interpolate-returns-0/54172 (linked also from the issue report). 

Before a crude hack was present, which could not work if the edge is horizontal.  
 
 Clean up also the class code and improve comments

Add also a test for the interpolation on points on the edges

This PR fixes  #12535 

