### PR TITLE
[ntuple] Rename `struct EmptyBase` and add to CustomStructLinkDef.h

### DIFF
--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -44,9 +44,8 @@ struct StructWithArrays {
    float f[2];
 };
 
-struct EmptyBase {
-};
-struct alignas(std::uint64_t) TestEBO : public EmptyBase {
+struct EmptyStruct {};
+struct alignas(std::uint64_t) TestEBO : public EmptyStruct {
    std::uint64_t u64;
 };
 

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -10,6 +10,7 @@
 #pragma link C++ class DerivedB+;
 #pragma link C++ class DerivedC+;
 #pragma link C++ class StructWithArrays + ;
+#pragma link C++ class EmptyStruct + ;
 #pragma link C++ class TestEBO+;
 #pragma link C++ class IOConstructor+;
 

--- a/tree/ntuple/v7/test/ntuple_modelext.cxx
+++ b/tree/ntuple/v7/test/ntuple_modelext.cxx
@@ -404,9 +404,9 @@ TEST(RNTuple, ModelExtensionComplex)
 
       modelUpdater->BeginUpdate();
       bool b = false;
-      EmptyBase noColumns{};
+      EmptyStruct noColumns{};
       modelUpdater->AddField<bool>("b", &b);
-      modelUpdater->AddField<EmptyBase>("noColumns", &noColumns);
+      modelUpdater->AddField<EmptyStruct>("noColumns", &noColumns);
       modelUpdater->CommitUpdate();
       for (unsigned int i = 30000; i < 40000; ++i) {
          updateInitialFields(i, *u32, *dbl);
@@ -425,7 +425,7 @@ TEST(RNTuple, ModelExtensionComplex)
    auto doubleAoA = modelRead->MakeField<doubleAoA_t>("doubleAoA");
    auto var = modelRead->MakeField<std::variant<std::uint64_t, double>>("var");
    auto b = modelRead->MakeField<bool>("b");
-   auto noColumns = modelRead->MakeField<EmptyBase>("noColumns");
+   auto noColumns = modelRead->MakeField<EmptyStruct>("noColumns");
 
    double chksumRead = 0.0;
    auto ntuple = RNTupleReader::Open(std::move(modelRead), "myNTuple", fileGuard.GetPath());

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -949,8 +949,8 @@ TEST(RNTuple, TClassEBO)
    {
       auto ntuple = RNTupleReader::Open("f", fileGuard.GetPath());
       EXPECT_EQ(1U, ntuple->GetNEntries());
-      auto idEmptyBase = ntuple->GetDescriptor()->FindFieldId("klass.:_0");
-      EXPECT_NE(idEmptyBase, ROOT::Experimental::kInvalidDescriptorId);
+      auto idEmptyStruct = ntuple->GetDescriptor()->FindFieldId("klass.:_0");
+      EXPECT_NE(idEmptyStruct, ROOT::Experimental::kInvalidDescriptorId);
       auto viewKlass = ntuple->GetView<TestEBO>("klass");
       EXPECT_EQ(42, viewKlass(0).u64);
    }


### PR DESCRIPTION
This pull request adds the `EmptyBase` class to CustomStructLinkDef.h (required now by the `ntuple_modelext` test).  It also renames the class to `EmptyStruct`, which probably makes more sense now.

This should fix the `ntuple_modelext` on Windows, that was complaining due to
```
unknown file: error: C++ exception with description: "RField: no I/O support for type EmptyBase
At:
   _cdecl ROOT::Experimental::RClassField::RClassField(class std::basic_string_view<char,struct std::char_traits<char> >, class std::basic_string_view<char,struct std::char_traits<char> >, class TClass *) [C:\ROOT-CI\src\tree\ntuple\v7\src\RField.cxx:1117]
" thrown in the test body.
```

## Checklist:
- [x] tested changes locally