### PR TITLE
[v626][RF] Backports of RooFit PRs to `v6-26-00-patches`: Part 28

### DIFF
--- a/roofit/batchcompute/src/Initialisation.cxx
+++ b/roofit/batchcompute/src/Initialisation.cxx
@@ -30,11 +30,9 @@ namespace {
 void loadWithErrorChecking(const std::string &libName)
 {
    const auto returnValue = gSystem->Load(libName.c_str());
-   if (returnValue == -1 || returnValue == -2)
+   if (returnValue == -1 || returnValue == -2) {
       throw std::runtime_error("RooFit was unable to load its computation library " + libName);
-   else if (returnValue == 1) // Library should not have been loaded before we tried to do it.
-      throw std::logic_error("RooFit computation library " + libName +
-                             " was loaded before RooFit initialisation began.");
+   }
 }
 
 } // end anonymous namespace

--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -1155,7 +1155,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
       fObsNameVec.push_back( fObsName );
     }
 
-    if (fObsNameVec.size() == 0 || fObsNameVec.size() >= 3) {
+    if (fObsNameVec.empty() || fObsNameVec.size() > 3) {
       throw hf_exc("HistFactory is limited to 1- to 3-dimensional histograms.");
     }
 


### PR DESCRIPTION
This is a backport of all the relevant bugfix RooFit PRs that were recently merged to master to v6-26-00-patches (in the right order, to not have the commit history diverge too much).

1. https://github.com/root-project/root/pull/12696
2. https://github.com/root-project/root/pull/12707

Related to https://github.com/root-project/root/issues/11534.

