### PR TITLE
[RF] Fix build due to changed compute() signature

### DIFF
--- a/roofit/roofitcore/src/RooPolyVar.cxx
+++ b/roofit/roofitcore/src/RooPolyVar.cxx
@@ -140,7 +140,8 @@ void RooPolyVar::computeBatchImpl(cudaStream_t *stream, double *output, size_t n
    }
    vars.push_back(dataMap.at(&x));
    auto dispatch = stream ? RooBatchCompute::dispatchCUDA : RooBatchCompute::dispatchCPU;
-   dispatch->compute(stream, RooBatchCompute::Polynomial, output, nEvents, vars, {double(vars.size() - 1)});
+   RooBatchCompute::ArgVector extraArgs{double(vars.size() - 1)};
+   dispatch->compute(stream, RooBatchCompute::Polynomial, output, nEvents, vars, extraArgs);
 }
 
 /// Compute multiple values of Polynomial.


### PR DESCRIPTION
There was a bad interaction between commit 8a67cf611c changing the signature of `compute()` to take a non-const reference, requiring an lvalue, and commit aa47d71aae introducing a new call to that same function with a temporary argument. Fix it in the same way as other call sites were changed in commit 8a67cf611c, by introducing a local variable.