### PR TITLE
[ntuple] Temporarily disable the `RNTuple.SmallClusters` test

### DIFF
--- a/tree/ntuple/v7/test/ntuple_extended.cxx
+++ b/tree/ntuple/v7/test/ntuple_extended.cxx
@@ -268,6 +268,9 @@ TEST(RNTuple, LargeFile2)
 }
 #endif
 
+// FIXME: apparently, this test continues to be broken for some CI configs, which needs to be investigated carefully;
+// thus disable temporarily.
+#if 0
 TEST(RNTuple, SmallClusters)
 {
    FileRaii fileGuard("test_ntuple_small_clusters.root");
@@ -331,3 +334,4 @@ TEST(RNTuple, SmallClusters)
       "failure committing ntuple: invalid attempt to write a cluster > 512MiB", false /* matchFullMessage */);
    writer = nullptr;
 }
+#endif


### PR DESCRIPTION
Apparently, this test continues to be broken for some CI configs, which needs to be investigated carefully; thus disable temporarily.

Related PRs fixing issues found while investigating this test: #13021, #13022.