### PR TITLE
[RF] Fix off-by-one error in HistoToWorkspaceFactoryFast

### DIFF
--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -757,7 +757,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
       fObsNameVec.push_back( fObsName );
     }
 
-    if (fObsNameVec.empty() || fObsNameVec.size() >= 3) {
+    if (fObsNameVec.empty() || fObsNameVec.size() > 3) {
       throw hf_exc("HistFactory is limited to 1- to 3-dimensional histograms.");
     }
 


### PR DESCRIPTION
There is an error here that was introduced in `dc65afe`:

https://github.com/root-project/root/blob/6abb8e90d9bea276269f375a67855c4065813343/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx#L760-L762

 This error should only be thrown when the number of observables is not 1, 2 or 3, but currently fires if the number is equal to 3.

See the change from `dc65afe` here where the mistake is evident:

https://github.com/root-project/root/commit/dc65afe00ec72d18ebc5d31e7b2d6b50c6a20423#diff-42ea09980f1ed2bacde4381f212c35d78be6ddedccf746953dc99d6455525d8aL1256-R1221

The conditional should be
`if (fObsNameVec.empty() || fObsNameVec.size() > 3)`

This needs to be backported to ROOT 6.26 and 6.28 to make it into the next patch releases.

Thanks to @CoffeeIntoScience for reporting this bug!