### PR TITLE
[ntuple] Add `RNTupleInspector::Create` for ntuple name and source path

### DIFF
--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -60,7 +60,8 @@ private:
    std::uint64_t fCompressedSize;
    std::uint64_t fUncompressedSize;
 
-   RNTupleInspector(std::unique_ptr<ROOT::Experimental::Detail::RPageSource> pageSource) : fPageSource(std::move(pageSource)) {};
+   RNTupleInspector(std::unique_ptr<ROOT::Experimental::Detail::RPageSource> pageSource)
+      : fPageSource(std::move(pageSource)){};
 
    void CollectSizeData();
 
@@ -72,8 +73,10 @@ public:
    ~RNTupleInspector() = default;
 
    /// Creates a new inspector for a given RNTuple.
-   static RResult<std::unique_ptr<RNTupleInspector>> Create(std::unique_ptr<ROOT::Experimental::Detail::RPageSource> pageSource);
+   static RResult<std::unique_ptr<RNTupleInspector>>
+   Create(std::unique_ptr<ROOT::Experimental::Detail::RPageSource> pageSource);
    static RResult<std::unique_ptr<RNTupleInspector>> Create(RNTuple *sourceNTuple);
+   static RResult<std::unique_ptr<RNTupleInspector>> Create(std::string_view ntupleName, std::string_view storage);
 
    /// Get the name of the RNTuple being inspected.
    std::string GetName();

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -55,6 +55,7 @@ std::cout << "The compression factor is " << std::fixed << std::setprecision(2)
 // clang-format on
 class RNTupleInspector {
 private:
+   std::unique_ptr<TFile> fSourceFile;
    std::unique_ptr<ROOT::Experimental::Detail::RPageSource> fPageSource;
    int fCompressionSettings;
    std::uint64_t fCompressedSize;

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -20,6 +20,8 @@
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleDescriptor.hxx>
 
+#include <TFile.h>
+
 #include <cstdlib>
 #include <memory>
 

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -19,6 +19,8 @@
 #include <ROOT/RNTupleInspector.hxx>
 #include <ROOT/RError.hxx>
 
+#include <TFile.h>
+
 #include <cstring>
 
 void ROOT::Experimental::RNTupleInspector::CollectSizeData()
@@ -65,9 +67,29 @@ ROOT::Experimental::RNTupleInspector::Create(std::unique_ptr<ROOT::Experimental:
 ROOT::Experimental::RResult<std::unique_ptr<ROOT::Experimental::RNTupleInspector>>
 ROOT::Experimental::RNTupleInspector::Create(ROOT::Experimental::RNTuple *sourceNTuple)
 {
+   if (!sourceNTuple) {
+      return R__FAIL("provided RNTuple is null");
+   }
+
    std::unique_ptr<ROOT::Experimental::Detail::RPageSource> pageSource = sourceNTuple->MakePageSource();
 
    return ROOT::Experimental::RNTupleInspector::Create(std::move(pageSource));
+}
+
+ROOT::Experimental::RResult<std::unique_ptr<ROOT::Experimental::RNTupleInspector>>
+ROOT::Experimental::RNTupleInspector::Create(std::string_view ntupleName, std::string_view sourceFileName)
+{
+   auto sourceFile = std::unique_ptr<TFile>(TFile::Open(std::string(sourceFileName).c_str()));
+   if (!sourceFile || sourceFile->IsZombie()) {
+      return R__FAIL("cannot open source file " + std::string(sourceFileName));
+   }
+   auto ntuple = std::unique_ptr<ROOT::Experimental::RNTuple>(
+      sourceFile->Get<ROOT::Experimental::RNTuple>(std::string(ntupleName).c_str()));
+   if (!ntuple) {
+      return R__FAIL("cannot read RNTuple " + std::string(ntupleName) + " from " + std::string(sourceFileName));
+   }
+
+   return ROOT::Experimental::RNTupleInspector::Create(ntuple.get());
 }
 
 std::string ROOT::Experimental::RNTupleInspector::GetName()

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -89,7 +89,12 @@ ROOT::Experimental::RNTupleInspector::Create(std::string_view ntupleName, std::s
       return R__FAIL("cannot read RNTuple " + std::string(ntupleName) + " from " + std::string(sourceFileName));
    }
 
-   return ROOT::Experimental::RNTupleInspector::Create(ntuple.get());
+   auto inspector = std::unique_ptr<RNTupleInspector>(new RNTupleInspector(ntuple->MakePageSource()));
+   inspector->fSourceFile = std::move(sourceFile);
+
+   inspector->CollectSizeData();
+
+   return inspector;
 }
 
 std::string ROOT::Experimental::RNTupleInspector::GetName()

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -12,9 +12,9 @@ using ROOT::Experimental::RNTupleReader;
 using ROOT::Experimental::RNTupleWriteOptions;
 using ROOT::Experimental::RNTupleWriter;
 
-TEST(RNTupleInspector, Name)
+TEST(RNTupleInspector, CreateFromPointer)
 {
-   FileRaii fileGuard("test_ntuple_inspector_name.root");
+   FileRaii fileGuard("test_ntuple_inspector_create_from_pointer.root");
    {
       auto model = RNTupleModel::Create();
       RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
@@ -23,8 +23,25 @@ TEST(RNTupleInspector, Name)
    std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
    auto ntuple = file->Get<RNTuple>("ntuple");
    auto inspector = RNTupleInspector::Create(ntuple).Unwrap();
-
    EXPECT_EQ("ntuple", inspector->GetName());
+
+   auto nullNTuple = file->Get<RNTuple>("null");
+   EXPECT_THROW(RNTupleInspector::Create(nullNTuple), ROOT::Experimental::RException);
+}
+
+TEST(RNTupleInspector, CreateFromString)
+{
+   FileRaii fileGuard("test_ntuple_inspector_open_from_string.root");
+   {
+      auto model = RNTupleModel::Create();
+      RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
+   }
+
+   auto inspector = RNTupleInspector::Create("ntuple", fileGuard.GetPath()).Unwrap();
+   EXPECT_EQ("ntuple", inspector->GetName());
+
+   EXPECT_THROW(RNTupleInspector::Create("nonexistent", fileGuard.GetPath()), ROOT::Experimental::RException);
+   EXPECT_THROW(RNTupleInspector::Create("ntuple", "nonexistent.root"), ROOT::Experimental::RException);
 }
 
 TEST(RNTupleInspector, NEntries)

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -31,10 +31,9 @@ TEST(RNTupleInspector, CreateFromPointer)
 
 TEST(RNTupleInspector, CreateFromString)
 {
-   FileRaii fileGuard("test_ntuple_inspector_open_from_string.root");
+   FileRaii fileGuard("test_ntuple_inspector_create_from_string.root");
    {
-      auto model = RNTupleModel::Create();
-      RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
+      RNTupleWriter::Recreate(RNTupleModel::Create(), "ntuple", fileGuard.GetPath());
    }
 
    auto inspector = RNTupleInspector::Create("ntuple", fileGuard.GetPath()).Unwrap();


### PR DESCRIPTION
This PR adds a new `Create` factory method to the `RNTupleInspector` that takes the name and source path of the `RNTuple` to be inspected as its arguments. This removes the need for the user to open the relevant `TFile` and load the `RNTuple` manually, which can be useful in case one is only interested in inspecting an `RNTuple`.

Additionally, a check is added to the existing `Create(RNTuple *sourceNTuple)` method to make sure the pointer that was passed does not refer to null.

