### PR TITLE
[modulemap] bits/chrono.h exists already with C++11:

### DIFF
--- a/interpreter/cling/include/cling/std.modulemap
+++ b/interpreter/cling/include/cling/std.modulemap
@@ -430,7 +430,6 @@ module "std" [system] {
     header "bits/basic_ios.h"
   }
   module "bits/chrono.h" [optional] {
-    requires cplusplus17
     export *
     header "bits/chrono.h"
   }

--- a/interpreter/llvm/src/tools/clang/lib/Serialization/ASTWriterDecl.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Serialization/ASTWriterDecl.cpp
@@ -2310,7 +2310,7 @@ void ASTWriter::WriteDeclAbbrevs() {
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // Defaulted
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // ExplicitlyDefaulted
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // ImplicitReturnZero
-  Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // Constexpr
+  Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 2)); // Constexpr
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // UsesSEHTry
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // SkippedBody
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // MultiVersion


### PR DESCRIPTION
It is needed for C++11 support of #include <chrono>. Failures:
```
Processing /home/sftnight/build/night/LABEL/ROOT-fedora36/SPEC/default/V/master/root/tutorials/multicore/mt201_parallelHistoFill.C...
In file included from input_line_10:1:
/home/sftnight/build/night/LABEL/ROOT-fedora36/SPEC/default/V/master/root/tutorials/multicore/mt201_parallelHistoFill.C:55:51: error: no member named 'duration' in namespace 'std::chrono'
         std::this_thread::sleep_for(std::chrono::duration<double, std::nano>(500));
                                     ~~~~~~~~~~~~~^
```

and

```
root [11] #include <bits/chrono.h>
/home/sftnight/build/night/LABEL/ROOT-fedora36/SPEC/default/V/master/build/etc/cling/std.modulemap:432:10: error: module 'std.bits/chrono.h' requires feature 'cplusplus17'
  module "bits/chrono.h" [optional] {
         ^
ROOT_prompt_11:1:10: note: submodule of top-level module 'std' implicitly imported here
         ^
```
