### PR TITLE
[ci] Upload build artifacts before testing

### DIFF
--- a/.github/workflows/root-ci-config/build_root.py
+++ b/.github/workflows/root-ci-config/build_root.py
@@ -126,6 +126,13 @@ def main():
 
     shell_log = build(options, args.buildtype, shell_log)
 
+    # Build artifacts should only be uploaded for full builds, and only for
+    # "official" branches (master, v?-??-??-patches), i.e. not for pull_request
+    # We also want to upload any successful build, even if it fails testing
+    # later on.
+    if not pull_request and not args.incremental:
+        archive_and_upload(yyyy_mm_dd, obj_prefix)
+
     testing: bool = options_dict['testing'].lower() == "on" and options_dict['roottest'].lower() == "on"
 
     if testing:
@@ -136,11 +143,6 @@ def main():
             extra_ctest_flags += "--build-config " + args.buildtype
 
         shell_log = run_ctest(shell_log, extra_ctest_flags)
-
-    # Build artifacts should only be uploaded for full builds, and only for "official" branches
-    # (master, v?-??-??-patches), i.e. not for pull_request
-    if not pull_request and not args.incremental:
-        archive_and_upload(yyyy_mm_dd, obj_prefix)
 
     print_shell_log(shell_log)
 


### PR DESCRIPTION
We want to upload any successful build, even if it fails testing (which makes the step and job fail since commit c8c0ea7c59).