### PR TITLE
[ntuple] Add support for `std::set` fields

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -720,6 +720,14 @@ This is called sparse representation.
 The alternative, dense representation uses a `Bit` column to mask non-existing instances of the subfield.
 In this second case, a default-constructed `T` (or, if applicable, a `T` constructed by the ROOT I/O constructor) is stored on disk for the non-existing instances.
 
+#### std::set<T>
+
+While STL sets by definition are associative containers (i.e., elements are referenced by their keys, which in the case for sets are equal to the values), on disk they are represented as indexed collections.
+This means that they have the same on-disk representation as `std::vector<T>`, using two fields:
+  - Collection mother field of type SplitIndex32 or SplitIndex64
+  - Child field of type `T`, which must by a type with RNTuple I/O support.
+    The name of the child field is `_0`.
+
 ### User-defined enums
 
 User-defined enums are stored as a leaf field with a single subfield named `_0`.

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -997,7 +997,6 @@ public:
 class RSetField : public RProxiedCollectionField {
 protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final;
-   void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) override;
 
 public:
    RSetField(std::string_view fieldName, std::unique_ptr<Detail::RFieldBase> itemField);

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -37,6 +37,7 @@
 #include <iterator>
 #include <memory>
 #include <new>
+#include <set>
 #include <string>
 #include <type_traits>
 #include <typeinfo>
@@ -973,6 +974,38 @@ public:
    size_t GetValueSize() const final;
    size_t GetAlignment() const final { return fMaxAlignment; }
    void CommitCluster() final;
+};
+
+/// The generic field for a std::set<Type>
+class RSetField : public Detail::RFieldBase {
+private:
+   std::size_t fItemSize;
+
+protected:
+   ClusterSize_t fNWritten;
+
+   std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const override;
+   std::size_t AppendImpl(const Detail::RFieldValue &value) override;
+   const RColumnRepresentations &GetColumnRepresentations() const final;
+   void GenerateColumnsImpl() final;
+   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+   void ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue *value) override;
+
+public:
+   RSetField(std::string_view fieldName, std::unique_ptr<Detail::RFieldBase> itemField);
+   RSetField(RSetField &&other) = default;
+   RSetField &operator=(RSetField &&other) = default;
+   ~RSetField() override = default;
+
+   using Detail::RFieldBase::GenerateValue;
+   Detail::RFieldValue GenerateValue(void *where) override;
+   void DestroyValue(const Detail::RFieldValue &value, bool dtorOnly = false) override;
+   Detail::RFieldValue CaptureValue(void *where) override;
+   std::vector<Detail::RFieldValue> SplitValue(const Detail::RFieldValue &value) const final;
+   size_t GetValueSize() const override { return sizeof(std::set<char>); }
+   size_t GetAlignment() const override { return std::alignment_of<std::set<char>>(); }
+   void CommitCluster() final;
+   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 };
 
 /// The field for values that may or may not be present in an entry. Parent class for unique pointer field and
@@ -1927,6 +1960,80 @@ public:
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
    ~RField() override = default;
+};
+
+template <typename ItemT> // TODO (fdegeus): Add comparator
+class RField<std::set<ItemT>> : public RSetField {
+   using ContainerT = typename std::set<ItemT>;
+
+protected:
+   std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final
+   {
+      auto newItemField = fSubFields[0]->Clone(fSubFields[0]->GetName());
+      return std::make_unique<RField<std::set<ItemT>>>(newName, std::move(newItemField));
+   }
+   std::size_t AppendImpl(const Detail::RFieldValue &value) final
+   {
+      auto typedValue = value.Get<ContainerT>();
+      auto nbytes = 0;
+      auto count = typedValue->size();
+      for (auto item : *typedValue) {
+         auto itemValue = fSubFields[0]->CaptureValue(static_cast<void *>(&item));
+         nbytes += fSubFields[0]->Append(itemValue);
+      }
+      Detail::RColumnElement<ClusterSize_t, EColumnType::kUnknown> elemIndex(&this->fNWritten);
+      this->fNWritten += count;
+      fColumns[0]->Append(elemIndex);
+      return nbytes + sizeof(elemIndex);
+   }
+   void ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue *value) final
+   {
+      auto typedValue = value->Get<ContainerT>();
+      RClusterIndex collectionStart;
+      ClusterSize_t nItems;
+      fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &nItems);
+      typedValue->clear();
+      for (unsigned i = 0; i < nItems; ++i) {
+         ItemT item;
+         auto itemValue = fSubFields[0]->CaptureValue(&item);
+         fSubFields[0]->Read(collectionStart + i, &itemValue);
+         typedValue->emplace(item);
+      }
+   }
+
+public:
+   static std::string TypeName() { return "std::set<" + RField<ItemT>::TypeName() + ">"; }
+
+   RField(std::string_view name, std::unique_ptr<Detail::RFieldBase> itemField) : RSetField(name, std::move(itemField))
+   {
+   }
+   explicit RField(std::string_view name) : RSetField(name, std::make_unique<RField<ItemT>>("_0")) {}
+   RField(RField &&other) = default;
+   RField &operator=(RField &&other) = default;
+   ~RField() override = default;
+
+   using Detail::RFieldBase::GenerateValue;
+   template <typename... ArgsT>
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where, ArgsT &&...args)
+   {
+      return Detail::RFieldValue(this, static_cast<ContainerT *>(where), std::forward<ArgsT>(args)...);
+   }
+   ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where) final
+   {
+      return GenerateValue(where, ContainerT());
+   }
+   Detail::RFieldValue CaptureValue(void *where) final
+   {
+      return Detail::RFieldValue(true /* captureFlag */, this, static_cast<ContainerT *>(where));
+   }
+   void DestroyValue(const Detail::RFieldValue &value, bool dtorOnly = false) final
+   {
+      reinterpret_cast<ContainerT *>(value.GetRawPtr())->~set();
+      if (!dtorOnly)
+         free(reinterpret_cast<ContainerT *>(value.GetRawPtr()));
+   }
+   size_t GetValueSize() const final { return sizeof(ContainerT); }
+   size_t GetAlignment() const final { return std::alignment_of<ContainerT>(); }
 };
 
 template <typename... ItemTs>

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -601,12 +601,8 @@ public:
 
 /// The field for a class representing a collection of elements via `TVirtualCollectionProxy`.
 /// Objects of such type behave as collections that can be accessed through the corresponding member functions in
-/// `TVirtualCollectionProxy`.
-/// The
-/// At a bare minimum, the user is required to provide an implementation for the following
-/// functions in `TVirtualCollectionProxy`: `HasPointers()`, `GetProperties()`, `GetValueClass()`, `GetType()`,
-/// `PushProxy()`, `PopProxy()`, `GetFunctionCreateIterators()`, `GetFunctionNext()`, and
-/// `GetFunctionDeleteTwoIterators()`.
+/// `TVirtualCollectionProxy`. For STL collections, these proxies are provided. Custom classes need to implement the
+/// corresponding member functions in `TVirtualCollectionProxy`.
 ///
 /// The collection proxy for a given class can be set via `TClass::CopyCollectionProxy()`.
 class RProxiedCollectionField : public Detail::RFieldBase {
@@ -726,12 +722,10 @@ public:
    }
 };
 
-/// The field for a class representing a custom collections of elements via `TVirtualCollectionProxy`.
-/// Objects of such type behave as collections that can be accessed through the corresponding member functions in
-/// `TVirtualCollectionProxy`. At a bare minimum, the user is required to provide an implementation for the following
-/// functions in `TVirtualCollectionProxy`: `HasPointers()`, `GetProperties()`, `GetValueClass()`, `GetType()`,
-/// `PushProxy()`, `PopProxy()`, `GetFunctionCreateIterators()`, `GetFunctionNext()`, and
-/// `GetFunctionDeleteTwoIterators()`.
+/// The field for a class representing a custom collections of elements via `TVirtualCollectionProxy`. At a bare
+/// minimum, the user is required to provide an implementation for the following functions in `TVirtualCollectionProxy`:
+/// `HasPointers()`, `GetProperties()`, `GetValueClass()`, `GetType()`, `PushProxy()`, `PopProxy()`,
+/// `GetFunctionCreateIterators()`, `GetFunctionNext()`, and `GetFunctionDeleteTwoIterators()`.
 ///
 /// The collection proxy for a given class can be set via `TClass::CopyCollectionProxy()`.
 class RCollectionClassField : public RProxiedCollectionField {

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -692,9 +692,9 @@ protected:
 
 protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const override;
-   const RColumnRepresentations &GetColumnRepresentations() const override;
+   const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() override;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) override;
+   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
    void GenerateValue(void *where) const override;
    void DestroyValue(void *objPtr, bool dtorOnly = false) const override;

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -1967,32 +1967,6 @@ class RField<std::set<ItemT>> : public RSetField {
    using ContainerT = typename std::set<ItemT>;
 
 protected:
-   std::size_t AppendImpl(const void *from) final
-   {
-      auto typedValue = static_cast<const ContainerT *>(from);
-      auto count = typedValue->size();
-      size_t nbytes = 0;
-      for (auto item : *typedValue) {
-         nbytes += fSubFields[0]->Append(&item);
-      }
-      this->fNWritten += count;
-      fColumns[0]->Append(&this->fNWritten);
-      return nbytes + fColumns[0]->GetElement()->GetPackedSize();
-   }
-
-   void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final
-   {
-      auto typedValue = static_cast<ContainerT *>(to);
-      RClusterIndex collectionStart;
-      ClusterSize_t nItems;
-      fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &nItems);
-      typedValue->clear();
-      ItemT item;
-      for (unsigned i = 0; i < nItems; ++i) {
-         fSubFields[0]->Read(collectionStart + i, &item);
-         typedValue->insert(item);
-      }
-   }
    void GenerateValue(void *where) const final { new (where) ContainerT(); }
    void DestroyValue(void *objPtr, bool dtorOnly = false) const final
    {

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -1974,8 +1974,8 @@ protected:
    std::size_t AppendImpl(const void *from) final
    {
       auto typedValue = static_cast<const ContainerT *>(from);
-      auto nbytes = 0;
       auto count = typedValue->size();
+      size_t nbytes = 0;
       for (auto item : *typedValue) {
          nbytes += fSubFields[0]->Append(&item);
       }
@@ -1991,8 +1991,8 @@ protected:
       ClusterSize_t nItems;
       fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &nItems);
       typedValue->clear();
+      ItemT item;
       for (unsigned i = 0; i < nItems; ++i) {
-         ItemT item;
          fSubFields[0]->Read(collectionStart + i, &item);
          typedValue->insert(item);
       }

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -601,7 +601,9 @@ public:
 
 /// The field for a class representing a collection of elements via `TVirtualCollectionProxy`.
 /// Objects of such type behave as collections that can be accessed through the corresponding member functions in
-/// `TVirtualCollectionProxy`. At a bare minimum, the user is required to provide an implementation for the following
+/// `TVirtualCollectionProxy`.
+/// The
+/// At a bare minimum, the user is required to provide an implementation for the following
 /// functions in `TVirtualCollectionProxy`: `HasPointers()`, `GetProperties()`, `GetValueClass()`, `GetType()`,
 /// `PushProxy()`, `PopProxy()`, `GetFunctionCreateIterators()`, `GetFunctionNext()`, and
 /// `GetFunctionDeleteTwoIterators()`.
@@ -724,7 +726,7 @@ public:
    }
 };
 
-/// The field for a class representing a collection of elements via `TVirtualCollectionProxy`.
+/// The field for a class representing a custom collections of elements via `TVirtualCollectionProxy`.
 /// Objects of such type behave as collections that can be accessed through the corresponding member functions in
 /// `TVirtualCollectionProxy`. At a bare minimum, the user is required to provide an implementation for the following
 /// functions in `TVirtualCollectionProxy`: `HasPointers()`, `GetProperties()`, `GetValueClass()`, `GetType()`,

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -689,7 +689,10 @@ protected:
    std::size_t fItemSize;
    ClusterSize_t fNWritten;
 
+   /// Constructor used when the value type of the collection is not known in advance, i.e. in the case of custom
+   /// collections.
    RProxiedCollectionField(std::string_view fieldName, std::string_view typeName, TClass *classp);
+   /// Constructor used when the value type of the collection is known in advance, e.g. in `RSetField`.
    RProxiedCollectionField(std::string_view fieldName, std::string_view typeName,
                            std::unique_ptr<Detail::RFieldBase> itemField);
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -691,14 +691,14 @@ protected:
 protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const override;
    const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() override;
+   void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
 
    void GenerateValue(void *where) const override;
    void DestroyValue(void *objPtr, bool dtorOnly = false) const override;
 
-   std::size_t AppendImpl(const void *from) override;
-   void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) override;
+   std::size_t AppendImpl(const void *from) final;
+   void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
 
 public:
    RProxiedCollectionField(std::string_view fieldName, std::string_view className);

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -1977,9 +1977,6 @@ protected:
 public:
    static std::string TypeName() { return "std::set<" + RField<ItemT>::TypeName() + ">"; }
 
-   RField(std::string_view name, std::unique_ptr<Detail::RFieldBase> itemField) : RSetField(name, std::move(itemField))
-   {
-   }
    explicit RField(std::string_view name) : RSetField(name, std::make_unique<RField<ItemT>>("_0")) {}
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -48,7 +48,7 @@ public:
    virtual void VisitBitsetField(const RBitsetField &field) { VisitField(field); }
    virtual void VisitBoolField(const RField<bool> &field) { VisitField(field); }
    virtual void VisitClassField(const RClassField &field) { VisitField(field); }
-   virtual void VisitCollectionClassField(const RCollectionClassField &field) { VisitField(field); }
+   virtual void VisitProxiedCollectionField(const RProxiedCollectionField &field) { VisitField(field); }
    virtual void VisitRecordField(const RRecordField &field) { VisitField(field); }
    virtual void VisitClusterSizeField(const RField<ClusterSize_t> &field) { VisitField(field); }
    virtual void VisitCardinalityField(const RCardinalityField &field) { VisitField(field); }
@@ -69,7 +69,6 @@ public:
    virtual void VisitVectorField(const RVectorField &field) { VisitField(field); }
    virtual void VisitVectorBoolField(const RField<std::vector<bool>> &field) { VisitField(field); }
    virtual void VisitRVecField(const RRVecField &field) { VisitField(field); }
-   virtual void VisitSetField(const RSetField &field) { VisitField(field); }
 }; // class RFieldVisitor
 
 } // namespace Detail
@@ -215,14 +214,13 @@ public:
    void VisitArrayField(const RArrayField &field) final;
    void VisitClassField(const RClassField &field) final;
    void VisitRecordField(const RRecordField &field) final;
-   void VisitCollectionClassField(const RCollectionClassField &field) final;
+   void VisitProxiedCollectionField(const RProxiedCollectionField &field) final;
    void VisitVectorField(const RVectorField &field) final;
    void VisitVectorBoolField(const RField<std::vector<bool>> &field) final;
    void VisitRVecField(const RRVecField &field) final;
    void VisitBitsetField(const RBitsetField &field) final;
    void VisitNullableField(const RNullableField &field) final;
    void VisitEnumField(const REnumField &field) final;
-   void VisitSetField(const RSetField &field) final;
 };
 
 

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -69,6 +69,7 @@ public:
    virtual void VisitVectorField(const RVectorField &field) { VisitField(field); }
    virtual void VisitVectorBoolField(const RField<std::vector<bool>> &field) { VisitField(field); }
    virtual void VisitRVecField(const RRVecField &field) { VisitField(field); }
+   virtual void VisitSetField(const RSetField &field) { VisitField(field); }
 }; // class RFieldVisitor
 
 } // namespace Detail
@@ -221,6 +222,7 @@ public:
    void VisitBitsetField(const RBitsetField &field) final;
    void VisitNullableField(const RNullableField &field) final;
    void VisitEnumField(const REnumField &field) final;
+   void VisitSetField(const RSetField &field) final;
 };
 
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -2424,31 +2424,6 @@ ROOT::Experimental::RSetField::CloneImpl(std::string_view newName) const
    return std::make_unique<RSetField>(newName, std::move(newItemField));
 }
 
-void ROOT::Experimental::RSetField::ReadGlobalImpl(NTupleSize_t globalIndex, void *to)
-{
-   ClusterSize_t nItems;
-   RClusterIndex collectionStart;
-   fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &nItems);
-
-   TVirtualCollectionProxy::TPushPop RAII(fProxy.get(), to);
-   fProxy->Clear();
-   void *item;
-   if (fProxy->GetType())
-      item = malloc(fItemSize);
-   else
-      item = fProxy->GetValueClass()->New();
-
-   for (unsigned i = 0; i < nItems; ++i) {
-      fSubFields[0]->Read(collectionStart + i, &item);
-      fProxy->Insert(item, to, 1);
-   }
-
-   if (fProxy->GetType())
-      free(item);
-   else
-      fProxy->GetValueClass()->Destructor(item);
-}
-
 //------------------------------------------------------------------------------
 
 ROOT::Experimental::RNullableField::RNullableField(std::string_view fieldName, std::string_view typeName,

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1459,8 +1459,9 @@ ROOT::Experimental::RProxiedCollectionField::RProxiedCollectionField(std::string
 std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>
 ROOT::Experimental::RProxiedCollectionField::CloneImpl(std::string_view newName) const
 {
+   auto newItemField = fSubFields[0]->Clone(fSubFields[0]->GetName());
    auto result = std::unique_ptr<RProxiedCollectionField>(
-      new RProxiedCollectionField(newName, GetType(), fProxy->GetCollectionClass()));
+      new RProxiedCollectionField(newName, GetType(), std::move(newItemField)));
    SyncFieldIDs(*this, *result);
    return result;
 }
@@ -2414,7 +2415,9 @@ std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>
 ROOT::Experimental::RSetField::CloneImpl(std::string_view newName) const
 {
    auto newItemField = fSubFields[0]->Clone(fSubFields[0]->GetName());
-   return std::make_unique<RSetField>(newName, GetType(), std::move(newItemField));
+   auto result = std::unique_ptr<RSetField>(new RSetField(newName, GetType(), std::move(newItemField)));
+   SyncFieldIDs(*this, *result);
+   return result;
 }
 
 //------------------------------------------------------------------------------

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -2429,17 +2429,21 @@ void ROOT::Experimental::RSetField::ReadGlobalImpl(NTupleSize_t globalIndex, voi
 
    TVirtualCollectionProxy::TPushPop RAII(fProxy.get(), to);
    fProxy->Clear();
-   for (unsigned i = 0; i < nItems; ++i) {
-      void *item;
-      if (fProxy->GetType())
-         item = malloc(fItemSize);
-      else
-         item = fProxy->GetValueClass()->New();
+   void *item;
+   if (fProxy->GetType())
+      item = malloc(fItemSize);
+   else
+      item = fProxy->GetValueClass()->New();
 
+   for (unsigned i = 0; i < nItems; ++i) {
       fSubFields[0]->Read(collectionStart + i, &item);
       fProxy->Insert(item, to, 1);
-      free(item);
    }
+
+   if (fProxy->GetType())
+      free(item);
+   else
+      fProxy->GetValueClass()->Destructor(item);
 }
 
 //------------------------------------------------------------------------------

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1459,10 +1459,8 @@ std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>
 ROOT::Experimental::RProxiedCollectionField::CloneImpl(std::string_view newName) const
 {
    auto newItemField = fSubFields[0]->Clone(fSubFields[0]->GetName());
-   auto result = std::unique_ptr<RProxiedCollectionField>(
+   return std::unique_ptr<RProxiedCollectionField>(
       new RProxiedCollectionField(newName, GetType(), std::move(newItemField)));
-   SyncFieldIDs(*this, *result);
-   return result;
 }
 
 std::size_t ROOT::Experimental::RProxiedCollectionField::AppendImpl(const void *from)
@@ -2414,9 +2412,7 @@ std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>
 ROOT::Experimental::RSetField::CloneImpl(std::string_view newName) const
 {
    auto newItemField = fSubFields[0]->Clone(fSubFields[0]->GetName());
-   auto result = std::unique_ptr<RSetField>(new RSetField(newName, GetType(), std::move(newItemField)));
-   SyncFieldIDs(*this, *result);
-   return result;
+   return std::unique_ptr<RSetField>(new RSetField(newName, GetType(), std::move(newItemField)));
 }
 
 //------------------------------------------------------------------------------

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -2408,6 +2408,10 @@ void ROOT::Experimental::RVariantField::CommitCluster()
 ROOT::Experimental::RSetField::RSetField(std::string_view fieldName, std::unique_ptr<Detail::RFieldBase> itemField)
    : ROOT::Experimental::RProxiedCollectionField(fieldName, "std::set<" + itemField->GetType() + ">")
 {
+   if (!fProxy->GetCollectionClass()->HasDictionary()) {
+      throw RException(R__FAIL("RField: no dictionary loaded for collection type " +
+                               GetNormalizedType(fProxy->GetCollectionClass()->GetName()).first));
+   }
 }
 
 std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>
@@ -2419,10 +2423,6 @@ ROOT::Experimental::RSetField::CloneImpl(std::string_view newName) const
 
 void ROOT::Experimental::RSetField::ReadGlobalImpl(NTupleSize_t globalIndex, void *to)
 {
-   if (!fProxy->GetCollectionClass()->HasDictionary()) {
-      throw RException(R__FAIL("RField: no dictionary loaded for collection type " + GetNormalizedTypeName(fProxy->GetCollectionClass()->GetName())));
-   }
-
    ClusterSize_t nItems;
    RClusterIndex collectionStart;
    fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &nItems);

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1402,37 +1402,6 @@ ROOT::Experimental::RProxiedCollectionField::RProxiedCollectionField(std::string
 
    fIFuncsRead = RCollectionIterableOnce::GetIteratorFuncs(fProxy.get(), true /* readFromDisk */);
    fIFuncsWrite = RCollectionIterableOnce::GetIteratorFuncs(fProxy.get(), false /* readFromDisk */);
-
-   std::unique_ptr<ROOT::Experimental::Detail::RFieldBase> itemField;
-
-   if (auto valueClass = fProxy->GetValueClass()) {
-      // Element type is a class
-      itemField = RFieldBase::Create("_0", valueClass->GetName()).Unwrap();
-   } else {
-      switch (fProxy->GetType()) {
-      case EDataType::kChar_t:   itemField = std::make_unique<RField<char>>("_0"); break;
-      case EDataType::kUChar_t:  itemField = std::make_unique<RField<std::uint8_t>>("_0"); break;
-      case EDataType::kShort_t:  itemField = std::make_unique<RField<std::int16_t>>("_0"); break;
-      case EDataType::kUShort_t: itemField = std::make_unique<RField<std::uint16_t>>("_0"); break;
-      case EDataType::kInt_t:    itemField = std::make_unique<RField<std::int32_t>>("_0"); break;
-      case EDataType::kUInt_t:   itemField = std::make_unique<RField<std::uint32_t>>("_0"); break;
-      case EDataType::kLong_t:
-      case EDataType::kLong64_t:
-         itemField = std::make_unique<RField<std::int64_t>>("_0");
-         break;
-      case EDataType::kULong_t:
-      case EDataType::kULong64_t:
-         itemField = std::make_unique<RField<std::uint64_t>>("_0");
-         break;
-      case EDataType::kFloat_t:  itemField = std::make_unique<RField<float>>("_0"); break;
-      case EDataType::kDouble_t: itemField = std::make_unique<RField<double>>("_0"); break;
-      case EDataType::kBool_t:   itemField = std::make_unique<RField<bool>>("_0"); break;
-      default:
-         throw RException(R__FAIL("unsupported value type"));
-      }
-   }
-   fItemSize = itemField->GetValueSize();
-   Attach(std::move(itemField));
 }
 
 std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>
@@ -1552,6 +1521,37 @@ ROOT::Experimental::RCollectionClassField::RCollectionClassField(std::string_vie
 {
    if (fProperties & TVirtualCollectionProxy::kIsAssociative)
       throw RException(R__FAIL("custom associative collection proxies not supported"));
+
+   std::unique_ptr<ROOT::Experimental::Detail::RFieldBase> itemField;
+
+   if (auto valueClass = fProxy->GetValueClass()) {
+      // Element type is a class
+      itemField = RFieldBase::Create("_0", valueClass->GetName()).Unwrap();
+   } else {
+      switch (fProxy->GetType()) {
+      case EDataType::kChar_t:   itemField = std::make_unique<RField<char>>("_0"); break;
+      case EDataType::kUChar_t:  itemField = std::make_unique<RField<std::uint8_t>>("_0"); break;
+      case EDataType::kShort_t:  itemField = std::make_unique<RField<std::int16_t>>("_0"); break;
+      case EDataType::kUShort_t: itemField = std::make_unique<RField<std::uint16_t>>("_0"); break;
+      case EDataType::kInt_t:    itemField = std::make_unique<RField<std::int32_t>>("_0"); break;
+      case EDataType::kUInt_t:   itemField = std::make_unique<RField<std::uint32_t>>("_0"); break;
+      case EDataType::kLong_t:
+      case EDataType::kLong64_t:
+         itemField = std::make_unique<RField<std::int64_t>>("_0");
+         break;
+      case EDataType::kULong_t:
+      case EDataType::kULong64_t:
+         itemField = std::make_unique<RField<std::uint64_t>>("_0");
+         break;
+      case EDataType::kFloat_t:  itemField = std::make_unique<RField<float>>("_0"); break;
+      case EDataType::kDouble_t: itemField = std::make_unique<RField<double>>("_0"); break;
+      case EDataType::kBool_t:   itemField = std::make_unique<RField<bool>>("_0"); break;
+      default:
+         throw RException(R__FAIL("unsupported value type"));
+      }
+   }
+   fItemSize = itemField->GetValueSize();
+   Attach(std::move(itemField));
 }
 
 std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>
@@ -2412,6 +2412,9 @@ ROOT::Experimental::RSetField::RSetField(std::string_view fieldName, std::unique
       throw RException(R__FAIL("RField: no dictionary loaded for collection type " +
                                GetNormalizedTypeName(fProxy->GetCollectionClass()->GetName())));
    }
+
+   fItemSize = itemField->GetValueSize();
+   Attach(std::move(itemField));
 }
 
 std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1395,6 +1395,10 @@ ROOT::Experimental::RProxiedCollectionField::RProxiedCollectionField(std::string
    fCollectionType = fProxy->GetCollectionType();
    if (fProxy->HasPointers())
       throw RException(R__FAIL("collection proxies whose value type is a pointer are not supported"));
+   if (!fProxy->GetCollectionClass()->HasDictionary()) {
+      throw RException(R__FAIL("dictionary not available for type " +
+                               GetNormalizedTypeName(fProxy->GetCollectionClass()->GetName())));
+   }
 
    fIFuncsRead = RCollectionIterableOnce::GetIteratorFuncs(fProxy.get(), true /* readFromDisk */);
    fIFuncsWrite = RCollectionIterableOnce::GetIteratorFuncs(fProxy.get(), false /* readFromDisk */);
@@ -1405,11 +1409,6 @@ ROOT::Experimental::RProxiedCollectionField::RProxiedCollectionField(std::string
                                                                      std::unique_ptr<Detail::RFieldBase> itemField)
    : RProxiedCollectionField(fieldName, typeName, TClass::GetClass(std::string(typeName).c_str()))
 {
-   if (!fProxy->GetCollectionClass()->HasDictionary()) {
-      throw RException(R__FAIL("dictionary not available for type " +
-                               GetNormalizedTypeName(fProxy->GetCollectionClass()->GetName())));
-   }
-
    fItemSize = itemField->GetValueSize();
    Attach(std::move(itemField));
 }

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -2410,7 +2410,7 @@ ROOT::Experimental::RSetField::RSetField(std::string_view fieldName, std::unique
 {
    if (!fProxy->GetCollectionClass()->HasDictionary()) {
       throw RException(R__FAIL("RField: no dictionary loaded for collection type " +
-                               GetNormalizedType(fProxy->GetCollectionClass()->GetName()).first));
+                               GetNormalizedTypeName(fProxy->GetCollectionClass()->GetName())));
    }
 }
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1430,12 +1430,12 @@ ROOT::Experimental::RProxiedCollectionField::RProxiedCollectionField(std::string
       itemField = RFieldBase::Create("_0", valueClass->GetName()).Unwrap();
    } else {
       switch (fProxy->GetType()) {
-      case EDataType::kChar_t:    itemField = std::make_unique<RField<char>>("_0"); break;
-      case EDataType::kUChar_t:   itemField = std::make_unique<RField<std::uint8_t>>("_0"); break;
-      case EDataType::kShort_t:   itemField = std::make_unique<RField<std::int16_t>>("_0"); break;
-      case EDataType::kUShort_t:  itemField = std::make_unique<RField<std::uint16_t>>("_0"); break;
-      case EDataType::kInt_t:     itemField = std::make_unique<RField<std::int32_t>>("_0"); break;
-      case EDataType::kUInt_t:    itemField = std::make_unique<RField<std::uint32_t>>("_0"); break;
+      case EDataType::kChar_t:   itemField = std::make_unique<RField<char>>("_0"); break;
+      case EDataType::kUChar_t:  itemField = std::make_unique<RField<std::uint8_t>>("_0"); break;
+      case EDataType::kShort_t:  itemField = std::make_unique<RField<std::int16_t>>("_0"); break;
+      case EDataType::kUShort_t: itemField = std::make_unique<RField<std::uint16_t>>("_0"); break;
+      case EDataType::kInt_t:    itemField = std::make_unique<RField<std::int32_t>>("_0"); break;
+      case EDataType::kUInt_t:   itemField = std::make_unique<RField<std::uint32_t>>("_0"); break;
       case EDataType::kLong_t:
       case EDataType::kLong64_t:
          itemField = std::make_unique<RField<std::int64_t>>("_0");
@@ -1444,9 +1444,9 @@ ROOT::Experimental::RProxiedCollectionField::RProxiedCollectionField(std::string
       case EDataType::kULong64_t:
          itemField = std::make_unique<RField<std::uint64_t>>("_0");
          break;
-      case EDataType::kFloat_t:   itemField = std::make_unique<RField<float>>("_0"); break;
-      case EDataType::kDouble_t:  itemField = std::make_unique<RField<double>>("_0"); break;
-      case EDataType::kBool_t:    itemField = std::make_unique<RField<bool>>("_0"); break;
+      case EDataType::kFloat_t:  itemField = std::make_unique<RField<float>>("_0"); break;
+      case EDataType::kDouble_t: itemField = std::make_unique<RField<double>>("_0"); break;
+      case EDataType::kBool_t:   itemField = std::make_unique<RField<bool>>("_0"); break;
       default:
          throw RException(R__FAIL("unsupported value type"));
       }

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -370,7 +370,7 @@ ROOT::Experimental::Detail::RFieldBase::Create(const std::string &fieldName, con
    } else if (canonicalType.substr(0, 9) == "std::set<") {
       std::string itemTypeName = canonicalType.substr(9, canonicalType.length() - 10);
       auto itemField = Create("_0", itemTypeName);
-      result = std::make_unique<RSetField>(fieldName, itemField.Unwrap());   
+      result = std::make_unique<RSetField>(fieldName, itemField.Unwrap());
    } else if (canonicalType == ":Collection:") {
       // TODO: create an RCollectionField?
       result = std::make_unique<RField<ClusterSize_t>>(fieldName);
@@ -1366,9 +1366,9 @@ void ROOT::Experimental::REnumField::AcceptVisitor(Detail::RFieldVisitor &visito
 
 //------------------------------------------------------------------------------
 
-ROOT::Experimental::RCollectionClassField::RCollectionIterableOnce::RIteratorFuncs
-ROOT::Experimental::RCollectionClassField::RCollectionIterableOnce::GetIteratorFuncs(TVirtualCollectionProxy *proxy,
-                                                                                     bool readFromDisk)
+ROOT::Experimental::RProxiedCollectionField::RCollectionIterableOnce::RIteratorFuncs
+ROOT::Experimental::RProxiedCollectionField::RCollectionIterableOnce::GetIteratorFuncs(TVirtualCollectionProxy *proxy,
+                                                                                       bool readFromDisk)
 {
    RIteratorFuncs ifuncs;
    ifuncs.fCreateIterators = proxy->GetFunctionCreateIterators(readFromDisk);
@@ -1379,13 +1379,13 @@ ROOT::Experimental::RCollectionClassField::RCollectionIterableOnce::GetIteratorF
    return ifuncs;
 }
 
-ROOT::Experimental::RCollectionClassField::RCollectionClassField(std::string_view fieldName, std::string_view className)
-   : RCollectionClassField(fieldName, className, TClass::GetClass(std::string(className).c_str()))
+ROOT::Experimental::RProxiedCollectionField::RProxiedCollectionField(std::string_view fieldName, std::string_view className)
+   : RProxiedCollectionField(fieldName, className, TClass::GetClass(std::string(className).c_str()))
 {
 }
 
-ROOT::Experimental::RCollectionClassField::RCollectionClassField(std::string_view fieldName, std::string_view className,
-                                                                 TClass *classp)
+ROOT::Experimental::RProxiedCollectionField::RProxiedCollectionField(std::string_view fieldName, std::string_view className,
+                                                                     TClass *classp)
    : ROOT::Experimental::Detail::RFieldBase(fieldName, className, ENTupleStructure::kCollection, false /* isSimple */),
      fNWritten(0)
 {
@@ -1399,13 +1399,12 @@ ROOT::Experimental::RCollectionClassField::RCollectionClassField(std::string_vie
    fCollectionType = fProxy->GetCollectionType();
    if (fProxy->HasPointers())
       throw RException(R__FAIL("collection proxies whose value type is a pointer are not supported"));
-   if (fProperties & TVirtualCollectionProxy::kIsAssociative)
-      throw RException(R__FAIL("associative collections not supported"));
 
    fIFuncsRead = RCollectionIterableOnce::GetIteratorFuncs(fProxy.get(), true /* readFromDisk */);
    fIFuncsWrite = RCollectionIterableOnce::GetIteratorFuncs(fProxy.get(), false /* readFromDisk */);
 
    std::unique_ptr<ROOT::Experimental::Detail::RFieldBase> itemField;
+
    if (auto valueClass = fProxy->GetValueClass()) {
       // Element type is a class
       itemField = RFieldBase::Create("_0", valueClass->GetName()).Unwrap();
@@ -1437,15 +1436,15 @@ ROOT::Experimental::RCollectionClassField::RCollectionClassField(std::string_vie
 }
 
 std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>
-ROOT::Experimental::RCollectionClassField::CloneImpl(std::string_view newName) const
+ROOT::Experimental::RProxiedCollectionField::CloneImpl(std::string_view newName) const
 {
-   auto result = std::unique_ptr<RCollectionClassField>(
-      new RCollectionClassField(newName, GetType(), fProxy->GetCollectionClass()));
+   auto result = std::unique_ptr<RProxiedCollectionField>(
+      new RProxiedCollectionField(newName, GetType(), fProxy->GetCollectionClass()));
    SyncFieldIDs(*this, *result);
    return result;
 }
 
-std::size_t ROOT::Experimental::RCollectionClassField::AppendImpl(const void *from)
+std::size_t ROOT::Experimental::RProxiedCollectionField::AppendImpl(const void *from)
 {
    std::size_t nbytes = 0;
    unsigned count = 0;
@@ -1461,7 +1460,7 @@ std::size_t ROOT::Experimental::RCollectionClassField::AppendImpl(const void *fr
    return nbytes + fColumns[0]->GetElement()->GetPackedSize();
 }
 
-void ROOT::Experimental::RCollectionClassField::ReadGlobalImpl(NTupleSize_t globalIndex, void *to)
+void ROOT::Experimental::RProxiedCollectionField::ReadGlobalImpl(NTupleSize_t globalIndex, void *to)
 {
    ClusterSize_t nItems;
    RClusterIndex collectionStart;
@@ -1481,7 +1480,7 @@ void ROOT::Experimental::RCollectionClassField::ReadGlobalImpl(NTupleSize_t glob
 }
 
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
-ROOT::Experimental::RCollectionClassField::GetColumnRepresentations() const
+ROOT::Experimental::RProxiedCollectionField::GetColumnRepresentations() const
 {
    static RColumnRepresentations representations(
       {{EColumnType::kSplitIndex64}, {EColumnType::kIndex64}, {EColumnType::kSplitIndex32}, {EColumnType::kIndex32}},
@@ -1489,23 +1488,23 @@ ROOT::Experimental::RCollectionClassField::GetColumnRepresentations() const
    return representations;
 }
 
-void ROOT::Experimental::RCollectionClassField::GenerateColumnsImpl()
+void ROOT::Experimental::RProxiedCollectionField::GenerateColumnsImpl()
 {
    fColumns.emplace_back(Detail::RColumn::Create<ClusterSize_t>(RColumnModel(GetColumnRepresentative()[0]), 0));
 }
 
-void ROOT::Experimental::RCollectionClassField::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+void ROOT::Experimental::RProxiedCollectionField::GenerateColumnsImpl(const RNTupleDescriptor &desc)
 {
    auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
    fColumns.emplace_back(Detail::RColumn::Create<ClusterSize_t>(RColumnModel(onDiskTypes[0]), 0));
 }
 
-void ROOT::Experimental::RCollectionClassField::GenerateValue(void *where) const
+void ROOT::Experimental::RProxiedCollectionField::GenerateValue(void *where) const
 {
    fProxy->New(where);
 }
 
-void ROOT::Experimental::RCollectionClassField::DestroyValue(void *objPtr, bool dtorOnly) const
+void ROOT::Experimental::RProxiedCollectionField::DestroyValue(void *objPtr, bool dtorOnly) const
 {
    if (fProperties & TVirtualCollectionProxy::kNeedDelete) {
       TVirtualCollectionProxy::TPushPop RAII(fProxy.get(), objPtr);
@@ -1519,7 +1518,7 @@ void ROOT::Experimental::RCollectionClassField::DestroyValue(void *objPtr, bool 
 }
 
 std::vector<ROOT::Experimental::Detail::RFieldBase::RValue>
-ROOT::Experimental::RCollectionClassField::SplitValue(const RValue &value) const
+ROOT::Experimental::RProxiedCollectionField::SplitValue(const RValue &value) const
 {
    std::vector<RValue> result;
    TVirtualCollectionProxy::TPushPop RAII(fProxy.get(), value.GetRawPtr());
@@ -1530,14 +1529,36 @@ ROOT::Experimental::RCollectionClassField::SplitValue(const RValue &value) const
    return result;
 }
 
-void ROOT::Experimental::RCollectionClassField::CommitCluster()
+void ROOT::Experimental::RProxiedCollectionField::CommitCluster()
 {
    fNWritten = 0;
 }
 
-void ROOT::Experimental::RCollectionClassField::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+void ROOT::Experimental::RProxiedCollectionField::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
-   visitor.VisitCollectionClassField(*this);
+   visitor.VisitProxiedCollectionField(*this);
+}
+
+//------------------------------------------------------------------------------
+
+ROOT::Experimental::RCollectionClassField::RCollectionClassField(std::string_view fieldName, std::string_view className)
+   : RCollectionClassField(fieldName, className, TClass::GetClass(std::string(className).c_str()))
+{
+}
+
+ROOT::Experimental::RCollectionClassField::RCollectionClassField(std::string_view fieldName, std::string_view className,
+                                                                 TClass *classp)
+   : ROOT::Experimental::RProxiedCollectionField(fieldName, className, classp)
+{
+   if (fProperties & TVirtualCollectionProxy::kIsAssociative)
+      throw RException(R__FAIL("custom associative collection proxies not supported"));
+}
+
+std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>
+ROOT::Experimental::RCollectionClassField::CloneImpl(std::string_view newName) const
+{
+   return std::unique_ptr<RCollectionClassField>(
+      new RCollectionClassField(newName, GetType(), fProxy->GetCollectionClass()));
 }
 
 //------------------------------------------------------------------------------
@@ -2385,12 +2406,8 @@ void ROOT::Experimental::RVariantField::CommitCluster()
 //------------------------------------------------------------------------------
 
 ROOT::Experimental::RSetField::RSetField(std::string_view fieldName, std::unique_ptr<Detail::RFieldBase> itemField)
-   : ROOT::Experimental::Detail::RFieldBase(fieldName, "std::set<" + itemField->GetType() + ">",
-                                            ENTupleStructure::kCollection, false /* isSimple */),
-     fItemSize(itemField->GetValueSize()),
-     fNWritten(0)
+   : ROOT::Experimental::RProxiedCollectionField(fieldName, "std::set<" + itemField->GetType() + ">")
 {
-   Attach(std::move(itemField));
 }
 
 std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>
@@ -2400,71 +2417,29 @@ ROOT::Experimental::RSetField::CloneImpl(std::string_view newName) const
    return std::make_unique<RSetField>(newName, std::move(newItemField));
 }
 
-const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
-ROOT::Experimental::RSetField::GetColumnRepresentations() const
+void ROOT::Experimental::RSetField::ReadGlobalImpl(NTupleSize_t globalIndex, void *to)
 {
-   static RColumnRepresentations representations(
-      {{EColumnType::kSplitIndex64}, {EColumnType::kIndex64}, {EColumnType::kSplitIndex32}, {EColumnType::kIndex32}},
-      {});
-   return representations;
-}
+   if (!fProxy->GetCollectionClass()->HasDictionary()) {
+      throw RException(R__FAIL("RField: no dictionary loaded for collection type " + GetNormalizedTypeName(fProxy->GetCollectionClass()->GetName())));
+   }
 
-void ROOT::Experimental::RSetField::GenerateColumnsImpl()
-{
-   fColumns.emplace_back(Detail::RColumn::Create<ClusterSize_t>(RColumnModel(GetColumnRepresentative()[0]), 0));
-}
+   ClusterSize_t nItems;
+   RClusterIndex collectionStart;
+   fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &nItems);
 
-void ROOT::Experimental::RSetField::GenerateColumnsImpl(const RNTupleDescriptor &desc)
-{
-   auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
-   fColumns.emplace_back(Detail::RColumn::Create<ClusterSize_t>(RColumnModel(onDiskTypes[0]), 0));
-}
+   TVirtualCollectionProxy::TPushPop RAII(fProxy.get(), to);
+   fProxy->Clear();
+   for (unsigned i = 0; i < nItems; ++i) {
+      void *item;
+      if (fProxy->GetType())
+         item = malloc(fItemSize);
+      else
+         item = fProxy->GetValueClass()->New();
 
-std::size_t ROOT::Experimental::RSetField::AppendImpl(const Detail::RFieldValue & /*value*/)
-{
-   // TODO(fdegeus)
-   R__ASSERT(false);
-   return -1;
-}
-
-void ROOT::Experimental::RSetField::ReadGlobalImpl(NTupleSize_t /*globalIndex*/, Detail::RFieldValue * /*value*/)
-{
-   // TODO(fdegeus)
-   R__ASSERT(false);
-}
-
-ROOT::Experimental::Detail::RFieldValue ROOT::Experimental::RSetField::GenerateValue(void *where)
-{
-   return Detail::RFieldValue(this, reinterpret_cast<std::set<char> *>(where));
-}
-
-void ROOT::Experimental::RSetField::DestroyValue(const Detail::RFieldValue & /*value*/, bool /*dtorOnly*/)
-{
-   // TODO(fdegeus)
-   R__ASSERT(false);
-}
-
-ROOT::Experimental::Detail::RFieldValue ROOT::Experimental::RSetField::CaptureValue(void *where)
-{
-   return Detail::RFieldValue(true /* captureFlag */, this, where);
-}
-
-std::vector<ROOT::Experimental::Detail::RFieldValue>
-ROOT::Experimental::RSetField::SplitValue(const Detail::RFieldValue & /*value*/) const
-{
-   //  TODO(fdegeus)
-   R__ASSERT(false);
-   return {};
-}
-
-void ROOT::Experimental::RSetField::CommitCluster()
-{
-   fNWritten = 0;
-}
-
-void ROOT::Experimental::RSetField::AcceptVisitor(Detail::RFieldVisitor &visitor) const
-{
-   visitor.VisitSetField(*this);
+      fSubFields[0]->Read(collectionStart + i, &item);
+      fProxy->Insert(item, to, 1);
+      free(item);
+   }
 }
 
 //------------------------------------------------------------------------------

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -380,7 +380,7 @@ void ROOT::Experimental::RPrintValueVisitor::VisitEnumField(const REnumField &fi
    intValue.GetField()->AcceptVisitor(visitor);
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitCollectionClassField(const RCollectionClassField &field)
+void ROOT::Experimental::RPrintValueVisitor::VisitProxiedCollectionField(const RProxiedCollectionField &field)
 {
    PrintCollection(field);
 }
@@ -390,18 +390,12 @@ void ROOT::Experimental::RPrintValueVisitor::VisitVectorField(const RVectorField
    PrintCollection(field);
 }
 
-
 void ROOT::Experimental::RPrintValueVisitor::VisitVectorBoolField(const RField<std::vector<bool>> &field)
 {
    PrintCollection(field);
 }
 
 void ROOT::Experimental::RPrintValueVisitor::VisitRVecField(const RRVecField &field)
-{
-   PrintCollection(field);
-}
-
-void ROOT::Experimental::RPrintValueVisitor::VisitSetField(const RSetField &field)
 {
    PrintCollection(field);
 }

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -401,6 +401,11 @@ void ROOT::Experimental::RPrintValueVisitor::VisitRVecField(const RRVecField &fi
    PrintCollection(field);
 }
 
+void ROOT::Experimental::RPrintValueVisitor::VisitSetField(const RSetField &field)
+{
+   PrintCollection(field);
+}
+
 //---------------------------- RNTupleFormatter --------------------------------
 
 

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -5,10 +5,10 @@
 #include <TRootIOCtor.h>
 
 #include <cstdint>
+#include <set>
 #include <string>
 #include <variant>
 #include <vector>
-#include <set>
 
 /**
  * Used to test serialization and deserialization of classes in RNTuple with TClass

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -8,6 +8,7 @@
 #include <string>
 #include <variant>
 #include <vector>
+#include <set>
 
 /**
  * Used to test serialization and deserialization of classes in RNTuple with TClass
@@ -29,6 +30,10 @@ struct CustomStruct {
    std::vector<float> v1;
    std::vector<std::vector<float>> v2;
    std::string s;
+
+   bool operator <(const CustomStruct& c) const {
+      return a < c.a;
+   }
 };
 
 struct DerivedA : public CustomStruct {

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -34,6 +34,8 @@ struct CustomStruct {
    bool operator <(const CustomStruct& c) const {
       return a < c.a;
    }
+
+   bool operator==(const CustomStruct &c) const { return a == c.a && v1 == c.v1 && v2 == c.v2 && s == c.s; }
 };
 
 struct DerivedA : public CustomStruct {

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -31,9 +31,7 @@ struct CustomStruct {
    std::vector<std::vector<float>> v2;
    std::string s;
 
-   bool operator <(const CustomStruct& c) const {
-      return a < c.a;
-   }
+   bool operator<(const CustomStruct &c) const { return a < c.a && v1 < c.v1 && v2 < c.v2 && s < c.s; }
 
    bool operator==(const CustomStruct &c) const { return a == c.a && v1 == c.v1 && v2 == c.v2 && s == c.s; }
 };

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -51,6 +51,8 @@
 #pragma link C++ class ConstructorTraits + ;
 #pragma link C++ class DestructorTraits + ;
 
+#pragma link C++ class std::set<std::set<char>> +;
+
 #pragma link C++ options = version(3) class StructWithIORulesBase + ;
 #pragma link C++ options = version(3) class StructWithTransientString + ;
 #pragma link C++ options = version(3) class StructWithIORules + ;

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -51,7 +51,9 @@
 #pragma link C++ class ConstructorTraits + ;
 #pragma link C++ class DestructorTraits + ;
 
+#pragma link C++ class std::set<std::set<CustomStruct>> +;
 #pragma link C++ class std::set<std::set<char>> +;
+#pragma link C++ class std::set<std::pair<int, CustomStruct>> +;
 
 #pragma link C++ options = version(3) class StructWithIORulesBase + ;
 #pragma link C++ options = version(3) class StructWithTransientString + ;

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -51,6 +51,7 @@
 #pragma link C++ class ConstructorTraits + ;
 #pragma link C++ class DestructorTraits + ;
 
+#pragma link C++ class std::set<std::int64_t> +;
 #pragma link C++ class std::set<std::set<CustomStruct>> +;
 #pragma link C++ class std::set<std::set<char>> +;
 #pragma link C++ class std::set<std::pair<int, CustomStruct>> +;

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -52,6 +52,8 @@
 #pragma link C++ class DestructorTraits + ;
 
 #pragma link C++ class std::set<std::int64_t> +;
+#pragma link C++ class std::set<std::string> +;
+#pragma link C++ class std::set<float> +;
 #pragma link C++ class std::set<std::set<CustomStruct>> +;
 #pragma link C++ class std::set<std::set<char>> +;
 #pragma link C++ class std::set<std::pair<int, CustomStruct>> +;

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -1212,7 +1212,7 @@ TEST(RNTuple, TVirtualCollectionProxy)
    SimpleCollectionProxy<StructUsingCollectionProxy<CustomStruct>> proxyS;
    SimpleCollectionProxy<StructUsingCollectionProxy<StructUsingCollectionProxy<float>>> proxyNested;
 
-   // `RCollectionClassField` instantiated but no collection proxy set (yet)
+   // `RProxiedCollectionField` instantiated but no collection proxy set (yet)
    EXPECT_THROW(RField<StructUsingCollectionProxy<float>>("hasTraitButNoCollectionProxySet"),
                 ROOT::Experimental::RException);
 

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -362,13 +362,8 @@ TEST(RNTuple, StdSet)
       EXPECT_EQ(std::set<std::set<char>>({{static_cast<char>(i), 'a'}, {'r', 'o', 'o', 't'}, {'h', 'i'}}), viewSet4(i));
    }
 
-   auto model = RNTupleModel::Create();
-   model->AddField(RFieldBase::Create("mySet2", "std::set<std::pair<int, CustomStruct>>").Unwrap());
-
-   auto ntuple2 = RNTupleReader::Open(std::move(model), "set_ntuple", fileGuard.GetPath());
-
-   ntuple2->LoadEntry(0);
-   auto mySet2 = ntuple2->GetModel()->GetDefaultEntry()->Get<std::set<std::pair<int, CustomStruct>>>("mySet2");
+   ntuple->LoadEntry(0);
+   auto mySet2 = ntuple->GetModel()->GetDefaultEntry()->Get<std::set<std::pair<int, CustomStruct>>>("mySet2");
    auto pairSet =
       std::set<std::pair<int, CustomStruct>>({std::make_pair(0, CustomStruct{6.f, {7.f, 8.f}, {{9.f}, {10.f}}, "foo"}),
                                               std::make_pair(1, CustomStruct{2.f, {3.f, 4.f}, {{5.f}, {6.f}}, "bar"})});

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -312,31 +312,31 @@ TEST(RNTuple, StdSet)
    EXPECT_EQ((sizeof(std::set<int64_t>)), otherField->GetValueSize());
    EXPECT_EQ((alignof(std::set<int64_t>)), field.GetAlignment());
    EXPECT_EQ((alignof(std::set<int64_t>)), otherField->GetAlignment());
-
-   // TODO(fdegeus): add and test custom comparators
-   // auto setSetField = RField<std::set<std::set<CustomStruct>>>("setSetField");
-   // EXPECT_STREQ("std::set<std::set<CustomStruct>>", setSetField.GetType().c_str());
+   auto setSetField = RField<std::set<std::set<CustomStruct>>>("setSetField");
+   EXPECT_STREQ("std::set<std::set<CustomStruct>>", setSetField.GetType().c_str());
 
    FileRaii fileGuard("test_ntuple_rfield_stdset.root");
    {
       auto model = RNTupleModel::Create();
       auto set_field = model->MakeField<std::set<float>>({"mySet", "float set"});
-      auto mySet2 = model->MakeField<std::set<std::string>>({"mySet2", "string set"});
-      auto mySet3 = model->MakeField<std::set<std::set<char>>>({"mySet3", "nested set"});
+      // For templated set fields, no dictionary should be necessary.
+      auto set_field2 = model->MakeField<std::set<std::set<int>>>({"mySet2"});
 
-      // TODO(fdegeus): add and test non-templated set fields
-      // auto mySet2 = RFieldBase::Create("mySet2", "std::set<std::string>").Unwrap();
-      // auto mySet3 = RFieldBase::Create("mySet3", "std::set<std::set<char>>").Unwrap();
-      // model->AddField(std::move(mySet2));
-      // model->AddField(std::move(mySet3));
+      auto mySet3 = RFieldBase::Create("mySet3", "std::set<std::string>").Unwrap();
+      // This field type has a dictionary entry, so reading and writing should be possible without any problems.
+      auto mySet4 = RFieldBase::Create("mySet4", "std::set<std::set<char>>").Unwrap();
+
+      model->AddField(std::move(mySet3));
+      model->AddField(std::move(mySet4));
 
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "set_ntuple", fileGuard.GetPath());
-      auto set_field2 = ntuple->GetModel()->GetDefaultEntry()->Get<std::set<std::string>>("mySet2");
-      auto set_field3 = ntuple->GetModel()->GetDefaultEntry()->Get<std::set<std::set<char>>>("mySet3");
+      auto set_field3 = ntuple->GetModel()->GetDefaultEntry()->Get<std::set<std::string>>("mySet3");
+      auto set_field4 = ntuple->GetModel()->GetDefaultEntry()->Get<std::set<std::set<char>>>("mySet4");
       for (int i = 0; i < 2; i++) {
          *set_field = {static_cast<float>(i), 3.14, 0.42};
-         *set_field2 = {"Hello", "world!", std::to_string(i)};
-         *set_field3 = {{static_cast<char>(i), 'a'}, {'r', 'o', 'o', 't'}, {'h', 'i'}};
+         *set_field2 = {{static_cast<int>(i)}, {static_cast<int>(i * 2), 3}, {}};
+         *set_field3 = {"Hello", "world!", std::to_string(i)};
+         *set_field4 = {{static_cast<char>(i), 'a'}, {'r', 'o', 'o', 't'}, {'h', 'i'}};
          ntuple->Fill();
       }
    }
@@ -345,12 +345,14 @@ TEST(RNTuple, StdSet)
    EXPECT_EQ(2, ntuple->GetNEntries());
 
    auto viewSet = ntuple->GetView<std::set<float>>("mySet");
-   auto viewSet2 = ntuple->GetView<std::set<std::string>>("mySet2");
-   auto viewSet3 = ntuple->GetView<std::set<std::set<char>>>("mySet3");
+   auto viewSet2 = ntuple->GetView<std::set<std::set<int>>>("mySet2");
+   auto viewSet3 = ntuple->GetView<std::set<std::string>>("mySet3");
+   auto viewSet4 = ntuple->GetView<std::set<std::set<char>>>("mySet4");
    for (auto i : ntuple->GetEntryRange()) {
       EXPECT_EQ(std::set<float>({static_cast<float>(i), 3.14, 0.42}), viewSet(i));
-      EXPECT_EQ(std::set<std::string>({"Hello", "world!", std::to_string(i)}), viewSet2(i));
-      EXPECT_EQ(std::set<std::set<char>>({{static_cast<char>(i), 'a'}, {'r', 'o', 'o', 't'}, {'h', 'i'}}), viewSet3(i));
+      EXPECT_EQ(std::set<std::set<int>>({{static_cast<int>(i)}, {static_cast<int>(i * 2), 3}, {}}), viewSet2(i));
+      EXPECT_EQ(std::set<std::string>({"Hello", "world!", std::to_string(i)}), viewSet3(i));
+      EXPECT_EQ(std::set<std::set<char>>({{static_cast<char>(i), 'a'}, {'r', 'o', 'o', 't'}, {'h', 'i'}}), viewSet4(i));
    }
 }
 

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -361,6 +361,18 @@ TEST(RNTuple, StdSet)
       EXPECT_EQ(std::set<std::string>({"Hello", "world!", std::to_string(i)}), viewSet3(i));
       EXPECT_EQ(std::set<std::set<char>>({{static_cast<char>(i), 'a'}, {'r', 'o', 'o', 't'}, {'h', 'i'}}), viewSet4(i));
    }
+
+   auto model = RNTupleModel::Create();
+   model->AddField(RFieldBase::Create("mySet2", "std::set<std::pair<int, CustomStruct>>").Unwrap());
+
+   auto ntuple2 = RNTupleReader::Open(std::move(model), "set_ntuple", fileGuard.GetPath());
+
+   ntuple2->LoadEntry(0);
+   auto mySet2 = ntuple2->GetModel()->GetDefaultEntry()->Get<std::set<std::pair<int, CustomStruct>>>("mySet2");
+   auto pairSet =
+      std::set<std::pair<int, CustomStruct>>({std::make_pair(0, CustomStruct{6.f, {7.f, 8.f}, {{9.f}, {10.f}}, "foo"}),
+                                              std::make_pair(1, CustomStruct{2.f, {3.f, 4.f}, {{5.f}, {6.f}}, "bar"})});
+   EXPECT_EQ(pairSet, *mySet2);
 }
 
 TEST(RNTuple, Int64)

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -322,11 +322,9 @@ TEST(RNTuple, StdSet)
    {
       auto model = RNTupleModel::Create();
       auto set_field = model->MakeField<std::set<float>>({"mySet", "float set"});
-      // For templated set fields, no dictionary should be necessary.
       auto set_field2 = model->MakeField<std::set<std::pair<int, CustomStruct>>>({"mySet2"});
 
       auto mySet3 = RFieldBase::Create("mySet3", "std::set<std::string>").Unwrap();
-      // This field type has a dictionary entry, so reading and writing should be possible without any problems.
       auto mySet4 = RFieldBase::Create("mySet4", "std::set<std::set<char>>").Unwrap();
 
       model->AddField(std::move(mySet3));


### PR DESCRIPTION
This PR adds `std::set` fields. For type-erased fields, we use virtual collection proxies. This already implemented for `RCollectionClassField` fields, but reading from disk for associative containers works slightly different. Therefore, a `RProxiedCollectionField` class is introduced that takes care of all proxy-related implementation and can be used for custom collections, and `RSetField` which inherits from this and specializes for `std::set` (and other related STL collections that will be addressed in a follow-up PR).

