### PR TITLE
[CMake] Add warning for the `minuit2_omp` or `minuit2_mpi` build options

### DIFF
--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -435,6 +435,12 @@ foreach(opt cxxmodules gfal gsl_shared jemalloc monalisa pyroot_legacy tcmalloc 
   endif()
 endforeach()
 
+foreach(opt minuit2_omp minuit2_mpi)
+  if(${opt})
+      message(WARNING "The option '${opt}' can only be used to minimise thread-safe functions in Minuit2. It cannot be used for Histogram/Graph fitting and for RooFit. If you want to use Minuit2 with OpenMP or MPI support, it is better to build Minuit2 as a standalone library.")
+  endif()
+endforeach()
+
 #---Replaced options--------------------------------------------------------------------------
 if(python)
   message(STATUS ">>> INFO: 'python' option was removed. Instead, please check, that it was enabled a 'pyroot' option (by default it is ON).")


### PR DESCRIPTION
The options `minuit2_omp` and `minuit2_mpi` are dangerous because it means you can only minimize thread-safe functions with Minuit2. If you want Minuit2 with OpenMP or MPI support, it is better to build Minuit2 standalone.

Related to #12940.