### PR TITLE
[ntuple] Fix `RXxxField::AppendImpl()` return value

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -318,7 +318,7 @@ public:
 
    void *GetRawContent() const { return fRawContent; }
    std::size_t GetSize() const { return fSize; }
-   std::size_t GetPackedSize(std::size_t nElements) const { return (nElements * GetBitsOnStorage() + 7) / 8; }
+   std::size_t GetPackedSize(std::size_t nElements = 1U) const { return (nElements * GetBitsOnStorage() + 7) / 8; }
 };
 
 /**

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1082,7 +1082,7 @@ std::size_t ROOT::Experimental::RField<std::string>::AppendImpl(const ROOT::Expe
    fColumns[1]->AppendV(elemChars, length);
    fIndex += length;
    fColumns[0]->Append(fElemIndex);
-   return length + sizeof(fElemIndex);
+   return length + fColumns[0]->GetElement()->GetPackedSize();
 }
 
 void ROOT::Experimental::RField<std::string>::ReadGlobalImpl(
@@ -1395,7 +1395,7 @@ std::size_t ROOT::Experimental::RCollectionClassField::AppendImpl(const Detail::
    Detail::RColumnElement<ClusterSize_t> elemIndex(&fNWritten);
    fNWritten += count;
    fColumns[0]->Append(elemIndex);
-   return nbytes + sizeof(elemIndex);
+   return nbytes + fColumns[0]->GetElement()->GetPackedSize();
 }
 
 void ROOT::Experimental::RCollectionClassField::ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue *value)
@@ -1640,7 +1640,7 @@ std::size_t ROOT::Experimental::RVectorField::AppendImpl(const Detail::RFieldVal
    Detail::RColumnElement<ClusterSize_t> elemIndex(&fNWritten);
    fNWritten += count;
    fColumns[0]->Append(elemIndex);
-   return nbytes + sizeof(elemIndex);
+   return nbytes + fColumns[0]->GetElement()->GetPackedSize();
 }
 
 void ROOT::Experimental::RVectorField::ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue *value)
@@ -1781,7 +1781,7 @@ std::size_t ROOT::Experimental::RRVecField::AppendImpl(const Detail::RFieldValue
    Detail::RColumnElement<ClusterSize_t> elemIndex(&fNWritten);
    fNWritten += *sizePtr;
    fColumns[0]->Append(elemIndex);
-   return nbytes + sizeof(elemIndex);
+   return nbytes + fColumns[0]->GetElement()->GetPackedSize();
 }
 
 void ROOT::Experimental::RRVecField::ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue *value)
@@ -2021,7 +2021,7 @@ std::size_t ROOT::Experimental::RField<std::vector<bool>>::AppendImpl(const Deta
    Detail::RColumnElement<ClusterSize_t> elemIndex(&fNWritten);
    fNWritten += count;
    fColumns[0]->Append(elemIndex);
-   return count + sizeof(elemIndex);
+   return count + fColumns[0]->GetElement()->GetPackedSize();
 }
 
 void ROOT::Experimental::RField<std::vector<bool>>::ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue* value)

--- a/tree/ntuple/v7/test/ntuple_extended.cxx
+++ b/tree/ntuple/v7/test/ntuple_extended.cxx
@@ -315,11 +315,14 @@ TEST(RNTuple, SmallClusters)
    auto fldVec = model->MakeField<std::vector<float>>("vec");
    RNTupleWriteOptions options;
    options.SetHasSmallClusters(true);
+   options.SetCompression(0);
    options.SetMaxUnzippedClusterSize(1000 * 1000 * 1000); // 1GB
+   options.SetApproxZippedClusterSize(1000 * 1000 * 1000); // 1GB
    auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath(), options);
    fldVec->push_back(1.0);
    // One float and one 32bit integer per entry
-   for (unsigned int i = 0; i < (300 * 1000 * 1000) / 8; ++i) {
+   constexpr std::size_t nEntries = RNTupleWriteOptions::kMaxSmallClusterSize / (sizeof(float) + sizeof(std::int32_t));
+   for (unsigned int i = 0; i < nEntries; ++i) {
       writer->Fill();
    }
    writer->Fill();


### PR DESCRIPTION
`AppendImpl()` returns the number of bytes written.  For collections, this accounts for the size of the written elements + one element in the index column.  However, `sizeof(RColumnElement<T>)` was erroneously taken as the size of the latter.

Instead, use the packed size of an element in the principal column.  Note that such size may be either 64 or 32 bit, depending on whether small clusters are used.  The `RNTuple.SmallClusters` test was adjusted accordingly.

As side effect, this PR should fix the RNTuple.SmallClusters test on Win32 (and thus supersedes #13004).

## Changes or fixes:
- Fix return value of `AppendImpl()` for collection fields.
- Adjust RNTuple.SmallClusters; also, set the target zipped cluster size and no compression, as otherwise the estimation of the zipped cluster size hits in.

## Checklist:
- [x] tested changes locally
- [ ] updated the docs (if necessary)