### PR TITLE
[ntuple] Avoid warning about possibly uninitialized variable

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -187,7 +187,7 @@ static void CastDeltaSplitUnpack(void *destination, const void *source, std::siz
    auto splitArray = reinterpret_cast<const char *>(source);
    auto dst = reinterpret_cast<DestT *>(destination);
    for (std::size_t i = 0; i < count; ++i) {
-      SourceT val;
+      SourceT val = 0;
       for (std::size_t b = 0; b < N; ++b) {
          reinterpret_cast<char *>(&val)[b] = splitArray[b * count + i];
       }


### PR DESCRIPTION
As noted in commit 538396a869 some weeks ago, Clang 15 warns that the variable v may be used uninitialized because it does not understand the pointer hackery to read individual bytes.