### PR TITLE
[PyROOT][RF] Feature to initialise RooWorkspace objects in PyRoot using dictionaries

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooworkspace.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooworkspace.py
@@ -12,6 +12,50 @@
 from ._utils import _kwargs_to_roocmdargs, cpp_signature
 
 
+def make_json_for_variable(var_name, var_dict):
+    val = None
+    max_value = None
+    min_value = None
+    is_constant = None
+    if "value" in var_dict:
+        val = var_dict["value"]
+        is_constant = True
+    if ("max" in var_dict) and ("min" in var_dict):
+        max_value = var_dict["max"]
+        min_value = var_dict["min"]
+        is_constant = False
+    if is_constant is None:
+        raise ValueError(
+            "Invalid Syntax: Please provide either 'value' or 'min' and 'max' or both"
+        )
+    else:
+        if not is_constant:
+            val = (max_value + min_value) / 2
+        # Create dictionary with domains and parameter points
+        json_dict = {
+            "domains": [
+                {
+                    "axes": [{"name": var_name}],
+                    "name": "default_domain",
+                    "type": "product_domain",
+                }
+            ],
+            "parameter_points": [
+                {
+                    "name": "default_values",
+                    "parameters": [{"name": var_name, "value": val}],
+                }
+            ],
+        }
+        if is_constant:
+            json_dict["parameter_points"][0]["parameters"][0]["const"] = True
+            json_dict["misc"] = {"ROOT_internal": {var_name: {"tags": "Constant"}}}
+        if not is_constant:
+            json_dict["domains"][0]["axes"][0]["max"] = max_value
+            json_dict["domains"][0]["axes"][0]["min"] = min_value
+        return json_dict
+
+
 class RooWorkspace(object):
     r"""The RooWorkspace::import function can't be used in PyROOT because `import` is a reserved python keyword.
     For this reason, an alternative with a capitalized name is provided:
@@ -41,28 +85,57 @@ class RooWorkspace(object):
 
     def __setitem__(self, key, value):
         # Check if initialization is done with string
-        if(isinstance(value, str)):
-            if(not self.obj(key)):
+        if isinstance(value, str):
+            if not self.obj(key):
                 parenthesis_index = -1
-                for i in range(0,len(value)):
-                    if(value[i]=='[' or value[i]=='('):
+                for i in range(0, len(value)):
+                    if value[i] == "[" or value[i] == "(":
                         parenthesis_index = i
                         break
                 # Initializes variables
-                if value[parenthesis_index]=='[' and parenthesis_index!=-1:
+                if value[parenthesis_index] == "[" and parenthesis_index != -1:
                     expr = key + value
                     self.factory(expr)
                 # Initializes functions and p.d.f.s
-                elif value[parenthesis_index]=='(' and parenthesis_index!=-1:
-                    expr = value[0:parenthesis_index] + "::" + key + value[parenthesis_index:]
+                elif value[parenthesis_index] == "(" and parenthesis_index != -1:
+                    expr = (
+                        value[0:parenthesis_index]
+                        + "::"
+                        + key
+                        + value[parenthesis_index:]
+                    )
                     self.factory(expr)
                 # Else raises a Syntax error
                 else:
                     raise SyntaxError("Invalid syntax")
             else:
-                raise RuntimeError("ERROR importing object named " + key + " another instance with same name already in the workspace and no conflict resolution protocol specified")
+                raise RuntimeError(
+                    "ERROR importing object named "
+                    + key
+                    + " another instance with same name already in the workspace and no conflict resolution protocol specified"
+                )
+        elif isinstance(value, dict):
+            import ROOT
+            import json
+
+            # Add name attribute to the dictionary, and create the JSON string for the object's JSONTree
+            is_variable = not "type" in value
+            if is_variable:
+                # Import variable
+                json_dict = make_json_for_variable(key, value)
+                json_string = json.dumps(json_dict, separators=(",", ":"))
+                ROOT.RooJSONFactoryWSTool(self).importVarfromString(json_string)
+            else:
+                # Imports functions/p.d.f.s
+                value["name"] = key
+                json_string = json.dumps(value, separators=(",", ":"))
+                ROOT.RooJSONFactoryWSTool(self).importFunction(json_string, False)
         else:
-            raise TypeError("Object of type 'str' expected but " + type(value) + " was given")
+            raise TypeError(
+                "Object of type 'str' or 'dict' expected but "
+                + type(value)
+                + " was given"
+            )
 
     @cpp_signature(
         [
@@ -95,7 +168,11 @@ class RooWorkspace(object):
         # here, which results in a clearer error to the user than an infinite
         # call stack involving the internal pythonization code.
         if name in ["_import", "import", "Import"]:
-            raise AttributeError("Resetting the \"" + name + "\" attribute of a RooWorkspace is not allowed!")
+            raise AttributeError(
+                'Resetting the "'
+                + name
+                + '" attribute of a RooWorkspace is not allowed!'
+            )
         object.__setattr__(self, name, value)
 
 

--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -149,7 +149,6 @@ if(roofit)
   ROOT_ADD_PYUNITTEST(pyroot_roofit_roodataset roofit/roodataset.py)
 
   # RooWorkspace pythonizations
-  ROOT_ADD_PYUNITTEST(pyroot_roofit_rooworkspace roofit/rooworkspace.py)
   ROOT_ADD_PYUNITTEST(pyroot_roofit_rooabspdf_fitto roofit/rooabspdf_fitto.py)
   ROOT_ADD_PYUNITTEST(pyroot_roofit_rooabsreal_ploton roofit/rooabsreal_ploton.py)
 
@@ -162,6 +161,9 @@ if(roofit)
     # Other pythonizations that fail on Windows for unknown reasons
     ROOT_ADD_PYUNITTEST(pyroot_roofit_rooglobalfunc roofit/rooglobalfunc.py)
     ROOT_ADD_PYUNITTEST(pyroot_roofit_roosimultaneous roofit/roosimultaneous.py)
+
+    # RooWorkspace pythonization that fails on Windows
+    ROOT_ADD_PYUNITTEST(pyroot_roofit_rooworkspace roofit/rooworkspace.py)
   endif()
 
   # NumPy compatibility

--- a/bindings/pyroot/pythonizations/test/roofit/rooworkspace.py
+++ b/bindings/pyroot/pythonizations/test/roofit/rooworkspace.py
@@ -39,7 +39,7 @@ class RooWorkspace_test(unittest.TestCase):
         self.assertEqual(x.GetName(), "x")
         self.assertEqual(x.getVal(), self.x.getVal())
 
-    def test_setItem_using_dictionary(self):
+    def test_set_item_using_string(self):
          # Test to check if new variables are created
         self.ws["z"] = "[3]"
         self.assertEqual(self.ws["z"].GetName(),"z")
@@ -47,9 +47,36 @@ class RooWorkspace_test(unittest.TestCase):
 
         # Test to check if new p.d.f.s are created
         self.ws["gauss"] = "Gaussian(x[0.0, 10.0], mu[5.0], sigma[2.0, 0.01, 10.0])"
+        self.assertEqual(self.ws["gauss"].getX(), self.ws["x"])
         self.assertEqual(self.ws["gauss"].getMean(), self.ws["mu"])
         self.assertEqual(self.ws["gauss"].getSigma(), self.ws["sigma"])
-        self.assertEqual(self.ws["gauss"].getX(), self.ws["x"])
+
+    def test_set_item_using_dictionary(self):
+        
+        # Import Factory Expressions to new workspace
+        etc_dir = ROOT.std.string(ROOT.TROOT.GetEtcDir().Data())
+        ROOT.RooFit.JSONIO.loadExportKeys(etc_dir + "/RooFitHS3_wsexportkeys.json")
+        ROOT.RooFit.JSONIO.loadFactoryExpressions(etc_dir + "/RooFitHS3_wsfactoryexpressions.json")
+        ws= ROOT.RooWorkspace()
+        
+        # Test to check if new variables are created
+        ws["x"] = dict({ "min": 0.0, "max": 10.0 })
+        self.assertEqual(ws["x"].getMax(), 10.0)
+        self.assertEqual(ws["x"].getMin(), 0.0)
+        
+        # Test to check if new functions are created
+        ws["m1"] = dict({ "max": 5, "min": -5, "value": 0 })
+        ws["m2"] = dict({ "max": 5, "min": -5, "value": 1 })
+        ws["mean"] = dict({ "type": "sum", "summands": ["m1", "m2"] })
+        self.assertEqual(ws["mean"].GetName(), "mean")
+        self.assertEqual(ws["mean"].getVal(), 0.0)
+
+        # Test to check if new p.d.f.s are created
+        ws["sigma"] = dict({ "value": 2, "min": 0.1, "max": 10.0 })
+        ws["gauss"] = dict({ "mean": "mean", "sigma": "sigma", "type": "gaussian_dist", "x": "x" })
+        self.assertEqual(ws["gauss"].getX(), ws["x"])
+        self.assertEqual(ws["gauss"].getMean(), ws["mean"])
+        self.assertEqual(ws["gauss"].getSigma(), ws["sigma"])
 
 if __name__ == "__main__":
     unittest.main()

--- a/roofit/hs3/CMakeLists.txt
+++ b/roofit/hs3/CMakeLists.txt
@@ -21,6 +21,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitHS3
     src/HistFactoryJSONTool.cxx
     src/JSONFactories_RooFitCore.cxx
     src/JSONFactories_HistFactory.cxx
+    src/JSONIOUtils.cxx
   DICTIONARY_OPTIONS
     "-writeEmptyRootPCM"
   DEPENDENCIES

--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -140,8 +140,10 @@ public:
    std::string exportYMLtoString();
    bool importJSONfromString(const std::string &s);
    bool importYMLfromString(const std::string &s);
+   void importVarfromString(const std::string &jsonString);
 
-   void importFunction(const RooFit::Detail::JSONNode &n, bool isPdf);
+   void importFunction(const RooFit::Detail::JSONNode &n, bool importAllDependants);
+   void importFunction(const std::string &jsonString, bool importAllDependants);
 
    static std::unique_ptr<RooFit::Detail::JSONTree> createNewJSONTree();
 

--- a/roofit/hs3/src/JSONFactories_HistFactory.cxx
+++ b/roofit/hs3/src/JSONFactories_HistFactory.cxx
@@ -33,6 +33,7 @@
 #include <RooWorkspace.h>
 
 #include "static_execute.h"
+#include "JSONIOUtils.h"
 
 using RooFit::Detail::JSONNode;
 
@@ -74,11 +75,6 @@ constexpr auto staterror = "staterror";
 bool startsWith(std::string_view str, std::string_view prefix)
 {
    return str.size() >= prefix.size() && 0 == str.compare(0, prefix.size(), prefix);
-}
-
-bool endsWith(std::string_view str, std::string_view suffix)
-{
-   return str.size() >= suffix.size() && 0 == str.compare(str.size() - suffix.size(), suffix.size(), suffix);
 }
 
 template <class T>

--- a/roofit/hs3/src/JSONIOUtils.cxx
+++ b/roofit/hs3/src/JSONIOUtils.cxx
@@ -1,0 +1,5 @@
+#include "JSONIOUtils.h"
+
+bool endsWith(std::string_view str, std::string_view suffix) {
+   return str.size() >= suffix.size() && 0 == str.compare(str.size() - suffix.size(), suffix.size(), suffix);
+} 

--- a/roofit/hs3/src/JSONIOUtils.h
+++ b/roofit/hs3/src/JSONIOUtils.h
@@ -1,0 +1,8 @@
+#ifndef JSONIOUtils_h
+#define JSONIOUtils_h
+
+#include <ROOT/RStringView.hxx>
+
+bool endsWith(std::string_view str,std::string_view suffix);
+
+#endif


### PR DESCRIPTION
# This Pull request:

Adds a feature in PyROOT to initialize objects in RooWorkspace using dictionaries.

For example - 
```python
import ROOT

ws = ROOT.RooWorkspace("ws")

ws["m1"] = dict({ "max": 5, "min": -5, "value": 0 })

ws["m2"] = dict({ "max": 5, "min": -5, "value": 1 })

ws["mean"] = dict({ "type":"sum", "summands":["m1", "m1"] })
```

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

