### PR TITLE
[RF] Automatic JSON I/O key management

### DIFF
--- a/bindings/pyroot/pythonizations/test/roofit/rooworkspace.py
+++ b/bindings/pyroot/pythonizations/test/roofit/rooworkspace.py
@@ -40,10 +40,10 @@ class RooWorkspace_test(unittest.TestCase):
         self.assertEqual(x.getVal(), self.x.getVal())
 
     def test_set_item_using_string(self):
-         # Test to check if new variables are created
+        # Test to check if new variables are created
         self.ws["z"] = "[3]"
-        self.assertEqual(self.ws["z"].GetName(),"z")
-        self.assertEqual(self.ws["z"].getVal(),3.0)
+        self.assertEqual(self.ws["z"].GetName(), "z")
+        self.assertEqual(self.ws["z"].getVal(), 3.0)
 
         # Test to check if new p.d.f.s are created
         self.ws["gauss"] = "Gaussian(x[0.0, 10.0], mu[5.0], sigma[2.0, 0.01, 10.0])"
@@ -52,31 +52,27 @@ class RooWorkspace_test(unittest.TestCase):
         self.assertEqual(self.ws["gauss"].getSigma(), self.ws["sigma"])
 
     def test_set_item_using_dictionary(self):
-        
-        # Import Factory Expressions to new workspace
-        etc_dir = ROOT.std.string(ROOT.TROOT.GetEtcDir().Data())
-        ROOT.RooFit.JSONIO.loadExportKeys(etc_dir + "/RooFitHS3_wsexportkeys.json")
-        ROOT.RooFit.JSONIO.loadFactoryExpressions(etc_dir + "/RooFitHS3_wsfactoryexpressions.json")
-        ws= ROOT.RooWorkspace()
-        
+        ws = ROOT.RooWorkspace()
+
         # Test to check if new variables are created
-        ws["x"] = dict({ "min": 0.0, "max": 10.0 })
+        ws["x"] = dict({"min": 0.0, "max": 10.0})
         self.assertEqual(ws["x"].getMax(), 10.0)
         self.assertEqual(ws["x"].getMin(), 0.0)
-        
+
         # Test to check if new functions are created
-        ws["m1"] = dict({ "max": 5, "min": -5, "value": 0 })
-        ws["m2"] = dict({ "max": 5, "min": -5, "value": 1 })
-        ws["mean"] = dict({ "type": "sum", "summands": ["m1", "m2"] })
+        ws["m1"] = dict({"max": 5, "min": -5, "value": 0})
+        ws["m2"] = dict({"max": 5, "min": -5, "value": 1})
+        ws["mean"] = dict({"type": "sum", "summands": ["m1", "m2"]})
         self.assertEqual(ws["mean"].GetName(), "mean")
         self.assertEqual(ws["mean"].getVal(), 0.0)
 
         # Test to check if new p.d.f.s are created
-        ws["sigma"] = dict({ "value": 2, "min": 0.1, "max": 10.0 })
-        ws["gauss"] = dict({ "mean": "mean", "sigma": "sigma", "type": "gaussian_dist", "x": "x" })
+        ws["sigma"] = dict({"value": 2, "min": 0.1, "max": 10.0})
+        ws["gauss"] = dict({"mean": "mean", "sigma": "sigma", "type": "gaussian_dist", "x": "x"})
         self.assertEqual(ws["gauss"].getX(), ws["x"])
         self.assertEqual(ws["gauss"].getMean(), ws["mean"])
         self.assertEqual(ws["gauss"].getSigma(), ws["sigma"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/roofit/histfactory/test/testHistFactory.cxx
+++ b/roofit/histfactory/test/testHistFactory.cxx
@@ -39,19 +39,6 @@ namespace {
 // If the JSON files should be written out for debugging purpose.
 const bool writeJsonFiles = false;
 
-void setupKeys()
-{
-   static bool isAlreadySetup = false;
-   if (isAlreadySetup)
-      return;
-
-   auto etcDir = std::string(TROOT::GetEtcDir());
-   RooFit::JSONIO::loadExportKeys(etcDir + "/RooFitHS3_wsexportkeys.json");
-   RooFit::JSONIO::loadFactoryExpressions(etcDir + "/RooFitHS3_wsfactoryexpressions.json");
-
-   isAlreadySetup = true;
-}
-
 } // namespace
 
 using namespace RooStats;
@@ -531,8 +518,6 @@ TEST_P(HFFixture, HistFactoryJSONTool)
 {
    RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
 
-   setupKeys();
-
    if (writeJsonFiles) {
       RooStats::HistFactory::JSONTool{*_measurement}.PrintJSON(_name + "_1.json");
    }
@@ -588,8 +573,6 @@ TEST_P(HFFixture, HistFactoryJSONTool)
 TEST_P(HFFixture, HS3ClosureLoop)
 {
    RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
-
-   setupKeys();
 
    auto *mc = dynamic_cast<RooStats::ModelConfig *>(ws->obj("ModelConfig"));
    EXPECT_TRUE(mc != nullptr);

--- a/roofit/hs3/inc/RooFitHS3/JSONIO.h
+++ b/roofit/hs3/inc/RooFitHS3/JSONIO.h
@@ -61,6 +61,7 @@ using ExportMap = std::map<TClass const *, std::vector<std::unique_ptr<const Exp
 using ExportKeysMap = std::map<TClass const *, ExportKeys>;
 using ImportExpressionMap = std::map<const std::string, ImportExpression>;
 
+void setupKeys();
 ImportMap &importers();
 ExportMap &exporters();
 ImportExpressionMap &pdfImportExpressions();

--- a/roofit/hs3/src/JSONIO.cxx
+++ b/roofit/hs3/src/JSONIO.cxx
@@ -17,12 +17,27 @@
 #include <RooAbsPdf.h>
 
 #include <TClass.h>
+#include <TROOT.h>
 
 #include <iostream>
 #include <fstream>
 
 namespace RooFit {
 namespace JSONIO {
+
+void setupKeys()
+{
+   static bool isAlreadySetup = false;
+   if (isAlreadySetup) {
+      return;
+   }
+
+   isAlreadySetup = true;
+
+   auto etcDir = std::string(TROOT::GetEtcDir());
+   loadExportKeys(etcDir + "/RooFitHS3_wsexportkeys.json");
+   loadFactoryExpressions(etcDir + "/RooFitHS3_wsfactoryexpressions.json");
+}
 
 ImportMap &importers()
 {
@@ -38,18 +53,21 @@ ExportMap &exporters()
 
 ImportExpressionMap &pdfImportExpressions()
 {
+   setupKeys();
    static ImportExpressionMap _pdfFactoryExpressions;
    return _pdfFactoryExpressions;
 }
 
 ImportExpressionMap &functionImportExpressions()
 {
+   setupKeys();
    static ImportExpressionMap _funcFactoryExpressions;
    return _funcFactoryExpressions;
 }
 
 ExportKeysMap &exportKeys()
 {
+   setupKeys();
    static ExportKeysMap _exportKeys;
    return _exportKeys;
 }

--- a/roofit/hs3/test/testHS3SimultaneousFit.cxx
+++ b/roofit/hs3/test/testHS3SimultaneousFit.cxx
@@ -23,19 +23,6 @@
 
 namespace {
 
-void setupKeys()
-{
-   static bool isAlreadySetup = false;
-   if (isAlreadySetup)
-      return;
-
-   auto etcDir = std::string(TROOT::GetEtcDir());
-   RooFit::JSONIO::loadExportKeys(etcDir + "/RooFitHS3_wsexportkeys.json");
-   RooFit::JSONIO::loadFactoryExpressions(etcDir + "/RooFitHS3_wsfactoryexpressions.json");
-
-   isAlreadySetup = true;
-}
-
 std::unique_ptr<RooFitResult> writeJSONAndFitModel(std::string &jsonStr)
 {
    using namespace RooFit;
@@ -117,8 +104,6 @@ std::unique_ptr<RooFitResult> readJSONAndFitModel(std::string const &jsonStr)
 TEST(RooFitHS3, SimultaneousFit)
 {
    RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
-
-   setupKeys();
 
    using namespace RooFit;
 

--- a/roofit/hs3/test/testRooFitHS3.cxx
+++ b/roofit/hs3/test/testRooFitHS3.cxx
@@ -26,22 +26,6 @@
 
 namespace {
 
-void setupKeys()
-{
-   // Uncomment this line to test the rapidyaml backend
-   // RooFit::Detail::JSONTree::setBackend("rapidyaml");
-
-   static bool isAlreadySetup = false;
-   if (isAlreadySetup)
-      return;
-
-   auto etcDir = std::string(TROOT::GetEtcDir());
-   RooFit::JSONIO::loadExportKeys(etcDir + "/RooFitHS3_wsexportkeys.json");
-   RooFit::JSONIO::loadFactoryExpressions(etcDir + "/RooFitHS3_wsfactoryexpressions.json");
-
-   isAlreadySetup = true;
-}
-
 // Validate the JSON IO for a given RooAbsReal in a RooWorkspace. The workspace
 // will be written out and read back, and then the values of the old and new
 // RooAbsReal will be compared for equality in each bin of the observable that
@@ -95,7 +79,6 @@ int validate(RooAbsArg const &arg)
 // Test that the IO of attributes and string attributes works.
 TEST(RooFitHS3, AttributesIO)
 {
-   setupKeys();
 
    std::string jsonString;
 


### PR DESCRIPTION
# This Pull request:

Loads factory expressions  and export keys in RooFit automatically to avoid unnecessary imports

## Changes:

It's not required to call `loadExportKeys` and `loadFactoryExpressions` every time to load default JSON I/O keys.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
