### PR TITLE
[test] HistoFit: remove color output:

### DIFF
--- a/test/stressHistoFit.cxx
+++ b/test/stressHistoFit.cxx
@@ -418,7 +418,7 @@ enum testOpt {
 };
 
 // Default options that all tests will have
-int defaultOptions = testOptColor | testOptCheck;// | testOptDebug;
+int defaultOptions = testOptCheck;// | testOptDebug;
 
 // Object to manage the fitter depending on the optiones used
 template <typename T>


### PR DESCRIPTION
This causes a flood of "NON_XML_CHAR" etc output in Jenkins, cluttering the output and making the actual failure virtually invisible.

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

