### PR TITLE
[v6-28] Qualify calls to llvm::format that have ::std:: types as parameters to avoid ambiguity in overload resolution when ADL finds `std::format`.

### DIFF
--- a/interpreter/llvm/src/utils/TableGen/GlobalISel/GIMatchDag.cpp
+++ b/interpreter/llvm/src/utils/TableGen/GlobalISel/GIMatchDag.cpp
@@ -48,7 +48,7 @@ void GIMatchDag::writeDOTGraph(raw_ostream &OS, StringRef ID) const {
          << Assignment.first << ")";
       Separator = ", ";
     }
-    OS << format("|%p|", &N);
+    OS << llvm::format("|%p|", &N);
     writePorts("d", N->getOperandInfo());
     OS << "}\"";
     if (N->isMatchRoot())
@@ -82,7 +82,7 @@ void GIMatchDag::writeDOTGraph(raw_ostream &OS, StringRef ID) const {
     writePorts("s", N->getOperandInfo());
     OS << "|" << N->getName() << "|";
     N->printDescription(OS);
-    OS << format("|%p|", &N);
+    OS << llvm::format("|%p|", &N);
     writePorts("d", N->getOperandInfo());
     OS << "}\",style=dotted]\n";
   }


### PR DESCRIPTION

Differential Revision: https://reviews.llvm.org/D119213
