### PR TITLE
[RF] Introduce `RooFit::OwningPtr<T>` alias for owning pointers

### DIFF
--- a/roofit/histfactory/src/HistFactoryNavigation.cxx
+++ b/roofit/histfactory/src/HistFactoryNavigation.cxx
@@ -354,7 +354,8 @@ namespace RooStats {
     void HistFactoryNavigation::PrintParameters(bool IncludeConstantParams) {
 
       // Get the list of parameters
-      RooArgSet* params = fModel->getParameters(*fObservables);
+      RooArgSet params;
+      fModel->getParameters(fObservables, params);
 
       std::cout << std::endl;
 
@@ -366,7 +367,7 @@ namespace RooStats {
       << std::endl;
 
       // Loop over the parameters and print their values, etc
-      for (auto const *param : static_range_cast<RooRealVar *>(*params)) {
+      for (auto const *param : static_range_cast<RooRealVar *>(params)) {
         if( !IncludeConstantParams && param->isConstant() ) continue;
 
         std::cout << std::setw(30) << param->GetName();
@@ -383,7 +384,8 @@ namespace RooStats {
                          bool IncludeConstantParams) {
 
       // Get the list of parameters
-      RooArgSet* params = fModel->getParameters(*fObservables);
+      RooArgSet params;
+      fModel->getParameters(fObservables, params);
 
       // Get the pdf for this channel
       RooAbsPdf* channel_pdf = GetChannelPdf(channel);
@@ -398,7 +400,7 @@ namespace RooStats {
       << std::endl;
 
       // Loop over the parameters and print their values, etc
-      for (auto const *param : static_range_cast<RooRealVar *>(*params)) {
+      for (auto const *param : static_range_cast<RooRealVar *>(params)) {
         if( !IncludeConstantParams && param->isConstant() ) continue;
         if( findChild(param->GetName(), channel_pdf)==nullptr ) continue;
         std::cout << std::setw(30) << param->GetName();
@@ -417,7 +419,8 @@ namespace RooStats {
                         bool IncludeConstantParams) {
 
       // Get the list of parameters
-      RooArgSet* params = fModel->getParameters(*fObservables);
+      RooArgSet params;
+      fModel->getParameters(fObservables, params);
 
       // Get the pdf for this channel
       RooAbsReal* sample_func = SampleFunction(channel, sample);
@@ -432,7 +435,7 @@ namespace RooStats {
       << std::endl;
 
       // Loop over the parameters and print their values, etc
-      for (auto const *param : static_range_cast<RooRealVar *>(*params)) {
+      for (auto const *param : static_range_cast<RooRealVar *>(params)) {
         if( !IncludeConstantParams && param->isConstant() ) continue;
         if( findChild(param->GetName(), sample_func)==nullptr ) continue;
         std::cout << std::setw(30) << param->GetName();
@@ -1198,7 +1201,8 @@ namespace RooStats {
       // set the constant as
 
       // Get the list of parameters
-      RooArgSet* params = fModel->getParameters(*fObservables);
+      RooArgSet params;
+      fModel->getParameters(fObservables, params);
 
       std::cout << std::endl;
 
@@ -1210,7 +1214,7 @@ namespace RooStats {
       << std::endl;
 
       // Loop over the parameters and print their values, etc
-      for (auto *param : static_range_cast<RooRealVar *>(*params)) {
+      for (auto *param : static_range_cast<RooRealVar *>(params)) {
 
           std::string ParamName = param->GetName();
           TString ParamNameTString(ParamName);

--- a/roofit/roofit/inc/RooBDecay.h
+++ b/roofit/roofit/inc/RooBDecay.h
@@ -45,7 +45,7 @@ public:
   ~RooBDecay() override;
 
   double coefficient(Int_t basisIndex) const override;
-  RooArgSet* coefVars(Int_t coefIdx) const override ;
+  RooFit::OwningPtr<RooArgSet> coefVars(Int_t coefIdx) const override ;
 
   Int_t getCoefAnalyticalIntegral(Int_t coef, RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
   double coefAnalyticalIntegral(Int_t coef, Int_t code, const char* rangeName=nullptr) const override ;

--- a/roofit/roofit/inc/RooIntegralMorph.h
+++ b/roofit/roofit/inc/RooIntegralMorph.h
@@ -95,7 +95,7 @@ protected:
   PdfCacheElem* createCache(const RooArgSet* nset) const override ;
   const char* inputBaseName() const override ;
   RooArgSet* actualObservables(const RooArgSet& nset) const override ;
-  RooArgSet* actualParameters(const RooArgSet& nset) const override ;
+  RooFit::OwningPtr<RooArgSet> actualParameters(const RooArgSet& nset) const override ;
   void fillCacheObject(PdfCacheElem& cache) const override ;
 
   RooRealProxy pdf1 ; // First input shape

--- a/roofit/roofit/src/RooBDecay.cxx
+++ b/roofit/roofit/src/RooBDecay.cxx
@@ -132,7 +132,7 @@ double RooBDecay::coefficient(Int_t basisIndex) const
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooArgSet* RooBDecay::coefVars(Int_t basisIndex) const
+RooFit::OwningPtr<RooArgSet> RooBDecay::coefVars(Int_t basisIndex) const
 {
   if(basisIndex == _basisCosh)
     {
@@ -151,7 +151,7 @@ RooArgSet* RooBDecay::coefVars(Int_t basisIndex) const
       return _f3.arg().getVariables();
     }
 
-  return 0 ;
+  return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooIntegralMorph.cxx
+++ b/roofit/roofit/src/RooIntegralMorph.cxx
@@ -147,9 +147,9 @@ RooArgSet* RooIntegralMorph::actualObservables(const RooArgSet& /*nset*/) const
 /// Parameters of the cache. Returns parameters of both pdf1 and pdf2
 /// and parameter cache, in case doCacheAlpha is not set.
 
-RooArgSet* RooIntegralMorph::actualParameters(const RooArgSet& /*nset*/) const
+RooFit::OwningPtr<RooArgSet> RooIntegralMorph::actualParameters(const RooArgSet& /*nset*/) const
 {
-  RooArgSet* par1 = pdf1.arg().getParameters(static_cast<RooArgSet*>(nullptr));
+  auto par1 = pdf1.arg().getParameters(static_cast<RooArgSet*>(nullptr));
   RooArgSet par2;
   pdf2.arg().getParameters(nullptr, par2);
   par1->add(par2,true) ;
@@ -157,7 +157,7 @@ RooArgSet* RooIntegralMorph::actualParameters(const RooArgSet& /*nset*/) const
   if (!_cacheAlpha) {
     par1->add(alpha.arg()) ;
   }
-  return par1 ;
+  return RooFit::OwningPtr<RooArgSet>{std::move(par1)};
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooJeffreysPrior.cxx
+++ b/roofit/roofit/src/RooJeffreysPrior.cxx
@@ -107,7 +107,7 @@ double RooJeffreysPrior::evaluate() const
     //and we start to clone again.
     auto& pdf = _nominal.arg();
     RooAbsPdf* clonePdf = static_cast<RooAbsPdf*>(pdf.cloneTree());
-    auto vars = clonePdf->getParameters(_obsSet);
+    std::unique_ptr<RooArgSet> vars{clonePdf->getParameters(_obsSet)};
     for (auto varTmp : *vars) {
       auto& var = static_cast<RooRealVar&>(*varTmp);
       auto range = var.getRange();
@@ -117,7 +117,7 @@ double RooJeffreysPrior::evaluate() const
 
     cacheElm = new CacheElem;
     cacheElm->_pdf.reset(clonePdf);
-    cacheElm->_pdfVariables.reset(vars);
+    cacheElm->_pdfVariables = std::move(vars);
 
     _cacheMgr.setObj(nullptr, cacheElm);
   }

--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -20,6 +20,7 @@ endif()
 
 ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
   HEADERS
+    RooFit/Config.h
     RooFit/Detail/AnalyticalIntegrals.h
     RooFit/Detail/EvaluateFuncs.h
     RooFit/Detail/CodeSquashContext.h

--- a/roofit/roofitcore/inc/RooAbsAnaConvPdf.h
+++ b/roofit/roofitcore/inc/RooAbsAnaConvPdf.h
@@ -63,7 +63,7 @@ public:
   bool forceAnalyticalInt(const RooAbsArg& dep) const override ;
 
   virtual double coefficient(Int_t basisIndex) const = 0 ;
-  virtual RooArgSet* coefVars(Int_t coefIdx) const ;
+  virtual RooFit::OwningPtr<RooArgSet> coefVars(Int_t coefIdx) const ;
 
   bool isDirectGenSafe(const RooAbsArg& arg) const override ;
 

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -24,6 +24,7 @@
 #include "RooAbsCache.h"
 #include "RooNameReg.h"
 #include "RooLinkedListIter.h"
+#include <RooFit/Config.h>
 #include <RooFit/Detail/NormalizationHelpers.h>
 #include <RooStringView.h>
 
@@ -285,17 +286,11 @@ public:
 
 
   // Parameter & observable interpretation of servers
-  RooArgSet* getVariables(bool stripDisconnected=true) const ;
-  RooArgSet* getParameters(const RooAbsData* data, bool stripDisconnected=true) const ;
-  /// Return the parameters of this p.d.f when used in conjuction with dataset 'data'
-  RooArgSet* getParameters(const RooAbsData& data, bool stripDisconnected=true) const {
-    return getParameters(&data,stripDisconnected) ;
-  }
-  /// Return the parameters of the p.d.f given the provided set of observables
-  RooArgSet* getParameters(const RooArgSet& observables, bool stripDisconnected=true) const {
-    return getParameters(&observables,stripDisconnected);
-  }
-  RooArgSet* getParameters(const RooArgSet* observables, bool stripDisconnected=true) const;
+  RooFit::OwningPtr<RooArgSet> getVariables(bool stripDisconnected=true) const ;
+  RooFit::OwningPtr<RooArgSet> getParameters(const RooAbsData* data, bool stripDisconnected=true) const;
+  RooFit::OwningPtr<RooArgSet> getParameters(const RooAbsData& data, bool stripDisconnected=true) const;
+  RooFit::OwningPtr<RooArgSet> getParameters(const RooArgSet& observables, bool stripDisconnected=true) const;
+  RooFit::OwningPtr<RooArgSet> getParameters(const RooArgSet* observables, bool stripDisconnected=true) const;
   virtual bool getParameters(const RooArgSet* observables, RooArgSet& outputSet, bool stripDisconnected=true) const;
   /// Given a set of possible observables, return the observables that this PDF depends on.
   RooArgSet* getObservables(const RooArgSet& set, bool valueOnly=true) const {

--- a/roofit/roofitcore/inc/RooAbsCachedPdf.h
+++ b/roofit/roofitcore/inc/RooAbsCachedPdf.h
@@ -101,7 +101,7 @@ public:
   }
   virtual const char* inputBaseName() const = 0 ;
   virtual RooArgSet* actualObservables(const RooArgSet& nset) const = 0 ;
-  virtual RooArgSet* actualParameters(const RooArgSet& nset) const = 0 ;
+  virtual RooFit::OwningPtr<RooArgSet> actualParameters(const RooArgSet& nset) const = 0 ;
   virtual RooAbsArg& pdfObservable(RooAbsArg& histObservable) const { return histObservable ; }
   virtual void fillCacheObject(PdfCacheElem& cache) const = 0 ;
 

--- a/roofit/roofitcore/inc/RooAbsCachedReal.h
+++ b/roofit/roofitcore/inc/RooAbsCachedReal.h
@@ -96,7 +96,7 @@ protected:
   virtual FuncCacheElem* createCache(const RooArgSet* nset) const ;
   virtual const char* inputBaseName() const = 0 ;
   virtual RooArgSet* actualObservables(const RooArgSet& nset) const = 0 ;
-  virtual RooArgSet* actualParameters(const RooArgSet& nset) const = 0 ;
+  virtual RooFit::OwningPtr<RooArgSet> actualParameters(const RooArgSet& nset) const = 0 ;
   virtual void fillCacheObject(FuncCacheElem& cache) const = 0 ;
 
   mutable RooObjCacheManager _cacheMgr ; ///<! The cache manager

--- a/roofit/roofitcore/inc/RooAbsSelfCachedPdf.h
+++ b/roofit/roofitcore/inc/RooAbsSelfCachedPdf.h
@@ -33,7 +33,7 @@ protected:
     return GetName() ;
   }
   RooArgSet* actualObservables(const RooArgSet& nset) const override ;
-  RooArgSet* actualParameters(const RooArgSet& nset) const override ;
+  RooFit::OwningPtr<RooArgSet> actualParameters(const RooArgSet& nset) const override ;
   void fillCacheObject(PdfCacheElem& cache) const override ;
 
 private:

--- a/roofit/roofitcore/inc/RooAbsSelfCachedReal.h
+++ b/roofit/roofitcore/inc/RooAbsSelfCachedReal.h
@@ -33,7 +33,7 @@ protected:
     return GetName() ;
   }
   RooArgSet* actualObservables(const RooArgSet& nset) const override ;
-  RooArgSet* actualParameters(const RooArgSet& nset) const override ;
+  RooFit::OwningPtr<RooArgSet> actualParameters(const RooArgSet& nset) const override ;
   void fillCacheObject(FuncCacheElem& cache) const override ;
 
 private:

--- a/roofit/roofitcore/inc/RooCachedPdf.h
+++ b/roofit/roofitcore/inc/RooCachedPdf.h
@@ -35,7 +35,7 @@ protected:
     return pdf.arg().GetName() ;
   } ;
   RooArgSet* actualObservables(const RooArgSet& nset) const override ;
-  RooArgSet* actualParameters(const RooArgSet& nset) const override ;
+  RooFit::OwningPtr<RooArgSet> actualParameters(const RooArgSet& nset) const override ;
   void fillCacheObject(PdfCacheElem& cachePdf) const override ;
   double evaluate() const override {
     // Dummy evaluate, it is never called

--- a/roofit/roofitcore/inc/RooCachedReal.h
+++ b/roofit/roofitcore/inc/RooCachedReal.h
@@ -50,7 +50,7 @@ protected:
     return func.arg().GetName() ;
   } ;
   RooArgSet* actualObservables(const RooArgSet& nset) const override ;
-  RooArgSet* actualParameters(const RooArgSet& nset) const override ;
+  RooFit::OwningPtr<RooArgSet> actualParameters(const RooArgSet& nset) const override;
   void fillCacheObject(FuncCacheElem& cacheFunc) const override ;
   /// Dummy evaluate, it is never called
   double evaluate() const override {

--- a/roofit/roofitcore/inc/RooFFTConvPdf.h
+++ b/roofit/roofitcore/inc/RooFFTConvPdf.h
@@ -96,7 +96,7 @@ protected:
   double evaluate() const override { RooArgSet dummy(_x.arg()) ; return getVal(&dummy) ; } ; // dummy
   const char* inputBaseName() const override ;
   RooArgSet* actualObservables(const RooArgSet& nset) const override ;
-  RooArgSet* actualParameters(const RooArgSet& nset) const override ;
+  RooFit::OwningPtr<RooArgSet> actualParameters(const RooArgSet& nset) const override ;
   RooAbsArg& pdfObservable(RooAbsArg& histObservable) const override ;
   void fillCacheObject(PdfCacheElem& cache) const override ;
   void fillCacheSlice(FFTCacheElem& cache, const RooArgSet& slicePosition) const ;

--- a/roofit/roofitcore/inc/RooFit/Config.h
+++ b/roofit/roofitcore/inc/RooFit/Config.h
@@ -1,0 +1,31 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   Jonas Rembser, CERN 2023
+ *
+ * Copyright (c) 2023, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#ifndef RooFit_Config_h
+#define RooFit_Config_h
+
+namespace RooFit {
+
+/// An alias for raw pointers for indicating that the return type of a RooFit
+/// function is an owning pointer that must be deleted by the caller. For
+/// RooFit developers, it can be very useful to make this an alias to
+/// std::unique_ptr<T>, in order to check that your code has no memory
+/// problems. Changing this alias is equivalent to forcing all code immediately
+/// wraps the result of functions returning a RooFit::OwningPtr<T> in a
+/// std::unique_ptr<T>.
+template<typename T>
+using OwningPtr = T*;
+//using OwningPtr = std::unique_ptr<T>;
+
+}
+
+#endif

--- a/roofit/roofitcore/inc/RooGenFitStudy.h
+++ b/roofit/roofitcore/inc/RooGenFitStudy.h
@@ -68,10 +68,10 @@ public:
   RooAbsPdf::GenSpec* _genSpec ; ///<!
   RooRealVar* _nllVar ; ///<!
   RooRealVar* _ngenVar ; ///<!
-  RooArgSet* _params ; ///<!
+  std::unique_ptr<RooArgSet> _params; ///<!
   RooArgSet* _initParams; ///<!
 
-  ClassDefOverride(RooGenFitStudy,1) // Generate-and-Fit study module
+  ClassDefOverride(RooGenFitStudy,2) // Generate-and-Fit study module
 } ;
 
 

--- a/roofit/roofitcore/inc/RooNumRunningInt.h
+++ b/roofit/roofitcore/inc/RooNumRunningInt.h
@@ -48,7 +48,7 @@ protected:
   FuncCacheElem* createCache(const RooArgSet* nset) const override ;
   const char* inputBaseName() const override ;
   RooArgSet* actualObservables(const RooArgSet& nset) const override ;
-  RooArgSet* actualParameters(const RooArgSet& nset) const override ;
+  RooFit::OwningPtr<RooArgSet> actualParameters(const RooArgSet& nset) const override ;
   void fillCacheObject(FuncCacheElem& cacheFunc) const override ;
   double evaluate() const override ;
 

--- a/roofit/roofitcore/src/ModelConfig.cxx
+++ b/roofit/roofitcore/src/ModelConfig.cxx
@@ -113,13 +113,13 @@ void ModelConfig::GuessObsAndNuisance(const RooAbsData &data, bool printModelCon
    //      SetParametersOfInterest(RooArgSet());
    //   }
    if (!GetNuisanceParameters()) {
-      const RooArgSet *params = GetPdf()->getParameters(data);
-      RooArgSet p(*params);
+      RooArgSet params;
+      GetPdf()->getParameters(data.get(), params);
+      RooArgSet p(params);
       p.remove(*GetParametersOfInterest());
       removeConstantParameters(p);
       if (p.getSize() > 0)
          SetNuisanceParameters(p);
-      delete params;
    }
 
    // print Modelconfig as an info message

--- a/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
@@ -614,10 +614,8 @@ void RooAbsAnaConvPdf::makeCoefVarList(RooArgList& varList) const
 {
   // Instantate a coefficient variables
   for (Int_t i=0 ; i<_convSet.getSize() ; i++) {
-    RooArgSet* cvars = coefVars(i) ;
-    RooAbsReal* coefVar = new RooConvCoefVar(Form("%s_coefVar_%d",GetName(),i),"coefVar",*this,i,cvars) ;
-    varList.addOwned(*coefVar) ;
-    delete cvars ;
+    auto cvars = coefVars(i);
+    varList.addOwned(std::make_unique<RooConvCoefVar>(Form("%s_coefVar_%d",GetName(),i),"coefVar",*this,i,&*cvars));
   }
 
 }
@@ -626,9 +624,9 @@ void RooAbsAnaConvPdf::makeCoefVarList(RooArgList& varList) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Return set of parameters with are used exclusively by the coefficient functions
 
-RooArgSet* RooAbsAnaConvPdf::coefVars(Int_t /*coefIdx*/) const
+RooFit::OwningPtr<RooArgSet> RooAbsAnaConvPdf::coefVars(Int_t /*coefIdx*/) const
 {
-  RooArgSet* cVars = getParameters((RooArgSet*)0) ;
+  auto cVars = getParameters(static_cast<RooArgSet*>(nullptr));
   std::vector<RooAbsArg*> tmp;
   for (auto arg : *cVars) {
     for (auto convSetArg : _convSet) {
@@ -640,7 +638,7 @@ RooArgSet* RooAbsAnaConvPdf::coefVars(Int_t /*coefIdx*/) const
 
   cVars->remove(tmp.begin(), tmp.end(), true, true);
 
-  return cVars ;
+  return RooFit::OwningPtr<RooArgSet>{std::move(cVars)};
 }
 
 

--- a/roofit/roofitcore/src/RooAbsCachedReal.cxx
+++ b/roofit/roofitcore/src/RooAbsCachedReal.cxx
@@ -207,7 +207,7 @@ RooAbsCachedReal::FuncCacheElem::FuncCacheElem(const RooAbsCachedReal& self, con
   _func->setValueDirty() ;
 
   // Create pseudo-object that tracks changes in parameter values
-  RooArgSet* params = self.actualParameters(orderedObs) ;
+  std::unique_ptr<RooArgSet> params{self.actualParameters(orderedObs)};
   string name= Form("%s_CACHEPARAMS",_func->GetName()) ;
   _paramTracker = new RooChangeTracker(name.c_str(),name.c_str(),*params,true) ;
   _paramTracker->hasChanged(true) ; // clear dirty flag as cache is up-to-date upon creation
@@ -216,11 +216,8 @@ RooAbsCachedReal::FuncCacheElem::FuncCacheElem(const RooAbsCachedReal& self, con
   // makes the correct decisions
   _func->addServerList(*params) ;
 
-
   delete observables ;
-  delete params ;
   delete nset2 ;
-
 }
 
 

--- a/roofit/roofitcore/src/RooAbsSelfCachedPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsSelfCachedPdf.cxx
@@ -120,7 +120,7 @@ RooArgSet* RooAbsSelfCachedPdf::actualObservables(const RooArgSet& /*nset*/) con
 /// subset of variables of self that is not contained in the
 /// supplied nset
 
-RooArgSet* RooAbsSelfCachedPdf::actualParameters(const RooArgSet& nset) const
+RooFit::OwningPtr<RooArgSet> RooAbsSelfCachedPdf::actualParameters(const RooArgSet& nset) const
 {
   RooArgSet *serverSet = new RooArgSet;
 
@@ -131,7 +131,7 @@ RooArgSet* RooAbsSelfCachedPdf::actualParameters(const RooArgSet& nset) const
   // Remove all given observables from server list
   serverSet->remove(nset,true,true);
 
-  return serverSet;
+  return RooFit::OwningPtr<RooArgSet>{serverSet};
 }
 
 

--- a/roofit/roofitcore/src/RooAbsSelfCachedReal.cxx
+++ b/roofit/roofitcore/src/RooAbsSelfCachedReal.cxx
@@ -118,7 +118,7 @@ RooArgSet* RooAbsSelfCachedReal::actualObservables(const RooArgSet& nset) const
 /// subset of variables of self that is not contained in the
 /// supplied nset
 
-RooArgSet* RooAbsSelfCachedReal::actualParameters(const RooArgSet& nset) const
+RooFit::OwningPtr<RooArgSet> RooAbsSelfCachedReal::actualParameters(const RooArgSet& nset) const
 {
   // Make list of servers
   RooArgSet *serverSet = new RooArgSet;
@@ -130,12 +130,5 @@ RooArgSet* RooAbsSelfCachedReal::actualParameters(const RooArgSet& nset) const
   // Remove all given observables from server list
   serverSet->remove(nset,true,true);
 
-  return serverSet;
+  return RooFit::OwningPtr<RooArgSet>{serverSet};
 }
-
-
-
-
-
-
-

--- a/roofit/roofitcore/src/RooAbsTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsTestStatistic.cxx
@@ -501,13 +501,12 @@ void RooAbsTestStatistic::initSimMode(RooSimultaneous* simpdf, RooAbsData* data,
 
       // Servers may have been redirected between instantiation and (deferred) initialization
 
-      RooArgSet *actualParams = binnedInfo.binnedPdf ? binnedInfo.binnedPdf->getParameters(dset) : pdf->getParameters(dset);
+      auto actualParams = binnedInfo.binnedPdf ? binnedInfo.binnedPdf->getParameters(dset) : pdf->getParameters(dset);
       RooArgSet* selTargetParams = (RooArgSet*) _paramSet.selectCommon(*actualParams);
 
       _gofArray.back()->recursiveRedirectServers(*selTargetParams);
 
       delete selTargetParams;
-      delete actualParams;
     }
   }
   for(auto& gof : _gofArray) {

--- a/roofit/roofitcore/src/RooCachedPdf.cxx
+++ b/roofit/roofitcore/src/RooCachedPdf.cxx
@@ -156,12 +156,9 @@ RooArgSet* RooCachedPdf::actualObservables(const RooArgSet& nset) const
 /// the cache observables. If this p.d.f is operated in automatic mode,
 /// return the parameters of the external input p.d.f
 
-RooArgSet* RooCachedPdf::actualParameters(const RooArgSet& nset) const
+RooFit::OwningPtr<RooArgSet> RooCachedPdf::actualParameters(const RooArgSet& nset) const
 {
-  if (_cacheObs.getSize()>0) {
-    return pdf.arg().getParameters(_cacheObs) ;
-  }
-  return pdf.arg().getParameters(nset) ;
+   return pdf.arg().getParameters(_cacheObs.empty() ? nset : _cacheObs) ;
 }
 
 

--- a/roofit/roofitcore/src/RooCachedReal.cxx
+++ b/roofit/roofitcore/src/RooCachedReal.cxx
@@ -190,12 +190,9 @@ RooArgSet* RooCachedReal::actualObservables(const RooArgSet& nset) const
 /// the cache observables. If this p.d.f is operated in automatic mode,
 /// return the parameters of the external input p.d.f
 
-RooArgSet* RooCachedReal::actualParameters(const RooArgSet& nset) const
+RooFit::OwningPtr<RooArgSet> RooCachedReal::actualParameters(const RooArgSet& nset) const
 {
-  if (_cacheObs.getSize()>0) {
-    return func.arg().getParameters(_cacheObs) ;
-  }
-  return func.arg().getParameters(nset) ;
+   return func->getParameters(_cacheObs.empty() ? nset : _cacheObs);
 }
 
 

--- a/roofit/roofitcore/src/RooFFTConvPdf.cxx
+++ b/roofit/roofitcore/src/RooFFTConvPdf.cxx
@@ -741,12 +741,12 @@ RooArgSet* RooFFTConvPdf::actualObservables(const RooArgSet& nset) const
 /// set nset. For this p.d.f these are the parameters of the input p.d.f.
 /// but never the convolution variable, in case it is not part of nset.
 
-RooArgSet* RooFFTConvPdf::actualParameters(const RooArgSet& nset) const
+RooFit::OwningPtr<RooArgSet> RooFFTConvPdf::actualParameters(const RooArgSet& nset) const
 {
-  RooArgSet* vars = getVariables() ;
+  auto vars = getVariables() ;
   vars->remove(*std::unique_ptr<RooArgSet>{actualObservables(nset)});
 
-  return vars ;
+  return RooFit::OwningPtr<RooArgSet>{std::move(vars)};
 }
 
 

--- a/roofit/roofitcore/src/RooGenFitStudy.cxx
+++ b/roofit/roofitcore/src/RooGenFitStudy.cxx
@@ -51,7 +51,6 @@ RooGenFitStudy::RooGenFitStudy(const char* name, const char* title) :
   _genSpec(0),
   _nllVar(0),
   _ngenVar(0),
-  _params(0),
   _initParams(0)
 {
 }
@@ -72,7 +71,6 @@ RooGenFitStudy::RooGenFitStudy(const RooGenFitStudy& other) :
   _genSpec(0),
   _nllVar(0),
   _ngenVar(0),
-  _params(0),
   _initParams(0)
 {
   for(TObject * o : other._genOpts) _genOpts.Add(o->Clone());
@@ -85,7 +83,6 @@ RooGenFitStudy::RooGenFitStudy(const RooGenFitStudy& other) :
 
 RooGenFitStudy::~RooGenFitStudy()
 {
-  if (_params) delete _params ;
 }
 
 
@@ -164,7 +161,7 @@ bool RooGenFitStudy::initialize()
   _nllVar = new RooRealVar("NLL","-log(Likelihood)",0) ;
   _ngenVar = new RooRealVar("ngen","number of generated events",0) ;
 
-  _params = _fitPdf->getParameters(_genObs) ;
+  _params = std::unique_ptr<RooArgSet>{_fitPdf->getParameters(_genObs)};
   RooArgSet modelParams(*_params) ;
   _initParams = new RooArgSet;
   _params->snapshot(*_initParams);
@@ -206,12 +203,11 @@ bool RooGenFitStudy::execute()
 
 bool RooGenFitStudy::finalize()
 {
-  delete _params ;
   delete _nllVar ;
   delete _ngenVar ;
   delete _initParams ;
   delete _genSpec ;
-  _params = 0 ;
+  _params.reset();
   _nllVar = 0 ;
   _ngenVar = 0 ;
   _initParams = 0 ;

--- a/roofit/roofitcore/src/RooNumRunningInt.cxx
+++ b/roofit/roofitcore/src/RooNumRunningInt.cxx
@@ -270,11 +270,11 @@ RooArgSet* RooNumRunningInt::actualObservables(const RooArgSet& /*nset*/) const
 /// These are always the input functions parameter, but never the
 /// integrated variable x.
 
-RooArgSet* RooNumRunningInt::actualParameters(const RooArgSet& /*nset*/) const
+RooFit::OwningPtr<RooArgSet> RooNumRunningInt::actualParameters(const RooArgSet& /*nset*/) const
 {
-  RooArgSet* ret = func.arg().getParameters(RooArgSet()) ;
+  auto ret = func.arg().getParameters(RooArgSet()) ;
   ret->remove(x.arg(),true,true) ;
-  return ret ;
+  return ret;
 }
 
 

--- a/roofit/roofitcore/src/RooRealMPFE.cxx
+++ b/roofit/roofitcore/src/RooRealMPFE.cxx
@@ -170,7 +170,7 @@ void RooRealMPFE::initVars()
   _saveVars.removeAll() ;
 
   // Retrieve non-constant parameters
-  RooArgSet* vars = _arg.arg().getParameters(RooArgSet()) ;
+  auto vars = _arg->getParameters(RooArgSet());
   //RooArgSet* ncVars = (RooArgSet*) vars->selectByAttrib("Constant",false) ;
   RooArgList varList(*vars) ;
 
@@ -182,9 +182,6 @@ void RooRealMPFE::initVars()
 
   // Force next calculation
   _forceCalc = true ;
-
-  delete vars ;
-  //delete ncVars ;
 }
 
 double RooRealMPFE::getCarry() const

--- a/roofit/roofitcore/src/RooVectorDataStore.cxx
+++ b/roofit/roofitcore/src/RooVectorDataStore.cxx
@@ -829,14 +829,15 @@ void RooVectorDataStore::cacheArgs(const RooAbsArg* owner, RooArgSet& newVarSet,
   RooAbsArg::setDirtyInhibit(true) ;
 
   std::vector<RooArgSet*> nsetList ;
-  std::vector<RooArgSet*> argObsList ;
+  std::vector<std::unique_ptr<RooArgSet>> argObsList ;
 
   // Now need to attach branch buffers of clones
   for (const auto arg : cloneSet) {
     arg->attachToVStore(*newCache) ;
 
-    RooArgSet* argObs = nset ? arg->getObservables(*nset) : arg->getVariables() ;
-    argObsList.push_back(argObs) ;
+    if(nset) argObsList.emplace_back(arg->getObservables(*nset));
+    else argObsList.emplace_back(arg->getVariables());
+    RooArgSet* argObs = argObsList.back().get();
 
     RooArgSet* normSet(0) ;
     const char* catNset = arg->getStringAttribute("CATNormSet") ;
@@ -902,11 +903,6 @@ void RooVectorDataStore::cacheArgs(const RooAbsArg* owner, RooArgSet& newVarSet,
       rv->setNset(nsetList[idx]) ;
     }
 
-  }
-
-
-  for (auto set : argObsList) {
-    delete set;
   }
 
   _cache = newCache ;

--- a/roofit/roostats/inc/RooStats/MaxLikelihoodEstimateTestStat.h
+++ b/roofit/roostats/inc/RooStats/MaxLikelihoodEstimateTestStat.h
@@ -78,8 +78,8 @@ class MaxLikelihoodEstimateTestStat: public TestStatistic {
     return ret;
     */
 
-    RooArgSet* allParams = fPdf->getParameters(data);
-    RooStats::RemoveConstantParameters(allParams);
+    std::unique_ptr<RooArgSet> allParams{fPdf->getParameters(data)};
+    RooStats::RemoveConstantParameters(&*allParams);
 
     // need to call constrain for RooSimultaneous until stripDisconnected problem fixed
     RooAbsReal* nll = fPdf->createNLL(data, RooFit::CloneData(false),RooFit::Constrain(*allParams),RooFit::ConditionalObservables(fConditionalObs));

--- a/roofit/roostats/inc/RooStats/SimpleLikelihoodRatioTestStat.h
+++ b/roofit/roostats/inc/RooStats/SimpleLikelihoodRatioTestStat.h
@@ -48,13 +48,11 @@ namespace RooStats {
          fNullPdf = &nullPdf;
          fAltPdf = &altPdf;
 
-         RooArgSet * allNullVars = fNullPdf->getVariables();
+         std::unique_ptr<RooArgSet> allNullVars{fNullPdf->getVariables()};
          fNullParameters = (RooArgSet*) allNullVars->snapshot();
-         delete allNullVars;
 
-         RooArgSet * allAltVars = fAltPdf->getVariables();
+         std::unique_ptr<RooArgSet> allAltVars{fAltPdf->getVariables()};
          fAltParameters = (RooArgSet*) allAltVars->snapshot();
-         delete allAltVars;
 
          fDetailedOutputEnabled = false;
          fDetailedOutput = nullptr;

--- a/roofit/roostats/src/AsymptoticCalculator.cxx
+++ b/roofit/roostats/src/AsymptoticCalculator.cxx
@@ -176,8 +176,8 @@ bool AsymptoticCalculator::Initialize() const {
 
    // keep snapshot for the initial parameter values (need for nominal Asimov)
    RooArgSet nominalParams;
-   RooArgSet * allParams = nullPdf->getParameters(data);
-   RemoveConstantParameters(allParams);
+   std::unique_ptr<RooArgSet> allParams{nullPdf->getParameters(data)};
+   RemoveConstantParameters(&*allParams);
    if (fNominalAsimov) {
       allParams->snapshot(nominalParams);
    }
@@ -197,7 +197,6 @@ bool AsymptoticCalculator::Initialize() const {
       oocoutP(nullptr,Eval) << "Best fitted POI value = " << muBest->getVal() << " +/- " << muBest->getError() << std::endl;
    // keep snapshot of all best fit parameters
    allParams->snapshot(fBestFitParams);
-   delete allParams;
 
    // compute Asimov data set for the background (alt poi ) value
    const RooArgSet * altSnapshot = GetAlternateModel()->GetSnapshot();
@@ -295,8 +294,8 @@ double AsymptoticCalculator::EvaluateNLL(RooAbsPdf & pdf, RooAbsData& data,   co
     if (verbose < 2) RooMsgService::instance().setGlobalKillBelow(RooFit::FATAL);
 
 
-    RooArgSet* allParams = pdf.getParameters(data);
-    RooStats::RemoveConstantParameters(allParams);
+    std::unique_ptr<RooArgSet> allParams{pdf.getParameters(data)};
+    RooStats::RemoveConstantParameters(&*allParams);
     // add constraint terms for all non-constant parameters
 
     RooArgSet conditionalObs;
@@ -309,7 +308,7 @@ double AsymptoticCalculator::EvaluateNLL(RooAbsPdf & pdf, RooAbsData& data,   co
     RooAbsReal* nll = pdf.createNLL(data, RooFit::CloneData(false),RooFit::Constrain(*allParams),RooFit::ConditionalObservables(conditionalObs), RooFit::GlobalObservables(globalObs),
         RooFit::Offset(config.useLikelihoodOffset));
 
-    RooArgSet* attachedSet = nll->getVariables();
+    std::unique_ptr<RooArgSet> attachedSet{nll->getVariables()};
 
     // if poi are specified - do a conditional fit
     RooArgSet paramsSetConstant;
@@ -351,7 +350,6 @@ double AsymptoticCalculator::EvaluateNLL(RooAbsPdf & pdf, RooAbsData& data,   co
     //check if needed to skip the fit
     RooArgSet nllParams(*attachedSet);
     RooStats::RemoveConstantParameters(&nllParams);
-    delete attachedSet;
     bool skipFit = (nllParams.empty());
 
     if (skipFit)
@@ -457,7 +455,6 @@ double AsymptoticCalculator::EvaluateNLL(RooAbsPdf & pdf, RooAbsData& data,   co
 
     if (verbose < 2) RooMsgService::instance().setGlobalKillBelow(msglevel);
 
-    delete allParams;
     delete nll;
 
     return val;
@@ -507,9 +504,8 @@ HypoTestResult* AsymptoticCalculator::GetHypoTest() const {
       oocoutW(nullptr,InputArguments) << "AsymptoticCalculator::GetHypoTest: snapshot has more than one POI - assume as POI first parameter " << std::endl;
    }
 
-   RooArgSet * allParams = nullPdf->getParameters(*GetData() );
+   std::unique_ptr<RooArgSet> allParams{nullPdf->getParameters(*GetData() )};
    allParams->assign(fBestFitParams);
-   delete allParams;
 
    // set the one-side condition
    // (this works when we have only one params of interest
@@ -1311,8 +1307,8 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(RooAbsData & realData, const M
    SetAllConstant(paramsSetConstant, false);
 
 
-   RooArgSet *  allParams = model.GetPdf()->getParameters(realData);
-   RooStats::RemoveConstantParameters( allParams );
+   std::unique_ptr<RooArgSet> allParams{model.GetPdf()->getParameters(realData)};
+   RooStats::RemoveConstantParameters( &*allParams );
 
    // if a RooArgSet of poi is passed , different poi will be used for generating the Asimov data set
    if (genPoiValues) {
@@ -1321,12 +1317,7 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(RooAbsData & realData, const M
 
    // now do the actual generation of the AsimovData Set
    // no need to pass parameters values since we have set them before
-   RooAbsData * asimovData =  MakeAsimovData(model, *allParams, asimovGlobObs);
-
-   delete allParams;
-
-   return asimovData;
-
+   return MakeAsimovData(model, *allParams, asimovGlobObs);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1348,9 +1339,8 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(const ModelConfig & model, con
    // set the parameter values (do I need the poi to be constant ? )
    // the nuisance parameter values could be set at their fitted value (the MLE)
    if (!allParamValues.empty()) {
-      RooArgSet *  allVars = model.GetPdf()->getVariables();
+      std::unique_ptr<RooArgSet> allVars{model.GetPdf()->getVariables()};
       allVars->assign(allParamValues);
-      delete allVars;
    }
 
 

--- a/roofit/roostats/src/BayesianCalculator.cxx
+++ b/roofit/roostats/src/BayesianCalculator.cxx
@@ -489,7 +489,7 @@ public:
 
       ooccoutI(nullptr,InputArguments) << "PosteriorFunctionFromToyMC::Pdf used for randomizing the nuisance is " << fPdf->GetName() << std::endl;
       // check that pdf contains  the nuisance
-      RooArgSet * vars = fPdf->getVariables();
+      std::unique_ptr<RooArgSet> vars{fPdf->getVariables()};
       for (int i = 0; i < fNuisParams.getSize(); ++i) {
          if (!vars->find( fNuisParams[i].GetName() ) ) {
             ooccoutW(nullptr,InputArguments) << "Nuisance parameter " << fNuisParams[i].GetName()
@@ -497,7 +497,6 @@ public:
                                                  << "they will be treated as constant " << std::endl;
          }
       }
-      delete vars;
 
       if (!fRedoToys) {
          ooccoutI(nullptr,InputArguments) << "PosteriorFunctionFromToyMC::Generate nuisance toys only one time (for all POI points)" << std::endl;
@@ -799,9 +798,9 @@ RooAbsReal* BayesianCalculator::GetPosteriorFunction() const
    }
 
 
-   RooArgSet* constrainedParams = fPdf->getParameters(*fData);
+   std::unique_ptr<RooArgSet> constrainedParams{fPdf->getParameters(*fData)};
    // remove the constant parameters
-   RemoveConstantParameters(constrainedParams);
+   RemoveConstantParameters(&*constrainedParams);
 
    //constrainedParams->Print("V");
 
@@ -866,8 +865,6 @@ RooAbsReal* BayesianCalculator::GetPosteriorFunction() const
 
    delete nllFunc;
 
-   delete constrainedParams;
-
 
    if ( fNuisanceParameters.empty() ||  fIntegrationType.Contains("ROOFIT") ) {
 
@@ -898,11 +895,10 @@ RooAbsReal* BayesianCalculator::GetPosteriorFunction() const
          pdfAndPrior = fProductPdf;
       }
 
-      RooArgSet* constrParams = fPdf->getParameters(*fData);
+      std::unique_ptr<RooArgSet> constrParams{fPdf->getParameters(*fData)};
       // remove the constant parameters
-      RemoveConstantParameters(constrParams);
+      RemoveConstantParameters(&*constrParams);
       fLogLike = pdfAndPrior->createNLL(*fData, RooFit::Constrain(*constrParams),RooFit::ConditionalObservables(fConditionalObs),RooFit::GlobalObservables(fGlobalObs) );
-      delete constrParams;
 
       TString likeName = TString("likelihood_times_prior_") + TString(pdfAndPrior->GetName());
       TString formula;

--- a/roofit/roostats/src/FrequentistCalculator.cxx
+++ b/roofit/roostats/src/FrequentistCalculator.cxx
@@ -56,8 +56,8 @@ int FrequentistCalculator::PreNullHook(RooArgSet *parameterPoint, double obsTest
    // ****** any TestStatSampler ********
 
    // create profile keeping everything but nuisance parameters fixed
-   RooArgSet * allParams = fNullModel->GetPdf()->getParameters(*fData);
-   RemoveConstantParameters(allParams);
+   std::unique_ptr<RooArgSet> allParams{fNullModel->GetPdf()->getParameters(*fData)};
+   RemoveConstantParameters(&*allParams);
 
    // note: making nll or profile class variables can only be done in the constructor
    // as all other hooks are const (which has to be because GetHypoTest is const). However,
@@ -132,8 +132,6 @@ int FrequentistCalculator::PreNullHook(RooArgSet *parameterPoint, double obsTest
    if(fNullModel->GetNuisanceParameters())
       parameterPoint->add(*fNullModel->GetNuisanceParameters());
 
-   delete allParams;
-
 
    // ***** ToyMCSampler specific *******
 
@@ -173,8 +171,8 @@ int FrequentistCalculator::PreAltHook(RooArgSet *parameterPoint, double obsTestS
    // ****** any TestStatSampler ********
 
    // create profile keeping everything but nuisance parameters fixed
-   RooArgSet * allParams = fAltModel->GetPdf()->getParameters(*fData);
-   RemoveConstantParameters(allParams);
+   std::unique_ptr<RooArgSet> allParams{fAltModel->GetPdf()->getParameters(*fData)};
+   RemoveConstantParameters(&*allParams);
 
    bool doProfile = true;
    RooArgSet allButNuisance(*allParams);
@@ -243,8 +241,6 @@ int FrequentistCalculator::PreAltHook(RooArgSet *parameterPoint, double obsTestS
    // add nuisance parameters to parameter point
    if(fAltModel->GetNuisanceParameters())
       parameterPoint->add(*fAltModel->GetNuisanceParameters());
-
-   delete allParams;
 
    // ***** ToyMCSampler specific *******
 

--- a/roofit/roostats/src/HypoTestCalculatorGeneric.cxx
+++ b/roofit/roostats/src/HypoTestCalculatorGeneric.cxx
@@ -128,10 +128,9 @@ HypoTestResult* HypoTestCalculatorGeneric::GetHypoTest() const {
    }
 
    // get a big list of all variables for convenient switching
-   RooArgSet *nullParams = fNullModel->GetPdf()->getParameters(*fData);
-   RooArgSet *altParams = fAltModel->GetPdf()->getParameters(*fData);
+   std::unique_ptr<RooArgSet> altParams{fAltModel->GetPdf()->getParameters(*fData)};
    // save all parameters so we can set them back to what they were
-   RooArgSet *bothParams = fNullModel->GetPdf()->getParameters(*fData);
+   std::unique_ptr<RooArgSet> bothParams{fNullModel->GetPdf()->getParameters(*fData)};
    bothParams->add(*altParams,false);
    RooArgSet *saveAll = (RooArgSet*) bothParams->snapshot();
 
@@ -244,10 +243,7 @@ HypoTestResult* HypoTestCalculatorGeneric::GetHypoTest() const {
 
    bothParams->assign(*saveAll);
    delete allTS;
-   delete bothParams;
    delete saveAll;
-   delete altParams;
-   delete nullParams;
    delete nullSnapshot;
    PostHook();
    return res;

--- a/roofit/roostats/src/HypoTestInverter.cxx
+++ b/roofit/roostats/src/HypoTestInverter.cxx
@@ -144,7 +144,7 @@ void HypoTestInverter::CheckInputModels(const HypoTestCalculatorGeneric &hc,cons
       oocoutE(nullptr,InputArguments) << "HypoTestInverter - B model has no pdf or observables defined" <<  std::endl;
       return;
    }
-   RooArgSet * bParams = bPdf->getParameters(*bObs);
+   std::unique_ptr<RooArgSet> bParams{bPdf->getParameters(*bObs)};
    if (!bParams) {
       oocoutE(nullptr,InputArguments) << "HypoTestInverter - pdf of B model has no parameters" << std::endl;
       return;
@@ -158,7 +158,6 @@ void HypoTestInverter::CheckInputModels(const HypoTestCalculatorGeneric &hc,cons
                                              << " user must check input model configurations " << endl;
       if (poiB) delete poiB;
    }
-   delete bParams;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1167,7 +1166,7 @@ SamplingDistribution * HypoTestInverter::RebuildDistributions(bool isUpper, int 
    // save all parameters to restore them later
    assert(bModel->GetPdf() );
    assert(bModel->GetObservables() );
-   RooArgSet * allParams = bModel->GetPdf()->getParameters( *bModel->GetObservables() );
+   std::unique_ptr<RooArgSet> allParams{bModel->GetPdf()->getParameters( *bModel->GetObservables() )};
    RooArgSet saveParams;
    allParams->snapshot(saveParams);
 

--- a/roofit/roostats/src/LikelihoodInterval.cxx
+++ b/roofit/roostats/src/LikelihoodInterval.cxx
@@ -129,7 +129,7 @@ bool LikelihoodInterval::IsInInterval(const RooArgSet &parameterPoint) const
 
 
   // set parameters
-  SetParameters(&parameterPoint, fLikelihoodRatio->getVariables() );
+  SetParameters(&parameterPoint, std::unique_ptr<RooArgSet>{fLikelihoodRatio->getVariables()}.get());
 
 
   // evaluate likelihood ratio, see if it's bigger than threshold
@@ -227,12 +227,11 @@ bool LikelihoodInterval::CreateMinimizer() {
    // bind the nll function in the right interface for the Minimizer class
    // as a function of only the parameters (poi + nuisance parameters)
 
-   RooArgSet * partmp = profilell->getVariables();
+   std::unique_ptr<RooArgSet> partmp{profilell->getVariables()};
    // need to remove constant parameters
-   RemoveConstantParameters(partmp);
+   RemoveConstantParameters(&*partmp);
 
    RooArgList params(*partmp);
-   delete partmp;
 
    // need to restore values and errors for POI
    if (fBestFitParams) {
@@ -311,10 +310,9 @@ bool LikelihoodInterval::FindLimits(const RooRealVar & param, double &lower, dou
    }
 
 
-   RooArgSet * partmp = fLikelihoodRatio->getVariables();
-   RemoveConstantParameters(partmp);
+   std::unique_ptr<RooArgSet> partmp{fLikelihoodRatio->getVariables()};
+   RemoveConstantParameters(&*partmp);
    RooArgList params(*partmp);
-   delete partmp;
    int ix = params.index(&param);
    if (ix < 0 ) {
       ccoutE(InputArguments) << "Error - invalid parameter " << param.GetName() << " specified for finding the interval limits " << std::endl;
@@ -375,10 +373,9 @@ Int_t LikelihoodInterval::GetContourPoints(const RooRealVar & paramX, const RooR
    // check the parameters
    // variable index in minimizer
    // is index in the RooArgList obtained from the profileLL variables
-   RooArgSet * partmp = fLikelihoodRatio->getVariables();
-   RemoveConstantParameters(partmp);
+   std::unique_ptr<RooArgSet> partmp{fLikelihoodRatio->getVariables()};
+   RemoveConstantParameters(&*partmp);
    RooArgList params(*partmp);
-   delete partmp;
    int ix = params.index(&paramX);
    int iy = params.index(&paramY);
    if (ix < 0 || iy < 0) {

--- a/roofit/roostats/src/MCMCCalculator.cxx
+++ b/roofit/roostats/src/MCMCCalculator.cxx
@@ -170,18 +170,17 @@ MCMCInterval* MCMCCalculator::GetInterval() const
       prodPdf = new RooProdPdf(prodName,prodName,RooArgList(*fPdf,*fPriorPdf) );
    }
 
-   RooArgSet* constrainedParams = prodPdf->getParameters(*fData);
+   std::unique_ptr<RooArgSet> constrainedParams{prodPdf->getParameters(*fData)};
    RooAbsReal* nll = prodPdf->createNLL(*fData, Constrain(*constrainedParams),ConditionalObservables(fConditionalObs),GlobalObservables(fGlobalObs));
-   delete constrainedParams;
 
-   RooArgSet* params = nll->getParameters(*fData);
-   RemoveConstantParameters(params);
+   std::unique_ptr<RooArgSet> params{nll->getParameters(*fData)};
+   RemoveConstantParameters(&*params);
    if (fNumBins > 0) {
       SetBins(*params, fNumBins);
       SetBins(fPOI, fNumBins);
       if (dynamic_cast<PdfProposal*>(fPropFunc)) {
-         RooArgSet* proposalVars = ((PdfProposal*)fPropFunc)->GetPdf()->
-                                               getParameters((RooAbsData*)nullptr);
+         std::unique_ptr<RooArgSet> proposalVars{((PdfProposal*)fPropFunc)->GetPdf()->
+                                               getParameters((RooAbsData*)nullptr)};
          SetBins(*proposalVars, fNumBins);
       }
    }
@@ -217,7 +216,6 @@ MCMCInterval* MCMCCalculator::GetInterval() const
    if (useDefaultPropFunc) delete fPropFunc;
    if (usePriorPdf) delete prodPdf;
    delete nll;
-   delete params;
 
    return interval;
 }

--- a/roofit/roostats/src/ProfileLikelihoodCalculator.cxx
+++ b/roofit/roostats/src/ProfileLikelihoodCalculator.cxx
@@ -131,9 +131,9 @@ RooAbsReal *  ProfileLikelihoodCalculator::DoGlobalFit() const {
    if (!data || !pdf ) return 0;
 
    // get all non-const parameters
-   RooArgSet* constrainedParams = pdf->getParameters(*data);
+   std::unique_ptr<RooArgSet> constrainedParams{pdf->getParameters(*data)};
    if (!constrainedParams) return 0;
-   RemoveConstantParameters(constrainedParams);
+   RemoveConstantParameters(&*constrainedParams);
 
    const auto& config = GetGlobalRooStatsConfig();
    RooAbsReal * nll = pdf->createNLL(*data, CloneData(true), Constrain(*constrainedParams),ConditionalObservables(fConditionalObs), GlobalObservables(fGlobalObs),
@@ -141,7 +141,6 @@ RooAbsReal *  ProfileLikelihoodCalculator::DoGlobalFit() const {
 
    // check if global fit has been already done
    if (fFitResult && fGlobalFitDone) {
-      delete constrainedParams;
       return nll;
    }
 
@@ -161,7 +160,6 @@ RooAbsReal *  ProfileLikelihoodCalculator::DoGlobalFit() const {
          fGlobalFitDone = true;
    }
 
-   delete constrainedParams;
    return nll;
 }
 
@@ -226,10 +224,10 @@ LikelihoodInterval* ProfileLikelihoodCalculator::GetInterval() const {
 //    RooAbsData* data = fWS->data(fDataName);
    RooAbsPdf * pdf = GetPdf();
    RooAbsData* data = GetData();
-   if (!data || !pdf || fPOI.empty()) return 0;
+   if (!data || !pdf || fPOI.empty()) return nullptr;
 
-   RooArgSet* constrainedParams = pdf->getParameters(*data);
-   RemoveConstantParameters(constrainedParams);
+   std::unique_ptr<RooArgSet> constrainedParams{pdf->getParameters(*data)};
+   RemoveConstantParameters(&*constrainedParams);
 
 
    /*
@@ -284,7 +282,6 @@ LikelihoodInterval* ProfileLikelihoodCalculator::GetInterval() const {
    // and bestPOI contains a snapshot with the best fit values
    LikelihoodInterval* interval = new LikelihoodInterval(name, profile, &fPOI, bestPOI);
    interval->SetConfidenceLevel(1.-fSize);
-   delete constrainedParams;
    return interval;
 }
 
@@ -324,8 +321,8 @@ HypoTestResult* ProfileLikelihoodCalculator::GetHypoTest() const {
       return 0;
    }
 
-   RooArgSet* constrainedParams = pdf->getParameters(*data);
-   RemoveConstantParameters(constrainedParams);
+   std::unique_ptr<RooArgSet> constrainedParams{pdf->getParameters(*data)};
+   RemoveConstantParameters(&*constrainedParams);
 
    double nLLatMLE = fFitResult->minNll();
    // in case of using offset need to save offset value
@@ -408,7 +405,6 @@ HypoTestResult* ProfileLikelihoodCalculator::GetHypoTest() const {
       }
    }
 
-   delete constrainedParams;
    delete nll;
    return htr;
 

--- a/roofit/roostats/src/ProfileLikelihoodTestStat.cxx
+++ b/roofit/roostats/src/ProfileLikelihoodTestStat.cxx
@@ -84,8 +84,8 @@ double RooStats::ProfileLikelihoodTestStat::EvaluateProfileLikelihood(int type, 
 
        bool created(false) ;
        if (!reuse || fNll==0) {
-          RooArgSet* allParams = fPdf->getParameters(data);
-          RooStats::RemoveConstantParameters(allParams);
+          std::unique_ptr<RooArgSet> allParams{fPdf->getParameters(data)};
+          RooStats::RemoveConstantParameters(&*allParams);
 
           // need to call constrain for RooSimultaneous until stripDisconnected problem fixed
           fNll = fPdf->createNLL(data, RooFit::CloneData(false),RooFit::Constrain(*allParams),
@@ -94,7 +94,6 @@ double RooStats::ProfileLikelihoodTestStat::EvaluateProfileLikelihood(int type, 
           if (fPrintLevel > 0 && fLOffset) cout << "ProfileLikelihoodTestStat::Evaluate - Use Offset in creating NLL " << endl ;
 
           created = true ;
-          delete allParams;
           if (fPrintLevel > 1) cout << "creating NLL " << fNll << " with data = " << &data << endl ;
        }
        if (reuse && !created) {
@@ -109,7 +108,7 @@ double RooStats::ProfileLikelihoodTestStat::EvaluateProfileLikelihood(int type, 
 
 
        // make sure we set the variables attached to this nll
-       RooArgSet* attachedSet = fNll->getVariables();
+       std::unique_ptr<RooArgSet> attachedSet{fNll->getVariables()};
 
        attachedSet->assign(paramsOfInterest);
        RooArgSet* origAttachedSet = (RooArgSet*) attachedSet->snapshot();
@@ -272,7 +271,6 @@ double RooStats::ProfileLikelihoodTestStat::EvaluateProfileLikelihood(int type, 
        // need to restore the values ?
        attachedSet->assign(*origAttachedSet);
 
-       delete attachedSet;
        delete origAttachedSet;
        delete snap;
 

--- a/roofit/roostats/src/SPlot.cxx
+++ b/roofit/roostats/src/SPlot.cxx
@@ -423,10 +423,10 @@ void SPlot::AddSWeight( RooAbsPdf* pdf, const RooArgList &yieldsTmp,
 
   // Find Parameters in the PDF to be considered fixed when calculating the SWeights
   // and be sure to NOT include the yields in that list
-  RooArgList* constParameters = (RooArgList*)pdf->getParameters(fSData) ;
+  std::unique_ptr<RooArgSet> constParameters{pdf->getParameters(fSData)};
   for (unsigned int i=0; i < constParameters->size(); ++i) {
     // Need a counting loop since collection is being modified
-    auto& par = (*constParameters)[i];
+    auto& par = *(*constParameters)[i];
     if (std::any_of(yieldsTmp.begin(), yieldsTmp.end(), [&](const RooAbsArg* yield){ return yield->dependsOn(par); })) {
       constParameters->remove(par, true, true);
       --i;
@@ -440,7 +440,7 @@ void SPlot::AddSWeight( RooAbsPdf* pdf, const RooArgList &yieldsTmp,
 
   for(Int_t i = 0; i < constParameters->getSize(); i++)
   {
-    RooAbsRealLValue* varTemp = static_cast<RooAbsRealLValue*>( constParameters->at(i) );
+    RooAbsRealLValue* varTemp = static_cast<RooAbsRealLValue*>( (*constParameters)[i] );
     if(varTemp &&  varTemp->isConstant() == 0 )
     {
       varTemp->setConstant();
@@ -531,7 +531,7 @@ void SPlot::AddSWeight( RooAbsPdf* pdf, const RooArgList &yieldsTmp,
   // and all others to 0.  Evaluate the pdf for each event
   // and store the values.
 
-  RooArgSet * pdfvars = pdf->getVariables();
+  std::unique_ptr<RooArgSet> pdfvars{pdf->getVariables()};
   std::vector<std::vector<double> > pdfvalues(numevents,std::vector<double>(nspec,0)) ;
 
   for (Int_t ievt = 0; ievt <numevents; ievt++)
@@ -553,7 +553,6 @@ void SPlot::AddSWeight( RooAbsPdf* pdf, const RooArgList &yieldsTmp,
       theVar->setVal( 0 ) ;
     }
   }
-  delete pdfvars;
 
   // check that the likelihood normalization is fine
   std::vector<double> norm(nspec,0) ;

--- a/roofit/roostats/src/SimpleLikelihoodRatioTestStat.cxx
+++ b/roofit/roostats/src/SimpleLikelihoodRatioTestStat.cxx
@@ -50,9 +50,8 @@ double RooStats::SimpleLikelihoodRatioTestStat::Evaluate(RooAbsData& data, RooAr
 
    bool created = false ;
    if (!fNllNull) {
-      RooArgSet* allParams = fNullPdf->getParameters(data);
+      std::unique_ptr<RooArgSet> allParams{fNullPdf->getParameters(data)};
       fNllNull = fNullPdf->createNLL(data, RooFit::CloneData(false),RooFit::Constrain(*allParams),RooFit::GlobalObservables(fGlobalObs),RooFit::ConditionalObservables(fConditionalObs));
-      delete allParams;
       created = true ;
    }
    if (reuse && !created) {
@@ -60,7 +59,7 @@ double RooStats::SimpleLikelihoodRatioTestStat::Evaluate(RooAbsData& data, RooAr
    }
 
    // make sure we set the variables attached to this nll
-   RooArgSet* attachedSet = fNllNull->getVariables();
+   std::unique_ptr<RooArgSet> attachedSet{fNllNull->getVariables()};
    attachedSet->assign(*fNullParameters);
    attachedSet->assign(nullPOI);
    double nullNLL = fNllNull->getVal();
@@ -72,20 +71,18 @@ double RooStats::SimpleLikelihoodRatioTestStat::Evaluate(RooAbsData& data, RooAr
    if (!reuse) {
       delete fNllNull ; fNllNull = nullptr ;
    }
-   delete attachedSet;
 
    created = false ;
    if (!fNllAlt) {
-      RooArgSet* allParams = fAltPdf->getParameters(data);
+      std::unique_ptr<RooArgSet> allParams{fAltPdf->getParameters(data)};
       fNllAlt = fAltPdf->createNLL(data, RooFit::CloneData(false),RooFit::Constrain(*allParams),RooFit::GlobalObservables(fGlobalObs),RooFit::ConditionalObservables(fConditionalObs));
-      delete allParams;
       created = true ;
    }
    if (reuse && !created) {
       fNllAlt->setData(data, false) ;
    }
    // make sure we set the variables attached to this nll
-   attachedSet = fNllAlt->getVariables();
+   attachedSet = std::unique_ptr<RooArgSet>{fNllAlt->getVariables()};
    attachedSet->assign(*fAltParameters);
    double altNLL = fNllAlt->getVal();
 
@@ -99,7 +96,6 @@ double RooStats::SimpleLikelihoodRatioTestStat::Evaluate(RooAbsData& data, RooAr
    if (!reuse) {
       delete fNllAlt ; fNllAlt = nullptr ;
    }
-   delete attachedSet;
 
 
 

--- a/roofit/roostats/src/ToyMCImportanceSampler.cxx
+++ b/roofit/roostats/src/ToyMCImportanceSampler.cxx
@@ -281,7 +281,7 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
 
 
    // assign input paramPoint
-   RooArgSet* allVars = fPdf->getVariables();
+   std::unique_ptr<RooArgSet> allVars{fPdf->getVariables()};
    allVars->assign(paramPoint);
 
 
@@ -300,9 +300,8 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
    // save values to restore later.
    // but this must remain after(!) generating global observables
    if( !fGenerateFromNull ) {
-      RooArgSet* allVarsImpDens = fImportanceDensities[fIndexGenDensity]->getVariables();
+      std::unique_ptr<RooArgSet> allVarsImpDens{fImportanceDensities[fIndexGenDensity]->getVariables()};
       allVars->add(*allVarsImpDens);
-      delete allVarsImpDens;
    }
    const RooArgSet* saveVars = (const RooArgSet*)allVars->snapshot();
 
@@ -358,10 +357,9 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
 
       allVars->assign(*fNullSnapshots[i]);
       if( !fNullNLLs[i] ) {
-         RooArgSet* allParams = fNullDensities[i]->getParameters(*data);
+         std::unique_ptr<RooArgSet> allParams{fNullDensities[i]->getParameters(*data)};
          fNullNLLs[i] = fNullDensities[i]->createNLL(*data, RooFit::CloneData(false), RooFit::Constrain(*allParams),
                                                      RooFit::ConditionalObservables(fConditionalObs));
-         delete allParams;
       }else{
          fNullNLLs[i]->setData( *data, false );
       }
@@ -384,10 +382,9 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
         allVars->assign(*fImportanceSnapshots[i]);
       }
       if( !fImpNLLs[i] ) {
-         RooArgSet* allParams = fImportanceDensities[i]->getParameters(*data);
+         std::unique_ptr<RooArgSet> allParams{fImportanceDensities[i]->getParameters(*data)};
          fImpNLLs[i] = fImportanceDensities[i]->createNLL(*data, RooFit::CloneData(false), RooFit::Constrain(*allParams),
                                                           RooFit::ConditionalObservables(fConditionalObs));
-         delete allParams;
       }else{
          fImpNLLs[i]->setData( *data, false );
       }
@@ -420,7 +417,6 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
 
 
    allVars->assign(*saveVars);
-   delete allVars;
    delete saveVars;
 
    return data;

--- a/roofit/xroofit/src/xRooNLLVar.cxx
+++ b/roofit/xroofit/src/xRooNLLVar.cxx
@@ -344,7 +344,7 @@ void xRooNLLVar::reinitialize()
       }
    }
 
-   fFuncVars.reset(std::shared_ptr<RooAbsReal>::get()->getVariables());
+   fFuncVars = std::unique_ptr<RooArgSet>{std::shared_ptr<RooAbsReal>::get()->getVariables()};
    if (fGlobs) {
       fFuncGlobs.reset(fFuncVars->selectCommon(*fGlobs));
       fFuncGlobs->setAttribAll("Constant", true);

--- a/roofit/xroofit/src/xRooNode.cxx
+++ b/roofit/xroofit/src/xRooNode.cxx
@@ -5746,8 +5746,8 @@ public:
       RooAbsPdf *clonePdf = dynamic_cast<RooAbsPdf *>(cloneFunc);
       RooArgSet *errorParams = cloneFunc->getObservables(fpf_stripped);
 
-      RooArgSet *nset =
-         nset_in.getSize() == 0 ? cloneFunc->getParameters(*errorParams) : cloneFunc->getObservables(nset_in);
+      std::unique_ptr<RooArgSet> nset =
+         nset_in.empty() ? std::unique_ptr<RooArgSet>{cloneFunc->getParameters(*errorParams)} : std::unique_ptr<RooArgSet>{cloneFunc->getObservables(nset_in)};
 
       // Make list of parameter instances of cloneFunc in order of error matrix
       RooArgList paramList;
@@ -5776,13 +5776,13 @@ public:
 
          // Make Plus variation
          ((RooRealVar *)paramList.at(ivar))->setVal(cenVal + errVal);
-         plusVar.push_back((fExpectedEventsMode ? 1. : cloneFunc->getVal(nset)) *
-                           (clonePdf ? clonePdf->expectedEvents(nset) : 1.));
+         plusVar.push_back((fExpectedEventsMode ? 1. : cloneFunc->getVal(&*nset)) *
+                           (clonePdf ? clonePdf->expectedEvents(&*nset) : 1.));
 
          // Make Minus variation
          ((RooRealVar *)paramList.at(ivar))->setVal(cenVal - errVal);
-         minusVar.push_back((fExpectedEventsMode ? 1. : cloneFunc->getVal(nset)) *
-                            (clonePdf ? clonePdf->expectedEvents(nset) : 1.));
+         minusVar.push_back((fExpectedEventsMode ? 1. : cloneFunc->getVal(&*nset)) *
+                            (clonePdf ? clonePdf->expectedEvents(&*nset) : 1.));
 
          ((RooRealVar *)paramList.at(ivar))->setVal(cenVal);
       }
@@ -5808,7 +5808,6 @@ public:
 
       delete cloneFunc;
       delete errorParams;
-      delete nset;
 
       return sqrt(sum);
    }

--- a/test/fit/WrapperRooPdf.h
+++ b/test/fit/WrapperRooPdf.h
@@ -23,22 +23,20 @@ public:
    WrapperRooPdf(RooAbsPdf * pdf, const std::string xvar = "x", bool norm = true) :
       fNorm(norm),
       fPdf(pdf),
-      fX(0),
-      fParams(nullptr)
+      fX(0)
    {
       assert(fPdf != nullptr);
 
-      RooArgSet *vars = fPdf->getVariables();
+      std::unique_ptr<RooArgSet> vars{fPdf->getVariables()};
       RooAbsArg * arg = vars->find(xvar.c_str());  // code should abort if not found
       if (!arg) std::cout <<"Error - observable " << xvar << "is not in the list of pdf variables" << std::endl;
       assert(arg != nullptr);
       RooArgSet obsList(*arg);
       //arg.setDirtyInhibit(true); // do have faster setter of values
       fX = fPdf->getObservables(obsList);
-      fParams = fPdf->getParameters(obsList);
+      fParams = std::unique_ptr<RooArgSet>{fPdf->getParameters(obsList)};
       assert(fX != nullptr);
       assert(fParams != nullptr);
-      delete vars;
 #ifdef DEBUG
       fX->Print("v");
       fParams->Print("v");
@@ -54,13 +52,12 @@ public:
    WrapperRooPdf(RooAbsPdf * pdf, const RooArgSet & obsList, bool norm = true ) :
       fNorm(norm),
       fPdf(pdf),
-      fX(nullptr),
-      fParams(nullptr)
+      fX(nullptr)
    {
       assert(fPdf != nullptr);
 
       fX = fPdf->getObservables(obsList);
-      fParams = fPdf->getParameters(obsList);
+      fParams = std::unique_ptr<RooArgSet>{fPdf->getParameters(obsList)};
       assert(fX != nullptr);
       assert(fParams != nullptr);
 #ifdef DEBUG
@@ -81,7 +78,6 @@ public:
    ~WrapperRooPdf() override {
       // need to delete observables and parameter list
       if (fX) delete fX;
-      if (fParams) delete fParams;
    }
 
    /**
@@ -204,7 +200,7 @@ private:
    bool fNorm;
    mutable RooAbsPdf * fPdf;
    mutable RooArgSet * fX;
-   mutable RooArgSet * fParams;
+   mutable std::unique_ptr<RooArgSet> fParams;
    mutable std::vector<double> fParamValues;
 
 

--- a/test/fit/testRooFit.cxx
+++ b/test/fit/testRooFit.cxx
@@ -238,9 +238,8 @@ int  FitUsingRooFit(TTree & tree, RooAbsPdf & pdf, RooArgSet & xvars) {
    w.Stop();
 
    std::cout << "RooFit result " << std::endl;
-   RooArgSet * params = pdf.getParameters(xvars);
+   std::unique_ptr<RooArgSet> params{pdf.getParameters(xvars)};
    params->Print("v");
-   delete params;
 
 
    std::cout << "\nTime: \t" << w.RealTime() << " , " << w.CpuTime() << std::endl;

--- a/test/stressHistFactory_tests.cxx
+++ b/test/stressHistFactory_tests.cxx
@@ -383,8 +383,8 @@ private:
     const Int_t iSamplingPoints = 100;
 
     // get variables
-    RooArgSet* pVars1 = rPDF1.getVariables();
-    RooArgSet* pVars2 = rPDF2.getVariables();
+    std::unique_ptr<RooArgSet> pVars1{rPDF1.getVariables()};
+    std::unique_ptr<RooArgSet> pVars2{rPDF2.getVariables()};
 
     if(!CompareParameters(*pVars1,*pVars2))
     {

--- a/test/stressRooStats_tests.h
+++ b/test/stressRooStats_tests.h
@@ -354,9 +354,8 @@ public:
       w->var("y")->setVal(fObsValueY);
       w->data("data")->add(*model->GetObservables());
 
-      const RooArgSet * initialVariables = model->GetPdf()->getVariables();
+      std::unique_ptr<RooArgSet> initialVariables{model->GetPdf()->getVariables()};
       w->saveSnapshot("initialVariables",*initialVariables);
-      delete initialVariables;
 
       // build likelihood interval with ProfileLikelihoodCalculator
       ProfileLikelihoodCalculator *plc = new ProfileLikelihoodCalculator(*w->data("data"), *model);
@@ -876,9 +875,8 @@ public:
       w->var("y")->setVal(fObsValueY);
       w->data("data")->add(*model->GetObservables());
 
-      const RooArgSet * initialVariables = model->GetPdf()->getVariables();
+      std::unique_ptr<RooArgSet> initialVariables{model->GetPdf()->getVariables()};
       w->saveSnapshot("initialVariables",*initialVariables);
-      delete initialVariables;
 
       // NOTE: Roo1DIntegrator is too slow and gives poor results
 #ifdef R__HAS_MATHMORE
@@ -1004,9 +1002,8 @@ public:
       w->var("y")->setVal(fObsValueY);
       w->data("data")->add(*model->GetObservables());
 
-      const RooArgSet * initialVariables = model->GetPdf()->getVariables();
+      std::unique_ptr<RooArgSet> initialVariables{model->GetPdf()->getVariables()};
       w->saveSnapshot("initialVariables",*initialVariables);
-      delete initialVariables;
 
       // NOTE: Roo1DIntegrator is too slow and gives poor results
 #ifdef R__HAS_MATHMORE
@@ -1487,9 +1484,8 @@ public:
       w->var("y")->setVal(fObsValueY);
       w->data("data")->add(*sbModel->GetObservables());
 
-      const RooArgSet * initialVariables = sbModel->GetPdf()->getVariables();
+      std::unique_ptr<RooArgSet> initialVariables{sbModel->GetPdf()->getVariables()};
       w->saveSnapshot("initialVariables",*initialVariables);
-      delete initialVariables;
 
       // set snapshots
       w->var("sig")->setVal(fObsValueX - w->var("bkg1")->getValV());
@@ -1657,9 +1653,8 @@ public:
       w->var("x")->setVal(fObsValueX);
       w->data("data")->add(*sbModel->GetObservables());
 
-      const RooArgSet * initialVariables = sbModel->GetPdf()->getVariables();
+      std::unique_ptr<RooArgSet> initialVariables{sbModel->GetPdf()->getVariables()};
       w->saveSnapshot("initialVariables",*initialVariables);
-      delete initialVariables;
 
       // set snapshots
       sbModel->SetSnapshot(*sbModel->GetParametersOfInterest());


### PR DESCRIPTION
This commit introduces an alias for raw pointers for indicating that the return type of a RooFit function is an owning pointer that must be deleted by the caller. For RooFit developers, it can be very useful to make this an alias to `std::unique_ptr<T>`, in order to check that your code has no memory problems. Changing this alias is equivalent to forcing all code immediately wraps the result of functions returning a `RooFit::OwningPtr<T>` in a `std::unique_ptr<T>`.

The two fundamental RooFit functions `RooAbsArg::getVariables()` and `RooAbsArg::getParameters()` are also migrated to this new alias, and I tried to recompile ROOT locally using the `std::unique_ptr<T>` alias. This commit includes also the necessary changes to make ROOT compile with both raw and smart pointer alias, always wrapping the result of these functions in `std::unique_ptr<RooArgSet>`.

There are many benefits of this alias, and my ultimate goal here is to eventually make PyROOT aware of it to always take ownership of the referenced objects. But it's also a great tool for developers to check that there are no memory issues in RooFit code.

Now that this PR sets the first examples of how to use this alias, I can make further migrations also a good warm-up projects for new contributors such as students.