### PR TITLE
[NFC] Tell git to ignore cmake-build* instead of cmake-build-*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ project.xcworkspace
 
 # CLion
 .idea/*
-cmake-build-*/
+cmake-build*/
 
 # QtCreator
 CMakeLists.txt.user


### PR DESCRIPTION
ROOT's build directory (or any project's) should be included in .gitignore (it helps with a lot of tools as well as IDE/code editor file switchers).

Now, 2 years ago [I proposed to reserve "_build"](https://github.com/root-project/root/pull/8009) in .gitignore as a simple build directory name that we could use. That PR was closed in favor of [removing the "build" directory](https://github.com/root-project/root/issues/8031) from ROOT's sources and use that name instead.

Since then I have been naming my build directories something that the current .gitignore would ignore: `cmake-build-foo` or similar. I realize it might seem silly, but it would be a non-negligible quality of life improvement for me if I could just use `cmake-build` instead, hence this PR (while we wait for #8031).

