### PR TITLE
[skip-ci][NFC][DF] Fix doxygen formatting, simplify wording

### DIFF
--- a/tree/dataframe/src/RDataFrame.cxx
+++ b/tree/dataframe/src/RDataFrame.cxx
@@ -666,10 +666,7 @@ parts of the RDataFrame API currently work with this package. The subset that is
 with support for more operations coming in the future. Data sources other than TTree and TChain (e.g. CSV, RNTuple) are
 currently not supported.
 
-**Note** that the distributed RDataFrame module is available in a ROOT installation if the following criteria are met:
-- PyROOT is available
-- RDataFrame is available
-- The version of the Python interpreter used to build ROOT is greater or equal than 3.7
+\note The distributed RDataFrame module requires at least Python version 3.8.
 
 ### Connecting to a Spark cluster
 


### PR DESCRIPTION
`**note**` -> `\note`, and that PyROOT and RDataFrame are required for distRDF is kind of obvious and anyways they are included in virtually any ROOT installation.