### PR TITLE
[RF] Fixes for nested RooSimultaneous pdfs

### DIFF
--- a/roofit/roofitcore/inc/RooSimultaneous.h
+++ b/roofit/roofitcore/inc/RooSimultaneous.h
@@ -28,14 +28,29 @@
 #include "RooArgList.h"
 #include <map>
 #include <string>
+
 class RooAbsCategoryLValue ;
 class RooFitResult ;
 class RooPlot ;
 class RooAbsData ;
 class RooLinkedList ;
+class RooSuperCategory ;
 
 class RooSimultaneous : public RooAbsPdf {
 public:
+
+  /// Internal struct used for initialization.
+  struct InitializationOutput {
+
+     ~InitializationOutput();
+
+     void addPdf(const RooAbsPdf &pdf, std::string const &catLabel);
+
+     std::vector<RooAbsPdf const *> finalPdfs;
+     std::vector<std::string> finalCatLabels;
+     RooAbsCategoryLValue *indexCat = nullptr;
+     std::unique_ptr<RooSuperCategory> superIndex;
+  };
 
   // Constructors, assignment etc
   inline RooSimultaneous() : _plotCoefNormRange(nullptr), _partIntMgr(this,10) {}
@@ -98,8 +113,6 @@ public:
 
 protected:
 
-  void initialize(RooAbsCategoryLValue& inIndexCat, std::map<std::string,RooAbsPdf*> pdfMap) ;
-
   void selectNormalization(const RooArgSet* depSet=nullptr, bool force=false) override ;
   void selectNormalizationRange(const char* rangeName=nullptr, bool force=false) override ;
 
@@ -123,7 +136,16 @@ protected:
   RooCategoryProxy _indexCat ; ///< Index category
   TList    _pdfProxyList ;     ///< List of PDF proxies (named after applicable category state)
   Int_t    _numPdf = 0;        ///< Number of registered PDFs
+
 private:
+
+  /// Private internal constructor.
+  RooSimultaneous(const char *name, const char *title, InitializationOutput && initInfo);
+
+  static std::unique_ptr<RooSimultaneous::InitializationOutput>
+  initialize(std::string const& name, RooAbsCategoryLValue &inIndexCat,
+             std::map<std::string, RooAbsPdf *> const &pdfMap);
+
   mutable std::unique_ptr<RooArgSet> _indexCatSet ; ///<! Index category wrapped in a RooArgSet if needed internally
 
   ClassDefOverride(RooSimultaneous,3)  // Simultaneous operator p.d.f, functions like C++  'switch()' on input p.d.fs operating on index category5A

--- a/roofit/roofitcore/inc/RooSimultaneous.h
+++ b/roofit/roofitcore/inc/RooSimultaneous.h
@@ -84,12 +84,6 @@ public:
   }
   RooPlot* plotOn(RooPlot* frame, RooLinkedList& cmdList) const override ;
 
-  // Backward compatibility function
-  virtual RooPlot *plotOn(RooPlot *frame, Option_t* drawOptions, double scaleFactor=1.0,
-           ScaleType stype=Relative, const RooAbsData* projData=nullptr, const RooArgSet* projSet=nullptr,
-           double precision=1e-3, bool shiftToZero=false, const RooArgSet* projDataSet=nullptr,
-           double rangeLo=0.0, double rangeHi=0.0, RooCurve::WingMode wmode=RooCurve::Extended) const;
-
   RooAbsPdf* getPdf(RooStringView catName) const ;
   const RooAbsCategoryLValue& indexCat() const { return (RooAbsCategoryLValue&) _indexCat.arg() ; }
 

--- a/roofit/roofitcore/src/RooSimultaneous.cxx
+++ b/roofit/roofitcore/src/RooSimultaneous.cxx
@@ -49,7 +49,6 @@ in each category.
 #include "RooSimultaneous.h"
 #include "RooAbsCategoryLValue.h"
 #include "RooPlot.h"
-#include "RooCurve.h"
 #include "RooRealVar.h"
 #include "RooAddPdf.h"
 #include "RooAbsData.h"
@@ -917,32 +916,6 @@ RooPlot* RooSimultaneous::plotOn(RooPlot *frame, RooLinkedList& cmdList) const
 
   return frame2 ;
 }
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// OBSOLETE -- Retained for backward compatibility
-
-RooPlot* RooSimultaneous::plotOn(RooPlot *frame, Option_t* drawOptions, double scaleFactor,
-             ScaleType stype, const RooAbsData* projData, const RooArgSet* projSet,
-             double /*precision*/, bool /*shiftToZero*/, const RooArgSet* /*projDataSet*/,
-             double /*rangeLo*/, double /*rangeHi*/, RooCurve::WingMode /*wmode*/) const
-{
-  // Make command list
-  RooLinkedList cmdList ;
-  cmdList.Add(new RooCmdArg(RooFit::DrawOption(drawOptions))) ;
-  cmdList.Add(new RooCmdArg(RooFit::Normalization(scaleFactor,stype))) ;
-  if (projData) cmdList.Add(new RooCmdArg(RooFit::ProjWData(*projData))) ;
-  if (projSet) cmdList.Add(new RooCmdArg(RooFit::Project(*projSet))) ;
-
-  // Call new method
-  RooPlot* ret = plotOn(frame,cmdList) ;
-
-  // Cleanup
-  cmdList.Delete() ;
-  return ret ;
-}
-
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooSimultaneous.cxx
+++ b/roofit/roofitcore/src/RooSimultaneous.cxx
@@ -696,7 +696,7 @@ RooPlot* RooSimultaneous::plotOn(RooPlot *frame, RooLinkedList& cmdList) const
     // Determine if any servers of the index category are in the projectedVars
     RooArgSet projIdxServers ;
     bool anyServers(false) ;
-    for (const auto server : _indexCat->servers()) {
+    for (const auto server : flattenedCatList()) {
       if (projectedVars.find(server->GetName())) {
         anyServers=true ;
         projIdxServers.add(*server) ;


### PR DESCRIPTION
1. Fix proxy-server desync for nested RooSimultaneous
2. Remove obsolete `RooSimultaneous::plotOn()` override
3. Fix plotting of nested RooSimultanous when projection with data over index category

More detail in the commit descriptions.

Closes #12652.

FYI, @elusian 