### PR TITLE
RDF:Graph() fix graph title to y-axis vs. x-axis

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -1908,8 +1908,8 @@ public:
       const auto validatedColumns = GetValidatedColumnNames(2, userColumns);
 
       // We build a default name and title based on the input columns
-      const auto g_name = validatedColumns[0] + "_vs_" + validatedColumns[1];
-      const auto g_title = validatedColumns[0] + " vs " + validatedColumns[1];
+      const auto g_name = validatedColumns[1] + "_vs_" + validatedColumns[0];
+      const auto g_title = validatedColumns[1] + " vs " + validatedColumns[0];
       graph->SetNameTitle(g_name.c_str(), g_title.c_str());
       graph->GetXaxis()->SetTitle(validatedColumns[0].c_str());
       graph->GetYaxis()->SetTitle(validatedColumns[1].c_str());
@@ -1962,8 +1962,8 @@ public:
       const auto validatedColumns = GetValidatedColumnNames(6, userColumns);
 
       // We build a default name and title based on the input columns
-      const auto g_name = validatedColumns[0] + "_vs_" + validatedColumns[1];
-      const auto g_title = validatedColumns[0] + " vs " + validatedColumns[1];
+      const auto g_name = validatedColumns[1] + "_vs_" + validatedColumns[0];
+      const auto g_title = validatedColumns[1] + " vs " + validatedColumns[0];
       graph->SetNameTitle(g_name.c_str(), g_title.c_str());
       graph->GetXaxis()->SetTitle(validatedColumns[0].c_str());
       graph->GetYaxis()->SetTitle(validatedColumns[1].c_str());

--- a/tree/dataframe/test/dataframe_simple.cxx
+++ b/tree/dataframe/test/dataframe_simple.cxx
@@ -804,8 +804,8 @@ TEST(RDFSimpleTests, AutomaticNamesOfHisto1DAndGraph)
    EXPECT_STREQ(hxy->GetTitle(), "x, weights: y");
    EXPECT_STREQ(hxy->GetXaxis()->GetTitle(), "x");
    EXPECT_STREQ(hxy->GetYaxis()->GetTitle(), "count * y");
-   EXPECT_STREQ(gxy->GetName(), "x_vs_y");
-   EXPECT_STREQ(gxy->GetTitle(), "x vs y");
+   EXPECT_STREQ(gxy->GetName(), "y_vs_x");
+   EXPECT_STREQ(gxy->GetTitle(), "y vs x");
    EXPECT_STREQ(gxy->GetXaxis()->GetTitle(), "x");
    EXPECT_STREQ(gxy->GetYaxis()->GetTitle(), "y");
 


### PR DESCRIPTION
Following up on github issue #12870, fixing RDataFrame::Graph SetTitle to y-axis-variable vs. x-axis-variable (was the opposite before). 



