### PR TITLE
[RF] Modernize memory management in RooFit and RooStats

### DIFF
--- a/roofit/roofitcore/inc/RooAbsCollection.h
+++ b/roofit/roofitcore/inc/RooAbsCollection.h
@@ -115,7 +115,16 @@ public:
 
   // List content management
   virtual bool add(const RooAbsArg& var, bool silent=false) ;
+// The following function is not memory safe, because it takes ownership of var
+// without moving it. It is not publically available in the memory safe
+// interfaces mode.
+#ifdef ROOFIT_MEMORY_SAFE_INTERFACES
+protected:
+#endif
   virtual bool addOwned(RooAbsArg& var, bool silent=false);
+#ifdef ROOFIT_MEMORY_SAFE_INTERFACES
+public:
+#endif
   bool addOwned(std::unique_ptr<RooAbsArg> var, bool silent=false);
   virtual RooAbsArg *addClone(const RooAbsArg& var, bool silent=false) ;
   virtual bool replace(const RooAbsArg& var1, const RooAbsArg& var2) ;

--- a/roofit/roofitcore/inc/RooAbsIntegrator.h
+++ b/roofit/roofitcore/inc/RooAbsIntegrator.h
@@ -65,9 +65,9 @@ public:
 
 protected:
 
-  const RooAbsFunc *_function; ///< Pointer to function binding of integrand
-  bool _valid;               ///< Is integrator in valid state?
-  bool _printEvalCounter ;   ///< If true print number of function evaluation required for integration
+  const RooAbsFunc *_function = nullptr; ///< Pointer to function binding of integrand
+  bool _valid = false;                   ///< Is integrator in valid state?
+  bool _printEvalCounter = false;        ///< If true print number of function evaluation required for integration
 
   ClassDefOverride(RooAbsIntegrator,0) // Abstract interface for real-valued function integrators
 };

--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -204,40 +204,40 @@ public:
   virtual RooAbsReal* createProfile(const RooArgSet& paramsOfInterest) ;
 
 
-  RooAbsReal* createIntegral(const RooArgSet& iset, const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg::none(),
+  RooFit::OwningPtr<RooAbsReal> createIntegral(const RooArgSet& iset, const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg::none(),
                              const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),
               const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),
               const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) const ;
 
   /// Create integral over observables in iset in range named rangeName.
-  RooAbsReal* createIntegral(const RooArgSet& iset, const char* rangeName) const {
+  RooFit::OwningPtr<RooAbsReal> createIntegral(const RooArgSet& iset, const char* rangeName) const {
     return createIntegral(iset,nullptr,nullptr,rangeName) ;
   }
   /// Create integral over observables in iset in range named rangeName with integrand normalized over observables in nset
-  RooAbsReal* createIntegral(const RooArgSet& iset, const RooArgSet& nset, const char* rangeName=nullptr) const {
+  RooFit::OwningPtr<RooAbsReal> createIntegral(const RooArgSet& iset, const RooArgSet& nset, const char* rangeName=nullptr) const {
     return createIntegral(iset,&nset,nullptr,rangeName) ;
   }
   /// Create integral over observables in iset in range named rangeName with integrand normalized over observables in nset while
   /// using specified configuration for any numeric integration.
-  RooAbsReal* createIntegral(const RooArgSet& iset, const RooArgSet& nset, const RooNumIntConfig& cfg, const char* rangeName=nullptr) const {
+  RooFit::OwningPtr<RooAbsReal> createIntegral(const RooArgSet& iset, const RooArgSet& nset, const RooNumIntConfig& cfg, const char* rangeName=nullptr) const {
     return createIntegral(iset,&nset,&cfg,rangeName) ;
   }
   /// Create integral over observables in iset in range named rangeName using specified configuration for any numeric integration.
-  RooAbsReal* createIntegral(const RooArgSet& iset, const RooNumIntConfig& cfg, const char* rangeName=nullptr) const {
+  RooFit::OwningPtr<RooAbsReal> createIntegral(const RooArgSet& iset, const RooNumIntConfig& cfg, const char* rangeName=nullptr) const {
     return createIntegral(iset,nullptr,&cfg,rangeName) ;
   }
-  virtual RooAbsReal* createIntegral(const RooArgSet& iset, const RooArgSet* nset=nullptr, const RooNumIntConfig* cfg=nullptr, const char* rangeName=nullptr) const ;
+  virtual RooFit::OwningPtr<RooAbsReal> createIntegral(const RooArgSet& iset, const RooArgSet* nset=nullptr, const RooNumIntConfig* cfg=nullptr, const char* rangeName=nullptr) const ;
 
 
   void setParameterizeIntegral(const RooArgSet& paramVars) ;
 
   // Create running integrals
-  RooFit::OwningPtr<RooAbsReal> createRunningIntegral(const RooArgSet& iset, const RooArgSet& nset=RooArgSet()) ;
+  RooFit::OwningPtr<RooAbsReal> createRunningIntegral(const RooArgSet& iset, const RooArgSet& nset={}) ;
   RooFit::OwningPtr<RooAbsReal> createRunningIntegral(const RooArgSet& iset, const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg::none(),
          const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),
          const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),
          const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;
-  RooFit::OwningPtr<RooAbsReal> createIntRI(const RooArgSet& iset, const RooArgSet& nset=RooArgSet()) ;
+  RooFit::OwningPtr<RooAbsReal> createIntRI(const RooArgSet& iset, const RooArgSet& nset={}) ;
   RooFit::OwningPtr<RooAbsReal> createScanRI(const RooArgSet& iset, const RooArgSet& nset, Int_t numScanBins, Int_t intOrder) ;
 
 

--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -441,7 +441,7 @@ protected:
          const RooArgSet& set) const ;
 
 
-  RooAbsReal* createIntObj(const RooArgSet& iset, const RooArgSet* nset, const RooNumIntConfig* cfg, const char* rangeName) const ;
+  RooFit::OwningPtr<RooAbsReal> createIntObj(const RooArgSet& iset, const RooArgSet* nset, const RooNumIntConfig* cfg, const char* rangeName) const ;
   void findInnerMostIntegration(const RooArgSet& allObs, RooArgSet& innerObs, const char* rangeName) const ;
 
 

--- a/roofit/roofitcore/inc/RooAbsRealLValue.h
+++ b/roofit/roofitcore/inc/RooAbsRealLValue.h
@@ -153,7 +153,7 @@ public:
   static TH1* createHistogram(const char *name, RooArgList &vars, const char *tAxisLabel, double* xlo, double* xhi, Int_t* nBins) ;
   static TH1* createHistogram(const char *name, RooArgList &vars, const char *tAxisLabel, const RooAbsBinning** bins) ;
 
-  RooAbsReal* createIntegral(const RooArgSet& iset, const RooArgSet* nset=nullptr, const RooNumIntConfig* cfg=nullptr, const char* rangeName=nullptr) const override;
+  RooFit::OwningPtr<RooAbsReal> createIntegral(const RooArgSet& iset, const RooArgSet* nset=nullptr, const RooNumIntConfig* cfg=nullptr, const char* rangeName=nullptr) const override;
 
 protected:
 

--- a/roofit/roofitcore/inc/RooBinSamplingPdf.h
+++ b/roofit/roofitcore/inc/RooBinSamplingPdf.h
@@ -65,7 +65,7 @@ public:
   bool selfNormalized() const override { return true; }
 
   /// Forwards to the PDF's implementation.
-  RooAbsReal* createIntegral(const RooArgSet& iset,
+  RooFit::OwningPtr<RooAbsReal> createIntegral(const RooArgSet& iset,
                              const RooArgSet* nset=nullptr,
                              const RooNumIntConfig* cfg=nullptr,
                              const char* rangeName=nullptr) const override {

--- a/roofit/roofitcore/inc/RooCollectionProxy.h
+++ b/roofit/roofitcore/inc/RooCollectionProxy.h
@@ -113,7 +113,17 @@ public:
    }
 
    using RooAbsCollection::addOwned;
+
+// The following function is not memory safe, because it takes ownership of var
+// without moving it. It is not publically available in the memory safe
+// interfaces mode.
+#ifdef ROOFIT_MEMORY_SAFE_INTERFACES
+protected:
+#endif
    bool addOwned(RooAbsArg &var, bool silent = false) override;
+#ifdef ROOFIT_MEMORY_SAFE_INTERFACES
+public:
+#endif
 
    using RooAbsCollection::addClone;
    RooAbsArg *addClone(const RooAbsArg &var, bool silent = false) override;

--- a/roofit/roofitcore/inc/RooCurve.h
+++ b/roofit/roofitcore/inc/RooCurve.h
@@ -88,7 +88,7 @@ protected:
 
   void shiftCurveToZero(double prevYMax) ;
 
-  bool _showProgress ; ///<! Show progress indication when adding points
+  bool _showProgress = false; ///<! Show progress indication when adding points
 
   ClassDefOverride(RooCurve,1) // 1-dimensional smooth curve for use in RooPlots
 };

--- a/roofit/roofitcore/inc/RooFit/Config.h
+++ b/roofit/roofitcore/inc/RooFit/Config.h
@@ -13,6 +13,20 @@
 #ifndef RooFit_Config_h
 #define RooFit_Config_h
 
+// Define ROOFIT_MEMORY_SAFE_INTERFACES to change RooFit interfaces to be
+// memory safe.
+//#define ROOFIT_MEMORY_SAFE_INTERFACES
+
+// The memory safe interfaces mode implies that all RooFit::OwningPtr<T> are
+// std::unique_ptr<T>.
+#ifdef ROOFIT_MEMORY_SAFE_INTERFACES
+#ifndef ROOFIT_OWNING_PTR_IS_UNIQUE_PTR
+#define ROOFIT_OWNING_PTR_IS_UNIQUE_PTR
+#endif
+#endif
+
+#include <memory>
+
 namespace RooFit {
 
 /// An alias for raw pointers for indicating that the return type of a RooFit
@@ -22,10 +36,28 @@ namespace RooFit {
 /// problems. Changing this alias is equivalent to forcing all code immediately
 /// wraps the result of functions returning a RooFit::OwningPtr<T> in a
 /// std::unique_ptr<T>.
-template<typename T>
-using OwningPtr = T*;
-//using OwningPtr = std::unique_ptr<T>;
+template <typename T>
+#ifdef ROOFIT_OWNING_PTR_IS_UNIQUE_PTR
+using OwningPtr = std::unique_ptr<T>;
+#else
+using OwningPtr = T *;
+#endif
 
+namespace Detail {
+
+/// Internal helper to turn a std::unique_ptr<T> into an OwningPtr.
+template <typename T>
+OwningPtr<T> owningPtr(std::unique_ptr<T> &&ptr)
+{
+#ifdef ROOFIT_OWNING_PTR_IS_UNIQUE_PTR
+   return ptr;
+#else
+   return ptr.release();
+#endif
 }
+
+} // namespace Detail
+
+} // namespace RooFit
 
 #endif

--- a/roofit/roofitcore/inc/RooGenContext.h
+++ b/roofit/roofitcore/inc/RooGenContext.h
@@ -47,7 +47,7 @@ protected:
   RooArgSet _directVars,_uniformVars,_otherVars; ///< List of observables generated internally, randomly, and by accept/reject sampling
   Int_t _code;                                   ///< Internal generation code
   double _maxProb{0.}, _area{0.}, _norm{0.};   ///< Maximum probability, p.d.f area and normalization
-  RooRealIntegral *_acceptRejectFunc; ///< Projection function to be passed to accept/reject sampler
+  std::unique_ptr<RooRealIntegral> _acceptRejectFunc; ///< Projection function to be passed to accept/reject sampler
   RooAbsNumGenerator *_generator;     ///< MC sampling generation engine
   RooRealVar *_maxVar ;               ///< Variable holding maximum value of p.d.f
   Int_t _updateFMaxPerEvent ;         ///< If true, maximum p.d.f value needs to be recalculated for each event

--- a/roofit/roofitcore/inc/RooMsgService.h
+++ b/roofit/roofitcore/inc/RooMsgService.h
@@ -203,9 +203,9 @@ protected:
 
   std::vector<StreamConfig> _streams ;
   std::stack<std::vector<StreamConfig> > _streamsSaved ;
-  std::ostream* _devnull ;
+  std::unique_ptr<std::ofstream> _devnull ;
 
-  std::map<std::string,std::ostream*> _files ;
+  std::map<std::string,std::unique_ptr<std::ostream>> _files ;
   RooFit::MsgLevel _globMinLevel ;
   RooFit::MsgLevel _lastMsgLevel ;
 
@@ -218,7 +218,7 @@ protected:
   RooMsgService() ;
   RooMsgService(const RooMsgService&) ;
 
-  RooWorkspace* _debugWorkspace ;
+  std::unique_ptr<RooWorkspace> _debugWorkspace;
 
   Int_t _debugCode ;
 

--- a/roofit/roofitcore/inc/RooProdPdf.h
+++ b/roofit/roofitcore/inc/RooProdPdf.h
@@ -157,8 +157,8 @@ private:
 
   CacheElem* getCacheElem(RooArgSet const* nset) const ;
   void rearrangeProduct(CacheElem&) const;
-  RooAbsReal* specializeIntegral(RooAbsReal& orig, const char* targetRangeName) const ;
-  RooAbsReal* specializeRatio(RooFormulaVar& input, const char* targetRangeName) const ;
+  std::unique_ptr<RooAbsReal> specializeIntegral(RooAbsReal& orig, const char* targetRangeName) const ;
+  std::unique_ptr<RooAbsReal> specializeRatio(RooFormulaVar& input, const char* targetRangeName) const ;
   double calculate(const RooProdPdf::CacheElem& cache, bool verbose=false) const ;
   void calculateBatch(const RooProdPdf::CacheElem& cache, cudaStream_t*, double* output, size_t nEvents, RooFit::Detail::DataMap const&) const;
 

--- a/roofit/roofitcore/inc/RooRealIntegral.h
+++ b/roofit/roofitcore/inc/RooRealIntegral.h
@@ -76,7 +76,7 @@ public:
     return _function->plotSamplingHint(obs,xlo,xhi) ;
   }
 
-  RooAbsReal* createIntegral(const RooArgSet& iset, const RooArgSet* nset=nullptr, const RooNumIntConfig* cfg=nullptr, const char* rangeName=nullptr) const override ;
+  RooFit::OwningPtr<RooAbsReal> createIntegral(const RooArgSet& iset, const RooArgSet* nset=nullptr, const RooNumIntConfig* cfg=nullptr, const char* rangeName=nullptr) const override ;
 
   void setAllowComponentSelection(bool allow);
   bool getAllowComponentSelection() const;

--- a/roofit/roofitcore/inc/RooSegmentedIntegrator1D.h
+++ b/roofit/roofitcore/inc/RooSegmentedIntegrator1D.h
@@ -56,7 +56,7 @@ protected:
   bool _useIntegrandLimits ;
 
   RooNumIntConfig _config ;
-  RooIntegrator1D** _array ; ///< Array of segment integrators
+  std::vector<std::unique_ptr<RooIntegrator1D>> _array ; ///< Array of segment integrators
 
   bool initialize();
 

--- a/roofit/roofitcore/inc/RooSegmentedIntegrator2D.h
+++ b/roofit/roofitcore/inc/RooSegmentedIntegrator2D.h
@@ -44,8 +44,8 @@ protected:
   friend class RooNumIntFactory ;
   static void registerIntegrator(RooNumIntFactory& fact) ;
 
-  RooSegmentedIntegrator1D* _xIntegrator ;
-  RooAbsFunc* _xint ;
+  std::unique_ptr<RooSegmentedIntegrator1D> _xIntegrator;
+  std::unique_ptr<RooAbsFunc> _xint;
 
   ClassDefOverride(RooSegmentedIntegrator2D,0) // 2-dimensional piece-wise numerical integration engine
 };

--- a/roofit/roofitcore/inc/RooXYChi2Var.h
+++ b/roofit/roofitcore/inc/RooXYChi2Var.h
@@ -80,7 +80,7 @@ protected:
   double evaluatePartition(std::size_t firstEvent, std::size_t lastEvent, std::size_t stepSize) const override ;
 
   RooNumIntConfig   _intConfig ; ///< Numeric integrator configuration for integration of function over bin
-  RooAbsReal*       _funcInt = nullptr; ///<! Function integral
+  std::unique_ptr<RooAbsReal>    _funcInt; ///<! Function integral
   std::list<RooAbsBinning*> _binList ; ///<! Bin ranges
 
   ClassDefOverride(RooXYChi2Var,0) // Chi^2 function of p.d.f w.r.t a unbinned dataset with X and Y values

--- a/roofit/roofitcore/src/RooAbsIntegrator.cxx
+++ b/roofit/roofitcore/src/RooAbsIntegrator.cxx
@@ -32,17 +32,8 @@ functions that implement the RooAbsFunc interface.
 using namespace std;
 
 ClassImp(RooAbsIntegrator);
-;
 
-
-////////////////////////////////////////////////////////////////////////////////
-/// Default constructor
-
-RooAbsIntegrator::RooAbsIntegrator() : _function(0), _valid(false), _printEvalCounter(false)
-{
-}
-
-
+RooAbsIntegrator::RooAbsIntegrator() = default;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy constructor

--- a/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
@@ -202,10 +202,9 @@ void RooAbsOptTestStatistic::initSlave(RooAbsReal& real, RooAbsData& indata, con
   }
 
   // Mark all projected dependents as such
-  if (projDeps.getSize()>0) {
-    RooArgSet *projDataDeps = (RooArgSet*) _funcObsSet->selectCommon(projDeps) ;
+  if (!projDeps.empty()) {
+    std::unique_ptr<RooArgSet> projDataDeps{static_cast<RooArgSet*>(_funcObsSet->selectCommon(projDeps))};
     projDataDeps->setAttribAll("projectedDependent") ;
-    delete projDataDeps ;
   }
 
   // If PDF is a RooProdPdf (with possible constraint terms)

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1020,7 +1020,7 @@ RooFit::OwningPtr<RooAbsReal> RooAbsPdf::createNLL(RooAbsData& data, const RooLi
              .GlobalObservables(glObsSet)
              .GlobalObservablesTag(rangeName.c_str());
 
-      return RooFit::OwningPtr<RooAbsReal>{new RooFit::TestStatistics::RooRealL("likelihood", "", builder.build())};
+      return RooFit::Detail::owningPtr(std::make_unique<RooFit::TestStatistics::RooRealL>("likelihood", "", builder.build()));
   }
 
   // Decode command line arguments
@@ -1143,7 +1143,7 @@ RooFit::OwningPtr<RooAbsReal> RooAbsPdf::createNLL(RooAbsData& data, const RooLi
        compiledConstr->addOwnedComponents(std::move(constr));
     }
 
-    return RooFit::OwningPtr<RooAbsReal>{RooFit::BatchModeHelpers::createNLL(
+    return RooFit::Detail::owningPtr(RooFit::BatchModeHelpers::createNLL(
             std::move(pdfClone),
             data,
             std::move(compiledConstr),
@@ -1153,7 +1153,7 @@ RooFit::OwningPtr<RooAbsReal> RooAbsPdf::createNLL(RooAbsData& data, const RooLi
             pc.getDouble("IntegrateBins"),
             batchMode,
             offset,
-            takeGlobalObservablesFromData).release()};
+            takeGlobalObservablesFromData));
   }
 
   // Construct NLL
@@ -1207,7 +1207,7 @@ RooFit::OwningPtr<RooAbsReal> RooAbsPdf::createNLL(RooAbsData& data, const RooLi
     nll->enableOffsetting(true) ;
   }
 
-  return RooFit::OwningPtr<RooAbsReal>{nll.release()};
+  return RooFit::Detail::owningPtr(std::move(nll));
 }
 
 
@@ -1736,7 +1736,7 @@ RooFit::OwningPtr<RooFitResult> RooAbsPdf::fitTo(RooAbsData& data, const RooLink
   cfg.enableParallelGradient = pc.getInt("enableParallelGradient");
   cfg.enableParallelDescent = pc.getInt("enableParallelDescent");
   cfg.timingAnalysis = pc.getInt("timingAnalysis");
-  return RooFit::OwningPtr<RooFitResult>{minimizeNLL(*nll, data, cfg).release()};
+  return RooFit::Detail::owningPtr(minimizeNLL(*nll, data, cfg));
 }
 
 
@@ -3362,7 +3362,7 @@ RooFit::OwningPtr<RooAbsReal> RooAbsPdf::createScanCdf(const RooArgSet& iset, co
   ivar->setBins(numScanBins,"numcdf") ;
   auto ret = std::make_unique<RooNumCdf>(name.c_str(),name.c_str(),*this,*ivar,"numcdf");
   ret->setInterpolationOrder(intOrder) ;
-  return RooFit::OwningPtr<RooAbsReal>{ret.release()};
+  return RooFit::Detail::owningPtr(std::move(ret));
 }
 
 

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -500,7 +500,7 @@ RooAbsReal* RooAbsReal::createProfile(const RooArgSet& paramsOfInterest)
 /// | `NumIntConfig(const RooNumIntConfig&)` | Use given configuration for any numeric integration, if necessary
 /// | `Range(const char* name)`              | Integrate only over given range. Multiple ranges may be specified by passing multiple Range() arguments
 
-RooAbsReal* RooAbsReal::createIntegral(const RooArgSet& iset, const RooCmdArg& arg1, const RooCmdArg& arg2,
+RooFit::OwningPtr<RooAbsReal> RooAbsReal::createIntegral(const RooArgSet& iset, const RooCmdArg& arg1, const RooCmdArg& arg2,
                    const RooCmdArg& arg3, const RooCmdArg& arg4, const RooCmdArg& arg5,
                    const RooCmdArg& arg6, const RooCmdArg& arg7, const RooCmdArg& arg8) const
 {
@@ -541,12 +541,12 @@ RooAbsReal* RooAbsReal::createIntegral(const RooArgSet& iset, const RooCmdArg& a
 /// aspect of the integral. It will not force the integral to be performed numerically, which is
 /// decided automatically by RooRealIntegral.
 
-RooAbsReal* RooAbsReal::createIntegral(const RooArgSet& iset, const RooArgSet* nset,
+RooFit::OwningPtr<RooAbsReal> RooAbsReal::createIntegral(const RooArgSet& iset, const RooArgSet* nset,
                    const RooNumIntConfig* cfg, const char* rangeName) const
 {
   if (!rangeName || strchr(rangeName,',')==0) {
     // Simple case: integral over full range or single limited range
-    return createIntObj(iset,nset,cfg,rangeName) ;
+    return RooFit::OwningPtr<RooAbsReal>{createIntObj(iset,nset,cfg,rangeName)};
   }
 
   // Integral over multiple ranges
@@ -571,7 +571,7 @@ RooAbsReal* RooAbsReal::createIntegral(const RooArgSet& iset, const RooArgSet* n
   const std::string title = std::string("Integral of ") + GetTitle();
   const std::string fullName = std::string(GetName()) + integralNameSuffix(iset,nset,rangeName).Data();
 
-  return new RooAddition(fullName.c_str(), title.c_str(), components, true);
+  return RooFit::OwningPtr<RooAbsReal>{new RooAddition(fullName.c_str(), title.c_str(), components, true)};
 }
 
 
@@ -3882,8 +3882,8 @@ RooFit::OwningPtr<RooAbsReal> RooAbsReal::createRunningIntegral(const RooArgSet&
     return createScanRI(iset,nset,numScanBins,intOrder) ;
   }
   if (doScanNum) {
-    std::unique_ptr<RooRealIntegral> tmp{static_cast<RooRealIntegral*>(createIntegral(iset))};
-    Int_t isNum= (tmp->numIntRealVars().size()==1) ;
+    std::unique_ptr<RooAbsReal> tmp{createIntegral(iset)} ;
+    Int_t isNum= !static_cast<RooRealIntegral&>(*tmp).numIntRealVars().empty();
 
     if (isNum) {
       coutI(NumIntegration) << "RooAbsPdf::createRunningIntegral(" << GetName() << ") integration over observable(s) " << iset << " involves numeric integration," << std::endl
@@ -3894,7 +3894,7 @@ RooFit::OwningPtr<RooAbsReal> RooAbsReal::createRunningIntegral(const RooArgSet&
 
     return isNum ? createScanRI(iset,nset,numScanBins,intOrder) : createIntRI(iset,nset) ;
   }
-  return 0 ;
+  return nullptr;
 }
 
 

--- a/roofit/roofitcore/src/RooAbsRealLValue.cxx
+++ b/roofit/roofitcore/src/RooAbsRealLValue.cxx
@@ -1061,7 +1061,7 @@ bool RooAbsRealLValue::isJacobianOK(const RooArgSet&) const
 }
 
 
-RooAbsReal* RooAbsRealLValue::createIntegral(const RooArgSet&, const RooArgSet*, const RooNumIntConfig*, const char*) const
+RooFit::OwningPtr<RooAbsReal> RooAbsRealLValue::createIntegral(const RooArgSet&, const RooArgSet*, const RooNumIntConfig*, const char*) const
 {
   std::stringstream errStream;
   errStream << "Attempting to integrate the " << ClassName() << " \"" << GetName()

--- a/roofit/roofitcore/src/RooBinnedGenContext.cxx
+++ b/roofit/roofitcore/src/RooBinnedGenContext.cxx
@@ -70,15 +70,6 @@ RooBinnedGenContext::RooBinnedGenContext(const RooAbsPdf &model, const RooArgSet
   _pdf->recursiveRedirectServers(_theEvent) ;
   _vars = std::unique_ptr<RooArgSet>{_pdf->getObservables(vars)};
 
-  // If pdf has boundary definitions, follow those for the binning
-  for (auto* rvar: dynamic_range_cast<RooRealVar*>(*_vars)) {
-    if (rvar) {
-      list<double>* binb = model.binBoundaries(*rvar,rvar->getMin(),rvar->getMax()) ;
-      delete binb ;
-    }
-  }
-
-
   // Create empty RooDataHist
   _hist = std::make_unique<RooDataHist>("genData","genData",*_vars);
 

--- a/roofit/roofitcore/src/RooCurve.cxx
+++ b/roofit/roofitcore/src/RooCurve.cxx
@@ -65,7 +65,7 @@ ClassImp(RooCurve);
 ////////////////////////////////////////////////////////////////////////////////
 /// Default constructor.
 
-RooCurve::RooCurve() : _showProgress(false)
+RooCurve::RooCurve()
 {
   initialize();
 }
@@ -116,13 +116,10 @@ RooCurve::RooCurve(const RooAbsReal &f, RooAbsRealLValue &x, double xlo, double 
   double prevYMax = getYAxisMax() ;
   if(xbins > 0){
     // regular mode - use the sampling hint to decide where to evaluate the pdf
-    list<double>* hint = f.plotSamplingHint(x,xlo,xhi) ;
-    addPoints(*funcPtr,xlo,xhi,xbins+1,prec,resolution,wmode,nEvalError,doEEVal,eeVal,hint);
+    std::unique_ptr<std::list<double>> hint{f.plotSamplingHint(x,xlo,xhi)};
+    addPoints(*funcPtr,xlo,xhi,xbins+1,prec,resolution,wmode,nEvalError,doEEVal,eeVal,hint.get());
     if (_showProgress) {
       ccoutP(Plotting) << endl ;
-    }
-    if (hint) {
-      delete hint ;
     }
   } else {
     // if number of bins is set to <= 0, skip any interpolation and just evaluate the pdf at the bin centers
@@ -155,8 +152,7 @@ RooCurve::RooCurve(const RooAbsReal &f, RooAbsRealLValue &x, double xlo, double 
 
 RooCurve::RooCurve(const char *name, const char *title, const RooAbsFunc &func,
          double xlo, double xhi, UInt_t minPoints, double prec, double resolution,
-         bool shiftToZero, WingMode wmode, Int_t nEvalError, Int_t doEEVal, double eeVal) :
-  _showProgress(false)
+         bool shiftToZero, WingMode wmode, Int_t nEvalError, Int_t doEEVal, double eeVal)
 {
   SetName(name);
   SetTitle(title);
@@ -187,8 +183,7 @@ RooCurve::RooCurve(const char *name, const char *title, const RooAbsFunc &func,
 /// \param[in] scale1 Scale y values for c1 by this factor.
 /// \param[in] scale2 Scale y values for c2 by this factor.
 
-RooCurve::RooCurve(const char* name, const char* title, const RooCurve& c1, const RooCurve& c2, double scale1, double scale2) :
-  _showProgress(false)
+RooCurve::RooCurve(const char* name, const char* title, const RooCurve& c1, const RooCurve& c2, double scale1, double scale2)
 {
   initialize() ;
   SetName(name) ;

--- a/roofit/roofitcore/src/RooFactoryWSTool.cxx
+++ b/roofit/roofitcore/src/RooFactoryWSTool.cxx
@@ -2121,15 +2121,15 @@ std::string RooFactoryWSTool::SpecialsIFace::create(RooFactoryWSTool& ft, const 
     std::unique_ptr<RooAbsReal> integral;
     if (pargv.size()==2) {
       if (range && strlen(range)) {
-        integral.reset(func.createIntegral(ft.asSET(intobs),Range(range)));
+        integral = std::unique_ptr<RooAbsReal>{func.createIntegral(ft.asSET(intobs),Range(range))};
       } else {
-        integral.reset(func.createIntegral(ft.asSET(intobs)));
+        integral = std::unique_ptr<RooAbsReal>{func.createIntegral(ft.asSET(intobs))};
       }
     } else {
       if (range && strlen(range)) {
-        integral.reset(func.createIntegral(ft.asSET(intobs),Range(range),NormSet(ft.asSET(pargv[2].c_str()))));
+        integral = std::unique_ptr<RooAbsReal>{func.createIntegral(ft.asSET(intobs),Range(range),NormSet(ft.asSET(pargv[2].c_str())))};
       } else {
-        integral.reset(func.createIntegral(ft.asSET(intobs),NormSet(ft.asSET(pargv[2].c_str()))));
+        integral = std::unique_ptr<RooAbsReal>{func.createIntegral(ft.asSET(intobs),NormSet(ft.asSET(pargv[2].c_str())))};
       }
     }
 

--- a/roofit/roofitcore/src/RooFirstMoment.cxx
+++ b/roofit/roofitcore/src/RooFirstMoment.cxx
@@ -68,24 +68,26 @@ RooFirstMoment::RooFirstMoment(const char* name, const char* title, RooAbsReal& 
 {
   setExpensiveObjectCache(func.expensiveObjectCache()) ;
 
-  string pname=Form("%s_product",name) ;
+  std::string pname = std::string(name) + "_product";
 
-  RooProduct* XF = new RooProduct(pname.c_str(),pname.c_str(),RooArgSet(x,func)) ;
+  auto XF = std::make_unique<RooProduct>(pname.c_str(),pname.c_str(),RooArgSet(x,func));
   XF->setExpensiveObjectCache(func.expensiveObjectCache()) ;
 
   if (func.isBinnedDistribution(x)) {
     XF->specialIntegratorConfig(true)->method1D().setLabel("RooBinIntegrator");
   }
 
-  RooRealIntegral* intXF = (RooRealIntegral*) XF->createIntegral(x) ;
-  RooRealIntegral* intF =  (RooRealIntegral*) func.createIntegral(x) ;
-  intXF->setCacheNumeric(true) ;
-  intF->setCacheNumeric(true) ;
+  std::unique_ptr<RooAbsReal> intXF{XF->createIntegral(x)};
+  std::unique_ptr<RooAbsReal> intF{func.createIntegral(x)};
+  static_cast<RooRealIntegral&>(*intXF).setCacheNumeric(true) ;
+  static_cast<RooRealIntegral&>(*intF).setCacheNumeric(true) ;
 
   _xf.setArg(*XF) ;
   _ixf.setArg(*intXF) ;
   _if.setArg(*intF) ;
-  addOwnedComponents(RooArgSet(*XF,*intXF,*intF)) ;
+  addOwnedComponents(std::move(XF)) ;
+  addOwnedComponents(std::move(intXF));
+  addOwnedComponents(std::move(intF));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -100,9 +102,9 @@ RooFirstMoment::RooFirstMoment(const char* name, const char* title, RooAbsReal& 
 
   _nset.add(nset) ;
 
-  string pname=Form("%s_product",name) ;
+  std::string pname = std::string(name) + "_product";
 
-  RooProduct* XF = new RooProduct(pname.c_str(),pname.c_str(),RooArgSet(x,func)) ;
+  auto XF = std::make_unique<RooProduct>(pname.c_str(),pname.c_str(),RooArgSet(x,func)) ;
   XF->setExpensiveObjectCache(func.expensiveObjectCache()) ;
 
   if (func.isBinnedDistribution(x)) {
@@ -116,15 +118,17 @@ RooFirstMoment::RooFirstMoment(const char* name, const char* title, RooAbsReal& 
 
   RooArgSet intSet(x) ;
   if (intNSet) intSet.add(_nset,true) ;
-  RooRealIntegral* intXF = (RooRealIntegral*) XF->createIntegral(intSet,&_nset) ;
-  RooRealIntegral* intF =  (RooRealIntegral*) func.createIntegral(intSet,&_nset) ;
-  intXF->setCacheNumeric(true) ;
-  intF->setCacheNumeric(true) ;
+  std::unique_ptr<RooAbsReal> intXF{XF->createIntegral(intSet, &_nset)};
+  std::unique_ptr<RooAbsReal> intF{func.createIntegral(intSet, &_nset)};
+  static_cast<RooRealIntegral&>(*intXF).setCacheNumeric(true) ;
+  static_cast<RooRealIntegral&>(*intF).setCacheNumeric(true) ;
 
   _xf.setArg(*XF) ;
   _ixf.setArg(*intXF) ;
   _if.setArg(*intF) ;
-  addOwnedComponents(RooArgSet(*XF,*intXF,*intF)) ;
+  addOwnedComponents(std::move(XF)) ;
+  addOwnedComponents(std::move(intXF));
+  addOwnedComponents(std::move(intF));
 }
 
 

--- a/roofit/roofitcore/src/RooMCStudy.cxx
+++ b/roofit/roofitcore/src/RooMCStudy.cxx
@@ -640,7 +640,7 @@ RooFit::OwningPtr<RooFitResult> RooMCStudy::refit(RooAbsData* genSample)
     fr = std::unique_ptr<RooFitResult>{doFit(genSample)};
   }
 
-  return RooFit::OwningPtr<RooFitResult>(fr.release());
+  return RooFit::Detail::owningPtr(std::move(fr));
 }
 
 

--- a/roofit/roofitcore/src/RooMsgService.cxx
+++ b/roofit/roofitcore/src/RooMsgService.cxx
@@ -79,7 +79,7 @@ Int_t RooMsgService::_debugCount = 0;
 
 RooMsgService::RooMsgService()
 {
-  _devnull = new ofstream("/dev/null") ;
+  _devnull = std::make_unique<ofstream>("/dev/null") ;
 
   _levelNames[DEBUG]="DEBUG" ;
   _levelNames[INFO]="INFO" ;
@@ -116,13 +116,9 @@ void RooMsgService::reset() {
   _globMinLevel = DEBUG ;
   _lastMsgLevel = DEBUG ;
 
-  delete _debugWorkspace;
   _debugWorkspace = nullptr;
   _debugCode = 0 ;
 
-  for (auto &item : _files) {
-    delete item.second;
-  }
   _files.clear();
 
   // Old-style streams
@@ -133,24 +129,7 @@ void RooMsgService::reset() {
 }
 
 
-////////////////////////////////////////////////////////////////////////////////
-/// Destructor
-
-RooMsgService::~RooMsgService()
-{
-  // Delete all ostreams we own ;
-  map<string,ostream*>::iterator iter = _files.begin() ;
-  for (; iter != _files.end() ; ++iter) {
-    delete iter->second ;
-  }
-
-  if (_debugWorkspace) {
-    delete _debugWorkspace ;
-  }
-
-  delete _devnull ;
-}
-
+RooMsgService::~RooMsgService() = default;
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -168,9 +147,9 @@ bool RooMsgService::anyDebug()
 RooWorkspace* RooMsgService::debugWorkspace()
 {
   if (!_debugWorkspace) {
-    _debugWorkspace = new RooWorkspace("wdebug") ;
+    _debugWorkspace = std::make_unique<RooWorkspace>("wdebug") ;
   }
-  return _debugWorkspace ;
+  return _debugWorkspace.get();
 }
 
 
@@ -270,7 +249,7 @@ Int_t RooMsgService::addStream(RooFit::MsgLevel level, const RooCmdArg& arg1, co
   } else if (string(outFile).size()>0) {
 
     // See if we already opened the file
-    ostream* os2 = _files["outFile"] ;
+    ostream* os2 = _files["outFile"].get();
 
     if (!os2) {
 
@@ -286,8 +265,8 @@ Int_t RooMsgService::addStream(RooFit::MsgLevel level, const RooCmdArg& arg1, co
       }
 
     } else {
-      _files["outFile"] = os2 ;
       newStream.os = os2 ;
+      _files["outFile"] = std::unique_ptr<std::ostream>{os2};
     }
 
 

--- a/roofit/roofitcore/src/RooNormalizedPdf.h
+++ b/roofit/roofitcore/src/RooNormalizedPdf.h
@@ -21,7 +21,7 @@ public:
    RooNormalizedPdf(RooAbsPdf &pdf, RooArgSet const &normSet)
       : _pdf("numerator", "numerator", this, pdf),
         _normIntegral("denominator", "denominator", this,
-                      *pdf.createIntegral(normSet, *pdf.getIntegratorConfig(), pdf.normRange()), true, false, true),
+                      *std::unique_ptr<RooAbsReal>{pdf.createIntegral(normSet, *pdf.getIntegratorConfig(), pdf.normRange())}.release(), true, false, true),
         _normSet{normSet}
    {
       auto name = std::string(pdf.GetName()) + "_over_" + _normIntegral->GetName();

--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -1186,7 +1186,7 @@ void RooProdPdf::rearrangeProduct(RooProdPdf::CacheElem& cache) const
   string name = Form("%s_numerator",GetName()) ;
   // WVE FIX THIS (2)
 
-  RooAbsReal* numerator = new RooProduct(name.c_str(),name.c_str(),nomList) ;
+  std::unique_ptr<RooAbsReal> numerator = std::make_unique<RooProduct>(name.c_str(),name.c_str(),nomList) ;
 
   RooArgSet products ;
 //   cout << "nomList = " << nomList << endl ;
@@ -1207,11 +1207,11 @@ void RooProdPdf::rearrangeProduct(RooProdPdf::CacheElem& cache) const
 
     string namesr = Form("SPEC_RATIO(%s,%s)",numerator->GetName(),norm->GetName()) ;
     RooFormulaVar* ndr = new RooFormulaVar(namesr.c_str(),"@0/@1",RooArgList(*numerator,*norm)) ;
+    ndr->addOwnedComponents(std::move(numerator));
 
     // Integral of ratio
-    RooAbsReal* numtmp = ndr->createIntegral(specIntDeps,specIntRange.c_str()) ;
+    numerator = std::unique_ptr<RooAbsReal>{ndr->createIntegral(specIntDeps,specIntRange.c_str())};
 
-    numerator = numtmp ;
     norm = (RooAbsReal*) RooFit::RooConst(1).Clone() ;
   }
 
@@ -1225,7 +1225,7 @@ void RooProdPdf::rearrangeProduct(RooProdPdf::CacheElem& cache) const
   // WVE DEBUG
   //RooMsgService::instance().debugWorkspace()->import(RooArgSet(*numerator,*norm)) ;
 
-  cache._rearrangedNum.reset(numerator);
+  cache._rearrangedNum = std::move(numerator);
   cache._rearrangedDen.reset(norm);
   cache._isRearranged = true ;
 
@@ -1395,7 +1395,7 @@ std::vector<RooAbsReal*> RooProdPdf::processProductTerm(const RooArgSet* nset, c
 
       RooAbsPdf* pdf = (RooAbsPdf*) term->first() ;
 
-      RooAbsReal* partInt = pdf->createIntegral(termISet,termNSet,isetRangeName) ;
+      RooAbsReal* partInt = std::unique_ptr<RooAbsReal>{pdf->createIntegral(termISet,termNSet,isetRangeName)}.release();
       partInt->setOperMode(operMode()) ;
       partInt->setStringAttribute("PROD_TERM_TYPE","IIIa") ;
 
@@ -1406,8 +1406,8 @@ std::vector<RooAbsReal*> RooProdPdf::processProductTerm(const RooArgSet* nset, c
       ret[0] = partInt ;
 
       // Split mode results
-      ret[1] = pdf->createIntegral(termISet,isetRangeName) ;
-      ret[2] = pdf->createIntegral(termNSet,normRange()) ;
+      ret[1] = std::unique_ptr<RooAbsReal>{pdf->createIntegral(termISet,isetRangeName)}.release();
+      ret[2] = std::unique_ptr<RooAbsReal>{pdf->createIntegral(termNSet,normRange())}.release();
 
       return ret ;
 
@@ -1433,8 +1433,8 @@ std::vector<RooAbsReal*> RooProdPdf::processProductTerm(const RooArgSet* nset, c
       // WVE FIX THIS
       RooProduct* tmp_prod = new RooProduct(name1.c_str(),name1.c_str(),*term) ;
 
-      ret[1] = tmp_prod->createIntegral(termISet,isetRangeName) ;
-      ret[2] = tmp_prod->createIntegral(termNSet,normRange()) ;
+      ret[1] = std::unique_ptr<RooAbsReal>{tmp_prod->createIntegral(termISet,isetRangeName)}.release();
+      ret[2] = std::unique_ptr<RooAbsReal>{tmp_prod->createIntegral(termNSet,normRange())}.release();
 
       return ret ;
     }
@@ -1462,8 +1462,8 @@ std::vector<RooAbsReal*> RooProdPdf::processProductTerm(const RooArgSet* nset, c
     // WVE FIX THIS
     RooProduct* tmp_prod = new RooProduct(name1.c_str(),name1.c_str(),*term) ;
 
-    ret[1] = tmp_prod->createIntegral(termISet,isetRangeName) ;
-    ret[2] = tmp_prod->createIntegral(termNSet,normRange()) ;
+    ret[1] = std::unique_ptr<RooAbsReal>{tmp_prod->createIntegral(termISet,isetRangeName)}.release();
+    ret[2] = std::unique_ptr<RooAbsReal>{tmp_prod->createIntegral(termNSet,normRange())}.release();
 
     return ret ;
   }
@@ -1500,8 +1500,8 @@ std::vector<RooAbsReal*> RooProdPdf::processProductTerm(const RooArgSet* nset, c
 
       ret[0] = partInt ;
 
-      ret[1] = pdf->createIntegral(RooArgSet()) ;
-      ret[2] = pdf->createIntegral(termNSet,normRange()) ;
+      ret[1] = std::unique_ptr<RooAbsReal>{pdf->createIntegral(RooArgSet())}.release();
+      ret[2] = std::unique_ptr<RooAbsReal>{pdf->createIntegral(termNSet,normRange())}.release();
 
       return ret ;
 
@@ -1515,8 +1515,9 @@ std::vector<RooAbsReal*> RooProdPdf::processProductTerm(const RooArgSet* nset, c
       pdf->setStringAttribute("PROD_TERM_TYPE","IVb") ;
       ret[0] = pdf ;
 
-      ret[1] = pdf->createIntegral(RooArgSet()) ;
-      ret[2] = termNSet.getSize()>0 ? pdf->createIntegral(termNSet,normRange()) : ((RooAbsReal*)RooFit::RooConst(1).clone("1")) ;
+      ret[1] = std::unique_ptr<RooAbsReal>{pdf->createIntegral(RooArgSet())}.release();
+      ret[2] = !termNSet.empty() ? std::unique_ptr<RooAbsReal>{pdf->createIntegral(termNSet,normRange())}.release()
+                                 : ((RooAbsReal*)RooFit::RooConst(1).clone("1"));
       return ret  ;
     }
   }

--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -952,12 +952,13 @@ std::unique_ptr<RooProdPdf::CacheElem> RooProdPdf::createCacheElem(const RooArgS
 
 std::unique_ptr<RooAbsReal> RooProdPdf::makeCondPdfRatioCorr(RooAbsReal& pdf, const RooArgSet& termNset, const RooArgSet& /*termImpSet*/, const char* normRangeTmp, const char* refRange) const
 {
-  RooAbsReal* ratio_num = pdf.createIntegral(termNset,normRangeTmp) ;
-  RooAbsReal* ratio_den = pdf.createIntegral(termNset,refRange) ;
+  std::unique_ptr<RooAbsReal> ratio_num{pdf.createIntegral(termNset,normRangeTmp)};
+  std::unique_ptr<RooAbsReal> ratio_den{pdf.createIntegral(termNset,refRange)};
   auto ratio = std::make_unique<RooFormulaVar>(Form("ratio(%s,%s)",ratio_num->GetName(),ratio_den->GetName()),"@0/@1",
                   RooArgList(*ratio_num,*ratio_den)) ;
 
-  ratio->addOwnedComponents(RooArgSet(*ratio_num,*ratio_den)) ;
+  ratio->addOwnedComponents(std::move(ratio_num));
+  ratio->addOwnedComponents(std::move(ratio_den));
   ratio->setAttribute("RATIO_TERM") ;
   return ratio ;
 }
@@ -985,7 +986,7 @@ void RooProdPdf::rearrangeProduct(RooProdPdf::CacheElem& cache) const
   }
 
 
-  map<string,RooArgSet> denListList ;
+  std::map<std::string,RooArgSet> denListList ;
   RooArgSet specIntDeps ;
   string specIntRange ;
 
@@ -1089,7 +1090,7 @@ void RooProdPdf::rearrangeProduct(RooProdPdf::CacheElem& cache) const
 //        cout << "depends in value of ratio" << endl ;
 
        // Make specialize ratio instance
-       RooAbsReal* specializedRatio = specializeRatio(*(RooFormulaVar*)ratio,iter->c_str()) ;
+       std::unique_ptr<RooAbsReal> specializedRatio{specializeRatio(*(RooFormulaVar*)ratio,iter->c_str())};
 
 //        cout << "specRatio = " << endl ;
 //        specializedRatio->printComponentTree() ;
@@ -1116,19 +1117,21 @@ void RooProdPdf::rearrangeProduct(RooProdPdf::CacheElem& cache) const
 //        cout << "customized function = " << endl ;
 //        partCust->printComponentTree() ;
 
-       RooAbsReal* specializedPartCust = specializeIntegral(*(RooAbsReal*)partCust,iter->c_str()) ;
+       std::unique_ptr<RooAbsReal> specializedPartCust{specializeIntegral(*(RooAbsReal*)partCust,iter->c_str())};
 
        // Finally divide again by ratio
        string name = Form("%s_divided_by_ratio",specializedPartCust->GetName()) ;
-       RooFormulaVar* specIntFinal = new RooFormulaVar(name.c_str(),"@0/@1",RooArgList(*specializedPartCust,*specializedRatio)) ;
+       auto specIntFinal = std::make_unique<RooFormulaVar>(name.c_str(),"@0/@1",RooArgList(*specializedPartCust,*specializedRatio)) ;
+       specIntFinal->addOwnedComponents(std::move(specializedPartCust));
+       specIntFinal->addOwnedComponents(std::move(specializedRatio));
 
-       denListList[*iter].add(*specIntFinal) ;
+       denListList[*iter].addOwned(std::move(specIntFinal));
      } else {
 
 //        cout << "does NOT depend on value of ratio" << endl ;
 //        parg->Print("t") ;
 
-       denListList[*iter].add(*specializeIntegral(*parg,iter->c_str())) ;
+       denListList[*iter].addOwned(specializeIntegral(*parg,iter->c_str()));
 
      }
    }
@@ -1137,7 +1140,7 @@ void RooProdPdf::rearrangeProduct(RooProdPdf::CacheElem& cache) const
 
    if (ratio) {
 
-     RooAbsReal* specRatio = specializeRatio(*(RooFormulaVar*)ratio,iter->c_str()) ;
+     std::unique_ptr<RooAbsReal> specRatio{specializeRatio(*(RooFormulaVar*)ratio,iter->c_str())};
 
      // If integral is 'Int r(y)*g(y) dy ' then divide a posteriori by r(y)
 //      cout << "have ratio, orig den = " << den->GetName() << endl ;
@@ -1145,25 +1148,29 @@ void RooProdPdf::rearrangeProduct(RooProdPdf::CacheElem& cache) const
      RooArgSet tmp(origNumTerm) ;
      tmp.add(*specRatio) ;
      const string pname = makeRGPPName("PROD",tmp,RooArgSet(),RooArgSet(),0) ;
-     RooProduct* specDenProd = new RooProduct(pname.c_str(),pname.c_str(),tmp) ;
-     RooAbsReal* specInt(0) ;
+     auto specDenProd = std::make_unique<RooProduct>(pname.c_str(),pname.c_str(),tmp) ;
+     std::unique_ptr<RooAbsReal> specInt;
 
      if (den->InheritsFrom(RooRealIntegral::Class())) {
-       specInt = specDenProd->createIntegral(((RooRealIntegral*)den)->intVars(),iter->c_str()) ;
+       specInt = std::unique_ptr<RooAbsReal>{specDenProd->createIntegral(((RooRealIntegral*)den)->intVars(),iter->c_str())};
+       specInt->addOwnedComponents(std::move(specDenProd));
      } else if (den->InheritsFrom(RooAddition::Class())) {
        RooAddition* orig = (RooAddition*)den ;
        RooRealIntegral* origInt = (RooRealIntegral*) orig->list1().first() ;
-       specInt = specDenProd->createIntegral(origInt->intVars(),iter->c_str()) ;
+       specInt = std::unique_ptr<RooAbsReal>{specDenProd->createIntegral(origInt->intVars(),iter->c_str())};
+       specInt->addOwnedComponents(std::move(specDenProd));
      } else {
        throw string("this should not happen") ;
      }
 
      //RooAbsReal* specInt = specializeIntegral(*den,iter->c_str()) ;
      string name = Form("%s_divided_by_ratio",specInt->GetName()) ;
-     RooFormulaVar* specIntFinal = new RooFormulaVar(name.c_str(),"@0/@1",RooArgList(*specInt,*specRatio)) ;
-     denListList[*iter].add(*specIntFinal) ;
+     auto specIntFinal = std::make_unique<RooFormulaVar>(name.c_str(),"@0/@1",RooArgList(*specInt,*specRatio)) ;
+     specIntFinal->addOwnedComponents(std::move(specInt));
+     specIntFinal->addOwnedComponents(std::move(specRatio));
+     denListList[*iter].addOwned(std::move(specIntFinal));
    } else {
-     denListList[*iter].add(*specializeIntegral(*den,iter->c_str())) ;
+     denListList[*iter].addOwned(specializeIntegral(*den,iter->c_str()));
    }
 
       }
@@ -1188,13 +1195,14 @@ void RooProdPdf::rearrangeProduct(RooProdPdf::CacheElem& cache) const
     name = Form("%s_denominator_comp_%s",GetName(),iter->first.c_str()) ;
     // WVE FIX THIS (2)
     RooProduct* prod_comp = new RooProduct(name.c_str(),name.c_str(),iter->second) ;
+    prod_comp->addOwnedComponents(std::move(iter->second));
     products.add(*prod_comp) ;
   }
   name = Form("%s_denominator_sum",GetName()) ;
   RooAbsReal* norm = new RooAddition(name.c_str(),name.c_str(),products) ;
   norm->addOwnedComponents(products) ;
 
-  if (specIntDeps.getSize()>0) {
+  if (!specIntDeps.empty()) {
     // Apply posterior integration required for SPECINT case
 
     string namesr = Form("SPEC_RATIO(%s,%s)",numerator->GetName(),norm->GetName()) ;
@@ -1226,31 +1234,31 @@ void RooProdPdf::rearrangeProduct(RooProdPdf::CacheElem& cache) const
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooAbsReal* RooProdPdf::specializeRatio(RooFormulaVar& input, const char* targetRangeName) const
+std::unique_ptr<RooAbsReal> RooProdPdf::specializeRatio(RooFormulaVar& input, const char* targetRangeName) const
 {
   RooRealIntegral* numint = (RooRealIntegral*) input.getParameter(0) ;
   RooRealIntegral* denint = (RooRealIntegral*) input.getParameter(1) ;
 
-  RooAbsReal* numint_spec = specializeIntegral(*numint,targetRangeName) ;
+  std::unique_ptr<RooAbsReal> numint_spec{specializeIntegral(*numint,targetRangeName)};
 
-  RooAbsReal* ret =  new RooFormulaVar(Form("ratio(%s,%s)",numint_spec->GetName(),denint->GetName()),"@0/@1",RooArgList(*numint_spec,*denint)) ;
-  ret->addOwnedComponents(*numint_spec) ;
+  std::unique_ptr<RooAbsReal> ret = std::make_unique<RooFormulaVar>(Form("ratio(%s,%s)",numint_spec->GetName(),denint->GetName()),"@0/@1",RooArgList(*numint_spec,*denint)) ;
+  ret->addOwnedComponents(std::move(numint_spec));
 
-  return ret ;
+  return ret;
 }
 
 
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooAbsReal* RooProdPdf::specializeIntegral(RooAbsReal& input, const char* targetRangeName) const
+std::unique_ptr<RooAbsReal> RooProdPdf::specializeIntegral(RooAbsReal& input, const char* targetRangeName) const
 {
   if (input.InheritsFrom(RooRealIntegral::Class())) {
 
     // If input is integral, recreate integral but override integration range to be targetRangeName
     RooRealIntegral* orig = (RooRealIntegral*)&input ;
 //     cout << "creating integral: integrand =  " << orig->integrand().GetName() << " vars = " << orig->intVars() << " range = " << targetRangeName << endl ;
-    return orig->integrand().createIntegral(orig->intVars(),targetRangeName) ;
+    return std::unique_ptr<RooAbsReal>{orig->integrand().createIntegral(orig->intVars(),targetRangeName)};
 
   } else if (input.InheritsFrom(RooAddition::Class())) {
 
@@ -1258,14 +1266,12 @@ RooAbsReal* RooProdPdf::specializeIntegral(RooAbsReal& input, const char* target
     RooAddition* orig = (RooAddition*)&input ;
     RooRealIntegral* origInt = (RooRealIntegral*) orig->list1().first() ;
 //     cout << "creating integral from addition: integrand =  " << origInt->integrand().GetName() << " vars = " << origInt->intVars() << " range = " << targetRangeName << endl ;
-    return origInt->integrand().createIntegral(origInt->intVars(),targetRangeName) ;
-
-  } else {
-
-//     cout << "specializeIntegral: unknown input type " << input.ClassName() << "::" << input.GetName() << endl ;
+    return std::unique_ptr<RooAbsReal>{origInt->integrand().createIntegral(origInt->intVars(),targetRangeName)};
   }
 
-  return &input ;
+  std::stringstream errMsg;
+  errMsg << "specializeIntegral: unknown input type " << input.ClassName() << "::" << input.GetName();
+  throw std::runtime_error(errMsg.str());
 }
 
 

--- a/roofit/roofitcore/src/RooRealIntegral.cxx
+++ b/roofit/roofitcore/src/RooRealIntegral.cxx
@@ -771,7 +771,7 @@ RooRealIntegral::~RooRealIntegral()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooAbsReal* RooRealIntegral::createIntegral(const RooArgSet& iset, const RooArgSet* nset, const RooNumIntConfig* cfg, const char* rangeName) const
+RooFit::OwningPtr<RooAbsReal> RooRealIntegral::createIntegral(const RooArgSet& iset, const RooArgSet* nset, const RooNumIntConfig* cfg, const char* rangeName) const
 {
   // Handle special case of no integration with default algorithm
   if (iset.empty()) {
@@ -797,9 +797,7 @@ RooAbsReal* RooRealIntegral::createIntegral(const RooArgSet& iset, const RooArgS
     tmp->add(*_funcNormSet,true) ;
     newNormSet = tmp.get();
   }
-  RooAbsReal* ret =  _function->createIntegral(isetAll,newNormSet,cfg,rangeName) ;
-
-  return ret ;
+  return  _function->createIntegral(isetAll,newNormSet,cfg,rangeName);
 }
 
 

--- a/roofit/roofitcore/src/RooSecondMoment.cxx
+++ b/roofit/roofitcore/src/RooSecondMoment.cxx
@@ -70,7 +70,7 @@ RooSecondMoment::RooSecondMoment(const char* name, const char* title, RooAbsReal
 {
   setExpensiveObjectCache(func.expensiveObjectCache()) ;
 
-  RooAbsReal* XF(0) ;
+  std::unique_ptr<RooAbsReal> XF;
   if (centr) {
 
     string m1name=Form("%s_moment1",GetName()) ;
@@ -78,12 +78,12 @@ RooSecondMoment::RooSecondMoment(const char* name, const char* title, RooAbsReal
 
     string pname=Form("%s_product",name) ;
     _xfOffset = _mean->getVal() ;
-    XF = new RooFormulaVar(pname.c_str(),Form("pow((@0-%f),2)*@1",_xfOffset),RooArgList(x,func)) ;
+    XF = std::make_unique<RooFormulaVar>(pname.c_str(),Form("pow((@0-%f),2)*@1",_xfOffset),RooArgList(x,func)) ;
 
   } else {
 
     string pname=Form("%s_product",name) ;
-    XF = new RooProduct(pname.c_str(),pname.c_str(),RooArgList(x,x,func)) ;
+    XF = std::make_unique<RooProduct>(pname.c_str(),pname.c_str(),RooArgList(x,x,func)) ;
   }
 
   XF->setExpensiveObjectCache(func.expensiveObjectCache()) ;
@@ -92,15 +92,17 @@ RooSecondMoment::RooSecondMoment(const char* name, const char* title, RooAbsReal
     XF->specialIntegratorConfig(true)->method1D().setLabel("RooBinIntegrator");
   }
 
-  RooRealIntegral* intXF = (RooRealIntegral*) XF->createIntegral(x) ;
-  RooRealIntegral* intF =  (RooRealIntegral*) func.createIntegral(x) ;
-  intXF->setCacheNumeric(true) ;
-  intF->setCacheNumeric(true) ;
+  std::unique_ptr<RooAbsReal> intXF{XF->createIntegral(x)};
+  std::unique_ptr<RooAbsReal> intF{func.createIntegral(x)};
+  static_cast<RooRealIntegral&>(*intXF).setCacheNumeric(true) ;
+  static_cast<RooRealIntegral&>(*intF).setCacheNumeric(true) ;
 
   _xf.setArg(*XF) ;
   _ixf.setArg(*intXF) ;
   _if.setArg(*intF) ;
-  addOwnedComponents(RooArgSet(*XF,*intXF,*intF)) ;
+  addOwnedComponents(std::move(XF)) ;
+  addOwnedComponents(std::move(intXF));
+  addOwnedComponents(std::move(intF));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -117,7 +119,7 @@ RooSecondMoment::RooSecondMoment(const char* name, const char* title, RooAbsReal
 
   _nset.add(nset) ;
 
-  RooAbsReal* XF(0) ;
+  std::unique_ptr<RooAbsReal> XF;
   if (centr) {
 
     string m1name=Form("%s_moment1",GetName()) ;
@@ -125,13 +127,13 @@ RooSecondMoment::RooSecondMoment(const char* name, const char* title, RooAbsReal
 
     string pname=Form("%s_product",name) ;
     _xfOffset = _mean->getVal() ;
-    XF = new RooFormulaVar(pname.c_str(),Form("pow((@0-%f),2)*@1",_xfOffset),RooArgList(x,func)) ;
+    XF = std::make_unique<RooFormulaVar>(pname.c_str(),Form("pow((@0-%f),2)*@1",_xfOffset),RooArgList(x,func)) ;
 
 
   } else {
 
     string pname=Form("%s_product",name) ;
-    XF = new RooProduct(pname.c_str(),pname.c_str(),RooArgList(x,x,func)) ;
+    XF = std::make_unique<RooProduct>(pname.c_str(),pname.c_str(),RooArgList(x,x,func)) ;
 
   }
 
@@ -147,15 +149,17 @@ RooSecondMoment::RooSecondMoment(const char* name, const char* title, RooAbsReal
 
   RooArgSet intSet(x) ;
   if (intNSet) intSet.add(_nset,true) ;
-  RooRealIntegral* intXF = (RooRealIntegral*) XF->createIntegral(intSet,&_nset) ;
-  RooRealIntegral* intF =  (RooRealIntegral*) func.createIntegral(intSet,&_nset) ;
-  intXF->setCacheNumeric(true) ;
-  intF->setCacheNumeric(true) ;
+  std::unique_ptr<RooAbsReal> intXF{XF->createIntegral(intSet, &_nset)};
+  std::unique_ptr<RooAbsReal> intF{func.createIntegral(intSet, &_nset)};
+  static_cast<RooRealIntegral&>(*intXF).setCacheNumeric(true) ;
+  static_cast<RooRealIntegral&>(*intF).setCacheNumeric(true) ;
 
   _xf.setArg(*XF) ;
   _ixf.setArg(*intXF) ;
   _if.setArg(*intF) ;
-  addOwnedComponents(RooArgSet(*XF,*intXF,*intF)) ;
+  addOwnedComponents(std::move(XF)) ;
+  addOwnedComponents(std::move(intXF));
+  addOwnedComponents(std::move(intF));
 }
 
 

--- a/roofit/roofitcore/src/RooXYChi2Var.cxx
+++ b/roofit/roofitcore/src/RooXYChi2Var.cxx
@@ -245,7 +245,7 @@ void RooXYChi2Var::initialize()
 void RooXYChi2Var::initIntegrator()
 {
   if (!_funcInt) {
-    _funcInt = _funcClone->createIntegral(_rrvArgs,_rrvArgs,_intConfig,"bin") ;
+    _funcInt = std::unique_ptr<RooAbsReal>{_funcClone->createIntegral(_rrvArgs,_rrvArgs,_intConfig,"bin")};
     for(auto * x : static_range_cast<RooRealVar*>(_rrvArgs)) {
       _binList.push_back(&x->getBinning("bin",false,true)) ;
     }
@@ -254,16 +254,7 @@ void RooXYChi2Var::initIntegrator()
 }
 
 
-
-////////////////////////////////////////////////////////////////////////////////
-/// Destructor
-
-RooXYChi2Var::~RooXYChi2Var()
-{
-  if (_funcInt) delete _funcInt ;
-}
-
-
+RooXYChi2Var::~RooXYChi2Var() = default;
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/test/TestStatistics/testRooRealL.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testRooRealL.cxx
@@ -102,7 +102,8 @@ void count_NLL_components(RooAbsReal *nll, bool verbose = false)
          std::cout << "the NLL object is a RooAddition*..." << std::endl;
       }
       std::size_t nll_component_count = 0;
-      for (const auto &component : *nll->getComponents()) {
+      std::unique_ptr<RooArgSet> components{nll->getComponents()};
+      for (const auto &component : *components) {
          if (component->IsA() == RooNLLVar::Class()) {
             ++nll_component_count;
          }

--- a/roofit/roostats/src/BayesianCalculator.cxx
+++ b/roofit/roostats/src/BayesianCalculator.cxx
@@ -913,7 +913,7 @@ RooAbsReal* BayesianCalculator::GetPosteriorFunction() const
       }
       else
          // case of using RooFit for the integration
-         fIntegratedLikelihood = fLikelihood->createIntegral(fNuisanceParameters);
+         fIntegratedLikelihood = std::unique_ptr<RooAbsReal>{fLikelihood->createIntegral(fNuisanceParameters)}.release();
 
 
    }

--- a/roofit/roostats/src/FrequentistCalculator.cxx
+++ b/roofit/roostats/src/FrequentistCalculator.cxx
@@ -105,11 +105,9 @@ int FrequentistCalculator::PreNullHook(RooArgSet *parameterPoint, double obsTest
 
       // Hack to extract a RooFitResult
       if (fStoreFitInfo) {
-         RooFitResult *result = profile->minimizer()->save();
-         RooArgSet * detOutput = DetailedOutputAggregator::GetAsArgSet(result, "fitNull_");
+         std::unique_ptr<RooFitResult> result {profile->minimizer()->save()};
+         std::unique_ptr<RooArgSet> detOutput {DetailedOutputAggregator::GetAsArgSet(result.get(), "fitNull_")};
          fFitInfo->addOwned(*detOutput);
-         delete detOutput;
-         delete result;
       }
 
       RooMsgService::instance().setGlobalKillBelow(msglevel);
@@ -213,11 +211,9 @@ int FrequentistCalculator::PreAltHook(RooArgSet *parameterPoint, double obsTestS
 
       // Hack to extract a RooFitResult
       if (fStoreFitInfo) {
-         RooFitResult *result = profile->minimizer()->save();
-         RooArgSet * detOutput =  DetailedOutputAggregator::GetAsArgSet(result, "fitAlt_");
+         std::unique_ptr<RooFitResult> result {profile->minimizer()->save()};
+         std::unique_ptr<RooArgSet> detOutput {DetailedOutputAggregator::GetAsArgSet(result.get(), "fitAlt_")};
          fFitInfo->addOwned(*detOutput);
-         delete detOutput;
-         delete result;
       }
 
       RooMsgService::instance().setGlobalKillBelow(msglevel);

--- a/roofit/roostats/src/HypoTestCalculatorGeneric.cxx
+++ b/roofit/roostats/src/HypoTestCalculatorGeneric.cxx
@@ -110,7 +110,7 @@ HypoTestResult* HypoTestCalculatorGeneric::GetHypoTest() const {
    const_cast<ModelConfig*>(fNullModel)->GuessObsAndNuisance(*fData);
    const_cast<ModelConfig*>(fAltModel)->GuessObsAndNuisance(*fData);
 
-   const RooArgSet * nullSnapshot = fNullModel->GetSnapshot();
+   std::unique_ptr<const RooArgSet> nullSnapshot {fNullModel->GetSnapshot()};
    if(nullSnapshot == nullptr) {
       oocoutE(nullptr,Generation) << "Null model needs a snapshot. Set using modelconfig->SetSnapshot(poi)." << endl;
       return 0;
@@ -132,7 +132,7 @@ HypoTestResult* HypoTestCalculatorGeneric::GetHypoTest() const {
    // save all parameters so we can set them back to what they were
    std::unique_ptr<RooArgSet> bothParams{fNullModel->GetPdf()->getParameters(*fData)};
    bothParams->add(*altParams,false);
-   RooArgSet *saveAll = (RooArgSet*) bothParams->snapshot();
+   std::unique_ptr<RooArgSet> saveAll {(RooArgSet*) bothParams->snapshot()};
 
    // check whether we have a ToyMCSampler and if so, keep a pointer to it
    ToyMCSampler* toymcs = dynamic_cast<ToyMCSampler*>( fTestStatSampler );
@@ -142,17 +142,16 @@ HypoTestResult* HypoTestCalculatorGeneric::GetHypoTest() const {
    RooArgSet nullP(*nullSnapshot);
    double obsTestStat;
 
-   RooArgList* allTS = nullptr;
+   std::unique_ptr<RooArgList> allTS;
    if( toymcs ) {
-      allTS = toymcs->EvaluateAllTestStatistics(*const_cast<RooAbsData*>(fData), nullP);
+      allTS = std::unique_ptr<RooArgList>{toymcs->EvaluateAllTestStatistics(*const_cast<RooAbsData*>(fData), nullP)};
       if (!allTS) return 0;
       //oocoutP(nullptr,Generation) << "All Test Statistics on data: " << endl;
       //allTS->Print("v");
       RooRealVar* firstTS = (RooRealVar*)allTS->at(0);
       obsTestStat = firstTS->getVal();
       if (allTS->getSize()<=1) {
-        delete allTS;
-        allTS= 0;  // don't save
+        allTS = nullptr; // don't save
       }
    }else{
       obsTestStat = fTestStatSampler->EvaluateTestStatistic(*const_cast<RooAbsData*>(fData), nullP);
@@ -228,11 +227,11 @@ HypoTestResult* HypoTestCalculatorGeneric::GetHypoTest() const {
    HypoTestResult* res = new HypoTestResult(resultname.c_str());
    res->SetPValueIsRightTail(fTestStatSampler->GetTestStatistic()->PValueIsRightTail());
    res->SetTestStatisticData(obsTestStat);
-   res->SetAltDistribution(samp_alt);
-   res->SetNullDistribution(samp_null);
+   res->SetAltDistribution(samp_alt); // takes ownership of samp_alt
+   res->SetNullDistribution(samp_null); // takes ownership of samp_null
    res->SetAltDetailedOutput( detOut_alt );
    res->SetNullDetailedOutput( detOut_null );
-   res->SetAllTestStatisticsData( allTS );
+   res->SetAllTestStatisticsData( allTS.get() );
 
    const RooArgSet *aset = GetFitInfo();
    if (aset != nullptr) {
@@ -242,9 +241,6 @@ HypoTestResult* HypoTestCalculatorGeneric::GetHypoTest() const {
    }
 
    bothParams->assign(*saveAll);
-   delete allTS;
-   delete saveAll;
-   delete nullSnapshot;
    PostHook();
    return res;
 }

--- a/roofit/roostats/src/MCMCInterval.cxx
+++ b/roofit/roostats/src/MCMCInterval.cxx
@@ -724,10 +724,8 @@ void MCMCInterval::DetermineByKeys()
 
    double cutoff = 0.0;
    fCutoffVar->setVal(cutoff);
-   RooAbsReal* integral = fProduct->createIntegral(fParameters, NormSet(fParameters));
-   double full = integral->getVal(fParameters);
+   double full = std::unique_ptr<RooAbsReal>{fProduct->createIntegral(fParameters, NormSet(fParameters))}->getVal(fParameters);
    fFull = full;
-   delete integral;
    if (full < 0.98) {
       coutW(Eval) << "Warning: Integral of Keys PDF came out to " << full
          << " instead of expected value 1.  Will continue using this "
@@ -1379,14 +1377,10 @@ double MCMCInterval::GetKeysPdfCutoff()
 
 double MCMCInterval::CalcConfLevel(double cutoff, double full)
 {
-   RooAbsReal* integral;
-   double confLevel;
    fCutoffVar->setVal(cutoff);
-   integral = fProduct->createIntegral(fParameters, NormSet(fParameters));
-   confLevel = integral->getVal(fParameters) / full;
+   std::unique_ptr<RooAbsReal> integral{fProduct->createIntegral(fParameters, NormSet(fParameters))};
+   double confLevel = integral->getVal(fParameters) / full;
    coutI(Eval) << "cutoff = " << cutoff << ", conf = " << confLevel << endl;
-   //cout << "tmp: cutoff = " << cutoff << ", conf = " << confLevel << endl;
-   delete integral;
    return confLevel;
 }
 

--- a/roofit/roostats/src/ProposalHelper.cxx
+++ b/roofit/roostats/src/ProposalHelper.cxx
@@ -111,31 +111,26 @@ ProposalFunction* ProposalHelper::GetProposalFunction()
 
 void ProposalHelper::CreatePdf()
 {
-   // kbelasco: check here for memory leaks:
-   // does RooMultiVarGaussian make copies of xVec and muVec?
-   // or should we delete them?
    if (fVars == nullptr) {
       coutE(InputArguments) << "ProposalHelper::CreatePdf(): " <<
          "Variables to create proposal function for are not set." << endl;
       return;
    }
-   RooArgList* xVec = new RooArgList();
-   RooArgList* muVec = new RooArgList();
+   RooArgList xVec{};
+   RooArgList muVec{};
    RooRealVar* clone; 
    for (auto *r : static_range_cast<RooRealVar *> (*fVars)){
-      xVec->add(*r);
+      xVec.add(*r);
       TString cloneName = TString::Format("%s%s", "mu__", r->GetName());
       clone = static_cast<RooRealVar*>(r->clone(cloneName.Data()));
-      muVec->add(*clone);
+      muVec.add(*clone);
       if (fUseUpdates)
          fPdfProp->AddMapping(*clone, *r);
    }
    if (fCovMatrix == nullptr)
-      CreateCovMatrix(*xVec);
-   fPdf = new RooMultiVarGaussian("mvg", "MVG Proposal", *xVec, *muVec,
+      CreateCovMatrix(xVec);
+   fPdf = new RooMultiVarGaussian("mvg", "MVG Proposal", xVec, muVec,
                                   *fCovMatrix);
-   delete xVec;
-   delete muVec;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roostats/src/ProposalHelper.cxx
+++ b/roofit/roostats/src/ProposalHelper.cxx
@@ -77,10 +77,8 @@ ProposalFunction* ProposalHelper::GetProposalFunction()
 {
    if (fPdf == nullptr)
       CreatePdf();
-   // kbelasco: check here for memory leaks: does RooAddPdf make copies or
-   // take ownership of components, coeffs
-   RooArgList* components = new RooArgList();
-   RooArgList* coeffs = new RooArgList();
+   RooArgList components;
+   RooArgList coeffs;
    if (fCluesPdf == nullptr)
       CreateCluesPdf();
    if (fCluesPdf != nullptr) {
@@ -88,17 +86,17 @@ ProposalFunction* ProposalHelper::GetProposalFunction()
          fCluesFrac = DEFAULT_CLUES_FRAC;
       printf("added clues from dataset %s with fraction %g\n",
             fClues->GetName(), fCluesFrac);
-      components->add(*fCluesPdf);
-      coeffs->add(RooConst(fCluesFrac));
+      components.add(*fCluesPdf);
+      coeffs.add(RooConst(fCluesFrac));
    }
    if (fUniFrac > 0.) {
       CreateUniformPdf();
-      components->add(*fUniformPdf);
-      coeffs->add(RooConst(fUniFrac));
+      components.add(*fUniformPdf);
+      coeffs.add(RooConst(fUniFrac));
    }
-   components->add(*fPdf);
+   components.add(*fPdf);
    RooAddPdf* addPdf = new RooAddPdf("proposalFunction", "Proposal Density",
-         *components, *coeffs);
+         components, coeffs);
    fPdfProp->SetPdf(*addPdf);
    fPdfProp->SetOwnsPdf(true);
    if (fCacheSize > 0)

--- a/roofit/roostats/src/ToyMCSampler.cxx
+++ b/roofit/roostats/src/ToyMCSampler.cxx
@@ -291,15 +291,13 @@ SamplingDistribution* ToyMCSampler::GetSamplingDistribution(RooArgSet& paramPoin
       }
    }
 
-   RooDataSet* r = GetSamplingDistributions(paramPointIn);
+   std::unique_ptr<RooDataSet> r{GetSamplingDistributions(paramPointIn)};
    if(r == nullptr || r->numEntries() == 0) {
       oocoutW(nullptr, Generation) << "no sampling distribution generated" << endl;
       return nullptr;
    }
 
-   SamplingDistribution* samp = new SamplingDistribution( r->GetName(), r->GetTitle(), *r );
-   delete r;
-   return samp;
+   return new SamplingDistribution( r->GetName(), r->GetTitle(), *r );
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Modernize memory management in RooStats by using more `std::unique_ptr`

