### PR TITLE
[RF] Speed up implementation of `RooHelpers::cloneTreeWithSameParameters()` and friends

### DIFF
--- a/roofit/roofitcore/inc/RooAbsCollection.h
+++ b/roofit/roofitcore/inc/RooAbsCollection.h
@@ -363,9 +363,6 @@ protected:
 
   void deleteList() ;
 
-  // Support for snapshot method
-  bool addServerClonesToList(const RooAbsArg& var) ;
-
   inline TNamed* structureTag() { if (_structureTag==nullptr) makeStructureTag() ; return _structureTag ; }
   inline TNamed* typedStructureTag() { if (_typedStructureTag==nullptr) makeTypedStructureTag() ; return _typedStructureTag ; }
 

--- a/roofit/roofitcore/inc/RooHelpers.h
+++ b/roofit/roofitcore/inc/RooHelpers.h
@@ -137,6 +137,11 @@ bool checkIfRangesOverlap(RooArgSet const& observables, std::vector<std::string>
 std::string getColonSeparatedNameString(RooArgSet const& argSet);
 RooArgSet selectFromArgSet(RooArgSet const&, std::string const& names);
 
+namespace Detail {
+
+bool snapshotImpl(RooAbsCollection const& input, RooAbsCollection& output, bool deepCopy);
+
+} // namespace Detail
 
 /// Clone RooAbsArg object and reattach to original parameters.
 template<class T>

--- a/roofit/roofitcore/inc/RooHelpers.h
+++ b/roofit/roofitcore/inc/RooHelpers.h
@@ -139,18 +139,15 @@ RooArgSet selectFromArgSet(RooArgSet const&, std::string const& names);
 
 namespace Detail {
 
-bool snapshotImpl(RooAbsCollection const& input, RooAbsCollection& output, bool deepCopy);
+bool snapshotImpl(RooAbsCollection const& input, RooAbsCollection& output, bool deepCopy, RooArgSet const *observables);
+RooAbsArg *cloneTreeWithSameParametersImpl(RooAbsArg const &arg, RooArgSet const *observables);
 
 } // namespace Detail
 
 /// Clone RooAbsArg object and reattach to original parameters.
 template<class T>
 std::unique_ptr<T> cloneTreeWithSameParameters(T const& arg, RooArgSet const* observables=nullptr) {
-  std::unique_ptr<T> clone{static_cast<T *>(arg.cloneTree())};
-  RooArgSet origParams;
-  arg.getParameters(observables, origParams);
-  clone->recursiveRedirectServers(origParams);
-  return clone;
+  return std::unique_ptr<T>{static_cast<T *>(Detail::cloneTreeWithSameParametersImpl(arg, observables))};
 }
 
 std::string getRangeNameForSimComponent(std::string const& rangeName, bool splitRange, std::string const& catName);

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -2257,32 +2257,12 @@ bool RooAbsArg::addOwnedComponents(RooArgList&& comps) {
 
 RooAbsArg* RooAbsArg::cloneTree(const char* newname) const
 {
-  // Clone tree using snapshot
-  RooArgSet clonedNodes;
-  RooArgSet(*this).snapshot(clonedNodes, true);
-
-  // Find the head node in the cloneSet
-  RooAbsArg* head = clonedNodes.find(*this) ;
-  assert(head);
-
-  // We better to release the ownership before removing the "head". Otherwise,
-  // "head" might also be deleted as the clonedNodes collection owns it.
-  // (Actually this does not happen because even an owning collection doesn't
-  // delete the element when removed by pointer lookup, but it's better not to
-  // rely on this unexpected fact).
-  clonedNodes.releaseOwnership();
-
-  // Remove the head node from the cloneSet
-  // To release it from the set ownership
-  clonedNodes.remove(*head) ;
-
-  // Add the set as owned component of the head
-  head->addOwnedComponents(std::move(clonedNodes)) ;
+  // In the RooHelpers, there is a more general implementation that we will reuse here
+  RooAbsArg *head = RooHelpers::Detail::cloneTreeWithSameParametersImpl(*this, nullptr);
 
   // Adjust name of head node if requested
   if (newname) {
-    head->TNamed::SetName(newname) ;
-    head->_namePtr = RooNameReg::instance().constPtr(newname) ;
+    head->SetName(newname) ;
   }
 
   // Return the head

--- a/roofit/roofitcore/src/RooAbsCollection.cxx
+++ b/roofit/roofitcore/src/RooAbsCollection.cxx
@@ -254,7 +254,7 @@ RooAbsCollection* RooAbsCollection::snapshot(bool deepCopy) const
 
 bool RooAbsCollection::snapshot(RooAbsCollection& output, bool deepCopy) const
 {
-  return RooHelpers::Detail::snapshotImpl(*this, output, deepCopy);
+  return RooHelpers::Detail::snapshotImpl(*this, output, deepCopy, nullptr);
 }
 
 

--- a/roofit/roofitcore/src/RooAbsCollection.cxx
+++ b/roofit/roofitcore/src/RooAbsCollection.cxx
@@ -42,8 +42,9 @@ implemented using the container denoted by RooAbsCollection::Storage_t.
 #include "RooRealVar.h"
 #include "RooGlobalFunc.h"
 #include "RooMsgService.h"
-#include "strlcpy.h"
+#include <RooHelpers.h>
 
+#include <strlcpy.h>
 #include <algorithm>
 #include <iomanip>
 #include <iostream>
@@ -253,71 +254,8 @@ RooAbsCollection* RooAbsCollection::snapshot(bool deepCopy) const
 
 bool RooAbsCollection::snapshot(RooAbsCollection& output, bool deepCopy) const
 {
-  // Copy contents
-  output.reserve(_list.size());
-  for (auto orig : _list) {
-    output.add(*static_cast<RooAbsArg*>(orig->Clone()));
-  }
-
-  // Add external dependents
-  bool error(false) ;
-  if (deepCopy) {
-    // Recursively add clones of all servers
-    // Can only do index access because collection might reallocate when growing
-    for (Storage_t::size_type i = 0; i < output._list.size(); ++i) {
-      const auto var = output._list[i];
-      error |= output.addServerClonesToList(*var);
-    }
-  }
-
-  // Handle eventual error conditions
-  if (error) {
-    coutE(ObjectHandling) << "RooAbsCollection::snapshot(): Errors occurred in deep clone process, snapshot not created" << std::endl;
-    output._ownCont = true ;
-    return true ;
-  }
-
-
-
-   // Redirect all server connections to internal list members
-  for (auto var : output) {
-    var->redirectServers(output,deepCopy);
-  }
-
-
-  // Transfer ownership of contents to list
-  output._ownCont = true ;
-  return false ;
+  return RooHelpers::Detail::snapshotImpl(*this, output, deepCopy);
 }
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Add clones of servers of given argument to end of list
-
-bool RooAbsCollection::addServerClonesToList(const RooAbsArg& var)
-{
-  bool ret(false) ;
-
-  // This can be a very heavy operation if existing elements depend on many others,
-  // so make sure that we have the hash map available for faster finding.
-  if (var.servers().size() > 20 || _list.size() > 30)
-    useHashMapForFind(true);
-
-  for (const auto server : var.servers()) {
-    RooAbsArg* tmp = find(*server) ;
-
-    if (!tmp) {
-      auto* serverClone = static_cast<RooAbsArg*>(server->Clone());
-      serverClone->setAttribute("SnapShot_ExtRefClone") ;
-      insert(serverClone);
-      ret |= addServerClonesToList(*server) ;
-    }
-  }
-
-  return ret ;
-}
-
 
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Some time ago, I introduced the `RooHelpers::cloneTreeWithSameParameters()` function to eventually speed up cloning a RooAbsArg tree and then redirecting the parameters in a single pass.

This speeds up the likelihood creation in ATLAS Higgs combination fits for example, because the parameter redirection pass is quite expensive.

Things are now rewritten such that the parameters are not cloned to begin with, and therefore also don't need to be redirected to the original ones.

Since `RooHelpers::cloneTreeWithSameParameters()` and its implementation helpers are now generalizations of `RooAbsArg::cloneTree()` and `RooAbsCollection::snapshot()`, these methods are not implemented in terms of the RooHelpers.

