### PR TITLE
[ntuple] Do not try to resolve `ROOT::Experimental::ClusterSize_t`

### DIFF
--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -130,7 +130,7 @@ std::tuple<std::string, std::vector<size_t>> ParseArrayType(std::string_view typ
 {
    std::vector<size_t> sizeVec;
 
-   /// Only parse outer array definition, i.e. the right `]` should be at the end of the type name
+   // Only parse outer array definition, i.e. the right `]` should be at the end of the type name
    while (typeName.back() == ']') {
       auto posRBrace = typeName.size() - 1;
       auto posLBrace = typeName.find_last_of("[", posRBrace);
@@ -147,10 +147,12 @@ std::tuple<std::string, std::vector<size_t>> ParseArrayType(std::string_view typ
 }
 
 std::string GetNormalizedType(const std::string &typeName) {
-   std::string normalizedType(
-      TClassEdit::ResolveTypedef(TClassEdit::CleanType(typeName.c_str(),
-                                                       /*mode=*/2).c_str()));
+   std::string normalizedType(TClassEdit::CleanType(typeName.c_str(), /*mode=*/2));
+   // The following types are asummed to be canonical names; thus, do not perform `typedef` resolution on those
+   if (normalizedType == "ROOT::Experimental::ClusterSize_t")
+      return normalizedType;
 
+   normalizedType = TClassEdit::ResolveTypedef(normalizedType.c_str());
    auto translatedType = typeTranslationMap.find(normalizedType);
    if (translatedType != typeTranslationMap.end())
       normalizedType = translatedType->second;


### PR DESCRIPTION
On Windows, the type `ROOT::Experimental::ClusterSize_t` is resolved to the underlying type `ROOT::Experimental::RClusterSize`. `ROOT::Experimental::ClusterSize_t` is already in its canonical form and `typedef` resolution should not be attempted.

TL;DR, if the type is resolved to `ROOT::Experimental::RClusterSize`, the logic in `RFieldBase::Create()` falls back to creating a `RClassField` instance, which is obviously not intended.

This fixes the `ntuple_packing` test on Windows.

## Checklist:
- [X] tested changes locally