### PR TITLE
[RF] Support multiple NLL with BatchMode existing at the same time

### DIFF
--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -448,6 +448,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     src/RooFitLegacy/RooCatTypeLegacy.cxx
     src/RunContext.cxx
     src/RooFit/Detail/CodeSquashContext.cxx
+    src/RooFit/Detail/DataMap.cxx
     src/TestStatistics/ConstantTermsOptimizer.cxx
     src/TestStatistics/LikelihoodGradientWrapper.cxx
     src/TestStatistics/LikelihoodWrapper.cxx

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -705,8 +705,8 @@ private:
   /// Returns the token for retrieving results in the BatchMode. For internal use only.
   std::size_t dataToken() const { return _dataToken; }
 
-  /// Sets the token for retrieving results in the BatchMode. For internal use only.
-  void setDataToken(std::size_t index) { _dataToken = index; }
+  void setDataToken(std::size_t index);
+  void resetDataToken() { _dataToken = std::numeric_limits<std::size_t>::max(); }
  protected:
 
 
@@ -733,7 +733,7 @@ private:
 
   mutable RooWorkspace *_myws; //! In which workspace do I live, if any
 
-  std::size_t _dataToken = 0; //! Set by the RooFitDriver for this arg to retrieve its result in the run context
+  std::size_t _dataToken = std::numeric_limits<std::size_t>::max(); //! Set by the RooFitDriver for this arg to retrieve its result in the run context
 
   /// \cond Internal
   // Legacy streamers need the following statics:

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -704,7 +704,7 @@ private:
 
   /// Returns the token for retrieving results in the BatchMode. For internal use only.
   std::size_t dataToken() const { return _dataToken; }
-
+  bool hasDataToken() const { return _dataToken != std::numeric_limits<std::size_t>::max(); }
   void setDataToken(std::size_t index);
   void resetDataToken() { _dataToken = std::numeric_limits<std::size_t>::max(); }
  protected:

--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -460,7 +460,6 @@ protected:
 
   //---------- Interface to access batch data ---------------------------
   //
-  friend class BatchInterfaceAccessor;
 
  private:
   void checkBatchComputation(const RooBatchCompute::RunContext& evalData, std::size_t evtNo, const RooArgSet* normSet = nullptr, double relAccuracy = 1.E-13) const;
@@ -471,8 +470,17 @@ protected:
   //--------------------------------------------------------------------
 
  protected:
+  friend class BatchInterfaceAccessor;
+  friend class RooVectorDataStore;
+  friend class RooRealBinding;
+  friend class RooRealSumPdf;
+  friend class RooRealSumFunc;
+  friend class RooAddHelpers;
+  friend class RooAddPdf;
+  friend class RooAddModel;
+  friend class RooFit::Detail::DataMap;
+
   // Hooks for RooDataSet interface
-  friend class RooVectorDataStore ;
   void syncCache(const RooArgSet* set=nullptr) override { getVal(set) ; }
   void copyCache(const RooAbsArg* source, bool valueOnly=false, bool setValDirty=true) override ;
   void attachToTree(TTree& t, Int_t bufSize=32000) override ;
@@ -480,7 +488,6 @@ protected:
   void setTreeBranchStatus(TTree& t, bool active) override ;
   void fillTreeBranch(TTree& t) override ;
 
-  friend class RooRealBinding ;
   double _plotMin = 0.0;       ///< Minimum of plot range
   double _plotMax = 0.0;       ///< Maximum of plot range
   Int_t _plotBins = 100;       ///< Number of plot bins
@@ -551,12 +558,6 @@ protected:
 
   bool redirectServersHook(const RooAbsCollection & newServerList, bool mustReplaceAll,
                                    bool nameChange, bool isRecursiveStep) override;
-
-  friend class RooRealSumPdf ;
-  friend class RooRealSumFunc;
-  friend class RooAddHelpers ;
-  friend class RooAddPdf ;
-  friend class RooAddModel ;
 
   static void globalSelectComp(bool flag) ;
   bool _selectComp = true;         //! Component selection flag for RooAbsPdf::plotCompOn

--- a/roofit/roofitcore/inc/RooFit/Detail/DataMap.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/DataMap.h
@@ -85,25 +85,29 @@ public:
    auto size() const { return _dataMap.size(); }
    auto resize(std::size_t n) { return _dataMap.resize(n); }
 
-   inline auto &at(RooAbsArg const *arg, RooAbsArg const * /*caller*/ = nullptr)
+   inline void set(RooAbsArg const *arg, RooSpan<const double> const &span)
    {
+      if (!arg->hasDataToken())
+         return;
       std::size_t idx = arg->dataToken();
-      return _dataMap[idx];
+      _dataMap[idx] = span;
    }
 
-   inline auto &at(RooAbsArg const *arg, RooAbsArg const *caller = nullptr) const
+   RooSpan<const double> at(RooAbsArg const *arg, RooAbsArg const * caller = nullptr);
+
+   inline RooSpan<const double> at(RooAbsArg const *arg, RooAbsArg const *caller = nullptr) const
    {
       return const_cast<DataMap *>(this)->at(arg, caller);
    }
 
    template <class T>
-   inline auto &at(RooTemplateProxy<T> const &proxy)
+   inline RooSpan<const double> at(RooTemplateProxy<T> const &proxy)
    {
       return at(&proxy.arg(), proxy.owner());
    }
 
    template <class T>
-   inline auto &at(RooTemplateProxy<T> const &proxy) const
+   inline RooSpan<const double> at(RooTemplateProxy<T> const &proxy) const
    {
       return at(&proxy.arg(), proxy.owner());
    }

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -2534,3 +2534,19 @@ void RooAbsArg::translate(RooFit::Detail::CodeSquashContext & /*ctx*/) const
    coutE(Minimization) << errorMsg.str() << std::endl;
    throw std::runtime_error(errorMsg.str().c_str());
 }
+
+/// Sets the token for retrieving results in the BatchMode. For internal use only.
+void RooAbsArg::setDataToken(std::size_t index)
+{
+   if (_dataToken == index) {
+      return;
+   }
+   if (_dataToken != std::numeric_limits<std::size_t>::max()) {
+      std::stringstream errMsg;
+      errMsg << "The data token for \"" << GetName() << "\" is already set!"
+             << " Are you trying to evaluate the same object by multiple RooFitDriver instances?"
+             << " This is not allowed.";
+      throw std::runtime_error(errMsg.str());
+   }
+   _dataToken = index;
+}

--- a/roofit/roofitcore/src/RooFit/Detail/DataMap.cxx
+++ b/roofit/roofitcore/src/RooFit/Detail/DataMap.cxx
@@ -1,0 +1,33 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   Garima Singh, CERN 2023
+ *   Jonas Rembser, CERN 2023
+ *
+ * Copyright (c) 2023, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#include <RooFit/Detail/DataMap.h>
+
+#include <RooRealVar.h>
+
+namespace RooFit {
+namespace Detail {
+
+RooSpan<const double> DataMap::at(RooAbsArg const *arg, RooAbsArg const * /*caller*/)
+{
+   if (!arg->hasDataToken()) {
+      auto var = static_cast<RooRealVar const *>(arg);
+      return {&var->_value, 1};
+   }
+   std::size_t idx = arg->dataToken();
+   return _dataMap[idx];
+}
+
+
+} // namespace Detail
+} // namespace RooFit

--- a/roofit/roofitcore/src/RooFitDriver.cxx
+++ b/roofit/roofitcore/src/RooFitDriver.cxx
@@ -124,7 +124,6 @@ struct NodeInfo {
    bool hasLogged = false;
    std::size_t outputSize = 1;
    std::size_t lastSetValCount = std::numeric_limits<std::size_t>::max();
-   std::size_t originalDataToken = 0;
    double scalarBuffer = 0.0;
    std::vector<NodeInfo *> serverInfos;
    std::vector<NodeInfo *> clientInfos;
@@ -176,7 +175,6 @@ RooFitDriver::RooFitDriver(const RooAbsReal &absReal, RooFit::BatchModeOption ba
       nodeInfo.iNode = iNode;
       nodeInfos[arg] = &nodeInfo;
 
-      nodeInfo.originalDataToken = arg->dataToken();
       arg->setDataToken(iNode);
 
       if (dynamic_cast<RooRealVar const *>(arg)) {
@@ -285,7 +283,7 @@ void RooFitDriver::setData(DataSpansMap const &dataSpans)
 RooFitDriver::~RooFitDriver()
 {
    for (auto &info : _nodes) {
-      info.absArg->setDataToken(info.originalDataToken);
+      info.absArg->resetDataToken();
    }
 
    if (_batchMode == RooFit::BatchModeOption::Cuda) {

--- a/roofit/roofitcore/src/RooFitDriver.cxx
+++ b/roofit/roofitcore/src/RooFitDriver.cxx
@@ -160,7 +160,6 @@ RooFitDriver::RooFitDriver(const RooAbsReal &absReal, RooFit::BatchModeOption ba
    _dataMapCPU.resize(serverSet.size());
    _dataMapCUDA.resize(serverSet.size());
 
-   std::unordered_map<TNamed const *, std::size_t> tokens;
    std::map<RooFit::Detail::DataKey, NodeInfo *> nodeInfos;
 
    // Fill the ordered nodes list and initialize the node info structs.
@@ -168,17 +167,15 @@ RooFitDriver::RooFitDriver(const RooAbsReal &absReal, RooFit::BatchModeOption ba
    std::size_t iNode = 0;
    for (RooAbsArg *arg : serverSet) {
 
-      tokens[arg->namePtr()] = iNode;
-
       auto &nodeInfo = _nodes[iNode];
       nodeInfo.absArg = arg;
       nodeInfo.iNode = iNode;
       nodeInfos[arg] = &nodeInfo;
 
-      arg->setDataToken(iNode);
-
       if (dynamic_cast<RooRealVar const *>(arg)) {
          nodeInfo.isVariable = true;
+      } else {
+         arg->setDataToken(iNode);
       }
       if (dynamic_cast<RooAbsCategory const *>(arg)) {
          nodeInfo.isCategory = true;
@@ -195,15 +192,35 @@ RooFitDriver::RooFitDriver(const RooAbsReal &absReal, RooFit::BatchModeOption ba
             info.serverInfos.emplace_back(serverInfo);
             serverInfo->clientInfos.emplace_back(&info);
          }
-         server->setDataToken(tokens.at(server->namePtr()));
       }
    }
+
+   syncDataTokens();
 
    if (_batchMode == RooFit::BatchModeOption::Cuda) {
       // create events and streams for every node
       for (auto &info : _nodes) {
          info.event = RooBatchCompute::dispatchCUDA->newCudaEvent(true);
          info.stream = RooBatchCompute::dispatchCUDA->newCudaStream();
+      }
+   }
+}
+
+/// If there are servers with the same name that got de-duplicated in the
+/// `_nodes` list, we need to set their data tokens too. We find such nodes by
+/// visiting the servers of every known node.
+void RooFitDriver::syncDataTokens()
+{
+   for (NodeInfo &info : _nodes) {
+      std::size_t iValueServer = 0;
+      for (RooAbsArg *server : info.absArg->servers()) {
+         if (server->isValueServer(*info.absArg)) {
+            auto *knownServer = info.serverInfos[iValueServer]->absArg;
+            if (knownServer->hasDataToken()) {
+               server->setDataToken(knownServer->dataToken());
+            }
+            ++iValueServer;
+         }
       }
    }
 }
@@ -224,6 +241,7 @@ void RooFitDriver::setData(DataSpansMap const &dataSpans)
    // they are used in the computation graph. If yes, add the span to the data
    // map and set the node info accordingly.
    std::size_t totalSize = 0;
+   std::size_t iNode = 0;
    for (auto &info : _nodes) {
       if (info.buffer) {
          delete info.buffer;
@@ -231,7 +249,8 @@ void RooFitDriver::setData(DataSpansMap const &dataSpans)
       }
       auto found = dataSpans.find(info.absArg->namePtr());
       if (found != dataSpans.end()) {
-         _dataMapCPU.at(info.absArg) = found->second;
+         info.absArg->setDataToken(iNode);
+         _dataMapCPU.set(info.absArg, found->second);
          info.fromDataset = true;
          info.isDirty = false;
          totalSize += found->second.size();
@@ -239,7 +258,10 @@ void RooFitDriver::setData(DataSpansMap const &dataSpans)
          info.fromDataset = false;
          info.isDirty = true;
       }
+      ++iNode;
    }
+
+   syncDataTokens();
 
    for (auto &info : _nodes) {
       info.outputSize = outputSizeMap.at(info.absArg);
@@ -268,9 +290,9 @@ void RooFitDriver::setData(DataSpansMap const &dataSpans)
       std::size_t size = info.outputSize;
       if (size == 1) {
          // Scalar observables from the data don't need to be copied to the GPU
-         _dataMapCUDA.at(info.absArg) = _dataMapCPU.at(info.absArg);
+         _dataMapCUDA.set(info.absArg, _dataMapCPU.at(info.absArg));
       } else {
-         _dataMapCUDA.at(info.absArg) = RooSpan<double>(_cudaMemDataset + idx, size);
+         _dataMapCUDA.set(info.absArg, {_cudaMemDataset + idx, size});
          RooBatchCompute::dispatchCUDA->memcpyToCUDA(_cudaMemDataset + idx, _dataMapCPU.at(info.absArg).data(),
                                                      size * sizeof(double));
          idx += size;
@@ -316,7 +338,7 @@ void RooFitDriver::computeCPUNode(const RooAbsArg *node, NodeInfo &info)
    if (nOut == 1) {
       buffer = &info.scalarBuffer;
       if (_batchMode == RooFit::BatchModeOption::Cuda) {
-         _dataMapCUDA.at(node) = RooSpan<const double>(buffer, nOut);
+         _dataMapCUDA.set(node, {buffer, nOut});
       }
    } else {
       if (!info.hasLogged && _batchMode == RooFit::BatchModeOption::Cuda) {
@@ -333,10 +355,10 @@ void RooFitDriver::computeCPUNode(const RooAbsArg *node, NodeInfo &info)
       }
       buffer = info.buffer->cpuWritePtr();
    }
-   _dataMapCPU.at(node) = RooSpan<const double>(buffer, nOut);
+   _dataMapCPU.set(node, {buffer, nOut});
    nodeAbsReal->computeBatch(nullptr, buffer, nOut, _dataMapCPU);
    if (info.copyAfterEvaluation) {
-      _dataMapCUDA.at(node) = RooSpan<const double>(info.buffer->gpuReadPtr(), nOut);
+      _dataMapCUDA.set(node, {info.buffer->gpuReadPtr(), nOut});
       if (info.event) {
          RooBatchCompute::dispatchCUDA->cudaEventRecord(info.event, info.stream);
       }
@@ -475,17 +497,17 @@ void RooFitDriver::assignToGPU(NodeInfo &info)
    double *buffer = nullptr;
    if (nOut == 1) {
       buffer = &info.scalarBuffer;
-      _dataMapCPU.at(node) = RooSpan<const double>(buffer, nOut);
+      _dataMapCPU.set(node, {buffer, nOut});
    } else {
       info.buffer = info.copyAfterEvaluation ? _bufferManager.makePinnedBuffer(nOut, info.stream)
                                              : _bufferManager.makeGpuBuffer(nOut);
       buffer = info.buffer->gpuWritePtr();
    }
-   _dataMapCUDA.at(node) = RooSpan<const double>(buffer, nOut);
+   _dataMapCUDA.set(node, {buffer, nOut});
    node->computeBatch(info.stream, buffer, nOut, _dataMapCUDA);
    RooBatchCompute::dispatchCUDA->cudaEventRecord(info.event, info.stream);
    if (info.copyAfterEvaluation) {
-      _dataMapCPU.at(node) = RooSpan<const double>(info.buffer->cpuReadPtr(), nOut);
+      _dataMapCPU.set(node, {info.buffer->cpuReadPtr(), nOut});
    }
 }
 
@@ -576,8 +598,8 @@ void RooFitDriver::print(std::ostream &os) const
    printHorizontalRow();
 }
 
-RooAbsRealWrapper::RooAbsRealWrapper(std::unique_ptr<RooFitDriver> driver, std::string const &rangeName, RooSimultaneous const *simPdf,
-                  bool takeGlobalObservablesFromData)
+RooAbsRealWrapper::RooAbsRealWrapper(std::unique_ptr<RooFitDriver> driver, std::string const &rangeName,
+                                     RooSimultaneous const *simPdf, bool takeGlobalObservablesFromData)
    : RooAbsReal{"RooFitDriverWrapper", "RooFitDriverWrapper"},
      _driver{std::move(driver)},
      _topNode("topNode", "top node", this, _driver->topNode()),
@@ -599,7 +621,8 @@ RooAbsRealWrapper::RooAbsRealWrapper(const RooAbsRealWrapper &other, const char 
 {
 }
 
-bool RooAbsRealWrapper::getParameters(const RooArgSet *observables, RooArgSet &outputSet, bool /*stripDisconnected*/) const
+bool RooAbsRealWrapper::getParameters(const RooArgSet *observables, RooArgSet &outputSet,
+                                      bool /*stripDisconnected*/) const
 {
    outputSet.add(_parameters);
    if (observables) {

--- a/roofit/roofitcore/src/RooFitDriver.h
+++ b/roofit/roofitcore/src/RooFitDriver.h
@@ -66,6 +66,7 @@ private:
    void assignToGPU(NodeInfo &info);
    void computeCPUNode(const RooAbsArg *node, NodeInfo &info);
    void setOperMode(RooAbsArg *arg, RooAbsArg::OperMode opMode);
+   void syncDataTokens();
 
    ///////////////////////////
    // Private member variables


### PR DESCRIPTION
The RooFitDriver mutates the RooAbsArgs it evaluates by setting a
specific index token to quickly look up cached information for a given
RooAbsArg.

Because of this, it's not possible to evaluate two computation graphs
that share RooAbsArgs with two separate RooFitDrivers.

However, this usecase needs to be supported, because in RooStats is
often happens that different likelihoods based on the same model are
instantiated.

The key to the solution in this commit is the insight that for each
likelihood, almost the full compute graph is cloned anyway, *except* for
the parameters. Therefore, the solution proposed in this commit is to
not set the data tokens for the parameters and not fill the data map
with their values. Instead, when querying their values, they are just
retrieved from the object itself. This is possible because parameters
are always scalar, and the RooAbsReal can already cache scalar members
in the `_value` field.

This PR fixes the failure of some RooStats tutorials if BatchMode would be enabled by default.

After this PR is merged, the CI would be completely green if `BatchMode("cpu")` would be made the default!