### PR TITLE
[ci] Use unique name in publish test result to deconfuse GH Actions:

### DIFF
--- a/.github/workflows/test-result-comment.yml
+++ b/.github/workflows/test-result-comment.yml
@@ -1,5 +1,5 @@
 
-name: Test Summary PR comment
+name: Test Summary as PR comment
 
 on:
   workflow_run:
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
   comment-test-results:
-    name: Publish Test Results
+    name: Download and Publish Test Results
 
     if: github.event.workflow_run.event == 'pull_request'
 


### PR DESCRIPTION
GH currently puts this under seemingly arbitrary jobs, such as the unrelated SonarCloud.

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

