### PR TITLE
Fix cling incorrect LLVM path for external LLVM + clang

### DIFF
--- a/interpreter/cling/include/cling/Interpreter/Interpreter.h
+++ b/interpreter/cling/include/cling/Interpreter/Interpreter.h
@@ -10,6 +10,10 @@
 #ifndef CLING_INTERPRETER_H
 #define CLING_INTERPRETER_H
 
+#ifndef LLVM_PATH
+#define LLVM_PATH nullptr
+#endif
+
 #include "cling/Interpreter/InvocationOptions.h"
 #include "cling/Interpreter/RuntimeOptions.h"
 
@@ -357,7 +361,7 @@ namespace cling {
     ///\param[in] extraLibHandle - resolve symbols also from this dylib
     ///\param[in] noRuntime - flag to control the presence of runtime universe
     ///
-    Interpreter(int argc, const char* const* argv, const char* llvmdir = nullptr,
+    Interpreter(int argc, const char* const* argv, const char* llvmdir = LLVM_PATH,
                 const ModuleFileExtensions& moduleExtensions = {},
                 void *extraLibHandle = nullptr, bool noRuntime = false)
         : Interpreter(argc, argv, llvmdir, moduleExtensions, extraLibHandle,
@@ -374,7 +378,7 @@ namespace cling {
     ///\param[in] noRuntime - flag to control the presence of runtime universe
     ///
     Interpreter(const Interpreter& parentInterpreter, int argc,
-                const char* const* argv, const char* llvmdir = nullptr,
+                const char* const* argv, const char* llvmdir = LLVM_PATH,
                 const ModuleFileExtensions& moduleExtensions = {},
                 void *extraLibHandle = nullptr, bool noRuntime = true);
 

--- a/interpreter/cling/lib/Interpreter/CMakeLists.txt
+++ b/interpreter/cling/lib/Interpreter/CMakeLists.txt
@@ -373,3 +373,9 @@ if ((NOT builtin_llvm) AND builtin_clang)
   list(INSERT P 0 ${FixInclude})
   set_property(SOURCE TransactionUnloader.cpp PROPERTY INCLUDE_DIRECTORIES "${P}")
 endif()
+
+# If both LLVM and Clang are external, we need to define LLVM_PATH in order for
+# cling to use the correct (external) LLVM/Clang directories.
+if ((NOT builtin_llvm) AND (NOT builtin_clang))
+  target_compile_definitions(clingInterpreter PUBLIC "LLVM_PATH=\"${LLVM_BINARY_DIR}\"")
+endif()


### PR DESCRIPTION
When cling is compiled standalone against an external instance of LLVM and clang, cling cannot be reliably used. This is because ```createCI()``` throws an error about a non-existing clang resource directory inside the cling directories and a crash occurs shortly afterwards, when a code to be interpreted is entered.

The reason of the above seems to be the inability of cling and its build system to flag properly that there is no built-in LLVM/clang and therefore cling should use the external one instead.

This PR fixes it by introducing the ```LLVM_PATH``` pre-processor definition which is populated automatically by CMake with the detected LLVM directory as soon as both ```builtin_llvm``` and ```builtin_clang``` are off.

If I should have done this in a different way, there are pieces of code where ```LLVM_PATH``` should be also used but it isn't (or vice versa), or you have any other comments, I'm happy to hear your suggestions :)