### PR TITLE
[ntuple] Add iteration over all available columns

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -25,7 +25,6 @@
 
 #include <algorithm>
 #include <chrono>
-#include <deque>
 #include <functional>
 #include <iterator>
 #include <map>

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -473,6 +473,8 @@ public:
       const RNTupleDescriptor &fNTuple;
       /// The descriptor ids of the columns ordered by index id
       std::vector<DescriptorId_t> fColumns = {};
+
+      void CollectColumnIds(DescriptorId_t fieldId);
    public:
       class RIterator {
       private:
@@ -497,40 +499,8 @@ public:
          bool operator==(const iterator &rh) const { return fIndex == rh.fIndex; }
       };
 
-      RColumnDescriptorIterable(const RNTupleDescriptor &ntuple, const RFieldDescriptor &field)
-         : fNTuple(ntuple)
-      {
-         for (unsigned int i = 0; true; ++i) {
-            auto logicalId = ntuple.FindLogicalColumnId(field.GetId(), i);
-            if (logicalId == kInvalidDescriptorId)
-               break;
-            fColumns.emplace_back(logicalId);
-         }
-      }
-
-      RColumnDescriptorIterable(const RNTupleDescriptor &ntuple)
-         : fNTuple(ntuple)
-      {
-         std::deque<DescriptorId_t> fieldIdQueue{ntuple.GetFieldZeroId()};
-
-         while (!fieldIdQueue.empty()) {
-            auto currFieldId = fieldIdQueue.front();
-            fieldIdQueue.pop_front();
-
-            for (const auto &field : ntuple.GetFieldIterable(currFieldId)) {
-               auto fieldId = field.GetId();
-
-               for (unsigned int i = 0; true; ++i) {
-                  auto logicalId = ntuple.FindLogicalColumnId(fieldId, i);
-                  if (logicalId == kInvalidDescriptorId)
-                     break;
-                  fColumns.emplace_back(logicalId);
-               }
-
-               fieldIdQueue.push_back(fieldId);
-            }
-         }
-      }
+      RColumnDescriptorIterable(const RNTupleDescriptor &ntuple, const RFieldDescriptor &field);
+      RColumnDescriptorIterable(const RNTupleDescriptor &ntuple);
 
       RIterator begin() { return RIterator(fNTuple, fColumns, 0); }
       RIterator end() { return RIterator(fNTuple, fColumns, fColumns.size()); }

--- a/tree/ntuple/v7/test/ntuple_descriptor.cxx
+++ b/tree/ntuple/v7/test/ntuple_descriptor.cxx
@@ -427,6 +427,13 @@ TEST(RColumnDescriptorIterable, IterateOverColumns)
       counter++;
    }
    EXPECT_EQ(3, counter);
+
+   counter = 0;
+   for (const auto &c : desc->GetColumnIterable()) {
+      (void)c;
+      counter++;
+   }
+   EXPECT_EQ(desc->GetNLogicalColumns(), counter);
 }
 
 TEST(RClusterDescriptor, GetBytesOnStorage)


### PR DESCRIPTION
This PR adds the `RNTupleDescriptor::GetColumnIterable()` method, which returns an iterator over all (logical) columns of the RNTuple (without having to specify a field).

Some questions to still consider:
1. The original `RNTupleDescriptor::GetColumnIterable(const RFieldDescriptor &field)` method returns an iterator over the _logical_ columns. Would it make more sense to return physical columns for this method or should we stay consistent across methods? For the `RNTupleInspector`, we're interested in physical columns but if we have the logical columns we could filter out the non-physical ones.
2. The original method only returns the columns for the specified field, without considering its potential sub-fields. Would it be useful to add a flag to toggle whether the columns for sub-fields should be included (in a separate PR)?
