### PR TITLE
[ntuple][cxx20] RNTupleSerialize: do not use iterators to construct `std::span`

### DIFF
--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -1044,7 +1044,7 @@ std::uint32_t ROOT::Experimental::Internal::RNTupleSerializer::SerializeSchemaDe
       nAliasColumns = desc.GetNLogicalColumns() - desc.GetNPhysicalColumns();
    }
    const auto &onDiskFields = context.GetOnDiskFieldList();
-   std::span<const DescriptorId_t> fieldList{onDiskFields.begin() + fieldListOffset, onDiskFields.end()};
+   std::span<const DescriptorId_t> fieldList{&(*(onDiskFields.cbegin() + fieldListOffset)), &(*onDiskFields.cend())};
 
    auto frame = pos;
    pos += SerializeListFramePreamble(nFields, *where);


### PR DESCRIPTION
Constructing a `std::span<T>` from a pair of `std::vector<T>::iterator` fails in Apple clang with libc++.  Revert to the pointer/pointer constructor, which should work in both GCC/clang and libstdc++/libc++.

See also: https://stackoverflow.com/questions/72935737/stdspan-on-apple-clang-cant-be-constructed.

This fixes the following error seen in the nighlies for cxx20 builds.
```
   std::span<const DescriptorId_t> fieldList{onDiskFields.begin() + fieldListOffset, onDiskFields.end()};
                                   ^        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX13.1.sdk/usr/include/c++/v1/span:405:41: note: candidate constructor not viable: no known conversion from 'std::__wrap_iter<const unsigned long long *>' to 'std::span<const unsigned long long, 18446744073709551615>::pointer' (aka 'const unsigned long long *') for 1st argument
    _LIBCPP_INLINE_VISIBILITY constexpr span(pointer __ptr, size_type __count) : __data{__ptr}, __size{__count} {}
                                        ^
/Library/Developer/CommandLineTools/SDKs/MacOSX13.1.sdk/usr/include/c++/v1/span:406:41: note: candidate constructor not viable: no known conversion from 'std::__wrap_iter<const unsigned long long *>' to 'std::span<const unsigned long long, 18446744073709551615>::pointer' (aka 'const unsigned long long *') for 1st argument
    _LIBCPP_INLINE_VISIBILITY constexpr span(pointer __f, pointer __l) : __data{__f}, __size{static_cast<size_t>(distance(__f, __l))} {}
                                        ^
/Library/Developer/CommandLineTools/SDKs/MacOSX13.1.sdk/usr/include/c++/v1/span:424:19: note: candidate template ignored: requirement '__is_span_compatible_container<std::__wrap_iter<const unsigned long long *>, const unsigned long long, void>::value' was not satisfied [with _Container = std::__wrap_iter<const unsigned long long *>]
        constexpr span(      _Container& __c,
                  ^
/Library/Developer/CommandLineTools/SDKs/MacOSX13.1.sdk/usr/include/c++/v1/span:430:19: note: candidate template ignored: requirement '__is_span_compatible_container<const std::__wrap_iter<const unsigned long long *>, const unsigned long long, void>::value' was not satisfied [with _Container = std::__wrap_iter<const unsigned long long *>]
        constexpr span(const _Container& __c,
                  ^
/Library/Developer/CommandLineTools/SDKs/MacOSX13.1.sdk/usr/include/c++/v1/span:437:19: note: candidate template ignored: could not match 'span' against '__wrap_iter'
        constexpr span(const span<_OtherElementType, _OtherExtent>& __other,
                  ^
/Library/Developer/CommandLineTools/SDKs/MacOSX13.1.sdk/usr/include/c++/v1/span:402:15: note: candidate constructor not viable: requires 1 argument, but 2 were provided
    constexpr span           (const span&) noexcept = default;
              ^
/Library/Developer/CommandLineTools/SDKs/MacOSX13.1.sdk/usr/include/c++/v1/span:410:15: note: candidate constructor template not viable: requires single argument '__arr', but 2 arguments were provided
    constexpr span(element_type (&__arr)[_Sz])          noexcept : __data{__arr}, __size{_Sz} {}
              ^
/Library/Developer/CommandLineTools/SDKs/MacOSX13.1.sdk/usr/include/c++/v1/span:415:15: note: candidate constructor template not viable: requires single argument '__arr', but 2 arguments were provided
    constexpr span(array<_OtherElementType, _Sz>& __arr) noexcept : __data{__arr.data()}, __size{_Sz} {}
              ^
/Library/Developer/CommandLineTools/SDKs/MacOSX13.1.sdk/usr/include/c++/v1/span:420:15: note: candidate constructor template not viable: requires single argument '__arr', but 2 arguments were provided
    constexpr span(const array<_OtherElementType, _Sz>& __arr) noexcept : __data{__arr.data()}, __size{_Sz} {}
              ^
/Library/Developer/CommandLineTools/SDKs/MacOSX13.1.sdk/usr/include/c++/v1/span:400:41: note: candidate constructor not viable: requires 0 arguments, but 2 were provided
    _LIBCPP_INLINE_VISIBILITY constexpr span() noexcept : __data{nullptr}, __size{0} {}
```

## Checklist:
- [X] tested changes locally