### PR TITLE
[ci] Report test failures also for failed tests: [skip-ci]

### DIFF
--- a/.github/workflows/test-result-comment.yml
+++ b/.github/workflows/test-result-comment.yml
@@ -13,7 +13,7 @@ jobs:
   comment-test-results:
     name: Publish Test Results
 
-    if: github.event.workflow_run.event == 'pull_request'
+    if: 'github.event.workflow_run.event == "pull_request" && !cancelled()'
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
now that failed roottest causes the ROOT CI workflow to fail, reporing needs to happen also if the workflow failed, otherwise only successful tests are reported.

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

