### PR TITLE
[v628][RF] Backports of RooFit PRs to `v6-28-00-patches`: Part 17

### DIFF
--- a/core/multiproc/inc/TMPWorkerExecutor.h
+++ b/core/multiproc/inc/TMPWorkerExecutor.h
@@ -16,6 +16,7 @@
 #include "MPSendRecv.h"
 #include "PoolUtils.h"
 #include "TMPWorker.h"
+
 #include <string>
 #include <vector>
 
@@ -173,13 +174,12 @@ public:
    {
       unsigned code = msg.first;
       TSocket *s = GetSocket();
-      std::string reply = "S" + std::to_string(GetNWorker());
       if (code == MPCode::kExecFuncWithArg) {
          unsigned n;
          msg.second->ReadUInt(n);
          MPSend(s, MPCode::kFuncResult, fFunc(fArgs[n]));
       } else {
-         reply += ": unknown code received: " + std::to_string(code);
+         std::string reply = "S" + std::to_string(GetNWorker()) + ": unknown code received: " + std::to_string(code);
          MPSend(s, MPCode::kError, reply.c_str());
       }
    }

--- a/math/mathmore/inc/Math/VavilovAccurate.h
+++ b/math/mathmore/inc/Math/VavilovAccurate.h
@@ -329,14 +329,14 @@ public:
 
 
 private:
-   enum{MAXTERMS=500};
+   constexpr static int MAXTERMS{500};
    double fH[8], fT0, fT1, fT, fOmega, fA_pdf[MAXTERMS+1], fB_pdf[MAXTERMS+1], fA_cdf[MAXTERMS+1], fB_cdf[MAXTERMS+1], fX0;
    double fKappa, fBeta2;
    double fEpsilonPM, fEpsilon;
 
    mutable bool fQuantileInit;
    mutable int fNQuant;
-   enum{kNquantMax=32};
+   constexpr static int kNquantMax{32};
    mutable double fQuant[kNquantMax];
    mutable double fLambda[kNquantMax];
 

--- a/math/minuit/inc/TMinuit.h
+++ b/math/minuit/inc/TMinuit.h
@@ -252,7 +252,7 @@ public:
    virtual void   mnset();
    virtual void   mnsimp();
    virtual void   mnstat(Double_t &fmin, Double_t &fedm, Double_t &errdef, Int_t &npari, Int_t &nparx, Int_t &istat);
-   virtual void   mntiny(volatile Double_t epsp1, Double_t &epsbak);
+   virtual void   mntiny(Double_t epsp1, Double_t &epsbak);
    Bool_t         mnunpt(TString &cfname);
    virtual void   mnvert(Double_t *a, Int_t l, Int_t m, Int_t n, Int_t &ifail);
    virtual void   mnwarn(const char *copt, const char *corg, const char *cmes);

--- a/math/minuit/src/TMinuit.cxx
+++ b/math/minuit/src/TMinuit.cxx
@@ -7657,7 +7657,7 @@ void TMinuit::mnstat(Double_t &fmin, Double_t &fedm, Double_t &errdef, Int_t &np
 /// the value .TRUE. if they are equal.  To find EPSMAC
 /// safely by foiling the Fortran optimiser
 
-void TMinuit::mntiny(volatile Double_t epsp1, Double_t &epsbak)
+void TMinuit::mntiny(Double_t epsp1, Double_t &epsbak)
 {
    epsbak = epsp1 - 1;
 }

--- a/math/minuit2/inc/Minuit2/MnTiny.h
+++ b/math/minuit2/inc/Minuit2/MnTiny.h
@@ -23,7 +23,7 @@ public:
 
    double One() const;
 
-   double operator()(volatile double epsp1) const;
+   double operator()(double epsp1) const;
 
 private:
    double fOne;

--- a/math/minuit2/src/MnTiny.cxx
+++ b/math/minuit2/src/MnTiny.cxx
@@ -18,7 +18,7 @@ double MnTiny::One() const
    return fOne;
 }
 
-double MnTiny::operator()(volatile double epsp1) const
+double MnTiny::operator()(double epsp1) const
 {
    // evaluate minimal diference between two floating points
    double result = epsp1 - One();

--- a/roofit/batchcompute/src/Initialisation.cxx
+++ b/roofit/batchcompute/src/Initialisation.cxx
@@ -31,11 +31,9 @@ namespace {
 void loadWithErrorChecking(const std::string &libName)
 {
    const auto returnValue = gSystem->Load(libName.c_str());
-   if (returnValue == -1 || returnValue == -2)
+   if (returnValue == -1 || returnValue == -2) {
       throw std::runtime_error("RooFit was unable to load its computation library " + libName);
-   else if (returnValue == 1) // Library should not have been loaded before we tried to do it.
-      throw std::logic_error("RooFit computation library " + libName +
-                             " was loaded before RooFit initialisation began.");
+   }
 }
 
 } // end anonymous namespace

--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -757,7 +757,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
       fObsNameVec.push_back( fObsName );
     }
 
-    if (fObsNameVec.empty() || fObsNameVec.size() >= 3) {
+    if (fObsNameVec.empty() || fObsNameVec.size() > 3) {
       throw hf_exc("HistFactory is limited to 1- to 3-dimensional histograms.");
     }
 

--- a/roofit/roofit/inc/RooKeysPdf.h
+++ b/roofit/roofit/inc/RooKeysPdf.h
@@ -63,7 +63,7 @@ private:
   double *_weights;  //[_nEvents]
   double _sumWgt ;
 
-  enum { _nPoints = 1000 };
+  constexpr static int _nPoints{1000};
   double _lookupTable[_nPoints+1];
 
   double g(double x,double sigma) const;

--- a/roofit/roofit/src/RooGamma.cxx
+++ b/roofit/roofit/src/RooGamma.cxx
@@ -113,12 +113,47 @@ double RooGamma::analyticalIntegral(Int_t code, const char* rangeName) const
   return integral ;
 }
 
+namespace {
+
+inline double randomGamma(double gamma, double beta, double mu, double xmin, double xmax)
+{
+   while (true) {
+
+      double d = gamma - 1. / 3.;
+      double c = 1. / TMath::Sqrt(9. * d);
+      double xgen = 0;
+      double v = 0;
+
+      while (v <= 0.) {
+         xgen = RooRandom::randomGenerator()->Gaus();
+         v = 1. + c * xgen;
+      }
+      v = v * v * v;
+      double u = RooRandom::randomGenerator()->Uniform();
+      if (u < 1. - .0331 * (xgen * xgen) * (xgen * xgen)) {
+         double x = ((d * v) * beta + mu);
+         if ((x < xmax) && (x > xmin)) {
+            return x;
+         }
+      }
+      if (TMath::Log(u) < 0.5 * xgen * xgen + d * (1. - v + TMath::Log(v))) {
+         double x = ((d * v) * beta + mu);
+         if ((x < xmax) && (x > xmin)) {
+            return x;
+         }
+      }
+   }
+}
+
+} // namespace
+
 ////////////////////////////////////////////////////////////////////////////////
 
-Int_t RooGamma::getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, bool /*staticInitOK*/) const
+Int_t RooGamma::getGenerator(const RooArgSet &directVars, RooArgSet &generateVars, bool /*staticInitOK*/) const
 {
-  if (matchArgs(directVars,generateVars,x)) return 1 ;
-  return 0 ;
+   if (matchArgs(directVars, generateVars, x))
+      return 1;
+   return 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -130,41 +165,22 @@ Int_t RooGamma::getGenerator(const RooArgSet& directVars, RooArgSet &generateVar
 /// The speed of this algorithm depends on the speed of generating normal variates.
 /// The algorithm is limited to \f$ \gamma \geq 0 \f$ !
 
-void RooGamma::generateEvent(Int_t code)
+void RooGamma::generateEvent(Int_t /*code*/)
 {
-  R__ASSERT(code==1) ;
+   if (gamma >= 1) {
+      x = randomGamma(gamma, beta, mu, x.min(), x.max());
+      return;
+   }
 
+   double xVal = 0.0;
+   bool accepted = false;
 
-  while(1) {
+   while (!accepted) {
+      double u = RooRandom::randomGenerator()->Uniform();
+      double tmp = randomGamma(1 + gamma, beta, mu, 0, std::numeric_limits<double>::infinity());
+      xVal = tmp * std::pow(u, 1.0 / gamma);
+      accepted = xVal < x.max() && xVal > x.min();
+   }
 
-  double d = 0;
-  double c = 0;
-  double xgen = 0;
-  double v = 0;
-  double u = 0;
-  d = gamma -1./3.; c = 1./TMath::Sqrt(9.*d);
-
-  while(v <= 0.){
-    xgen = RooRandom::randomGenerator()->Gaus(); v = 1. + c*xgen;
-  }
-  v = v*v*v; u = RooRandom::randomGenerator()->Uniform();
-  if( u < 1.-.0331*(xgen*xgen)*(xgen*xgen) ) {
-    if ( (((d*v)* beta + mu ) < x.max()) && (((d*v)* beta + mu) > x.min()) ) {
-      x = ((d*v)* beta + mu) ;
-      break;
-    }
-  }
-  if( TMath::Log(u) < 0.5*xgen*xgen + d*(1.-v + TMath::Log(v)) ) {
-    if ( (((d*v)* beta + mu ) < x.max()) && (((d*v)* beta + mu) > x.min()) ) {
-      x = ((d*v)* beta + mu) ;
-      break;
-    }
-  }
-
-  }
-
-
-  return;
+   x = xVal;
 }
-
-

--- a/roofit/roofitcore/src/RooRealIntegral.cxx
+++ b/roofit/roofitcore/src/RooRealIntegral.cxx
@@ -227,7 +227,7 @@ Int_t RooRealIntegral::_cacheAllNDim(2) ;
 
 RooRealIntegral::RooRealIntegral()
 {
-  TRACE_CREATE
+  TRACE_CREATE;
 }
 
 
@@ -357,9 +357,10 @@ RooRealIntegral::RooRealIntegral(const char *name, const char *title,
   }
   exclLVBranches.remove(depList,true,true) ;
 
-  // Initial fill of list of LValue leaf servers (put in intDepList)
+  // Initial fill of list of LValue leaf servers (put in intDepList, but the
+  // instances that are in the actual computation graph of the function)
   RooArgSet exclLVServers("exclLVServers") ;
-  exclLVServers.add(intDepList) ;
+  function.getObservables(&intDepList, exclLVServers);
 
   // Obtain mutual exclusive dependence by iterative reduction
   bool converged(false) ;
@@ -447,14 +448,9 @@ RooRealIntegral::RooRealIntegral(const char *name, const char *title,
   // * E) interact with function to make list of objects actually integrated analytically  *
   // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
-  RooArgSet anIntDepList ;
+  _mode = function.getAnalyticalIntegralWN(anIntOKDepList,_anaList,_funcNormSet.get(),RooNameReg::str(_rangeName)) ;
 
-  RooArgSet anaSet{ _anaList, Form("UniqueCloneOf_%s",_anaList.GetName())};
-  _mode = function.getAnalyticalIntegralWN(anIntOKDepList,anaSet,_funcNormSet.get(),RooNameReg::str(_rangeName)) ;
-  _anaList.removeAll() ;
-  _anaList.add(anaSet);
-
-  // Avoid confusion -- if mode is zero no analytical integral is defined regardless of contents of _anaListx
+  // Avoid confusion -- if mode is zero no analytical integral is defined regardless of contents of _anaList
   if (_mode==0) {
     _anaList.removeAll() ;
   }
@@ -600,7 +596,7 @@ RooRealIntegral::RooRealIntegral(const char *name, const char *title,
     }
   }
 
-  TRACE_CREATE
+  TRACE_CREATE;
 }
 
 
@@ -758,7 +754,7 @@ RooRealIntegral::RooRealIntegral(const RooRealIntegral& other, const char* name)
  other._intList.snapshot(_saveInt) ;
  other._sumList.snapshot(_saveSum) ;
 
-  TRACE_CREATE
+  TRACE_CREATE;
 }
 
 
@@ -766,7 +762,7 @@ RooRealIntegral::RooRealIntegral(const RooRealIntegral& other, const char* name)
 
 RooRealIntegral::~RooRealIntegral()
 {
-  TRACE_DESTROY
+  TRACE_DESTROY;
 }
 
 


### PR DESCRIPTION
This is a backport of some RooFit PRs that were recently merged to master to v6-28-00-patches.

1. https://github.com/root-project/root/pull/12682
2. https://github.com/root-project/root/pull/12696
3. https://github.com/root-project/root/pull/12699
4. https://github.com/root-project/root/pull/12702
5. https://github.com/root-project/root/pull/12707

Related to https://github.com/root-project/root/issues/12319.

After merging this PR, the following RooFit commits in ROOT `master` (as of `d6cb771d7f`) are the ones that are not in `v6-28-00-patches` (as of `to fill out after merging`).

```txt
7c88a7414b [RF] Migrate more RooFit functions to `RooFit::OwningPtr<T>`
5d5e1bcce1 [RF] Fix build due to changed compute() signature
f69a346520 [RF] Update FitParabola test in `testNaNPacker` to also run on GPU
a3294b725f [RF] Code format for `testNaNPacker.cxx`
8a67cf611c [RF] Support pdf normalization with error logging in RooBatchCompute
5ae7ae018e [RF] More `RooNaNPacker` to RooBatchCompute
84870e3207 [RF] Less use of the `RunContext` class in RooFit
aa47d71aae [RF] Implement `RooPolynomial` and `RooPolyVar` in BatchMode
e826686911 [RF] Remove the `RooAbsReal::evaluateSpan()` family of functions
3608bc02fb [RF] Don't put scalar intermediate results into loops in generated code
249131f739 [RF] Generalize and reuse some of the BatchMode code in code squashing
7a12837f66 [RF] Split up CodeSquashContext in `.h` and `.cxx` file
1985b1b8d7 [RF] Reuse BatchMode code to fill observables vector in RooFuncVector
022e9fbd49 [RF] Improved implementation of `RooHelpers::Detail::snapshotImpl()`
d2bb816269 [RF] Move implemenation of `RooAbsArg::cloneTree()` to RooHelpers
cf515dec74 [RF] Optimize implementation of `cloneTreeWithSameParameters()`
3d258d8a4c [RF] Mode `RooAbsCollection::snapshot()` implementation to RooHelpers
f4fc140268 [RF] Remove RooMomentMorphND
6af8005e97 [RF] Add `selfNormalized` flag to RooWrapperPdf
d677b811d9 [RF] Increase version number of `RooRealVar` from 9 to 10
13d83d5808 [RF] Fix wrong size for gradient output array in testRooFuncWrapper.
912c32c5e2 [RF] Remove deprecated `Format(const char*, int)` command argument
6dcc352289 [RF] Move loop management for code generation into CodeSquashContext
ad2361c6ea [RF] Avoid need for buildLoopBegin() by recursive calls to translate()
c43c1ff1f3 [RF] Add 'translate' to RooNllVarNew.
666a4fcbde [RF] Minor improvements to RooFit evaluation code generation
c51376731b [RF][NFC] Fix typo.
826a6b38f4 [RF] Disable RooFuncWrapper test if clad is off.
4148a05e5a [RF] Remove wrong header declaration from roofit/roofit.
98d004c200 [RF] Fix visibility of the res/ directories.
e97347056c [RF] Make RooBatchCompute dependency public.
4483b01b7f [RF] Add initial interface and implementation for code-squashing.
f230374eb5 [RF] Enable passing of gradient function directly to RooMinimizer
0e5633535a [RF] Add support for differentiating Gaussian integrals using AD. This commits adds support for including analytical integrals into the mock code-squashing test by introducing a private header that stores the stateless implementation details.
7d39c0769c [RF] Enable analytic integration of RooHistPdfs with RooLinearVars
fce73f0565 [RF] Replace `RooAbsReal::_lastNSet` pointer with ID of last normSet
7e9c10b714 [RF] Remove `evaluateSpan()` from RooGenericPdf and RooFormulaVar
bf4990c5d4 [RF] Exclude RooHistError from IO
79edfbafa6 [RF] Remove `add(row, weight, weightError)` from RooAbsData interface
f355c3ced4 [RF] Code-format `testRooDataHist.cxx`
3fd99f7679 [RF] Enable AD code-gen test for RooFit.
a654d915e5 [RF] Less manual memory management in RooAbsArg and RooProdGenContext
1367091202 [RF] Code modernization of RooAbsReal
5c20fdc652 [RF] Add intiial minimizer interface for RooFuncWrapper.
cf88615b6e [RF] Improve code in `MinuitFcnGrad`
17bac5528b [RF] Code improvements in tests for new TestStatistics
afcb2d3931 [RF] Composition over inheritance in RooAbsMinimizerFcn implementations
3a52e89a99 [RF] No need for `RooAbsMinimizerFcn::fit()` method
3869282efb Fix modules and modules.idx generation on Windows and disable a few more modules causing potential crashes (#12252)
55bc2c0484 [RF] Define infinity as `std::numeric_limits<double>::infinity()`
026a1a701b [RF] Split RooFuncWrapper into '.h' and '.cxx'.
5964158260 [RF] Add observables as another parameter in RooFuncWrapper.
cca7c59a08 [RF] Test rough prototype of code generation in `testRooFuncWrapper`
333e857cc6 Add AD based derivatives for RooFuncWrapper.
46ba2eefd0 [cxxmodules] Enable a few modules for Windows. Now we can run hsimple.C.
fe8738ab41 [RF] Make it possible to switch to `ryml` backend after building ROOT
1ca66d2949 [RF] Add a C/C++ function wrapper class in roofit.
f457ca57c1 [RF] Fix implementation error from typo in `RooGenProdProj`
cc9d4e8025 [RF] New mechanism to implicitly convert numbers to RooRealVar&
8798fca2a3 [RF] Remove RooFormula code for gcc <= 4.8
a89130ac51 [RF] Remove `RooGenFunction` and `RooMultiGenFunction`
1554fba5e2 [RF] More use of `snapshot()` overload with output parameter
72cfdc9192 [RF] Bring back `RooStats::FeldmanCousins::SetData()`
faea4c9de4 [RF] Remove deprecated RooFit parts that are marked for removal in 6.30
```