### PR TITLE
Fully qualify ROOT namespace

### DIFF
--- a/core/base/inc/TDirectory.h
+++ b/core/base/inc/TDirectory.h
@@ -381,6 +381,6 @@ namespace Internal {
    };
 } // Internal
 } // ROOT
-#define gDirectory (ROOT::Internal::TDirectoryAtomicAdapter{})
+#define gDirectory (::ROOT::Internal::TDirectoryAtomicAdapter{})
 
 #endif


### PR DESCRIPTION
# This Pull request:

Addresses an infelicity in the definition of the `gDirectory` macro.

## Changes or fixes:

The leading `ROOT` namespace qualification in the macro definition is prefixed with the global namespace (`::`).

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #12623.

