### PR TITLE
[RF][math][core] Fix some C++20 warnings

### DIFF
--- a/core/multiproc/inc/TMPWorkerExecutor.h
+++ b/core/multiproc/inc/TMPWorkerExecutor.h
@@ -16,6 +16,7 @@
 #include "MPSendRecv.h"
 #include "PoolUtils.h"
 #include "TMPWorker.h"
+
 #include <string>
 #include <vector>
 
@@ -173,13 +174,12 @@ public:
    {
       unsigned code = msg.first;
       TSocket *s = GetSocket();
-      std::string reply = "S" + std::to_string(GetNWorker());
       if (code == MPCode::kExecFuncWithArg) {
          unsigned n;
          msg.second->ReadUInt(n);
          MPSend(s, MPCode::kFuncResult, fFunc(fArgs[n]));
       } else {
-         reply += ": unknown code received: " + std::to_string(code);
+         std::string reply = "S" + std::to_string(GetNWorker()) + ": unknown code received: " + std::to_string(code);
          MPSend(s, MPCode::kError, reply.c_str());
       }
    }

--- a/math/mathmore/inc/Math/VavilovAccurate.h
+++ b/math/mathmore/inc/Math/VavilovAccurate.h
@@ -329,14 +329,14 @@ public:
 
 
 private:
-   enum{MAXTERMS=500};
+   constexpr static int MAXTERMS{500};
    double fH[8], fT0, fT1, fT, fOmega, fA_pdf[MAXTERMS+1], fB_pdf[MAXTERMS+1], fA_cdf[MAXTERMS+1], fB_cdf[MAXTERMS+1], fX0;
    double fKappa, fBeta2;
    double fEpsilonPM, fEpsilon;
 
    mutable bool fQuantileInit;
    mutable int fNQuant;
-   enum{kNquantMax=32};
+   constexpr static int kNquantMax{32};
    mutable double fQuant[kNquantMax];
    mutable double fLambda[kNquantMax];
 

--- a/math/minuit/inc/TMinuit.h
+++ b/math/minuit/inc/TMinuit.h
@@ -252,7 +252,7 @@ public:
    virtual void   mnset();
    virtual void   mnsimp();
    virtual void   mnstat(Double_t &fmin, Double_t &fedm, Double_t &errdef, Int_t &npari, Int_t &nparx, Int_t &istat);
-   virtual void   mntiny(volatile Double_t epsp1, Double_t &epsbak);
+   virtual void   mntiny(Double_t epsp1, Double_t &epsbak);
    Bool_t         mnunpt(TString &cfname);
    virtual void   mnvert(Double_t *a, Int_t l, Int_t m, Int_t n, Int_t &ifail);
    virtual void   mnwarn(const char *copt, const char *corg, const char *cmes);

--- a/math/minuit/src/TMinuit.cxx
+++ b/math/minuit/src/TMinuit.cxx
@@ -7657,7 +7657,7 @@ void TMinuit::mnstat(Double_t &fmin, Double_t &fedm, Double_t &errdef, Int_t &np
 /// the value .TRUE. if they are equal.  To find EPSMAC
 /// safely by foiling the Fortran optimiser
 
-void TMinuit::mntiny(volatile Double_t epsp1, Double_t &epsbak)
+void TMinuit::mntiny(Double_t epsp1, Double_t &epsbak)
 {
    epsbak = epsp1 - 1;
 }

--- a/math/minuit2/inc/Minuit2/MnTiny.h
+++ b/math/minuit2/inc/Minuit2/MnTiny.h
@@ -23,7 +23,7 @@ public:
 
    double One() const;
 
-   double operator()(volatile double epsp1) const;
+   double operator()(double epsp1) const;
 
 private:
    double fOne;

--- a/math/minuit2/src/MnTiny.cxx
+++ b/math/minuit2/src/MnTiny.cxx
@@ -18,7 +18,7 @@ double MnTiny::One() const
    return fOne;
 }
 
-double MnTiny::operator()(volatile double epsp1) const
+double MnTiny::operator()(double epsp1) const
 {
    // evaluate minimal diference between two floating points
    double result = epsp1 - One();

--- a/roofit/roofit/inc/RooKeysPdf.h
+++ b/roofit/roofit/inc/RooKeysPdf.h
@@ -63,7 +63,7 @@ private:
   double *_weights;  //[_nEvents]
   double _sumWgt ;
 
-  enum { _nPoints = 1000 };
+  constexpr static int _nPoints{1000};
   double _lookupTable[_nPoints+1];
 
   double g(double x,double sigma) const;


### PR DESCRIPTION
* Fix unused variable warning in `TMPWorkerExecutor` by moving variable in the only code branch where it's actually used

* Fix some warnings about deprecated enum arithmetics by using `constexpr static int` instead of `enum`

* Fix warnings about the deprecation of `volatile` in C++ by not using it

With these changes, I can compile RooFit again without seeing warnings.