### PR TITLE
[PyROOT][DF] Remove deprecated MakeNumpyDataFrame

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_facade.py
@@ -327,12 +327,6 @@ class ROOTFacade(types.ModuleType):
         try:
             # Inject FromNumpy function
             from libROOTPythonizations import MakeNumpyDataFrame
-            def DeprecatedMakeNumpy(*args, **kwargs):
-                import warnings
-                warnings.warn("MakeNumpyDataFrame is deprecated since v6.28 and will be removed in v6.30."\
-                              "Please use FromNumpy instead.", FutureWarning)
-                return MakeNumpyDataFrame(*args, **kwargs)
-            ns.MakeNumpyDataFrame = DeprecatedMakeNumpy
             ns.FromNumpy = MakeNumpyDataFrame
 
             if sys.version_info >= (3, 8):


### PR DESCRIPTION
It escaped the after-release purge because it does not use the `R__DEPRECATED` mechanism.