### PR TITLE
Don't check CMAKE_GENERATOR use MSVC instead

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -899,7 +899,7 @@ function(ROOT_LINKER_LIBRARY library)
     set(library ${library}_new)
   endif()
   if(WIN32 AND ARG_TYPE STREQUAL SHARED AND NOT ARG_DLLEXPORT)
-    if(CMAKE_GENERATOR MATCHES "Visual Studio")
+    if(MSVC)
       set(library_name ${libprefix}${library})
     endif()
     #---create a shared library with the .def file------------------------


### PR DESCRIPTION
## Changes or fixes:
Fix shared library output name if the generator is not `Visual Studio` but e.g. `Ninja`

## Checklist:
- [x] tested changes locally
- [x] ~~updated the docs (if necessary)~~

