### PR TITLE
[RF][PyROOT] Refactor: move RooWorkspace variable creation logic to C++ backend

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooworkspace.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooworkspace.py
@@ -12,50 +12,6 @@
 from ._utils import _kwargs_to_roocmdargs, cpp_signature
 
 
-def make_json_for_variable(var_name, var_dict):
-    val = None
-    max_value = None
-    min_value = None
-    is_constant = None
-    if "value" in var_dict:
-        val = var_dict["value"]
-        is_constant = True
-    if ("max" in var_dict) and ("min" in var_dict):
-        max_value = var_dict["max"]
-        min_value = var_dict["min"]
-        is_constant = False
-    if is_constant is None:
-        raise ValueError(
-            "Invalid Syntax: Please provide either 'value' or 'min' and 'max' or both"
-        )
-    else:
-        if not is_constant:
-            val = (max_value + min_value) / 2
-        # Create dictionary with domains and parameter points
-        json_dict = {
-            "domains": [
-                {
-                    "axes": [{"name": var_name}],
-                    "name": "default_domain",
-                    "type": "product_domain",
-                }
-            ],
-            "parameter_points": [
-                {
-                    "name": "default_values",
-                    "parameters": [{"name": var_name, "value": val}],
-                }
-            ],
-        }
-        if is_constant:
-            json_dict["parameter_points"][0]["parameters"][0]["const"] = True
-            json_dict["misc"] = {"ROOT_internal": {var_name: {"tags": "Constant"}}}
-        if not is_constant:
-            json_dict["domains"][0]["axes"][0]["max"] = max_value
-            json_dict["domains"][0]["axes"][0]["min"] = min_value
-        return json_dict
-
-
 class RooWorkspace(object):
     r"""The RooWorkspace::import function can't be used in PyROOT because `import` is a reserved python keyword.
     For this reason, an alternative with a capitalized name is provided:
@@ -98,12 +54,7 @@ class RooWorkspace(object):
                     self.factory(expr)
                 # Initializes functions and p.d.f.s
                 elif value[parenthesis_index] == "(" and parenthesis_index != -1:
-                    expr = (
-                        value[0:parenthesis_index]
-                        + "::"
-                        + key
-                        + value[parenthesis_index:]
-                    )
+                    expr = value[0:parenthesis_index] + "::" + key + value[parenthesis_index:]
                     self.factory(expr)
                 # Else raises a Syntax error
                 else:
@@ -118,24 +69,10 @@ class RooWorkspace(object):
             import ROOT
             import json
 
-            # Add name attribute to the dictionary, and create the JSON string for the object's JSONTree
-            is_variable = not "type" in value
-            if is_variable:
-                # Import variable
-                json_dict = make_json_for_variable(key, value)
-                json_string = json.dumps(json_dict, separators=(",", ":"))
-                ROOT.RooJSONFactoryWSTool(self).importVarfromString(json_string)
-            else:
-                # Imports functions/p.d.f.s
-                value["name"] = key
-                json_string = json.dumps(value, separators=(",", ":"))
-                ROOT.RooJSONFactoryWSTool(self).importFunction(json_string, False)
+            json_string = json.dumps(value, separators=(",", ":"))
+            ROOT.RooJSONFactoryWSTool(self).importJSONElement(key, json_string)
         else:
-            raise TypeError(
-                "Object of type 'str' or 'dict' expected but "
-                + type(value)
-                + " was given"
-            )
+            raise TypeError("Object of type 'str' or 'dict' expected but " + type(value) + " was given")
 
     @cpp_signature(
         [
@@ -168,11 +105,7 @@ class RooWorkspace(object):
         # here, which results in a clearer error to the user than an infinite
         # call stack involving the internal pythonization code.
         if name in ["_import", "import", "Import"]:
-            raise AttributeError(
-                'Resetting the "'
-                + name
-                + '" attribute of a RooWorkspace is not allowed!'
-            )
+            raise AttributeError('Resetting the "' + name + '" attribute of a RooWorkspace is not allowed!')
         object.__setattr__(self, name, value)
 
 

--- a/bindings/pyroot/pythonizations/test/roofit/rooworkspace.py
+++ b/bindings/pyroot/pythonizations/test/roofit/rooworkspace.py
@@ -64,7 +64,7 @@ class RooWorkspace_test(unittest.TestCase):
         ws["m2"] = dict({"max": 5, "min": -5, "value": 1})
         ws["mean"] = dict({"type": "sum", "summands": ["m1", "m2"]})
         self.assertEqual(ws["mean"].GetName(), "mean")
-        self.assertEqual(ws["mean"].getVal(), 0.0)
+        self.assertEqual(ws["mean"].getVal(), 1.0)
 
         # Test to check if new p.d.f.s are created
         ws["sigma"] = dict({"value": 2, "min": 0.1, "max": 10.0})

--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -141,7 +141,8 @@ public:
    std::string exportYMLtoString();
    bool importJSONfromString(const std::string &s);
    bool importYMLfromString(const std::string &s);
-   void importVarfromString(const std::string &jsonString);
+   void importJSONElement(const std::string &name, const std::string &jsonString);
+   void importVariableElement(const RooFit::Detail::JSONNode &n);
 
    void importFunction(const RooFit::Detail::JSONNode &n, bool importAllDependants);
    void importFunction(const std::string &jsonString, bool importAllDependants);

--- a/roofit/hs3/src/JSONIOUtils.cxx
+++ b/roofit/hs3/src/JSONIOUtils.cxx
@@ -1,5 +1,8 @@
 #include "JSONIOUtils.h"
 
+using RooFit::Detail::JSONNode;
+using RooFit::Detail::JSONTree;
+
 bool startsWith(std::string_view str, std::string_view prefix)
 {
    return str.size() >= prefix.size() && 0 == str.compare(0, prefix.size(), prefix);
@@ -8,4 +11,64 @@ bool startsWith(std::string_view str, std::string_view prefix)
 bool endsWith(std::string_view str, std::string_view suffix)
 {
    return str.size() >= suffix.size() && 0 == str.compare(str.size() - suffix.size(), suffix.size(), suffix);
+}
+
+std::unique_ptr<RooFit::Detail::JSONTree> varJSONString(const JSONNode &treeRoot)
+{
+   std::string varName = treeRoot.find("name")->val();
+   double val = 0;
+   double maxVal = 0;
+   double minVal = 0;
+   bool isConstant = false;
+   bool isRange = false;
+
+   if (auto n = treeRoot.find("value")) {
+      val = n->val_double();
+      isConstant = true;
+   }
+
+   auto maxNode = treeRoot.find("max");
+   auto minNode = treeRoot.find("min");
+   if (maxNode && minNode) {
+      maxVal = maxNode->val_double();
+      minVal = minNode->val_double();
+      isRange = true;
+   }
+   if (!isConstant) {
+      val = (maxVal + minVal) / 2;
+   }
+   // Check if variable is at least a range or constant else throw error
+   if (!isConstant && !isRange) {
+      throw std::invalid_argument("Invalid Syntax: Please provide either 'value' or 'min' and 'max' or both");
+   }
+
+   std::unique_ptr<RooFit::Detail::JSONTree> jsonDict = RooFit::Detail::JSONTree::create();
+   JSONNode &n = jsonDict->rootnode().set_map();
+   JSONNode &_domains = n["domains"].set_seq().append_child().set_map();
+   JSONNode &_parameterPoints = n["parameter_points"].set_seq().append_child().set_map();
+
+   _domains["name"] << "default_domain";
+   _domains["type"] << "product_domain";
+   JSONNode &_axes = _domains["axes"].set_seq().append_child().set_map();
+   _axes["name"] << varName;
+
+   _parameterPoints["name"] << "default_values";
+   JSONNode &_parameters = _parameterPoints["parameters"].set_seq().append_child().set_map();
+   _parameters["name"] << varName;
+   _parameters["value"] << val;
+
+   if (isRange) {
+      _axes["max"] << maxVal;
+      _axes["min"] << minVal;
+   }
+
+   if (isConstant && !isRange) {
+      _parameters["const"] << true;
+      JSONNode &_misc = n["misc"].set_map();
+      JSONNode &rootInternal = _misc["ROOT_internal"].set_map();
+      JSONNode &_var = rootInternal[varName].set_map();
+      _var["tags"] << "Constant";
+   }
+
+   return jsonDict;
 }

--- a/roofit/hs3/src/JSONIOUtils.h
+++ b/roofit/hs3/src/JSONIOUtils.h
@@ -2,8 +2,10 @@
 #define JSONIOUtils_h
 
 #include <ROOT/RStringView.hxx>
+#include <RooFit/Detail/JSONInterface.h>
 
 bool startsWith(std::string_view str, std::string_view prefix);
 bool endsWith(std::string_view str, std::string_view suffix);
+std::unique_ptr<RooFit::Detail::JSONTree> varJSONString(const RooFit::Detail::JSONNode &treeRoot);
 
 #endif

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -1654,11 +1654,28 @@ bool RooJSONFactoryWSTool::importYML(std::string const &filename)
    return this->importYML(infile);
 }
 
-void RooJSONFactoryWSTool::importVarfromString(const std::string &jsonString)
+void RooJSONFactoryWSTool::importJSONElement(const std::string &name, const std::string &jsonString)
 {
-   std::unique_ptr<JSONTree> tree = JSONTree::create(jsonString);
-   const JSONNode &n = tree->rootnode();
+   std::unique_ptr<RooFit::Detail::JSONTree> tree = RooFit::Detail::JSONTree::create(jsonString);
+   JSONNode &n = tree->rootnode();
+   n["name"] << name;
 
+   bool isVariable = true;
+   if (n.find("type")) {
+      isVariable = false;
+   }
+
+   if (isVariable) {
+      this->importVariableElement(n);
+   } else {
+      this->importFunction(n, false);
+   }
+}
+
+void RooJSONFactoryWSTool::importVariableElement(const JSONNode &elementNode)
+{
+   std::unique_ptr<RooFit::Detail::JSONTree> tree = varJSONString(elementNode);
+   JSONNode &n = tree->rootnode();
    _domains = std::make_unique<RooFit::JSONIO::Detail::Domains>();
    if (auto domains = n.find("domains"))
       _domains->readJSON(*domains);


### PR DESCRIPTION
# This Pull request:

Refactors the code and moves the logic of creating variables in RooWorkspace to C++-backend

## Changes:

Moves `make_json_for_variable` from `_rooworkspace.py` to `varJSONString` in `JSONIOUtils`

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
