### PR TITLE
[modulemap] Remove module for xlocale.h

### DIFF
--- a/interpreter/cling/include/cling/libc.modulemap
+++ b/interpreter/cling/include/cling/libc.modulemap
@@ -62,13 +62,4 @@ module "libc" [system] [extern_c] [no_undeclared_includes] {
     export *
     header "wchar.h"
   }
-
-  use "xlocale.h"
-}
-
-// glib specific header. In it's own module because it
-// doesn't exist on some systems with unpatched glib 2.26+
-module "xlocale.h" [system] [extern_c] {
-  export *
-  header "xlocale.h"
 }


### PR DESCRIPTION
As commit 2db042523a explains, this header doesn't exist anymore since glibc 2.26. The oldest distributions that ROOT currently supports are EL8 and Debian 10, both of which have glibc 2.28. Remove the module as it also causes problems on FreeBSD due to including `locale.h` and a cyclic dependency `std -> xlocale.h -> std`.