### PR TITLE
[RF] Replace `RooCmdArg()` with `{}` in default parameter lists

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabscollection.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabscollection.py
@@ -49,10 +49,10 @@ class RooAbsCollection(object):
         SetOwnership(arg, False)
 
     @cpp_signature(
-        "RooAbsCollection::printLatex(const RooCmdArg& arg1=RooCmdArg(), const RooCmdArg& arg2=RooCmdArg(),"
-        "                        const RooCmdArg& arg3=RooCmdArg(), const RooCmdArg& arg4=RooCmdArg(),"
-        "                        const RooCmdArg& arg5=RooCmdArg(), const RooCmdArg& arg6=RooCmdArg(),"
-        "                        const RooCmdArg& arg7=RooCmdArg(), const RooCmdArg& arg8=RooCmdArg()) const ;"
+        "RooAbsCollection::printLatex(const RooCmdArg& arg1={}, const RooCmdArg& arg2={},"
+        "                        const RooCmdArg& arg3={}, const RooCmdArg& arg4={},"
+        "                        const RooCmdArg& arg5={}, const RooCmdArg& arg6={},"
+        "                        const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) const ;"
     )
     def printLatex(self, *args, **kwargs):
         r"""The RooAbsCollection::printLatex() function is pythonized with the command argument pythonization.

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabsdata.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabsdata.py
@@ -30,10 +30,10 @@ class RooAbsData(object):
 
     @cpp_signature(
         "RooPlot *RooAbsData::plotOn(RooPlot* frame,"
-        "			  const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),"
-        "			  const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),"
-        "			  const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),"
-        "			  const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) const ;"
+        "			  const RooCmdArg& arg1={}, const RooCmdArg& arg2={},"
+        "			  const RooCmdArg& arg3={}, const RooCmdArg& arg4={},"
+        "			  const RooCmdArg& arg5={}, const RooCmdArg& arg6={},"
+        "			  const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) const ;"
     )
     def plotOn(self, *args, **kwargs):
         r"""The RooAbsData::plotOn() function is pythonized with the command argument pythonization.
@@ -45,10 +45,10 @@ class RooAbsData(object):
 
     @cpp_signature(
         "TH1 *RooAbsData::createHistogram(const char *name, const RooAbsRealLValue& xvar,"
-        "                       const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),"
-        "                       const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),"
-        "                       const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),"
-        "                       const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) const ;"
+        "                       const RooCmdArg& arg1={}, const RooCmdArg& arg2={},"
+        "                       const RooCmdArg& arg3={}, const RooCmdArg& arg4={},"
+        "                       const RooCmdArg& arg5={}, const RooCmdArg& arg6={},"
+        "                       const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) const ;"
     )
     def createHistogram(self, *args, **kwargs):
         r"""The RooAbsData::createHistogram() function is pythonized with the command argument pythonization.
@@ -59,10 +59,10 @@ class RooAbsData(object):
         return self._createHistogram(*args, **kwargs)
 
     @cpp_signature(
-        "RooAbsData *RooAbsData::reduce(const RooCmdArg& arg1,const RooCmdArg& arg2=RooCmdArg(),"
-        "                   const RooCmdArg& arg3=RooCmdArg(),const RooCmdArg& arg4=RooCmdArg(),"
-        "                   const RooCmdArg& arg5=RooCmdArg(),const RooCmdArg& arg6=RooCmdArg(),"
-        "                   const RooCmdArg& arg7=RooCmdArg(),const RooCmdArg& arg8=RooCmdArg()) ;"
+        "RooAbsData *RooAbsData::reduce(const RooCmdArg& arg1,const RooCmdArg& arg2={},"
+        "                   const RooCmdArg& arg3={},const RooCmdArg& arg4={},"
+        "                   const RooCmdArg& arg5={},const RooCmdArg& arg6={},"
+        "                   const RooCmdArg& arg7={},const RooCmdArg& arg8={}) ;"
     )
     def reduce(self, *args, **kwargs):
         r"""The RooAbsData::reduce() function is pythonized with the command argument pythonization.
@@ -74,10 +74,10 @@ class RooAbsData(object):
 
     @cpp_signature(
         "RooPlot *RooAbsData::statOn(RooPlot* frame,"
-        "                          const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),"
-        "                          const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),"
-        "                          const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),"
-        "                          const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;"
+        "                          const RooCmdArg& arg1={}, const RooCmdArg& arg2={},"
+        "                          const RooCmdArg& arg3={}, const RooCmdArg& arg4={},"
+        "                          const RooCmdArg& arg5={}, const RooCmdArg& arg6={},"
+        "                          const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;"
     )
     def statOn(self, *args, **kwargs):
         r"""The RooAbsData::statOn() function is pythonized with the command argument pythonization.

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabspdf.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabspdf.py
@@ -63,11 +63,11 @@ class RooAbsPdf(RooAbsReal):
 
     @cpp_signature(
         "RooPlot *RooAbsPdf::plotOn(RooPlot* frame,"
-        "    const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),"
-        "    const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),"
-        "    const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),"
-        "    const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none(),"
-        "    const RooCmdArg& arg9=RooCmdArg::none(), const RooCmdArg& arg10=RooCmdArg::none()"
+        "    const RooCmdArg& arg1={}, const RooCmdArg& arg2={},"
+        "    const RooCmdArg& arg3={}, const RooCmdArg& arg4={},"
+        "    const RooCmdArg& arg5={}, const RooCmdArg& arg6={},"
+        "    const RooCmdArg& arg7={}, const RooCmdArg& arg8={},"
+        "    const RooCmdArg& arg9={}, const RooCmdArg& arg10={}"
         ") const;"
     )
     def plotOn(self, *args, **kwargs):
@@ -80,9 +80,9 @@ class RooAbsPdf(RooAbsReal):
 
     @cpp_signature(
         "RooDataSet *RooAbsPdf::generate(const RooArgSet &whatVars,"
-        "    const RooCmdArg& arg1=RooCmdArg::none(),const RooCmdArg& arg2=RooCmdArg::none(),"
-        "    const RooCmdArg& arg3=RooCmdArg::none(),const RooCmdArg& arg4=RooCmdArg::none(),"
-        "    const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none()) ;"
+        "    const RooCmdArg& arg1={},const RooCmdArg& arg2={},"
+        "    const RooCmdArg& arg3={},const RooCmdArg& arg4={},"
+        "    const RooCmdArg& arg5={},const RooCmdArg& arg6={}) ;"
     )
     def generate(self, *args, **kwargs):
         r"""The RooAbsPdf::generate() function is pythonized with the command argument pythonization.
@@ -94,10 +94,10 @@ class RooAbsPdf(RooAbsReal):
 
     @cpp_signature(
         "RooPlot *RooAbsPdf::paramOn(RooPlot* frame,"
-        "    const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),"
-        "    const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),"
-        "    const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),"
-        "    const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;"
+        "    const RooCmdArg& arg1={}, const RooCmdArg& arg2={},"
+        "    const RooCmdArg& arg3={}, const RooCmdArg& arg4={},"
+        "    const RooCmdArg& arg5={}, const RooCmdArg& arg6={},"
+        "    const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;"
     )
     def paramOn(self, *args, **kwargs):
         r"""The RooAbsPdf::paramOn() function is pythonized with the command argument pythonization.
@@ -116,9 +116,9 @@ class RooAbsPdf(RooAbsReal):
         return self._createNLL(args[0], _pack_cmd_args(*args[1:], **kwargs))
 
     @cpp_signature(
-        "RooAbsReal *RooAbsPdf::createChi2(RooDataHist& data, const RooCmdArg& arg1=RooCmdArg::none(),  const RooCmdArg& arg2=RooCmdArg::none(),"
-        "    const RooCmdArg& arg3=RooCmdArg::none(),  const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(),"
-        "    const RooCmdArg& arg6=RooCmdArg::none(),  const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;"
+        "RooAbsReal *RooAbsPdf::createChi2(RooDataHist& data, const RooCmdArg& arg1={},  const RooCmdArg& arg2={},"
+        "    const RooCmdArg& arg3={},  const RooCmdArg& arg4={}, const RooCmdArg& arg5={},"
+        "    const RooCmdArg& arg6={},  const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;"
     )
     def createChi2(self, *args, **kwargs):
         r"""The RooAbsPdf::createChi2() function is pythonized with the command argument pythonization.
@@ -129,10 +129,10 @@ class RooAbsPdf(RooAbsReal):
         return self._createChi2(*args, **kwargs)
 
     @cpp_signature(
-        "RooAbsReal *RooAbsPdf::createCdf(const RooArgSet& iset, const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg::none(),"
-        "    const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),"
-        "    const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),"
-        "    const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;"
+        "RooAbsReal *RooAbsPdf::createCdf(const RooArgSet& iset, const RooCmdArg& arg1, const RooCmdArg& arg2={},"
+        "    const RooCmdArg& arg3={}, const RooCmdArg& arg4={},"
+        "    const RooCmdArg& arg5={}, const RooCmdArg& arg6={},"
+        "    const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;"
     )
     def createCdf(self, *args, **kwargs):
         r"""The RooAbsPdf::createCdf() function is pythonized with the command argument pythonization.
@@ -144,9 +144,9 @@ class RooAbsPdf(RooAbsReal):
 
     @cpp_signature(
         "RooDataHist *RooAbsPdf::generateBinned(const RooArgSet &whatVars,"
-        "   const RooCmdArg& arg1=RooCmdArg::none(),const RooCmdArg& arg2=RooCmdArg::none(),"
-        "    const RooCmdArg& arg3=RooCmdArg::none(),const RooCmdArg& arg4=RooCmdArg::none(),"
-        "    const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none()) const;"
+        "   const RooCmdArg& arg1={},const RooCmdArg& arg2={},"
+        "    const RooCmdArg& arg3={},const RooCmdArg& arg4={},"
+        "    const RooCmdArg& arg5={},const RooCmdArg& arg6={}) const;"
     )
     def generateBinned(self, *args, **kwargs):
         r"""The RooAbsPdf::generateBinned() function is pythonized with the command argument pythonization.
@@ -158,9 +158,9 @@ class RooAbsPdf(RooAbsReal):
 
     @cpp_signature(
         "GenSpec *RooAbsPdf::prepareMultiGen(const RooArgSet &whatVars,"
-        "    const RooCmdArg& arg1=RooCmdArg::none(),const RooCmdArg& arg2=RooCmdArg::none(),"
-        "    const RooCmdArg& arg3=RooCmdArg::none(),const RooCmdArg& arg4=RooCmdArg::none(),"
-        "    const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none()) ;"
+        "    const RooCmdArg& arg1={},const RooCmdArg& arg2={},"
+        "    const RooCmdArg& arg3={},const RooCmdArg& arg4={},"
+        "    const RooCmdArg& arg5={},const RooCmdArg& arg6={}) ;"
     )
     def prepareMultiGen(self, *args, **kwargs):
         r"""The RooAbsPdf::prepareMultiGen() function is pythonized with the command argument pythonization.

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabsreal.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabsreal.py
@@ -31,11 +31,11 @@ class RooAbsReal(object):
 
     @cpp_signature(
         "RooPlot* RooAbsReal::plotOn(RooPlot* frame,"
-        "    const RooCmdArg& arg1=RooCmdArg(), const RooCmdArg& arg2=RooCmdArg(),"
-        "    const RooCmdArg& arg3=RooCmdArg(), const RooCmdArg& arg4=RooCmdArg(),"
-        "    const RooCmdArg& arg5=RooCmdArg(), const RooCmdArg& arg6=RooCmdArg(),"
-        "    const RooCmdArg& arg7=RooCmdArg(), const RooCmdArg& arg8=RooCmdArg(),"
-        "    const RooCmdArg& arg9=RooCmdArg(), const RooCmdArg& arg10=RooCmdArg()) const ;"
+        "    const RooCmdArg& arg1={}, const RooCmdArg& arg2={},"
+        "    const RooCmdArg& arg3={}, const RooCmdArg& arg4={},"
+        "    const RooCmdArg& arg5={}, const RooCmdArg& arg6={},"
+        "    const RooCmdArg& arg7={}, const RooCmdArg& arg8={},"
+        "    const RooCmdArg& arg9={}, const RooCmdArg& arg10={}) const ;"
     )
     def plotOn(self, *args, **kwargs):
         r"""The RooAbsReal::plotOn() function is pythonized with the command argument pythonization.
@@ -47,10 +47,10 @@ class RooAbsReal(object):
 
     @cpp_signature(
         "TH1 *RooAbsReal::createHistogram(const char *name, const RooAbsRealLValue& xvar,"
-        "    const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),"
-        "    const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),"
-        "    const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),"
-        "    const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) const ;"
+        "    const RooCmdArg& arg1={}, const RooCmdArg& arg2={},"
+        "    const RooCmdArg& arg3={}, const RooCmdArg& arg4={},"
+        "    const RooCmdArg& arg5={}, const RooCmdArg& arg6={},"
+        "    const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) const ;"
     )
     def createHistogram(self, *args, **kwargs):
         r"""The RooAbsReal::createHistogram() function is pythonized with the command argument pythonization.
@@ -61,10 +61,10 @@ class RooAbsReal(object):
         return self._createHistogram(*args, **kwargs)
 
     @cpp_signature(
-        "RooAbsReal* RooAbsReal::createIntegral(const RooArgSet& iset, const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg::none(),"
-        "    const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),"
-        "    const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),"
-        "    const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) const ;"
+        "RooAbsReal* RooAbsReal::createIntegral(const RooArgSet& iset, const RooCmdArg& arg1, const RooCmdArg& arg2={},"
+        "    const RooCmdArg& arg3={}, const RooCmdArg& arg4={},"
+        "    const RooCmdArg& arg5={}, const RooCmdArg& arg6={},"
+        "    const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) const ;"
     )
     def createIntegral(self, *args, **kwargs):
         r"""The RooAbsReal::createIntegral() function is pythonized with the command argument pythonization.
@@ -75,10 +75,10 @@ class RooAbsReal(object):
         return self._createIntegral(*args, **kwargs)
 
     @cpp_signature(
-        "RooAbsReal* RooAbsReal::createRunningIntegral(const RooArgSet& iset, const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg::none(),"
-        "    const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),"
-        "    const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),"
-        "    const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;"
+        "RooAbsReal* RooAbsReal::createRunningIntegral(const RooArgSet& iset, const RooCmdArg& arg1, const RooCmdArg& arg2={},"
+        "    const RooCmdArg& arg3={}, const RooCmdArg& arg4={},"
+        "    const RooCmdArg& arg5={}, const RooCmdArg& arg6={},"
+        "    const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;"
     )
     def createRunningIntegral(self, *args, **kwargs):
         r"""The RooAbsReal::createRunningIntegral() function is pythonized with the command argument pythonization.
@@ -89,9 +89,9 @@ class RooAbsReal(object):
         return self._createRunningIntegral(*args, **kwargs)
 
     @cpp_signature(
-        "RooAbsReal* RooAbsReal::createChi2(RooDataHist& data, const RooCmdArg& arg1=RooCmdArg::none(),  const RooCmdArg& arg2=RooCmdArg::none(),"
-        "    const RooCmdArg& arg3=RooCmdArg::none(),  const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(),"
-        "    const RooCmdArg& arg6=RooCmdArg::none(),  const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;"
+        "RooAbsReal* RooAbsReal::createChi2(RooDataHist& data, const RooCmdArg& arg1={},  const RooCmdArg& arg2={},"
+        "    const RooCmdArg& arg3={},  const RooCmdArg& arg4={}, const RooCmdArg& arg5={},"
+        "    const RooCmdArg& arg6={},  const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;"
     )
     def createChi2(self, *args, **kwargs):
         r"""The RooAbsReal::createChi2() function is pythonized with the command argument pythonization.
@@ -102,9 +102,9 @@ class RooAbsReal(object):
         return self._createChi2(*args, **kwargs)
 
     @cpp_signature(
-        "RooFitResult *RooAbsReal::chi2FitTo(RooDataSet& xydata, const RooCmdArg& arg1=RooCmdArg::none(),  const RooCmdArg& arg2=RooCmdArg::none(),"
-        "    const RooCmdArg& arg3=RooCmdArg::none(),  const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(),"
-        "    const RooCmdArg& arg6=RooCmdArg::none(),  const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;"
+        "RooFitResult *RooAbsReal::chi2FitTo(RooDataSet& xydata, const RooCmdArg& arg1={},  const RooCmdArg& arg2={},"
+        "    const RooCmdArg& arg3={},  const RooCmdArg& arg4={}, const RooCmdArg& arg5={},"
+        "    const RooCmdArg& arg6={},  const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;"
     )
     def chi2FitTo(self, *args, **kwargs):
         r"""The RooAbsReal::chi2FitTo() function is pythonized with the command argument pythonization.

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabsreallvalue.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabsreallvalue.py
@@ -29,10 +29,10 @@ class RooAbsRealLValue(object):
 
     @cpp_signature(
         "TH1 *RooAbsRealLValue::createHistogram(const char *name,"
-        "    const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),"
-        "    const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),"
-        "    const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),"
-        "    const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) const ;"
+        "    const RooCmdArg& arg1={}, const RooCmdArg& arg2={},"
+        "    const RooCmdArg& arg3={}, const RooCmdArg& arg4={},"
+        "    const RooCmdArg& arg5={}, const RooCmdArg& arg6={},"
+        "    const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) const ;"
     )
     def createHistogram(self, *args, **kwargs):
         r"""The RooAbsRealLValue::createHistogram() function is pythonized with the command argument pythonization.
@@ -43,9 +43,9 @@ class RooAbsRealLValue(object):
         return self._createHistogram(*args, **kwargs)
 
     @cpp_signature(
-        "RooPlot *RooAbsRealLValue::frame(const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg::none(),"
-        "    const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(),"
-        "    const RooCmdArg& arg6=RooCmdArg::none(), const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) const ;"
+        "RooPlot *RooAbsRealLValue::frame(const RooCmdArg& arg1, const RooCmdArg& arg2={},"
+        "    const RooCmdArg& arg3={}, const RooCmdArg& arg4={}, const RooCmdArg& arg5={},"
+        "    const RooCmdArg& arg6={}, const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) const ;"
     )
     def frame(self, *args, **kwargs):
         r"""The RooAbsRealLValue::frame() function is pythonized with the command argument pythonization.

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roochi2var.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roochi2var.py
@@ -20,13 +20,13 @@ class RooChi2Var(object):
     @cpp_signature(
         [
             "RooChi2Var(const char* name, const char* title, RooAbsReal& func, RooDataHist& data,"
-            "        const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg::none(),const RooCmdArg& arg3=RooCmdArg::none(),"
-            "        const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none(),"
-            "        const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none(),const RooCmdArg& arg9=RooCmdArg::none()) ;",
+            "        const RooCmdArg& arg1, const RooCmdArg& arg2={},const RooCmdArg& arg3={},"
+            "        const RooCmdArg& arg4={}, const RooCmdArg& arg5={},const RooCmdArg& arg6={},"
+            "        const RooCmdArg& arg7={}, const RooCmdArg& arg8={},const RooCmdArg& arg9={}) ;",
             "RooChi2Var(const char* name, const char* title, RooAbsPdf& pdf, RooDataHist& data,"
-            "        const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg::none(),const RooCmdArg& arg3=RooCmdArg::none(),"
-            "        const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none(),"
-            "        const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none(),const RooCmdArg& arg9=RooCmdArg::none()) ;",
+            "        const RooCmdArg& arg1, const RooCmdArg& arg2={},const RooCmdArg& arg3={},"
+            "        const RooCmdArg& arg4={}, const RooCmdArg& arg5={},const RooCmdArg& arg6={},"
+            "        const RooCmdArg& arg7={}, const RooCmdArg& arg8={},const RooCmdArg& arg9={}) ;",
         ]
     )
     def __init__(self, *args, **kwargs):

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roodataset.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roodataset.py
@@ -28,9 +28,9 @@ class RooDataSet(object):
     """
 
     @cpp_signature(
-        "RooDataSet(std::string_view name, std::string_view title, const RooArgSet& vars, const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg(),"
-        "    const RooCmdArg& arg3=RooCmdArg(), const RooCmdArg& arg4=RooCmdArg(),const RooCmdArg& arg5=RooCmdArg(),"
-        "    const RooCmdArg& arg6=RooCmdArg(),const RooCmdArg& arg7=RooCmdArg(),const RooCmdArg& arg8=RooCmdArg()) ;"
+        "RooDataSet(std::string_view name, std::string_view title, const RooArgSet& vars, const RooCmdArg& arg1, const RooCmdArg& arg2={},"
+        "    const RooCmdArg& arg3={}, const RooCmdArg& arg4={},const RooCmdArg& arg5={},"
+        "    const RooCmdArg& arg6={},const RooCmdArg& arg7={},const RooCmdArg& arg8={}) ;"
     )
     def __init__(self, *args, **kwargs):
         r"""The RooDataSet constructor is pythonized with the command argument pythonization.
@@ -42,10 +42,10 @@ class RooDataSet(object):
 
     @cpp_signature(
         "RooPlot *RooDataSet::plotOnXY(RooPlot* frame,"
-        "    const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),"
-        "    const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),"
-        "    const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),"
-        "    const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) const ;"
+        "    const RooCmdArg& arg1={}, const RooCmdArg& arg2={},"
+        "    const RooCmdArg& arg3={}, const RooCmdArg& arg4={},"
+        "    const RooCmdArg& arg5={}, const RooCmdArg& arg6={},"
+        "    const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) const ;"
     )
     def plotOnXY(self, *args, **kwargs):
         r"""The RooDataSet::plotOnXY() function is pythonized with the command argument pythonization.

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roogenfitstudy.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roogenfitstudy.py
@@ -21,8 +21,8 @@ class RooGenFitStudy(object):
 
     @cpp_signature(
         [
-            "RooGenFitStudy::setGenConfig(const char* pdfName, const char* obsName, const RooCmdArg& arg1=RooCmdArg(), const RooCmdArg& arg2=RooCmdArg(),const RooCmdArg& arg3=RooCmdArg()) ;",
-            "RooGenFitStudy::setFitConfig(const char* pdfName, const char* obsName, const RooCmdArg& arg1=RooCmdArg(),const RooCmdArg& arg2=RooCmdArg(),const RooCmdArg& arg3=RooCmdArg()) ;",
+            "RooGenFitStudy::setGenConfig(const char* pdfName, const char* obsName, const RooCmdArg& arg1={}, const RooCmdArg& arg2={},const RooCmdArg& arg3={}) ;",
+            "RooGenFitStudy::setFitConfig(const char* pdfName, const char* obsName, const RooCmdArg& arg1={},const RooCmdArg& arg2={},const RooCmdArg& arg3={}) ;",
         ]
     )
     def setGenConfig(self, *args, **kwargs):

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooglobalfunc.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooglobalfunc.py
@@ -55,9 +55,9 @@ _style_map = {"-": "kSolid", "--": "kDashed", ":": "kDotted", "-.": "kDashDotted
 
 
 @cpp_signature(
-    "RooFit::FitOptions(const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg::none(),"
-    "const RooCmdArg& arg3=RooCmdArg::none(),const RooCmdArg& arg4=RooCmdArg::none(),"
-    "const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none()) ;"
+    "RooFit::FitOptions(const RooCmdArg& arg1, const RooCmdArg& arg2={},"
+    "const RooCmdArg& arg3={},const RooCmdArg& arg4={},"
+    "const RooCmdArg& arg5={},const RooCmdArg& arg6={}) ;"
 )
 def FitOptions(*args, **kwargs):
     r"""The FitOptions() function is pythonized with the command argument pythonization.
@@ -71,10 +71,10 @@ def FitOptions(*args, **kwargs):
 
 
 @cpp_signature(
-    "RooFit::Format(const char* what, const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),"
-    "const RooCmdArg& arg3=RooCmdArg::none(),const RooCmdArg& arg4=RooCmdArg::none(),"
-    "const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none(),"
-    "const RooCmdArg& arg7=RooCmdArg::none(),const RooCmdArg& arg8=RooCmdArg::none()) ;"
+    "RooFit::Format(const char* what, const RooCmdArg& arg1={}, const RooCmdArg& arg2={},"
+    "const RooCmdArg& arg3={},const RooCmdArg& arg4={},"
+    "const RooCmdArg& arg5={},const RooCmdArg& arg6={},"
+    "const RooCmdArg& arg7={},const RooCmdArg& arg8={}) ;"
 )
 def Format(*args, **kwargs):
     r"""The Format() function is pythonized with the command argument pythonization.
@@ -91,9 +91,9 @@ def Format(*args, **kwargs):
 
 
 @cpp_signature(
-    "RooFit::Frame(const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg::none(),"
-    "const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),"
-    "const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none()) ;"
+    "RooFit::Frame(const RooCmdArg& arg1, const RooCmdArg& arg2={},"
+    "const RooCmdArg& arg3={}, const RooCmdArg& arg4={},"
+    "const RooCmdArg& arg5={}, const RooCmdArg& arg6={}) ;"
 )
 def Frame(*args, **kwargs):
     r"""The Frame() function is pythonized with the command argument pythonization.
@@ -108,9 +108,9 @@ def Frame(*args, **kwargs):
 
 @cpp_signature(
     "RooFit::MultiArg(const RooCmdArg& arg1, const RooCmdArg& arg2,"
-    "const RooCmdArg& arg3=RooCmdArg::none(),const RooCmdArg& arg4=RooCmdArg::none(),"
-    "const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none(),"
-    "const RooCmdArg& arg7=RooCmdArg::none(),const RooCmdArg& arg8=RooCmdArg::none()) ;"
+    "const RooCmdArg& arg3={},const RooCmdArg& arg4={},"
+    "const RooCmdArg& arg5={},const RooCmdArg& arg6={},"
+    "const RooCmdArg& arg7={},const RooCmdArg& arg8={}) ;"
 )
 def MultiArg(*args, **kwargs):
     r"""The MultiArg() function is pythonized with the command argument pythonization.
@@ -123,7 +123,7 @@ def MultiArg(*args, **kwargs):
     return RooFit._MultiArg(*args, **kwargs)
 
 
-@cpp_signature("RooFit::YVar(const RooAbsRealLValue& var, const RooCmdArg& arg=RooCmdArg::none()) ;")
+@cpp_signature("RooFit::YVar(const RooAbsRealLValue& var, const RooCmdArg& arg={}) ;")
 def YVar(*args, **kwargs):
     r"""The YVar() function is pythonized with the command argument pythonization.
     The keywords must correspond to the CmdArg of the function.
@@ -138,7 +138,7 @@ def YVar(*args, **kwargs):
     return RooFit._YVar(*args, **kwargs)
 
 
-@cpp_signature("RooFit::ZVar(const RooAbsRealLValue& var, const RooCmdArg& arg=RooCmdArg::none()) ;")
+@cpp_signature("RooFit::ZVar(const RooAbsRealLValue& var, const RooCmdArg& arg={}) ;")
 def ZVar(*args, **kwargs):
     r"""The ZVar() function is pythonized with the command argument pythonization.
     The keywords must correspond to the CmdArg of the function.

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roomcstudy.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roomcstudy.py
@@ -29,9 +29,9 @@ class RooMCStudy(object):
 
     @cpp_signature(
         "RooMCStudy(const RooAbsPdf& model, const RooArgSet& observables,"
-        "    const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),"
-        "    const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(),"
-        "    const RooCmdArg& arg6=RooCmdArg::none(), const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;"
+        "    const RooCmdArg& arg1={}, const RooCmdArg& arg2={},"
+        "    const RooCmdArg& arg3={}, const RooCmdArg& arg4={}, const RooCmdArg& arg5={},"
+        "    const RooCmdArg& arg6={}, const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;"
     )
     def __init__(self, *args, **kwargs):
         r"""The RooMCStudy constructor is pythonized with the command argument pythonization.
@@ -42,10 +42,10 @@ class RooMCStudy(object):
         self._init(*args, **kwargs)
 
     @cpp_signature(
-        "RooPlot *RooMCStudy::plotParamOn(RooPlot* frame, const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),"
-        "    const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),"
-        "    const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),"
-        "    const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;"
+        "RooPlot *RooMCStudy::plotParamOn(RooPlot* frame, const RooCmdArg& arg1={}, const RooCmdArg& arg2={},"
+        "    const RooCmdArg& arg3={}, const RooCmdArg& arg4={},"
+        "    const RooCmdArg& arg5={}, const RooCmdArg& arg6={},"
+        "    const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;"
     )
     def plotParamOn(self, *args, **kwargs):
         r"""The RooMCStudy::plotParamOn() function is pythonized with the command argument pythonization.
@@ -56,13 +56,13 @@ class RooMCStudy(object):
 
     @cpp_signature(
         [
-            "RooPlot *RooMCStudy::plotParam(const RooRealVar& param, const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),"
-            "    const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),"
-            "    const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),"
-            "    const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;",
-            "RooPlot *RooMCStudy::plotParam(const char* paramName, const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),"
-            "    const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(), "
-            "    const RooCmdArg& arg6=RooCmdArg::none(), const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;",
+            "RooPlot *RooMCStudy::plotParam(const RooRealVar& param, const RooCmdArg& arg1={}, const RooCmdArg& arg2={},"
+            "    const RooCmdArg& arg3={}, const RooCmdArg& arg4={},"
+            "    const RooCmdArg& arg5={}, const RooCmdArg& arg6={},"
+            "    const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;",
+            "RooPlot *RooMCStudy::plotParam(const char* paramName, const RooCmdArg& arg1={}, const RooCmdArg& arg2={},"
+            "    const RooCmdArg& arg3={}, const RooCmdArg& arg4={}, const RooCmdArg& arg5={}, "
+            "    const RooCmdArg& arg6={}, const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;",
         ]
     )
     def plotParam(self, *args, **kwargs):
@@ -74,10 +74,10 @@ class RooMCStudy(object):
         return self._plotParam(*args, **kwargs)
 
     @cpp_signature(
-        "RooPlot *RooMCStudy::plotNLL(const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),"
-        "    const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),"
-        "    const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),"
-        "    const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;"
+        "RooPlot *RooMCStudy::plotNLL(const RooCmdArg& arg1={}, const RooCmdArg& arg2={},"
+        "    const RooCmdArg& arg3={}, const RooCmdArg& arg4={},"
+        "    const RooCmdArg& arg5={}, const RooCmdArg& arg6={},"
+        "    const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;"
     )
     def plotNLL(self, *args, **kwargs):
         r"""The RooMCStudy::plotNLL() function is pythonized with the command argument pythonization.
@@ -88,10 +88,10 @@ class RooMCStudy(object):
         return self._plotNLL(*args, **kwargs)
 
     @cpp_signature(
-        "RooPlot *RooMCStudy::plotError(const RooRealVar& param, const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),"
-        "    const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),"
-        "    const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),"
-        "    const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;"
+        "RooPlot *RooMCStudy::plotError(const RooRealVar& param, const RooCmdArg& arg1={}, const RooCmdArg& arg2={},"
+        "    const RooCmdArg& arg3={}, const RooCmdArg& arg4={},"
+        "    const RooCmdArg& arg5={}, const RooCmdArg& arg6={},"
+        "    const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;"
     )
     def plotError(self, *args, **kwargs):
         r"""The RooMCStudy::plotError() function is pythonized with the command argument pythonization.
@@ -102,10 +102,10 @@ class RooMCStudy(object):
         return self._plotError(*args, **kwargs)
 
     @cpp_signature(
-        "RooPlot *RooMCStudy::plotPull(const RooRealVar& param, const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg::none(),"
-        "    const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),"
-        "    const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),"
-        "    const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;"
+        "RooPlot *RooMCStudy::plotPull(const RooRealVar& param, const RooCmdArg& arg1, const RooCmdArg& arg2={},"
+        "    const RooCmdArg& arg3={}, const RooCmdArg& arg4={},"
+        "    const RooCmdArg& arg5={}, const RooCmdArg& arg6={},"
+        "    const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;"
     )
     def plotPull(self, *args, **kwargs):
         r"""The RooMCStudy::plotError() function is pythonized with the command argument pythonization.

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roomsgservice.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roomsgservice.py
@@ -27,8 +27,8 @@ class RooMsgService(object):
     \endcode"""
 
     @cpp_signature(
-        "Int_t RooMsgService::addStream(RooFit::MsgLevel level, const RooCmdArg& arg1=RooCmdArg(), const RooCmdArg& arg2=RooCmdArg(), const RooCmdArg& arg3=RooCmdArg(),"
-        "    const RooCmdArg& arg4=RooCmdArg(), const RooCmdArg& arg5=RooCmdArg(), const RooCmdArg& arg6=RooCmdArg());"
+        "Int_t RooMsgService::addStream(RooFit::MsgLevel level, const RooCmdArg& arg1={}, const RooCmdArg& arg2={}, const RooCmdArg& arg3={},"
+        "    const RooCmdArg& arg4={}, const RooCmdArg& arg5={}, const RooCmdArg& arg6={});"
     )
     def addStream(self, *args, **kwargs):
         r"""The RooMsgService::addStream() function is pythonized with the command argument pythonization.

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roonllvar.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roonllvar.py
@@ -19,9 +19,9 @@ class RooNLLVar(object):
 
     @cpp_signature(
         "RooNLLVar(const char* name, const char* title, RooAbsPdf& pdf, RooAbsData& data,"
-        "    const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),const RooCmdArg& arg3=RooCmdArg::none(),"
-        "    const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none(),"
-        "    const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none(),const RooCmdArg& arg9=RooCmdArg::none()) ;"
+        "    const RooCmdArg& arg1={}, const RooCmdArg& arg2={},const RooCmdArg& arg3={},"
+        "    const RooCmdArg& arg4={}, const RooCmdArg& arg5={},const RooCmdArg& arg6={},"
+        "    const RooCmdArg& arg7={}, const RooCmdArg& arg8={},const RooCmdArg& arg9={}) ;"
     )
     def __init__(self, *args, **kwargs):
         r"""The RooNLLVar constructor is pythonized with the command argument pythonization.

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooprodpdf.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooprodpdf.py
@@ -32,10 +32,10 @@ class RooProdPdf(object):
 
     @cpp_signature(
         "RooProdPdf(const char* name, const char* title, const RooArgSet& fullPdfSet,"
-        "    const RooCmdArg& arg1            , const RooCmdArg& arg2=RooCmdArg(),"
-        "    const RooCmdArg& arg3=RooCmdArg(), const RooCmdArg& arg4=RooCmdArg(),"
-        "    const RooCmdArg& arg5=RooCmdArg(), const RooCmdArg& arg6=RooCmdArg(),"
-        "    const RooCmdArg& arg7=RooCmdArg(), const RooCmdArg& arg8=RooCmdArg()) ;"
+        "    const RooCmdArg& arg1            , const RooCmdArg& arg2={},"
+        "    const RooCmdArg& arg3={}, const RooCmdArg& arg4={},"
+        "    const RooCmdArg& arg5={}, const RooCmdArg& arg6={},"
+        "    const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;"
     )
     def __init__(self, *args, **kwargs):
         r"""The RooProdPdf constructor is pythonized with the command argument pythonization.

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roosimultaneous.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roosimultaneous.py
@@ -42,11 +42,11 @@ class RooSimultaneous(object):
 
     @cpp_signature(
         "RooPlot *RooSimultaneous::plotOn(RooPlot* frame,"
-        "    const RooCmdArg& arg1            , const RooCmdArg& arg2=RooCmdArg(),"
-        "    const RooCmdArg& arg3=RooCmdArg(), const RooCmdArg& arg4=RooCmdArg(),"
-        "    const RooCmdArg& arg5=RooCmdArg(), const RooCmdArg& arg6=RooCmdArg(),"
-        "    const RooCmdArg& arg7=RooCmdArg(), const RooCmdArg& arg8=RooCmdArg(),"
-        "    const RooCmdArg& arg9=RooCmdArg(), const RooCmdArg& arg10=RooCmdArg()) const;"
+        "    const RooCmdArg& arg1            , const RooCmdArg& arg2={},"
+        "    const RooCmdArg& arg3={}, const RooCmdArg& arg4={},"
+        "    const RooCmdArg& arg5={}, const RooCmdArg& arg6={},"
+        "    const RooCmdArg& arg7={}, const RooCmdArg& arg8={},"
+        "    const RooCmdArg& arg9={}, const RooCmdArg& arg10={}) const;"
     )
     def plotOn(self, *args, **kwargs):
         r"""The RooSimultaneous::plotOn() function is pythonized with the command argument pythonization.

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roosimwstool.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roosimwstool.py
@@ -29,9 +29,9 @@ class RooSimWSTool(object):
 
     @cpp_signature(
         "RooSimultaneous *RooSimWSTool::build(const char* simPdfName, const char* protoPdfName,"
-        "    const RooCmdArg& arg1=RooCmdArg::none(),const RooCmdArg& arg2=RooCmdArg::none(),"
-        "    const RooCmdArg& arg3=RooCmdArg::none(),const RooCmdArg& arg4=RooCmdArg::none(),"
-        "    const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none()) ;"
+        "    const RooCmdArg& arg1={},const RooCmdArg& arg2={},"
+        "    const RooCmdArg& arg3={},const RooCmdArg& arg4={},"
+        "    const RooCmdArg& arg5={},const RooCmdArg& arg6={}) ;"
     )
     def build(self, *args, **kwargs):
         r"""The RooSimWSTool::build() function is pythonized with the command argument pythonization.

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooworkspace.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooworkspace.py
@@ -66,9 +66,9 @@ class RooWorkspace(object):
 
     @cpp_signature(
         "Bool_t RooWorkspace::import(const RooAbsArg& arg,"
-        "    const RooCmdArg& arg1=RooCmdArg(),const RooCmdArg& arg2=RooCmdArg(),const RooCmdArg& arg3=RooCmdArg(),"
-        "    const RooCmdArg& arg4=RooCmdArg(),const RooCmdArg& arg5=RooCmdArg(),const RooCmdArg& arg6=RooCmdArg(),"
-        "    const RooCmdArg& arg7=RooCmdArg(),const RooCmdArg& arg8=RooCmdArg(),const RooCmdArg& arg9=RooCmdArg()) ;"
+        "    const RooCmdArg& arg1={},const RooCmdArg& arg2={},const RooCmdArg& arg3={},"
+        "    const RooCmdArg& arg4={},const RooCmdArg& arg5={},const RooCmdArg& arg6={},"
+        "    const RooCmdArg& arg7={},const RooCmdArg& arg8={},const RooCmdArg& arg9={}) ;"
     )
     def __init__(self, *args, **kwargs):
         r"""The RooWorkspace constructor is pythonized with the command argument pythonization.
@@ -140,17 +140,17 @@ class RooWorkspace(object):
     @cpp_signature(
         [
             "Bool_t RooWorkspace::import(const RooAbsArg& arg,"
-            "         const RooCmdArg& arg1=RooCmdArg(),const RooCmdArg& arg2=RooCmdArg(),const RooCmdArg& arg3=RooCmdArg(),"
-            "         const RooCmdArg& arg4=RooCmdArg(),const RooCmdArg& arg5=RooCmdArg(),const RooCmdArg& arg6=RooCmdArg(),"
-            "         const RooCmdArg& arg7=RooCmdArg(),const RooCmdArg& arg8=RooCmdArg(),const RooCmdArg& arg9=RooCmdArg()) ;",
+            "         const RooCmdArg& arg1={},const RooCmdArg& arg2={},const RooCmdArg& arg3={},"
+            "         const RooCmdArg& arg4={},const RooCmdArg& arg5={},const RooCmdArg& arg6={},"
+            "         const RooCmdArg& arg7={},const RooCmdArg& arg8={},const RooCmdArg& arg9={}) ;",
             "Bool_t RooWorkspace::import(RooAbsData& data,"
-            "         const RooCmdArg& arg1=RooCmdArg(),const RooCmdArg& arg2=RooCmdArg(),const RooCmdArg& arg3=RooCmdArg(),"
-            "         const RooCmdArg& arg4=RooCmdArg(),const RooCmdArg& arg5=RooCmdArg(),const RooCmdArg& arg6=RooCmdArg(),"
-            "         const RooCmdArg& arg7=RooCmdArg(),const RooCmdArg& arg8=RooCmdArg(),const RooCmdArg& arg9=RooCmdArg()) ;",
+            "         const RooCmdArg& arg1={},const RooCmdArg& arg2={},const RooCmdArg& arg3={},"
+            "         const RooCmdArg& arg4={},const RooCmdArg& arg5={},const RooCmdArg& arg6={},"
+            "         const RooCmdArg& arg7={},const RooCmdArg& arg8={},const RooCmdArg& arg9={}) ;",
             "RooWorkspace::import(const char *fileSpec,"
-            "         const RooCmdArg& arg1=RooCmdArg(),const RooCmdArg& arg2=RooCmdArg(),const RooCmdArg& arg3=RooCmdArg(),"
-            "         const RooCmdArg& arg4=RooCmdArg(),const RooCmdArg& arg5=RooCmdArg(),const RooCmdArg& arg6=RooCmdArg(),"
-            "         const RooCmdArg& arg7=RooCmdArg(),const RooCmdArg& arg8=RooCmdArg(),const RooCmdArg& arg9=RooCmdArg()) ;",
+            "         const RooCmdArg& arg1={},const RooCmdArg& arg2={},const RooCmdArg& arg3={},"
+            "         const RooCmdArg& arg4={},const RooCmdArg& arg5={},const RooCmdArg& arg6={},"
+            "         const RooCmdArg& arg7={},const RooCmdArg& arg8={},const RooCmdArg& arg9={}) ;",
         ]
     )
     def Import(self, *args, **kwargs):

--- a/bindings/pyroot/pythonizations/test/roofit/roodatahist_ploton.py
+++ b/bindings/pyroot/pythonizations/test/roofit/roodatahist_ploton.py
@@ -48,11 +48,11 @@ class RooDataHistPlotOn(unittest.TestCase):
         dh, yframe = self.create_hist_and_frame()
 
         # Overload taken from RooAbsData
-        # RooPlot* RooAbsData::plotOn(RooPlot* frame, const RooCmdArg& arg1 = RooCmdArg::none(),
-        # const RooCmdArg& arg2 = RooCmdArg::none(), const RooCmdArg& arg3 = RooCmdArg::none(),
-        # const RooCmdArg& arg4 = RooCmdArg::none(), const RooCmdArg& arg5 = RooCmdArg::none(),
-        # const RooCmdArg& arg6 = RooCmdArg::none(), const RooCmdArg& arg7 = RooCmdArg::none(),
-        # const RooCmdArg& arg8 = RooCmdArg::none())
+        # RooPlot* RooAbsData::plotOn(RooPlot* frame, const RooCmdArg& arg1 = {},
+        # const RooCmdArg& arg2 = {}, const RooCmdArg& arg3 = {},
+        # const RooCmdArg& arg4 = {}, const RooCmdArg& arg5 = {},
+        # const RooCmdArg& arg6 = {}, const RooCmdArg& arg7 = {},
+        # const RooCmdArg& arg8 = {})
         res = dh.plotOn(yframe)
         self.assertEqual(type(res), ROOT.RooPlot)
 

--- a/roofit/roofitcore/inc/RooAbsCollection.h
+++ b/roofit/roofitcore/inc/RooAbsCollection.h
@@ -322,10 +322,10 @@ public:
   Int_t defaultPrintContents(Option_t* opt) const override ;
 
   // Latex printing methods
-  void printLatex(const RooCmdArg& arg1=RooCmdArg(), const RooCmdArg& arg2=RooCmdArg(),
-        const RooCmdArg& arg3=RooCmdArg(), const RooCmdArg& arg4=RooCmdArg(),
-        const RooCmdArg& arg5=RooCmdArg(), const RooCmdArg& arg6=RooCmdArg(),
-        const RooCmdArg& arg7=RooCmdArg(), const RooCmdArg& arg8=RooCmdArg()) const ;
+  void printLatex(const RooCmdArg& arg1={}, const RooCmdArg& arg2={},
+        const RooCmdArg& arg3={}, const RooCmdArg& arg4={},
+        const RooCmdArg& arg5={}, const RooCmdArg& arg6={},
+        const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) const ;
   void printLatex(std::ostream& ofs, Int_t ncol, const char* option="NEYU", Int_t sigDigit=1,
                   const RooLinkedList& siblingLists=RooLinkedList(), const RooCmdArg* formatCmd=nullptr) const ;
 

--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -68,8 +68,8 @@ public:
   virtual RooAbsData* emptyClone(const char* newName=nullptr, const char* newTitle=nullptr, const RooArgSet* vars=nullptr, const char* wgtVarName=nullptr) const = 0 ;
 
   // Reduction methods
-  RooAbsData* reduce(const RooCmdArg& arg1,const RooCmdArg& arg2=RooCmdArg(),const RooCmdArg& arg3=RooCmdArg(),const RooCmdArg& arg4=RooCmdArg(),
-                     const RooCmdArg& arg5=RooCmdArg(),const RooCmdArg& arg6=RooCmdArg(),const RooCmdArg& arg7=RooCmdArg(),const RooCmdArg& arg8=RooCmdArg()) ;
+  RooAbsData* reduce(const RooCmdArg& arg1,const RooCmdArg& arg2={},const RooCmdArg& arg3={},const RooCmdArg& arg4={},
+                     const RooCmdArg& arg5={},const RooCmdArg& arg6={},const RooCmdArg& arg7={},const RooCmdArg& arg8={}) ;
   RooAbsData* reduce(const char* cut) ;
   RooAbsData* reduce(const RooFormulaVar& cutVar) ;
   RooAbsData* reduce(const RooArgSet& varSubset, const char* cut=nullptr) ;
@@ -168,10 +168,10 @@ public:
   virtual Roo1DTable* table(const RooAbsCategory& cat, const char* cuts="", const char* opts="") const ;
   /// \see RooPlot* plotOn(RooPlot* frame, const RooLinkedList& cmdList) const
   virtual RooPlot* plotOn(RooPlot* frame,
-           const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),
-           const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),
-           const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),
-           const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) const ;
+           const RooCmdArg& arg1={}, const RooCmdArg& arg2={},
+           const RooCmdArg& arg3={}, const RooCmdArg& arg4={},
+           const RooCmdArg& arg5={}, const RooCmdArg& arg6={},
+           const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) const ;
 
   virtual RooPlot* plotOn(RooPlot* frame, const RooLinkedList& cmdList) const ;
 
@@ -208,13 +208,13 @@ public:
 
   /// Calls createHistogram(const char *name, const RooAbsRealLValue& xvar, const RooLinkedList& argList) const
   TH1 *createHistogram(const char *name, const RooAbsRealLValue& xvar,
-                       const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),
-                       const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),
-                       const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),
-                       const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) const ;
+                       const RooCmdArg& arg1={}, const RooCmdArg& arg2={},
+                       const RooCmdArg& arg3={}, const RooCmdArg& arg4={},
+                       const RooCmdArg& arg5={}, const RooCmdArg& arg6={},
+                       const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) const ;
   TH1 *createHistogram(const char* varNameList,
-                       const RooCmdArg& binArgX=RooCmdArg::none(), const RooCmdArg& binArgY=RooCmdArg::none(),
-                       const RooCmdArg& binArgZ=RooCmdArg::none()) const;
+                       const RooCmdArg& binArgX={}, const RooCmdArg& binArgY={},
+                       const RooCmdArg& binArgZ={}) const;
   /// Create and fill a ROOT histogram TH1,TH2 or TH3 with the values of this dataset.
   TH1 *createHistogram(const char *name, const RooAbsRealLValue& xvar, const RooLinkedList& argList) const ;
   TH2F* createHistogram(const RooAbsRealLValue& var1, const RooAbsRealLValue& var2, const char* cuts="",
@@ -261,10 +261,10 @@ public:
   RooRealVar* rmsVar(const RooRealVar &var, const char* cutSpec=nullptr, const char* cutRange=nullptr) const ;
 
   virtual RooPlot* statOn(RooPlot* frame,
-                          const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),
-                          const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),
-                          const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),
-                          const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;
+                          const RooCmdArg& arg1={}, const RooCmdArg& arg2={},
+                          const RooCmdArg& arg3={}, const RooCmdArg& arg4={},
+                          const RooCmdArg& arg5={}, const RooCmdArg& arg6={},
+                          const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;
 
   virtual RooPlot* statOn(RooPlot* frame, const char *what,
            const char *label= "", Int_t sigDigits= 2,

--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -58,14 +58,14 @@ public:
   /// \param[in] nEvents How many events to generate
   /// \param arg1,arg2,arg3,arg4,arg5 Optional command arguments.
   RooFit::OwningPtr<RooDataSet> generate(const RooArgSet &whatVars, Int_t nEvents, const RooCmdArg& arg1,
-                       const RooCmdArg& arg2=RooCmdArg::none(), const RooCmdArg& arg3=RooCmdArg::none(),
-                       const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none()) {
+                       const RooCmdArg& arg2={}, const RooCmdArg& arg3={},
+                       const RooCmdArg& arg4={}, const RooCmdArg& arg5={}) {
     return generate(whatVars,RooFit::NumEvents(nEvents),arg1,arg2,arg3,arg4,arg5) ;
   }
   RooFit::OwningPtr<RooDataSet> generate(const RooArgSet &whatVars,
-                       const RooCmdArg& arg1=RooCmdArg::none(),const RooCmdArg& arg2=RooCmdArg::none(),
-                       const RooCmdArg& arg3=RooCmdArg::none(),const RooCmdArg& arg4=RooCmdArg::none(),
-                       const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none()) ;
+                       const RooCmdArg& arg1={},const RooCmdArg& arg2={},
+                       const RooCmdArg& arg3={},const RooCmdArg& arg4={},
+                       const RooCmdArg& arg5={},const RooCmdArg& arg6={}) ;
   RooFit::OwningPtr<RooDataSet> generate(const RooArgSet &whatVars, double nEvents = 0, bool verbose=false, bool autoBinned=true,
              const char* binnedTag="", bool expectedData=false, bool extended = false) const;
   RooFit::OwningPtr<RooDataSet> generate(const RooArgSet &whatVars, const RooDataSet &prototype, Int_t nEvents= 0,
@@ -97,9 +97,9 @@ public:
 
   ///Prepare GenSpec configuration object for efficient generation of multiple datasets from identical specification.
   GenSpec* prepareMultiGen(const RooArgSet &whatVars,
-            const RooCmdArg& arg1=RooCmdArg::none(),const RooCmdArg& arg2=RooCmdArg::none(),
-            const RooCmdArg& arg3=RooCmdArg::none(),const RooCmdArg& arg4=RooCmdArg::none(),
-            const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none()) ;
+            const RooCmdArg& arg1={},const RooCmdArg& arg2={},
+            const RooCmdArg& arg3={},const RooCmdArg& arg4={},
+            const RooCmdArg& arg5={},const RooCmdArg& arg6={}) ;
   ///Generate according to GenSpec obtained from prepareMultiGen().
   RooFit::OwningPtr<RooDataSet> generate(GenSpec&) const ;
 
@@ -110,25 +110,25 @@ public:
   /// \param[in] nEvents How many events to generate
   /// \param arg1,arg2,arg3,arg4,arg5 ordered arguments
   virtual RooFit::OwningPtr<RooDataHist> generateBinned(const RooArgSet &whatVars, double nEvents, const RooCmdArg& arg1,
-               const RooCmdArg& arg2=RooCmdArg::none(), const RooCmdArg& arg3=RooCmdArg::none(),
-               const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none()) const {
+               const RooCmdArg& arg2={}, const RooCmdArg& arg3={},
+               const RooCmdArg& arg4={}, const RooCmdArg& arg5={}) const {
     return generateBinned(whatVars,RooFit::NumEvents(nEvents),arg1,arg2,arg3,arg4,arg5);
   }
   virtual RooFit::OwningPtr<RooDataHist> generateBinned(const RooArgSet &whatVars,
-               const RooCmdArg& arg1=RooCmdArg::none(),const RooCmdArg& arg2=RooCmdArg::none(),
-               const RooCmdArg& arg3=RooCmdArg::none(),const RooCmdArg& arg4=RooCmdArg::none(),
-               const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none()) const;
+               const RooCmdArg& arg1={},const RooCmdArg& arg2={},
+               const RooCmdArg& arg3={},const RooCmdArg& arg4={},
+               const RooCmdArg& arg5={},const RooCmdArg& arg6={}) const;
   virtual RooFit::OwningPtr<RooDataHist> generateBinned(const RooArgSet &whatVars, double nEvents, bool expectedData=false, bool extended=false) const;
 
   virtual RooFit::OwningPtr<RooDataSet> generateSimGlobal(const RooArgSet& whatVars, Int_t nEvents) ;
 
   ///Helper calling plotOn(RooPlot*, RooLinkedList&) const
   RooPlot* plotOn(RooPlot* frame,
-           const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),
-           const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),
-           const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),
-           const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none(),
-           const RooCmdArg& arg9=RooCmdArg::none(), const RooCmdArg& arg10=RooCmdArg::none()
+           const RooCmdArg& arg1={}, const RooCmdArg& arg2={},
+           const RooCmdArg& arg3={}, const RooCmdArg& arg4={},
+           const RooCmdArg& arg5={}, const RooCmdArg& arg6={},
+           const RooCmdArg& arg7={}, const RooCmdArg& arg8={},
+           const RooCmdArg& arg9={}, const RooCmdArg& arg10={}
               ) const override {
     return RooAbsReal::plotOn(frame,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10) ;
   }
@@ -136,10 +136,10 @@ public:
 
   /// Add a box with parameter values (and errors) to the specified frame
   virtual RooPlot* paramOn(RooPlot* frame,
-                           const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),
-                           const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),
-                           const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),
-                           const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;
+                           const RooCmdArg& arg1={}, const RooCmdArg& arg2={},
+                           const RooCmdArg& arg3={}, const RooCmdArg& arg4={},
+                           const RooCmdArg& arg5={}, const RooCmdArg& arg6={},
+                           const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;
 
   // Built-in generator support
   virtual Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, bool staticInitOK=true) const;
@@ -209,9 +209,9 @@ public:
   using RooAbsReal::chi2FitTo ;
   using RooAbsReal::createChi2 ;
   RooFit::OwningPtr<RooFitResult> chi2FitTo(RooDataHist& data, const RooLinkedList& cmdList) override ;
-  RooFit::OwningPtr<RooAbsReal> createChi2(RooDataHist& data, const RooCmdArg& arg1=RooCmdArg::none(),  const RooCmdArg& arg2=RooCmdArg::none(),
-             const RooCmdArg& arg3=RooCmdArg::none(),  const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(),
-             const RooCmdArg& arg6=RooCmdArg::none(),  const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) override ;
+  RooFit::OwningPtr<RooAbsReal> createChi2(RooDataHist& data, const RooCmdArg& arg1={},  const RooCmdArg& arg2={},
+             const RooCmdArg& arg3={},  const RooCmdArg& arg4={}, const RooCmdArg& arg5={},
+             const RooCmdArg& arg6={},  const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) override ;
 
   // Chi^2 fits to X-Y datasets
   RooFit::OwningPtr<RooAbsReal> createChi2(RooDataSet& data, const RooLinkedList& cmdList) override ;
@@ -232,10 +232,10 @@ public:
 
   // Create cumulative density function from p.d.f
   RooFit::OwningPtr<RooAbsReal> createCdf(const RooArgSet& iset, const RooArgSet& nset=RooArgSet()) ;
-  RooFit::OwningPtr<RooAbsReal> createCdf(const RooArgSet& iset, const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg::none(),
-         const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),
-         const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),
-         const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;
+  RooFit::OwningPtr<RooAbsReal> createCdf(const RooArgSet& iset, const RooCmdArg& arg1, const RooCmdArg& arg2={},
+         const RooCmdArg& arg3={}, const RooCmdArg& arg4={},
+         const RooCmdArg& arg5={}, const RooCmdArg& arg6={},
+         const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;
   RooFit::OwningPtr<RooAbsReal> createScanCdf(const RooArgSet& iset, const RooArgSet& nset, Int_t numScanBins, Int_t intOrder) ;
 
   // Function evaluation support

--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -179,35 +179,35 @@ public:
   bool getForceNumInt() const { return _forceNumInt ; }
 
   // Chi^2 fits to histograms
-  virtual RooFit::OwningPtr<RooFitResult> chi2FitTo(RooDataHist& data, const RooCmdArg& arg1=RooCmdArg::none(),  const RooCmdArg& arg2=RooCmdArg::none(),
-                              const RooCmdArg& arg3=RooCmdArg::none(),  const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(),
-                              const RooCmdArg& arg6=RooCmdArg::none(),  const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;
+  virtual RooFit::OwningPtr<RooFitResult> chi2FitTo(RooDataHist& data, const RooCmdArg& arg1={},  const RooCmdArg& arg2={},
+                              const RooCmdArg& arg3={},  const RooCmdArg& arg4={}, const RooCmdArg& arg5={},
+                              const RooCmdArg& arg6={},  const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;
   virtual RooFit::OwningPtr<RooFitResult> chi2FitTo(RooDataHist& data, const RooLinkedList& cmdList) ;
 
   virtual RooFit::OwningPtr<RooAbsReal> createChi2(RooDataHist& data, const RooLinkedList& cmdList) ;
-  virtual RooFit::OwningPtr<RooAbsReal> createChi2(RooDataHist& data, const RooCmdArg& arg1=RooCmdArg::none(),  const RooCmdArg& arg2=RooCmdArg::none(),
-             const RooCmdArg& arg3=RooCmdArg::none(),  const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(),
-             const RooCmdArg& arg6=RooCmdArg::none(),  const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;
+  virtual RooFit::OwningPtr<RooAbsReal> createChi2(RooDataHist& data, const RooCmdArg& arg1={},  const RooCmdArg& arg2={},
+             const RooCmdArg& arg3={},  const RooCmdArg& arg4={}, const RooCmdArg& arg5={},
+             const RooCmdArg& arg6={},  const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;
 
   // Chi^2 fits to X-Y datasets
-  virtual RooFit::OwningPtr<RooFitResult> chi2FitTo(RooDataSet& xydata, const RooCmdArg& arg1=RooCmdArg::none(),  const RooCmdArg& arg2=RooCmdArg::none(),
-                              const RooCmdArg& arg3=RooCmdArg::none(),  const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(),
-                              const RooCmdArg& arg6=RooCmdArg::none(),  const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;
+  virtual RooFit::OwningPtr<RooFitResult> chi2FitTo(RooDataSet& xydata, const RooCmdArg& arg1={},  const RooCmdArg& arg2={},
+                              const RooCmdArg& arg3={},  const RooCmdArg& arg4={}, const RooCmdArg& arg5={},
+                              const RooCmdArg& arg6={},  const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;
   virtual RooFit::OwningPtr<RooFitResult> chi2FitTo(RooDataSet& xydata, const RooLinkedList& cmdList) ;
 
   virtual RooFit::OwningPtr<RooAbsReal> createChi2(RooDataSet& data, const RooLinkedList& cmdList) ;
-  virtual RooFit::OwningPtr<RooAbsReal> createChi2(RooDataSet& data, const RooCmdArg& arg1=RooCmdArg::none(),  const RooCmdArg& arg2=RooCmdArg::none(),
-               const RooCmdArg& arg3=RooCmdArg::none(),  const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(),
-               const RooCmdArg& arg6=RooCmdArg::none(),  const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;
+  virtual RooFit::OwningPtr<RooAbsReal> createChi2(RooDataSet& data, const RooCmdArg& arg1={},  const RooCmdArg& arg2={},
+               const RooCmdArg& arg3={},  const RooCmdArg& arg4={}, const RooCmdArg& arg5={},
+               const RooCmdArg& arg6={},  const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;
 
 
   virtual RooFit::OwningPtr<RooAbsReal> createProfile(const RooArgSet& paramsOfInterest) ;
 
 
-  RooFit::OwningPtr<RooAbsReal> createIntegral(const RooArgSet& iset, const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg::none(),
-                             const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),
-              const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),
-              const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) const ;
+  RooFit::OwningPtr<RooAbsReal> createIntegral(const RooArgSet& iset, const RooCmdArg& arg1, const RooCmdArg& arg2={},
+                             const RooCmdArg& arg3={}, const RooCmdArg& arg4={},
+              const RooCmdArg& arg5={}, const RooCmdArg& arg6={},
+              const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) const ;
 
   /// Create integral over observables in iset in range named rangeName.
   RooFit::OwningPtr<RooAbsReal> createIntegral(const RooArgSet& iset, const char* rangeName) const {
@@ -233,10 +233,10 @@ public:
 
   // Create running integrals
   RooFit::OwningPtr<RooAbsReal> createRunningIntegral(const RooArgSet& iset, const RooArgSet& nset={}) ;
-  RooFit::OwningPtr<RooAbsReal> createRunningIntegral(const RooArgSet& iset, const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg::none(),
-         const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),
-         const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),
-         const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;
+  RooFit::OwningPtr<RooAbsReal> createRunningIntegral(const RooArgSet& iset, const RooCmdArg& arg1, const RooCmdArg& arg2={},
+         const RooCmdArg& arg3={}, const RooCmdArg& arg4={},
+         const RooCmdArg& arg5={}, const RooCmdArg& arg6={},
+         const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;
   RooFit::OwningPtr<RooAbsReal> createIntRI(const RooArgSet& iset, const RooArgSet& nset={}) ;
   RooFit::OwningPtr<RooAbsReal> createScanRI(const RooArgSet& iset, const RooArgSet& nset, Int_t numScanBins, Int_t intOrder) ;
 
@@ -271,11 +271,11 @@ public:
 
   // User entry point for plotting
   virtual RooPlot* plotOn(RooPlot* frame,
-           const RooCmdArg& arg1=RooCmdArg(), const RooCmdArg& arg2=RooCmdArg(),
-           const RooCmdArg& arg3=RooCmdArg(), const RooCmdArg& arg4=RooCmdArg(),
-           const RooCmdArg& arg5=RooCmdArg(), const RooCmdArg& arg6=RooCmdArg(),
-           const RooCmdArg& arg7=RooCmdArg(), const RooCmdArg& arg8=RooCmdArg(),
-           const RooCmdArg& arg9=RooCmdArg(), const RooCmdArg& arg10=RooCmdArg()
+           const RooCmdArg& arg1={}, const RooCmdArg& arg2={},
+           const RooCmdArg& arg3={}, const RooCmdArg& arg4={},
+           const RooCmdArg& arg5={}, const RooCmdArg& arg6={},
+           const RooCmdArg& arg7={}, const RooCmdArg& arg8={},
+           const RooCmdArg& arg9={}, const RooCmdArg& arg10={}
               ) const ;
 
 
@@ -294,10 +294,10 @@ public:
   TH1 *createHistogram(RooStringView varNameList, Int_t xbins=0, Int_t ybins=0, Int_t zbins=0) const ;
   TH1* createHistogram(const char *name, const RooAbsRealLValue& xvar, RooLinkedList& argList) const ;
   TH1 *createHistogram(const char *name, const RooAbsRealLValue& xvar,
-                       const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),
-                       const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),
-                       const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),
-                       const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) const ;
+                       const RooCmdArg& arg1={}, const RooCmdArg& arg2={},
+                       const RooCmdArg& arg3={}, const RooCmdArg& arg4={},
+                       const RooCmdArg& arg5={}, const RooCmdArg& arg6={},
+                       const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) const ;
 
   // Fill a RooDataHist
   RooDataHist* fillDataHist(RooDataHist *hist, const RooArgSet* nset, double scaleFactor,

--- a/roofit/roofitcore/inc/RooAbsRealLValue.h
+++ b/roofit/roofitcore/inc/RooAbsRealLValue.h
@@ -120,9 +120,9 @@ public:
 
 
   // Build 1-dimensional plots
-  RooPlot* frame(const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg::none(),
-                 const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(),
-                 const RooCmdArg& arg6=RooCmdArg::none(), const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) const ;
+  RooPlot* frame(const RooCmdArg& arg1, const RooCmdArg& arg2={},
+                 const RooCmdArg& arg3={}, const RooCmdArg& arg4={}, const RooCmdArg& arg5={},
+                 const RooCmdArg& arg6={}, const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) const ;
   RooPlot *frame(const RooLinkedList& cmdList) const ;
   RooPlot *frame(double lo, double hi, Int_t nbins) const;
   RooPlot *frame(double lo, double hi) const;
@@ -131,10 +131,10 @@ public:
 
   // Create empty 1,2, and 3D histograms from a list of 1-3 RooAbsReals
   TH1 *createHistogram(const char *name,
-                       const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),
-                       const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),
-                       const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),
-                       const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) const ;
+                       const RooCmdArg& arg1={}, const RooCmdArg& arg2={},
+                       const RooCmdArg& arg3={}, const RooCmdArg& arg4={},
+                       const RooCmdArg& arg5={}, const RooCmdArg& arg6={},
+                       const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) const ;
   TH1 *createHistogram(const char *name, const RooLinkedList& cmdList) const ;
 
   TH1F *createHistogram(const char *name, const char *yAxisLabel) const ;

--- a/roofit/roofitcore/inc/RooChi2Var.h
+++ b/roofit/roofitcore/inc/RooChi2Var.h
@@ -27,14 +27,14 @@ public:
 
   // Constructors, assignment etc
   RooChi2Var(const char *name, const char* title, RooAbsReal& func, RooDataHist& data,
-        const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),const RooCmdArg& arg3=RooCmdArg::none(),
-        const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none(),
-        const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none(),const RooCmdArg& arg9=RooCmdArg::none()) ;
+        const RooCmdArg& arg1={}, const RooCmdArg& arg2={},const RooCmdArg& arg3={},
+        const RooCmdArg& arg4={}, const RooCmdArg& arg5={},const RooCmdArg& arg6={},
+        const RooCmdArg& arg7={}, const RooCmdArg& arg8={},const RooCmdArg& arg9={}) ;
 
   RooChi2Var(const char *name, const char* title, RooAbsPdf& pdf, RooDataHist& data,
-        const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),const RooCmdArg& arg3=RooCmdArg::none(),
-        const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none(),
-        const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none(),const RooCmdArg& arg9=RooCmdArg::none()) ;
+        const RooCmdArg& arg1={}, const RooCmdArg& arg2={},const RooCmdArg& arg3={},
+        const RooCmdArg& arg4={}, const RooCmdArg& arg5={},const RooCmdArg& arg6={},
+        const RooCmdArg& arg7={}, const RooCmdArg& arg8={},const RooCmdArg& arg9={}) ;
 
   enum FuncMode { Function, Pdf, ExtendedPdf } ;
 

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -47,8 +47,8 @@ public:
   RooDataHist(RooStringView name, RooStringView title, const RooArgList& vars, RooCategory& indexCat, std::map<std::string,TH1*> histMap, double initWgt=1.0) ;
   RooDataHist(RooStringView name, RooStringView title, const RooArgList& vars, RooCategory& indexCat, std::map<std::string,RooDataHist*> dhistMap, double wgt=1.0) ;
   //RooDataHist(const char *name, const char *title, const RooArgList& vars, double initWgt=1.0) ;
-  RooDataHist(RooStringView name, RooStringView title, const RooArgList& vars, const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg(), const RooCmdArg& arg3=RooCmdArg(),
-        const RooCmdArg& arg4=RooCmdArg(),const RooCmdArg& arg5=RooCmdArg(),const RooCmdArg& arg6=RooCmdArg(),const RooCmdArg& arg7=RooCmdArg(),const RooCmdArg& arg8=RooCmdArg()) ;
+  RooDataHist(RooStringView name, RooStringView title, const RooArgList& vars, const RooCmdArg& arg1, const RooCmdArg& arg2={}, const RooCmdArg& arg3={},
+        const RooCmdArg& arg4={},const RooCmdArg& arg5={},const RooCmdArg& arg6={},const RooCmdArg& arg7={},const RooCmdArg& arg8={}) ;
   RooDataHist& operator=(const RooDataHist&) = delete;
 
   RooDataHist(const RooDataHist& other, const char* newname = nullptr) ;

--- a/roofit/roofitcore/inc/RooDataSet.h
+++ b/roofit/roofitcore/inc/RooDataSet.h
@@ -70,9 +70,9 @@ public:
      R__SUGGEST_ALTERNATIVE("Use RooDataSet(name, title, vars, RooFit::WeightVar(wgtVarName)).");
 
   // Universal constructor
-  RooDataSet(RooStringView name, RooStringView title, const RooArgSet& vars, const RooCmdArg& arg1=RooCmdArg(), const RooCmdArg& arg2=RooCmdArg(),
-             const RooCmdArg& arg3=RooCmdArg(), const RooCmdArg& arg4=RooCmdArg(),const RooCmdArg& arg5=RooCmdArg(),
-             const RooCmdArg& arg6=RooCmdArg(),const RooCmdArg& arg7=RooCmdArg(),const RooCmdArg& arg8=RooCmdArg()) ;
+  RooDataSet(RooStringView name, RooStringView title, const RooArgSet& vars, const RooCmdArg& arg1={}, const RooCmdArg& arg2={},
+             const RooCmdArg& arg3={}, const RooCmdArg& arg4={},const RooCmdArg& arg5={},
+             const RooCmdArg& arg6={},const RooCmdArg& arg7={},const RooCmdArg& arg8={}) ;
 
     // Constructor for subset of existing dataset
   RooDataSet(RooStringView name, RooStringView title, RooDataSet *data, const RooArgSet& vars,
@@ -101,10 +101,10 @@ public:
   double sumEntries(const char* cutSpec, const char* cutRange=nullptr) const override;
 
   virtual RooPlot* plotOnXY(RooPlot* frame,
-             const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),
-             const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),
-             const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),
-             const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) const ;
+             const RooCmdArg& arg1={}, const RooCmdArg& arg2={},
+             const RooCmdArg& arg3={}, const RooCmdArg& arg4={},
+             const RooCmdArg& arg5={}, const RooCmdArg& arg6={},
+             const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) const ;
 
 
   /// Read data from a text file and create a dataset from it.

--- a/roofit/roofitcore/inc/RooGenFitStudy.h
+++ b/roofit/roofitcore/inc/RooGenFitStudy.h
@@ -40,8 +40,8 @@ public:
   ~RooGenFitStudy() override ;
   RooAbsStudy* clone(const char* newname="") const override { return new RooGenFitStudy(newname?newname:GetName(),GetTitle()) ; }
 
-  void setGenConfig(const char* pdfName, const char* obsName, const RooCmdArg& arg1=RooCmdArg(),const RooCmdArg& arg2=RooCmdArg(),const RooCmdArg& arg3=RooCmdArg()) ;
-  void setFitConfig(const char* pdfName, const char* obsName, const RooCmdArg& arg1=RooCmdArg(),const RooCmdArg& arg2=RooCmdArg(),const RooCmdArg& arg3=RooCmdArg()) ;
+  void setGenConfig(const char* pdfName, const char* obsName, const RooCmdArg& arg1={},const RooCmdArg& arg2={},const RooCmdArg& arg3={}) ;
+  void setFitConfig(const char* pdfName, const char* obsName, const RooCmdArg& arg1={},const RooCmdArg& arg2={},const RooCmdArg& arg3={}) ;
 
   bool attach(RooWorkspace& w) override ;
   bool initialize() override ;

--- a/roofit/roofitcore/inc/RooGlobalFunc.h
+++ b/roofit/roofitcore/inc/RooGlobalFunc.h
@@ -195,10 +195,10 @@ RooCmdArg OwnLinked() ;
 // RooAbsPdf::printLatex arguments
 RooCmdArg Columns(Int_t ncol) ;
 RooCmdArg OutputFile(const char* fileName) ;
-RooCmdArg Format(const char* what, const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),
-                 const RooCmdArg& arg3=RooCmdArg::none(),const RooCmdArg& arg4=RooCmdArg::none(),
-                 const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none(),
-                 const RooCmdArg& arg7=RooCmdArg::none(),const RooCmdArg& arg8=RooCmdArg::none()) ;
+RooCmdArg Format(const char* what, const RooCmdArg& arg1={}, const RooCmdArg& arg2={},
+                 const RooCmdArg& arg3={},const RooCmdArg& arg4={},
+                 const RooCmdArg& arg5={},const RooCmdArg& arg6={},
+                 const RooCmdArg& arg7={},const RooCmdArg& arg8={}) ;
 RooCmdArg Sibling(const RooAbsCollection& sibling) ;
 
 // RooAbsRealLValue::frame arguments
@@ -331,8 +331,8 @@ RooCmdArg Asimov(bool flag=true) ;
 /** @} */
 
 // RooAbsRealLValue::createHistogram arguments
-RooCmdArg YVar(const RooAbsRealLValue& var, const RooCmdArg& arg=RooCmdArg::none()) ;
-RooCmdArg ZVar(const RooAbsRealLValue& var, const RooCmdArg& arg=RooCmdArg::none()) ;
+RooCmdArg YVar(const RooAbsRealLValue& var, const RooCmdArg& arg={}) ;
+RooCmdArg ZVar(const RooAbsRealLValue& var, const RooCmdArg& arg={}) ;
 RooCmdArg AxisLabel(const char* name) ;
 RooCmdArg Scaling(bool flag) ;
 
@@ -352,15 +352,15 @@ RooCmdArg NumIntConfig(const RooNumIntConfig& cfg) ;
 // RooMCStudy::ctor arguments
 RooCmdArg Silence(bool flag=true) ;
 RooCmdArg FitModel(RooAbsPdf& pdf) ;
-RooCmdArg FitOptions(const RooCmdArg& arg1                ,const RooCmdArg& arg2=RooCmdArg::none(),
-                     const RooCmdArg& arg3=RooCmdArg::none(),const RooCmdArg& arg4=RooCmdArg::none(),
-                     const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none()) ;
+RooCmdArg FitOptions(const RooCmdArg& arg1                ,const RooCmdArg& arg2={},
+                     const RooCmdArg& arg3={},const RooCmdArg& arg4={},
+                     const RooCmdArg& arg5={},const RooCmdArg& arg6={}) ;
 RooCmdArg Binned(bool flag=true) ;
 
 // RooMCStudy::plot* arguments
-RooCmdArg Frame(const RooCmdArg& arg1                ,const RooCmdArg& arg2=RooCmdArg::none(),
-                const RooCmdArg& arg3=RooCmdArg::none(),const RooCmdArg& arg4=RooCmdArg::none(),
-                const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none()) ;
+RooCmdArg Frame(const RooCmdArg& arg1                ,const RooCmdArg& arg2={},
+                const RooCmdArg& arg3={},const RooCmdArg& arg4={},
+                const RooCmdArg& arg5={},const RooCmdArg& arg6={}) ;
 RooCmdArg FrameBins(Int_t nbins) ;
 RooCmdArg FrameRange(double xlo, double xhi) ;
 RooCmdArg FitGauss(bool flag=true) ;
@@ -410,9 +410,9 @@ RooCmdArg ScanNoCdf() ;
 
 // Generic container arguments (to be able to supply more command line arguments)
 RooCmdArg MultiArg(const RooCmdArg& arg1, const RooCmdArg& arg2,
-         const RooCmdArg& arg3=RooCmdArg::none(),const RooCmdArg& arg4=RooCmdArg::none(),
-         const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none(),
-         const RooCmdArg& arg7=RooCmdArg::none(),const RooCmdArg& arg8=RooCmdArg::none()) ;
+         const RooCmdArg& arg3={},const RooCmdArg& arg4={},
+         const RooCmdArg& arg5={},const RooCmdArg& arg6={},
+         const RooCmdArg& arg7={},const RooCmdArg& arg8={}) ;
 
 RooConstVar& RooConst(double val) ;
 

--- a/roofit/roofitcore/inc/RooMCStudy.h
+++ b/roofit/roofitcore/inc/RooMCStudy.h
@@ -33,9 +33,9 @@ class RooMCStudy : public TNamed {
 public:
 
   RooMCStudy(const RooAbsPdf& model, const RooArgSet& observables,
-        const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),
-             const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(),
-             const RooCmdArg& arg6=RooCmdArg::none(), const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;
+        const RooCmdArg& arg1={}, const RooCmdArg& arg2={},
+             const RooCmdArg& arg3={}, const RooCmdArg& arg4={}, const RooCmdArg& arg5={},
+             const RooCmdArg& arg6={}, const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;
 
   ~RooMCStudy() override ;
 
@@ -62,30 +62,30 @@ public:
   }
 
   // Plot methods
-  RooPlot* plotParamOn(RooPlot* frame, const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),
-                       const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),
-                       const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),
-                       const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;
-  RooPlot* plotParam(const RooRealVar& param, const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),
-                     const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),
-                     const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),
-                     const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;
-  RooPlot* plotParam(const char* paramName, const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),
-                     const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),
-                     const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),
-                     const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;
-  RooPlot* plotNLL(const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),
-                     const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),
-                     const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),
-                     const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;
-  RooPlot* plotError(const RooRealVar& param, const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),
-                     const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),
-                     const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),
-                     const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;
-  RooPlot* plotPull(const RooRealVar& param, const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg::none(),
-                     const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),
-                     const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),
-                     const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;
+  RooPlot* plotParamOn(RooPlot* frame, const RooCmdArg& arg1={}, const RooCmdArg& arg2={},
+                       const RooCmdArg& arg3={}, const RooCmdArg& arg4={},
+                       const RooCmdArg& arg5={}, const RooCmdArg& arg6={},
+                       const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;
+  RooPlot* plotParam(const RooRealVar& param, const RooCmdArg& arg1={}, const RooCmdArg& arg2={},
+                     const RooCmdArg& arg3={}, const RooCmdArg& arg4={},
+                     const RooCmdArg& arg5={}, const RooCmdArg& arg6={},
+                     const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;
+  RooPlot* plotParam(const char* paramName, const RooCmdArg& arg1={}, const RooCmdArg& arg2={},
+                     const RooCmdArg& arg3={}, const RooCmdArg& arg4={},
+                     const RooCmdArg& arg5={}, const RooCmdArg& arg6={},
+                     const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;
+  RooPlot* plotNLL(const RooCmdArg& arg1={}, const RooCmdArg& arg2={},
+                     const RooCmdArg& arg3={}, const RooCmdArg& arg4={},
+                     const RooCmdArg& arg5={}, const RooCmdArg& arg6={},
+                     const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;
+  RooPlot* plotError(const RooRealVar& param, const RooCmdArg& arg1={}, const RooCmdArg& arg2={},
+                     const RooCmdArg& arg3={}, const RooCmdArg& arg4={},
+                     const RooCmdArg& arg5={}, const RooCmdArg& arg6={},
+                     const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;
+  RooPlot* plotPull(const RooRealVar& param, const RooCmdArg& arg1, const RooCmdArg& arg2={},
+                     const RooCmdArg& arg3={}, const RooCmdArg& arg4={},
+                     const RooCmdArg& arg5={}, const RooCmdArg& arg6={},
+                     const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;
 
 
   RooPlot* plotNLL(double lo, double hi, Int_t nBins=100) ;

--- a/roofit/roofitcore/inc/RooMsgService.h
+++ b/roofit/roofitcore/inc/RooMsgService.h
@@ -150,8 +150,8 @@ public:
   static bool anyDebug() ;
 
   // User interface -- Add or delete reporting streams ;
-  Int_t addStream(RooFit::MsgLevel level, const RooCmdArg& arg1=RooCmdArg(), const RooCmdArg& arg2=RooCmdArg(), const RooCmdArg& arg3=RooCmdArg(),
-                          const RooCmdArg& arg4=RooCmdArg(), const RooCmdArg& arg5=RooCmdArg(), const RooCmdArg& arg6=RooCmdArg());
+  Int_t addStream(RooFit::MsgLevel level, const RooCmdArg& arg1={}, const RooCmdArg& arg2={}, const RooCmdArg& arg3={},
+                          const RooCmdArg& arg4={}, const RooCmdArg& arg5={}, const RooCmdArg& arg6={});
   void deleteStream(Int_t id) ;
   StreamConfig& getStream(Int_t id) { return _streams[id] ; }
 

--- a/roofit/roofitcore/inc/RooNLLVar.h
+++ b/roofit/roofitcore/inc/RooNLLVar.h
@@ -33,9 +33,9 @@ public:
   // Constructors, assignment etc
   RooNLLVar();
   RooNLLVar(const char *name, const char* title, RooAbsPdf& pdf, RooAbsData& data,
-       const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),const RooCmdArg& arg3=RooCmdArg::none(),
-       const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none(),
-       const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none(),const RooCmdArg& arg9=RooCmdArg::none()) ;
+       const RooCmdArg& arg1={}, const RooCmdArg& arg2={},const RooCmdArg& arg3={},
+       const RooCmdArg& arg4={}, const RooCmdArg& arg5={},const RooCmdArg& arg6={},
+       const RooCmdArg& arg7={}, const RooCmdArg& arg8={},const RooCmdArg& arg9={}) ;
 
   RooNLLVar(const char *name, const char *title, RooAbsPdf& pdf, RooAbsData& data,
             bool extended,

--- a/roofit/roofitcore/inc/RooProdPdf.h
+++ b/roofit/roofitcore/inc/RooProdPdf.h
@@ -40,16 +40,16 @@ public:
   RooProdPdf(const char* name, const char* title, const RooArgSet& fullPdfSet, const RooLinkedList& cmdArgList) ;
 
   RooProdPdf(const char* name, const char* title, const RooArgSet& fullPdfSet,
-           const RooCmdArg& arg1            , const RooCmdArg& arg2=RooCmdArg(),
-             const RooCmdArg& arg3=RooCmdArg(), const RooCmdArg& arg4=RooCmdArg(),
-             const RooCmdArg& arg5=RooCmdArg(), const RooCmdArg& arg6=RooCmdArg(),
-             const RooCmdArg& arg7=RooCmdArg(), const RooCmdArg& arg8=RooCmdArg()) ;
+           const RooCmdArg& arg1            , const RooCmdArg& arg2={},
+             const RooCmdArg& arg3={}, const RooCmdArg& arg4={},
+             const RooCmdArg& arg5={}, const RooCmdArg& arg6={},
+             const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;
 
   RooProdPdf(const char* name, const char* title,
-             const RooCmdArg& arg1,             const RooCmdArg& arg2=RooCmdArg(),
-             const RooCmdArg& arg3=RooCmdArg(), const RooCmdArg& arg4=RooCmdArg(),
-             const RooCmdArg& arg5=RooCmdArg(), const RooCmdArg& arg6=RooCmdArg(),
-             const RooCmdArg& arg7=RooCmdArg(), const RooCmdArg& arg8=RooCmdArg()) ;
+             const RooCmdArg& arg1,             const RooCmdArg& arg2={},
+             const RooCmdArg& arg3={}, const RooCmdArg& arg4={},
+             const RooCmdArg& arg5={}, const RooCmdArg& arg6={},
+             const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;
 
   RooProdPdf(const RooProdPdf& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooProdPdf(*this,newname) ; }

--- a/roofit/roofitcore/inc/RooSimWSTool.h
+++ b/roofit/roofitcore/inc/RooSimWSTool.h
@@ -51,9 +51,9 @@ public:
   class ObjSplitRule ;
 
   RooSimultaneous* build(const char* simPdfName, const char* protoPdfName,
-          const RooCmdArg& arg1=RooCmdArg::none(),const RooCmdArg& arg2=RooCmdArg::none(),
-          const RooCmdArg& arg3=RooCmdArg::none(),const RooCmdArg& arg4=RooCmdArg::none(),
-          const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none()) ;
+          const RooCmdArg& arg1={},const RooCmdArg& arg2={},
+          const RooCmdArg& arg3={},const RooCmdArg& arg4={},
+          const RooCmdArg& arg5={},const RooCmdArg& arg6={}) ;
 
   RooSimultaneous* build(const char* simPdfName,BuildConfig& bc, bool verbose=true) ;
 
@@ -84,9 +84,9 @@ protected:
    friend class RooSimWSTool ;
    friend class BuildConfig ;
    friend class MultiBuildConfig ;
-   void configure(const RooCmdArg& arg1=RooCmdArg::none(),const RooCmdArg& arg2=RooCmdArg::none(),
-                  const RooCmdArg& arg3=RooCmdArg::none(),const RooCmdArg& arg4=RooCmdArg::none(),
-                  const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none()) ;
+   void configure(const RooCmdArg& arg1={},const RooCmdArg& arg2={},
+                  const RooCmdArg& arg3={},const RooCmdArg& arg4={},
+                  const RooCmdArg& arg5={},const RooCmdArg& arg6={}) ;
 
    std::list<std::string>                                             _miStateNameList ;
    std::map<std::string, std::pair<std::list<std::string>,std::string> > _paramSplitMap  ; //<paramName,<std::list<splitCatSet>,remainderStateName>>
@@ -98,9 +98,9 @@ class RooSimWSTool::BuildConfig
 {
  public:
   BuildConfig(const char* pdfName, SplitRule& sr) ;
-  BuildConfig(const char* pdfName, const RooCmdArg& arg1=RooCmdArg::none(),const RooCmdArg& arg2=RooCmdArg::none(),
-         const RooCmdArg& arg3=RooCmdArg::none(),const RooCmdArg& arg4=RooCmdArg::none(),
-         const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none()) ;
+  BuildConfig(const char* pdfName, const RooCmdArg& arg1={},const RooCmdArg& arg2={},
+         const RooCmdArg& arg3={},const RooCmdArg& arg4={},
+         const RooCmdArg& arg5={},const RooCmdArg& arg6={}) ;
 
   BuildConfig(const RooArgSet& legacyBuildConfig) ;
 
@@ -128,9 +128,9 @@ class RooSimWSTool::MultiBuildConfig : public RooSimWSTool::BuildConfig
   ~MultiBuildConfig() override {} ;
   void addPdf(const char* miStateList, const char* pdfName, SplitRule& sr) ;
   void addPdf(const char* miStateList, const char* pdfName,
-         const RooCmdArg& arg1=RooCmdArg::none(),const RooCmdArg& arg2=RooCmdArg::none(),
-         const RooCmdArg& arg3=RooCmdArg::none(),const RooCmdArg& arg4=RooCmdArg::none(),
-         const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none()) ;
+         const RooCmdArg& arg1={},const RooCmdArg& arg2={},
+         const RooCmdArg& arg3={},const RooCmdArg& arg4={},
+         const RooCmdArg& arg5={},const RooCmdArg& arg6={}) ;
 
  protected:
   friend class RooSimWSTool ;

--- a/roofit/roofitcore/inc/RooSimultaneous.h
+++ b/roofit/roofitcore/inc/RooSimultaneous.h
@@ -75,11 +75,11 @@ public:
 
   using RooAbsPdf::plotOn ;
   RooPlot* plotOn(RooPlot* frame,
-           const RooCmdArg& arg1            , const RooCmdArg& arg2=RooCmdArg(),
-           const RooCmdArg& arg3=RooCmdArg(), const RooCmdArg& arg4=RooCmdArg(),
-           const RooCmdArg& arg5=RooCmdArg(), const RooCmdArg& arg6=RooCmdArg(),
-           const RooCmdArg& arg7=RooCmdArg(), const RooCmdArg& arg8=RooCmdArg(),
-           const RooCmdArg& arg9=RooCmdArg(), const RooCmdArg& arg10=RooCmdArg()) const override {
+           const RooCmdArg& arg1            , const RooCmdArg& arg2={},
+           const RooCmdArg& arg3={}, const RooCmdArg& arg4={},
+           const RooCmdArg& arg5={}, const RooCmdArg& arg6={},
+           const RooCmdArg& arg7={}, const RooCmdArg& arg8={},
+           const RooCmdArg& arg9={}, const RooCmdArg& arg10={}) const override {
     return RooAbsReal::plotOn(frame,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10) ;
   }
   RooPlot* plotOn(RooPlot* frame, RooLinkedList& cmdList) const override ;

--- a/roofit/roofitcore/inc/RooWorkspace.h
+++ b/roofit/roofitcore/inc/RooWorkspace.h
@@ -58,21 +58,21 @@ public:
 
   // Import functions for dataset, functions, generic objects
   bool import(const RooAbsArg& arg,
-      const RooCmdArg& arg1=RooCmdArg(),const RooCmdArg& arg2=RooCmdArg(),const RooCmdArg& arg3=RooCmdArg(),
-      const RooCmdArg& arg4=RooCmdArg(),const RooCmdArg& arg5=RooCmdArg(),const RooCmdArg& arg6=RooCmdArg(),
-      const RooCmdArg& arg7=RooCmdArg(),const RooCmdArg& arg8=RooCmdArg(),const RooCmdArg& arg9=RooCmdArg()) ;
+      const RooCmdArg& arg1={},const RooCmdArg& arg2={},const RooCmdArg& arg3={},
+      const RooCmdArg& arg4={},const RooCmdArg& arg5={},const RooCmdArg& arg6={},
+      const RooCmdArg& arg7={},const RooCmdArg& arg8={},const RooCmdArg& arg9={}) ;
   bool import(const RooArgSet& args,
-      const RooCmdArg& arg1=RooCmdArg(),const RooCmdArg& arg2=RooCmdArg(),const RooCmdArg& arg3=RooCmdArg(),
-      const RooCmdArg& arg4=RooCmdArg(),const RooCmdArg& arg5=RooCmdArg(),const RooCmdArg& arg6=RooCmdArg(),
-      const RooCmdArg& arg7=RooCmdArg(),const RooCmdArg& arg8=RooCmdArg(),const RooCmdArg& arg9=RooCmdArg()) ;
+      const RooCmdArg& arg1={},const RooCmdArg& arg2={},const RooCmdArg& arg3={},
+      const RooCmdArg& arg4={},const RooCmdArg& arg5={},const RooCmdArg& arg6={},
+      const RooCmdArg& arg7={},const RooCmdArg& arg8={},const RooCmdArg& arg9={}) ;
   bool import(RooAbsData const& data,
-      const RooCmdArg& arg1=RooCmdArg(),const RooCmdArg& arg2=RooCmdArg(),const RooCmdArg& arg3=RooCmdArg(),
-      const RooCmdArg& arg4=RooCmdArg(),const RooCmdArg& arg5=RooCmdArg(),const RooCmdArg& arg6=RooCmdArg(),
-      const RooCmdArg& arg7=RooCmdArg(),const RooCmdArg& arg8=RooCmdArg(),const RooCmdArg& arg9=RooCmdArg()) ;
+      const RooCmdArg& arg1={},const RooCmdArg& arg2={},const RooCmdArg& arg3={},
+      const RooCmdArg& arg4={},const RooCmdArg& arg5={},const RooCmdArg& arg6={},
+      const RooCmdArg& arg7={},const RooCmdArg& arg8={},const RooCmdArg& arg9={}) ;
   bool import(const char *fileSpec,
-      const RooCmdArg& arg1=RooCmdArg(),const RooCmdArg& arg2=RooCmdArg(),const RooCmdArg& arg3=RooCmdArg(),
-      const RooCmdArg& arg4=RooCmdArg(),const RooCmdArg& arg5=RooCmdArg(),const RooCmdArg& arg6=RooCmdArg(),
-      const RooCmdArg& arg7=RooCmdArg(),const RooCmdArg& arg8=RooCmdArg(),const RooCmdArg& arg9=RooCmdArg()) ;
+      const RooCmdArg& arg1={},const RooCmdArg& arg2={},const RooCmdArg& arg3={},
+      const RooCmdArg& arg4={},const RooCmdArg& arg5={},const RooCmdArg& arg6={},
+      const RooCmdArg& arg7={},const RooCmdArg& arg8={},const RooCmdArg& arg9={}) ;
   bool import(TObject const& object, bool replaceExisting=false) ;
   bool import(TObject const& object, const char* aliasName, bool replaceExisting=false) ;
 

--- a/roofit/roofitcore/test/testGlobalObservables.cxx
+++ b/roofit/roofitcore/test/testGlobalObservables.cxx
@@ -97,10 +97,9 @@ public:
    RooAbsPdf &model() { return *ws().pdf("model"); }
    RooAbsPdf &modelc() { return *ws().pdf("modelc"); }
 
-   std::unique_ptr<RooFitResult> doFit(RooAbsPdf &model, RooAbsData &data, RooCmdArg const &arg1 = RooCmdArg::none(),
-                                       RooCmdArg const &arg2 = RooCmdArg::none(),
-                                       RooCmdArg const &arg3 = RooCmdArg::none(),
-                                       RooCmdArg const &arg4 = RooCmdArg::none())
+   std::unique_ptr<RooFitResult> doFit(RooAbsPdf &model, RooAbsData &data, RooCmdArg const &arg1 = {},
+                                       RooCmdArg const &arg2 = {}, RooCmdArg const &arg3 = {},
+                                       RooCmdArg const &arg4 = {})
    {
       using namespace RooFit;
       return std::unique_ptr<RooFitResult>(

--- a/roofit/roostats/inc/RooStats/MarkovChain.h
+++ b/roofit/roostats/inc/RooStats/MarkovChain.h
@@ -69,10 +69,10 @@ namespace RooStats {
       /// Get a clone of the markov chain on which this interval is based
       /// as a RooDataSet.  You own the returned RooDataSet*
       virtual RooDataSet* GetAsDataSet(const RooCmdArg& arg1,
-                                       const RooCmdArg& arg2=RooCmdArg::none(), const RooCmdArg& arg3=RooCmdArg::none(),
-                                       const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(),
-                                       const RooCmdArg& arg6=RooCmdArg::none(), const RooCmdArg& arg7=RooCmdArg::none(),
-                                       const RooCmdArg& arg8=RooCmdArg::none() ) const;
+                                       const RooCmdArg& arg2={}, const RooCmdArg& arg3={},
+                                       const RooCmdArg& arg4={}, const RooCmdArg& arg5={},
+                                       const RooCmdArg& arg6={}, const RooCmdArg& arg7={},
+                                       const RooCmdArg& arg8={} ) const;
 
       virtual const RooDataSet* GetAsConstDataSet() const { return fChain; }
 
@@ -85,10 +85,10 @@ namespace RooStats {
       /// Get a clone of the markov chain on which this interval is based
       /// as a RooDataHist.  You own the returned RooDataHist*
       virtual RooDataHist* GetAsDataHist(const RooCmdArg & arg1,
-                                         const RooCmdArg& arg2=RooCmdArg::none(), const RooCmdArg& arg3=RooCmdArg::none(),
-                                         const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(),
-                                         const RooCmdArg& arg6=RooCmdArg::none(), const RooCmdArg& arg7=RooCmdArg::none(),
-                                         const RooCmdArg& arg8=RooCmdArg::none() ) const;
+                                         const RooCmdArg& arg2={}, const RooCmdArg& arg3={},
+                                         const RooCmdArg& arg4={}, const RooCmdArg& arg5={},
+                                         const RooCmdArg& arg6={}, const RooCmdArg& arg7={},
+                                         const RooCmdArg& arg8={} ) const;
 
       /// Get a clone of the markov chain on which this interval is based
       /// as a sparse histogram.  You own the returned THnSparse*

--- a/roofit/roostats/inc/RooStats/SPlot.h
+++ b/roofit/roostats/inc/RooStats/SPlot.h
@@ -41,10 +41,10 @@ namespace RooStats{
     SPlot(const char* name, const char* title,RooDataSet& data, RooAbsPdf* pdf,
      const RooArgList &yieldsList,const RooArgSet &projDeps=RooArgSet(),
      bool useWeights=true, bool copyDataSet = false, const char* newName = "",
-     const RooCmdArg& fitToarg5=RooCmdArg::none(),
-     const RooCmdArg& fitToarg6=RooCmdArg::none(),
-     const RooCmdArg& fitToarg7=RooCmdArg::none(),
-     const RooCmdArg& fitToarg8=RooCmdArg::none());
+     const RooCmdArg& fitToarg5={},
+     const RooCmdArg& fitToarg6={},
+     const RooCmdArg& fitToarg7={},
+     const RooCmdArg& fitToarg8={});
 
     RooDataSet* SetSData(RooDataSet* data);
 
@@ -56,10 +56,10 @@ namespace RooStats{
 
     void AddSWeight(RooAbsPdf* pdf, const RooArgList &yieldsTmp,
           const RooArgSet &projDeps=RooArgSet(), bool includeWeights=true,
-          const RooCmdArg& fitToarg5=RooCmdArg::none(),
-          const RooCmdArg& fitToarg6=RooCmdArg::none(),
-          const RooCmdArg& fitToarg7=RooCmdArg::none(),
-          const RooCmdArg& fitToarg8=RooCmdArg::none());
+          const RooCmdArg& fitToarg5={},
+          const RooCmdArg& fitToarg6={},
+          const RooCmdArg& fitToarg7={},
+          const RooCmdArg& fitToarg8={});
 
     double GetSumOfEventSWeight(Int_t numEvent) const;
 

--- a/roofit/xroofit/inc/RooFit/xRooFit/xRooFit.h
+++ b/roofit/xroofit/inc/RooFit/xRooFit/xRooFit.h
@@ -73,11 +73,9 @@ public:
    static xRooNLLVar createNLL(const std::shared_ptr<RooAbsPdf> pdf, const std::shared_ptr<RooAbsData> data,
                                const RooLinkedList &nllOpts);
    static xRooNLLVar createNLL(RooAbsPdf &pdf, RooAbsData *data, const RooLinkedList &nllOpts);
-   static xRooNLLVar createNLL(RooAbsPdf &pdf, RooAbsData *data, const RooCmdArg &arg1 = RooCmdArg::none(),
-                               const RooCmdArg &arg2 = RooCmdArg::none(), const RooCmdArg &arg3 = RooCmdArg::none(),
-                               const RooCmdArg &arg4 = RooCmdArg::none(), const RooCmdArg &arg5 = RooCmdArg::none(),
-                               const RooCmdArg &arg6 = RooCmdArg::none(), const RooCmdArg &arg7 = RooCmdArg::none(),
-                               const RooCmdArg &arg8 = RooCmdArg::none());
+   static xRooNLLVar createNLL(RooAbsPdf &pdf, RooAbsData *data, const RooCmdArg &arg1 = {}, const RooCmdArg &arg2 = {},
+                               const RooCmdArg &arg3 = {}, const RooCmdArg &arg4 = {}, const RooCmdArg &arg5 = {},
+                               const RooCmdArg &arg6 = {}, const RooCmdArg &arg7 = {}, const RooCmdArg &arg8 = {});
 
    static std::shared_ptr<ROOT::Fit::FitConfig> createFitConfig(); // obtain instance of default fit configuration
    static std::shared_ptr<RooLinkedList> createNLLOptions();       // obtain instance of default nll options


### PR DESCRIPTION
In C++, `foo(RooCmdArg const& = RooCmdArg())` and
`foo(RooCmdArg const& = {})` mean the same, but the latter is nuch shorter.

This is especially nice to use for the doxygen documentation of e.g. RooAbsReal, where these long function signatures are quite distracting.