### PR TITLE
Add jitlink to LLVM_LINK_COMPONENTS in relevant cling parts

### DIFF
--- a/interpreter/cling/lib/Interpreter/CMakeLists.txt
+++ b/interpreter/cling/lib/Interpreter/CMakeLists.txt
@@ -30,6 +30,7 @@ set(LLVM_LINK_COMPONENTS
   coverage
   executionengine
   ipo
+  jitlink
   lto
   mc
   object

--- a/interpreter/cling/tools/libcling/CMakeLists.txt
+++ b/interpreter/cling/tools/libcling/CMakeLists.txt
@@ -32,6 +32,7 @@ set( LLVM_LINK_COMPONENTS
   coverage
   executionengine
   ipo
+  jitlink
   mc
   object
   option


### PR DESCRIPTION
When cling is compiled standalone without the help of the Cling Packaging Tool, errors about missing ```llvm::jitlink``` symbols may occur. For example, I could not build cling against [an external instance of LLVM + clang](https://github.com/root-project/llvm-project/tree/cling-llvm13) compiled with ```BUILD_SHARED_LIBS=ON```.

This PR fixes it by updating 2 offensive CMakeLists.txt's.

(Contributing to the ROOT repository rather than the cling one by request of @Axel-Naumann)
