### PR TITLE
[RF] Increase version number of `RooRealVar` from 9 to 10

### DIFF
--- a/roofit/roofitcore/inc/RooRealVar.h
+++ b/roofit/roofitcore/inc/RooRealVar.h
@@ -174,7 +174,7 @@ public:
 
   std::size_t _valueResetCounter = 0; ///<! How many times the value of this variable was reset
 
-  ClassDefOverride(RooRealVar,9); // Real-valued variable
+  ClassDefOverride(RooRealVar,10); // Real-valued variable
 };
 
 #endif


### PR DESCRIPTION
In 13670912, the class version of the `RooAbsReal` class was incremented.

As explained in #8791, there are sometimes warnings in the IO of derived classes if their version number is not increased as well.

Increasing the class version of RooRealVar indeed fixes this warning that one gets right now when reading old workspaces:

```
Warning in <TStreamerInfo::CompareContent>: The following data member of
the on-file layout version 9 of class 'RooRealVar' differs from
the in-memory layout version 9:
   RooAbsBinning _binning; //
vs
   unique_ptr<RooAbsBinning,default_delete<RooAbsBinning> > _binning;
```

Thanks to @will-cern for catching this problem!
