### PR TITLE
[cling][v6-28] DefinitionShadower: fix crash with C++20 concepts

### DIFF
--- a/interpreter/cling/lib/Interpreter/DefinitionShadower.cpp
+++ b/interpreter/cling/lib/Interpreter/DefinitionShadower.cpp
@@ -35,7 +35,9 @@ namespace cling {
            && (SM.getFileID(SM.getIncludeLoc(FID)) == SM.getMainFileID());
   }
 
-  /// \brief Returns whether the given {Function,Tag,Var}Decl/TemplateDecl is a definition.
+  /// \brief Returns whether a declaration is a definition.  A `TemplateDecl` is
+  /// a definition if the templated decl is itself a definition; a concept is
+  /// always considered a definition.
   static bool isDefinition(const Decl *D) {
     if (auto FD = dyn_cast<FunctionDecl>(D))
       return FD->isThisDeclarationADefinition();
@@ -44,7 +46,7 @@ namespace cling {
     if (auto VD = dyn_cast<VarDecl>(D))
       return VD->isThisDeclarationADefinition();
     if (auto TD = dyn_cast<TemplateDecl>(D))
-      return isDefinition(TD->getTemplatedDecl());
+      return isa<ConceptDecl>(TD) || isDefinition(TD->getTemplatedDecl());
     return true;
   }
 

--- a/interpreter/cling/test/CodeUnloading/DeclShadowing.C
+++ b/interpreter/cling/test/CodeUnloading/DeclShadowing.C
@@ -6,14 +6,17 @@
 // LICENSE.TXT for details.
 //------------------------------------------------------------------------------
 
-// RUN: cat %s | %cling 2>&1 | FileCheck %s
+// RUN: cat %s | %cling 2>&1 | FileCheck --implicit-check-not error: %s
 #include "cling/Interpreter/Interpreter.h"
 #include "cling/Utils/AST.h"
 #include "clang/AST/Decl.h"
 
-#include <type_traits>
+#if __cplusplus > 202002L
+#include <concepts>
+#endif
 #include <cstdlib>
 #include <string>
+#include <type_traits>
 
 unsigned _i;
 struct _X {};
@@ -97,6 +100,18 @@ f(33)
 //CHECK-NEXT: (int) 43605
 f(3.3f)
 //CHECK-NEXT: (int) 21930
+
+#if __cplusplus > 202002L
+template <typename T>
+concept IsIntegral = false;
+
+// Replace concept definition; no error is expected in `constrained_fn(10)` below
+template <typename T>
+concept IsIntegral = std::is_integral<T>::value;
+
+void constrained_fn(IsIntegral auto x) {}
+void g() { constrained_fn(10); }
+#endif
 
 cling::runtime::gClingOpts->AllowRedefinition = 0;
 


### PR DESCRIPTION
This PR is a backport of #12781.

The change in this PR fixes a segfault when defining a C++20 concept if definition shadowing is enabled.
In principle, for a `TemplateDecl`, `isDefinition()` issues a recursive call passing the templated decl as a parameter.  A `ConceptDecl`, however, should always be considered a definition.

Also, update the DeclShadowing test incorporating a C++20 concept.

## Checklist:
- [X] tested changes locally
- [X] updated the docs (if necessary)

This PR fixes #12779.