### PR TITLE
[ntuple] Add support for (Split)Index64 column types

### DIFF
--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -74,7 +74,7 @@ public:
    const RColumnRepresentations &GetColumnRepresentations() const final
    {
       static RColumnRepresentations representations(
-         {{EColumnType::kSplitIndex32}, {EColumnType::kIndex32}, {EColumnType::kSplitIndex64}, {EColumnType::kIndex64}},
+         {{EColumnType::kSplitIndex64}, {EColumnType::kIndex64}, {EColumnType::kSplitIndex32}, {EColumnType::kIndex32}},
          {});
       return representations;
    }

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -73,7 +73,9 @@ public:
 
    const RColumnRepresentations &GetColumnRepresentations() const final
    {
-      static RColumnRepresentations representations({{EColumnType::kSplitIndex32}, {EColumnType::kIndex32}}, {{}});
+      static RColumnRepresentations representations(
+         {{EColumnType::kSplitIndex32}, {EColumnType::kIndex32}, {EColumnType::kSplitIndex64}, {EColumnType::kIndex64}},
+         {});
       return representations;
    }
    // Field is only used for reading

--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -745,11 +745,32 @@ public:
 };
 
 template <>
+class RColumnElement<ClusterSize_t, EColumnType::kIndex64> : public RColumnElementLE<std::uint64_t> {
+public:
+   static constexpr std::size_t kSize = sizeof(ClusterSize_t);
+   static constexpr std::size_t kBitsOnStorage = 64;
+   explicit RColumnElement(ClusterSize_t *value) : RColumnElementLE(value, kSize) {}
+   bool IsMappable() const final { return kIsMappable; }
+   std::size_t GetBitsOnStorage() const final { return kBitsOnStorage; }
+};
+
+template <>
 class RColumnElement<ClusterSize_t, EColumnType::kIndex32> : public RColumnElementCastLE<std::uint64_t, std::uint32_t> {
 public:
    static constexpr std::size_t kSize = sizeof(ClusterSize_t);
    static constexpr std::size_t kBitsOnStorage = 32;
    explicit RColumnElement(ClusterSize_t *value) : RColumnElementCastLE(value, kSize) {}
+   bool IsMappable() const final { return kIsMappable; }
+   std::size_t GetBitsOnStorage() const final { return kBitsOnStorage; }
+};
+
+template <>
+class RColumnElement<ClusterSize_t, EColumnType::kSplitIndex64>
+   : public RColumnElementDeltaSplitLE<std::uint64_t, std::uint64_t> {
+public:
+   static constexpr std::size_t kSize = sizeof(ClusterSize_t);
+   static constexpr std::size_t kBitsOnStorage = 64;
+   explicit RColumnElement(ClusterSize_t *value) : RColumnElementDeltaSplitLE(value, kSize) {}
    bool IsMappable() const final { return kIsMappable; }
    std::size_t GetBitsOnStorage() const final { return kBitsOnStorage; }
 };
@@ -808,6 +829,7 @@ template <typename CppT>
 std::unique_ptr<RColumnElementBase> RColumnElementBase::Generate(EColumnType type)
 {
    switch (type) {
+   case EColumnType::kIndex64: return std::make_unique<RColumnElement<CppT, EColumnType::kIndex64>>(nullptr);
    case EColumnType::kIndex32: return std::make_unique<RColumnElement<CppT, EColumnType::kIndex32>>(nullptr);
    case EColumnType::kSwitch: return std::make_unique<RColumnElement<CppT, EColumnType::kSwitch>>(nullptr);
    case EColumnType::kByte: return std::make_unique<RColumnElement<CppT, EColumnType::kByte>>(nullptr);
@@ -819,6 +841,7 @@ std::unique_ptr<RColumnElementBase> RColumnElementBase::Generate(EColumnType typ
    case EColumnType::kInt32: return std::make_unique<RColumnElement<CppT, EColumnType::kInt32>>(nullptr);
    case EColumnType::kInt16: return std::make_unique<RColumnElement<CppT, EColumnType::kInt16>>(nullptr);
    case EColumnType::kInt8: return std::make_unique<RColumnElement<CppT, EColumnType::kInt8>>(nullptr);
+   case EColumnType::kSplitIndex64: return std::make_unique<RColumnElement<CppT, EColumnType::kSplitIndex64>>(nullptr);
    case EColumnType::kSplitIndex32: return std::make_unique<RColumnElement<CppT, EColumnType::kSplitIndex32>>(nullptr);
    case EColumnType::kSplitReal64: return std::make_unique<RColumnElement<CppT, EColumnType::kSplitReal64>>(nullptr);
    case EColumnType::kSplitReal32: return std::make_unique<RColumnElement<CppT, EColumnType::kSplitReal32>>(nullptr);

--- a/tree/ntuple/v7/inc/ROOT/RColumnModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnModel.hxx
@@ -42,7 +42,8 @@ When changed, remember to update
 // clang-format on
 enum class EColumnType {
    kUnknown = 0,
-   // type for root columns of (nested) collections; 32bit integers that count relative to the current cluster
+   // type for root columns of (nested) collections; offsets are relative to the current cluster
+   kIndex64,
    kIndex32,
    // 64 bit column that uses the lower 44 bits like kIndex64, higher 20 bits are a dispatch tag to a column ID;
    // used to serialize std::variant.
@@ -57,6 +58,7 @@ enum class EColumnType {
    kInt32,
    kInt16,
    kInt8,
+   kSplitIndex64,
    kSplitIndex32,
    kSplitReal64,
    kSplitReal32,

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -200,6 +200,11 @@ protected:
    /// Called by `ConnectPageSource()` only once connected; derived classes may override this
    /// as appropriate
    virtual void OnConnectPageSource() {}
+   /// When connecting a field to a page source, the field's default column representation is subject
+   /// to adjustment according to the write options. E.g., if compression is turned off, encoded columns
+   /// are changed to their unencoded counterparts.
+   void AutoAdjustColumnTypes(const RNTupleWriteOptions &options);
+
 
 public:
    /// Iterates over the sub tree of fields in depth-first search order

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -200,7 +200,7 @@ protected:
    /// Called by `ConnectPageSource()` only once connected; derived classes may override this
    /// as appropriate
    virtual void OnConnectPageSource() {}
-   /// When connecting a field to a page source, the field's default column representation is subject
+   /// When connecting a field to a page sink, the field's default column representation is subject
    /// to adjustment according to the write options. E.g., if compression is turned off, encoded columns
    /// are changed to their unencoded counterparts.
    void AutoAdjustColumnTypes(const RNTupleWriteOptions &options);

--- a/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
@@ -61,6 +61,9 @@ protected:
    /// fApproxUnzippedPageSize/2 and fApproxUnzippedPageSize * 1.5 in size.
    std::size_t fApproxUnzippedPageSize = 64 * 1024;
    bool fUseBufferedWrite = true;
+   /// If set, 64bit index columns are replaced by 32bit index columns. This limits the cluster size to 512MB
+   /// but it can result in smaller file sizes for data sets with many collections and lz4 or no compression.
+   bool fHasSmallClusters = false;
 
 public:
    virtual ~RNTupleWriteOptions() = default;
@@ -86,6 +89,9 @@ public:
 
    bool GetUseBufferedWrite() const { return fUseBufferedWrite; }
    void SetUseBufferedWrite(bool val) { fUseBufferedWrite = val; }
+
+   bool GetHasSmallClusters() const { return fHasSmallClusters; }
+   void SetHasSmallClusters(bool val) { fHasSmallClusters = val; }
 };
 
 // clang-format off

--- a/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
@@ -66,6 +66,11 @@ protected:
    bool fHasSmallClusters = false;
 
 public:
+   /// A maximum size of 512MB still allows for a vector of bool to be stored in a small cluster.  This is the
+   /// worst case wrt. the maximum required size of the index column.  A 32bit index column can address 512MB
+   /// of 1-bit (on disk size) bools.
+   static constexpr std::uint64_t kMaxSmallClusterSize = 512 * 1024 * 1024;
+
    virtual ~RNTupleWriteOptions() = default;
    virtual std::unique_ptr<RNTupleWriteOptions> Clone() const;
 

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -28,6 +28,7 @@ std::unique_ptr<ROOT::Experimental::Detail::RColumnElementBase>
 ROOT::Experimental::Detail::RColumnElementBase::Generate<void>(EColumnType type)
 {
    switch (type) {
+   case EColumnType::kIndex64: return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kIndex64>>(nullptr);
    case EColumnType::kIndex32: return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kIndex32>>(nullptr);
    case EColumnType::kSwitch: return std::make_unique<RColumnElement<RColumnSwitch, EColumnType::kSwitch>>(nullptr);
    case EColumnType::kByte: return std::make_unique<RColumnElement<std::uint8_t, EColumnType::kByte>>(nullptr);
@@ -39,6 +40,8 @@ ROOT::Experimental::Detail::RColumnElementBase::Generate<void>(EColumnType type)
    case EColumnType::kInt32: return std::make_unique<RColumnElement<std::int32_t, EColumnType::kInt32>>(nullptr);
    case EColumnType::kInt16: return std::make_unique<RColumnElement<std::int16_t, EColumnType::kInt16>>(nullptr);
    case EColumnType::kInt8: return std::make_unique<RColumnElement<std::int8_t, EColumnType::kInt8>>(nullptr);
+   case EColumnType::kSplitIndex64:
+      return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kSplitIndex64>>(nullptr);
    case EColumnType::kSplitIndex32:
       return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kSplitIndex32>>(nullptr);
    case EColumnType::kSplitReal64: return std::make_unique<RColumnElement<double, EColumnType::kSplitReal64>>(nullptr);
@@ -57,6 +60,7 @@ ROOT::Experimental::Detail::RColumnElementBase::Generate<void>(EColumnType type)
 
 std::size_t ROOT::Experimental::Detail::RColumnElementBase::GetBitsOnStorage(EColumnType type) {
    switch (type) {
+   case EColumnType::kIndex64: return 64;
    case EColumnType::kIndex32: return 32;
    case EColumnType::kSwitch: return 64;
    case EColumnType::kByte: return 8;
@@ -68,6 +72,7 @@ std::size_t ROOT::Experimental::Detail::RColumnElementBase::GetBitsOnStorage(ECo
    case EColumnType::kInt32: return 32;
    case EColumnType::kInt16: return 16;
    case EColumnType::kInt8: return 8;
+   case EColumnType::kSplitIndex64: return 64;
    case EColumnType::kSplitIndex32: return 32;
    case EColumnType::kSplitReal64: return 64;
    case EColumnType::kSplitReal32: return 32;
@@ -82,6 +87,7 @@ std::size_t ROOT::Experimental::Detail::RColumnElementBase::GetBitsOnStorage(ECo
 
 std::string ROOT::Experimental::Detail::RColumnElementBase::GetTypeName(EColumnType type) {
    switch (type) {
+   case EColumnType::kIndex64: return "Index64";
    case EColumnType::kIndex32: return "Index32";
    case EColumnType::kSwitch: return "Switch";
    case EColumnType::kByte: return "Byte";
@@ -93,6 +99,7 @@ std::string ROOT::Experimental::Detail::RColumnElementBase::GetTypeName(EColumnT
    case EColumnType::kInt32: return "Int32";
    case EColumnType::kInt16: return "Int16";
    case EColumnType::kInt8: return "Int8";
+   case EColumnType::kSplitIndex64: return "SplitIndex64";
    case EColumnType::kSplitIndex32: return "SplitIndex32";
    case EColumnType::kSplitReal64: return "SplitReal64";
    case EColumnType::kSplitReal32: return "SplitReal32";

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -484,12 +484,9 @@ void ROOT::Experimental::Detail::RFieldBase::RemoveReadCallback(size_t idx)
    fIsSimple = (fTraits & kTraitMappable) && fReadCallbacks.empty();
 }
 
-void ROOT::Experimental::Detail::RFieldBase::ConnectPageSink(RPageSink &pageSink)
+void ROOT::Experimental::Detail::RFieldBase::AutoAdjustColumnTypes(const RNTupleWriteOptions &options)
 {
-   R__ASSERT(fColumns.empty());
-
-   /// Fix-up default encoding: if the ntuple is uncompressed, the default encoding should be non-split
-   if ((pageSink.GetWriteOptions().GetCompression() == 0) && HasDefaultColumnRepresentative()) {
+   if ((options.GetCompression() == 0) && HasDefaultColumnRepresentative()) {
       ColumnRepresentation_t rep = GetColumnRepresentative();
       for (auto &colType : rep) {
          switch (colType) {
@@ -505,7 +502,8 @@ void ROOT::Experimental::Detail::RFieldBase::ConnectPageSink(RPageSink &pageSink
       }
       SetColumnRepresentative(rep);
    }
-   if (pageSink.GetWriteOptions().GetHasSmallClusters()) {
+
+   if (options.GetHasSmallClusters()) {
       ColumnRepresentation_t rep = GetColumnRepresentative();
       for (auto &colType : rep) {
          switch (colType) {
@@ -516,6 +514,13 @@ void ROOT::Experimental::Detail::RFieldBase::ConnectPageSink(RPageSink &pageSink
       }
       SetColumnRepresentative(rep);
    }
+}
+
+void ROOT::Experimental::Detail::RFieldBase::ConnectPageSink(RPageSink &pageSink)
+{
+   R__ASSERT(fColumns.empty());
+
+   AutoAdjustColumnTypes(pageSink.GetWriteOptions());
 
    GenerateColumnsImpl();
    if (!fColumns.empty())

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -493,6 +493,7 @@ void ROOT::Experimental::Detail::RFieldBase::ConnectPageSink(RPageSink &pageSink
       ColumnRepresentation_t rep = GetColumnRepresentative();
       for (auto &colType : rep) {
          switch (colType) {
+         case EColumnType::kSplitIndex64: colType = EColumnType::kIndex64; break;
          case EColumnType::kSplitIndex32: colType = EColumnType::kIndex32; break;
          case EColumnType::kSplitReal64: colType = EColumnType::kReal64; break;
          case EColumnType::kSplitReal32: colType = EColumnType::kReal32; break;
@@ -612,7 +613,9 @@ void ROOT::Experimental::RFieldZero::AcceptVisitor(Detail::RFieldVisitor &visito
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kSplitIndex32}, {EColumnType::kIndex32}}, {{}});
+   static RColumnRepresentations representations(
+      {{EColumnType::kSplitIndex32}, {EColumnType::kIndex32}, {EColumnType::kSplitIndex64}, {EColumnType::kIndex64}},
+      {});
    return representations;
 }
 
@@ -637,7 +640,9 @@ void ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::AcceptVisito
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<ROOT::Experimental::RNTupleCardinality>::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kSplitIndex32}, {EColumnType::kIndex32}}, {{}});
+   static RColumnRepresentations representations(
+      {{EColumnType::kSplitIndex32}, {EColumnType::kIndex32}, {EColumnType::kSplitIndex64}, {EColumnType::kIndex64}},
+      {});
    return representations;
 }
 
@@ -961,8 +966,11 @@ void ROOT::Experimental::RField<std::int64_t>::AcceptVisitor(Detail::RFieldVisit
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<std::string>::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations(
-      {{EColumnType::kSplitIndex32, EColumnType::kChar}, {EColumnType::kIndex32, EColumnType::kChar}}, {{}});
+   static RColumnRepresentations representations({{EColumnType::kSplitIndex32, EColumnType::kChar},
+                                                  {EColumnType::kIndex32, EColumnType::kChar},
+                                                  {EColumnType::kSplitIndex64, EColumnType::kChar},
+                                                  {EColumnType::kIndex64, EColumnType::kChar}},
+                                                 {});
    return representations;
 }
 
@@ -1326,7 +1334,9 @@ void ROOT::Experimental::RCollectionClassField::ReadGlobalImpl(NTupleSize_t glob
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RCollectionClassField::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kSplitIndex32}, {EColumnType::kIndex32}}, {{}});
+   static RColumnRepresentations representations(
+      {{EColumnType::kSplitIndex32}, {EColumnType::kIndex32}, {EColumnType::kSplitIndex64}, {EColumnType::kIndex64}},
+      {});
    return representations;
 }
 
@@ -1585,7 +1595,9 @@ void ROOT::Experimental::RVectorField::ReadGlobalImpl(NTupleSize_t globalIndex, 
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RVectorField::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kSplitIndex32}, {EColumnType::kIndex32}}, {{}});
+   static RColumnRepresentations representations(
+      {{EColumnType::kSplitIndex32}, {EColumnType::kIndex32}, {EColumnType::kSplitIndex64}, {EColumnType::kIndex64}},
+      {});
    return representations;
 }
 
@@ -1756,7 +1768,9 @@ void ROOT::Experimental::RRVecField::ReadGlobalImpl(NTupleSize_t globalIndex, De
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RRVecField::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kSplitIndex32}, {EColumnType::kIndex32}}, {{}});
+   static RColumnRepresentations representations(
+      {{EColumnType::kSplitIndex32}, {EColumnType::kIndex32}, {EColumnType::kSplitIndex64}, {EColumnType::kIndex64}},
+      {});
    return representations;
 }
 
@@ -1943,7 +1957,9 @@ void ROOT::Experimental::RField<std::vector<bool>>::ReadGlobalImpl(NTupleSize_t 
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<std::vector<bool>>::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kSplitIndex32}, {EColumnType::kIndex32}}, {{}});
+   static RColumnRepresentations representations(
+      {{EColumnType::kSplitIndex32}, {EColumnType::kIndex32}, {EColumnType::kSplitIndex64}, {EColumnType::kIndex64}},
+      {});
    return representations;
 }
 
@@ -2430,7 +2446,9 @@ ROOT::Experimental::RCollectionField::RCollectionField(
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RCollectionField::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kSplitIndex32}, {EColumnType::kIndex32}}, {{}});
+   static RColumnRepresentations representations(
+      {{EColumnType::kSplitIndex32}, {EColumnType::kIndex32}, {EColumnType::kSplitIndex64}, {EColumnType::kIndex64}},
+      {});
    return representations;
 }
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -625,7 +625,7 @@ const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<ROOT::Experimental::ClusterSize_t>::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations(
-      {{EColumnType::kSplitIndex32}, {EColumnType::kIndex32}, {EColumnType::kSplitIndex64}, {EColumnType::kIndex64}},
+      {{EColumnType::kSplitIndex64}, {EColumnType::kIndex64}, {EColumnType::kSplitIndex32}, {EColumnType::kIndex32}},
       {});
    return representations;
 }
@@ -977,10 +977,10 @@ void ROOT::Experimental::RField<std::int64_t>::AcceptVisitor(Detail::RFieldVisit
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<std::string>::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kSplitIndex32, EColumnType::kChar},
-                                                  {EColumnType::kIndex32, EColumnType::kChar},
-                                                  {EColumnType::kSplitIndex64, EColumnType::kChar},
-                                                  {EColumnType::kIndex64, EColumnType::kChar}},
+   static RColumnRepresentations representations({{EColumnType::kSplitIndex64, EColumnType::kChar},
+                                                  {EColumnType::kIndex64, EColumnType::kChar},
+                                                  {EColumnType::kSplitIndex32, EColumnType::kChar},
+                                                  {EColumnType::kIndex32, EColumnType::kChar}},
                                                  {});
    return representations;
 }
@@ -1346,7 +1346,7 @@ const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RCollectionClassField::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations(
-      {{EColumnType::kSplitIndex32}, {EColumnType::kIndex32}, {EColumnType::kSplitIndex64}, {EColumnType::kIndex64}},
+      {{EColumnType::kSplitIndex64}, {EColumnType::kIndex64}, {EColumnType::kSplitIndex32}, {EColumnType::kIndex32}},
       {});
    return representations;
 }
@@ -1607,7 +1607,7 @@ const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RVectorField::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations(
-      {{EColumnType::kSplitIndex32}, {EColumnType::kIndex32}, {EColumnType::kSplitIndex64}, {EColumnType::kIndex64}},
+      {{EColumnType::kSplitIndex64}, {EColumnType::kIndex64}, {EColumnType::kSplitIndex32}, {EColumnType::kIndex32}},
       {});
    return representations;
 }
@@ -1780,7 +1780,7 @@ const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RRVecField::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations(
-      {{EColumnType::kSplitIndex32}, {EColumnType::kIndex32}, {EColumnType::kSplitIndex64}, {EColumnType::kIndex64}},
+      {{EColumnType::kSplitIndex64}, {EColumnType::kIndex64}, {EColumnType::kSplitIndex32}, {EColumnType::kIndex32}},
       {});
    return representations;
 }
@@ -1969,7 +1969,7 @@ const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<std::vector<bool>>::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations(
-      {{EColumnType::kSplitIndex32}, {EColumnType::kIndex32}, {EColumnType::kSplitIndex64}, {EColumnType::kIndex64}},
+      {{EColumnType::kSplitIndex64}, {EColumnType::kIndex64}, {EColumnType::kSplitIndex32}, {EColumnType::kIndex32}},
       {});
    return representations;
 }
@@ -2458,7 +2458,7 @@ const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RCollectionField::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations(
-      {{EColumnType::kSplitIndex32}, {EColumnType::kIndex32}, {EColumnType::kSplitIndex64}, {EColumnType::kIndex64}},
+      {{EColumnType::kSplitIndex64}, {EColumnType::kIndex64}, {EColumnType::kSplitIndex32}, {EColumnType::kIndex32}},
       {});
    return representations;
 }

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -505,6 +505,17 @@ void ROOT::Experimental::Detail::RFieldBase::ConnectPageSink(RPageSink &pageSink
       }
       SetColumnRepresentative(rep);
    }
+   if (pageSink.GetWriteOptions().GetHasSmallClusters()) {
+      ColumnRepresentation_t rep = GetColumnRepresentative();
+      for (auto &colType : rep) {
+         switch (colType) {
+         case EColumnType::kSplitIndex64: colType = EColumnType::kSplitIndex32; break;
+         case EColumnType::kIndex64: colType = EColumnType::kIndex32; break;
+         default: break;
+         }
+      }
+      SetColumnRepresentative(rep);
+   }
 
    GenerateColumnsImpl();
    if (!fColumns.empty())

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -302,8 +302,12 @@ ROOT::Experimental::RNTupleWriter::RNTupleWriter(std::unique_ptr<ROOT::Experimen
 
 ROOT::Experimental::RNTupleWriter::~RNTupleWriter()
 {
-   CommitCluster(true /* commitClusterGroup */);
-   fSink->CommitDataset();
+   try {
+      CommitCluster(true /* commitClusterGroup */);
+      fSink->CommitDataset();
+   } catch (const RException &err) {
+      R__LOG_ERROR(NTupleLog()) << "failure committing ntuple: " << err.GetError().GetReport();
+   }
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleWriter>
@@ -339,6 +343,9 @@ void ROOT::Experimental::RNTupleWriter::CommitCluster(bool commitClusterGroup)
       if (commitClusterGroup)
          CommitClusterGroup();
       return;
+   }
+   if (fSink->GetWriteOptions().GetHasSmallClusters() && (fUnzippedClusterSize > 512 * 1024 * 1024)) {
+      throw RException(R__FAIL("invalid attempt to write a cluster > 512MiB with 'small clusters' option enabled"));
    }
    for (auto &field : *fModel->GetFieldZero()) {
       field.Flush();

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -344,7 +344,9 @@ void ROOT::Experimental::RNTupleWriter::CommitCluster(bool commitClusterGroup)
          CommitClusterGroup();
       return;
    }
-   if (fSink->GetWriteOptions().GetHasSmallClusters() && (fUnzippedClusterSize > 512 * 1024 * 1024)) {
+   if (fSink->GetWriteOptions().GetHasSmallClusters() &&
+      (fUnzippedClusterSize > RNTupleWriteOptions::kMaxSmallClusterSize))
+   {
       throw RException(R__FAIL("invalid attempt to write a cluster > 512MiB with 'small clusters' option enabled"));
    }
    for (auto &field : *fModel->GetFieldZero()) {

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -508,6 +508,7 @@ std::uint16_t ROOT::Experimental::Internal::RNTupleSerializer::SerializeColumnTy
 {
    using EColumnType = ROOT::Experimental::EColumnType;
    switch (type) {
+   case EColumnType::kIndex64: return SerializeUInt16(0x01, buffer);
    case EColumnType::kIndex32: return SerializeUInt16(0x02, buffer);
    case EColumnType::kSwitch: return SerializeUInt16(0x03, buffer);
    case EColumnType::kByte: return SerializeUInt16(0x04, buffer);
@@ -520,6 +521,7 @@ std::uint16_t ROOT::Experimental::Internal::RNTupleSerializer::SerializeColumnTy
    case EColumnType::kInt32: return SerializeUInt16(0x0B, buffer);
    case EColumnType::kInt16: return SerializeUInt16(0x0C, buffer);
    case EColumnType::kInt8: return SerializeUInt16(0x0D, buffer);
+   case EColumnType::kSplitIndex64: return SerializeUInt16(0x0E, buffer);
    case EColumnType::kSplitIndex32: return SerializeUInt16(0x0F, buffer);
    case EColumnType::kSplitReal64: return SerializeUInt16(0x10, buffer);
    case EColumnType::kSplitReal32: return SerializeUInt16(0x11, buffer);
@@ -538,6 +540,7 @@ RResult<std::uint16_t> ROOT::Experimental::Internal::RNTupleSerializer::Deserial
    std::uint16_t onDiskType;
    auto result = DeserializeUInt16(buffer, onDiskType);
    switch (onDiskType) {
+   case 0x01: type = EColumnType::kIndex64; break;
    case 0x02: type = EColumnType::kIndex32; break;
    case 0x03: type = EColumnType::kSwitch; break;
    case 0x04: type = EColumnType::kByte; break;
@@ -550,6 +553,7 @@ RResult<std::uint16_t> ROOT::Experimental::Internal::RNTupleSerializer::Deserial
    case 0x0B: type = EColumnType::kInt32; break;
    case 0x0C: type = EColumnType::kInt16; break;
    case 0x0D: type = EColumnType::kInt8; break;
+   case 0x0E: type = EColumnType::kSplitIndex64; break;
    case 0x0F: type = EColumnType::kSplitIndex32; break;
    case 0x10: type = EColumnType::kSplitReal64; break;
    case 0x11: type = EColumnType::kSplitReal32; break;

--- a/tree/ntuple/v7/test/ntuple_descriptor.cxx
+++ b/tree/ntuple/v7/test/ntuple_descriptor.cxx
@@ -348,7 +348,7 @@ TEST(RClusterDescriptor, GetBytesOnStorage)
 
    auto clusterID = desc->FindClusterId(0, 0);
    ASSERT_NE(ROOT::Experimental::kInvalidDescriptorId, clusterID);
-   EXPECT_EQ(4 + 8 + 4 + 3, desc->GetClusterDescriptor(clusterID).GetBytesOnStorage());
+   EXPECT_EQ(8 + 8 + 8 + 3, desc->GetClusterDescriptor(clusterID).GetBytesOnStorage());
 }
 
 TEST(RNTupleDescriptor, Clone)

--- a/tree/ntuple/v7/test/ntuple_extended.cxx
+++ b/tree/ntuple/v7/test/ntuple_extended.cxx
@@ -259,3 +259,84 @@ TEST(RNTuple, LargeFile2)
    }
 }
 #endif
+
+namespace {
+
+int gTestLastLevel = -1;
+bool gTestLastAbort = false;
+std::string gTestLastLocation;
+std::string gTestLastMsg;
+
+static void TestErrorHandler(int level, Bool_t abort, const char *location, const char *msg)
+{
+   gTestLastLevel = level;
+   gTestLastAbort = abort;
+   gTestLastLocation = location;
+   gTestLastMsg = msg;
+}
+
+} // namespace
+
+TEST(RNTuple, SmallClusters)
+{
+   FileRaii fileGuard("test_ntuple_small_clusters.root");
+
+   {
+      auto model = RNTupleModel::Create();
+      auto fldVec = model->MakeField<std::vector<float>>("vec");
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+      fldVec->push_back(1.0);
+      writer->Fill();
+   }
+   {
+      auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+      auto desc = reader->GetDescriptor();
+      auto colId = desc->FindLogicalColumnId(desc->FindFieldId("vec"), 0);
+      EXPECT_EQ(EColumnType::kSplitIndex64, desc->GetColumnDescriptor(colId).GetModel().GetType());
+      reader->LoadEntry(0);
+      auto entry = reader->GetModel()->GetDefaultEntry();
+      EXPECT_FLOAT_EQ(1u, entry->Get<std::vector<float>>("vec")->size());
+      EXPECT_FLOAT_EQ(1.0, entry->Get<std::vector<float>>("vec")->at(0));
+   }
+
+   {
+      auto model = RNTupleModel::Create();
+      auto fldVec = model->MakeField<std::vector<float>>("vec");
+      RNTupleWriteOptions options;
+      options.SetHasSmallClusters(true);
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath(), options);
+      fldVec->push_back(1.0);
+      writer->Fill();
+   }
+   {
+      auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+      auto desc = reader->GetDescriptor();
+      auto colId = desc->FindLogicalColumnId(desc->FindFieldId("vec"), 0);
+      EXPECT_EQ(EColumnType::kSplitIndex32, desc->GetColumnDescriptor(colId).GetModel().GetType());
+      reader->LoadEntry(0);
+      auto entry = reader->GetModel()->GetDefaultEntry();
+      EXPECT_FLOAT_EQ(1u, entry->Get<std::vector<float>>("vec")->size());
+      EXPECT_FLOAT_EQ(1.0, entry->Get<std::vector<float>>("vec")->at(0));
+   }
+
+   // Throw on attempt to commit cluster > 512MB
+   {
+      auto model = RNTupleModel::Create();
+      auto fldVec = model->MakeField<std::vector<float>>("vec");
+      RNTupleWriteOptions options;
+      options.SetHasSmallClusters(true);
+      options.SetMaxUnzippedClusterSize(1000 * 1000 * 1000); // 1GB
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath(), options);
+      fldVec->push_back(1.0);
+      // One float and one 32bit integer per entry
+      for (unsigned int i = 0; i < (300 * 1000 * 1000) / 8; ++i) {
+         writer->Fill();
+      }
+      writer->Fill();
+      EXPECT_THROW(writer->CommitCluster(), ROOT::Experimental::RException);
+      SetErrorHandler(TestErrorHandler);
+   }
+   // On destruction of the writer, the exception in CommitCluster() produced an error log
+   EXPECT_EQ(kError, gTestLastLevel);
+   EXPECT_THAT(gTestLastMsg, testing::HasSubstr("invalid attempt to write a cluster > 512MiB"));
+}

--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -53,7 +53,8 @@ using PackingIntTypes =
 TYPED_TEST_SUITE(PackingInt, PackingIntTypes);
 
 using PackingIndexTypes = ::testing::Types<
-   Helper<ROOT::Experimental::ClusterSize_t, std::uint32_t, ROOT::Experimental::EColumnType::kSplitIndex32>>;
+   Helper<ROOT::Experimental::ClusterSize_t, std::uint32_t, ROOT::Experimental::EColumnType::kSplitIndex32>,
+   Helper<ROOT::Experimental::ClusterSize_t, std::uint64_t, ROOT::Experimental::EColumnType::kSplitIndex64>>;
 TYPED_TEST_SUITE(PackingIndex, PackingIndexTypes);
 
 TEST(Packing, Bitfield)

--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -213,7 +213,7 @@ TEST(Packing, OnDiskEncoding)
       *e->Get<float>("float") = std::nextafterf(1.f, 2.f); // 0 01111111 00000000000000000000001 == 0x3f800001
       *e->Get<double>("double") = std::nextafter(1., 2.);  // 0x3ff0 0000 0000 0001
       *e->Get<ClusterSize_t>("index32") = 39916801;        // 0x0261 1501
-      *e->Get<ClusterSize_t>("index64") = 39916801;        // 0x0261 1501
+      *e->Get<ClusterSize_t>("index64") = 0x0706050403020100L;
       e->Get<std::string>("str")->assign("abc");
 
       writer->Fill(*e);
@@ -224,7 +224,7 @@ TEST(Packing, OnDiskEncoding)
       *e->Get<float>("float") = std::nextafterf(1.f, 0.f);            // 0 01111110 11111111111111111111111 = 0x3f7fffff
       *e->Get<double>("double") = std::numeric_limits<double>::max(); // 0x7fef ffff ffff ffff
       *e->Get<ClusterSize_t>("index32") = 39916808;                   // d(previous) == 7
-      *e->Get<ClusterSize_t>("index64") = 39916808;                   // d(previous) == 7
+      *e->Get<ClusterSize_t>("index64") = 0x070605040302010DL;        // d(previous) == 13
       e->Get<std::string>("str")->assign("de");
 
       writer->Fill(*e);
@@ -268,8 +268,8 @@ TEST(Packing, OnDiskEncoding)
    EXPECT_EQ(memcmp(sealedPage.fBuffer, expIndex32, sizeof(expIndex32)), 0);
 
    source->LoadSealedPage(fnGetColumnId("index64"), RClusterIndex(0, 0), sealedPage);
-   unsigned char expIndex64[] = {0x01, 0x07, 0x15, 0x00, 0x61, 0x00, 0x02, 0x00,
-                                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+   unsigned char expIndex64[] = {0x00, 0x0D, 0x01, 0x00, 0x02, 0x00, 0x03, 0x00,
+                                 0x04, 0x00, 0x05, 0x00, 0x06, 0x00, 0x07, 0x00};
    EXPECT_EQ(memcmp(sealedPage.fBuffer, expIndex64, sizeof(expIndex64)), 0);
 
    auto reader = RNTupleReader(std::move(source));

--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -198,6 +198,7 @@ TEST(Packing, OnDiskEncoding)
    AddField<float, ROOT::Experimental::EColumnType::kSplitReal32>(*model, "float");
    AddField<double, ROOT::Experimental::EColumnType::kSplitReal64>(*model, "double");
    AddField<ClusterSize_t, ROOT::Experimental::EColumnType::kSplitIndex32>(*model, "index32");
+   AddField<ClusterSize_t, ROOT::Experimental::EColumnType::kSplitIndex64>(*model, "index64");
    auto fldStr = std::make_unique<RField<std::string>>("str");
    model->AddField(std::move(fldStr));
    {
@@ -212,6 +213,7 @@ TEST(Packing, OnDiskEncoding)
       *e->Get<float>("float") = std::nextafterf(1.f, 2.f); // 0 01111111 00000000000000000000001 == 0x3f800001
       *e->Get<double>("double") = std::nextafter(1., 2.);  // 0x3ff0 0000 0000 0001
       *e->Get<ClusterSize_t>("index32") = 39916801;        // 0x0261 1501
+      *e->Get<ClusterSize_t>("index64") = 39916801;        // 0x0261 1501
       e->Get<std::string>("str")->assign("abc");
 
       writer->Fill(*e);
@@ -222,6 +224,7 @@ TEST(Packing, OnDiskEncoding)
       *e->Get<float>("float") = std::nextafterf(1.f, 0.f);            // 0 01111110 11111111111111111111111 = 0x3f7fffff
       *e->Get<double>("double") = std::numeric_limits<double>::max(); // 0x7fef ffff ffff ffff
       *e->Get<ClusterSize_t>("index32") = 39916808;                   // d(previous) == 7
+      *e->Get<ClusterSize_t>("index64") = 39916808;                   // d(previous) == 7
       e->Get<std::string>("str")->assign("de");
 
       writer->Fill(*e);
@@ -261,11 +264,16 @@ TEST(Packing, OnDiskEncoding)
    EXPECT_EQ(memcmp(sealedPage.fBuffer, expDouble, sizeof(expDouble)), 0);
 
    source->LoadSealedPage(fnGetColumnId("index32"), RClusterIndex(0, 0), sealedPage);
-   unsigned char expIndex[] = {0x01, 0x07, 0x15, 0x00, 0x61, 0x00, 0x02, 0x00};
-   EXPECT_EQ(memcmp(sealedPage.fBuffer, expIndex, sizeof(expIndex)), 0);
+   unsigned char expIndex32[] = {0x01, 0x07, 0x15, 0x00, 0x61, 0x00, 0x02, 0x00};
+   EXPECT_EQ(memcmp(sealedPage.fBuffer, expIndex32, sizeof(expIndex32)), 0);
+
+   source->LoadSealedPage(fnGetColumnId("index64"), RClusterIndex(0, 0), sealedPage);
+   unsigned char expIndex64[] = {0x01, 0x07, 0x15, 0x00, 0x61, 0x00, 0x02, 0x00,
+                                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+   EXPECT_EQ(memcmp(sealedPage.fBuffer, expIndex64, sizeof(expIndex64)), 0);
 
    auto reader = RNTupleReader(std::move(source));
-   EXPECT_EQ(EColumnType::kIndex32, reader.GetModel()->GetField("str")->GetColumnRepresentative()[0]);
+   EXPECT_EQ(EColumnType::kIndex64, reader.GetModel()->GetField("str")->GetColumnRepresentative()[0]);
    EXPECT_EQ(2u, reader.GetNEntries());
    auto viewStr = reader.GetView<std::string>("str");
    EXPECT_EQ(std::string("abc"), viewStr(0));

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -25,6 +25,7 @@
 #include <ROOT/RPageStorageFile.hxx>
 #include <ROOT/RRawFile.hxx>
 #include <ROOT/RVec.hxx>
+#include <ROOT/TestSupport.hxx>
 
 #include <RZip.h>
 #include <TClass.h>


### PR DESCRIPTION
Add support for 64bit split and unsplit column types. It also makes them the default for index columns. When compressed, the difference to 32bit on-disk offsets is [almost none](https://docs.google.com/spreadsheets/d/1M7DR5obCOG0aTx_5zTLBjXJZb1uXWkHXPBcUpDIkSEc/edit?usp=sharing).

64bit on-disk index columns are the missing piece for supporting large events/clusters (>512MB). In memory, offsets are already 64bit, always. Validation of large events is for a follow-up PR.

Uncompressed, 64bit index columns may still hurt, so there is an option to use 32bit columns instead. In this case, the attempt to write large clusters will fail/throw.