### PR TITLE
[ntuple] Fix a memory leak in `RPageSinkBuf`

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -320,6 +320,7 @@ public:
    ColumnId_t GetColumnIdSource() const { return fColumnIdSource; }
    NTupleSize_t GetFirstElementIndex() const { return fFirstElementIndex; }
    RPageSource *GetPageSource() const { return fPageSource; }
+   RPageSink *GetPageSink() const { return fPageSink; }
    RPageStorage::ColumnHandle_t GetHandleSource() const { return fHandleSource; }
    RPageStorage::ColumnHandle_t GetHandleSink() const { return fHandleSink; }
 };

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -108,11 +108,13 @@ private:
 
    private:
       RPageStorage::ColumnHandle_t fCol;
-      // Using a deque guarantees that element iterators are never invalidated
-      // by appends to the end of the iterator by BufferPage.
+      /// Using a deque guarantees that element iterators are never invalidated
+      /// by appends to the end of the iterator by BufferPage.
       std::deque<RPageZipItem> fBufferedPages;
-      // Pages that have been already sealed by a concurrent task. A vector commit can be issued if all
-      // buffered pages have been sealed.
+      /// Pages that have been already sealed by a concurrent task. A vector commit can be issued if all
+      /// buffered pages have been sealed.
+      /// Note that each RSealedPage refers to the same buffer as `fBufferedPages[i].fBuf` for some value of `i`, and
+      /// thus owned by RPageZipItem
       RPageStorage::SealedPageSequence_t fSealedPages;
    };
 

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -28,6 +28,8 @@ void ROOT::Experimental::Detail::RPageSinkBuf::RColumnBuf::DropBufferedPages()
       fCol.fColumn->GetPageSink()->ReleasePage(bufPage.fPage);
    }
    fBufferedPages.clear();
+   // Each RSealedPage points to the same region as `fBuf` for some element in `fBufferedPages`; thus, no further
+   // clean-up is required
    fSealedPages.clear();
 }
 


### PR DESCRIPTION
RPageSinkBuf calls `ReservePage()` as part of a `CommitPageImpl()` call. This memory is release in `CommitClusterImpl()` by calling `ReleasePage()` accordingly.

However, if `CommitClusterImpl()` is never invoked (e.g., because the 'small cluster' check failed in RNTuple.cxx:336), this memory is leaked.
This patch fixes that by making `RColumnBuf` adopt the pages. `DrainBufferedPages()` gives back the ownership to the caller, who is then responsible of calling `ReleasePage()`.

FWIW, this bug was found while hunting the issues seen in the CI for the `RNTuple.SmallClusters` test.

## Checklist:
- [x] tested changes locally
- [x] updated the docs (if necessary)