### PR TITLE
[RF] Make datasets that contain strings cloneable

### DIFF
--- a/roofit/roofitcore/inc/RooStringVar.h
+++ b/roofit/roofitcore/inc/RooStringVar.h
@@ -72,6 +72,7 @@ protected:
 
 private:
   std::string _string;
+  std::string* _stringAddr; //! Required to connect to TTree branch
   ClassDefOverride(RooStringVar,2) // String-valued variable
 };
 

--- a/roofit/roofitcore/src/RooStringVar.cxx
+++ b/roofit/roofitcore/src/RooStringVar.cxx
@@ -35,7 +35,7 @@ RooStringVar is a RooAbsArg implementing string values.
 /// Constructor with initial value. The size argument is ignored.
 RooStringVar::RooStringVar(const char *name, const char *title, const char* value, Int_t) :
   RooAbsArg(name, title),
-  _string(value)
+  _string(value), _stringAddr(&_string)
 {
   setValueDirty();
 }
@@ -47,7 +47,7 @@ RooStringVar::RooStringVar(const char *name, const char *title, const char* valu
 
 RooStringVar::RooStringVar(const RooStringVar& other, const char* name) :
   RooAbsArg(other, name),
-  _string(other._string)
+  _string(other._string), _stringAddr(&_string)
 {
   setValueDirty();
 }
@@ -105,7 +105,7 @@ void RooStringVar::attachToTree(TTree& t, Int_t)
   // First determine if branch is taken
   TBranch* branch ;
   if ((branch = t.GetBranch(GetName()))) {
-    t.SetBranchAddress(GetName(), &_string);
+    t.SetBranchAddress(GetName(), &_stringAddr);
   } else {
     t.Branch(GetName(), &_string);
   }

--- a/roofit/roofitcore/test/testRooDataSet.cxx
+++ b/roofit/roofitcore/test/testRooDataSet.cxx
@@ -10,6 +10,7 @@
 #include <RooCategory.h>
 #include <RooWorkspace.h>
 #include <RooVectorDataStore.h>
+#include <RooStringVar.h>
 
 #include <TFile.h>
 #include <TTree.h>
@@ -463,4 +464,26 @@ TEST(RooDataSet, ReadDataSetWithErrors626)
    EXPECT_DOUBLE_EQ(y.getVal(), 4.0);
    EXPECT_DOUBLE_EQ(y.getAsymErrorLo(), -2.0);
    EXPECT_DOUBLE_EQ(y.getAsymErrorHi(), 1.0);
+}
+
+TEST(RooDataSet,RooStringVarStorage) {
+   /* RooDataSet should be able to store strings
+    * although this currently will only work for tree storage
+    * */
+
+   RooStringVar str("str","test string","");
+   RooDataSet data("data","data",str);
+   data.convertToTreeStore(); // necessary until VectorStore supports strings
+   data.add(str="str1");
+   data.add(str="str2");
+
+   ASSERT_STREQ(data.get(0)->getStringValue("str"),"str1");
+   ASSERT_STREQ(data.get(1)->getStringValue("str"),"str2");
+
+   // ensure dataset is cloneable
+   RooDataSet dataClone(data);
+
+   ASSERT_STREQ(dataClone.get(0)->getStringValue("str"),"str1");
+   ASSERT_STREQ(dataClone.get(1)->getStringValue("str"),"str2");
+
 }


### PR DESCRIPTION
I discovered that RooDataSets that contain RooStringVar aren't cloneable, because the SetBranchAddress method of TTree expects the address of a string pointer, not the address of the string.

I added a test that would crash before I implemented the fix in RooStringVar.

Should be backported to 6.28