### PR TITLE
Remove checks for deprecated _REENTRANT macro

### DIFF
--- a/cmake/modules/SetUpFreeBSD.cmake
+++ b/cmake/modules/SetUpFreeBSD.cmake
@@ -77,8 +77,6 @@ if(CMAKE_COMPILER_IS_GNUCXX)
   endif()
 
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL Clang)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_REENTRANT")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_REENTRANT")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pipe ${FP_MATH_FLAGS} -Wall -W -Woverloaded-virtual -fsigned-char")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pipe -Wall -W")
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -std=legacy")

--- a/config/root-config.in
+++ b/config/root-config.in
@@ -359,7 +359,7 @@ esac
 
 case $arch in
 freebsd*)
-   auxcflags="-pthread -D_REENTRANT $auxcflags"
+   auxcflags="-pthread $auxcflags"
    auxlibs="-pthread $auxlibs"
 
    for f in $features ; do
@@ -391,7 +391,6 @@ macosx*)
       auxcflags="-pthread $auxcflags"
       auxlibs="-lpthread $auxlibs"
    else
-      auxcflags="-D_REENTRANT $auxcflags"
       auxlibs="-lpthread $auxlibs"
    fi
    for f in $features ; do
@@ -413,7 +412,6 @@ hpuxacc | hpuxia64acc)
 win32)
    ;;
 *)
-   auxcflags="-D_REENTRANT $auxcflags"
    auxlibs="-lpthread $auxlibs"
    ;;
 esac

--- a/config/root-config.in
+++ b/config/root-config.in
@@ -413,10 +413,8 @@ hpuxacc | hpuxia64acc)
 win32)
    ;;
 *)
-   for f in $features ; do
-      auxcflags="-D_REENTRANT $auxcflags"
-      auxlibs="-lpthread $auxlibs"
-   done
+   auxcflags="-D_REENTRANT $auxcflags"
+   auxlibs="-lpthread $auxlibs"
    ;;
 esac
 

--- a/core/base/inc/TVirtualMutex.h
+++ b/core/base/inc/TVirtualMutex.h
@@ -89,12 +89,8 @@ public:
    ClassDefNV(TLockGuard,0)  // Exception safe locking/unlocking of mutex
 };
 
-// Zero overhead macros in case not compiled with thread support (-pthread)
 // Use with a trailing semicolon and pass a pointer as argument, e.g.:
 // TMutex m; R__LOCKGUARD(&m);
-// Warning: if program is compiled without pthread support, _REENTRANT will
-// be undefined and the macro has (silently) no effect, no locks are performed.
-#if defined (_REENTRANT) || defined (WIN32) || defined (R__FBSD)
 
 #define R__LOCKGUARD(mutex) TLockGuard _R__UNIQUE_(R__guard)(mutex)
 #define R__LOCKGUARD2(mutex)                             \
@@ -107,13 +103,6 @@ public:
    R__LOCKGUARD(mutex)
 #define R__LOCKGUARD_NAMED(name,mutex) TLockGuard _NAME2_(R__guard,name)(mutex)
 #define R__LOCKGUARD_UNLOCK(name) _NAME2_(R__guard,name).UnLock()
-#else
-//@todo: mutex is not checked to be of type TVirtualMutex*.
-#define R__LOCKGUARD(mutex)  (void)(mutex); { }
-#define R__LOCKGUARD_NAMED(name,mutex) (void)(mutex); { }
-#define R__LOCKGUARD2(mutex) (void)(mutex); { }
-#define R__LOCKGUARD_UNLOCK(name) { }
-#endif
 
 #ifdef R__USE_IMT
 #define R__LOCKGUARD_IMT(mutex)  R__LOCKGUARD(ROOT::Internal::IsParBranchProcessingEnabled() ? mutex : nullptr)

--- a/core/base/inc/TVirtualRWMutex.h
+++ b/core/base/inc/TVirtualRWMutex.h
@@ -149,28 +149,12 @@ public:
 
 } // namespace ROOT.
 
-// Zero overhead macros in case not compiled with thread support (-pthread)
 // Use with a trailing semicolon and pass a pointer as argument, e.g.:
 // TMutex m; R__READ_LOCKGUARD(&m);
-// Warning: if program is compiled without pthread support, _REENTRANT will
-// be undefined and the macro has (silently) no effect, no locks are performed.
-#if defined (_REENTRANT) || defined (WIN32) || defined (R__FBSD)
-
 #define R__READ_LOCKGUARD(mutex) ::ROOT::TReadLockGuard _R__UNIQUE_(R__readguard)(mutex)
 #define R__READ_LOCKGUARD_NAMED(name,mutex) ::ROOT::TReadLockGuard _NAME2_(R__readguard,name)(mutex)
 
 #define R__WRITE_LOCKGUARD(mutex) ::ROOT::TWriteLockGuard _R__UNIQUE_(R__readguard)(mutex)
 #define R__WRITE_LOCKGUARD_NAMED(name,mutex) ::ROOT::TWriteLockGuard _NAME2_(R__readguard,name)(mutex)
-
-#else
-//@todo: mutex is not checked to be of type TVirtualMutex*.
-#define R__READ_LOCKGUARD(mutex) (void)mutex
-#define R__READ_LOCKGUARD_NAMED(name,mutex) (void)mutex
-
-#define R__WRITE_LOCKGUARD(mutex) (void)mutex
-#define R__WRITE_LOCKGUARD_NAMED(name,mutex) (void)mutex
-
-#endif
-
 
 #endif

--- a/core/base/src/TDatime.cxx
+++ b/core/base/src/TDatime.cxx
@@ -121,7 +121,7 @@ const char *TDatime::AsString() const
 const char *TDatime::AsString(char *out) const
 {
    time_t t = Convert();
-#ifdef _REENTRANT
+#ifndef WIN32
 #if defined(R__SOLARIS) && (_POSIX_C_SOURCE - 0 < 199506L)
    char *retStr = ctime_r(&t, out, 26);
 #else
@@ -132,7 +132,7 @@ const char *TDatime::AsString(char *out) const
 #endif
    if (retStr) {
       *(retStr + 24) = 0;
-#ifndef _REENTRANT
+#ifdef WIN32
       strcpy(out, retStr);
 #endif
       return retStr;
@@ -203,7 +203,7 @@ UInt_t TDatime::Convert(Bool_t toGMT) const
       return 0;
    }
    if (toGMT) {
-#ifdef _REENTRANT
+#ifndef WIN32
       struct tm tg;
       struct tm *tgp = gmtime_r(&t, &tg);
 #else
@@ -290,12 +290,8 @@ void TDatime::Set()
 {
 #ifndef WIN32
    time_t tloc   = time(nullptr);
-#ifdef _REENTRANT
    struct tm tpa;
    struct tm *tp = localtime_r(&tloc, &tpa);
-#else
-   struct tm *tp = localtime(&tloc);
-#endif
    UInt_t year   = tp->tm_year;
    UInt_t month  = tp->tm_mon + 1;
    UInt_t day    = tp->tm_mday;
@@ -335,7 +331,7 @@ void TDatime::Set(UInt_t tloc, Bool_t dosDate)
       sec   = (tloc & 0x1f) * 2;
    } else {
       time_t t = (time_t) tloc;
-#ifdef _REENTRANT
+#ifndef WIN32
       struct tm tpa;
       struct tm *tp = localtime_r(&t, &tpa);
 #else

--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -262,15 +262,7 @@ const char *TSystem::GetError()
 
 Int_t TSystem::GetErrno()
 {
-#ifdef _REENTRANT
-   return errno; // errno can be a macro if _REENTRANT is set
-#else
-#ifdef R__SOLARIS_CC50
-   return ::errno;
-#else
    return errno;
-#endif
-#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -278,15 +270,7 @@ Int_t TSystem::GetErrno()
 
 void TSystem::ResetErrno()
 {
-#ifdef _REENTRANT
-   errno = 0; // errno can be a macro if _REENTRANT is set
-#else
-#ifdef R__SOLARIS_CC50
-   ::errno = 0;
-#else
    errno = 0;
-#endif
-#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/base/src/TTimeStamp.cxx
+++ b/core/base/src/TTimeStamp.cxx
@@ -317,7 +317,7 @@ const Char_t *TTimeStamp::AsString(Option_t *option) const
 
    // get the components into a tm struct
    time_t seconds = (time_t) fSec;
-#ifdef _REENTRANT
+#ifndef R__WIN32
    struct tm buf;
    struct tm *ptm = (asLocal) ? localtime_r(&seconds, &buf) : gmtime_r(&seconds, &buf);
 #else
@@ -355,7 +355,7 @@ UInt_t TTimeStamp::GetDate(Bool_t inUTC, Int_t secOffset,
                            UInt_t *year, UInt_t *month, UInt_t *day) const
 {
    time_t atime = fSec + secOffset;
-#ifdef _REENTRANT
+#ifndef R__WIN32
    struct tm buf;
    struct tm *ptm = (inUTC) ? gmtime_r(&atime, &buf) : localtime_r(&atime, &buf);
 #else
@@ -377,7 +377,7 @@ UInt_t TTimeStamp::GetTime(Bool_t inUTC, Int_t secOffset,
                            UInt_t *hour, UInt_t *min, UInt_t *sec) const
 {
    time_t atime = fSec + secOffset;
-#ifdef _REENTRANT
+#ifndef R__WIN32
    struct tm buf;
    struct tm *ptm = (inUTC) ? gmtime_r(&atime, &buf) : localtime_r(&atime, &buf);
 #else
@@ -398,7 +398,7 @@ UInt_t TTimeStamp::GetTime(Bool_t inUTC, Int_t secOffset,
 Int_t TTimeStamp::GetDayOfYear(Bool_t inUTC, Int_t secOffset) const
 {
    time_t atime = fSec + secOffset;
-#ifdef _REENTRANT
+#ifndef R__WIN32
    struct tm buf;
    struct tm *ptm = (inUTC) ? gmtime_r(&atime, &buf) : localtime_r(&atime, &buf);
 #else
@@ -419,7 +419,7 @@ Int_t TTimeStamp::GetDayOfYear(Bool_t inUTC, Int_t secOffset) const
 Int_t TTimeStamp::GetDayOfWeek(Bool_t inUTC, Int_t secOffset) const
 {
    time_t atime = fSec + secOffset;
-#ifdef _REENTRANT
+#ifndef R__WIN32
    struct tm buf;
    struct tm *ptm = (inUTC) ? gmtime_r(&atime, &buf) : localtime_r(&atime, &buf);
 #else
@@ -439,7 +439,7 @@ Int_t TTimeStamp::GetDayOfWeek(Bool_t inUTC, Int_t secOffset) const
 Int_t TTimeStamp::GetMonth(Bool_t inUTC, Int_t secOffset) const
 {
    time_t atime = fSec + secOffset;
-#ifdef _REENTRANT
+#ifndef R__WIN32
    struct tm buf;
    struct tm *ptm = (inUTC) ? gmtime_r(&atime, &buf) : localtime_r(&atime, &buf);
 #else
@@ -457,7 +457,7 @@ Int_t TTimeStamp::GetMonth(Bool_t inUTC, Int_t secOffset) const
 Int_t TTimeStamp::GetWeek(Bool_t inUTC, Int_t secOffset) const
 {
    time_t atime = fSec + secOffset;
-#ifdef _REENTRANT
+#ifndef R__WIN32
    struct tm buf;
    struct tm *ptm = (inUTC) ? gmtime_r(&atime, &buf) : localtime_r(&atime, &buf);
 #else
@@ -485,7 +485,7 @@ Int_t TTimeStamp::GetWeek(Bool_t inUTC, Int_t secOffset) const
 Bool_t TTimeStamp::IsLeapYear(Bool_t inUTC, Int_t secOffset) const
 {
    time_t atime = fSec + secOffset;
-#ifdef _REENTRANT
+#ifndef R__WIN32
    struct tm buf;
    struct tm *ptm = (inUTC) ? gmtime_r(&atime, &buf) : localtime_r(&atime, &buf);
 #else
@@ -515,7 +515,7 @@ Int_t TTimeStamp::GetZoneOffset()
 #else
    time_t tp = 0;
    time(&tp);
-#ifdef _REENTRANT
+#ifndef R__WIN32
    struct tm buf;
    return -localtime_r(&tp, &buf)->tm_gmtoff;
 #else
@@ -703,7 +703,7 @@ void TTimeStamp::Set(UInt_t tloc, Bool_t isUTC, Int_t secOffset, Bool_t dosDate)
       localtm.tm_isdst = -1;
    } else {
       time_t t = (time_t) tloc;
-#ifdef _REENTRANT
+#ifndef R__WIN32
       struct tm tpa;
       struct tm *tp = localtime_r(&t, &tpa);
 #else

--- a/core/cont/inc/TCollection.h
+++ b/core/cont/inc/TCollection.h
@@ -357,9 +357,6 @@ using TRangeStaticCast = TRangeCast<T, false>;
 template <typename T>
 using TRangeDynCast = ROOT::Detail::TRangeCast<T, true>;
 
-// Zero overhead macros in case not compiled with thread support
-#if defined (_REENTRANT) || defined (WIN32) || defined (R__FBSD)
-
 #define R__COLL_COND_MUTEX(mutex) this->IsUsingRWLock() ? mutex : nullptr
 
 #define R__COLLECTION_READ_LOCKGUARD(mutex) ::ROOT::TReadLockGuard _R__UNIQUE_(R__readguard)(R__COLL_COND_MUTEX(mutex))
@@ -367,16 +364,6 @@ using TRangeDynCast = ROOT::Detail::TRangeCast<T, true>;
 
 #define R__COLLECTION_WRITE_LOCKGUARD(mutex) ::ROOT::TWriteLockGuard _R__UNIQUE_(R__readguard)(R__COLL_COND_MUTEX(mutex))
 #define R__COLLECTION_WRITE_LOCKGUARD_NAMED(name,mutex) ::ROOT::TWriteLockGuard _NAME2_(R__readguard,name)(R__COLL_COND_MUTEX(mutex))
-
-#else
-
-#define R__COLLECTION_READ_LOCKGUARD(mutex) (void)mutex
-#define R__COLLECTION_COLLECTION_READ_LOCKGUARD_NAMED(name,mutex) (void)mutex
-
-#define R__COLLECTION_WRITE_LOCKGUARD(mutex) (void)mutex
-#define R__COLLECTION_WRITE_LOCKGUARD_NAMED(name,mutex) (void)mutex
-
-#endif
 
 //---- R__FOR_EACH macro -------------------------------------------------------
 

--- a/core/meta/inc/TInterpreter.h
+++ b/core/meta/inc/TInterpreter.h
@@ -45,11 +45,7 @@ class TSeqCollection;
 
 R__EXTERN TVirtualMutex *gInterpreterMutex;
 
-#if defined (_REENTRANT) || defined (WIN32) || defined (R__FBSD)
 # define R__LOCKGUARD_CLING(mutex)  ::ROOT::Internal::InterpreterMutexRegistrationRAII _R__UNIQUE_(R__guard)(mutex); { }
-#else
-# define R__LOCKGUARD_CLING(mutex)  (void)(mutex); { }
-#endif
 
 namespace ROOT {
 namespace Internal {

--- a/core/thread/src/TThread.cxx
+++ b/core/thread/src/TThread.cxx
@@ -320,11 +320,6 @@ void TThread::Init()
 {
    if (fgThreadImp || fgIsTearDown) return;
 
-#if !defined (_REENTRANT) && !defined (WIN32)
-   // Not having it means (See TVirtualMutext.h) that the LOCKGUARD macro are empty.
-   ::Fatal("Init","_REENTRANT must be #define-d for TThread to work properly.");
-#endif
-
    // 'Insure' gROOT is created before initializing the Thread safe behavior
    // (to make sure we do not have two attempting to create it).
    ROOT::GetROOT();

--- a/graf2d/x11/src/GX11Gui.cxx
+++ b/graf2d/x11/src/GX11Gui.cxx
@@ -808,7 +808,6 @@ void TGX11::GetWindowAttributes(Window_t id, WindowAttributes_t &attr)
 
 Int_t TGX11::OpenDisplay(const char *dpyName)
 {
-#ifdef _REENTRANT
    // In some cases there can be problems due to XInitThreads, like when
    // using Qt, so we allow for it to be turned off
    if (gEnv->GetValue("X11.XInitThread", 1)) {
@@ -816,7 +815,6 @@ Int_t TGX11::OpenDisplay(const char *dpyName)
       if (!XInitThreads())
          Warning("OpenDisplay", "system has no X11 thread support");
    }
-#endif
 
    Display *dpy;
    if (!(dpy = XOpenDisplay(dpyName)))

--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -414,7 +414,7 @@ namespace {
     Opts.MathErrno = 0;
 #endif
 
-#ifdef _REENTRANT
+#ifndef _WIN32
     Opts.POSIXThreads = 1;
 #endif
 #ifdef __FAST_MATH__

--- a/net/net/src/TS3HTTPRequest.cxx
+++ b/net/net/src/TS3HTTPRequest.cxx
@@ -159,14 +159,9 @@ TS3HTTPRequest& TS3HTTPRequest::SetTimeStamp()
 {
    time_t now = time(NULL);
    char result[128];
-#ifdef _REENTRANT
    struct tm dateFormat;
    strftime(result, sizeof(result), "%a, %d %b %Y %H:%M:%S GMT",
       gmtime_r(&now, &dateFormat));
-#else
-   strftime(result, sizeof(result), "%a, %d %b %Y %H:%M:%S GMT",
-      gmtime(&now));
-#endif
    fTimeStamp = result;
    return *this;
 }

--- a/net/rpdutils/src/error.cxx
+++ b/net/rpdutils/src/error.cxx
@@ -34,14 +34,6 @@ extern "C" {
 }
 #endif
 
-#ifdef __sun
-#   ifndef _REENTRANT
-#      if __SUNPRO_CC > 0x420
-#         define GLOBAL_ERRNO
-#      endif
-#   endif
-#endif
-
 #include "rpderr.h"
 #include "rpdp.h"
 
@@ -56,22 +48,14 @@ extern bool gSysLog;
 
 int GetErrno()
 {
-#ifdef GLOBAL_ERRNO
-   return ::errno;
-#else
    return errno;
-#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 void ResetErrno()
 {
-#ifdef GLOBAL_ERRNO
-   ::errno = 0;
-#else
    errno = 0;
-#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/rootx/src/rootx.cxx
+++ b/rootx/src/rootx.cxx
@@ -45,14 +45,6 @@
 #include <libprocstat.h>
 #endif // R__FBSD
 
-#ifdef __sun
-#   ifndef _REENTRANT
-#      if __SUNPRO_CC > 0x420
-#         define GLOBAL_ERRNO
-#      endif
-#   endif
-#endif
-
 #if defined(__CYGWIN__) && defined(__GNUC__)
 #define ROOTBINARY "root_exe.exe"
 #else
@@ -90,20 +82,12 @@ using ROOT::ROOTX::gChildpid;
 static int gChildpid;
 static int GetErrno()
 {
-#ifdef GLOBAL_ERRNO
-   return ::errno;
-#else
    return errno;
-#endif
 }
 
 static void ResetErrno()
 {
-#ifdef GLOBAL_ERRNO
-   ::errno = 0;
-#else
    errno = 0;
-#endif
 }
 
 #endif


### PR DESCRIPTION
According to `feature_test_macros`, this macro is obsolete and "glibc has been thread-safe by default for many years." Other platforms don't use it at all, for example FreeBSD.

Some parts of ROOT used it to determine if we are compiling with `-pthread`, but this is essentially unused these days because the CMake build always enables threading support and there exists no option to turn it off.