### PR TITLE
[skip-ci][windows] Use the correct syntax for the `START` command

### DIFF
--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -629,7 +629,7 @@ void TApplication::OpenInBrowser(const TString &url)
    gSystem->Exec(cMac);
 #elif defined(R__WIN32)
    // Command for opening a browser on Windows.
-   TString cWindows("start ");
+   TString cWindows("start \"\" ");
    cWindows.Append(url);
    gSystem->Exec(cWindows);
 #else


### PR DESCRIPTION
Use the correct syntax for the `START` command, which is:
```
START "title" [/D path] [options] "command" [parameters]
```
This prevent the following error with the `.forum bug` command:
```
root [0] .forum bug
The system cannot accept the START command parameter  "https://root-forum.cern.ch/new-topic?category=ROOT&tags=bug&body=___%0A_Please read [tips for efficient and successful posting](https:%2F%2Froot-forum.cern.ch%2Ft%2Ftips-for-efficient-and-successful-posting%2F28292) and [posting code](https:%2F%2Froot-forum.cern.ch%2Ft%2Fposting-code-read-this-first%2F28293)_%0A%0A%23%23%23 Describe the bug%0A<!--%0AA clear and concise description of what the wrong behavior is.%0A-->%0A%23%23%23 Expected behavior%0A<!--%0AA clear and concise description of what you expected to happen.%0A-->%0A%0A%23%23%23 To Reproduce%0A<!--%0ASteps to reproduce the behavior:%0A1. Your code that triggers the issue: at least a part%3B ideally something we can run ourselves.%0A2. Don't forget to attach the required input files!%0A3. How to run your code and %2F or build it, e.g. %60root myMacro.C%60, ...%0A-->%0A%0A%23%23%23 Setup%0A%60%60%60%0AROOT v6.29%2F01%0ABuilt for win32 on Jun 26 2023, 07:55:07%0AFrom heads%2Fmaster@v6-29-01-1740-ga5471d735c%0AWith MSVC 19.29.30146.0%0ABinary directory: C:\Users\bellenot\build\x86\release\bin%0A%60%60%60%0A%0A<!--%0APlease specify also how you obtained ROOT, such as %60dnf install%60 %2F binary download %2F you built it yourself.%0A-->%0A%0A%23%23%23 Additional context%0A<!--%0AAdd any other context about the problem here.%0A-->&".
root [1]
```
