### PR TITLE
[PyROOT] Only forward some tp_flags

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/MemoryRegulator.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/MemoryRegulator.cxx
@@ -135,7 +135,10 @@ bool CPyCppyy::MemoryRegulator::RecursiveRemove(
             CPyCppyy_NoneType.tp_traverse   = Py_TYPE(pyobj)->tp_traverse;
             CPyCppyy_NoneType.tp_clear      = Py_TYPE(pyobj)->tp_clear;
             CPyCppyy_NoneType.tp_free       = Py_TYPE(pyobj)->tp_free;
-            CPyCppyy_NoneType.tp_flags      = Py_TYPE(pyobj)->tp_flags;
+#ifdef Py_TPFLAGS_MANAGED_DICT
+            CPyCppyy_NoneType.tp_flags     |= (Py_TYPE(pyobj)->tp_flags & Py_TPFLAGS_MANAGED_DICT);
+#endif
+            CPyCppyy_NoneType.tp_flags     |= (Py_TYPE(pyobj)->tp_flags & Py_TPFLAGS_HAVE_GC);
         } else if (CPyCppyy_NoneType.tp_traverse != Py_TYPE(pyobj)->tp_traverse) {
         // TODO: SystemError?
             std::cerr << "in CPyCppyy::MemoryRegulater, unexpected object of type: "

--- a/bindings/pyroot/cppyy/patches/gc_flags.patch
+++ b/bindings/pyroot/cppyy/patches/gc_flags.patch
@@ -16,11 +16,14 @@ diff --git a/bindings/pyroot/cppyy/CPyCppyy/src/MemoryRegulator.cxx b/bindings/p
 index f9e92f9c8c..510d65f88a 100644
 --- a/bindings/pyroot/cppyy/CPyCppyy/src/MemoryRegulator.cxx
 +++ b/bindings/pyroot/cppyy/CPyCppyy/src/MemoryRegulator.cxx
-@@ -135,6 +135,7 @@ bool CPyCppyy::MemoryRegulator::RecursiveRemove(
+@@ -135,6 +135,10 @@ bool CPyCppyy::MemoryRegulator::RecursiveRemove(
              CPyCppyy_NoneType.tp_traverse   = Py_TYPE(pyobj)->tp_traverse;
              CPyCppyy_NoneType.tp_clear      = Py_TYPE(pyobj)->tp_clear;
              CPyCppyy_NoneType.tp_free       = Py_TYPE(pyobj)->tp_free;
-+            CPyCppyy_NoneType.tp_flags      = Py_TYPE(pyobj)->tp_flags;
++#ifdef Py_TPFLAGS_MANAGED_DICT
++            CPyCppyy_NoneType.tp_flags     |= (Py_TYPE(pyobj)->tp_flags & Py_TPFLAGS_MANAGED_DICT);
++#endif
++            CPyCppyy_NoneType.tp_flags     |= (Py_TYPE(pyobj)->tp_flags & Py_TPFLAGS_HAVE_GC);
          } else if (CPyCppyy_NoneType.tp_traverse != Py_TYPE(pyobj)->tp_traverse) {
          // TODO: SystemError?
              std::cerr << "in CPyCppyy::MemoryRegulater, unexpected object of type: "


### PR DESCRIPTION
The `pyobj`'s `tp_flags` can have a number of other bits set, for example `Py_TPFLAGS_HEAPTYPE` and `Py_TPFLAGS_BASETYPE`. Only forward the two bits for `Py_TPFLAGS_HAVE_GC` and (since Python 3.11) `Py_TPFLAGS_MANAGED_DICT`. This fixes test failures seen with a Debug build on Fedora 38, but likely affecting all builds against Python 3.11.