### PR TITLE
[http] fix custom JSROOT usage with `THttpServer`

### DIFF
--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -811,8 +811,10 @@ void THttpServer::ReplaceJSROOTLinks(std::shared_ptr<THttpCallArg> &arg)
       }
    }
 
-   if (!repl.empty())
+   if (!repl.empty()) {
       arg->ReplaceAllinContent("=\"jsrootsys/", repl);
+      arg->ReplaceAllinContent("from './jsrootsys/", TString::Format("from '%s", repl.substr(2).c_str()).Data());
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tutorials/http/httpaccess.C
+++ b/tutorials/http/httpaccess.C
@@ -58,7 +58,7 @@ void httpaccess()
 
    // One could specify location of newer version of JSROOT
    // serv->SetJSROOT("https://root.cern.ch/js/latest/");
-   // serv->SetJSROOT("http://jsroot.gsi.de/latest/");
+   // serv->SetJSROOT("https://jsroot.gsi.de/dev/");
 
    // register histograms
    serv->Register("/", hpx);

--- a/tutorials/http/httptextlog.C
+++ b/tutorials/http/httptextlog.C
@@ -152,7 +152,7 @@ void httptextlog()
 
    // One could specify location of newer version of JSROOT
    // serv->SetJSROOT("https://root.cern.ch/js/latest/");
-   // serv->SetJSROOT("http://jsroot.gsi.de/latest/");
+   // serv->SetJSROOT("https://jsroot.gsi.de/dev/");
 
    // let always load httptextlog.js script in the browser
    serv->GetSniffer()->SetAutoLoad("currentdir/httptextlog.js");


### PR DESCRIPTION
With JSROOT v7 URL links to JSROOT sources are changed for THttpServer.
Now syntax is like:
```
 import { redraw } from './jsrootsys/modules/main.mjs';
```
One need to handle also these links for custom JSROOT locations