### PR TITLE
Fix dictionary issues when unloading/reloading the same libraries

### DIFF
--- a/core/base/inc/Rtypes.h
+++ b/core/base/inc/Rtypes.h
@@ -105,6 +105,7 @@ template <class Tmpl> TBuffer &operator<<(TBuffer &buf, const Tmpl *obj);
 namespace ROOT {
 
    class TGenericClassInfo;
+   class TClassAlt;
    typedef void *(*NewFunc_t)(void *);
    typedef void *(*NewArrFunc_t)(Long_t size, void *arena);
    typedef void  (*DelFunc_t)(void *);
@@ -124,7 +125,8 @@ namespace ROOT {
                         DictFuncPtr_t dict, Int_t pragmabits);
    extern void RemoveClass(const char *cname, TClass *cl);
    extern void ResetClassVersion(TClass*, const char*, Short_t);
-   extern void AddClassAlternate(const char *normName, const char *alternate);
+   extern ROOT::TClassAlt* AddClassAlternate(const char *normName, const char *alternate);
+   extern void RemoveClassAlternate(ROOT::TClassAlt*);
 
    extern TNamed *RegisterClassTemplate(const char *name,
                                         const char *file, Int_t line);

--- a/core/base/inc/Rtypes.h
+++ b/core/base/inc/Rtypes.h
@@ -122,7 +122,7 @@ namespace ROOT {
                               Int_t dl, Int_t il);
    extern void AddClass(const char *cname, Version_t id, const std::type_info &info,
                         DictFuncPtr_t dict, Int_t pragmabits);
-   extern void RemoveClass(const char *cname);
+   extern void RemoveClass(const char *cname, TClass *cl);
    extern void ResetClassVersion(TClass*, const char*, Short_t);
    extern void AddClassAlternate(const char *normName, const char *alternate);
 
@@ -153,7 +153,7 @@ namespace ROOT {
       virtual void Register(const char *cname, Version_t id,
                             const std::type_info &info,
                             DictFuncPtr_t dict, Int_t pragmabits) const = 0;
-      virtual void Unregister(const char *classname) const = 0;
+      virtual void Unregister(const char *classname, TClass *cl) const = 0;
       virtual TClass *CreateClass(const char *cname, Version_t id,
                                   const std::type_info &info, TVirtualIsAProxy *isa,
                                   const char *dfil, const char *ifil,
@@ -168,8 +168,8 @@ namespace ROOT {
          ROOT::AddClass(cname, id, info, dict, pragmabits);
       }
 
-      void Unregister(const char *classname) const override {
-         ROOT::RemoveClass(classname);
+      void Unregister(const char *classname, TClass *cl) const override {
+         ROOT::RemoveClass(classname, cl);
       }
 
       TClass *CreateClass(const char *cname, Version_t id,

--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -1998,15 +1998,15 @@ void ROOT::TMetaUtils::WriteClassInit(std::ostream& finalString,
    /////////////////////////////////////////////////////////////////////////////
 
    if (cl.GetRequestedName()[0] && classname != cl.GetRequestedName()) {
-      finalString << "\n" << "      ::ROOT::AddClassAlternate(\""
-                  << classname << "\",\"" << cl.GetRequestedName() << "\");\n";
+      finalString << "\n" << "      instance.AdoptAlternate(::ROOT::AddClassAlternate(\""
+                  << classname << "\",\"" << cl.GetRequestedName() << "\"));\n";
    }
 
    if (!cl.GetDemangledTypeInfo().empty()
          && cl.GetDemangledTypeInfo() != classname
          && cl.GetDemangledTypeInfo() != cl.GetRequestedName()) {
-      finalString << "\n" << "      ::ROOT::AddClassAlternate(\""
-                  << classname << "\",\"" << cl.GetDemangledTypeInfo() << "\");\n";
+      finalString << "\n" << "      instance.AdoptAlternate(::ROOT::AddClassAlternate(\""
+                  << classname << "\",\"" << cl.GetDemangledTypeInfo() << "\"));\n";
 
    }
 

--- a/core/cont/inc/TClassTable.h
+++ b/core/cont/inc/TClassTable.h
@@ -68,27 +68,28 @@ public:
 
    ~TClassTable();
 
-   static void          Add(const char *cname, Version_t id,
-                            const std::type_info &info, DictFuncPtr_t dict,
-                            Int_t pragmabits);
-   static void          Add(TProtoClass *protoClass);
-   static void          AddAlternate(const char *normname, const char *alternate);
-   static char         *At(UInt_t index);
-   int                  Classes();
-   static Bool_t        Check(const char *cname, std::string &normname);
-   static Version_t     GetID(const char *cname);
-   static Int_t         GetPragmaBits(const char *name);
-   static DictFuncPtr_t GetDict(const char *cname);
-   static DictFuncPtr_t GetDict(const std::type_info& info);
-   static DictFuncPtr_t GetDictNorm(const char *cname);
-   static TProtoClass  *GetProto(const char *cname);
-   static TProtoClass  *GetProtoNorm(const char *cname);
-   static void          Init();
-   static char         *Next();
-   void                 Print(Option_t *option="") const override;
-   static void          PrintTable();
-   static void          Remove(const char *cname);
-   static void          Terminate();
+   static void             Add(const char *cname, Version_t id,
+                               const std::type_info &info, DictFuncPtr_t dict,
+                               Int_t pragmabits);
+   static void             Add(TProtoClass *protoClass);
+   static ROOT::TClassAlt *AddAlternate(const char *normname, const char *alternate);
+   static char            *At(UInt_t index);
+   int                     Classes();
+   static Bool_t           Check(const char *cname, std::string &normname);
+   static Version_t        GetID(const char *cname);
+   static Int_t            GetPragmaBits(const char *name);
+   static DictFuncPtr_t    GetDict(const char *cname);
+   static DictFuncPtr_t    GetDict(const std::type_info& info);
+   static DictFuncPtr_t    GetDictNorm(const char *cname);
+   static TProtoClass     *GetProto(const char *cname);
+   static TProtoClass     *GetProtoNorm(const char *cname);
+   static void             Init();
+   static char            *Next();
+   void                    Print(Option_t *option="") const override;
+   static void             PrintTable();
+   static void             Remove(const char *cname);
+   static void             RemoveAlternate(ROOT::TClassAlt *alt);
+   static void             Terminate();
 
    ClassDefOverride(TClassTable,0)  //Table of known classes
 };

--- a/core/cont/inc/TClassTable.h
+++ b/core/cont/inc/TClassTable.h
@@ -98,7 +98,7 @@ R__EXTERN TClassTable *gClassTable;
 namespace ROOT {
    extern void AddClass(const char *cname, Version_t id, DictFuncPtr_t dict,
                         Int_t pragmabits);
-   extern void RemoveClass(const char *cname);
+   extern void RemoveClass(const char *cname, TClass *cl);
 }
 
 #endif

--- a/core/cont/src/TClassTable.cxx
+++ b/core/cont/src/TClassTable.cxx
@@ -521,8 +521,8 @@ void TClassTable::AddAlternate(const char *normName, const char *alternate)
             fprintf(stderr,"Error in TClassTable::AddAlternate: "
                     "Second registration of %s with a different normalized name (old: '%s', new: '%s')\n",
                     alternate, a->fNormName, normName);
-            return;
          }
+         return;
       }
    }
 

--- a/core/cont/src/TClassTable.cxx
+++ b/core/cont/src/TClassTable.cxx
@@ -504,7 +504,7 @@ void TClassTable::Add(TProtoClass *proto)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TClassTable::AddAlternate(const char *normName, const char *alternate)
+ROOT::TClassAlt* TClassTable::AddAlternate(const char *normName, const char *alternate)
 {
    // This will be set at the lastest during TROOT construction, so before
    // any threading could happen.
@@ -522,11 +522,40 @@ void TClassTable::AddAlternate(const char *normName, const char *alternate)
                     "Second registration of %s with a different normalized name (old: '%s', new: '%s')\n",
                     alternate, a->fNormName, normName);
          }
-         return;
+         return nullptr;
       }
    }
 
    fgAlternate[slot] = new TClassAlt(alternate,normName,fgAlternate[slot]);
+   return fgAlternate[slot];
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+void TClassTable::RemoveAlternate(ROOT::TClassAlt *alt)
+{
+   if (!alt || !gClassTable)
+      return;
+
+   std::lock_guard<std::mutex> lock(GetClassTableMutex());
+
+   UInt_t slot = ROOT::ClassTableHash(alt->fName, fgSize);
+
+   if (!fgAlternate[slot])
+      return;
+
+   if (fgAlternate[slot] == alt)
+      fgAlternate[slot] = alt->fNext.release();
+   else {
+      for (TClassAlt *a = fgAlternate[slot]; a; a = a->fNext.get()) {
+         if (a->fNext.get() == alt) {
+            a->fNext.swap( alt->fNext );
+	    assert( alt == alt->fNext.get());
+	    alt->fNext.release();
+	 }
+      }
+   }
+   delete alt;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -886,13 +915,24 @@ void ROOT::AddClass(const char *cname, Version_t id,
 /// Global function called by GenerateInitInstance.
 /// (see the ClassImp macro).
 
-void ROOT::AddClassAlternate(const char *normName, const char *alternate)
+ROOT::TClassAlt* ROOT::AddClassAlternate(const char *normName, const char *alternate)
 {
    if (!TROOT::Initialized() && !gClassTable) {
       GetDelayedAddClassAlternate().emplace_back(normName, alternate);
+      // If a library is loaded before gROOT is initialized we can assume
+      // it is hard linked along side libCore (or is libCore) thus can't
+      // really be unloaded.
+      return nullptr;
    } else {
-      TClassTable::AddAlternate(normName, alternate);
+      return TClassTable::AddAlternate(normName, alternate);
    }
+}
+
+void ROOT::RemoveClassAlternate(TClassAlt *alt)
+{
+   // This routine is meant to be called (indirectly) by dlclose so we
+   // we are guaranteed that the library initialization has completed.
+   TClassTable::RemoveAlternate(alt);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/cont/src/TClassTable.cxx
+++ b/core/cont/src/TClassTable.cxx
@@ -975,13 +975,17 @@ TNamed *ROOT::RegisterClassTemplate(const char *name, const char *file,
 
    TString classname(name);
    Ssiz_t loc = classname.Index("<");
-   if (loc >= 1) classname.Remove(loc);
+   if (loc >= 1)
+      classname.Remove(loc);
+   TNamed *reg = (TNamed*)table.FindObject(classname);
    if (file) {
-      TNamed *obj = new TNamed((const char*)classname, file);
-      obj->SetUniqueID(line);
-      table.Add(obj);
-      return obj;
+      if (reg)
+         reg->SetTitle(file);
+      else {
+         reg = new TNamed((const char*)classname, file);
+         table.Add(reg);
+      }
+      reg->SetUniqueID(line);
    }
-
-   return (TNamed*)table.FindObject(classname);
+   return reg;
 }

--- a/core/cont/src/TClassTable.cxx
+++ b/core/cont/src/TClassTable.cxx
@@ -942,7 +942,7 @@ void ROOT::ResetClassVersion(TClass *cl, const char *cname, Short_t newid)
 /// Global function called by the dtor of a class's init class
 /// (see the ClassImp macro).
 
-void ROOT::RemoveClass(const char *cname)
+void ROOT::RemoveClass(const char *cname, TClass *oldcl)
 {
    // don't delete class information since it is needed by the I/O system
    // to write the StreamerInfo to file
@@ -952,14 +952,8 @@ void ROOT::RemoveClass(const char *cname)
       // pointer is now invalid ....
       // We still keep the TClass object around because TFile needs to
       // get to the TStreamerInfo.
-      if (gROOT && gROOT->GetListOfClasses()) {
-         TObject *pcname;
-         if ((pcname = gROOT->GetListOfClasses()->FindObject(cname))) {
-            TClass *cl = dynamic_cast<TClass*>(pcname);
-            if (cl)
-               cl->SetUnloaded();
-         }
-      }
+      if (oldcl)
+         oldcl->SetUnloaded();
       TClassTable::Remove(cname);
    }
 }

--- a/core/meta/inc/TGenericClassInfo.h
+++ b/core/meta/inc/TGenericClassInfo.h
@@ -71,6 +71,7 @@ namespace ROOT {
       Detail::TCollectionProxyInfo *fCollectionStreamerInfo;
       std::vector<ROOT::Internal::TSchemaHelper>  fReadRules;
       std::vector<ROOT::Internal::TSchemaHelper>  fReadRawRules;
+      std::vector<ROOT::TClassAlt*>               fAlternate;
 
    public:
       TGenericClassInfo(const char *fullClassname,
@@ -116,6 +117,7 @@ namespace ROOT {
 
       TClass                           *IsA(const void *obj);
 
+      void                              AdoptAlternate(ROOT::TClassAlt *alt);
       Short_t                           AdoptStreamer(TClassStreamer*);
       Short_t                           AdoptCollectionProxy(TVirtualCollectionProxy*);
       void                              AdoptCollectionProxyInfo(Detail::TCollectionProxyInfo*);

--- a/core/meta/src/TGenericClassInfo.cxx
+++ b/core/meta/src/TGenericClassInfo.cxx
@@ -218,7 +218,7 @@ namespace Internal {
       fIsA = nullptr;
       using ROOT::Internal::gROOTLocal;
       if (!gROOTLocal || !gROOTLocal->Initialized() || !gROOTLocal->GetListOfClasses()) return;
-      if (fAction) GetAction().Unregister(GetClassName());
+      if (fAction) GetAction().Unregister(GetClassName(), fClass);
    }
 
    const Internal::TInitBehavior &TGenericClassInfo::GetAction() const

--- a/core/meta/src/TGenericClassInfo.cxx
+++ b/core/meta/src/TGenericClassInfo.cxx
@@ -214,11 +214,14 @@ namespace Internal {
       delete fCollectionProxyInfo;
       delete fCollectionStreamerInfo;
       delete fStreamer;
-      if (!fClass) delete fIsA; // fIsA is adopted by the class if any.
+      if (!fClass)
+         delete fIsA; // fIsA is adopted by the class if any.
       fIsA = nullptr;
       using ROOT::Internal::gROOTLocal;
-      if (!gROOTLocal || !gROOTLocal->Initialized() || !gROOTLocal->GetListOfClasses()) return;
-      if (fAction) GetAction().Unregister(GetClassName(), fClass);
+      if (!gROOTLocal || !gROOTLocal->Initialized() || !gROOTLocal->GetListOfClasses())
+         return;
+      if (fAction)
+         GetAction().Unregister(GetClassName(), fClass);
    }
 
    const Internal::TInitBehavior &TGenericClassInfo::GetAction() const

--- a/core/meta/src/TGenericClassInfo.cxx
+++ b/core/meta/src/TGenericClassInfo.cxx
@@ -220,6 +220,8 @@ namespace Internal {
       using ROOT::Internal::gROOTLocal;
       if (!gROOTLocal || !gROOTLocal->Initialized() || !gROOTLocal->GetListOfClasses())
          return;
+      for(auto alt : fAlternate)
+         ROOT::RemoveClassAlternate(alt);
       if (fAction)
          GetAction().Unregister(GetClassName(), fClass);
    }
@@ -422,6 +424,11 @@ namespace Internal {
       ROOT::ResetClassVersion(fClass, GetClassName(),version);
       fVersion = version;
       return version;
+   }
+
+   void TGenericClassInfo::AdoptAlternate(ROOT::TClassAlt *alt)
+   {
+      fAlternate.push_back(alt);
    }
 
    void TGenericClassInfo::AdoptCollectionProxyInfo(TCollectionProxyInfo *info)

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1851,7 +1851,13 @@ void TCling::LoadPCM(std::string pcmFileNameFullPath)
 
       cling::Interpreter::PushTransactionRAII deserRAII(GetInterpreterImpl());
       LoadPCMImpl(pcmMemFile);
-      fPendingRdicts.erase(pendingRdict);
+      // Currently the module file are never unloaded (even if the library is
+      // unloaded) and, of course, never reloaded.
+      // Consequently, we must NOT remove the `pendingRdict` from the list
+      // of pending dictionary, otherwise if a library is unloaded and then
+      // reload we will be unable to update properly the TClass object
+      // (because we wont be able to load the rootpcm file by executing the
+      // above lines)
 
       return;
    }


### PR DESCRIPTION
This problem appears "only" in newer OS/compiler (as seen in the original reports leading to #12715) the dependent library are now dlclose'd when the 'main' library is dlclose'd.  In the example a cmake generated library is linked against `libHist` and  `libHist` is then loaded and unloaded when the example's library is (intentionally) loaded and unloaded.  `libHist` happens to share a STL collection's dictionary (`std::vector<TString>`) with `libCore` (and this collection is used for the reading of rootpcm files and thus during the loading of the example's library). 

Details:

Unload only the TClass actually generated by the unloaded library.

The TGenericClassInfo's destructor now passes the TClass that they actually generated in
addition to the name so that only that TClass is destroyed.

This avoid the problem (seen in #12715) where 2 librares (`A` and `B`)  have a dictionary for the same
STL collection (this is supported) and we have the following sequence of operation:

1. load library A
2. load library B (dictionary registration is ignored as intended)
3. request TClass for STL collection.
4. unload (dclose) library B
5. use TClass for STL collection.

With the previous code, step 4. would lead to the TClass for STL
collection to be marked as "unloaded" even though it library (A)
was still actually loaded.


Fix reloading of library with a module.

Prior to this fix, the in-memory rootpcm loaded as part of the module was removed
from memory on first use and thus if the library was closed and re-opened/loaded
we no longer had the information needed to restore the TClass object corresponding
to that library

This 2 changes fix #12715

The commit [TClassTable: Remove alternate names upon library unloading.](https://github.com/root-project/root/pull/12863/commits/17e8833ec3deb32ca509bf08d31b56f93058d414) fix #12868
