### PR TITLE
[cling][v6-28] Ignore -Wunused-result in wrapped code

### DIFF
--- a/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
@@ -164,6 +164,7 @@ namespace {
                           const Diagnostic &Info) override {
       if (Ignoring()) {
         if (Info.getID() == diag::warn_unused_expr
+            || Info.getID() == diag::warn_unused_result
             || Info.getID() == diag::warn_unused_call
             || Info.getID() == diag::warn_unused_comparison)
           return; // ignore!

--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -773,7 +773,7 @@ namespace cling {
     CO.CodeGeneration = m_IncrParser->hasCodeGenerator();
     CO.DynamicScoping = isDynamicLookupEnabled();
     CO.Debug = isPrintingDebug();
-    CO.IgnorePromptDiags = !isRawInputEnabled();
+    CO.IgnorePromptDiags = 0;
     CO.CheckPointerValidity = !isRawInputEnabled();
     CO.OptLevel = getDefaultOptLevel();
     return CO;

--- a/interpreter/cling/test/Prompt/decls.C
+++ b/interpreter/cling/test/Prompt/decls.C
@@ -25,4 +25,9 @@ printf("j=%d\n",j); // CHECK:j=12
 std::string str("abc");
 printf("str=%s\n",str.c_str()); // CHECK: str=abc
 
+[[nodiscard]] int f() { return 0; }
+void g() { f(); } // expected-warning@1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+// -Wunused-result is filtered for code parsed via `Interpreter::EvaluateInternal()`
+f();
+
 .q


### PR DESCRIPTION
Make `FilteringDiagConsumer` also ignore -Wunused-result. Whether or not such diagnostic is filtered depends on `CompilationOptions::IgnorePromptDiags`.

In particular, `IgnorePromptDiags` should _only_ be enabled for code parsed via `Interpreter::EvaluateInternal()`.  Thus, as of this commit `IgnorePromptDiags` defaults to 0 in `makeDefaultCompilationOpts()`

The observable effect of this change is ignoring `-Wunused-result` for wrapped code, e.g.
```c++
[[nodiscard]] int f() { return 0; }

// This yields `warning: ignoring return value of function declared with 'nodiscard' attribute [-Wunused-result]`
void g() { f(); }

f(); // but this should not
```

This PR is a backport of #12654.