### PR TITLE
[meta] Getter should take `0`, not `1`:

### DIFF
--- a/core/meta/src/TDataMember.cxx
+++ b/core/meta/src/TDataMember.cxx
@@ -886,8 +886,8 @@ TMethodCall *TDataMember::SetterMethod(TClass *cl)
          TString settername;
          settername.Form( "Set%s", dataname+1);
          if (strstr(settername, "Is")) settername.Form( "Set%s", dataname+3);
-         if (GetClass()->GetMethod(settername, "1"))
-            fValueSetter = new TMethodCall(cl, settername, "1");
+         if (GetClass()->GetMethod(settername, "0"))
+            fValueSetter = new TMethodCall(cl, settername, "0");
          if (!fValueSetter)
             if (GetClass()->GetMethod(settername, "true"))
                fValueSetter = new TMethodCall(cl, settername, "true");


### PR DESCRIPTION
This failure exists since ROOT 6: while CINT happily converted 1 to the world, cling refuses to convert it to e.g. const char*. Pass `0` which is "more compatible" with datatypes. This is still terrible design, but at least it is not making things worse, only better...

Before TNamed::SetName was looked up as a call `named.SetName(1)` which - with cling - means that no method is found. Now `named.SetName(0)` finds the right method.

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

