### PR TITLE
[math] Add missing `<limits>` include to `Delaunay2D.cxx`

### DIFF
--- a/math/mathcore/src/Delaunay2D.cxx
+++ b/math/mathcore/src/Delaunay2D.cxx
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 
 #include <iostream>
+#include <limits>
 
 namespace ROOT {
 


### PR DESCRIPTION
Follows up on:

https://github.com/root-project/root/pull/12545

To fix the errors seen here, for example:
https://github.com/root-project/root/pull/12955#issuecomment-1592735649

