### PR TITLE
[ntuple] Add basic support for Double32_t

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -604,6 +604,11 @@ The following fundamental types are stored as `leaf` fields with a single column
 Possibly available `const` and `volatile` qualifiers of the C++ types are ignored for serialization.
 If the ntuple is stored uncompressed, the default changes from split encoding to non-split encoding where applicable.
 
+### Low-precision Floating Points
+
+The ROOT type `Double32_t` is stored on disk as a `double` field with a `SplitReal32` column representation.
+The field's type alias is set to `Double32_t`.
+
 ### STL Types and Collections
 
 The following STL and collection types are supported.

--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -636,7 +636,7 @@ They are stored as two fields:
 
 Fixed-sized arrays are stored as two fields:
   - A repetitive field of type `std::array<T, N>` with no attached columns. The array size `N` is stored in the field meta-data.
-  - Child field of type `T`, which must be a type with RNTuple I/O support.
+  - Child field of type `T` named `_0`, which must be a type with RNTuple I/O support.
 
 Multi-dimensional arrays of the form `T[N][M]...` are currently not supported.
 

--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -745,6 +745,26 @@ public:
 };
 
 template <>
+class RColumnElement<double, EColumnType::kReal32> : public RColumnElementCastLE<double, float> {
+public:
+   static constexpr std::size_t kSize = sizeof(double);
+   static constexpr std::size_t kBitsOnStorage = sizeof(float) * 8;
+   explicit RColumnElement(double *value) : RColumnElementCastLE(value, kSize) {}
+   bool IsMappable() const final { return kIsMappable; }
+   std::size_t GetBitsOnStorage() const final { return kBitsOnStorage; }
+};
+
+template <>
+class RColumnElement<double, EColumnType::kSplitReal32> : public RColumnElementSplitLE<double, float> {
+public:
+   static constexpr std::size_t kSize = sizeof(double);
+   static constexpr std::size_t kBitsOnStorage = sizeof(float) * 8;
+   explicit RColumnElement(double *value) : RColumnElementSplitLE(value, kSize) {}
+   bool IsMappable() const final { return kIsMappable; }
+   std::size_t GetBitsOnStorage() const final { return kBitsOnStorage; }
+};
+
+template <>
 class RColumnElement<ClusterSize_t, EColumnType::kIndex64> : public RColumnElementLE<std::uint64_t> {
 public:
    static constexpr std::size_t kSize = sizeof(ClusterSize_t);

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -1347,6 +1347,9 @@ public:
    size_t GetValueSize() const final { return sizeof(double); }
    size_t GetAlignment() const final { return alignof(double); }
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+
+   // Set the column representation to 16 bit floating point and the type alias to Double32_t
+   void SetDouble32();
 };
 
 template <>

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -1352,7 +1352,7 @@ public:
    size_t GetAlignment() const final { return alignof(double); }
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 
-   // Set the column representation to 16 bit floating point and the type alias to Double32_t
+   // Set the column representation to 32 bit floating point and the type alias to Double32_t
    void SetDouble32();
 };
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -258,7 +258,8 @@ public:
    std::unique_ptr<RFieldBase> Clone(std::string_view newName) const;
 
    /// Factory method to resurrect a field from the stored on-disk type information
-   static RResult<std::unique_ptr<RFieldBase>> Create(const std::string &fieldName, const std::string &typeName);
+   static RResult<std::unique_ptr<RFieldBase>>
+   Create(const std::string &fieldName, const std::string &typeName, const std::string &typeAlias = "");
    /// Check whether a given string is a valid field name
    static RResult<void> EnsureValidFieldName(std::string_view fieldName);
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -259,7 +259,7 @@ public:
 
    /// Factory method to resurrect a field from the stored on-disk type information
    static RResult<std::unique_ptr<RFieldBase>>
-   Create(const std::string &fieldName, const std::string &typeName, const std::string &typeAlias = "");
+   Create(const std::string &fieldName, const std::string &typeName);
    /// Check whether a given string is a valid field name
    static RResult<void> EnsureValidFieldName(std::string_view fieldName);
 
@@ -1890,8 +1890,7 @@ public:
    static std::string TypeName() {
       return "std::array<" + RField<ItemT>::TypeName() + "," + std::to_string(N) + ">";
    }
-   explicit RField(std::string_view name)
-      : RArrayField(name, std::make_unique<RField<ItemT>>(RField<ItemT>::TypeName()), N)
+   explicit RField(std::string_view name) : RArrayField(name, std::make_unique<RField<ItemT>>("_0"), N)
    {}
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -159,6 +159,8 @@ protected:
    std::vector<std::unique_ptr<RColumn>> fColumns;
    /// Properties of the type that allow for optimizations of collections of that type
    int fTraits = 0;
+   /// A typedef or using name that was used when creating the field
+   std::string fTypeAlias;
    /// List of functions to be called after reading a value
    std::vector<ReadCallback_t> fReadCallbacks;
    /// C++ type version cached from the descriptor after a call to `ConnectPageSource()`
@@ -332,6 +334,7 @@ public:
    /// Returns the field name and parent field names separated by dots ("grandparent.parent.child")
    std::string GetQualifiedFieldName() const;
    std::string GetType() const { return fType; }
+   std::string GetTypeAlias() const { return fTypeAlias; }
    ENTupleStructure GetStructure() const { return fStructure; }
    std::size_t GetNRepetitions() const { return fNRepetitions; }
    NTupleSize_t GetNElements() const { return fPrincipalColumn->GetNElements(); }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -71,6 +71,8 @@ private:
    std::string fFieldDescription;
    /// The C++ type that was used when writing the field
    std::string fTypeName;
+   /// A typedef or using directive that resolved to the type name during field creation
+   std::string fTypeAlias;
    /// The number of elements per entry for fixed-size arrays
    std::uint64_t fNRepetitions = 0;
    /// The structural information carried by this field in the data model tree
@@ -101,6 +103,7 @@ public:
    std::string GetFieldName() const { return fFieldName; }
    std::string GetFieldDescription() const { return fFieldDescription; }
    std::string GetTypeName() const { return fTypeName; }
+   std::string GetTypeAlias() const { return fTypeAlias; }
    std::uint64_t GetNRepetitions() const { return fNRepetitions; }
    ENTupleStructure GetStructure() const { return fStructure; }
    DescriptorId_t GetParentId() const { return fParentId; }
@@ -883,6 +886,11 @@ public:
    }
    RFieldDescriptorBuilder& TypeName(const std::string& typeName) {
       fField.fTypeName = typeName;
+      return *this;
+   }
+   RFieldDescriptorBuilder &TypeAlias(const std::string &typeAlias)
+   {
+      fField.fTypeAlias = typeAlias;
       return *this;
    }
    RFieldDescriptorBuilder& NRepetitions(std::uint64_t nRepetitions) {

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -244,8 +244,8 @@ ROOT::Experimental::Detail::RFieldBase::Create(const std::string &fieldName, con
       // TODO(jalopezg): support multi-dimensional row-major (C order) arrays in RArrayField
       if (arraySize.size() > 1)
          return R__FAIL("multi-dimensional array type not supported " + normalizedType);
-      auto itemField = Create(GetNormalizedType(arrayBaseType), arrayBaseType);
-      return {std::make_unique<RArrayField>(fieldName, itemField.Unwrap(), arraySize[0])};
+      auto itemField = Create(GetNormalizedType(arrayBaseType), arrayBaseType).Unwrap();
+      return {std::make_unique<RArrayField>(fieldName, std::move(itemField), arraySize[0])};
    }
 
    std::unique_ptr<ROOT::Experimental::Detail::RFieldBase> result;
@@ -527,6 +527,9 @@ void ROOT::Experimental::Detail::RFieldBase::AutoAdjustColumnTypes(const RNTuple
       }
       SetColumnRepresentative(rep);
    }
+
+   if (fTypeAlias == "Double32_t")
+      SetColumnRepresentative({EColumnType::kSplitReal32});
 }
 
 void ROOT::Experimental::Detail::RFieldBase::ConnectPageSink(RPageSink &pageSink)
@@ -842,7 +845,6 @@ void ROOT::Experimental::RField<double>::AcceptVisitor(Detail::RFieldVisitor &vi
 
 void ROOT::Experimental::RField<double>::SetDouble32()
 {
-   SetColumnRepresentative({EColumnType::kSplitReal32});
    fTypeAlias = "Double32_t";
 }
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -277,6 +277,9 @@ ROOT::Experimental::Detail::RFieldBase::Create(const std::string &fieldName, con
       result = std::make_unique<RField<float>>(fieldName);
    } else if (normalizedType == "double") {
       result = std::make_unique<RField<double>>(fieldName);
+   } else if (normalizedType == "Double32_t") {
+      result = std::make_unique<RField<double>>(fieldName);
+      static_cast<RField<double> *>(result.get())->SetDouble32();
    } else if (normalizedType == "std::string") {
       result = std::make_unique<RField<std::string>>(fieldName);
    } else if (normalizedType == "std::vector<bool>") {
@@ -839,6 +842,7 @@ void ROOT::Experimental::RField<double>::AcceptVisitor(Detail::RFieldVisitor &vi
 void ROOT::Experimental::RField<double>::SetDouble32()
 {
    SetColumnRepresentative({EColumnType::kSplitReal32});
+   fTypeAlias = "Double32_t";
 }
 
 //------------------------------------------------------------------------------

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -815,7 +815,8 @@ void ROOT::Experimental::RField<float>::AcceptVisitor(Detail::RFieldVisitor &vis
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<double>::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kSplitReal64}, {EColumnType::kReal64}}, {{}});
+   static RColumnRepresentations representations(
+      {{EColumnType::kSplitReal64}, {EColumnType::kReal64}, {EColumnType::kSplitReal32}, {EColumnType::kReal32}}, {});
    return representations;
 }
 
@@ -833,6 +834,11 @@ void ROOT::Experimental::RField<double>::GenerateColumnsImpl(const RNTupleDescri
 void ROOT::Experimental::RField<double>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitDoubleField(*this);
+}
+
+void ROOT::Experimental::RField<double>::SetDouble32()
+{
+   SetColumnRepresentative({EColumnType::kSplitReal32});
 }
 
 //------------------------------------------------------------------------------

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -189,11 +189,16 @@ ROOT::Experimental::RClusterDescriptor ROOT::Experimental::RClusterDescriptor::C
 
 bool ROOT::Experimental::RNTupleDescriptor::operator==(const RNTupleDescriptor &other) const
 {
-   return fName == other.fName && fDescription == other.fDescription && fNEntries == other.fNEntries &&
-          fGeneration == other.fGeneration && fFieldDescriptors == other.fFieldDescriptors &&
+   // clang-format off
+   return fName == other.fName &&
+          fDescription == other.fDescription &&
+          fNEntries == other.fNEntries &&
+          fGeneration == other.fGeneration &&
+          fFieldDescriptors == other.fFieldDescriptors &&
           fColumnDescriptors == other.fColumnDescriptors &&
           fClusterGroupDescriptors == other.fClusterGroupDescriptors &&
           fClusterDescriptors == other.fClusterDescriptors;
+   // clang-format on
 }
 
 ROOT::Experimental::NTupleSize_t

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -33,16 +33,10 @@
 
 bool ROOT::Experimental::RFieldDescriptor::operator==(const RFieldDescriptor &other) const
 {
-   return fFieldId == other.fFieldId &&
-          fFieldVersion == other.fFieldVersion &&
-          fTypeVersion == other.fTypeVersion &&
-          fFieldName == other.fFieldName &&
-          fFieldDescription == other.fFieldDescription &&
-          fTypeName == other.fTypeName &&
-          fNRepetitions == other.fNRepetitions &&
-          fStructure == other.fStructure &&
-          fParentId == other.fParentId &&
-          fLinkIds == other.fLinkIds;
+   return fFieldId == other.fFieldId && fFieldVersion == other.fFieldVersion && fTypeVersion == other.fTypeVersion &&
+          fFieldName == other.fFieldName && fFieldDescription == other.fFieldDescription &&
+          fTypeName == other.fTypeName && fTypeAlias == other.fTypeAlias && fNRepetitions == other.fNRepetitions &&
+          fStructure == other.fStructure && fParentId == other.fParentId && fLinkIds == other.fLinkIds;
 }
 
 ROOT::Experimental::RFieldDescriptor
@@ -55,6 +49,7 @@ ROOT::Experimental::RFieldDescriptor::Clone() const
    clone.fFieldName = fFieldName;
    clone.fFieldDescription = fFieldDescription;
    clone.fTypeName = fTypeName;
+   clone.fTypeAlias = fTypeAlias;
    clone.fNRepetitions = fNRepetitions;
    clone.fStructure = fStructure;
    clone.fParentId = fParentId;
@@ -79,7 +74,7 @@ ROOT::Experimental::RFieldDescriptor::CreateField(const RNTupleDescriptor &ntplD
       return collectionField;
    }
 
-   auto field = Detail::RFieldBase::Create(GetFieldName(), GetTypeName()).Unwrap();
+   auto field = Detail::RFieldBase::Create(GetFieldName(), GetTypeName(), GetTypeAlias()).Unwrap();
    field->SetOnDiskId(fFieldId);
    for (auto &f : *field)
       f.SetOnDiskId(ntplDesc.FindFieldId(f.GetName(), f.GetParent()->GetOnDiskId()));
@@ -565,6 +560,7 @@ ROOT::Experimental::RFieldDescriptorBuilder::FromField(const Detail::RFieldBase&
       .FieldName(field.GetName())
       .FieldDescription(field.GetDescription())
       .TypeName(field.GetType())
+      .TypeAlias(field.GetTypeAlias())
       .Structure(field.GetStructure())
       .NRepetitions(field.GetNRepetitions());
    return fieldDesc;

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -74,7 +74,8 @@ ROOT::Experimental::RFieldDescriptor::CreateField(const RNTupleDescriptor &ntplD
       return collectionField;
    }
 
-   auto field = Detail::RFieldBase::Create(GetFieldName(), GetTypeName(), GetTypeAlias()).Unwrap();
+   auto field =
+      Detail::RFieldBase::Create(GetFieldName(), GetTypeAlias().empty() ? GetTypeName() : GetTypeAlias()).Unwrap();
    field->SetOnDiskId(fFieldId);
    for (auto &f : *field)
       f.SetOnDiskId(ntplDesc.FindFieldId(f.GetName(), f.GetParent()->GetOnDiskId()));

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -56,7 +56,7 @@ std::uint32_t SerializeFieldV1(const ROOT::Experimental::RFieldDescriptor &field
    }
    pos += RNTupleSerializer::SerializeString(fieldDesc.GetFieldName(), *where);
    pos += RNTupleSerializer::SerializeString(fieldDesc.GetTypeName(), *where);
-   pos += RNTupleSerializer::SerializeString("" /* type alias */, *where);
+   pos += RNTupleSerializer::SerializeString(fieldDesc.GetTypeAlias(), *where);
    pos += RNTupleSerializer::SerializeString(fieldDesc.GetFieldDescription(), *where);
 
    auto size = pos - base;
@@ -142,7 +142,7 @@ RResult<std::uint32_t> DeserializeFieldV1(
 
    std::string fieldName;
    std::string typeName;
-   std::string aliasName; // so far unused
+   std::string aliasName;
    std::string description;
    result = RNTupleSerializer::DeserializeString(bytes, fnFrameSizeLeft(), fieldName).Unwrap();
    if (!result)
@@ -160,7 +160,7 @@ RResult<std::uint32_t> DeserializeFieldV1(
    if (!result)
       return R__FORWARD_ERROR(result);
    bytes += result.Unwrap();
-   fieldDesc.FieldName(fieldName).TypeName(typeName).FieldDescription(description);
+   fieldDesc.FieldName(fieldName).TypeName(typeName).TypeAlias(aliasName).FieldDescription(description);
 
    return frameSize;
 }

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -1,6 +1,7 @@
 #ifndef ROOT7_RNTuple_Test_CustomStruct
 #define ROOT7_RNTuple_Test_CustomStruct
 
+#include <RtypesCore.h> // for Double32_t
 #include <TRootIOCtor.h>
 
 #include <cstdint>
@@ -62,6 +63,13 @@ public:
    IOConstructor(TRootIOCtor *) {};
 
    int a = 7;
+};
+
+class LowPrecisionFloats {
+public:
+   double a = 0.0;
+   Double32_t b = 1.0;
+   Double32_t c[2] = {2.0, 3.0};
 };
 
 /// The classes below are based on an excerpt provided by Marcin Nowak (EP-UAT)

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -733,7 +733,6 @@ TEST(RNTuple, Double32)
    auto fldD1 = RFieldBase::Create("d1", "double").Unwrap();
    fldD1->SetColumnRepresentative({EColumnType::kReal32});
    auto fldD2 = RFieldBase::Create("d2", "Double32_t").Unwrap();
-   EXPECT_EQ(EColumnType::kSplitReal32, fldD2->GetColumnRepresentative()[0]);
    EXPECT_EQ("Double32_t", fldD2->GetTypeAlias());
 
    auto model = RNTupleModel::Create();
@@ -805,6 +804,29 @@ TEST(RNTuple, Double32)
    EXPECT_DOUBLE_EQ(std::numeric_limits<float>::infinity(), *d2Float);
    readerFloat->LoadEntry(5);
    EXPECT_DOUBLE_EQ(std::numeric_limits<float>::denorm_min(), *d2Float);
+}
+
+TEST(RNTuple, Double32Extended)
+{
+   FileRaii fileGuard("test_ntuple_double32_extended.root");
+
+   auto fldObj = RFieldBase::Create("obj", "LowPrecisionFloats").Unwrap();
+   auto model = RNTupleModel::Create();
+   model->AddField(std::move(fldObj));
+
+   {
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
+      writer->Fill();
+   }
+
+   auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
+   auto obj = reader->GetModel()->GetDefaultEntry()->Get<LowPrecisionFloats>("obj");
+   EXPECT_EQ("Double32_t", reader->GetModel()->GetField("obj")->GetSubFields()[1]->GetTypeAlias());
+   EXPECT_EQ("Double32_t", reader->GetModel()->GetField("obj")->GetSubFields()[2]->GetSubFields()[0]->GetTypeAlias());
+   EXPECT_DOUBLE_EQ(0.0, obj->a);
+   EXPECT_DOUBLE_EQ(1.0, obj->b);
+   EXPECT_DOUBLE_EQ(2.0, obj->c[0]);
+   EXPECT_DOUBLE_EQ(3.0, obj->c[1]);
 }
 
 TEST(RNTuple, TClass)

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -731,9 +731,10 @@ TEST(RNTuple, Double32)
    FileRaii fileGuard("test_ntuple_double32.root");
 
    auto fldD1 = RFieldBase::Create("d1", "double").Unwrap();
-   auto fldD2 = RFieldBase::Create("d2", "Double32_t").Unwrap();
    fldD1->SetColumnRepresentative({EColumnType::kReal32});
+   auto fldD2 = RFieldBase::Create("d2", "Double32_t").Unwrap();
    EXPECT_EQ(EColumnType::kSplitReal32, fldD2->GetColumnRepresentative()[0]);
+   EXPECT_EQ("Double32_t", fldD2->GetTypeAlias());
 
    auto model = RNTupleModel::Create();
    model->AddField(std::move(fldD1));
@@ -765,7 +766,9 @@ TEST(RNTuple, Double32)
 
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
    EXPECT_EQ(EColumnType::kReal32, reader->GetModel()->GetField("d1")->GetColumnRepresentative()[0]);
+   EXPECT_EQ("", reader->GetModel()->GetField("d1")->GetTypeAlias());
    EXPECT_EQ(EColumnType::kSplitReal32, reader->GetModel()->GetField("d2")->GetColumnRepresentative()[0]);
+   EXPECT_EQ("Double32_t", reader->GetModel()->GetField("d2")->GetTypeAlias());
    auto d1 = reader->GetModel()->GetDefaultEntry()->Get<double>("d1");
    auto d2 = reader->GetModel()->GetDefaultEntry()->Get<double>("d2");
    reader->LoadEntry(0);

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -731,62 +731,77 @@ TEST(RNTuple, Double32)
    FileRaii fileGuard("test_ntuple_double32.root");
 
    auto fldD1 = RFieldBase::Create("d1", "double").Unwrap();
-   // auto fldD2 = RFieldBase::Create("d2", "Double32_t").Unwrap();
+   auto fldD2 = RFieldBase::Create("d2", "Double32_t").Unwrap();
    fldD1->SetColumnRepresentative({EColumnType::kReal32});
-   // EXPECT_EQ(EColumnType::kSplitReal32, fldD2->GetColumnRepresentative()[0]);
+   EXPECT_EQ(EColumnType::kSplitReal32, fldD2->GetColumnRepresentative()[0]);
 
    auto model = RNTupleModel::Create();
    model->AddField(std::move(fldD1));
-   // model->AddField(std::move(fldD2));
+   model->AddField(std::move(fldD2));
 
    {
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
       auto d1 = writer->GetModel()->GetDefaultEntry()->Get<double>("d1");
+      auto d2 = writer->GetModel()->GetDefaultEntry()->Get<double>("d2");
       *d1 = 0.0;
+      *d2 = 0.0;
       writer->Fill();
       *d1 = std::numeric_limits<float>::max();
+      *d2 = *d1;
       writer->Fill();
       *d1 = std::numeric_limits<float>::min();
+      *d2 = *d1;
       writer->Fill();
       *d1 = std::numeric_limits<float>::lowest();
+      *d2 = *d1;
       writer->Fill();
       *d1 = std::numeric_limits<float>::infinity();
+      *d2 = *d1;
       writer->Fill();
       *d1 = std::numeric_limits<float>::denorm_min();
+      *d2 = *d1;
       writer->Fill();
    }
 
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
    EXPECT_EQ(EColumnType::kReal32, reader->GetModel()->GetField("d1")->GetColumnRepresentative()[0]);
+   EXPECT_EQ(EColumnType::kSplitReal32, reader->GetModel()->GetField("d2")->GetColumnRepresentative()[0]);
    auto d1 = reader->GetModel()->GetDefaultEntry()->Get<double>("d1");
+   auto d2 = reader->GetModel()->GetDefaultEntry()->Get<double>("d2");
    reader->LoadEntry(0);
    EXPECT_DOUBLE_EQ(0.0, *d1);
+   EXPECT_DOUBLE_EQ(*d1, *d2);
    reader->LoadEntry(1);
    EXPECT_DOUBLE_EQ(std::numeric_limits<float>::max(), *d1);
+   EXPECT_DOUBLE_EQ(*d1, *d2);
    reader->LoadEntry(2);
    EXPECT_DOUBLE_EQ(std::numeric_limits<float>::min(), *d1);
+   EXPECT_DOUBLE_EQ(*d1, *d2);
    reader->LoadEntry(3);
    EXPECT_DOUBLE_EQ(std::numeric_limits<float>::lowest(), *d1);
+   EXPECT_DOUBLE_EQ(*d1, *d2);
    reader->LoadEntry(4);
    EXPECT_DOUBLE_EQ(std::numeric_limits<float>::infinity(), *d1);
+   EXPECT_DOUBLE_EQ(*d1, *d2);
    reader->LoadEntry(5);
    EXPECT_DOUBLE_EQ(std::numeric_limits<float>::denorm_min(), *d1);
+   EXPECT_DOUBLE_EQ(*d1, *d2);
 
    auto modelFloat = RNTupleModel::Create();
-   auto d1Float = modelFloat->MakeField<float>("d1");
+   auto d2Float = modelFloat->MakeField<float>("d2");
    auto readerFloat = RNTupleReader::Open(std::move(modelFloat), "ntuple", fileGuard.GetPath());
    readerFloat->LoadEntry(0);
-   EXPECT_FLOAT_EQ(0.0, *d1Float);
+   EXPECT_FLOAT_EQ(0.0, *d2Float);
    readerFloat->LoadEntry(1);
-   EXPECT_DOUBLE_EQ(std::numeric_limits<float>::max(), *d1Float);
+   EXPECT_DOUBLE_EQ(std::numeric_limits<float>::max(), *d2Float);
    readerFloat->LoadEntry(2);
-   EXPECT_DOUBLE_EQ(std::numeric_limits<float>::min(), *d1Float);
+   EXPECT_DOUBLE_EQ(std::numeric_limits<float>::min(), *d2Float);
    readerFloat->LoadEntry(3);
-   EXPECT_DOUBLE_EQ(std::numeric_limits<float>::lowest(), *d1Float);
+   EXPECT_DOUBLE_EQ(std::numeric_limits<float>::lowest(), *d2Float);
    readerFloat->LoadEntry(4);
-   EXPECT_DOUBLE_EQ(std::numeric_limits<float>::infinity(), *d1Float);
+   EXPECT_DOUBLE_EQ(std::numeric_limits<float>::infinity(), *d2Float);
    readerFloat->LoadEntry(5);
-   EXPECT_DOUBLE_EQ(std::numeric_limits<float>::denorm_min(), *d1Float);
+   EXPECT_DOUBLE_EQ(std::numeric_limits<float>::denorm_min(), *d2Float);
 }
 
 TEST(RNTuple, TClass)


### PR DESCRIPTION
Enables support for doubles stored as float on disk (`Double32_t`). The field has `double` as its type with a `kReal32` column representation. The field's type alias is set to `Double32_t`. This PR only implements basic support, i.e. storing a `double` in memory as `float` on disk. Custom bit lengths and value ranges are for a future PR.