### PR TITLE
[RF] Add 'translate' to RooNllVarNew.

### DIFF
--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -50,6 +50,11 @@ using RooSetProxy = RooCollectionProxy<RooArgSet>;
 using RooListProxy = RooCollectionProxy<RooArgList>;
 class RooExpensiveObjectCache ;
 class RooWorkspace ;
+namespace RooFit {
+namespace Detail {
+class CodeSquashContext;
+}
+}
 
 class RooRefArray : public TObjArray {
  public:
@@ -584,6 +589,8 @@ public:
   virtual std::unique_ptr<RooAbsArg> compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileContext & ctx) const;
 
   virtual bool isCategory() const { return false; }
+
+  virtual void translate(RooFit::Detail::CodeSquashContext &ctx) const;
 
 protected:
    void graphVizAddConnections(std::set<std::pair<RooAbsArg*,RooAbsArg*> >&) ;

--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -427,10 +427,8 @@ protected:
                      RooArgSet *&cloneSet, const char* rangeName=nullptr, const RooArgSet* condObs=nullptr) const;
   virtual void computeBatch(cudaStream_t*, double* output, size_t size, RooFit::Detail::DataMap const&) const;
 
-  virtual void translate(RooFit::Detail::CodeSquashContext &ctx) const;
   virtual std::string
   buildCallToAnalyticIntegral(Int_t code, const char *rangeName, RooFit::Detail::CodeSquashContext &ctx) const;
-  virtual void buildLoopBegin(RooFit::Detail::CodeSquashContext &ctx) const;
 
  protected:
 

--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -430,6 +430,7 @@ protected:
   virtual void translate(RooFit::Detail::CodeSquashContext &ctx) const;
   virtual std::string
   buildCallToAnalyticIntegral(Int_t code, const char *rangeName, RooFit::Detail::CodeSquashContext &ctx) const;
+  virtual void buildLoopBegin(RooFit::Detail::CodeSquashContext &ctx) const;
 
  protected:
 

--- a/roofit/roofitcore/inc/RooFit/Detail/CodeSquashContext.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/CodeSquashContext.h
@@ -32,33 +32,45 @@ namespace Detail {
 /// @brief A class to maintain the context for squashing of RooFit models into code.
 class CodeSquashContext {
 public:
-   /// @brief A crude way of keeping track of loop ranges for nodes like NLLs.
-   const std::size_t numEntries;
-
-   CodeSquashContext(const RooAbsData *data = nullptr) : numEntries(data ? data->numEntries() : 0) {}
+   CodeSquashContext(const RooAbsData *data = nullptr) : _numEntries(data ? data->numEntries() : 0) {}
 
    /// @brief Adds (or overwrites) the string representing the result of a node.
    /// @param key The node to add the result for.
    /// @param value The new name to assign/overwrite.
-   inline void addResult(RooAbsArg const *key, std::string value) { _nodeNames[key->namePtr()] = value; }
+   inline void addResult(RooAbsArg const *key, std::string const &value) { addResult(key->namePtr(), value); }
 
-   inline void addResult(const char *key, std::string value)
+   inline void addResult(const char *key, std::string const &value)
    {
       const TNamed *namePtr = RooNameReg::known(key);
       if (namePtr)
-         _nodeNames[namePtr] = value;
+         addResult(namePtr, value);
    }
 
-   /// @brief Gets the result for the given node using the node name.
+   /// @brief Gets the result for the given node using the node name. This node also performs the necessary
+   /// code generation through recursive calls to 'translate'. A call to this function modifies the already
+   /// existing code body.
    /// @param key The node to get the result string for.
    /// @return String representing the result of this node.
    inline std::string const &getResult(RooAbsArg const &arg)
    {
-
+      // If the result has already been recorded, just return the result.
+      // It is usually the responsibility of each translate function to assign
+      // the proper result to its class. Hence, if a result has already been recorded
+      // for a particular node, it means the node has already been 'translate'd and we
+      // dont need to visit it again.
       auto found = _nodeNames.find(arg.namePtr());
       if (found != _nodeNames.end())
          return found->second;
 
+      // The result for vector observables should already be in the map if you
+      // opened the loop scope. This is just to check if we did not request the
+      // result of a vector-valued observable outside of the scope of a loop.
+      auto foundVecObs = _vecObsIndices.find(arg.namePtr());
+      if (foundVecObs != _vecObsIndices.end()) {
+         throw std::runtime_error("You requested the result of a vector observable outside a loop scope for it!");
+      }
+
+      // Now, recursively call translate into the current argument to load the correct result.
       arg.translate(*this);
 
       return _nodeNames.at(arg.namePtr());
@@ -97,15 +109,6 @@ public:
          _vecObsIndices[namePtr] = idx;
    }
 
-   /// @brief Get the start index of the node representing the key. If the key is not found (in the case the key is
-   /// scalar), return -1.
-   /// @param key The node to perform a lookup for.
-   /// @return The start index of the observable if found, otherwise -1.
-   inline int getVecObsStartIdx(RooAbsArg const *key)
-   {
-      return _vecObsIndices.find(key->namePtr()) == _vecObsIndices.end() ? -1 : _vecObsIndices[key->namePtr()];
-   }
-
    /// @brief Adds the input string to the squashed code body. If a class implements a translate function that wants to
    /// emit something to the squashed code body, it must call this function with the code it wants to emit.
    /// @param in String to add to the squashed code.
@@ -122,7 +125,65 @@ public:
       return ss.str();
    }
 
+   /// @brief A class to manage loop scopes using the RAII technique. To wrap your code around a loop,
+   /// simply place it between a brace inclosed scope with a call to beginLoop at the top. For e.g.
+   /// {
+   ///   auto scope = ctx.beginLoop({<-set of vector observables to loop over->});
+   ///   // your loop body code goes here.
+   /// }
+   class LoopScope {
+   public:
+      LoopScope(CodeSquashContext &ctx, std::vector<TNamed const *> &&vars) : _ctx{ctx}, _vars{vars} {}
+      ~LoopScope() { _ctx.endLoop(*this); }
+
+      std::vector<TNamed const *> const &vars() const { return _vars; }
+
+   private:
+      CodeSquashContext &_ctx;
+      const std::vector<TNamed const *> _vars;
+   };
+
+   /// @brief Create a RAII scope for iterating over vector observables. You can't use the result of vector observables
+   /// outside these loop scopes.
+   /// @param loopVars The vector observables to iterate over. If one of the
+   /// loopVars is not a vector observable, it is ignored, i.e., it can be used just like outside the loop scope.
+   std::unique_ptr<LoopScope> beginLoop(RooArgSet const &loopVars)
+   {
+      // Make sure that the name of this variable doesn't clash with other stuff
+      std::string idx = "loopIdx" + std::to_string(_loopLevel);
+      addToCodeBody("for(int " + idx + " = 0; " + idx + " < " + std::to_string(_numEntries) + "; " + idx + "++) {\n");
+
+      std::vector<TNamed const *> vars;
+      for (RooAbsArg const *var : loopVars) {
+         vars.push_back(var->namePtr());
+      }
+
+      for (auto const &ptr : vars) {
+         // set the results of the vector observables
+         auto found = _vecObsIndices.find(ptr);
+         if (found != _vecObsIndices.end())
+            _nodeNames[found->first] = "obs[" + std::to_string(found->second) + " + " + idx + "]";
+      }
+
+      ++_loopLevel;
+      return std::make_unique<LoopScope>(*this, std::move(vars));
+   }
+
 private:
+   void endLoop(LoopScope const &scope)
+   {
+      _code += "}\n";
+
+      // clear the results of the loop variables if they were vector observables
+      for (auto const &ptr : scope.vars()) {
+         if (_vecObsIndices.find(ptr) != _vecObsIndices.end())
+            _nodeNames.erase(ptr);
+      }
+      --_loopLevel;
+   }
+
+   inline void addResult(TNamed const *key, std::string const &value) { _nodeNames[key] = value; }
+
    std::string buildArg(double x) { return RooNumber::toString(x); }
 
    template <class T>
@@ -145,6 +206,8 @@ private:
       return buildArg(arg) + ", " + buildArgs(args...);
    }
 
+   /// @brief A crude way of keeping track of loop ranges for nodes like NLLs.
+   const std::size_t _numEntries = 0;
    /// @brief Map of node names to their result strings.
    std::unordered_map<const TNamed *, std::string> _nodeNames;
    /// @brief Block of code that is placed before the rest of the function body.
@@ -153,6 +216,8 @@ private:
    std::unordered_map<const TNamed *, int> _vecObsIndices;
    /// @brief Stores the squashed code body.
    std::string _code;
+   /// @brief The current number of for loops the started.
+   int _loopLevel = 0;
 };
 
 } // namespace Detail

--- a/roofit/roofitcore/inc/RooFit/Detail/CodeSquashContext.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/CodeSquashContext.h
@@ -52,20 +52,22 @@ public:
    /// @brief Gets the result for the given node using the node name.
    /// @param key The node to get the result string for.
    /// @return String representing the result of this node.
-   inline std::string const &getResult(RooAbsArg const &key) const { return _nodeNames.at(key.namePtr()); }
-
-   template <class T>
-   std::string const &getResult(RooTemplateProxy<T> const &key) const
+   inline std::string const &getResult(RooAbsArg const &arg)
    {
-      return getResult(key.arg());
+
+      auto found = _nodeNames.find(arg.namePtr());
+      if (found != _nodeNames.end())
+         return found->second;
+
+      arg.translate(*this);
+
+      return _nodeNames.at(arg.namePtr());
    }
 
-   /// @brief Checks if the current node has a result string already assigned.
-   /// @param key The node to get the result string for.
-   /// @return True if the node was assigned a result string, false otherwise.
-   inline bool isResultAssigned(RooAbsArg const *key) const
+   template <class T>
+   std::string const &getResult(RooTemplateProxy<T> const &key)
    {
-      return _nodeNames.find(key->namePtr()) != _nodeNames.end();
+      return getResult(key.arg());
    }
 
    /// @brief Adds the given string to the string block that will be emitted at the top of the squashed function. Useful
@@ -113,7 +115,7 @@ public:
    /// The arguments can either be doubles or some RooFit arguments whose
    /// results will be looked up in the context.
    template <typename... Args_t>
-   std::string buildCall(std::string const &funcname, Args_t const &...args) const
+   std::string buildCall(std::string const &funcname, Args_t const &...args)
    {
       std::stringstream ss;
       ss << funcname << "(" << buildArgs(args...) << ")" << std::endl;
@@ -121,24 +123,24 @@ public:
    }
 
 private:
-   std::string buildArg(double x) const { return RooNumber::toString(x); }
+   std::string buildArg(double x) { return RooNumber::toString(x); }
 
    template <class T>
-   std::string buildArg(T const &arg) const
+   std::string buildArg(T const &arg)
    {
       return getResult(arg);
    }
 
-   std::string buildArgs() const { return ""; }
+   std::string buildArgs() { return ""; }
 
    template <class Arg_t>
-   std::string buildArgs(Arg_t const &arg) const
+   std::string buildArgs(Arg_t const &arg)
    {
       return buildArg(arg);
    }
 
    template <typename Arg_t, typename... Args_t>
-   std::string buildArgs(Arg_t const &arg, Args_t const &...args) const
+   std::string buildArgs(Arg_t const &arg, Args_t const &...args)
    {
       return buildArg(arg) + ", " + buildArgs(args...);
    }

--- a/roofit/roofitcore/inc/RooFuncWrapper.h
+++ b/roofit/roofitcore/inc/RooFuncWrapper.h
@@ -21,7 +21,7 @@
 
 /// @brief  A wrapper class to store a C++ function of type 'double (*)(double*, double*)'.
 /// The parameters can be accessed as params[<relative position of param in paramSet>] in the function body.
-/// The observables can be accessed as obs[i * num_entries + j], where i represents the observable position and j
+/// The observables can be accessed as obs[i + j], where i represents the observable position and j
 /// represents the data entry.
 class RooFuncWrapper final : public RooAbsReal {
 public:
@@ -47,6 +47,8 @@ protected:
 private:
    std::string
    buildCode(RooAbsReal const &head, RooArgSet const & /* paramSet */, RooArgSet const &obsSet, const RooAbsData *data);
+
+   void BuildCodeRecur(RooFit::Detail::CodeSquashContext &ctx, RooAbsReal const &head);
 
    void updateGradientVarBuffer() const;
 

--- a/roofit/roofitcore/inc/RooFuncWrapper.h
+++ b/roofit/roofitcore/inc/RooFuncWrapper.h
@@ -48,8 +48,6 @@ private:
    std::string
    buildCode(RooAbsReal const &head, RooArgSet const & /* paramSet */, RooArgSet const &obsSet, const RooAbsData *data);
 
-   void BuildCodeRecur(RooFit::Detail::CodeSquashContext &ctx, RooAbsReal const &head);
-
    void updateGradientVarBuffer() const;
 
    void

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -2499,3 +2499,21 @@ std::unique_ptr<RooAbsArg> RooAbsArg::compileForNormSet(RooArgSet const & normSe
    ctx.compileServers(*newArg, normSet);
    return newArg;
 }
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// This function defines a translation for each RooAbsReal based object that can be used
+/// to express the class as simple C++ code. The function adds the code represented by
+/// each class as an std::string (that is later concatenated with code strings from translate calls)
+/// to form the C++ code that AD tools can understand. Any class that wants to support AD, has to
+/// implement this function.
+///
+/// \param[in] ctx An object to manage auxilary information for code-squashing. Also takes the
+/// code string that this class outputs into the squashed code through the 'addToCodeBody' function.
+void RooAbsArg::translate(RooFit::Detail::CodeSquashContext & /*ctx*/) const
+{
+   std::stringstream errorMsg;
+   errorMsg << "Translate function for class \"" << ClassName() << "\" has not yet been implemented.";
+   coutE(Minimization) << errorMsg.str() << std::endl;
+   throw std::runtime_error(errorMsg.str().c_str());
+}

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -4726,23 +4726,6 @@ void RooAbsReal::computeBatch(cudaStream_t*, double* output, size_t nEvents, Roo
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// This function defines a translation for each RooAbsReal based object that can be used
-/// to express the class as simple C++ code. The function adds the code represented by
-/// each class as an std::string (that is later concatenated with code strings from translate calls)
-/// to form the C++ code that AD tools can understand. Any class that wants to support AD, has to
-/// implement this function.
-///
-/// \param[in] ctx An object to manage auxilary information for code-squashing. Also takes the
-/// code string that this class outputs into the squashed code through the 'addToCodeBody' function.
-void RooAbsReal::translate(RooFit::Detail::CodeSquashContext & /*ctx*/) const
-{
-   std::stringstream errorMsg;
-   errorMsg << "Translate function for class " << GetName() << " has not yet been implemented.";
-   coutE(Minimization) << errorMsg.str() << std::endl;
-   throw std::runtime_error(errorMsg.str().c_str());
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// This function defines the analytical integral translation for the class.
 ///
 /// \param[in] code The code that decides the integrands.
@@ -4754,23 +4737,7 @@ std::string RooAbsReal::buildCallToAnalyticIntegral(Int_t /* code */, const char
                                                     RooFit::Detail::CodeSquashContext & /*ctx*/) const
 {
    std::stringstream errorMsg;
-   errorMsg << "An analytical integral function for class " << GetName() << " has not yet been implemented.";
-   coutE(Minimization) << errorMsg.str() << std::endl;
-   throw std::runtime_error(errorMsg.str().c_str());
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// This function defines how to build the beginning of a loop. Only applicable
-/// to classes/objects that produce loops (i.e. are reducer nodes).
-///
-/// \param[in] ctx An object to manage auxilary information for code-squashing.
-/// Also takes the code string that this class outputs into the squashed code
-/// through the 'addToCodeBody' function.
-void RooAbsReal::buildLoopBegin(RooFit::Detail::CodeSquashContext & /* ctx */) const
-{
-   std::stringstream errorMsg;
-   errorMsg << "Class " << GetName()
-            << "does not yet define how to build a loop begining despite being a reducer node.";
+   errorMsg << "An analytical integral function for class \"" << ClassName() << "\" has not yet been implemented.";
    coutE(Minimization) << errorMsg.str() << std::endl;
    throw std::runtime_error(errorMsg.str().c_str());
 }

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -4759,6 +4759,22 @@ std::string RooAbsReal::buildCallToAnalyticIntegral(Int_t /* code */, const char
    throw std::runtime_error(errorMsg.str().c_str());
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// This function defines how to build the beginning of a loop. Only applicable
+/// to classes/objects that produce loops (i.e. are reducer nodes).
+///
+/// \param[in] ctx An object to manage auxilary information for code-squashing.
+/// Also takes the code string that this class outputs into the squashed code
+/// through the 'addToCodeBody' function.
+void RooAbsReal::buildLoopBegin(RooFit::Detail::CodeSquashContext & /* ctx */) const
+{
+   std::stringstream errorMsg;
+   errorMsg << "Class " << GetName()
+            << "does not yet define how to build a loop begining despite being a reducer node.";
+   coutE(Minimization) << errorMsg.str() << std::endl;
+   throw std::runtime_error(errorMsg.str().c_str());
+}
+
 double RooAbsReal::_DEBUG_getVal(const RooArgSet* normalisationSet) const {
 
   const bool tmpFast = _fast;

--- a/roofit/roofitcore/src/RooFuncWrapper.cxx
+++ b/roofit/roofitcore/src/RooFuncWrapper.cxx
@@ -232,26 +232,5 @@ std::string RooFuncWrapper::buildCode(RooAbsReal const &head, RooArgSet const & 
          ctx.addResult(weightName, "1");
    }
 
-   BuildCodeRecur(ctx, head);
-
    return ctx.assembleCode(ctx.getResult(head));
-}
-
-void RooFuncWrapper::BuildCodeRecur(RooFit::Detail::CodeSquashContext &ctx, RooAbsReal const &head)
-{
-   if (head.isReducerNode())
-      head.buildLoopBegin(ctx);
-
-   for (auto pcurr : head.servers()) {
-      RooAbsReal *curr = dynamic_cast<RooAbsReal *>(pcurr);
-      if (!curr) {
-         std::stringstream errorMsg;
-         errorMsg << "Translate is only supported for RooAbsReal derived objects.";
-         oocoutE(nullptr, Minimization) << errorMsg.str() << std::endl;
-         throw std::runtime_error(errorMsg.str().c_str());
-      }
-      BuildCodeRecur(ctx, *curr);
-   }
-
-   head.translate(ctx);
 }

--- a/roofit/roofitcore/src/RooNLLVarNew.cxx
+++ b/roofit/roofitcore/src/RooNLLVarNew.cxx
@@ -78,8 +78,11 @@ RooRealVar *dummyVar(const char *name)
 **/
 RooNLLVarNew::RooNLLVarNew(const char *name, const char *title, RooAbsPdf &pdf, RooArgSet const &observables,
                            bool isExtended, RooFit::OffsetMode offsetMode)
-   : RooAbsReal(name, title), _pdf{"pdf", "pdf", this, pdf}, _observables{getObs(pdf, observables)},
-     _isExtended{isExtended}, _binnedL{pdf.getAttribute("BinnedLikelihoodActive")},
+   : RooAbsReal(name, title),
+     _pdf{"pdf", "pdf", this, pdf},
+     _observables{getObs(pdf, observables)},
+     _isExtended{isExtended},
+     _binnedL{pdf.getAttribute("BinnedLikelihoodActive")},
      _weightVar{"weightVar", "weightVar", this, *dummyVar(weightVarName), true, false, true},
      _weightSquaredVar{weightVarNameSumW2, weightVarNameSumW2, this, *dummyVar("weightSquardVar"), true, false, true},
      _binVolumeVar{"binVolumeVar", "binVolumeVar", this, *dummyVar("_bin_volume"), true, false, true}
@@ -94,11 +97,17 @@ RooNLLVarNew::RooNLLVarNew(const char *name, const char *title, RooAbsPdf &pdf, 
 }
 
 RooNLLVarNew::RooNLLVarNew(const RooNLLVarNew &other, const char *name)
-   : RooAbsReal(other, name), _pdf{"pdf", this, other._pdf}, _observables{other._observables},
-     _isExtended{other._isExtended}, _weightSquared{other._weightSquared}, _binnedL{other._binnedL},
-     _doOffset{other._doOffset}, _simCount{other._simCount}, _prefix{other._prefix},
-     _weightVar{"weightVar", this, other._weightVar}, _weightSquaredVar{"weightSquaredVar", this,
-                                                                        other._weightSquaredVar}
+   : RooAbsReal(other, name),
+     _pdf{"pdf", this, other._pdf},
+     _observables{other._observables},
+     _isExtended{other._isExtended},
+     _weightSquared{other._weightSquared},
+     _binnedL{other._binnedL},
+     _doOffset{other._doOffset},
+     _simCount{other._simCount},
+     _prefix{other._prefix},
+     _weightVar{"weightVar", this, other._weightVar},
+     _weightSquaredVar{"weightSquaredVar", this, other._weightSquaredVar}
 {
 }
 
@@ -290,22 +299,6 @@ double RooNLLVarNew::finalizeResult(ROOT::Math::KahanSum<double> &&result, doubl
 
 void RooNLLVarNew::translate(RooFit::Detail::CodeSquashContext &ctx) const
 {
-   std::string className = GetName();
-   std::string resName = className + "Result";
-   ctx.addResult(this, resName);
-   ctx.addToGlobalScope("double " + resName + " = 0;\n");
-
-   std::string tmpName = className + "Temp";
-   std::string code = "double " + tmpName + ";\n";
-   code += tmpName + " = std::log(" + ctx.getResult(_pdf.arg()) + ");\n";
-   code += resName + " -= " + ctx.getResult(_weightVar.arg()) + " * " + tmpName + ";\n";
-   ctx.addToCodeBody(code);
-   // Close the loop
-   ctx.addToCodeBody("}\n");
-}
-
-void RooNLLVarNew::buildLoopBegin(RooFit::Detail::CodeSquashContext &ctx) const
-{
    std::string loopIdx = GetName();
    loopIdx += "_i";
    for (auto *it : _observables) {
@@ -325,4 +318,17 @@ void RooNLLVarNew::buildLoopBegin(RooFit::Detail::CodeSquashContext &ctx) const
    // Here numEntries is a 'key' word defined by the upper level code squasher.
    ctx.addToCodeBody("for(int " + loopIdx + " = 0; " + loopIdx + " < " + std::to_string(ctx.numEntries) + "; " +
                      loopIdx + "++) {\n");
+
+   std::string className = GetName();
+   std::string resName = className + "Result";
+   ctx.addResult(this, resName);
+   ctx.addToGlobalScope("double " + resName + " = 0;\n");
+
+   std::string tmpName = className + "Temp";
+   std::string code = "double " + tmpName + ";\n";
+   code += tmpName + " = std::log(" + ctx.getResult(_pdf.arg()) + ");\n";
+   code += resName + " -= " + ctx.getResult(_weightVar.arg()) + " * " + tmpName + ";\n";
+   ctx.addToCodeBody(code);
+   // Close the loop
+   ctx.addToCodeBody("}\n");
 }

--- a/roofit/roofitcore/src/RooNLLVarNew.cxx
+++ b/roofit/roofitcore/src/RooNLLVarNew.cxx
@@ -299,36 +299,23 @@ double RooNLLVarNew::finalizeResult(ROOT::Math::KahanSum<double> &&result, doubl
 
 void RooNLLVarNew::translate(RooFit::Detail::CodeSquashContext &ctx) const
 {
-   std::string loopIdx = GetName();
-   loopIdx += "_i";
-   for (auto *it : _observables) {
-      int startIdx = ctx.getVecObsStartIdx(it);
-      if (startIdx == -1)
-         continue;
-      std::string const &varName = ctx.getResult(*it);
-      // create the obs[start + loopIdx] expression.
-      ctx.addResult(it, varName + "[" + std::to_string(startIdx) + " + " + loopIdx + "]");
-   }
-   // Also add weights
-   RooAbsArg const *weights = &_weightVar.arg();
-   std::string const &weightName = ctx.getResult(*weights);
-   if (weightName != "1")
-      ctx.addResult(weights, weightName + "[" + std::to_string(ctx.getVecObsStartIdx(weights)) + " + " + loopIdx + "]");
-
-   // Here numEntries is a 'key' word defined by the upper level code squasher.
-   ctx.addToCodeBody("for(int " + loopIdx + " = 0; " + loopIdx + " < " + std::to_string(ctx.numEntries) + "; " +
-                     loopIdx + "++) {\n");
-
    std::string className = GetName();
    std::string resName = className + "Result";
    ctx.addResult(this, resName);
    ctx.addToGlobalScope("double " + resName + " = 0;\n");
 
-   std::string tmpName = className + "Temp";
-   std::string code = "double " + tmpName + ";\n";
-   code += tmpName + " = std::log(" + ctx.getResult(_pdf.arg()) + ");\n";
-   code += resName + " -= " + ctx.getResult(_weightVar.arg()) + " * " + tmpName + ";\n";
-   ctx.addToCodeBody(code);
-   // Close the loop
-   ctx.addToCodeBody("}\n");
+   RooArgSet loopVars{_observables, *_weightVar};
+
+   // Begin loop scope for the observables and weight variable. If the weight
+   // is a scalar, the context will ignore it for the loop scope. The closing
+   // brackets of the loop is written at the end of the scopes lifetime.
+   {
+      auto scope = ctx.beginLoop(loopVars);
+
+      std::string tmpName = className + "Temp";
+      std::string code = "double " + tmpName + ";\n";
+      code += tmpName + " = std::log(" + ctx.getResult(_pdf.arg()) + ");\n";
+      code += resName + " -= " + ctx.getResult(_weightVar.arg()) + " * " + tmpName + ";\n";
+      ctx.addToCodeBody(code);
+   }
 }

--- a/roofit/roofitcore/src/RooNLLVarNew.h
+++ b/roofit/roofitcore/src/RooNLLVarNew.h
@@ -58,6 +58,10 @@ public:
 
    void setSimCount(int simCount) { _simCount = simCount; }
 
+   void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
+
+   void buildLoopBegin(RooFit::Detail::CodeSquashContext &ctx) const override;
+
 private:
    double evaluate() const override { return _value; }
    void resetWeightVarNames();

--- a/roofit/roofitcore/src/RooNLLVarNew.h
+++ b/roofit/roofitcore/src/RooNLLVarNew.h
@@ -60,8 +60,6 @@ public:
 
    void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
 
-   void buildLoopBegin(RooFit::Detail::CodeSquashContext &ctx) const override;
-
 private:
    double evaluate() const override { return _value; }
    void resetWeightVarNames();

--- a/roofit/roofitcore/src/RooRealVar.cxx
+++ b/roofit/roofitcore/src/RooRealVar.cxx
@@ -85,8 +85,7 @@ void RooRealVar::cleanup()
 
 void RooRealVar::translate(RooFit::Detail::CodeSquashContext &ctx) const
 {
-   if (!ctx.isResultAssigned(this))
-      ctx.addResult(this, GetName());
+   ctx.addResult(this, GetName());
 }
 
 /// Return a dummy object to use when properties are not initialised.

--- a/roofit/roofitcore/test/testRooFuncWrapper.cxx
+++ b/roofit/roofitcore/test/testRooFuncWrapper.cxx
@@ -15,6 +15,7 @@
 #include <RooAddition.h>
 #include <RooConstVar.h>
 #include <RooDataSet.h>
+#include <RooDataHist.h>
 #include <RooFitResult.h>
 #include <RooExponential.h>
 #include <RooFuncWrapper.h>
@@ -106,9 +107,6 @@ TEST(RooFuncWrapper, NllWithObservables)
    RooRealVar mu("mu", "mu", 0, -10, 10);
    RooRealVar sigma("sigma", "sigma", 2.0, 0.01, 10);
    RooGaussian gauss{"gauss", "gauss", x, mu, sigma};
-
-   mu.setError(2);
-   sigma.setError(1);
 
    RooArgSet normSet{x};
 
@@ -258,4 +256,91 @@ TEST(RooFuncWrapper, Exponential)
       EXPECT_NEAR(getNumDerivative(expo, static_cast<RooRealVar &>(*params[i]), normSet), dExpo[i], 1e-8)
          << params[i]->GetName();
    }
+}
+
+TEST(RooFuncWrapper, Nll)
+{
+   RooRealVar x("x", "x", 0, -10, 10);
+
+   RooRealVar mu("mu", "mu", 0, -10, 10);
+   RooRealVar shift("shift", "shift", 1.0, -10, 10);
+   RooAddition muShifted("mu_shifted", "mu_shifted", {mu, shift});
+
+   RooRealVar sigma("sigma", "sigma", 2.0, 0.01, 10);
+   RooConstVar scale("scale", "scale", 1.5);
+   RooProduct sigmaScaled("sigma_scaled", "sigma_scaled", sigma, scale);
+
+   RooGaussian gauss{"gauss", "gauss", x, muShifted, sigmaScaled};
+
+   RooArgSet normSet{x};
+
+   std::size_t nEvents = 10;
+   std::unique_ptr<RooDataSet> data0{gauss.generate(x, nEvents)};
+   std::unique_ptr<RooAbsData> data{data0->binnedClone()};
+   std::unique_ptr<RooAbsReal> nllRef{gauss.createNLL(*data, RooFit::BatchMode("cpu"))};
+   auto nllRefResolved = static_cast<RooAbsReal *>(nllRef->servers()[0]);
+
+   RooFuncWrapper nllFunc("myNll", "myNll", *nllRefResolved, normSet, data.get());
+
+   // Check if functions results are the same even after changing parameters.
+   EXPECT_NEAR(nllRef->getVal(normSet), nllFunc.getVal(), 1e-8);
+
+   mu.setVal(1);
+   EXPECT_NEAR(nllRef->getVal(normSet), nllFunc.getVal(), 1e-8);
+
+   // Check if the parameter layout and size is the same.
+   RooArgSet paramsRefNll;
+   nllRef->getParameters(nullptr, paramsRefNll);
+   RooArgSet paramsMyNLL;
+   nllFunc.getParameters(&normSet, paramsMyNLL);
+
+   EXPECT_TRUE(paramsMyNLL.hasSameLayout(paramsRefNll));
+   EXPECT_EQ(paramsMyNLL.size(), paramsRefNll.size());
+
+   // Get AD based derivative
+   double dMyNLL[2] = {};
+   nllFunc.getGradient(dMyNLL);
+
+   // Check if derivatives are equal
+   for (std::size_t i = 0; i < paramsMyNLL.size(); ++i) {
+      EXPECT_NEAR(getNumDerivative(*nllRef, static_cast<RooRealVar &>(*paramsMyNLL[i]), normSet), dMyNLL[i], 1e-6);
+   }
+
+   // Remember parameter state before minimization
+   RooArgSet parametersOrig;
+   paramsRefNll.snapshot(parametersOrig);
+
+   auto runMinimizer = [&](RooAbsReal &absReal, RooMinimizer::Config cfg = {}) -> std::unique_ptr<RooFitResult> {
+      RooMinimizer m{absReal, cfg};
+      m.setPrintLevel(-1);
+      m.setStrategy(0);
+      m.minimize("Minuit2");
+      auto result = std::unique_ptr<RooFitResult>{m.save()};
+      // reset parameters
+      paramsRefNll.assign(parametersOrig);
+      return result;
+   };
+
+   // Minimize the RooFuncWrapper Implementation
+   auto result = runMinimizer(nllFunc);
+
+   // Minimize the RooFuncWrapper Implementation with AD
+   RooMinimizer::Config minimizerCfgAd;
+   std::size_t nGradientCalls = 0;
+   minimizerCfgAd.gradFunc = [&](double *out) {
+      nllFunc.getGradient(out);
+      ++nGradientCalls;
+   };
+   auto resultAd = runMinimizer(nllFunc, minimizerCfgAd);
+   EXPECT_GE(nGradientCalls, 1); // make sure the gradient function was actually called
+
+   // Minimize the reference NLL
+   auto resultRef = runMinimizer(*nllRef);
+
+   // Compare minimization results
+   // TODO: the (global) correlation coefficients are still wrong. This needs
+   // to be understood next, and then we can also use the regular
+   // isIdentical().
+   EXPECT_TRUE(result->isIdenticalNoCov(*resultRef, 1e-3));
+   EXPECT_TRUE(resultAd->isIdenticalNoCov(*resultRef, 1e-3));
 }


### PR DESCRIPTION
This commit adds support for using RooNllVarNew in code-squashing/AD. It also adds a new test that uses code-squashing and AD based derivatives to minimize a simple model.