### PR TITLE
RF] Don't consider extended pdf in RooProdPdf as constraint term

### DIFF
--- a/roofit/roofitcore/inc/RooExtendedTerm.h
+++ b/roofit/roofitcore/inc/RooExtendedTerm.h
@@ -22,17 +22,18 @@
 class RooExtendedTerm : public RooAbsPdf {
 public:
 
-  RooExtendedTerm() ;
+  RooExtendedTerm() = default;
   RooExtendedTerm(const char *name, const char *title, const RooAbsReal& n) ;
   RooExtendedTerm(const RooExtendedTerm& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooExtendedTerm(*this,newname) ; }
-  ~RooExtendedTerm() override ;
 
   double evaluate() const override { return 1. ; }
 
   ExtendMode extendMode() const override { return CanBeExtended ; }
   /// Return number of expected events, in other words the value of the associated n parameter.
   double expectedEvents(const RooArgSet* nset) const override ;
+
+  std::unique_ptr<RooAbsReal> createExpectedEventsFunc(const RooArgSet* nset) const override;
 
 protected:
 

--- a/roofit/roofitcore/src/RooExtendedTerm.cxx
+++ b/roofit/roofitcore/src/RooExtendedTerm.cxx
@@ -24,21 +24,10 @@ an extended ML term for a given number of expected events term when an extended 
 is constructed.
 **/
 
-#include "RooExtendedTerm.h"
-
-using namespace std;
+#include <RooExtendedTerm.h>
+#include <RooProduct.h>
 
 ClassImp(RooExtendedTerm);
-;
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor
-
-RooExtendedTerm::RooExtendedTerm()
-{
-}
-
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -63,16 +52,6 @@ RooExtendedTerm::RooExtendedTerm(const RooExtendedTerm& other, const char* name)
 {
 }
 
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Destructor
-
-RooExtendedTerm::~RooExtendedTerm()
-{
-}
-
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Return number of expected events from associated event count variable
 
@@ -81,5 +60,8 @@ double RooExtendedTerm::expectedEvents(const RooArgSet* /*nset*/) const
   return _n ;
 }
 
-
-
+std::unique_ptr<RooAbsReal> RooExtendedTerm::createExpectedEventsFunc(const RooArgSet * /*nset*/) const
+{
+   auto name = std::string(GetName()) + "_expectedEvents";
+   return std::make_unique<RooProduct>(name.c_str(), name.c_str(), *_n);
+}

--- a/roofit/roofitcore/test/testRooProdPdf.cxx
+++ b/roofit/roofitcore/test/testRooProdPdf.cxx
@@ -14,6 +14,8 @@
 #include <RooWorkspace.h>
 #include <RooHelpers.h>
 
+#include <Math/PdfFuncMathCore.h>
+
 #include <gtest/gtest.h>
 
 // Backward compatibility for gtest version < 1.10.0
@@ -212,4 +214,26 @@ TEST(RooProdPdf, DISABLED_ChangeServerNormSetForProdPdfInAddPdf)
 
    EXPECT_FLOAT_EQ(val2, val1);
    EXPECT_FLOAT_EQ(val3, val1);
+}
+
+// Make sure that the pdf that provides the expected number of events in a
+// RooProdPdf is not considered as a constraint. Covers JIRA issue ROOT-7604.
+TEST(RooProdPdf, RooProdPdfWithExtendedTerm)
+{
+   RooHelpers::LocalChangeMsgLevel locmsg(RooFit::WARNING, 0u, RooFit::Minimization, false);
+
+   RooWorkspace ws;
+   ws.factory("Gaussian::L_constraint(L_nom[10],L[10,0,20],0.2)");
+   ws.factory("PROD::full_model( RooExtendedTerm::model( L ) , L_constraint )");
+
+   ws.factory("weightVar[10,0,100]");
+   ws.factory("dummy_obs[1,0,1]");
+   ws.defineSet("obs", "dummy_obs,weightVar");
+   RooDataSet data("data", "data", *ws.set("obs"), RooFit::WeightVar("weightVar"));
+   data.add(*ws.set("obs"), 5);
+
+   std::unique_ptr<RooAbsReal> nll1{ws.pdf("full_model")->createNLL(data)};
+   double refVal = -std::log(ROOT::Math::gaussian_pdf(10, 0.2, 10)) + (10. - 5 * std::log(10.));
+   double nll1Val = nll1->getVal();
+   EXPECT_FLOAT_EQ(nll1Val, refVal);
 }


### PR DESCRIPTION
If one of the pdfs in a RooProdPdf is extended, it should not be
considered to be extracted as a constraint term. Also, fix
`RooProdPdf::getConnectedParameters()` which should not consider the
extended pdf as disconnected, as the expected events of this RooProdPdf
depend on it.

Closes this old Jira ticket:
https://sft.its.cern.ch/jira/browse/ROOT-7604

FYI, @will-cern, sorry that it took almost 10 years :)