### PR TITLE
[tree] fix lambda this capture warnings

### DIFF
--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -3204,7 +3204,7 @@ Int_t TBranch::WriteBasketImpl(TBasket* basket, Int_t where, ROOT::Internal::TBr
    // Note: captures `basket`, `where`, and `this` by value; modifies the TBranch and basket,
    // as we make a copy of the pointer.  We cannot capture `basket` by reference as the pointer
    // itself might be modified after `WriteBasketImpl` exits.
-   auto doUpdates = [=]() {
+   auto doUpdates = [this, basket, where]() {
       Int_t nout  = basket->WriteBuffer();    //  Write buffer
       if (nout < 0)
          Error("WriteBasketImpl", "basket's WriteBuffer failed.");

--- a/tree/tree/src/TBranchIMTHelper.h
+++ b/tree/tree/src/TBranchIMTHelper.h
@@ -35,7 +35,7 @@ public:
    template<typename FN> void Run(const FN &lambda) {
 #ifdef R__USE_IMT
       if (!fGroup) { fGroup.reset(new TaskGroup_t()); }
-      fGroup->Run( [=]() {
+      fGroup->Run( [this, &lambda]() {
          auto nbytes = lambda();
          if (nbytes >= 0) {
             fBytes += nbytes;

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -5403,7 +5403,7 @@ Int_t TTree::GetBranchStyle()
 
 Long64_t TTree::GetCacheAutoSize(Bool_t withDefault /* = kFALSE */ )
 {
-   auto calculateCacheSize = [=](Double_t cacheFactor)
+   auto calculateCacheSize = [this](Double_t cacheFactor)
    {
       Long64_t cacheSize = 0;
       if (fAutoFlush < 0) {


### PR DESCRIPTION
Like:
```
tree/tree/src/TBranchIMTHelper.h: In lambda function:
tree/tree/src/TBranchIMTHelper.h:38:20: warning: implicit capture of ‘this’ via ‘[=]’ is deprecated in C++20 [-Wdeprecated]
   38 |       fGroup->Run( [=]() {
      |                    ^
tree/tree/src/TBranchIMTHelper.h:38:20: note: add explicit ‘this’ or ‘*this’ capture
```
