### PR TITLE
[cling] Fix remaining test failures

### DIFF
--- a/interpreter/cling/lib/Interpreter/DeclExtractor.cpp
+++ b/interpreter/cling/lib/Interpreter/DeclExtractor.cpp
@@ -262,9 +262,8 @@ namespace cling {
       IntegerLiteral* ZeroLit
         = IntegerLiteral::Create(*m_Context, ZeroInt, m_Context->IntTy,
                                  SourceLocation());
-      Stmts.push_back(m_Sema->ActOnReturnStmt(ZeroLit->getExprLoc(),
-                                              ZeroLit,
-                                              m_Sema->getCurScope()).get());
+      Stmts.push_back(
+          m_Sema->BuildReturnStmt(ZeroLit->getExprLoc(), ZeroLit).get());
     }
 
     // Wrap Stmts into a function body.

--- a/interpreter/cling/lib/Interpreter/IncrementalExecutor.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalExecutor.cpp
@@ -36,7 +36,7 @@ namespace cling {
 IncrementalExecutor::IncrementalExecutor(clang::DiagnosticsEngine& /*diags*/,
                                          const clang::CompilerInstance& CI,
                                          void *ExtraLibHandle, bool Verbose):
-  m_Callbacks(nullptr), m_externalIncrementalExecutor(nullptr)
+  m_Callbacks(nullptr)
 #if 0
   : m_Diags(diags)
 #endif
@@ -59,6 +59,11 @@ IncrementalExecutor::IncrementalExecutor(clang::DiagnosticsEngine& /*diags*/,
 }
 
 IncrementalExecutor::~IncrementalExecutor() {}
+
+void IncrementalExecutor::registerExternalIncrementalExecutor(
+    IncrementalExecutor& IE) {
+  m_JIT->addGenerator(IE.m_JIT->getGenerator());
+}
 
 void IncrementalExecutor::runAtExitFuncs() {
   // It is legal to register an atexit handler from within another atexit

--- a/interpreter/cling/lib/Interpreter/IncrementalExecutor.h
+++ b/interpreter/cling/lib/Interpreter/IncrementalExecutor.h
@@ -64,10 +64,6 @@ namespace cling {
     ///\brief Whom to call upon invocation of user code.
     InterpreterCallbacks* m_Callbacks;
 
-    ///\brief A pointer to the IncrementalExecutor of the parent Interpreter.
-    ///
-    IncrementalExecutor* m_externalIncrementalExecutor;
-
     ///\brief Helper that manages when the destructor of an object to be called.
     ///
     /// The object is registered first as an CXAAtExitElement and then cling
@@ -151,9 +147,11 @@ namespace cling {
 
     ~IncrementalExecutor();
 
-    void setExternalIncrementalExecutor(IncrementalExecutor *extIncrExec) {
-      m_externalIncrementalExecutor = extIncrExec;
-    }
+    /// Register a different `IncrementalExecutor` object that can provide
+    /// addresses for external symbols.  This is used by child interpreters to
+    /// lookup symbols defined in the parent.
+    void registerExternalIncrementalExecutor(IncrementalExecutor& IE);
+
     void setCallbacks(InterpreterCallbacks* callbacks);
 
     const DynamicLibraryManager& getDynamicLibraryManager() const {

--- a/interpreter/cling/lib/Interpreter/IncrementalJIT.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalJIT.cpp
@@ -403,6 +403,33 @@ Error RTDynamicLibrarySearchGenerator::tryToGenerate(
   return JD.define(absoluteSymbols(std::move(NewSymbols)), CurrentRT());
 }
 
+/// A definition generator that calls a user-provided function that is
+/// responsible for providing symbol addresses.
+/// This is used by `IncrementalJIT::getGenerator()` to yield a generator that
+/// resolves symbols defined in the IncrementalJIT object on which the function
+/// is called, which in turn may be used to provide lookup across different
+/// IncrementalJIT instances.
+class DelegateGenerator : public DefinitionGenerator {
+  using LookupFunc = std::function<Expected<JITEvaluatedSymbol>(StringRef)>;
+  LookupFunc lookup;
+
+public:
+  DelegateGenerator(LookupFunc lookup) : lookup(lookup) {}
+
+  Error tryToGenerate(LookupState& LS, LookupKind K, JITDylib& JD,
+                      JITDylibLookupFlags JDLookupFlags,
+                      const SymbolLookupSet& LookupSet) override {
+    SymbolMap Symbols;
+    for (auto& KV : LookupSet) {
+      if (auto Addr = lookup(*KV.first))
+        Symbols[KV.first] = Addr.get();
+    }
+    if (Symbols.empty())
+      return Error::success();
+    return JD.define(absoluteSymbols(std::move(Symbols)));
+  }
+};
+
 static bool UseJITLink(const Triple& TT) {
   bool jitLink = false;
   // Default to JITLink on macOS and RISC-V, as done in (recent) LLVM by
@@ -601,6 +628,11 @@ IncrementalJIT::IncrementalJIT(
     logAllUnhandledErrors(std::move(Err), errs(), "cling JIT session error: ");
   };
   Jit->getExecutionSession().setErrorReporter(ErrorReporter);
+}
+
+std::unique_ptr<llvm::orc::DefinitionGenerator> IncrementalJIT::getGenerator() {
+  return std::make_unique<DelegateGenerator>(
+      [&](StringRef UnmangledName) { return Jit->lookup(UnmangledName); });
 }
 
 void IncrementalJIT::addModule(Transaction& T) {

--- a/interpreter/cling/lib/Interpreter/IncrementalJIT.h
+++ b/interpreter/cling/lib/Interpreter/IncrementalJIT.h
@@ -66,6 +66,12 @@ public:
     Jit->getMainJITDylib().addGenerator(std::move(G));
   }
 
+  /// Return a `DefinitionGenerator` that can provide addresses for symbols
+  /// reachable from this IncrementalJIT object.  This function can be used in
+  /// conjunction with `addGenerator()` to provide symbol resolution across
+  /// diferent IncrementalJIT instances.
+  std::unique_ptr<llvm::orc::DefinitionGenerator> getGenerator();
+
   // FIXME: Accept a LLVMContext as well, e.g. the one that was used for the
   // particular module in Interpreter, CIFactory or BackendPasses (would be
   // more efficient)

--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -372,7 +372,8 @@ namespace cling {
 
       // Give my IncrementalExecutor a pointer to the Incremental executor of the
       // parent Interpreter.
-      m_Executor->setExternalIncrementalExecutor(parentInterpreter.m_Executor.get());
+      m_Executor->registerExternalIncrementalExecutor(
+          *parentInterpreter.m_Executor);
 
       if (auto C = parentInterpreter.m_IncrParser->getDiagnosticConsumer())
         m_IncrParser->setDiagnosticConsumer(C, /*Own=*/false);


### PR DESCRIPTION
This pull request fixes the remaining failing cling tests.  See below for the concrete changes.

@vgvassilev After the changes proposed in this PR, _all_ the cling tests are passing.

## Changes or fixes:
- Restore symbol lookup in child interpreters: prior to the upgrade to LLVM13, child interpreters used to also lookup symbols
in their parent.  This PR introduces a `DefinitionGenerator` that allows for symbol lookup across different `IncrementalJIT` instances, which restores the old behavior.
This change fixes the following tests: CodeUnloading/AtExit.C, MultipleInterpreters/MultipleInterpreters.C.
- `cling::DeclExtractor::EnforceInitOrder`: do not use `ActOnReturnStmt()`, given that the scope returned by `m_Sema->getCurScope()` might be == m_Sema->TUScope which obviously is not a function scope; use `BuildReturnStmt()` instead.
This fixes the following crash:
```
1:  https://github.com/root-project/root/pull/3 0x0000556b6a50389e clang::Sema::ActOnReturnStmt(clang::SourceLocation, clang::Expr*, clang::Scope*) (/home/jalopezg/CERN/repos/root/_build/interpreter/llvm/src/bin/cling+0x225389e)
1:  https://github.com/root-project/root/pull/4 0x0000556b69215c56 cling::DeclExtractor::EnforceInitOrder(llvm::SmallVector<clang::Stmt*>&) (/home/jalopezg/CERN/repos/root/_build/interpreter/llvm/src/bin/cling+0xf65c56)
1:  https://github.com/root-project/root/pull/5 0x0000556b69216788 cling::DeclExtractor::ExtractDecl(clang::FunctionDecl*) (/home/jalopezg/CERN/repos/root/_build/interpreter/llvm/src/bin/cling+0xf66788)
1:  https://github.com/root-project/root/pull/6 0x0000556b69216a75 cling::DeclExtractor::Transform(clang::Decl*) (/home/jalopezg/CERN/repos/root/_build/interpreter/llvm/src/bin/cling+0xf66a75)
```

## Checklist:
- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes #12455.