### PR TITLE
[cmake] Fix `CUDA_TOOKIT_ROOT` typo in SearchInstalledSoftware.cmake

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1754,7 +1754,7 @@ if(cuda OR tmva-gpu)
       find_program(CUDA_NVCC_EXECUTABLE
         NAMES nvcc nvcc.exe
         PATHS "${CUDA_TOOLKIT_ROOT_DIR}"
-          ENV CUDA_TOOKIT_ROOT
+          ENV CUDA_TOOLKIT_ROOT
           ENV CUDA_PATH
           ENV CUDA_BIN_PATH
         PATH_SUFFIXES bin bin64


### PR DESCRIPTION
This should obviously be `CUDA_TOOLKIT_ROOT` with an L.

I don't know if this typo has any negative consequences, but it's maybe better to fix it before there are bugs creeping up because of that.