### PR TITLE
[RF] Correctly reset y-axis limits after `RooCurve::shiftCurveToZero()`

### DIFF
--- a/roofit/roofitcore/inc/RooCurve.h
+++ b/roofit/roofitcore/inc/RooCurve.h
@@ -86,7 +86,7 @@ protected:
       Int_t numee=0, bool doEEVal=false, double eeVal=0.0);
 
 
-  void shiftCurveToZero(double prevYMax) ;
+  void shiftCurveToZero();
 
   bool _showProgress = false; ///<! Show progress indication when adding points
 

--- a/roofit/roofitcore/inc/RooPlotable.h
+++ b/roofit/roofitcore/inc/RooPlotable.h
@@ -25,9 +25,6 @@ class RooArgSet;
 
 class RooPlotable : public RooPrintable {
 public:
-  inline RooPlotable() : _ymin(0), _ymax(0), _normValue(0) { }
-  inline ~RooPlotable() override { }
-
   inline const char* getYAxisLabel() const { return _yAxisLabel.Data(); }
   inline void setYAxisLabel(const char *label) { _yAxisLabel= label; }
   inline void updateYAxisLimits(double y) {
@@ -52,7 +49,9 @@ public:
   TObject *crossCast();
 protected:
   TString _yAxisLabel;
-  double _ymin, _ymax, _normValue;
+  double _ymin = 0.0;
+  double _ymax = 0.0;
+  double _normValue = 0.0;
   ClassDefOverride(RooPlotable,1) // Abstract interface for plotable objects in a RooPlot
 };
 


### PR DESCRIPTION
This commit fixes the resetting of the y-axis limits at the end of `RooCurve::shiftCurveToZero()`. In particular, it now sets also the minimium limit correctly, which was not changed before even though it needs to be changed too.

Here is an example of a liklihood plot that looks good after this commit, but had wrong y-ranges before:

```c++
using namespace RooFit;

RooRealVar x("x", "", 100, 160);
RooRealVar sigmean("sigmean", "", 125, 100, 140);

RooGaussian signalModel("signal", "", x, sigmean, RooConst(2.0));
RooExponential background("background", "", x, RooConst(-0.03));

// double nbkgVal = 10;
// double nbkgVal = 200;
double nbkgVal = 5000;

RooRealVar nsig("nsig", "", 200, 0., 1000);
RooRealVar nbkg("nbkg", "", nbkgVal, 0., 10000);
RooAddPdf model("model", "", {signalModel, background}, {nsig, nbkg});

std::unique_ptr<RooDataSet> data{model.generate(x)};

std::unique_ptr<RooAbsReal> nll{model.createNLL(*data)};

RooPlot *frame1 = sigmean.frame();
nll->plotOn(frame1, ShiftToZero());

frame1->Draw();
```

