### PR TITLE
[ntuple] Fix failing tests for `-Dimt=OFF` builds

### DIFF
--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -395,7 +395,11 @@ TEST(RPageSinkBuf, ParallelZip) {
             auto *parallel_zip = ntuple->GetMetrics().GetCounter(
                "RNTupleWriter.RPageSinkBuf.ParallelZip");
             ASSERT_FALSE(parallel_zip == nullptr);
+#ifdef R__USE_IMT
             EXPECT_EQ(1, parallel_zip->GetValueAsInt());
+#else
+            EXPECT_EQ(0, parallel_zip->GetValueAsInt());
+#endif
          }
       }
    }
@@ -449,10 +453,15 @@ TEST(RPageSinkBuf, CommitSealedPageV)
       ntuple->Fill();
       ntuple->Fill();
       ntuple->CommitCluster();
+#ifdef R__USE_IMT
       // All pages in all columns committed via a single call to `CommitSealedPageV()`
       EXPECT_EQ(0, counters.fNCommitPage);
-      EXPECT_EQ(0, counters.fNCommitSealedPage);
       EXPECT_EQ(1, counters.fNCommitSealedPageV);
+#else
+      EXPECT_EQ(2, counters.fNCommitPage);
+      EXPECT_EQ(0, counters.fNCommitSealedPageV);
+#endif
+      EXPECT_EQ(0, counters.fNCommitSealedPage);
    }
 }
 

--- a/tree/ntuple/v7/test/ntuple_storage_daos.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage_daos.cxx
@@ -208,6 +208,9 @@ TEST_F(RPageStorageDaos, MultipleNTuplesPerContainer)
    EXPECT_THROW(RNTupleReader::Open("ntuple3", daosUri), ROOT::Experimental::RException);
 }
 
+#ifdef R__USE_IMT
+// This feature depends on RPageSinkBuf and the ability to issue a single `CommitSealedPageV()` call; thus, disable if
+// ROOT was built with `-Dimt=OFF`
 TEST_F(RPageStorageDaos, CagedPages)
 {
    std::string daosUri = RegisterLabel("ntuple-test-caged");
@@ -262,3 +265,4 @@ TEST_F(RPageStorageDaos, CagedPages)
       EXPECT_THROW(ntuple->LoadEntry(1), ROOT::Experimental::RException);
    }
 }
+#endif


### PR DESCRIPTION
This pull request fixes failing tests for ROOT builds configured with `-Dimt=OFF`.  Those tests incorrectly assumed that multi-threading support is just there after a call to `ROOT::EnableImplictMT()`.

## Checklist:
- [X] tested changes locally