### PR TITLE
[ntuple] Make sure that all tasks have finished in `~RPageStorage`

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -113,6 +113,13 @@ public:
 protected:
    std::string fNTupleName;
    RTaskScheduler *fTaskScheduler = nullptr;
+   void WaitForAllTasks()
+   {
+      if (!fTaskScheduler)
+         return;
+      fTaskScheduler->Wait();
+      fTaskScheduler->Reset();
+   }
 
 public:
    explicit RPageStorage(std::string_view name);

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -125,10 +125,7 @@ ROOT::Experimental::Detail::RPageSinkBuf::CommitSealedPageImpl(DescriptorId_t ph
 std::uint64_t
 ROOT::Experimental::Detail::RPageSinkBuf::CommitClusterImpl(ROOT::Experimental::NTupleSize_t nEntries)
 {
-   if (fTaskScheduler) {
-      fTaskScheduler->Wait();
-      fTaskScheduler->Reset();
-   }
+   WaitForAllTasks();
 
    // If we have only sealed pages in all buffered columns, commit them in a single `CommitSealedPageV()` call
    bool singleCommitCall = std::all_of(fBufferedColumns.begin(), fBufferedColumns.end(),

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -40,6 +40,8 @@ ROOT::Experimental::Detail::RPageStorage::RPageStorage(std::string_view name) : 
 
 ROOT::Experimental::Detail::RPageStorage::~RPageStorage()
 {
+   // Wait for unterminated tasks, if any, as they may still hold a reference to `this`
+   WaitForAllTasks();
 }
 
 


### PR DESCRIPTION
In the `RPageStorage` destructor: wait for unterminated tasks, if any, as they may still hold a reference to `this`.

This is known to happen, e.g. in `RPageSinkBuf` if `CommitClusterImpl()` is not called after committing some pages via `CommitPageImpl()` and the `RPageSinkBuf` is immediately destructed.

This fixes the ntuple_extended:`RNTuple.SmallClusters` test.

## Checklist:
- [x] tested changes locally
- [ ] updated the docs (if necessary)