### PR TITLE
[ntuple] Fix issue in `RPageSinkBuf::CommitClusterImpl()`

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -81,7 +81,8 @@ private:
          return std::prev(fBufferedPages.end());
       }
       const RPageStorage::ColumnHandle_t &GetHandle() const { return fCol; }
-      bool HasSealedPagesOnly() const { return fBufferedPages.size() && fBufferedPages.size() == fSealedPages.size(); }
+      bool IsEmpty() const { return fBufferedPages.empty(); }
+      bool HasSealedPagesOnly() const { return fBufferedPages.size() == fSealedPages.size(); }
       const RPageStorage::SealedPageSequence_t &GetSealedPages() const { return fSealedPages; }
 
       using BufferedPages_t = std::tuple<std::deque<RPageZipItem>, RPageStorage::SealedPageSequence_t>;

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -162,7 +162,7 @@ ROOT::Experimental::Detail::RPageSinkBuf::CommitClusterImpl(ROOT::Experimental::
       // In practice, either all (see above) or none of the buffered pages have been sealed, depending on whether
       // a task scheduler is available. The rare condition of a few columns consisting only of sealed pages should
       // not happen unless the API is misused.
-      if (bufColumn.HasSealedPagesOnly())
+      if (!bufColumn.IsEmpty() && bufColumn.HasSealedPagesOnly())
          throw RException(R__FAIL("only a few columns have all pages sealed"));
 
       // Slow path: if the buffered column contains both sealed and unsealed pages, commit them one by one.

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -426,7 +426,7 @@ TEST(RPageSinkBuf, ParallelZip) {
 TEST(RPageSinkBuf, CommitSealedPageV)
 {
    RNTupleWriteOptions options;
-   options.SetApproxUnzippedPageSize(8);
+   options.SetApproxUnzippedPageSize(16);
 
 #ifdef R__USE_IMT
    ROOT::DisableImplicitMT();
@@ -436,15 +436,16 @@ TEST(RPageSinkBuf, CommitSealedPageV)
       auto &counters = static_cast<RPageSinkMock *>(sink.get())->fCounters;
 
       auto model = RNTupleModel::Create();
-      auto u32Field = model->MakeField<std::uint32_t>("u32");
-      auto u16Field = model->MakeField<std::uint16_t>("u16");
+      auto u64Field = model->MakeField<std::uint64_t>("u64");
+      auto u32Field = model->MakeField<std::uint16_t>("u32");
+      auto strField = model->MakeField<std::string>("str");
       auto ntuple = std::make_unique<RNTupleWriter>(std::move(model), std::make_unique<RPageSinkBuf>(std::move(sink)));
       ntuple->Fill();
       ntuple->Fill();
       ntuple->Fill();
       ntuple->CommitCluster();
       // Parallel zip not available; all pages committed separately
-      EXPECT_EQ(3, counters.fNCommitPage);
+      EXPECT_EQ(5, counters.fNCommitPage);
       EXPECT_EQ(0, counters.fNCommitSealedPage);
       EXPECT_EQ(0, counters.fNCommitSealedPageV);
    }
@@ -456,8 +457,9 @@ TEST(RPageSinkBuf, CommitSealedPageV)
       auto &counters = static_cast<RPageSinkMock *>(sink.get())->fCounters;
 
       auto model = RNTupleModel::Create();
+      auto u64Field = model->MakeField<std::uint64_t>("u64");
       auto u32Field = model->MakeField<std::uint32_t>("u32");
-      auto u16Field = model->MakeField<std::uint16_t>("u16");
+      auto strField = model->MakeField<std::string>("str");
       auto ntuple = std::make_unique<RNTupleWriter>(std::move(model), std::make_unique<RPageSinkBuf>(std::move(sink)));
       ntuple->Fill();
       ntuple->Fill();
@@ -467,7 +469,7 @@ TEST(RPageSinkBuf, CommitSealedPageV)
       EXPECT_EQ(0, counters.fNCommitPage);
       EXPECT_EQ(1, counters.fNCommitSealedPageV);
 #else
-      EXPECT_EQ(2, counters.fNCommitPage);
+      EXPECT_EQ(3, counters.fNCommitPage);
       EXPECT_EQ(0, counters.fNCommitSealedPageV);
 #endif
       EXPECT_EQ(0, counters.fNCommitSealedPage);


### PR DESCRIPTION
Some columns may have no pages in a given cluster (e.g. a field with type `std::string` that contains no data).  In such cases, it is still okay to use `CommitSealedPageV()`.  However, the previous implementation of `RColumnBuf::HasSealedPagesOnly()` prevented that.

This pull request fixes the issue and updates the unit tests accordingly.

## Checklist:
- [x] tested changes locally
- [ ] updated the docs (if necessary)