### PR TITLE
Fix TTreeCache Scaling with the number of clusters/baskets.

### DIFF
--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -430,6 +430,7 @@ public:
    virtual Long64_t        Draw(const char* varexp, const char* selection, Option_t* option = "", Long64_t nentries = kMaxEntries, Long64_t firstentry = 0); // *MENU*
    virtual void            DropBaskets();
    virtual void            DropBuffers(Int_t nbytes);
+           Bool_t          EnableCache();
    virtual Int_t           Fill();
    virtual TBranch        *FindBranch(const char* name);
    virtual TLeaf          *FindLeaf(const char* name);

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -2674,6 +2674,29 @@ TStreamerInfo* TTree::BuildStreamerInfo(TClass* cl, void* pointer /* = 0 */, Boo
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Enable the TTreeCache unless explicitly disabled for this TTree by
+/// a prior call to `SetCacheSize(0)`.
+/// If the environment variable `ROOT_TTREECACHE_SIZE` or the rootrc config
+/// `TTreeCache.Size` has been set to zero, this call will over-ride them with
+/// a value of 1.0 (i.e. use a cache size to hold 1 cluster)
+///
+/// Return true if there is a cache attached to the `TTree` (either pre-exisiting
+/// or created as part of this call)
+Bool_t TTree::EnableCache()
+{
+   TFile* file = GetCurrentFile();
+   if (!file)
+      return kFALSE;
+   // Check for an existing cache
+   TTreeCache* pf = GetReadCache(file);
+   if (pf)
+      return kTRUE;
+   if (fCacheUserSet && fCacheSize == 0)
+      return kFALSE;
+   return (0 == SetCacheSizeAux(kTRUE, -1));
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Called by TTree::Fill() when file has reached its maximum fgMaxTreeSize.
 /// Create a new file. If the original file is named "myfile.root",
 /// subsequent files are named "myfile_1.root", "myfile_2.root", etc.

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -9540,34 +9540,13 @@ void TTree::Streamer(TBuffer& b)
             // current set of ranges.
             fMaxClusterRange = fNClusterRange;
          }
-         if (GetCacheAutoSize() != 0) {
-            // a cache will be automatically created.
-            // No need for TTreePlayer::Process to enable the cache
-            fCacheSize = 0;
-         } else if (fAutoFlush < 0) {
-            // If there is no autoflush set, let's keep the cache completely
-            // disable by default for now.
-            fCacheSize = fAutoFlush;
-         } else if (fAutoFlush != 0) {
-            // Estimate the cluster size.
-            // This will allow TTree::Process to enable the cache.
-            Long64_t zipBytes = GetZipBytes();
-            Long64_t totBytes = GetTotBytes();
-            if (zipBytes != 0) {
-               fCacheSize =  fAutoFlush*(zipBytes/fEntries);
-            } else if (totBytes != 0) {
-               fCacheSize =  fAutoFlush*(totBytes/fEntries);
-            } else {
-               fCacheSize = 30000000;
-            }
-            if (fCacheSize >= (INT_MAX / 4)) {
-               fCacheSize = INT_MAX / 4;
-            } else if (fCacheSize == 0) {
-               fCacheSize = 30000000;
-            }
-         } else {
-            fCacheSize = 0;
-         }
+
+         // Throughs calls to `GetCacheAutoSize` or `EnableCache` (for example
+         // by TTreePlayer::Process, the cache size will be automatically
+         // determined unless the user explicitly call `SetCacheSize`
+         fCacheSize = 0;
+         fCacheUserSet = kFALSE;
+
          ResetBit(kMustCleanup);
          return;
       }

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -5420,7 +5420,7 @@ Long64_t TTree::GetCacheAutoSize(Bool_t withDefault /* = kFALSE */ )
          if (medianClusterSize > 0)
             cacheSize = Long64_t(1.5 * medianClusterSize * GetZipBytes() / (fEntries + 1));
          else
-            cacheSize = Long64_t(cacheFactor * 1.5 * 30000000); // use the default value of fAutoFlush
+            cacheSize = Long64_t(1.5 * 30000000); // use the default value of fAutoFlush
       } else {
          cacheSize = Long64_t(1.5 * fAutoFlush * GetZipBytes() / (fEntries + 1));
       }

--- a/tree/tree/src/TTreeCache.cxx
+++ b/tree/tree/src/TTreeCache.cxx
@@ -1335,7 +1335,7 @@ Bool_t TTreeCache::FillBuffer()
 
    struct collectionInfo {
       Int_t fClusterStart{-1}; // First basket belonging to the current cluster
-      Int_t fCurrent{0};       // Currently visited basket
+      Int_t fCurrent{-1};       // Currently visited basket
       Bool_t fLoadedOnce{kFALSE};
 
       void Rewind() { fCurrent = (fClusterStart >= 0) ? fClusterStart : 0; }
@@ -1416,6 +1416,9 @@ Bool_t TTreeCache::FillBuffer()
 
             if (pass == kRewind)
                cursor[i].Rewind();
+            else if (cursor[i].fCurrent == -1) {
+               cursor[i].fCurrent = TMath::BinarySearch(b->GetWriteBasket() + 1, entries, minEntry);
+            }
             for (auto &j = cursor[i].fCurrent; j < nb; j++) {
                // This basket has already been read, skip it
 

--- a/tree/tree/src/TTreeCache.cxx
+++ b/tree/tree/src/TTreeCache.cxx
@@ -1332,18 +1332,20 @@ Bool_t TTreeCache::FillBuffer()
    Long64_t maxReadEntry = minEntry; // If we are stopped before the end of the 2nd pass, this marker will where we need to start next time.
    Int_t nReadPrefRequest = 0;
    auto perfStats = GetTree()->GetPerfStats();
+
+   struct collectionInfo {
+      Int_t fClusterStart{-1}; // First basket belonging to the current cluster
+      Int_t fCurrent{0};       // Currently visited basket
+      Bool_t fLoadedOnce{kFALSE};
+
+      void Rewind() { fCurrent = (fClusterStart >= 0) ? fClusterStart : 0; }
+   };
+   std::vector<collectionInfo> cursor(fNbranches);
+
    do {
       prevNtot = ntotCurrentBuf;
       Long64_t lowestMaxEntry = fEntryMax; // The lowest maximum entry in the TTreeCache for each branch for each pass.
 
-      struct collectionInfo {
-         Int_t fClusterStart{-1}; // First basket belonging to the current cluster
-         Int_t fCurrent{0};       // Currently visited basket
-         Bool_t fLoadedOnce{kFALSE};
-
-         void Rewind() { fCurrent = (fClusterStart >= 0) ? fClusterStart : 0; }
-      };
-      std::vector<collectionInfo> cursor(fNbranches);
       Bool_t reachedEnd = kFALSE;
       Bool_t skippedFirst = kFALSE;
       Bool_t oncePerBranch = kFALSE;

--- a/tree/tree/src/TTreeCache.cxx
+++ b/tree/tree/src/TTreeCache.cxx
@@ -1342,6 +1342,11 @@ Bool_t TTreeCache::FillBuffer()
    };
    std::vector<collectionInfo> cursor(fNbranches);
 
+   // Main loop to fill the cache, inside each loop we will loop over
+   // all the cached branch and collect the baskets within the 'current'
+   // range/cluster.  If there is still space in the cache after that, we
+   // will do another iteration to add one more cluster to the cache.
+   // i.e. essentially loop over the clusters.
    do {
       prevNtot = ntotCurrentBuf;
       Long64_t lowestMaxEntry = fEntryMax; // The lowest maximum entry in the TTreeCache for each branch for each pass.

--- a/tree/treeplayer/src/TTreePlayer.cxx
+++ b/tree/treeplayer/src/TTreePlayer.cxx
@@ -2253,12 +2253,14 @@ Long64_t TTreePlayer::Process(TSelector *selector,Option_t *option, Long64_t nen
       //set the file cache
       TTreeCache *tpf = 0;
       TFile *curfile = fTree->GetCurrentFile();
-      if (curfile && fTree->GetCacheSize() > 0) {
+      if (curfile) {
          tpf = (TTreeCache*)curfile->GetCacheRead(fTree);
          if (tpf)
             tpf->SetEntryRange(firstentry,firstentry+nentries);
          else {
-            fTree->SetCacheSize(fTree->GetCacheSize());
+            // Create the TTreeCache with the default size unless the
+            // user explicitly disabled it.
+            fTree->EnableCache();
             tpf = (TTreeCache*)curfile->GetCacheRead(fTree);
             if (tpf) tpf->SetEntryRange(firstentry,firstentry+nentries);
          }


### PR DESCRIPTION
On an extreme example:
```
    15,272,928 entries
       152,739 baskets (and as many clusters)
        10,000 Actual TTreeCache buffer size (minimum allowed)
         8,442 estimated buffer size of TTreeCache (1.5 times compressed buffer size)
           400 bytes per baskets
           100 entries per baskets (i.e. per clusters)
            25 number of cluster per TTreeCache buffer for single branch with default size.
             1 float per entry (reading a single branch).
```

This repairs the performance of a simple `TTree::Draw` of a single branch
from 1 hour back down to 7s (performance seem in v6.12).

One additional improvement, increase the performance by 20% on that same example.

This fixes #12649.
