### PR TITLE
[RF] Migrate `RooAbsPdf::createNLL()` to use the `RooFit::OwningPtr<T>`

### DIFF
--- a/roofit/histfactory/src/MakeModelAndMeasurementsFast.cxx
+++ b/roofit/histfactory/src/MakeModelAndMeasurementsFast.cxx
@@ -379,8 +379,8 @@ void RooStats::HistFactory::FitModelAndPlot(const std::string& MeasurementName,
   fprintf(tableFile, " %.4f / %.4f  ", poi->getErrorLo(), poi->getErrorHi());
 
   // Make the Profile Likelihood Plot
-  RooAbsReal* nll = model->createNLL(*simData);
-  RooAbsReal* profile = nll->createProfile(*poi);
+  std::unique_ptr<RooAbsReal> nll{model->createNLL(*simData)};
+  std::unique_ptr<RooAbsReal> profile{nll->createProfile(*poi)};
   if( profile==nullptr ) {
     cxcoutEHF << "Error: Failed to make ProfileLikelihood for: " << poi->GetName()
          << " using model: " << model->GetName()

--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -196,11 +196,11 @@ public:
   };
   std::unique_ptr<RooFitResult> minimizeNLL(RooAbsReal & nll, RooAbsData const& data, MinimizerConfig const& cfg);
 
-  virtual RooAbsReal* createNLL(RooAbsData& data, const RooLinkedList& cmdList={}) ;
+  virtual RooFit::OwningPtr<RooAbsReal> createNLL(RooAbsData& data, const RooLinkedList& cmdList={}) ;
   /// Takes an arbitrary number of RooCmdArg command options and calls
   /// RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList).
   template <typename... Args>
-  RooAbsReal* createNLL(RooAbsData& data, RooCmdArg const& arg1, Args const&... args)
+  RooFit::OwningPtr<RooAbsReal> createNLL(RooAbsData& data, RooCmdArg const& arg1, Args const&... args)
   {
     return createNLL(data, *RooFit::Detail::createCmdList(&arg1, &args...));
   }

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -964,7 +964,7 @@ double RooAbsPdf::extendedTerm(RooAbsData const& data, bool weightSquared, bool 
 ///
 ///
 
-RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
+RooFit::OwningPtr<RooAbsReal> RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
 {
   auto baseName = std::string("nll_") + GetName() + "_" + data.GetName();
 
@@ -1034,8 +1034,8 @@ RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
       RooFit::TestStatistics::ExternalConstraints extCons(extConsSet);
       RooFit::TestStatistics::GlobalObservables glObs(glObsSet);
 
-      return new RooFit::TestStatistics::RooRealL("likelihood", "",
-          RooFit::TestStatistics::buildLikelihood(this, &data, ext, cPars, extCons, glObs, rangeName));
+      return RooFit::OwningPtr<RooAbsReal>{new RooFit::TestStatistics::RooRealL("likelihood", "",
+          RooFit::TestStatistics::buildLikelihood(this, &data, ext, cPars, extCons, glObs, rangeName))};
   }
 
   // Decode command line arguments
@@ -1158,16 +1158,17 @@ RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
        compiledConstr->addOwnedComponents(std::move(constr));
     }
 
-    return RooFit::BatchModeHelpers::createNLL(std::move(pdfClone),
-                                               data,
-                                               std::move(compiledConstr),
-                                               rangeName ? rangeName : "",
-                                               projDeps,
-                                               ext,
-                                               pc.getDouble("IntegrateBins"),
-                                               batchMode,
-                                               offset,
-                                               takeGlobalObservablesFromData).release();
+    return RooFit::OwningPtr<RooAbsReal>{RooFit::BatchModeHelpers::createNLL(
+            std::move(pdfClone),
+            data,
+            std::move(compiledConstr),
+            rangeName ? rangeName : "",
+            projDeps,
+            ext,
+            pc.getDouble("IntegrateBins"),
+            batchMode,
+            offset,
+            takeGlobalObservablesFromData).release()};
   }
 
   // Construct NLL
@@ -1222,7 +1223,7 @@ RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
     nll->enableOffsetting(true) ;
   }
 
-  return nll.release() ;
+  return RooFit::OwningPtr<RooAbsReal>{nll.release()};
 }
 
 

--- a/roofit/roofitcore/test/TestStatistics/testInterface.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testInterface.cxx
@@ -43,9 +43,9 @@ TEST(Interface, createNLLRooAbsL)
    sigma->setConstant(true);
    RooAbsPdf *pdf = w.pdf("g");
    std::unique_ptr<RooDataSet> data{pdf->generate(*x, 10000)};
-   RooAbsReal *nll = pdf->createNLL(*data, RooFit::ModularL(true));
+   std::unique_ptr<RooAbsReal> nll{pdf->createNLL(*data, RooFit::ModularL(true))};
 
-   auto *nll_real = dynamic_cast<RooFit::TestStatistics::RooRealL *>(nll);
+   auto *nll_real = dynamic_cast<RooFit::TestStatistics::RooRealL *>(&*nll);
 
    EXPECT_TRUE(nll_real != nullptr);
 

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodJob.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodJob.cxx
@@ -163,7 +163,7 @@ TEST_F(LikelihoodJobBinnedDatasetTest, UnbinnedPdf)
 {
    data = std::unique_ptr<RooDataHist>{pdf->generateBinned(*w.var("x"))};
 
-   nll.reset(pdf->createNLL(*data));
+   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data)};
 
    likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
    auto nll_ts =
@@ -211,9 +211,9 @@ TEST_F(LikelihoodJobTest, SimBinned)
    w.factory("Uniform::u(x)");
 
    // Generate template histograms
-   RooDataHist *h_sigA = w.pdf("gA")->generateBinned(*w.var("x"), 1000);
-   RooDataHist *h_sigB = w.pdf("gB")->generateBinned(*w.var("x"), 1000);
-   RooDataHist *h_bkg = w.pdf("u")->generateBinned(*w.var("x"), 1000);
+   std::unique_ptr<RooDataHist> h_sigA{w.pdf("gA")->generateBinned(*w.var("x"), 1000)};
+   std::unique_ptr<RooDataHist> h_sigB{w.pdf("gB")->generateBinned(*w.var("x"), 1000)};
+   std::unique_ptr<RooDataHist> h_bkg{w.pdf("u")->generateBinned(*w.var("x"), 1000)};
 
    w.import(*h_sigA, RooFit::Rename("h_sigA"));
    w.import(*h_sigB, RooFit::Rename("h_sigB"));
@@ -237,7 +237,7 @@ TEST_F(LikelihoodJobTest, SimBinned)
    pdf = w.pdf("model");
    data = std::unique_ptr<RooDataSet>{pdf->generate({*w.var("x"), *w.cat("index")}, RooFit::AllBinned())};
 
-   nll.reset(pdf->createNLL(*data));
+   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data)};
 
    likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
    auto nll_ts =
@@ -260,8 +260,8 @@ TEST_F(LikelihoodJobTest, BinnedConstrained)
 
    // Generate template histograms
 
-   RooDataHist *h_sig = w.pdf("g")->generateBinned(*w.var("x"), 1000);
-   RooDataHist *h_bkg = w.pdf("u")->generateBinned(*w.var("x"), 1000);
+   std::unique_ptr<RooDataHist> h_sig{w.pdf("g")->generateBinned(*w.var("x"), 1000)};
+   std::unique_ptr<RooDataHist> h_bkg{w.pdf("u")->generateBinned(*w.var("x"), 1000)};
 
    w.import(*h_sig, RooFit::Rename("h_sig"));
    w.import(*h_bkg, RooFit::Rename("h_bkg"));
@@ -281,7 +281,7 @@ TEST_F(LikelihoodJobTest, BinnedConstrained)
    // Construct dataset from physics pdf
    data = std::unique_ptr<RooDataHist>{w.pdf("model_phys")->generateBinned(*w.var("x"))};
 
-   nll.reset(pdf->createNLL(*data, RooFit::GlobalObservables(*w.var("alpha_bkg_obs"))));
+   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data, RooFit::GlobalObservables(*w.var("alpha_bkg_obs")))};
 
    // --------
 
@@ -346,7 +346,7 @@ TEST_F(LikelihoodJobTest, SimUnbinnedNonExtended)
 
    pdf = w.pdf("model");
 
-   nll.reset(pdf->createNLL(*data));
+   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data)};
 
    likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
    auto nll_ts =
@@ -410,8 +410,8 @@ protected:
 TEST_F(LikelihoodJobSimBinnedConstrainedTest, BasicParameters)
 {
    // original test:
-   nll.reset(pdf->createNLL(
-      *data, RooFit::GlobalObservables(RooArgSet(*w.var("alpha_bkg_obs_A"), *w.var("alpha_bkg_obs_B")))));
+   nll = std::unique_ptr<RooAbsReal>{
+      pdf->createNLL(*data, RooFit::GlobalObservables(*w.var("alpha_bkg_obs_A"), *w.var("alpha_bkg_obs_B")))};
 
    // --------
 
@@ -432,8 +432,9 @@ TEST_F(LikelihoodJobSimBinnedConstrainedTest, BasicParameters)
 TEST_F(LikelihoodJobSimBinnedConstrainedTest, ConstrainedAndOffset)
 {
    // a variation to test some additional parameters (ConstrainedParameters and offsetting)
-   nll.reset(pdf->createNLL(*data, RooFit::Constrain(RooArgSet(*w.var("alpha_bkg_obs_A"))),
-                            RooFit::GlobalObservables(RooArgSet(*w.var("alpha_bkg_obs_B"))), RooFit::Offset(true)));
+   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data, RooFit::Constrain(*w.var("alpha_bkg_obs_A")),
+                                                    RooFit::GlobalObservables(*w.var("alpha_bkg_obs_B")),
+                                                    RooFit::Offset(true))};
 
    // --------
 
@@ -499,8 +500,9 @@ class LikelihoodJobSplitStrategies : public LikelihoodJobSimBinnedConstrainedTes
 TEST_P(LikelihoodJobSplitStrategies, SimBinnedConstrainedAndOffset)
 {
    // based on ConstrainedAndOffset, this test tests different parallelization strategies
-   nll.reset(pdf->createNLL(*data, RooFit::Constrain(RooArgSet(*w.var("alpha_bkg_obs_A"))),
-                            RooFit::GlobalObservables(RooArgSet(*w.var("alpha_bkg_obs_B"))), RooFit::Offset(true)));
+   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data, RooFit::Constrain(*w.var("alpha_bkg_obs_A")),
+                                                    RooFit::GlobalObservables(*w.var("alpha_bkg_obs_B")),
+                                                    RooFit::Offset(true))};
 
    // --------
 

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodSerial.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodSerial.cxx
@@ -133,7 +133,7 @@ TEST_F(LikelihoodSerialBinnedDatasetTest, UnbinnedPdf)
 {
    data = std::unique_ptr<RooDataHist>{pdf->generateBinned(*w.var("x"))};
 
-   nll.reset(pdf->createNLL(*data));
+   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data)};
 
    likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
    auto nll_ts = LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags);
@@ -205,7 +205,7 @@ TEST_F(LikelihoodSerialTest, SimBinned)
    pdf = w.pdf("model");
    data = std::unique_ptr<RooDataSet>{pdf->generate({*w.var("x"), *w.cat("index")}, RooFit::AllBinned())};
 
-   nll.reset(pdf->createNLL(*data));
+   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data)};
 
    likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
    auto nll_ts = LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags);
@@ -227,8 +227,8 @@ TEST_F(LikelihoodSerialTest, BinnedConstrained)
 
    // Generate template histograms
 
-   RooDataHist *h_sig = w.pdf("g")->generateBinned(*w.var("x"), 1000);
-   RooDataHist *h_bkg = w.pdf("u")->generateBinned(*w.var("x"), 1000);
+   std::unique_ptr<RooDataHist> h_sig{w.pdf("g")->generateBinned(*w.var("x"), 1000)};
+   std::unique_ptr<RooDataHist> h_bkg{w.pdf("u")->generateBinned(*w.var("x"), 1000)};
 
    w.import(*h_sig, RooFit::Rename("h_sig"));
    w.import(*h_bkg, RooFit::Rename("h_bkg"));
@@ -248,7 +248,7 @@ TEST_F(LikelihoodSerialTest, BinnedConstrained)
    // Construct dataset from physics pdf
    data = std::unique_ptr<RooDataHist>{w.pdf("model_phys")->generateBinned(*w.var("x"))};
 
-   nll.reset(pdf->createNLL(*data, RooFit::GlobalObservables(*w.var("alpha_bkg_obs"))));
+   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data, RooFit::GlobalObservables(*w.var("alpha_bkg_obs")))};
 
    // --------
 
@@ -276,7 +276,7 @@ TEST_F(LikelihoodSerialTest, SimUnbinned)
    // Construct dataset from physics pdf
    data = std::unique_ptr<RooDataSet>{pdf->generate({*w.var("x"), *w.cat("index")})};
 
-   nll.reset(pdf->createNLL(*data));
+   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data)};
 
    // --------
 
@@ -311,7 +311,7 @@ TEST_F(LikelihoodSerialTest, SimUnbinnedNonExtended)
 
    pdf = w.pdf("model");
 
-   nll.reset(pdf->createNLL(*data));
+   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data)};
 
    likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data.get());
    auto nll_ts = LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags);
@@ -374,8 +374,8 @@ protected:
 TEST_F(LikelihoodSerialSimBinnedConstrainedTest, BasicParameters)
 {
    // original test:
-   nll.reset(pdf->createNLL(
-      *data, RooFit::GlobalObservables(RooArgSet(*w.var("alpha_bkg_obs_A"), *w.var("alpha_bkg_obs_B")))));
+   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(
+      *data, RooFit::GlobalObservables(RooArgSet(*w.var("alpha_bkg_obs_A"), *w.var("alpha_bkg_obs_B"))))};
 
    // --------
 
@@ -395,8 +395,9 @@ TEST_F(LikelihoodSerialSimBinnedConstrainedTest, BasicParameters)
 TEST_F(LikelihoodSerialSimBinnedConstrainedTest, ConstrainedAndOffset)
 {
    // a variation to test some additional parameters (ConstrainedParameters and offsetting)
-   nll.reset(pdf->createNLL(*data, RooFit::Constrain(RooArgSet(*w.var("alpha_bkg_obs_A"))),
-                            RooFit::GlobalObservables(RooArgSet(*w.var("alpha_bkg_obs_B"))), RooFit::Offset(true)));
+   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data, RooFit::Constrain(RooArgSet(*w.var("alpha_bkg_obs_A"))),
+                                                    RooFit::GlobalObservables(RooArgSet(*w.var("alpha_bkg_obs_B"))),
+                                                    RooFit::Offset(true))};
 
    // --------
 

--- a/roofit/roofitcore/test/TestStatistics/testPlot.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testPlot.cxx
@@ -71,7 +71,7 @@ public:
       // --------------------------------------------------------------------------------
 
       // Creating a RooAbsL likelihood
-      RooAbsReal *likelihood = w.pdf("model")->createNLL(d, ModularL(true));
+      std::unique_ptr<RooAbsReal> likelihood{w.pdf("model")->createNLL(d, ModularL(true))};
 
       // Creating a minimizer and explicitly setting type of parallelization
       std::size_t nWorkers = 1;

--- a/roofit/roofitcore/test/testTestStatistics.cxx
+++ b/roofit/roofitcore/test/testTestStatistics.cxx
@@ -325,12 +325,11 @@ TEST(RooNLLVar, CopyRangedNLL)
 
    // This bug is related to the implementation details of the old test statistics, so BatchMode is forced to be off
    using namespace RooFit;
-   std::unique_ptr<RooNLLVar> nll{static_cast<RooNLLVar *>(model.createNLL(*ds, BatchMode("off")))};
-   std::unique_ptr<RooNLLVar> nllrange{
-      static_cast<RooNLLVar *>(model.createNLL(*ds, Range("fitrange"), BatchMode("off")))};
+   std::unique_ptr<RooAbsReal> nll{model.createNLL(*ds, BatchMode("off"))};
+   std::unique_ptr<RooAbsReal> nllrange{model.createNLL(*ds, Range("fitrange"), BatchMode("off"))};
 
-   auto nllClone = std::make_unique<RooNLLVar>(*nll);
-   auto nllrangeClone = std::make_unique<RooNLLVar>(*nllrange);
+   auto nllClone = std::make_unique<RooNLLVar>(static_cast<RooNLLVar &>(*nll));
+   auto nllrangeClone = std::make_unique<RooNLLVar>(static_cast<RooNLLVar &>(*nllrange));
 
    EXPECT_FLOAT_EQ(nll->getVal(), nllClone->getVal());
    EXPECT_FLOAT_EQ(nll->getVal(), nllrange->getVal());

--- a/roofit/roostats/inc/RooStats/BayesianCalculator.h
+++ b/roofit/roostats/inc/RooStats/BayesianCalculator.h
@@ -171,7 +171,7 @@ namespace RooStats {
       RooArgSet fGlobalObs;                      ///< global observables
 
       mutable RooAbsPdf* fProductPdf;            ///< internal pointer to model * prior
-      mutable RooAbsReal* fLogLike;              ///< internal pointer to log likelihood function
+      mutable std::unique_ptr<RooAbsReal> fLogLike; ///< internal pointer to log likelihood function
       mutable RooAbsReal* fLikelihood;           ///< internal pointer to likelihood function
       mutable RooAbsReal* fIntegratedLikelihood; ///< integrated likelihood function, i.e - unnormalized posterior function
       mutable RooAbsPdf* fPosteriorPdf;          ///< normalized (on the poi) posterior pdf
@@ -191,7 +191,7 @@ namespace RooStats {
 
    protected:
 
-      ClassDefOverride(BayesianCalculator,2)  // BayesianCalculator class
+      ClassDefOverride(BayesianCalculator,3)  // BayesianCalculator class
 
    };
 }

--- a/roofit/roostats/inc/RooStats/MaxLikelihoodEstimateTestStat.h
+++ b/roofit/roostats/inc/RooStats/MaxLikelihoodEstimateTestStat.h
@@ -82,7 +82,7 @@ class MaxLikelihoodEstimateTestStat: public TestStatistic {
     RooStats::RemoveConstantParameters(&*allParams);
 
     // need to call constrain for RooSimultaneous until stripDisconnected problem fixed
-    RooAbsReal* nll = fPdf->createNLL(data, RooFit::CloneData(false),RooFit::Constrain(*allParams),RooFit::ConditionalObservables(fConditionalObs));
+    std::unique_ptr<RooAbsReal> nll{fPdf->createNLL(data, RooFit::CloneData(false),RooFit::Constrain(*allParams),RooFit::ConditionalObservables(fConditionalObs))};
 
     //RooAbsReal* nll = fPdf->createNLL(data, RooFit::CloneData(false));
 
@@ -91,9 +91,6 @@ class MaxLikelihoodEstimateTestStat: public TestStatistic {
     // RooArgSet* vars = profile->getVariables();
     // RooMsgService::instance().setGlobalKillBelow(msglevel);
     // double ret = vars->getRealValue(fParameter->GetName());
-    // delete vars;
-    // delete nll;
-    // delete profile;
     // return ret;
 
 
@@ -123,7 +120,6 @@ class MaxLikelihoodEstimateTestStat: public TestStatistic {
      //allParams->Print("V");
 
      RooMsgService::instance().setGlobalKillBelow(msglevel);
-     delete nll;
 
      if (status != 0) return -1;
      return fParameter->getVal();

--- a/roofit/roostats/inc/RooStats/ProfileLikelihoodCalculator.h
+++ b/roofit/roostats/inc/RooStats/ProfileLikelihoodCalculator.h
@@ -61,7 +61,7 @@ namespace RooStats {
     void DoReset() const;
 
     /// perform a global fit
-    RooAbsReal * DoGlobalFit() const;
+    RooFit::OwningPtr<RooAbsReal> DoGlobalFit() const;
 
     /// minimize likelihood
     static RooFitResult * DoMinimizeNLL(RooAbsReal * nll);

--- a/roofit/roostats/inc/RooStats/ProfileLikelihoodTestStat.h
+++ b/roofit/roostats/inc/RooStats/ProfileLikelihoodTestStat.h
@@ -35,7 +35,6 @@ namespace RooStats {
      ProfileLikelihoodTestStat() {
         // Proof constructor. Do not use.
         fPdf = nullptr;
-        fNll = nullptr;
         fCachedBestFitParams = nullptr;
         fLastData = nullptr;
         fLimitType = twoSided;
@@ -54,7 +53,6 @@ namespace RooStats {
 
      ProfileLikelihoodTestStat(RooAbsPdf& pdf) {
        fPdf = &pdf;
-       fNll = nullptr;
        fCachedBestFitParams = nullptr;
        fLastData = nullptr;
        fLimitType = twoSided;
@@ -73,7 +71,6 @@ namespace RooStats {
      }
 
      ~ProfileLikelihoodTestStat() override {
-       if(fNll) delete fNll;
        if(fCachedBestFitParams) delete fCachedBestFitParams;
        if(fDetailedOutput) delete fDetailedOutput;
      }
@@ -139,7 +136,7 @@ namespace RooStats {
    private:
 
       RooAbsPdf* fPdf;
-      RooAbsReal* fNll; //!
+      std::unique_ptr<RooAbsReal> fNll; //!
       const RooArgSet* fCachedBestFitParams;
       RooAbsData* fLastData;
       //      double fLastMLE;

--- a/roofit/roostats/inc/RooStats/SimpleLikelihoodRatioTestStat.h
+++ b/roofit/roostats/inc/RooStats/SimpleLikelihoodRatioTestStat.h
@@ -34,8 +34,6 @@ namespace RooStats {
          fNullParameters = nullptr;
          fAltParameters = nullptr;
          fReuseNll=false ;
-         fNllNull=nullptr ;
-         fNllAlt=nullptr ;
       }
 
       /// Takes null and alternate parameters from PDF. Can be overridden.
@@ -58,8 +56,6 @@ namespace RooStats {
          fDetailedOutput = nullptr;
 
          fReuseNll=false ;
-         fNllNull=nullptr ;
-         fNllAlt=nullptr ;
       }
 
       /// Takes null and alternate parameters from values in nullParameters
@@ -82,15 +78,11 @@ namespace RooStats {
          fDetailedOutput = nullptr;
 
          fReuseNll=false ;
-         fNllNull=nullptr ;
-         fNllAlt=nullptr ;
       }
 
       ~SimpleLikelihoodRatioTestStat() override {
          if (fNullParameters) delete fNullParameters;
          if (fAltParameters) delete fAltParameters;
-         if (fNllNull) delete fNllNull ;
-         if (fNllAlt) delete fNllAlt ;
          if (fDetailedOutput) delete fDetailedOutput;
       }
 
@@ -158,8 +150,8 @@ namespace RooStats {
       bool fDetailedOutputEnabled;
       RooArgSet* fDetailedOutput; ///<!
 
-      RooAbsReal* fNllNull ;  ///<! transient copy of the null NLL
-      RooAbsReal* fNllAlt ;   ///<!  transient copy of the alt NLL
+      std::unique_ptr<RooAbsReal> fNllNull; ///<! transient copy of the null NLL
+      std::unique_ptr<RooAbsReal> fNllAlt;  ///<!  transient copy of the alt NLL
       static bool fgAlwaysReuseNll ;
       bool fReuseNll ;
 

--- a/roofit/roostats/inc/RooStats/ToyMCImportanceSampler.h
+++ b/roofit/roostats/inc/RooStats/ToyMCImportanceSampler.h
@@ -111,7 +111,7 @@ class ToyMCImportanceSampler: public ToyMCSampler {
 
          fNullDensities.push_back( p );
          fNullSnapshots.push_back( s );
-         fNullNLLs.push_back( nullptr );
+         fNullNLLs.emplace_back( nullptr );
          ClearCache();
       }
       /// overwrite from ToyMCSampler
@@ -190,8 +190,8 @@ class ToyMCImportanceSampler: public ToyMCSampler {
 
       toysStrategies fToysStrategy;
 
-      mutable std::vector<RooAbsReal*> fNullNLLs;    ///<!
-      mutable std::vector<RooAbsReal*> fImpNLLs;     ///<!
+      mutable std::vector<std::unique_ptr<RooAbsReal>> fNullNLLs;    ///<!
+      mutable std::vector<std::unique_ptr<RooAbsReal>> fImpNLLs;     ///<!
 
    protected:
    ClassDefOverride(ToyMCImportanceSampler,2) // An implementation of importance sampling

--- a/roofit/roostats/src/AsymptoticCalculator.cxx
+++ b/roofit/roostats/src/AsymptoticCalculator.cxx
@@ -305,8 +305,8 @@ double AsymptoticCalculator::EvaluateNLL(RooAbsPdf & pdf, RooAbsData& data,   co
 
     // need to call constrain for RooSimultaneous until stripDisconnected problem fixed
     auto& config = GetGlobalRooStatsConfig();
-    RooAbsReal* nll = pdf.createNLL(data, RooFit::CloneData(false),RooFit::Constrain(*allParams),RooFit::ConditionalObservables(conditionalObs), RooFit::GlobalObservables(globalObs),
-        RooFit::Offset(config.useLikelihoodOffset));
+    std::unique_ptr<RooAbsReal> nll{pdf.createNLL(data, RooFit::CloneData(false),RooFit::Constrain(*allParams),RooFit::ConditionalObservables(conditionalObs), RooFit::GlobalObservables(globalObs),
+        RooFit::Offset(config.useLikelihoodOffset))};
 
     std::unique_ptr<RooArgSet> attachedSet{nll->getVariables()};
 
@@ -454,8 +454,6 @@ double AsymptoticCalculator::EvaluateNLL(RooAbsPdf & pdf, RooAbsData& data,   co
 
 
     if (verbose < 2) RooMsgService::instance().setGlobalKillBelow(msglevel);
-
-    delete nll;
 
     return val;
 }

--- a/roofit/roostats/src/BayesianCalculator.cxx
+++ b/roofit/roostats/src/BayesianCalculator.cxx
@@ -644,7 +644,7 @@ BayesianCalculator::BayesianCalculator() :
    fPdf(0),
    fPriorPdf(0),
    fNuisancePdf(0),
-   fProductPdf (0), fLogLike(0), fLikelihood (0), fIntegratedLikelihood (0), fPosteriorPdf(0),
+   fProductPdf (0), fLikelihood (0), fIntegratedLikelihood (0), fPosteriorPdf(0),
    fPosteriorFunction(0), fApproxPosterior(0),
    fLower(0), fUpper(0),
    fNLLMin(0),
@@ -672,7 +672,7 @@ BayesianCalculator::BayesianCalculator( /* const char* name,  const char* title,
    fPOI(POI),
    fPriorPdf(&priorPdf),
    fNuisancePdf(0),
-   fProductPdf (0), fLogLike(0), fLikelihood (0), fIntegratedLikelihood (0), fPosteriorPdf(0),
+   fProductPdf (0), fLikelihood (0), fIntegratedLikelihood (0), fPosteriorPdf(0),
    fPosteriorFunction(0), fApproxPosterior(0),
    fLower(0), fUpper(0),
    fNLLMin(0),
@@ -698,7 +698,7 @@ BayesianCalculator::BayesianCalculator( RooAbsData& data,
    fPdf(model.GetPdf()),
    fPriorPdf( model.GetPriorPdf()),
    fNuisancePdf(0),
-   fProductPdf (0), fLogLike(0), fLikelihood (0), fIntegratedLikelihood (0), fPosteriorPdf(0),
+   fProductPdf (0), fLikelihood (0), fIntegratedLikelihood (0), fPosteriorPdf(0),
    fPosteriorFunction(0), fApproxPosterior(0),
    fLower(0), fUpper(0),
    fNLLMin(0),
@@ -723,7 +723,7 @@ BayesianCalculator::~BayesianCalculator()
 
 void BayesianCalculator::ClearAll() const {
    if (fProductPdf) delete fProductPdf;
-   if (fLogLike) delete fLogLike;
+   fLogLike.reset();
    if (fLikelihood) delete fLikelihood;
    if (fIntegratedLikelihood) delete fIntegratedLikelihood;
    if (fPosteriorPdf) delete fPosteriorPdf;
@@ -732,7 +732,6 @@ void BayesianCalculator::ClearAll() const {
    fPosteriorPdf = 0;
    fPosteriorFunction = 0;
    fProductPdf = 0;
-   fLogLike = 0;
    fLikelihood = 0;
    fIntegratedLikelihood = 0;
    fLower = 0;
@@ -805,7 +804,7 @@ RooAbsReal* BayesianCalculator::GetPosteriorFunction() const
    //constrainedParams->Print("V");
 
    // use RooFit::Constrain() to be sure constraints terms are taken into account
-   fLogLike = fPdf->createNLL(*fData, RooFit::Constrain(*constrainedParams), RooFit::ConditionalObservables(fConditionalObs), RooFit::GlobalObservables(fGlobalObs) );
+   fLogLike = std::unique_ptr<RooAbsReal>{fPdf->createNLL(*fData, RooFit::Constrain(*constrainedParams), RooFit::ConditionalObservables(fConditionalObs), RooFit::GlobalObservables(fGlobalObs) )};
 
 
 
@@ -880,7 +879,7 @@ RooAbsReal* BayesianCalculator::GetPosteriorFunction() const
 #else
       // here use RooProdPdf (not very nice) but working
 
-      if (fLogLike) delete fLogLike;
+      if (fLogLike) fLogLike.reset();
       if (fProductPdf) {
          delete fProductPdf;
          fProductPdf = 0;
@@ -898,7 +897,7 @@ RooAbsReal* BayesianCalculator::GetPosteriorFunction() const
       std::unique_ptr<RooArgSet> constrParams{fPdf->getParameters(*fData)};
       // remove the constant parameters
       RemoveConstantParameters(&*constrParams);
-      fLogLike = pdfAndPrior->createNLL(*fData, RooFit::Constrain(*constrParams),RooFit::ConditionalObservables(fConditionalObs),RooFit::GlobalObservables(fGlobalObs) );
+      fLogLike = std::unique_ptr<RooAbsReal>{pdfAndPrior->createNLL(*fData, RooFit::Constrain(*constrParams),RooFit::ConditionalObservables(fConditionalObs),RooFit::GlobalObservables(fGlobalObs) )};
 
       TString likeName = TString("likelihood_times_prior_") + TString(pdfAndPrior->GetName());
       TString formula;

--- a/roofit/roostats/src/FeldmanCousins.cxx
+++ b/roofit/roostats/src/FeldmanCousins.cxx
@@ -171,8 +171,8 @@ void FeldmanCousins::CreateParameterPoints() const{
     // make profile construction
     RooFit::MsgLevel previous  = RooMsgService::instance().globalKillBelow();
     RooMsgService::instance().setGlobalKillBelow(RooFit::FATAL) ;
-    RooAbsReal* nll = pdf->createNLL(fData,RooFit::CloneData(false));
-    RooAbsReal* profile = nll->createProfile(*fModel.GetParametersOfInterest());
+    std::unique_ptr<RooAbsReal> nll{pdf->createNLL(fData,RooFit::CloneData(false))};
+    std::unique_ptr<RooAbsReal> profile{nll->createProfile(*fModel.GetParametersOfInterest())};
 
     RooDataSet* profileConstructionPoints = new RooDataSet("profileConstruction",
                         "profileConstruction",
@@ -186,8 +186,6 @@ void FeldmanCousins::CreateParameterPoints() const{
       profileConstructionPoints->add(*parameters);
     }
     RooMsgService::instance().setGlobalKillBelow(previous) ;
-    delete profile;
-    delete nll;
     if(!fPOIToTest) delete parameterScan;
 
     // done

--- a/roofit/roostats/src/FrequentistCalculator.cxx
+++ b/roofit/roostats/src/FrequentistCalculator.cxx
@@ -94,11 +94,11 @@ int FrequentistCalculator::PreNullHook(RooArgSet *parameterPoint, double obsTest
       if (fNullModel->GetGlobalObservables()) globalObs.add(*fNullModel->GetGlobalObservables());
 
       auto& config = GetGlobalRooStatsConfig();
-      RooAbsReal* nll = fNullModel->GetPdf()->createNLL(*const_cast<RooAbsData*>(fData), RooFit::CloneData(false), RooFit::Constrain(*allParams),
+      std::unique_ptr<RooAbsReal> nll{fNullModel->GetPdf()->createNLL(*const_cast<RooAbsData*>(fData), RooFit::CloneData(false), RooFit::Constrain(*allParams),
                                                         RooFit::GlobalObservables(globalObs),
                                                         RooFit::ConditionalObservables(conditionalObs),
-                                                        RooFit::Offset(config.useLikelihoodOffset));
-      RooProfileLL* profile = dynamic_cast<RooProfileLL*>(nll->createProfile(allButNuisance));
+                                                        RooFit::Offset(config.useLikelihoodOffset))};
+      std::unique_ptr<RooProfileLL> profile{dynamic_cast<RooProfileLL*>(nll->createProfile(allButNuisance))};
       // set minimier options
       profile->minimizer()->setPrintLevel(ROOT::Math::MinimizerOptions::DefaultPrintLevel()-1);
       profile->getVal(); // this will do fit and set nuisance parameters to profiled values
@@ -112,8 +112,6 @@ int FrequentistCalculator::PreNullHook(RooArgSet *parameterPoint, double obsTest
          delete result;
       }
 
-      delete profile;
-      delete nll;
       RooMsgService::instance().setGlobalKillBelow(msglevel);
 
       // set in test statistics conditional and global observables
@@ -203,12 +201,12 @@ int FrequentistCalculator::PreAltHook(RooArgSet *parameterPoint, double obsTestS
       if (fAltModel->GetGlobalObservables()) globalObs.add(*fAltModel->GetGlobalObservables());
 
       const auto& config = GetGlobalRooStatsConfig();
-      RooAbsReal* nll = fAltModel->GetPdf()->createNLL(*const_cast<RooAbsData*>(fData), RooFit::CloneData(false), RooFit::Constrain(*allParams),
+      std::unique_ptr<RooAbsReal> nll{fAltModel->GetPdf()->createNLL(*const_cast<RooAbsData*>(fData), RooFit::CloneData(false), RooFit::Constrain(*allParams),
                                                        RooFit::GlobalObservables(globalObs),
                                                        RooFit::ConditionalObservables(conditionalObs),
-                                                       RooFit::Offset(config.useLikelihoodOffset));
+                                                       RooFit::Offset(config.useLikelihoodOffset))};
 
-      RooProfileLL* profile = dynamic_cast<RooProfileLL*>(nll->createProfile(allButNuisance));
+      std::unique_ptr<RooProfileLL> profile{dynamic_cast<RooProfileLL*>(nll->createProfile(allButNuisance))};
       // set minimizer options
       profile->minimizer()->setPrintLevel(ROOT::Math::MinimizerOptions::DefaultPrintLevel()-1); // use -1 to make more silent
       profile->getVal(); // this will do fit and set nuisance parameters to profiled values
@@ -222,8 +220,6 @@ int FrequentistCalculator::PreAltHook(RooArgSet *parameterPoint, double obsTestS
          delete result;
       }
 
-      delete profile;
-      delete nll;
       RooMsgService::instance().setGlobalKillBelow(msglevel);
 
       // set in test statistics conditional and global observables

--- a/roofit/roostats/src/MCMCCalculator.cxx
+++ b/roofit/roostats/src/MCMCCalculator.cxx
@@ -171,7 +171,7 @@ MCMCInterval* MCMCCalculator::GetInterval() const
    }
 
    std::unique_ptr<RooArgSet> constrainedParams{prodPdf->getParameters(*fData)};
-   RooAbsReal* nll = prodPdf->createNLL(*fData, Constrain(*constrainedParams),ConditionalObservables(fConditionalObs),GlobalObservables(fGlobalObs));
+   std::unique_ptr<RooAbsReal> nll{prodPdf->createNLL(*fData, Constrain(*constrainedParams),ConditionalObservables(fConditionalObs),GlobalObservables(fGlobalObs))};
 
    std::unique_ptr<RooArgSet> params{nll->getParameters(*fData)};
    RemoveConstantParameters(&*params);
@@ -215,7 +215,6 @@ MCMCInterval* MCMCCalculator::GetInterval() const
 
    if (useDefaultPropFunc) delete fPropFunc;
    if (usePriorPdf) delete prodPdf;
-   delete nll;
 
    return interval;
 }

--- a/roofit/roostats/src/ProfileInspector.cxx
+++ b/roofit/roostats/src/ProfileInspector.cxx
@@ -93,8 +93,8 @@ TList* ProfileInspector::GetListOfProfilePlots( RooAbsData& data, RooStats::Mode
     return 0;
   }
 
-  RooAbsReal* nll = pdf->createNLL(data);
-  RooAbsReal* profile = nll->createProfile(*poi);
+  std::unique_ptr<RooAbsReal> nll{pdf->createNLL(data)};
+  std::unique_ptr<RooAbsReal> profile{nll->createProfile(*poi)};
 
   TList * list = new TList;
   Int_t curve_N=100;
@@ -140,8 +140,5 @@ TList* ProfileInspector::GetListOfProfilePlots( RooAbsData& data, RooStats::Mode
 
   delete [] curve_x;
 
-
-  delete nll;
-  delete profile;
   return list;
 }

--- a/roofit/roostats/src/SimpleLikelihoodRatioTestStat.cxx
+++ b/roofit/roostats/src/SimpleLikelihoodRatioTestStat.cxx
@@ -51,7 +51,8 @@ double RooStats::SimpleLikelihoodRatioTestStat::Evaluate(RooAbsData& data, RooAr
    bool created = false ;
    if (!fNllNull) {
       std::unique_ptr<RooArgSet> allParams{fNullPdf->getParameters(data)};
-      fNllNull = fNullPdf->createNLL(data, RooFit::CloneData(false),RooFit::Constrain(*allParams),RooFit::GlobalObservables(fGlobalObs),RooFit::ConditionalObservables(fConditionalObs));
+      using namespace RooFit;
+      fNllNull = std::unique_ptr<RooAbsReal>{fNullPdf->createNLL(data, CloneData(false), Constrain(*allParams), GlobalObservables(fGlobalObs), ConditionalObservables(fConditionalObs))};
       created = true ;
    }
    if (reuse && !created) {
@@ -69,13 +70,14 @@ double RooStats::SimpleLikelihoodRatioTestStat::Evaluate(RooAbsData& data, RooAr
 
 
    if (!reuse) {
-      delete fNllNull ; fNllNull = nullptr ;
+      fNllNull.reset();
    }
 
    created = false ;
    if (!fNllAlt) {
       std::unique_ptr<RooArgSet> allParams{fAltPdf->getParameters(data)};
-      fNllAlt = fAltPdf->createNLL(data, RooFit::CloneData(false),RooFit::Constrain(*allParams),RooFit::GlobalObservables(fGlobalObs),RooFit::ConditionalObservables(fConditionalObs));
+      using namespace RooFit;
+      fNllAlt = std::unique_ptr<RooAbsReal>{fAltPdf->createNLL(data, CloneData(false), Constrain(*allParams), GlobalObservables(fGlobalObs), ConditionalObservables(fConditionalObs))};
       created = true ;
    }
    if (reuse && !created) {
@@ -94,7 +96,7 @@ double RooStats::SimpleLikelihoodRatioTestStat::Evaluate(RooAbsData& data, RooAr
 
 
    if (!reuse) {
-      delete fNllAlt ; fNllAlt = nullptr ;
+      fNllAlt.reset();
    }
 
 

--- a/roofit/roostats/src/ToyMCImportanceSampler.cxx
+++ b/roofit/roostats/src/ToyMCImportanceSampler.cxx
@@ -44,8 +44,8 @@ ToyMCImportanceSampler::~ToyMCImportanceSampler() {
 void ToyMCImportanceSampler::ClearCache(void) {
    ToyMCSampler::ClearCache();
 
-   for( unsigned int i=0; i < fImpNLLs.size(); i++ ) if(fImpNLLs[i]) { delete fImpNLLs[i]; fImpNLLs[i] = nullptr; }
-   for( unsigned int i=0; i < fNullNLLs.size(); i++ ) if(fNullNLLs[i]) { delete fNullNLLs[i]; fNullNLLs[i] = nullptr; }
+   for( unsigned int i=0; i < fImpNLLs.size(); i++ ) { fImpNLLs[i].reset(); }
+   for( unsigned int i=0; i < fNullNLLs.size(); i++ ) { fNullNLLs[i].reset(); }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -358,14 +358,14 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
       allVars->assign(*fNullSnapshots[i]);
       if( !fNullNLLs[i] ) {
          std::unique_ptr<RooArgSet> allParams{fNullDensities[i]->getParameters(*data)};
-         fNullNLLs[i] = fNullDensities[i]->createNLL(*data, RooFit::CloneData(false), RooFit::Constrain(*allParams),
-                                                     RooFit::ConditionalObservables(fConditionalObs));
+         fNullNLLs[i] = std::unique_ptr<RooAbsReal>{fNullDensities[i]->createNLL(*data, RooFit::CloneData(false), RooFit::Constrain(*allParams),
+                                                     RooFit::ConditionalObservables(fConditionalObs))};
       }else{
          fNullNLLs[i]->setData( *data, false );
       }
       nullNLLVals[i] = fNullNLLs[i]->getVal();
       // FOR DEBuGGING!!!!!!!!!!!!!!!!!
-      if( !fReuseNLL ) { delete fNullNLLs[i]; fNullNLLs[i] = nullptr; }
+      if( !fReuseNLL ) { fNullNLLs[i].reset(); }
    }
 
 
@@ -383,14 +383,14 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
       }
       if( !fImpNLLs[i] ) {
          std::unique_ptr<RooArgSet> allParams{fImportanceDensities[i]->getParameters(*data)};
-         fImpNLLs[i] = fImportanceDensities[i]->createNLL(*data, RooFit::CloneData(false), RooFit::Constrain(*allParams),
-                                                          RooFit::ConditionalObservables(fConditionalObs));
+         fImpNLLs[i] = std::unique_ptr<RooAbsReal>{fImportanceDensities[i]->createNLL(*data, RooFit::CloneData(false), RooFit::Constrain(*allParams),
+                                                          RooFit::ConditionalObservables(fConditionalObs))};
       }else{
          fImpNLLs[i]->setData( *data, false );
       }
       impNLLVals[i] = fImpNLLs[i]->getVal();
       // FOR DEBuGGING!!!!!!!!!!!!!!!!!
-      if( !fReuseNLL ) { delete fImpNLLs[i]; fImpNLLs[i] = nullptr; }
+      if( !fReuseNLL ) { fImpNLLs[i].reset(); }
 
       for( unsigned int j=0; j < nullNLLVals.size(); j++ ) {
          if( impNLLVals[i] < minNLLVals[j] ) minNLLVals[j] = impNLLVals[i];

--- a/roofit/xroofit/src/xRooNLLVar.cxx
+++ b/roofit/xroofit/src/xRooNLLVar.cxx
@@ -323,7 +323,7 @@ void xRooNLLVar::reinitialize()
       std::set<std::string> attribs;
       if (std::shared_ptr<RooAbsReal>::get())
          attribs = std::shared_ptr<RooAbsReal>::get()->attributes();
-      this->reset(fPdf->createNLL(*fData, *fOpts));
+      this->reset(std::unique_ptr<RooAbsReal>{fPdf->createNLL(*fData, *fOpts)}.release());
       // RooFit only swaps in what it calls parameters, this misses out the RooConstVars which we treat as pars as well
       // so swap those in ... question: is recursiveRedirectServers usage in RooAbsOptTestStatic (and here) a memory
       // leak?? where do the replaced servers get deleted??


### PR DESCRIPTION
Migrate `RooAbsPdf::createNLL()` to use the `RooFit::OwningPtr<T>`, and change all RooFit code such that it would still compile when defining the `OwningPtr` as `std::unique_ptr<T>`.

See https://github.com/root-project/root/pull/12614.