### PR TITLE
[HS3][RF] importing workspaces from JSON now successfully fills the NPs and Globs lists in ModelConfigs

### DIFF
--- a/roofit/histfactory/inc/RooStats/HistFactory/PiecewiseInterpolation.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/PiecewiseInterpolation.h
@@ -31,7 +31,11 @@ class PiecewiseInterpolation : public RooAbsReal {
 public:
 
   PiecewiseInterpolation() ;
-  PiecewiseInterpolation(const char *name, const char *title, const RooAbsReal& nominal, const RooArgList& lowSet, const RooArgList& highSet, const RooArgList& paramSet, bool takeOwnerShip=false) ;
+  PiecewiseInterpolation(const char *name, const char *title, const RooAbsReal& nominal, const RooArgList& lowSet, const RooArgList& highSet, const RooArgList& paramSet
+#ifndef ROOFIT_MEMORY_SAFE_INTERFACES
+              , bool takeOwnership=false
+#endif
+  );
   ~PiecewiseInterpolation() override ;
 
   PiecewiseInterpolation(const PiecewiseInterpolation& other, const char *name = nullptr);

--- a/roofit/histfactory/src/PiecewiseInterpolation.cxx
+++ b/roofit/histfactory/src/PiecewiseInterpolation.cxx
@@ -70,8 +70,11 @@ PiecewiseInterpolation::PiecewiseInterpolation() : _normIntMgr(this)
 PiecewiseInterpolation::PiecewiseInterpolation(const char* name, const char* title, const RooAbsReal& nominal,
                       const RooArgList& lowSet,
                       const RooArgList& highSet,
-                      const RooArgList& paramSet,
-                      bool takeOwnership) :
+                      const RooArgList& paramSet
+#ifndef ROOFIT_MEMORY_SAFE_INTERFACES
+                     , bool takeOwnership
+#endif
+  ) :
   RooAbsReal(name, title),
   _normIntMgr(this),
   _nominal("!nominal","nominal value", this, (RooAbsReal&)nominal),
@@ -94,9 +97,11 @@ PiecewiseInterpolation::PiecewiseInterpolation(const char* name, const char* tit
       RooErrorHandler::softAbort() ;
     }
     _lowSet.add(*comp) ;
+#ifndef ROOFIT_MEMORY_SAFE_INTERFACES
     if (takeOwnership) {
       _ownedList.addOwned(std::unique_ptr<RooAbsArg>{comp});
     }
+#endif
   }
 
 
@@ -107,9 +112,11 @@ PiecewiseInterpolation::PiecewiseInterpolation(const char* name, const char* tit
       RooErrorHandler::softAbort() ;
     }
     _highSet.add(*comp) ;
+#ifndef ROOFIT_MEMORY_SAFE_INTERFACES
     if (takeOwnership) {
       _ownedList.addOwned(std::unique_ptr<RooAbsArg>{comp});
     }
+#endif
   }
 
 
@@ -120,9 +127,11 @@ PiecewiseInterpolation::PiecewiseInterpolation(const char* name, const char* tit
       RooErrorHandler::softAbort() ;
     }
     _paramSet.add(*comp) ;
+#ifndef ROOFIT_MEMORY_SAFE_INTERFACES
     if (takeOwnership) {
       _ownedList.addOwned(std::unique_ptr<RooAbsArg>{comp});
     }
+#endif
     _interpCode.push_back(0); // default code: linear interpolation
   }
 

--- a/roofit/hs3/src/JSONFactories_HistFactory.cxx
+++ b/roofit/hs3/src/JSONFactories_HistFactory.cxx
@@ -327,8 +327,7 @@ bool importHistSample(RooJSONFactoryWSTool &tool, RooDataHist &dh, RooArgSet con
          normElems.add(v);
       }
       if (!histNps.empty()) {
-         auto &v =
-            tool.wsEmplace<PiecewiseInterpolation>("histoSys_" + prefixedName, hf, histoLo, histoHi, histNps, false);
+         auto &v = tool.wsEmplace<PiecewiseInterpolation>("histoSys_" + prefixedName, hf, histoLo, histoHi, histNps);
          v.setAllInterpCodes(4); // default interpCode for HistFactory
          shapeElems.add(v);
       } else {

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -464,7 +464,7 @@ void importAnalysis(const JSONNode &rootnode, const JSONNode &analysisNode, cons
 
    mc->SetPdf(*pdf);
 
-   if(!extConstraints.empty())
+   if (!extConstraints.empty())
       mc->SetExternalConstraints(extConstraints);
 
    auto readArgSet = [&](std::string const &name) {
@@ -477,6 +477,20 @@ void importAnalysis(const JSONNode &rootnode, const JSONNode &analysisNode, cons
 
    mc->SetParametersOfInterest(readArgSet("parameters_of_interest"));
    mc->SetObservables(observables);
+   RooArgSet pars;
+   pdf->getParameters(&observables, pars);
+   RooArgSet nps;
+   RooArgSet globs;
+   for (const auto &p : pars) {
+      if (mc->GetParametersOfInterest()->find(*p))
+         continue;
+      if (p->isConstant())
+         globs.add(*p);
+      else
+         nps.add(*p);
+   }
+   mc->SetGlobalObservables(globs);
+   mc->SetNuisanceParameters(nps);
 
    if (mcAuxNode) {
       if (auto found = mcAuxNode->find("combined_data_name")) {

--- a/roofit/jsoninterface/inc/RooFit/Detail/JSONInterface.h
+++ b/roofit/jsoninterface/inc/RooFit/Detail/JSONInterface.h
@@ -190,6 +190,7 @@ public:
 
    static std::unique_ptr<JSONTree> create();
    static std::unique_ptr<JSONTree> create(std::istream &is);
+   static std::unique_ptr<JSONTree> create(std::string const &str);
 
    static std::string getBackend();
    static void setBackend(std::string const &name);
@@ -201,6 +202,9 @@ private:
    enum class Backend { NlohmannJson, Ryml };
 
    static Backend &getBackendEnum();
+
+   template <typename... Args>
+   static std::unique_ptr<JSONTree> createImpl(Args &&...args);
 };
 
 std::ostream &operator<<(std::ostream &os, RooFit::Detail::JSONNode const &s);

--- a/roofit/roofitcore/inc/RooAddition.h
+++ b/roofit/roofitcore/inc/RooAddition.h
@@ -28,8 +28,16 @@ class RooAddition : public RooAbsReal {
 public:
 
   RooAddition() : _cacheMgr(this,10) {}
-  RooAddition(const char *name, const char *title, const RooArgList& sumSet, bool takeOwnerShip=false) ;
-  RooAddition(const char *name, const char *title, const RooArgList& sumSet1, const RooArgList& sumSet2, bool takeOwnerShip=false) ;
+  RooAddition(const char *name, const char *title, const RooArgList& sumSet
+#ifndef ROOFIT_MEMORY_SAFE_INTERFACES
+              , bool takeOwnership=false
+#endif
+  );
+  RooAddition(const char *name, const char *title, const RooArgList& sumSet1, const RooArgList& sumSet2
+#ifndef ROOFIT_MEMORY_SAFE_INTERFACES
+              , bool takeOwnership=false
+#endif
+  );
 
   RooAddition(const RooAddition& other, const char* name = nullptr);
   TObject* clone(const char* newname) const override { return new RooAddition(*this, newname); }

--- a/roofit/roofitcore/inc/RooFit/Config.h
+++ b/roofit/roofitcore/inc/RooFit/Config.h
@@ -50,7 +50,7 @@ template <typename T>
 OwningPtr<T> owningPtr(std::unique_ptr<T> &&ptr)
 {
 #ifdef ROOFIT_OWNING_PTR_IS_UNIQUE_PTR
-   return ptr;
+   return std::move(ptr);
 #else
    return ptr.release();
 #endif

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1840,14 +1840,15 @@ RooAbsReal* RooAbsPdf::createChi2(RooDataHist& data, const RooCmdArg& arg1,  con
     for (std::string& token : ROOT::Split(rangeName, ",")) {
       RooCmdArg subRangeCmd = RooFit::Range(token.c_str()) ;
       // Construct chi2 while substituting original RangeWithName argument with subrange argument created above
-      RooAbsReal* chi2Comp = new RooChi2Var(Form("%s_%s", baseName.c_str(), token.c_str()), "chi^2", *this, data,
+      auto chi2Comp = std::make_unique<RooChi2Var>(Form("%s_%s", baseName.c_str(), token.c_str()), "chi^2", *this, data,
                    &arg1==rarg?subRangeCmd:arg1,&arg2==rarg?subRangeCmd:arg2,
                    &arg3==rarg?subRangeCmd:arg3,&arg4==rarg?subRangeCmd:arg4,
                    &arg5==rarg?subRangeCmd:arg5,&arg6==rarg?subRangeCmd:arg6,
                    &arg7==rarg?subRangeCmd:arg7,&arg8==rarg?subRangeCmd:arg8) ;
-      chi2List.add(*chi2Comp) ;
+      chi2List.addOwned(std::move(chi2Comp));
     }
-    chi2 = new RooAddition(baseName.c_str(),"chi^2",chi2List,true) ;
+    chi2 = new RooAddition(baseName.c_str(),"chi^2",chi2List);
+    chi2->addOwnedComponents(std::move(chi2List));
   }
   RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::PrintErrors) ;
 

--- a/roofit/roofitcore/src/RooAddition.cxx
+++ b/roofit/roofitcore/src/RooAddition.cxx
@@ -52,7 +52,11 @@ ClassImp(RooAddition);
 /// \param[in] sumSet The value of the function will be the sum of the values in this set
 /// \param[in] takeOwnership If true, the RooAddition object will take ownership of the arguments in `sumSet`
 
-RooAddition::RooAddition(const char* name, const char* title, const RooArgList& sumSet, bool takeOwnership)
+RooAddition::RooAddition(const char* name, const char* title, const RooArgList& sumSet
+#ifndef ROOFIT_MEMORY_SAFE_INTERFACES
+                         , bool takeOwnership
+#endif
+  )
   : RooAbsReal(name, title)
   , _set("!set","set of components",this)
   , _cacheMgr(this,10)
@@ -64,7 +68,9 @@ RooAddition::RooAddition(const char* name, const char* title, const RooArgList& 
       RooErrorHandler::softAbort() ;
     }
     _set.add(*comp) ;
+#ifndef ROOFIT_MEMORY_SAFE_INTERFACES
     if (takeOwnership) _ownedList.addOwned(std::unique_ptr<RooAbsArg>{comp});
+#endif
   }
 
 }
@@ -85,7 +91,11 @@ RooAddition::RooAddition(const char* name, const char* title, const RooArgList& 
 /// \param[in] sumSet2 Right-hand element of the pair-wise products
 /// \param[in] takeOwnership If true, the RooAddition object will take ownership of the arguments in the `sumSets`
 ///
-RooAddition::RooAddition(const char* name, const char* title, const RooArgList& sumSet1, const RooArgList& sumSet2, bool takeOwnership)
+RooAddition::RooAddition(const char* name, const char* title, const RooArgList& sumSet1, const RooArgList& sumSet2
+#ifndef ROOFIT_MEMORY_SAFE_INTERFACES
+                         , bool takeOwnership
+#endif
+  )
     : RooAbsReal(name, title)
     , _set("!set","set of components",this)
     , _cacheMgr(this,10)
@@ -110,20 +120,21 @@ RooAddition::RooAddition(const char* name, const char* title, const RooArgList& 
              << " in first list is not of type RooAbsReal" << std::endl;
       RooErrorHandler::softAbort() ;
     }
-    // TODO: add flag to RooProduct c'tor to make it assume ownership...
     TString _name(name);
     _name.Append( "_[");
     _name.Append(comp1->GetName());
     _name.Append( "_x_");
     _name.Append(comp2->GetName());
     _name.Append( "]");
-    auto prod = std::make_unique<RooProduct>( _name, _name , RooArgSet(*comp1, *comp2) /*, takeOwnership */ );
+    auto prod = std::make_unique<RooProduct>( _name, _name , RooArgSet(*comp1, *comp2));
     _set.add(*prod);
     _ownedList.addOwned(std::move(prod));
+#ifndef ROOFIT_MEMORY_SAFE_INTERFACES
     if (takeOwnership) {
         _ownedList.addOwned(std::unique_ptr<RooAbsArg>{comp1});
         _ownedList.addOwned(std::unique_ptr<RooAbsArg>{comp2});
     }
+#endif
   }
 }
 

--- a/roofit/roostats/src/HypoTestInverterResult.cxx
+++ b/roofit/roostats/src/HypoTestInverterResult.cxx
@@ -171,7 +171,6 @@ HypoTestInverterResult::HypoTestInverterResult( const char* name,
    // to avoid I/O problem of the Result class -
    // make the set owning the cloned copy (use clone instead of Clone to not copying all links)
    fParameters.removeAll();
-   fParameters.takeOwnership();
    fParameters.addOwned(std::unique_ptr<RooRealVar>{static_cast<RooRealVar *>(scannedVariable.clone(scannedVariable.GetName()))});
 }
 


### PR DESCRIPTION
# This Pull request:

importing workspaces from JSON now successfully fills the NPs and Globs lists in ModelConfigs

## Changes or fixes:


The solution for now is a bit makeshift, as it relies on the const/non-const properties to be set correctly at the time of creation.
However, it's better than not doing anything, as this now allows the ```ModelConfig::createNLL``` to do its job correctly on imported workspaces.


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

