### PR TITLE
[RF] Fix error in RooProdPdf that comes from wrong `addOwned()`

### DIFF
--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -808,7 +808,8 @@ std::unique_ptr<RooProdPdf::CacheElem> RooProdPdf::createCacheElem(const RooArgS
       std::ostringstream str; termNSet.printValue(str);
       if (!ratioTerms[str.str()].empty()) {
 //    cout << "MUST INSERT RATIO OBJECT IN TERM (SINGLE) " << *term << endl;
-   term->addOwned(std::move(ratioTerms[str.str()]));
+      term->add(ratioTerms[str.str()]);
+      cache->_ownedList.addOwned(std::move(ratioTerms[str.str()]));
       }
     } else {
       RooArgSet compTermSet, compTermNorm;
@@ -822,7 +823,8 @@ std::unique_ptr<RooProdPdf::CacheElem> RooProdPdf::createCacheElem(const RooArgS
    ostringstream str; termNSet.printValue(str);
    if (!ratioTerms[str.str()].empty()) {
 //      cout << "MUST INSERT RATIO OBJECT IN TERM (COMPOSITE)" << *term << endl;
-     term->addOwned(std::move(ratioTerms[str.str()]));
+     term->add(ratioTerms[str.str()]);
+     cache->_ownedList.addOwned(std::move(ratioTerms[str.str()]));
    }
       }
     }


### PR DESCRIPTION
For some of the args created in the RooProdPdf cache, the ownership
model was wrong. They were attempted to be added to a list that is
actually not owning, but they should be added to the owning container of
the cache.

This fixes an issue with 6.28 reported on the forum:
https://root-forum.cern.ch/t/plot-normalization-after-rooaddpdf-fixaddcoefrange/54480

