### PR TITLE
[v628][RF] Backports of RooFit PRs to `v6-28-00-patches`: Part 12

### DIFF
--- a/roofit/batchcompute/inc/RooBatchCompute.h
+++ b/roofit/batchcompute/inc/RooBatchCompute.h
@@ -48,10 +48,12 @@ enum Computer {
    CBShape,
    Chebychev,
    ChiSquare,
+   DeltaFunction,
    DstD0BG,
    Exponential,
    Gamma,
    Gaussian,
+   Identity,
    Johnson,
    Landau,
    Lognormal,
@@ -61,6 +63,13 @@ enum Computer {
    Polynomial,
    ProdPdf,
    Ratio,
+   TruthModelExpBasis,
+   TruthModelSinBasis,
+   TruthModelCosBasis,
+   TruthModelLinBasis,
+   TruthModelQuadBasis,
+   TruthModelSinhBasis,
+   TruthModelCoshBasis,
    Voigtian
 };
 

--- a/roofit/batchcompute/inc/RooSpan.h
+++ b/roofit/batchcompute/inc/RooSpan.h
@@ -73,11 +73,7 @@ public:
 
 
   /// Construct from start pointer and size.
-  constexpr RooSpan(typename std::span<T>::pointer beginIn,
-      typename std::span<T>::size_type sizeIn) :
-  _span{beginIn, sizeIn}
-  { }
-
+  constexpr RooSpan(typename std::span<T>::pointer beginIn, std::size_t sizeIn) : _span{beginIn, sizeIn} {}
 
   constexpr RooSpan(const std::vector<typename std::remove_cv<T>::type>& vec) noexcept :
   _span{vec}
@@ -108,18 +104,21 @@ public:
   }
 
 #ifdef NDEBUG
-  constexpr typename std::span<T>::reference operator[](typename std::span<T>::size_type i) const noexcept {
-    return _span[i];
+  constexpr typename std::span<T>::reference operator[](std::size_t i) const noexcept
+  {
+     return _span[i];
   }
 #else
-  typename std::span<T>::reference operator[](typename std::span<T>::size_type i) const noexcept {
-    assert(i < _span.size());
-    return _span[i];
+  typename std::span<T>::reference operator[](std::size_t i) const noexcept
+  {
+     assert(i < _span.size());
+     return _span[i];
   }
 #endif
 
-  constexpr typename std::span<T>::size_type size() const noexcept {
-    return _span.size();
+  constexpr std::size_t size() const noexcept
+  {
+     return _span.size();
   }
 
   constexpr bool empty() const noexcept {

--- a/roofit/batchcompute/inc/RooVDTHeaders.h
+++ b/roofit/batchcompute/inc/RooVDTHeaders.h
@@ -25,44 +25,72 @@
 #include "RConfigure.h"
 
 #if defined(R__HAS_VDT) && !defined(__CUDACC__)
-#include "vdt/exp.h"
-#include "vdt/log.h"
-#include "vdt/sqrt.h"
+#include <vdt/cos.h>
+#include <vdt/exp.h>
+#include <vdt/log.h>
+#include <vdt/sin.h>
+#include <vdt/sqrt.h>
 
-namespace RooBatchCompute{
+namespace RooBatchCompute {
 
-inline double fast_exp(double x) {
-  return vdt::fast_exp(x);
+inline double fast_exp(double x)
+{
+   return vdt::fast_exp(x);
 }
 
-inline double fast_log(double x) {
-  return vdt::fast_log(x);
+inline double fast_sin(double x)
+{
+   return vdt::fast_sin(x);
 }
 
-inline double fast_isqrt(double x) {
-  return vdt::fast_isqrt(x);
+inline double fast_cos(double x)
+{
+   return vdt::fast_cos(x);
 }
 
+inline double fast_log(double x)
+{
+   return vdt::fast_log(x);
 }
+
+inline double fast_isqrt(double x)
+{
+   return vdt::fast_isqrt(x);
+}
+
+} // namespace RooBatchCompute
 
 #else
 #include <cmath>
 
-namespace RooBatchCompute{
+namespace RooBatchCompute {
 
-__roodevice__ inline double fast_exp(double x) {
-  return std::exp(x);
+__roodevice__ inline double fast_exp(double x)
+{
+   return std::exp(x);
 }
 
-__roodevice__ inline double fast_log(double x) {
-  return std::log(x);
+__roodevice__ inline double fast_sin(double x)
+{
+   return std::sin(x);
 }
 
-__roodevice__ inline double fast_isqrt(double x) {
-  return 1/std::sqrt(x);
+__roodevice__ inline double fast_cos(double x)
+{
+   return std::cos(x);
 }
 
+__roodevice__ inline double fast_log(double x)
+{
+   return std::log(x);
 }
+
+__roodevice__ inline double fast_isqrt(double x)
+{
+   return 1. / std::sqrt(x);
+}
+
+} // namespace RooBatchCompute
 
 #endif // defined(R__HAS_VDT) && !defined(__CUDACC__)
 

--- a/roofit/batchcompute/src/ComputeFunctions.cxx
+++ b/roofit/batchcompute/src/ComputeFunctions.cxx
@@ -288,6 +288,13 @@ __rooglobal__ void computeChiSquare(BatchesHandle batches)
    }
 }
 
+__rooglobal__ void computeDeltaFunction(BatchesHandle batches)
+{
+   for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
+      batches._output[i] = 0.0 + (batches[0][i] == 1.0);
+   }
+}
+
 __rooglobal__ void computeDstD0BG(BatchesHandle batches)
 {
    Batch DM = batches[0], DM0 = batches[1], C = batches[2], A = batches[3], B = batches[4];
@@ -341,6 +348,13 @@ __rooglobal__ void computeGaussian(BatchesHandle batches)
       const double arg = x[i] - mean[i];
       const double halfBySigmaSq = -0.5 / (sigma[i] * sigma[i]);
       batches._output[i] = fast_exp(arg * arg * halfBySigmaSq);
+   }
+}
+
+__rooglobal__ void computeIdentity(BatchesHandle batches)
+{
+   for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
+      batches._output[i] = batches[0][i];
    }
 }
 
@@ -574,17 +588,116 @@ __rooglobal__ void computePolynomial(BatchesHandle batches)
 __rooglobal__ void computeProdPdf(BatchesHandle batches)
 {
    const int nPdfs = batches.extraArg(0);
-   for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
+   for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
       batches._output[i] = 1.;
-   for (int pdf = 0; pdf < nPdfs; pdf++)
-      for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
+   }
+   for (int pdf = 0; pdf < nPdfs; pdf++) {
+      for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
          batches._output[i] *= batches[pdf][i];
+      }
+   }
 }
 
 __rooglobal__ void computeRatio(BatchesHandle batches)
 {
-   for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
+   for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
       batches._output[i] = batches[0][i] / batches[1][i];
+   }
+}
+
+__rooglobal__ void computeTruthModelExpBasis(BatchesHandle batches)
+{
+
+   const bool isMinus = batches.extraArg(0) < 0.0;
+   const bool isPlus = batches.extraArg(0) > 0.0;
+   for (std::size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
+      double x = batches[0][i];
+      // Enforce sign compatibility
+      const bool isOutOfSign = (isMinus && x > 0.0) || (isPlus && x < 0.0);
+      batches._output[i] = isOutOfSign ? 0.0 : fast_exp(-std::abs(x) / batches[1][i]);
+   }
+}
+
+__rooglobal__ void computeTruthModelSinBasis(BatchesHandle batches)
+{
+   const bool isMinus = batches.extraArg(0) < 0.0;
+   const bool isPlus = batches.extraArg(0) > 0.0;
+   for (std::size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
+      double x = batches[0][i];
+      // Enforce sign compatibility
+      const bool isOutOfSign = (isMinus && x > 0.0) || (isPlus && x < 0.0);
+      batches._output[i] = isOutOfSign ? 0.0 : fast_exp(-std::abs(x) / batches[1][i]) * fast_sin(x * batches[2][i]);
+   }
+}
+
+__rooglobal__ void computeTruthModelCosBasis(BatchesHandle batches)
+{
+   const bool isMinus = batches.extraArg(0) < 0.0;
+   const bool isPlus = batches.extraArg(0) > 0.0;
+   for (std::size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
+      double x = batches[0][i];
+      // Enforce sign compatibility
+      const bool isOutOfSign = (isMinus && x > 0.0) || (isPlus && x < 0.0);
+      batches._output[i] = isOutOfSign ? 0.0 : fast_exp(-std::abs(x) / batches[1][i]) * fast_cos(x * batches[2][i]);
+   }
+}
+
+__rooglobal__ void computeTruthModelLinBasis(BatchesHandle batches)
+{
+   const bool isMinus = batches.extraArg(0) < 0.0;
+   const bool isPlus = batches.extraArg(0) > 0.0;
+   for (std::size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
+      double x = batches[0][i];
+      // Enforce sign compatibility
+      const bool isOutOfSign = (isMinus && x > 0.0) || (isPlus && x < 0.0);
+      if (isOutOfSign) {
+         batches._output[i] = 0.0;
+      } else {
+         const double tscaled = std::abs(x) / batches[1][i];
+         batches._output[i] = fast_exp(-tscaled) * tscaled;
+      }
+   }
+}
+
+__rooglobal__ void computeTruthModelQuadBasis(BatchesHandle batches)
+{
+   const bool isMinus = batches.extraArg(0) < 0.0;
+   const bool isPlus = batches.extraArg(0) > 0.0;
+   for (std::size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
+      double x = batches[0][i];
+      // Enforce sign compatibility
+      const bool isOutOfSign = (isMinus && x > 0.0) || (isPlus && x < 0.0);
+      if (isOutOfSign) {
+         batches._output[i] = 0.0;
+      } else {
+         const double tscaled = std::abs(x) / batches[1][i];
+         batches._output[i] = fast_exp(-tscaled) * tscaled * tscaled;
+      }
+   }
+}
+
+__rooglobal__ void computeTruthModelSinhBasis(BatchesHandle batches)
+{
+   const bool isMinus = batches.extraArg(0) < 0.0;
+   const bool isPlus = batches.extraArg(0) > 0.0;
+   for (std::size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
+      double x = batches[0][i];
+      // Enforce sign compatibility
+      const bool isOutOfSign = (isMinus && x > 0.0) || (isPlus && x < 0.0);
+      batches._output[i] = isOutOfSign ? 0.0 : fast_exp(-std::abs(x) / batches[1][i]) * sinh(x * batches[2][i] * 0.5);
+   }
+}
+
+__rooglobal__ void computeTruthModelCoshBasis(BatchesHandle batches)
+{
+   const bool isMinus = batches.extraArg(0) < 0.0;
+   const bool isPlus = batches.extraArg(0) > 0.0;
+   for (std::size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
+      double x = batches[0][i];
+      // Enforce sign compatibility
+      const bool isOutOfSign = (isMinus && x > 0.0) || (isPlus && x < 0.0);
+      batches._output[i] = isOutOfSign ? 0.0 : fast_exp(-std::abs(x) / batches[1][i]) * cosh(x * batches[2][i] * .5);
+   }
 }
 
 __rooglobal__ void computeVoigtian(BatchesHandle batches)
@@ -603,7 +716,7 @@ __rooglobal__ void computeVoigtian(BatchesHandle batches)
          batches._output[i] = invSqrt2 / S[i];
    }
 
-   for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
+   for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
       if (S[i] != 0.0 && W[i] != 0.0) {
          if (batches._output[i] < 0)
             batches._output[i] = -batches._output[i];
@@ -611,19 +724,45 @@ __rooglobal__ void computeVoigtian(BatchesHandle batches)
          std::complex<double> z(batches._output[i] * (X[i] - M[i]), factor * batches._output[i] * W[i]);
          batches._output[i] *= faddeeva_impl::faddeeva(z).real();
       }
+   }
 }
 
 /// Returns a std::vector of pointers to the compute functions in this file.
 std::vector<void (*)(BatchesHandle)> getFunctions()
 {
-   return {computeAddPdf,      computeArgusBG,    computeBMixDecay,
-           computeBernstein,   computeBifurGauss, computeBreitWigner,
-           computeBukin,       computeCBShape,    computeChebychev,
-           computeChiSquare,   computeDstD0BG,    computeExponential,
-           computeGamma,       computeGaussian,   computeJohnson,
-           computeLandau,      computeLognormal,  computeNegativeLogarithms,
-           computeNovosibirsk, computePoisson,    computePolynomial,
-           computeProdPdf,     computeRatio,      computeVoigtian};
+   return {computeAddPdf,
+           computeArgusBG,
+           computeBMixDecay,
+           computeBernstein,
+           computeBifurGauss,
+           computeBreitWigner,
+           computeBukin,
+           computeCBShape,
+           computeChebychev,
+           computeChiSquare,
+           computeDeltaFunction,
+           computeDstD0BG,
+           computeExponential,
+           computeGamma,
+           computeGaussian,
+           computeIdentity,
+           computeJohnson,
+           computeLandau,
+           computeLognormal,
+           computeNegativeLogarithms,
+           computeNovosibirsk,
+           computePoisson,
+           computePolynomial,
+           computeProdPdf,
+           computeRatio,
+           computeTruthModelExpBasis,
+           computeTruthModelSinBasis,
+           computeTruthModelCosBasis,
+           computeTruthModelLinBasis,
+           computeTruthModelQuadBasis,
+           computeTruthModelSinhBasis,
+           computeTruthModelCoshBasis,
+           computeVoigtian};
 }
 } // End namespace RF_ARCH
 } // End namespace RooBatchCompute

--- a/roofit/histfactory/CMakeLists.txt
+++ b/roofit/histfactory/CMakeLists.txt
@@ -95,11 +95,12 @@ if(xml)
 endif()
 
 if(MSVC)
-  file(COPY config/prepareHistFactory.bat DESTINATION  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+  set(prepareHistFactory_script prepareHistFactory.bat)
 else()
-  file(COPY config/prepareHistFactory DESTINATION  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+  set(prepareHistFactory_script prepareHistFactory)
 endif()
-install(FILES ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/prepareHistFactory
+file(COPY config/${prepareHistFactory_script} DESTINATION  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+install(FILES ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${prepareHistFactory_script}
                 PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
                             GROUP_EXECUTE GROUP_READ
                             WORLD_EXECUTE WORLD_READ

--- a/roofit/histfactory/CMakeLists.txt
+++ b/roofit/histfactory/CMakeLists.txt
@@ -94,7 +94,11 @@ if(xml)
   )
 endif()
 
-file(COPY config/prepareHistFactory DESTINATION  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+if(MSVC)
+  file(COPY config/prepareHistFactory.bat DESTINATION  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+else()
+  file(COPY config/prepareHistFactory DESTINATION  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+endif()
 install(FILES ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/prepareHistFactory
                 PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
                             GROUP_EXECUTE GROUP_READ

--- a/roofit/histfactory/config/prepareHistFactory.bat
+++ b/roofit/histfactory/config/prepareHistFactory.bat
@@ -1,0 +1,53 @@
+@echo off
+setlocal enabledelayedexpansion
+
+rem HistFactory workplace setup script
+
+for /f "tokens=*" %%g in ('root-config --etcdir') do (set ROOTETCDIR=%%g)
+echo Using etcdir !ROOTETCDIR!
+for /f "tokens=*" %%g in ('root-config --tutdir') do (set ROOTTUTDIR=%%g)
+echo Using tutorials dir !ROOTTUTDIR!
+
+if not "%1" == "" (
+  set DIR=%~1
+  echo HistFactory workplace will be created in: !DIR!
+) else (
+  set DIR=.
+  echo HistFactory workplace will be created in the current directory
+)
+
+echo "Creating directory structure..."
+mkdir !DIR!\config
+mkdir !DIR!\config\examples
+mkdir !DIR!\data
+mkdir !DIR!\results
+
+echo "Copying skeleton configuration files..."
+copy !ROOTETCDIR!\HistFactorySchema.dtd !DIR!\config\
+copy !ROOTTUTDIR!\histfactory\example.xml !DIR!\config\
+copy !ROOTTUTDIR!\histfactory\example_channel.xml !DIR!\config\
+
+copy !ROOTETCDIR!\HistFactorySchema.dtd !DIR!\config\examples
+copy !ROOTTUTDIR!\histfactory\example_Expression.xml !DIR!\config\examples\
+copy !ROOTTUTDIR!\histfactory\example_Expression_channel.xml !DIR!\config\examples\
+copy !ROOTTUTDIR!\histfactory\example_ShapeSys.xml !DIR!\config\examples\
+copy !ROOTTUTDIR!\histfactory\example_ShapeSys_channel.xml !DIR!\config\examples\
+copy !ROOTTUTDIR!\histfactory\example_ShapeSys2D.xml !DIR!\config\examples\
+copy !ROOTTUTDIR!\histfactory\example_ShapeSys2D_channel.xml !DIR!\config\examples\
+copy !ROOTTUTDIR!\histfactory\example_DataDriven.xml !DIR!\config\examples\
+copy !ROOTTUTDIR!\histfactory\example_DataDriven_signalRegion.xml !DIR!\config\examples\
+copy !ROOTTUTDIR!\histfactory\example_DataDriven_controlRegion.xml !DIR!\config\examples\
+
+rem echo "Making skeleton data files..."
+root.exe -b -q !ROOTTUTDIR!\histfactory\makeExample.C
+move ShapeSys.root !DIR!\data\
+move ShapeSys2D.root !DIR!\data\
+move StatError.root !DIR!\data\
+move dataDriven.root !DIR!\data\
+move example.root !DIR!\data\
+
+echo Done!
+rem echo "You can run the example with: hist2workspace !DIR!\config\example.xml"
+
+exit /b 0
+

--- a/roofit/hs3/src/HistFactoryJSONTool.cxx
+++ b/roofit/hs3/src/HistFactoryJSONTool.cxx
@@ -42,11 +42,7 @@ void exportSample(const RooStats::HistFactory::Sample &sample, JSONNode &s)
    }
 
    if (sample.GetNormFactorList().size() > 0) {
-      auto &normFactors = s["normFactors"];
-      normFactors.set_seq();
-      for (auto &sys : sample.GetNormFactorList()) {
-         normFactors.append_child() << sys.GetName();
-      }
+      s["normFactors"].fill_seq(sample.GetNormFactorList(), [](auto const &x) { return x.GetName(); });
    }
 
    if (sample.GetHistoSysList().size() > 0) {

--- a/roofit/hs3/src/JSONFactories_HistFactory.cxx
+++ b/roofit/hs3/src/JSONFactories_HistFactory.cxx
@@ -82,8 +82,8 @@ inline void stackError(const JSONNode &n, std::vector<double> &sumW, std::vector
    }
    const size_t nbins = n["counts"].num_children();
    for (size_t ibin = 0; ibin < nbins; ++ibin) {
-      double w = n["counts"][ibin].val_float();
-      double e = n["errors"][ibin].val_float();
+      double w = n["counts"][ibin].val_double();
+      double e = n["errors"][ibin].val_double();
       if (ibin < sumW.size())
          sumW[ibin] += w;
       else
@@ -246,8 +246,8 @@ bool importHistSample(RooWorkspace &ws, Scope const &scope, const JSONNode &p)
                                                            : "alpha_" + sysname);
             if (RooRealVar *par = ::getNP(ws, parname.c_str())) {
                nps.add(*par);
-               low.push_back(sys["low"].val_float());
-               high.push_back(sys["high"].val_float());
+               low.push_back(sys["low"].val_double());
+               high.push_back(sys["high"].val_double());
             } else {
                RooJSONFactoryWSTool::error("overall systematic '" + sysname + "' doesn't have a valid parameter!");
             }
@@ -428,7 +428,7 @@ public:
       std::string sysname(RooJSONFactoryWSTool::name(p));
       std::vector<double> vals;
       for (const auto &v : p["vals"].children()) {
-         vals.push_back(v.val_float());
+         vals.push_back(v.val_double());
       }
       RooArgList gammas;
       return createPHF(sysname, phfname, vals, w, constraints, observables, p["constraint"].val(), gammas, 0, 1000);
@@ -453,7 +453,7 @@ public:
       if (p.has_child("statError")) {
          auto &staterr = p["statError"];
          if (staterr.has_child("relThreshold"))
-            statErrorThreshold = staterr["relThreshold"].val_float();
+            statErrorThreshold = staterr["relThreshold"].val_double();
          if (staterr.has_child("constraint"))
             statErrorType = staterr["constraint"].val();
       }
@@ -668,7 +668,7 @@ public:
          RooJSONFactoryWSTool::error("no nominal variation of '" + name + "'");
       }
 
-      double nom(p["nom"].val_float());
+      double nom(p["nom"].val_double());
 
       RooArgList vars;
       for (const auto &d : p["vars"].children()) {

--- a/roofit/hs3/src/JSONFactories_HistFactory.cxx
+++ b/roofit/hs3/src/JSONFactories_HistFactory.cxx
@@ -955,8 +955,7 @@ public:
    }
 };
 
-STATIC_EXECUTE(
-
+STATIC_EXECUTE([]() {
    using namespace RooFit::JSONIO;
 
    registerImporter<RooRealSumPdfFactory>("histfactory", true);
@@ -965,7 +964,6 @@ STATIC_EXECUTE(
    registerExporter<FlexibleInterpVarStreamer>(RooStats::HistFactory::FlexibleInterpVar::Class(), true);
    registerExporter<PiecewiseInterpolationStreamer>(PiecewiseInterpolation::Class(), true);
    registerExporter<HistFactoryStreamer>(RooProdPdf::Class(), true);
-
-)
+});
 
 } // namespace

--- a/roofit/hs3/src/JSONFactories_HistFactory.cxx
+++ b/roofit/hs3/src/JSONFactories_HistFactory.cxx
@@ -560,18 +560,13 @@ public:
    }
    bool exportObject(RooJSONFactoryWSTool *, const RooAbsArg *func, JSONNode &elem) const override
    {
-      const RooStats::HistFactory::FlexibleInterpVar *fip =
-         static_cast<const RooStats::HistFactory::FlexibleInterpVar *>(func);
+      auto fip = static_cast<const RooStats::HistFactory::FlexibleInterpVar *>(func);
       elem["type"] << key();
-      auto &vars = elem["vars"];
-      elem["interpolationCodes"] << fip->interpolationCodes();
-      vars.set_seq();
-      for (const auto &v : fip->variables()) {
-         vars.append_child() << v->GetName();
-      }
+      elem["vars"].fill_seq(fip->variables(), [](auto const &item) { return item->GetName(); });
+      elem["interpolationCodes"].fill_seq(fip->interpolationCodes());
       elem["nom"] << fip->nominal();
-      elem["high"] << fip->high();
-      elem["low"] << fip->low();
+      elem["high"].fill_seq(fip->high());
+      elem["low"].fill_seq(fip->low());
       return true;
    }
 };
@@ -587,27 +582,13 @@ public:
    {
       const PiecewiseInterpolation *pip = static_cast<const PiecewiseInterpolation *>(func);
       elem["type"] << key();
-      elem["interpolationCodes"] << pip->interpolationCodes();
-      auto &vars = elem["vars"];
-      vars.set_seq();
-      for (const auto &v : pip->paramList()) {
-         vars.append_child() << v->GetName();
-      }
-
+      elem["interpolationCodes"].fill_seq(pip->interpolationCodes());
+      elem["vars"].fill_seq(pip->paramList(), [](auto const &item) { return item->GetName(); });
       auto &nom = elem["nom"];
       nom << pip->nominalHist()->GetName();
 
-      auto &high = elem["high"];
-      high.set_seq();
-      for (const auto &v : pip->highList()) {
-         high.append_child() << v->GetName();
-      }
-
-      auto &low = elem["low"];
-      low.set_seq();
-      for (const auto &v : pip->lowList()) {
-         low.append_child() << v->GetName();
-      }
+      elem["high"].fill_seq(pip->highList(), [](auto const &item) { return item->GetName(); });
+      elem["low"].fill_seq(pip->lowList(), [](auto const &item) { return item->GetName(); });
       return true;
    }
 };
@@ -823,11 +804,7 @@ public:
          auto &s = samples[samplename];
          s.set_map();
 
-         for (const auto &norm : norms) {
-            auto &nfs = s["normFactors"];
-            nfs.set_seq();
-            nfs.append_child() << norm->GetName();
-         }
+         s["normFactors"].fill_seq(norms, [](auto const &item) { return item->GetName(); });
 
          if (pip) {
             auto &systs = s["histogramSystematics"];

--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -526,8 +526,7 @@ public:
 // instantiate all importers and exporters
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 
-STATIC_EXECUTE(
-
+STATIC_EXECUTE([]() {
    using namespace RooFit::JSONIO;
 
    registerImporter<RooProdPdfFactory>("pdfprod", false);
@@ -551,6 +550,7 @@ STATIC_EXECUTE(
    registerExporter<RooGenericPdfStreamer>(RooGenericPdf::Class(), false);
    registerExporter<RooFormulaVarStreamer>(RooFormulaVar::Class(), false);
    registerExporter<RooRealSumPdfStreamer>(RooRealSumPdf::Class(), false);
-   registerExporter<RooRealSumFuncStreamer>(RooRealSumFunc::Class(), false);)
+   registerExporter<RooRealSumFuncStreamer>(RooRealSumFunc::Class(), false);
+});
 
 } // namespace

--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -536,7 +536,7 @@ STATIC_EXECUTE(
    registerImporter<RooBinSamplingPdfFactory>("binsampling", false);
    registerImporter<RooAddPdfFactory>("pdfsum", false);
    registerImporter<RooHistFuncFactory>("histogram", false);
-   registerImporter<RooHistFuncFactory>("histogramPdf", false);
+   registerImporter<RooHistPdfFactory>("histogramPdf", false);
    registerImporter<RooSimultaneousFactory>("simultaneous", false);
    registerImporter<RooBinWidthFunctionFactory>("binwidth", false);
    registerImporter<RooRealSumPdfFactory>("sumpdf", false);

--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -24,6 +24,7 @@
 #include <RooHistFunc.h>
 #include <RooHistPdf.h>
 #include <RooProdPdf.h>
+#include <RooPolynomial.h>
 #include <RooRealSumFunc.h>
 #include <RooRealSumPdf.h>
 #include <RooRealVar.h>
@@ -286,6 +287,41 @@ public:
    }
 };
 
+class RooPolynomialFactory : public RooFit::JSONIO::Importer {
+public:
+   bool importPdf(RooJSONFactoryWSTool *tool, const JSONNode &p) const override
+   {
+      std::string name(RooJSONFactoryWSTool::name(p));
+      if (!p.has_child("x")) {
+         RooJSONFactoryWSTool::error("no x given in '" + name + "'");
+      }
+      if (!p.has_child("coefficients")) {
+         RooJSONFactoryWSTool::error("no coefficients given in '" + name + "'");
+      }
+      RooAbsReal *x = tool->request<RooAbsReal>(p["x"].val(), name);
+      RooArgList coefs;
+      int order = 0;
+      int lowestOrder = 0;
+      for (const auto &coef : p["coefficients"].children()) {
+         // As long as the coefficients match the default coefficients in
+         // RooFit, we don't have to instantiate RooFit objects but can
+         // increase the lowestOrder flag.
+         if (order == 0 && coef.val() == "1.0") {
+            ++lowestOrder;
+         } else if (coefs.empty() && coef.val() == "0.0") {
+            ++lowestOrder;
+         } else {
+            coefs.add(*tool->request<RooAbsReal>(coef.val(), name));
+         }
+         ++order;
+      }
+
+      RooPolynomial pdf(name.c_str(), name.c_str(), *x, coefs, lowestOrder);
+      tool->workspace()->import(pdf, RooFit::RecycleConflictNodes(true), RooFit::Silence(true));
+      return true;
+   }
+};
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 // specialized exporter implementations
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -522,6 +558,32 @@ public:
    }
 };
 
+class RooPolynomialStreamer : public RooFit::JSONIO::Exporter {
+public:
+   std::string const &key() const override
+   {
+      static const std::string keystring = "polynomialPdf";
+      return keystring;
+   }
+   bool exportObject(RooJSONFactoryWSTool *, const RooAbsArg *func, JSONNode &elem) const override
+   {
+      auto *pdf = static_cast<const RooPolynomial *>(func);
+      elem["type"] << key();
+      elem["x"] << pdf->x().GetName();
+      auto &coefs = elem["coefficients"];
+      // Write out the default coefficient that RooFit uses for the lower
+      // orders before the order of the first coefficient. Like this, the
+      // output is more self-documenting.
+      for (int i = 0; i < pdf->lowestOrder(); ++i) {
+         coefs.append_child() << (i == 0 ? "1.0" : "0.0");
+      }
+      for (const auto &coef : pdf->coefList()) {
+         coefs.append_child() << coef->GetName();
+      }
+      return true;
+   }
+};
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 // instantiate all importers and exporters
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -540,6 +602,7 @@ STATIC_EXECUTE([]() {
    registerImporter<RooBinWidthFunctionFactory>("binwidth", false);
    registerImporter<RooRealSumPdfFactory>("sumpdf", false);
    registerImporter<RooRealSumFuncFactory>("sumfunc", false);
+   registerImporter<RooPolynomialFactory>("polynomialPdf", false);
 
    registerExporter<RooBinWidthFunctionStreamer>(RooBinWidthFunction::Class(), false);
    registerExporter<RooProdPdfStreamer>(RooProdPdf::Class(), false);
@@ -551,6 +614,7 @@ STATIC_EXECUTE([]() {
    registerExporter<RooFormulaVarStreamer>(RooFormulaVar::Class(), false);
    registerExporter<RooRealSumPdfStreamer>(RooRealSumPdf::Class(), false);
    registerExporter<RooRealSumFuncStreamer>(RooRealSumFunc::Class(), false);
+   registerExporter<RooPolynomialStreamer>(RooPolynomial::Class(), false);
 });
 
 } // namespace

--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -301,16 +301,8 @@ public:
    {
       const RooRealSumPdf *pdf = static_cast<const RooRealSumPdf *>(func);
       elem["type"] << key();
-      auto &samples = elem["samples"];
-      samples.set_seq();
-      auto &coefs = elem["coefficients"];
-      coefs.set_seq();
-      for (const auto &s : pdf->funcList()) {
-         samples.append_child() << s->GetName();
-      }
-      for (const auto &c : pdf->coefList()) {
-         coefs.append_child() << c->GetName();
-      }
+      elem["samples"].fill_seq(pdf->funcList(), [](auto const &item) { return item->GetName(); });
+      elem["coefficients"].fill_seq(pdf->coefList(), [](auto const &item) { return item->GetName(); });
       elem["extended"] << (pdf->extendMode() == RooAbsPdf::CanBeExtended);
       return true;
    }
@@ -327,16 +319,8 @@ public:
    {
       const RooRealSumFunc *pdf = static_cast<const RooRealSumFunc *>(func);
       elem["type"] << key();
-      auto &samples = elem["samples"];
-      samples.set_seq();
-      auto &coefs = elem["coefficients"];
-      coefs.set_seq();
-      for (const auto &s : pdf->funcList()) {
-         samples.append_child() << s->GetName();
-      }
-      for (const auto &c : pdf->coefList()) {
-         coefs.append_child() << c->GetName();
-      }
+      elem["samples"].fill_seq(pdf->funcList(), [](auto const &item) { return item->GetName(); });
+      elem["coefficients"].fill_seq(pdf->coefList(), [](auto const &item) { return item->GetName(); });
       return true;
    }
 };
@@ -482,10 +466,7 @@ public:
    {
       const RooProdPdf *pdf = static_cast<const RooProdPdf *>(func);
       elem["type"] << key();
-      auto &factors = elem["pdfs"];
-      for (const auto &f : pdf->pdfList()) {
-         factors.append_child() << f->GetName();
-      }
+      elem["pdfs"].fill_seq(pdf->pdfList(), [](auto const &f) { return f->GetName(); });
       return true;
    }
 };
@@ -502,10 +483,7 @@ public:
       const RooGenericPdf *pdf = static_cast<const RooGenericPdf *>(func);
       elem["type"] << key();
       elem["formula"] << pdf->expression();
-      auto &factors = elem["dependents"];
-      for (const auto &f : pdf->dependents()) {
-         factors.append_child() << f->GetName();
-      }
+      elem["dependents"].fill_seq(pdf->dependents(), [](auto const &f) { return f->GetName(); });
       return true;
    }
 };
@@ -539,10 +517,7 @@ public:
       const RooFormulaVar *var = static_cast<const RooFormulaVar *>(func);
       elem["type"] << key();
       elem["formula"] << var->expression();
-      auto &factors = elem["dependents"];
-      for (const auto &f : var->dependents()) {
-         factors.append_child() << f->GetName();
-      }
+      elem["dependents"].fill_seq(var->dependents(), [](auto const &f) { return f->GetName(); });
       return true;
    }
 };
@@ -555,7 +530,8 @@ STATIC_EXECUTE(
 
    using namespace RooFit::JSONIO;
 
-   registerImporter<RooProdPdfFactory>("pdfprod", false); registerImporter<RooGenericPdfFactory>("genericpdf", false);
+   registerImporter<RooProdPdfFactory>("pdfprod", false);
+   registerImporter<RooGenericPdfFactory>("genericpdf", false);
    registerImporter<RooFormulaVarFactory>("formulavar", false);
    registerImporter<RooBinSamplingPdfFactory>("binsampling", false);
    registerImporter<RooAddPdfFactory>("pdfsum", false);
@@ -575,7 +551,6 @@ STATIC_EXECUTE(
    registerExporter<RooGenericPdfStreamer>(RooGenericPdf::Class(), false);
    registerExporter<RooFormulaVarStreamer>(RooFormulaVar::Class(), false);
    registerExporter<RooRealSumPdfStreamer>(RooRealSumPdf::Class(), false);
-   registerExporter<RooRealSumFuncStreamer>(RooRealSumFunc::Class(), false);
-)
+   registerExporter<RooRealSumFuncStreamer>(RooRealSumFunc::Class(), false);)
 
 } // namespace

--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -217,7 +217,7 @@ public:
       if (!p.has_child("epsilon")) {
          RooJSONFactoryWSTool::error("no epsilon given in '" + name + "'");
       }
-      double epsilon(p["epsilon"].val_float());
+      double epsilon(p["epsilon"].val_double());
 
       RooBinSamplingPdf thepdf(name.c_str(), name.c_str(), *obs, *pdf, epsilon);
       tool->workspace()->import(thepdf, RooFit::RecycleConflictNodes(true), RooFit::Silence(true));

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -224,14 +224,14 @@ RooJSONFactoryWSTool::Var::Var(const JSONNode &val)
       if (!val.has_child("min"))
          this->min = 0;
       else
-         this->min = val["min"].val_float();
+         this->min = val["min"].val_double();
       if (!val.has_child("max"))
          this->max = 1;
       else
-         this->max = val["max"].val_float();
+         this->max = val["max"].val_double();
    } else if (val.is_seq()) {
       for (size_t i = 0; i < val.num_children(); ++i) {
-         this->bounds.push_back(val[i].val_float());
+         this->bounds.push_back(val[i].val_double());
       }
       this->nbins = this->bounds.size();
       this->min = this->bounds[0];
@@ -852,9 +852,9 @@ std::map<std::string, std::unique_ptr<RooAbsData>> RooJSONFactoryWSTool::loadDat
             }
             for (size_t j = 0; j < point.num_children(); ++j) {
                auto *v = static_cast<RooRealVar *>(varlist.at(j));
-               v->setVal(point[j].val_float());
+               v->setVal(point[j].val_double());
             }
-            data->add(vars, weights[i].val_float());
+            data->add(vars, weights[i].val_double());
          }
          dataMap[name] = std::move(data);
       } else if (p.has_child("index")) {
@@ -1045,7 +1045,7 @@ std::unique_ptr<RooDataHist> RooJSONFactoryWSTool::readBinnedData(RooWorkspace &
          RooRealVar *v = (RooRealVar *)(varlist.at(i));
          v->setBin(bins[ibin][i]);
       }
-      dh->add(varlist, counts[ibin].val_float());
+      dh->add(varlist, counts[ibin].val_double());
    }
    // re-enable dirty flag propagation
    for (size_t i = 0; i < varlist.size(); ++i) {
@@ -1182,17 +1182,17 @@ void RooJSONFactoryWSTool::importVariable(const JSONNode &p)
 void RooJSONFactoryWSTool::configureVariable(const JSONNode &p, RooRealVar &v)
 {
    if (p.has_child("value"))
-      v.setVal(p["value"].val_float());
+      v.setVal(p["value"].val_double());
    if (p.has_child("min"))
-      v.setMin(p["min"].val_float());
+      v.setMin(p["min"].val_double());
    if (p.has_child("max"))
-      v.setMax(p["max"].val_float());
+      v.setMax(p["max"].val_double());
    if (p.has_child("nbins"))
       v.setBins(p["nbins"].val_int());
    if (p.has_child("relErr"))
-      v.setError(v.getVal() * p["relErr"].val_float());
+      v.setError(v.getVal() * p["relErr"].val_double());
    if (p.has_child("err"))
-      v.setError(p["err"].val_float());
+      v.setError(p["err"].val_double());
    if (p.has_child("const"))
       v.setConstant(p["const"].val_bool());
    else

--- a/roofit/hs3/src/static_execute.h
+++ b/roofit/hs3/src/static_execute.h
@@ -15,7 +15,7 @@
 
 // Execute code on library loading by running code in the constructor of a
 // class that is a static class member of another class.
-#define STATIC_EXECUTE(MY_CODE)   \
+#define STATIC_EXECUTE(MY_FUNC)   \
    struct StaticExecutorWrapper { \
       struct Executor {           \
          template <class Func>    \
@@ -27,6 +27,6 @@
       static Executor executor;   \
    };                             \
                                   \
-   StaticExecutorWrapper::Executor StaticExecutorWrapper::executor{[]() { MY_CODE }};
+   StaticExecutorWrapper::Executor StaticExecutorWrapper::executor{MY_FUNC};
 
 #endif

--- a/roofit/jsoninterface/inc/RooFit/Detail/JSONInterface.h
+++ b/roofit/jsoninterface/inc/RooFit/Detail/JSONInterface.h
@@ -83,15 +83,6 @@ public:
    virtual JSONNode &operator<<(std::string const &s) = 0;
    virtual JSONNode &operator<<(int i) = 0;
    virtual JSONNode &operator<<(double d) = 0;
-   template <class T>
-   JSONNode &operator<<(const std::vector<T> &v)
-   {
-      this->set_seq();
-      for (const auto &e : v) {
-         this->append_child() << e;
-      };
-      return *this;
-   }
    virtual const JSONNode &operator>>(std::string &v) const = 0;
    virtual JSONNode &operator[](std::string const &k) = 0;
    virtual JSONNode &operator[](size_t pos) = 0;
@@ -123,6 +114,24 @@ public:
    virtual const_children_view children() const;
    virtual JSONNode &child(size_t pos) = 0;
    virtual const JSONNode &child(size_t pos) const = 0;
+
+   template <typename Collection>
+   void fill_seq(Collection const &coll)
+   {
+      set_seq();
+      for (auto const &item : coll) {
+         append_child() << item;
+      }
+   }
+
+   template <typename Collection, typename TransformationFunc>
+   void fill_seq(Collection const &coll, TransformationFunc func)
+   {
+      set_seq();
+      for (auto const &item : coll) {
+         append_child() << func(item);
+      }
+   }
 };
 
 class JSONTree {

--- a/roofit/jsoninterface/inc/RooFit/Detail/JSONInterface.h
+++ b/roofit/jsoninterface/inc/RooFit/Detail/JSONInterface.h
@@ -97,7 +97,7 @@ public:
    virtual std::string key() const = 0;
    virtual std::string val() const = 0;
    virtual int val_int() const { return atoi(this->val().c_str()); }
-   virtual float val_float() const { return atof(this->val().c_str()); }
+   virtual double val_double() const { return std::stod(this->val()); }
    virtual bool val_bool() const { return atoi(this->val().c_str()); }
    template <class T>
    T val_t() const;

--- a/roofit/jsoninterface/src/JSONInterface.cxx
+++ b/roofit/jsoninterface/src/JSONInterface.cxx
@@ -75,14 +75,9 @@ int JSONNode::val_t<int>() const
    return val_int();
 }
 template <>
-float JSONNode::val_t<float>() const
-{
-   return val_float();
-}
-template <>
 double JSONNode::val_t<double>() const
 {
-   return val_float();
+   return val_double();
 }
 template <>
 bool JSONNode::val_t<bool>() const

--- a/roofit/jsoninterface/src/JSONParser.cxx
+++ b/roofit/jsoninterface/src/JSONParser.cxx
@@ -251,7 +251,7 @@ std::string TJSONTree::Node::val() const
    case nlohmann::json::value_t::boolean: return node->get().get<bool>() ? "true" : "false";
    case nlohmann::json::value_t::number_integer: return std::to_string(node->get().get<int>());
    case nlohmann::json::value_t::number_unsigned: return std::to_string(node->get().get<unsigned int>());
-   case nlohmann::json::value_t::number_float: return std::to_string(node->get().get<float>());
+   case nlohmann::json::value_t::number_float: return std::to_string(node->get().get<double>());
    default:
       throw std::runtime_error(std::string("node " + node->key() + ": implicit string conversion for type " +
                                            node->get().type_name() + " not supported!"));
@@ -262,9 +262,9 @@ int TJSONTree::Node::val_int() const
 {
    return node->get().get<int>();
 }
-float TJSONTree::Node::val_float() const
+double TJSONTree::Node::val_double() const
 {
-   return node->get().get<float>();
+   return node->get().get<double>();
 }
 bool TJSONTree::Node::val_bool() const
 {

--- a/roofit/jsoninterface/src/JSONParser.h
+++ b/roofit/jsoninterface/src/JSONParser.h
@@ -59,7 +59,7 @@ public:
       std::string key() const override;
       std::string val() const override;
       int val_int() const override;
-      float val_float() const override;
+      double val_double() const override;
       bool val_bool() const override;
       bool has_key() const override;
       bool has_val() const override;

--- a/roofit/jsoninterface/src/RYMLParser.cxx
+++ b/roofit/jsoninterface/src/RYMLParser.cxx
@@ -171,7 +171,7 @@ TRYMLTree::Node &TRYMLTree::Node::operator<<(int i)
 
 TRYMLTree::Node &TRYMLTree::Node::operator<<(double d)
 {
-   // write an float to this node
+   // write a double to this node
    node->get() << d;
    return *this;
 }

--- a/roofit/multiprocess/src/HeatmapAnalyzer.cxx
+++ b/roofit/multiprocess/src/HeatmapAnalyzer.cxx
@@ -47,9 +47,9 @@ namespace MultiProcess {
 HeatmapAnalyzer::HeatmapAnalyzer(std::string const &logs_dir)
 {
    TSystemDirectory dir(logs_dir.c_str(), logs_dir.c_str());
-   TList *duration_files = dir.GetListOfFiles();
+   std::unique_ptr<TList> durationFiles{dir.GetListOfFiles()};
 
-   for (const auto &&file : *duration_files) {
+   for (TObject *file : *durationFiles) {
       if (std::string(file->GetName()).find("p_") == std::string::npos)
          continue;
 
@@ -81,8 +81,6 @@ HeatmapAnalyzer::HeatmapAnalyzer(std::string const &logs_dir)
    }
 
    sortTaskNames(tasks_names_);
-
-   duration_files->Delete();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/multiprocess/src/HeatmapAnalyzer.cxx
+++ b/roofit/multiprocess/src/HeatmapAnalyzer.cxx
@@ -44,7 +44,7 @@ namespace MultiProcess {
 /// \param[in] logs_dir Directory where log files are stored in the format
 ///                     outputted by RooFit::MultiProcess::ProcessTimer.
 ///                     There can be other files in this directory as well.
-HeatmapAnalyzer::HeatmapAnalyzer(std::string const& logs_dir)
+HeatmapAnalyzer::HeatmapAnalyzer(std::string const &logs_dir)
 {
    TSystemDirectory dir(logs_dir.c_str(), logs_dir.c_str());
    TList *duration_files = dir.GetListOfFiles();
@@ -96,13 +96,14 @@ std::unique_ptr<TH2I> HeatmapAnalyzer::analyze(int analyzed_gradient)
    int gradient_start_t = gradients_["master:gradient"][analyzed_gradient * 2 - 2];
    int gradient_end_t = gradients_["master:gradient"][analyzed_gradient * 2 - 1];
 
-
-   std::unique_ptr<TH2I> total_matrix = std::make_unique<TH2I>("heatmap", "", eval_partitions_names_.size(), 0, 1, tasks_names_.size(), 0, 1);
+   std::unique_ptr<TH2I> total_matrix =
+      std::make_unique<TH2I>("heatmap", "", eval_partitions_names_.size(), 0, 1, tasks_names_.size(), 0, 1);
 
    // loop over all logfiles stored in durations_
    for (json &durations_json : durations_) {
       // partial heatmap is the heatmap that will be filled in for the current durations logfile
-      std::unique_ptr<TH2I> partial_matrix = std::make_unique<TH2I>("partial_heatmap", "", eval_partitions_names_.size(), 0, 1, tasks_names_.size(), 0, 1);
+      std::unique_ptr<TH2I> partial_matrix =
+         std::make_unique<TH2I>("partial_heatmap", "", eval_partitions_names_.size(), 0, 1, tasks_names_.size(), 0, 1);
 
       // remove unnecessary components (those that are out of range)
       for (auto &&el : durations_json.items()) {
@@ -135,8 +136,8 @@ std::unique_ptr<TH2I> HeatmapAnalyzer::analyze(int analyzed_gradient)
                find(eval_partitions_names_.begin(), eval_partitions_names_.end(), eval_partition_name) -
                eval_partitions_names_.begin() + 1;
             partial_matrix->SetBinContent(eval_partitions_idx, tasks_idx,
-                                         durations_json[eval_partition_name][idx + 1].get<int>() -
-                                            durations_json[eval_partition_name][idx].get<int>());
+                                          durations_json[eval_partition_name][idx + 1].get<int>() -
+                                             durations_json[eval_partition_name][idx].get<int>());
          }
       }
       // add all partial matrices to form one matrix with entire gradient evaluation information

--- a/roofit/roofit/inc/RooPolynomial.h
+++ b/roofit/roofit/inc/RooPolynomial.h
@@ -40,6 +40,15 @@ public:
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
   double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
 
+  /// Get the x variable.
+  RooAbsReal const& x() const { return _x.arg(); }
+
+  /// Get the coefficient list.
+  RooArgList const& coefList() const { return _coefList; }
+
+  /// Return the order for the first coefficient in the list.
+  int lowestOrder() const { return _lowestOrder; }
+
 protected:
 
   RooRealProxy _x;

--- a/roofit/roofitcore/inc/LinkDef.h
+++ b/roofit/roofitcore/inc/LinkDef.h
@@ -124,7 +124,6 @@
 #pragma link C++ class RooGenContext+ ;
 #pragma link C++ class RooGenericPdf+ ;
 #pragma link C++ class RooGenProdProj+ ;
-#pragma link C++ class RooGrid+ ;
 #pragma link C++ class RooHistError+ ;
 #pragma link C++ class RooHist+ ;
 #pragma link C++ class RooImproperIntegrator1D+ ;

--- a/roofit/roofitcore/inc/RooGrid.h
+++ b/roofit/roofitcore/inc/RooGrid.h
@@ -16,27 +16,21 @@
 #ifndef ROO_GRID
 #define ROO_GRID
 
-#include "TObject.h"
-#include "RooPrintable.h"
+#include <RtypesCore.h>
 
+#include <ostream>
 #include <vector>
 
 class RooAbsFunc;
 
-class RooGrid : public TObject, public RooPrintable {
+// Utility class for RooMCIntegrator holding a multi-dimensional grid
+class RooGrid {
 public:
   RooGrid() {}
   RooGrid(const RooAbsFunc &function);
 
   // Printing interface
-  void printName(std::ostream& os) const override ;
-  void printTitle(std::ostream& os) const override ;
-  void printClassName(std::ostream& os) const override ;
-  void printMultiline(std::ostream& os, Int_t contents, bool verbose=false, TString indent="") const override;
-
-  inline void Print(Option_t *options= nullptr) const override {
-    printStream(defaultPrintStream(),defaultPrintContents(options),defaultPrintStyle(options));
-  }
+  void print(std::ostream& os, bool verbose=false, std::string const& indent="") const;
 
   inline bool isValid() const { return _valid; }
   inline UInt_t getDimension() const { return _dim; }
@@ -59,15 +53,13 @@ public:
   enum { maxBins = 50 }; // must be even
 
   // Accessor for the j-th normalized grid point along the i-th dimension
-public:
   inline double coord(Int_t i, Int_t j) const { return _xi[i*_dim + j]; }
   inline double value(Int_t i,Int_t j) const { return _d[i*_dim + j]; }
+
 protected:
   inline double& coord(Int_t i, Int_t j) { return _xi[i*_dim + j]; }
   inline double& value(Int_t i,Int_t j) { return _d[i*_dim + j]; }
   inline double& newCoord(Int_t i) { return _xin[i]; }
-
-protected:
 
   bool _valid = false;         ///< Is configuration valid
   UInt_t _dim = 0;             ///< Number of dimensions, bins and boxes
@@ -83,7 +75,6 @@ protected:
   std::vector<double> _xin;    ///<! Internal workspace
   std::vector<double> _weight; ///<! Internal workspace
 
-  ClassDefOverride(RooGrid,1) // Utility class for RooMCIntegrator holding a multi-dimensional grid
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooHelpers.h
+++ b/roofit/roofitcore/inc/RooHelpers.h
@@ -157,6 +157,8 @@ struct BinnedLOutput {
 
 BinnedLOutput getBinnedL(RooAbsPdf &pdf);
 
+void getSortedComputationGraph(RooAbsReal const &func, RooArgSet &out);
+
 }
 
 #endif /* ROOFIT_ROOFITCORE_INC_ROOHELPERS_H_ */

--- a/roofit/roofitcore/inc/RooNumConvPdf.h
+++ b/roofit/roofitcore/inc/RooNumConvPdf.h
@@ -62,9 +62,9 @@ protected:
 
   RooNumConvolution& conv() const { if (!_init) initialize() ; return *_conv ; }
 
-  mutable bool _init ; ///<! do not persist
+  mutable bool _init = false; ///<! do not persist
   void initialize() const ;
-  mutable RooNumConvolution* _conv ; ///<! Actual convolution calculation
+  mutable std::unique_ptr<RooNumConvolution> _conv ; ///<! Actual convolution calculation
 
   RooRealProxy _origVar ;         ///< Original convolution variable
   RooRealProxy _origPdf ;         ///< Original input PDF

--- a/roofit/roofitcore/inc/RooProdPdf.h
+++ b/roofit/roofitcore/inc/RooProdPdf.h
@@ -96,8 +96,6 @@ public:
 
   RooArgSet* findPdfNSet(RooAbsPdf const& pdf) const ;
 
-  void writeCacheToStream(std::ostream& os, RooArgSet const* nset) const;
-
   std::unique_ptr<RooAbsArg> compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileContext & ctx) const override;
 
 private:

--- a/roofit/roofitcore/inc/RooTruthModel.h
+++ b/roofit/roofitcore/inc/RooTruthModel.h
@@ -53,6 +53,9 @@ public:
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
   double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
 
+  void computeBatch(cudaStream_t*, double* output, size_t size, RooFit::Detail::DataMap const&) const override;
+  inline bool canComputeBatchWithCuda() const override { return true; }
+
 protected:
   double evaluate() const override ;
   void changeBasis(RooFormulaVar* basis) override ;

--- a/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
@@ -313,8 +313,8 @@ bool RooAbsAnaConvPdf::isDirectGenSafe(const RooAbsArg& arg) const
 
 RooAbsRealLValue* RooAbsAnaConvPdf::convVar()
 {
-  RooResolutionModel* conv = (RooResolutionModel*) _convSet.at(0) ;
-  if (!conv) return 0 ;
+  auto* conv = static_cast<RooResolutionModel*>(_convSet.at(0));
+  if (!conv) return nullptr;
   return &conv->convVar() ;
 }
 
@@ -488,7 +488,7 @@ double RooAbsAnaConvPdf::analyticalIntegralWN(Int_t code, const RooArgSet* normS
     double integral(0) ;
     const TNamed *_rangeName = RooNameReg::ptr(rangeName);
     for (auto convArg : _convSet) {
-      auto conv = static_cast<RooResolutionModel*>(convArg);
+      auto conv = static_cast<RooAbsPdf*>(convArg);
       double coef = getCoefNorm(index++,intCoefSet,_rangeName) ;
       //cout << "coefInt[" << index << "] = " << coef << " " ; intCoefSet->Print("1") ;
       if (coef!=0) {
@@ -506,7 +506,7 @@ double RooAbsAnaConvPdf::analyticalIntegralWN(Int_t code, const RooArgSet* normS
     double norm(0) ;
     const TNamed *_rangeName = RooNameReg::ptr(rangeName);
     for (auto convArg : _convSet) {
-      auto conv = static_cast<RooResolutionModel*>(convArg);
+      auto conv = static_cast<RooAbsPdf*>(convArg);
 
       double coefInt = getCoefNorm(index,intCoefSet,_rangeName) ;
       //cout << "coefInt[" << index << "] = " << coefInt << "*" << term << " " << (intCoefSet?*intCoefSet:RooArgSet()) << endl ;
@@ -657,7 +657,7 @@ void RooAbsAnaConvPdf::printMultiline(ostream& os, Int_t contents, bool verbose,
   RooAbsPdf::printMultiline(os,contents,verbose,indent);
 
   os << indent << "--- RooAbsAnaConvPdf ---" << endl;
-  for (auto * conv : static_range_cast<RooResolutionModel*>(_convSet)) {
+  for (RooAbsArg * conv : _convSet) {
     conv->printMultiline(os,contents,verbose,indent) ;
   }
 }

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -1064,9 +1064,12 @@ bool RooAbsArg::redirectServers(const RooAbsCollection& newSetOrig, bool mustRep
 
     if (!newServer) {
       if (mustReplaceAll) {
-        coutE(LinkStateMgmt) << "RooAbsArg::redirectServers(" << (void*)this << "," << GetName() << "): server " << oldServer->GetName()
-                    << " (" << (void*)oldServer << ") not redirected" << (nameChange?"[nameChange]":"") << endl ;
-        ret = true ;
+        std::stringstream ss;
+        ss << "RooAbsArg::redirectServers(" << (void*)this << "," << GetName() << "): server " << oldServer->GetName()
+           << " (" << (void*)oldServer << ") not redirected" << (nameChange?"[nameChange]":"");
+        const std::string errorMsg = ss.str();
+        coutE(LinkStateMgmt) << errorMsg << std::endl;
+        throw std::runtime_error(errorMsg);
       }
       continue ;
     }

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -1386,7 +1386,7 @@ TH1* RooAbsReal::createHistogram(const char *name, const RooAbsRealLValue& xvar,
   const RooArgSet* compSet = pc.getSet("compSet");
   bool haveCompSel = ( (compSpec && strlen(compSpec)>0) || compSet) ;
 
-  RooBinning* intBinning(0) ;
+  std::unique_ptr<RooBinning> intBinning;
   if (doIntBinning>0) {
     // Given RooAbsPdf* pdf and RooRealVar* obs
     std::unique_ptr<std::list<double>> bl{binBoundaries(const_cast<RooAbsRealLValue&>(xvar),xvar.getMin(),xvar.getMax())};
@@ -1404,7 +1404,7 @@ TH1* RooAbsReal::createHistogram(const char *name, const RooAbsRealLValue& xvar,
       std::vector<double> ba(bl->size());
       int i=0 ;
       for (auto const& elem : *bl) { ba[i++] = elem ; }
-      intBinning = new RooBinning(bl->size()-1,ba.data()) ;
+      intBinning = std::make_unique<RooBinning>(bl->size()-1,ba.data()) ;
     }
   }
 
@@ -1416,7 +1416,6 @@ TH1* RooAbsReal::createHistogram(const char *name, const RooAbsRealLValue& xvar,
     RooCmdArg tmp = RooFit::Binning(*intBinning) ;
     argListCreate.Add(&tmp) ;
     histo = xvar.createHistogram(name,argListCreate) ;
-    delete intBinning ;
   } else {
     histo = xvar.createHistogram(name,argListCreate) ;
   }

--- a/roofit/roofitcore/src/RooFitDriver.cxx
+++ b/roofit/roofitcore/src/RooFitDriver.cxx
@@ -126,17 +126,8 @@ RooFitDriver::RooFitDriver(const RooAbsReal &absReal, RooFit::BatchModeOption ba
    // Some checks and logging of used architectures
    RooFit::BatchModeHelpers::logArchitectureInfo(_batchMode);
 
-   // Get the set of nodes in the computation graph. Do the detour via
-   // RooArgList to avoid deduplication done after adding each element.
-   RooArgList serverList;
-   topNode().treeNodeServerList(&serverList, nullptr, true, true, false, true);
-   // If we fill the servers in reverse order, they are approximately in
-   // topological order so we save a bit of work in sortTopologically().
    RooArgSet serverSet;
-   serverSet.add(serverList.rbegin(), serverList.rend(), /*silent=*/true);
-   // Sort nodes topologically: the servers of any node will be before that
-   // node in the collection.
-   serverSet.sortTopologically();
+   RooHelpers::getSortedComputationGraph(topNode(), serverSet);
 
    _dataMapCPU.resize(serverSet.size());
    _dataMapCUDA.resize(serverSet.size());

--- a/roofit/roofitcore/src/RooGrid.cxx
+++ b/roofit/roofitcore/src/RooGrid.cxx
@@ -30,15 +30,11 @@ integration, following the VEGAS algorithm.
 #include "RooRandom.h"
 #include "TMath.h"
 #include "RooMsgService.h"
-#include "TClass.h"
 
 #include <math.h>
 #include "Riostream.h"
 #include <iomanip>
 
-using namespace std;
-
-ClassImp(RooGrid);
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -49,7 +45,7 @@ RooGrid::RooGrid(const RooAbsFunc &function)
 {
   // check that the input function is valid
   if(!(_valid= function.isValid())) {
-    oocoutE(nullptr,InputArguments) << ClassName() << ": cannot initialize using an invalid function" << endl;
+    oocoutE(nullptr,InputArguments) << "RooGrid: cannot initialize using an invalid function" << std::endl;
     return;
   }
 
@@ -80,18 +76,18 @@ bool RooGrid::initialize(const RooAbsFunc &function)
   for(UInt_t index= 0; index < _dim; index++) {
     _xl[index]= function.getMinLimit(index);
     if(RooNumber::isInfinite(_xl[index])) {
-      oocoutE(nullptr,Integration) << ClassName() << ": lower limit of dimension " << index << " is infinite" << endl;
+      oocoutE(nullptr,Integration) << "RooGrid: lower limit of dimension " << index << " is infinite" << std::endl;
       return false;
     }
     _xu[index]= function.getMaxLimit(index);
     if(RooNumber::isInfinite(_xl[index])) {
-      oocoutE(nullptr,Integration) << ClassName() << ": upper limit of dimension " << index << " is infinite" << endl;
+      oocoutE(nullptr,Integration) << "RooGrid: upper limit of dimension " << index << " is infinite" << std::endl;
       return false;
     }
     double dx= _xu[index] - _xl[index];
     if(dx <= 0) {
-      oocoutE(nullptr,Integration) << ClassName() << ": bad range for dimension " << index << ": [" << _xl[index]
-                   << "," << _xu[index] << "]" << endl;
+      oocoutE(nullptr,Integration) << "RooGrid: bad range for dimension " << index << ": [" << _xl[index]
+                   << "," << _xu[index] << "]" << std::endl;
       return false;
     }
     _delx[index]= dx;
@@ -186,7 +182,7 @@ void RooGrid::generatePoint(const UInt_t box[], double x[], UInt_t bin[], double
     // store the bin in which this point lies along the j-th
     // coordinate axis and calculate its width and position y
     // in normalized bin coordinates.
-    Int_t k= (Int_t)z;
+    Int_t k= static_cast<Int_t>(z);
     bin[j] = k;
     double y, bin_width;
     if(k == 0) {
@@ -242,49 +238,21 @@ bool RooGrid::nextBox(UInt_t box[]) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Print info about this object to the specified stream.
 
-void RooGrid::printMultiline(ostream& os, Int_t /*contents*/, bool verbose, TString indent) const
+void RooGrid::print(std::ostream& os, bool verbose, std::string const& indent) const
 {
-  os << ClassName() << ": volume = " << getVolume() << endl;
+  os << "RooGrid: volume = " << getVolume() << std::endl;
   os << indent << "  Has " << getDimension() << " dimension(s) each subdivided into "
-     << getNBins() << " bin(s) and sampled with " << _boxes << " box(es)" << endl;
-  for(UInt_t index= 0; index < getDimension(); index++) {
+     << getNBins() << " bin(s) and sampled with " << _boxes << " box(es)" << std::endl;
+  for(std::size_t index= 0; index < getDimension(); index++) {
     os << indent << "  (" << index << ") ["
-       << setw(10) << _xl[index] << "," << setw(10) << _xu[index] << "]" << endl;
+       << std::setw(10) << _xl[index] << "," << std::setw(10) << _xu[index] << "]" << std::endl;
     if(!verbose) continue;
-    for(UInt_t bin= 0; bin < _bins; bin++) {
+    for(std::size_t bin= 0; bin < _bins; bin++) {
       os << indent << "    bin-" << bin << " : x = " << coord(bin,index) << " , y = "
-    << value(bin,index) << endl;
+    << value(bin,index) << std::endl;
     }
   }
 }
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Print name of grid object
-
-void RooGrid::printName(ostream& os) const
-{
-  os << GetName() ;
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Print title of grid object
-
-void RooGrid::printTitle(ostream& os) const
-{
-  os << GetTitle() ;
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Print class name of grid object
-
-void RooGrid::printClassName(ostream& os) const
-{
-  os << ClassName() ;
-}
-
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -345,9 +313,8 @@ void RooGrid::refine(double alpha)
     double xnew = 0;
     double dw = 0;
 
-    UInt_t k;
     i = 1;
-    for (k = 0; k < _bins; k++) {
+    for (UInt_t k = 0; k < _bins; k++) {
       dw += _weight[k];
       xold = xnew;
       xnew = coord(k+1,j);
@@ -358,7 +325,7 @@ void RooGrid::refine(double alpha)
       }
     }
 
-    for (k = 1 ; k < _bins ; k++) {
+    for (UInt_t k = 1 ; k < _bins ; k++) {
       coord( k, j) = newCoord(k);
     }
 

--- a/roofit/roofitcore/src/RooHelpers.cxx
+++ b/roofit/roofitcore/src/RooHelpers.cxx
@@ -295,4 +295,19 @@ BinnedLOutput getBinnedL(RooAbsPdf &pdf)
    return {nullptr, false};
 }
 
+/// Get the topologically-sorted list of all nodes in the computation graph.
+void getSortedComputationGraph(RooAbsReal const &func, RooArgSet &out)
+{
+   // Get the set of nodes in the computation graph. Do the detour via
+   // RooArgList to avoid deduplication done after adding each element.
+   RooArgList serverList;
+   func.treeNodeServerList(&serverList, nullptr, true, true, false, true);
+   // If we fill the servers in reverse order, they are approximately in
+   // topological order so we save a bit of work in sortTopologically().
+   out.add(serverList.rbegin(), serverList.rend(), /*silent=*/true);
+   // Sort nodes topologically: the servers of any node will be before that
+   // node in the collection.
+   out.sortTopologically();
+}
+
 }

--- a/roofit/roofitcore/src/RooHistFunc.cxx
+++ b/roofit/roofitcore/src/RooHistFunc.cxx
@@ -238,13 +238,8 @@ void RooHistFunc::computeBatch(cudaStream_t*, double* output, size_t size, RooFi
 
 Int_t RooHistFunc::getMaxVal(const RooArgSet& vars) const
 {
-  RooAbsCollection* common = _depList.selectCommon(vars) ;
-  if (common->size()==_depList.size()) {
-    delete common ;
-    return 1;
-  }
-  delete common ;
-  return 0 ;
+  std::unique_ptr<RooAbsCollection> common{_depList.selectCommon(vars)};
+  return common->size() == _depList.size() ? 1 : 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooMCIntegrator.cxx
+++ b/roofit/roofitcore/src/RooMCIntegrator.cxx
@@ -113,7 +113,7 @@ RooMCIntegrator::RooMCIntegrator(const RooAbsFunc& function, SamplingMode mode,
 {
   // coverity[UNINIT_CTOR]
   if(!(_valid= _grid.isValid())) return;
-  if(_verbose) _grid.Print();
+  if(_verbose) _grid.print(std::cout);
 }
 
 
@@ -136,7 +136,7 @@ RooMCIntegrator::RooMCIntegrator(const RooAbsFunc& function, const RooNumIntConf
 
   // check that our grid initialized without errors
   if(!(_valid= _grid.isValid())) return;
-  if(_verbose) _grid.Print();
+  if(_verbose) _grid.print(std::cout);
 }
 
 
@@ -358,7 +358,7 @@ double RooMCIntegrator::vegas(Stage stage, UInt_t calls, UInt_t iterations, doub
                  << ")" << endl;
     // print the grid after the final iteration
     if (oodologD((TObject*)0,Integration)) {
-      if(it + 1 == iterations) _grid.Print("V");
+      if(it + 1 == iterations) _grid.print(std::cout, true);
     }
     _grid.refine(_alpha);
   }

--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -2318,10 +2318,6 @@ void RooProdPdf::CacheElem::writeToStream(std::ostream& os) const {
   }
 }
 
-void RooProdPdf::writeCacheToStream(std::ostream& os, RooArgSet const* nset) const {
-  getCacheElem(nset)->writeToStream(os);
-}
-
 std::unique_ptr<RooArgSet> RooProdPdf::fillNormSetForServer(RooArgSet const &normSet, RooAbsArg const &server) const
 {
    if (normSet.empty())

--- a/roofit/roofitcore/src/RooRealVar.cxx
+++ b/roofit/roofitcore/src/RooRealVar.cxx
@@ -727,9 +727,7 @@ void RooRealVar::writeToStream(ostream& os, bool compact) const
 
       os << " " ;
     } else {
-      TString* tmp = format(_printSigDigits,"EFA") ;
-      os << tmp->Data() << " " ;
-      delete tmp ;
+      os << std::unique_ptr<TString>{format(_printSigDigits,"EFA")}->Data() << " " ;
     }
 
     // Append limits if not constants

--- a/roofit/roofitcore/src/RooTruthModel.cxx
+++ b/roofit/roofitcore/src/RooTruthModel.cxx
@@ -78,28 +78,33 @@ RooTruthModel::~RooTruthModel()
 
 Int_t RooTruthModel::basisCode(const char* name) const
 {
-  // Check for optimized basis functions
-  if (!TString("exp(-@0/@1)").CompareTo(name)) return expBasisPlus ;
-  if (!TString("exp(@0/@1)").CompareTo(name)) return expBasisMinus ;
-  if (!TString("exp(-abs(@0)/@1)").CompareTo(name)) return expBasisSum ;
-  if (!TString("exp(-@0/@1)*sin(@0*@2)").CompareTo(name)) return sinBasisPlus ;
-  if (!TString("exp(@0/@1)*sin(@0*@2)").CompareTo(name)) return sinBasisMinus ;
-  if (!TString("exp(-abs(@0)/@1)*sin(@0*@2)").CompareTo(name)) return sinBasisSum ;
-  if (!TString("exp(-@0/@1)*cos(@0*@2)").CompareTo(name)) return cosBasisPlus ;
-  if (!TString("exp(@0/@1)*cos(@0*@2)").CompareTo(name)) return cosBasisMinus ;
-  if (!TString("exp(-abs(@0)/@1)*cos(@0*@2)").CompareTo(name)) return cosBasisSum ;
-  if (!TString("(@0/@1)*exp(-@0/@1)").CompareTo(name)) return linBasisPlus ;
-  if (!TString("(@0/@1)*(@0/@1)*exp(-@0/@1)").CompareTo(name)) return quadBasisPlus ;
-  if (!TString("exp(-@0/@1)*cosh(@0*@2/2)").CompareTo(name)) return coshBasisPlus;
-  if (!TString("exp(@0/@1)*cosh(@0*@2/2)").CompareTo(name)) return coshBasisMinus;
-  if (!TString("exp(-abs(@0)/@1)*cosh(@0*@2/2)").CompareTo(name)) return coshBasisSum;
-  if (!TString("exp(-@0/@1)*sinh(@0*@2/2)").CompareTo(name)) return sinhBasisPlus;
-  if (!TString("exp(@0/@1)*sinh(@0*@2/2)").CompareTo(name)) return sinhBasisMinus;
-  if (!TString("exp(-abs(@0)/@1)*sinh(@0*@2/2)").CompareTo(name)) return sinhBasisSum;
+   std::string str = name;
 
-  // Truth model is delta function, i.e. convolution integral
-  // is basis function, therefore we can handle any basis function
-  return genericBasis ;
+   // Remove whitespaces from the input string
+   str.erase(remove(str.begin(),str.end(),' '),str.end());
+
+   // Check for optimized basis functions
+   if (str == "exp(-@0/@1)") return expBasisPlus ;
+   if (str == "exp(@0/@1)") return expBasisMinus ;
+   if (str == "exp(-abs(@0)/@1)") return expBasisSum ;
+   if (str == "exp(-@0/@1)*sin(@0*@2)") return sinBasisPlus ;
+   if (str == "exp(@0/@1)*sin(@0*@2)") return sinBasisMinus ;
+   if (str == "exp(-abs(@0)/@1)*sin(@0*@2)") return sinBasisSum ;
+   if (str == "exp(-@0/@1)*cos(@0*@2)") return cosBasisPlus ;
+   if (str == "exp(@0/@1)*cos(@0*@2)") return cosBasisMinus ;
+   if (str == "exp(-abs(@0)/@1)*cos(@0*@2)") return cosBasisSum ;
+   if (str == "(@0/@1)*exp(-@0/@1)") return linBasisPlus ;
+   if (str == "(@0/@1)*(@0/@1)*exp(-@0/@1)") return quadBasisPlus ;
+   if (str == "exp(-@0/@1)*cosh(@0*@2/2)") return coshBasisPlus;
+   if (str == "exp(@0/@1)*cosh(@0*@2/2)") return coshBasisMinus;
+   if (str == "exp(-abs(@0)/@1)*cosh(@0*@2/2)") return coshBasisSum;
+   if (str == "exp(-@0/@1)*sinh(@0*@2/2)") return sinhBasisPlus;
+   if (str == "exp(@0/@1)*sinh(@0*@2/2)") return sinhBasisMinus;
+   if (str == "exp(-abs(@0)/@1)*sinh(@0*@2/2)") return sinhBasisSum;
+
+   // Truth model is delta function, i.e. convolution integral is basis
+   // function, therefore we can handle any basis function
+   return genericBasis ;
 }
 
 

--- a/roofit/roofitcore/src/RooTruthModel.cxx
+++ b/roofit/roofitcore/src/RooTruthModel.cxx
@@ -104,31 +104,45 @@ Int_t RooTruthModel::basisCode(const char* name) const
 
 
 
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Changes associated bases function to 'inBasis'
 
 void RooTruthModel::changeBasis(RooFormulaVar* inBasis)
 {
-  // Process change basis function. Since we actually
-  // evaluate the basis function object, we need to
-  // adjust our client-server links to the basis function here
+   // Remove client-server link to old basis
+   if (_basis) {
+      if (_basisCode == genericBasis) {
+         // In the case of a generic basis, we evaluate it directly, so the
+         // basis was a direct server.
+         removeServer(*_basis);
+      } else {
+         for (RooAbsArg *basisServer : _basis->servers()) {
+            removeServer(*basisServer);
+         }
+      }
 
-  // Remove client-server link to old basis
-  if (_basis) {
-    removeServer(*_basis) ;
-  }
+      if (_ownBasis) {
+         delete _basis;
+      }
+   }
+   _ownBasis = false;
 
-  // Change basis pointer and update client-server link
-  _basis = inBasis ;
-  if (_basis) {
-    addServer(*_basis,true,false) ;
-  }
+   _basisCode = inBasis ? basisCode(inBasis->GetTitle()) : 0;
 
-  _basisCode = inBasis?basisCode(inBasis->GetTitle()):0 ;
+   // Change basis pointer and update client-server link
+   _basis = inBasis;
+   if (_basis) {
+      if (_basisCode == genericBasis) {
+         // Since we actually evaluate the basis function object, we need to
+         // adjust our client-server links to the basis function here
+         addServer(*_basis, true, false);
+      } else {
+         for (RooAbsArg *basisServer : _basis->servers()) {
+            addServer(*basisServer, true, false);
+         }
+      }
+   }
 }
-
-
 
 
 

--- a/roofit/roofitcore/src/RooTruthModel.cxx
+++ b/roofit/roofitcore/src/RooTruthModel.cxx
@@ -358,9 +358,8 @@ RooAbsGenContext* RooTruthModel::modelGenContext
 (const RooAbsAnaConvPdf& convPdf, const RooArgSet &vars, const RooDataSet *prototype,
  const RooArgSet* auxProto, bool verbose) const
 {
-  RooArgSet forceDirect(convVar()) ;
-  return new RooGenContext(dynamic_cast<const RooAbsPdf&>(convPdf), vars, prototype,
-                           auxProto, verbose, &forceDirect) ;
+   RooArgSet forceDirect(convVar()) ;
+   return new RooGenContext(convPdf, vars, prototype, auxProto, verbose, &forceDirect);
 }
 
 

--- a/roofit/roofitcore/test/testRooDataHist.cxx
+++ b/roofit/roofitcore/test/testRooDataHist.cxx
@@ -193,16 +193,16 @@ public:
     TFile file(GetParam(), "READ");
     ASSERT_TRUE(file.IsOpen());
 
-    file.GetObject("dataHist", legacy);
+    legacy = std::unique_ptr<RooDataHist>{file.Get<RooDataHist>("dataHist")};
     ASSERT_NE(legacy, nullptr);
   }
 
   void TearDown() override {
-    delete legacy;
+    legacy.reset();
   }
 
 protected:
-  RooDataHist* legacy{nullptr};
+  std::unique_ptr<RooDataHist> legacy;
 };
 
 TEST_P(RooDataHistIO, ReadLegacy) {

--- a/roofit/roofitcore/test/testRooDataSet.cxx
+++ b/roofit/roofitcore/test/testRooDataSet.cxx
@@ -120,13 +120,15 @@ TEST(RooDataSet, BinnedClone)
    RooRealVar mes("Mes", "Mes", 5.28, 5.24, 5.29);
    mes.setBin(40);
    RooRealVar weight("weight", "weight", 1, 0, 100);
-   RooDataSet *data = new RooDataSet("dataset", "dataset", &chain, RooArgSet(mes, weight), 0, weight.GetName());
-   RooDataHist *hist = data->binnedClone();
 
-   EXPECT_DOUBLE_EQ(hist->sumEntries(), sumW);
+   {
+      RooDataSet data{"dataset", "dataset", &chain, RooArgSet(mes, weight), 0, weight.GetName()};
+      std::unique_ptr<RooDataHist> hist{data.binnedClone()};
 
-   delete hist; // invalid read here
-   delete data; // and here too
+      EXPECT_DOUBLE_EQ(hist->sumEntries(), sumW);
+
+      // the original crash happened when "hist" and "data" got destructed
+   }
 
    gSystem->Unlink(filename[0]);
    gSystem->Unlink(filename[1]);

--- a/roofit/roofitcore/test/testRooFormula.cxx
+++ b/roofit/roofitcore/test/testRooFormula.cxx
@@ -34,11 +34,10 @@ TEST(RooFormula, TestInvalidFormulae) {
   ASSERT_ANY_THROW(RooFormula("form", "x+t", x)) << "Formulae with y,z,t and no RooFit variable cannot work.";
   ASSERT_ANY_THROW(RooFormula("form", "x+a", x)) << "Formulae with unknown variable cannot work.";
 
-  RooFormula* form6 = nullptr;
-  ASSERT_NO_THROW( form6 = new RooFormula("form", "x+y", RooArgSet(x,y))) << "Formula with x,y must work.";
+  std::unique_ptr<RooFormula> form6;
+  ASSERT_NO_THROW( form6 = std::make_unique<RooFormula>("form", "x+y", RooArgList{x,y})) << "Formula with x,y must work.";
   ASSERT_NE(form6, nullptr);
   EXPECT_FLOAT_EQ(form6->eval(nullptr), 1.337 - 1.);
-  delete form6;
 }
 
 // In case of named arguments, the RooFormula will replace the argument names

--- a/roofit/roofitcore/test/testWorkspace.cxx
+++ b/roofit/roofitcore/test/testWorkspace.cxx
@@ -38,26 +38,23 @@ TEST(RooWorkspace, CloneModelConfig_ROOT_9777)
       TFile outfile(filename, "RECREATE");
 
       // now create the model config for this problem
-      RooWorkspace* w = new RooWorkspace("ws");
-      ModelConfig modelConfig("ModelConfig", w);
+      RooWorkspace ws{"ws"};
+      ModelConfig modelConfig("ModelConfig", &ws);
       modelConfig.SetPdf(pdf);
       modelConfig.SetParametersOfInterest(RooArgSet(sigma));
       modelConfig.SetGlobalObservables(RooArgSet(mu));
-      w->import(modelConfig);
+      ws.import(modelConfig);
 
-      outfile.WriteObject(w, "ws");
-      delete w;
+      outfile.WriteObject(&ws, "ws");
    }
 
    RooWorkspace *w2;
    {
       TFile infile(filename, "READ");
-      RooWorkspace *w;
-      infile.GetObject("ws", w);
-      ASSERT_TRUE(w) << "Workspace not read from file.";
+      std::unique_ptr<RooWorkspace> ws{infile.Get<RooWorkspace>("ws")};
+      ASSERT_TRUE(ws) << "Workspace not read from file.";
 
-      w2 = new RooWorkspace(*w);
-      delete w;
+      w2 = new RooWorkspace(*ws);
    }
 
    if(verbose) w2->Print();

--- a/test/stressRooFit_tests.h
+++ b/test/stressRooFit_tests.h
@@ -4638,22 +4638,18 @@ public:
   RooRealVar t("t","time",-1.,15.);
   RooRealVar cosa("cosa","cos(alpha)",-1.,1.);
 
-  // Use RooTruthModel to obtain compiled implementation of sinh/cosh modulated decay functions
-  RooRealVar tau("tau","#tau",1.5);
+  RooRealVar tau("tau", "#tau", 1.5);
   RooRealVar deltaGamma("deltaGamma","deltaGamma", 0.3);
-  RooTruthModel tm("tm","tm",t) ;
-  RooFormulaVar coshGBasis("coshGBasis","exp(-@0/ @1)*cosh(@0*@2/2)",RooArgList(t,tau,deltaGamma));
-  RooFormulaVar sinhGBasis("sinhGBasis","exp(-@0/ @1)*sinh(@0*@2/2)",RooArgList(t,tau,deltaGamma));
-  std::unique_ptr<RooAbsReal> coshGConv{tm.convolution(&coshGBasis,&t)};
-  std::unique_ptr<RooAbsReal> sinhGConv{tm.convolution(&sinhGBasis,&t)};
+  RooFormulaVar coshG("coshGBasis","exp(-@0/ @1)*cosh(@0*@2/2)", {t,tau,deltaGamma});
+  RooFormulaVar sinhG("sinhGBasis","exp(-@0/ @1)*sinh(@0*@2/2)", {t,tau,deltaGamma});
 
   // Construct polynomial amplitudes in cos(a)
   RooPolyVar poly1("poly1","poly1",cosa,RooArgList(RooConst(0.5),RooConst(0.2),RooConst(0.2)),0);
   RooPolyVar poly2("poly2","poly2",cosa,RooArgList(RooConst(1),RooConst(-0.2),RooConst(3)),0);
 
   // Construct 2D amplitude as uncorrelated product of amp(t)*amp(cosa)
-  RooProduct  ampl1("ampl1","amplitude 1",RooArgSet(poly1,*coshGConv));
-  RooProduct  ampl2("ampl2","amplitude 2",RooArgSet(poly2,*sinhGConv));
+  RooProduct  ampl1("ampl1","amplitude 1", {poly1, coshG});
+  RooProduct  ampl2("ampl2","amplitude 2", {poly2, sinhG});
 
 
 

--- a/tutorials/roofit/rf704_amplitudefit.C
+++ b/tutorials/roofit/rf704_amplitudefit.C
@@ -13,7 +13,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooTruthModel.h"
 #include "RooFormulaVar.h"
 #include "RooRealSumPdf.h"
 #include "RooPolyVar.h"
@@ -33,22 +32,18 @@ void rf704_amplitudefit()
    RooRealVar t("t", "time", -1., 15.);
    RooRealVar cosa("cosa", "cos(alpha)", -1., 1.);
 
-   // Use RooTruthModel to obtain compiled implementation of sinh/cosh modulated decay functions
    RooRealVar tau("tau", "#tau", 1.5);
    RooRealVar deltaGamma("deltaGamma", "deltaGamma", 0.3);
-   RooTruthModel truthModel("tm", "tm", t);
-   RooFormulaVar coshGBasis("coshGBasis", "exp(-@0/ @1)*cosh(@0*@2/2)", RooArgList(t, tau, deltaGamma));
-   RooFormulaVar sinhGBasis("sinhGBasis", "exp(-@0/ @1)*sinh(@0*@2/2)", RooArgList(t, tau, deltaGamma));
-   RooAbsReal *coshGConv = truthModel.convolution(&coshGBasis, &t);
-   RooAbsReal *sinhGConv = truthModel.convolution(&sinhGBasis, &t);
+   RooFormulaVar coshG("coshGBasis", "exp(-@0/ @1)*cosh(@0*@2/2)", {t, tau, deltaGamma});
+   RooFormulaVar sinhG("sinhGBasis", "exp(-@0/ @1)*sinh(@0*@2/2)", {t, tau, deltaGamma});
 
    // Construct polynomial amplitudes in cos(a)
-   RooPolyVar poly1("poly1", "poly1", cosa, RooArgList(0.5, 0.2, 0.2), 0);
-   RooPolyVar poly2("poly2", "poly2", cosa, RooArgList(1.0, -0.2, 3.0), 0);
+   RooPolyVar poly1("poly1", "poly1", cosa, RooArgList{0.5, 0.2, 0.2}, 0);
+   RooPolyVar poly2("poly2", "poly2", cosa, RooArgList{1.0, -0.2, 3.0}, 0);
 
    // Construct 2D amplitude as uncorrelated product of amp(t)*amp(cosa)
-   RooProduct ampl1("ampl1", "amplitude 1", RooArgSet(poly1, *coshGConv));
-   RooProduct ampl2("ampl2", "amplitude 2", RooArgSet(poly2, *sinhGConv));
+   RooProduct ampl1("ampl1", "amplitude 1", {poly1, coshG});
+   RooProduct ampl2("ampl2", "amplitude 2", {poly2, sinhG});
 
    // C o n s t r u c t   a m p l i t u d e   s u m   p d f
    // -----------------------------------------------------

--- a/tutorials/roofit/rf704_amplitudefit.py
+++ b/tutorials/roofit/rf704_amplitudefit.py
@@ -18,23 +18,18 @@ import ROOT
 t = ROOT.RooRealVar("t", "time", -1.0, 15.0)
 cosa = ROOT.RooRealVar("cosa", "cos(alpha)", -1.0, 1.0)
 
-# Use ROOT.RooTruthModel to obtain compiled implementation of sinh/cosh
-# modulated decay functions
 tau = ROOT.RooRealVar("tau", "#tau", 1.5)
 deltaGamma = ROOT.RooRealVar("deltaGamma", "deltaGamma", 0.3)
-tm = ROOT.RooTruthModel("tm", "tm", t)
-coshGBasis = ROOT.RooFormulaVar("coshGBasis", "exp(-@0/ @1)*cosh(@0*@2/2)", [t, tau, deltaGamma])
-sinhGBasis = ROOT.RooFormulaVar("sinhGBasis", "exp(-@0/ @1)*sinh(@0*@2/2)", [t, tau, deltaGamma])
-coshGConv = tm.convolution(coshGBasis, t)
-sinhGConv = tm.convolution(sinhGBasis, t)
+coshG = ROOT.RooFormulaVar("coshGBasis", "exp(-@0/ @1)*cosh(@0*@2/2)", [t, tau, deltaGamma])
+sinhG = ROOT.RooFormulaVar("sinhGBasis", "exp(-@0/ @1)*sinh(@0*@2/2)", [t, tau, deltaGamma])
 
 # Construct polynomial amplitudes in cos(a)
 poly1 = ROOT.RooPolyVar("poly1", "poly1", cosa, [0.5, 0.2, 0.2], 0)
 poly2 = ROOT.RooPolyVar("poly2", "poly2", cosa, [1.0, -0.2, 3.0], 0)
 
 # Construct 2D amplitude as uncorrelated product of amp(t)*amp(cosa)
-ampl1 = ROOT.RooProduct("ampl1", "amplitude 1", [poly1, coshGConv])
-ampl2 = ROOT.RooProduct("ampl2", "amplitude 2", [poly2, sinhGConv])
+ampl1 = ROOT.RooProduct("ampl1", "amplitude 1", [poly1, coshG])
+ampl2 = ROOT.RooProduct("ampl2", "amplitude 2", [poly2, sinhG])
 
 # Construct amplitude sum pdf
 # -----------------------------------------------------


### PR DESCRIPTION
This is a backport of some RooFit PRs that were recently merged to master to v6-28-00-patches.

1. https://github.com/root-project/root/pull/11942
2. https://github.com/root-project/root/pull/9539
   The final commit with the code modernization (others have already been backported in #11960)
3. https://github.com/root-project/root/pull/11963
4. https://github.com/root-project/root/pull/12015
5. https://github.com/root-project/root/pull/12022
    Only the last one about throwing the exception in `RooAbsArg::redirectServers (the other commits have been backported already in #12057 and #12092)
6. https://github.com/root-project/root/pull/12180
7. https://github.com/root-project/root/pull/12223
8. https://github.com/root-project/root/pull/12232
9. https://github.com/root-project/root/pull/12219
    Except for the first and last commit that relate to the RooFit AD work
10. https://github.com/root-project/root/pull/12304
11. https://github.com/root-project/root/pull/12442
     Only the first two commits that were not already backported
12. https://github.com/root-project/root/pull/12447


Related to https://github.com/root-project/root/issues/12319.

