### PR TITLE
[CI] Change artifact upload heuristics and do clean builds on push

### DIFF
--- a/.github/workflows/root-ci-config/build_root.py
+++ b/.github/workflows/root-ci-config/build_root.py
@@ -134,7 +134,7 @@ def main():
 
         shell_log = run_ctest(shell_log, extra_ctest_flags)
 
-    if CONNECTION:
+    if not pull_request and not args.incremenetal:
         archive_and_upload(yyyy_mm_dd, obj_prefix)
 
     print_shell_log(shell_log)

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -126,7 +126,7 @@ jobs:
         run: ".github/workflows/root-ci-config/build_root.py
                     --buildtype      ${{ matrix.config }}
                     --platform       ${{ matrix.platform }}
-                    --incremental    true
+                    --incremental    false
                     --base_ref       ${{ github.ref_name }}
                     --repository     ${{ github.server_url }}/${{ github.repository }}"
 
@@ -208,7 +208,7 @@ jobs:
               python .github/workflows/root-ci-config/build_root.py
                     --buildtype      ${{ matrix.config }}
                     --platform       windows10
-                    --incremental    true
+                    --incremental    false
                     --base_ref       ${{ github.ref_name }}
                     --repository     ${{ github.server_url }}/${{ github.repository }}
                     --architecture   ${{ matrix.target_arch }}  "
@@ -348,7 +348,7 @@ jobs:
         run: ".github/workflows/root-ci-config/build_root.py
                     --buildtype      ${{ matrix.config }}
                     --platform       ${{ matrix.image }}
-                    --incremental    true
+                    --incremental    false
                     --base_ref       ${{ github.ref_name }}
                     --repository     ${{ github.server_url }}/${{ github.repository }}
               "


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

### push-events

Builds triggered by push events never download previous artifacts and always do clean builds.

### Use different heuristics to decide when to upload artifacts

#### Old
- Check if connection to s3 was possible

#### New
- Never upload on pull request
- Never upload incremental builds

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

