### PR TITLE
Fix YML syntax in github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -4,7 +4,7 @@ labels: ["bug"]
 body:
   - type: markdown
     attributes:
-      value: Thanks for taking the time to fill out this bug report! Note that you can also prefill this template (from v6.28/06) using: `root -b -e '.gh bug' -q`
+      value: Thanks for taking the time to fill out this bug report! Note that you can also prefill this template (from v6.28/06) using `root -b -e '.gh bug' -q`
   - type: checkboxes
     id: check-duplicates
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -44,7 +44,7 @@ body:
     attributes:
       label: ROOT version
       description: What version of ROOT are you running?
-      placeholder: Unix `root -b -q | xclip -sel clip`, Windows: `root -b -q | clip.exe`
+      placeholder: Unix `root -b -q | xclip -sel clip`, Windows `root -b -q | clip.exe`
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -4,7 +4,7 @@ labels: ["new feature"]
 body:
   - type: markdown
     attributes:
-      value: Thanks for taking the time to fill out this feature request! Note that you can also prefill this template (from v6.28/06) using: `root -b -e '.gh feature' -q`
+      value: Thanks for taking the time to fill out this feature request! Note that you can also prefill this template (from v6.28/06) using `root -b -e '.gh feature' -q`
   - type: textarea
     id: problem-description
     attributes:

--- a/.github/ISSUE_TEMPLATE/improvement_report.yml
+++ b/.github/ISSUE_TEMPLATE/improvement_report.yml
@@ -4,7 +4,7 @@ labels: ["improvement"]
 body:
   - type: markdown
     attributes:
-      value: Thanks for taking the time to fill out this improvement suggestion! Note that you can also prefill this template (from v6.28/06) using: `root -b -e '.gh improvement' -q`
+      value: Thanks for taking the time to fill out this improvement suggestion! Note that you can also prefill this template (from v6.28/06) using `root -b -e '.gh improvement' -q`
   - type: textarea
     id: improvement-description
     attributes:

--- a/.github/ISSUE_TEMPLATE/improvement_report.yml
+++ b/.github/ISSUE_TEMPLATE/improvement_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: ROOT version
       description: What version of ROOT are you running?
-      placeholder: Unix `root -b -q | xclip -sel clip`, Windows: `root -b -q | clip.exe`
+      placeholder: Unix `root -b -q | xclip -sel clip`, Windows `root -b -q | clip.exe`
     validations:
       required: true
   - type: input


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Fixes a couple of syntax issues introduced in the last PR, which prevents from correctly opening new Issues on GitHub