### PR TITLE
[RF] New function for server changing without setting attributes

### DIFF
--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -35,6 +35,7 @@
 #include <set>
 #include <stack>
 #include <string>
+#include <unordered_map>
 
 
 class TTree ;
@@ -267,6 +268,7 @@ public:
 
   // Server redirection interface
   bool redirectServers(const RooAbsCollection& newServerList, bool mustReplaceAll=false, bool nameChange=false, bool isRecursionStep=false) ;
+  bool redirectServers(std::unordered_map<RooAbsArg*, RooAbsArg*> const& replacements);
   bool recursiveRedirectServers(const RooAbsCollection& newServerList, bool mustReplaceAll=false, bool nameChange=false, bool recurseInNewSet=true) ;
 
   virtual bool redirectServersHook(const RooAbsCollection & newServerList, bool mustReplaceAll,
@@ -744,6 +746,10 @@ private:
  protected:
   static std::stack<RooAbsArg*> _ioReadStack ; // reading stack
   /// \endcond
+
+ private:
+  void substituteServer(RooAbsArg *oldServer, RooAbsArg *newServer);
+  bool callRedirectServersHook(RooAbsCollection const& newSet, bool mustReplaceAll, bool nameChange, bool isRecursionStep);
 
   ClassDefOverride(RooAbsArg,9) // Abstract variable
 };

--- a/roofit/roofitcore/inc/RooAbsProxy.h
+++ b/roofit/roofitcore/inc/RooAbsProxy.h
@@ -27,6 +27,10 @@
 
 #include <TClass.h>
 
+#include <string>
+#include <unordered_map>
+
+class RooAbsArg;
 class RooAbsCollection;
 class RooArgSet;
 
@@ -57,6 +61,7 @@ protected:
 
   friend class RooAbsArg ;
   virtual bool changePointer(const RooAbsCollection& newServerSet, bool nameChange=false, bool factoryInitMode=false) = 0 ;
+  virtual bool changePointer(std::unordered_map<RooAbsArg*, RooAbsArg*> const& replacements) = 0 ;
 
   friend class RooAbsPdf ;
   virtual void changeNormSet(const RooArgSet* newNormSet) ;

--- a/roofit/roofitcore/inc/RooArgProxy.h
+++ b/roofit/roofitcore/inc/RooArgProxy.h
@@ -71,6 +71,7 @@ protected:
   friend class RooRealIntegral;
 
   bool changePointer(const RooAbsCollection& newServerSet, bool nameChange=false, bool factoryInitMode=false) override ;
+  bool changePointer(std::unordered_map<RooAbsArg*, RooAbsArg*> const& replacements) override;
 
   virtual void changeDataSet(const RooArgSet* newNormSet) ;
 

--- a/roofit/roofitcore/inc/RooCollectionProxy.h
+++ b/roofit/roofitcore/inc/RooCollectionProxy.h
@@ -55,10 +55,12 @@ public:
    /// Copy constructor.
    template <class Other_t>
    RooCollectionProxy(const char *inName, RooAbsArg *owner, const Other_t &other)
-      : RooCollection_t(other, inName), _owner(owner), _defValueServer(other.defValueServer()),
+      : RooCollection_t(other, inName),
+        _owner(owner),
+        _defValueServer(other.defValueServer()),
         _defShapeServer(other.defShapeServer())
    {
-     _owner->registerProxy(*this);
+      _owner->registerProxy(*this);
    }
 
    /// Initializes this RooCollection proxy from another proxy. Should not be
@@ -89,8 +91,8 @@ public:
    // but value syncronization! Should it be re-implemented to be actual
    // assignment? That would be inconsistent with the base class! So it's
    // better to not support it at all.
-   RooCollectionProxy& operator=(RooCollectionProxy const& other) = delete;
-   RooCollectionProxy& operator=(RooCollectionProxy && other) = delete;
+   RooCollectionProxy &operator=(RooCollectionProxy const &other) = delete;
+   RooCollectionProxy &operator=(RooCollectionProxy &&other) = delete;
 
    ~RooCollectionProxy() override
    {
@@ -163,6 +165,8 @@ private:
 
    bool
    changePointer(const RooAbsCollection &newServerSet, bool nameChange = false, bool factoryInitMode = false) override;
+
+   bool changePointer(std::unordered_map<RooAbsArg *, RooAbsArg *> const &replacements) override;
 
    void checkValid() const
    {
@@ -297,6 +301,20 @@ bool RooCollectionProxy<RooCollection_t>::changePointer(const RooAbsCollection &
       RooAbsArg *newArg = arg->findNewServer(newServerList, nameChange);
       if (newArg && newArg != _owner)
          error |= !RooCollection_t::replace(*arg, *newArg);
+   }
+   return !error;
+}
+
+template <class RooCollection_t>
+bool RooCollectionProxy<RooCollection_t>::changePointer(
+   std::unordered_map<RooAbsArg *, RooAbsArg *> const &replacements)
+{
+   bool error(false);
+   for (auto const &arg : *this) {
+      auto newArgFound = replacements.find(arg);
+      if (newArgFound != replacements.end()) {
+         error |= !RooCollection_t::replace(*arg, *newArgFound->second);
+      }
    }
    return !error;
 }

--- a/roofit/roofitcore/inc/RooFit/Detail/NormalizationHelpers.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/NormalizationHelpers.h
@@ -14,6 +14,7 @@
 #define RooFit_Detail_NormalizationHelpers_h
 
 #include <memory>
+#include <string>
 #include <unordered_map>
 
 class RooAbsArg;
@@ -38,6 +39,7 @@ public:
    }
 
    void compileServers(RooAbsArg &arg, RooArgSet const &normSet);
+   void compileServer(RooAbsArg &server, RooAbsArg &arg, RooArgSet const &normSet);
 
    void markAsCompiled(RooAbsArg &arg) const;
 
@@ -49,6 +51,7 @@ private:
 
    RooArgSet const &_topLevelNormSet;
    std::unordered_map<TNamed const *, RooAbsArg *> _clonedArgsSet;
+   std::unordered_map<RooAbsArg *, RooAbsArg *> _replacements;
 };
 
 template <class T>

--- a/roofit/roofitcore/inc/RooFit/Detail/NormalizationHelpers.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/NormalizationHelpers.h
@@ -39,10 +39,13 @@ public:
 
    void compileServers(RooAbsArg &arg, RooArgSet const &normSet);
 
+   void markAsCompiled(RooAbsArg &arg) const;
+
 private:
    RooAbsArg *compileImpl(RooAbsArg &arg, RooAbsArg &owner, RooArgSet const &normSet);
    void add(RooAbsArg &arg);
    RooAbsArg *find(RooAbsArg &arg) const;
+   bool isMarkedAsCompiled(RooAbsArg const &arg) const;
 
    RooArgSet const &_topLevelNormSet;
    std::unordered_map<TNamed const *, RooAbsArg *> _clonedArgsSet;

--- a/roofit/roofitcore/src/NormalizationHelpers.cxx
+++ b/roofit/roofitcore/src/NormalizationHelpers.cxx
@@ -38,13 +38,16 @@ RooAbsArg *RooFit::Detail::CompileContext::find(RooAbsArg &arg) const
 
 void RooFit::Detail::CompileContext::compileServers(RooAbsArg &arg, RooArgSet const &normSet)
 {
-   RooArgList serverClones;
-   for (const auto server : arg.servers()) {
-      if (auto serverClone = this->compile(*server, arg, normSet)) {
-         serverClones.add(*serverClone);
-      }
+   for (RooAbsArg *server : arg.servers()) {
+      this->compile(*server, arg, normSet);
    }
-   arg.redirectServers(serverClones, false, true);
+   arg.redirectServers(_replacements);
+}
+
+void RooFit::Detail::CompileContext::compileServer(RooAbsArg &server, RooAbsArg &arg, RooArgSet const &normSet)
+{
+   this->compile(server, arg, normSet);
+   arg.redirectServers(_replacements);
 }
 
 RooAbsArg *RooFit::Detail::CompileContext::compileImpl(RooAbsArg &arg, RooAbsArg &owner, RooArgSet const &normSet)
@@ -61,8 +64,7 @@ RooAbsArg *RooFit::Detail::CompileContext::compileImpl(RooAbsArg &arg, RooAbsArg
 
    std::unique_ptr<RooAbsArg> newArg = arg.compileForNormSet(normSet, *this);
    markAsCompiled(*newArg);
-   const std::string attrib = std::string("ORIGNAME:") + arg.GetName();
-   newArg->setAttribute(attrib.c_str());
+   _replacements[&arg] = newArg.get();
    this->add(*newArg);
    RooAbsArg *out = newArg.get();
    owner.addOwnedComponents(std::move(newArg));

--- a/roofit/roofitcore/src/NormalizationHelpers.cxx
+++ b/roofit/roofitcore/src/NormalizationHelpers.cxx
@@ -55,16 +55,26 @@ RooAbsArg *RooFit::Detail::CompileContext::compileImpl(RooAbsArg &arg, RooAbsArg
    if (arg.isFundamental() && !_topLevelNormSet.find(arg)) {
       return nullptr;
    }
-   if (arg.getAttribute("_COMPILED")) {
+   if (isMarkedAsCompiled(arg)) {
       return nullptr;
    }
 
    std::unique_ptr<RooAbsArg> newArg = arg.compileForNormSet(normSet, *this);
-   newArg->setAttribute("_COMPILED");
+   markAsCompiled(*newArg);
    const std::string attrib = std::string("ORIGNAME:") + arg.GetName();
    newArg->setAttribute(attrib.c_str());
    this->add(*newArg);
    RooAbsArg *out = newArg.get();
    owner.addOwnedComponents(std::move(newArg));
    return out;
+}
+
+void RooFit::Detail::CompileContext::markAsCompiled(RooAbsArg &arg) const
+{
+   arg.setAttribute("_COMPILED");
+}
+
+bool RooFit::Detail::CompileContext::isMarkedAsCompiled(RooAbsArg const &arg) const
+{
+   return arg.getAttribute("_COMPILED");
 }

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -2512,7 +2512,7 @@ void RooAbsArg::applyWeightSquared(bool flag) {
 std::unique_ptr<RooAbsArg> RooAbsArg::compileForNormSet(RooArgSet const & normSet, RooFit::Detail::CompileContext & ctx) const
 {
    auto newArg = std::unique_ptr<RooAbsArg>{static_cast<RooAbsArg *>(Clone())};
-   newArg->setAttribute("_COMPILED");
+   ctx.markAsCompiled(*newArg);
    ctx.compileServers(*newArg, normSet);
    return newArg;
 }

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -1091,11 +1091,6 @@ bool RooAbsArg::redirectServers(const RooAbsCollection& newSetOrig, bool mustRep
 
     RooAbsArg * newServer= oldServer->findNewServer(*newSet, nameChange);
 
-    if (newServer && _verboseDirty) {
-      cxcoutD(LinkStateMgmt) << "RooAbsArg::redirectServers(" << (void*)this << "," << GetName() << "): server " << oldServer->GetName()
-                  << " redirected from " << oldServer << " to " << newServer << endl ;
-    }
-
     if (!newServer) {
       if (mustReplaceAll) {
         std::stringstream ss;
@@ -1109,22 +1104,9 @@ bool RooAbsArg::redirectServers(const RooAbsCollection& newSetOrig, bool mustRep
     }
 
     if (newServer != this) {
-      _serverList.Replace(oldServer, newServer);
-
-      const int clientListRefCount = oldServer->_clientList.Remove(this, true);
-      const int clientListValueRefCount = oldServer->_clientListValue.Remove(this, true);
-      const int clientListShapeRefCount = oldServer->_clientListShape.Remove(this, true);
-
-      newServer->_clientList.Add(this, clientListRefCount);
-      newServer->_clientListValue.Add(this, clientListValueRefCount);
-      newServer->_clientListShape.Add(this, clientListShapeRefCount);
-
-      if (clientListValueRefCount > 0 && newServer->operMode() == ADirty && operMode() != ADirty) {
-        setOperMode(ADirty);
-      }
+      substituteServer(oldServer, newServer);
     }
   }
-
 
   setValueDirty() ;
   setShapeDirty() ;
@@ -1138,7 +1120,7 @@ bool RooAbsArg::redirectServers(const RooAbsCollection& newSetOrig, bool mustRep
     bool ret2 = p->changePointer(*newSet,nameChange,false) ;
 
     if (mustReplaceAll && !ret2) {
-      auto ap = static_cast<const RooArgProxy*>(p);
+      auto ap = dynamic_cast<const RooArgProxy*>(p);
       coutE(LinkStateMgmt) << "RooAbsArg::redirectServers(" << GetName()
               << "): ERROR, proxy '" << p->name()
               << "' with arg '" << (ap ? ap->absArg()->GetName() : "<could not cast>") << "' could not be adjusted" << endl;
@@ -1146,14 +1128,88 @@ bool RooAbsArg::redirectServers(const RooAbsCollection& newSetOrig, bool mustRep
     }
   }
 
-
   // Optional subclass post-processing
-  for (Int_t i=0 ;i<numCaches() ; i++) {
-    ret |= getCache(i)->redirectServersHook(*newSet,mustReplaceAll,nameChange,isRecursionStep) ;
-  }
-  ret |= redirectServersHook(*newSet,mustReplaceAll,nameChange,isRecursionStep) ;
+  ret |= callRedirectServersHook(*newSet, mustReplaceAll, nameChange, isRecursionStep);
+  return ret;
+}
 
-  return ret ;
+/// Private helper function for RooAbsArg::redirectServers().
+void RooAbsArg::substituteServer(RooAbsArg *oldServer, RooAbsArg *newServer)
+{
+   _serverList.Replace(oldServer, newServer);
+
+   const int clientListRefCount = oldServer->_clientList.Remove(this, true);
+   const int clientListValueRefCount = oldServer->_clientListValue.Remove(this, true);
+   const int clientListShapeRefCount = oldServer->_clientListShape.Remove(this, true);
+
+   newServer->_clientList.Add(this, clientListRefCount);
+   newServer->_clientListValue.Add(this, clientListValueRefCount);
+   newServer->_clientListShape.Add(this, clientListShapeRefCount);
+
+   if (clientListValueRefCount > 0 && newServer->operMode() == ADirty && operMode() != ADirty) {
+      setOperMode(ADirty);
+   }
+}
+
+/// Private helper function for RooAbsArg::redirectServers().
+bool RooAbsArg::callRedirectServersHook(RooAbsCollection const &newSet, bool mustReplaceAll, bool nameChange,
+                                        bool isRecursionStep)
+{
+   bool ret = false;
+   for (Int_t i = 0; i < numCaches(); i++) {
+      ret |= getCache(i)->redirectServersHook(newSet, mustReplaceAll, nameChange, isRecursionStep);
+   }
+   ret |= redirectServersHook(newSet, mustReplaceAll, nameChange, isRecursionStep);
+
+   return ret;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Replace some servers of this object. If there are proxies that correspond
+/// to the replaced servers, these proxies are adjusted as well.
+/// \param[in] replacements Map that specifiecs which args replace which servers.
+bool RooAbsArg::redirectServers(std::unordered_map<RooAbsArg *, RooAbsArg *> const &replacements)
+{
+   bool ret(false);
+   bool nameChange = false;
+
+   RooArgList newList;
+
+   // Replace current servers with new servers with the same name from the given list
+   for (auto oldServer : _serverList) {
+
+      auto newServerFound = replacements.find(oldServer);
+      RooAbsArg *newServer = newServerFound != replacements.end() ? newServerFound->second : nullptr;
+
+      if (!newServer || newServer == this) {
+         continue;
+      }
+
+      if (nameChange == false)
+         nameChange = strcmp(newServerFound->first->GetName(), newServerFound->second->GetName()) != 0;
+
+      substituteServer(oldServer, newServer);
+      newList.add(*newServer);
+   }
+
+   // No servers were replaced, we don't need to process proxies and call the
+   // redirectServersHook.
+   if (newList.empty())
+      return ret;
+
+   setValueDirty();
+   setShapeDirty();
+
+   // Process the proxies
+   for (int i = 0; i < numProxies(); i++) {
+      if (RooAbsProxy *p = getProxy(i)) {
+         p->changePointer(replacements);
+      }
+   }
+
+   // Optional subclass post-processing
+   ret |= callRedirectServersHook(newList, false, nameChange, false);
+   return ret;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooAbsCachedPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsCachedPdf.cxx
@@ -418,9 +418,9 @@ RooAbsCachedPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::Com
    // The direct servers are this pdf and the normalization integral, which
    // don't need to be compiled further.
    for (RooAbsArg *server : newArg->servers()) {
-      server->setAttribute("_COMPILED");
+      ctx.markAsCompiled(*server);
    }
-   newArg->setAttribute("_COMPILED");
+   ctx.markAsCompiled(*newArg);
    newArg->addOwnedComponents(std::move(pdfClone));
    return newArg;
 }

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -3601,9 +3601,9 @@ RooAbsPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileCo
    // The direct servers are this pdf and the normalization integral, which
    // don't need to be compiled further.
    for (RooAbsArg *server : newArg->servers()) {
-      server->setAttribute("_COMPILED");
+      ctx.markAsCompiled(*server);
    }
-   newArg->setAttribute("_COMPILED");
+   ctx.markAsCompiled(*newArg);
    newArg->addOwnedComponents(std::move(pdfClone));
    return newArg;
 }

--- a/roofit/roofitcore/src/RooArgProxy.cxx
+++ b/roofit/roofitcore/src/RooArgProxy.cxx
@@ -131,6 +131,31 @@ bool RooArgProxy::changePointer(const RooAbsCollection& newServerList, bool name
   return newArg != nullptr;
 }
 
+bool RooArgProxy::changePointer(std::unordered_map<RooAbsArg *, RooAbsArg *> const &replacements)
+{
+   if (!_arg)
+      return true;
+
+   RooAbsArg *newArg = nullptr;
+
+   auto newArgFound = replacements.find(_arg);
+   if (newArgFound != replacements.end()) {
+      newArg = newArgFound->second;
+   }
+
+   if (newArg) {
+      if (_ownArg) {
+         // We refer to an object that somebody gave to us. Now, we are not owning it, any more.
+         delete _arg;
+         _ownArg = false;
+      }
+
+      _arg = newArg;
+      _isFund = _arg->isFundamental();
+   }
+
+   return newArg != nullptr;
+}
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooConstraintSum.cxx
+++ b/roofit/roofitcore/src/RooConstraintSum.cxx
@@ -108,15 +108,11 @@ std::unique_ptr<RooAbsArg> RooConstraintSum::compileForNormSet(RooArgSet const &
 {
    std::unique_ptr<RooAbsReal> newArg{static_cast<RooAbsReal*>(this->Clone())};
 
-   RooArgList serverClones;
    for (const auto server : newArg->servers()) {
       RooArgSet nset;
       server->getObservables(&_paramSet, nset);
-      if (auto serverClone = ctx.compile(*server, *newArg, nset)) {
-         serverClones.add(*serverClone);
-      }
+      ctx.compileServer(*server, *newArg, nset);
    }
-   newArg->redirectServers(serverClones, false, true);
 
    return newArg;
 }

--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -2384,7 +2384,6 @@ RooProdPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileC
    std::unique_ptr<RooProdPdf> prodPdfClone{static_cast<RooProdPdf *>(this->Clone())};
    ctx.markAsCompiled(*prodPdfClone);
 
-   RooArgList serverClones;
    for (const auto server : prodPdfClone->servers()) {
       auto nsetForServer = fillNormSetForServer(normSet, *server);
       RooArgSet const &nset = nsetForServer ? *nsetForServer : normSet;
@@ -2392,11 +2391,8 @@ RooProdPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileC
       auto depList = new RooArgSet; // INTENTIONAL LEAK FOR NOW!
       server->getObservables(&nset, *depList);
 
-      if (auto serverClone = ctx.compile(*server, *prodPdfClone, *depList)) {
-         serverClones.add(*serverClone);
-      }
+      ctx.compileServer(*server, *prodPdfClone, *depList);
    }
-   prodPdfClone->redirectServers(serverClones, false, true);
 
    auto fixedProdPdf = std::make_unique<RooFixedProdPdf>(std::move(prodPdfClone), normSet);
    ctx.markAsCompiled(*fixedProdPdf);

--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -2382,7 +2382,7 @@ std::unique_ptr<RooAbsArg>
 RooProdPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileContext &ctx) const
 {
    std::unique_ptr<RooProdPdf> prodPdfClone{static_cast<RooProdPdf *>(this->Clone())};
-   prodPdfClone->setAttribute("_COMPILED");
+   ctx.markAsCompiled(*prodPdfClone);
 
    RooArgList serverClones;
    for (const auto server : prodPdfClone->servers()) {
@@ -2399,7 +2399,7 @@ RooProdPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileC
    prodPdfClone->redirectServers(serverClones, false, true);
 
    auto fixedProdPdf = std::make_unique<RooFixedProdPdf>(std::move(prodPdfClone), normSet);
-   fixedProdPdf->setAttribute("_COMPILED");
+   ctx.markAsCompiled(*fixedProdPdf);
 
    return fixedProdPdf;
 }

--- a/roofit/roofitcore/src/RooProjectedPdf.cxx
+++ b/roofit/roofitcore/src/RooProjectedPdf.cxx
@@ -279,13 +279,14 @@ void RooProjectedPdf::CacheElem::printCompactTreeHook(std::ostream& os, const ch
 }
 
 
-std::unique_ptr<RooAbsArg> RooProjectedPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileContext & /*ctx*/) const
+std::unique_ptr<RooAbsArg>
+RooProjectedPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileContext &ctx) const
 {
-  RooArgSet nset2;
-  intpdf->getObservables(&normSet, nset2);
-  nset2.add(intobs);
+   RooArgSet nset2;
+   intpdf->getObservables(&normSet, nset2);
+   nset2.add(intobs);
 
-  auto newArg = std::unique_ptr<RooAbsReal>{intpdf->createIntegral(intobs,&nset2)};
-  newArg->setAttribute("_COMPILED");
-  return newArg;
+   auto newArg = std::unique_ptr<RooAbsReal>{intpdf->createIntegral(intobs, &nset2)};
+   ctx.markAsCompiled(*newArg);
+   return newArg;
 }

--- a/roofit/roofitcore/src/RooRealSumFunc.cxx
+++ b/roofit/roofitcore/src/RooRealSumFunc.cxx
@@ -173,7 +173,7 @@ void RooRealSumFunc::printMetaArgs(std::ostream &os) const
 std::unique_ptr<RooAbsArg> RooRealSumFunc::compileForNormSet(RooArgSet const &/*normSet*/, RooFit::Detail::CompileContext & ctx) const
 {
    auto newArg = std::unique_ptr<RooAbsArg>{static_cast<RooAbsArg *>(Clone())};
-   newArg->setAttribute("_COMPILED");
+   ctx.markAsCompiled(*newArg);
    ctx.compileServers(*newArg, {});
    return newArg;
 }

--- a/roofit/roofitcore/src/RooRealSumPdf.cxx
+++ b/roofit/roofitcore/src/RooRealSumPdf.cxx
@@ -801,9 +801,9 @@ std::unique_ptr<RooAbsArg> RooRealSumPdf::compileForNormSet(RooArgSet const &nor
    // The direct servers are this pdf and the normalization integral, which
    // don't need to be compiled further.
    for(RooAbsArg * server : newArg->servers()) {
-      server->setAttribute("_COMPILED");
+      ctx.markAsCompiled(*server);
    }
-   newArg->setAttribute("_COMPILED");
+   ctx.markAsCompiled(*newArg);
    newArg->addOwnedComponents(std::move(pdfClone));
    return newArg;
 }


### PR DESCRIPTION
If one wants to replace some servers of a RooAbsArg with
other servers, this is the the only option you have:

```c++
bool RooAbsArg::redirectServers(const RooAbsCollection& newSetOrig,
                                bool mustReplaceAll, bool nameChange,
                                bool isRecursionStep)
```

That's not so great, because if the new servers have different names,
thes old names must be set as the `"ORIGNAME:<myname>"` attribute for
the function to know which servers should be replaced.

These attributes are generally not reset, and this mutation of the
server attributes can cause trouble down the line.

Notably, this causes trouble in the BatchMode when compiling the
computation graph for a given normalization set. One single new server
might replace differently-named original servers. In that case, the new
servers get *two* "ORIGNAME:" attributes and the the `redirectServers()`
function doesn't know what to do.

Also, it's inefficient because of the string matching.

For this reason, a new overload is suggested, where one can simply
specify what should replace what in a lookup map, and it doesn't matter
if the names are different:

```c++
bool RooAbsArg::redirectServers(
    std::unordered_map<RooAbsArg *, RooAbsArg *> const &replacements
)
```

The implementation of `redirectServers()` calls
`RooAbsProxy::changePointer()`, for which such a new overload also had
to be added.

Using the new `RooAbsArg::redirectServers()` overload that takes a
lookup map of server replacements, the helper class that compiles the computation graph for a given normalization set can be
improved such that it's not necessary to set the `"ORIGNAME:"`
attributes of new servers.

This fixes some failures in the RooFit tutorials with BatchMode where
some servers eventually aggregated multiple `"ORIGNAME:"` attributes,
causing `redirectServers()` to error out.

