### PR TITLE
[DF] Fix MakeNumpyDataFrame

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_facade.py
@@ -331,7 +331,7 @@ class ROOTFacade(types.ModuleType):
                 import warnings
                 warnings.warn("MakeNumpyDataFrame is deprecated since v6.28 and will be removed in v6.30."\
                               "Please use FromNumpy instead.", FutureWarning)
-                MakeNumpyDataFrame(*args, **kwargs)
+                return MakeNumpyDataFrame(*args, **kwargs)
             ns.MakeNumpyDataFrame = DeprecatedMakeNumpy
             ns.FromNumpy = MakeNumpyDataFrame
 


### PR DESCRIPTION
The deprecated overload returned None instead of an RDataFrame after printing the deprecation warning.