### PR TITLE
[cmake] Pass isysroot to clang when determining stdlib incpath:

### DIFF
--- a/interpreter/cling/lib/Interpreter/CMakeLists.txt
+++ b/interpreter/cling/lib/Interpreter/CMakeLists.txt
@@ -235,6 +235,8 @@ if (UNIX)
           set(CLING_CXX_RLTV "${CLING_CXX_RLTV} --gcc-toolchain=${gcctoolchain}")
         endif()
       endif()
+    elseif (APPLE)
+      set(CLING_CXX_PATH_ARGS "-isysroot;${CMAKE_OSX_SYSROOT}")
     endif()
   endif()
 

--- a/proof/proofd/inc/XProofProtocol.h
+++ b/proof/proofd/inc/XProofProtocol.h
@@ -4,10 +4,6 @@
 #ifndef ROOT_XProofProtocol
 #define ROOT_XProofProtocol
 
-#ifdef __CINT__
-#define __attribute__(x)
-#endif
-
 #include "XProtocol/XProtocol.hh"
 
 #define XPD_DEF_PORT 1093


### PR DESCRIPTION
isysroot influences where clang will pick up libc++. Without this, and with
Xcode 14.3, cling will use libc++ from Xcode (or the command line tools) rather
than stdc++ from the macOS SDK, as clang would normally use. Passing the isysroot
(which point to the SDK) fixes this.

This solves build errors such as:
```
While building module 'Core':
While building module 'std' imported from input_line_1:1:
In file included from <module-includes>:17:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/math.h:309:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/type_traits:462:1: error: cannot template a using declaration
using _BoolConstant _LIBCPP_NODEBUG_TYPE = integral_constant<bool, _Val>;
^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/type_traits:462:21: error: C++ requires a type specifier for all declarations
using _BoolConstant _LIBCPP_NODEBUG_TYPE = integral_constant<bool, _Val>;
                    ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/type_traits:462:68: error: use of undeclared identifier '_Val'
using _BoolConstant _LIBCPP_NODEBUG_TYPE = integral_constant<bool, _Val>;
                                                                   ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/type_traits:462:73: error: expected '(' for function-style cast or type construction
using _BoolConstant _LIBCPP_NODEBUG_TYPE = integral_constant<bool, _Val>;
                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
```
