### PR TITLE
[clad] Fix corrupt patch file (missing space in context).

### DIFF
--- a/interpreter/cling/tools/plugins/clad/patches/clad_array_size_type.patch
+++ b/interpreter/cling/tools/plugins/clad/patches/clad_array_size_type.patch
@@ -25,6 +25,6 @@ index c5f7b46..59c5178 100644
 +  CUDA_HOST_DEVICE T& operator[](std::ptrdiff_t i) { return m_arr[i]; }
    /// Returns the reference to the underlying array
    CUDA_HOST_DEVICE T& operator*() { return *m_arr; }
-
+ 
 --
 2.17.1

--- a/interpreter/cling/tools/plugins/clad/patches/clad_local_array.patch
+++ b/interpreter/cling/tools/plugins/clad/patches/clad_local_array.patch
@@ -29,7 +29,7 @@ index 0c38c68..381c3f4 100644
 @@ -322,6 +322,59 @@ double func5(int k) {
  //CHECK-NEXT:     * _d_k += _d_n;
  //CHECK-NEXT: }
-
+ 
 +double func6(double seed) {
 +  double sum = 0;
 +  for (int i = 0; i < 3; i++) {


### PR DESCRIPTION
Fixes Windows patch error.