### PR TITLE
[windows] Add a couple of missing symbols in the export list

### DIFF
--- a/core/metacling/src/CMakeLists.txt
+++ b/core/metacling/src/CMakeLists.txt
@@ -143,6 +143,8 @@ if(MSVC)
       ??_U@YAPEAX_K@Z
       ??_V@YAXPEAX@Z
       ??_V@YAXPEAX_K@Z
+      ??2@YAPEAX_KAEBUnothrow_t@std@@@Z
+      ??_U@YAPEAX_KAEBUnothrow_t@std@@@Z
       ??6?$basic_ostream@DU?$char_traits@D@std@@@std@@QEAAAEAV01@H@Z
       ??6?$basic_ostream@DU?$char_traits@D@std@@@std@@QEAAAEAV01@M@Z
       ??6?$basic_ostream@DU?$char_traits@D@std@@@std@@QEAAAEAV01@N@Z
@@ -166,6 +168,8 @@ if(MSVC)
       ??_U@YAPAXI@Z
       ??_V@YAXPAX@Z
       ??_V@YAXPAXI@Z
+      ??2@YAPAXIABUnothrow_t@std@@@Z
+      ??_U@YAPAXIABUnothrow_t@std@@@Z
       ??6?$basic_ostream@DU?$char_traits@D@std@@@std@@QAEAAV01@H@Z
       ??6?$basic_ostream@DU?$char_traits@D@std@@@std@@QAEAAV01@M@Z
       ??6?$basic_ostream@DU?$char_traits@D@std@@@std@@QAEAAV01@N@Z


### PR DESCRIPTION
Export the following missing symbols:
```
void * __ptr64 __cdecl operator new(unsigned __int64,struct std::nothrow_t const & __ptr64)
void * __ptr64 __cdecl operator new[](unsigned __int64,struct std::nothrow_t const & __ptr64)
```
and
```
void * __cdecl operator new[](unsigned int,struct std::nothrow_t const &)
void * __cdecl operator new(unsigned int,struct std::nothrow_t const &)
```
