### PR TITLE
[DF] Return the number of graphs actually processed from RunGraphs

### DIFF
--- a/bindings/experimental/distrdf/python/DistRDF/__init__.py
+++ b/bindings/experimental/distrdf/python/DistRDF/__init__.py
@@ -17,7 +17,7 @@ import types
 
 import concurrent.futures
 
-from typing import TYPE_CHECKING
+from typing import Iterable, TYPE_CHECKING
 
 from DistRDF.Backends import build_backends_submodules
 
@@ -71,7 +71,7 @@ def create_logger(level="WARNING", log_path="./DistRDF.log"):
     return logger
 
 
-def RunGraphs(proxies):
+def RunGraphs(proxies: Iterable) -> int:
     """
     Trigger the execution of multiple RDataFrame computation graphs on a certain
     distributed backend. If the backend doesn't support multiple job
@@ -82,6 +82,10 @@ def RunGraphs(proxies):
         proxies(list): List of action proxies that should be triggered. Only
             actions belonging to different RDataFrame graphs will be
             triggered to avoid useless calls.
+
+    Return:
+        (int): The number of unique computation graphs executed by this call.
+
 
     Example:
 
@@ -99,7 +103,7 @@ def RunGraphs(proxies):
         ]
 
         # Execute the 3 computation graphs
-        RunGraphs(histoproxies)
+        n_graphs_run = RunGraphs(histoproxies)
         # Retrieve all the histograms in one go
         histos = [histoproxy.GetValue() for histoproxy in histoproxies]
         @endcode
@@ -120,6 +124,8 @@ def RunGraphs(proxies):
     with concurrent.futures.ThreadPoolExecutor(max_workers=len(uniqueproxies)) as executor:
         futures = [executor.submit(execute_graph, proxy.proxied_node) for proxy in uniqueproxies]
         concurrent.futures.wait(futures)
+
+    return len(uniqueproxies)
 
 
 def VariationsFor(actionproxy: ActionProxy) -> VariationsProxy:

--- a/tree/dataframe/inc/ROOT/RDFHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDFHelpers.hxx
@@ -159,6 +159,7 @@ RNode AsRNode(NodeType node)
 // clang-format off
 /// Trigger the event loop of multiple RDataFrames concurrently
 /// \param[in] handles A vector of RResultHandles
+/// \return The number of distinct computation graphs that have been processed
 ///
 /// This function triggers the event loop of all computation graphs which relate to the
 /// given RResultHandles. The advantage compared to running the event loop implicitly by accessing the
@@ -177,7 +178,7 @@ RNode AsRNode(NodeType node)
 /// ROOT::RDF::RunGraphs({r1, r2});
 /// ~~~
 // clang-format on
-void RunGraphs(std::vector<RResultHandle> handles);
+unsigned int RunGraphs(std::vector<RResultHandle> handles);
 
 namespace Experimental {
 

--- a/tree/dataframe/inc/ROOT/RResultHandle.hxx
+++ b/tree/dataframe/inc/ROOT/RResultHandle.hxx
@@ -33,7 +33,7 @@ class RResultHandle {
    const std::type_info *fType = nullptr; ///< Type of the wrapped result
 
    // The ROOT::RDF::RunGraphs helper has to access the loop manager to check whether two RResultHandles belong to the same computation graph
-   friend void RunGraphs(std::vector<RResultHandle>);
+   friend unsigned int RunGraphs(std::vector<RResultHandle>);
 
    /// Get the pointer to the encapsulated result.
    /// Ownership is not transferred to the caller.

--- a/tree/dataframe/src/RDFHelpers.cxx
+++ b/tree/dataframe/src/RDFHelpers.cxx
@@ -26,11 +26,11 @@
 
 using ROOT::RDF::RResultHandle;
 
-void ROOT::RDF::RunGraphs(std::vector<RResultHandle> handles)
+unsigned int ROOT::RDF::RunGraphs(std::vector<RResultHandle> handles)
 {
    if (handles.empty()) {
       Warning("RunGraphs", "Got an empty list of handles, now quitting.");
-      return;
+      return 0u;
    }
 
    // Check that there are results which have not yet been run
@@ -41,7 +41,7 @@ void ROOT::RDF::RunGraphs(std::vector<RResultHandle> handles)
               handles.size() - nToRun);
    }
    if (nToRun == 0u)
-      return;
+      return 0u;
 
    // Find the unique event loops
    auto sameGraph = [](const RResultHandle &a, const RResultHandle &b) { return a.fLoopManager < b.fLoopManager; };
@@ -91,6 +91,8 @@ void ROOT::RDF::RunGraphs(std::vector<RResultHandle> handles)
    R__LOG_INFO(ROOT::Detail::RDF::RDFLogChannel())
       << "Finished RunGraphs run (" << uniqueLoops.size() << " unique computation graphs, " << sw.CpuTime() << "s CPU, "
       << sw.RealTime() << "s elapsed).";
+
+   return uniqueLoops.size();
 }
 
 ROOT::RDF::Experimental::SnapshotPtr_t ROOT::RDF::Experimental::VariationsFor(ROOT::RDF::Experimental::SnapshotPtr_t)


### PR DESCRIPTION
This is mostly useful to assert that things worked as expected whenever RunGraphs is invoked.
