### PR TITLE
[cling][v6-28] Fix a number of failures in cling tests

### DIFF
--- a/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
@@ -162,15 +162,15 @@ namespace {
 
     void HandleDiagnostic(DiagnosticsEngine::Level DiagLevel,
                           const Diagnostic &Info) override {
+      if (Info.getID() == diag::warn_falloff_nonvoid_function) {
+        DiagLevel = DiagnosticsEngine::Error;
+      }
       if (Ignoring()) {
         if (Info.getID() == diag::warn_unused_expr
             || Info.getID() == diag::warn_unused_result
             || Info.getID() == diag::warn_unused_call
             || Info.getID() == diag::warn_unused_comparison)
           return; // ignore!
-        if (Info.getID() == diag::warn_falloff_nonvoid_function) {
-          DiagLevel = DiagnosticsEngine::Error;
-        }
         if (Info.getID() == diag::ext_return_has_expr) {
           // An error that we need to suppress.
           auto Diags = const_cast<DiagnosticsEngine*>(Info.getDiags());

--- a/interpreter/cling/test/CodeUnloading/Macros.C
+++ b/interpreter/cling/test/CodeUnloading/Macros.C
@@ -13,16 +13,8 @@
 "TEST"
 // CHECK: (const char [5]) "TEST"
 
-// Make sure one Transactin can handle redefinitions
+// Make sure one transaction can handle redefinitions
 #include "Macros.h"
-// expected-warning@Macros.h:3 {{'TEST' macro redefined}}
-// expected-note@Macros.h:2 {{previous definition is here}}
-// expected-warning@Macros.h:4 {{'TEST' macro redefined}}
-// expected-note@Macros.h:3 {{previous definition is here}}
-// expected-warning@Macros.h:5 {{'TEST' macro redefined}}
-// expected-note@Macros.h:4 {{previous definition is here}}
-// expected-warning@Macros.h:6 {{'TEST' macro redefined}}
-// expected-note@Macros.h:5 {{previous definition is here}}
 
 TEST
 // CHECK: (const char [7]) "TEST 4"
@@ -31,7 +23,7 @@ TEST
 .undo //include
 .undo // FIXME: REMOVE once print unloading is merged
 
-TEST // expected-error@2 {{use of undeclared identifier 'TEST'}}
+TEST // expected-error {{use of undeclared identifier 'TEST'}}
 
 #define TEST "DEFINED"
 #undef TEST
@@ -42,13 +34,11 @@ TEST
 .undo // define
 .undo // FIXME: REMOVE once print unloading is merged
 
-TEST // expected-error@2 {{use of undeclared identifier 'TEST'}}
+TEST // expected-error {{use of undeclared identifier 'TEST'}}
 
-// Make sure one Transactin can handle undef, redef
+// Make sure one transaction can handle undef, redef
 #define TESTB
 #include "Macros.h"
-// expected-warning@Macros.h:19 {{'TEST' macro redefined}}
-// expected-note@Macros.h:18 {{previous definition is here}}
 
 TEST // CHECK: (const char [7]) "TEST G"
 .q

--- a/interpreter/cling/test/CodeUnloading/Macros.h
+++ b/interpreter/cling/test/CodeUnloading/Macros.h
@@ -4,6 +4,14 @@
   #define TEST "TEST 2"
   #define TEST "TEST 3"
   #define TEST "TEST 4"
+  // expected-warning@3 {{'TEST' macro redefined}}
+  // expected-note@2 {{previous definition is here}}
+  // expected-warning@4 {{'TEST' macro redefined}}
+  // expected-note@3 {{previous definition is here}}
+  // expected-warning@5 {{'TEST' macro redefined}}
+  // expected-note@4 {{previous definition is here}}
+  // expected-warning@6 {{'TEST' macro redefined}}
+  // expected-note@5 {{previous definition is here}}
 #else
   #define TEST "TEST A"
   #undef TEST
@@ -17,4 +25,6 @@
   #undef TEST
   #define TEST "TEST F"
   #define TEST "TEST G"
+  // expected-warning@27 {{'TEST' macro redefined}}
+  // expected-note@26 {{previous definition is here}}
 #endif

--- a/interpreter/cling/test/DynamicLibraryManager/cached_realpath.C
+++ b/interpreter/cling/test/DynamicLibraryManager/cached_realpath.C
@@ -71,19 +71,20 @@
 #include "../lib/Interpreter/DynamicLibraryManagerSymbol.cpp"
 
 .rawInput 1
-void test_realpath(std::string path) {
+void test_realpath(const std::string &path) {
+  int err_s = 0, err_c = 0;
+
   // system realpath
-  errno = 0;
-  char system_resolved_path[4096];
-  system_resolved_path[0] = '\0';
-  realpath(path.c_str(), system_resolved_path);
-  int err_s = errno;
-  if (err_s !=0 ) system_resolved_path[0] = '\0';
+  char system_resolved_path[4096]{};
+  if (!realpath(path.c_str(), system_resolved_path)) {
+    system_resolved_path[0] = '\0';
+    err_s = errno;
+  }
 
   // cached_realpath
-  errno = 0;
   std::string cached_resolved_path = cached_realpath(path);
-  int err_c = errno;
+  if (cached_resolved_path.empty())
+    err_c = errno;
 
   if (err_s != err_c || std::string(system_resolved_path) != cached_resolved_path) {
     std::cout << "realpath: " << path.c_str() << "\n";

--- a/interpreter/cling/test/DynamicLibraryManager/callable_lib_L_AB_order1.C
+++ b/interpreter/cling/test/DynamicLibraryManager/callable_lib_L_AB_order1.C
@@ -13,7 +13,7 @@
 // RUN: %clang -shared -DCLING_EXPORT=%dllexport %S/call_lib_B.c -o%t-dir/rlib1/libcall_lib_B%shlibext
 // RUN: %clang -shared -DCLING_EXPORT=%dllexport %S/call_lib_AA.c -o%t-dir/rlib2/libcall_lib_A%shlibext
 // RUN: %clang -shared -DCLING_EXPORT=%dllexport %S/call_lib_BB.c -o%t-dir/rlib2/libcall_lib_B%shlibext
-// RUN: %clang %fPIC -shared -Wl,-rpath,%t-dir/rlib1 -DCLING_EXPORT=%dllexport %S/call_lib_L_AB.c -o%t-dir/lib/libcall_lib_L_AB%shlibext -L %t-dir/rlib1 -lcall_lib_A -lcall_lib_B
+// RUN: %clang %fPIC -shared -Wl,--enable-new-dtags -Wl,-rpath,%t-dir/rlib1 -DCLING_EXPORT=%dllexport %S/call_lib_L_AB.c -o%t-dir/lib/libcall_lib_L_AB%shlibext -L %t-dir/rlib1 -lcall_lib_A -lcall_lib_B
 // RUN: cat %s | LD_LIBRARY_PATH="%t-dir/lib:%t-dir/rlib2" %cling 2>&1 | FileCheck %s
 
 // Test: Lookup and load library Lib_L_AB that depends on two libraries Lib_A


### PR DESCRIPTION
This pull request fixes a number of failures in cling tests.  See below for the specific tests that are fixed by this PR.

This is a backport of PR #12855.
 
## Changes or fixes:
- SourceCall/ErrorMacro.C: the failure here is due to `diag::warn_falloff_nonvoid_function` not being promoted from warning to error.  This should always be done, regardless of the ignoring state in `FilteringDiagConsumer`.
The failure became visible after merging https://github.com/root-project/root/pull/12654, given that `IgnorePromptDiags`
now defaults to 0 in `makeDefaultCompilationOptions()`.
- CodeUnloading/Macros.C: clang diagnostic verification was unhappy with the previous state of affairs. Move affected `expected-(warning|note)` markers to `Macros.h`.
- DynamicLibraryManager/callable_lib_L_AB_order1.C: `--enable-new-dtags` is needed in some toolchains to emit the new ELF dynamic tags, i.e. RUNPATH.
Per ld(1) manual page: `By default, the new dynamic tags are not created.`
- DynamicLibraryManager/cached_realpath.C: fetching the value of `errno` only makes sense after a failed call to
`realpath()`, i.e. if the return value of the function is NULL.  Fix that.

## Checklist:
- [x] tested changes locally
- [ ] updated the docs (if necessary)