### PR TITLE
[webcanv] support "Bring to front" command for different classes

### DIFF
--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -1564,6 +1564,23 @@ Bool_t TWebCanvas::ProcessData(unsigned connid, const std::string &arg)
          Canvas()->fCw = arr->at(0);
          Canvas()->fCh = arr->at(1);
       }
+   } else if (arg.compare(0, 7, "POPOBJ:") == 0) {
+      auto arr = TBufferJSON::FromJSON<std::vector<std::string>>(arg.substr(7));
+      if (arr && arr->size() == 2) {
+         TPad *pad = dynamic_cast<TPad *>(FindPrimitive(arr->at(0)));
+         TObject *obj = FindPrimitive(arr->at(1), 0, pad);
+         if (pad && obj && (obj != pad->GetListOfPrimitives()->Last())) {
+            TIter next(pad->GetListOfPrimitives());
+            while (auto o = next())
+               if (obj == o) {
+                  TString opt = next.GetOption();
+                  pad->GetListOfPrimitives()->Remove(obj);
+                  pad->GetListOfPrimitives()->AddLast(obj, opt.Data());
+                  pad->Modified();
+                  break;
+               }
+         }
+      }
    } else if (arg == "INTERRUPT"s) {
       gROOT->SetInterrupt();
    } else {

--- a/js/build/jsroot.js
+++ b/js/build/jsroot.js
@@ -11,7 +11,7 @@ let version_id = 'dev';
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-let version_date = '23/06/2023';
+let version_date = '26/06/2023';
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}
@@ -8547,6 +8547,17 @@ async function svgToImage(svg, image_format, as_buffer) {
    if (image_format == 'svg')
       return svg;
 
+   if (!isNodeJs()) {
+      // required with df104.py/df105.py example with RCanvas
+      const doctype = '<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">';
+      svg = encodeURIComponent(doctype + svg);
+      svg = svg.replace(/%([0-9A-F]{2})/g, (match, p1) => {
+          let c = String.fromCharCode('0x'+p1);
+          return c === '%' ? '%25' : c;
+      });
+      svg = decodeURIComponent(svg);
+   }
+
    const img_src = 'data:image/svg+xml;base64,' + btoa_func(svg);
 
    if (isNodeJs())
@@ -8564,6 +8575,7 @@ async function svgToImage(svg, image_format, as_buffer) {
       });
 
    return new Promise(resolveFunc => {
+
       const image = document.createElement('img');
 
       image.onload = function() {
@@ -59304,7 +59316,7 @@ function showPainterMenu(evnt, painter, kind) {
 
    createMenu$1(evnt, painter).then(menu => {
       painter.fillContextMenu(menu);
-      if ((kind == kToFront) && isFunc(painter.bringToFront)) {
+      if ((kind === kToFront) && isFunc(painter.bringToFront)) {
          menu.add('Bring to front', () => painter.bringToFront(true));
          kind = undefined;
       }
@@ -67330,8 +67342,7 @@ class TPadPainter extends ObjectPainter {
          for (let k = 0; k < items.length; ++k) {
             let item = items[k];
 
-            if (item.img)
-               item.img.remove(); // delete embed image
+            item.img?.remove(); // delete embed image
 
             let prim = item.prnt.select('.primitives_layer');
 
@@ -114772,8 +114783,7 @@ class RPadPainter extends RObjectPainter {
          for (let k = 0; k < items.length; ++k) {
             let item = items[k];
 
-            if (item.img)
-               item.img.remove(); // delete embed image
+            item.img?.remove(); // delete embed image
 
             let prim = item.prnt.select('.primitives_layer');
 

--- a/js/changes.md
+++ b/js/changes.md
@@ -1,13 +1,13 @@
 # JSROOT changelog
 
-## Changed in dev
+## Changes in dev
 
 1. Correctly implement TH2 projections like MERCATOR or PARABOLIC
 2. Use https://github.com/georgealways/lil-gui/ instead of dat.GUI
 3. Let configure material and scene properties in geom control gui
 4. Upgrade three.js r151 -> r153
 5. Let toggle vertical/horizontal flag for color palette via context menu
-6. Provide "Bring to front" menu command for title/stats/palette/legend objects
+6. Provide "Bring to front" menu command for different objects like pave, box, marker, ...
 7. Handle "dark mode" in geom painter - automatically adjust background
 
 

--- a/js/modules/base/BasePainter.mjs
+++ b/js/modules/base/BasePainter.mjs
@@ -722,6 +722,17 @@ async function svgToImage(svg, image_format, as_buffer) {
    if (image_format == 'svg')
       return svg;
 
+   if (!isNodeJs()) {
+      // required with df104.py/df105.py example with RCanvas
+      const doctype = '<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">';
+      svg = encodeURIComponent(doctype + svg);
+      svg = svg.replace(/%([0-9A-F]{2})/g, (match, p1) => {
+          let c = String.fromCharCode('0x'+p1);
+          return c === '%' ? '%25' : c;
+      });
+      svg = decodeURIComponent(svg);
+   }
+
    const img_src = 'data:image/svg+xml;base64,' + btoa_func(svg);
 
    if (isNodeJs())
@@ -739,6 +750,7 @@ async function svgToImage(svg, image_format, as_buffer) {
       });
 
    return new Promise(resolveFunc => {
+
       const image = document.createElement('img');
 
       image.onload = function() {

--- a/js/modules/base/ObjectPainter.mjs
+++ b/js/modules/base/ObjectPainter.mjs
@@ -327,6 +327,19 @@ class ObjectPainter extends BasePainter {
       return this.draw_g;
    }
 
+   /** @summary Bring draw element to the front */
+   bringToFront(check_online) {
+      if (!this.draw_g) return;
+      let prnt = this.draw_g.node().parentNode;
+      prnt?.appendChild(this.draw_g.node());
+
+      if (!check_online || !this.snapid) return;
+      let pp = this.getPadPainter();
+      if (!pp?.snapid) return;
+
+      this.getCanvPainter()?.sendWebsocket('POPOBJ:'+JSON.stringify([pp.snapid.toString(), this.snapid.toString()]));
+   }
+
    /** @summary Canvas main svg element
      * @return {object} d3 selection with canvas svg
      * @protected */

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -5,7 +5,7 @@ let version_id = 'dev';
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-let version_date = '23/06/2023';
+let version_date = '26/06/2023';
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}

--- a/js/modules/draw/TLinePainter.mjs
+++ b/js/modules/draw/TLinePainter.mjs
@@ -2,7 +2,7 @@ import { BIT } from '../core.mjs';
 import { ObjectPainter } from '../base/ObjectPainter.mjs';
 import { ensureTCanvas } from '../gpad/TCanvasPainter.mjs';
 import { addMoveHandler } from '../gui/utils.mjs';
-import { assignContextMenu } from '../gui/menu.mjs';
+import { assignContextMenu, kToFront } from '../gui/menu.mjs';
 
 class TLinePainter extends ObjectPainter {
 
@@ -75,7 +75,7 @@ class TLinePainter extends ObjectPainter {
       this.addExtras(elem);
 
       addMoveHandler(this);
-      assignContextMenu(this);
+      assignContextMenu(this, kToFront);
 
       return this;
    }

--- a/js/modules/draw/more.mjs
+++ b/js/modules/draw/more.mjs
@@ -2,7 +2,7 @@ import { BIT, isFunc, clTLatex, clTMathText, clTAnnotation, clTPolyLine } from '
 import { rgb as d3_rgb, select as d3_select } from '../d3.mjs';
 import { BasePainter, makeTranslate } from '../base/BasePainter.mjs';
 import { addMoveHandler } from '../gui/utils.mjs';
-import { assignContextMenu } from '../gui/menu.mjs';
+import { assignContextMenu, kToFront } from '../gui/menu.mjs';
 
 
 /** @summary Draw TText
@@ -96,7 +96,7 @@ async function drawText() {
          };
       }
 
-      assignContextMenu(this);
+      assignContextMenu(this, kToFront);
 
       return this;
    });
@@ -133,7 +133,7 @@ function drawPolyLine() {
       elem.call(this.lineatt.func)
           .style('fill', 'none');
 
-   assignContextMenu(this);
+   assignContextMenu(this, kToFront);
 
    addMoveHandler(this);
 
@@ -255,7 +255,7 @@ function drawEllipse() {
       .call(this.lineatt.func)
       .call(this.fillatt.func);
 
-   assignContextMenu(this);
+   assignContextMenu(this, kToFront);
 
    addMoveHandler(this);
 
@@ -373,7 +373,7 @@ function drawBox() {
                  .style('fill', d3_rgb(this.fillatt.color).darker(0.5).formatHex());
    }
 
-   assignContextMenu(this);
+   assignContextMenu(this, kToFront);
 
    addMoveHandler(this);
 
@@ -435,7 +435,7 @@ function drawMarker() {
           .attr('d', path)
           .call(this.markeratt.func);
 
-   assignContextMenu(this);
+   assignContextMenu(this, kToFront);
 
    addMoveHandler(this);
 
@@ -478,7 +478,7 @@ function drawPolyMarker() {
           .attr('d', path)
           .call(this.markeratt.func);
 
-   assignContextMenu(this);
+   assignContextMenu(this, kToFront);
 
    addMoveHandler(this);
 

--- a/js/modules/gpad/RPadPainter.mjs
+++ b/js/modules/gpad/RPadPainter.mjs
@@ -1397,8 +1397,7 @@ class RPadPainter extends RObjectPainter {
          for (let k = 0; k < items.length; ++k) {
             let item = items[k];
 
-            if (item.img)
-               item.img.remove(); // delete embed image
+            item.img?.remove(); // delete embed image
 
             let prim = item.prnt.select('.primitives_layer');
 

--- a/js/modules/gpad/TPadPainter.mjs
+++ b/js/modules/gpad/TPadPainter.mjs
@@ -2052,8 +2052,7 @@ class TPadPainter extends ObjectPainter {
          for (let k = 0; k < items.length; ++k) {
             let item = items[k];
 
-            if (item.img)
-               item.img.remove(); // delete embed image
+            item.img?.remove(); // delete embed image
 
             let prim = item.prnt.select('.primitives_layer');
 

--- a/js/modules/gui/menu.mjs
+++ b/js/modules/gui/menu.mjs
@@ -1397,7 +1397,7 @@ function showPainterMenu(evnt, painter, kind) {
 
    createMenu(evnt, painter).then(menu => {
       painter.fillContextMenu(menu);
-      if ((kind == kToFront) && isFunc(painter.bringToFront)) {
+      if ((kind === kToFront) && isFunc(painter.bringToFront)) {
          menu.add('Bring to front', () => painter.bringToFront(true));
          kind = undefined;
       }

--- a/js/modules/gui/menu.mjs
+++ b/js/modules/gui/menu.mjs
@@ -6,6 +6,7 @@ import { TAttMarkerHandler } from '../base/TAttMarkerHandler.mjs';
 import { getSvgLineStyle } from '../base/TAttLineHandler.mjs';
 import { FontHandler } from '../base/FontHandler.mjs';
 
+const kToFront = '__front__';
 
 /**
  * @summary Abstract class for creating context menu
@@ -1396,6 +1397,10 @@ function showPainterMenu(evnt, painter, kind) {
 
    createMenu(evnt, painter).then(menu => {
       painter.fillContextMenu(menu);
+      if ((kind == kToFront) && isFunc(painter.bringToFront)) {
+         menu.add('Bring to front', () => painter.bringToFront(true));
+         kind = undefined;
+      }
       return painter.fillObjectExecMenu(menu, kind);
    }).then(menu => menu.show());
 }
@@ -1407,4 +1412,4 @@ function assignContextMenu(painter, kind) {
       painter.draw_g.on('contextmenu', settings.ContextMenu ? evnt => showPainterMenu(evnt, painter, kind) : null);
 }
 
-export { createMenu, closeMenu, showPainterMenu, assignContextMenu };
+export { createMenu, closeMenu, showPainterMenu, assignContextMenu, kToFront };

--- a/js/modules/hist/TPavePainter.mjs
+++ b/js/modules/hist/TPavePainter.mjs
@@ -974,19 +974,9 @@ class TPavePainter extends ObjectPainter {
          });
    }
 
-   /** @summary Bring pave painter as last in list of primitives of its parent */
-   bringToFront() {
-      if (!this.draw_g) return;
-      let prnt = this.draw_g.node().parentNode;
-      prnt?.appendChild(this.draw_g.node());
-   }
-
    /** @summary Fill context menu items for the TPave object */
    fillContextMenuItems(menu) {
       let pave = this.getObject();
-
-
-      menu.add('Bring to front', () => this.bringToFront());
 
       if (this.isStats()) {
          menu.add('Default position', () => {
@@ -1096,6 +1086,8 @@ class TPavePainter extends ObjectPainter {
             gStyle.fTitleFont = pave.fTextFont;
          }, 'Store title position and graphical attributes to gStyle');
       }
+
+      menu.add('Bring to front', () => this.bringToFront(!this.isStats() && !this.z_handle));
    }
 
    /** @summary Show pave context menu */


### PR DESCRIPTION
Via special command from client move object in list of primitives to the
end. Reflect changes which are done with "Bring to front" menu command
on client side. Supported for objects like `TLine`, `TBox`, `TMarker`, `TPave` and few
others

It is more safer version of `TObject::Pop()` method - do not relies on `gPad`.



