### PR TITLE
[tree,html] Fix C++20/GCC13 warnings (enum arithmetic, this capture):

### DIFF
--- a/html/src/TDocParser.cxx
+++ b/html/src/TDocParser.cxx
@@ -1127,7 +1127,7 @@ Bool_t TDocParser::HandleDirective(TString& line, Ssiz_t& pos, TString& word,
          if (fParseContext.size()>1)
             fParseContext.pop_back();
          if (isInCxxComment && !InContext(kComment)) {
-            fParseContext.push_back(kComment | kCXXComment);
+            fParseContext.push_back((int)kComment | (int)kCXXComment);
             fDocOutput->DecorateEntityBegin(line, pos, kComment);
          }
       }

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -3204,7 +3204,7 @@ Int_t TBranch::WriteBasketImpl(TBasket* basket, Int_t where, ROOT::Internal::TBr
    // Note: captures `basket`, `where`, and `this` by value; modifies the TBranch and basket,
    // as we make a copy of the pointer.  We cannot capture `basket` by reference as the pointer
    // itself might be modified after `WriteBasketImpl` exits.
-   auto doUpdates = [=]() {
+   auto doUpdates = [this, basket, where]() {
       Int_t nout  = basket->WriteBuffer();    //  Write buffer
       if (nout < 0)
          Error("WriteBasketImpl", "basket's WriteBuffer failed.");

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -5910,7 +5910,7 @@ void TBranchElement::SetupAddresses()
 
 void TBranchElement::SetupAddressesImpl()
 {
-   if (TestBit(kDoNotProcess|kAddressSet)) {
+   if (TestBit((long)kDoNotProcess|(long)kAddressSet)) {
       // -- Do nothing if we have been told not to.
       // Or the data member in this branch is not longer part of the
       // parent's layout.

--- a/tree/tree/src/TBranchIMTHelper.h
+++ b/tree/tree/src/TBranchIMTHelper.h
@@ -35,7 +35,7 @@ public:
    template<typename FN> void Run(const FN &lambda) {
 #ifdef R__USE_IMT
       if (!fGroup) { fGroup.reset(new TaskGroup_t()); }
-      fGroup->Run( [=]() {
+      fGroup->Run( [this, lambda]() {
          auto nbytes = lambda();
          if (nbytes >= 0) {
             fBytes += nbytes;

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -5403,7 +5403,7 @@ Int_t TTree::GetBranchStyle()
 
 Long64_t TTree::GetCacheAutoSize(Bool_t withDefault /* = kFALSE */ )
 {
-   auto calculateCacheSize = [=](Double_t cacheFactor)
+   auto calculateCacheSize = [this](Double_t cacheFactor)
    {
       Long64_t cacheSize = 0;
       if (fAutoFlush < 0) {

--- a/tree/treeplayer/src/TTreeFormula.cxx
+++ b/tree/treeplayer/src/TTreeFormula.cxx
@@ -4760,7 +4760,7 @@ Bool_t  TTreeFormula::IsLeafString(Int_t code) const
                if (fIndexes[code][fNdimensions[code]-1] != -1) return kFALSE;
                return kTRUE;
             }
-            if ( elem->GetNewType()== TStreamerInfo::kCharStar) {
+            if ( elem->GetNewType() == TStreamerInfo::kCharStar) {
                // Check whether a specific element of the string is specified!
                if (fNdimensions[code] && fIndexes[code][fNdimensions[code]-1] != -1) return kFALSE;
                return kTRUE;


### PR DESCRIPTION
e.g.
```
bitwise operation between different enumeration types ‘TBranch::EStatusBits’ and ‘TBranchElement::EStatusBits’ is deprecated [-Wdeprecated-enum-enum-conversion]
```
```
implicit capture of ‘this’ via ‘[=]’ is deprecated in C++20 [-Wdeprecated]

```

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

