### PR TITLE
[RF] Don't add `weightVar` to observables in HistFactory

### DIFF
--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -1562,8 +1562,6 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
     combined->defineSet("globalObservables",globalObs);
     combined_config->SetGlobalObservables(*combined->set("globalObservables"));
 
-    combined->factory("weightVar[0,-1e10,1e10]");
-    obsList.add(*combined->var("weightVar"));
     combined->defineSet("observables",{obsList, *channelCat}, /*importMissing=*/true);
     combined_config->SetObservables(*combined->set("observables"));
 


### PR DESCRIPTION
It doesn't make sense to have the weight variable in the set of observables. This causes problems in various places, e.g.:

  * this dummy `weightVar` is polluting the JSON file when exporting the workspace

  * it is a nuisance for normalization because it will also appear in the normalization sets

This commit suggests to not add some dummy weight variable to the workspace.