### PR TITLE
[RF] Add missing declarations for JSONInterface template specializations

### DIFF
--- a/roofit/jsoninterface/inc/RooFit/Detail/JSONInterface.h
+++ b/roofit/jsoninterface/inc/RooFit/Detail/JSONInterface.h
@@ -234,6 +234,27 @@ std::vector<T> &operator<<(std::vector<T> &v, RooFit::Detail::JSONNode const &n)
    return v;
 }
 
+template <>
+inline int JSONNode::val_t<int>() const
+{
+   return val_int();
+}
+template <>
+inline double JSONNode::val_t<double>() const
+{
+   return val_double();
+}
+template <>
+inline bool JSONNode::val_t<bool>() const
+{
+   return val_bool();
+}
+template <>
+inline std::string JSONNode::val_t<std::string>() const
+{
+   return val();
+}
+
 } // namespace Detail
 } // namespace RooFit
 

--- a/roofit/jsoninterface/src/JSONInterface.cxx
+++ b/roofit/jsoninterface/src/JSONInterface.cxx
@@ -66,27 +66,6 @@ std::ostream &operator<<(std::ostream &os, JSONNode const &s)
    return os;
 }
 
-template <>
-int JSONNode::val_t<int>() const
-{
-   return val_int();
-}
-template <>
-double JSONNode::val_t<double>() const
-{
-   return val_double();
-}
-template <>
-bool JSONNode::val_t<bool>() const
-{
-   return val_bool();
-}
-template <>
-std::string JSONNode::val_t<std::string>() const
-{
-   return val();
-}
-
 std::unique_ptr<JSONTree> JSONTree::create()
 {
    if (getBackendEnum() == Backend::Ryml) {


### PR DESCRIPTION
In the RooFit `JSONInterface` there are some template specializations that are defined in the translation unit but are not declared in the header file.

This causes linker errors, because the compiler doesn't know that it has to look for the specializations, as explained here: https://stackoverflow.com/questions/11773960/do-template-specialisations-belong-into-the-header-or-source-file

To solve this problem, these small one-line functions are just inlined in the header.

Needs to be backported to 6.28.