### PR TITLE
[RF] Avoid RooBinWidthFunction in final likelihood computation graphs

### DIFF
--- a/roofit/roofitcore/inc/RooBinWidthFunction.h
+++ b/roofit/roofitcore/inc/RooBinWidthFunction.h
@@ -53,6 +53,8 @@ public:
 
   ~RooBinWidthFunction() override { }
 
+  std::unique_ptr<RooAbsArg> compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileContext & ctx) const override;
+
   /// Copy the object and return as TObject*.
   TObject* clone(const char* newname = nullptr) const override {
     return new RooBinWidthFunction(*this, newname);

--- a/roofit/roofitcore/inc/RooFit/Detail/NormalizationHelpers.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/NormalizationHelpers.h
@@ -43,6 +43,14 @@ public:
 
    void markAsCompiled(RooAbsArg &arg) const;
 
+   // This information is used for the binned likelihood optimization.
+   void setLikelihoodMode(bool flag) { _likelihoodMode = flag; }
+   bool likelihoodMode() const { return _likelihoodMode; }
+   void setBinnedLikelihoodMode(bool flag) { _binnedLikelihoodMode = flag; }
+   bool binnedLikelihoodMode() const { return _binnedLikelihoodMode; }
+   void setBinWidthFuncFlag(bool flag) { _binWidthFuncFlag = flag; }
+   bool binWidthFuncFlag() const { return _binWidthFuncFlag; }
+
 private:
    RooAbsArg *compileImpl(RooAbsArg &arg, RooAbsArg &owner, RooArgSet const &normSet);
    void add(RooAbsArg &arg);
@@ -52,6 +60,10 @@ private:
    RooArgSet const &_topLevelNormSet;
    std::unordered_map<TNamed const *, RooAbsArg *> _clonedArgsSet;
    std::unordered_map<RooAbsArg *, RooAbsArg *> _replacements;
+
+   bool _likelihoodMode = false;
+   bool _binnedLikelihoodMode = false;
+   bool _binWidthFuncFlag = false;
 };
 
 template <class T>

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1123,7 +1123,10 @@ RooFit::OwningPtr<RooAbsReal> RooAbsPdf::createNLL(RooAbsData& data, const RooLi
     this->setAttribute("SplitRange", splitRange);
     this->setStringAttribute("RangeName", rangeName);
 
-    std::unique_ptr<RooAbsPdf> pdfClone = RooFit::Detail::compileForNormSet(*this, normSet);
+    RooFit::Detail::CompileContext ctx{normSet};
+    ctx.setLikelihoodMode(true);
+    std::unique_ptr<RooAbsArg> head = this->compileForNormSet(normSet, ctx);
+    std::unique_ptr<RooAbsPdf> pdfClone = std::unique_ptr<RooAbsPdf>{static_cast<RooAbsPdf *>(head.release())};
 
     // reset attributes
     this->setAttribute("SplitRange", false);


### PR DESCRIPTION
Since ROOT 6.26, the HistFactory models include the RooBinWidthFunction
to multiply the yields in the RooHistFuncs with the inverse bin widths,
in order to get the correct probability density.

That's great and fixes HistFactory for non-uniform binnings, but it is
not optimal for the `BinnedLikelihood` code path. Here, the bin widths
need to multiplied back again to get the event yields in each bin.

This commit suggests to improve the situation for the new BatchMode by
propagating the information that we are building a binned likelihood
down to the RooBinWidthFunctions, such that they can remove themselves.

Then, if such RooBinWidthFunctions were encountered and disabled, the NLL
knows that it can skip the multiplication with the bin widths.

What is proposed here looks like a small performance optimization only,
but actually the main motivation is not performance but RooFit AD
support. By removing the RooBinWidthFunctions from the computation graphs
of HistFactory likelihoods, we don't need to implement code generation
support for this class, which would be not trivial in the general
n-dimensional case. With the suggestion in this PR, all that work is
avoided.