### PR TITLE
[doc] Fix PyROOT boxes background color in dark mode

### DIFF
--- a/documentation/doxygen/ROOT.css
+++ b/documentation/doxygen/ROOT.css
@@ -20,7 +20,7 @@ div.contents {
 
 .pyrootbox {
   border: 1px solid #879ecb;
-  background-color: #f9fafc;
+  background-color: var(--blockquote-background-color);
   padding: 15px;
 }
 


### PR DESCRIPTION
Before vs after this change:

![image](https://github.com/root-project/root/assets/10999034/36ec5f66-392e-4fdc-a6c8-219b3fd338be)

![image](https://github.com/root-project/root/assets/10999034/6968f5d8-4ed5-489e-9f84-c16333bfc8d3)

Related forum post:  https://root-forum.cern.ch/t/root-reference-webpage-theme-option/55524