### PR TITLE
[tmva][cmake] Fix issue introduced accidentally in PR #12751

### DIFF
--- a/tmva/pymva/test/CMakeLists.txt
+++ b/tmva/pymva/test/CMakeLists.txt
@@ -105,7 +105,7 @@ endif()
       )
    else()
       add_custom_command(TARGET SofieCompileModels_PyTorch POST_BUILD
-         COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}" ./emitFromPyTorch.exe
+         COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}" ./emitFromPyTorch
          USES_TERMINAL
       )
       ROOT_ADD_GTEST(TestRModelParserPyTorch TestRModelParserPyTorch.C


### PR DESCRIPTION
This pull request fixes an issue introduced accidentally in PR #12751.  In particular, the `.exe` suffix is not expected in non-Windows builds.

## Checklist:
- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes some failures seen in the nightly builds.