### PR TITLE
[RF] Don't throw an error if `roobatchcompute` lib was already loaded

### DIFF
--- a/roofit/batchcompute/src/Initialisation.cxx
+++ b/roofit/batchcompute/src/Initialisation.cxx
@@ -31,11 +31,9 @@ namespace {
 void loadWithErrorChecking(const std::string &libName)
 {
    const auto returnValue = gSystem->Load(libName.c_str());
-   if (returnValue == -1 || returnValue == -2)
+   if (returnValue == -1 || returnValue == -2) {
       throw std::runtime_error("RooFit was unable to load its computation library " + libName);
-   else if (returnValue == 1) // Library should not have been loaded before we tried to do it.
-      throw std::logic_error("RooFit computation library " + libName +
-                             " was loaded before RooFit initialisation began.");
+   }
 }
 
 } // end anonymous namespace


### PR DESCRIPTION
The `roobatchcompute` library dynamically loads the most performant implementation library that the CPU supports. However, it throws an error if the library was already loaded.

Indeed, in most usecases it's correct that the implementation library is not loaded before the RooBatchCompute main library is initialized, but if a RooFit script is executed via
`gInterpreter->LoadMacro("Macro_Name.cxx++")`, the library is already loaded the second time the macro is launched like this.

Hence, it's better is the `batchcompute` library throws no exception if the implementation is already loaded.

This fixes a problem reported on the forum:
https://root-forum.cern.ch/t/roofit-computation-library-libroobatchcompute-avx2-was-loaded-before-roofit-initialisation-began/54580
