### PR TITLE
[CI] Bump `EnricoMi/publish-test-result-action` to latest version

### DIFF
--- a/.github/workflows/test-result-comment.yml
+++ b/.github/workflows/test-result-comment.yml
@@ -39,7 +39,7 @@ jobs:
            done
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@v2.7.0
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           event_file: artifacts/Event File/event.json


### PR DESCRIPTION

New version v2.7.0 of EnricoMi/publish-unit-test-result-action was just released ([change log](https://github.com/EnricoMi/publish-unit-test-result-action/releases/tag/v2.7.0)), it adds test times to case annotations:
https://github.com/EnricoMi/publish-unit-test-result-action/issues/431

Thanks @EnricoMi!