### PR TITLE
[RF][HF] Remove commented-out `Systematic` class from HistFactory

### DIFF
--- a/roofit/histfactory/inc/LinkDef.h
+++ b/roofit/histfactory/inc/LinkDef.h
@@ -46,7 +46,6 @@
            newObj->SetHistoHigh( onfile.fhHigh.ReleaseObject() ); }"
 #pragma link C++ class RooStats::HistFactory::OverallSys+ ;
 #pragma link C++ class RooStats::HistFactory::NormFactor+ ;
-#pragma link C++ class RooStats::HistFactory::Systematic+ ;
 #pragma link C++ class RooStats::HistFactory::HistoFactor+ ;
 #pragma link C++ class RooStats::HistFactory::ShapeSys+ ;
 #pragma link C++ class RooStats::HistFactory::ShapeFactor+ ;

--- a/roofit/histfactory/inc/RooStats/HistFactory/Systematics.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/Systematics.h
@@ -27,21 +27,6 @@ namespace HistFactory {
     Type GetType( const std::string& Name );
   }
 
-
-  // Base class for common functions
-  /*
-  class Systematic {
-
-  public:
-
-    virtual void Print(std::ostream& = std::cout);
-    virtual void writeToFile(const std::string& FileName,
-              const std::string& Directory);
-
-
-  };
-  */
-
 /** \class OverallSys
  * \ingroup HistFactory
  * Configuration for a constrained overall systematic to scale sample normalisations.


### PR DESCRIPTION
Yesterday, I accidentally added a LinkDef entry for `RooStats::HistFactory::Systematic` (2607947ee3) as I didn't realize that this class was commented out.

This commit removes this LinkDef entry again, and removes the commented-out class declaration such that these mistakes don't happen again.

Follows up on #12969.