### PR TITLE
Fix seldom crash in `TPad::ShowGuidelines`

### DIFF
--- a/core/base/inc/TVirtualPad.h
+++ b/core/base/inc/TVirtualPad.h
@@ -67,6 +67,7 @@ public:
        ~TContext();
        auto IsInteractive() const { return fInteractive; }
        auto GetSaved() const { return fSaved; }
+       void PadDeleted(TVirtualPad *pad);
    };
 
 

--- a/core/base/src/TVirtualPad.cxx
+++ b/core/base/src/TVirtualPad.cxx
@@ -66,6 +66,15 @@ TVirtualPad::TContext::~TContext()
       fSaved->cd();
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// Inform context that pad deleted or will be deleted soon
+/// Reference on that pad should be cleared
+
+void TVirtualPad::TContext::PadDeleted(TVirtualPad *pad)
+{
+   if (pad == fSaved)
+      fSaved = nullptr;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return the current pad for the current thread.

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -6230,13 +6230,11 @@ void TPad::ShowGuidelines(TObject *object, const Int_t event, const char mode, c
 
    //delete all existing Guidelines and create new invisible pad
    if (tmpGuideLinePad) {
-      if (object == tmpGuideLinePad) { // in case of funny button click combination.
-         tmpGuideLinePad->Delete();
-         tmpGuideLinePad = nullptr;
-         return;
-      }
+      ctxt.PadDeleted(tmpGuideLinePad);
+      auto guidePadClicked = (object == tmpGuideLinePad); // in case of funny button click combination.
       tmpGuideLinePad->Delete();
       tmpGuideLinePad = nullptr;
+      if (guidePadClicked) return;
    }
 
    // Get Primitives

--- a/js/build/jsroot.js
+++ b/js/build/jsroot.js
@@ -11,7 +11,7 @@ let version_id = 'dev';
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-let version_date = '4/05/2023';
+let version_date = '5/05/2023';
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}
@@ -9157,11 +9157,7 @@ function parseLatex(node, arg, label, curr) {
             if (curr.x) elem.attr('x', curr.x);
             if (curr.y) elem.attr('y', curr.y);
 
-            // values used for superscript
-            curr.last_y1 = curr.y - rect.height*0.8;
-            curr.last_y2 = curr.y + rect.height*0.2;
-
-            extendPosition(curr.x, curr.last_y1, curr.x + rect.width, curr.last_y2);
+            extendPosition(curr.x, curr.y - rect.height*0.8, curr.x + rect.width, curr.y + rect.height*0.2);
 
             if (!alone) {
                shiftX(rect.width);
@@ -9301,10 +9297,6 @@ function parseLatex(node, arg, label, curr) {
             parseLatex(currG(), arg, subs.low, pos_low);
          }
 
-         if ((curr.last_y1 !== undefined) && (curr.last_y2 !== undefined)) {
-            y1 = curr.last_y1; y2 = curr.last_y2;
-         }
-
          if (pos_up) {
             positionGNode(pos_up, x, y1 - pos_up.rect.y1 - curr.fsize*0.1);
             w1 = pos_up.rect.width;
@@ -9392,10 +9384,6 @@ function parseLatex(node, arg, label, curr) {
          extendPosition(curr.x, curr.y + r.y1, curr.x + 4*w + r.width, curr.y + r.y2);
 
          shiftX(4*w + r.width);
-
-         // values used for superscript
-         curr.last_y1 = r.y1;
-         curr.last_y2 = r.y2;
 
          continue;
       }
@@ -66327,7 +66315,7 @@ class TFramePainter extends ObjectPainter {
          }
       }
 
-      if ((opts.zoom_ymin != opts.zoom_ymax) && (this.zoom_ymin == this.zoom_ymax) && !this.zoomChangedInteractive('y')) {
+      if ((opts.zoom_ymin != opts.zoom_ymax) && ((this.zoom_ymin == this.zoom_ymax) || !this.zoomChangedInteractive('y'))) {
          this.zoom_ymin = opts.zoom_ymin;
          this.zoom_ymax = opts.zoom_ymax;
       }
@@ -99934,8 +99922,12 @@ class HierarchyPainter extends BasePainter {
                   filepath += `&item=${name}`;
                }
 
+               let arg0 = 'nobrowser';
+               if (settings.WithCredentials)
+                  arg0 += '&with_credentials';
+
                menu.addDrawMenu('Draw in new tab', sett.opts,
-                                arg => window.open(`${exports.source_dir}index.htm?nobrowser&${filepath}&opt=${arg}`));
+                                arg => window.open(`${exports.source_dir}?${arg0}&${filepath}&opt=${arg}`));
             }
 
             if ((sett.expand || sett.get_expand) && !('_childs' in hitem) && (hitem._more || !('_more' in hitem)))
@@ -101014,9 +101006,9 @@ class HierarchyPainter extends BasePainter {
 
       if (sett.opts && (node._can_draw !== false))
          menu.addDrawMenu('Draw in new window', sett.opts,
-                           arg => window.open(onlineprop.server + '?nobrowser&item=' + onlineprop.itemname +
-                                              (this.isMonitoring() ? '&monitoring=' + this.getMonitoringInterval() : '') +
-                                              (arg ? '&opt=' + arg : '')));
+                           arg => window.open(onlineprop.server + `?nobrowser&item=${onlineprop.itemname}` +
+                                              (this.isMonitoring() ? `&monitoring=${this.getMonitoringInterval()}` : '') +
+                                              (arg ? `&opt=${arg}` : '')));
 
       if (sett.opts && (sett.opts.length > 0) && root_type && (node._can_draw !== false))
          menu.addDrawMenu('Draw as png', sett.opts,
@@ -108158,10 +108150,8 @@ let TGraphPainter$1 = class TGraphPainter extends ObjectPainter {
 
       // if our own histogram was used as axis drawing, we need update histogram as well
       if (this.axes_draw) {
-         let histo = this.createHistogram();
-         histo.fTitle = graph.fTitle; // copy title
-
-         let hist_painter = this.getMainPainter();
+         let histo = this.createHistogram(),
+             hist_painter = this.getMainPainter();
          if (hist_painter?.$secondary) {
             hist_painter.updateObject(histo, this.options.Axis);
             this.$redraw_hist = true;

--- a/js/changes.md
+++ b/js/changes.md
@@ -23,6 +23,7 @@
 20. Support new TScatter class
 21. Fix - rescan sumw2 when update TH1
 22. Fix - correct placing for TLegend header
+23. Fix - correctly align sub/super scripts in complex TLatex
 
 
 ## Changes in 7.3.1

--- a/js/modules/base/latex.mjs
+++ b/js/modules/base/latex.mjs
@@ -462,11 +462,7 @@ function parseLatex(node, arg, label, curr) {
             if (curr.x) elem.attr('x', curr.x);
             if (curr.y) elem.attr('y', curr.y);
 
-            // values used for superscript
-            curr.last_y1 = curr.y - rect.height*0.8;
-            curr.last_y2 = curr.y + rect.height*0.2;
-
-            extendPosition(curr.x, curr.last_y1, curr.x + rect.width, curr.last_y2);
+            extendPosition(curr.x, curr.y - rect.height*0.8, curr.x + rect.width, curr.y + rect.height*0.2);
 
             if (!alone) {
                shiftX(rect.width);
@@ -606,10 +602,6 @@ function parseLatex(node, arg, label, curr) {
             parseLatex(currG(), arg, subs.low, pos_low);
          }
 
-         if ((curr.last_y1 !== undefined) && (curr.last_y2 !== undefined)) {
-            y1 = curr.last_y1; y2 = curr.last_y2;
-         }
-
          if (pos_up) {
             positionGNode(pos_up, x, y1 - pos_up.rect.y1 - curr.fsize*0.1);
             w1 = pos_up.rect.width;
@@ -697,10 +689,6 @@ function parseLatex(node, arg, label, curr) {
          extendPosition(curr.x, curr.y + r.y1, curr.x + 4*w + r.width, curr.y + r.y2);
 
          shiftX(4*w + r.width);
-
-         // values used for superscript
-         curr.last_y1 = r.y1;
-         curr.last_y2 = r.y2;
 
          continue;
       }

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -5,7 +5,7 @@ let version_id = 'dev';
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-let version_date = '4/05/2023';
+let version_date = '5/05/2023';
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}

--- a/js/modules/gpad/TFramePainter.mjs
+++ b/js/modules/gpad/TFramePainter.mjs
@@ -1738,7 +1738,7 @@ class TFramePainter extends ObjectPainter {
          }
       }
 
-      if ((opts.zoom_ymin != opts.zoom_ymax) && (this.zoom_ymin == this.zoom_ymax) && !this.zoomChangedInteractive('y')) {
+      if ((opts.zoom_ymin != opts.zoom_ymax) && ((this.zoom_ymin == this.zoom_ymax) || !this.zoomChangedInteractive('y'))) {
          this.zoom_ymin = opts.zoom_ymin;
          this.zoom_ymax = opts.zoom_ymax;
       }

--- a/js/modules/gui/HierarchyPainter.mjs
+++ b/js/modules/gui/HierarchyPainter.mjs
@@ -1797,8 +1797,12 @@ class HierarchyPainter extends BasePainter {
                   filepath += `&item=${name}`;
                }
 
+               let arg0 = 'nobrowser';
+               if (settings.WithCredentials)
+                  arg0 += '&with_credentials';
+
                menu.addDrawMenu('Draw in new tab', sett.opts,
-                                arg => window.open(`${source_dir}index.htm?nobrowser&${filepath}&opt=${arg}`));
+                                arg => window.open(`${source_dir}?${arg0}&${filepath}&opt=${arg}`));
             }
 
             if ((sett.expand || sett.get_expand) && !('_childs' in hitem) && (hitem._more || !('_more' in hitem)))
@@ -2878,9 +2882,9 @@ class HierarchyPainter extends BasePainter {
 
       if (sett.opts && (node._can_draw !== false))
          menu.addDrawMenu('Draw in new window', sett.opts,
-                           arg => window.open(onlineprop.server + '?nobrowser&item=' + onlineprop.itemname +
-                                              (this.isMonitoring() ? '&monitoring=' + this.getMonitoringInterval() : '') +
-                                              (arg ? '&opt=' + arg : '')));
+                           arg => window.open(onlineprop.server + `?nobrowser&item=${onlineprop.itemname}` +
+                                              (this.isMonitoring() ? `&monitoring=${this.getMonitoringInterval()}` : '') +
+                                              (arg ? `&opt=${arg}` : '')));
 
       if (sett.opts && (sett.opts.length > 0) && root_type && (node._can_draw !== false))
          menu.addDrawMenu('Draw as png', sett.opts,

--- a/js/modules/hist2d/TGraphPainter.mjs
+++ b/js/modules/hist2d/TGraphPainter.mjs
@@ -1381,10 +1381,8 @@ class TGraphPainter extends ObjectPainter {
 
       // if our own histogram was used as axis drawing, we need update histogram as well
       if (this.axes_draw) {
-         let histo = this.createHistogram();
-         histo.fTitle = graph.fTitle; // copy title
-
-         let hist_painter = this.getMainPainter();
+         let histo = this.createHistogram(),
+             hist_painter = this.getMainPainter();
          if (hist_painter?.$secondary) {
             hist_painter.updateObject(histo, this.options.Axis);
             this.$redraw_hist = true;

--- a/tutorials/graphics/gtime.C
+++ b/tutorials/graphics/gtime.C
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_graphics
 /// Example of a graph of data moving in time.
-/// Use the canvas "File/Quit" to exit from this example
+/// Use the canvas "File/Quit ROOT" to exit from this example
 ///
 /// \macro_code
 ///
@@ -9,7 +9,7 @@
 
 void gtime()
 {
-   auto c1 = (TCanvas*) gROOT->FindObject("c1");
+   auto c1 = (TCanvas *) gROOT->FindObject("c1");
    if (c1) delete c1;
 
    c1 = new TCanvas("c1");
@@ -17,30 +17,33 @@ void gtime()
    const Int_t kNMAX = 10000;
    std::vector<Double_t> X(kNMAX), Y(kNMAX);
    Int_t cursor = kNMAX;
-   TGraph *g = new TGraph(ng);
-   g->SetMarkerStyle(21);
-   g->SetMarkerColor(kBlue);
-   Double_t x = 0;
+   Double_t x = 0, stepx = 0.1;
 
-   while (1) {
-      c1->Clear();
-      if (cursor > kNMAX-ng) {
+   while (!gSystem->ProcessEvents()) {
+      if (cursor + ng >= kNMAX) {
+         cursor = 0;
          for (Int_t i = 0; i < ng; i++) {
             X[i] = x;
-            Y[i] = sin(x);
-            x += 0.1;
+            Y[i] = TMath::Sin(x);
+            x += stepx;
          }
-         g->Draw("alp");
-         cursor = 0;
       } else {
-         x += 0.1;
          X[cursor+ng] = x;
          Y[cursor+ng] = TMath::Sin(x);
+         x += stepx;
          cursor++;
-         g->DrawGraph(ng, X.data()+cursor, Y.data()+cursor, "alp");
       }
+
+      TGraph *g = new TGraph(ng, X.data()+cursor, Y.data()+cursor);
+      g->SetMarkerStyle(21);
+      g->SetMarkerColor(kBlue);
+      g->SetLineColor(kGreen);
+      g->SetBit(kCanDelete); // let canvas delete graph when call TCanvas::Clear()
+
+      c1->Clear();
+      g->Draw("alp");
       c1->Update();
-      if (gSystem->ProcessEvents()) break;
+
       gSystem->Sleep(10);
    }
 }


### PR DESCRIPTION
In some cases gPad can be set to tmpGuideLinePad, which is deleted
any time ShowGuidelines method is called. In that case pointer on
this temporary pad should be removed from TContext object

Also fix graphics/gtime.C tutorial and several bugs in JSROOT