### PR TITLE
[rbrowser] use TWebCanvas in async mode

### DIFF
--- a/gui/browserv7/src/RBrowserTCanvasWidget.cxx
+++ b/gui/browserv7/src/RBrowserTCanvasWidget.cxx
@@ -97,6 +97,9 @@ public:
       // create implementation
       fWebCanvas = new TWebCanvas(fCanvas.get(), "title", 0, 0, 800, 600, readonly);
 
+      // use async mode to prevent blocking inside qt5/qt6/cef
+      fWebCanvas->SetAsyncMode(kTRUE);
+
       // assign implementation
       fCanvas->SetCanvasImp(fWebCanvas);
       SetPrivateCanvasFields(true);
@@ -115,6 +118,9 @@ public:
 
       // create implementation
       fWebCanvas = new TWebCanvas(fCanvas.get(), "title", 0, 0, 800, 600, readonly);
+
+      // use async mode to prevent blocking inside qt5/qt6/cef
+      fWebCanvas->SetAsyncMode(kTRUE);
 
       // assign implementation
       fCanvas->SetCanvasImp(fWebCanvas);


### PR DESCRIPTION
In special engines like qt5web or cefweb synchronous update of the canvas may block normal event loop of such engines.

