### PR TITLE
Fix std.modulemap for gcc13

### DIFF
--- a/interpreter/cling/include/cling/std.modulemap
+++ b/interpreter/cling/include/cling/std.modulemap
@@ -556,6 +556,10 @@ module "std" [system] {
     export bits_stl_algobase_h
     header "bits/uniform_int_dist.h"
   }
+  module "bits/utility.h" [optional] {
+    export *
+    header "bits/utility.h"
+  }
   module "bits/uses_allocator_args.h" [optional] {
     requires cplusplus17
     export *


### PR DESCRIPTION
This is needed also in v6-28-00-patches for building with GCC 13 since adding the `memory_resource` header in commit f7adbd2b04.

(cherry picked from commit e9a8c48e4f207d7015bbd212116486bbecbac066 and commit aae1cd064679f440ad80f39e4ee56bb0c1d9d396)

Backport of the following two PRs:
* https://github.com/root-project/root/pull/12765
* https://github.com/root-project/root/pull/12793