### PR TITLE
Move globbing logic out of TChain::Add

### DIFF
--- a/tree/tree/inc/ROOT/InternalTreeUtils.hxx
+++ b/tree/tree/inc/ROOT/InternalTreeUtils.hxx
@@ -78,6 +78,8 @@ public:
 std::unique_ptr<TChain> MakeChainForMT(const std::string &name = "", const std::string &title = "");
 std::vector<std::unique_ptr<TChain>> MakeFriends(const ROOT::TreeUtils::RFriendInfo &finfo);
 
+std::vector<std::string> ExpandGlob(const std::string &glob);
+
 } // namespace TreeUtils
 } // namespace Internal
 } // namespace ROOT


### PR DESCRIPTION
First attempt at moving the globbing logic in `TChain::Add` out of the method. The main remaining question is where will this new free function actually live. It depends on `TRegexp`, `TString` and `TSystem`, so I guess  somewhere in `core/base`. Any ideas here?

I removed usage of `TList` in the function, with C++17 support I could use `std::filesystem` instead of `gSystem` which could be another small improvement in the logic.