### PR TITLE
[RF] Always use `addOwned()` overload that takes `unique_ptr`

### DIFF
--- a/roofit/histfactory/src/PiecewiseInterpolation.cxx
+++ b/roofit/histfactory/src/PiecewiseInterpolation.cxx
@@ -92,7 +92,7 @@ PiecewiseInterpolation::PiecewiseInterpolation(const char* name, const char* tit
     }
     _lowSet.add(*comp) ;
     if (takeOwnership) {
-      _ownedList.addOwned(*comp) ;
+      _ownedList.addOwned(std::unique_ptr<RooAbsArg>{comp});
     }
   }
 
@@ -105,7 +105,7 @@ PiecewiseInterpolation::PiecewiseInterpolation(const char* name, const char* tit
     }
     _highSet.add(*comp) ;
     if (takeOwnership) {
-      _ownedList.addOwned(*comp) ;
+      _ownedList.addOwned(std::unique_ptr<RooAbsArg>{comp});
     }
   }
 
@@ -118,7 +118,7 @@ PiecewiseInterpolation::PiecewiseInterpolation(const char* name, const char* tit
     }
     _paramSet.add(*comp) ;
     if (takeOwnership) {
-      _ownedList.addOwned(*comp) ;
+      _ownedList.addOwned(std::unique_ptr<RooAbsArg>{comp});
     }
     _interpCode.push_back(0); // default code: linear interpolation
   }
@@ -126,7 +126,7 @@ PiecewiseInterpolation::PiecewiseInterpolation(const char* name, const char* tit
 
   // Choose special integrator by default
   specialIntegratorConfig(true)->method1D().setLabel("RooBinIntegrator") ;
-  TRACE_CREATE
+  TRACE_CREATE;
 }
 
 
@@ -145,7 +145,7 @@ PiecewiseInterpolation::PiecewiseInterpolation(const PiecewiseInterpolation& oth
   _interpCode(other._interpCode)
 {
   // Member _ownedList is intentionally not copy-constructed -- ownership is not transferred
-  TRACE_CREATE
+  TRACE_CREATE;
 }
 
 
@@ -155,7 +155,7 @@ PiecewiseInterpolation::PiecewiseInterpolation(const PiecewiseInterpolation& oth
 
 PiecewiseInterpolation::~PiecewiseInterpolation()
 {
-  TRACE_DESTROY
+  TRACE_DESTROY;
 }
 
 
@@ -506,19 +506,16 @@ Int_t PiecewiseInterpolation::getAnalyticalIntegralWN(RooArgSet& allVars, RooArg
 
   // Make list of function projection and normalization integrals
   RooAbsReal *func ;
-  RooAbsReal *funcInt;
 
   // do variations 
   for (auto it = _paramSet.begin(); it != _paramSet.end(); ++it)
   {
     auto i = it - _paramSet.begin();
     func = static_cast<RooAbsReal *>(_lowSet.at(i));
-    funcInt = func->createIntegral(analVars) ;
-    cache->_lowIntList.addOwned(*funcInt) ;
+    cache->_lowIntList.addOwned(std::unique_ptr<RooAbsReal>{func->createIntegral(analVars)});
 
     func = static_cast<RooAbsReal *>(_highSet.at(i));
-    funcInt = func->createIntegral(analVars) ;
-    cache->_highIntList.addOwned(*funcInt);
+    cache->_highIntList.addOwned(std::unique_ptr<RooAbsReal>{func->createIntegral(analVars)});
   }
 
   // Store cache element

--- a/roofit/roofit/src/RooLagrangianMorphFunc.cxx
+++ b/roofit/roofit/src/RooLagrangianMorphFunc.cxx
@@ -2155,7 +2155,7 @@ RooProduct *RooLagrangianMorphFunc::getSumElement(const char *name) const
       coutE(Eval) << "unable to retrieve morphing function" << std::endl;
       return nullptr;
    }
-   RooArgSet *args = mf->getComponents();
+   std::unique_ptr<RooArgSet> args{mf->getComponents()};
    TString prodname(name);
    prodname.Append("_");
    prodname.Append(this->GetName());
@@ -2554,7 +2554,7 @@ TH1 *RooLagrangianMorphFunc::createTH1(const std::string &name, bool correlateEr
 
    auto hist = std::make_unique<TH1F>(name.c_str(), name.c_str(), nbins, observable->getBinning().array());
 
-   RooArgSet *args = mf->getComponents();
+   std::unique_ptr<RooArgSet> args{mf->getComponents()};
    for (int i = 0; i < nbins; ++i) {
       observable->setBin(i);
       double val = 0;
@@ -2592,7 +2592,7 @@ int RooLagrangianMorphFunc::countContributingFormulas() const
    auto mf = std::make_unique<RooRealSumFunc>(*(this->getFunc()));
    if (!mf)
       coutE(InputArguments) << "unable to retrieve morphing function" << std::endl;
-   RooArgSet *args = mf->getComponents();
+   std::unique_ptr<RooArgSet> args{mf->getComponents()};
    for (auto itr : *args) {
       RooProduct *prod = dynamic_cast<RooProduct *>(itr);
       if (prod->getVal() != 0) {
@@ -2679,9 +2679,8 @@ void RooLagrangianMorphFunc::printEvaluation() const
       std::cerr << "Error: unable to retrieve morphing function" << std::endl;
       return;
    }
-   RooArgSet *args = mf->getComponents();
-   for (auto itr : *args) {
-      RooAbsReal *formula = dynamic_cast<RooAbsReal *>(itr);
+   std::unique_ptr<RooArgSet> args{mf->getComponents()};
+   for (auto *formula : dynamic_range_cast<RooAbsReal*>(*args)) {
       if (formula) {
          TString name(formula->GetName());
          name.Remove(0, 2);

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -313,7 +313,7 @@ public:
   bool observableOverlaps(const RooArgSet* depList, const RooAbsArg& testArg) const ;
   virtual bool checkObservables(const RooArgSet* nset) const ;
   bool recursiveCheckObservables(const RooArgSet* nset) const ;
-  RooArgSet* getComponents() const ;
+  RooFit::OwningPtr<RooArgSet> getComponents() const ;
 
 
 

--- a/roofit/roofitcore/inc/RooRealBinding.h
+++ b/roofit/roofitcore/inc/RooRealBinding.h
@@ -56,7 +56,7 @@ protected:
   const RooArgSet *_nset;
   mutable bool _xvecValid;
   bool _clipInvalid ;
-  mutable double* _xsave ;
+  mutable std::vector<double> _xsave ;
   const TNamed* _rangeName ; ///<!
 
   mutable std::vector<RooAbsReal*> _compList ; ///<!

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -788,15 +788,12 @@ bool RooAbsArg::getObservables(const RooAbsCollection* dataList, RooArgSet& outp
 ////////////////////////////////////////////////////////////////////////////////
 /// Create a RooArgSet with all components (branch nodes) of the
 /// expression tree headed by this object.
-RooArgSet* RooAbsArg::getComponents() const
+RooFit::OwningPtr<RooArgSet> RooAbsArg::getComponents() const
 {
-  TString name(GetName()) ;
-  name.Append("_components") ;
-
-  RooArgSet* set = new RooArgSet(name) ;
+  RooArgSet* set = new RooArgSet((std::string(GetName()) + "_components").c_str()) ;
   branchNodeServerList(set) ;
 
-  return set ;
+  return RooFit::OwningPtr<RooArgSet>{set};
 }
 
 

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -924,29 +924,28 @@ const RooAbsReal *RooAbsReal::createPlotProjection(const RooArgSet &dependentVar
   title.Prepend("Projection of ");
 
 
-  RooAbsReal* projected= theClone->createIntegral(*projectedVars,normSet,rangeName) ;
+  std::unique_ptr<RooAbsReal> projected{theClone->createIntegral(*projectedVars,normSet,rangeName)};
 
-  if(0 == projected || !projected->isValid()) {
+  if(nullptr == projected || !projected->isValid()) {
     coutE(Plotting) << ClassName() << "::" << GetName() << ":createPlotProjection: cannot integrate out ";
     projectedVars->printStream(std::cout,kName|kArgs,kSingleLine);
-    // cleanup and exit
-    if(0 != projected) delete projected;
     return 0;
   }
 
   if(projected->InheritsFrom(RooRealIntegral::Class())){
-    static_cast<RooRealIntegral*>(projected)->setAllowComponentSelection(true);
+    static_cast<RooRealIntegral&>(*projected).setAllowComponentSelection(true);
   }
 
   projected->SetName(name.Data()) ;
   projected->SetTitle(title.Data()) ;
 
   // Add the projection integral to the cloneSet so that it eventually gets cleaned up by the caller.
-  cloneSet->addOwned(*projected);
+  RooAbsReal *projectedPtr = projected.get();
+  cloneSet->addOwned(std::move(projected));
 
   // return a const pointer to remind the caller that they do not delete the returned object
   // directly (it is contained in the cloneSet instead).
-  return projected;
+  return projectedPtr;
 }
 
 

--- a/roofit/roofitcore/src/RooAddModel.cxx
+++ b/roofit/roofitcore/src/RooAddModel.cxx
@@ -499,8 +499,7 @@ void RooAddModel::getCompIntList(const RooArgSet* nset, const RooArgSet* iset, p
   for (auto obj : _pdfList) {
     auto model = static_cast<RooResolutionModel*>(obj);
 
-    RooAbsReal* intPdf = model->createIntegral(*iset,nset,0,isetRangeName) ;
-    cache->_intList.addOwned(*intPdf) ;
+    cache->_intList.addOwned(std::unique_ptr<RooAbsReal>{model->createIntegral(*iset,nset,0,isetRangeName)});
   }
 
   // Store the partial integral list and return the assigned code ;

--- a/roofit/roofitcore/src/RooAddition.cxx
+++ b/roofit/roofitcore/src/RooAddition.cxx
@@ -57,14 +57,14 @@ RooAddition::RooAddition(const char* name, const char* title, const RooArgList& 
   , _set("!set","set of components",this)
   , _cacheMgr(this,10)
 {
-  for (const auto comp : sumSet) {
+  for (RooAbsArg *comp : sumSet) {
     if (!dynamic_cast<RooAbsReal*>(comp)) {
       coutE(InputArguments) << "RooAddition::ctor(" << GetName() << ") ERROR: component " << comp->GetName()
              << " is not of type RooAbsReal" << std::endl;
       RooErrorHandler::softAbort() ;
     }
     _set.add(*comp) ;
-    if (takeOwnership) _ownedList.addOwned(*comp) ;
+    if (takeOwnership) _ownedList.addOwned(std::unique_ptr<RooAbsArg>{comp});
   }
 
 }
@@ -117,12 +117,12 @@ RooAddition::RooAddition(const char* name, const char* title, const RooArgList& 
     _name.Append( "_x_");
     _name.Append(comp2->GetName());
     _name.Append( "]");
-    RooProduct  *prod = new RooProduct( _name, _name , RooArgSet(*comp1, *comp2) /*, takeOwnership */ ) ;
+    auto prod = std::make_unique<RooProduct>( _name, _name , RooArgSet(*comp1, *comp2) /*, takeOwnership */ );
     _set.add(*prod);
-    _ownedList.addOwned(*prod) ;
+    _ownedList.addOwned(std::move(prod));
     if (takeOwnership) {
-        _ownedList.addOwned(*comp1) ;
-        _ownedList.addOwned(*comp2) ;
+        _ownedList.addOwned(std::unique_ptr<RooAbsArg>{comp1});
+        _ownedList.addOwned(std::unique_ptr<RooAbsArg>{comp2});
     }
   }
 }
@@ -297,9 +297,8 @@ Int_t RooAddition::getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars
 
   // we don't, so we make it right here....
   cache = new CacheElem;
-  for (const auto arg : _set) {// checked in c'tor that this will work...
-      RooAbsReal *I = static_cast<const RooAbsReal*>(arg)->createIntegral(analVars,rangeName);
-      cache->_I.addOwned(*I);
+  for (auto *arg : static_range_cast<RooAbsReal const*>(_set)) {// checked in c'tor that this will work...
+      cache->_I.addOwned(std::unique_ptr<RooAbsReal>{arg->createIntegral(analVars,rangeName)});
   }
 
   Int_t code = _cacheMgr.setObj(&analVars,&analVars,(RooAbsCacheElement*)cache,RooNameReg::ptr(rangeName));

--- a/roofit/roofitcore/src/RooConvGenContext.cxx
+++ b/roofit/roofitcore/src/RooConvGenContext.cxx
@@ -91,8 +91,7 @@ RooConvGenContext::RooConvGenContext(const RooAbsAnaConvPdf &model, const RooArg
     coutE(Generation) << "RooConvGenContext::RooConvGenContext(" << GetName() << ") Couldn't deep-clone resolution model, abort," << std::endl;
     RooErrorHandler::softAbort() ;
   }
-  auto modelClone = static_cast<RooResolutionModel*>(_modelCloneSet->find(model._convSet.at(0)->GetName())->Clone("smearing"));
-  _modelCloneSet->addOwned(*modelClone) ;
+  std::unique_ptr<RooResolutionModel> modelClone{static_cast<RooResolutionModel*>(_modelCloneSet->find(model._convSet.at(0)->GetName())->Clone("smearing"))};
   modelClone->changeBasis(0) ;
   convV = dynamic_cast<RooRealVar*>(&modelClone->convVar());
   if (!convV) {
@@ -106,6 +105,8 @@ RooConvGenContext::RooConvGenContext(const RooAbsAnaConvPdf &model, const RooArg
   _modelVars->add(modelClone->convVar()) ;
   _convVarName = modelClone->convVar().GetName() ;
   _modelGen.reset(modelClone->genContext(*_modelVars,prototype,auxProto,verbose));
+
+  _modelCloneSet->addOwned(std::move(modelClone));
 
   if (prototype) {
     _pdfVars->add(*prototype->get()) ;

--- a/roofit/roofitcore/src/RooCustomizer.cxx
+++ b/roofit/roofitcore/src/RooCustomizer.cxx
@@ -501,7 +501,7 @@ RooAbsArg* RooCustomizer::doBuild(const char* masterCatState, bool verbose)
    // Add to one-time use list and life-time use list
    clonedMasterNodes.add(*clone) ;
    if (_owning) {
-     _cloneNodeListOwned->addOwned(*clone) ;
+     _cloneNodeListOwned->addOwned(std::unique_ptr<RooAbsArg>{clone});
    } else {
      _cloneNodeListOwned->add(*clone) ;
    }

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -1300,10 +1300,11 @@ void RooDataSet::append(RooDataSet& data)
 RooAbsArg* RooDataSet::addColumn(RooAbsArg& var, bool adjustRange)
 {
   checkInit() ;
-  RooAbsArg* ret = _dstore->addColumn(var,adjustRange) ;
-  _vars.addOwned(*ret) ;
+  std::unique_ptr<RooAbsArg> ret{_dstore->addColumn(var,adjustRange)};
+  RooAbsArg* retPtr = ret.get();
+  _vars.addOwned(std::move(ret));
   initialize(_wgtVar?_wgtVar->GetName():0) ;
-  return ret ;
+  return retPtr;
 }
 
 

--- a/roofit/roofitcore/src/RooFitResult.cxx
+++ b/roofit/roofitcore/src/RooFitResult.cxx
@@ -638,7 +638,7 @@ void RooFitResult::fillLegacyCorrMatrix() const
     gcName.Append("]") ;
     TString gcTitle(arg->GetTitle()) ;
     gcTitle.Append(" Global Correlation") ;
-    _globalCorr->addOwned(*(new RooRealVar(gcName.Data(),gcTitle.Data(),0.))) ;
+    _globalCorr->addOwned(std::make_unique<RooRealVar>(gcName.Data(),gcTitle.Data(),0.));
 
     // Create array with correlation holders for this parameter
     TString name("C[") ;
@@ -657,7 +657,7 @@ void RooFitResult::fillLegacyCorrMatrix() const
       cTitle.Append(arg->GetName()) ;
       cTitle.Append(" and ") ;
       cTitle.Append(arg2->GetName()) ;
-      corrMatrixRow->addOwned(*(new RooRealVar(cName.Data(),cTitle.Data(),0.))) ;
+      corrMatrixRow->addOwned(std::make_unique<RooRealVar>(cName.Data(),cTitle.Data(),0.));
     }
   }
 
@@ -945,18 +945,18 @@ RooFitResult* RooFitResult::lastMinuitFit(const RooArgList& varList)
     double xerr = gMinuit->fWerr[l-1];
     double xval = gMinuit->fU[i-1] ;
 
-    RooRealVar* var ;
+    std::unique_ptr<RooRealVar> var;
     if (varList.empty()) {
 
       if ((xlo<xhi) && !isConst) {
-   var = new RooRealVar(varName,varName,xval,xlo,xhi) ;
+        var = std::make_unique<RooRealVar>(varName,varName,xval,xlo,xhi) ;
       } else {
-   var = new RooRealVar(varName,varName,xval) ;
+        var = std::make_unique<RooRealVar>(varName,varName,xval) ;
       }
       var->setConstant(isConst) ;
     } else {
 
-      var = (RooRealVar*) varList.at(i-1)->Clone() ;
+      var = std::unique_ptr<RooRealVar>{static_cast<RooRealVar*>(varList.at(i-1)->Clone())};
       var->setConstant(isConst) ;
       var->setVal(xval) ;
       if (xlo<xhi) {
@@ -970,10 +970,10 @@ RooFitResult* RooFitResult::lastMinuitFit(const RooArgList& varList)
     }
 
     if (isConst) {
-      constPars.addOwned(*var) ;
+      constPars.addOwned(std::move(var));
     } else {
       var->setError(xerr) ;
-      floatPars.addOwned(*var) ;
+      floatPars.addOwned(std::move(var));
     }
   }
 

--- a/roofit/roofitcore/src/RooGenProdProj.cxx
+++ b/roofit/roofitcore/src/RooGenProdProj.cxx
@@ -172,7 +172,7 @@ RooAbsReal* RooGenProdProj::makeIntegral(const char* name, const RooArgSet& comp
       Int_t code = pdf->getAnalyticalIntegralWN(anaIntSet,anaSet,0,isetRangeName) ;
       if (code!=0) {
         // Analytical integral, create integral object
-        RooAbsReal* pai = pdf->createIntegral(anaSet,emptyNormSet,isetRangeName) ;
+        std::unique_ptr<RooAbsReal> pai{pdf->createIntegral(anaSet,emptyNormSet,isetRangeName)};
         pai->setOperMode(_operMode) ;
 
         // Add to integral to product
@@ -182,7 +182,7 @@ RooAbsReal* RooGenProdProj::makeIntegral(const char* name, const RooArgSet& comp
         numIntSet.remove(anaSet) ;
 
         // Declare ownership of integral
-        saveSet.addOwned(*pai) ;
+        saveSet.addOwned(std::move(pai));
       } else {
         // Analytic integration of factorizable observable not possible, add straight pdf to product
         prodSet.add(*pdf) ;

--- a/roofit/roofitcore/src/RooMultiVarGaussian.cxx
+++ b/roofit/roofitcore/src/RooMultiVarGaussian.cxx
@@ -80,9 +80,9 @@ RooMultiVarGaussian::RooMultiVarGaussian(const char *name, const char *title,
   const RooArgList& fpf = fr.floatParsFinal() ;
   for (Int_t i=0 ; i<fpf.getSize() ; i++) {
     if (xvec.find(fpf.at(i)->GetName())) {
-      RooRealVar* parclone = (RooRealVar*) fpf.at(i)->Clone(Form("%s_centralvalue",fpf.at(i)->GetName())) ;
+      std::unique_ptr<RooRealVar> parclone{static_cast<RooRealVar*>(fpf.at(i)->Clone(Form("%s_centralvalue",fpf.at(i)->GetName())))};
       parclone->setConstant(true) ;
-      _mu.addOwned(*parclone) ;
+      _mu.addOwned(std::move(parclone));
       munames.push_back(fpf.at(i)->GetName()) ;
     }
   }

--- a/roofit/roofitcore/src/RooPolyFunc.cxx
+++ b/roofit/roofitcore/src/RooPolyFunc.cxx
@@ -47,17 +47,17 @@ void RooPolyFunc::addTerm(double coefficient)
    std::string coeff_name = Form("%s_c%d", GetName(), n_terms);
    std::string term_name = Form("%s_t%d", GetName(), n_terms);
    auto termList = std::make_unique<RooListProxy>(term_name.c_str(), term_name.c_str(), this);
-   auto coeff = new RooRealVar(coeff_name.c_str(), coeff_name.c_str(), coefficient);
-   auto exponents = new RooArgList();
+   auto coeff = std::make_unique<RooRealVar>(coeff_name.c_str(), coeff_name.c_str(), coefficient);
+   RooArgList exponents{};
 
    for (const auto &var : _vars) {
       std::string exponent_name = Form("%s_%s^%d", GetName(), var->GetName(), 0);
-      auto exponent = new RooRealVar(exponent_name.c_str(), exponent_name.c_str(), 0);
-      exponents->add(*exponent);
+      auto exponent = std::make_unique<RooRealVar>(exponent_name.c_str(), exponent_name.c_str(), 0);
+      exponents.addOwned(std::move(exponent));
    }
 
-   termList->addOwned(*exponents);
-   termList->addOwned(*coeff);
+   termList->addOwned(std::move(exponents));
+   termList->addOwned(std::move(coeff));
    _terms.push_back(std::move(termList));
 }
 
@@ -67,8 +67,8 @@ void RooPolyFunc::addTerm(double coefficient, const RooAbsReal &var1, int exp1)
    std::string coeff_name = Form("%s_c%d", GetName(), n_terms);
    std::string term_name = Form("%s_t%d", GetName(), n_terms);
    auto termList = std::make_unique<RooListProxy>(term_name.c_str(), term_name.c_str(), this);
-   auto coeff = new RooRealVar(coeff_name.c_str(), coeff_name.c_str(), coefficient);
-   auto exponents = new RooArgList();
+   auto coeff = std::make_unique<RooRealVar>(coeff_name.c_str(), coeff_name.c_str(), coefficient);
+   RooArgList exponents{};
 
    // linear iterate over all the variables, create var1^exp1 ..vark^0
    for (const auto &var : _vars) {
@@ -76,12 +76,12 @@ void RooPolyFunc::addTerm(double coefficient, const RooAbsReal &var1, int exp1)
       if (strcmp(var1.GetName(), var->GetName()) == 0)
          exp += exp1;
       std::string exponent_name = Form("%s_%s^%d", GetName(), var->GetName(), exp);
-      auto exponent = new RooRealVar(exponent_name.c_str(), exponent_name.c_str(), exp);
-      exponents->add(*exponent);
+      auto exponent = std::make_unique<RooRealVar>(exponent_name.c_str(), exponent_name.c_str(), exp);
+      exponents.addOwned(std::move(exponent));
    }
 
-   termList->addOwned(*exponents);
-   termList->addOwned(*coeff);
+   termList->addOwned(std::move(exponents));
+   termList->addOwned(std::move(coeff));
    _terms.push_back(std::move(termList));
 }
 
@@ -92,8 +92,8 @@ void RooPolyFunc::addTerm(double coefficient, const RooAbsReal &var1, int exp1, 
    std::string coeff_name = Form("%s_c%d", GetName(), n_terms);
    std::string term_name = Form("%s_t%d", GetName(), n_terms);
    auto termList = std::make_unique<RooListProxy>(term_name.c_str(), term_name.c_str(), this);
-   auto coeff = new RooRealVar(coeff_name.c_str(), coeff_name.c_str(), coefficient);
-   auto exponents = new RooArgList();
+   auto coeff = std::make_unique<RooRealVar>(coeff_name.c_str(), coeff_name.c_str(), coefficient);
+   RooArgList exponents{};
 
    for (const auto &var : _vars) {
       int exp = 0;
@@ -102,11 +102,11 @@ void RooPolyFunc::addTerm(double coefficient, const RooAbsReal &var1, int exp1, 
       if (strcmp(var2.GetName(), var->GetName()) == 0)
          exp += exp2;
       std::string exponent_name = Form("%s_%s^%d", GetName(), var->GetName(), exp);
-      auto exponent = new RooRealVar(exponent_name.c_str(), exponent_name.c_str(), exp);
-      exponents->add(*exponent);
+      auto exponent = std::make_unique<RooRealVar>(exponent_name.c_str(), exponent_name.c_str(), exp);
+      exponents.addOwned(std::move(exponent));
    }
-   termList->addOwned(*exponents);
-   termList->addOwned(*coeff);
+   termList->addOwned(std::move(exponents));
+   termList->addOwned(std::move(coeff));
    _terms.push_back(std::move(termList));
 }
 
@@ -121,9 +121,9 @@ void RooPolyFunc::addTerm(double coefficient, const RooAbsCollection &exponents)
    std::string coeff_name = Form("%s_c%d", GetName(), n_terms);
    std::string term_name = Form("%s_t%d", GetName(), n_terms);
    auto termList = std::make_unique<RooListProxy>(term_name.c_str(), term_name.c_str(), this);
-   auto coeff = new RooRealVar(coeff_name.c_str(), coeff_name.c_str(), coefficient);
+   auto coeff = std::make_unique<RooRealVar>(coeff_name.c_str(), coeff_name.c_str(), coefficient);
    termList->addOwned(exponents);
-   termList->addOwned(*coeff);
+   termList->addOwned(std::move(coeff));
    _terms.push_back(std::move(termList));
 }
 

--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -839,16 +839,13 @@ std::unique_ptr<RooProdPdf::CacheElem> RooProdPdf::createCacheElem(const RooArgS
         vector<RooAbsReal*> func = processProductTerm(nset, iset, isetRangeName, term, termNSet, termISet, isOwned);
         if (func[0]) {
           cache->_partList.add(*func[0]);
-          if (isOwned) cache->_ownedList.addOwned(*func[0]);
+          if (isOwned) cache->_ownedList.addOwned(std::unique_ptr<RooAbsArg>{func[0]});
 
           cache->_normList.emplace_back(std::make_unique<RooArgSet>());
           norm->snapshot(*cache->_normList.back(), false);
 
-          cache->_numList.addOwned(*func[1]);
-          cache->_denList.addOwned(*func[2]);
-//          cout << "func[0]=" << func[0]->ClassName() << "::" << func[0]->GetName() << endl;
-//          cout << "func[1]=" << func[1]->ClassName() << "::" << func[1]->GetName() << endl;
-//          cout << "func[2]=" << func[2]->ClassName() << "::" << func[2]->GetName() << endl;
+          cache->_numList.addOwned(std::unique_ptr<RooAbsArg>{func[1]});
+          cache->_denList.addOwned(std::unique_ptr<RooAbsArg>{func[2]});
         }
       } else {
 //        cout << "processing composite item" << endl;
@@ -875,7 +872,7 @@ std::unique_ptr<RooProdPdf::CacheElem> RooProdPdf::createCacheElem(const RooArgS
 //       cout << GetName() << ": created composite term component " << func[0]->GetName() << endl;
    if (func[0]) {
      compTermSet.add(*func[0]);
-     if (isOwned) cache->_ownedList.addOwned(*func[0]);
+     if (isOwned) cache->_ownedList.addOwned(std::unique_ptr<RooAbsArg>{func[0]});
      compTermNorm.add(*norm, false);
 
      compTermNum.add(*func[1]);
@@ -927,7 +924,7 @@ std::unique_ptr<RooProdPdf::CacheElem> RooProdPdf::createCacheElem(const RooArgS
       cache->_ownedList.addOwned(std::move(prodtmp_num));
       cache->_ownedList.addOwned(std::move(prodtmp_den));
       cache->_numList.addOwned(std::move(numtmp));
-      cache->_denList.addOwned(*(RooAbsArg*)RooFit::RooConst(1).clone("1"));
+      cache->_denList.addOwned(std::unique_ptr<RooAbsArg>{static_cast<RooAbsArg*>(RooFit::RooConst(1).clone("1"))});
       cache->_normList.emplace_back(std::make_unique<RooArgSet>());
       compTermNorm.snapshot(*cache->_normList.back(), false);
     }

--- a/roofit/roofitcore/src/RooRandomizeParamMCSModule.cxx
+++ b/roofit/roofitcore/src/RooRandomizeParamMCSModule.cxx
@@ -244,10 +244,9 @@ bool RooRandomizeParamMCSModule::initializeInstance()
     uiter->_param = actualPar ;
 
     // Add variable to summary dataset to hold generator value
-    TString parName = Form("%s_gen",uiter->_param->GetName()) ;
-    TString parTitle = Form("%s as generated",uiter->_param->GetTitle()) ;
-    RooRealVar* par_gen = new RooRealVar(parName.Data(),parTitle.Data(),0) ;
-    _genParSet.addOwned(*par_gen) ;
+    std::string parName = std::string(uiter->_param->GetName()) + "_gen";
+    std::string parTitle = std::string(uiter->_param->GetTitle()) + " as generated";
+    _genParSet.addOwned(std::make_unique<RooRealVar>(parName.c_str(),parTitle.c_str(),0));
   }
 
   // Loop over all gaussian smearing parameters
@@ -264,10 +263,9 @@ bool RooRandomizeParamMCSModule::initializeInstance()
     giter->_param = actualPar ;
 
     // Add variable to summary dataset to hold generator value
-    TString parName = Form("%s_gen",giter->_param->GetName()) ;
-    TString parTitle = Form("%s as generated",giter->_param->GetTitle()) ;
-    RooRealVar* par_gen = new RooRealVar(parName.Data(),parTitle.Data(),0) ;
-    _genParSet.addOwned(*par_gen) ;
+    std::string parName = std::string(giter->_param->GetName()) + "_gen";
+    std::string parTitle = std::string(giter->_param->GetTitle()) + " as generated";
+    _genParSet.addOwned(std::make_unique<RooRealVar>(parName.c_str(),parTitle.c_str(),0));
   }
 
 
@@ -290,10 +288,9 @@ bool RooRandomizeParamMCSModule::initializeInstance()
 
     // Add variables to summary dataset to hold generator values
     for(auto * param : static_range_cast<RooRealVar*>(usiter->_pset)) {
-      TString parName = Form("%s_gen",param->GetName()) ;
-      TString parTitle = Form("%s as generated",param->GetTitle()) ;
-      RooRealVar* par_gen = new RooRealVar(parName.Data(),parTitle.Data(),0) ;
-      _genParSet.addOwned(*par_gen) ;
+      std::string parName = std::string(param->GetName()) + "_gen";
+      std::string parTitle = std::string(param->GetTitle()) + " as generated";
+      _genParSet.addOwned(std::make_unique<RooRealVar>(parName.c_str(),parTitle.c_str(),0));
     }
   }
 
@@ -317,10 +314,9 @@ bool RooRandomizeParamMCSModule::initializeInstance()
 
     // Add variables to summary dataset to hold generator values
     for(auto * param : static_range_cast<RooRealVar*>(ugiter->_pset)) {
-      TString parName = Form("%s_gen",param->GetName()) ;
-      TString parTitle = Form("%s as generated",param->GetTitle()) ;
-      RooRealVar* par_gen = new RooRealVar(parName.Data(),parTitle.Data(),0) ;
-      _genParSet.addOwned(*par_gen) ;
+      std::string parName = std::string(param->GetName()) + "_gen";
+      std::string parTitle = std::string(param->GetTitle()) + " as generated";
+      _genParSet.addOwned(std::make_unique<RooRealVar>(parName.c_str(),parTitle.c_str(),0));
     }
   }
 

--- a/roofit/roofitcore/src/RooRealBinding.cxx
+++ b/roofit/roofitcore/src/RooRealBinding.cxx
@@ -53,7 +53,7 @@ ClassImp(RooRealBinding);
 /// range.
 
 RooRealBinding::RooRealBinding(const RooAbsReal& func, const RooArgSet &vars, const RooArgSet* nset, bool clipInvalid, const TNamed* rangeName) :
-  RooAbsFunc(vars.getSize()), _func(&func), _vars(), _nset(nset), _clipInvalid(clipInvalid), _xsave(0), _rangeName(rangeName), _funcSave(0)
+  RooAbsFunc(vars.getSize()), _func(&func), _vars(), _nset(nset), _clipInvalid(clipInvalid), _rangeName(rangeName), _funcSave(0)
 {
   // check that all of the arguments are real valued and store them
   for (unsigned int index=0; index < vars.size(); ++index) {
@@ -86,20 +86,13 @@ RooRealBinding::RooRealBinding(const RooAbsReal& func, const RooArgSet &vars, co
 
 RooRealBinding::RooRealBinding(const RooRealBinding& other, const RooArgSet* nset) :
   RooAbsFunc(other), _func(other._func), _vars(other._vars), _nset(nset?nset:other._nset), _xvecValid(other._xvecValid),
-  _clipInvalid(other._clipInvalid), _xsave(0), _rangeName(other._rangeName), _funcSave(other._funcSave)
+  _clipInvalid(other._clipInvalid), _rangeName(other._rangeName), _funcSave(other._funcSave)
 {
 
 }
 
 
-////////////////////////////////////////////////////////////////////////////////
-/// Destructor
-
-RooRealBinding::~RooRealBinding()
-{
-  if (_xsave) delete[] _xsave ;
-}
-
+RooRealBinding::~RooRealBinding() = default;
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -107,16 +100,15 @@ RooRealBinding::~RooRealBinding()
 
 void RooRealBinding::saveXVec() const
 {
-  if (!_xsave) {
-    _xsave = new double[getDimension()] ;
-    RooArgSet* comps = _func->getComponents() ;
+  if (_xsave.empty()) {
+    _xsave.resize(getDimension());
+    std::unique_ptr<RooArgSet> comps{_func->getComponents()};
     for (auto* arg : dynamic_range_cast<RooAbsArg*>(*comps)) {
       if (arg) {
         _compList.push_back(static_cast<RooAbsReal*>(arg)) ;
-        _compSave.push_back(0) ;
+        _compSave.push_back(0.0) ;
       }
     }
-    delete comps ;
   }
   _funcSave = _func->_value ;
 
@@ -140,7 +132,7 @@ void RooRealBinding::saveXVec() const
 
 void RooRealBinding::restoreXVec() const
 {
-  if (!_xsave) {
+  if (_xsave.empty()) {
     return ;
   }
   _func->_value = _funcSave ;

--- a/roofit/roofitcore/src/RooRealConstant.cxx
+++ b/roofit/roofitcore/src/RooRealConstant.cxx
@@ -59,11 +59,12 @@ RooConstVar& RooRealConstant::value(double value)
   std::ostringstream s ;
   s << value ;
 
-  auto var = new RooConstVar(s.str().c_str(),s.str().c_str(),value) ;
+  auto var = std::make_unique<RooConstVar>(s.str().c_str(),s.str().c_str(),value);
   var->setAttribute("RooRealConstant_Factory_Object",true) ;
-  constDB().addOwned(*var) ;
+  RooConstVar &varRef = *var;
+  constDB().addOwned(std::move(var));
 
-  return *var ;
+  return varRef;
 }
 
 
@@ -72,12 +73,13 @@ RooConstVar& RooRealConstant::value(double value)
 
 RooConstVar& RooRealConstant::removalDummy()
 {
-  RooConstVar* var = new RooConstVar("REMOVAL_DUMMY","REMOVAL_DUMMY",1) ;
+  auto var = std::make_unique<RooConstVar>("REMOVAL_DUMMY","REMOVAL_DUMMY",1) ;
   var->setAttribute("RooRealConstant_Factory_Object",true) ;
   var->setAttribute("REMOVAL_DUMMY") ;
-  constDB().addOwned(*var) ;
+  RooConstVar &varRef = *var;
+  constDB().addOwned(std::move(var));
 
-  return *var ;
+  return varRef;
 }
 
 

--- a/roofit/roofitcore/src/RooRealIntegral.cxx
+++ b/roofit/roofitcore/src/RooRealIntegral.cxx
@@ -318,10 +318,10 @@ RooRealIntegral::RooRealIntegral(const char *name, const char *title,
       _valid= false;
     }
     if (!function.dependsOn(*arg)) {
-      RooAbsArg* argClone = (RooAbsArg*) arg->Clone() ;
-      _facListOwned.addOwned(*argClone) ;
+      std::unique_ptr<RooAbsArg> argClone{static_cast<RooAbsArg*>(arg->Clone())};
       _facList.add(*argClone) ;
       addServer(*argClone,false,true) ;
+      _facListOwned.addOwned(std::move(argClone));
     }
   }
 
@@ -748,10 +748,10 @@ RooRealIntegral::RooRealIntegral(const RooRealIntegral& other, const char* name)
  }
 
  for (const auto arg : other._facList) {
-   RooAbsArg* argClone = (RooAbsArg*) arg->Clone() ;
-   _facListOwned.addOwned(*argClone) ;
+   std::unique_ptr<RooAbsArg> argClone{static_cast<RooAbsArg*>(arg->Clone())};
    _facList.add(*argClone) ;
    addServer(*argClone,false,true) ;
+   _facListOwned.addOwned(std::move(argClone));
  }
 
  other._intList.snapshot(_saveInt) ;

--- a/roofit/roofitcore/src/RooRealSumPdf.cxx
+++ b/roofit/roofitcore/src/RooRealSumPdf.cxx
@@ -460,12 +460,11 @@ Int_t RooRealSumPdf::getAnalyticalIntegralWN(RooAbsReal const& caller, RooObjCac
   for (const auto elm : funcList) {
     const auto func = static_cast<RooAbsReal*>(elm);
 
-    RooAbsReal* funcInt = func->createIntegral(analVars,rangeName) ;
-    if(funcInt->InheritsFrom(RooRealIntegral::Class())) ((RooRealIntegral*)funcInt)->setAllowComponentSelection(true);
-    cache->_funcIntList.addOwned(*funcInt) ;
+    std::unique_ptr<RooAbsReal> funcInt{func->createIntegral(analVars,rangeName)};
+    if(auto funcRealInt = dynamic_cast<RooRealIntegral*>(funcInt.get())) funcRealInt->setAllowComponentSelection(true);
+    cache->_funcIntList.addOwned(std::move(funcInt));
     if (normSet && !normSet->empty()) {
-      RooAbsReal* funcNorm = func->createIntegral(*normSet) ;
-      cache->_funcNormList.addOwned(*funcNorm) ;
+      cache->_funcNormList.addOwned(std::unique_ptr<RooAbsReal>{func->createIntegral(*normSet)});
     }
   }
 

--- a/roofit/roofitcore/src/RooSimultaneous.cxx
+++ b/roofit/roofitcore/src/RooSimultaneous.cxx
@@ -541,8 +541,7 @@ Int_t RooSimultaneous::getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& an
 
   // Create the partial integral set for this request
   for(auto * proxy : static_range_cast<RooRealProxy*>(_pdfProxyList)) {
-    RooAbsReal* pdfInt = proxy->arg().createIntegral(analVars,normSet,0,rangeName) ;
-    cache->_partIntList.addOwned(*pdfInt) ;
+    cache->_partIntList.addOwned(std::unique_ptr<RooAbsReal>{proxy->arg().createIntegral(analVars,normSet,0,rangeName)});
   }
 
   // Store the partial integral list and return the assigned code ;

--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -674,7 +674,7 @@ bool RooWorkspace::import(const RooAbsArg& inArg,
       recycledNodes.add(*_allOwnedNodes.find(node->GetName())) ;
 
       // Delete clone of incoming node
-      nodesToBeDeleted.addOwned(*node) ;
+      nodesToBeDeleted.addOwned(std::unique_ptr<RooAbsArg>{node});
 
       //cout << "WV: recycling existing node " << existingNode << " = " << existingNode->GetName() << " for imported node " << node << endl ;
 
@@ -684,7 +684,7 @@ bool RooWorkspace::import(const RooAbsArg& inArg,
         coutI(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") importing " << node->ClassName() << "::"
             << node->GetName() << endl ;
       }
-      _allOwnedNodes.addOwned(*node) ;
+      _allOwnedNodes.addOwned(std::unique_ptr<RooAbsArg>{node});
       if (_openTrans) {
         _sandboxNodes.add(*node) ;
       } else {

--- a/roofit/roofitcore/test/testRooAbsCollection.cxx
+++ b/roofit/roofitcore/test/testRooAbsCollection.cxx
@@ -80,13 +80,13 @@ TEST(RooArgSet, InsertAndDeduplicate) {
   RooArgList list2;
   for (unsigned int i = 0; i < 4; ++i) {
     char name[] = {char('a'+i), '\0'};
-    list.addOwned(*(new RooRealVar(name, name, 0.)));
+    list.addOwned(std::make_unique<RooRealVar>(name, name, 0.));
   }
   for (unsigned int i = 0; i < 5; ++i) {
     char name[] = {char('a'+i), '\0'};
-    list2.addOwned(*(new RooRealVar(name, name, 0.)));
+    list2.addOwned(std::make_unique<RooRealVar>(name, name, 0.));
     name[0] = char('a'+ 4 - i);
-    list2.addOwned(*(new RooRealVar(name, name, 0.)));
+    list2.addOwned(std::make_unique<RooRealVar>(name, name, 0.));
   }
 
   // Silence deduplication error messages
@@ -112,13 +112,13 @@ TEST(RooArgSet, HashAssistedFind) {
   RooArgList list2;
   for (unsigned int i = 0; i < 4; ++i) {
     char name[] = {char('a'+i), '\0'};
-    list.addOwned(*(new RooRealVar(name, name, 0.)));
+    list.addOwned(std::make_unique<RooRealVar>(name, name, 0.));
   }
   for (unsigned int i = 0; i < 5; ++i) {
     char name[] = {char('a'+i), '\0'};
-    list2.addOwned(*(new RooRealVar(name, name, 0.)));
+    list2.addOwned(std::make_unique<RooRealVar>(name, name, 0.));
     name[0] = char('a'+ 4 - i);
-    list2.addOwned(*(new RooRealVar(name, name, 0.)));
+    list2.addOwned(std::make_unique<RooRealVar>(name, name, 0.));
   }
 
   // Silence deduplication error messages

--- a/roofit/roostats/src/DetailedOutputAggregator.cxx
+++ b/roofit/roostats/src/DetailedOutputAggregator.cxx
@@ -99,17 +99,17 @@ namespace RooStats {
          TString renamed(TString::Format("%s%s", prefix.Data(), v->GetName()));
          if (fResult == nullptr) {
             // we never committed, so by default all columns are expected to not exist
-            RooAbsArg* var = v->createFundamental();
+            std::unique_ptr<RooAbsArg> var{v->createFundamental()};
             assert(var != nullptr);
             RooArgSet(*var).assign(RooArgSet(*v));
             var->SetName(renamed);
-            if (RooRealVar* rvar= dynamic_cast<RooRealVar*>(var)) {
+            if (RooRealVar* rvar= dynamic_cast<RooRealVar*>(var.get())) {
                if (v->getAttribute("StoreError"))     var->setAttribute("StoreError");
                else rvar->removeError();
                if (v->getAttribute("StoreAsymError")) var->setAttribute("StoreAsymError");
                else rvar->removeAsymError();
             }
-            if (fBuiltSet->addOwned(*var)) continue;  // OK - can skip past setting value
+            if (fBuiltSet->addOwned(std::move(var))) continue;  // OK - can skip past setting value
          }
          if (RooAbsArg* var = fBuiltSet->find(renamed)) {
             // we already committed an argset once, so we expect all columns to already be in the set

--- a/roofit/roostats/src/HypoTestInverterResult.cxx
+++ b/roofit/roostats/src/HypoTestInverterResult.cxx
@@ -172,7 +172,7 @@ HypoTestInverterResult::HypoTestInverterResult( const char* name,
    // make the set owning the cloned copy (use clone instead of Clone to not copying all links)
    fParameters.removeAll();
    fParameters.takeOwnership();
-   fParameters.addOwned(*((RooRealVar *) scannedVariable.clone(scannedVariable.GetName()) ));
+   fParameters.addOwned(std::unique_ptr<RooRealVar>{static_cast<RooRealVar *>(scannedVariable.clone(scannedVariable.GetName()))});
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roostats/src/RatioOfProfiledLikelihoodsTestStat.cxx
+++ b/roofit/roostats/src/RatioOfProfiledLikelihoodsTestStat.cxx
@@ -103,14 +103,14 @@ double  RooStats::RatioOfProfiledLikelihoodsTestStat::Evaluate(RooAbsData& data,
    if (fDetailedOutputEnabled) {
       fDetailedOutput = new RooArgSet();
       for (auto const *var : static_range_cast<RooRealVar *>(*nullset)) {
-         RooRealVar* cloneVar = new RooRealVar(TString::Format("nullprof_%s", var->GetName()),
+         auto cloneVar = std::make_unique<RooRealVar>(TString::Format("nullprof_%s", var->GetName()),
                                                TString::Format("%s for null", var->GetTitle()), var->getVal());
-         fDetailedOutput->addOwned(*cloneVar);
+         fDetailedOutput->addOwned(std::move(cloneVar));
       }
       for (auto const *var : static_range_cast<RooRealVar *>(*altset)) {
-         RooRealVar* cloneVar = new RooRealVar(TString::Format("altprof_%s", var->GetName()),
+         auto cloneVar = std::make_unique<RooRealVar>(TString::Format("altprof_%s", var->GetName()),
                                                TString::Format("%s for null", var->GetTitle()), var->getVal());
-         fDetailedOutput->addOwned(*cloneVar);
+         fDetailedOutput->addOwned(std::move(cloneVar));
       }
    }
 


### PR DESCRIPTION
This good practice to have the memory management handled automatically.

A few memory leaks were also found and fixed like this.

Also, use the `RooFit::OwningPtr<>` for `RooAbsArg::getComponents()`.