### PR TITLE
Improvement suggestions for GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -4,7 +4,7 @@ labels: ["bug"]
 body:
   - type: markdown
     attributes:
-      value: Thanks for taking the time to fill out this bug report! Note that you can also prefill this template (from v6.28/06) using `root -b -e '.gh bug' -q`
+      value: Thank you for taking the time to fill out this bug report! Note that since v6.28/06 you can also prefill this template using `root -q -e '.gh bug'`
   - type: checkboxes
     id: check-duplicates
     attributes:
@@ -17,47 +17,39 @@ body:
   - type: textarea
     id: bug-description
     attributes:
-      label: Describe the bug
-      description: A clear and concise description of what the wrong behavior is.
+      label: Description
+      description: A description of what the behavior is as opposed to the expected behavior.
     validations:
       required: true
   - type: textarea
-    id: expected-behaviour
-    attributes:
-      label: What is the expected behaviour?
-      description: A clear and concise description of what you expected to happen.
-    validations:
-      required: false
-  - type: textarea
     id: to-reproduce
     attributes:
-      label: How to reproduce?
+      label: Reproducer
       description: |
-        Describe the steps to reproduce the behavior:
-        1. Your code that triggers the issue: at least a part; ideally something we can run ourselves.
-        2. Don't forget to attach the required input files!
-        3. How to run your code and / or build it, e.g. `root myMacro.C`, ...
+        Step-by-step instructions to reproduce the issue.
+        - If possible, as a self-contained piece of code
+        - Don't forget to attach any required input files
+        - Please specify how to run your code, e.g. `root myMacro.C`, ...
     validations:
       required: true
   - type: textarea
     id: root-version
     attributes:
       label: ROOT version
-      description: What version of ROOT are you running?
-      placeholder: Unix `root -b -q | xclip -sel clip`, Windows `root -b -q | clip.exe`
+      description: On Linux/MacOS, `root -b -q | xclip -sel clip`. On Windows, `root -b -q | clip.exe`
     validations:
       required: true
   - type: input
     id: root-install-how
     attributes:
-      label: How did you install ROOT?
-      placeholder: Package manager, website download, conda, custom build...
+      label: Installation method
+      placeholder: Package manager (which?), pre-built binary, build from source, ...
     validations:
       required: true
   - type: input
     id: operating-system
     attributes:
-      label: Which operating system are you using?
+      label: Operating system
       placeholder: Windows, MacOS, Linux (which distribution?)
     validations:
       required: true
@@ -65,6 +57,5 @@ body:
     id: additional-context
     attributes:
       label: Additional context
-      description: Add any other context about the bug here.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -4,32 +4,24 @@ labels: ["new feature"]
 body:
   - type: markdown
     attributes:
-      value: Thanks for taking the time to fill out this feature request! Note that you can also prefill this template (from v6.28/06) using `root -b -e '.gh feature' -q`
+      value: Thank you for taking the time to fill out this feature request! Note that since v6.28/06 you can also prefill this template using `root -q -e '.gh feature'`
   - type: textarea
-    id: problem-description
+    id: feature-description
     attributes:
-      label: Is your feature request related to a problem? Please describe.
-      description: A clear and concise description of what the problem is. E.g "I always have to [...] when I want to [...]".
-    validations:
-      required: false
-  - type: textarea
-    id: expected-behaviour
-    attributes:
-      label: Describe the solution you'd like
-      description: A clear and concise description of what you want to happen.
+      label: Feature description
+      description: What problem does the feature solve? How does the solution look like?
     validations:
       required: true
   - type: textarea
     id: alternatives
     attributes:
-      label: Describe alternatives you've considered
-      description: Can you think of alternative solutions or features?
+      label: Alternatives considered
+      description: Can you think of any alternative solutions to the proposed feature?
     validations:
       required: false
   - type: textarea
     id: additional-context
     attributes:
       label: Additional context
-      description: Add any other context or screenshots about the feature requested here.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/improvement_report.yml
+++ b/.github/ISSUE_TEMPLATE/improvement_report.yml
@@ -4,49 +4,31 @@ labels: ["improvement"]
 body:
   - type: markdown
     attributes:
-      value: Thanks for taking the time to fill out this improvement suggestion! Note that you can also prefill this template (from v6.28/06) using `root -b -e '.gh improvement' -q`
+      value: Thank you for taking the time to fill out this improvement suggestion! Note that since v6.28/06 you can also prefill this template using `root -q -e '.gh improvement'`
   - type: textarea
     id: improvement-description
     attributes:
-      label: Explain what you would like to see improved
-    validations:
-      required: true
-  - type: textarea
-    id: how-to-improve
-    attributes:
-      label: Share how it could be improved
-    validations:
-      required: false
-  - type: textarea
-    id: to-reproduce
-    attributes:
-      label: How to reproduce?
-      description: |
-        Describe the steps to reproduce the behavior:
-        1. Your code that triggers the issue: at least a part; ideally something we can run ourselves.
-        2. Don't forget to attach the required input files!
-        3. How to run your code and / or build it, e.g. `root myMacro.C`, ...
+      label: Explain what you would like to see improved and how.
     validations:
       required: true
   - type: textarea
     id: root-version
     attributes:
       label: ROOT version
-      description: What version of ROOT are you running?
-      placeholder: Unix `root -b -q | xclip -sel clip`, Windows `root -b -q | clip.exe`
+      description: On Linux/MacOS, `root -b -q | xclip -sel clip`. On Windows, `root -b -q | clip.exe`
     validations:
       required: true
   - type: input
     id: root-install-how
     attributes:
-      label: How did you install ROOT?
-      placeholder: package manager, website download, conda, custom build...
+      label: Installation method
+      placeholder: Package manager (which?), pre-built binary, build from source, ...
     validations:
       required: true
   - type: input
     id: operating-system
     attributes:
-      label: Which operating system are you using?
+      label: Operating system
       placeholder: Windows, MacOS, Linux (which distribution?)
     validations:
       required: true
@@ -54,6 +36,5 @@ body:
     id: additional-context
     attributes:
       label: Additional context
-      description: Add any other context about the problem here.
     validations:
       required: false


### PR DESCRIPTION
- multiple fields have been unified, reducing the level of noise in the templates
- commands to retrieve ROOT version have been made copiable
- text style/tone has been made more uniform

Personally I find the current tone of the templates slightly condescending and the process of filling them less streamlined than it could be. I fully understand that some of the style decisions are completely subjective but even if only some of the suggestions are accepted I think it is worth it. Just wanted to bring this up :smile: 