### PR TITLE
[ntuple] Remove enum class ENTupleShowFormat

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -62,15 +62,6 @@ enum class ENTupleInfo {
    kMetrics, // internals performance counters, requires that EnableMetrics() was called
 };
 
-/**
- * Listing of the different entry output formats of RNTupleReader::Show()
- */
-enum class ENTupleShowFormat {
-   kCurrentModelJSON, // prints a single entry/row with the current active model in JSON format.
-   kCompleteJSON,  // prints a single entry/row with all the fields in JSON format.
-};
-
-
 #ifdef R__USE_IMT
 class TTaskGroup;
 class RNTupleImtTaskScheduler : public Detail::RPageStorage::RTaskScheduler {
@@ -248,8 +239,7 @@ public:
    /// Shows the values of the i-th entry/row, starting with 0 for the first entry. By default,
    /// prints the output in JSON format.
    /// Uses the visitor pattern to traverse through each field of the given entry.
-   void Show(NTupleSize_t index, const ENTupleShowFormat format = ENTupleShowFormat::kCurrentModelJSON,
-             std::ostream &output = std::cout);
+   void Show(NTupleSize_t index, std::ostream &output = std::cout);
 
    /// Analogous to Fill(), fills the default entry of the model. Returns false at the end of the ntuple.
    /// On I/O errors, raises an exception.
@@ -280,7 +270,7 @@ public:
    ///
    /// auto ntuple = RNTupleReader::Open("myNTuple", "some/file.root");
    /// for (auto i : ntuple->GetEntryRange()) {
-   ///    ntuple->Show(i, ENTupleShowFormat::kCompleteJSON);
+   ///    ntuple->Show(i);
    /// }
    /// ~~~
    RNTupleGlobalRange GetEntryRange() { return RNTupleGlobalRange(0, GetNEntries()); }

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -230,37 +230,26 @@ ROOT::Experimental::RNTupleReader *ROOT::Experimental::RNTupleReader::GetDisplay
    return fDisplayReader.get();
 }
 
-void ROOT::Experimental::RNTupleReader::Show(NTupleSize_t index, const ENTupleShowFormat format, std::ostream &output)
+void ROOT::Experimental::RNTupleReader::Show(NTupleSize_t index, std::ostream &output)
 {
-   RNTupleReader *reader = this;
-   REntry *entry = GetModel()->GetDefaultEntry();
+   auto reader = GetDisplayReader();
+   auto entry = reader->GetModel()->GetDefaultEntry();
 
-   switch (format) {
-   case ENTupleShowFormat::kCompleteJSON:
-      reader = GetDisplayReader();
-      entry = reader->GetModel()->GetDefaultEntry();
-      // Fall through
-   case ENTupleShowFormat::kCurrentModelJSON:
-      reader->LoadEntry(index);
-      output << "{";
-      for (auto iValue = entry->begin(); iValue != entry->end();) {
+   reader->LoadEntry(index);
+   output << "{";
+   for (auto iValue = entry->begin(); iValue != entry->end();) {
+      output << std::endl;
+      RPrintValueVisitor visitor(*iValue, output, 1 /* level */);
+      iValue->GetField()->AcceptVisitor(visitor);
+
+      if (++iValue == entry->end()) {
          output << std::endl;
-         RPrintValueVisitor visitor(*iValue, output, 1 /* level */);
-         iValue->GetField()->AcceptVisitor(visitor);
-
-         if (++iValue == entry->end()) {
-            output << std::endl;
-            break;
-         } else {
-            output << ",";
-         }
+         break;
+      } else {
+         output << ",";
       }
-      output << "}" << std::endl;
-      break;
-   default:
-      // Unhandled case, internal error
-      R__ASSERT(false);
    }
+   output << "}" << std::endl;
 }
 
 const ROOT::Experimental::RNTupleDescriptor *ROOT::Experimental::RNTupleReader::GetDescriptor()

--- a/tree/ntuple/v7/test/ntuple_show.cxx
+++ b/tree/ntuple/v7/test/ntuple_show.cxx
@@ -16,12 +16,12 @@ TEST(RNTupleShow, Empty)
    auto ntuple2 = RNTupleReader::Open(std::move(model2), ntupleName, rootFileName);
 
    std::ostringstream os;
-   ntuple2->Show(0, ROOT::Experimental::ENTupleShowFormat::kCurrentModelJSON, os);
+   ntuple2->Show(0, os);
    std::string fString{"{}\n"};
    EXPECT_EQ(fString, os.str());
 
    std::ostringstream os1;
-   ntuple2->Show(1, ROOT::Experimental::ENTupleShowFormat::kCurrentModelJSON, os1);
+   ntuple2->Show(1, os1);
    std::string fString1{"{}\n"};
    EXPECT_EQ(fString1, os1.str());
 }
@@ -70,7 +70,7 @@ TEST(RNTupleShow, BasicTypes)
    auto ntuple2 = RNTupleReader::Open(ntupleName, rootFileName);
 
    std::ostringstream os;
-   ntuple2->Show(0, ROOT::Experimental::ENTupleShowFormat::kCompleteJSON, os);
+   ntuple2->Show(0, os);
    // clang-format off
    std::string fString{ std::string("")
       + "{\n"
@@ -88,7 +88,7 @@ TEST(RNTupleShow, BasicTypes)
    EXPECT_EQ(fString, os.str());
 
    std::ostringstream os1;
-   ntuple2->Show(1, ROOT::Experimental::ENTupleShowFormat::kCompleteJSON, os1);
+   ntuple2->Show(1, os1);
    // clang-format off
    std::string fString1{ std::string("")
       + "{\n"
@@ -106,7 +106,7 @@ TEST(RNTupleShow, BasicTypes)
    EXPECT_EQ(fString1, os1.str());
 
    // TODO(jblomer): this should fail to an exception instead
-   EXPECT_DEATH(ntuple2->Show(2, ROOT::Experimental::ENTupleShowFormat::kCompleteJSON), ".*");
+   EXPECT_DEATH(ntuple2->Show(2), ".*");
 }
 
 TEST(RNTupleShow, Vectors)
@@ -139,7 +139,7 @@ TEST(RNTupleShow, Vectors)
    auto ntuple2 = RNTupleReader::Open(std::move(model2), ntupleName, rootFileName);
 
    std::ostringstream os;
-   ntuple2->Show(0, ROOT::Experimental::ENTupleShowFormat::kCurrentModelJSON, os);
+   ntuple2->Show(0, os);
    // clang-format off
    std::string fString{ std::string("")
       + "{\n"
@@ -151,7 +151,7 @@ TEST(RNTupleShow, Vectors)
    EXPECT_EQ(fString, os.str());
 
    std::ostringstream os1;
-   ntuple2->Show(1, ROOT::Experimental::ENTupleShowFormat::kCurrentModelJSON, os1);
+   ntuple2->Show(1, os1);
    // clang-format off
    std::string fString1{ std::string("")
       + "{\n"
@@ -208,7 +208,7 @@ TEST(RNTupleShow, Arrays)
    auto ntuple2 = RNTupleReader::Open(std::move(model2), ntupleName, rootFileName);
 
    std::ostringstream os;
-   ntuple2->Show(0, ROOT::Experimental::ENTupleShowFormat::kCurrentModelJSON, os);
+   ntuple2->Show(0, os);
    // clang-format off
    std::string fString{ std::string("")
       + "{\n"
@@ -223,7 +223,7 @@ TEST(RNTupleShow, Arrays)
    EXPECT_EQ(fString, os.str());
 
    std::ostringstream os1;
-   ntuple2->Show(1, ROOT::Experimental::ENTupleShowFormat::kCurrentModelJSON, os1);
+   ntuple2->Show(1, os1);
    // clang-format off
    std::string fString1{ std::string("")
       + "{\n"
@@ -277,7 +277,7 @@ TEST(RNTupleShow, Objects)
    auto ntuple2 = RNTupleReader::Open(std::move(model2), ntupleName, rootFileName);
 
    std::ostringstream os;
-   ntuple2->Show(0, ROOT::Experimental::ENTupleShowFormat::kCurrentModelJSON, os);
+   ntuple2->Show(0, os);
    // clang-format off
    std::string fString{ std::string("")
       + "{\n"
@@ -333,7 +333,7 @@ TEST(RNTupleShow, Collections)
 
    auto ntuple = RNTupleReader::Open(ntupleName, rootFileName);
    std::ostringstream osData;
-   ntuple->Show(0, ROOT::Experimental::ENTupleShowFormat::kCompleteJSON, osData);
+   ntuple->Show(0, osData);
    // clang-format off
    std::string outputData{ std::string("")
       + "{\n"
@@ -388,7 +388,7 @@ TEST(RNTupleShow, RVec)
    auto r = RNTupleReader::Open(std::move(modelRead), ntupleName, rootFileName);
 
    std::ostringstream os;
-   r->Show(0, ROOT::Experimental::ENTupleShowFormat::kCurrentModelJSON, os);
+   r->Show(0, os);
    // clang-format off
    std::string expected1{std::string("")
       + "{\n"
@@ -401,7 +401,7 @@ TEST(RNTupleShow, RVec)
    EXPECT_EQ(os.str(), expected1);
 
    std::ostringstream os2;
-   r->Show(1, ROOT::Experimental::ENTupleShowFormat::kCurrentModelJSON, os2);
+   r->Show(1, os2);
    // clang-format off
    std::string expected2{std::string("")
       + "{\n"
@@ -455,7 +455,7 @@ TEST(RNTupleShow, RVecTypeErased)
    auto ntuple = RNTupleReader::Open(ntupleName, rootFileName);
 
    std::ostringstream os;
-   ntuple->Show(0, ROOT::Experimental::ENTupleShowFormat::kCompleteJSON, os);
+   ntuple->Show(0, os);
    // clang-format off
    std::string fString{std::string("")
       + "{\n"
@@ -468,7 +468,7 @@ TEST(RNTupleShow, RVecTypeErased)
    EXPECT_EQ(fString, os.str());
 
    std::ostringstream os1;
-   ntuple->Show(1, ROOT::Experimental::ENTupleShowFormat::kCompleteJSON, os1);
+   ntuple->Show(1, os1);
    // clang-format off
    std::string fString1{std::string("")
       + "{\n"
@@ -509,7 +509,7 @@ TEST(RNTupleShow, CollectionProxy)
       EXPECT_EQ(1U, ntuple->GetNEntries());
 
       std::ostringstream os;
-      ntuple->Show(0, ROOT::Experimental::ENTupleShowFormat::kCompleteJSON, os);
+      ntuple->Show(0, os);
       // clang-format off
       std::string expected{std::string("")
          + "{\n"
@@ -519,57 +519,4 @@ TEST(RNTupleShow, CollectionProxy)
       // clang-format on
       EXPECT_EQ(os.str(), expected);
    }
-}
-
-TEST(RNTupleShow, CompleteOrCurrentModel)
-{
-   FileRaii fileGuard("test_ntuple_show_completeorcurrentmodel.root");
-   {
-      auto model = RNTupleModel::Create();
-      auto fldInt = model->MakeField<int>("int");
-      auto fldFloat = model->MakeField<float>("float");
-      auto ntuple = RNTupleWriter::Recreate(std::move(model), "f", fileGuard.GetPath());
-
-      *fldInt = 42;
-      *fldFloat = 3.14;
-      *fldFloat = ntuple->Fill();
-   }
-
-   auto ntuple1 = RNTupleReader::Open("f", fileGuard.GetPath());
-
-   auto model = RNTupleModel::Create();
-   auto fldInt = model->MakeField<int>("int");
-   auto ntuple2 = RNTupleReader::Open(std::move(model), "f", fileGuard.GetPath());
-
-   std::ostringstream os1;
-   ntuple1->Show(0, ROOT::Experimental::ENTupleShowFormat::kCurrentModelJSON, os1);
-   // clang-format off
-   std::string expected1{std::string("")
-      + "{\n"
-      + "  \"int\": 42,\n"
-      + "  \"float\": 3.14\n"
-      + "}\n"};
-   // clang-format on
-   EXPECT_EQ(expected1, os1.str());
-
-   std::ostringstream os2;
-   ntuple2->Show(0, ROOT::Experimental::ENTupleShowFormat::kCurrentModelJSON, os2);
-   // clang-format off
-   std::string expected2{std::string("")
-      + "{\n"
-      + "  \"int\": 42\n"
-      + "}\n"};
-   // clang-format on
-   EXPECT_EQ(expected2, os2.str());
-
-   std::ostringstream os3;
-   ntuple2->Show(0, ROOT::Experimental::ENTupleShowFormat::kCompleteJSON, os3);
-   // clang-format off
-   std::string expected3{std::string("")
-      + "{\n"
-      + "  \"int\": 42,\n"
-      + "  \"float\": 3.14\n"
-      + "}\n"};
-   // clang-format on
-   EXPECT_EQ(expected3, os3.str());
 }

--- a/tutorials/v7/ntuple/ntpl005_introspection.C
+++ b/tutorials/v7/ntuple/ntpl005_introspection.C
@@ -33,7 +33,6 @@ R__LOAD_LIBRARY(ROOTNTuple)
 
 // Import classes from experimental namespace for the time being
 using ENTupleInfo = ROOT::Experimental::ENTupleInfo;
-using ENTupleShowFormat = ROOT::Experimental::ENTupleShowFormat;
 using RNTupleModel = ROOT::Experimental::RNTupleModel;
 using RNTupleReader = ROOT::Experimental::RNTupleReader;
 using RNTupleWriter = ROOT::Experimental::RNTupleWriter;
@@ -90,8 +89,8 @@ void ntpl005_introspection() {
    // Display information about the storage layout of the data
    ntuple->PrintInfo(ENTupleInfo::kStorageDetails);
 
-   // Display the first entry; no model was defined, hence we use kCompleteJSON to force showing all fields
-   ntuple->Show(0, ENTupleShowFormat::kCompleteJSON);
+   // Display the first entry
+   ntuple->Show(0);
 
    // Collect I/O runtime counters when processing the data set.
    // Maintaining the counters comes with a small performance overhead, so it has to be explicitly enabled


### PR DESCRIPTION
Simplifies `RNTuple::Show` and fixes the ntpl005 tutorial. Show now uses unconditionally the model bound to the reader.