### PR TITLE
[treeplayer] fix compiler warnings concerning enum combination

### DIFF
--- a/tree/treeplayer/src/TFormLeafInfo.cxx
+++ b/tree/treeplayer/src/TFormLeafInfo.cxx
@@ -358,7 +358,7 @@ Bool_t TFormLeafInfo::IsString() const
       case kChar_t:
          // This is new in ROOT 3.02/05
          return kFALSE;
-      case TStreamerInfo::kOffsetL + kChar_t:
+      case TStreamerInfo::kOffsetL + TStreamerInfo::kChar:
          // This is new in ROOT 3.02/05
          return kTRUE;
       case TStreamerInfo::kCharStar:
@@ -887,7 +887,7 @@ T TFormLeafInfo::ReadValueImpl(char *thisobj, Int_t instance)
       case TStreamerInfo::kOffsetL + TStreamerInfo::kULong64:
          {Long64_t *val = (Long64_t*)(thisobj+fOffset);   return T(val[instance]);}
 #else
-      case TStreamerInfo::kOffsetL + kULong64_t:
+      case TStreamerInfo::kOffsetL + TStreamerInfo::kULong64:
          {ULong64_t *val = (ULong64_t*)(thisobj+fOffset); return T(val[instance]);}
 #endif
 

--- a/tree/treeplayer/src/TTreeFormula.cxx
+++ b/tree/treeplayer/src/TTreeFormula.cxx
@@ -4755,7 +4755,7 @@ Bool_t  TTreeFormula::IsLeafString(Int_t code) const
                // let's assume it is NOT a string.
                return kFALSE;
             }
-            if (elem->GetNewType()== TStreamerInfo::kOffsetL +kChar_t) {
+            if (elem->GetNewType() == TStreamerInfo::kOffsetL + TStreamerInfo::kChar) {
                // Check whether a specific element of the string is specified!
                if (fIndexes[code][fNdimensions[code]-1] != -1) return kFALSE;
                return kTRUE;


### PR DESCRIPTION
Warning like this:
```
tree/treeplayer/src/TFormLeafInfo.cxx: In member function ‘virtual Bool_t TFormLeafInfo::IsString() const’:
tree/treeplayer/src/TFormLeafInfo.cxx:361:36: warning: arithmetic between different enumeration types ‘TStreamerInfo::EReadWrite’ and ‘EDataType’ is deprecated [-Wdeprecated-enum-enum-conversion]
  361 |       case TStreamerInfo::kOffsetL + kChar_t:
      |            ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
tree/treeplayer/src/TFormLeafInfo.cxx: In member function ‘T TFormLeafInfo::ReadValueImpl(char*, Int_t)’:
tree/treeplayer/src/TFormLeafInfo.cxx:890:36: warning: arithmetic between different enumeration types ‘TStreamerInfo::EReadWrite’ and ‘EDataType’ is deprecated [-Wdeprecated-enum-enum-conversion]
  890 |       case TStreamerInfo::kOffsetL + kULong64_t:
      |            ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
```
