### PR TITLE
TString: Enable spaceship operator with libc++ [v6.28]

### DIFF
--- a/core/base/inc/TString.h
+++ b/core/base/inc/TString.h
@@ -169,7 +169,7 @@ operator+(T f, const TString &s);
 
 friend Bool_t  operator==(const TString &s1, const TString &s2);
 friend Bool_t  operator==(const TString &s1, const char *s2);
-#ifdef __cpp_lib_three_way_comparison
+#if __cplusplus >= 202002L
 friend std::strong_ordering operator<=>(const TString &s1, const TString &s2) {
    const int cmp = s1.CompareTo(s2);
    if (cmp == 0) return std::strong_ordering::equal;


### PR DESCRIPTION
The feature test __cpp_lib_three_way_comparison is for library support of the three-way comparison. libc++ doesn't expose this yet, presumably because the operator has not been added yet for all classes. However, some classes already use it, which requires us to implement the operator as discussed in https://github.com/root-project/root/pull/12525.

(cherry picked from commit b85231d2ad62645f0fe7291a64284f61bb8a83c2)