### PR TITLE
[RF] Fix `RooAddPdf::expectedEvents()` in conditional fits

### DIFF
--- a/roofit/roofitcore/inc/RooFit/Detail/NormalizationHelpers.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/NormalizationHelpers.h
@@ -44,6 +44,8 @@ public:
    void markAsCompiled(RooAbsArg &arg) const;
    void markSubtreeAsCompiled(RooAbsArg &arg) const;
 
+   void redirectToCompiledServers(RooAbsArg &topNode) const;
+
    // This information is used for the binned likelihood optimization.
    void setLikelihoodMode(bool flag) { _likelihoodMode = flag; }
    bool likelihoodMode() const { return _likelihoodMode; }
@@ -71,7 +73,9 @@ template <class T>
 std::unique_ptr<T> compileForNormSet(T const &arg, RooArgSet const &normSet)
 {
    RooFit::Detail::CompileContext ctx{normSet};
-   return std::unique_ptr<T>{static_cast<T *>(arg.compileForNormSet(normSet, ctx).release())};
+   std::unique_ptr<T> out{static_cast<T *>(arg.compileForNormSet(normSet, ctx).release())};
+   ctx.redirectToCompiledServers(*out);
+   return out;
 }
 
 } // namespace Detail

--- a/roofit/roofitcore/src/FitHelpers.cxx
+++ b/roofit/roofitcore/src/FitHelpers.cxx
@@ -507,6 +507,7 @@ std::unique_ptr<RooAbsPdf> compilePdfForFit(RooAbsPdf &pdf, RooArgSet const &nor
    RooFit::Detail::CompileContext ctx{normSet};
    ctx.setLikelihoodMode(likelihoodMode);
    std::unique_ptr<RooAbsArg> head = pdf.compileForNormSet(normSet, ctx);
+   ctx.redirectToCompiledServers(*head);
    std::unique_ptr<RooAbsPdf> pdfClone{&dynamic_cast<RooAbsPdf &>(*head.release())};
 
    if (addCoefRangeName && *addCoefRangeName) {

--- a/roofit/roofitcore/src/NormalizationHelpers.cxx
+++ b/roofit/roofitcore/src/NormalizationHelpers.cxx
@@ -95,3 +95,28 @@ bool RooFit::Detail::CompileContext::isMarkedAsCompiled(RooAbsArg const &arg) co
 {
    return arg.getAttribute("_COMPILED");
 }
+
+/// Replace any reference to the original computation graph that is left in the
+/// compiled one. Objects that are created while compiling, like the
+/// normalization integrals, are built from the original normalization set, so
+/// they can still reference the original observables. Such a leftover is a
+/// second node with the same name in the compiled graph, which breaks the
+/// lookup of nodes by name later on: the dataset columns would potentially be
+/// attached to the leftover instead of the compiled observable, in which case
+/// the compiled function doesn't depend on the data at all anymore.
+void RooFit::Detail::CompileContext::redirectToCompiledServers(RooAbsArg &topNode) const
+{
+   RooArgList nodes;
+   topNode.treeNodeServerList(&nodes, nullptr, /*doBranch=*/true, /*doLeaf=*/true, /*valueOnly=*/false,
+                              /*recurseNonDerived=*/false);
+   for (RooAbsArg *node : nodes) {
+      // Original nodes can also be reachable from the compiled graph, e.g. the
+      // integrand of an integral that RooProjectedPdf::compileForNormSet()
+      // created from the original pdf. They must not be redirected: their
+      // servers would be replaced by compiled clones that die with the
+      // computation graph, silently corrupting the users' original model.
+      if (isMarkedAsCompiled(*node)) {
+         node->redirectServers(_replacements);
+      }
+   }
+}

--- a/roofit/roofitcore/src/RooAddHelpers.cxx
+++ b/roofit/roofitcore/src/RooAddHelpers.cxx
@@ -271,7 +271,7 @@ void RooAddHelpers::updateCoefficients(RooAbsPdf const &addPdf, std::size_t nPdf
    // Adjust coefficients for given projection
    double coefSum(0);
    for (std::size_t i = 0; i < nPdfs; i++) {
-      coefCache[i] *= cache.projVal(i) / cache.projSuppNormVal(i) * cache.rangeProjScaleFactor(i);
+      coefCache[i] *= cache.coefProjectionFactor(i);
       coefSum += coefCache[i];
    }
 

--- a/roofit/roofitcore/src/RooAddHelpers.h
+++ b/roofit/roofitcore/src/RooAddHelpers.h
@@ -32,6 +32,13 @@ public:
 
    inline bool doProjection() const { return !_projList.empty(); }
 
+   inline double coefProjectionFactor(std::size_t idx) {
+         return projVal(idx) / projSuppNormVal(idx) * rangeProjScaleFactor(idx);
+   }
+
+   void print() const;
+
+private:
    inline double projVal(std::size_t idx) const { return _projList[idx] ? _projList[idx]->getVal() : 1.0; }
 
    inline double projSuppNormVal(std::size_t idx) const
@@ -44,9 +51,6 @@ public:
       return _rangeProjList[idx] ? _rangeProjList[idx]->getVal() : 1.0;
    }
 
-   void print() const;
-
-private:
    using OwningArgVector = std::vector<std::unique_ptr<RooAbsReal>>;
 
    OwningArgVector _suppNormList; ///< Supplemental normalization list

--- a/roofit/roofitcore/src/RooAddHelpers.h
+++ b/roofit/roofitcore/src/RooAddHelpers.h
@@ -32,6 +32,16 @@ public:
 
    inline bool doProjection() const { return !_projList.empty(); }
 
+   /// Factor that transforms a coefficient defined in the reference
+   /// normalization set to the current normalization set.
+   inline double coefProjectionFactor(std::size_t idx) const
+   {
+      return projVal(idx) / projSuppNormVal(idx) * rangeProjScaleFactor(idx);
+   }
+
+   void print() const;
+
+private:
    inline double projVal(std::size_t idx) const { return _projList[idx] ? _projList[idx]->getVal() : 1.0; }
 
    inline double projSuppNormVal(std::size_t idx) const
@@ -44,9 +54,6 @@ public:
       return _rangeProjList[idx] ? _rangeProjList[idx]->getVal() : 1.0;
    }
 
-   void print() const;
-
-private:
    using OwningArgVector = std::vector<std::unique_ptr<RooAbsReal>>;
 
    OwningArgVector _suppNormList; ///< Supplemental normalization list

--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -763,9 +763,19 @@ double RooAddPdf::expectedEvents(const RooArgSet* nset) const
   if (cache.doProjection()) {
 
     for (std::size_t i = 0; i < _pdfList.size(); ++i) {
-      double ncomp = _allExtendable ? static_cast<RooAbsPdf&>(_pdfList[i]).expectedEvents(nset)
+      // There are two cases covered here:
+      //   1. The expected events is the sum of expectedEvents() for each pdf
+      //   2. Get the expected events from the coeffiecients
+      // For case #2, multiplying with coefProjectionFactor(i) gives the right
+      // coefs for this RooAddPdf to be normalized over nset, while the coefs
+      // where determined with the components normalized over _refCoefNorm. To
+      // reuse the same projection factor also in the first case, we evaluate
+      // the individual expected events for _refCoefNorm as well. This is done
+      // to avoid confusion about different projection factors extracted from
+      // cache, as like this we only need one factor for each pdf.
+      double ncomp = _allExtendable ? static_cast<RooAbsPdf&>(_pdfList[i]).expectedEvents(_refCoefNorm)
                                     : static_cast<RooAbsReal&>(_coefList[i]).getVal(nset);
-      expectedTotal += cache.rangeProjScaleFactor(i) * ncomp ;
+      expectedTotal += cache.coefProjectionFactor(i) * ncomp ;
 
     }
 

--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -762,10 +762,28 @@ double RooAddPdf::expectedEvents(const RooArgSet* nset) const
 
   if (cache.doProjection()) {
 
+    // The normalization set in which the individual expected number of events
+    // are evaluated. It has to be the same set in which the coefficients are
+    // defined, because the transformation from that set to nset is done with
+    // the projection factor from the cache. If there is no reference set for
+    // the coefficients, the projection is only for range reasons and the
+    // expected events are evaluated in nset itself.
+    const RooArgSet *ncompNormSet = !_refCoefNorm.empty() ? &_refCoefNorm : nset;
+
     for (std::size_t i = 0; i < _pdfList.size(); ++i) {
-      double ncomp = _allExtendable ? static_cast<RooAbsPdf&>(_pdfList[i]).expectedEvents(nset)
+      // There are two cases covered here:
+      //   1. The expected events is the sum of expectedEvents() for each pdf
+      //   2. Get the expected events from the coeffiecients
+      // For case #2, multiplying with coefProjectionFactor(i) gives the right
+      // coefs for this RooAddPdf to be normalized over nset, while the coefs
+      // where determined with the components normalized over _refCoefNorm. To
+      // reuse the same projection factor also in the first case, we evaluate
+      // the individual expected events for _refCoefNorm as well. This is done
+      // to avoid confusion about different projection factors extracted from
+      // cache, as like this we only need one factor for each pdf.
+      double ncomp = _allExtendable ? static_cast<RooAbsPdf&>(_pdfList[i]).expectedEvents(ncompNormSet)
                                     : static_cast<RooAbsReal&>(_coefList[i]).getVal(nset);
-      expectedTotal += cache.rangeProjScaleFactor(i) * ncomp ;
+      expectedTotal += cache.coefProjectionFactor(i) * ncomp ;
 
     }
 
@@ -790,11 +808,24 @@ std::unique_ptr<RooAbsReal> RooAddPdf::createExpectedEventsFunc(const RooArgSet 
 {
    std::unique_ptr<RooAbsReal> out;
 
+   // Make sure _refCoefNorm is defined
+   materializeRefCoefNormFromAttribute();
+
+   // If the _refCoefNorm is empty or it's equal to normSet anyway, this is not
+   // a conditional pdf and we don't need to do any transformation. See also
+   // RooAddPdf::compileForNormSet() for more explanations on a similar logic.
+   const bool doCoefProjection = !_refCoefNorm.empty() && nset && !nset->equals(_refCoefNorm);
+
    auto name = std::string(GetName()) + "_expectedEvents";
    if (_allExtendable) {
       RooArgSet sumSet;
+      // Like in expectedEvents(), the expected number of events of the
+      // components are evaluated in the set in which the coefficients are
+      // defined, because the transformation to nset is done by the projection
+      // integral that is multiplied in below.
+      const RooArgSet *compNormSet = doCoefProjection ? &_refCoefNorm : nset;
       for (auto *pdf : static_range_cast<RooAbsPdf *>(_pdfList)) {
-         sumSet.addOwned(pdf->createExpectedEventsFunc(nset));
+         sumSet.addOwned(pdf->createExpectedEventsFunc(compNormSet));
       }
       out = std::make_unique<RooAddition>(name.c_str(), name.c_str(), sumSet);
       out->addOwnedComponents(std::move(sumSet));
@@ -804,17 +835,11 @@ std::unique_ptr<RooAbsReal> RooAddPdf::createExpectedEventsFunc(const RooArgSet 
 
    RooArgList prodList;
 
-   // Make sure _refCoefNorm is defined
-   materializeRefCoefNormFromAttribute();
+   if (doCoefProjection) {
+      prodList.addOwned(std::unique_ptr<RooAbsReal>{createIntegral(*nset, _refCoefNorm)});
+   }
 
    if (!_allExtendable) {
-      // If the _refCoefNorm is empty or it's equal to normSet anyway, this is not
-      // a conditional pdf and we don't need to do any transformation. See also
-      // RooAddPdf::compileForNormSet() for more explanations on a similar logic.
-      if (!_refCoefNorm.empty() && !nset->equals(_refCoefNorm)) {
-         prodList.addOwned(std::unique_ptr<RooAbsReal>{createIntegral(*nset, _refCoefNorm)});
-      }
-
       // Optionally multiply with fractional normalization. I this case, we
       // replace the original factor stored in "out".
       if (!_normRange.IsNull()) {

--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -69,6 +69,7 @@ An (enforced) condition for this assumption is that each \f$ \mathrm{PDF}_i \f$ 
 #include <RooAddition.h>
 #include <RooBatchCompute.h>
 #include <RooDataSet.h>
+#include <RooExtendPdf.h>
 #include <RooGenericPdf.h>
 #include <RooGlobalFunc.h>
 #include <RooProdPdf.h>
@@ -1080,14 +1081,34 @@ RooAddPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileCo
    // this here in compileForNormSet(), we don't invoke the old RooAddPdf
    // projection caches (note that no conditional pdfs are on the right hand
    // side of the equation).
-   std::string finalName = std::string(GetName()) + "_conditional";
+   std::string condName = std::string(GetName()) + "_conditional";
    std::unique_ptr<RooAbsReal> denom{newArg->createIntegral(normSet, _refCoefNorm)};
-   auto finalArg = std::make_unique<RooGenericPdf>(finalName.c_str(), "@0/@1", RooArgList{*newArg, *denom});
+   auto condArg = std::make_unique<RooGenericPdf>(condName.c_str(), "@0/@1", RooArgList{*newArg, *denom});
    ctx.compileServers(*denom, _refCoefNorm);
    ctx.markAsCompiled(*denom);
-   ctx.markAsCompiled(*finalArg);
+   ctx.markAsCompiled(*condArg);
    ctx.compileServers(*newArg, _refCoefNorm);
-   finalArg->addOwnedComponents(std::move(newArg));
-   finalArg->addOwnedComponents(std::move(denom));
+   condArg->addOwnedComponents(std::move(newArg));
+   condArg->addOwnedComponents(std::move(denom));
+
+   if (!canBeExtended()) {
+      return condArg;
+   }
+
+   // The conditional pdf that we just created is a plain RooGenericPdf that
+   // doesn't know anything about the expected number of events anymore. To not
+   // silently lose the extended term of the likelihood, we wrap it in a
+   // RooExtendPdf. Like RooAbsPdf::extendedTerm() in the legacy evaluation
+   // backend, the expected number of events is evaluated in the reference
+   // normalization set of the coefficients, i.e., including the conditional
+   // observables.
+   std::unique_ptr<RooAbsReal> nExpected{createExpectedEventsFunc(&_refCoefNorm)};
+   std::string finalName = condName + "_extended";
+   auto finalArg = std::make_unique<RooExtendPdf>(finalName.c_str(), finalName.c_str(), *condArg, *nExpected);
+   ctx.compileServers(*nExpected, _refCoefNorm);
+   ctx.markAsCompiled(*nExpected);
+   ctx.markAsCompiled(*finalArg);
+   finalArg->addOwnedComponents(std::move(condArg));
+   finalArg->addOwnedComponents(std::move(nExpected));
    return finalArg;
 }

--- a/roofit/roofitcore/src/RooFit/Evaluator.cxx
+++ b/roofit/roofitcore/src/RooFit/Evaluator.cxx
@@ -342,10 +342,15 @@ void Evaluator::updateOutputSizes()
 
 Evaluator::~Evaluator()
 {
+   // Also the variables need to have their data tokens reset. They get a token
+   // in setInput(), and they are not necessarily owned by the computation graph
+   // that this Evaluator was created for: the conditional observables of a
+   // likelihood, for example, are not cloned when the computation graph is
+   // compiled. If we would leave the token set, creating a second Evaluator
+   // for such a graph would wrongly complain that the same object is evaluated
+   // by multiple Evaluator instances.
    for (auto &info : _nodes) {
-      if (!info.isVariable) {
-         info.absArg->resetDataToken();
-      }
+      info.absArg->resetDataToken();
    }
    if (_cudaStream) {
       RooBatchCompute::dispatchCUDA->deleteCudaStream(_cudaStream);

--- a/roofit/roofitcore/src/RooProjectedPdf.cxx
+++ b/roofit/roofitcore/src/RooProjectedPdf.cxx
@@ -323,6 +323,16 @@ RooProjectedPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::Com
    std::string namePdf = nameRatio + "_wrapped_pdf";
    auto newArgPdf = std::make_unique<RooWrapperPdf>(namePdf.c_str(), namePdf.c_str(), *ratio);
 
+   // Compile the integrand into the computation graph. The integrals were
+   // created from the original pdf, so without this the original pdf and its
+   // observables would be left in the compiled graph, and the dataset columns
+   // could get attached to a different node than the compiled observables that
+   // the rest of the graph uses. The integrand is compiled with an empty
+   // normalization set because the projection integrals are over the raw
+   // (unnormalized) pdf.
+   ctx.compileServers(*numerator, {});
+   ctx.compileServers(*denominator, {});
+
    ctx.markAsCompiled(*numerator);
    ctx.markAsCompiled(*denominator);
    ctx.markAsCompiled(*ratio);

--- a/roofit/roofitcore/src/RooRealIntegral.cxx
+++ b/roofit/roofitcore/src/RooRealIntegral.cxx
@@ -397,9 +397,15 @@ RooRealIntegral::RooRealIntegral(const char *name, const char *title,
       _valid= false;
     }
     if (!function.dependsOn(*arg)) {
-      std::unique_ptr<RooAbsArg> argClone{static_cast<RooAbsArg*>(arg->Clone())};
-      _facList.add(*argClone);
-      addOwnedComponents(std::move(argClone));
+      // Note that the factorizing observable itself is added, and not a clone
+      // of it. A clone would be a second node with the same name in the
+      // computation graph, and such duplicates can't be resolved by name
+      // anymore, for example when the observables of a compiled computation
+      // graph are connected to the dataset columns. Since the factorizing
+      // observables are only shape servers, the integral is not recomputed
+      // when their value changes, but only when their range changes, which is
+      // what we want.
+      _facList.add(*arg);
     }
   }
 

--- a/roofit/roofitcore/src/RooRealIntegral.cxx
+++ b/roofit/roofitcore/src/RooRealIntegral.cxx
@@ -1118,9 +1118,14 @@ Int_t RooRealIntegral::getCacheAllNumeric()
 }
 
 std::unique_ptr<RooAbsArg>
-RooRealIntegral::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileContext &ctx) const
+RooRealIntegral::compileForNormSet(RooArgSet const & /*normSet*/, RooFit::Detail::CompileContext &ctx) const
 {
-   return RooAbsReal::compileForNormSet(_funcNormSet ? *_funcNormSet : normSet, ctx);
+   // The integrand is compiled with the function normalization set of this
+   // integral, and not with the normalization set of the client: a raw
+   // integral (no function normalization set) evaluates its integrand
+   // unnormalized, so passing down the outer normalization set would wrongly
+   // wrap the integrand in a normalized pdf.
+   return RooAbsReal::compileForNormSet(_funcNormSet ? *_funcNormSet : RooArgSet{}, ctx);
 }
 
 /// Sort numeric integration variables in summation and integration lists.

--- a/roofit/roofitcore/test/testRooAddPdf.cxx
+++ b/roofit/roofitcore/test/testRooAddPdf.cxx
@@ -6,13 +6,16 @@
 #include <RooConstVar.h>
 #include <RooDataHist.h>
 #include <RooFit/Evaluator.h>
+#include <RooFormulaVar.h>
 #include <RooGaussian.h>
 #include <RooGenericPdf.h>
 #include <RooHelpers.h>
 #include <RooHistPdf.h>
 #include <RooMsgService.h>
+#include <RooPolynomial.h>
 #include <RooProdPdf.h>
 #include <RooRealIntegral.h>
+#include <RooRealSumPdf.h>
 #include <RooUniform.h>
 #include <RooWorkspace.h>
 
@@ -452,4 +455,122 @@ TEST(RooAddPdf, NLLWithRecursiveFractions)
     std::unique_ptr<RooDataSet> data{model.generate(RooArgSet(x), 1000)};
 
     std::unique_ptr<RooAbsReal> nll{model.createNLL(*data)};
+}
+
+/// Test that we get the right expectedEvents() in conditional fits when
+/// getting the expected number of events from the coefficients.
+TEST(RooAddPdf, ConditionalExpectedEventsFromCoefs)
+{
+   RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
+
+   using namespace RooFit;
+
+   const double yInterval = 5.0;
+
+   // Create observables
+   RooRealVar x("x", "x", 0, 5);
+   RooRealVar y("y", "y", 0, yInterval);
+
+   // Create uniform signal and background
+   RooPolynomial gx("gx", "gx", x);
+   RooPolynomial gy("gy", "gy", y);
+   RooProdPdf sig("sig", "sig", RooArgSet(gx, gy));
+   RooPolynomial ux("ux", "ux", x);
+   RooPolynomial uy("uy", "uy", y);
+   RooProdPdf bkg("bkg", "bkg", RooArgSet(ux, uy));
+
+   // Create composite pdf sig+bkg
+   RooRealVar nsig("nsig", "", 100, 0., 1000.);
+   RooRealVar nbkg("nbkg", "", 1000, 0., 10000.);
+   RooAddPdf model("model", "model", {sig, bkg}, {nsig, nbkg});
+
+   RooArgSet nsetX{x};
+   RooArgSet nsetXY{x, y};
+
+   // As necessary for conditional fits, we need to fix the coefficient
+   // normalization set to the union set of the observables and conditional
+   // observables.
+   model.fixAddCoefNormalization(nsetXY);
+
+   // Test both the method to get expectedEvents directly, and the method that
+   // returns a RooAbsReal representing the expected number of events.
+   const double nExpected = model.expectedEvents(&nsetXY);
+   std::unique_ptr<RooAbsReal> nExpectedArg = model.createExpectedEventsFunc(&nsetXY);
+
+   // In conditional fits, the conditional observable is taken out of the
+   // normalization set.
+   const double nExpectedConditional = model.expectedEvents(&nsetX);
+   std::unique_ptr<RooAbsReal> nExpectedConditionalArg = model.createExpectedEventsFunc(&nsetX);
+
+   // Since we don't integrate the uniform expected events over the conditional
+   // observable y, we expect there to be a factor ymax - ymin.
+   EXPECT_DOUBLE_EQ(nExpectedConditional * yInterval, nExpected);
+
+   EXPECT_DOUBLE_EQ(nExpectedArg->getVal(), nExpected);
+   EXPECT_DOUBLE_EQ(nExpectedConditionalArg->getVal(), nExpectedConditional);
+}
+
+/// Test that we get the right expectedEvents() in conditional fits when
+/// getting the expected number of events from the component pdfs.
+TEST(RooAddPdf, ConditionalExpectedEventsFromPdfs)
+{
+   RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
+
+   using namespace RooFit;
+
+   // Observables
+   RooRealVar x("x", "x", 0, 5);
+   RooRealVar y("y", "y", 0, 5);
+
+   // Yield functions: uniform yield that articficially depends on x and y
+   // because RooRealSumPdf::expectedEvents() uses the normalization integrals
+   // as the expected events via getNorm(nset). As getNorm() strips away the
+   // observables the pdf doesn't depend on (different from
+   // createIntegral(nset)), we would not get the desired expected events of
+   // xmax-xmin and ymax-ymin if we would not do this trick.
+   RooFormulaVar yieldSig{"yield_sig", "1 + x - x + y - y", {x, y}};
+   RooFormulaVar yieldBkg{"yield_bkg", "1 + x - x + y - y", {x, y}};
+
+   RooRealSumPdf pdfSig{"pdf_sig", "", yieldSig, RooArgList{1.0}, true};
+   RooRealSumPdf pdfBkg{"pdf_bkg", "", yieldBkg, RooArgList{1.0}, true};
+
+   RooAddPdf pdf{"pdf", "", {pdfSig, pdfBkg}};
+
+   RooArgSet nsetX{x};
+   RooArgSet nsetXY{x, y};
+
+   // As necessary for conditional fits, we need to fix the coefficient
+   // normalization set to the union set of the observables and conditional
+   // observables.
+   pdf.fixAddCoefNormalization(nsetXY);
+
+   // Test both the method to get expectedEvents directly, and the method that
+   // returns a RooAbsReal representing the expected number of events.
+   double nSig = pdfSig.expectedEvents(&nsetXY);
+   double nBkg = pdfBkg.expectedEvents(&nsetXY);
+   double nSum = pdf.expectedEvents(&nsetXY);
+   std::unique_ptr<RooAbsReal> nSigArg = pdfSig.createExpectedEventsFunc(&nsetXY);
+   std::unique_ptr<RooAbsReal> nBkgArg = pdfBkg.createExpectedEventsFunc(&nsetXY);
+   std::unique_ptr<RooAbsReal> nSumArg = pdf.createExpectedEventsFunc(&nsetXY);
+
+   // In conditional fits, the conditional observable is taken out of the
+   // normalization set.
+   double nSigCond = pdfSig.expectedEvents(&nsetX);
+   double nBkgCond = pdfBkg.expectedEvents(&nsetX);
+   double nSumCond = pdf.expectedEvents(&nsetX);
+   std::unique_ptr<RooAbsReal> nSigCondArg = pdfSig.createExpectedEventsFunc(&nsetX);
+   std::unique_ptr<RooAbsReal> nBkgCondArg = pdfBkg.createExpectedEventsFunc(&nsetX);
+   std::unique_ptr<RooAbsReal> nSumCondArg = pdf.createExpectedEventsFunc(&nsetX);
+
+   // We expect that the expected events of the AddPdf is the sum of the
+   // components expectedEvents(), for both normalization sets.
+   EXPECT_DOUBLE_EQ(nSum, nSig + nBkg);
+   EXPECT_DOUBLE_EQ(nSumCond, nSigCond + nBkgCond);
+
+   EXPECT_DOUBLE_EQ(nSigArg->getVal(), nSig);
+   EXPECT_DOUBLE_EQ(nBkgArg->getVal(), nBkg);
+   EXPECT_DOUBLE_EQ(nSumArg->getVal(), nSum);
+   EXPECT_DOUBLE_EQ(nSigCondArg->getVal(), nSigCond);
+   EXPECT_DOUBLE_EQ(nBkgCondArg->getVal(), nBkgCond);
+   EXPECT_DOUBLE_EQ(nSumCondArg->getVal(), nSumCond);
 }

--- a/roofit/roofitcore/test/testRooAddPdf.cxx
+++ b/roofit/roofitcore/test/testRooAddPdf.cxx
@@ -16,6 +16,7 @@
 #include <RooMsgService.h>
 #include <RooPolynomial.h>
 #include <RooProdPdf.h>
+#include <RooRandom.h>
 #include <RooRealIntegral.h>
 #include <RooRealSumPdf.h>
 #include <RooUniform.h>
@@ -25,6 +26,7 @@
 
 #include "gtest_wrapper.h"
 
+#include <cmath>
 #include <memory>
 
 /// Verify that sPlot does work with a RooAddPdf. This reproduces GitHub issue
@@ -766,4 +768,74 @@ TEST(RooAddPdf, ExpectedEventsWithNormRange)
    // which is 60 % of the full range for these uniform pdfs.
    model.setNormRange("sub");
    EXPECT_FLOAT_EQ(model.expectedEvents(&nsetX), 600.0);
+}
+
+/// The evaluation backends must agree on the likelihood of a conditional fit,
+/// also if the coefficients of a RooAddPdf are defined in a normalization set
+/// that includes the conditional observables. Covers the case where the
+/// compiled computation graph contained a leftover reference to the original
+/// observable, such that the pdf didn't depend on the fit observable at all,
+/// and the case where the extended term went missing in the new backends.
+TEST(RooAddPdf, ConditionalLikelihoodBackendConsistency)
+{
+   RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
+
+   RooRealVar x{"x", "x", 0, 10};
+   RooRealVar y{"y", "y", 0, 1};
+
+   RooArgSet nsetXY{x, y};
+
+   // The signal depends on the conditional observable y, the background
+   // doesn't. Like this, the coefficient projection is not trivial.
+   RooRealVar mean{"mean", "", 5.0};
+   RooRealVar sigma{"sigma", "", 1.0};
+   RooGaussian gx{"gx", "", x, mean, sigma};
+   RooRealVar cy{"cy", "", -3.0};
+   RooExponential ey{"ey", "", y, cy};
+   RooProdPdf sig{"sig", "", {gx, ey}};
+
+   RooRealVar cx{"cx", "", -0.2};
+   RooExponential ex{"ex", "", x, cx};
+   RooPolynomial uy{"uy", "", y};
+   RooProdPdf bkg{"bkg", "", {ex, uy}};
+
+   RooRealVar nsig{"nsig", "", 300., 0., 100000.};
+   RooRealVar nbkg{"nbkg", "", 700., 0., 100000.};
+   RooAddPdf model{"model", "", {sig, bkg}, {nsig, nbkg}};
+   model.fixCoefNormalization(nsetXY);
+
+   RooRandom::randomGenerator()->SetSeed(42);
+   std::unique_ptr<RooAbsData> data{model.generate(nsetXY, 500)};
+
+   // Reference values, computed event by event with the plain RooFit
+   // interfaces: the conditional pdf is the joint pdf divided by its integral
+   // over the non-conditional observables.
+   std::unique_ptr<RooAbsReal> denom{model.createIntegral(RooArgSet{x}, nsetXY)};
+   double refNll = 0.0;
+   for (int i = 0; i < data->numEntries(); ++i) {
+      RooArgSet const &row = *data->get(i);
+      x.setVal(row.getRealValue("x"));
+      y.setVal(row.getRealValue("y"));
+      const double pdfVal = model.getVal(nsetXY);
+      x.setVal(row.getRealValue("x"));
+      y.setVal(row.getRealValue("y"));
+      refNll -= std::log(pdfVal / denom->getVal());
+   }
+   // The extended term is the one of the full model, like in the legacy
+   // evaluation backend, where the expected number of events is evaluated in
+   // the full set of dataset observables.
+   const double nExpected = nsig.getVal() + nbkg.getVal();
+   const double refNllExt = refNll + nExpected - data->sumEntries() * std::log(nExpected);
+
+   for (auto backend : {RooFit::EvalBackend::Legacy(), RooFit::EvalBackend::Cpu()}) {
+      for (bool extended : {false, true}) {
+         nsig.setVal(300.);
+         nbkg.setVal(700.);
+         std::unique_ptr<RooAbsReal> nll{
+            model.createNLL(*data, RooFit::ConditionalObservables(y), RooFit::Extended(extended), backend)};
+         const double ref = extended ? refNllExt : refNll;
+         EXPECT_NEAR(nll->getVal(), ref, 1e-8 * std::abs(ref))
+            << "backend " << backend.name() << ", extended " << extended;
+      }
+   }
 }

--- a/roofit/roofitcore/test/testRooAddPdf.cxx
+++ b/roofit/roofitcore/test/testRooAddPdf.cxx
@@ -5,14 +5,19 @@
 #include <RooChebychev.h>
 #include <RooConstVar.h>
 #include <RooDataHist.h>
+#include <RooExponential.h>
+#include <RooExtendPdf.h>
 #include <RooFit/Evaluator.h>
+#include <RooFormulaVar.h>
 #include <RooGaussian.h>
 #include <RooGenericPdf.h>
 #include <RooHelpers.h>
 #include <RooHistPdf.h>
 #include <RooMsgService.h>
+#include <RooPolynomial.h>
 #include <RooProdPdf.h>
 #include <RooRealIntegral.h>
+#include <RooRealSumPdf.h>
 #include <RooUniform.h>
 #include <RooWorkspace.h>
 
@@ -452,4 +457,313 @@ TEST(RooAddPdf, NLLWithRecursiveFractions)
     std::unique_ptr<RooDataSet> data{model.generate(RooArgSet(x), 1000)};
 
     std::unique_ptr<RooAbsReal> nll{model.createNLL(*data)};
+}
+
+/// Test that we get the right expectedEvents() in conditional fits when
+/// getting the expected number of events from the coefficients.
+TEST(RooAddPdf, ConditionalExpectedEventsFromCoefs)
+{
+   RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
+
+   using namespace RooFit;
+
+   const double yInterval = 5.0;
+
+   // Create observables
+   RooRealVar x("x", "x", 0, 5);
+   RooRealVar y("y", "y", 0, yInterval);
+
+   // Create uniform signal and background
+   RooPolynomial gx("gx", "gx", x);
+   RooPolynomial gy("gy", "gy", y);
+   RooProdPdf sig("sig", "sig", RooArgSet(gx, gy));
+   RooPolynomial ux("ux", "ux", x);
+   RooPolynomial uy("uy", "uy", y);
+   RooProdPdf bkg("bkg", "bkg", RooArgSet(ux, uy));
+
+   // Create composite pdf sig+bkg
+   RooRealVar nsig("nsig", "", 100, 0., 1000.);
+   RooRealVar nbkg("nbkg", "", 1000, 0., 10000.);
+   RooAddPdf model("model", "model", {sig, bkg}, {nsig, nbkg});
+
+   RooArgSet nsetX{x};
+   RooArgSet nsetXY{x, y};
+
+   // As necessary for conditional fits, we need to fix the coefficient
+   // normalization set to the union set of the observables and conditional
+   // observables.
+   model.fixAddCoefNormalization(nsetXY);
+
+   // Test both the method to get expectedEvents directly, and the method that
+   // returns a RooAbsReal representing the expected number of events.
+   const double nExpected = model.expectedEvents(&nsetXY);
+   std::unique_ptr<RooAbsReal> nExpectedArg = model.createExpectedEventsFunc(&nsetXY);
+
+   // In conditional fits, the conditional observable is taken out of the
+   // normalization set.
+   const double nExpectedConditional = model.expectedEvents(&nsetX);
+   std::unique_ptr<RooAbsReal> nExpectedConditionalArg = model.createExpectedEventsFunc(&nsetX);
+
+   // Since we don't integrate the uniform expected events over the conditional
+   // observable y, we expect there to be a factor ymax - ymin.
+   EXPECT_DOUBLE_EQ(nExpectedConditional * yInterval, nExpected);
+
+   EXPECT_DOUBLE_EQ(nExpectedArg->getVal(), nExpected);
+   EXPECT_DOUBLE_EQ(nExpectedConditionalArg->getVal(), nExpectedConditional);
+}
+
+/// Test that we get the right expectedEvents() in conditional fits when
+/// getting the expected number of events from the component pdfs.
+TEST(RooAddPdf, ConditionalExpectedEventsFromPdfs)
+{
+   RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
+
+   using namespace RooFit;
+
+   // Observables
+   RooRealVar x("x", "x", 0, 5);
+   RooRealVar y("y", "y", 0, 5);
+
+   // Yield functions: uniform yield that articficially depends on x and y
+   // because RooRealSumPdf::expectedEvents() uses the normalization integrals
+   // as the expected events via getNorm(nset). As getNorm() strips away the
+   // observables the pdf doesn't depend on (different from
+   // createIntegral(nset)), we would not get the desired expected events of
+   // xmax-xmin and ymax-ymin if we would not do this trick.
+   RooFormulaVar yieldSig{"yield_sig", "1 + x - x + y - y", {x, y}};
+   RooFormulaVar yieldBkg{"yield_bkg", "1 + x - x + y - y", {x, y}};
+
+   RooRealSumPdf pdfSig{"pdf_sig", "", yieldSig, RooArgList{1.0}, true};
+   RooRealSumPdf pdfBkg{"pdf_bkg", "", yieldBkg, RooArgList{1.0}, true};
+
+   RooAddPdf pdf{"pdf", "", {pdfSig, pdfBkg}};
+
+   RooArgSet nsetX{x};
+   RooArgSet nsetXY{x, y};
+
+   // As necessary for conditional fits, we need to fix the coefficient
+   // normalization set to the union set of the observables and conditional
+   // observables.
+   pdf.fixAddCoefNormalization(nsetXY);
+
+   // Test both the method to get expectedEvents directly, and the method that
+   // returns a RooAbsReal representing the expected number of events.
+   double nSig = pdfSig.expectedEvents(&nsetXY);
+   double nBkg = pdfBkg.expectedEvents(&nsetXY);
+   double nSum = pdf.expectedEvents(&nsetXY);
+   std::unique_ptr<RooAbsReal> nSigArg = pdfSig.createExpectedEventsFunc(&nsetXY);
+   std::unique_ptr<RooAbsReal> nBkgArg = pdfBkg.createExpectedEventsFunc(&nsetXY);
+   std::unique_ptr<RooAbsReal> nSumArg = pdf.createExpectedEventsFunc(&nsetXY);
+
+   // In conditional fits, the conditional observable is taken out of the
+   // normalization set.
+   double nSigCond = pdfSig.expectedEvents(&nsetX);
+   double nBkgCond = pdfBkg.expectedEvents(&nsetX);
+   double nSumCond = pdf.expectedEvents(&nsetX);
+   std::unique_ptr<RooAbsReal> nSigCondArg = pdfSig.createExpectedEventsFunc(&nsetX);
+   std::unique_ptr<RooAbsReal> nBkgCondArg = pdfBkg.createExpectedEventsFunc(&nsetX);
+   std::unique_ptr<RooAbsReal> nSumCondArg = pdf.createExpectedEventsFunc(&nsetX);
+
+   // We expect that the expected events of the AddPdf is the sum of the
+   // components expectedEvents(), for both normalization sets.
+   EXPECT_DOUBLE_EQ(nSum, nSig + nBkg);
+   EXPECT_DOUBLE_EQ(nSumCond, nSigCond + nBkgCond);
+
+   EXPECT_DOUBLE_EQ(nSigArg->getVal(), nSig);
+   EXPECT_DOUBLE_EQ(nBkgArg->getVal(), nBkg);
+   EXPECT_DOUBLE_EQ(nSumArg->getVal(), nSum);
+   EXPECT_DOUBLE_EQ(nSigCondArg->getVal(), nSigCond);
+   EXPECT_DOUBLE_EQ(nBkgCondArg->getVal(), nBkgCond);
+   EXPECT_DOUBLE_EQ(nSumCondArg->getVal(), nSumCond);
+}
+
+/// Test that a model where some components are grouped in a nested extended
+/// RooAddPdf gives the same conditional pdf and the same expected number of
+/// events as the equivalent "flat" RooAddPdf. This only works if
+/// RooAddPdf::expectedEvents() transforms the coefficients from the reference
+/// normalization set to the requested one, because the outer RooAddPdf takes
+/// its coefficients from the expectedEvents() of the inner one.
+TEST(RooAddPdf, ConditionalExpectedEventsNestedVsFlat)
+{
+   RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
+
+   RooRealVar x{"x", "x", 0, 10};
+   RooRealVar y{"y", "y", 0, 1};
+
+   RooArgSet nsetX{x};
+   RooArgSet nsetXY{x, y};
+
+   // Two signal components and one background component, each with a different
+   // dependence on the conditional observable y.
+   RooRealVar mean1{"mean1", "", 5.0};
+   RooRealVar sigma1{"sigma1", "", 1.0};
+   RooGaussian gx1{"gx1", "", x, mean1, sigma1};
+   RooRealVar cy1{"cy1", "", -3.0};
+   RooExponential ey1{"ey1", "", y, cy1};
+   RooProdPdf sig1{"sig1", "", {gx1, ey1}};
+
+   RooRealVar mean2{"mean2", "", 7.0};
+   RooRealVar sigma2{"sigma2", "", 0.8};
+   RooGaussian gx2{"gx2", "", x, mean2, sigma2};
+   RooRealVar cy2{"cy2", "", -1.0};
+   RooExponential ey2{"ey2", "", y, cy2};
+   RooProdPdf sig2{"sig2", "", {gx2, ey2}};
+
+   RooRealVar cx{"cx", "", -0.2};
+   RooExponential ex{"ex", "", x, cx};
+   RooPolynomial uy{"uy", "", y};
+   RooProdPdf bkg{"bkg", "", {ex, uy}};
+
+   RooRealVar nsig1{"nsig1", "", 300.0};
+   RooRealVar nsig2{"nsig2", "", 200.0};
+   RooRealVar nbkg{"nbkg", "", 700.0};
+
+   // The model with all components in the same RooAddPdf.
+   RooAddPdf flat{"flat", "", {sig1, sig2, bkg}, {nsig1, nsig2, nbkg}};
+   flat.fixCoefNormalization(nsetXY);
+
+   // The equivalent model, with the two signals grouped in an inner RooAddPdf.
+   RooAddPdf inner{"inner", "", {sig1, sig2}, {nsig1, nsig2}};
+   inner.fixCoefNormalization(nsetXY);
+   RooExtendPdf ebkg{"ebkg", "", bkg, nbkg};
+   RooAddPdf nested{"nested", "", {inner, ebkg}};
+
+   // Reference values, computed from the component pdfs normalized over the
+   // full set of observables: the intensity lambda(x, y) and its integral over
+   // the observables that are not conditional.
+   std::unique_ptr<RooAbsReal> sig1IntX{sig1.createIntegral(nsetX, nsetXY)};
+   std::unique_ptr<RooAbsReal> sig2IntX{sig2.createIntegral(nsetX, nsetXY)};
+   std::unique_ptr<RooAbsReal> bkgIntX{bkg.createIntegral(nsetX, nsetXY)};
+
+   auto refExpectedEvents = [&]() {
+      return nsig1.getVal() * sig1IntX->getVal() + nsig2.getVal() * sig2IntX->getVal() +
+             nbkg.getVal() * bkgIntX->getVal();
+   };
+   auto refIntensity = [&]() {
+      return nsig1.getVal() * sig1.getVal(nsetXY) + nsig2.getVal() * sig2.getVal(nsetXY) +
+             nbkg.getVal() * bkg.getVal(nsetXY);
+   };
+
+   for (double yVal : {0.1, 0.5, 0.9}) {
+      y.setVal(yVal);
+      const double ref = refExpectedEvents();
+
+      y.setVal(yVal);
+      const double nExpFlat = flat.expectedEvents(&nsetX);
+      y.setVal(yVal);
+      const double nExpNested = nested.expectedEvents(&nsetX);
+
+      EXPECT_FLOAT_EQ(nExpFlat, ref) << "for y = " << yVal;
+      EXPECT_FLOAT_EQ(nExpNested, ref) << "for y = " << yVal;
+
+      for (double xVal : {2.0, 5.0, 7.0}) {
+         x.setVal(xVal);
+         y.setVal(yVal);
+         const double valFlat = flat.getVal(&nsetX);
+         x.setVal(xVal);
+         y.setVal(yVal);
+         const double valNested = nested.getVal(&nsetX);
+         x.setVal(xVal);
+         y.setVal(yVal);
+         const double intensity = refIntensity();
+
+         // The two ways to build the model must agree...
+         EXPECT_FLOAT_EQ(valNested, valFlat) << "for x = " << xVal << ", y = " << yVal;
+         // ...and the pdf times the expected number of events must reproduce
+         // the intensity of the model.
+         EXPECT_FLOAT_EQ(valFlat * nExpFlat, intensity) << "for x = " << xVal << ", y = " << yVal;
+      }
+   }
+}
+
+/// Test that expectedEvents() and createExpectedEventsFunc() agree for a
+/// conditional RooAddPdf of extended pdfs, and that they both reproduce the
+/// integral of the model intensity over the non-conditional observables.
+TEST(RooAddPdf, ConditionalExpectedEventsFromExtendPdfs)
+{
+   RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
+
+   RooRealVar x{"x", "x", 0, 10};
+   RooRealVar y{"y", "y", 0, 1};
+
+   RooArgSet nsetX{x};
+   RooArgSet nsetXY{x, y};
+
+   RooRealVar mean{"mean", "", 5.0};
+   RooRealVar sigma{"sigma", "", 1.0};
+   RooGaussian gx{"gx", "", x, mean, sigma};
+   RooRealVar cy{"cy", "", -3.0};
+   RooExponential ey{"ey", "", y, cy};
+   RooProdPdf sig{"sig", "", {gx, ey}};
+
+   RooRealVar cx{"cx", "", -0.2};
+   RooExponential ex{"ex", "", x, cx};
+   RooPolynomial uy{"uy", "", y};
+   RooProdPdf bkg{"bkg", "", {ex, uy}};
+
+   RooRealVar nsig{"nsig", "", 300.0};
+   RooRealVar nbkg{"nbkg", "", 700.0};
+
+   RooExtendPdf esig{"esig", "", sig, nsig};
+   RooExtendPdf ebkg{"ebkg", "", bkg, nbkg};
+   RooAddPdf model{"model", "", {esig, ebkg}};
+   model.fixCoefNormalization(nsetXY);
+
+   std::unique_ptr<RooAbsReal> sigIntX{sig.createIntegral(nsetX, nsetXY)};
+   std::unique_ptr<RooAbsReal> bkgIntX{bkg.createIntegral(nsetX, nsetXY)};
+
+   std::unique_ptr<RooAbsReal> nExpArg{model.createExpectedEventsFunc(&nsetX)};
+
+   for (double yVal : {0.1, 0.5, 0.9}) {
+      y.setVal(yVal);
+      const double ref = nsig.getVal() * sigIntX->getVal() + nbkg.getVal() * bkgIntX->getVal();
+      y.setVal(yVal);
+      const double nExp = model.expectedEvents(&nsetX);
+      y.setVal(yVal);
+      const double nExpFromArg = nExpArg->getVal();
+
+      EXPECT_FLOAT_EQ(nExp, ref) << "for y = " << yVal;
+      EXPECT_FLOAT_EQ(nExpFromArg, ref) << "for y = " << yVal;
+   }
+
+   // Without conditional observables, the expected number of events is simply
+   // the sum of the component yields.
+   EXPECT_FLOAT_EQ(model.expectedEvents(&nsetXY), nsig.getVal() + nbkg.getVal());
+}
+
+/// The projection cache of a RooAddPdf is also used when there is no reference
+/// normalization set for the coefficients, but only a normalization range. In
+/// that case, the expected number of events of the components has to be
+/// evaluated in the given normalization set. Covers a regression where the
+/// components were asked for their expected number of events in the empty
+/// reference normalization set.
+TEST(RooAddPdf, ExpectedEventsWithNormRange)
+{
+   RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
+
+   RooRealVar x{"x", "x", 0, 10};
+   x.setRange("sub", 2, 8);
+   RooArgSet nsetX{x};
+
+   // Two uniform extended RooRealSumPdfs, with yields of 300 and 700 events in
+   // the full range. Their expectedEvents() depends on the normalization set,
+   // as it is given by the integral of the sum of functions.
+   RooPolynomial f1{"f1", "", x};
+   RooPolynomial f2{"f2", "", x};
+   RooRealVar c1{"c1", "", 30.0};
+   RooRealVar c2{"c2", "", 70.0};
+   RooRealSumPdf sum1{"sum1", "", f1, RooArgList{c1}, true};
+   RooRealSumPdf sum2{"sum2", "", f2, RooArgList{c2}, true};
+
+   RooAddPdf model{"model", "", {sum1, sum2}};
+
+   ASSERT_FLOAT_EQ(sum1.expectedEvents(&nsetX), 300.0);
+   ASSERT_FLOAT_EQ(sum2.expectedEvents(&nsetX), 700.0);
+
+   EXPECT_FLOAT_EQ(model.expectedEvents(&nsetX), 1000.0);
+
+   // With a normalization range, we expect only the events inside that range,
+   // which is 60 % of the full range for these uniform pdfs.
+   model.setNormRange("sub");
+   EXPECT_FLOAT_EQ(model.expectedEvents(&nsetX), 600.0);
 }

--- a/roofit/roofitcore/test/testRooAddPdf.cxx
+++ b/roofit/roofitcore/test/testRooAddPdf.cxx
@@ -16,6 +16,7 @@
 #include <RooMsgService.h>
 #include <RooPolynomial.h>
 #include <RooProdPdf.h>
+#include <RooProduct.h>
 #include <RooRandom.h>
 #include <RooRealIntegral.h>
 #include <RooRealSumPdf.h>
@@ -838,4 +839,91 @@ TEST(RooAddPdf, ConditionalLikelihoodBackendConsistency)
             << "backend " << backend.name() << ", extended " << extended;
       }
    }
+}
+
+/// An extended RooAddPdf with a RooProjectedPdf component and a coefficient
+/// that contains a user-created raw integral, condensed from the neutrino
+/// oscillation model in the rs401d_FeldmanCousins tutorial. Covers the
+/// compilation of such a model for the new evaluation backends: the
+/// projection integrals have to reference the compiled pdf and observables
+/// (and not leftovers from the original graph that never see the dataset),
+/// the integrand of a raw integral must not get wrapped in a normalized pdf,
+/// and compiling the model must not mutate the original model, which has to
+/// support creating a second likelihood after the first one is gone.
+TEST(RooAddPdf, ProjectedPdfLikelihoodBackendConsistency)
+{
+   RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
+
+   RooRealVar E{"E", "", 15, 10, 60};
+   RooRealVar L{"L", "", 0.8, 0.6, 1.0};
+   RooRealVar deltaMSq{"deltaMSq", "", 40, 1, 300};
+   RooRealVar sinSq2theta{"sinSq2theta", "", 0.006, 0.0, 0.02};
+   auto oscillationFormula = "std::pow(std::sin(1.27 * x[2] * x[0] / x[1]), 2)";
+   RooGenericPdf pOsc{"pOsc", "", oscillationFormula, {L, E, deltaMSq}};
+
+   // Signal shape in E: the oscillation pdf with the decay position
+   // integrated out.
+   std::unique_ptr<RooAbsPdf> sigModel{pOsc.createProjection(L)};
+
+   // The average oscillation probability enters the signal yield via a raw
+   // integral over an independent copy of the oscillation pdf.
+   RooRealVar EPrime{"EPrime", "", 15, 10, 60};
+   RooRealVar LPrime{"LPrime", "", 0.8, 0.6, 1.0};
+   RooGenericPdf pOscPrime{"pOscPrime", "", oscillationFormula, {LPrime, EPrime, deltaMSq}};
+   std::unique_ptr<RooAbsReal> intProbToOsc{pOscPrime.createIntegral({EPrime, LPrime})};
+
+   RooConstVar maxEventsTot{"maxEventsTot", "", 50000};
+   RooConstVar inverseArea{"inverseArea", "", 1. / 50. / 0.4};
+   RooProduct sigNorm{"sigNorm", "", {maxEventsTot, *intProbToOsc, inverseArea, sinSq2theta}};
+   RooConstVar bkgNorm{"bkgNorm", "", 500};
+   RooPolynomial bkgEShape{"bkgEShape", "", E};
+
+   RooAddPdf model{"model", "", {*sigModel, bkgEShape}, {sigNorm, bkgNorm}};
+
+   RooArgSet nsetE{E};
+
+   RooRandom::randomGenerator()->SetSeed(3);
+   std::unique_ptr<RooAbsData> data{model.generate(nsetE, 100)};
+
+   // Reference values, computed event by event with the plain RooFit
+   // interfaces, on a parameter grid that varies the oscillation parameters.
+   auto refNll = [&](double dm, double st) {
+      deltaMSq.setVal(dm);
+      sinSq2theta.setVal(st);
+      double out = 0.0;
+      for (int i = 0; i < data->numEntries(); ++i) {
+         E.setVal(data->get(i)->getRealValue("E"));
+         out -= std::log(model.getVal(nsetE));
+      }
+      const double nExpected = sigNorm.getVal() + bkgNorm.getVal();
+      return out + nExpected - data->sumEntries() * std::log(nExpected);
+   };
+
+   auto checkNll = [&](RooAbsReal &nll, const char *when) {
+      for (double dm : {1., 35., 300.}) {
+         for (double st : {0.002, 0.02}) {
+            const double ref = refNll(dm, st);
+            deltaMSq.setVal(dm);
+            sinSq2theta.setVal(st);
+            EXPECT_NEAR(nll.getVal(), ref, 1e-6 * std::abs(ref))
+               << when << ", deltaMSq " << dm << ", sinSq2theta " << st;
+         }
+      }
+   };
+
+   {
+      std::unique_ptr<RooAbsReal> nll{model.createNLL(*data, RooFit::Extended(true), RooFit::EvalBackend("cpu"))};
+      checkNll(*nll, "first likelihood");
+   }
+
+   // Compiling the likelihood must not have mutated the original model.
+   EXPECT_TRUE(pOsc.dependsOn(E));
+   deltaMSq.setVal(40.);
+   sinSq2theta.setVal(0.006);
+   RooArgSet snap;
+   RooArgSet{model}.snapshot(snap, true);
+
+   // Creating a second likelihood for the same model must still work.
+   std::unique_ptr<RooAbsReal> nll{model.createNLL(*data, RooFit::Extended(true), RooFit::EvalBackend("cpu"))};
+   checkNll(*nll, "second likelihood");
 }


### PR DESCRIPTION
So far, the projection coefficient for coefficients in RooAddPdfs was missing in `RooAddPdf::expectedEvents()`. However, this is important to include in conditional fits where the normalization set of `expectedEvents()` is different from the normalization set for coefficient determination. This PR includes this missing factor.

A unit test that covers both the case where the expected events are taken from the coefs and the one where they are taken from the pdfs is included.