### PR TITLE
[DF] Move TriggerRun to more appropriate header and fix signature

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -762,8 +762,6 @@ struct IsDeque_t<std::deque<T>> : std::true_type {};
 
 void CheckForDuplicateSnapshotColumns(const ColumnNames_t &cols);
 
-void TriggerRun(ROOT::RDF::RNode &node);
-
 template <typename T>
 struct InnerValueType {
    using type = T; // fallback for when T is not a nested RVec

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -88,6 +88,7 @@ namespace RDF {
 class GraphCreatorHelper;
 void ChangeEmptyEntryRange(const ROOT::RDF::RNode &node, std::pair<ULong64_t, ULong64_t> &&newRange);
 void ChangeSpec(const ROOT::RDF::RNode &node, ROOT::RDF::Experimental::RDatasetSpec &&spec);
+void TriggerRun(ROOT::RDF::RNode node);
 } // namespace RDF
 } // namespace Internal
 
@@ -117,7 +118,7 @@ class RInterface : public RInterfaceBase {
    template <typename T, typename W>
    friend class RInterface;
 
-   friend void RDFInternal::TriggerRun(RNode &node);
+   friend void RDFInternal::TriggerRun(RNode node);
    friend void RDFInternal::ChangeEmptyEntryRange(const RNode &node, std::pair<ULong64_t, ULong64_t> &&newRange);
    friend void RDFInternal::ChangeSpec(const RNode &node, ROOT::RDF::Experimental::RDatasetSpec &&spec);
 

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -966,16 +966,6 @@ void CheckForDuplicateSnapshotColumns(const ColumnNames_t &cols)
    }
 }
 
-////////////////////////////////////////////////////////////////////////////////
-/// \brief Trigger the execution of an RDataFrame computation graph.
-/// \param[in] node A node of the computation graph (not a result).
-///
-/// This function calls the RLoopManager::Run method on the \p fLoopManager data
-/// member of the input argument. It is intended for internal use only.
-void TriggerRun(ROOT::RDF::RNode &node){
-   node.fLoopManager->Run();
-}
-
 /// Return copies of colsWithoutAliases and colsWithAliases with size branches for variable-sized array branches added
 /// in the right positions (i.e. before the array branches that need them).
 std::pair<std::vector<std::string>, std::vector<std::string>>

--- a/tree/dataframe/src/RInterface.cxx
+++ b/tree/dataframe/src/RInterface.cxx
@@ -27,3 +27,15 @@ void ROOT::Internal::RDF::ChangeSpec(const ROOT::RDF::RNode &node, ROOT::RDF::Ex
 {
    node.GetLoopManager()->ChangeSpec(std::move(spec));
 }
+
+/**
+ * \brief Trigger the execution of an RDataFrame computation graph.
+ * \param[in] node A node of the computation graph (not a result).
+ *
+ * This function calls the RLoopManager::Run method on the \p fLoopManager data
+ * member of the input argument. It is intended for internal use only.
+ */
+void ROOT::Internal::RDF::TriggerRun(ROOT::RDF::RNode node)
+{
+   node.fLoopManager->Run();
+}


### PR DESCRIPTION
I took the chance to also move the function to a better header, since we discussed that `InterfaceUtils` is for stuff which `RInterface` depends from and not the other way around.