### PR TITLE
[ntuple] Add importer option for converting dots in branch names

### DIFF
--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -222,6 +222,10 @@ private:
    std::unique_ptr<TFile> fDestFile;
    RNTupleWriteOptions fWriteOptions;
 
+   /// Whether or not dot characters in branch names should be converted to underscores. If this option is not set and a
+   /// branch with a '.' is encountered, the importer will throw an exception.
+   bool fConvertDotsInBranchNames = false;
+
    /// The maximum number of entries to import. When this value is -1 (default), import all entries.
    std::int64_t fMaxEntries = -1;
 
@@ -264,6 +268,10 @@ public:
    void SetWriteOptions(RNTupleWriteOptions options) { fWriteOptions = options; }
    void SetNTupleName(const std::string &name) { fNTupleName = name; }
    void SetMaxEntries(std::uint64_t maxEntries) { fMaxEntries = maxEntries; };
+
+   /// Whereas branch names may contain dots, RNTuple field names may not. By setting this option, dot characters are
+   /// automatically converted into underscores to prevent the importer from throwing an exception.
+   void SetConvertDotsInBranchNames(bool value) { fConvertDotsInBranchNames = value; }
 
    /// Whether or not information and progress is printed to stdout.
    void SetIsQuiet(bool value) { fIsQuiet = value; }

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -228,11 +228,7 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSc
             fieldType = "std::array<" + fieldType + "," + std::to_string(countval) + ">";
 
          if (fConvertDotsInBranchNames) {
-            // If present, remove the trailing dot at the end of a field name. For an explanation as to why some branch
-            // names have this, see https://root.cern/doc/master/classTTree.html#a9193737b5c102ef8d7301410adf73e2f.
-            fieldName.erase(fieldName.find_last_not_of(".") + 1, std::string::npos);
-
-            // Replace any other occurrence with an underscore.
+            // Replace any occurrence of a dot ('.') with an underscore.
             std::replace(fieldName.begin(), fieldName.end(), '.', '_');
          }
 

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -227,6 +227,15 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSc
          if (isFixedSizeArray)
             fieldType = "std::array<" + fieldType + "," + std::to_string(countval) + ">";
 
+         if (fConvertDotsInBranchNames) {
+            // If present, remove the trailing dot at the end of a field name. For an explanation as to why some branch
+            // names have this, see https://root.cern/doc/master/classTTree.html#a9193737b5c102ef8d7301410adf73e2f.
+            fieldName.erase(fieldName.find_last_not_of(".") + 1, std::string::npos);
+
+            // Replace any other occurrence with an underscore.
+            std::replace(fieldName.begin(), fieldName.end(), '.', '_');
+         }
+
          RImportField f;
          f.fIsClass = isClass;
          auto fieldOrError = Detail::RFieldBase::Create(fieldName, fieldType);

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -177,6 +177,31 @@ TEST(RNTupleImporter, FieldName)
    EXPECT_EQ(42, *reader->GetModel()->Get<std::int32_t>("a"));
 }
 
+TEST(RNTupleImporter, ConvertDotsInBranchNames)
+{
+   FileRaii fileGuard("test_ntuple_importer_field_name.root");
+   {
+      std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
+      auto tree = std::make_unique<TTree>("tree", "");
+      Int_t a = 42;
+      tree->Branch("a.a", &a);
+      tree->Fill();
+      tree->Write();
+   }
+
+   auto importer = RNTupleImporter::Create(fileGuard.GetPath(), "tree", fileGuard.GetPath());
+   importer->SetIsQuiet(true);
+   importer->SetNTupleName("ntuple");
+
+   EXPECT_THROW(importer->Import(), ROOT::Experimental::RException);
+
+   importer->SetConvertDotsInBranchNames(true);
+   importer->Import();
+   auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
+   reader->LoadEntry(0);
+   EXPECT_EQ(42, *reader->GetModel()->Get<std::int32_t>("a_a"));
+}
+
 TEST(RNTupleImporter, CString)
 {
    FileRaii fileGuard("test_ntuple_importer_cstring.root");


### PR DESCRIPTION
This PR adds the importer option to convert dot characters in branch names to underscores, preventing the importer from raising an exception if such branch names are encountered (because dot characters are not allowed in field names).
