### PR TITLE
[RF] Implement correct sampling for RooGamma with `gamma < 1`

### DIFF
--- a/roofit/roofit/src/RooGamma.cxx
+++ b/roofit/roofit/src/RooGamma.cxx
@@ -113,12 +113,47 @@ double RooGamma::analyticalIntegral(Int_t code, const char* rangeName) const
   return integral ;
 }
 
+namespace {
+
+inline double randomGamma(double gamma, double beta, double mu, double xmin, double xmax)
+{
+   while (true) {
+
+      double d = gamma - 1. / 3.;
+      double c = 1. / TMath::Sqrt(9. * d);
+      double xgen = 0;
+      double v = 0;
+
+      while (v <= 0.) {
+         xgen = RooRandom::randomGenerator()->Gaus();
+         v = 1. + c * xgen;
+      }
+      v = v * v * v;
+      double u = RooRandom::randomGenerator()->Uniform();
+      if (u < 1. - .0331 * (xgen * xgen) * (xgen * xgen)) {
+         double x = ((d * v) * beta + mu);
+         if ((x < xmax) && (x > xmin)) {
+            return x;
+         }
+      }
+      if (TMath::Log(u) < 0.5 * xgen * xgen + d * (1. - v + TMath::Log(v))) {
+         double x = ((d * v) * beta + mu);
+         if ((x < xmax) && (x > xmin)) {
+            return x;
+         }
+      }
+   }
+}
+
+} // namespace
+
 ////////////////////////////////////////////////////////////////////////////////
 
-Int_t RooGamma::getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, bool /*staticInitOK*/) const
+Int_t RooGamma::getGenerator(const RooArgSet &directVars, RooArgSet &generateVars, bool /*staticInitOK*/) const
 {
-  if (matchArgs(directVars,generateVars,x)) return 1 ;
-  return 0 ;
+   if (matchArgs(directVars, generateVars, x))
+      return 1;
+   return 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -130,41 +165,22 @@ Int_t RooGamma::getGenerator(const RooArgSet& directVars, RooArgSet &generateVar
 /// The speed of this algorithm depends on the speed of generating normal variates.
 /// The algorithm is limited to \f$ \gamma \geq 0 \f$ !
 
-void RooGamma::generateEvent(Int_t code)
+void RooGamma::generateEvent(Int_t /*code*/)
 {
-  R__ASSERT(code==1) ;
+   if (gamma >= 1) {
+      x = randomGamma(gamma, beta, mu, x.min(), x.max());
+      return;
+   }
 
+   double xVal = 0.0;
+   bool accepted = false;
 
-  while(1) {
+   while (!accepted) {
+      double u = RooRandom::randomGenerator()->Uniform();
+      double tmp = randomGamma(1 + gamma, beta, mu, 0, std::numeric_limits<double>::infinity());
+      xVal = tmp * std::pow(u, 1.0 / gamma);
+      accepted = xVal < x.max() && xVal > x.min();
+   }
 
-  double d = 0;
-  double c = 0;
-  double xgen = 0;
-  double v = 0;
-  double u = 0;
-  d = gamma -1./3.; c = 1./TMath::Sqrt(9.*d);
-
-  while(v <= 0.){
-    xgen = RooRandom::randomGenerator()->Gaus(); v = 1. + c*xgen;
-  }
-  v = v*v*v; u = RooRandom::randomGenerator()->Uniform();
-  if( u < 1.-.0331*(xgen*xgen)*(xgen*xgen) ) {
-    if ( (((d*v)* beta + mu ) < x.max()) && (((d*v)* beta + mu) > x.min()) ) {
-      x = ((d*v)* beta + mu) ;
-      break;
-    }
-  }
-  if( TMath::Log(u) < 0.5*xgen*xgen + d*(1.-v + TMath::Log(v)) ) {
-    if ( (((d*v)* beta + mu ) < x.max()) && (((d*v)* beta + mu) > x.min()) ) {
-      x = ((d*v)* beta + mu) ;
-      break;
-    }
-  }
-
-  }
-
-
-  return;
+   x = xVal;
 }
-
-


### PR DESCRIPTION
This fixes the JIRA ticket ROOT-4188:
https://sft.its.cern.ch/jira/browse/ROOT-4188

The solution to the problem was already written in the linked JIRA ticket by @lmoneta.

This fix can be validated with this macro:
```c++
void repro()
{
    RooRealVar x{"x", "", 0.0005, 0.001};
    RooRealVar gamma{"gamma", "", 0.5};
    RooRealVar beta{"beta", "", 2};
    RooRealVar mu{"mu", "", 0};

    RooGamma pdf{"pdf", "", x, gamma, beta, mu};

    std::unique_ptr<RooDataSet> data{pdf.generate(x, 1000000)};

    auto frame = x.frame(RooFit::Title("RooGamma(x, 0.5, 2, 0)"));

    TCanvas c1;

    data->plotOn(frame);
    pdf.plotOn(frame);
    frame->Draw();

    c1.SaveAs("plot.png");
}
```

Result before this PR:
![plot](https://user-images.githubusercontent.com/6578603/234061105-3fff0cc9-d040-4b55-93bd-20a34f48da55.png)

And with this PR:
![plot_new](https://user-images.githubusercontent.com/6578603/234061143-66e64f5c-eb81-489d-8ccd-c0e2a188dbff.png)
