### PR TITLE
[RF] Use `std::unique_ptr` in RooFit and RooStats tutorials

### DIFF
--- a/tutorials/roofit/rf103_interprfuncs.C
+++ b/tutorials/roofit/rf103_interprfuncs.C
@@ -82,8 +82,8 @@ void rf103_interprfuncs()
    // -------------------------------------------------------------------
 
    // Fit g2 to data from g1
-   RooFitResult *r = g2.fitTo(*data2, Save());
-   r->Print();
+   std::unique_ptr<RooFitResult> fitResult{g2.fitTo(*data2, Save())};
+   fitResult->Print();
 
    // Plot data on frame and overlay projection of g2
    RooPlot *xframe2 = x.frame(Title("Tailored Gaussian pdf"));

--- a/tutorials/roofit/rf110_normintegration.C
+++ b/tutorials/roofit/rf110_normintegration.C
@@ -42,7 +42,7 @@ void rf110_normintegration()
 
    // Create object representing integral over gx
    // which is used to calculate  gx_Norm[x] == gx / gx_Int[x]
-   RooAbsReal *igx = gx.createIntegral(x);
+   std::unique_ptr<RooAbsReal> igx{gx.createIntegral(x)};
    cout << "gx_Int[x] = " << igx->getVal() << endl;
 
    // I n t e g r a t e   n o r m a l i z e d   p d f   o v e r   s u b r a n g e
@@ -54,7 +54,7 @@ void rf110_normintegration()
    // Create an integral of gx_Norm[x] over x in range "signal"
    // This is the fraction of of pdf gx_Norm[x] which is in the
    // range named "signal"
-   RooAbsReal *igx_sig = gx.createIntegral(x, NormSet(x), Range("signal"));
+   std::unique_ptr<RooAbsReal> igx_sig{gx.createIntegral(x, NormSet(x), Range("signal"))};
    cout << "gx_Int[x|signal]_Norm[x] = " << igx_sig->getVal() << endl;
 
    // C o n s t r u c t   c u m u l a t i v e   d i s t r i b u t i o n   f u n c t i o n   f r o m   p d f
@@ -62,7 +62,7 @@ void rf110_normintegration()
 
    // Create the cumulative distribution function of gx
    // i.e. calculate Int[-10,x] gx(x') dx'
-   RooAbsReal *gx_cdf = gx.createCdf(x);
+   std::unique_ptr<RooAbsReal> gx_cdf{gx.createCdf(x)};
 
    // Plot cdf of gx versus x
    RooPlot *frame = x.frame(Title("cdf of Gaussian pdf"));

--- a/tutorials/roofit/rf203_ranges.C
+++ b/tutorials/roofit/rf203_ranges.C
@@ -48,7 +48,7 @@ void rf203_ranges()
    // ---------------------------
 
    // Fit pdf to all data
-   RooFitResult *r_full = model.fitTo(*modelData, Save(true));
+   std::unique_ptr<RooFitResult> r_full{model.fitTo(*modelData, Save(true))};
 
    // F i t   p a r t i a l   r a n g e
    // ----------------------------------
@@ -57,7 +57,7 @@ void rf203_ranges()
    x.setRange("signal", -3, 3);
 
    // Fit pdf only to data in "signal" range
-   RooFitResult *r_sig = model.fitTo(*modelData, Save(true), Range("signal"));
+   std::unique_ptr<RooFitResult> r_sig{model.fitTo(*modelData, Save(true), Range("signal"))};
 
    // P l o t   /   p r i n t   r e s u l t s
    // ---------------------------------------

--- a/tutorials/roofit/rf204a_extendedLikelihood.C
+++ b/tutorials/roofit/rf204a_extendedLikelihood.C
@@ -95,7 +95,7 @@ void rf204a_extendedLikelihood()
    // the interpretation of the coefficients is tied to the fit range
    // that's used in the first fit
    RooAddPdf model1(model);
-   RooFitResult* r = model1.fitTo(*data,Save()) ;
+   std::unique_ptr<RooFitResult> r{model1.fitTo(*data,Save())};
    r->Print() ;
 
    RooPlot * frame = x.frame(Title("Full range fitted"));
@@ -114,9 +114,7 @@ void rf204a_extendedLikelihood()
    x.setRange("right", 6., 10.);
 
    RooAddPdf model2(model);
-   RooFitResult* r2 = model2.fitTo(*data,
-      Range("left,right"),
-      Save()) ;
+   std::unique_ptr<RooFitResult> r2{model2.fitTo(*data, Range("left,right"), Save())};
    r2->Print();
 
 
@@ -137,9 +135,7 @@ void rf204a_extendedLikelihood()
    x.setRange("leftToMiddle",  0., 5.);
 
    RooAddPdf model3(model);
-   RooFitResult* r3 = model3.fitTo(*data,
-      Range("leftToMiddle"),
-      Save()) ;
+   std::unique_ptr<RooFitResult> r3{model3.fitTo(*data, Range("leftToMiddle"), Save())};
    r3->Print();
 
 

--- a/tutorials/roofit/rf207_comptools.C
+++ b/tutorials/roofit/rf207_comptools.C
@@ -70,26 +70,26 @@ void rf207_comptools()
    // shared between a model and a dataset. In this case
    // that is the variable 'x'
 
-   RooArgSet *model_obs = model.getObservables(data);
+   std::unique_ptr<RooArgSet> model_obs{model.getObservables(data)};
    model_obs->Print("v");
 
    // G e t   l i s t   o f   p a r a m e t e r s
    // -------------------------------------------
 
    // Get list of parameters, given list of observables
-   RooArgSet *model_params = model.getParameters(x);
+   std::unique_ptr<RooArgSet> model_params{model.getParameters(x)};
    model_params->Print("v");
 
    // Get list of parameters, given a dataset
    // (Gives identical results to operation above)
-   RooArgSet *model_params2 = model.getParameters(data);
+   std::unique_ptr<RooArgSet> model_params2{model.getParameters(data)};
    model_params2->Print();
 
    // G e t   l i s t   o f   c o m p o n e n t s
    // -------------------------------------------
 
    // Get list of component objects, including top-level node
-   RooArgSet *model_comps = model.getComponents();
+   std::unique_ptr<RooArgSet> model_comps{model.getComponents()};
    model_comps->Print("v");
 
    // -------------------------------------------------------------------------------

--- a/tutorials/roofit/rf308_normintegration2d.C
+++ b/tutorials/roofit/rf308_normintegration2d.C
@@ -49,7 +49,7 @@ void rf308_normintegration2d()
 
    // Create object representing integral over gx
    // which is used to calculate  gx_Norm[x,y] == gx / gx_Int[x,y]
-   RooAbsReal *igxy = gxy.createIntegral(RooArgSet(x, y));
+   std::unique_ptr<RooAbsReal> igxy{gxy.createIntegral(RooArgSet(x, y))};
    cout << "gx_Int[x,y] = " << igxy->getVal() << endl;
 
    // NB: it is also possible to do the following
@@ -72,7 +72,7 @@ void rf308_normintegration2d()
    // Create an integral of gxy_Norm[x,y] over x and y in range "signal"
    // This is the fraction of of pdf gxy_Norm[x,y] which is in the
    // range named "signal"
-   RooAbsReal *igxy_sig = gxy.createIntegral(RooArgSet(x, y), NormSet(RooArgSet(x, y)), Range("signal"));
+   std::unique_ptr<RooAbsReal> igxy_sig{gxy.createIntegral({x, y}, NormSet(RooArgSet(x, y)), Range("signal"))};
    cout << "gx_Int[x,y|signal]_Norm[x,y] = " << igxy_sig->getVal() << endl;
 
    // C o n s t r u c t   c u m u l a t i v e   d i s t r i b u t i o n   f u n c t i o n   f r o m   p d f
@@ -80,7 +80,7 @@ void rf308_normintegration2d()
 
    // Create the cumulative distribution function of gx
    // i.e. calculate Int[-10,x] gx(x') dx'
-   RooAbsReal *gxy_cdf = gxy.createCdf(RooArgSet(x, y));
+   std::unique_ptr<RooAbsReal> gxy_cdf{gxy.createCdf(RooArgSet(x, y))};
 
    // Plot cdf of gx versus x
    TH1 *hh_cdf = gxy_cdf->createHistogram("hh_cdf", x, Binning(40), YVar(y, Binning(40)));

--- a/tutorials/roofit/rf312_multirangefit.C
+++ b/tutorials/roofit/rf312_multirangefit.C
@@ -87,17 +87,17 @@ void rf312_multirangefit()
    // -------------------------------------------------------------------------------------
 
    // Perform fit in SideBand1 region (RooAddPdf coefficients will be interpreted in full range)
-   RooFitResult *r_sb1 = model.fitTo(*modelData, Range("SB1"), Save());
+   std::unique_ptr<RooFitResult> r_sb1{model.fitTo(*modelData, Range("SB1"), Save())};
 
    // Perform fit in SideBand2 region (RooAddPdf coefficients will be interpreted in full range)
-   RooFitResult *r_sb2 = model.fitTo(*modelData, Range("SB2"), Save());
+   std::unique_ptr<RooFitResult> r_sb2{model.fitTo(*modelData, Range("SB2"), Save())};
 
    // P e r f o r m   f i t s   i n   j o i n t    s i d e b a n d   r e g i o n s
    // -----------------------------------------------------------------------------
 
    // Now perform fit to joint 'L-shaped' sideband region 'SB1|SB2'
    // (RooAddPdf coefficients will be interpreted in full range)
-   RooFitResult *r_sb12 = model.fitTo(*modelData, Range("SB1,SB2"), Save());
+   std::unique_ptr<RooFitResult> r_sb12{model.fitTo(*modelData, Range("SB1,SB2"), Save())};
 
    // Print results for comparison
    r_sb1->Print();

--- a/tutorials/roofit/rf313_paramranges.C
+++ b/tutorials/roofit/rf313_paramranges.C
@@ -60,7 +60,7 @@ void rf313_paramranges()
    // ----------------------------------------------------------------------------------
 
    // Create integral over normalized pdf model over x,y,z in "R" region
-   RooAbsReal *intPdf = pxyz.createIntegral(RooArgSet(x, y, z), RooArgSet(x, y, z), "R");
+   std::unique_ptr<RooAbsReal> intPdf{pxyz.createIntegral(RooArgSet(x, y, z), RooArgSet(x, y, z), "R")};
 
    // Plot value of integral as function of pdf parameter z0
    RooPlot *frame = z0.frame(Title("Integral of pxyz over x,y,z in region R"));

--- a/tutorials/roofit/rf314_paramfitrange.C
+++ b/tutorials/roofit/rf314_paramfitrange.C
@@ -59,7 +59,7 @@ void rf314_paramfitrange()
    // F i t   p d f   t o   d a t a   i n   a c c e p t a n c e   r e g i o n
    // -----------------------------------------------------------------------
 
-   RooFitResult *r = model.fitTo(*dacc, Save());
+   std::unique_ptr<RooFitResult> r{model.fitTo(*dacc, Save())};
 
    // P l o t   f i t t e d   p d f   o n   f u l l   a n d   a c c e p t e d   d a t a
    // ---------------------------------------------------------------------------------

--- a/tutorials/roofit/rf403_weightedevts.C
+++ b/tutorials/roofit/rf403_weightedevts.C
@@ -73,7 +73,7 @@ void rf403_weightedevts()
    //       event weights represent Poisson statistics themselves.
    //
    // Fit with 'wrong' errors
-   RooFitResult *r_ml_wgt = p2.fitTo(wdata, Save());
+   std::unique_ptr<RooFitResult> r_ml_wgt{p2.fitTo(wdata, Save())};
 
    // A first order correction to estimated parameter errors in an
    // (unbinned) ML fit can be obtained by calculating the
@@ -88,7 +88,7 @@ void rf403_weightedevts()
    //
    // A fit in this mode can be performed as follows:
 
-   RooFitResult *r_ml_wgt_corr = p2.fitTo(wdata, Save(), SumW2Error(true));
+   std::unique_ptr<RooFitResult> r_ml_wgt_corr{p2.fitTo(wdata, Save(), SumW2Error(true))};
 
    // P l o t   w e i g h e d   d a t a   a n d   f i t   r e s u l t
    // ---------------------------------------------------------------
@@ -115,8 +115,8 @@ void rf403_weightedevts()
    RooDataSet *data3 = genPdf.generate(x, 43000);
 
    // Fit the 2nd order polynomial to both unweighted datasets and save the results for comparison
-   RooFitResult *r_ml_unw10 = p2.fitTo(*data2, Save());
-   RooFitResult *r_ml_unw43 = p2.fitTo(*data3, Save());
+   std::unique_ptr<RooFitResult> r_ml_unw10{p2.fitTo(*data2, Save())};
+   std::unique_ptr<RooFitResult> r_ml_unw43{p2.fitTo(*data3, Save())};
 
    // C h i 2   f i t   o f   p d f   t o   b i n n e d   w e i g h t e d   d a t a s e t
    // ------------------------------------------------------------------------------------
@@ -136,7 +136,7 @@ void rf403_weightedevts()
    m.hesse();
 
    // Plot chi^2 fit result on frame as well
-   RooFitResult *r_chi2_wgt = m.save();
+   std::unique_ptr<RooFitResult> r_chi2_wgt{m.save()};
    p2.plotOn(frame, LineStyle(kDashed), LineColor(kRed));
 
    // C o m p a r e   f i t   r e s u l t s   o f   c h i 2 , M L   f i t s   t o   ( u n ) w e i g h t e d   d a t a

--- a/tutorials/roofit/rf407_latextables.C
+++ b/tutorials/roofit/rf407_latextables.C
@@ -60,10 +60,10 @@ void rf407_latextables()
    // ----------------------------------------------------------------------------------------
 
    // Make list of model parameters
-   RooArgSet *params = model.getParameters(x);
+   std::unique_ptr<RooArgSet> params{model.getParameters(x)};
 
    // Save snapshot of prefit parameters
-   RooArgSet *initParams = (RooArgSet *)params->snapshot();
+   std::unique_ptr<RooArgSet> initParams{static_cast<RooArgSet *>(params->snapshot())};
 
    // Do fit to data, to obtain error estimates on parameters
    RooDataSet *data = model.generate(x, 1000);

--- a/tutorials/roofit/rf505_asciicfg.C
+++ b/tutorials/roofit/rf505_asciicfg.C
@@ -48,7 +48,7 @@ void rf505_asciicfg()
    // -----------------------------------------------------------
 
    // Obtain set of parameters
-   RooArgSet *params = model.getParameters(x);
+   std::unique_ptr<RooArgSet> params{model.getParameters(x)};
 
    // Write parameters to file
    params->writeToFile("rf505_asciicfg_example.txt");

--- a/tutorials/roofit/rf506_msgservice.C
+++ b/tutorials/roofit/rf506_msgservice.C
@@ -60,7 +60,7 @@ void rf506_msgservice()
    RooMsgService::instance().getStream(1).addTopic(Integration);
 
    // Construct integral over gauss to demonstrate new message stream
-   RooAbsReal *igauss = gauss.createIntegral(x);
+   std::unique_ptr<RooAbsReal> igauss{gauss.createIntegral(x)};
    igauss->Print();
 
    // Print streams configuration in verbose, which also shows inactive streams

--- a/tutorials/roofit/rf509_wsinteractive.C
+++ b/tutorials/roofit/rf509_wsinteractive.C
@@ -40,17 +40,12 @@ void rf509_wsinteractive()
    // U s e   w o r k s p a c e   c o n t e n t s
    // ----------------------------------------------
 
-   // Old syntax to use the name space prefix operator to access the workspace contents
-   //
-   // RooDataSet* d = w::model.generate(w::x,1000) ;
-   // RooFitResult* r = w::model.fitTo(*d) ;
-
    // use normal workspace methods
    RooAbsPdf *model = w1->pdf("model");
    RooRealVar *x = w1->var("x");
 
    RooDataSet *d = model->generate(*x, 1000);
-   RooFitResult *r = model->fitTo(*d);
+   std::unique_ptr<RooFitResult> r{model->fitTo(*d)};
 
    // old syntax to access the variable x
    // RooPlot* frame = w::x.frame() ;

--- a/tutorials/roofit/rf510_wsnamedsets.C
+++ b/tutorials/roofit/rf510_wsnamedsets.C
@@ -111,7 +111,7 @@ void fillWorkspace(RooWorkspace &w)
    // of defineSet must be set to import them on the fly. Named sets contain only references
    // to the original variables, therefore the value of observables in named sets already
    // reflect their 'current' value
-   RooArgSet *params = (RooArgSet *)model.getParameters(x);
+   std::unique_ptr<RooArgSet> params{model.getParameters(x)};
    w.defineSet("parameters", *params);
    w.defineSet("observables", x);
 

--- a/tutorials/roofit/rf601_intminuit.C
+++ b/tutorials/roofit/rf601_intminuit.C
@@ -46,7 +46,7 @@ void rf601_intminuit()
    RooDataSet *data = model.generate(x, 1000);
 
    // Construct unbinned likelihood of model w.r.t. data
-   RooAbsReal *nll = model.createNLL(*data);
+   std::unique_ptr<RooAbsReal> nll{model.createNLL(*data)};
 
    // I n t e r a c t i v e   m i n i m i z a t i o n ,   e r r o r   a n a l y s i s
    // -------------------------------------------------------------------------------

--- a/tutorials/roofit/rf604_constraints.C
+++ b/tutorials/roofit/rf604_constraints.C
@@ -61,10 +61,10 @@ void rf604_constraints()
    RooProdPdf modelc("modelc", "model with constraint", RooArgSet(model, fconstraint));
 
    // Fit model (without use of constraint term)
-   RooFitResult *r1 = model.fitTo(*d, Save(), PrintLevel(-1));
+   std::unique_ptr<RooFitResult> r1{model.fitTo(*d, Save(), PrintLevel(-1))};
 
    // Fit modelc with constraint term on parameter f
-   RooFitResult *r2 = modelc.fitTo(*d, Constrain(f), Save(), PrintLevel(-1));
+   std::unique_ptr<RooFitResult> r2{modelc.fitTo(*d, Constrain(f), Save(), PrintLevel(-1))};
 
    // M E T H O D   2   -     S p e c i f y   e x t e r n a l   c o n s t r a i n t   w h e n   f i t t i n g
    // -------------------------------------------------------------------------------------------------------
@@ -73,7 +73,7 @@ void rf604_constraints()
    RooGaussian fconstext("fconstext", "fconstext", f, 0.2, 0.1);
 
    // Fit with external constraint
-   RooFitResult *r3 = model.fitTo(*d, ExternalConstraints(fconstext), Save(), PrintLevel(-1));
+   std::unique_ptr<RooFitResult> r3{model.fitTo(*d, ExternalConstraints(fconstext), Save(), PrintLevel(-1))};
 
    // Print the fit results
    cout << "fit result without constraint (data generated at f=0.5)" << endl;

--- a/tutorials/roofit/rf605_profilell.C
+++ b/tutorials/roofit/rf605_profilell.C
@@ -46,7 +46,7 @@ void rf605_profilell()
    // ---------------------------------------------------
 
    // Construct unbinned likelihood
-   RooAbsReal *nll = model.createNLL(*data, NumCPU(2));
+   std::unique_ptr<RooAbsReal> nll{model.createNLL(*data, NumCPU(2))};
 
    // Minimize likelihood w.r.t all parameters before making plots
    RooMinimizer(*nll).migrad();
@@ -102,5 +102,4 @@ void rf605_profilell()
 
    delete pll_frac;
    delete pll_sigmag2;
-   delete nll;
 }

--- a/tutorials/roofit/rf607_fitresult.C
+++ b/tutorials/roofit/rf607_fitresult.C
@@ -62,7 +62,7 @@ void rf607_fitresult()
    // -------------------------------------------------------------
 
    // Perform fit and save result
-   RooFitResult *r = model.fitTo(*data, Save());
+   std::unique_ptr<RooFitResult> r{model.fitTo(*data, Save())};
 
    // P r i n t   f i t   r e s u l t s
    // ---------------------------------

--- a/tutorials/roofit/rf608_fitresultaspdf.C
+++ b/tutorials/roofit/rf608_fitresultaspdf.C
@@ -52,7 +52,7 @@ void rf608_fitresultaspdf()
    // F i t   m o d e l   t o   d a t a
    // ----------------------------------
 
-   RooFitResult *r = model.fitTo(*data, Save());
+   std::unique_ptr<RooFitResult> r{model.fitTo(*data, Save())};
 
    // C r e a t e M V   G a u s s i a n   p d f   o f   f i t t e d    p a r a m e t e r s
    // ------------------------------------------------------------------------------------

--- a/tutorials/roofit/rf610_visualerror.C
+++ b/tutorials/roofit/rf610_visualerror.C
@@ -44,7 +44,7 @@ void rf610_visualerror()
    RooAbsData *d = model.generateBinned(x, 1000);
 
    // Perform fit and save fit result
-   RooFitResult *r = model.fitTo(*d, Save());
+   std::unique_ptr<RooFitResult> r{model.fitTo(*d, Save())};
 
    // V i s u a l i z e   f i t   e r r o r
    // -------------------------------------

--- a/tutorials/roofit/rf611_weightedfits.C
+++ b/tutorials/roofit/rf611_weightedfits.C
@@ -166,17 +166,17 @@ int rf611_weightedfits(int acceptancemodel=2) {
     //F i t   t o y   u s i n g   t h e   t h r e e   d i f f e r e n t   a p p r o a c h e s   t o   u n c e r t a i n t y   d e t e r m i n a t i o n
     //-------------------------------------------------------------------------------------------------------------------------------------------------
     //this uses the inverse weighted Hessian matrix
-    RooFitResult* result = pol.fitTo(data, Save(true), SumW2Error(false), PrintLevel(-1), BatchMode(true));
+    std::unique_ptr<RooFitResult> result{pol.fitTo(data, Save(true), SumW2Error(false), PrintLevel(-1), BatchMode(true))};
     hc0pull1->Fill((c0.getVal()-c0gen)/c0.getError());
     hc1pull1->Fill((c1.getVal()-c1gen)/c1.getError());
 
     //this uses the correction with the Hesse matrix with squared weights
-    result = pol.fitTo(data, Save(true), SumW2Error(true), PrintLevel(-1), BatchMode(true));
+    result = std::unique_ptr<RooFitResult>{pol.fitTo(data, Save(true), SumW2Error(true), PrintLevel(-1), BatchMode(true))};
     hc0pull2->Fill((c0.getVal()-c0gen)/c0.getError());
     hc1pull2->Fill((c1.getVal()-c1gen)/c1.getError());
 
     //this uses the asymptotically correct approach
-    result = pol.fitTo(data, Save(true), AsymptoticError(true), PrintLevel(-1), BatchMode(true));
+    result = std::unique_ptr<RooFitResult>{pol.fitTo(data, Save(true), AsymptoticError(true), PrintLevel(-1), BatchMode(true))};
     hc0pull3->Fill((c0.getVal()-c0gen)/c0.getError());
     hc1pull3->Fill((c1.getVal()-c1gen)/c1.getError());
   }

--- a/tutorials/roofit/rf612_recoverFromInvalidParameters.C
+++ b/tutorials/roofit/rf612_recoverFromInvalidParameters.C
@@ -77,10 +77,10 @@ void rf612_recoverFromInvalidParameters() {
   a2.setVal(-1.);
 
   // Perform a fit:
-  RooFitResult* fitWithoutRecovery = pdf.fitTo(*data, RooFit::Save(),
+  std::unique_ptr<RooFitResult> fitWithoutRecovery{pdf.fitTo(*data, RooFit::Save(),
       RooFit::RecoverFromUndefinedRegions(0.), // This is how RooFit behaved prior to ROOT 6.24
       RooFit::PrintEvalErrors(-1), // We are expecting a lot of evaluation errors. -1 switches off printing.
-      RooFit::PrintLevel(-1));
+      RooFit::PrintLevel(-1))};
 
   pdf.plotOn(frame, RooFit::LineColor(kRed), RooFit::Name("noRecovery"));
 
@@ -97,11 +97,11 @@ void rf612_recoverFromInvalidParameters() {
   a2.setVal(-1.);
 
   // Fit again, but pass recovery information to the minimiser:
-  RooFitResult* fitWithRecovery = pdf.fitTo(*data, RooFit::Save(),
+  std::unique_ptr<RooFitResult> fitWithRecovery{pdf.fitTo(*data, RooFit::Save(),
       RooFit::RecoverFromUndefinedRegions(1.), // The magnitude of the recovery information can be chosen here.
-                                                // Higher values mean more aggressive recovery.
+                                               // Higher values mean more aggressive recovery.
       RooFit::PrintEvalErrors(-1), // We are still expecting a few evaluation errors.
-      RooFit::PrintLevel(0));
+      RooFit::PrintLevel(0))};
 
   pdf.plotOn(frame, RooFit::LineColor(kBlue), RooFit::Name("recovery"));
 

--- a/tutorials/roofit/rf901_numintconfig.C
+++ b/tutorials/roofit/rf901_numintconfig.C
@@ -57,7 +57,7 @@ void rf901_numintconfig()
    RooMsgService::instance().addStream(DEBUG, Topic(Integration));
 
    // Calculate integral over landau with default choice of numeric integrator
-   RooAbsReal *intLandau = landau.createIntegral(x);
+   std::unique_ptr<RooAbsReal> intLandau{landau.createIntegral(x)};
    double val = intLandau->getVal();
    cout << " [1] int_dx landau(x) = " << setprecision(15) << val << endl;
 
@@ -74,7 +74,7 @@ void rf901_numintconfig()
 #endif
 
    // Calculate integral over landau with custom integral specification
-   RooAbsReal *intLandau2 = landau.createIntegral(x, NumIntConfig(customConfig));
+   std::unique_ptr<RooAbsReal> intLandau2{landau.createIntegral(x, NumIntConfig(customConfig))};
    double val2 = intLandau2->getVal();
    cout << " [2] int_dx landau(x) = " << val2 << endl;
 
@@ -85,7 +85,7 @@ void rf901_numintconfig()
    landau.setIntegratorConfig(customConfig);
 
    // Calculate integral over landau custom numeric integrator specified as object default
-   RooAbsReal *intLandau3 = landau.createIntegral(x);
+   std::unique_ptr<RooAbsReal> intLandau3{landau.createIntegral(x)};
    double val3 = intLandau3->getVal();
    cout << " [3] int_dx landau(x) = " << val3 << endl;
 

--- a/tutorials/roostats/FourBinInstructional.C
+++ b/tutorials/roostats/FourBinInstructional.C
@@ -266,7 +266,7 @@ void FourBinInstructional(bool doBayesian = false, bool doFeldmanCousins = false
    // use MCMCCalculator  (takes about 1 min)
    // Want an efficient proposal function, so derive it from covariance
    // matrix of fit
-   RooFitResult *fit = wspace->pdf("model")->fitTo(*data, Save());
+   std::unique_ptr<RooFitResult> fit{wspace->pdf("model")->fitTo(*data, Save())};
    ProposalHelper ph;
    ph.SetVariables((RooArgSet &)fit->floatParsFinal());
    ph.SetCovMatrix(fit->covarianceMatrix());

--- a/tutorials/roostats/HybridInstructional.C
+++ b/tutorials/roostats/HybridInstructional.C
@@ -193,7 +193,7 @@ ClassImp(BinCountTestStat)
    // numeric RooFit Z_Gamma
    w->var("y")->setVal(100);
    w->var("x")->setVal(150);
-   RooAbsReal *cdf = w->pdf("averagedModel")->createCdf(*w->var("x"));
+   std::unique_ptr<RooAbsReal> cdf{w->pdf("averagedModel")->createCdf(*w->var("x"))};
    cdf->getVal(); // get ugly print messages out of the way
    cout << "-----------------------------------------" << endl;
    cout << "Part 2" << endl;

--- a/tutorials/roostats/MultivariateGaussianTest.C
+++ b/tutorials/roostats/MultivariateGaussianTest.C
@@ -112,7 +112,7 @@ void MultivariateGaussianTest(Int_t dim = 4, Int_t nPOI = 2)
    // MCMC
    // we want to setup an efficient proposal function
    // using the covariance matrix from a fit to the data
-   RooFitResult *fit = mvg.fitTo(*data, Save(true));
+   std::unique_ptr<RooFitResult> fit{mvg.fitTo(*data, Save(true))};
    ProposalHelper ph;
    ph.SetVariables((RooArgSet &)fit->floatParsFinal());
    ph.SetCovMatrix(fit->covarianceMatrix());

--- a/tutorials/roostats/OneSidedFrequentistUpperLimitWithBands.C
+++ b/tutorials/roostats/OneSidedFrequentistUpperLimitWithBands.C
@@ -306,8 +306,8 @@ void OneSidedFrequentistUpperLimitWithBands(const char *infile = "", const char 
    // Now we generate the expected bands and power-constraint
 
    // First: find parameter point for mu=0, with conditional MLEs for nuisance parameters
-   RooAbsReal *nll = mc->GetPdf()->createNLL(*data);
-   RooAbsReal *profile = nll->createProfile(*mc->GetParametersOfInterest());
+   std::unique_ptr<RooAbsReal> nll{mc->GetPdf()->createNLL(*data)};
+   std::unique_ptr<RooAbsReal> profile{nll->createProfile(*mc->GetParametersOfInterest())};
    firstPOI->setVal(0.);
    profile->getVal(); // this will do fit and set nuisance parameters to profiled values
    RooArgSet *poiAndNuisance = new RooArgSet();
@@ -357,9 +357,8 @@ void OneSidedFrequentistUpperLimitWithBands(const char *infile = "", const char 
       if (!simPdf) {
          RooDataSet *one = mc->GetPdf()->generate(*mc->GetGlobalObservables(), 1);
          const RooArgSet *values = one->get();
-         RooArgSet *allVars = mc->GetPdf()->getVariables();
-         *allVars = *values;
-         delete allVars;
+         std::unique_ptr<RooArgSet> allVars{mc->GetPdf()->getVariables()};
+         allVars->assign(*values);
          delete values;
          delete one;
       } else {
@@ -495,7 +494,4 @@ void OneSidedFrequentistUpperLimitWithBands(const char *infile = "", const char 
    cout << "\nobserved 95% upper-limit " << interval->UpperLimit(*firstPOI) << endl;
    cout << "CLb strict [P(toy>obs|0)] for observed 95% upper-limit " << CLb << endl;
    cout << "CLb inclusive [P(toy>=obs|0)] for observed 95% upper-limit " << CLbinclusive << endl;
-
-   delete profile;
-   delete nll;
 }

--- a/tutorials/roostats/StandardBayesianNumericalDemo.C
+++ b/tutorials/roostats/StandardBayesianNumericalDemo.C
@@ -153,9 +153,9 @@ void StandardBayesianNumericalDemo(const char *infile = "", const char *workspac
    if (nSigmaNuisance > 0) {
       RooAbsPdf *pdf = mc->GetPdf();
       assert(pdf);
-      RooFitResult *res =
+      std::unique_ptr<RooFitResult> res{
          pdf->fitTo(*data, Save(true), Minimizer(ROOT::Math::MinimizerOptions::DefaultMinimizerType().c_str()),
-                    Hesse(true), PrintLevel(ROOT::Math::MinimizerOptions::DefaultPrintLevel() - 1));
+                    Hesse(true), PrintLevel(ROOT::Math::MinimizerOptions::DefaultPrintLevel() - 1))};
 
       res->Print();
       RooArgList nuisPar(*mc->GetNuisanceParameters());

--- a/tutorials/roostats/StandardHistFactoryPlotsWithCategories.C
+++ b/tutorials/roostats/StandardHistFactoryPlotsWithCategories.C
@@ -151,7 +151,7 @@ void StandardHistFactoryPlotsWithCategories(const char *infile = "", const char 
       RooCategory *channelCat = (RooCategory *)(&simPdf->indexCat());
       auto const& catName = channelCat->begin()->first;
       RooAbsPdf *pdftmp = ((RooSimultaneous *)mc->GetPdf())->getPdf(catName.c_str());
-      RooArgSet *obstmp = pdftmp->getObservables(*mc->GetObservables());
+      std::unique_ptr<RooArgSet> obstmp{pdftmp->getObservables(*mc->GetObservables())};
       obs = ((RooRealVar *)obstmp->first());
       RooPlot *frame = obs->frame();
       cout << Form("%s==%s::%s", channelCat->GetName(), channelCat->GetName(), catName.c_str()) << endl;
@@ -203,7 +203,7 @@ void StandardHistFactoryPlotsWithCategories(const char *infile = "", const char 
          RooAbsPdf *pdftmp = simPdf->getPdf(catName.c_str());
 
          // Generate observables defined by the pdf associated with this state
-         RooArgSet *obstmp = pdftmp->getObservables(*mc->GetObservables());
+         std::unique_ptr<RooArgSet> obstmp{pdftmp->getObservables(*mc->GetObservables())};
          //      obstmp->Print();
 
          obs = ((RooRealVar *)obstmp->first());

--- a/tutorials/roostats/StandardHypoTestDemo.C
+++ b/tutorials/roostats/StandardHypoTestDemo.C
@@ -330,12 +330,11 @@ void StandardHypoTestDemo(const char *infile = "", const char *workspaceName = "
 
       const RooArgSet *nuisParams =
          (bModel->GetNuisanceParameters()) ? bModel->GetNuisanceParameters() : sbModel->GetNuisanceParameters();
-      RooArgSet *np = nuisPdf->getObservables(*nuisParams);
+      std::unique_ptr<RooArgSet> np{nuisPdf->getObservables(*nuisParams)};
       if (np->getSize() == 0) {
          Warning("StandardHypoTestDemo",
                  "Prior nuisance does not depend on nuisance parameters. They will be smeared in their full range");
       }
-      delete np;
 
       ((HybridCalculator *)hypoCalc)->ForcePriorNuisanceAlt(*nuisPdf);
       ((HybridCalculator *)hypoCalc)->ForcePriorNuisanceNull(*nuisPdf);

--- a/tutorials/roostats/StandardHypoTestInvDemo.C
+++ b/tutorials/roostats/StandardHypoTestInvDemo.C
@@ -641,9 +641,8 @@ HypoTestInverterResult *RooStats::HypoTestInvTool::RunInverter(RooWorkspace *w, 
 
    // save all initial parameters of the model including the global observables
    RooArgSet initialParameters;
-   RooArgSet *allParams = sbModel->GetPdf()->getParameters(*data);
+   std::unique_ptr<RooArgSet> allParams{sbModel->GetPdf()->getParameters(*data)};
    allParams->snapshot(initialParameters);
-   delete allParams;
 
    // run first a data fit
 
@@ -683,15 +682,15 @@ HypoTestInverterResult *RooStats::HypoTestInvTool::RunInverter(RooWorkspace *w, 
          constrainParams.add(*sbModel->GetNuisanceParameters());
       RooStats::RemoveConstantParameters(&constrainParams);
       tw.Start();
-      RooFitResult *fitres = sbModel->GetPdf()->fitTo(
+      std::unique_ptr<RooFitResult> fitres{sbModel->GetPdf()->fitTo(
          *data, InitialHesse(false), Hesse(false), Minimizer(mMinimizerType.c_str(), "Migrad"), Strategy(0),
-         PrintLevel(mPrintLevel), Constrain(constrainParams), Save(true), Offset(RooStats::IsNLLOffset()));
+         PrintLevel(mPrintLevel), Constrain(constrainParams), Save(true), Offset(RooStats::IsNLLOffset()))};
       if (fitres->status() != 0) {
          Warning("StandardHypoTestInvDemo",
                  "Fit to the model failed - try with strategy 1 and perform first an Hesse computation");
-         fitres = sbModel->GetPdf()->fitTo(
+         fitres = std::unique_ptr<RooFitResult>{sbModel->GetPdf()->fitTo(
             *data, InitialHesse(true), Hesse(false), Minimizer(mMinimizerType.c_str(), "Migrad"), Strategy(1),
-            PrintLevel(mPrintLevel + 1), Constrain(constrainParams), Save(true), Offset(RooStats::IsNLLOffset()));
+            PrintLevel(mPrintLevel + 1), Constrain(constrainParams), Save(true), Offset(RooStats::IsNLLOffset()))};
       }
       if (fitres->status() != 0)
          Warning("StandardHypoTestInvDemo", " Fit still failed - continue anyway.....");
@@ -908,12 +907,11 @@ HypoTestInverterResult *RooStats::HypoTestInvTool::RunInverter(RooWorkspace *w, 
 
          const RooArgSet *nuisParams =
             (bModel->GetNuisanceParameters()) ? bModel->GetNuisanceParameters() : sbModel->GetNuisanceParameters();
-         RooArgSet *np = nuisPdf->getObservables(*nuisParams);
+         std::unique_ptr<RooArgSet> np{nuisPdf->getObservables(*nuisParams)};
          if (np->getSize() == 0) {
             Warning("StandardHypoTestInvDemo",
                     "Prior nuisance does not depend on nuisance parameters. They will be smeared in their full range");
          }
-         delete np;
 
          hhc->ForcePriorNuisanceAlt(*nuisPdf);
          hhc->ForcePriorNuisanceNull(*nuisPdf);
@@ -974,14 +972,14 @@ HypoTestInverterResult *RooStats::HypoTestInvTool::RunInverter(RooWorkspace *w, 
       std::cout << "Rebuild the upper limit distribution by re-generating new set of pseudo-experiment and re-compute "
                    "for each of them a new upper limit\n\n";
 
-      allParams = sbModel->GetPdf()->getParameters(*data);
+      allParams = std::unique_ptr<RooArgSet>{sbModel->GetPdf()->getParameters(*data)};
 
       // define on which value of nuisance parameters to do the rebuild
       // default is best fit value for bmodel snapshot
 
       if (mRebuildParamValues != 0) {
          // set all parameters to their initial workspace values
-         *allParams = initialParameters;
+         allParams->assign(initialParameters);
       }
       if (mRebuildParamValues == 0 || mRebuildParamValues == 1) {
          RooArgSet constrainParams;
@@ -1009,7 +1007,6 @@ HypoTestInverterResult *RooStats::HypoTestInvTool::RunInverter(RooWorkspace *w, 
       }
       std::cout << "StandardHypoTestInvDemo: Initial parameters used for rebuilding: ";
       RooStats::PrintListContent(*allParams, std::cout);
-      delete allParams;
 
       calc.SetCloseProof(1);
       tw.Start();

--- a/tutorials/roostats/TwoSidedFrequentistUpperLimitWithBands.C
+++ b/tutorials/roostats/TwoSidedFrequentistUpperLimitWithBands.C
@@ -304,8 +304,8 @@ void TwoSidedFrequentistUpperLimitWithBands(const char *infile = "", const char 
    // Now we generate the expected bands and power-constraint
 
    // First: find parameter point for mu=0, with conditional MLEs for nuisance parameters
-   RooAbsReal *nll = mc->GetPdf()->createNLL(*data);
-   RooAbsReal *profile = nll->createProfile(*mc->GetParametersOfInterest());
+   std::unique_ptr<RooAbsReal> nll{mc->GetPdf()->createNLL(*data)};
+   std::unique_ptr<RooAbsReal> profile{nll->createProfile(*mc->GetParametersOfInterest())};
    firstPOI->setVal(0.);
    profile->getVal(); // this will do fit and set nuisance parameters to profiled values
    RooArgSet *poiAndNuisance = new RooArgSet();
@@ -358,16 +358,14 @@ void TwoSidedFrequentistUpperLimitWithBands(const char *infile = "", const char 
       if (!simPdf) {
          RooDataSet *one = mc->GetPdf()->generate(*mc->GetGlobalObservables(), 1);
          const RooArgSet *values = one->get();
-         RooArgSet *allVars = mc->GetPdf()->getVariables();
-         *allVars = *values;
-         delete allVars;
+         std::unique_ptr<RooArgSet> allVars{mc->GetPdf()->getVariables()};
+         allVars->assign(*values);
          delete one;
       } else {
          RooDataSet *one = simPdf->generateSimGlobal(*mc->GetGlobalObservables(), 1);
          const RooArgSet *values = one->get();
-         RooArgSet *allVars = mc->GetPdf()->getVariables();
-         *allVars = *values;
-         delete allVars;
+         std::unique_ptr<RooArgSet> allVars{mc->GetPdf()->getVariables()};
+         allVars->assign(*values);
          delete one;
       }
 
@@ -449,7 +447,4 @@ void TwoSidedFrequentistUpperLimitWithBands(const char *infile = "", const char 
    cout << "\nobserved 95% upper-limit " << interval->UpperLimit(*firstPOI) << endl;
    cout << "CLb strict [P(toy>obs|0)] for observed 95% upper-limit " << CLb << endl;
    cout << "CLb inclusive [P(toy>=obs|0)] for observed 95% upper-limit " << CLbinclusive << endl;
-
-   delete profile;
-   delete nll;
 }

--- a/tutorials/roostats/Zbi_Zgamma.C
+++ b/tutorials/roostats/Zbi_Zgamma.C
@@ -47,7 +47,7 @@ void Zbi_Zgamma()
    // numeric RooFit Z_Gamma
    w1->var("y")->setVal(100);
    w1->var("x")->setVal(150);
-   RooAbsReal *cdf = w1->pdf("averagedModel")->createCdf(*w1->var("x"));
+   std::unique_ptr<RooAbsReal> cdf{w1->pdf("averagedModel")->createCdf(*w1->var("x"))};
    cdf->getVal(); // get ugly print messages out of the way
 
    cout << "Hybrid p-value = " << cdf->getVal() << endl;

--- a/tutorials/roostats/rs101_limitexample.C
+++ b/tutorials/roostats/rs101_limitexample.C
@@ -135,7 +135,7 @@ void rs101_limitexample()
    //  fc.SaveBeltToFile(true); // optional
    std::unique_ptr<PointSetInterval> fcint{static_cast<PointSetInterval*>(fc.GetInterval())};
 
-   RooFitResult *fit = modelWithConstraints->fitTo(data, Save(true), PrintLevel(-1));
+   std::unique_ptr<RooFitResult> fit{modelWithConstraints->fitTo(data, Save(true), PrintLevel(-1))};
 
    // Third, use a Calculator based on Markov Chain monte carlo
    // Before configuring the calculator, let's make a ProposalFunction

--- a/tutorials/roostats/rs302_JeffreysPriorDemo.C
+++ b/tutorials/roostats/rs302_JeffreysPriorDemo.C
@@ -58,7 +58,7 @@ void rs302_JeffreysPriorDemo()
 
    RooDataHist *asimov = w.pdf("p")->generateBinned(*w.var("x"), ExpectedData());
 
-   RooFitResult *res = w.pdf("p")->fitTo(*asimov, Save(), SumW2Error(kTRUE));
+   std::unique_ptr<RooFitResult> res{w.pdf("p")->fitTo(*asimov, Save(), SumW2Error(kTRUE))};
 
    asimov->Print();
    res->Print();
@@ -98,7 +98,7 @@ void TestJeffreysGaussMean()
 
    RooDataHist *asimov = w.pdf("p")->generateBinned(*w.var("x"), ExpectedData());
 
-   RooFitResult *res = w.pdf("p")->fitTo(*asimov, Save(), SumW2Error(kTRUE));
+   std::unique_ptr<RooFitResult> res{w.pdf("p")->fitTo(*asimov, Save(), SumW2Error(kTRUE))};
 
    asimov->Print();
    res->Print();
@@ -148,7 +148,7 @@ void TestJeffreysGaussSigma()
 
    RooDataHist *asimov = w.pdf("p")->generateBinned(*w.var("x"), ExpectedData());
 
-   RooFitResult *res = w.pdf("p")->fitTo(*asimov, Save(), SumW2Error(kTRUE));
+   std::unique_ptr<RooFitResult> res{w.pdf("p")->fitTo(*asimov, Save(), SumW2Error(kTRUE))};
 
    asimov->Print();
    res->Print();
@@ -196,7 +196,7 @@ void TestJeffreysGaussMeanAndSigma()
 
    RooDataHist *asimov = w.pdf("p")->generateBinned(*w.var("x"), ExpectedData());
 
-   RooFitResult *res = w.pdf("p")->fitTo(*asimov, Save(), SumW2Error(kTRUE));
+   std::unique_ptr<RooFitResult> res{w.pdf("p")->fitTo(*asimov, Save(), SumW2Error(kTRUE))};
 
    asimov->Print();
    res->Print();


### PR DESCRIPTION
Wrap owning pointers in the RooFit tutorials in `std::unique_ptr`. This has three benefits:

1. Less memory leaks in tutorials (`delete` was almost never done)
2. Tutorials would also run if the `RooFit::OwningPtr` were to be defined at `std::unique_ptr`, which is useful for debug builds
3. Users learn about automatic memory management correctly