### PR TITLE
[v628][RF] Backports of RooFit PRs to `v6-28-00-patches`: Part 16

### DIFF
--- a/core/cont/src/TRefArray.cxx
+++ b/core/cont/src/TRefArray.cxx
@@ -218,6 +218,7 @@ Bool_t TRefArray::GetObjectUID(Int_t &uid, TObject *obj, const char *methodname)
       } else {
          if (GetAbsLast() < 0) {
             // The container is empty, we can switch the ProcessID.
+            uid = obj->GetUniqueID();
             fPID = TProcessID::GetProcessWithUID(obj);
             valid = kTRUE;
             if (gDebug > 3)

--- a/roofit/histfactory/CMakeLists.txt
+++ b/roofit/histfactory/CMakeLists.txt
@@ -22,6 +22,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(HistFactory
     RooStats/HistFactory/Asimov.h
     RooStats/HistFactory/Channel.h
     RooStats/HistFactory/Data.h
+    RooStats/HistFactory/Detail/HistFactoryImpl.h
     RooStats/HistFactory/FlexibleInterpVar.h
     RooStats/HistFactory/HistFactoryException.h
     RooStats/HistFactory/HistFactoryModelUtils.h
@@ -43,6 +44,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(HistFactory
     src/Channel.cxx
     src/Data.cxx
     src/FlexibleInterpVar.cxx
+    src/HistFactoryImpl.cxx
     src/HistFactoryModelUtils.cxx
     src/HistFactoryNavigation.cxx
     src/HistoToWorkspaceFactoryFast.cxx

--- a/roofit/histfactory/inc/RooStats/HistFactory/Detail/HistFactoryImpl.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/Detail/HistFactoryImpl.h
@@ -1,0 +1,38 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   Jonas Rembser, CERN 2023
+ *
+ * Copyright (c) 2023, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#ifndef HistFactoryImplHelpers_h
+#define HistFactoryImplHelpers_h
+
+#include <RooGlobalFunc.h>
+#include <RooWorkspace.h>
+
+namespace RooStats {
+namespace HistFactory {
+namespace Detail {
+
+template <class Arg_t, class... Params_t>
+Arg_t &getOrCreate(RooWorkspace &ws, std::string const &name, Params_t &&...params)
+{
+   Arg_t *arg = static_cast<Arg_t *>(ws.obj(name));
+   if (arg)
+      return *arg;
+   Arg_t newArg(name.c_str(), name.c_str(), std::forward<Params_t>(params)...);
+   ws.import(newArg, RooFit::RecycleConflictNodes(true), RooFit::Silence(true));
+   return *static_cast<Arg_t *>(ws.obj(name));
+}
+
+} // namespace Detail
+} // namespace HistFactory
+} // namespace RooStats
+
+#endif

--- a/roofit/histfactory/src/HistFactoryImpl.cxx
+++ b/roofit/histfactory/src/HistFactoryImpl.cxx
@@ -1,0 +1,13 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   Jonas Rembser, CERN 2023
+ *
+ * Copyright (c) 2023, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#include <RooStats/HistFactory/Detail/HistFactoryImpl.h>

--- a/roofit/histfactory/src/HistFactoryNavigation.cxx
+++ b/roofit/histfactory/src/HistFactoryNavigation.cxx
@@ -354,7 +354,8 @@ namespace RooStats {
     void HistFactoryNavigation::PrintParameters(bool IncludeConstantParams) {
 
       // Get the list of parameters
-      RooArgSet* params = fModel->getParameters(*fObservables);
+      RooArgSet params;
+      fModel->getParameters(fObservables, params);
 
       std::cout << std::endl;
 
@@ -366,7 +367,7 @@ namespace RooStats {
       << std::endl;
 
       // Loop over the parameters and print their values, etc
-      for (auto const *param : static_range_cast<RooRealVar *>(*params)) {
+      for (auto const *param : static_range_cast<RooRealVar *>(params)) {
         if( !IncludeConstantParams && param->isConstant() ) continue;
 
         std::cout << std::setw(30) << param->GetName();
@@ -383,7 +384,8 @@ namespace RooStats {
                          bool IncludeConstantParams) {
 
       // Get the list of parameters
-      RooArgSet* params = fModel->getParameters(*fObservables);
+      RooArgSet params;
+      fModel->getParameters(fObservables, params);
 
       // Get the pdf for this channel
       RooAbsPdf* channel_pdf = GetChannelPdf(channel);
@@ -398,7 +400,7 @@ namespace RooStats {
       << std::endl;
 
       // Loop over the parameters and print their values, etc
-      for (auto const *param : static_range_cast<RooRealVar *>(*params)) {
+      for (auto const *param : static_range_cast<RooRealVar *>(params)) {
         if( !IncludeConstantParams && param->isConstant() ) continue;
         if( findChild(param->GetName(), channel_pdf)==nullptr ) continue;
         std::cout << std::setw(30) << param->GetName();
@@ -417,7 +419,8 @@ namespace RooStats {
                         bool IncludeConstantParams) {
 
       // Get the list of parameters
-      RooArgSet* params = fModel->getParameters(*fObservables);
+      RooArgSet params;
+      fModel->getParameters(fObservables, params);
 
       // Get the pdf for this channel
       RooAbsReal* sample_func = SampleFunction(channel, sample);
@@ -432,7 +435,7 @@ namespace RooStats {
       << std::endl;
 
       // Loop over the parameters and print their values, etc
-      for (auto const *param : static_range_cast<RooRealVar *>(*params)) {
+      for (auto const *param : static_range_cast<RooRealVar *>(params)) {
         if( !IncludeConstantParams && param->isConstant() ) continue;
         if( findChild(param->GetName(), sample_func)==nullptr ) continue;
         std::cout << std::setw(30) << param->GetName();
@@ -1198,7 +1201,8 @@ namespace RooStats {
       // set the constant as
 
       // Get the list of parameters
-      RooArgSet* params = fModel->getParameters(*fObservables);
+      RooArgSet params;
+      fModel->getParameters(fObservables, params);
 
       std::cout << std::endl;
 
@@ -1210,7 +1214,7 @@ namespace RooStats {
       << std::endl;
 
       // Loop over the parameters and print their values, etc
-      for (auto *param : static_range_cast<RooRealVar *>(*params)) {
+      for (auto *param : static_range_cast<RooRealVar *>(params)) {
 
           std::string ParamName = param->GetName();
           TString ParamNameTString(ParamName);

--- a/roofit/histfactory/src/MakeModelAndMeasurementsFast.cxx
+++ b/roofit/histfactory/src/MakeModelAndMeasurementsFast.cxx
@@ -379,8 +379,8 @@ void RooStats::HistFactory::FitModelAndPlot(const std::string& MeasurementName,
   fprintf(tableFile, " %.4f / %.4f  ", poi->getErrorLo(), poi->getErrorHi());
 
   // Make the Profile Likelihood Plot
-  RooAbsReal* nll = model->createNLL(*simData);
-  RooAbsReal* profile = nll->createProfile(*poi);
+  std::unique_ptr<RooAbsReal> nll{model->createNLL(*simData)};
+  std::unique_ptr<RooAbsReal> profile{nll->createProfile(*poi)};
   if( profile==nullptr ) {
     cxcoutEHF << "Error: Failed to make ProfileLikelihood for: " << poi->GetName()
          << " using model: " << model->GetName()

--- a/roofit/histfactory/test/testParamHistFunc.cxx
+++ b/roofit/histfactory/test/testParamHistFunc.cxx
@@ -10,6 +10,7 @@
 #include <RooStats/HistFactory/ParamHistFunc.h>
 
 #include <gtest/gtest.h>
+#include <array>
 
 /// Validate the ParamHistFunc in the n-dimensional case, comparing both the
 /// BatchMode and the old implementation results to a manually-compute

--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -34,7 +34,6 @@ namespace RooStats {
 class ModelConfig;
 }
 
-class TH1;
 class TClass;
 
 class RooJSONFactoryWSTool {
@@ -117,10 +116,6 @@ public:
    static void error(const char *s);
    inline static void error(const std::string &s) { error(s.c_str()); }
 
-   static void exportHistogram(const TH1 &h, RooFit::Detail::JSONNode &n, const std::vector<std::string> &obsnames,
-                               const TH1 *errH = nullptr, bool writeObservables = true, bool writeErrors = true);
-   static void writeObservables(const TH1 &h, RooFit::Detail::JSONNode &n, const std::vector<std::string> &varnames);
-
    static std::unique_ptr<RooDataHist> readBinnedData(const RooFit::Detail::JSONNode &n, const std::string &namecomp);
    static std::unique_ptr<RooDataHist>
    readBinnedData(const RooFit::Detail::JSONNode &n, const std::string &namecomp, RooArgList const &varlist);
@@ -167,6 +162,8 @@ public:
 
    static void
    exportHisto(RooArgSet const &vars, std::size_t n, double const *contents, RooFit::Detail::JSONNode &output);
+
+   static void exportArray(std::size_t n, double const *contents, RooFit::Detail::JSONNode &output);
 
    static void exportCategory(RooAbsCategory const &cat, RooFit::Detail::JSONNode &node);
 

--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -177,7 +177,6 @@ private:
 
    void importAllNodes(const RooFit::Detail::JSONNode &n);
 
-   void importVariables(const RooFit::Detail::JSONNode &n);
    void importVariable(const RooFit::Detail::JSONNode &n);
    void importDependants(const RooFit::Detail::JSONNode &n);
 

--- a/roofit/hs3/src/HistFactoryJSONTool.cxx
+++ b/roofit/hs3/src/HistFactoryJSONTool.cxx
@@ -327,6 +327,7 @@ void exportMeasurement(RooStats::HistFactory::Measurement &measurement, JSONNode
       pdfs2.append_child() << (std::string("model_") + c.GetName());
 
       JSONNode &dataOutput = RooJSONFactoryWSTool::appendNamedChild(n["data"], std::string("obsData_") + c.GetName());
+      dataOutput["type"] << "binned";
 
       const std::vector<std::string> obsnames = getObsnames(c);
 

--- a/roofit/roofit/inc/RooBDecay.h
+++ b/roofit/roofit/inc/RooBDecay.h
@@ -45,7 +45,7 @@ public:
   ~RooBDecay() override;
 
   double coefficient(Int_t basisIndex) const override;
-  RooArgSet* coefVars(Int_t coefIdx) const override ;
+  RooFit::OwningPtr<RooArgSet> coefVars(Int_t coefIdx) const override ;
 
   Int_t getCoefAnalyticalIntegral(Int_t coef, RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
   double coefAnalyticalIntegral(Int_t coef, Int_t code, const char* rangeName=nullptr) const override ;

--- a/roofit/roofit/inc/RooIntegralMorph.h
+++ b/roofit/roofit/inc/RooIntegralMorph.h
@@ -95,7 +95,7 @@ protected:
   PdfCacheElem* createCache(const RooArgSet* nset) const override ;
   const char* inputBaseName() const override ;
   RooArgSet* actualObservables(const RooArgSet& nset) const override ;
-  RooArgSet* actualParameters(const RooArgSet& nset) const override ;
+  RooFit::OwningPtr<RooArgSet> actualParameters(const RooArgSet& nset) const override ;
   void fillCacheObject(PdfCacheElem& cache) const override ;
 
   RooRealProxy pdf1 ; // First input shape

--- a/roofit/roofit/src/RooBDecay.cxx
+++ b/roofit/roofit/src/RooBDecay.cxx
@@ -132,7 +132,7 @@ double RooBDecay::coefficient(Int_t basisIndex) const
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooArgSet* RooBDecay::coefVars(Int_t basisIndex) const
+RooFit::OwningPtr<RooArgSet> RooBDecay::coefVars(Int_t basisIndex) const
 {
   if(basisIndex == _basisCosh)
     {
@@ -151,7 +151,7 @@ RooArgSet* RooBDecay::coefVars(Int_t basisIndex) const
       return _f3.arg().getVariables();
     }
 
-  return 0 ;
+  return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooIntegralMorph.cxx
+++ b/roofit/roofit/src/RooIntegralMorph.cxx
@@ -147,9 +147,9 @@ RooArgSet* RooIntegralMorph::actualObservables(const RooArgSet& /*nset*/) const
 /// Parameters of the cache. Returns parameters of both pdf1 and pdf2
 /// and parameter cache, in case doCacheAlpha is not set.
 
-RooArgSet* RooIntegralMorph::actualParameters(const RooArgSet& /*nset*/) const
+RooFit::OwningPtr<RooArgSet> RooIntegralMorph::actualParameters(const RooArgSet& /*nset*/) const
 {
-  RooArgSet* par1 = pdf1.arg().getParameters(static_cast<RooArgSet*>(nullptr));
+  auto par1 = pdf1.arg().getParameters(static_cast<RooArgSet*>(nullptr));
   RooArgSet par2;
   pdf2.arg().getParameters(nullptr, par2);
   par1->add(par2,true) ;
@@ -157,7 +157,7 @@ RooArgSet* RooIntegralMorph::actualParameters(const RooArgSet& /*nset*/) const
   if (!_cacheAlpha) {
     par1->add(alpha.arg()) ;
   }
-  return par1 ;
+  return RooFit::OwningPtr<RooArgSet>{std::move(par1)};
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooJeffreysPrior.cxx
+++ b/roofit/roofit/src/RooJeffreysPrior.cxx
@@ -107,7 +107,7 @@ double RooJeffreysPrior::evaluate() const
     //and we start to clone again.
     auto& pdf = _nominal.arg();
     RooAbsPdf* clonePdf = static_cast<RooAbsPdf*>(pdf.cloneTree());
-    auto vars = clonePdf->getParameters(_obsSet);
+    std::unique_ptr<RooArgSet> vars{clonePdf->getParameters(_obsSet)};
     for (auto varTmp : *vars) {
       auto& var = static_cast<RooRealVar&>(*varTmp);
       auto range = var.getRange();
@@ -117,7 +117,7 @@ double RooJeffreysPrior::evaluate() const
 
     cacheElm = new CacheElem;
     cacheElm->_pdf.reset(clonePdf);
-    cacheElm->_pdfVariables.reset(vars);
+    cacheElm->_pdfVariables = std::move(vars);
 
     _cacheMgr.setObj(nullptr, cacheElm);
   }

--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -15,6 +15,7 @@ endif()
 
 ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
   HEADERS
+    RooFit/Config.h
     RooFit/Detail/DataMap.h
     RooFit/Detail/NormalizationHelpers.h
     RooFit/Floats.h

--- a/roofit/roofitcore/inc/RooAbsAnaConvPdf.h
+++ b/roofit/roofitcore/inc/RooAbsAnaConvPdf.h
@@ -63,7 +63,7 @@ public:
   bool forceAnalyticalInt(const RooAbsArg& dep) const override ;
 
   virtual double coefficient(Int_t basisIndex) const = 0 ;
-  virtual RooArgSet* coefVars(Int_t coefIdx) const ;
+  virtual RooFit::OwningPtr<RooArgSet> coefVars(Int_t coefIdx) const ;
 
   bool isDirectGenSafe(const RooAbsArg& arg) const override ;
 

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -24,6 +24,7 @@
 #include "RooAbsCache.h"
 #include "RooNameReg.h"
 #include "RooLinkedListIter.h"
+#include <RooFit/Config.h>
 #include <RooFit/Detail/NormalizationHelpers.h>
 #include <RooStringView.h>
 
@@ -280,17 +281,11 @@ public:
 
 
   // Parameter & observable interpretation of servers
-  RooArgSet* getVariables(bool stripDisconnected=true) const ;
-  RooArgSet* getParameters(const RooAbsData* data, bool stripDisconnected=true) const ;
-  /// Return the parameters of this p.d.f when used in conjuction with dataset 'data'
-  RooArgSet* getParameters(const RooAbsData& data, bool stripDisconnected=true) const {
-    return getParameters(&data,stripDisconnected) ;
-  }
-  /// Return the parameters of the p.d.f given the provided set of observables
-  RooArgSet* getParameters(const RooArgSet& observables, bool stripDisconnected=true) const {
-    return getParameters(&observables,stripDisconnected);
-  }
-  RooArgSet* getParameters(const RooArgSet* observables, bool stripDisconnected=true) const;
+  RooFit::OwningPtr<RooArgSet> getVariables(bool stripDisconnected=true) const ;
+  RooFit::OwningPtr<RooArgSet> getParameters(const RooAbsData* data, bool stripDisconnected=true) const;
+  RooFit::OwningPtr<RooArgSet> getParameters(const RooAbsData& data, bool stripDisconnected=true) const;
+  RooFit::OwningPtr<RooArgSet> getParameters(const RooArgSet& observables, bool stripDisconnected=true) const;
+  RooFit::OwningPtr<RooArgSet> getParameters(const RooArgSet* observables, bool stripDisconnected=true) const;
   virtual bool getParameters(const RooArgSet* observables, RooArgSet& outputSet, bool stripDisconnected=true) const;
   /// Given a set of possible observables, return the observables that this PDF depends on.
   RooArgSet* getObservables(const RooArgSet& set, bool valueOnly=true) const {

--- a/roofit/roofitcore/inc/RooAbsCachedPdf.h
+++ b/roofit/roofitcore/inc/RooAbsCachedPdf.h
@@ -101,7 +101,7 @@ public:
   }
   virtual const char* inputBaseName() const = 0 ;
   virtual RooArgSet* actualObservables(const RooArgSet& nset) const = 0 ;
-  virtual RooArgSet* actualParameters(const RooArgSet& nset) const = 0 ;
+  virtual RooFit::OwningPtr<RooArgSet> actualParameters(const RooArgSet& nset) const = 0 ;
   virtual RooAbsArg& pdfObservable(RooAbsArg& histObservable) const { return histObservable ; }
   virtual void fillCacheObject(PdfCacheElem& cache) const = 0 ;
 

--- a/roofit/roofitcore/inc/RooAbsCachedReal.h
+++ b/roofit/roofitcore/inc/RooAbsCachedReal.h
@@ -96,7 +96,7 @@ protected:
   virtual FuncCacheElem* createCache(const RooArgSet* nset) const ;
   virtual const char* inputBaseName() const = 0 ;
   virtual RooArgSet* actualObservables(const RooArgSet& nset) const = 0 ;
-  virtual RooArgSet* actualParameters(const RooArgSet& nset) const = 0 ;
+  virtual RooFit::OwningPtr<RooArgSet> actualParameters(const RooArgSet& nset) const = 0 ;
   virtual void fillCacheObject(FuncCacheElem& cache) const = 0 ;
 
   mutable RooObjCacheManager _cacheMgr ; ///<! The cache manager

--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -200,11 +200,11 @@ public:
   };
   std::unique_ptr<RooFitResult> minimizeNLL(RooAbsReal & nll, RooAbsData const& data, MinimizerConfig const& cfg);
 
-  virtual RooAbsReal* createNLL(RooAbsData& data, const RooLinkedList& cmdList={}) ;
+  virtual RooFit::OwningPtr<RooAbsReal> createNLL(RooAbsData& data, const RooLinkedList& cmdList={}) ;
   /// Takes an arbitrary number of RooCmdArg command options and calls
   /// RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList).
   template <typename... Args>
-  RooAbsReal* createNLL(RooAbsData& data, RooCmdArg const& arg1, Args const&... args)
+  RooFit::OwningPtr<RooAbsReal> createNLL(RooAbsData& data, RooCmdArg const& arg1, Args const&... args)
   {
     return createNLL(data, *RooFit::Detail::createCmdList(&arg1, &args...));
   }

--- a/roofit/roofitcore/inc/RooAbsSelfCachedPdf.h
+++ b/roofit/roofitcore/inc/RooAbsSelfCachedPdf.h
@@ -33,7 +33,7 @@ protected:
     return GetName() ;
   }
   RooArgSet* actualObservables(const RooArgSet& nset) const override ;
-  RooArgSet* actualParameters(const RooArgSet& nset) const override ;
+  RooFit::OwningPtr<RooArgSet> actualParameters(const RooArgSet& nset) const override ;
   void fillCacheObject(PdfCacheElem& cache) const override ;
 
 private:

--- a/roofit/roofitcore/inc/RooAbsSelfCachedReal.h
+++ b/roofit/roofitcore/inc/RooAbsSelfCachedReal.h
@@ -33,7 +33,7 @@ protected:
     return GetName() ;
   }
   RooArgSet* actualObservables(const RooArgSet& nset) const override ;
-  RooArgSet* actualParameters(const RooArgSet& nset) const override ;
+  RooFit::OwningPtr<RooArgSet> actualParameters(const RooArgSet& nset) const override ;
   void fillCacheObject(FuncCacheElem& cache) const override ;
 
 private:

--- a/roofit/roofitcore/inc/RooCachedPdf.h
+++ b/roofit/roofitcore/inc/RooCachedPdf.h
@@ -35,7 +35,7 @@ protected:
     return pdf.arg().GetName() ;
   } ;
   RooArgSet* actualObservables(const RooArgSet& nset) const override ;
-  RooArgSet* actualParameters(const RooArgSet& nset) const override ;
+  RooFit::OwningPtr<RooArgSet> actualParameters(const RooArgSet& nset) const override ;
   void fillCacheObject(PdfCacheElem& cachePdf) const override ;
   double evaluate() const override {
     // Dummy evaluate, it is never called

--- a/roofit/roofitcore/inc/RooCachedReal.h
+++ b/roofit/roofitcore/inc/RooCachedReal.h
@@ -50,7 +50,7 @@ protected:
     return func.arg().GetName() ;
   } ;
   RooArgSet* actualObservables(const RooArgSet& nset) const override ;
-  RooArgSet* actualParameters(const RooArgSet& nset) const override ;
+  RooFit::OwningPtr<RooArgSet> actualParameters(const RooArgSet& nset) const override;
   void fillCacheObject(FuncCacheElem& cacheFunc) const override ;
   /// Dummy evaluate, it is never called
   double evaluate() const override {

--- a/roofit/roofitcore/inc/RooFFTConvPdf.h
+++ b/roofit/roofitcore/inc/RooFFTConvPdf.h
@@ -96,7 +96,7 @@ protected:
   double evaluate() const override { RooArgSet dummy(_x.arg()) ; return getVal(&dummy) ; } ; // dummy
   const char* inputBaseName() const override ;
   RooArgSet* actualObservables(const RooArgSet& nset) const override ;
-  RooArgSet* actualParameters(const RooArgSet& nset) const override ;
+  RooFit::OwningPtr<RooArgSet> actualParameters(const RooArgSet& nset) const override ;
   RooAbsArg& pdfObservable(RooAbsArg& histObservable) const override ;
   void fillCacheObject(PdfCacheElem& cache) const override ;
   void fillCacheSlice(FFTCacheElem& cache, const RooArgSet& slicePosition) const ;

--- a/roofit/roofitcore/inc/RooFit/Config.h
+++ b/roofit/roofitcore/inc/RooFit/Config.h
@@ -1,0 +1,31 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   Jonas Rembser, CERN 2023
+ *
+ * Copyright (c) 2023, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#ifndef RooFit_Config_h
+#define RooFit_Config_h
+
+namespace RooFit {
+
+/// An alias for raw pointers for indicating that the return type of a RooFit
+/// function is an owning pointer that must be deleted by the caller. For
+/// RooFit developers, it can be very useful to make this an alias to
+/// std::unique_ptr<T>, in order to check that your code has no memory
+/// problems. Changing this alias is equivalent to forcing all code immediately
+/// wraps the result of functions returning a RooFit::OwningPtr<T> in a
+/// std::unique_ptr<T>.
+template<typename T>
+using OwningPtr = T*;
+//using OwningPtr = std::unique_ptr<T>;
+
+}
+
+#endif

--- a/roofit/roofitcore/inc/RooGenFitStudy.h
+++ b/roofit/roofitcore/inc/RooGenFitStudy.h
@@ -68,10 +68,10 @@ public:
   RooAbsPdf::GenSpec* _genSpec ; ///<!
   RooRealVar* _nllVar ; ///<!
   RooRealVar* _ngenVar ; ///<!
-  RooArgSet* _params ; ///<!
+  std::unique_ptr<RooArgSet> _params; ///<!
   RooArgSet* _initParams; ///<!
 
-  ClassDefOverride(RooGenFitStudy,1) // Generate-and-Fit study module
+  ClassDefOverride(RooGenFitStudy,2) // Generate-and-Fit study module
 } ;
 
 

--- a/roofit/roofitcore/inc/RooNumRunningInt.h
+++ b/roofit/roofitcore/inc/RooNumRunningInt.h
@@ -48,7 +48,7 @@ protected:
   FuncCacheElem* createCache(const RooArgSet* nset) const override ;
   const char* inputBaseName() const override ;
   RooArgSet* actualObservables(const RooArgSet& nset) const override ;
-  RooArgSet* actualParameters(const RooArgSet& nset) const override ;
+  RooFit::OwningPtr<RooArgSet> actualParameters(const RooArgSet& nset) const override ;
   void fillCacheObject(FuncCacheElem& cacheFunc) const override ;
   double evaluate() const override ;
 

--- a/roofit/roofitcore/inc/RooSimultaneous.h
+++ b/roofit/roofitcore/inc/RooSimultaneous.h
@@ -28,14 +28,29 @@
 #include "RooArgList.h"
 #include <map>
 #include <string>
+
 class RooAbsCategoryLValue ;
 class RooFitResult ;
 class RooPlot ;
 class RooAbsData ;
 class RooLinkedList ;
+class RooSuperCategory ;
 
 class RooSimultaneous : public RooAbsPdf {
 public:
+
+  /// Internal struct used for initialization.
+  struct InitializationOutput {
+
+     ~InitializationOutput();
+
+     void addPdf(const RooAbsPdf &pdf, std::string const &catLabel);
+
+     std::vector<RooAbsPdf const *> finalPdfs;
+     std::vector<std::string> finalCatLabels;
+     RooAbsCategoryLValue *indexCat = nullptr;
+     std::unique_ptr<RooSuperCategory> superIndex;
+  };
 
   // Constructors, assignment etc
   inline RooSimultaneous() : _plotCoefNormRange(nullptr), _partIntMgr(this,10) {}
@@ -98,8 +113,6 @@ public:
 
 protected:
 
-  void initialize(RooAbsCategoryLValue& inIndexCat, std::map<std::string,RooAbsPdf*> pdfMap) ;
-
   void selectNormalization(const RooArgSet* depSet=nullptr, bool force=false) override ;
   void selectNormalizationRange(const char* rangeName=nullptr, bool force=false) override ;
 
@@ -123,7 +136,16 @@ protected:
   RooCategoryProxy _indexCat ; ///< Index category
   TList    _pdfProxyList ;     ///< List of PDF proxies (named after applicable category state)
   Int_t    _numPdf = 0;        ///< Number of registered PDFs
+
 private:
+
+  /// Private internal constructor.
+  RooSimultaneous(const char *name, const char *title, InitializationOutput && initInfo);
+
+  static std::unique_ptr<RooSimultaneous::InitializationOutput>
+  initialize(std::string const& name, RooAbsCategoryLValue &inIndexCat,
+             std::map<std::string, RooAbsPdf *> const &pdfMap);
+
   mutable std::unique_ptr<RooArgSet> _indexCatSet ; ///<! Index category wrapped in a RooArgSet if needed internally
 
   ClassDefOverride(RooSimultaneous,3)  // Simultaneous operator p.d.f, functions like C++  'switch()' on input p.d.fs operating on index category5A

--- a/roofit/roofitcore/inc/RooSimultaneous.h
+++ b/roofit/roofitcore/inc/RooSimultaneous.h
@@ -84,12 +84,6 @@ public:
   }
   RooPlot* plotOn(RooPlot* frame, RooLinkedList& cmdList) const override ;
 
-  // Backward compatibility function
-  virtual RooPlot *plotOn(RooPlot *frame, Option_t* drawOptions, double scaleFactor=1.0,
-           ScaleType stype=Relative, const RooAbsData* projData=nullptr, const RooArgSet* projSet=nullptr,
-           double precision=1e-3, bool shiftToZero=false, const RooArgSet* projDataSet=nullptr,
-           double rangeLo=0.0, double rangeHi=0.0, RooCurve::WingMode wmode=RooCurve::Extended) const;
-
   RooAbsPdf* getPdf(RooStringView catName) const ;
   const RooAbsCategoryLValue& indexCat() const { return (RooAbsCategoryLValue&) _indexCat.arg() ; }
 

--- a/roofit/roofitcore/inc/RooWorkspace.h
+++ b/roofit/roofitcore/inc/RooWorkspace.h
@@ -65,7 +65,7 @@ public:
       const RooCmdArg& arg1=RooCmdArg(),const RooCmdArg& arg2=RooCmdArg(),const RooCmdArg& arg3=RooCmdArg(),
       const RooCmdArg& arg4=RooCmdArg(),const RooCmdArg& arg5=RooCmdArg(),const RooCmdArg& arg6=RooCmdArg(),
       const RooCmdArg& arg7=RooCmdArg(),const RooCmdArg& arg8=RooCmdArg(),const RooCmdArg& arg9=RooCmdArg()) ;
-  bool import(RooAbsData& data,
+  bool import(RooAbsData const& data,
       const RooCmdArg& arg1=RooCmdArg(),const RooCmdArg& arg2=RooCmdArg(),const RooCmdArg& arg3=RooCmdArg(),
       const RooCmdArg& arg4=RooCmdArg(),const RooCmdArg& arg5=RooCmdArg(),const RooCmdArg& arg6=RooCmdArg(),
       const RooCmdArg& arg7=RooCmdArg(),const RooCmdArg& arg8=RooCmdArg(),const RooCmdArg& arg9=RooCmdArg()) ;
@@ -73,8 +73,8 @@ public:
       const RooCmdArg& arg1=RooCmdArg(),const RooCmdArg& arg2=RooCmdArg(),const RooCmdArg& arg3=RooCmdArg(),
       const RooCmdArg& arg4=RooCmdArg(),const RooCmdArg& arg5=RooCmdArg(),const RooCmdArg& arg6=RooCmdArg(),
       const RooCmdArg& arg7=RooCmdArg(),const RooCmdArg& arg8=RooCmdArg(),const RooCmdArg& arg9=RooCmdArg()) ;
-  bool import(TObject& object, bool replaceExisting=false) ;
-  bool import(TObject& object, const char* aliasName, bool replaceExisting=false) ;
+  bool import(TObject const& object, bool replaceExisting=false) ;
+  bool import(TObject const& object, const char* aliasName, bool replaceExisting=false) ;
 
   // Transaction management interface for multi-step import operations
   bool startTransaction() ;

--- a/roofit/roofitcore/inc/RooWorkspace.h
+++ b/roofit/roofitcore/inc/RooWorkspace.h
@@ -51,6 +51,8 @@ public:
   RooWorkspace(const RooWorkspace& other) ;
   ~RooWorkspace() override ;
 
+  TObject *Clone(const char *newname="") const override;
+
   bool importClassCode(const char* pat="*", bool doReplace=false) ;
   bool importClassCode(TClass* theClass, bool doReplace=false) ;
 

--- a/roofit/roofitcore/src/ModelConfig.cxx
+++ b/roofit/roofitcore/src/ModelConfig.cxx
@@ -113,13 +113,13 @@ void ModelConfig::GuessObsAndNuisance(const RooAbsData &data, bool printModelCon
    //      SetParametersOfInterest(RooArgSet());
    //   }
    if (!GetNuisanceParameters()) {
-      const RooArgSet *params = GetPdf()->getParameters(data);
-      RooArgSet p(*params);
+      RooArgSet params;
+      GetPdf()->getParameters(data.get(), params);
+      RooArgSet p(params);
       p.remove(*GetParametersOfInterest());
       removeConstantParameters(p);
       if (p.getSize() > 0)
          SetNuisanceParameters(p);
-      delete params;
    }
 
    // print Modelconfig as an info message

--- a/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
@@ -614,10 +614,8 @@ void RooAbsAnaConvPdf::makeCoefVarList(RooArgList& varList) const
 {
   // Instantate a coefficient variables
   for (Int_t i=0 ; i<_convSet.getSize() ; i++) {
-    RooArgSet* cvars = coefVars(i) ;
-    RooAbsReal* coefVar = new RooConvCoefVar(Form("%s_coefVar_%d",GetName(),i),"coefVar",*this,i,cvars) ;
-    varList.addOwned(*coefVar) ;
-    delete cvars ;
+    auto cvars = coefVars(i);
+    varList.addOwned(std::make_unique<RooConvCoefVar>(Form("%s_coefVar_%d",GetName(),i),"coefVar",*this,i,&*cvars));
   }
 
 }
@@ -626,9 +624,9 @@ void RooAbsAnaConvPdf::makeCoefVarList(RooArgList& varList) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Return set of parameters with are used exclusively by the coefficient functions
 
-RooArgSet* RooAbsAnaConvPdf::coefVars(Int_t /*coefIdx*/) const
+RooFit::OwningPtr<RooArgSet> RooAbsAnaConvPdf::coefVars(Int_t /*coefIdx*/) const
 {
-  RooArgSet* cVars = getParameters((RooArgSet*)0) ;
+  auto cVars = getParameters(static_cast<RooArgSet*>(nullptr));
   std::vector<RooAbsArg*> tmp;
   for (auto arg : *cVars) {
     for (auto convSetArg : _convSet) {
@@ -640,7 +638,7 @@ RooArgSet* RooAbsAnaConvPdf::coefVars(Int_t /*coefIdx*/) const
 
   cVars->remove(tmp.begin(), tmp.end(), true, true);
 
-  return cVars ;
+  return RooFit::OwningPtr<RooArgSet>{std::move(cVars)};
 }
 
 

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -2461,7 +2461,7 @@ void RooRefArray::Streamer(TBuffer &R__b)
      R__c = R__b.WriteVersion(RooRefArray::IsA(), true);
 
      // Make a temporary refArray and write that to the streamer
-     TRefArray refArray(GetEntriesFast());
+     TRefArray refArray;
      for(TObject * tmpObj : *this) {
        refArray.Add(tmpObj) ;
      }

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -560,9 +560,38 @@ void RooAbsArg::treeNodeServerList(RooAbsCollection* list, const RooAbsArg* arg,
 /// function is responsible for deleting the returned argset.
 /// The complement of this function is getObservables()
 
-RooArgSet* RooAbsArg::getParameters(const RooAbsData* set, bool stripDisconnected) const
+RooFit::OwningPtr<RooArgSet> RooAbsArg::getParameters(const RooAbsData* set, bool stripDisconnected) const
 {
   return getParameters(set?set->get():0,stripDisconnected) ;
+}
+
+
+/// Return the parameters of this p.d.f when used in conjuction with dataset 'data'.
+RooFit::OwningPtr<RooArgSet> RooAbsArg::getParameters(const RooAbsData& data, bool stripDisconnected) const
+{
+  return getParameters(&data,stripDisconnected) ;
+}
+
+
+/// Return the parameters of the p.d.f given the provided set of observables.
+RooFit::OwningPtr<RooArgSet> RooAbsArg::getParameters(const RooArgSet& observables, bool stripDisconnected) const
+{
+  return getParameters(&observables,stripDisconnected);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Create a list of leaf nodes in the arg tree starting with
+/// ourself as top node that don't match any of the names the args in the
+/// supplied argset. The caller of this function is responsible
+/// for deleting the returned argset. The complement of this function
+/// is getObservables().
+
+RooFit::OwningPtr<RooArgSet> RooAbsArg::getParameters(const RooArgSet* observables, bool stripDisconnected) const
+{
+  auto * outputSet = new RooArgSet;
+  getParameters(observables, *outputSet, stripDisconnected);
+  return RooFit::OwningPtr<RooArgSet>{outputSet};
 }
 
 
@@ -636,19 +665,6 @@ std::size_t RooAbsArg::getParametersSizeEstimate(const RooArgSet* nset) const
   }
 
   return res;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Create a list of leaf nodes in the arg tree starting with
-/// ourself as top node that don't match any of the names the args in the
-/// supplied argset. The caller of this function is responsible
-/// for deleting the returned argset. The complement of this function
-/// is getObservables().
-
-RooArgSet* RooAbsArg::getParameters(const RooArgSet* observables, bool stripDisconnected) const {
-  auto * outputSet = new RooArgSet;
-  getParameters(observables, *outputSet, stripDisconnected);
-  return outputSet;
 }
 
 
@@ -1819,14 +1835,14 @@ bool RooAbsArg::findConstantNodes(const RooArgSet& observables, RooArgSet& cache
 
   // Check if node depends on any non-constant parameter
   bool canOpt(true) ;
-  RooArgSet* paramSet = getParameters(observables) ;
-  for(RooAbsArg * param : *paramSet) {
+  RooArgSet paramSet;
+  getParameters(&observables, paramSet);
+  for(RooAbsArg * param : paramSet) {
     if (!param->isConstant()) {
       canOpt=false ;
       break ;
     }
   }
-  delete paramSet ;
 
 
   if (getAttribute("NeverConstant")) {
@@ -2080,7 +2096,7 @@ RooAbsCache* RooAbsArg::getCache(Int_t index) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Return RooArgSet with all variables (tree leaf nodes of expresssion tree)
 
-RooArgSet* RooAbsArg::getVariables(bool stripDisconnected) const
+RooFit::OwningPtr<RooArgSet> RooAbsArg::getVariables(bool stripDisconnected) const
 {
   return getParameters(RooArgSet(),stripDisconnected) ;
 }

--- a/roofit/roofitcore/src/RooAbsCachedReal.cxx
+++ b/roofit/roofitcore/src/RooAbsCachedReal.cxx
@@ -207,7 +207,7 @@ RooAbsCachedReal::FuncCacheElem::FuncCacheElem(const RooAbsCachedReal& self, con
   _func->setValueDirty() ;
 
   // Create pseudo-object that tracks changes in parameter values
-  RooArgSet* params = self.actualParameters(orderedObs) ;
+  std::unique_ptr<RooArgSet> params{self.actualParameters(orderedObs)};
   string name= Form("%s_CACHEPARAMS",_func->GetName()) ;
   _paramTracker = new RooChangeTracker(name.c_str(),name.c_str(),*params,true) ;
   _paramTracker->hasChanged(true) ; // clear dirty flag as cache is up-to-date upon creation
@@ -216,11 +216,8 @@ RooAbsCachedReal::FuncCacheElem::FuncCacheElem(const RooAbsCachedReal& self, con
   // makes the correct decisions
   _func->addServerList(*params) ;
 
-
   delete observables ;
-  delete params ;
   delete nset2 ;
-
 }
 
 

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -964,7 +964,7 @@ double RooAbsPdf::extendedTerm(RooAbsData const& data, bool weightSquared, bool 
 ///
 ///
 
-RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
+RooFit::OwningPtr<RooAbsReal> RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
 {
   auto baseName = std::string("nll_") + GetName() + "_" + data.GetName();
 
@@ -1034,8 +1034,8 @@ RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
       RooFit::TestStatistics::ExternalConstraints extCons(extConsSet);
       RooFit::TestStatistics::GlobalObservables glObs(glObsSet);
 
-      return new RooFit::TestStatistics::RooRealL("likelihood", "",
-          RooFit::TestStatistics::buildLikelihood(this, &data, ext, cPars, extCons, glObs, rangeName));
+      return RooFit::OwningPtr<RooAbsReal>{new RooFit::TestStatistics::RooRealL("likelihood", "",
+          RooFit::TestStatistics::buildLikelihood(this, &data, ext, cPars, extCons, glObs, rangeName))};
   }
 
   // Decode command line arguments
@@ -1158,16 +1158,17 @@ RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
        compiledConstr->addOwnedComponents(std::move(constr));
     }
 
-    return RooFit::BatchModeHelpers::createNLL(std::move(pdfClone),
-                                               data,
-                                               std::move(compiledConstr),
-                                               rangeName ? rangeName : "",
-                                               projDeps,
-                                               ext,
-                                               pc.getDouble("IntegrateBins"),
-                                               batchMode,
-                                               offset,
-                                               takeGlobalObservablesFromData).release();
+    return RooFit::OwningPtr<RooAbsReal>{RooFit::BatchModeHelpers::createNLL(
+            std::move(pdfClone),
+            data,
+            std::move(compiledConstr),
+            rangeName ? rangeName : "",
+            projDeps,
+            ext,
+            pc.getDouble("IntegrateBins"),
+            batchMode,
+            offset,
+            takeGlobalObservablesFromData).release()};
   }
 
   // Construct NLL
@@ -1222,7 +1223,7 @@ RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
     nll->enableOffsetting(true) ;
   }
 
-  return nll.release() ;
+  return RooFit::OwningPtr<RooAbsReal>{nll.release()};
 }
 
 

--- a/roofit/roofitcore/src/RooAbsSelfCachedPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsSelfCachedPdf.cxx
@@ -121,7 +121,7 @@ RooArgSet* RooAbsSelfCachedPdf::actualObservables(const RooArgSet& /*nset*/) con
 /// subset of variables of self that is not contained in the
 /// supplied nset
 
-RooArgSet* RooAbsSelfCachedPdf::actualParameters(const RooArgSet& nset) const
+RooFit::OwningPtr<RooArgSet> RooAbsSelfCachedPdf::actualParameters(const RooArgSet& nset) const
 {
   RooArgSet *serverSet = new RooArgSet;
 
@@ -132,7 +132,7 @@ RooArgSet* RooAbsSelfCachedPdf::actualParameters(const RooArgSet& nset) const
   // Remove all given observables from server list
   serverSet->remove(nset,true,true);
 
-  return serverSet;
+  return RooFit::OwningPtr<RooArgSet>{serverSet};
 }
 
 

--- a/roofit/roofitcore/src/RooAbsSelfCachedReal.cxx
+++ b/roofit/roofitcore/src/RooAbsSelfCachedReal.cxx
@@ -119,7 +119,7 @@ RooArgSet* RooAbsSelfCachedReal::actualObservables(const RooArgSet& nset) const
 /// subset of variables of self that is not contained in the
 /// supplied nset
 
-RooArgSet* RooAbsSelfCachedReal::actualParameters(const RooArgSet& nset) const
+RooFit::OwningPtr<RooArgSet> RooAbsSelfCachedReal::actualParameters(const RooArgSet& nset) const
 {
   // Make list of servers
   RooArgSet *serverSet = new RooArgSet;
@@ -131,12 +131,5 @@ RooArgSet* RooAbsSelfCachedReal::actualParameters(const RooArgSet& nset) const
   // Remove all given observables from server list
   serverSet->remove(nset,true,true);
 
-  return serverSet;
+  return RooFit::OwningPtr<RooArgSet>{serverSet};
 }
-
-
-
-
-
-
-

--- a/roofit/roofitcore/src/RooAbsTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsTestStatistic.cxx
@@ -501,13 +501,12 @@ void RooAbsTestStatistic::initSimMode(RooSimultaneous* simpdf, RooAbsData* data,
 
       // Servers may have been redirected between instantiation and (deferred) initialization
 
-      RooArgSet *actualParams = binnedInfo.binnedPdf ? binnedInfo.binnedPdf->getParameters(dset) : pdf->getParameters(dset);
+      auto actualParams = binnedInfo.binnedPdf ? binnedInfo.binnedPdf->getParameters(dset) : pdf->getParameters(dset);
       RooArgSet* selTargetParams = (RooArgSet*) _paramSet.selectCommon(*actualParams);
 
       _gofArray.back()->recursiveRedirectServers(*selTargetParams);
 
       delete selTargetParams;
-      delete actualParams;
     }
   }
   for(auto& gof : _gofArray) {

--- a/roofit/roofitcore/src/RooCachedPdf.cxx
+++ b/roofit/roofitcore/src/RooCachedPdf.cxx
@@ -156,12 +156,9 @@ RooArgSet* RooCachedPdf::actualObservables(const RooArgSet& nset) const
 /// the cache observables. If this p.d.f is operated in automatic mode,
 /// return the parameters of the external input p.d.f
 
-RooArgSet* RooCachedPdf::actualParameters(const RooArgSet& nset) const
+RooFit::OwningPtr<RooArgSet> RooCachedPdf::actualParameters(const RooArgSet& nset) const
 {
-  if (_cacheObs.getSize()>0) {
-    return pdf.arg().getParameters(_cacheObs) ;
-  }
-  return pdf.arg().getParameters(nset) ;
+   return pdf.arg().getParameters(_cacheObs.empty() ? nset : _cacheObs) ;
 }
 
 

--- a/roofit/roofitcore/src/RooCachedReal.cxx
+++ b/roofit/roofitcore/src/RooCachedReal.cxx
@@ -190,12 +190,9 @@ RooArgSet* RooCachedReal::actualObservables(const RooArgSet& nset) const
 /// the cache observables. If this p.d.f is operated in automatic mode,
 /// return the parameters of the external input p.d.f
 
-RooArgSet* RooCachedReal::actualParameters(const RooArgSet& nset) const
+RooFit::OwningPtr<RooArgSet> RooCachedReal::actualParameters(const RooArgSet& nset) const
 {
-  if (_cacheObs.getSize()>0) {
-    return func.arg().getParameters(_cacheObs) ;
-  }
-  return func.arg().getParameters(nset) ;
+   return func->getParameters(_cacheObs.empty() ? nset : _cacheObs);
 }
 
 

--- a/roofit/roofitcore/src/RooFFTConvPdf.cxx
+++ b/roofit/roofitcore/src/RooFFTConvPdf.cxx
@@ -741,12 +741,12 @@ RooArgSet* RooFFTConvPdf::actualObservables(const RooArgSet& nset) const
 /// set nset. For this p.d.f these are the parameters of the input p.d.f.
 /// but never the convolution variable, in case it is not part of nset.
 
-RooArgSet* RooFFTConvPdf::actualParameters(const RooArgSet& nset) const
+RooFit::OwningPtr<RooArgSet> RooFFTConvPdf::actualParameters(const RooArgSet& nset) const
 {
-  RooArgSet* vars = getVariables() ;
+  auto vars = getVariables() ;
   vars->remove(*std::unique_ptr<RooArgSet>{actualObservables(nset)});
 
-  return vars ;
+  return RooFit::OwningPtr<RooArgSet>{std::move(vars)};
 }
 
 

--- a/roofit/roofitcore/src/RooGenFitStudy.cxx
+++ b/roofit/roofitcore/src/RooGenFitStudy.cxx
@@ -51,7 +51,6 @@ RooGenFitStudy::RooGenFitStudy(const char* name, const char* title) :
   _genSpec(0),
   _nllVar(0),
   _ngenVar(0),
-  _params(0),
   _initParams(0)
 {
 }
@@ -72,7 +71,6 @@ RooGenFitStudy::RooGenFitStudy(const RooGenFitStudy& other) :
   _genSpec(0),
   _nllVar(0),
   _ngenVar(0),
-  _params(0),
   _initParams(0)
 {
   for(TObject * o : other._genOpts) _genOpts.Add(o->Clone());
@@ -85,7 +83,6 @@ RooGenFitStudy::RooGenFitStudy(const RooGenFitStudy& other) :
 
 RooGenFitStudy::~RooGenFitStudy()
 {
-  if (_params) delete _params ;
 }
 
 
@@ -164,7 +161,7 @@ bool RooGenFitStudy::initialize()
   _nllVar = new RooRealVar("NLL","-log(Likelihood)",0) ;
   _ngenVar = new RooRealVar("ngen","number of generated events",0) ;
 
-  _params = _fitPdf->getParameters(_genObs) ;
+  _params = std::unique_ptr<RooArgSet>{_fitPdf->getParameters(_genObs)};
   RooArgSet modelParams(*_params) ;
   _initParams = (RooArgSet*) _params->snapshot() ;
   _params->add(*_nllVar) ;
@@ -205,12 +202,11 @@ bool RooGenFitStudy::execute()
 
 bool RooGenFitStudy::finalize()
 {
-  delete _params ;
   delete _nllVar ;
   delete _ngenVar ;
   delete _initParams ;
   delete _genSpec ;
-  _params = 0 ;
+  _params.reset();
   _nllVar = 0 ;
   _ngenVar = 0 ;
   _initParams = 0 ;

--- a/roofit/roofitcore/src/RooNumRunningInt.cxx
+++ b/roofit/roofitcore/src/RooNumRunningInt.cxx
@@ -270,11 +270,11 @@ RooArgSet* RooNumRunningInt::actualObservables(const RooArgSet& /*nset*/) const
 /// These are always the input functions parameter, but never the
 /// integrated variable x.
 
-RooArgSet* RooNumRunningInt::actualParameters(const RooArgSet& /*nset*/) const
+RooFit::OwningPtr<RooArgSet> RooNumRunningInt::actualParameters(const RooArgSet& /*nset*/) const
 {
-  RooArgSet* ret = func.arg().getParameters(RooArgSet()) ;
+  auto ret = func.arg().getParameters(RooArgSet()) ;
   ret->remove(x.arg(),true,true) ;
-  return ret ;
+  return ret;
 }
 
 

--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -804,7 +804,8 @@ std::unique_ptr<RooProdPdf::CacheElem> RooProdPdf::createCacheElem(const RooArgS
       std::ostringstream str; termNSet.printValue(str);
       if (!ratioTerms[str.str()].empty()) {
 //    cout << "MUST INSERT RATIO OBJECT IN TERM (SINGLE) " << *term << endl;
-   term->addOwned(std::move(ratioTerms[str.str()]));
+      term->add(ratioTerms[str.str()]);
+      cache->_ownedList.addOwned(std::move(ratioTerms[str.str()]));
       }
     } else {
       RooArgSet compTermSet, compTermNorm;
@@ -818,7 +819,8 @@ std::unique_ptr<RooProdPdf::CacheElem> RooProdPdf::createCacheElem(const RooArgS
    ostringstream str; termNSet.printValue(str);
    if (!ratioTerms[str.str()].empty()) {
 //      cout << "MUST INSERT RATIO OBJECT IN TERM (COMPOSITE)" << *term << endl;
-     term->addOwned(std::move(ratioTerms[str.str()]));
+     term->add(ratioTerms[str.str()]);
+     cache->_ownedList.addOwned(std::move(ratioTerms[str.str()]));
    }
       }
     }

--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -309,8 +309,8 @@ void RooProdPdf::initializeFromCmdArgList(const RooArgSet& fullPdfSet, const Roo
     if (0 == strcmp(carg->GetName(), "Conditional")) {
 
       Int_t argType = carg->getInt(0) ;
-      RooArgSet* pdfSet = (RooArgSet*) carg->getSet(0) ;
-      RooArgSet* normSet = (RooArgSet*) carg->getSet(1) ;
+      auto pdfSet = static_cast<RooArgSet const*>(carg->getSet(0));
+      auto normSet = static_cast<RooArgSet const*>(carg->getSet(1));
 
       for(auto * thePdf : static_range_cast<RooAbsPdf*>(*pdfSet)) {
         _pdfList.add(*thePdf) ;
@@ -601,7 +601,6 @@ void RooProdPdf::factorizeProduct(const RooArgSet& normSet, const RooArgSet& int
     if (!done) {
       if (!(pdfNormDeps.empty() && pdfAllDeps.empty() &&
        pdfIntSet.empty()) || normSet.empty()) {
-//    cout << GetName() << ": creating new term" << endl;
    term = new RooArgSet("term");
    termNormDeps = new RooArgSet("termNormDeps");
    depAllList.emplace_back(pdfAllDeps.begin(), pdfAllDeps.end(), "termAllDeps");
@@ -752,7 +751,6 @@ std::unique_ptr<RooProdPdf::CacheElem> RooProdPdf::createCacheElem(const RooArgS
     } else {
 //       cout<<"FK: Starting Composite Term"<<endl;
 
-      RooArgSet compTermSet, compTermNorm;
       for (auto const& term : group) {
 
    Int_t termIdx = terms.IndexOf(term);
@@ -792,23 +790,6 @@ std::unique_ptr<RooProdPdf::CacheElem> RooProdPdf::createCacheElem(const RooArgS
   // Find groups with y as termNSet
   // Replace G(y) with (G(y),ratio)
   for (auto const& group : groupedList) {
-    if (1 == group.size()) {
-      RooArgSet* term = group[0];
-
-      Int_t termIdx = terms.IndexOf(term);
-      norm = (RooArgSet*) norms.At(termIdx);
-      imps = (RooArgSet*) imp.At(termIdx);
-      RooArgSet termNSet(*norm), termImpSet(*imps);
-
-      // If termNset matches index of ratioTerms, insert ratio here
-      std::ostringstream str; termNSet.printValue(str);
-      if (!ratioTerms[str.str()].empty()) {
-//    cout << "MUST INSERT RATIO OBJECT IN TERM (SINGLE) " << *term << endl;
-      term->add(ratioTerms[str.str()]);
-      cache->_ownedList.addOwned(std::move(ratioTerms[str.str()]));
-      }
-    } else {
-      RooArgSet compTermSet, compTermNorm;
       for (auto const& term : group) {
    Int_t termIdx = terms.IndexOf(term);
    norm = (RooArgSet*) norms.At(termIdx);
@@ -823,7 +804,6 @@ std::unique_ptr<RooProdPdf::CacheElem> RooProdPdf::createCacheElem(const RooArgS
      cache->_ownedList.addOwned(std::move(ratioTerms[str.str()]));
    }
       }
-    }
   }
 
   for (auto const& group : groupedList) {
@@ -849,11 +829,6 @@ std::unique_ptr<RooProdPdf::CacheElem> RooProdPdf::createCacheElem(const RooArgS
         // Cross-imported integrated dependents
         termXSet.add(*xdeps);
         termImpSet.add(*imps);
-
-//       cout << GetName() << ": termISet = " << termISet << endl;
-//       cout << GetName() << ": termNSet = " << termNSet << endl;
-//       cout << GetName() << ": termXSet = " << termXSet << endl;
-//       cout << GetName() << ": termImpSet = " << termImpSet << endl;
 
         // Add prefab term to partIntList.
         bool isOwned(false);
@@ -889,12 +864,6 @@ std::unique_ptr<RooProdPdf::CacheElem> RooProdPdf::createCacheElem(const RooArgS
 
    // Remove outer integration dependents from termISet
    termISet.remove(outerIntDeps, true, true);
-//       cout << "termISet = "; termISet.Print("1");
-
-//    cout << GetName() << ": termISet = " << termISet << endl;
-//    cout << GetName() << ": termNSet = " << termNSet << endl;
-//    cout << GetName() << ": termXSet = " << termXSet << endl;
-//    cout << GetName() << ": termImpSet = " << termImpSet << endl;
 
    bool isOwned = false;
    vector<RooAbsReal*> func = processProductTerm(nset, iset, isetRangeName, term, termNSet, termISet, isOwned, true);
@@ -909,9 +878,6 @@ std::unique_ptr<RooProdPdf::CacheElem> RooProdPdf::createCacheElem(const RooArgS
      //cache->_numList.add(*func[1]);
      //cache->_denList.add(*func[2]);
 
-//      cout << "func[0]=" << func[0]->ClassName() << "::" << func[0]->GetName() << endl;
-//      cout << "func[1]=" << func[1]->ClassName() << "::" << func[1]->GetName() << endl;
-//      cout << "func[2]=" << func[2]->ClassName() << "::" << func[2]->GetName() << endl;
    }
       }
 
@@ -960,26 +926,6 @@ std::unique_ptr<RooProdPdf::CacheElem> RooProdPdf::createCacheElem(const RooArgS
       cache->_normList.emplace_back(compTermNorm.snapshot(false));
     }
   }
-
-  // WVE DEBUG PRINTING
-//   cout << "RooProdPdf::getPartIntList(" << GetName() << ") made cache " << cache << " with the following nset pointers ";
-//   TIterator* nliter = nsetList->MakeIterator();
-//   RooArgSet* ns;
-//   while((ns=(RooArgSet*)nliter->Next())) {
-//     cout << ns << " ";
-//   }
-//   cout << endl;
-//   delete nliter;
-
-//   cout << "   FOLKERT::RooProdPdf::getPartIntList END(" << GetName() <<")  nset = " << (nset?*nset:RooArgSet()) << endl
-//        << "   _normRange = " << _normRange << endl
-//        << "   iset = " << (iset?*iset:RooArgSet()) << endl
-//        << "   partList = ";
-//   if(partListPointer) partListPointer->Print();
-//   cout << "   nsetList = ";
-//   if(nsetListPointer) nsetListPointer->Print("");
-//   cout << "   code = " << returnCode << endl
-//        << "   isetRangeName = " << (isetRangeName?isetRangeName:"<null>") << endl;
 
   // Need to rearrange product in case of multiple ranges
   if (_normRange.Contains(",")) {
@@ -1388,7 +1334,7 @@ void RooProdPdf::groupProductTerms(std::list<std::vector<RooArgSet*>>& groupedTe
      newGroup->emplace_back(term2) ;
    }
 
-   // Remove this group from list and delete it (but not its contents)
+   // Remove this non-owning group from list
    group = groupedTerms.erase(group);
       } else {
         ++group;
@@ -1408,16 +1354,6 @@ std::vector<RooAbsReal*> RooProdPdf::processProductTerm(const RooArgSet* nset, c
                      const RooArgSet* term,const RooArgSet& termNSet, const RooArgSet& termISet,
                      bool& isOwned, bool forceWrap) const
 {
-//    cout << "   FOLKERT::RooProdPdf(" << GetName() <<") processProductTerm nset = " << (nset?*nset:RooArgSet()) << endl
-//          << "   _normRange = " << _normRange << endl
-//          << "   iset = " << (iset?*iset:RooArgSet()) << endl
-//          << "   isetRangeName = " << (isetRangeName?isetRangeName:"<null>") << endl
-//          << "   term = " << (term?*term:RooArgSet()) << endl
-//          << "   termNSet = " << termNSet << endl
-//          << "   termISet = " << termISet << endl
-//          << "   isOwned = " << isOwned << endl
-//          << "   forceWrap = " << forceWrap << endl ;
-
   vector<RooAbsReal*> ret(3) ; ret[0] = 0 ; ret[1] = 0 ; ret[2] = 0 ;
 
   // CASE I: factorizing term: term is integrated over all normalizing observables
@@ -2280,9 +2216,8 @@ bool RooProdPdf::redirectServersHook(const RooAbsCollection& newServerList, bool
         // Need to do some tricks here because it's not possible to replace in
         // an owning RooAbsCollection.
         normSet->releaseOwnership();
-        normSet->replace(*arg, *newArg->cloneTree());
+        normSet->replace(*std::unique_ptr<RooAbsArg>{arg}, *newArg->cloneTree());
         normSet->takeOwnership();
-        delete arg;
       }
     }
   }

--- a/roofit/roofitcore/src/RooRealMPFE.cxx
+++ b/roofit/roofitcore/src/RooRealMPFE.cxx
@@ -170,7 +170,7 @@ void RooRealMPFE::initVars()
   _saveVars.removeAll() ;
 
   // Retrieve non-constant parameters
-  RooArgSet* vars = _arg.arg().getParameters(RooArgSet()) ;
+  auto vars = _arg->getParameters(RooArgSet());
   //RooArgSet* ncVars = (RooArgSet*) vars->selectByAttrib("Constant",false) ;
   RooArgList varList(*vars) ;
 
@@ -182,9 +182,6 @@ void RooRealMPFE::initVars()
 
   // Force next calculation
   _forceCalc = true ;
-
-  delete vars ;
-  //delete ncVars ;
 }
 
 double RooRealMPFE::getCarry() const

--- a/roofit/roofitcore/src/RooSimultaneous.cxx
+++ b/roofit/roofitcore/src/RooSimultaneous.cxx
@@ -49,7 +49,6 @@ in each category.
 #include "RooSimultaneous.h"
 #include "RooAbsCategoryLValue.h"
 #include "RooPlot.h"
-#include "RooCurve.h"
 #include "RooRealVar.h"
 #include "RooAddPdf.h"
 #include "RooAbsData.h"
@@ -916,32 +915,6 @@ RooPlot* RooSimultaneous::plotOn(RooPlot *frame, RooLinkedList& cmdList) const
 
   return frame2 ;
 }
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// OBSOLETE -- Retained for backward compatibility
-
-RooPlot* RooSimultaneous::plotOn(RooPlot *frame, Option_t* drawOptions, double scaleFactor,
-             ScaleType stype, const RooAbsData* projData, const RooArgSet* projSet,
-             double /*precision*/, bool /*shiftToZero*/, const RooArgSet* /*projDataSet*/,
-             double /*rangeLo*/, double /*rangeHi*/, RooCurve::WingMode /*wmode*/) const
-{
-  // Make command list
-  RooLinkedList cmdList ;
-  cmdList.Add(new RooCmdArg(RooFit::DrawOption(drawOptions))) ;
-  cmdList.Add(new RooCmdArg(RooFit::Normalization(scaleFactor,stype))) ;
-  if (projData) cmdList.Add(new RooCmdArg(RooFit::ProjWData(*projData))) ;
-  if (projSet) cmdList.Add(new RooCmdArg(RooFit::Project(*projSet))) ;
-
-  // Call new method
-  RooPlot* ret = plotOn(frame,cmdList) ;
-
-  // Cleanup
-  cmdList.Delete() ;
-  return ret ;
-}
-
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooSimultaneous.cxx
+++ b/roofit/roofitcore/src/RooSimultaneous.cxx
@@ -696,7 +696,7 @@ RooPlot* RooSimultaneous::plotOn(RooPlot *frame, RooLinkedList& cmdList) const
     // Determine if any servers of the index category are in the projectedVars
     RooArgSet projIdxServers ;
     bool anyServers(false) ;
-    for (const auto server : _indexCat->servers()) {
+    for (const auto server : flattenedCatList()) {
       if (projectedVars.find(server->GetName())) {
         anyServers=true ;
         projIdxServers.add(*server) ;

--- a/roofit/roofitcore/src/RooVectorDataStore.cxx
+++ b/roofit/roofitcore/src/RooVectorDataStore.cxx
@@ -828,14 +828,15 @@ void RooVectorDataStore::cacheArgs(const RooAbsArg* owner, RooArgSet& newVarSet,
   RooAbsArg::setDirtyInhibit(true) ;
 
   std::vector<RooArgSet*> nsetList ;
-  std::vector<RooArgSet*> argObsList ;
+  std::vector<std::unique_ptr<RooArgSet>> argObsList ;
 
   // Now need to attach branch buffers of clones
   for (const auto arg : cloneSet) {
     arg->attachToVStore(*newCache) ;
 
-    RooArgSet* argObs = nset ? arg->getObservables(*nset) : arg->getVariables() ;
-    argObsList.push_back(argObs) ;
+    if(nset) argObsList.emplace_back(arg->getObservables(*nset));
+    else argObsList.emplace_back(arg->getVariables());
+    RooArgSet* argObs = argObsList.back().get();
 
     RooArgSet* normSet(0) ;
     const char* catNset = arg->getStringAttribute("CATNormSet") ;
@@ -903,11 +904,7 @@ void RooVectorDataStore::cacheArgs(const RooAbsArg* owner, RooArgSet& newVarSet,
 
   }
 
-
   for (auto set : vlist) {
-    delete set;
-  }
-  for (auto set : argObsList) {
     delete set;
   }
 

--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -718,7 +718,7 @@ bool RooWorkspace::import(const RooAbsArg& inArg,
 /// <tr><td> `RenameVariable(const char* inputName, const char* outputName)` <td> Change names of observables in dataset upon insertion
 /// <tr><td> `Silence` <td> Be quiet, except in case of errors
 /// \note From python, use `Import()`, since `import` is a reserved keyword.
-bool RooWorkspace::import(RooAbsData& inData,
+bool RooWorkspace::import(RooAbsData const& inData,
              const RooCmdArg& arg1, const RooCmdArg& arg2, const RooCmdArg& arg3,
              const RooCmdArg& arg4, const RooCmdArg& arg5, const RooCmdArg& arg6,
              const RooCmdArg& arg7, const RooCmdArg& arg8, const RooCmdArg& arg9)
@@ -1899,7 +1899,7 @@ bool RooWorkspace::makeDir()
 ///
 /// Returns true if an error has occurred.
 
-bool RooWorkspace::import(TObject& object, bool replaceExisting)
+bool RooWorkspace::import(TObject const& object, bool replaceExisting)
 {
   // First check if object with given name already exists
   std::unique_ptr<TObject> oldObj{_genObjects.FindObject(object.GetName())};
@@ -1939,7 +1939,7 @@ bool RooWorkspace::import(TObject& object, bool replaceExisting)
 ///
 /// Returns true if an error has occurred.
 
-bool RooWorkspace::import(TObject& object, const char* aliasName, bool replaceExisting)
+bool RooWorkspace::import(TObject const& object, const char* aliasName, bool replaceExisting)
 {
   // First check if object with given name already exists
   std::unique_ptr<TObject> oldObj{_genObjects.FindObject(object.GetName())};

--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -1942,10 +1942,10 @@ bool RooWorkspace::import(TObject const& object, bool replaceExisting)
 bool RooWorkspace::import(TObject const& object, const char* aliasName, bool replaceExisting)
 {
   // First check if object with given name already exists
-  std::unique_ptr<TObject> oldObj{_genObjects.FindObject(object.GetName())};
+  std::unique_ptr<TObject> oldObj{_genObjects.FindObject(aliasName)};
   if (oldObj && !replaceExisting) {
     coutE(InputArguments) << "RooWorkspace::import(" << GetName() << ") generic object with name "
-           << object.GetName() << " is already in workspace and replaceExisting flag is set to false" << endl ;
+           << aliasName << " is already in workspace and replaceExisting flag is set to false" << endl ;
     return true ;
   }
 

--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -223,6 +223,16 @@ RooWorkspace::RooWorkspace(const RooWorkspace& other) :
 }
 
 
+/// TObject::Clone() needs to be overridden.
+TObject *RooWorkspace::Clone(const char *newname) const
+{
+   auto out = new RooWorkspace{*this};
+   if(newname && std::string(newname) != GetName()) {
+      out->SetName(newname);
+   }
+   return out;
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Workspace destructor

--- a/roofit/roofitcore/test/TestStatistics/testInterface.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testInterface.cxx
@@ -43,9 +43,9 @@ TEST(Interface, createNLLRooAbsL)
    sigma->setConstant(true);
    RooAbsPdf *pdf = w.pdf("g");
    std::unique_ptr<RooDataSet> data{pdf->generate(*x, 10000)};
-   RooAbsReal *nll = pdf->createNLL(*data, RooFit::ModularL(true));
+   std::unique_ptr<RooAbsReal> nll{pdf->createNLL(*data, RooFit::ModularL(true))};
 
-   auto *nll_real = dynamic_cast<RooFit::TestStatistics::RooRealL *>(nll);
+   auto *nll_real = dynamic_cast<RooFit::TestStatistics::RooRealL *>(&*nll);
 
    EXPECT_TRUE(nll_real != nullptr);
 

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodJob.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodJob.cxx
@@ -163,7 +163,7 @@ TEST_F(LikelihoodJobBinnedDatasetTest, UnbinnedPdf)
 {
    data = pdf->generateBinned(*w.var("x"));
 
-   nll.reset(pdf->createNLL(*data));
+   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data)};
 
    likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data);
    auto nll_ts =
@@ -211,9 +211,9 @@ TEST_F(LikelihoodJobTest, SimBinned)
    w.factory("Uniform::u(x)");
 
    // Generate template histograms
-   RooDataHist *h_sigA = w.pdf("gA")->generateBinned(*w.var("x"), 1000);
-   RooDataHist *h_sigB = w.pdf("gB")->generateBinned(*w.var("x"), 1000);
-   RooDataHist *h_bkg = w.pdf("u")->generateBinned(*w.var("x"), 1000);
+   std::unique_ptr<RooDataHist> h_sigA{w.pdf("gA")->generateBinned(*w.var("x"), 1000)};
+   std::unique_ptr<RooDataHist> h_sigB{w.pdf("gB")->generateBinned(*w.var("x"), 1000)};
+   std::unique_ptr<RooDataHist> h_bkg{w.pdf("u")->generateBinned(*w.var("x"), 1000)};
 
    w.import(*h_sigA, RooFit::Rename("h_sigA"));
    w.import(*h_sigB, RooFit::Rename("h_sigB"));
@@ -237,7 +237,7 @@ TEST_F(LikelihoodJobTest, SimBinned)
    pdf = w.pdf("model");
    data = pdf->generate(RooArgSet(*w.var("x"), *w.cat("index")), RooFit::AllBinned());
 
-   nll.reset(pdf->createNLL(*data));
+   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data)};
 
    likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data);
    auto nll_ts =
@@ -260,8 +260,8 @@ TEST_F(LikelihoodJobTest, BinnedConstrained)
 
    // Generate template histograms
 
-   RooDataHist *h_sig = w.pdf("g")->generateBinned(*w.var("x"), 1000);
-   RooDataHist *h_bkg = w.pdf("u")->generateBinned(*w.var("x"), 1000);
+   std::unique_ptr<RooDataHist> h_sig{w.pdf("g")->generateBinned(*w.var("x"), 1000)};
+   std::unique_ptr<RooDataHist> h_bkg{w.pdf("u")->generateBinned(*w.var("x"), 1000)};
 
    w.import(*h_sig, RooFit::Rename("h_sig"));
    w.import(*h_bkg, RooFit::Rename("h_bkg"));
@@ -281,7 +281,7 @@ TEST_F(LikelihoodJobTest, BinnedConstrained)
    // Construct dataset from physics pdf
    data = w.pdf("model_phys")->generateBinned(*w.var("x"));
 
-   nll.reset(pdf->createNLL(*data, RooFit::GlobalObservables(*w.var("alpha_bkg_obs"))));
+   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data, RooFit::GlobalObservables(*w.var("alpha_bkg_obs")))};
 
    // --------
 
@@ -346,7 +346,7 @@ TEST_F(LikelihoodJobTest, SimUnbinnedNonExtended)
 
    pdf = w.pdf("model");
 
-   nll.reset(pdf->createNLL(*data));
+   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data)};
 
    likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data);
    auto nll_ts =
@@ -410,8 +410,8 @@ protected:
 TEST_F(LikelihoodJobSimBinnedConstrainedTest, BasicParameters)
 {
    // original test:
-   nll.reset(pdf->createNLL(
-      *data, RooFit::GlobalObservables(RooArgSet(*w.var("alpha_bkg_obs_A"), *w.var("alpha_bkg_obs_B")))));
+   nll = std::unique_ptr<RooAbsReal>{
+      pdf->createNLL(*data, RooFit::GlobalObservables(*w.var("alpha_bkg_obs_A"), *w.var("alpha_bkg_obs_B")))};
 
    // --------
 
@@ -431,8 +431,9 @@ TEST_F(LikelihoodJobSimBinnedConstrainedTest, BasicParameters)
 TEST_F(LikelihoodJobSimBinnedConstrainedTest, ConstrainedAndOffset)
 {
    // a variation to test some additional parameters (ConstrainedParameters and offsetting)
-   nll.reset(pdf->createNLL(*data, RooFit::Constrain(RooArgSet(*w.var("alpha_bkg_obs_A"))),
-                            RooFit::GlobalObservables(RooArgSet(*w.var("alpha_bkg_obs_B"))), RooFit::Offset(true)));
+   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data, RooFit::Constrain(*w.var("alpha_bkg_obs_A")),
+                                                    RooFit::GlobalObservables(*w.var("alpha_bkg_obs_B")),
+                                                    RooFit::Offset(true))};
 
    // --------
 
@@ -498,8 +499,9 @@ class LikelihoodJobSplitStrategies : public LikelihoodJobSimBinnedConstrainedTes
 TEST_P(LikelihoodJobSplitStrategies, SimBinnedConstrainedAndOffset)
 {
    // based on ConstrainedAndOffset, this test tests different parallelization strategies
-   nll.reset(pdf->createNLL(*data, RooFit::Constrain(RooArgSet(*w.var("alpha_bkg_obs_A"))),
-                            RooFit::GlobalObservables(RooArgSet(*w.var("alpha_bkg_obs_B"))), RooFit::Offset(true)));
+   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data, RooFit::Constrain(*w.var("alpha_bkg_obs_A")),
+                                                    RooFit::GlobalObservables(*w.var("alpha_bkg_obs_B")),
+                                                    RooFit::Offset(true))};
 
    // --------
 

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodSerial.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodSerial.cxx
@@ -133,7 +133,7 @@ TEST_F(LikelihoodSerialBinnedDatasetTest, UnbinnedPdf)
 {
    data = pdf->generateBinned(*w.var("x"));
 
-   nll.reset(pdf->createNLL(*data));
+   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data)};
 
    likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data);
    auto nll_ts = LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags);
@@ -205,7 +205,7 @@ TEST_F(LikelihoodSerialTest, SimBinned)
    pdf = w.pdf("model");
    data = pdf->generate(RooArgSet(*w.var("x"), *w.cat("index")), RooFit::AllBinned());
 
-   nll.reset(pdf->createNLL(*data));
+   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data)};
 
    likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data);
    auto nll_ts = LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags);
@@ -227,8 +227,8 @@ TEST_F(LikelihoodSerialTest, BinnedConstrained)
 
    // Generate template histograms
 
-   RooDataHist *h_sig = w.pdf("g")->generateBinned(*w.var("x"), 1000);
-   RooDataHist *h_bkg = w.pdf("u")->generateBinned(*w.var("x"), 1000);
+   std::unique_ptr<RooDataHist> h_sig{w.pdf("g")->generateBinned(*w.var("x"), 1000)};
+   std::unique_ptr<RooDataHist> h_bkg{w.pdf("u")->generateBinned(*w.var("x"), 1000)};
 
    w.import(*h_sig, RooFit::Rename("h_sig"));
    w.import(*h_bkg, RooFit::Rename("h_bkg"));
@@ -248,7 +248,7 @@ TEST_F(LikelihoodSerialTest, BinnedConstrained)
    // Construct dataset from physics pdf
    data = w.pdf("model_phys")->generateBinned(*w.var("x"));
 
-   nll.reset(pdf->createNLL(*data, RooFit::GlobalObservables(*w.var("alpha_bkg_obs"))));
+   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data, RooFit::GlobalObservables(*w.var("alpha_bkg_obs")))};
 
    // --------
 
@@ -276,7 +276,7 @@ TEST_F(LikelihoodSerialTest, SimUnbinned)
    // Construct dataset from physics pdf
    data = pdf->generate(RooArgSet(*w.var("x"), *w.cat("index")));
 
-   nll.reset(pdf->createNLL(*data));
+   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data)};
 
    // --------
 
@@ -311,7 +311,7 @@ TEST_F(LikelihoodSerialTest, SimUnbinnedNonExtended)
 
    pdf = w.pdf("model");
 
-   nll.reset(pdf->createNLL(*data));
+   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data)};
 
    likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data);
    auto nll_ts = LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::serial, likelihood, clean_flags);
@@ -374,8 +374,8 @@ protected:
 TEST_F(LikelihoodSerialSimBinnedConstrainedTest, BasicParameters)
 {
    // original test:
-   nll.reset(pdf->createNLL(
-      *data, RooFit::GlobalObservables(RooArgSet(*w.var("alpha_bkg_obs_A"), *w.var("alpha_bkg_obs_B")))));
+   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(
+      *data, RooFit::GlobalObservables(RooArgSet(*w.var("alpha_bkg_obs_A"), *w.var("alpha_bkg_obs_B"))))};
 
    // --------
 
@@ -394,8 +394,9 @@ TEST_F(LikelihoodSerialSimBinnedConstrainedTest, BasicParameters)
 TEST_F(LikelihoodSerialSimBinnedConstrainedTest, ConstrainedAndOffset)
 {
    // a variation to test some additional parameters (ConstrainedParameters and offsetting)
-   nll.reset(pdf->createNLL(*data, RooFit::Constrain(RooArgSet(*w.var("alpha_bkg_obs_A"))),
-                            RooFit::GlobalObservables(RooArgSet(*w.var("alpha_bkg_obs_B"))), RooFit::Offset(true)));
+   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data, RooFit::Constrain(RooArgSet(*w.var("alpha_bkg_obs_A"))),
+                                                    RooFit::GlobalObservables(RooArgSet(*w.var("alpha_bkg_obs_B"))),
+                                                    RooFit::Offset(true))};
 
    // --------
 

--- a/roofit/roofitcore/test/TestStatistics/testPlot.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testPlot.cxx
@@ -71,7 +71,7 @@ public:
       // --------------------------------------------------------------------------------
 
       // Creating a RooAbsL likelihood
-      RooAbsReal *likelihood = w.pdf("model")->createNLL(d, ModularL(true));
+      std::unique_ptr<RooAbsReal> likelihood{w.pdf("model")->createNLL(d, ModularL(true))};
 
       // Creating a minimizer and explicitly setting type of parallelization
       std::size_t nWorkers = 1;
@@ -84,6 +84,10 @@ public:
 
       // Minimize
       m.migrad();
+
+      // To reset the fitter. Otherwise, the fitter will point to a functor
+      // that points to the likelihood that will be deleted before.
+      m.cleanup();
 
       // C o n v e r t  t o  R o o R e a l L  a n d  p l o t
       // ---------------------------------------------------

--- a/roofit/roofitcore/test/testTestStatistics.cxx
+++ b/roofit/roofitcore/test/testTestStatistics.cxx
@@ -325,12 +325,11 @@ TEST(RooNLLVar, CopyRangedNLL)
 
    // This bug is related to the implementation details of the old test statistics, so BatchMode is forced to be off
    using namespace RooFit;
-   std::unique_ptr<RooNLLVar> nll{static_cast<RooNLLVar *>(model.createNLL(*ds, BatchMode("off")))};
-   std::unique_ptr<RooNLLVar> nllrange{
-      static_cast<RooNLLVar *>(model.createNLL(*ds, Range("fitrange"), BatchMode("off")))};
+   std::unique_ptr<RooAbsReal> nll{model.createNLL(*ds, BatchMode("off"))};
+   std::unique_ptr<RooAbsReal> nllrange{model.createNLL(*ds, Range("fitrange"), BatchMode("off"))};
 
-   auto nllClone = std::make_unique<RooNLLVar>(*nll);
-   auto nllrangeClone = std::make_unique<RooNLLVar>(*nllrange);
+   auto nllClone = std::make_unique<RooNLLVar>(static_cast<RooNLLVar &>(*nll));
+   auto nllrangeClone = std::make_unique<RooNLLVar>(static_cast<RooNLLVar &>(*nllrange));
 
    EXPECT_FLOAT_EQ(nll->getVal(), nllClone->getVal());
    EXPECT_FLOAT_EQ(nll->getVal(), nllrange->getVal());

--- a/roofit/roostats/inc/RooStats/BayesianCalculator.h
+++ b/roofit/roostats/inc/RooStats/BayesianCalculator.h
@@ -171,7 +171,7 @@ namespace RooStats {
       RooArgSet fGlobalObs;                      ///< global observables
 
       mutable RooAbsPdf* fProductPdf;            ///< internal pointer to model * prior
-      mutable RooAbsReal* fLogLike;              ///< internal pointer to log likelihood function
+      mutable std::unique_ptr<RooAbsReal> fLogLike; ///< internal pointer to log likelihood function
       mutable RooAbsReal* fLikelihood;           ///< internal pointer to likelihood function
       mutable RooAbsReal* fIntegratedLikelihood; ///< integrated likelihood function, i.e - unnormalized posterior function
       mutable RooAbsPdf* fPosteriorPdf;          ///< normalized (on the poi) posterior pdf
@@ -191,7 +191,7 @@ namespace RooStats {
 
    protected:
 
-      ClassDefOverride(BayesianCalculator,2)  // BayesianCalculator class
+      ClassDefOverride(BayesianCalculator,3)  // BayesianCalculator class
 
    };
 }

--- a/roofit/roostats/inc/RooStats/MaxLikelihoodEstimateTestStat.h
+++ b/roofit/roostats/inc/RooStats/MaxLikelihoodEstimateTestStat.h
@@ -82,7 +82,7 @@ class MaxLikelihoodEstimateTestStat: public TestStatistic {
     RooStats::RemoveConstantParameters(&*allParams);
 
     // need to call constrain for RooSimultaneous until stripDisconnected problem fixed
-    RooAbsReal* nll = fPdf->createNLL(data, RooFit::CloneData(false),RooFit::Constrain(*allParams),RooFit::ConditionalObservables(fConditionalObs));
+    std::unique_ptr<RooAbsReal> nll{fPdf->createNLL(data, RooFit::CloneData(false),RooFit::Constrain(*allParams),RooFit::ConditionalObservables(fConditionalObs))};
 
     //RooAbsReal* nll = fPdf->createNLL(data, RooFit::CloneData(false));
 
@@ -91,9 +91,6 @@ class MaxLikelihoodEstimateTestStat: public TestStatistic {
     // RooArgSet* vars = profile->getVariables();
     // RooMsgService::instance().setGlobalKillBelow(msglevel);
     // double ret = vars->getRealValue(fParameter->GetName());
-    // delete vars;
-    // delete nll;
-    // delete profile;
     // return ret;
 
 
@@ -123,7 +120,6 @@ class MaxLikelihoodEstimateTestStat: public TestStatistic {
      //allParams->Print("V");
 
      RooMsgService::instance().setGlobalKillBelow(msglevel);
-     delete nll;
 
      if (status != 0) return -1;
      return fParameter->getVal();

--- a/roofit/roostats/inc/RooStats/MaxLikelihoodEstimateTestStat.h
+++ b/roofit/roostats/inc/RooStats/MaxLikelihoodEstimateTestStat.h
@@ -78,8 +78,8 @@ class MaxLikelihoodEstimateTestStat: public TestStatistic {
     return ret;
     */
 
-    RooArgSet* allParams = fPdf->getParameters(data);
-    RooStats::RemoveConstantParameters(allParams);
+    std::unique_ptr<RooArgSet> allParams{fPdf->getParameters(data)};
+    RooStats::RemoveConstantParameters(&*allParams);
 
     // need to call constrain for RooSimultaneous until stripDisconnected problem fixed
     RooAbsReal* nll = fPdf->createNLL(data, RooFit::CloneData(false),RooFit::Constrain(*allParams),RooFit::ConditionalObservables(fConditionalObs));

--- a/roofit/roostats/inc/RooStats/ProfileLikelihoodCalculator.h
+++ b/roofit/roostats/inc/RooStats/ProfileLikelihoodCalculator.h
@@ -61,7 +61,7 @@ namespace RooStats {
     void DoReset() const;
 
     /// perform a global fit
-    RooAbsReal * DoGlobalFit() const;
+    RooFit::OwningPtr<RooAbsReal> DoGlobalFit() const;
 
     /// minimize likelihood
     static RooFitResult * DoMinimizeNLL(RooAbsReal * nll);

--- a/roofit/roostats/inc/RooStats/ProfileLikelihoodTestStat.h
+++ b/roofit/roostats/inc/RooStats/ProfileLikelihoodTestStat.h
@@ -35,7 +35,6 @@ namespace RooStats {
      ProfileLikelihoodTestStat() {
         // Proof constructor. Do not use.
         fPdf = nullptr;
-        fNll = nullptr;
         fCachedBestFitParams = nullptr;
         fLastData = nullptr;
         fLimitType = twoSided;
@@ -54,7 +53,6 @@ namespace RooStats {
 
      ProfileLikelihoodTestStat(RooAbsPdf& pdf) {
        fPdf = &pdf;
-       fNll = nullptr;
        fCachedBestFitParams = nullptr;
        fLastData = nullptr;
        fLimitType = twoSided;
@@ -73,7 +71,6 @@ namespace RooStats {
      }
 
      ~ProfileLikelihoodTestStat() override {
-       if(fNll) delete fNll;
        if(fCachedBestFitParams) delete fCachedBestFitParams;
        if(fDetailedOutput) delete fDetailedOutput;
      }
@@ -139,7 +136,7 @@ namespace RooStats {
    private:
 
       RooAbsPdf* fPdf;
-      RooAbsReal* fNll; //!
+      std::unique_ptr<RooAbsReal> fNll; //!
       const RooArgSet* fCachedBestFitParams;
       RooAbsData* fLastData;
       //      double fLastMLE;

--- a/roofit/roostats/inc/RooStats/SimpleLikelihoodRatioTestStat.h
+++ b/roofit/roostats/inc/RooStats/SimpleLikelihoodRatioTestStat.h
@@ -34,8 +34,6 @@ namespace RooStats {
          fNullParameters = nullptr;
          fAltParameters = nullptr;
          fReuseNll=false ;
-         fNllNull=nullptr ;
-         fNllAlt=nullptr ;
       }
 
       /// Takes null and alternate parameters from PDF. Can be overridden.
@@ -58,8 +56,6 @@ namespace RooStats {
          fDetailedOutput = nullptr;
 
          fReuseNll=false ;
-         fNllNull=nullptr ;
-         fNllAlt=nullptr ;
       }
 
       /// Takes null and alternate parameters from values in nullParameters
@@ -82,15 +78,11 @@ namespace RooStats {
          fDetailedOutput = nullptr;
 
          fReuseNll=false ;
-         fNllNull=nullptr ;
-         fNllAlt=nullptr ;
       }
 
       ~SimpleLikelihoodRatioTestStat() override {
          if (fNullParameters) delete fNullParameters;
          if (fAltParameters) delete fAltParameters;
-         if (fNllNull) delete fNllNull ;
-         if (fNllAlt) delete fNllAlt ;
          if (fDetailedOutput) delete fDetailedOutput;
       }
 
@@ -158,8 +150,8 @@ namespace RooStats {
       bool fDetailedOutputEnabled;
       RooArgSet* fDetailedOutput; ///<!
 
-      RooAbsReal* fNllNull ;  ///<! transient copy of the null NLL
-      RooAbsReal* fNllAlt ;   ///<!  transient copy of the alt NLL
+      std::unique_ptr<RooAbsReal> fNllNull; ///<! transient copy of the null NLL
+      std::unique_ptr<RooAbsReal> fNllAlt;  ///<!  transient copy of the alt NLL
       static bool fgAlwaysReuseNll ;
       bool fReuseNll ;
 

--- a/roofit/roostats/inc/RooStats/SimpleLikelihoodRatioTestStat.h
+++ b/roofit/roostats/inc/RooStats/SimpleLikelihoodRatioTestStat.h
@@ -48,13 +48,11 @@ namespace RooStats {
          fNullPdf = &nullPdf;
          fAltPdf = &altPdf;
 
-         RooArgSet * allNullVars = fNullPdf->getVariables();
+         std::unique_ptr<RooArgSet> allNullVars{fNullPdf->getVariables()};
          fNullParameters = (RooArgSet*) allNullVars->snapshot();
-         delete allNullVars;
 
-         RooArgSet * allAltVars = fAltPdf->getVariables();
+         std::unique_ptr<RooArgSet> allAltVars{fAltPdf->getVariables()};
          fAltParameters = (RooArgSet*) allAltVars->snapshot();
-         delete allAltVars;
 
          fDetailedOutputEnabled = false;
          fDetailedOutput = nullptr;

--- a/roofit/roostats/inc/RooStats/ToyMCImportanceSampler.h
+++ b/roofit/roostats/inc/RooStats/ToyMCImportanceSampler.h
@@ -111,7 +111,7 @@ class ToyMCImportanceSampler: public ToyMCSampler {
 
          fNullDensities.push_back( p );
          fNullSnapshots.push_back( s );
-         fNullNLLs.push_back( nullptr );
+         fNullNLLs.emplace_back( nullptr );
          ClearCache();
       }
       /// overwrite from ToyMCSampler
@@ -190,8 +190,8 @@ class ToyMCImportanceSampler: public ToyMCSampler {
 
       toysStrategies fToysStrategy;
 
-      mutable std::vector<RooAbsReal*> fNullNLLs;    ///<!
-      mutable std::vector<RooAbsReal*> fImpNLLs;     ///<!
+      mutable std::vector<std::unique_ptr<RooAbsReal>> fNullNLLs;    ///<!
+      mutable std::vector<std::unique_ptr<RooAbsReal>> fImpNLLs;     ///<!
 
    protected:
    ClassDefOverride(ToyMCImportanceSampler,2) // An implementation of importance sampling

--- a/roofit/roostats/src/AsymptoticCalculator.cxx
+++ b/roofit/roostats/src/AsymptoticCalculator.cxx
@@ -176,8 +176,8 @@ bool AsymptoticCalculator::Initialize() const {
 
    // keep snapshot for the initial parameter values (need for nominal Asimov)
    RooArgSet nominalParams;
-   RooArgSet * allParams = nullPdf->getParameters(data);
-   RemoveConstantParameters(allParams);
+   std::unique_ptr<RooArgSet> allParams{nullPdf->getParameters(data)};
+   RemoveConstantParameters(&*allParams);
    if (fNominalAsimov) {
       allParams->snapshot(nominalParams);
    }
@@ -197,7 +197,6 @@ bool AsymptoticCalculator::Initialize() const {
       oocoutP(nullptr,Eval) << "Best fitted POI value = " << muBest->getVal() << " +/- " << muBest->getError() << std::endl;
    // keep snapshot of all best fit parameters
    allParams->snapshot(fBestFitParams);
-   delete allParams;
 
    // compute Asimov data set for the background (alt poi ) value
    const RooArgSet * altSnapshot = GetAlternateModel()->GetSnapshot();
@@ -295,8 +294,8 @@ double AsymptoticCalculator::EvaluateNLL(RooAbsPdf & pdf, RooAbsData& data,   co
     if (verbose < 2) RooMsgService::instance().setGlobalKillBelow(RooFit::FATAL);
 
 
-    RooArgSet* allParams = pdf.getParameters(data);
-    RooStats::RemoveConstantParameters(allParams);
+    std::unique_ptr<RooArgSet> allParams{pdf.getParameters(data)};
+    RooStats::RemoveConstantParameters(&*allParams);
     // add constraint terms for all non-constant parameters
 
     RooArgSet conditionalObs;
@@ -309,7 +308,7 @@ double AsymptoticCalculator::EvaluateNLL(RooAbsPdf & pdf, RooAbsData& data,   co
     RooAbsReal* nll = pdf.createNLL(data, RooFit::CloneData(false),RooFit::Constrain(*allParams),RooFit::ConditionalObservables(conditionalObs), RooFit::GlobalObservables(globalObs),
         RooFit::Offset(config.useLikelihoodOffset));
 
-    RooArgSet* attachedSet = nll->getVariables();
+    std::unique_ptr<RooArgSet> attachedSet{nll->getVariables()};
 
     // if poi are specified - do a conditional fit
     RooArgSet paramsSetConstant;
@@ -351,7 +350,6 @@ double AsymptoticCalculator::EvaluateNLL(RooAbsPdf & pdf, RooAbsData& data,   co
     //check if needed to skip the fit
     RooArgSet nllParams(*attachedSet);
     RooStats::RemoveConstantParameters(&nllParams);
-    delete attachedSet;
     bool skipFit = (nllParams.empty());
 
     if (skipFit)
@@ -457,7 +455,6 @@ double AsymptoticCalculator::EvaluateNLL(RooAbsPdf & pdf, RooAbsData& data,   co
 
     if (verbose < 2) RooMsgService::instance().setGlobalKillBelow(msglevel);
 
-    delete allParams;
     delete nll;
 
     return val;
@@ -507,9 +504,8 @@ HypoTestResult* AsymptoticCalculator::GetHypoTest() const {
       oocoutW(nullptr,InputArguments) << "AsymptoticCalculator::GetHypoTest: snapshot has more than one POI - assume as POI first parameter " << std::endl;
    }
 
-   RooArgSet * allParams = nullPdf->getParameters(*GetData() );
+   std::unique_ptr<RooArgSet> allParams{nullPdf->getParameters(*GetData() )};
    allParams->assign(fBestFitParams);
-   delete allParams;
 
    // set the one-side condition
    // (this works when we have only one params of interest
@@ -1311,8 +1307,8 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(RooAbsData & realData, const M
    SetAllConstant(paramsSetConstant, false);
 
 
-   RooArgSet *  allParams = model.GetPdf()->getParameters(realData);
-   RooStats::RemoveConstantParameters( allParams );
+   std::unique_ptr<RooArgSet> allParams{model.GetPdf()->getParameters(realData)};
+   RooStats::RemoveConstantParameters( &*allParams );
 
    // if a RooArgSet of poi is passed , different poi will be used for generating the Asimov data set
    if (genPoiValues) {
@@ -1321,12 +1317,7 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(RooAbsData & realData, const M
 
    // now do the actual generation of the AsimovData Set
    // no need to pass parameters values since we have set them before
-   RooAbsData * asimovData =  MakeAsimovData(model, *allParams, asimovGlobObs);
-
-   delete allParams;
-
-   return asimovData;
-
+   return MakeAsimovData(model, *allParams, asimovGlobObs);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1348,9 +1339,8 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(const ModelConfig & model, con
    // set the parameter values (do I need the poi to be constant ? )
    // the nuisance parameter values could be set at their fitted value (the MLE)
    if (!allParamValues.empty()) {
-      RooArgSet *  allVars = model.GetPdf()->getVariables();
+      std::unique_ptr<RooArgSet> allVars{model.GetPdf()->getVariables()};
       allVars->assign(allParamValues);
-      delete allVars;
    }
 
 

--- a/roofit/roostats/src/AsymptoticCalculator.cxx
+++ b/roofit/roostats/src/AsymptoticCalculator.cxx
@@ -305,8 +305,8 @@ double AsymptoticCalculator::EvaluateNLL(RooAbsPdf & pdf, RooAbsData& data,   co
 
     // need to call constrain for RooSimultaneous until stripDisconnected problem fixed
     auto& config = GetGlobalRooStatsConfig();
-    RooAbsReal* nll = pdf.createNLL(data, RooFit::CloneData(false),RooFit::Constrain(*allParams),RooFit::ConditionalObservables(conditionalObs), RooFit::GlobalObservables(globalObs),
-        RooFit::Offset(config.useLikelihoodOffset));
+    std::unique_ptr<RooAbsReal> nll{pdf.createNLL(data, RooFit::CloneData(false),RooFit::Constrain(*allParams),RooFit::ConditionalObservables(conditionalObs), RooFit::GlobalObservables(globalObs),
+        RooFit::Offset(config.useLikelihoodOffset))};
 
     std::unique_ptr<RooArgSet> attachedSet{nll->getVariables()};
 
@@ -454,8 +454,6 @@ double AsymptoticCalculator::EvaluateNLL(RooAbsPdf & pdf, RooAbsData& data,   co
 
 
     if (verbose < 2) RooMsgService::instance().setGlobalKillBelow(msglevel);
-
-    delete nll;
 
     return val;
 }

--- a/roofit/roostats/src/BayesianCalculator.cxx
+++ b/roofit/roostats/src/BayesianCalculator.cxx
@@ -489,7 +489,7 @@ public:
 
       ooccoutI(nullptr,InputArguments) << "PosteriorFunctionFromToyMC::Pdf used for randomizing the nuisance is " << fPdf->GetName() << std::endl;
       // check that pdf contains  the nuisance
-      RooArgSet * vars = fPdf->getVariables();
+      std::unique_ptr<RooArgSet> vars{fPdf->getVariables()};
       for (int i = 0; i < fNuisParams.getSize(); ++i) {
          if (!vars->find( fNuisParams[i].GetName() ) ) {
             ooccoutW(nullptr,InputArguments) << "Nuisance parameter " << fNuisParams[i].GetName()
@@ -497,7 +497,6 @@ public:
                                                  << "they will be treated as constant " << std::endl;
          }
       }
-      delete vars;
 
       if (!fRedoToys) {
          ooccoutI(nullptr,InputArguments) << "PosteriorFunctionFromToyMC::Generate nuisance toys only one time (for all POI points)" << std::endl;
@@ -799,9 +798,9 @@ RooAbsReal* BayesianCalculator::GetPosteriorFunction() const
    }
 
 
-   RooArgSet* constrainedParams = fPdf->getParameters(*fData);
+   std::unique_ptr<RooArgSet> constrainedParams{fPdf->getParameters(*fData)};
    // remove the constant parameters
-   RemoveConstantParameters(constrainedParams);
+   RemoveConstantParameters(&*constrainedParams);
 
    //constrainedParams->Print("V");
 
@@ -866,8 +865,6 @@ RooAbsReal* BayesianCalculator::GetPosteriorFunction() const
 
    delete nllFunc;
 
-   delete constrainedParams;
-
 
    if ( fNuisanceParameters.empty() ||  fIntegrationType.Contains("ROOFIT") ) {
 
@@ -898,11 +895,10 @@ RooAbsReal* BayesianCalculator::GetPosteriorFunction() const
          pdfAndPrior = fProductPdf;
       }
 
-      RooArgSet* constrParams = fPdf->getParameters(*fData);
+      std::unique_ptr<RooArgSet> constrParams{fPdf->getParameters(*fData)};
       // remove the constant parameters
-      RemoveConstantParameters(constrParams);
+      RemoveConstantParameters(&*constrParams);
       fLogLike = pdfAndPrior->createNLL(*fData, RooFit::Constrain(*constrParams),RooFit::ConditionalObservables(fConditionalObs),RooFit::GlobalObservables(fGlobalObs) );
-      delete constrParams;
 
       TString likeName = TString("likelihood_times_prior_") + TString(pdfAndPrior->GetName());
       TString formula;

--- a/roofit/roostats/src/BayesianCalculator.cxx
+++ b/roofit/roostats/src/BayesianCalculator.cxx
@@ -644,7 +644,7 @@ BayesianCalculator::BayesianCalculator() :
    fPdf(0),
    fPriorPdf(0),
    fNuisancePdf(0),
-   fProductPdf (0), fLogLike(0), fLikelihood (0), fIntegratedLikelihood (0), fPosteriorPdf(0),
+   fProductPdf (0), fLikelihood (0), fIntegratedLikelihood (0), fPosteriorPdf(0),
    fPosteriorFunction(0), fApproxPosterior(0),
    fLower(0), fUpper(0),
    fNLLMin(0),
@@ -672,7 +672,7 @@ BayesianCalculator::BayesianCalculator( /* const char* name,  const char* title,
    fPOI(POI),
    fPriorPdf(&priorPdf),
    fNuisancePdf(0),
-   fProductPdf (0), fLogLike(0), fLikelihood (0), fIntegratedLikelihood (0), fPosteriorPdf(0),
+   fProductPdf (0), fLikelihood (0), fIntegratedLikelihood (0), fPosteriorPdf(0),
    fPosteriorFunction(0), fApproxPosterior(0),
    fLower(0), fUpper(0),
    fNLLMin(0),
@@ -698,7 +698,7 @@ BayesianCalculator::BayesianCalculator( RooAbsData& data,
    fPdf(model.GetPdf()),
    fPriorPdf( model.GetPriorPdf()),
    fNuisancePdf(0),
-   fProductPdf (0), fLogLike(0), fLikelihood (0), fIntegratedLikelihood (0), fPosteriorPdf(0),
+   fProductPdf (0), fLikelihood (0), fIntegratedLikelihood (0), fPosteriorPdf(0),
    fPosteriorFunction(0), fApproxPosterior(0),
    fLower(0), fUpper(0),
    fNLLMin(0),
@@ -723,7 +723,7 @@ BayesianCalculator::~BayesianCalculator()
 
 void BayesianCalculator::ClearAll() const {
    if (fProductPdf) delete fProductPdf;
-   if (fLogLike) delete fLogLike;
+   fLogLike.reset();
    if (fLikelihood) delete fLikelihood;
    if (fIntegratedLikelihood) delete fIntegratedLikelihood;
    if (fPosteriorPdf) delete fPosteriorPdf;
@@ -732,7 +732,6 @@ void BayesianCalculator::ClearAll() const {
    fPosteriorPdf = 0;
    fPosteriorFunction = 0;
    fProductPdf = 0;
-   fLogLike = 0;
    fLikelihood = 0;
    fIntegratedLikelihood = 0;
    fLower = 0;
@@ -805,7 +804,7 @@ RooAbsReal* BayesianCalculator::GetPosteriorFunction() const
    //constrainedParams->Print("V");
 
    // use RooFit::Constrain() to be sure constraints terms are taken into account
-   fLogLike = fPdf->createNLL(*fData, RooFit::Constrain(*constrainedParams), RooFit::ConditionalObservables(fConditionalObs), RooFit::GlobalObservables(fGlobalObs) );
+   fLogLike = std::unique_ptr<RooAbsReal>{fPdf->createNLL(*fData, RooFit::Constrain(*constrainedParams), RooFit::ConditionalObservables(fConditionalObs), RooFit::GlobalObservables(fGlobalObs) )};
 
 
 
@@ -880,7 +879,7 @@ RooAbsReal* BayesianCalculator::GetPosteriorFunction() const
 #else
       // here use RooProdPdf (not very nice) but working
 
-      if (fLogLike) delete fLogLike;
+      if (fLogLike) fLogLike.reset();
       if (fProductPdf) {
          delete fProductPdf;
          fProductPdf = 0;
@@ -898,7 +897,7 @@ RooAbsReal* BayesianCalculator::GetPosteriorFunction() const
       std::unique_ptr<RooArgSet> constrParams{fPdf->getParameters(*fData)};
       // remove the constant parameters
       RemoveConstantParameters(&*constrParams);
-      fLogLike = pdfAndPrior->createNLL(*fData, RooFit::Constrain(*constrParams),RooFit::ConditionalObservables(fConditionalObs),RooFit::GlobalObservables(fGlobalObs) );
+      fLogLike = std::unique_ptr<RooAbsReal>{pdfAndPrior->createNLL(*fData, RooFit::Constrain(*constrParams),RooFit::ConditionalObservables(fConditionalObs),RooFit::GlobalObservables(fGlobalObs) )};
 
       TString likeName = TString("likelihood_times_prior_") + TString(pdfAndPrior->GetName());
       TString formula;

--- a/roofit/roostats/src/FeldmanCousins.cxx
+++ b/roofit/roostats/src/FeldmanCousins.cxx
@@ -171,8 +171,8 @@ void FeldmanCousins::CreateParameterPoints() const{
     // make profile construction
     RooFit::MsgLevel previous  = RooMsgService::instance().globalKillBelow();
     RooMsgService::instance().setGlobalKillBelow(RooFit::FATAL) ;
-    RooAbsReal* nll = pdf->createNLL(fData,RooFit::CloneData(false));
-    RooAbsReal* profile = nll->createProfile(*fModel.GetParametersOfInterest());
+    std::unique_ptr<RooAbsReal> nll{pdf->createNLL(fData,RooFit::CloneData(false))};
+    std::unique_ptr<RooAbsReal> profile{nll->createProfile(*fModel.GetParametersOfInterest())};
 
     RooDataSet* profileConstructionPoints = new RooDataSet("profileConstruction",
                         "profileConstruction",
@@ -186,8 +186,6 @@ void FeldmanCousins::CreateParameterPoints() const{
       profileConstructionPoints->add(*parameters);
     }
     RooMsgService::instance().setGlobalKillBelow(previous) ;
-    delete profile;
-    delete nll;
     if(!fPOIToTest) delete parameterScan;
 
     // done

--- a/roofit/roostats/src/FrequentistCalculator.cxx
+++ b/roofit/roostats/src/FrequentistCalculator.cxx
@@ -56,8 +56,8 @@ int FrequentistCalculator::PreNullHook(RooArgSet *parameterPoint, double obsTest
    // ****** any TestStatSampler ********
 
    // create profile keeping everything but nuisance parameters fixed
-   RooArgSet * allParams = fNullModel->GetPdf()->getParameters(*fData);
-   RemoveConstantParameters(allParams);
+   std::unique_ptr<RooArgSet> allParams{fNullModel->GetPdf()->getParameters(*fData)};
+   RemoveConstantParameters(&*allParams);
 
    // note: making nll or profile class variables can only be done in the constructor
    // as all other hooks are const (which has to be because GetHypoTest is const). However,
@@ -132,8 +132,6 @@ int FrequentistCalculator::PreNullHook(RooArgSet *parameterPoint, double obsTest
    if(fNullModel->GetNuisanceParameters())
       parameterPoint->add(*fNullModel->GetNuisanceParameters());
 
-   delete allParams;
-
 
    // ***** ToyMCSampler specific *******
 
@@ -173,8 +171,8 @@ int FrequentistCalculator::PreAltHook(RooArgSet *parameterPoint, double obsTestS
    // ****** any TestStatSampler ********
 
    // create profile keeping everything but nuisance parameters fixed
-   RooArgSet * allParams = fAltModel->GetPdf()->getParameters(*fData);
-   RemoveConstantParameters(allParams);
+   std::unique_ptr<RooArgSet> allParams{fAltModel->GetPdf()->getParameters(*fData)};
+   RemoveConstantParameters(&*allParams);
 
    bool doProfile = true;
    RooArgSet allButNuisance(*allParams);
@@ -243,8 +241,6 @@ int FrequentistCalculator::PreAltHook(RooArgSet *parameterPoint, double obsTestS
    // add nuisance parameters to parameter point
    if(fAltModel->GetNuisanceParameters())
       parameterPoint->add(*fAltModel->GetNuisanceParameters());
-
-   delete allParams;
 
    // ***** ToyMCSampler specific *******
 

--- a/roofit/roostats/src/FrequentistCalculator.cxx
+++ b/roofit/roostats/src/FrequentistCalculator.cxx
@@ -94,11 +94,11 @@ int FrequentistCalculator::PreNullHook(RooArgSet *parameterPoint, double obsTest
       if (fNullModel->GetGlobalObservables()) globalObs.add(*fNullModel->GetGlobalObservables());
 
       auto& config = GetGlobalRooStatsConfig();
-      RooAbsReal* nll = fNullModel->GetPdf()->createNLL(*const_cast<RooAbsData*>(fData), RooFit::CloneData(false), RooFit::Constrain(*allParams),
+      std::unique_ptr<RooAbsReal> nll{fNullModel->GetPdf()->createNLL(*const_cast<RooAbsData*>(fData), RooFit::CloneData(false), RooFit::Constrain(*allParams),
                                                         RooFit::GlobalObservables(globalObs),
                                                         RooFit::ConditionalObservables(conditionalObs),
-                                                        RooFit::Offset(config.useLikelihoodOffset));
-      RooProfileLL* profile = dynamic_cast<RooProfileLL*>(nll->createProfile(allButNuisance));
+                                                        RooFit::Offset(config.useLikelihoodOffset))};
+      std::unique_ptr<RooProfileLL> profile{dynamic_cast<RooProfileLL*>(nll->createProfile(allButNuisance))};
       // set minimier options
       profile->minimizer()->setPrintLevel(ROOT::Math::MinimizerOptions::DefaultPrintLevel()-1);
       profile->getVal(); // this will do fit and set nuisance parameters to profiled values
@@ -112,8 +112,6 @@ int FrequentistCalculator::PreNullHook(RooArgSet *parameterPoint, double obsTest
          delete result;
       }
 
-      delete profile;
-      delete nll;
       RooMsgService::instance().setGlobalKillBelow(msglevel);
 
       // set in test statistics conditional and global observables
@@ -203,12 +201,12 @@ int FrequentistCalculator::PreAltHook(RooArgSet *parameterPoint, double obsTestS
       if (fAltModel->GetGlobalObservables()) globalObs.add(*fAltModel->GetGlobalObservables());
 
       const auto& config = GetGlobalRooStatsConfig();
-      RooAbsReal* nll = fAltModel->GetPdf()->createNLL(*const_cast<RooAbsData*>(fData), RooFit::CloneData(false), RooFit::Constrain(*allParams),
+      std::unique_ptr<RooAbsReal> nll{fAltModel->GetPdf()->createNLL(*const_cast<RooAbsData*>(fData), RooFit::CloneData(false), RooFit::Constrain(*allParams),
                                                        RooFit::GlobalObservables(globalObs),
                                                        RooFit::ConditionalObservables(conditionalObs),
-                                                       RooFit::Offset(config.useLikelihoodOffset));
+                                                       RooFit::Offset(config.useLikelihoodOffset))};
 
-      RooProfileLL* profile = dynamic_cast<RooProfileLL*>(nll->createProfile(allButNuisance));
+      std::unique_ptr<RooProfileLL> profile{dynamic_cast<RooProfileLL*>(nll->createProfile(allButNuisance))};
       // set minimizer options
       profile->minimizer()->setPrintLevel(ROOT::Math::MinimizerOptions::DefaultPrintLevel()-1); // use -1 to make more silent
       profile->getVal(); // this will do fit and set nuisance parameters to profiled values
@@ -222,8 +220,6 @@ int FrequentistCalculator::PreAltHook(RooArgSet *parameterPoint, double obsTestS
          delete result;
       }
 
-      delete profile;
-      delete nll;
       RooMsgService::instance().setGlobalKillBelow(msglevel);
 
       // set in test statistics conditional and global observables

--- a/roofit/roostats/src/HypoTestCalculatorGeneric.cxx
+++ b/roofit/roostats/src/HypoTestCalculatorGeneric.cxx
@@ -128,10 +128,9 @@ HypoTestResult* HypoTestCalculatorGeneric::GetHypoTest() const {
    }
 
    // get a big list of all variables for convenient switching
-   RooArgSet *nullParams = fNullModel->GetPdf()->getParameters(*fData);
-   RooArgSet *altParams = fAltModel->GetPdf()->getParameters(*fData);
+   std::unique_ptr<RooArgSet> altParams{fAltModel->GetPdf()->getParameters(*fData)};
    // save all parameters so we can set them back to what they were
-   RooArgSet *bothParams = fNullModel->GetPdf()->getParameters(*fData);
+   std::unique_ptr<RooArgSet> bothParams{fNullModel->GetPdf()->getParameters(*fData)};
    bothParams->add(*altParams,false);
    RooArgSet *saveAll = (RooArgSet*) bothParams->snapshot();
 
@@ -244,10 +243,7 @@ HypoTestResult* HypoTestCalculatorGeneric::GetHypoTest() const {
 
    bothParams->assign(*saveAll);
    delete allTS;
-   delete bothParams;
    delete saveAll;
-   delete altParams;
-   delete nullParams;
    delete nullSnapshot;
    PostHook();
    return res;

--- a/roofit/roostats/src/HypoTestInverter.cxx
+++ b/roofit/roostats/src/HypoTestInverter.cxx
@@ -144,7 +144,7 @@ void HypoTestInverter::CheckInputModels(const HypoTestCalculatorGeneric &hc,cons
       oocoutE(nullptr,InputArguments) << "HypoTestInverter - B model has no pdf or observables defined" <<  std::endl;
       return;
    }
-   RooArgSet * bParams = bPdf->getParameters(*bObs);
+   std::unique_ptr<RooArgSet> bParams{bPdf->getParameters(*bObs)};
    if (!bParams) {
       oocoutE(nullptr,InputArguments) << "HypoTestInverter - pdf of B model has no parameters" << std::endl;
       return;
@@ -158,7 +158,6 @@ void HypoTestInverter::CheckInputModels(const HypoTestCalculatorGeneric &hc,cons
                                              << " user must check input model configurations " << endl;
       if (poiB) delete poiB;
    }
-   delete bParams;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1167,7 +1166,7 @@ SamplingDistribution * HypoTestInverter::RebuildDistributions(bool isUpper, int 
    // save all parameters to restore them later
    assert(bModel->GetPdf() );
    assert(bModel->GetObservables() );
-   RooArgSet * allParams = bModel->GetPdf()->getParameters( *bModel->GetObservables() );
+   std::unique_ptr<RooArgSet> allParams{bModel->GetPdf()->getParameters( *bModel->GetObservables() )};
    RooArgSet saveParams;
    allParams->snapshot(saveParams);
 

--- a/roofit/roostats/src/LikelihoodInterval.cxx
+++ b/roofit/roostats/src/LikelihoodInterval.cxx
@@ -129,7 +129,7 @@ bool LikelihoodInterval::IsInInterval(const RooArgSet &parameterPoint) const
 
 
   // set parameters
-  SetParameters(&parameterPoint, fLikelihoodRatio->getVariables() );
+  SetParameters(&parameterPoint, std::unique_ptr<RooArgSet>{fLikelihoodRatio->getVariables()}.get());
 
 
   // evaluate likelihood ratio, see if it's bigger than threshold
@@ -227,12 +227,11 @@ bool LikelihoodInterval::CreateMinimizer() {
    // bind the nll function in the right interface for the Minimizer class
    // as a function of only the parameters (poi + nuisance parameters)
 
-   RooArgSet * partmp = profilell->getVariables();
+   std::unique_ptr<RooArgSet> partmp{profilell->getVariables()};
    // need to remove constant parameters
-   RemoveConstantParameters(partmp);
+   RemoveConstantParameters(&*partmp);
 
    RooArgList params(*partmp);
-   delete partmp;
 
    // need to restore values and errors for POI
    if (fBestFitParams) {
@@ -311,10 +310,9 @@ bool LikelihoodInterval::FindLimits(const RooRealVar & param, double &lower, dou
    }
 
 
-   RooArgSet * partmp = fLikelihoodRatio->getVariables();
-   RemoveConstantParameters(partmp);
+   std::unique_ptr<RooArgSet> partmp{fLikelihoodRatio->getVariables()};
+   RemoveConstantParameters(&*partmp);
    RooArgList params(*partmp);
-   delete partmp;
    int ix = params.index(&param);
    if (ix < 0 ) {
       ccoutE(InputArguments) << "Error - invalid parameter " << param.GetName() << " specified for finding the interval limits " << std::endl;
@@ -375,10 +373,9 @@ Int_t LikelihoodInterval::GetContourPoints(const RooRealVar & paramX, const RooR
    // check the parameters
    // variable index in minimizer
    // is index in the RooArgList obtained from the profileLL variables
-   RooArgSet * partmp = fLikelihoodRatio->getVariables();
-   RemoveConstantParameters(partmp);
+   std::unique_ptr<RooArgSet> partmp{fLikelihoodRatio->getVariables()};
+   RemoveConstantParameters(&*partmp);
    RooArgList params(*partmp);
-   delete partmp;
    int ix = params.index(&paramX);
    int iy = params.index(&paramY);
    if (ix < 0 || iy < 0) {

--- a/roofit/roostats/src/MCMCCalculator.cxx
+++ b/roofit/roostats/src/MCMCCalculator.cxx
@@ -171,7 +171,7 @@ MCMCInterval* MCMCCalculator::GetInterval() const
    }
 
    std::unique_ptr<RooArgSet> constrainedParams{prodPdf->getParameters(*fData)};
-   RooAbsReal* nll = prodPdf->createNLL(*fData, Constrain(*constrainedParams),ConditionalObservables(fConditionalObs),GlobalObservables(fGlobalObs));
+   std::unique_ptr<RooAbsReal> nll{prodPdf->createNLL(*fData, Constrain(*constrainedParams),ConditionalObservables(fConditionalObs),GlobalObservables(fGlobalObs))};
 
    std::unique_ptr<RooArgSet> params{nll->getParameters(*fData)};
    RemoveConstantParameters(&*params);
@@ -215,7 +215,6 @@ MCMCInterval* MCMCCalculator::GetInterval() const
 
    if (useDefaultPropFunc) delete fPropFunc;
    if (usePriorPdf) delete prodPdf;
-   delete nll;
 
    return interval;
 }

--- a/roofit/roostats/src/MCMCCalculator.cxx
+++ b/roofit/roostats/src/MCMCCalculator.cxx
@@ -170,18 +170,17 @@ MCMCInterval* MCMCCalculator::GetInterval() const
       prodPdf = new RooProdPdf(prodName,prodName,RooArgList(*fPdf,*fPriorPdf) );
    }
 
-   RooArgSet* constrainedParams = prodPdf->getParameters(*fData);
+   std::unique_ptr<RooArgSet> constrainedParams{prodPdf->getParameters(*fData)};
    RooAbsReal* nll = prodPdf->createNLL(*fData, Constrain(*constrainedParams),ConditionalObservables(fConditionalObs),GlobalObservables(fGlobalObs));
-   delete constrainedParams;
 
-   RooArgSet* params = nll->getParameters(*fData);
-   RemoveConstantParameters(params);
+   std::unique_ptr<RooArgSet> params{nll->getParameters(*fData)};
+   RemoveConstantParameters(&*params);
    if (fNumBins > 0) {
       SetBins(*params, fNumBins);
       SetBins(fPOI, fNumBins);
       if (dynamic_cast<PdfProposal*>(fPropFunc)) {
-         RooArgSet* proposalVars = ((PdfProposal*)fPropFunc)->GetPdf()->
-                                               getParameters((RooAbsData*)nullptr);
+         std::unique_ptr<RooArgSet> proposalVars{((PdfProposal*)fPropFunc)->GetPdf()->
+                                               getParameters((RooAbsData*)nullptr)};
          SetBins(*proposalVars, fNumBins);
       }
    }
@@ -217,7 +216,6 @@ MCMCInterval* MCMCCalculator::GetInterval() const
    if (useDefaultPropFunc) delete fPropFunc;
    if (usePriorPdf) delete prodPdf;
    delete nll;
-   delete params;
 
    return interval;
 }

--- a/roofit/roostats/src/ProfileInspector.cxx
+++ b/roofit/roostats/src/ProfileInspector.cxx
@@ -93,8 +93,8 @@ TList* ProfileInspector::GetListOfProfilePlots( RooAbsData& data, RooStats::Mode
     return 0;
   }
 
-  RooAbsReal* nll = pdf->createNLL(data);
-  RooAbsReal* profile = nll->createProfile(*poi);
+  std::unique_ptr<RooAbsReal> nll{pdf->createNLL(data)};
+  std::unique_ptr<RooAbsReal> profile{nll->createProfile(*poi)};
 
   TList * list = new TList;
   Int_t curve_N=100;
@@ -140,8 +140,5 @@ TList* ProfileInspector::GetListOfProfilePlots( RooAbsData& data, RooStats::Mode
 
   delete [] curve_x;
 
-
-  delete nll;
-  delete profile;
   return list;
 }

--- a/roofit/roostats/src/ProfileLikelihoodCalculator.cxx
+++ b/roofit/roostats/src/ProfileLikelihoodCalculator.cxx
@@ -131,9 +131,9 @@ RooAbsReal *  ProfileLikelihoodCalculator::DoGlobalFit() const {
    if (!data || !pdf ) return 0;
 
    // get all non-const parameters
-   RooArgSet* constrainedParams = pdf->getParameters(*data);
+   std::unique_ptr<RooArgSet> constrainedParams{pdf->getParameters(*data)};
    if (!constrainedParams) return 0;
-   RemoveConstantParameters(constrainedParams);
+   RemoveConstantParameters(&*constrainedParams);
 
    const auto& config = GetGlobalRooStatsConfig();
    RooAbsReal * nll = pdf->createNLL(*data, CloneData(true), Constrain(*constrainedParams),ConditionalObservables(fConditionalObs), GlobalObservables(fGlobalObs),
@@ -141,7 +141,6 @@ RooAbsReal *  ProfileLikelihoodCalculator::DoGlobalFit() const {
 
    // check if global fit has been already done
    if (fFitResult && fGlobalFitDone) {
-      delete constrainedParams;
       return nll;
    }
 
@@ -161,7 +160,6 @@ RooAbsReal *  ProfileLikelihoodCalculator::DoGlobalFit() const {
          fGlobalFitDone = true;
    }
 
-   delete constrainedParams;
    return nll;
 }
 
@@ -226,10 +224,10 @@ LikelihoodInterval* ProfileLikelihoodCalculator::GetInterval() const {
 //    RooAbsData* data = fWS->data(fDataName);
    RooAbsPdf * pdf = GetPdf();
    RooAbsData* data = GetData();
-   if (!data || !pdf || fPOI.empty()) return 0;
+   if (!data || !pdf || fPOI.empty()) return nullptr;
 
-   RooArgSet* constrainedParams = pdf->getParameters(*data);
-   RemoveConstantParameters(constrainedParams);
+   std::unique_ptr<RooArgSet> constrainedParams{pdf->getParameters(*data)};
+   RemoveConstantParameters(&*constrainedParams);
 
 
    /*
@@ -284,7 +282,6 @@ LikelihoodInterval* ProfileLikelihoodCalculator::GetInterval() const {
    // and bestPOI contains a snapshot with the best fit values
    LikelihoodInterval* interval = new LikelihoodInterval(name, profile, &fPOI, bestPOI);
    interval->SetConfidenceLevel(1.-fSize);
-   delete constrainedParams;
    return interval;
 }
 
@@ -324,8 +321,8 @@ HypoTestResult* ProfileLikelihoodCalculator::GetHypoTest() const {
       return 0;
    }
 
-   RooArgSet* constrainedParams = pdf->getParameters(*data);
-   RemoveConstantParameters(constrainedParams);
+   std::unique_ptr<RooArgSet> constrainedParams{pdf->getParameters(*data)};
+   RemoveConstantParameters(&*constrainedParams);
 
    double nLLatMLE = fFitResult->minNll();
    // in case of using offset need to save offset value
@@ -408,7 +405,6 @@ HypoTestResult* ProfileLikelihoodCalculator::GetHypoTest() const {
       }
    }
 
-   delete constrainedParams;
    delete nll;
    return htr;
 

--- a/roofit/roostats/src/ProfileLikelihoodTestStat.cxx
+++ b/roofit/roostats/src/ProfileLikelihoodTestStat.cxx
@@ -84,8 +84,8 @@ double RooStats::ProfileLikelihoodTestStat::EvaluateProfileLikelihood(int type, 
 
        bool created(false) ;
        if (!reuse || fNll==0) {
-          RooArgSet* allParams = fPdf->getParameters(data);
-          RooStats::RemoveConstantParameters(allParams);
+          std::unique_ptr<RooArgSet> allParams{fPdf->getParameters(data)};
+          RooStats::RemoveConstantParameters(&*allParams);
 
           // need to call constrain for RooSimultaneous until stripDisconnected problem fixed
           fNll = fPdf->createNLL(data, RooFit::CloneData(false),RooFit::Constrain(*allParams),
@@ -94,7 +94,6 @@ double RooStats::ProfileLikelihoodTestStat::EvaluateProfileLikelihood(int type, 
           if (fPrintLevel > 0 && fLOffset) cout << "ProfileLikelihoodTestStat::Evaluate - Use Offset in creating NLL " << endl ;
 
           created = true ;
-          delete allParams;
           if (fPrintLevel > 1) cout << "creating NLL " << fNll << " with data = " << &data << endl ;
        }
        if (reuse && !created) {
@@ -109,7 +108,7 @@ double RooStats::ProfileLikelihoodTestStat::EvaluateProfileLikelihood(int type, 
 
 
        // make sure we set the variables attached to this nll
-       RooArgSet* attachedSet = fNll->getVariables();
+       std::unique_ptr<RooArgSet> attachedSet{fNll->getVariables()};
 
        attachedSet->assign(paramsOfInterest);
        RooArgSet* origAttachedSet = (RooArgSet*) attachedSet->snapshot();
@@ -272,7 +271,6 @@ double RooStats::ProfileLikelihoodTestStat::EvaluateProfileLikelihood(int type, 
        // need to restore the values ?
        attachedSet->assign(*origAttachedSet);
 
-       delete attachedSet;
        delete origAttachedSet;
        delete snap;
 

--- a/roofit/roostats/src/SPlot.cxx
+++ b/roofit/roostats/src/SPlot.cxx
@@ -423,10 +423,10 @@ void SPlot::AddSWeight( RooAbsPdf* pdf, const RooArgList &yieldsTmp,
 
   // Find Parameters in the PDF to be considered fixed when calculating the SWeights
   // and be sure to NOT include the yields in that list
-  RooArgList* constParameters = (RooArgList*)pdf->getParameters(fSData) ;
+  std::unique_ptr<RooArgSet> constParameters{pdf->getParameters(fSData)};
   for (unsigned int i=0; i < constParameters->size(); ++i) {
     // Need a counting loop since collection is being modified
-    auto& par = (*constParameters)[i];
+    auto& par = *(*constParameters)[i];
     if (std::any_of(yieldsTmp.begin(), yieldsTmp.end(), [&](const RooAbsArg* yield){ return yield->dependsOn(par); })) {
       constParameters->remove(par, true, true);
       --i;
@@ -440,7 +440,7 @@ void SPlot::AddSWeight( RooAbsPdf* pdf, const RooArgList &yieldsTmp,
 
   for(Int_t i = 0; i < constParameters->getSize(); i++)
   {
-    RooAbsRealLValue* varTemp = static_cast<RooAbsRealLValue*>( constParameters->at(i) );
+    RooAbsRealLValue* varTemp = static_cast<RooAbsRealLValue*>( (*constParameters)[i] );
     if(varTemp &&  varTemp->isConstant() == 0 )
     {
       varTemp->setConstant();
@@ -531,7 +531,7 @@ void SPlot::AddSWeight( RooAbsPdf* pdf, const RooArgList &yieldsTmp,
   // and all others to 0.  Evaluate the pdf for each event
   // and store the values.
 
-  RooArgSet * pdfvars = pdf->getVariables();
+  std::unique_ptr<RooArgSet> pdfvars{pdf->getVariables()};
   std::vector<std::vector<double> > pdfvalues(numevents,std::vector<double>(nspec,0)) ;
 
   for (Int_t ievt = 0; ievt <numevents; ievt++)
@@ -553,7 +553,6 @@ void SPlot::AddSWeight( RooAbsPdf* pdf, const RooArgList &yieldsTmp,
       theVar->setVal( 0 ) ;
     }
   }
-  delete pdfvars;
 
   // check that the likelihood normalization is fine
   std::vector<double> norm(nspec,0) ;

--- a/roofit/roostats/src/SimpleLikelihoodRatioTestStat.cxx
+++ b/roofit/roostats/src/SimpleLikelihoodRatioTestStat.cxx
@@ -50,9 +50,8 @@ double RooStats::SimpleLikelihoodRatioTestStat::Evaluate(RooAbsData& data, RooAr
 
    bool created = false ;
    if (!fNllNull) {
-      RooArgSet* allParams = fNullPdf->getParameters(data);
+      std::unique_ptr<RooArgSet> allParams{fNullPdf->getParameters(data)};
       fNllNull = fNullPdf->createNLL(data, RooFit::CloneData(false),RooFit::Constrain(*allParams),RooFit::GlobalObservables(fGlobalObs),RooFit::ConditionalObservables(fConditionalObs));
-      delete allParams;
       created = true ;
    }
    if (reuse && !created) {
@@ -60,7 +59,7 @@ double RooStats::SimpleLikelihoodRatioTestStat::Evaluate(RooAbsData& data, RooAr
    }
 
    // make sure we set the variables attached to this nll
-   RooArgSet* attachedSet = fNllNull->getVariables();
+   std::unique_ptr<RooArgSet> attachedSet{fNllNull->getVariables()};
    attachedSet->assign(*fNullParameters);
    attachedSet->assign(nullPOI);
    double nullNLL = fNllNull->getVal();
@@ -72,20 +71,18 @@ double RooStats::SimpleLikelihoodRatioTestStat::Evaluate(RooAbsData& data, RooAr
    if (!reuse) {
       delete fNllNull ; fNllNull = nullptr ;
    }
-   delete attachedSet;
 
    created = false ;
    if (!fNllAlt) {
-      RooArgSet* allParams = fAltPdf->getParameters(data);
+      std::unique_ptr<RooArgSet> allParams{fAltPdf->getParameters(data)};
       fNllAlt = fAltPdf->createNLL(data, RooFit::CloneData(false),RooFit::Constrain(*allParams),RooFit::GlobalObservables(fGlobalObs),RooFit::ConditionalObservables(fConditionalObs));
-      delete allParams;
       created = true ;
    }
    if (reuse && !created) {
       fNllAlt->setData(data, false) ;
    }
    // make sure we set the variables attached to this nll
-   attachedSet = fNllAlt->getVariables();
+   attachedSet = std::unique_ptr<RooArgSet>{fNllAlt->getVariables()};
    attachedSet->assign(*fAltParameters);
    double altNLL = fNllAlt->getVal();
 
@@ -99,7 +96,6 @@ double RooStats::SimpleLikelihoodRatioTestStat::Evaluate(RooAbsData& data, RooAr
    if (!reuse) {
       delete fNllAlt ; fNllAlt = nullptr ;
    }
-   delete attachedSet;
 
 
 

--- a/roofit/roostats/src/SimpleLikelihoodRatioTestStat.cxx
+++ b/roofit/roostats/src/SimpleLikelihoodRatioTestStat.cxx
@@ -51,7 +51,8 @@ double RooStats::SimpleLikelihoodRatioTestStat::Evaluate(RooAbsData& data, RooAr
    bool created = false ;
    if (!fNllNull) {
       std::unique_ptr<RooArgSet> allParams{fNullPdf->getParameters(data)};
-      fNllNull = fNullPdf->createNLL(data, RooFit::CloneData(false),RooFit::Constrain(*allParams),RooFit::GlobalObservables(fGlobalObs),RooFit::ConditionalObservables(fConditionalObs));
+      using namespace RooFit;
+      fNllNull = std::unique_ptr<RooAbsReal>{fNullPdf->createNLL(data, CloneData(false), Constrain(*allParams), GlobalObservables(fGlobalObs), ConditionalObservables(fConditionalObs))};
       created = true ;
    }
    if (reuse && !created) {
@@ -69,13 +70,14 @@ double RooStats::SimpleLikelihoodRatioTestStat::Evaluate(RooAbsData& data, RooAr
 
 
    if (!reuse) {
-      delete fNllNull ; fNllNull = nullptr ;
+      fNllNull.reset();
    }
 
    created = false ;
    if (!fNllAlt) {
       std::unique_ptr<RooArgSet> allParams{fAltPdf->getParameters(data)};
-      fNllAlt = fAltPdf->createNLL(data, RooFit::CloneData(false),RooFit::Constrain(*allParams),RooFit::GlobalObservables(fGlobalObs),RooFit::ConditionalObservables(fConditionalObs));
+      using namespace RooFit;
+      fNllAlt = std::unique_ptr<RooAbsReal>{fAltPdf->createNLL(data, CloneData(false), Constrain(*allParams), GlobalObservables(fGlobalObs), ConditionalObservables(fConditionalObs))};
       created = true ;
    }
    if (reuse && !created) {
@@ -94,7 +96,7 @@ double RooStats::SimpleLikelihoodRatioTestStat::Evaluate(RooAbsData& data, RooAr
 
 
    if (!reuse) {
-      delete fNllAlt ; fNllAlt = nullptr ;
+      fNllAlt.reset();
    }
 
 

--- a/roofit/roostats/src/ToyMCImportanceSampler.cxx
+++ b/roofit/roostats/src/ToyMCImportanceSampler.cxx
@@ -44,8 +44,8 @@ ToyMCImportanceSampler::~ToyMCImportanceSampler() {
 void ToyMCImportanceSampler::ClearCache(void) {
    ToyMCSampler::ClearCache();
 
-   for( unsigned int i=0; i < fImpNLLs.size(); i++ ) if(fImpNLLs[i]) { delete fImpNLLs[i]; fImpNLLs[i] = nullptr; }
-   for( unsigned int i=0; i < fNullNLLs.size(); i++ ) if(fNullNLLs[i]) { delete fNullNLLs[i]; fNullNLLs[i] = nullptr; }
+   for( unsigned int i=0; i < fImpNLLs.size(); i++ ) { fImpNLLs[i].reset(); }
+   for( unsigned int i=0; i < fNullNLLs.size(); i++ ) { fNullNLLs[i].reset(); }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -358,14 +358,14 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
       allVars->assign(*fNullSnapshots[i]);
       if( !fNullNLLs[i] ) {
          std::unique_ptr<RooArgSet> allParams{fNullDensities[i]->getParameters(*data)};
-         fNullNLLs[i] = fNullDensities[i]->createNLL(*data, RooFit::CloneData(false), RooFit::Constrain(*allParams),
-                                                     RooFit::ConditionalObservables(fConditionalObs));
+         fNullNLLs[i] = std::unique_ptr<RooAbsReal>{fNullDensities[i]->createNLL(*data, RooFit::CloneData(false), RooFit::Constrain(*allParams),
+                                                     RooFit::ConditionalObservables(fConditionalObs))};
       }else{
          fNullNLLs[i]->setData( *data, false );
       }
       nullNLLVals[i] = fNullNLLs[i]->getVal();
       // FOR DEBuGGING!!!!!!!!!!!!!!!!!
-      if( !fReuseNLL ) { delete fNullNLLs[i]; fNullNLLs[i] = nullptr; }
+      if( !fReuseNLL ) { fNullNLLs[i].reset(); }
    }
 
 
@@ -383,14 +383,14 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
       }
       if( !fImpNLLs[i] ) {
          std::unique_ptr<RooArgSet> allParams{fImportanceDensities[i]->getParameters(*data)};
-         fImpNLLs[i] = fImportanceDensities[i]->createNLL(*data, RooFit::CloneData(false), RooFit::Constrain(*allParams),
-                                                          RooFit::ConditionalObservables(fConditionalObs));
+         fImpNLLs[i] = std::unique_ptr<RooAbsReal>{fImportanceDensities[i]->createNLL(*data, RooFit::CloneData(false), RooFit::Constrain(*allParams),
+                                                          RooFit::ConditionalObservables(fConditionalObs))};
       }else{
          fImpNLLs[i]->setData( *data, false );
       }
       impNLLVals[i] = fImpNLLs[i]->getVal();
       // FOR DEBuGGING!!!!!!!!!!!!!!!!!
-      if( !fReuseNLL ) { delete fImpNLLs[i]; fImpNLLs[i] = nullptr; }
+      if( !fReuseNLL ) { fImpNLLs[i].reset(); }
 
       for( unsigned int j=0; j < nullNLLVals.size(); j++ ) {
          if( impNLLVals[i] < minNLLVals[j] ) minNLLVals[j] = impNLLVals[i];

--- a/roofit/roostats/src/ToyMCImportanceSampler.cxx
+++ b/roofit/roostats/src/ToyMCImportanceSampler.cxx
@@ -281,7 +281,7 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
 
 
    // assign input paramPoint
-   RooArgSet* allVars = fPdf->getVariables();
+   std::unique_ptr<RooArgSet> allVars{fPdf->getVariables()};
    allVars->assign(paramPoint);
 
 
@@ -300,9 +300,8 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
    // save values to restore later.
    // but this must remain after(!) generating global observables
    if( !fGenerateFromNull ) {
-      RooArgSet* allVarsImpDens = fImportanceDensities[fIndexGenDensity]->getVariables();
+      std::unique_ptr<RooArgSet> allVarsImpDens{fImportanceDensities[fIndexGenDensity]->getVariables()};
       allVars->add(*allVarsImpDens);
-      delete allVarsImpDens;
    }
    const RooArgSet* saveVars = (const RooArgSet*)allVars->snapshot();
 
@@ -358,10 +357,9 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
 
       allVars->assign(*fNullSnapshots[i]);
       if( !fNullNLLs[i] ) {
-         RooArgSet* allParams = fNullDensities[i]->getParameters(*data);
+         std::unique_ptr<RooArgSet> allParams{fNullDensities[i]->getParameters(*data)};
          fNullNLLs[i] = fNullDensities[i]->createNLL(*data, RooFit::CloneData(false), RooFit::Constrain(*allParams),
                                                      RooFit::ConditionalObservables(fConditionalObs));
-         delete allParams;
       }else{
          fNullNLLs[i]->setData( *data, false );
       }
@@ -384,10 +382,9 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
         allVars->assign(*fImportanceSnapshots[i]);
       }
       if( !fImpNLLs[i] ) {
-         RooArgSet* allParams = fImportanceDensities[i]->getParameters(*data);
+         std::unique_ptr<RooArgSet> allParams{fImportanceDensities[i]->getParameters(*data)};
          fImpNLLs[i] = fImportanceDensities[i]->createNLL(*data, RooFit::CloneData(false), RooFit::Constrain(*allParams),
                                                           RooFit::ConditionalObservables(fConditionalObs));
-         delete allParams;
       }else{
          fImpNLLs[i]->setData( *data, false );
       }
@@ -420,7 +417,6 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
 
 
    allVars->assign(*saveVars);
-   delete allVars;
    delete saveVars;
 
    return data;

--- a/roofit/xroofit/src/xRooNLLVar.cxx
+++ b/roofit/xroofit/src/xRooNLLVar.cxx
@@ -344,7 +344,7 @@ void xRooNLLVar::reinitialize()
       }
    }
 
-   fFuncVars.reset(std::shared_ptr<RooAbsReal>::get()->getVariables());
+   fFuncVars = std::unique_ptr<RooArgSet>{std::shared_ptr<RooAbsReal>::get()->getVariables()};
    if (fGlobs) {
       fFuncGlobs.reset(fFuncVars->selectCommon(*fGlobs));
       fFuncGlobs->setAttribAll("Constant", true);

--- a/roofit/xroofit/src/xRooNLLVar.cxx
+++ b/roofit/xroofit/src/xRooNLLVar.cxx
@@ -323,7 +323,7 @@ void xRooNLLVar::reinitialize()
       std::set<std::string> attribs;
       if (std::shared_ptr<RooAbsReal>::get())
          attribs = std::shared_ptr<RooAbsReal>::get()->attributes();
-      this->reset(fPdf->createNLL(*fData, *fOpts));
+      this->reset(std::unique_ptr<RooAbsReal>{fPdf->createNLL(*fData, *fOpts)}.release());
       // RooFit only swaps in what it calls parameters, this misses out the RooConstVars which we treat as pars as well
       // so swap those in ... question: is recursiveRedirectServers usage in RooAbsOptTestStatic (and here) a memory
       // leak?? where do the replaced servers get deleted??

--- a/roofit/xroofit/src/xRooNode.cxx
+++ b/roofit/xroofit/src/xRooNode.cxx
@@ -5746,8 +5746,8 @@ public:
       RooAbsPdf *clonePdf = dynamic_cast<RooAbsPdf *>(cloneFunc);
       RooArgSet *errorParams = cloneFunc->getObservables(fpf_stripped);
 
-      RooArgSet *nset =
-         nset_in.getSize() == 0 ? cloneFunc->getParameters(*errorParams) : cloneFunc->getObservables(nset_in);
+      std::unique_ptr<RooArgSet> nset =
+         nset_in.empty() ? std::unique_ptr<RooArgSet>{cloneFunc->getParameters(*errorParams)} : std::unique_ptr<RooArgSet>{cloneFunc->getObservables(nset_in)};
 
       // Make list of parameter instances of cloneFunc in order of error matrix
       RooArgList paramList;
@@ -5776,13 +5776,13 @@ public:
 
          // Make Plus variation
          ((RooRealVar *)paramList.at(ivar))->setVal(cenVal + errVal);
-         plusVar.push_back((fExpectedEventsMode ? 1. : cloneFunc->getVal(nset)) *
-                           (clonePdf ? clonePdf->expectedEvents(nset) : 1.));
+         plusVar.push_back((fExpectedEventsMode ? 1. : cloneFunc->getVal(&*nset)) *
+                           (clonePdf ? clonePdf->expectedEvents(&*nset) : 1.));
 
          // Make Minus variation
          ((RooRealVar *)paramList.at(ivar))->setVal(cenVal - errVal);
-         minusVar.push_back((fExpectedEventsMode ? 1. : cloneFunc->getVal(nset)) *
-                            (clonePdf ? clonePdf->expectedEvents(nset) : 1.));
+         minusVar.push_back((fExpectedEventsMode ? 1. : cloneFunc->getVal(&*nset)) *
+                            (clonePdf ? clonePdf->expectedEvents(&*nset) : 1.));
 
          ((RooRealVar *)paramList.at(ivar))->setVal(cenVal);
       }
@@ -5808,7 +5808,6 @@ public:
 
       delete cloneFunc;
       delete errorParams;
-      delete nset;
 
       return sqrt(sum);
    }

--- a/test/fit/WrapperRooPdf.h
+++ b/test/fit/WrapperRooPdf.h
@@ -23,22 +23,20 @@ public:
    WrapperRooPdf(RooAbsPdf * pdf, const std::string xvar = "x", bool norm = true) :
       fNorm(norm),
       fPdf(pdf),
-      fX(0),
-      fParams(nullptr)
+      fX(0)
    {
       assert(fPdf != nullptr);
 
-      RooArgSet *vars = fPdf->getVariables();
+      std::unique_ptr<RooArgSet> vars{fPdf->getVariables()};
       RooAbsArg * arg = vars->find(xvar.c_str());  // code should abort if not found
       if (!arg) std::cout <<"Error - observable " << xvar << "is not in the list of pdf variables" << std::endl;
       assert(arg != nullptr);
       RooArgSet obsList(*arg);
       //arg.setDirtyInhibit(true); // do have faster setter of values
       fX = fPdf->getObservables(obsList);
-      fParams = fPdf->getParameters(obsList);
+      fParams = std::unique_ptr<RooArgSet>{fPdf->getParameters(obsList)};
       assert(fX != nullptr);
       assert(fParams != nullptr);
-      delete vars;
 #ifdef DEBUG
       fX->Print("v");
       fParams->Print("v");
@@ -54,13 +52,12 @@ public:
    WrapperRooPdf(RooAbsPdf * pdf, const RooArgSet & obsList, bool norm = true ) :
       fNorm(norm),
       fPdf(pdf),
-      fX(nullptr),
-      fParams(nullptr)
+      fX(nullptr)
    {
       assert(fPdf != nullptr);
 
       fX = fPdf->getObservables(obsList);
-      fParams = fPdf->getParameters(obsList);
+      fParams = std::unique_ptr<RooArgSet>{fPdf->getParameters(obsList)};
       assert(fX != nullptr);
       assert(fParams != nullptr);
 #ifdef DEBUG
@@ -81,7 +78,6 @@ public:
    ~WrapperRooPdf() override {
       // need to delete observables and parameter list
       if (fX) delete fX;
-      if (fParams) delete fParams;
    }
 
    /**
@@ -204,7 +200,7 @@ private:
    bool fNorm;
    mutable RooAbsPdf * fPdf;
    mutable RooArgSet * fX;
-   mutable RooArgSet * fParams;
+   mutable std::unique_ptr<RooArgSet> fParams;
    mutable std::vector<double> fParamValues;
 
 

--- a/test/fit/testRooFit.cxx
+++ b/test/fit/testRooFit.cxx
@@ -238,9 +238,8 @@ int  FitUsingRooFit(TTree & tree, RooAbsPdf & pdf, RooArgSet & xvars) {
    w.Stop();
 
    std::cout << "RooFit result " << std::endl;
-   RooArgSet * params = pdf.getParameters(xvars);
+   std::unique_ptr<RooArgSet> params{pdf.getParameters(xvars)};
    params->Print("v");
-   delete params;
 
 
    std::cout << "\nTime: \t" << w.RealTime() << " , " << w.CpuTime() << std::endl;

--- a/test/stressHistFactory_tests.cxx
+++ b/test/stressHistFactory_tests.cxx
@@ -383,8 +383,8 @@ private:
     const Int_t iSamplingPoints = 100;
 
     // get variables
-    RooArgSet* pVars1 = rPDF1.getVariables();
-    RooArgSet* pVars2 = rPDF2.getVariables();
+    std::unique_ptr<RooArgSet> pVars1{rPDF1.getVariables()};
+    std::unique_ptr<RooArgSet> pVars2{rPDF2.getVariables()};
 
     if(!CompareParameters(*pVars1,*pVars2))
     {

--- a/test/stressRooStats_tests.h
+++ b/test/stressRooStats_tests.h
@@ -354,9 +354,8 @@ public:
       w->var("y")->setVal(fObsValueY);
       w->data("data")->add(*model->GetObservables());
 
-      const RooArgSet * initialVariables = model->GetPdf()->getVariables();
+      std::unique_ptr<RooArgSet> initialVariables{model->GetPdf()->getVariables()};
       w->saveSnapshot("initialVariables",*initialVariables);
-      delete initialVariables;
 
       // build likelihood interval with ProfileLikelihoodCalculator
       ProfileLikelihoodCalculator *plc = new ProfileLikelihoodCalculator(*w->data("data"), *model);
@@ -876,9 +875,8 @@ public:
       w->var("y")->setVal(fObsValueY);
       w->data("data")->add(*model->GetObservables());
 
-      const RooArgSet * initialVariables = model->GetPdf()->getVariables();
+      std::unique_ptr<RooArgSet> initialVariables{model->GetPdf()->getVariables()};
       w->saveSnapshot("initialVariables",*initialVariables);
-      delete initialVariables;
 
       // NOTE: Roo1DIntegrator is too slow and gives poor results
 #ifdef R__HAS_MATHMORE
@@ -1004,9 +1002,8 @@ public:
       w->var("y")->setVal(fObsValueY);
       w->data("data")->add(*model->GetObservables());
 
-      const RooArgSet * initialVariables = model->GetPdf()->getVariables();
+      std::unique_ptr<RooArgSet> initialVariables{model->GetPdf()->getVariables()};
       w->saveSnapshot("initialVariables",*initialVariables);
-      delete initialVariables;
 
       // NOTE: Roo1DIntegrator is too slow and gives poor results
 #ifdef R__HAS_MATHMORE
@@ -1487,9 +1484,8 @@ public:
       w->var("y")->setVal(fObsValueY);
       w->data("data")->add(*sbModel->GetObservables());
 
-      const RooArgSet * initialVariables = sbModel->GetPdf()->getVariables();
+      std::unique_ptr<RooArgSet> initialVariables{sbModel->GetPdf()->getVariables()};
       w->saveSnapshot("initialVariables",*initialVariables);
-      delete initialVariables;
 
       // set snapshots
       w->var("sig")->setVal(fObsValueX - w->var("bkg1")->getValV());
@@ -1657,9 +1653,8 @@ public:
       w->var("x")->setVal(fObsValueX);
       w->data("data")->add(*sbModel->GetObservables());
 
-      const RooArgSet * initialVariables = sbModel->GetPdf()->getVariables();
+      std::unique_ptr<RooArgSet> initialVariables{sbModel->GetPdf()->getVariables()};
       w->saveSnapshot("initialVariables",*initialVariables);
-      delete initialVariables;
 
       // set snapshots
       sbModel->SetSnapshot(*sbModel->GetParametersOfInterest());

--- a/tutorials/roofit/rf515_hfJSON.json
+++ b/tutorials/roofit/rf515_hfJSON.json
@@ -126,7 +126,8 @@
                     "max": 2
                 }
             ],
-            "contents": [122, 112]
+            "contents": [122, 112],
+            "type": "binned"
         }
     ]
 }


### PR DESCRIPTION
This is a backport of some RooFit PRs that were recently merged to master to v6-28-00-patches.

1. https://github.com/root-project/root/pull/12640
2. https://github.com/root-project/root/pull/12638
3. https://github.com/root-project/root/pull/12636
4. https://github.com/root-project/root/pull/12614
5. https://github.com/root-project/root/pull/12643
6. https://github.com/root-project/root/pull/12641
7. https://github.com/root-project/root/pull/12647
8. https://github.com/root-project/root/pull/12660
9. https://github.com/root-project/root/pull/12668

Related to https://github.com/root-project/root/issues/12319.

After merging this PR, the following RooFit commits in ROOT `master` (as of `4afc9f56bb`) are the ones that are not in `v6-28-00-patches` (as of `to fill out after merging`).

```txt
3608bc02fb [RF] Don't put scalar intermediate results into loops in generated code
249131f739 [RF] Generalize and reuse some of the BatchMode code in code squashing
7a12837f66 [RF] Split up CodeSquashContext in `.h` and `.cxx` file
1985b1b8d7 [RF] Reuse BatchMode code to fill observables vector in RooFuncVector
022e9fbd49 [RF] Improved implementation of `RooHelpers::Detail::snapshotImpl()`
d2bb816269 [RF] Move implemenation of `RooAbsArg::cloneTree()` to RooHelpers
cf515dec74 [RF] Optimize implementation of `cloneTreeWithSameParameters()`
3d258d8a4c [RF] Mode `RooAbsCollection::snapshot()` implementation to RooHelpers
f4fc140268 [RF] Remove RooMomentMorphND
6af8005e97 [RF] Add `selfNormalized` flag to RooWrapperPdf
d677b811d9 [RF] Increase version number of `RooRealVar` from 9 to 10
13d83d5808 [RF] Fix wrong size for gradient output array in testRooFuncWrapper.
912c32c5e2 [RF] Remove deprecated `Format(const char*, int)` command argument
6dcc352289 [RF] Move loop management for code generation into CodeSquashContext
ad2361c6ea [RF] Avoid need for buildLoopBegin() by recursive calls to translate()
c43c1ff1f3 [RF] Add 'translate' to RooNllVarNew.
666a4fcbde [RF] Minor improvements to RooFit evaluation code generation
c51376731b [RF][NFC] Fix typo.
826a6b38f4 [RF] Disable RooFuncWrapper test if clad is off.
4148a05e5a [RF] Remove wrong header declaration from roofit/roofit.
98d004c200 [RF] Fix visibility of the res/ directories.
e97347056c [RF] Make RooBatchCompute dependency public.
4483b01b7f [RF] Add initial interface and implementation for code-squashing.
f230374eb5 [RF] Enable passing of gradient function directly to RooMinimizer
0e5633535a [RF] Add support for differentiating Gaussian integrals using AD. This commits adds support for including analytical integrals into the mock code-squashing test by introducing a private header that stores the stateless implementation details.
7d39c0769c [RF] Enable analytic integration of RooHistPdfs with RooLinearVars
fce73f0565 [RF] Replace `RooAbsReal::_lastNSet` pointer with ID of last normSet
7e9c10b714 [RF] Remove `evaluateSpan()` from RooGenericPdf and RooFormulaVar
bf4990c5d4 [RF] Exclude RooHistError from IO
79edfbafa6 [RF] Remove `add(row, weight, weightError)` from RooAbsData interface
f355c3ced4 [RF] Code-format `testRooDataHist.cxx`
3fd99f7679 [RF] Enable AD code-gen test for RooFit.
a654d915e5 [RF] Less manual memory management in RooAbsArg and RooProdGenContext
1367091202 [RF] Code modernization of RooAbsReal
5c20fdc652 [RF] Add intiial minimizer interface for RooFuncWrapper.
cf88615b6e [RF] Improve code in `MinuitFcnGrad`
17bac5528b [RF] Code improvements in tests for new TestStatistics
afcb2d3931 [RF] Composition over inheritance in RooAbsMinimizerFcn implementations
3a52e89a99 [RF] No need for `RooAbsMinimizerFcn::fit()` method
3869282efb Fix modules and modules.idx generation on Windows and disable a few more modules causing potential crashes (#12252)
55bc2c0484 [RF] Define infinity as `std::numeric_limits<double>::infinity()`
026a1a701b [RF] Split RooFuncWrapper into '.h' and '.cxx'.
5964158260 [RF] Add observables as another parameter in RooFuncWrapper.
cca7c59a08 [RF] Test rough prototype of code generation in `testRooFuncWrapper`
333e857cc6 Add AD based derivatives for RooFuncWrapper.
46ba2eefd0 [cxxmodules] Enable a few modules for Windows. Now we can run hsimple.C.
fe8738ab41 [RF] Make it possible to switch to `ryml` backend after building ROOT
1ca66d2949 [RF] Add a C/C++ function wrapper class in roofit.
f457ca57c1 [RF] Fix implementation error from typo in `RooGenProdProj`
cc9d4e8025 [RF] New mechanism to implicitly convert numbers to RooRealVar&
8798fca2a3 [RF] Remove RooFormula code for gcc <= 4.8
a89130ac51 [RF] Remove `RooGenFunction` and `RooMultiGenFunction`
1554fba5e2 [RF] More use of `snapshot()` overload with output parameter
72cfdc9192 [RF] Bring back `RooStats::FeldmanCousins::SetData()`
faea4c9de4 [RF] Remove deprecated RooFit parts that are marked for removal in 6.30
```

