### PR TITLE
C++20 fixes: add missing include, fix span constructor, symmetric equality operator

### DIFF
--- a/hist/histv7/inc/ROOT/RHistBufferedFill.hxx
+++ b/hist/histv7/inc/ROOT/RHistBufferedFill.hxx
@@ -19,6 +19,9 @@
 #include "ROOT/RSpan.hxx"
 #include <array>
 
+#include <cstddef>
+#include <array>
+
 namespace ROOT {
 namespace Experimental {
 

--- a/hist/histv7/inc/ROOT/RHistBufferedFill.hxx
+++ b/hist/histv7/inc/ROOT/RHistBufferedFill.hxx
@@ -18,9 +18,7 @@
 
 #include "ROOT/RSpan.hxx"
 #include <array>
-
 #include <cstddef>
-#include <array>
 
 namespace ROOT {
 namespace Experimental {

--- a/roofit/roofitcore/inc/RooFit/TestStatistics/RooAbsL.h
+++ b/roofit/roofitcore/inc/RooFit/TestStatistics/RooAbsL.h
@@ -74,8 +74,8 @@ public:
          }
       }
 
-      bool operator==(const Section& rhs) {
-         return begin_fraction == rhs.begin_fraction && end_fraction == rhs.end_fraction;
+      friend bool operator==(const Section& lhs, const Section& rhs) {
+         return lhs.begin_fraction == rhs.begin_fraction && lhs.end_fraction == rhs.end_fraction;
       }
 
       double begin_fraction;

--- a/roofit/roofitcore/inc/RooVectorDataStore.h
+++ b/roofit/roofitcore/inc/RooVectorDataStore.h
@@ -293,7 +293,7 @@ public:
       auto beg = std::min(_vec.cbegin() + first, _vec.cend());
       auto end = std::min(_vec.cbegin() + last,  _vec.cend());
 
-      return RooSpan<const double>(beg, end);
+      return RooSpan<const double>(&*beg, std::distance(beg, end));
     }
 
     std::size_t size() const { return _vec.size() ; }
@@ -500,7 +500,7 @@ public:
       auto beg = std::min(_vec.cbegin() + first, _vec.cend());
       auto end = std::min(_vec.cbegin() + last,  _vec.cend());
 
-      return RooSpan<const RooAbsCategory::value_type>(beg, end);
+      return RooSpan<const RooAbsCategory::value_type>(&*beg, std::distance(beg, end));
     }
 
 

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -937,7 +937,7 @@ RooSpan<const double> RooDataSet::getWeightBatch(std::size_t first, std::size_t 
   RooSpan<const double> allWeights = _dstore->getWeightBatch(0, numEntries());
   if(allWeights.empty()) return {};
 
-  if(!sumW2) return {std::cbegin(allWeights) + first, std::cbegin(allWeights) + first + len};
+  if(!sumW2) return {&*(std::cbegin(allWeights) + first), len};
 
   // Treat the sumW2 case with a result buffer, first reset buffer if the
   // number of entries doesn't match with the dataset anymore
@@ -953,7 +953,7 @@ RooSpan<const double> RooDataSet::getWeightBatch(std::size_t first, std::size_t 
     }
   }
 
-  return RooSpan<const double>(_sumW2Buffer->begin() + first, _sumW2Buffer->begin() + first + len);
+  return RooSpan<const double>(&*(_sumW2Buffer->begin() + first), len);
 }
 
 


### PR DESCRIPTION
I observed these building on macOS 13.2.1 and XCode 14.2.

- Construction of `std::span` from vector iterators directly fails to compile due to not finding a conversion. This can be worked around by passing in a pointer and a size.
- Warning about C++20 preferring symmetric equality operators (this is not a failure (yet)).
