### PR TITLE
[windows] Fix many warnings on Windows

### DIFF
--- a/graf2d/win32gdk/inc/TGWin32.h
+++ b/graf2d/win32gdk/inc/TGWin32.h
@@ -152,247 +152,247 @@ public:
    virtual ~TGWin32();
 
    void      DrawText(Int_t x, Int_t y, Float_t angle, Float_t mgn,
-                   const char *text, ETextMode mode);
+                   const char *text, ETextMode mode) override;
    void      DrawText(Int_t x, Int_t y, Float_t angle, Float_t mgn,
-                   const wchar_t *text, ETextMode mode);
-   void      SetTextFont(Font_t fontnumber);
-   Int_t     SetTextFont(char *fontname, ETextSetMode mode);
-   void      SetTextSize(Float_t textsize);
+                   const wchar_t *text, ETextMode mode) override;
+   void      SetTextFont(Font_t fontnumber) override;
+   Int_t     SetTextFont(char *fontname, ETextSetMode mode) override;
+   void      SetTextSize(Float_t textsize) override;
 
-   Bool_t    Init(void *display=0);
+   Bool_t    Init(void *display=0) override;
    //UInt_t  ExecCommand(TGWin32Command *);
-   void      ClearWindow();
-   void      ClosePixmap();
-   void      CloseWindow();
-   void      CopyPixmap(Int_t wid, Int_t xpos, Int_t ypos);
-   void      DrawBox(Int_t x1, Int_t y1, Int_t x2, Int_t y2, EBoxMode mode);
-   void      DrawCellArray(Int_t x1, Int_t y1, Int_t x2, Int_t y2, Int_t nx, Int_t ny, Int_t *ic);
-   void      DrawFillArea(Int_t n, TPoint *xy);
-   void      DrawLine(Int_t x1, Int_t y1, Int_t x2, Int_t y2);
-   void      DrawPolyLine(Int_t n, TPoint *xy);
-   void      DrawPolyMarker(Int_t n, TPoint *xy);
-   void      GetCharacterUp(Float_t &chupx, Float_t &chupy);
-   Int_t     GetDoubleBuffer(Int_t wid);
-   void      GetGeometry(Int_t wid, Int_t &x, Int_t &y, UInt_t &w, UInt_t &h);
-   const char *DisplayName(const char *dpyName = 0);
-   ULong_t   GetPixel(Color_t cindex);
-   void      GetPlanes(Int_t &nplanes);
-   void      GetRGB(Int_t index, Float_t &r, Float_t &g, Float_t &b);
-   virtual void GetTextExtent(UInt_t &w, UInt_t &h, char *mess);
-   virtual void GetTextExtent(UInt_t &, UInt_t &, wchar_t *){}
-   Float_t   GetTextMagnitude() {return fTextMagnitude;}
-   Window_t  GetWindowID(Int_t wid);
-   Bool_t    HasTTFonts() const { return fHasTTFonts; }
-   Int_t     InitWindow(ULongptr_t window);
-   Int_t     AddPixmap(ULongptr_t pix, UInt_t w, UInt_t h);
-   void      MoveWindow(Int_t wid, Int_t x, Int_t y);
-   Int_t     OpenPixmap(UInt_t w, UInt_t h);
-   void      QueryPointer(Int_t &ix, Int_t &iy);
-   Pixmap_t  ReadGIF(Int_t x0, Int_t y0, const char *file, Window_t id=0);
-   Int_t     RequestLocator(Int_t mode, Int_t ctyp, Int_t &x, Int_t &y);
-   Int_t     RequestString(Int_t x, Int_t y, char *text);
-   void      RescaleWindow(Int_t wid, UInt_t w, UInt_t h);
-   Int_t     ResizePixmap(Int_t wid, UInt_t w, UInt_t h);
-   void      ResizeWindow(Int_t wid);
-   void      SelectWindow(Int_t wid);
-   void      SetCharacterUp(Float_t chupx, Float_t chupy);
-   void      SetClipOFF(Int_t wid);
-   void      SetClipRegion(Int_t wid, Int_t x, Int_t y, UInt_t w, UInt_t h);
-   void      SetCursor(Int_t wid, ECursor cursor);
-   void      SetDoubleBuffer(Int_t wid, Int_t mode);
-   void      SetDoubleBufferOFF();
-   void      SetDoubleBufferON();
-   void      SetDrawMode(EDrawMode mode);
-   void      SetFillColor(Color_t cindex);
-   void      SetFillStyle(Style_t style);
-   void      SetLineColor(Color_t cindex);
-   void      SetLineType(Int_t n, Int_t *dash);
-   void      SetLineStyle(Style_t linestyle);
-   void      SetLineWidth(Width_t width);
-   void      SetMarkerColor(Color_t cindex);
-   void      SetMarkerSize(Float_t markersize);
-   void      SetMarkerStyle(Style_t markerstyle);
-   void      SetOpacity(Int_t percent);
-   void      SetRGB(Int_t cindex, Float_t r, Float_t g, Float_t b);
-   void      SetTextAlign(Short_t talign=11);
-   void      SetTextColor(Color_t cindex);
-   void      SetTextMagnitude(Float_t mgn=1) { fTextMagnitude = mgn;}
-   void      Sync(Int_t mode);
-   void      UpdateWindow(Int_t mode);
-   void      Warp(Int_t ix, Int_t iy, Window_t id = 0);
-   Int_t     WriteGIF(char *name);
-   void      WritePixmap(Int_t wid, UInt_t w, UInt_t h, char *pxname);
-   Window_t  GetCurrentWindow() const;
+   void      ClearWindow() override;
+   void      ClosePixmap() override;
+   void      CloseWindow() override;
+   void      CopyPixmap(Int_t wid, Int_t xpos, Int_t ypos) override;
+   void      DrawBox(Int_t x1, Int_t y1, Int_t x2, Int_t y2, EBoxMode mode) override;
+   void      DrawCellArray(Int_t x1, Int_t y1, Int_t x2, Int_t y2, Int_t nx, Int_t ny, Int_t *ic) override;
+   void      DrawFillArea(Int_t n, TPoint *xy) override;
+   void      DrawLine(Int_t x1, Int_t y1, Int_t x2, Int_t y2) override;
+   void      DrawPolyLine(Int_t n, TPoint *xy) override;
+   void      DrawPolyMarker(Int_t n, TPoint *xy) override;
+   void      GetCharacterUp(Float_t &chupx, Float_t &chupy) override;
+   Int_t     GetDoubleBuffer(Int_t wid) override;
+   void      GetGeometry(Int_t wid, Int_t &x, Int_t &y, UInt_t &w, UInt_t &h) override;
+   const char *DisplayName(const char *dpyName = 0) override;
+   ULong_t   GetPixel(Color_t cindex) override;
+   void      GetPlanes(Int_t &nplanes) override;
+   void      GetRGB(Int_t index, Float_t &r, Float_t &g, Float_t &b) override;
+   virtual void GetTextExtent(UInt_t &w, UInt_t &h, char *mess) override;
+   virtual void GetTextExtent(UInt_t &, UInt_t &, wchar_t *) override {}
+   Float_t   GetTextMagnitude() override {return fTextMagnitude;}
+   Window_t  GetWindowID(Int_t wid) override;
+   Bool_t    HasTTFonts() const override { return fHasTTFonts; }
+   Int_t     InitWindow(ULongptr_t window) override;
+   Int_t     AddPixmap(ULongptr_t pix, UInt_t w, UInt_t h) override;
+   void      MoveWindow(Int_t wid, Int_t x, Int_t y) override;
+   Int_t     OpenPixmap(UInt_t w, UInt_t h) override;
+   void      QueryPointer(Int_t &ix, Int_t &iy) override;
+   Pixmap_t  ReadGIF(Int_t x0, Int_t y0, const char *file, Window_t id=0) override;
+   Int_t     RequestLocator(Int_t mode, Int_t ctyp, Int_t &x, Int_t &y) override;
+   Int_t     RequestString(Int_t x, Int_t y, char *text) override;
+   void      RescaleWindow(Int_t wid, UInt_t w, UInt_t h) override;
+   Int_t     ResizePixmap(Int_t wid, UInt_t w, UInt_t h) override;
+   void      ResizeWindow(Int_t wid) override;
+   void      SelectWindow(Int_t wid) override;
+   void      SetCharacterUp(Float_t chupx, Float_t chupy) override;
+   void      SetClipOFF(Int_t wid) override;
+   void      SetClipRegion(Int_t wid, Int_t x, Int_t y, UInt_t w, UInt_t h) override;
+   void      SetCursor(Int_t wid, ECursor cursor) override;
+   void      SetDoubleBuffer(Int_t wid, Int_t mode) override;
+   void      SetDoubleBufferOFF() override;
+   void      SetDoubleBufferON() override;
+   void      SetDrawMode(EDrawMode mode) override;
+   void      SetFillColor(Color_t cindex) override;
+   void      SetFillStyle(Style_t style) override;
+   void      SetLineColor(Color_t cindex) override;
+   void      SetLineType(Int_t n, Int_t *dash) override;
+   void      SetLineStyle(Style_t linestyle) override;
+   void      SetLineWidth(Width_t width) override;
+   void      SetMarkerColor(Color_t cindex) override;
+   void      SetMarkerSize(Float_t markersize) override;
+   void      SetMarkerStyle(Style_t markerstyle) override;
+   void      SetOpacity(Int_t percent) override;
+   void      SetRGB(Int_t cindex, Float_t r, Float_t g, Float_t b) override;
+   void      SetTextAlign(Short_t talign=11) override;
+   void      SetTextColor(Color_t cindex) override;
+   void      SetTextMagnitude(Float_t mgn=1) override { fTextMagnitude = mgn;}
+   void      Sync(Int_t mode) override;
+   void      UpdateWindow(Int_t mode) override;
+   void      Warp(Int_t ix, Int_t iy, Window_t id = 0) override;
+   Int_t     WriteGIF(char *name) override;
+   void      WritePixmap(Int_t wid, UInt_t w, UInt_t h, char *pxname) override;
+   Window_t  GetCurrentWindow() const override;
 
    //---- Methods used for GUI -----
-   void         GetWindowAttributes(Window_t id, WindowAttributes_t &attr);
-   void         MapWindow(Window_t id);
-   void         MapSubwindows(Window_t id);
-   void         MapRaised(Window_t id);
-   void         UnmapWindow(Window_t id);
-   void         DestroyWindow(Window_t id);
-   void         DestroySubwindows(Window_t id);
-   void         RaiseWindow(Window_t id);
-   void         LowerWindow(Window_t id);
-   void         MoveWindow(Window_t id, Int_t x, Int_t y);
-   void         MoveResizeWindow(Window_t id, Int_t x, Int_t y, UInt_t w, UInt_t h);
-   void         ResizeWindow(Window_t id, UInt_t w, UInt_t h);
-   void         IconifyWindow(Window_t id);
-   void         ReparentWindow(Window_t id, Window_t pid, Int_t x, Int_t y);
-   void         SetWindowBackground(Window_t id, ULong_t color);
-   void         SetWindowBackgroundPixmap(Window_t id, Pixmap_t pxm);
+   void         GetWindowAttributes(Window_t id, WindowAttributes_t &attr) override;
+   void         MapWindow(Window_t id) override;
+   void         MapSubwindows(Window_t id) override;
+   void         MapRaised(Window_t id) override;
+   void         UnmapWindow(Window_t id) override;
+   void         DestroyWindow(Window_t id) override;
+   void         DestroySubwindows(Window_t id) override;
+   void         RaiseWindow(Window_t id) override;
+   void         LowerWindow(Window_t id) override;
+   void         MoveWindow(Window_t id, Int_t x, Int_t y) override;
+   void         MoveResizeWindow(Window_t id, Int_t x, Int_t y, UInt_t w, UInt_t h) override;
+   void         ResizeWindow(Window_t id, UInt_t w, UInt_t h) override;
+   void         IconifyWindow(Window_t id) override;
+   void         ReparentWindow(Window_t id, Window_t pid, Int_t x, Int_t y) override;
+   void         SetWindowBackground(Window_t id, ULong_t color) override;
+   void         SetWindowBackgroundPixmap(Window_t id, Pixmap_t pxm) override;
    Window_t     CreateWindow(Window_t parent, Int_t x, Int_t y,
                              UInt_t w, UInt_t h, UInt_t border,
                              Int_t depth, UInt_t clss,
                              void *visual, SetWindowAttributes_t *attr,
-                             UInt_t wtype);
-   Int_t        OpenDisplay(const char *dpyName=0);
-   void         CloseDisplay();
-   Display_t    GetDisplay() const;
-   Visual_t     GetVisual() const { return 0; }
-   Int_t        GetScreen() const { return 0; }
-   Int_t        GetDepth() const;
-   Colormap_t   GetColormap() const { return (Colormap_t) fColormap; }
-   Atom_t       InternAtom(const char *atom_name, Bool_t only_if_exist);
-   Window_t     GetDefaultRootWindow() const;
-   Window_t     GetParent(Window_t id) const;
-   FontStruct_t LoadQueryFont(const char *font_name);
-   FontH_t      GetFontHandle(FontStruct_t fs);
-   void         DeleteFont(FontStruct_t fs);
-   GContext_t   CreateGC(Drawable_t id, GCValues_t *gval);
-   void         ChangeGC(GContext_t gc, GCValues_t *gval);
-   void         CopyGC(GContext_t org, GContext_t dest, Mask_t mask);
-   void         DeleteGC(GContext_t gc);
-   Cursor_t     CreateCursor(ECursor cursor);
-   void         SetCursor(Window_t id, Cursor_t curid);
-   Pixmap_t     CreatePixmap(Drawable_t id, UInt_t w, UInt_t h);
+                             UInt_t wtype) override;
+   Int_t        OpenDisplay(const char *dpyName=0) override;
+   void         CloseDisplay() override;
+   Display_t    GetDisplay() const override;
+   Visual_t     GetVisual() const override { return 0; }
+   Int_t        GetScreen() const override { return 0; }
+   Int_t        GetDepth() const override;
+   Colormap_t   GetColormap() const override { return (Colormap_t) fColormap; }
+   Atom_t       InternAtom(const char *atom_name, Bool_t only_if_exist) override;
+   Window_t     GetDefaultRootWindow() const override;
+   Window_t     GetParent(Window_t id) const override;
+   FontStruct_t LoadQueryFont(const char *font_name) override;
+   FontH_t      GetFontHandle(FontStruct_t fs) override;
+   void         DeleteFont(FontStruct_t fs) override;
+   GContext_t   CreateGC(Drawable_t id, GCValues_t *gval) override;
+   void         ChangeGC(GContext_t gc, GCValues_t *gval) override;
+   void         CopyGC(GContext_t org, GContext_t dest, Mask_t mask) override;
+   void         DeleteGC(GContext_t gc) override;
+   Cursor_t     CreateCursor(ECursor cursor) override;
+   void         SetCursor(Window_t id, Cursor_t curid) override;
+   Pixmap_t     CreatePixmap(Drawable_t id, UInt_t w, UInt_t h) override;
    Pixmap_t     CreatePixmap(Drawable_t id, const char *bitmap, UInt_t width,
                              UInt_t height, ULong_t forecolor, ULong_t backcolor,
-                             Int_t depth);
-   Pixmap_t     CreatePixmapFromData(unsigned char *bits, UInt_t width, UInt_t height);
+                             Int_t depth) override;
+   Pixmap_t     CreatePixmapFromData(unsigned char *bits, UInt_t width, UInt_t height) override;
    Pixmap_t     CreateBitmap(Drawable_t id, const char *bitmap,
-                             UInt_t width, UInt_t height);
-   void         DeletePixmap(Pixmap_t pmap);
+                             UInt_t width, UInt_t height) override;
+   void         DeletePixmap(Pixmap_t pmap) override;
    Bool_t       CreatePictureFromFile(Drawable_t id, const char *filename,
                                       Pixmap_t &pict, Pixmap_t &pict_mask,
-                                      PictureAttributes_t &attr);
+                                      PictureAttributes_t &attr) override;
    Bool_t       CreatePictureFromData(Drawable_t id, char **data,
                                       Pixmap_t &pict, Pixmap_t &pict_mask,
-                                      PictureAttributes_t &attr);
-   Bool_t       ReadPictureDataFromFile(const char *filename, char ***ret_data);
-   void         DeletePictureData(void *data);
-   void         SetDashes(GContext_t gc, Int_t offset, const char *dash_list, Int_t n);
-   Bool_t       ParseColor(Colormap_t cmap, const char *cname, ColorStruct_t &color);
-   Bool_t       AllocColor(Colormap_t cmap, ColorStruct_t &color);
-   void         QueryColor(Colormap_t cmap, ColorStruct_t &color);
-   void         FreeColor(Colormap_t cmap, ULong_t pixel);
-   Int_t        EventsPending();
-   void         NextEvent(Event_t &event);
-   void         Bell(Int_t percent);
+                                      PictureAttributes_t &attr) override;
+   Bool_t       ReadPictureDataFromFile(const char *filename, char ***ret_data) override;
+   void         DeletePictureData(void *data) override;
+   void         SetDashes(GContext_t gc, Int_t offset, const char *dash_list, Int_t n) override;
+   Bool_t       ParseColor(Colormap_t cmap, const char *cname, ColorStruct_t &color) override;
+   Bool_t       AllocColor(Colormap_t cmap, ColorStruct_t &color) override;
+   void         QueryColor(Colormap_t cmap, ColorStruct_t &color) override;
+   void         FreeColor(Colormap_t cmap, ULong_t pixel) override;
+   Int_t        EventsPending() override;
+   void         NextEvent(Event_t &event) override;
+   void         Bell(Int_t percent) override;
    void         CopyArea(Drawable_t src, Drawable_t dest, GContext_t gc,
                          Int_t src_x, Int_t src_y, UInt_t width, UInt_t height,
-                         Int_t dest_x, Int_t dest_y);
-   void         ChangeWindowAttributes(Window_t id, SetWindowAttributes_t *attr);
+                         Int_t dest_x, Int_t dest_y) override;
+   void         ChangeWindowAttributes(Window_t id, SetWindowAttributes_t *attr) override;
    void         ChangeProperty(Window_t id, Atom_t property, Atom_t type,
-                               UChar_t *data, Int_t len);
-   void         DrawLine(Drawable_t id, GContext_t gc, Int_t x1, Int_t y1, Int_t x2, Int_t y2);
-   void         ClearArea(Window_t id, Int_t x, Int_t y, UInt_t w, UInt_t h);
-   Bool_t       CheckEvent(Window_t id, EGEventType type, Event_t &ev);
-   void         SendEvent(Window_t id, Event_t *ev);
-   void         WMDeleteNotify(Window_t id);
-   void         SetKeyAutoRepeat(Bool_t on = kTRUE);
-   void         GrabKey(Window_t id, Int_t keycode, UInt_t modifier, Bool_t grab = kTRUE);
+                               UChar_t *data, Int_t len) override;
+   void         DrawLine(Drawable_t id, GContext_t gc, Int_t x1, Int_t y1, Int_t x2, Int_t y2) override;
+   void         ClearArea(Window_t id, Int_t x, Int_t y, UInt_t w, UInt_t h) override;
+   Bool_t       CheckEvent(Window_t id, EGEventType type, Event_t &ev) override;
+   void         SendEvent(Window_t id, Event_t *ev) override;
+   void         WMDeleteNotify(Window_t id) override;
+   void         SetKeyAutoRepeat(Bool_t on = kTRUE) override;
+   void         GrabKey(Window_t id, Int_t keycode, UInt_t modifier, Bool_t grab = kTRUE) override;
    void         GrabButton(Window_t id, EMouseButton button, UInt_t modifier,
                            UInt_t evmask, Window_t confine, Cursor_t cursor,
-                           Bool_t grab = kTRUE);
+                           Bool_t grab = kTRUE) override;
    void         GrabPointer(Window_t id, UInt_t evmask, Window_t confine,
                             Cursor_t cursor, Bool_t grab = kTRUE,
-                            Bool_t owner_events = kTRUE);
-   void         SetWindowName(Window_t id, char *name);
-   void         SetIconName(Window_t id, char *name);
-   void         SetIconPixmap(Window_t id, Pixmap_t pic);
-   void         SetClassHints(Window_t id, char *className, char *resourceName);
-   void         SetMWMHints(Window_t id, UInt_t value, UInt_t funcs, UInt_t input);
-   void         SetWMPosition(Window_t id, Int_t x, Int_t y);
-   void         SetWMSize(Window_t id, UInt_t w, UInt_t h);
+                            Bool_t owner_events = kTRUE) override;
+   void         SetWindowName(Window_t id, char *name) override;
+   void         SetIconName(Window_t id, char *name) override;
+   void         SetIconPixmap(Window_t id, Pixmap_t pic) override;
+   void         SetClassHints(Window_t id, char *className, char *resourceName) override;
+   void         SetMWMHints(Window_t id, UInt_t value, UInt_t funcs, UInt_t input) override;
+   void         SetWMPosition(Window_t id, Int_t x, Int_t y) override;
+   void         SetWMSize(Window_t id, UInt_t w, UInt_t h) override;
    void         SetWMSizeHints(Window_t id, UInt_t wmin, UInt_t hmin,
-                               UInt_t wmax, UInt_t hmax, UInt_t winc, UInt_t hinc);
-   void         SetWMState(Window_t id, EInitialState state);
-   void         SetWMTransientHint(Window_t id, Window_t main_id);
+                               UInt_t wmax, UInt_t hmax, UInt_t winc, UInt_t hinc) override;
+   void         SetWMState(Window_t id, EInitialState state) override;
+   void         SetWMTransientHint(Window_t id, Window_t main_id) override;
    void         DrawString(Drawable_t id, GContext_t gc, Int_t x, Int_t y,
-                           const char *s, Int_t len);
-   Int_t        TextWidth(FontStruct_t font, const char *s, Int_t len);
-   void         GetFontProperties(FontStruct_t font, Int_t &max_ascent, Int_t &max_descent);
-   void         GetGCValues(GContext_t gc, GCValues_t &gval);
-   FontStruct_t GetFontStruct(FontH_t fh);
-   void         FreeFontStruct(FontStruct_t fs);
-   void         ClearWindow(Window_t id);
-   Int_t        KeysymToKeycode(UInt_t keysym);
+                           const char *s, Int_t len) override;
+   Int_t        TextWidth(FontStruct_t font, const char *s, Int_t len) override;
+   void         GetFontProperties(FontStruct_t font, Int_t &max_ascent, Int_t &max_descent) override;
+   void         GetGCValues(GContext_t gc, GCValues_t &gval) override;
+   FontStruct_t GetFontStruct(FontH_t fh) override;
+   void         FreeFontStruct(FontStruct_t fs) override;
+   void         ClearWindow(Window_t id) override;
+   Int_t        KeysymToKeycode(UInt_t keysym) override;
    void         FillRectangle(Drawable_t id, GContext_t gc, Int_t x, Int_t y,
-                              UInt_t w, UInt_t h);
+                              UInt_t w, UInt_t h) override;
    void         DrawRectangle(Drawable_t id, GContext_t gc, Int_t x, Int_t y,
-                              UInt_t w, UInt_t h);
-   void         DrawSegments(Drawable_t id, GContext_t gc, Segment_t *seg, Int_t nseg);
-   void         SelectInput(Window_t id, UInt_t evmask);
-   Window_t     GetInputFocus();
-   void         SetInputFocus(Window_t id);
-   Window_t     GetPrimarySelectionOwner();
-   void         SetPrimarySelectionOwner(Window_t id);
-   void         ConvertPrimarySelection(Window_t id, Atom_t clipboard, Time_t when);
-   void         LookupString(Event_t *event, char *buf, Int_t buflen, UInt_t &keysym);
+                              UInt_t w, UInt_t h) override;
+   void         DrawSegments(Drawable_t id, GContext_t gc, Segment_t *seg, Int_t nseg) override;
+   void         SelectInput(Window_t id, UInt_t evmask) override;
+   Window_t     GetInputFocus() override;
+   void         SetInputFocus(Window_t id) override;
+   Window_t     GetPrimarySelectionOwner() override;
+   void         SetPrimarySelectionOwner(Window_t id) override;
+   void         ConvertPrimarySelection(Window_t id, Atom_t clipboard, Time_t when) override;
+   void         LookupString(Event_t *event, char *buf, Int_t buflen, UInt_t &keysym) override;
    void         GetPasteBuffer(Window_t id, Atom_t atom, TString &text,
-                               Int_t &nchar, Bool_t del);
+                               Int_t &nchar, Bool_t del) override;
    void         TranslateCoordinates(Window_t src, Window_t dest, Int_t src_x,
-                    Int_t src_y, Int_t &dest_x, Int_t &dest_y, Window_t &child);
-   void         GetWindowSize(Drawable_t id, Int_t &x, Int_t &y, UInt_t &w, UInt_t &h);
-   void         FillPolygon(Window_t id, GContext_t gc, Point_t *points, Int_t npnt);
+                    Int_t src_y, Int_t &dest_x, Int_t &dest_y, Window_t &child) override;
+   void         GetWindowSize(Drawable_t id, Int_t &x, Int_t &y, UInt_t &w, UInt_t &h) override;
+   void         FillPolygon(Window_t id, GContext_t gc, Point_t *points, Int_t npnt) override;
    void         QueryPointer(Window_t id, Window_t &rootw, Window_t &childw,
                              Int_t &root_x, Int_t &root_y, Int_t &win_x,
-                             Int_t &win_y, UInt_t &mask);
-   void         SetForeground(GContext_t gc, ULong_t foreground);
-   void         SetClipRectangles(GContext_t gc, Int_t x, Int_t y, Rectangle_t *recs, Int_t n);
-   void         Update(Int_t mode = 0);
-   Region_t     CreateRegion();
-   void         DestroyRegion(Region_t reg);
-   void         UnionRectWithRegion(Rectangle_t *rect, Region_t src, Region_t dest);
-   Region_t     PolygonRegion(Point_t *points, Int_t np, Bool_t winding);
-   void         UnionRegion(Region_t rega, Region_t regb, Region_t result);
-   void         IntersectRegion(Region_t rega, Region_t regb, Region_t result);
-   void         SubtractRegion(Region_t rega, Region_t regb, Region_t result);
-   void         XorRegion(Region_t rega, Region_t regb, Region_t result);
-   Bool_t       EmptyRegion(Region_t reg);
-   Bool_t       PointInRegion(Int_t x, Int_t y, Region_t reg);
-   Bool_t       EqualRegion(Region_t rega, Region_t regb);
-   void         GetRegionBox(Region_t reg, Rectangle_t *);
-   char       **ListFonts(const char *fontname, Int_t max, Int_t &count);
-   void         FreeFontNames(char **fontlist);
-   Drawable_t   CreateImage(UInt_t width, UInt_t height);
-   void         GetImageSize(Drawable_t id, UInt_t &width, UInt_t &height);
-   void         PutPixel(Drawable_t id, Int_t x, Int_t y, ULong_t pixel);
+                             Int_t &win_y, UInt_t &mask) override;
+   void         SetForeground(GContext_t gc, ULong_t foreground) override;
+   void         SetClipRectangles(GContext_t gc, Int_t x, Int_t y, Rectangle_t *recs, Int_t n) override;
+   void         Update(Int_t mode = 0) override;
+   Region_t     CreateRegion() override;
+   void         DestroyRegion(Region_t reg) override;
+   void         UnionRectWithRegion(Rectangle_t *rect, Region_t src, Region_t dest) override;
+   Region_t     PolygonRegion(Point_t *points, Int_t np, Bool_t winding) override;
+   void         UnionRegion(Region_t rega, Region_t regb, Region_t result) override;
+   void         IntersectRegion(Region_t rega, Region_t regb, Region_t result) override;
+   void         SubtractRegion(Region_t rega, Region_t regb, Region_t result) override;
+   void         XorRegion(Region_t rega, Region_t regb, Region_t result) override;
+   Bool_t       EmptyRegion(Region_t reg) override;
+   Bool_t       PointInRegion(Int_t x, Int_t y, Region_t reg) override;
+   Bool_t       EqualRegion(Region_t rega, Region_t regb) override;
+   void         GetRegionBox(Region_t reg, Rectangle_t *) override;
+   char       **ListFonts(const char *fontname, Int_t max, Int_t &count) override;
+   void         FreeFontNames(char **fontlist) override;
+   Drawable_t   CreateImage(UInt_t width, UInt_t height) override;
+   void         GetImageSize(Drawable_t id, UInt_t &width, UInt_t &height) override;
+   void         PutPixel(Drawable_t id, Int_t x, Int_t y, ULong_t pixel) override;
    void         PutImage(Drawable_t id, GContext_t gc, Drawable_t img,
                          Int_t dx, Int_t dy, Int_t x, Int_t y,
-                         UInt_t w, UInt_t h);
-   void         DeleteImage(Drawable_t img);
-   unsigned char *GetColorBits(Drawable_t wid, Int_t x, Int_t y, UInt_t width, UInt_t height);
-   Int_t        AddWindow(ULongptr_t qwid, UInt_t w, UInt_t h);
-   void         RemoveWindow(ULongptr_t qwid);
-   void         ShapeCombineMask(Window_t id, Int_t x, Int_t y, Pixmap_t mask);
-   UInt_t       ScreenWidthMM() const;
+                         UInt_t w, UInt_t h) override;
+   void         DeleteImage(Drawable_t img) override;
+   unsigned char *GetColorBits(Drawable_t wid, Int_t x, Int_t y, UInt_t width, UInt_t height) override;
+   Int_t        AddWindow(ULongptr_t qwid, UInt_t w, UInt_t h) override;
+   void         RemoveWindow(ULongptr_t qwid) override;
+   void         ShapeCombineMask(Window_t id, Int_t x, Int_t y, Pixmap_t mask) override;
+   UInt_t       ScreenWidthMM() const override;
 
-   void         DeleteProperty(Window_t, Atom_t&);
+   void         DeleteProperty(Window_t, Atom_t&) override;
    Int_t        GetProperty(Window_t, Atom_t, Long_t, Long_t, Bool_t, Atom_t,
-                            Atom_t*, Int_t*, ULong_t*, ULong_t*, unsigned char**);
-   void         ChangeActivePointerGrab(Window_t, UInt_t, Cursor_t);
-   void         ConvertSelection(Window_t, Atom_t&, Atom_t&, Atom_t&, Time_t&);
-   Bool_t       SetSelectionOwner(Window_t, Atom_t&);
+                            Atom_t*, Int_t*, ULong_t*, ULong_t*, unsigned char**) override;
+   void         ChangeActivePointerGrab(Window_t, UInt_t, Cursor_t) override;
+   void         ConvertSelection(Window_t, Atom_t&, Atom_t&, Atom_t&, Time_t&) override;
+   Bool_t       SetSelectionOwner(Window_t, Atom_t&) override;
    void         ChangeProperties(Window_t id, Atom_t property, Atom_t type,
-                                 Int_t format, UChar_t *data, Int_t len);
-   void         SetDNDAware(Window_t win, Atom_t *typelist);
-   void         SetTypeList(Window_t win, Atom_t prop, Atom_t *typelist);
-   Window_t     FindRWindow(Window_t win, Window_t dragwin, Window_t input, int x, int y, int maxd);
-   Bool_t       IsDNDAware(Window_t win, Atom_t *typelist);
+                                 Int_t format, UChar_t *data, Int_t len) override;
+   void         SetDNDAware(Window_t win, Atom_t *typelist) override;
+   void         SetTypeList(Window_t win, Atom_t prop, Atom_t *typelist) override;
+   Window_t     FindRWindow(Window_t win, Window_t dragwin, Window_t input, int x, int y, int maxd) override;
+   Bool_t       IsDNDAware(Window_t win, Atom_t *typelist) override;
 
-   Bool_t       IsCmdThread() const;
+   Bool_t       IsCmdThread() const override;
    void         SetUserThreadId(ULong_t id);
 
    static void Lock();


### PR DESCRIPTION
Fix 203 warnings like the following:
```
 TGWin32.h(154,14): warning GEB472421: 'DrawText' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
```
