### PR TITLE
[RF] RooAbsReal::getPropagatedError: fix for case of negative parameter with zero error

### DIFF
--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -2593,7 +2593,7 @@ double RooAbsReal::getPropagatedError(const RooFitResult &fr, const RooArgSet &n
      if(rrvFitRes->namePtr() == namePtr()) return rrvFitRes->getError();
 
      // Strip out parameters with zero error
-     if (rrvFitRes->getError() <= rrvFitRes->getVal() * std::numeric_limits<double>::epsilon()) continue;
+     if (rrvFitRes->getError() <= std::abs(rrvFitRes->getVal()) * std::numeric_limits<double>::epsilon()) continue;
 
      // Ignore parameters in the fit result that this RooAbsReal doesn't depend on
      if(!rrvInAbsReal) continue;


### PR DESCRIPTION
A one-line fix, but should be backported!

If the parameter was negative, it was slipping past this line and causing nan error to come back from the function!