### PR TITLE
[RF] Update RooAbsCollection.cxx - fix invalid read bug in remove

### DIFF
--- a/roofit/roofitcore/src/RooAbsCollection.cxx
+++ b/roofit/roofitcore/src/RooAbsCollection.cxx
@@ -672,12 +672,6 @@ bool RooAbsCollection::remove(const RooAbsCollection& list, bool /*silent*/, boo
 
     _list.erase(std::remove_if(_list.begin(), _list.end(), nameMatchAndMark), _list.end());
 
-    std::set<const RooAbsArg*> toBeDeleted(markedItems.begin(), markedItems.end());
-    if (_ownCont) {
-      for (auto arg : toBeDeleted) {
-        delete arg;
-      }
-    }
   }
   else {
     auto argMatchAndMark = [&list, &markedItems](const RooAbsArg* elm) {
@@ -694,6 +688,13 @@ bool RooAbsCollection::remove(const RooAbsCollection& list, bool /*silent*/, boo
   if (_hashAssistedFind && oldSize != _list.size()) {
     for( auto& var : markedItems ) {
       _hashAssistedFind->erase(var);
+    }
+  }
+  
+  if (matchByNameOnly && _ownCont) {
+    std::set<const RooAbsArg*> toBeDeleted(markedItems.begin(), markedItems.end());
+    for (auto arg : toBeDeleted) {
+        delete arg;
     }
   }
 


### PR DESCRIPTION
if the hashAssistedFind feature is active, the old code gave an invalid read because of the delete further up. This change ensures the deletion happens last
