### PR TITLE
[RF] Support extended fits in RooFit code generation for AD

### DIFF
--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -286,6 +286,8 @@ public:
     return expectedEvents(&nset) ;
   }
 
+  virtual std::unique_ptr<RooAbsReal> createExpectedEventsFunc(const RooArgSet* nset) const;
+
   // Printing interface (human readable)
   void printValue(std::ostream& os) const override ;
   void printMultiline(std::ostream& os, Int_t contents, bool verbose=false, TString indent="") const override ;

--- a/roofit/roofitcore/inc/RooAddPdf.h
+++ b/roofit/roofitcore/inc/RooAddPdf.h
@@ -65,6 +65,8 @@ public:
   /// is the sum of all coefficients.
   double expectedEvents(const RooArgSet* nset) const override;
 
+  std::unique_ptr<RooAbsReal> createExpectedEventsFunc(const RooArgSet* nset) const override;
+
   const RooArgList& pdfList() const {
     // Return list of component p.d.fs
     return _pdfList ;

--- a/roofit/roofitcore/inc/RooExtendPdf.h
+++ b/roofit/roofitcore/inc/RooExtendPdf.h
@@ -48,6 +48,8 @@ public:
   double expectedEvents(const RooArgSet* nset) const override ;
   std::unique_ptr<RooAbsReal> createExpectedEventsFunc(const RooArgSet* nset) const override;
 
+  void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
+
 protected:
 
   RooTemplateProxy<RooAbsPdf>  _pdf;  ///< Input p.d.f

--- a/roofit/roofitcore/inc/RooExtendPdf.h
+++ b/roofit/roofitcore/inc/RooExtendPdf.h
@@ -22,7 +22,7 @@
 class RooExtendPdf : public RooAbsPdf {
 public:
 
-  RooExtendPdf() ;
+  RooExtendPdf() = default;
   // Original constructor without RooAbsReal::Ref for backwards compatibility.
   RooExtendPdf(const char *name, const char *title, RooAbsPdf& pdf,
                       RooAbsReal& norm, const char* rangeName=nullptr);
@@ -30,7 +30,6 @@ public:
           RooAbsReal::Ref norm, const char* rangeName=nullptr) ;
   RooExtendPdf(const RooExtendPdf& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooExtendPdf(*this,newname) ; }
-  ~RooExtendPdf() override ;
 
   double evaluate() const override { return _pdf ; }
 
@@ -47,12 +46,13 @@ public:
   bool selfNormalized() const override { return true ; }
   ExtendMode extendMode() const override { return CanBeExtended ; }
   double expectedEvents(const RooArgSet* nset) const override ;
+  std::unique_ptr<RooAbsReal> createExpectedEventsFunc(const RooArgSet* nset) const override;
 
 protected:
 
-  RooTemplateProxy<RooAbsPdf>  _pdf; ///< Input p.d.f
-  RooTemplateProxy<RooAbsReal> _n;   ///< Number of expected events
-  const TNamed* _rangeName ;         ///< Name of subset range
+  RooTemplateProxy<RooAbsPdf>  _pdf;  ///< Input p.d.f
+  RooTemplateProxy<RooAbsReal> _n;    ///< Number of expected events
+  const TNamed* _rangeName = nullptr; ///< Name of subset range
 
 
   ClassDefOverride(RooExtendPdf,2) // Wrapper p.d.f adding an extended likelihood term to an existing p.d.f

--- a/roofit/roofitcore/inc/RooProdPdf.h
+++ b/roofit/roofitcore/inc/RooProdPdf.h
@@ -62,6 +62,7 @@ public:
 
   ExtendMode extendMode() const override ;
   double expectedEvents(const RooArgSet* nset) const override ;
+  std::unique_ptr<RooAbsReal> createExpectedEventsFunc(const RooArgSet* nset) const override;
 
   const RooArgList& pdfList() const { return _pdfList ; }
 

--- a/roofit/roofitcore/inc/RooRealSumPdf.h
+++ b/roofit/roofitcore/inc/RooRealSumPdf.h
@@ -70,6 +70,8 @@ public:
 
   std::unique_ptr<RooAbsArg> compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileContext & ctx) const override;
 
+  std::unique_ptr<RooAbsReal> createExpectedEventsFunc(const RooArgSet* nset) const override;
+
   void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
 
 protected:

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -3607,3 +3607,16 @@ RooAbsPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileCo
    newArg->addOwnedComponents(std::move(pdfClone));
    return newArg;
 }
+
+/// Returns an object that represents the expected number of events for a given
+/// normalization set, similar to how createIntegral() returns an object that
+/// returns the integral. This is used to build the computation graph for the
+/// final likelihood.
+std::unique_ptr<RooAbsReal> RooAbsPdf::createExpectedEventsFunc(const RooArgSet * /*nset*/) const
+{
+   std::stringstream errMsg;
+   errMsg << "The pdf \"" << GetName() << "\" of type " << ClassName()
+          << " did not overload RooAbsPdf::createExpectedEventsFunc()!";
+   coutE(InputArguments) << errMsg.str() << std::endl;
+   return nullptr;
+}

--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -65,6 +65,8 @@ An (enforced) condition for this assumption is that each \f$ \mathrm{PDF}_i \f$ 
 
 #include "RooAddPdf.h"
 
+#include "RooAddition.h"
+#include "RooRealSumFunc.h"
 #include "RooAddHelpers.h"
 #include "RooAddGenContext.h"
 #include "RooBatchCompute.h"
@@ -76,6 +78,8 @@ An (enforced) condition for this assumption is that each \f$ \mathrm{PDF}_i \f$ 
 #include "RooRealSumPdf.h"
 #include "RooRecursiveFraction.h"
 #include "RooGenericPdf.h"
+#include "RooProduct.h"
+#include "RooRatio.h"
 
 #include <algorithm>
 #include <memory>
@@ -730,6 +734,71 @@ double RooAddPdf::expectedEvents(const RooArgSet* nset) const
   return expectedTotal ;
 }
 
+
+std::unique_ptr<RooAbsReal> RooAddPdf::createExpectedEventsFunc(const RooArgSet *nset) const
+{
+   std::unique_ptr<RooAbsReal> out;
+
+   auto name = std::string(GetName()) + "_expectedEvents";
+   if (_allExtendable) {
+      RooArgSet sumSet;
+      for (auto *pdf : static_range_cast<RooAbsPdf *>(_pdfList)) {
+         sumSet.addOwned(pdf->createExpectedEventsFunc(nset));
+      }
+      out = std::make_unique<RooAddition>(name.c_str(), name.c_str(), sumSet);
+      out->addOwnedComponents(std::move(sumSet));
+   } else {
+      out = std::make_unique<RooAddition>(name.c_str(), name.c_str(), _coefList);
+   }
+
+   RooArgList prodList;
+
+   if (!_allExtendable) {
+      // If the _refCoefNorm is empty or it's equal to normSet anyway, this is not
+      // a conditional pdf and we don't need to do any transformation. See also
+      // RooAddPdf::compleForNormSet() for more explanations on a similar logic.
+      if (!_refCoefNorm.empty() && !nset->equals(_refCoefNorm)) {
+         prodList.addOwned(std::unique_ptr<RooAbsReal>{createIntegral(*nset, _refCoefNorm)});
+      }
+
+      // Optionally multiply with fractional normalization. I this case, we
+      // replace the original factor stored in "out".
+      if (_normRange) {
+         std::unique_ptr<RooAbsReal> owner;
+         RooArgList terms;
+         // The integrals own each other in a chain. We do this because it's
+         // not possible to add two objects with the same name via
+         // addOwnedComponents(), and it happens in some user models that some
+         // component pdfs are the same. Hence, the integrals might share names
+         // too and we can't add them all in one go as owned objects of the
+         // final integral sum.
+         for (auto *pdf : static_range_cast<RooAbsPdf *>(_pdfList)) {
+            auto next = std::unique_ptr<RooAbsReal>{pdf->createIntegral(*nset, *nset, _normRange)};
+            terms.add(*next);
+            if (owner)
+               next->addOwnedComponents(std::move(owner));
+            owner = std::move(next);
+         }
+         auto fracIntegName = std::string(GetName()) + "_integSum";
+         auto fracInteg =
+            std::make_unique<RooRealSumFunc>(fracIntegName.c_str(), fracIntegName.c_str(), _coefList, terms);
+         fracInteg->addOwnedComponents(std::move(owner));
+
+         out = std::move(fracInteg);
+      }
+   }
+
+   std::string finalName = std::string(out->GetName()) + "_finalized";
+   if (prodList.empty()) {
+      // If there are no additional factors, just return the single factor we have
+      return out;
+   } else {
+      prodList.addOwned(std::move(out));
+   }
+   auto finalOut = std::make_unique<RooProduct>(finalName.c_str(), finalName.c_str(), prodList);
+   finalOut->addOwnedComponents(std::move(prodList));
+   return finalOut;
+}
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooExtendPdf.cxx
+++ b/roofit/roofitcore/src/RooExtendPdf.cxx
@@ -176,3 +176,10 @@ std::unique_ptr<RooAbsReal> RooExtendPdf::createExpectedEventsFunc(const RooArgS
    }
    return out;
 }
+
+
+void RooExtendPdf::translate(RooFit::Detail::CodeSquashContext &ctx) const
+{
+   // Use the result of the underlying pdf.
+   ctx.addResult(this, ctx.getResult(_pdf));
+}

--- a/roofit/roofitcore/src/RooExtendPdf.cxx
+++ b/roofit/roofitcore/src/RooExtendPdf.cxx
@@ -42,6 +42,9 @@ the nominal integration range \f$ \mathrm{normRegion}[x] \f$.
 #include "RooRealVar.h"
 #include "RooFormulaVar.h"
 #include "RooNameReg.h"
+#include "RooConstVar.h"
+#include "RooProduct.h"
+#include "RooRatio.h"
 #include "RooMsgService.h"
 
 
@@ -49,13 +52,6 @@ the nominal integration range \f$ \mathrm{normRegion}[x] \f$.
 using namespace std;
 
 ClassImp(RooExtendPdf);
-;
-
-
-RooExtendPdf::RooExtendPdf() : _rangeName(0)
-{
-  // Default constructor
-}
 
 RooExtendPdf::RooExtendPdf(const char *name, const char *title, RooAbsPdf& pdf,
                     RooAbsReal& norm, const char* rangeName)
@@ -94,13 +90,6 @@ RooExtendPdf::RooExtendPdf(const RooExtendPdf& other, const char* name) :
   _rangeName(other._rangeName)
 {
   // Copy constructor
-}
-
-
-RooExtendPdf::~RooExtendPdf()
-{
-  // Destructor
-
 }
 
 
@@ -143,10 +132,6 @@ double RooExtendPdf::expectedEvents(const RooArgSet* nset) const
     }
 
     nExp /= fracInt ;
-
-
-    // cout << "RooExtendPdf::expectedEvents(" << GetName() << ") fracInt = " << fracInt << " _n = " << _n << " nExpect = " << nExp << endl ;
-
   }
 
   // Multiply with original Nexpected, if defined
@@ -156,4 +141,38 @@ double RooExtendPdf::expectedEvents(const RooArgSet* nset) const
 }
 
 
+std::unique_ptr<RooAbsReal> RooExtendPdf::createExpectedEventsFunc(const RooArgSet *nset) const
+{
+   const RooAbsPdf& pdf = *_pdf;
 
+   RooArgList prodList;
+   prodList.add(*_n);
+
+   // Optionally multiply with fractional normalization
+   std::unique_ptr<RooAbsReal> rangeFactor;
+   if (_rangeName) {
+      std::unique_ptr<RooAbsReal> fracInteg{pdf.createIntegral(*nset, *nset, RooNameReg::str(_rangeName))};
+      // Create one over integral term
+      auto rangeFactorName = std::string("one_over_") + fracInteg->GetName();
+      rangeFactor = std::make_unique<RooRatio>(rangeFactorName.c_str(), rangeFactorName.c_str(), RooFit::RooConst(1.0), *fracInteg);
+      rangeFactor->addOwnedComponents(std::move(fracInteg));
+      prodList.add(*rangeFactor);
+   }
+
+   // Multiply with original Nexpected, if defined
+   std::unique_ptr<RooAbsReal> pdfExpectedEvents;
+   if (pdf.canBeExtended()) {
+      pdfExpectedEvents = pdf.createExpectedEventsFunc(nset);
+      prodList.add(*pdfExpectedEvents);
+   }
+
+   auto name = std::string(GetName()) + "_expectedEvents";
+   auto out = std::make_unique<RooProduct>(name.c_str(), name.c_str(), prodList);
+   if(rangeFactor) {
+      out->addOwnedComponents(std::move(rangeFactor));
+   }
+   if(pdfExpectedEvents) {
+      out->addOwnedComponents(std::move(pdfExpectedEvents));
+   }
+   return out;
+}

--- a/roofit/roofitcore/src/RooNLLVarNew.h
+++ b/roofit/roofitcore/src/RooNLLVarNew.h
@@ -64,23 +64,22 @@ private:
    double evaluate() const override { return _value; }
    void resetWeightVarNames();
    double finalizeResult(ROOT::Math::KahanSum<double> result, double weightSum) const;
-   void fillBinWidthsFromPdfBoundaries(RooAbsReal const &pdf);
+   void fillBinWidthsFromPdfBoundaries(RooAbsReal const &pdf, RooArgSet const &observables);
    double computeBatchBinnedL(RooSpan<const double> preds, RooSpan<const double> weights) const;
 
    RooTemplateProxy<RooAbsPdf> _pdf;
-   RooArgSet _observables;
+   RooTemplateProxy<RooAbsReal> _weightVar;
+   RooTemplateProxy<RooAbsReal> _weightSquaredVar;
+   RooTemplateProxy<RooAbsReal> _binVolumeVar;
+   std::unique_ptr<RooTemplateProxy<RooAbsReal>> _expectedEvents;
    mutable double _sumWeight = 0.0;  //!
    mutable double _sumWeight2 = 0.0; //!
-   bool _isExtended;
    bool _weightSquared = false;
    bool _binnedL = false;
    bool _doOffset = false;
    bool _doBinOffset = false;
    int _simCount = 1;
    std::string _prefix;
-   RooTemplateProxy<RooAbsReal> _weightVar;
-   RooTemplateProxy<RooAbsReal> _weightSquaredVar;
-   RooTemplateProxy<RooAbsReal> _binVolumeVar;
    std::vector<double> _binw;
    mutable ROOT::Math::KahanSum<double> _offset{0.}; ///<! Offset as KahanSum to avoid loss of precision
 

--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -1655,9 +1655,18 @@ double RooProdPdf::expectedEvents(const RooArgSet* nset) const
     throw std::logic_error(std::string("RooProdPdf ") + GetName() + " could not be extended.");
   }
 
-  return ((RooAbsPdf*)_pdfList.at(_extendedIndex))->expectedEvents(nset) ;
+  return static_cast<RooAbsPdf*>(_pdfList.at(_extendedIndex))->expectedEvents(nset) ;
 }
 
+std::unique_ptr<RooAbsReal> RooProdPdf::createExpectedEventsFunc(const RooArgSet* nset) const
+{
+  if (_extendedIndex<0) {
+    coutF(Generation) << "Requesting expected number of events from a RooProdPdf that does not contain an extended p.d.f" << endl ;
+    throw std::logic_error(std::string("RooProdPdf ") + GetName() + " could not be extended.");
+  }
+
+  return static_cast<RooAbsPdf*>(_pdfList.at(_extendedIndex))->createExpectedEventsFunc(nset);
+}
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2330,6 +2339,10 @@ public:
 
    ExtendMode extendMode() const override { return _prodPdf->extendMode(); }
    double expectedEvents(const RooArgSet * /*nset*/) const override { return _prodPdf->expectedEvents(&_normSet); }
+   std::unique_ptr<RooAbsReal> createExpectedEventsFunc(const RooArgSet * /*nset*/) const override
+   {
+      return _prodPdf->createExpectedEventsFunc(&_normSet);
+   }
 
    // Analytical Integration handling
    bool forceAnalyticalInt(const RooAbsArg &dep) const override { return _prodPdf->forceAnalyticalInt(dep); }

--- a/roofit/roofitcore/src/RooRealSumPdf.cxx
+++ b/roofit/roofitcore/src/RooRealSumPdf.cxx
@@ -807,3 +807,10 @@ std::unique_ptr<RooAbsArg> RooRealSumPdf::compileForNormSet(RooArgSet const &nor
    newArg->addOwnedComponents(std::move(pdfClone));
    return newArg;
 }
+
+std::unique_ptr<RooAbsReal> RooRealSumPdf::createExpectedEventsFunc(const RooArgSet *nset) const
+{
+   if (nset == nullptr)
+      return nullptr;
+   return std::unique_ptr<RooAbsReal>{createIntegral(*nset, *getIntegratorConfig(), normRange())};
+}

--- a/roofit/roofitcore/test/testRooFuncWrapper.cxx
+++ b/roofit/roofitcore/test/testRooFuncWrapper.cxx
@@ -476,7 +476,20 @@ FactoryTestParams param5{"SimPdf", getSimPdfModel,
                          5e-3,
                          /*randomizeParameters=*/true};
 
-INSTANTIATE_TEST_SUITE_P(RooFuncWrapper, FactoryTest, testing::Values(param1, param2, param3, param4, param5),
+FactoryTestParams param6{"GaussianExtended",
+                         [](RooWorkspace &ws) {
+                            ws.factory("Gaussian::gauss(x[0, -10, 10], mu[0, -10, 10], sigma[3.0, 0.01, 10])");
+                            ws.factory("ExtendPdf::model(gauss, n[100, 0, 10000])");
+                            ws.defineSet("observables", "x");
+                         },
+                         [](RooAbsPdf &pdf, RooAbsData &data, RooWorkspace &) {
+                            return std::unique_ptr<RooAbsReal>{
+                               pdf.createNLL(data, RooFit::BatchMode("cpu"), RooFit::Extended(true))};
+                         },
+                         1e-4,
+                         /*randomizeParameters=*/false};
+
+INSTANTIATE_TEST_SUITE_P(RooFuncWrapper, FactoryTest, testing::Values(param1, param2, param3, param4, param5, param6),
                          [](testing::TestParamInfo<FactoryTest::ParamType> const &paramInfo) {
                             return paramInfo.param._name;
                          });


### PR DESCRIPTION
Introduce the new `RooAbsPdf::createExpectedEvents()` method to
explicitly create an object that represents the expected number of
events. Like this, the expected number of events is fully exposed in the
computation graph, just like the integrals.

This makes adding support of RooFit codegen+AD for extended fits
trivial, and also optimizes the BatchMode because the RooFitDriver can
de-duplicate integrals that appear both in the regular evaluation path
and `RooAbsPdf::expectedEvents()`.

Now that a function that represents the expected events is
part of the computation graph, using it in the RooFit code generation
for the NLL is straight forward.
