### PR TITLE
[RF] Remove unused class rules for RooInt and RooConvIntegrandBinding

### DIFF
--- a/roofit/roofitcore/inc/LinkDef.h
+++ b/roofit/roofitcore/inc/LinkDef.h
@@ -91,7 +91,6 @@
              }"
 #pragma link C++ class RooConvCoefVar+ ;
 #pragma link C++ class RooConvGenContext+ ;
-#pragma link C++ class RooConvIntegrandBinding+ ;
 #pragma link C++ class RooCurve+ ;
 #pragma link C++ class RooDataHist- ;
 #pragma link C++ class RooDataProjBinding+ ;
@@ -130,7 +129,6 @@
 #pragma link C++ class RooBinIntegrator+ ;
 #pragma link C++ class RooIntegrator2D+ ;
 #pragma link C++ class RooIntegratorBinding+ ;
-#pragma link C++ class RooInt+ ;
 #pragma link C++ class RooInvTransform+ ;
 #pragma link C++ class RooLinearVar+ ;
 #pragma link C++ class RooLinearCombination+ ;


### PR DESCRIPTION
after commit ca29ccf161 ("[RF] Some cleanup of public `roofitcore` classes").