### PR TITLE
[RF] Only register actual vars as server in `RooFormulaVar`/`GenericPdf`

### DIFF
--- a/README/ReleaseNotes/v630/index.md
+++ b/README/ReleaseNotes/v630/index.md
@@ -67,6 +67,13 @@ Therefore, the behavior of `TMath::AreEqualAbs()` was changed to return always `
 
 ## RooFit Libraries
 
+### Changes in RooFormulaVar and RooGenericPdf
+
+The TFormula-based RooFit classes `RooFormulaVar` and `RooGenericPdf` change a bit their behavior to be more consistent:
+
+1. No matter which variables you pass to the constructor, only the variables that the formula depends on are registered as value servers.
+2. Similarly, the `dependents()` method of RooFormulaVar and RooGenericPdf will only return the list of actual value servers.
+
 ### Removal of the RooGenFunction and RooMultiGenFunction classes
 
 The `RooGenFunction` was only a lightweight adaptor that exports a RooAbsReal as a `ROOT::Math::IGenFunction`.

--- a/roofit/roofitcore/inc/RooGenericPdf.h
+++ b/roofit/roofitcore/inc/RooGenericPdf.h
@@ -55,8 +55,6 @@ protected:
   double evaluate() const override ;
   void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooFit::Detail::DataMap const&) const override;
 
-  bool setFormula(const char* formula) ;
-
   // Post-processing of server redirection
   bool redirectServersHook(const RooAbsCollection& newServerList, bool mustReplaceAll, bool nameChange, bool isRecursive) override ;
 

--- a/roofit/roofitcore/src/RooFormula.cxx
+++ b/roofit/roofitcore/src/RooFormula.cxx
@@ -179,18 +179,10 @@ void replaceVarNamesWithIndexStyle(std::string &formula, RooArgList const &varLi
 
       oocxcoutD(static_cast<TObject *>(nullptr), InputArguments)
          << "Preprocessing formula: replace named references: " << varName << " --> " << replacement << "\n\t"
-         << formula << endl;
+         << formula << std::endl;
    }
 }
 
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Default constructor
-/// coverity[UNINIT_CTOR]
-
-RooFormula::RooFormula() : TNamed()
-{
 }
 
 
@@ -252,7 +244,7 @@ std::string RooFormula::processFormula(std::string formula) const {
   // compilation.
 
   cxcoutD(InputArguments) << "Preprocessing formula step 1: find category tags (catName::catState) in "
-      << formula << endl;
+      << formula << std::endl;
 
   // Step 1: Find all category tags and the corresponding index numbers
   static const std::regex categoryReg("(\\w+)::(\\w+)");
@@ -267,13 +259,13 @@ std::string RooFormula::processFormula(std::string formula) const {
     const auto catVariable = dynamic_cast<const RooAbsCategory*>(_origList.find(catName.c_str()));
     if (!catVariable) {
       cxcoutD(InputArguments) << "Formula " << GetName() << " uses '::' to reference a category state as '" << fullMatch
-          << "' but a category '" << catName << "' cannot be found in the input variables." << endl;
+          << "' but a category '" << catName << "' cannot be found in the input variables." << std::endl;
       continue;
     }
 
     if (!catVariable->hasLabel(catState)) {
       coutE(InputArguments) << "Formula " << GetName() << " uses '::' to reference a category state as '" << fullMatch
-          << "' but the category '" << catName << "' does not seem to have the state '" << catState << "'." << endl;
+          << "' but the category '" << catName << "' does not seem to have the state '" << catState << "'." << std::endl;
       throw std::invalid_argument(formula);
     }
     const int catNum = catVariable->lookupIndex(catState);
@@ -281,24 +273,24 @@ std::string RooFormula::processFormula(std::string formula) const {
     categoryStates[fullMatch] = catNum;
     cxcoutD(InputArguments) << "\n\t" << fullMatch << "\tname=" << catName << "\tstate=" << catState << "=" << catNum;
   }
-  cxcoutD(InputArguments) << "-- End of category tags --"<< endl;
+  cxcoutD(InputArguments) << "-- End of category tags --"<< std::endl;
 
   // Step 2: Replace all category tags
   for (const auto& catState : categoryStates) {
     replaceAll(formula, catState.first, std::to_string(catState.second));
   }
 
-  cxcoutD(InputArguments) << "Preprocessing formula step 2: replace category tags\n\t" << formula << endl;
+  cxcoutD(InputArguments) << "Preprocessing formula step 2: replace category tags\n\t" << formula << std::endl;
 
   // Step 3: Convert `@i`-style references to `x[i]`
   convertArobaseReferences(formula);
 
-  cxcoutD(InputArguments) << "Preprocessing formula step 3: replace '@'-references\n\t" << formula << endl;
+  cxcoutD(InputArguments) << "Preprocessing formula step 3: replace '@'-references\n\t" << formula << std::endl;
 
   // Step 4: Replace all named references with "x[i]"-style
   replaceVarNamesWithIndexStyle(formula, _origList);
 
-  cxcoutD(InputArguments) << "Final formula:\n\t" << formula << endl;
+  cxcoutD(InputArguments) << "Final formula:\n\t" << formula << std::endl;
 
   return formula;
 }
@@ -351,25 +343,6 @@ std::string RooFormula::reconstructFormula(std::string internalRepr) const {
 }
 
 
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Recompile formula with new expression. In case of error, the old formula is
-/// retained.
-bool RooFormula::reCompile(const char* newFormula)
-{
-  try {
-    installFormulaOrThrow(newFormula);
-  } catch (std::runtime_error& e) {
-    coutE(InputArguments) << __func__ << ": new equation doesn't compile, formula unchanged."
-        << "\n" << e.what() << endl;
-    return true;
-  }
-
-  SetTitle(newFormula);
-  return false;
-}
-
 void RooFormula::dump() const
 {
   printMultiline(std::cout, 0);
@@ -400,7 +373,7 @@ bool RooFormula::changeDependents(const RooAbsCollection& newDeps, bool mustRepl
       }
 
     } else if (mustReplaceAll) {
-      coutE(LinkStateMgmt) << __func__ << ": cannot find replacement for " << arg->GetName() << endl;
+      coutE(LinkStateMgmt) << __func__ << ": cannot find replacement for " << arg->GetName() << std::endl;
       errorStat = true;
     }
   }
@@ -422,7 +395,7 @@ bool RooFormula::changeDependents(const RooAbsCollection& newDeps, bool mustRepl
 double RooFormula::eval(const RooArgSet* nset) const
 {
   if (!_tFormula) {
-    coutF(Eval) << __func__ << " (" << GetName() << "): Formula didn't compile: " << GetTitle() << endl;
+    coutF(Eval) << __func__ << " (" << GetName() << "): Formula didn't compile: " << GetTitle() << std::endl;
     std::string what = "Formula ";
     what += GetTitle();
     what += " didn't compile.";
@@ -464,12 +437,12 @@ void RooFormula::computeBatch(cudaStream_t*, double* output, size_t nEvents, Roo
 
 void RooFormula::printMultiline(ostream& os, Int_t /*contents*/, bool /*verbose*/, TString indent) const
 {
-  os << indent << "--- RooFormula ---" << endl;
-  os << indent << " Formula:        '" << GetTitle() << "'" << endl;
-  os << indent << " Interpretation: '" << reconstructFormula(GetTitle()) << "'" << endl;
+  os << indent << "--- RooFormula ---" << std::endl;
+  os << indent << " Formula:        '" << GetTitle() << "'" << std::endl;
+  os << indent << " Interpretation: '" << reconstructFormula(GetTitle()) << "'" << std::endl;
   indent.Append("  ");
   os << indent << "Servers: " << _origList << "\n";
-  os << indent << "In use : " << actualDependents() << endl;
+  os << indent << "In use : " << actualDependents() << std::endl;
 }
 
 
@@ -532,7 +505,7 @@ void RooFormula::installFormulaOrThrow(const std::string& formula) {
       << "\n\t" << processedFormula
       << "\n  and used as"
       << "\n\t" << reconstructFormula(processedFormula)
-      << "\n  with the parameters " << _origList << endl;
+      << "\n  with the parameters " << _origList << std::endl;
 
   auto theFormula = std::make_unique<TFormula>(GetName(), processedFormula.c_str(), false);
 

--- a/roofit/roofitcore/src/RooFormula.cxx
+++ b/roofit/roofitcore/src/RooFormula.cxx
@@ -386,7 +386,9 @@ bool RooFormula::changeDependents(const RooAbsCollection& newDeps, bool mustRepl
   //Change current servers to new servers with the same name given in list
   bool errorStat = false;
 
-  for (const auto arg : _origList) {
+  // We only consider the usedVariables() for replacement, because only these
+  // are registered as servers.
+  for (const auto arg : usedVariables()) {
     RooAbsReal* replace = (RooAbsReal*) arg->findNewServer(newDeps,nameChange) ;
     if (replace) {
       _origList.replace(*arg, *replace);

--- a/roofit/roofitcore/src/RooFormula.h
+++ b/roofit/roofitcore/src/RooFormula.h
@@ -28,7 +28,6 @@ class RooAbsReal;
 class RooFormula : public TNamed, public RooPrintable {
 public:
    // Constructors etc.
-   RooFormula();
    RooFormula(const char *name, const char *formula, const RooArgList &varList, bool checkVariables = true);
    RooFormula(const RooFormula &other, const char *name = nullptr);
    TObject *Clone(const char *newName = nullptr) const override { return new RooFormula(*this, newName); }
@@ -56,7 +55,6 @@ public:
 
    /// DEBUG: Dump state information
    void dump() const;
-   bool reCompile(const char *newFormula);
 
    void printValue(std::ostream &os) const override;
    void printName(std::ostream &os) const override;

--- a/roofit/roofitcore/src/RooFormulaVar.cxx
+++ b/roofit/roofitcore/src/RooFormulaVar.cxx
@@ -80,13 +80,12 @@ RooFormulaVar::RooFormulaVar(const char *name, const char *title, const char* in
   _actualVars("actualVars","Variables used by formula expression",this),
   _formExpr(inFormula)
 {
-  _actualVars.add(dependents) ;
-
-  if (_actualVars.empty()) {
+  if (dependents.empty()) {
     _value = traceEval(nullptr);
   } else {
-    _formula = new RooFormula(GetName(), _formExpr, _actualVars, checkVariables);
+    _formula = new RooFormula(GetName(), _formExpr, dependents, checkVariables);
     _formExpr = _formula->formulaString().c_str();
+    _actualVars.add(_formula->actualDependents());
   }
 }
 
@@ -104,13 +103,12 @@ RooFormulaVar::RooFormulaVar(const char *name, const char *title, const RooArgLi
   _actualVars("actualVars","Variables used by formula expression",this),
   _formExpr(title)
 {
-  _actualVars.add(dependents) ;
-
-  if (_actualVars.empty()) {
+  if (dependents.empty()) {
     _value = traceEval(0);
   } else {
-    _formula = new RooFormula(GetName(), _formExpr, _actualVars, checkVariables);
+    _formula = new RooFormula(GetName(), _formExpr, dependents, checkVariables);
     _formExpr = _formula->formulaString().c_str();
+    _actualVars.add(_formula->actualDependents());
   }
 }
 

--- a/roofit/roofitcore/src/RooGenericPdf.cxx
+++ b/roofit/roofitcore/src/RooGenericPdf.cxx
@@ -142,19 +142,6 @@ void RooGenericPdf::computeBatch(cudaStream_t* stream, double* output, size_t nE
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Change formula expression to given expression
-
-bool RooGenericPdf::setFormula(const char* inFormula)
-{
-  if (formula().reCompile(inFormula)) return true ;
-
-  _formExpr = inFormula ;
-  setValueDirty() ;
-  return false ;
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
 /// Propagate server changes to embedded formula object
 
 bool RooGenericPdf::redirectServersHook(const RooAbsCollection& newServerList, bool mustReplaceAll, bool nameChange, bool isRecursive)
@@ -196,15 +183,10 @@ void RooGenericPdf::dumpFormula() { formula().dump() ; }
 ////////////////////////////////////////////////////////////////////////////////
 /// Read object contents from given stream
 
-bool RooGenericPdf::readFromStream(istream& is, bool compact, bool /*verbose*/)
+bool RooGenericPdf::readFromStream(istream& /*is*/, bool /*compact*/, bool /*verbose*/)
 {
-  if (compact) {
-    coutE(InputArguments) << "RooGenericPdf::readFromStream(" << GetName() << "): can't read in compact mode" << endl ;
-    return true ;
-  } else {
-    RooStreamParser parser(is) ;
-    return setFormula(parser.readLine()) ;
-  }
+  coutE(InputArguments) << "RooGenericPdf::readFromStream(" << GetName() << "): can't read" << std::endl;
+  return true;
 }
 
 
@@ -219,6 +201,3 @@ void RooGenericPdf::writeToStream(ostream& os, bool compact) const
     os << GetTitle() ;
   }
 }
-
-
-

--- a/roofit/roofitcore/src/RooGenericPdf.cxx
+++ b/roofit/roofitcore/src/RooGenericPdf.cxx
@@ -69,10 +69,13 @@ RooGenericPdf::RooGenericPdf(const char *name, const char *title, const RooArgLi
   _actualVars("actualVars","Variables used by PDF expression",this),
   _formExpr(title)
 {
-  _actualVars.add(dependents) ;
-  formula();
-
-  if (_actualVars.empty()) _value = traceEval(0) ;
+  if (dependents.empty()) {
+    _value = traceEval(nullptr);
+  } else {
+    _formula = new RooFormula(GetName(), _formExpr, dependents);
+    _formExpr = _formula->formulaString().c_str();
+    _actualVars.add(_formula->actualDependents());
+  }
 }
 
 
@@ -86,10 +89,13 @@ RooGenericPdf::RooGenericPdf(const char *name, const char *title,
   _actualVars("actualVars","Variables used by PDF expression",this),
   _formExpr(inFormula)
 {
-  _actualVars.add(dependents) ;
-  formula();
-
-  if (_actualVars.empty()) _value = traceEval(0) ;
+  if (dependents.empty()) {
+    _value = traceEval(0);
+  } else {
+    _formula = new RooFormula(GetName(), _formExpr, dependents);
+    _formExpr = _formula->formulaString().c_str();
+    _actualVars.add(_formula->actualDependents());
+  }
 }
 
 

--- a/roofit/roofitcore/test/testRooFormula.cxx
+++ b/roofit/roofitcore/test/testRooFormula.cxx
@@ -1,12 +1,14 @@
 // Tests for the RooFormula
-// Author: Stephan Hageboeck, CERN  2020
+// Authors: Stephan Hageboeck, CERN  2020
+//          Jonas Rembser, CERN 2023
 
 #include "../src/RooFormula.h"
-#include "RooRealVar.h"
+#include <RooFormulaVar.h>
+#include <RooRealVar.h>
 
-#include "ROOT/TestSupport.hxx"
+#include <ROOT/TestSupport.hxx>
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 /// Since TFormula does very surprising things,
 /// RooFit needs to do safety checks.
@@ -16,28 +18,31 @@
 /// ```
 /// is, for example, legal, and silently uses an undefined
 /// value for y. RooFit needs to detect this.
-TEST(RooFormula, TestInvalidFormulae) {
-  ROOT::TestSupport::CheckDiagsRAII checkDiag;
-  checkDiag.requiredDiag(kError, "prepareMethod", "Can't compile function TFormula", false);
-  checkDiag.requiredDiag(kError, "TFormula::InputFormulaIntoCling", "Error compiling formula expression in Cling", true);
-  checkDiag.requiredDiag(kError, "TFormula::ProcessFormula", " is invalid", false);
-  checkDiag.requiredDiag(kError, "TFormula::ProcessFormula", "has not been matched in the formula expression", false);
-  checkDiag.requiredDiag(kError, "cling", "undeclared identifier", false);
+TEST(RooFormula, TestInvalidFormulae)
+{
+   ROOT::TestSupport::CheckDiagsRAII checkDiag;
+   checkDiag.requiredDiag(kError, "prepareMethod", "Can't compile function TFormula", false);
+   checkDiag.requiredDiag(kError, "TFormula::InputFormulaIntoCling", "Error compiling formula expression in Cling",
+                          true);
+   checkDiag.requiredDiag(kError, "TFormula::ProcessFormula", " is invalid", false);
+   checkDiag.requiredDiag(kError, "TFormula::ProcessFormula", "has not been matched in the formula expression", false);
+   checkDiag.requiredDiag(kError, "cling", "undeclared identifier", false);
 
-  RooRealVar x("x", "x", 1.337);
-  RooRealVar y("y", "y", -1.);
-  RooFormula form("form", "x+10", x);
-  EXPECT_FLOAT_EQ(form.eval(nullptr), 11.337);
+   RooRealVar x("x", "x", 1.337);
+   RooRealVar y("y", "y", -1.);
+   RooFormula form("form", "x+10", x);
+   EXPECT_FLOAT_EQ(form.eval(nullptr), 11.337);
 
-  ASSERT_ANY_THROW(RooFormula("form", "x+y", x)) << "Formulae with y,z,t and no RooFit variable cannot work.";
-  ASSERT_ANY_THROW(RooFormula("form", "x+z", x)) << "Formulae with y,z,t and no RooFit variable cannot work.";
-  ASSERT_ANY_THROW(RooFormula("form", "x+t", x)) << "Formulae with y,z,t and no RooFit variable cannot work.";
-  ASSERT_ANY_THROW(RooFormula("form", "x+a", x)) << "Formulae with unknown variable cannot work.";
+   ASSERT_ANY_THROW(RooFormula("form", "x+y", x)) << "Formulae with y,z,t and no RooFit variable cannot work.";
+   ASSERT_ANY_THROW(RooFormula("form", "x+z", x)) << "Formulae with y,z,t and no RooFit variable cannot work.";
+   ASSERT_ANY_THROW(RooFormula("form", "x+t", x)) << "Formulae with y,z,t and no RooFit variable cannot work.";
+   ASSERT_ANY_THROW(RooFormula("form", "x+a", x)) << "Formulae with unknown variable cannot work.";
 
-  std::unique_ptr<RooFormula> form6;
-  ASSERT_NO_THROW( form6 = std::make_unique<RooFormula>("form", "x+y", RooArgList{x,y})) << "Formula with x,y must work.";
-  ASSERT_NE(form6, nullptr);
-  EXPECT_FLOAT_EQ(form6->eval(nullptr), 1.337 - 1.);
+   std::unique_ptr<RooFormula> form6;
+   ASSERT_NO_THROW(form6 = std::make_unique<RooFormula>("form", "x+y", RooArgList{x, y}))
+      << "Formula with x,y must work.";
+   ASSERT_NE(form6, nullptr);
+   EXPECT_FLOAT_EQ(form6->eval(nullptr), 1.337 - 1.);
 }
 
 // In case of named arguments, the RooFormula will replace the argument names
@@ -47,12 +52,28 @@ TEST(RooFormula, TestInvalidFormulae) {
 // replace existing x[i]. Second, variables with integer names like "0" should
 // only be substituted if the match is not followed by a "]", again to avoid
 // replacing x[i]. This test checks that these cases are handled correctly.
-TEST(RooFormula, TestDangerousVariableNames) {
-  RooRealVar dt("dt", "dt", -10, 10);
-  RooRealVar x("x", "x", 1.547);
-  RooRealVar zero("0", "0", 0);
+TEST(RooFormula, TestDangerousVariableNames)
+{
+   RooRealVar dt("dt", "dt", -10, 10);
+   RooRealVar x("x", "x", 1.547);
+   RooRealVar zero("0", "0", 0);
 
-  // Create the formula, triggers an error if the formula doesn't compile
-  // correctly because the dangerous variable names haven't been treated right.
-  RooFormula formula("formula", "exp(-abs(@0)/@1)*cos(@0*@2)", {dt, x, zero});
+   // Create the formula, triggers an error if the formula doesn't compile
+   // correctly because the dangerous variable names haven't been treated right.
+   RooFormula formula("formula", "exp(-abs(@0)/@1)*cos(@0*@2)", {dt, x, zero});
+}
+
+/// Check that the RooFormulaVar has the right number of servers when some
+/// variables are unused.
+TEST(RooFormula, UnusedVariables)
+{
+   RooRealVar x{"x", "x", 1};
+   RooRealVar y{"y", "y", 2};
+   RooRealVar z{"z", "z", 3};
+
+   RooFormulaVar func{"func", "x * y", {x, y, z}};
+
+   // There are expected to be two servers only because "z" is not used in the
+   // formula.
+   EXPECT_EQ(func.servers().size(), 2);
 }


### PR DESCRIPTION
With PR https://github.com/root-project/root/pull/12800, the `RooFormula` was taken out of the public user
interface, because it is an implementation detail of the RooFormulaVar
and RooGenericPdf.

However, there are cases where people used the RooFormula interface to
access some information that was otherwise unavailable, like the set of
actual variables that the formula depends on.

There is some code in RooFormulaVar and RooGenericPdf that makes it seem
like these classes provide an interface to the actual variables
themselves:

```c++
  const RooArgList& dependents() const { return _actualVars; }
  ...

  RooListProxy _actualVars ;     ///< Actual parameters used by formula engine
```

However, `_actualVars` is containing **all** variables, not the actual
variables as the name suggests!

Fixing this removes the need to access the actual vars via the
`RooFormula`.

This connects to a discussion that was held on GitHub:
https://github.com/root-project/root/commit/a470a3d85e8b5c93917d3e84c39e9d5f0066da97#commitcomment-113514331


Furthermore, a second commit in this PR suggests to remove the possibility to reset the formula in a `RooFormula`, because this i not correctly supported anyway, untested, and greatly increases the possibility for implementation errors. It was only every used in `RooGenericPdf::readFromStream()`, which is not used.
