### PR TITLE
Automatically add `override` to gui with clang-tidy

### DIFF
--- a/gui/fitpanel/inc/TAdvancedGraphicsDialog.h
+++ b/gui/fitpanel/inc/TAdvancedGraphicsDialog.h
@@ -80,12 +80,12 @@ private:
 
 public:
    TAdvancedGraphicsDialog(const TGWindow *p, const TGWindow *main);
-   ~TAdvancedGraphicsDialog();
+   ~TAdvancedGraphicsDialog() override;
 
    void DoDraw();
    void DoChangedScanPar(Int_t selected);
 
-   ClassDef(TAdvancedGraphicsDialog, 0)  // Simple input dialog
+   ClassDefOverride(TAdvancedGraphicsDialog, 0)  // Simple input dialog
 };
 
 #endif

--- a/gui/fitpanel/inc/TFitEditor.h
+++ b/gui/fitpanel/inc/TFitEditor.h
@@ -163,7 +163,7 @@ protected:
    void        CreateMinimizationTab();
    void        MakeTitle(TGCompositeFrame *parent, const char *title);
    TF1*        HasFitFunction();
-   void        SetEditable(Bool_t);
+   void        SetEditable(Bool_t) override;
 
 private:
    TFitEditor(const TFitEditor&);              // not implemented
@@ -173,12 +173,12 @@ private:
 
 public:
    TFitEditor(TVirtualPad* pad, TObject *obj);
-   virtual ~TFitEditor();
+   ~TFitEditor() override;
 
    TList*  GetListOfFittingFunctions(TObject *obj = nullptr);
 
    static  TFitEditor *GetInstance(TVirtualPad* pad = nullptr, TObject *obj = nullptr);
-   virtual Option_t  *GetDrawOption() const;
+   Option_t  *GetDrawOption() const override;
    virtual void       Hide();
    virtual void       Show(TVirtualPad* pad, TObject *obj);
 
@@ -187,10 +187,10 @@ public:
    virtual void       Terminate();
            void       UpdateGUI();
 
-   virtual void   CloseWindow();
+   void   CloseWindow() override;
    virtual void   ConnectSlots();
    virtual void   DisconnectSlots();
-   virtual void   RecursiveRemove(TObject* obj);
+   void   RecursiveRemove(TObject* obj) override;
 
 protected:
    virtual void   SetCanvas(TCanvas *c);
@@ -239,7 +239,7 @@ public:
    typedef std::vector<FuncParamData_t > FuncParams_t;
 
    friend class FitEditorUnitTesting;
-   ClassDef(TFitEditor,0)  //Fit Panel interface
+   ClassDefOverride(TFitEditor,0)  //Fit Panel interface
 };
 
 #endif

--- a/gui/fitpanel/inc/TFitParametersDialog.h
+++ b/gui/fitpanel/inc/TFitParametersDialog.h
@@ -83,9 +83,9 @@ protected:
 public:
    TFitParametersDialog(const TGWindow *p, const TGWindow *main, TF1 *func,
                         TVirtualPad *pad, Int_t *ret_code = nullptr);
-   virtual ~TFitParametersDialog();
+   ~TFitParametersDialog() override;
 
-   virtual void  CloseWindow();
+   void  CloseWindow() override;
    virtual void  DoApply();
    virtual void  DoCancel();
    virtual void  DoOK();
@@ -106,7 +106,7 @@ public:
 protected:
    void SetParameters();
 
-   ClassDef(TFitParametersDialog, 0)  // Fit function parameters dialog
+   ClassDefOverride(TFitParametersDialog, 0)  // Fit function parameters dialog
 };
 
 #endif

--- a/gui/fitpanel/inc/TTreeInput.h
+++ b/gui/fitpanel/inc/TTreeInput.h
@@ -35,10 +35,10 @@ private:
 public:
    TTreeInput(const TGWindow *p, const TGWindow *main,
               char *strvars, char* strcuts);
-   ~TTreeInput();
-   virtual Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t);
+   ~TTreeInput() override;
+   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t) override;
 
-   ClassDef(TTreeInput, 0)  // Simple input dialog
+   ClassDefOverride(TTreeInput, 0)  // Simple input dialog
 
 };
 

--- a/gui/ged/inc/TArrowEditor.h
+++ b/gui/ged/inc/TArrowEditor.h
@@ -38,14 +38,14 @@ public:
                 Int_t width = 140, Int_t height = 30,
                 UInt_t options = kChildFrame,
                 Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TArrowEditor();
+   ~TArrowEditor() override;
 
-   virtual void   SetModel(TObject* obj);
+   void   SetModel(TObject* obj) override;
    virtual void   DoAngle();
    virtual void   DoOption(Int_t id);
    virtual void   DoSize();
 
-   ClassDef(TArrowEditor,0)  // GUI for editing arrow attributes
+   ClassDefOverride(TArrowEditor,0)  // GUI for editing arrow attributes
 };
 
 #endif

--- a/gui/ged/inc/TAttFillEditor.h
+++ b/gui/ged/inc/TAttFillEditor.h
@@ -36,9 +36,9 @@ public:
                   Int_t width = 140, Int_t height = 30,
                   UInt_t options = kChildFrame,
                   Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TAttFillEditor();
+   ~TAttFillEditor() override;
 
-   virtual void   SetModel(TObject* obj);
+   void   SetModel(TObject* obj) override;
    virtual void   DoFillColor(Pixel_t color);
    virtual void   DoFillAlphaColor(ULongptr_t p);
    virtual void   DoFillPattern(Style_t color);
@@ -47,7 +47,7 @@ public:
    virtual void   DoLiveAlpha(Int_t a);
    virtual void   GetCurAlpha();
 
-   ClassDef(TAttFillEditor,0)  //GUI for editing fill attributes
+   ClassDefOverride(TAttFillEditor,0)  //GUI for editing fill attributes
 };
 
 #endif

--- a/gui/ged/inc/TAttLineEditor.h
+++ b/gui/ged/inc/TAttLineEditor.h
@@ -38,9 +38,9 @@ public:
                   Int_t width = 140, Int_t height = 30,
                   UInt_t options = kChildFrame,
                   Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TAttLineEditor();
+   ~TAttLineEditor() override;
 
-   virtual void   SetModel(TObject* obj);
+   void   SetModel(TObject* obj) override;
    virtual void   DoLineColor(Pixel_t color);
    virtual void   DoLineAlphaColor(ULongptr_t p);
    virtual void   DoLineStyle(Int_t style);
@@ -50,7 +50,7 @@ public:
    virtual void   DoLiveAlpha(Int_t a);
    virtual void   GetCurAlpha();
 
-   ClassDef(TAttLineEditor,0)  // GUI for editing line attributes
+   ClassDefOverride(TAttLineEditor,0)  // GUI for editing line attributes
 };
 
 #endif

--- a/gui/ged/inc/TAttMarkerEditor.h
+++ b/gui/ged/inc/TAttMarkerEditor.h
@@ -39,9 +39,9 @@ public:
                     Int_t width = 140, Int_t height = 30,
                     UInt_t options = kChildFrame,
                     Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TAttMarkerEditor();
+   ~TAttMarkerEditor() override;
 
-   virtual void     SetModel(TObject* obj);
+   void     SetModel(TObject* obj) override;
    virtual void     DoMarkerColor(Pixel_t color);
    virtual void     DoMarkerAlphaColor(ULongptr_t p);
    virtual void     DoMarkerSize();
@@ -51,7 +51,7 @@ public:
    virtual void     DoLiveAlpha(Int_t a);
    virtual void     GetCurAlpha();
 
-   ClassDef(TAttMarkerEditor,0)  // GUI for editing marker attributes
+   ClassDefOverride(TAttMarkerEditor,0)  // GUI for editing marker attributes
 };
 
 #endif

--- a/gui/ged/inc/TAttTextEditor.h
+++ b/gui/ged/inc/TAttTextEditor.h
@@ -42,10 +42,10 @@ public:
                   Int_t width = 140, Int_t height = 30,
                   UInt_t options = kChildFrame,
                   Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TAttTextEditor();
+   ~TAttTextEditor() override;
 
-   virtual void     SetModel(TObject* obj);
-   virtual Bool_t   ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2);
+   void     SetModel(TObject* obj) override;
+   Bool_t   ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
    virtual void     DoTextAlphaColor(ULongptr_t p);
    virtual void     DoAlpha();
    virtual void     DoAlphaField();
@@ -53,7 +53,7 @@ public:
    virtual void     GetCurAlpha();
    virtual void     DoTextColor(Pixel_t color);
 
-   ClassDef(TAttTextEditor,0)  //GUI for editing text attributes
+   ClassDefOverride(TAttTextEditor,0)  //GUI for editing text attributes
 };
 
 #endif

--- a/gui/ged/inc/TAxisEditor.h
+++ b/gui/ged/inc/TAxisEditor.h
@@ -62,8 +62,8 @@ public:
                Int_t width = 140, Int_t height = 30,
                UInt_t options = kChildFrame,
                Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TAxisEditor();
-   virtual void   SetModel(TObject* obj);
+   ~TAxisEditor() override;
+   void   SetModel(TObject* obj) override;
    // slots related to axis attributes
    virtual void   DoTickLength();
    virtual void   DoAxisColor(Pixel_t color);
@@ -87,7 +87,7 @@ public:
    virtual void   DoNoExponent();
    virtual void   DoDecimal(Bool_t on);
 
-   ClassDef(TAxisEditor,0)  // axis editor
+   ClassDefOverride(TAxisEditor,0)  // axis editor
 };
 
 #endif

--- a/gui/ged/inc/TCurlyArcEditor.h
+++ b/gui/ged/inc/TCurlyArcEditor.h
@@ -35,15 +35,15 @@ public:
                 Int_t width = 140, Int_t height = 30,
                 UInt_t options = kChildFrame,
                 Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TCurlyArcEditor();
+   ~TCurlyArcEditor() override;
 
-   virtual void   SetModel(TObject* obj);
+   void   SetModel(TObject* obj) override;
    virtual void   DoRadius();
    virtual void   DoPhimin();
    virtual void   DoPhimax();
    virtual void   DoCenterXY();
 
-   ClassDef(TCurlyArcEditor,0)  // GUI for editing arrow attributes
+   ClassDefOverride(TCurlyArcEditor,0)  // GUI for editing arrow attributes
 };
 
 #endif

--- a/gui/ged/inc/TCurlyLineEditor.h
+++ b/gui/ged/inc/TCurlyLineEditor.h
@@ -39,17 +39,17 @@ public:
                 Int_t width = 140, Int_t height = 30,
                 UInt_t options = kChildFrame,
                 Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TCurlyLineEditor();
+   ~TCurlyLineEditor() override;
 
-   virtual void   SetModel(TObject* obj);
-   virtual void   ActivateBaseClassEditors(TClass* cl);
+   void   SetModel(TObject* obj) override;
+   void   ActivateBaseClassEditors(TClass* cl) override;
    virtual void   DoStartXY();
    virtual void   DoEndXY();
    virtual void   DoAmplitude();
    virtual void   DoWaveLength();
    virtual void   DoWavy();
 
-   ClassDef(TCurlyLineEditor,0)  // GUI for editing arrow attributes
+   ClassDefOverride(TCurlyLineEditor,0)  // GUI for editing arrow attributes
 };
 
 #endif

--- a/gui/ged/inc/TF1Editor.h
+++ b/gui/ged/inc/TF1Editor.h
@@ -43,10 +43,10 @@ protected:
 public:
    TF1Editor(const TGWindow *p = nullptr,  Int_t width = 140, Int_t height = 30,
              UInt_t options = kChildFrame, Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TF1Editor();
+   ~TF1Editor() override;
 
-   virtual void   SetModel(TObject* obj);
-   virtual void   ActivateBaseClassEditors(TClass* cl);
+   void   SetModel(TObject* obj) override;
+   void   ActivateBaseClassEditors(TClass* cl) override;
 
    virtual void   DoParameterSettings();
    virtual void   DoXPoints();
@@ -55,7 +55,7 @@ public:
    virtual void   DoSliderXReleased();
    virtual void   DoXRange();
 
-   ClassDef(TF1Editor,0)  // user interface for TF1 objects
+   ClassDefOverride(TF1Editor,0)  // user interface for TF1 objects
 };
 
 #endif

--- a/gui/ged/inc/TFrameEditor.h
+++ b/gui/ged/inc/TFrameEditor.h
@@ -37,13 +37,13 @@ public:
                 Int_t width = 140, Int_t height = 30,
                 UInt_t options = kChildFrame,
                 Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TFrameEditor();
+   ~TFrameEditor() override;
 
-   virtual void   SetModel(TObject* obj);
+   void   SetModel(TObject* obj) override;
    virtual void   DoBorderMode();
    virtual void   DoBorderSize(Int_t size);
 
-   ClassDef(TFrameEditor,0)  //editor of TFrame objects
+   ClassDefOverride(TFrameEditor,0)  //editor of TFrame objects
 };
 
 #endif

--- a/gui/ged/inc/TFunctionParametersDialog.h
+++ b/gui/ged/inc/TFunctionParametersDialog.h
@@ -64,9 +64,9 @@ public:
    TFunctionParametersDialog(const TGWindow *p, const TGWindow *main,
                              TF1 *func, TVirtualPad *pad,
                              Double_t rmin, Double_t rmax);
-   virtual ~TFunctionParametersDialog();
+   ~TFunctionParametersDialog() override;
 
-   virtual void  CloseWindow();
+   void  CloseWindow() override;
    virtual void  DoApply();
    virtual void  DoCancel();
    virtual void  DoFix(Bool_t on);
@@ -79,7 +79,7 @@ public:
    virtual void  HandleButtons(Bool_t update);
    virtual void  RedrawFunction();
 
-   ClassDef(TFunctionParametersDialog, 0)  // Function parameters dialog
+   ClassDefOverride(TFunctionParametersDialog, 0)  // Function parameters dialog
 };
 
 #endif

--- a/gui/ged/inc/TGedEditor.h
+++ b/gui/ged/inc/TGedEditor.h
@@ -59,7 +59,7 @@ protected:
 
 public:
    TGedEditor(TCanvas* canvas = nullptr, UInt_t width = 175, UInt_t height = 20);
-   virtual ~TGedEditor();
+   ~TGedEditor() override;
 
    void          PrintFrameStat();
    virtual void  Update(TGedFrame* frame = nullptr);

--- a/gui/ged/inc/TGedFrame.h
+++ b/gui/ged/inc/TGedFrame.h
@@ -59,11 +59,11 @@ public:
              Int_t width = 140, Int_t height = 30,
              UInt_t options = kChildFrame,
              Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGedFrame();
+   ~TGedFrame() override;
 
    virtual void      Update();
 
-   virtual Option_t *GetDrawOption() const;
+   Option_t *GetDrawOption() const override;
 
    TClass*           GetModelClass()              { return fModelClass;  }
    Int_t             GetPriority()                { return fPriority;    }
@@ -73,14 +73,14 @@ public:
    virtual TGVerticalFrame* CreateEditorTabSubFrame(const char* name);
 
    virtual void      Refresh(TObject *model);
-   virtual void      SetDrawOption(Option_t *option="");
+   void      SetDrawOption(Option_t *option="") override;
    virtual Bool_t    AcceptModel(TObject*) { return kTRUE; }
    void              SetModelClass(TClass* mcl)   { fModelClass = mcl; }
    virtual void      SetModel(TObject* obj) = 0;
    virtual void      SetGedEditor(TGedEditor* ed) { fGedEditor = ed; }
    virtual void      ActivateBaseClassEditors(TClass* cl);
 
-   ClassDef(TGedFrame, 0); //base editor's frame
+   ClassDefOverride(TGedFrame, 0); //base editor's frame
 };
 
 class TGedNameFrame : public TGedFrame {
@@ -98,14 +98,14 @@ public:
                  Int_t width = 170, Int_t height = 30,
                  UInt_t options = kChildFrame,
                  Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGedNameFrame();
+   ~TGedNameFrame() override;
 
-   virtual Bool_t   HandleButton(Event_t *event);
-   virtual Bool_t   HandleCrossing(Event_t *event);
+   Bool_t   HandleButton(Event_t *event) override;
+   Bool_t   HandleCrossing(Event_t *event) override;
 
-   virtual void     SetModel(TObject* obj);
+   void     SetModel(TObject* obj) override;
 
-   ClassDef(TGedNameFrame,0)      //frame showing the selected object name
+   ClassDefOverride(TGedNameFrame,0)      //frame showing the selected object name
 };
 
 #endif

--- a/gui/ged/inc/TGedMarkerSelect.h
+++ b/gui/ged/inc/TGedMarkerSelect.h
@@ -26,11 +26,11 @@ protected:
 
 public:
    TGedMarkerPopup(const TGWindow *p, const TGWindow *m, Style_t markerStyle);
-   virtual ~TGedMarkerPopup();
+   ~TGedMarkerPopup() override;
 
-   virtual Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2);
+   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
 
-   ClassDef(TGedMarkerPopup,0)  //marker select popup
+   ClassDefOverride(TGedMarkerPopup,0)  //marker select popup
 };
 
 
@@ -40,20 +40,20 @@ protected:
    Style_t          fMarkerStyle;   ///< marker style
    const TGPicture *fPicture;       ///< image used for popup window
 
-   virtual void     DoRedraw();
+   void     DoRedraw() override;
 
 public:
    TGedMarkerSelect(const TGWindow *p, Style_t markerStyle, Int_t id);
-   virtual ~TGedMarkerSelect() { if(fPicture) gClient->FreePicture(fPicture);}
+   ~TGedMarkerSelect() override { if(fPicture) gClient->FreePicture(fPicture);}
 
-   virtual Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2);
+   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
    Style_t        GetMarkerStyle() const { return fMarkerStyle; }
    void           SetMarkerStyle(Style_t pattern);
    virtual void   MarkerSelected(Style_t marker = 0) { Emit("MarkerSelected(Style_t)", marker ? marker : GetMarkerStyle()); }  // *SIGNAL*
-   virtual void   SavePrimitive(std::ostream &out, Option_t * = "");
-   virtual TGDimension GetDefaultSize() const { return TGDimension(38, 21); }
+   void   SavePrimitive(std::ostream &out, Option_t * = "") override;
+   TGDimension GetDefaultSize() const override { return TGDimension(38, 21); }
 
-   ClassDef(TGedMarkerSelect,0)  // Marker selection button
+   ClassDefOverride(TGedMarkerSelect,0)  // Marker selection button
 };
 
 #endif

--- a/gui/ged/inc/TGedPatternSelect.h
+++ b/gui/ged/inc/TGedPatternSelect.h
@@ -25,14 +25,14 @@ protected:
 public:
    TGedPopup(const TGWindow* p, const TGWindow *m, UInt_t w, UInt_t h,
              UInt_t options = 0, Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGedPopup() { }
+   ~TGedPopup() override { }
 
-   virtual Bool_t HandleButton(Event_t *event);
-   virtual Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2);
+   Bool_t HandleButton(Event_t *event) override;
+   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
    void           PlacePopup(Int_t x, Int_t y, UInt_t w, UInt_t h);
    void           EndPopup();
 
-   ClassDef(TGedPopup,0)  //popup window
+   ClassDefOverride(TGedPopup,0)  //popup window
 };
 
 class TGedPatternFrame : public TGFrame {
@@ -45,22 +45,22 @@ protected:
    TGToolTip      *fTip;         ///< tool tip associated with a button
    char            fTipText[7];
 
-   virtual void    DoRedraw();
+   void    DoRedraw() override;
 
 public:
    TGedPatternFrame(const TGWindow *p, Style_t pattern, Int_t width = 40,
                     Int_t height = 20);
-   virtual ~TGedPatternFrame() { delete fTip; }
+   ~TGedPatternFrame() override { delete fTip; }
 
-   virtual Bool_t  HandleButton(Event_t *event);
-   virtual Bool_t  HandleCrossing(Event_t *event);
-   virtual void    DrawBorder();
+   Bool_t  HandleButton(Event_t *event) override;
+   Bool_t  HandleCrossing(Event_t *event) override;
+   void    DrawBorder() override;
 
    void            SetActive(Bool_t in) { fActive = in; gClient->NeedRedraw(this); }
    Style_t         GetPattern() const { return fPattern; }
    static void     SetFillStyle(TGGC* gc, Style_t fstyle); //set fill style for given GC
 
-   ClassDef(TGedPatternFrame,0)  //pattern frame
+   ClassDefOverride(TGedPatternFrame,0)  //pattern frame
 };
 
 class TGedPatternSelector : public TGCompositeFrame {
@@ -72,13 +72,13 @@ protected:
 
 public:
    TGedPatternSelector(const TGWindow *p);
-   virtual ~TGedPatternSelector();
+   ~TGedPatternSelector() override;
 
-   virtual Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2);
+   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
    void           SetActive(Int_t newat);
    Int_t          GetActive() const { return fActive; }
 
-   ClassDef(TGedPatternSelector,0)  //select pattern frame
+   ClassDefOverride(TGedPatternSelector,0)  //select pattern frame
 };
 
 class TGedPatternPopup : public TGedPopup {
@@ -88,11 +88,11 @@ protected:
 
 public:
    TGedPatternPopup(const TGWindow *p, const TGWindow *m, Style_t pattern);
-   virtual ~TGedPatternPopup();
+   ~TGedPatternPopup() override;
 
-   virtual Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2);
+   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
 
-   ClassDef(TGedPatternPopup,0)  // Color selector popup
+   ClassDefOverride(TGedPatternPopup,0)  // Color selector popup
 };
 
 class TGedSelect : public TGCheckButton {
@@ -101,20 +101,20 @@ protected:
    TGGC           *fDrawGC;
    TGedPopup      *fPopup;
 
-   virtual void   DoRedraw();
+   void   DoRedraw() override;
    void           DrawTriangle(GContext_t gc, Int_t x, Int_t y);
 
 public:
    TGedSelect(const TGWindow *p, Int_t id);
-   virtual ~TGedSelect();
+   ~TGedSelect() override;
 
-   virtual Bool_t HandleButton(Event_t *event);
+   Bool_t HandleButton(Event_t *event) override;
 
    virtual void   Enable();
    virtual void   Disable();
    virtual void   SetPopup(TGedPopup* p) { fPopup = p; }  // popup will be deleted in destructor.
 
-   ClassDef(TGedSelect,0)  //selection check-button
+   ClassDefOverride(TGedSelect,0)  //selection check-button
 };
 
 class TGedPatternSelect : public TGedSelect {
@@ -122,21 +122,21 @@ class TGedPatternSelect : public TGedSelect {
 protected:
    Style_t      fPattern;
 
-   virtual void DoRedraw();
+   void DoRedraw() override;
 
 public:
    TGedPatternSelect(const TGWindow *p, Style_t pattern, Int_t id);
-   virtual ~TGedPatternSelect() {}
+   ~TGedPatternSelect() override {}
 
    void           SetPattern(Style_t pattern, Bool_t emit=kTRUE);
    Style_t        GetPattern() const { return fPattern; }
-   virtual        TGDimension GetDefaultSize() const { return TGDimension(55, 21); }
+          TGDimension GetDefaultSize() const override { return TGDimension(55, 21); }
    virtual void   PatternSelected(Style_t pattern = 0)
                   { Emit("PatternSelected(Style_t)", pattern ? pattern : GetPattern()); }  // *SIGNAL*
-   virtual Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2);
-   virtual void   SavePrimitive(std::ostream &out, Option_t * = "");
+   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
+   void   SavePrimitive(std::ostream &out, Option_t * = "") override;
 
-   ClassDef(TGedPatternSelect,0)  //pattern selection check-button
+   ClassDefOverride(TGedPatternSelect,0)  //pattern selection check-button
 };
 
 #endif

--- a/gui/ged/inc/TGraphEditor.h
+++ b/gui/ged/inc/TGraphEditor.h
@@ -47,8 +47,8 @@ public:
                Int_t width = 140, Int_t height = 30,
                UInt_t options = kChildFrame,
                Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGraphEditor();
-   virtual void SetModel(TObject* obj);
+   ~TGraphEditor() override;
+   void SetModel(TObject* obj) override;
 
    // slots related to graph attributes
    virtual void DoShape();
@@ -56,7 +56,7 @@ public:
    virtual void DoTitle(const char *text);
    virtual void DoGraphLineWidth();
 
-   ClassDef(TGraphEditor,0)        // graph editor
+   ClassDefOverride(TGraphEditor,0)        // graph editor
 };
 #endif
 

--- a/gui/ged/inc/TH1Editor.h
+++ b/gui/ged/inc/TH1Editor.h
@@ -125,10 +125,10 @@ public:
                Int_t width = 140, Int_t height = 30,
                UInt_t options = kChildFrame,
                Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TH1Editor();
+   ~TH1Editor() override;
 
-   virtual Bool_t AcceptModel(TObject* model);
-   virtual void   SetModel(TObject* obj);
+   Bool_t AcceptModel(TObject* model) override;
+   void   SetModel(TObject* obj) override;
 
    virtual void DoTitle(const char *text);
    virtual void DoAddMarker(Bool_t on);
@@ -162,10 +162,10 @@ public:
    virtual void DoCancel();
    virtual void PaintBox3D(Float_t *p1, Float_t *p2,Float_t *p3, Float_t *p4);
    Int_t* Dividers(Int_t n);
-   virtual void RecursiveRemove(TObject* obj);
+   void RecursiveRemove(TObject* obj) override;
 
 
-   ClassDef(TH1Editor,0)  // TH1 editor
+   ClassDefOverride(TH1Editor,0)  // TH1 editor
 };
 
 #endif

--- a/gui/ged/inc/TH2Editor.h
+++ b/gui/ged/inc/TH2Editor.h
@@ -141,11 +141,11 @@ public:
              Int_t width = 140, Int_t height = 30,
              UInt_t options = kChildFrame,
              Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TH2Editor();
+   ~TH2Editor() override;
 
-   virtual Bool_t AcceptModel(TObject* model);
-   virtual void   SetModel(TObject* obj);
-   virtual void   ActivateBaseClassEditors(TClass* cl);
+   Bool_t AcceptModel(TObject* model) override;
+   void   SetModel(TObject* obj) override;
+   void   ActivateBaseClassEditors(TClass* cl) override;
 
    virtual void DoTitle(const char *text);
    virtual void DoHistView();
@@ -191,9 +191,9 @@ public:
 
    Int_t* Dividers(Int_t n);
 
-   virtual void RecursiveRemove(TObject* obj);
+   void RecursiveRemove(TObject* obj) override;
 
-   ClassDef(TH2Editor,0)  // TH2 editor
+   ClassDefOverride(TH2Editor,0)  // TH2 editor
 };
 
 #endif

--- a/gui/ged/inc/TLineEditor.h
+++ b/gui/ged/inc/TLineEditor.h
@@ -37,15 +37,15 @@ public:
                Int_t width = 140, Int_t height = 30,
                UInt_t options = kChildFrame,
                Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TLineEditor();
+   ~TLineEditor() override;
 
-   virtual void   SetModel(TObject* obj);
+   void   SetModel(TObject* obj) override;
    virtual void   DoStartPoint();
    virtual void   DoEndPoint();
    virtual void   DoLineVertical();
    virtual void   DoLineHorizontal();
 
-   ClassDef(TLineEditor,0)  // GUI for editing Line attributes
+   ClassDefOverride(TLineEditor,0)  // GUI for editing Line attributes
 };
 
 #endif

--- a/gui/ged/inc/TPadEditor.h
+++ b/gui/ged/inc/TPadEditor.h
@@ -50,10 +50,10 @@ public:
               Int_t width = 140, Int_t height = 30,
               UInt_t options = kChildFrame,
               Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TPadEditor();
+   ~TPadEditor() override;
 
-   virtual void   SetModel(TObject* obj);
-   virtual void   ActivateBaseClassEditors(TClass* cl);
+   void   SetModel(TObject* obj) override;
+   void   ActivateBaseClassEditors(TClass* cl) override;
 
    virtual void   DoEditable(Bool_t on);
    virtual void   DoCrosshair(Bool_t on);
@@ -68,7 +68,7 @@ public:
    virtual void   DoBorderMode();
    virtual void   DoBorderSize(Int_t size);
 
-   ClassDef(TPadEditor,0)  //editor of TPad objects
+   ClassDefOverride(TPadEditor,0)  //editor of TPad objects
 };
 
 #endif

--- a/gui/ged/inc/TPaveStatsEditor.h
+++ b/gui/ged/inc/TPaveStatsEditor.h
@@ -46,14 +46,14 @@ public:
                     Int_t width = 140, Int_t height = 30,
                     UInt_t options = kChildFrame,
                     Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TPaveStatsEditor();
+   ~TPaveStatsEditor() override;
 
-   virtual void   SetModel(TObject* obj);
+   void   SetModel(TObject* obj) override;
    virtual void   DoStatOptions();
    virtual void   DoFitOptions();
    virtual void   SetValuesON(Bool_t on);
 
-   ClassDef(TPaveStatsEditor,0)  // GUI for editing TPaveStats
+   ClassDefOverride(TPaveStatsEditor,0)  // GUI for editing TPaveStats
 };
 
 #endif

--- a/gui/ged/inc/TPieEditor.h
+++ b/gui/ged/inc/TPieEditor.h
@@ -54,9 +54,9 @@ public:
                Int_t width = 140, Int_t height = 30,
                UInt_t options = kChildFrame,
                Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TPieEditor();
-   virtual void SetModel(TObject* );
-   virtual void ActivateBaseClassEditors(TClass*);
+   ~TPieEditor() override;
+   void SetModel(TObject* ) override;
+   void ActivateBaseClassEditors(TClass*) override;
 
    // slots related to graph attributes
    virtual void DoShape();
@@ -66,6 +66,6 @@ public:
    virtual void DoChange3DAngle();
    virtual void DoTextChange();
 
-   ClassDef(TPieEditor,0)        // piechart editor
+   ClassDefOverride(TPieEditor,0)        // piechart editor
 };
 #endif

--- a/gui/ged/inc/TPieSliceEditor.h
+++ b/gui/ged/inc/TPieSliceEditor.h
@@ -34,15 +34,15 @@ public:
                   Int_t width = 140, Int_t height = 30,
                   UInt_t options = kChildFrame,
                   Pixel_t back = GetDefaultFrameBackground());
-   ~TPieSliceEditor();
+   ~TPieSliceEditor() override;
 
-   void SetModel(TObject *);
+   void SetModel(TObject *) override;
 
    void DoTitle(const char*);
    void DoValue();
    void DoOffset();
 
-   ClassDef(TPieSliceEditor,0)        // piechart' slice editor
+   ClassDefOverride(TPieSliceEditor,0)        // piechart' slice editor
 };
 
 #endif // ROOT_TPieSliceEditor

--- a/gui/ged/inc/TStyleDialog.h
+++ b/gui/ged/inc/TStyleDialog.h
@@ -44,14 +44,14 @@ private:
 public:
    TStyleDialog(TStyleManager *sm, TStyle *cur, Int_t mode,
                   TVirtualPad *currentPad = nullptr);
-   virtual ~TStyleDialog();
+   ~TStyleDialog() override;
 
    void DoCloseWindow();                  // SLOT
    void DoCancel();                       // SLOT
    void DoOK();                           // SLOT
    void DoUpdate();                       // SLOT
 
-   ClassDef(TStyleDialog, 0) // Dialog box used by the TStyleManager class
+   ClassDefOverride(TStyleDialog, 0) // Dialog box used by the TStyleManager class
 };
 
 #endif

--- a/gui/ged/inc/TStyleManager.h
+++ b/gui/ged/inc/TStyleManager.h
@@ -440,7 +440,7 @@ private:
 
 public:
    TStyleManager(const TGWindow *);
-   virtual ~TStyleManager();
+   ~TStyleManager() override;
 
    static void Show();
    static void Terminate();
@@ -469,7 +469,7 @@ public:
    void DoSelectNoCanvas();                  // SLOT
    void DoSelectCanvas(TVirtualPad *pad,
          TObject *obj, Int_t mouseButton);   // SLOT
-   void CloseWindow();                       // SLOT
+   void CloseWindow() override;                       // SLOT
 
 // GENERAL
    void ModFillColor();                      // SLOT
@@ -651,7 +651,7 @@ public:
    void ModPaperSizePredef();                // SLOT
    void ModPaperSizeXY();                    // SLOT
 
-   ClassDef(TStyleManager, 0) // Graphical User Interface for managing styles
+   ClassDefOverride(TStyleManager, 0) // Graphical User Interface for managing styles
 };
 
 #endif

--- a/gui/ged/inc/TStylePreview.h
+++ b/gui/ged/inc/TStylePreview.h
@@ -29,12 +29,12 @@ private:
 
 public:
    TStylePreview(const TGWindow *p, TStyle *style, TVirtualPad *currentPad);
-   virtual ~TStylePreview();
+   ~TStylePreview() override;
    void Update(TStyle *style, TVirtualPad *pad);
    void MapTheWindow();
    TCanvas *GetMainCanvas();
 
-   ClassDef(TStylePreview, 0) // Preview window used by the TStyleManager class
+   ClassDefOverride(TStylePreview, 0) // Preview window used by the TStyleManager class
 };
 
 #endif

--- a/gui/ged/inc/TTextEditor.h
+++ b/gui/ged/inc/TTextEditor.h
@@ -37,9 +37,9 @@ public:
                   Int_t width = 140, Int_t height = 30,
                   UInt_t options = kChildFrame,
                   Pixel_t back = GetDefaultFrameBackground());
-   ~TTextEditor();
+   ~TTextEditor() override;
 
-   void SetModel(TObject *);
+   void SetModel(TObject *) override;
 
    void DoAngle();
    void DoSize();
@@ -47,7 +47,7 @@ public:
    void DoXpos();
    void DoYpos();
 
-   ClassDef(TTextEditor,0)        // text editor
+   ClassDefOverride(TTextEditor,0)        // text editor
 };
 
 #endif // ROOT_TTextEditor

--- a/gui/gui/inc/TGApplication.h
+++ b/gui/gui/inc/TGApplication.h
@@ -32,7 +32,7 @@ public:
    TGApplication(const char *appClassName,
                  Int_t *argc, char **argv,
                  void *options = nullptr, Int_t numOptions = 0);
-   virtual ~TGApplication();
+   ~TGApplication() override;
 
    void GetOptions(Int_t *argc, char **argv) override;
 

--- a/gui/gui/inc/TGButton.h
+++ b/gui/gui/inc/TGButton.h
@@ -100,7 +100,7 @@ public:
 
    TGButton(const TGWindow *p = nullptr, Int_t id = -1, GContext_t norm = GetDefaultGC()(),
             UInt_t option = kRaisedFrame | kDoubleBorder);
-   virtual ~TGButton();
+   ~TGButton() override;
 
    Bool_t               HandleButton(Event_t *event) override;
    Bool_t               HandleCrossing(Event_t *event) override;
@@ -181,7 +181,7 @@ public:
                 FontStruct_t font = GetDefaultFontStruct(),
                 UInt_t option = kRaisedFrame | kDoubleBorder);
 
-   virtual ~TGTextButton();
+   ~TGTextButton() override;
 
    TGDimension        GetDefaultSize() const override;
 
@@ -249,7 +249,7 @@ public:
    TGPictureButton(const TGWindow *p = nullptr, const char* pic = nullptr, Int_t id = -1,
                    GContext_t norm = GetDefaultGC()(),
                    UInt_t option = kRaisedFrame | kDoubleBorder);
-   virtual ~TGPictureButton();
+   ~TGPictureButton() override;
 
    virtual void     SetPicture(const TGPicture *new_pic);
    virtual void     SetDisabledPicture(const TGPicture *pic);
@@ -299,7 +299,7 @@ public:
                  GContext_t norm = GetDefaultGC()(),
                  FontStruct_t font = GetDefaultFontStruct(),
                  UInt_t option = 0);
-   virtual ~TGCheckButton();
+   ~TGCheckButton() override;
 
    TGDimension    GetDefaultSize() const override;
 
@@ -355,7 +355,7 @@ public:
                  GContext_t norm = GetDefaultGC()(),
                  FontStruct_t font = GetDefaultFontStruct(),
                  UInt_t option = 0);
-   virtual ~TGRadioButton();
+   ~TGRadioButton() override;
 
    TGDimension    GetDefaultSize() const override;
 
@@ -418,7 +418,7 @@ public:
                 FontStruct_t fontstruct = GetDefaultFontStruct(),
                 UInt_t option = kRaisedFrame | kDoubleBorder);
 
-   virtual ~TGSplitButton();
+   ~TGSplitButton() override;
 
    TGDimension  GetDefaultSize() const override;
 

--- a/gui/gui/inc/TGButtonGroup.h
+++ b/gui/gui/inc/TGButtonGroup.h
@@ -51,7 +51,7 @@ public:
                  FontStruct_t font = GetDefaultFontStruct(),
                  Pixel_t back = GetDefaultFrameBackground());
 
-   virtual ~TGButtonGroup();
+   ~TGButtonGroup() override;
 
    virtual void Pressed(Int_t id)  { Emit("Pressed(Int_t)",id); }   //*SIGNAL*
    virtual void Released(Int_t id) { Emit("Released(Int_t)",id);}   //*SIGNAL*
@@ -102,7 +102,7 @@ public:
       TGButtonGroup(parent, title, kChildFrame | kVerticalFrame,
                     norm, font, back) {}
 
-   virtual ~TGVButtonGroup() {}
+   ~TGVButtonGroup() override {}
    void SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
    ClassDefOverride(TGVButtonGroup,0)  // A button group with one vertical column
@@ -120,7 +120,7 @@ public:
       TGButtonGroup(parent, title, kChildFrame | kHorizontalFrame,
                     norm, font, back) { }
 
-   virtual ~TGHButtonGroup() {}
+   ~TGHButtonGroup() override {}
    void SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
    ClassDefOverride(TGHButtonGroup,0)  // A button group with one horizontal row

--- a/gui/gui/inc/TGCanvas.h
+++ b/gui/gui/inc/TGCanvas.h
@@ -82,7 +82,7 @@ public:
    TGContainer(TGCanvas *p,UInt_t options = kSunkenFrame,
                Pixel_t back = GetDefaultFrameBackground());
 
-   virtual ~TGContainer();
+   ~TGContainer() override;
 
    virtual void DrawRegion(Int_t x, Int_t y, UInt_t w, UInt_t h);
    virtual void ClearViewPort();
@@ -211,7 +211,7 @@ public:
    TGCanvas(const TGWindow *p = nullptr, UInt_t w = 1, UInt_t h = 1,
             UInt_t options = kSunkenFrame | kDoubleBorder,
             Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGCanvas();
+   ~TGCanvas() override;
 
    TGFrame      *GetContainer() const { return fVport->GetContainer(); }
    TGViewPort   *GetViewPort() const { return fVport; }

--- a/gui/gui/inc/TGClient.h
+++ b/gui/gui/inc/TGClient.h
@@ -75,7 +75,7 @@ protected:
 
 public:
    TGClient(const char *dpyName = nullptr);
-   virtual ~TGClient();
+   ~TGClient() override;
 
    const TGWindow *GetRoot() const;
    const TGWindow *GetDefaultRoot() const;

--- a/gui/gui/inc/TGColorDialog.h
+++ b/gui/gui/inc/TGColorDialog.h
@@ -54,7 +54,7 @@ protected:
 
 public:
    TGColorPalette(const TGWindow *p = nullptr, Int_t cols = 8, Int_t rows = 8, Int_t id = -1);
-   virtual ~TGColorPalette();
+   ~TGColorPalette() override;
 
    Bool_t HandleButton(Event_t *event) override;
    Bool_t HandleMotion(Event_t *event) override;
@@ -117,7 +117,7 @@ protected:
 
 public:
    TGColorPick(const TGWindow *p = nullptr, Int_t w = 1, Int_t h = 1, Int_t id = -1);
-   virtual ~TGColorPick();
+   ~TGColorPick() override;
 
    Bool_t HandleButton(Event_t *event) override;
    Bool_t HandleMotion(Event_t *event) override;
@@ -171,7 +171,7 @@ protected:
 public:
    TGColorDialog(const TGWindow *p = nullptr, const TGWindow *m = nullptr, Int_t *retc = nullptr,
                  Pixel_t *color = nullptr, Bool_t wait = kTRUE);
-   virtual ~TGColorDialog();
+   ~TGColorDialog() override;
 
    TGColorPalette *GetPalette() const { return fPalette; }
    TGColorPalette *GetCustomPalette() const { return fCpalette; }

--- a/gui/gui/inc/TGColorSelect.h
+++ b/gui/gui/inc/TGColorSelect.h
@@ -34,7 +34,7 @@ private:
 
 public:
    TGColorFrame(const TGWindow *p = nullptr, Pixel_t c = 0, Int_t n = 1);
-   virtual ~TGColorFrame() { }
+   ~TGColorFrame() override { }
 
    Bool_t   HandleButton(Event_t *event) override;
    void     DrawBorder() override;
@@ -60,7 +60,7 @@ private:
 
 public:
    TG16ColorSelector(const TGWindow *p = nullptr);
-   virtual ~TG16ColorSelector();
+   ~TG16ColorSelector() override;
 
    Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
 
@@ -86,7 +86,7 @@ private:
 
 public:
    TGColorPopup(const TGWindow *p = nullptr, const TGWindow *m = nullptr, Pixel_t color = 0);
-   virtual ~TGColorPopup();
+   ~TGColorPopup() override;
 
    Bool_t  HandleButton(Event_t *event) override;
    Bool_t  ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
@@ -120,7 +120,7 @@ private:
 public:
    TGColorSelect(const TGWindow *p = nullptr, Pixel_t color = 0,
                  Int_t id = -1);
-   virtual ~TGColorSelect();
+   ~TGColorSelect() override;
 
    Bool_t  HandleButton(Event_t *event) override;
    Bool_t  ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;

--- a/gui/gui/inc/TGComboBox.h
+++ b/gui/gui/inc/TGComboBox.h
@@ -71,7 +71,7 @@ public:
               UInt_t options = kHorizontalFrame | kSunkenFrame | kDoubleBorder,
               Pixel_t back = GetWhitePixel());
 
-   virtual ~TGComboBox();
+   ~TGComboBox() override;
 
    void DrawBorder() override;
    TGDimension GetDefaultSize() const override { return TGDimension(fWidth, fHeight); }
@@ -184,7 +184,7 @@ public:
    TGFontTypeComboBox(const TGWindow *p = nullptr, Int_t id = -1,
             UInt_t options = kHorizontalFrame | kSunkenFrame | kDoubleBorder,
             Pixel_t bask = GetWhitePixel());
-   virtual ~TGFontTypeComboBox();
+   ~TGFontTypeComboBox() override;
 
    ClassDefOverride(TGFontTypeComboBox, 0)  // Font type combobox widget
 };

--- a/gui/gui/inc/TGCommandPlugin.h
+++ b/gui/gui/inc/TGCommandPlugin.h
@@ -40,7 +40,7 @@ protected:
 public:
 
    TGCommandPlugin(const TGWindow *p, UInt_t w, UInt_t h);
-   virtual ~TGCommandPlugin();
+   ~TGCommandPlugin() override;
 
    void           CheckRemote(const char * /*str*/);
    void           HandleArrows(Int_t keysym);

--- a/gui/gui/inc/TGDNDManager.h
+++ b/gui/gui/inc/TGDNDManager.h
@@ -34,7 +34,7 @@ protected:
 public:
    TGDragWindow(const TGWindow *p, Pixmap_t pic, Pixmap_t mask,
                 UInt_t options = kChildFrame, Pixel_t back = GetWhitePixel());
-   virtual ~TGDragWindow();
+   ~TGDragWindow() override;
 
    TGDimension GetDefaultSize() const override { return TGDimension(fPw, fPh); }
 
@@ -69,7 +69,7 @@ private:
 public:
    TDNDData(Atom_t dt = kNone, void *d = nullptr, Int_t len = 0, Atom_t act = kNone) :
       fDataType(dt), fAction(act), fData(d), fDataLength(len) {}
-   ~TDNDData() {}
+   ~TDNDData() override {}
 
    Atom_t    fDataType;       ///< Data type description
    Atom_t    fAction;         ///< Action description
@@ -148,7 +148,7 @@ protected:
 
 public:
    TGDNDManager(TGFrame *toplevel, Atom_t *typelist);
-   virtual ~TGDNDManager();
+   ~TGDNDManager() override;
 
    Bool_t         HandleClientMessage(Event_t *event);
    Bool_t         HandleSelectionRequest(Event_t *event);

--- a/gui/gui/inc/TGDockableFrame.h
+++ b/gui/gui/inc/TGDockableFrame.h
@@ -36,7 +36,7 @@ protected:
 
 public:
    TGDockButton(const TGCompositeFrame *p = nullptr, Int_t id = 1);
-   virtual ~TGDockButton();
+   ~TGDockButton() override;
 
    Bool_t HandleCrossing(Event_t *event) override;
 
@@ -70,7 +70,7 @@ protected:
 
 public:
    TGUndockedFrame(const TGWindow *p = nullptr, TGDockableFrame *dockable = nullptr);
-   virtual ~TGUndockedFrame();
+   ~TGUndockedFrame() override;
 
    void FixSize();
    void CloseWindow() override;
@@ -104,7 +104,7 @@ protected:
 public:
    TGDockableFrame(const TGWindow *p = nullptr, Int_t id = -1,
                    UInt_t options = kHorizontalFrame);
-   virtual ~TGDockableFrame();
+   ~TGDockableFrame() override;
 
    void AddFrame(TGFrame *f, TGLayoutHints *hints) override;
 

--- a/gui/gui/inc/TGDoubleSlider.h
+++ b/gui/gui/inc/TGDoubleSlider.h
@@ -71,7 +71,7 @@ public:
                   Bool_t reversed = kFALSE,
                   Bool_t mark_ends = kFALSE);
 
-   virtual ~TGDoubleSlider() { }
+   ~TGDoubleSlider() override { }
 
    Bool_t HandleButton(Event_t *event) override = 0;
    Bool_t HandleMotion(Event_t *event) override = 0;
@@ -181,7 +181,7 @@ public:
                    Bool_t reversed = kFALSE,
                    Bool_t mark_ends = kFALSE);
 
-   virtual ~TGDoubleVSlider();
+   ~TGDoubleVSlider() override;
 
    Bool_t HandleButton(Event_t *event) override;
    Bool_t HandleMotion(Event_t *event) override;
@@ -207,7 +207,7 @@ public:
                    Bool_t reversed = kFALSE,
                    Bool_t mark_ends = kFALSE);
 
-   virtual ~TGDoubleHSlider();
+   ~TGDoubleHSlider() override;
 
    Bool_t HandleButton(Event_t *event) override;
    Bool_t HandleMotion(Event_t *event) override;

--- a/gui/gui/inc/TGEventHandler.h
+++ b/gui/gui/inc/TGEventHandler.h
@@ -35,7 +35,7 @@ private:
 public:
    TGEventHandler(const char *name, TGWindow *w, TObject *obj, const char *title="") :
       TNamed(name, title), fIsActive(kTRUE), fWindow(w), fObject(obj) { }
-   virtual ~TGEventHandler() { }
+   ~TGEventHandler() override { }
 
    void           Activate() { fIsActive = kTRUE; }
    void           DeActivate() { fIsActive = kFALSE; }

--- a/gui/gui/inc/TGFSComboBox.h
+++ b/gui/gui/inc/TGFSComboBox.h
@@ -48,7 +48,7 @@ public:
                  Int_t id = -1, TGString *path = nullptr, GContext_t norm = GetDefaultGC()(),
                  FontStruct_t font = GetDefaultFontStruct(),
                  UInt_t options = kHorizontalFrame, Pixel_t back = GetWhitePixel());
-   virtual ~TGTreeLBEntry();
+   ~TGTreeLBEntry() override;
 
    const TGString  *GetText() const { return fText; }
    const TGPicture *GetPicture() const { return fPic; }

--- a/gui/gui/inc/TGFSContainer.h
+++ b/gui/gui/inc/TGFSContainer.h
@@ -73,7 +73,7 @@ public:
               EListViewMode viewMode = kLVList, UInt_t options = kVerticalFrame,
               Pixel_t back = GetWhitePixel());
 
-   virtual ~TGFileItem();
+   ~TGFileItem() override;
 
    void     SetViewMode(EListViewMode viewMode) override;
 
@@ -144,7 +144,7 @@ public:
    TGFileContainer(TGCanvas *p, UInt_t options = kSunkenFrame,
                    Pixel_t back = GetDefaultFrameBackground());
 
-   virtual ~TGFileContainer();
+   ~TGFileContainer() override;
 
    Bool_t HandleTimer(TTimer *t) override;
    void StopRefreshTimer();

--- a/gui/gui/inc/TGFileBrowser.h
+++ b/gui/gui/inc/TGFileBrowser.h
@@ -77,7 +77,7 @@ protected:
 
 public:
    TGFileBrowser(const TGWindow *p, TBrowser *b = nullptr, UInt_t w = 200, UInt_t h = 400);
-   virtual ~TGFileBrowser();
+   ~TGFileBrowser() override;
 
    void         Add(TObject *obj, const char *name = nullptr, Int_t check = -1) override;
    void         BrowseObj(TObject *obj) override;

--- a/gui/gui/inc/TGFileDialog.h
+++ b/gui/gui/inc/TGFileDialog.h
@@ -93,7 +93,7 @@ private:
 public:
    TGFileDialog(const TGWindow *p = nullptr, const TGWindow *main = nullptr,
                 EFileDialogMode dlg_type = kFDOpen, TGFileInfo *file_info = nullptr);
-   virtual ~TGFileDialog();
+   ~TGFileDialog() override;
 
    Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
    void CloseWindow() override;

--- a/gui/gui/inc/TGFont.h
+++ b/gui/gui/inc/TGFont.h
@@ -119,7 +119,7 @@ protected:
 
 public:
    TGTextLayout(): fFont(nullptr), fString(""), fWidth(0), fNumChunks(0), fChunks(nullptr) {}
-   virtual ~TGTextLayout();
+   ~TGTextLayout() override;
 
    void   DrawText(Drawable_t dst, GContext_t gc, Int_t x, Int_t y,
                    Int_t firstChar, Int_t lastChar) const;
@@ -178,7 +178,7 @@ protected:
                            const char *start, int numChars,
                            int curX, int newX, int y) const;
 public:
-   virtual ~TGFont();
+   ~TGFont() override;
 
    FontH_t      GetFontHandle() const { return fFontH; }
    FontStruct_t GetFontStruct() const { return fFontStruct; }
@@ -236,7 +236,7 @@ protected:
 
 public:
    TGFontPool(TGClient *client);
-   virtual ~TGFontPool();
+   ~TGFontPool() override;
 
    TGFont  *GetFont(const char *font, Bool_t fixedDefault = kTRUE);
    TGFont  *GetFont(const TGFont *font);

--- a/gui/gui/inc/TGFontDialog.h
+++ b/gui/gui/inc/TGFontDialog.h
@@ -67,7 +67,7 @@ public:
    TGFontDialog(const TGWindow *parent = nullptr, const TGWindow *t = nullptr,
                 FontProp_t *fontProp = nullptr, const TString &sample = "",
                 char **fontList = nullptr, Bool_t wait = kTRUE);
-   virtual ~TGFontDialog();
+   ~TGFontDialog() override;
 
    virtual void SetFont(TGFont *font);
    virtual void SetColor(Pixel_t color);

--- a/gui/gui/inc/TGFrame.h
+++ b/gui/gui/inc/TGFrame.h
@@ -147,7 +147,7 @@ public:
    TGFrame(const TGWindow *p = nullptr, UInt_t w = 1, UInt_t h = 1,
            UInt_t options = 0, Pixel_t back = GetDefaultFrameBackground());
    TGFrame(TGClient *c, Window_t id, const TGWindow *parent = nullptr);
-   virtual ~TGFrame();
+   ~TGFrame() override;
 
    virtual void DeleteWindow();
    virtual void ReallyDelete() { delete this; }
@@ -305,7 +305,7 @@ public:
                     UInt_t options = 0,
                     Pixel_t back = GetDefaultFrameBackground());
    TGCompositeFrame(TGClient *c, Window_t id, const TGWindow *parent = nullptr);
-   virtual ~TGCompositeFrame();
+   ~TGCompositeFrame() override;
 
    virtual TList *GetList() const { return fList; }
 
@@ -443,7 +443,7 @@ private:
 public:
    TGMainFrame(const TGWindow *p = nullptr, UInt_t w = 1, UInt_t h = 1,
                UInt_t options = kVerticalFrame);
-   virtual ~TGMainFrame();
+   ~TGMainFrame() override;
 
    Bool_t HandleKey(Event_t *event) override;
    Bool_t HandleClientMessage(Event_t *event) override;
@@ -553,7 +553,7 @@ public:
                 GContext_t norm = GetDefaultGC()(),
                 FontStruct_t font = GetDefaultFontStruct(),
                 Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGGroupFrame();
+   ~TGGroupFrame() override;
 
    TGDimension GetDefaultSize() const override;
    void  DrawBorder() override;

--- a/gui/gui/inc/TGGC.h
+++ b/gui/gui/inc/TGGC.h
@@ -35,7 +35,7 @@ protected:
 public:
    TGGC(GCValues_t *values = nullptr);
    TGGC(const TGGC &g);
-   virtual ~TGGC();
+   ~TGGC() override;
    TGGC &operator=(const TGGC &rhs);
 
    GContext_t GetGC() const { return fContext; }
@@ -124,7 +124,7 @@ protected:
 
 public:
    TGGCPool(TGClient *client);
-   virtual ~TGGCPool();
+   ~TGGCPool() override;
 
    TGGC *GetGC(GCValues_t *values, Bool_t rw = kFALSE);
    TGGC *GetGC(GContext_t gct);

--- a/gui/gui/inc/TGIcon.h
+++ b/gui/gui/inc/TGIcon.h
@@ -39,7 +39,7 @@ public:
 
    TGIcon(const TGWindow *p = nullptr, const char *image = nullptr);
 
-   virtual ~TGIcon();
+   ~TGIcon() override;
 
    virtual void Reset();         //*MENU*
    const TGPicture *GetPicture() const { return fPic; }

--- a/gui/gui/inc/TGIdleHandler.h
+++ b/gui/gui/inc/TGIdleHandler.h
@@ -23,7 +23,7 @@ private:
 
 public:
    TGIdleHandler(TGWindow *w);
-   virtual ~TGIdleHandler();
+   ~TGIdleHandler() override;
 
    virtual Bool_t HandleEvent();
 

--- a/gui/gui/inc/TGImageMap.h
+++ b/gui/gui/inc/TGImageMap.h
@@ -41,7 +41,7 @@ public:
    TGRegion(Int_t n, Int_t *x, Int_t *y, Bool_t winding = kFALSE);
    TGRegion(const TArrayS &x, const TArrayS &y, Bool_t winding = kFALSE);
    TGRegion(const TGRegion &reg);
-   virtual ~TGRegion();
+   ~TGRegion() override;
 
    Bool_t      Contains(const TPoint &p) const;
    Bool_t      Contains(Int_t x, Int_t y) const;
@@ -90,7 +90,7 @@ public:
    TGRegionWithId(Int_t id, Int_t n, TPoint *points, Bool_t winding = kFALSE);
    TGRegionWithId(const TGRegionWithId &reg);
    TGRegionWithId(const TGRegion &reg, Int_t id);
-   virtual ~TGRegionWithId();
+   ~TGRegionWithId() override;
 
    Int_t        GetId() const { return fId; }
    TGToolTip   *GetToolTipText() const { return fTip; }
@@ -126,7 +126,7 @@ protected:
 public:
    TGImageMap(const TGWindow *p = nullptr, const TGPicture *pic = nullptr);
    TGImageMap(const TGWindow *p, const TString &pic);
-   virtual ~TGImageMap();
+   ~TGImageMap() override;
 
    Bool_t HandleButton(Event_t *event) override;
    Bool_t HandleDoubleClick(Event_t *event) override;

--- a/gui/gui/inc/TGInputDialog.h
+++ b/gui/gui/inc/TGInputDialog.h
@@ -36,7 +36,7 @@ public:
    TGInputDialog(const TGWindow *p = nullptr, const TGWindow *main = nullptr,
                  const char *prompt = nullptr, const char *defval = nullptr,
                  char *retstr = nullptr, UInt_t options = kVerticalFrame);
-   ~TGInputDialog();
+   ~TGInputDialog() override;
 
    Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t) override;
 

--- a/gui/gui/inc/TGLabel.h
+++ b/gui/gui/inc/TGLabel.h
@@ -67,7 +67,7 @@ public:
            UInt_t options = kChildFrame,
            Pixel_t back = GetDefaultFrameBackground());
 
-   virtual ~TGLabel();
+   ~TGLabel() override;
 
    TGDimension GetDefaultSize() const override;
 

--- a/gui/gui/inc/TGLayout.h
+++ b/gui/gui/inc/TGLayout.h
@@ -77,7 +77,7 @@ public:
 
    TGLayoutHints(const TGLayoutHints &lh);
 
-   virtual ~TGLayoutHints();
+   ~TGLayoutHints() override;
 
    ULong_t GetLayoutHints() const { return fLayoutHints; }
    Int_t   GetPadTop() const { return fPadtop; }
@@ -115,7 +115,7 @@ public:
 
    TGFrameElement() : fFrame(nullptr), fState(0), fLayout(nullptr) { }
    TGFrameElement(TGFrame *f, TGLayoutHints *l);
-   ~TGFrameElement();
+   ~TGFrameElement() override;
 
    void Print(Option_t* option = "") const override;
    void ls(Option_t* option = "") const override { Print(option); }

--- a/gui/gui/inc/TGListBox.h
+++ b/gui/gui/inc/TGListBox.h
@@ -73,7 +73,7 @@ public:
                  FontStruct_t font = GetDefaultFontStruct(),
                  UInt_t options = kHorizontalFrame,
                  Pixel_t back = GetWhitePixel());
-   virtual ~TGTextLBEntry();
+   ~TGTextLBEntry() override;
 
    TGDimension GetDefaultSize() const override { return TGDimension(fTWidth, fTHeight+1); }
    const TGString *GetText() const { return fText; }
@@ -113,7 +113,7 @@ public:
                      UInt_t w = 0, Style_t s = 0,
                      UInt_t options = kHorizontalFrame,
                      Pixel_t back = GetWhitePixel());
-   virtual ~TGLineLBEntry();
+   ~TGLineLBEntry() override;
 
    TGDimension   GetDefaultSize() const override
                   { return TGDimension(fTWidth, fTHeight+1); }
@@ -146,7 +146,7 @@ public:
                  UInt_t w = 0, Style_t s = 0,
                  UInt_t options = kHorizontalFrame,
                  Pixel_t back = GetWhitePixel());
-   virtual ~TGIconLBEntry();
+   ~TGIconLBEntry() override;
 
    TGDimension   GetDefaultSize() const override
                   { return TGDimension(fTWidth, fTHeight+1); }
@@ -182,7 +182,7 @@ public:
    TGLBContainer(const TGWindow *p = nullptr, UInt_t w = 1, UInt_t h = 1,
                  UInt_t options = kSunkenFrame,
                  Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGLBContainer();
+   ~TGLBContainer() override;
 
    virtual void AddEntry(TGLBEntry *lbe, TGLayoutHints *lhints);
    virtual void AddEntrySort(TGLBEntry *lbe, TGLayoutHints *lhints);
@@ -239,7 +239,7 @@ public:
    TGListBox(const TGWindow *p = nullptr, Int_t id = -1,
              UInt_t options = kSunkenFrame | kDoubleBorder,
              Pixel_t back = GetWhitePixel());
-   virtual ~TGListBox();
+   ~TGListBox() override;
 
    virtual void AddEntry(TGString *s, Int_t id);
    virtual void AddEntry(const char *s, Int_t id);

--- a/gui/gui/inc/TGListTree.h
+++ b/gui/gui/inc/TGListTree.h
@@ -148,7 +148,7 @@ public:
    TGListTreeItemStd(TGClient *fClient = gClient, const char *name = nullptr,
                      const TGPicture *opened = nullptr, const TGPicture *closed = nullptr,
                      Bool_t checkbox = kFALSE);
-   virtual ~TGListTreeItemStd();
+   ~TGListTreeItemStd() override;
 
    Pixel_t         GetActiveColor() const override;
    Bool_t          IsActive() const override { return fActive; }
@@ -308,7 +308,7 @@ public:
               UInt_t options = 0, Pixel_t back = GetWhitePixel());
    TGListTree(TGCanvas *p, UInt_t options, Pixel_t back = GetWhitePixel());
 
-   virtual ~TGListTree();
+   ~TGListTree() override;
 
    Bool_t HandleButton(Event_t *event) override;
    Bool_t HandleDoubleClick(Event_t *event) override;

--- a/gui/gui/inc/TGListView.h
+++ b/gui/gui/inc/TGListView.h
@@ -79,7 +79,7 @@ public:
              const TString& name, const TString& cname, TGString **subnames = nullptr,
              UInt_t options = kChildFrame, Pixel_t back = GetWhitePixel());
 
-   virtual ~TGLVEntry();
+   ~TGLVEntry() override;
 
    virtual void SetViewMode(EListViewMode viewMode);
 
@@ -143,7 +143,7 @@ public:
    TGListView(const TGWindow *p, UInt_t w, UInt_t h,
               UInt_t options = kSunkenFrame | kDoubleBorder,
               Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGListView();
+   ~TGListView() override;
 
    virtual void   ResizeColumns();
    void           Layout() override;
@@ -200,7 +200,7 @@ public:
    TGLVContainer(TGCanvas *p, UInt_t options = kSunkenFrame,
                  Pixel_t back = GetDefaultFrameBackground());
 
-   virtual ~TGLVContainer();
+   ~TGLVContainer() override;
 
    TGListView  *GetListView() const { return fListView; }
 

--- a/gui/gui/inc/TGMdiDecorFrame.h
+++ b/gui/gui/inc/TGMdiDecorFrame.h
@@ -137,7 +137,7 @@ protected:
 
 public:
    TGMdiButtons(const TGWindow *p, const TGWindow *titlebar);
-   virtual ~TGMdiButtons();
+   ~TGMdiButtons() override;
 
    TGPictureButton *GetButton(Int_t no) const { return fButton[no]; }
 
@@ -161,7 +161,7 @@ protected:
 public:
    TGMdiTitleIcon(const TGWindow *p, const TGWindow *titlebar,
                   const TGPicture *pic, Int_t w, Int_t h);
-   virtual ~TGMdiTitleIcon();
+   ~TGMdiTitleIcon() override;
 
    Bool_t HandleDoubleClick(Event_t *event) override;
    Bool_t HandleButton(Event_t *event) override;
@@ -197,7 +197,7 @@ protected:
    void RemoveFrames(TGMdiTitleIcon *icon, TGMdiButtons *buttons);
 
 public:
-   virtual ~TGMdiTitleBar();
+   ~TGMdiTitleBar() override;
 
    Bool_t               HandleButton(Event_t *event) override;
    Bool_t               HandleDoubleClick(Event_t *event) override;
@@ -259,7 +259,7 @@ public:
    TGMdiDecorFrame(TGMdiMainFrame *main, TGMdiFrame *frame, Int_t w, Int_t h,
                    const TGGC *boxGC, UInt_t options = 0,
                    Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGMdiDecorFrame();
+   ~TGMdiDecorFrame() override;
 
    Bool_t           HandleButton(Event_t *event) override;
    Bool_t           HandleConfigureNotify(Event_t *event) override;

--- a/gui/gui/inc/TGMdiFrame.h
+++ b/gui/gui/inc/TGMdiFrame.h
@@ -56,7 +56,7 @@ public:
    TGMdiFrame(TGMdiMainFrame *main, Int_t w, Int_t h,
               UInt_t options = 0,
               Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGMdiFrame();
+   ~TGMdiFrame() override;
 
    void              Move(Int_t x, Int_t y) override;
    virtual Bool_t    CloseWindow();     //*SIGNAL*

--- a/gui/gui/inc/TGMdiMainFrame.h
+++ b/gui/gui/inc/TGMdiMainFrame.h
@@ -166,7 +166,7 @@ public:
    TGMdiMainFrame(const TGWindow *p, TGMdiMenuBar *menu, Int_t w, Int_t h,
                   UInt_t options = 0,
                   Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGMdiMainFrame();
+   ~TGMdiMainFrame() override;
 
    Bool_t           HandleKey(Event_t *event) override;
    Bool_t           ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;

--- a/gui/gui/inc/TGMdiMenu.h
+++ b/gui/gui/inc/TGMdiMenu.h
@@ -60,7 +60,7 @@ protected:
 
 public:
    TGMdiMenuBar(const TGWindow *p, Int_t w = 1, Int_t h = 20);
-   virtual ~TGMdiMenuBar();
+   ~TGMdiMenuBar() override;
 
    void AddPopup(TGHotString *s, TGPopupMenu *menu, TGLayoutHints *l);
    TGMenuBar *GetMenuBar() const { return fBar;}

--- a/gui/gui/inc/TGMenu.h
+++ b/gui/gui/inc/TGMenu.h
@@ -78,7 +78,7 @@ private:
 public:
    TGMenuEntry(): fEntryId(0), fUserData(nullptr), fType(), fStatus(0),
       fEx(0), fEy(0), fEw(0), fEh(0), fLabel(nullptr), fShortcut(nullptr), fPic(nullptr), fPopup(nullptr) { }
-   virtual ~TGMenuEntry() { if (fLabel) delete fLabel; if (fShortcut) delete fShortcut; }
+   ~TGMenuEntry() override { if (fLabel) delete fLabel; if (fShortcut) delete fShortcut; }
 
    Int_t          GetEntryId() const { return fEntryId; }
    const char    *GetName() const override { return fLabel ? fLabel->GetString() : nullptr; }
@@ -160,7 +160,7 @@ private:
 public:
    TGPopupMenu(const TGWindow *p = nullptr, UInt_t w = 10, UInt_t h = 10,
                UInt_t options = 0);
-   virtual ~TGPopupMenu();
+   ~TGPopupMenu() override;
 
    virtual void AddEntry(TGHotString *s, Int_t id, void *ud = nullptr,
                          const TGPicture *p = nullptr, TGMenuEntry *before = nullptr);
@@ -263,7 +263,7 @@ public:
                GContext_t norm = GetDefaultGC()(),
                FontStruct_t font = GetDefaultFontStruct(),
                UInt_t options = 0);
-   virtual ~TGMenuTitle() { if (fLabel) delete fLabel; }
+   ~TGMenuTitle() override { if (fLabel) delete fLabel; }
 
    Pixel_t      GetTextColor() const { return fTextColor; }
    void         SetTextColor(Pixel_t col) { fTextColor = col; }
@@ -310,7 +310,7 @@ private:
 public:
    TGMenuBar(const TGWindow *p = nullptr, UInt_t w = 60, UInt_t h = 20,
              UInt_t options = kHorizontalFrame | kRaisedFrame);
-   virtual ~TGMenuBar();
+   ~TGMenuBar() override;
 
    virtual void AddPopup(TGHotString *s, TGPopupMenu *menu, TGLayoutHints *l,
                          TGPopupMenu *before = nullptr);

--- a/gui/gui/inc/TGMimeTypes.h
+++ b/gui/gui/inc/TGMimeTypes.h
@@ -40,7 +40,7 @@ private:
 
 public:
    TGMime() : fReg(nullptr) {}
-   ~TGMime();
+   ~TGMime() override;
 };
 
 
@@ -58,7 +58,7 @@ protected:
 
 public:
    TGMimeTypes(TGClient *client, const char *file);
-   virtual ~TGMimeTypes();
+   ~TGMimeTypes() override;
 
    void   SaveMimes();
    Bool_t HasChanged() const { return fChanged; }

--- a/gui/gui/inc/TGMsgBox.h
+++ b/gui/gui/inc/TGMsgBox.h
@@ -82,7 +82,7 @@ public:
             Int_t buttons = kMBDismiss, Int_t *ret_code = nullptr,
             UInt_t options = kVerticalFrame,
             Int_t text_align = kTextCenterX | kTextCenterY);
-   virtual ~TGMsgBox();
+   ~TGMsgBox() override;
 
    void CloseWindow() override;
    Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;

--- a/gui/gui/inc/TGNumberEntry.h
+++ b/gui/gui/inc/TGNumberEntry.h
@@ -171,7 +171,7 @@ public:
                  EAttribute attr = kNEAAnyNumber,
                  ELimit limits = kNELNoLimits,
                  Double_t min = 0, Double_t max = 1);
-   virtual ~TGNumberEntry();
+   ~TGNumberEntry() override;
 
    virtual void SetNumber(Double_t val, Bool_t emit = kTRUE) {
       // Set the numeric value (floating point representation)

--- a/gui/gui/inc/TGObject.h
+++ b/gui/gui/inc/TGObject.h
@@ -37,7 +37,7 @@ protected:
 public:
    TGObject(): fId(0), fClient(nullptr) { }
    TGObject(const TGObject& tgo): TObject(tgo), fId(tgo.fId), fClient(tgo.fClient) { }
-   virtual ~TGObject();
+   ~TGObject() override;
    Handle_t  GetId() const { return fId; }
    TGClient *GetClient() const { return fClient; }
    ULong_t   Hash() const override { return (ULong_t) fId >> 0; }

--- a/gui/gui/inc/TGPack.h
+++ b/gui/gui/inc/TGPack.h
@@ -72,7 +72,7 @@ public:
    TGPack(const TGWindow *p = nullptr, UInt_t w = 1, UInt_t h = 1, UInt_t options = 0,
           Pixel_t back = GetDefaultFrameBackground());
    TGPack(TGClient *c, Window_t id, const TGWindow *parent = nullptr);
-   virtual ~TGPack();
+   ~TGPack() override;
 
    virtual void AddFrameWithWeight(TGFrame *f, TGLayoutHints* l, Float_t w);
    void AddFrame(TGFrame *f, TGLayoutHints* l = nullptr) override;

--- a/gui/gui/inc/TGPicture.h
+++ b/gui/gui/inc/TGPicture.h
@@ -46,7 +46,7 @@ protected:
    void Draw(Option_t * = "") override { MayNotUse("Draw(Option_t*)"); }
 
 public:
-   virtual ~TGPicture();
+   ~TGPicture() override;
 
    const char *GetName() const override { return fName.Data(); }
    UInt_t      GetWidth() const { return fAttributes.fWidth; }
@@ -80,7 +80,7 @@ protected:
 
 public:
    TGSelectedPicture(const TGClient *client, const TGPicture *p);
-   virtual ~TGSelectedPicture();
+   ~TGSelectedPicture() override;
 
    ClassDefOverride(TGSelectedPicture,0)  // Selected looking picture
 };
@@ -99,7 +99,7 @@ protected:
 public:
    TGPicturePool(const TGClient *client, const char *path):
       fClient(client), fPath(path), fPicList(nullptr) { }
-   virtual ~TGPicturePool();
+   ~TGPicturePool() override;
 
    const char      *GetPath() const { return fPath; }
    const TGPicture *GetPicture(const char *name);

--- a/gui/gui/inc/TGProgressBar.h
+++ b/gui/gui/inc/TGProgressBar.h
@@ -40,7 +40,7 @@ protected:
    GContext_t    fNormGC;       ///< text drawing graphics context
    FontStruct_t  fFontStruct;   ///< font used to draw position text
 
-   virtual void DoRedraw() override = 0;
+   void DoRedraw() override = 0;
 
    static const TGFont *fgDefaultFont;
    static TGGC         *fgDefaultGC;
@@ -55,7 +55,7 @@ public:
                  GContext_t norm = GetDefaultGC()(),
                  FontStruct_t font = GetDefaultFontStruct(),
                  UInt_t options = kDoubleBorder | kSunkenFrame);
-   virtual ~TGProgressBar() { }
+   ~TGProgressBar() override { }
 
    Float_t      GetMin() const { return fMin; }
    Float_t      GetMax() const { return fMax; }
@@ -105,7 +105,7 @@ public:
                   FontStruct_t font = GetDefaultFontStruct(),
                   UInt_t options = kDoubleBorder | kSunkenFrame);
    TGHProgressBar(const TGWindow *p, EBarType type, UInt_t w);
-   virtual ~TGHProgressBar() { }
+   ~TGHProgressBar() override { }
 
    TGDimension GetDefaultSize() const override
                { return TGDimension(fWidth, fBarWidth); }
@@ -133,7 +133,7 @@ public:
                   FontStruct_t font = GetDefaultFontStruct(),
                   UInt_t options = kDoubleBorder | kSunkenFrame);
    TGVProgressBar(const TGWindow *p, EBarType type, UInt_t h);
-   virtual ~TGVProgressBar() { }
+   ~TGVProgressBar() override { }
 
    TGDimension GetDefaultSize() const override
                 { return TGDimension(fBarWidth, fHeight); }

--- a/gui/gui/inc/TGResourcePool.h
+++ b/gui/gui/inc/TGResourcePool.h
@@ -88,7 +88,7 @@ private:
 
 public:
    TGResourcePool(TGClient *client);
-   virtual ~TGResourcePool();
+   ~TGResourcePool() override;
 
    TGGCPool       *GetGCPool() const { return fGCPool; }
    TGFontPool     *GetFontPool() const { return fFontPool; }

--- a/gui/gui/inc/TGScrollBar.h
+++ b/gui/gui/inc/TGScrollBar.h
@@ -46,7 +46,7 @@ public:
                       UInt_t w = 1, UInt_t h = 1,
                       UInt_t options = kRaisedFrame | kDoubleBorder,
                       Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGScrollBarElement();
+   ~TGScrollBarElement() override;
 
    virtual void SetState(Int_t state);
    void DrawBorder() override;
@@ -96,7 +96,7 @@ public:
    TGScrollBar(const TGWindow *p = nullptr, UInt_t w = 1, UInt_t h = 1,
                UInt_t options = kChildFrame,
                Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGScrollBar();
+   ~TGScrollBar() override;
 
    void           GrabPointer(Bool_t grab) { fGrabPointer = grab; }
 
@@ -145,7 +145,7 @@ public:
    TGHScrollBar(const TGWindow *p = nullptr, UInt_t w = 4, UInt_t h = 2,
                 UInt_t options = kHorizontalFrame,
                 Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGHScrollBar() { }
+   ~TGHScrollBar() override { }
 
    Bool_t HandleButton(Event_t *event) override;
    Bool_t HandleMotion(Event_t *event) override;
@@ -168,7 +168,7 @@ public:
    TGVScrollBar(const TGWindow *p = nullptr, UInt_t w = 2, UInt_t h = 4,
                 UInt_t options = kVerticalFrame,
                 Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGVScrollBar() { }
+   ~TGVScrollBar() override { }
 
    Bool_t HandleButton(Event_t *event) override;
    Bool_t HandleMotion(Event_t *event) override;

--- a/gui/gui/inc/TGShapedFrame.h
+++ b/gui/gui/inc/TGShapedFrame.h
@@ -32,7 +32,7 @@ protected:
 
 public:
    TGShapedFrame(const char *fname = nullptr, const TGWindow *p = nullptr, UInt_t w = 1, UInt_t h = 1, UInt_t options = 0);
-   virtual ~TGShapedFrame();
+   ~TGShapedFrame() override;
 
    const TGPicture   GetPicture() const { return *fBgnd; }
    TImage            GetImage() const { return *fImage; }

--- a/gui/gui/inc/TGShutter.h
+++ b/gui/gui/inc/TGShutter.h
@@ -39,7 +39,7 @@ private:
 public:
    TGShutterItem(const TGWindow *p = nullptr, TGHotString *s = nullptr, Int_t id = -1,
                  UInt_t options = 0);
-   virtual ~TGShutterItem();
+   ~TGShutterItem() override;
 
    TGButton *GetButton() const { return fButton; }
    TGFrame  *GetContainer() const { return fCanvas->GetContainer(); }
@@ -71,7 +71,7 @@ private:
 
 public:
    TGShutter(const TGWindow *p = nullptr, UInt_t options = kSunkenFrame);
-   virtual ~TGShutter();
+   ~TGShutter() override;
 
    virtual void   AddItem(TGShutterItem *item);
    virtual void   RemoveItem(const char *name);

--- a/gui/gui/inc/TGSimpleTable.h
+++ b/gui/gui/inc/TGSimpleTable.h
@@ -18,7 +18,7 @@ class TGSimpleTable : public TGTable {
 public:
    TGSimpleTable(TGWindow *p, Int_t id, Double_t **data,
                  UInt_t nrows, UInt_t ncolumns);
-   virtual ~TGSimpleTable();
+   ~TGSimpleTable() override;
 
    ClassDefOverride(TGSimpleTable, 0) // A simple table that owns it's interface.
 };

--- a/gui/gui/inc/TGSimpleTableInterface.h
+++ b/gui/gui/inc/TGSimpleTableInterface.h
@@ -28,7 +28,7 @@ protected:
 public:
    TGSimpleTableInterface(Double_t **data, UInt_t nrows = 2,
                           UInt_t ncolumns = 2);
-   virtual ~TGSimpleTableInterface();
+   ~TGSimpleTableInterface() override;
 
    Double_t    GetValue(UInt_t row, UInt_t column) override;
    const char *GetValueAsString(UInt_t row, UInt_t column) override;

--- a/gui/gui/inc/TGSlider.h
+++ b/gui/gui/inc/TGSlider.h
@@ -63,7 +63,7 @@ public:
             UInt_t options = kChildFrame,
             Pixel_t back = GetDefaultFrameBackground());
 
-   virtual ~TGSlider() {}
+   ~TGSlider() override {}
 
    Bool_t HandleButton(Event_t *event) override = 0;
    Bool_t HandleConfigureNotify(Event_t* event) override = 0;
@@ -101,7 +101,7 @@ public:
              UInt_t type = kSlider1 | kScaleBoth, Int_t id = -1,
              UInt_t options = kVerticalFrame,
              Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGVSlider();
+   ~TGVSlider() override;
 
    Bool_t HandleButton(Event_t *event) override;
    Bool_t HandleConfigureNotify(Event_t* event) override;
@@ -128,7 +128,7 @@ public:
              UInt_t type = kSlider1 | kScaleBoth, Int_t id = -1,
              UInt_t options = kHorizontalFrame,
              Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGHSlider();
+   ~TGHSlider() override;
 
    Bool_t HandleButton(Event_t *event) override;
    Bool_t HandleConfigureNotify(Event_t* event) override;

--- a/gui/gui/inc/TGSpeedo.h
+++ b/gui/gui/inc/TGSpeedo.h
@@ -59,7 +59,7 @@ public:
    TGSpeedo(const TGWindow *p, Float_t smin, Float_t smax,
             const char *lbl1 = "", const char *lbl2 = "",
             const char *dsp1 = "", const char *dsp2 = "", int id = -1);
-   virtual ~TGSpeedo();
+   ~TGSpeedo() override;
 
    TGDimension          GetDefaultSize() const override;
    Bool_t               HandleButton(Event_t *event) override;

--- a/gui/gui/inc/TGSplitFrame.h
+++ b/gui/gui/inc/TGSplitFrame.h
@@ -34,7 +34,7 @@ public:
    // constructors
    TGRectMap(Int_t rx, Int_t ry, UInt_t rw, UInt_t rh):
              fX(rx), fY(ry), fW(rw), fH(rh) {}
-   virtual ~TGRectMap() {}
+   ~TGRectMap() override {}
 
    // methods
    Bool_t Contains(Int_t px, Int_t py) const
@@ -59,7 +59,7 @@ private:
 
 public:
    TGSplitTool(const TGWindow *p = nullptr, const TGFrame *f = nullptr);
-   virtual ~TGSplitTool();
+   ~TGSplitTool() override;
 
    void   AddRectangle(TGFrame *frm, Int_t x, Int_t y, Int_t w, Int_t h);
    void   DoRedraw() override;
@@ -93,7 +93,7 @@ protected:
 public:
    TGSplitFrame(const TGWindow *p = nullptr, UInt_t w = 1, UInt_t h = 1,
                 UInt_t options = 0);
-   virtual ~TGSplitFrame();
+   ~TGSplitFrame() override;
 
    void           AddFrame(TGFrame *f, TGLayoutHints *l = nullptr) override;
    void           Cleanup() override;

--- a/gui/gui/inc/TGSplitter.h
+++ b/gui/gui/inc/TGSplitter.h
@@ -32,13 +32,13 @@ public:
    TGSplitter(const TGWindow *p = nullptr, UInt_t w = 2, UInt_t h = 4,
               UInt_t options = kChildFrame,
               Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGSplitter() { }
+   ~TGSplitter() override { }
 
    virtual void   SetFrame(TGFrame *frame, Bool_t prev) = 0;
 
-   virtual Bool_t HandleButton(Event_t *event) override = 0;
-   virtual Bool_t HandleMotion(Event_t *event) override = 0;
-   virtual Bool_t HandleCrossing(Event_t *event) override = 0;
+   Bool_t HandleButton(Event_t *event) override = 0;
+   Bool_t HandleMotion(Event_t *event) override = 0;
+   Bool_t HandleCrossing(Event_t *event) override = 0;
 
    void DragStarted();      // *SIGNAL*
    void Moved(Int_t delta); // *SIGNAL*
@@ -70,7 +70,7 @@ public:
                UInt_t options = kChildFrame,
                Pixel_t back = GetDefaultFrameBackground());
    TGVSplitter(const TGWindow *p, UInt_t w, UInt_t h, Bool_t external);
-   virtual ~TGVSplitter();
+   ~TGVSplitter() override;
 
    void           DrawBorder() override;
    void           SetFrame(TGFrame *frame, Bool_t left) override;
@@ -107,7 +107,7 @@ public:
                UInt_t options = kChildFrame,
                Pixel_t back = GetDefaultFrameBackground());
    TGHSplitter(const TGWindow *p, UInt_t w, UInt_t h, Bool_t external);
-   virtual ~TGHSplitter();
+   ~TGHSplitter() override;
 
    void           DrawBorder() override;
    void           SetFrame(TGFrame *frame, Bool_t above) override;
@@ -133,7 +133,7 @@ public:
    TGVFileSplitter(const TGWindow *p = nullptr, UInt_t w = 4, UInt_t h = 4,
                UInt_t options = kChildFrame,
                Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGVFileSplitter();
+   ~TGVFileSplitter() override;
 
    Bool_t HandleDoubleClick(Event_t *) override;
    Bool_t HandleButton(Event_t *event) override;

--- a/gui/gui/inc/TGStatusBar.h
+++ b/gui/gui/inc/TGStatusBar.h
@@ -46,7 +46,7 @@ public:
    TGStatusBar(const TGWindow *p = nullptr, UInt_t w = 4, UInt_t h = 2,
                UInt_t options = kSunkenFrame | kHorizontalFrame,
                Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGStatusBar();
+   ~TGStatusBar() override;
 
    void         DrawBorder() override;
    virtual void SetText(TGString *text, Int_t partidx = 0);

--- a/gui/gui/inc/TGString.h
+++ b/gui/gui/inc/TGString.h
@@ -24,7 +24,7 @@ public:
    TGString(const char *s) : TString(s) { }
    TGString(Int_t number) : TString() { *this += number; }
    TGString(const TGString *s);
-   virtual ~TGString() {}
+   ~TGString() override {}
 
    Int_t GetLength() const { return Length(); }
    const char  *GetString() const { return Data(); }

--- a/gui/gui/inc/TGTab.h
+++ b/gui/gui/inc/TGTab.h
@@ -72,7 +72,7 @@ public:
          FontStruct_t font = GetDefaultFontStruct(),
          UInt_t options = kChildFrame,
          Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGTab();
+   ~TGTab() override;
 
    virtual TGCompositeFrame *AddTab(TGString *text);
    virtual TGCompositeFrame *AddTab(const char *text);
@@ -138,7 +138,7 @@ public:
                 FontStruct_t font = TGTab::GetDefaultFontStruct(),
                 UInt_t options = kRaisedFrame,
                 Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGTabElement();
+   ~TGTabElement() override;
 
    void             DrawBorder() override;
    TGDimension      GetDefaultSize() const override;

--- a/gui/gui/inc/TGTable.h
+++ b/gui/gui/inc/TGTable.h
@@ -126,7 +126,7 @@ public:
    TGTable(const TGWindow *p = nullptr, Int_t id = 0,
            TVirtualTableInterface *interface = nullptr, UInt_t nrows = 50,
            UInt_t ncolumns = 20);
-   virtual ~TGTable();
+   ~TGTable() override;
 
    virtual TObjArray *GetRow(UInt_t row);
    virtual TObjArray *GetColumn(UInt_t columns);

--- a/gui/gui/inc/TGTableCell.h
+++ b/gui/gui/inc/TGTableCell.h
@@ -69,7 +69,7 @@ public:
                FontStruct_t font = GetDefaultFontStruct(),
                UInt_t option = 0, Bool_t resize =  kTRUE);
 
-   virtual ~TGTableCell();
+   ~TGTableCell() override;
 
            void DrawCopy(Handle_t id, Int_t x, Int_t y) override;
 

--- a/gui/gui/inc/TGTableContainer.h
+++ b/gui/gui/inc/TGTableContainer.h
@@ -22,7 +22,7 @@ protected:
 
 public:
    TGTableFrame(const TGWindow *p, UInt_t nrows, UInt_t ncolumns);
-   virtual ~TGTableFrame() { delete fFrame; }
+   ~TGTableFrame() override { delete fFrame; }
 
    TGFrame *GetFrame() const { return fFrame; }
 
@@ -44,7 +44,7 @@ public:
    TGTableHeaderFrame(const TGWindow *p, TGTable *table = nullptr, UInt_t w = 1,
                       UInt_t h = 1, EHeaderType type = kColumnHeader,
                       UInt_t option = 0);
-   ~TGTableHeaderFrame() {}
+   ~TGTableHeaderFrame() override {}
 
    virtual void DrawRegion(Int_t x, Int_t y, UInt_t w, UInt_t h);
 

--- a/gui/gui/inc/TGTableHeader.h
+++ b/gui/gui/inc/TGTableHeader.h
@@ -46,7 +46,7 @@ public:
                  GContext_t norm = GetDefaultGC()(),
                  FontStruct_t font = GetDefaultFontStruct(),
                  UInt_t option = 0);
-   virtual ~TGTableHeader();
+   ~TGTableHeader() override;
 
    void SetWidth(UInt_t width) override;
    void SetHeight(UInt_t height) override;

--- a/gui/gui/inc/TGTableLayout.h
+++ b/gui/gui/inc/TGTableLayout.h
@@ -46,7 +46,7 @@ public:
          fAttachRight(attach_right),
          fAttachTop(attach_top),
          fAttachBottom(attach_bottom) { }
-   virtual ~TGTableLayoutHints() { }
+   ~TGTableLayoutHints() override { }
 
    UInt_t GetAttachLeft() const { return fAttachLeft; }
    UInt_t GetAttachRight() const { return fAttachRight; }
@@ -103,7 +103,7 @@ public:
 
    TGTableLayout(TGCompositeFrame *main, UInt_t nrows, UInt_t ncols,
                  Bool_t homogeneous = kFALSE, Int_t sep = 0, Int_t hints = 0);
-   virtual ~TGTableLayout();
+   ~TGTableLayout() override;
 
    void Layout() override;
    TGDimension GetDefaultSize() const override; // return sum of all child sizes

--- a/gui/gui/inc/TGTextEdit.h
+++ b/gui/gui/inc/TGTextEdit.h
@@ -70,7 +70,7 @@ public:
    TGTextEdit(const TGWindow *parent, UInt_t w, UInt_t h, const char *string,
               Int_t id = -1, UInt_t sboptions = 0, Pixel_t back = GetWhitePixel());
 
-   virtual ~TGTextEdit();
+   ~TGTextEdit() override;
 
    virtual Bool_t SaveFile(const char *fname, Bool_t saveas = kFALSE);
            void   Clear(Option_t * = "") override;

--- a/gui/gui/inc/TGTextEditDialogs.h
+++ b/gui/gui/inc/TGTextEditDialogs.h
@@ -60,7 +60,7 @@ public:
    TGSearchDialog(const TGWindow *p = nullptr, const TGWindow *main = nullptr, UInt_t w = 1, UInt_t h = 1,
                   TGSearchType *sstruct = nullptr, Int_t *ret_code = nullptr,
                   UInt_t options = kVerticalFrame);
-   virtual ~TGSearchDialog();
+   ~TGSearchDialog() override;
 
    void   CloseWindow() override;
    Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
@@ -96,7 +96,7 @@ public:
    TGPrintDialog(const TGWindow *p = nullptr, const TGWindow *main = nullptr, UInt_t w = 1, UInt_t h = 1,
                  char **printerName = nullptr, char **printProg = nullptr, Int_t *ret_code = nullptr,
                  UInt_t options = kVerticalFrame);
-   virtual ~TGPrintDialog();
+   ~TGPrintDialog() override;
 
    void   CloseWindow() override;
    virtual void   GetPrinters();
@@ -121,7 +121,7 @@ protected:
 public:
    TGGotoDialog(const TGWindow *p = nullptr, const TGWindow *main = nullptr, UInt_t w = 1, UInt_t h = 1,
                 Long_t *ret_code = nullptr, UInt_t options = kVerticalFrame);
-   virtual ~TGGotoDialog();
+   ~TGGotoDialog() override;
 
    void   CloseWindow() override;
    Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;

--- a/gui/gui/inc/TGTextEditor.h
+++ b/gui/gui/inc/TGTextEditor.h
@@ -61,7 +61,7 @@ public:
                 UInt_t w = 900, UInt_t h = 600);
    TGTextEditor(TMacro *macro, const TGWindow *p = nullptr, UInt_t w = 0,
                 UInt_t h = 0);
-   virtual ~TGTextEditor();
+   ~TGTextEditor() override;
 
    void           ClearText();
    Bool_t         LoadBuffer(const char *buf) { return fTextEdit->LoadBuffer(buf); }

--- a/gui/gui/inc/TGTextEntry.h
+++ b/gui/gui/inc/TGTextEntry.h
@@ -91,7 +91,7 @@ public:
    TGTextEntry(const TGWindow *parent = nullptr, const char *text = nullptr, Int_t id = -1);
    TGTextEntry(const TString &contents, const TGWindow *parent, Int_t id = -1);
 
-   virtual ~TGTextEntry();
+   ~TGTextEntry() override;
 
             TGDimension GetDefaultSize() const override;
    virtual  void        SetDefaultSize(UInt_t w, UInt_t h);

--- a/gui/gui/inc/TGTextView.h
+++ b/gui/gui/inc/TGTextView.h
@@ -72,7 +72,7 @@ public:
    TGTextView(const TGWindow *parent, UInt_t w, UInt_t h, const char *string,
               Int_t id = -1, UInt_t sboptions = 0, Pixel_t back = GetWhitePixel());
 
-   virtual ~TGTextView();
+   ~TGTextView() override;
 
    virtual Bool_t IsSaved() { fIsSaved = fText->IsSaved(); return fIsSaved;}
    virtual Long_t ToObjXCoord(Long_t xCoord, Long_t line);

--- a/gui/gui/inc/TGTextViewStream.h
+++ b/gui/gui/inc/TGTextViewStream.h
@@ -34,7 +34,7 @@ protected:
 
 public:
    TGTextViewStreamBuf(TGTextView *textview);
-   virtual ~TGTextViewStreamBuf() {}
+   ~TGTextViewStreamBuf() override {}
 
    ClassDef(TGTextViewStreamBuf, 0) // Specialization of std::streambuf
 };
@@ -54,7 +54,7 @@ public:
    TGTextViewostream(const TGWindow *parent, UInt_t w, UInt_t h,
                      const char *string, Int_t id, UInt_t sboptions,
                      ULong_t back);
-   virtual ~TGTextViewostream() {}
+   ~TGTextViewostream() override {}
 
    ClassDefOverride(TGTextViewostream, 0) // Specialization of TGTextView and std::ostream
 };

--- a/gui/gui/inc/TGToolBar.h
+++ b/gui/gui/inc/TGToolBar.h
@@ -45,7 +45,7 @@ public:
    TGToolBar(const TGWindow *p = nullptr, UInt_t w = 1, UInt_t h = 1,
              UInt_t options = kHorizontalFrame,
              Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGToolBar();
+   ~TGToolBar() override;
 
    virtual TGButton *AddButton(const TGWindow *w, ToolBarData_t *button, Int_t spacing = 0);
    virtual TGButton *AddButton(const TGWindow *w, TGPictureButton *button, Int_t spacing = 0);

--- a/gui/gui/inc/TGToolTip.h
+++ b/gui/gui/inc/TGToolTip.h
@@ -41,7 +41,7 @@ public:
    TGToolTip(const TGWindow *p, const TBox *b, const char *text, Long_t delayms);
    TGToolTip(const TBox *b, const char *text, Long_t delayms);
    TGToolTip(Int_t x, Int_t y, const char *text, Long_t delayms);
-   virtual ~TGToolTip();
+   ~TGToolTip() override;
 
    void DrawBorder() override;
 

--- a/gui/gui/inc/TGTripleSlider.h
+++ b/gui/gui/inc/TGTripleSlider.h
@@ -38,7 +38,7 @@ public:
                    Bool_t constrained = kTRUE,
                    Bool_t relative = kFALSE);
 
-   virtual ~TGTripleVSlider();
+   ~TGTripleVSlider() override;
 
    virtual void      PointerPositionChanged() { Emit("PointerPositionChanged()"); } //*SIGNAL*
    virtual void      DrawPointer();
@@ -91,7 +91,7 @@ public:
                    Bool_t constrained = kTRUE,
                    Bool_t relative = kFALSE);
 
-   virtual ~TGTripleHSlider();
+   ~TGTripleHSlider() override;
 
    virtual void      PointerPositionChanged() { Emit("PointerPositionChanged()"); } //*SIGNAL*
    virtual void      DrawPointer();

--- a/gui/gui/inc/TGView.h
+++ b/gui/gui/inc/TGView.h
@@ -61,7 +61,7 @@ public:
           UInt_t sboptions = 0,
           Pixel_t back = GetWhitePixel());
 
-   virtual ~TGView();
+   ~TGView() override;
 
    TGViewFrame   *GetCanvas() const { return fCanvas; }
 

--- a/gui/gui/inc/TGWindow.h
+++ b/gui/gui/inc/TGWindow.h
@@ -78,7 +78,7 @@ public:
             UInt_t wtype = 0);
    TGWindow(TGClient *c, Window_t id, const TGWindow *parent = nullptr);
 
-   virtual ~TGWindow();
+   ~TGWindow() override;
 
    const TGWindow *GetParent() const { return fParent; }
    virtual const TGWindow *GetMainFrame() const;
@@ -142,7 +142,7 @@ class TGUnknownWindowHandler : public TObject {
 
 public:
    TGUnknownWindowHandler() {}
-   virtual ~TGUnknownWindowHandler() {}
+   ~TGUnknownWindowHandler() override {}
 
    virtual Bool_t HandleEvent(Event_t *) = 0;
 

--- a/gui/gui/inc/TGuiBuilder.h
+++ b/gui/gui/inc/TGuiBuilder.h
@@ -33,7 +33,7 @@ public:
 
    TGuiBldAction(const char *name = nullptr, const char *title = nullptr,
                  Int_t type = kGuiBldCtor, TGLayoutHints *hints = nullptr);
-   virtual ~TGuiBldAction();
+   ~TGuiBldAction() override;
 
    ClassDefOverride(TGuiBldAction,0)  // gui builder action
 };

--- a/gui/gui/inc/TRootApplication.h
+++ b/gui/gui/inc/TRootApplication.h
@@ -31,7 +31,7 @@ private:
 
 public:
    TRootApplication(const char *appClassName, Int_t *argc, char **argv);
-   virtual ~TRootApplication();
+   ~TRootApplication() override;
 
    TGClient *Client() const { return fClient; }
 

--- a/gui/gui/inc/TRootBrowser.h
+++ b/gui/gui/inc/TRootBrowser.h
@@ -42,7 +42,7 @@ public:
    TBrowserPlugin(const char *name, const char *cmd = "", Int_t tab = 1,
                   Int_t sub = -1) : TNamed(name, cmd), fTab(tab),
       fSubTab(sub), fCommand(cmd) { }
-   virtual ~TBrowserPlugin() {}
+   ~TBrowserPlugin() override {}
 
    void     SetTab(Int_t tab) { fTab = tab; }
    void     SetSubTab(Int_t sub) { fSubTab = sub; }
@@ -123,7 +123,7 @@ public:
 
    TRootBrowser(TBrowser *b = nullptr, const char *name = "ROOT Browser", UInt_t width = 800, UInt_t height = 500, Option_t *opt = "", Bool_t initshow = kTRUE);
    TRootBrowser(TBrowser *b, const char *name, Int_t x, Int_t y, UInt_t width, UInt_t height, Option_t *opt = "", Bool_t initshow = kTRUE);
-   virtual ~TRootBrowser();
+   ~TRootBrowser() override;
 
    void              InitPlugins(Option_t *opt="");
 

--- a/gui/gui/inc/TRootBrowserLite.h
+++ b/gui/gui/inc/TRootBrowserLite.h
@@ -114,7 +114,7 @@ protected:
 public:
    TRootBrowserLite(TBrowser *b = nullptr, const char *title = "ROOT Browser", UInt_t width = 800, UInt_t height = 500);
    TRootBrowserLite(TBrowser *b, const char *title, Int_t x, Int_t y, UInt_t width, UInt_t height);
-   virtual ~TRootBrowserLite();
+   ~TRootBrowserLite() override;
 
    void         Add(TObject *obj, const char *name = nullptr, Int_t check = -1) override;
    virtual void AddToBox(TObject *obj, const char *name);

--- a/gui/gui/inc/TRootCanvas.h
+++ b/gui/gui/inc/TRootCanvas.h
@@ -102,7 +102,7 @@ private:
 public:
    TRootCanvas(TCanvas *c = nullptr, const char *name = "ROOT Canvas", UInt_t width = 500, UInt_t height = 300);
    TRootCanvas(TCanvas *c, const char *name, Int_t x, Int_t y, UInt_t width, UInt_t height);
-   virtual ~TRootCanvas();
+   ~TRootCanvas() override;
 
    void     AdjustSize();
    void     Close() override;

--- a/gui/gui/inc/TRootContextMenu.h
+++ b/gui/gui/inc/TRootContextMenu.h
@@ -31,7 +31,7 @@ private:
 
 public:
    TRootContextMenu(TContextMenu *c = nullptr, const char *name = "ROOT Context Menu");
-   virtual ~TRootContextMenu();
+   ~TRootContextMenu() override;
 
    void   DisplayPopup(Int_t x, Int_t y) override;
    void   Dialog(TObject *object, TMethod *method) override;

--- a/gui/gui/inc/TRootControlBar.h
+++ b/gui/gui/inc/TRootControlBar.h
@@ -30,7 +30,7 @@ private:
 public:
    TRootControlBar(TControlBar *c = nullptr, const char *title = "ROOT Control Bar",
                    Int_t x = -999, Int_t y = -999);
-   virtual ~TRootControlBar();
+   ~TRootControlBar() override;
 
    void Create() override;
    void Hide() override;

--- a/gui/gui/inc/TRootDialog.h
+++ b/gui/gui/inc/TRootDialog.h
@@ -35,7 +35,7 @@ public:
                const char *title = "ROOT Dialog", Bool_t okB = kTRUE,
                Bool_t cancelB = kTRUE, Bool_t applyB = kFALSE,
                Bool_t helpB = kTRUE);
-   virtual ~TRootDialog();
+   ~TRootDialog() override;
 
    virtual void Add(const char *argname, const char *value, const char *type);
    //virtual void Add(TGComboBox *optionSel);

--- a/gui/gui/inc/TRootEmbeddedCanvas.h
+++ b/gui/gui/inc/TRootEmbeddedCanvas.h
@@ -49,7 +49,7 @@ public:
    TRootEmbeddedCanvas(const char *name = nullptr, const TGWindow *p = nullptr, UInt_t w = 10,
             UInt_t h = 10, UInt_t options = kSunkenFrame | kDoubleBorder,
             Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TRootEmbeddedCanvas();
+   ~TRootEmbeddedCanvas() override;
 
    void       AdoptCanvas(TCanvas *c);
    TCanvas   *GetCanvas() const { return fCanvas; }

--- a/gui/gui/inc/TRootGuiFactory.h
+++ b/gui/gui/inc/TRootGuiFactory.h
@@ -28,7 +28,7 @@ class TRootGuiFactory : public TGuiFactory {
 
 public:
    TRootGuiFactory(const char *name = "Root", const char *title = "ROOT GUI Factory");
-   virtual ~TRootGuiFactory() {}
+   ~TRootGuiFactory() override {}
 
    TApplicationImp *CreateApplicationImp(const char *classname, int *argc, char **argv) override;
 

--- a/gui/gui/inc/TRootHelpDialog.h
+++ b/gui/gui/inc/TRootHelpDialog.h
@@ -34,7 +34,7 @@ private:
 public:
    TRootHelpDialog(const TGWindow *main = nullptr, const char *title = "ROOT Help Dialog",
                    UInt_t w = 1, UInt_t h = 1);
-   virtual ~TRootHelpDialog();
+   ~TRootHelpDialog() override;
 
    void   SetText(const char *helpText);
    void   AddText(const char *helpText);

--- a/gui/gui/src/TGImageMap.cxx
+++ b/gui/gui/src/TGImageMap.cxx
@@ -53,7 +53,7 @@ private:
 
 public:
    TGRegionData() { fRgn = 0; fIsNull = kTRUE; AddReference(); }
-   ~TGRegionData() { }
+   ~TGRegionData() override { }
    TGRegionData &operator=(const TGRegionData &r);
 };
 

--- a/gui/gui/src/TGListBox.cxx
+++ b/gui/gui/src/TGListBox.cxx
@@ -455,7 +455,7 @@ void TGIconLBEntry::SetPicture(const TGPicture *pic)
 class TGLBFrameElement : public TGFrameElement {
 public:
    TGLBFrameElement(TGFrame *f, TGLayoutHints *l) : TGFrameElement(f, l) {}
-   virtual ~TGLBFrameElement() {}
+   ~TGLBFrameElement() override {}
 
    Bool_t IsSortable() const override { return kTRUE; }
    Int_t  Compare(const TObject *obj) const override

--- a/gui/gui/src/TGNumberEntry.cxx
+++ b/gui/gui/src/TGNumberEntry.cxx
@@ -1842,7 +1842,7 @@ public:
     : TGPictureButton(p, pic, id), fTimer(0), fIgnoreNextFire(0),
        fStep(TGNumberFormat::kNSSSmall), fStepLog(logstep), fDoLogStep(logstep)
        { fEditDisabled = kEditDisable | kEditDisableGrab; }
-   virtual ~TGRepeatFireButton() { delete fTimer; }
+   ~TGRepeatFireButton() override { delete fTimer; }
 
    Bool_t HandleButton(Event_t *event) override;
    void   FireButton();

--- a/gui/gui/src/TGStatusBar.cxx
+++ b/gui/gui/src/TGStatusBar.cxx
@@ -49,7 +49,7 @@ private:
 
 public:
    TGStatusBarPart(const TGWindow *p, Int_t h, Int_t y, ULong_t back = GetDefaultFrameBackground());
-   ~TGStatusBarPart() { delete fStatusInfo; DestroyWindow(); }
+   ~TGStatusBarPart() override { delete fStatusInfo; DestroyWindow(); }
    void SetText(TGString *text);
    const TGString *GetText() const { return fStatusInfo; }
 };

--- a/gui/gui/src/TGTextEdit.cxx
+++ b/gui/gui/src/TGTextEdit.cxx
@@ -63,7 +63,7 @@ class TGTextEditHist : public TList {
 
 public:
    TGTextEditHist() {}
-   virtual ~TGTextEditHist() { Delete(); }
+   ~TGTextEditHist() override { Delete(); }
 
    Bool_t Notify() override
    { //
@@ -197,7 +197,7 @@ public:
       fText = new TGText(dtc.fText);
       fBreakLine = dtc.fBreakLine;
    }
-   virtual ~TDelTextCom() { delete fText; }
+   ~TDelTextCom() override { delete fText; }
 
    TDelTextCom &operator=(const TDelTextCom &dtc) {
       if (this != &dtc) {

--- a/gui/gui/src/TRootBrowserLite.cxx
+++ b/gui/gui/src/TRootBrowserLite.cxx
@@ -339,7 +339,7 @@ private:
 
 public:
    TRootIconList(TRootIconBox* box = nullptr);
-   virtual ~TRootIconList();
+   ~TRootIconList() override;
    void              UpdateName();
    const char       *GetTitle() const  override{ return "ListView Container"; }
    Bool_t            IsFolder() const override { return kFALSE; }
@@ -418,7 +418,7 @@ public:
                 UInt_t options = kSunkenFrame,
                 ULong_t back = GetDefaultFrameBackground());
 
-   virtual ~TRootIconBox();
+   ~TRootIconBox() override;
 
    void   AddObjItem(const char *name, TObject *obj, TClass *cl);
    void   GetObjPictures(const TGPicture **pic, const TGPicture **spic,

--- a/gui/guibuilder/inc/TGuiBldDragManager.h
+++ b/gui/guibuilder/inc/TGuiBldDragManager.h
@@ -159,14 +159,14 @@ private:
    void           CheckTargetUnderGrab();
    void           HighlightCompositeFrame(Window_t);
    void           Compact(Bool_t global = kTRUE);
-   Bool_t         StartDrag(TGFrame *src, Int_t x, Int_t y);
-   Bool_t         EndDrag();
-   Bool_t         Drop();
-   Bool_t         Cancel(Bool_t delSrc);
+   Bool_t         StartDrag(TGFrame *src, Int_t x, Int_t y) override;
+   Bool_t         EndDrag() override;
+   Bool_t         Drop() override;
+   Bool_t         Cancel(Bool_t delSrc) override;
    void           Menu4Frame(TGFrame *, Int_t x, Int_t y);
    void           Menu4Lasso(Int_t x, Int_t y);
    void           CreatePropertyEditor();
-   void           DoRedraw();
+   void           DoRedraw() override;
    void           SwitchEditable(TGFrame *frame);
    void           UnmapAllPopups();
    void           BreakLayout();
@@ -175,33 +175,33 @@ private:
    Bool_t         RecognizeGesture(Event_t *, TGFrame *frame = nullptr);
    Bool_t         HandleButtonPress(Event_t *);
    Bool_t         HandleButtonRelease(Event_t *);
-   Bool_t         HandleButton(Event_t *);
-   Bool_t         HandleDoubleClick(Event_t*);
-   Bool_t         HandleMotion(Event_t *);
-   Bool_t         HandleClientMessage(Event_t *);
+   Bool_t         HandleButton(Event_t *) override;
+   Bool_t         HandleDoubleClick(Event_t*) override;
+   Bool_t         HandleMotion(Event_t *) override;
+   Bool_t         HandleClientMessage(Event_t *) override;
    Bool_t         HandleDestroyNotify(Event_t *);
-   Bool_t         HandleSelection(Event_t *);
-   Bool_t         HandleExpose(Event_t *);
-   Bool_t         HandleConfigureNotify(Event_t *);
-   Bool_t         HandleSelectionRequest(Event_t *);
+   Bool_t         HandleSelection(Event_t *) override;
+   Bool_t         HandleExpose(Event_t *) override;
+   Bool_t         HandleConfigureNotify(Event_t *) override;
+   Bool_t         HandleSelectionRequest(Event_t *) override;
    void           HandleButon3Pressed(Event_t *, TGFrame *frame = nullptr);
-   Bool_t         HandleEvent(Event_t *);
-   Bool_t         HandleTimer(TTimer *);
+   Bool_t         HandleEvent(Event_t *) override;
+   Bool_t         HandleTimer(TTimer *) override;
 
    Bool_t         IsMoveWaiting() const;
    Bool_t         IsLassoDrawn() const { return fLassoDrawn; }
    void           SetLassoDrawn(Bool_t on);
    void           HideGrabRectangles();
-   Bool_t         IgnoreEvent(Event_t *e);
+   Bool_t         IgnoreEvent(Event_t *e) override;
    Bool_t         CheckDragResize(Event_t *event);
    Bool_t         IsPasteFrameExist();
 
 public:
    TGuiBldDragManager();
-   virtual        ~TGuiBldDragManager();
+          ~TGuiBldDragManager() override;
 
    void           HandleAction(Int_t act);
-   Bool_t         HandleKey(Event_t *);
+   Bool_t         HandleKey(Event_t *) override;
 
    TGFrame       *GetTarget() const { return fTarget; }
    TGFrame       *GetSelected() const;
@@ -209,21 +209,21 @@ public:
    void           SetGridStep(UInt_t step);
    UInt_t         GetGridStep();
    void           HandleUpdateSelected(TGFrame *);
-   Int_t          GetStrartDragX() const;
-   Int_t          GetStrartDragY() const;
-   Int_t          GetEndDragX() const;
-   Int_t          GetEndDragY() const;
+   Int_t          GetStrartDragX() const override;
+   Int_t          GetStrartDragY() const override;
+   Int_t          GetEndDragX() const override;
+   Int_t          GetEndDragY() const override;
 
    Bool_t         GetDropStatus() const { return fDropStatus; }
    void           SetBuilder(TRootGuiBuilder *b) { fBuilder = b; }
 
    Bool_t         IsStopped() const { return fStop; }
-   void           SetEditable(Bool_t on = kTRUE);
+   void           SetEditable(Bool_t on = kTRUE) override;
    void           SelectFrame(TGFrame *frame, Bool_t add = kFALSE);
 
    static void    MapGlobalDialog(TGMainFrame *dialog, TGFrame *fr);
 
-   Bool_t         HandleTimerEvent(Event_t *ev, TTimer *t);
+   Bool_t         HandleTimerEvent(Event_t *ev, TTimer *t) override;
    void           TimerEvent(Event_t *ev)
                      { Emit("TimerEvent(Event_t*)", (Longptr_t)ev); } // *SIGNAL*
 
@@ -256,7 +256,7 @@ public:
    void ChangeBackgroundColor(TGFrame *);             //*MENU* *DIALOG*icon=bld_colorselect.png*
    void ChangeBackgroundColor(TGCompositeFrame *);    //*MENU* *DIALOG*icon=bld_colorselect.png*
 
-   ClassDef(TGuiBldDragManager,0)  // drag and drop manager
+   ClassDefOverride(TGuiBldDragManager,0)  // drag and drop manager
 };
 
 

--- a/gui/guibuilder/inc/TGuiBldEditor.h
+++ b/gui/guibuilder/inc/TGuiBldEditor.h
@@ -52,7 +52,7 @@ private:
 
 public:
    TGuiBldEditor(const TGWindow *p = nullptr);
-   virtual ~TGuiBldEditor();
+   ~TGuiBldEditor() override;
 
    Int_t    GetXPos() const { return fXpos->GetIntNumber(); }
    Int_t    GetYPos() const { return fYpos->GetIntNumber(); }
@@ -69,13 +69,13 @@ public:
    void     Reset();
    TGuiBldHintsEditor *GetHintsEditor() const { return fHintsFrame; }
 
-   void     RemoveFrame(TGFrame *);
+   void     RemoveFrame(TGFrame *) override;
    void     TabSelected(Int_t id);
    void     UpdateSelected(TGFrame* = nullptr); //*SIGNAL*
    void     ChangeSelected(TGFrame*);     //*SIGNAL*
    void     SwitchLayout();
 
-   ClassDef(TGuiBldEditor,0)  // frame property editor
+   ClassDefOverride(TGuiBldEditor,0)  // frame property editor
 };
 
 #endif

--- a/gui/guibuilder/inc/TGuiBldGeometryFrame.h
+++ b/gui/guibuilder/inc/TGuiBldGeometryFrame.h
@@ -38,12 +38,12 @@ private:
 
 public:
    TGuiBldGeometryFrame(const TGWindow *p, TGuiBldEditor *editor);
-   virtual ~TGuiBldGeometryFrame() { }
+   ~TGuiBldGeometryFrame() override { }
 
    void ResizeSelected();
    void ChangeSelected(TGFrame *frame);
 
-   ClassDef(TGuiBldGeometryFrame, 0) // frame geometry editor
+   ClassDefOverride(TGuiBldGeometryFrame, 0) // frame geometry editor
 };
 
 #endif

--- a/gui/guibuilder/inc/TGuiBldHintsButton.h
+++ b/gui/guibuilder/inc/TGuiBldHintsButton.h
@@ -29,13 +29,13 @@ protected:
    virtual void DrawBottomLeft();
    virtual void DrawBottomRight();
 
-   virtual void DoRedraw();
+   void DoRedraw() override;
 
 public:
    TGuiBldHintsButton(const TGWindow *p, Int_t id);
-   virtual ~TGuiBldHintsButton() {}
+   ~TGuiBldHintsButton() override {}
 
-   ClassDef(TGuiBldHintsButton,0) //Button for editing layout hints in GUI Builder
+   ClassDefOverride(TGuiBldHintsButton,0) //Button for editing layout hints in GUI Builder
 };
 
 #endif

--- a/gui/guibuilder/inc/TGuiBldHintsEditor.h
+++ b/gui/guibuilder/inc/TGuiBldHintsEditor.h
@@ -57,7 +57,7 @@ public:
 
 public:
    TGuiBldHintsEditor(const TGWindow *p, TGuiBldEditor *e);
-   virtual ~TGuiBldHintsEditor() {}
+   ~TGuiBldHintsEditor() override {}
 
    void     ChangeSelected(TGFrame *);
    void     LayoutSubframes(Bool_t on = kTRUE);
@@ -65,7 +65,7 @@ public:
    void     SetPosition();
    void     UpdateState();
 
-   ClassDef(TGuiBldHintsEditor,0) // layout hints editor
+   ClassDefOverride(TGuiBldHintsEditor,0) // layout hints editor
 };
 
 #endif

--- a/gui/guibuilder/inc/TGuiBldNameFrame.h
+++ b/gui/guibuilder/inc/TGuiBldNameFrame.h
@@ -41,23 +41,23 @@ private:
    TGCanvas             *fCanvas;
 
 protected:
-   void DoRedraw();
+   void DoRedraw() override;
 
 public:
    TGuiBldNameFrame(const TGWindow *p, TGuiBldEditor *editor);
-   virtual ~TGuiBldNameFrame() { }
+   ~TGuiBldNameFrame() override { }
 
    void              ChangeSelected(TGFrame *frame);
    Bool_t            CheckItems(TGCompositeFrame *main);
    TGListTreeItem   *FindItemByName(TGListTree *tree, const char* name, TGListTreeItem *item = nullptr);
    TGCompositeFrame *GetMdi(TGFrame *frame);
    void              MapItems(TGCompositeFrame *main);
-   void              RemoveFrame(TGFrame *frame);
+   void              RemoveFrame(TGFrame *frame) override;
    void              Reset();
    void              SelectFrameByItem(TGListTreeItem* item, Int_t i = 0);
    void              UpdateName();
 
-   ClassDef(TGuiBldNameFrame, 0) // frame name editor
+   ClassDefOverride(TGuiBldNameFrame, 0) // frame name editor
 };
 
 

--- a/gui/guibuilder/inc/TRootGuiBuilder.h
+++ b/gui/guibuilder/inc/TRootGuiBuilder.h
@@ -94,15 +94,15 @@ private:
 
 public:
    TRootGuiBuilder(const TGWindow *p = nullptr);
-   virtual ~TRootGuiBuilder();
+   ~TRootGuiBuilder() override;
 
-   virtual void      AddAction(TGuiBldAction *act, const char *sect);
+   void      AddAction(TGuiBldAction *act, const char *sect) override;
    virtual void      AddMacro(const char *macro, TImage *img);
-   virtual void      AddSection(const char *sect);
-   virtual TGFrame  *ExecuteAction();
+   void      AddSection(const char *sect) override;
+   TGFrame  *ExecuteAction() override;
    virtual void      HandleButtons();
-   virtual void      Show() { MapRaised(); }
-   virtual void      Hide();
+   void      Show() override { MapRaised(); }
+   void      Hide() override;
    virtual void      ChangeSelected(TGFrame *f);
    virtual void      Update();
    virtual Bool_t    IsSelectMode() const;
@@ -110,9 +110,9 @@ public:
    virtual Bool_t    OpenProject(Event_t *event = nullptr);
    virtual Bool_t    SaveProject(Event_t *event = nullptr);
    virtual Bool_t    NewProject(TString type = "");
-   virtual Bool_t    HandleKey(Event_t *event);
+   Bool_t    HandleKey(Event_t *event) override;
    virtual void      HandleMenu(Int_t id);
-   virtual void      CloseWindow();
+   void      CloseWindow() override;
    virtual void      MaybeCloseWindow();
    virtual void      HandleWindowClosed(Int_t id);
    virtual void      UpdateStatusBar(const char *text = nullptr);
@@ -155,7 +155,7 @@ public:
    static TGFrame     *BuildVProgressBar();
 
 
-   ClassDef(TRootGuiBuilder,0)  // ROOT GUI Builder
+   ClassDefOverride(TRootGuiBuilder,0)  // ROOT GUI Builder
 };
 
 

--- a/gui/guibuilder/src/TGuiBldDragManager.cxx
+++ b/gui/guibuilder/src/TGuiBldDragManager.cxx
@@ -120,11 +120,11 @@ public:
    TList          *fWidgets;  // list of widgets
 
 public:
-   virtual ~TGuiBldMenuDialog();
+   ~TGuiBldMenuDialog() override;
    TGuiBldMenuDialog(const TGWindow *main, TObject *obj, TMethod *method);
 
    const char *GetParameters();
-   void CloseWindow();
+   void CloseWindow() override;
    void ConnectButtonSignals();
    void Build();
    void Popup();
@@ -674,7 +674,7 @@ private:
 public:
    TGuiBldDragManagerRepeatTimer(TGuiBldDragManager *m, Long_t ms) :
                                  TTimer(ms, kTRUE) { fManager = m; }
-   Bool_t Notify() { fManager->HandleTimer(this); Reset(); return kFALSE; }
+   Bool_t Notify() override { fManager->HandleTimer(this); Reset(); return kFALSE; }
 };
 
 
@@ -687,9 +687,9 @@ private:
 
 public:
    TGGrabRect(Int_t type);
-   ~TGGrabRect() {}
+   ~TGGrabRect() override {}
 
-   Bool_t HandleButton(Event_t *ev);
+   Bool_t HandleButton(Event_t *ev) override;
    ECursor GetType() const { return fType; }
 };
 
@@ -769,7 +769,7 @@ class TGAroundFrame : public TGFrame {
 
 public:
    TGAroundFrame();
-   ~TGAroundFrame() {}
+   ~TGAroundFrame() override {}
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gui/guibuilder/src/TGuiBldEditor.cxx
+++ b/gui/guibuilder/src/TGuiBldEditor.cxx
@@ -55,7 +55,7 @@ private:
 
 public:
    TGuiBldBorderFrame(const TGWindow *p, TGuiBldEditor *editor);
-   virtual ~TGuiBldBorderFrame() { }
+   ~TGuiBldBorderFrame() override { }
 
    void  ChangeSelected(TGFrame*);
 };

--- a/gui/guibuilder/src/TGuiBldHintsEditor.cxx
+++ b/gui/guibuilder/src/TGuiBldHintsEditor.cxx
@@ -48,7 +48,7 @@ public:
 
 public:
    TGuiBldHintsManager(const TGWindow *p, TGuiBldEditor *editor, TGuiBldHintsEditor *hints);
-   virtual ~TGuiBldHintsManager() { }
+   ~TGuiBldHintsManager() override { }
    void ChangeSelected(TGFrame *frame);
 };
 

--- a/gui/guibuilder/src/TRootGuiBuilder.cxx
+++ b/gui/guibuilder/src/TRootGuiBuilder.cxx
@@ -236,10 +236,10 @@ private:
    Pixel_t fBgndColor;
 
 protected:
-   void DoRedraw();
+   void DoRedraw() override;
 
 public:
-   virtual ~TGuiBldMenuTitle() {}
+   ~TGuiBldMenuTitle() override {}
    TGuiBldMenuTitle(const TGWindow *p, TGHotString *s, TGPopupMenu *menu) :
       TGMenuTitle(p, s, menu) {
          fEditDisabled = kEditDisable;
@@ -248,7 +248,7 @@ public:
          AddInput(kEnterWindowMask | kLeaveWindowMask);
    }
 
-   Bool_t HandleCrossing(Event_t *event);
+   Bool_t HandleCrossing(Event_t *event) override;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -299,14 +299,14 @@ void TGuiBldMenuTitle::DoRedraw()
 class TGuiBldPopupMenu : public TGPopupMenu {
 
 public:
-   virtual ~TGuiBldPopupMenu() { }
+   ~TGuiBldPopupMenu() override { }
    TGuiBldPopupMenu() :
       TGPopupMenu(gClient->GetDefaultRoot()) {
       fEditDisabled = kEditDisable;
       SetBackgroundColor(TRootGuiBuilder::GetPopupBgnd());
       fEntrySep = 8;
    }
-   void DrawEntry(TGMenuEntry *entry);
+   void DrawEntry(TGMenuEntry *entry) override;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -465,20 +465,20 @@ private:
    Pixel_t fBgndColor;
 
 protected:
-   void  DoRedraw();
+   void  DoRedraw() override;
 
 public:
-   virtual ~TGuiBldToolButton() { }
+   ~TGuiBldToolButton() override { }
    TGuiBldToolButton(const TGWindow *p, const TGPicture *pic, Int_t id = -1) :
          TGPictureButton(p, pic, id) {
       fBgndColor = TRootGuiBuilder::GetBgnd();
       ChangeOptions(GetOptions() & ~kRaisedFrame);
    }
 
-   Bool_t IsDown() const { return (fOptions & kSunkenFrame); }
-   void SetState(EButtonState state, Bool_t emit = kTRUE);
-   Bool_t HandleCrossing(Event_t *event);
-   void SetBackgroundColor(Pixel_t bgnd) { fBgndColor = bgnd; TGFrame::SetBackgroundColor(bgnd); }
+   Bool_t IsDown() const override { return (fOptions & kSunkenFrame); }
+   void SetState(EButtonState state, Bool_t emit = kTRUE) override;
+   Bool_t HandleCrossing(Event_t *event) override;
+   void SetBackgroundColor(Pixel_t bgnd) override { fBgndColor = bgnd; TGFrame::SetBackgroundColor(bgnd); }
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gui/guihtml/inc/TGHtml.h
+++ b/gui/guihtml/inc/TGHtml.h
@@ -290,7 +290,7 @@ private:
 
 public:
    TGHtmlTextElement(int size);
-   virtual ~TGHtmlTextElement();
+   ~TGHtmlTextElement() override;
 
    Html_32_t    fY;                // y coordinate where text should be rendered
    Html_16_t    fX;                // x coordinate where text should be rendered
@@ -324,13 +324,13 @@ public:
 class TGHtmlMarkupElement : public TGHtmlElement {
 public:
    TGHtmlMarkupElement(int type, int argc, int arglen[], char *argv[]);
-   virtual ~TGHtmlMarkupElement();
+   ~TGHtmlMarkupElement() override;
 
-   virtual const char *MarkupArg(const char *tag, const char *zDefault);
-   virtual int  GetAlignment(int dflt);
-   virtual int  GetOrderedListType(int dflt);
-   virtual int  GetUnorderedListType(int dflt);
-   virtual int  GetVerticalAlignment(int dflt);
+   const char *MarkupArg(const char *tag, const char *zDefault) override;
+   int  GetAlignment(int dflt) override;
+   int  GetOrderedListType(int dflt) override;
+   int  GetUnorderedListType(int dflt) override;
+   int  GetVerticalAlignment(int dflt) override;
 
 public://protected:
    char **fArgv;
@@ -354,7 +354,7 @@ public://protected:
 class TGHtmlTable : public TGHtmlMarkupElement {
 public:
    TGHtmlTable(int type, int argc, int arglen[], char *argv[]);
-   ~TGHtmlTable();
+   ~TGHtmlTable() override;
 
 public:
    Html_u8_t      fBorderWidth;              // Width of the border
@@ -381,7 +381,7 @@ public:
 class TGHtmlCell : public TGHtmlMarkupElement {
 public:
    TGHtmlCell(int type, int argc, int arglen[], char *argv[]);
-   ~TGHtmlCell();
+   ~TGHtmlCell() override;
 
 public:
    Html_16_t      fRowspan;      // Number of rows spanned by this cell
@@ -405,7 +405,7 @@ public:
 class TGHtmlRef : public TGHtmlMarkupElement {
 public:
    TGHtmlRef(int type, int argc, int arglen[], char *argv[]);
-   ~TGHtmlRef();
+   ~TGHtmlRef() override;
 
 public:
    TGHtmlElement *fPOther;      // Pointer to some other Html element
@@ -512,7 +512,7 @@ private:
 public:
    TGHtmlImage(TGHtml *htm, const char *url, const char *width,
                const char *height);
-   virtual ~TGHtmlImage();
+   ~TGHtmlImage() override;
 
 public:
    TGHtml            *fHtml;              // The owner of this image
@@ -711,7 +711,7 @@ public:
 class TGHtmlBlock : public TGHtmlElement {
 public:
    TGHtmlBlock();
-   virtual ~TGHtmlBlock();
+   ~TGHtmlBlock() override;
 
 public:
    char        *fZ;                 // Space to hold text when n > 0
@@ -873,19 +873,19 @@ class THashTable;
 class TGHtml : public TGView {
 public:
    TGHtml(const TGWindow *p, int w, int h, int id = -1);
-   virtual ~TGHtml();
+   ~TGHtml() override;
 
-   virtual Bool_t HandleFocusChange(Event_t *event);
-   virtual Bool_t HandleButton(Event_t *event);
-   virtual Bool_t HandleMotion(Event_t *event);
+   Bool_t HandleFocusChange(Event_t *event) override;
+   Bool_t HandleButton(Event_t *event) override;
+   Bool_t HandleMotion(Event_t *event) override;
 
-   virtual Bool_t HandleIdleEvent(TGIdleHandler *i);
-   virtual Bool_t HandleTimer(TTimer *timer);
+   Bool_t HandleIdleEvent(TGIdleHandler *i) override;
+   Bool_t HandleTimer(TTimer *timer) override;
 
-   virtual Bool_t ProcessMessage(Longptr_t, Longptr_t, Longptr_t);
+   Bool_t ProcessMessage(Longptr_t, Longptr_t, Longptr_t) override;
 
-   virtual void   DrawRegion(Int_t x, Int_t y, UInt_t w, UInt_t h);
-   virtual Bool_t ItemLayout();
+   void   DrawRegion(Int_t x, Int_t y, UInt_t w, UInt_t h) override;
+   Bool_t ItemLayout() override;
 
    Bool_t         HandleHtmlInput(TGHtmlInput *pr, Event_t *event);
    Bool_t         HandleRadioButton(TGHtmlInput *p);
@@ -911,7 +911,7 @@ public:   // user commands
 public:   // reloadable methods
 
    // called when the widget is cleared
-   virtual void Clear(Option_t * = "");
+   void Clear(Option_t * = "") override;
 
    // User function to resolve URIs
    virtual char *ResolveUri(const char *uri);
@@ -1123,10 +1123,10 @@ public:
    virtual void CheckToggled(const char *name, Bool_t on, const char *val); // *SIGNAL*
    virtual void RadioChanged(const char *name, const char *val); // *SIGNAL*
    virtual void InputSelected(const char *name, const char *val);   //*SIGNAL*
-   virtual void SavePrimitive(std::ostream &out, Option_t * = "");
+   void SavePrimitive(std::ostream &out, Option_t * = "") override;
 
 protected:
-   virtual void UpdateBackgroundStart();
+   void UpdateBackgroundStart() override;
 
 protected:
    enum {
@@ -1287,7 +1287,7 @@ protected:
    const char       *fLastUri;               // Used in HandleMotion
    int               fExiting;               // True if the widget is being destroyed
 
-   ClassDef(TGHtml, 0); // HTML widget
+   ClassDefOverride(TGHtml, 0); // HTML widget
 };
 
 

--- a/gui/guihtml/inc/TGHtmlBrowser.h
+++ b/gui/guihtml/inc/TGHtmlBrowser.h
@@ -57,9 +57,9 @@ protected:
 public:
    TGHtmlBrowser(const char *filename = nullptr, const TGWindow *p = nullptr,
                  UInt_t w = 900, UInt_t h = 600);
-   virtual ~TGHtmlBrowser() {}
+   ~TGHtmlBrowser() override {}
 
-   virtual Bool_t    ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t);
+   Bool_t    ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t) override;
    void              Selected(const char *txt);
    void              URLChanged();
    void              Back();
@@ -71,7 +71,7 @@ public:
    void              MouseDown(const char *);
    void              Clicked(char *uri) { Emit("Clicked(char *)",uri); } // *SIGNAL*
 
-   ClassDef(TGHtmlBrowser, 0) // very simple html browser
+   ClassDefOverride(TGHtmlBrowser, 0) // very simple html browser
 };
 
 #endif

--- a/gui/guihtml/inc/TGHtmlUri.h
+++ b/gui/guihtml/inc/TGHtmlUri.h
@@ -60,7 +60,7 @@ private:
 public:
    TGHtmlUri(const char *zUri = nullptr);
    TGHtmlUri(const TGHtmlUri *uri);
-   virtual ~TGHtmlUri();
+   ~TGHtmlUri() override;
 
    char *BuildUri();
    int  EqualsUri(const TGHtmlUri *uri, int field_mask = URI_FULL_MASK);

--- a/gui/guihtml/src/TGHtmlForm.cxx
+++ b/gui/guihtml/src/TGHtmlForm.cxx
@@ -281,7 +281,7 @@ class TGHtmlLBEntry : public TGTextLBEntry {
 public:
    TGHtmlLBEntry(const TGWindow *p, TGString *s, TGString *val, int ID) :
       TGTextLBEntry(p, s, ID) { fVal = val; }
-   virtual ~TGHtmlLBEntry() { if (fVal) delete fVal; }
+   ~TGHtmlLBEntry() override { if (fVal) delete fVal; }
 
    const char *GetValue() const { return fVal ? fVal->GetString() : 0; }
 

--- a/gui/recorder/inc/TRecorder.h
+++ b/gui/recorder/inc/TRecorder.h
@@ -74,7 +74,7 @@ public:
       fEventTime = t;
    }
 
-   ClassDef(TRecEvent,1) // Abstract class. Defines basic interface for storing information about ROOT events
+   ClassDefOverride(TRecEvent,1) // Abstract class. Defines basic interface for storing information about ROOT events
 };
 
 
@@ -108,18 +108,18 @@ public:
       return fText.Data();
    }
 
-   virtual ERecEventType GetType() const {
+   ERecEventType GetType() const override {
       // Returns what kind of event it stores (commandline event)
       return TRecEvent::kCmdEvent;
    }
 
-   virtual void ReplayEvent(Bool_t) {
+   void ReplayEvent(Bool_t) override {
       // Stored command is executed again
       std::cout << GetText() << std::endl;
       gApplication->ProcessLine(GetText());
    }
 
-   ClassDef(TRecCmdEvent,1) // Class stores information about 1 commandline event (= 1 command typed by user in commandline)
+   ClassDefOverride(TRecCmdEvent,1) // Class stores information about 1 commandline event (= 1 command typed by user in commandline)
 };
 
 
@@ -153,18 +153,18 @@ public:
       return fText;
    }
 
-   virtual ERecEventType GetType() const {
+   ERecEventType GetType() const override {
       // Returns what kind of event it stores (Especial event)
       return TRecEvent::kExtraEvent;
    }
 
-   virtual void ReplayEvent(Bool_t) {
+   void ReplayEvent(Bool_t) override {
       // Stored event is executed again
 
       gApplication->ProcessLine(GetText());
    }
 
-   ClassDef(TRecExtraEvent,1) // Class stores information about extra events
+   ClassDefOverride(TRecExtraEvent,1) // Class stores information about extra events
 };
 
 
@@ -220,15 +220,15 @@ public:
       kROOT_MESSAGE     = 10002
    };
 
-   virtual ERecEventType GetType() const {
+   ERecEventType GetType() const override {
       // Returns what kind of event it stores (GUI event)
       return TRecEvent::kGuiEvent;
    }
 
-   virtual void    ReplayEvent(Bool_t showMouseCursor = kTRUE);
+   void    ReplayEvent(Bool_t showMouseCursor = kTRUE) override;
    static Event_t *CreateEvent(TRecGuiEvent *ge);
 
-   ClassDef(TRecGuiEvent,1) // Class stores information about 1 GUI event in ROOT
+   ClassDefOverride(TRecGuiEvent,1) // Class stores information about 1 GUI event in ROOT
 };
 
 
@@ -258,7 +258,7 @@ public:
    // Creates a new key-value mapping of window IDs
    TRecWinPair(Window_t key, Window_t value): fKey(key), fValue(value) {}
 
-   ClassDef(TRecWinPair,1) // Class used for storing of window IDs mapping. Needed for replaying events.
+   ClassDefOverride(TRecWinPair,1) // Class used for storing of window IDs mapping. Needed for replaying events.
 };
 
 
@@ -301,9 +301,9 @@ public:
    TRecorder(const char *filename, Option_t *option = "READ");
 
    // Deletes recorder together with its current state
-   virtual ~TRecorder();
+   ~TRecorder() override;
 
-   void Browse(TBrowser *);
+   void Browse(TBrowser *) override;
 
    // Starts recording of events to the given file
    void Start(const char *filename, Option_t *option = "RECREATE", Window_t *w = nullptr, Int_t winCount = 0);
@@ -338,7 +338,7 @@ public:
    // Saves all the canvases previous to the TRecorder
    void PrevCanvases(const char *filename, Option_t *option);
 
-   ClassDef(TRecorder,2) // Class provides direct recorder/replayer interface for a user.
+   ClassDefOverride(TRecorder,2) // Class provides direct recorder/replayer interface for a user.
 };
 
 /** \class TRecorderState
@@ -395,7 +395,7 @@ Not intended to be used by a user directly.
 class TRecorderReplaying : public TRecorderState
 {
 private:
-   virtual  ~TRecorderReplaying();
+    ~TRecorderReplaying() override;
    Bool_t   PrepareNextEvent();
    Bool_t   RemapWindowReferences();
    Bool_t   CanOverlap();
@@ -463,16 +463,16 @@ protected:
    Bool_t     Initialize(TRecorder *r, Bool_t showMouseCursor, TRecorder::EReplayModes mode);
 
 public:
-   virtual TRecorder::ERecorderState GetState() const { return TRecorder::kReplaying; }
+   TRecorder::ERecorderState GetState() const override { return TRecorder::kReplaying; }
 
-   virtual void   Pause(TRecorder *r);
+   void   Pause(TRecorder *r) override;
    virtual void   Continue();
-   virtual void   ReplayStop(TRecorder *r);
+   void   ReplayStop(TRecorder *r) override;
 
    void           RegisterWindow(Window_t w);   //SLOT
    void           ReplayRealtime();             //SLOT
 
-   ClassDef(TRecorderReplaying, 0) // Represents state of TRecorder when replaying
+   ClassDefOverride(TRecorderReplaying, 0) // Represents state of TRecorder when replaying
 };
 
 /** \class TRecorderRecording
@@ -487,7 +487,7 @@ Not intended to be used by a user directly.
 class TRecorderRecording: public TRecorderState
 {
 private:
-   virtual ~TRecorderRecording();
+   ~TRecorderRecording() override;
    Bool_t  IsFiltered(Window_t id);
    void    SetTypeOfConfigureNotify(Event_t *e);
    void    CopyEvent(Event_t *e, Window_t wid);
@@ -529,9 +529,9 @@ protected:
    Bool_t StartRecording();
 
 public:
-   virtual TRecorder::ERecorderState GetState() const { return TRecorder::kRecording; }
+   TRecorder::ERecorderState GetState() const override { return TRecorder::kRecording; }
 
-   virtual void Stop(TRecorder *r, Bool_t guiCommand);
+   void Stop(TRecorder *r, Bool_t guiCommand) override;
 
    void  RegisterWindow(Window_t w);               //SLOT
    void  RecordCmdEvent(const char *line);         //SLOT
@@ -546,7 +546,7 @@ public:
 
    void  RecordExtraEvent(TString line, TTime extTime);
 
-   ClassDef(TRecorderRecording, 0) // Represents state of TRecorder when recording events
+   ClassDefOverride(TRecorderRecording, 0) // Represents state of TRecorder when recording events
 };
 
 /** \class TRecorderInactive
@@ -567,23 +567,23 @@ private:
    TSeqCollection *fCollect;
 
 public:
-   virtual        ~TRecorderInactive() {}
+          ~TRecorderInactive() override {}
    TRecorderInactive() : fCollect(nullptr) {}
 
-   virtual void   ListCmd(const char *filename);
-   virtual void   ListGui(const char *filename);
+   void   ListCmd(const char *filename) override;
+   void   ListGui(const char *filename) override;
 
-   virtual void   Start(TRecorder *r, const char *filename, Option_t *option, Window_t *w = nullptr, Int_t winCount = 0);
-   virtual Bool_t Replay(TRecorder *r, const char *filename, Bool_t showMouseCursor, TRecorder::EReplayModes mode);
+   void   Start(TRecorder *r, const char *filename, Option_t *option, Window_t *w = nullptr, Int_t winCount = 0) override;
+   Bool_t Replay(TRecorder *r, const char *filename, Bool_t showMouseCursor, TRecorder::EReplayModes mode) override;
 
-   virtual TRecorder::ERecorderState GetState() const { return TRecorder::kInactive; }
+   TRecorder::ERecorderState GetState() const override { return TRecorder::kInactive; }
 
    static void    DumpRootEvent(TRecGuiEvent *e, Int_t n);
    static long    DisplayValid(Long_t n) { return ( n < 0 ? -1 : n); }
 
-   void PrevCanvases(const char *filename, Option_t *option);
+   void PrevCanvases(const char *filename, Option_t *option) override;
 
-   ClassDef(TRecorderInactive, 0) // Represents state of TRecorder after its creation
+   ClassDefOverride(TRecorderInactive, 0) // Represents state of TRecorder after its creation
 };
 
 /** \class TRecorderPaused
@@ -602,7 +602,7 @@ Not intended to be used by a user directly.
 class TRecorderPaused: public TRecorderState
 {
 private:
-   virtual ~TRecorderPaused() {}
+   ~TRecorderPaused() override {}
 
    TRecorderReplaying       *fReplayingState;      // Replaying that is paused
 
@@ -611,12 +611,12 @@ protected:
    TRecorderPaused(TRecorderReplaying *state);
 
 public:
-   virtual TRecorder::ERecorderState GetState() const { return TRecorder::kPaused; }
+   TRecorder::ERecorderState GetState() const override { return TRecorder::kPaused; }
 
-   virtual void Resume(TRecorder *r);
-   virtual void ReplayStop(TRecorder *r);
+   void Resume(TRecorder *r) override;
+   void ReplayStop(TRecorder *r) override;
 
-   ClassDef(TRecorderPaused, 0) // Represents state of TRecorder when paused
+   ClassDefOverride(TRecorderPaused, 0) // Represents state of TRecorder when paused
 };
 
 
@@ -649,13 +649,13 @@ private:
 
 public:
    TGRecorder(const TGWindow *p = nullptr, UInt_t w = 230, UInt_t h = 150);
-   virtual ~TGRecorder();
+   ~TGRecorder() override;
 
    void StartStop();
    void Update();
    void Replay();
 
-   ClassDef(TGRecorder,0) // GUI class of the event recorder.
+   ClassDefOverride(TGRecorder,0) // GUI class of the event recorder.
 };
 
 #endif // ROOT_TRecorder

--- a/gui/recorder/src/TRecorder.cxx
+++ b/gui/recorder/src/TRecorder.cxx
@@ -138,7 +138,7 @@ protected:
 
 public:
    TGCursorWindow();
-   virtual ~TGCursorWindow();
+   ~TGCursorWindow() override;
 };
 
 static TGCursorWindow *gCursorWin = 0;

--- a/gui/sessionviewer/inc/TProofProgressLog.h
+++ b/gui/sessionviewer/inc/TProofProgressLog.h
@@ -67,7 +67,7 @@ private:
 public:
    TProofProgressLog(TProofProgressDialog *d, Int_t w = 700, Int_t h = 600);
    TProofProgressLog(const char *url = nullptr, Int_t sessionidx = 0, Int_t w = 700, Int_t h = 600);
-   virtual ~TProofProgressLog();
+   ~TProofProgressLog() override;
 
    void   BuildLogList(Bool_t create = kFALSE);
    void   DoLog(Bool_t grep=kFALSE);
@@ -79,7 +79,7 @@ public:
 
    void   LoadFile(const char *file);
 
-   void   Clear(Option_t * = nullptr);
+   void   Clear(Option_t * = nullptr) override;
    void   Popup();
    void   SaveToFile();
    void   NoLineEntry();
@@ -88,9 +88,9 @@ public:
 
    void   SetUrl(const char *url) { fSessionUrl = url; }
    // slots
-   void   CloseWindow();
+   void   CloseWindow() override;
 
-   ClassDef(TProofProgressLog,0) //Class implementing a log graphic box
+   ClassDefOverride(TProofProgressLog,0) //Class implementing a log graphic box
 };
 
 #endif

--- a/gui/sessionviewer/inc/TProofProgressMemoryPlot.h
+++ b/gui/sessionviewer/inc/TProofProgressMemoryPlot.h
@@ -50,13 +50,13 @@ class TProofProgressMemoryPlot : public TGTransientFrame {
 
  public:
    TProofProgressMemoryPlot(TProofProgressDialog *d, Int_t w = 700, Int_t h = 300);
-   virtual ~TProofProgressMemoryPlot();
+   ~TProofProgressMemoryPlot() override;
 
-   void       Clear(Option_t * = nullptr);
+   void       Clear(Option_t * = nullptr) override;
    void       DoPlot();
    void       Select(Int_t id);
 
-   ClassDef(TProofProgressMemoryPlot,0) //PROOF progress memory plots
+   ClassDefOverride(TProofProgressMemoryPlot,0) //PROOF progress memory plots
 };
 
 #endif

--- a/gui/sessionviewer/inc/TSessionDialogs.h
+++ b/gui/sessionviewer/inc/TSessionDialogs.h
@@ -47,7 +47,7 @@ private:
 
 public:
    TNewChainDlg(const TGWindow *p=nullptr, const TGWindow *main=nullptr);
-   virtual ~TNewChainDlg();
+   ~TNewChainDlg() override;
 
    void         UpdateList();
    virtual void OnDoubleClick(TGLVEntry*,Int_t);
@@ -55,10 +55,10 @@ public:
    void         OnElementClicked(TGLVEntry* entry, Int_t btn);
    void         OnElementSelected(TObject *obj); //*SIGNAL*
 
-   virtual Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2);
-   virtual void CloseWindow();
+   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
+   void CloseWindow() override;
 
-   ClassDef(TNewChainDlg, 0) // New chain dialog
+   ClassDefOverride(TNewChainDlg, 0) // New chain dialog
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -91,7 +91,7 @@ private:
 public:
    TNewQueryDlg(TSessionViewer *gui, Int_t Width, Int_t Height,
                    TQueryDescription *query = nullptr, Bool_t editmode = kFALSE);
-   virtual ~TNewQueryDlg();
+   ~TNewQueryDlg() override;
    void     Build(TSessionViewer *gui);
    void     OnNewQueryMore();
    void     OnBrowseChain();
@@ -101,13 +101,13 @@ public:
    void     OnBtnCloseClicked();
    void     OnBtnSubmitClicked();
    void     OnElementSelected(TObject *obj);
-   void     CloseWindow();
+   void     CloseWindow() override;
    void     Popup();
    void     SettingsChanged();
    void     UpdateFields(TQueryDescription *desc);
-   virtual Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2);
+   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
 
-   ClassDef(TNewQueryDlg, 0) // New query dialog
+   ClassDefOverride(TNewQueryDlg, 0) // New query dialog
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -137,10 +137,10 @@ private:
 
 public:
    TUploadDataSetDlg(TSessionViewer *gui, Int_t w, Int_t h);
-   virtual ~TUploadDataSetDlg();
+   ~TUploadDataSetDlg() override;
 
-   virtual void   CloseWindow();
-   virtual Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2);
+   void   CloseWindow() override;
+   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
    void           AddFiles(const char *fileName);
    void           AddFiles(TList *fileList);
    void           BrowseFiles();
@@ -151,7 +151,7 @@ public:
    void           OnOverwriteFiles(Bool_t on);
    void           OnAppendFiles(Bool_t on);
 
-   ClassDef(TUploadDataSetDlg, 0) // New query dialog
+   ClassDefOverride(TUploadDataSetDlg, 0) // New query dialog
 };
 
 #endif

--- a/gui/sessionviewer/inc/TSessionLogView.h
+++ b/gui/sessionviewer/inc/TSessionLogView.h
@@ -31,20 +31,20 @@ private:
 
 public:
    TSessionLogView(TSessionViewer *viewer, UInt_t w, UInt_t h);
-   virtual ~TSessionLogView();
+   ~TSessionLogView() override;
 
    void   AddBuffer(const char *buffer);
    void   LoadBuffer(const char *buffer);
    void   LoadFile(const char *file);
 
-   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2);
+   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
 
-   void   CloseWindow();
+   void   CloseWindow() override;
    void   ClearLogView();
    void   Popup();
    void   SetTitle();
 
-   ClassDef(TSessionLogView, 0)  // PROOF progress dialog
+   ClassDefOverride(TSessionLogView, 0)  // PROOF progress dialog
 };
 
 #endif

--- a/gui/sessionviewer/inc/TSessionViewer.h
+++ b/gui/sessionviewer/inc/TSessionViewer.h
@@ -108,9 +108,9 @@ public:
    TObject       *fChain;           // dataset on which to process selector
    TQueryResult  *fResult;          // query result received back
 
-   const char    *GetName() const { return fQueryName; }
+   const char    *GetName() const override { return fQueryName; }
 
-   ClassDef(TQueryDescription, 1)  // Query description
+   ClassDefOverride(TQueryDescription, 1)  // Query description
 };
 
 
@@ -146,9 +146,9 @@ public:
    TProofMgr         *fProofMgr;    // Proof sessions manager
    Int_t              fNbHistos;    // number of feedback histos
 
-   const char        *GetName() const { return fName; }
+   const char        *GetName() const override { return fName; }
 
-   ClassDef(TSessionDescription, 1) // Session description
+   ClassDefOverride(TSessionDescription, 1) // Session description
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -164,9 +164,9 @@ public:
    Bool_t         fUploaded;     // package has been uploaded
    Bool_t         fEnabled;      // package has been enabled
 
-   const char    *GetName() const { return fName; }
+   const char    *GetName() const override { return fName; }
 
-   ClassDef(TPackageDescription, 1) // Package description
+   ClassDefOverride(TPackageDescription, 1) // Package description
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -194,11 +194,11 @@ private:
 
 public:
    TSessionServerFrame(TGWindow *parent, Int_t w, Int_t h);
-   virtual ~TSessionServerFrame();
+   ~TSessionServerFrame() override;
 
    void        Build(TSessionViewer *gui);
 
-   const char *GetName() const { return fTxtName->GetText(); }
+   const char *GetName() const override { return fTxtName->GetText(); }
    const char *GetAddress() const { return fTxtAddress->GetText(); }
    Int_t       GetPortNumber() const { return fNumPort->GetIntNumber(); }
    Int_t       GetLogLevel() const { return fLogLevel->GetIntNumber(); }
@@ -210,7 +210,7 @@ public:
                on == kTRUE ? ShowFrame(fBtnAdd) : HideFrame(fBtnAdd); }
    void        SetConnectEnabled(Bool_t on = kTRUE) {
                on == kTRUE ? ShowFrame(fBtnConnect) : HideFrame(fBtnConnect); }
-   void        SetName(const char *str) { fTxtName->SetText(str); }
+   void        SetName(const char *str) override { fTxtName->SetText(str); }
    void        SetAddress(const char *str) { fTxtAddress->SetText(str); }
    void        SetPortNumber(Int_t port) { fNumPort->SetIntNumber(port); }
    void        SetLogLevel(Int_t log) { fLogLevel->SetIntNumber(log); }
@@ -227,10 +227,10 @@ public:
    void        OnBtnAddClicked();
    void        OnConfigFileClicked();
    void        Update(TSessionDescription* desc);
-   virtual Bool_t HandleExpose(Event_t *event);
-   virtual Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2);
+   Bool_t HandleExpose(Event_t *event) override;
+   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
 
-   ClassDef(TSessionServerFrame, 0) // Server frame
+   ClassDefOverride(TSessionServerFrame, 0) // Server frame
 };
 
 
@@ -289,7 +289,7 @@ private:
 
 public:
    TSessionFrame(TGWindow* parent, Int_t w, Int_t h);
-   virtual ~TSessionFrame();
+   ~TSessionFrame() override;
 
    void     Build(TSessionViewer *gui);
    void     CheckAutoEnPack(Bool_t checked = kTRUE) {
@@ -325,7 +325,7 @@ public:
    void     OnBtnVerifyDSet();
    void     UpdateListOfDataSets();
 
-   ClassDef(TSessionFrame, 0) // Session frame
+   ClassDefOverride(TSessionFrame, 0) // Session frame
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -352,7 +352,7 @@ private:
 
 public:
    TEditQueryFrame(TGWindow* p, Int_t w, Int_t h);
-   virtual ~TEditQueryFrame();
+   ~TEditQueryFrame() override;
    void     Build(TSessionViewer *gui);
    void     OnNewQueryMore();
    void     OnBrowseChain();
@@ -363,7 +363,7 @@ public:
    void     SettingsChanged();
    void     UpdateFields(TQueryDescription *desc);
 
-   ClassDef(TEditQueryFrame, 0) // Edit query frame
+   ClassDefOverride(TEditQueryFrame, 0) // Edit query frame
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -411,7 +411,7 @@ private:
 
 public:
    TSessionQueryFrame(TGWindow* parent, Int_t w, Int_t h);
-   virtual ~TSessionQueryFrame();
+   ~TSessionQueryFrame() override;
 
    void     Build(TSessionViewer *gui);
 
@@ -445,7 +445,7 @@ public:
    void     UpdateButtons(TQueryDescription *desc);
    void     UpdateHistos(TList *objs);
 
-   ClassDef(TSessionQueryFrame, 0) // Query frame
+   ClassDefOverride(TSessionQueryFrame, 0) // Query frame
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -465,16 +465,16 @@ private:
 
 public:
    TSessionOutputFrame(TGWindow* parent, Int_t w, Int_t h);
-   virtual ~TSessionOutputFrame();
+   ~TSessionOutputFrame() override;
 
    void           AddObject(TObject *obj);
    void           Build(TSessionViewer *gui);
    TGLVContainer  *GetLVContainer() { return fLVContainer; }
    void           OnElementClicked(TGLVEntry* entry, Int_t btn, Int_t x, Int_t y);
    void           OnElementDblClicked(TGLVEntry *entry ,Int_t btn, Int_t x, Int_t y);
-   void           RemoveAll() { fLVContainer->RemoveAll(); }
+   void           RemoveAll() override { fLVContainer->RemoveAll(); }
 
-   ClassDef(TSessionOutputFrame, 0) // Output frame
+   ClassDefOverride(TSessionOutputFrame, 0) // Output frame
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -493,14 +493,14 @@ private:
 
 public:
    TSessionInputFrame(TGWindow* parent, Int_t w, Int_t h);
-   virtual ~TSessionInputFrame();
+   ~TSessionInputFrame() override;
 
    void           AddObject(TObject *obj);
    void           Build(TSessionViewer *gui);
-   void           RemoveAll() { fLVContainer->RemoveAll(); }
+   void           RemoveAll() override { fLVContainer->RemoveAll(); }
    TGLVContainer  *GetLVContainer() { return fLVContainer; }
 
-   ClassDef(TSessionInputFrame, 0) // Input frame
+   ClassDefOverride(TSessionInputFrame, 0) // Input frame
 };
 
 
@@ -567,9 +567,9 @@ public:
 
    TSessionViewer(const char *title = "ROOT Session Viewer", UInt_t w = 550, UInt_t h = 320);
    TSessionViewer(const char *title, Int_t x, Int_t y, UInt_t w, UInt_t h);
-   virtual ~TSessionViewer();
+   ~TSessionViewer() override;
    virtual void Build();
-   virtual Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t);
+   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t) override;
 
    TSessionServerFrame    *GetServerFrame() const { return fServerFrame; }
    TSessionFrame          *GetSessionFrame() const { return fSessionFrame; }
@@ -596,11 +596,11 @@ public:
 
    void     ChangeRightLogo(const char *name);
    void     CleanupSession();
-   void     CloseWindow();
+   void     CloseWindow() override;
    void     DisableTimer();
    void     EditQuery();
    void     EnableTimer();
-   Bool_t   HandleTimer(TTimer *);
+   Bool_t   HandleTimer(TTimer *) override;
    Bool_t   IsBusy() const { return fBusy; }
    Bool_t   IsAutoSave() const { return fAutoSave; }
    void     LogMessage(const char *msg, Bool_t all);
@@ -628,7 +628,7 @@ public:
    void     StartViewer();
    void     Terminate();
 
-   ClassDef(TSessionViewer, 0) // Session Viewer
+   ClassDefOverride(TSessionViewer, 0) // Session Viewer
 };
 
 R__EXTERN TSessionViewer *gSessionViewer;

--- a/gui/webdisplay/inc/ROOT/RWebDisplayHandle.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebDisplayHandle.hxx
@@ -55,7 +55,7 @@ protected:
 
       std::unique_ptr<RWebDisplayHandle> Display(const RWebDisplayArgs &args) override;
 
-      virtual ~BrowserCreator() = default;
+      ~BrowserCreator() override = default;
    };
 
    class ChromeCreator : public BrowserCreator {
@@ -63,7 +63,7 @@ protected:
       std::string fEnvPrefix; // rc parameters prefix
    public:
       ChromeCreator(bool is_edge = false);
-      virtual ~ChromeCreator() = default;
+      ~ChromeCreator() override = default;
       bool IsActive() const override { return !fProg.empty(); }
       void ProcessGeometry(std::string &, const RWebDisplayArgs &args) override;
       std::string MakeProfile(std::string &exec, bool) override;
@@ -72,7 +72,7 @@ protected:
    class FirefoxCreator : public BrowserCreator {
    public:
       FirefoxCreator();
-      virtual ~FirefoxCreator() = default;
+      ~FirefoxCreator() override = default;
       bool IsActive() const override { return !fProg.empty(); }
       std::string MakeProfile(std::string &exec, bool batch) override;
    };

--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -120,7 +120,7 @@ public:
    {
    }
 
-   virtual ~RWebBrowserHandle()
+   ~RWebBrowserHandle() override
    {
 #ifdef _MSC_VER
       if (fHasPid)

--- a/gui/webdisplay/src/RWebWindowWSHandler.hxx
+++ b/gui/webdisplay/src/RWebWindowWSHandler.hxx
@@ -114,7 +114,7 @@ public:
    {
    }
 
-   virtual ~RWebWindowWSHandler() = default;
+   ~RWebWindowWSHandler() override = default;
 
    /// returns content of default web-page
    /// THttpWSHandler interface

--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -152,7 +152,7 @@ protected:
 
 public:
    TWebCanvas(TCanvas *c, const char *name, Int_t x, Int_t y, UInt_t width, UInt_t height, Bool_t readonly = kTRUE);
-   virtual ~TWebCanvas() = default;
+   ~TWebCanvas() override = default;
 
    void ShowWebWindow(const ROOT::Experimental::RWebDisplayArgs &user_args = "");
 

--- a/gui/webgui6/inc/TWebControlBar.h
+++ b/gui/webgui6/inc/TWebControlBar.h
@@ -26,7 +26,7 @@ protected:
 
 public:
    TWebControlBar(TControlBar *bar, const char *title, Int_t x, Int_t y);
-   virtual ~TWebControlBar() = default;
+   ~TWebControlBar() override = default;
 
    void Create() override { }
    void Hide() override;

--- a/gui/webgui6/inc/TWebMenuItem.h
+++ b/gui/webgui6/inc/TWebMenuItem.h
@@ -66,7 +66,7 @@ public:
    }
 
    /** virtual destructor need for vtable, used when vector of TMenuItem* is stored */
-   virtual ~TWebCheckedMenuItem() = default;
+   ~TWebCheckedMenuItem() override = default;
 
    /** Set checked state for the item, default is none */
    void SetChecked(bool on = true) { fChecked = on; }
@@ -105,7 +105,7 @@ public:
    TWebArgsMenuItem(const std::string &name, const std::string &title) : TWebMenuItem(name, title) {}
 
    /** virtual destructor need for vtable, used when vector of TMenuItem* is stored */
-   virtual ~TWebArgsMenuItem() = default;
+   ~TWebArgsMenuItem() override = default;
 
    std::vector<TWebMenuArgument> &GetArgs() { return fArgs; }
 

--- a/gui/webgui6/inc/TWebPainting.h
+++ b/gui/webgui6/inc/TWebPainting.h
@@ -35,7 +35,7 @@ class TWebPainting : public TObject {
    public:
 
       TWebPainting();
-      virtual ~TWebPainting() = default;
+      ~TWebPainting() override = default;
 
       Bool_t IsEmpty() const { return fOper.empty() && (fBuf.GetSize() == 0); }
 

--- a/gui/webgui6/inc/TWebSnapshot.h
+++ b/gui/webgui6/inc/TWebSnapshot.h
@@ -39,7 +39,7 @@ public:
      kStyle = 5        ///< gStyle object
    };
 
-   virtual ~TWebSnapshot();
+   ~TWebSnapshot() override;
 
    void SetObjectIDAsPtr(void *ptr);
    void SetObjectID(const std::string &id) { fObjectID = id; }


### PR DESCRIPTION
This commit only contains changes that were automatically generated by `clang-tidy`, and replaces `ClassDef` with `ClassDefOverride` where appropriate.

Several directories in the ROOT repo were already treated like this, the last one was `tree`:
https://github.com/root-project/root/pull/11290