### PR TITLE
[RF] Fix RooFit warnings in the nightlies

### DIFF
--- a/roofit/jsoninterface/inc/RooFit/Detail/JSONInterface.h
+++ b/roofit/jsoninterface/inc/RooFit/Detail/JSONInterface.h
@@ -57,8 +57,8 @@ public:
       Nd &operator*() const { return it->current(); }
       Nd &operator->() const { return it->current(); }
 
-      bool operator!=(const child_iterator_t &that) const { return !this->it->equal(*that.it); }
-      bool operator==(const child_iterator_t &that) const { return this->it->equal(*that.it); }
+      friend bool operator!=(child_iterator_t const &lhs, child_iterator_t const &rhs) { return !lhs.it->equal(*rhs.it); }
+      friend bool operator==(child_iterator_t const &lhs, child_iterator_t const &rhs) { return lhs.it->equal(*rhs.it); }
    };
 
    using child_iterator = child_iterator_t<JSONNode>;

--- a/roofit/jsoninterface/src/JSONParser.cxx
+++ b/roofit/jsoninterface/src/JSONParser.cxx
@@ -336,7 +336,9 @@ public:
    }
    bool equal(const typename child_iterator::Impl &other) const override
    {
-      auto it = dynamic_cast<const ChildItImpl<Nd, NdType, json_it> *>(&other);
+      // We can use static_cast here because we never compare Iterators for
+      // different JSON node types.
+      auto it = static_cast<const ChildItImpl<Nd, NdType, json_it> *>(&other);
       return it && it->iter == this->iter;
    }
 

--- a/roofit/roofitcore/inc/LinkDef.h
+++ b/roofit/roofitcore/inc/LinkDef.h
@@ -328,9 +328,9 @@
 #pragma link C++ class RooVectorDataStore::RealFullVector+ ;
 #pragma read sourceClass="RooVectorDataStore::RealFullVector" targetClass="RooVectorDataStore::RealFullVector" version="[1]" \
   source="std::vector<double>* _vecE; std::vector<double>* _vecEL; std::vector<double>* _vecEH" target="_vecE, _vecEL, _vecEH" \
-  code="{ if(onfile._vecE) _vecE = *onfile._vecE;    \
-          if(onfile._vecEL) _vecEL = *onfile._vecEL; \
-          if(onfile._vecEH) _vecEH = *onfile._vecEH; }";
+  code="{ if(onfile._vecE) { _vecE = *onfile._vecE; }     \
+          if(onfile._vecEL) { _vecEL = *onfile._vecEL; }  \
+          if(onfile._vecEH) { _vecEH = *onfile._vecEH; }  }";
 #pragma link C++ class RooVectorDataStore::CatVector+;
 #pragma read sourceClass="RooVectorDataStore::CatVector" targetClass="RooVectorDataStore::CatVector" version="[1]" \
   source="std::vector<RooCatType> _vec;" target="_vec" \


### PR DESCRIPTION
This is a follow-up to 82d17fb69c9a, fixing these warnings seen in the nightlies (Ubuntu 20.04):

https://lcgapp-services.cern.ch/root-jenkins/view/ROOT%20Nightly/job/root-nightly-master/LABEL=ROOT-ubuntu2004-clang,SPEC=soversion,V=master/lastBuild/parsed_console/

```
/home/sftnight/build/night/LABEL/ROOT-ubuntu2004-clang/SPEC/soversion/V/master/build/roofit/roofitcore/G__RooFitCore.cxx:8047:11: warning: misleading indentation; statement is not part of the previous 'if' [-Wmisleading-indentation]
          if(onfile._vecEL) _vecEL = *onfile._vecEL; \
          ^
/home/sftnight/build/night/LABEL/ROOT-ubuntu2004-clang/SPEC/soversion/V/master/build/roofit/roofitcore/G__RooFitCore.cxx:8046:7: note: previous statement is here
      if(onfile._vecE) _vecE = *onfile._vecE;    \
      ^

/home/sftnight/build/night/LABEL/ROOT-ubuntu2004-clang/SPEC/soversion/V/master/build/roofit/roofitcore/G__RooFitCore.cxx:8048:11: warning: misleading indentation; statement is not part of the previous 'if' [-Wmisleading-indentation]
          if(onfile._vecEH) _vecEH = *onfile._vecEH;
          ^
/home/sftnight/build/night/LABEL/ROOT-ubuntu2004-clang/SPEC/soversion/V/master/build/roofit/roofitcore/G__RooFitCore.cxx:8047:11: note: previous statement is here
          if(onfile._vecEL) _vecEL = *onfile._vecEL; \
          ^
```