### PR TITLE
[RF] Remove useless variable ownership management from RooAbsData

### DIFF
--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -278,8 +278,6 @@ public:
   bool hasFilledCache() const ;
 
   void addOwnedComponent(const char* idxlabel, RooAbsData& data) ;
-  static void claimVars(RooAbsData*) ;
-  static bool releaseVars(RooAbsData*) ;
 
   enum StorageType { Tree, Vector, Composite };
 


### PR DESCRIPTION
Looking at the code, it was probably the idea at some point in the `RooAbsData` design that the ownership of the variables in the dataset can be shared, i.e. that the outside world can "claim" and "release" the variables in a RooAbsData. If anything else is still claiming the variables, they will not be deleted by the RooAbsData destructor.

That's quite messy. For example, if the RooAbsData is destructed before the external "claimers" releases the variables, the claimers suddenly has the responsability to delete the variables themselves. And who of them should do it then? The ownership model is completely unclear.

This and other reasons explain probably why the
`RooAbsData::claimVars()` and `RooAbsData::releaseVars()` are not used at all outside the RooAbsData, and this commit suggests to remove these memory-unsafe functions.