### PR TITLE
[CI] Fix macOS and Windows not building outside of pull requests

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -65,7 +65,7 @@ env:
 
 jobs:
   build-macos:
-    if: github.repository_owner == 'root_project' || github.event_name == 'pull_request'
+    if: github.repository_owner == 'root-project' || github.event_name == 'pull_request'
 
     permissions:
       contents: read
@@ -138,7 +138,7 @@ jobs:
 
 
   build-windows:
-    if: github.repository_owner == 'root_project' || github.event_name == 'pull_request'
+    if: github.repository_owner == 'root-project' || github.event_name == 'pull_request'
 
     permissions:
       contents: read


### PR DESCRIPTION
#### typo made build get skipped on macOS and windows:
```
if: github.repository_owner == 'root_project' || github.event_name == 'pull_request'
                                ^^^^^^^^^^^^: changed to 'root-project'
```

<details><summary></summary>
<p>
[skip-ci]
</p>
</details> 