### PR TITLE
[cocoa] Prevent cocoa FontCache::GetTextWidth() crash:

### DIFF
--- a/graf2d/cocoa/src/FontCache.mm
+++ b/graf2d/cocoa/src/FontCache.mm
@@ -417,6 +417,9 @@ void FontCache::FreeFontNames(char **fontList)
 //______________________________________________________________________________
 unsigned FontCache::GetTextWidth(FontStruct_t font, const char *text, int nChars)
 {
+   if (nChars == 0)
+      return 0;
+
    typedef std::vector<CGSize>::size_type size_type;
    //
    CTFontRef fontRef = (CTFontRef)font;


### PR DESCRIPTION
On macOS 13.3 with Xcode 14.3, vector construction begin begin/end iterators -to-dofferent-type (here, casting char to UniChar aka unsigned short) fails in optimized mode for seemingly dubious reasons (i.e. likely an optimizer bug). Short-circuit this by returning 0 early for an extent of 0 characters - which is the only case where this construction (i.e. end==begin) is known to fail.
