### PR TITLE
Apply some fixes in stressHistoFit, TMVA Keras tutorials and mathmore

### DIFF
--- a/math/mathmore/src/GSLRndmEngines.cxx
+++ b/math/mathmore/src/GSLRndmEngines.cxx
@@ -258,7 +258,11 @@ namespace Math {
       if (covmat) {
          gsl_matrix_const_view A = gsl_matrix_const_view_array(covmat, dim, dim);
          gsl_matrix_memcpy(&L.matrix, &A.matrix);
+#if ((GSL_MAJOR_VERSION >= 2) && (GSL_MINOR_VERSION > 2))
          gsl_linalg_cholesky_decomp1(&L.matrix);
+#else
+         gsl_linalg_cholesky_decomp(&L.matrix);
+#endif
       }
       // if covMat is not provide we use directly L
       gsl_ran_multivariate_gaussian(fRng->Rng(), &mu.vector, &L.matrix, &x.vector);

--- a/test/stressHistoFit.cxx
+++ b/test/stressHistoFit.cxx
@@ -569,7 +569,7 @@ int testFit(int itest, const char* str1, const char* str2, const char* str3,
          }
          fflush(stdout);
       }
-      setColor(0);
+      if (opts & testOptColor ) setColor(0);
    }
 
    if ( opts & testOptErr )
@@ -630,7 +630,7 @@ int testFit(int itest, const char* str1, const char* str2, const char* str3,
 
    if ( opts != 0 )
    {
-      setColor(0);
+      if ( opts & testOptColor ) setColor(0);
       if ( debug )
          printf("\n");
    }

--- a/tutorials/tmva/keras/ClassificationKeras.py
+++ b/tutorials/tmva/keras/ClassificationKeras.py
@@ -22,7 +22,7 @@ from tensorflow.keras.optimizers import SGD
 TMVA.Tools.Instance()
 TMVA.PyMethodBase.PyInitialize()
 
-output = TFile.Open('TMVA.root', 'RECREATE')
+output = TFile.Open('TMVA_Classification_Keras.root', 'RECREATE')
 factory = TMVA.Factory('TMVAClassification', output,
                        '!V:!Silent:Color:DrawProgressBar:Transformations=D,G:AnalysisType=Classification')
 

--- a/tutorials/tmva/keras/RegressionKeras.py
+++ b/tutorials/tmva/keras/RegressionKeras.py
@@ -22,7 +22,7 @@ from tensorflow.keras.optimizers import SGD
 TMVA.Tools.Instance()
 TMVA.PyMethodBase.PyInitialize()
 
-output = TFile.Open('TMVA.root', 'RECREATE')
+output = TFile.Open('TMVA_Regression_Keras.root', 'RECREATE')
 factory = TMVA.Factory('TMVARegression', output,
         '!V:!Silent:Color:DrawProgressBar:Transformations=D,G:AnalysisType=Regression')
 


### PR DESCRIPTION
This PR fixes: 
- stressHistoFit - so not use colour (even black) to keep a nice output log
- TMVA Keras tutorial: use different output file to avoid sporadic failures
- mathmore (GSL) : add a check for correct GSL version (2.3) introducing the new function `gsl_linalg_cholesky_decomp1`. Use the older `gsl_linalg_cholesky_decomp` for the old versions. 


