### PR TITLE
[RF] Minor improvements to RooFit evaluation code generation

### DIFF
--- a/roofit/roofit/inc/RooExponential.h
+++ b/roofit/roofit/inc/RooExponential.h
@@ -34,6 +34,10 @@ public:
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override;
   double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override;
 
+  void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
+  std::string
+  buildCallToAnalyticIntegral(Int_t code, const char *rangeName, RooFit::Detail::CodeSquashContext &ctx) const override;
+
 protected:
   RooRealProxy x;
   RooRealProxy c;

--- a/roofit/roofitcore/inc/RooFit/Detail/AnalyticalIntegrals.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/AnalyticalIntegrals.h
@@ -16,6 +16,8 @@
 
 #include <TMath.h>
 
+#include <cmath>
+
 namespace RooFit {
 
 namespace Detail {
@@ -61,6 +63,15 @@ inline double gaussianIntegral(double xMin, double xMax, double mean, double sig
    else
       cond = ecmin - ecmax;
    return resultScale * 0.5 * cond;
+}
+
+inline double exponentialIntegral(double xMin, double xMax, double constant)
+{
+   if (constant == 0.0) {
+      return xMax - xMin;
+   }
+
+   return (std::exp(constant * xMax) - std::exp(constant * xMin)) / constant;
 }
 
 } // namespace AnalyticalIntegrals

--- a/roofit/roofitcore/inc/RooFit/Detail/EvaluateFuncs.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/EvaluateFuncs.h
@@ -23,7 +23,7 @@ namespace Detail {
 namespace EvaluateFuncs {
 
 /// @brief Function to evaluate an un-normalized RooGaussian.
-inline double gaussEvaluate(double x, double mean, double sigma)
+inline double gaussianEvaluate(double x, double mean, double sigma)
 {
    const double arg = x - mean;
    const double sig = sigma;

--- a/roofit/roofitcore/inc/RooFuncWrapper.h
+++ b/roofit/roofitcore/inc/RooFuncWrapper.h
@@ -45,8 +45,8 @@ protected:
    double evaluate() const override;
 
 private:
-   std::string buildCode(RooAbsReal const &head, RooArgSet const & /* paramSet */, RooArgSet const &obsSet,
-                  const RooAbsData *data);
+   std::string
+   buildCode(RooAbsReal const &head, RooArgSet const & /* paramSet */, RooArgSet const &obsSet, const RooAbsData *data);
 
    void updateGradientVarBuffer() const;
 

--- a/roofit/roofitcore/src/RooAddition.cxx
+++ b/roofit/roofitcore/src/RooAddition.cxx
@@ -189,7 +189,7 @@ void RooAddition::translate(RooFit::Detail::CodeSquashContext &ctx) const
       std::string decl = "double " + varName + "[" + std::to_string(eleSize) + "]{";
       int idx = 0;
       for (RooAbsArg *it : _set) {
-         decl += ctx.getResult(it) + ",";
+         decl += ctx.getResult(*it) + ",";
          ctx.addResult(it, varName + "[" + std::to_string(idx) + "]");
          idx++;
       }
@@ -208,7 +208,7 @@ void RooAddition::translate(RooFit::Detail::CodeSquashContext &ctx) const
 
    result = "(";
    for (RooAbsArg *it : _set) {
-      result += ctx.getResult(it) + '+';
+      result += ctx.getResult(*it) + '+';
    }
    result.back() = ')';
    ctx.addResult(this, result);

--- a/roofit/roofitcore/src/RooFuncWrapper.cxx
+++ b/roofit/roofitcore/src/RooFuncWrapper.cxx
@@ -43,11 +43,11 @@ RooFuncWrapper::RooFuncWrapper(const char *name, const char *title, RooAbsReal c
    std::unique_ptr<RooAbsReal> pdf{RooFit::Detail::compileForNormSet(obj, normSet)};
    // Get the parameters.
    RooArgSet paramSet;
-   pdf->getParameters(data ? data->get() : nullptr, paramSet);
+   obj.getParameters(data ? data->get() : nullptr, paramSet);
    // Get the observable if we have a valid dataset.
    RooArgSet obsSet;
    if (data)
-      pdf->getObservables(data->get(), obsSet);
+      obj.getObservables(data->get(), obsSet);
 
    // Load the parameters and observables.
    loadParamsAndObs(name, paramSet, obsSet, data);
@@ -58,7 +58,7 @@ RooFuncWrapper::RooFuncWrapper(const char *name, const char *title, RooAbsReal c
    declareAndDiffFunction(name, func);
 }
 
-RooFuncWrapper::RooFuncWrapper(const RooFuncWrapper &other, const char *name /*=nullptr*/)
+RooFuncWrapper::RooFuncWrapper(const RooFuncWrapper &other, const char *name)
    : RooAbsReal(other, name),
      _params("!params", this, other._params),
      _func(other._func),
@@ -177,8 +177,8 @@ void RooFuncWrapper::gradient(const double *x, double *g) const
    _grad(const_cast<double *>(x), _observables.data(), g);
 }
 
-std::string RooFuncWrapper::buildCode(RooAbsReal const &head, RooArgSet const & /* paramSet */,
-                               RooArgSet const &obsSet, const RooAbsData *data)
+std::string RooFuncWrapper::buildCode(RooAbsReal const &head, RooArgSet const & /* paramSet */, RooArgSet const &obsSet,
+                                      const RooAbsData *data)
 {
    RooFit::Detail::CodeSquashContext ctx;
 
@@ -224,5 +224,5 @@ std::string RooFuncWrapper::buildCode(RooAbsReal const &head, RooArgSet const & 
       curr->translate(ctx);
    }
 
-   return ctx.assembleCode(ctx.getResult(&head));
+   return ctx.assembleCode(ctx.getResult(head));
 }

--- a/roofit/roofitcore/src/RooNormalizedPdf.cxx
+++ b/roofit/roofitcore/src/RooNormalizedPdf.cxx
@@ -20,7 +20,7 @@
  */
 
 void RooNormalizedPdf::computeBatch(cudaStream_t * /*stream*/, double *output, size_t nEvents,
-                                    RooFit::Detail::DataMap const& dataMap) const
+                                    RooFit::Detail::DataMap const &dataMap) const
 {
    auto nums = dataMap.at(_pdf);
    auto integralSpan = dataMap.at(_normIntegral);
@@ -40,5 +40,5 @@ void RooNormalizedPdf::computeBatch(cudaStream_t * /*stream*/, double *output, s
 void RooNormalizedPdf::translate(RooFit::Detail::CodeSquashContext &ctx) const
 {
    // For now just return function/normalization integral.
-   ctx.addResult(this, ctx.getResult(&_pdf.arg()) + "/" + ctx.getResult(&_normIntegral.arg()));
+   ctx.addResult(this, ctx.getResult(_pdf) + "/" + ctx.getResult(_normIntegral));
 }

--- a/roofit/roofitcore/src/RooProduct.cxx
+++ b/roofit/roofitcore/src/RooProduct.cxx
@@ -500,8 +500,8 @@ void RooProduct::translate(RooFit::Detail::CodeSquashContext &ctx) const
    std::string result;
    // Build a (node1 * node2 * node3 * ...) like expression.
    result = '(';
-   for (const auto item : _compRSet) {
-      result += ctx.getResult(item) + "*";
+   for (RooAbsArg* item : _compRSet) {
+      result += ctx.getResult(*item) + "*";
    }
    result.back() = ')';
    ctx.addResult(this, result);


### PR DESCRIPTION
  * fix invalid memory access in RooFuncWrapper by getting observables and parameters of the original function, and not the one that is compiled for a normalization set, which is temporary. What matters are the names of the parameters and observables, and they are the same anyway

  * new `CodeSquashContext::buildCall()` function to avoid code duplication

  * add support for `RooExponential`, including unit test

Followup to #12529.