### PR TITLE
[skip-ci] fix an issue with python 3.12

### DIFF
--- a/build/misc/argparse2help.py
+++ b/build/misc/argparse2help.py
@@ -54,7 +54,7 @@ def write_man(parser, fileName):
 			listOptions = [arg.dest]
 		else:
 			listOptions = arg.option_strings
-		options = "\ ".join(listOptions)
+		options = " ".join(listOptions)
 		if help != None:
 			file.write(".IP {}\n".format(options))
 			file.write(help.replace("\n","\n.IP\n")+ "\n")


### PR DESCRIPTION
Fix this error:
```
$ python3.12 build/misc/argparse2help.py
/home/blue/ROOT/master-py312/build/misc/argparse2help.py:57: SyntaxWarning: invalid escape sequence '\ '
  options = "\ ".join(listOptions)
```

