### PR TITLE
[core] Always assign correct `uid` output in TRefArray::GetObjectUID()

### DIFF
--- a/core/cont/src/TRefArray.cxx
+++ b/core/cont/src/TRefArray.cxx
@@ -218,6 +218,7 @@ Bool_t TRefArray::GetObjectUID(Int_t &uid, TObject *obj, const char *methodname)
       } else {
          if (GetAbsLast() < 0) {
             // The container is empty, we can switch the ProcessID.
+            uid = obj->GetUniqueID();
             fPID = TProcessID::GetProcessWithUID(obj);
             valid = kTRUE;
             if (gDebug > 3)

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -2457,7 +2457,7 @@ void RooRefArray::Streamer(TBuffer &R__b)
      R__c = R__b.WriteVersion(RooRefArray::IsA(), true);
 
      // Make a temporary refArray and write that to the streamer
-     TRefArray refArray(GetEntriesFast());
+     TRefArray refArray;
      for(TObject * tmpObj : *this) {
        refArray.Add(tmpObj) ;
      }


### PR DESCRIPTION
In `TRefArray::GetObjectUID(int &uid, TObjet *obj)`, there is a code
branch for the case of an empty TRefArray and an object with a UID
assigned. Is this case a new process ID corresponding to the object is
assigned to the `TRefArray`. However, the `uid` output parameter is not
correctly assigned in this code branch, which is fixed in this commit.

The consequence of this bug is that the, since the `uid` output
parameter is not correctly assigned, that the implementation of
`TRefArray::Add*()` does not correctly work then.

Closes https://github.com/root-project/root/issues/12329.

