### PR TITLE
[webgui] provide method which checks if image can be produced with web browsers

### DIFF
--- a/gui/canvaspainter/src/RCanvasPainter.cxx
+++ b/gui/canvaspainter/src/RCanvasPainter.cxx
@@ -457,13 +457,19 @@ void RCanvasPainter::DoWhenReady(const std::string &name, const std::string &arg
 
 bool RCanvasPainter::ProduceBatchOutput(const std::string &fname, int width, int height)
 {
+   auto len = fname.length();
+   bool is_json = (len > 4) && ((fname.compare(len-4,4,".json") == 0) || (fname.compare(len-4,4,".JSON") == 0));
+
+   // do not try to produce image if current settings not allowing this
+   if (!is_json && !RWebDisplayHandle::CanProduceImages())
+      return false;
+
    RDrawable::RDisplayContext ctxt(&fCanvas, &fCanvas, 0);
    ctxt.SetConnection(1, true);
 
    auto snapshot = CreateSnapshot(ctxt);
 
-   auto len = fname.length();
-   if ((len > 4) && ((fname.compare(len-4,4,".json") == 0) || (fname.compare(len-4,4,".JSON") == 0))) {
+   if (is_json) {
       std::ofstream f(fname);
       if (!f) {
          R__LOG_ERROR(CanvasPainerLog()) << "Fail to open file " << fname << " to store canvas snapshot";

--- a/gui/webdisplay/inc/ROOT/RWebDisplayHandle.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebDisplayHandle.hxx
@@ -81,6 +81,8 @@ protected:
 
    static std::unique_ptr<Creator> &FindCreator(const std::string &name, const std::string &libname = "");
 
+   static bool CheckIfCanProduceImages(RWebDisplayArgs &args);
+
 public:
 
    /// constructor
@@ -103,6 +105,8 @@ public:
    static std::unique_ptr<RWebDisplayHandle> Display(const RWebDisplayArgs &args);
 
    static bool DisplayUrl(const std::string &url);
+
+   static bool CanProduceImages(const std::string &browser = "");
 
    static bool ProduceImage(const std::string &fname, const std::string &json, int width = 800, int height = 600, const char *batch_file = nullptr);
 };

--- a/tutorials/rcanvas/df104.py
+++ b/tutorials/rcanvas/df104.py
@@ -236,5 +236,5 @@ c.SetSize(700, 780)
 c.Show()
 
 # Save plot in PNG file
-c.SaveAs("df104.png")
-print("Saved figure to df104.png")
+if c.SaveAs("df104.png") :
+   print("Saved figure to df104.png")

--- a/tutorials/rcanvas/df105.py
+++ b/tutorials/rcanvas/df105.py
@@ -236,5 +236,5 @@ c.SetSize(600, 600)
 c.Show()
 
 # Save the plot
-c.SaveAs("df105.png")
-print("Saved figure to df105.png")
+if c.SaveAs("df105.png") :
+    print("Saved figure to df105.png")

--- a/tutorials/rcanvas/rline.cxx
+++ b/tutorials/rcanvas/rline.cxx
@@ -44,7 +44,8 @@ void rline()
 
    canvas->SetSize(900, 700);
 
-   canvas->SaveAs("line.png");
+   if (canvas->SaveAs("line.png"))
+      printf("Store RCanvas in line.png\n");
 
    canvas->Show();
 }


### PR DESCRIPTION
Used in `RCanvas::SaveAs()` method to avoid failure message when image production in 
tutorials macros is not possible.

Should fix newly introduced errors in Jenkins