### PR TITLE
[windows] Fix the C++ notebooks on Windows (#12912)

### DIFF
--- a/bindings/jupyroot/python/JupyROOT/helpers/cppcompleter.py
+++ b/bindings/jupyroot/python/JupyROOT/helpers/cppcompleter.py
@@ -14,6 +14,7 @@
 ################################################################################
 
 from JupyROOT.helpers import utils
+import platform
 import ROOT
 
 # Jit a wrapper for the ttabcom
@@ -106,8 +107,11 @@ class CppCompleter(object):
     def activate(self):
         self.active = True
         if self.firstActivation:
-            utils.declareCppCode('#include "dlfcn.h"')
-            dlOpenRint = 'dlopen("libRint.so",RTLD_NOW);'
+            if platform.system() == 'Windows':
+                dlOpenRint = 'gInterpreter->LoadFile("libRint.dll");'
+            else:
+                utils.declareCppCode('#include "dlfcn.h"')
+                dlOpenRint = 'dlopen("libRint.so",RTLD_NOW);'
             utils.processCppCode(dlOpenRint)
             utils.declareCppCode(_TTabComHookCode)
             self.hook = ROOT._TTabComHook

--- a/bindings/jupyroot/python/JupyROOT/kernel/utils.py
+++ b/bindings/jupyroot/python/JupyROOT/kernel/utils.py
@@ -62,10 +62,12 @@ def GetDisplayer(poller):
 class MagicLoader(object):
     '''Class to load JupyROOT Magics'''
     def __init__(self,kernel):
-         magics_path = os.path.dirname(__file__)+"/magics/*.py"
+         magics_path = os.path.join(os.path.dirname(__file__), "magics", "*.py")
          for file in glob(magics_path):
               if file != magics_path.replace("*.py","__init__.py"):
-                  module_path="JupyROOT.kernel.magics."+file.split("/")[-1].replace(".py","")
+                  module_prefix = "JupyROOT.kernel.magics."
+                  module_name = os.path.splitext(os.path.basename(file))[0]
+                  module_path = module_prefix + module_name
                   try:
                       module = importlib.import_module(module_path)
                       module.register_magics(kernel)


### PR DESCRIPTION
* [windows][skip-ci] Fix the C++ notebooks on Windows

* [windows][skip-ci] Fix the C++ notebooks on Windows

Fix the following errors in `bindings/jupyroot/python/JupyROOT/kernel/utils.py`:
```
Traceback (most recent call last):
  File "C:\Users\bellenot\build\x86\release\bin\JupyROOT\kernel\utils.py", line 70, in __init__
    module = importlib.import_module(module_path)
  File "c:\python39-32\lib\importlib\__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 984, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'JupyROOT.kernel.magics.magics\\cppmagic'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "c:\python39-32\lib\runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "c:\python39-32\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\Users\bellenot\build\x86\release\bin\JupyROOT\kernel\rootkernel.py", line 137, in <module>
    main()
  File "C:\Users\bellenot\build\x86\release\bin\JupyROOT\kernel\rootkernel.py", line 134, in main
    IPKernelApp.launch_instance(kernel_class=ROOTKernel)
  File "c:\python39-32\lib\site-packages\traitlets\config\application.py", line 844, in launch_instance
    app.initialize(argv)
  File "c:\python39-32\lib\site-packages\traitlets\config\application.py", line 87, in inner
    return method(app, *args, **kwargs)
  File "c:\python39-32\lib\site-packages\ipykernel\kernelapp.py", line 637, in initialize
    self.init_kernel()
  File "c:\python39-32\lib\site-packages\ipykernel\kernelapp.py", line 489, in init_kernel
    kernel = kernel_factory(parent=self, session=self.session,
  File "c:\python39-32\lib\site-packages\traitlets\config\configurable.py", line 537, in instance
    inst = cls(*args, **kwargs)
  File "C:\Users\bellenot\build\x86\release\bin\JupyROOT\kernel\rootkernel.py", line 67, in __init__
    self.magicloader = MagicLoader(self)
  File "C:\Users\bellenot\build\x86\release\bin\JupyROOT\kernel\utils.py", line 73, in __init__
    raise Exception("Error importing Magic: %s"%module_path)
Exception: Error importing Magic: JupyROOT.kernel.magics.magics\cppmagic
```
And these ones in `bindings/jupyroot/python/JupyROOT/helpers/cppcompleter.py`:
```
input_line_37:1:10: fatal error: 'dlfcn.h' file not found
         ^~~~~~~~~
input_line_41:2:24: error: use of undeclared identifier 'RTLD_NOW'
 (dlopen("libRint.so", RTLD_NOW))
                       ^
```

* Update bindings/jupyroot/python/JupyROOT/kernel/utils.py



* Apply suggestion from Vincenzo + fix indentation

---------

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

