### PR TITLE
[http] Let configure `Access-Control-Allow-Credentials` header

### DIFF
--- a/net/http/inc/THttpServer.h
+++ b/net/http/inc/THttpServer.h
@@ -51,6 +51,7 @@ protected:
    std::string fDrawPage;        ///<! file name for drawing of single element
    std::string fDrawPageCont;    ///<! content of draw html page
    std::string fCors;            ///<! CORS: sets Access-Control-Allow-Origin header for ProcessRequest responses
+   std::string fCorsCredentials; ///<! CORS: add Access-Control-Allow-Credentials: true response header
 
    std::mutex fMutex;                                        ///<! mutex to protect list with arguments
    std::queue<std::shared_ptr<THttpCallArg>> fArgs;          ///<! submitted arguments
@@ -111,6 +112,15 @@ public:
 
    /** Returns specified CORS domain */
    const char *GetCors() const { return fCors.c_str(); }
+
+   /** Enable/disable usage Access-Control-Allow-Credentials response header */
+   void SetCorsCredentials(const std::string &value = "true") { fCorsCredentials = value; }
+
+   /** Returns kTRUE if Access-Control-Allow-Credentials header should be used */
+   Bool_t IsCorsCredentials() const { return !fCorsCredentials.empty(); }
+
+   /** Returns specified CORS credentials value - if any */
+   const char *GetCorsCredentials() const { return fCorsCredentials.c_str(); }
 
    /** set name of top item in objects hierarchy */
    void SetTopName(const char *top) { fTopName = top; }

--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -609,6 +609,11 @@ Bool_t TCivetweb::Create(const char *args)
                GetServer()->SetCors(cors && *cors ? cors : "*");
             }
 
+            if (GetServer() && url.HasOption("cred_cors")) {
+               const char *cred = url.GetValueFromOptions("cred_cors");
+               GetServer()->SetCorsCredentials(cred && *cred ? cred : "true");
+            }
+
             if (url.HasOption("nocache"))
                fMaxAge = 0;
 
@@ -620,7 +625,7 @@ Bool_t TCivetweb::Create(const char *args)
       }
    }
 
-   const char *options[25];
+   const char *options[30];
    int op = 0;
 
    Info("Create", "Starting HTTP server on port %s", sport.Data());
@@ -660,6 +665,17 @@ Bool_t TCivetweb::Create(const char *args)
    if (max_age.Length() > 0) {
       options[op++] = "static_file_max_age";
       options[op++] = max_age.Data();
+   }
+
+   if (GetServer() && GetServer()->IsCors()) {
+      // also used for the file transfer
+      options[op++] = "access_control_allow_origin";
+      options[op++] = GetServer()->GetCors();
+   }
+
+   if (GetServer() && GetServer()->IsCorsCredentials()) {
+      options[op++] = "access_control_allow_credentials";
+      options[op++] = GetServer()->GetCorsCredentials();
    }
 
    options[op++] = "enable_directory_listing";

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -1067,9 +1067,11 @@ void THttpServer::ProcessRequest(std::shared_ptr<THttpCallArg> arg)
    // try to avoid caching on the browser
    arg->AddNoCacheHeader();
 
-   // potentially add cors header
+   // potentially add cors headers
    if (IsCors())
       arg->AddHeader("Access-Control-Allow-Origin", GetCors());
+   if (IsCorsCredentials())
+      arg->AddHeader("Access-Control-Allow-Credentials", GetCorsCredentials());
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Allows to access files from `THttpServer` when it protected with `htdigest` password.

Addresses issue discussed here:

https://root-forum.cern.ch/t/localhost-jsroot-server/54607/60

Example of starting such server on localhost:8011:
```
THttpServer* serv = new THttpServer("http:8011?auth_file=auth.txt&auth_domain=root&cred_cors&cors=http://localhost:8000");
```

Here crucial exact CORS url and `cred_cors` option which enables `Access-Control-Allow-Credentials`  header.

Server `localhost:8000` is just plain JSROOT installation with python3.

To open ROOT file on such server:
```
http://localhost:8000/jsroot/?with_credentials&file=http://localhost:8011/currentdir/hsimple.root
```




