### PR TITLE
Revert D41416: "Do not deserialize all lazy template specializations when looking for one."

### DIFF
--- a/interpreter/llvm-project/clang/include/clang/AST/DeclTemplate.h
+++ b/interpreter/llvm-project/clang/include/clang/AST/DeclTemplate.h
@@ -261,9 +261,6 @@ public:
   static TemplateArgumentList *CreateCopy(ASTContext &Context,
                                           ArrayRef<TemplateArgument> Args);
 
-  /// \brief Create hash for the given arguments.
-  static unsigned ComputeODRHash(ArrayRef<TemplateArgument> Args);
-
   /// Construct a new, temporary template argument list on the stack.
   ///
   /// The template argument list does not own the template arguments
@@ -766,26 +763,6 @@ class RedeclarableTemplateDecl : public TemplateDecl,
   }
 
   void anchor() override;
-  struct LazySpecializationInfo {
-    uint32_t DeclID = ~0U;
-    unsigned ODRHash = ~0U;
-    bool IsPartial = false;
-    LazySpecializationInfo(uint32_t ID, unsigned Hash = ~0U,
-                           bool Partial = false)
-      : DeclID(ID), ODRHash(Hash), IsPartial(Partial) { }
-    LazySpecializationInfo() { }
-    bool operator<(const LazySpecializationInfo &Other) const {
-      return DeclID < Other.DeclID;
-    }
-    bool operator==(const LazySpecializationInfo &Other) const {
-      assert((DeclID != Other.DeclID || ODRHash == Other.ODRHash) &&
-             "Hashes differ!");
-      assert((DeclID != Other.DeclID || IsPartial == Other.IsPartial) &&
-             "Both must be the same kinds!");
-      return DeclID == Other.DeclID;
-    }
-  };
-
 protected:
   template <typename EntryType> struct SpecEntryTraits {
     using DeclType = EntryType;
@@ -826,13 +803,7 @@ protected:
     return SpecIterator<EntryType>(isEnd ? Specs.end() : Specs.begin());
   }
 
-  void loadLazySpecializationsImpl(bool OnlyPartial = false) const;
-
-  ///\returns true if any lazy specialization was loaded.
-  bool loadLazySpecializationsImpl(llvm::ArrayRef<TemplateArgument> Args,
-                                   TemplateParameterList *TPL = nullptr) const;
-
-  Decl *loadLazySpecializationImpl(LazySpecializationInfo &LazySpecInfo) const;
+  void loadLazySpecializationsImpl() const;
 
   template <class EntryType, typename ...ProfileArguments>
   typename SpecEntryTraits<EntryType>::DeclType*
@@ -859,7 +830,7 @@ protected:
     ///
     /// The first value in the array is the number of specializations/partial
     /// specializations that follow.
-    LazySpecializationInfo *LazySpecializations = nullptr;
+    uint32_t *LazySpecializations = nullptr;
   };
 
   /// Pointer to the common data shared by all declarations of this
@@ -2314,7 +2285,7 @@ public:
   friend class ASTDeclWriter;
 
   /// Load any lazily-loaded specializations from the external source.
-  void LoadLazySpecializations(bool OnlyPartial = false) const;
+  void LoadLazySpecializations() const;
 
   /// Get the underlying class declarations of the template.
   CXXRecordDecl *getTemplatedDecl() const {
@@ -3143,7 +3114,7 @@ public:
   friend class ASTDeclWriter;
 
   /// Load any lazily-loaded specializations from the external source.
-  void LoadLazySpecializations(bool OnlyPartial = false) const;
+  void LoadLazySpecializations() const;
 
   /// Get the underlying variable declarations of the template.
   VarDecl *getTemplatedDecl() const {

--- a/interpreter/llvm-project/clang/lib/Serialization/ASTReader.cpp
+++ b/interpreter/llvm-project/clang/lib/Serialization/ASTReader.cpp
@@ -7287,23 +7287,14 @@ void ASTReader::CompleteRedeclChain(const Decl *D) {
     }
   }
 
-  RedeclarableTemplateDecl *Template = nullptr;
-  ArrayRef<TemplateArgument> Args;
-  if (auto *CTSD = dyn_cast<ClassTemplateSpecializationDecl>(D)) {
-    Template = CTSD->getSpecializedTemplate();
-    Args = CTSD->getTemplateArgs().asArray();
-  } else if (auto *VTSD = dyn_cast<VarTemplateSpecializationDecl>(D)) {
-    Template = VTSD->getSpecializedTemplate();
-    Args = VTSD->getTemplateArgs().asArray();
-  } else if (auto *FD = dyn_cast<FunctionDecl>(D)) {
-    if (auto *Tmplt = FD->getPrimaryTemplate()) {
-      Template = Tmplt;
-      Args = FD->getTemplateSpecializationArgs()->asArray();
-    }
+  if (auto *CTSD = dyn_cast<ClassTemplateSpecializationDecl>(D))
+    CTSD->getSpecializedTemplate()->LoadLazySpecializations();
+  if (auto *VTSD = dyn_cast<VarTemplateSpecializationDecl>(D))
+    VTSD->getSpecializedTemplate()->LoadLazySpecializations();
+  if (auto *FD = dyn_cast<FunctionDecl>(D)) {
+    if (auto *Template = FD->getPrimaryTemplate())
+      Template->LoadLazySpecializations();
   }
-
-  if (Template)
-    Template->loadLazySpecializationsImpl(Args);
 }
 
 CXXCtorInitializer **

--- a/interpreter/llvm-project/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/interpreter/llvm-project/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -83,9 +83,9 @@ namespace clang {
     ASTReader::RecordLocation Loc;
     const DeclID ThisDeclID;
     const SourceLocation ThisDeclLoc;
+
     using RecordData = ASTReader::RecordData;
-    using LazySpecializationInfo
-      = RedeclarableTemplateDecl::LazySpecializationInfo;
+
     TypeID DeferredTypeID = 0;
     unsigned AnonymousDeclNumber;
     GlobalDeclID NamedDeclForTagDecl = 0;
@@ -131,16 +131,9 @@ namespace clang {
       return Record.readString();
     }
 
-    LazySpecializationInfo ReadLazySpecializationInfo() {
-      DeclID ID = readDeclID();
-      unsigned Hash = Record.readInt();
-      bool IsPartial = Record.readInt();
-      return LazySpecializationInfo(ID, Hash, IsPartial);
-    }
-
-    void readDeclIDList(SmallVectorImpl<LazySpecializationInfo> &IDs) {
+    void readDeclIDList(SmallVectorImpl<DeclID> &IDs) {
       for (unsigned I = 0, Size = Record.readInt(); I != Size; ++I)
-        IDs.push_back(ReadLazySpecializationInfo());
+        IDs.push_back(readDeclID());
     }
 
     Decl *readDecl() {
@@ -261,7 +254,7 @@ namespace clang {
 
     template <typename T> static
     void AddLazySpecializations(T *D,
-                                SmallVectorImpl<LazySpecializationInfo>& IDs) {
+                                SmallVectorImpl<serialization::DeclID>& IDs) {
       if (IDs.empty())
         return;
 
@@ -271,11 +264,12 @@ namespace clang {
       auto *&LazySpecializations = D->getCommonPtr()->LazySpecializations;
 
       if (auto &Old = LazySpecializations) {
-        IDs.insert(IDs.end(), Old + 1, Old + 1 + Old[0].DeclID);
-        std::sort(IDs.begin(), IDs.end());
+        IDs.insert(IDs.end(), Old + 1, Old + 1 + Old[0]);
+        llvm::sort(IDs);
         IDs.erase(std::unique(IDs.begin(), IDs.end()), IDs.end());
       }
-      auto *Result = new (C) LazySpecializationInfo[1 + IDs.size()];
+
+      auto *Result = new (C) serialization::DeclID[1 + IDs.size()];
       *Result = IDs.size();
       std::copy(IDs.begin(), IDs.end(), Result + 1);
 
@@ -313,7 +307,7 @@ namespace clang {
     void ReadFunctionDefinition(FunctionDecl *FD);
     void Visit(Decl *D);
 
-    void UpdateDecl(Decl *D, llvm::SmallVectorImpl<LazySpecializationInfo>&);
+    void UpdateDecl(Decl *D, SmallVectorImpl<serialization::DeclID> &);
 
     static void setNextObjCCategory(ObjCCategoryDecl *Cat,
                                     ObjCCategoryDecl *Next) {
@@ -2141,7 +2135,7 @@ void ASTDeclReader::VisitClassTemplateDecl(ClassTemplateDecl *D) {
   if (ThisDeclID == Redecl.getFirstID()) {
     // This ClassTemplateDecl owns a CommonPtr; read it to keep track of all of
     // the specializations.
-    SmallVector<LazySpecializationInfo, 32> SpecIDs;
+    SmallVector<serialization::DeclID, 32> SpecIDs;
     readDeclIDList(SpecIDs);
     ASTDeclReader::AddLazySpecializations(D, SpecIDs);
   }
@@ -2168,7 +2162,7 @@ void ASTDeclReader::VisitVarTemplateDecl(VarTemplateDecl *D) {
   if (ThisDeclID == Redecl.getFirstID()) {
     // This VarTemplateDecl owns a CommonPtr; read it to keep track of all of
     // the specializations.
-    SmallVector<LazySpecializationInfo, 32> SpecIDs;
+    SmallVector<serialization::DeclID, 32> SpecIDs;
     readDeclIDList(SpecIDs);
     ASTDeclReader::AddLazySpecializations(D, SpecIDs);
   }
@@ -2278,7 +2272,7 @@ void ASTDeclReader::VisitFunctionTemplateDecl(FunctionTemplateDecl *D) {
 
   if (ThisDeclID == Redecl.getFirstID()) {
     // This FunctionTemplateDecl owns a CommonPtr; read it.
-    SmallVector<LazySpecializationInfo, 32> SpecIDs;
+    SmallVector<serialization::DeclID, 32> SpecIDs;
     readDeclIDList(SpecIDs);
     ASTDeclReader::AddLazySpecializations(D, SpecIDs);
   }
@@ -4207,9 +4201,7 @@ void ASTReader::loadDeclUpdateRecords(PendingUpdateRecord &Record) {
   ProcessingUpdatesRAIIObj ProcessingUpdates(*this);
   DeclUpdateOffsetsMap::iterator UpdI = DeclUpdateOffsets.find(ID);
 
-  using LazySpecializationInfo
-    = RedeclarableTemplateDecl::LazySpecializationInfo;
-  llvm::SmallVector<LazySpecializationInfo, 8> PendingLazySpecializationIDs;
+  SmallVector<serialization::DeclID, 8> PendingLazySpecializationIDs;
 
   if (UpdI != DeclUpdateOffsets.end()) {
     auto UpdateOffsets = std::move(UpdI->second);
@@ -4480,7 +4472,7 @@ static void forAllLaterRedecls(DeclT *D, Fn F) {
 }
 
 void ASTDeclReader::UpdateDecl(Decl *D,
-        SmallVectorImpl<LazySpecializationInfo> &PendingLazySpecializationIDs) {
+   llvm::SmallVectorImpl<serialization::DeclID> &PendingLazySpecializationIDs) {
   while (Record.getIdx() < Record.size()) {
     switch ((DeclUpdateKind)Record.readInt()) {
     case UPD_CXX_ADDED_IMPLICIT_MEMBER: {
@@ -4497,7 +4489,7 @@ void ASTDeclReader::UpdateDecl(Decl *D,
 
     case UPD_CXX_ADDED_TEMPLATE_SPECIALIZATION:
       // It will be added to the template's lazy specialization set.
-      PendingLazySpecializationIDs.push_back(ReadLazySpecializationInfo());
+      PendingLazySpecializationIDs.push_back(readDeclID());
       break;
 
     case UPD_CXX_ADDED_ANONYMOUS_NAMESPACE: {

--- a/interpreter/llvm-project/clang/lib/Serialization/ASTWriter.cpp
+++ b/interpreter/llvm-project/clang/lib/Serialization/ASTWriter.cpp
@@ -4877,29 +4877,12 @@ void ASTWriter::WriteDeclUpdatesBlocks(RecordDataImpl &OffsetsRecord) {
 
       switch (Kind) {
       case UPD_CXX_ADDED_IMPLICIT_MEMBER:
+      case UPD_CXX_ADDED_TEMPLATE_SPECIALIZATION:
       case UPD_CXX_ADDED_ANONYMOUS_NAMESPACE:
         assert(Update.getDecl() && "no decl to add?");
         Record.push_back(GetDeclRef(Update.getDecl()));
         break;
-      case UPD_CXX_ADDED_TEMPLATE_SPECIALIZATION: {
-        const Decl *Spec = Update.getDecl();
-        assert(Spec && "no decl to add?");
-        Record.push_back(GetDeclRef(Spec));
-        ArrayRef<TemplateArgument> Args;
-        if (auto *CTSD = dyn_cast<ClassTemplateSpecializationDecl>(Spec))
-          Args = CTSD->getTemplateArgs().asArray();
-        else if (auto *VTSD = dyn_cast<VarTemplateSpecializationDecl>(Spec))
-          Args = VTSD->getTemplateArgs().asArray();
-        else if (auto *FD = dyn_cast<FunctionDecl>(Spec))
-          Args = FD->getTemplateSpecializationArgs()->asArray();
-        assert(Args.size());
-        Record.push_back(TemplateArgumentList::ComputeODRHash(Args));
-        bool IsPartialSpecialization
-          = isa<ClassTemplatePartialSpecializationDecl>(Spec) ||
-          isa<VarTemplatePartialSpecializationDecl>(Spec);
-        Record.push_back(IsPartialSpecialization);
-        break;
-      }
+
       case UPD_CXX_ADDED_FUNCTION_DEFINITION:
         break;
 

--- a/interpreter/llvm-project/clang/lib/Serialization/ASTWriterDecl.cpp
+++ b/interpreter/llvm-project/clang/lib/Serialization/ASTWriterDecl.cpp
@@ -173,11 +173,11 @@ namespace clang {
       Record.AddSourceLocation(typeParams->getRAngleLoc());
     }
 
-    /// Collect the first declaration from each module file that provides a
-    /// declaration of D.
-    void CollectFirstDeclFromEachModule(const Decl *D, bool IncludeLocal,
-                            llvm::MapVector<ModuleFile*, const Decl*> &Firsts) {
-
+    /// Add to the record the first declaration from each module file that
+    /// provides a declaration of D. The intent is to provide a sufficient
+    /// set such that reloading this set will load all current redeclarations.
+    void AddFirstDeclFromEachModule(const Decl *D, bool IncludeLocal) {
+      llvm::MapVector<ModuleFile*, const Decl*> Firsts;
       // FIXME: We can skip entries that we know are implied by others.
       for (const Decl *R = D->getMostRecentDecl(); R; R = R->getPreviousDecl()) {
         if (R->isFromASTFile())
@@ -185,47 +185,8 @@ namespace clang {
         else if (IncludeLocal)
           Firsts[nullptr] = R;
       }
-    }
-
-    /// Add to the record the first declaration from each module file that
-    /// provides a declaration of D. The intent is to provide a sufficient
-    /// set such that reloading this set will load all current redeclarations.
-    void AddFirstDeclFromEachModule(const Decl *D, bool IncludeLocal) {
-      llvm::MapVector<ModuleFile*, const Decl*> Firsts;
-      CollectFirstDeclFromEachModule(D, IncludeLocal, Firsts);
-
       for (const auto &F : Firsts)
         Record.AddDeclRef(F.second);
-    }
-
-    /// Add to the record the first template specialization from each module
-    /// file that provides a declaration of D. We store the DeclId and an
-    /// ODRHash of the template arguments of D which should provide enough
-    /// information to load D only if the template instantiator needs it.
-    void AddFirstSpecializationDeclFromEachModule(const Decl *D,
-                                                  bool IncludeLocal) {
-      assert(isa<ClassTemplateSpecializationDecl>(D) ||
-             isa<VarTemplateSpecializationDecl>(D) || isa<FunctionDecl>(D) &&
-             "Must not be called with other decls");
-      llvm::MapVector<ModuleFile*, const Decl*> Firsts;
-      CollectFirstDeclFromEachModule(D, IncludeLocal, Firsts);
-
-      for (const auto &F : Firsts) {
-        Record.AddDeclRef(F.second);
-        ArrayRef<TemplateArgument> Args;
-        if (auto *CTSD = dyn_cast<ClassTemplateSpecializationDecl>(D))
-          Args = CTSD->getTemplateArgs().asArray();
-        else if (auto *VTSD = dyn_cast<VarTemplateSpecializationDecl>(D))
-          Args = VTSD->getTemplateArgs().asArray();
-        else if (auto *FD = dyn_cast<FunctionDecl>(D))
-          Args = FD->getTemplateSpecializationArgs()->asArray();
-        assert(Args.size());
-        Record.push_back(TemplateArgumentList::ComputeODRHash(Args));
-        bool IsPartialSpecialization
-          = isa<ClassTemplatePartialSpecializationDecl>(D) ||
-          isa<VarTemplatePartialSpecializationDecl>(D);
-        Record.push_back(IsPartialSpecialization);
-      }
     }
 
     /// Get the specialization decl from an entry in the specialization list.
@@ -240,8 +201,7 @@ namespace clang {
     decltype(T::PartialSpecializations) &getPartialSpecializations(T *Common) {
       return Common->PartialSpecializations;
     }
-    MutableArrayRef<FunctionTemplateSpecializationInfo>
-    getPartialSpecializations(FunctionTemplateDecl::Common *) {
+    ArrayRef<Decl> getPartialSpecializations(FunctionTemplateDecl::Common *) {
       return None;
     }
 
@@ -258,11 +218,9 @@ namespace clang {
         assert(!Common->LazySpecializations);
       }
 
-      using LazySpecializationInfo
-        = RedeclarableTemplateDecl::LazySpecializationInfo;
-      ArrayRef<LazySpecializationInfo> LazySpecializations;
+      ArrayRef<DeclID> LazySpecializations;
       if (auto *LS = Common->LazySpecializations)
-        LazySpecializations = llvm::makeArrayRef(LS + 1, LS[0].DeclID);
+        LazySpecializations = llvm::makeArrayRef(LS + 1, LS[0]);
 
       // Add a slot to the record for the number of specializations.
       unsigned I = Record.size();
@@ -278,20 +236,12 @@ namespace clang {
 
       for (auto *D : Specs) {
         assert(D->isCanonicalDecl() && "non-canonical decl in set");
-        AddFirstSpecializationDeclFromEachModule(D, /*IncludeLocal*/true);
+        AddFirstDeclFromEachModule(D, /*IncludeLocal*/true);
       }
-      for (auto &SpecInfo : LazySpecializations) {
-        Record.push_back(SpecInfo.DeclID);
-        Record.push_back(SpecInfo.ODRHash);
-        Record.push_back(SpecInfo.IsPartial);
-      }
+      Record.append(LazySpecializations.begin(), LazySpecializations.end());
 
-      // Update the size entry we added earlier. We linerized the
-      // LazySpecializationInfo members and we need to adjust the size as we
-      // will read them always together.
-      assert ((Record.size() - I - 1) % 3 == 0
-              && "Must be divisible by LazySpecializationInfo count!");
-      Record[I] = (Record.size() - I - 1) / 3;
+      // Update the size entry we added earlier.
+      Record[I] = Record.size() - I - 1;
     }
 
     /// Ensure that this template specialization is associated with the specified


### PR DESCRIPTION
The lazy loading approach may be faster, but it is continuously leading to problems with template instantiations and ODR violation checks in the most inconvenient places.