### PR TITLE
Disable call to diagnoseOdrViolations()

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReader.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReader.cpp
@@ -11671,7 +11671,9 @@ void ASTReader::FinishedDeserializing() {
     if (ReadTimer)
       ReadTimer->stopTimer();
 
+#if 0
     diagnoseOdrViolations();
+#endif
 
     // We are not in recursive loading, so it's safe to pass the "interesting"
     // decls to the consumer.


### PR DESCRIPTION
This is a hack to make C++17 builds on macOS pass all tests.

Fixes #12003