### PR TITLE
v628: IO: Fix StreamerInfo record write during file update.

### DIFF
--- a/io/io/inc/TFile.h
+++ b/io/io/inc/TFile.h
@@ -34,11 +34,8 @@
 // #include "TMap.h"
 // #endif
 
-#ifdef R__USE_IMT
 #include "ROOT/TRWSpinLock.hxx"
 #include <mutex>
-#endif
-
 
 class TMap;
 class TFree;
@@ -117,8 +114,8 @@ protected:
 
 #ifdef R__USE_IMT
    std::mutex                                 fWriteMutex;  ///<!Lock for writing baskets / keys into the file.
-   static ROOT::Internal::RConcurrentHashColl fgTsSIHashes; ///<!TS Set of hashes built from read streamer infos
 #endif
+   static ROOT::Internal::RConcurrentHashColl fgTsSIHashes; ///<!TS Set of hashes built from read streamer infos
 
    static TList    *fgAsyncOpenRequests; //List of handles for pending open requests
 

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -147,9 +147,7 @@ Bool_t   TFile::fgCacheFileForce = kFALSE;
 Bool_t   TFile::fgCacheFileDisconnected = kTRUE;
 UInt_t   TFile::fgOpenTimeout = TFile::kEternalTimeout;
 Bool_t   TFile::fgOnlyStaged = kFALSE;
-#ifdef R__USE_IMT
 ROOT::Internal::RConcurrentHashColl TFile::fgTsSIHashes;
-#endif
 
 #ifdef R__MACOSX
 /* On macOS getxattr takes two extra arguments that should be set to 0 */
@@ -1360,7 +1358,6 @@ TFile::InfoListRet TFile::GetStreamerInfoListImpl(bool lookupSICache)
          return {nullptr, 1, hash};
       }
 
-#ifdef R__USE_IMT
       if (lookupSICache) {
          // key data must be excluded from the hash, otherwise the timestamp will
          // always lead to unique hashes for each file
@@ -1374,9 +1371,6 @@ TFile::InfoListRet TFile::GetStreamerInfoListImpl(bool lookupSICache)
             return {nullptr, 0, hash};
          }
       }
-#else
-      (void) lookupSICache;
-#endif
       key->ReadKeyBuffer(buf);
       list = dynamic_cast<TList*>(key->ReadObjWithBuffer(buffer.data()));
       if (list) list->SetOwner();
@@ -3684,11 +3678,9 @@ void TFile::ReadStreamerInfo()
    list->Clear();  //this will delete all TStreamerInfo objects with kCanDelete bit set
    delete list;
 
-#ifdef R__USE_IMT
    // We are done processing the record, let future calls and other threads that it
    // has been done.
    fgTsSIHashes.Insert(listRetcode.fHash, std::move(si_uids));
-#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fix #12783

Since "66dfb08bd7 - [IO] Do not process the streamerinfo record of a file if we read the si already read"
which was extended in scope by "7cf9d5dc8c - fix hashing of streamer info,"

if a file is opened in update mode and the reading of its `StreamerInfo` record is skip (but
an identical record was already read) *and* some data is stored in the file, the new
`StreamerInfo` record written was missing all the classes in the original record that
were not used during the update.

To resolve this we record not only the fact that the record has been read and process
but also its content (via a collectin of uid of the `TStreamerInfo` objects).
Upon skipping the `StreamerInfo` record, we now mark of its `TStreamerInfo` objects has
been used by the file (and thus upon writing the record is complete).

This behavior was seen #12783 due an awkward 'create, fill, close, update immediately' cycle
for a couple of files.