### PR TITLE
[RF] Use BatchMode for data projection plots

### DIFF
--- a/README/ReleaseNotes/v630/index.md
+++ b/README/ReleaseNotes/v630/index.md
@@ -42,6 +42,7 @@ that were deprecated in v6.02/00.
 - The deprecated `RooAbsPdf::paramOn()` overload that directly takes a formatting string was removed. Please take the overload that uses command arguments.
 - The `RooCatType` class was deprecated in ROOT 6.22 and its original `RooCatType.h` header is now removed. If you still need access to this class, please include `RooFitLegacy/RooCatTypeLegacy.h`.
 - The `RooAbsString` that was only an alias for `RooStringVar` got removed.
+- The `RooDataWeightedAverage` is now deprecated and will be removed in 6.32. It was only supposed to be an implementation detail of RooFits plotting that is now not necessary anymore.
 
 ## Core Libraries
 

--- a/roofit/roofitcore/inc/RooDataWeightedAverage.h
+++ b/roofit/roofitcore/inc/RooDataWeightedAverage.h
@@ -52,6 +52,13 @@ protected:
   double evaluatePartition(std::size_t firstEvent, std::size_t lastEvent, std::size_t stepSize) const override ;
 
   ClassDefOverride(RooDataWeightedAverage,0) // Optimized calculator of data weighted average of a RooAbsReal
+
+// Undocumented preprocessor define such that the implementation in
+// RooDataWeightedAverage.cxx can suppress the deprecation warning.
+#ifndef __ROOFIT_SUPPRESS_ROODATAWEIGHTEDAVERAGE_DEPRECATION_WARNING
+} R__DEPRECATED(6, 32, "RooDataWeightedAverage is an implementation detail of RooFit that will be removed from the public user interface.");
+#else
 };
+#endif
 
 #endif

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -56,7 +56,6 @@
 #include "RooAddition.h"
 #include "RooDataSet.h"
 #include "RooDataHist.h"
-#include "RooDataWeightedAverage.h"
 #include "RooNumRunningInt.h"
 #include "RooGlobalFunc.h"
 #include "RooParamBinning.h"
@@ -106,6 +105,58 @@
 #include <limits>
 #include <sstream>
 #include <sys/types.h>
+
+namespace {
+
+// Internal helper RooAbsFunc that evalutes the scaled data-weighted average of
+// given RooAbsReal as a function of a single variable using the RooFitDriver.
+class ScaledDataWeightedAverage : public RooAbsFunc {
+public:
+   ScaledDataWeightedAverage(RooAbsReal const &arg, RooAbsData const &data, double scaleFactor, RooAbsRealLValue &var)
+      : RooAbsFunc{1}, _var{var}, _dataWeights{data.getWeightBatch(0, data.numEntries())}, _scaleFactor{scaleFactor}
+   {
+      _arg = RooFit::Detail::compileForNormSet(arg, *data.get());
+      _arg->recursiveRedirectServers(RooArgList{var});
+      _driver = std::make_unique<ROOT::Experimental::RooFitDriver>(*_arg, RooFit::BatchModeOption::Cpu);
+      _driver->setData(data, "");
+   }
+
+   double operator()(const double xvector[]) const override
+   {
+      double oldVal = _var.getVal();
+      _var.setVal(xvector[0]);
+
+      double out = 0.0;
+      auto pdfValues = _driver->getValues();
+      if (_dataWeights.empty()) {
+         out = std::accumulate(pdfValues.begin(), pdfValues.end(), 0.0) / pdfValues.size();
+      } else {
+         double weightsSum = 0.0;
+         for (std::size_t i = 0; i < pdfValues.size(); ++i) {
+            out += pdfValues[i] * _dataWeights[i];
+            weightsSum += _dataWeights[i];
+         }
+         out /= weightsSum;
+      }
+      out *= _scaleFactor;
+
+      _var.setVal(oldVal);
+      return out;
+   }
+   double getMinLimit(UInt_t /*dimension*/) const override { return _var.getMin(); }
+   double getMaxLimit(UInt_t /*dimension*/) const override { return _var.getMax(); }
+
+private:
+   RooAbsRealLValue &_var;
+   std::unique_ptr<RooAbsReal> _arg;
+   RooSpan<const double> _dataWeights;
+   double _scaleFactor;
+   std::unique_ptr<ROOT::Experimental::RooFitDriver> _driver;
+};
+
+} // namespace
+
+using namespace std ;
 
 ClassImp(RooAbsReal)
 
@@ -949,7 +1000,6 @@ const RooAbsReal *RooAbsReal::createPlotProjection(const RooArgSet &dependentVar
   // directly (it is contained in the cloneSet instead).
   return projectedPtr;
 }
-
 
 
 
@@ -2104,25 +2154,8 @@ RooPlot* RooAbsReal::plotOn(RooPlot *frame, PlotOpt o) const
       projDataSel = tmp ;
     }
 
-
-
-    // Attach dataset
-    projection->getVal(projDataSel->get()) ;
-    projection->attachDataSet(*projDataSel) ;
-
-    // Construct optimized data weighted average
-    RooAbsTestStatistic::Configuration cfg;
-    cfg.nCPU = o.numCPU;
-    cfg.interleave = o.interleave;
-    RooDataWeightedAverage dwa((std::string(GetName()) + "DataWgtAvg").c_str(),"Data Weighted average",*projection,*projDataSel,RooArgSet()/**projDataSel->get()*/,
-            std::move(cfg), true) ;
-    //RooDataWeightedAverage dwa(Form("%sDataWgtAvg",GetName()),"Data Weighted average",*projection,*projDataSel,*projDataSel->get(),o.numCPU,o.interleave,true) ;
-
-    // Do _not_ activate cache-and-track as necessary information to define normalization observables are not present in the underlying dataset
-    dwa.constOptimizeTestStatistic(Activate,false) ;
-
-    RooProduct scaledDwa{"scaled_dwa", "Data Weighted average", dwa, {RooFit::RooConst(o.scaleFactor)}};
-    RooRealBinding scaleBind(scaledDwa,*plotVar) ;
+    // Construct scaled data weighted average
+    ScaledDataWeightedAverage scaleBind{*projection, *projDataSel, o.scaleFactor, *plotVar};
 
     // Set default range, if not specified
     if (o.rangeLo==0 && o.rangeHi==0) {
@@ -2475,19 +2508,8 @@ RooPlot* RooAbsReal::plotAsymOn(RooPlot *frame, const RooAbsCategoryLValue& asym
     }
 
 
-    RooAbsTestStatistic::Configuration cfg;
-    cfg.nCPU = o.numCPU;
-    cfg.interleave = o.interleave;
-    RooDataWeightedAverage dwa(Form("%sDataWgtAvg",GetName()),"Data Weighted average",funcAsym,*projDataSel,RooArgSet()/**projDataSel->get()*/,
-            std::move(cfg),true) ;
-    //RooDataWeightedAverage dwa(Form("%sDataWgtAvg",GetName()),"Data Weighted average",*funcAsym,*projDataSel,*projDataSel->get(),o.numCPU,o.interleave,true) ;
-    dwa.constOptimizeTestStatistic(Activate) ;
-
-    ((RooAbsReal*)posProj)->attachDataSet(*projDataSel) ;
-    ((RooAbsReal*)negProj)->attachDataSet(*projDataSel) ;
-
-    RooProduct scaledDwa{"scaled_dwa", "Data Weighted average", {dwa, RooFit::RooConst(o.scaleFactor)}};
-    RooRealBinding scaleBind(scaledDwa,*plotVar) ;
+    // Construct scaled data weighted average
+    ScaledDataWeightedAverage scaleBind{funcAsym, *projDataSel, o.scaleFactor, *plotVar};
 
     // Set default range, if not specified
     if (o.rangeLo==0 && o.rangeHi==0) {

--- a/roofit/roofitcore/src/RooDataWeightedAverage.cxx
+++ b/roofit/roofitcore/src/RooDataWeightedAverage.cxx
@@ -30,9 +30,13 @@ plot option.
 
 **/
 
+#define __ROOFIT_SUPPRESS_ROODATAWEIGHTEDAVERAGE_DEPRECATION_WARNING
+// At least for building the implementation we have to suppress the deprecation warning
+#include "RooDataWeightedAverage.h"
+#undef __ROOFIT_SUPPRESS_ROODATAWEIGHTEDAVERAGE_DEPRECATION_WARNING
+
 #include "Riostream.h"
 
-#include "RooDataWeightedAverage.h"
 #include "RooAbsData.h"
 #include "RooAbsPdf.h"
 #include "RooCmdConfig.h"


### PR DESCRIPTION
Use the CPU BatchMode instead of the RooDataWeightedAverage for data
projection plots. This greatly speeds up the plotting of conditional
models when averaging one observable over the dataset.

