### PR TITLE
Avoid recursive powershell.exe

### DIFF
--- a/.github/workflows/root-ci-config/build_root.py
+++ b/.github/workflows/root-ci-config/build_root.py
@@ -148,6 +148,7 @@ def cleanup_previous_build(shell_log):
 
     if WINDOWS:
         # windows
+        prevComSpec = os.environ['COMSPEC']
         os.environ['COMSPEC'] = 'powershell.exe'
         result, shell_log = subprocess_with_log(f"""
             $ErrorActionPreference = 'Stop'
@@ -156,6 +157,7 @@ def cleanup_previous_build(shell_log):
             }}
             New-Item -Force -Type directory -Path {WORKDIR}
         """, shell_log)
+        os.environ['COMSPEC'] = prevComSpec
     else:
         # mac/linux/POSIX
         result, shell_log = subprocess_with_log(f"""


### PR DESCRIPTION
This prevent having up to 400 Powershell instances when building ROOT (every time `root-config --has-whatever` is called)