### PR TITLE
[ntuple] Add support for unique pointers

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -670,7 +670,7 @@ Note that RNTuple does not support polymorphism, so the type `T` is expected to 
 By default, the mother field has a principal column of type `(Split)Index[64|32]`.
 This is called sparse representation.
 The alternative, dense representation uses a `Bit` column to mask non-existing instances of the subfield.
-In this second case, a default-constructed `T` is stored on disk for the non-existing instances.
+In this second case, a default-constructed `T` (or, if applicable, a `T` constructed by the ROOT I/O constructor) is stored on disk for the non-existing instances.
 
 ### User-defined classes
 

--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -665,6 +665,8 @@ Within the repetition blocks, bits are stored in little-endian order, i.e. the l
 A unique pointer and an optional type have the same on disk representation.
 They are represented as a collection of `T`s of zero or one elements.
 A collection mother field has a single subfield named `_0` for `T`, where `T` must have RNTuple I/O support.
+Note that RNTuple does not support polymorphism, so the type `T` is expected to be `T` and not a child class of `T`.
+
 By default, the mother field has a principal column of type `(Split)Index[64|32]`.
 This is called sparse representation.
 The alternative, dense representation uses a `Bit` column to mask non-existing instances of the subfield.

--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -652,13 +652,23 @@ The child fileds are named `_0` and `_1`.
 #### std::tuple<T1, T2, ..., Tn>
 
 A tuple is stored using an empty mother field with $n$ subfields of type `T1`, `T2`, ..., `Tn`. All types must have RNTuple I/O support.
-The child fileds are named `_0`, `_1`, ...
+The child fields are named `_0`, `_1`, ...
 
 #### std::bitset<N>
 
 A bitset is stored as a repetitive leaf field with an attached `Bit` column.
 The bitset size `N` is stored as repetition parameter in the field meta-data.
 Within the repetition blocks, bits are stored in little-endian order, i.e. the least significant bits come first.
+
+#### std::unique_ptr<T>, std::optional<T>
+
+A unique pointer and an optional type have the same on disk representation.
+They are represented as a collection of `T`s of zero or one elements.
+A collection mother field has a single subfield named `_0` for `T`, where `T` must have RNTuple I/O support.
+By default, the mother field has a principal column of type `(Split)Index[64|32]`.
+This is called sparse representation.
+The alternative, dense representation uses a `Bit` column to mask non-existing instances of the subfield.
+In this second case, a default-constructed `T` is stored on disk for the non-existing instances.
 
 ### User-defined classes
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -815,7 +815,7 @@ class RNullableField : public Detail::RFieldBase {
    /// For a dense nullable field, used to write a default-constructed item for missing ones.
    Detail::RFieldValue fDefaultItemValue;
    /// For a sparse nullable field, the number of written non-null items in this cluster
-   ClusterSize_t::ValueType fNWritten{0};
+   ClusterSize_t fNWritten{0};
 
 protected:
    const Detail::RFieldBase::RColumnRepresentations &GetColumnRepresentations() const final;
@@ -839,7 +839,7 @@ public:
    bool IsDense() const { return GetColumnRepresentative() == ColumnRepresentation_t({EColumnType::kBit}); }
    bool IsSparse() const { return !IsDense(); }
    void SetDense() { SetColumnRepresentative({EColumnType::kBit}); }
-   void SetSparse() { SetColumnRepresentative({EColumnType::kSwitch}); }
+   void SetSparse() { SetColumnRepresentative({EColumnType::kSplitIndex32}); }
 
    void CommitCluster() final { fNWritten = 0; }
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -804,6 +804,29 @@ public:
    void CommitCluster() final;
 };
 
+/// The field for values that may or may not be present in an entry. Parent class for unique pointer field and
+/// optional field. A nullable field cannot be instantiated itself but only its descendants.
+class RNullableField : public Detail::RFieldBase {
+protected:
+   const Detail::RFieldBase::RColumnRepresentations &GetColumnRepresentations() const final;
+   void GenerateColumnsImpl() final;
+   void GenerateColumnsImpl(const RNTupleDescriptor &) final;
+
+   std::size_t AppendNull();
+   std::size_t AppendValue(const Detail::RFieldValue &value);
+   bool IsNull(NTupleSize_t globalIndex);
+   void ReadValue(NTupleSize_t globalIndex, Detail::RFieldValue *value);
+
+   RNullableField(std::string_view fieldName, std::string_view typeName,
+                  std::unique_ptr<Detail::RFieldBase> &&itemField);
+
+public:
+   RNullableField(RNullableField &&other) = default;
+   RNullableField &operator=(RNullableField &&other) = default;
+   ~RNullableField() override = default;
+
+   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+};
 
 /// Classes with dictionaries that can be inspected by TClass
 template <typename T, typename=void>

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -806,7 +806,7 @@ public:
 
 /// The field for values that may or may not be present in an entry. Parent class for unique pointer field and
 /// optional field. A nullable field cannot be instantiated itself but only its descendants.
-/// The RNullableField takes care of the on-disk representation. Child classes are charged with the in-memory
+/// The RNullableField takes care of the on-disk representation. Child classes are responsible for the in-memory
 /// representation.  The on-disk representation can be "dense" or "sparse". Dense nullable fields have a bitmask
 /// (true: item available, false: item missing) and serialize a default-constructed item for missing items.
 /// Sparse nullable fields use a switch column to point to the available items.

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -809,8 +809,8 @@ public:
 /// The RNullableField takes care of the on-disk representation. Child classes are responsible for the in-memory
 /// representation.  The on-disk representation can be "dense" or "sparse". Dense nullable fields have a bitmask
 /// (true: item available, false: item missing) and serialize a default-constructed item for missing items.
-/// Sparse nullable fields use a switch column to point to the available items.
-/// By default, items whose size is smaller or equal to 8 bytes (size of switch column element) are stored densely.
+/// Sparse nullable fields use a (Split)Index[64|32] column to point to the available items.
+/// By default, items whose size is smaller or equal to 4 bytes (size of (Split)Index32 column element) are stored densely.
 class RNullableField : public Detail::RFieldBase {
    /// For a dense nullable field, used to write a default-constructed item for missing ones.
    Detail::RFieldValue fDefaultItemValue;

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -810,7 +810,8 @@ public:
 /// representation.  The on-disk representation can be "dense" or "sparse". Dense nullable fields have a bitmask
 /// (true: item available, false: item missing) and serialize a default-constructed item for missing items.
 /// Sparse nullable fields use a (Split)Index[64|32] column to point to the available items.
-/// By default, items whose size is smaller or equal to 4 bytes (size of (Split)Index32 column element) are stored densely.
+/// By default, items whose size is smaller or equal to 4 bytes (size of (Split)Index32 column element) are stored
+/// densely.
 class RNullableField : public Detail::RFieldBase {
    /// For a dense nullable field, used to write a default-constructed item for missing ones.
    Detail::RFieldValue fDefaultItemValue;
@@ -828,8 +829,7 @@ protected:
    /// if it is null, returns kInvalidClusterIndex
    RClusterIndex GetItemIndex(NTupleSize_t globalIndex);
 
-   RNullableField(std::string_view fieldName, std::string_view typeName,
-                  std::unique_ptr<Detail::RFieldBase> itemField);
+   RNullableField(std::string_view fieldName, std::string_view typeName, std::unique_ptr<Detail::RFieldBase> itemField);
 
 public:
    RNullableField(RNullableField &&other) = default;

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -886,7 +886,15 @@ public:
    {
       return Detail::RFieldValue(this, static_cast<T *>(where), std::forward<ArgsT>(args)...);
    }
-   ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where) final { return GenerateValue(where, T()); }
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where) final
+   {
+      if constexpr (std::is_default_constructible_v<T>) {
+         return GenerateValue(where, T());
+      } else {
+         // If there is no default constructor, try with the IO constructor
+         return GenerateValue(where, T(static_cast<TRootIOCtor *>(nullptr)));
+      }
+   }
 };
 
 template <typename T, typename = void>

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -836,7 +836,7 @@ public:
    RNullableField &operator=(RNullableField &&other) = default;
    ~RNullableField() override;
 
-   bool IsDense() const { return GetColumnRepresentative() == ColumnRepresentation_t({EColumnType::kBit}); }
+   bool IsDense() const { return GetColumnRepresentative()[0] ==  EColumnType::kBit; }
    bool IsSparse() const { return !IsDense(); }
    void SetDense() { SetColumnRepresentative({EColumnType::kBit}); }
    void SetSparse() { SetColumnRepresentative({EColumnType::kSplitIndex32}); }

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -853,10 +853,11 @@ protected:
    void ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue *value) final;
 
 public:
-   RUniquePtrField(std::string_view fieldName, std::unique_ptr<Detail::RFieldBase> &&itemField);
+   RUniquePtrField(std::string_view fieldName, std::string_view typeName,
+                   std::unique_ptr<Detail::RFieldBase> itemField);
    RUniquePtrField(RUniquePtrField &&other) = default;
    RUniquePtrField &operator=(RUniquePtrField &&other) = default;
-   ~RUniquePtrField() = default;
+   ~RUniquePtrField() override = default;
 
    using Detail::RFieldBase::GenerateValue;
    Detail::RFieldValue GenerateValue(void *where) override;
@@ -2252,7 +2253,7 @@ template <typename ItemT>
 class RField<std::unique_ptr<ItemT>> : public RUniquePtrField {
 public:
    static std::string TypeName() { return "std::unique_ptr<" + RField<ItemT>::TypeName() + ">"; }
-   explicit RField(std::string_view name) : RUniquePtrField(name, std::make_unique<RField<ItemT>>("_0")) {}
+   explicit RField(std::string_view name) : RUniquePtrField(name, TypeName(), std::make_unique<RField<ItemT>>("_0")) {}
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
    ~RField() override = default;

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -862,6 +862,7 @@ public:
    Detail::RFieldValue GenerateValue(void *where) override;
    void DestroyValue(const Detail::RFieldValue &value, bool dtorOnly = false) final;
    Detail::RFieldValue CaptureValue(void *where) final;
+   std::vector<Detail::RFieldValue> SplitValue(const Detail::RFieldValue &value) const final;
    size_t GetValueSize() const final { return sizeof(std::unique_ptr<char>); }
    size_t GetAlignment() const final { return alignof(std::unique_ptr<char>); }
 };

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -829,7 +829,7 @@ protected:
    RClusterIndex GetItemIndex(NTupleSize_t globalIndex);
 
    RNullableField(std::string_view fieldName, std::string_view typeName,
-                  std::unique_ptr<Detail::RFieldBase> &&itemField);
+                  std::unique_ptr<Detail::RFieldBase> itemField);
 
 public:
    RNullableField(RNullableField &&other) = default;

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -219,6 +219,7 @@ public:
    void VisitVectorBoolField(const RField<std::vector<bool>> &field) final;
    void VisitRVecField(const RRVecField &field) final;
    void VisitBitsetField(const RBitsetField &field) final;
+   void VisitNullableField(const RNullableField &field) final;
 };
 
 

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -60,6 +60,7 @@ public:
    virtual void VisitInt16Field(const RField<std::int16_t> &field) { VisitField(field); }
    virtual void VisitIntField(const RField<int> &field) { VisitField(field); }
    virtual void VisitInt64Field(const RField<std::int64_t> &field) { VisitField(field); }
+   virtual void VisitNullableField(const RNullableField &field) { VisitField(field); }
    virtual void VisitStringField(const RField<std::string> &field) { VisitField(field); }
    virtual void VisitUInt16Field(const RField<std::uint16_t> &field) { VisitField(field); }
    virtual void VisitUInt32Field(const RField<std::uint32_t> &field) { VisitField(field); }

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -2507,6 +2507,18 @@ ROOT::Experimental::Detail::RFieldValue ROOT::Experimental::RUniquePtrField::Cap
    return Detail::RFieldValue(true /* captureFlag */, this, where);
 }
 
+std::vector<ROOT::Experimental::Detail::RFieldValue>
+ROOT::Experimental::RUniquePtrField::SplitValue(const Detail::RFieldValue &value) const
+{
+   std::vector<Detail::RFieldValue> result;
+   auto ptr = value.Get<std::unique_ptr<char>>();
+   if (*ptr) {
+      auto itemValue = fSubFields[0]->CaptureValue(ptr->get());
+      result.emplace_back(itemValue);
+   }
+   return result;
+}
+
 //------------------------------------------------------------------------------
 
 std::string ROOT::Experimental::RPairField::RPairField::GetTypeList(

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -2471,13 +2471,15 @@ void ROOT::Experimental::RUniquePtrField::ReadGlobalImpl(NTupleSize_t globalInde
       return;
    }
 
-   if (!isValidValue && isValidItem) {
+   if (!isValidItem) // On-disk value missing; nothing else to do
+      return;
+
+   if (!isValidValue) {
       itemValue = fSubFields[0]->GenerateValue();
       ptr->reset(itemValue.Get<char>());
    }
 
-   if (isValidItem)
-      fSubFields[0]->Read(itemIndex, &itemValue);
+   fSubFields[0]->Read(itemIndex, &itemValue);
 }
 
 ROOT::Experimental::Detail::RFieldValue ROOT::Experimental::RUniquePtrField::GenerateValue(void *where)

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -2329,7 +2329,7 @@ void ROOT::Experimental::RVariantField::CommitCluster()
 //------------------------------------------------------------------------------
 
 ROOT::Experimental::RNullableField::RNullableField(std::string_view fieldName, std::string_view typeName,
-                                                   std::unique_ptr<Detail::RFieldBase> &&itemField)
+                                                   std::unique_ptr<Detail::RFieldBase> itemField)
    : ROOT::Experimental::Detail::RFieldBase(fieldName, typeName, ENTupleStructure::kCollection, false /* isSimple */)
 {
    Attach(std::move(itemField));

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -2321,6 +2321,45 @@ void ROOT::Experimental::RVariantField::CommitCluster()
 
 //------------------------------------------------------------------------------
 
+ROOT::Experimental::RNullableField::RNullableField(std::string_view fieldName, std::string_view typeName,
+                                                   std::unique_ptr<Detail::RFieldBase> &&itemField)
+   : ROOT::Experimental::Detail::RFieldBase(fieldName, typeName, ENTupleStructure::kVariant, false /* isSimple */)
+{
+   Attach(std::move(itemField));
+}
+
+const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
+ROOT::Experimental::RNullableField::GetColumnRepresentations() const
+{
+   static RColumnRepresentations representations({{EColumnType::kBit}, {EColumnType::kSwitch}}, {});
+   return representations;
+}
+
+void ROOT::Experimental::RNullableField::GenerateColumnsImpl() {}
+
+void ROOT::Experimental::RNullableField::GenerateColumnsImpl(const RNTupleDescriptor &) {}
+
+std::size_t ROOT::Experimental::RNullableField::AppendNull()
+{
+   return 0;
+}
+
+std::size_t ROOT::Experimental::RNullableField::AppendValue(const Detail::RFieldValue &value)
+{
+   return 0;
+}
+
+bool ROOT::Experimental::RNullableField::IsNull(NTupleSize_t globalIndex) {}
+
+void ROOT::Experimental::RNullableField::ReadValue(NTupleSize_t globalIndex, Detail::RFieldValue *value) {}
+
+void ROOT::Experimental::RNullableField::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+{
+   visitor.VisitNullableField(*this);
+}
+
+//------------------------------------------------------------------------------
+
 std::string ROOT::Experimental::RPairField::RPairField::GetTypeList(
    const std::array<std::unique_ptr<Detail::RFieldBase>, 2> &itemFields)
 {

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -2429,8 +2429,7 @@ void ROOT::Experimental::RNullableField::AcceptVisitor(Detail::RFieldVisitor &vi
 
 //------------------------------------------------------------------------------
 
-ROOT::Experimental::RUniquePtrField::RUniquePtrField(std::string_view fieldName,
-                                                     std::string_view typeName,
+ROOT::Experimental::RUniquePtrField::RUniquePtrField(std::string_view fieldName, std::string_view typeName,
                                                      std::unique_ptr<Detail::RFieldBase> itemField)
    : RNullableField(fieldName, typeName, std::move(itemField))
 {

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -2370,11 +2370,10 @@ void ROOT::Experimental::RNullableField::GenerateColumnsImpl()
 void ROOT::Experimental::RNullableField::GenerateColumnsImpl(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
-   switch (onDiskTypes[0]) {
-   case EColumnType::kBit:
+   if (onDiskTypes[0] == EColumnType::kBit) {
       fColumns.emplace_back(Detail::RColumn::Create<bool>(RColumnModel(EColumnType::kBit), 0));
-      break;
-   default: fColumns.emplace_back(Detail::RColumn::Create<ClusterSize_t>(RColumnModel(onDiskTypes[0]), 0)); break;
+   } else {
+      fColumns.emplace_back(Detail::RColumn::Create<ClusterSize_t>(RColumnModel(onDiskTypes[0]), 0));
    }
 }
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -2357,14 +2357,11 @@ void ROOT::Experimental::RNullableField::GenerateColumnsImpl()
          SetColumnRepresentative({EColumnType::kBit});
       }
    }
-   switch (GetColumnRepresentative()[0]) {
-   case EColumnType::kBit:
+   if (IsDense()) {
       fDefaultItemValue = fSubFields[0]->GenerateValue();
       fColumns.emplace_back(Detail::RColumn::Create<bool>(RColumnModel(EColumnType::kBit), 0));
-      break;
-   default:
+   } else {
       fColumns.emplace_back(Detail::RColumn::Create<ClusterSize_t>(RColumnModel(GetColumnRepresentative()[0]), 0));
-      break;
    }
 }
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -2348,7 +2348,8 @@ const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RNullableField::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations(
-      {{EColumnType::kSplitIndex32}, {EColumnType::kIndex32}, {EColumnType::kBit}}, {});
+      {{EColumnType::kSplitIndex64}, {EColumnType::kIndex64}, {EColumnType::kSplitIndex32}, {EColumnType::kIndex32},
+       {EColumnType::kBit}}, {});
    return representations;
 }
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -2454,7 +2454,7 @@ std::size_t ROOT::Experimental::RUniquePtrField::AppendImpl(const Detail::RField
 void ROOT::Experimental::RUniquePtrField::ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue *value)
 {
    auto ptr = value->Get<std::unique_ptr<char>>();
-   bool isValidValue = !!(*ptr);
+   bool isValidValue = static_cast<bool>(*ptr);
 
    auto itemIndex = GetItemIndex(globalIndex);
    bool isValidItem = itemIndex.GetIndex() != kInvalidClusterIndex;

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -345,6 +345,22 @@ void ROOT::Experimental::RPrintValueVisitor::VisitRecordField(const RRecordField
    fOutput << "}";
 }
 
+void ROOT::Experimental::RPrintValueVisitor::VisitNullableField(const RNullableField &field)
+{
+   PrintIndent();
+   PrintName(field);
+   auto elems = field.SplitValue(fValue);
+   if (elems.empty()) {
+      fOutput << "null";
+   } else {
+      RPrintOptions options;
+      options.fPrintSingleLine = true;
+      options.fPrintName = false;
+      RPrintValueVisitor visitor(elems[0], fOutput, fLevel, options);
+      elems[0].GetField()->AcceptVisitor(visitor);
+   }
+}
+
 void ROOT::Experimental::RPrintValueVisitor::VisitCollectionClassField(const RCollectionClassField &field)
 {
    PrintCollection(field);

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -1,6 +1,8 @@
 #ifndef ROOT7_RNTuple_Test_CustomStruct
 #define ROOT7_RNTuple_Test_CustomStruct
 
+#include <TRootIOCtor.h>
+
 #include <cstdint>
 #include <string>
 #include <variant>
@@ -52,6 +54,14 @@ class EdmWrapper {
 public:
    bool fIsPresent = true;
    T fMember;
+};
+
+class IOConstructor {
+private:
+   IOConstructor();
+public:
+   int a = 7;
+   IOConstructor(TRootIOCtor *) {};
 };
 
 /// The classes below are based on an excerpt provided by Marcin Nowak (EP-UAT)

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -57,11 +57,11 @@ public:
 };
 
 class IOConstructor {
-private:
-   IOConstructor();
 public:
-   int a = 7;
+   IOConstructor() = delete;
    IOConstructor(TRootIOCtor *) {};
+
+   int a = 7;
 };
 
 /// The classes below are based on an excerpt provided by Marcin Nowak (EP-UAT)

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -11,6 +11,7 @@
 #pragma link C++ class DerivedC+;
 #pragma link C++ class StructWithArrays + ;
 #pragma link C++ class TestEBO+;
+#pragma link C++ class IOConstructor+;
 
 #pragma link C++ class EdmWrapper<CustomStruct> +;
 

--- a/tree/ntuple/v7/test/ntuple_show.cxx
+++ b/tree/ntuple/v7/test/ntuple_show.cxx
@@ -42,6 +42,7 @@ TEST(RNTupleShow, BasicTypes)
       auto fieldbool = model->MakeField<bool>("boolean");
       auto fieldchar = model->MakeField<uint8_t>("uint8");
       auto fieldbitset = model->MakeField<std::bitset<65>>("bitset");
+      auto fielduniqueptr = model->MakeField<std::unique_ptr<std::string>>("pstring");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, rootFileName);
 
       *fieldPt = 5.0f;
@@ -53,6 +54,7 @@ TEST(RNTupleShow, BasicTypes)
       *fieldbool = true;
       *fieldchar = 97;
       *fieldbitset = std::bitset<65>("10000000000000000000000000000010000000000000000000000000000010010");
+      *fielduniqueptr = std::make_unique<std::string>("abc");
       ntuple->Fill();
 
       *fieldPt = 8.5f;
@@ -64,6 +66,7 @@ TEST(RNTupleShow, BasicTypes)
       *fieldbool = false;
       *fieldchar = 98;
       fieldbitset->flip();
+      fielduniqueptr->reset();
       ntuple->Fill();
    }
 
@@ -82,7 +85,8 @@ TEST(RNTupleShow, BasicTypes)
       + "  \"string\": \"TestString\",\n"
       + "  \"boolean\": true,\n"
       + "  \"uint8\": 97,\n"
-      + "  \"bitset\": \"10000000000000000000000000000010000000000000000000000000000010010\"\n"
+      + "  \"bitset\": \"10000000000000000000000000000010000000000000000000000000000010010\",\n"
+      + "  \"pstring\": \"abc\"\n"
       + "}\n" };
    // clang-format on
    EXPECT_EQ(fString, os.str());
@@ -100,7 +104,8 @@ TEST(RNTupleShow, BasicTypes)
       + "  \"string\": \"TestString2\",\n"
       + "  \"boolean\": false,\n"
       + "  \"uint8\": 98,\n"
-      + "  \"bitset\": \"01111111111111111111111111111101111111111111111111111111111101101\"\n"
+      + "  \"bitset\": \"01111111111111111111111111111101111111111111111111111111111101101\",\n"
+      + "  \"pstring\": null\n"
       + "}\n" };
    // clang-format on
    EXPECT_EQ(fString1, os1.str());

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -837,6 +837,24 @@ TEST(RNTuple, TClassEBO)
    }
 }
 
+TEST(RNTuple, IOConstructor)
+{
+   FileRaii fileGuard("test_ntuple_ioconstructor.ntuple");
+
+   auto model = RNTupleModel::Create();
+   auto fldObj = RFieldBase::Create("obj", "IOConstructor").Unwrap();
+   model->AddField(std::move(fldObj));
+   {
+      auto writer = RNTupleWriter::Recreate(std::move(model), "f", fileGuard.GetPath());
+      writer->Fill();
+   }
+
+   auto ntuple = RNTupleReader::Open("f", fileGuard.GetPath());
+   EXPECT_EQ(1U, ntuple->GetNEntries());
+   auto obj = ntuple->GetModel()->GetDefaultEntry()->Get<IOConstructor>("obj");
+   EXPECT_EQ(7, obj->a);
+}
+
 TEST(RNTuple, TClassTemplateBased)
 {
    FileRaii fileGuard("test_ntuple_tclass_templatebased.ntuple");


### PR DESCRIPTION
Adds a nullable field as a base class for unique pointer support. A follow-up PR will add `std::optional` support using the same base class. The nullable field is usually stored like a collection that can have zero or one element per entry. Optionally, nullable fields can be stored in "dense mode", with a bitmap mask and default-constructed values for the null entries.