### PR TITLE
[RF] Override `TObject::Clone()` in RooWorkspace

### DIFF
--- a/roofit/roofitcore/inc/RooWorkspace.h
+++ b/roofit/roofitcore/inc/RooWorkspace.h
@@ -51,6 +51,8 @@ public:
   RooWorkspace(const RooWorkspace& other) ;
   ~RooWorkspace() override ;
 
+  TObject *Clone(const char *newname="") const override;
+
   bool importClassCode(const char* pat="*", bool doReplace=false) ;
   bool importClassCode(TClass* theClass, bool doReplace=false) ;
 

--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -224,6 +224,16 @@ RooWorkspace::RooWorkspace(const RooWorkspace& other) :
 }
 
 
+/// TObject::Clone() needs to be overridden.
+TObject *RooWorkspace::Clone(const char *newname) const
+{
+   auto out = new RooWorkspace{*this};
+   if(newname && std::string(newname) != GetName()) {
+      out->SetName(newname);
+   }
+   return out;
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Workspace destructor


### PR DESCRIPTION
Many users expect to use `Clone()` to copy RooWorkspaces, but so far this resulted in corrupt workspaces because the `Clone()` function was not overridden.

This is an important fix that needs to be backported at least to 6.28 and 6.26, better yet every ROOT release used in production.

