### PR TITLE
Support multiple connections in `RFileDialog`

### DIFF
--- a/graf3d/eve7/CMakeLists.txt
+++ b/graf3d/eve7/CMakeLists.txt
@@ -132,7 +132,6 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTEve
     TreePlayer
     RCsg
     ROOTWebDisplay
-    ROOTBrowserv7
   ${EXTRA_DICT_OPTS}
 )
 

--- a/graf3d/eve7/src/REveManager.cxx
+++ b/graf3d/eve7/src/REveManager.cxx
@@ -18,7 +18,6 @@
 #include <ROOT/REveSceneInfo.hxx>
 #include <ROOT/REveClient.hxx>
 #include <ROOT/RWebWindow.hxx>
-#include <ROOT/RFileDialog.hxx>
 #include <ROOT/RLogger.hxx>
 #include <ROOT/REveSystem.hxx>
 
@@ -849,10 +848,10 @@ void REveManager::WindowData(unsigned connid, const std::string &arg)
 
       return;
    }
-   else if (arg.compare( 0, 10, "FILEDIALOG") == 0)
+   else if (RWebWindow::IsFileDialogMessage(arg))
    {
       // file dialog
-       RFileDialog::Embedded(fWebWindow, arg);
+      RWebWindow::EmbedFileDialog(fWebWindow, connid, arg);
        return;
    }
 
@@ -986,7 +985,7 @@ void REveManager::SendSceneChanges()
       std::stringstream strm;
       for (auto entry : gEveLogEntries) {
          nlohmann::json item = {};
-         item["lvl"] = entry.fLevel; 
+         item["lvl"] = entry.fLevel;
          int cappedLevel = std::min(static_cast<int>(entry.fLevel), numLevels - 1);
          strm <<  "Server " << sTag[cappedLevel] << ":";
 

--- a/gui/browserv7/inc/ROOT/RFileDialog.hxx
+++ b/gui/browserv7/inc/ROOT/RFileDialog.hxx
@@ -116,7 +116,7 @@ public:
    static std::string SaveAs(const std::string &title = "", const std::string &fname = "");
    static std::string NewFile(const std::string &title = "", const std::string &fname = "");
 
-   static std::shared_ptr<RFileDialog> Embedded(const std::shared_ptr<RWebWindow> &window, const std::string &args);
+   static std::shared_ptr<RFileDialog> Embed(const std::shared_ptr<RWebWindow> &window, unsigned connid, const std::string &args);
 
    static bool IsMessageToStartDialog(const std::string &msg);
 

--- a/gui/browserv7/src/RBrowser.cxx
+++ b/gui/browserv7/src/RBrowser.cxx
@@ -796,8 +796,10 @@ void RBrowser::ProcessMsg(unsigned connid, const std::string &arg0)
       auto logs = GetRootLogs();
       fWebWindow->Send(connid, "LOGS:"s + TBufferJSON::ToJSON(&logs, TBufferJSON::kNoSpaces).Data());
 
-   } else if (kind == "FILEDIALOG") {
-      RFileDialog::Embedded(fWebWindow, arg0);
+   } else if (RFileDialog::IsMessageToStartDialog(arg0)) {
+
+      RFileDialog::Embed(fWebWindow, connid, arg0);
+
    } else if (kind == "SYNCEDITOR") {
       auto arr = TBufferJSON::FromJSON<std::vector<std::string>>(msg);
       if (arr && (arr->size() > 4)) {

--- a/gui/browserv7/src/RFileDialog.cxx
+++ b/gui/browserv7/src/RFileDialog.cxx
@@ -430,11 +430,11 @@ bool RFileDialog::IsMessageToStartDialog(const std::string &msg)
 /// Create dialog instance to use as embedded dialog inside other widget
 /// Embedded dialog started on the client side where FileDialogController.SaveAs() method called
 /// Such method immediately send message with "FILEDIALOG:" prefix
-/// On the server side widget should detect such message and call RFileDialog::Embedded()
+/// On the server side widget should detect such message and call RFileDialog::Embed()
 /// providing received string as second argument.
 /// Returned instance of shared_ptr<RFileDialog> may be used to assign callback when file is selected
 
-std::shared_ptr<RFileDialog> RFileDialog::Embedded(const std::shared_ptr<RWebWindow> &window, const std::string &args)
+std::shared_ptr<RFileDialog> RFileDialog::Embed(const std::shared_ptr<RWebWindow> &window, unsigned connid, const std::string &args)
 {
    if (!IsMessageToStartDialog(args))
       return nullptr;
@@ -476,7 +476,7 @@ std::shared_ptr<RFileDialog> RFileDialog::Embedded(const std::shared_ptr<RWebWin
       dialog->SetNameFilters(*arr);
    }
 
-   dialog->Show({window, 0, chid});
+   dialog->Show({window, connid, chid});
 
    // use callback to release pointer, actually not needed but just to avoid compiler warning
    dialog->SetCallback([dialog](const std::string &) mutable { dialog.reset(); });
@@ -490,8 +490,8 @@ std::shared_ptr<RFileDialog> RFileDialog::Embedded(const std::shared_ptr<RWebWin
 void RFileDialog::SetStartFunc(bool on)
 {
    if (on)
-      RWebWindow::SetStartDialogFunc([](const std::shared_ptr<RWebWindow> &window, const std::string &args) -> bool {
-         auto res = RFileDialog::Embedded(window, args);
+      RWebWindow::SetStartDialogFunc([](const std::shared_ptr<RWebWindow> &window, unsigned connid, const std::string &args) -> bool {
+         auto res = RFileDialog::Embed(window, connid, args);
          return res ? true : false;
       });
    else

--- a/gui/canvaspainter/src/RCanvasPainter.cxx
+++ b/gui/canvaspainter/src/RCanvasPainter.cxx
@@ -554,7 +554,7 @@ void RCanvasPainter::ProcessData(unsigned connid, const std::string &arg)
       delete f;
    } else if (RWebWindow::IsFileDialogMessage(arg)) {
 
-      RWebWindow::EmbedFileDialog(fWindow, arg);
+      RWebWindow::EmbedFileDialog(fWindow, connid, arg);
 
    } else if (check_header("REQ:")) {
       auto req = TBufferJSON::FromJSON<RDrawableRequest>(cdata);

--- a/gui/webdisplay/inc/ROOT/RWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindow.hxx
@@ -228,7 +228,9 @@ private:
 
    void CheckThreadAssign();
 
-   static void SetStartDialogFunc(std::function<bool(const std::shared_ptr<RWebWindow> &, const std::string &)>);
+   static std::function<bool(const std::shared_ptr<RWebWindow> &, unsigned, const std::string &)> gStartDialogFunc;
+
+   static void SetStartDialogFunc(std::function<bool(const std::shared_ptr<RWebWindow> &, unsigned, const std::string &)>);
 
 public:
 
@@ -394,7 +396,7 @@ public:
 
    static bool IsFileDialogMessage(const std::string &msg);
 
-   static bool EmbedFileDialog(const std::shared_ptr<RWebWindow> &window, const std::string &args);
+   static bool EmbedFileDialog(const std::shared_ptr<RWebWindow> &window, unsigned connid, const std::string &args);
 };
 
 } // namespace Experimental

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -1772,13 +1772,13 @@ unsigned RWebWindow::ShowWindow(std::shared_ptr<RWebWindow> window, const RWebDi
    return window->Show(args);
 }
 
-std::function<bool(const std::shared_ptr<RWebWindow> &, const std::string &)> gStartDialogFunc = nullptr;
+std::function<bool(const std::shared_ptr<RWebWindow> &, unsigned, const std::string &)> RWebWindow::gStartDialogFunc = nullptr;
 
 /////////////////////////////////////////////////////////////////////////////////////
 /// Configure func which has to be used for starting dialog
 
 
-void RWebWindow::SetStartDialogFunc(std::function<bool(const std::shared_ptr<RWebWindow> &, const std::string &)> func)
+void RWebWindow::SetStartDialogFunc(std::function<bool(const std::shared_ptr<RWebWindow> &, unsigned, const std::string &)> func)
 {
    gStartDialogFunc = func;
 }
@@ -1802,7 +1802,7 @@ bool RWebWindow::IsFileDialogMessage(const std::string &msg)
 /// providing received string as second argument.
 /// Returned instance of shared_ptr<RFileDialog> may be used to assign callback when file is selected
 
-bool RWebWindow::EmbedFileDialog(const std::shared_ptr<RWebWindow> &window, const std::string &args)
+bool RWebWindow::EmbedFileDialog(const std::shared_ptr<RWebWindow> &window, unsigned connid, const std::string &args)
 {
    if (!gStartDialogFunc)
       gSystem->Load("libROOTBrowserv7");
@@ -1810,5 +1810,5 @@ bool RWebWindow::EmbedFileDialog(const std::shared_ptr<RWebWindow> &window, cons
    if (!gStartDialogFunc)
       return false;
 
-   return gStartDialogFunc(window, args);
+   return gStartDialogFunc(window, connid, args);
 }

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -1361,7 +1361,7 @@ Bool_t TWebCanvas::ProcessData(unsigned connid, const std::string &arg)
       }
    } else if (ROOT::Experimental::RWebWindow::IsFileDialogMessage(arg)) {
 
-      ROOT::Experimental::RWebWindow::EmbedFileDialog(fWindow, arg);
+      ROOT::Experimental::RWebWindow::EmbedFileDialog(fWindow, connid, arg);
 
    } else if (IsReadOnly()) {
 


### PR DESCRIPTION
One have to provide connection id when accepting file dialog request from client.
This allows to use file dialogs for window with multiple connections at the same time.

In eve7 use `RWebWindow` methods to avoid direct dependency from `RBrowser`

`RFileDialog` also used in `RBrowser`, `RCanvas`, `TWebCanvas`