### PR TITLE
[RF] Update ParamHistFunc.cxx - remove bogus assertion

### DIFF
--- a/roofit/histfactory/src/ParamHistFunc.cxx
+++ b/roofit/histfactory/src/ParamHistFunc.cxx
@@ -673,7 +673,6 @@ double ParamHistFunc::analyticalIntegralWN(Int_t /*code*/, const RooArgSet* /*no
 
   for (unsigned int i=0; i < _paramSet.size(); ++i) {
     const auto& param = static_cast<const RooAbsReal&>(_paramSet[i]);
-    assert(static_cast<Int_t>(i) == _dataSet.getIndex(param)); // We assume that each parameter i belongs to bin i
 
     // Get the gamma's value
     const double paramVal = param.getVal();


### PR DESCRIPTION
the assertion seems bogus - the param value is not the coordinate in the paramHistFunc, so just get rid of that assert
