### PR TITLE
Automatically add `override` to proof with clang-tidy

### DIFF
--- a/proof/proof/inc/TCondor.h
+++ b/proof/proof/inc/TCondor.h
@@ -41,9 +41,9 @@ public:
    TString  fOrdinal;
    TString  fWorkDir;
 
-   void        Print(Option_t *option="") const;
+   void        Print(Option_t *option="") const override;
 
-   ClassDef(TCondorSlave,0)  // Describes a claimed slave
+   ClassDefOverride(TCondorSlave,0)  // Describes a claimed slave
 };
 
 
@@ -65,10 +65,10 @@ protected:
 
 public:
    TCondor(const char *pool = "");
-   virtual ~TCondor();
+   ~TCondor() override;
 
 
-   void           Print(Option_t *option="") const;
+   void           Print(Option_t *option="") const override;
    Bool_t         IsValid() const { return fValid; }
 
    TList         *GetVirtualMachines() const;
@@ -85,7 +85,7 @@ public:
    TString        GetImage(const char *host) const;
 
 
-   ClassDef(TCondor,0)  // Interface to the Condor System
+   ClassDefOverride(TCondor,0)  // Interface to the Condor System
 };
 
 #endif

--- a/proof/proof/inc/TDSet.h
+++ b/proof/proof/inc/TDSet.h
@@ -103,7 +103,7 @@ public:
                 const char *dir = 0, Long64_t first = 0, Long64_t num = -1,
                 const char *msd = 0, const char *dataset = 0);
    TDSetElement(const TDSetElement& elem);
-   virtual ~TDSetElement();
+   ~TDSetElement() override;
 
    virtual TList   *GetListOfFriends() const { return fFriends; }
    virtual void     AddFriend(TDSetElement *friendElement, const char *alias);
@@ -124,7 +124,7 @@ public:
    void             AddAssocObj(TObject *assocobj);
    TList           *GetListOfAssocObjs() const { return fAssocObjList; }
    TObject         *GetAssocObj(Long64_t i, Bool_t isentry = kFALSE);
-   void             Print(Option_t *options="") const;
+   void             Print(Option_t *options="") const override;
    Long64_t         GetTDSetOffset() const { return fTDSetOffset; }
    void             SetTDSetOffset(Long64_t offset) { fTDSetOffset = offset; }
    void             SetEntryList(TObject *aList, Long64_t first = -1, Long64_t num = -1);
@@ -133,8 +133,8 @@ public:
    void             Validate(TDSetElement *elem);
    void             Invalidate() { fValid = kFALSE; }
    void             SetValid() { fValid = kTRUE; }
-   Int_t            Compare(const TObject *obj) const;
-   Bool_t           IsSortable() const { return kTRUE; }
+   Int_t            Compare(const TObject *obj) const override;
+   Bool_t           IsSortable() const override { return kTRUE; }
    Int_t            Lookup(Bool_t force = kFALSE);
    void             SetLookedUp() { SetBit(kHasBeenLookedUp); }
    TFileInfo       *GetFileInfo(const char *type = "TTree");
@@ -146,7 +146,7 @@ public:
 
    Int_t            MergeElement(TDSetElement *elem);
 
-   ClassDef(TDSetElement,9)  // A TDSet element
+   ClassDefOverride(TDSetElement,9)  // A TDSet element
 };
 
 
@@ -188,7 +188,7 @@ public:
    TDSet(const char *name, const char *objname = "*",
          const char *dir = "/", const char *type = 0);
    TDSet(const TChain &chain, Bool_t withfriends = kTRUE);
-   virtual ~TDSet();
+   ~TDSet() override;
 
    virtual Bool_t        Add(const char *file, const char *objname = 0,
                              const char *dir = 0, Long64_t first = 0,
@@ -213,11 +213,11 @@ public:
    virtual Long64_t      Draw(const char *varexp, const TCut &selection,
                               Option_t *option = "", Long64_t nentries = -1,
                               Long64_t firstentry = 0); // *MENU*
-   virtual void          Draw(Option_t *opt) { Draw(opt, "", "", -1, 0); }
+   void          Draw(Option_t *opt) override { Draw(opt, "", "", -1, 0); }
 
    Int_t                 ExportFileList(const char *filepath, Option_t *opt = "");
 
-   void                  Print(Option_t *option="") const;
+   void                  Print(Option_t *option="") const override;
 
    void                  SetObjName(const char *objname);
    void                  SetDirectory(const char *dir);
@@ -259,7 +259,7 @@ public:
 
    void                  SetWriteV3(Bool_t on = kTRUE);
 
-   ClassDef(TDSet,9)  // Data set for remote processing (PROOF)
+   ClassDefOverride(TDSet,9)  // Data set for remote processing (PROOF)
 };
 
 #endif

--- a/proof/proof/inc/TDSetProxy.h
+++ b/proof/proof/inc/TDSetProxy.h
@@ -35,12 +35,12 @@ public:
    TDSetProxy();
    TDSetProxy(const char *type, const char *objname = "*", const char *dir = "/");
 
-   void           Reset();
-   TDSetElement  *Next(Long64_t totalEntries = -1);
+   void           Reset() override;
+   TDSetElement  *Next(Long64_t totalEntries = -1) override;
 
    void  SetProofServ(TProofServ *serv);
 
-   ClassDef(TDSetProxy,1)  // TDSet proxy for use on slaves
+   ClassDefOverride(TDSetProxy,1)  // TDSet proxy for use on slaves
 };
 
 #endif

--- a/proof/proof/inc/TDataSetManager.h
+++ b/proof/proof/inc/TDataSetManager.h
@@ -105,7 +105,7 @@ public:
                            };
 
    TDataSetManager(const char *group = 0, const char *user = 0, const char *options = 0);
-   virtual ~TDataSetManager();
+   ~TDataSetManager() override;
 
    virtual Int_t            ClearCache(const char *uri);
    virtual Long64_t         GetAvgFileSize() const { return fAvgFileSize; }
@@ -155,7 +155,7 @@ public:
    static Int_t             ScanFile(TFileInfo *fileinfo, Bool_t notify);
    static Int_t             FillMetaData(TFileInfo *fi, TDirectory *d, const char *rdir = "/");
 
-   ClassDef(TDataSetManager, 0)  // Abstract data set manager class
+   ClassDefOverride(TDataSetManager, 0)  // Abstract data set manager class
 };
 
 #endif

--- a/proof/proof/inc/TDataSetManagerFile.h
+++ b/proof/proof/inc/TDataSetManagerFile.h
@@ -64,27 +64,27 @@ protected:
    Int_t  CreateLsFile(const char *group, const char *user, Long_t &mtime, TString &checksum);
    Int_t  FillLsDataSet(const char *group, const char *user, const char *dsName, TList *out, UInt_t option);
 
-   void UpdateUsedSpace();
+   void UpdateUsedSpace() override;
 
 public:
    TDataSetManagerFile() : TDataSetManager(0, 0, 0) { }
    TDataSetManagerFile(const char *group, const char *user, const char *ins);
    TDataSetManagerFile(const char *ins);
-   virtual ~TDataSetManagerFile() { }
+   ~TDataSetManagerFile() override { }
 
-   void             ParseInitOpts(const char *opts);
+   void             ParseInitOpts(const char *opts) override;
 
-   Int_t            ClearCache(const char *uri = 0);
-   TFileCollection *GetDataSet(const char *uri, const char *srv = 0);
-   TMap            *GetDataSets(const char *uri, UInt_t option = TDataSetManager::kExport);
-   Bool_t           ExistsDataSet(const char *uri);
-   Bool_t           RemoveDataSet(const char *uri);
+   Int_t            ClearCache(const char *uri = 0) override;
+   TFileCollection *GetDataSet(const char *uri, const char *srv = 0) override;
+   TMap            *GetDataSets(const char *uri, UInt_t option = TDataSetManager::kExport) override;
+   Bool_t           ExistsDataSet(const char *uri) override;
+   Bool_t           RemoveDataSet(const char *uri) override;
 
-   Int_t            RegisterDataSet(const char *uri, TFileCollection *dataSet, const char *opt);
-   Int_t            ScanDataSet(const char *uri, UInt_t option = kReopen | kDebug);
+   Int_t            RegisterDataSet(const char *uri, TFileCollection *dataSet, const char *opt) override;
+   Int_t            ScanDataSet(const char *uri, UInt_t option = kReopen | kDebug) override;
    Int_t            NotifyUpdate(const char *group, const char *user,
-                                 const char *dspath, Long_t mtime, const char *checksum = 0);
-   Int_t            ShowCache(const char *uri = 0);
+                                 const char *dspath, Long_t mtime, const char *checksum = 0) override;
+   Int_t            ShowCache(const char *uri = 0) override;
 
    // These should / could be private but they are used directly by the external daemon
    TFileCollection *GetDataSet(const char *group, const char *user, const char *dsName,
@@ -97,7 +97,7 @@ public:
                                  TFileCollection *dataset, UInt_t option = 0, TMD5 *checksum = 0);
    Long_t           GetModTime(const char *uri);
 
-   ClassDef(TDataSetManagerFile, 0) // DataSet manager for files
+   ClassDefOverride(TDataSetManagerFile, 0) // DataSet manager for files
 };
 
 #endif

--- a/proof/proof/inc/TLockPath.h
+++ b/proof/proof/inc/TLockPath.h
@@ -30,9 +30,9 @@ private:
 
 public:
    TLockPath(const char *path = "");
-   ~TLockPath() { if (IsLocked()) Unlock(); }
+   ~TLockPath() override { if (IsLocked()) Unlock(); }
 
-   const char   *GetName() const { return fName; }
+   const char   *GetName() const override { return fName; }
    void          SetName(const char *path) { fName = path; }
 
    Int_t         Lock(Bool_t shared = kFALSE);
@@ -40,7 +40,7 @@ public:
 
    Bool_t        IsLocked() const { return (fLockId > -1); }
 
-   ClassDef(TLockPath, 0)  // Path locking class
+   ClassDefOverride(TLockPath, 0)  // Path locking class
 };
 
 class TLockPathGuard {

--- a/proof/proof/inc/TPackMgr.h
+++ b/proof/proof/inc/TPackMgr.h
@@ -56,11 +56,11 @@ private:
 
 public:
    TPackMgr(const char *dir, const char *key = "L0");
-   virtual ~TPackMgr();
+   ~TPackMgr() override;
 
-   const char       *GetName() const { return fName.Data(); }
-   void              SetName(const char *name) { fName = name; }
-   const char       *GetTitle() const { return GetDir(); }
+   const char       *GetName() const override { return fName.Data(); }
+   void              SetName(const char *name) override { fName = name; }
+   const char       *GetTitle() const override { return GetDir(); }
 
    TLockPath        *GetLock() { return &fLock; }
 
@@ -103,7 +103,7 @@ public:
    static Int_t      FindParPath(TPackMgr *packmgr, const char *pack, TString &par);
    static Bool_t     IsEnabled(const char *pack, TPackMgr *packmgr = nullptr);
 
-   ClassDef(TPackMgr,0)  // Package manager interface
+   ClassDefOverride(TPackMgr,0)  // Package manager interface
 };
 
 #endif

--- a/proof/proof/inc/TProof.h
+++ b/proof/proof/inc/TProof.h
@@ -177,8 +177,8 @@ public:
                       fTotal(tot), fProcessed(proc), fBytesRead(bytes),
                       fInitTime(initt), fProcTime(proct), fEvtRateI(evts), fMBRateI(mbs),
                       fActWorkers(actw), fTotSessions(tsess), fEffSessions(esess) { }
-   virtual ~TProofProgressInfo() { }
-   ClassDef(TProofProgressInfo, 1); // Progress information
+   ~TProofProgressInfo() override { }
+   ClassDefOverride(TProofProgressInfo, 1); // Progress information
 };
 
 // PROOF Interrupt signal handler
@@ -191,7 +191,7 @@ private:
 public:
    TProofInterruptHandler(TProof *p)
       : TSignalHandler(kSigInterrupt, kFALSE), fProof(p) { }
-   Bool_t Notify();
+   Bool_t Notify() override;
 };
 
 // Input handler for messages from TProofServ
@@ -204,8 +204,8 @@ private:
    TProofInputHandler& operator=(const TProofInputHandler&); // Not implemented
 public:
    TProofInputHandler(TProof *p, TSocket *s);
-   Bool_t Notify();
-   Bool_t ReadNotify() { return Notify(); }
+   Bool_t Notify() override;
+   Bool_t ReadNotify() override { return Notify(); }
 };
 
 // Slaves info class
@@ -228,19 +228,19 @@ public:
 
    const char *GetDataDir() const { return fDataDir; }
    const char *GetMsd() const { return fMsd; }
-   const char *GetName() const { return fHostName; }
+   const char *GetName() const override { return fHostName; }
    const char *GetOrdinal() const { return fOrdinal; }
    SysInfo_t   GetSysInfo() const { return fSysInfo; }
    void        SetStatus(ESlaveStatus stat) { fStatus = stat; }
    void        SetSysInfo(SysInfo_t si);
    void        SetOrdinal(const char *ord) { fOrdinal = ord; }
 
-   Int_t  Compare(const TObject *obj) const;
-   Bool_t IsSortable() const { return kTRUE; }
-   void   Print(Option_t *option="") const;
-   Bool_t IsEqual(const TObject* obj) const;
+   Int_t  Compare(const TObject *obj) const override;
+   Bool_t IsSortable() const override { return kTRUE; }
+   void   Print(Option_t *option="") const override;
+   Bool_t IsEqual(const TObject* obj) const override;
 
-   ClassDef(TSlaveInfo,4) //basic info on workers
+   ClassDefOverride(TSlaveInfo,4) //basic info on workers
 };
 
 // Merger info class
@@ -266,7 +266,7 @@ public:
    TMergerInfo(TSlave *t, Int_t port, Int_t forHowManyWorkers) :
                fMerger(t), fPort(port), fMergedObjects(0), fWorkersToMerge(forHowManyWorkers),
                fMergedWorkers(0), fWorkers(0), fIsActive(kTRUE) { }
-   virtual ~TMergerInfo();
+   ~TMergerInfo() override;
 
    void        AddWorker(TSlave *sl);
    TList      *GetWorkers() { return fWorkers; }
@@ -287,7 +287,7 @@ public:
    void Deactivate() { fIsActive = kFALSE; }
    Bool_t      IsActive() { return fIsActive; }
 
-   ClassDef(TMergerInfo,0)          // Basic info on merger, i.e. worker serving as merger
+   ClassDefOverride(TMergerInfo,0)          // Basic info on merger, i.e. worker serving as merger
 };
 
 // Small auxiliary class for merging progress notification
@@ -775,7 +775,7 @@ public:
    TProof(const char *masterurl, const char *conffile = kPROOF_ConfFile,
           const char *confdir = kPROOF_ConfDir, Int_t loglevel = 0,
           const char *alias = 0, TProofMgr *mgr = 0);
-   virtual ~TProof();
+   ~TProof() override;
 
    void        cd(Int_t id = -1);
 
@@ -834,7 +834,7 @@ public:
    void        DisableGoAsyn();
    void        GoAsynchronous();
    void        StopProcess(Bool_t abort, Int_t timeout = -1);
-   void        Browse(TBrowser *b);
+   void        Browse(TBrowser *b) override;
 
    virtual Int_t Echo(const TObject *obj);
    virtual Int_t Echo(const char *str);
@@ -843,7 +843,7 @@ public:
    void        SetLogLevel(Int_t level, UInt_t mask = TProofDebug::kAll);
 
    void        Close(Option_t *option="");
-   virtual void Print(Option_t *option="") const;
+   void Print(Option_t *option="") const override;
 
    //-- cache and package management
    virtual void  ShowCache(Bool_t all = kFALSE);
@@ -932,7 +932,7 @@ public:
 
    Bool_t      IsLite() const { return (fServType == TProofMgr::kProofLite) ? kTRUE : kFALSE; }
    Bool_t      IsProofd() const { return (fServType == TProofMgr::kProofd) ? kTRUE : kFALSE; }
-   Bool_t      IsFolder() const { return kTRUE; }
+   Bool_t      IsFolder() const override { return kTRUE; }
    Bool_t      IsMaster() const { return fMasterServ; }
    Bool_t      IsValid() const { return fValid; }
    Bool_t      IsTty() const { return fTty; }
@@ -1070,7 +1070,7 @@ public:
    static Int_t         GetParameter(TCollection *c, const char *par, Long64_t &value);
    static Int_t         GetParameter(TCollection *c, const char *par, Double_t &value);
 
-   ClassDef(TProof,0)  //PROOF control class
+   ClassDefOverride(TProof,0)  //PROOF control class
 };
 
 // Global object with default PROOF session

--- a/proof/proof/inc/TProofChain.h
+++ b/proof/proof/inc/TProofChain.h
@@ -46,47 +46,47 @@ public:
    TProofChain();
    TProofChain(TChain *chain, Bool_t gettreeheader);
    TProofChain(TDSet *dset, Bool_t gettreeheader);
-   virtual ~TProofChain();
+   ~TProofChain() override;
 
-   virtual void         Browse(TBrowser *b);
+   void         Browse(TBrowser *b) override;
    Int_t                Debug() const {return fDebug;}
-   virtual Long64_t     Draw(const char *varexp, const TCut &selection, Option_t *option=""
-                             ,Long64_t nentries=TTree::kMaxEntries, Long64_t firstentry=0);
-   virtual Long64_t     Draw(const char *varexp, const char *selection, Option_t *option=""
-                             ,Long64_t nentries=TTree::kMaxEntries, Long64_t firstentry=0); // *MENU*
-   virtual void         Draw(Option_t *opt) { Draw(opt, "", "", TTree::kMaxEntries, 0); }
-   virtual TBranch     *FindBranch(const char *name);
-   virtual TLeaf       *FindLeaf(const char *name);
-   virtual TBranch     *GetBranch(const char *name);
-   virtual Bool_t       GetBranchStatus(const char *branchname) const;
-   virtual Long64_t     GetEntries() const;
-   virtual Long64_t     GetEntries(const char *sel);
-   virtual TList       *GetListOfClones() { return 0; }
-   virtual TObjArray   *GetListOfBranches() {return (fTree ? fTree->GetListOfBranches() : (TObjArray *)0); }
-   virtual TObjArray   *GetListOfLeaves()   {return (fTree ? fTree->GetListOfLeaves() : (TObjArray *)0);}
-   virtual TList       *GetListOfFriends()    const {return 0;}
-   virtual TList       *GetListOfAliases() const {return 0;}
+   Long64_t     Draw(const char *varexp, const TCut &selection, Option_t *option=""
+                             ,Long64_t nentries=TTree::kMaxEntries, Long64_t firstentry=0) override;
+   Long64_t     Draw(const char *varexp, const char *selection, Option_t *option=""
+                             ,Long64_t nentries=TTree::kMaxEntries, Long64_t firstentry=0) override; // *MENU*
+   void         Draw(Option_t *opt) override { Draw(opt, "", "", TTree::kMaxEntries, 0); }
+   TBranch     *FindBranch(const char *name) override;
+   TLeaf       *FindLeaf(const char *name) override;
+   TBranch     *GetBranch(const char *name) override;
+   Bool_t       GetBranchStatus(const char *branchname) const override;
+   Long64_t     GetEntries() const override;
+   Long64_t     GetEntries(const char *sel) override;
+   TList       *GetListOfClones() override { return 0; }
+   TObjArray   *GetListOfBranches() override {return (fTree ? fTree->GetListOfBranches() : (TObjArray *)0); }
+   TObjArray   *GetListOfLeaves() override   {return (fTree ? fTree->GetListOfLeaves() : (TObjArray *)0);}
+   TList       *GetListOfFriends()    const override {return 0;}
+   TList       *GetListOfAliases() const override {return 0;}
 
     // GetMakeClass is left non-virtual for efficiency reason.
     // Making it virtual affects the performance of the I/O
            Int_t        GetMakeClass() const {return fMakeClass;}
 
    TVirtualTreePlayer  *GetPlayer();
-   virtual Long64_t     GetReadEntry()  const;
+   Long64_t     GetReadEntry()  const override;
    Bool_t               HasTreeHeader() const { return (fTree ? kTRUE : kFALSE); }
-   virtual Long64_t     Process(const char *filename, Option_t *option="",
-                                Long64_t nentries=TTree::kMaxEntries, Long64_t firstentry=0); // *MENU*
+   Long64_t     Process(const char *filename, Option_t *option="",
+                                Long64_t nentries=TTree::kMaxEntries, Long64_t firstentry=0) override; // *MENU*
    virtual void         Progress(Long64_t total, Long64_t processed);
-   virtual Long64_t     Process(TSelector *selector, Option_t *option="",
-                                Long64_t nentries=TTree::kMaxEntries, Long64_t firstentry=0);
-   virtual void         SetDebug(Int_t level=1, Long64_t min=0, Long64_t max=9999999); // *MENU*
-   virtual void         SetEventList(TEventList *evlist) { fEventList = evlist; }
-   virtual void         SetEntryList(TEntryList *enlist, const Option_t *) { fEntryList = enlist; }
-   virtual void         SetName(const char *name); // *MENU*
+   Long64_t     Process(TSelector *selector, Option_t *option="",
+                                Long64_t nentries=TTree::kMaxEntries, Long64_t firstentry=0) override;
+   void         SetDebug(Int_t level=1, Long64_t min=0, Long64_t max=9999999) override; // *MENU*
+   void         SetEventList(TEventList *evlist) override { fEventList = evlist; }
+   void         SetEntryList(TEntryList *enlist, const Option_t *) override { fEntryList = enlist; }
+   void         SetName(const char *name) override; // *MENU*
    virtual void         ConnectProof();
    virtual void         ReleaseProof();
 
-   ClassDef(TProofChain,0)  //TChain proxy for running chains on PROOF
+   ClassDefOverride(TProofChain,0)  //TChain proxy for running chains on PROOF
 };
 
 #endif

--- a/proof/proof/inc/TProofCondor.h
+++ b/proof/proof/inc/TProofCondor.h
@@ -39,18 +39,18 @@ private:
    TTimer  *fTimer;  //timer for delayed Condor COD suspend
 
 protected:
-   Bool_t   StartSlaves(Bool_t);
+   Bool_t   StartSlaves(Bool_t) override;
    TString  GetJobAd();
 
 public:
    TProofCondor(const char *masterurl, const char *conffile = kPROOF_ConfFile,
                 const char *confdir = kPROOF_ConfDir, Int_t loglevel = 0,
                 const char *alias = 0, TProofMgr *mgr = 0);
-   virtual ~TProofCondor();
+   ~TProofCondor() override;
    virtual void SetActive() { TProof::SetActive(); }
    virtual void SetActive(Bool_t active);
 
-   ClassDef(TProofCondor,0) //PROOF control class for slaves allocated by condor
+   ClassDefOverride(TProofCondor,0) //PROOF control class for slaves allocated by condor
 };
 
 #endif

--- a/proof/proof/inc/TProofLite.h
+++ b/proof/proof/inc/TProofLite.h
@@ -73,14 +73,14 @@ private:
 
    Int_t CleanupSandbox();
    Int_t CreateSandbox();
-   void FindUniqueSlaves();
+   void FindUniqueSlaves() override;
    void  NotifyStartUp(const char *action, Int_t done, Int_t tot);
    Int_t SetProofServEnv(const char *ord);
    Int_t InitDataSetManager();
 
    void  ResolveKeywords(TString &s, const char *ord, const char *logfile);
 
-   void  SendInputDataFile();
+   void  SendInputDataFile() override;
    void  ShowDataDir(const char *dirname);
 
 protected:
@@ -97,77 +97,77 @@ protected:
    Int_t CopyMacroToCache(const char *macro, Int_t headerRequired = 0,
                           TSelector **selector = 0, Int_t opt = 0, TList *wrks = 0);
 
-   Int_t PollForNewWorkers();
+   Int_t PollForNewWorkers() override;
 
 public:
    TProofLite(const char *masterurl, const char *conffile = kPROOF_ConfFile,
               const char *confdir = kPROOF_ConfDir, Int_t loglevel = 0,
               const char *alias = 0, TProofMgr *mgr = 0);
-   virtual ~TProofLite();
+   ~TProofLite() override;
 
-   void Print(Option_t *option="") const;
+   void Print(Option_t *option="") const override;
 
    Long64_t DrawSelect(TDSet *dset, const char *varexp,
                        const char *selection = "",
                        Option_t *option = "", Long64_t nentries = -1,
-                       Long64_t firstentry = 0);
+                       Long64_t firstentry = 0) override;
    Long64_t Process(TDSet *dset, const char *sel, Option_t *o = "",
-                    Long64_t nent = -1, Long64_t fst = 0);
+                    Long64_t nent = -1, Long64_t fst = 0) override;
    Long64_t Process(TFileCollection *fc, const char *sel, Option_t *o = "",
-                    Long64_t nent = -1, Long64_t fst = 0)
+                    Long64_t nent = -1, Long64_t fst = 0) override
                     { return TProof::Process(fc, sel, o, nent, fst); }
    Long64_t Process(const char *dsname, const char *sel, Option_t *o = "",
-                    Long64_t nent = -1, Long64_t fst = 0, TObject *enl = 0)
+                    Long64_t nent = -1, Long64_t fst = 0, TObject *enl = 0) override
                     { return TProof::Process(dsname, sel, o, nent, fst, enl); }
-   Long64_t Process(const char *sel, Long64_t nent, Option_t *o = "")
+   Long64_t Process(const char *sel, Long64_t nent, Option_t *o = "") override
                     { return TProof::Process(sel, nent, o); }
    // Process via TSelector
    Long64_t Process(TDSet *dset, TSelector *sel, Option_t *o = "",
-                    Long64_t nent = -1, Long64_t fst = 0)
+                    Long64_t nent = -1, Long64_t fst = 0) override
                     { return TProof::Process(dset, sel, o, nent, fst); }
    Long64_t Process(TFileCollection *fc, TSelector *sel, Option_t *o = "",
-                    Long64_t nent = -1, Long64_t fst = 0)
+                    Long64_t nent = -1, Long64_t fst = 0) override
                     { return TProof::Process(fc, sel, o, nent, fst); }
    Long64_t Process(const char *dsname, TSelector *sel, Option_t *o = "",
-                    Long64_t nent = -1, Long64_t fst = 0, TObject *enl = 0)
+                    Long64_t nent = -1, Long64_t fst = 0, TObject *enl = 0) override
                     { return TProof::Process(dsname, sel, o, nent, fst, enl); }
-   Long64_t Process(TSelector* sel, Long64_t nent, Option_t *o = "")
+   Long64_t Process(TSelector* sel, Long64_t nent, Option_t *o = "") override
                     { return TProof::Process(sel, nent, o); }
 
    // Cache management
-   void  ShowCache(Bool_t all = kFALSE);
-   void  ClearCache(const char *file = 0);
+   void  ShowCache(Bool_t all = kFALSE) override;
+   void  ClearCache(const char *file = 0) override;
    Int_t Load(const char *macro, Bool_t notOnClient = kFALSE, Bool_t uniqueOnly = kTRUE,
-              TList *wrks = 0);
+              TList *wrks = 0) override;
 
    // Data management
-   void ShowData();
+   void ShowData() override;
 
    // Query management
-   TList *GetListOfQueries(Option_t *opt = "");
+   TList *GetListOfQueries(Option_t *opt = "") override;
    Int_t Remove(const char *ref, Bool_t all);
 
    // Dataset handling
-   Bool_t   RegisterDataSet(const char *dsName, TFileCollection *ds, const char *opt = "");
-   Bool_t   ExistsDataSet(const char *uri);
-   TMap    *GetDataSets(const char *uri = "", const char * = 0);
-   void     ShowDataSets(const char *uri = "", const char * = 0);
-   TFileCollection *GetDataSet(const char *uri, const char * = 0);
-   Int_t    RemoveDataSet(const char *uri, const char * = 0);
-   Bool_t   RequestStagingDataSet(const char *dataset);
-   Bool_t   CancelStagingDataSet(const char *dataset);
-   TFileCollection *GetStagingStatusDataSet(const char *dataset);
-   Int_t    VerifyDataSet(const char *uri, const char * = 0);
-   Int_t    SetDataSetTreeName( const char *dataset, const char *treename);
-   void     ShowDataSetCache(const char *dataset = 0);
-   void     ClearDataSetCache(const char *dataset = 0);
+   Bool_t   RegisterDataSet(const char *dsName, TFileCollection *ds, const char *opt = "") override;
+   Bool_t   ExistsDataSet(const char *uri) override;
+   TMap    *GetDataSets(const char *uri = "", const char * = 0) override;
+   void     ShowDataSets(const char *uri = "", const char * = 0) override;
+   TFileCollection *GetDataSet(const char *uri, const char * = 0) override;
+   Int_t    RemoveDataSet(const char *uri, const char * = 0) override;
+   Bool_t   RequestStagingDataSet(const char *dataset) override;
+   Bool_t   CancelStagingDataSet(const char *dataset) override;
+   TFileCollection *GetStagingStatusDataSet(const char *dataset) override;
+   Int_t    VerifyDataSet(const char *uri, const char * = 0) override;
+   Int_t    SetDataSetTreeName( const char *dataset, const char *treename) override;
+   void     ShowDataSetCache(const char *dataset = 0) override;
+   void     ClearDataSetCache(const char *dataset = 0) override;
 
    // Browsing
-   TTree *GetTreeHeader(TDSet *tdset);
+   TTree *GetTreeHeader(TDSet *tdset) override;
 
    static Int_t GetNumberOfWorkers(const char *url = 0);
 
-   ClassDef(TProofLite,0)  //PROOF-Lite control class
+   ClassDefOverride(TProofLite,0)  //PROOF-Lite control class
 };
 
 #endif

--- a/proof/proof/inc/TProofLog.h
+++ b/proof/proof/inc/TProofLog.h
@@ -52,12 +52,12 @@ public:
                          kAll = 0x3, kGrep = 0x4 };
 
    TProofLog(const char *stag, const char *url, TProofMgr *mgr);
-   virtual ~TProofLog();
+   ~TProofLog() override;
 
    void   Display(const char *ord = "*", Int_t from = -10, Int_t to = -1);
    TList *GetListOfLogs() const { return fElem; }
    Int_t  Grep(const char *txt, Int_t from = 0);
-   void   Print(Option_t *opt = 0) const;
+   void   Print(Option_t *opt = 0) const override;
    void   Prt(const char *what, Bool_t newline = kTRUE);
    Int_t  Retrieve(const char *ord = "*",
                   TProofLog::ERetrieveOpt opt = TProofLog::kTrailing,
@@ -72,7 +72,7 @@ public:
 
    static void SetMaxTransferSize(Long64_t maxsz);
 
-   ClassDef(TProofLog,0)  // PROOF session log handler
+   ClassDefOverride(TProofLog,0)  // PROOF session log handler
 };
 
 
@@ -94,7 +94,7 @@ private:
 public:
    TProofLogElem(const char *ord, const char *url,
                  TProofLog *logger);
-   virtual ~TProofLogElem();
+   ~TProofLogElem() override;
 
    void    Display(Int_t from = 0, Int_t to = -1);
    TMacro *GetMacro() const { return fMacro; }
@@ -103,7 +103,7 @@ public:
    Bool_t  IsMaster() const { return (fRole == "master") ? kTRUE : kFALSE; }
    Bool_t  IsSubMaster() const { return (fRole == "submaster") ? kTRUE : kFALSE; }
    Bool_t  IsWorker() const { return (fRole == "worker") ? kTRUE : kFALSE; }
-   void    Print(Option_t *opt = 0) const;
+   void    Print(Option_t *opt = 0) const override;
    void    Prt(const char *what);
    Int_t   Retrieve(TProofLog::ERetrieveOpt opt = TProofLog::kTrailing,
                     const char *pattern = 0);
@@ -111,7 +111,7 @@ public:
    static Long64_t GetMaxTransferSize();
    static void     SetMaxTransferSize(Long64_t maxsz);
 
-   ClassDef(TProofLogElem,0)  // PROOF session log element
+   ClassDefOverride(TProofLogElem,0)  // PROOF session log element
 };
 
 #endif

--- a/proof/proof/inc/TProofMgr.h
+++ b/proof/proof/inc/TProofMgr.h
@@ -70,7 +70,7 @@ protected:
 
 public:
    TProofMgr(const char *url, Int_t loglevel = -1, const char *alias = "");
-   virtual ~TProofMgr();
+   ~TProofMgr() override;
 
    virtual Bool_t      IsLite() const { return (fServType == kProofLite); }
    virtual Bool_t      IsProofd() const { return (fServType == kProofd); }
@@ -133,7 +133,7 @@ public:
    static TFileCollection *UploadFiles(TList *src, const char *mss, const char *dest = 0);
    static TFileCollection *UploadFiles(const char *txtfile, const char *mss, const char *dest = 0);
 
-   ClassDef(TProofMgr,0)  // Abstract PROOF manager interface
+   ClassDefOverride(TProofMgr,0)  // Abstract PROOF manager interface
 };
 
 //
@@ -158,7 +158,7 @@ public:
                      Int_t id = -1, Int_t remid = -1, Int_t status = kIdle, TProof *p = 0)
                     : TNamed(tag, alias),
      fLocalId(id), fStatus(0), fProof(p), fRemoteId(remid), fUrl(url) { SetStatus(status); }
-   virtual ~TProofDesc() { }
+   ~TProofDesc() override { }
 
    Int_t          GetLocalId() const { return fLocalId; }
    TProof        *GetProof() const { return fProof; }
@@ -172,14 +172,14 @@ public:
 
    Bool_t         MatchId(Int_t id) const { return (fLocalId == id); }
 
-   void           Print(Option_t *opt = "") const;
+   void           Print(Option_t *opt = "") const override;
 
    void           SetStatus(Int_t st) { fStatus = (st < kIdle || st > kShutdown) ? -1 : st; }
 
    void           SetProof(TProof *p) { fProof = p; }
    void           SetRemoteId(Int_t id) { fRemoteId = id; }
 
-   ClassDef(TProofDesc,1)  // Small class describing a proof session
+   ClassDefOverride(TProofDesc,1)  // Small class describing a proof session
 };
 
 #endif

--- a/proof/proof/inc/TProofMgrLite.h
+++ b/proof/proof/inc/TProofMgrLite.h
@@ -28,15 +28,15 @@ class TProofMgrLite : public TProofMgr {
 
 public:
    TProofMgrLite(const char *url, Int_t loglevel = -1, const char *alias = "");
-   virtual ~TProofMgrLite() { }
+   ~TProofMgrLite() override { }
 
-   TProof     *CreateSession(const char * = 0, const char * = 0, Int_t = -1);
+   TProof     *CreateSession(const char * = 0, const char * = 0, Int_t = -1) override;
    TProofLog  *GetSessionLogs(Int_t ridx = 0, const char *stag = 0,
-                              const char *pattern = "-v | SvcMsg", Bool_t rescan = kFALSE);
-   TObjString *ReadBuffer(const char *file, Long64_t ofs, Int_t len);
-   TObjString *ReadBuffer(const char *file, const char *pattern);
+                              const char *pattern = "-v | SvcMsg", Bool_t rescan = kFALSE) override;
+   TObjString *ReadBuffer(const char *file, Long64_t ofs, Int_t len) override;
+   TObjString *ReadBuffer(const char *file, const char *pattern) override;
 
-   ClassDef(TProofMgrLite,0)  // XrdProofd PROOF manager interface
+   ClassDefOverride(TProofMgrLite,0)  // XrdProofd PROOF manager interface
 };
 
 #endif

--- a/proof/proof/inc/TProofNodeInfo.h
+++ b/proof/proof/inc/TProofNodeInfo.h
@@ -56,9 +56,9 @@ public:
    TProofNodeInfo();
    TProofNodeInfo(const char *str);
    TProofNodeInfo(const TProofNodeInfo &nodeInfo);
-   ~TProofNodeInfo() { }
+   ~TProofNodeInfo() override { }
 
-   const char    *GetName() const { return fName; }
+   const char    *GetName() const override { return fName; }
    ENodeType      GetNodeType() const { return fNodeType; }
    const TString &GetNodeName() const { return fNodeName; }
    const TString &GetWorkDir() const { return fWorkDir; }
@@ -80,11 +80,11 @@ public:
 
    void Assign(const TProofNodeInfo &n);
 
-   void Print(const Option_t *) const;
+   void Print(const Option_t *) const override;
 
    static ENodeType GetNodeType(const TString &type);
 
-   ClassDef(TProofNodeInfo,1) // Class describing a PROOF node
+   ClassDefOverride(TProofNodeInfo,1) // Class describing a PROOF node
 };
 
 #endif

--- a/proof/proof/inc/TProofOutputFile.h
+++ b/proof/proof/inc/TProofOutputFile.h
@@ -91,7 +91,7 @@ public:
                         fDataSet(0), fMerger(0) { }
    TProofOutputFile(const char *path, const char *option = "M", const char *dsname = 0);
    TProofOutputFile(const char *path, ERunType type, UInt_t opt = kRemote, const char *dsname = 0);
-   virtual ~TProofOutputFile();
+   ~TProofOutputFile() override;
 
    const char *GetDir(Bool_t raw = kFALSE) const { return (raw) ? fRawDir : fDir; }
    TFileCollection *GetFileCollection();
@@ -115,13 +115,13 @@ public:
    Int_t AdoptFile(TFile *f);                    // Adopt a TFile already open
    TFile* OpenFile(const char *opt);             // Open a file with the specified name in fFileName1
    Long64_t Merge(TCollection *list);
-   void Print(Option_t *option = "") const;
+   void Print(Option_t *option = "") const override;
    void SetOutputFileName(const char *name);
    void ResetFileCollection() { fDataSet = 0; }
 
    static Int_t AssertDir(const char *dirpath);
 
-   ClassDef(TProofOutputFile,5) // Wrapper class to steer the merging of files produced on workers
+   ClassDefOverride(TProofOutputFile,5) // Wrapper class to steer the merging of files produced on workers
 };
 
 #endif

--- a/proof/proof/inc/TProofOutputList.h
+++ b/proof/proof/inc/TProofOutputList.h
@@ -31,22 +31,22 @@ private:
 public:
    TProofOutputList(const char *dontshow = "PROOF_*");
 TProofOutputList(TObject *o) : TList(o), fDontShow(0) { } // for backward compatibility, don't use
-   virtual ~TProofOutputList();
+   ~TProofOutputList() override;
 
    void AttachList(TList *alist);
 
-   virtual void ls(Option_t *option="") const ;
-   virtual void Print(Option_t *option="") const;
-   virtual void Print(Option_t *option, Int_t recurse) const
+   void ls(Option_t *option="") const override ;
+   void Print(Option_t *option="") const override;
+   void Print(Option_t *option, Int_t recurse) const override
                                 { TCollection::Print(option, recurse); }
-   virtual void Print(Option_t *option, const char* wildcard, Int_t recurse=1) const
+   void Print(Option_t *option, const char* wildcard, Int_t recurse=1) const override
                                 { TCollection::Print(option, wildcard, recurse); }
-   virtual void Print(Option_t *option, TPRegexp& regexp, Int_t recurse=1) const
+   void Print(Option_t *option, TPRegexp& regexp, Int_t recurse=1) const override
                                 { TCollection::Print(option, regexp, recurse);}
 
    TList *GetDontShowList() { return fDontShow; }
 
-   ClassDef(TProofOutputList, 1);  // Output list specific TList derivation
+   ClassDefOverride(TProofOutputList, 1);  // Output list specific TList derivation
 };
 
 #endif

--- a/proof/proof/inc/TProofProgressStatus.h
+++ b/proof/proof/inc/TProofProgressStatus.h
@@ -67,13 +67,13 @@ public:
    inline void     SetCPUTime(Double_t procTime) { fCPUTime = procTime; }
    inline void     IncCPUTime(Double_t procTime) { fCPUTime += procTime; }
    void     SetLastUpdate(Double_t updtTime = 0);
-   void     Print(Option_t* option = "") const;
+   void     Print(Option_t* option = "") const override;
 
    TProofProgressStatus operator-(TProofProgressStatus &st);
    TProofProgressStatus &operator+=(const TProofProgressStatus &st);
    TProofProgressStatus &operator-=(const TProofProgressStatus &st);
 
-   ClassDef(TProofProgressStatus,2) // Proof progress status class
+   ClassDefOverride(TProofProgressStatus,2) // Proof progress status class
 };
 
 #endif

--- a/proof/proof/inc/TProofQueryResult.h
+++ b/proof/proof/inc/TProofQueryResult.h
@@ -38,18 +38,18 @@ private:
                      Long64_t entries, Long64_t first, TDSet *dset,
                      const char *selec, TObject *elist = 0);
 
-   void  RecordEnd(EQueryStatus status, TList *outlist = 0)
+   void  RecordEnd(EQueryStatus status, TList *outlist = 0) override
          { TQueryResult::RecordEnd(status, outlist); }
 
-   void  SetFinalized() { TQueryResult::SetFinalized(); }
+   void  SetFinalized() override { TQueryResult::SetFinalized(); }
    void  SetResultFile(const char *rf) { fResultFile = rf; }
    void  SetRunning(Int_t startlog, const char *par, Int_t nwrks);
 
 public:
    TProofQueryResult() : TQueryResult(), fStartLog(-1) { }
-   virtual ~TProofQueryResult() { }
+   ~TProofQueryResult() override { }
 
-   ClassDef(TProofQueryResult,1)  //Class describing a PROOF query
+   ClassDefOverride(TProofQueryResult,1)  //Class describing a PROOF query
 };
 
 #endif

--- a/proof/proof/inc/TProofResources.h
+++ b/proof/proof/inc/TProofResources.h
@@ -38,14 +38,14 @@ protected:
 
 public:
    TProofResources() : fValid(kFALSE) { }
-   virtual ~TProofResources() { }
+   ~TProofResources() override { }
 
    virtual TProofNodeInfo *GetMaster() = 0;
    virtual TList          *GetSubmasters() = 0;
    virtual TList          *GetWorkers() = 0;
    virtual Bool_t          IsValid() const { return fValid; }
 
-   ClassDef(TProofResources,0)  // Abstract class describing PROOF resources
+   ClassDefOverride(TProofResources,0)  // Abstract class describing PROOF resources
 };
 
 #endif

--- a/proof/proof/inc/TProofResourcesStatic.h
+++ b/proof/proof/inc/TProofResourcesStatic.h
@@ -57,14 +57,14 @@ private:
 public:
    TProofResourcesStatic();
    TProofResourcesStatic(const char *confDir, const char *fileName);
-   virtual ~TProofResourcesStatic();
+   ~TProofResourcesStatic() override;
 
-   TProofNodeInfo *GetMaster();
-   TList          *GetSubmasters();
-   TList          *GetWorkers();
+   TProofNodeInfo *GetMaster() override;
+   TList          *GetSubmasters() override;
+   TList          *GetWorkers() override;
    TString         GetFileName() const { return fFileName; }
 
-   ClassDef(TProofResourcesStatic,0) // Class to handle PROOF static config
+   ClassDefOverride(TProofResourcesStatic,0) // Class to handle PROOF static config
 };
 
 #endif

--- a/proof/proof/inc/TProofServ.h
+++ b/proof/proof/inc/TProofServ.h
@@ -230,7 +230,7 @@ protected:
 
 public:
    TProofServ(Int_t *argc, char **argv, FILE *flog = 0);
-   virtual ~TProofServ();
+   ~TProofServ() override;
 
    virtual Int_t  CreateServer();
 
@@ -263,7 +263,7 @@ public:
    Int_t          GetActSessions() const { return fActSessions; }
    Float_t        GetEffSessions() const { return fEffSessions; }
 
-   void           GetOptions(Int_t *argc, char **argv);
+   void           GetOptions(Int_t *argc, char **argv) override;
    TList         *GetEnabledPackages() const { return fPackMgr->GetListOfEnabled(); }
 
    static Long_t  GetVirtMemMax();
@@ -282,7 +282,7 @@ public:
 
    virtual EQueryAction GetWorkers(TList *workers, Int_t &prioritychange,
                                    Bool_t resume = kFALSE);
-   virtual void   HandleException(Int_t sig);
+   void   HandleException(Int_t sig) override;
    virtual Int_t  HandleSocketInput(TMessage *mess, Bool_t all);
    virtual void   HandleSocketInput();
    virtual void   HandleUrgentData();
@@ -294,9 +294,9 @@ public:
    Bool_t         IsParallel() const;
    Bool_t         IsTopMaster() const { return fOrdinal == "0"; }
 
-   void           Run(Bool_t retrn = kFALSE);
+   void           Run(Bool_t retrn = kFALSE) override;
 
-   void           Print(Option_t *option="") const;
+   void           Print(Option_t *option="") const override;
 
    void           RestartComputeTime();
 
@@ -316,7 +316,7 @@ public:
    virtual void   DisableTimeout() { }
    virtual void   EnableTimeout() { }
 
-   virtual void   Terminate(Int_t status);
+   void   Terminate(Int_t status) override;
 
    // Log control
    void           LogToMaster(Bool_t on = kTRUE) { fSendLogToMaster = on; }
@@ -341,7 +341,7 @@ public:
    static Bool_t      IsActive();
    static TProofServ *This();
 
-   ClassDef(TProofServ,0)  //PROOF Server Application Interface
+   ClassDefOverride(TProofServ,0)  //PROOF Server Application Interface
 };
 
 R__EXTERN TProofServ *gProofServ;
@@ -352,7 +352,7 @@ private:
 
 public:
    TProofLockPath(const char *path) : TNamed(path,path), fLockId(-1) { }
-   ~TProofLockPath() { if (IsLocked()) Unlock(); }
+   ~TProofLockPath() override { if (IsLocked()) Unlock(); }
 
    Int_t         Lock();
    Int_t         Unlock();
@@ -385,12 +385,12 @@ public:
    enum EStatusBits { kFileIsPipe = BIT(23) };
    TProofServLogHandler(const char *cmd, TSocket *s, const char *pfx = "");
    TProofServLogHandler(FILE *f, TSocket *s, const char *pfx = "");
-   virtual ~TProofServLogHandler();
+   ~TProofServLogHandler() override;
 
    Bool_t IsValid() { return ((fFile && fSocket) ? kTRUE : kFALSE); }
 
-   Bool_t Notify();
-   Bool_t ReadNotify() { return Notify(); }
+   Bool_t Notify() override;
+   Bool_t ReadNotify() override { return Notify(); }
 
    static void SetDefaultPrefix(const char *pfx);
    static Int_t GetCmdRtn();
@@ -421,7 +421,7 @@ private:
 public:
    TShutdownTimer(TProofServ *p, Int_t delay);
 
-   Bool_t Notify();
+   Bool_t Notify() override;
 };
 
 //--- Synchronous timer used to reap children processes change of state
@@ -432,10 +432,10 @@ private:
 
 public:
    TReaperTimer(Long_t frequency = 1000) : TTimer(frequency, kTRUE), fChildren(0) { }
-   virtual ~TReaperTimer();
+   ~TReaperTimer() override;
 
    void AddPid(Int_t pid);
-   Bool_t Notify();
+   Bool_t Notify() override;
 };
 
 //--- Special timer to terminate idle sessions
@@ -447,7 +447,7 @@ private:
 public:
    TIdleTOTimer(TProofServ *p, Int_t delay) : TTimer(delay, kTRUE), fProofServ(p) { }
 
-   Bool_t Notify();
+   Bool_t Notify() override;
 };
 //______________________________________________________________________________
 class TIdleTOTimerGuard {

--- a/proof/proof/inc/TProofServLite.h
+++ b/proof/proof/inc/TProofServLite.h
@@ -35,24 +35,24 @@ private:
 
    Bool_t        fTerminated; //true if Terminate() has been already called
 
-   Int_t         Setup();
+   Int_t         Setup() override;
    Int_t         SetupOnFork(const char *ord);
 
 public:
    TProofServLite(Int_t *argc, char **argv, FILE *flog = 0);
-   virtual ~TProofServLite();
+   ~TProofServLite() override;
 
-   Int_t         CreateServer();
+   Int_t         CreateServer() override;
 
-   void          HandleFork(TMessage *mess);
+   void          HandleFork(TMessage *mess) override;
 
    //void          HandleUrgentData();
-   void          HandleSigPipe();
-   void          HandleTermination();
+   void          HandleSigPipe() override;
+   void          HandleTermination() override;
 
-   void          Terminate(Int_t status);
+   void          Terminate(Int_t status) override;
 
-   ClassDef(TProofServLite,0)  //PROOF-Lite Server Application Interface
+   ClassDefOverride(TProofServLite,0)  //PROOF-Lite Server Application Interface
 };
 
 #endif

--- a/proof/proof/inc/TProofSuperMaster.h
+++ b/proof/proof/inc/TProofSuperMaster.h
@@ -35,44 +35,44 @@ class TProofSuperMaster : public TProof {
 friend class TProofPlayerSuperMaster;
 
 protected:
-   Bool_t    StartSlaves(Bool_t);
-   void      ValidateDSet(TDSet *dset);
-   virtual   TVirtualProofPlayer *MakePlayer(const char *player = 0, TSocket *s = 0);
+   Bool_t    StartSlaves(Bool_t) override;
+   void      ValidateDSet(TDSet *dset) override;
+     TVirtualProofPlayer *MakePlayer(const char *player = 0, TSocket *s = 0) override;
 
 public:
    TProofSuperMaster(const char *masterurl, const char *conffile = kPROOF_ConfFile,
                      const char *confdir = kPROOF_ConfDir, Int_t loglevel = 0,
                      const char *alias = 0, TProofMgr *mgr = 0);
-   virtual ~TProofSuperMaster() { }
+   ~TProofSuperMaster() override { }
 
    Long64_t Process(TDSet *set, const char *selector,
                     Option_t *option = "", Long64_t nentries = -1,
-                    Long64_t firstentry = 0);
+                    Long64_t firstentry = 0) override;
    Long64_t Process(TFileCollection *fc, const char *sel, Option_t *o = "",
-                    Long64_t nent = -1, Long64_t fst = 0)
+                    Long64_t nent = -1, Long64_t fst = 0) override
                     { return TProof::Process(fc, sel, o, nent, fst); }
    Long64_t Process(const char *dsname, const char *sel,
                     Option_t *o = "", Long64_t nent = -1,
-                    Long64_t fst = 0, TObject *enl = 0)
+                    Long64_t fst = 0, TObject *enl = 0) override
                     { return TProof::Process(dsname, sel, o, nent, fst, enl); }
-   Long64_t Process(const char *sel, Long64_t nent, Option_t *o = "")
+   Long64_t Process(const char *sel, Long64_t nent, Option_t *o = "") override
                     { return TProof::Process(sel, nent, o); }
    // Process via TSelector
    Long64_t Process(TDSet *set, TSelector *selector,
                     Option_t *option = "", Long64_t nentries = -1,
-                    Long64_t firstentry = 0)
+                    Long64_t firstentry = 0) override
                     { return TProof::Process(set, selector, option, nentries, firstentry); }
    Long64_t Process(TFileCollection *fc, TSelector *sel, Option_t *o = "",
-                    Long64_t nent = -1, Long64_t fst = 0)
+                    Long64_t nent = -1, Long64_t fst = 0) override
                     { return TProof::Process(fc, sel, o, nent, fst); }
    Long64_t Process(const char *dsname, TSelector *sel,
                     Option_t *o = "", Long64_t nent = -1,
-                    Long64_t fst = 0, TObject *enl = 0)
+                    Long64_t fst = 0, TObject *enl = 0) override
                     { return TProof::Process(dsname, sel, o, nent, fst, enl); }
-   Long64_t Process(TSelector *sel, Long64_t nent, Option_t *o = "")
+   Long64_t Process(TSelector *sel, Long64_t nent, Option_t *o = "") override
                     { return TProof::Process(sel, nent, o); }
 
-   ClassDef(TProofSuperMaster,0) //PROOF control class for making submasters
+   ClassDefOverride(TProofSuperMaster,0) //PROOF control class for making submasters
 };
 
 #endif

--- a/proof/proof/inc/TQueryResultManager.h
+++ b/proof/proof/inc/TQueryResultManager.h
@@ -52,7 +52,7 @@ private:
 public:
    TQueryResultManager(const char *qdir, const char *stag, const char *sdir,
                        TProofLockPath *lck, FILE *logfile = 0);
-   virtual ~TQueryResultManager();
+   ~TQueryResultManager() override;
 
    const char   *QueryDir() const { return fQueryDir.Data(); }
    Int_t         SeqNum() const { return fSeqNum; }
@@ -81,7 +81,7 @@ public:
    Int_t         CleanupSession(const char *sessiontag);
    void          ScanPreviousQueries(const char *dir);
 
-   ClassDef(TQueryResultManager,0)  //PROOF query result manager
+   ClassDefOverride(TQueryResultManager,0)  //PROOF query result manager
 };
 
 #endif

--- a/proof/proof/inc/TSelVerifyDataSet.h
+++ b/proof/proof/inc/TSelVerifyDataSet.h
@@ -70,21 +70,21 @@ public :
 
    TSelVerifyDataSet(TTree *);
    TSelVerifyDataSet();
-   virtual ~TSelVerifyDataSet() {}
-   virtual Int_t   Version() const {return 1;}
-   virtual void    Begin(TTree *) { }
-   virtual void    SlaveBegin(TTree *tree);
-   virtual void    Init(TTree *) { }
-   virtual Bool_t  Notify() { return kTRUE; }
-   virtual Bool_t  Process(Long64_t entry);
-   virtual void    SetOption(const char *option) { fOption = option; }
-   virtual void    SetObject(TObject *obj) { fObject = obj; }
-   virtual void    SetInputList(TList *input) {fInput = input;}
-   virtual TList  *GetOutputList() const { return fOutput; }
-   virtual void    SlaveTerminate();
-   virtual void    Terminate() { }
+   ~TSelVerifyDataSet() override {}
+   Int_t   Version() const override {return 1;}
+   void    Begin(TTree *) override { }
+   void    SlaveBegin(TTree *tree) override;
+   void    Init(TTree *) override { }
+   Bool_t  Notify() override { return kTRUE; }
+   Bool_t  Process(Long64_t entry) override;
+   void    SetOption(const char *option) override { fOption = option; }
+   void    SetObject(TObject *obj) override { fObject = obj; }
+   void    SetInputList(TList *input) override {fInput = input;}
+   TList  *GetOutputList() const override { return fOutput; }
+   void    SlaveTerminate() override;
+   void    Terminate() override { }
 
-   ClassDef(TSelVerifyDataSet,0) //PROOF selector for parallel dataset verification
+   ClassDefOverride(TSelVerifyDataSet,0) //PROOF selector for parallel dataset verification
 };
 
 #endif

--- a/proof/proof/inc/TSlave.h
+++ b/proof/proof/inc/TSlave.h
@@ -114,14 +114,14 @@ protected:
    virtual void  StopProcess(Bool_t abort, Int_t timeout);
 
 public:
-   virtual ~TSlave();
+   ~TSlave() override;
 
    virtual void   Close(Option_t *opt = "");
 
-   Int_t          Compare(const TObject *obj) const;
-   Bool_t         IsSortable() const { return kTRUE; }
+   Int_t          Compare(const TObject *obj) const override;
+   Bool_t         IsSortable() const override { return kTRUE; }
 
-   const char    *GetName() const { return fName; }
+   const char    *GetName() const override { return fName; }
    const char    *GetImage() const { return fImage; }
    const char    *GetProofWorkDir() const { return fProofWorkDir; }
    const char    *GetWorkDir() const { return fWorkDir; }
@@ -149,7 +149,7 @@ public:
 
    virtual Bool_t IsValid() const { return fSocket ? kTRUE : kFALSE; }
 
-   virtual void   Print(Option_t *option="") const;
+   void   Print(Option_t *option="") const override;
 
    virtual Int_t  SetupServ(Int_t stype, const char *conffile);
 
@@ -164,7 +164,7 @@ public:
 
    virtual void   Touch() { }
 
-   ClassDef(TSlave,0)  //PROOF slave server
+   ClassDefOverride(TSlave,0)  //PROOF slave server
 };
 
 #endif

--- a/proof/proof/inc/TSlaveLite.h
+++ b/proof/proof/inc/TSlaveLite.h
@@ -42,16 +42,16 @@ public:
    TSlaveLite(const char *ord, Int_t perf,
               const char *image, TProof *proof, Int_t stype,
               const char *workdir, const char *msd, Int_t = 1);
-   virtual ~TSlaveLite();
+   ~TSlaveLite() override;
 
-   void   Close(Option_t *opt = "");
+   void   Close(Option_t *opt = "") override;
    void   DoError(int level, const char *location, const char *fmt,
-                  va_list va) const;
+                  va_list va) const override;
 
-   void   Print(Option_t *option="") const;
-   Int_t  SetupServ(Int_t stype, const char *conffile);
+   void   Print(Option_t *option="") const override;
+   Int_t  SetupServ(Int_t stype, const char *conffile) override;
 
-   ClassDef(TSlaveLite, 0)  //PROOF lite worker server
+   ClassDefOverride(TSlaveLite, 0)  //PROOF lite worker server
 };
 
 #endif

--- a/proof/proof/inc/TVirtualPacketizer.h
+++ b/proof/proof/inc/TVirtualPacketizer.h
@@ -109,11 +109,11 @@ protected:
 
    TDSetElement  *CreateNewPacket(TDSetElement* base, Long64_t first, Long64_t num);
    Long64_t       GetEntries(Bool_t tree, TDSetElement *e); // Num of entries or objects
-   virtual Bool_t HandleTimer(TTimer *timer);
+   Bool_t HandleTimer(TTimer *timer) override;
 
 public:
    enum EStatusBits { kIsInitializing = BIT(16), kIsDone = BIT(17), kIsTree = BIT(18) };
-   virtual ~TVirtualPacketizer();
+   ~TVirtualPacketizer() override;
 
    virtual Int_t           AssignWork(TDSet* /*dset*/, Long64_t /*first*/, Long64_t /*num*/) { return -1; }
    Bool_t                  IsValid() const { return fValid; }
@@ -149,7 +149,7 @@ public:
 
    virtual Int_t GetActiveWorkers() { return -1; }
 
-   ClassDef(TVirtualPacketizer,0)  //Generate work packets for parallel processing
+   ClassDefOverride(TVirtualPacketizer,0)  //Generate work packets for parallel processing
 };
 
 //------------------------------------------------------------------------------
@@ -165,7 +165,7 @@ protected:
    TProofProgressStatus *fStatus; // status as of the last finished packet
 
 public:
-   const char *GetName() const { return fWrkFQDN.Data(); }
+   const char *GetName() const override { return fWrkFQDN.Data(); }
    const char *GetOrdinal() const { return fSlave->GetOrdinal(); }
    Long64_t    GetEntriesProcessed() const { return fStatus?fStatus->GetEntries():-1; }
    Double_t    GetProcTime() const { return fStatus?fStatus->GetProcTime():-1; }

--- a/proof/proof/inc/TVirtualProofPlayer.h
+++ b/proof/proof/inc/TVirtualProofPlayer.h
@@ -48,7 +48,7 @@ public:
    enum EExitStatus { kFinished, kStopped, kAborted };
 
    TVirtualProofPlayer() { ResetBit(TVirtualProofPlayer::kIsSubmerger); }
-   virtual ~TVirtualProofPlayer() { }
+   ~TVirtualProofPlayer() override { }
 
    virtual Long64_t  Process(TDSet *set,
                              const char *selector, Option_t *option = "",
@@ -139,7 +139,7 @@ public:
 
    static TVirtualProofPlayer *Create(const char *player, TProof *p, TSocket *s = 0);
 
-   ClassDef(TVirtualProofPlayer,0)  // Abstract PROOF player
+   ClassDefOverride(TVirtualProofPlayer,0)  // Abstract PROOF player
 };
 
 #endif

--- a/proof/proof/src/TProofServ.cxx
+++ b/proof/proof/src/TProofServ.cxx
@@ -156,7 +156,7 @@ class TProofServTerminationHandler : public TSignalHandler {
 public:
    TProofServTerminationHandler(TProofServ *s)
       : TSignalHandler(kSigTermination, kFALSE) { fServ = s; }
-   Bool_t  Notify();
+   Bool_t  Notify() override;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -177,7 +177,7 @@ class TProofServInterruptHandler : public TSignalHandler {
 public:
    TProofServInterruptHandler(TProofServ *s)
       : TSignalHandler(kSigUrgent, kFALSE) { fServ = s; }
-   Bool_t  Notify();
+   Bool_t  Notify() override;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -200,7 +200,7 @@ class TProofServSigPipeHandler : public TSignalHandler {
 public:
    TProofServSigPipeHandler(TProofServ *s) : TSignalHandler(kSigPipe, kFALSE)
       { fServ = s; }
-   Bool_t  Notify();
+   Bool_t  Notify() override;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -220,8 +220,8 @@ class TProofServInputHandler : public TFileHandler {
 public:
    TProofServInputHandler(TProofServ *s, Int_t fd) : TFileHandler(fd, 1)
       { fServ = s; }
-   Bool_t Notify();
-   Bool_t ReadNotify() { return Notify(); }
+   Bool_t Notify() override;
+   Bool_t ReadNotify() override { return Notify(); }
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/proof/proof/src/TProofServLite.cxx
+++ b/proof/proof/src/TProofServLite.cxx
@@ -76,7 +76,7 @@ class TProofServLiteInterruptHandler : public TSignalHandler {
 public:
    TProofServLiteInterruptHandler(TProofServLite *s)
       : TSignalHandler(kSigUrgent, kFALSE) { fServ = s; }
-   Bool_t  Notify();
+   Bool_t  Notify() override;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -99,7 +99,7 @@ class TProofServLiteSigPipeHandler : public TSignalHandler {
 public:
    TProofServLiteSigPipeHandler(TProofServLite *s) : TSignalHandler(kSigPipe, kFALSE)
       { fServ = s; }
-   Bool_t  Notify();
+   Bool_t  Notify() override;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -119,7 +119,7 @@ class TProofServLiteTerminationHandler : public TSignalHandler {
 public:
    TProofServLiteTerminationHandler(TProofServLite *s)
       : TSignalHandler(kSigTermination, kFALSE) { fServ = s; }
-   Bool_t  Notify();
+   Bool_t  Notify() override;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -141,7 +141,7 @@ class TProofServLiteSegViolationHandler : public TSignalHandler {
 public:
    TProofServLiteSegViolationHandler(TProofServLite *s)
       : TSignalHandler(kSigSegmentationViolation, kFALSE) { fServ = s; }
-   Bool_t  Notify();
+   Bool_t  Notify() override;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -164,8 +164,8 @@ class TProofServLiteInputHandler : public TFileHandler {
 public:
    TProofServLiteInputHandler(TProofServLite *s, Int_t fd) : TFileHandler(fd, 1)
       { fServ = s; }
-   Bool_t Notify();
-   Bool_t ReadNotify() { return Notify(); }
+   Bool_t Notify() override;
+   Bool_t ReadNotify() override { return Notify(); }
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/proof/proofbench/inc/TProofBench.h
+++ b/proof/proofbench/inc/TProofBench.h
@@ -92,7 +92,7 @@ public:
 
    TProofBench(const char *url, const char *outfile = "<default>", const char *proofopt = 0);
 
-   virtual ~TProofBench();
+   ~TProofBench() override;
 
    Int_t RunCPU(Long64_t nevents=-1, Int_t start=-1, Int_t stop=-1, Int_t step=-1);
    Int_t RunCPUx(Long64_t nevents=-1, Int_t start=-1, Int_t stop=-1);
@@ -140,7 +140,7 @@ public:
 
    static TList *GetGraphs() { return fgGraphs; }
 
-   ClassDef(TProofBench, 0)   // Steering class for PROOF benchmarks
+   ClassDefOverride(TProofBench, 0)   // Steering class for PROOF benchmarks
 };
 
 #endif

--- a/proof/proofbench/inc/TProofBenchDataSet.h
+++ b/proof/proofbench/inc/TProofBenchDataSet.h
@@ -36,7 +36,7 @@ protected:
 public:
 
    TProofBenchDataSet(TProof *proof = 0);
-   virtual ~TProofBenchDataSet() { }
+   ~TProofBenchDataSet() override { }
 
    Bool_t IsProof(TProof *p) { return (p == fProof) ? kTRUE : kFALSE; }
 
@@ -44,7 +44,7 @@ public:
    Int_t ReleaseCache(const char *dset);
    Int_t RemoveFiles(const char *dset);
 
-   ClassDef(TProofBenchDataSet,0)   //Handle operations on datasets
+   ClassDefOverride(TProofBenchDataSet,0)   //Handle operations on datasets
 };
 
 #endif

--- a/proof/proofbench/inc/TProofBenchRun.h
+++ b/proof/proofbench/inc/TProofBenchRun.h
@@ -40,7 +40,7 @@ public:
 
    TProofBenchRun(TProof *proof = 0, const char *sel = 0);
 
-   virtual ~TProofBenchRun();
+   ~TProofBenchRun() override;
 
    virtual const char *GetSelName() { return fSelName; }
    virtual const char *GetParList() { return fParList; }
@@ -55,9 +55,9 @@ public:
                     Int_t step = -1, Int_t ntries = -1, Int_t debug = -1,
                     Int_t draw = -1) = 0;
 
-   virtual void Print(Option_t *option = "") const=0;
+   void Print(Option_t *option = "") const override =0;
 
-   ClassDef(TProofBenchRun, 0)   //Abstract base class for PROOF benchmark run
+   ClassDefOverride(TProofBenchRun, 0)   //Abstract base class for PROOF benchmark run
 };
 
 #endif

--- a/proof/proofbench/inc/TProofBenchRunCPU.h
+++ b/proof/proofbench/inc/TProofBenchRunCPU.h
@@ -92,15 +92,15 @@ public:
                      Long64_t nevents=1000000, Int_t ntries=2, Int_t start=1,
                      Int_t stop=-1, Int_t step=1, Int_t draw=0, Int_t debug=0);
 
-   virtual ~TProofBenchRunCPU();
+   ~TProofBenchRunCPU() override;
 
    void Run(Long64_t nevents, Int_t start, Int_t stop, Int_t step, Int_t ntries,
-            Int_t debug, Int_t draw);
-   void Run(const char *, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t) { }
+            Int_t debug, Int_t draw) override;
+   void Run(const char *, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t) override { }
 
    void DrawPerfPlots();
 
-   void Print(Option_t* option="") const;
+   void Print(Option_t* option="") const override;
 
    void SetHistType(TPBHistType *histtype);
    void SetNHists(Int_t nhists) { fNHists = nhists; }
@@ -126,11 +126,11 @@ public:
    TDirectory* GetDirProofBench() const { return fDirProofBench; }
    TList* GetListPerfPlots() const { return fListPerfPlots; }
    TCanvas* GetCanvas() const { return fCanvas; }
-   const char* GetName() const { return fName; }
+   const char* GetName() const override { return fName; }
 
    TString GetNameStem() const;
 
-   ClassDef(TProofBenchRunCPU,0)     //CPU-intensive PROOF benchmark
+   ClassDefOverride(TProofBenchRunCPU,0)     //CPU-intensive PROOF benchmark
 };
 
 #endif

--- a/proof/proofbench/inc/TProofBenchRunDataRead.h
+++ b/proof/proofbench/inc/TProofBenchRunDataRead.h
@@ -102,17 +102,17 @@ public:
                           Long64_t nevents=-1, Int_t ntries=2, Int_t start=1, Int_t stop=-1,
                           Int_t step=1, Int_t debug=0);
 
-   virtual ~TProofBenchRunDataRead();
+   ~TProofBenchRunDataRead() override;
 
-   void Run(Long64_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t) { }
+   void Run(Long64_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t) override { }
    void Run(const char *dset, Int_t start, Int_t stop, Int_t step, Int_t ntries,
-            Int_t debug, Int_t);
+            Int_t debug, Int_t) override;
 
    TFileCollection *GetDataSet(const char *dset, Int_t nact, Bool_t nx);
 
    void DrawPerfProfiles();
 
-   void Print(Option_t* option="") const;
+   void Print(Option_t* option="") const override;
 
    void SetReadType(TPBReadType *readtype) { fReadType = readtype; }
    void SetNEvents(Long64_t nevents) { fNEvents = nevents; }
@@ -134,11 +134,11 @@ public:
    Int_t GetDebug() const { return fDebug; }
    TDirectory* GetDirProofBench() const { return fDirProofBench; }
    TCanvas* GetCPerfProfiles() const { return fCPerfProfiles; }
-   const char* GetName() const { return fName; }
+   const char* GetName() const override { return fName; }
 
    TString GetNameStem() const;
 
-   ClassDef(TProofBenchRunDataRead,0)         //IO-intensive PROOF benchmark
+   ClassDefOverride(TProofBenchRunDataRead,0)         //IO-intensive PROOF benchmark
 };
 
 #endif

--- a/proof/proofbench/inc/TProofBenchTypes.h
+++ b/proof/proofbench/inc/TProofBenchTypes.h
@@ -43,15 +43,15 @@ private:
    TString fName;
 public:
    TPBReadType(EReadType type = kReadOpt) : fType(type), fName("PROOF_Benchmark_ReadType") { }
-   virtual ~TPBReadType() { }
+   ~TPBReadType() override { }
 
    EReadType GetType() const { return fType; }
    Bool_t IsReadFull() const { return (fType == kReadFull) ? kTRUE : kFALSE; }
    Bool_t IsReadOpt() const { return (fType == kReadOpt) ? kTRUE : kFALSE; }
    Bool_t IsReadNo() const { return (fType == kReadNo) ? kTRUE : kFALSE; }
-   const char *GetName() const { return fName; }
+   const char *GetName() const override { return fName; }
 
-   ClassDef(TPBReadType, 1)     // Streamable PBReadType
+   ClassDefOverride(TPBReadType, 1)     // Streamable PBReadType
 };
 
 class TPBHistType : public TObject {
@@ -68,16 +68,16 @@ private:
    TString fName;
 public:
    TPBHistType(EHistType type = kHist1D) : fType(type), fName("PROOF_Benchmark_HistType") { }
-   virtual ~TPBHistType() { }
+   ~TPBHistType() override { }
 
    EHistType GetType() const { return fType; }
    Bool_t IsHist1D() const { return (fType == kHist1D) ? kTRUE : kFALSE; }
    Bool_t IsHist2D() const { return (fType == kHist2D) ? kTRUE : kFALSE; }
    Bool_t IsHist3D() const { return (fType == kHist3D) ? kTRUE : kFALSE; }
    Bool_t IsHistAll() const { return (fType == kHistAll) ? kTRUE : kFALSE; }
-   const char *GetName() const { return fName; }
+   const char *GetName() const override { return fName; }
 
-   ClassDef(TPBHistType, 1)     // Streamable PBHistType
+   ClassDefOverride(TPBHistType, 1)     // Streamable PBHistType
 };
 
 class TPBHandleDSType : public TObject {
@@ -93,16 +93,16 @@ private:
    TString fName;
 public:
    TPBHandleDSType(EHandleDSType type = kReleaseCache) : fType(type), fName("PROOF_Benchmark_HandleDSType") { }
-   virtual ~TPBHandleDSType() { }
+   ~TPBHandleDSType() override { }
 
    EHandleDSType GetType() const { return fType; }
    Bool_t IsReleaseCache() const { return (fType == kReleaseCache) ? kTRUE : kFALSE; }
    Bool_t IsCheckCache() const { return (fType == kCheckCache) ? kTRUE : kFALSE; }
    Bool_t IsRemoveFiles() const { return (fType == kRemoveFiles) ? kTRUE : kFALSE; }
    Bool_t IsCopyFiles() const { return (fType == kCopyFiles) ? kTRUE : kFALSE; }
-   const char *GetName() const { return fName; }
+   const char *GetName() const override { return fName; }
 
-   ClassDef(TPBHandleDSType, 1)     // Streamable PBHandleDSType
+   ClassDefOverride(TPBHandleDSType, 1)     // Streamable PBHandleDSType
 };
 
 #endif

--- a/proof/proofbench/inc/TProofNodes.h
+++ b/proof/proofbench/inc/TProofNodes.h
@@ -41,7 +41,7 @@ private:
 public:
    TProofNodes(TProof* proof);
 
-   virtual ~TProofNodes();
+   ~TProofNodes() override;
    Int_t ActivateWorkers(Int_t nwrks);
    Int_t ActivateWorkers(const char *workers);
    Int_t GetMaxWrksPerNode() const { return fMaxWrksNode; }
@@ -52,9 +52,9 @@ public:
    Int_t GetNActives() const { return fNActiveWrks; }
    TMap* GetMapOfNodes() const { return fNodes; }
    TMap* GetMapOfActiveNodes() const { return fActiveNodes; }
-   void Print(Option_t* option="") const;
+   void Print(Option_t* option="") const override;
 
-   ClassDef(TProofNodes, 0) //Node and worker information
+   ClassDefOverride(TProofNodes, 0) //Node and worker information
 };
 
 #endif

--- a/proof/proofbench/inc/TProofPerfAnalysis.h
+++ b/proof/proofbench/inc/TProofPerfAnalysis.h
@@ -83,7 +83,7 @@ public:
    TProofPerfAnalysis(const char *perffile, const char *title = "",
                   const char *treename = "PROOF_PerfStats");
    TProofPerfAnalysis(TTree *tree, const char *title = "");
-   virtual ~TProofPerfAnalysis();
+   ~TProofPerfAnalysis() override;
 
    Bool_t IsValid() const { return (fFile && fTree) ? kTRUE : kFALSE; }
    Bool_t WrkInfoOK() const { return (fWrksInfo.GetSize() > 0) ? kTRUE : kFALSE; }
@@ -115,7 +115,7 @@ public:
    void  SetDebug(Int_t d = 0);   // Setter for the verbosity level
    static void  SetgDebug(Bool_t on = kTRUE);   // Overall verbosity level
 
-   ClassDef(TProofPerfAnalysis, 0)   // Set of tools to analyse the performance tree
+   ClassDefOverride(TProofPerfAnalysis, 0)   // Set of tools to analyse the performance tree
 };
 
 #endif

--- a/proof/proofbench/inc/TSelEvent.h
+++ b/proof/proofbench/inc/TSelEvent.h
@@ -121,7 +121,7 @@ public :
    TH1F* GetPtHist(){return fPtHist;}
    TH1F* GetNTracksHist(){return fNTracksHist;}
 
-   ClassDef(TSelEvent,0) //PROOF selector for I/O-intensive benchmark test
+   ClassDefOverride(TSelEvent,0) //PROOF selector for I/O-intensive benchmark test
 };
 
 #endif

--- a/proof/proofbench/inc/TSelEventGen.h
+++ b/proof/proofbench/inc/TSelEventGen.h
@@ -56,22 +56,22 @@ public :
 
 //   TSelEventGen(TTree *);
    TSelEventGen();
-   virtual ~TSelEventGen() { }
-   virtual Int_t   Version() const {return 1;}
-   virtual void    Begin(TTree *);
-   virtual void    SlaveBegin(TTree *tree);
-   virtual void    Init(TTree *tree);
-   virtual Bool_t  Notify();
-   virtual Bool_t  Process(Long64_t entry);
-   virtual void    SetOption(const char *option) { fOption = option; }
-   virtual void    SetObject(TObject *obj) { fObject = obj; }
-   virtual void    SetInputList(TList *input) {fInput = input;}
-   virtual TList  *GetOutputList() const { return fOutput; }
-   virtual void    SlaveTerminate();
-   virtual void    Terminate();
-   virtual void    Print(Option_t *option="") const;
+   ~TSelEventGen() override { }
+   Int_t   Version() const override {return 1;}
+   void    Begin(TTree *) override;
+   void    SlaveBegin(TTree *tree) override;
+   void    Init(TTree *tree) override;
+   Bool_t  Notify() override;
+   Bool_t  Process(Long64_t entry) override;
+   void    SetOption(const char *option) override { fOption = option; }
+   void    SetObject(TObject *obj) override { fObject = obj; }
+   void    SetInputList(TList *input) override {fInput = input;}
+   TList  *GetOutputList() const override { return fOutput; }
+   void    SlaveTerminate() override;
+   void    Terminate() override;
+   void    Print(Option_t *option="") const override;
 
-   ClassDef(TSelEventGen,0)     //PROOF selector for event file generation
+   ClassDefOverride(TSelEventGen,0)     //PROOF selector for event file generation
 };
 
 #endif

--- a/proof/proofbench/inc/TSelHandleDataSet.h
+++ b/proof/proofbench/inc/TSelHandleDataSet.h
@@ -40,21 +40,21 @@ private:
 public :
 
    TSelHandleDataSet() : fType(0) { }
-   virtual ~TSelHandleDataSet() { }
-   virtual Int_t   Version() const {return 2;}
-   virtual void    Begin(TTree *) { }
-   virtual void    SlaveBegin(TTree *);
-   virtual void    Init(TTree *) { }
-   virtual Bool_t  Notify() { return kTRUE; }
-   virtual Bool_t  Process(Long64_t entry);
-   virtual void    SetOption(const char *option) { fOption = option; }
-   virtual void    SetObject(TObject *obj) { fObject = obj; }
-   virtual void    SetInputList(TList *input) {fInput = input;}
-   virtual TList  *GetOutputList() const { return fOutput; }
-   virtual void    SlaveTerminate() { }
-   virtual void    Terminate() { }
+   ~TSelHandleDataSet() override { }
+   Int_t   Version() const override {return 2;}
+   void    Begin(TTree *) override { }
+   void    SlaveBegin(TTree *) override;
+   void    Init(TTree *) override { }
+   Bool_t  Notify() override { return kTRUE; }
+   Bool_t  Process(Long64_t entry) override;
+   void    SetOption(const char *option) override { fOption = option; }
+   void    SetObject(TObject *obj) override { fObject = obj; }
+   void    SetInputList(TList *input) override {fInput = input;}
+   TList  *GetOutputList() const override { return fOutput; }
+   void    SlaveTerminate() override { }
+   void    Terminate() override { }
 
-   ClassDef(TSelHandleDataSet,0)     //PROOF selector for event file generation
+   ClassDefOverride(TSelHandleDataSet,0)     //PROOF selector for event file generation
 };
 
 #endif

--- a/proof/proofbench/inc/TSelHist.h
+++ b/proof/proofbench/inc/TSelHist.h
@@ -45,19 +45,19 @@ public :
    TCanvas         *fCHist3D;
 
    TSelHist();
-   virtual ~TSelHist();
-   virtual Int_t   Version() const { return 2; }
-   virtual void    Begin(TTree *tree);
-   virtual void    SlaveBegin(TTree *tree);
-   virtual Bool_t  Process(Long64_t entry);
-   virtual void    SetOption(const char *option) { fOption = option; }
-   virtual void    SetObject(TObject *obj) { fObject = obj; }
-   virtual void    SetInputList(TList *input) { fInput = input; }
-   virtual TList  *GetOutputList() const { return fOutput; }
-   virtual void    SlaveTerminate();
-   virtual void    Terminate();
+   ~TSelHist() override;
+   Int_t   Version() const override { return 2; }
+   void    Begin(TTree *tree) override;
+   void    SlaveBegin(TTree *tree) override;
+   Bool_t  Process(Long64_t entry) override;
+   void    SetOption(const char *option) override { fOption = option; }
+   void    SetObject(TObject *obj) override { fObject = obj; }
+   void    SetInputList(TList *input) override { fInput = input; }
+   TList  *GetOutputList() const override { return fOutput; }
+   void    SlaveTerminate() override;
+   void    Terminate() override;
 
-   ClassDef(TSelHist,0)  //PROOF selector for CPU-intensive benchmark test
+   ClassDefOverride(TSelHist,0)  //PROOF selector for CPU-intensive benchmark test
 };
 
 #endif

--- a/proof/proofbench/src/TProofBench.cxx
+++ b/proof/proofbench/src/TProofBench.cxx
@@ -745,7 +745,7 @@ public:
    TString fDesc; // Test description string, if any
    fileDesc(const char *n, const char *o,
             Long_t t, const char *d) : TNamed(n, o), fMtime(t), fDesc(d) { }
-   Int_t   Compare(const TObject *o) const {
+   Int_t   Compare(const TObject *o) const override {
       const fileDesc *fd = static_cast<const fileDesc *>(o);
       if (!fd || (fd && fd->fMtime == fMtime)) return 0;
       if (fMtime < fd->fMtime) return -1;

--- a/proof/proofbench/src/TProofPerfAnalysis.cxx
+++ b/proof/proofbench/src/TProofPerfAnalysis.cxx
@@ -47,7 +47,7 @@ public:
       TNamed(ord, name), fPackets(0), fRemotePackets(0), fEventsProcessed(0),
       fBytesRead(0), fLatency(0), fProcTime(0), fCpuTime(0), fStart(0), fStop(-1),
       fRateT(0), fRateRemoteT(0), fMBRateT(0), fMBRateRemoteT(0), fLatencyT(0) { }
-   virtual ~TWrkInfo() { SafeDelete(fRateT); SafeDelete(fRateRemoteT);
+   ~TWrkInfo() override { SafeDelete(fRateT); SafeDelete(fRateRemoteT);
                          SafeDelete(fMBRateT); SafeDelete(fMBRateRemoteT);
                          SafeDelete(fLatencyT); }
 
@@ -71,7 +71,7 @@ public:
    Double_t  AvgRate() { if (fProcTime > 0) return (fEventsProcessed/fProcTime); return -1.; }
    Double_t  AvgIO() { if (fProcTime > 0) return (fBytesRead/fProcTime); return -1.; }
 
-   void Print(Option_t * = "") const {
+   void Print(Option_t * = "") const override {
       Printf(" +++ TWrkInfo ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ ");
       Printf(" +++ Worker:             %s, %s", GetName(), GetTitle());
       Printf(" +++ Activity interval:  %f -> %f", fStart, fStop);
@@ -85,7 +85,7 @@ public:
       Printf(" +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ ");
    }
 
-   Int_t Compare(const TObject *o) const { TWrkInfo *wi = (TWrkInfo *)o;
+   Int_t Compare(const TObject *o) const override { TWrkInfo *wi = (TWrkInfo *)o;
                                            if (wi) {
                                              if (fStop < wi->fStop) {
                                                 return -1;
@@ -106,7 +106,7 @@ public:
    Float_t   fStop;             // When the packet has been finished
    Long64_t  fSize;             // Packet size
    Double_t  fMBRate;           // Processing rate MB/s
-   void Print(Option_t *opt= "") const {
+   void Print(Option_t *opt= "") const override {
       if (!strcmp(opt, "S")) {
          Printf("       \t%10lld evts, \t%12.2f MB/s, \t%12.3f -> %12.3f s", fSize, fMBRate, fStart, fStop);
       } else {
@@ -118,9 +118,9 @@ public:
 class TProofPerfAnalysis::TWrkInfoFile : public TNamed {
 public:
    TWrkInfoFile(const char *ord, const char *name) :  TNamed(ord, name) { }
-   ~TWrkInfoFile() {fPackets.SetOwner(kFALSE); fPackets.Clear("nodelete");}
+   ~TWrkInfoFile() override {fPackets.SetOwner(kFALSE); fPackets.Clear("nodelete");}
    TList     fPackets;          // Packest from this file processed by this worker
-   void Print(Option_t *opt= "") const {
+   void Print(Option_t *opt= "") const override {
       if (!strcmp(opt, "R")) {
          Printf(" Worker: %s,\tpacket(s): %d", GetName(), fPackets.GetSize());
       } else {
@@ -139,7 +139,7 @@ public:
    Double_t fEvtRate;        // Event processing rate from this worker for this packet
    Double_t fMBRate;         // I/O processing rate from this worker for this packet
    Double_t fProcTime;       // Processing time
-   void Print(Option_t * = "") const { Printf("%.4f \t%.3f evt/s \t%.3f MB/s \t%.3f s ", fXx, fEvtRate, fMBRate, fProcTime); }
+   void Print(Option_t * = "") const override { Printf("%.4f \t%.3f evt/s \t%.3f MB/s \t%.3f s ", fXx, fEvtRate, fMBRate, fProcTime); }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -151,7 +151,7 @@ public:
       fSizeAvg(0), fSizeMax(-1.), fSizeMin(-1.),
       fMBRateAvg(0), fMBRateMax(-1.), fMBRateMin(-1.), fSizeP(0),
       fRateP(0), fRatePRemote(0), fMBRateP(0), fMBRatePRemote(0) { }
-   virtual ~TFileInfo() {SafeDelete(fSizeP);
+   ~TFileInfo() override {SafeDelete(fSizeP);
                          SafeDelete(fRateP); SafeDelete(fRatePRemote);
                          SafeDelete(fMBRateP); SafeDelete(fMBRatePRemote);
                          fPackList.SetOwner(kTRUE); fPackList.Clear();
@@ -182,7 +182,7 @@ public:
    TGraph   *fMBRateP;           // Byte processing rate vs packet (all)
    TGraph   *fMBRatePRemote;     // Byte processing rate vs packet (remote workers)
 
-   void Print(Option_t *opt = "") const {
+   void Print(Option_t *opt = "") const override {
       Printf(" +++ TFileInfo ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ ");
       Printf(" +++ Server:         %s", GetTitle());
       Printf(" +++ File:           %s", GetName());
@@ -200,7 +200,7 @@ public:
       Printf(" +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ ");
    }
 
-   Int_t Compare(const TObject *o) const { TFileInfo *wi = (TFileInfo *)o;
+   Int_t Compare(const TObject *o) const override { TFileInfo *wi = (TFileInfo *)o;
                                            if (wi) {
                                              if (fStop < wi->fStop) {
                                                 return -1;

--- a/proof/proofplayer/inc/TDrawFeedback.h
+++ b/proof/proofplayer/inc/TDrawFeedback.h
@@ -44,14 +44,14 @@ protected:
 
 public:
    TDrawFeedback(TProof *proof = 0, TSeqCollection *names = 0);
-   ~TDrawFeedback();
+   ~TDrawFeedback() override;
 
    void Feedback(TList *objs);
-   const char *GetName() const { return fName.Data(); }
-   ULong_t  Hash() const { return fName.Hash(); }
+   const char *GetName() const override { return fName.Data(); }
+   ULong_t  Hash() const override { return fName.Hash(); }
    void SetOption(Option_t *option) { fOption = option; }
 
-   ClassDef(TDrawFeedback,0)  // Present PROOF query feedback
+   ClassDefOverride(TDrawFeedback,0)  // Present PROOF query feedback
 };
 
 #endif

--- a/proof/proofplayer/inc/TEventIter.h
+++ b/proof/proofplayer/inc/TEventIter.h
@@ -76,7 +76,7 @@ protected:
 public:
    TEventIter();
    TEventIter(TDSet *dset, TSelector *sel, Long64_t first, Long64_t num);
-   virtual ~TEventIter();
+   ~TEventIter() override;
 
    virtual Long64_t  GetCacheSize() = 0;
    virtual Int_t     GetLearnEntries() = 0;
@@ -90,7 +90,7 @@ public:
 
    static TEventIter *Create(TDSet *dset, TSelector *sel, Long64_t first, Long64_t num);
 
-   ClassDef(TEventIter,0)  // Event iterator used by TProofPlayer's
+   ClassDefOverride(TEventIter,0)  // Event iterator used by TProofPlayer's
 };
 
 
@@ -106,14 +106,14 @@ private:
 public:
    TEventIterUnit();
    TEventIterUnit(TDSet *dset, TSelector *sel, Long64_t num);
-   ~TEventIterUnit() { }
+   ~TEventIterUnit() override { }
 
-   Long64_t GetCacheSize() {return -1;}
-   Int_t    GetLearnEntries() {return -1;}
-   Long64_t GetNextEvent();
-   Int_t    GetNextPacket(Long64_t &first, Long64_t &num);
+   Long64_t GetCacheSize() override {return -1;}
+   Int_t    GetLearnEntries() override {return -1;}
+   Long64_t GetNextEvent() override;
+   Int_t    GetNextPacket(Long64_t &first, Long64_t &num) override;
 
-   ClassDef(TEventIterUnit,0)  // Event iterator for objects
+   ClassDefOverride(TEventIterUnit,0)  // Event iterator for objects
 };
 
 
@@ -128,19 +128,19 @@ private:
    TObject *fObj;          // object found
 
 protected:
-   void PreProcessEvent(Long64_t);
+   void PreProcessEvent(Long64_t) override;
 
 public:
    TEventIterObj();
    TEventIterObj(TDSet *dset, TSelector *sel, Long64_t first, Long64_t num);
-   ~TEventIterObj();
+   ~TEventIterObj() override;
 
-   Long64_t GetCacheSize() {return -1;}
-   Int_t    GetLearnEntries() {return -1;}
-   Long64_t GetNextEvent();
-   Int_t    GetNextPacket(Long64_t &first, Long64_t &num);
+   Long64_t GetCacheSize() override {return -1;}
+   Int_t    GetLearnEntries() override {return -1;}
+   Long64_t GetNextEvent() override;
+   Int_t    GetNextPacket(Long64_t &first, Long64_t &num) override;
 
-   ClassDef(TEventIterObj,0)  // Event iterator for objects
+   ClassDefOverride(TEventIterObj,0)  // Event iterator for objects
 };
 
 
@@ -166,26 +166,26 @@ private:
       TFile    *fFile;
       TList    *fTrees;
       TFileTree(const char *name, TFile *f, Bool_t islocal);
-      virtual ~TFileTree();
+      ~TFileTree() override;
    };
 
    TTree* Load(TDSetElement *elem, Bool_t &localfile, const char *objname = 0);
    TTree* GetTrees(TDSetElement *elem);
 
 protected:
-   void PreProcessEvent(Long64_t ent);
+   void PreProcessEvent(Long64_t ent) override;
 
 public:
    TEventIterTree();
    TEventIterTree(TDSet *dset, TSelector *sel, Long64_t first, Long64_t num);
-   ~TEventIterTree();
+   ~TEventIterTree() override;
 
-   Long64_t GetCacheSize();
-   Int_t    GetLearnEntries();
-   Long64_t GetNextEvent();
-   Int_t    GetNextPacket(Long64_t &first, Long64_t &num);
+   Long64_t GetCacheSize() override;
+   Int_t    GetLearnEntries() override;
+   Long64_t GetNextEvent() override;
+   Int_t    GetNextPacket(Long64_t &first, Long64_t &num) override;
 
-   ClassDef(TEventIterTree,0)  // Event iterator for Trees
+   ClassDefOverride(TEventIterTree,0)  // Event iterator for Trees
 };
 
 #endif

--- a/proof/proofplayer/inc/TOutputListSelectorDataMap.h
+++ b/proof/proofplayer/inc/TOutputListSelectorDataMap.h
@@ -31,11 +31,11 @@ class TOutputListSelectorDataMap: public TObject {
 public:
 
    TOutputListSelectorDataMap(TSelector* sel = 0);
-   virtual ~TOutputListSelectorDataMap() {}
+   ~TOutputListSelectorDataMap() override {}
 
    static TOutputListSelectorDataMap* FindInList(TCollection* coll);
 
-   const char* GetName() const;
+   const char* GetName() const override;
 
    Bool_t Init(TSelector* sel);
    Bool_t SetDataMembers(TSelector* sel) const;
@@ -45,7 +45,7 @@ public:
 
 private:
    TCollection* fMap;
-   ClassDef(TOutputListSelectorDataMap, 1)  // Converter from output list to TSelector data members
+   ClassDefOverride(TOutputListSelectorDataMap, 1)  // Converter from output list to TSelector data members
 };
 
 

--- a/proof/proofplayer/inc/TPacketizer.h
+++ b/proof/proofplayer/inc/TPacketizer.h
@@ -88,16 +88,16 @@ private:
 public:
    TPacketizer(TDSet *dset, TList *slaves, Long64_t first, Long64_t num,
                 TList *input, TProofProgressStatus *st);
-   virtual ~TPacketizer();
+   ~TPacketizer() override;
 
-   Int_t         AddWorkers(TList *workers);
-   TDSetElement *GetNextPacket(TSlave *sl, TMessage *r);
+   Int_t         AddWorkers(TList *workers) override;
+   TDSetElement *GetNextPacket(TSlave *sl, TMessage *r) override;
    Long64_t      GetEntriesProcessed(TSlave *sl) const;
 
-   Float_t       GetCurrentRate(Bool_t &all);
-   Int_t         GetActiveWorkers();
+   Float_t       GetCurrentRate(Bool_t &all) override;
+   Int_t         GetActiveWorkers() override;
 
-   ClassDef(TPacketizer,0)  //Generate work packets for parallel processing
+   ClassDefOverride(TPacketizer,0)  //Generate work packets for parallel processing
 };
 
 #endif

--- a/proof/proofplayer/inc/TPacketizerAdaptive.h
+++ b/proof/proofplayer/inc/TPacketizerAdaptive.h
@@ -105,19 +105,19 @@ private:
 public:
    TPacketizerAdaptive(TDSet *dset, TList *slaves, Long64_t first, Long64_t num,
                        TList *input, TProofProgressStatus *st);
-   virtual ~TPacketizerAdaptive();
+   ~TPacketizerAdaptive() override;
 
    Int_t         AddProcessed(TSlave *sl, TProofProgressStatus *st,
-                               Double_t latency, TList **listOfMissingFiles = 0);
-   Int_t         GetEstEntriesProcessed(Float_t, Long64_t &ent, Long64_t &bytes, Long64_t &calls);
-   Float_t       GetCurrentRate(Bool_t &all);
+                               Double_t latency, TList **listOfMissingFiles = 0) override;
+   Int_t         GetEstEntriesProcessed(Float_t, Long64_t &ent, Long64_t &bytes, Long64_t &calls) override;
+   Float_t       GetCurrentRate(Bool_t &all) override;
    Int_t         CalculatePacketSize(TObject *slstat, Long64_t cachesz, Int_t learnent);
-   TDSetElement *GetNextPacket(TSlave *sl, TMessage *r);
-   void          MarkBad(TSlave *s, TProofProgressStatus *status, TList **missingFiles);
+   TDSetElement *GetNextPacket(TSlave *sl, TMessage *r) override;
+   void          MarkBad(TSlave *s, TProofProgressStatus *status, TList **missingFiles) override;
 
-   Int_t         GetActiveWorkers();
+   Int_t         GetActiveWorkers() override;
 
-   ClassDef(TPacketizerAdaptive,0)  //Generate work packets for parallel processing
+   ClassDefOverride(TPacketizerAdaptive,0)  //Generate work packets for parallel processing
 };
 
 #endif

--- a/proof/proofplayer/inc/TPacketizerFile.h
+++ b/proof/proofplayer/inc/TPacketizerFile.h
@@ -54,16 +54,16 @@ private:
 
 public:
    TPacketizerFile(TList *workers, Long64_t, TList *input, TProofProgressStatus *st = 0);
-   virtual ~TPacketizerFile();
+   ~TPacketizerFile() override;
 
-   TDSetElement *GetNextPacket(TSlave *wrk, TMessage *r);
+   TDSetElement *GetNextPacket(TSlave *wrk, TMessage *r) override;
 
    Double_t      GetCurrentTime();
 
-   Float_t       GetCurrentRate(Bool_t &all);
-   Int_t         GetActiveWorkers() { return -1; }
+   Float_t       GetCurrentRate(Bool_t &all) override;
+   Int_t         GetActiveWorkers() override { return -1; }
 
-   ClassDef(TPacketizerFile,0)  //Generate work packets for parallel processing
+   ClassDefOverride(TPacketizerFile,0)  //Generate work packets for parallel processing
 };
 
 //-------------------------------------------------------------------------------

--- a/proof/proofplayer/inc/TPacketizerMulti.h
+++ b/proof/proofplayer/inc/TPacketizerMulti.h
@@ -54,27 +54,27 @@ private:
 public:
    TPacketizerMulti(TDSet *dset, TList *slaves, Long64_t first, Long64_t num,
                     TList *input, TProofProgressStatus *st);
-   virtual ~TPacketizerMulti();
+   ~TPacketizerMulti() override;
 
-   TDSetElement *GetNextPacket(TSlave *wrk, TMessage *r);
+   TDSetElement *GetNextPacket(TSlave *wrk, TMessage *r) override;
 
-   Int_t    GetEstEntriesProcessed(Float_t f, Long64_t &ent, Long64_t &bytes, Long64_t &calls)
+   Int_t    GetEstEntriesProcessed(Float_t f, Long64_t &ent, Long64_t &bytes, Long64_t &calls) override
                     { if (fCurrent) return fCurrent->GetEstEntriesProcessed(f,ent,bytes,calls);
                       return 1; }
-   Float_t  GetCurrentRate(Bool_t &all) { all = kTRUE;
+   Float_t  GetCurrentRate(Bool_t &all) override { all = kTRUE;
                                           return (fCurrent? fCurrent->GetCurrentRate(all) : 0.); }
-   void     StopProcess(Bool_t abort, Bool_t stoptimer = kFALSE) {
+   void     StopProcess(Bool_t abort, Bool_t stoptimer = kFALSE) override {
                                         if (fCurrent) fCurrent->StopProcess(abort, stoptimer);
                                         TVirtualPacketizer::StopProcess(abort, stoptimer); }
-   void     MarkBad(TSlave *wrk, TProofProgressStatus *st, TList **missing)
+   void     MarkBad(TSlave *wrk, TProofProgressStatus *st, TList **missing) override
                     { if (fCurrent) fCurrent->MarkBad(wrk, st, missing); return; }
-   Int_t    AddProcessed(TSlave *wrk, TProofProgressStatus *st, Double_t lat, TList **missing)
+   Int_t    AddProcessed(TSlave *wrk, TProofProgressStatus *st, Double_t lat, TList **missing) override
                     { if (fCurrent) return fCurrent->AddProcessed(wrk, st, lat, missing);
                       return -1; }
 
-   Int_t    GetActiveWorkers() { if (fCurrent) return fCurrent->GetActiveWorkers(); return 0; }
+   Int_t    GetActiveWorkers() override { if (fCurrent) return fCurrent->GetActiveWorkers(); return 0; }
 
-   ClassDef(TPacketizerMulti,0)  //Generate work packets for parallel processing
+   ClassDefOverride(TPacketizerMulti,0)  //Generate work packets for parallel processing
 };
 
 #endif

--- a/proof/proofplayer/inc/TPacketizerUnit.h
+++ b/proof/proofplayer/inc/TPacketizerUnit.h
@@ -63,19 +63,19 @@ private:
 
 public:
    TPacketizerUnit(TList *slaves, Long64_t num, TList *input, TProofProgressStatus *st = 0);
-   virtual ~TPacketizerUnit();
+   ~TPacketizerUnit() override;
 
-   Int_t         AssignWork(TDSet* /*dset*/, Long64_t /*first*/, Long64_t num);
-   TDSetElement *GetNextPacket(TSlave *sl, TMessage *r);
+   Int_t         AssignWork(TDSet* /*dset*/, Long64_t /*first*/, Long64_t num) override;
+   TDSetElement *GetNextPacket(TSlave *sl, TMessage *r) override;
 
    Double_t      GetCurrentTime();
 
-   Float_t       GetCurrentRate(Bool_t &all);
-   Int_t         GetActiveWorkers() { return fWrkStats->GetSize(); }
+   Float_t       GetCurrentRate(Bool_t &all) override;
+   Int_t         GetActiveWorkers() override { return fWrkStats->GetSize(); }
 
-   Int_t         AddWorkers(TList *workers);
+   Int_t         AddWorkers(TList *workers) override;
 
-   ClassDef(TPacketizerUnit,0)  //Generate work packets for parallel processing
+   ClassDefOverride(TPacketizerUnit,0)  //Generate work packets for parallel processing
 };
 
 #endif

--- a/proof/proofplayer/inc/TPerfStats.h
+++ b/proof/proofplayer/inc/TPerfStats.h
@@ -57,13 +57,13 @@ public:
    Bool_t                        fIsOk;
 
    TPerfEvent(TTimeStamp *offset = 0);
-   virtual ~TPerfEvent() {}
+   ~TPerfEvent() override {}
 
-   Bool_t   IsSortable() const { return kTRUE; }
-   Int_t    Compare(const TObject *obj) const;
-   void     Print(Option_t *option="") const;
+   Bool_t   IsSortable() const override { return kTRUE; }
+   Int_t    Compare(const TObject *obj) const override;
+   void     Print(Option_t *option="") const override;
 
-   ClassDef(TPerfEvent,3) // Class holding TProof Event Info
+   ClassDefOverride(TPerfEvent,3) // Class holding TProof Event Info
 };
 
 
@@ -111,38 +111,38 @@ private:
    TPerfStats(TList *input, TList *output);
    void WriteQueryLog();
 
-   void SetFile(TFile *) {}
+   void SetFile(TFile *) override {}
 
 public:
-   virtual ~TPerfStats();
+   ~TPerfStats() override;
 
-   void SimpleEvent(EEventType type);
+   void SimpleEvent(EEventType type) override;
    void PacketEvent(const char *slave, const char *slavename, const char *filename,
                     Long64_t eventsprocessed, Double_t latency,
-                    Double_t proctime, Double_t cputime, Long64_t bytesRead);
+                    Double_t proctime, Double_t cputime, Long64_t bytesRead) override;
    void FileEvent(const char *slave, const char *slavename, const char *nodename, const char *filename,
-                  Bool_t isStart);
+                  Bool_t isStart) override;
 
-   void FileOpenEvent(TFile *file, const char *filename, Double_t start);
-   void FileReadEvent(TFile *file, Int_t len, Double_t start);
-   void UnzipEvent(TObject *tree, Long64_t pos, Double_t start, Int_t complen, Int_t objlen);
+   void FileOpenEvent(TFile *file, const char *filename, Double_t start) override;
+   void FileReadEvent(TFile *file, Int_t len, Double_t start) override;
+   void UnzipEvent(TObject *tree, Long64_t pos, Double_t start, Int_t complen, Int_t objlen) override;
    void RateEvent(Double_t proctime, Double_t deltatime,
-                  Long64_t eventsprocessed, Long64_t bytesRead);
-   void SetBytesRead(Long64_t num);
-   Long64_t GetBytesRead() const;
-   void SetNumEvents(Long64_t num) { fNumEvents = num; }
-   Long64_t GetNumEvents() const { return fNumEvents; }
+                  Long64_t eventsprocessed, Long64_t bytesRead) override;
+   void SetBytesRead(Long64_t num) override;
+   Long64_t GetBytesRead() const override;
+   void SetNumEvents(Long64_t num) override { fNumEvents = num; }
+   Long64_t GetNumEvents() const override { return fNumEvents; }
 
-   void        PrintBasketInfo(Option_t * = "") const {}
-   void        SetLoaded(TBranch *, size_t) {}
-   void        SetLoaded(size_t, size_t) {}
-   void        SetLoadedMiss(TBranch *, size_t) {}
-   void        SetLoadedMiss(size_t, size_t) {}
-   void        SetMissed(TBranch *, size_t) {}
-   void        SetMissed(size_t, size_t) {}
-   void        SetUsed(TBranch *, size_t) {}
-   void        SetUsed(size_t, size_t) {}
-   void        UpdateBranchIndices(TObjArray *) {}
+   void        PrintBasketInfo(Option_t * = "") const override {}
+   void        SetLoaded(TBranch *, size_t) override {}
+   void        SetLoaded(size_t, size_t) override {}
+   void        SetLoadedMiss(TBranch *, size_t) override {}
+   void        SetLoadedMiss(size_t, size_t) override {}
+   void        SetMissed(TBranch *, size_t) override {}
+   void        SetMissed(size_t, size_t) override {}
+   void        SetUsed(TBranch *, size_t) override {}
+   void        SetUsed(size_t, size_t) override {}
+   void        UpdateBranchIndices(TObjArray *) override {}
 
    static void Start(TList *input, TList *output);
    static void Stop();
@@ -150,7 +150,7 @@ public:
    static void SetMemValues();
    static void GetMemValues(Long_t &vmax, Long_t &rmax);
 
-   ClassDef(TPerfStats,0)  // Class for collecting PROOF statistics
+   ClassDefOverride(TPerfStats,0)  // Class for collecting PROOF statistics
 };
 
 

--- a/proof/proofplayer/inc/TProofDraw.h
+++ b/proof/proofplayer/inc/TProofDraw.h
@@ -80,17 +80,17 @@ protected:
 
 public:
    TProofDraw();
-   virtual            ~TProofDraw();
-   virtual int         Version() const { return 1; }
-   virtual void        Init(TTree *);
-   virtual void        Begin(TTree *);
-   virtual void        SlaveBegin(TTree *);
-   virtual Bool_t      Notify();
-   virtual Bool_t      Process(Long64_t /*entry*/);
-   virtual void        SlaveTerminate();
-   virtual void        Terminate();
+              ~TProofDraw() override;
+   int         Version() const override { return 1; }
+   void        Init(TTree *) override;
+   void        Begin(TTree *) override;
+   void        SlaveBegin(TTree *) override;
+   Bool_t      Notify() override;
+   Bool_t      Process(Long64_t /*entry*/) override;
+   void        SlaveTerminate() override;
+   void        Terminate() override;
 
-   ClassDef(TProofDraw,0)  //Tree drawing selector for PROOF
+   ClassDefOverride(TProofDraw,0)  //Tree drawing selector for PROOF
 };
 
 
@@ -107,17 +107,17 @@ protected:
    virtual void        Begin1D(TTree *t);
    virtual void        Begin2D(TTree *t);
    virtual void        Begin3D(TTree *t);
-   virtual void        DoFill(Long64_t entry, Double_t w, const Double_t *v);
-   virtual void        DefVar();
+   void        DoFill(Long64_t entry, Double_t w, const Double_t *v) override;
+   void        DefVar() override;
 
 public:
    TProofDrawHist() : fHistogram(0) { }
-   virtual void        Begin(TTree *t);
-   virtual void        Init(TTree *);
-   virtual void        SlaveBegin(TTree *);
-   virtual void        Terminate();
+   void        Begin(TTree *t) override;
+   void        Init(TTree *) override;
+   void        SlaveBegin(TTree *) override;
+   void        Terminate() override;
 
-   ClassDef(TProofDrawHist,0)  //Tree drawing selector for PROOF
+   ClassDefOverride(TProofDrawHist,0)  //Tree drawing selector for PROOF
 };
 
 
@@ -127,38 +127,38 @@ protected:
    TEventList*    fElist;          //  event list
    TList*         fEventLists;     //  a list of EventLists
 
-   virtual void   DoFill(Long64_t entry, Double_t w, const Double_t *v);
-   virtual void   DefVar() { }
+   void   DoFill(Long64_t entry, Double_t w, const Double_t *v) override;
+   void   DefVar() override { }
 
 public:
    TProofDrawEventList() : fElist(0), fEventLists(0) {}
-   ~TProofDrawEventList() {}
+   ~TProofDrawEventList() override {}
 
-   virtual void        Init(TTree *);
-   virtual void        SlaveBegin(TTree *);
-   virtual void        SlaveTerminate();
-   virtual void        Terminate();
+   void        Init(TTree *) override;
+   void        SlaveBegin(TTree *) override;
+   void        SlaveTerminate() override;
+   void        Terminate() override;
 
-   ClassDef(TProofDrawEventList,0)  //Tree drawing selector for PROOF
+   ClassDefOverride(TProofDrawEventList,0)  //Tree drawing selector for PROOF
 };
 
 class TProofDrawEntryList : public TProofDraw {
  protected:
    TEntryList *fElist;
 
-   virtual void DoFill(Long64_t entry, Double_t w, const Double_t *v);
-   virtual void DefVar() {}
+   void DoFill(Long64_t entry, Double_t w, const Double_t *v) override;
+   void DefVar() override {}
 
  public:
    TProofDrawEntryList() : fElist(0) {}
-   ~TProofDrawEntryList() {}
+   ~TProofDrawEntryList() override {}
 
-   virtual void Init(TTree *);
-   virtual void SlaveBegin(TTree *);
-   virtual void SlaveTerminate();
-   virtual void Terminate();
+   void Init(TTree *) override;
+   void SlaveBegin(TTree *) override;
+   void SlaveTerminate() override;
+   void Terminate() override;
 
-   ClassDef(TProofDrawEntryList, 0)  //A Selectoor to fill a TEntryList from TTree::Draw
+   ClassDefOverride(TProofDrawEntryList, 0)  //A Selectoor to fill a TEntryList from TTree::Draw
 };
 
 
@@ -167,17 +167,17 @@ class TProofDrawProfile : public TProofDraw {
 protected:
    TProfile           *fProfile;
 
-   virtual void        DoFill(Long64_t entry, Double_t w, const Double_t *v);
-   virtual void        DefVar();
+   void        DoFill(Long64_t entry, Double_t w, const Double_t *v) override;
+   void        DefVar() override;
 
 public:
    TProofDrawProfile() : fProfile(0) { }
-   virtual void        Init(TTree *);
-   virtual void        Begin(TTree *t);
-   virtual void        SlaveBegin(TTree *);
-   virtual void        Terminate();
+   void        Init(TTree *) override;
+   void        Begin(TTree *t) override;
+   void        SlaveBegin(TTree *) override;
+   void        Terminate() override;
 
-   ClassDef(TProofDrawProfile,0)  //Tree drawing selector for PROOF
+   ClassDefOverride(TProofDrawProfile,0)  //Tree drawing selector for PROOF
 };
 
 
@@ -186,17 +186,17 @@ class TProofDrawProfile2D : public TProofDraw {
 protected:
    TProfile2D         *fProfile;
 
-   virtual void        DoFill(Long64_t entry, Double_t w, const Double_t *v);
-   virtual void        DefVar();
+   void        DoFill(Long64_t entry, Double_t w, const Double_t *v) override;
+   void        DefVar() override;
 
 public:
    TProofDrawProfile2D() : fProfile(0) { }
-   virtual void        Init(TTree *);
-   virtual void        Begin(TTree *t);
-   virtual void        SlaveBegin(TTree *);
-   virtual void        Terminate();
+   void        Init(TTree *) override;
+   void        Begin(TTree *t) override;
+   void        SlaveBegin(TTree *) override;
+   void        Terminate() override;
 
-   ClassDef(TProofDrawProfile2D,0)  //Tree drawing selector for PROOF
+   ClassDefOverride(TProofDrawProfile2D,0)  //Tree drawing selector for PROOF
 };
 
 
@@ -205,16 +205,16 @@ class TProofDrawGraph : public TProofDraw {
 protected:
    TGraph             *fGraph;
 
-   virtual void        DoFill(Long64_t entry, Double_t w, const Double_t *v);
-   virtual void        DefVar() { }
+   void        DoFill(Long64_t entry, Double_t w, const Double_t *v) override;
+   void        DefVar() override { }
 
 public:
    TProofDrawGraph() : fGraph(0) { }
-   virtual void        Init(TTree *tree);
-   virtual void        SlaveBegin(TTree *);
-   virtual void        Terminate();
+   void        Init(TTree *tree) override;
+   void        SlaveBegin(TTree *) override;
+   void        Terminate() override;
 
-   ClassDef(TProofDrawGraph,0)  //Tree drawing selector for PROOF
+   ClassDefOverride(TProofDrawGraph,0)  //Tree drawing selector for PROOF
 };
 
 
@@ -223,16 +223,16 @@ class TProofDrawPolyMarker3D : public TProofDraw {
 protected:
    TPolyMarker3D      *fPolyMarker3D;
 
-   virtual void        DoFill(Long64_t entry, Double_t w, const Double_t *v);
-   virtual void        DefVar() { }
+   void        DoFill(Long64_t entry, Double_t w, const Double_t *v) override;
+   void        DefVar() override { }
 
 public:
    TProofDrawPolyMarker3D() : fPolyMarker3D(0) { }
-   virtual void        Init(TTree *tree);
-   virtual void        SlaveBegin(TTree *);
-   virtual void        Terminate();
+   void        Init(TTree *tree) override;
+   void        SlaveBegin(TTree *) override;
+   void        Terminate() override;
 
-   ClassDef(TProofDrawPolyMarker3D,0)  //Tree drawing selector for PROOF
+   ClassDefOverride(TProofDrawPolyMarker3D,0)  //Tree drawing selector for PROOF
 };
 
 template <typename T>
@@ -246,12 +246,12 @@ protected:
 public:
    TProofVectorContainer(std::vector<T>* anVector) : fVector(anVector) { }
    TProofVectorContainer() : fVector(0) { }
-   ~TProofVectorContainer() { delete fVector; }
+   ~TProofVectorContainer() override { delete fVector; }
 
    std::vector<T> *GetVector() const { return fVector; }
    Long64_t        Merge(TCollection* list);
 
-   ClassDef(TProofVectorContainer,1) //Class describing a vector container
+   ClassDefOverride(TProofVectorContainer,1) //Class describing a vector container
 };
 
 class TProofDrawListOfGraphs : public TProofDraw {
@@ -266,15 +266,15 @@ public:
 
 protected:
    TProofVectorContainer<Point3D_t> *fPoints;
-   virtual void        DoFill(Long64_t entry, Double_t w, const Double_t *v);
-   virtual void        DefVar() { }
+   void        DoFill(Long64_t entry, Double_t w, const Double_t *v) override;
+   void        DefVar() override { }
 
 public:
    TProofDrawListOfGraphs() : fPoints(0) { }
-   virtual void        SlaveBegin(TTree *);
-   virtual void        Terminate();
+   void        SlaveBegin(TTree *) override;
+   void        Terminate() override;
 
-   ClassDef(TProofDrawListOfGraphs,0)  //Tree drawing selector for PROOF
+   ClassDefOverride(TProofDrawListOfGraphs,0)  //Tree drawing selector for PROOF
 };
 
 
@@ -290,15 +290,15 @@ public:
 
 protected:
    TProofVectorContainer<Point4D_t> *fPoints;
-   virtual void        DoFill(Long64_t entry, Double_t w, const Double_t *v);
-   virtual void        DefVar() { }
+   void        DoFill(Long64_t entry, Double_t w, const Double_t *v) override;
+   void        DefVar() override { }
 
 public:
    TProofDrawListOfPolyMarkers3D() : fPoints(0) { }
-   virtual void        SlaveBegin(TTree *);
-   virtual void        Terminate();
+   void        SlaveBegin(TTree *) override;
+   void        Terminate() override;
 
-   ClassDef(TProofDrawListOfPolyMarkers3D,0)  //Tree drawing selector for PROOF
+   ClassDefOverride(TProofDrawListOfPolyMarkers3D,0)  //Tree drawing selector for PROOF
 };
 
 #ifndef __CINT__

--- a/proof/proofplayer/inc/TProofLimitsFinder.h
+++ b/proof/proofplayer/inc/TProofLimitsFinder.h
@@ -29,17 +29,17 @@ class TProofLimitsFinder : public THLimitsFinder {
 
 public:
    TProofLimitsFinder() { }
-   virtual ~TProofLimitsFinder() { }
-   virtual Int_t FindGoodLimits(TH1 *h, Axis_t xmin, Axis_t xmax);
-   virtual Int_t FindGoodLimits(TH1 *h, Axis_t xmin, Axis_t xmax, Axis_t ymin, Axis_t ymax);
-   virtual Int_t FindGoodLimits(TH1 *h, Axis_t xmin, Axis_t xmax, Axis_t ymin, Axis_t ymax, Axis_t zmin, Axis_t zmax);
+   ~TProofLimitsFinder() override { }
+   Int_t FindGoodLimits(TH1 *h, Axis_t xmin, Axis_t xmax) override;
+   Int_t FindGoodLimits(TH1 *h, Axis_t xmin, Axis_t xmax, Axis_t ymin, Axis_t ymax) override;
+   Int_t FindGoodLimits(TH1 *h, Axis_t xmin, Axis_t xmax, Axis_t ymin, Axis_t ymax, Axis_t zmin, Axis_t zmax) override;
 
    static void AutoBinFunc(TString& key,
                            Double_t& xmin, Double_t& xmax,
                            Double_t& ymin, Double_t& ymax,
                            Double_t& zmin, Double_t& zmax);
 
-   ClassDef(TProofLimitsFinder,0)  //Find and communicate best axis limits
+   ClassDefOverride(TProofLimitsFinder,0)  //Find and communicate best axis limits
 };
 
 #endif

--- a/proof/proofplayer/inc/TProofMonSender.h
+++ b/proof/proofplayer/inc/TProofMonSender.h
@@ -47,7 +47,7 @@ protected:
       TDSet   *fDSet;
       TDSetPlet(const char *name, TDSet *ds = 0) :
          TNamed(name, ""), fFiles(0), fMissing(0), fDSet(ds) { }
-      virtual ~TDSetPlet() { }
+      ~TDSetPlet() override { }
    };
 
 public:
@@ -59,7 +59,7 @@ public:
                      SetBit(kSendSummary);
                      SetBit(kSendDataSetInfo);
                      ResetBit(kSendFileInfo); }
-   virtual ~TProofMonSender() { }
+   ~TProofMonSender() override { }
 
    // This changes the send control options
    Int_t SetSendOptions(const char *);
@@ -76,7 +76,7 @@ public:
    // Detailed information about files
    virtual Int_t SendFileInfo(TDSet *, TList *, const char *, const char *) = 0;
 
-   ClassDef(TProofMonSender,0); // Interface for PROOF monitoring
+   ClassDefOverride(TProofMonSender,0); // Interface for PROOF monitoring
 };
 
 #endif

--- a/proof/proofplayer/inc/TProofMonSenderML.h
+++ b/proof/proofplayer/inc/TProofMonSenderML.h
@@ -36,18 +36,18 @@ public:
 
    TProofMonSenderML(const char *serv, const char *tag, const char *id = 0,
                      const char *subid = 0, const char *opt = "");
-   virtual ~TProofMonSenderML();
+   ~TProofMonSenderML() override;
 
    // Summary record
-   Int_t SendSummary(TList *, const char *);
+   Int_t SendSummary(TList *, const char *) override;
 
    // Information about the dataset(s) processed
-   Int_t SendDataSetInfo(TDSet *, TList *, const char *, const char *);
+   Int_t SendDataSetInfo(TDSet *, TList *, const char *, const char *) override;
 
    // Detailed infoirmation about files
-   Int_t SendFileInfo(TDSet *, TList *, const char *, const char *);
+   Int_t SendFileInfo(TDSet *, TList *, const char *, const char *) override;
 
-   ClassDef(TProofMonSenderML, 0); // Interface for PROOF monitoring
+   ClassDefOverride(TProofMonSenderML, 0); // Interface for PROOF monitoring
 };
 
 #endif

--- a/proof/proofplayer/inc/TProofMonSenderSQL.h
+++ b/proof/proofplayer/inc/TProofMonSenderSQL.h
@@ -39,18 +39,18 @@ public:
    TProofMonSenderSQL(const char *serv, const char *user, const char *pass,
                       const char *table = "proof.proofquerylog",
                       const char *dstab = 0, const char *filestab = 0);
-   virtual ~TProofMonSenderSQL();
+   ~TProofMonSenderSQL() override;
 
    // Summary record
-   Int_t SendSummary(TList *, const char *);
+   Int_t SendSummary(TList *, const char *) override;
 
    // Information about the dataset(s) processed
-   Int_t SendDataSetInfo(TDSet *, TList *, const char *, const char *);
+   Int_t SendDataSetInfo(TDSet *, TList *, const char *, const char *) override;
 
    // Detailed information about files
-   Int_t SendFileInfo(TDSet *, TList *, const char *, const char *);
+   Int_t SendFileInfo(TDSet *, TList *, const char *, const char *) override;
 
-   ClassDef(TProofMonSenderSQL, 0); // Interface for PROOF monitoring
+   ClassDefOverride(TProofMonSenderSQL, 0); // Interface for PROOF monitoring
 };
 
 #endif

--- a/proof/proofplayer/inc/TProofPlayer.h
+++ b/proof/proofplayer/inc/TProofPlayer.h
@@ -102,13 +102,13 @@ protected:
 
    static THashList *fgDrawInputPars;  // List of input parameters to be kept on drawing actions
 
-   void         *GetSender() { return this; }  //used to set gTQSender
+   void         *GetSender() override { return this; }  //used to set gTQSender
 
    virtual Int_t DrawCanvas(TObject *obj); // Canvas drawing via libProofDraw
 
    virtual void SetupFeedback();  // specialized setup
    
-   virtual void  MergeOutput(Bool_t savememvalues = kFALSE);
+   void  MergeOutput(Bool_t savememvalues = kFALSE) override;
 
 public:   // fix for broken compilers so TCleanup can call StopFeedback()
    virtual void StopFeedback();   // specialized teardown
@@ -132,100 +132,100 @@ public:
                       kMaxProcTimeReached = BIT(17), kMaxProcTimeExtended = BIT(18) };
 
    TProofPlayer(TProof *proof = 0);
-   virtual ~TProofPlayer();
+   ~TProofPlayer() override;
 
    Long64_t  Process(TDSet *set,
                      const char *selector, Option_t *option = "",
-                     Long64_t nentries = -1, Long64_t firstentry = 0);
+                     Long64_t nentries = -1, Long64_t firstentry = 0) override;
    Long64_t  Process(TDSet *set,
                      TSelector *selector, Option_t *option = "",
-                     Long64_t nentries = -1, Long64_t firstentry = 0);
-   virtual Bool_t JoinProcess(TList *workers);
-   TVirtualPacketizer *GetPacketizer() const { return 0; }
-   Long64_t  Finalize(Bool_t force = kFALSE, Bool_t sync = kFALSE);
-   Long64_t  Finalize(TQueryResult *qr);
+                     Long64_t nentries = -1, Long64_t firstentry = 0) override;
+   Bool_t JoinProcess(TList *workers) override;
+   TVirtualPacketizer *GetPacketizer() const override { return 0; }
+   Long64_t  Finalize(Bool_t force = kFALSE, Bool_t sync = kFALSE) override;
+   Long64_t  Finalize(TQueryResult *qr) override;
    Long64_t  DrawSelect(TDSet *set, const char *varexp,
                         const char *selection, Option_t *option = "",
-                        Long64_t nentries = -1, Long64_t firstentry = 0);
+                        Long64_t nentries = -1, Long64_t firstentry = 0) override;
    Int_t     GetDrawArgs(const char *var, const char *sel, Option_t *opt,
-                         TString &selector, TString &objname);
-   void      HandleGetTreeHeader(TMessage *mess);
-   void      HandleRecvHisto(TMessage *mess);
+                         TString &selector, TString &objname) override;
+   void      HandleGetTreeHeader(TMessage *mess) override;
+   void      HandleRecvHisto(TMessage *mess) override;
    void      FeedBackCanvas(const char *name, Bool_t create);
 
-   void      StopProcess(Bool_t abort, Int_t timeout = -1);
-   void      AddInput(TObject *inp);
-   void      ClearInput();
-   TObject  *GetOutput(const char *name) const;
-   TList    *GetOutputList() const;
-   TList    *GetInputList() const { return fInput; }
-   TList    *GetListOfResults() const { return fQueryResults; }
-   void      AddQueryResult(TQueryResult *q);
-   TQueryResult *GetCurrentQuery() const { return fQuery; }
-   TQueryResult *GetQueryResult(const char *ref);
-   void      RemoveQueryResult(const char *ref);
-   void      SetCurrentQuery(TQueryResult *q);
-   void      SetMaxDrawQueries(Int_t max) { fMaxDrawQueries = max; }
-   void      RestorePreviousQuery() { fQuery = fPreviousQuery; }
-   Int_t     AddOutputObject(TObject *obj);
-   void      AddOutput(TList *out);   // Incorporate a list
-   void      StoreOutput(TList *out);   // Adopts the list
-   void      StoreFeedback(TObject *slave, TList *out); // Adopts the list
-   void      Progress(Long64_t total, Long64_t processed); // *SIGNAL*
-   void      Progress(TSlave *, Long64_t total, Long64_t processed)
+   void      StopProcess(Bool_t abort, Int_t timeout = -1) override;
+   void      AddInput(TObject *inp) override;
+   void      ClearInput() override;
+   TObject  *GetOutput(const char *name) const override;
+   TList    *GetOutputList() const override;
+   TList    *GetInputList() const override { return fInput; }
+   TList    *GetListOfResults() const override { return fQueryResults; }
+   void      AddQueryResult(TQueryResult *q) override;
+   TQueryResult *GetCurrentQuery() const override { return fQuery; }
+   TQueryResult *GetQueryResult(const char *ref) override;
+   void      RemoveQueryResult(const char *ref) override;
+   void      SetCurrentQuery(TQueryResult *q) override;
+   void      SetMaxDrawQueries(Int_t max) override { fMaxDrawQueries = max; }
+   void      RestorePreviousQuery() override { fQuery = fPreviousQuery; }
+   Int_t     AddOutputObject(TObject *obj) override;
+   void      AddOutput(TList *out) override;   // Incorporate a list
+   void      StoreOutput(TList *out) override;   // Adopts the list
+   void      StoreFeedback(TObject *slave, TList *out) override; // Adopts the list
+   void      Progress(Long64_t total, Long64_t processed) override; // *SIGNAL*
+   void      Progress(TSlave *, Long64_t total, Long64_t processed) override
                 { Progress(total, processed); }
    void      Progress(Long64_t total, Long64_t processed, Long64_t bytesread,
                       Float_t initTime, Float_t procTime,
-                      Float_t evtrti, Float_t mbrti); // *SIGNAL*
+                      Float_t evtrti, Float_t mbrti) override; // *SIGNAL*
    void      Progress(TSlave *, Long64_t total, Long64_t processed, Long64_t bytesread,
                       Float_t initTime, Float_t procTime,
-                      Float_t evtrti, Float_t mbrti)
+                      Float_t evtrti, Float_t mbrti) override
                 { Progress(total, processed, bytesread, initTime, procTime,
                            evtrti, mbrti); } // *SIGNAL*
-   void      Progress(TProofProgressInfo *pi); // *SIGNAL*
-   void      Progress(TSlave *, TProofProgressInfo *pi) { Progress(pi); } // *SIGNAL*
-   void      Feedback(TList *objs); // *SIGNAL*
+   void      Progress(TProofProgressInfo *pi) override; // *SIGNAL*
+   void      Progress(TSlave *, TProofProgressInfo *pi) override { Progress(pi); } // *SIGNAL*
+   void      Feedback(TList *objs) override; // *SIGNAL*
 
-   TDrawFeedback *CreateDrawFeedback(TProof *p);
-   void           SetDrawFeedbackOption(TDrawFeedback *f, Option_t *opt);
-   void           DeleteDrawFeedback(TDrawFeedback *f);
+   TDrawFeedback *CreateDrawFeedback(TProof *p) override;
+   void           SetDrawFeedbackOption(TDrawFeedback *f, Option_t *opt) override;
+   void           DeleteDrawFeedback(TDrawFeedback *f) override;
 
-   TDSetElement *GetNextPacket(TSlave *slave, TMessage *r);
+   TDSetElement *GetNextPacket(TSlave *slave, TMessage *r) override;
 
-   Int_t     ReinitSelector(TQueryResult *qr);
+   Int_t     ReinitSelector(TQueryResult *qr) override;
 
    void      UpdateAutoBin(const char *name,
                            Double_t& xmin, Double_t& xmax,
                            Double_t& ymin, Double_t& ymax,
-                           Double_t& zmin, Double_t& zmax);
+                           Double_t& zmin, Double_t& zmax) override;
 
-   Bool_t    IsClient() const { return kFALSE; }
+   Bool_t    IsClient() const override { return kFALSE; }
 
-   void      SetExitStatus(EExitStatus st) { fExitStatus = st; }
-   EExitStatus GetExitStatus() const { return fExitStatus; }
-   Long64_t    GetEventsProcessed() const { return fProgressStatus->GetEntries(); }
-   void        AddEventsProcessed(Long64_t ev) { fProgressStatus->IncEntries(ev); }
+   void      SetExitStatus(EExitStatus st) override { fExitStatus = st; }
+   EExitStatus GetExitStatus() const override { return fExitStatus; }
+   Long64_t    GetEventsProcessed() const override { return fProgressStatus->GetEntries(); }
+   void        AddEventsProcessed(Long64_t ev) override { fProgressStatus->IncEntries(ev); }
 
-   void      SetDispatchTimer(Bool_t on = kTRUE);
+   void      SetDispatchTimer(Bool_t on = kTRUE) override;
    void      SetStopTimer(Bool_t on = kTRUE,
-                          Bool_t abort = kFALSE, Int_t timeout = 0);
+                          Bool_t abort = kFALSE, Int_t timeout = 0) override;
 
-   virtual void      SetInitTime() { }
+   void      SetInitTime() override { }
 
-   virtual void      SetMerging(Bool_t = kTRUE) { }
+   void      SetMerging(Bool_t = kTRUE) override { }
 
-   Long64_t  GetCacheSize();
-   Int_t     GetLearnEntries();
+   Long64_t  GetCacheSize() override;
+   Int_t     GetLearnEntries() override;
 
-   void      SetOutputFilePath(const char *fp) { fOutputFilePath = fp; }
-   Int_t     SavePartialResults(Bool_t queryend = kFALSE, Bool_t force = kFALSE);
+   void      SetOutputFilePath(const char *fp) override { fOutputFilePath = fp; }
+   Int_t     SavePartialResults(Bool_t queryend = kFALSE, Bool_t force = kFALSE) override;
 
    void              SetProcessing(Bool_t on = kTRUE);
-   TProofProgressStatus  *GetProgressStatus() const { return fProgressStatus; }
+   TProofProgressStatus  *GetProgressStatus() const override { return fProgressStatus; }
 
-   void      UpdateProgressInfo();
+   void      UpdateProgressInfo() override;
 
-   ClassDef(TProofPlayer,0)  // Basic PROOF player
+   ClassDefOverride(TProofPlayer,0)  // Basic PROOF player
 };
 
 
@@ -237,25 +237,25 @@ private:
    Bool_t   fIsClient;
 
 protected:
-   void SetupFeedback() { }
-   void StopFeedback() { }
+   void SetupFeedback() override { }
+   void StopFeedback() override { }
 
 public:
    TProofPlayerLocal(Bool_t client = kTRUE) : fIsClient(client) { }
-   virtual ~TProofPlayerLocal() { }
+   ~TProofPlayerLocal() override { }
 
-   Bool_t         IsClient() const { return fIsClient; }
+   Bool_t         IsClient() const override { return fIsClient; }
    Long64_t  Process(const char *selector, Long64_t nentries = -1, Option_t *option = "");
    Long64_t  Process(TSelector *selector, Long64_t nentries = -1, Option_t *option = "");
    Long64_t  Process(TDSet *set,
                      const char *selector, Option_t *option = "",
-                     Long64_t nentries = -1, Long64_t firstentry = 0) {
+                     Long64_t nentries = -1, Long64_t firstentry = 0) override {
              return TProofPlayer::Process(set, selector, option, nentries, firstentry); }
    Long64_t  Process(TDSet *set,
                      TSelector *selector, Option_t *option = "",
-                     Long64_t nentries = -1, Long64_t firstentry = 0) {
+                     Long64_t nentries = -1, Long64_t firstentry = 0) override {
              return TProofPlayer::Process(set, selector, option, nentries, firstentry); }
-   ClassDef(TProofPlayerLocal,0)  // PROOF player running on client
+   ClassDefOverride(TProofPlayerLocal,0)  // PROOF player running on client
 };
 
 
@@ -295,7 +295,7 @@ protected:
    TStopwatch         *fMergeSTW;      // Merging stop watch
    Int_t               fNumMergers;    // Number of submergers
 
-   virtual Bool_t  HandleTimer(TTimer *timer);
+   Bool_t  HandleTimer(TTimer *timer) override;
    Int_t           InitPacketizer(TDSet *dset, Long64_t nentries,
                                   Long64_t first, const char *defpackunit,
                                   const char *defpackdata);
@@ -305,8 +305,8 @@ protected:
    void            SetLastMergingMsg(TObject *obj);
    virtual Bool_t  SendSelector(const char *selector_file); //send selector to slaves
    TProof         *GetProof() const { return fProof; }
-   void            SetupFeedback();  // specialized setup
-   void            StopFeedback();   // specialized teardown
+   void            SetupFeedback() override;  // specialized setup
+   void            StopFeedback() override;   // specialized teardown
    void            SetSelectorDataMembersFromOutputList();
 
 public:
@@ -316,54 +316,54 @@ public:
                                            fMergeTH1OneByOne(kTRUE), fProcPackets(0),
                                            fProcessMessage(0), fMergeSTW(0), fNumMergers(0) 
                                            { fProgressStatus = new TProofProgressStatus(); }
-   virtual ~TProofPlayerRemote();   // Owns the fOutput list
-   virtual Long64_t Process(TDSet *set, const char *selector,
+   ~TProofPlayerRemote() override;   // Owns the fOutput list
+   Long64_t Process(TDSet *set, const char *selector,
                             Option_t *option = "", Long64_t nentries = -1,
-                            Long64_t firstentry = 0);
-   virtual Long64_t Process(TDSet *set, TSelector *selector,
+                            Long64_t firstentry = 0) override;
+   Long64_t Process(TDSet *set, TSelector *selector,
                             Option_t *option = "", Long64_t nentries = -1,
-                            Long64_t firstentry = 0);
-   virtual Bool_t JoinProcess(TList *workers);
-   virtual Long64_t Finalize(Bool_t force = kFALSE, Bool_t sync = kFALSE);
-   virtual Long64_t Finalize(TQueryResult *qr);
+                            Long64_t firstentry = 0) override;
+   Bool_t JoinProcess(TList *workers) override;
+   Long64_t Finalize(Bool_t force = kFALSE, Bool_t sync = kFALSE) override;
+   Long64_t Finalize(TQueryResult *qr) override;
    Long64_t       DrawSelect(TDSet *set, const char *varexp,
                              const char *selection, Option_t *option = "",
-                             Long64_t nentries = -1, Long64_t firstentry = 0);
+                             Long64_t nentries = -1, Long64_t firstentry = 0) override;
 
    void           RedirectOutput(Bool_t on = kTRUE);
-   void           StopProcess(Bool_t abort, Int_t timeout = -1);
-   void           StoreOutput(TList *out);   // Adopts the list
-   virtual void   StoreFeedback(TObject *slave, TList *out); // Adopts the list
+   void           StopProcess(Bool_t abort, Int_t timeout = -1) override;
+   void           StoreOutput(TList *out) override;   // Adopts the list
+   void   StoreFeedback(TObject *slave, TList *out) override; // Adopts the list
    Int_t          Incorporate(TObject *obj, TList *out, Bool_t &merged);
    TObject       *HandleHistogram(TObject *obj, Bool_t &merged);
    Bool_t         HistoSameAxis(TH1 *h0, TH1 *h1);
-   Int_t          AddOutputObject(TObject *obj);
-   void           AddOutput(TList *out);   // Incorporate a list
-   virtual void   MergeOutput(Bool_t savememvalues = kFALSE);
-   void           Progress(Long64_t total, Long64_t processed); // *SIGNAL*
-   void           Progress(TSlave*, Long64_t total, Long64_t processed)
+   Int_t          AddOutputObject(TObject *obj) override;
+   void           AddOutput(TList *out) override;   // Incorporate a list
+   void   MergeOutput(Bool_t savememvalues = kFALSE) override;
+   void           Progress(Long64_t total, Long64_t processed) override; // *SIGNAL*
+   void           Progress(TSlave*, Long64_t total, Long64_t processed) override
                      { Progress(total, processed); }
    void           Progress(Long64_t total, Long64_t processed, Long64_t bytesread,
                            Float_t initTime, Float_t procTime,
-                           Float_t evtrti, Float_t mbrti); // *SIGNAL*
+                           Float_t evtrti, Float_t mbrti) override; // *SIGNAL*
    void           Progress(TSlave *, Long64_t total, Long64_t processed, Long64_t bytesread,
                            Float_t initTime, Float_t procTime,
-                           Float_t evtrti, Float_t mbrti)
+                           Float_t evtrti, Float_t mbrti) override
                       { Progress(total, processed, bytesread, initTime, procTime,
                            evtrti, mbrti); } // *SIGNAL*
-   void           Progress(TProofProgressInfo *pi); // *SIGNAL*
-   void           Progress(TSlave *, TProofProgressInfo *pi) { Progress(pi); } // *SIGNAL*
-   void           Feedback(TList *objs); // *SIGNAL*
-   TDSetElement  *GetNextPacket(TSlave *slave, TMessage *r);
-   TVirtualPacketizer *GetPacketizer() const { return fPacketizer; }
+   void           Progress(TProofProgressInfo *pi) override; // *SIGNAL*
+   void           Progress(TSlave *, TProofProgressInfo *pi) override { Progress(pi); } // *SIGNAL*
+   void           Feedback(TList *objs) override; // *SIGNAL*
+   TDSetElement  *GetNextPacket(TSlave *slave, TMessage *r) override;
+   TVirtualPacketizer *GetPacketizer() const override { return fPacketizer; }
 
-   Bool_t         IsClient() const;
+   Bool_t         IsClient() const override;
 
-   void           SetInitTime();
+   void           SetInitTime() override;
 
-   void           SetMerging(Bool_t on = kTRUE);
+   void           SetMerging(Bool_t on = kTRUE) override;
 
-   ClassDef(TProofPlayerRemote,0)  // PROOF player running on master server
+   ClassDefOverride(TProofPlayerRemote,0)  // PROOF player running on master server
 };
 
 
@@ -375,18 +375,18 @@ private:
    TSocket *fSocket;
    TList   *fFeedback;  // List of objects to send updates of
 
-   Bool_t HandleTimer(TTimer *timer);
+   Bool_t HandleTimer(TTimer *timer) override;
 
 protected:
-   void SetupFeedback();
-   void StopFeedback();
+   void SetupFeedback() override;
+   void StopFeedback() override;
 
 public:
    TProofPlayerSlave(TSocket *socket = 0) : fSocket(socket), fFeedback(0) { }
 
-   void  HandleGetTreeHeader(TMessage *mess);
+   void  HandleGetTreeHeader(TMessage *mess) override;
 
-   ClassDef(TProofPlayerSlave,0)  // PROOF player running on slave server
+   ClassDefOverride(TProofPlayerSlave,0)  // PROOF player running on slave server
 };
 
 
@@ -409,37 +409,37 @@ private:
    Bool_t    fReturnFeedback;
 
 protected:
-   Bool_t HandleTimer(TTimer *timer);
-   void   SetupFeedback();
+   Bool_t HandleTimer(TTimer *timer) override;
+   void   SetupFeedback() override;
 
 public:
    TProofPlayerSuperMaster(TProof *proof = 0) :
       TProofPlayerRemote(proof), fReturnFeedback(kFALSE) { }
-   virtual ~TProofPlayerSuperMaster() { }
+   ~TProofPlayerSuperMaster() override { }
 
    Long64_t Process(TDSet *set, const char *selector,
                     Option_t *option = "", Long64_t nentries = -1,
-                    Long64_t firstentry = 0);
+                    Long64_t firstentry = 0) override;
    Long64_t Process(TDSet *set, TSelector *selector,
                     Option_t *option = "", Long64_t nentries = -1,
-                    Long64_t firstentry = 0)
+                    Long64_t firstentry = 0) override
                     { return TProofPlayerRemote::Process(set, selector, option,
                                                          nentries, firstentry); }
-   void  Progress(Long64_t total, Long64_t processed)
+   void  Progress(Long64_t total, Long64_t processed) override
                     { TProofPlayerRemote::Progress(total, processed); }
    void  Progress(Long64_t total, Long64_t processed, Long64_t bytesread,
                   Float_t initTime, Float_t procTime,
-                  Float_t evtrti, Float_t mbrti)
+                  Float_t evtrti, Float_t mbrti) override
                     { TProofPlayerRemote::Progress(total, processed, bytesread,
                                                    initTime, procTime, evtrti, mbrti); }
-   void  Progress(TProofProgressInfo *pi) { TProofPlayerRemote::Progress(pi); }
-   void  Progress(TSlave *sl, Long64_t total, Long64_t processed);
+   void  Progress(TProofProgressInfo *pi) override { TProofPlayerRemote::Progress(pi); }
+   void  Progress(TSlave *sl, Long64_t total, Long64_t processed) override;
    void  Progress(TSlave *sl, Long64_t total, Long64_t processed, Long64_t bytesread,
                   Float_t initTime, Float_t procTime,
-                  Float_t evtrti, Float_t mbrti);
-   void  Progress(TSlave *sl, TProofProgressInfo *pi);
+                  Float_t evtrti, Float_t mbrti) override;
+   void  Progress(TSlave *sl, TProofProgressInfo *pi) override;
 
-   ClassDef(TProofPlayerSuperMaster,0)  // PROOF player running on super master
+   ClassDefOverride(TProofPlayerSuperMaster,0)  // PROOF player running on super master
 };
 
 #endif

--- a/proof/proofplayer/inc/TProofPlayerLite.h
+++ b/proof/proofplayer/inc/TProofPlayerLite.h
@@ -28,29 +28,29 @@
 class TProofPlayerLite : public TProofPlayerRemote {
 
 protected:
-   Bool_t  HandleTimer(TTimer *timer);
+   Bool_t  HandleTimer(TTimer *timer) override;
 
    Int_t   MakeSelector(const char *selfile);
-   void    SetupFeedback();
+   void    SetupFeedback() override;
 
 public:
    TProofPlayerLite(TProof *proof = 0) : TProofPlayerRemote(proof) { }
 
-   virtual ~TProofPlayerLite() { }   // Owns the fOutput list
+   ~TProofPlayerLite() override { }   // Owns the fOutput list
 
    Long64_t       Process(TDSet *set, const char *selector,
                           Option_t *option = "", Long64_t nentries = -1,
-                          Long64_t firstentry = 0);
+                          Long64_t firstentry = 0) override;
    Long64_t       Process(TDSet *set, TSelector *selector,
                           Option_t *option = "", Long64_t nentries = -1,
-                          Long64_t firstentry = 0);
-   Long64_t       Finalize(Bool_t force = kFALSE, Bool_t sync = kFALSE);
-   Long64_t       Finalize(TQueryResult *qr)
+                          Long64_t firstentry = 0) override;
+   Long64_t       Finalize(Bool_t force = kFALSE, Bool_t sync = kFALSE) override;
+   Long64_t       Finalize(TQueryResult *qr) override
                             { return TProofPlayerRemote::Finalize(qr); }
 
-   void           StoreFeedback(TObject *slave, TList *out); // Adopts the list
+   void           StoreFeedback(TObject *slave, TList *out) override; // Adopts the list
 
-   ClassDef(TProofPlayerLite,0)  // PROOF player running in PROOF-Lite
+   ClassDefOverride(TProofPlayerLite,0)  // PROOF player running in PROOF-Lite
 };
 
 #endif

--- a/proof/proofplayer/inc/TStatsFeedback.h
+++ b/proof/proofplayer/inc/TStatsFeedback.h
@@ -35,13 +35,13 @@ protected:
    TProof        *fProof;  //handle to PROOF session
 public:
    TStatsFeedback(TProof *proof = 0);
-   ~TStatsFeedback();
+   ~TStatsFeedback() override;
 
    void        Feedback(TList *objs);
-   const char *GetName() const { return fName.Data(); }
-   ULong_t     Hash() const { return fName.Hash(); }
+   const char *GetName() const override { return fName.Data(); }
+   ULong_t     Hash() const override { return fName.Hash(); }
 
-   ClassDef(TStatsFeedback,0)  // Present PROOF query feedback
+   ClassDefOverride(TStatsFeedback,0)  // Present PROOF query feedback
 };
 
 #endif

--- a/proof/proofplayer/inc/TStatus.h
+++ b/proof/proofplayer/inc/TStatus.h
@@ -49,13 +49,13 @@ private:
 
 public:
    TStatus();
-   virtual ~TStatus() { }
+   ~TStatus() override { }
 
    inline Bool_t  IsOk() const { return TestBit(kNotOk) ? kFALSE : kTRUE; }
    void           Add(const char *mesg);
    void           AddInfo(const char *mesg);
    virtual Int_t  Merge(TCollection *list);
-   virtual void   Print(Option_t *option="") const;
+   void   Print(Option_t *option="") const override;
    void           Reset();
    const char    *NextMesg();
 
@@ -66,7 +66,7 @@ public:
    void           SetExitStatus(Int_t est) { fExitStatus = est; }
    void           SetMemValues(Long_t vmem = -1, Long_t rmem = -1, Bool_t master = kFALSE);
 
-   ClassDef(TStatus,5);  // Status class
+   ClassDefOverride(TStatus,5);  // Status class
 };
 
 #endif

--- a/proof/proofplayer/src/TOutputListSelectorDataMap.cxx
+++ b/proof/proofplayer/src/TOutputListSelectorDataMap.cxx
@@ -44,7 +44,7 @@ namespace {
    public:
       TSetSelDataMembers(const TOutputListSelectorDataMap& owner, TCollection* dmInfo, TList* output);
       using TMemberInspector::Inspect;
-      void Inspect(TClass *cl, const char *parent, const char *name, const void *addr, Bool_t isTransient);
+      void Inspect(TClass *cl, const char *parent, const char *name, const void *addr, Bool_t isTransient) override;
       Ssiz_t GetNumSet() const { return fNumSet; }
    private:
       TCollection* fDMInfo; // output list object name / member name pairs for output list entries
@@ -116,9 +116,9 @@ namespace {
    class TCollectDataMembers: public TMemberInspector {
    public:
       TCollectDataMembers(const TOutputListSelectorDataMap& owner): fOwner(owner) { }
-      ~TCollectDataMembers();
+      ~TCollectDataMembers() override;
       using TMemberInspector::Inspect;
-      void Inspect(TClass *cl, const char *parent, const char *name, const void *addr, Bool_t isTransient);
+      void Inspect(TClass *cl, const char *parent, const char *name, const void *addr, Bool_t isTransient) override;
       TExMap& GetMemberPointers() { return fMap; }
    private:
       TExMap fMap; //map of data member's value to TDataMember

--- a/proof/proofplayer/src/TPacketizer.cxx
+++ b/proof/proofplayer/src/TPacketizer.cxx
@@ -103,16 +103,16 @@ private:
 
 public:
    TFileNode(const char *name);
-   ~TFileNode() { delete fFiles; delete fActFiles; }
+   ~TFileNode() override { delete fFiles; delete fActFiles; }
 
    void        IncMySlaveCnt() { fMySlaveCnt++; }
    void        IncSlaveCnt(const char *slave) { if (fNodeName != slave) fSlaveCnt++; }
    void        DecSlaveCnt(const char *slave) { if (fNodeName != slave) fSlaveCnt--; R__ASSERT(fSlaveCnt >= 0); }
    Int_t       GetSlaveCnt() const {return fMySlaveCnt + fSlaveCnt;}
    Int_t       GetNumberOfActiveFiles() const { return fActFiles->GetSize(); }
-   Bool_t      IsSortable() const { return kTRUE; }
+   Bool_t      IsSortable() const override { return kTRUE; }
 
-   const char *GetName() const { return fNodeName.Data(); }
+   const char *GetName() const override { return fNodeName.Data(); }
 
    void Add(TDSetElement *elem)
    {
@@ -156,7 +156,7 @@ public:
       if (fActFileNext == 0) fActFileNext = fActFiles->First();
    }
 
-   Int_t Compare(const TObject *other) const
+   Int_t Compare(const TObject *other) const override
    {
       // Must return -1 if this is smaller than obj, 0 if objects are equal
       // and 1 if this is larger than obj.
@@ -177,7 +177,7 @@ public:
       }
    }
 
-   void Print(Option_t *) const
+   void Print(Option_t *) const override
    {
       std::cout << "OBJ: " << IsA()->GetName() << "\t" << fNodeName
            << "\tMySlaveCount " << fMySlaveCnt
@@ -216,10 +216,10 @@ private:
    TFileNode     *fFileNode;     // corresponding node or 0
    TFileStat     *fCurFile;      // file currently being processed
    TDSetElement  *fCurElem;      // TDSetElement currently being processed
-   TProofProgressStatus *AddProcessed(TProofProgressStatus *st);
+   TProofProgressStatus *AddProcessed(TProofProgressStatus *st) override;
 public:
    TSlaveStat(TSlave *slave);
-   ~TSlaveStat();
+   ~TSlaveStat() override;
 
    TFileNode  *GetFileNode() const { return fFileNode; }
 

--- a/proof/proofplayer/src/TPacketizerAdaptive.cxx
+++ b/proof/proofplayer/src/TPacketizerAdaptive.cxx
@@ -84,7 +84,7 @@ public:
    TFileStat(TFileNode *node, TDSetElement *elem, TList *file);
 
    Bool_t         IsDone() const {return fIsDone;}
-   Bool_t         IsSortable() const { return kTRUE; }
+   Bool_t         IsSortable() const override { return kTRUE; }
    void           SetDone() {fIsDone = kTRUE;}
    TFileNode     *GetNode() const {return fNode;}
    TDSetElement  *GetElement() const {return fElement;}
@@ -92,7 +92,7 @@ public:
    void           MoveNextEntry(Long64_t step) {fNextEntry += step;}
 
    // This method is used to keep a sorted list of remaining files to be processed
-   Int_t          Compare(const TObject* obj) const
+   Int_t          Compare(const TObject* obj) const override
    {
       // Return -1 if elem.entries < obj.elem.entries, 0 if elem.entries equal
       // and 1 if elem.entries < obj.elem.entries.
@@ -113,7 +113,7 @@ public:
       // No info: assume equal (no change in order)
       return 0;
    }
-   void Print(Option_t * = 0) const
+   void Print(Option_t * = 0) const override
    {  // Notify file name and entries
       Printf("TFileStat: %s %lld", fElement ? fElement->GetName() : "---",
                                    fElement ? fElement->GetNum() : -1);
@@ -153,7 +153,7 @@ private:
 
 public:
    TFileNode(const char *name, Int_t strategy, TSortedList *files);
-   ~TFileNode() { delete fFiles; delete fActFiles; }
+   ~TFileNode() override { delete fFiles; delete fActFiles; }
 
    void        IncMySlaveCnt() { fMySlaveCnt++; }
    Int_t       GetMySlaveCnt() const { return fMySlaveCnt; }
@@ -165,7 +165,7 @@ public:
    Int_t       GetRunSlaveCnt() const { return fRunSlaveCnt; }
    Int_t       GetExtSlaveCnt() const { return fExtSlaveCnt; }
    Int_t       GetNumberOfActiveFiles() const { return fActFiles->GetSize(); }
-   Bool_t      IsSortable() const { return kTRUE; }
+   Bool_t      IsSortable() const override { return kTRUE; }
    Int_t       GetNumberOfFiles() { return fFiles->GetSize(); }
    void        IncProcessed(Long64_t nEvents)
                   { fProcessed += nEvents; }
@@ -176,10 +176,10 @@ public:
    Long64_t    GetEventsLeftPerSlave() const
       { return ((fEvents - fProcessed)/(fRunSlaveCnt + 1)); }
    void        IncEvents(Long64_t nEvents) { fEvents += nEvents; }
-   const char *GetName() const { return fNodeName.Data(); }
+   const char *GetName() const override { return fNodeName.Data(); }
    Long64_t    GetNEvents() const { return fEvents; }
 
-   void Print(Option_t * = 0) const
+   void Print(Option_t * = 0) const override
    {
       TFileStat *fs = 0;
       TDSetElement *e = 0;
@@ -258,7 +258,7 @@ public:
       if (fActFileNext == 0) fActFileNext = fActFiles->First();
    }
 
-   Int_t Compare(const TObject *other) const
+   Int_t Compare(const TObject *other) const override
    {
       // Must return -1 if this is smaller than obj, 0 if objects are equal
       // and 1 if this is larger than obj.
@@ -344,7 +344,7 @@ private:
 
 public:
    TSlaveStat(TSlave *slave);
-   ~TSlaveStat();
+   ~TSlaveStat() override;
    TFileNode  *GetFileNode() const { return fFileNode; }
    Long64_t    GetEntriesProcessed() const { return fStatus?fStatus->GetEntries():-1; }
    Double_t    GetProcTime() const { return fStatus?fStatus->GetProcTime():-1; }
@@ -358,7 +358,7 @@ public:
       return fFileNode?(fFileNode->GetEventsLeftPerSlave()):0; }
    TList      *GetProcessedSubSet() { return fDSubSet; }
    TProofProgressStatus *GetProgressStatus() { return fStatus; }
-   TProofProgressStatus *AddProcessed(TProofProgressStatus *st = 0);
+   TProofProgressStatus *AddProcessed(TProofProgressStatus *st = 0) override;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/proof/proofplayer/src/TPacketizerFile.cxx
+++ b/proof/proofplayer/src/TPacketizerFile.cxx
@@ -62,12 +62,12 @@ private:
 
 public:
    TSlaveStat(TSlave *sl, TList *input);
-   ~TSlaveStat();
+   ~TSlaveStat() override;
 
    void        GetCurrentTime();
 
    void        UpdatePerformance(Double_t time);
-   TProofProgressStatus *AddProcessed(TProofProgressStatus *st);
+   TProofProgressStatus *AddProcessed(TProofProgressStatus *st) override;
 };
 
 // Iterator wrapper
@@ -79,11 +79,11 @@ private:
 
 public:
    TIterObj(const char *n, TIter *iter) : fName(n), fIter(iter) { }
-   virtual ~TIterObj() { if (fIter) delete fIter; }
+   ~TIterObj() override { if (fIter) delete fIter; }
 
-   const char *GetName() const {return fName;}
+   const char *GetName() const override {return fName;}
    TIter      *GetIter() const {return fIter;}
-   void        Print(Option_t* option = "") const;
+   void        Print(Option_t* option = "") const override;
 };
 
 ClassImp(TPacketizerFile);

--- a/proof/proofplayer/src/TPacketizerUnit.cxx
+++ b/proof/proofplayer/src/TPacketizerUnit.cxx
@@ -73,14 +73,14 @@ private:
 
 public:
    TSlaveStat(TSlave *sl, TList *input);
-   ~TSlaveStat();
+   ~TSlaveStat() override;
 
 //   void        GetCurrentTime();
 
    void        UpdatePerformance(Double_t time);
-   TProofProgressStatus *AddProcessed(TProofProgressStatus *st);
+   TProofProgressStatus *AddProcessed(TProofProgressStatus *st) override;
 
-//   ClassDef(TPacketizerUnit::TSlaveStat, 0);
+//   ClassDefOverride(TPacketizerUnit::TSlaveStat, 0);
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/proof/proofplayer/src/TProofPlayer.cxx
+++ b/proof/proofplayer/src/TProofPlayer.cxx
@@ -116,7 +116,7 @@ private:
 public:
    TDispatchTimer(TProofPlayer *p) : TTimer(1000, kFALSE), fPlayer(p) { }
 
-   Bool_t Notify();
+   Bool_t Notify() override;
 };
 ////////////////////////////////////////////////////////////////////////////////
 /// Handle expiration of the timer associated with dispatching pending
@@ -145,7 +145,7 @@ private:
 public:
    TProctimeTimer(TProofPlayer *p, Long_t to) : TTimer(to, kFALSE), fPlayer(p) { }
 
-   Bool_t Notify();
+   Bool_t Notify() override;
 };
 ////////////////////////////////////////////////////////////////////////////////
 /// Handle expiration of the timer associated with dispatching pending
@@ -174,7 +174,7 @@ private:
 public:
    TStopTimer(TProofPlayer *p, Bool_t abort, Int_t to);
 
-   Bool_t Notify();
+   Bool_t Notify() override;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/proof/proofx/inc/TXHandler.h
+++ b/proof/proofx/inc/TXHandler.h
@@ -34,7 +34,7 @@ public:
    virtual Bool_t HandleInput(const void *in = 0);
    virtual Bool_t HandleError(const void *in = 0);
 
-   ClassDef(TXHandler, 0) //Template class for handling of async events
+   ClassDefOverride(TXHandler, 0) //Template class for handling of async events
 };
 
 #endif

--- a/proof/proofx/inc/TXProofMgr.h
+++ b/proof/proofx/inc/TXProofMgr.h
@@ -52,48 +52,48 @@ private:
 
 public:
    TXProofMgr(const char *url, Int_t loglevel = -1, const char *alias = "");
-   virtual ~TXProofMgr();
+   ~TXProofMgr() override;
 
-   Bool_t      HandleInput(const void *);
-   Bool_t      HandleError(const void *in = 0);
+   Bool_t      HandleInput(const void *) override;
+   Bool_t      HandleError(const void *in = 0) override;
 
-   Bool_t      IsValid() const { return fSocket; }
-   void        SetInvalid();
+   Bool_t      IsValid() const override { return fSocket; }
+   void        SetInvalid() override;
 
-   TProof     *AttachSession(Int_t id, Bool_t gui = kFALSE)
+   TProof     *AttachSession(Int_t id, Bool_t gui = kFALSE) override
                       { return TProofMgr::AttachSession(id, gui); }
-   TProof     *AttachSession(TProofDesc *d, Bool_t gui = kFALSE);
-   void        DetachSession(Int_t, Option_t * = "");
-   void        DetachSession(TProof *, Option_t * = "");
-   const char *GetMssUrl(Bool_t = kFALSE);
+   TProof     *AttachSession(TProofDesc *d, Bool_t gui = kFALSE) override;
+   void        DetachSession(Int_t, Option_t * = "") override;
+   void        DetachSession(TProof *, Option_t * = "") override;
+   const char *GetMssUrl(Bool_t = kFALSE) override;
    TProofLog  *GetSessionLogs(Int_t ridx = 0, const char *stag = 0,
                               const char *pattern = "-v \"| SvcMsg\"",
-                              Bool_t rescan = kFALSE);
-   Bool_t      MatchUrl(const char *url);
-   void        ShowROOTVersions();
-   TList      *QuerySessions(Option_t *opt = "S");
-   TObjString *ReadBuffer(const char *file, Long64_t ofs, Int_t len);
-   TObjString *ReadBuffer(const char *file, const char *pattern);
-   Int_t       Reset(Bool_t hard = kFALSE, const char *usr = 0);
-   Int_t       SendMsgToUsers(const char *msg, const char *usr = 0);
-   Int_t       SetROOTVersion(const char *tag);
-   void        ShowWorkers();
+                              Bool_t rescan = kFALSE) override;
+   Bool_t      MatchUrl(const char *url) override;
+   void        ShowROOTVersions() override;
+   TList      *QuerySessions(Option_t *opt = "S") override;
+   TObjString *ReadBuffer(const char *file, Long64_t ofs, Int_t len) override;
+   TObjString *ReadBuffer(const char *file, const char *pattern) override;
+   Int_t       Reset(Bool_t hard = kFALSE, const char *usr = 0) override;
+   Int_t       SendMsgToUsers(const char *msg, const char *usr = 0) override;
+   Int_t       SetROOTVersion(const char *tag) override;
+   void        ShowWorkers() override;
 
    // Remote file system actions
-   Int_t       Cp(const char *src, const char *dst = 0, const char *opts = 0);
-   void        Find(const char *what = "~/", const char *how = "-type f", const char *where = 0);
-   void        Grep(const char *what, const char *how = 0, const char *where = 0);
-   void        Ls(const char *what = "~/", const char *how = 0, const char *where = 0);
-   void        More(const char *what, const char *how = 0, const char *where = 0);
-   Int_t       Rm(const char *what, const char *how = 0, const char *where = 0);
-   void        Tail(const char *what, const char *how = 0, const char *where = 0);
-   Int_t       Md5sum(const char *what, TString &sum, const char *where = 0);
-   Int_t       Stat(const char *what, FileStat_t &st, const char *where = 0);
+   Int_t       Cp(const char *src, const char *dst = 0, const char *opts = 0) override;
+   void        Find(const char *what = "~/", const char *how = "-type f", const char *where = 0) override;
+   void        Grep(const char *what, const char *how = 0, const char *where = 0) override;
+   void        Ls(const char *what = "~/", const char *how = 0, const char *where = 0) override;
+   void        More(const char *what, const char *how = 0, const char *where = 0) override;
+   Int_t       Rm(const char *what, const char *how = 0, const char *where = 0) override;
+   void        Tail(const char *what, const char *how = 0, const char *where = 0) override;
+   Int_t       Md5sum(const char *what, TString &sum, const char *where = 0) override;
+   Int_t       Stat(const char *what, FileStat_t &st, const char *where = 0) override;
 
-   Int_t       GetFile(const char *remote, const char *local, const char *opt = 0);
-   Int_t       PutFile(const char *local, const char *remote, const char *opt = 0);
+   Int_t       GetFile(const char *remote, const char *local, const char *opt = 0) override;
+   Int_t       PutFile(const char *local, const char *remote, const char *opt = 0) override;
 
-   ClassDef(TXProofMgr,0)  // XrdProofd PROOF manager interface
+   ClassDefOverride(TXProofMgr,0)  // XrdProofd PROOF manager interface
 };
 
 #endif

--- a/proof/proofx/inc/TXProofServ.h
+++ b/proof/proofx/inc/TXProofServ.h
@@ -38,32 +38,32 @@ private:
 
    Int_t         LockSession(const char *sessiontag, TProofLockPath **lck);
 
-   Int_t         Setup();
+   Int_t         Setup() override;
 
 public:
    TXProofServ(Int_t *argc, char **argv, FILE *flog = 0);
-   virtual ~TXProofServ();
+   ~TXProofServ() override;
 
-   Int_t         CreateServer();
+   Int_t         CreateServer() override;
 
    // Disable / Enable read timeout
-   void          DisableTimeout();
-   void          EnableTimeout();
+   void          DisableTimeout() override;
+   void          EnableTimeout() override;
 
    EQueryAction  GetWorkers(TList *workers, Int_t &prioritychange,
-                            Bool_t resume = kFALSE);
+                            Bool_t resume = kFALSE) override;
 
-   Bool_t        HandleError(const void *in = 0); // Error Handler
-   Bool_t        HandleInput(const void *in = 0); // Input handler
+   Bool_t        HandleError(const void *in = 0) override; // Error Handler
+   Bool_t        HandleInput(const void *in = 0) override; // Input handler
 
-   void          HandleUrgentData();
-   void          HandleSigPipe();
-   void          HandleTermination();
+   void          HandleUrgentData() override;
+   void          HandleSigPipe() override;
+   void          HandleTermination() override;
 
-   void          ReleaseWorker(const char *ord);
-   void          Terminate(Int_t status);
+   void          ReleaseWorker(const char *ord) override;
+   void          Terminate(Int_t status) override;
 
-   ClassDef(TXProofServ,0)  //XRD PROOF Server Application Interface
+   ClassDefOverride(TXProofServ,0)  //XRD PROOF Server Application Interface
 };
 
 #endif

--- a/proof/proofx/inc/TXSlave.h
+++ b/proof/proofx/inc/TXSlave.h
@@ -46,34 +46,34 @@ private:
    static Int_t GetProofdProtocol(TSocket *s);
 
 protected:
-   void     FlushSocket();
-   void     Interrupt(Int_t type);
-   Int_t    Ping();
-   TObjString *SendCoordinator(Int_t kind, const char *msg = 0, Int_t int2 = 0);
-   Int_t    SendGroupPriority(const char *grp, Int_t priority);
-   void     SetAlias(const char *alias);
-   void     StopProcess(Bool_t abort, Int_t timeout);
+   void     FlushSocket() override;
+   void     Interrupt(Int_t type) override;
+   Int_t    Ping() override;
+   TObjString *SendCoordinator(Int_t kind, const char *msg = 0, Int_t int2 = 0) override;
+   Int_t    SendGroupPriority(const char *grp, Int_t priority) override;
+   void     SetAlias(const char *alias) override;
+   void     StopProcess(Bool_t abort, Int_t timeout) override;
 
 public:
    TXSlave(const char *url, const char *ord, Int_t perf,
            const char *image, TProof *proof, Int_t stype,
            const char *workdir, const char *msd, Int_t nwk = 1);
-   virtual ~TXSlave();
+   ~TXSlave() override;
 
-   void   Close(Option_t *opt = "");
+   void   Close(Option_t *opt = "") override;
    void   DoError(int level, const char *location, const char *fmt,
-                  va_list va) const;
+                  va_list va) const override;
 
-   Bool_t HandleError(const void *in = 0); // Error Handler
-   Bool_t HandleInput(const void *in = 0); // Input handler
+   Bool_t HandleError(const void *in = 0) override; // Error Handler
+   Bool_t HandleInput(const void *in = 0) override; // Input handler
 
-   void   SetInterruptHandler(Bool_t on = kTRUE);
+   void   SetInterruptHandler(Bool_t on = kTRUE) override;
 
-   Int_t  SetupServ(Int_t stype, const char *conffile);
+   Int_t  SetupServ(Int_t stype, const char *conffile) override;
 
-   void   Touch();
+   void   Touch() override;
 
-   ClassDef(TXSlave,0)  //Xrd PROOF slave server
+   ClassDefOverride(TXSlave,0)  //Xrd PROOF slave server
 };
 
 #endif

--- a/proof/proofx/inc/TXSocket.h
+++ b/proof/proofx/inc/TXSocket.h
@@ -230,7 +230,7 @@ public:
    // Try reconnection after error
    virtual Int_t       Reconnect();
 
-   ClassDef(TXSocket, 0) //A high level connection class for PROOF
+   ClassDefOverride(TXSocket, 0) //A high level connection class for PROOF
 };
 
 

--- a/proof/proofx/inc/TXSocketHandler.h
+++ b/proof/proofx/inc/TXSocketHandler.h
@@ -48,7 +48,7 @@ public:
 
    static TXSocketHandler *GetSocketHandler(TFileHandler *h = 0, TSocket *s = 0);
 
-   ClassDef(TXSocketHandler, 0) //Input handler class for xproofd sockets
+   ClassDefOverride(TXSocketHandler, 0) //Input handler class for xproofd sockets
 };
 
 #endif

--- a/proof/proofx/inc/TXUnixSocket.h
+++ b/proof/proofx/inc/TXUnixSocket.h
@@ -47,7 +47,7 @@ public:
    // Try reconnection after error
    Int_t Reconnect();
 
-   ClassDef(TXUnixSocket, 0) //Connection class for Xrd PROOF using UNIX sockets
+   ClassDefOverride(TXUnixSocket, 0) //Connection class for Xrd PROOF using UNIX sockets
 };
 
 #endif


### PR DESCRIPTION
This commit only contains changes that were automatically generated by `clang-tidy`, plus replacing `ClassDef` with `ClassDefOverride` where appropriate.

Several directories in the ROOT repo were already treated like this.
