### PR TITLE
Patch builtin_tbb for GCC 13

### DIFF
--- a/builtins/tbb/patches/gcc13.patch
+++ b/builtins/tbb/patches/gcc13.patch
@@ -1,0 +1,11 @@
+--- include/tbb/task.h	2023-04-27 10:36:57.063855815 +0200
++++ include/tbb/task.h	2023-04-27 10:37:14.823074536 +0200
+@@ -238,7 +238,7 @@
+ #if __TBB_TASK_PRIORITY
+         //! Pointer to the next offloaded lower priority task.
+         /** Used to maintain a list of offloaded tasks inside the scheduler. **/
+-        task* next_offloaded;
++        tbb::task* next_offloaded;
+ #endif
+ 
+ #if __TBB_PREVIEW_RESUMABLE_TASKS

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1404,6 +1404,7 @@ if(builtin_tbb)
       URL_HASH SHA256=${tbb_sha256}
       INSTALL_DIR ${CMAKE_BINARY_DIR}
       PATCH_COMMAND sed -i -e "/clang -v/s@-v@--version@" build/macos.inc
+      COMMAND patch -p0 -i ${CMAKE_SOURCE_DIR}/builtins/tbb/patches/gcc13.patch
       COMMAND ${tbb_command}
       CONFIGURE_COMMAND ""
       BUILD_COMMAND make ${_tbb_compiler} cpp0x=1 "CXXFLAGS=${_tbb_cxxflags}" CPLUS=${CMAKE_CXX_COMPILER} CONLY=${CMAKE_C_COMPILER} "LDFLAGS=${_tbb_ldflags}"


### PR DESCRIPTION
The new compiler complains that the declaration of `task_prefix::task()` changes meaning of `task`, as used in `task* next_offloaded`.