### PR TITLE
[RF] Migrate more RooFit functions to `RooFit::OwningPtr<T>`

### DIFF
--- a/roofit/histfactory/test/testHistFactory.cxx
+++ b/roofit/histfactory/test/testHistFactory.cxx
@@ -512,19 +512,19 @@ TEST_P(HFFixture, Fit) {
         poi->setConstant();
       }
 
-      auto fitResult = simPdf->fitTo(*data,
+      std::unique_ptr<RooFitResult> fitResult{simPdf->fitTo(*data,
           RooFit::BatchMode(batchFit),
           RooFit::Optimize(constTermOptimisation),
           RooFit::GlobalObservables(*mc->GetGlobalObservables()),
           RooFit::Save(),
-          RooFit::PrintLevel(verbose ? 1 : -1));
+          RooFit::PrintLevel(verbose ? 1 : -1))};
       ASSERT_NE(fitResult, nullptr);
       if (verbose)
         fitResult->Print();
       EXPECT_EQ(fitResult->status(), 0);
 
 
-      auto checkParam = [fitResult](const std::string& param, double target, double absPrecision) {
+      auto checkParam = [&fitResult](const std::string& param, double target, double absPrecision) {
         auto par = dynamic_cast<RooRealVar*>(fitResult->floatParsFinal().find(param.c_str()));
         if (!par) {
           // Parameter was constant in this fit

--- a/roofit/roofit/inc/RooIntegralMorph.h
+++ b/roofit/roofit/inc/RooIntegralMorph.h
@@ -73,8 +73,8 @@ public:
     RooAbsPdf* _pdf2 ; // PDF2
     RooRealVar* _x   ; // X
     RooAbsReal* _alpha ; // ALPHA
-    RooAbsReal* _c1 ; // CDF of PDF 1
-    RooAbsReal* _c2 ; // CDF of PDF 2
+    std::unique_ptr<RooAbsReal> _c1 ; // CDF of PDF 1
+    std::unique_ptr<RooAbsReal> _c2 ; // CDF of PDF 2
     RooAbsFunc* _cb1 ; // Binding of CDF1
     RooAbsFunc* _cb2 ; // Binding of CDF2
     std::unique_ptr<RooBrentRootFinder> _rf1; // ROOT finder on CDF1

--- a/roofit/roofit/src/RooIntegralMorph.cxx
+++ b/roofit/roofit/src/RooIntegralMorph.cxx
@@ -246,8 +246,8 @@ RooIntegralMorph::MorphCacheElem::MorphCacheElem(RooIntegralMorph& self, const R
   _alpha = (RooAbsReal*)self.alpha.absArg() ;
   _pdf1 = (RooAbsPdf*)(self.pdf1.absArg()) ;
   _pdf2 = (RooAbsPdf*)(self.pdf2.absArg()) ;
-  _c1 = _pdf1->createCdf(*_x);
-  _c2 = _pdf2->createCdf(*_x) ;
+  _c1 = std::unique_ptr<RooAbsReal>{_pdf1->createCdf(*_x)};
+  _c2 = std::unique_ptr<RooAbsReal>{_pdf2->createCdf(*_x)};
   _cb1 = _c1->bindVars(*_x,_nset.get());
   _cb2 = _c2->bindVars(*_x,_nset.get());
   _self = &self ;

--- a/roofit/roofitcore/inc/RooAbsMCStudyModule.h
+++ b/roofit/roofitcore/inc/RooAbsMCStudyModule.h
@@ -77,9 +77,7 @@ protected:
    // which are only functional after module has been attached to a RooMCStudy object
 
    /// Refit model using original or specified data sample
-   RooFitResult* refit(RooAbsData* inGenSample=nullptr) {
-     if (_mcs) return _mcs->refit(inGenSample) ; else return nullptr ;
-   }
+   RooFit::OwningPtr<RooFitResult> refit(RooAbsData* inGenSample=nullptr);
 
    /// Return generate sample
    RooAbsData* genSample() {

--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -156,11 +156,11 @@ public:
   void setGeneratorConfig(const RooNumGenConfig& config) ;
 
   // -log(L) fits to binned and unbinned data
-  virtual RooFitResult* fitTo(RooAbsData& data, const RooLinkedList& cmdList={}) ;
+  virtual RooFit::OwningPtr<RooFitResult> fitTo(RooAbsData& data, const RooLinkedList& cmdList={}) ;
   /// Takes an arbitrary number of RooCmdArg command options and calls
   /// RooAbsPdf::fitTo(RooAbsData& data, const RooLinkedList& cmdList).
   template <typename... Args>
-  RooFitResult* fitTo(RooAbsData& data, RooCmdArg const& arg1, Args const&... args)
+  RooFit::OwningPtr<RooFitResult> fitTo(RooAbsData& data, RooCmdArg const& arg1, Args const&... args)
   {
     return fitTo(data, *RooFit::Detail::createCmdList(&arg1, &args...));
   }
@@ -231,12 +231,12 @@ public:
   virtual RooAbsPdf* createProjection(const RooArgSet& iset) ;
 
   // Create cumulative density function from p.d.f
-  RooAbsReal* createCdf(const RooArgSet& iset, const RooArgSet& nset=RooArgSet()) ;
-  RooAbsReal* createCdf(const RooArgSet& iset, const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg::none(),
+  RooFit::OwningPtr<RooAbsReal> createCdf(const RooArgSet& iset, const RooArgSet& nset=RooArgSet()) ;
+  RooFit::OwningPtr<RooAbsReal> createCdf(const RooArgSet& iset, const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg::none(),
          const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),
          const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),
          const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;
-  RooAbsReal* createScanCdf(const RooArgSet& iset, const RooArgSet& nset, Int_t numScanBins, Int_t intOrder) ;
+  RooFit::OwningPtr<RooAbsReal> createScanCdf(const RooArgSet& iset, const RooArgSet& nset, Int_t numScanBins, Int_t intOrder) ;
 
   // Function evaluation support
   double getValV(const RooArgSet* set=nullptr) const override ;

--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -245,13 +245,13 @@ public:
   void setParameterizeIntegral(const RooArgSet& paramVars) ;
 
   // Create running integrals
-  RooAbsReal* createRunningIntegral(const RooArgSet& iset, const RooArgSet& nset=RooArgSet()) ;
-  RooAbsReal* createRunningIntegral(const RooArgSet& iset, const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg::none(),
+  RooFit::OwningPtr<RooAbsReal> createRunningIntegral(const RooArgSet& iset, const RooArgSet& nset=RooArgSet()) ;
+  RooFit::OwningPtr<RooAbsReal> createRunningIntegral(const RooArgSet& iset, const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg::none(),
          const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),
          const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),
          const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;
-  RooAbsReal* createIntRI(const RooArgSet& iset, const RooArgSet& nset=RooArgSet()) ;
-  RooAbsReal* createScanRI(const RooArgSet& iset, const RooArgSet& nset, Int_t numScanBins, Int_t intOrder) ;
+  RooFit::OwningPtr<RooAbsReal> createIntRI(const RooArgSet& iset, const RooArgSet& nset=RooArgSet()) ;
+  RooFit::OwningPtr<RooAbsReal> createScanRI(const RooArgSet& iset, const RooArgSet& nset, Int_t numScanBins, Int_t intOrder) ;
 
 
   // Optimized accept/reject generator support

--- a/roofit/roofitcore/inc/RooAbsStudy.h
+++ b/roofit/roofitcore/inc/RooAbsStudy.h
@@ -59,7 +59,7 @@ public:
   friend class RooStudyPackage ;
   void registerSummaryOutput(const RooArgSet& allVars, const RooArgSet& varsWithError=RooArgSet(), const RooArgSet& varsWithAsymError=RooArgSet()) ;
   void storeSummaryOutput(const RooArgSet& vars) ;
-  void storeDetailedOutput(TNamed& object) ;
+  void storeDetailedOutput(std::unique_ptr<TNamed> object) ;
   void aggregateSummaryOutput(TList* chunkList) ;
 
  private:

--- a/roofit/roofitcore/inc/RooMCStudy.h
+++ b/roofit/roofitcore/inc/RooMCStudy.h
@@ -100,7 +100,7 @@ protected:
 
   bool run(bool generate, bool fit, Int_t nSamples, Int_t nEvtPerSample, bool keepGenData, const char* asciiFilePat) ;
   bool fitSample(RooAbsData* genSample) ;
-  RooFitResult* doFit(RooAbsData* genSample) ;
+  RooFit::OwningPtr<RooFitResult> doFit(RooAbsData* genSample) ;
 
   void calcPulls() ;
 
@@ -141,7 +141,7 @@ protected:
   std::list<RooAbsMCStudyModule*> _modList ; ///< List of additional study modules ;
 
   // Utilities for modules ;
-  RooFitResult* refit(RooAbsData* genSample=nullptr) ;
+  RooFit::OwningPtr<RooFitResult> refit(RooAbsData* genSample=nullptr) ;
   void resetFitParams() ;
   void RecursiveRemove(TObject *obj) override;
 

--- a/roofit/roofitcore/inc/RooUnitTest.h
+++ b/roofit/roofitcore/inc/RooUnitTest.h
@@ -44,7 +44,7 @@ public:
   void setSilentMode() ;
   void clearSilentMode() ;
   void regPlot(RooPlot* frame, const char* refName) ;
-  void regResult(RooFitResult* r, const char* refName) ;
+  void regResult(std::unique_ptr<RooFitResult> r, const char* refName) ;
   void regValue(double value, const char* refName) ;
   void regTable(RooTable* t, const char* refName) ;
   void regWS(RooWorkspace* ws, const char* refName) ;

--- a/roofit/roofitcore/src/RooAbsMCStudyModule.cxx
+++ b/roofit/roofitcore/src/RooAbsMCStudyModule.cxx
@@ -31,12 +31,13 @@ summaryData() is merged with the 'master' summary dataset in RooMCStudy.
 Look at RooDLLSignificanceMCSModule for an example of an implementation.
 **/
 
-#include "RooAbsMCStudyModule.h"
+#include <RooAbsMCStudyModule.h>
+
+#include <RooFitResult.h>
 
 using namespace std;
 
 ClassImp(RooAbsMCStudyModule);
-  ;
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -65,3 +66,6 @@ bool RooAbsMCStudyModule::doInitializeInstance(RooMCStudy& study)
   return initializeInstance() ;
 }
 
+RooFit::OwningPtr<RooFitResult> RooAbsMCStudyModule::refit(RooAbsData* inGenSample) {
+  if (_mcs) return _mcs->refit(inGenSample) ; else return nullptr ;
+}

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1610,7 +1610,7 @@ std::unique_ptr<RooFitResult> RooAbsPdf::minimizeNLL(RooAbsReal & nll,
 /// </table>
 ///
 
-RooFitResult* RooAbsPdf::fitTo(RooAbsData& data, const RooLinkedList& cmdList)
+RooFit::OwningPtr<RooFitResult> RooAbsPdf::fitTo(RooAbsData& data, const RooLinkedList& cmdList)
 {
   // Select the pdf-specific commands
   RooCmdConfig pc(Form("RooAbsPdf::fitTo(%s)",GetName())) ;
@@ -1752,7 +1752,7 @@ RooFitResult* RooAbsPdf::fitTo(RooAbsData& data, const RooLinkedList& cmdList)
   cfg.enableParallelGradient = pc.getInt("enableParallelGradient");
   cfg.enableParallelDescent = pc.getInt("enableParallelDescent");
   cfg.timingAnalysis = pc.getInt("timingAnalysis");
-  return minimizeNLL(*nll, data, cfg).release();
+  return RooFit::OwningPtr<RooFitResult>{minimizeNLL(*nll, data, cfg).release()};
 }
 
 
@@ -3294,7 +3294,7 @@ RooAbsPdf* RooAbsPdf::createProjection(const RooArgSet& iset)
 /// over z results in a maximum value of 1. To construct such a cdf pass
 /// z as argument to the optional nset argument
 
-RooAbsReal* RooAbsPdf::createCdf(const RooArgSet& iset, const RooArgSet& nset)
+RooFit::OwningPtr<RooAbsReal> RooAbsPdf::createCdf(const RooArgSet& iset, const RooArgSet& nset)
 {
   return createCdf(iset,RooFit::SupNormSet(nset)) ;
 }
@@ -3316,7 +3316,7 @@ RooAbsReal* RooAbsPdf::createCdf(const RooArgSet& iset, const RooArgSet& nset)
 /// | ScanNoCdf()                          | Never apply scanning technique
 /// | ScanParameters(Int_t nbins, Int_t intOrder) | Parameters for scanning technique of making CDF: number of sampled bins and order of interpolation applied on numeric cdf
 
-RooAbsReal* RooAbsPdf::createCdf(const RooArgSet& iset, const RooCmdArg& arg1, const RooCmdArg& arg2,
+RooFit::OwningPtr<RooAbsReal> RooAbsPdf::createCdf(const RooArgSet& iset, const RooCmdArg& arg1, const RooCmdArg& arg2,
              const RooCmdArg& arg3, const RooCmdArg& arg4, const RooCmdArg& arg5,
              const RooCmdArg& arg6, const RooCmdArg& arg7, const RooCmdArg& arg8)
 {
@@ -3371,14 +3371,14 @@ RooAbsReal* RooAbsPdf::createCdf(const RooArgSet& iset, const RooCmdArg& arg1, c
   return 0 ;
 }
 
-RooAbsReal* RooAbsPdf::createScanCdf(const RooArgSet& iset, const RooArgSet& nset, Int_t numScanBins, Int_t intOrder)
+RooFit::OwningPtr<RooAbsReal> RooAbsPdf::createScanCdf(const RooArgSet& iset, const RooArgSet& nset, Int_t numScanBins, Int_t intOrder)
 {
   string name = string(GetName()) + "_NUMCDF_" + integralNameSuffix(iset,&nset).Data() ;
   RooRealVar* ivar = (RooRealVar*) iset.first() ;
   ivar->setBins(numScanBins,"numcdf") ;
-  RooNumCdf* ret = new RooNumCdf(name.c_str(),name.c_str(),*this,*ivar,"numcdf") ;
+  auto ret = std::make_unique<RooNumCdf>(name.c_str(),name.c_str(),*this,*ivar,"numcdf");
   ret->setInterpolationOrder(intOrder) ;
-  return ret ;
+  return RooFit::OwningPtr<RooAbsReal>{ret.release()};
 }
 
 

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -3801,7 +3801,7 @@ void RooAbsReal::preferredObservableScanOrder(const RooArgSet& obs, RooArgSet& o
 ////////////////////////////////////////////////////////////////////////////////
 /// Calls createRunningIntegral(const RooArgSet&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&)
 
-RooAbsReal* RooAbsReal::createRunningIntegral(const RooArgSet& iset, const RooArgSet& nset)
+RooFit::OwningPtr<RooAbsReal> RooAbsReal::createRunningIntegral(const RooArgSet& iset, const RooArgSet& nset)
 {
   return createRunningIntegral(iset,RooFit::SupNormSet(nset)) ;
 }
@@ -3845,7 +3845,7 @@ RooAbsReal* RooAbsReal::createRunningIntegral(const RooArgSet& iset, const RooAr
 /// | `ScanAll()`                            | Always apply scanning technique
 /// | `ScanNone()`                           | Never apply scanning technique
 
-RooAbsReal* RooAbsReal::createRunningIntegral(const RooArgSet& iset, const RooCmdArg& arg1, const RooCmdArg& arg2,
+RooFit::OwningPtr<RooAbsReal> RooAbsReal::createRunningIntegral(const RooArgSet& iset, const RooCmdArg& arg1, const RooCmdArg& arg2,
              const RooCmdArg& arg3, const RooCmdArg& arg4, const RooCmdArg& arg5,
              const RooCmdArg& arg6, const RooCmdArg& arg7, const RooCmdArg& arg8)
 {
@@ -3905,14 +3905,14 @@ RooAbsReal* RooAbsReal::createRunningIntegral(const RooArgSet& iset, const RooCm
 /// Utility function for createRunningIntegral that construct an object
 /// implementing the numeric scanning technique for calculating the running integral
 
-RooAbsReal* RooAbsReal::createScanRI(const RooArgSet& iset, const RooArgSet& nset, Int_t numScanBins, Int_t intOrder)
+RooFit::OwningPtr<RooAbsReal> RooAbsReal::createScanRI(const RooArgSet& iset, const RooArgSet& nset, Int_t numScanBins, Int_t intOrder)
 {
   std::string name = std::string(GetName()) + "_NUMRUNINT_" + integralNameSuffix(iset,&nset).Data() ;
   RooRealVar* ivar = (RooRealVar*) iset.first() ;
   ivar->setBins(numScanBins,"numcdf") ;
-  RooNumRunningInt* ret = new RooNumRunningInt(name.c_str(),name.c_str(),*this,*ivar,"numrunint") ;
+  auto ret = std::make_unique<RooNumRunningInt>(name.c_str(),name.c_str(),*this,*ivar,"numrunint") ;
   ret->setInterpolationOrder(intOrder) ;
-  return ret ;
+  return RooFit::OwningPtr<RooAbsReal>{ret.release()};
 }
 
 
@@ -3922,7 +3922,7 @@ RooAbsReal* RooAbsReal::createScanRI(const RooArgSet& iset, const RooArgSet& nse
 /// object implementing the standard (analytical) integration
 /// technique for calculating the running integral.
 
-RooAbsReal* RooAbsReal::createIntRI(const RooArgSet& iset, const RooArgSet& nset)
+RooFit::OwningPtr<RooAbsReal> RooAbsReal::createIntRI(const RooArgSet& iset, const RooArgSet& nset)
 {
   // Make std::list of input arguments keeping only RooRealVars
   RooArgList ilist ;
@@ -3967,14 +3967,14 @@ RooAbsReal* RooAbsReal::createIntRI(const RooArgSet& iset, const RooArgSet& nset
   // Construct final normalization set for c.d.f = integrated observables + any extra specified by user
   RooArgSet finalNset(nset) ;
   finalNset.add(cloneList,true) ;
-  RooAbsReal* cdf = tmp->createIntegral(cloneList,finalNset,"CDF") ;
+  std::unique_ptr<RooAbsReal> cdf{tmp->createIntegral(cloneList,finalNset,"CDF")};
 
   // Transfer ownership of cloned items to top-level c.d.f object
   cdf->addOwnedComponents(*tmp) ;
   cdf->addOwnedComponents(cloneList) ;
   cdf->addOwnedComponents(loList) ;
 
-  return cdf ;
+  return RooFit::OwningPtr<RooAbsReal>{cdf.release()};
 }
 
 

--- a/roofit/roofitcore/src/RooAbsStudy.cxx
+++ b/roofit/roofitcore/src/RooAbsStudy.cxx
@@ -100,9 +100,9 @@ void RooAbsStudy::storeSummaryOutput(const RooArgSet& vars)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void RooAbsStudy::storeDetailedOutput(TNamed& object)
+void RooAbsStudy::storeDetailedOutput(std::unique_ptr<TNamed> object)
 {
-  if (_storeDetails) {
+  if (!_storeDetails) return;
 
     if (!_detailData) {
       _detailData = new RooLinkedList ;
@@ -110,12 +110,9 @@ void RooAbsStudy::storeDetailedOutput(TNamed& object)
       //cout << "RooAbsStudy::ctor() detailData name = " << _detailData->GetName() << endl ;
     }
 
-    object.SetName(TString::Format("%s_detailed_data_%d",GetName(),_detailData->GetSize())) ;
+    object->SetName(TString::Format("%s_detailed_data_%d",GetName(),_detailData->GetSize())) ;
     //cout << "storing detailed data with name " << object.GetName() << endl ;
-    _detailData->Add(&object) ;
-  } else {
-    delete &object ;
-  }
+    _detailData->Add(object.release());
 }
 
 
@@ -144,7 +141,7 @@ void RooAbsStudy::aggregateSummaryOutput(TList* chunkList)
 
     if (auto dlist = dynamic_cast<RooLinkedList*>(obj)) {
       if (TString(dlist->GetName()).BeginsWith(Form("%s_detailed_data",GetName()))) {
-        for(auto * dobj : static_range_cast<TNamed*>(*dlist)) storeDetailedOutput(*dobj) ;
+        for(auto * dobj : static_range_cast<TNamed*>(*dlist)) storeDetailedOutput(std::unique_ptr<TNamed>{dobj}) ;
       }
     }
   }

--- a/roofit/roofitcore/src/RooDLLSignificanceMCSModule.cxx
+++ b/roofit/roofitcore/src/RooDLLSignificanceMCSModule.cxx
@@ -174,7 +174,7 @@ bool RooDLLSignificanceMCSModule::processAfterFit(Int_t /*sampleNum*/)
   RooRealVar* par = static_cast<RooRealVar*>(fitParams()->find(_parName.c_str())) ;
   par->setVal(_nullValue) ;
   par->setConstant(true) ;
-  RooFitResult* frnull = refit() ;
+  std::unique_ptr<RooFitResult> frnull{refit()};
   par->setConstant(false) ;
 
   _nll0h->setVal(frnull->minNll()) ;
@@ -186,8 +186,6 @@ bool RooDLLSignificanceMCSModule::processAfterFit(Int_t /*sampleNum*/)
 
 
   _data->add(RooArgSet(*_nll0h,*_dll0h,*_sig0h)) ;
-
-  delete frnull ;
 
   return true ;
 }

--- a/roofit/roofitcore/src/RooFactoryWSTool.cxx
+++ b/roofit/roofitcore/src/RooFactoryWSTool.cxx
@@ -2168,9 +2168,9 @@ std::string RooFactoryWSTool::SpecialsIFace::create(RooFactoryWSTool& ft, const 
 
     std::unique_ptr<RooAbsReal> cdf;
     if (pargv.size()==2) {
-      cdf.reset(pdf.createCdf(ft.asSET(pargv[1].c_str())));
+      cdf = std::unique_ptr<RooAbsReal>{pdf.createCdf(ft.asSET(pargv[1].c_str()))};
     } else {
-      cdf.reset(pdf.createCdf(ft.asSET(pargv[1].c_str()),ft.asSET(pargv[2].c_str())));
+      cdf = std::unique_ptr<RooAbsReal>{pdf.createCdf(ft.asSET(pargv[1].c_str()),ft.asSET(pargv[2].c_str()))};
     }
 
     cdf->SetName(instName) ;

--- a/roofit/roofitcore/src/RooGenFitStudy.cxx
+++ b/roofit/roofitcore/src/RooGenFitStudy.cxx
@@ -182,17 +182,16 @@ bool RooGenFitStudy::initialize()
 bool RooGenFitStudy::execute()
 {
   _params->assign(*_initParams) ;
-  RooDataSet* data = _genPdf->generate(*_genSpec) ;
-  RooFitResult* fr  = _fitPdf->fitTo(*data,RooFit::Save(true),(RooCmdArg&)*_fitOpts.At(0),(RooCmdArg&)*_fitOpts.At(1),(RooCmdArg&)*_fitOpts.At(2)) ;
+  std::unique_ptr<RooDataSet> data{_genPdf->generate(*_genSpec)};
+  std::unique_ptr<RooFitResult> fr{_fitPdf->fitTo(*data,RooFit::Save(true),(RooCmdArg&)*_fitOpts.At(0),(RooCmdArg&)*_fitOpts.At(1),(RooCmdArg&)*_fitOpts.At(2))};
 
   if (fr->status()==0) {
     _ngenVar->setVal(data->sumEntries()) ;
     _nllVar->setVal(fr->minNll()) ;
     storeSummaryOutput(*_params) ;
-    storeDetailedOutput(*fr) ;
+    storeDetailedOutput(std::move(fr)) ;
   }
 
-  delete data ;
   return false ;
 }
 

--- a/roofit/roofitcore/src/RooMCStudy.cxx
+++ b/roofit/roofitcore/src/RooMCStudy.cxx
@@ -596,7 +596,7 @@ void RooMCStudy::resetFitParams()
 ////////////////////////////////////////////////////////////////////////////////
 /// Internal function. Performs actual fit according to specifications
 
-RooFitResult* RooMCStudy::doFit(RooAbsData* genSample)
+RooFit::OwningPtr<RooFitResult> RooMCStudy::doFit(RooAbsData* genSample)
 {
   // Optionally bin dataset before fitting
   std::unique_ptr<RooDataHist> ownedDataHist;
@@ -620,9 +620,7 @@ RooFitResult* RooMCStudy::doFit(RooAbsData* genSample)
     fitOptList.Add(&condo) ;
   }
   fitOptList.Add(&plevel) ;
-  RooFitResult* fr = _fitModel->fitTo(*data,fitOptList) ;
-
-  return fr ;
+  return _fitModel->fitTo(*data,fitOptList);
 }
 
 
@@ -631,18 +629,18 @@ RooFitResult* RooMCStudy::doFit(RooAbsData* genSample)
 /// Redo fit on 'current' toy sample, or if genSample is not nullptr
 /// do fit on given sample instead
 
-RooFitResult* RooMCStudy::refit(RooAbsData* genSample)
+RooFit::OwningPtr<RooFitResult> RooMCStudy::refit(RooAbsData* genSample)
 {
   if (!genSample) {
     genSample = _genSample ;
   }
 
-  RooFitResult* fr(0) ;
+  std::unique_ptr<RooFitResult> fr;
   if (genSample->sumEntries()>0) {
-    fr = doFit(genSample) ;
+    fr = std::unique_ptr<RooFitResult>{doFit(genSample)};
   }
 
-  return fr ;
+  return RooFit::OwningPtr<RooFitResult>(fr.release());
 }
 
 
@@ -667,7 +665,7 @@ bool RooMCStudy::fitSample(RooAbsData* genSample)
   bool ok ;
   std::unique_ptr<RooFitResult> fr;
   if (genSample->sumEntries()>0) {
-    fr.reset(doFit(genSample));
+    fr = std::unique_ptr<RooFitResult>{doFit(genSample)};
     ok = (fr->status()==0) ;
   } else {
     ok = false ;

--- a/roofit/roofitcore/src/RooUnitTest.cxx
+++ b/roofit/roofitcore/src/RooUnitTest.cxx
@@ -94,13 +94,11 @@ void RooUnitTest::regPlot(RooPlot* frame, const char* refName)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void RooUnitTest::regResult(RooFitResult* r, const char* refName)
+void RooUnitTest::regResult(std::unique_ptr<RooFitResult> r, const char* refName)
 {
   if (_refFile) {
     string refNameStr(refName) ;
-    _regResults.push_back(make_pair(r,refNameStr)) ;
-  } else {
-    delete r ;
+    _regResults.push_back(make_pair(r.release(),refNameStr)) ;
   }
 }
 

--- a/roofit/roostats/src/BayesianCalculator.cxx
+++ b/roofit/roostats/src/BayesianCalculator.cxx
@@ -1211,10 +1211,10 @@ void BayesianCalculator::ComputeIntervalUsingRooFit(double lowerCutOff, double u
    if (!fPosteriorPdf) fPosteriorPdf = (RooAbsPdf*) GetPosteriorPdf();
    if (!fPosteriorPdf) return;
 
-   RooAbsReal* cdf = fPosteriorPdf->createCdf(fPOI,RooFit::ScanNoCdf());
+   std::unique_ptr<RooAbsReal> cdf{fPosteriorPdf->createCdf(fPOI,RooFit::ScanNoCdf())};
    if (!cdf) return;
 
-   RooAbsFunc* cdf_bind = cdf->bindVars(fPOI,&fPOI);
+   std::unique_ptr<RooAbsFunc> cdf_bind{cdf->bindVars(fPOI,&fPOI)};
    if (!cdf_bind) return;
 
    RooBrentRootFinder brf(*cdf_bind);
@@ -1244,9 +1244,6 @@ void BayesianCalculator::ComputeIntervalUsingRooFit(double lowerCutOff, double u
 
 
    poi->setVal(tmpVal); // patch: restore the original value of poi
-
-   delete cdf_bind;
-   delete cdf;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roostats/src/ToyMCStudy.cxx
+++ b/roofit/roostats/src/ToyMCStudy.cxx
@@ -79,8 +79,7 @@ bool ToyMCStudy::execute(void) {
 
    coutP(Generation) << "ToyMCStudy::execute - run with seed " <<   RooRandom::randomGenerator()->Integer(TMath::Limits<unsigned int>::Max() ) << std::endl;
    RooDataSet* sd = fToyMCSampler->GetSamplingDistributionsSingleWorker(fParamPoint);
-   ToyMCPayload *sdw = new ToyMCPayload(sd);
-   storeDetailedOutput(*sdw);
+   storeDetailedOutput(std::make_unique<ToyMCPayload>(sd));
 
    return false;
 }

--- a/test/fit/testFitPerf.cxx
+++ b/test/fit/testFitPerf.cxx
@@ -574,11 +574,7 @@ int  FitUsingRooFit(TTree * tree, TF1 * func) {
       bool save = false;
 #endif
 
-//#ifndef _WIN32 // until a bug 30762 is fixed
-      RooFitResult * result = pdf.fitTo(data, RooFit::Minos(0), RooFit::Hesse(1) , RooFit::PrintLevel(level), RooFit::Save(save) );
-// #else
-//       RooFitResult * result = pdf.fitTo(data );
-// #endif
+      std::unique_ptr<RooFitResult> result{pdf.fitTo(data, RooFit::Minos(0), RooFit::Hesse(1) , RooFit::PrintLevel(level), RooFit::Save(save) )};
 
 #ifdef DEBUG
       mean.Print();
@@ -671,11 +667,7 @@ int  FitUsingRooFit2(TTree * tree) {
 #endif
 
 
-#ifndef _WIN32 // until a bug 30762 is fixed
-      RooFitResult * result = pdf[N-1]->fitTo(data, RooFit::Minos(0), RooFit::Hesse(1) , RooFit::PrintLevel(level), RooFit::Save(save) );
-#else
-      RooFitResult * result = pdf[N-1]->fitTo(data);
-#endif
+      std::unique_ptr<RooFitResult> result{pdf[N-1]->fitTo(data, RooFit::Minos(0), RooFit::Hesse(1) , RooFit::PrintLevel(level), RooFit::Save(save) )};
 
 #ifdef DEBUG
       assert(result != 0);

--- a/test/fit/testRooFit.cxx
+++ b/test/fit/testRooFit.cxx
@@ -213,18 +213,14 @@ int  FitUsingRooFit(TTree & tree, RooAbsPdf & pdf, RooArgSet & xvars) {
       int level = 2;
       std::cout << "num entries = " << data.numEntries() << std::endl;
       bool save = true;
-      pdf.getVariables()->Print("v"); // print the parameters
+      std::unique_ptr<RooArgSet>{pdf.getVariables()}->Print("v"); // print the parameters
       std::cout << "\n\nDo the fit now \n\n";
 #else
       int level = -1;
       bool save = false;
 #endif
 
-#ifndef _WIN32 // until a bug 30762 is fixed
-      RooFitResult * result = pdf.fitTo(data, RooFit::Minos(0), RooFit::Hesse(0) , RooFit::PrintLevel(level), RooFit::Save(save) );
-#else
-      RooFitResult * result = pdf.fitTo(data );
-#endif
+      std::unique_ptr<RooFitResult> result{pdf.fitTo(data, RooFit::Minos(0), RooFit::Hesse(0) , RooFit::PrintLevel(level), RooFit::Save(save) )};
 
 #ifdef DEBUG
       assert(result != nullptr);

--- a/test/stressHistFactory_tests.cxx
+++ b/test/stressHistFactory_tests.cxx
@@ -442,12 +442,12 @@ private:
     if (gSystem->Load("libMinuit2") < 0) minimizerType = "Minuit";
     gErrorIgnoreLevel=prec;
 
-    RooFitResult* r1 = rPDF1.fitTo(rTestData,Save(), RooFit::Minimizer(minimizerType.c_str()));
+    std::unique_ptr<RooFitResult> r1{rPDF1.fitTo(rTestData,Save(), RooFit::Minimizer(minimizerType.c_str()))};
     //L.M:  for minuit we need ot rest otherwise fit could fail
     if (minimizerType == "Minuit") {
        if (gMinuit) { delete gMinuit; gMinuit=0; }
     }
-    RooFitResult* r2 = rPDF2.fitTo(rTestData,Save(), RooFit::Minimizer(minimizerType.c_str()));
+    std::unique_ptr<RooFitResult> r2{rPDF2.fitTo(rTestData,Save(), RooFit::Minimizer(minimizerType.c_str()))};
 
     if(_verb > 0)
     {

--- a/test/stressRooFit_tests.h
+++ b/test/stressRooFit_tests.h
@@ -398,7 +398,7 @@ public:
     // -------------------------------------------------------------------
 
     // Fit g2 to data from g1
-    RooFitResult* r = g2.fitTo(*data2,Save(),BatchMode(_batchMode)) ;
+    std::unique_ptr<RooFitResult> r{g2.fitTo(*data2,Save(),BatchMode(_batchMode))};
 
     // Plot data on frame and overlay projection of g2
     RooPlot* xframe2 = x.frame(Title("Tailored Gaussian pdf")) ;
@@ -407,7 +407,7 @@ public:
 
     regPlot(xframe,"rf103_plot1") ;
     regPlot(xframe2,"rf103_plot2") ;
-    regResult(r,"rf103_fit1") ;
+    regResult(std::move(r),"rf103_fit1") ;
 
     return true ;
   }
@@ -1115,7 +1115,7 @@ public:
     // ---------------------------
 
     // Fit p.d.f to all data
-    RooFitResult* r_full = model.fitTo(*modelData,Save(true),BatchMode(_batchMode)) ;
+    std::unique_ptr<RooFitResult> r_full{model.fitTo(*modelData,Save(true),BatchMode(_batchMode))};
 
 
     // F i t   p a r t i a l   r a n g e
@@ -1125,7 +1125,7 @@ public:
     x.setRange("signal",-3,3) ;
 
     // Fit p.d.f only to data in "signal" range
-    RooFitResult* r_sig = model.fitTo(*modelData,Save(true),Range("signal"),BatchMode(_batchMode)) ;
+    std::unique_ptr<RooFitResult> r_sig{model.fitTo(*modelData,Save(true),Range("signal"),BatchMode(_batchMode))};
 
 
     // P l o t   /   p r i n t   r e s u l t s
@@ -1138,8 +1138,8 @@ public:
     model.plotOn(frame) ; // By default only fitted range is shown
 
     regPlot(frame,"rf203_plot") ;
-    regResult(r_full,"rf203_r_full") ;
-    regResult(r_sig,"rf203_r_sig") ;
+    regResult(std::move(r_full),"rf203_r_full") ;
+    regResult(std::move(r_sig),"rf203_r_sig") ;
 
     return true;
   }
@@ -1216,10 +1216,10 @@ public:
 
 
     // Perform unbinned extended ML fit to data
-    RooFitResult* r = model.fitTo(*data,Extended(true),Save(),BatchMode(_batchMode)) ;
+    std::unique_ptr<RooFitResult> r{model.fitTo(*data,Extended(true),Save(),BatchMode(_batchMode))};
 
 
-    regResult(r,"rf204_result") ;
+    regResult(std::move(r),"rf204_result") ;
 
     return true ;
   }
@@ -2485,10 +2485,10 @@ public:
   // -------------------------------------------------------------------------------------
 
   // Perform fit in SideBand1 region (RooAddPdf coefficients will be interpreted in full range)
-  RooFitResult* r_sb1 = model.fitTo(*modelData,Range("SB1"),Save(),BatchMode(_batchMode)) ;
+  std::unique_ptr<RooFitResult> r_sb1{model.fitTo(*modelData,Range("SB1"),Save(),BatchMode(_batchMode))};
 
   // Perform fit in SideBand2 region (RooAddPdf coefficients will be interpreted in full range)
-  RooFitResult* r_sb2 = model.fitTo(*modelData,Range("SB2"),Save(),BatchMode(_batchMode)) ;
+  std::unique_ptr<RooFitResult> r_sb2{model.fitTo(*modelData,Range("SB2"),Save(),BatchMode(_batchMode))};
 
 
 
@@ -2497,12 +2497,12 @@ public:
 
   // Now perform fit to joint 'L-shaped' sideband region 'SB1|SB2'
   // (RooAddPdf coefficients will be interpreted in full range)
-  RooFitResult* r_sb12 = model.fitTo(*modelData,Range("SB1,SB2"),Save(),BatchMode(_batchMode)) ;
+  std::unique_ptr<RooFitResult> r_sb12{model.fitTo(*modelData,Range("SB1,SB2"),Save(),BatchMode(_batchMode))};
 
 
-  regResult(r_sb1,"rf312_fit_sb1") ;
-  regResult(r_sb2,"rf312_fit_sb2") ;
-  regResult(r_sb12,"rf312_fit_sb12") ;
+  regResult(std::move(r_sb1),"rf312_fit_sb1") ;
+  regResult(std::move(r_sb2),"rf312_fit_sb2") ;
+  regResult(std::move(r_sb12),"rf312_fit_sb12") ;
 
   return true ;
 
@@ -2641,7 +2641,7 @@ public:
   // F i t   p d f   t o   d a t a   i n   a c c e p t a n c e   r e g i o n
   // -----------------------------------------------------------------------
 
-  RooFitResult* r = model.fitTo(*dacc,Save(),BatchMode(_batchMode)) ;
+  std::unique_ptr<RooFitResult> r{model.fitTo(*dacc,Save(),BatchMode(_batchMode))};
 
 
 
@@ -2655,7 +2655,7 @@ public:
   dacc->plotOn(frame,Name("dacc")) ;
 
   // Print fit results to demonstrate absence of bias
-  regResult(r,"rf314_fit") ;
+  regResult(std::move(r),"rf314_fit") ;
   regPlot(frame,"rf314_plot1") ;
 
   return true;
@@ -3025,7 +3025,7 @@ public:
   //       event weights represent Poisson statistics themselves.
   //       In general, parameter error reflect precision of SumOfWeights
   //       events rather than NumEvents events. See comparisons below
-  RooFitResult* r_ml_wgt = p2.fitTo(dataw,Save(),BatchMode(_batchMode)) ;
+  std::unique_ptr<RooFitResult> r_ml_wgt{p2.fitTo(dataw,Save(),BatchMode(_batchMode))};
 
 
 
@@ -3056,8 +3056,8 @@ public:
   std::unique_ptr<RooDataSet> data3{genPdf.generate(x,43000)};
 
   // Fit the 2nd order polynomial to both unweighted datasets and save the results for comparison
-  RooFitResult* r_ml_unw10 = p2.fitTo(*data2,Save(),BatchMode(_batchMode)) ;
-  RooFitResult* r_ml_unw43 = p2.fitTo(*data3,Save(),BatchMode(_batchMode)) ;
+  std::unique_ptr<RooFitResult> r_ml_unw10{p2.fitTo(*data2,Save(),BatchMode(_batchMode))};
+  std::unique_ptr<RooFitResult> r_ml_unw43{p2.fitTo(*data3,Save(),BatchMode(_batchMode))};
 
 
   // C h i 2   f i t   o f   p d f   t o   b i n n e d   w e i g h t e d   d a t a s e t
@@ -3077,7 +3077,7 @@ public:
   m.hesse() ;
 
   // Plot chi^2 fit result on frame as well
-  RooFitResult* r_chi2_wgt = m.save() ;
+  std::unique_ptr<RooFitResult> r_chi2_wgt{m.save()};
   p2.plotOn(frame,LineStyle(kDashed),LineColor(kRed),Name("p2_alt")) ;
 
 
@@ -3089,10 +3089,10 @@ public:
   // than to 1Kevt of unweighted data, whereas the reference chi^2 fit with SumW2 error gives a result closer to
   // that of an unbinned ML fit to 1Kevt of unweighted data.
 
-  regResult(r_ml_unw10,"rf403_ml_unw10") ;
-  regResult(r_ml_unw43,"rf403_ml_unw43") ;
-  regResult(r_ml_wgt  ,"rf403_ml_wgt") ;
-  regResult(r_chi2_wgt ,"rf403_ml_chi2") ;
+  regResult(std::move(r_ml_unw10),"rf403_ml_unw10") ;
+  regResult(std::move(r_ml_unw43),"rf403_ml_unw43") ;
+  regResult(std::move(r_ml_wgt)  ,"rf403_ml_wgt") ;
+  regResult(std::move(r_chi2_wgt) ,"rf403_ml_chi2") ;
   regPlot(frame,"rf403_plot1") ;
 
   return true ;
@@ -3813,7 +3813,7 @@ public:
   // matrix, the EDM, the minimized FCN , the last MINUIT status code and
   // the number of times the RooFit function object has indicated evaluation
   // problems (e.g. zero probabilities during likelihood evaluation)
-  RooFitResult* r = m.save() ;
+  std::unique_ptr<RooFitResult> r{m.save()};
 
 
   // C h a n g e   p a r a m e t e r   v a l u e s ,   f l o a t i n g
@@ -3834,10 +3834,10 @@ public:
   m.migrad() ;
   m.hesse() ;
 
-  RooFitResult* r2 = m.save() ;
+  std::unique_ptr<RooFitResult> r2{m.save()};
 
-  regResult(r,"rf601_r") ;
-  regResult(r2,"rf601_r2") ;
+  regResult(std::move(r),"rf601_r") ;
+  regResult(std::move(r2),"rf601_r2") ;
 
   return true ;
   }
@@ -3906,9 +3906,9 @@ public:
   m.migrad() ;
   m.hesse() ;
 
-  RooFitResult* r = m.save() ;
+  std::unique_ptr<RooFitResult> r{ m.save()};
 
-  regResult(r,"rf602_r") ;
+  regResult(std::move(r),"rf602_r");
 
   return true ;
   }
@@ -3971,10 +3971,10 @@ public:
   RooProdPdf modelc("modelc","model with constraint",RooArgSet(model,fconstraint)) ;
 
   // Fit modelc without use of constraint term
-  RooFitResult* r1 = modelc.fitTo(*d,Save(),BatchMode(_batchMode)) ;
+  std::unique_ptr<RooFitResult> r1{modelc.fitTo(*d,Save(),BatchMode(_batchMode))};
 
   // Fit modelc with constraint term on parameter f
-  RooFitResult* r2 = modelc.fitTo(*d,Constrain(f),Save(),BatchMode(_batchMode)) ;
+  std::unique_ptr<RooFitResult> r2{modelc.fitTo(*d,Constrain(f),Save(),BatchMode(_batchMode))};
 
 
 
@@ -3985,12 +3985,12 @@ public:
   RooGaussian fconstext("fconstext","fconstext",f,0.2,0.1) ;
 
   // Fit with external constraint
-  RooFitResult* r3 = model.fitTo(*d,ExternalConstraints(fconstext),Save(),BatchMode(_batchMode)) ;
+  std::unique_ptr<RooFitResult> r3{model.fitTo(*d,ExternalConstraints(fconstext),Save(),BatchMode(_batchMode))};
 
 
-  regResult(r1,"rf604_r1") ;
-  regResult(r2,"rf604_r2") ;
-  regResult(r3,"rf604_r3") ;
+  regResult(std::move(r1),"rf604_r1") ;
+  regResult(std::move(r2),"rf604_r2") ;
+  regResult(std::move(r3),"rf604_r3") ;
 
   return true ;
   }


### PR DESCRIPTION
In particular, this commit migrates `RooAbsPdf::fitTo()` and the functions to create cumulative density functions.

