### PR TITLE
[webgui] support qt6 version when create embedding qualifier [skip-ci]

### DIFF
--- a/gui/webdisplay/inc/ROOT/RWebDisplayArgs.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebDisplayArgs.hxx
@@ -206,7 +206,7 @@ public:
    /// [internal] returns web-driver data, used to start window
    void *GetDriverData() const { return fDriverData; }
 
-   static std::string GetQt5EmbedQualifier(const void *qparent, const std::string &urlopt = "");
+   static std::string GetQt5EmbedQualifier(const void *qparent, const std::string &urlopt = "", unsigned qtversion = 0x50000);
 };
 
 }

--- a/gui/webdisplay/src/RWebDisplayArgs.cxx
+++ b/gui/webdisplay/src/RWebDisplayArgs.cxx
@@ -344,9 +344,9 @@ std::string RWebDisplayArgs::GetCustomExec() const
 ///
 ///     auto view = qparent->findChild<QWebEngineView*>("RootWebView");
 
-std::string RWebDisplayArgs::GetQt5EmbedQualifier(const void *qparent, const std::string &urlopt)
+std::string RWebDisplayArgs::GetQt5EmbedQualifier(const void *qparent, const std::string &urlopt, unsigned qtversion)
 {
-   std::string where = "qt5";
+   std::string where = (qtversion >= 0x60000) ? "qt6" : "qt5";
    if (qparent) {
       where.append(":");
       where.append(std::to_string((uintptr_t) qparent));
@@ -357,4 +357,3 @@ std::string RWebDisplayArgs::GetQt5EmbedQualifier(const void *qparent, const std
    }
    return where;
 }
-


### PR DESCRIPTION
Backport from master
Let use newest qtweb tutorial also with 6.26 branch