### PR TITLE
Make PaintInitH and PaintInit similar

### DIFF
--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -7404,7 +7404,7 @@ Int_t THistPainter::PaintInitH()
             xmax = 0;
             xmin *= 2;
          } else {
-            xmin = -1;
+            xmin = 0;
             xmax = 1;
          }
       }


### PR DESCRIPTION
PaintInit and PaintInitH differed for the content axis definition.
This problem was mentionned here: https://github.com/root-project/root/issues/12567

