### PR TITLE
Revert "[llvm] Override llvm-visibility-default:"

### DIFF
--- a/interpreter/llvm/src/CMakeLists.txt
+++ b/interpreter/llvm/src/CMakeLists.txt
@@ -754,6 +754,9 @@ foreach(t ${LLVM_TARGETS_TO_BUILD})
   endif()
 endforeach(t)
 
+# Provide an LLVM_ namespaced alias for use in #cmakedefine.
+set(LLVM_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
+
 # Produce the target definition files, which provide a way for clients to easily
 # include various classes of targets.
 configure_file(

--- a/interpreter/llvm/src/include/llvm/Config/llvm-config.h.cmake
+++ b/interpreter/llvm/src/include/llvm/Config/llvm-config.h.cmake
@@ -100,5 +100,10 @@
 /* Whether Timers signpost passes in Xcode Instruments */
 #cmakedefine01 LLVM_SUPPORT_XCODE_SIGNPOSTS
 
+/* Define if building libLLVM shared library */
+#cmakedefine LLVM_BUILD_LLVM_DYLIB
+
+/* Define if building LLVM with BUILD_SHARED_LIBS */
+#cmakedefine LLVM_BUILD_SHARED_LIBS
 
 #endif

--- a/interpreter/llvm/src/include/llvm/Support/Compiler.h
+++ b/interpreter/llvm/src/include/llvm/Support/Compiler.h
@@ -126,7 +126,11 @@
 #if (__has_attribute(visibility) || LLVM_GNUC_PREREQ(4, 0, 0)) &&              \
     !defined(__MINGW32__) && !defined(__CYGWIN__) && !defined(_WIN32)
 #define LLVM_LIBRARY_VISIBILITY __attribute__ ((visibility("hidden")))
-#define LLVM_EXTERNAL_VISIBILITY __attribute__ ((visibility("default")))
+#if defined(LLVM_BUILD_LLVM_DYLIB) || defined(LLVM_BUILD_SHARED_LIBS)
+#define LLVM_EXTERNAL_VISIBILITY __attribute__((visibility("default")))
+#else
+#define LLVM_EXTERNAL_VISIBILITY
+#endif
 #else
 #define LLVM_LIBRARY_VISIBILITY
 #define LLVM_EXTERNAL_VISIBILITY

--- a/interpreter/llvm/src/include/llvm/Support/Compiler.h
+++ b/interpreter/llvm/src/include/llvm/Support/Compiler.h
@@ -126,8 +126,7 @@
 #if (__has_attribute(visibility) || LLVM_GNUC_PREREQ(4, 0, 0)) &&              \
     !defined(__MINGW32__) && !defined(__CYGWIN__) && !defined(_WIN32)
 #define LLVM_LIBRARY_VISIBILITY __attribute__ ((visibility("hidden")))
-//#define LLVM_EXTERNAL_VISIBILITY __attribute__ ((visibility("default")))
-#define LLVM_EXTERNAL_VISIBILITY
+#define LLVM_EXTERNAL_VISIBILITY __attribute__ ((visibility("default")))
 #else
 #define LLVM_LIBRARY_VISIBILITY
 #define LLVM_EXTERNAL_VISIBILITY


### PR DESCRIPTION
This reverts commit 0363aed.
Use llvm-upstream commit instead!# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

