### PR TITLE
[skip-ci][NFC][DF] Fix doxygen formatting

### DIFF
--- a/tree/dataframe/src/RDataFrame.cxx
+++ b/tree/dataframe/src/RDataFrame.cxx
@@ -959,7 +959,7 @@ not limited to string expressions but they can also pass any valid C++ callable,
 complex functors. The callable can be applied to zero or more existing columns and it will always receive their
 _nominal_ values in input.
 
-**Varying multiple columns in lockstep**
+#### Varying multiple columns in lockstep
 
 In the following Python snippet we use the Vary() signature that allows varying multiple columns simultaneously or
 "in lockstep":
@@ -977,7 +977,7 @@ this case we also have to explicitly pass a variation name as there is no one co
 
 The call above will produce variations "ptAndEta:down" and "ptAndEta:up".
 
-**Combining multiple variations**
+#### Combining multiple variations
 
 Even if a result depends on multiple variations, only one is applied at a time, i.e. there will be no result produced
 by applying multiple systematic variations at the same time.


### PR DESCRIPTION
I don't know why doxygen does not put those titles in bold, but it doesn't:

![image](https://github.com/root-project/root/assets/10999034/ec9eb86c-7dfc-49d0-b081-a58db417e366)