### PR TITLE
[RF] Speed up `getParameters()` for BatchMode NLL 

### DIFF
--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1116,14 +1116,14 @@ RooFit::OwningPtr<RooAbsReal> RooAbsPdf::createNLL(RooAbsData& data, const RooLi
     TString oldNormRange = _normRange;
     setNormRange(rangeName);
 
-    auto normSet = new RooArgSet; // INTENTIONAL LEAK FOR NOW!
-    getObservables(data.get(), *normSet);
-    normSet->remove(projDeps, true, true);
+    RooArgSet normSet;
+    getObservables(data.get(), normSet);
+    normSet.remove(projDeps, true, true);
 
     this->setAttribute("SplitRange", splitRange);
     this->setStringAttribute("RangeName", rangeName);
 
-    std::unique_ptr<RooAbsPdf> pdfClone = RooFit::Detail::compileForNormSet(*this, *normSet);
+    std::unique_ptr<RooAbsPdf> pdfClone = RooFit::Detail::compileForNormSet(*this, normSet);
 
     // reset attributes
     this->setAttribute("SplitRange", false);

--- a/roofit/roofitcore/src/RooFitDriver.h
+++ b/roofit/roofitcore/src/RooFitDriver.h
@@ -50,6 +50,8 @@ public:
                 bool skipZeroWeights = false, bool takeGlobalObservablesFromData = true);
    void setData(DataSpansMap const &dataSpans);
 
+   RooArgSet getParameters() const;
+
    ~RooFitDriver();
    std::vector<double> getValues();
    double getVal();

--- a/roofit/roofitcore/src/RooNLLVarNew.cxx
+++ b/roofit/roofitcore/src/RooNLLVarNew.cxx
@@ -26,6 +26,7 @@ functions from `RooBatchCompute` library to provide faster computation times.
 
 #include <RooBatchCompute.h>
 #include <RooNaNPacker.h>
+#include <RooConstVar.h>
 #include <RooRealVar.h>
 #include "RooFit/Detail/Buffers.h"
 
@@ -54,9 +55,10 @@ RooArgSet getObs(RooAbsArg const &arg, RooArgSet const &observables)
    return out;
 }
 
-RooRealVar *dummyVar(const char *name)
+// Use RooConstVar for dummies such that they don't get included in getParameters().
+RooConstVar *dummyVar(const char *name)
 {
-   return new RooRealVar(name, name, 1.0);
+   return new RooConstVar(name, name, 1.0);
 }
 
 } // namespace

--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -2401,10 +2401,10 @@ RooProdPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileC
       auto nsetForServer = fillNormSetForServer(normSet, *server);
       RooArgSet const &nset = nsetForServer ? *nsetForServer : normSet;
 
-      auto depList = new RooArgSet; // INTENTIONAL LEAK FOR NOW!
-      server->getObservables(&nset, *depList);
+      RooArgSet depList;
+      server->getObservables(&nset, depList);
 
-      ctx.compileServer(*server, *prodPdfClone, *depList);
+      ctx.compileServer(*server, *prodPdfClone, depList);
    }
 
    auto fixedProdPdf = std::make_unique<RooFixedProdPdf>(std::move(prodPdfClone), normSet);

--- a/roofit/roofitcore/src/RooRealSumPdf.cxx
+++ b/roofit/roofitcore/src/RooRealSumPdf.cxx
@@ -793,10 +793,10 @@ std::unique_ptr<RooAbsArg> RooRealSumPdf::compileForNormSet(RooArgSet const &nor
    std::unique_ptr<RooAbsPdf> pdfClone(static_cast<RooAbsPdf*>(this->Clone()));
    ctx.compileServers(*pdfClone, {});
 
-   auto depList = new RooArgSet; // INTENTIONAL LEAK FOR NOW!
-   pdfClone->getObservables(&normSet, *depList);
+   RooArgSet depList;
+   pdfClone->getObservables(&normSet, depList);
 
-   auto newArg = std::make_unique<RooNormalizedPdf>(*pdfClone, *depList);
+   auto newArg = std::make_unique<RooNormalizedPdf>(*pdfClone, depList);
 
    // The direct servers are this pdf and the normalization integral, which
    // don't need to be compiled further.


### PR DESCRIPTION
In the `getParameters()` implementation of the RooFitDriver wrapper,
there was a call to `RooAbsArg::getParameters()`, which is expensive.

It's better to let the Driver figure out what the parameters are, given
that it already stores all the information to figure this out very
quickly.

This speeds up the likelihood creation for ATLAS Higgs combination
models by about 20 % when using the BatchMode.

This commit also fixes some memory leaks in the `compileForNormSet()` implementations that were put there on purpose in lack of a better solution at the time, but now they are not needed anymore.