### PR TITLE
[RF] Implement `compileForNormSet()` for RooRealIntegral and RooAddPdf

### DIFF
--- a/roofit/roofitcore/inc/RooAddPdf.h
+++ b/roofit/roofitcore/inc/RooAddPdf.h
@@ -93,6 +93,8 @@ public:
 
   void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
 
+  std::unique_ptr<RooAbsArg> compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileContext & ctx) const override;
+
   protected:
   void selectNormalization(const RooArgSet* depSet=nullptr, bool force=false) override;
   void selectNormalizationRange(const char* rangeName=nullptr, bool force=false) override;

--- a/roofit/roofitcore/inc/RooRealIntegral.h
+++ b/roofit/roofitcore/inc/RooRealIntegral.h
@@ -81,6 +81,8 @@ public:
   void setAllowComponentSelection(bool allow);
   bool getAllowComponentSelection() const;
 
+  std::unique_ptr<RooAbsArg> compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileContext & ctx) const override;
+
   void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
 protected:
 

--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -75,6 +75,7 @@ An (enforced) condition for this assumption is that each \f$ \mathrm{PDF}_i \f$ 
 #include "RooRealConstant.h"
 #include "RooRealSumPdf.h"
 #include "RooRecursiveFraction.h"
+#include "RooGenericPdf.h"
 
 #include <algorithm>
 #include <memory>
@@ -832,4 +833,54 @@ bool RooAddPdf::redirectServersHook(const RooAbsCollection & newServerList, bool
   // to the right observables anymore. We need to reset it.
   _copyOfLastNormSet.reset();
   return RooAbsPdf::redirectServersHook(newServerList, mustReplaceAll, nameChange, isRecursiveStep);
+}
+
+
+std::unique_ptr<RooAbsArg>
+RooAddPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileContext &ctx) const
+{
+   auto newArg = std::unique_ptr<RooAbsReal>{static_cast<RooAbsReal *>(Clone())};
+   ctx.markAsCompiled(*newArg);
+
+   // In case conditional observables, e.g. p(x|y), the _refCoefNorm is set to
+   // all observables (x, y) and the normSet doesn't contain the condidional
+   // observables (so it only contains x in this example).
+
+   // If the _refCoefNorm is empty or it's equal to normSet anyway, this is not
+   // a conditional pdf and we don't need to do any transformation.
+   if(_refCoefNorm.empty() || normSet.equals(_refCoefNorm)) {
+     ctx.compileServers(*newArg, normSet);
+     return newArg;
+   }
+
+   // In the conditional case, things become more complicated. The original
+   // getValV() method is covering this case with very complicated logic,
+   // caching multiple new RooFit objects to scale the individual coefficients
+   // of the RooAddPdf.
+   //
+   // However, it's not complicated what we need to do mathematically:
+   //
+   // Since:
+   //   1. p(x, y) = p(x | y) * p(y)
+   //   2. p(y) = Integral of p(x, y) over x
+   //
+   // We conculde:
+   //                      p(x, y)
+   //   p(x | y) = --------------------------
+   //              Integral of p(x, y) over x
+   //
+   // What follows is the implementation of this formula in RooFit. By doing
+   // this here in complieForNormSet(), we don't invoke the old RooAddPdf
+   // projection caches (note that no conditional pdfs are on the right hand
+   // side of the equation).
+   std::string finalName = std::string(GetName()) + "_conditional";
+   std::unique_ptr<RooAbsReal> denom{newArg->createIntegral(normSet, _refCoefNorm)};
+   auto finalArg = std::make_unique<RooGenericPdf>(finalName.c_str(), "@0/@1", RooArgList{*newArg, *denom});
+   ctx.compileServers(*denom, _refCoefNorm);
+   ctx.markAsCompiled(*denom);
+   ctx.markAsCompiled(*finalArg);
+   ctx.compileServers(*newArg, _refCoefNorm);
+   finalArg->addOwnedComponents(std::move(newArg));
+   finalArg->addOwnedComponents(std::move(denom));
+   return finalArg;
 }

--- a/roofit/roofitcore/src/RooRealIntegral.cxx
+++ b/roofit/roofitcore/src/RooRealIntegral.cxx
@@ -1168,3 +1168,10 @@ Int_t RooRealIntegral::getCacheAllNumeric()
 {
   return _cacheAllNDim ;
 }
+
+
+std::unique_ptr<RooAbsArg>
+RooRealIntegral::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileContext &ctx) const
+{
+   return RooAbsReal::compileForNormSet(_funcNormSet ? *_funcNormSet : normSet, ctx);
+}


### PR DESCRIPTION
This fixes remaining problems with the BatchMode that would have become apparent when using it for data projections in `RooAbsReal::plotOn()`.

