### PR TITLE
Fix warning in asimage about redefinition of TObject::Hash()

### DIFF
--- a/graf2d/asimage/inc/TASImagePlugin.h
+++ b/graf2d/asimage/inc/TASImagePlugin.h
@@ -27,7 +27,9 @@ class TASImagePlugin : public TImagePlugin {
 
 public:
    TASImagePlugin(const char *ext) : TImagePlugin(ext) { }
-   virtual ~TASImagePlugin() { }
+   virtual ~TASImagePlugin() { ROOT::CallRecursiveRemoveIfNeeded(*this); }
+
+   ULong_t Hash() const override { return fExtension.Hash(); }
 
    unsigned char *ReadFile(const char * /*filename*/, UInt_t & /*w*/,  UInt_t & /*h*/) override { return nullptr; }
    Bool_t WriteFile(const char * /*filename*/, unsigned char * /*argb*/, UInt_t /*w*/,  UInt_t  /*h*/) override { return kFALSE; }

--- a/graf2d/asimage/inc/TASPluginGS.h
+++ b/graf2d/asimage/inc/TASPluginGS.h
@@ -31,6 +31,8 @@ public:
    TASPluginGS(const char *ext);
    virtual ~TASPluginGS();
 
+   ULong_t Hash() const override { return fExtension.Hash(); }
+
    ASImage *File2ASImage(const char *filename) override;
 
    ClassDefOverride(TASPluginGS, 0)  // PS/EPS/PDF plugin based on GhostScript interpreter

--- a/graf2d/asimage/src/TASPluginGS.cxx
+++ b/graf2d/asimage/src/TASPluginGS.cxx
@@ -64,6 +64,8 @@ TASPluginGS::TASPluginGS(const char *ext) : TASImagePlugin(ext)
 
 TASPluginGS::~TASPluginGS()
 {
+   ROOT::CallRecursiveRemoveIfNeeded(*this);
+
    delete [] fInterpreter;
    fInterpreter = nullptr;
 }


### PR DESCRIPTION
All derived classes should also redefine Hash and call recursive remove

