### PR TITLE
TClassTable: fix data race between dlopen and other uses

### DIFF
--- a/core/cont/inc/TClassTable.h
+++ b/core/cont/inc/TClassTable.h
@@ -25,7 +25,6 @@
 #include "TObject.h"
 #include <string>
 #include <atomic>
-#include <mutex>
 
 class TProtoClass;
 

--- a/core/cont/inc/TClassTable.h
+++ b/core/cont/inc/TClassTable.h
@@ -24,6 +24,8 @@
 
 #include "TObject.h"
 #include <string>
+#include <atomic>
+#include <mutex>
 
 class TProtoClass;
 
@@ -40,13 +42,15 @@ friend  class TROOT;
 
 private:
    typedef ROOT::TMapTypeToClassRec IdMap_t;
+   using atomic_uint = std::atomic<UInt_t>;
+   class LockAndNormalize;
 
    static ROOT::TClassAlt **fgAlternate;
    static ROOT::TClassRec **fgTable;
    static ROOT::TClassRec **fgSortedTable;
    static IdMap_t     *fgIdMap;
    static UInt_t       fgSize;
-   static UInt_t       fgTally;
+   static atomic_uint  fgTally;
    static Bool_t       fgSorted;
    static UInt_t       fgCursor;
 

--- a/core/cont/inc/TClassTable.h
+++ b/core/cont/inc/TClassTable.h
@@ -56,8 +56,7 @@ private:
 
    TClassTable();
 
-   static ROOT::TClassRec   *FindElementImpl(const char *cname, Bool_t insert);
-   static ROOT::TClassRec   *FindElement(const char *cname, Bool_t insert=kFALSE);
+   static ROOT::TClassRec   *FindElement(const char *cname, Bool_t insert);
    static void         SortTable();
 
    static Bool_t CheckClassTableInit();

--- a/core/cont/inc/TClassTable.h
+++ b/core/cont/inc/TClassTable.h
@@ -42,17 +42,16 @@ friend  class TROOT;
 
 private:
    typedef ROOT::TMapTypeToClassRec IdMap_t;
-   using atomic_uint = std::atomic<UInt_t>;
    class NormalizeThenLock;
 
-   static ROOT::TClassAlt **fgAlternate;
-   static ROOT::TClassRec **fgTable;
-   static ROOT::TClassRec **fgSortedTable;
-   static IdMap_t     *fgIdMap;
-   static UInt_t       fgSize;
-   static atomic_uint  fgTally;
-   static Bool_t       fgSorted;
-   static UInt_t       fgCursor;
+   static ROOT::TClassAlt   **fgAlternate;
+   static ROOT::TClassRec   **fgTable;
+   static ROOT::TClassRec   **fgSortedTable;
+   static IdMap_t            *fgIdMap;
+   static UInt_t              fgSize;
+   static std::atomic<UInt_t> fgTally;
+   static Bool_t              fgSorted;
+   static UInt_t              fgCursor;
 
    TClassTable();
 

--- a/core/cont/inc/TClassTable.h
+++ b/core/cont/inc/TClassTable.h
@@ -43,7 +43,7 @@ friend  class TROOT;
 private:
    typedef ROOT::TMapTypeToClassRec IdMap_t;
    using atomic_uint = std::atomic<UInt_t>;
-   class LockAndNormalize;
+   class NormalizeThenLock;
 
    static ROOT::TClassAlt **fgAlternate;
    static ROOT::TClassRec **fgTable;

--- a/core/cont/src/TClassTable.cxx
+++ b/core/cont/src/TClassTable.cxx
@@ -64,7 +64,7 @@ static std::mutex &GetClassTableMutex()
 }
 
 // RAII to first normalize the input classname (operation that
-// both requires the ROOT global lock and might call `TClassTable
+// both requires the ROOT global lock and might call `TClassTable`
 // resursively) and then acquire a lock on `TClassTable` local
 // mutex.
 class TClassTable::NormalizeThenLock {

--- a/core/cont/src/TClassTable.cxx
+++ b/core/cont/src/TClassTable.cxx
@@ -299,6 +299,8 @@ TClassTable::~TClassTable()
 
 inline Bool_t TClassTable::CheckClassTableInit()
 {
+   // This will be set at the lastest during TROOT construction, so before
+   // any threading could happen.
    if (!gClassTable || !fgTable) {
       if (GetDelayedAddClass().size()) {
          new TClassTable;
@@ -389,10 +391,12 @@ void TClassTable::Add(const char *cname, Version_t id,  const std::type_info &in
    if (!cname || *cname == 0)
       ::Fatal("TClassTable::Add()", "Failed to deduce type for '%s'", info.name());
 
-   std::lock_guard<std::mutex> lock(GetClassTableMutex());
-
+   // This will be set at the lastest during TROOT construction, so before
+   // any threading could happen.
    if (!gClassTable)
       new TClassTable;
+
+   std::lock_guard<std::mutex> lock(GetClassTableMutex());
 
    // check if already in table, if so return
    TClassRec *r = FindElement(cname, kTRUE);
@@ -442,10 +446,12 @@ void TClassTable::Add(const char *cname, Version_t id,  const std::type_info &in
 
 void TClassTable::Add(TProtoClass *proto)
 {
-   std::lock_guard<std::mutex> lock(GetClassTableMutex());
-
+   // This will be set at the lastest during TROOT construction, so before
+   // any threading could happen.
    if (!gClassTable)
       new TClassTable;
+
+   std::lock_guard<std::mutex> lock(GetClassTableMutex());
 
    // By definition the name in the TProtoClass is (must be) the normalized
    // name, so there is no need to tweak it.
@@ -486,10 +492,12 @@ void TClassTable::Add(TProtoClass *proto)
 
 void TClassTable::AddAlternate(const char *normName, const char *alternate)
 {
-   std::lock_guard<std::mutex> lock(GetClassTableMutex());
-
+   // This will be set at the lastest during TROOT construction, so before
+   // any threading could happen.
    if (!gClassTable)
       new TClassTable;
+
+   std::lock_guard<std::mutex> lock(GetClassTableMutex());
 
    UInt_t slot = ROOT::ClassTableHash(alternate, fgSize);
 

--- a/core/cont/src/TClassTable.cxx
+++ b/core/cont/src/TClassTable.cxx
@@ -223,8 +223,8 @@ TClassTable::TClassTable()
    fgTable = new TClassRec* [fgSize];
    fgAlternate = new TClassAlt* [fgSize];
    fgIdMap = new IdMap_t;
-   memset(fgTable, 0, fgSize*sizeof(TClassRec*));
-   memset(fgAlternate, 0, fgSize*sizeof(TClassAlt*));
+   memset(fgTable, 0, fgSize * sizeof(TClassRec*));
+   memset(fgAlternate, 0, fgSize * sizeof(TClassAlt*));
    gClassTable = this;
 
    for (auto &&r : GetDelayedAddClass()) {
@@ -324,7 +324,8 @@ char *TClassTable::At(UInt_t index)
    SortTable();
    if (index < fgTally) {
       TClassRec *r = fgSortedTable[index];
-      if (r) return r->fName;
+      if (r)
+         return r->fName;
    }
    return nullptr;
 }
@@ -352,8 +353,8 @@ void TClassTable::Add(const char *cname, Version_t id,  const std::type_info &in
    // check if already in table, if so return
    TClassRec *r = FindElementImpl(cname, kTRUE);
    if (r->fName && r->fInfo) {
-      if ( strcmp(r->fInfo->name(),typeid(ROOT::TForNamespace).name())==0
-           && strcmp(info.name(),typeid(ROOT::TForNamespace).name())==0 ) {
+      if ( strcmp(r->fInfo->name(), typeid(ROOT::TForNamespace).name()) ==0
+           && strcmp(info.name(), typeid(ROOT::TForNamespace).name()) ==0 ) {
          // We have a namespace being reloaded.
          // This okay we just keep the old one.
          return;
@@ -376,11 +377,12 @@ void TClassTable::Add(const char *cname, Version_t id,  const std::type_info &in
          // was able to make with the library containing the TClass Init.
          // Because it is already known to the interpreter, the update class info
          // will not be triggered, we need to force it.
-         gCling->RegisterTClassUpdate(oldcl,dict);
+         gCling->RegisterTClassUpdate(oldcl, dict);
       }
    }
 
-   if (!r->fName) r->fName = StrDup(cname);
+   if (!r->fName)
+      r->fName = StrDup(cname);
    r->fId   = id;
    r->fBits = pragmabits;
    r->fDict = dict;
@@ -461,7 +463,8 @@ void TClassTable::AddAlternate(const char *normName, const char *alternate)
 
 Bool_t TClassTable::Check(const char *cname, std::string &normname)
 {
-   if (!CheckClassTableInit()) return kFALSE;
+   if (!CheckClassTableInit())
+      return kFALSE;
 
    UInt_t slot = ROOT::ClassTableHash(cname, fgSize);
 
@@ -486,9 +489,10 @@ Bool_t TClassTable::Check(const char *cname, std::string &normname)
 
 void TClassTable::Remove(const char *cname)
 {
-   if (!CheckClassTableInit()) return;
+   if (!CheckClassTableInit())
+      return;
 
-   UInt_t slot = ROOT::ClassTableHash(cname,fgSize);
+   UInt_t slot = ROOT::ClassTableHash(cname, fgSize);
 
    TClassRec *r;
    TClassRec *prev = nullptr;
@@ -519,9 +523,11 @@ TClassRec *TClassTable::FindElementImpl(const char *cname, Bool_t insert)
    UInt_t slot = ROOT::ClassTableHash(cname,fgSize);
 
    for (TClassRec *r = fgTable[slot]; r; r = r->fNext)
-      if (strcmp(cname,r->fName)==0) return r;
+      if (strcmp(cname, r->fName) == 0)
+         return r;
 
-   if (!insert) return nullptr;
+   if (!insert)
+      return nullptr;
 
    fgTable[slot] = new TClassRec(fgTable[slot]);
 
@@ -538,7 +544,8 @@ TClassRec *TClassTable::FindElementImpl(const char *cname, Bool_t insert)
 
 TClassRec *TClassTable::FindElement(const char *cname, Bool_t insert)
 {
-   if (!CheckClassTableInit()) return nullptr;
+   if (!CheckClassTableInit())
+      return nullptr;
 
    // The recorded name is normalized, let's make sure we convert the
    // input accordingly.
@@ -554,7 +561,8 @@ TClassRec *TClassTable::FindElement(const char *cname, Bool_t insert)
 Version_t TClassTable::GetID(const char *cname)
 {
    TClassRec *r = FindElement(cname);
-   if (r) return r->fId;
+   if (r)
+      return r->fId;
    return -1;
 }
 
@@ -564,7 +572,8 @@ Version_t TClassTable::GetID(const char *cname)
 Int_t TClassTable::GetPragmaBits(const char *cname)
 {
    TClassRec *r = FindElement(cname);
-   if (r) return r->fBits;
+   if (r)
+      return r->fBits;
    return 0;
 }
 
@@ -580,7 +589,8 @@ DictFuncPtr_t TClassTable::GetDict(const char *cname)
    }
 
    TClassRec *r = FindElement(cname);
-   if (r) return r->fDict;
+   if (r)
+      return r->fDict;
    return nullptr;
 }
 
@@ -590,7 +600,8 @@ DictFuncPtr_t TClassTable::GetDict(const char *cname)
 
 DictFuncPtr_t TClassTable::GetDict(const std::type_info& info)
 {
-   if (!CheckClassTableInit()) return nullptr;
+   if (!CheckClassTableInit())
+      return nullptr;
 
    if (gDebug > 9) {
       ::Info("GetDict", "searches for %s at 0x%zx", info.name(), (size_t)&info);
@@ -598,7 +609,8 @@ DictFuncPtr_t TClassTable::GetDict(const std::type_info& info)
    }
 
    TClassRec *r = fgIdMap->Find(info.name());
-   if (r) return r->fDict;
+   if (r)
+      return r->fDict;
    return nullptr;
 }
 
@@ -608,15 +620,17 @@ DictFuncPtr_t TClassTable::GetDict(const std::type_info& info)
 
 DictFuncPtr_t TClassTable::GetDictNorm(const char *cname)
 {
-   if (!CheckClassTableInit()) return nullptr;
+   if (!CheckClassTableInit())
+      return nullptr;
 
    if (gDebug > 9) {
       ::Info("GetDict", "searches for %s", cname);
       fgIdMap->Print();
    }
 
-   TClassRec *r = FindElementImpl(cname,kFALSE);
-   if (r) return r->fDict;
+   TClassRec *r = FindElementImpl(cname, kFALSE);
+   if (r)
+      return r->fDict;
    return nullptr;
 }
 
@@ -630,7 +644,8 @@ TProtoClass *TClassTable::GetProto(const char *cname)
       ::Info("GetDict", "searches for %s", cname);
    }
 
-   if (!CheckClassTableInit()) return nullptr;
+   if (!CheckClassTableInit())
+      return nullptr;
 
    if (gDebug > 9) {
       ::Info("GetDict", "searches for %s", cname);
@@ -638,7 +653,8 @@ TProtoClass *TClassTable::GetProto(const char *cname)
    }
 
    TClassRec *r = FindElement(cname);
-   if (r) return r->fProto;
+   if (r)
+      return r->fProto;
    return nullptr;
 }
 
@@ -652,14 +668,16 @@ TProtoClass *TClassTable::GetProtoNorm(const char *cname)
       ::Info("GetDict", "searches for %s", cname);
    }
 
-   if (!CheckClassTableInit()) return nullptr;
+   if (!CheckClassTableInit())
+      return nullptr;
 
    if (gDebug > 9) {
       fgIdMap->Print();
    }
 
-   TClassRec *r = FindElementImpl(cname,kFALSE);
-   if (r) return r->fProto;
+   TClassRec *r = FindElementImpl(cname, kFALSE);
+   if (r)
+      return r->fProto;
    return nullptr;
 }
 
@@ -809,9 +827,11 @@ void ROOT::AddClassAlternate(const char *normName, const char *alternate)
 
 void ROOT::ResetClassVersion(TClass *cl, const char *cname, Short_t newid)
 {
-   if (cname && cname!=(void*)-1) {
-      TClassRec *r = TClassTable::FindElement(cname,kFALSE);
-      if (r) r->fId = newid;
+
+   if (cname && cname != (void*)-1) {
+      TClassRec *r = TClassTable::FindElement(cname, kFALSE);
+      if (r)
+         r->fId = newid;
    }
    if (cl) {
       if (cl->fVersionUsed) {
@@ -851,9 +871,10 @@ void ROOT::RemoveClass(const char *cname)
       // get to the TStreamerInfo.
       if (gROOT && gROOT->GetListOfClasses()) {
          TObject *pcname;
-         if ((pcname=gROOT->GetListOfClasses()->FindObject(cname))) {
+         if ((pcname = gROOT->GetListOfClasses()->FindObject(cname))) {
             TClass *cl = dynamic_cast<TClass*>(pcname);
-            if (cl) cl->SetUnloaded();
+            if (cl)
+               cl->SetUnloaded();
          }
       }
       TClassTable::Remove(cname);

--- a/core/cont/src/TClassTable.cxx
+++ b/core/cont/src/TClassTable.cxx
@@ -389,7 +389,7 @@ void TClassTable::Add(const char *cname, Version_t id,  const std::type_info &in
       new TClassTable;
 
    // check if already in table, if so return
-   TClassRec *r = FindElementImpl(cname, kTRUE);
+   TClassRec *r = FindElement(cname, kTRUE);
    if (r->fName && r->fInfo) {
       if ( strcmp(r->fInfo->name(), typeid(ROOT::TForNamespace).name()) ==0
            && strcmp(info.name(), typeid(ROOT::TForNamespace).name()) ==0 ) {
@@ -446,7 +446,7 @@ void TClassTable::Add(TProtoClass *proto)
    const char *cname = proto->GetName();
 
    // check if already in table, if so return
-   TClassRec *r = FindElementImpl(cname, kTRUE);
+   TClassRec *r = FindElement(cname, kTRUE);
    if (r->fName) {
       if (r->fProto) delete r->fProto;
       r->fProto = proto;
@@ -564,7 +564,7 @@ void TClassTable::Remove(const char *cname)
 /// 0 if the class is not in the table. Unless arguments insert is true in
 /// which case a new entry is created and returned.
 
-TClassRec *TClassTable::FindElementImpl(const char *cname, Bool_t insert)
+TClassRec *TClassTable::FindElement(const char *cname, Bool_t insert)
 {
    // Internal routine, no explicit lock needed here.
 
@@ -584,33 +584,13 @@ TClassRec *TClassTable::FindElementImpl(const char *cname, Bool_t insert)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Find a class by name in the class table (using hash of name). Returns
-/// 0 if the class is not in the table. Unless arguments insert is true in
-/// which case a new entry is created and returned.
-/// cname can be any spelling of the class name.  See FindElementImpl if the
-/// name is already normalized.
-
-TClassRec *TClassTable::FindElement(const char *cname, Bool_t insert)
-{
-   if (!CheckClassTableInit())
-      return nullptr;
-
-   // The recorded name is normalized, let's make sure we convert the
-   // input accordingly.
-   std::string normalized;
-   TClassEdit::GetNormalizedName(normalized,cname);
-
-   return FindElementImpl(normalized.c_str(), insert);
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Returns the ID of a class.
 
 Version_t TClassTable::GetID(const char *cname)
 {
    LockAndNormalize guard(cname);
 
-   TClassRec *r = FindElementImpl(guard.GetNormalizedName().c_str(), kFALSE);
+   TClassRec *r = FindElement(guard.GetNormalizedName().c_str(), kFALSE);
    if (r)
       return r->fId;
    return -1;
@@ -623,7 +603,7 @@ Int_t TClassTable::GetPragmaBits(const char *cname)
 {
    LockAndNormalize guard(cname);
 
-   TClassRec *r = FindElementImpl(guard.GetNormalizedName().c_str(), kFALSE);
+   TClassRec *r = FindElement(guard.GetNormalizedName().c_str(), kFALSE);
    if (r)
       return r->fBits;
    return 0;
@@ -641,7 +621,7 @@ DictFuncPtr_t TClassTable::GetDict(const char *cname)
    }
    LockAndNormalize guard(cname);
 
-   TClassRec *r = FindElementImpl(guard.GetNormalizedName().c_str(), kFALSE);
+   TClassRec *r = FindElement(guard.GetNormalizedName().c_str(), kFALSE);
    if (r)
       return r->fDict;
    return nullptr;
@@ -685,7 +665,7 @@ DictFuncPtr_t TClassTable::GetDictNorm(const char *cname)
       fgIdMap->Print();
    }
 
-   TClassRec *r = FindElementImpl(cname, kFALSE);
+   TClassRec *r = FindElement(cname, kFALSE);
    if (r)
       return r->fDict;
    return nullptr;
@@ -711,7 +691,7 @@ TProtoClass *TClassTable::GetProto(const char *cname)
 
    LockAndNormalize guard(cname);
 
-   TClassRec *r = FindElementImpl(guard.GetNormalizedName().c_str(), kFALSE);
+   TClassRec *r = FindElement(guard.GetNormalizedName().c_str(), kFALSE);
    if (r)
       return r->fProto;
    return nullptr;
@@ -736,7 +716,7 @@ TProtoClass *TClassTable::GetProtoNorm(const char *cname)
       fgIdMap->Print();
    }
 
-   TClassRec *r = FindElementImpl(cname, kFALSE);
+   TClassRec *r = FindElement(cname, kFALSE);
    if (r)
       return r->fProto;
    return nullptr;
@@ -897,7 +877,7 @@ void ROOT::ResetClassVersion(TClass *cl, const char *cname, Short_t newid)
 
    if (cname && cname != (void*)-1 && TClassTable::CheckClassTableInit()) {
       TClassTable::LockAndNormalize guard(cname);
-      TClassRec *r = TClassTable::FindElementImpl(guard.GetNormalizedName().c_str(), kFALSE);
+      TClassRec *r = TClassTable::FindElement(guard.GetNormalizedName().c_str(), kFALSE);
       if (r)
          r->fId = newid;
    }

--- a/core/cont/src/TClassTable.cxx
+++ b/core/cont/src/TClassTable.cxx
@@ -43,13 +43,13 @@ using namespace ROOT;
 
 TClassTable *gClassTable;
 
-TClassAlt  **TClassTable::fgAlternate;
-TClassRec  **TClassTable::fgTable;
-TClassRec  **TClassTable::fgSortedTable;
-UInt_t       TClassTable::fgSize;
-std::atomic<UInt_t>  TClassTable::fgTally;
-Bool_t       TClassTable::fgSorted;
-UInt_t       TClassTable::fgCursor;
+TClassAlt           **TClassTable::fgAlternate;
+TClassRec           **TClassTable::fgTable;
+TClassRec           **TClassTable::fgSortedTable;
+UInt_t                TClassTable::fgSize;
+std::atomic<UInt_t>   TClassTable::fgTally;
+Bool_t                TClassTable::fgSorted;
+UInt_t                TClassTable::fgCursor;
 TClassTable::IdMap_t *TClassTable::fgIdMap;
 
 ClassImp(TClassTable);
@@ -885,10 +885,8 @@ void ROOT::AddClassAlternate(const char *normName, const char *alternate)
 ///  - The Class Version 0 request the whole object to be transient
 ///  - The Class Version 1, unless specify via ClassDef indicates that the
 ///    I/O should use the TClass checksum to distinguish the layout of the class
-
 void ROOT::ResetClassVersion(TClass *cl, const char *cname, Short_t newid)
 {
-
    if (cname && cname != (void*)-1 && TClassTable::CheckClassTableInit()) {
       TClassTable::NormalizeThenLock guard(cname);
       TClassRec *r = TClassTable::FindElement(guard.GetNormalizedName().c_str(), kFALSE);

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -1447,6 +1447,19 @@ Bool_t TBranch::SupportsBulkRead() const {
 ///
 /// where T is the type stored on this branch.
 ///
+/// When `count_buf` points to a valid TBuffer and the branch has a branch count,
+/// `count_buf` will be filled (via a call to GetEntriesSerialized) with the data
+/// from the branchCount.  After deserialization those value can be used to calculate
+/// the number of elements corresponding to each entries.
+///
+/// For each entry the number of elements is the multiplication of
+///    TLeaf *leaf = dynamic_cast<TLeaf*>(branch->GetListOfLeaves()->At(0))
+///    auto len = leaf->GetLen();
+/// and the value in the BranchCount corresponding to that entry (can be obtained
+/// from branch->GetBranchCount())
+///
+///
+///
 /// NOTES:
 /// - This interface is meant to be used by higher-level, type-safe wrappers, not
 ///   by end-users.


### PR DESCRIPTION
This fixes https://github.com/root-project/root/issues/12552

This commit add a mutex for the TClassTable inner operations.
Several changes were needed to insure that operation that can
either take the ROOT global lock or recursively call TClassTable
are executed outside of the TClassTable critical sections.
