### PR TITLE
[RF] Improvements to `RooAbsPdf::paramOn()` formatting

### DIFF
--- a/README/ReleaseNotes/v630/index.md
+++ b/README/ReleaseNotes/v630/index.md
@@ -38,6 +38,8 @@ The following people have contributed to this new version:
 - The TStorage reallocation routine without a size (`TStorage::ReAlloc(void *ovp, size_t size`) and heap
 related routines (`TStorage::AddToHeap`, `TStorage::IsOnHeap`, `TStorage::GetHeapBegin`, `TStorage::GetHeapEnd`)
 that were deprecated in v6.02/00.
+- The deprecated `Format(const char* option, int sigDigits)` option for `RooAbsPdf::paramOn()` was removed. Please use the `Format(const char* option, ...)` overload that takes command arguments.
+- The deprecated `RooAbsPdf::paramOn()` overload that directly takes a formatting string was removed. Please take the overload that uses command arguments.
 
 ## Core Libraries
 

--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -141,10 +141,6 @@ public:
                            const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),
                            const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;
 
-  virtual RooPlot* paramOn(RooPlot* frame, const RooAbsData* data, const char *label= "", Int_t sigDigits = 2,
-            Option_t *options = "NELU", double xmin=0.65,
-            double xmax = 0.9, double ymax = 0.9) ;
-
   // Built-in generator support
   virtual Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, bool staticInitOK=true) const;
   virtual void initGenerator(Int_t code) ;
@@ -332,8 +328,8 @@ private:
 
   // Implementation version
   virtual RooPlot* paramOn(RooPlot* frame, const RooArgSet& params, bool showConstants=false,
-                           const char *label= "", Int_t sigDigits = 2, Option_t *options = "NELU", double xmin=0.65,
-            double xmax= 0.99,double ymax=0.95, const RooCmdArg* formatCmd=nullptr) ;
+                           const char *label= "", double xmin=0.65,
+                           double xmax= 0.99,double ymax=0.95, const RooCmdArg* formatCmd=nullptr) ;
 
   void logBatchComputationErrors(RooSpan<const double>& outputs, std::size_t begin) const;
   bool traceEvalPdf(double value) const;

--- a/roofit/roofitcore/inc/RooGlobalFunc.h
+++ b/roofit/roofitcore/inc/RooGlobalFunc.h
@@ -195,7 +195,6 @@ RooCmdArg OwnLinked() ;
 // RooAbsPdf::printLatex arguments
 RooCmdArg Columns(Int_t ncol) ;
 RooCmdArg OutputFile(const char* fileName) ;
-RooCmdArg Format(const char* format, Int_t sigDigit) ;
 RooCmdArg Format(const char* what, const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),
                  const RooCmdArg& arg3=RooCmdArg::none(),const RooCmdArg& arg4=RooCmdArg::none(),
                  const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none(),

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -3080,7 +3080,7 @@ RooPlot* RooAbsPdf::plotOn(RooPlot *frame, PlotOpt o) const
 /// <tr><td> `Format(const char* what,...)`       <td>  Parameter formatting options.
 ///   | Parameter              | Format
 ///   | ---------------------- | --------------------------
-///   | `const char* what`     |  Controls what is shown. "N" adds name, "E" adds error, "A" shows asymmetric error, "U" shows unit, "H" hides the value
+///   | `const char* what`     |  Controls what is shown. "N" adds name (alternatively, "T" adds the title), "E" adds error, "A" shows asymmetric error, "U" shows unit, "H" hides the value
 ///   | `FixedPrecision(int n)`|  Controls precision, set fixed number of digits
 ///   | `AutoPrecision(int n)` |  Controls precision. Number of shown digits is calculated from error + n specified additional digits (1 is sensible default)
 /// <tr><td> `Label(const chat* label)`           <td>  Add label to parameter box. Use `\n` for multi-line labels.

--- a/roofit/roofitcore/src/RooGlobalFunc.cxx
+++ b/roofit/roofitcore/src/RooGlobalFunc.cxx
@@ -216,7 +216,6 @@ namespace RooFit {
   RooCmdArg Columns(Int_t ncol)                           { return RooCmdArg("Columns",ncol,0,0,0,0,0,0,0) ; }
   RooCmdArg OutputFile(const char* fileName)              { return RooCmdArg("OutputFile",0,0,0,0,fileName,0,0,0) ; }
   RooCmdArg Sibling(const RooAbsCollection& sibling)      { return RooCmdArg("Sibling",0,0,0,0,0,0,&sibling,0) ; }
-  RooCmdArg Format(const char* format, Int_t sigDigit)    { return RooCmdArg("Format",sigDigit,0,0,0,format,0,0,0) ; }
   RooCmdArg Format(const char* what, const RooCmdArg& arg1,const RooCmdArg& arg2,const RooCmdArg& arg3,const RooCmdArg& arg4,
                    const RooCmdArg& arg5,const RooCmdArg& arg6,const RooCmdArg& arg7,const RooCmdArg& arg8) {
             RooCmdArg ret("FormatArgs",0,0,0,0,what,0,0,0) ; ret.addArg(arg1) ; ret.addArg(arg2) ;

--- a/roofit/roofitcore/src/RooRealVar.cxx
+++ b/roofit/roofitcore/src/RooRealVar.cxx
@@ -913,6 +913,7 @@ TString* RooRealVar::format(const RooCmdArg& formatArg) const
 ///
 /// To control what is shown use the following options
 /// N = show name
+/// T = show title (takes precedent over `N`, falls back to `N` if title is empty)
 /// H = hide value
 /// E = show error
 /// A = show asymmetric error instead of parabolic error (if available)
@@ -929,12 +930,12 @@ TString* RooRealVar::format(const RooCmdArg& formatArg) const
 
 TString *RooRealVar::format(Int_t sigDigits, const char *options) const
 {
-  //cout << "format = " << options << endl ;
-
   // parse the options string
   TString opts(options);
   opts.ToLower();
+
   bool showName= opts.Contains("n");
+  bool showTitle = opts.Contains("t");
   bool hideValue= opts.Contains("h");
   bool showError= opts.Contains("e");
   bool showUnit= opts.Contains("u");
@@ -942,6 +943,12 @@ TString *RooRealVar::format(Int_t sigDigits, const char *options) const
   bool latexMode= opts.Contains("x");
   bool latexTableMode = opts.Contains("y") ;
   bool latexVerbatimName = opts.Contains("v") ;
+
+  std::string label = showName ? getPlotLabel() : "";
+  if(showTitle) {
+     label = GetTitle();
+     if(label.empty()) label = getPlotLabel();
+  }
 
   if (latexTableMode) latexMode = true ;
   bool asymError= opts.Contains("a") ;
@@ -967,11 +974,11 @@ TString *RooRealVar::format(Int_t sigDigits, const char *options) const
   TString *text= new TString();
   if(latexMode) text->Append("$");
   // begin the string with "<name> = " if requested
-  if(showName) {
+  if(showName || showTitle) {
     if (latexTableMode && latexVerbatimName) {
       text->Append("\\verb+") ;
     }
-    text->Append(getPlotLabel());
+    text->Append(label);
     if (latexVerbatimName) text->Append("+") ;
 
     if (!latexTableMode) {


### PR DESCRIPTION
Two changes: 

1. Removes the deprecated `RooFit::Format(const char* option, int)` command argument
2. Remove deprecated `RooAbsPdf::paramOn()` overload that take a formatting string directly
3. Make it possible to use parameter titles instead of variables in `RooAbsPdf::paramOn()`, closing the followng JIRA ticket:
    https://sft.its.cern.ch/jira/browse/ROOT-6039

More detail in the commit descriptions.