### PR TITLE
[cxxmodules] Avoid loading more modules while instantiating templates [v6.28]

### DIFF
--- a/core/metacling/src/TClingCallbacks.cxx
+++ b/core/metacling/src/TClingCallbacks.cxx
@@ -442,6 +442,14 @@ bool TClingCallbacks::findInGlobalModuleIndex(DeclarationName Name, bool loadFir
    if (fIsCodeGening)
       return false;
 
+   // We are currently instantiating one (or more) templates. At that point,
+   // all Decls are present in the AST (with possibly deserialization pending),
+   // and we should not load more modules which could find an implicit template
+   // instantiation that is lazily loaded.
+   Sema &SemaR = m_Interpreter->getSema();
+   if (SemaR.InstantiatingSpecializations.size() > 0)
+      return false;
+
    GlobalModuleIndex *Index = CI->getASTReader()->getGlobalIndex();
    if (!Index)
       return false;


### PR DESCRIPTION
When instantiating templates, all Decls are present in the AST (with possibly deserialization pending). At that point, we should not load more modules which could find an implicit template instantiation that is lazily loaded.

Fixes #12003

(cherry picked from commit ffdc579bbcd858e966db879c4258d0623eb520f1)

Backport of https://github.com/root-project/root/pull/13046