### PR TITLE
[pad] fix seldom crash in `TPad::ShowGuidelines` [6.28]

### DIFF
--- a/core/base/inc/TVirtualPad.h
+++ b/core/base/inc/TVirtualPad.h
@@ -67,6 +67,7 @@ public:
        ~TContext();
        auto IsInteractive() const { return fInteractive; }
        auto GetSaved() const { return fSaved; }
+       void PadDeleted(TVirtualPad *pad);
    };
 
 

--- a/core/base/src/TVirtualPad.cxx
+++ b/core/base/src/TVirtualPad.cxx
@@ -66,6 +66,15 @@ TVirtualPad::TContext::~TContext()
       fSaved->cd();
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// Inform context that pad deleted or will be deleted soon
+/// Reference on that pad should be cleared
+
+void TVirtualPad::TContext::PadDeleted(TVirtualPad *pad)
+{
+   if (pad == fSaved)
+      fSaved = nullptr;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return the current pad for the current thread.

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -6217,13 +6217,11 @@ void TPad::ShowGuidelines(TObject *object, const Int_t event, const char mode, c
 
    //delete all existing Guidelines and create new invisible pad
    if (tmpGuideLinePad) {
-      if (object == tmpGuideLinePad) { // in case of funny button click combination.
-         tmpGuideLinePad->Delete();
-         tmpGuideLinePad = nullptr;
-         return;
-      }
+      ctxt.PadDeleted(tmpGuideLinePad);
+      auto guidePadClicked = (object == tmpGuideLinePad); // in case of funny button click combination.
       tmpGuideLinePad->Delete();
       tmpGuideLinePad = nullptr;
+      if (guidePadClicked) return;
    }
 
    // Get Primitives


### PR DESCRIPTION
In some cases gPad can be set to tmpGuideLinePad, which is deleted any time ShowGuidelines method is called. In that case pointer on this temporary pad should be removed from TContext object

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

