### PR TITLE
User guide: remove contradiciton on STL splitting

### DIFF
--- a/documentation/users-guide/Trees.md
+++ b/documentation/users-guide/Trees.md
@@ -767,10 +767,6 @@ differently. Here are the rules that apply when splitting a branch.
    deque<pair<float,float> > fDequePair;
 ```
 
--   As of ROOT 4.01/00, only `std::vector` of objects can be split.
-    Support for splitting the other type of STL containers will be
-    introduced in the near future.
-
 -   C-structure data members are not supported in split mode.
 
 -   An object that is not split may be slow to browse.


### PR DESCRIPTION
# This Pull request:

While looking at the documentation for split branches, I noticed a direct contradiction in the user guide:

>   As of ROOT 4.01/00, only `std::vector` of objects can be split.
>   Support for splitting the other type of STL containers will be
>    introduced in the near future.

vs.

> All STL containers are supported.

## Changes or fixes:

As now all STL containers are supported, I remove the bullet discussion the ROOT 4.01/00 state.

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

