### PR TITLE
[RF] Update RooFitResult.cxx - use printValue for constPars 

### DIFF
--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -386,23 +386,6 @@ public:
   static void setHideOffset(bool flag);
   static bool hideOffset() ;
 
-protected:
-  // Hook for objects with normalization-dependent parameters interpretation
-  virtual void selectNormalization(const RooArgSet* depSet=nullptr, bool force=false) ;
-  virtual void selectNormalizationRange(const char* rangeName=nullptr, bool force=false) ;
-
-  // Helper functions for plotting
-  bool plotSanityChecks(RooPlot* frame) const ;
-  void makeProjectionSet(const RooAbsArg* plotVar, const RooArgSet* allVars,
-          RooArgSet& projectedVars, bool silent) const ;
-
-  TString integralNameSuffix(const RooArgSet& iset, const RooArgSet* nset=nullptr, const char* rangeName=nullptr, bool omitEmpty=false) const ;
-
-
-
-
-
- public:
   bool isSelectedComp() const ;
   void selectComp(bool flag) {
      // If flag is true, only selected component will be included in evaluates of RooAddPdf components
@@ -422,7 +405,30 @@ protected:
   virtual std::string
   buildCallToAnalyticIntegral(Int_t code, const char *rangeName, RooFit::Detail::CodeSquashContext &ctx) const;
 
- protected:
+  // PlotOn with command list
+  virtual RooPlot* plotOn(RooPlot* frame, RooLinkedList& cmdList) const ;
+
+protected:
+  friend class BatchInterfaceAccessor;
+  friend class RooVectorDataStore;
+  friend class RooRealBinding;
+  friend class RooRealSumPdf;
+  friend class RooRealSumFunc;
+  friend class RooAddHelpers;
+  friend class RooAddPdf;
+  friend class RooAddModel;
+  friend class RooFit::Detail::DataMap;
+
+  // Hook for objects with normalization-dependent parameters interpretation
+  virtual void selectNormalization(const RooArgSet* depSet=nullptr, bool force=false) ;
+  virtual void selectNormalizationRange(const char* rangeName=nullptr, bool force=false) ;
+
+  // Helper functions for plotting
+  bool plotSanityChecks(RooPlot* frame) const ;
+  void makeProjectionSet(const RooAbsArg* plotVar, const RooArgSet* allVars,
+          RooArgSet& projectedVars, bool silent) const ;
+
+  TString integralNameSuffix(const RooArgSet& iset, const RooArgSet* nset=nullptr, const char* rangeName=nullptr, bool omitEmpty=false) const ;
 
   RooFit::OwningPtr<RooFitResult> chi2FitDriver(RooAbsReal& fcn, RooLinkedList& cmdList);
 
@@ -445,10 +451,8 @@ protected:
   bool matchArgs(const RooArgSet& allDeps, RooArgSet& numDeps,
          const RooArgSet& set) const ;
 
-
   RooFit::OwningPtr<RooAbsReal> createIntObj(const RooArgSet& iset, const RooArgSet* nset, const RooNumIntConfig* cfg, const char* rangeName) const ;
   void findInnerMostIntegration(const RooArgSet& allObs, RooArgSet& innerObs, const char* rangeName) const ;
-
 
   // Internal consistency checking (needed by RooDataSet)
   /// Check if current value is valid.
@@ -456,34 +460,11 @@ protected:
   /// Interface function to check if given value is a valid value for this object. Returns true unless overridden.
   virtual bool isValidReal(double /*value*/, bool printError = false) const { (void)printError; return true; }
 
-
   // Function evaluation and error tracing
   double traceEval(const RooArgSet* set) const ;
 
   /// Evaluate this PDF / function / constant. Needs to be overridden by all derived classes.
   virtual double evaluate() const = 0;
-
-  //---------- Interface to access batch data ---------------------------
-  //
-
- private:
-  void checkBatchComputation(const RooBatchCompute::RunContext& evalData, std::size_t evtNo, const RooArgSet* normSet = nullptr, double relAccuracy = 1.E-13) const;
-
-  /// Debug version of getVal(), which is slow and does error checking.
-  double _DEBUG_getVal(const RooArgSet* normalisationSet) const;
-
-  //--------------------------------------------------------------------
-
- protected:
-  friend class BatchInterfaceAccessor;
-  friend class RooVectorDataStore;
-  friend class RooRealBinding;
-  friend class RooRealSumPdf;
-  friend class RooRealSumFunc;
-  friend class RooAddHelpers;
-  friend class RooAddPdf;
-  friend class RooAddModel;
-  friend class RooFit::Detail::DataMap;
 
   // Hooks for RooDataSet interface
   void syncCache(const RooArgSet* set=nullptr) override { getVal(set) ; }
@@ -493,80 +474,49 @@ protected:
   void setTreeBranchStatus(TTree& t, bool active) override ;
   void fillTreeBranch(TTree& t) override ;
 
-  double _plotMin = 0.0;       ///< Minimum of plot range
-  double _plotMax = 0.0;       ///< Maximum of plot range
-  Int_t _plotBins = 100;       ///< Number of plot bins
-  mutable double _value = 0.0; ///< Cache for current value of object
-  TString _unit ;              ///< Unit for objects value
-  TString _label ;             ///< Plot label for objects value
-  bool _forceNumInt = false;   ///< Force numerical integration if flag set
-
-  std::unique_ptr<RooNumIntConfig> _specIntegratorConfig; // Numeric integrator configuration specific for this object
-
   struct PlotOpt {
-   PlotOpt() : drawOptions("L"), scaleFactor(1.0), stype(Relative), projData(nullptr), binProjData(false), projSet(nullptr), precision(1e-3),
-               shiftToZero(false),projDataSet(nullptr),normRangeName(nullptr),rangeLo(0),rangeHi(0),postRangeFracScale(false),wmode(RooCurve::Extended),
-               projectionRangeName(nullptr),curveInvisible(false), curveName(nullptr),addToCurveName(nullptr),addToWgtSelf(1.),addToWgtOther(1.),
-               numCPU(1),interleave(RooFit::Interleave),curveNameSuffix(""), numee(10), eeval(0), doeeval(false), progress(false), errorFR(nullptr) {}
-   Option_t* drawOptions ;
-   double scaleFactor ;
-   ScaleType stype ;
-   const RooAbsData* projData ;
-   bool binProjData ;
-   const RooArgSet* projSet ;
-   double precision ;
-   bool shiftToZero ;
-   const RooArgSet* projDataSet ;
-   const char* normRangeName ;
-   double rangeLo ;
-   double rangeHi ;
-   bool postRangeFracScale ;
-   RooCurve::WingMode wmode ;
-   const char* projectionRangeName ;
-   bool curveInvisible ;
-   const char* curveName ;
-   const char* addToCurveName ;
-   double addToWgtSelf ;
-   double addToWgtOther ;
-   Int_t    numCPU ;
-   RooFit::MPSplit interleave ;
-   const char* curveNameSuffix ;
-   Int_t    numee ;
-   double eeval ;
-   bool   doeeval ;
-   bool progress ;
-   const RooFitResult* errorFR ;
-  } ;
+     Option_t *drawOptions = "L";
+     double scaleFactor = 1.0;
+     ScaleType stype = Relative;
+     const RooAbsData *projData = nullptr;
+     bool binProjData = false;
+     const RooArgSet *projSet = nullptr;
+     double precision = 1e-3;
+     bool shiftToZero = false;
+     const RooArgSet *projDataSet = nullptr;
+     const char *normRangeName = nullptr;
+     double rangeLo = 0.0;
+     double rangeHi = 0.0;
+     bool postRangeFracScale = false;
+     RooCurve::WingMode wmode = RooCurve::Extended;
+     const char *projectionRangeName = nullptr;
+     bool curveInvisible = false;
+     const char *curveName = nullptr;
+     const char *addToCurveName = nullptr;
+     double addToWgtSelf = 1.0;
+     double addToWgtOther = 1.0;
+     Int_t numCPU = 1;
+     RooFit::MPSplit interleave = RooFit::Interleave;
+     const char *curveNameSuffix = "";
+     Int_t numee = 10;
+     double eeval = 0.0;
+     bool doeeval = false;
+     bool progress = false;
+     const RooFitResult *errorFR = nullptr;
+  };
 
   // Plot implementation functions
   virtual RooPlot *plotOn(RooPlot* frame, PlotOpt o) const;
 
-public:
-  // PlotOn with command list
-  virtual RooPlot* plotOn(RooPlot* frame, RooLinkedList& cmdList) const ;
-
- protected:
   virtual RooPlot *plotAsymOn(RooPlot *frame, const RooAbsCategoryLValue& asymCat, PlotOpt o) const;
 
-
-private:
-
-  static ErrorLoggingMode _evalErrorMode ;
-  static std::map<const RooAbsArg*,std::pair<std::string,std::list<EvalError> > > _evalErrorList ;
-  static Int_t _evalErrorCount ;
-
   bool matchArgsByName(const RooArgSet &allArgs, RooArgSet &matchedArgs, const TList &nameList) const;
-
-  std::unique_ptr<TreeReadBuffer> _treeReadBuffer; //! A buffer for reading values from trees
-
-protected:
 
   bool redirectServersHook(const RooAbsCollection & newServerList, bool mustReplaceAll,
                                    bool nameChange, bool isRecursiveStep) override;
 
   static void globalSelectComp(bool flag) ;
-  bool _selectComp = true;         //! Component selection flag for RooAbsPdf::plotCompOn
-  static bool _globalSelectComp ;  // Global activation switch for component selection
+
   // This struct can be used to flip the global switch to select components.
   // Doing this with RAII prevents forgetting to reset the state.
   struct GlobalSelectComponentRAII {
@@ -585,10 +535,37 @@ protected:
   };
 
 
-  mutable RooFit::UniqueId<RooArgSet>::Value_t _lastNormSetId = RooFit::UniqueId<RooArgSet>::nullval; ///<!
-  static bool _hideOffset ;    ///< Offset hiding flag
+private:
+  //---------- Interface to access batch data ---------------------------
+  //
+  void checkBatchComputation(const RooBatchCompute::RunContext& evalData, std::size_t evtNo, const RooArgSet* normSet = nullptr, double relAccuracy = 1.E-13) const;
 
-  ClassDefOverride(RooAbsReal,3) // Abstract real-valued variable
+  /// Debug version of getVal(), which is slow and does error checking.
+  double _DEBUG_getVal(const RooArgSet* normalisationSet) const;
+
+  //--------------------------------------------------------------------
+
+ protected:
+
+   double _plotMin = 0.0;                                  ///< Minimum of plot range
+   double _plotMax = 0.0;                                  ///< Maximum of plot range
+   Int_t _plotBins = 100;                                  ///< Number of plot bins
+   mutable double _value = 0.0;                            ///< Cache for current value of object
+   TString _unit;                                          ///< Unit for objects value
+   TString _label;                                         ///< Plot label for objects value
+   bool _forceNumInt = false;                              ///< Force numerical integration if flag set
+   std::unique_ptr<RooNumIntConfig> _specIntegratorConfig; // Numeric integrator configuration specific for this object
+   std::unique_ptr<TreeReadBuffer> _treeReadBuffer;        //! A buffer for reading values from trees
+   bool _selectComp = true;                                //! Component selection flag for RooAbsPdf::plotCompOn
+   mutable RooFit::UniqueId<RooArgSet>::Value_t _lastNormSetId = RooFit::UniqueId<RooArgSet>::nullval; ///<!
+
+   static ErrorLoggingMode _evalErrorMode;
+   static std::map<const RooAbsArg *, std::pair<std::string, std::list<EvalError>>> _evalErrorList;
+   static Int_t _evalErrorCount;
+   static bool _globalSelectComp; // Global activation switch for component selection
+   static bool _hideOffset;       ///< Offset hiding flag
+
+   ClassDefOverride(RooAbsReal,3); // Abstract real-valued variable
 };
 
 

--- a/roofit/roofitcore/src/RooFitResult.cxx
+++ b/roofit/roofitcore/src/RooFitResult.cxx
@@ -517,9 +517,13 @@ void RooFitResult::printMultiline(ostream& os, Int_t /*contents*/, bool verbose,
     << indent << "  --------------------  ------------" << endl ;
 
       for (i=0 ; i<_constPars->getSize() ; i++) {
-   os << indent << "  " << setw(20) << ((RooAbsArg*)_constPars->at(i))->GetName()
-      << "  " << setw(12) << Form("%12.4e",((RooRealVar*)_constPars->at(i))->getVal())
-      << endl ;
+        os << indent << "  " << setw(20) << _constPars->at(i)->GetName() << "  " << setw(12);
+        if(RooRealVar* v = dynamic_cast<RooRealVar*>(_constPars->at(i))) {
+         os << TString::Format("%12.4e",v->getVal());
+        } else {
+          _constPars->at(i)->printValue(os); // for anything other than RooRealVar use printValue method to print
+        }  
+        os << endl ;
       }
 
       os << endl ;


### PR DESCRIPTION

in some user cases there are things in the constPar list that aren't a RooRealVar, so make this printout more flexible by using the printValue method.

