### PR TITLE
[ntuple] Add LowPrecisionFloats to LinkDef.h

### DIFF
--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -13,6 +13,7 @@
 #pragma link C++ class EmptyStruct + ;
 #pragma link C++ class TestEBO+;
 #pragma link C++ class IOConstructor+;
+#pragma link C++ class LowPrecisionFloats+;
 
 #pragma link C++ class EdmWrapper<CustomStruct> +;
 


### PR DESCRIPTION
This fixes the test `gtest-tree-ntuple-v7-test-ntuple-types` when building with `runtime_cxxmodules=OFF`, see #13058.