### PR TITLE
[VecOps] Add VecOps::ResetView

### DIFF
--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -537,6 +537,18 @@ void UninitializedValueConstruct(ForwardIt first, ForwardIt last)
 #endif
 }
 
+/// An unsafe function to reset the buffer for which this RVec is acting as a view.
+///
+/// \note This is a low-level method that _must_ be called on RVecs that are already non-owning:
+/// - it does not put the RVec in "non-owning mode" (fCapacity == -1)
+/// - it does not free any owned buffer
+template <typename T>
+void ResetView(RVec<T> &v, T* addr, std::size_t sz)
+{
+   v.fBeginX = addr;
+   v.fSize = sz;
+}
+
 } // namespace VecOps
 } // namespace Internal
 
@@ -1479,6 +1491,9 @@ hpt->Draw();
 template <typename T>
 class R__CLING_PTRCHECK(off) RVec : public RVecN<T, Internal::VecOps::RVecInlineStorageSize<T>::value> {
    using SuperClass = RVecN<T, Internal::VecOps::RVecInlineStorageSize<T>::value>;
+
+   friend void Internal::VecOps::ResetView<>(RVec<T> &v, T *addr, std::size_t sz);
+
 public:
    using reference = typename SuperClass::reference;
    using const_reference = typename SuperClass::const_reference;


### PR DESCRIPTION
This is a low-level function to reset the buffer for which this RVec is acting as a view. Before this commit, the only way to reset the pointed-to address of a non-owning RVec was to construct a new RVec and swap it with the old one, which is much more expensive than the two assignments ResetView performs.

It is immediately useful for RDF bulk processing.