### PR TITLE
[ntuple] Remove `RResult` from public importer interface

### DIFF
--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -248,11 +248,11 @@ public:
    ~RNTupleImporter() = default;
 
    /// Opens the input file for reading and the output file for writing (update).
-   static RResult<std::unique_ptr<RNTupleImporter>>
+   static std::unique_ptr<RNTupleImporter>
    Create(std::string_view sourceFileName, std::string_view treeName, std::string_view destFileName);
 
    /// Directly uses the provided tree and opens the output file for writing (update).
-   static RResult<std::unique_ptr<RNTupleImporter>> Create(TTree *sourceTree, std::string_view destFileName);
+   static std::unique_ptr<RNTupleImporter> Create(TTree *sourceTree, std::string_view destFileName);
 
    RNTupleWriteOptions GetWriteOptions() const { return fWriteOptions; }
    void SetWriteOptions(RNTupleWriteOptions options) { fWriteOptions = options; }
@@ -267,7 +267,7 @@ public:
    ///    fields and the model
    /// 2. An event loop reads every entry from the TTree, applies transformations where necessary, and writes the
    ///    output entry to the RNTuple.
-   RResult<void> Import();
+   void Import();
 }; // class RNTupleImporter
 
 } // namespace Experimental

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -39,7 +39,7 @@ namespace Experimental {
 
 // clang-format off
 /**
-\class ROOT::Experimental::Detail::RNTupleImporter
+\class ROOT::Experimental::RNTupleImporter
 \ingroup NTuple
 \brief Converts a TTree into an RNTuple
 
@@ -59,7 +59,14 @@ Note that input file and output file can be identical if the ntuple is stored un
 (use `SetNTupleName()`).
 
 By default, the RNTuple is compressed with zstd, independent of the input compression. The compression settings
-(and other output parameters) can be changed by `SetWriteOptions()`.
+(and other output parameters) can be changed by `SetWriteOptions()`. For example, to compress the imported RNTuple
+using lz4 (with compression level 4) instead:
+
+~~~ {.cpp}
+auto writeOptions = importer->GetWriteOptions();
+writeOptions.SetCompression(404);
+importer->SetWriteOptions(writeOptions);
+~~~
 
 Most RNTuple fields have a type identical to the corresponding TTree input branch. Exceptions are
   - C string branches are translated to std::string fields
@@ -81,7 +88,6 @@ Most RNTuple fields have a type identical to the corresponding TTree input branc
     These projections are meta-data only operations and don't involve duplicating the data.
 
 Current limitations of the importer:
-  - Importing collection proxies is untested
   - No support for trees containing TObject (or derived classes) or TClonesArray collections
   - Due to RNTuple currently storing data fully split, "don't split" markers are ignored
   - Some types are not (yet) available in RNTuple, such as pointers, Double32_t or std::map

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -25,7 +25,7 @@ TEST(RNTupleImporter, Empty)
       tree->Write();
    }
 
-   auto importer = RNTupleImporter::Create(fileGuard.GetPath(), "tree", fileGuard.GetPath()).Unwrap();
+   auto importer = RNTupleImporter::Create(fileGuard.GetPath(), "tree", fileGuard.GetPath());
    importer->SetIsQuiet(true);
    EXPECT_THROW(importer->Import(), ROOT::Experimental::RException);
    importer->SetNTupleName("ntuple");
@@ -47,7 +47,7 @@ TEST(RNTupleImporter, CreateFromTree)
    std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
    auto tree = file->Get<TTree>("tree");
 
-   auto importer = RNTupleImporter::Create(tree, fileGuard.GetPath()).Unwrap();
+   auto importer = RNTupleImporter::Create(tree, fileGuard.GetPath());
    importer->SetIsQuiet(true);
    EXPECT_THROW(importer->Import(), ROOT::Experimental::RException);
    importer->SetNTupleName("ntuple");
@@ -85,7 +85,7 @@ TEST(RNTupleImporter, CreateFromChain)
    chain->Add(fileGuard1.GetPath().c_str());
    chain->Add(fileGuard2.GetPath().c_str());
 
-   auto importer = RNTupleImporter::Create(chain, fileGuard1.GetPath()).Unwrap();
+   auto importer = RNTupleImporter::Create(chain, fileGuard1.GetPath());
    importer->SetIsQuiet(true);
    EXPECT_THROW(importer->Import(), ROOT::Experimental::RException);
    importer->SetNTupleName("ntuple");
@@ -134,7 +134,7 @@ TEST(RNTupleImporter, Simple)
       tree->Write();
    }
 
-   auto importer = RNTupleImporter::Create(fileGuard.GetPath(), "tree", fileGuard.GetPath()).Unwrap();
+   auto importer = RNTupleImporter::Create(fileGuard.GetPath(), "tree", fileGuard.GetPath());
    importer->SetIsQuiet(true);
    importer->SetNTupleName("ntuple");
    importer->Import();
@@ -167,7 +167,7 @@ TEST(RNTupleImporter, FieldName)
       tree->Write();
    }
 
-   auto importer = RNTupleImporter::Create(fileGuard.GetPath(), "tree", fileGuard.GetPath()).Unwrap();
+   auto importer = RNTupleImporter::Create(fileGuard.GetPath(), "tree", fileGuard.GetPath());
    importer->SetIsQuiet(true);
    importer->SetNTupleName("ntuple");
    importer->Import();
@@ -195,7 +195,7 @@ TEST(RNTupleImporter, CString)
       tree->Write();
    }
 
-   auto importer = RNTupleImporter::Create(fileGuard.GetPath(), "tree", fileGuard.GetPath()).Unwrap();
+   auto importer = RNTupleImporter::Create(fileGuard.GetPath(), "tree", fileGuard.GetPath());
    importer->SetIsQuiet(true);
    importer->SetNTupleName("ntuple");
    importer->Import();
@@ -224,7 +224,7 @@ TEST(RNTupleImporter, Leaflist)
       tree->Write();
    }
 
-   auto importer = RNTupleImporter::Create(fileGuard.GetPath(), "tree", fileGuard.GetPath()).Unwrap();
+   auto importer = RNTupleImporter::Create(fileGuard.GetPath(), "tree", fileGuard.GetPath());
    importer->SetIsQuiet(true);
    importer->SetNTupleName("ntuple");
    importer->Import();
@@ -260,7 +260,7 @@ TEST(RNTupleImporter, FixedSizeArray)
       tree->Write();
    }
 
-   auto importer = RNTupleImporter::Create(fileGuard.GetPath(), "tree", fileGuard.GetPath()).Unwrap();
+   auto importer = RNTupleImporter::Create(fileGuard.GetPath(), "tree", fileGuard.GetPath());
    importer->SetIsQuiet(true);
    importer->SetNTupleName("ntuple");
    importer->Import();
@@ -329,7 +329,7 @@ TEST(RNTupleImporter, LeafCountArray)
       tree->Write();
    }
 
-   auto importer = RNTupleImporter::Create(fileGuard.GetPath(), "tree", fileGuard.GetPath()).Unwrap();
+   auto importer = RNTupleImporter::Create(fileGuard.GetPath(), "tree", fileGuard.GetPath());
    importer->SetIsQuiet(true);
    importer->SetNTupleName("ntuple");
    importer->Import();
@@ -418,7 +418,7 @@ TEST(RNTupleImporter, STL)
       delete tuple;
    }
 
-   auto importer = RNTupleImporter::Create(fileGuard.GetPath(), "tree", fileGuard.GetPath()).Unwrap();
+   auto importer = RNTupleImporter::Create(fileGuard.GetPath(), "tree", fileGuard.GetPath());
    importer->SetIsQuiet(true);
    importer->SetNTupleName("ntuple");
    importer->Import();
@@ -459,7 +459,7 @@ TEST(RNTupleImporter, CustomClass)
       tree->Write();
    }
 
-   auto importer = RNTupleImporter::Create(fileGuard.GetPath(), "tree", fileGuard.GetPath()).Unwrap();
+   auto importer = RNTupleImporter::Create(fileGuard.GetPath(), "tree", fileGuard.GetPath());
    importer->SetIsQuiet(true);
    importer->SetNTupleName("ntuple");
    importer->Import();
@@ -502,7 +502,7 @@ TEST(RNTupleImporter, ComplexClass)
          tree->Write();
       }
 
-      auto importer = RNTupleImporter::Create(fileGuard.GetPath(), "tree", fileGuard.GetPath()).Unwrap();
+      auto importer = RNTupleImporter::Create(fileGuard.GetPath(), "tree", fileGuard.GetPath());
       importer->SetIsQuiet(true);
       importer->SetNTupleName("ntuple");
       importer->Import();
@@ -544,7 +544,7 @@ TEST(RNTupleImporter, CollectionProxyClass)
          tree->Write();
       }
 
-      auto importer = RNTupleImporter::Create(fileGuard.GetPath(), "tree", fileGuard.GetPath()).Unwrap();
+      auto importer = RNTupleImporter::Create(fileGuard.GetPath(), "tree", fileGuard.GetPath());
       importer->SetIsQuiet(true);
       importer->SetNTupleName("ntuple");
       importer->Import();
@@ -579,7 +579,7 @@ TEST(RNTUpleImporter, MaxEntries)
       tree->Write();
    }
 
-   auto importer = RNTupleImporter::Create(fileGuard.GetPath(), "tree", fileGuard.GetPath()).Unwrap();
+   auto importer = RNTupleImporter::Create(fileGuard.GetPath(), "tree", fileGuard.GetPath());
 
    // Base case, we don't do anything with `SetMaxEntries`.
    importer->SetIsQuiet(true);

--- a/tutorials/v7/ntuple/ntpl008_import.C
+++ b/tutorials/v7/ntuple/ntpl008_import.C
@@ -47,10 +47,10 @@ void ntpl008_import()
    // RNTupleImporter::Create() returns a wrapper for an RNTupleImporter. If the creation fails,
    // the result will contain an exception. Calling Unwrap() returns the actual RNTupleImporter
    // class or throws the exception in case of errors.
-   auto importer = RNTupleImporter::Create(kTreeFileName, kTreeName, kNTupleFileName).Unwrap();
+   auto importer = RNTupleImporter::Create(kTreeFileName, kTreeName, kNTupleFileName);
 
    // Using `ThrowOnError()` makes sure that the macro abort if the import fails.
-   importer->Import().ThrowOnError();
+   importer->Import();
 
    // Inspect the schema of the written RNTuple
    auto file = std::unique_ptr<TFile>(TFile::Open(kNTupleFileName));

--- a/tutorials/v7/ntuple/ntpl008_import.C
+++ b/tutorials/v7/ntuple/ntpl008_import.C
@@ -25,12 +25,12 @@ R__LOAD_LIBRARY(ROOTNTupleUtil)
 #include <TFile.h>
 #include <TROOT.h>
 
-// Import classes from experimental namespace for the time being
+// Import classes from experimental namespace for the time being.
 using RNTuple = ROOT::Experimental::RNTuple;
 using RNTupleImporter = ROOT::Experimental::RNTupleImporter;
 using RNTupleReader = ROOT::Experimental::RNTupleReader;
 
-// Input and output
+// Input and output.
 constexpr char const *kTreeFileName = "http://root.cern.ch/files/HiggsTauTauReduced/GluGluToHToTauTau.root";
 constexpr char const *kTreeName = "Events";
 constexpr char const *kNTupleFileName = "ntpl008_import.root";
@@ -41,18 +41,21 @@ void ntpl008_import()
    // with `Key 'Events' already exists in file ntpl008_import.root` by removing the output file.
    gSystem->Unlink(kNTupleFileName);
 
-   // Use multiple threads to compress RNTuple data
+   // Use multiple threads to compress RNTuple data.
    ROOT::EnableImplicitMT();
 
-   // RNTupleImporter::Create() returns a wrapper for an RNTupleImporter. If the creation fails,
-   // the result will contain an exception. Calling Unwrap() returns the actual RNTupleImporter
-   // class or throws the exception in case of errors.
+   // Create a new RNTupleImporter object.
    auto importer = RNTupleImporter::Create(kTreeFileName, kTreeName, kNTupleFileName);
 
-   // Using `ThrowOnError()` makes sure that the macro abort if the import fails.
+   // Configure the RNTuple to be compressed using the zstd algorithm.
+   auto writeOptions = importer->GetWriteOptions();
+   writeOptions.SetCompression(505);
+   importer->SetWriteOptions(writeOptions);
+
+   // Begin importing.
    importer->Import();
 
-   // Inspect the schema of the written RNTuple
+   // Inspect the schema of the written RNTuple.
    auto file = std::unique_ptr<TFile>(TFile::Open(kNTupleFileName));
    if (!file || file->IsZombie()) {
       std::cerr << "cannot open " << kNTupleFileName << std::endl;

--- a/tutorials/v7/ntuple/ntpl008_import.C
+++ b/tutorials/v7/ntuple/ntpl008_import.C
@@ -47,11 +47,6 @@ void ntpl008_import()
    // Create a new RNTupleImporter object.
    auto importer = RNTupleImporter::Create(kTreeFileName, kTreeName, kNTupleFileName);
 
-   // Configure the RNTuple to be compressed using the zstd algorithm.
-   auto writeOptions = importer->GetWriteOptions();
-   writeOptions.SetCompression(505);
-   importer->SetWriteOptions(writeOptions);
-
    // Begin importing.
    importer->Import();
 


### PR DESCRIPTION
This PR removes the `RResult` wrapper from the public `RNTupleImporter` interface; private methods are still wrapped.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

