### PR TITLE
[RF] RooCurve: Reduce last x by relative value

### DIFF
--- a/roofit/roofitcore/src/RooCurve.cxx
+++ b/roofit/roofitcore/src/RooCurve.cxx
@@ -342,7 +342,7 @@ void RooCurve::addPoints(const RooAbsFunc &func, double xlo, double xhi,
   for (unsigned int step=0; step < xval.size(); ++step) {
     double xx = xval[step];
     if (step == static_cast<unsigned int>(minPoints-1))
-      xx -= 1e-15;
+      xx -= 1e-9 * dx;
 
     yval[step]= func(&xx);
     if (_showProgress) {


### PR DESCRIPTION
Subtracting a constant `1e-15` might not result in a representation that is different from the previous value. Instead subtract the relative value `1e-9 * dx`, with `dx` being the equidistant step size between points. This fixes `stressRooFit` on mac13arm.