### PR TITLE
[RF][HF] Consistent 6th-degree polynomial interpolation in HistFactory

### DIFF
--- a/roofit/histfactory/inc/RooStats/HistFactory/FlexibleInterpVar.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/FlexibleInterpVar.h
@@ -11,13 +11,10 @@
 #ifndef ROOSTATS_FLEXIBLEINTERPVAR
 #define ROOSTATS_FLEXIBLEINTERPVAR
 
-#include "RooAbsPdf.h"
-#include "RooRealProxy.h"
-#include "RooListProxy.h"
-#include <vector>
+#include <RooAbsReal.h>
+#include <RooListProxy.h>
 
-class RooRealVar;
-class RooArgList ;
+#include <vector>
 
 namespace RooStats{
 namespace HistFactory{
@@ -25,18 +22,15 @@ namespace HistFactory{
   class FlexibleInterpVar : public RooAbsReal {
   public:
 
-    FlexibleInterpVar() ;
-    FlexibleInterpVar(const char *name, const char *title,
-            const RooArgList& _paramList,
-            double nominal, const RooArgList& low, const RooArgList& high);
+    FlexibleInterpVar();
 
     FlexibleInterpVar(const char *name, const char *title,
             const RooArgList& _paramList,
-            double nominal, std::vector<double> low, std::vector<double> high);
+            double nominal, std::vector<double> const& low, std::vector<double> const& high);
 
     FlexibleInterpVar(const char *name, const char *title,
-            const RooArgList& _paramList, double nominal, std::vector<double> low,
-            std::vector<double> high,std::vector<int> code);
+            const RooArgList& _paramList, double nominal, std::vector<double> const& low,
+            std::vector<double> const& high,std::vector<int> const& code);
 
     FlexibleInterpVar(const char *name, const char *title);
     FlexibleInterpVar(const FlexibleInterpVar&, const char*);
@@ -57,10 +51,10 @@ namespace HistFactory{
     void printMultiline(std::ostream& os, Int_t contents, bool verbose = false, TString indent = "") const override;
     virtual void printFlexibleInterpVars(std::ostream& os) const;
 
-    const RooListProxy& variables() const;
-    double nominal() const;
-    const std::vector<double>& low() const;
-    const std::vector<double>& high() const;
+    const RooListProxy& variables() const { return _paramList; }
+    double nominal() const { return _nominal; }
+    const std::vector<double>& low() const { return _low; }
+    const std::vector<double>& high() const { return _high; }
 
     void computeBatch(cudaStream_t*, double* output, size_t size, RooFit::Detail::DataMap const&) const override;
 
@@ -69,15 +63,15 @@ namespace HistFactory{
   protected:
 
     RooListProxy _paramList ;
-    double _nominal;
+    double _nominal = 0.0;
     std::vector<double> _low;
     std::vector<double> _high;
     std::vector<int> _interpCode;
-    double _interpBoundary;
+    double _interpBoundary = 1.0;
 
     double evaluate() const override;
 
-    ClassDefOverride(RooStats::HistFactory::FlexibleInterpVar,2) // flexible interpolation
+    ClassDefOverride(RooStats::HistFactory::FlexibleInterpVar,2); // flexible interpolation
   };
 }
 }

--- a/roofit/histfactory/inc/RooStats/HistFactory/FlexibleInterpVar.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/FlexibleInterpVar.h
@@ -75,9 +75,6 @@ namespace HistFactory{
     std::vector<int> _interpCode;
     double _interpBoundary;
 
-    mutable bool         _logInit ;            ///<! flag used for caching polynomial coefficients
-    mutable std::vector< double>  _polCoeff;     ///<! cached polynomial coefficients
-
     double evaluate() const override;
 
     ClassDefOverride(RooStats::HistFactory::FlexibleInterpVar,2) // flexible interpolation


### PR DESCRIPTION
The `FlexibleInterpVar` and the `PiecewiseInterpolation` classes in
HistFactory can both interpolate asymmetric up-and-down variations
between the +/- one standard deviation such that both the first and
second derivatives of the scale factors are smooth.

The `PiecewiseInterpolation` class is more general, because instead of
taking constant interpolation parameters, it takes other `RooAbsReals`.
That means it makes no sense for that class to cache the polynomial
coefficients that have to re recomputed anyway each time the input
changes. It uses an optimized formula to do the interpolation on the
fly.

The `FlexibleInterpVar` however precomputes and caches the polynomial
coefficients. This has serveral disadvantages:

  * High cost in memory (the big ATLAS models can have thousands of
    `FlexibleInterpVars`

  * It's inconsistent with the `PiecewiseInterpolation`, which should be
    equivalent

  * Most importantly, and this was the motivation for this PR now:
    when we do the code generation for AD, we can't pre-compute cached
    coefficients because it would bloat the generated code with constant
    arrays. Computing on the fly is much more AD-friendly.

Validation of the new `FlexibleInterpVar` values for `low=0.9` and
`high=1.2` that shows the interpolated values are agreeing to the 5e-4
level. This is completely accepatable for such an ad-hoc polynomial
motivation, where the shape is not given by any physical meaning anyway
but just by the continuity condition at the boundaries. And at the
boundaries (and `param=0`), the difference between both implementations
goes to zero. It was also checked that this change has no performance
effect on fitting the full ATLAS Higgs combination modes.

```txt
    param           ref           new       diff_abs   diff_rel
0   -1.00  0.9000000000  0.9000000000   0.0000000000   0.00E+00
1   -0.95  0.9047424331  0.9047437816   0.0000013485   1.49E-06
2   -0.85  0.9140836603  0.9141118876   0.0000282273   3.09E-05
3   -0.75  0.9230659064  0.9231653329   0.0000994265   1.08E-04
4   -0.65  0.9317147727  0.9319176341   0.0002028614   2.18E-04
5   -0.55  0.9402402768  0.9405514067   0.0003111300   3.31E-04
6   -0.45  0.9489635592  0.9493568763   0.0003933171   4.14E-04
7   -0.35  0.9582539443  0.9586769214   0.0004229771   4.41E-04
8   -0.25  0.9684763536  0.9688599643   0.0003836107   3.96E-04
9   -0.15  0.9799490728  0.9802212720   0.0002721992   2.78E-04
10  -0.05  0.9929118716  0.9930125518   0.0001006802   1.01E-04
11   0.05  1.0075044778  1.0073993699  -0.0001051079  -1.04E-04
12   0.15  1.0237554038  1.0234460012  -0.0003094025  -3.02E-04
13   0.25  1.0415811263  1.0411077858  -0.0004733405  -4.54E-04
14   0.35  1.0607956204  1.0602318105  -0.0005638099  -5.31E-04
15   0.45  1.0811302458  1.0805675762  -0.0005626696  -5.20E-04
16   0.55  1.1022639865  1.1017900409  -0.0004739457  -4.30E-04
17   0.65  1.1238640449  1.1235378523  -0.0003261926  -2.90E-04
18   0.75  1.1456367871  1.1454695261  -0.0001672610  -1.46E-04
19   0.85  1.1673890440  1.1673397731  -0.0000492709  -4.22E-05
20   0.95  1.1890997634  1.1890973372  -0.0000024261  -2.04E-06
21   1.00  1.2000000000  1.2000000000   0.0000000000   0.00E+00
```

In case this is useful later, here is how I produced this validation
table.

Print `FlexibleInterpVar` values for differnt parameters both with and
without this PR using the following code:

```C++
using namespace RooFit;
using RooStats::HistFactory::FlexibleInterpVar;

RooRealVar param{"param", "param", -1, 1};
param.setBins(20);

double nominal = 1.;
std::vector<double> low{0.90};
std::vector<double> high{1.20};

std::vector<std::unique_ptr<RooAbsReal>> interps;

for (int code = 0; code < 5; ++code) {
   std::vector<int> codes{code};
   interps.emplace_back(std::make_unique<FlexibleInterpVar>("interp", "interp", param, nominal, low, high, codes));
}

cout.precision(12);

param.setVal(-1);
std::cout << param.getVal() << "," << interps[4]->getVal() << std::endl;
for (int i = 0; i < param.numBins(); ++i) {
   param.setBin(i);
   std::cout << param.getVal() << "," << interps[4]->getVal() << std::endl;
}
param.setVal(1);
std::cout << param.getVal() << "," << interps[4]->getVal() << std::endl;
```

Then I concatenated the output with and without this PR to a `.csv` file
that was analyzed with pandas:

```Python
import pandas as pd

df = pd.read_csv("interp.csv")

df["diff_abs"] = df["new"] - df["ref"]
df["diff_rel"] = (df["new"] - df["ref"]) / df["ref"]

format_mapping = {"new": "{:.10f}", "ref": "{:.10f}", "diff_abs": "{:.10f}", "diff_rel": "{:.2E}"}

for key, value in format_mapping.items():
    df[key] = df[key].apply(value.format)

print(df)
```