### PR TITLE
[v6-28][skip-ci][windows] Install also cfitsio.dll

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -915,6 +915,7 @@ if(fitsio OR builtin_cfitsio)
         TIMEOUT 600
       )
       set(CFITSIO_INCLUDE_DIR ${CMAKE_BINARY_DIR}/CFITSIO-prefix/src/CFITSIO)
+      install(DIRECTORY ${CMAKE_BINARY_DIR}/bin/ DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT libraries FILES_MATCHING PATTERN "cfitsio*.dll")
     else()
       ExternalProject_Add(
         CFITSIO


### PR DESCRIPTION
This should fix the error [reported on the forum](https://root-forum.cern.ch/t/windows-visual-studio-binary-root-v6-28-04-win64-vc17-exe-fitio-fails/55244)
