### PR TITLE
[CI] Fix nightlies on Windows

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -197,7 +197,7 @@ jobs:
                     --buildtype    ${{ matrix.config }}
                     --platform     windows10
                     --incremental  false
-                    --base_ref     ${{ github.base_ref }}
+                    --base_ref     ${{ github.ref_name }}
                     --repository   ${{ github.server_url }}/${{ github.repository }}
                     --architecture ${{ matrix.target_arch }}  "
 


### PR DESCRIPTION

Fixes wrong variable being used to specify branch for windows nightlies
```diff
                     --platform     windows10
                     --incremental  false
-                    --base_ref     ${{ github.base_ref }}
+                    --base_ref     ${{ github.ref_name }}
                     --repository   ${{ github.server_url }}/${{ github.repository }}
```

