### PR TITLE
[RF] Implement `RooPolynomial` plus `RooPolyVar` in BatchMode and remove some old code

### DIFF
--- a/roofit/batchcompute/inc/RooBatchCompute.h
+++ b/roofit/batchcompute/inc/RooBatchCompute.h
@@ -25,7 +25,7 @@
  * Namespace for dispatching RooFit computations to various backends.
  *
  * This namespace contains an interface for providing high-performance computation functions for use in
- * RooAbsReal::evaluateSpan(), see RooBatchComputeInterface.
+ * RooAbsReal::computeBatch(), see RooBatchComputeInterface.
  *
  * Furthermore, several implementations of this interface can be created, which reside in RooBatchCompute::RF_ARCH,
  * where RF_ARCH may be replaced by the architecture that this implementation targets, e.g. SSE, AVX, etc.
@@ -77,7 +77,7 @@ enum Computer {
  * \class RooBatchComputeInterface
  * \ingroup Roobatchcompute
  * \brief The interface which should be implemented to provide optimised computation functions for implementations of
- * RooAbsReal::evaluateSpan().
+ * RooAbsReal::computeBatch().
  *
  * The class RooBatchComputeInterface provides the mechanism for external modules (like RooFit) to call
  * functions from the library. The power lies in the virtual functions that can resolve to different

--- a/roofit/batchcompute/src/ComputeFunctions.cxx
+++ b/roofit/batchcompute/src/ComputeFunctions.cxx
@@ -546,41 +546,19 @@ __rooglobal__ void computePoisson(BatchesHandle batches)
 
 __rooglobal__ void computePolynomial(BatchesHandle batches)
 {
-   Batch X = batches[0];
-   const int nCoef = batches.getNExtraArgs() - 1;
-   const int lowestOrder = batches.extraArg(nCoef);
-   if (nCoef == 0) {
-      for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
-         batches._output[i] = (lowestOrder > 0.0);
-      return;
-   } else
-      for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
-         batches._output[i] = batches.extraArg(nCoef - 1);
+   const int nCoef = batches.extraArg(0);
+   const std::size_t nEvents = batches.getNEvents();
+   Batch x = batches[nCoef];
 
-   /* Indexes are in range 0..nCoef-1 but coefList[nCoef-1]
-    * has already been processed. In order to traverse the list,
-    * with step of 2 we have to start at index nCoef-3 and use
-    * coefList[k+1] and coefList[k]
-    */
-   for (int k = nCoef - 3; k >= 0; k -= 2)
-      for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
-         batches._output[i] = X[i] * (batches._output[i] * X[i] + batches.extraArg(k + 1)) + batches.extraArg(k);
+   for (size_t i = BEGIN; i < nEvents; i += STEP) {
+      batches._output[i] = batches[nCoef - 1][i];
+   }
 
-   // If nCoef is even, then the coefList[0] didn't get processed
-   if (nCoef % 2 == 0)
-      for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
-         batches._output[i] = batches._output[i] * X[i] + batches.extraArg(0);
-
-   // Increase the order of the polynomial, first by myltiplying with X[i]^2
-   if (lowestOrder != 0) {
-      for (int k = 2; k <= lowestOrder; k += 2)
-         for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
-            batches._output[i] *= X[i] * X[i];
-
-      for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
-         if (lowestOrder % 2 == 1)
-            batches._output[i] *= X[i];
-         batches._output[i] += 1.0;
+   // Indexes are in range 0..nCoef-1 but coefList[nCoef-1] has already been
+   // processed.
+   for (int k = nCoef - 2; k >= 0; k--) {
+      for (size_t i = BEGIN; i < nEvents; i += STEP) {
+         batches._output[i] = batches[k][i] + x[i] * batches._output[i];
       }
    }
 }

--- a/roofit/histfactory/src/ParamHistFunc.cxx
+++ b/roofit/histfactory/src/ParamHistFunc.cxx
@@ -46,7 +46,6 @@
 #include "RooRealVar.h"
 #include "RooArgList.h"
 #include "RooWorkspace.h"
-#include "RunContext.h"
 
 #include "TH1.h"
 

--- a/roofit/histfactory/src/PiecewiseInterpolation.cxx
+++ b/roofit/histfactory/src/PiecewiseInterpolation.cxx
@@ -423,9 +423,9 @@ void PiecewiseInterpolation::computeBatch(cudaStream_t*, double* sum, size_t /*s
       }
       break;
     default:
-      coutE(InputArguments) << "PiecewiseInterpolation::evaluateSpan(): " << _paramSet[i].GetName()
+      coutE(InputArguments) << "PiecewiseInterpolation::computeBatch(): " << _paramSet[i].GetName()
                        << " with unknown interpolation code" << icode << std::endl;
-      throw std::invalid_argument("PiecewiseInterpolation::evaluateSpan() got invalid interpolation code " + std::to_string(icode));
+      throw std::invalid_argument("PiecewiseInterpolation::computeBatch() got invalid interpolation code " + std::to_string(icode));
       break;
     }
   }

--- a/roofit/histfactory/src/PiecewiseInterpolation.cxx
+++ b/roofit/histfactory/src/PiecewiseInterpolation.cxx
@@ -31,7 +31,6 @@
 #include "RooMsgService.h"
 #include "RooNumIntConfig.h"
 #include "RooTrace.h"
-#include "RunContext.h"
 
 #include <exception>
 #include <math.h>

--- a/roofit/histfactory/test/testHistFactory.cxx
+++ b/roofit/histfactory/test/testHistFactory.cxx
@@ -515,7 +515,7 @@ TEST_P(HFFixture, Fit) {
   ASSERT_NE(mc, nullptr);
 
   for (bool batchFit : {true, false}) {
-    for (bool constTermOptimisation : {true, false}) { // This tests both correct pre-caching of constant terms and (if false) that all evaluateSpan() are correct.
+    for (bool constTermOptimisation : {true, false}) { // This tests both correct pre-caching of constant terms and (if false) that all computeBatch() are correct.
       SCOPED_TRACE(batchFit ? "Batch fit" : "Normal fit");
       SCOPED_TRACE(constTermOptimisation ? "const term optimisation" : "No const term optimisation");
 

--- a/roofit/histfactory/test/testHistFactory.cxx
+++ b/roofit/histfactory/test/testHistFactory.cxx
@@ -7,6 +7,7 @@
 #include "RooFit/ModelConfig.h"
 
 #include "RooFit/Common.h"
+#include "RooDataHist.h"
 #include "RooWorkspace.h"
 #include "RooArgSet.h"
 #include "RooSimultaneous.h"
@@ -431,24 +432,12 @@ TEST_P(HFFixture, BatchEvaluation) {
   ASSERT_NE(mc, nullptr);
 
   // Test evaluating the model:
-  RooBatchCompute::RunContext evalDataOrig;
-  auto batch = evalDataOrig.makeBatch(obs, 2);
-  obs->setBin(0);
-  batch[0] = obs->getVal();
-  obs->setBin(1);
-  batch[1] = obs->getVal();
+  RooDataHist dataHist{"dataHist", "dataHist", *obs};
 
-  RooBatchCompute::RunContext evalData1;
-  evalData1.spans = evalDataOrig.spans;
-  auto results = channelPdf->getValues(evalData1, nullptr);
-  RooBatchCompute::RunContext evalData2;
-  evalData2.spans = evalDataOrig.spans;
-  auto normResults = channelPdf->getValues(evalData2, mc->GetObservables());
+  std::vector<double> normResults = channelPdf->getValues(dataHist);
 
   for (unsigned int i=0; i < 2; ++i) {
     obs->setBin(i);
-    EXPECT_NEAR(results[i],
-        _targetNominal[i]/obs->getBinWidth(i), 1.E-9);
     EXPECT_NEAR(normResults[i],
         _targetNominal[i]/obs->getBinWidth(i)/(_targetNominal[0]+_targetNominal[1]), 1.E-9);
   }
@@ -462,31 +451,17 @@ TEST_P(HFFixture, BatchEvaluation) {
 
     // Test syst up:
     var->setVal(1.);
-    RooBatchCompute::RunContext evalData3;
-    evalData3.spans = evalDataOrig.spans;
-    auto resultsSyst = channelPdf->getValues(evalData3, nullptr);
-    RooBatchCompute::RunContext evalData4;
-    evalData4.spans = evalDataOrig.spans;
-    auto normResultsSyst = channelPdf->getValues(evalData4, mc->GetObservables());
+    std::vector<double> normResultsSyst = channelPdf->getValues(dataHist);
     for (unsigned int i=0; i < 2; ++i) {
-      EXPECT_NEAR(resultsSyst[i],
-          _targetSysUp[i]/obs->getBinWidth(i), 1.E-6);
       EXPECT_NEAR(normResultsSyst[i],
           _targetSysUp[i]/obs->getBinWidth(i)/(_targetSysUp[0]+_targetSysUp[1]), 1.E-6);
     }
 
     // Test syst down:
     var->setVal(-1.);
-    RooBatchCompute::RunContext evalData5;
-    evalData5.spans = evalDataOrig.spans;
-    resultsSyst = channelPdf->getValues(evalData5, nullptr);
-    RooBatchCompute::RunContext evalData6;
-    evalData6.spans = evalDataOrig.spans;
-    normResultsSyst = channelPdf->getValues(evalData6, mc->GetObservables());
+    normResultsSyst = channelPdf->getValues(dataHist);
     for (unsigned int i=0; i < 2; ++i) {
       obs->setBin(i);
-      EXPECT_NEAR(resultsSyst[i],
-          _targetSysDo[i]/obs->getBinWidth(i), 1.E-6);
       EXPECT_NEAR(normResultsSyst[i],
           _targetSysDo[i]/obs->getBinWidth(i)/(_targetSysDo[0]+_targetSysDo[1]), 1.E-6);
     }

--- a/roofit/roofit/inc/RooPolynomial.h
+++ b/roofit/roofit/inc/RooPolynomial.h
@@ -16,26 +16,22 @@
 #ifndef ROO_POLYNOMIAL
 #define ROO_POLYNOMIAL
 
+#include <RooAbsPdf.h>
+#include <RooRealProxy.h>
+#include <RooListProxy.h>
+
 #include <vector>
-
-#include "RooAbsPdf.h"
-#include "RooRealProxy.h"
-#include "RooListProxy.h"
-
-class RooRealVar;
-class RooArgList ;
 
 class RooPolynomial : public RooAbsPdf {
 public:
 
-  RooPolynomial() ;
+  RooPolynomial() {}
   RooPolynomial(const char* name, const char* title, RooAbsReal& x) ;
   RooPolynomial(const char *name, const char *title,
       RooAbsReal& _x, const RooArgList& _coefList, Int_t lowestOrder=1) ;
 
   RooPolynomial(const RooPolynomial& other, const char *name = nullptr);
   TObject* clone(const char* newname) const override { return new RooPolynomial(*this, newname); }
-  ~RooPolynomial() override ;
 
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
   double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
@@ -49,20 +45,28 @@ public:
   /// Return the order for the first coefficient in the list.
   int lowestOrder() const { return _lowestOrder; }
 
+  // If this polynomial has no terms it's a uniform distribution, and a uniform
+  // pdf is a reducer node because it doesn't depend on the observables.
+  bool isReducerNode() const override { return _coefList.empty(); }
+
 protected:
 
   RooRealProxy _x;
   RooListProxy _coefList ;
-  Int_t _lowestOrder ;
+  Int_t _lowestOrder = 1;
 
   mutable std::vector<double> _wksp; //! do not persist
 
   /// Evaluation
   double evaluate() const override;
-  //void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooFit::DataMap&) const;
-  //inline bool canComputeBatchWithCuda() const { return true; }
+  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooFit::Detail::DataMap const&) const override;
 
-  ClassDefOverride(RooPolynomial,1) // Polynomial PDF
+  // It doesn't make sense to use the GPU if the polynomial has no terms.
+  inline bool canComputeBatchWithCuda() const override { return !_coefList.empty(); }
+
+private:
+
+  ClassDefOverride(RooPolynomial,1); // Polynomial PDF
 };
 
 #endif

--- a/roofit/roofit/inc/RooUniform.h
+++ b/roofit/roofit/inc/RooUniform.h
@@ -40,7 +40,6 @@ protected:
   RooListProxy x ;
 
   double evaluate() const override ;
-  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* /*normSet*/ = nullptr) const override;
 
 
 private:

--- a/roofit/roofit/src/RooUniform.cxx
+++ b/roofit/roofit/src/RooUniform.cxx
@@ -52,28 +52,6 @@ double RooUniform::evaluate() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-///Compute multiple values of the uniform distribution (effectively return a span with ones)
-RooSpan<double> RooUniform::evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* /*normSet*/) const
-{
-  size_t nEvents = 1;
-  for (auto elm : x) {
-    size_t nEventsCurrent = static_cast<const RooAbsReal*>(elm)->getValues(evalData).size();
-    if(nEventsCurrent != 1 && nEvents != 1 && nEventsCurrent != nEvents) {
-      auto errorMsg = std::string("RooUniform::evaluateSpan(): number of entries for input variables does not match")
-                      + "in RooUniform with name \"" + GetName() + "\".";
-      coutE(FastEvaluations) << errorMsg << std::endl ;
-      throw std::runtime_error(errorMsg);
-    }
-    nEvents = std::max(nEvents, nEventsCurrent);
-  }
-  RooSpan<double> values = evalData.makeBatch(this, nEvents);
-  for (size_t i=0; i<nEvents; i++) {
-    values[i] = 1.0;
-  }
-  return values;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Advertise analytical integral
 
 Int_t RooUniform::getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* /*rangeName*/) const

--- a/roofit/roofit/src/RooUniform.cxx
+++ b/roofit/roofit/src/RooUniform.cxx
@@ -23,7 +23,6 @@ Flat p.d.f. in N dimensions
 #include "RooArgSet.h"
 #include "RooRealVar.h"
 #include "RooUniform.h"
-#include "RunContext.h"
 
 
 ClassImp(RooUniform);

--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -47,9 +47,6 @@ class RooAbsDataStore ;
 template<typename T> class TMatrixTSym;
 using TMatrixDSym = TMatrixTSym<double>;
 class RooFormulaVar;
-namespace RooBatchCompute{
-struct RunContext;
-}
 namespace RooFit {
 namespace TestStatistics {
 class RooAbsL;

--- a/roofit/roofitcore/inc/RooAbsDataStore.h
+++ b/roofit/roofitcore/inc/RooAbsDataStore.h
@@ -29,9 +29,6 @@
 class RooAbsArg ;
 class RooArgList ;
 class TTree ;
-namespace RooBatchCompute {
-struct RunContext;
-}
 
 
 class RooAbsDataStore : public TNamed, public RooPrintable {

--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -471,22 +471,6 @@ protected:
   /// Evaluate this PDF / function / constant. Needs to be overridden by all derived classes.
   virtual double evaluate() const = 0;
 
-  /// \deprecated evaluateBatch() has been removed in favour of the faster evaluateSpan(). If your code is affected
-  /// by this change, please consult the release notes for ROOT 6.24 for guidance on how to make this transition.
-  /// https://root.cern/doc/v624/release-notes.html
-#ifndef R__MACOSX
-  virtual RooSpan<double> evaluateBatch(std::size_t /*begin*/, std::size_t /*maxSize*/) = delete;
-#else
-  //AppleClang in MacOS10.14 has a linker bug and fails to link programs that create objects of classes containing virtual deleted methods.
-  //This can be safely deleted when MacOS10.14 is no longer supported by ROOT. See https://reviews.llvm.org/D37830
-  virtual RooSpan<double> evaluateBatch(std::size_t /*begin*/, std::size_t /*maxSize*/) final {
-    throw std::logic_error("Deprecated evaluatedBatch() has been removed in favour of the faster evaluateSpan(). If your code is affected by this change, please consult the release notes for ROOT 6.24 for guidance on how to make this transition. https://root.cern/doc/v624/release-notes.html");
-  }
-#endif
-
-  virtual RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const;
-
-
   //---------- Interface to access batch data ---------------------------
   //
   friend class BatchInterfaceAccessor;

--- a/roofit/roofitcore/inc/RooBinWidthFunction.h
+++ b/roofit/roofitcore/inc/RooBinWidthFunction.h
@@ -22,8 +22,6 @@
 #include "RooTemplateProxy.h"
 #include "RooHistFunc.h"
 
-namespace BatchHelpers { struct RunContext; }
-
 class RooBinWidthFunction : public RooAbsReal {
   static bool _enabled;
   

--- a/roofit/roofitcore/inc/RooFit/TestStatistics/RooUnbinnedL.h
+++ b/roofit/roofitcore/inc/RooFit/TestStatistics/RooUnbinnedL.h
@@ -21,9 +21,6 @@
 class RooAbsPdf;
 class RooAbsData;
 class RooArgSet;
-namespace RooBatchCompute {
-struct RunContext;
-}
 class RooChangeTracker;
 
 namespace RooFit {

--- a/roofit/roofitcore/inc/RooFormula.h
+++ b/roofit/roofitcore/inc/RooFormula.h
@@ -58,7 +58,6 @@ public:
   bool ok() const { return _tFormula != nullptr; }
   /// Evalute all parameters/observables, and then evaluate formula.
   double eval(const RooArgSet* nset=nullptr) const;
-  RooSpan<double> evaluateSpan(const RooAbsReal* dataOwner, RooBatchCompute::RunContext& inputData, const RooArgSet* nset = nullptr) const;
   void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooFit::Detail::DataMap const&) const;
 
   /// DEBUG: Dump state information

--- a/roofit/roofitcore/inc/RooPolyVar.h
+++ b/roofit/roofitcore/inc/RooPolyVar.h
@@ -16,26 +16,22 @@
 #ifndef ROO_POLY_VAR
 #define ROO_POLY_VAR
 
+#include <RooAbsReal.h>
+#include <RooRealProxy.h>
+#include <RooListProxy.h>
+
 #include <vector>
-
-#include "RooAbsReal.h"
-#include "RooRealProxy.h"
-#include "RooListProxy.h"
-
-class RooRealVar;
-class RooArgList ;
 
 class RooPolyVar : public RooAbsReal {
 public:
 
-  RooPolyVar() ;
+  RooPolyVar() {}
   RooPolyVar(const char* name, const char* title, RooAbsReal& x) ;
   RooPolyVar(const char *name, const char *title,
       RooAbsReal& _x, const RooArgList& _coefList, Int_t lowestOrder=0) ;
 
   RooPolyVar(const RooPolyVar& other, const char *name = nullptr);
   TObject* clone(const char* newname) const override { return new RooPolyVar(*this, newname); }
-  ~RooPolyVar() override ;
 
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
   double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
@@ -44,13 +40,25 @@ protected:
 
   RooRealProxy _x;
   RooListProxy _coefList ;
-  Int_t _lowestOrder ;
+  Int_t _lowestOrder  = 0;
 
   mutable std::vector<double> _wksp; ///<! do not persist
 
   double evaluate() const override;
+  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooFit::Detail::DataMap const&) const override;
 
-  ClassDefOverride(RooPolyVar,1) // Polynomial function
+  // It doesn't make sense to use the GPU if the polynomial has no terms.
+  inline bool canComputeBatchWithCuda() const override { return !_coefList.empty(); }
+
+private:
+
+  friend class RooPolynomial;
+
+  static void computeBatchImpl(cudaStream_t *, double *output, size_t nEvents, RooFit::Detail::DataMap const &,
+                               RooAbsReal const &x, RooArgList const &coefs, int lowestOrder);
+
+
+  ClassDefOverride(RooPolyVar,1); // Polynomial function
 };
 
 #endif

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -126,11 +126,11 @@ the proxy holds a function, and will trigger an assert.
 ### Batched function evaluations (Advanced usage)
 
 To speed up computations with large numbers of data events in unbinned fits,
-it is beneficial to override `evaluateSpan()`. Like this, large spans of
+it is beneficial to override `computeBatch()`. Like this, large spans of
 computations can be done, without having to call `evaluate()` for each single data event.
-`evaluateSpan()` should execute the same computation as `evaluate()`, but it
+`computeBatch()` should execute the same computation as `evaluate()`, but it
 may choose an implementation that is capable of SIMD computations.
-If evaluateSpan is not implemented, the classic and slower `evaluate()` will be
+If computeBatch is not implemented, the classic and slower `evaluate()` will be
 called for each data event.
 */
 

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -245,7 +245,7 @@ double RooAbsReal::getValV(const RooArgSet* nset) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute batch of values for input data stored in `evalData`.
 ///
-/// This is a faster, multi-value version of getVal(). It calls evaluateSpan() to trigger computations, and
+/// This is a faster, multi-value version of getVal(). It calls computeBatch() to trigger computations, and
 /// finalises those (e.g. error checking or automatic normalisation) before returning a span with the results.
 /// This span will also be stored in `evalData`, so subsquent calls of getValues() will return immediately.
 ///
@@ -4557,95 +4557,6 @@ void RooAbsReal::setParameterizeIntegral(const RooArgSet& paramVars)
     plist += arg->GetName() ;
   }
   setStringAttribute("CACHEPARAMINT",plist.c_str()) ;
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Evaluate this object for a batch/span of data points.
-/// This is the backend used by getValues() to perform computations. A span pointing to the computation results
-/// will be stored in `evalData`, and also be returned to getValues(), which then finalises the computation.
-///
-/// \note Derived classes should override this function to reach maximal performance. If this function is not overridden, the slower,
-/// single-valued evaluate() will be called in a loop.
-///
-/// A computation proceeds as follows:
-/// - Request input data from all our servers using `getValues(evalData, normSet)`. Those will return
-///   - batches of size 1 if their value is constant over the entire dataset.
-///   - batches of the size of the dataset stored in `evalData` otherwise.
-///   If `evalData` already contains values for those objects, these will return data
-///   without recomputing those.
-/// - Create a new batch in `evalData` of the same size as those returned from the servers.
-/// - Use the input data to perform the computations, and store those in the batch.
-///
-/// \note Error checking and normalisation (of PDFs) will be performed in getValues().
-///
-/// \param[in,out] evalData Object holding data that should be used in computations.
-/// Computation results have to be stored here.
-/// \param[in]  normSet  Optional normalisation set passed down to the servers of this object.
-/// \return     Span pointing to the results. The memory is owned by `evalData`.
-RooSpan<double> RooAbsReal::evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const {
-
-  // Find all servers that are serving real numbers to us, retrieve their batch data,
-  // and switch them into "always clean" operating mode, so they return always the last-set value.
-  struct ServerData {
-    RooAbsReal* server;
-    RooSpan<const double> batch;
-    double oldValue;
-    RooAbsArg::OperMode oldOperMode;
-  };
-  std::vector<ServerData> ourServers;
-  std::size_t dataSize = 1;
-
-  for (auto absArgServer : servers()) {
-    if (absArgServer->IsA()->InheritsFrom(RooAbsReal::Class()) && absArgServer->isValueServer(*this)) {
-      auto server = static_cast<RooAbsReal*>(absArgServer);
-      ourServers.push_back({server,
-          server->getValues(evalData, normSet),
-          server->getVal(normSet),
-          server->operMode()});
-      // Prevent the server from evaluating; just return cached result, which we will side load:
-      server->setOperMode(RooAbsArg::AClean);
-      dataSize = std::max(dataSize, ourServers.back().batch.size());
-    }
-  }
-
-
-  // Make sure that we restore all state when we finish:
-  struct RestoreStateRAII {
-    RestoreStateRAII(std::vector<ServerData>& servers) :
-      _servers{servers} { }
-
-    ~RestoreStateRAII() {
-      for (auto& serverData : _servers) {
-        serverData.server->setCachedValue(serverData.oldValue, true);
-        serverData.server->setOperMode(serverData.oldOperMode);
-      }
-    }
-
-    std::vector<ServerData>& _servers;
-  } restoreState{ourServers};
-
-
-  // Advising to implement the batch interface makes only sense if the batch was not a scalar.
-  // Otherwise, there would be no speedup benefit.
-  if(dataSize > 1 && RooMsgService::instance().isActive(this, RooFit::FastEvaluations, RooFit::INFO)) {
-    coutI(FastEvaluations) << "The class " << ClassName() << " does not implement the faster batch evaluation interface."
-        << " Consider requesting or implementing it to benefit from a speed up." << std::endl;
-  }
-
-
-  // For each event, write temporary values into our servers' caches, and run a single-value computation.
-  auto outputData = evalData.makeBatch(this, dataSize);
-
-  for (std::size_t i=0; i < outputData.size(); ++i) {
-    for (auto& serv : ourServers) {
-      serv.server->setCachedValue(serv.batch[std::min(i, serv.batch.size()-1)], /*notifyClients=*/ false);
-    }
-
-    outputData[i] = evaluate();
-  }
-
-  return outputData;
 }
 
 

--- a/roofit/roofitcore/src/RooBinSamplingPdf.cxx
+++ b/roofit/roofitcore/src/RooBinSamplingPdf.cxx
@@ -93,7 +93,6 @@
 
 #include "RooHelpers.h"
 #include "RooRealBinding.h"
-#include "RunContext.h"
 #include "RooRealVar.h"
 #include "RooGlobalFunc.h"
 #include "RooDataHist.h"

--- a/roofit/roofitcore/src/RooBinWidthFunction.cxx
+++ b/roofit/roofitcore/src/RooBinWidthFunction.cxx
@@ -27,7 +27,6 @@
 #include "RooBinWidthFunction.h"
 
 #include "RooDataHist.h"
-#include "RunContext.h"
 
 bool RooBinWidthFunction::_enabled = true;
 

--- a/roofit/roofitcore/src/RooFormula.cxx
+++ b/roofit/roofitcore/src/RooFormula.cxx
@@ -59,7 +59,6 @@ Check the tutorial rf506_msgservice.C for details.
 #include "RooAbsCategory.h"
 #include "RooArgList.h"
 #include "RooMsgService.h"
-#include "RunContext.h"
 #include "RooBatchCompute.h"
 
 #include "TObjString.h"

--- a/roofit/roofitcore/src/RooFormula.cxx
+++ b/roofit/roofitcore/src/RooFormula.cxx
@@ -445,50 +445,6 @@ double RooFormula::eval(const RooArgSet* nset) const
   return _tFormula->EvalPar(pars.data());
 }
 
-
-RooSpan<double> RooFormula::evaluateSpan(const RooAbsReal* dataOwner, RooBatchCompute::RunContext& inputData, const RooArgSet* nset) const {
-  if (!_tFormula) {
-    coutF(Eval) << __func__ << " (" << GetName() << "): Formula didn't compile: " << GetTitle() << endl;
-    std::string what = "Formula ";
-    what += GetTitle();
-    what += " didn't compile.";
-    throw std::runtime_error(what);
-  }
-
-  std::vector<RooBatchCompute::BracketAdapterWithMask> valueAdapters;
-  std::vector<RooSpan<const double>> inputSpans;
-  size_t nData=1;
-  for (const auto arg : _origList) {
-    auto realArg = static_cast<const RooAbsReal*>(arg);
-    auto batch = realArg->getValues(inputData, nset);
-    assert(!batch.empty());
-    nData = std::max(nData, batch.size());
-    valueAdapters.emplace_back(batch[0], batch);
-    inputSpans.push_back(std::move(batch));
-  }
-
-  auto output = inputData.makeBatch(dataOwner, nData);
-  std::vector<double> pars(_origList.size());
-
-
-  for (std::size_t i=0; i < nData; ++i) {
-    for (unsigned int j=0; j < _origList.size(); ++j) {
-      if (_isCategory[j]) {
-        // TODO: As long as category states cannot be passed in the RunContext,
-        // the current state has to be used.
-        const auto& cat = static_cast<RooAbsCategory&>(_origList[j]);
-        pars[j] = cat.getCurrentIndex();
-      } else {
-        pars[j] = valueAdapters[j][i];
-      }
-    }
-
-    output[i] = _tFormula->EvalPar(pars.data());
-  }
-
-  return output;
-}
-
 void RooFormula::computeBatch(cudaStream_t*, double* output, size_t nEvents, RooFit::Detail::DataMap const& dataMap) const
 {
   const int nPars=_origList.size();

--- a/roofit/roofitcore/src/RooGenericPdf.cxx
+++ b/roofit/roofitcore/src/RooGenericPdf.cxx
@@ -47,7 +47,6 @@ the names of the arguments are not hard coded.
 #include "RooStreamParser.h"
 #include "RooMsgService.h"
 #include "RooArgList.h"
-#include "RunContext.h"
 
 using namespace std;
 

--- a/roofit/roofitcore/src/RooRealSumPdf.cxx
+++ b/roofit/roofitcore/src/RooRealSumPdf.cxx
@@ -301,7 +301,7 @@ void RooRealSumPdf::computeBatch(cudaStream_t* /*stream*/, double* output, size_
     // Warn about degeneration of last coefficient
     if (coef == nullptr && (coefVal < 0 || coefVal > 1.)) {
       if (!_haveWarned) {
-        coutW(Eval) << "RooRealSumPdf::evaluateSpan(" << GetName()
+        coutW(Eval) << "RooRealSumPdf::computeBatch(" << GetName()
             << ") WARNING: sum of FUNC coefficients not in range [0-1], value="
             << sumCoeff << ". This means that the PDF is not properly normalised. If the PDF was meant to be extended, provide as many coefficients as functions." << endl ;
         _haveWarned = true;

--- a/roofit/roofitcore/src/RooRealSumPdf.cxx
+++ b/roofit/roofitcore/src/RooRealSumPdf.cxx
@@ -52,7 +52,6 @@ to the fractions of the various functions. **This requires setting the last argu
 #include "RooRealVar.h"
 #include "RooMsgService.h"
 #include "RooNaNPacker.h"
-#include "RunContext.h"
 
 #include <TError.h>
 

--- a/roofit/roofitmore/inc/RooHypatia2.h
+++ b/roofit/roofitmore/inc/RooHypatia2.h
@@ -53,7 +53,7 @@ private:
   RooRealProxy _n2;
 
   double evaluate() const override;
-  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const override;
+  void computeBatch(cudaStream_t*, double* output, size_t size, RooFit::Detail::DataMap const&) const override;
 
   /// \cond CLASS_DEF_DOXY
   ClassDefOverride(RooHypatia2, 1);

--- a/roofit/roofitmore/inc/RooLegendre.h
+++ b/roofit/roofitmore/inc/RooLegendre.h
@@ -42,7 +42,7 @@ protected: // allow RooSpHarmonic access...
   int _l2,_m2;
 
   double evaluate() const override;
-  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const override;
+  void computeBatch(cudaStream_t*, double* output, size_t size, RooFit::Detail::DataMap const&) const override;
 
   ClassDefOverride(RooLegendre,1) // Legendre polynomial
 };

--- a/roofit/roofitmore/src/RooHypatia2.cxx
+++ b/roofit/roofitmore/src/RooHypatia2.cxx
@@ -93,7 +93,6 @@
 #include "BracketAdapters.h"
 #include "RooAbsReal.h"
 #include "RooHelpers.h"
-#include "RunContext.h"
 
 #include "TMath.h"
 #include "Math/SpecFunc.h"

--- a/roofit/roofitmore/src/RooLegendre.cxx
+++ b/roofit/roofitmore/src/RooLegendre.cxx
@@ -168,12 +168,9 @@ void compute(  size_t batchSize, const int l1, const int m1, const int l2, const
 }
 };
 
-RooSpan<double> RooLegendre::evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const {
-  RooSpan<const double> cthetaData = _ctheta->getValues(evalData, normSet);
-  size_t batchSize = cthetaData.size();
-  auto output = evalData.makeBatch(this, batchSize);
-  compute(batchSize, _l1, _m1, _l2, _m2, output.data(), cthetaData.data());
-  return output;
+void RooLegendre::computeBatch(cudaStream_t*, double* output, size_t size, RooFit::Detail::DataMap const& dataMap) const
+{
+  compute(size, _l1, _m1, _l2, _m2, output, dataMap.at(_ctheta).data());
 }
 
 

--- a/roofit/roofitmore/src/RooLegendre.cxx
+++ b/roofit/roofitmore/src/RooLegendre.cxx
@@ -22,7 +22,6 @@
 **/
 
 #include "RooLegendre.h"
-#include "RunContext.h"
 #include "RooAbsReal.h"
 
 #include "Math/SpecFunc.h"


### PR DESCRIPTION
The existing implementation in RooBatchCompute for polynomials was not
adequate, because it couldn't deal with coefficients that are different
for each event.

This PR is re-implementing the support for RooPolynomial, and also
re-uses the same code for the `RooPolyVar`, which is identical to the
`RooPolynomial` apart from the base class.

Also, this PR is removing the old `RooAbsReal::evaluateSpan()` family of functions that was used for the BatchMode before ROOT 6.26.

Furthermore, this PR also reduces the use of the `RunContext` class that was connected to the old BatchMode implementation.
