### PR TITLE
[RF] Add exceptions to set methods for non-existing objects

### DIFF
--- a/roofit/roofitcore/inc/RooFit/ModelConfig.h
+++ b/roofit/roofitcore/inc/RooFit/ModelConfig.h
@@ -232,8 +232,13 @@ public:
 
       if (GetWS()->pdf(name))
          fPdfName = name;
-      else
-         coutE(ObjectHandling) << "pdf " << name << " does not exist in workspace" << std::endl;
+      else{
+         std::stringstream ss;
+         ss << "pdf " << name << " does not exist in workspace" ;
+         const std::string errorMsg = ss.str();
+         coutE(ObjectHandling) << errorMsg << std::endl;
+         throw std::runtime_error(errorMsg);
+      }
    }
 
    /// Specify the name of the PDF in the workspace to be used.
@@ -244,8 +249,13 @@ public:
 
       if (GetWS()->pdf(name))
          fPriorPdfName = name;
-      else
-         coutE(ObjectHandling) << "pdf " << name << " does not exist in workspace" << std::endl;
+      else{
+         std::stringstream ss;
+         ss << "pdf " << name << " does not exist in workspace" ;
+         const std::string errorMsg = ss.str();
+         coutE(ObjectHandling) << errorMsg << std::endl;
+         throw std::runtime_error(errorMsg);
+      }
    }
 
    /// Specify the name of the dataset in the workspace to be used.
@@ -256,8 +266,13 @@ public:
 
       if (GetWS()->data(name))
          fProtoDataName = name;
-      else
-         coutE(ObjectHandling) << "dataset " << name << " does not exist in workspace" << std::endl;
+      else{
+         std::stringstream ss;
+         ss << "dataset " << name << " does not exist in workspace" ;
+         const std::string errorMsg = ss.str();
+         coutE(ObjectHandling) << errorMsg << std::endl;
+         throw std::runtime_error(errorMsg);
+      }
    }
 
    /* getter methods */

--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -1272,7 +1272,11 @@ RooArgSet RooWorkspace::argSet(RooStringView nameList) const
     if (oneArg) {
       ret.add(*oneArg) ;
     } else {
-      coutE(InputArguments) << " RooWorkspace::argSet(" << GetName() << ") no RooAbsArg named \"" << token << "\" in workspace" << endl ;
+      std::stringstream ss;
+      ss << " RooWorkspace::argSet(" << GetName() << ") no RooAbsArg named \"" << token << "\" in workspace" ;
+      const std::string errorMsg = ss.str();
+      coutE(InputArguments) << errorMsg << std::endl;
+      throw std::runtime_error(errorMsg);
     }
   }
   return ret ;


### PR DESCRIPTION
# This Pull request:

Improves exception handling of RooWorkspace for non-existing objects

## Changes or fixes:

Adding a non-existing object to RooWorkspace prints an error message but doesn't terminate the program, which might lead to segmentation faults. The fix prints the error message and then throws a runtime error to handle such cases.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes [JIRA: ROOT-7922](https://sft.its.cern.ch/jira/browse/ROOT-7922)