### PR TITLE
PCA : Appropriately handle histogram bins for few data points

### DIFF
--- a/hist/hist/src/TPrincipal.cxx
+++ b/hist/hist/src/TPrincipal.cxx
@@ -671,7 +671,7 @@ void TPrincipal::MakeHistograms(const char *name, Option_t *opt)
          // histogram.
          Double_t xlowb  = fMeanValues(i) - 4 * fSigmas(i);
          Double_t xhighb = fMeanValues(i) + 4 * fSigmas(i);
-         Int_t    xbins  = fNumberOfDataPoints/100;
+         Int_t    xbins  = (fNumberOfDataPoints > 0 && fNumberOfDataPoints < 100 ? 1 : fNumberOfDataPoints/100);
          hX[i]           = new TH1F(Form("%s_x%03d", name, i),
             Form("Pattern space, variable %d", i),
             xbins,xlowb,xhighb);
@@ -683,7 +683,7 @@ void TPrincipal::MakeHistograms(const char *name, Option_t *opt)
          // The upper limit below is arbitrary!!!
          Double_t dlowb  = 0;
          Double_t dhighb = 20;
-         Int_t    dbins  = fNumberOfDataPoints/100;
+         Int_t    dbins  = (fNumberOfDataPoints > 0 && fNumberOfDataPoints < 100 ? 1 : fNumberOfDataPoints/100);
          hD[i]           = new TH2F(Form("%s_d%03d", name, i),
             Form("Distance from pattern to "
             "feature space, variable %d", i),


### PR DESCRIPTION
When using option "x" for TPrincipal::MakeHistograms(), the histogram is made with the number of bins as calculated by:
`Int_t xbins = fNumberOfDataPoints/100;`
If the number of data points is less than 100, this will try to make a histogram with 0 bins. The code still functions, as TH1 itself compensates by setting the number of bins to 1, and issuing a warning. But clearly TPrincipal could be smarter to avoid the unnecessary / unhelpful warning.

The same happens for the calculation of `dbins` with the "d" option.

Sidenote: this was a non-urgent issue I raised 7 years ago, but if no one else has been complaining, it's clearly a low priority ;-)

https://sft.its.cern.ch/jira/browse/ROOT-8238

-Gene