### PR TITLE
[PyROOT] Feature to initialise RooWorkspace objects in PyRoot using strings

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooworkspace.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooworkspace.py
@@ -39,6 +39,31 @@ class RooWorkspace(object):
         # The key is passed to the general `RooWorkspace::obj()` function.
         return self.obj(key)
 
+    def __setitem__(self, key, value):
+        # Check if initialization is done with string
+        if(isinstance(value, str)):
+            if(not self.obj(key)):
+                parenthesis_index = -1
+                for i in range(0,len(value)):
+                    if(value[i]=='[' or value[i]=='('):
+                        parenthesis_index = i
+                        break
+                # Initializes variables
+                if value[parenthesis_index]=='[' and parenthesis_index!=-1:
+                    expr = key + value
+                    self.factory(expr)
+                # Initializes functions and p.d.f.s
+                elif value[parenthesis_index]=='(' and parenthesis_index!=-1:
+                    expr = value[0:parenthesis_index] + "::" + key + value[parenthesis_index:]
+                    self.factory(expr)
+                # Else raises a Syntax error
+                else:
+                    raise SyntaxError("Invalid syntax")
+            else:
+                raise RuntimeError("ERROR importing object named " + key + " another instance with same name already in the workspace and no conflict resolution protocol specified")
+        else:
+            raise TypeError("Object of type 'str' expected but " + type(value) + " was given")
+
     @cpp_signature(
         [
             "Bool_t RooWorkspace::import(const RooAbsArg& arg,"

--- a/bindings/pyroot/pythonizations/test/roofit/rooworkspace.py
+++ b/bindings/pyroot/pythonizations/test/roofit/rooworkspace.py
@@ -39,6 +39,17 @@ class RooWorkspace_test(unittest.TestCase):
         self.assertEqual(x.GetName(), "x")
         self.assertEqual(x.getVal(), self.x.getVal())
 
+    def test_setItem_using_dictionary(self):
+         # Test to check if new variables are created
+        self.ws["z"] = "[3]"
+        self.assertEqual(self.ws["z"].GetName(),"z")
+        self.assertEqual(self.ws["z"].getVal(),3.0)
+
+        # Test to check if new p.d.f.s are created
+        self.ws["gauss"] = "Gaussian(x[0.0, 10.0], mu[5.0], sigma[2.0, 0.01, 10.0])"
+        self.assertEqual(self.ws["gauss"].getMean(), self.ws["mu"])
+        self.assertEqual(self.ws["gauss"].getSigma(), self.ws["sigma"])
+        self.assertEqual(self.ws["gauss"].getX(), self.ws["x"])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# This Pull request:

Adds a feature in PyROOT to create new objects in RooWorkspace using a key-value pair, which has the object name as its key and an initialization string as its value.

For example, the following snippet creates a gaussian p.d.f. - 


```Python
import ROOT

ws = ROOT.RooWorkspace("ws")

ws["gauss"] = "Gaussian(x[0.0, 10.0], mu[5.0], sigma[2.0, 0.01, 10.0])"
````

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)