### PR TITLE
Automatically add `override` to graf3d with clang-tidy

### DIFF
--- a/graf3d/csg/src/CsgOps.cxx
+++ b/graf3d/csg/src/CsgOps.cxx
@@ -1665,12 +1665,12 @@ namespace RootCsg {
       const PLIST &Polys()const{return fPolys;}
 
       //TBaseMesh's final-overriders
-      UInt_t          NumberOfPolys()const{return fPolys.size();}
-      UInt_t          NumberOfVertices()const{return fVerts.size();}
-      UInt_t          SizeOfPoly(UInt_t polyIndex)const{return fPolys[polyIndex].Size();}
-      const Double_t *GetVertex(UInt_t vertexNum)const{return fVerts[vertexNum].GetValue();}
+      UInt_t          NumberOfPolys()const override{return fPolys.size();}
+      UInt_t          NumberOfVertices()const override{return fVerts.size();}
+      UInt_t          SizeOfPoly(UInt_t polyIndex)const override{return fPolys[polyIndex].Size();}
+      const Double_t *GetVertex(UInt_t vertexNum)const override{return fVerts[vertexNum].GetValue();}
 
-      Int_t GetVertexIndex(UInt_t polyNum, UInt_t vertexNum)const
+      Int_t GetVertexIndex(UInt_t polyNum, UInt_t vertexNum)const override
       {
          return fPolys[polyNum][vertexNum];
       }

--- a/graf3d/eve/inc/TEveArrow.h
+++ b/graf3d/eve/inc/TEveArrow.h
@@ -45,9 +45,9 @@ protected:
 public:
    TEveArrow(Float_t xVec=0, Float_t yVec=0, Float_t zVec=1,
              Float_t xOrg=0, Float_t yOrg=0, Float_t zOrg=0);
-   virtual ~TEveArrow() {}
+   ~TEveArrow() override {}
 
-   virtual TObject* GetObject(const TEveException& ) const
+   TObject* GetObject(const TEveException& ) const override
    { const TObject* obj = this; return const_cast<TObject*>(obj); }
 
    void    StampGeom() { ResetBBox(); AddStamp(kCBTransBBox | kCBObjProps); }
@@ -73,10 +73,10 @@ public:
    Int_t GetDrawQuality() const  { return fDrawQuality; }
    void  SetDrawQuality(Int_t q) { fDrawQuality = q;    }
 
-   virtual void ComputeBBox();
-   virtual void Paint(Option_t* option="");
+   void ComputeBBox() override;
+   void Paint(Option_t* option="") override;
 
-   ClassDef(TEveArrow, 0); // Class for gl visualisation of arrow.
+   ClassDefOverride(TEveArrow, 0); // Class for gl visualisation of arrow.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveArrowEditor.h
+++ b/graf3d/eve/inc/TEveArrowEditor.h
@@ -37,16 +37,16 @@ protected:
 public:
    TEveArrowEditor(const TGWindow *p = nullptr, Int_t width=170, Int_t height=30,
          UInt_t options=kChildFrame, Pixel_t back=GetDefaultFrameBackground());
-   virtual ~TEveArrowEditor() {}
+   ~TEveArrowEditor() override {}
 
-   virtual void SetModel(TObject* obj);
+   void SetModel(TObject* obj) override;
 
    void DoTubeR();
    void DoConeR();
    void DoConeL();
    void DoVertex();
 
-   ClassDef(TEveArrowEditor, 0); // GUI editor for TEveArrow.
+   ClassDefOverride(TEveArrowEditor, 0); // GUI editor for TEveArrow.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveArrowGL.h
+++ b/graf3d/eve/inc/TEveArrowGL.h
@@ -29,13 +29,13 @@ protected:
 
 public:
    TEveArrowGL();
-   virtual ~TEveArrowGL() {}
+   ~TEveArrowGL() override {}
 
-   virtual Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr);
-   virtual void   SetBBox();
-   virtual void   DirectDraw(TGLRnrCtx & rnrCtx) const;
+   Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr) override;
+   void   SetBBox() override;
+   void   DirectDraw(TGLRnrCtx & rnrCtx) const override;
 
-   ClassDef(TEveArrowGL, 0); // GL renderer class for TEveArrow.
+   ClassDefOverride(TEveArrowGL, 0); // GL renderer class for TEveArrow.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveBox.h
+++ b/graf3d/eve/inc/TEveBox.h
@@ -31,7 +31,7 @@ protected:
 
 public:
    TEveBox(const char* n="TEveBox", const char* t="");
-   virtual ~TEveBox();
+   ~TEveBox() override;
 
    void SetVertex(Int_t i, Float_t x, Float_t y, Float_t z);
    void SetVertex(Int_t i, const Float_t* v);
@@ -40,12 +40,12 @@ public:
    const Float_t* GetVertex(Int_t i) const { return fVertices[i]; }
 
    // For TAttBBox:
-   virtual void ComputeBBox();
+   void ComputeBBox() override;
 
    // Projectable:
-   virtual TClass* ProjectedClass(const TEveProjection* p) const;
+   TClass* ProjectedClass(const TEveProjection* p) const override;
 
-   ClassDef(TEveBox, 0); // 3D box with arbitrary vertices.
+   ClassDefOverride(TEveBox, 0); // 3D box with arbitrary vertices.
 };
 
 
@@ -67,27 +67,27 @@ protected:
    Int_t        fBreakIdx;
    vVector2_t   fDebugPoints;
 
-   virtual void SetDepthLocal(Float_t d);
+   void SetDepthLocal(Float_t d) override;
 
    static Bool_t fgDebugCornerPoints;
 
 public:
    TEveBoxProjected(const char* n="TEveBoxProjected", const char* t="");
-   virtual ~TEveBoxProjected();
+   ~TEveBoxProjected() override;
 
    // For TAttBBox:
-   virtual void ComputeBBox();
+   void ComputeBBox() override;
 
    // Projected:
-   virtual void SetProjection(TEveProjectionManager* mng, TEveProjectable* model);
-   virtual void UpdateProjection();
+   void SetProjection(TEveProjectionManager* mng, TEveProjectable* model) override;
+   void UpdateProjection() override;
 
-   virtual TEveElement* GetProjectedAsElement() { return this; }
+   TEveElement* GetProjectedAsElement() override { return this; }
 
    static Bool_t GetDebugCornerPoints();
    static void   SetDebugCornerPoints(Bool_t d);
 
-   ClassDef(TEveBoxProjected, 0); // Projection of TEveBox.
+   ClassDefOverride(TEveBoxProjected, 0); // Projection of TEveBox.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveBoxGL.h
+++ b/graf3d/eve/inc/TEveBoxGL.h
@@ -39,21 +39,21 @@ protected:
 
 public:
    TEveBoxGL();
-   virtual ~TEveBoxGL() {}
+   ~TEveBoxGL() override {}
 
-   virtual Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr);
-   virtual void   SetBBox();
+   Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr) override;
+   void   SetBBox() override;
 
-   virtual void Draw(TGLRnrCtx& rnrCtx) const;
-   virtual void DirectDraw(TGLRnrCtx& rnrCtx) const;
+   void Draw(TGLRnrCtx& rnrCtx) const override;
+   void DirectDraw(TGLRnrCtx& rnrCtx) const override;
 
-   virtual Bool_t IgnoreSizeForOfInterest() const { return kTRUE; }
+   Bool_t IgnoreSizeForOfInterest() const override { return kTRUE; }
 
    // To support two-level selection
    // virtual Bool_t SupportsSecondarySelect() const { return kTRUE; }
    // virtual void ProcessSelection(TGLRnrCtx & rnrCtx, TGLSelectRecord & rec);
 
-   ClassDef(TEveBoxGL, 0); // GL renderer class for TEveBox.
+   ClassDefOverride(TEveBoxGL, 0); // GL renderer class for TEveBox.
 };
 
 
@@ -74,21 +74,21 @@ protected:
 
 public:
    TEveBoxProjectedGL();
-   virtual ~TEveBoxProjectedGL() {}
+   ~TEveBoxProjectedGL() override {}
 
-   virtual Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr);
-   virtual void   SetBBox();
+   Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr) override;
+   void   SetBBox() override;
 
-   virtual void Draw(TGLRnrCtx& rnrCtx) const;
-   virtual void DirectDraw(TGLRnrCtx& rnrCtx) const;
+   void Draw(TGLRnrCtx& rnrCtx) const override;
+   void DirectDraw(TGLRnrCtx& rnrCtx) const override;
 
-   virtual Bool_t IgnoreSizeForOfInterest() const { return kTRUE; }
+   Bool_t IgnoreSizeForOfInterest() const override { return kTRUE; }
 
    // To support two-level selection
    // virtual Bool_t SupportsSecondarySelect() const { return kTRUE; }
    // virtual void ProcessSelection(TGLRnrCtx & rnrCtx, TGLSelectRecord & rec);
 
-   ClassDef(TEveBoxProjectedGL, 0); // GL renderer class for TEveBoxProjected.
+   ClassDefOverride(TEveBoxProjectedGL, 0); // GL renderer class for TEveBoxProjected.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveBoxSet.h
+++ b/graf3d/eve/inc/TEveBoxSet.h
@@ -65,7 +65,7 @@ protected:
 
 public:
    TEveBoxSet(const char* n="TEveBoxSet", const char* t="");
-   virtual ~TEveBoxSet() {}
+   ~TEveBoxSet() override {}
 
    void Reset(EBoxType_e boxType, Bool_t valIsCol, Int_t chunkSize);
    void Reset();
@@ -79,7 +79,7 @@ public:
 
    void AddHex(const TEveVector& pos, Float_t r, Float_t angle, Float_t depth);
 
-   virtual void ComputeBBox();
+   void ComputeBBox() override;
    // virtual void Paint(Option_t* option = "");
 
    void Test(Int_t nboxes);
@@ -97,7 +97,7 @@ public:
    Int_t GetBoxSkip()   const { return fBoxSkip; }
    void  SetBoxSkip(Int_t bs) { fBoxSkip = bs; }
 
-   ClassDef(TEveBoxSet, 0); // Collection of 3D primitives (fixed-size boxes, boxes of different sizes, or arbitrary sexto-epipeds); each primitive can be assigned a signal value and a TRef.
+   ClassDefOverride(TEveBoxSet, 0); // Collection of 3D primitives (fixed-size boxes, boxes of different sizes, or arbitrary sexto-epipeds); each primitive can be assigned a signal value and a TRef.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveBoxSetGL.h
+++ b/graf3d/eve/inc/TEveBoxSetGL.h
@@ -35,18 +35,18 @@ protected:
 
 public:
    TEveBoxSetGL();
-   virtual ~TEveBoxSetGL();
+   ~TEveBoxSetGL() override;
 
-   virtual Bool_t ShouldDLCache(const TGLRnrCtx& rnrCtx) const;
-   virtual void   DLCacheDrop();
-   virtual void   DLCachePurge();
+   Bool_t ShouldDLCache(const TGLRnrCtx& rnrCtx) const override;
+   void   DLCacheDrop() override;
+   void   DLCachePurge() override;
 
-   virtual Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr);
-   virtual void   DirectDraw(TGLRnrCtx& rnrCtx) const;
+   Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr) override;
+   void   DirectDraw(TGLRnrCtx& rnrCtx) const override;
 
    virtual void Render(TGLRnrCtx& rnrCtx);
 
-   ClassDef(TEveBoxSetGL, 0); // GL-renderer for TEveBoxSet class.
+   ClassDefOverride(TEveBoxSetGL, 0); // GL-renderer for TEveBoxSet class.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveBrowser.h
+++ b/graf3d/eve/inc/TEveBrowser.h
@@ -39,43 +39,43 @@ protected:
 
 public:
    TEveListTreeItem(TEveElement* el) : TGListTreeItem(), fElement(el) {}
-   virtual ~TEveListTreeItem() {}
+   ~TEveListTreeItem() override {}
 
-   virtual Bool_t          IsActive()       const { return fElement->GetSelectedLevel() != 0; }
-   virtual Pixel_t         GetActiveColor() const;
-   virtual void            SetActive(Bool_t)      { NotSupported("SetActive"); }
+   Bool_t          IsActive()       const override { return fElement->GetSelectedLevel() != 0; }
+   Pixel_t         GetActiveColor() const override;
+   void            SetActive(Bool_t) override      { NotSupported("SetActive"); }
 
-   virtual const char     *GetText()          const { return fElement->GetElementName(); }
-   virtual Int_t           GetTextLength()    const { return strlen(fElement->GetElementName()); }
-   virtual const char     *GetTipText()       const { return fElement->GetElementTitle(); }
-   virtual Int_t           GetTipTextLength() const { return strlen(fElement->GetElementTitle()); }
-   virtual void            SetText(const char *)    { NotSupported("SetText"); }
-   virtual void            SetTipText(const char *) { NotSupported("SetTipText"); }
+   const char     *GetText()          const override { return fElement->GetElementName(); }
+   Int_t           GetTextLength()    const override { return strlen(fElement->GetElementName()); }
+   const char     *GetTipText()       const override { return fElement->GetElementTitle(); }
+   Int_t           GetTipTextLength() const override { return strlen(fElement->GetElementTitle()); }
+   void            SetText(const char *) override    { NotSupported("SetText"); }
+   void            SetTipText(const char *) override { NotSupported("SetTipText"); }
 
-   virtual void            SetUserData(void *, Bool_t=kFALSE) { NotSupported("SetUserData"); }
-   virtual void           *GetUserData() const { return fElement; }
+   void            SetUserData(void *, Bool_t=kFALSE) override { NotSupported("SetUserData"); }
+   void           *GetUserData() const override { return fElement; }
 
-   virtual const TGPicture*GetPicture()         const { return fElement->GetListTreeIcon(fOpen); }
-   virtual const TGPicture*GetCheckBoxPicture() const { return fElement->GetListTreeCheckBoxIcon(); }
+   const TGPicture*GetPicture()         const override { return fElement->GetListTreeIcon(fOpen); }
+   const TGPicture*GetCheckBoxPicture() const override { return fElement->GetListTreeCheckBoxIcon(); }
 
-   virtual void            SetPictures(const TGPicture*, const TGPicture*) { NotSupported("SetUserData"); }
-   virtual void            SetCheckBoxPictures(const TGPicture*, const TGPicture*) { NotSupported("SetUserData"); }
+   void            SetPictures(const TGPicture*, const TGPicture*) override { NotSupported("SetUserData"); }
+   void            SetCheckBoxPictures(const TGPicture*, const TGPicture*) override { NotSupported("SetUserData"); }
 
-   virtual void            SetCheckBox(Bool_t=kTRUE) { NotSupported("SetCheckBox"); }
-   virtual Bool_t          HasCheckBox()       const { return kTRUE; }
-   virtual void            CheckItem(Bool_t=kTRUE)   { printf("TEveListTreeItem::CheckItem - to be ignored ... all done via signal Checked().\n"); }
-   virtual void            Toggle();
-   virtual Bool_t          IsChecked()         const { return fElement->GetRnrState(); }
+   void            SetCheckBox(Bool_t=kTRUE) override { NotSupported("SetCheckBox"); }
+   Bool_t          HasCheckBox()       const override { return kTRUE; }
+   void            CheckItem(Bool_t=kTRUE) override   { printf("TEveListTreeItem::CheckItem - to be ignored ... all done via signal Checked().\n"); }
+   void            Toggle() override;
+   Bool_t          IsChecked()         const override { return fElement->GetRnrState(); }
 
    // Propagation of checked-state form children to parents. Not needed, ignore.
 
    // Item coloration (underline + minibox)
-   virtual Bool_t          HasColor()  const { return fElement->HasMainColor(); }
-   virtual Color_t         GetColor()  const { return fElement->GetMainColor(); }
-   virtual void            SetColor(Color_t) { NotSupported("SetColor"); }
-   virtual void            ClearColor()      { NotSupported("ClearColor"); }
+   Bool_t          HasColor()  const override { return fElement->HasMainColor(); }
+   Color_t         GetColor()  const override { return fElement->GetMainColor(); }
+   void            SetColor(Color_t) override { NotSupported("SetColor"); }
+   void            ClearColor() override      { NotSupported("ClearColor"); }
 
-   ClassDef(TEveListTreeItem,0); // Special llist-tree-item for Eve.
+   ClassDefOverride(TEveListTreeItem,0); // Special llist-tree-item for Eve.
 };
 
 
@@ -103,7 +103,7 @@ protected:
 
 public:
    TEveGListTreeEditorFrame(const TGWindow *p = nullptr, Int_t width=250, Int_t height=700);
-   virtual ~TEveGListTreeEditorFrame();
+   ~TEveGListTreeEditorFrame() override;
 
    void ConnectSignals();
    void DisconnectSignals();
@@ -121,7 +121,7 @@ public:
 
    static void SetEditorClass(const char* edclass);
 
-   ClassDef(TEveGListTreeEditorFrame, 0); // Composite GUI frame for parallel display of a TGListTree and TEveGedEditor.
+   ClassDefOverride(TEveGListTreeEditorFrame, 0); // Composite GUI frame for parallel display of a TGListTree and TEveGedEditor.
 };
 
 // ----------------------------------------------------------------
@@ -142,11 +142,11 @@ protected:
 
 public:
    TEveBrowser(UInt_t w, UInt_t h);
-   virtual ~TEveBrowser() { CloseTabs(); }
+   ~TEveBrowser() override { CloseTabs(); }
 
-   virtual void ReallyDelete();
-   virtual void CloseTab(Int_t id);
-   virtual void CloseWindow();
+   void ReallyDelete() override;
+   void CloseTab(Int_t id) override;
+   void CloseWindow() override;
 
    void InitPlugins(Option_t *opt="FI");
 
@@ -164,7 +164,7 @@ public:
 
    void SanitizeTabCounts();
 
-   ClassDef(TEveBrowser, 0); // Specialization of TRootBrowser for Eve.
+   ClassDefOverride(TEveBrowser, 0); // Specialization of TRootBrowser for Eve.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveCalo.h
+++ b/graf3d/eve/inc/TEveCalo.h
@@ -71,14 +71,14 @@ protected:
 public:
    TEveCaloViz(TEveCaloData* data=nullptr, const char* n="TEveCaloViz", const char* t="");
 
-   virtual ~TEveCaloViz();
+   ~TEveCaloViz() override;
 
-   virtual TEveElement* ForwardSelection();
-   virtual TEveElement* ForwardEdit();
+   TEveElement* ForwardSelection() override;
+   TEveElement* ForwardEdit() override;
 
-   virtual void Paint(Option_t* option="");
+   void Paint(Option_t* option="") override;
 
-   virtual TClass* ProjectedClass(const TEveProjection* p) const;
+   TClass* ProjectedClass(const TEveProjection* p) const override;
    virtual Float_t GetValToHeight() const;
    virtual void    CellSelectionChanged() {}
 
@@ -148,7 +148,7 @@ public:
 
    Bool_t  CellInEtaPhiRng (TEveCaloData::CellData_t&) const;
 
-   ClassDef(TEveCaloViz, 0); // Base-class for visualization of calorimeter eventdata.
+   ClassDefOverride(TEveCaloViz, 0); // Base-class for visualization of calorimeter eventdata.
 };
 
 /**************************************************************************/
@@ -171,12 +171,12 @@ protected:
    Color_t   fFrameColor;
    Char_t    fFrameTransparency;
 
-   virtual void BuildCellIdCache();
+   void BuildCellIdCache() override;
 
 public:
    TEveCalo3D(TEveCaloData* d=nullptr, const char* n="TEveCalo3D", const char* t="xx");
-   virtual ~TEveCalo3D() {}
-   virtual void ComputeBBox();
+   ~TEveCalo3D() override {}
+   void ComputeBBox() override;
 
    void    SetFrameWidth(Float_t w) { fFrameWidth = w; }
    Float_t GetFrameWidth() const    { return fFrameWidth; }
@@ -191,7 +191,7 @@ public:
    void   SetFrameTransparency(Char_t x) { fFrameTransparency = x; }
    Char_t GetFrameTransparency() const { return fFrameTransparency; }
 
-   ClassDef(TEveCalo3D, 0); // Class for 3D visualization of calorimeter event data.
+   ClassDefOverride(TEveCalo3D, 0); // Class for 3D visualization of calorimeter event data.
 };
 
 /**************************************************************************/
@@ -222,27 +222,27 @@ protected:
    Float_t                                 fMaxESumBin;
    Float_t                                 fMaxEtSumBin;
 
-   virtual void BuildCellIdCache();
+   void BuildCellIdCache() override;
 
-   virtual void SetDepthLocal(Float_t x) { fDepth = x; }
+   void SetDepthLocal(Float_t x) override { fDepth = x; }
 
 public:
    TEveCalo2D(const char* n="TEveCalo2D", const char* t="");
-   virtual ~TEveCalo2D();
+   ~TEveCalo2D() override;
 
-   virtual void SetProjection(TEveProjectionManager* proj, TEveProjectable* model);
-   virtual void UpdateProjection();
-   virtual void ComputeBBox();
+   void SetProjection(TEveProjectionManager* proj, TEveProjectable* model) override;
+   void UpdateProjection() override;
+   void ComputeBBox() override;
 
-   virtual void CellSelectionChanged();
+   void CellSelectionChanged() override;
 
-   virtual void    SetScaleAbs(Bool_t);
+   void    SetScaleAbs(Bool_t) override;
 
-   virtual Float_t GetValToHeight() const;
+   Float_t GetValToHeight() const override;
 
    const TEveCalo2D::vBinCells_t& GetBinLists() const { return fCellLists; }
 
-   ClassDef(TEveCalo2D, 0); // Class for visualization of projected calorimeter event data.
+   ClassDefOverride(TEveCalo2D, 0); // Class for visualization of projected calorimeter event data.
 };
 /**************************************************************************/
 /**************************************************************************/
@@ -289,13 +289,13 @@ protected:
    Int_t                   fDrawNumberCellPixels;
    Int_t                   fCellPixelFontSize;
 
-   virtual void BuildCellIdCache();
+   void BuildCellIdCache() override;
 
 public:
    TEveCaloLego(TEveCaloData* data=nullptr, const char* n="TEveCaloLego", const char* t="");
-   virtual ~TEveCaloLego(){}
+   ~TEveCaloLego() override{}
 
-   virtual void ComputeBBox();
+   void ComputeBBox() override;
    virtual void  SetData(TEveCaloData* d);
 
    Color_t  GetFontColor() const { return fFontColor; }
@@ -348,7 +348,7 @@ public:
    Int_t    GetCellPixelFontSize() { return fCellPixelFontSize; }
    void     SetCellPixelFontSize(Int_t x) { fCellPixelFontSize = x; }
 
-   ClassDef(TEveCaloLego, 0);  // Class for visualization of calorimeter histogram data.
+   ClassDefOverride(TEveCaloLego, 0);  // Class for visualization of calorimeter histogram data.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveCalo2DGL.h
+++ b/graf3d/eve/inc/TEveCalo2DGL.h
@@ -45,20 +45,20 @@ protected:
 
 public:
    TEveCalo2DGL();
-   virtual ~TEveCalo2DGL() {}
+   ~TEveCalo2DGL() override {}
 
-   virtual Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr);
-   virtual void   SetBBox();
+   Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr) override;
+   void   SetBBox() override;
 
-   virtual void DirectDraw(TGLRnrCtx & rnrCtx) const;
-   virtual void DrawHighlight(TGLRnrCtx& rnrCtx, const TGLPhysicalShape* ps, Int_t lvl=-1) const;
+   void DirectDraw(TGLRnrCtx & rnrCtx) const override;
+   void DrawHighlight(TGLRnrCtx& rnrCtx, const TGLPhysicalShape* ps, Int_t lvl=-1) const override;
 
    // To support two-level selection
-   virtual Bool_t SupportsSecondarySelect() const { return kTRUE; }
-   virtual Bool_t AlwaysSecondarySelect()   const { return kTRUE; }
-   virtual void ProcessSelection(TGLRnrCtx & rnrCtx, TGLSelectRecord & rec);
+   Bool_t SupportsSecondarySelect() const override { return kTRUE; }
+   Bool_t AlwaysSecondarySelect()   const override { return kTRUE; }
+   void ProcessSelection(TGLRnrCtx & rnrCtx, TGLSelectRecord & rec) override;
 
-   ClassDef(TEveCalo2DGL, 0); // GL renderer class for TEveCalo2D.
+   ClassDefOverride(TEveCalo2DGL, 0); // GL renderer class for TEveCalo2D.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveCalo3DGL.h
+++ b/graf3d/eve/inc/TEveCalo3DGL.h
@@ -42,20 +42,20 @@ protected:
 
 public:
    TEveCalo3DGL();
-   virtual ~TEveCalo3DGL() {}
+   ~TEveCalo3DGL() override {}
 
-   virtual Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr);
-   virtual void   SetBBox();
+   Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr) override;
+   void   SetBBox() override;
 
-   virtual void   DirectDraw(TGLRnrCtx & rnrCtx) const;
-   virtual void   DrawHighlight(TGLRnrCtx & rnrCtx, const TGLPhysicalShape* ps, Int_t lvl=-1) const;
+   void   DirectDraw(TGLRnrCtx & rnrCtx) const override;
+   void   DrawHighlight(TGLRnrCtx & rnrCtx, const TGLPhysicalShape* ps, Int_t lvl=-1) const override;
 
-   virtual Bool_t ShouldDLCache(const TGLRnrCtx& rnrCtx) const;
-   virtual Bool_t SupportsSecondarySelect() const { return kTRUE; }
-   virtual Bool_t AlwaysSecondarySelect()   const { return kTRUE; }
-   virtual void   ProcessSelection(TGLRnrCtx & rnrCtx, TGLSelectRecord & rec);
+   Bool_t ShouldDLCache(const TGLRnrCtx& rnrCtx) const override;
+   Bool_t SupportsSecondarySelect() const override { return kTRUE; }
+   Bool_t AlwaysSecondarySelect()   const override { return kTRUE; }
+   void   ProcessSelection(TGLRnrCtx & rnrCtx, TGLSelectRecord & rec) override;
 
-   ClassDef(TEveCalo3DGL, 0); // GL renderer class for TEveCalo.
+   ClassDefOverride(TEveCalo3DGL, 0); // GL renderer class for TEveCalo.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveCaloData.h
+++ b/graf3d/eve/inc/TEveCaloData.h
@@ -118,10 +118,10 @@ public:
       Float_t fValue;
 
       CellData_t() : CellGeom_t(), fValue(0) {}
-      virtual ~CellData_t() {}
+      ~CellData_t() override {}
 
       Float_t Value(Bool_t) const;
-      virtual void Dump() const;
+      void Dump() const override;
    };
 
 
@@ -172,14 +172,14 @@ protected:
 
 public:
    TEveCaloData(const char* n="TEveCalData", const char* t="");
-   virtual ~TEveCaloData() {}
+   ~TEveCaloData() override {}
 
-   virtual void UnSelected();
-   virtual void UnHighlighted();
+   void UnSelected() override;
+   void UnHighlighted() override;
 
-   virtual TString GetHighlightTooltip();
+   TString GetHighlightTooltip() override;
 
-   virtual void    FillImpliedSelectedSet(Set_t& impSelSet);
+   void    FillImpliedSelectedSet(Set_t& impSelSet) override;
 
    virtual void    GetCellList(Float_t etaMin, Float_t etaMax,
                                Float_t phi,    Float_t phiRng,
@@ -230,7 +230,7 @@ public:
    static  Float_t EtaToTheta(Float_t eta);
 
 
-   ClassDef(TEveCaloData, 0); // Manages calorimeter event data.
+   ClassDefOverride(TEveCaloData, 0); // Manages calorimeter event data.
 };
 
 /**************************************************************************/
@@ -263,7 +263,7 @@ protected:
 
 public:
    TEveCaloDataVec(Int_t nslices);
-   virtual ~TEveCaloDataVec();
+   ~TEveCaloDataVec() override;
 
    Int_t AddSlice();
    Int_t AddTower(Float_t etaMin, Float_t etaMax, Float_t phiMin, Float_t phiMax);
@@ -274,21 +274,21 @@ public:
    std::vector<Float_t>&  GetSliceVals(Int_t slice) { return fSliceVec[slice]; }
    std::vector<TEveCaloData::CellGeom_t>& GetCellGeom() { return fGeomVec; }
 
-   virtual void GetCellList(Float_t etaMin, Float_t etaMax,
+   void GetCellList(Float_t etaMin, Float_t etaMax,
                             Float_t phi,    Float_t phiRng,
-                            vCellId_t &out) const;
+                            vCellId_t &out) const override;
 
-   virtual void Rebin(TAxis *ax, TAxis *ay, vCellId_t &in, Bool_t et, RebinData_t &out) const;
+   void Rebin(TAxis *ax, TAxis *ay, vCellId_t &in, Bool_t et, RebinData_t &out) const override;
 
-   virtual void GetCellData(const TEveCaloData::CellId_t &id, TEveCaloData::CellData_t& data) const;
-   virtual void GetEtaLimits(Double_t &min, Double_t &max) const { min=fEtaMin, max=fEtaMax;}
-   virtual void GetPhiLimits(Double_t &min, Double_t &max) const { min=fPhiMin; max=fPhiMax;}
+   void GetCellData(const TEveCaloData::CellId_t &id, TEveCaloData::CellData_t& data) const override;
+   void GetEtaLimits(Double_t &min, Double_t &max) const override { min=fEtaMin, max=fEtaMax;}
+   void GetPhiLimits(Double_t &min, Double_t &max) const override { min=fPhiMin; max=fPhiMax;}
 
 
-   virtual void  DataChanged();
+   void  DataChanged() override;
    void          SetAxisFromBins(Double_t epsX=0.001, Double_t epsY=0.001);
 
-   ClassDef(TEveCaloDataVec, 0); // Manages calorimeter event data.
+   ClassDefOverride(TEveCaloDataVec, 0); // Manages calorimeter event data.
 };
 
 /**************************************************************************/
@@ -305,20 +305,20 @@ protected:
 
 public:
    TEveCaloDataHist();
-   virtual ~TEveCaloDataHist();
+   ~TEveCaloDataHist() override;
 
-   virtual void GetCellList( Float_t etaMin, Float_t etaMax,
-                             Float_t phi, Float_t phiRng, vCellId_t &out) const;
+   void GetCellList( Float_t etaMin, Float_t etaMax,
+                             Float_t phi, Float_t phiRng, vCellId_t &out) const override;
 
-   virtual void Rebin(TAxis *ax, TAxis *ay, vCellId_t &in, Bool_t et, RebinData_t &out) const;
+   void Rebin(TAxis *ax, TAxis *ay, vCellId_t &in, Bool_t et, RebinData_t &out) const override;
 
-   virtual void GetCellData(const TEveCaloData::CellId_t &id, TEveCaloData::CellData_t& data) const;
+   void GetCellData(const TEveCaloData::CellId_t &id, TEveCaloData::CellData_t& data) const override;
 
-   virtual void GetEtaLimits(Double_t &min, Double_t &max) const;
-   virtual void GetPhiLimits(Double_t &min, Double_t &max) const;
+   void GetEtaLimits(Double_t &min, Double_t &max) const override;
+   void GetPhiLimits(Double_t &min, Double_t &max) const override;
 
 
-   virtual void DataChanged();
+   void DataChanged() override;
 
    THStack* GetStack() { return fHStack; }
 
@@ -326,7 +326,7 @@ public:
 
    Int_t   AddHistogram(TH2F* hist);
 
-   ClassDef(TEveCaloDataHist, 0); // Manages calorimeter TH2F event data.
+   ClassDefOverride(TEveCaloDataHist, 0); // Manages calorimeter TH2F event data.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveCaloLegoEditor.h
+++ b/graf3d/eve/inc/TEveCaloLegoEditor.h
@@ -53,9 +53,9 @@ protected:
 public:
    TEveCaloLegoEditor(const TGWindow *p = nullptr, Int_t width=170, Int_t height=30,
          UInt_t options=kChildFrame, Pixel_t back=GetDefaultFrameBackground());
-   virtual ~TEveCaloLegoEditor() {}
+   ~TEveCaloLegoEditor() override {}
 
-   virtual void SetModel(TObject* obj);
+   void SetModel(TObject* obj) override;
 
    // Declare callback/slot methods
    void DoGridColor(Pixel_t color);
@@ -73,7 +73,7 @@ public:
    void DoPixelsPerBin();
    void DoNormalize();
 
-   ClassDef(TEveCaloLegoEditor, 0); // GUI editor for TEveCaloLego.
+   ClassDefOverride(TEveCaloLegoEditor, 0); // GUI editor for TEveCaloLego.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveCaloLegoGL.h
+++ b/graf3d/eve/inc/TEveCaloLegoGL.h
@@ -123,23 +123,23 @@ private:
 
 public:
    TEveCaloLegoGL();
-   virtual ~TEveCaloLegoGL();
+   ~TEveCaloLegoGL() override;
 
-   virtual Bool_t SetModel(TObject* obj, const Option_t* opt = nullptr);
+   Bool_t SetModel(TObject* obj, const Option_t* opt = nullptr) override;
 
-   virtual void   SetBBox();
+   void   SetBBox() override;
 
-   virtual void   DLCacheDrop();
-   virtual void   DLCachePurge();
+   void   DLCacheDrop() override;
+   void   DLCachePurge() override;
 
-   virtual void   DirectDraw(TGLRnrCtx & rnrCtx) const;
-   virtual void   DrawHighlight(TGLRnrCtx& rnrCtx, const TGLPhysicalShape* ps, Int_t lvl=-1) const;
+   void   DirectDraw(TGLRnrCtx & rnrCtx) const override;
+   void   DrawHighlight(TGLRnrCtx& rnrCtx, const TGLPhysicalShape* ps, Int_t lvl=-1) const override;
 
-   virtual Bool_t SupportsSecondarySelect() const { return kTRUE; }
-   virtual Bool_t AlwaysSecondarySelect()   const { return kTRUE; }
-   virtual void   ProcessSelection(TGLRnrCtx & rnrCtx, TGLSelectRecord & rec);
+   Bool_t SupportsSecondarySelect() const override { return kTRUE; }
+   Bool_t AlwaysSecondarySelect()   const override { return kTRUE; }
+   void   ProcessSelection(TGLRnrCtx & rnrCtx, TGLSelectRecord & rec) override;
 
-   ClassDef(TEveCaloLegoGL, 0); // GL renderer class for TEveCaloLego.
+   ClassDefOverride(TEveCaloLegoGL, 0); // GL renderer class for TEveCaloLego.
 };
 
 //______________________________________________________________________________

--- a/graf3d/eve/inc/TEveCaloLegoOverlay.h
+++ b/graf3d/eve/inc/TEveCaloLegoOverlay.h
@@ -75,15 +75,15 @@ protected:
 
 public:
    TEveCaloLegoOverlay();
-   virtual ~TEveCaloLegoOverlay(){}
+   ~TEveCaloLegoOverlay() override{}
 
    //rendering
-   virtual  void   Render(TGLRnrCtx& rnrCtx);
+    void   Render(TGLRnrCtx& rnrCtx) override;
 
    // event handling
-   virtual  Bool_t MouseEnter(TGLOvlSelectRecord& selRec);
-   virtual  Bool_t Handle(TGLRnrCtx& rnrCtx, TGLOvlSelectRecord& selRec, Event_t* event);
-   virtual  void   MouseLeave();
+    Bool_t MouseEnter(TGLOvlSelectRecord& selRec) override;
+    Bool_t Handle(TGLRnrCtx& rnrCtx, TGLOvlSelectRecord& selRec, Event_t* event) override;
+    void   MouseLeave() override;
 
 
    TEveCaloLego* GetCaloLego() {return fCalo;}
@@ -101,7 +101,7 @@ public:
 
    void          SetFrameAttribs(Color_t frameCol, Char_t lineTransp, Char_t bgTransp);
 
-   ClassDef(TEveCaloLegoOverlay, 0); // GL-overaly control GUI for TEveCaloLego.
+   ClassDefOverride(TEveCaloLegoOverlay, 0); // GL-overaly control GUI for TEveCaloLego.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveCaloVizEditor.h
+++ b/graf3d/eve/inc/TEveCaloVizEditor.h
@@ -54,9 +54,9 @@ protected:
 public:
    TEveCaloVizEditor(const TGWindow *p = nullptr, Int_t width=170, Int_t height=30,
                      UInt_t options=kChildFrame, Pixel_t back=GetDefaultFrameBackground());
-   virtual ~TEveCaloVizEditor() {}
+   ~TEveCaloVizEditor() override {}
 
-   virtual void SetModel(TObject* obj);
+   void SetModel(TObject* obj) override;
 
    void DoMaxTowerH();
    void DoScaleAbs();
@@ -71,7 +71,7 @@ public:
    void DoSliceColor(Pixel_t color);
    void DoSliceTransparency(Long_t transp);
 
-   ClassDef(TEveCaloVizEditor, 0); // GUI editor for TEveCaloVizEditor.
+   ClassDefOverride(TEveCaloVizEditor, 0); // GUI editor for TEveCaloVizEditor.
 };
 
 /**************************************************************************/
@@ -89,12 +89,12 @@ protected:
 public:
    TEveCalo3DEditor(const TGWindow *p = nullptr, Int_t width=170, Int_t height=30,
                      UInt_t options=kChildFrame, Pixel_t back=GetDefaultFrameBackground());
-   virtual ~TEveCalo3DEditor() {}
+   ~TEveCalo3DEditor() override {}
 
-   virtual void SetModel(TObject* obj);
+   void SetModel(TObject* obj) override;
    void    DoFrameTransparency();
 
-   ClassDef(TEveCalo3DEditor, 0); // GUI editor for TEveCalo3DEditor.
+   ClassDefOverride(TEveCalo3DEditor, 0); // GUI editor for TEveCalo3DEditor.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveChunkManager.h
+++ b/graf3d/eve/inc/TEveChunkManager.h
@@ -130,14 +130,14 @@ private:
 public:
    TEveChunkVector()                 : TEveChunkManager() {}
    TEveChunkVector(Int_t chunk_size) : TEveChunkManager(sizeof(T), chunk_size) {}
-   virtual ~TEveChunkVector() {}
+   ~TEveChunkVector() override {}
 
    void Reset(Int_t chunk_size) { Reset(sizeof(T), chunk_size); }
 
    T* At(Int_t idx)  { return reinterpret_cast<T*>(Atom(idx)); }
    T& Ref(Int_t idx) { return *At(idx); }
 
-   ClassDef(TEveChunkVector, 1); // Templated class for specific atom classes (given as template argument).
+   ClassDefOverride(TEveChunkVector, 1); // Templated class for specific atom classes (given as template argument).
 };
 
 #endif

--- a/graf3d/eve/inc/TEveCompound.h
+++ b/graf3d/eve/inc/TEveCompound.h
@@ -32,24 +32,24 @@ protected:
 public:
    TEveCompound(const char* n="TEveCompound", const char* t="",
                 Bool_t doColor=kTRUE, Bool_t doTransparency=kFALSE);
-   virtual ~TEveCompound() {}
+   ~TEveCompound() override {}
 
    void   OpenCompound()         { ++fCompoundOpen;  }
    void   CloseCompound()        { --fCompoundOpen; }
    Bool_t IsCompoundOpen() const { return fCompoundOpen > 0; }
 
-   virtual void SetMainColor(Color_t color);
-   virtual void SetMainTransparency(Char_t t);
+   void SetMainColor(Color_t color) override;
+   void SetMainTransparency(Char_t t) override;
 
-   virtual void AddElement(TEveElement* el);
-   virtual void RemoveElementLocal(TEveElement* el);
-   virtual void RemoveElementsLocal();
+   void AddElement(TEveElement* el) override;
+   void RemoveElementLocal(TEveElement* el) override;
+   void RemoveElementsLocal() override;
 
-   virtual void FillImpliedSelectedSet(Set_t& impSelSet);
+   void FillImpliedSelectedSet(Set_t& impSelSet) override;
 
-   virtual TClass* ProjectedClass(const TEveProjection* p) const;
+   TClass* ProjectedClass(const TEveProjection* p) const override;
 
-   ClassDef(TEveCompound, 0); // Container for managing compounds of TEveElements.
+   ClassDefOverride(TEveCompound, 0); // Container for managing compounds of TEveElements.
 };
 
 
@@ -66,14 +66,14 @@ private:
 
 public:
    TEveCompoundProjected();
-   virtual ~TEveCompoundProjected() {}
+   ~TEveCompoundProjected() override {}
 
-   virtual void SetMainColor(Color_t color);
+   void SetMainColor(Color_t color) override;
 
-   virtual void UpdateProjection()      {}
-   virtual TEveElement* GetProjectedAsElement() { return this; }
+   void UpdateProjection() override      {}
+   TEveElement* GetProjectedAsElement() override { return this; }
 
-   ClassDef(TEveCompoundProjected, 0); // Projected TEveCompund container.
+   ClassDefOverride(TEveCompoundProjected, 0); // Projected TEveCompund container.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveDigitSet.h
+++ b/graf3d/eve/inc/TEveDigitSet.h
@@ -84,9 +84,9 @@ protected:
 
 public:
    TEveDigitSet(const char* n="TEveDigitSet", const char* t="");
-   virtual ~TEveDigitSet();
+   ~TEveDigitSet() override;
 
-   virtual TObject* GetObject(const TEveException&) const
+   TObject* GetObject(const TEveException&) const override
    { const TObject* obj = this; return const_cast<TObject*>(obj); }
 
    void   UseSingleColor();
@@ -94,12 +94,12 @@ public:
    Bool_t GetAntiFlick() const   { return fAntiFlick; }
    void   SetAntiFlick(Bool_t f) { fAntiFlick = f; }
 
-   virtual void SetMainColor(Color_t color);
+   void SetMainColor(Color_t color) override;
 
-   virtual void UnSelected();
-   virtual void UnHighlighted();
+   void UnSelected() override;
+   void UnHighlighted() override;
 
-   virtual TString GetHighlightTooltip();
+   TString GetHighlightTooltip() override;
 
    // Implemented in sub-classes:
    // virtual void Reset(EQuadType_e quadType, Bool_t valIsCol, Int_t chunkSize);
@@ -136,7 +136,7 @@ public:
    // Implemented in subclasses:
    // virtual void ComputeBBox();
 
-   virtual void Paint(Option_t* option="");
+   void Paint(Option_t* option="") override;
 
    virtual void DigitSelected(Int_t idx);
    virtual void SecSelected(TEveDigitSet* qs, Int_t idx); // *SIGNAL*
@@ -178,7 +178,7 @@ public:
    TooltipCB_foo GetTooltipCBFoo()          const { return fTooltipCBFoo; }
    void          SetTooltipCBFoo(TooltipCB_foo f) { fTooltipCBFoo = f; }
 
-   ClassDef(TEveDigitSet, 0); // Base-class for storage of digit collections; provides transformation matrix (TEveTrans), signal to color mapping (TEveRGBAPalette) and visual grouping (TEveFrameBox).
+   ClassDefOverride(TEveDigitSet, 0); // Base-class for storage of digit collections; provides transformation matrix (TEveTrans), signal to color mapping (TEveRGBAPalette) and visual grouping (TEveFrameBox).
 };
 
 #endif

--- a/graf3d/eve/inc/TEveDigitSetEditor.h
+++ b/graf3d/eve/inc/TEveDigitSetEditor.h
@@ -46,16 +46,16 @@ protected:
 public:
    TEveDigitSetEditor(const TGWindow *p = nullptr, Int_t width=170, Int_t height=30,
                       UInt_t options = kChildFrame, Pixel_t back=GetDefaultFrameBackground());
-   virtual ~TEveDigitSetEditor() {}
+   ~TEveDigitSetEditor() override {}
 
-   virtual void SetModel(TObject* obj);
+   void SetModel(TObject* obj) override;
 
    // Declare callback/slot methods
    void DoHisto();
    void DoRangeHisto();
    void PlotHisto(Int_t min, Int_t max);
 
-   ClassDef(TEveDigitSetEditor, 0); // Editor for TEveDigitSet class.
+   ClassDefOverride(TEveDigitSetEditor, 0); // Editor for TEveDigitSet class.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveDigitSetGL.h
+++ b/graf3d/eve/inc/TEveDigitSetGL.h
@@ -36,17 +36,17 @@ protected:
 
 public:
    TEveDigitSetGL();
-   virtual ~TEveDigitSetGL() {}
+   ~TEveDigitSetGL() override {}
 
-   virtual void   SetBBox();
+   void   SetBBox() override;
 
-   virtual void   DrawHighlight(TGLRnrCtx& rnrCtx, const TGLPhysicalShape* pshp, Int_t lvl=-1) const;
+   void   DrawHighlight(TGLRnrCtx& rnrCtx, const TGLPhysicalShape* pshp, Int_t lvl=-1) const override;
 
-   virtual Bool_t SupportsSecondarySelect() const { return kTRUE; }
-   virtual Bool_t AlwaysSecondarySelect()   const { return ((TEveDigitSet*)fExternalObj)->GetAlwaysSecSelect(); }
-   virtual void   ProcessSelection(TGLRnrCtx& rnrCtx, TGLSelectRecord& rec);
+   Bool_t SupportsSecondarySelect() const override { return kTRUE; }
+   Bool_t AlwaysSecondarySelect()   const override { return ((TEveDigitSet*)fExternalObj)->GetAlwaysSecSelect(); }
+   void   ProcessSelection(TGLRnrCtx& rnrCtx, TGLSelectRecord& rec) override;
 
-   ClassDef(TEveDigitSetGL, 0); // GL renderer class for TEveDigitSet.
+   ClassDefOverride(TEveDigitSetGL, 0); // GL renderer class for TEveDigitSet.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveElement.h
+++ b/graf3d/eve/inc/TEveElement.h
@@ -442,33 +442,33 @@ public:
    TEveElementList(const char* n="TEveElementList", const char* t="",
                    Bool_t doColor=kFALSE, Bool_t doTransparency=kFALSE);
    TEveElementList(const TEveElementList& e);
-   virtual ~TEveElementList() {}
+   ~TEveElementList() override {}
 
-   virtual TObject* GetObject(const TEveException& /*eh*/="TEveElementList::GetObject ") const
+   TObject* GetObject(const TEveException& /*eh*/="TEveElementList::GetObject ") const override
    { const TObject* obj = this; return const_cast<TObject*>(obj); }
 
-   virtual TEveElementList* CloneElement() const;
+   TEveElementList* CloneElement() const override;
 
-   virtual const char* GetElementName()  const { return GetName();  }
-   virtual const char* GetElementTitle() const { return GetTitle(); }
+   const char* GetElementName()  const override { return GetName();  }
+   const char* GetElementTitle() const override { return GetTitle(); }
 
-   virtual void SetElementName (const char* name)
+   void SetElementName (const char* name) override
    { TNamed::SetName(name); NameTitleChanged(); }
 
-   virtual void SetElementTitle(const char* title)
+   void SetElementTitle(const char* title) override
    { TNamed::SetTitle(title); NameTitleChanged(); }
 
-   virtual void SetElementNameTitle(const char* name, const char* title)
+   void SetElementNameTitle(const char* name, const char* title) override
    { TNamed::SetNameTitle(name, title); NameTitleChanged(); }
 
    TClass* GetChildClass() const { return fChildClass; }
    void    SetChildClass(TClass* c) { fChildClass = c; }
 
-   virtual Bool_t  AcceptElement(TEveElement* el);
+   Bool_t  AcceptElement(TEveElement* el) override;
 
-   virtual TClass* ProjectedClass(const TEveProjection* p) const;
+   TClass* ProjectedClass(const TEveProjection* p) const override;
 
-   ClassDef(TEveElementList, 0); // List of TEveElement objects with a possibility to limit the class of accepted elements.
+   ClassDefOverride(TEveElementList, 0); // List of TEveElement objects with a possibility to limit the class of accepted elements.
 };
 
 
@@ -485,12 +485,12 @@ private:
 
 public:
    TEveElementListProjected();
-   virtual ~TEveElementListProjected() {}
+   ~TEveElementListProjected() override {}
 
-   virtual void UpdateProjection();
-   virtual TEveElement* GetProjectedAsElement() { return this; }
+   void UpdateProjection() override;
+   TEveElement* GetProjectedAsElement() override { return this; }
 
-   ClassDef(TEveElementListProjected, 0); // Projected TEveElementList.
+   ClassDefOverride(TEveElementListProjected, 0); // Projected TEveElementList.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveElementEditor.h
+++ b/graf3d/eve/inc/TEveElementEditor.h
@@ -42,9 +42,9 @@ protected:
 public:
    TEveElementEditor(const TGWindow *p = nullptr, Int_t width=170, Int_t height=30,
                      UInt_t options=kChildFrame, Pixel_t back=GetDefaultFrameBackground());
-   virtual ~TEveElementEditor() {}
+   ~TEveElementEditor() override {}
 
-   virtual void SetModel(TObject* obj);
+   void SetModel(TObject* obj) override;
 
    void DoRnrSelf();
    void DoRnrChildren();
@@ -52,7 +52,7 @@ public:
    void DoMainColor(Pixel_t color);
    void DoTransparency();
 
-   ClassDef(TEveElementEditor, 0); // Editor for TEveElement class.
+   ClassDefOverride(TEveElementEditor, 0); // Editor for TEveElement class.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveEventManager.h
+++ b/graf3d/eve/inc/TEveEventManager.h
@@ -23,7 +23,7 @@ protected:
 
 public:
    TEveEventManager(const char* n="TEveEventManager", const char* t="");
-   virtual ~TEveEventManager() {}
+   ~TEveEventManager() override {}
 
    std::vector<TString>& GetNewEventCommands() { return fNewEventCommands; }
 
@@ -39,7 +39,7 @@ public:
    virtual void RemoveNewEventCommand(const TString& cmd);
    virtual void ClearNewEventCommands();
 
-   ClassDef(TEveEventManager, 0); // Base class for event management and navigation.
+   ClassDefOverride(TEveEventManager, 0); // Base class for event management and navigation.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveFrameBox.h
+++ b/graf3d/eve/inc/TEveFrameBox.h
@@ -41,7 +41,7 @@ protected:
 
 public:
    TEveFrameBox();
-   virtual ~TEveFrameBox();
+   ~TEveFrameBox() override;
 
    void SetAAQuadXY(Float_t x, Float_t y, Float_t z, Float_t dx, Float_t dy);
    void SetAAQuadXZ(Float_t x, Float_t y, Float_t z, Float_t dx, Float_t dz);
@@ -85,9 +85,9 @@ public:
    Bool_t GetDrawBack() const   { return fDrawBack; }
    void   SetDrawBack(Bool_t f) { fDrawBack = f;    }
 
-   virtual void OnZeroRefCount() { delete this; }
+   void OnZeroRefCount() override { delete this; }
 
-   ClassDef(TEveFrameBox, 0); // Description of a 2D or 3D frame that can be used to visually group a set of objects.
+   ClassDefOverride(TEveFrameBox, 0); // Description of a 2D or 3D frame that can be used to visually group a set of objects.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveGValuators.h
+++ b/graf3d/eve/inc/TEveGValuators.h
@@ -35,7 +35,7 @@ protected:
 
 public:
    TEveGValuatorBase(const TGWindow *p, const char* title, UInt_t w, UInt_t h, Int_t widgetId=-1);
-   virtual ~TEveGValuatorBase() {}
+   ~TEveGValuatorBase() override {}
 
    virtual void Build(Bool_t connect=kTRUE) = 0;
 
@@ -48,7 +48,7 @@ public:
 
    TGLabel* GetLabel() {return fLabel;}
 
-   ClassDef(TEveGValuatorBase, 0); // Base class for composite GUI elements for setting of numeric values.
+   ClassDefOverride(TEveGValuatorBase, 0); // Base class for composite GUI elements for setting of numeric values.
 };
 
 
@@ -73,9 +73,9 @@ protected:
 
 public:
    TEveGValuator(const TGWindow *p, const char* title, UInt_t w, UInt_t h, Int_t widgetId=-1);
-   virtual ~TEveGValuator() {}
+   ~TEveGValuator() override {}
 
-   virtual void Build(Bool_t connect=kTRUE);
+   void Build(Bool_t connect=kTRUE) override;
 
    Float_t GetValue() const { return fValue; }
    virtual void SetValue(Float_t v, Bool_t emit=kFALSE);
@@ -99,7 +99,7 @@ public:
    void SetToolTip(const char* tip);
    void SetEnabled(Bool_t state);
 
-   ClassDef(TEveGValuator, 0); // Composite GUI element for single value selection (supports label, number-entry and slider).
+   ClassDefOverride(TEveGValuator, 0); // Composite GUI element for single value selection (supports label, number-entry and slider).
 };
 
 
@@ -117,9 +117,9 @@ protected:
 
 public:
    TEveGDoubleValuator(const TGWindow *p, const char* title, UInt_t w, UInt_t h, Int_t widgetId=-1);
-   virtual ~TEveGDoubleValuator() {}
+   ~TEveGDoubleValuator() override {}
 
-   virtual void Build(Bool_t connect=kTRUE);
+   void Build(Bool_t connect=kTRUE) override;
 
    void MinEntryCallback();
    void MaxEntryCallback();
@@ -141,7 +141,7 @@ public:
    Float_t GetLimitMin() const { return fMinEntry->GetNumMin(); }
    Float_t GetLimitMax() const { return fMaxEntry->GetNumMax(); }
 
-   ClassDef(TEveGDoubleValuator, 0); // Composite GUI element for selection of range (label, two number-entries and double-slider).
+   ClassDefOverride(TEveGDoubleValuator, 0); // Composite GUI element for selection of range (label, two number-entries and double-slider).
 };
 
 
@@ -162,7 +162,7 @@ protected:
 
 public:
    TEveGTriVecValuator(const TGWindow *p, const char* name, UInt_t w, UInt_t h, Int_t widgetId=-1);
-   virtual ~TEveGTriVecValuator() {}
+   ~TEveGTriVecValuator() override {}
 
    void Build(Bool_t vertical, const char* lab0, const char* lab1, const char* lab2);
 
@@ -196,7 +196,7 @@ public:
    void SetLimits(Float_t min, Float_t max,
                   TGNumberFormat::EStyle nef=TGNumberFormat::kNESRealTwo);
 
-   ClassDef(TEveGTriVecValuator, 0); // Composite GUI element for setting three numerical values (label, three number-entries).
+   ClassDefOverride(TEveGTriVecValuator, 0); // Composite GUI element for setting three numerical values (label, three number-entries).
 };
 
 #endif

--- a/graf3d/eve/inc/TEveGedEditor.h
+++ b/graf3d/eve/inc/TEveGedEditor.h
@@ -35,7 +35,7 @@ protected:
    TEveElement   *fElement;    // Cached eve-element pointer.
    TObject       *fObject;     // Cached tobj pointer.
 
-   virtual TGedFrame* CreateNameFrame(const TGWindow* parent, const char* tab_name);
+   TGedFrame* CreateNameFrame(const TGWindow* parent, const char* tab_name) override;
 
    static Int_t   fgMaxExtraEditors;
    static TList  *fgExtraEditors;
@@ -44,17 +44,17 @@ protected:
 
 public:
    TEveGedEditor(TCanvas* canvas=nullptr, UInt_t width=250, UInt_t height=400);
-   virtual ~TEveGedEditor();
+   ~TEveGedEditor() override;
 
-   virtual void CloseWindow();
+   void CloseWindow() override;
 
    TEveElement* GetEveElement() const;
 
    void DisplayElement(TEveElement* re);
    void DisplayObject(TObject* obj);
 
-   virtual void SetModel(TVirtualPad* pad, TObject* obj, Int_t event, Bool_t force=kFALSE);
-   virtual void Update(TGedFrame* gframe=nullptr);
+   void SetModel(TVirtualPad* pad, TObject* obj, Int_t event, Bool_t force=kFALSE) override;
+   void Update(TGedFrame* gframe=nullptr) override;
 
    // --- Statics for extra editors. ---
 
@@ -66,7 +66,7 @@ public:
 
    static TContextMenu* GetContextMenu();
 
-   ClassDef(TEveGedEditor, 0); // Specialization of TGedEditor for proper update propagation to TEveManager.
+   ClassDefOverride(TEveGedEditor, 0); // Specialization of TGedEditor for proper update propagation to TEveManager.
 };
 
 
@@ -86,13 +86,13 @@ protected:
 public:
    TEveGedNameFrame(const TGWindow *p=nullptr, Int_t width=140, Int_t height=30,
                     UInt_t options=kChildFrame | kHorizontalFrame);
-   virtual ~TEveGedNameFrame();
+   ~TEveGedNameFrame() override;
 
-   virtual void SetModel(TObject* obj);
+   void SetModel(TObject* obj) override;
 
    void SpawnEditorClone();
 
-   ClassDef(TEveGedNameFrame, 0); // Top name-frame used in EVE.
+   ClassDefOverride(TEveGedNameFrame, 0); // Top name-frame used in EVE.
 };
 
 
@@ -110,11 +110,11 @@ private:
 
 public:
    TEveGedNameTextButton(TEveGedNameFrame* p);
-   virtual ~TEveGedNameTextButton();
+   ~TEveGedNameTextButton() override;
 
-   virtual Bool_t HandleButton(Event_t* event);
+   Bool_t HandleButton(Event_t* event) override;
 
-   ClassDef(TEveGedNameTextButton, 0); // Button for GED name-frame.
+   ClassDefOverride(TEveGedNameTextButton, 0); // Button for GED name-frame.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveGeoNode.h
+++ b/graf3d/eve/inc/TEveGeoNode.h
@@ -43,31 +43,31 @@ protected:
 public:
    TEveGeoNode(TGeoNode* node);
 
-   virtual TObject* GetObject(const TEveException&) const
+   TObject* GetObject(const TEveException&) const override
    { const TObject* obj = this; return const_cast<TObject*>(obj); }
 
-   virtual const char* GetName()  const;
-   virtual const char* GetTitle() const;
-   virtual const char* GetElementName()  const;
-   virtual const char* GetElementTitle() const;
+   const char* GetName()  const override;
+   const char* GetTitle() const override;
+   const char* GetElementName()  const override;
+   const char* GetElementTitle() const override;
 
    TGeoNode* GetNode() const { return fNode; }
 
-   virtual void   ExpandIntoListTree(TGListTree* ltree, TGListTreeItem* parent);
+   void   ExpandIntoListTree(TGListTree* ltree, TGListTreeItem* parent) override;
 
    virtual void   ExpandIntoListTrees();
    virtual void   ExpandIntoListTreesRecursively();
 
-   virtual Bool_t CanEditElement() const { return kFALSE; }
+   Bool_t CanEditElement() const override { return kFALSE; }
 
-   virtual void   AddStamp(UChar_t bits);
+   void   AddStamp(UChar_t bits) override;
 
-   virtual Bool_t CanEditMainColor() const;
-   virtual void   SetMainColor(Color_t color);
+   Bool_t CanEditMainColor() const override;
+   void   SetMainColor(Color_t color) override;
 
-   virtual Bool_t  CanEditMainTransparency() const;
-   virtual Char_t  GetMainTransparency() const;
-   virtual void    SetMainTransparency(Char_t t);
+   Bool_t  CanEditMainTransparency() const override;
+   Char_t  GetMainTransparency() const override;
+   void    SetMainTransparency(Char_t t) override;
 
    void UpdateNode(TGeoNode* node);
    void UpdateVolume(TGeoVolume* volume);
@@ -76,12 +76,12 @@ public:
    void SaveExtract(const char* file, const char* name, Bool_t leafs_only);
    void WriteExtract(const char* name, Bool_t leafs_only);
 
-   virtual void Draw(Option_t* option="");
+   void Draw(Option_t* option="") override;
 
    static Int_t GetCSGExportNSeg();
    static void  SetCSGExportNSeg(Int_t nseg);
 
-   ClassDef(TEveGeoNode, 0); // Wrapper for TGeoNode that allows it to be shown in GUI and controlled as a TEveElement.
+   ClassDefOverride(TEveGeoNode, 0); // Wrapper for TGeoNode that allows it to be shown in GUI and controlled as a TEveElement.
 };
 
 //----------------------------------------------------------------
@@ -100,7 +100,7 @@ protected:
 public:
    TEveGeoTopNode(TGeoManager* manager, TGeoNode* node, Int_t visopt=1,
                   Int_t vislvl=3, Int_t maxvisnds=10000);
-   virtual ~TEveGeoTopNode() {}
+   ~TEveGeoTopNode() override {}
 
    void         UseNodeTrans();
 
@@ -113,13 +113,13 @@ public:
    Int_t GetMaxVisNodes()    const { return fMaxVisNodes; }
    void  SetMaxVisNodes(Int_t mvn) { fMaxVisNodes = mvn;  }
 
-   virtual Bool_t CanEditElement() const { return kTRUE; }
-   virtual Bool_t SingleRnrState() const { return kTRUE; }
+   Bool_t CanEditElement() const override { return kTRUE; }
+   Bool_t SingleRnrState() const override { return kTRUE; }
 
-   virtual void   AddStamp(UChar_t bits);
+   void   AddStamp(UChar_t bits) override;
 
-   virtual void Draw(Option_t* option="");
-   virtual void Paint(Option_t* option="");
+   void Draw(Option_t* option="") override;
+   void Paint(Option_t* option="") override;
 
    // Signals from GeoManager.
    // These are not available any more ... colors in list-tree not refreshed
@@ -128,7 +128,7 @@ public:
    void VolumeColChanged(TGeoVolume* volume);
    void NodeVisChanged(TGeoNode* node);
 
-   ClassDef(TEveGeoTopNode, 0); // Top-level TEveGeoNode with a pointer to TGeoManager and controls for steering of TGeoPainter.
+   ClassDefOverride(TEveGeoTopNode, 0); // Top-level TEveGeoNode with a pointer to TGeoManager and controls for steering of TGeoPainter.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveGeoNodeEditor.h
+++ b/graf3d/eve/inc/TEveGeoNodeEditor.h
@@ -39,16 +39,16 @@ protected:
 public:
    TEveGeoNodeEditor(const TGWindow *p = nullptr, Int_t width=170, Int_t height=30,
                      UInt_t options=kChildFrame, Pixel_t back=GetDefaultFrameBackground());
-   virtual ~TEveGeoNodeEditor() {}
+   ~TEveGeoNodeEditor() override {}
 
-   virtual void SetModel(TObject* obj);
+   void SetModel(TObject* obj) override;
 
    void DoVizNode();
    void DoVizNodeDaughters();
    void DoVizVolume();
    void DoVizVolumeDaughters();
 
-   ClassDef(TEveGeoNodeEditor, 0); // Editor for TEveGeoNode class.
+   ClassDefOverride(TEveGeoNodeEditor, 0); // Editor for TEveGeoNode class.
 };
 
 /******************************************************************************/
@@ -68,15 +68,15 @@ protected:
 public:
    TEveGeoTopNodeEditor(const TGWindow *p = nullptr, Int_t width=170, Int_t height=30,
                         UInt_t options=kChildFrame, Pixel_t back=GetDefaultFrameBackground());
-   virtual ~TEveGeoTopNodeEditor() {}
+   ~TEveGeoTopNodeEditor() override {}
 
-   virtual void SetModel(TObject* obj);
+   void SetModel(TObject* obj) override;
 
    void DoVisOption();
    void DoVisLevel();
    void DoMaxVisNodes();
 
-   ClassDef(TEveGeoTopNodeEditor, 0); // Editor for TEveGeoTopNode class.
+   ClassDefOverride(TEveGeoTopNodeEditor, 0); // Editor for TEveGeoTopNode class.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveGeoPolyShape.h
+++ b/graf3d/eve/inc/TEveGeoPolyShape.h
@@ -33,7 +33,7 @@ protected:
    std::vector<Int_t>    fPolyDesc;
    UInt_t                fNbPols;
 
-   virtual void FillBuffer3D(TBuffer3D& buffer, Int_t reqSections, Bool_t localFrame) const;
+   void FillBuffer3D(TBuffer3D& buffer, Int_t reqSections, Bool_t localFrame) const override;
 
    struct Edge_t
    {
@@ -55,16 +55,16 @@ protected:
 
 public:
    TEveGeoPolyShape();
-   virtual ~TEveGeoPolyShape() {}
+   ~TEveGeoPolyShape() override {}
 
    static TEveGeoPolyShape* Construct(TGeoCompositeShape *cshp, Int_t n_seg);
 
    void SetFromFaceSet(TGLFaceSet* fs);
 
-   virtual const TBuffer3D& GetBuffer3D(Int_t reqSections, Bool_t localFrame) const;
-   virtual       TBuffer3D* MakeBuffer3D() const;
+   const TBuffer3D& GetBuffer3D(Int_t reqSections, Bool_t localFrame) const override;
+         TBuffer3D* MakeBuffer3D() const override;
 
-   ClassDef(TEveGeoPolyShape, 1); // A shape with arbitrary tesselation for visualization of CSG shapes.
+   ClassDefOverride(TEveGeoPolyShape, 1); // A shape with arbitrary tesselation for visualization of CSG shapes.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveGeoShape.h
+++ b/graf3d/eve/inc/TEveGeoShape.h
@@ -40,9 +40,9 @@ protected:
 
 public:
    TEveGeoShape(const char* name="TEveGeoShape", const char* title=nullptr);
-   virtual ~TEveGeoShape();
+   ~TEveGeoShape() override;
 
-   virtual TObject* GetObject(const TEveException&) const
+   TObject* GetObject(const TEveException&) const override
    { const TObject* obj = this; return const_cast<TObject*>(obj); }
 
    Int_t       GetNSegments()  const { return fNSegments; }
@@ -50,8 +50,8 @@ public:
    void        SetNSegments(Int_t s);
    void        SetShape(TGeoShape* s);
 
-   virtual void ComputeBBox();
-   virtual void Paint(Option_t* option="");
+   void ComputeBBox() override;
+   void Paint(Option_t* option="") override;
 
    void Save(const char* file, const char* name="Extract");
    void SaveExtract(const char* file, const char* name);
@@ -61,12 +61,12 @@ public:
 
    // GeoProjectable
    virtual TBuffer3D*   MakeBuffer3D();
-   virtual TClass*      ProjectedClass(const TEveProjection* p) const;
+   TClass*      ProjectedClass(const TEveProjection* p) const override;
 
    static TGeoManager*  GetGeoMangeur();
    static TGeoHMatrix*  GetGeoHMatrixIdentity();
 
-   ClassDef(TEveGeoShape, 0); // Wrapper for TGeoShape with absolute positioning and color attributes allowing display of extracted TGeoShape's (without an active TGeoManager) and simplified geometries (needed for NLT projections).
+   ClassDefOverride(TEveGeoShape, 0); // Wrapper for TGeoShape with absolute positioning and color attributes allowing display of extracted TGeoShape's (without an active TGeoManager) and simplified geometries (needed for NLT projections).
 };
 
 //------------------------------------------------------------------------------
@@ -81,19 +81,19 @@ private:
 protected:
    TBuffer3D   *fBuff;
 
-   virtual void SetDepthLocal(Float_t d);
+   void SetDepthLocal(Float_t d) override;
 
 public:
    TEveGeoShapeProjected();
-   virtual ~TEveGeoShapeProjected();
+   ~TEveGeoShapeProjected() override;
 
-   virtual void SetProjection(TEveProjectionManager* proj, TEveProjectable* model);
-   virtual void UpdateProjection();
-   virtual TEveElement* GetProjectedAsElement() { return this; }
+   void SetProjection(TEveProjectionManager* proj, TEveProjectable* model) override;
+   void UpdateProjection() override;
+   TEveElement* GetProjectedAsElement() override { return this; }
 
-   virtual void ComputeBBox();
+   void ComputeBBox() override;
 
-   ClassDef(TEveGeoShapeProjected, 0);
+   ClassDefOverride(TEveGeoShapeProjected, 0);
 };
 
 #endif

--- a/graf3d/eve/inc/TEveGeoShapeExtract.h
+++ b/graf3d/eve/inc/TEveGeoShapeExtract.h
@@ -35,7 +35,7 @@ protected:
 
 public:
    TEveGeoShapeExtract(const char* n="TEveGeoShapeExtract", const char* t=nullptr);
-   ~TEveGeoShapeExtract();
+   ~TEveGeoShapeExtract() override;
 
    Bool_t HasElements();
    void   AddElement(TEveGeoShapeExtract* gse);
@@ -60,7 +60,7 @@ public:
    TGeoShape* GetShape()       { return fShape;    }
    TList*     GetElements()    { return fElements; }
 
-   ClassDef(TEveGeoShapeExtract, 2); // Globally positioned TGeoShape with rendering attributes and an optional list of daughter shape-extracts.
+   ClassDefOverride(TEveGeoShapeExtract, 2); // Globally positioned TGeoShape with rendering attributes and an optional list of daughter shape-extracts.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveGridStepper.h
+++ b/graf3d/eve/inc/TEveGridStepper.h
@@ -41,7 +41,7 @@ protected:
 
 public:
    TEveGridStepper(Int_t sm=kSM_XYZ);
-   virtual ~TEveGridStepper() {}
+   ~TEveGridStepper() override {}
 
    void Reset();
    void Subtract(TEveGridStepper& s);
@@ -72,7 +72,7 @@ public:
    Float_t GetOy() const { return fOy; }
    Float_t GetOz() const { return fOz; }
 
-   ClassDef(TEveGridStepper, 1); // Provide discrete position coordinates for placement of objects on regular grids.
+   ClassDefOverride(TEveGridStepper, 1); // Provide discrete position coordinates for placement of objects on regular grids.
 }; // end class TEveGridStepper
 
 #endif

--- a/graf3d/eve/inc/TEveGridStepperEditor.h
+++ b/graf3d/eve/inc/TEveGridStepperEditor.h
@@ -40,7 +40,7 @@ protected:
 
 public:
    TEveGridStepperSubEditor(const TGWindow* p);
-   virtual ~TEveGridStepperSubEditor() {}
+   ~TEveGridStepperSubEditor() override {}
 
    void SetModel(TEveGridStepper* m);
 
@@ -49,7 +49,7 @@ public:
    void DoNs();
    void DoDs();
 
-   ClassDef(TEveGridStepperSubEditor, 0); // Sub-editor for TEveGridStepper class.
+   ClassDefOverride(TEveGridStepperSubEditor, 0); // Sub-editor for TEveGridStepper class.
 };
 
 
@@ -65,11 +65,11 @@ protected:
 
 public:
    TEveGridStepperEditor(const TGWindow *p = nullptr, Int_t width=170, Int_t height=30, UInt_t options=kChildFrame, Pixel_t back=GetDefaultFrameBackground());
-   virtual ~TEveGridStepperEditor() {}
+   ~TEveGridStepperEditor() override {}
 
-   virtual void SetModel(TObject* obj);
+   void SetModel(TObject* obj) override;
 
-   ClassDef(TEveGridStepperEditor, 0); // Editor for TEveGridStepper class.
+   ClassDefOverride(TEveGridStepperEditor, 0); // Editor for TEveGridStepper class.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveJetCone.h
+++ b/graf3d/eve/inc/TEveJetCone.h
@@ -46,10 +46,10 @@ protected:
 
 public:
    TEveJetCone(const Text_t* n="TEveJetCone", const Text_t* t="");
-   virtual ~TEveJetCone() {}
+   ~TEveJetCone() override {}
 
-   virtual void    ComputeBBox();
-   virtual TClass* ProjectedClass(const TEveProjection* p) const;
+   void    ComputeBBox() override;
+   TClass* ProjectedClass(const TEveProjection* p) const override;
 
    void  SetApex(const TEveVector& a)      { fApex = a; }
    void  SetCylinder(Float_t r, Float_t z) { fLimits.Set(0, r, z); fThetaC = fLimits.Theta(); }
@@ -61,7 +61,7 @@ public:
    Int_t AddCone(Float_t eta, Float_t phi, Float_t cone_r, Float_t length=0);
    Int_t AddEllipticCone(Float_t eta, Float_t phi, Float_t reta, Float_t rphi, Float_t length=0);
 
-   ClassDef(TEveJetCone, 0); // Short description.
+   ClassDefOverride(TEveJetCone, 0); // Short description.
 };
 
 
@@ -79,22 +79,22 @@ private:
    TEveJetConeProjected& operator=(const TEveJetConeProjected&); // Not implemented
 
 protected:
-   virtual void SetDepthLocal(Float_t d);
+   void SetDepthLocal(Float_t d) override;
 
 public:
    TEveJetConeProjected(const char* n="TEveJetConeProjected", const char* t="");
-   virtual ~TEveJetConeProjected();
+   ~TEveJetConeProjected() override;
 
    // For TAttBBox:
-   virtual void ComputeBBox();
+   void ComputeBBox() override;
 
    // Projected:
-   virtual void SetProjection(TEveProjectionManager* mng, TEveProjectable* model);
-   virtual void UpdateProjection();
+   void SetProjection(TEveProjectionManager* mng, TEveProjectable* model) override;
+   void UpdateProjection() override;
 
-   virtual TEveElement* GetProjectedAsElement() { return this; }
+   TEveElement* GetProjectedAsElement() override { return this; }
 
-   ClassDef(TEveJetConeProjected, 0); // Projection of TEveJetCone.
+   ClassDefOverride(TEveJetConeProjected, 0); // Projection of TEveJetCone.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveJetConeEditor.h
+++ b/graf3d/eve/inc/TEveJetConeEditor.h
@@ -36,14 +36,14 @@ protected:
 public:
    TEveJetConeEditor(const TGWindow *p = nullptr, Int_t width=170, Int_t height=30,
                      UInt_t options=kChildFrame, Pixel_t back=GetDefaultFrameBackground());
-   virtual ~TEveJetConeEditor() {}
+   ~TEveJetConeEditor() override {}
 
-   virtual void SetModel(TObject* obj);
+   void SetModel(TObject* obj) override;
 
    // Declare callback/slot methods
    // void DoXYZZ();
 
-   ClassDef(TEveJetConeEditor, 0); // GUI editor for TEveJetCone.
+   ClassDefOverride(TEveJetConeEditor, 0); // GUI editor for TEveJetCone.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveJetConeGL.h
+++ b/graf3d/eve/inc/TEveJetConeGL.h
@@ -40,16 +40,16 @@ protected:
 
 public:
    TEveJetConeGL();
-   virtual ~TEveJetConeGL() {}
+   ~TEveJetConeGL() override {}
 
-   virtual Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr);
-   virtual void   SetBBox();
+   Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr) override;
+   void   SetBBox() override;
 
-   virtual void   DLCacheClear();
-   virtual void   Draw(TGLRnrCtx& rnrCtx) const;
-   virtual void   DirectDraw(TGLRnrCtx & rnrCtx) const;
+   void   DLCacheClear() override;
+   void   Draw(TGLRnrCtx& rnrCtx) const override;
+   void   DirectDraw(TGLRnrCtx & rnrCtx) const override;
 
-   ClassDef(TEveJetConeGL, 0); // GL renderer class for TEveJetCone.
+   ClassDefOverride(TEveJetConeGL, 0); // GL renderer class for TEveJetCone.
 };
 
 
@@ -66,22 +66,22 @@ private:
 protected:
    TEveJetConeProjected  *fM;  // Model object.
 
-   virtual void CalculatePoints() const;
+   void CalculatePoints() const override;
 
    void RenderOutline() const;
    void RenderPolygon() const;
 
 public:
    TEveJetConeProjectedGL();
-   virtual ~TEveJetConeProjectedGL() {}
+   ~TEveJetConeProjectedGL() override {}
 
-   virtual Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr);
-   virtual void   SetBBox();
+   Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr) override;
+   void   SetBBox() override;
 
-   virtual void   Draw(TGLRnrCtx& rnrCtx) const;
-   virtual void   DirectDraw(TGLRnrCtx & rnrCtx) const;
+   void   Draw(TGLRnrCtx& rnrCtx) const override;
+   void   DirectDraw(TGLRnrCtx & rnrCtx) const override;
 
-   ClassDef(TEveJetConeProjectedGL, 0); // GL renderer class for TEveJetCone.
+   ClassDefOverride(TEveJetConeProjectedGL, 0); // GL renderer class for TEveJetCone.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveLegoEventHandler.h
+++ b/graf3d/eve/inc/TEveLegoEventHandler.h
@@ -31,15 +31,15 @@ protected:
    Float_t  fTransTheta; // transition theta in radians
    Float_t  fTheta;
 
-   virtual Bool_t Rotate(Int_t xDelta, Int_t yDelta, Bool_t mod1, Bool_t mod2);
+   Bool_t Rotate(Int_t xDelta, Int_t yDelta, Bool_t mod1, Bool_t mod2) override;
 
 public:
    TEveCaloLego*  fLego;
 
    TEveLegoEventHandler(TGWindow *w, TObject *obj, TEveCaloLego* lego = nullptr);
-   virtual ~TEveLegoEventHandler() {}
+   ~TEveLegoEventHandler() override {}
 
-   virtual Bool_t HandleKey(Event_t *event);
+   Bool_t HandleKey(Event_t *event) override;
 
    Float_t GetTransTheta() {return fTransTheta;}
    void    SetTransTheta(Float_t h) {fTransTheta=h;}
@@ -47,7 +47,7 @@ public:
    TEveCaloLego* GetLego() { return fLego; }
    void          SetLego( TEveCaloLego* x) { fLego = x; }
 
-   ClassDef(TEveLegoEventHandler, 0); // A GL event handler class. Switches perspective or orthographic camera.
+   ClassDefOverride(TEveLegoEventHandler, 0); // A GL event handler class. Switches perspective or orthographic camera.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveLine.h
+++ b/graf3d/eve/inc/TEveLine.h
@@ -41,13 +41,13 @@ protected:
 public:
    TEveLine(Int_t n_points=0, ETreeVarType_e tv_type=kTVT_XYZ);
    TEveLine(const char* name, Int_t n_points=0, ETreeVarType_e tv_type=kTVT_XYZ);
-   virtual ~TEveLine() {}
+   ~TEveLine() override {}
 
-   virtual void SetMarkerColor(Color_t col);
+   void SetMarkerColor(Color_t col) override;
 
-   virtual void SetLineColor(Color_t col)   { SetMainColor(col); }
-   virtual void SetLineStyle(Style_t lstyle);
-   virtual void SetLineWidth(Width_t lwidth);
+   void SetLineColor(Color_t col) override   { SetMainColor(col); }
+   void SetLineStyle(Style_t lstyle) override;
+   void SetLineWidth(Width_t lwidth) override;
 
    Bool_t GetRnrLine() const     { return fRnrLine;   }
    Bool_t GetRnrPoints() const   { return fRnrPoints; }
@@ -62,17 +62,17 @@ public:
    TEveVector GetLineStart() const;
    TEveVector GetLineEnd()   const;
 
-   virtual const TGPicture* GetListTreeIcon(Bool_t open=kFALSE);
+   const TGPicture* GetListTreeIcon(Bool_t open=kFALSE) override;
 
-   virtual void CopyVizParams(const TEveElement* el);
-   virtual void WriteVizParams(std::ostream& out, const TString& var);
+   void CopyVizParams(const TEveElement* el) override;
+   void WriteVizParams(std::ostream& out, const TString& var) override;
 
-   virtual TClass* ProjectedClass(const TEveProjection* p) const;
+   TClass* ProjectedClass(const TEveProjection* p) const override;
 
    static Bool_t GetDefaultSmooth();
    static void   SetDefaultSmooth(Bool_t r);
 
-   ClassDef(TEveLine, 0); // An arbitrary polyline with fixed line and marker attributes.
+   ClassDefOverride(TEveLine, 0); // An arbitrary polyline with fixed line and marker attributes.
 };
 
 
@@ -88,17 +88,17 @@ private:
    TEveLineProjected& operator=(const TEveLineProjected&); // Not implemented
 
 protected:
-   virtual void SetDepthLocal(Float_t d);
+   void SetDepthLocal(Float_t d) override;
 
 public:
    TEveLineProjected();
-   virtual ~TEveLineProjected() {}
+   ~TEveLineProjected() override {}
 
-   virtual void SetProjection(TEveProjectionManager* mng, TEveProjectable* model);
-   virtual void UpdateProjection();
-   virtual TEveElement* GetProjectedAsElement() { return this; }
+   void SetProjection(TEveProjectionManager* mng, TEveProjectable* model) override;
+   void UpdateProjection() override;
+   TEveElement* GetProjectedAsElement() override { return this; }
 
-   ClassDef(TEveLineProjected, 0); // Projected replica of a TEveLine.
+   ClassDefOverride(TEveLineProjected, 0); // Projected replica of a TEveLine.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveLineEditor.h
+++ b/graf3d/eve/inc/TEveLineEditor.h
@@ -35,15 +35,15 @@ protected:
 
 public:
    TEveLineEditor(const TGWindow *p = nullptr, Int_t width=170, Int_t height=30, UInt_t options = kChildFrame, Pixel_t back=GetDefaultFrameBackground());
-   virtual ~TEveLineEditor() {}
+   ~TEveLineEditor() override {}
 
-   virtual void SetModel(TObject* obj);
+   void SetModel(TObject* obj) override;
 
    void DoRnrLine();
    void DoRnrPoints();
    void DoSmooth();
 
-   ClassDef(TEveLineEditor, 0); // Editor for TEveLine class.
+   ClassDefOverride(TEveLineEditor, 0); // Editor for TEveLine class.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveLineGL.h
+++ b/graf3d/eve/inc/TEveLineGL.h
@@ -31,16 +31,16 @@ protected:
 
 public:
    TEveLineGL();
-   virtual ~TEveLineGL() {}
+   ~TEveLineGL() override {}
 
-   virtual Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr);
-   virtual void   DirectDraw(TGLRnrCtx & rnrCtx) const;
+   Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr) override;
+   void   DirectDraw(TGLRnrCtx & rnrCtx) const override;
 
    // To support two-level selection
    // virtual Bool_t SupportsSecondarySelect() const { return kTRUE; }
    // virtual void ProcessSelection(UInt_t* ptr, TGLViewer*, TGLScene*);
 
-   ClassDef(TEveLineGL, 0); // GL-renderer for TEveLine class.
+   ClassDefOverride(TEveLineGL, 0); // GL-renderer for TEveLine class.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveMacro.h
+++ b/graf3d/eve/inc/TEveMacro.h
@@ -24,13 +24,13 @@ public:
    TEveMacro();
    TEveMacro(const TEveMacro&);
    TEveMacro(const char* name);
-   virtual ~TEveMacro() {}
+   ~TEveMacro() override {}
 
-   virtual Longptr_t Exec(const char* params = "0", Int_t* error = nullptr);
+   Longptr_t Exec(const char* params = "0", Int_t* error = nullptr) override;
 
    void ResetRoot();
 
-   ClassDef(TEveMacro, 1); // TMacro wrapper (attempting to fix issues with different macro loading and execution schemes).
+   ClassDefOverride(TEveMacro, 1); // TMacro wrapper (attempting to fix issues with different macro loading and execution schemes).
 };
 
 #endif

--- a/graf3d/eve/inc/TEveManager.h
+++ b/graf3d/eve/inc/TEveManager.h
@@ -72,11 +72,11 @@ public:
    {
    public:
       TExceptionHandler() : TStdExceptionHandler() { Add(); }
-      virtual ~TExceptionHandler()                 { Remove(); }
+      ~TExceptionHandler() override                 { Remove(); }
 
-      virtual EStatus  Handle(std::exception& exc);
+      EStatus  Handle(std::exception& exc) override;
 
-      ClassDef(TExceptionHandler, 0); // Exception handler for Eve exceptions.
+      ClassDefOverride(TExceptionHandler, 0); // Exception handler for Eve exceptions.
    };
 
 protected:

--- a/graf3d/eve/inc/TEvePad.h
+++ b/graf3d/eve/inc/TEvePad.h
@@ -21,16 +21,16 @@ public:
    TEvePad(const char* name, const char* title,
            Double_t xlow, Double_t ylow, Double_t xup, Double_t yup,
            Color_t color = -1, Short_t bordersize = -1, Short_t bordermode = -2);
-   virtual ~TEvePad() {}
+   ~TEvePad() override {}
 
-   virtual Bool_t    IsBatch() const { return kTRUE; }
+   Bool_t    IsBatch() const override { return kTRUE; }
 
-   virtual void      Update() { PaintModified(); }
+   void      Update() override { PaintModified(); }
 
-   virtual TVirtualViewer3D *GetViewer3D(Option_t * /*type*/ = "")
+   TVirtualViewer3D *GetViewer3D(Option_t * /*type*/ = "") override
    { return fViewer3D; }
 
-   ClassDef(TEvePad, 1); // Internal TEveUtil pad class (sub-class of TPad) overriding handling of updates and 3D-viewers.
+   ClassDefOverride(TEvePad, 1); // Internal TEveUtil pad class (sub-class of TPad) overriding handling of updates and 3D-viewers.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveParamList.h
+++ b/graf3d/eve/inc/TEveParamList.h
@@ -80,7 +80,7 @@ protected:
 
 public:
    TEveParamList(const char* n="TEveParamList", const char* t="", Bool_t doColor=kFALSE);
-   virtual ~TEveParamList() {}
+   ~TEveParamList() override {}
 
    void AddParameter(const FloatConfig_t& parameter) { fFloatParameters.push_back(parameter); }
    void AddParameter(const IntConfig_t& parameter)   { fIntParameters.push_back(parameter); }
@@ -96,7 +96,7 @@ public:
 
    void ParamChanged(const char* name); // *SIGNAL*
 
-   ClassDef(TEveParamList, 0); // Eve element to store generic configuration information.
+   ClassDefOverride(TEveParamList, 0); // Eve element to store generic configuration information.
 };
 
 
@@ -137,15 +137,15 @@ protected:
 public:
    TEveParamListEditor(const TGWindow *p = nullptr, Int_t width=170, Int_t height=30,
          UInt_t options=kChildFrame, Pixel_t back=GetDefaultFrameBackground());
-   virtual ~TEveParamListEditor() {}
+   ~TEveParamListEditor() override {}
 
-   virtual void SetModel(TObject* obj);
+   void SetModel(TObject* obj) override;
 
    // Declare callback/slot methods
    void DoIntUpdate();
    void DoFloatUpdate();
    void DoBoolUpdate();
 
-   ClassDef(TEveParamListEditor, 0); // GUI editor for TEveParamList.
+   ClassDefOverride(TEveParamListEditor, 0); // GUI editor for TEveParamList.
 };
 #endif

--- a/graf3d/eve/inc/TEvePlot3D.h
+++ b/graf3d/eve/inc/TEvePlot3D.h
@@ -33,7 +33,7 @@ protected:
 
 public:
    TEvePlot3D(const char* n="TEvePlot3D", const char* t="");
-   virtual ~TEvePlot3D() {}
+   ~TEvePlot3D() override {}
 
    void SetPlot(TObject* obj, const TString& opt) { fPlot = obj; fPlotOption = opt; }
 
@@ -50,9 +50,9 @@ public:
    Bool_t   GetLogY() const { return fLogY; }
    Bool_t   GetLogZ() const { return fLogZ; }
 
-   virtual void Paint(Option_t* option="");
+   void Paint(Option_t* option="") override;
 
-   ClassDef(TEvePlot3D, 0); // Short description.
+   ClassDefOverride(TEvePlot3D, 0); // Short description.
 };
 
 #endif

--- a/graf3d/eve/inc/TEvePlot3DGL.h
+++ b/graf3d/eve/inc/TEvePlot3DGL.h
@@ -32,20 +32,20 @@ protected:
 
 public:
    TEvePlot3DGL();
-   virtual ~TEvePlot3DGL() {}
+   ~TEvePlot3DGL() override {}
 
-   virtual Bool_t KeepDuringSmartRefresh() const { return kFALSE; }
+   Bool_t KeepDuringSmartRefresh() const override { return kFALSE; }
 
-   virtual Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr);
-   virtual void   SetBBox();
+   Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr) override;
+   void   SetBBox() override;
 
-   virtual void DirectDraw(TGLRnrCtx & rnrCtx) const;
+   void DirectDraw(TGLRnrCtx & rnrCtx) const override;
 
    // To support two-level selection
    // virtual Bool_t SupportsSecondarySelect() const { return kTRUE; }
    // virtual void ProcessSelection(TGLRnrCtx & rnrCtx, TGLSelectRecord & rec);
 
-   ClassDef(TEvePlot3DGL, 0); // GL renderer class for TEvePlot3D.
+   ClassDefOverride(TEvePlot3DGL, 0); // GL renderer class for TEvePlot3D.
 };
 
 #endif

--- a/graf3d/eve/inc/TEvePointSet.h
+++ b/graf3d/eve/inc/TEvePointSet.h
@@ -50,25 +50,25 @@ public:
    TEvePointSet(Int_t n_points=0, ETreeVarType_e tv_type=kTVT_XYZ);
    TEvePointSet(const char* name, Int_t n_points=0, ETreeVarType_e tv_type=kTVT_XYZ);
    TEvePointSet(const TEvePointSet& e);
-   virtual ~TEvePointSet();
+   ~TEvePointSet() override;
 
-   virtual TObject* GetObject(const TEveException&) const
+   TObject* GetObject(const TEveException&) const override
    { const TObject* obj = this; return const_cast<TObject*>(obj); }
 
-   virtual TEvePointSet* CloneElement() const { return new TEvePointSet(*this); }
+   TEvePointSet* CloneElement() const override { return new TEvePointSet(*this); }
 
    virtual void ClonePoints(const TEvePointSet& e);
 
    void  Reset(Int_t n_points=0, Int_t n_int_ids=0);
    Int_t GrowFor(Int_t n_points);
 
-   virtual const char* GetTitle()         const { return fTitle; }
-   virtual const char* GetElementName()   const { return TPointSet3D::GetName(); }
-   virtual const char* GetElementTitle()  const { return fTitle; }
-   virtual void  SetElementName (const char* n) { fName  = n; NameTitleChanged(); }
+   const char* GetTitle()         const override { return fTitle; }
+   const char* GetElementName()   const override { return TPointSet3D::GetName(); }
+   const char* GetElementTitle()  const override { return fTitle; }
+   void  SetElementName (const char* n) override { fName  = n; NameTitleChanged(); }
    virtual void  SetTitle(const char* t)        { fTitle = t; NameTitleChanged(); }
-   virtual void  SetElementTitle(const char* t) { fTitle = t; NameTitleChanged(); }
-   virtual void  SetElementNameTitle(const char* n, const char* t)
+   void  SetElementTitle(const char* t) override { fTitle = t; NameTitleChanged(); }
+   void  SetElementNameTitle(const char* n, const char* t) override
    { fName = n; fTitle = t; NameTitleChanged(); }
 
    Int_t  GetIntIdsPerPoint() const { return fIntIdsPerPoint; }
@@ -78,25 +78,25 @@ public:
    void   SetPointIntIds(Int_t* ids);
    void   SetPointIntIds(Int_t n, Int_t* ids);
 
-   virtual void SetMarkerColor(Color_t col) { SetMainColor(col); }
-   virtual void SetMarkerStyle(Style_t mstyle=1);
-   virtual void SetMarkerSize(Size_t msize=1);
+   void SetMarkerColor(Color_t col) override { SetMainColor(col); }
+   void SetMarkerStyle(Style_t mstyle=1) override;
+   void SetMarkerSize(Size_t msize=1) override;
 
-   virtual void Paint(Option_t* option="");
+   void Paint(Option_t* option="") override;
 
-   virtual void InitFill(Int_t subIdNum);
-   virtual void TakeAction(TEvePointSelector*);
+   void InitFill(Int_t subIdNum) override;
+   void TakeAction(TEvePointSelector*) override;
 
-   virtual void PointSelected(Int_t id); // *SIGNAL*
+   void PointSelected(Int_t id) override; // *SIGNAL*
 
-   virtual const TGPicture* GetListTreeIcon(Bool_t open=kFALSE);
+   const TGPicture* GetListTreeIcon(Bool_t open=kFALSE) override;
 
-   virtual void CopyVizParams(const TEveElement* el);
-   virtual void WriteVizParams(std::ostream& out, const TString& var);
+   void CopyVizParams(const TEveElement* el) override;
+   void WriteVizParams(std::ostream& out, const TString& var) override;
 
-   virtual TClass* ProjectedClass(const TEveProjection* p) const;
+   TClass* ProjectedClass(const TEveProjection* p) const override;
 
-   ClassDef(TEvePointSet, 0); // Set of 3D points with same marker attributes; optionally each point can be assigned an external TRef or a number of integer indices.
+   ClassDefOverride(TEvePointSet, 0); // Set of 3D points with same marker attributes; optionally each point can be assigned an external TRef or a number of integer indices.
 };
 
 
@@ -126,16 +126,16 @@ protected:
 
 public:
    TEvePointSetArray(const char* name="TEvePointSetArray", const char* title="");
-   virtual ~TEvePointSetArray();
+   ~TEvePointSetArray() override;
 
-   virtual void RemoveElementLocal(TEveElement* el);
-   virtual void RemoveElementsLocal();
+   void RemoveElementLocal(TEveElement* el) override;
+   void RemoveElementsLocal() override;
 
-   virtual void SetMarkerColor(Color_t tcolor=1);
-   virtual void SetMarkerStyle(Style_t mstyle=1);
-   virtual void SetMarkerSize(Size_t msize=1);
+   void SetMarkerColor(Color_t tcolor=1) override;
+   void SetMarkerStyle(Style_t mstyle=1) override;
+   void SetMarkerSize(Size_t msize=1) override;
 
-   virtual void TakeAction(TEvePointSelector*);
+   void TakeAction(TEvePointSelector*) override;
 
    virtual Int_t Size(Bool_t under=kFALSE, Bool_t over=kFALSE) const;
 
@@ -159,7 +159,7 @@ public:
 
    void SetRange(Double_t min, Double_t max);
 
-   ClassDef(TEvePointSetArray, 0); // Array of TEvePointSet's filled via a common point-source; range of displayed TEvePointSet's can be controlled, based on a separating quantity provided on fill-time by a user.
+   ClassDefOverride(TEvePointSetArray, 0); // Array of TEvePointSet's filled via a common point-source; range of displayed TEvePointSet's can be controlled, based on a separating quantity provided on fill-time by a user.
 };
 
 
@@ -175,20 +175,20 @@ private:
    TEvePointSetProjected& operator=(const TEvePointSetProjected&); // Not implemented
 
 protected:
-   virtual void SetDepthLocal(Float_t d);
+   void SetDepthLocal(Float_t d) override;
 
 public:
    TEvePointSetProjected();
-   virtual ~TEvePointSetProjected() {}
+   ~TEvePointSetProjected() override {}
 
-   virtual void SetProjection(TEveProjectionManager* proj, TEveProjectable* model);
-   virtual void UpdateProjection();
-   virtual TEveElement* GetProjectedAsElement() { return this; }
+   void SetProjection(TEveProjectionManager* proj, TEveProjectable* model) override;
+   void UpdateProjection() override;
+   TEveElement* GetProjectedAsElement() override { return this; }
 
-   virtual void PointSelected(Int_t id);
+   void PointSelected(Int_t id) override;
 
 
-   ClassDef(TEvePointSetProjected, 0); // Projected copy of a TEvePointSet.
+   ClassDefOverride(TEvePointSetProjected, 0); // Projected copy of a TEvePointSet.
 };
 
 #endif

--- a/graf3d/eve/inc/TEvePointSetArrayEditor.h
+++ b/graf3d/eve/inc/TEvePointSetArrayEditor.h
@@ -36,13 +36,13 @@ protected:
 public:
    TEvePointSetArrayEditor(const TGWindow *p = nullptr, Int_t width=170, Int_t height=30,
                            UInt_t options=kChildFrame, Pixel_t back=GetDefaultFrameBackground());
-   ~TEvePointSetArrayEditor();
+   ~TEvePointSetArrayEditor() override;
 
-   virtual void SetModel(TObject* obj);
+   void SetModel(TObject* obj) override;
 
    void DoRange();
 
-   ClassDef(TEvePointSetArrayEditor, 0); // Editor for TEvePointSetArray class.
+   ClassDefOverride(TEvePointSetArrayEditor, 0); // Editor for TEvePointSetArray class.
 };
 
 #endif

--- a/graf3d/eve/inc/TEvePolygonSetProjected.h
+++ b/graf3d/eve/inc/TEvePolygonSetProjected.h
@@ -71,26 +71,26 @@ protected:
    Int_t        fNPnts;    // number of reduced and projected points
    TEveVector*  fPnts;     // reduced and projected points
 
-   virtual void SetDepthLocal(Float_t d);
+   void SetDepthLocal(Float_t d) override;
 
    Float_t PolygonSurfaceXY(const Polygon_t& poly) const;
 
 public:
    TEvePolygonSetProjected(const char* n="TEvePolygonSetProjected", const char* t="");
-   virtual ~TEvePolygonSetProjected();
+   ~TEvePolygonSetProjected() override;
 
-   virtual void    ComputeBBox();
+   void    ComputeBBox() override;
 
-   virtual void    SetProjection(TEveProjectionManager* mng, TEveProjectable* model);
-   virtual void    UpdateProjection();
-   virtual TEveElement* GetProjectedAsElement() { return this; }
+   void    SetProjection(TEveProjectionManager* mng, TEveProjectable* model) override;
+   void    UpdateProjection() override;
+   TEveElement* GetProjectedAsElement() override { return this; }
 
    void            ProjectBuffer3D();
 
    virtual void    DumpPolys() const;
    void            DumpBuffer3D();
 
-   ClassDef(TEvePolygonSetProjected,0); // Set of projected polygons with outline; typically produced from a TBuffer3D.
+   ClassDefOverride(TEvePolygonSetProjected,0); // Set of projected polygons with outline; typically produced from a TBuffer3D.
 
 };
 

--- a/graf3d/eve/inc/TEvePolygonSetProjectedGL.h
+++ b/graf3d/eve/inc/TEvePolygonSetProjectedGL.h
@@ -41,21 +41,21 @@ protected:
 
 public:
    TEvePolygonSetProjectedGL();
-   virtual  ~TEvePolygonSetProjectedGL() {}
+    ~TEvePolygonSetProjectedGL() override {}
 
-   virtual Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr);
-   virtual void   SetBBox();
-   virtual void   Draw(TGLRnrCtx& rnrCtx) const;
-   virtual void   DirectDraw(TGLRnrCtx& rnrCtx) const;
+   Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr) override;
+   void   SetBBox() override;
+   void   Draw(TGLRnrCtx& rnrCtx) const override;
+   void   DirectDraw(TGLRnrCtx& rnrCtx) const override;
 
-   virtual void   DrawHighlight(TGLRnrCtx& rnrCtx, const TGLPhysicalShape* pshp, Int_t lvl=-1) const;
+   void   DrawHighlight(TGLRnrCtx& rnrCtx, const TGLPhysicalShape* pshp, Int_t lvl=-1) const override;
 
-   virtual Bool_t IgnoreSizeForOfInterest() const { return kTRUE; }
+   Bool_t IgnoreSizeForOfInterest() const override { return kTRUE; }
 
 private:
    void DrawOutline() const;
 
-   ClassDef(TEvePolygonSetProjectedGL,0);  // GL-renderer for TEvePolygonSetProjected class.
+   ClassDefOverride(TEvePolygonSetProjectedGL,0);  // GL-renderer for TEvePolygonSetProjected class.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveProjectionAxes.h
+++ b/graf3d/eve/inc/TEveProjectionAxes.h
@@ -51,7 +51,7 @@ protected:
 
 public:
    TEveProjectionAxes(TEveProjectionManager* m, Bool_t useColorSet = kTRUE);
-   virtual ~TEveProjectionAxes();
+   ~TEveProjectionAxes() override;
 
    TEveProjectionManager* GetManager()      { return fManager; }
 
@@ -65,12 +65,12 @@ public:
    void            SetDrawOrigin(Bool_t x)   { fDrawOrigin = x; }
    Bool_t          GetDrawOrigin() const     { return fDrawOrigin; }
 
-   virtual void    Paint(Option_t* option="");
-   virtual void    ComputeBBox();
+   void    Paint(Option_t* option="") override;
+   void    ComputeBBox() override;
 
-   virtual const   TGPicture* GetListTreeIcon(Bool_t open=kFALSE);
+   const   TGPicture* GetListTreeIcon(Bool_t open=kFALSE) override;
 
-   ClassDef(TEveProjectionAxes, 0); // Class to draw scales in non-linear projections.
+   ClassDefOverride(TEveProjectionAxes, 0); // Class to draw scales in non-linear projections.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveProjectionAxesEditor.h
+++ b/graf3d/eve/inc/TEveProjectionAxesEditor.h
@@ -39,9 +39,9 @@ protected:
 public:
    TEveProjectionAxesEditor(const TGWindow *p = nullptr, Int_t width=170, Int_t height=30,
                             UInt_t options=kChildFrame, Pixel_t back=GetDefaultFrameBackground());
-   virtual ~TEveProjectionAxesEditor() {}
+   ~TEveProjectionAxesEditor() override {}
 
-   virtual void SetModel(TObject* obj);
+   void SetModel(TObject* obj) override;
 
    // Declare callback/slot methods
 
@@ -51,7 +51,7 @@ public:
    void DoDrawCenter();
    void DoDrawOrigin();
 
-   ClassDef(TEveProjectionAxesEditor, 0); // GUI editor for TEveProjectionAxes.
+   ClassDefOverride(TEveProjectionAxesEditor, 0); // GUI editor for TEveProjectionAxes.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveProjectionAxesGL.h
+++ b/graf3d/eve/inc/TEveProjectionAxesGL.h
@@ -36,16 +36,16 @@ protected:
 
 public:
    TEveProjectionAxesGL();
-   virtual ~TEveProjectionAxesGL() {}
+   ~TEveProjectionAxesGL() override {}
 
-   virtual Bool_t  SetModel(TObject* obj, const Option_t* opt = nullptr);
-   virtual void    SetBBox();
-   virtual void    Draw(TGLRnrCtx& rnrCtx) const;
-   virtual void    DirectDraw(TGLRnrCtx & rnrCtx) const;
+   Bool_t  SetModel(TObject* obj, const Option_t* opt = nullptr) override;
+   void    SetBBox() override;
+   void    Draw(TGLRnrCtx& rnrCtx) const override;
+   void    DirectDraw(TGLRnrCtx & rnrCtx) const override;
 
-   Bool_t IgnoreSizeForOfInterest() const { return kTRUE; }
+   Bool_t IgnoreSizeForOfInterest() const override { return kTRUE; }
 
-   ClassDef(TEveProjectionAxesGL, 0); // GL renderer class for TEveProjectionAxes.
+   ClassDefOverride(TEveProjectionAxesGL, 0); // GL renderer class for TEveProjectionAxes.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveProjectionManager.h
+++ b/graf3d/eve/inc/TEveProjectionManager.h
@@ -40,7 +40,7 @@ protected:
 
 public:
    TEveProjectionManager(TEveProjection::EPType_e type=TEveProjection::kPT_Unknown);
-   virtual ~TEveProjectionManager();
+   ~TEveProjectionManager() override;
 
    void AddDependent(TEveElement* el);
    void RemoveDependent(TEveElement* el);
@@ -59,7 +59,7 @@ public:
    void            SetImportEmpty(Bool_t ie)  { fImportEmpty = ie;   }
    Bool_t          GetImportEmpty()     const { return fImportEmpty; }
 
-   virtual Bool_t  HandleElementPaste(TEveElement* el);
+   Bool_t  HandleElementPaste(TEveElement* el) override;
 
    virtual TEveElement* ImportElementsRecurse(TEveElement* el,
                                               TEveElement* parent);
@@ -72,9 +72,9 @@ public:
    virtual void    ProjectChildren();
    virtual void    ProjectChildrenRecurse(TEveElement* el);
 
-   virtual void    ComputeBBox();
+   void    ComputeBBox() override;
 
-   ClassDef(TEveProjectionManager, 0); // Manager class for steering of projections and managing projected objects.
+   ClassDefOverride(TEveProjectionManager, 0); // Manager class for steering of projections and managing projected objects.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveProjectionManagerEditor.h
+++ b/graf3d/eve/inc/TEveProjectionManagerEditor.h
@@ -47,9 +47,9 @@ protected:
 
 public:
    TEveProjectionManagerEditor(const TGWindow *p = nullptr, Int_t width=170, Int_t height=30, UInt_t options = kChildFrame, Pixel_t back=GetDefaultFrameBackground());
-   virtual ~TEveProjectionManagerEditor(){}
+   ~TEveProjectionManagerEditor() override{}
 
-   virtual void SetModel(TObject* obj);
+   void SetModel(TObject* obj) override;
 
    // Declare callback/slot methods
 
@@ -63,7 +63,7 @@ public:
    void DoMaxTrackStep();
    void DoCenter();
 
-   ClassDef(TEveProjectionManagerEditor, 0); // Editor for TEveProjectionManager class.
+   ClassDefOverride(TEveProjectionManagerEditor, 0); // Editor for TEveProjectionManager class.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveProjections.h
+++ b/graf3d/eve/inc/TEveProjections.h
@@ -164,23 +164,23 @@ private:
 
 public:
    TEveRhoZProjection();
-   virtual ~TEveRhoZProjection() {}
+   ~TEveRhoZProjection() override {}
 
-   virtual Bool_t      Is2D() const { return kTRUE;  }
-   virtual Bool_t      Is3D() const { return kFALSE; }
+   Bool_t      Is2D() const override { return kTRUE;  }
+   Bool_t      Is3D() const override { return kFALSE; }
 
-   virtual void        ProjectPoint(Float_t& x, Float_t& y, Float_t& z, Float_t d, EPProc_e proc = kPP_Full);
+   void        ProjectPoint(Float_t& x, Float_t& y, Float_t& z, Float_t d, EPProc_e proc = kPP_Full) override;
 
-   virtual void        SetCenter(TEveVector& v);
-   virtual Float_t*    GetProjectedCenter() { return fProjectedCenter.Arr(); }
+   void        SetCenter(TEveVector& v) override;
+   Float_t*    GetProjectedCenter() override { return fProjectedCenter.Arr(); }
 
-   virtual Bool_t      HasSeveralSubSpaces() const { return kTRUE; }
-   virtual Bool_t      AcceptSegment(TEveVector& v1, TEveVector& v2, Float_t tolerance) const;
-   virtual Int_t       SubSpaceId(const TEveVector& v) const;
-   virtual Bool_t      IsOnSubSpaceBoundrary(const TEveVector& v) const;
-   virtual void        SetDirectionalVector(Int_t screenAxis, TEveVector& vec);
+   Bool_t      HasSeveralSubSpaces() const override { return kTRUE; }
+   Bool_t      AcceptSegment(TEveVector& v1, TEveVector& v2, Float_t tolerance) const override;
+   Int_t       SubSpaceId(const TEveVector& v) const override;
+   Bool_t      IsOnSubSpaceBoundrary(const TEveVector& v) const override;
+   void        SetDirectionalVector(Int_t screenAxis, TEveVector& vec) override;
 
-   ClassDef(TEveRhoZProjection, 0); // Rho/Z non-linear projection.
+   ClassDefOverride(TEveRhoZProjection, 0); // Rho/Z non-linear projection.
 };
 
 
@@ -192,14 +192,14 @@ class TEveRPhiProjection : public TEveProjection
 {
 public:
    TEveRPhiProjection();
-   virtual ~TEveRPhiProjection() {}
+   ~TEveRPhiProjection() override {}
 
-   virtual Bool_t Is2D() const { return kTRUE;  }
-   virtual Bool_t Is3D() const { return kFALSE; }
+   Bool_t Is2D() const override { return kTRUE;  }
+   Bool_t Is3D() const override { return kFALSE; }
 
-   virtual void   ProjectPoint(Float_t& x, Float_t& y, Float_t& z, Float_t d, EPProc_e proc = kPP_Full);
+   void   ProjectPoint(Float_t& x, Float_t& y, Float_t& z, Float_t d, EPProc_e proc = kPP_Full) override;
 
-   ClassDef(TEveRPhiProjection, 0); // XY non-linear projection.
+   ClassDefOverride(TEveRPhiProjection, 0); // XY non-linear projection.
 };
 
 
@@ -214,19 +214,19 @@ private:
 
 public:
    TEveXZProjection();
-   virtual ~TEveXZProjection() {}
+   ~TEveXZProjection() override {}
 
-   virtual Bool_t Is2D() const { return kTRUE;  }
-   virtual Bool_t Is3D() const { return kFALSE; }
+   Bool_t Is2D() const override { return kTRUE;  }
+   Bool_t Is3D() const override { return kFALSE; }
 
-   virtual void   ProjectPoint(Float_t& x, Float_t& y, Float_t& z, Float_t d, EPProc_e proc = kPP_Full);
+   void   ProjectPoint(Float_t& x, Float_t& y, Float_t& z, Float_t d, EPProc_e proc = kPP_Full) override;
 
-   virtual void     SetCenter(TEveVector& v);
-   virtual Float_t* GetProjectedCenter() { return fProjectedCenter.Arr(); }
+   void     SetCenter(TEveVector& v) override;
+   Float_t* GetProjectedCenter() override { return fProjectedCenter.Arr(); }
 
-   virtual void     SetDirectionalVector(Int_t screenAxis, TEveVector& vec);
+   void     SetDirectionalVector(Int_t screenAxis, TEveVector& vec) override;
 
-   ClassDef(TEveXZProjection, 0); // XZ non-linear projection.
+   ClassDefOverride(TEveXZProjection, 0); // XZ non-linear projection.
 };
 
 
@@ -241,19 +241,19 @@ private:
 
 public:
    TEveYZProjection();
-   virtual ~TEveYZProjection() {}
+   ~TEveYZProjection() override {}
 
-   virtual Bool_t Is2D() const { return kTRUE;  }
-   virtual Bool_t Is3D() const { return kFALSE; }
+   Bool_t Is2D() const override { return kTRUE;  }
+   Bool_t Is3D() const override { return kFALSE; }
 
-   virtual void   ProjectPoint(Float_t& x, Float_t& y, Float_t& z, Float_t d, EPProc_e proc = kPP_Full);
+   void   ProjectPoint(Float_t& x, Float_t& y, Float_t& z, Float_t d, EPProc_e proc = kPP_Full) override;
 
-   virtual void     SetCenter(TEveVector& v);
-   virtual Float_t* GetProjectedCenter() { return fProjectedCenter.Arr(); }
+   void     SetCenter(TEveVector& v) override;
+   Float_t* GetProjectedCenter() override { return fProjectedCenter.Arr(); }
 
-   virtual void     SetDirectionalVector(Int_t screenAxis, TEveVector& vec);
+   void     SetDirectionalVector(Int_t screenAxis, TEveVector& vec) override;
 
-   ClassDef(TEveYZProjection, 0); // XY non-linear projection.
+   ClassDefOverride(TEveYZProjection, 0); // XY non-linear projection.
 };
 
 
@@ -268,19 +268,19 @@ private:
 
 public:
    TEveZXProjection();
-   virtual ~TEveZXProjection() {}
+   ~TEveZXProjection() override {}
 
-   virtual Bool_t Is2D() const { return kTRUE;  }
-   virtual Bool_t Is3D() const { return kFALSE; }
+   Bool_t Is2D() const override { return kTRUE;  }
+   Bool_t Is3D() const override { return kFALSE; }
 
-   virtual void   ProjectPoint(Float_t& x, Float_t& y, Float_t& z, Float_t d, EPProc_e proc = kPP_Full);
+   void   ProjectPoint(Float_t& x, Float_t& y, Float_t& z, Float_t d, EPProc_e proc = kPP_Full) override;
 
-   virtual void     SetCenter(TEveVector& v);
-   virtual Float_t* GetProjectedCenter() { return fProjectedCenter.Arr(); }
+   void     SetCenter(TEveVector& v) override;
+   Float_t* GetProjectedCenter() override { return fProjectedCenter.Arr(); }
 
-   virtual void     SetDirectionalVector(Int_t screenAxis, TEveVector& vec);
+   void     SetDirectionalVector(Int_t screenAxis, TEveVector& vec) override;
 
-   ClassDef(TEveZXProjection, 0); // XZ non-linear projection.
+   ClassDefOverride(TEveZXProjection, 0); // XZ non-linear projection.
 };
 
 
@@ -295,19 +295,19 @@ private:
 
 public:
    TEveZYProjection();
-   virtual ~TEveZYProjection() {}
+   ~TEveZYProjection() override {}
 
-   virtual Bool_t Is2D() const { return kTRUE;  }
-   virtual Bool_t Is3D() const { return kFALSE; }
+   Bool_t Is2D() const override { return kTRUE;  }
+   Bool_t Is3D() const override { return kFALSE; }
 
-   virtual void   ProjectPoint(Float_t& x, Float_t& y, Float_t& z, Float_t d, EPProc_e proc = kPP_Full);
+   void   ProjectPoint(Float_t& x, Float_t& y, Float_t& z, Float_t d, EPProc_e proc = kPP_Full) override;
 
-   virtual void     SetCenter(TEveVector& v);
-   virtual Float_t* GetProjectedCenter() { return fProjectedCenter.Arr(); }
+   void     SetCenter(TEveVector& v) override;
+   Float_t* GetProjectedCenter() override { return fProjectedCenter.Arr(); }
 
-   virtual void     SetDirectionalVector(Int_t screenAxis, TEveVector& vec);
+   void     SetDirectionalVector(Int_t screenAxis, TEveVector& vec) override;
 
-   ClassDef(TEveZYProjection, 0); // XY non-linear projection.
+   ClassDefOverride(TEveZYProjection, 0); // XY non-linear projection.
 };
 
 
@@ -319,14 +319,14 @@ class TEve3DProjection : public TEveProjection
 {
 public:
    TEve3DProjection();
-   virtual ~TEve3DProjection() {}
+   ~TEve3DProjection() override {}
 
-   virtual Bool_t Is2D() const { return kFALSE; }
-   virtual Bool_t Is3D() const { return kTRUE;  }
+   Bool_t Is2D() const override { return kFALSE; }
+   Bool_t Is3D() const override { return kTRUE;  }
 
-   virtual void   ProjectPoint(Float_t& x, Float_t& y, Float_t& z, Float_t d, EPProc_e proc = kPP_Full);
+   void   ProjectPoint(Float_t& x, Float_t& y, Float_t& z, Float_t d, EPProc_e proc = kPP_Full) override;
 
-   ClassDef(TEve3DProjection, 0); // 3D scaling "projection"
+   ClassDefOverride(TEve3DProjection, 0); // 3D scaling "projection"
 };
 
 // AMT: temporary workaround till root pactches are integrated in CMSSW

--- a/graf3d/eve/inc/TEveQuadSet.h
+++ b/graf3d/eve/inc/TEveQuadSet.h
@@ -81,7 +81,7 @@ public:
    TEveQuadSet(const char* n="TEveQuadSet", const char* t="");
    TEveQuadSet(EQuadType_e quadType, Bool_t valIsCol, Int_t chunkSize,
                const char* n="TEveQuadSet", const char* t="");
-   virtual ~TEveQuadSet() {}
+   ~TEveQuadSet() override {}
 
    void Reset(EQuadType_e quadType, Bool_t valIsCol, Int_t chunkSize);
 
@@ -116,11 +116,11 @@ public:
 
    // void Test(Int_t nquads);
 
-   virtual void ComputeBBox();
+   void ComputeBBox() override;
 
    // virtual void Paint(Option_t* option="");
 
-   ClassDef(TEveQuadSet, 0); // Collection of 2D primitives (rectangles, hexagons, or lines); each primitive can be assigned a signal value and a TRef.
+   ClassDefOverride(TEveQuadSet, 0); // Collection of 2D primitives (rectangles, hexagons, or lines); each primitive can be assigned a signal value and a TRef.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveQuadSetGL.h
+++ b/graf3d/eve/inc/TEveQuadSetGL.h
@@ -29,14 +29,14 @@ protected:
 
 public:
    TEveQuadSetGL();
-   virtual ~TEveQuadSetGL() {}
+   ~TEveQuadSetGL() override {}
 
-   virtual Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr);
-   virtual void   DirectDraw(TGLRnrCtx& rnrCtx) const;
+   Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr) override;
+   void   DirectDraw(TGLRnrCtx& rnrCtx) const override;
 
-   virtual Bool_t IgnoreSizeForOfInterest() const { return kTRUE; }
+   Bool_t IgnoreSizeForOfInterest() const override { return kTRUE; }
 
-   ClassDef(TEveQuadSetGL, 0); // GL-renderer for TEveQuadSet class.
+   ClassDefOverride(TEveQuadSetGL, 0); // GL-renderer for TEveQuadSet class.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveRGBAPalette.h
+++ b/graf3d/eve/inc/TEveRGBAPalette.h
@@ -77,7 +77,7 @@ public:
    TEveRGBAPalette();
    TEveRGBAPalette(Int_t min, Int_t max, Bool_t interp=kTRUE,
                    Bool_t showdef=kTRUE, Bool_t fixcolrng=kFALSE);
-   virtual ~TEveRGBAPalette();
+   ~TEveRGBAPalette() override;
 
    void SetupColorArray() const;
    void ClearColorArray();
@@ -151,13 +151,13 @@ public:
    void   SetOverColorPixel(Pixel_t pix);
    void   SetOverColorRGBA(UChar_t r, UChar_t g, UChar_t b, UChar_t a=255);
 
-   virtual void OnZeroRefCount() { delete this; }
+   void OnZeroRefCount() override { delete this; }
 
    // ================================================================
 
    void MinMaxValChanged(); // *SIGNAL*
 
-   ClassDef(TEveRGBAPalette, 0); // A generic, speed-optimised mapping from value to RGBA color supporting different wrapping and range truncation modes.
+   ClassDefOverride(TEveRGBAPalette, 0); // A generic, speed-optimised mapping from value to RGBA color supporting different wrapping and range truncation modes.
 };
 
 

--- a/graf3d/eve/inc/TEveRGBAPaletteEditor.h
+++ b/graf3d/eve/inc/TEveRGBAPaletteEditor.h
@@ -47,7 +47,7 @@ protected:
 
 public:
    TEveRGBAPaletteSubEditor(const TGWindow* p);
-   virtual ~TEveRGBAPaletteSubEditor() {}
+   ~TEveRGBAPaletteSubEditor() override {}
 
    void SetModel(TEveRGBAPalette* p);
 
@@ -64,7 +64,7 @@ public:
    void DoUnderflowAction(Int_t mode);
    void DoOverflowAction(Int_t mode);
 
-   ClassDef(TEveRGBAPaletteSubEditor, 0); // Sub-editor for TEveRGBAPalette class.
+   ClassDefOverride(TEveRGBAPaletteSubEditor, 0); // Sub-editor for TEveRGBAPalette class.
 };
 
 
@@ -83,11 +83,11 @@ protected:
 
 public:
    TEveRGBAPaletteEditor(const TGWindow *p = nullptr, Int_t width=170, Int_t height=30, UInt_t options = kChildFrame, Pixel_t back=GetDefaultFrameBackground());
-   virtual ~TEveRGBAPaletteEditor() {}
+   ~TEveRGBAPaletteEditor() override {}
 
-   virtual void SetModel(TObject* obj);
+   void SetModel(TObject* obj) override;
 
-   ClassDef(TEveRGBAPaletteEditor, 0); // Editor for TEveRGBAPalette class.
+   ClassDefOverride(TEveRGBAPaletteEditor, 0); // Editor for TEveRGBAPalette class.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveRGBAPaletteOverlay.h
+++ b/graf3d/eve/inc/TEveRGBAPaletteOverlay.h
@@ -37,9 +37,9 @@ protected:
 public:
    TEveRGBAPaletteOverlay(TEveRGBAPalette* p, Float_t posx, Float_t posy,
                           Float_t width, Float_t height);
-   virtual ~TEveRGBAPaletteOverlay() {}
+   ~TEveRGBAPaletteOverlay() override {}
 
-   virtual void Render(TGLRnrCtx& rnrCtx);
+   void Render(TGLRnrCtx& rnrCtx) override;
 
    TAxis&           RefAxis() { return fAxis; }
    TGLAxisPainter&  RefAxisPainter() { return fAxisPainter; }
@@ -48,7 +48,7 @@ public:
    void SetPosition(Float_t x, Float_t y) { fPosX = x; fPosY = y; }
    void SetSize(Float_t w, Float_t h) { fWidth = w; fHeight = h; }
 
-   ClassDef(TEveRGBAPaletteOverlay, 0); // Draws TEveRGBAPalette as GL overlay.
+   ClassDefOverride(TEveRGBAPaletteOverlay, 0); // Draws TEveRGBAPalette as GL overlay.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveScalableStraightLineSet.h
+++ b/graf3d/eve/inc/TEveScalableStraightLineSet.h
@@ -26,13 +26,13 @@ protected:
 
 public:
    TEveScalableStraightLineSet(const char* n="ScalableStraightLineSet", const char* t="");
-   virtual ~TEveScalableStraightLineSet() {}
+   ~TEveScalableStraightLineSet() override {}
 
    void SetScaleCenter(Float_t x, Float_t y, Float_t z);
    void SetScale(Double_t scale);
 
    Double_t GetScale() const;
 
-   ClassDef(TEveScalableStraightLineSet, 0); // Straight-line-set with extra scaling.
+   ClassDefOverride(TEveScalableStraightLineSet, 0); // Straight-line-set with extra scaling.
 };
 #endif

--- a/graf3d/eve/inc/TEveScene.h
+++ b/graf3d/eve/inc/TEveScene.h
@@ -42,11 +42,11 @@ protected:
 public:
    TEveScene(const char* n="TEveScene", const char* t="");
    TEveScene(TGLScenePad* gl_scene, const char* n="TEveScene", const char* t="");
-   virtual ~TEveScene();
+   ~TEveScene() override;
 
-   virtual void CollectSceneParents(List_t& scenes);
+   void CollectSceneParents(List_t& scenes) override;
 
-   virtual Bool_t SingleRnrState() const { return kTRUE; }
+   Bool_t SingleRnrState() const override { return kTRUE; }
 
    void   Changed()         { fChanged = kTRUE; }
    Bool_t IsChanged() const { return fChanged;  }
@@ -60,15 +60,15 @@ public:
    TGLScenePad* GetGLScene() const { return fGLScene; }
    void SetGLScene(TGLScenePad* s) { fGLScene = s; }
 
-   virtual void SetName(const char* n);
-   virtual void Paint(Option_t* option = "");
+   void SetName(const char* n) override;
+   void Paint(Option_t* option = "") override;
 
    void DestroyElementRenderers(TEveElement* element);
    void DestroyElementRenderers(TObject* rnrObj);
 
-   virtual const TGPicture* GetListTreeIcon(Bool_t open=kFALSE);
+   const TGPicture* GetListTreeIcon(Bool_t open=kFALSE) override;
 
-   ClassDef(TEveScene, 0); // Reve representation of TGLScene.
+   ClassDefOverride(TEveScene, 0); // Reve representation of TGLScene.
 };
 
 
@@ -86,7 +86,7 @@ protected:
 
 public:
    TEveSceneList(const char* n="TEveSceneList", const char* t="");
-   virtual ~TEveSceneList() {}
+   ~TEveSceneList() override {}
 
    void DestroyScenes();
 
@@ -97,7 +97,7 @@ public:
 
    void ProcessSceneChanges(Bool_t dropLogicals, TExMap* stampMap);
 
-   ClassDef(TEveSceneList, 0); // List of Scenes providing common operations on TEveScene collections.
+   ClassDefOverride(TEveSceneList, 0); // List of Scenes providing common operations on TEveScene collections.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveSceneInfo.h
+++ b/graf3d/eve/inc/TEveSceneInfo.h
@@ -34,21 +34,21 @@ protected:
 
 public:
    TEveSceneInfo(TEveViewer* viewer, TEveScene* scene, TGLSceneInfo* sinfo);
-   virtual ~TEveSceneInfo() {}
+   ~TEveSceneInfo() override {}
 
    TEveViewer   * GetViewer()      const { return fViewer; }
    TEveScene    * GetScene()       const { return fScene;  }
    TGLSceneInfo * GetGLSceneInfo() const { return fGLSceneInfo; }
    TGLSceneBase * GetGLScene()     const;
 
-   virtual Bool_t SingleRnrState() const { return kTRUE; }
+   Bool_t SingleRnrState() const override { return kTRUE; }
 
-   virtual void   AddStamp(UChar_t bits);
+   void   AddStamp(UChar_t bits) override;
 
-   virtual Bool_t AcceptElement(TEveElement* el);
-   virtual Bool_t HandleElementPaste(TEveElement* el);
+   Bool_t AcceptElement(TEveElement* el) override;
+   Bool_t HandleElementPaste(TEveElement* el) override;
 
-   ClassDef(TEveSceneInfo, 0); // TEveUtil representation of TGLSceneInfo.
+   ClassDefOverride(TEveSceneInfo, 0); // TEveUtil representation of TGLSceneInfo.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveSelection.h
+++ b/graf3d/eve/inc/TEveSelection.h
@@ -57,7 +57,7 @@ protected:
 
 public:
    TEveSelection(const char* n="TEveSelection", const char* t="");
-   virtual ~TEveSelection() {}
+   ~TEveSelection() override {}
 
    void SetHighlightMode();
 
@@ -67,13 +67,13 @@ public:
    Bool_t GetIsMaster()       const { return fIsMaster; }
    void   SetIsMaster(Bool_t m)     { fIsMaster = m; }
 
-   virtual Bool_t AcceptElement(TEveElement* el);
+   Bool_t AcceptElement(TEveElement* el) override;
 
-   virtual void AddElement(TEveElement* el);
-   virtual void RemoveElement(TEveElement* el);
-   virtual void RemoveElementLocal(TEveElement* el);
-   virtual void RemoveElements();
-   virtual void RemoveElementsLocal();
+   void AddElement(TEveElement* el) override;
+   void RemoveElement(TEveElement* el) override;
+   void RemoveElementLocal(TEveElement* el) override;
+   void RemoveElements() override;
+   void RemoveElementsLocal() override;
 
    virtual void RemoveImpliedSelected(TEveElement* el);
 
@@ -101,7 +101,7 @@ public:
 
    // ----------------------------------------------------------------
 
-   ClassDef(TEveSelection, 0); // Container for selected and highlighted elements.
+   ClassDefOverride(TEveSelection, 0); // Container for selected and highlighted elements.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveShape.h
+++ b/graf3d/eve/inc/TEveShape.h
@@ -45,10 +45,10 @@ protected:
 
 public:
    TEveShape(const char* n="TEveShape", const char* t="");
-   virtual ~TEveShape();
+   ~TEveShape() override;
 
    // Rendering parameters.
-   virtual void    SetMainColor(Color_t color);
+   void    SetMainColor(Color_t color) override;
 
    virtual Color_t GetFillColor() const { return fFillColor; }
    virtual Color_t GetLineColor() const { return fLineColor; }
@@ -66,13 +66,13 @@ public:
 
    // ----------------------------------------------------------------
 
-   virtual void CopyVizParams(const TEveElement* el);
-   virtual void WriteVizParams(std::ostream& out, const TString& var);
+   void CopyVizParams(const TEveElement* el) override;
+   void WriteVizParams(std::ostream& out, const TString& var) override;
 
    // ----------------------------------------------------------------
 
    // Virtual from TObject
-   virtual void Paint(Option_t* option="");
+   void Paint(Option_t* option="") override;
 
    // Abstract function from TAttBBox:
    // virtual void ComputeBBox();
@@ -90,7 +90,7 @@ public:
    static void   CheckAndFixBoxOrientationEv(TEveVector box[8]);
    static void   CheckAndFixBoxOrientationFv(Float_t    box[8][3]);
 
-   ClassDef(TEveShape, 0); // Abstract base-class for 2D/3D shapes.
+   ClassDefOverride(TEveShape, 0); // Abstract base-class for 2D/3D shapes.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveShapeEditor.h
+++ b/graf3d/eve/inc/TEveShapeEditor.h
@@ -38,16 +38,16 @@ protected:
 public:
    TEveShapeEditor(const TGWindow *p = nullptr, Int_t width=170, Int_t height=30,
          UInt_t options=kChildFrame, Pixel_t back=GetDefaultFrameBackground());
-   virtual ~TEveShapeEditor() {}
+   ~TEveShapeEditor() override {}
 
-   virtual void SetModel(TObject* obj);
+   void SetModel(TObject* obj) override;
 
    void DoLineWidth();
    void DoLineColor(Pixel_t color);
    void DoDrawFrame();
    void DoHighlightFrame();
 
-   ClassDef(TEveShapeEditor, 0); // GUI editor for TEveShape.
+   ClassDefOverride(TEveShapeEditor, 0); // GUI editor for TEveShape.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveStraightLineSet.h
+++ b/graf3d/eve/inc/TEveStraightLineSet.h
@@ -85,9 +85,9 @@ protected:
 
 public:
    TEveStraightLineSet(const char* n="StraightLineSet", const char* t="");
-   virtual ~TEveStraightLineSet() {}
+   ~TEveStraightLineSet() override {}
 
-   virtual void SetLineColor(Color_t col) { SetMainColor(col); }
+   void SetLineColor(Color_t col) override { SetMainColor(col); }
 
    Line_t*   AddLine(Float_t x1, Float_t y1, Float_t z1, Float_t x2, Float_t y2, Float_t z2);
    Line_t*   AddLine(const TEveVector& p1, const TEveVector& p2);
@@ -109,15 +109,15 @@ public:
    virtual void SetRnrLines(Bool_t x)   { fRnrLines   = x; }
    virtual void SetDepthTest(Bool_t x)  { fDepthTest   = x; }
 
-   virtual void CopyVizParams(const TEveElement* el);
-   virtual void WriteVizParams(std::ostream& out, const TString& var);
+   void CopyVizParams(const TEveElement* el) override;
+   void WriteVizParams(std::ostream& out, const TString& var) override;
 
-   virtual TClass* ProjectedClass(const TEveProjection* p) const;
+   TClass* ProjectedClass(const TEveProjection* p) const override;
 
-   virtual void ComputeBBox();
-   virtual void Paint(Option_t* option="");
+   void ComputeBBox() override;
+   void Paint(Option_t* option="") override;
 
-   ClassDef(TEveStraightLineSet, 0); // Set of straight lines with optional markers along the lines.
+   ClassDefOverride(TEveStraightLineSet, 0); // Set of straight lines with optional markers along the lines.
 };
 
 
@@ -131,17 +131,17 @@ private:
    TEveStraightLineSetProjected& operator=(const TEveStraightLineSetProjected&); // Not implemented
 
 protected:
-   virtual void SetDepthLocal(Float_t d);
+   void SetDepthLocal(Float_t d) override;
 
 public:
    TEveStraightLineSetProjected();
-   virtual ~TEveStraightLineSetProjected() {}
+   ~TEveStraightLineSetProjected() override {}
 
-   virtual void SetProjection(TEveProjectionManager* mng, TEveProjectable* model);
-   virtual void UpdateProjection();
-   virtual TEveElement* GetProjectedAsElement() { return this; }
+   void SetProjection(TEveProjectionManager* mng, TEveProjectable* model) override;
+   void UpdateProjection() override;
+   TEveElement* GetProjectedAsElement() override { return this; }
 
-   ClassDef(TEveStraightLineSetProjected, 0); // Projected copy of a TEveStraightLineSet.
+   ClassDefOverride(TEveStraightLineSetProjected, 0); // Projected copy of a TEveStraightLineSet.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveStraightLineSetEditor.h
+++ b/graf3d/eve/inc/TEveStraightLineSetEditor.h
@@ -35,15 +35,15 @@ protected:
 
 public:
    TEveStraightLineSetEditor(const TGWindow *p = nullptr, Int_t width=170, Int_t height=30, UInt_t options = kChildFrame, Pixel_t back=GetDefaultFrameBackground());
-   virtual ~TEveStraightLineSetEditor() {}
+   ~TEveStraightLineSetEditor() override {}
 
-   virtual void SetModel(TObject* obj);
+   void SetModel(TObject* obj) override;
 
    // Declare callback/slot methods
    void DoRnrMarkers();
    void DoRnrLines();
 
-   ClassDef(TEveStraightLineSetEditor, 0); // Editor for TEveStraightLineSet class.
+   ClassDefOverride(TEveStraightLineSetEditor, 0); // Editor for TEveStraightLineSet class.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveStraightLineSetGL.h
+++ b/graf3d/eve/inc/TEveStraightLineSetGL.h
@@ -30,20 +30,20 @@ protected:
 
 public:
    TEveStraightLineSetGL();
-   virtual ~TEveStraightLineSetGL() {}
+   ~TEveStraightLineSetGL() override {}
 
-   virtual Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr);
-   virtual void   SetBBox();
-   virtual void   Draw(TGLRnrCtx& rnrCtx) const;
-   virtual void   DirectDraw(TGLRnrCtx& rnrCtx) const;
+   Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr) override;
+   void   SetBBox() override;
+   void   Draw(TGLRnrCtx& rnrCtx) const override;
+   void   DirectDraw(TGLRnrCtx& rnrCtx) const override;
 
-   virtual Bool_t IgnoreSizeForOfInterest() const { return kTRUE; }
+   Bool_t IgnoreSizeForOfInterest() const override { return kTRUE; }
 
-   virtual Bool_t ShouldDLCache(const TGLRnrCtx& rnrCtx) const;
-   virtual Bool_t SupportsSecondarySelect() const { return kTRUE; }
-   virtual void ProcessSelection(TGLRnrCtx& rnrCtx, TGLSelectRecord& rec);
+   Bool_t ShouldDLCache(const TGLRnrCtx& rnrCtx) const override;
+   Bool_t SupportsSecondarySelect() const override { return kTRUE; }
+   void ProcessSelection(TGLRnrCtx& rnrCtx, TGLSelectRecord& rec) override;
 
-   ClassDef(TEveStraightLineSetGL, 0); // GL-renderer for TEveStraightLineSet class.
+   ClassDefOverride(TEveStraightLineSetGL, 0); // GL-renderer for TEveStraightLineSet class.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveText.h
+++ b/graf3d/eve/inc/TEveText.h
@@ -44,7 +44,7 @@ protected:
 
 public:
    TEveText(const char* txt="");
-   virtual ~TEveText() {}
+   ~TEveText() override {}
 
    Int_t   GetFontSize() const { return fFontSize; }
    Int_t   GetFontFile() const { return fFontFile; }
@@ -69,12 +69,12 @@ public:
    Float_t  GetPolygonOffset(Int_t i) const { return fPolygonOffset[i]; }
    void     SetPolygonOffset(Float_t factor, Float_t units);
 
-   virtual void   Paint(Option_t* option="");
-   virtual void   ComputeBBox();
+   void   Paint(Option_t* option="") override;
+   void   ComputeBBox() override;
 
-   virtual const TGPicture* GetListTreeIcon(Bool_t open=kFALSE);
+   const TGPicture* GetListTreeIcon(Bool_t open=kFALSE) override;
 
-   ClassDef(TEveText, 0); // Class for visualisation of text with FTGL font.
+   ClassDefOverride(TEveText, 0); // Class for visualisation of text with FTGL font.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveTextEditor.h
+++ b/graf3d/eve/inc/TEveTextEditor.h
@@ -44,9 +44,9 @@ protected:
 public:
    TEveTextEditor(const TGWindow *p = nullptr, Int_t width=170, Int_t height=30,
                   UInt_t options=kChildFrame, Pixel_t back=GetDefaultFrameBackground());
-   virtual ~TEveTextEditor() {}
+   ~TEveTextEditor() override {}
 
-   virtual void SetModel(TObject* obj);
+   void SetModel(TObject* obj) override;
 
    void DoText(const char*);
 
@@ -58,7 +58,7 @@ public:
    void DoAutoLighting();
    void DoExtrude();
 
-   ClassDef(TEveTextEditor, 0); // GUI editor for TEveText.
+   ClassDefOverride(TEveTextEditor, 0); // GUI editor for TEveText.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveTextGL.h
+++ b/graf3d/eve/inc/TEveTextGL.h
@@ -30,14 +30,14 @@ protected:
 
 public:
    TEveTextGL();
-   virtual ~TEveTextGL() {}
+   ~TEveTextGL() override {}
 
-   virtual Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr);
-   virtual void   SetBBox();
+   Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr) override;
+   void   SetBBox() override;
 
-   virtual void DirectDraw(TGLRnrCtx & rnrCtx) const;
+   void DirectDraw(TGLRnrCtx & rnrCtx) const override;
 
-   ClassDef(TEveTextGL, 0); // GL renderer class for TEveText.
+   ClassDefOverride(TEveTextGL, 0); // GL renderer class for TEveText.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveTrack.h
+++ b/graf3d/eve/inc/TEveTrack.h
@@ -70,9 +70,9 @@ public:
    TEveTrack(TEveRecTrack* t, TEveTrackPropagator* prop=nullptr);
    TEveTrack(TEveRecTrackD* t, TEveTrackPropagator* prop=nullptr);
    TEveTrack(const TEveTrack& t);
-   virtual ~TEveTrack();
+   ~TEveTrack() override;
 
-   virtual void ComputeBBox();
+   void ComputeBBox() override;
 
    virtual void SetStdTitle();
 
@@ -120,14 +120,14 @@ public:
 
    virtual void SecSelected(TEveTrack*); // *SIGNAL*
 
-   virtual const TGPicture* GetListTreeIcon(Bool_t open=kFALSE);
+   const TGPicture* GetListTreeIcon(Bool_t open=kFALSE) override;
 
-   virtual void CopyVizParams(const TEveElement* el);
-   virtual void WriteVizParams(std::ostream& out, const TString& var);
+   void CopyVizParams(const TEveElement* el) override;
+   void WriteVizParams(std::ostream& out, const TString& var) override;
 
-   virtual TClass* ProjectedClass(const TEveProjection* p) const;
+   TClass* ProjectedClass(const TEveProjection* p) const override;
 
-   ClassDef(TEveTrack, 0); // Track with given vertex, momentum and optional referece-points (path-marks) along its path.
+   ClassDefOverride(TEveTrack, 0); // Track with given vertex, momentum and optional referece-points (path-marks) along its path.
 };
 
 /******************************************************************************/
@@ -166,7 +166,7 @@ protected:
 public:
    TEveTrackList(TEveTrackPropagator* prop=nullptr);
    TEveTrackList(const char* name, TEveTrackPropagator* prop=nullptr);
-   virtual ~TEveTrackList();
+   ~TEveTrackList() override;
 
    void  MakeTracks(Bool_t recurse=kTRUE);
    void  FindMomentumLimits(Bool_t recurse=kTRUE);
@@ -179,19 +179,19 @@ public:
 
    //--------------------------------
 
-   virtual void   SetMainColor(Color_t c);
-   virtual void   SetLineColor(Color_t c) { SetMainColor(c); }
+   void   SetMainColor(Color_t c) override;
+   void   SetLineColor(Color_t c) override { SetMainColor(c); }
    virtual void   SetLineColor(Color_t c, TEveElement* el);
-   virtual void   SetLineWidth(Width_t w);
+   void   SetLineWidth(Width_t w) override;
    virtual void   SetLineWidth(Width_t w, TEveElement* el);
-   virtual void   SetLineStyle(Style_t s);
+   void   SetLineStyle(Style_t s) override;
    virtual void   SetLineStyle(Style_t s, TEveElement* el);
 
-   virtual void   SetMarkerColor(Color_t c);
+   void   SetMarkerColor(Color_t c) override;
    virtual void   SetMarkerColor(Color_t c, TEveElement* el);
-   virtual void   SetMarkerSize(Size_t s);
+   void   SetMarkerSize(Size_t s) override;
    virtual void   SetMarkerSize(Size_t s, TEveElement* el);
-   virtual void   SetMarkerStyle(Style_t s);
+   void   SetMarkerStyle(Style_t s) override;
    virtual void   SetMarkerStyle(Style_t s, TEveElement* el);
 
    void   SetRnrLine(Bool_t rnr);
@@ -219,12 +219,12 @@ public:
    TEveTrack* FindTrackByLabel(Int_t label); // *MENU*
    TEveTrack* FindTrackByIndex(Int_t index); // *MENU*
 
-   virtual void CopyVizParams(const TEveElement* el);
-   virtual void WriteVizParams(std::ostream& out, const TString& var);
+   void CopyVizParams(const TEveElement* el) override;
+   void WriteVizParams(std::ostream& out, const TString& var) override;
 
-   virtual TClass* ProjectedClass(const TEveProjection* p) const;
+   TClass* ProjectedClass(const TEveProjection* p) const override;
 
-   ClassDef(TEveTrackList, 0); // A list of tracks supporting change of common attributes and selection based on track parameters.
+   ClassDefOverride(TEveTrackList, 0); // A list of tracks supporting change of common attributes and selection based on track parameters.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveTrackEditor.h
+++ b/graf3d/eve/inc/TEveTrackEditor.h
@@ -42,12 +42,12 @@ protected:
 public:
    TEveTrackEditor(const TGWindow *p = nullptr, Int_t width=170, Int_t height=30,
                    UInt_t options=kChildFrame, Pixel_t back=GetDefaultFrameBackground());
-   virtual ~TEveTrackEditor() {}
+   ~TEveTrackEditor() override {}
 
-   virtual void SetModel(TObject* obj);
+   void SetModel(TObject* obj) override;
    void DoEditPropagator();
 
-   ClassDef(TEveTrackEditor, 0); // Editor for TEveTrack class.
+   ClassDefOverride(TEveTrackEditor, 0); // Editor for TEveTrack class.
 };
 
 
@@ -78,10 +78,10 @@ protected:
 public:
    TEveTrackListEditor(const TGWindow *p = nullptr, Int_t width=170, Int_t height=30,
                        UInt_t options=kChildFrame, Pixel_t back=GetDefaultFrameBackground());
-   virtual ~TEveTrackListEditor() {}
+   ~TEveTrackListEditor() override {}
 
    void CreateRefsTab();
-   virtual void SetModel(TObject* obj);
+   void SetModel(TObject* obj) override;
 
    void DoRnrLine();
    void DoRnrPoints();
@@ -89,7 +89,7 @@ public:
    void DoPtRange();
    void DoPRange();
 
-   ClassDef(TEveTrackListEditor, 0); // Editor for TEveTrackList class.
+   ClassDefOverride(TEveTrackListEditor, 0); // Editor for TEveTrackList class.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveTrackGL.h
+++ b/graf3d/eve/inc/TEveTrackGL.h
@@ -32,15 +32,15 @@ protected:
 
 public:
    TEveTrackGL();
-   virtual ~TEveTrackGL() {}
+   ~TEveTrackGL() override {}
 
-   virtual Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr);
-   virtual void   DirectDraw(TGLRnrCtx & rnrCtx) const;
+   Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr) override;
+   void   DirectDraw(TGLRnrCtx & rnrCtx) const override;
 
-   virtual Bool_t SupportsSecondarySelect() const { return kTRUE; }
-   virtual void   ProcessSelection(TGLRnrCtx& rnrCtx, TGLSelectRecord& rec);
+   Bool_t SupportsSecondarySelect() const override { return kTRUE; }
+   void   ProcessSelection(TGLRnrCtx& rnrCtx, TGLSelectRecord& rec) override;
 
-   ClassDef(TEveTrackGL, 0); // GL-renderer for TEveTrack class.
+   ClassDefOverride(TEveTrackGL, 0); // GL-renderer for TEveTrack class.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveTrackProjected.h
+++ b/graf3d/eve/inc/TEveTrackProjected.h
@@ -32,24 +32,24 @@ private:
 protected:
    std::vector<Int_t>   fBreakPoints; // indices of track break-points
 
-   virtual void SetDepthLocal(Float_t d);
+   void SetDepthLocal(Float_t d) override;
 
 public:
    TEveTrackProjected();
-   virtual ~TEveTrackProjected() {}
+   ~TEveTrackProjected() override {}
 
-   virtual void SetProjection(TEveProjectionManager* mng, TEveProjectable* model);
+   void SetProjection(TEveProjectionManager* mng, TEveProjectable* model) override;
 
-   virtual void UpdateProjection();
-   virtual TEveElement* GetProjectedAsElement() { return this; }
-   virtual void MakeTrack(Bool_t recurse=kTRUE);
+   void UpdateProjection() override;
+   TEveElement* GetProjectedAsElement() override { return this; }
+   void MakeTrack(Bool_t recurse=kTRUE) override;
 
 
    void         PrintLineSegments();
 
-   virtual void SecSelected(TEveTrack*); // marked as signal in TEveTrack
+   void SecSelected(TEveTrack*) override; // marked as signal in TEveTrack
 
-   ClassDef(TEveTrackProjected, 0); // Projected copy of a TEveTrack.
+   ClassDefOverride(TEveTrackProjected, 0); // Projected copy of a TEveTrack.
 };
 
 
@@ -65,20 +65,20 @@ private:
    TEveTrackListProjected& operator=(const TEveTrackListProjected&); // Not implemented
 
 protected:
-   virtual void SetDepthLocal(Float_t d);
+   void SetDepthLocal(Float_t d) override;
 
 public:
    TEveTrackListProjected();
-   virtual ~TEveTrackListProjected() {}
+   ~TEveTrackListProjected() override {}
 
-   virtual void SetProjection(TEveProjectionManager* proj, TEveProjectable* model);
-   virtual void UpdateProjection()  {}
-   virtual TEveElement* GetProjectedAsElement() { return this; }
+   void SetProjection(TEveProjectionManager* proj, TEveProjectable* model) override;
+   void UpdateProjection() override  {}
+   TEveElement* GetProjectedAsElement() override { return this; }
 
-   virtual void SetDepth(Float_t d);
+   void SetDepth(Float_t d) override;
    virtual void SetDepth(Float_t d, TEveElement* el);
 
-   ClassDef(TEveTrackListProjected, 0); // Specialization of TEveTrackList for holding TEveTrackProjected objects.
+   ClassDefOverride(TEveTrackListProjected, 0); // Specialization of TEveTrackList for holding TEveTrackProjected objects.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveTrackProjectedGL.h
+++ b/graf3d/eve/inc/TEveTrackProjectedGL.h
@@ -30,12 +30,12 @@ protected:
 
 public:
    TEveTrackProjectedGL();
-   virtual ~TEveTrackProjectedGL() {}
+   ~TEveTrackProjectedGL() override {}
 
-   virtual Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr);
-   virtual void   DirectDraw(TGLRnrCtx & rnrCtx) const;
+   Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr) override;
+   void   DirectDraw(TGLRnrCtx & rnrCtx) const override;
 
-   ClassDef(TEveTrackProjectedGL, 0); // GL-renderer for TEveTrackProjected class.
+   ClassDefOverride(TEveTrackProjectedGL, 0); // GL-renderer for TEveTrackProjected class.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveTrackPropagator.h
+++ b/graf3d/eve/inc/TEveTrackPropagator.h
@@ -76,12 +76,12 @@ public:
    TEveMagFieldConst(Double_t x, Double_t y, Double_t z) :
       TEveMagField(), fB(x, y, z)
    { fFieldConstant = kTRUE; }
-   virtual ~TEveMagFieldConst() {}
+   ~TEveMagFieldConst() override {}
 
-   virtual Double_t    GetMaxFieldMagD() const { return fB.Mag(); };
-   virtual TEveVectorD GetFieldD(Double_t /*x*/, Double_t /*y*/, Double_t /*z*/) const { return fB; }
+   Double_t    GetMaxFieldMagD() const override { return fB.Mag(); };
+   TEveVectorD GetFieldD(Double_t /*x*/, Double_t /*y*/, Double_t /*z*/) const override { return fB; }
 
-   ClassDef(TEveMagFieldConst, 0); // Interface to constant magnetic field.
+   ClassDefOverride(TEveMagFieldConst, 0); // Interface to constant magnetic field.
 };
 
 
@@ -103,14 +103,14 @@ public:
    {
       fFieldConstant = kFALSE;
    }
-   virtual ~TEveMagFieldDuo() {}
+   ~TEveMagFieldDuo() override {}
 
-   virtual Double_t GetMaxFieldMagD() const { return std::max(fBIn.Mag(), fBOut.Mag()); }
+   Double_t GetMaxFieldMagD() const override { return std::max(fBIn.Mag(), fBOut.Mag()); }
 
-   virtual TEveVectorD GetFieldD(Double_t x, Double_t y, Double_t /*z*/) const
+   TEveVectorD GetFieldD(Double_t x, Double_t y, Double_t /*z*/) const override
    { return  ((x*x+y*y)<fR2) ? fBIn : fBOut; }
 
-   ClassDef(TEveMagFieldDuo, 0); // Interface to magnetic field with two different values depending on radius.
+   ClassDefOverride(TEveMagFieldDuo, 0); // Interface to magnetic field with two different values depending on radius.
 };
 
 
@@ -245,13 +245,13 @@ protected:
 public:
    TEveTrackPropagator(const char* n="TEveTrackPropagator", const char* t="",
                        TEveMagField* field=nullptr, Bool_t own_field=kTRUE);
-   virtual ~TEveTrackPropagator();
+   ~TEveTrackPropagator() override;
 
-   virtual void OnZeroRefCount();
+   void OnZeroRefCount() override;
 
-   virtual void CheckReferenceCount(const TEveException& eh="TEveElement::CheckReferenceCount ");
+   void CheckReferenceCount(const TEveException& eh="TEveElement::CheckReferenceCount ") override;
 
-   virtual void ElementChanged(Bool_t update_scenes=kTRUE, Bool_t redraw=kFALSE);
+   void ElementChanged(Bool_t update_scenes=kTRUE, Bool_t redraw=kFALSE) override;
 
    // propagation
    void   InitTrack(const TEveVectorD& v, Int_t charge);
@@ -345,7 +345,7 @@ public:
    static Double_t             fgEditorMaxR;  // Max R that can be set in GUI editor.
    static Double_t             fgEditorMaxZ;  // Max Z that can be set in GUI editor.
 
-   ClassDef(TEveTrackPropagator, 0); // Calculates path of a particle taking into account special path-marks and imposed boundaries.
+   ClassDefOverride(TEveTrackPropagator, 0); // Calculates path of a particle taking into account special path-marks and imposed boundaries.
 };
 
 //______________________________________________________________________________

--- a/graf3d/eve/inc/TEveTrackPropagatorEditor.h
+++ b/graf3d/eve/inc/TEveTrackPropagatorEditor.h
@@ -71,7 +71,7 @@ protected:
 
 public:
    TEveTrackPropagatorSubEditor(const TGWindow* p);
-   virtual ~TEveTrackPropagatorSubEditor() {}
+   ~TEveTrackPropagatorSubEditor() override {}
 
    void SetModel(TEveTrackPropagator* m);
 
@@ -93,7 +93,7 @@ public:
 
    void CreateRefsContainer(TGVerticalFrame* p);
 
-   ClassDef(TEveTrackPropagatorSubEditor, 0); // Sub-editor for TEveTrackPropagator class.
+   ClassDefOverride(TEveTrackPropagatorSubEditor, 0); // Sub-editor for TEveTrackPropagator class.
 };
 
 /******************************************************************************/
@@ -114,11 +114,11 @@ protected:
 public:
    TEveTrackPropagatorEditor(const TGWindow *p = nullptr, Int_t width=170, Int_t height=30,
                              UInt_t options=kChildFrame, Pixel_t back=GetDefaultFrameBackground());
-   virtual ~TEveTrackPropagatorEditor() {}
+   ~TEveTrackPropagatorEditor() override {}
 
-   virtual void SetModel(TObject* obj);
+   void SetModel(TObject* obj) override;
 
-   ClassDef(TEveTrackPropagatorEditor, 0); // Editor for TEveTrackPropagator class.
+   ClassDefOverride(TEveTrackPropagatorEditor, 0); // Editor for TEveTrackPropagator class.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveTrans.h
+++ b/graf3d/eve/inc/TEveTrans.h
@@ -50,7 +50,7 @@ public:
    TEveTrans(const TEveTrans& t);
    TEveTrans(const Double_t arr[16]);
    TEveTrans(const Float_t  arr[16]);
-   virtual ~TEveTrans() {}
+   ~TEveTrans() override {}
 
    // General operations
 
@@ -156,7 +156,7 @@ public:
    void     RotateIP(Float_t*  v) const;
    TVector3 Rotate(const TVector3& v) const;
 
-   virtual void Print(Option_t* option = "") const;
+   void Print(Option_t* option = "") const override;
 
    // TEveUtil stuff
 
@@ -178,7 +178,7 @@ public:
 
    Bool_t IsScale(Double_t low=0.9, Double_t high=1.1) const;
 
-   ClassDef(TEveTrans, 1); // Column-major 4x4 transforamtion matrix for homogeneous coordinates.
+   ClassDefOverride(TEveTrans, 1); // Column-major 4x4 transforamtion matrix for homogeneous coordinates.
 };
 
 std::ostream& operator<<(std::ostream& s, const TEveTrans& t);

--- a/graf3d/eve/inc/TEveTransEditor.h
+++ b/graf3d/eve/inc/TEveTransEditor.h
@@ -45,7 +45,7 @@ protected:
 
 public:
    TEveTransSubEditor(TGWindow* p);
-   virtual ~TEveTransSubEditor() {}
+   ~TEveTransSubEditor() override {}
 
    void SetModel(TEveTrans* t);
    void SetTransFromData();
@@ -61,7 +61,7 @@ public:
    TEveGTriVecValuator*  GetRotValuator(){ return fRot;}
    TEveGTriVecValuator*  GetScaleValuator(){ return fScale;}
 
-   ClassDef(TEveTransSubEditor, 0); // Sub-editor for TEveTrans class.
+   ClassDefOverride(TEveTransSubEditor, 0); // Sub-editor for TEveTrans class.
 };
 
 
@@ -77,11 +77,11 @@ protected:
 
 public:
    TEveTransEditor(const TGWindow *p = nullptr, Int_t width=170, Int_t height=30, UInt_t options = kChildFrame, Pixel_t back=GetDefaultFrameBackground());
-   virtual ~TEveTransEditor() {}
+   ~TEveTransEditor() override {}
 
-   virtual void SetModel(TObject* obj);
+   void SetModel(TObject* obj) override;
 
-   ClassDef(TEveTransEditor, 0); // Editor for TEveTrans class.
+   ClassDefOverride(TEveTransEditor, 0); // Editor for TEveTrans class.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveTreeTools.h
+++ b/graf3d/eve/inc/TEveTreeTools.h
@@ -30,10 +30,10 @@ protected:
 public:
    TEveSelectorToEventList(TEventList* evl, const char* sel);
 
-   virtual Int_t  Version() const { return 1; }
-   virtual Bool_t Process(Long64_t entry);
+   Int_t  Version() const override { return 1; }
+   Bool_t Process(Long64_t entry) override;
 
-   ClassDef(TEveSelectorToEventList, 2); // TSelector that stores entry numbers of matching TTree entries into an event-list.
+   ClassDefOverride(TEveSelectorToEventList, 2); // TSelector that stores entry numbers of matching TTree entries into an event-list.
 };
 
 /******************************************************************************/
@@ -83,11 +83,11 @@ protected:
 public:
    TEvePointSelector(TTree* t=nullptr, TEvePointSelectorConsumer* c=nullptr,
                      const char* vexp="", const char* sel="");
-   virtual ~TEvePointSelector() {}
+   ~TEvePointSelector() override {}
 
    virtual Long64_t Select(const char* selection=nullptr);
    virtual Long64_t Select(TTree* t, const char* selection=nullptr);
-   virtual void  TakeAction();
+   void  TakeAction() override;
 
 
    TTree* GetTree() const   { return fSelectTree; }
@@ -107,7 +107,7 @@ public:
 
    Int_t GetSubIdNum() const { return fSubIdNum; }
 
-   ClassDef(TEvePointSelector, 2); // TSelector for direct extraction of point-like data from a Tree.
+   ClassDefOverride(TEvePointSelector, 2); // TSelector for direct extraction of point-like data from a Tree.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveTriangleSet.h
+++ b/graf3d/eve/inc/TEveTriangleSet.h
@@ -43,9 +43,9 @@ protected:
 
 public:
    TEveTriangleSet(Int_t nv, Int_t nt, Bool_t norms=kFALSE, Bool_t cols=kFALSE);
-   ~TEveTriangleSet();
+   ~TEveTriangleSet() override;
 
-   virtual Bool_t CanEditMainTransparency() const { return kTRUE; }
+   Bool_t CanEditMainTransparency() const override { return kTRUE; }
 
    Int_t GetNVerts()  const { return fNVerts;  }
    Int_t GetNTrings() const { return fNTrings; }
@@ -67,14 +67,14 @@ public:
    void GenerateZNormalColors(Float_t fac=20, Int_t min=-20, Int_t max=20,
                               Bool_t interp=kFALSE, Bool_t wrap=kFALSE);
 
-   virtual void ComputeBBox();
-   virtual void Paint(Option_t* option="");
+   void ComputeBBox() override;
+   void Paint(Option_t* option="") override;
 
    void SetTransparency(Char_t tr) { SetMainTransparency(tr); } // *MENU*
 
    static TEveTriangleSet* ReadTrivialFile(const char* file);
 
-   ClassDef(TEveTriangleSet, 0); // Generic mesh or soup of triangles with per-triangle normals and colors.
+   ClassDefOverride(TEveTriangleSet, 0); // Generic mesh or soup of triangles with per-triangle normals and colors.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveTriangleSetEditor.h
+++ b/graf3d/eve/inc/TEveTriangleSetEditor.h
@@ -31,11 +31,11 @@ protected:
 
 public:
    TEveTriangleSetEditor(const TGWindow *p = nullptr, Int_t width=170, Int_t height=30, UInt_t options = kChildFrame, Pixel_t back=GetDefaultFrameBackground());
-   virtual ~TEveTriangleSetEditor() {}
+   ~TEveTriangleSetEditor() override {}
 
-   virtual void SetModel(TObject* obj);
+   void SetModel(TObject* obj) override;
 
-   ClassDef(TEveTriangleSetEditor, 0); // Editor for TEveTriangleSet class.
+   ClassDefOverride(TEveTriangleSetEditor, 0); // Editor for TEveTriangleSet class.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveTriangleSetGL.h
+++ b/graf3d/eve/inc/TEveTriangleSetGL.h
@@ -29,17 +29,17 @@ protected:
 
 public:
    TEveTriangleSetGL();
-   virtual ~TEveTriangleSetGL();
+   ~TEveTriangleSetGL() override;
 
-   virtual Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr);
-   virtual void   SetBBox();
-   virtual void   DirectDraw(TGLRnrCtx & rnrCtx) const;
+   Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr) override;
+   void   SetBBox() override;
+   void   DirectDraw(TGLRnrCtx & rnrCtx) const override;
 
    // To support two-level selection
    // virtual Bool_t SupportsSecondarySelect() const { return kTRUE; }
    // virtual void ProcessSelection(UInt_t* ptr, TGLViewer*, TGLScene*);
 
-   ClassDef(TEveTriangleSetGL, 0); // GL-renderer for TEveTriangleSet class.
+   ClassDefOverride(TEveTriangleSetGL, 0); // GL-renderer for TEveTriangleSet class.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveUtil.h
+++ b/graf3d/eve/inc/TEveUtil.h
@@ -106,11 +106,11 @@ public:
    TEveException(const char* s)    : TString(s) {}
    TEveException(const std::string& s);
 
-   virtual ~TEveException() noexcept {}
+   ~TEveException() noexcept override {}
 
-   virtual const char* what() const noexcept { return Data(); }
+   const char* what() const noexcept override { return Data(); }
 
-   ClassDef(TEveException, 1); // Exception-type thrown by Eve classes.
+   ClassDefOverride(TEveException, 1); // Exception-type thrown by Eve classes.
 };
 
 TEveException operator+(const TEveException &s1, const std::string  &s2);
@@ -193,7 +193,7 @@ protected:
 
 public:
    TEveRefBackPtr();
-   virtual ~TEveRefBackPtr();
+   ~TEveRefBackPtr() override;
 
    TEveRefBackPtr(const TEveRefBackPtr&);
    TEveRefBackPtr& operator=(const TEveRefBackPtr&);
@@ -205,7 +205,7 @@ public:
 
    virtual void StampBackPtrElements(UChar_t stamps);
 
-   ClassDef(TEveRefBackPtr, 0); // Base-class for reference-counted objects with reverse references to TEveElement objects.
+   ClassDefOverride(TEveRefBackPtr, 0); // Base-class for reference-counted objects with reverse references to TEveElement objects.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveVSD.h
+++ b/graf3d/eve/inc/TEveVSD.h
@@ -49,7 +49,7 @@ public:
 
 public:
    TEveVSD(const char* name="TEveVSD", const char* title="");
-   virtual ~TEveVSD();
+   ~TEveVSD() override;
 
    virtual void SetDirectory(TDirectory* dir);
 
@@ -64,7 +64,7 @@ public:
 
    static void DisableTObjectStreamersForVSDStruct();
 
-   ClassDef(TEveVSD, 1); // Visualization Summary Data - a collection of trees holding standard event data in experiment independent format.
+   ClassDefOverride(TEveVSD, 1); // Visualization Summary Data - a collection of trees holding standard event data in experiment independent format.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveVSDStructs.h
+++ b/graf3d/eve/inc/TEveVSDStructs.h
@@ -54,14 +54,14 @@ public:
 
    TEveMCTrack() : fLabel(-1), fIndex(-1), fEvaLabel(-1),
                    fDecayed(kFALSE), fTDecay(0), fVDecay(), fPDecay() {}
-   virtual ~TEveMCTrack() {}
+   ~TEveMCTrack() override {}
 
    TEveMCTrack& operator=(const TParticle& p)
    { *((TParticle*)this) = p; return *this; }
 
    void ResetPdgCode() { fPdgCode = 0; }
 
-   ClassDef(TEveMCTrack, 1); // Monte Carlo track (also used in VSD).
+   ClassDefOverride(TEveMCTrack, 1); // Monte Carlo track (also used in VSD).
 };
 
 
@@ -88,9 +88,9 @@ public:
    // Float_t charge; probably specific.
 
    TEveHit() : fDetId(0), fSubdetId(0), fLabel(0), fEvaLabel(0), fV() {}
-   virtual ~TEveHit() {}
+   ~TEveHit() override {}
 
-   ClassDef(TEveHit, 1); // Monte Carlo hit (also used in VSD).
+   ClassDefOverride(TEveHit, 1); // Monte Carlo hit (also used in VSD).
 };
 
 
@@ -116,9 +116,9 @@ public:
    // Coord system? Errors and/or widths Wz, Wy?
 
    TEveCluster() : fDetId(0), fSubdetId(0), fV() { fLabel[0] = fLabel[1] = fLabel[2] = 0; }
-   virtual ~TEveCluster() {}
+   ~TEveCluster() override {}
 
-   ClassDef(TEveCluster, 1); // Reconstructed cluster (also used in VSD).
+   ClassDefOverride(TEveCluster, 1); // Reconstructed cluster (also used in VSD).
 };
 
 
@@ -144,11 +144,11 @@ public:
    // PID data missing
 
    TEveRecTrackT() : fLabel(-1), fIndex(-1), fStatus(0), fSign(0), fV(), fP(), fBeta(0), fDcaXY(0), fDcaZ(0), fPVX(0), fPVY(0), fPVZ(0) {}
-   virtual ~TEveRecTrackT() {}
+   ~TEveRecTrackT() override {}
 
    Float_t Pt() { return fP.Perp(); }
 
-   ClassDef(TEveRecTrackT, 2); // Template for reconstructed track (also used in VSD).
+   ClassDefOverride(TEveRecTrackT, 2); // Template for reconstructed track (also used in VSD).
 };
 
 typedef TEveRecTrackT<Float_t>  TEveRecTrack;
@@ -184,9 +184,9 @@ public:
      fKinkIndex[0] = fKinkIndex[1] = 0;
      fKinkPdg[0]   = fKinkPdg[1]   = 0;
    }
-   virtual ~TEveRecKink() {}
+   ~TEveRecKink() override {}
 
-   ClassDef(TEveRecKink, 1); // Reconstructed kink (also used in VSD).
+   ClassDefOverride(TEveRecKink, 1); // Reconstructed kink (also used in VSD).
 };
 
 
@@ -215,9 +215,9 @@ public:
    TEveRecV0() : fStatus(), fVNeg(), fPNeg(), fVPos(), fPPos(),
                  fVCa(), fV0Birth(), fLabel(0), fPdg(0)
    { fDLabel[0] = fDLabel[1] = 0; }
-   virtual ~TEveRecV0() {}
+   ~TEveRecV0() override {}
 
-   ClassDef(TEveRecV0, 1); // Reconstructed V0 (also used in VSD).
+   ClassDefOverride(TEveRecV0, 1); // Reconstructed V0 (also used in VSD).
 };
 
 
@@ -244,9 +244,9 @@ public:
    TEveRecCascade() : fStatus(),  fVBac(), fPBac(),
                       fCascadeVCa(), fCascadeBirth(),
                       fLabel(0), fPdg(0), fDLabel(0) {}
-   virtual ~TEveRecCascade() {}
+   ~TEveRecCascade() override {}
 
-   ClassDef(TEveRecCascade, 1); // Reconstructed Cascade (also used in VSD).
+   ClassDefOverride(TEveRecCascade, 1); // Reconstructed Cascade (also used in VSD).
 };
 
 
@@ -266,9 +266,9 @@ public:
 
    TEveMCRecCrossRef() : fIsRec(false), fHasV0(false), fHasKink(false),
                          fLabel(0), fNHits(0), fNClus(0) {}
-   virtual ~TEveMCRecCrossRef() {}
+   ~TEveMCRecCrossRef() override {}
 
-   ClassDef(TEveMCRecCrossRef, 1); // Cross-reference of sim/rec data per particle (also used in VSD).
+   ClassDefOverride(TEveMCRecCrossRef, 1); // Cross-reference of sim/rec data per particle (also used in VSD).
 };
 
 

--- a/graf3d/eve/inc/TEveViewer.h
+++ b/graf3d/eve/inc/TEveViewer.h
@@ -43,10 +43,10 @@ protected:
 
 public:
    TEveViewer(const char* n="TEveViewer", const char* t="");
-   virtual ~TEveViewer();
+   ~TEveViewer() override;
 
-   virtual void PreUndock();
-   virtual void PostDock();
+   void PreUndock() override;
+   void PostDock() override;
 
    TGLViewer* GetGLViewer() const { return fGLViewer; }
    void SetGLViewer(TGLViewer* viewer, TGFrame* frame);
@@ -59,16 +59,16 @@ public:
 
    virtual void AddScene(TEveScene* scene);
 
-   virtual void RemoveElementLocal(TEveElement* el);
-   virtual void RemoveElementsLocal();
+   void RemoveElementLocal(TEveElement* el) override;
+   void RemoveElementsLocal() override;
 
-   virtual TObject* GetEditorObject(const TEveException& eh="TEveViewer::GetEditorObject ") const;
+   TObject* GetEditorObject(const TEveException& eh="TEveViewer::GetEditorObject ") const override;
 
-   virtual Bool_t HandleElementPaste(TEveElement* el);
+   Bool_t HandleElementPaste(TEveElement* el) override;
 
-   virtual const TGPicture* GetListTreeIcon(Bool_t open=kFALSE);
+   const TGPicture* GetListTreeIcon(Bool_t open=kFALSE) override;
 
-   ClassDef(TEveViewer, 0); // Reve representation of TGLViewer.
+   ClassDefOverride(TEveViewer, 0); // Reve representation of TGLViewer.
 };
 
 
@@ -92,11 +92,11 @@ protected:
 
 public:
    TEveViewerList(const char* n="TEveViewerList", const char* t="");
-   virtual ~TEveViewerList();
+   ~TEveViewerList() override;
 
-   virtual void AddElement(TEveElement* el);
-   virtual void RemoveElementLocal(TEveElement* el);
-   virtual void RemoveElementsLocal();
+   void AddElement(TEveElement* el) override;
+   void RemoveElementLocal(TEveElement* el) override;
+   void RemoveElementsLocal() override;
 
    // --------------------------------
 
@@ -129,7 +129,7 @@ public:
    Bool_t  UseLightColorSet()   const { return fUseLightColorSet; }
    void    SwitchColorSet();
 
-   ClassDef(TEveViewerList, 0); // List of Viewers providing common operations on TEveViewer collections.
+   ClassDefOverride(TEveViewerList, 0); // List of Viewers providing common operations on TEveViewer collections.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveViewerListEditor.h
+++ b/graf3d/eve/inc/TEveViewerListEditor.h
@@ -32,15 +32,15 @@ protected:
 public:
    TEveViewerListEditor(const TGWindow *p = nullptr, Int_t width=170, Int_t height=30,
          UInt_t options=kChildFrame, Pixel_t back=GetDefaultFrameBackground());
-   virtual ~TEveViewerListEditor() {}
+   ~TEveViewerListEditor() override {}
 
-   virtual void SetModel(TObject* obj);
+   void SetModel(TObject* obj) override;
 
    // Declare callback/slot methods
    void DoBrightness();
    void SwitchColorSet();
 
-   ClassDef(TEveViewerListEditor, 0); // GUI editor for TEveViewerList.
+   ClassDefOverride(TEveViewerListEditor, 0); // GUI editor for TEveViewerList.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveWindow.h
+++ b/graf3d/eve/inc/TEveWindow.h
@@ -74,7 +74,7 @@ protected:
 
 public:
    TEveCompositeFrame(TGCompositeFrame* gui_parent, TEveWindow* eve_parent);
-   virtual ~TEveCompositeFrame();
+   ~TEveCompositeFrame() override;
 
    virtual void WindowNameChanged(const TString& name);
 
@@ -100,7 +100,7 @@ public:
                                 UInt_t mini_bar_height    = 4,
                                 Bool_t allow_top_collapse = kTRUE);
 
-   ClassDef(TEveCompositeFrame, 0); // Composite frame containing eve-window-controls and eve-windows.
+   ClassDefOverride(TEveCompositeFrame, 0); // Composite frame containing eve-window-controls and eve-windows.
 };
 
 
@@ -122,11 +122,11 @@ protected:
 public:
    TEveCompositeFrameInMainFrame(TGCompositeFrame* parent, TEveWindow* eve_parent,
                                  TGMainFrame* mf);
-   virtual ~TEveCompositeFrameInMainFrame();
+   ~TEveCompositeFrameInMainFrame() override;
 
-   virtual void WindowNameChanged(const TString& name);
+   void WindowNameChanged(const TString& name) override;
 
-   virtual void Destroy();
+   void Destroy() override;
 
    void SetOriginalSlotAndContainer(TEveWindow* slot, TEveWindow* container);
 
@@ -136,7 +136,7 @@ public:
    TEveWindow* GetOriginalSlot() const { return fOriginalSlot; }
    TEveWindow* GetOriginalContainer() const { return fOriginalContainer; }
 
-   ClassDef(TEveCompositeFrameInMainFrame, 0); // Eve-composite-frame that is contained in one tab of a TGTab.
+   ClassDefOverride(TEveCompositeFrameInMainFrame, 0); // Eve-composite-frame that is contained in one tab of a TGTab.
 };
 
 
@@ -156,11 +156,11 @@ protected:
 public:
    TEveCompositeFrameInPack(TGCompositeFrame* parent, TEveWindow* eve_parent,
                             TGPack* pack);
-   virtual ~TEveCompositeFrameInPack();
+   ~TEveCompositeFrameInPack() override;
 
-   virtual void Destroy();
+   void Destroy() override;
 
-   ClassDef(TEveCompositeFrameInPack, 0); // Eve-composite-frame that is contained in a TGPack.
+   ClassDefOverride(TEveCompositeFrameInPack, 0); // Eve-composite-frame that is contained in a TGPack.
 };
 
 
@@ -183,15 +183,15 @@ protected:
 public:
    TEveCompositeFrameInTab(TGCompositeFrame* parent, TEveWindow* eve_parent,
                            TGTab* tab);
-   virtual ~TEveCompositeFrameInTab();
+   ~TEveCompositeFrameInTab() override;
 
-   virtual void WindowNameChanged(const TString& name);
+   void WindowNameChanged(const TString& name) override;
 
-   virtual void Destroy();
+   void Destroy() override;
 
-   virtual void SetCurrent(Bool_t curr);
+   void SetCurrent(Bool_t curr) override;
 
-   ClassDef(TEveCompositeFrameInTab, 0); // Eve-composite-frame that is contained in one tab of a TGTab.
+   ClassDefOverride(TEveCompositeFrameInTab, 0); // Eve-composite-frame that is contained in one tab of a TGTab.
 };
 
 
@@ -226,13 +226,13 @@ protected:
    static Pixel_t       fgCurrentBackgroundColor;
    static Pixel_t       fgMiniBarBackgroundColor;
 
-   virtual void PreDeleteElement();
+   void PreDeleteElement() override;
 
 public:
    TEveWindow(const char* n="TEveWindow", const char* t="");
-   virtual ~TEveWindow();
+   ~TEveWindow() override;
 
-   virtual void NameTitleChanged();
+   void NameTitleChanged() override;
 
    virtual TGFrame*        GetGUIFrame() = 0;
    virtual void            PreUndock();
@@ -290,7 +290,7 @@ public:
    static void    SetCurrentBackgroundColor(Pixel_t p);
    static void    SetMiniBarBackgroundColor(Pixel_t p);
 
-   ClassDef(TEveWindow, 0); // Abstract base-class for eve-windows.
+   ClassDefOverride(TEveWindow, 0); // Abstract base-class for eve-windows.
 };
 
 
@@ -308,13 +308,13 @@ protected:
    TGTextButton      *fEmptyButt;
    TGCompositeFrame  *fEmbedBuffer;
 
-   virtual void SetCurrent(Bool_t curr);
+   void SetCurrent(Bool_t curr) override;
 
 public:
    TEveWindowSlot(const char* n="TEveWindowSlot", const char* t="");
-   virtual ~TEveWindowSlot();
+   ~TEveWindowSlot() override;
 
-   virtual TGFrame* GetGUIFrame();
+   TGFrame* GetGUIFrame() override;
 
    TEveWindowPack*   MakePack(); // *MENU*
    TEveWindowTab*    MakeTab();  // *MENU*
@@ -324,7 +324,7 @@ public:
    TGCompositeFrame* StartEmbedding();
    TEveWindowFrame*  StopEmbedding(const char* name=nullptr);
 
-   ClassDef(TEveWindowSlot, 0); // An unoccupied eve-window slot.
+   ClassDefOverride(TEveWindowSlot, 0); // An unoccupied eve-window slot.
 };
 
 
@@ -343,13 +343,13 @@ protected:
 
 public:
    TEveWindowFrame(TGFrame* frame, const char* n="TEveWindowFrame", const char* t="");
-   virtual ~TEveWindowFrame();
+   ~TEveWindowFrame() override;
 
-   virtual TGFrame* GetGUIFrame() { return fGUIFrame; }
+   TGFrame* GetGUIFrame() override { return fGUIFrame; }
 
    TGCompositeFrame* GetGUICompositeFrame();
 
-   ClassDef(TEveWindowFrame, 0); // Eve-window containing any TGFrame.
+   ClassDefOverride(TEveWindowFrame, 0); // Eve-window containing any TGFrame.
 };
 
 
@@ -368,13 +368,13 @@ protected:
 
 public:
    TEveWindowPack(TGPack* p, const char* n="TEveWindowPack", const char* t="");
-   virtual ~TEveWindowPack();
+   ~TEveWindowPack() override;
 
-   virtual TGFrame*        GetGUIFrame();
+   TGFrame*        GetGUIFrame() override;
 
-   virtual Bool_t          CanMakeNewSlots() const { return kTRUE; }
+   Bool_t          CanMakeNewSlots() const override { return kTRUE; }
    virtual TEveWindowSlot* NewSlotWithWeight(Float_t w);
-   virtual TEveWindowSlot* NewSlot(); // *MENU*
+   TEveWindowSlot* NewSlot() override; // *MENU*
 
    void FlipOrientation(); // *MENU*
    void SetVertical(Bool_t x=kTRUE);
@@ -384,7 +384,7 @@ public:
 
    TGPack* GetPack() const { return fPack; }
 
-   ClassDef(TEveWindowPack, 0); // Eve-window containing a TGPack.
+   ClassDefOverride(TEveWindowPack, 0); // Eve-window containing a TGPack.
 };
 
 
@@ -403,16 +403,16 @@ protected:
 
 public:
    TEveWindowTab(TGTab* tab, const char* n="TEveWindowTab", const char* t="");
-   virtual ~TEveWindowTab();
+   ~TEveWindowTab() override;
 
-   virtual TGFrame*        GetGUIFrame();
+   TGFrame*        GetGUIFrame() override;
 
-   virtual Bool_t          CanMakeNewSlots() const { return kTRUE; }
-   virtual TEveWindowSlot* NewSlot(); // *MENU*
+   Bool_t          CanMakeNewSlots() const override { return kTRUE; }
+   TEveWindowSlot* NewSlot() override; // *MENU*
 
    TGTab* GetTab() const { return fTab; }
 
-   ClassDef(TEveWindowTab, 0); // Eve-window containing a TGTab.
+   ClassDefOverride(TEveWindowTab, 0); // Eve-window containing a TGTab.
 };
 
 
@@ -434,7 +434,7 @@ public:
 
    void SetupAndPopup(TGWindow* button, TObject* obj);
 
-   ClassDef(TEveContextMenu, 0) // Specialization of TContextMenu for Eve.
+   ClassDefOverride(TEveContextMenu, 0) // Specialization of TContextMenu for Eve.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveWindowEditor.h
+++ b/graf3d/eve/inc/TEveWindowEditor.h
@@ -35,13 +35,13 @@ protected:
 public:
    TEveWindowEditor(const TGWindow *p = nullptr, Int_t width=170, Int_t height=30,
          UInt_t options=kChildFrame, Pixel_t back=GetDefaultFrameBackground());
-   virtual ~TEveWindowEditor() {}
+   ~TEveWindowEditor() override {}
 
-   virtual void SetModel(TObject* obj);
+   void SetModel(TObject* obj) override;
 
    void DoShowTitleBar();
 
-   ClassDef(TEveWindowEditor, 0); // GUI editor for TEveWindow.
+   ClassDefOverride(TEveWindowEditor, 0); // GUI editor for TEveWindow.
 };
 
 #endif

--- a/graf3d/eve/inc/TEveWindowManager.h
+++ b/graf3d/eve/inc/TEveWindowManager.h
@@ -33,7 +33,7 @@ protected:
 
 public:
    TEveWindowManager(const char* n="TEveWindowManager", const char* t="");
-   virtual ~TEveWindowManager();
+   ~TEveWindowManager() override;
 
    void SelectWindow(TEveWindow* w);
    void DeleteWindow(TEveWindow* w);
@@ -59,7 +59,7 @@ public:
    void ShowNormalEveDecorations();
    void SetShowTitleBars(Bool_t state);
 
-   ClassDef(TEveWindowManager, 0); // Manager for EVE windows.
+   ClassDefOverride(TEveWindowManager, 0); // Manager for EVE windows.
 };
 
 #endif

--- a/graf3d/eve7/inc/ROOT/REveGeoPolyShape.hxx
+++ b/graf3d/eve7/inc/ROOT/REveGeoPolyShape.hxx
@@ -37,7 +37,7 @@ protected:
    std::vector<UInt_t>   fPolyDesc;
    Int_t                 fNbPols{0};
 
-   virtual void FillBuffer3D(TBuffer3D &buffer, Int_t reqSections, Bool_t localFrame) const;
+   void FillBuffer3D(TBuffer3D &buffer, Int_t reqSections, Bool_t localFrame) const override;
 
    void SetFromBuff3D(const TBuffer3D &buffer);
 
@@ -67,7 +67,7 @@ protected:
 public:
    REveGeoPolyShape() = default;
 
-   virtual ~REveGeoPolyShape() = default;
+   ~REveGeoPolyShape() override = default;
 
    Int_t GetNumFaces() const { return fNbPols; }
 
@@ -79,15 +79,15 @@ public:
    void EnforceTriangles();
    void CalculateNormals();
 
-   virtual const TBuffer3D& GetBuffer3D(Int_t reqSections, Bool_t localFrame) const;
-   virtual TBuffer3D *MakeBuffer3D() const;
+   const TBuffer3D& GetBuffer3D(Int_t reqSections, Bool_t localFrame) const override;
+   TBuffer3D *MakeBuffer3D() const override;
 
    static void   SetAutoEnforceTriangles(Bool_t f);
    static Bool_t GetAutoEnforceTriangles();
    static void   SetAutoCalculateNormals(Bool_t f);
    static Bool_t GetAutoCalculateNormals();
 
-   ClassDef(REveGeoPolyShape, 1); // A shape with arbitrary tesselation for visualization of CSG shapes.
+   ClassDefOverride(REveGeoPolyShape, 1); // A shape with arbitrary tesselation for visualization of CSG shapes.
 };
 
 }}

--- a/graf3d/eve7/inc/ROOT/REveGeoShapeExtract.hxx
+++ b/graf3d/eve7/inc/ROOT/REveGeoShapeExtract.hxx
@@ -38,7 +38,7 @@ protected:
 
 public:
    REveGeoShapeExtract(const char *n = "REveGeoShapeExtract", const char *t = nullptr);
-   ~REveGeoShapeExtract();
+   ~REveGeoShapeExtract() override;
 
    Bool_t HasElements();
    void   AddElement(REveGeoShapeExtract* gse);
@@ -63,7 +63,7 @@ public:
    TGeoShape* GetShape()       { return fShape;    }
    TList*     GetElements()    { return fElements; }
 
-   ClassDef(REveGeoShapeExtract, 1); // Globally positioned TGeoShape with rendering attributes and an optional list of daughter shape-extracts.
+   ClassDefOverride(REveGeoShapeExtract, 1); // Globally positioned TGeoShape with rendering attributes and an optional list of daughter shape-extracts.
 };
 
 } // namespace Experimental

--- a/graf3d/eve7/inc/ROOT/REveTrans.hxx
+++ b/graf3d/eve7/inc/ROOT/REveTrans.hxx
@@ -165,7 +165,7 @@ public:
    void RotateIP(Float_t *v) const;
    TVector3 Rotate(const TVector3 &v) const;
 
-   virtual void Print(Option_t *option = "") const;
+   void Print(Option_t *option = "") const override;
 
    // REveUtil stuff
 
@@ -187,7 +187,7 @@ public:
 
    Bool_t IsScale(Double_t low = 0.9, Double_t high = 1.1) const;
 
-   ClassDef(REveTrans, 1); // Column-major 4x4 transforamtion matrix for homogeneous coordinates.
+   ClassDefOverride(REveTrans, 1); // Column-major 4x4 transforamtion matrix for homogeneous coordinates.
 };
 
 std::ostream &operator<<(std::ostream &s, const REveTrans &t);

--- a/graf3d/eve7/inc/ROOT/REveTreeTools.hxx
+++ b/graf3d/eve7/inc/ROOT/REveTreeTools.hxx
@@ -34,12 +34,12 @@ protected:
 
 public:
    REveSelectorToEventList(TEventList *evl, const char *sel);
-   virtual ~REveSelectorToEventList() {}
+   ~REveSelectorToEventList() override {}
 
-   virtual Int_t Version() const { return 1; }
-   virtual Bool_t Process(Long64_t entry);
+   Int_t Version() const override { return 1; }
+   Bool_t Process(Long64_t entry) override;
 
-   ClassDef(REveSelectorToEventList, 2); // TSelector that stores entry numbers of matching TTree entries into an event-list.
+   ClassDefOverride(REveSelectorToEventList, 2); // TSelector that stores entry numbers of matching TTree entries into an event-list.
 };
 
 /////////////////////////////////////////////////////////////////////////////////
@@ -92,11 +92,11 @@ protected:
 
 public:
    REvePointSelector(TTree *t = nullptr, REvePointSelectorConsumer *c = nullptr, const char *vexp = "", const char *sel = "");
-   virtual ~REvePointSelector() {}
+   ~REvePointSelector() override {}
 
    virtual Long64_t Select(const char *selection = nullptr);
    virtual Long64_t Select(TTree *t, const char *selection = nullptr);
-   virtual void TakeAction();
+   void TakeAction() override;
 
    TTree *GetTree() const { return fSelectTree; }
    void SetTree(TTree *t) { fSelectTree = t; }
@@ -115,7 +115,7 @@ public:
 
    Int_t GetSubIdNum() const { return fSubIdNum; }
 
-   ClassDef(REvePointSelector, 2); // TSelector for direct extraction of point-like data from a Tree.
+   ClassDefOverride(REvePointSelector, 2); // TSelector for direct extraction of point-like data from a Tree.
 };
 
 } // namespace Experimental

--- a/graf3d/eve7/inc/ROOT/REveTypes.hxx
+++ b/graf3d/eve7/inc/ROOT/REveTypes.hxx
@@ -43,7 +43,7 @@ class REveException : public std::exception {
 public:
    REveException() = default;
    explicit REveException(const std::string &s) : fWhat(s) {}
-   virtual ~REveException() noexcept {}
+   ~REveException() noexcept override {}
    void append(const std::string &s) { fWhat.append(s); }
 
    const char *what() const noexcept override { return fWhat.c_str(); }

--- a/graf3d/eve7/inc/ROOT/REveUtil.hxx
+++ b/graf3d/eve7/inc/ROOT/REveUtil.hxx
@@ -138,7 +138,7 @@ protected:
 
 public:
    REveRefBackPtr() = default;
-   virtual ~REveRefBackPtr();
+   ~REveRefBackPtr() override;
 
    using REveRefCnt::DecRefCount;
    using REveRefCnt::IncRefCount;

--- a/graf3d/eve7/inc/ROOT/REveVSD.hxx
+++ b/graf3d/eve7/inc/ROOT/REveVSD.hxx
@@ -69,7 +69,7 @@ public:
 
    static void DisableTObjectStreamersForVSDStruct();
 
-   ClassDef(REveVSD, 1); // Visualization Summary Data - a collection of trees holding standard event data in experiment independent format.
+   ClassDefOverride(REveVSD, 1); // Visualization Summary Data - a collection of trees holding standard event data in experiment independent format.
 };
 
 } // namespace Experimental

--- a/graf3d/eve7/inc/ROOT/REveVSDStructs.hxx
+++ b/graf3d/eve7/inc/ROOT/REveVSDStructs.hxx
@@ -65,7 +65,7 @@ public:
 
    void ResetPdgCode() { fPdgCode = 0; }
 
-   ClassDef(REveMCTrack, 1); // Monte Carlo track (also used in VSD).
+   ClassDefOverride(REveMCTrack, 1); // Monte Carlo track (also used in VSD).
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf3d/g3d/inc/TAxis3D.h
+++ b/graf3d/g3d/inc/TAxis3D.h
@@ -42,7 +42,7 @@ protected:
    Bool_t              fZoomMode;   // Zoom mode for the entire parent TPad
    Bool_t              fStickyZoom; // StickyZoom mode:  zoom will not be disabled    after zooming attempt if true
 
-   virtual void        Copy(TObject &hnew) const;
+   void        Copy(TObject &hnew) const override;
    void                InitSet();
    Bool_t              SwitchZoom();
 
@@ -50,12 +50,12 @@ public:
    TAxis3D();
    TAxis3D(Option_t *option);
    TAxis3D(const TAxis3D &axis);
-   virtual ~TAxis3D(){}
+   ~TAxis3D() override{}
 
-   virtual void     Browse(TBrowser *b);
+   void     Browse(TBrowser *b) override;
 
-   virtual Int_t    DistancetoPrimitive(Int_t px, Int_t py);
-   virtual void     ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   Int_t    DistancetoPrimitive(Int_t px, Int_t py) override;
+   void     ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
 
    Bool_t & StickyZoom(){return fStickyZoom;}
    Bool_t & Zoom(){return fZoomMode;}
@@ -74,18 +74,18 @@ public:
 
    virtual void     GetLowEdge(Axis_t *edge) {fAxis[0].GetLowEdge(edge);}
 
-   virtual char    *GetObjectInfo(Int_t px, Int_t py) const;
+   char    *GetObjectInfo(Int_t px, Int_t py) const override;
 
-   Option_t        *GetOption() const {return fOption.Data();}
+   Option_t        *GetOption() const override {return fOption.Data();}
 
    virtual TAxis   *GetXaxis() {return &fAxis[0];}
    virtual TAxis   *GetYaxis() {return &fAxis[1];}
    virtual TAxis   *GetZaxis() {return &fAxis[2];}
-   virtual Bool_t   IsFolder() const { return kTRUE;}
-   virtual void     Paint(Option_t *option="");
+   Bool_t   IsFolder() const override { return kTRUE;}
+   void     Paint(Option_t *option="") override;
    void             PaintAxis(TGaxis *axis, Float_t ang);
    static Double_t *PixeltoXYZ(Double_t px, Double_t py, Double_t *point3D, TView *view = nullptr);
-   virtual void     SavePrimitive(std::ostream &out, Option_t *option = "");
+   void     SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
    virtual void     SetAxisColor(Color_t color=1, Option_t *axis="*"); // *MENU*
    virtual void     SetAxisRange(Double_t xmin, Double_t xmax, Option_t *axis="*");
@@ -104,9 +104,9 @@ public:
    virtual void     SetZTitle(const char *title) {fAxis[2].SetTitle(title);} // *MENU*
    static  TAxis3D *ToggleRulers(TVirtualPad *pad = nullptr);
    static  TAxis3D *ToggleZoom(TVirtualPad *pad = nullptr);
-   void             UseCurrentStyle();
+   void             UseCurrentStyle() override;
 
-   ClassDef(TAxis3D,1)  //3-D ruler painting class
+   ClassDefOverride(TAxis3D,1)  //3-D ruler painting class
 };
 
 

--- a/graf3d/g3d/inc/TBRIK.h
+++ b/graf3d/g3d/inc/TBRIK.h
@@ -30,20 +30,20 @@ protected:
    Float_t fDy;        // half length in y
    Float_t fDz;        // half length in z
 
-   virtual void    SetPoints(Double_t * points) const;
+   void    SetPoints(Double_t * points) const override;
 public:
    TBRIK();
    TBRIK(const char *name, const char *title, const char *material, Float_t dx, Float_t dy, Float_t dz);
-   virtual ~TBRIK();
+   ~TBRIK() override;
 
-   virtual Int_t   DistancetoPrimitive(Int_t px, Int_t py);
-   virtual const TBuffer3D &GetBuffer3D(Int_t reqSections) const;
+   Int_t   DistancetoPrimitive(Int_t px, Int_t py) override;
+   const TBuffer3D &GetBuffer3D(Int_t reqSections) const override;
    Float_t         GetDx() const {return fDx;}
    Float_t         GetDy() const {return fDy;}
    Float_t         GetDz() const {return fDz;}
-   virtual void    Sizeof3D() const;
+   void    Sizeof3D() const override;
 
-   ClassDef(TBRIK,1)  //TBRIK shape
+   ClassDefOverride(TBRIK,1)  //TBRIK shape
 };
 
 #endif

--- a/graf3d/g3d/inc/TCONE.h
+++ b/graf3d/g3d/inc/TCONE.h
@@ -31,18 +31,18 @@ protected:
    Float_t fRmin2;        // inside radius at the high z limit
    Float_t fRmax2;        // outside radius at the high z limit
 
-   virtual void    SetPoints(Double_t *points) const;
+   void    SetPoints(Double_t *points) const override;
 public:
    TCONE();
    TCONE(const char *name, const char *title, const char *material, Float_t dz, Float_t rmin1, Float_t rmax1,
          Float_t rmin2, Float_t rmax2);
    TCONE(const char *name, const char *title, const char *material, Float_t dz, Float_t rmax1, Float_t rmax2 =0);
-   virtual ~TCONE();
+   ~TCONE() override;
 
    Float_t         GetRmin2() const {return fRmin2;}
    Float_t         GetRmax2() const {return fRmax2;}
 
-   ClassDef(TCONE,1)  //CONE shape
+   ClassDefOverride(TCONE,1)  //CONE shape
 };
 
 #endif

--- a/graf3d/g3d/inc/TCONS.h
+++ b/graf3d/g3d/inc/TCONS.h
@@ -30,19 +30,19 @@ protected:
    Float_t fRmin2;        // inside radius at the high z limit
    Float_t fRmax2;        // outside radius at the high z limit
 
-   virtual void    SetPoints(Double_t *points) const;
+   void    SetPoints(Double_t *points) const override;
 public:
    TCONS();
    TCONS(const char *name, const char *title, const char *material, Float_t dz, Float_t rmin1, Float_t rmax1,
          Float_t rmin2, Float_t rmax2, Float_t phi1, Float_t phi2);
    TCONS(const char *name, const char *title, const char *material, Float_t rmax1, Float_t dz
                           , Float_t phi1, Float_t phi2, Float_t rmax2 = 0);
-   virtual ~TCONS();
+   ~TCONS() override;
 
    virtual Float_t GetRmin2() const {return fRmin2;}
    virtual Float_t GetRmax2() const {return fRmax2;}
 
-   ClassDef(TCONS,1)  //CONS shape
+   ClassDefOverride(TCONS,1)  //CONS shape
 };
 
 #endif

--- a/graf3d/g3d/inc/TCTUB.h
+++ b/graf3d/g3d/inc/TCTUB.h
@@ -32,7 +32,7 @@ protected:
    Float_t fCosLow[3];        // dir cosinus of surface cutting tube at low z
    Float_t fCosHigh[3];       // dir cosinus of surface cutting tube at high z
 
-   virtual void    SetPoints(Double_t *points) const;
+   void    SetPoints(Double_t *points) const override;
 public:
    TCTUB();
    TCTUB(const char *name, const char *title, const char *material, Float_t rmin,
@@ -42,9 +42,9 @@ public:
    TCTUB(const char *name, const char *title, const char *material, Float_t rmin,
          Float_t rmax, Float_t dz, Float_t phi1, Float_t phi2,
          Float_t *lowNormal, Float_t *highNormal);
-   virtual ~TCTUB();
+   ~TCTUB() override;
 
-   ClassDef(TCTUB,2)  //The Cut Tube shape
+   ClassDefOverride(TCTUB,2)  //The Cut Tube shape
 };
 
 #endif

--- a/graf3d/g3d/inc/TELTU.h
+++ b/graf3d/g3d/inc/TELTU.h
@@ -33,9 +33,9 @@ class TELTU : public TTUBE {
 public:
    TELTU();
    TELTU(const char *name, const char *title, const char *material, Float_t rx, Float_t ry,Float_t dz);
-   virtual ~TELTU();
+   ~TELTU() override;
 
-   ClassDef(TELTU,1)  //ELTU shape
+   ClassDefOverride(TELTU,1)  //ELTU shape
 };
 
 #endif

--- a/graf3d/g3d/inc/TGTRA.h
+++ b/graf3d/g3d/inc/TGTRA.h
@@ -37,13 +37,13 @@ protected:
    Float_t fTl2;       // half length in x at high z and y high edge
    Float_t fAlpha2;    // angle w.r.t. the y axis
 
-   virtual void    SetPoints(Double_t *points) const;
+   void    SetPoints(Double_t *points) const override;
 public:
    TGTRA();
    TGTRA(const char *name, const char *title, const char *material, Float_t dz, Float_t theta, Float_t phi, Float_t twist, Float_t h1,
          Float_t bl1, Float_t tl1, Float_t alpha1, Float_t h2, Float_t bl2, Float_t tl2,
          Float_t alpha2);
-   virtual ~TGTRA();
+   ~TGTRA() override;
 
    Float_t         GetTwist() const  {return fTwist;}
    Float_t         GetH1() const     {return fH1;}
@@ -55,7 +55,7 @@ public:
    Float_t         GetTl2() const    {return fTl2;}
    Float_t         GetAlpha2() const {return fAlpha2;}
 
-   ClassDef(TGTRA,1)  //GTRA shape
+   ClassDefOverride(TGTRA,1)  //GTRA shape
 };
 
 #endif

--- a/graf3d/g3d/inc/TGeometry.h
+++ b/graf3d/g3d/inc/TGeometry.h
@@ -64,12 +64,12 @@ protected:
 public:
    TGeometry();
    TGeometry(const char *name, const char *title);
-   virtual           ~TGeometry();
-   virtual void      Browse(TBrowser *b);
+             ~TGeometry() override;
+   void      Browse(TBrowser *b) override;
    virtual void      cd(const char *path=nullptr);
-   virtual void      Draw(Option_t *option="");
-   virtual TObject  *FindObject(const char *name) const;
-   virtual TObject  *FindObject(const TObject *obj) const;
+   void      Draw(Option_t *option="") override;
+   TObject  *FindObject(const char *name) const override;
+   TObject  *FindObject(const TObject *obj) const override;
    Float_t           GetBomb() const {return fBomb;}
    Int_t             GeomLevel() const {return fGeomLevel;}
    THashList        *GetListOfShapes() const  {return fShapes;}
@@ -88,17 +88,17 @@ public:
    TRotMatrix       *GetCurrentPosition(Double_t *x,Double_t *y,Double_t *z) const;
    TRotMatrix       *GetCurrentPosition(Float_t *x,Float_t *y,Float_t *z) const;
    Bool_t            GetCurrentReflection() const;
-   Bool_t            IsFolder() const {return kTRUE;}
+   Bool_t            IsFolder() const override {return kTRUE;}
    virtual void      Local2Master(Double_t *local, Double_t *master);
    virtual void      Local2Master(Float_t *local, Float_t *master);
-   virtual void      ls(Option_t *option="rsn2") const;
+   void      ls(Option_t *option="rsn2") const override;
    virtual void      Master2Local(Double_t *master, Double_t *local);
    virtual void      Master2Local(Float_t *master, Float_t *local);
    virtual void      Node(const char *name, const char *title, const char *shapename, Double_t x=0, Double_t y=0, Double_t z=0
                         , const char *matrixname="", Option_t *option="");
    virtual Int_t     PushLevel(){return fGeomLevel++;}
    virtual Int_t     PopLevel(){return fGeomLevel>0?fGeomLevel--:0;}
-   virtual void      RecursiveRemove(TObject *obj);
+   void      RecursiveRemove(TObject *obj) override;
    virtual void      SetBomb(Float_t bomb=1.4) {fBomb = bomb;}
    virtual void      SetCurrentNode(TNode *node) {fCurrentNode = node;}
    virtual void      SetGeomLevel(Int_t level=0){fGeomLevel=level;}
@@ -116,7 +116,7 @@ public:
                                       Double_t x, Double_t y, Double_t z, Double_t *matrix,
                                       Double_t *dxnew, Double_t *rmatnew);
 
-   ClassDef(TGeometry,2)  //Structure for Matrices, Shapes and Nodes
+   ClassDefOverride(TGeometry,2)  //Structure for Matrices, Shapes and Nodes
 };
 
 

--- a/graf3d/g3d/inc/THYPE.h
+++ b/graf3d/g3d/inc/THYPE.h
@@ -34,11 +34,11 @@ public:
    THYPE();
    THYPE(const char *name, const char *title, const char *material, Float_t rmin, Float_t rmax, Float_t dz,
          Float_t phi);
-   virtual ~THYPE();
+   ~THYPE() override;
 
    virtual Float_t GetPhi() const {return fPhi;}
 
-   ClassDef(THYPE,1)  //HYPE shape
+   ClassDefOverride(THYPE,1)  //HYPE shape
 };
 
 #endif

--- a/graf3d/g3d/inc/THelix.h
+++ b/graf3d/g3d/inc/THelix.h
@@ -50,14 +50,14 @@ public:
           Double_t const* range=nullptr, EHelixRangeType rtype=kHelixZ,
           Double_t const* axis=nullptr);
    THelix(const THelix &helix);
-   virtual ~THelix();
+   ~THelix() override;
 
-   virtual void    Copy(TObject &helix) const;
-   virtual void    Draw(Option_t *option="");
-   Option_t       *GetOption() const {return fOption.Data();}
-   virtual void    Print(Option_t *option="") const;
-   virtual void    SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void    SetOption(Option_t *option="") {fOption = option;}
+   void    Copy(TObject &helix) const override;
+   void    Draw(Option_t *option="") override;
+   Option_t       *GetOption() const override {return fOption.Data();}
+   void    Print(Option_t *option="") const override;
+   void    SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void    SetOption(Option_t *option="") override {fOption = option;}
    virtual void    SetAxis(Double_t const* axis);       //Define new axis
    virtual void    SetAxis(Double_t x, Double_t y, Double_t z);
    virtual void    SetRange(Double_t * range, EHelixRangeType rtype=kHelixZ);
@@ -66,7 +66,7 @@ public:
                             Double_t const* range=nullptr, EHelixRangeType type=kUnchanged,
                             Double_t const* axis=nullptr);
 
-   ClassDef(THelix,2)  //A Helix drawn as a PolyLine3D
+   ClassDefOverride(THelix,2)  //A Helix drawn as a PolyLine3D
 };
 
 #endif

--- a/graf3d/g3d/inc/TMarker3DBox.h
+++ b/graf3d/g3d/inc/TMarker3DBox.h
@@ -58,25 +58,25 @@ public:
    TMarker3DBox(Float_t x, Float_t y, Float_t z,
                 Float_t dx, Float_t dy, Float_t dz,
                 Float_t theta, Float_t phi);
-   virtual        ~TMarker3DBox();
+          ~TMarker3DBox() override;
 
-   virtual Int_t   DistancetoPrimitive(Int_t px, Int_t py);
-   virtual void    ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   Int_t   DistancetoPrimitive(Int_t px, Int_t py) override;
+   void    ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
    TObject        *GetRefObject() const {return fRefObject;}
    virtual void    GetDirection(Float_t &theta, Float_t &phi) const {theta = fTheta; phi = fPhi;}
    virtual void    GetPosition(Float_t &x, Float_t &y, Float_t &z) const {x=fX; y=fY, z=fZ;}
    virtual void    GetSize(Float_t &dx, Float_t &dy, Float_t &dz) const {dx=fDx; dy=fDy; dz=fDz;}
 
-   virtual void    Paint(Option_t *option);
+   void    Paint(Option_t *option) override;
    static  void    PaintH3(TH1 *h, Option_t *option);
-   virtual void    SavePrimitive(std::ostream &out, Option_t *option = "");
+   void    SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void    SetPoints(Double_t *buff) const;
    virtual void    SetDirection(Float_t theta, Float_t phi);
    virtual void    SetPosition(Float_t x, Float_t y, Float_t z);
    virtual void    SetSize(Float_t dx, Float_t dy, Float_t dz);
    virtual void    SetRefObject(TObject *obj = nullptr) {fRefObject = obj;}
 
-   ClassDef(TMarker3DBox,2)  //A special 3-D marker designed for event display
+   ClassDefOverride(TMarker3DBox,2)  //A special 3-D marker designed for event display
 };
 
 #endif

--- a/graf3d/g3d/inc/TMaterial.h
+++ b/graf3d/g3d/inc/TMaterial.h
@@ -38,7 +38,7 @@ public:
    TMaterial();
    TMaterial(const char *name, const char *title, Float_t a, Float_t z, Float_t density);
    TMaterial(const char *name, const char *title, Float_t a, Float_t z, Float_t density, Float_t radl, Float_t inter);
-   virtual ~TMaterial();
+   ~TMaterial() override;
    virtual Int_t     GetNumber() const      {return fNumber;}
    virtual Float_t   GetA() const           {return fA;}
    virtual Float_t   GetZ() const           {return fZ;}
@@ -46,7 +46,7 @@ public:
    virtual Float_t   GetRadLength() const   {return fRadLength;}
    virtual Float_t   GetInterLength() const {return fInterLength;}
 
-   ClassDef(TMaterial,3)  //Materials used in the Geometry Shapes
+   ClassDefOverride(TMaterial,3)  //Materials used in the Geometry Shapes
 };
 
 #endif

--- a/graf3d/g3d/inc/TMixture.h
+++ b/graf3d/g3d/inc/TMixture.h
@@ -34,7 +34,7 @@ protected:
 public:
    TMixture();
    TMixture(const char *name, const char *title, Int_t nmixt);
-   virtual ~TMixture();
+   ~TMixture() override;
 
    virtual void  DefineElement(Int_t n, Float_t a, Float_t z, Float_t w);
    Int_t         GetNmixt() const {return fNmixt;}
@@ -42,7 +42,7 @@ public:
    Float_t      *GetZmixt() const {return fZmixt;}
    Float_t      *GetWmixt() const {return fWmixt;}
 
-   ClassDef(TMixture,1)  //Mixtures used in the Geometry Shapes
+   ClassDefOverride(TMixture,1)  //Mixtures used in the Geometry Shapes
 };
 
 #endif

--- a/graf3d/g3d/inc/TNode.h
+++ b/graf3d/g3d/inc/TNode.h
@@ -54,19 +54,19 @@ public:
          const char *matrixname="", Option_t *option="");
    TNode(const char *name, const char *title, TShape *shape, Double_t x=0, Double_t y=0, Double_t z=0,
          TRotMatrix *matrix=nullptr, Option_t *option="");
-   virtual ~TNode();
-   virtual void        Browse(TBrowser *b);
+   ~TNode() override;
+   void        Browse(TBrowser *b) override;
    virtual void        BuildListOfNodes();
    virtual void        cd(const char *path=nullptr); // *MENU*
-   virtual Int_t       DistancetoPrimitive(Int_t px, Int_t py);
-   virtual void        Draw(Option_t *option=""); // *MENU*
+   Int_t       DistancetoPrimitive(Int_t px, Int_t py) override;
+   void        Draw(Option_t *option="") override; // *MENU*
    virtual void        DrawOnly(Option_t *option="");
-   virtual void        ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   void        ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
    TList              *GetListOfNodes() const {return fNodes;}
    virtual TRotMatrix *GetMatrix() const {return fMatrix;}
    virtual TNode      *GetNode(const char *name) const;
-   virtual char       *GetObjectInfo(Int_t px, Int_t py) const;
-   const   Option_t   *GetOption() const { return fOption.Data();}
+   char       *GetObjectInfo(Int_t px, Int_t py) const override;
+   const   Option_t   *GetOption() const override { return fOption.Data();}
    virtual TNode      *GetParent() const {return fParent;}
    TShape             *GetShape() const {return fShape;}
    Int_t               GetVisibility() const {return fVisibility;}
@@ -74,27 +74,27 @@ public:
    virtual Double_t    GetY() const {return fY;}
    virtual Double_t    GetZ() const {return fZ;}
    virtual void        ImportShapeAttributes();
-   Bool_t              IsFolder() const;
+   Bool_t              IsFolder() const override;
    virtual void        Local2Master(const Double_t *local, Double_t *master);
    virtual void        Local2Master(const Float_t *local, Float_t *master);
-   virtual void        ls(Option_t *option="2") const; // *MENU*
+   void        ls(Option_t *option="2") const override; // *MENU*
    virtual void        Master2Local(const Double_t *master, Double_t *local);
    virtual void        Master2Local(const Float_t *master, Float_t *local);
-   virtual void        Paint(Option_t *option="");
-   virtual void        RecursiveRemove(TObject *obj);
+   void        Paint(Option_t *option="") override;
+   void        RecursiveRemove(TObject *obj) override;
    virtual void        SetMatrix(TRotMatrix *matrix=nullptr) {fMatrix = matrix;}
-   virtual void        SetName(const char *name);
+   void        SetName(const char *name) override;
    virtual void        SetParent(TNode *parent);
-   virtual void        SetNameTitle(const char *name, const char *title);
+   void        SetNameTitle(const char *name, const char *title) override;
    virtual void        SetPosition( Double_t x=0, Double_t y=0, Double_t z=0) {fX=x; fY=y; fZ=z;}
    virtual void        SetVisibility(Int_t vis=1); // *MENU*
-   virtual void        Sizeof3D() const;
+   void        Sizeof3D() const override;
    virtual void        UpdateMatrix();
    virtual void        UpdateTempMatrix(const Double_t *dx1,const Double_t *rmat1,
                               Double_t x, Double_t y, Double_t z, Double_t *matrix,
                               Double_t *dxnew, Double_t *rmatnew);
 
-   ClassDef(TNode,3)  //Description of parameters to position a 3-D geometry object
+   ClassDefOverride(TNode,3)  //Description of parameters to position a 3-D geometry object
 };
 
 #endif

--- a/graf3d/g3d/inc/TNodeDiv.h
+++ b/graf3d/g3d/inc/TNodeDiv.h
@@ -34,11 +34,11 @@ public:
    TNodeDiv();
    TNodeDiv(const char *name, const char *title, const char *shapename, Int_t ndiv, Int_t axis, Option_t *option="");
    TNodeDiv(const char *name, const char *title, TShape *shape, Int_t ndiv, Int_t axis, Option_t *option="");
-   virtual ~TNodeDiv();
-   virtual void             Draw(Option_t *option="");
-   virtual void             Paint(Option_t *option="");
+   ~TNodeDiv() override;
+   void             Draw(Option_t *option="") override;
+   void             Paint(Option_t *option="") override;
 
-   ClassDef(TNodeDiv,1)  //Description of parameters to divide a 3-D geometry object
+   ClassDefOverride(TNodeDiv,1)  //Description of parameters to divide a 3-D geometry object
 };
 
 #endif

--- a/graf3d/g3d/inc/TPARA.h
+++ b/graf3d/g3d/inc/TPARA.h
@@ -33,19 +33,19 @@ protected:
    Float_t fTheta;  // polar angle from the centre of the low z to the high z
    Float_t fPhi;    // polar angle from the centre of the low z to the high z
 
-   virtual void    SetPoints(Double_t *points) const;
+   void    SetPoints(Double_t *points) const override;
 
 public:
    TPARA();
    TPARA(const char *name, const char *title, const char *material, Float_t dx, Float_t dy, Float_t dz,
          Float_t alpha, Float_t theta, Float_t phi);
-   virtual ~TPARA();
+   ~TPARA() override;
 
    virtual Float_t  GetAlpha() const  {return fAlpha;}
    virtual Float_t  GetTheta() const  {return fTheta;}
    virtual Float_t  GetPhi() const    {return fPhi;}
 
-   ClassDef(TPARA,1)  //PARA shape
+   ClassDefOverride(TPARA,1)  //PARA shape
 };
 
 #endif

--- a/graf3d/g3d/inc/TPCON.h
+++ b/graf3d/g3d/inc/TPCON.h
@@ -49,17 +49,17 @@ protected:
 
    virtual void    MakeTableOfCoSin() const;  // Create the table of the fSiTab; fCoTab
    virtual void    FillTableOfCoSin(Double_t phi, Double_t angstep,Int_t n) const; // Fill the table of cosin
-   virtual void    SetPoints(Double_t *points) const;
+   void    SetPoints(Double_t *points) const override;
    virtual Bool_t  SetSegsAndPols(TBuffer3D & buffer) const;
 
 public:
    TPCON();
    TPCON(const char *name, const char *title, const char *material, Float_t phi1, Float_t dphi1, Int_t nz);
-   virtual ~TPCON();
+   ~TPCON() override;
 
    virtual void     DefineSection(Int_t secNum, Float_t z, Float_t rmin, Float_t rmax);
-   virtual Int_t    DistancetoPrimitive(Int_t px, Int_t py);
-   virtual const TBuffer3D &GetBuffer3D(Int_t reqSections) const;
+   Int_t    DistancetoPrimitive(Int_t px, Int_t py) override;
+   const TBuffer3D &GetBuffer3D(Int_t reqSections) const override;
    virtual Int_t    GetNumberOfDivisions () const {if (fNdiv) return fNdiv; else return kDiv;}
    virtual Float_t  GetPhi1() const  {return fPhi1;}
    virtual Float_t  GetDhi1() const  {return fDphi1;}
@@ -69,9 +69,9 @@ public:
    virtual Float_t *GetDz() const    {return fDz;}
    virtual Int_t    GetNdiv() const  {return fNdiv;}
    virtual void     SetNumberOfDivisions (Int_t p);
-   virtual void     Sizeof3D() const;
+   void     Sizeof3D() const override;
 
-   ClassDef(TPCON,2)  //PCON shape
+   ClassDefOverride(TPCON,2)  //PCON shape
 };
 
 #endif

--- a/graf3d/g3d/inc/TPGON.h
+++ b/graf3d/g3d/inc/TPGON.h
@@ -29,14 +29,14 @@
 
 class TPGON : public TPCON {
 protected:
-   virtual void    FillTableOfCoSin(Double_t phi, Double_t angstep,Int_t n) const; // Fill the table of cosin
+   void    FillTableOfCoSin(Double_t phi, Double_t angstep,Int_t n) const override; // Fill the table of cosin
 
 public:
    TPGON();
    TPGON(const char *name, const char *title, const char *material, Float_t phi1, Float_t dphi1,
          Int_t npdv, Int_t nz);
-   virtual ~TPGON();
-   ClassDef(TPGON,1)  //PGON shape
+   ~TPGON() override;
+   ClassDefOverride(TPGON,1)  //PGON shape
 };
 
 #endif

--- a/graf3d/g3d/inc/TPointSet3D.h
+++ b/graf3d/g3d/inc/TPointSet3D.h
@@ -39,9 +39,9 @@ public:
 
    TPointSet3D& operator=(const TPointSet3D& t);
 
-   virtual ~TPointSet3D();
+   ~TPointSet3D() override;
 
-   virtual void ComputeBBox();
+   void ComputeBBox() override;
 
    void     SetPointId(TObject* id);
    void     SetPointId(Int_t n, TObject* id);
@@ -53,7 +53,7 @@ public:
 
    virtual void PointSelected(Int_t n);
 
-   ClassDef(TPointSet3D,1); // TPolyMarker3D with direct OpenGL rendering.
+   ClassDefOverride(TPointSet3D,1); // TPolyMarker3D with direct OpenGL rendering.
 };
 
 #endif

--- a/graf3d/g3d/inc/TPoints3DABC.h
+++ b/graf3d/g3d/inc/TPoints3DABC.h
@@ -26,13 +26,13 @@ class TPoints3DABC : public TObject {
 
 public:
    TPoints3DABC(){}
-   virtual ~TPoints3DABC(){}
+   ~TPoints3DABC() override{}
 
    static  Int_t     DistancetoLine(Int_t px, Int_t py, Float_t x1, Float_t y1, Float_t x2, Float_t y2, Int_t lineWidth = 1 );
 
    virtual Int_t     Add(Float_t x, Float_t y, Float_t z);
    virtual Int_t     AddLast(Float_t x, Float_t y, Float_t z);
-   virtual Int_t     DistancetoPrimitive(Int_t px, Int_t py)=0;
+   Int_t     DistancetoPrimitive(Int_t px, Int_t py) override =0;
    virtual Int_t     GetLastPosition()const    =0;
    // GetN()  returns the number of allocated cells if any.
    //         GetN() > 0 shows how many cells
@@ -45,7 +45,7 @@ public:
    virtual Float_t   GetZ(Int_t idx)  const    =0;
    virtual Float_t  *GetXYZ(Float_t *xyz,Int_t idx,Int_t num=1)  const;
    virtual const Float_t  *GetXYZ(Int_t idx)   =0;
-   virtual Option_t *GetOption()      const    =0;
+   Option_t *GetOption()      const    override =0;
    virtual void      PaintPoints(Int_t n, Float_t *p,Option_t *option="")  =0;
    virtual Int_t     SetLastPosition(Int_t idx)=0;
    virtual Int_t     SetNextPoint(Float_t x, Float_t y, Float_t z);
@@ -54,7 +54,7 @@ public:
    virtual Int_t     SetPoints(Int_t n, Float_t *p=nullptr, Option_t *option="") =0;
    virtual Int_t     Size() const              =0;
 
-   ClassDef(TPoints3DABC,0)  //A 3-D Points
+   ClassDefOverride(TPoints3DABC,0)  //A 3-D Points
 };
 
 #endif

--- a/graf3d/g3d/inc/TPolyLine3D.h
+++ b/graf3d/g3d/inc/TPolyLine3D.h
@@ -46,7 +46,7 @@ public:
    TPolyLine3D(Int_t n, Double_t const* x, Double_t const* y, Double_t const* z, Option_t *option="");
    TPolyLine3D(const TPolyLine3D &polylin);
    TPolyLine3D& operator=(const TPolyLine3D &polylin);
-   virtual ~TPolyLine3D();
+   ~TPolyLine3D() override;
 
    void              Copy(TObject &polyline) const override;
    Int_t             DistancetoPrimitive(Int_t px, Int_t py) override;

--- a/graf3d/g3d/inc/TPolyMarker3D.h
+++ b/graf3d/g3d/inc/TPolyMarker3D.h
@@ -45,7 +45,7 @@ public:
    TPolyMarker3D(Int_t n, Double_t *p, Marker_t marker=1, Option_t *option="");
    TPolyMarker3D(const TPolyMarker3D &p);
    TPolyMarker3D& operator=(const TPolyMarker3D&);
-   virtual ~TPolyMarker3D();
+   ~TPolyMarker3D() override;
 
    void              Copy(TObject &polymarker) const override;
    Int_t             DistancetoPrimitive(Int_t px, Int_t py)  override;

--- a/graf3d/g3d/inc/TRotMatrix.h
+++ b/graf3d/g3d/inc/TRotMatrix.h
@@ -49,7 +49,7 @@ public:
    TRotMatrix(const char *name, const char *title, Double_t theta1, Double_t phi1,
                                            Double_t theta2, Double_t phi2,
                                            Double_t theta3, Double_t phi3);
-   virtual ~TRotMatrix();
+   ~TRotMatrix() override;
    virtual Double_t  Determinant() const ;   // returns the determinant of this matrix
    virtual Double_t* GetMatrix()         {return &fMatrix[0];}
    virtual Int_t     GetNumber()   const {return fNumber;}
@@ -61,9 +61,9 @@ public:
    virtual Bool_t    IsReflection() const {return TestBit(kReflection);}  // Return kTRUE if this matrix defines the reflection
    virtual const     Double_t* SetAngles(Double_t theta1, Double_t phi1,Double_t theta2, Double_t phi2, Double_t theta3, Double_t phi3);
    virtual void      SetMatrix(const Double_t *matrix);
-   virtual void      SetName(const char *name);
+   void      SetName(const char *name) override;
 
-   ClassDef(TRotMatrix,2)  //Rotation Matrix for 3-D geometry objects
+   ClassDefOverride(TRotMatrix,2)  //Rotation Matrix for 3-D geometry objects
 };
 
 inline void TRotMatrix::SetName(const char *) { }

--- a/graf3d/g3d/inc/TSPHE.h
+++ b/graf3d/g3d/inc/TSPHE.h
@@ -47,16 +47,16 @@ protected:
    Float_t faZ;      // Coeff along Oz
 
    virtual void    MakeTableOfCoSin() const;  // Create the table of the fSiTab; fCoTab
-   virtual void    SetPoints(Double_t *points) const;
+   void    SetPoints(Double_t *points) const override;
 
 public:
    TSPHE();
    TSPHE(const char *name, const char *title, const char *material, Float_t rmin, Float_t rmax, Float_t themin,
          Float_t themax, Float_t phimin, Float_t phimax);
    TSPHE(const char *name, const char *title, const char *material, Float_t rmax);
-   virtual ~TSPHE();
-   virtual Int_t   DistancetoPrimitive(Int_t px, Int_t py);
-   virtual const TBuffer3D &GetBuffer3D(Int_t reqSections) const;
+   ~TSPHE() override;
+   Int_t   DistancetoPrimitive(Int_t px, Int_t py) override;
+   const TBuffer3D &GetBuffer3D(Int_t reqSections) const override;
    virtual Float_t GetRmin() const {return fRmin;}
    virtual Float_t GetRmax() const {return fRmax;}
    virtual Float_t GetThemin() const {return fThemin;}
@@ -68,9 +68,9 @@ public:
    virtual void    SetAspectRatio(Float_t factor=1.0){ fAspectRatio = factor; MakeTableOfCoSin();}
    virtual void    SetEllipse(const Float_t *factors);
    virtual void    SetNumberOfDivisions (Int_t p);
-   virtual void    Sizeof3D() const;
+   void    Sizeof3D() const override;
 
-   ClassDef(TSPHE,3)  //SPHE shape
+   ClassDefOverride(TSPHE,3)  //SPHE shape
 };
 
 #endif

--- a/graf3d/g3d/inc/TShape.h
+++ b/graf3d/g3d/inc/TShape.h
@@ -50,19 +50,19 @@ public:
    TShape(const char *name, const char *title, const char *material);
    TShape(const TShape&);
    TShape& operator=(const TShape&);
-   virtual         ~TShape();
+           ~TShape() override;
 
    virtual const   TBuffer3D &GetBuffer3D(Int_t reqSections) const;
    TMaterial      *GetMaterial()  const {return fMaterial;}
    virtual Int_t   GetNumber()     const {return fNumber;}
    Int_t           GetVisibility() const {return fVisibility;}
-   virtual void    Paint(Option_t *option="");
-   virtual void    SetName(const char *name);
+   void    Paint(Option_t *option="") override;
+   void    SetName(const char *name) override;
    virtual void    SetPoints(Double_t *points) const ;
    virtual void    SetVisibility(Int_t vis) {fVisibility = vis;} // *MENU*
    void            TransformPoints(Double_t *points, UInt_t NbPnts) const;
 
-   ClassDef(TShape,2)  //Basic shape
+   ClassDefOverride(TShape,2)  //Basic shape
 };
 
 R__EXTERN TNode *gNode;

--- a/graf3d/g3d/inc/TTRAP.h
+++ b/graf3d/g3d/inc/TTRAP.h
@@ -41,14 +41,14 @@ protected:
    Float_t fTl2;       // half length in x at high z and y high edge
    Float_t fAlpha2;    // angle w.r.t. the y axis
 
-   virtual void     SetPoints(Double_t *points) const;
+   void     SetPoints(Double_t *points) const override;
 
 public:
    TTRAP();
    TTRAP(const char *name, const char *title, const char *material, Float_t dz, Float_t theta, Float_t phi, Float_t h1,
          Float_t bl1, Float_t tl1, Float_t alpha1, Float_t h2, Float_t bl2, Float_t tl2,
          Float_t alpha2);
-   virtual ~TTRAP();
+   ~TTRAP() override;
 
    virtual Float_t  GetH1() const     {return fH1;}
    virtual Float_t  GetBl1() const    {return fBl1;}
@@ -59,7 +59,7 @@ public:
    virtual Float_t  GetTl2() const    {return fTl2;}
    virtual Float_t  GetAlpha2() const {return fAlpha2;}
 
-   ClassDef(TTRAP,1)  //TRAP shape
+   ClassDefOverride(TTRAP,1)  //TRAP shape
 };
 
 #endif

--- a/graf3d/g3d/inc/TTRD1.h
+++ b/graf3d/g3d/inc/TTRD1.h
@@ -29,16 +29,16 @@ class TTRD1 : public TBRIK {
 protected:
    Float_t fDx2;        // half length in x at the high z surface
 
-   virtual void    SetPoints(Double_t *points) const;
+   void    SetPoints(Double_t *points) const override;
 
 public:
    TTRD1();
    TTRD1(const char *name, const char *title, const char *material, Float_t dx1, Float_t dx2, Float_t dy, Float_t dz);
-   virtual ~TTRD1();
+   ~TTRD1() override;
 
    virtual Float_t GetDx2() const {return fDx2;}
 
-   ClassDef(TTRD1,1)  //TRD1 shape
+   ClassDefOverride(TTRD1,1)  //TRD1 shape
 };
 
 #endif

--- a/graf3d/g3d/inc/TTRD2.h
+++ b/graf3d/g3d/inc/TTRD2.h
@@ -31,18 +31,18 @@ protected:
    Float_t fDx2;        // half length in x at the high z surface
    Float_t fDy2;        // half length in y at the high z surface
 
-   virtual void    SetPoints(Double_t *points) const;
+   void    SetPoints(Double_t *points) const override;
 
 public:
    TTRD2();
    TTRD2(const char *name, const char *title, const char *material, Float_t dx1, Float_t dx2,
          Float_t dy1, Float_t dy2, Float_t dz);
-   virtual ~TTRD2();
+   ~TTRD2() override;
 
    Float_t         GetDx2() const {return fDx2;}
    Float_t         GetDy2() const {return fDy2;}
 
-   ClassDef(TTRD2,1)  //TRD2 shape
+   ClassDefOverride(TTRD2,1)  //TRD2 shape
 };
 
 #endif

--- a/graf3d/g3d/inc/TTUBE.h
+++ b/graf3d/g3d/inc/TTUBE.h
@@ -48,17 +48,17 @@ protected:
    TTUBE& operator=(const TTUBE&);
 
    virtual void    MakeTableOfCoSin() const;  // Create the table of the fSiTab; fCoTab
-   virtual void    SetPoints(Double_t *points) const;
+   void    SetPoints(Double_t *points) const override;
    virtual void    SetSegsAndPols(TBuffer3D & buffer) const;
 
 public:
    TTUBE();
    TTUBE(const char *name, const char *title, const char *material, Float_t rmin, Float_t rmax, Float_t dz, Float_t aspect=1);
    TTUBE(const char *name, const char *title, const char *material, Float_t rmax, Float_t dz);
-   virtual ~TTUBE();
+   ~TTUBE() override;
 
-   virtual Int_t   DistancetoPrimitive(Int_t px, Int_t py);
-   virtual const TBuffer3D &GetBuffer3D(Int_t reqSections) const;
+   Int_t   DistancetoPrimitive(Int_t px, Int_t py) override;
+   const TBuffer3D &GetBuffer3D(Int_t reqSections) const override;
    virtual Float_t GetRmin() const  {return fRmin;}
    virtual Float_t GetRmax() const  {return fRmax;}
    virtual Float_t GetDz()   const  {return fDz;}
@@ -67,9 +67,9 @@ public:
    virtual Int_t   GetNumberOfDivisions () const {if (fNdiv) return fNdiv; else return kDivNum;}
    virtual void    SetNumberOfDivisions (Int_t ndiv);
    virtual void    SetAspectRatio(Float_t factor=1){fAspectRatio = factor;}
-   virtual void    Sizeof3D() const;
+   void    Sizeof3D() const override;
 
-   ClassDef(TTUBE,3)  //TUBE shape
+   ClassDefOverride(TTUBE,3)  //TUBE shape
 };
 
 #endif

--- a/graf3d/g3d/inc/TTUBS.h
+++ b/graf3d/g3d/inc/TTUBS.h
@@ -30,9 +30,9 @@ class TTUBS : public TTUBE {
 protected:
    Float_t fPhi1;        // first phi limit
    Float_t fPhi2;        // second phi limit
-   virtual void    MakeTableOfCoSin() const;  // Create the table of the fSiTab; fCoTab
+   void    MakeTableOfCoSin() const override;  // Create the table of the fSiTab; fCoTab
 
-   virtual void    SetPoints(Double_t *points) const;
+   void    SetPoints(Double_t *points) const override;
 
 public:
    TTUBS();
@@ -40,15 +40,15 @@ public:
          Float_t phi1, Float_t phi2);
    TTUBS(const char *name, const char *title, const char *material, Float_t rmax, Float_t dz,
          Float_t phi1, Float_t phi2);
-   virtual ~TTUBS();
+   ~TTUBS() override;
 
-   virtual Int_t   DistancetoPrimitive(Int_t px, Int_t py);
-   virtual const TBuffer3D &GetBuffer3D(Int_t reqSections) const;
+   Int_t   DistancetoPrimitive(Int_t px, Int_t py) override;
+   const TBuffer3D &GetBuffer3D(Int_t reqSections) const override;
    virtual Float_t GetPhi1() const {return fPhi1;}
    virtual Float_t GetPhi2() const {return fPhi2;}
-   virtual void    Sizeof3D() const;
+   void    Sizeof3D() const override;
 
-   ClassDef(TTUBS,1)  //TUBS shape
+   ClassDefOverride(TTUBS,1)  //TUBS shape
 };
 
 #endif

--- a/graf3d/g3d/inc/TView3D.h
+++ b/graf3d/g3d/inc/TView3D.h
@@ -69,104 +69,104 @@ public:
 
    TView3D();
    TView3D(Int_t system, const Double_t *rmin, const Double_t *rmax);
-   virtual ~TView3D();
+   ~TView3D() override;
 
-   virtual void     AxisVertex(Double_t ang, Double_t *av, Int_t &ix1, Int_t &ix2, Int_t &iy1, Int_t &iy2, Int_t &iz1, Int_t &iz2);
-   virtual void     DefinePerspectiveView();
-   virtual void     DefineViewDirection(const Double_t *s, const Double_t *c,
+   void     AxisVertex(Double_t ang, Double_t *av, Int_t &ix1, Int_t &ix2, Int_t &iy1, Int_t &iy2, Int_t &iz1, Int_t &iz2) override;
+   void     DefinePerspectiveView() override;
+   void     DefineViewDirection(const Double_t *s, const Double_t *c,
                                         Double_t cosphi, Double_t sinphi,
                                         Double_t costhe, Double_t sinthe,
                                         Double_t cospsi, Double_t sinpsi,
-                                        Double_t *tnorm, Double_t *tback);
-   virtual void      DrawOutlineCube(TList *outline, Double_t *rmin, Double_t *rmax);
-   virtual void      ExecuteEvent(Int_t event, Int_t px, Int_t py);
-   virtual void      ExecuteRotateView(Int_t event, Int_t px, Int_t py);
-   virtual void      FindScope(Double_t *scale, Double_t *center, Int_t &irep);
-   virtual Int_t     GetDistancetoAxis(Int_t axis, Int_t px, Int_t py, Double_t &ratio);
-   virtual Double_t  GetDview() const {return fDview;}
-   virtual Double_t  GetDproj() const {return fDproj;}
-   virtual Double_t  GetExtent() const;
-   virtual Bool_t    GetAutoRange() {return fAutoRange;}
-   virtual Double_t  GetLatitude() {return fLatitude;}
-   virtual Double_t  GetLongitude() {return fLongitude;}
-   virtual Double_t  GetPsi() {return fPsi;}
-   virtual void      GetRange (Float_t *min, Float_t *max);
-   virtual void      GetRange (Double_t *min, Double_t *max);
-   virtual Double_t *GetRmax() {return fRmax;}
-   virtual Double_t *GetRmin() {return fRmin;}
-   virtual TSeqCollection *GetOutline() {return fOutline; }
-   virtual Double_t *GetTback() {return fTback;}
-   virtual Double_t *GetTN() {return fTN;}
-   virtual Double_t *GetTnorm() {return fTnorm;}
-   virtual Int_t     GetSystem() {return fSystem;}
-   virtual void      GetWindow(Double_t &u0, Double_t &v0, Double_t &du, Double_t &dv) const;
-   virtual Double_t  GetWindowWidth() const {return 0.5*(fUVcoord[1]-fUVcoord[0]);}
-   virtual Double_t  GetWindowHeight() const {return 0.5*(fUVcoord[3]-fUVcoord[2]);}
-   virtual void      FindNormal(Double_t x, Double_t  y, Double_t z, Double_t &zn);
-   virtual void      FindPhiSectors(Int_t iopt, Int_t &kphi, Double_t *aphi, Int_t &iphi1, Int_t &iphi2);
-   virtual void      FindThetaSectors(Int_t iopt, Double_t phi, Int_t &kth, Double_t *ath, Int_t &ith1, Int_t &ith2);
-   virtual Bool_t    IsClippedNDC(Double_t *p) const;
-   virtual Bool_t    IsPerspective() const {return TestBit(kPerspective);}
-   virtual Bool_t    IsViewChanged() const {return fChanged;}
-   virtual void      NDCtoWC(const Float_t *pn, Float_t *pw);
-   virtual void      NDCtoWC(const Double_t *pn, Double_t *pw);
-   virtual void      NormalWCtoNDC(const Float_t *pw, Float_t *pn);
-   virtual void      NormalWCtoNDC(const Double_t *pw, Double_t *pn);
-   virtual void      PadRange(Int_t rback);
-   virtual void      ResizePad();
-   virtual void      SetAutoRange(Bool_t autorange=kTRUE) {fAutoRange=autorange;}
-   virtual void      SetAxisNDC(const Double_t *x1, const Double_t *x2, const Double_t *y1, const Double_t *y2, const Double_t *z1, const Double_t *z2);
-   virtual void      SetDefaultWindow();
-   virtual void      SetDview(Double_t dview) {fDview=dview;}
-   virtual void      SetDproj(Double_t dproj) {fDproj=dproj;}
-   virtual void      SetLatitude(Double_t latitude) {fLatitude = latitude;}
-   virtual void      SetLongitude(Double_t longitude) {fLongitude = longitude;}
-   virtual void      SetPsi(Double_t psi) {fPsi = psi;}
-   virtual void      SetOutlineToCube();
-   virtual void      SetParallel(); // *MENU*
-   virtual void      SetPerspective(); // *MENU*
-   virtual void      SetRange(const Double_t *min, const Double_t *max);
-   virtual void      SetRange(Double_t x0, Double_t y0, Double_t z0, Double_t x1, Double_t y1, Double_t z1, Int_t flag=0);
-   virtual void      SetSystem(Int_t system) {fSystem = system;}
-   virtual void      SetView(Double_t longitude, Double_t latitude, Double_t psi, Int_t &irep);
-   virtual void      SetViewChanged(Bool_t flag=kTRUE) {fChanged = flag;}
-   virtual void      SetWindow(Double_t u0, Double_t v0, Double_t du, Double_t dv);
-   virtual void      WCtoNDC(const Float_t *pw, Float_t *pn);
-   virtual void      WCtoNDC(const Double_t *pw, Double_t *pn);
+                                        Double_t *tnorm, Double_t *tback) override;
+   void      DrawOutlineCube(TList *outline, Double_t *rmin, Double_t *rmax) override;
+   void      ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
+   void      ExecuteRotateView(Int_t event, Int_t px, Int_t py) override;
+   void      FindScope(Double_t *scale, Double_t *center, Int_t &irep) override;
+   Int_t     GetDistancetoAxis(Int_t axis, Int_t px, Int_t py, Double_t &ratio) override;
+   Double_t  GetDview() const override {return fDview;}
+   Double_t  GetDproj() const override {return fDproj;}
+   Double_t  GetExtent() const override;
+   Bool_t    GetAutoRange() override {return fAutoRange;}
+   Double_t  GetLatitude() override {return fLatitude;}
+   Double_t  GetLongitude() override {return fLongitude;}
+   Double_t  GetPsi() override {return fPsi;}
+   void      GetRange (Float_t *min, Float_t *max) override;
+   void      GetRange (Double_t *min, Double_t *max) override;
+   Double_t *GetRmax() override {return fRmax;}
+   Double_t *GetRmin() override {return fRmin;}
+   TSeqCollection *GetOutline() override {return fOutline; }
+   Double_t *GetTback() override {return fTback;}
+   Double_t *GetTN() override {return fTN;}
+   Double_t *GetTnorm() override {return fTnorm;}
+   Int_t     GetSystem() override {return fSystem;}
+   void      GetWindow(Double_t &u0, Double_t &v0, Double_t &du, Double_t &dv) const override;
+   Double_t  GetWindowWidth() const override {return 0.5*(fUVcoord[1]-fUVcoord[0]);}
+   Double_t  GetWindowHeight() const override {return 0.5*(fUVcoord[3]-fUVcoord[2]);}
+   void      FindNormal(Double_t x, Double_t  y, Double_t z, Double_t &zn) override;
+   void      FindPhiSectors(Int_t iopt, Int_t &kphi, Double_t *aphi, Int_t &iphi1, Int_t &iphi2) override;
+   void      FindThetaSectors(Int_t iopt, Double_t phi, Int_t &kth, Double_t *ath, Int_t &ith1, Int_t &ith2) override;
+   Bool_t    IsClippedNDC(Double_t *p) const override;
+   Bool_t    IsPerspective() const override {return TestBit(kPerspective);}
+   Bool_t    IsViewChanged() const override {return fChanged;}
+   void      NDCtoWC(const Float_t *pn, Float_t *pw) override;
+   void      NDCtoWC(const Double_t *pn, Double_t *pw) override;
+   void      NormalWCtoNDC(const Float_t *pw, Float_t *pn) override;
+   void      NormalWCtoNDC(const Double_t *pw, Double_t *pn) override;
+   void      PadRange(Int_t rback) override;
+   void      ResizePad() override;
+   void      SetAutoRange(Bool_t autorange=kTRUE) override {fAutoRange=autorange;}
+   void      SetAxisNDC(const Double_t *x1, const Double_t *x2, const Double_t *y1, const Double_t *y2, const Double_t *z1, const Double_t *z2) override;
+   void      SetDefaultWindow() override;
+   void      SetDview(Double_t dview) override {fDview=dview;}
+   void      SetDproj(Double_t dproj) override {fDproj=dproj;}
+   void      SetLatitude(Double_t latitude) override {fLatitude = latitude;}
+   void      SetLongitude(Double_t longitude) override {fLongitude = longitude;}
+   void      SetPsi(Double_t psi) override {fPsi = psi;}
+   void      SetOutlineToCube() override;
+   void      SetParallel() override; // *MENU*
+   void      SetPerspective() override; // *MENU*
+   void      SetRange(const Double_t *min, const Double_t *max) override;
+   void      SetRange(Double_t x0, Double_t y0, Double_t z0, Double_t x1, Double_t y1, Double_t z1, Int_t flag=0) override;
+   void      SetSystem(Int_t system) override {fSystem = system;}
+   void      SetView(Double_t longitude, Double_t latitude, Double_t psi, Int_t &irep) override;
+   void      SetViewChanged(Bool_t flag=kTRUE) override {fChanged = flag;}
+   void      SetWindow(Double_t u0, Double_t v0, Double_t du, Double_t dv) override;
+   void      WCtoNDC(const Float_t *pw, Float_t *pn) override;
+   void      WCtoNDC(const Double_t *pw, Double_t *pn) override;
 
 //--
-   virtual void      MoveFocus(Double_t *center, Double_t dx, Double_t dy, Double_t dz, Int_t nsteps=10,
-                               Double_t dlong=0, Double_t dlat=0, Double_t dpsi=0);
-   virtual void      MoveViewCommand(Char_t chCode, Int_t count=1);
-   virtual void      MoveWindow(Char_t option);
+   void      MoveFocus(Double_t *center, Double_t dx, Double_t dy, Double_t dz, Int_t nsteps=10,
+                               Double_t dlong=0, Double_t dlat=0, Double_t dpsi=0) override;
+   void      MoveViewCommand(Char_t chCode, Int_t count=1) override;
+   void      MoveWindow(Char_t option) override;
 
-   virtual void      AdjustScales(TVirtualPad *pad = nullptr);
-   virtual void      Centered3DImages(TVirtualPad *pad = nullptr);
-   virtual void      Centered();                       // *MENU*
-   virtual void      FrontView(TVirtualPad *pad = nullptr);
-   virtual void      Front();                          // *MENU*
+   void      AdjustScales(TVirtualPad *pad = nullptr) override;
+   void      Centered3DImages(TVirtualPad *pad = nullptr) override;
+   void      Centered() override;                       // *MENU*
+   void      FrontView(TVirtualPad *pad = nullptr) override;
+   void      Front() override;                          // *MENU*
 
-   virtual void      ZoomIn(); // *MENU*
-   virtual void      ZoomOut(); // *MENU*
-   virtual void      ZoomView(TVirtualPad *pad = nullptr, Double_t zoomFactor = 1.25 );
-   virtual void      UnzoomView(TVirtualPad *pad = nullptr,Double_t unZoomFactor = 1.25);
+   void      ZoomIn() override; // *MENU*
+   void      ZoomOut() override; // *MENU*
+   void      ZoomView(TVirtualPad *pad = nullptr, Double_t zoomFactor = 1.25 ) override;
+   void      UnzoomView(TVirtualPad *pad = nullptr,Double_t unZoomFactor = 1.25) override;
 
-   virtual void      RotateView(Double_t phi, Double_t theta, TVirtualPad *pad = nullptr);
-   virtual void      SideView(TVirtualPad *pad = nullptr);
-   virtual void      Side();                          // *MENU*
-   virtual void      TopView(TVirtualPad *pad = nullptr);
-   virtual void      Top();                           // *MENU*
+   void      RotateView(Double_t phi, Double_t theta, TVirtualPad *pad = nullptr) override;
+   void      SideView(TVirtualPad *pad = nullptr) override;
+   void      Side() override;                          // *MENU*
+   void      TopView(TVirtualPad *pad = nullptr) override;
+   void      Top() override;                           // *MENU*
 
-   virtual void      ToggleRulers(TVirtualPad *pad = nullptr);
-   virtual void      ShowAxis();                      // *MENU*
-   virtual void      ToggleZoom(TVirtualPad *pad = nullptr);
-   virtual void      ZoomMove();                      // *MENU*
-   virtual void      Zoom();                          // *MENU*
-   virtual void      UnZoom();                        // *MENU*
+   void      ToggleRulers(TVirtualPad *pad = nullptr) override;
+   void      ShowAxis() override;                      // *MENU*
+   void      ToggleZoom(TVirtualPad *pad = nullptr) override;
+   void      ZoomMove() override;                      // *MENU*
+   void      Zoom() override;                          // *MENU*
+   void      UnZoom() override;                        // *MENU*
 
    static  void      AdjustPad(TVirtualPad *pad = nullptr);
 
-   ClassDef(TView3D,3);  //3-D View
+   ClassDefOverride(TView3D,3);  //3-D View
 };
 
 #endif

--- a/graf3d/g3d/inc/TXTRU.h
+++ b/graf3d/g3d/inc/TXTRU.h
@@ -25,15 +25,15 @@ public:
    TXTRU(const char *name, const char *title, const char *material,
          Int_t nyx, Int_t nz);
    TXTRU(const TXTRU &xtru);
-   virtual ~TXTRU();
+   ~TXTRU() override;
    TXTRU& operator=(const TXTRU& rhs);
 
-   virtual void     Copy(TObject &xtru) const;
+   void     Copy(TObject &xtru) const override;
    virtual void     DefineSection(Int_t secNum, Float_t z, Float_t scale=1.,
                                   Float_t x0=0., Float_t y0=0.);
    virtual void     DefineVertex(Int_t pointNum, Float_t x, Float_t y);
-   virtual Int_t    DistancetoPrimitive(Int_t px, Int_t py);
-   virtual const    TBuffer3D &GetBuffer3D(Int_t) const;
+   Int_t    DistancetoPrimitive(Int_t px, Int_t py) override;
+   const    TBuffer3D &GetBuffer3D(Int_t) const override;
    virtual Int_t    GetNxy() const { return fNxy; }
    virtual Int_t    GetNz() const { return fNz; }
    virtual Float_t  GetOutlinePointX(Int_t pointNum) const;
@@ -48,15 +48,15 @@ public:
    virtual Float_t *GetScale() const {return fScale; }
    virtual Float_t *GetX0() const {return fX0; }
    virtual Float_t *GetY0() const {return fY0; }
-   virtual void     Print(Option_t *option="") const;
-   virtual void     Sizeof3D() const;
+   void     Print(Option_t *option="") const override;
+   void     Sizeof3D() const override;
    void             SplitConcavePolygon(Bool_t split = kTRUE);
    virtual void     TruncateNxy(Int_t npts);
    virtual void     TruncateNz(Int_t npts);
 
 protected:
    void            CheckOrdering();
-   virtual void    SetPoints(Double_t *points) const;
+   void    SetPoints(Double_t *points) const override;
 
    Int_t       fNxy{0};             // number of x-y points in the cross section
    Int_t       fNxyAlloc{0};        // number of x-y points allocated
@@ -89,7 +89,7 @@ private:
    void DumpSegments(int nsegments, int *segbuff) const;
    void DumpPolygons(int npolygons, int *polybuff, int buffsize) const;
 
-   ClassDef(TXTRU,1)  //TXTRU shape
+   ClassDefOverride(TXTRU,1)  //TXTRU shape
 };
 
 #endif

--- a/graf3d/gl/inc/TF2GL.h
+++ b/graf3d/gl/inc/TF2GL.h
@@ -30,19 +30,19 @@ protected:
 
 public:
    TF2GL();
-   virtual ~TF2GL();
+   ~TF2GL() override;
 
-   virtual Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr);
-   virtual void   SetBBox();
-   virtual void   DirectDraw(TGLRnrCtx & rnrCtx) const;
+   Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr) override;
+   void   SetBBox() override;
+   void   DirectDraw(TGLRnrCtx & rnrCtx) const override;
 
-   virtual Bool_t KeepDuringSmartRefresh() const { return kFALSE; }
+   Bool_t KeepDuringSmartRefresh() const override { return kFALSE; }
 
    // To support two-level selection
    // virtual Bool_t SupportsSecondarySelect() const { return kTRUE; }
    // virtual void ProcessSelection(UInt_t* ptr, TGLViewer*, TGLScene*);
 
-   ClassDef(TF2GL, 0); // GL renderer for TF2 and TF3.
+   ClassDefOverride(TF2GL, 0); // GL renderer for TF2 and TF3.
 };
 
 #endif

--- a/graf3d/gl/inc/TGL5D.h
+++ b/graf3d/gl/inc/TGL5D.h
@@ -36,10 +36,10 @@ public:
 
    //These are functions for TPad and
    //TPad's standard machinery (picking, painting).
-   Int_t    DistancetoPrimitive(Int_t px, Int_t py);
-   void     ExecuteEvent(Int_t event, Int_t px, Int_t py);
-   char    *GetObjectInfo(Int_t px, Int_t py) const;
-   void     Paint(Option_t *option);
+   Int_t    DistancetoPrimitive(Int_t px, Int_t py) override;
+   void     ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
+   char    *GetObjectInfo(Int_t px, Int_t py) const override;
+   void     Paint(Option_t *option) override;
 
    //This is for editor.
    TGL5DPainter *GetRealPainter()const;
@@ -105,7 +105,7 @@ private:
    TGL5DDataSet(const TGL5DDataSet &rhs);
    TGL5DDataSet &operator = (const TGL5DDataSet &rhs);
 
-   ClassDef(TGL5DDataSet, 0)//Class to read data from TTree and create TGL5DPainter.
+   ClassDefOverride(TGL5DDataSet, 0)//Class to read data from TTree and create TGL5DPainter.
 };
 
 #endif

--- a/graf3d/gl/inc/TGL5DDataSetEditor.h
+++ b/graf3d/gl/inc/TGL5DDataSetEditor.h
@@ -113,9 +113,9 @@ private:
 public:
    TGL5DDataSetEditor(const TGWindow *p = nullptr, Int_t width = 140, Int_t height = 30,
                       UInt_t options = kChildFrame, Pixel_t back = GetDefaultFrameBackground());
-   ~TGL5DDataSetEditor();
+   ~TGL5DDataSetEditor() override;
 
-   virtual void   SetModel(TObject* obj);
+   void   SetModel(TObject* obj) override;
 
    //Slots for "Grid" tab events.
    void GridParametersChanged();
@@ -146,7 +146,7 @@ public:
    void NContoursChanged();
 
 
-   ClassDef(TGL5DDataSetEditor, 0); //GUI for editing OpenGL 5D Viewer attributes
+   ClassDefOverride(TGL5DDataSetEditor, 0); //GUI for editing OpenGL 5D Viewer attributes
 };
 
 #endif

--- a/graf3d/gl/inc/TGL5DPainter.h
+++ b/graf3d/gl/inc/TGL5DPainter.h
@@ -91,12 +91,12 @@ public:
    void       RemoveSurface(SurfIter_t surf);
 
    //TGLPlotPainter final-overriders.
-   char      *GetPlotInfo(Int_t px, Int_t py);
-   Bool_t     InitGeometry();
-   void       StartPan(Int_t px, Int_t py);
-   void       Pan(Int_t px, Int_t py);
-   void       AddOption(const TString &option);
-   void       ProcessEvent(Int_t event, Int_t px, Int_t py);
+   char      *GetPlotInfo(Int_t px, Int_t py) override;
+   Bool_t     InitGeometry() override;
+   void       StartPan(Int_t px, Int_t py) override;
+   void       Pan(Int_t px, Int_t py) override;
+   void       AddOption(const TString &option) override;
+   void       ProcessEvent(Int_t event, Int_t px, Int_t py) override;
 
    //Methods for ged.
    void       ShowBoxCut(Bool_t show) {fBoxCut.SetActive(show);}
@@ -115,15 +115,15 @@ public:
 
 private:
    //TGLPlotPainter final-overriders.
-   void       InitGL()const;
-   void       DeInitGL()const;
+   void       InitGL()const override;
+   void       DeInitGL()const override;
 
-   void       DrawPlot()const;
+   void       DrawPlot()const override;
 
    //Empty overriders.
-   void       DrawSectionXOZ()const{}
-   void       DrawSectionYOZ()const{}
-   void       DrawSectionXOY()const{}
+   void       DrawSectionXOZ()const override{}
+   void       DrawSectionYOZ()const override{}
+   void       DrawSectionXOY()const override{}
 
    //Auxiliary functions.
    void       SetSurfaceColor(ConstSurfIter_t surf)const;

--- a/graf3d/gl/inc/TGLAdapter.h
+++ b/graf3d/gl/inc/TGLAdapter.h
@@ -21,10 +21,10 @@ private:
 public:
    explicit TGLAdapter(Int_t glDevice = -1);
 
-   Bool_t            MakeCurrent();
-   void              SwapBuffers();
-   const TGLFormat  *GetPixelFormat()const{return nullptr;}
-   const TGLContext *GetContext()const{return nullptr;}
+   Bool_t            MakeCurrent() override;
+   void              SwapBuffers() override;
+   const TGLFormat  *GetPixelFormat()const override{return nullptr;}
+   const TGLContext *GetContext()const override{return nullptr;}
 
    void SetGLDevice(Int_t glDevice)
    {
@@ -34,16 +34,16 @@ public:
    void ReadGLBuffer();
    void SelectOffScreenDevice();
    void MarkForDirectCopy(Bool_t isDirect);
-   void ExtractViewport(Int_t *vp)const;
+   void ExtractViewport(Int_t *vp)const override;
 
 private:
    TGLAdapter(const TGLAdapter &);
    TGLAdapter &operator = (const TGLAdapter &);
 
-   void AddContext(TGLContext *){}
-   void RemoveContext(TGLContext *){}
+   void AddContext(TGLContext *) override{}
+   void RemoveContext(TGLContext *) override{}
 
-   ClassDef(TGLAdapter, 0) // Allow plot-painters to be used for gl-inpad and gl-viewer.
+   ClassDefOverride(TGLAdapter, 0) // Allow plot-painters to be used for gl-inpad and gl-viewer.
 };
 
 #endif

--- a/graf3d/gl/inc/TGLAnnotation.h
+++ b/graf3d/gl/inc/TGLAnnotation.h
@@ -73,7 +73,7 @@ protected:
 public:
    TGLAnnotation(TGLViewerBase *parent, const char *text, Float_t posx, Float_t posy);
    TGLAnnotation(TGLViewerBase *parent, const char *text, Float_t posx, Float_t posy, TGLVector3 ref);
-   virtual ~TGLAnnotation();
+   ~TGLAnnotation() override;
 
    void  SetText(const TString& x)   { fText = x; }
    const TString& GetText()    const { return fText; }
@@ -99,18 +99,18 @@ public:
    TGLFont::ETextAlignH_e GetTextAlign() const { return fTextAlign; }
    void SetTextAlign(TGLFont::ETextAlignH_e a) { fTextAlign = a; }
 
-   virtual Bool_t MouseEnter(TGLOvlSelectRecord& selRec);
-   virtual Bool_t Handle(TGLRnrCtx& rnrCtx, TGLOvlSelectRecord& selRec,
-                         Event_t* event);
-   virtual void   MouseLeave();
+   Bool_t MouseEnter(TGLOvlSelectRecord& selRec) override;
+   Bool_t Handle(TGLRnrCtx& rnrCtx, TGLOvlSelectRecord& selRec,
+                         Event_t* event) override;
+   void   MouseLeave() override;
 
    void CloseEditor();
 
    void UpdateText();
 
-   virtual void   Render(TGLRnrCtx& rnrCtx);
+   void   Render(TGLRnrCtx& rnrCtx) override;
 
-   ClassDef(TGLAnnotation, 0); // GL-annotation.
+   ClassDefOverride(TGLAnnotation, 0); // GL-annotation.
 };
 
 #endif

--- a/graf3d/gl/inc/TGLAutoRotator.h
+++ b/graf3d/gl/inc/TGLAutoRotator.h
@@ -53,7 +53,7 @@ protected:
 
 public:
    TGLAutoRotator(TGLViewer* v);
-   virtual ~TGLAutoRotator();
+   ~TGLAutoRotator() override;
 
    TGLViewer* GetViewer() const { return fViewer; }
    TGLCamera* GetCamera() const { return fCamera; }
@@ -111,7 +111,7 @@ public:
 
    void     StartImageAutoSaveWithGUISettings();
 
-   ClassDef(TGLAutoRotator, 0); // Automatic, timer-based, rotation of GL-viewer's camera.
+   ClassDefOverride(TGLAutoRotator, 0); // Automatic, timer-based, rotation of GL-viewer's camera.
 };
 
 #endif

--- a/graf3d/gl/inc/TGLAxis.h
+++ b/graf3d/gl/inc/TGLAxis.h
@@ -48,7 +48,7 @@ private:
 
 public:
    TGLAxis();
-   virtual ~TGLAxis();
+   ~TGLAxis() override;
 
    void PaintGLAxis             (const Double_t p1[3], const Double_t p2[3],
                                  Double_t wmin , Double_t wmax , Int_t ndiv,
@@ -68,7 +68,7 @@ public:
    void SetGridLength           (Double_t grid){fGridLength = grid;}
    void SetLabelsAngles         (Double_t a1, Double_t a2, Double_t a3);
 
-   ClassDef(TGLAxis,0) // a GL Axis
+   ClassDefOverride(TGLAxis,0) // a GL Axis
 };
 
 #endif

--- a/graf3d/gl/inc/TGLAxisPainter.h
+++ b/graf3d/gl/inc/TGLAxisPainter.h
@@ -146,14 +146,14 @@ protected:
 
 public:
    TGLAxisPainterBox();
-   virtual ~TGLAxisPainterBox();
+   ~TGLAxisPainterBox() override;
 
    void SetAxis3DTitlePos(TGLRnrCtx &rnrCtx);
    void DrawAxis3D(TGLRnrCtx &rnrCtx);
 
    void PlotStandard(TGLRnrCtx &rnrCtx, TH1* histo, const TGLBoundingBox& bbox);
 
-   ClassDef(TGLAxisPainterBox, 0); // Painter of GL axes for a 3D box.
+   ClassDefOverride(TGLAxisPainterBox, 0); // Painter of GL axes for a 3D box.
 };
 
 #endif

--- a/graf3d/gl/inc/TGLBoxPainter.h
+++ b/graf3d/gl/inc/TGLBoxPainter.h
@@ -59,34 +59,34 @@ public:
    TGLBoxPainter(TH1 *hist, TPolyMarker3D * pm,
                  TGLPlotCamera *camera, TGLPlotCoordinates *coord);
 
-   char   *GetPlotInfo(Int_t px, Int_t py);
-   Bool_t  InitGeometry();
-   void    StartPan(Int_t px, Int_t py);
-   void    Pan(Int_t px, Int_t py);
-   void    AddOption(const TString &stringOption);
-   void    ProcessEvent(Int_t event, Int_t px, Int_t py);
+   char   *GetPlotInfo(Int_t px, Int_t py) override;
+   Bool_t  InitGeometry() override;
+   void    StartPan(Int_t px, Int_t py) override;
+   void    Pan(Int_t px, Int_t py) override;
+   void    AddOption(const TString &stringOption) override;
+   void    ProcessEvent(Int_t event, Int_t px, Int_t py) override;
 
 private:
    //Overriders
-   void    InitGL()const;
-   void    DeInitGL()const;
+   void    InitGL()const override;
+   void    DeInitGL()const override;
 
-   void    DrawPlot()const;
+   void    DrawPlot()const override;
    //Special type of TH3:
    void    DrawCloud()const;
 
    void    SetPlotColor()const;
 
-   void    DrawSectionXOZ()const;
-   void    DrawSectionYOZ()const;
-   void    DrawSectionXOY()const;
+   void    DrawSectionXOZ()const override;
+   void    DrawSectionYOZ()const override;
+   void    DrawSectionXOY()const override;
 
    void    DrawPalette()const;
-   void    DrawPaletteAxis()const;
+   void    DrawPaletteAxis()const override;
 
    Bool_t  HasSections()const;
 
-   ClassDef(TGLBoxPainter, 0)//Box painter
+   ClassDefOverride(TGLBoxPainter, 0)//Box painter
 };
 
 #endif

--- a/graf3d/gl/inc/TGLCamera.h
+++ b/graf3d/gl/inc/TGLCamera.h
@@ -113,7 +113,7 @@ protected:
 public:
    TGLCamera();
    TGLCamera(const TGLVector3 & hAxis, const TGLVector3 & vAxis);
-   virtual ~TGLCamera();
+   ~TGLCamera() override;
 
    virtual Bool_t IsOrthographic() const {  return kFALSE; }
    virtual Bool_t IsPerspective() const { return kFALSE; }
@@ -213,7 +213,7 @@ public:
    // Debuging - draw frustum and interest boxes
    void  DrawDebugAids() const;
 
-   ClassDef(TGLCamera,1); // Camera abstract base class.
+   ClassDefOverride(TGLCamera,1); // Camera abstract base class.
 };
 
 inline const TGLPlane & TGLCamera::FrustumPlane(EFrustumPlane plane) const

--- a/graf3d/gl/inc/TGLCameraGuide.h
+++ b/graf3d/gl/inc/TGLCameraGuide.h
@@ -31,21 +31,21 @@ protected:
 public:
    TGLCameraGuide(Float_t x, Float_t y, Float_t s,
                   ERole role=kUser, EState state=kActive);
-   virtual ~TGLCameraGuide() {}
+   ~TGLCameraGuide() override {}
 
    void SetX(Float_t x) { fXPos = x; }
    void SetY(Float_t y) { fYPos = y; }
    void SetXY(Float_t x, Float_t y) { fXPos = x; fYPos = y; }
    void SetSize(Float_t s) { fSize = s; }
 
-   virtual Bool_t MouseEnter(TGLOvlSelectRecord& selRec);
-   virtual Bool_t Handle(TGLRnrCtx& rnrCtx, TGLOvlSelectRecord& selRec,
-                         Event_t* event);
-   virtual void   MouseLeave();
+   Bool_t MouseEnter(TGLOvlSelectRecord& selRec) override;
+   Bool_t Handle(TGLRnrCtx& rnrCtx, TGLOvlSelectRecord& selRec,
+                         Event_t* event) override;
+   void   MouseLeave() override;
 
-   virtual void Render(TGLRnrCtx& rnrCtx);
+   void Render(TGLRnrCtx& rnrCtx) override;
 
-   ClassDef(TGLCameraGuide, 0); // Short description.
+   ClassDefOverride(TGLCameraGuide, 0); // Short description.
 };
 
 #endif

--- a/graf3d/gl/inc/TGLCameraOverlay.h
+++ b/graf3d/gl/inc/TGLCameraOverlay.h
@@ -56,9 +56,9 @@ protected:
 
 public:
    TGLCameraOverlay(Bool_t showOrtho=kTRUE, Bool_t showPersp=kFALSE);
-   virtual ~TGLCameraOverlay();
+   ~TGLCameraOverlay() override;
 
-   virtual  void   Render(TGLRnrCtx& rnrCtx);
+    void   Render(TGLRnrCtx& rnrCtx) override;
 
    TGLPlane& RefExternalRefPlane() { return fExternalRefPlane; }
    void      UseExternalRefPlane(Bool_t x) { fUseExternalRefPlane=x; }
@@ -78,7 +78,7 @@ public:
 
    TAttAxis* GetAttAxis();
 
-   ClassDef(TGLCameraOverlay, 1); // Show coorinates of current camera frustum.
+   ClassDefOverride(TGLCameraOverlay, 1); // Show coorinates of current camera frustum.
 };
 
 #endif

--- a/graf3d/gl/inc/TGLClip.h
+++ b/graf3d/gl/inc/TGLClip.h
@@ -50,7 +50,7 @@ protected:
 
 public:
    TGLClip(const TGLLogicalShape & logical, const TGLMatrix & transform, const float color[4]);
-   virtual ~TGLClip();
+   ~TGLClip() override;
 
    virtual void Modified() { TGLPhysicalShape::Modified(); IncTimeStamp(); }
 
@@ -66,10 +66,10 @@ public:
    Bool_t IsValid() const { return fValid;   }
    void   Invalidate()    { fValid = kFALSE; }
 
-   virtual void Draw(TGLRnrCtx & rnrCtx) const;
+   void Draw(TGLRnrCtx & rnrCtx) const override;
    virtual void PlaneSet(TGLPlaneSet_t & set) const = 0;
 
-   ClassDef(TGLClip,0); // abstract clipping object
+   ClassDefOverride(TGLClip,0); // abstract clipping object
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -89,16 +89,16 @@ private:
 
 public:
    TGLClipPlane();
-   virtual ~TGLClipPlane();
+   ~TGLClipPlane() override;
 
-   virtual void Setup(const TGLBoundingBox & bbox);
-   virtual void Setup(const TGLVector3& point, const TGLVector3& normal);
+   void Setup(const TGLBoundingBox & bbox) override;
+   void Setup(const TGLVector3& point, const TGLVector3& normal) override;
 
    void Set(const TGLPlane & plane);
 
-   virtual void PlaneSet(TGLPlaneSet_t & set) const;
+   void PlaneSet(TGLPlaneSet_t & set) const override;
 
-   ClassDef(TGLClipPlane, 0); // clipping plane
+   ClassDefOverride(TGLClipPlane, 0); // clipping plane
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -117,14 +117,14 @@ private:
 
 public:
    TGLClipBox();
-   virtual ~TGLClipBox();
+   ~TGLClipBox() override;
 
-   virtual void Setup(const TGLBoundingBox & bbox);
-   virtual void Setup(const TGLVector3& min_point, const TGLVector3& max_point);
+   void Setup(const TGLBoundingBox & bbox) override;
+   void Setup(const TGLVector3& min_point, const TGLVector3& max_point) override;
 
-   virtual void PlaneSet(TGLPlaneSet_t & set) const;
+   void PlaneSet(TGLPlaneSet_t & set) const override;
 
-   ClassDef(TGLClipBox, 0); // clipping box
+   ClassDefOverride(TGLClipBox, 0); // clipping box
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -156,15 +156,15 @@ protected:
 
 public:
    TGLClipSet();
-   virtual ~TGLClipSet();
+   ~TGLClipSet() override;
 
-   virtual Bool_t MouseEnter(TGLOvlSelectRecord& selRec);
-   virtual Bool_t MouseStillInside(TGLOvlSelectRecord& selRec);
-   virtual Bool_t Handle(TGLRnrCtx& rnrCtx, TGLOvlSelectRecord& selRec,
-                         Event_t* event);
-   virtual void   MouseLeave();
+   Bool_t MouseEnter(TGLOvlSelectRecord& selRec) override;
+   Bool_t MouseStillInside(TGLOvlSelectRecord& selRec) override;
+   Bool_t Handle(TGLRnrCtx& rnrCtx, TGLOvlSelectRecord& selRec,
+                         Event_t* event) override;
+   void   MouseLeave() override;
 
-   virtual void Render(TGLRnrCtx& rnrCtx);
+   void Render(TGLRnrCtx& rnrCtx) override;
 
    Bool_t    IsClipping()     const { return fCurrentClip != nullptr; }
    TGLClip*  GetCurrentClip() const { return fCurrentClip; }
@@ -192,7 +192,7 @@ public:
    Bool_t GetShowClip()       const { return fShowClip; }
    void   SetShowClip(Bool_t show)  { fShowClip = show; }
 
-   ClassDef(TGLClipSet, 0); // A collection of supported clip-objects
+   ClassDefOverride(TGLClipSet, 0); // A collection of supported clip-objects
 };
 
 #endif

--- a/graf3d/gl/inc/TGLClipSetEditor.h
+++ b/graf3d/gl/inc/TGLClipSetEditor.h
@@ -49,7 +49,7 @@ protected:
 
 public:
    TGLClipSetSubEditor(const TGWindow* p);
-   virtual ~TGLClipSetSubEditor() {}
+   ~TGLClipSetSubEditor() override {}
 
    void SetModel(TGLClipSet* m);
 
@@ -61,7 +61,7 @@ public:
    void UpdateViewerClip();
    void ResetViewerClip();
 
-   ClassDef(TGLClipSetSubEditor, 0); // Sub-editor for TGLClipSet.
+   ClassDefOverride(TGLClipSetSubEditor, 0); // Sub-editor for TGLClipSet.
 };
 
 
@@ -77,11 +77,11 @@ protected:
 
 public:
    TGLClipSetEditor(const TGWindow *p = nullptr, Int_t width=170, Int_t height=30, UInt_t options=kChildFrame, Pixel_t back=GetDefaultFrameBackground());
-   virtual ~TGLClipSetEditor() {}
+   ~TGLClipSetEditor() override {}
 
-   virtual void SetModel(TObject* obj);
+   void SetModel(TObject* obj) override;
 
-   ClassDef(TGLClipSetEditor, 0); // GUI editor for TGLClipSet.
+   ClassDefOverride(TGLClipSetEditor, 0); // GUI editor for TGLClipSet.
 };
 
 #endif

--- a/graf3d/gl/inc/TGLCylinder.h
+++ b/graf3d/gl/inc/TGLCylinder.h
@@ -30,24 +30,24 @@ private:
 
 public:
    TGLCylinder(const TBuffer3DTube & buffer);
-   ~TGLCylinder();
+   ~TGLCylinder() override;
 
-   virtual UInt_t DLOffset(Short_t lod) const;
+   UInt_t DLOffset(Short_t lod) const override;
 
    // Cylinders support LOD (tesselation quality) adjustment along
    // X/Y axes (round the cylinder radius), but not along length (Z)
-   virtual ELODAxes SupportedLODAxes() const
+   ELODAxes SupportedLODAxes() const override
    {
       // return ELODAxes(kLODAxesX | kLODAxesY);
       // MT 2020-06-05: There seems to be a problem with TGLPhysicalShape::CalculateShapeLOD()
       // and LOD is set to Pixel way too early. Resetting this to kLODAxesAll.
       return ELODAxes(kLODAxesAll);
    }
-   virtual Short_t  QuantizeShapeLOD(Short_t shapeLOD, Short_t combiLOD) const;
-   virtual void     DirectDraw(TGLRnrCtx & rnrCtx) const;
+   Short_t  QuantizeShapeLOD(Short_t shapeLOD, Short_t combiLOD) const override;
+   void     DirectDraw(TGLRnrCtx & rnrCtx) const override;
 
 private:
-   ClassDef(TGLCylinder,0); // a cylinderical logical shape
+   ClassDefOverride(TGLCylinder,0); // a cylinderical logical shape
 };
 
 #endif

--- a/graf3d/gl/inc/TGLEmbeddedViewer.h
+++ b/graf3d/gl/inc/TGLEmbeddedViewer.h
@@ -36,12 +36,12 @@ private:
 public:
    TGLEmbeddedViewer(const TGWindow *parent, TVirtualPad *pad = nullptr, Int_t border=2);
    TGLEmbeddedViewer(const TGWindow *parent, TVirtualPad *pad, TGedEditor *ged, Int_t border=2);
-   ~TGLEmbeddedViewer();
+   ~TGLEmbeddedViewer() override;
 
-   virtual void CreateGLWidget();
-   virtual void DestroyGLWidget();
+   void CreateGLWidget() override;
+   void DestroyGLWidget() override;
 
-   virtual const char *GetName() const { return "GLViewer"; }
+   const char *GetName() const override { return "GLViewer"; }
 
    TGCompositeFrame*   GetFrame() const { return fFrame; }
 
@@ -50,7 +50,7 @@ public:
    TGLOrthoCamera     *GetOrthoZOYCamera() { return &fOrthoZOYCamera; }
    TGLOrthoCamera     *GetOrthoZOXCamera() { return &fOrthoZOXCamera; }
 
-   ClassDef(TGLEmbeddedViewer, 0); // Embedded GL viewer.
+   ClassDefOverride(TGLEmbeddedViewer, 0); // Embedded GL viewer.
 };
 
 #endif

--- a/graf3d/gl/inc/TGLEventHandler.h
+++ b/graf3d/gl/inc/TGLEventHandler.h
@@ -65,23 +65,23 @@ protected:
 
 public:
    TGLEventHandler(TGWindow *w, TObject *obj);
-   virtual ~TGLEventHandler();
+   ~TGLEventHandler() override;
 
-   virtual void   ExecuteEvent(Int_t event, Int_t px, Int_t py);
-   virtual Bool_t HandleEvent(Event_t *event);
+   void   ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
+   Bool_t HandleEvent(Event_t *event) override;
    virtual Bool_t HandleExpose(Event_t * event);
-   virtual Bool_t HandleFocusChange(Event_t *event);
-   virtual Bool_t HandleCrossing(Event_t *event);
-   virtual Bool_t HandleButton(Event_t * event);
-   virtual Bool_t HandleDoubleClick(Event_t *event);
-   virtual Bool_t HandleConfigureNotify(Event_t *event);
-   virtual Bool_t HandleKey(Event_t *event);
-   virtual Bool_t HandleMotion(Event_t * event);
-   virtual Bool_t HandleTimer(TTimer *t);
+   Bool_t HandleFocusChange(Event_t *event) override;
+   Bool_t HandleCrossing(Event_t *event) override;
+   Bool_t HandleButton(Event_t * event) override;
+   Bool_t HandleDoubleClick(Event_t *event) override;
+   Bool_t HandleConfigureNotify(Event_t *event) override;
+   Bool_t HandleKey(Event_t *event) override;
+   Bool_t HandleMotion(Event_t * event) override;
+   Bool_t HandleTimer(TTimer *t) override;
    virtual void   StartMouseTimer();
    virtual void   StopMouseTimer();
    virtual void   ClearMouseOver();
-   virtual void   Repaint();
+   void   Repaint() override;
 
    virtual void   PopupContextMenu(TGLPhysicalShape* pshp, Event_t *event, Int_t gx, Int_t gy);
 
@@ -103,7 +103,7 @@ public:
    Bool_t GetArcBall() const   { return fArcBall; }
    void   SetArcBall(Bool_t a) { fArcBall = a;    }
 
-   ClassDef(TGLEventHandler, 0); // Base-class and default implementation of event-handler for TGLViewer.
+   ClassDefOverride(TGLEventHandler, 0); // Base-class and default implementation of event-handler for TGLViewer.
 };
 
 #endif

--- a/graf3d/gl/inc/TGLFaceSet.h
+++ b/graf3d/gl/inc/TGLFaceSet.h
@@ -32,7 +32,7 @@ private:
 public:
    TGLFaceSet(const TBuffer3D & buffer);
 
-   virtual void DirectDraw(TGLRnrCtx & rnrCtx) const;
+   void DirectDraw(TGLRnrCtx & rnrCtx) const override;
 
    void SetFromMesh(const RootCsg::TBaseMesh *m);
    void CalculateNormals();
@@ -52,7 +52,7 @@ private:
 
    static Bool_t Eq(const Double_t *p1, const Double_t *p2);
 
-   ClassDef(TGLFaceSet,0) // a faceset logical shape
+   ClassDefOverride(TGLFaceSet,0) // a faceset logical shape
 };
 
 #endif

--- a/graf3d/gl/inc/TGLH2PolyPainter.h
+++ b/graf3d/gl/inc/TGLH2PolyPainter.h
@@ -15,18 +15,18 @@ class TGLH2PolyPainter : public TGLPlotPainter {
 public:
    TGLH2PolyPainter(TH1 *hist, TGLPlotCamera *camera, TGLPlotCoordinates *coord);
 
-   char        *GetPlotInfo(Int_t px, Int_t py);
-   Bool_t       InitGeometry();
-   void         StartPan(Int_t px, Int_t py);
-   void         Pan(Int_t px, Int_t py);
-   void         AddOption(const TString &stringOption);
-   void         ProcessEvent(Int_t event, Int_t px, Int_t py);
+   char        *GetPlotInfo(Int_t px, Int_t py) override;
+   Bool_t       InitGeometry() override;
+   void         StartPan(Int_t px, Int_t py) override;
+   void         Pan(Int_t px, Int_t py) override;
+   void         AddOption(const TString &stringOption) override;
+   void         ProcessEvent(Int_t event, Int_t px, Int_t py) override;
 
 private:
    //Overriders
-   void         InitGL()const;
-   void         DeInitGL()const;
-   void         DrawPlot()const;
+   void         InitGL()const override;
+   void         DeInitGL()const override;
+   void         DrawPlot()const override;
    //Aux. functions.
    //Draw edges of a bin.
    void         DrawExtrusion()const;
@@ -46,11 +46,11 @@ private:
    void         SetBinColor(Int_t bin)const;
 
    //Empty overriders.
-   void         DrawSectionXOZ()const;
-   void         DrawSectionYOZ()const;
-   void         DrawSectionXOY()const;
+   void         DrawSectionXOZ()const override;
+   void         DrawSectionYOZ()const override;
+   void         DrawSectionXOY()const override;
    void         DrawPalette()const;
-   void         DrawPaletteAxis()const;
+   void         DrawPaletteAxis()const override;
 
    //Aux. staff.
    void         FillTemporaryPolygon(const Double_t *xs, const Double_t *ys, Double_t z, Int_t n)const;
@@ -67,7 +67,7 @@ private:
    Bool_t                             fZLog;//Change in logZ updates only bin heights.
    Double_t                           fZMin;
 
-   ClassDef(TGLH2PolyPainter, 0); //Painter class for TH2Poly.
+   ClassDefOverride(TGLH2PolyPainter, 0); //Painter class for TH2Poly.
 };
 
 #endif

--- a/graf3d/gl/inc/TGLHistPainter.h
+++ b/graf3d/gl/inc/TGLHistPainter.h
@@ -60,22 +60,22 @@ public:
    TGLHistPainter(TGLTH3Composition *comp);
 
    //TVirtualHistPainter final overriders
-   Int_t          DistancetoPrimitive(Int_t px, Int_t py);
-   void           DrawPanel();
-   void           ExecuteEvent(Int_t event, Int_t px, Int_t py);
-   TList         *GetContourList(Double_t contour)const;
-   char          *GetObjectInfo(Int_t px, Int_t py)const;
-   TList         *GetStack()const;
-   Bool_t         IsInside(Int_t x, Int_t y);
-   Bool_t         IsInside(Double_t x, Double_t y);
-   void           Paint(Option_t *option);
-   void           PaintStat(Int_t dostat, TF1 *fit);
-   void           ProcessMessage(const char *message, const TObject *obj);
-   void           SetHighlight();
-   void           SetHistogram(TH1 *hist);
-   void           SetStack(TList *stack);
-   Int_t          MakeCuts(char *cutsOpt);
-   void           SetShowProjection(const char *option, Int_t nbins);
+   Int_t          DistancetoPrimitive(Int_t px, Int_t py) override;
+   void           DrawPanel() override;
+   void           ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
+   TList         *GetContourList(Double_t contour)const override;
+   char          *GetObjectInfo(Int_t px, Int_t py)const override;
+   TList         *GetStack()const override;
+   Bool_t         IsInside(Int_t x, Int_t y) override;
+   Bool_t         IsInside(Double_t x, Double_t y) override;
+   void           Paint(Option_t *option) override;
+   void           PaintStat(Int_t dostat, TF1 *fit) override;
+   void           ProcessMessage(const char *message, const TObject *obj) override;
+   void           SetHighlight() override;
+   void           SetHistogram(TH1 *hist) override;
+   void           SetStack(TList *stack) override;
+   Int_t          MakeCuts(char *cutsOpt) override;
+   void           SetShowProjection(const char *option, Int_t nbins) override;
 
    TGLPlotPainter *GetRealPainter(){return fGLPainter.get();}
 private:
@@ -91,7 +91,7 @@ private:
    TGLHistPainter(const TGLHistPainter &);
    TGLHistPainter &operator = (const TGLHistPainter &);
 
-   ClassDef(TGLHistPainter, 0) //Proxy class for GL hist painters.
+   ClassDefOverride(TGLHistPainter, 0) //Proxy class for GL hist painters.
 };
 
 #endif

--- a/graf3d/gl/inc/TGLLegoPainter.h
+++ b/graf3d/gl/inc/TGLLegoPainter.h
@@ -61,12 +61,12 @@ public:
    TGLLegoPainter(TH1 *hist, TGLPlotCamera *camera, TGLPlotCoordinates *coord);
 
    //TGLPlotPainter's final-overriders
-   char        *GetPlotInfo(Int_t px, Int_t py);
-   Bool_t       InitGeometry();
-   void         StartPan(Int_t px, Int_t py);
-   void         Pan(Int_t px, Int_t py);
-   void         AddOption(const TString &stringOption);
-   void         ProcessEvent(Int_t event, Int_t px, Int_t py);
+   char        *GetPlotInfo(Int_t px, Int_t py) override;
+   Bool_t       InitGeometry() override;
+   void         StartPan(Int_t px, Int_t py) override;
+   void         Pan(Int_t px, Int_t py) override;
+   void         AddOption(const TString &stringOption) override;
+   void         ProcessEvent(Int_t event, Int_t px, Int_t py) override;
 
 private:
    //Auxilary functions.
@@ -75,10 +75,10 @@ private:
    Bool_t       InitGeometryCylindrical();
    Bool_t       InitGeometrySpherical();
    //Overriders
-   void         InitGL()const;
-   void         DeInitGL()const;
+   void         InitGL()const override;
+   void         DeInitGL()const override;
 
-   void         DrawPlot()const;
+   void         DrawPlot()const override;
 
    void         DrawLegoCartesian()const;
    void         DrawLegoPolar()const;
@@ -87,17 +87,17 @@ private:
 
    void         SetLegoColor()const;
 
-   void         DrawSectionXOZ()const;
-   void         DrawSectionYOZ()const;
-   void         DrawSectionXOY()const;
+   void         DrawSectionXOZ()const override;
+   void         DrawSectionYOZ()const override;
+   void         DrawSectionXOY()const override;
 
    Bool_t       ClampZ(Double_t &zVal)const;
    Bool_t       PreparePalette()const;
 
    void         DrawPalette()const;
-   void         DrawPaletteAxis()const;
+   void         DrawPaletteAxis()const override;
 
-   ClassDef(TGLLegoPainter, 0)//Lego painter
+   ClassDefOverride(TGLLegoPainter, 0)//Lego painter
 };
 
 #endif

--- a/graf3d/gl/inc/TGLLightSet.h
+++ b/graf3d/gl/inc/TGLLightSet.h
@@ -42,7 +42,7 @@ protected:
 
 public:
    TGLLightSet();
-   virtual ~TGLLightSet() {}
+   ~TGLLightSet() override {}
 
    void    ToggleLight(ELight light);
    void    SetLight(ELight light, Bool_t on);
@@ -61,7 +61,7 @@ public:
    void StdSetupLights(const TGLBoundingBox& bbox, const TGLCamera& camera,
                        Bool_t debug=kFALSE);
 
-   ClassDef(TGLLightSet, 0) // A set of OpenGL lights.
+   ClassDefOverride(TGLLightSet, 0) // A set of OpenGL lights.
 }; // endclass TGLLightSet
 
 

--- a/graf3d/gl/inc/TGLLightSetEditor.h
+++ b/graf3d/gl/inc/TGLLightSetEditor.h
@@ -39,7 +39,7 @@ protected:
 
 public:
    TGLLightSetSubEditor(const TGWindow* p);
-   virtual ~TGLLightSetSubEditor() {}
+   ~TGLLightSetSubEditor() override {}
 
    void SetModel(TGLLightSet* m);
 
@@ -47,7 +47,7 @@ public:
 
    void DoButton();
 
-   ClassDef(TGLLightSetSubEditor, 0) // Sub-editor for TGLLightSet.
+   ClassDefOverride(TGLLightSetSubEditor, 0) // Sub-editor for TGLLightSet.
 };
 
 
@@ -63,11 +63,11 @@ protected:
 
 public:
    TGLLightSetEditor(const TGWindow *p = nullptr, Int_t width=170, Int_t height=30, UInt_t options=kChildFrame, Pixel_t back=GetDefaultFrameBackground());
-   virtual ~TGLLightSetEditor();
+   ~TGLLightSetEditor() override;
 
-   virtual void SetModel(TObject* obj);
+   void SetModel(TObject* obj) override;
 
-   ClassDef(TGLLightSetEditor, 0); // Editor for TGLLightSet.
+   ClassDefOverride(TGLLightSetEditor, 0); // Editor for TGLLightSet.
 }; // endclass TGLLightSetEditor
 
 #endif

--- a/graf3d/gl/inc/TGLManip.h
+++ b/graf3d/gl/inc/TGLManip.h
@@ -47,7 +47,7 @@ protected:
 public:
    TGLManip();
    TGLManip(TGLPhysicalShape* shape);
-   virtual ~TGLManip();
+   ~TGLManip() override;
 
    UInt_t GetSelectedWidget()   const { return fSelectedWidget; }
    void   SetSelectedWidget(UInt_t s) { fSelectedWidget = s; }
@@ -60,12 +60,12 @@ public:
 
    virtual void   Draw(const TGLCamera& camera) const = 0;
    // CRAPPY TVirtualGLManip TTTT, just override it here
-   virtual Bool_t Select(const TGLCamera&, const TGLRect&, const TGLBoundingBox&) { return kFALSE; }
+   Bool_t Select(const TGLCamera&, const TGLRect&, const TGLBoundingBox&) override { return kFALSE; }
 
    virtual Bool_t HandleButton(const Event_t& event, const TGLCamera& camera);
    virtual Bool_t HandleMotion(const Event_t& event, const TGLCamera& camera);
 
-   ClassDef(TGLManip, 0); // abstract base GL manipulator widget
+   ClassDefOverride(TGLManip, 0); // abstract base GL manipulator widget
 };
 
 #endif

--- a/graf3d/gl/inc/TGLManipSet.h
+++ b/graf3d/gl/inc/TGLManipSet.h
@@ -35,16 +35,16 @@ protected:
 
 public:
    TGLManipSet();
-   virtual ~TGLManipSet();
+   ~TGLManipSet() override;
 
-   virtual void SetPShape(TGLPhysicalShape* shape);
+   void SetPShape(TGLPhysicalShape* shape) override;
 
-   virtual Bool_t MouseEnter(TGLOvlSelectRecord& selRec);
-   virtual Bool_t Handle(TGLRnrCtx& rnrCtx, TGLOvlSelectRecord& selRec,
-                         Event_t* event);
-   virtual void   MouseLeave();
+   Bool_t MouseEnter(TGLOvlSelectRecord& selRec) override;
+   Bool_t Handle(TGLRnrCtx& rnrCtx, TGLOvlSelectRecord& selRec,
+                         Event_t* event) override;
+   void   MouseLeave() override;
 
-   virtual void Render(TGLRnrCtx& rnrCtx);
+   void Render(TGLRnrCtx& rnrCtx) override;
 
    TGLManip* GetCurrentManip() const { return fManip[fType]; }
 
@@ -53,7 +53,7 @@ public:
    Bool_t GetDrawBBox()    const { return fDrawBBox; }
    void   SetDrawBBox(Bool_t bb) { fDrawBBox = bb; }
 
-   ClassDef(TGLManipSet, 0); // A collection of available manipulators.
+   ClassDefOverride(TGLManipSet, 0); // A collection of available manipulators.
 }; // endclass TGLManipSet
 
 

--- a/graf3d/gl/inc/TGLObject.h
+++ b/graf3d/gl/inc/TGLObject.h
@@ -51,16 +51,16 @@ protected:
 
 public:
    TGLObject() : TGLLogicalShape(nullptr), fMultiColor(kFALSE) {}
-   virtual ~TGLObject() {}
+   ~TGLObject() override {}
 
-   virtual Bool_t ShouldDLCache(const TGLRnrCtx& rnrCtx) const;
+   Bool_t ShouldDLCache(const TGLRnrCtx& rnrCtx) const override;
 
    // Kept from TGLLogicalShape
    // virtual ELODAxes SupportedLODAxes() const { return kLODAxesNone; }
 
    // Changed from TGLLogicalShape
-   virtual Bool_t KeepDuringSmartRefresh() const { return kTRUE; }
-   virtual void   UpdateBoundingBox();
+   Bool_t KeepDuringSmartRefresh() const override { return kTRUE; }
+   void   UpdateBoundingBox() override;
 
    // TGLObject virtuals
    virtual Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr) = 0;
@@ -71,7 +71,7 @@ public:
    // Interface to class .vs. classGL map.
    static TClass* GetGLRenderer(TClass* isa);
 
-   ClassDef(TGLObject, 0); // Base-class for direct OpenGL renderers
+   ClassDefOverride(TGLObject, 0); // Base-class for direct OpenGL renderers
 };
 
 #endif

--- a/graf3d/gl/inc/TGLOrthoCamera.h
+++ b/graf3d/gl/inc/TGLOrthoCamera.h
@@ -58,24 +58,24 @@ private:
 public:
    TGLOrthoCamera();
    TGLOrthoCamera(EType type, const TGLVector3 & hAxis, const TGLVector3 & vAxis);
-   virtual ~TGLOrthoCamera();
+   ~TGLOrthoCamera() override;
 
-   virtual Bool_t IsOrthographic() const { return kTRUE; }
+   Bool_t IsOrthographic() const override { return kTRUE; }
 
-   virtual void   Setup(const TGLBoundingBox & box, Bool_t reset=kTRUE);
-   virtual void   Reset();
+   void   Setup(const TGLBoundingBox & box, Bool_t reset=kTRUE) override;
+   void   Reset() override;
 
-   virtual Bool_t Dolly(Int_t delta, Bool_t mod1, Bool_t mod2);
-   virtual Bool_t Zoom (Int_t delta, Bool_t mod1, Bool_t mod2);
+   Bool_t Dolly(Int_t delta, Bool_t mod1, Bool_t mod2) override;
+   Bool_t Zoom (Int_t delta, Bool_t mod1, Bool_t mod2) override;
    using   TGLCamera::Truck;
-   virtual Bool_t Truck(Int_t xDelta, Int_t yDelta, Bool_t mod1, Bool_t mod2);
-   virtual Bool_t Rotate(Int_t xDelta, Int_t yDelta, Bool_t mod1, Bool_t mod2);
-   virtual void   Apply(const TGLBoundingBox & sceneBox, const TGLRect * pickRect = nullptr) const;
+   Bool_t Truck(Int_t xDelta, Int_t yDelta, Bool_t mod1, Bool_t mod2) override;
+   Bool_t Rotate(Int_t xDelta, Int_t yDelta, Bool_t mod1, Bool_t mod2) override;
+   void   Apply(const TGLBoundingBox & sceneBox, const TGLRect * pickRect = nullptr) const override;
 
    // External scripting control
    //   void Configure(Double_t left, Double_t right, Double_t top, Double_t bottom);
-   virtual void Configure(Double_t zoom, Double_t dolly, Double_t center[3],
-                          Double_t hRotate, Double_t vRotate);
+   void Configure(Double_t zoom, Double_t dolly, Double_t center[3],
+                          Double_t hRotate, Double_t vRotate) override;
 
    void     SetEnableRotate(Bool_t x) { fEnableRotate = x; }
    Bool_t   GetEnableRotate()   const { return fEnableRotate; }
@@ -92,7 +92,7 @@ public:
    void     SetZoom(Double_t x) { fZoom = x; }
    Double_t GetZoom() const { return fZoom; }
 
-   ClassDef(TGLOrthoCamera,1) // Camera for orthographic view.
+   ClassDefOverride(TGLOrthoCamera,1) // Camera for orthographic view.
 };
 
 #endif // ROOT_TGLOrthoCamera

--- a/graf3d/gl/inc/TGLOverlayButton.h
+++ b/graf3d/gl/inc/TGLOverlayButton.h
@@ -46,13 +46,13 @@ protected:
 public:
    TGLOverlayButton(TGLViewerBase *parent, const char *text, Float_t posx,
                     Float_t posy, Float_t width, Float_t height);
-   virtual ~TGLOverlayButton() { }
+   ~TGLOverlayButton() override { }
 
-   virtual Bool_t       MouseEnter(TGLOvlSelectRecord& selRec);
-   virtual Bool_t       Handle(TGLRnrCtx& rnrCtx, TGLOvlSelectRecord& selRec, Event_t* event);
-   virtual void         MouseLeave();
+   Bool_t       MouseEnter(TGLOvlSelectRecord& selRec) override;
+   Bool_t       Handle(TGLRnrCtx& rnrCtx, TGLOvlSelectRecord& selRec, Event_t* event) override;
+   void         MouseLeave() override;
 
-   virtual void         Render(TGLRnrCtx& rnrCtx);
+   void         Render(TGLRnrCtx& rnrCtx) override;
    virtual void         ResetState() { fActiveID = -1; }
 
    virtual const char  *GetText() const { return fText.Data(); }
@@ -67,7 +67,7 @@ public:
 
    virtual void         Clicked(TGLViewerBase *viewer); // *SIGNAL*
 
-   ClassDef(TGLOverlayButton, 0); // GL-overlay button.
+   ClassDefOverride(TGLOverlayButton, 0); // GL-overlay button.
 };
 
 #endif

--- a/graf3d/gl/inc/TGLPShapeObj.h
+++ b/graf3d/gl/inc/TGLPShapeObj.h
@@ -26,15 +26,15 @@ public:
    TGLPShapeObj() : TObject(), fPShape(nullptr), fViewer(nullptr) {}
    TGLPShapeObj(TGLPhysicalShape* sh, TGLViewer* v) :
       TObject(), fPShape(sh), fViewer(v) {}
-   virtual ~TGLPShapeObj() {}
+   ~TGLPShapeObj() override {}
 
-   virtual const char* GetName() const { return "Selected"; }
+   const char* GetName() const override { return "Selected"; }
 
 private:
    TGLPShapeObj(const TGLPShapeObj &); // Not implemented
    TGLPShapeObj& operator=(const TGLPShapeObj &); // Not implemented
 
-   ClassDef(TGLPShapeObj, 0) // This object wraps TGLPhysicalShape (not a TObject)
+   ClassDefOverride(TGLPShapeObj, 0) // This object wraps TGLPhysicalShape (not a TObject)
 };
 
 #endif

--- a/graf3d/gl/inc/TGLPShapeObjEditor.h
+++ b/graf3d/gl/inc/TGLPShapeObjEditor.h
@@ -70,20 +70,20 @@ private:
    void CreateGeoControls();
    void CreateColorControls();
 
-   virtual void DoRedraw();
+   void DoRedraw() override;
 
 public:
    TGLPShapeObjEditor(const TGWindow *p = nullptr,
                       Int_t width = 140, Int_t height = 30,
                       UInt_t options = kChildFrame,
                       Pixel_t back = GetDefaultFrameBackground());
-   ~TGLPShapeObjEditor();
+   ~TGLPShapeObjEditor() override;
 
    // Virtuals from TGLPShapeRef
-   virtual void SetPShape(TGLPhysicalShape * shape);
-   virtual void PShapeModified();
+   void SetPShape(TGLPhysicalShape * shape) override;
+   void PShapeModified() override;
 
-   virtual void SetModel(TObject* obj);
+   void SetModel(TObject* obj) override;
 
    // geometry
    void SetCenter(const Double_t *center);
@@ -104,7 +104,7 @@ public:
    void DoColorSlider(Int_t val);
    void DoColorButton();
 
-   ClassDef(TGLPShapeObjEditor, 0); //GUI for editing attributes of a physical-shape.
+   ClassDefOverride(TGLPShapeObjEditor, 0); //GUI for editing attributes of a physical-shape.
 };
 
 #endif

--- a/graf3d/gl/inc/TGLPadPainter.h
+++ b/graf3d/gl/inc/TGLPadPainter.h
@@ -52,75 +52,75 @@ public:
    //Final overriders for TVirtualPadPainter pure virtual functions.
    //1. Part, which simply delegates to TVirtualX.
    //Line attributes.
-   Color_t  GetLineColor() const;
-   Style_t  GetLineStyle() const;
-   Width_t  GetLineWidth() const;
+   Color_t  GetLineColor() const override;
+   Style_t  GetLineStyle() const override;
+   Width_t  GetLineWidth() const override;
 
-   void     SetLineColor(Color_t lcolor);
-   void     SetLineStyle(Style_t lstyle);
-   void     SetLineWidth(Width_t lwidth);
+   void     SetLineColor(Color_t lcolor) override;
+   void     SetLineStyle(Style_t lstyle) override;
+   void     SetLineWidth(Width_t lwidth) override;
    //Fill attributes.
-   Color_t  GetFillColor() const;
-   Style_t  GetFillStyle() const;
-   Bool_t   IsTransparent() const;
+   Color_t  GetFillColor() const override;
+   Style_t  GetFillStyle() const override;
+   Bool_t   IsTransparent() const override;
 
-   void     SetFillColor(Color_t fcolor);
-   void     SetFillStyle(Style_t fstyle);
-   void     SetOpacity(Int_t percent);
+   void     SetFillColor(Color_t fcolor) override;
+   void     SetFillStyle(Style_t fstyle) override;
+   void     SetOpacity(Int_t percent) override;
    //Text attributes.
-   Short_t  GetTextAlign() const;
-   Float_t  GetTextAngle() const;
-   Color_t  GetTextColor() const;
-   Font_t   GetTextFont()  const;
-   Float_t  GetTextSize()  const;
-   Float_t  GetTextMagnitude() const;
+   Short_t  GetTextAlign() const override;
+   Float_t  GetTextAngle() const override;
+   Color_t  GetTextColor() const override;
+   Font_t   GetTextFont()  const override;
+   Float_t  GetTextSize()  const override;
+   Float_t  GetTextMagnitude() const override;
 
-   void     SetTextAlign(Short_t align);
-   void     SetTextAngle(Float_t tangle);
-   void     SetTextColor(Color_t tcolor);
-   void     SetTextFont(Font_t tfont);
-   void     SetTextSize(Float_t tsize);
-   void     SetTextSizePixels(Int_t npixels);
+   void     SetTextAlign(Short_t align) override;
+   void     SetTextAngle(Float_t tangle) override;
+   void     SetTextColor(Color_t tcolor) override;
+   void     SetTextFont(Font_t tfont) override;
+   void     SetTextSize(Float_t tsize) override;
+   void     SetTextSizePixels(Int_t npixels) override;
 
    //2. "Off-screen management" part.
-   Int_t    CreateDrawable(UInt_t w, UInt_t h);
-   void     ClearDrawable();
-   void     CopyDrawable(Int_t device, Int_t px, Int_t py);
-   void     DestroyDrawable(Int_t device);
-   void     SelectDrawable(Int_t device);
+   Int_t    CreateDrawable(UInt_t w, UInt_t h) override;
+   void     ClearDrawable() override;
+   void     CopyDrawable(Int_t device, Int_t px, Int_t py) override;
+   void     DestroyDrawable(Int_t device) override;
+   void     SelectDrawable(Int_t device) override;
 
-   void     InitPainter();
-   void     InvalidateCS();
-   void     LockPainter();
+   void     InitPainter() override;
+   void     InvalidateCS() override;
+   void     LockPainter() override;
 
-   void     DrawLine(Double_t x1, Double_t y1, Double_t x2, Double_t y2);
-   void     DrawLineNDC(Double_t u1, Double_t v1, Double_t u2, Double_t v2);
+   void     DrawLine(Double_t x1, Double_t y1, Double_t x2, Double_t y2) override;
+   void     DrawLineNDC(Double_t u1, Double_t v1, Double_t u2, Double_t v2) override;
 
-   void     DrawBox(Double_t x1, Double_t y1, Double_t x2, Double_t y2, EBoxMode mode);
+   void     DrawBox(Double_t x1, Double_t y1, Double_t x2, Double_t y2, EBoxMode mode) override;
    //TPad needs double and float versions.
-   void     DrawFillArea(Int_t n, const Double_t *x, const Double_t *y);
-   void     DrawFillArea(Int_t n, const Float_t *x, const Float_t *y);
+   void     DrawFillArea(Int_t n, const Double_t *x, const Double_t *y) override;
+   void     DrawFillArea(Int_t n, const Float_t *x, const Float_t *y) override;
 
    //TPad needs both double and float versions of DrawPolyLine.
-   void     DrawPolyLine(Int_t n, const Double_t *x, const Double_t *y);
-   void     DrawPolyLine(Int_t n, const Float_t *x, const Float_t *y);
-   void     DrawPolyLineNDC(Int_t n, const Double_t *u, const Double_t *v);
+   void     DrawPolyLine(Int_t n, const Double_t *x, const Double_t *y) override;
+   void     DrawPolyLine(Int_t n, const Float_t *x, const Float_t *y) override;
+   void     DrawPolyLineNDC(Int_t n, const Double_t *u, const Double_t *v) override;
 
    //TPad needs both versions.
-   void     DrawPolyMarker(Int_t n, const Double_t *x, const Double_t *y);
-   void     DrawPolyMarker(Int_t n, const Float_t *x, const Float_t *y);
+   void     DrawPolyMarker(Int_t n, const Double_t *x, const Double_t *y) override;
+   void     DrawPolyMarker(Int_t n, const Float_t *x, const Float_t *y) override;
 
-   void     DrawText(Double_t x, Double_t y, const char *text, ETextMode mode);
-   void     DrawText(Double_t, Double_t, const wchar_t *, ETextMode);
-   void     DrawTextNDC(Double_t x, Double_t y, const char *text, ETextMode mode);
-   void     DrawTextNDC(Double_t, Double_t, const wchar_t *, ETextMode);
+   void     DrawText(Double_t x, Double_t y, const char *text, ETextMode mode) override;
+   void     DrawText(Double_t, Double_t, const wchar_t *, ETextMode) override;
+   void     DrawTextNDC(Double_t x, Double_t y, const char *text, ETextMode mode) override;
+   void     DrawTextNDC(Double_t, Double_t, const wchar_t *, ETextMode) override;
 
    //jpg, png, gif and bmp output.
-   void     SaveImage(TVirtualPad *pad, const char *fileName, Int_t type) const;
+   void     SaveImage(TVirtualPad *pad, const char *fileName, Int_t type) const override;
 
    //TASImage support.
    void     DrawPixels(const unsigned char *pixelData, UInt_t width, UInt_t height,
-                       Int_t dstX, Int_t dstY, Bool_t enableBlending);
+                       Int_t dstX, Int_t dstY, Bool_t enableBlending) override;
 
 
 private:
@@ -151,7 +151,7 @@ private:
    TGLPadPainter(const TGLPadPainter &rhs);
    TGLPadPainter & operator = (const TGLPadPainter &rhs);
 
-   ClassDef(TGLPadPainter, 0)
+   ClassDefOverride(TGLPadPainter, 0)
 };
 
 #endif

--- a/graf3d/gl/inc/TGLParametric.h
+++ b/graf3d/gl/inc/TGLParametric.h
@@ -72,17 +72,17 @@ public:
 
    void         EvalVertex(TGLVertex3 &newVertex, Double_t u, Double_t v)const;
 
-   Int_t        DistancetoPrimitive(Int_t px, Int_t py);
-   void         ExecuteEvent(Int_t event, Int_t px, Int_t py);
-   char        *GetObjectInfo(Int_t px, Int_t py) const;
-   void         Paint(Option_t *option);
+   Int_t        DistancetoPrimitive(Int_t px, Int_t py) override;
+   void         ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
+   char        *GetObjectInfo(Int_t px, Int_t py) const override;
+   void         Paint(Option_t *option) override;
 
 private:
 
    TGLParametricEquation(const TGLParametricEquation &);
    TGLParametricEquation &operator = (const TGLParametricEquation &);
 
-   ClassDef(TGLParametricEquation, 0)//Equation of parametric surface.
+   ClassDefOverride(TGLParametricEquation, 0)//Equation of parametric surface.
 };
 
 class TGLParametricPlot : public TGLPlotPainter {
@@ -112,31 +112,31 @@ private:
 public:
    TGLParametricPlot(TGLParametricEquation *equation, TGLPlotCamera *camera);
 
-   Bool_t   InitGeometry();
-   void     StartPan(Int_t px, Int_t py);
-   void     Pan(Int_t px, Int_t py);
-   char    *GetPlotInfo(Int_t px, Int_t py);
-   void     AddOption(const TString &option);
-   void     ProcessEvent(Int_t event, Int_t px, Int_t py);
+   Bool_t   InitGeometry() override;
+   void     StartPan(Int_t px, Int_t py) override;
+   void     Pan(Int_t px, Int_t py) override;
+   char    *GetPlotInfo(Int_t px, Int_t py) override;
+   void     AddOption(const TString &option) override;
+   void     ProcessEvent(Int_t event, Int_t px, Int_t py) override;
 
 private:
-   void     InitGL()const;
-   void     DeInitGL()const;
+   void     InitGL()const override;
+   void     DeInitGL()const override;
 
-   void     DrawPlot()const;
+   void     DrawPlot()const override;
 
    void     InitColors();
 
-   void     DrawSectionXOZ()const;
-   void     DrawSectionYOZ()const;
-   void     DrawSectionXOY()const;
+   void     DrawSectionXOZ()const override;
+   void     DrawSectionYOZ()const override;
+   void     DrawSectionXOY()const override;
 
    void     SetSurfaceColor()const;
 
    TGLParametricPlot(const TGLParametricPlot &);
    TGLParametricPlot &operator = (const TGLParametricPlot &);
 
-   ClassDef(TGLParametricPlot, 0)//Parametric plot's painter.
+   ClassDefOverride(TGLParametricPlot, 0)//Parametric plot's painter.
 };
 
 #endif

--- a/graf3d/gl/inc/TGLParametricEquationGL.h
+++ b/graf3d/gl/inc/TGLParametricEquationGL.h
@@ -30,19 +30,19 @@ protected:
 
 public:
    TGLParametricEquationGL();
-   virtual ~TGLParametricEquationGL();
+   ~TGLParametricEquationGL() override;
 
-   virtual Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr);
-   virtual void   SetBBox();
-   virtual void   DirectDraw(TGLRnrCtx & rnrCtx) const;
+   Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr) override;
+   void   SetBBox() override;
+   void   DirectDraw(TGLRnrCtx & rnrCtx) const override;
 
-   virtual Bool_t KeepDuringSmartRefresh() const { return kFALSE; }
+   Bool_t KeepDuringSmartRefresh() const override { return kFALSE; }
 
    // To support two-level selection
    // virtual Bool_t SupportsSecondarySelect() const { return kTRUE; }
    // virtual void ProcessSelection(UInt_t* ptr, TGLViewer*, TGLScene*);
 
-   ClassDef(TGLParametricEquationGL, 0); // GL renderer for TGLParametricEquation
+   ClassDefOverride(TGLParametricEquationGL, 0); // GL renderer for TGLParametricEquation
 };
 
 #endif

--- a/graf3d/gl/inc/TGLPerspectiveCamera.h
+++ b/graf3d/gl/inc/TGLPerspectiveCamera.h
@@ -34,25 +34,25 @@ private:
 public:
    TGLPerspectiveCamera();
    TGLPerspectiveCamera(const TGLVector3 & hAxis, const TGLVector3 & vAxis);
-   virtual ~TGLPerspectiveCamera();
+   ~TGLPerspectiveCamera() override;
 
-   virtual Bool_t IsPerspective() const { return kTRUE; }
+   Bool_t IsPerspective() const override { return kTRUE; }
 
    Double_t GetFOV() const { return fFOV; }
    void     SetFOV(Double_t fov) { fFOV = fov; }
 
-   virtual void   Setup(const TGLBoundingBox & box, Bool_t reset=kTRUE);
-   virtual void   Reset();
-   virtual Bool_t Zoom (Int_t delta, Bool_t mod1, Bool_t mod2);
+   void   Setup(const TGLBoundingBox & box, Bool_t reset=kTRUE) override;
+   void   Reset() override;
+   Bool_t Zoom (Int_t delta, Bool_t mod1, Bool_t mod2) override;
    using   TGLCamera::Truck;
-   virtual Bool_t Truck(Int_t xDelta, Int_t yDelta, Bool_t mod1, Bool_t mod2);
-   virtual void   Apply(const TGLBoundingBox & box, const TGLRect * pickRect = nullptr) const;
+   Bool_t Truck(Int_t xDelta, Int_t yDelta, Bool_t mod1, Bool_t mod2) override;
+   void   Apply(const TGLBoundingBox & box, const TGLRect * pickRect = nullptr) const override;
 
    // External scripting control
-   virtual void Configure(Double_t fov, Double_t dolly, Double_t center[3],
-                          Double_t hRotate, Double_t vRotate);
+   void Configure(Double_t fov, Double_t dolly, Double_t center[3],
+                          Double_t hRotate, Double_t vRotate) override;
 
-   ClassDef(TGLPerspectiveCamera,1) // Camera for perspective view.
+   ClassDefOverride(TGLPerspectiveCamera,1) // Camera for perspective view.
 };
 
 #endif // ROOT_TGLPerspectiveCamera

--- a/graf3d/gl/inc/TGLPlot3D.h
+++ b/graf3d/gl/inc/TGLPlot3D.h
@@ -35,15 +35,15 @@ protected:
 
 public:
    TGLPlot3D();
-   virtual ~TGLPlot3D();
+   ~TGLPlot3D() override;
 
-   virtual Bool_t KeepDuringSmartRefresh() const { return kFALSE; }
+   Bool_t KeepDuringSmartRefresh() const override { return kFALSE; }
 
    static TGLPlot3D* CreatePlot(TH3 *h, TPolyMarker3D *pm);
    static TGLPlot3D* CreatePlot(TObject* obj, const Option_t* opt, TVirtualPad* pad);
    static TGLPlot3D* CreatePlot(TObject* obj, const Option_t* opt, Bool_t logx, Bool_t logy, Bool_t logz);
 
-   ClassDef(TGLPlot3D, 0); // Short description.
+   ClassDefOverride(TGLPlot3D, 0); // Short description.
 };
 
 #endif

--- a/graf3d/gl/inc/TGLPlotPainter.h
+++ b/graf3d/gl/inc/TGLPlotPainter.h
@@ -149,7 +149,7 @@ private:
    void   DrawSliceTextured(Double_t pos)const;
    void   DrawSliceFrame(Int_t low, Int_t up)const;
 
-   ClassDef(TGLTH3Slice, 0) // TH3 slice
+   ClassDefOverride(TGLTH3Slice, 0) // TH3 slice
 };
 
 
@@ -237,10 +237,10 @@ public:
    virtual void     InitGL()const = 0;
    virtual void     DeInitGL()const = 0;
    virtual void     DrawPlot()const = 0;
-   virtual void     Paint();
+   void     Paint() override;
 
    //Checks, if mouse cursor is above plot.
-   virtual Bool_t   PlotSelected(Int_t px, Int_t py);
+   Bool_t   PlotSelected(Int_t px, Int_t py) override;
    //Init geometry does plot's specific initialization.
    virtual Bool_t   InitGeometry() = 0;
 
@@ -297,7 +297,7 @@ protected:
    void             RestoreModelviewMatrix()const;
    void             RestoreProjectionMatrix()const;
 
-   ClassDef(TGLPlotPainter, 0) //Base for gl plots
+   ClassDefOverride(TGLPlotPainter, 0) //Base for gl plots
 };
 
 /*

--- a/graf3d/gl/inc/TGLPolyLine.h
+++ b/graf3d/gl/inc/TGLPolyLine.h
@@ -29,9 +29,9 @@ private:
 public:
    TGLPolyLine(const TBuffer3D & buffer);
 
-   virtual void DirectDraw(TGLRnrCtx & rnrCtx) const;
+   void DirectDraw(TGLRnrCtx & rnrCtx) const override;
 
-   ClassDef(TGLPolyLine,0) // a polyline logical shape
+   ClassDefOverride(TGLPolyLine,0) // a polyline logical shape
 };
 
 #endif

--- a/graf3d/gl/inc/TGLPolyMarker.h
+++ b/graf3d/gl/inc/TGLPolyMarker.h
@@ -31,14 +31,14 @@ private:
 public:
    TGLPolyMarker(const TBuffer3D & buffer);
 
-   virtual void DirectDraw(TGLRnrCtx & rnrCtx) const;
+   void DirectDraw(TGLRnrCtx & rnrCtx) const override;
 
-   virtual Bool_t   IgnoreSizeForOfInterest() const { return kTRUE; }
+   Bool_t   IgnoreSizeForOfInterest() const override { return kTRUE; }
 
 private:
    void DrawStars()const;
 
-   ClassDef(TGLPolyMarker,0) // a polymarker logical shape
+   ClassDefOverride(TGLPolyMarker,0) // a polymarker logical shape
 };
 
 #endif

--- a/graf3d/gl/inc/TGLRotateManip.h
+++ b/graf3d/gl/inc/TGLRotateManip.h
@@ -44,13 +44,13 @@ protected:
 public:
    TGLRotateManip();
    TGLRotateManip(TGLPhysicalShape* shape);
-   virtual ~TGLRotateManip();
+   ~TGLRotateManip() override;
 
-   virtual void   Draw(const TGLCamera& camera) const;
-   virtual Bool_t HandleButton(const Event_t& event, const TGLCamera& camera);
-   virtual Bool_t HandleMotion(const Event_t& event, const TGLCamera& camera);
+   void   Draw(const TGLCamera& camera) const override;
+   Bool_t HandleButton(const Event_t& event, const TGLCamera& camera) override;
+   Bool_t HandleMotion(const Event_t& event, const TGLCamera& camera) override;
 
-   ClassDef(TGLRotateManip, 0); // GL rotation manipulator widget
+   ClassDefOverride(TGLRotateManip, 0); // GL rotation manipulator widget
 };
 
 #endif

--- a/graf3d/gl/inc/TGLSAFrame.h
+++ b/graf3d/gl/inc/TGLSAFrame.h
@@ -37,12 +37,12 @@ private:
 public:
    TGLSAFrame(TGLSAViewer &viewer);
    TGLSAFrame(const TGWindow *parent, TGLSAViewer &viewer);
-   virtual ~TGLSAFrame();
+   ~TGLSAFrame() override;
 
-   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2);
-   void   CloseWindow();
+   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
+   void   CloseWindow() override;
 
-   ClassDef(TGLSAFrame, 0) // GUI frame for standalone viewer
+   ClassDefOverride(TGLSAFrame, 0) // GUI frame for standalone viewer
 };
 
 #endif

--- a/graf3d/gl/inc/TGLSAViewer.h
+++ b/graf3d/gl/inc/TGLSAViewer.h
@@ -96,14 +96,14 @@ public:
    TGLSAViewer(TVirtualPad* pad, TGLFormat* format=nullptr);
    TGLSAViewer(const TGWindow* parent, TVirtualPad *pad, TGedEditor *ged=nullptr,
                TGLFormat* format=nullptr);
-   ~TGLSAViewer();
+   ~TGLSAViewer() override;
 
-   virtual void CreateGLWidget();
-   virtual void DestroyGLWidget();
+   void CreateGLWidget() override;
+   void DestroyGLWidget() override;
 
-   virtual const char* GetName() const { return "GLViewer"; }
+   const char* GetName() const override { return "GLViewer"; }
 
-   virtual void SelectionChanged();
+   void SelectionChanged() override;
 
    void   Show();
    void   Close();
@@ -129,7 +129,7 @@ public:
 
    static void SetMenuHidingTimeout(Long_t timeout);
 
-   ClassDef(TGLSAViewer, 0); // Standalone GL viewer.
+   ClassDefOverride(TGLSAViewer, 0); // Standalone GL viewer.
 };
 
 #endif

--- a/graf3d/gl/inc/TGLScaleManip.h
+++ b/graf3d/gl/inc/TGLScaleManip.h
@@ -35,13 +35,13 @@ private:
 public:
    TGLScaleManip();
    TGLScaleManip(TGLPhysicalShape * shape);
-   virtual ~TGLScaleManip();
+   ~TGLScaleManip() override;
 
-   virtual void   Draw(const TGLCamera & camera) const;
-   virtual Bool_t HandleButton(const Event_t & event, const TGLCamera & camera);
-   virtual Bool_t HandleMotion(const Event_t & event, const TGLCamera & camera);
+   void   Draw(const TGLCamera & camera) const override;
+   Bool_t HandleButton(const Event_t & event, const TGLCamera & camera) override;
+   Bool_t HandleMotion(const Event_t & event, const TGLCamera & camera) override;
 
-   ClassDef(TGLScaleManip,0) // GL scaling manipulator widget
+   ClassDefOverride(TGLScaleManip,0) // GL scaling manipulator widget
 };
 
 #endif

--- a/graf3d/gl/inc/TGLScene.h
+++ b/graf3d/gl/inc/TGLScene.h
@@ -96,7 +96,7 @@ public:
       DrawElementPtrVec_t fSelTranspElements;
 
       TSceneInfo(TGLViewerBase* view=nullptr, TGLScene* scene=nullptr);
-      virtual ~TSceneInfo();
+      ~TSceneInfo() override;
 
       void ClearAfterRebuild();
       void ClearAfterUpdate();
@@ -144,32 +144,32 @@ protected:
 
 public:
    TGLScene();
-   virtual ~TGLScene();
+   ~TGLScene() override;
 
-   virtual void CalcBoundingBox() const;
+   void CalcBoundingBox() const override;
 
-   virtual TSceneInfo* CreateSceneInfo(TGLViewerBase* view);
-   virtual void        RebuildSceneInfo(TGLRnrCtx& rnrCtx);
-   virtual void        UpdateSceneInfo(TGLRnrCtx& rnrCtx);
-   virtual void        LodifySceneInfo(TGLRnrCtx& rnrCtx);
+   TSceneInfo* CreateSceneInfo(TGLViewerBase* view) override;
+   void        RebuildSceneInfo(TGLRnrCtx& rnrCtx) override;
+   void        UpdateSceneInfo(TGLRnrCtx& rnrCtx) override;
+   void        LodifySceneInfo(TGLRnrCtx& rnrCtx) override;
 
 
    // Rendering
-   virtual void PreDraw        (TGLRnrCtx& rnrCtx);
+   void PreDraw        (TGLRnrCtx& rnrCtx) override;
    // virtual void PreRender   (TGLRnrCtx& rnrCtx);
    // virtual void Render      (TGLRnrCtx& rnrCtx);
-   virtual void RenderOpaque   (TGLRnrCtx& rnrCtx);
-   virtual void RenderTransp   (TGLRnrCtx& rnrCtx);
-   virtual void RenderSelOpaque(TGLRnrCtx& rnrCtx);
-   virtual void RenderSelTransp(TGLRnrCtx& rnrCtx);
-   virtual void RenderSelOpaqueForHighlight(TGLRnrCtx& rnrCtx);
-   virtual void RenderSelTranspForHighlight(TGLRnrCtx& rnrCtx);
+   void RenderOpaque   (TGLRnrCtx& rnrCtx) override;
+   void RenderTransp   (TGLRnrCtx& rnrCtx) override;
+   void RenderSelOpaque(TGLRnrCtx& rnrCtx) override;
+   void RenderSelTransp(TGLRnrCtx& rnrCtx) override;
+   void RenderSelOpaqueForHighlight(TGLRnrCtx& rnrCtx) override;
+   void RenderSelTranspForHighlight(TGLRnrCtx& rnrCtx) override;
 
    virtual void RenderHighlight(TGLRnrCtx&           rnrCtx,
                                 DrawElementPtrVec_t& elVec);
 
    // virtual void PostRender(TGLRnrCtx& rnrCtx);
-   virtual void PostDraw       (TGLRnrCtx& rnrCtx);
+   void PostDraw       (TGLRnrCtx& rnrCtx) override;
 
    virtual void RenderAllPasses(TGLRnrCtx&           rnrCtx,
                                 DrawElementPtrVec_t& elVec,
@@ -182,13 +182,13 @@ public:
                                 const TGLPlaneSet_t* clipPlanes = nullptr);
 
    // Selection
-   virtual Bool_t ResolveSelectRecord(TGLSelectRecord& rec, Int_t curIdx);
+   Bool_t ResolveSelectRecord(TGLSelectRecord& rec, Int_t curIdx) override;
 
    // Basic logical shape management
    virtual void              AdoptLogical(TGLLogicalShape& shape);
    virtual Bool_t            DestroyLogical(TObject* logid, Bool_t mustFind=kTRUE);
    virtual Int_t             DestroyLogicals();
-   virtual TGLLogicalShape*  FindLogical(TObject* logid)  const;
+   TGLLogicalShape*  FindLogical(TObject* logid)  const override;
 
    // Basic physical shape management
    virtual void              AdoptPhysical(TGLPhysicalShape& shape);
@@ -241,7 +241,7 @@ public:
    static Bool_t IsOutside(const TGLBoundingBox& box,
                            const TGLPlaneSet_t& planes);
 
-   ClassDef(TGLScene, 0); // Standard ROOT OpenGL scene with logial/physical shapes.
+   ClassDefOverride(TGLScene, 0); // Standard ROOT OpenGL scene with logial/physical shapes.
 };
 
 

--- a/graf3d/gl/inc/TGLSceneBase.h
+++ b/graf3d/gl/inc/TGLSceneBase.h
@@ -70,13 +70,13 @@ protected:
 
 public:
    TGLSceneBase();
-   virtual ~TGLSceneBase();
+   ~TGLSceneBase() override;
 
    void AddViewer(TGLViewerBase* viewer);
    void RemoveViewer(TGLViewerBase* viewer);
    void TagViewersChanged();
 
-   virtual const char* LockIdStr() const;
+   const char* LockIdStr() const override;
 
    virtual const char  *GetName()  const { return fName; }
    virtual const char  *GetTitle() const { return fTitle; }
@@ -139,7 +139,7 @@ public:
    { if (!fBoundingBoxValid) CalcBoundingBox(); return fBoundingBox; }
 
 
-   ClassDef(TGLSceneBase, 0) // Base-class for OpenGL scenes.
+   ClassDefOverride(TGLSceneBase, 0) // Base-class for OpenGL scenes.
 }; // endclass TGLSceneBase
 
 

--- a/graf3d/gl/inc/TGLScenePad.h
+++ b/graf3d/gl/inc/TGLScenePad.h
@@ -57,7 +57,7 @@ protected:
 
 public:
    TGLScenePad(TVirtualPad* pad);
-   virtual ~TGLScenePad() {}
+   ~TGLScenePad() override {}
 
    TVirtualPad* GetPad() const { return fPad; }
    void SetPad(TVirtualPad* p) { fPad = p; }
@@ -75,27 +75,27 @@ public:
 
    // TVirtualViewer3D interface
 
-   virtual Bool_t CanLoopOnPrimitives() const { return kTRUE; }
-   virtual void   PadPaint(TVirtualPad* pad);
-   virtual void   ObjectPaint(TObject* obj, Option_t* opt="");
+   Bool_t CanLoopOnPrimitives() const override { return kTRUE; }
+   void   PadPaint(TVirtualPad* pad) override;
+   void   ObjectPaint(TObject* obj, Option_t* opt="") override;
 
    // For now handled by viewer
-   virtual Int_t  DistancetoPrimitive(Int_t /*px*/, Int_t /*py*/) { return 9999; }
-   virtual void   ExecuteEvent(Int_t /*event*/, Int_t /*px*/, Int_t /*py*/) {}
+   Int_t  DistancetoPrimitive(Int_t /*px*/, Int_t /*py*/) override { return 9999; }
+   void   ExecuteEvent(Int_t /*event*/, Int_t /*px*/, Int_t /*py*/) override {}
 
-   virtual Bool_t PreferLocalFrame() const { return kTRUE; }
+   Bool_t PreferLocalFrame() const override { return kTRUE; }
 
-   virtual void   BeginScene();
-   virtual Bool_t BuildingScene() const { return CurrentLock() == kModifyLock; }
-   virtual void   EndScene();
+   void   BeginScene() override;
+   Bool_t BuildingScene() const override { return CurrentLock() == kModifyLock; }
+   void   EndScene() override;
 
-   virtual Int_t  AddObject(const TBuffer3D& buffer, Bool_t* addChildren = nullptr);
-   virtual Int_t  AddObject(UInt_t physicalID, const TBuffer3D& buffer, Bool_t* addChildren = nullptr);
-   virtual Bool_t OpenComposite(const TBuffer3D& buffer, Bool_t* addChildren = nullptr);
-   virtual void   CloseComposite();
-   virtual void   AddCompositeOp(UInt_t operation);
+   Int_t  AddObject(const TBuffer3D& buffer, Bool_t* addChildren = nullptr) override;
+   Int_t  AddObject(UInt_t physicalID, const TBuffer3D& buffer, Bool_t* addChildren = nullptr) override;
+   Bool_t OpenComposite(const TBuffer3D& buffer, Bool_t* addChildren = nullptr) override;
+   void   CloseComposite() override;
+   void   AddCompositeOp(UInt_t operation) override;
 
-   ClassDef(TGLScenePad, 0); // GL-scene filled via TPad-TVirtualViewer interface.
+   ClassDefOverride(TGLScenePad, 0); // GL-scene filled via TPad-TVirtualViewer interface.
 };
 
 #endif

--- a/graf3d/gl/inc/TGLSelectRecord.h
+++ b/graf3d/gl/inc/TGLSelectRecord.h
@@ -94,12 +94,12 @@ public:
    TGLSelectRecord();
    TGLSelectRecord(UInt_t* data);
    TGLSelectRecord(const TGLSelectRecord& rec);
-   virtual ~TGLSelectRecord();
+   ~TGLSelectRecord() override;
 
    TGLSelectRecord& operator=(const TGLSelectRecord& rec);
 
-   virtual void Set(UInt_t* data);
-   virtual void Reset();
+   void Set(UInt_t* data) override;
+   void Reset() override;
 
    Bool_t             GetTransparent() const { return fTransparent; }
    TGLSceneInfo     * GetSceneInfo()   const { return fSceneInfo; }
@@ -128,7 +128,7 @@ public:
    static Bool_t AreSameSelectionWise(const TGLSelectRecord& r1,
                                       const TGLSelectRecord& r2);
 
-   ClassDef(TGLSelectRecord, 0) // Standard GL selection record.
+   ClassDefOverride(TGLSelectRecord, 0) // Standard GL selection record.
 };
 
 
@@ -146,17 +146,17 @@ public:
    TGLOvlSelectRecord();
    TGLOvlSelectRecord(UInt_t* data);
    TGLOvlSelectRecord(const TGLOvlSelectRecord& rec);
-   virtual ~TGLOvlSelectRecord();
+   ~TGLOvlSelectRecord() override;
 
    TGLOvlSelectRecord& operator=(const TGLOvlSelectRecord& rec);
 
-   virtual void Set(UInt_t* data);
-   virtual void Reset();
+   void Set(UInt_t* data) override;
+   void Reset() override;
 
    TGLOverlayElement* GetOvlElement() const { return fOvlElement; }
    void SetOvlElement(TGLOverlayElement* e) { fOvlElement = e; }
 
-   ClassDef(TGLOvlSelectRecord, 0) // Standard GL overlay-selection record.
+   ClassDefOverride(TGLOvlSelectRecord, 0) // Standard GL overlay-selection record.
 };
 
 #endif

--- a/graf3d/gl/inc/TGLSphere.h
+++ b/graf3d/gl/inc/TGLSphere.h
@@ -26,13 +26,13 @@ private:
 public:
    TGLSphere(const TBuffer3DSphere &buffer);
 
-   virtual UInt_t DLOffset(Short_t lod) const;
+   UInt_t DLOffset(Short_t lod) const override;
 
-   virtual ELODAxes SupportedLODAxes() const { return kLODAxesAll; }
-   virtual Short_t  QuantizeShapeLOD(Short_t shapeLOD, Short_t combiLOD) const;
-   virtual void     DirectDraw(TGLRnrCtx & rnrCtx) const;
+   ELODAxes SupportedLODAxes() const override { return kLODAxesAll; }
+   Short_t  QuantizeShapeLOD(Short_t shapeLOD, Short_t combiLOD) const override;
+   void     DirectDraw(TGLRnrCtx & rnrCtx) const override;
 
-   ClassDef(TGLSphere,0); // a spherical logical shape
+   ClassDefOverride(TGLSphere,0); // a spherical logical shape
 };
 
 #endif

--- a/graf3d/gl/inc/TGLSurfacePainter.h
+++ b/graf3d/gl/inc/TGLSurfacePainter.h
@@ -65,18 +65,18 @@ public:
    TGLSurfacePainter(TH1 *hist, TGLPlotCamera *camera, TGLPlotCoordinates *coord);
 
    //TGLPlotPainter's final-overriders.
-   char  *GetPlotInfo(Int_t px, Int_t py);
-   Bool_t InitGeometry();
-   void   StartPan(Int_t px, Int_t py);
-   void   Pan(Int_t px, Int_t py);
-   void   AddOption(const TString &stringOption);
-   void   ProcessEvent(Int_t event, Int_t px, Int_t py);
+   char  *GetPlotInfo(Int_t px, Int_t py) override;
+   Bool_t InitGeometry() override;
+   void   StartPan(Int_t px, Int_t py) override;
+   void   Pan(Int_t px, Int_t py) override;
+   void   AddOption(const TString &stringOption) override;
+   void   ProcessEvent(Int_t event, Int_t px, Int_t py) override;
 
 private:
-   void   InitGL()const;
-   void   DeInitGL()const;
+   void   InitGL()const override;
+   void   DeInitGL()const override;
 
-   void   DrawPlot()const;
+   void   DrawPlot()const override;
 
    void   SetNormals();
    void   SetSurfaceColor()const;
@@ -87,9 +87,9 @@ private:
    Bool_t InitGeometrySpherical();
 
    void   DrawProjections()const;
-   void   DrawSectionXOZ()const;
-   void   DrawSectionYOZ()const;
-   void   DrawSectionXOY()const;
+   void   DrawSectionXOZ()const override;
+   void   DrawSectionYOZ()const override;
+   void   DrawSectionXOY()const override;
 
    void   ClampZ(Double_t &zVal)const;
 
@@ -104,11 +104,11 @@ private:
    Bool_t HasProjections()const;
 
    void   DrawPalette()const;
-   void   DrawPaletteAxis()const;
+   void   DrawPaletteAxis()const override;
 
    static TRandom *fgRandom;
 
-   ClassDef(TGLSurfacePainter, 0)//Surface painter.
+   ClassDefOverride(TGLSurfacePainter, 0)//Surface painter.
 };
 
 #endif

--- a/graf3d/gl/inc/TGLTF3Painter.h
+++ b/graf3d/gl/inc/TGLTF3Painter.h
@@ -47,18 +47,18 @@ private:
 public:
    TGLTF3Painter(TF3 *fun, TH1 *hist, TGLPlotCamera *camera, TGLPlotCoordinates *coord);
 
-   char   *GetPlotInfo(Int_t px, Int_t py);
-   Bool_t  InitGeometry();
-   void    StartPan(Int_t px, Int_t py);
-   void    Pan(Int_t px, Int_t py);
-   void    AddOption(const TString &stringOption);
-   void    ProcessEvent(Int_t event, Int_t px, Int_t py);
+   char   *GetPlotInfo(Int_t px, Int_t py) override;
+   Bool_t  InitGeometry() override;
+   void    StartPan(Int_t px, Int_t py) override;
+   void    Pan(Int_t px, Int_t py) override;
+   void    AddOption(const TString &stringOption) override;
+   void    ProcessEvent(Int_t event, Int_t px, Int_t py) override;
 
 private:
-   void    InitGL()const;
-   void    DeInitGL()const;
+   void    InitGL()const override;
+   void    DeInitGL()const override;
 
-   void    DrawPlot()const;
+   void    DrawPlot()const override;
    //
    void    DrawToSelectionBuffer()const;
    void    DrawDefaultPlot()const;
@@ -68,11 +68,11 @@ private:
    void    SetSurfaceColor()const;
    Bool_t  HasSections()const;
 
-   void    DrawSectionXOZ()const;
-   void    DrawSectionYOZ()const;
-   void    DrawSectionXOY()const;
+   void    DrawSectionXOZ()const override;
+   void    DrawSectionYOZ()const override;
+   void    DrawSectionXOY()const override;
 
-   ClassDef(TGLTF3Painter, 0) // GL TF3 painter.
+   ClassDefOverride(TGLTF3Painter, 0) // GL TF3 painter.
 };
 
 /*
@@ -113,22 +113,22 @@ public:
    TGLIsoPainter(TH1 *hist, TGLPlotCamera *camera, TGLPlotCoordinates *coord);
 
    //TGLPlotPainter final-overriders.
-   char    *GetPlotInfo(Int_t px, Int_t py);
-   Bool_t   InitGeometry();
-   void     StartPan(Int_t px, Int_t py);
-   void     Pan(Int_t px, Int_t py);
-   void     AddOption(const TString &option);
-   void     ProcessEvent(Int_t event, Int_t px, Int_t py);
+   char    *GetPlotInfo(Int_t px, Int_t py) override;
+   Bool_t   InitGeometry() override;
+   void     StartPan(Int_t px, Int_t py) override;
+   void     Pan(Int_t px, Int_t py) override;
+   void     AddOption(const TString &option) override;
+   void     ProcessEvent(Int_t event, Int_t px, Int_t py) override;
 
 private:
    //TGLPlotPainter final-overriders.
-   void     InitGL()const;
-   void     DeInitGL()const;
+   void     InitGL()const override;
+   void     DeInitGL()const override;
 
-   void     DrawPlot()const;
-   void     DrawSectionXOZ()const;
-   void     DrawSectionYOZ()const;
-   void     DrawSectionXOY()const;
+   void     DrawPlot()const override;
+   void     DrawSectionXOZ()const override;
+   void     DrawSectionYOZ()const override;
+   void     DrawSectionXOY()const override;
    //Auxiliary methods.
    Bool_t   HasSections()const;
    void     SetSurfaceColor(Int_t ind)const;
@@ -139,7 +139,7 @@ private:
    TGLIsoPainter(const TGLIsoPainter &);
    TGLIsoPainter &operator = (const TGLIsoPainter &);
 
-   ClassDef(TGLIsoPainter, 0) // Iso option for TH3.
+   ClassDefOverride(TGLIsoPainter, 0) // Iso option for TH3.
 };
 
 #endif

--- a/graf3d/gl/inc/TGLTH3Composition.h
+++ b/graf3d/gl/inc/TGLTH3Composition.h
@@ -38,10 +38,10 @@ public:
 
    //These are functions for TPad and
    //TPad's standard machinery (picking, painting).
-   Int_t    DistancetoPrimitive(Int_t px, Int_t py);
-   void     ExecuteEvent(Int_t event, Int_t px, Int_t py);
-   char    *GetObjectInfo(Int_t px, Int_t py) const;
-   void     Paint(Option_t *option);
+   Int_t    DistancetoPrimitive(Int_t px, Int_t py) override;
+   void     ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
+   char    *GetObjectInfo(Int_t px, Int_t py) const override;
+   void     Paint(Option_t *option) override;
 
 private:
    void CheckRanges(const TH3 *hist);
@@ -54,7 +54,7 @@ private:
    TGLTH3Composition(const TGLTH3Composition &rhs);
    TGLTH3Composition &operator = (const TGLTH3Composition &);
 
-   ClassDef(TGLTH3Composition, 0)//Composition of TH3 objects.
+   ClassDefOverride(TGLTH3Composition, 0)//Composition of TH3 objects.
 };
 
 //
@@ -66,24 +66,24 @@ public:
                             TGLPlotCoordinates *coord);
 
    //TGLPlotPainter final-overriders.
-   char      *GetPlotInfo(Int_t px, Int_t py);
-   Bool_t     InitGeometry();
-   void       StartPan(Int_t px, Int_t py);
-   void       Pan(Int_t px, Int_t py);
-   void       AddOption(const TString &option);
-   void       ProcessEvent(Int_t event, Int_t px, Int_t py);
+   char      *GetPlotInfo(Int_t px, Int_t py) override;
+   Bool_t     InitGeometry() override;
+   void       StartPan(Int_t px, Int_t py) override;
+   void       Pan(Int_t px, Int_t py) override;
+   void       AddOption(const TString &option) override;
+   void       ProcessEvent(Int_t event, Int_t px, Int_t py) override;
 
 private:
    //TGLPlotPainter final-overriders.
-   void       InitGL()const;
-   void       DeInitGL()const;
+   void       InitGL()const override;
+   void       DeInitGL()const override;
 
-   void       DrawPlot()const;
+   void       DrawPlot()const override;
 
    //Empty overriders.
-   void       DrawSectionXOZ()const{}
-   void       DrawSectionYOZ()const{}
-   void       DrawSectionXOY()const{}
+   void       DrawSectionXOZ()const override{}
+   void       DrawSectionYOZ()const override{}
+   void       DrawSectionXOY()const override{}
 
    void       SetColor(Int_t color)const;
 
@@ -95,7 +95,7 @@ private:
    TGLTH3CompositionPainter(const TGLTH3CompositionPainter &rhs);
    TGLTH3CompositionPainter &operator = (const TGLTH3CompositionPainter &rhs);
 
-   ClassDef(TGLTH3CompositionPainter, 0)//Painter to draw several TH3.
+   ClassDefOverride(TGLTH3CompositionPainter, 0)//Painter to draw several TH3.
 };
 
 

--- a/graf3d/gl/inc/TGLText.h
+++ b/graf3d/gl/inc/TGLText.h
@@ -32,7 +32,7 @@ private:
 public:
    TGLText();
    TGLText(Double_t x, Double_t y, Double_t z, const char *text);
-   virtual ~TGLText();
+   ~TGLText() override;
 
    FTFont* GetFont() { return fGLTextFont; }
 
@@ -43,7 +43,7 @@ public:
    void BBox(const char* string, float& llx, float& lly, float& llz,
                                  float& urx, float& ury, float& urz);
 
-   ClassDef(TGLText,0) // a GL text
+   ClassDefOverride(TGLText,0) // a GL text
 };
 
 #endif

--- a/graf3d/gl/inc/TGLTransManip.h
+++ b/graf3d/gl/inc/TGLTransManip.h
@@ -31,12 +31,12 @@ private:
 public:
    TGLTransManip();
    TGLTransManip(TGLPhysicalShape * shape);
-   virtual ~TGLTransManip();
+   ~TGLTransManip() override;
 
-   virtual void   Draw(const TGLCamera & camera) const;
-   virtual Bool_t HandleMotion(const Event_t & event, const TGLCamera & camera);
+   void   Draw(const TGLCamera & camera) const override;
+   Bool_t HandleMotion(const Event_t & event, const TGLCamera & camera) override;
 
-   ClassDef(TGLTransManip,0) // GL translation manipulator widget
+   ClassDefOverride(TGLTransManip,0) // GL translation manipulator widget
 };
 
 #endif

--- a/graf3d/gl/inc/TGLViewer.h
+++ b/graf3d/gl/inc/TGLViewer.h
@@ -166,7 +166,7 @@ protected:
    // Methods
    ///////////////////////////////////////////////////////////////////////
 
-   virtual void SetupClipObject();
+   void SetupClipObject() override;
 
    // Drawing - can tidy up/remove lots when TGLManager added
    void InitGL();
@@ -194,31 +194,31 @@ protected:
 public:
    TGLViewer(TVirtualPad* pad, Int_t x, Int_t y, Int_t width, Int_t height);
    TGLViewer(TVirtualPad* pad);
-   virtual ~TGLViewer();
+   ~TGLViewer() override;
 
    // TVirtualViewer3D interface ... mostly a facade
 
    // Forward to TGLScenePad
-   virtual Bool_t CanLoopOnPrimitives() const { return kTRUE; }
-   virtual void   PadPaint(TVirtualPad* pad);
+   Bool_t CanLoopOnPrimitives() const override { return kTRUE; }
+   void   PadPaint(TVirtualPad* pad) override;
    // Actually used by GL-in-pad
-   virtual Int_t  DistancetoPrimitive(Int_t px, Int_t py);
-   virtual void   ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   Int_t  DistancetoPrimitive(Int_t px, Int_t py) override;
+   void   ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
    // Only implemented because they're abstract ... should throw an
    // exception or assert they are not called.
-   virtual Bool_t PreferLocalFrame() const { return kTRUE; }
-   virtual void   BeginScene() {}
-   virtual Bool_t BuildingScene() const { return kFALSE; }
-   virtual void   EndScene() {}
-   virtual Int_t  AddObject(const TBuffer3D&, Bool_t* = nullptr) { return TBuffer3D::kNone; }
-   virtual Int_t  AddObject(UInt_t, const TBuffer3D&, Bool_t* = nullptr) { return TBuffer3D::kNone; }
-   virtual Bool_t OpenComposite(const TBuffer3D&, Bool_t* = nullptr) { return kFALSE; }
-   virtual void   CloseComposite() {}
-   virtual void   AddCompositeOp(UInt_t) {}
+   Bool_t PreferLocalFrame() const override { return kTRUE; }
+   void   BeginScene() override {}
+   Bool_t BuildingScene() const override { return kFALSE; }
+   void   EndScene() override {}
+   Int_t  AddObject(const TBuffer3D&, Bool_t* = nullptr) override { return TBuffer3D::kNone; }
+   Int_t  AddObject(UInt_t, const TBuffer3D&, Bool_t* = nullptr) override { return TBuffer3D::kNone; }
+   Bool_t OpenComposite(const TBuffer3D&, Bool_t* = nullptr) override { return kFALSE; }
+   void   CloseComposite() override {}
+   void   AddCompositeOp(UInt_t) override {}
 
-   virtual void   PrintObjects();
-   virtual void   ResetCameras()                { SetupCameras(kTRUE); }
-   virtual void   ResetCamerasAfterNextUpdate() { fResetCamerasOnNextUpdate = kTRUE; }
+   void   PrintObjects() override;
+   void   ResetCameras() override                { SetupCameras(kTRUE); }
+   void   ResetCamerasAfterNextUpdate() override { fResetCamerasOnNextUpdate = kTRUE; }
 
    TGLWidget* GetGLWidget() { return fGLWidget; }
 
@@ -312,9 +312,9 @@ public:
 
    // Request methods post cross thread request via TROOT::ProcessLineFast().
    void RequestDraw(Short_t LOD = TGLRnrCtx::kLODMed); // Cross thread draw request
-   virtual void PreRender();
-   virtual void Render();
-   virtual void PostRender();
+   void PreRender() override;
+   void Render() override;
+   void PostRender() override;
    void DoDraw(Bool_t swap_buffers=kTRUE);
    void DoDrawMono(Bool_t swap_buffers);
    void DoDrawStereo(Bool_t swap_buffers);
@@ -385,14 +385,14 @@ public:
    virtual void OverlayDragFinished();
    virtual void RefreshPadEditor(TObject* obj=nullptr);
 
-   virtual void RemoveOverlayElement(TGLOverlayElement* el);
+   void RemoveOverlayElement(TGLOverlayElement* el) override;
 
    TGLSelectRecord&    GetSelRec()    { return fSelRec; }
    TGLOvlSelectRecord& GetOvlSelRec() { return fOvlSelRec; }
    TGLOverlayElement*  GetCurrentOvlElm() const { return fCurrentOvlElm; }
    void                ClearCurrentOvlElm();
 
-   ClassDef(TGLViewer,0) // Standard ROOT GL viewer.
+   ClassDefOverride(TGLViewer,0) // Standard ROOT GL viewer.
 };
 
 
@@ -407,7 +407,7 @@ private:
 public:
    TGLRedrawTimer(TGLViewer & viewer) :
       fViewer(viewer), fRedrawLOD(TGLRnrCtx::kLODHigh), fPending(kFALSE) {}
-   ~TGLRedrawTimer() {}
+   ~TGLRedrawTimer() override {}
    void RequestDraw(Int_t milliSec, Short_t redrawLOD)
    {
       if (fPending) TurnOff(); else fPending = kTRUE;
@@ -415,11 +415,11 @@ public:
       TTimer::Start(milliSec, kTRUE);
    }
    Bool_t IsPending() const { return fPending; }
-   virtual void Stop()
+   void Stop() override
    {
       if (fPending) { TurnOff(); fPending = kFALSE; }
    }
-   Bool_t Notify()
+   Bool_t Notify() override
    {
       TurnOff();
       fPending = kFALSE;

--- a/graf3d/gl/inc/TGLViewerBase.h
+++ b/graf3d/gl/inc/TGLViewerBase.h
@@ -83,9 +83,9 @@ protected:
 public:
 
    TGLViewerBase();
-   virtual ~TGLViewerBase();
+   ~TGLViewerBase() override;
 
-   virtual const char* LockIdStr() const;
+   const char* LockIdStr() const override;
 
    TGLSceneInfo* AddScene(TGLSceneBase* scene);
    void          RemoveScene(TGLSceneBase* scene);
@@ -158,7 +158,7 @@ public:
    TGLRnrCtx* GetRnrCtx() const { return  fRnrCtx; }
    TGLRnrCtx& RnrCtx() const    { return *fRnrCtx; }
 
-   ClassDef(TGLViewerBase, 0); // GL Viewer base-class.
+   ClassDefOverride(TGLViewerBase, 0); // GL Viewer base-class.
 };
 
 

--- a/graf3d/gl/inc/TGLViewerEditor.h
+++ b/graf3d/gl/inc/TGLViewerEditor.h
@@ -122,11 +122,11 @@ private:
 public:
    TGLViewerEditor(const TGWindow *p=nullptr, Int_t width=140, Int_t height=30,
                    UInt_t options=kChildFrame, Pixel_t back=GetDefaultFrameBackground());
-   ~TGLViewerEditor();
+   ~TGLViewerEditor() override;
 
    virtual void ViewerRedraw();
 
-   virtual void SetModel(TObject* obj);
+   void SetModel(TObject* obj) override;
 
    void SetGuides();
    void DoClearColor(Pixel_t color);
@@ -161,7 +161,7 @@ public:
    static TGNumberEntry* MakeLabeledNEntry(TGCompositeFrame* p, const char* name,
                                            Int_t labelw, Int_t nd=7, Int_t s=5);
 
-   ClassDef(TGLViewerEditor, 0); //GUI for editing TGLViewer attributes
+   ClassDefOverride(TGLViewerEditor, 0); //GUI for editing TGLViewer attributes
 };
 
 #endif

--- a/graf3d/gl/inc/TGLVoxelPainter.h
+++ b/graf3d/gl/inc/TGLVoxelPainter.h
@@ -27,27 +27,27 @@ private:
 public:
    TGLVoxelPainter(TH1 *hist, TGLPlotCamera *camera, TGLPlotCoordinates *coord);
 
-   char   *GetPlotInfo(Int_t px, Int_t py);
-   Bool_t  InitGeometry();
-   void    StartPan(Int_t px, Int_t py);
-   void    Pan(Int_t px, Int_t py);
-   void    AddOption(const TString &stringOption);
-   void    ProcessEvent(Int_t event, Int_t px, Int_t py);
+   char   *GetPlotInfo(Int_t px, Int_t py) override;
+   Bool_t  InitGeometry() override;
+   void    StartPan(Int_t px, Int_t py) override;
+   void    Pan(Int_t px, Int_t py) override;
+   void    AddOption(const TString &stringOption) override;
+   void    ProcessEvent(Int_t event, Int_t px, Int_t py) override;
 
 private:
    //Overriders
-   void    InitGL()const;
-   void    DeInitGL()const;
+   void    InitGL()const override;
+   void    DeInitGL()const override;
 
-   void    DrawPlot()const;
+   void    DrawPlot()const override;
 
 
-   void    DrawSectionXOZ()const;
-   void    DrawSectionYOZ()const;
-   void    DrawSectionXOY()const;
+   void    DrawSectionXOZ()const override;
+   void    DrawSectionYOZ()const override;
+   void    DrawSectionXOY()const override;
 
    void    DrawPalette()const;
-   void    DrawPaletteAxis()const;
+   void    DrawPaletteAxis()const override;
 
    //Aux. functions.
    void    FindVoxelColor(Double_t binContent, Float_t *rgba)const;
@@ -58,7 +58,7 @@ private:
 
    TF1    *fTransferFunc;
 
-   ClassDef(TGLVoxelPainter, 0)//Voxel painter
+   ClassDefOverride(TGLVoxelPainter, 0)//Voxel painter
 };
 
 #endif

--- a/graf3d/gl/inc/TGLWidget.h
+++ b/graf3d/gl/inc/TGLWidget.h
@@ -54,36 +54,36 @@ public:
              Bool_t shareDefault, const TGLPaintDevice *shareDevice,
              UInt_t width, UInt_t height);
 
-   ~TGLWidget();
+   ~TGLWidget() override;
 
    virtual void      InitGL();
    virtual void      PaintGL();
 
-   Bool_t            MakeCurrent();
+   Bool_t            MakeCurrent() override;
    Bool_t            ClearCurrent();
-   void              SwapBuffers();
-   const TGLContext *GetContext()const;
+   void              SwapBuffers() override;
+   const TGLContext *GetContext()const override;
 
-   const  TGLFormat *GetPixelFormat()const;
+   const  TGLFormat *GetPixelFormat()const override;
 
    //This function is public _ONLY_ for calls
    //via gInterpreter. Do not call it directly.
    void              SetFormat();
    //To repaint gl-widget without GUI events.
-   void              ExtractViewport(Int_t *vp)const;
+   void              ExtractViewport(Int_t *vp)const override;
 
    TGEventHandler   *GetEventHandler() const { return fEventHandler; }
    void              SetEventHandler(TGEventHandler *eh);
 
-   Bool_t HandleButton(Event_t *ev);
-   Bool_t HandleDoubleClick(Event_t *ev);
-   Bool_t HandleConfigureNotify(Event_t *ev);
-   Bool_t HandleKey(Event_t *ev);
-   Bool_t HandleMotion(Event_t *ev);
-   Bool_t HandleFocusChange(Event_t *);
-   Bool_t HandleCrossing(Event_t *);
+   Bool_t HandleButton(Event_t *ev) override;
+   Bool_t HandleDoubleClick(Event_t *ev) override;
+   Bool_t HandleConfigureNotify(Event_t *ev) override;
+   Bool_t HandleKey(Event_t *ev) override;
+   Bool_t HandleMotion(Event_t *ev) override;
+   Bool_t HandleFocusChange(Event_t *) override;
+   Bool_t HandleCrossing(Event_t *) override;
 
-   void   DoRedraw();
+   void   DoRedraw() override;
 
 private:
    TGLWidget(const TGLWidget &);              // Not implemented.
@@ -96,12 +96,12 @@ protected:
                                 UInt_t width, UInt_t height,
                                 std::pair<void *, void *>& innerData);
 
-   void AddContext(TGLContext *ctx);
-   void RemoveContext(TGLContext *ctx);
+   void AddContext(TGLContext *ctx) override;
+   void RemoveContext(TGLContext *ctx) override;
 
    std::pair<void *, void *> GetInnerData()const;
 
-   ClassDef(TGLWidget, 0); //Window (widget) version of TGLPaintDevice
+   ClassDefOverride(TGLWidget, 0); //Window (widget) version of TGLPaintDevice
 };
 
 #endif

--- a/graf3d/gl/inc/TH2GL.h
+++ b/graf3d/gl/inc/TH2GL.h
@@ -31,17 +31,17 @@ protected:
 
 public:
    TH2GL();
-   virtual ~TH2GL();
+   ~TH2GL() override;
 
-   virtual Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr);
-   virtual void   SetBBox();
-   virtual void   DirectDraw(TGLRnrCtx & rnrCtx) const;
+   Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr) override;
+   void   SetBBox() override;
+   void   DirectDraw(TGLRnrCtx & rnrCtx) const override;
 
    // To support two-level selection
    // virtual Bool_t SupportsSecondarySelect() const { return kTRUE; }
    // virtual void ProcessSelection(UInt_t* ptr, TGLViewer*, TGLScene*);
 
-   ClassDef(TH2GL, 0); // GL renderer for TH2.
+   ClassDefOverride(TH2GL, 0); // GL renderer for TH2.
 }; // endclass TH2GL
 
 #endif

--- a/graf3d/gl/inc/TH3GL.h
+++ b/graf3d/gl/inc/TH3GL.h
@@ -35,18 +35,18 @@ protected:
 public:
    TH3GL();
    TH3GL(TH3 *h, TPolyMarker3D *pm);
-   virtual ~TH3GL();
+   ~TH3GL() override;
 
-   virtual Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr);
-   virtual void   SetBBox();
+   Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr) override;
+   void   SetBBox() override;
 
-   virtual void DirectDraw(TGLRnrCtx & rnrCtx) const;
+   void DirectDraw(TGLRnrCtx & rnrCtx) const override;
 
    // To support two-level selection
    // virtual Bool_t SupportsSecondarySelect() const { return kTRUE; }
    // virtual void ProcessSelection(TGLRnrCtx & rnrCtx, TGLSelectRecord & rec);
 
-   ClassDef(TH3GL, 0); // GL renderer class for TH3.
+   ClassDefOverride(TH3GL, 0); // GL renderer class for TH3.
 };
 
 #endif

--- a/graf3d/gl/inc/TPointSet3DGL.h
+++ b/graf3d/gl/inc/TPointSet3DGL.h
@@ -22,20 +22,20 @@ class TPointSet3DGL : public TGLObject
 public:
    TPointSet3DGL() : TGLObject() {}
 
-   virtual Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr);
-   virtual void   SetBBox();
-   virtual void   DirectDraw(TGLRnrCtx & rnrCtx) const;
+   Bool_t SetModel(TObject* obj, const Option_t *opt = nullptr) override;
+   void   SetBBox() override;
+   void   DirectDraw(TGLRnrCtx & rnrCtx) const override;
 
-   virtual Bool_t IgnoreSizeForOfInterest() const { return kTRUE; }
+   Bool_t IgnoreSizeForOfInterest() const override { return kTRUE; }
 
-   virtual Bool_t ShouldDLCache(const TGLRnrCtx & rnrCtx) const;
+   Bool_t ShouldDLCache(const TGLRnrCtx & rnrCtx) const override;
 
-   virtual void   Draw(TGLRnrCtx & rnrCtx) const;
+   void   Draw(TGLRnrCtx & rnrCtx) const override;
 
-   virtual Bool_t SupportsSecondarySelect() const { return kTRUE; }
-   virtual void   ProcessSelection(TGLRnrCtx & rnrCtx, TGLSelectRecord & rec);
+   Bool_t SupportsSecondarySelect() const override { return kTRUE; }
+   void   ProcessSelection(TGLRnrCtx & rnrCtx, TGLSelectRecord & rec) override;
 
-   ClassDef(TPointSet3DGL,1)  // GL renderer for TPointSet3D
+   ClassDefOverride(TPointSet3DGL,1)  // GL renderer for TPointSet3D
 };
 
 #endif

--- a/graf3d/gl/inc/TX11GL.h
+++ b/graf3d/gl/inc/TX11GL.h
@@ -38,50 +38,50 @@ private:
 
 public:
    TX11GLManager();
-   ~TX11GLManager();
+   ~TX11GLManager() override;
 
    //All public functions are TGLManager's final-overriders
 
    //index returned can be used as a result of gVirtualX->InitWindow
-   Int_t    InitGLWindow(Window_t winID);
+   Int_t    InitGLWindow(Window_t winID) override;
    //winInd is the index, returned by InitGLWindow
-   Int_t    CreateGLContext(Int_t winInd);
+   Int_t    CreateGLContext(Int_t winInd) override;
 
    //[            Off-screen rendering part
    //create pixmap to read GL buffer into it,
    //ctxInd is the index, returned by CreateGLContext
-   Bool_t   AttachOffScreenDevice(Int_t ctxInd, Int_t x, Int_t y, UInt_t w, UInt_t h);
-   Bool_t   ResizeOffScreenDevice(Int_t devInd, Int_t x, Int_t y, UInt_t w, UInt_t h);
+   Bool_t   AttachOffScreenDevice(Int_t ctxInd, Int_t x, Int_t y, UInt_t w, UInt_t h) override;
+   Bool_t   ResizeOffScreenDevice(Int_t devInd, Int_t x, Int_t y, UInt_t w, UInt_t h) override;
    //analog of gVirtualX->SelectWindow(fPixmapID) => gVirtualGL->SelectOffScreenDevice(fPixmapID)
-   void     SelectOffScreenDevice(Int_t devInd);
+   void     SelectOffScreenDevice(Int_t devInd) override;
    //Index of pixmap, valid for gVirtualX
-   Int_t    GetVirtualXInd(Int_t devInd);
+   Int_t    GetVirtualXInd(Int_t devInd) override;
    //copy pixmap into window directly/by pad
-   void     MarkForDirectCopy(Int_t devInd, Bool_t);
+   void     MarkForDirectCopy(Int_t devInd, Bool_t) override;
    //Off-screen device holds sizes for glViewport
-   void     ExtractViewport(Int_t devInd, Int_t *vp);
+   void     ExtractViewport(Int_t devInd, Int_t *vp) override;
    //Read GL buffer into pixmap
-   void     ReadGLBuffer(Int_t devInd);
+   void     ReadGLBuffer(Int_t devInd) override;
    //]
 
    //Make the gl context current
-   Bool_t   MakeCurrent(Int_t devInd);
+   Bool_t   MakeCurrent(Int_t devInd) override;
    //Sswap buffers or copies pixmap (XCopyArea)
-   void     Flush(Int_t ctxInd);
+   void     Flush(Int_t ctxInd) override;
    //Generic function for gl context and off-screen device deletion
-   void     DeleteGLContext(Int_t devInd);
+   void     DeleteGLContext(Int_t devInd) override;
 
    //used by viewer
-   Bool_t   SelectManip(TVirtualGLManip *manip, const TGLCamera *camera, const TGLRect *rect, const TGLBoundingBox *sceneBox);
+   Bool_t   SelectManip(TVirtualGLManip *manip, const TGLCamera *camera, const TGLRect *rect, const TGLBoundingBox *sceneBox) override;
    //
-   Bool_t   PlotSelected(TVirtualGLPainter *plot, Int_t px, Int_t py);
-   char    *GetPlotInfo(TVirtualGLPainter *plot, Int_t px, Int_t py);
+   Bool_t   PlotSelected(TVirtualGLPainter *plot, Int_t px, Int_t py) override;
+   char    *GetPlotInfo(TVirtualGLPainter *plot, Int_t px, Int_t py) override;
    //
-   void     PaintSingleObject(TVirtualGLPainter *);
-   void     PanObject(TVirtualGLPainter *o, Int_t x, Int_t y);
-   void     PrintViewer(TVirtualViewer3D *vv);
+   void     PaintSingleObject(TVirtualGLPainter *) override;
+   void     PanObject(TVirtualGLPainter *o, Int_t x, Int_t y) override;
+   void     PrintViewer(TVirtualViewer3D *vv) override;
 
-   Bool_t   HighColorFormat(Int_t /*ctxInd*/){return kFALSE;}
+   Bool_t   HighColorFormat(Int_t /*ctxInd*/) override{return kFALSE;}
 
    struct TGLContext_t;
 
@@ -93,7 +93,7 @@ private:
    TX11GLManager(const TX11GLManager &);
    TX11GLManager &operator = (const TX11GLManager &);
 
-   ClassDef(TX11GLManager, 0) //X11-specific version of TGLManager
+   ClassDefOverride(TX11GLManager, 0) //X11-specific version of TGLManager
 };
 
 

--- a/graf3d/gl/src/TGLClip.cxx
+++ b/graf3d/gl/src/TGLClip.cxx
@@ -24,7 +24,7 @@ namespace
 class TGLClipPlaneLogical : public TGLLogicalShape
 {
 protected:
-   virtual void DirectDraw(TGLRnrCtx & rnrCtx) const
+   void DirectDraw(TGLRnrCtx & rnrCtx) const override
    {
       glBegin(rnrCtx.IsDrawPassFilled() ? GL_QUADS : GL_LINE_LOOP);
       glNormal3d (0.0, 0.0, 1.0);
@@ -37,7 +37,7 @@ protected:
 
 public:
    TGLClipPlaneLogical() : TGLLogicalShape() { fDLCache = kFALSE; }
-   virtual ~TGLClipPlaneLogical() {}
+   ~TGLClipPlaneLogical() override {}
 
    void Resize(Double_t ext)
    {
@@ -52,7 +52,7 @@ public:
 class TGLClipBoxLogical : public TGLLogicalShape
 {
 protected:
-   virtual void DirectDraw(TGLRnrCtx & rnrCtx) const
+   void DirectDraw(TGLRnrCtx & rnrCtx) const override
    {
       glEnable(GL_NORMALIZE);
       fBoundingBox.Draw(rnrCtx.IsDrawPassFilled());
@@ -61,7 +61,7 @@ protected:
 
 public:
    TGLClipBoxLogical() : TGLLogicalShape() { fDLCache = kFALSE; }
-   virtual ~TGLClipBoxLogical() {}
+   ~TGLClipBoxLogical() override {}
 
    void Resize(const TGLVertex3 & lowVertex, const TGLVertex3 & highVertex)
    {

--- a/graf3d/gl/src/TGLCylinder.cxx
+++ b/graf3d/gl/src/TGLCylinder.cxx
@@ -63,7 +63,7 @@ public:
                Double_t phi1, Double_t phi2, const TGLVector3 &l = gLowNormalDefault,
                const TGLVector3 &h = gHighNormalDefault);
 
-   void Draw() const;
+   void Draw() const override;
 };
 
 //four quad strips:
@@ -79,7 +79,7 @@ public:
    TubeMesh(UInt_t LOD, Double_t r1, Double_t r2, Double_t r3, Double_t r4, Double_t dz,
             const TGLVector3 &l = gLowNormalDefault, const TGLVector3 &h = gHighNormalDefault);
 
-   void Draw() const;
+   void Draw() const override;
 };
 
 //One quad mesh and 2 triangle funs
@@ -93,7 +93,7 @@ public:
    TCylinderMesh(UInt_t LOD, Double_t r1, Double_t r2, Double_t dz,
                  const TGLVector3 &l = gLowNormalDefault, const TGLVector3 &h = gHighNormalDefault);
 
-   void Draw() const;
+   void Draw() const override;
 };
 
 //One quad mesh and 2 triangle fans
@@ -107,7 +107,7 @@ private:
 public:
    TCylinderSegMesh(UInt_t LOD, Double_t r1, Double_t r2, Double_t dz, Double_t phi1, Double_t phi2,
                     const TGLVector3 &l = gLowNormalDefault, const TGLVector3 &h = gHighNormalDefault);
-   void Draw() const;
+   void Draw() const override;
 };
 
 TGLMesh::TGLMesh(UInt_t LOD, Double_t r1, Double_t r2, Double_t r3, Double_t r4, Double_t dz,

--- a/graf3d/gviz3d/inc/TStructNode.h
+++ b/graf3d/gviz3d/inc/TStructNode.h
@@ -57,9 +57,9 @@ private:
 
 public:
    TStructNode(TString name, TString typeName, void* pointer, TStructNode* parent, ULong_t size, ENodeType type);
-   ~TStructNode();
+   ~TStructNode() override;
 
-   virtual Int_t  Compare(const TObject* obj) const;
+   Int_t  Compare(const TObject* obj) const override;
    ULong_t        GetAllMembersCount() const;
    Float_t        GetCenter() const;
    Float_t        GetHeight() const;
@@ -69,7 +69,7 @@ public:
    TList*         GetMembers() const;
    ULong_t        GetMembersCount() const;
    Float_t        GetMiddle() const;
-   const char*    GetName() const;
+   const char*    GetName() const override;
    ENodeType      GetNodeType() const;
    TStructNode   *GetParent() const;
    void*          GetPointer() const;
@@ -86,7 +86,7 @@ public:
    Float_t        GetX() const;
    Float_t        GetY() const;
    Bool_t         IsCollapsed() const;
-   virtual Bool_t IsSortable() const;
+   Bool_t IsSortable() const override;
    bool           IsVisible() const;
    void           SetAllMembersCount(ULong_t count);
    void           SetCollapsed(Bool_t collapsed);
@@ -105,7 +105,7 @@ public:
    void           SetX(Float_t x);
    void           SetY(Float_t y);
 
-   ClassDef(TStructNode,0); // Node with information about class
+   ClassDefOverride(TStructNode,0); // Node with information about class
 };
 
 #endif

--- a/graf3d/gviz3d/inc/TStructNodeEditor.h
+++ b/graf3d/gviz3d/inc/TStructNodeEditor.h
@@ -46,7 +46,7 @@ protected:
 public:
    TStructNodeEditor(TList* colors, const TGWindow *p = nullptr, Int_t width = 140, Int_t height = 30,
       UInt_t options = kChildFrame, Pixel_t back = GetDefaultFrameBackground());
-   ~TStructNodeEditor();
+   ~TStructNodeEditor() override;
 
    void  ApplyButtonSlot();
    void  AutoRefreshButtonSlot(Bool_t on);
@@ -54,11 +54,11 @@ public:
    void  DefaultButtonSlot();
    void  MaxLevelsValueSetSlot(Long_t);
    void  MaxObjectsValueSetSlot(Long_t);
-   void  SetModel(TObject* obj);
+   void  SetModel(TObject* obj) override;
    void  Update(Bool_t resetCamera);
-   void  Update();
+   void  Update() override;
 
-   ClassDef(TStructNodeEditor, 0); // GUI fo editing TStructNode
+   ClassDefOverride(TStructNodeEditor, 0); // GUI fo editing TStructNode
 };
 #endif // ROOT_TStructNodeEditor
 

--- a/graf3d/gviz3d/inc/TStructNodeProperty.h
+++ b/graf3d/gviz3d/inc/TStructNodeProperty.h
@@ -24,17 +24,17 @@ private:
 public:
    TStructNodeProperty(const char * name, Int_t color);
    TStructNodeProperty(const char * name, Pixel_t pixel);
-   ~TStructNodeProperty();
+   ~TStructNodeProperty() override;
 
    TColor   GetColor() const;
    Pixel_t  GetPixel() const;
    void     SetColor(const TColor & color);
    void     SetColor(Pixel_t pixel);
    void     SetColor(Int_t color);
-   Int_t    Compare(const TObject* obj) const;
-   Bool_t   IsSortable() const;
+   Int_t    Compare(const TObject* obj) const override;
+   Bool_t   IsSortable() const override;
 
-   ClassDef(TStructNodeProperty, 1); // Class with nodes color property
+   ClassDefOverride(TStructNodeProperty, 1); // Class with nodes color property
 };
 
 #endif

--- a/graf3d/gviz3d/inc/TStructViewer.h
+++ b/graf3d/gviz3d/inc/TStructViewer.h
@@ -45,9 +45,9 @@ private:
 
 public:
    TStructViewer(void* ptr = nullptr, const char * clname = nullptr);
-   ~TStructViewer();
+   ~TStructViewer() override;
 
-   void     Draw(Option_t *option = "");
+   void     Draw(Option_t *option = "") override;
    TCanvas* GetCanvas();
    TGMainFrame* GetFrame();
    TColor   GetColor(const char* typeName);
@@ -59,7 +59,7 @@ public:
    void     SetLinksVisibility(Bool_t val);
    void     SetPointer(void* ptr, const char* clname = nullptr);
 
-   ClassDef(TStructViewer, 0); // A 3D struct viewer
+   ClassDefOverride(TStructViewer, 0); // A 3D struct viewer
 };
 
 #endif

--- a/graf3d/gviz3d/inc/TStructViewerGUI.h
+++ b/graf3d/gviz3d/inc/TStructViewerGUI.h
@@ -91,14 +91,14 @@ private:
 public:
    TStructViewerGUI(TStructViewer* parent, TStructNode* nodePtr, TList* colors, const TGWindow *p = nullptr,
       UInt_t w = 800, UInt_t h = 600);
-   ~TStructViewerGUI();
+   ~TStructViewerGUI() override;
 
    void           AutoRefreshButtonSlot(Bool_t on);
    void           BoxHeightValueSetSlot(Long_t h);
-   void           CloseWindow();
+   void           CloseWindow() override;
    void           ColorSelectedSlot(Pixel_t pixel);
    void           DoubleClickedSlot();
-   void           Draw(Option_t* option = "");
+   void           Draw(Option_t* option = "") override;
    TCanvas       *GetCanvas();
    Int_t          GetColor(TStructNode* node);
    TStructNodeProperty* GetDefaultColor();
@@ -118,7 +118,7 @@ public:
    void           Update(Bool_t resetCamera = false);
    void           UpdateButtonSlot();
 
-   ClassDef(TStructViewerGUI, 0); // A GUI fo 3D struct viewer
+   ClassDefOverride(TStructViewerGUI, 0); // A GUI fo 3D struct viewer
 };
 
 #endif

--- a/graf3d/x3d/inc/TViewerX3D.h
+++ b/graf3d/x3d/inc/TViewerX3D.h
@@ -73,7 +73,7 @@ public:
               UInt_t width = 800, UInt_t height = 600);
    TViewerX3D(TVirtualPad *pad, Option_t *option, const char *title,
               Int_t x, Int_t y, UInt_t width, UInt_t height);
-   virtual ~TViewerX3D();
+   ~TViewerX3D() override;
 
    Int_t    ExecCommand(Int_t px, Int_t py, char command);
    void     GetPosition(Float_t &longitude, Float_t &latitude, Float_t &psi);
@@ -85,22 +85,22 @@ public:
    void     PaintPolyMarker(const TBuffer3D & buffer) const;
 
    // TVirtualViewer3D interface
-   virtual Bool_t PreferLocalFrame() const { return kFALSE; }
-   virtual void   BeginScene();
-   virtual Bool_t BuildingScene()    const { return fBuildingScene; }
-   virtual void   EndScene();
-   virtual Int_t  AddObject(const TBuffer3D & buffer, Bool_t * addChildren = nullptr);
-   virtual Int_t  AddObject(UInt_t placedID, const TBuffer3D & buffer, Bool_t * addChildren = nullptr);
+   Bool_t PreferLocalFrame() const override { return kFALSE; }
+   void   BeginScene() override;
+   Bool_t BuildingScene()    const override { return fBuildingScene; }
+   void   EndScene() override;
+   Int_t  AddObject(const TBuffer3D & buffer, Bool_t * addChildren = nullptr) override;
+   Int_t  AddObject(UInt_t placedID, const TBuffer3D & buffer, Bool_t * addChildren = nullptr) override;
 
    // Composite shapes not supported on this viewer currently - ignore.
    // Will result in a set of component shapes
-   virtual Bool_t OpenComposite(const TBuffer3D & /*buffer*/, Bool_t * = nullptr) { return kTRUE; }
-   virtual void   CloseComposite() {};
-   virtual void   AddCompositeOp(UInt_t /*operation*/) {};
+   Bool_t OpenComposite(const TBuffer3D & /*buffer*/, Bool_t * = nullptr) override { return kTRUE; }
+   void   CloseComposite() override {};
+   void   AddCompositeOp(UInt_t /*operation*/) override {};
 
    Bool_t   ProcessFrameMessage(Long_t msg, Long_t parm1, Long_t parm2);
 
-   ClassDef(TViewerX3D,0)  //Interface to the X3D viewer
+   ClassDefOverride(TViewerX3D,0)  //Interface to the X3D viewer
 };
 
 #endif

--- a/graf3d/x3d/inc/TX3DFrame.h
+++ b/graf3d/x3d/inc/TX3DFrame.h
@@ -28,12 +28,12 @@ class TX3DFrame : public TGMainFrame
 private:
    TViewerX3D & fViewer;
 
-   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2);
-   void   CloseWindow();
+   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
+   void   CloseWindow() override;
 
 public:
    TX3DFrame(TViewerX3D & viewer, const TGWindow * win, UInt_t width, UInt_t height);
-   ~TX3DFrame();
+   ~TX3DFrame() override;
 };
 
 #endif

--- a/graf3d/x3d/src/TViewerX3D.cxx
+++ b/graf3d/x3d/src/TViewerX3D.cxx
@@ -109,19 +109,19 @@ private:
 public:
    TX3DContainer(TViewerX3D *c, Window_t id, const TGWindow *parent);
 
-   Bool_t  HandleButton(Event_t *ev)
+   Bool_t  HandleButton(Event_t *ev) override
                   {  x3d_dispatch_event(gVirtualX->GetNativeEvent());
                      return fViewer->HandleContainerButton(ev); }
-   Bool_t  HandleConfigureNotify(Event_t *ev)
+   Bool_t  HandleConfigureNotify(Event_t *ev) override
                   {  TGFrame::HandleConfigureNotify(ev);
                      return x3d_dispatch_event(gVirtualX->GetNativeEvent()); }
-   Bool_t  HandleKey(Event_t *)
+   Bool_t  HandleKey(Event_t *) override
                   {  return x3d_dispatch_event(gVirtualX->GetNativeEvent()); }
-   Bool_t  HandleMotion(Event_t *)
+   Bool_t  HandleMotion(Event_t *) override
                   {  return x3d_dispatch_event(gVirtualX->GetNativeEvent()); }
-   Bool_t  HandleExpose(Event_t *)
+   Bool_t  HandleExpose(Event_t *) override
                   {  return x3d_dispatch_event(gVirtualX->GetNativeEvent()); }
-   Bool_t  HandleColormapChange(Event_t *)
+   Bool_t  HandleColormapChange(Event_t *) override
                   {  return x3d_dispatch_event(gVirtualX->GetNativeEvent()); }
 };
 


### PR DESCRIPTION
This commit only contains changes that were automatically generated by `clang-tidy`, and replaces `ClassDef` with `ClassDefOverride` where appropriate.

Several directories in the ROOT repo were already treated like this, the last one was `tree`:
https://github.com/root-project/root/pull/11290