### PR TITLE
[RF] RooProjectedPdf support extended pdfs and normalization ranges

### DIFF
--- a/roofit/roofitcore/inc/RooProjectedPdf.h
+++ b/roofit/roofitcore/inc/RooProjectedPdf.h
@@ -43,6 +43,11 @@ public:
 
   std::unique_ptr<RooAbsArg> compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileContext & ctx) const override;
 
+  // Handle case of projecting an Extended pdf
+  double expectedEvents(const RooArgSet* nset) const override { return static_cast<RooAbsPdf*>(intpdf.absArg())->expectedEvents(nset); }
+  ExtendMode extendMode() const override { return static_cast<RooAbsPdf*>(intpdf.absArg())->extendMode(); }
+  
+
 protected:
 
   RooRealProxy intpdf ; ///< p.d.f that is integrated

--- a/roofit/roofitcore/src/RooProjectedPdf.cxx
+++ b/roofit/roofitcore/src/RooProjectedPdf.cxx
@@ -95,7 +95,7 @@ double RooProjectedPdf::evaluate() const
 {
   // Calculate current unnormalized value of object
   int code ;
-  return getProjection(&intobs, _normSet, (_normRangeOverride.Length()>0 ? _normRangeOverride.Data() : (_normRange.Length()>0 ? _normRange.Data() : 0)), code)->getVal() ;
+  return getProjection(&intobs, _normSet, normRange(), code)->getVal() ;
 }
 
 

--- a/roofit/roofitcore/src/RooProjectedPdf.cxx
+++ b/roofit/roofitcore/src/RooProjectedPdf.cxx
@@ -95,7 +95,7 @@ double RooProjectedPdf::evaluate() const
 {
   // Calculate current unnormalized value of object
   int code ;
-  return getProjection(&intobs, _normSet, 0, code)->getVal() ;
+  return getProjection(&intobs, _normSet, (_normRangeOverride.Length()>0 ? _normRangeOverride.Data() : (_normRange.Length()>0 ? _normRange.Data() : 0)), code)->getVal() ;
 }
 
 


### PR DESCRIPTION
This is a suggestion for two improvements to the class:

1. The projected pdf should be extended if the pdf it is projecting is also extended.
2. The projection should respect the normalization range if one is given.

Submitting this PR to solicit feedback on these proposals
