### PR TITLE
[ntuple] Distinguish between 32bit and 64bit cardinality fields

### DIFF
--- a/gui/browsable/src/RFieldProvider.hxx
+++ b/gui/browsable/src/RFieldProvider.hxx
@@ -166,10 +166,9 @@ class RFieldProvider : public RProvider {
       {
          if (const auto f32 = field.Is32Bit()) {
             FillHistogram(*f32);
-            return;
-         }
-         if (const auto f64 = field.Is64Bit())
+         } else if (const auto f64 = field.Is64Bit()) {
             FillHistogram(*f64);
+         }
       }
    }; // class RDrawVisitor
 

--- a/gui/browsable/src/RFieldProvider.hxx
+++ b/gui/browsable/src/RFieldProvider.hxx
@@ -162,9 +162,14 @@ class RFieldProvider : public RProvider {
       void VisitUInt32Field(const RField<std::uint32_t> &field) final { FillHistogram(field); }
       void VisitUInt64Field(const RField<std::uint64_t> &field) final { FillHistogram(field); }
       void VisitUInt8Field(const RField<std::uint8_t> &field) final { FillHistogram(field); }
-      void VisitCardinalityField(const RField<ROOT::Experimental::RNTupleCardinality> &field) final
+      void VisitCardinalityField(const ROOT::Experimental::RCardinalityField &field) final
       {
-         FillHistogram(field);
+         if (const auto f32 = field.Is32Bit()) {
+            FillHistogram(*f32);
+            return;
+         }
+         if (const auto f64 = field.Is64Bit())
+            FillHistogram(*f64);
       }
    }; // class RDrawVisitor
 

--- a/gui/browsable/src/RFieldProvider.hxx
+++ b/gui/browsable/src/RFieldProvider.hxx
@@ -164,9 +164,9 @@ class RFieldProvider : public RProvider {
       void VisitUInt8Field(const RField<std::uint8_t> &field) final { FillHistogram(field); }
       void VisitCardinalityField(const ROOT::Experimental::RCardinalityField &field) final
       {
-         if (const auto f32 = field.Is32Bit()) {
+         if (const auto f32 = field.As32Bit()) {
             FillHistogram(*f32);
-         } else if (const auto f64 = field.Is64Bit()) {
+         } else if (const auto f64 = field.As64Bit()) {
             FillHistogram(*f64);
          }
       }

--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -707,13 +707,16 @@ The on-disk representation is similar to a `std::vector<T>` where `T` is the val
   - Child field of type `T`, which must by a type with RNTuple I/O support.
     The name of the child field is `_0`.
 
-### ROOT::Experimental::RNTupleCardinality
+### ROOT::Experimental::RNTupleCardinality<SizeT>
 
-A field whose type is `ROOT::Experimental::RNTupleCardinality` is associated to a single column of type (Split)Index32 or (Split)Index64.
+A field whose type is `ROOT::Experimental::RNTupleCardinality<SizeT>` is associated to a single column of type (Split)Index32 or (Split)Index64.
 This field presents the offsets in the index column as lengths that correspond to the cardinality of the pointed-to collection.
 
 The value for the $i$-th element is computed by subtracting the $(i-1)$-th value from the $i$-th value in the index column.
 If $i == 0$, i.e. it falls on the start of a cluster, the $(i-1)$-th value in the index column is assumed to be 0, e.g. given the index column values `[1, 1, 3]`, the values yielded by `RNTupleCardinality` shall be `[1, 0, 2]`.
+
+The `SizeT` template parameter defines the in-memory integer type of the collection size.
+The valid types are `std::uint32_t` and `std::uint64_t`.
 
 ## Limits
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -1092,8 +1092,8 @@ public:
 
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 
-   const RField<RNTupleCardinality<std::uint32_t>> *Is32Bit() const;
-   const RField<RNTupleCardinality<std::uint64_t>> *Is64Bit() const;
+   const RField<RNTupleCardinality<std::uint32_t>> *As32Bit() const;
+   const RField<RNTupleCardinality<std::uint64_t>> *As64Bit() const;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -52,7 +52,7 @@ public:
    virtual void VisitCollectionClassField(const RCollectionClassField &field) { VisitField(field); }
    virtual void VisitRecordField(const RRecordField &field) { VisitField(field); }
    virtual void VisitClusterSizeField(const RField<ClusterSize_t> &field) { VisitField(field); }
-   virtual void VisitCardinalityField(const RField<RNTupleCardinality> &field) { VisitField(field); }
+   virtual void VisitCardinalityField(const RCardinalityField &field) { VisitField(field); }
    virtual void VisitDoubleField(const RField<double> &field) { VisitField(field); }
    virtual void VisitFloatField(const RField<float> &field) { VisitField(field); }
    virtual void VisitCharField(const RField<char> &field) { VisitField(field); }
@@ -209,8 +209,8 @@ public:
    void VisitUInt16Field(const RField<std::uint16_t> &field) final;
    void VisitUInt32Field(const RField<std::uint32_t> &field) final;
    void VisitUInt64Field(const RField<std::uint64_t> &field) final;
-   void VisitCardinalityField(const RField<RNTupleCardinality> &field) final;
 
+   void VisitCardinalityField(const RCardinalityField &field) final;
    void VisitArrayField(const RArrayField &field) final;
    void VisitClassField(const RClassField &field) final;
    void VisitRecordField(const RRecordField &field) final;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -68,7 +68,7 @@ constexpr ClusterSize_t kInvalidClusterIndex(std::uint64_t(-1));
 template <typename SizeT>
 struct RNTupleCardinality {
    static_assert(std::is_same_v<SizeT, std::uint32_t> || std::is_same_v<SizeT, std::uint64_t>,
-                 "RNTupleCardinality is only support with std::uint32_t or std::uint64_t template parameters");
+                 "RNTupleCardinality is only supported with std::uint32_t or std::uint64_t template parameters");
 
    using ValueType = SizeT;
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -63,9 +63,14 @@ struct RClusterSize {
 using ClusterSize_t = RClusterSize;
 constexpr ClusterSize_t kInvalidClusterIndex(std::uint64_t(-1));
 
-/// Helper type to present an offset column as array of collection sizes. See RField<RNTupleCardinality> for details.
+/// Helper types to present an offset column as array of collection sizes.
+/// See RField<RNTupleCardinality<SizeT>> for details.
+template <typename SizeT>
 struct RNTupleCardinality {
-   using ValueType = std::size_t;
+   static_assert(std::is_same_v<SizeT, std::uint32_t> || std::is_same_v<SizeT, std::uint64_t>,
+                 "RNTupleCardinality is only support with std::uint32_t or std::uint64_t template parameters");
+
+   using ValueType = SizeT;
 
    RNTupleCardinality() : fValue(0) {}
    explicit constexpr RNTupleCardinality(ValueType value) : fValue(value) {}

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -705,13 +705,13 @@ void ROOT::Experimental::RCardinalityField::AcceptVisitor(Detail::RFieldVisitor 
 }
 
 const ROOT::Experimental::RField<ROOT::Experimental::RNTupleCardinality<std::uint32_t>> *
-ROOT::Experimental::RCardinalityField::Is32Bit() const
+ROOT::Experimental::RCardinalityField::As32Bit() const
 {
    return dynamic_cast<const RField<RNTupleCardinality<std::uint32_t>> *>(this);
 }
 
 const ROOT::Experimental::RField<ROOT::Experimental::RNTupleCardinality<std::uint64_t>> *
-ROOT::Experimental::RCardinalityField::Is64Bit() const
+ROOT::Experimental::RCardinalityField::As64Bit() const
 {
    return dynamic_cast<const RField<RNTupleCardinality<std::uint64_t>> *>(this);
 }

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -254,11 +254,19 @@ void ROOT::Experimental::RPrintValueVisitor::VisitUInt64Field(const RField<std::
    fOutput << *fValue.Get<std::uint64_t>();
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitCardinalityField(const RField<RNTupleCardinality> &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitCardinalityField(const RCardinalityField &field)
 {
    PrintIndent();
    PrintName(field);
-   fOutput << static_cast<std::size_t>(*fValue.Get<RNTupleCardinality>());
+   if (field.Is32Bit()) {
+      fOutput << *fValue.Get<std::uint32_t>();
+      return;
+   }
+   if (field.Is64Bit()) {
+      fOutput << *fValue.Get<std::uint64_t>();
+      return;
+   }
+   fOutput << "\"unsupported cardinality size type\"";
 }
 
 void ROOT::Experimental::RPrintValueVisitor::VisitBitsetField(const RBitsetField &field)

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -258,11 +258,11 @@ void ROOT::Experimental::RPrintValueVisitor::VisitCardinalityField(const RCardin
 {
    PrintIndent();
    PrintName(field);
-   if (field.Is32Bit()) {
+   if (field.As32Bit()) {
       fOutput << *fValue.Get<std::uint32_t>();
       return;
    }
-   if (field.Is64Bit()) {
+   if (field.As64Bit()) {
       fOutput << *fValue.Get<std::uint64_t>();
       return;
    }

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -266,7 +266,7 @@ void ROOT::Experimental::RPrintValueVisitor::VisitCardinalityField(const RCardin
       fOutput << *fValue.Get<std::uint64_t>();
       return;
    }
-   fOutput << "\"unsupported cardinality size type\"";
+   R__ASSERT(false && "unsupported cardinality size type");
 }
 
 void ROOT::Experimental::RPrintValueVisitor::VisitBitsetField(const RBitsetField &field)

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -29,9 +29,9 @@ ROOT::Experimental::RNTupleModel::RProjectedFields::EnsureValidMapping(const Det
                                                                        const FieldMap_t &fieldMap)
 {
    auto source = fieldMap.at(target);
-   const bool hasCompatibleStructure = (source->GetStructure() == target->GetStructure()) ||
-                                       ((source->GetStructure() == ENTupleStructure::kCollection) &&
-                                        (target->GetType() == "ROOT::Experimental::RNTupleCardinality"));
+   const bool hasCompatibleStructure =
+      (source->GetStructure() == target->GetStructure()) ||
+      ((source->GetStructure() == ENTupleStructure::kCollection) && dynamic_cast<const RCardinalityField *>(target));
    if (!hasCompatibleStructure)
       return R__FAIL("field mapping structural mismatch: " + source->GetName() + " --> " + target->GetName());
    if (source->GetStructure() == ENTupleStructure::kLeaf) {

--- a/tree/ntuple/v7/test/ntuple_project.cxx
+++ b/tree/ntuple/v7/test/ntuple_project.cxx
@@ -19,7 +19,7 @@ TEST(RNTupleProjection, Basics)
       else
          return "vec._0";
    });
-   auto f3 = RFieldBase::Create("vecSize", "ROOT::Experimental::RNTupleCardinality").Unwrap();
+   auto f3 = RFieldBase::Create("vecSize", "ROOT::Experimental::RNTupleCardinality<std::uint64_t>").Unwrap();
    model->AddProjectedField(std::move(f3), [](const std::string &) { return "vec"; });
 
    {
@@ -30,7 +30,7 @@ TEST(RNTupleProjection, Basics)
    auto reader = RNTupleReader::Open("A", fileGuard.GetPath());
    auto viewMissingE = reader->GetView<float>("missingE");
    auto viewAliasVec = reader->GetView<std::vector<float>>("aliasVec");
-   auto viewVecSize = reader->GetView<ROOT::Experimental::RNTupleCardinality>("vecSize");
+   auto viewVecSize = reader->GetView<ROOT::Experimental::RNTupleCardinality<std::uint64_t>>("vecSize");
    EXPECT_FLOAT_EQ(42.0, viewMissingE(0));
    EXPECT_EQ(2U, viewAliasVec(0).size());
    EXPECT_FLOAT_EQ(1.0, viewAliasVec(0).at(0));

--- a/tree/ntuple/v7/test/rfield_vector.cxx
+++ b/tree/ntuple/v7/test/rfield_vector.cxx
@@ -131,7 +131,7 @@ TEST(RNTuple, InsideCollection)
    field->SetOnDiskId(idKlassVec);
    field->ConnectPageSource(*source);
 
-   auto fieldCardinality = RFieldBase::Create("", "ROOT::Experimental::RNTupleCardinality").Unwrap();
+   auto fieldCardinality = RFieldBase::Create("", "ROOT::Experimental::RNTupleCardinality<std::uint64_t>").Unwrap();
    fieldCardinality->SetOnDiskId(idKlassVec);
    fieldCardinality->ConnectPageSource(*source);
 
@@ -144,7 +144,7 @@ TEST(RNTuple, InsideCollection)
 
    auto valueCardinality = fieldCardinality->GenerateValue();
    fieldCardinality->Read(0, &valueCardinality);
-   EXPECT_EQ(1U, *valueCardinality.Get<std::size_t>());
+   EXPECT_EQ(1U, *valueCardinality.Get<std::uint64_t>());
    fieldCardinality->DestroyValue(valueCardinality);
 
    // TODO: test reading of "klassVec.v1"

--- a/tree/ntuple/v7/test/rfield_vector.cxx
+++ b/tree/ntuple/v7/test/rfield_vector.cxx
@@ -131,9 +131,12 @@ TEST(RNTuple, InsideCollection)
    field->SetOnDiskId(idKlassVec);
    field->ConnectPageSource(*source);
 
-   auto fieldCardinality = RFieldBase::Create("", "ROOT::Experimental::RNTupleCardinality<std::uint64_t>").Unwrap();
-   fieldCardinality->SetOnDiskId(idKlassVec);
-   fieldCardinality->ConnectPageSource(*source);
+   auto fieldCardinality64 = RFieldBase::Create("", "ROOT::Experimental::RNTupleCardinality<std::uint64_t>").Unwrap();
+   fieldCardinality64->SetOnDiskId(idKlassVec);
+   fieldCardinality64->ConnectPageSource(*source);
+   auto fieldCardinality32 = RFieldBase::Create("", "ROOT::Experimental::RNTupleCardinality<std::uint32_t>").Unwrap();
+   fieldCardinality32->SetOnDiskId(idKlassVec);
+   fieldCardinality32->ConnectPageSource(*source);
 
    auto value = field->GenerateValue();
    field->Read(0, &value);
@@ -142,10 +145,15 @@ TEST(RNTuple, InsideCollection)
    EXPECT_EQ(42.0, (*aVec)[0]);
    field->DestroyValue(value);
 
-   auto valueCardinality = fieldCardinality->GenerateValue();
-   fieldCardinality->Read(0, &valueCardinality);
-   EXPECT_EQ(1U, *valueCardinality.Get<std::uint64_t>());
-   fieldCardinality->DestroyValue(valueCardinality);
+   auto valueCardinality64 = fieldCardinality64->GenerateValue();
+   fieldCardinality64->Read(0, &valueCardinality64);
+   EXPECT_EQ(1U, *valueCardinality64.Get<std::uint64_t>());
+   fieldCardinality64->DestroyValue(valueCardinality64);
+
+   auto valueCardinality32 = fieldCardinality32->GenerateValue();
+   fieldCardinality32->Read(0, &valueCardinality32);
+   EXPECT_EQ(1U, *valueCardinality32.Get<std::uint32_t>());
+   fieldCardinality32->DestroyValue(valueCardinality32);
 
    // TODO: test reading of "klassVec.v1"
 }

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -330,7 +330,7 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSc
       }
       // Add projected fields for count leaf
       auto projectedField =
-         Detail::RFieldBase::Create(countLeafName, "ROOT::Experimental::RNTupleCardinality").Unwrap();
+         Detail::RFieldBase::Create(countLeafName, "ROOT::Experimental::RNTupleCardinality<std::uint32_t>").Unwrap();
       fModel->AddProjectedField(std::move(projectedField), [&c](const std::string &) { return c.fFieldName; });
       iLeafCountCollection++;
    }

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -347,10 +347,10 @@ TEST(RNTupleImporter, LeafCountArray)
    auto viewJetEta = viewJets.GetView<float>("jet_eta");
    auto viewMuons = reader->GetViewCollection("_collection1");
    auto viewMuonPt = viewMuons.GetView<float>("muon_pt");
-   auto viewProjectedNjets = reader->GetView<ROOT::Experimental::RNTupleCardinality>("njets");
+   auto viewProjectedNjets = reader->GetView<ROOT::Experimental::RNTupleCardinality<std::uint32_t>>("njets");
    auto viewProjectedJetPt = reader->GetView<ROOT::RVec<float>>("jet_pt");
    auto viewProjectedJetEta = reader->GetView<ROOT::RVec<float>>("jet_eta");
-   auto viewProjectedNmuons = reader->GetView<ROOT::Experimental::RNTupleCardinality>("nmuons");
+   auto viewProjectedNmuons = reader->GetView<ROOT::Experimental::RNTupleCardinality<std::uint32_t>>("nmuons");
    auto viewProjectedMuonPt = reader->GetView<ROOT::RVec<float>>("muon_pt");
 
    // Entry 0: 1 jet, 1 muon


### PR DESCRIPTION
Provides support for both 32bit and 64bit cardinality fields. This has no implication on the width of the on-disk offsets but the cardinality field width (32bit or 64bit) is for the width of the collection sizes that are computed from the offsets.

For converted TTree files with leaf count arrays, 32bit widths cardinality fields must be used because the count leaf is 32bit. This makes sure that the (projected) leaf count field in the RNTuple (e.g., `nJets`) can be accessed with the same type than the TTree branch, e.g. in RDataFrame.