### PR TITLE
[v626] Backport some commits that add missing includes

### DIFF
--- a/math/mathcore/inc/Math/Random.h
+++ b/math/mathcore/inc/Math/Random.h
@@ -25,6 +25,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 
 namespace ROOT {

--- a/tree/ntuple/v7/inc/ROOT/RDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RDaos.hxx
@@ -24,6 +24,7 @@
 // Also, this header file is known to provide macros that conflict with std::min()/std::max().
 extern "C" void d_rank_list_free(d_rank_list_t *rank_list);
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -1,6 +1,7 @@
 #ifndef ROOT7_RNTuple_Test_CustomStruct
 #define ROOT7_RNTuple_Test_CustomStruct
 
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Backport two PRs that fix compilation of 6.26 with gcc 13:
* https://github.com/root-project/root/pull/11958
* https://github.com/root-project/root/pull/12065