### PR TITLE
[ntuple] Fix mismatch class vs struct for RNTupleModelChangeset

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -47,7 +47,7 @@ class RColumn;
 class RColumnElementBase;
 class RNTupleCompressor;
 class RNTupleDecompressor;
-class RNTupleModelChangeset;
+struct RNTupleModelChangeset;
 class RPagePool;
 class RFieldBase;
 


### PR DESCRIPTION
Clang complains:
```
warning: 'RNTupleModelChangeset' defined as a struct here but previously declared as a class; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
```