### PR TITLE
Use TWebCanvas by default in interactive sessions

### DIFF
--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -649,6 +649,12 @@ else()
    set(hashardwareinterferencesize undef)
 endif()
 
+if(webgui)
+   set(root_canvas_class "TWebCanvas")
+else()
+   set(root_canvas_class "TRootCanvas")
+endif()
+
 if(root7 AND webgui)
    set(root_browser_class "ROOT::Experimental::RWebBrowserImp")
 else()

--- a/config/rootrc.in
+++ b/config/rootrc.in
@@ -103,6 +103,7 @@ Root.Fitter:             Minuit
 # HighLightColor 2 = red. ShowEventStatus allows the event status bar to
 # be turned on by default. AutoExec allows TExec objects to be executed
 # on mouse and key events.
+Canvas.Name:                @root_canvas_class@
 Canvas.MoveOpaque:          true
 Canvas.ResizeOpaque:        true
 Canvas.ShowGuideLines:      true

--- a/config/rootrc.in
+++ b/config/rootrc.in
@@ -103,6 +103,8 @@ Root.Fitter:             Minuit
 # HighLightColor 2 = red. ShowEventStatus allows the event status bar to
 # be turned on by default. AutoExec allows TExec objects to be executed
 # on mouse and key events.
+#
+# As options for Canvas.Name, ROOT provides TWebCanvas and the legacy TRootCanvas.
 Canvas.Name:                @root_canvas_class@
 Canvas.MoveOpaque:          true
 Canvas.ResizeOpaque:        true

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -2798,6 +2798,8 @@ void TROOT::SetWebDisplay(const char *webdisplay)
    }
 
    if (fIsWebDisplay) {
+      // restore canvas and browser classes configured at the moment when gROOT->SetWebDisplay() was called for the first time
+      // This is necessary when SetWebDisplay() called several times and therefore current settings may differ
       gEnv->SetValue("Canvas.Name", canName);
       gEnv->SetValue("Browser.Name", brName);
       gEnv->SetValue("TreeViewer.Name", "RTreeViewer");

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -2766,6 +2766,7 @@ void TROOT::SetWebDisplay(const char *webdisplay)
    const char *wd = webdisplay ? webdisplay : "";
 
    // store default values to set them back when needed
+   static TString canName = gEnv->GetValue("Canvas.Name", "");
    static TString brName = gEnv->GetValue("Browser.Name", "");
    static TString trName = gEnv->GetValue("TreeViewer.Name", "");
 
@@ -2797,9 +2798,11 @@ void TROOT::SetWebDisplay(const char *webdisplay)
    }
 
    if (fIsWebDisplay) {
+      gEnv->SetValue("Canvas.Name", canName);
       gEnv->SetValue("Browser.Name", brName);
       gEnv->SetValue("TreeViewer.Name", "RTreeViewer");
    } else {
+      gEnv->SetValue("Canvas.Name", "TRootCanvas");
       gEnv->SetValue("Browser.Name", "TRootBrowser");
       gEnv->SetValue("TreeViewer.Name", trName);
    }

--- a/gui/gui/inc/TRootGuiFactory.h
+++ b/gui/gui/inc/TRootGuiFactory.h
@@ -26,6 +26,9 @@ class TControlBar;
 
 class TRootGuiFactory : public TGuiFactory {
 
+protected:
+   void ShowWebCanvasWarning();
+
 public:
    TRootGuiFactory(const char *name = "Root", const char *title = "ROOT GUI Factory");
    ~TRootGuiFactory() override {}

--- a/gui/gui/src/TRootGuiFactory.cxx
+++ b/gui/gui/src/TRootGuiFactory.cxx
@@ -160,6 +160,9 @@ TContextMenuImp *TRootGuiFactory::CreateContextMenuImp(TContextMenu *c,
 
 TControlBarImp *TRootGuiFactory::CreateControlBarImp(TControlBar *c, const char *title)
 {
+   if (gROOT->IsWebDisplay())
+      return TGuiFactory::CreateControlBarImp(c, title);
+
    return new TRootControlBar(c, title);
 }
 
@@ -169,5 +172,8 @@ TControlBarImp *TRootGuiFactory::CreateControlBarImp(TControlBar *c, const char 
 TControlBarImp *TRootGuiFactory::CreateControlBarImp(TControlBar *c, const char *title,
                                                      Int_t x, Int_t y)
 {
+   if (gROOT->IsWebDisplay())
+      return TGuiFactory::CreateControlBarImp(c, title, x, y);
+
    return new TRootControlBar(c, title, x, y);
 }

--- a/gui/gui/src/TRootGuiFactory.cxx
+++ b/gui/gui/src/TRootGuiFactory.cxx
@@ -60,6 +60,16 @@ TApplicationImp *TRootGuiFactory::CreateApplicationImp(const char *classname,
 TCanvasImp *TRootGuiFactory::CreateCanvasImp(TCanvas *c, const char *title,
                                              UInt_t width, UInt_t height)
 {
+   TString canvName = gEnv->GetValue("Canvas.Name", "TWebCanvas");
+   if (canvName == "TWebCanvas") {
+      auto ph = gROOT->GetPluginManager()->FindHandler("TCanvasImp", "TWebCanvas");
+
+      if (ph && ph->LoadPlugin() != -1) {
+         auto imp = (TCanvasImp *) ph->ExecPlugin(6, c, title, 0, 0, width, height);
+         if (imp) return imp;
+      }
+   }
+
    return new TRootCanvas(c, title, width, height);
 }
 
@@ -69,6 +79,16 @@ TCanvasImp *TRootGuiFactory::CreateCanvasImp(TCanvas *c, const char *title,
 TCanvasImp *TRootGuiFactory::CreateCanvasImp(TCanvas *c, const char *title,
                                   Int_t x, Int_t y, UInt_t width, UInt_t height)
 {
+   TString canvName = gEnv->GetValue("Canvas.Name", "TWebCanvas");
+   if (canvName == "TWebCanvas") {
+      auto ph = gROOT->GetPluginManager()->FindHandler("TCanvasImp", "TWebCanvas");
+
+      if (ph && ph->LoadPlugin() != -1) {
+         auto imp = (TCanvasImp *) ph->ExecPlugin(6, c, title, x, y, width, height);
+         if (imp) return imp;
+      }
+   }
+
    return new TRootCanvas(c, title, x, y, width, height);
 }
 

--- a/gui/gui/src/TRootGuiFactory.cxx
+++ b/gui/gui/src/TRootGuiFactory.cxx
@@ -30,6 +30,8 @@ the member functions of the ABS TGuiFactory.
 #include "TPluginManager.h"
 #include "TEnv.h"
 
+#include <iostream>
+
 ClassImp(TRootGuiFactory);
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -49,9 +51,29 @@ TApplicationImp *TRootGuiFactory::CreateApplicationImp(const char *classname,
    TRootApplication *app = new TRootApplication(classname, argc, argv);
    if (!app->Client()) {
       delete app;
-      app = 0;
+      app = nullptr;
    }
    return app;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+/// Show warning that TWebCanvas will be started by default
+
+void TRootGuiFactory::ShowWebCanvasWarning()
+{
+   static bool show_warn = true;
+   if (!show_warn || gROOT->IsWebDisplay()) return;
+   show_warn = false;
+
+   std::cout << "\n"
+                "   !!! ATTENTION !!! \n"
+                "\n"
+                "ROOT comes with a web-based canvas, which is now being started. \n"
+                "Revert to default by setting \"Canvas.Name: TRootCanvas\" in rootrc file or\n"
+                "by starting \"root --web=off\". Web-based TCanvas can be used in batch mode for\n"
+                "image generation when running with \"root -b --web\"\n"
+                "Find more info on https://root.cern/for_developers/root7/#twebcanvas\n"
+                "\n";
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -65,6 +87,7 @@ TCanvasImp *TRootGuiFactory::CreateCanvasImp(TCanvas *c, const char *title,
       auto ph = gROOT->GetPluginManager()->FindHandler("TCanvasImp", "TWebCanvas");
 
       if (ph && ph->LoadPlugin() != -1) {
+         ShowWebCanvasWarning();
          auto imp = (TCanvasImp *) ph->ExecPlugin(6, c, title, 0, 0, width, height);
          if (imp) return imp;
       }
@@ -84,6 +107,7 @@ TCanvasImp *TRootGuiFactory::CreateCanvasImp(TCanvas *c, const char *title,
       auto ph = gROOT->GetPluginManager()->FindHandler("TCanvasImp", "TWebCanvas");
 
       if (ph && ph->LoadPlugin() != -1) {
+         ShowWebCanvasWarning();
          auto imp = (TCanvasImp *) ph->ExecPlugin(6, c, title, x, y, width, height);
          if (imp) return imp;
       }

--- a/gui/gui/src/TRootGuiFactory.cxx
+++ b/gui/gui/src/TRootGuiFactory.cxx
@@ -69,9 +69,8 @@ void TRootGuiFactory::ShowWebCanvasWarning()
                 "   !!! ATTENTION !!! \n"
                 "\n"
                 "ROOT comes with a web-based canvas, which is now being started. \n"
-                "Revert to default by setting \"Canvas.Name: TRootCanvas\" in rootrc file or\n"
-                "by starting \"root --web=off\". Web-based TCanvas can be used in batch mode for\n"
-                "image generation when running with \"root -b --web\"\n"
+                "Revert to the legacy canvas by setting \"Canvas.Name: TRootCanvas\" in rootrc file or\n"
+                "by starting \"root --web=off\".\n"
                 "Find more info on https://root.cern/for_developers/root7/#twebcanvas\n"
                 "\n";
 }


### PR DESCRIPTION
1. Create TWebCanvas from TRootGuiFactory if nothing else is configured
2. Add warning message when web-based canvas started by default
3. Add `Canvas.Name` parameter to rootrc to be able change default behaviour back
4. Set `Canvas.Name` during configure depending if `webgui` compiled or not

Should behaves similar as with `TBrowser`.
If no extra command-line arguments are specified, web canvas will be started and warning message will appear.
Via `.rootrc ` file or with `--web=off` web canvas can be disabled.

In batch mode one have to use `root --web -b tutorials/hsimple.C` to use web-based image generation.
