### PR TITLE
Resize the canvas when displaying the editor

### DIFF
--- a/gui/gui/src/TRootCanvas.cxx
+++ b/gui/gui/src/TRootCanvas.cxx
@@ -1543,6 +1543,7 @@ void TRootCanvas::ShowEditor(Bool_t show)
    }
    else {
       lambda_show();
+      Resize(w, h);
    }
 }
 


### PR DESCRIPTION
Add forgotten `Resize(w, h);` when the editor is displayed in a stand-alone canvas. This fix an issue reported on the Forum https://root-forum.cern.ch/t/minor-issue-with-new-root-6-28-04/54792
