### PR TITLE
[ntuple] Remove restriction for dots in field names

### DIFF
--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -344,8 +344,6 @@ ROOT::Experimental::Detail::RFieldBase::EnsureValidFieldName(std::string_view fi
 {
    if (fieldName == "") {
       return R__FAIL("name cannot be empty string \"\"");
-   } else if (fieldName.find(".") != std::string::npos) {
-      return R__FAIL("name '" + std::string(fieldName) + "' cannot contain dot characters '.'");
    }
    return RResult<void>::Success();
 }

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -317,12 +317,6 @@ TEST(RNTupleModel, EnforceValidFieldNames)
    } catch (const RException& err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("name cannot be empty string"));
    }
-   try {
-      auto field3 = model->MakeField<float>("pt.pt", 42.0);
-      FAIL() << "field name with periods should throw";
-   } catch (const RException& err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("name 'pt.pt' cannot contain dot characters '.'"));
-   }
 
    // AddField
    try {


### PR DESCRIPTION
This PR removes the restriction on dot characters in field names. Removing this restriction will allow for a one-to-one correspondence to branch and field names in ATLAS PHYS(LITE) DAODs.

