### PR TITLE
[tmva] fix capture warning from c++20

### DIFF
--- a/tmva/tmva/src/Classification.cxx
+++ b/tmva/tmva/src/Classification.cxx
@@ -262,7 +262,7 @@ void TMVA::Experimental::Classification::Evaluate()
 #ifndef _MSC_VER
       fWorkers.SetNWorkers(fJobs);
 #endif
-      auto executor = [=](UInt_t workerID) -> ClassificationResult {
+      auto executor = [this](UInt_t workerID) -> ClassificationResult {
          TMVA::MsgLogger::InhibitOutput();
          TMVA::gConfig().SetSilent(kTRUE);
          TMVA::gConfig().SetUseColor(kFALSE);


### PR DESCRIPTION
It is:

```
tmva/tmva/src/Classification.cxx: In lambda function:
tmva/tmva/src/Classification.cxx:265:23: warning: implicit capture of ‘this’ via ‘[=]’ is deprecated in C++20 [-Wdeprecated]
  265 |       auto executor = [=](UInt_t workerID) ->ClassificationResult {
      |                       ^
tmva/tmva/src/Classification.cxx:265:23: note: add explicit ‘this’ or ‘*this’ capture
```
