### PR TITLE
[RF][HS3] Correct support for combined datasets and simultaneous pdfs

### DIFF
--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -116,41 +116,6 @@ public:
 
    static void error(const char *s);
    inline static void error(const std::string &s) { error(s.c_str()); }
-   template <class T>
-   static std::string concat(const T *items, const std::string &sep = ",")
-   {
-      // Returns a string being the concatenation of strings in input list <items>
-      // (names of objects obtained using GetName()) separated by string <sep>.
-      bool first = true;
-      std::string text;
-
-      // iterate over strings in list
-      for (auto it : *items) {
-         if (!first) {
-            // insert separator string
-            text += sep;
-         } else {
-            first = false;
-         }
-         if (!it)
-            text += "nullptr";
-         else
-            text += it->GetName();
-      }
-      return text;
-   }
-   template <class T>
-   static std::vector<std::string> names(T const &items)
-   {
-      // Returns a string being the concatenation of strings in input list <items>
-      // (names of objects obtained using GetName()) separated by string <sep>.
-      std::vector<std::string> names;
-      // iterate over strings in list
-      for (auto it : items) {
-         names.push_back(it ? it->GetName() : "nullptr");
-      }
-      return names;
-   }
 
    static void exportHistogram(const TH1 &h, RooFit::Detail::JSONNode &n, const std::vector<std::string> &obsnames,
                                const TH1 *errH = nullptr, bool writeObservables = true, bool writeErrors = true);
@@ -202,6 +167,8 @@ public:
 
    static void writeChannelNames(RooFit::Detail::JSONNode &rootnode, std::string const &simPdfName,
                                  std::vector<std::string> const &channelNames);
+
+   static void exportDataHist(RooDataHist const &dataHist, RooFit::Detail::JSONNode &node);
 
 private:
    struct Config {

--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -211,7 +211,7 @@ private:
    template <class T>
    T *requestImpl(const std::string &objname);
 
-   void exportData(RooAbsData &data);
+   void exportData(RooAbsData const &data);
 
    void importAllNodes(const RooFit::Detail::JSONNode &n);
 

--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -165,10 +165,9 @@ public:
    static void
    writeCombinedDataName(RooFit::Detail::JSONNode &rootnode, std::string const &pdfName, std::string const &dataName);
 
-   static void writeChannelNames(RooFit::Detail::JSONNode &rootnode, std::string const &simPdfName,
-                                 std::vector<std::string> const &channelNames);
-
    static void exportDataHist(RooDataHist const &dataHist, RooFit::Detail::JSONNode &node);
+
+   static void exportCategory(RooAbsCategory const &cat, RooFit::Detail::JSONNode &node);
 
 private:
    struct Config {

--- a/roofit/hs3/src/HistFactoryJSONTool.cxx
+++ b/roofit/hs3/src/HistFactoryJSONTool.cxx
@@ -221,11 +221,7 @@ void exportMeasurement(RooStats::HistFactory::Measurement &measurement, JSONNode
    }
 
    // the data
-   auto &miscinfo = n["misc"];
-   miscinfo.set_map();
-   auto &rootinfo = miscinfo["ROOT_internal"];
-   rootinfo.set_map();
-   auto &child = RooJSONFactoryWSTool::appendNamedChild(rootinfo["combined_datasets"], "obsData");
+   auto &child = RooJSONFactoryWSTool::appendNamedChild(n.get("misc", "ROOT_internal", "combined_datasets"), "obsData");
    child["index_cat"] << "channelCat";
    auto &labels = child["labels"];
    labels.set_seq();

--- a/roofit/hs3/src/HistFactoryJSONTool.cxx
+++ b/roofit/hs3/src/HistFactoryJSONTool.cxx
@@ -221,8 +221,22 @@ void exportMeasurement(RooStats::HistFactory::Measurement &measurement, JSONNode
    }
 
    // the data
+   auto &miscinfo = n["misc"];
+   miscinfo.set_map();
+   auto &rootinfo = miscinfo["ROOT_internal"];
+   rootinfo.set_map();
+   auto &child = RooJSONFactoryWSTool::appendNamedChild(rootinfo["combined_datasets"], "obsData");
+   child["index_cat"] << "channelCat";
+   auto &labels = child["labels"];
+   labels.set_seq();
+   auto &indices = child["indices"];
+   indices.set_seq();
+
    std::vector<std::string> channelNames;
    for (const auto &c : measurement.GetChannels()) {
+      labels.append_child() << c.GetName();
+      indices.append_child() << int(channelNames.size());
+
       JSONNode &dataOutput = RooJSONFactoryWSTool::appendNamedChild(n["data"], std::string("obsData_") + c.GetName());
 
       const std::vector<std::string> obsnames = getObsnames(c);

--- a/roofit/hs3/src/HistFactoryJSONTool.cxx
+++ b/roofit/hs3/src/HistFactoryJSONTool.cxx
@@ -150,7 +150,7 @@ void exportMeasurement(RooStats::HistFactory::Measurement &measurement, JSONNode
 
    auto &pdflist = n["distributions"];
 
-   auto &analysisNode = RooJSONFactoryWSTool::appendNamedChild(n["analyses"], measurement.GetName());
+   auto &analysisNode = RooJSONFactoryWSTool::appendNamedChild(n["analyses"], "simPdf");
    analysisNode.set_map();
    analysisNode["InterpolationScheme"] << measurement.GetInterpolationScheme();
    auto &analysisDomains = analysisNode["domains"];
@@ -221,17 +221,31 @@ void exportMeasurement(RooStats::HistFactory::Measurement &measurement, JSONNode
    }
 
    // the data
-   auto &child = RooJSONFactoryWSTool::appendNamedChild(n.get("misc", "ROOT_internal", "combined_datasets"), "obsData");
-   child["index_cat"] << "channelCat";
-   auto &labels = child["labels"];
-   labels.set_seq();
-   auto &indices = child["indices"];
-   indices.set_seq();
+   auto &child1 = RooJSONFactoryWSTool::appendNamedChild(n.get("misc", "ROOT_internal", "combined_datas"), "obsData");
+   auto &child2 =
+      RooJSONFactoryWSTool::appendNamedChild(n.get("misc", "ROOT_internal", "combined_distributions"), "simPdf");
+
+   child1["index_cat"] << "channelCat";
+   auto &labels1 = child1["labels"];
+   labels1.set_seq();
+   auto &indices1 = child1["indices"];
+   indices1.set_seq();
+
+   child2["index_cat"] << "channelCat";
+   auto &labels2 = child2["labels"];
+   labels2.set_seq();
+   auto &indices2 = child2["indices"];
+   indices2.set_seq();
+   auto &pdfs2 = child2["distributions"];
+   pdfs2.set_seq();
 
    std::vector<std::string> channelNames;
    for (const auto &c : measurement.GetChannels()) {
-      labels.append_child() << c.GetName();
-      indices.append_child() << int(channelNames.size());
+      labels1.append_child() << c.GetName();
+      indices1.append_child() << int(channelNames.size());
+      labels2.append_child() << c.GetName();
+      indices2.append_child() << int(channelNames.size());
+      pdfs2.append_child() << (std::string("model_") + c.GetName());
 
       JSONNode &dataOutput = RooJSONFactoryWSTool::appendNamedChild(n["data"], std::string("obsData_") + c.GetName());
 
@@ -245,8 +259,7 @@ void exportMeasurement(RooStats::HistFactory::Measurement &measurement, JSONNode
       channelNames.push_back(c.GetName());
    }
 
-   RooJSONFactoryWSTool::writeCombinedDataName(n, measurement.GetName(), "obsData");
-   RooJSONFactoryWSTool::writeChannelNames(n, measurement.GetName(), channelNames);
+   RooJSONFactoryWSTool::writeCombinedDataName(n, "simPdf", "obsData");
 }
 
 } // namespace

--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -324,16 +324,11 @@ public:
       static const std::string keystring = "histogram";
       return keystring;
    }
-   bool exportObject(RooJSONFactoryWSTool *, const RooAbsArg *func, JSONNode &elem) const override
+   bool exportObject(RooJSONFactoryWSTool *tool, const RooAbsArg *func, JSONNode &elem) const override
    {
       const RooHistFunc *hf = static_cast<const RooHistFunc *>(func);
       elem["type"] << key();
-      std::unique_ptr<RooArgSet> vars{hf->getVariables()};
-      std::unique_ptr<TH1> hist{hf->createHistogram(RooJSONFactoryWSTool::concat(vars.get()))};
-      if (!hist)
-         return false;
-      auto &data = elem["data"];
-      RooJSONFactoryWSTool::exportHistogram(*hist, data, RooJSONFactoryWSTool::names(*vars));
+      tool->exportDataHist(hf->dataHist(), elem["data"]);
       return true;
    }
 };
@@ -359,16 +354,11 @@ public:
       static const std::string keystring = "histogram_dist";
       return keystring;
    }
-   bool exportObject(RooJSONFactoryWSTool *, const RooAbsArg *func, JSONNode &elem) const override
+   bool exportObject(RooJSONFactoryWSTool *tool, const RooAbsArg *func, JSONNode &elem) const override
    {
       const RooHistPdf *hf = static_cast<const RooHistPdf *>(func);
       elem["type"] << key();
-      std::unique_ptr<RooArgSet> vars{hf->getVariables()};
-      std::unique_ptr<TH1> hist{hf->createHistogram(RooJSONFactoryWSTool::concat(vars.get()))};
-      if (!hist)
-         return false;
-      auto &data = elem["data"];
-      RooJSONFactoryWSTool::exportHistogram(*hist, data, RooJSONFactoryWSTool::names(*vars));
+      tool->exportDataHist(hf->dataHist(), elem["data"]);
       return true;
    }
 };

--- a/roofit/hs3/test/testHS3HistFactory.cxx
+++ b/roofit/hs3/test/testHS3HistFactory.cxx
@@ -136,7 +136,7 @@ TEST(TestHS3HistFactoryJSON, Closure)
    RooAbsPdf *pdf = mc->GetPdf();
    EXPECT_TRUE(pdf != nullptr);
 
-   RooAbsPdf *pdfFromJson = wsFromJson.pdf(meas->GetName());
+   RooAbsPdf *pdfFromJson = mcFromJson->GetPdf();
    EXPECT_TRUE(pdfFromJson != nullptr);
 
    RooAbsData *data = ws->data("obsData");

--- a/roofit/hs3/test/testHS3HistFactory.cxx
+++ b/roofit/hs3/test/testHS3HistFactory.cxx
@@ -181,9 +181,6 @@ TEST(TestHS3HistFactoryJSON, ClosureLoop)
    RooAbsPdf *pdf = mc->GetPdf();
    EXPECT_TRUE(pdf != nullptr);
 
-   // For now, this is the way to tell the JSONIO what the combined datasets are
-   pdf->setStringAttribute("combined_data_name", "obsData");
-
    std::string const &js = RooJSONFactoryWSTool{*ws}.exportJSONtoString();
    if (writeJsonFiles) {
       RooJSONFactoryWSTool{*ws}.exportJSON("hf2.json");

--- a/roofit/hs3/test/testHS3SimultaneousFit.cxx
+++ b/roofit/hs3/test/testHS3SimultaneousFit.cxx
@@ -61,12 +61,9 @@ std::unique_ptr<RooFitResult> writeJSONAndFitModel(std::string &jsonStr)
    x1.setBins(20);
    x2.setBins(20);
 
-   RooAbsPdf &model_1 = *ws.pdf("model_1");
-   RooAbsPdf &model_2 = *ws.pdf("model_2");
-
    std::map<std::string, std::unique_ptr<RooAbsData>> datas;
-   datas["channel_1"] = std::unique_ptr<RooDataHist>{model_1.generateBinned(x1)};
-   datas["channel_2"] = std::unique_ptr<RooDataHist>{model_2.generateBinned(x2)};
+   datas["channel_1"] = std::unique_ptr<RooDataHist>{ws.pdf("model_1")->generateBinned(x1)};
+   datas["channel_2"] = std::unique_ptr<RooDataHist>{ws.pdf("model_2")->generateBinned(x2)};
 
    datas["channel_1"]->SetName("obsData_channel_1");
    datas["channel_2"]->SetName("obsData_channel_2");
@@ -76,9 +73,6 @@ std::unique_ptr<RooFitResult> writeJSONAndFitModel(std::string &jsonStr)
 
    auto &pdf = *ws.pdf("simPdf");
    auto &data = *ws.data("obsData");
-
-   // For now, this is the way to tell the JSONIO what the combined datasets are
-   pdf.setStringAttribute("combined_data_name", data.GetName());
 
    // Export before fitting to keep the prefit values
    jsonStr = RooJSONFactoryWSTool{ws}.exportJSONtoString();

--- a/roofit/hs3/test/testRooFitHS3.cxx
+++ b/roofit/hs3/test/testRooFitHS3.cxx
@@ -191,20 +191,13 @@ TEST(RooFitHS3, RooPolynomial)
 
 TEST(RooFitHS3, SimultaneousGaussians)
 {
-   using namespace RooFit;
-
-   // Import keys and factory expressions files for the RooJSONFactoryWSTool.
-   auto etcDir = std::string(TROOT::GetEtcDir());
-   RooFit::JSONIO::loadExportKeys(etcDir + "/RooFitHS3_wsexportkeys.json");
-   RooFit::JSONIO::loadFactoryExpressions(etcDir + "/RooFitHS3_wsfactoryexpressions.json");
-
    // Create a test model: RooSimultaneous with Gaussian in one component, and
    // product of two Gaussians in the other.
    RooRealVar x("x", "x", -8, 8);
    RooRealVar mean("mean", "mean", 0, -8, 8);
    RooRealVar sigma("sigma", "sigma", 0.3, 0.1, 10);
    RooGaussian g1("g1", "g1", x, mean, sigma);
-   RooGaussian g2("g2", "g2", x, mean, RooConst(0.3));
+   RooGaussian g2("g2", "g2", x, mean, 0.3);
    RooProdPdf model("model", "model", RooArgList{g1, g2});
    RooGaussian model_ctl("model_ctl", "model_ctl", x, mean, sigma);
    RooCategory sample("sample", "sample", {{"physics", 0}, {"control", 1}});
@@ -212,19 +205,6 @@ TEST(RooFitHS3, SimultaneousGaussians)
    simPdf.addPdf(model, "physics");
    simPdf.addPdf(model_ctl, "control");
 
-   std::string jsonString;
-
-   // Export to JSON
-   {
-      RooWorkspace ws{"workspace"};
-      ws.import(simPdf, RooFit::Silence());
-      jsonString = RooJSONFactoryWSTool{ws}.exportJSONtoString();
-   }
-
-   // Import JSON
-   RooWorkspace ws{"workspace"};
-   RooJSONFactoryWSTool{ws}.importJSONfromString(jsonString);
-
-   EXPECT_TRUE(ws.pdf("g1"));
-   EXPECT_TRUE(ws.pdf("g2"));
+   int status = validate(simPdf);
+   EXPECT_EQ(status, 0);
 }

--- a/roofit/hs3/test/testRooFitHS3.cxx
+++ b/roofit/hs3/test/testRooFitHS3.cxx
@@ -164,8 +164,8 @@ TEST(RooFitHS3, RooHistPdf)
    x.setBins(2);
 
    RooDataHist dataHist{"myDataHist", "myDataHist", x};
-   dataHist.set(0, 25.0, 5.0);
-   dataHist.set(1, 25.0, 5.0);
+   dataHist.set(0, 23, -1);
+   dataHist.set(1, 17, -1);
 
    int status = validate(RooHistPdf{"histPdf", "histPdf", x, dataHist});
    EXPECT_EQ(status, 0);
@@ -211,9 +211,6 @@ TEST(RooFitHS3, SimultaneousGaussians)
    RooSimultaneous simPdf("simPdf", "simultaneous pdf", sample);
    simPdf.addPdf(model, "physics");
    simPdf.addPdf(model_ctl, "control");
-
-   // this is a handy way of triggering the creation of a ModelConfig upon re-import
-   simPdf.setAttribute("toplevel");
 
    std::string jsonString;
 

--- a/roofit/jsoninterface/inc/RooFit/Detail/JSONInterface.h
+++ b/roofit/jsoninterface/inc/RooFit/Detail/JSONInterface.h
@@ -146,6 +146,33 @@ public:
          }
       }
    }
+
+   JSONNode const *find(std::string const &key) const
+   {
+      auto &n = *this;
+      return n.has_child(key) ? &n[key] : nullptr;
+   }
+
+   template <typename... Keys_t>
+   JSONNode const *find(std::string const &key, Keys_t const &...keys) const
+   {
+      auto &n = *this;
+      return n.has_child(key) ? n[key].find(keys...) : nullptr;
+   }
+
+   JSONNode &get(std::string const &key)
+   {
+      auto &n = *this;
+      return n[key];
+   }
+
+   template <typename... Keys_t>
+   JSONNode &get(std::string const &key, Keys_t const &...keys)
+   {
+      auto &next = get(key);
+      next.set_map();
+      return next.get(keys...);
+   }
 };
 
 class JSONTree {

--- a/tutorials/roofit/rf515_hfJSON.json
+++ b/tutorials/roofit/rf515_hfJSON.json
@@ -7,7 +7,19 @@
         },
         "channel_names" : {
             "main": ["channel1"]
-        }
+        },
+        "combined_datasets": [
+            {
+                "index_cat": "channelCat",
+                "indices": [
+                    0
+                ],
+                "labels": [
+                    "channel1"
+                ],
+                "name": "observed"
+            }
+        ]
     }},
     "analyses": [
         {

--- a/tutorials/roofit/rf515_hfJSON.json
+++ b/tutorials/roofit/rf515_hfJSON.json
@@ -1,36 +1,38 @@
 {
-    "misc" : { "ROOT_internal" : {
-        "ModelConfigs" : {
-            "main": {
-                "combined_data_name": "observed"
-            }
-        },
-        "channel_names" : {
-            "main": ["channel1"]
-        },
-        "combined_datasets": [
-            {
-                "index_cat": "channelCat",
-                "indices": [
-                    0
-                ],
-                "labels": [
-                    "channel1"
-                ],
-                "name": "observed"
-            }
-        ]
-    }},
+    "misc": {
+        "ROOT_internal": {
+            "ModelConfigs": {
+                "main": {
+                    "combined_data_name": "observed"
+                }
+            },
+            "combined_datas": [
+                {
+                    "index_cat": "channelCat",
+                    "indices": [0],
+                    "labels": ["channel1"],
+                    "name": "observed"
+                }
+            ],
+            "combined_distributions": [
+                {
+                    "distributions": [
+                        "model_channel1"
+                    ],
+                    "index_cat": "channelCat",
+                    "indices": [0],
+                    "labels": ["channel1"],
+                    "name": "main"
+                }
+            ]
+        }
+    },
     "analyses": [
         {
             "name": "main",
             "likelihood": "main_likelihood",
-            "pois": [
-                "mu"
-            ],
-            "observables": [
-                "obs_x_channel1"
-            ]
+            "pois": ["mu"],
+            "observables": ["obs_x_channel1"]
         }
     ],
     "likelihoods": [

--- a/tutorials/roofit/rf515_hfJSON.json
+++ b/tutorials/roofit/rf515_hfJSON.json
@@ -1,11 +1,6 @@
 {
     "misc": {
         "ROOT_internal": {
-            "ModelConfigs": {
-                "main": {
-                    "combined_data_name": "observed"
-                }
-            },
             "combined_datas": [
                 {
                     "index_cat": "channelCat",


### PR DESCRIPTION
Put all the information necessary in the JSON to correctly reconstruct combined datasets and simultaneous pdfs.

Also, fix the export of `RooHistPdf` and `RooHistFunc` to not normalize the content of the template histograms, which can cause numerical precision problems.

More details in the commit descriptions.