### PR TITLE
[RF] Improve Copy Constructor of HypoTestResult

### DIFF
--- a/roofit/roostats/src/HypoTestResult.cxx
+++ b/roofit/roostats/src/HypoTestResult.cxx
@@ -110,9 +110,9 @@ HypoTestResult::HypoTestResult(const char* name, double nullp, double altp) :
 
 HypoTestResult::HypoTestResult(const HypoTestResult& other) :
    TNamed(other),
-   fNullPValue(NaN), fAlternatePValue(NaN),
-   fNullPValueError(0), fAlternatePValueError(0),
-   fTestStatisticData(NaN),
+   fNullPValue(other.fNullPValue), fAlternatePValue(other.fAlternatePValue),
+   fNullPValueError(other.fNullPValueError), fAlternatePValueError(other.fAlternatePValueError),
+   fTestStatisticData(other.fTestStatisticData),
    fAllTestStatisticsData(nullptr),
    fNullDistr(nullptr), fAltDistr(nullptr),
    fNullDetailedOutput(nullptr), fAltDetailedOutput(nullptr),


### PR DESCRIPTION
While I believe this class and others probably could do with a big rework, in my attempts so far to find ways to use them in their current form I have stumbled across some very annoying behaviours -- this PR fixes one of these: that the results wouldn't copy reliably at all. 