### PR TITLE
[ci] A failing test is an error: [skip-ci]

### DIFF
--- a/.github/workflows/root-ci-config/build_root.py
+++ b/.github/workflows/root-ci-config/build_root.py
@@ -249,7 +249,7 @@ def run_ctest(shell_log: str, extra_ctest_flags: str) -> str:
     """, shell_log)
 
     if result != 0:
-        print_warning("Some tests failed")
+        die(result, "Some tests failed", shell_log)
 
     return shell_log
 


### PR DESCRIPTION
Even if the test collection comment is conveying it, it's important to make those platforms fail that have failing tests, for visibility reasons.

This fixes https://github.com/root-project/root/issues/12307

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

