### PR TITLE
[DF] Actually push back values, do not write to uninitialized memory (v6.28)

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -270,7 +270,7 @@ BuildAction(const ColumnNames_t &colNames, const std::shared_ptr<SnapshotHelperA
       std::vector<bool> isDef;
       isDef.reserve(sizeof...(ColTypes));
       for (auto i = 0u; i < sizeof...(ColTypes); ++i)
-         isDef[i] = colRegister.IsDefineOrAlias(colNames[i]);
+         isDef.push_back(colRegister.IsDefineOrAlias(colNames[i]));
       return isDef;
    };
    std::vector<bool> isDefine = makeIsDefine();


### PR DESCRIPTION
This fixes a bug in the creation of Snapshot actions. We were writing and then reading back booleans from uninitialized memory (just reserve'd). It happens to work, but of course it is incorrect.

