### PR TITLE
[skip-ci] doc fix.

### DIFF
--- a/math/physics/src/TRolke.cxx
+++ b/math/physics/src/TRolke.cxx
@@ -32,7 +32,7 @@
    from sidebands (or MC), and
    the signal efficiency was determined from Monte Carlo
 
-2: SetPoissonBkgGaussEff(x,y,em,sde,tau)
+2: SetPoissonBkgGaussEff(x,y,em,tau,sde)
 ~~~
    Background: Poisson
    Efficiency: Gaussian


### PR DESCRIPTION
From Isabel Goos:

I am just writing because I found a mistake on your reference guide that should be corrected.
On this page: https://root.cern.ch/doc/master/classTRolke.html#a77ed9095b5fe47050eeec195eb3b669d
we see the example "SetPoissonBkgGaussEff(x,y,em,sde,tau)"
but later "void 	SetPoissonBkgGaussEff (Int_t x, Int_t y, Double_t em, Double_t tau, Double_t sde)".
So, in the example sde and tau are interchanged. 
We lost some nerves finding this out :) so, if we can avoid this for someone else, we are happy.
