### PR TITLE
Add numba compatible with Python 3.11 to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ numpy>=1.4.1
 
 # PyROOT: ROOT.Numba.Declare decorator
 numba>=0.47.0 ; python_version < "3.11" # See https://github.com/numba/numba/issues/8304
+numba>=0.57.0 ; python_version >= "3.11"
 cffi>=1.9.1
 
 # Notebooks: ROOT C++ kernel


### PR DESCRIPTION
Python 3.11 is supported by the latest Numba release https://numba.readthedocs.io/en/stable/release-notes.html#version-0-57-0-1-may-2023