### PR TITLE
Automatically add `override` to io with clang-tidy

### DIFF
--- a/io/dcache/inc/TDCacheFile.h
+++ b/io/dcache/inc/TDCacheFile.h
@@ -31,27 +31,27 @@ private:
    TDCacheFile() : fStatCached(kFALSE) { }
 
    // Interface to basic system I/O routines
-   Int_t    SysOpen(const char *pathname, Int_t flags, UInt_t mode);
-   Int_t    SysClose(Int_t fd);
-   Int_t    SysRead(Int_t fd, void *buf, Int_t len);
-   Int_t    SysWrite(Int_t fd, const void *buf, Int_t len);
-   Long64_t SysSeek(Int_t fd, Long64_t offset, Int_t whence);
-   Int_t    SysStat(Int_t fd, Long_t *id, Long64_t *size, Long_t *flags, Long_t *modtime);
-   Int_t    SysSync(Int_t fd);
+   Int_t    SysOpen(const char *pathname, Int_t flags, UInt_t mode) override;
+   Int_t    SysClose(Int_t fd) override;
+   Int_t    SysRead(Int_t fd, void *buf, Int_t len) override;
+   Int_t    SysWrite(Int_t fd, const void *buf, Int_t len) override;
+   Long64_t SysSeek(Int_t fd, Long64_t offset, Int_t whence) override;
+   Int_t    SysStat(Int_t fd, Long_t *id, Long64_t *size, Long_t *flags, Long_t *modtime) override;
+   Int_t    SysSync(Int_t fd) override;
 
 public:
    TDCacheFile(const char *path, Option_t *option="",
                const char *ftitle="", Int_t compress = ROOT::RCompressionSetting::EDefaults::kUseCompiledDefault);
 
-   ~TDCacheFile();
+   ~TDCacheFile() override;
 
-   Bool_t  ReadBuffer(char *buf, Int_t len);
-   Bool_t  ReadBuffer(char *buf, Long64_t pos, Int_t len);
-   Bool_t  WriteBuffer(const char *buf, Int_t len);
+   Bool_t  ReadBuffer(char *buf, Int_t len) override;
+   Bool_t  ReadBuffer(char *buf, Long64_t pos, Int_t len) override;
+   Bool_t  WriteBuffer(const char *buf, Int_t len) override;
 
-   Bool_t  ReadBuffers(char *buf, Long64_t *pos, Int_t *len, Int_t nbuf);
+   Bool_t  ReadBuffers(char *buf, Long64_t *pos, Int_t *len, Int_t nbuf) override;
 
-   void    ResetErrno() const;
+   void    ResetErrno() const override;
 
    static Bool_t Stage(const char *path, UInt_t secs,
                        const char *location = 0);
@@ -72,7 +72,7 @@ public:
    static TString GetDcapPath(const char *path);
 
 
-   ClassDef(TDCacheFile,1)  //A ROOT file that reads/writes via a dCache server
+   ClassDefOverride(TDCacheFile,1)  //A ROOT file that reads/writes via a dCache server
 };
 
 
@@ -81,20 +81,20 @@ class TDCacheSystem : public TSystem {
 private:
    void    *fDirp;   ///< directory handler
 
-   void    *GetDirPtr() const { return fDirp; }
+   void    *GetDirPtr() const override { return fDirp; }
 
 public:
    TDCacheSystem();
-   virtual ~TDCacheSystem() { }
+   ~TDCacheSystem() override { }
 
-   Int_t       MakeDirectory(const char *name);
-   void       *OpenDirectory(const char *name);
-   void        FreeDirectory(void *dirp);
-   const char *GetDirEntry(void *dirp);
-   Int_t       GetPathInfo(const char *path, FileStat_t &buf);
-   Bool_t      AccessPathName(const char *path, EAccessMode mode);
+   Int_t       MakeDirectory(const char *name) override;
+   void       *OpenDirectory(const char *name) override;
+   void        FreeDirectory(void *dirp) override;
+   const char *GetDirEntry(void *dirp) override;
+   Int_t       GetPathInfo(const char *path, FileStat_t &buf) override;
+   Bool_t      AccessPathName(const char *path, EAccessMode mode) override;
 
-   ClassDef(TDCacheSystem,0)  // Directory handler for DCache
+   ClassDefOverride(TDCacheSystem,0)  // Directory handler for DCache
 };
 
 #endif

--- a/io/gfal/inc/TGFALFile.h
+++ b/io/gfal/inc/TGFALFile.h
@@ -25,24 +25,24 @@ private:
    TGFALFile() : fStatCached(kFALSE) { }
 
    // Interface to basic system I/O routines
-   Int_t    SysOpen(const char *pathname, Int_t flags, UInt_t mode);
-   Int_t    SysClose(Int_t fd);
-   Int_t    SysRead(Int_t fd, void *buf, Int_t len);
-   Int_t    SysWrite(Int_t fd, const void *buf, Int_t len);
-   Long64_t SysSeek(Int_t fd, Long64_t offset, Int_t whence);
-   Int_t    SysStat(Int_t fd, Long_t *id, Long64_t *size, Long_t *flags, Long_t *modtime);
-   Int_t    SysSync(Int_t) { /* no fsync for GFAL */ return 0; }
+   Int_t    SysOpen(const char *pathname, Int_t flags, UInt_t mode) override;
+   Int_t    SysClose(Int_t fd) override;
+   Int_t    SysRead(Int_t fd, void *buf, Int_t len) override;
+   Int_t    SysWrite(Int_t fd, const void *buf, Int_t len) override;
+   Long64_t SysSeek(Int_t fd, Long64_t offset, Int_t whence) override;
+   Int_t    SysStat(Int_t fd, Long_t *id, Long64_t *size, Long_t *flags, Long_t *modtime) override;
+   Int_t    SysSync(Int_t) override { /* no fsync for GFAL */ return 0; }
 
 public:
    TGFALFile(const char *url, Option_t *option="",
              const char *ftitle="", Int_t compress = ROOT::RCompressionSetting::EDefaults::kUseCompiledDefault);
-   ~TGFALFile();
+   ~TGFALFile() override;
 
-   Bool_t  ReadBuffer(char *buf, Int_t len);
-   Bool_t  ReadBuffer(char *buf, Long64_t pos, Int_t len);
-   Bool_t  WriteBuffer(const char *buf, Int_t len);
+   Bool_t  ReadBuffer(char *buf, Int_t len) override;
+   Bool_t  ReadBuffer(char *buf, Long64_t pos, Int_t len) override;
+   Bool_t  WriteBuffer(const char *buf, Int_t len) override;
 
-   ClassDef(TGFALFile,1)  //A ROOT file that reads/writes via a GFAL
+   ClassDefOverride(TGFALFile,1)  //A ROOT file that reads/writes via a GFAL
 };
 
 
@@ -51,20 +51,20 @@ class TGFALSystem : public TSystem {
 private:
    void    *fDirp;   // directory handler
 
-   void    *GetDirPtr() const { return fDirp; }
+   void    *GetDirPtr() const override { return fDirp; }
 
 public:
    TGFALSystem();
-   virtual ~TGFALSystem() { }
+   ~TGFALSystem() override { }
 
-   Int_t       MakeDirectory(const char *name);
-   void       *OpenDirectory(const char *name);
-   void        FreeDirectory(void *dirp);
-   const char *GetDirEntry(void *dirp);
-   Int_t       GetPathInfo(const char *path, FileStat_t &buf);
-   Bool_t      AccessPathName(const char *path, EAccessMode mode);
+   Int_t       MakeDirectory(const char *name) override;
+   void       *OpenDirectory(const char *name) override;
+   void        FreeDirectory(void *dirp) override;
+   const char *GetDirEntry(void *dirp) override;
+   Int_t       GetPathInfo(const char *path, FileStat_t &buf) override;
+   Bool_t      AccessPathName(const char *path, EAccessMode mode) override;
 
-   ClassDef(TGFALSystem,0)  // Directory handler for GFAL
+   ClassDefOverride(TGFALSystem,0)  // Directory handler for GFAL
 };
 
 #endif

--- a/io/io/inc/ROOT/RRawFileUnix.hxx
+++ b/io/io/inc/ROOT/RRawFileUnix.hxx
@@ -42,7 +42,7 @@ protected:
 
 public:
    RRawFileUnix(std::string_view url, RRawFile::ROptions options);
-   ~RRawFileUnix();
+   ~RRawFileUnix() override;
    std::unique_ptr<RRawFile> Clone() const final;
    int GetFeatures() const final;
    int GetFd() const { return fFileDes; }

--- a/io/io/inc/ROOT/RRawFileWin.hxx
+++ b/io/io/inc/ROOT/RRawFileWin.hxx
@@ -41,7 +41,7 @@ protected:
 
 public:
    RRawFileWin(std::string_view url, RRawFile::ROptions options);
-   ~RRawFileWin();
+   ~RRawFileWin() override;
    std::unique_ptr<RRawFile> Clone() const final;
    int GetFeatures() const final { return kFeatureHasSize; }
 };

--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -197,7 +197,7 @@ private:
 
 public:
    /** Destructor */
-   ~TBufferMergerFile();
+   ~TBufferMergerFile() override;
 
    using TMemFile::Write;
 
@@ -208,7 +208,7 @@ public:
     * This function must be called before the TBufferMergerFile gets destroyed,
     * or no data is appended to the TBufferMerger.
     */
-   virtual Int_t Write(const char *name = nullptr, Int_t opt = 0, Int_t bufsize = 0) override;
+   Int_t Write(const char *name = nullptr, Int_t opt = 0, Int_t bufsize = 0) override;
 
    ClassDefOverride(TBufferMergerFile, 0);
 };

--- a/io/io/inc/TArchiveFile.h
+++ b/io/io/inc/TArchiveFile.h
@@ -40,7 +40,7 @@ protected:
 public:
    TArchiveFile() : fArchiveName(""), fMemberName(""), fMemberIndex(-1), fFile(nullptr), fMembers(nullptr), fCurMember(nullptr) { }
    TArchiveFile(const char *archive, const char *member, TFile *file);
-   virtual ~TArchiveFile();
+   ~TArchiveFile() override;
 
    virtual Int_t   OpenArchive() = 0;
    virtual Int_t   SetCurrentMember() = 0;
@@ -81,7 +81,7 @@ public:
    TArchiveMember(const char *name);
    TArchiveMember(const TArchiveMember &member);
    TArchiveMember &operator=(const TArchiveMember &rhs);
-   virtual ~TArchiveMember() { }
+   ~TArchiveMember() override { }
 
    const char *GetName() const override { return fName; }
    const char *GetComment() const { return fComment; }

--- a/io/io/inc/TBufferFile.h
+++ b/io/io/inc/TBufferFile.h
@@ -71,7 +71,7 @@ public:
    TBufferFile(TBuffer::EMode mode);
    TBufferFile(TBuffer::EMode mode, Int_t bufsiz);
    TBufferFile(TBuffer::EMode mode, Int_t bufsiz, void *buf, Bool_t adopt = kTRUE, ReAllocCharFun_t reallocfunc = nullptr);
-   virtual ~TBufferFile();
+   ~TBufferFile() override;
 
    Int_t      CheckByteCount(UInt_t startpos, UInt_t bcnt, const TClass *clss) override;
    Int_t      CheckByteCount(UInt_t startpos, UInt_t bcnt, const char *classname) override;

--- a/io/io/inc/TBufferIO.h
+++ b/io/io/inc/TBufferIO.h
@@ -71,7 +71,7 @@ public:
       kUser3 = BIT(23)  // free for user
    };
 
-   virtual ~TBufferIO();
+   ~TBufferIO() override;
 
    Int_t GetVersionOwner() const override;
 

--- a/io/io/inc/TBufferJSON.h
+++ b/io/io/inc/TBufferJSON.h
@@ -49,7 +49,7 @@ public:
    };
 
    TBufferJSON(TBuffer::EMode mode = TBuffer::kWrite);
-   virtual ~TBufferJSON();
+   ~TBufferJSON() override;
 
    void SetCompact(int level);
    void SetTypenameTag(const char *tag = "_typename");

--- a/io/io/inc/TBufferText.h
+++ b/io/io/inc/TBufferText.h
@@ -24,7 +24,7 @@ protected:
    TBufferText(TBuffer::EMode mode, TObject *parent = nullptr);
 
 public:
-   virtual ~TBufferText();
+   ~TBufferText() override;
 
    // virtual TBuffer methods, which are generic for all text-based streamers
 

--- a/io/io/inc/TCollectionProxyFactory.h
+++ b/io/io/inc/TCollectionProxyFactory.h
@@ -165,7 +165,7 @@ public:
    /// Initializing constructor
    TCollectionClassStreamer() : TClassStreamer(nullptr) {                        }
    /// Standard destructor
-   virtual ~TCollectionClassStreamer()                  {                        }
+   ~TCollectionClassStreamer() override                  {                        }
    /// Streamer for I/O handling
    void operator()(TBuffer &buff, void *obj) override { Streamer(buff,obj,0,fOnFileClass); }
 
@@ -212,7 +212,7 @@ public:
    TCollectionMemberStreamer(const TCollectionMemberStreamer& c)
       : TMemberStreamer(c), TCollectionStreamer(c)   { }
    /// Standard destructor
-   virtual ~TCollectionMemberStreamer()             { }
+   ~TCollectionMemberStreamer() override             { }
    /// Streamer for I/O handling
    void operator()(TBuffer &buff,void *obj, Int_t siz = 0) override
    { Streamer(buff, obj, siz, nullptr); /* FIXME */ }

--- a/io/io/inc/TContainerConverters.h
+++ b/io/io/inc/TContainerConverters.h
@@ -24,7 +24,7 @@ class TConvertClonesArrayToProxy : public TMemberStreamer {
    TClass *fCollectionClass;
 public:
    TConvertClonesArrayToProxy(TVirtualCollectionProxy *proxy, Bool_t isPointer, Bool_t isPrealloc);
-   ~TConvertClonesArrayToProxy();
+   ~TConvertClonesArrayToProxy() override;
    void operator()(TBuffer &b, void *pmember, Int_t size=0) override;
 };
 

--- a/io/io/inc/TDirectoryFile.h
+++ b/io/io/inc/TDirectoryFile.h
@@ -59,7 +59,7 @@ public:
 
    TDirectoryFile();
    TDirectoryFile(const char *name, const char *title, Option_t *option="", TDirectory* motherDir = nullptr);
-   virtual ~TDirectoryFile();
+   ~TDirectoryFile() override;
 
           void        Append(TObject *obj, Bool_t replace = kFALSE) override;
           void        Add(TObject *obj, Bool_t replace = kFALSE) override { Append(obj,replace); }

--- a/io/io/inc/TEmulatedCollectionProxy.h
+++ b/io/io/inc/TEmulatedCollectionProxy.h
@@ -56,7 +56,7 @@ public:
    TEmulatedCollectionProxy(const char* cl_name, Bool_t silent);
 
    // Standard destructor
-   virtual ~TEmulatedCollectionProxy();
+   ~TEmulatedCollectionProxy() override;
 
    // Virtual constructor
    void* New() const override             {  return new Cont_t;         }

--- a/io/io/inc/TEmulatedMapProxy.h
+++ b/io/io/inc/TEmulatedMapProxy.h
@@ -35,7 +35,7 @@ public:
    TEmulatedMapProxy(const char* cl_name, Bool_t silent);
 
    // Standard destructor
-   virtual ~TEmulatedMapProxy();
+   ~TEmulatedMapProxy() override;
 
    // Return the address of the value at index 'idx'
    void *At(UInt_t idx) override;

--- a/io/io/inc/TFPBlock.h
+++ b/io/io/inc/TFPBlock.h
@@ -36,7 +36,7 @@ private:
 public:
 
    TFPBlock(Long64_t*, Int_t*, Int_t);
-   virtual ~TFPBlock();
+   ~TFPBlock() override;
 
    Long64_t  GetPos(Int_t) const;
    Int_t     GetLen(Int_t) const;

--- a/io/io/inc/TFile.h
+++ b/io/io/inc/TFile.h
@@ -197,7 +197,7 @@ public:
 
    TFile();
    TFile(const char *fname, Option_t *option="", const char *ftitle="", Int_t compress = ROOT::RCompressionSetting::EDefaults::kUseCompiledDefault);
-   virtual ~TFile();
+   ~TFile() override;
 
            void        Close(Option_t *option="") override; // *MENU*
            void        Copy(TObject &) const override { MayNotUse("Copy(TObject &)"); }
@@ -376,7 +376,7 @@ private:
    TFile      *GetFile() const { return fFile; }
 
 public:
-   ~TFileOpenHandle() { }
+   ~TFileOpenHandle() override { }
 
    Bool_t      Matches(const char *name);
 

--- a/io/io/inc/TFileCacheRead.h
+++ b/io/io/inc/TFileCacheRead.h
@@ -79,7 +79,7 @@ private:
 public:
    TFileCacheRead();
    TFileCacheRead(TFile *file, Int_t buffersize, TObject *tree = nullptr);
-   virtual ~TFileCacheRead();
+   ~TFileCacheRead() override;
    virtual Int_t       AddBranch(TBranch * /*b*/, Bool_t /*subbranches*/ = kFALSE) { return 0; }
    virtual Int_t       AddBranch(const char * /*branch*/, Bool_t /*subbranches*/ = kFALSE) { return 0; }
    virtual void        AddNoCacheBytesRead(Long64_t len) { fNoCacheBytesRead += len; }

--- a/io/io/inc/TFileCacheWrite.h
+++ b/io/io/inc/TFileCacheWrite.h
@@ -33,7 +33,7 @@ private:
 public:
    TFileCacheWrite();
    TFileCacheWrite(TFile *file, Int_t buffersize);
-   virtual ~TFileCacheWrite();
+   ~TFileCacheWrite() override;
    virtual Bool_t      Flush();
    virtual Int_t       GetBytesInCache() const { return fNtot; }
            void        Print(Option_t *option="") const override;

--- a/io/io/inc/TFileMerger.h
+++ b/io/io/inc/TFileMerger.h
@@ -82,7 +82,7 @@ public:
    };
 
    TFileMerger(Bool_t isLocal = kTRUE, Bool_t histoOneGo = kTRUE);
-   virtual ~TFileMerger();
+   ~TFileMerger() override;
 
    Int_t       GetPrintLevel() const { return fPrintLevel; }
    void        SetPrintLevel(Int_t level) { fPrintLevel = level; }

--- a/io/io/inc/TFilePrefetch.h
+++ b/io/io/inc/TFilePrefetch.h
@@ -51,7 +51,7 @@ private:
 
 public:
    TFilePrefetch(TFile*);
-   virtual ~TFilePrefetch();
+   ~TFilePrefetch() override;
 
    void      ReadAsync(TFPBlock*, Bool_t&);
    void      ReadListOfBlocks();

--- a/io/io/inc/TFree.h
+++ b/io/io/inc/TFree.h
@@ -33,7 +33,7 @@ protected:
 public:
    TFree();
    TFree(TList *lfree, Long64_t first, Long64_t last);
-   virtual ~TFree();
+   ~TFree() override;
            TFree    *AddFree(TList *lfree, Long64_t first, Long64_t last);
    virtual void      FillBuffer(char *&buffer);
            TFree    *GetBestFree(TList *lfree, Int_t nbytes);

--- a/io/io/inc/TGenCollectionProxy.h
+++ b/io/io/inc/TGenCollectionProxy.h
@@ -342,7 +342,7 @@ private:
 public:
 
    // Virtual copy constructor.
-   virtual TVirtualCollectionProxy* Generate() const override;
+   TVirtualCollectionProxy* Generate() const override;
 
    // Copy constructor.
    TGenCollectionProxy(const TGenCollectionProxy& copy);
@@ -357,7 +357,7 @@ public:
    TGenCollectionProxy(const ROOT::Detail::TCollectionProxyInfo &info, TClass *cl);
 
    // Standard destructor.
-   virtual ~TGenCollectionProxy();
+   ~TGenCollectionProxy() override;
 
    // Reset the info gathered from StreamerInfos and value's TClass.
    Bool_t Reset() override;
@@ -482,7 +482,7 @@ struct AnyCollectionProxy : public TGenCollectionProxy  {
       fFeed           = T::feed;
       CheckFunctions();
    }
-   virtual ~AnyCollectionProxy() {  }
+   ~AnyCollectionProxy() override {  }
 };
 
 #endif

--- a/io/io/inc/TGenCollectionStreamer.h
+++ b/io/io/inc/TGenCollectionStreamer.h
@@ -57,7 +57,7 @@ public:
    TGenCollectionStreamer(const ROOT::TCollectionProxyInfo &info, TClass *cl);
 
    // Standard destructor
-   virtual ~TGenCollectionStreamer();
+   ~TGenCollectionStreamer() override;
 
    // Streamer I/O overload
    void Streamer(TBuffer &refBuffer) override;
@@ -94,7 +94,7 @@ struct AnyCollectionStreamer : public TGenCollectionStreamer  {
       fFeed           = T::feed;
       CheckFunctions();
    }
-   virtual ~AnyCollectionStreamer() {}
+   ~AnyCollectionStreamer() override {}
 };
 
 // Forward declaration in the event of later separation

--- a/io/io/inc/TKey.h
+++ b/io/io/inc/TKey.h
@@ -66,7 +66,7 @@ protected:
    TKey(const TObject *obj, const char *name, Int_t bufsize, TDirectory* motherDir);
    TKey(const void *obj, const TClass *cl, const char *name, Int_t bufsize, TDirectory* motherDir);
    TKey(Long64_t pointer, Int_t nbytes, TDirectory* motherDir = nullptr);
-   virtual ~TKey();
+   ~TKey() override;
 
            void        Browse(TBrowser *b) override;
            void        Delete(Option_t *option="") override;

--- a/io/io/inc/TKeyMapFile.h
+++ b/io/io/inc/TKeyMapFile.h
@@ -28,7 +28,7 @@ private:
 public:
    TKeyMapFile();
    TKeyMapFile(const char *name, const char *classname, TMapFile *mapfile);
-   virtual ~TKeyMapFile() {}
+   ~TKeyMapFile() override {}
    void      Browse(TBrowser *b) override;
 
    ClassDefOverride(TKeyMapFile,0);  //Utility class for browsing TMapFile objects.

--- a/io/io/inc/TLockFile.h
+++ b/io/io/inc/TLockFile.h
@@ -29,7 +29,7 @@ protected:
 
 public:
    TLockFile(const char *path, Int_t timeLimit = 0);
-   virtual ~TLockFile();
+   ~TLockFile() override;
 
    ClassDefOverride(TLockFile, 0) //Lock an object using a file
 };

--- a/io/io/inc/TMapFile.h
+++ b/io/io/inc/TMapFile.h
@@ -76,7 +76,7 @@ public:
    enum { kDefaultMapSize = 0x80000 }; // default size of mapped heap is 500 KB
 
    // Should both be protected (waiting for cint)
-   virtual ~TMapFile();
+   ~TMapFile() override;
    void *operator new(size_t sz) { return TObject::operator new(sz); }
    void *operator new[](size_t sz) { return TObject::operator new[](sz); }
    void *operator new(size_t sz, void *vp) { return TObject::operator new(sz, vp); }

--- a/io/io/inc/TMemFile.h
+++ b/io/io/inc/TMemFile.h
@@ -95,7 +95,7 @@ public:
    TMemFile(const char *name, const ZeroCopyView_t &datarange);
    TMemFile(const char *name, std::unique_ptr<TBufferFile> buffer);
    TMemFile(const TMemFile &orig);
-   virtual ~TMemFile();
+   ~TMemFile() override;
 
    virtual Long64_t CopyTo(void *to, Long64_t maxsize) const;
    virtual void     CopyTo(TBuffer &tobuf) const;

--- a/io/io/inc/TStreamerInfo.h
+++ b/io/io/inc/TStreamerInfo.h
@@ -181,7 +181,7 @@ public:
 
    TStreamerInfo();
    TStreamerInfo(TClass *cl);
-   virtual            ~TStreamerInfo();
+              ~TStreamerInfo() override;
    void                Build(Bool_t isTransient = kFALSE) override;
    void                BuildCheck(TFile *file = nullptr, Bool_t load = kTRUE) override;
    void                BuildEmulated(TFile *file) override;

--- a/io/io/inc/TStreamerInfoActions.h
+++ b/io/io/inc/TStreamerInfoActions.h
@@ -111,7 +111,7 @@ namespace TStreamerInfoActions {
       {
          // Usual constructor.
       }
-      ~TConfiguredAction() {
+      ~TConfiguredAction() override {
          // Usual destructor.
          // Idea: the configuration ownership might be moved to a single list so that
          // we can shared them between the optimized and non-optimized list of actions.
@@ -191,7 +191,7 @@ namespace TStreamerInfoActions {
             SetBit((UInt_t)EStatusBits::kVectorPtrLooper);
          fActions.reserve(maxdata);
       };
-      ~TActionSequence() {
+      ~TActionSequence() override {
          delete fLoopConfig;
       }
 

--- a/io/io/inc/TZIPFile.h
+++ b/io/io/inc/TZIPFile.h
@@ -134,7 +134,7 @@ protected:
 public:
    TZIPFile();
    TZIPFile(const char *archive, const char *member, TFile *file);
-   virtual ~TZIPFile() { }
+   ~TZIPFile() override { }
 
    Int_t      OpenArchive() override;
    Int_t      SetCurrentMember() override;
@@ -173,7 +173,7 @@ public:
    TZIPMember(const char *name);
    TZIPMember(const TZIPMember &member);
    TZIPMember &operator=(const TZIPMember &rhs);
-   virtual ~TZIPMember();
+   ~TZIPMember() override;
 
    void     *GetLocal() const { return fLocal; }
    UInt_t    GetLocalLen() const { return fLocalLen; }

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -359,7 +359,7 @@ public:
 
    TJSONStackObj() = default;
 
-   ~TJSONStackObj()
+   ~TJSONStackObj() override
    {
       if (fIsElemOwner)
          delete fElem;

--- a/io/io/src/TGenCollectionProxy.cxx
+++ b/io/io/src/TGenCollectionProxy.cxx
@@ -43,7 +43,7 @@ public:
    {
    }
    // Standard Destructor
-   virtual ~TGenVectorProxy()
+   ~TGenVectorProxy() override
    {
    }
    // Return the address of the value at index 'idx'
@@ -93,7 +93,7 @@ public:
    {
       // Standard Constructor.
    }
-   virtual ~TGenVectorBoolProxy()
+   ~TGenVectorBoolProxy() override
    {
       // Standard Destructor.
    }
@@ -139,7 +139,7 @@ public:
    {
       // Standard Constructor.
    }
-   virtual ~TGenBitsetProxy()
+   ~TGenBitsetProxy() override
    {
       // Standard Destructor.
    }
@@ -194,7 +194,7 @@ public:
    {
    }
    // Standard Destructor
-   virtual ~TGenListProxy()
+   ~TGenListProxy() override
    {
    }
    // Return the address of the value at index 'idx'
@@ -236,7 +236,7 @@ public:
    {
    }
    // Standard Destructor
-   virtual ~TGenSetProxy()
+   ~TGenSetProxy() override
    {
    }
    // Return the address of the value at index 'idx'
@@ -281,7 +281,7 @@ public:
    {
    }
    // Standard Destructor
-   virtual ~TGenMapProxy()
+   ~TGenMapProxy() override
    {
    }
    // Call to delete/destruct individual item

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -1030,7 +1030,7 @@ namespace TStreamerInfoActions
    public:
       TVectorLoopConfig(TVirtualCollectionProxy *proxy, Long_t increment, Bool_t /* read */) : TLoopConfiguration(proxy), fIncrement(increment) {};
       //virtual void PrintDebug(TBuffer &buffer, void *);
-      virtual ~TVectorLoopConfig() {};
+      ~TVectorLoopConfig() override {};
       void Print() const override
       {
          printf("TVectorLoopConfig: increment=%ld\n",fIncrement);
@@ -1051,7 +1051,7 @@ namespace TStreamerInfoActions
    public:
       TAssocLoopConfig(TVirtualCollectionProxy *proxy, Bool_t /* read */) : TLoopConfiguration(proxy) {};
       //virtual void PrintDebug(TBuffer &buffer, void *);
-      virtual ~TAssocLoopConfig() {};
+      ~TAssocLoopConfig() override {};
       void Print() const override
       {
          printf("TAssocLoopConfig: proxy=%s\n",fProxy->GetCollectionClass()->GetName());
@@ -1098,7 +1098,7 @@ namespace TStreamerInfoActions
       {
          Init(read);
       }
-      virtual ~TGenericLoopConfig() {};
+      ~TGenericLoopConfig() override {};
       void Print() const override
       {
          printf("TGenericLoopConfig: proxy=%s\n",fProxy->GetCollectionClass()->GetName());
@@ -1570,7 +1570,7 @@ namespace TStreamerInfoActions
          }
 
       }
-      virtual ~TConfigurationUseCache() {}
+      ~TConfigurationUseCache() override {}
       TConfiguration *Copy() override
       {
          TConfigurationUseCache *copy = new TConfigurationUseCache(*this);

--- a/io/mpi/inc/TMPIFile.h
+++ b/io/mpi/inc/TMPIFile.h
@@ -71,10 +71,10 @@ private:
       
    public:
       ParallelFileMerger(const char *filename, Int_t compression_settings, Bool_t writeCache = kFALSE);
-      virtual ~ParallelFileMerger();
+      ~ParallelFileMerger() override;
 
-      ULong_t Hash() const { return fFilename.Hash(); };
-      const char *GetName() const { return fFilename; };
+      ULong_t Hash() const override { return fFilename.Hash(); };
+      const char *GetName() const override { return fFilename; };
 
       static Bool_t NeedInitialMerge(TDirectory *dir);
 
@@ -97,7 +97,7 @@ public:
             const char *ftitle = "", Int_t compress = 4);
    TMPIFile(const char *name, Option_t *option = "", Int_t split = 1, const char *ftitle = "",
             Int_t compress = 4); // no complete implementation
-   virtual ~TMPIFile();
+   ~TMPIFile() override;
 
    // some functions on MPI information
    Int_t GetMPIGlobalSize() const { return fMPIGlobalSize; };
@@ -122,6 +122,6 @@ public:
    // Finalize work and save output in disk.
    void Close(Option_t *option = "") final;
 
-   ClassDef(TMPIFile, 0)
+   ClassDefOverride(TMPIFile, 0)
 };
 #endif

--- a/io/sql/inc/TBufferSQL2.h
+++ b/io/sql/inc/TBufferSQL2.h
@@ -123,7 +123,7 @@ protected:
 
 public:
    TBufferSQL2(TBuffer::EMode mode, TSQLFile *file = nullptr);
-   virtual ~TBufferSQL2();
+   ~TBufferSQL2() override;
 
    void SetCompressionLevel(int level) { fCompressLevel = level; }
 

--- a/io/sql/inc/TKeySQL.h
+++ b/io/sql/inc/TKeySQL.h
@@ -38,7 +38,7 @@ public:
    TKeySQL(TDirectory *mother, const void *obj, const TClass *cl, const char *name, const char *title = nullptr);
    TKeySQL(TDirectory *mother, Long64_t keyid, Long64_t objid, const char *name, const char *title,
            const char *keydatetime, Int_t cycle, const char *classname);
-   virtual ~TKeySQL() = default;
+   ~TKeySQL() override = default;
 
    Bool_t IsKeyModified(const char *keyname, const char *keytitle, const char *keydatime, Int_t cycle, const char *classname);
 

--- a/io/sql/inc/TSQLClassInfo.h
+++ b/io/sql/inc/TSQLClassInfo.h
@@ -42,7 +42,7 @@ class TSQLClassInfo final : public TObject {
 public:
    TSQLClassInfo() {} // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see ROOT-10300
    TSQLClassInfo(Long64_t classid, const char *classname, Int_t version);
-   virtual ~TSQLClassInfo();
+   ~TSQLClassInfo() override;
 
    Long64_t GetClassId() const { return fClassId; }
 

--- a/io/sql/inc/TSQLFile.h
+++ b/io/sql/inc/TSQLFile.h
@@ -178,7 +178,7 @@ public:
 
    TSQLFile();
    TSQLFile(const char *dbname, Option_t *option = "read", const char *user = "user", const char *pass = "pass");
-   virtual ~TSQLFile();
+   ~TSQLFile() override;
 
    // configuration of SQL
    Bool_t GetUseSuffixes() const { return fUseSuffixes; }

--- a/io/sql/inc/TSQLObjectData.h
+++ b/io/sql/inc/TSQLObjectData.h
@@ -28,7 +28,7 @@ class TSQLObjectInfo : public TObject {
 public:
    TSQLObjectInfo();
    TSQLObjectInfo(Long64_t objid, const char *classname, Version_t version);
-   virtual ~TSQLObjectInfo();
+   ~TSQLObjectInfo() override;
 
    Long64_t GetObjId() const { return fObjId; }
    const char *GetObjClassName() const { return fClassName.Data(); }
@@ -52,7 +52,7 @@ public:
    TSQLObjectData(TSQLClassInfo *sqlinfo, Long64_t objid, TSQLResult *classdata, TSQLRow *classrow,
                   TSQLResult *blobdata, TSQLStatement *blobstmt);
 
-   virtual ~TSQLObjectData();
+   ~TSQLObjectData() override;
 
    Long64_t GetObjId() const { return fObjId; }
    TSQLClassInfo *GetInfo() const { return fInfo; }
@@ -110,7 +110,7 @@ class TSQLObjectDataPool : public TObject {
 public:
    TSQLObjectDataPool();
    TSQLObjectDataPool(TSQLClassInfo *info, TSQLResult *data);
-   virtual ~TSQLObjectDataPool();
+   ~TSQLObjectDataPool() override;
 
    TSQLClassInfo *GetSqlInfo() const { return fInfo; }
    TSQLResult *GetClassData() const { return fClassData; }

--- a/io/sql/inc/TSQLStructure.h
+++ b/io/sql/inc/TSQLStructure.h
@@ -69,7 +69,7 @@ protected:
 
 public:
    TSQLTableData(TSQLFile *f = nullptr, TSQLClassInfo *info = nullptr);
-   virtual ~TSQLTableData();
+   ~TSQLTableData() override;
 
    void AddColumn(const char *name, Long64_t value);
    void AddColumn(const char *name, const char *sqltype, const char *value, Bool_t numeric);
@@ -111,7 +111,7 @@ protected:
 
 public:
    TSQLStructure() {} // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see ROOT-10300
-   virtual ~TSQLStructure();
+   ~TSQLStructure() override;
 
    TSQLStructure *GetParent() const { return fParent; }
    void SetParent(TSQLStructure *p) { fParent = p; }

--- a/io/sql/src/TSQLStructure.cxx
+++ b/io/sql/src/TSQLStructure.cxx
@@ -789,7 +789,7 @@ class TSqlCmdsBuffer : public TObject {
 public:
    TSqlCmdsBuffer(TSQLFile *f, TSQLClassInfo *info) : TObject(), fFile(f), fInfo(info), fBlobStmt(nullptr), fNormStmt(nullptr) {}
 
-   virtual ~TSqlCmdsBuffer()
+   ~TSqlCmdsBuffer() override
    {
       fNormCmds.Delete();
       fBlobCmds.Delete();
@@ -844,7 +844,7 @@ public:
 
    TSQLStatement *fRegStmt;
 
-   virtual ~TSqlRegistry()
+   ~TSqlRegistry() override
    {
       fPool.DeleteValues();
       fLongStrValues.Delete();
@@ -1089,7 +1089,7 @@ public:
       fMaxStrSize = reg->fFile->SQLSmallTextTypeLimit();
    }
 
-   virtual ~TSqlRawBuffer()
+   ~TSqlRawBuffer() override
    {
       // close blob statement for Oracle
       TSQLStatement *stmt = fCmdBuf->fBlobStmt;

--- a/io/xml/inc/TBufferXML.h
+++ b/io/xml/inc/TBufferXML.h
@@ -37,7 +37,7 @@ class TBufferXML final : public TBufferText, public TXMLSetup {
 public:
    TBufferXML(TBuffer::EMode mode);
    TBufferXML(TBuffer::EMode mode, TXMLFile *file);
-   virtual ~TBufferXML();
+   ~TBufferXML() override;
 
    static TString ConvertToXML(const TObject *obj, Bool_t GenericLayout = kFALSE, Bool_t UseNamespaces = kFALSE);
    static TString

--- a/io/xml/inc/TKeyXML.h
+++ b/io/xml/inc/TKeyXML.h
@@ -32,7 +32,7 @@ public:
    TKeyXML(TDirectory *mother, Long64_t keyid, const void *obj, const TClass *cl, const char *name,
            const char *title = nullptr);
    TKeyXML(TDirectory *mother, Long64_t keyid, XMLNodePointer_t keynode);
-   virtual ~TKeyXML();
+   ~TKeyXML() override;
 
    // redefined TKey Methods
    void Delete(Option_t *option = "") final;

--- a/io/xml/inc/TXMLEngine.h
+++ b/io/xml/inc/TXMLEngine.h
@@ -43,7 +43,7 @@ protected:
 
 public:
    TXMLEngine();
-   virtual ~TXMLEngine();
+   ~TXMLEngine() override;
 
    void SetSkipComments(Bool_t on = kTRUE) { fSkipComments = on; }
    Bool_t GetSkipComments() const { return fSkipComments; }

--- a/io/xml/inc/TXMLFile.h
+++ b/io/xml/inc/TXMLFile.h
@@ -50,7 +50,7 @@ private:
 public:
    TXMLFile() {} // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see ROOT-10300
    TXMLFile(const char *filename, Option_t *option = "read", const char *title = "title", Int_t compression = ROOT::RCompressionSetting::EDefaults::kUseCompiledDefault);
-   virtual ~TXMLFile();
+   ~TXMLFile() override;
 
    void Close(Option_t *option = "") final; // *MENU*
    TKey *CreateKey(TDirectory *mother, const TObject *obj, const char *name, Int_t bufsize) final;

--- a/io/xml/inc/TXMLPlayer.h
+++ b/io/xml/inc/TXMLPlayer.h
@@ -25,7 +25,7 @@ class TList;
 class TXMLPlayer : public TObject {
 public:
    TXMLPlayer();
-   virtual ~TXMLPlayer();
+   ~TXMLPlayer() override;
 
    Bool_t ProduceCode(TList *cllist, const char *filename);
 

--- a/io/xmlparser/inc/TDOMParser.h
+++ b/io/xmlparser/inc/TDOMParser.h
@@ -28,7 +28,7 @@ private:
 
 public:
    TDOMParser();
-   virtual ~TDOMParser();
+   ~TDOMParser() override;
 
    Int_t   ParseFile(const char *filename) override;
    Int_t   ParseBuffer(const char *buffer, Int_t len) override;

--- a/io/xmlparser/inc/TSAXParser.h
+++ b/io/xmlparser/inc/TSAXParser.h
@@ -34,7 +34,7 @@ private:
 
 public:
    TSAXParser();
-   virtual ~TSAXParser();
+   ~TSAXParser() override;
 
            Int_t           ParseFile(const char *filename) override;
            Int_t           ParseBuffer(const char *contents, Int_t len) override;

--- a/io/xmlparser/inc/TXMLAttr.h
+++ b/io/xmlparser/inc/TXMLAttr.h
@@ -26,7 +26,7 @@ private:
 
 public:
    TXMLAttr(const char *key, const char *value) : fKey(key), fValue(value) {}
-   virtual ~TXMLAttr() {}
+   ~TXMLAttr() override {}
 
    const char *GetName() const override { return fKey; }
    const char *Key() const { return fKey; }

--- a/io/xmlparser/inc/TXMLDocument.h
+++ b/io/xmlparser/inc/TXMLDocument.h
@@ -29,7 +29,7 @@ private:
 
 public:
    TXMLDocument(_xmlDoc *doc);
-   virtual ~TXMLDocument();
+   ~TXMLDocument() override;
 
    TXMLNode   *GetRootNode() const;
 

--- a/io/xmlparser/inc/TXMLNode.h
+++ b/io/xmlparser/inc/TXMLNode.h
@@ -42,7 +42,7 @@ public:
 
    TXMLNode(_xmlNode *node, TXMLNode *parent = nullptr, TXMLNode *previous = nullptr);
 
-   virtual ~TXMLNode();
+   ~TXMLNode() override;
 
    EXMLElementType GetNodeType() const;
    const char *GetNodeName() const;

--- a/io/xmlparser/inc/TXMLParser.h
+++ b/io/xmlparser/inc/TXMLParser.h
@@ -44,7 +44,7 @@ protected:
 
 public:
    TXMLParser();
-   virtual ~TXMLParser();
+   ~TXMLParser() override;
 
    void                SetValidate(Bool_t val = kTRUE);
    Bool_t              GetValidate() const { return fValidate; }


### PR DESCRIPTION
This commit only contains changes that were automatically generated by `clang-tidy`, plus replacing `ClassDef` with `ClassDefOverride` where appropriate.

Several directories in the ROOT repo were already treated like this, for example `tree`:
https://github.com/root-project/root/pull/11290