### PR TITLE
[ntuple][skip-ci] Update `std::variant` section in specifications.md

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -635,8 +635,11 @@ Multi-dimensional arrays of the form `T[N][M]...` are currently not supported.
 #### std::variant<T1, T2, ..., Tn>
 
 Variants are stored in $n+1$ fields:
-  - Variant mother field of type Switch; the dispatch tag points to the principle column of the active type
+  - Variant mother field with one column of type Switch; the dispatch tag points to the principal column of the active type
   - Child fields of types `T1`, ..., `Tn`; their names are `_0`, `_1`, ...
+
+The dispatch tag ranges from 1 to $n$.
+A value of 0 indicates that the variant is in the invalid state, i.e., it does not hold any of the valid alternatives.
 
 #### std::pair<T1, T2>
 


### PR DESCRIPTION
Add a few clarifications to the description of the `std::variant<T1, T2, ..., Tn>` type in the RNTuple Reference Specifications document.

Currently, the dispatch tag is `== 0` _iif_ the variant was in the invalid state when the entry was filled.  This condition is also expected to happen after the late model extension PRs are merged, given that late-added fields of type `std::variant<Ts...>` are in an invalid state for entries for which there is no data.

## Checklist:
- [X] updated the docs (if necessary)