### PR TITLE
[ci] mac13, fed38: switch from C++20 to default or 17: [skip-ci]

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/fedora38.txt
+++ b/.github/workflows/root-ci-config/buildconfig/fedora38.txt
@@ -1,4 +1,3 @@
 tmva-pymva=Off
 test_distrdf_pyspark=OFF
 pythia8=Off
-CMAKE_CXX_STANDARD=20

--- a/.github/workflows/root-ci-config/buildconfig/mac13.txt
+++ b/.github/workflows/root-ci-config/buildconfig/mac13.txt
@@ -1,4 +1,4 @@
-CMAKE_CXX_STANDARD=20
+CMAKE_CXX_STANDARD=17
 builtin_afterimage=ON
 builtin_cfitsio=ON
 builtin_cppzmq=ON


### PR DESCRIPTION
We *know* C++20 is failing the test suite, make the builds green by adding C++20 support to a PR rather than master.

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

