### PR TITLE
Automatically add `override` to geom with clang-tidy

### DIFF
--- a/geom/gdml/inc/TGDMLParse.h
+++ b/geom/gdml/inc/TGDMLParse.h
@@ -37,7 +37,7 @@ public:
       fMatrix = nullptr;
    }
 
-   virtual ~TGDMLRefl() {}
+   ~TGDMLRefl() override {}
 
    TGDMLRefl(const char* name, const char* solid, TGeoMatrix* matrix);
    TGeoMatrix* GetMatrix();
@@ -48,7 +48,7 @@ private:
    const char*     fSolid;      //!solid name being reflected
    TGeoMatrix     *fMatrix;     //!matrix of reflected solid
 
-   ClassDef(TGDMLRefl, 0)     //helper class used for the storage of reflected solids
+   ClassDefOverride(TGDMLRefl, 0)     //helper class used for the storage of reflected solids
 };
 
 /*************************************************************************
@@ -107,7 +107,7 @@ public:
    std::string fDefault_aunit = "rad";
 
    TGDMLParse();
-   virtual ~TGDMLParse() {}
+   ~TGDMLParse() override {}
 
    static TGeoVolume* StartGDML(const char* filename) {
       TGDMLParse* parser = new TGDMLParse;
@@ -222,7 +222,7 @@ private:
    ConstMap fconsts;              //!Map containing values of constants declared in the file
    MatrixMap fmatrices;           //!Map containing matrices defined in the GDML file
 
-   ClassDef(TGDMLParse, 0)    //imports GDML using DOM and binds it to ROOT
+   ClassDefOverride(TGDMLParse, 0)    //imports GDML using DOM and binds it to ROOT
 };
 
 #endif

--- a/geom/gdml/inc/TGDMLWrite.h
+++ b/geom/gdml/inc/TGDMLWrite.h
@@ -56,7 +56,7 @@ class TGeoBorderSurface;
 class TGDMLWrite : public TObject {
 public:
    TGDMLWrite();
-   virtual ~TGDMLWrite();
+   ~TGDMLWrite() override;
 
    static void StartGDMLWriting(TGeoManager * geomanager, const char* filename, TString option) {
       //static function -
@@ -246,7 +246,7 @@ private:
    void WriteGDMLfile(TGeoManager * geomanager, TGeoVolume* top_vol, TList* materialsLst, const char* filename, TString option);
    void ExtractVolumes(TGeoVolume* topVolume);    //result <volume> node...  + corresp. shape
 
-   ClassDef(TGDMLWrite, 0)    //imports GDML using DOM and binds it to ROOT
+   ClassDefOverride(TGDMLWrite, 0)    //imports GDML using DOM and binds it to ROOT
 };
 
 #endif /* ROOT_TGDMLWRITE */

--- a/geom/geom/inc/TGDMLMatrix.h
+++ b/geom/geom/inc/TGDMLMatrix.h
@@ -37,7 +37,7 @@ public:
    TGDMLMatrix(const char *name, size_t rows,size_t cols);
    TGDMLMatrix(const TGDMLMatrix& rhs);
    TGDMLMatrix& operator=(const TGDMLMatrix& rhs);
-  ~TGDMLMatrix() { delete [] fMatrix; }
+  ~TGDMLMatrix() override { delete [] fMatrix; }
 
    void        Set(size_t r, size_t c, Double_t a);
    Double_t    Get(size_t r, size_t c) const;
@@ -46,7 +46,7 @@ public:
    void        SetMatrixAsString(const char *mat) { fTitle = mat; }
    const char *GetMatrixAsString() const { return fTitle.Data(); }
 
-   void        Print(Option_t *option="") const;
+   void        Print(Option_t *option="") const override;
 
  private:
 
@@ -55,7 +55,7 @@ public:
    size_t fNcols = 0;                // Number of columns
    Double_t *fMatrix = nullptr;      // [fNelem] Matrix elements
 
-   ClassDef(TGDMLMatrix, 1)          // Class representing a matrix used temporary for GDML parsing
+   ClassDefOverride(TGDMLMatrix, 1)          // Class representing a matrix used temporary for GDML parsing
 };
 
 #endif /* ROOT_TGDMLMATRIX */

--- a/geom/geom/inc/TGeoArb8.h
+++ b/geom/geom/inc/TGeoArb8.h
@@ -39,53 +39,53 @@ public:
    TGeoArb8(Double_t dz, Double_t *vertices=nullptr);
    TGeoArb8(const char *name, Double_t dz, Double_t *vertices=nullptr);
    // destructor
-   virtual ~TGeoArb8();
+   ~TGeoArb8() override;
    // methods
-   virtual Double_t      Capacity() const;
-   virtual void          ComputeBBox();
-   virtual void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm);
-   virtual void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize);
+   Double_t      Capacity() const override;
+   void          ComputeBBox() override;
+   void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
    void                  ComputeTwist();
-   virtual Bool_t        Contains(const Double_t *point) const;
-   virtual void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const;
+   Bool_t        Contains(const Double_t *point) const override;
+   void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;
    Double_t              DistToPlane(const Double_t *point, const Double_t *dir, Int_t ipl, Bool_t in) const;
-   virtual Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
-                                Double_t start, Double_t step);
-   virtual Double_t      GetAxisRange(Int_t iaxis, Double_t &xlo, Double_t &xhi) const;
-   virtual void          GetBoundingCylinder(Double_t *param) const;
-   virtual Int_t         GetByteCount() const {return 100;}
+   Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
+                                Double_t start, Double_t step) override;
+   Double_t      GetAxisRange(Int_t iaxis, Double_t &xlo, Double_t &xhi) const override;
+   void          GetBoundingCylinder(Double_t *param) const override;
+   Int_t         GetByteCount() const override {return 100;}
    Double_t              GetClosestEdge(const Double_t *point, Double_t *vert, Int_t &isegment) const;
-   virtual Bool_t        GetPointsOnFacet(Int_t /*index*/, Int_t /*npoints*/, Double_t * /*array*/) const;
+   Bool_t        GetPointsOnFacet(Int_t /*index*/, Int_t /*npoints*/, Double_t * /*array*/) const override;
    Double_t              GetDz() const {return fDz;}
-   virtual Int_t         GetFittingBox(const TGeoBBox *parambox, TGeoMatrix *mat, Double_t &dx, Double_t &dy, Double_t &dz) const;
-   virtual TGeoShape    *GetMakeRuntimeShape(TGeoShape * /*mother*/, TGeoMatrix * /*mat*/) const {return nullptr;}
+   Int_t         GetFittingBox(const TGeoBBox *parambox, TGeoMatrix *mat, Double_t &dx, Double_t &dy, Double_t &dz) const override;
+   TGeoShape    *GetMakeRuntimeShape(TGeoShape * /*mother*/, TGeoMatrix * /*mat*/) const override {return nullptr;}
    static void           GetPlaneNormal(Double_t *p1, Double_t *p2, Double_t *p3, Double_t *norm);
    Double_t             *GetVertices() {return &fXY[0][0];}
    Double_t              GetTwist(Int_t iseg) const;
-   virtual Bool_t        IsCylType() const {return kFALSE;}
+   Bool_t        IsCylType() const override {return kFALSE;}
    static Bool_t         IsSamePoint(const Double_t *p1, const Double_t *p2) {return (TMath::Abs(p1[0]-p2[0])<1.E-16 && TMath::Abs(p1[1]-p2[1])<1.E-16)?kTRUE:kFALSE;}
    static Bool_t         InsidePolygon(Double_t x, Double_t y, Double_t *pts);
-   virtual void          InspectShape() const;
+   void          InspectShape() const override;
    Bool_t                IsTwisted() const { return !fTwist ? kFALSE : kTRUE; }
    Double_t              SafetyToFace(const Double_t *point, Int_t iseg, Bool_t in) const;
-   virtual Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const;
-   virtual void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const;
-   virtual void          SavePrimitive(std::ostream &out, Option_t *option = "");
+   Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const override;
+   void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const override;
+   void          SavePrimitive(std::ostream &out, Option_t *option = "") override;
    void                  SetPlaneVertices(Double_t zpl, Double_t *vertices) const;
    virtual void          SetVertex(Int_t vnum, Double_t x, Double_t y);
-   virtual void          SetDimensions(Double_t *param);
+   void          SetDimensions(Double_t *param) override;
    void                  SetDz(Double_t dz) {fDz = dz;}
-   virtual void          SetPoints(Double_t *points) const;
-   virtual void          SetPoints(Float_t *points) const;
-   virtual void          Sizeof3D() const;
+   void          SetPoints(Double_t *points) const override;
+   void          SetPoints(Float_t *points) const override;
+   void          Sizeof3D() const override;
 
-   ClassDef(TGeoArb8, 1)         // arbitrary trapezoid with 8 vertices
+   ClassDefOverride(TGeoArb8, 1)         // arbitrary trapezoid with 8 vertices
 };
 
 class TGeoTrap : public TGeoArb8
@@ -114,15 +114,15 @@ public:
             Double_t bl1, Double_t tl1, Double_t alpha1, Double_t h2, Double_t bl2,
             Double_t tl2, Double_t alpha2);
    // destructor
-   virtual ~TGeoTrap();
-   virtual Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
-                                Double_t start, Double_t step);
+   ~TGeoTrap() override;
+   Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
+                                Double_t start, Double_t step) override;
    Double_t              GetTheta() const {return fTheta;}
    Double_t              GetPhi() const   {return fPhi;}
    Double_t              GetH1() const    {return fH1;}
@@ -133,13 +133,13 @@ public:
    Double_t              GetBl2() const   {return fBl2;}
    Double_t              GetTl2() const   {return fTl2;}
    Double_t              GetAlpha2() const   {return fAlpha2;}
-   virtual TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const;
-   virtual void          SetDimensions(Double_t *param);
-   virtual Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const;
-   virtual void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const;
-   virtual void          SavePrimitive(std::ostream &out, Option_t *option = "");
+   TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const override;
+   void          SetDimensions(Double_t *param) override;
+   Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const override;
+   void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const override;
+   void          SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
-   ClassDef(TGeoTrap, 1)         // G3 TRAP shape
+   ClassDefOverride(TGeoTrap, 1)         // G3 TRAP shape
 };
 
 class TGeoGtra : public TGeoTrap
@@ -157,21 +157,21 @@ public:
             Double_t bl1, Double_t tl1, Double_t alpha1, Double_t h2, Double_t bl2,
             Double_t tl2, Double_t alpha2);
    // destructor
-   virtual ~TGeoGtra();
-   virtual Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const;
+   ~TGeoGtra() override;
+   Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const override;
    Double_t              GetTwistAngle() const {return fTwistAngle;}
-   virtual Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const;
-   virtual void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const;
-   virtual void          SetDimensions(Double_t *param);
-   virtual void          SavePrimitive(std::ostream &out, Option_t *option = "");
+   Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const override;
+   void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const override;
+   void          SetDimensions(Double_t *param) override;
+   void          SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
-   ClassDef(TGeoGtra, 1)         // G3 GTRA shape
+   ClassDefOverride(TGeoGtra, 1)         // G3 GTRA shape
 };
 
 #endif

--- a/geom/geom/inc/TGeoBBox.h
+++ b/geom/geom/inc/TGeoBBox.h
@@ -23,7 +23,7 @@ protected :
    Double_t              fDZ;        // Z half-length
    Double_t              fOrigin[3]; // box origin
 // methods
-   virtual void FillBuffer3D(TBuffer3D & buffer, Int_t reqSections, Bool_t localFrame) const;
+   void FillBuffer3D(TBuffer3D & buffer, Int_t reqSections, Bool_t localFrame) const override;
 
    TGeoBBox(const TGeoBBox&) = delete;
    TGeoBBox& operator=(const TGeoBBox&) = delete;
@@ -35,63 +35,63 @@ public:
    TGeoBBox(const char *name, Double_t dx, Double_t dy, Double_t dz, Double_t *origin=nullptr);
    TGeoBBox(Double_t *param);
    // destructor
-   virtual ~TGeoBBox();
+   ~TGeoBBox() override;
    // methods
    static  Bool_t        AreOverlapping(const TGeoBBox *box1, const TGeoMatrix *mat1, const TGeoBBox *box2, const TGeoMatrix *mat2);
-   virtual Double_t      Capacity() const;
-   virtual void          ComputeBBox();
-   virtual void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm);
-   virtual void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize);
-   virtual Bool_t        Contains(const Double_t *point) const;
-   virtual void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const;
+   Double_t      Capacity() const override;
+   void          ComputeBBox() override;
+   void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
+   Bool_t        Contains(const Double_t *point) const override;
+   void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;
    static  Bool_t        Contains(const Double_t *point, Double_t dx, Double_t dy, Double_t dz, const Double_t *origin);
-   virtual Bool_t        CouldBeCrossed(const Double_t *point, const Double_t *dir) const;
-   virtual Int_t         DistancetoPrimitive(Int_t px, Int_t py);
-   virtual Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
+   Bool_t        CouldBeCrossed(const Double_t *point, const Double_t *dir) const override;
+   Int_t         DistancetoPrimitive(Int_t px, Int_t py) override;
+   Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
    static  Double_t      DistFromInside(const Double_t *point,const Double_t *dir,
                                    Double_t dx, Double_t dy, Double_t dz, const Double_t *origin, Double_t stepmax=TGeoShape::Big());
-   virtual Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
+   Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
    static  Double_t      DistFromOutside(const Double_t *point,const Double_t *dir,
                                    Double_t dx, Double_t dy, Double_t dz, const Double_t *origin, Double_t stepmax=TGeoShape::Big());
-   virtual TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
-                                Double_t start, Double_t step);
-   virtual const char   *GetAxisName(Int_t iaxis) const;
-   virtual Double_t      GetAxisRange(Int_t iaxis, Double_t &xlo, Double_t &xhi) const;
-   virtual void          GetBoundingCylinder(Double_t *param) const;
-   virtual const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const;
-   virtual Int_t         GetByteCount() const {return 36;}
+   TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
+                                Double_t start, Double_t step) override;
+   const char   *GetAxisName(Int_t iaxis) const override;
+   Double_t      GetAxisRange(Int_t iaxis, Double_t &xlo, Double_t &xhi) const override;
+   void          GetBoundingCylinder(Double_t *param) const override;
+   const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const override;
+   Int_t         GetByteCount() const override {return 36;}
    virtual Double_t      GetFacetArea(Int_t index=0) const;
    virtual Bool_t        GetPointsOnFacet(Int_t index, Int_t npoints, Double_t *array) const;
-   virtual Bool_t        GetPointsOnSegments(Int_t npoints, Double_t *array) const;
-   virtual Int_t         GetFittingBox(const TGeoBBox *parambox, TGeoMatrix *mat, Double_t &dx, Double_t &dy, Double_t &dz) const;
-   virtual TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const;
-   virtual void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const;
-   virtual Int_t         GetNmeshVertices() const {return 8;}
+   Bool_t        GetPointsOnSegments(Int_t npoints, Double_t *array) const override;
+   Int_t         GetFittingBox(const TGeoBBox *parambox, TGeoMatrix *mat, Double_t &dx, Double_t &dy, Double_t &dz) const override;
+   TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const override;
+   void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const override;
+   Int_t         GetNmeshVertices() const override {return 8;}
    virtual Double_t      GetDX() const  {return fDX;}
    virtual Double_t      GetDY() const  {return fDY;}
    virtual Double_t      GetDZ() const  {return fDZ;}
    virtual const Double_t *GetOrigin() const {return fOrigin;}
-   virtual void          InspectShape() const;
-   virtual Bool_t        IsCylType() const {return kFALSE;}
-   virtual Bool_t        IsValidBox() const {return ((fDX<0)||(fDY<0)||(fDZ<0))?kFALSE:kTRUE;}
+   void          InspectShape() const override;
+   Bool_t        IsCylType() const override {return kFALSE;}
+   Bool_t        IsValidBox() const override {return ((fDX<0)||(fDY<0)||(fDZ<0))?kFALSE:kTRUE;}
    virtual Bool_t        IsNullBox() const {return ((fDX<1.E-16)&&(fDY<1.E-16)&&(fDZ<1.E-16))?kTRUE:kFALSE;}
-   virtual TBuffer3D    *MakeBuffer3D() const;
-   virtual Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const;
-   virtual void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const;
-   virtual void          SavePrimitive(std::ostream &out, Option_t *option = "");
+   TBuffer3D    *MakeBuffer3D() const override;
+   Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const override;
+   void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const override;
+   void          SavePrimitive(std::ostream &out, Option_t *option = "") override;
    void                  SetBoxDimensions(Double_t dx, Double_t dy, Double_t dz, Double_t *origin=nullptr);
-   virtual void          SetDimensions(Double_t *param);
+   void          SetDimensions(Double_t *param) override;
    void                  SetBoxPoints(Double_t *points) const;
-   virtual void          SetPoints(Double_t *points) const;
-   virtual void          SetPoints(Float_t *points) const;
-   virtual void          SetSegsAndPols(TBuffer3D &buffer) const;
-   virtual void          Sizeof3D() const;
+   void          SetPoints(Double_t *points) const override;
+   void          SetPoints(Float_t *points) const override;
+   void          SetSegsAndPols(TBuffer3D &buffer) const override;
+   void          Sizeof3D() const override;
 
-   ClassDef(TGeoBBox, 1)         // box primitive
+   ClassDefOverride(TGeoBBox, 1)         // box primitive
 };
 
 #endif

--- a/geom/geom/inc/TGeoBoolNode.h
+++ b/geom/geom/inc/TGeoBoolNode.h
@@ -66,7 +66,7 @@ public:
    TGeoBoolNode(TGeoShape *left, TGeoShape *right, TGeoMatrix *lmat = nullptr, TGeoMatrix *rmat = nullptr);
 
    // destructor
-   virtual ~TGeoBoolNode();
+   ~TGeoBoolNode() override;
    // methods
    virtual void      ComputeBBox(Double_t &dx, Double_t &dy, Double_t &dz, Double_t *origin) = 0;
    virtual void      ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) = 0;
@@ -111,7 +111,7 @@ public:
    TGeoUnion(TGeoShape *left, TGeoShape *right, TGeoMatrix *lmat = nullptr, TGeoMatrix *rmat = nullptr);
 
    // destructor
-   virtual ~TGeoUnion();
+   ~TGeoUnion() override;
    // methods
    void      ComputeBBox(Double_t &dx, Double_t &dy, Double_t &dz, Double_t *origin) override;
    void      ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
@@ -150,7 +150,7 @@ public:
    TGeoIntersection(TGeoShape *left, TGeoShape *right, TGeoMatrix *lmat = nullptr, TGeoMatrix *rmat = nullptr);
 
    // destructor
-   virtual ~TGeoIntersection();
+   ~TGeoIntersection() override;
    // methods
    void      ComputeBBox(Double_t &dx, Double_t &dy, Double_t &dz, Double_t *origin) override;
    void      ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
@@ -188,7 +188,7 @@ public:
    TGeoSubtraction(TGeoShape *left, TGeoShape *right, TGeoMatrix *lmat = nullptr, TGeoMatrix *rmat = nullptr);
 
    // destructor
-   virtual ~TGeoSubtraction();
+   ~TGeoSubtraction() override;
    // methods
    void      ComputeBBox(Double_t &dx, Double_t &dy, Double_t &dz, Double_t *origin) override;
    void      ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;

--- a/geom/geom/inc/TGeoBranchArray.h
+++ b/geom/geom/inc/TGeoBranchArray.h
@@ -83,7 +83,7 @@ public:
    void UpdateArray(size_t nobj);
 
    // Destructor. Release instance to be called instead
-   virtual ~TGeoBranchArray() {}
+   ~TGeoBranchArray() override {}
 
    Bool_t operator ==(const TGeoBranchArray& other) const;
    Bool_t operator !=(const TGeoBranchArray& other) const;
@@ -94,7 +94,7 @@ public:
 
    void              AddLevel(Int_t dindex);
    static Long64_t   BinarySearch(Long64_t n, const TGeoBranchArray **array, TGeoBranchArray *value);
-   virtual Int_t     Compare(const TObject *obj) const;
+   Int_t     Compare(const TObject *obj) const override;
    void              CleanMatrix();
    TGeoNode        **GetArray() const    {return fArray;}
    size_t            GetLevel() const    {return fLevel;}
@@ -106,13 +106,13 @@ public:
    void              GetPath(TString &path) const;
    void              Init(TGeoNode **branch, TGeoMatrix *global, Int_t level);
    void              InitFromNavigator(TGeoNavigator *nav);
-   virtual Bool_t    IsSortable() const {return kTRUE;}
+   Bool_t    IsSortable() const override {return kTRUE;}
    Bool_t            IsOutside() const {return (fLevel<0)?kTRUE:kFALSE;}
-   virtual void      Print(Option_t *option="") const;
+   void      Print(Option_t *option="") const override;
    static void       Sort(Int_t n, TGeoBranchArray **array, Int_t *index, Bool_t down=kTRUE);
    void              UpdateNavigator(TGeoNavigator *nav) const;
 
-   ClassDef(TGeoBranchArray, 4)
+   ClassDefOverride(TGeoBranchArray, 4)
 };
 
 struct compareBAasc {

--- a/geom/geom/inc/TGeoBuilder.h
+++ b/geom/geom/inc/TGeoBuilder.h
@@ -38,7 +38,7 @@ private :
    void                   SetGeometry(TGeoManager *geom) {fGeometry = geom;}
 
 public :
-   virtual ~TGeoBuilder();
+   ~TGeoBuilder() override;
 
    static TGeoBuilder    *Instance(TGeoManager *geom);
 
@@ -129,7 +129,7 @@ public :
    TGeoVolume            *Volume(const char *name, const char *shape, Int_t nmed,
                                        Double_t *upar, Int_t npar=0);
 
-   ClassDef(TGeoBuilder, 0)          // geometry builder singleton
+   ClassDefOverride(TGeoBuilder, 0)          // geometry builder singleton
 };
 
 #endif

--- a/geom/geom/inc/TGeoCache.h
+++ b/geom/geom/inc/TGeoCache.h
@@ -46,12 +46,12 @@ protected:
 public:
    TGeoCacheState();
    TGeoCacheState(Int_t capacity);
-   virtual ~TGeoCacheState();
+   ~TGeoCacheState() override;
 
    void                 SetState(Int_t level, Int_t startlevel, Int_t nmany, Bool_t ovlp, Double_t *point=nullptr);
    Bool_t               GetState(Int_t &level, Int_t &nmany, Double_t *point) const;
 
-   ClassDef(TGeoCacheState, 0)       // class storing the cache state
+   ClassDefOverride(TGeoCacheState, 0)       // class storing the cache state
 };
 
 class TGeoNodeCache : public TObject
@@ -84,7 +84,7 @@ private:
 public:
    TGeoNodeCache();
    TGeoNodeCache(TGeoNode *top, Bool_t nodeid=kFALSE, Int_t capacity=30);
-   virtual ~TGeoNodeCache();
+   ~TGeoNodeCache() override;
 
    void                 BuildIdArray();
    void                 BuildInfoBranch();
@@ -129,7 +129,7 @@ public:
    void                 Refresh() {fNode=fNodeBranch[fLevel]; fMatrix=fMatrixBranch[fLevel];}
    Bool_t               RestoreState(Int_t &nmany, TGeoCacheState *state, Double_t *point=nullptr);
 
-   ClassDef(TGeoNodeCache, 0)        // cache of reusable physical nodes
+   ClassDefOverride(TGeoNodeCache, 0)        // cache of reusable physical nodes
 };
 
 #endif

--- a/geom/geom/inc/TGeoCompositeShape.h
+++ b/geom/geom/inc/TGeoCompositeShape.h
@@ -41,46 +41,46 @@ public:
    TGeoCompositeShape(const char *expression);
    TGeoCompositeShape(const char *name, TGeoBoolNode *node);
    // destructor
-   virtual ~TGeoCompositeShape();
+   ~TGeoCompositeShape() override;
    // methods
-   virtual Double_t      Capacity() const;
-   virtual void          ClearThreadData() const;
-   virtual void          CreateThreadData(Int_t nthreads);
-   virtual void          ComputeBBox();
-   virtual void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm);
-   virtual void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize);
-   virtual Bool_t        Contains(const Double_t *point) const;
-   virtual void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const;
-   virtual Int_t         DistancetoPrimitive(Int_t px, Int_t py);
-   virtual Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
-                                Double_t start, Double_t step);
+   Double_t      Capacity() const override;
+   void          ClearThreadData() const override;
+   void          CreateThreadData(Int_t nthreads) override;
+   void          ComputeBBox() override;
+   void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
+   Bool_t        Contains(const Double_t *point) const override;
+   void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;
+   Int_t         DistancetoPrimitive(Int_t px, Int_t py) override;
+   Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
+                                Double_t start, Double_t step) override;
    TGeoBoolNode         *GetBoolNode() const {return fNode;}
-   virtual void          GetBoundingCylinder(Double_t * /*param*/) const {}
-   virtual TGeoShape    *GetMakeRuntimeShape(TGeoShape * /*mother*/, TGeoMatrix * /*mat*/) const {return nullptr;}
-   virtual void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const;
-   virtual Int_t         GetNmeshVertices() const;
-   virtual Bool_t        GetPointsOnSegments(Int_t /*npoints*/, Double_t * /*array*/) const {return kFALSE;}
-   virtual void          InspectShape() const;
-   virtual Bool_t        IsComposite() const {return kTRUE;}
-   virtual Bool_t        IsCylType() const {return kFALSE;}
+   void          GetBoundingCylinder(Double_t * /*param*/) const override {}
+   TGeoShape    *GetMakeRuntimeShape(TGeoShape * /*mother*/, TGeoMatrix * /*mat*/) const override {return nullptr;}
+   void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const override;
+   Int_t         GetNmeshVertices() const override;
+   Bool_t        GetPointsOnSegments(Int_t /*npoints*/, Double_t * /*array*/) const override {return kFALSE;}
+   void          InspectShape() const override;
+   Bool_t        IsComposite() const override {return kTRUE;}
+   Bool_t        IsCylType() const override {return kFALSE;}
    void                  MakeNode(const char *expression);
    virtual Bool_t        PaintComposite(Option_t *option = "") const;
    void                  RegisterYourself();
-   virtual Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const;
-   virtual void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const;
-   virtual void          SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void          SetDimensions(Double_t * /*param*/) {}
-   virtual void          SetPoints(Double_t *points) const;
-   virtual void          SetPoints(Float_t *points) const;
-   virtual void          Sizeof3D() const;
+   Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const override;
+   void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const override;
+   void          SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void          SetDimensions(Double_t * /*param*/) override {}
+   void          SetPoints(Double_t *points) const override;
+   void          SetPoints(Float_t *points) const override;
+   void          Sizeof3D() const override;
 
-   ClassDef(TGeoCompositeShape, 1)         // boolean composite shape
+   ClassDefOverride(TGeoCompositeShape, 1)         // boolean composite shape
 };
 
 

--- a/geom/geom/inc/TGeoCone.h
+++ b/geom/geom/inc/TGeoCone.h
@@ -36,65 +36,65 @@ public:
             Double_t rmin2, Double_t rmax2);
    TGeoCone(Double_t *params);
    // destructor
-   virtual ~TGeoCone();
+   ~TGeoCone() override;
    // methods
 
-   virtual Double_t      Capacity() const;
+   Double_t      Capacity() const override;
    static  Double_t      Capacity(Double_t dz, Double_t rmin1, Double_t rmax1, Double_t rmin2, Double_t rmax2);
-   virtual void          ComputeBBox();
-   virtual void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm);
-   virtual void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize);
+   void          ComputeBBox() override;
+   void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
    static  void          ComputeNormalS(const Double_t *point, const Double_t *dir, Double_t *norm,
                                         Double_t dz, Double_t rmin1, Double_t rmax1, Double_t rmin2, Double_t rmax2);
-   virtual Bool_t        Contains(const Double_t *point) const;
-   virtual void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const;
-   virtual Int_t         DistancetoPrimitive(Int_t px, Int_t py);
+   Bool_t        Contains(const Double_t *point) const override;
+   void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;
+   Int_t         DistancetoPrimitive(Int_t px, Int_t py) override;
    static  void          DistToCone(const Double_t *point, const Double_t *dir, Double_t dz, Double_t r1, Double_t r2, Double_t &b, Double_t &delta);
    static  Double_t      DistFromInsideS(const Double_t *point, const Double_t *dir, Double_t dz,
                                     Double_t rmin1, Double_t rmax1, Double_t rmin2, Double_t rmax2);
-   virtual Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
+   Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
    static  Double_t      DistFromOutsideS(const Double_t *point, const Double_t *dir, Double_t dz,
                                    Double_t rmin1, Double_t rmax1, Double_t rmin2, Double_t rmax2);
-   virtual Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
-                                Double_t start, Double_t step);
+   Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
+                                Double_t start, Double_t step) override;
 
-   virtual const char   *GetAxisName(Int_t iaxis) const;
-   virtual Double_t      GetAxisRange(Int_t iaxis, Double_t &xlo, Double_t &xhi) const;
-   virtual void          GetBoundingCylinder(Double_t *param) const;
-   virtual Int_t         GetByteCount() const {return 56;}
-   virtual const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const;
+   const char   *GetAxisName(Int_t iaxis) const override;
+   Double_t      GetAxisRange(Int_t iaxis, Double_t &xlo, Double_t &xhi) const override;
+   void          GetBoundingCylinder(Double_t *param) const override;
+   Int_t         GetByteCount() const override {return 56;}
+   const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const override;
    virtual Double_t      GetDz() const    {return fDz;}
-   virtual TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const;
-   virtual void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const;
-   virtual Int_t         GetNmeshVertices() const;
-   virtual Bool_t        GetPointsOnSegments(Int_t npoints, Double_t *array) const;
+   TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const override;
+   void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const override;
+   Int_t         GetNmeshVertices() const override;
+   Bool_t        GetPointsOnSegments(Int_t npoints, Double_t *array) const override;
    virtual Double_t      GetRmin1() const {return fRmin1;}
    virtual Double_t      GetRmax1() const {return fRmax1;}
    virtual Double_t      GetRmin2() const {return fRmin2;}
    virtual Double_t      GetRmax2() const {return fRmax2;}
 
-   virtual void          InspectShape() const;
-   virtual Bool_t        IsCylType() const {return kTRUE;}
-   virtual TBuffer3D    *MakeBuffer3D() const;
-   virtual Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const;
-   virtual void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const;
+   void          InspectShape() const override;
+   Bool_t        IsCylType() const override {return kTRUE;}
+   TBuffer3D    *MakeBuffer3D() const override;
+   Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const override;
+   void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const override;
    static  Double_t      SafetyS(const Double_t *point, Bool_t in, Double_t dz, Double_t rmin1, Double_t rmax1,
                                  Double_t rmin2, Double_t rmax2, Int_t skipz=0);
-   virtual void          SavePrimitive(std::ostream &out, Option_t *option = "");
+   void          SavePrimitive(std::ostream &out, Option_t *option = "") override;
    void                  SetConeDimensions(Double_t dz, Double_t rmin1, Double_t rmax1,
                                        Double_t rmin2, Double_t rmax2);
-   virtual void          SetDimensions(Double_t *param);
-   virtual void          SetPoints(Double_t *points) const;
-   virtual void          SetPoints(Float_t *points) const;
-   virtual void          SetSegsAndPols(TBuffer3D &buffer) const;
-   virtual void          Sizeof3D() const;
+   void          SetDimensions(Double_t *param) override;
+   void          SetPoints(Double_t *points) const override;
+   void          SetPoints(Float_t *points) const override;
+   void          SetSegsAndPols(TBuffer3D &buffer) const override;
+   void          Sizeof3D() const override;
 
-   ClassDef(TGeoCone, 1)         // conical tube class
+   ClassDefOverride(TGeoCone, 1)         // conical tube class
 
 };
 
@@ -124,60 +124,60 @@ public:
                Double_t rmin2, Double_t rmax2, Double_t phi1, Double_t phi2);
    TGeoConeSeg(Double_t *params);
    // destructor
-   virtual ~TGeoConeSeg();
+   ~TGeoConeSeg() override;
    // methods
-   virtual void          AfterStreamer();
-   virtual Double_t      Capacity() const;
+   void          AfterStreamer() override;
+   Double_t      Capacity() const override;
    static  Double_t      Capacity(Double_t dz, Double_t rmin1, Double_t rmax1, Double_t rmin2, Double_t rmax2, Double_t phi1, Double_t phi2);
-   virtual void          ComputeBBox();
-   virtual void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm);
-   virtual void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize);
+   void          ComputeBBox() override;
+   void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
    static  void          ComputeNormalS(const Double_t *point, const Double_t *dir, Double_t *norm,
                                         Double_t dz, Double_t rmin1, Double_t rmax1, Double_t rmin2, Double_t rmax2,
                                         Double_t c1, Double_t s1, Double_t c2, Double_t s2);
-   virtual Bool_t        Contains(const Double_t *point) const;
-   virtual void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const;
+   Bool_t        Contains(const Double_t *point) const override;
+   void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;
 
-   virtual Int_t         DistancetoPrimitive(Int_t px, Int_t py);
+   Int_t         DistancetoPrimitive(Int_t px, Int_t py) override;
    static  Double_t      DistToCons(const Double_t *point, const Double_t *dir, Double_t r1, Double_t z1, Double_t r2, Double_t z2, Double_t phi1, Double_t phi2);
    static  Double_t      DistFromInsideS(const Double_t *point, const Double_t *dir, Double_t dz, Double_t rmin1, Double_t rmax1,
                                    Double_t rmin2, Double_t rmax2, Double_t c1, Double_t s1, Double_t c2, Double_t s2, Double_t cm, Double_t sm, Double_t cdfi);
-   virtual Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
+   Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
    static  Double_t      DistFromOutsideS(const Double_t *point, const Double_t *dir, Double_t dz, Double_t rmin1, Double_t rmax1, Double_t rmin2, Double_t rmax2,
                                    Double_t c1, Double_t s1, Double_t c2, Double_t s2, Double_t cm, Double_t sm, Double_t cdfi);
-   virtual Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
-                                Double_t start, Double_t step);
-   virtual Double_t      GetAxisRange(Int_t iaxis, Double_t &xlo, Double_t &xhi) const;
-   virtual void          GetBoundingCylinder(Double_t *param) const;
-   virtual const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const;
-   virtual Int_t         GetByteCount() const {return 64;}
-   virtual TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const;
-   virtual void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const;
-   virtual Int_t         GetNmeshVertices() const;
-   virtual Bool_t        GetPointsOnSegments(Int_t npoints, Double_t *array) const;
+   Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
+                                Double_t start, Double_t step) override;
+   Double_t      GetAxisRange(Int_t iaxis, Double_t &xlo, Double_t &xhi) const override;
+   void          GetBoundingCylinder(Double_t *param) const override;
+   const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const override;
+   Int_t         GetByteCount() const override {return 64;}
+   TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const override;
+   void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const override;
+   Int_t         GetNmeshVertices() const override;
+   Bool_t        GetPointsOnSegments(Int_t npoints, Double_t *array) const override;
    Double_t              GetPhi1() const {return fPhi1;}
    Double_t              GetPhi2() const {return fPhi2;}
-   virtual void          InspectShape() const;
-   virtual TBuffer3D    *MakeBuffer3D() const;
-   virtual Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const;
-   virtual void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const;
+   void          InspectShape() const override;
+   TBuffer3D    *MakeBuffer3D() const override;
+   Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const override;
+   void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const override;
    static  Double_t      SafetyS(const Double_t *point, Bool_t in, Double_t dz, Double_t rmin1, Double_t rmax1,
                                  Double_t rmin2, Double_t rmax2, Double_t phi1, Double_t phi2, Int_t skipz=0);
-   virtual void          SavePrimitive(std::ostream &out, Option_t *option = "");
+   void          SavePrimitive(std::ostream &out, Option_t *option = "") override;
    void                  SetConsDimensions(Double_t dz, Double_t rmin1, Double_t rmax1,
                                        Double_t rmin2, Double_t rmax2, Double_t phi1, Double_t phi2);
-   virtual void          SetDimensions(Double_t *param);
-   virtual void          SetPoints(Double_t *points) const;
-   virtual void          SetPoints(Float_t *points) const;
-   virtual void          SetSegsAndPols(TBuffer3D &buffer) const;
-   virtual void          Sizeof3D() const;
+   void          SetDimensions(Double_t *param) override;
+   void          SetPoints(Double_t *points) const override;
+   void          SetPoints(Float_t *points) const override;
+   void          SetSegsAndPols(TBuffer3D &buffer) const override;
+   void          Sizeof3D() const override;
 
-   ClassDef(TGeoConeSeg, 2)         // conical tube segment class
+   ClassDefOverride(TGeoConeSeg, 2)         // conical tube segment class
 };
 
 #endif

--- a/geom/geom/inc/TGeoElement.h
+++ b/geom/geom/inc/TGeoElement.h
@@ -67,7 +67,7 @@ public:
    TGeoElement(const char *name, const char *title, Int_t nisotopes);
    TGeoElement(const char *name, const char *title, Int_t z, Int_t n, Double_t a);
    // destructor
-   virtual ~TGeoElement();
+   ~TGeoElement() override;
    // methods
    virtual Int_t            ENDFCode()    const { return 0;}
    Int_t                    Z() const {return fZ;}
@@ -86,7 +86,7 @@ public:
    Bool_t                   IsDefined() const {return TObject::TestBit(kElemDefined);}
    virtual Bool_t           IsRadioNuclide() const {return kFALSE;}
    Bool_t                   IsUsed() const {return TObject::TestBit(kElemUsed);}
-   virtual void             Print(Option_t *option = "") const;
+   void             Print(Option_t *option = "") const override;
    void                     SetDefined(Bool_t flag=kTRUE) {TObject::SetBit(kElemDefined,flag);}
    void                     SetUsed(Bool_t flag=kTRUE) {TObject::SetBit(kElemUsed,flag);}
    static TGeoElementTable *GetElementTable();
@@ -95,7 +95,7 @@ public:
    // Tsai formula for the radiation length
    inline Double_t          GetfRadTsai() const {return fRadTsai;}
 
-   ClassDef(TGeoElement, 3)              // base element class
+   ClassDefOverride(TGeoElement, 3)              // base element class
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -115,15 +115,15 @@ protected:
 public:
    TGeoIsotope();
    TGeoIsotope(const char *name, Int_t z, Int_t n, Double_t a);
-   virtual ~TGeoIsotope() {}
+   ~TGeoIsotope() override {}
 
    Int_t                    GetZ() const {return fZ;}
    Int_t                    GetN() const {return fN;}
    Double_t                 GetA() const {return fA;}
    static TGeoIsotope      *FindIsotope(const char *name);
-   virtual void             Print(Option_t *option = "") const;
+   void             Print(Option_t *option = "") const override;
 
-   ClassDef(TGeoIsotope, 1)              // Isotope class defined by Z,N,A
+   ClassDefOverride(TGeoIsotope, 1)              // Isotope class defined by Z,N,A
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -166,7 +166,7 @@ public:
          Double_t deltaM, Double_t halfLife, const char* JP,
          Double_t natAbun, Double_t th_f, Double_t tg_f, Double_t th_s,
          Double_t tg_s, Int_t status);
-   virtual ~TGeoElementRN();
+   ~TGeoElementRN() override;
 
    void                     AddDecay(Int_t decay, Int_t diso, Double_t branchingRatio, Double_t qValue);
    void                     AddDecay(TGeoDecayChannel *dc);
@@ -175,9 +175,9 @@ public:
    static Int_t             ENDF(Int_t a, Int_t z, Int_t iso) {return 10000*z+10*a+iso;}
 
    // Getters
-   virtual Int_t            ENDFCode()    const {return fENDFcode;}
-   virtual Double_t         GetSpecificActivity() const;
-   virtual Bool_t           IsRadioNuclide() const {return kTRUE;}
+   Int_t            ENDFCode()    const override {return fENDFcode;}
+   Double_t         GetSpecificActivity() const override;
+   Bool_t           IsRadioNuclide() const override {return kTRUE;}
    Int_t                    MassNo()      const {return (Int_t)fA;}
    Int_t                    AtomicNo()    const {return fZ;}
    Int_t                    IsoNo()       const {return fIso;}
@@ -200,11 +200,11 @@ public:
    Bool_t                   CheckDecays() const;
    Int_t                    DecayResult(TGeoDecayChannel *dc) const;
    void                     FillPopulation(TObjArray *population, Double_t precision=0.001, Double_t factor=1.);
-   virtual void             Print(Option_t *option = "") const;
+   void             Print(Option_t *option = "") const override;
    static TGeoElementRN    *ReadElementRN(const char *record, Int_t &ndecays);
-   virtual void             SavePrimitive(std::ostream &out, Option_t *option = "");
+   void             SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
-   ClassDef(TGeoElementRN, 2)           // radionuclides class
+   ClassDefOverride(TGeoElementRN, 2)           // radionuclides class
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -246,13 +246,13 @@ public:
                   : fDecay(decay), fDiso(diso), fBranchingRatio(branchingRatio), fQvalue(qValue), fParent(nullptr), fDaughter(nullptr) {}
    TGeoDecayChannel(const TGeoDecayChannel &dc) : TObject(dc),fDecay(dc.fDecay),fDiso(dc.fDiso),fBranchingRatio(dc.fBranchingRatio),
                                                   fQvalue(dc.fQvalue),fParent(dc.fParent),fDaughter(dc.fDaughter) {}
-   virtual ~TGeoDecayChannel() {}
+   ~TGeoDecayChannel() override {}
 
    TGeoDecayChannel& operator=(const TGeoDecayChannel& dc);
 
    // Getters
    Int_t                    GetIndex()       const;
-   virtual const char      *GetName()        const;
+   const char      *GetName()        const override;
    UInt_t                   Decay()          const {return fDecay;}
    Double_t                 BranchingRatio() const {return fBranchingRatio;}
    Double_t                 Qvalue()         const {return fQvalue;}
@@ -264,12 +264,12 @@ public:
    void                     SetParent(TGeoElementRN *parent) {fParent = parent;}
    void                     SetDaughter(TGeoElementRN *daughter) {fDaughter = daughter;}
    // Services
-   virtual void             Print(Option_t *opt = " ") const;
+   void             Print(Option_t *opt = " ") const override;
    static TGeoDecayChannel *ReadDecay(const char *record);
-   virtual void             SavePrimitive(std::ostream &out, Option_t *option = "");
+   void             SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void             DecayShift(Int_t &dA, Int_t &dZ, Int_t &dI) const ;
 
-   ClassDef(TGeoDecayChannel,1)    // Decay channel for Elements
+   ClassDefOverride(TGeoDecayChannel,1)    // Decay channel for Elements
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -298,25 +298,25 @@ public:
    TGeoBatemanSol(TGeoElementRN *elem);
    TGeoBatemanSol(const TObjArray *chain);
    TGeoBatemanSol(const TGeoBatemanSol& other);
-   ~TGeoBatemanSol();
+   ~TGeoBatemanSol() override;
 
    TGeoBatemanSol& operator=(const TGeoBatemanSol& other);
    TGeoBatemanSol& operator+=(const TGeoBatemanSol& other);
 
    Double_t                 Concentration(Double_t time) const;
-   virtual void             Draw(Option_t *option="");
+   void             Draw(Option_t *option="") override;
    void                     GetCoeff(Int_t i, Double_t &cn, Double_t &lambda) const {cn=fCoeff[i].cn; lambda=fCoeff[i].lambda;}
    void                     GetRange(Double_t &tmin, Double_t &tmax) const {tmin=fTmin; tmax=fTmax;}
    TGeoElementRN           *GetElement()    const {return fElem;}
    TGeoElementRN           *GetTopElement() const {return fElemTop;}
    Int_t                    GetNcoeff()     const  {return fNcoeff;}
-   virtual void             Print(Option_t *option = "") const;
+   void             Print(Option_t *option = "") const override;
    void                     SetRange(Double_t tmin=0., Double_t tmax=0.) {fTmin=tmin; fTmax=tmax;}
    void                     SetFactor(Double_t factor) {fFactor = factor;}
    void                     FindSolution(const TObjArray *array);
    void                     Normalize(Double_t factor);
 
-   ClassDef(TGeoBatemanSol,1)       // Solution for the Bateman equation
+   ClassDefOverride(TGeoBatemanSol,1)       // Solution for the Bateman equation
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -390,7 +390,7 @@ public:
    TGeoElementTable();
    TGeoElementTable(Int_t nelements);
    // destructor
-   virtual ~TGeoElementTable();
+   ~TGeoElementTable() override;
    // methods
 
    enum EGeoETStatus {
@@ -417,9 +417,9 @@ public:
    Int_t                    GetNelements() const {return fNelements;}
    Int_t                    GetNelementsRN() const {return fNelementsRN;}
    void                     ExportElementsRN(const char *filename="");
-   virtual void             Print(Option_t *option = "") const;
+   void             Print(Option_t *option = "") const override;
 
-   ClassDef(TGeoElementTable,4)              // table of elements
+   ClassDefOverride(TGeoElementTable,4)              // table of elements
 };
 
 #endif

--- a/geom/geom/inc/TGeoEltu.h
+++ b/geom/geom/inc/TGeoEltu.h
@@ -26,42 +26,42 @@ public:
    TGeoEltu(const char *name, Double_t a, Double_t b, Double_t dz);
    TGeoEltu(Double_t *params);
    // destructor
-   virtual ~TGeoEltu();
+   ~TGeoEltu() override;
    // methods
-   virtual Double_t      Capacity() const;
-   virtual void          ComputeBBox();
-   virtual void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm);
-   virtual void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize);
-   virtual Bool_t        Contains(const Double_t *point) const;
-   virtual void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const;
-   virtual Int_t         DistancetoPrimitive(Int_t px, Int_t py);
-   virtual Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
-                                Double_t start, Double_t step);
+   Double_t      Capacity() const override;
+   void          ComputeBBox() override;
+   void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
+   Bool_t        Contains(const Double_t *point) const override;
+   void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;
+   Int_t         DistancetoPrimitive(Int_t px, Int_t py) override;
+   Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
+                                Double_t start, Double_t step) override;
    virtual Double_t      GetA() const    {return fRmin;}
    virtual Double_t      GetB() const    {return fRmax;}
-   virtual void          GetBoundingCylinder(Double_t *param) const;
-   virtual const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const;
-   virtual TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const;
-   virtual void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const;
-   virtual Int_t         GetNmeshVertices() const;
-   virtual Bool_t        GetPointsOnSegments(Int_t /*npoints*/, Double_t * /*array*/) const {return kFALSE;}
-   virtual void          InspectShape() const;
-   virtual Bool_t        IsCylType() const {return kTRUE;}
-   virtual Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const;
-   virtual void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const;
-   virtual void          SavePrimitive(std::ostream &out, Option_t *option = "");
+   void          GetBoundingCylinder(Double_t *param) const override;
+   const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const override;
+   TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const override;
+   void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const override;
+   Int_t         GetNmeshVertices() const override;
+   Bool_t        GetPointsOnSegments(Int_t /*npoints*/, Double_t * /*array*/) const override {return kFALSE;}
+   void          InspectShape() const override;
+   Bool_t        IsCylType() const override {return kTRUE;}
+   Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const override;
+   void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const override;
+   void          SavePrimitive(std::ostream &out, Option_t *option = "") override;
    void                  SetEltuDimensions(Double_t a, Double_t b, Double_t dz);
-   virtual void          SetDimensions(Double_t *param);
-   virtual void          SetPoints(Double_t *points) const;
-   virtual void          SetPoints(Float_t *points) const;
+   void          SetDimensions(Double_t *param) override;
+   void          SetPoints(Double_t *points) const override;
+   void          SetPoints(Float_t *points) const override;
 
-   ClassDef(TGeoEltu, 1)         // elliptical tube class
+   ClassDefOverride(TGeoEltu, 1)         // elliptical tube class
 
 };
 

--- a/geom/geom/inc/TGeoExtension.h
+++ b/geom/geom/inc/TGeoExtension.h
@@ -20,7 +20,7 @@ class TGeoExtension : public TObject
 {
 protected:
    TGeoExtension() : TObject() {}
-   virtual ~TGeoExtension() {}
+   ~TGeoExtension() override {}
 
 public:
    // Method called whenever requiring a pointer to the extension
@@ -30,13 +30,13 @@ public:
    // Equivalent to delete()
    virtual void           Release() const = 0;
 
-   ClassDef(TGeoExtension, 1)       // User extension for volumes and nodes
+   ClassDefOverride(TGeoExtension, 1)       // User extension for volumes and nodes
 };
 
 class TGeoRCExtension : public TGeoExtension
 {
 protected:
-   virtual ~TGeoRCExtension() {delete fUserObject;}
+   ~TGeoRCExtension() override {delete fUserObject;}
 public:
    TGeoRCExtension() : TGeoExtension(), fRC(0), fUserObject(nullptr) { fRC++; }
    TGeoRCExtension(TObject *obj) : TGeoExtension(), fRC(0), fUserObject(obj) { fRC++; }

--- a/geom/geom/inc/TGeoGlobalMagField.h
+++ b/geom/geom/inc/TGeoGlobalMagField.h
@@ -29,7 +29,7 @@ protected:
 
 public:
    TGeoGlobalMagField();
-   virtual ~TGeoGlobalMagField();
+   ~TGeoGlobalMagField() override;
 
    // Using SetField() makes a given field global. The field manager owns it from now on.
    TVirtualMagField       *GetField() const {return fField;}
@@ -44,7 +44,7 @@ public:
    // Inline access to Field() method
    void                    Field(const Double_t *x, Double_t *B) {if (fField) fField->Field(x,B);}
 
-   ClassDef(TGeoGlobalMagField, 0)              // Global field manager
+   ClassDefOverride(TGeoGlobalMagField, 0)              // Global field manager
 };
 
 #endif

--- a/geom/geom/inc/TGeoHalfSpace.h
+++ b/geom/geom/inc/TGeoHalfSpace.h
@@ -29,40 +29,40 @@ public:
    TGeoHalfSpace(const char *name, Double_t *p, Double_t *n);
    TGeoHalfSpace(Double_t *params);
    // destructor
-   virtual ~TGeoHalfSpace();
+   ~TGeoHalfSpace() override;
    // methods
-   virtual Double_t      Capacity() const {return 0.;}
-   virtual void          ComputeBBox() {}
-   virtual void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm);
-   virtual void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize);
-   virtual Bool_t        Contains(const Double_t *point) const;
-   virtual void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const;
-   virtual Int_t         DistancetoPrimitive(Int_t px, Int_t py);
-   virtual Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
-                                Double_t start, Double_t step);
+   Double_t      Capacity() const override {return 0.;}
+   void          ComputeBBox() override {}
+   void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
+   Bool_t        Contains(const Double_t *point) const override;
+   void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;
+   Int_t         DistancetoPrimitive(Int_t px, Int_t py) override;
+   Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
+                                Double_t start, Double_t step) override;
    virtual Double_t     *GetPoint()    {return fP;}
    virtual Double_t     *GetNorm()     {return fN;}
-   virtual void          GetBoundingCylinder(Double_t * /*param*/) const {}
-   virtual TGeoShape    *GetMakeRuntimeShape(TGeoShape * /*mother*/, TGeoMatrix * /*mat*/) const {return nullptr;}
-   virtual void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const;
-   virtual Int_t         GetNmeshVertices() const {return 0;}
-   virtual void          InspectShape() const;
-   virtual Bool_t        IsCylType() const {return kFALSE;}
-   virtual Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const;
-   virtual void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const;
-   virtual void          SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void          SetDimensions(Double_t *param);
-   virtual void          SetPoints(Double_t * /*points*/) const {}
-   virtual void          SetPoints(Float_t * /*points*/) const {}
-   virtual void          Sizeof3D() const {}
+   void          GetBoundingCylinder(Double_t * /*param*/) const override {}
+   TGeoShape    *GetMakeRuntimeShape(TGeoShape * /*mother*/, TGeoMatrix * /*mat*/) const override {return nullptr;}
+   void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const override;
+   Int_t         GetNmeshVertices() const override {return 0;}
+   void          InspectShape() const override;
+   Bool_t        IsCylType() const override {return kFALSE;}
+   Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const override;
+   void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const override;
+   void          SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void          SetDimensions(Double_t *param) override;
+   void          SetPoints(Double_t * /*points*/) const override {}
+   void          SetPoints(Float_t * /*points*/) const override {}
+   void          Sizeof3D() const override {}
 
-   ClassDef(TGeoHalfSpace, 1)         // half-space class
+   ClassDefOverride(TGeoHalfSpace, 1)         // half-space class
 };
 
 

--- a/geom/geom/inc/TGeoHelix.h
+++ b/geom/geom/inc/TGeoHelix.h
@@ -44,7 +44,7 @@ public:
    TGeoHelix();
    TGeoHelix(Double_t curvature, Double_t step, Int_t charge=1);
    // destructor
-   virtual ~TGeoHelix();
+   ~TGeoHelix() override;
 
    void            InitPoint(Double_t x0, Double_t y0, Double_t z0);
    void            InitPoint(Double_t *point);
@@ -72,7 +72,7 @@ public:
 
    void            UpdateHelix();
 
-   ClassDef(TGeoHelix, 1)              // helix class
+   ClassDefOverride(TGeoHelix, 1)              // helix class
 };
 
 #endif

--- a/geom/geom/inc/TGeoHype.h
+++ b/geom/geom/inc/TGeoHype.h
@@ -41,54 +41,54 @@ public:
    TGeoHype(const char *name, Double_t rin, Double_t stin, Double_t rout, Double_t stout, Double_t dz);
    TGeoHype(Double_t *params);
    // destructor
-   virtual ~TGeoHype();
+   ~TGeoHype() override;
    // methods
 
-   virtual Double_t      Capacity() const;
-   virtual void          ComputeBBox();
-   virtual void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm);
-   virtual void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize);
-   virtual Bool_t        Contains(const Double_t *point) const;
-   virtual void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const;
-   virtual Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
+   Double_t      Capacity() const override;
+   void          ComputeBBox() override;
+   void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
+   Bool_t        Contains(const Double_t *point) const override;
+   void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;
+   Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
    Int_t                 DistToHype(const Double_t *point, const Double_t *dir, Double_t *s, Bool_t inner, Bool_t in) const;
-   virtual Int_t         DistancetoPrimitive(Int_t px, Int_t py);
-   virtual TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
-                                Double_t start, Double_t step);
-   virtual Double_t      GetAxisRange(Int_t iaxis, Double_t &xlo, Double_t &xhi) const;
-   virtual void          GetBoundingCylinder(Double_t *param) const;
-   virtual const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const;
-   virtual Int_t         GetByteCount() const {return 64;}
-   virtual Bool_t        GetPointsOnSegments(Int_t /*npoints*/, Double_t * /*array*/) const {return kFALSE;}
-   virtual TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const;
-   virtual void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const;
-   virtual Int_t         GetNmeshVertices() const;
+   Int_t         DistancetoPrimitive(Int_t px, Int_t py) override;
+   TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
+                                Double_t start, Double_t step) override;
+   Double_t      GetAxisRange(Int_t iaxis, Double_t &xlo, Double_t &xhi) const override;
+   void          GetBoundingCylinder(Double_t *param) const override;
+   const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const override;
+   Int_t         GetByteCount() const override {return 64;}
+   Bool_t        GetPointsOnSegments(Int_t /*npoints*/, Double_t * /*array*/) const override {return kFALSE;}
+   TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const override;
+   void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const override;
+   Int_t         GetNmeshVertices() const override;
    Double_t              GetStIn() const {return fStIn;}
    Double_t              GetStOut() const {return fStOut;}
    Bool_t                HasInner() const {return !TestShapeBit(kGeoRSeg);}
    Double_t              RadiusHypeSq(Double_t z, Bool_t inner) const;
    Double_t              ZHypeSq(Double_t r, Bool_t inner) const;
-   virtual void          InspectShape() const;
-   virtual Bool_t        IsCylType() const {return kTRUE;}
-   virtual TBuffer3D    *MakeBuffer3D() const;
+   void          InspectShape() const override;
+   Bool_t        IsCylType() const override {return kTRUE;}
+   TBuffer3D    *MakeBuffer3D() const override;
    //virtual void          Paint(Option_t *option);
-   virtual Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const;
-   virtual void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const;
+   Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const override;
+   void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const override;
    Double_t              SafetyToHype(const Double_t *point, Bool_t inner, Bool_t in) const;
-   virtual void          SavePrimitive(std::ostream &out, Option_t *option = "");
+   void          SavePrimitive(std::ostream &out, Option_t *option = "") override;
    void                  SetHypeDimensions(Double_t rin, Double_t stin, Double_t rout, Double_t stout, Double_t dz);
-   virtual void          SetDimensions(Double_t *param);
-   virtual void          SetPoints(Double_t *points) const;
-   virtual void          SetPoints(Float_t *points) const;
-   virtual void          SetSegsAndPols(TBuffer3D &buff) const;
-   virtual void          Sizeof3D() const;
+   void          SetDimensions(Double_t *param) override;
+   void          SetPoints(Double_t *points) const override;
+   void          SetPoints(Float_t *points) const override;
+   void          SetSegsAndPols(TBuffer3D &buff) const override;
+   void          Sizeof3D() const override;
 
-   ClassDef(TGeoHype, 1)         // hyperboloid class
+   ClassDefOverride(TGeoHype, 1)         // hyperboloid class
 
 };
 

--- a/geom/geom/inc/TGeoManager.h
+++ b/geom/geom/inc/TGeoManager.h
@@ -165,7 +165,7 @@ public:
    TGeoManager();
    TGeoManager(const char *name, const char *title);
    // destructor
-   virtual ~TGeoManager();
+   ~TGeoManager() override;
    //--- adding geometrical objects
    Int_t                  AddMaterial(const TGeoMaterial *material);
    Int_t                  AddOverlap(const TNamed *ovlp);
@@ -184,7 +184,7 @@ public:
    void                   RegisterMatrix(const TGeoMatrix *matrix);
    void                   SortOverlaps();
    //--- browsing and tree navigation
-   void                   Browse(TBrowser *b);
+   void                   Browse(TBrowser *b) override;
    void                   SetVisibility(TObject *obj, Bool_t vis);
    virtual Bool_t         cd(const char *path=""); // *MENU*
    Bool_t                 CheckPath(const char *path) const;
@@ -199,7 +199,7 @@ public:
    Int_t                  GetNmany() const {return GetCurrentNavigator()->GetNmany();}
    const char            *GetPdgName(Int_t pdg) const;
    void                   SetPdgName(Int_t pdg, const char *name);
-   Bool_t                 IsFolder() const { return kTRUE; }
+   Bool_t                 IsFolder() const override { return kTRUE; }
    //--- visualization settings
    virtual void           Edit(Option_t *option="");  // *MENU*
    void                   BombTranslation(const Double_t *tr, Double_t *bombtr);
@@ -445,7 +445,7 @@ public:
    //--- utilities
    Int_t                  CountNodes(const TGeoVolume *vol=nullptr, Int_t nlevels=10000, Int_t option=0);
    void                   CountLevels();
-   virtual void           ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   void           ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
    static Int_t           Parse(const char* expr, TString &expr1, TString &expr2, TString &expr3);
    Int_t                  ReplaceVolume(TGeoVolume *vorig, TGeoVolume *vnew);
    Int_t                  TransformVolumeToAssembly(const char *vname);
@@ -596,7 +596,7 @@ public:
    void                  SetUseParallelWorldNav(Bool_t flag);
    Bool_t                IsParallelWorldNav() const {return fUsePWNav;}
 
-   ClassDef(TGeoManager, 17)          // geometry manager
+   ClassDefOverride(TGeoManager, 17)          // geometry manager
 };
 
 R__EXTERN TGeoManager *gGeoManager;

--- a/geom/geom/inc/TGeoMaterial.h
+++ b/geom/geom/inc/TGeoMaterial.h
@@ -80,7 +80,7 @@ public:
    TGeoMaterial(const char *name, TGeoElement *elem, Double_t rho);
 
    // destructor
-   virtual ~TGeoMaterial();
+   ~TGeoMaterial() override;
    // methods
    static  Double_t         Coulomb(Double_t z);
    // radioactive mixture evolution
@@ -128,8 +128,8 @@ public:
    virtual Bool_t           IsEq(const TGeoMaterial *other) const;
    Bool_t                   IsUsed() const {return TObject::TestBit(kMatUsed);}
    virtual Bool_t           IsMixture() const {return kFALSE;}
-   virtual void             Print(const Option_t *option="") const;
-   virtual void             SavePrimitive(std::ostream &out, Option_t *option = "");
+   void             Print(const Option_t *option="") const override;
+   void             SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void             SetA(Double_t a) {fA = a; SetRadLen(0);}
    virtual void             SetZ(Double_t z) {fZ = z; SetRadLen(0);}
    virtual void             SetDensity(Double_t density) {fDensity = density; SetRadLen(0);}
@@ -147,7 +147,7 @@ public:
 
 
 
-   ClassDef(TGeoMaterial, 7)              // base material class
+   ClassDefOverride(TGeoMaterial, 7)              // base material class
 
 //***** Need to add classes and globals to LinkDef.h *****
 };
@@ -174,7 +174,7 @@ public:
    TGeoMixture();
    TGeoMixture(const char *name, Int_t nel, Double_t rho=-1);
    // destructor
-   virtual ~TGeoMixture();
+   ~TGeoMixture() override;
    // methods for adding elements
    void                     AddElement(Double_t a, Double_t z, Double_t weight);
    void                     AddElement(TGeoMaterial *mat, Double_t weight);
@@ -185,31 +185,31 @@ public:
    void                     DefineElement(Int_t iel, TGeoElement *elem, Double_t weight);
    void                     DefineElement(Int_t iel, Int_t z, Int_t natoms);
    // radioactive mixture evolution
-   virtual TGeoMaterial    *DecayMaterial(Double_t time, Double_t precision=0.001);
-   virtual void             FillMaterialEvolution(TObjArray *population, Double_t precision=0.001);
+   TGeoMaterial    *DecayMaterial(Double_t time, Double_t precision=0.001) override;
+   void             FillMaterialEvolution(TObjArray *population, Double_t precision=0.001) override;
    // getters
-   virtual Int_t            GetByteCount() const {return 48+12*fNelements;}
-   virtual TGeoElement     *GetElement(Int_t i=0) const;
-   virtual void             GetElementProp(Double_t &a, Double_t &z, Double_t &w, Int_t i=0) {a=fAmixture[i]; z=fZmixture[i]; w=fWeights[i];}
-   virtual Int_t            GetNelements() const {return fNelements;}
+   Int_t            GetByteCount() const override {return 48+12*fNelements;}
+   TGeoElement     *GetElement(Int_t i=0) const override;
+   void             GetElementProp(Double_t &a, Double_t &z, Double_t &w, Int_t i=0) override {a=fAmixture[i]; z=fZmixture[i]; w=fWeights[i];}
+   Int_t            GetNelements() const override {return fNelements;}
    Double_t                *GetZmixt() const     {return fZmixture;}
    Double_t                *GetAmixt() const     {return fAmixture;}
    Double_t                *GetWmixt() const     {return fWeights;}
    Int_t                   *GetNmixt() const     {return fNatoms;}
-   virtual Double_t         GetSpecificActivity(Int_t i=-1) const;
+   Double_t         GetSpecificActivity(Int_t i=-1) const override;
    // utilities
-   virtual Bool_t           IsEq(const TGeoMaterial *other) const;
-   virtual Bool_t           IsMixture() const {return kTRUE;}
-   virtual void             Print(const Option_t *option="") const;
-   virtual void             SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void             SetA(Double_t a) {fA = a;}
-   virtual void             SetZ(Double_t z) {fZ = z;}
-   virtual void             SetDensity(Double_t density) {fDensity = density; AverageProperties();}
+   Bool_t           IsEq(const TGeoMaterial *other) const override;
+   Bool_t           IsMixture() const override {return kTRUE;}
+   void             Print(const Option_t *option="") const override;
+   void             SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void             SetA(Double_t a) override {fA = a;}
+   void             SetZ(Double_t z) override {fZ = z;}
+   void             SetDensity(Double_t density) override {fDensity = density; AverageProperties();}
    void                     ComputeDerivedQuantities();
    void                     ComputeRadiationLength();
    void                     ComputeNuclearInterLength();
 
-   ClassDef(TGeoMixture, 3)              // material mixtures
+   ClassDefOverride(TGeoMixture, 3)              // material mixtures
 };
 
 inline void TGeoMixture::DefineElement(Int_t, Double_t a, Double_t z, Double_t weight)

--- a/geom/geom/inc/TGeoMatrix.h
+++ b/geom/geom/inc/TGeoMatrix.h
@@ -61,7 +61,7 @@ protected:
 public :
    TGeoMatrix();
    TGeoMatrix(const char *name);
-   virtual ~TGeoMatrix();
+   ~TGeoMatrix() override;
 
    Bool_t               IsIdentity()    const {return !TestBit(kGeoGenTrans);}
    Bool_t               IsTranslation() const {return TestBit(kGeoTranslation);}
@@ -92,7 +92,7 @@ public :
    virtual void         MasterToLocalVect(const Double_t *master, Double_t *local) const;
    virtual void         MasterToLocalBomb(const Double_t *master, Double_t *local) const;
    static void          Normalize(Double_t *vect);
-   void                 Print(Option_t *option="") const; // *MENU*
+   void                 Print(Option_t *option="") const override; // *MENU*
    virtual void         RotateX(Double_t) {}
    virtual void         RotateY(Double_t) {}
    virtual void         RotateZ(Double_t) {}
@@ -106,7 +106,7 @@ public :
    virtual void         SetDz(Double_t) {}
    void                 SetShared(Bool_t flag=kTRUE) {SetBit(kGeoShared, flag);}
 
-   ClassDef(TGeoMatrix, 1)                 // base geometrical transformation class
+   ClassDefOverride(TGeoMatrix, 1)                 // base geometrical transformation class
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -128,7 +128,7 @@ public :
    TGeoTranslation(const TGeoMatrix &other);
    TGeoTranslation(Double_t dx, Double_t dy, Double_t dz);
    TGeoTranslation(const char *name, Double_t dx, Double_t dy, Double_t dz);
-   virtual ~TGeoTranslation() {}
+   ~TGeoTranslation() override {}
 
    TGeoTranslation &operator  =(const TGeoTranslation &other) {return TGeoTranslation::operator=((TGeoMatrix&)other);}
    TGeoTranslation &operator  =(const TGeoMatrix &matrix);
@@ -138,30 +138,30 @@ public :
    Bool_t           operator ==(const TGeoTranslation &other) const;
 
    void                 Add(const TGeoTranslation *other);
-   TGeoHMatrix          Inverse() const;
-   virtual void         LocalToMaster(const Double_t *local, Double_t *master) const;
-   virtual void         LocalToMasterVect(const Double_t *local, Double_t *master) const;
-   virtual void         LocalToMasterBomb(const Double_t *local, Double_t *master) const;
-   virtual TGeoMatrix  *MakeClone() const;
-   virtual void         MasterToLocal(const Double_t *master, Double_t *local) const;
-   virtual void         MasterToLocalVect(const Double_t *master, Double_t *local) const;
-   virtual void         MasterToLocalBomb(const Double_t *master, Double_t *local) const;
-   virtual void         RotateX(Double_t angle);
-   virtual void         RotateY(Double_t angle);
-   virtual void         RotateZ(Double_t angle);
-   virtual void         SavePrimitive(std::ostream &out, Option_t *option = "");
+   TGeoHMatrix          Inverse() const override;
+   void         LocalToMaster(const Double_t *local, Double_t *master) const override;
+   void         LocalToMasterVect(const Double_t *local, Double_t *master) const override;
+   void         LocalToMasterBomb(const Double_t *local, Double_t *master) const override;
+   TGeoMatrix  *MakeClone() const override;
+   void         MasterToLocal(const Double_t *master, Double_t *local) const override;
+   void         MasterToLocalVect(const Double_t *master, Double_t *local) const override;
+   void         MasterToLocalBomb(const Double_t *master, Double_t *local) const override;
+   void         RotateX(Double_t angle) override;
+   void         RotateY(Double_t angle) override;
+   void         RotateZ(Double_t angle) override;
+   void         SavePrimitive(std::ostream &out, Option_t *option = "") override;
    void                 Subtract(const TGeoTranslation *other);
    void                 SetTranslation(Double_t dx, Double_t dy, Double_t dz);
    void                 SetTranslation(const TGeoMatrix &other);
-   virtual void         SetDx(Double_t dx) {SetTranslation(dx, fTranslation[1], fTranslation[2]);}
-   virtual void         SetDy(Double_t dy) {SetTranslation(fTranslation[0], dy, fTranslation[2]);}
-   virtual void         SetDz(Double_t dz) {SetTranslation(fTranslation[0], fTranslation[1], dz);}
+   void         SetDx(Double_t dx) override {SetTranslation(dx, fTranslation[1], fTranslation[2]);}
+   void         SetDy(Double_t dy) override {SetTranslation(fTranslation[0], dy, fTranslation[2]);}
+   void         SetDz(Double_t dz) override {SetTranslation(fTranslation[0], fTranslation[1], dz);}
 
-   virtual const Double_t    *GetTranslation() const {return &fTranslation[0];}
-   virtual const Double_t    *GetRotationMatrix() const {return &kIdentityMatrix[0];}
-   virtual const Double_t    *GetScale()       const {return &kUnitScale[0];}
+   const Double_t    *GetTranslation() const override {return &fTranslation[0];}
+   const Double_t    *GetRotationMatrix() const override {return &kIdentityMatrix[0];}
+   const Double_t    *GetScale()       const override {return &kUnitScale[0];}
 
-   ClassDef(TGeoTranslation, 1)                 // translation class
+   ClassDefOverride(TGeoTranslation, 1)                 // translation class
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -186,7 +186,7 @@ public :
    TGeoRotation(const char *name, Double_t phi, Double_t theta, Double_t psi);
    TGeoRotation(const char *name, Double_t theta1, Double_t phi1, Double_t theta2, Double_t phi2,
                 Double_t theta3, Double_t phi3);
-   virtual ~TGeoRotation() {}
+   ~TGeoRotation() override {}
 
    TGeoRotation &operator  =(const TGeoRotation &other) {return TGeoRotation::operator=((TGeoMatrix&)other);}
    TGeoRotation &operator  =(const TGeoMatrix &other);
@@ -196,29 +196,29 @@ public :
    Bool_t        operator ==(const TGeoRotation &other) const;
 
    Bool_t               IsValid() const;
-   TGeoHMatrix          Inverse() const;
-   void                 Clear(Option_t *option ="");
+   TGeoHMatrix          Inverse() const override;
+   void                 Clear(Option_t *option ="") override;
    Double_t             Determinant() const;
    void                 FastRotZ(const Double_t *sincos);
    void                 GetAngles(Double_t &theta1, Double_t &phi1, Double_t &theta2, Double_t &phi2,
                                   Double_t &theta3, Double_t &phi3) const;
    void                 GetAngles(Double_t &phi, Double_t &theta, Double_t &psi) const;
    Double_t             GetPhiRotation(Bool_t fixX=kFALSE) const;
-   virtual void         LocalToMaster(const Double_t *local, Double_t *master) const;
-   virtual void         LocalToMasterVect(const Double_t *local, Double_t *master) const {TGeoRotation::LocalToMaster(local, master);}
-   virtual void         LocalToMasterBomb(const Double_t *local, Double_t *master) const {TGeoRotation::LocalToMaster(local, master);}
-   virtual TGeoMatrix  *MakeClone() const;
-   virtual void         MasterToLocal(const Double_t *master, Double_t *local) const;
-   virtual void         MasterToLocalVect(const Double_t *master, Double_t *local) const {TGeoRotation::MasterToLocal(master, local);}
-   virtual void         MasterToLocalBomb(const Double_t *master, Double_t *local) const {TGeoRotation::MasterToLocal(master, local);}
+   void         LocalToMaster(const Double_t *local, Double_t *master) const override;
+   void         LocalToMasterVect(const Double_t *local, Double_t *master) const override {TGeoRotation::LocalToMaster(local, master);}
+   void         LocalToMasterBomb(const Double_t *local, Double_t *master) const override {TGeoRotation::LocalToMaster(local, master);}
+   TGeoMatrix  *MakeClone() const override;
+   void         MasterToLocal(const Double_t *master, Double_t *local) const override;
+   void         MasterToLocalVect(const Double_t *master, Double_t *local) const override {TGeoRotation::MasterToLocal(master, local);}
+   void         MasterToLocalBomb(const Double_t *master, Double_t *local) const override {TGeoRotation::MasterToLocal(master, local);}
    void                 MultiplyBy(const TGeoRotation *rot, Bool_t after=kTRUE);
-   virtual void         RotateX(Double_t angle);
-   virtual void         RotateY(Double_t angle);
-   virtual void         RotateZ(Double_t angle);
-   virtual void         SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void         ReflectX(Bool_t leftside, Bool_t rotonly=kFALSE);
-   virtual void         ReflectY(Bool_t leftside, Bool_t rotonly=kFALSE);
-   virtual void         ReflectZ(Bool_t leftside, Bool_t rotonly=kFALSE);
+   void         RotateX(Double_t angle) override;
+   void         RotateY(Double_t angle) override;
+   void         RotateZ(Double_t angle) override;
+   void         SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void         ReflectX(Bool_t leftside, Bool_t rotonly=kFALSE) override;
+   void         ReflectY(Bool_t leftside, Bool_t rotonly=kFALSE) override;
+   void         ReflectZ(Bool_t leftside, Bool_t rotonly=kFALSE) override;
    void                 SetAngles(Double_t phi, Double_t theta, Double_t psi);
    void                 SetAngles(Double_t theta1, Double_t phi1, Double_t theta2, Double_t phi2,
                                   Double_t theta3, Double_t phi3);
@@ -226,11 +226,11 @@ public :
    void                 SetRotation(const TGeoMatrix &other);
    void                 GetInverse(Double_t *invmat) const;
 
-   virtual const Double_t    *GetTranslation()    const {return &kNullVector[0];}
-   virtual const Double_t    *GetRotationMatrix() const {return &fRotationMatrix[0];}
-   virtual const Double_t    *GetScale()          const {return &kUnitScale[0];}
+   const Double_t    *GetTranslation()    const override {return &kNullVector[0];}
+   const Double_t    *GetRotationMatrix() const override {return &fRotationMatrix[0];}
+   const Double_t    *GetScale()          const override {return &kUnitScale[0];}
 
-   ClassDef(TGeoRotation, 1)               // rotation class
+   ClassDefOverride(TGeoRotation, 1)               // rotation class
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -251,7 +251,7 @@ public :
    TGeoScale(const TGeoMatrix &other);
    TGeoScale(Double_t sx, Double_t sy, Double_t sz);
    TGeoScale(const char *name, Double_t sx, Double_t sy, Double_t sz);
-   virtual ~TGeoScale();
+   ~TGeoScale() override;
 
    TGeoScale  &operator  =(const TGeoScale &other) {return TGeoScale::operator=((TGeoMatrix&)other);}
    TGeoScale  &operator  =(const TGeoMatrix &other);
@@ -260,25 +260,25 @@ public :
    TGeoHMatrix operator  *(const TGeoMatrix &right) const;
    Bool_t      operator ==(const TGeoScale &other) const;
 
-   TGeoHMatrix          Inverse() const;
+   TGeoHMatrix          Inverse() const override;
    void                 SetScale(Double_t sx, Double_t sy, Double_t sz);
    void                 SetScale(const TGeoMatrix &other);
-   virtual void         LocalToMaster(const Double_t *local, Double_t *master) const;
+   void         LocalToMaster(const Double_t *local, Double_t *master) const override;
    Double_t             LocalToMaster(Double_t dist, const Double_t *dir=nullptr) const;
-   virtual void         LocalToMasterVect(const Double_t *local, Double_t *master) const {TGeoScale::LocalToMaster(local, master);}
-   virtual TGeoMatrix  *MakeClone() const;
-   virtual void         MasterToLocal(const Double_t *master, Double_t *local) const;
+   void         LocalToMasterVect(const Double_t *local, Double_t *master) const override {TGeoScale::LocalToMaster(local, master);}
+   TGeoMatrix  *MakeClone() const override;
+   void         MasterToLocal(const Double_t *master, Double_t *local) const override;
    Double_t             MasterToLocal(Double_t dist, const Double_t *dir=nullptr) const;
-   virtual void         MasterToLocalVect(const Double_t *master, Double_t *local) const {TGeoScale::MasterToLocal(master, local);}
-   virtual void         ReflectX(Bool_t, Bool_t) {fScale[0]=-fScale[0]; SetBit(kGeoReflection, !IsReflection());}
-   virtual void         ReflectY(Bool_t, Bool_t) {fScale[1]=-fScale[1]; SetBit(kGeoReflection, !IsReflection());}
-   virtual void         ReflectZ(Bool_t, Bool_t) {fScale[2]=-fScale[2]; SetBit(kGeoReflection, !IsReflection());}
+   void         MasterToLocalVect(const Double_t *master, Double_t *local) const override {TGeoScale::MasterToLocal(master, local);}
+   void         ReflectX(Bool_t, Bool_t) override {fScale[0]=-fScale[0]; SetBit(kGeoReflection, !IsReflection());}
+   void         ReflectY(Bool_t, Bool_t) override {fScale[1]=-fScale[1]; SetBit(kGeoReflection, !IsReflection());}
+   void         ReflectZ(Bool_t, Bool_t) override {fScale[2]=-fScale[2]; SetBit(kGeoReflection, !IsReflection());}
 
-   virtual const Double_t    *GetTranslation()    const {return &kNullVector[0];}
-   virtual const Double_t    *GetRotationMatrix() const {return &kIdentityMatrix[0];}
-   virtual const Double_t    *GetScale()          const {return &fScale[0];}
+   const Double_t    *GetTranslation()    const override {return &kNullVector[0];}
+   const Double_t    *GetRotationMatrix() const override {return &kIdentityMatrix[0];}
+   const Double_t    *GetScale()          const override {return &fScale[0];}
 
-   ClassDef(TGeoScale, 1)                 // scaling class
+   ClassDefOverride(TGeoScale, 1)                 // scaling class
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -308,23 +308,23 @@ public :
    TGeoCombiTrans  operator  *(const TGeoMatrix &other) const;
    Bool_t          operator ==(const TGeoMatrix &other) const;
 
-   virtual ~TGeoCombiTrans();
+   ~TGeoCombiTrans() override;
 
-   void                 Clear(Option_t *option ="");
-   TGeoHMatrix          Inverse() const;
-   virtual TGeoMatrix  *MakeClone() const;
+   void                 Clear(Option_t *option ="") override;
+   TGeoHMatrix          Inverse() const override;
+   TGeoMatrix  *MakeClone() const override;
    void                 Multiply(const TGeoMatrix *right);
-   virtual void         RegisterYourself();
-   virtual void         RotateX(Double_t angle);
-   virtual void         RotateY(Double_t angle);
-   virtual void         RotateZ(Double_t angle);
-   virtual void         ReflectX(Bool_t leftside, Bool_t rotonly=kFALSE);
-   virtual void         ReflectY(Bool_t leftside, Bool_t rotonly=kFALSE);
-   virtual void         ReflectZ(Bool_t leftside, Bool_t rotonly=kFALSE);
-   virtual void         SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void         SetDx(Double_t dx) {SetTranslation(dx, fTranslation[1], fTranslation[2]);}
-   virtual void         SetDy(Double_t dy) {SetTranslation(fTranslation[0], dy, fTranslation[2]);}
-   virtual void         SetDz(Double_t dz) {SetTranslation(fTranslation[0], fTranslation[1], dz);}
+   void         RegisterYourself() override;
+   void         RotateX(Double_t angle) override;
+   void         RotateY(Double_t angle) override;
+   void         RotateZ(Double_t angle) override;
+   void         ReflectX(Bool_t leftside, Bool_t rotonly=kFALSE) override;
+   void         ReflectY(Bool_t leftside, Bool_t rotonly=kFALSE) override;
+   void         ReflectZ(Bool_t leftside, Bool_t rotonly=kFALSE) override;
+   void         SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void         SetDx(Double_t dx) override {SetTranslation(dx, fTranslation[1], fTranslation[2]);}
+   void         SetDy(Double_t dy) override {SetTranslation(fTranslation[0], dy, fTranslation[2]);}
+   void         SetDz(Double_t dz) override {SetTranslation(fTranslation[0], fTranslation[1], dz);}
    void                 SetTranslation(const TGeoTranslation &tr);
    void                 SetTranslation(Double_t dx, Double_t dy, Double_t dz);
    void                 SetTranslation(Double_t *vect);
@@ -333,11 +333,11 @@ public :
 
    TGeoRotation              *GetRotation() const    {return fRotation;}
 
-   virtual const Double_t    *GetTranslation()    const {return &fTranslation[0];}
-   virtual const Double_t    *GetRotationMatrix() const;
-   virtual const Double_t    *GetScale()          const {return &kUnitScale[0];}
+   const Double_t    *GetTranslation()    const override {return &fTranslation[0];}
+   const Double_t    *GetRotationMatrix() const override;
+   const Double_t    *GetScale()          const override {return &kUnitScale[0];}
 
-   ClassDef(TGeoCombiTrans, 1)            // rotation + translation
+   ClassDefOverride(TGeoCombiTrans, 1)            // rotation + translation
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -358,18 +358,18 @@ public :
                 Double_t sx, Double_t sy, Double_t sz, TGeoRotation *rot);
    TGeoGenTrans(const char *name, Double_t dx, Double_t dy, Double_t dz,
                 Double_t sx, Double_t sy, Double_t sz, TGeoRotation *rot);
-   virtual ~TGeoGenTrans();
+   ~TGeoGenTrans() override;
 
-   void                 Clear(Option_t *option ="");
-   TGeoHMatrix          Inverse() const;
+   void                 Clear(Option_t *option ="") override;
+   TGeoHMatrix          Inverse() const override;
    void                 SetScale(Double_t sx, Double_t sy, Double_t sz);
    void                 SetScale(Double_t *scale) {memcpy(&fScale[0], scale, 3*sizeof(Double_t));}
-   virtual TGeoMatrix  *MakeClone() const {return nullptr;}
+   TGeoMatrix  *MakeClone() const override {return nullptr;}
    Bool_t               Normalize();
 
-   virtual const Double_t    *GetScale()     const {return &fScale[0];}
+   const Double_t    *GetScale()     const override {return &fScale[0];}
 
-   ClassDef(TGeoGenTrans, 1)            // rotation + translation + scale
+   ClassDefOverride(TGeoGenTrans, 1)            // rotation + translation + scale
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -387,23 +387,23 @@ private:
 public :
    TGeoIdentity();
    TGeoIdentity(const char *name);
-   virtual ~TGeoIdentity() {}
+   ~TGeoIdentity() override {}
 
-   TGeoHMatrix          Inverse() const;
-   virtual void         LocalToMaster(const Double_t *local, Double_t *master) const {memcpy(master, local, 3*sizeof(Double_t));}
-   virtual void         LocalToMasterVect(const Double_t *local, Double_t *master) const {memcpy(master, local, 3*sizeof(Double_t));}
-   virtual void         LocalToMasterBomb(const Double_t *local, Double_t *master) const {TGeoIdentity::LocalToMaster(local, master);}
-   virtual TGeoMatrix  *MakeClone() const {return nullptr;}
-   virtual void         MasterToLocal(const Double_t *master, Double_t *local) const {memcpy(local, master, 3*sizeof(Double_t));}
-   virtual void         MasterToLocalVect(const Double_t *master, Double_t *local) const {memcpy(local, master, 3*sizeof(Double_t));}
-   virtual void         MasterToLocalBomb(const Double_t *master, Double_t *local) const {TGeoIdentity::MasterToLocal(master, local);}
+   TGeoHMatrix          Inverse() const override;
+   void         LocalToMaster(const Double_t *local, Double_t *master) const override {memcpy(master, local, 3*sizeof(Double_t));}
+   void         LocalToMasterVect(const Double_t *local, Double_t *master) const override {memcpy(master, local, 3*sizeof(Double_t));}
+   void         LocalToMasterBomb(const Double_t *local, Double_t *master) const override {TGeoIdentity::LocalToMaster(local, master);}
+   TGeoMatrix  *MakeClone() const override {return nullptr;}
+   void         MasterToLocal(const Double_t *master, Double_t *local) const override {memcpy(local, master, 3*sizeof(Double_t));}
+   void         MasterToLocalVect(const Double_t *master, Double_t *local) const override {memcpy(local, master, 3*sizeof(Double_t));}
+   void         MasterToLocalBomb(const Double_t *master, Double_t *local) const override {TGeoIdentity::MasterToLocal(master, local);}
 
-   virtual const Double_t    *GetTranslation() const {return &kNullVector[0];}
-   virtual const Double_t    *GetRotationMatrix() const {return &kIdentityMatrix[0];}
-   virtual const Double_t    *GetScale()       const {return &kUnitScale[0];}
-   virtual void         SavePrimitive(std::ostream &, Option_t * = "") {}
+   const Double_t    *GetTranslation() const override {return &kNullVector[0];}
+   const Double_t    *GetRotationMatrix() const override {return &kIdentityMatrix[0];}
+   const Double_t    *GetScale()       const override {return &kUnitScale[0];}
+   void         SavePrimitive(std::ostream &, Option_t * = "") override {}
 
-   ClassDef(TGeoIdentity, 1)                 // identity transformation class
+   ClassDefOverride(TGeoIdentity, 1)                 // identity transformation class
 };
 
 
@@ -429,7 +429,7 @@ public :
    TGeoHMatrix(const TGeoHMatrix &other) : TGeoHMatrix((TGeoMatrix&)other) {}
    TGeoHMatrix(const TGeoMatrix &matrix);
    TGeoHMatrix(const char *name);
-   virtual ~TGeoHMatrix();
+   ~TGeoHMatrix() override;
 
    TGeoHMatrix& operator  =(const TGeoHMatrix &other) {return TGeoHMatrix::operator=((TGeoMatrix&)other);}
    TGeoHMatrix& operator  =(const TGeoMatrix *other);
@@ -438,40 +438,40 @@ public :
    TGeoHMatrix  operator  *(const TGeoMatrix &other) const;
    Bool_t       operator ==(const TGeoMatrix &other) const;
 
-   void                 Clear(Option_t *option ="");
+   void                 Clear(Option_t *option ="") override;
    void                 CopyFrom(const TGeoMatrix *other);
    Double_t             Determinant() const;
    void                 FastRotZ(const Double_t *sincos);
-   TGeoHMatrix          Inverse() const;
-   virtual TGeoMatrix  *MakeClone() const;
+   TGeoHMatrix          Inverse() const override;
+   TGeoMatrix  *MakeClone() const override;
    void                 Multiply(const TGeoMatrix *right);
    void                 Multiply(const TGeoMatrix &right) {Multiply(&right);}
    void                 MultiplyLeft(const TGeoMatrix *left);
    void                 MultiplyLeft(const TGeoMatrix &left) {MultiplyLeft(&left);}
 
-   virtual void         RotateX(Double_t angle);
-   virtual void         RotateY(Double_t angle);
-   virtual void         RotateZ(Double_t angle);
-   virtual void         ReflectX(Bool_t leftside, Bool_t rotonly=kFALSE);
-   virtual void         ReflectY(Bool_t leftside, Bool_t rotonly=kFALSE);
-   virtual void         ReflectZ(Bool_t leftside, Bool_t rotonly=kFALSE);
-   virtual void         SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void         SetDx(Double_t dx) {fTranslation[0] = dx; SetBit(kGeoTranslation);}
-   virtual void         SetDy(Double_t dy) {fTranslation[1] = dy; SetBit(kGeoTranslation);}
-   virtual void         SetDz(Double_t dz) {fTranslation[2] = dz; SetBit(kGeoTranslation);}
+   void         RotateX(Double_t angle) override;
+   void         RotateY(Double_t angle) override;
+   void         RotateZ(Double_t angle) override;
+   void         ReflectX(Bool_t leftside, Bool_t rotonly=kFALSE) override;
+   void         ReflectY(Bool_t leftside, Bool_t rotonly=kFALSE) override;
+   void         ReflectZ(Bool_t leftside, Bool_t rotonly=kFALSE) override;
+   void         SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void         SetDx(Double_t dx) override {fTranslation[0] = dx; SetBit(kGeoTranslation);}
+   void         SetDy(Double_t dy) override {fTranslation[1] = dy; SetBit(kGeoTranslation);}
+   void         SetDz(Double_t dz) override {fTranslation[2] = dz; SetBit(kGeoTranslation);}
    void                 SetTranslation(const Double_t *vect) {SetBit(kGeoTranslation); memcpy(&fTranslation[0], vect, 3*sizeof(Double_t));}
    void                 SetRotation(const Double_t *matrix) {SetBit(kGeoRotation); memcpy(&fRotationMatrix[0], matrix, 9*sizeof(Double_t));}
    void                 SetScale(const Double_t *scale) {SetBit(kGeoScale); memcpy(&fScale[0], scale, 3*sizeof(Double_t));}
 
 
-   virtual const Double_t    *GetTranslation() const {return &fTranslation[0];}
-   virtual const Double_t    *GetRotationMatrix() const {return &fRotationMatrix[0];}
-   virtual const Double_t    *GetScale() const {return &fScale[0];}
+   const Double_t    *GetTranslation() const override {return &fTranslation[0];}
+   const Double_t    *GetRotationMatrix() const override {return &fRotationMatrix[0];}
+   const Double_t    *GetScale() const override {return &fScale[0];}
 
    virtual Double_t    *GetTranslation() {return &fTranslation[0];}
    virtual Double_t    *GetRotationMatrix() {return &fRotationMatrix[0];}
    virtual Double_t    *GetScale() {return &fScale[0];}
-   ClassDef(TGeoHMatrix, 1)                 // global matrix class
+   ClassDefOverride(TGeoHMatrix, 1)                 // global matrix class
 };
 
 

--- a/geom/geom/inc/TGeoMedium.h
+++ b/geom/geom/inc/TGeoMedium.h
@@ -42,7 +42,7 @@ public:
    TGeoMedium(const char *name, Int_t numed, const TGeoMaterial *mat, Double_t *params=nullptr);
    TGeoMedium(const char *name, Int_t numed, Int_t imat, Int_t isvol, Int_t ifield,
               Double_t fieldm, Double_t tmaxfd, Double_t stemax, Double_t deemax, Double_t epsil, Double_t stmin);
-   virtual ~TGeoMedium();
+   ~TGeoMedium() override;
    // methods
    virtual Int_t            GetByteCount() const {return sizeof(*this);}
    Int_t                    GetId()   const     {return fId;}
@@ -50,11 +50,11 @@ public:
    void                     SetParam(Int_t i, Double_t val)   {fParams[i] = val;}
    const char              *GetPointerName() const;
    TGeoMaterial            *GetMaterial() const {return fMaterial;}
-   virtual void             SavePrimitive(std::ostream &out, Option_t *option = "");
+   void             SavePrimitive(std::ostream &out, Option_t *option = "") override;
    void                     SetId(Int_t id)     {fId = id;}
    void                     SetMaterial(TGeoMaterial *mat) {fMaterial = mat;}
    virtual void             SetCerenkovProperties(TObject* cerenkov) {fMaterial->SetCerenkovProperties(cerenkov);}
-   ClassDef(TGeoMedium, 1)              // tracking medium
+   ClassDefOverride(TGeoMedium, 1)              // tracking medium
 
 };
 

--- a/geom/geom/inc/TGeoNavigator.h
+++ b/geom/geom/inc/TGeoNavigator.h
@@ -87,7 +87,7 @@ private :
 public :
    TGeoNavigator();
    TGeoNavigator(TGeoManager* geom);
-   virtual ~TGeoNavigator();
+   ~TGeoNavigator() override;
 
    void                   BuildCache(Bool_t dummy=kFALSE, Bool_t nodeid=kFALSE);
    Bool_t                 cd(const char *path="");
@@ -201,7 +201,7 @@ public :
    Bool_t                 PopPoint(Int_t index) {fCurrentOverlapping=fCache->PopState(fNmany,index, fPoint); fCurrentNode=fCache->GetNode(); fLevel=fCache->GetLevel(); fGlobalMatrix=fCache->GetCurrentMatrix();return fCurrentOverlapping;}
    void                   PopDummy(Int_t ipop=9999) {fCache->PopDummy(ipop);}
 
-   ClassDef(TGeoNavigator, 0)          // geometry navigator class
+   ClassDefOverride(TGeoNavigator, 0)          // geometry navigator class
 };
 
 #include "TObjArray.h"
@@ -225,13 +225,13 @@ private:
 public:
    TGeoNavigatorArray() : TObjArray(), fCurrentNavigator(nullptr), fGeoManager(nullptr) {}
    TGeoNavigatorArray(TGeoManager *mgr) : TObjArray(), fCurrentNavigator(nullptr), fGeoManager(mgr) {SetOwner();}
-   virtual ~TGeoNavigatorArray() {}
+   ~TGeoNavigatorArray() override {}
 
    TGeoNavigator         *AddNavigator();
    inline TGeoNavigator  *GetCurrentNavigator() const {return fCurrentNavigator;}
    TGeoNavigator         *SetCurrentNavigator(Int_t inav) {return (fCurrentNavigator=(TGeoNavigator*)At(inav));}
 
-   ClassDef(TGeoNavigatorArray, 0)       // An array of navigators
+   ClassDefOverride(TGeoNavigatorArray, 0)       // An array of navigators
 };
 #endif
 

--- a/geom/geom/inc/TGeoNode.h
+++ b/geom/geom/inc/TGeoNode.h
@@ -67,18 +67,18 @@ public:
    TGeoNode();
    TGeoNode(const TGeoVolume *vol);
    // destructor
-   virtual ~TGeoNode();
+   ~TGeoNode() override;
 
-   void              Browse(TBrowser *b);
+   void              Browse(TBrowser *b) override;
    virtual void      cd() const {}
    void              CheckOverlaps(Double_t ovlp=0.1, Option_t *option=""); // *MENU*
    void              CheckShapes();
    Int_t             CountDaughters(Bool_t unique_volumes=kFALSE);
-   virtual Int_t     DistancetoPrimitive(Int_t px, Int_t py);
-   void              Draw(Option_t *option="");
+   Int_t     DistancetoPrimitive(Int_t px, Int_t py) override;
+   void              Draw(Option_t *option="") override;
    void              DrawOnly(Option_t *option="");
    void              DrawOverlaps();
-   virtual void      ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   void      ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
    void              FillIdArray(Int_t &ifree, Int_t &nodeid, Int_t *array) const;
    Int_t             FindNode(const TGeoNode *node, Int_t level);
    virtual Int_t     GetByteCount() const {return 44;}
@@ -95,11 +95,11 @@ public:
    Int_t             GetNumber() const {return fNumber;}
    Int_t            *GetOverlaps(Int_t &novlp) const {novlp=fNovlp; return fOverlaps;}
    TGeoVolume       *GetVolume() const                   {return fVolume;}
-   virtual char     *GetObjectInfo(Int_t px, Int_t py) const;
+   char     *GetObjectInfo(Int_t px, Int_t py) const override;
    virtual Int_t     GetOptimalVoxels() const {return 0;}
    void              InspectNode() const; // *MENU*
    Bool_t            IsCloned() const {return TObject::TestBit(kGeoNodeCloned);}
-   virtual Bool_t    IsFolder() const {return (GetNdaughters()?kTRUE:kFALSE);}
+   Bool_t    IsFolder() const override {return (GetNdaughters()?kTRUE:kFALSE);}
    Bool_t            IsOffset() const {return TObject::TestBit(kGeoNodeOffset);}
    Bool_t            IsOnScreen() const; // *MENU*
    Bool_t            IsOverlapping() const {return TObject::TestBit(kGeoNodeOverlap);}
@@ -117,7 +117,7 @@ public:
    void              SetCloned(Bool_t flag=kTRUE)        {TObject::SetBit(kGeoNodeCloned, flag);}
    void              SetOverlapping(Bool_t flag=kTRUE)   {TObject::SetBit(kGeoNodeOverlap, flag);}
    void              SetVirtual()                        {TObject::SetBit(kGeoNodeVC, kTRUE);}
-   void              SetVisibility(Bool_t vis=kTRUE); // *MENU*
+   void              SetVisibility(Bool_t vis=kTRUE) override; // *MENU*
    void              SetInvisible()                      {SetVisibility(kFALSE);} // *MENU*
    void              SetAllInvisible()                   {VisibleDaughters(kFALSE);} // *MENU*
    void              SetMotherVolume(TGeoVolume *mother) {fMother = mother;}
@@ -134,13 +134,13 @@ public:
    virtual void      LocalToMaster(const Double_t *local, Double_t *master) const;
    virtual void      LocalToMasterVect(const Double_t *local, Double_t *master) const;
 
-   virtual void      ls(Option_t *option = "") const;
-   virtual void      Paint(Option_t *option = "");
+   void      ls(Option_t *option = "") const override;
+   void      Paint(Option_t *option = "") override;
    void              PrintCandidates() const; // *MENU*
    void              PrintOverlaps() const; // *MENU*
    void              VisibleDaughters(Bool_t vis=kTRUE); // *MENU*
 
-   ClassDef(TGeoNode, 2)               // base class for all geometry nodes
+   ClassDefOverride(TGeoNode, 2)               // base class for all geometry nodes
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -162,16 +162,16 @@ public:
    TGeoNodeMatrix();
    TGeoNodeMatrix(const TGeoVolume *vol, const TGeoMatrix *matrix);
    // destructor
-   virtual ~TGeoNodeMatrix();
+   ~TGeoNodeMatrix() override;
 
-   virtual Int_t     GetByteCount() const;
-   virtual Int_t     GetOptimalVoxels() const;
-   virtual Bool_t    IsFolder() const {return kTRUE;}
-   virtual TGeoMatrix *GetMatrix() const   {return fMatrix;}
-   virtual TGeoNode *MakeCopyNode() const;
+   Int_t     GetByteCount() const override;
+   Int_t     GetOptimalVoxels() const override;
+   Bool_t    IsFolder() const override {return kTRUE;}
+   TGeoMatrix *GetMatrix() const override   {return fMatrix;}
+   TGeoNode *MakeCopyNode() const override;
    void              SetMatrix(const TGeoMatrix *matrix);
 
-   ClassDef(TGeoNodeMatrix, 1)               // a geometry node in the general case
+   ClassDefOverride(TGeoNodeMatrix, 1)               // a geometry node in the general case
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -195,17 +195,17 @@ public:
    TGeoNodeOffset();
    TGeoNodeOffset(const TGeoVolume *vol, Int_t index, Double_t offset);
    // destructor
-   virtual ~TGeoNodeOffset();
+   ~TGeoNodeOffset() override;
 
-   virtual void      cd() const           {fFinder->cd(fIndex);}
+   void      cd() const override           {fFinder->cd(fIndex);}
    Double_t          GetOffset() const {return fOffset;}
-   virtual Int_t     GetIndex() const;
-   virtual TGeoPatternFinder *GetFinder() const {return fFinder;}
-   virtual TGeoMatrix *GetMatrix() const {cd(); return fFinder->GetMatrix();}
-   virtual TGeoNode *MakeCopyNode() const;
+   Int_t     GetIndex() const override;
+   TGeoPatternFinder *GetFinder() const override {return fFinder;}
+   TGeoMatrix *GetMatrix() const override {cd(); return fFinder->GetMatrix();}
+   TGeoNode *MakeCopyNode() const override;
    void              SetFinder(TGeoPatternFinder *finder) {fFinder = finder;}
 
-   ClassDef(TGeoNodeOffset, 1)      // a geometry node with just an offset
+   ClassDefOverride(TGeoNodeOffset, 1)      // a geometry node with just an offset
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -227,12 +227,12 @@ private:
    TGeoIteratorPlugin &operator=(const TGeoIteratorPlugin &);
 public:
    TGeoIteratorPlugin() : TObject(),fIterator(nullptr) {}
-   virtual ~TGeoIteratorPlugin() {}
+   ~TGeoIteratorPlugin() override {}
 
    virtual void      ProcessNode() = 0;
    void              SetIterator(const TGeoIterator *iter) {fIterator = iter;}
 
-   ClassDef(TGeoIteratorPlugin, 0)  // ABC for user plugins connecter to a geometry iterator.
+   ClassDefOverride(TGeoIteratorPlugin, 0)  // ABC for user plugins connecter to a geometry iterator.
 };
 
 ////////////////////////////////////////////////////////////////////////////

--- a/geom/geom/inc/TGeoOpticalSurface.h
+++ b/geom/geom/inc/TGeoOpticalSurface.h
@@ -115,7 +115,7 @@ public:
    TGeoOpticalSurface(const char *name, ESurfaceModel model = kMglisur, ESurfaceFinish finish = kFpolished,
                       ESurfaceType type = kTdielectric_dielectric, Double_t value = 1.0);
 
-   virtual ~TGeoOpticalSurface() {}
+   ~TGeoOpticalSurface() override {}
 
    // Accessors
    bool AddProperty(const char *property, const char *ref);
@@ -138,7 +138,7 @@ public:
    void SetValue(Double_t value) { fValue = value; }
    void SetSigmaAlpha(Double_t sigmaalpha) { fSigmaAlpha = sigmaalpha; }
 
-   void Print(Option_t *option = "") const;
+   void Print(Option_t *option = "") const override;
 
    static ESurfaceType StringToType(const char *type);
    static const char *TypeToString(ESurfaceType type);
@@ -147,7 +147,7 @@ public:
    static ESurfaceFinish StringToFinish(const char *finish);
    static const char *FinishToString(ESurfaceFinish finish);
 
-   ClassDef(TGeoOpticalSurface, 1) // Class representing an optical surface
+   ClassDefOverride(TGeoOpticalSurface, 1) // Class representing an optical surface
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -169,14 +169,14 @@ public:
       : TNamed(name, ref), fSurface(surf), fVolume(vol)
    {
    }
-   virtual ~TGeoSkinSurface() {}
+   ~TGeoSkinSurface() override {}
 
    TGeoOpticalSurface const *GetSurface() const { return fSurface; }
    TGeoVolume const *GetVolume() const { return fVolume; }
 
-   void Print(Option_t *option = "") const;
+   void Print(Option_t *option = "") const override;
 
-   ClassDef(TGeoSkinSurface, 1) // A surface with optical properties surrounding a volume
+   ClassDefOverride(TGeoSkinSurface, 1) // A surface with optical properties surrounding a volume
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -200,15 +200,15 @@ public:
       : TNamed(name, ref), fSurface(surf), fNode1(node1), fNode2(node2)
    {
    }
-   virtual ~TGeoBorderSurface() {}
+   ~TGeoBorderSurface() override {}
 
    TGeoOpticalSurface const *GetSurface() const { return fSurface; }
    TGeoNode const *GetNode1() const { return fNode1; }
    TGeoNode const *GetNode2() const { return fNode2; }
 
-   void Print(Option_t *option = "") const;
+   void Print(Option_t *option = "") const override;
 
-   ClassDef(TGeoBorderSurface, 1) // A surface with optical properties betwqeen 2 touching volumes
+   ClassDefOverride(TGeoBorderSurface, 1) // A surface with optical properties betwqeen 2 touching volumes
 };
 
 #endif // ROOT_TGeoOpticalSurface

--- a/geom/geom/inc/TGeoPara.h
+++ b/geom/geom/inc/TGeoPara.h
@@ -39,28 +39,28 @@ public:
    TGeoPara(const char *name, Double_t dx, Double_t dy, Double_t dz, Double_t alpha, Double_t theta, Double_t phi);
    TGeoPara(Double_t *param);
    // destructor
-   virtual ~TGeoPara();
+   ~TGeoPara() override;
    // methods
-   virtual Double_t      Capacity() const;
-   virtual void          ComputeBBox();
-   virtual void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm);
-   virtual void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize);
-   virtual Bool_t        Contains(const Double_t *point) const;
-   virtual void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const;
-   virtual Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
-                                Double_t start, Double_t step);
-   virtual Double_t      GetAxisRange(Int_t iaxis, Double_t &xlo, Double_t &xhi) const;
-   virtual void          GetBoundingCylinder(Double_t *param) const;
-   virtual Int_t         GetByteCount() const {return 48;}
-   virtual Int_t         GetFittingBox(const TGeoBBox *parambox, TGeoMatrix *mat, Double_t &dx, Double_t &dy, Double_t &dz) const;
-   virtual TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const;
-   virtual Int_t         GetNmeshVertices() const {return 8;}
+   Double_t      Capacity() const override;
+   void          ComputeBBox() override;
+   void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
+   Bool_t        Contains(const Double_t *point) const override;
+   void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;
+   Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
+                                Double_t start, Double_t step) override;
+   Double_t      GetAxisRange(Int_t iaxis, Double_t &xlo, Double_t &xhi) const override;
+   void          GetBoundingCylinder(Double_t *param) const override;
+   Int_t         GetByteCount() const override {return 48;}
+   Int_t         GetFittingBox(const TGeoBBox *parambox, TGeoMatrix *mat, Double_t &dx, Double_t &dy, Double_t &dz) const override;
+   TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const override;
+   Int_t         GetNmeshVertices() const override {return 8;}
    Double_t              GetX() const  {return fX;}
    Double_t              GetY() const  {return fY;}
    Double_t              GetZ() const  {return fZ;}
@@ -70,17 +70,17 @@ public:
    Double_t              GetTxy() const {return fTxy;}
    Double_t              GetTxz() const {return fTxz;}
    Double_t              GetTyz() const {return fTyz;}
-   virtual void          InspectShape() const;
-   virtual Bool_t        IsCylType() const {return kFALSE;}
-   virtual Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const;
-   virtual void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const;
-   virtual void          SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void          SetDimensions(Double_t *param);
-   virtual void          SetPoints(Double_t *points) const;
-   virtual void          SetPoints(Float_t *points) const;
-   virtual void          Sizeof3D() const;
+   void          InspectShape() const override;
+   Bool_t        IsCylType() const override {return kFALSE;}
+   Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const override;
+   void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const override;
+   void          SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void          SetDimensions(Double_t *param) override;
+   void          SetPoints(Double_t *points) const override;
+   void          SetPoints(Float_t *points) const override;
+   void          Sizeof3D() const override;
 
-   ClassDef(TGeoPara, 1)         // box primitive
+   ClassDefOverride(TGeoPara, 1)         // box primitive
 };
 
 #endif

--- a/geom/geom/inc/TGeoParaboloid.h
+++ b/geom/geom/inc/TGeoParaboloid.h
@@ -33,48 +33,48 @@ public:
    TGeoParaboloid(const char *name, Double_t rlo, Double_t rhi, Double_t dz);
    TGeoParaboloid(Double_t *params);
    // destructor
-   virtual ~TGeoParaboloid();
+   ~TGeoParaboloid() override;
    // methods
-   virtual Double_t      Capacity() const;
-   virtual void          ComputeBBox();
-   virtual void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm);
-   virtual void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize);
-   virtual Bool_t        Contains(const Double_t *point) const;
-   virtual void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const;
-   virtual Int_t         DistancetoPrimitive(Int_t px, Int_t py);
+   Double_t      Capacity() const override;
+   void          ComputeBBox() override;
+   void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
+   Bool_t        Contains(const Double_t *point) const override;
+   void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;
+   Int_t         DistancetoPrimitive(Int_t px, Int_t py) override;
    Double_t              DistToParaboloid(const Double_t *point, const Double_t *dir, Bool_t in) const;
-   virtual Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
-                                Double_t start, Double_t step);
-   virtual const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const;
+   Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
+                                Double_t start, Double_t step) override;
+   const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const override;
    Double_t              GetRlo() const    {return fRlo;}
    Double_t              GetRhi() const    {return fRhi;}
    Double_t              GetDz() const     {return fDz;}
 
-   virtual void          GetBoundingCylinder(Double_t *param) const;
-   virtual TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const;
-   virtual void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const;
-   virtual Int_t         GetNmeshVertices() const;
-   virtual Bool_t        GetPointsOnSegments(Int_t /*npoints*/, Double_t * /*array*/) const {return kFALSE;}
-   virtual void          InspectShape() const;
-   virtual Bool_t        IsCylType() const {return kTRUE;}
-   virtual TBuffer3D    *MakeBuffer3D() const;
-   virtual Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const;
-   virtual void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const;
-   virtual void          SavePrimitive(std::ostream &out, Option_t *option = "");
+   void          GetBoundingCylinder(Double_t *param) const override;
+   TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const override;
+   void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const override;
+   Int_t         GetNmeshVertices() const override;
+   Bool_t        GetPointsOnSegments(Int_t /*npoints*/, Double_t * /*array*/) const override {return kFALSE;}
+   void          InspectShape() const override;
+   Bool_t        IsCylType() const override {return kTRUE;}
+   TBuffer3D    *MakeBuffer3D() const override;
+   Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const override;
+   void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const override;
+   void          SavePrimitive(std::ostream &out, Option_t *option = "") override;
    void                  SetParaboloidDimensions(Double_t rlo, Double_t rhi, Double_t dz);
-   virtual void          SetDimensions(Double_t *param);
-   virtual void          SetPoints(Double_t *points) const;
-   virtual void          SetPoints(Float_t *points) const;
-   virtual void          SetSegsAndPols(TBuffer3D &buff) const;
-   virtual void          Sizeof3D() const;
+   void          SetDimensions(Double_t *param) override;
+   void          SetPoints(Double_t *points) const override;
+   void          SetPoints(Float_t *points) const override;
+   void          SetSegsAndPols(TBuffer3D &buff) const override;
+   void          Sizeof3D() const override;
 
-   ClassDef(TGeoParaboloid, 1)         // paraboloid class
+   ClassDefOverride(TGeoParaboloid, 1)         // paraboloid class
 
 };
 

--- a/geom/geom/inc/TGeoParallelWorld.h
+++ b/geom/geom/inc/TGeoParallelWorld.h
@@ -38,7 +38,7 @@ public:
    TGeoParallelWorld(const char *name, TGeoManager *mgr);
 
    // destructor
-   virtual ~TGeoParallelWorld();
+   ~TGeoParallelWorld() override;
    // API for adding components nodes
    void              AddNode(const char *path);
    // Activate/deactivate  overlap usage
@@ -68,9 +68,9 @@ public:
 
    // Utilities
    void              CheckOverlaps(Double_t ovlp=0.001); // default 10 microns
-   void              Draw(Option_t *option);
+   void              Draw(Option_t *option) override;
 
-   ClassDef(TGeoParallelWorld, 3)     // parallel world base class
+   ClassDefOverride(TGeoParallelWorld, 3)     // parallel world base class
 };
 
 #endif

--- a/geom/geom/inc/TGeoPatternFinder.h
+++ b/geom/geom/inc/TGeoPatternFinder.h
@@ -72,7 +72,7 @@ public:
    TGeoPatternFinder();
    TGeoPatternFinder(TGeoVolume *vol, Int_t ndiv);
    // destructor
-   virtual ~TGeoPatternFinder();
+   ~TGeoPatternFinder() override;
    // methods
    virtual TGeoMatrix* CreateMatrix() const = 0;
    virtual void        cd(Int_t /*idiv*/) {}
@@ -103,7 +103,7 @@ public:
    void                SetVolume(TGeoVolume *vol) {fVolume = vol;}
    virtual void        UpdateMatrix(Int_t , TGeoHMatrix &) const {}
 
-   ClassDef(TGeoPatternFinder, 4)              // patterns to divide volumes
+   ClassDefOverride(TGeoPatternFinder, 4)              // patterns to divide volumes
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -126,20 +126,20 @@ public:
    TGeoPatternX& operator=(const TGeoPatternX&);
 
    // destructor
-   virtual ~TGeoPatternX();
+   ~TGeoPatternX() override;
    // methods
-   virtual TGeoMatrix* CreateMatrix() const;
-   virtual void        cd(Int_t idiv);
-   virtual TGeoNode   *FindNode(Double_t *point, const Double_t *dir=nullptr);
+   TGeoMatrix* CreateMatrix() const override;
+   void        cd(Int_t idiv) override;
+   TGeoNode   *FindNode(Double_t *point, const Double_t *dir=nullptr) override;
    virtual Double_t    FindNextBoundary(Double_t *point, Double_t *dir, Int_t &indnext);
-   virtual Int_t       GetDivAxis()      {return 1;}
-   virtual Bool_t      IsOnBoundary(const Double_t *point) const;
-   virtual
-   TGeoPatternFinder  *MakeCopy(Bool_t reflect=kFALSE);
-   virtual void        SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void        UpdateMatrix(Int_t idiv, TGeoHMatrix &matrix) const;
+   Int_t       GetDivAxis() override      {return 1;}
+   Bool_t      IsOnBoundary(const Double_t *point) const override;
+   
+   TGeoPatternFinder  *MakeCopy(Bool_t reflect=kFALSE) override;
+   void        SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void        UpdateMatrix(Int_t idiv, TGeoHMatrix &matrix) const override;
 
-   ClassDef(TGeoPatternX, 1)              // X division pattern
+   ClassDefOverride(TGeoPatternX, 1)              // X division pattern
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -159,20 +159,20 @@ public:
    TGeoPatternY(const TGeoPatternY &pf);
    TGeoPatternY& operator=(const TGeoPatternY&);
    // destructor
-   virtual ~TGeoPatternY();
+   ~TGeoPatternY() override;
    // methods
-   virtual TGeoMatrix* CreateMatrix() const;
-   virtual void        cd(Int_t idiv);
-   virtual TGeoNode   *FindNode(Double_t *point, const Double_t *dir=nullptr);
+   TGeoMatrix* CreateMatrix() const override;
+   void        cd(Int_t idiv) override;
+   TGeoNode   *FindNode(Double_t *point, const Double_t *dir=nullptr) override;
    virtual Double_t    FindNextBoundary(Double_t *point, Double_t *dir, Int_t &indnext);
-   virtual Int_t       GetDivAxis()      {return 2;}
-   virtual Bool_t      IsOnBoundary(const Double_t *point) const;
-   virtual
-   TGeoPatternFinder  *MakeCopy(Bool_t reflect=kFALSE);
-   virtual void        SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void        UpdateMatrix(Int_t idiv, TGeoHMatrix &matrix) const;
+   Int_t       GetDivAxis() override      {return 2;}
+   Bool_t      IsOnBoundary(const Double_t *point) const override;
+   
+   TGeoPatternFinder  *MakeCopy(Bool_t reflect=kFALSE) override;
+   void        SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void        UpdateMatrix(Int_t idiv, TGeoHMatrix &matrix) const override;
 
-   ClassDef(TGeoPatternY, 1)              // Y division pattern
+   ClassDefOverride(TGeoPatternY, 1)              // Y division pattern
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -192,20 +192,20 @@ public:
    TGeoPatternZ(const TGeoPatternZ &pf);
    TGeoPatternZ& operator=(const TGeoPatternZ&);
    // destructor
-   virtual ~TGeoPatternZ();
+   ~TGeoPatternZ() override;
    // methods
-   virtual TGeoMatrix* CreateMatrix() const;
-   virtual void        cd(Int_t idiv);
-   virtual TGeoNode   *FindNode(Double_t *point, const Double_t *dir=nullptr);
+   TGeoMatrix* CreateMatrix() const override;
+   void        cd(Int_t idiv) override;
+   TGeoNode   *FindNode(Double_t *point, const Double_t *dir=nullptr) override;
    virtual Double_t    FindNextBoundary(Double_t *point, Double_t *dir, Int_t &indnext);
-   virtual Int_t       GetDivAxis()      {return 3;}
-   virtual Bool_t      IsOnBoundary(const Double_t *point) const;
-   virtual
-   TGeoPatternFinder  *MakeCopy(Bool_t reflect=kFALSE);
-   virtual void        SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void        UpdateMatrix(Int_t idiv, TGeoHMatrix &matrix) const;
+   Int_t       GetDivAxis() override      {return 3;}
+   Bool_t      IsOnBoundary(const Double_t *point) const override;
+   
+   TGeoPatternFinder  *MakeCopy(Bool_t reflect=kFALSE) override;
+   void        SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void        UpdateMatrix(Int_t idiv, TGeoHMatrix &matrix) const override;
 
-   ClassDef(TGeoPatternZ, 1)              // Z division pattern
+   ClassDefOverride(TGeoPatternZ, 1)              // Z division pattern
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -226,19 +226,19 @@ public:
    TGeoPatternParaX& operator=(const TGeoPatternParaX&);
 
    // destructor
-   virtual ~TGeoPatternParaX();
+   ~TGeoPatternParaX() override;
    // methods
-   virtual TGeoMatrix* CreateMatrix() const;
-   virtual void        cd(Int_t idiv);
-   virtual TGeoNode   *FindNode(Double_t *point, const Double_t *dir=nullptr);
-   virtual Int_t       GetDivAxis()      {return 1;}
-   virtual Bool_t      IsOnBoundary(const Double_t *point) const;
-   virtual
-   TGeoPatternFinder  *MakeCopy(Bool_t reflect=kFALSE);
-   virtual void        SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void        UpdateMatrix(Int_t idiv, TGeoHMatrix &matrix) const;
+   TGeoMatrix* CreateMatrix() const override;
+   void        cd(Int_t idiv) override;
+   TGeoNode   *FindNode(Double_t *point, const Double_t *dir=nullptr) override;
+   Int_t       GetDivAxis() override      {return 1;}
+   Bool_t      IsOnBoundary(const Double_t *point) const override;
+   
+   TGeoPatternFinder  *MakeCopy(Bool_t reflect=kFALSE) override;
+   void        SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void        UpdateMatrix(Int_t idiv, TGeoHMatrix &matrix) const override;
 
-   ClassDef(TGeoPatternParaX, 1)              // Para X division pattern
+   ClassDefOverride(TGeoPatternParaX, 1)              // Para X division pattern
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -262,19 +262,19 @@ public:
    TGeoPatternParaY& operator=(const TGeoPatternParaY&);
 
    // destructor
-   virtual ~TGeoPatternParaY();
+   ~TGeoPatternParaY() override;
    // methods
-   virtual TGeoMatrix* CreateMatrix() const;
-   virtual void        cd(Int_t idiv);
-   virtual TGeoNode   *FindNode(Double_t *point, const Double_t *dir=nullptr);
-   virtual Int_t       GetDivAxis()      {return 2;}
-   virtual Bool_t      IsOnBoundary(const Double_t *point) const;
-   virtual
-   TGeoPatternFinder  *MakeCopy(Bool_t reflect=kFALSE);
-   virtual void        SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void        UpdateMatrix(Int_t idiv, TGeoHMatrix &matrix) const;
+   TGeoMatrix* CreateMatrix() const override;
+   void        cd(Int_t idiv) override;
+   TGeoNode   *FindNode(Double_t *point, const Double_t *dir=nullptr) override;
+   Int_t       GetDivAxis() override      {return 2;}
+   Bool_t      IsOnBoundary(const Double_t *point) const override;
+   
+   TGeoPatternFinder  *MakeCopy(Bool_t reflect=kFALSE) override;
+   void        SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void        UpdateMatrix(Int_t idiv, TGeoHMatrix &matrix) const override;
 
-   ClassDef(TGeoPatternParaY, 1)              // Para Y division pattern
+   ClassDefOverride(TGeoPatternParaY, 1)              // Para Y division pattern
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -299,19 +299,19 @@ public:
    TGeoPatternParaZ& operator=(const TGeoPatternParaZ&);
 
    // destructor
-   virtual ~TGeoPatternParaZ();
+   ~TGeoPatternParaZ() override;
    // methods
-   virtual TGeoMatrix* CreateMatrix() const;
-   virtual void        cd(Int_t idiv);
-   virtual TGeoNode   *FindNode(Double_t *point, const Double_t *dir=nullptr);
-   virtual Int_t       GetDivAxis()      {return 3;}
-   virtual Bool_t      IsOnBoundary(const Double_t *point) const;
-   virtual
-   TGeoPatternFinder  *MakeCopy(Bool_t reflect=kFALSE);
-   virtual void        SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void        UpdateMatrix(Int_t idiv, TGeoHMatrix &matrix) const;
+   TGeoMatrix* CreateMatrix() const override;
+   void        cd(Int_t idiv) override;
+   TGeoNode   *FindNode(Double_t *point, const Double_t *dir=nullptr) override;
+   Int_t       GetDivAxis() override      {return 3;}
+   Bool_t      IsOnBoundary(const Double_t *point) const override;
+   
+   TGeoPatternFinder  *MakeCopy(Bool_t reflect=kFALSE) override;
+   void        SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void        UpdateMatrix(Int_t idiv, TGeoHMatrix &matrix) const override;
 
-   ClassDef(TGeoPatternParaZ, 1)              // Para Z division pattern
+   ClassDefOverride(TGeoPatternParaZ, 1)              // Para Z division pattern
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -336,21 +336,21 @@ public:
    TGeoPatternTrapZ& operator=(const TGeoPatternTrapZ&);
 
    // destructor
-   virtual ~TGeoPatternTrapZ();
+   ~TGeoPatternTrapZ() override;
    // methods
-   virtual TGeoMatrix* CreateMatrix() const;
+   TGeoMatrix* CreateMatrix() const override;
    Double_t            GetTxz() const {return fTxz;}
    Double_t            GetTyz() const {return fTyz;}
-   virtual void        cd(Int_t idiv);
-   virtual TGeoNode   *FindNode(Double_t *point, const Double_t *dir=nullptr);
-   virtual Int_t       GetDivAxis()      {return 3;}
-   virtual Bool_t      IsOnBoundary(const Double_t *point) const;
-   virtual
-   TGeoPatternFinder  *MakeCopy(Bool_t reflect=kFALSE);
-   virtual void        SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void        UpdateMatrix(Int_t idiv, TGeoHMatrix &matrix) const;
+   void        cd(Int_t idiv) override;
+   TGeoNode   *FindNode(Double_t *point, const Double_t *dir=nullptr) override;
+   Int_t       GetDivAxis() override      {return 3;}
+   Bool_t      IsOnBoundary(const Double_t *point) const override;
+   
+   TGeoPatternFinder  *MakeCopy(Bool_t reflect=kFALSE) override;
+   void        SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void        UpdateMatrix(Int_t idiv, TGeoHMatrix &matrix) const override;
 
-   ClassDef(TGeoPatternTrapZ, 1)              // Trap od Gtra Z division pattern
+   ClassDefOverride(TGeoPatternTrapZ, 1)              // Trap od Gtra Z division pattern
 };
 
 
@@ -371,19 +371,19 @@ public:
    TGeoPatternCylR(const TGeoPatternCylR &pf);
    TGeoPatternCylR& operator=(const TGeoPatternCylR&);
    // destructor
-   virtual ~TGeoPatternCylR();
+   ~TGeoPatternCylR() override;
    // methods
-   virtual TGeoMatrix* CreateMatrix() const;
-   virtual void        cd(Int_t idiv);
-   virtual TGeoNode   *FindNode(Double_t *point, const Double_t *dir=nullptr);
-   virtual Int_t       GetDivAxis()      {return 1;}
-   virtual Bool_t      IsOnBoundary(const Double_t *point) const;
-   virtual
-   TGeoPatternFinder  *MakeCopy(Bool_t reflect=kFALSE);
-   virtual void        SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void        UpdateMatrix(Int_t idiv, TGeoHMatrix &matrix) const;
+   TGeoMatrix* CreateMatrix() const override;
+   void        cd(Int_t idiv) override;
+   TGeoNode   *FindNode(Double_t *point, const Double_t *dir=nullptr) override;
+   Int_t       GetDivAxis() override      {return 1;}
+   Bool_t      IsOnBoundary(const Double_t *point) const override;
+   
+   TGeoPatternFinder  *MakeCopy(Bool_t reflect=kFALSE) override;
+   void        SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void        UpdateMatrix(Int_t idiv, TGeoHMatrix &matrix) const override;
 
-   ClassDef(TGeoPatternCylR, 1)              // Cylindrical R division pattern
+   ClassDefOverride(TGeoPatternCylR, 1)              // Cylindrical R division pattern
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -412,19 +412,19 @@ public:
    TGeoPatternCylPhi(TGeoVolume *vol, Int_t ndivisions, Double_t step);
    TGeoPatternCylPhi(TGeoVolume *vol, Int_t ndivisions, Double_t start, Double_t end);
    // destructor
-   virtual ~TGeoPatternCylPhi();
+   ~TGeoPatternCylPhi() override;
    // methods
-   virtual TGeoMatrix* CreateMatrix() const;
-   virtual void        cd(Int_t idiv);
-   virtual TGeoNode   *FindNode(Double_t *point, const Double_t *dir=nullptr);
-   virtual Int_t       GetDivAxis()      {return 2;}
-   virtual Bool_t      IsOnBoundary(const Double_t *point) const;
-   virtual
-   TGeoPatternFinder  *MakeCopy(Bool_t reflect=kFALSE);
-   virtual void        SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void        UpdateMatrix(Int_t idiv, TGeoHMatrix &matrix) const;
+   TGeoMatrix* CreateMatrix() const override;
+   void        cd(Int_t idiv) override;
+   TGeoNode   *FindNode(Double_t *point, const Double_t *dir=nullptr) override;
+   Int_t       GetDivAxis() override      {return 2;}
+   Bool_t      IsOnBoundary(const Double_t *point) const override;
+   
+   TGeoPatternFinder  *MakeCopy(Bool_t reflect=kFALSE) override;
+   void        SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void        UpdateMatrix(Int_t idiv, TGeoHMatrix &matrix) const override;
 
-   ClassDef(TGeoPatternCylPhi, 1)              // Cylindrical phi division pattern
+   ClassDefOverride(TGeoPatternCylPhi, 1)              // Cylindrical phi division pattern
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -444,18 +444,18 @@ public:
    TGeoPatternSphR(const TGeoPatternSphR &pf);
    TGeoPatternSphR& operator=(const TGeoPatternSphR&);
    // destructor
-   virtual ~TGeoPatternSphR();
+   ~TGeoPatternSphR() override;
    // methods
-   virtual TGeoMatrix* CreateMatrix() const;
-   virtual void        cd(Int_t idiv);
-   virtual TGeoNode   *FindNode(Double_t *point, const Double_t *dir=nullptr);
-   virtual Int_t       GetDivAxis()      {return 1;}
-   virtual
-   TGeoPatternFinder  *MakeCopy(Bool_t reflect=kFALSE);
-   virtual void        SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void        UpdateMatrix(Int_t idiv, TGeoHMatrix &matrix) const;
+   TGeoMatrix* CreateMatrix() const override;
+   void        cd(Int_t idiv) override;
+   TGeoNode   *FindNode(Double_t *point, const Double_t *dir=nullptr) override;
+   Int_t       GetDivAxis() override      {return 1;}
+   
+   TGeoPatternFinder  *MakeCopy(Bool_t reflect=kFALSE) override;
+   void        SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void        UpdateMatrix(Int_t idiv, TGeoHMatrix &matrix) const override;
 
-   ClassDef(TGeoPatternSphR, 1)              // spherical R division pattern
+   ClassDefOverride(TGeoPatternSphR, 1)              // spherical R division pattern
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -475,18 +475,18 @@ public:
    TGeoPatternSphTheta(const TGeoPatternSphTheta &pf);
    TGeoPatternSphTheta& operator=(const TGeoPatternSphTheta&);
    // destructor
-   virtual ~TGeoPatternSphTheta();
+   ~TGeoPatternSphTheta() override;
    // methods
-   virtual TGeoMatrix* CreateMatrix() const;
-   virtual void        cd(Int_t idiv);
-   virtual TGeoNode   *FindNode(Double_t *point, const Double_t *dir=nullptr);
-   virtual Int_t       GetDivAxis()      {return 3;}
-   virtual
-   TGeoPatternFinder  *MakeCopy(Bool_t reflect=kFALSE);
-   virtual void        SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void        UpdateMatrix(Int_t idiv, TGeoHMatrix &matrix) const;
+   TGeoMatrix* CreateMatrix() const override;
+   void        cd(Int_t idiv) override;
+   TGeoNode   *FindNode(Double_t *point, const Double_t *dir=nullptr) override;
+   Int_t       GetDivAxis() override      {return 3;}
+   
+   TGeoPatternFinder  *MakeCopy(Bool_t reflect=kFALSE) override;
+   void        SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void        UpdateMatrix(Int_t idiv, TGeoHMatrix &matrix) const override;
 
-   ClassDef(TGeoPatternSphTheta, 1)              // spherical theta division pattern
+   ClassDefOverride(TGeoPatternSphTheta, 1)              // spherical theta division pattern
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -511,19 +511,19 @@ public:
    TGeoPatternSphPhi(TGeoVolume *vol, Int_t ndivisions, Double_t step);
    TGeoPatternSphPhi(TGeoVolume *vol, Int_t ndivisions, Double_t start, Double_t end);
    // destructor
-   virtual ~TGeoPatternSphPhi();
+   ~TGeoPatternSphPhi() override;
    // methods
-   virtual TGeoMatrix* CreateMatrix() const;
-   virtual void        cd(Int_t idiv);
-   virtual TGeoNode   *FindNode(Double_t *point, const Double_t *dir=nullptr);
-   virtual Int_t       GetDivAxis()      {return 2;}
-   virtual Bool_t      IsOnBoundary(const Double_t *point) const;
-   virtual
-   TGeoPatternFinder  *MakeCopy(Bool_t reflect=kFALSE);
-   virtual void        SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void        UpdateMatrix(Int_t idiv, TGeoHMatrix &matrix) const;
+   TGeoMatrix* CreateMatrix() const override;
+   void        cd(Int_t idiv) override;
+   TGeoNode   *FindNode(Double_t *point, const Double_t *dir=nullptr) override;
+   Int_t       GetDivAxis() override      {return 2;}
+   Bool_t      IsOnBoundary(const Double_t *point) const override;
+   
+   TGeoPatternFinder  *MakeCopy(Bool_t reflect=kFALSE) override;
+   void        SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void        UpdateMatrix(Int_t idiv, TGeoHMatrix &matrix) const override;
 
-   ClassDef(TGeoPatternSphPhi, 1)              // Spherical phi division pattern
+   ClassDefOverride(TGeoPatternSphPhi, 1)              // Spherical phi division pattern
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -550,15 +550,15 @@ public:
    TGeoPatternHoneycomb();
    TGeoPatternHoneycomb(TGeoVolume *vol, Int_t nrows);
    // destructor
-   virtual ~TGeoPatternHoneycomb();
+   ~TGeoPatternHoneycomb() override;
    // methods
-   TGeoPatternFinder  *MakeCopy(Bool_t) {return nullptr;}
-   virtual TGeoMatrix* CreateMatrix() const;
-   virtual void        cd(Int_t idiv);
-   virtual TGeoNode   *FindNode(Double_t *point, const Double_t *dir=nullptr);
-   virtual void        UpdateMatrix(Int_t idiv, TGeoHMatrix &matrix) const;
+   TGeoPatternFinder  *MakeCopy(Bool_t) override {return nullptr;}
+   TGeoMatrix* CreateMatrix() const override;
+   void        cd(Int_t idiv) override;
+   TGeoNode   *FindNode(Double_t *point, const Double_t *dir=nullptr) override;
+   void        UpdateMatrix(Int_t idiv, TGeoHMatrix &matrix) const override;
 
-   ClassDef(TGeoPatternHoneycomb, 1)             // pattern for honeycomb divisions
+   ClassDefOverride(TGeoPatternHoneycomb, 1)             // pattern for honeycomb divisions
 };
 
 #endif

--- a/geom/geom/inc/TGeoPcon.h
+++ b/geom/geom/inc/TGeoPcon.h
@@ -48,30 +48,30 @@ public:
    TGeoPcon(const char *name, Double_t phi, Double_t dphi, Int_t nz);
    TGeoPcon(Double_t *params);
    // destructor
-   virtual ~TGeoPcon();
+   ~TGeoPcon() override;
    // methods
-   virtual Double_t      Capacity() const;
-   virtual void          ComputeBBox();
-   virtual void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm);
-   virtual void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize);
-   virtual Bool_t        Contains(const Double_t *point) const;
-   virtual void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const;
+   Double_t      Capacity() const override;
+   void          ComputeBBox() override;
+   void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
+   Bool_t        Contains(const Double_t *point) const override;
+   void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;
    virtual void          DefineSection(Int_t snum, Double_t z, Double_t rmin, Double_t rmax);
-   virtual Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
+   Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
    Double_t              DistToSegZ(const Double_t *point, const Double_t *dir, Int_t &iz) const;
-   virtual Int_t         DistancetoPrimitive(Int_t px, Int_t py);
-   virtual TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
-                                Double_t start, Double_t step);
-   virtual const char   *GetAxisName(Int_t iaxis) const;
-   virtual Double_t      GetAxisRange(Int_t iaxis, Double_t &xlo, Double_t &xhi) const;
-   virtual void          GetBoundingCylinder(Double_t *param) const;
-   virtual const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const;
-   virtual Int_t         GetByteCount() const {return 60+12*fNz;}
+   Int_t         DistancetoPrimitive(Int_t px, Int_t py) override;
+   TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
+                                Double_t start, Double_t step) override;
+   const char   *GetAxisName(Int_t iaxis) const override;
+   Double_t      GetAxisRange(Int_t iaxis, Double_t &xlo, Double_t &xhi) const override;
+   void          GetBoundingCylinder(Double_t *param) const override;
+   const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const override;
+   Int_t         GetByteCount() const override {return 60+12*fNz;}
    Double_t              GetPhi1() const {return fPhi1;}
    Double_t              GetDphi() const {return fDphi;}
    Int_t                 GetNz() const   {return fNz;}
@@ -82,29 +82,29 @@ public:
    Double_t              GetRmax(Int_t ipl) const;
    Double_t             *GetZ() const    {return fZ;}
    Double_t              GetZ(Int_t ipl) const;
-   virtual TGeoShape    *GetMakeRuntimeShape(TGeoShape * /*mother*/, TGeoMatrix * /*mat*/) const {return nullptr;}
-   virtual Int_t         GetNmeshVertices() const;
-   virtual Bool_t        GetPointsOnSegments(Int_t /*npoints*/, Double_t * /*array*/) const {return kFALSE;}
-   virtual void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const;
-   virtual void          InspectShape() const;
-   virtual Bool_t        IsCylType() const {return kTRUE;}
-   virtual TBuffer3D    *MakeBuffer3D() const;
+   TGeoShape    *GetMakeRuntimeShape(TGeoShape * /*mother*/, TGeoMatrix * /*mat*/) const override {return nullptr;}
+   Int_t         GetNmeshVertices() const override;
+   Bool_t        GetPointsOnSegments(Int_t /*npoints*/, Double_t * /*array*/) const override {return kFALSE;}
+   void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const override;
+   void          InspectShape() const override;
+   Bool_t        IsCylType() const override {return kTRUE;}
+   TBuffer3D    *MakeBuffer3D() const override;
    Double_t             &Phi1()          {return fPhi1;}
    Double_t             &Dphi()          {return fDphi;}
    Double_t             &Rmin(Int_t ipl) {return fRmin[ipl];}
    Double_t             &Rmax(Int_t ipl) {return fRmax[ipl];}
    Double_t             &Z(Int_t ipl) {return fZ[ipl];}
-   virtual Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const;
-   virtual void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const;
+   Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const override;
+   void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const override;
    Double_t              SafetyToSegment(const Double_t *point, Int_t ipl, Bool_t in=kTRUE, Double_t safmin=TGeoShape::Big()) const;
-   virtual void          SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void          SetDimensions(Double_t *param);
-   virtual void          SetPoints(Double_t *points) const;
-   virtual void          SetPoints(Float_t *points) const;
-   virtual void          SetSegsAndPols(TBuffer3D &buff) const;
-   virtual void          Sizeof3D() const;
+   void          SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void          SetDimensions(Double_t *param) override;
+   void          SetPoints(Double_t *points) const override;
+   void          SetPoints(Float_t *points) const override;
+   void          SetSegsAndPols(TBuffer3D &buff) const override;
+   void          Sizeof3D() const override;
 
-   ClassDef(TGeoPcon, 1)         // polycone class
+   ClassDefOverride(TGeoPcon, 1)         // polycone class
 };
 
 #endif

--- a/geom/geom/inc/TGeoPgon.h
+++ b/geom/geom/inc/TGeoPgon.h
@@ -29,8 +29,8 @@ public:
       ~ThreadData_t();
    };
    ThreadData_t&     GetThreadData()   const;
-   void              ClearThreadData() const;
-   void              CreateThreadData(Int_t nthreads);
+   void              ClearThreadData() const override;
+   void              CreateThreadData(Int_t nthreads) override;
 
 protected:
    // data members
@@ -61,46 +61,46 @@ public:
    TGeoPgon(const char *name, Double_t phi, Double_t dphi, Int_t nedges, Int_t nz);
    TGeoPgon(Double_t *params);
    // destructor
-   virtual ~TGeoPgon();
+   ~TGeoPgon() override;
    // methods
-   virtual Double_t      Capacity() const;
-   virtual void          ComputeBBox();
-   virtual void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm);
-   virtual void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize);
-   virtual Bool_t        Contains(const Double_t *point) const;
-   virtual void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const;
-   virtual Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual Int_t         DistancetoPrimitive(Int_t px, Int_t py);
-   virtual TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
-                                Double_t start, Double_t step);
-   virtual void          GetBoundingCylinder(Double_t *param) const;
-   virtual const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const;
-   virtual Int_t         GetByteCount() const {return 64+12*fNz;}
-   virtual TGeoShape    *GetMakeRuntimeShape(TGeoShape * /*mother*/, TGeoMatrix * /*mat*/) const {return nullptr;}
-   virtual void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const;
+   Double_t      Capacity() const override;
+   void          ComputeBBox() override;
+   void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
+   Bool_t        Contains(const Double_t *point) const override;
+   void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;
+   Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   Int_t         DistancetoPrimitive(Int_t px, Int_t py) override;
+   TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
+                                Double_t start, Double_t step) override;
+   void          GetBoundingCylinder(Double_t *param) const override;
+   const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const override;
+   Int_t         GetByteCount() const override {return 64+12*fNz;}
+   TGeoShape    *GetMakeRuntimeShape(TGeoShape * /*mother*/, TGeoMatrix * /*mat*/) const override {return nullptr;}
+   void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const override;
    Int_t                 GetNedges() const   {return fNedges;}
-   virtual Int_t         GetNmeshVertices() const;
-   virtual Int_t         GetNsegments() const {return fNedges;}
-   virtual Bool_t        GetPointsOnSegments(Int_t npoints, Double_t *array) const {return TGeoBBox::GetPointsOnSegments(npoints,array);}
-   virtual void          InspectShape() const;
-   virtual TBuffer3D    *MakeBuffer3D() const;
-   virtual Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const;
-   virtual void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const;
+   Int_t         GetNmeshVertices() const override;
+   Int_t         GetNsegments() const override {return fNedges;}
+   Bool_t        GetPointsOnSegments(Int_t npoints, Double_t *array) const override {return TGeoBBox::GetPointsOnSegments(npoints,array);}
+   void          InspectShape() const override;
+   TBuffer3D    *MakeBuffer3D() const override;
+   Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const override;
+   void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const override;
    Double_t              SafetyToSegment(const Double_t *point, Int_t ipl, Int_t iphi, Bool_t in, Double_t safphi, Double_t safmin=TGeoShape::Big()) const;
-   virtual void          SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void          SetDimensions(Double_t *param);
+   void          SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void          SetDimensions(Double_t *param) override;
    void                  SetNedges(Int_t ne) {if (ne>2) fNedges=ne;}
-   virtual void          SetPoints(Double_t *points) const;
-   virtual void          SetPoints(Float_t *points) const;
-   virtual void          SetSegsAndPols(TBuffer3D &buff) const;
-   virtual void          Sizeof3D() const;
+   void          SetPoints(Double_t *points) const override;
+   void          SetPoints(Float_t *points) const override;
+   void          SetSegsAndPols(TBuffer3D &buff) const override;
+   void          Sizeof3D() const override;
 
-   ClassDef(TGeoPgon, 1)         // polygone class
+   ClassDefOverride(TGeoPgon, 1)         // polygone class
 };
 
 #endif

--- a/geom/geom/inc/TGeoPhysicalNode.h
+++ b/geom/geom/inc/TGeoPhysicalNode.h
@@ -60,11 +60,11 @@ public:
    TGeoPhysicalNode();
    TGeoPhysicalNode(const char *path);
    // destructor
-   virtual ~TGeoPhysicalNode();
+   ~TGeoPhysicalNode() override;
 
    Bool_t            Align(TGeoMatrix *newmat=nullptr, TGeoShape *newshape=nullptr, Bool_t check=kFALSE, Double_t ovlp=0.001);
    void              cd() const;
-   void              Draw(Option_t *option="");
+   void              Draw(Option_t *option="") override;
    Int_t             GetLevel() const {return fLevel;}
    TGeoHMatrix      *GetMatrix(Int_t level=-1) const;
    TGeoHMatrix      *GetOriginalMatrix() const {return fMatrixOrig;}
@@ -80,17 +80,17 @@ public:
    Bool_t            IsVisible() const {return TObject::TestBit(kGeoPNodeVisible);}
    Bool_t            IsVisibleFull() const {return TObject::TestBit(kGeoPNodeFull);}
 
-   virtual void      Print(Option_t *option="") const;
+   void      Print(Option_t *option="") const override;
    void              Refresh();
 
    void              SetMatrixOrig(const TGeoMatrix *local);
    void              SetIsVolAtt(Bool_t flag=kTRUE) {TObject::SetBit(kGeoPNodeVolAtt,flag);}
    void              SetVisibility(Bool_t flag=kTRUE)  {TObject::SetBit(kGeoPNodeVisible,flag);}
    void              SetVisibleFull(Bool_t flag=kTRUE) {TObject::SetBit(kGeoPNodeFull,flag);}
-   virtual void      Paint(Option_t *option = "");
+   void      Paint(Option_t *option = "") override;
 
 
-   ClassDef(TGeoPhysicalNode, 1)               // base class for physical nodes
+   ClassDefOverride(TGeoPhysicalNode, 1)               // base class for physical nodes
 };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -120,7 +120,7 @@ protected:
 public:
    TGeoPNEntry();
    TGeoPNEntry(const char *unique_name, const char *path);
-   virtual ~TGeoPNEntry();
+   ~TGeoPNEntry() override;
 
    inline const char   *GetPath() const {return GetTitle();}
    const TGeoHMatrix   *GetMatrix() const {return fMatrix;}
@@ -130,7 +130,7 @@ public:
    void              SetMatrix(const TGeoHMatrix *matrix);
    void              SetPhysicalNode(TGeoPhysicalNode *node);
 
-   ClassDef(TGeoPNEntry, 4)                  // a physical node entry with unique name
+   ClassDefOverride(TGeoPNEntry, 4)                  // a physical node entry with unique name
 };
 
 #endif

--- a/geom/geom/inc/TGeoPolygon.h
+++ b/geom/geom/inc/TGeoPolygon.h
@@ -46,11 +46,11 @@ public:
    TGeoPolygon();
    TGeoPolygon(Int_t nvert);
    // destructor
-   virtual ~TGeoPolygon();
+   ~TGeoPolygon() override;
    // methods
    Double_t            Area() const;
    Bool_t              Contains(const Double_t *point) const;
-   virtual void        Draw(Option_t *option="");
+   void        Draw(Option_t *option="") override;
    void                FinishPolygon();
    Int_t               GetNvert() const {return fNvert;}
    Int_t               GetNconvex() const {return fNconvex;}
@@ -67,7 +67,7 @@ public:
    void                SetXY(Double_t *x, Double_t *y);
    void                SetNextIndex(Int_t index=-1);
 
-   ClassDef(TGeoPolygon, 2)         // class for handling arbitrary polygons
+   ClassDefOverride(TGeoPolygon, 2)         // class for handling arbitrary polygons
 };
 
 #endif

--- a/geom/geom/inc/TGeoRCPtr.h
+++ b/geom/geom/inc/TGeoRCPtr.h
@@ -31,7 +31,7 @@ public:
    void print() const {printf("MyExtension object %p\n", this);}
 private:
    mutable Int_t        fRC;           // Reference counter
-   ClassDef(MyExtension,1)
+   ClassDefOverride(MyExtension,1)
 };
 ~~~
 

--- a/geom/geom/inc/TGeoRegion.h
+++ b/geom/geom/inc/TGeoRegion.h
@@ -25,12 +25,12 @@ public:
    TGeoRegionCut() {}
    TGeoRegionCut(const char *name, Double_t cut) : TNamed(name, ""), fCut(cut) {}
 
-   virtual ~TGeoRegionCut() {}
+   ~TGeoRegionCut() override {}
 
    Double_t GetCut() const { return fCut; }
    void SetCut(Double_t cut) { fCut = cut; }
 
-   ClassDef(TGeoRegionCut, 1) // A region cut
+   ClassDefOverride(TGeoRegionCut, 1) // A region cut
 };
 
 class TGeoRegion : public TNamed {
@@ -43,7 +43,7 @@ public:
    TGeoRegion(const char *name, const char *title = "") : TNamed(name, title) {}
    TGeoRegion(const TGeoRegion &other);
    TGeoRegion &operator=(const TGeoRegion &other);
-   virtual ~TGeoRegion();
+   ~TGeoRegion() override;
 
    // Volume accessors
    void AddVolume(TGeoVolume *vol) { fVolumes.Add(vol); }
@@ -57,9 +57,9 @@ public:
    int GetNcuts() const { return fCuts.GetEntriesFast(); }
    TGeoRegionCut *GetCut(int i) const { return (TGeoRegionCut *)fCuts.At(i); }
 
-   virtual void Print(Option_t *option = "") const; // *MENU*
+   void Print(Option_t *option = "") const override; // *MENU*
 
-   ClassDef(TGeoRegion, 1) // Region wrapper class
+   ClassDefOverride(TGeoRegion, 1) // Region wrapper class
 };
 
 #endif

--- a/geom/geom/inc/TGeoScaledShape.h
+++ b/geom/geom/inc/TGeoScaledShape.h
@@ -30,44 +30,44 @@ public:
    TGeoScaledShape(const char *name, TGeoShape *shape, TGeoScale *scale);
    TGeoScaledShape(TGeoShape *shape, TGeoScale *scale);
    // destructor
-   virtual ~TGeoScaledShape();
+   ~TGeoScaledShape() override;
    // methods
-   virtual Double_t      Capacity() const;
-   virtual void          ComputeBBox();
-   virtual void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm);
-   virtual void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize);
-   virtual Bool_t        Contains(const Double_t *point) const;
-   virtual void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const;
-   virtual Int_t         DistancetoPrimitive(Int_t px, Int_t py);
-   virtual Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
-                                Double_t start, Double_t step);
-   virtual TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const;
-   virtual const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const;
-   virtual void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const;
-   virtual Int_t         GetNmeshVertices() const {return fShape->GetNmeshVertices();}
+   Double_t      Capacity() const override;
+   void          ComputeBBox() override;
+   void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
+   Bool_t        Contains(const Double_t *point) const override;
+   void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;
+   Int_t         DistancetoPrimitive(Int_t px, Int_t py) override;
+   Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
+                                Double_t start, Double_t step) override;
+   TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const override;
+   const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const override;
+   void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const override;
+   Int_t         GetNmeshVertices() const override {return fShape->GetNmeshVertices();}
    TGeoShape            *GetShape() const {return fShape;}
    TGeoScale            *GetScale() const {return fScale;}
-   virtual void          InspectShape() const;
-   virtual Bool_t        IsAssembly() const;
-   virtual Bool_t        IsCylType() const {return fShape->IsCylType();}
-   virtual Bool_t        IsReflected() const;
-   virtual TBuffer3D    *MakeBuffer3D() const;
+   void          InspectShape() const override;
+   Bool_t        IsAssembly() const override;
+   Bool_t        IsCylType() const override {return fShape->IsCylType();}
+   Bool_t        IsReflected() const override;
+   TBuffer3D    *MakeBuffer3D() const override;
    static  TGeoShape    *MakeScaledShape(const char *name, TGeoShape *shape, TGeoScale *scale);
-   virtual Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const;
-   virtual void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const;
-   virtual void          SavePrimitive(std::ostream &out, Option_t *option = "");
+   Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const override;
+   void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const override;
+   void          SavePrimitive(std::ostream &out, Option_t *option = "") override;
    void                  SetScale(TGeoScale *scale) {fScale = scale;}
-   virtual void          SetPoints(Double_t *points) const;
-   virtual void          SetPoints(Float_t *points) const;
-   virtual void          SetSegsAndPols(TBuffer3D &buffer) const;
+   void          SetPoints(Double_t *points) const override;
+   void          SetPoints(Float_t *points) const override;
+   void          SetSegsAndPols(TBuffer3D &buffer) const override;
 
-   ClassDef(TGeoScaledShape, 1)         // a scaled shape
+   ClassDefOverride(TGeoScaledShape, 1)         // a scaled shape
 };
 
 #endif

--- a/geom/geom/inc/TGeoShape.h
+++ b/geom/geom/inc/TGeoShape.h
@@ -82,7 +82,7 @@ public:
    TGeoShape();
    TGeoShape(const char *name);
    // destructor
-   virtual ~TGeoShape();
+   ~TGeoShape() override;
    // methods
 
    static Double_t       Big() {return 1.E30;}
@@ -100,7 +100,7 @@ public:
    virtual Bool_t        Contains(const Double_t *point) const         = 0;
    virtual void          Contains_v(const Double_t *, Bool_t *, Int_t) const {}
    virtual Bool_t        CouldBeCrossed(const Double_t *point, const Double_t *dir) const = 0;
-   virtual Int_t         DistancetoPrimitive(Int_t px, Int_t py) = 0;
+   Int_t         DistancetoPrimitive(Int_t px, Int_t py) override = 0;
    virtual Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
                                    Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const = 0;
    virtual void          DistFromInside_v(const Double_t *, const Double_t *, Double_t *, Int_t, Double_t *) const {}
@@ -111,8 +111,8 @@ public:
                                       Double_t sm, Double_t cm, Bool_t in=kTRUE);
    virtual TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
                                 Double_t start, Double_t step)   = 0;
-   virtual void          Draw(Option_t *option=""); // *MENU*
-   virtual void          ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   void          Draw(Option_t *option="") override; // *MENU*
+   void          ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
    virtual const char   *GetAxisName(Int_t iaxis) const = 0;
    virtual Double_t      GetAxisRange(Int_t iaxis, Double_t &xlo, Double_t &xhi) const = 0;
    virtual void          GetBoundingCylinder(Double_t *param) const = 0;
@@ -123,7 +123,7 @@ public:
    Int_t                 GetId() const  {return fShapeId;}
    virtual TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const  = 0;
    virtual void          GetMeshNumbers(Int_t &/*nvert*/, Int_t &/*nsegs*/, Int_t &/*npols*/) const {}
-   virtual const char   *GetName() const;
+   const char   *GetName() const override;
    virtual Int_t         GetNmeshVertices() const {return 0;}
    const char           *GetPointerName() const;
    virtual Bool_t        IsAssembly() const {return kFALSE;}
@@ -142,7 +142,7 @@ public:
    virtual void          InspectShape() const                    = 0;
    virtual TBuffer3D    *MakeBuffer3D() const {return nullptr;}
    static void           NormalPhi(const Double_t *point, const Double_t *dir, Double_t *norm, Double_t c1, Double_t s1, Double_t c2, Double_t s2);
-   virtual void          Paint(Option_t *option="");
+   void          Paint(Option_t *option="") override;
    virtual Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const = 0;
    virtual void          Safety_v(const Double_t *, const Bool_t *, Double_t *, Int_t) const {}
    static  Double_t      SafetyPhi(const Double_t *point, Bool_t in, Double_t phi1, Double_t phi2);
@@ -164,7 +164,7 @@ public:
    Int_t    TestShapeBits(UInt_t f) const { return (Int_t) (fShapeBits & f); }
    void     InvertShapeBit(UInt_t f) { fShapeBits ^= f & kBitMask32; }
 
-   ClassDef(TGeoShape, 2)           // base class for shapes
+   ClassDefOverride(TGeoShape, 2)           // base class for shapes
 };
 
 #endif

--- a/geom/geom/inc/TGeoShapeAssembly.h
+++ b/geom/geom/inc/TGeoShapeAssembly.h
@@ -29,38 +29,38 @@ public:
    TGeoShapeAssembly();
    TGeoShapeAssembly(TGeoVolumeAssembly *vol);
    // destructor
-   virtual ~TGeoShapeAssembly();
+   ~TGeoShapeAssembly() override;
    // methods
-   virtual void          ComputeBBox();
-   virtual void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm);
-   virtual void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize);
-   virtual Bool_t        Contains(const Double_t *point) const;
-   virtual void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const;
-   virtual Int_t         DistancetoPrimitive(Int_t px, Int_t py);
-   virtual Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
-                                Double_t start, Double_t step);
-   virtual TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const;
-   virtual void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const;
-   virtual Int_t         GetNmeshVertices() const {return 0;}
-   virtual void          InspectShape() const;
-   virtual Bool_t        IsAssembly() const {return kTRUE;}
-   virtual Bool_t        IsCylType() const {return kFALSE;}
+   void          ComputeBBox() override;
+   void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
+   Bool_t        Contains(const Double_t *point) const override;
+   void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;
+   Int_t         DistancetoPrimitive(Int_t px, Int_t py) override;
+   Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
+                                Double_t start, Double_t step) override;
+   TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const override;
+   void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const override;
+   Int_t         GetNmeshVertices() const override {return 0;}
+   void          InspectShape() const override;
+   Bool_t        IsAssembly() const override {return kTRUE;}
+   Bool_t        IsCylType() const override {return kFALSE;}
    void                  NeedsBBoxRecompute() {fBBoxOK = kFALSE;}
    void                  RecomputeBoxLast();
-   virtual Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const;
-   virtual void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const;
-   virtual void          SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void          SetPoints(Double_t *points) const;
-   virtual void          SetPoints(Float_t *points) const;
-   virtual void          SetSegsAndPols(TBuffer3D &buff) const;
+   Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const override;
+   void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const override;
+   void          SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void          SetPoints(Double_t *points) const override;
+   void          SetPoints(Float_t *points) const override;
+   void          SetSegsAndPols(TBuffer3D &buff) const override;
 
-   ClassDef(TGeoShapeAssembly, 2)         // assembly shape
+   ClassDefOverride(TGeoShapeAssembly, 2)         // assembly shape
 };
 
 #endif

--- a/geom/geom/inc/TGeoSphere.h
+++ b/geom/geom/inc/TGeoSphere.h
@@ -38,34 +38,34 @@ public:
               Double_t phi1=0, Double_t phi2=360);
    TGeoSphere(Double_t *param, Int_t nparam=6);
    // destructor
-   virtual ~TGeoSphere();
+   ~TGeoSphere() override;
    // methods
-   virtual Double_t      Capacity() const;
-   virtual void          ComputeBBox();
-   virtual void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm);
-   virtual void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize);
-   virtual Bool_t        Contains(const Double_t *point) const;
-   virtual void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const;
-   virtual Int_t         DistancetoPrimitive(Int_t px, Int_t py);
-   virtual Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
+   Double_t      Capacity() const override;
+   void          ComputeBBox() override;
+   void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
+   Bool_t        Contains(const Double_t *point) const override;
+   void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;
+   Int_t         DistancetoPrimitive(Int_t px, Int_t py) override;
+   Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
    Double_t              DistToSphere(const Double_t *point, const Double_t *dir, Double_t rsph, Bool_t check=kTRUE, Bool_t firstcross=kTRUE) const;
-   virtual TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
-                                Double_t start, Double_t step);
-   virtual const char   *GetAxisName(Int_t iaxis) const;
-   virtual Double_t      GetAxisRange(Int_t iaxis, Double_t &xlo, Double_t &xhi) const;
-   virtual void          GetBoundingCylinder(Double_t *param) const;
-   virtual const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const;
-   virtual Int_t         GetByteCount() const {return 42;}
-   virtual TGeoShape    *GetMakeRuntimeShape(TGeoShape * /*mother*/, TGeoMatrix * /*mat*/) const {return nullptr;}
-   virtual void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const;
-   virtual Int_t         GetNmeshVertices() const;
+   TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
+                                Double_t start, Double_t step) override;
+   const char   *GetAxisName(Int_t iaxis) const override;
+   Double_t      GetAxisRange(Int_t iaxis, Double_t &xlo, Double_t &xhi) const override;
+   void          GetBoundingCylinder(Double_t *param) const override;
+   const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const override;
+   Int_t         GetByteCount() const override {return 42;}
+   TGeoShape    *GetMakeRuntimeShape(TGeoShape * /*mother*/, TGeoMatrix * /*mat*/) const override {return nullptr;}
+   void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const override;
+   Int_t         GetNmeshVertices() const override;
    Int_t                 GetNumberOfDivisions() const {return fNseg;}
-   virtual Bool_t        GetPointsOnSegments(Int_t /*npoints*/, Double_t * /*array*/) const {return kFALSE;}
+   Bool_t        GetPointsOnSegments(Int_t /*npoints*/, Double_t * /*array*/) const override {return kFALSE;}
    Int_t                 GetNz() const   {return fNz;}
    virtual Double_t      GetRmin() const {return fRmin;}
    virtual Double_t      GetRmax() const {return fRmax;}
@@ -73,25 +73,25 @@ public:
    Double_t              GetTheta2() const {return fTheta2;}
    Double_t              GetPhi1() const {return fPhi1;}
    Double_t              GetPhi2() const {return fPhi2;}
-   virtual void          InspectShape() const;
-   virtual Bool_t        IsCylType() const {return kFALSE;}
+   void          InspectShape() const override;
+   Bool_t        IsCylType() const override {return kFALSE;}
    Int_t                 IsOnBoundary(const Double_t *point) const;
    Bool_t                IsPointInside(const Double_t *point, Bool_t checkR=kTRUE, Bool_t checkTh=kTRUE, Bool_t checkPh=kTRUE) const;
-   virtual TBuffer3D    *MakeBuffer3D() const;
-   virtual Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const;
-   virtual void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const;
-   virtual void          SavePrimitive(std::ostream &out, Option_t *option = "");
+   TBuffer3D    *MakeBuffer3D() const override;
+   Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const override;
+   void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const override;
+   void          SavePrimitive(std::ostream &out, Option_t *option = "") override;
    void                  SetSphDimensions(Double_t rmin, Double_t rmax, Double_t theta1,
                                        Double_t theta2, Double_t phi1, Double_t phi2);
    virtual void          SetNumberOfDivisions(Int_t p);
-   virtual void          SetDimensions(Double_t *param);
+   void          SetDimensions(Double_t *param) override;
    void                  SetDimensions(Double_t *param, Int_t nparam);
-   virtual void          SetPoints(Double_t *points) const;
-   virtual void          SetPoints(Float_t *points) const;
-   virtual void          SetSegsAndPols(TBuffer3D &buff) const;
-   virtual void          Sizeof3D() const;
+   void          SetPoints(Double_t *points) const override;
+   void          SetPoints(Float_t *points) const override;
+   void          SetSegsAndPols(TBuffer3D &buff) const override;
+   void          Sizeof3D() const override;
 
-   ClassDef(TGeoSphere, 1)         // sphere class
+   ClassDefOverride(TGeoSphere, 1)         // sphere class
 };
 
 #endif

--- a/geom/geom/inc/TGeoTessellated.h
+++ b/geom/geom/inc/TGeoTessellated.h
@@ -125,9 +125,9 @@ public:
    TGeoTessellated(const char *name, int nfacets = 0);
    TGeoTessellated(const char *name, const std::vector<Vertex_t> &vertices);
    // destructor
-   virtual ~TGeoTessellated() {}
+   ~TGeoTessellated() override {}
 
-   void ComputeBBox();
+   void ComputeBBox() override;
    void CloseShape(bool check = true, bool fixFlipped = true, bool verbose = true);
 
    bool AddFacet(const Vertex_t &pt0, const Vertex_t &pt1, const Vertex_t &pt2);
@@ -144,19 +144,19 @@ public:
    const TGeoFacet &GetFacet(int i) const { return fFacets[i]; }
    const Vertex_t &GetVertex(int i) const { return fVertices[i]; }
 
-   virtual void AfterStreamer();
-   virtual int DistancetoPrimitive(int, int) { return 99999; }
-   virtual const TBuffer3D &GetBuffer3D(int reqSections, Bool_t localFrame) const;
-   virtual void GetMeshNumbers(int &nvert, int &nsegs, int &npols) const;
-   virtual int GetNmeshVertices() const { return fNvert; }
-   virtual void InspectShape() const {}
-   virtual TBuffer3D *MakeBuffer3D() const;
-   virtual void Print(Option_t *option = "") const;
-   virtual void SavePrimitive(std::ostream &, Option_t *) {}
-   virtual void SetPoints(double *points) const;
-   virtual void SetPoints(Float_t *points) const;
-   virtual void SetSegsAndPols(TBuffer3D &buff) const;
-   virtual void Sizeof3D() const {}
+   void AfterStreamer() override;
+   int DistancetoPrimitive(int, int) override { return 99999; }
+   const TBuffer3D &GetBuffer3D(int reqSections, Bool_t localFrame) const override;
+   void GetMeshNumbers(int &nvert, int &nsegs, int &npols) const override;
+   int GetNmeshVertices() const override { return fNvert; }
+   void InspectShape() const override {}
+   TBuffer3D *MakeBuffer3D() const override;
+   void Print(Option_t *option = "") const override;
+   void SavePrimitive(std::ostream &, Option_t *) override {}
+   void SetPoints(double *points) const override;
+   void SetPoints(Float_t *points) const override;
+   void SetSegsAndPols(TBuffer3D &buff) const override;
+   void Sizeof3D() const override {}
 
    /// Resize and center the shape in a box of size maxsize
    void ResizeCenter(double maxsize);
@@ -173,7 +173,7 @@ public:
    /// Reader from .obj format
    static TGeoTessellated *ImportFromObjFormat(const char *objfile, bool check = false, bool verbose = false);
 
-   ClassDef(TGeoTessellated, 1) // tessellated shape class
+   ClassDefOverride(TGeoTessellated, 1) // tessellated shape class
 };
 
 #endif

--- a/geom/geom/inc/TGeoTorus.h
+++ b/geom/geom/inc/TGeoTorus.h
@@ -28,7 +28,7 @@ protected :
    TGeoTorus& operator=(const TGeoTorus&) = delete;
 
 public:
-   virtual Double_t      Capacity() const;
+   Double_t      Capacity() const override;
    Double_t              Daxis(const Double_t *pt, const Double_t *dir, Double_t t) const;
    Double_t              DDaxis(const Double_t *pt, const Double_t *dir, Double_t t) const;
    Double_t              DDDaxis(const Double_t *pt, const Double_t *dir, Double_t t) const;
@@ -42,51 +42,51 @@ public:
    TGeoTorus(const char * name, Double_t r, Double_t rmin, Double_t rmax, Double_t phi1=0, Double_t dphi=360);
    TGeoTorus(Double_t *params);
    // destructor
-   virtual ~TGeoTorus() {}
+   ~TGeoTorus() override {}
    // methods
 
-   virtual void          ComputeBBox();
-   virtual void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm);
-   virtual void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize);
-   virtual Bool_t        Contains(const Double_t *point) const;
-   virtual void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const;
-   virtual Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual Int_t         DistancetoPrimitive(Int_t px, Int_t py);
-   virtual TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
-                                Double_t start, Double_t step);
-   virtual const char   *GetAxisName(Int_t iaxis) const;
-   virtual Double_t      GetAxisRange(Int_t iaxis, Double_t &xlo, Double_t &xhi) const;
-   virtual void          GetBoundingCylinder(Double_t *param) const;
-   virtual const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const;
-   virtual Int_t         GetByteCount() const {return 56;}
-   virtual TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const;
-   virtual void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const;
-   virtual Int_t         GetNmeshVertices() const;
-   virtual Bool_t        GetPointsOnSegments(Int_t /*npoints*/, Double_t * /*array*/) const {return kFALSE;}
+   void          ComputeBBox() override;
+   void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
+   Bool_t        Contains(const Double_t *point) const override;
+   void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;
+   Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   Int_t         DistancetoPrimitive(Int_t px, Int_t py) override;
+   TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
+                                Double_t start, Double_t step) override;
+   const char   *GetAxisName(Int_t iaxis) const override;
+   Double_t      GetAxisRange(Int_t iaxis, Double_t &xlo, Double_t &xhi) const override;
+   void          GetBoundingCylinder(Double_t *param) const override;
+   const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const override;
+   Int_t         GetByteCount() const override {return 56;}
+   TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const override;
+   void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const override;
+   Int_t         GetNmeshVertices() const override;
+   Bool_t        GetPointsOnSegments(Int_t /*npoints*/, Double_t * /*array*/) const override {return kFALSE;}
    Double_t              GetR() const    {return fR;}
    Double_t              GetRmin() const {return fRmin;}
    Double_t              GetRmax() const {return fRmax;}
    Double_t              GetPhi1() const {return fPhi1;}
    Double_t              GetDphi() const {return fDphi;}
-   virtual void          InspectShape() const;
-   virtual Bool_t        IsCylType() const {return kTRUE;}
-   virtual TBuffer3D    *MakeBuffer3D() const;
-   virtual Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const;
-   virtual void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const;
-   virtual void          SavePrimitive(std::ostream &out, Option_t *option = "");
+   void          InspectShape() const override;
+   Bool_t        IsCylType() const override {return kTRUE;}
+   TBuffer3D    *MakeBuffer3D() const override;
+   Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const override;
+   void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const override;
+   void          SavePrimitive(std::ostream &out, Option_t *option = "") override;
    void                  SetTorusDimensions(Double_t r, Double_t rmin, Double_t rmax, Double_t phi1, Double_t dphi);
-   virtual void          SetDimensions(Double_t *param);
-   virtual void          SetPoints(Double_t *points) const;
-   virtual void          SetPoints(Float_t *points) const;
-   virtual void          SetSegsAndPols(TBuffer3D &buff) const;
-   virtual void          Sizeof3D() const;
+   void          SetDimensions(Double_t *param) override;
+   void          SetPoints(Double_t *points) const override;
+   void          SetPoints(Float_t *points) const override;
+   void          SetSegsAndPols(TBuffer3D &buff) const override;
+   void          Sizeof3D() const override;
 
-   ClassDef(TGeoTorus, 1)         // torus class
+   ClassDefOverride(TGeoTorus, 1)         // torus class
 
 };
 

--- a/geom/geom/inc/TGeoTrd1.h
+++ b/geom/geom/inc/TGeoTrd1.h
@@ -34,46 +34,46 @@ public:
    TGeoTrd1(const char *name, Double_t dx1, Double_t dx2, Double_t dy, Double_t dz);
    TGeoTrd1(Double_t *params);
    // destructor
-   virtual ~TGeoTrd1();
+   ~TGeoTrd1() override;
    // methods
 
-   virtual Double_t      Capacity() const;
-   virtual void          ComputeBBox();
-   virtual void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm);
-   virtual void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize);
-   virtual Bool_t        Contains(const Double_t *point) const;
-   virtual void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const;
-   virtual Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
-                                Double_t start, Double_t step);
-   virtual Double_t      GetAxisRange(Int_t iaxis, Double_t &xlo, Double_t &xhi) const;
-   virtual void          GetBoundingCylinder(Double_t *param) const;
-   virtual Int_t         GetByteCount() const {return 52;}
+   Double_t      Capacity() const override;
+   void          ComputeBBox() override;
+   void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
+   Bool_t        Contains(const Double_t *point) const override;
+   void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;
+   Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
+                                Double_t start, Double_t step) override;
+   Double_t      GetAxisRange(Int_t iaxis, Double_t &xlo, Double_t &xhi) const override;
+   void          GetBoundingCylinder(Double_t *param) const override;
+   Int_t         GetByteCount() const override {return 52;}
    Double_t              GetDx1() const {return fDx1;}
    Double_t              GetDx2() const {return fDx2;}
    Double_t              GetDy() const  {return fDy;}
    Double_t              GetDz() const  {return fDz;}
-   virtual Int_t         GetFittingBox(const TGeoBBox *parambox, TGeoMatrix *mat, Double_t &dx, Double_t &dy, Double_t &dz) const;
-   virtual TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const;
+   Int_t         GetFittingBox(const TGeoBBox *parambox, TGeoMatrix *mat, Double_t &dx, Double_t &dy, Double_t &dz) const override;
+   TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const override;
    void                  GetVisibleCorner(const Double_t *point, Double_t *vertex, Double_t *normals) const;
    void                  GetOppositeCorner(const Double_t *point, Int_t inorm, Double_t *vertex, Double_t *normals) const;
-   virtual void          InspectShape() const;
-   virtual Bool_t        IsCylType() const {return kFALSE;}
-   virtual Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const;
-   virtual void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const;
-   virtual void          SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void          SetDimensions(Double_t *param);
-   virtual void          SetPoints(Double_t *points) const;
-   virtual void          SetPoints(Float_t *points) const;
+   void          InspectShape() const override;
+   Bool_t        IsCylType() const override {return kFALSE;}
+   Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const override;
+   void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const override;
+   void          SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void          SetDimensions(Double_t *param) override;
+   void          SetPoints(Double_t *points) const override;
+   void          SetPoints(Float_t *points) const override;
    void                  SetVertex(Double_t *vertex) const;
-   virtual void          Sizeof3D() const;
+   void          Sizeof3D() const override;
 
-   ClassDef(TGeoTrd1, 1)         // TRD1 shape class
+   ClassDefOverride(TGeoTrd1, 1)         // TRD1 shape class
 };
 
 #endif

--- a/geom/geom/inc/TGeoTrd2.h
+++ b/geom/geom/inc/TGeoTrd2.h
@@ -35,47 +35,47 @@ public:
    TGeoTrd2(const char *name, Double_t dx1, Double_t dx2, Double_t dy1, Double_t dy2, Double_t dz);
    TGeoTrd2(Double_t *params);
    // destructor
-   virtual ~TGeoTrd2();
+   ~TGeoTrd2() override;
    // methods
 
-   virtual Double_t      Capacity() const;
-   virtual Bool_t        Contains(const Double_t *point) const;
-   virtual void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const;
-   virtual void          ComputeBBox();
-   virtual void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm);
-   virtual void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize);
-   virtual Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
-                                Double_t start, Double_t step);
-   virtual Double_t      GetAxisRange(Int_t iaxis, Double_t &xlo, Double_t &xhi) const;
-   virtual void          GetBoundingCylinder(Double_t *param) const;
-   virtual Int_t         GetByteCount() const {return 56;}
+   Double_t      Capacity() const override;
+   Bool_t        Contains(const Double_t *point) const override;
+   void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;
+   void          ComputeBBox() override;
+   void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
+   Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
+                                Double_t start, Double_t step) override;
+   Double_t      GetAxisRange(Int_t iaxis, Double_t &xlo, Double_t &xhi) const override;
+   void          GetBoundingCylinder(Double_t *param) const override;
+   Int_t         GetByteCount() const override {return 56;}
    Double_t              GetDx1() const {return fDx1;}
    Double_t              GetDx2() const {return fDx2;}
    Double_t              GetDy1() const {return fDy1;}
    Double_t              GetDy2() const {return fDy2;}
    Double_t              GetDz() const  {return fDz;}
-   virtual Int_t         GetFittingBox(const TGeoBBox *parambox, TGeoMatrix *mat, Double_t &dx, Double_t &dy, Double_t &dz) const;
-   virtual TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const;
+   Int_t         GetFittingBox(const TGeoBBox *parambox, TGeoMatrix *mat, Double_t &dx, Double_t &dy, Double_t &dz) const override;
+   TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const override;
    void                  GetVisibleCorner(const Double_t *point, Double_t *vertex, Double_t *normals) const;
    void                  GetOppositeCorner(const Double_t *point, Int_t inorm, Double_t *vertex, Double_t *normals) const;
-   virtual void          InspectShape() const;
-   virtual Bool_t        IsCylType() const {return kFALSE;}
-   virtual Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const;
-   virtual void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const;
-   virtual void          SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void          SetDimensions(Double_t *param);
-   virtual void          SetPoints(Double_t *points) const;
-   virtual void          SetPoints(Float_t *points) const;
+   void          InspectShape() const override;
+   Bool_t        IsCylType() const override {return kFALSE;}
+   Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const override;
+   void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const override;
+   void          SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void          SetDimensions(Double_t *param) override;
+   void          SetPoints(Double_t *points) const override;
+   void          SetPoints(Float_t *points) const override;
    void                  SetVertex(Double_t *vertex) const;
-   virtual void          Sizeof3D() const;
+   void          Sizeof3D() const override;
 
-   ClassDef(TGeoTrd2, 1)         // TRD2 shape class
+   ClassDefOverride(TGeoTrd2, 1)         // TRD2 shape class
 };
 
 #endif

--- a/geom/geom/inc/TGeoTube.h
+++ b/geom/geom/inc/TGeoTube.h
@@ -33,58 +33,58 @@ public:
    TGeoTube(const char * name, Double_t rmin, Double_t rmax, Double_t dz);
    TGeoTube(Double_t *params);
    // destructor
-   virtual ~TGeoTube();
+   ~TGeoTube() override;
    // methods
 
-   virtual Double_t      Capacity() const;
+   Double_t      Capacity() const override;
    static  Double_t      Capacity(Double_t rmin, Double_t rmax, Double_t dz);
-   virtual void          ComputeBBox();
-   virtual void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm);
-   virtual void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize);
+   void          ComputeBBox() override;
+   void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
    static  void          ComputeNormalS(const Double_t *point, const Double_t *dir, Double_t *norm,
                                         Double_t rmin, Double_t rmax, Double_t dz);
-   virtual Bool_t        Contains(const Double_t *point) const;
-   virtual void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const;
+   Bool_t        Contains(const Double_t *point) const override;
+   void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;
    static  Double_t      DistFromInsideS(const Double_t *point, const Double_t *dir, Double_t rmin, Double_t rmax, Double_t dz);
-   virtual Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
+   Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
    static  Double_t      DistFromOutsideS(const Double_t *point, const Double_t *dir, Double_t rmin, Double_t rmax, Double_t dz);
-   virtual Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
+   Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
    static  void          DistToTube(Double_t rsq, Double_t nsq, Double_t rdotn, Double_t radius, Double_t &b, Double_t &delta);
-   virtual Int_t         DistancetoPrimitive(Int_t px, Int_t py);
-   virtual TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
-                                Double_t start, Double_t step);
-   virtual const char   *GetAxisName(Int_t iaxis) const;
-   virtual Double_t      GetAxisRange(Int_t iaxis, Double_t &xlo, Double_t &xhi) const;
-   virtual void          GetBoundingCylinder(Double_t *param) const;
-   virtual const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const;
-   virtual Int_t         GetByteCount() const {return 48;}
-   virtual Bool_t        GetPointsOnSegments(Int_t npoints, Double_t *array) const;
-   virtual TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const;
-   virtual void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const;
-   virtual Int_t         GetNmeshVertices() const;
+   Int_t         DistancetoPrimitive(Int_t px, Int_t py) override;
+   TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
+                                Double_t start, Double_t step) override;
+   const char   *GetAxisName(Int_t iaxis) const override;
+   Double_t      GetAxisRange(Int_t iaxis, Double_t &xlo, Double_t &xhi) const override;
+   void          GetBoundingCylinder(Double_t *param) const override;
+   const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const override;
+   Int_t         GetByteCount() const override {return 48;}
+   Bool_t        GetPointsOnSegments(Int_t npoints, Double_t *array) const override;
+   TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const override;
+   void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const override;
+   Int_t         GetNmeshVertices() const override;
    virtual Double_t      GetRmin() const {return fRmin;}
    virtual Double_t      GetRmax() const {return fRmax;}
    virtual Double_t      GetDz() const   {return fDz;}
    Bool_t                HasRmin() const {return (fRmin>0)?kTRUE:kFALSE;}
-   virtual void          InspectShape() const;
-   virtual Bool_t        IsCylType() const {return kTRUE;}
-   virtual TBuffer3D    *MakeBuffer3D() const;
-   virtual Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const;
-   virtual void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const;
+   void          InspectShape() const override;
+   Bool_t        IsCylType() const override {return kTRUE;}
+   TBuffer3D    *MakeBuffer3D() const override;
+   Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const override;
+   void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const override;
    static  Double_t      SafetyS(const Double_t *point, Bool_t in, Double_t rmin, Double_t rmax, Double_t dz, Int_t skipz=0);
-   virtual void          SavePrimitive(std::ostream &out, Option_t *option = "");
+   void          SavePrimitive(std::ostream &out, Option_t *option = "") override;
    void                  SetTubeDimensions(Double_t rmin, Double_t rmax, Double_t dz);
-   virtual void          SetDimensions(Double_t *param);
-   virtual void          SetPoints(Double_t *points) const;
-   virtual void          SetPoints(Float_t *points) const;
-   virtual void          SetSegsAndPols(TBuffer3D &buff) const;
-   virtual void          Sizeof3D() const;
+   void          SetDimensions(Double_t *param) override;
+   void          SetPoints(Double_t *points) const override;
+   void          SetPoints(Float_t *points) const override;
+   void          SetSegsAndPols(TBuffer3D &buff) const override;
+   void          Sizeof3D() const override;
 
-   ClassDef(TGeoTube, 1)         // cylindrical tube class
+   ClassDefOverride(TGeoTube, 1)         // cylindrical tube class
 
 };
 
@@ -114,58 +114,58 @@ public:
                Double_t phi1, Double_t phi2);
    TGeoTubeSeg(Double_t *params);
    // destructor
-   virtual ~TGeoTubeSeg();
+   ~TGeoTubeSeg() override;
    // methods
-   virtual void          AfterStreamer();
-   virtual Double_t      Capacity() const;
+   void          AfterStreamer() override;
+   Double_t      Capacity() const override;
    static  Double_t      Capacity(Double_t rmin, Double_t rmax, Double_t dz, Double_t phi1, Double_t phi2);
-   virtual void          ComputeBBox();
-   virtual void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm);
-   virtual void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize);
+   void          ComputeBBox() override;
+   void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
    static  void          ComputeNormalS(const Double_t *point, const Double_t *dir, Double_t *norm,
                                         Double_t rmin, Double_t rmax, Double_t dz,
                                         Double_t c1, Double_t s1, Double_t c2, Double_t s2);
-   virtual Bool_t        Contains(const Double_t *point) const;
-   virtual void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const;
-   virtual Int_t         DistancetoPrimitive(Int_t px, Int_t py);
+   Bool_t        Contains(const Double_t *point) const override;
+   void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;
+   Int_t         DistancetoPrimitive(Int_t px, Int_t py) override;
    static  Double_t      DistFromInsideS(const Double_t *point, const Double_t *dir,Double_t rmin, Double_t rmax, Double_t dz,
                                     Double_t c1, Double_t s1, Double_t c2, Double_t s2, Double_t cm, Double_t sm, Double_t cdfi);
-   virtual Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
+   Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
    static  Double_t      DistFromOutsideS(const Double_t *point, const Double_t *dir, Double_t rmin, Double_t rmax, Double_t dz,
                                    Double_t c1, Double_t s1, Double_t c2, Double_t s2, Double_t cm, Double_t sm, Double_t cdfi);
-   virtual Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
-                                Double_t start, Double_t step);
-   virtual Double_t      GetAxisRange(Int_t iaxis, Double_t &xlo, Double_t &xhi) const;
-   virtual void          GetBoundingCylinder(Double_t *param) const;
-   virtual const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const;
-   virtual Int_t         GetByteCount() const {return 56;}
-   virtual Bool_t        GetPointsOnSegments(Int_t npoints, Double_t *array) const;
-   virtual TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const;
-   virtual Int_t         GetNmeshVertices() const;
-   virtual void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const;
+   Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
+                                Double_t start, Double_t step) override;
+   Double_t      GetAxisRange(Int_t iaxis, Double_t &xlo, Double_t &xhi) const override;
+   void          GetBoundingCylinder(Double_t *param) const override;
+   const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const override;
+   Int_t         GetByteCount() const override {return 56;}
+   Bool_t        GetPointsOnSegments(Int_t npoints, Double_t *array) const override;
+   TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const override;
+   Int_t         GetNmeshVertices() const override;
+   void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const override;
    Double_t              GetPhi1() const {return fPhi1;}
    Double_t              GetPhi2() const {return fPhi2;}
-   virtual void          InspectShape() const;
-   virtual TBuffer3D    *MakeBuffer3D() const;
-   virtual Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const;
-   virtual void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const;
+   void          InspectShape() const override;
+   TBuffer3D    *MakeBuffer3D() const override;
+   Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const override;
+   void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const override;
    static  Double_t      SafetyS(const Double_t *point, Bool_t in, Double_t rmin, Double_t rmax, Double_t dz,
                                  Double_t phi1, Double_t phi2, Int_t skipz=0);
-   virtual void          SavePrimitive(std::ostream &out, Option_t *option = "");
+   void          SavePrimitive(std::ostream &out, Option_t *option = "") override;
    void                  SetTubsDimensions(Double_t rmin, Double_t rmax, Double_t dz,
                                        Double_t phi1, Double_t phi2);
-   virtual void          SetDimensions(Double_t *param);
-   virtual void          SetPoints(Double_t *points) const;
-   virtual void          SetPoints(Float_t *points) const;
-   virtual void          SetSegsAndPols(TBuffer3D &buff) const;
-   virtual void          Sizeof3D() const;
+   void          SetDimensions(Double_t *param) override;
+   void          SetPoints(Double_t *points) const override;
+   void          SetPoints(Float_t *points) const override;
+   void          SetSegsAndPols(TBuffer3D &buff) const override;
+   void          Sizeof3D() const override;
 
-   ClassDef(TGeoTubeSeg, 2)         // cylindrical tube segment class
+   ClassDefOverride(TGeoTubeSeg, 2)         // cylindrical tube segment class
 };
 
 class TGeoCtub : public TGeoTubeSeg
@@ -184,44 +184,44 @@ public:
             Double_t lx, Double_t ly, Double_t lz, Double_t tx, Double_t ty, Double_t tz);
    TGeoCtub(Double_t *params);
    // destructor
-   virtual ~TGeoCtub();
+   ~TGeoCtub() override;
    // methods
-   virtual Double_t      Capacity() const;
-   virtual void          ComputeBBox();
-   virtual void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm);
-   virtual void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize);
-   virtual Bool_t        Contains(const Double_t *point) const;
-   virtual void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const;
-   virtual Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
-                                Double_t start, Double_t step);
-   virtual Double_t      GetAxisRange(Int_t iaxis, Double_t &xlo, Double_t &xhi) const;
-   virtual const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const;
-   virtual Int_t         GetByteCount() const {return 98;}
-   virtual Bool_t        GetPointsOnSegments(Int_t npoints, Double_t *array) const;
-   virtual TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const;
-   virtual void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const;
-   virtual Int_t         GetNmeshVertices() const;
+   Double_t      Capacity() const override;
+   void          ComputeBBox() override;
+   void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
+   Bool_t        Contains(const Double_t *point) const override;
+   void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;
+   Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   TGeoVolume   *Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndiv,
+                                Double_t start, Double_t step) override;
+   Double_t      GetAxisRange(Int_t iaxis, Double_t &xlo, Double_t &xhi) const override;
+   const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const override;
+   Int_t         GetByteCount() const override {return 98;}
+   Bool_t        GetPointsOnSegments(Int_t npoints, Double_t *array) const override;
+   TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const override;
+   void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const override;
+   Int_t         GetNmeshVertices() const override;
    const Double_t       *GetNlow() const {return &fNlow[0];}
    const Double_t       *GetNhigh() const {return &fNhigh[0];}
    Double_t              GetZcoord(Double_t xc, Double_t yc, Double_t zc) const;
-   virtual void          InspectShape() const;
-   virtual Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const;
-   virtual void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const;
-   virtual void          SavePrimitive(std::ostream &out, Option_t *option = "");
+   void          InspectShape() const override;
+   Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const override;
+   void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const override;
+   void          SavePrimitive(std::ostream &out, Option_t *option = "") override;
    void                  SetCtubDimensions(Double_t rmin, Double_t rmax, Double_t dz,
                                        Double_t phi1, Double_t phi2, Double_t lx, Double_t ly, Double_t lz,
                                        Double_t tx, Double_t ty, Double_t tz);
-   virtual void          SetDimensions(Double_t *param);
-   virtual void          SetPoints(Double_t *points) const;
-   virtual void          SetPoints(Float_t *points) const;
+   void          SetDimensions(Double_t *param) override;
+   void          SetPoints(Double_t *points) const override;
+   void          SetPoints(Float_t *points) const override;
 
-   ClassDef(TGeoCtub, 1)         // cut tube segment class
+   ClassDefOverride(TGeoCtub, 1)         // cut tube segment class
 };
 
 #endif

--- a/geom/geom/inc/TGeoVolume.h
+++ b/geom/geom/inc/TGeoVolume.h
@@ -91,10 +91,10 @@ public:
    TGeoVolume(const char *name, const TGeoShape *shape, const TGeoMedium *med=nullptr);
 
    // destructor
-   virtual ~TGeoVolume();
+   ~TGeoVolume() override;
    // methods
    virtual void    cd(Int_t inode) const;
-   void            Browse(TBrowser *b);
+   void            Browse(TBrowser *b) override;
    Double_t        Capacity() const;
    void            CheckShapes();
    void            ClearNodes() {fNodes = nullptr;}
@@ -110,7 +110,7 @@ public:
    static void     CreateDummyMedium();
    static TGeoMedium *DummyMedium();
    virtual Bool_t  IsAssembly() const;
-   virtual Bool_t  IsFolder() const;
+   Bool_t  IsFolder() const override;
    Bool_t          IsRunTime() const {return fShape->IsRunTimeShape();}
    virtual Bool_t  IsVolumeMulti() const {return kFALSE;}
    virtual TGeoNode *
@@ -119,14 +119,14 @@ public:
    virtual void    AddNodeOverlap(TGeoVolume *vol, Int_t copy_no, TGeoMatrix *mat=nullptr, Option_t *option="");
 
    virtual TGeoVolume *Divide(const char *divname, Int_t iaxis, Int_t ndiv, Double_t start, Double_t step, Int_t numed=0, Option_t *option="");
-   virtual Int_t   DistancetoPrimitive(Int_t px, Int_t py);
-   virtual void    Draw(Option_t *option=""); // *MENU*
+   Int_t   DistancetoPrimitive(Int_t px, Int_t py) override;
+   void    Draw(Option_t *option="") override; // *MENU*
    virtual void    DrawOnly(Option_t *option=""); // *MENU*
    TH2F           *LegoPlot(Int_t ntheta=20, Double_t themin=0., Double_t themax=180.,
                             Int_t nphi=60, Double_t phimin=0., Double_t phimax=360.,
                             Double_t rmin=0., Double_t rmax=9999999, Option_t *option=""); // *MENU*
-   virtual void    Paint(Option_t *option="");
-   virtual void    Print(Option_t *option="") const; // *MENU*
+   void    Paint(Option_t *option="") override;
+   void    Print(Option_t *option="") const override; // *MENU*
    void            PrintNodes() const;
    void            PrintVoxels() const; // *MENU*
    void            ReplayCreation(const TGeoVolume *other);
@@ -139,7 +139,7 @@ public:
    TGeoExtension  *GrabFWExtension() const;
    void            Grab()                   {fRefCount++;}
    void            Release()                {fRefCount--; if (fRefCount==0) delete this;}
-   virtual void    ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   void    ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
 
    Bool_t          IsActive() const {return TGeoAtt::IsActive();}
    Bool_t          IsActiveDaughters() const {return TGeoAtt::IsActiveDaughters();}
@@ -175,15 +175,15 @@ public:
    TObject        *GetField() const                  {return fField;}
    TGeoPatternFinder *GetFinder() const              {return fFinder;}
    TGeoVoxelFinder   *GetVoxels() const;
-   const char     *GetIconName() const               {return fShape->GetName();}
+   const char     *GetIconName() const override               {return fShape->GetName();}
    Int_t           GetIndex(const TGeoNode *node) const;
    TGeoNode       *GetNode(const char *name) const;
    TGeoNode       *GetNode(Int_t i) const {return (TGeoNode*)fNodes->UncheckedAt(i);}
    Int_t           GetNodeIndex(const TGeoNode *node, Int_t *check_list, Int_t ncheck) const;
    Int_t           GetNumber() const {return fNumber;}
-   virtual char   *GetObjectInfo(Int_t px, Int_t py) const;
+   char   *GetObjectInfo(Int_t px, Int_t py) const override;
    Bool_t          GetOptimalVoxels() const;
-   Option_t       *GetOption() const { return fOption.Data(); }
+   Option_t       *GetOption() const override { return fOption.Data(); }
    const char     *GetPointerName() const;
    Char_t          GetTransparency() const { return !fMedium ? 0 : fMedium->GetMaterial()->GetTransparency(); }
    TGeoShape      *GetShape() const                  {return fShape;}
@@ -202,8 +202,8 @@ public:
    void            RegisterYourself(Option_t *option="");
    void            RemoveNode(TGeoNode *node);
    TGeoNode       *ReplaceNode(TGeoNode *nodeorig, TGeoShape *newshape=nullptr, TGeoMatrix *newpos=nullptr, TGeoMedium *newmed=nullptr);
-   void            SaveAs(const char *filename,Option_t *option="") const; // *MENU*
-   virtual void    SavePrimitive(std::ostream &out, Option_t *option = "");
+   void            SaveAs(const char *filename,Option_t *option="") const override; // *MENU*
+   void    SavePrimitive(std::ostream &out, Option_t *option = "") override;
    void            SelectVolume(Bool_t clear = kFALSE);
    void            SetActivity(Bool_t flag=kTRUE) {TGeoAtt::SetActivity(flag);}
    void            SetActiveDaughters(Bool_t flag=kTRUE) {TGeoAtt::SetActiveDaughters(flag);}
@@ -219,13 +219,13 @@ public:
    void            SetField(TObject *field)          {fField = field;}
    void            SetOption(const char *option);
    void            SetAttVisibility(Bool_t vis) {TGeoAtt::SetVisibility(vis);}
-   virtual void    SetVisibility(Bool_t vis=kTRUE); // *TOGGLE* *GETTER=IsVisible
-   virtual void    SetVisContainers(Bool_t flag=kTRUE); // *TOGGLE* *GETTER=IsVisContainers
-   virtual void    SetVisLeaves(Bool_t flag=kTRUE); // *TOGGLE* *GETTER=IsVisLeaves
-   virtual void    SetVisOnly(Bool_t flag=kTRUE); // *TOGGLE* *GETTER=IsVisOnly
-   virtual void    SetLineColor(Color_t lcolor);
-   virtual void    SetLineStyle(Style_t lstyle);
-   virtual void    SetLineWidth(Width_t lwidth);
+   void    SetVisibility(Bool_t vis=kTRUE) override; // *TOGGLE* *GETTER=IsVisible
+   void    SetVisContainers(Bool_t flag=kTRUE) override; // *TOGGLE* *GETTER=IsVisContainers
+   void    SetVisLeaves(Bool_t flag=kTRUE) override; // *TOGGLE* *GETTER=IsVisLeaves
+   void    SetVisOnly(Bool_t flag=kTRUE) override; // *TOGGLE* *GETTER=IsVisOnly
+   void    SetLineColor(Color_t lcolor) override;
+   void    SetLineStyle(Style_t lstyle) override;
+   void    SetLineWidth(Width_t lwidth) override;
    void            SetInvisible() {SetVisibility(kFALSE);}
    virtual void    SetMedium(TGeoMedium *medium) {fMedium = medium;}
    void            SetVoxelFinder(TGeoVoxelFinder *finder) {fVoxels = finder;}
@@ -241,7 +241,7 @@ public:
    Double_t        Weight(Double_t precision=0.01, Option_t *option="va"); // *MENU*
    Double_t        WeightA() const;
 
-   ClassDef(TGeoVolume, 6)              // geometry volume descriptor
+   ClassDefOverride(TGeoVolume, 6)              // geometry volume descriptor
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -269,29 +269,29 @@ private:
 public:
    TGeoVolumeMulti();
    TGeoVolumeMulti(const char* name, TGeoMedium *med=nullptr);
-   virtual ~TGeoVolumeMulti();
+   ~TGeoVolumeMulti() override;
 
    void            AddVolume(TGeoVolume *vol);
    TGeoVolume     *GetVolume(Int_t id) const {return (TGeoVolume*)fVolumes->At(id);}
-   virtual TGeoNode *
-   AddNode(TGeoVolume *vol, Int_t copy_no, TGeoMatrix *mat, Option_t *option = ""); // most general case
-   virtual void    AddNodeOverlap(TGeoVolume *vol, Int_t copy_no, TGeoMatrix *mat, Option_t *option="");
-   virtual TGeoVolume *Divide(const char *divname, Int_t iaxis, Int_t ndiv, Double_t start, Double_t step, Int_t numed=0, Option_t *option="");
+   TGeoNode *
+   AddNode(TGeoVolume *vol, Int_t copy_no, TGeoMatrix *mat, Option_t *option = "") override; // most general case
+   void    AddNodeOverlap(TGeoVolume *vol, Int_t copy_no, TGeoMatrix *mat, Option_t *option="") override;
+   TGeoVolume *Divide(const char *divname, Int_t iaxis, Int_t ndiv, Double_t start, Double_t step, Int_t numed=0, Option_t *option="") override;
    TGeoShape      *GetLastShape() const;
    Int_t           GetNvolumes() const {return fVolumes->GetEntriesFast();}
    Int_t           GetAxis() const {return fNdiv;}
    Int_t           GetNdiv() const {return fNdiv;}
    Double_t        GetStart() const {return fStart;}
    Double_t        GetStep() const {return fStep;}
-   virtual Bool_t  IsVolumeMulti() const {return kTRUE;}
-   virtual TGeoVolume *MakeCopyVolume(TGeoShape *newshape);
-   virtual void    SetLineColor(Color_t lcolor);
-   virtual void    SetLineStyle(Style_t lstyle);
-   virtual void    SetLineWidth(Width_t lwidth);
-   virtual void    SetMedium(TGeoMedium *medium);
-   virtual void    SetVisibility(Bool_t vis=kTRUE);
+   Bool_t  IsVolumeMulti() const override {return kTRUE;}
+   TGeoVolume *MakeCopyVolume(TGeoShape *newshape) override;
+   void    SetLineColor(Color_t lcolor) override;
+   void    SetLineStyle(Style_t lstyle) override;
+   void    SetLineWidth(Width_t lwidth) override;
+   void    SetMedium(TGeoMedium *medium) override;
+   void    SetVisibility(Bool_t vis=kTRUE) override;
 
-   ClassDef(TGeoVolumeMulti, 3)     // class to handle multiple volumes in one step
+   ClassDefOverride(TGeoVolumeMulti, 3)     // class to handle multiple volumes in one step
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -314,8 +314,8 @@ public:
    };
 
    ThreadData_t& GetThreadData()   const;
-   virtual void  ClearThreadData() const;
-   virtual void  CreateThreadData(Int_t nthreads);
+   void  ClearThreadData() const override;
+   void  CreateThreadData(Int_t nthreads) override;
 
 protected:
    mutable std::vector<ThreadData_t*> fThreadData; //! Thread specific data vector
@@ -329,23 +329,23 @@ private:
 public:
    TGeoVolumeAssembly();
    TGeoVolumeAssembly(const char *name);
-   virtual ~TGeoVolumeAssembly();
+   ~TGeoVolumeAssembly() override;
 
-   virtual TGeoNode *AddNode(TGeoVolume *vol, Int_t copy_no, TGeoMatrix *mat = nullptr, Option_t *option = "");
-   virtual void    AddNodeOverlap(TGeoVolume *vol, Int_t copy_no, TGeoMatrix *mat, Option_t *option);
-   virtual TGeoVolume *CloneVolume() const;
-   virtual TGeoVolume *Divide(const char *divname, Int_t iaxis, Int_t ndiv, Double_t start, Double_t step, Int_t numed=0, Option_t *option="");
+   TGeoNode *AddNode(TGeoVolume *vol, Int_t copy_no, TGeoMatrix *mat = nullptr, Option_t *option = "") override;
+   void    AddNodeOverlap(TGeoVolume *vol, Int_t copy_no, TGeoMatrix *mat, Option_t *option) override;
+   TGeoVolume *CloneVolume() const override;
+   TGeoVolume *Divide(const char *divname, Int_t iaxis, Int_t ndiv, Double_t start, Double_t step, Int_t numed=0, Option_t *option="") override;
    TGeoVolume     *Divide(TGeoVolume *cell, TGeoPatternFinder *pattern, Option_t *option="spacedout");
-   virtual void    DrawOnly(Option_t *) {}
-   virtual Int_t   GetCurrentNodeIndex() const;
-   virtual Int_t   GetNextNodeIndex() const;
-   virtual Bool_t  IsAssembly() const {return kTRUE;}
-   virtual Bool_t  IsVisible() const {return kFALSE;}
+   void    DrawOnly(Option_t *) override {}
+   Int_t   GetCurrentNodeIndex() const override;
+   Int_t   GetNextNodeIndex() const override;
+   Bool_t  IsAssembly() const override {return kTRUE;}
+   Bool_t  IsVisible() const override {return kFALSE;}
    static TGeoVolumeAssembly *MakeAssemblyFromVolume(TGeoVolume *vol);
    void            SetCurrentNodeIndex(Int_t index);
    void            SetNextNodeIndex(Int_t index);
 
-   ClassDef(TGeoVolumeAssembly, 2)   // an assembly of volumes
+   ClassDefOverride(TGeoVolumeAssembly, 2)   // an assembly of volumes
 };
 
 inline Int_t TGeoVolume::GetNdaughters() const {if (!fNodes) return 0; return (fNodes->GetEntriesFast());}

--- a/geom/geom/inc/TGeoVoxelFinder.h
+++ b/geom/geom/inc/TGeoVoxelFinder.h
@@ -94,7 +94,7 @@ protected:
 public :
    TGeoVoxelFinder();
    TGeoVoxelFinder(TGeoVolume *vol);
-   virtual ~TGeoVoxelFinder();
+   ~TGeoVoxelFinder() override;
    void                DaughterToMother(Int_t id, const Double_t *local, Double_t *master) const;
    virtual Double_t    Efficiency();
    virtual Int_t      *GetCheckList(const Double_t *point, Int_t &nelem, TGeoStateInfo &td);
@@ -105,7 +105,7 @@ public :
    Bool_t              NeedRebuild() const {return TObject::TestBit(kGeoRebuildVoxels);}
    Double_t           *GetBoxes() const {return fBoxes;}
    Bool_t              IsSafeVoxel(const Double_t *point, Int_t inode, Double_t minsafe) const;
-   virtual void        Print(Option_t *option="") const;
+   void        Print(Option_t *option="") const override;
    void                PrintVoxelLimits(const Double_t *point) const;
    void                SetInvalid(Bool_t flag=kTRUE) {TObject::SetBit(kGeoInvalidVoxels, flag);}
    void                SetNeedRebuild(Bool_t flag=kTRUE) {TObject::SetBit(kGeoRebuildVoxels, flag);}
@@ -113,7 +113,7 @@ public :
    virtual void        SortCrossedVoxels(const Double_t *point, const Double_t *dir, TGeoStateInfo &td);
    virtual void        Voxelize(Option_t *option="");
 
-   ClassDef(TGeoVoxelFinder, 4)                // voxel finder class
+   ClassDefOverride(TGeoVoxelFinder, 4)                // voxel finder class
 };
 
 #endif

--- a/geom/geom/inc/TGeoXtru.h
+++ b/geom/geom/inc/TGeoXtru.h
@@ -34,8 +34,8 @@ public:
       ~ThreadData_t();
    };
    ThreadData_t&         GetThreadData()   const;
-   virtual void          ClearThreadData() const;
-   virtual void          CreateThreadData(Int_t nthreads);
+   void          ClearThreadData() const override;
+   void          CreateThreadData(Int_t nthreads) override;
 
 protected:
    // data members
@@ -71,25 +71,25 @@ public:
    TGeoXtru(Int_t nz);
    TGeoXtru(Double_t *param);
    // destructor
-   virtual ~TGeoXtru();
+   ~TGeoXtru() override;
    // methods
-   virtual Double_t      Capacity() const;
-   virtual void          ComputeBBox();
-   virtual void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm);
-   virtual void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize);
-   virtual Bool_t        Contains(const Double_t *point) const;
-   virtual void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const;
+   Double_t      Capacity() const override;
+   void          ComputeBBox() override;
+   void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   void          ComputeNormal_v(const Double_t *points, const Double_t *dirs, Double_t *norms, Int_t vecsize) override;
+   Bool_t        Contains(const Double_t *point) const override;
+   void          Contains_v(const Double_t *points, Bool_t *inside, Int_t vecsize) const override;
    Bool_t                DefinePolygon(Int_t nvert, const Double_t *xv, const Double_t *yv);
    virtual void          DefineSection(Int_t snum, Double_t z, Double_t x0=0., Double_t y0=0., Double_t scale=1.);
-   virtual Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const;
-   virtual Int_t         DistancetoPrimitive(Int_t px, Int_t py);
+   Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromInside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   void          DistFromOutside_v(const Double_t *points, const Double_t *dirs, Double_t *dists, Int_t vecsize, Double_t *step) const override;
+   Int_t         DistancetoPrimitive(Int_t px, Int_t py) override;
    void                  DrawPolygon(Option_t *option="");
-   virtual const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const;
+   const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const override;
 //   virtual Int_t         GetByteCount() const {return 60+12*fNz;}
    Int_t                 GetNz() const    {return fNz;}
    Int_t                 GetNvert() const {return fNvert;}
@@ -100,24 +100,24 @@ public:
    Double_t              GetScale(Int_t i) const {return (i<fNz&&i>-1 && fScale) ? fScale[i] : 1.0;}
    Double_t             *GetZ() const     {return fZ;}
    Double_t              GetZ(Int_t ipl) const;
-   virtual TGeoShape    *GetMakeRuntimeShape(TGeoShape * /*mother*/, TGeoMatrix * /*mat*/) const {return nullptr;}
-   virtual void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const;
-   virtual Int_t         GetNmeshVertices() const;
-   virtual void          InspectShape() const;
-   virtual TBuffer3D    *MakeBuffer3D() const;
+   TGeoShape    *GetMakeRuntimeShape(TGeoShape * /*mother*/, TGeoMatrix * /*mat*/) const override {return nullptr;}
+   void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const override;
+   Int_t         GetNmeshVertices() const override;
+   void          InspectShape() const override;
+   TBuffer3D    *MakeBuffer3D() const override;
    Double_t             &Z(Int_t ipl) {return fZ[ipl];}
-   virtual Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const;
-   virtual void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const;
-   virtual void          SavePrimitive(std::ostream &out, Option_t *option = "");
+   Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const override;
+   void          Safety_v(const Double_t *points, const Bool_t *inside, Double_t *safe, Int_t vecsize) const override;
+   void          SavePrimitive(std::ostream &out, Option_t *option = "") override;
    void                  SetCurrentZ(Double_t z, Int_t iz);
    void                  SetCurrentVertices(Double_t x0, Double_t y0, Double_t scale);
-   virtual void          SetDimensions(Double_t *param);
-   virtual void          SetPoints(Double_t *points) const;
-   virtual void          SetPoints(Float_t *points) const;
-   virtual void          SetSegsAndPols(TBuffer3D &buff) const;
-   virtual void          Sizeof3D() const;
+   void          SetDimensions(Double_t *param) override;
+   void          SetPoints(Double_t *points) const override;
+   void          SetPoints(Float_t *points) const override;
+   void          SetSegsAndPols(TBuffer3D &buff) const override;
+   void          Sizeof3D() const override;
 
-   ClassDef(TGeoXtru, 3)         // extruded polygon class
+   ClassDefOverride(TGeoXtru, 3)         // extruded polygon class
 };
 
 #endif

--- a/geom/geom/inc/TVirtualGeoConverter.h
+++ b/geom/geom/inc/TVirtualGeoConverter.h
@@ -22,14 +22,14 @@ protected:
    TGeoManager                   *fGeom; // Pointer to geometry manager
 public:
    TVirtualGeoConverter(TGeoManager *geom);
-   virtual ~TVirtualGeoConverter();
+   ~TVirtualGeoConverter() override;
 
    virtual void       ConvertGeometry() {}
    static  TVirtualGeoConverter *Instance(TGeoManager *geom=nullptr);
    static void        SetConverter(const TVirtualGeoConverter *conv);
    void               SetGeometry(TGeoManager *geom) { fGeom = geom; }
 
-   ClassDef(TVirtualGeoConverter,0)  // Abstract interface for geometry converters
+   ClassDefOverride(TVirtualGeoConverter,0)  // Abstract interface for geometry converters
 };
 
 #endif

--- a/geom/geom/inc/TVirtualGeoPainter.h
+++ b/geom/geom/inc/TVirtualGeoPainter.h
@@ -54,7 +54,7 @@ enum EGeoBombOption {
 
 public:
    TVirtualGeoPainter(TGeoManager *manager);
-   virtual ~TVirtualGeoPainter();
+   ~TVirtualGeoPainter() override;
 
    virtual void       AddSize3D(Int_t numpoints, Int_t numsegs, Int_t numpolys) = 0;
    virtual TVirtualGeoTrack *AddTrack(Int_t id, Int_t pdgcode, TObject *particle) = 0;
@@ -106,7 +106,7 @@ public:
                             Double_t rmin=0., Double_t rmax=9999999, Option_t *option="") = 0;
    virtual void       ModifiedPad(Bool_t update=kFALSE) const = 0;
    virtual void       OpProgress(const char *opname, Long64_t current, Long64_t size, TStopwatch *watch=nullptr, Bool_t last=kFALSE, Bool_t refresh=kFALSE, const char *msg="") = 0;
-   virtual void       Paint(Option_t *option="") = 0;
+   void       Paint(Option_t *option="") override = 0;
    virtual void       PaintNode(TGeoNode *node, Option_t *option="", TGeoMatrix* global=nullptr) = 0;
    virtual void       PaintShape(TGeoShape *shape, Option_t *option="") = 0;
    virtual void       PaintOverlap(void *ovlp, Option_t *option="")  = 0;
@@ -139,7 +139,7 @@ public:
    virtual void       UnbombTranslation(const Double_t *tr, Double_t *bombtr) = 0;
    virtual Double_t   Weight(Double_t precision, Option_t *option="v") = 0;
 
-   ClassDef(TVirtualGeoPainter,0)  //Abstract interface for geometry painters
+   ClassDefOverride(TVirtualGeoPainter,0)  //Abstract interface for geometry painters
 };
 
 #endif

--- a/geom/geom/inc/TVirtualGeoTrack.h
+++ b/geom/geom/inc/TVirtualGeoTrack.h
@@ -38,7 +38,7 @@ protected:
 public:
    TVirtualGeoTrack();
    TVirtualGeoTrack(Int_t id, Int_t pdgcode, TVirtualGeoTrack *parent=nullptr, TObject *particle=nullptr);
-   virtual ~TVirtualGeoTrack();
+   ~TVirtualGeoTrack() override;
 
    virtual TVirtualGeoTrack *AddDaughter(Int_t id, Int_t pdgcode, TObject *particle=nullptr) = 0;
    virtual Int_t       AddDaughter(TVirtualGeoTrack *other) = 0;
@@ -49,7 +49,7 @@ public:
    TVirtualGeoTrack   *GetDaughter(Int_t index) const {return (TVirtualGeoTrack*)fTracks->At(index);}
    TVirtualGeoTrack   *GetMother() const {return fParent;}
    TObject            *GetMotherParticle() const {return fParent ? fParent->GetParticle() : nullptr;}
-   virtual const char *GetName() const;
+   const char *GetName() const override;
    Int_t               GetNdaughters() const {return fTracks ? fTracks->GetEntriesFast() : 0;}
    virtual Int_t       GetNpoints() const = 0;
    Int_t               GetParentId() const   {return fParent?fParent->GetId():-1;}
@@ -62,7 +62,7 @@ public:
    virtual const Double_t *GetPoint(Int_t i) const = 0;
    Bool_t              HasPoints() const {return (GetNpoints()==0)?kFALSE:kTRUE;}
    Bool_t              IsInTimeRange() const;
-   virtual void        Paint(Option_t *option="") = 0;
+   void        Paint(Option_t *option="") override = 0;
    virtual void        PaintCollect(Double_t /*time*/, Double_t * /*box*/) {}
    virtual void        PaintCollectTrack(Double_t /*time*/, Double_t * /*box*/) {}
    virtual void        PaintTrack(Option_t *option="") = 0;
@@ -73,7 +73,7 @@ public:
    void                SetId(Int_t id)       {fId = id;}
    virtual void        SetPDG(Int_t pdgcode) {fPDG = pdgcode;}
 
-   ClassDef(TVirtualGeoTrack, 1)              // virtual geometry tracks
+   ClassDefOverride(TVirtualGeoTrack, 1)              // virtual geometry tracks
 };
 
 #endif

--- a/geom/geom/inc/TVirtualMagField.h
+++ b/geom/geom/inc/TVirtualMagField.h
@@ -18,11 +18,11 @@ class TVirtualMagField : public TNamed
 public:
    TVirtualMagField()                 : TNamed() {}
    TVirtualMagField(const char *name) : TNamed(name,"") {}
-   virtual ~TVirtualMagField();
+   ~TVirtualMagField() override;
 
    virtual void Field(const Double_t *x, Double_t *B) = 0;
 
-   ClassDef(TVirtualMagField, 1)              // Abstract base field class
+   ClassDefOverride(TVirtualMagField, 1)              // Abstract base field class
 };
 
 
@@ -44,7 +44,7 @@ protected:
 public:
    TGeoUniformMagField();
    TGeoUniformMagField(Double_t Bx, Double_t By, Double_t Bz);
-   virtual ~TGeoUniformMagField() {}
+   ~TGeoUniformMagField() override {}
 
    void            Field(const Double_t * /*x*/, Double_t *B) override {B[0]=fB[0]; B[1]=fB[1]; B[2]=fB[2];}
 

--- a/geom/geombuilder/inc/TGeoBBoxEditor.h
+++ b/geom/geombuilder/inc/TGeoBBoxEditor.h
@@ -55,8 +55,8 @@ public:
                    Int_t width = 140, Int_t height = 30,
                    UInt_t options = kChildFrame,
                    Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGeoBBoxEditor();
-   virtual void   SetModel(TObject *obj);
+   ~TGeoBBoxEditor() override;
+   void   SetModel(TObject *obj) override;
 
    void           DoDx();
    void           DoDy();
@@ -69,7 +69,7 @@ public:
    void           DoApply();
    void           DoUndo();
 
-   ClassDef(TGeoBBoxEditor,0)   // TGeoBBox editor
+   ClassDefOverride(TGeoBBoxEditor,0)   // TGeoBBox editor
 };
 
 #endif

--- a/geom/geombuilder/inc/TGeoConeEditor.h
+++ b/geom/geombuilder/inc/TGeoConeEditor.h
@@ -58,8 +58,8 @@ public:
                   Int_t width = 140, Int_t height = 30,
                   UInt_t options = kChildFrame,
                   Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGeoConeEditor();
-   virtual void   SetModel(TObject *obj);
+   ~TGeoConeEditor() override;
+   void   SetModel(TObject *obj) override;
 
    void           DoRmin1();
    void           DoRmin2();
@@ -71,7 +71,7 @@ public:
    virtual void   DoApply();
    virtual void   DoUndo();
 
-   ClassDef(TGeoConeEditor,0)   // TGeoCone editor
+   ClassDefOverride(TGeoConeEditor,0)   // TGeoCone editor
 };
 
 
@@ -88,23 +88,23 @@ protected:
    TGNumberEntry   *fEPhi1;             // Number entry for phi1
    TGNumberEntry   *fEPhi2;             // Number entry for phi2
 
-   virtual void ConnectSignals2Slots();   // Connect the signals to the slots
+   void ConnectSignals2Slots() override;   // Connect the signals to the slots
 
 public:
    TGeoConeSegEditor(const TGWindow *p = nullptr,
                    Int_t width = 140, Int_t height = 30,
                    UInt_t options = kChildFrame,
                    Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGeoConeSegEditor();
-   virtual void   SetModel(TObject *obj);
+   ~TGeoConeSegEditor() override;
+   void   SetModel(TObject *obj) override;
 
    void           DoPhi();
    void           DoPhi1();
    void           DoPhi2();
-   virtual void   DoApply();
-   virtual void   DoUndo();
+   void   DoApply() override;
+   void   DoUndo() override;
 
-   ClassDef(TGeoConeSegEditor,0)   // TGeoConeSeg editor
+   ClassDefOverride(TGeoConeSegEditor,0)   // TGeoConeSeg editor
 };
 
 #endif

--- a/geom/geombuilder/inc/TGeoEltuEditor.h
+++ b/geom/geombuilder/inc/TGeoEltuEditor.h
@@ -52,8 +52,8 @@ public:
                    Int_t width = 140, Int_t height = 30,
                    UInt_t options = kChildFrame,
                    Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGeoEltuEditor();
-   virtual void   SetModel(TObject *obj);
+   ~TGeoEltuEditor() override;
+   void   SetModel(TObject *obj) override;
 
    void           DoA();
    void           DoB();
@@ -63,7 +63,7 @@ public:
    void           DoApply();
    void           DoUndo();
 
-   ClassDef(TGeoEltuEditor,0)   // TGeoEltu editor
+   ClassDefOverride(TGeoEltuEditor,0)   // TGeoEltu editor
 };
 
 #endif

--- a/geom/geombuilder/inc/TGeoGedFrame.h
+++ b/geom/geombuilder/inc/TGeoGedFrame.h
@@ -24,9 +24,9 @@ public:
                 Pixel_t back = GetDefaultFrameBackground());
 
    virtual void SetActive(Bool_t active = kTRUE);
-   virtual void Update();
+   void Update() override;
 
-   ClassDef(TGeoGedFrame, 0) // Common base-class for geombuilder editors.
+   ClassDefOverride(TGeoGedFrame, 0) // Common base-class for geombuilder editors.
 };
 
 #endif

--- a/geom/geombuilder/inc/TGeoHypeEditor.h
+++ b/geom/geombuilder/inc/TGeoHypeEditor.h
@@ -56,8 +56,8 @@ public:
                    Int_t width = 140, Int_t height = 30,
                    UInt_t options = kChildFrame,
                    Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGeoHypeEditor();
-   virtual void   SetModel(TObject *obj);
+   ~TGeoHypeEditor() override;
+   void   SetModel(TObject *obj) override;
 
    void           DoRin();
    void           DoRout();
@@ -69,7 +69,7 @@ public:
    void           DoApply();
    void           DoUndo();
 
-   ClassDef(TGeoHypeEditor,0)   // TGeoHype editor
+   ClassDefOverride(TGeoHypeEditor,0)   // TGeoHype editor
 };
 
 #endif

--- a/geom/geombuilder/inc/TGeoManagerEditor.h
+++ b/geom/geombuilder/inc/TGeoManagerEditor.h
@@ -112,9 +112,9 @@ public:
                     Int_t width = 140, Int_t height = 30,
                     UInt_t options = kChildFrame,
                     Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGeoManagerEditor();
+   ~TGeoManagerEditor() override;
    static void    LoadLib();
-   virtual void   SetModel(TObject *obj);
+   void   SetModel(TObject *obj) override;
 
    virtual void   SelectedSlot(TVirtualPad* pad, TObject* obj, Int_t event);
    void           ConnectSelected(TCanvas *c);
@@ -168,7 +168,7 @@ public:
    void           DoExportGeometry();
    void           DoCloseGeometry();
 
-   ClassDef(TGeoManagerEditor,0)   // TGeoManager editor
+   ClassDefOverride(TGeoManagerEditor,0)   // TGeoManager editor
 };
 
 #endif

--- a/geom/geombuilder/inc/TGeoMaterialEditor.h
+++ b/geom/geombuilder/inc/TGeoMaterialEditor.h
@@ -59,8 +59,8 @@ public:
                    Int_t width = 140, Int_t height = 30,
                    UInt_t options = kChildFrame,
                    Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGeoMaterialEditor();
-   virtual void   SetModel(TObject *obj);
+   ~TGeoMaterialEditor() override;
+   void   SetModel(TObject *obj) override;
 
    void           DoA();
    void           DoZ();
@@ -74,7 +74,7 @@ public:
    void           DoApply();
    void           DoUndo();
 
-   ClassDef(TGeoMaterialEditor,0)   // TGeoMaterial editor
+   ClassDefOverride(TGeoMaterialEditor,0)   // TGeoMaterial editor
 };
 
 class TGCheckButton;
@@ -97,15 +97,15 @@ protected:
    TGTextButton        *fBAddElem;          // Button for adding element as component
    TGCompositeFrame    *fComps;             // Frame with components
 
-   virtual void ConnectSignals2Slots();     // Connect the signals to the slots
+   void ConnectSignals2Slots() override;     // Connect the signals to the slots
 
 public:
    TGeoMixtureEditor(const TGWindow *p = nullptr,
                    Int_t width = 140, Int_t height = 30,
                    UInt_t options = kChildFrame,
                    Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGeoMixtureEditor() {}
-   virtual void   SetModel(TObject *obj);
+   ~TGeoMixtureEditor() override {}
+   void   SetModel(TObject *obj) override;
    void           UpdateElements();
 
    void           DoApply1();
@@ -117,7 +117,7 @@ public:
    void           DoSelectElement(Int_t iel);
    void           DoAddElem();
 
-   ClassDef(TGeoMixtureEditor,0)   // TGeoMixture editor
+   ClassDefOverride(TGeoMixtureEditor,0)   // TGeoMixture editor
 };
 
 #endif

--- a/geom/geombuilder/inc/TGeoMatrixEditor.h
+++ b/geom/geombuilder/inc/TGeoMatrixEditor.h
@@ -53,8 +53,8 @@ public:
                    Int_t width = 140, Int_t height = 30,
                    UInt_t options = kChildFrame,
                    Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGeoTranslationEditor();
-   virtual void   SetModel(TObject *obj);
+   ~TGeoTranslationEditor() override;
+   void   SetModel(TObject *obj) override;
 
    void           DoDx();
    void           DoDy();
@@ -66,7 +66,7 @@ public:
    void           DoCancel();
    void           DoUndo();
 
-   ClassDef(TGeoTranslationEditor,0)   // TGeoTranslation editor
+   ClassDefOverride(TGeoTranslationEditor,0)   // TGeoTranslation editor
 };
 
 
@@ -103,8 +103,8 @@ public:
                    Int_t width = 140, Int_t height = 30,
                    UInt_t options = kChildFrame,
                    Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGeoRotationEditor();
-   virtual void   SetModel(TObject *obj);
+   ~TGeoRotationEditor() override;
+   void   SetModel(TObject *obj) override;
 
    void           DoRotPhi();
    void           DoRotTheta();
@@ -117,7 +117,7 @@ public:
    void           DoCancel();
    void           DoUndo();
 
-   ClassDef(TGeoRotationEditor,0)   // TGeoRotation editor
+   ClassDefOverride(TGeoRotationEditor,0)   // TGeoRotation editor
 };
 
 
@@ -160,8 +160,8 @@ public:
                    Int_t width = 140, Int_t height = 30,
                    UInt_t options = kChildFrame,
                    Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGeoCombiTransEditor();
-   virtual void   SetModel(TObject *obj);
+   ~TGeoCombiTransEditor() override;
+   void   SetModel(TObject *obj) override;
 
    void           DoDx();
    void           DoDy();
@@ -177,7 +177,7 @@ public:
    void           DoCancel();
    void           DoUndo();
 
-   ClassDef(TGeoCombiTransEditor,0)   // TGeoCombiTrans editor
+   ClassDefOverride(TGeoCombiTransEditor,0)   // TGeoCombiTrans editor
 };
 
 #endif

--- a/geom/geombuilder/inc/TGeoMediumEditor.h
+++ b/geom/geombuilder/inc/TGeoMediumEditor.h
@@ -60,8 +60,8 @@ public:
                    Int_t width = 140, Int_t height = 30,
                    UInt_t options = kChildFrame,
                    Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGeoMediumEditor();
-   virtual void   SetModel(TObject *obj);
+   ~TGeoMediumEditor() override;
+   void   SetModel(TObject *obj) override;
 
    void           DoEditMaterial();
    void           DoSelectMaterial();
@@ -78,7 +78,7 @@ public:
    void           DoApply();
    void           DoUndo();
 
-   ClassDef(TGeoMediumEditor,0)   // TGeoMedium editor
+   ClassDefOverride(TGeoMediumEditor,0)   // TGeoMedium editor
 };
 
 #endif

--- a/geom/geombuilder/inc/TGeoNodeEditor.h
+++ b/geom/geombuilder/inc/TGeoNodeEditor.h
@@ -59,8 +59,8 @@ public:
                   Int_t width = 140, Int_t height = 30,
                   UInt_t options = kChildFrame,
                   Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGeoNodeEditor();
-   virtual void   SetModel(TObject *obj);
+   ~TGeoNodeEditor() override;
+   void   SetModel(TObject *obj) override;
 
    void           DoEditMother();
    void           DoEditVolume();
@@ -73,7 +73,7 @@ public:
    void           DoApply();
    void           DoUndo();
 
-   ClassDef(TGeoNodeEditor,0)   // TGeoNode editor
+   ClassDefOverride(TGeoNodeEditor,0)   // TGeoNode editor
 };
 
 #endif

--- a/geom/geombuilder/inc/TGeoParaEditor.h
+++ b/geom/geombuilder/inc/TGeoParaEditor.h
@@ -58,8 +58,8 @@ public:
                    Int_t width = 140, Int_t height = 30,
                    UInt_t options = kChildFrame,
                    Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGeoParaEditor();
-   virtual void   SetModel(TObject *obj);
+   ~TGeoParaEditor() override;
+   void   SetModel(TObject *obj) override;
 
    void           DoX();
    void           DoY();
@@ -72,7 +72,7 @@ public:
    void           DoApply();
    void           DoUndo();
 
-   ClassDef(TGeoParaEditor,0)   // TGeoPara editor
+   ClassDefOverride(TGeoParaEditor,0)   // TGeoPara editor
 };
 
 #endif

--- a/geom/geombuilder/inc/TGeoPconEditor.h
+++ b/geom/geombuilder/inc/TGeoPconEditor.h
@@ -64,8 +64,8 @@ public:
                    Int_t width = 140, Int_t height = 30,
                    UInt_t options = kChildFrame,
                    Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGeoPconEditor();
-   virtual void   SetModel(TObject *obj);
+   ~TGeoPconEditor() override;
+   void   SetModel(TObject *obj) override;
 
    void           DoModified();
    void           DoName();
@@ -75,7 +75,7 @@ public:
    virtual void   DoApply();
    virtual void   DoUndo();
 
-   ClassDef(TGeoPconEditor,0)   // TGeoPcon editor
+   ClassDefOverride(TGeoPconEditor,0)   // TGeoPcon editor
 };
 
 
@@ -91,7 +91,7 @@ protected:
 
 public:
    TGeoPconSection(const TGWindow *p, UInt_t w, UInt_t h, Int_t id);
-   virtual ~TGeoPconSection();
+   ~TGeoPconSection() override;
    void         HideDaughters();
    Double_t     GetZ() const;
    Double_t     GetRmin() const;
@@ -106,6 +106,6 @@ public:
 
    virtual void Changed(Int_t i);   // *SIGNAL*
 
-   ClassDef(TGeoPconSection,0)   // TGeoPcon section
+   ClassDefOverride(TGeoPconSection,0)   // TGeoPcon section
 };
 #endif

--- a/geom/geombuilder/inc/TGeoPgonEditor.h
+++ b/geom/geombuilder/inc/TGeoPgonEditor.h
@@ -23,20 +23,20 @@ protected:
    Int_t                fNedgesi;           // Initial number of edges
    TGNumberEntry       *fENedges;           // Number entry for nsections
 
-   virtual void CreateEdges();
+   void CreateEdges() override;
 
 public:
    TGeoPgonEditor(const TGWindow *p = nullptr,
                    Int_t width = 140, Int_t height = 30,
                    UInt_t options = kChildFrame,
                    Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGeoPgonEditor();
-   virtual void   SetModel(TObject *obj);
+   ~TGeoPgonEditor() override;
+   void   SetModel(TObject *obj) override;
 
    void           DoNedges();
-   virtual void   DoApply();
-   virtual void   DoUndo();
+   void   DoApply() override;
+   void   DoUndo() override;
 
-   ClassDef(TGeoPgonEditor,0)   // TGeoPgon editor
+   ClassDefOverride(TGeoPgonEditor,0)   // TGeoPgon editor
 };
 #endif

--- a/geom/geombuilder/inc/TGeoSphereEditor.h
+++ b/geom/geombuilder/inc/TGeoSphereEditor.h
@@ -62,8 +62,8 @@ public:
                   Int_t width = 140, Int_t height = 30,
                   UInt_t options = kChildFrame,
                   Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGeoSphereEditor();
-   virtual void   SetModel(TObject *obj);
+   ~TGeoSphereEditor() override;
+   void   SetModel(TObject *obj) override;
 
    void           DoRmin();
    void           DoRmax();
@@ -78,7 +78,7 @@ public:
    virtual void   DoApply();
    virtual void   DoUndo();
 
-   ClassDef(TGeoSphereEditor,0)   // TGeoSphere editor
+   ClassDefOverride(TGeoSphereEditor,0)   // TGeoSphere editor
 };
 
 #endif

--- a/geom/geombuilder/inc/TGeoTabManager.h
+++ b/geom/geombuilder/inc/TGeoTabManager.h
@@ -57,7 +57,7 @@ private:
    void                GetEditors(TClass *cl);
 public:
    TGeoTabManager(TGedEditor *ged);
-   virtual ~TGeoTabManager();
+   ~TGeoTabManager() override;
 
    static TGeoTabManager *GetMakeTabManager(TGedEditor *ged);
    static void         Cleanup(TGCompositeFrame *frame);
@@ -78,7 +78,7 @@ public:
    TGCompositeFrame   *GetVolumeTab() const {return fVolumeTab;}
    TGeoVolume         *GetVolume() const {return fVolume;}
 
-   ClassDef(TGeoTabManager, 0)   // Tab manager for geometry editors
+   ClassDefOverride(TGeoTabManager, 0)   // Tab manager for geometry editors
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -103,7 +103,7 @@ protected:
    virtual void        ConnectSignalsToSlots() = 0;
 public:
    TGeoTreeDialog(TGFrame *caller, const TGWindow *main, UInt_t w = 1, UInt_t h = 1);
-   virtual ~TGeoTreeDialog();
+   ~TGeoTreeDialog() override;
 
    static TObject     *GetSelected();
    // Slots
@@ -111,7 +111,7 @@ public:
    virtual void        DoItemClick(TGListTreeItem *item, Int_t btn) = 0;
    void                DoSelect(TGListTreeItem *item);
 
-   ClassDef(TGeoTreeDialog, 0)   // List-Tree based dialog
+   ClassDefOverride(TGeoTreeDialog, 0)   // List-Tree based dialog
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -125,18 +125,18 @@ public:
 class TGeoVolumeDialog : public TGeoTreeDialog {
 
 protected:
-   virtual void        BuildListTree();
-   virtual void        ConnectSignalsToSlots();
+   void        BuildListTree() override;
+   void        ConnectSignalsToSlots() override;
 
 public:
    TGeoVolumeDialog(TGFrame *caller, const TGWindow *main, UInt_t w = 1, UInt_t h = 1);
-   virtual ~TGeoVolumeDialog() {}
+   ~TGeoVolumeDialog() override {}
 
    // Slots
-   virtual void        DoClose();
-   virtual void        DoItemClick(TGListTreeItem *item, Int_t btn);
+   void        DoClose() override;
+   void        DoItemClick(TGListTreeItem *item, Int_t btn) override;
 
-   ClassDef(TGeoVolumeDialog, 0)   // List-Tree based volume dialog
+   ClassDefOverride(TGeoVolumeDialog, 0)   // List-Tree based volume dialog
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -150,18 +150,18 @@ public:
 class TGeoShapeDialog : public TGeoTreeDialog {
 
 protected:
-   virtual void        BuildListTree();
-   virtual void        ConnectSignalsToSlots();
+   void        BuildListTree() override;
+   void        ConnectSignalsToSlots() override;
 
 public:
    TGeoShapeDialog(TGFrame *caller, const TGWindow *main, UInt_t w = 1, UInt_t h = 1);
-   virtual ~TGeoShapeDialog() {}
+   ~TGeoShapeDialog() override {}
 
    // Slots
-   virtual void        DoClose();
-   virtual void        DoItemClick(TGListTreeItem *item, Int_t btn);
+   void        DoClose() override;
+   void        DoItemClick(TGListTreeItem *item, Int_t btn) override;
 
-   ClassDef(TGeoShapeDialog, 0)   // List-Tree based shape dialog
+   ClassDefOverride(TGeoShapeDialog, 0)   // List-Tree based shape dialog
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -175,18 +175,18 @@ public:
 class TGeoMediumDialog : public TGeoTreeDialog {
 
 protected:
-   virtual void        BuildListTree();
-   virtual void        ConnectSignalsToSlots();
+   void        BuildListTree() override;
+   void        ConnectSignalsToSlots() override;
 
 public:
    TGeoMediumDialog(TGFrame *caller, const TGWindow *main, UInt_t w = 1, UInt_t h = 1);
-   virtual ~TGeoMediumDialog() {}
+   ~TGeoMediumDialog() override {}
 
    // Slots
-   virtual void        DoClose();
-   virtual void        DoItemClick(TGListTreeItem *item, Int_t btn);
+   void        DoClose() override;
+   void        DoItemClick(TGListTreeItem *item, Int_t btn) override;
 
-   ClassDef(TGeoMediumDialog, 0)   // List-Tree based medium dialog
+   ClassDefOverride(TGeoMediumDialog, 0)   // List-Tree based medium dialog
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -200,18 +200,18 @@ public:
 class TGeoMaterialDialog : public TGeoTreeDialog {
 
 protected:
-   virtual void        BuildListTree();
-   virtual void        ConnectSignalsToSlots();
+   void        BuildListTree() override;
+   void        ConnectSignalsToSlots() override;
 
 public:
    TGeoMaterialDialog(TGFrame *caller, const TGWindow *main, UInt_t w = 1, UInt_t h = 1);
-   virtual ~TGeoMaterialDialog() {}
+   ~TGeoMaterialDialog() override {}
 
    // Slots
-   virtual void        DoClose();
-   virtual void        DoItemClick(TGListTreeItem *item, Int_t btn);
+   void        DoClose() override;
+   void        DoItemClick(TGListTreeItem *item, Int_t btn) override;
 
-   ClassDef(TGeoMaterialDialog, 0)   // List-Tree based material dialog
+   ClassDefOverride(TGeoMaterialDialog, 0)   // List-Tree based material dialog
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -225,18 +225,18 @@ public:
 class TGeoMatrixDialog : public TGeoTreeDialog {
 
 protected:
-   virtual void        BuildListTree();
-   virtual void        ConnectSignalsToSlots();
+   void        BuildListTree() override;
+   void        ConnectSignalsToSlots() override;
 
 public:
    TGeoMatrixDialog(TGFrame *caller, const TGWindow *main, UInt_t w = 1, UInt_t h = 1);
-   virtual ~TGeoMatrixDialog() {}
+   ~TGeoMatrixDialog() override {}
 
    // Slots
-   virtual void        DoClose();
-   virtual void        DoItemClick(TGListTreeItem *item, Int_t btn);
+   void        DoClose() override;
+   void        DoItemClick(TGListTreeItem *item, Int_t btn) override;
 
-   ClassDef(TGeoMatrixDialog, 0)   // List-Tree based matrix dialog
+   ClassDefOverride(TGeoMatrixDialog, 0)   // List-Tree based matrix dialog
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -258,9 +258,9 @@ class TGeoTransientPanel : public TGMainFrame {
 
 public:
    TGeoTransientPanel(TGedEditor* ged, const char *name, TObject *obj);
-   virtual ~TGeoTransientPanel();
+   ~TGeoTransientPanel() override;
 
-   virtual void        CloseWindow();
+   void        CloseWindow() override;
    virtual void        DeleteEditors();
 
    TGTab              *GetTab() const {return fTab;}
@@ -272,7 +272,7 @@ public:
    virtual void        Show();
    void                SetModel(TObject *model);
 
-   ClassDef(TGeoTransientPanel, 0)   // List-Tree based dialog
+   ClassDefOverride(TGeoTransientPanel, 0)   // List-Tree based dialog
 };
 
 #endif

--- a/geom/geombuilder/inc/TGeoTorusEditor.h
+++ b/geom/geombuilder/inc/TGeoTorusEditor.h
@@ -56,8 +56,8 @@ public:
                    Int_t width = 140, Int_t height = 30,
                    UInt_t options = kChildFrame,
                    Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGeoTorusEditor();
-   virtual void   SetModel(TObject *obj);
+   ~TGeoTorusEditor() override;
+   void   SetModel(TObject *obj) override;
 
    void           DoR();
    void           DoRmin();
@@ -69,7 +69,7 @@ public:
    void           DoApply();
    void           DoUndo();
 
-   ClassDef(TGeoTorusEditor,0)   // TGeoTorus editor
+   ClassDefOverride(TGeoTorusEditor,0)   // TGeoTorus editor
 };
 
 #endif

--- a/geom/geombuilder/inc/TGeoTrapEditor.h
+++ b/geom/geombuilder/inc/TGeoTrapEditor.h
@@ -65,8 +65,8 @@ public:
                    Int_t width = 140, Int_t height = 30,
                    UInt_t options = kChildFrame,
                    Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGeoTrapEditor();
-   virtual void   SetModel(TObject *obj);
+   ~TGeoTrapEditor() override;
+   void   SetModel(TObject *obj) override;
 
    void           DoH1();
    void           DoBl1();
@@ -82,7 +82,7 @@ public:
    virtual void   DoApply();
    virtual void   DoUndo();
 
-   ClassDef(TGeoTrapEditor,0)   // TGeoTrap editor
+   ClassDefOverride(TGeoTrapEditor,0)   // TGeoTrap editor
 };
 
 class TGeoGtraEditor : public TGeoTrapEditor {
@@ -97,14 +97,14 @@ public:
                    Int_t width = 140, Int_t height = 30,
                    UInt_t options = kChildFrame,
                    Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGeoGtraEditor();
-   virtual void   SetModel(TObject *obj);
+   ~TGeoGtraEditor() override;
+   void   SetModel(TObject *obj) override;
 
    void           DoTwist();
-   virtual void   DoApply();
-   virtual void   DoUndo();
+   void   DoApply() override;
+   void   DoUndo() override;
 
-   ClassDef(TGeoGtraEditor,0)   // TGeoTrap editor
+   ClassDefOverride(TGeoGtraEditor,0)   // TGeoTrap editor
 };
 
 #endif

--- a/geom/geombuilder/inc/TGeoTrd1Editor.h
+++ b/geom/geombuilder/inc/TGeoTrd1Editor.h
@@ -54,8 +54,8 @@ public:
                    Int_t width = 140, Int_t height = 30,
                    UInt_t options = kChildFrame,
                    Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGeoTrd1Editor();
-   virtual void   SetModel(TObject *obj);
+   ~TGeoTrd1Editor() override;
+   void   SetModel(TObject *obj) override;
 
    void           DoDx1();
    void           DoDx2();
@@ -66,7 +66,7 @@ public:
    void           DoApply();
    void           DoUndo();
 
-   ClassDef(TGeoTrd1Editor,0)   // TGeoTrd1 editor
+   ClassDefOverride(TGeoTrd1Editor,0)   // TGeoTrd1 editor
 };
 
 #endif

--- a/geom/geombuilder/inc/TGeoTrd2Editor.h
+++ b/geom/geombuilder/inc/TGeoTrd2Editor.h
@@ -56,8 +56,8 @@ public:
                    Int_t width = 140, Int_t height = 30,
                    UInt_t options = kChildFrame,
                    Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGeoTrd2Editor();
-   virtual void   SetModel(TObject *obj);
+   ~TGeoTrd2Editor() override;
+   void   SetModel(TObject *obj) override;
 
    void           DoDx1();
    void           DoDx2();
@@ -69,7 +69,7 @@ public:
    void           DoApply();
    void           DoUndo();
 
-   ClassDef(TGeoTrd2Editor,0)   // TGeoTrd2 editor
+   ClassDefOverride(TGeoTrd2Editor,0)   // TGeoTrd2 editor
 };
 
 #endif

--- a/geom/geombuilder/inc/TGeoTubeEditor.h
+++ b/geom/geombuilder/inc/TGeoTubeEditor.h
@@ -54,8 +54,8 @@ public:
                   Int_t width = 140, Int_t height = 30,
                   UInt_t options = kChildFrame,
                   Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGeoTubeEditor();
-   virtual void   SetModel(TObject *obj);
+   ~TGeoTubeEditor() override;
+   void   SetModel(TObject *obj) override;
 
    void           DoRmin();
    void           DoRmax();
@@ -65,7 +65,7 @@ public:
    virtual void   DoApply();
    virtual void   DoUndo();
 
-   ClassDef(TGeoTubeEditor,0)   // TGeoTube editor
+   ClassDefOverride(TGeoTubeEditor,0)   // TGeoTube editor
 };
 
 
@@ -82,23 +82,23 @@ protected:
    TGNumberEntry   *fEPhi1;             // Number entry for phi1
    TGNumberEntry   *fEPhi2;             // Number entry for phi2
 
-   virtual void ConnectSignals2Slots();   // Connect the signals to the slots
+   void ConnectSignals2Slots() override;   // Connect the signals to the slots
 
 public:
    TGeoTubeSegEditor(const TGWindow *p = nullptr,
                    Int_t width = 140, Int_t height = 30,
                    UInt_t options = kChildFrame,
                    Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGeoTubeSegEditor();
-   virtual void   SetModel(TObject *obj);
+   ~TGeoTubeSegEditor() override;
+   void   SetModel(TObject *obj) override;
 
    void           DoPhi();
    void           DoPhi1();
    void           DoPhi2();
-   virtual void   DoApply();
-   virtual void   DoUndo();
+   void   DoApply() override;
+   void   DoUndo() override;
 
-   ClassDef(TGeoTubeSegEditor,0)   // TGeoTubeSeg editor
+   ClassDefOverride(TGeoTubeSegEditor,0)   // TGeoTubeSeg editor
 };
 
 class TGeoCtubEditor : public TGeoTubeSegEditor {
@@ -118,17 +118,17 @@ public:
                    Int_t width = 140, Int_t height = 30,
                    UInt_t options = kChildFrame,
                    Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGeoCtubEditor();
-   virtual void   SetModel(TObject *obj);
+   ~TGeoCtubEditor() override;
+   void   SetModel(TObject *obj) override;
 
    void           DoThlo();
    void           DoPhlo();
    void           DoThhi();
    void           DoPhhi();
-   virtual void   DoApply();
-   virtual void   DoUndo();
+   void   DoApply() override;
+   void   DoUndo() override;
 
-   ClassDef(TGeoCtubEditor,0)   // TGeoCtub editor
+   ClassDefOverride(TGeoCtubEditor,0)   // TGeoCtub editor
 };
 
 #endif

--- a/geom/geombuilder/inc/TGeoVolumeEditor.h
+++ b/geom/geombuilder/inc/TGeoVolumeEditor.h
@@ -82,9 +82,9 @@ public:
                     Int_t width = 140, Int_t height = 30,
                     UInt_t options = kChildFrame,
                     Pixel_t back = GetDefaultFrameBackground());
-   virtual ~TGeoVolumeEditor();
-   virtual void   SetModel(TObject *obj);
-   virtual void   ActivateBaseClassEditors(TClass* cl);
+   ~TGeoVolumeEditor() override;
+   void   SetModel(TObject *obj) override;
+   void   ActivateBaseClassEditors(TClass* cl) override;
 
    void           DoAddNode();
    void           DoVolumeName();
@@ -111,7 +111,7 @@ public:
    void           DoApplyDiv();
    void           DoRaytrace();
 
-   ClassDef(TGeoVolumeEditor,0)   // TGeoVolume editor
+   ClassDefOverride(TGeoVolumeEditor,0)   // TGeoVolume editor
 };
 
 #endif

--- a/geom/geompainter/inc/TGeoChecker.h
+++ b/geom/geompainter/inc/TGeoChecker.h
@@ -61,7 +61,7 @@ public:
    TGeoChecker();
    TGeoChecker(TGeoManager *geom);
    // destructor
-   virtual ~TGeoChecker();
+   ~TGeoChecker() override;
    // methods
    virtual void     CheckBoundaryErrors(Int_t ntracks=1000000, Double_t radius=-1.);
    virtual void     CheckBoundaryReference(Int_t icheck=-1);
@@ -92,7 +92,7 @@ public:
    Bool_t           TestVoxels(TGeoVolume *vol, Int_t npoints=1000000);
    Double_t         Weight(Double_t precision=0.01, Option_t *option="v");
 
-   ClassDef(TGeoChecker, 2)               // a simple geometry checker
+   ClassDefOverride(TGeoChecker, 2)               // a simple geometry checker
 };
 
 #endif

--- a/geom/geompainter/inc/TGeoOverlap.h
+++ b/geom/geompainter/inc/TGeoOverlap.h
@@ -62,13 +62,13 @@ public:
    TGeoOverlap(const char *name, TGeoVolume *vol1, TGeoVolume *vol2,
                const TGeoMatrix *matrix1, const TGeoMatrix *matrix2,
                Bool_t isovlp=kTRUE,  Double_t ovlp=0.01);
-   virtual           ~TGeoOverlap();
+             ~TGeoOverlap() override;
 
-   void              Browse(TBrowser *b);
-   virtual Int_t     Compare(const TObject *obj) const;
-   virtual Int_t     DistancetoPrimitive(Int_t px, Int_t py);
-   virtual void      Draw(Option_t *option=""); // *MENU*
-   virtual void      ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   void              Browse(TBrowser *b) override;
+   Int_t     Compare(const TObject *obj) const override;
+   Int_t     DistancetoPrimitive(Int_t px, Int_t py) override;
+   void      Draw(Option_t *option="") override; // *MENU*
+   void      ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
    TPolyMarker3D    *GetPolyMarker() const {return fMarker;}
    TGeoVolume       *GetFirstVolume() const {return fVolume1;}
    TGeoVolume       *GetSecondVolume() const {return fVolume2;}
@@ -77,12 +77,12 @@ public:
    Double_t          GetOverlap() const {return fOverlap;}
    Bool_t            IsExtrusion() const {return TObject::TestBit(kGeoExtrusion);}
    Bool_t            IsOverlap() const {return TObject::TestBit(kGeoOverlap);}
-   Bool_t            IsFolder() const {return kFALSE;}
-   virtual Bool_t    IsSortable() const {return kTRUE;}
-   virtual void      Paint(Option_t *option="");
-   virtual void      Print(Option_t *option="") const; // *MENU*
+   Bool_t            IsFolder() const override {return kFALSE;}
+   Bool_t    IsSortable() const override {return kTRUE;}
+   void      Paint(Option_t *option="") override;
+   void      Print(Option_t *option="") const override; // *MENU*
    virtual void      PrintInfo() const;
-   virtual void      Sizeof3D() const;
+   void      Sizeof3D() const override;
    void              SampleOverlap(Int_t npoints=1000000); // *MENU*
    void              SetIsExtrusion(Bool_t flag=kTRUE) {TObject::SetBit(kGeoExtrusion,flag); TObject::SetBit(kGeoOverlap,!flag);}
    void              SetIsOverlap(Bool_t flag=kTRUE) {TObject::SetBit(kGeoOverlap,flag); TObject::SetBit(kGeoExtrusion,!flag);}
@@ -94,7 +94,7 @@ public:
    void              SetOverlap(Double_t ovlp)  {fOverlap=ovlp;}
    void              Validate() const; // *MENU*
 
-   ClassDef(TGeoOverlap, 2)         // base class for geometical overlaps
+   ClassDefOverride(TGeoOverlap, 2)         // base class for geometical overlaps
 };
 
 #endif

--- a/geom/geompainter/inc/TGeoPainter.h
+++ b/geom/geompainter/inc/TGeoPainter.h
@@ -78,7 +78,7 @@ protected:
 
 public:
    TGeoPainter(TGeoManager *manager);
-   virtual ~TGeoPainter();
+   ~TGeoPainter() override;
 
    void       AddSize3D(Int_t numpoints, Int_t numsegs, Int_t numpolys) override;
    TVirtualGeoTrack *AddTrack(Int_t id, Int_t pdgcode, TObject *part) override;

--- a/geom/geompainter/inc/TGeoTrack.h
+++ b/geom/geompainter/inc/TGeoTrack.h
@@ -47,36 +47,36 @@ protected:
 public:
    TGeoTrack();
    TGeoTrack(Int_t id, Int_t pdgcode, TVirtualGeoTrack *parent=nullptr, TObject *particle=nullptr);
-   virtual ~TGeoTrack();
+   ~TGeoTrack() override;
 
-   virtual TVirtualGeoTrack *AddDaughter(Int_t id, Int_t pdgcode, TObject *particle=nullptr);
-   virtual Int_t       AddDaughter(TVirtualGeoTrack *other);
-   virtual void        AddPoint(Double_t x, Double_t y, Double_t z, Double_t t);
+   TVirtualGeoTrack *AddDaughter(Int_t id, Int_t pdgcode, TObject *particle=nullptr) override;
+   Int_t       AddDaughter(TVirtualGeoTrack *other) override;
+   void        AddPoint(Double_t x, Double_t y, Double_t z, Double_t t) override;
    virtual void        AnimateTrack(Double_t tmin=0, Double_t tmax=5E-8, Double_t nframes=200, Option_t *option="/*"); // *MENU*
-   void                Browse(TBrowser *b);
-   virtual Int_t       DistancetoPrimitive(Int_t px, Int_t py);
-   virtual void        Draw(Option_t *option=""); // *MENU*
-   virtual void        ExecuteEvent(Int_t event, Int_t px, Int_t py);
-   virtual char       *GetObjectInfo(Int_t px, Int_t py) const;
-   virtual Int_t       GetNpoints() const {return (fNpoints>>2);}
-   virtual Int_t       GetPoint(Int_t i, Double_t &x, Double_t &y, Double_t &z, Double_t &t) const;
-   virtual const Double_t *GetPoint(Int_t i) const;
+   void                Browse(TBrowser *b) override;
+   Int_t       DistancetoPrimitive(Int_t px, Int_t py) override;
+   void        Draw(Option_t *option="") override; // *MENU*
+   void        ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
+   char       *GetObjectInfo(Int_t px, Int_t py) const override;
+   Int_t       GetNpoints() const override {return (fNpoints>>2);}
+   Int_t       GetPoint(Int_t i, Double_t &x, Double_t &y, Double_t &z, Double_t &t) const override;
+   const Double_t *GetPoint(Int_t i) const override;
    Int_t               GetPoint(Double_t tof, Double_t *point, Int_t istart=0) const;
-   Bool_t              IsFolder() const {return (GetNdaughters()>0)?kTRUE:kFALSE;}
-   virtual void        Paint(Option_t *option="");
-   virtual void        PaintCollect(Double_t time, Double_t *box);
-   virtual void        PaintCollectTrack(Double_t time, Double_t *box);
+   Bool_t              IsFolder() const override {return (GetNdaughters()>0)?kTRUE:kFALSE;}
+   void        Paint(Option_t *option="") override;
+   void        PaintCollect(Double_t time, Double_t *box) override;
+   void        PaintCollectTrack(Double_t time, Double_t *box) override;
    void                PaintMarker(Double_t *point, Option_t *option="");
-   virtual void        PaintTrack(Option_t *option="");
-   virtual void        Print(Option_t *option="") const; // *MENU*
-   virtual void        ResetTrack();
+   void        PaintTrack(Option_t *option="") override;
+   void        Print(Option_t *option="") const override; // *MENU*
+   void        ResetTrack() override;
    Int_t               SearchPoint(Double_t time, Int_t istart=0) const;
    void                SetBits(Bool_t is_default=kTRUE, Bool_t is_onelevel=kFALSE,
                                Bool_t is_all=kFALSE, Bool_t is_type=kFALSE);
    Int_t               Size(Int_t &imin, Int_t &imax);
    virtual void        Sizeof3D() const;
 
-   ClassDef(TGeoTrack, 1)              // geometry tracks class
+   ClassDefOverride(TGeoTrack, 1)              // geometry tracks class
 };
 
 #endif

--- a/geom/vecgeom/inc/TGeoVGConverter.h
+++ b/geom/vecgeom/inc/TGeoVGConverter.h
@@ -25,11 +25,11 @@
 class TGeoVGConverter : public TVirtualGeoConverter {
 public:
    TGeoVGConverter(TGeoManager *manager);
-   virtual ~TGeoVGConverter();
+   ~TGeoVGConverter() override;
 
-   virtual void       ConvertGeometry();
+   void       ConvertGeometry() override;
 
-   ClassDef(TGeoVGConverter,0)  // VecGeom geometry converter
+   ClassDefOverride(TGeoVGConverter,0)  // VecGeom geometry converter
 };
 
 #endif

--- a/geom/vecgeom/inc/TGeoVGShape.h
+++ b/geom/vecgeom/inc/TGeoVGShape.h
@@ -38,67 +38,67 @@ private:
 
 public:
    TGeoVGShape() : TGeoBBox(), fVGShape(nullptr), fShape(nullptr) {}
-   virtual ~TGeoVGShape();
+   ~TGeoVGShape() override;
    static vecgeom::cxx::Transformation3D *
                          Convert(TGeoMatrix const *const geomatrix);
    static vecgeom::cxx::VUnplacedVolume *
                          Convert(TGeoShape const *const shape);
    static TGeoVGShape   *Create(TGeoShape *shape);
-   virtual Double_t      Capacity() const;
-   virtual void          ComputeBBox();
-   virtual void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm);
-   virtual Bool_t        Contains(const Double_t *point) const;
-   virtual Bool_t        CouldBeCrossed(const Double_t *point, const Double_t *dir) const
+   Double_t      Capacity() const override;
+   void          ComputeBBox() override;
+   void          ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) override;
+   Bool_t        Contains(const Double_t *point) const override;
+   Bool_t        CouldBeCrossed(const Double_t *point, const Double_t *dir) const override
                             { return fShape->CouldBeCrossed(point,dir); }
-   virtual Int_t         DistancetoPrimitive(Int_t px, Int_t py)
+   Int_t         DistancetoPrimitive(Int_t px, Int_t py) override
                             { return fShape->DistancetoPrimitive(px, py); }
-   virtual Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
-                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const;
-   virtual TGeoVolume   *Divide(TGeoVolume *, const char *, Int_t, Int_t, Double_t, Double_t)
+   Double_t      DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   Double_t      DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact=1,
+                                   Double_t step=TGeoShape::Big(), Double_t *safe=nullptr) const override;
+   TGeoVolume   *Divide(TGeoVolume *, const char *, Int_t, Int_t, Double_t, Double_t) override
                             { return nullptr; }
-   virtual void          Draw(Option_t *option="") { fShape->Draw(option); } // *MENU*
-   virtual const char   *GetAxisName(Int_t iaxis) const
+   void          Draw(Option_t *option="") override { fShape->Draw(option); } // *MENU*
+   const char   *GetAxisName(Int_t iaxis) const override
                             { return ( fShape->GetAxisName(iaxis) ); }
-   virtual Double_t      GetAxisRange(Int_t iaxis, Double_t &xlo, Double_t &xhi) const
+   Double_t      GetAxisRange(Int_t iaxis, Double_t &xlo, Double_t &xhi) const override
                             { return ( fShape->GetAxisRange(iaxis, xlo, xhi) ); }
-   virtual void          GetBoundingCylinder(Double_t *param) const
+   void          GetBoundingCylinder(Double_t *param) const override
                             { return ( fShape->GetBoundingCylinder(param) ); }
-   virtual const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const
+   const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const override
                             { return ( fShape->GetBuffer3D(reqSections, localFrame) ); }
-   virtual Int_t         GetByteCount() const { return ( fShape->GetByteCount() ); }
-   virtual Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const;
-   virtual Bool_t        GetPointsOnSegments(Int_t npoints, Double_t *array) const
+   Int_t         GetByteCount() const override { return ( fShape->GetByteCount() ); }
+   Double_t      Safety(const Double_t *point, Bool_t in=kTRUE) const override;
+   Bool_t        GetPointsOnSegments(Int_t npoints, Double_t *array) const override
                             { return ( fShape->GetPointsOnSegments(npoints, array) ); }
-   virtual Int_t         GetFittingBox(const TGeoBBox *parambox, TGeoMatrix *mat, Double_t &dx, Double_t &dy, Double_t &dz) const
+   Int_t         GetFittingBox(const TGeoBBox *parambox, TGeoMatrix *mat, Double_t &dx, Double_t &dy, Double_t &dz) const override
                             { return ( fShape->GetFittingBox(parambox, mat, dx, dy, dz) ); }
-   virtual TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const
+   TGeoShape    *GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const override
                             { return ( fShape->GetMakeRuntimeShape(mother, mat) ); }
-   virtual void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const
+   void          GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const override
                             { fShape->GetMeshNumbers(nvert, nsegs, npols); }
-   virtual const char   *GetName() const
+   const char   *GetName() const override
                             { return ( fShape->GetName() ); }
-   virtual Int_t         GetNmeshVertices() const
+   Int_t         GetNmeshVertices() const override
                             {return ( fShape->GetNmeshVertices() );}
-   virtual Bool_t        IsAssembly() const { return ( fShape->IsAssembly() ); }
-   virtual Bool_t        IsComposite() const { return ( fShape->IsComposite() ); }
-   virtual Bool_t        IsCylType() const { return ( fShape->IsCylType() ); }
-   virtual Bool_t        IsReflected() const { return ( fShape->IsReflected() ); }
-   virtual Bool_t        IsValidBox() const  { return ( fShape->IsValidBox() ); }
-   virtual Bool_t        IsVecGeom() const {return kTRUE;}
-   virtual void          InspectShape() const;
-   virtual TBuffer3D    *MakeBuffer3D() const { return ( fShape->MakeBuffer3D() );}
-   virtual void          Paint(Option_t *option="") { fShape->Paint(option); }
-   virtual void          SetDimensions(Double_t *param) { fShape->SetDimensions(param); }
-   virtual void          SetPoints(Double_t *points) const { fShape->SetPoints(points); }
-   virtual void          SetPoints(Float_t *points) const { fShape->SetPoints(points); }
-   virtual void          SetSegsAndPols(TBuffer3D &buff) const { fShape->SetSegsAndPols(buff); }
-   virtual void          Sizeof3D() const { fShape->Sizeof3D(); }
+   Bool_t        IsAssembly() const override { return ( fShape->IsAssembly() ); }
+   Bool_t        IsComposite() const override { return ( fShape->IsComposite() ); }
+   Bool_t        IsCylType() const override { return ( fShape->IsCylType() ); }
+   Bool_t        IsReflected() const override { return ( fShape->IsReflected() ); }
+   Bool_t        IsValidBox() const override  { return ( fShape->IsValidBox() ); }
+   Bool_t        IsVecGeom() const override {return kTRUE;}
+   void          InspectShape() const override;
+   TBuffer3D    *MakeBuffer3D() const override { return ( fShape->MakeBuffer3D() );}
+   void          Paint(Option_t *option="") override { fShape->Paint(option); }
+   void          SetDimensions(Double_t *param) override { fShape->SetDimensions(param); }
+   void          SetPoints(Double_t *points) const override { fShape->SetPoints(points); }
+   void          SetPoints(Float_t *points) const override { fShape->SetPoints(points); }
+   void          SetSegsAndPols(TBuffer3D &buff) const override { fShape->SetSegsAndPols(buff); }
+   void          Sizeof3D() const override { fShape->Sizeof3D(); }
 
    TGeoShape            *GetShape() const { return fShape; }
    vecgeom::cxx::VPlacedVolume *GetVGShape() const { return fVGShape; }
 
-   ClassDef(TGeoVGShape, 0) // Adapter for a VecGeom shape
+   ClassDefOverride(TGeoVGShape, 0) // Adapter for a VecGeom shape
 };
 #endif

--- a/geom/webviewer/inc/ROOT/RGeoPainter.hxx
+++ b/geom/webviewer/inc/ROOT/RGeoPainter.hxx
@@ -27,7 +27,7 @@ class RGeoPainter : public TVirtualGeoPainter {
 
 public:
    RGeoPainter(TGeoManager *manager);
-   virtual ~RGeoPainter();
+   ~RGeoPainter() override;
 
    void       AddSize3D(Int_t, Int_t, Int_t) override {}
    TVirtualGeoTrack *AddTrack(Int_t, Int_t, TObject *) override { return nullptr; }

--- a/geom/webviewer/inc/ROOT/RGeomData.hxx
+++ b/geom/webviewer/inc/ROOT/RGeomData.hxx
@@ -105,7 +105,7 @@ public:
    }
 
    // should be here, one needs virtual table for correct streaming of RRootBrowserReply
-   virtual ~RGeoItem() = default;
+   ~RGeoItem() override = default;
 
    void SetTop(bool on = true) { top = on; }
 };
@@ -123,14 +123,14 @@ class RGeomRawRenderInfo : public RGeomRenderInfo  {
 public:
    std::vector<unsigned char> raw;  ///< float vertices as raw data, JSON_base64
    std::vector<int> idx;            ///< vertex indexes, always triangles
-   virtual ~RGeomRawRenderInfo() = default;
+   ~RGeomRawRenderInfo() override = default;
 };
 
 /** Render info with shape itself - client can produce shape better */
 class RGeomShapeRenderInfo : public RGeomRenderInfo  {
 public:
    TGeoShape *shape{nullptr}; ///< original shape - can be much less than binary data
-   virtual ~RGeomShapeRenderInfo() = default;
+   ~RGeomShapeRenderInfo() override = default;
 };
 
 


### PR DESCRIPTION
This commit only contains changes that were automatically generated by `clang-tidy`, plus replacing `ClassDef` with `ClassDefOverride` where appropriate.

Several directories in the ROOT repo were already treated like this.