### PR TITLE
[RF][HS3] Fix some closure issues between HistFactory and HistFactory HS3 implementation

### DIFF
--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -170,10 +170,6 @@ public:
    static void exportCategory(RooAbsCategory const &cat, RooFit::Detail::JSONNode &node);
 
 private:
-   struct Config {
-      static bool stripObservables;
-   };
-
    template <class T>
    T *requestImpl(const std::string &objname);
 

--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -165,7 +165,8 @@ public:
    static void
    writeCombinedDataName(RooFit::Detail::JSONNode &rootnode, std::string const &pdfName, std::string const &dataName);
 
-   static void exportDataHist(RooDataHist const &dataHist, RooFit::Detail::JSONNode &node);
+   static void
+   exportHisto(RooArgSet const &vars, std::size_t n, double const *contents, RooFit::Detail::JSONNode &output);
 
    static void exportCategory(RooAbsCategory const &cat, RooFit::Detail::JSONNode &node);
 

--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -170,6 +170,8 @@ public:
 
    static void exportCategory(RooAbsCategory const &cat, RooFit::Detail::JSONNode &node);
 
+   void queueExport(RooAbsArg const &arg) { _serversToExport.push_back(&arg); }
+
 private:
    template <class T>
    T *requestImpl(const std::string &objname);
@@ -198,5 +200,6 @@ private:
 
    // objects to represent intermediate information
    std::unique_ptr<RooFit::JSONIO::Detail::Domains> _domains;
+   std::vector<RooAbsArg const *> _serversToExport;
 };
 #endif

--- a/roofit/hs3/src/Domains.cxx
+++ b/roofit/hs3/src/Domains.cxx
@@ -97,8 +97,7 @@ void Domains::ProductDomain::writeJSON(RooFit::Detail::JSONNode &node) const
 
    for (auto const &item : _map) {
       auto const &elem = item.second;
-      RooFit::Detail::JSONNode &varnode = variablesNode.append_child();
-      varnode.set_map();
+      RooFit::Detail::JSONNode &varnode = variablesNode.append_child().set_map();
       varnode["name"] << item.first;
       if (elem.hasMin)
          varnode["min"] << elem.min;

--- a/roofit/hs3/src/HistFactoryJSONTool.cxx
+++ b/roofit/hs3/src/HistFactoryJSONTool.cxx
@@ -156,15 +156,11 @@ void exportMeasurement(RooStats::HistFactory::Measurement &measurement, JSONNode
    auto &analysisNode = RooJSONFactoryWSTool::appendNamedChild(n["analyses"], "simPdf");
    analysisNode.set_map();
    analysisNode["InterpolationScheme"] << measurement.GetInterpolationScheme();
-   auto &analysisDomains = analysisNode["domains"];
-   analysisDomains.set_seq();
-   analysisDomains.append_child() << "default_domain";
+   analysisNode["domains"].set_seq().append_child() << "default_domain";
 
-   auto &analysisPois = analysisNode["pois"];
-   analysisPois.set_seq();
+   auto &analysisPois = analysisNode["pois"].set_seq();
 
-   auto &analysisObservables = analysisNode["observables"];
-   analysisObservables.set_seq();
+   auto &analysisObservables = analysisNode["observables"].set_seq();
 
    for (const auto &poi : measurement.GetPOIList()) {
       analysisPois.append_child() << poi;
@@ -247,18 +243,13 @@ void exportMeasurement(RooStats::HistFactory::Measurement &measurement, JSONNode
       RooJSONFactoryWSTool::appendNamedChild(n.get("misc", "ROOT_internal", "combined_distributions"), "simPdf");
 
    child1["index_cat"] << "channelCat";
-   auto &labels1 = child1["labels"];
-   labels1.set_seq();
-   auto &indices1 = child1["indices"];
-   indices1.set_seq();
+   auto &labels1 = child1["labels"].set_seq();
+   auto &indices1 = child1["indices"].set_seq();
 
    child2["index_cat"] << "channelCat";
-   auto &labels2 = child2["labels"];
-   labels2.set_seq();
-   auto &indices2 = child2["indices"];
-   indices2.set_seq();
-   auto &pdfs2 = child2["distributions"];
-   pdfs2.set_seq();
+   auto &labels2 = child2["labels"].set_seq();
+   auto &indices2 = child2["indices"].set_seq();
+   auto &pdfs2 = child2["distributions"].set_seq();
 
    std::vector<std::string> channelNames;
    for (const auto &c : measurement.GetChannels()) {
@@ -327,10 +318,7 @@ void RooStats::HistFactory::JSONTool::PrintYAML(std::string const &filename)
 
 void RooStats::HistFactory::JSONTool::activateStatError(JSONNode &sampleNode)
 {
-   auto &modifiers = sampleNode["modifiers"];
-   modifiers.set_seq();
-   auto &node = modifiers.append_child();
-   node.set_map();
+   auto &node = sampleNode["modifiers"].set_seq().append_child().set_map();
    node["type"] << "staterror";
    node["name"] << "mcstat";
 }

--- a/roofit/hs3/src/JSONFactories_HistFactory.cxx
+++ b/roofit/hs3/src/JSONFactories_HistFactory.cxx
@@ -280,9 +280,11 @@ ParamHistFunc &createPHFMCStat(std::string name, const std::vector<double> &sumW
 
    ParamHistFunc &phf = createPHF(sysname, phfname, vals, tool, constraints, observables, statErrType, gammas, 0, 10);
 
-   // set constant NPs which are below the MC stat threshold, and remove them from the np list
+   // Set a reasonable range for gamma and set constant NPs which are below the
+   // MC stat threshold, and remove them from the np list.
    for (size_t i = 0; i < sumW.size(); ++i) {
       auto g = static_cast<RooRealVar *>(gammas.at(i));
+      g->setMax(1 + 5 * errs[i]);
       g->setError(errs[i]);
       if (errs[i] < statErrThresh) {
          g->setConstant(true); // all negative errs are set constant

--- a/roofit/hs3/src/JSONFactories_HistFactory.cxx
+++ b/roofit/hs3/src/JSONFactories_HistFactory.cxx
@@ -921,8 +921,7 @@ bool tryExportHistFactory(RooJSONFactoryWSTool *tool, const std::string &pdfname
 
       auto &s = RooJSONFactoryWSTool::appendNamedChild(elem["samples"], sample.name);
 
-      auto &modifiers = s["modifiers"];
-      modifiers.set_seq();
+      auto &modifiers = s["modifiers"].set_seq();
 
       for (const auto &nf : sample.normfactors) {
          auto &mod = RooJSONFactoryWSTool::appendNamedChild(modifiers, nf.name);
@@ -938,8 +937,7 @@ bool tryExportHistFactory(RooJSONFactoryWSTool *tool, const std::string &pdfname
          auto &mod = RooJSONFactoryWSTool::appendNamedChild(modifiers, sys.name);
          mod["type"] << "normsys";
          mod["constraint"] << toString(sys.constraint);
-         auto &data = mod["data"];
-         data.set_map();
+         auto &data = mod["data"].set_map();
          data["lo"] << sys.low;
          data["hi"] << sys.high;
       }
@@ -948,8 +946,7 @@ bool tryExportHistFactory(RooJSONFactoryWSTool *tool, const std::string &pdfname
          auto &mod = RooJSONFactoryWSTool::appendNamedChild(modifiers, sys.name);
          mod["type"] << "histosys";
          mod["constraint"] << toString(sys.constraint);
-         auto &data = mod["data"];
-         data.set_map();
+         auto &data = mod["data"].set_map();
          RooJSONFactoryWSTool::exportHistogram(*sys.low, data["lo"], varnames, nullptr, false, false);
          RooJSONFactoryWSTool::exportHistogram(*sys.high, data["hi"], varnames, nullptr, false, false);
       }
@@ -959,8 +956,7 @@ bool tryExportHistFactory(RooJSONFactoryWSTool *tool, const std::string &pdfname
          mod["type"] << "shapesys";
          mod["constraint"] << toString(sys.constraint);
          if (sys.constraint) {
-            auto &data = mod["data"];
-            data.set_map();
+            auto &data = mod["data"].set_map();
             auto &vals = data["vals"];
             vals.fill_seq(sys.constraints);
          }

--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -297,7 +297,8 @@ public:
    {
       const RooHistFunc *hf = static_cast<const RooHistFunc *>(func);
       elem["type"] << key();
-      tool->exportDataHist(hf->dataHist(), elem["data"]);
+      RooDataHist const &dh = hf->dataHist();
+      tool->exportHisto(*dh.get(), dh.numEntries(), dh.weightArray(), elem["data"]);
       return true;
    }
 };
@@ -323,7 +324,8 @@ public:
    {
       const RooHistPdf *hf = static_cast<const RooHistPdf *>(func);
       elem["type"] << key();
-      tool->exportDataHist(hf->dataHist(), elem["data"]);
+      RooDataHist const &dh = hf->dataHist();
+      tool->exportHisto(*dh.get(), dh.numEntries(), dh.weightArray(), elem["data"]);
       return true;
    }
 };

--- a/roofit/hs3/src/JSONIO.cxx
+++ b/roofit/hs3/src/JSONIO.cxx
@@ -13,7 +13,6 @@
 #include <RooFitHS3/JSONIO.h>
 
 #include <RooFit/Detail/JSONInterface.h>
-#include <RooFitHS3/RooJSONFactoryWSTool.h>
 
 #include <RooAbsPdf.h>
 
@@ -137,7 +136,7 @@ void loadFactoryExpressions(const std::string &fname)
    std::unique_ptr<RooFit::Detail::JSONTree> tree = RooFit::Detail::JSONTree::create(infile);
    const RooFit::Detail::JSONNode &n = tree->rootnode();
    for (const auto &cl : n.children()) {
-      std::string key(RooJSONFactoryWSTool::name(cl));
+      std::string key = cl.key();
       if (!cl.has_child("class")) {
          std::cerr << "error in file '" << fname << "' for entry '" << key << "': 'class' key is required!"
                    << std::endl;
@@ -215,7 +214,7 @@ void loadExportKeys(const std::string &fname)
    std::unique_ptr<RooFit::Detail::JSONTree> tree = RooFit::Detail::JSONTree::create(infile);
    const RooFit::Detail::JSONNode &n = tree->rootnode();
    for (const auto &cl : n.children()) {
-      std::string classname(RooJSONFactoryWSTool::name(cl));
+      std::string classname = cl.key();
       TClass *c = TClass::GetClass(classname.c_str());
       if (!c) {
          std::cerr << "unable to find class " << classname << ", skipping." << std::endl;
@@ -231,9 +230,7 @@ void loadExportKeys(const std::string &fname)
          }
          ex.type = cl["type"].val();
          for (const auto &k : cl["proxies"].children()) {
-            std::string key(RooJSONFactoryWSTool::name(k));
-            std::string val(k.val());
-            ex.proxies[key] = val;
+            ex.proxies[k.key()] = k.val();
          }
          exportKeys[c] = ex;
       }

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -28,6 +28,7 @@
 #include "Domains.h"
 
 #include "TH1.h"
+#include "TROOT.h"
 
 #include <algorithm>
 #include <fstream>
@@ -1394,9 +1395,20 @@ std::unique_ptr<JSONTree> RooJSONFactoryWSTool::createNewJSONTree()
    std::unique_ptr<JSONTree> tree = JSONTree::create();
    JSONNode &n = tree->rootnode();
    n.set_map();
-   n["metadata"].set_map();
-   // The currently implemented HS3 standard is version 0.1
-   n["metadata"]["version"] << "0.1.90";
+   auto& metadata = n["metadata"];
+   metadata.set_map();
+
+   // Bump to 0.2.0 once the HS3 v2 standard is final
+   metadata["hs3_version"] << "0.1.90";
+
+   // Add information about the ROOT version that was used to generate this file
+   auto& rootInfo = appendNamedChild(metadata["packages"], "ROOT");
+   std::string versionName = gROOT->GetVersion();
+   // We want to consistently use dots such that the version name can be easily
+   // digested automatically.
+   std::replace(versionName.begin(), versionName.end(), '/', '.');
+   rootInfo["version"] << versionName;
+
    return tree;
 }
 

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -340,9 +340,7 @@ void exportAttributes(const RooAbsArg *arg, JSONNode &rootnode)
          if (it.first == "factory_tag" || it.first == "PROD_TERM_TYPE")
             continue;
          initializeNode();
-         auto &dict = (*node)["dict"];
-         dict.set_map();
-         dict[it.first] << it.second;
+         (*node)["dict"].set_map()[it.first] << it.second;
       }
    }
    if (!arg->attributes().empty()) {
@@ -351,9 +349,7 @@ void exportAttributes(const RooAbsArg *arg, JSONNode &rootnode)
          if (attr == "SnapShot_ExtRefClone" || attr == "RooRealConstant_Factory_Object")
             continue;
          initializeNode();
-         auto &tags = (*node)["tags"];
-         tags.set_seq();
-         tags.append_child() << attr;
+         (*node)["tags"].set_seq().append_child() << attr;
       }
    }
 }
@@ -572,9 +568,7 @@ RooJSONFactoryWSTool::~RooJSONFactoryWSTool() {}
 
 JSONNode &RooJSONFactoryWSTool::appendNamedChild(JSONNode &node, std::string const &name)
 {
-   node.set_seq();
-   JSONNode &child = node.append_child();
-   child.set_map();
+   JSONNode &child = node.set_seq().append_child().set_map();
    child["name"] << name;
    return child;
 }
@@ -591,9 +585,7 @@ JSONNode const *RooJSONFactoryWSTool::findNamedChild(JSONNode const &node, std::
 JSONNode &RooJSONFactoryWSTool::makeVariablesNode(JSONNode &rootNode)
 {
    JSONNode &container = appendNamedChild(rootNode["parameter_points"], "default_values");
-   JSONNode &list = container["parameters"];
-   list.set_seq();
-   return list;
+   return container["parameters"].set_seq();
 }
 
 template <>
@@ -666,12 +658,10 @@ void RooJSONFactoryWSTool::exportHistogram(const TH1 &histo, JSONNode &node, con
                                            const TH1 *errH, bool writeObservables, bool writeErrors)
 {
    node.set_map();
-   auto &weights = node["contents"];
-   weights.set_seq();
+   auto &weights = node["contents"].set_seq();
    JSONNode *errors = nullptr;
    if (writeErrors) {
-      errors = &node["errors"];
-      errors->set_seq();
+      errors = &node["errors"].set_seq();
    }
    if (writeObservables) {
       RooJSONFactoryWSTool::writeObservables(histo, node, varnames);
@@ -954,8 +944,7 @@ void RooJSONFactoryWSTool::exportHisto(RooArgSet const &vars, std::size_t n, dou
       observableNode["nbins"] << var->numBins();
    }
 
-   auto &weights = output["contents"];
-   weights.set_seq();
+   auto &weights = output["contents"].set_seq();
    for (std::size_t i = 0; i < n; ++i) {
       double w = contents[i];
       // To make sure there are no unnecessary floating points in the JSON
@@ -969,10 +958,8 @@ void RooJSONFactoryWSTool::exportHisto(RooArgSet const &vars, std::size_t n, dou
 
 void RooJSONFactoryWSTool::exportCategory(RooAbsCategory const &cat, RooFit::Detail::JSONNode &node)
 {
-   auto &labels = node["labels"];
-   labels.set_seq();
-   auto &indices = node["indices"];
-   indices.set_seq();
+   auto &labels = node["labels"].set_seq();
+   auto &indices = node["indices"].set_seq();
 
    for (auto const &item : cat) {
       labels.append_child() << item.first;
@@ -1074,11 +1061,8 @@ void RooJSONFactoryWSTool::exportData(RooAbsData const &data)
    }
 
    exportVariables(variables, output["axes"]);
-   auto &coords = output["entries"];
-   coords.set_seq();
-   auto *weights = data.isWeighted() ? &output["weights"] : nullptr;
-   if (weights)
-      weights->set_seq();
+   auto &coords = output["entries"].set_seq();
+   auto *weights = data.isWeighted() ? &output["weights"].set_seq() : nullptr;
    for (int i = 0; i < data.numEntries(); ++i) {
       data.get(i);
       coords.append_child().fill_seq(variables, [](auto x) { return static_cast<RooRealVar *>(x)->getVal(); });
@@ -1243,9 +1227,7 @@ void RooJSONFactoryWSTool::exportModelConfig(JSONNode &rootnode, RooStats::Model
 
    JSONNode &analysisNode = appendNamedChild(rootnode["analyses"], pdf->GetName());
 
-   auto &analysisDomains = analysisNode["domains"];
-   analysisDomains.set_seq();
-   analysisDomains.append_child() << "default_domain";
+   analysisNode["domains"].set_seq().append_child() << "default_domain";
 
    analysisNode["likelihood"] << pdf->GetName();
 

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -216,7 +216,7 @@ void importAttributes(RooAbsArg *arg, JSONNode const &node)
 {
    if (auto seq = node.find("dict")) {
       for (const auto &attr : seq->children()) {
-         arg->setStringAttribute(RooJSONFactoryWSTool::name(attr).c_str(), attr.val().c_str());
+         arg->setStringAttribute(attr.key().c_str(), attr.val().c_str());
       }
    }
    if (auto seq = node.find("tags")) {
@@ -1192,7 +1192,7 @@ void RooJSONFactoryWSTool::importDependants(const JSONNode &n)
 
 std::string RooJSONFactoryWSTool::name(const JSONNode &n)
 {
-   return n.is_container() && n.has_child("name") ? n["name"].val() : (n.has_key() ? n.key() : n.val());
+   return n["name"].val();
 }
 
 void RooJSONFactoryWSTool::writeCombinedDataName(JSONNode &rootnode, std::string const &pdfName,
@@ -1426,7 +1426,7 @@ void RooJSONFactoryWSTool::importAllNodes(const RooFit::Detail::JSONNode &n)
             continue;
          RooArgSet vars;
          for (const auto &var : snsh.children()) {
-            if (RooRealVar *rrv = _workspace.var(RooJSONFactoryWSTool::name(var))) {
+            if (RooRealVar *rrv = _workspace.var(var.key())) {
                configureVariable(*_domains, var, *rrv);
                vars.add(*rrv);
             }

--- a/roofit/hs3/test/testHS3HistFactory.cxx
+++ b/roofit/hs3/test/testHS3HistFactory.cxx
@@ -189,10 +189,14 @@ TEST(TestHS3HistFactoryJSON, ClosureLoop)
    RooJSONFactoryWSTool newtool{newws};
    newtool.importJSONfromString(js);
 
-   // To check that JSON > WS > JSON doesn't change the JSON
+   std::string const &js3 = RooJSONFactoryWSTool{newws}.exportJSONtoString();
+
    if (writeJsonFiles) {
       RooJSONFactoryWSTool{newws}.exportJSON("hf3.json");
    }
+
+   // Chack that JSON > WS > JSON doesn't change the JSON
+   EXPECT_EQ(js, js3) << "The JSON -> WS -> JSON roundtrip did not result in the original JSON!";
 
    auto *newmc = dynamic_cast<RooStats::ModelConfig *>(newws.obj("ModelConfig"));
    EXPECT_TRUE(newmc != nullptr);

--- a/roofit/hs3/test/testHS3HistFactory.cxx
+++ b/roofit/hs3/test/testHS3HistFactory.cxx
@@ -23,7 +23,6 @@ const bool writeJsonFiles = false;
 
 void createInputFile(std::string const &inputFileName)
 {
-
    TH1F data("data", "data", 2, 1.0, 2.0);
 
    TH1F signal("signal", "signal histogram (pb)", 2, 1.0, 2.0);

--- a/roofit/hs3/test/testHS3SimultaneousFit.cxx
+++ b/roofit/hs3/test/testHS3SimultaneousFit.cxx
@@ -23,6 +23,19 @@
 
 namespace {
 
+void setupKeys()
+{
+   static bool isAlreadySetup = false;
+   if (isAlreadySetup)
+      return;
+
+   auto etcDir = std::string(TROOT::GetEtcDir());
+   RooFit::JSONIO::loadExportKeys(etcDir + "/RooFitHS3_wsexportkeys.json");
+   RooFit::JSONIO::loadFactoryExpressions(etcDir + "/RooFitHS3_wsfactoryexpressions.json");
+
+   isAlreadySetup = true;
+}
+
 std::unique_ptr<RooFitResult> writeJSONAndFitModel(std::string &jsonStr)
 {
    using namespace RooFit;
@@ -105,11 +118,9 @@ TEST(RooFitHS3, SimultaneousFit)
 {
    RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
 
-   using namespace RooFit;
+   setupKeys();
 
-   auto etcDir = std::string(TROOT::GetEtcDir());
-   RooFit::JSONIO::loadExportKeys(etcDir + "/RooFitHS3_wsexportkeys.json");
-   RooFit::JSONIO::loadFactoryExpressions(etcDir + "/RooFitHS3_wsfactoryexpressions.json");
+   using namespace RooFit;
 
    std::string jsonStr;
 

--- a/roofit/hs3/test/testRooFitHS3.cxx
+++ b/roofit/hs3/test/testRooFitHS3.cxx
@@ -27,9 +27,15 @@ namespace {
 
 void setupKeys()
 {
+   static bool isAlreadySetup = false;
+   if (isAlreadySetup)
+      return;
+
    auto etcDir = std::string(TROOT::GetEtcDir());
    RooFit::JSONIO::loadExportKeys(etcDir + "/RooFitHS3_wsexportkeys.json");
    RooFit::JSONIO::loadFactoryExpressions(etcDir + "/RooFitHS3_wsfactoryexpressions.json");
+
+   isAlreadySetup = true;
 }
 
 // Validate the JSON IO for a given RooAbsReal in a RooWorkspace. The workspace

--- a/roofit/jsoninterface/inc/RooFit/Detail/JSONInterface.h
+++ b/roofit/jsoninterface/inc/RooFit/Detail/JSONInterface.h
@@ -91,8 +91,8 @@ public:
    virtual bool is_container() const = 0;
    virtual bool is_map() const = 0;
    virtual bool is_seq() const = 0;
-   virtual void set_map() = 0;
-   virtual void set_seq() = 0;
+   virtual JSONNode &set_map() = 0;
+   virtual JSONNode &set_seq() = 0;
    virtual void clear() = 0;
 
    virtual std::string key() const = 0;

--- a/roofit/jsoninterface/src/JSONParser.cxx
+++ b/roofit/jsoninterface/src/JSONParser.cxx
@@ -14,14 +14,7 @@
 
 #include <sstream>
 
-#include "nlohmann/json.hpp"
-
-// TJSONTree interface
-
-TJSONTree::Node &TJSONTree::rootnode()
-{
-   return root;
-}
+#include <nlohmann/json.hpp>
 
 // TJSONTree methods
 
@@ -40,19 +33,9 @@ TJSONTree::Node &TJSONTree::incache(const TJSONTree::Node &n)
    return _nodecache.back();
 }
 
-TJSONTree *TJSONTree::Node::get_tree()
-{
-   return tree;
-}
-
 const TJSONTree::Node::Impl &TJSONTree::Node::get_node() const
 {
    return *node;
-}
-
-const TJSONTree *TJSONTree::Node::get_tree() const
-{
-   return tree;
 }
 
 TJSONTree::Node::Impl &TJSONTree::Node::get_node()
@@ -213,10 +196,10 @@ bool isResettingPossible(nlohmann::json const &node)
 }
 } // namespace
 
-void TJSONTree::Node::set_map()
+TJSONTree::Node &TJSONTree::Node::set_map()
 {
    if (node->get().type() == nlohmann::json::value_t::object)
-      return;
+      return *this;
 
    if (isResettingPossible(node->get())) {
       node->get() = nlohmann::json::object();
@@ -224,12 +207,13 @@ void TJSONTree::Node::set_map()
       throw std::runtime_error("cannot declare " + this->key() + " to be of map-type, already of type " +
                                node->get().type_name());
    }
+   return *this;
 }
 
-void TJSONTree::Node::set_seq()
+TJSONTree::Node &TJSONTree::Node::set_seq()
 {
    if (node->get().type() == nlohmann::json::value_t::array)
-      return;
+      return *this;
 
    if (isResettingPossible(node->get())) {
       node->get() = nlohmann::json::array();
@@ -237,6 +221,7 @@ void TJSONTree::Node::set_seq()
       throw std::runtime_error("cannot declare " + this->key() + " to be of seq-type, already of type " +
                                node->get().type_name());
    }
+   return *this;
 }
 
 void TJSONTree::Node::clear()
@@ -289,7 +274,7 @@ bool TJSONTree::Node::val_bool() const
 
 bool TJSONTree::Node::has_key() const
 {
-   return node->key().size() > 0;
+   return !node->key().empty();
 }
 
 bool TJSONTree::Node::has_val() const

--- a/roofit/jsoninterface/src/JSONParser.h
+++ b/roofit/jsoninterface/src/JSONParser.h
@@ -30,8 +30,8 @@ public:
       friend TJSONTree;
       std::unique_ptr<Impl> node;
 
-      const TJSONTree *get_tree() const;
-      TJSONTree *get_tree();
+      const TJSONTree *get_tree() const { return tree; }
+      TJSONTree *get_tree() { return tree; }
       const Impl &get_node() const;
       Impl &get_node();
 
@@ -54,8 +54,8 @@ public:
       bool is_container() const override;
       bool is_map() const override;
       bool is_seq() const override;
-      void set_map() override;
-      void set_seq() override;
+      Node &set_map() override;
+      Node &set_seq() override;
       void clear() override;
       std::string key() const override;
       std::string val() const override;
@@ -85,6 +85,6 @@ public:
    TJSONTree(std::istream &is);
    TJSONTree::Node &incache(const TJSONTree::Node &n);
 
-   Node &rootnode() override;
+   Node &rootnode() override { return root; }
 };
 #endif

--- a/roofit/jsoninterface/src/RYMLParser.cxx
+++ b/roofit/jsoninterface/src/RYMLParser.cxx
@@ -109,16 +109,18 @@ void TRYMLTree::Node::writeYML(std::ostream &os) const
    os << node->get();
 }
 
-void TRYMLTree::Node::set_map()
+TRYMLTree::Node &TRYMLTree::Node::set_map()
 {
    // assign this node to be a map (JSON object)
    node->get() |= c4::yml::MAP;
+   return *this;
 }
 
-void TRYMLTree::Node::set_seq()
+TRYMLTree::Node &TRYMLTree::Node::set_seq()
 {
    // assign this node to be a sequence (JSON array)
    node->get() |= c4::yml::SEQ;
+   return *this;
 }
 
 void TRYMLTree::Node::clear()

--- a/roofit/jsoninterface/src/RYMLParser.h
+++ b/roofit/jsoninterface/src/RYMLParser.h
@@ -51,8 +51,8 @@ public:
       bool is_container() const override;
       bool is_map() const override;
       bool is_seq() const override;
-      void set_map() override;
-      void set_seq() override;
+      Node &set_map() override;
+      Node &set_seq() override;
       void clear() override;
       std::string key() const override;
       std::string val() const override;


### PR DESCRIPTION
This PR achieves several things in the RooFit HS3 format:

* JSON -> WS -> JSON closure in the HistFactory test (the JSON is now invariant)
* Fix export of RooDataSets with only one entry
* Automatically export RooDataSets that represents binned datasets to the same format at binned datasets
* Also export special `Lumi` parameter from HistFactory
* Achieve exactly the same fit results with the same parameters when exporting HistFactory workspace to JSON and importing it back