### PR TITLE
[RF] Fix memory leaks from `RooAbsL::getParameters()`

### DIFF
--- a/roofit/roofitcore/inc/RooFit/TestStatistics/RooAbsL.h
+++ b/roofit/roofitcore/inc/RooFit/TestStatistics/RooAbsL.h
@@ -99,7 +99,7 @@ public:
    evaluatePartition(Section events, std::size_t components_begin, std::size_t components_end) = 0;
 
    // necessary from MinuitFcnGrad to reach likelihood properties:
-   virtual RooArgSet *getParameters();
+   virtual std::unique_ptr<RooArgSet> getParameters();
 
    /// \brief Interface function signaling a request to perform constant term optimization.
    ///

--- a/roofit/roofitcore/inc/RooFit/TestStatistics/RooSubsidiaryL.h
+++ b/roofit/roofitcore/inc/RooFit/TestStatistics/RooSubsidiaryL.h
@@ -28,7 +28,7 @@ public:
 
    ROOT::Math::KahanSum<double>
    evaluatePartition(Section events, std::size_t components_begin, std::size_t components_end) override;
-   inline RooArgSet *getParameters() override { return &parameter_set_; }
+   inline std::unique_ptr<RooArgSet> getParameters() override { return std::make_unique<RooArgSet>(parameter_set_); }
    inline std::string GetName() const override { return std::string("subsidiary_pdf_of_") + parent_pdf_name_; }
 
    inline std::string GetTitle() const override

--- a/roofit/roofitcore/src/TestStatistics/LikelihoodJob.cxx
+++ b/roofit/roofitcore/src/TestStatistics/LikelihoodJob.cxx
@@ -70,9 +70,10 @@ void LikelihoodJob::init_vars()
    save_vars_.removeAll();
 
    // Retrieve non-constant parameters
-   auto vars = std::make_unique<RooArgSet>(
-      *likelihood_->getParameters()); // TODO: make sure this is the right list of parameters, compare to original
-                                      // implementation in RooRealMPFE.cxx
+   std::unique_ptr<RooArgSet> vars{likelihood_->getParameters()};
+   // TODO: make sure this is the right list of parameters, compare to original
+   // implementation in RooRealMPFE.cxx
+
    RooArgList varList(*vars);
 
    // Save in lists

--- a/roofit/roofitcore/src/TestStatistics/LikelihoodSerial.cxx
+++ b/roofit/roofitcore/src/TestStatistics/LikelihoodSerial.cxx
@@ -67,7 +67,7 @@ void LikelihoodSerial::initVars()
    _saveVars.removeAll();
 
    // Retrieve non-constant parameters
-   auto vars = std::make_unique<RooArgSet>(*likelihood_->getParameters());
+   std::unique_ptr<RooArgSet> vars{likelihood_->getParameters()};
 
    RooArgList varList(*vars);
 

--- a/roofit/roofitcore/src/TestStatistics/MinuitFcnGrad.cxx
+++ b/roofit/roofitcore/src/TestStatistics/MinuitFcnGrad.cxx
@@ -82,7 +82,7 @@ private:
 MinuitFcnGrad::MinuitFcnGrad(const std::shared_ptr<RooFit::TestStatistics::RooAbsL> &absL, RooMinimizer *context,
                              std::vector<ROOT::Fit::ParameterSettings> &parameters, LikelihoodMode likelihoodMode,
                              LikelihoodGradientMode likelihoodGradientMode)
-   : RooAbsMinimizerFcn(RooArgList(*absL->getParameters()), context),
+   : RooAbsMinimizerFcn(*absL->getParameters(), context),
      _minuitInternalX(NDim(), 0),
      _minuitExternalX(NDim(), 0),
      _multiGenFcn{std::make_unique<MinuitGradFunctor>(*this)}

--- a/roofit/roofitcore/src/TestStatistics/RooAbsL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooAbsL.cxx
@@ -219,10 +219,9 @@ void RooAbsL::initClones(RooAbsPdf &inpdf, RooAbsData &indata)
    data_->optimizeReadingWithCaching(*pdf_, RooArgSet(), RooArgSet());
 }
 
-RooArgSet *RooAbsL::getParameters()
+std::unique_ptr<RooArgSet> RooAbsL::getParameters()
 {
-   auto ding = pdf_->getParameters(*data_);
-   return ding;
+   return std::unique_ptr<RooArgSet>{pdf_->getParameters(*data_)};
 }
 
 void RooAbsL::constOptimizeTestStatistic(RooAbsArg::ConstOpCode opcode, bool doAlsoTrackingOpt)

--- a/roofit/roofitcore/src/TestStatistics/RooRealL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooRealL.cxx
@@ -31,8 +31,9 @@ RooRealL::RooRealL(const char *name, const char *title, std::shared_ptr<RooAbsL>
    : RooAbsReal(name, title), likelihood_(std::move(likelihood)),
      vars_proxy_("varsProxy", "proxy set of parameters", this)
 {
-   vars_obs_.add(*likelihood_->getParameters());
-   vars_proxy_.add(*likelihood_->getParameters());
+   std::unique_ptr<RooArgSet> params{likelihood_->getParameters()};
+   vars_obs_.add(*params);
+   vars_proxy_.add(*params);
 }
 
 RooRealL::RooRealL(const RooRealL &other, const char *name)


### PR DESCRIPTION
The implementations of the virtual `RooAbsL::getParameters()` either returned an owning of a non-owning pointer, depending on the implementation class. RooSubsidiaryL returned a non-owning pointer, and the default implementation an owning pointer.

The caller code of course doesn't know what to do with this, resulting in memory leaks.

To fix this problem, the interface is suggested to return `std::unique_ptr<RooArgSet>`. Changing this interface now is okay because it has not been adopted by the users yet (it's from the new test statistic classes introduced in ROOT 6.26).