### PR TITLE
Solve warnings in tests

### DIFF
--- a/tree/dataframe/test/datasource_ntuple.cxx
+++ b/tree/dataframe/test/datasource_ntuple.cxx
@@ -124,6 +124,7 @@ TEST_F(RNTupleDSTest, Read)
    ReadTest(fNtplName, fFileName);
 }
 
+#ifdef R__USE_IMT
 struct IMTRAII {
    IMTRAII() { ROOT::EnableImplicitMT(); }
    ~IMTRAII() { ROOT::DisableImplicitMT(); }
@@ -135,3 +136,4 @@ TEST_F(RNTupleDSTest, ReadMT)
 
    ReadTest(fNtplName, fFileName);
 }
+#endif

--- a/tree/ntuple/v7/test/ntuple_extended.cxx
+++ b/tree/ntuple/v7/test/ntuple_extended.cxx
@@ -6,7 +6,9 @@
 
 TEST(RNTuple, RealWorld1)
 {
+#ifdef R__USE_IMT
    ROOT::EnableImplicitMT();
+#endif
    FileRaii fileGuard("test_ntuple_realworld1.root");
 
    // See https://github.com/olifre/root-io-bench/blob/master/benchmark.cpp
@@ -74,7 +76,9 @@ TEST(RNTuple, RealWorld1)
 // Stress test the asynchronous cluster pool by a deliberately unfavourable read pattern
 TEST(RNTuple, RandomAccess)
 {
+#ifdef R__USE_IMT
    ROOT::EnableImplicitMT();
+#endif
    FileRaii fileGuard("test_ntuple_random_access.root");
 
    auto modelWrite = RNTupleModel::Create();
@@ -111,7 +115,9 @@ TEST(RNTuple, RandomAccess)
 #if !defined(_MSC_VER) || defined(R__ENABLE_BROKEN_WIN_TESTS)
 TEST(RNTuple, LargeFile1)
 {
+#ifdef R__USE_IMT
    ROOT::EnableImplicitMT();
+#endif
    FileRaii fileGuard("test_large_file1.root");
 
    auto modelWrite = RNTupleModel::Create();
@@ -171,7 +177,9 @@ TEST(RNTuple, LargeFile1)
 
 TEST(RNTuple, LargeFile2)
 {
+#ifdef R__USE_IMT
    ROOT::EnableImplicitMT();
+#endif
    FileRaii fileGuard("test_large_file2.root");
 
    // Start out with a mini-file created small file

--- a/tree/ntuple/v7/test/ntuple_rdf.cxx
+++ b/tree/ntuple/v7/test/ntuple_rdf.cxx
@@ -36,7 +36,9 @@ TEST(RNTuple, RDF)
       ntuple->Fill();
    }
 
+#ifdef R__USE_IMT
    ROOT::EnableImplicitMT();
+#endif
    auto f = std::unique_ptr<TFile>(TFile::Open(fileGuard.GetPath().c_str()));
    auto rdf = ROOT::RDF::Experimental::FromRNTuple(f->Get<RNTuple>("myNTuple"));
    EXPECT_EQ(42.0, *rdf.Min("pt"));

--- a/tree/ntuple/v7/test/ntuple_schemaext.cxx
+++ b/tree/ntuple/v7/test/ntuple_schemaext.cxx
@@ -168,7 +168,9 @@ TEST(RNTuple, SchemaExtensionProject)
 // Based on the RealWorld1 test in `ntuple_extended.cxx`, but here some fields are added after the fact
 TEST(RNTuple, SchemaExtensionRealWorld1)
 {
+#ifdef R__USE_IMT
    ROOT::EnableImplicitMT();
+#endif
    FileRaii fileGuard("test_ntuple_schemaext_realworld1.root");
 
    // See https://github.com/olifre/root-io-bench/blob/master/benchmark.cpp

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -372,7 +372,9 @@ TEST(RPageSinkBuf, Basics)
 }
 
 TEST(RPageSinkBuf, ParallelZip) {
+#ifdef R__USE_IMT
    ROOT::EnableImplicitMT();
+#endif
 
    FileRaii fileGuard("test_ntuple_sinkbuf_pzip.root");
    {
@@ -426,7 +428,9 @@ TEST(RPageSinkBuf, CommitSealedPageV)
    RNTupleWriteOptions options;
    options.SetApproxUnzippedPageSize(8);
 
+#ifdef R__USE_IMT
    ROOT::DisableImplicitMT();
+#endif
    {
       std::unique_ptr<RPageSink> sink(new RPageSinkMock(options));
       auto &counters = static_cast<RPageSinkMock *>(sink.get())->fCounters;
@@ -444,7 +448,9 @@ TEST(RPageSinkBuf, CommitSealedPageV)
       EXPECT_EQ(0, counters.fNCommitSealedPage);
       EXPECT_EQ(0, counters.fNCommitSealedPageV);
    }
+#ifdef R__USE_IMT
    ROOT::EnableImplicitMT();
+#endif
    {
       std::unique_ptr<RPageSink> sink(new RPageSinkMock(options));
       auto &counters = static_cast<RPageSinkMock *>(sink.get())->fCounters;

--- a/tree/readspeed/test/readspeed_general.cxx
+++ b/tree/readspeed/test/readspeed_general.cxx
@@ -9,6 +9,7 @@
 #include "ReadSpeed.hxx"
 #include "ReadSpeedCLI.hxx"
 
+#include <ROOT/TestSupport.hxx>
 #ifdef R__USE_IMT
 #include "ROOT/TTreeProcessorMT.hxx" // for TTreeProcessorMT::GetTasksPerWorkerHint
 #endif
@@ -87,6 +88,10 @@ TEST_F(ReadSpeedIntegration, MultiThread)
 
 TEST_F(ReadSpeedIntegration, NonExistentFile)
 {
+   ROOT::TestSupport::CheckDiagsRAII diag;
+   diag.requiredDiag(kError, "TFile::TFile", "test_fake.root does not exist",
+                     /*matchFullMessage=*/false);
+
    EXPECT_THROW(EvalThroughput({{"t"}, {"test_fake.root"}, {"x"}}, 0), std::runtime_error)
       << "Should throw for non-existent file";
 }


### PR DESCRIPTION
 * Protect `EnableImplicitMT()` with `R__USE_IMT`.
 * Expect error about non existent file in `readspeed` test.

Those should have been caught by the `TestSupport` library, but that one doesn't work at the moment (see https://github.com/root-project/root/issues/12828).