### PR TITLE
Enable reading on-disk std::array as RVec 

### DIFF
--- a/tree/dataframe/inc/ROOT/RNTupleDS.hxx
+++ b/tree/dataframe/inc/ROOT/RNTupleDS.hxx
@@ -93,18 +93,25 @@ class RNTupleDS final : public ROOT::RDF::RDataSource {
    /// onto slots.  In the InitSlot method, the column readers use this map to find the correct range to connect to.
    std::unordered_map<ULong64_t, std::size_t> fFirstEntry2RangeIdx;
 
+   /// \brief Holds useful information about fields added to the RNTupleDS
+   struct RFieldInfo {
+      DescriptorId_t fFieldId;
+      std::size_t fNRepetitions;
+      // Enable `std::vector::emplace_back` for this type
+      RFieldInfo(DescriptorId_t fieldId, std::size_t nRepetitions) : fFieldId(fieldId), fNRepetitions(nRepetitions) {}
+   };
+
    /// Provides the RDF column "colName" given the field identified by fieldID. For records and collections,
-   /// AddField recurses into the sub fields. The skeinIDs is the list of field IDs of the outer collections
-   /// of fieldId. For instance, if fieldId refers to an `std::vector<Jet>`, with
+   /// AddField recurses into the sub fields. The fieldInfos argument is a list of objects holding info
+   /// about the fields of the outer collection(s) (w.r.t. fieldId). For instance, if fieldId refers to an
+   /// `std::vector<Jet>`, with
    /// struct Jet {
    ///    float pt;
    ///    float eta;
    /// };
    /// AddField will recurse into Jet.pt and Jet.eta and provide the two inner fields as std::vector<float> each.
-   void AddField(const RNTupleDescriptor &desc,
-                 std::string_view colName,
-                 DescriptorId_t fieldId,
-                 std::vector<DescriptorId_t> skeinIDs);
+   void AddField(const RNTupleDescriptor &desc, std::string_view colName, DescriptorId_t fieldId,
+                 std::vector<RFieldInfo> fieldInfos);
 
    /// Populates fNextRanges with the next set of entry ranges. Opens files from the chain as necessary
    /// and aligns ranges with cluster boundaries for scheduling the tail of files.

--- a/tree/dataframe/test/CMakeLists.txt
+++ b/tree/dataframe/test/CMakeLists.txt
@@ -105,6 +105,10 @@ if(root7)
   endif()
 
   ROOT_ADD_GTEST(dataframe_unified_constructor dataframe_unified_constructor.cxx LIBRARIES ROOTDataFrame)
+
+  ROOT_GENERATE_DICTIONARY(ClassWithArraysDict ${CMAKE_CURRENT_SOURCE_DIR}/ClassWithArrays.h
+                           MODULE datasource_ntuple LINKDEF ClassWithArraysLinkDef.h OPTIONS -inlineInputHeader
+                           DEPENDENCIES ROOTVecOps)
 endif()
 
 if(sqlite)

--- a/tree/dataframe/test/ClassWithArrays.h
+++ b/tree/dataframe/test/ClassWithArrays.h
@@ -1,0 +1,28 @@
+#ifndef DATASOURCE_NTUPLE_TEST_CLASS_WITH_ARRAYS
+#define DATASOURCE_NTUPLE_TEST_CLASS_WITH_ARRAYS
+
+#include <array>
+
+#include <Rtypes.h>
+#include <ROOT/RVec.hxx>
+
+class ClassWithArrays {
+public:
+   virtual ~ClassWithArrays() {} // to make dictionary generation happy
+
+   std::array<float, 3> fArr{};
+   std::array<ROOT::RVecF, 3> fArrRVec{};
+   ROOT::RVec<std::array<float, 3>> fRVecArr{};
+
+   ClassWithArrays() {}
+
+   ClassWithArrays(std::array<float, 3> &&arr, std::array<ROOT::RVecF, 3> &&arrRvec,
+                   ROOT::RVec<std::array<float, 3>> &&rVecArr)
+      : fArr(std::move(arr)), fArrRVec(std::move(arrRvec)), fRVecArr(std::move(rVecArr))
+   {
+   }
+
+   ClassDef(ClassWithArrays, 2)
+};
+
+#endif // DATASOURCE_NTUPLE_TEST_CLASS_WITH_ARRAYS

--- a/tree/dataframe/test/ClassWithArraysLinkDef.h
+++ b/tree/dataframe/test/ClassWithArraysLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __ROOTCLING__
+
+#pragma link C++ class ClassWithArrays + ;
+
+#endif

--- a/tree/dataframe/test/datasource_ntuple.cxx
+++ b/tree/dataframe/test/datasource_ntuple.cxx
@@ -10,6 +10,10 @@
 
 #include <gtest/gtest.h>
 
+#include "ClassWithArrays.h"
+
+#include <limits>
+
 using ROOT::Experimental::RNTupleDS;
 using ROOT::Experimental::RNTupleWriter;
 using ROOT::Experimental::RNTupleModel;

--- a/tree/dataframe/test/datasource_ntuple.cxx
+++ b/tree/dataframe/test/datasource_ntuple.cxx
@@ -19,6 +19,15 @@ using ROOT::Experimental::RNTupleWriter;
 using ROOT::Experimental::RNTupleModel;
 using ROOT::Experimental::Detail::RPageSource;
 
+template <typename V1, typename V2>
+void EXPECT_VEC_EQ(const V1 &v1, const V2 &v2)
+{
+   ASSERT_EQ(v1.size(), v2.size());
+   for (std::size_t i = 0ul; i < v1.size(); ++i) {
+      EXPECT_EQ(v1[i], v2[i]);
+   }
+}
+
 class RNTupleDSTest : public ::testing::Test {
 protected:
    std::string fFileName = "RNTupleDS_test.root";
@@ -239,5 +248,273 @@ TEST_F(RNTupleDSTest, ChainMT)
    IMTRAII _;
 
    ChainTest(fNtplName, fFileName);
+}
+#endif
+
+const static std::array<ROOT::RVec<std::array<ROOT::RVecI, 3>>, 3> arraysDatasetCol4El{
+   ROOT::RVec<std::array<ROOT::RVecI, 3>>{
+      {ROOT::RVecI{1, 2}, ROOT::RVecI{4, 5, 6}, ROOT::RVecI{42, 43, 44, 45}},
+   },
+   ROOT::RVec<std::array<ROOT::RVecI, 3>>{
+      {ROOT::RVecI{55, 66}, ROOT::RVecI{-18, 33, std::numeric_limits<std::int32_t>::max()},
+       ROOT::RVecI{42, std::numeric_limits<std::int32_t>::min(), 44, 1888}},
+      {ROOT::RVecI{10, 11}, ROOT::RVecI{-32, -33, -34}, ROOT::RVecI{2953, -20, 343212}},
+   },
+   ROOT::RVec<std::array<ROOT::RVecI, 3>>{
+      {ROOT::RVecI{-32, -33, -34}, ROOT::RVecI{42, -43, 44, -45}, ROOT::RVecI{1}},
+      {ROOT::RVecI{0, 0, std::numeric_limits<std::int32_t>::min(), 42}, ROOT::RVecI{-32, -33, -34},
+       ROOT::RVecI{30000, 40000, 50000}},
+      {ROOT::RVecI{0, 0, std::numeric_limits<std::int32_t>::min(), 42}, ROOT::RVecI{-32, -33, -34},
+       ROOT::RVecI{std::numeric_limits<std::int32_t>::min(), std::numeric_limits<std::int32_t>::max(),
+                   std::numeric_limits<std::int32_t>::min()}},
+   }};
+
+class RNTupleDSArraysDataset : public ::testing::Test {
+protected:
+   std::string fFileName = "rntupleds_arrays_dataset.root";
+   std::string fNtplName = "ntuple";
+
+   void SetUp() override
+   {
+      auto model = RNTupleModel::Create();
+      auto col1_arr = model->MakeField<std::array<int, 3>>("col1_arr");
+      auto col2_arr_rvec = model->MakeField<std::array<ROOT::RVecI, 3>>("col2_arr_rvec");
+      auto col3_rvec_arr = model->MakeField<ROOT::RVec<std::array<int, 3>>>("col3_rvec_arr");
+      auto col4_arr_rvec_arr_rvec =
+         model->MakeField<std::array<ROOT::RVec<std::array<ROOT::RVecI, 3>>, 3>>("col4_arr_rvec_arr_rvec");
+      auto col5_class_with_arrays = model->MakeField<ClassWithArrays>("col5_class_with_arrays");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), fNtplName, fFileName);
+      for (int i = 1; i <= 5; i++) {
+
+         *col1_arr = {1 * i, 2 * i, 3 * i};
+
+         *col2_arr_rvec = {ROOT::RVecI{i}, ROOT::RVecI{1 * i, 2 * i, 3 * i},
+                           ROOT::RVecI{-1 * i, -2 * i, -3 * i, -4 * i, -5 * i}};
+
+         ROOT::RVec<std::array<int, 3>> rvecVal;
+         rvecVal.reserve(i);
+         for (auto j = 0; j < i; j++) {
+            rvecVal.emplace_back(std::array<int, 3>{1 * i, 2 * i, 3 * i});
+         }
+         *col3_rvec_arr = rvecVal;
+
+         *col4_arr_rvec_arr_rvec = arraysDatasetCol4El;
+
+         std::array<float, 3> col5_member_1{42.f, std::numeric_limits<float>::max(), 0.f};
+         std::array<ROOT::RVecF, 3> col5_member_2{ROOT::RVecF{1.f}, ROOT::RVecF{2.f, 3.f}, ROOT::RVecF{4.f, 5.f, 6.f}};
+         ROOT::RVec<std::array<float, 3>> col5_member_3{col5_member_1, col5_member_1, col5_member_1, col5_member_1};
+         *col5_class_with_arrays =
+            ClassWithArrays{std::move(col5_member_1), std::move(col5_member_2), std::move(col5_member_3)};
+
+         ntuple->Fill();
+      }
+   }
+
+   void TearDown() override { std::remove(fFileName.c_str()); }
+};
+
+void ReadArraysTest(const std::string &name, const std::string &fname)
+{
+   // These tests use the columns that contain std::array data on disk as RVecs
+   // reading them into RVecs and checking their values.
+   auto df = ROOT::RDF::Experimental::FromRNTuple(name, fname);
+
+   auto count = df.Count();
+
+   auto col1Take = df.Take<ROOT::RVecI>("col1_arr");
+   auto col2Take = df.Take<ROOT::RVec<ROOT::RVecI>>("col2_arr_rvec");
+   auto col3Take = df.Take<ROOT::RVec<ROOT::RVecI>>("col3_rvec_arr");
+   auto col4Take = df.Take<ROOT::RVec<ROOT::RVec<ROOT::RVec<ROOT::RVecI>>>>("col4_arr_rvec_arr_rvec");
+   auto col5TakeArr = df.Take<ROOT::RVecF>("col5_class_with_arrays.fArr");
+   auto col5TakeArrRVec = df.Take<ROOT::RVec<ROOT::RVecF>>("col5_class_with_arrays.fArrRVec");
+   auto col5TakeRVecArr = df.Take<ROOT::RVec<ROOT::RVecF>>("col5_class_with_arrays.fRVecArr");
+
+   EXPECT_EQ(5ull, count.GetValue());
+
+   auto col1Val = col1Take.GetValue();
+   EXPECT_EQ(col1Val.size(), 5);
+   for (int i = 1; i <= 5; i++) {
+      EXPECT_VEC_EQ(col1Val[i - 1], ROOT::RVecI{1 * i, 2 * i, 3 * i});
+   }
+
+   auto col2Val = col2Take.GetValue();
+   EXPECT_EQ(col2Val.size(), 5);
+   for (int i = 1; i <= 5; i++) {
+      EXPECT_VEC_EQ(col2Val[i - 1][0], ROOT::RVecI{i});
+      EXPECT_VEC_EQ(col2Val[i - 1][1], ROOT::RVecI{1 * i, 2 * i, 3 * i});
+      EXPECT_VEC_EQ(col2Val[i - 1][2], ROOT::RVecI{-1 * i, -2 * i, -3 * i, -4 * i, -5 * i});
+   }
+
+   auto col3Val = col3Take.GetValue();
+   EXPECT_EQ(col3Val.size(), 5);
+   for (int i = 1; i <= 5; i++) {
+      for (auto j = 0; j < i; j++) {
+         EXPECT_VEC_EQ(col3Val[i - 1][j], std::array<int, 3>{1 * i, 2 * i, 3 * i});
+      }
+   }
+
+   auto col4Val = col4Take.GetValue();
+   EXPECT_EQ(col4Val.size(), 5);
+
+   // Each event contains the values of arraysDatasetCol4El in column 4
+   for (unsigned i = 0; i < 5; i++) {
+      // Unpack the three top-level std::arrays
+      const auto &arr1 = col4Val[i][0];
+      const auto &arr2 = col4Val[i][1];
+      const auto &arr3 = col4Val[i][2];
+
+      // The first contains an RVec with only one element
+      for (unsigned k = 0; k < arr1.size(); k++) {
+         EXPECT_VEC_EQ(arr1[0][k], arraysDatasetCol4El[0][0][k]);
+      }
+
+      // The others contain more than one element in their sub-level RVecs
+      for (unsigned j = 0; j < arr2.size(); j++) {
+         for (unsigned k = 0; k < arr2[j].size(); k++) {
+            EXPECT_VEC_EQ(arr2[j][k], arraysDatasetCol4El[1][j][k]);
+         }
+      }
+
+      for (unsigned j = 0; j < arr3.size(); j++) {
+         for (unsigned k = 0; k < arr3[j].size(); k++) {
+            EXPECT_VEC_EQ(arr3[j][k], arraysDatasetCol4El[2][j][k]);
+         }
+      }
+   }
+
+   auto col5ValArr = col5TakeArr.GetValue();
+   auto col5ValArrRVec = col5TakeArrRVec.GetValue();
+   auto col5ValRVecArr = col5TakeRVecArr.GetValue();
+   EXPECT_EQ(col5ValArr.size(), 5);
+   EXPECT_EQ(col5ValArrRVec.size(), 5);
+   EXPECT_EQ(col5ValRVecArr.size(), 5);
+
+   std::array<float, 3> col5_member_1{42.f, std::numeric_limits<float>::max(), 0.f};
+   for (const auto &arr : col5ValArr) {
+      EXPECT_VEC_EQ(arr, col5_member_1);
+   }
+
+   std::array<ROOT::RVecF, 3> col5_member_2{ROOT::RVecF{1.f}, ROOT::RVecF{2.f, 3.f}, ROOT::RVecF{4.f, 5.f, 6.f}};
+   for (const auto &arr : col5ValArrRVec) {
+      for (unsigned i = 0; i < 3; i++) {
+         EXPECT_VEC_EQ(arr[i], col5_member_2[i]);
+      }
+   }
+
+   ROOT::RVec<std::array<float, 3>> col5_member_3{col5_member_1, col5_member_1, col5_member_1, col5_member_1};
+   for (const auto &arr : col5ValRVecArr) {
+      for (unsigned i = 0; i < 4; i++) {
+         EXPECT_VEC_EQ(arr[i], col5_member_3[i]);
+      }
+   }
+}
+
+TEST_F(RNTupleDSArraysDataset, Read)
+{
+   ReadArraysTest(fNtplName, fFileName);
+}
+
+#ifdef R__USE_IMT
+
+TEST_F(RNTupleDSArraysDataset, ReadMT)
+{
+   IMTRAII _;
+
+   ReadArraysTest(fNtplName, fFileName);
+}
+#endif
+
+void UseArraysAsRVec(const std::string &name, const std::string &fname)
+{
+   // These tests use the columns that contain std::array data on disk as RVecs
+   // passing them as arguments to functions that expect RVecs.
+   auto df = ROOT::RDF::Experimental::FromRNTuple(name, fname);
+
+   auto df1 = df.Define("col1_short", [](const ROOT::RVecI &arr) { return ROOT::VecOps::Take(arr, 2); }, {"col1_arr"});
+   auto take1 = df1.Take<ROOT::RVecI>("col1_short");
+
+   // Exercise jitting
+   auto df2 = df1.Define("sum_col2",
+                         "int sum = 0; for (const auto &v: col3_rvec_arr) sum += ROOT::VecOps::Sum(v); return sum;");
+   auto take2 = df2.Take<int>("sum_col2");
+
+   auto take1Val = take1.GetValue();
+   for (int i = 0; i < 5; i++) {
+      EXPECT_VEC_EQ(take1Val[i], ROOT::RVecI{(i + 1), (i + 1) * 2});
+   }
+
+   std::array<int, 5> expectedVals{6, 24, 54, 96, 150};
+   EXPECT_VEC_EQ(take2.GetValue(), expectedVals);
+}
+
+TEST_F(RNTupleDSArraysDataset, UseArrays)
+{
+   UseArraysAsRVec(fNtplName, fFileName);
+}
+
+#ifdef R__USE_IMT
+
+TEST_F(RNTupleDSArraysDataset, UseArraysMT)
+{
+   IMTRAII _;
+
+   UseArraysAsRVec(fNtplName, fFileName);
+}
+#endif
+
+void UseArraySizeColumn(const std::string &name, const std::string &fname)
+{
+   // These tests use the columns that contain std::array data on disk as RVecs
+   // checking the size of the collection with the R_rdf_sizeof_* columns
+   auto df = ROOT::RDF::Experimental::FromRNTuple(name, fname);
+
+   auto sizeOfCol1 = df.Take<std::size_t>("R_rdf_sizeof_col1_arr");
+   // Use # here to exercise that too
+   auto sizeOfCol2 = df.Take<ROOT::RVec<std::size_t>>("#col2_arr_rvec");
+   auto sizeOfCol4 = df.Take<ROOT::RVec<ROOT::RVec<ROOT::RVec<std::size_t>>>>("R_rdf_sizeof_col4_arr_rvec_arr_rvec");
+
+   EXPECT_VEC_EQ(sizeOfCol1.GetValue(), std::array<std::size_t, 5>{3, 3, 3, 3, 3});
+
+   for (const auto &sizeVec : sizeOfCol2) {
+      EXPECT_VEC_EQ(sizeVec, ROOT::RVecULL{1, 3, 5});
+   }
+
+   // The sizes of elements in col4 are
+   // { { { 2, 3, 4 } }, { { 2, 3, 4 }, { 2, 3, 3 } }, { { 3, 4, 1 }, { 4, 3, 3 }, { 4, 3, 3 } } }
+   auto sizeOfCol4Val = sizeOfCol4.GetValue();
+   for (unsigned i = 0; i < 5; i++) {
+      // Unpack the three top-level vectors
+      const auto &rvec1 = sizeOfCol4Val[i][0];
+      const auto &rvec2 = sizeOfCol4Val[i][1];
+      const auto &rvec3 = sizeOfCol4Val[i][2];
+
+      // The first contains an RVec with only one element
+      EXPECT_VEC_EQ(rvec1[0], ROOT::RVecULL{2, 3, 4});
+
+      // The others contain more than one element in their sub-level RVecs
+      ROOT::RVec<ROOT::RVecULL> expectedRVecs2{{2, 3, 4}, {2, 3, 3}};
+      for (unsigned j = 0; j < rvec2.size(); j++) {
+         EXPECT_VEC_EQ(rvec2[j], expectedRVecs2[j]);
+      }
+
+      ROOT::RVec<ROOT::RVecULL> expectedRVecs3{{3, 4, 1}, {4, 3, 3}, {4, 3, 3}};
+      for (unsigned j = 0; j < rvec3.size(); j++) {
+         EXPECT_VEC_EQ(rvec3[j], expectedRVecs3[j]);
+      }
+   }
+}
+
+TEST_F(RNTupleDSArraysDataset, UseArraySizeColumn)
+{
+   UseArraySizeColumn(fNtplName, fFileName);
+}
+
+#ifdef R__USE_IMT
+
+TEST_F(RNTupleDSArraysDataset, UseArraySizeColumnMT)
+{
+   IMTRAII _;
+
+   UseArraySizeColumn(fNtplName, fFileName);
 }
 #endif

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -1112,6 +1112,9 @@ public:
 
    std::size_t GetValueSize() const final { return fValueSize; }
    std::size_t GetAlignment() const final;
+
+   std::vector<Detail::RFieldBase::RValue> SplitValue(const Detail::RFieldBase::RValue &value) const final;
+   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 };
 
 /// The generic field an std::bitset<N>. All compilers we care about store the bits in an array of unsigned long.

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -45,6 +45,7 @@ public:
    virtual void VisitField(const Detail::RFieldBase &field) = 0;
    virtual void VisitFieldZero(const RFieldZero &field) { VisitField(field); }
    virtual void VisitArrayField(const RArrayField &field) { VisitField(field); }
+   virtual void VisitArrayAsRVecField(const RArrayAsRVecField &field) { VisitField(field); }
    virtual void VisitAtomicField(const RAtomicField &field) { VisitField(field); }
    virtual void VisitBitsetField(const RBitsetField &field) { VisitField(field); }
    virtual void VisitBoolField(const RField<bool> &field) { VisitField(field); }
@@ -215,6 +216,7 @@ public:
 
    void VisitCardinalityField(const RCardinalityField &field) final;
    void VisitArrayField(const RArrayField &field) final;
+   void VisitArrayAsRVecField(const RArrayAsRVecField &field) final;
    void VisitClassField(const RClassField &field) final;
    void VisitRecordField(const RRecordField &field) final;
    void VisitProxiedCollectionField(const RProxiedCollectionField &field) final;

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -2634,6 +2634,22 @@ size_t ROOT::Experimental::RArrayAsRVecField::GetAlignment() const
    return EvalRVecAlignment(fSubFields[0]->GetAlignment());
 }
 
+std::vector<ROOT::Experimental::Detail::RFieldBase::RValue>
+ROOT::Experimental::RArrayAsRVecField::SplitValue(const ROOT::Experimental::Detail::RFieldBase::RValue &value) const
+{
+   auto arrayPtr = value.Get<unsigned char>();
+   std::vector<ROOT::Experimental::Detail::RFieldBase::RValue> result;
+   for (unsigned i = 0; i < fArrayLength; ++i) {
+      result.emplace_back(fSubFields[0]->BindValue(arrayPtr + (i * fItemSize)));
+   }
+   return result;
+}
+
+void ROOT::Experimental::RArrayAsRVecField::AcceptVisitor(ROOT::Experimental::Detail::RFieldVisitor &visitor) const
+{
+   visitor.VisitArrayAsRVecField(*this);
+}
+
 // RArrayAsRVecField
 //------------------------------------------------------------------------------
 

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -302,6 +302,10 @@ void ROOT::Experimental::RPrintValueVisitor::VisitArrayField(const RArrayField &
    PrintCollection(field);
 }
 
+void ROOT::Experimental::RPrintValueVisitor::VisitArrayAsRVecField(const RArrayAsRVecField &field)
+{
+   PrintCollection(field);
+}
 
 void ROOT::Experimental::RPrintValueVisitor::VisitClassField(const RClassField &field)
 {

--- a/tree/ntuple/v7/test/ntuple_print.cxx
+++ b/tree/ntuple/v7/test/ntuple_print.cxx
@@ -115,6 +115,23 @@ TEST(RNtuplePrint, Vector)
    EXPECT_EQ(expected, os.str());
 }
 
+TEST(RNtuplePrint, ArrayAsRVec)
+{
+   std::stringstream os;
+   RPrepareVisitor prepVisitor;
+   ROOT::Experimental::RArrayAsRVecField testField("arrayasrvecfield",
+                                                   std::make_unique<ROOT::Experimental::RField<float>>("myfloat"), 0);
+   testField.AcceptVisitor(prepVisitor);
+   RPrintSchemaVisitor visitor(os, '$');
+   visitor.SetDeepestLevel(prepVisitor.GetDeepestLevel());
+   visitor.SetNumFields(prepVisitor.GetNumFields());
+   testField.AcceptVisitor(visitor);
+   std::string expected{std::string("") +
+                        "$ Field 1       : arrayasrvecfield (ROOT::VecOps::RVec<float>)                 $\n" +
+                        "$   Field 1.1   : myfloat (float)                                              $\n"};
+   EXPECT_EQ(expected, os.str());
+}
+
 TEST(RNtuplePrint, VectorNested)
 {
    std::stringstream os;


### PR DESCRIPTION
The most common way to deal with columns containing collections in an
RDataFrame execution is through RVec. The changes in this commit allow
reading on-disk std::array fields as RVecs in memory. A new RArrayAsRVec
RField subclass is implemented with this aim.

UPDATE:
Tests are present for:
1. `std::array`
2. Combinations of `std::array` and `ROOT::RVec` up to 4 levels of nestedness
3. Custom classes containing `std::array` and combinations with `ROOT::RVec` in the data members