### PR TITLE
TTreeGeneratorBase::AddHeader: Move special case for pair before custom file

### DIFF
--- a/tree/treeplayer/src/TTreeGeneratorBase.cxx
+++ b/tree/treeplayer/src/TTreeGeneratorBase.cxx
@@ -91,6 +91,17 @@ namespace Internal {
             directive.Append(what);
             directive.Append(">\n");
          }
+      } else if (TClassEdit::IsStdPair(cl->GetName())) {
+         TClassEdit::TSplitType split(cl->GetName());
+         // 4 elements expected: "pair", "first type name", "second type name", "trailing stars"
+         // However legacy code had a test for 3, we will leave it here until
+         // a test is developed (or found :) ) that exercise these lines of code.
+         if (split.fElements.size() == 3 || split.fElements.size() == 4) {
+            for (int arg = 1; arg < 3; ++arg) {
+               TClass* clArg = TClass::GetClass(split.fElements[arg].c_str());
+               if (clArg) AddHeader(clArg);
+            }
+         }
       } else if (cl->GetDeclFileName() && strlen(cl->GetDeclFileName()) ) { // Custom file
          const char *filename = cl->GetDeclFileName();
 
@@ -122,17 +133,6 @@ namespace Internal {
             }
          }
          directive = Form("#include \"%s\"\n",filename);
-      } else if (TClassEdit::IsStdPair(cl->GetName())) {
-         TClassEdit::TSplitType split(cl->GetName());
-         // 4 elements expected: "pair", "first type name", "second type name", "trailing stars"
-         // However legacy code had a test for 3, we will leave it here until
-         // a test is developed (or found :) ) that exercise these lines of code.
-         if (split.fElements.size() == 3 || split.fElements.size() == 4) {
-            for (int arg = 1; arg < 3; ++arg) {
-               TClass* clArg = TClass::GetClass(split.fElements[arg].c_str());
-               if (clArg) AddHeader(clArg);
-            }
-         }
       }
       // Add directive (if it is not added already)
       if (directive.Length()) {


### PR DESCRIPTION
This makes the test `roottest-root-treeproxy-make` pass on macOS 13, where a proxy pulling in `pair<int,int>` was trying to include the (private) header `__bit_reference`.