### PR TITLE
[RF] Mark template specialization as inline

### DIFF
--- a/roofit/roofitcore/inc/RooAbsSelfCachedReal.h
+++ b/roofit/roofitcore/inc/RooAbsSelfCachedReal.h
@@ -109,7 +109,7 @@ RooArgSet *RooAbsSelfCached<Base_t>::actualObservables(const RooArgSet &nset) co
 }
 
 template <>
-RooArgSet *RooAbsSelfCached<RooAbsCachedPdf>::actualObservables(const RooArgSet & /*nset*/) const
+inline RooArgSet *RooAbsSelfCached<RooAbsCachedPdf>::actualObservables(const RooArgSet & /*nset*/) const
 {
    // Make list of servers
    auto serverSet = new RooArgSet;


### PR DESCRIPTION
Otherwise generation of `modules.idx` fails with "Failed to materialize symbols", naming this exact template specialization. An alternative would be outline this function to a source file and compile it into the library.

Fixes commit 9357c9842a ("[RF] Unify RooAbsSelfCachedPdf and RooAbsSelfCachedReal code").