### PR TITLE
[ntuple] Move the `WaitForAllTasks()` call to `~RPageSinkBuf`

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -140,7 +140,7 @@ public:
    RPageSinkBuf& operator=(const RPageSinkBuf&) = delete;
    RPageSinkBuf(RPageSinkBuf&&) = default;
    RPageSinkBuf& operator=(RPageSinkBuf&&) = default;
-   ~RPageSinkBuf() override = default;
+   ~RPageSinkBuf() override;
 
    void UpdateSchema(const RNTupleModelChangeset &changeset) final;
    RPage ReservePage(ColumnHandle_t columnHandle, std::size_t nElements) final;

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -33,6 +33,14 @@ ROOT::Experimental::Detail::RPageSinkBuf::RPageSinkBuf(std::unique_ptr<RPageSink
    fMetrics.ObserveMetrics(fInnerSink->GetMetrics());
 }
 
+ROOT::Experimental::Detail::RPageSinkBuf::~RPageSinkBuf()
+{
+   // Wait for unterminated tasks, if any, as they may still hold a reference to `this`.
+   // This cannot be moved to the base class destructor, given non-static members have been destroyed by the time the
+   // base class destructor is invoked.
+   WaitForAllTasks();
+}
+
 void ROOT::Experimental::Detail::RPageSinkBuf::CreateImpl(const RNTupleModel &model,
                                                           unsigned char * /* serializedHeader */,
                                                           std::uint32_t /* length */)

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -38,12 +38,7 @@ ROOT::Experimental::Detail::RPageStorage::RPageStorage(std::string_view name) : 
 {
 }
 
-ROOT::Experimental::Detail::RPageStorage::~RPageStorage()
-{
-   // Wait for unterminated tasks, if any, as they may still hold a reference to `this`
-   WaitForAllTasks();
-}
-
+ROOT::Experimental::Detail::RPageStorage::~RPageStorage() {}
 
 //------------------------------------------------------------------------------
 


### PR DESCRIPTION
This pull request is a follow-up from PR #12824.  This cannot be in the base class destructor (`~RPageStorage`), given non-static members have been destroyed by the time the base class destructor is invoked.

Second try at fixing the ntuple_extended:`RNTuple.SmallClusters` test.

## Checklist:
- [x] tested changes locally