### PR TITLE
Fix to https://github.com/root-project/root/pull/12650

### DIFF
--- a/tree/tree/src/TTreeCache.cxx
+++ b/tree/tree/src/TTreeCache.cxx
@@ -1422,7 +1422,8 @@ Bool_t TTreeCache::FillBuffer()
             if (pass == kRewind)
                cursor[i].Rewind();
             else if (cursor[i].fCurrent == -1) {
-               cursor[i].fCurrent = TMath::BinarySearch(b->GetWriteBasket() + 1, entries, minEntry);
+               auto start = TMath::BinarySearch(b->GetWriteBasket() + 1, entries, minEntry);
+               cursor[i].fCurrent = (start < 0) ? 0 : start;
             }
             for (auto &j = cursor[i].fCurrent; j < nb; j++) {
                // This basket has already been read, skip it


### PR DESCRIPTION
Address: https://github.com/root-project/root/pull/12650#issuecomment-1517450219

From @hahnjo:

Hi @pcanal, our AddressSanitizer build reports a heap-buffer-overflow: https://lcgapp-services.cern.ch/root-jenkins/job/root-asan/LABEL=ROOT-centos8,SPEC=asan,V=master/lastCompletedBuild/testReport/projectroot.roottest.root.tree/stl/roottest_root_tree_stl_make/

I bisected this to commit https://github.com/root-project/root/commit/2fa93de2a51e248a56418d8c6488b043746d0925; the error message says "0x60700022d458 is located 8 bytes to the left of 80-byte region". However, the stack trace points to the loop immediately after the added condition to perform the binary search. Could you take a look, please? What does TMath::BinarySearch return in case the element is not found?

Answer: yep it was missing the error handling (return value of -1)