### PR TITLE
[ci] Upload test results unless cancelled

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -131,6 +131,7 @@ jobs:
                     --repository     ${{ github.server_url }}/${{ github.repository }}"
 
       - name: Upload test results
+        if:   ${{ !cancelled() }}
         uses: actions/upload-artifact@v3
         with:
           name:  Test Results ${{ matrix.platform }} ${{ matrix.arch }} ${{ matrix.config }}
@@ -356,6 +357,7 @@ jobs:
               "
 
       - name: Upload test results
+        if:   ${{ !cancelled() }}
         uses: actions/upload-artifact@v3
         with:
           name:  Test Results ${{ matrix.image }} ${{ matrix.config }}


### PR DESCRIPTION
Commit c8c0ea7c59 made the step and job fail in case of a test error. We still want the results to be uploaded to show them on GitHub.