### PR TITLE
[v626] TClassTable: fix data race between dlopen and other uses

### DIFF
--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -213,7 +213,10 @@ void TDirectory::Append(TObject *obj, Bool_t replace /* = kFALSE */)
    }
 
    fList->Add(obj);
-   obj->SetBit(kMustCleanup);
+   // A priori, a `TDirectory` object is assumed to not have shared ownership.
+   // If it is, let's rely on the user to update the bit.
+   if (!dynamic_cast<TDirectory*>(obj))
+      obj->SetBit(kMustCleanup);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/cont/inc/TClassTable.h
+++ b/core/cont/inc/TClassTable.h
@@ -25,7 +25,6 @@
 #include "TObject.h"
 #include <string>
 #include <atomic>
-#include <mutex>
 
 class TProtoClass;
 

--- a/core/cont/src/TClassTable.cxx
+++ b/core/cont/src/TClassTable.cxx
@@ -64,7 +64,7 @@ static std::mutex &GetClassTableMutex()
 }
 
 // RAII to first normalize the input classname (operation that
-// both requires the ROOT global lock and might call `TClassTable
+// both requires the ROOT global lock and might call `TClassTable`
 // resursively) and then acquire a lock on `TClassTable` local
 // mutex.
 class TClassTable::NormalizeThenLock {

--- a/core/cont/src/TClassTable.cxx
+++ b/core/cont/src/TClassTable.cxx
@@ -328,10 +328,12 @@ inline Bool_t TClassTable::CheckClassTableInit()
 
 void TClassTable::Print(Option_t *option) const
 {
+   std::lock_guard<std::mutex> lock(GetClassTableMutex());
+
+   // This is the very rare case (i.e. called before any dictionary load)
+   // so we don't need to execute this outside of the critical section.
    if (fgTally == 0 || !fgTable)
       return;
-
-   std::lock_guard<std::mutex> lock(GetClassTableMutex());
 
    SortTable();
 
@@ -472,6 +474,8 @@ void TClassTable::Add(TProtoClass *proto)
       if (r->fProto) delete r->fProto;
       r->fProto = proto;
       TClass *oldcl = (TClass*)gROOT->GetListOfClasses()->FindObject(cname);
+
+      lock.unlock(); // FillTClass might recursively call TClassTable during gROOT init
       if (oldcl && oldcl->GetState() == TClass::kHasTClassInit)
          proto->FillTClass(oldcl);
       return;
@@ -715,12 +719,14 @@ TProtoClass *TClassTable::GetProto(const char *cname)
    if (!CheckClassTableInit())
       return nullptr;
 
+   NormalizeThenLock guard(cname);
+
    if (gDebug > 9) {
+      // Because of the early call to Info, gROOT is already initialized
+      // and thus this will not cause a recursive call to TClassTable.
       ::Info("GetDict", "searches for %s", cname);
       fgIdMap->Print();
    }
-
-   NormalizeThenLock guard(cname);
 
    TClassRec *r = FindElement(guard.GetNormalizedName().c_str(), kFALSE);
    if (r)


### PR DESCRIPTION

This fixes https://github.com/root-project/root/issues/12552

This commit add a mutex for the TClassTable inner operations.
Several changes were needed to insure that operation that can
either take the ROOT global lock or recursively call TClassTable
are executed outside of the TClassTable critical sections.