### PR TITLE
[webcanvas] support latest `TScatter` changes

### DIFF
--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -226,8 +226,8 @@ public:
    void SetAsyncMode(Bool_t on = kTRUE) { fAsyncMode = on; }
    Bool_t IsAsyncMode() const { return fAsyncMode; }
 
-   static TString CreatePadJSON(TPad *pad, Int_t json_compression = 0);
-   static TString CreateCanvasJSON(TCanvas *c, Int_t json_compression = 0);
+   static TString CreatePadJSON(TPad *pad, Int_t json_compression = 0, Bool_t batchmode = kFALSE);
+   static TString CreateCanvasJSON(TCanvas *c, Int_t json_compression = 0, Bool_t batchmode = kFALSE);
    static Int_t StoreCanvasJSON(TCanvas *c, const char *filename, const char *option = "");
 
    static bool ProduceImage(TPad *pad, const char *filename, Int_t width = 0, Int_t height = 0);

--- a/gui/webgui6/inc/TWebSnapshot.h
+++ b/gui/webgui6/inc/TWebSnapshot.h
@@ -61,16 +61,18 @@ protected:
    bool fActive{false};                                    ///< true when pad is active
    bool fReadOnly{true};                                   ///< when canvas or pad are in readonly mode
    bool fSetObjectIds{true};                               ///<! set objects ids
+   bool fBatchMode{false};                                 ///<! if object created for image generation
    bool fWithoutPrimitives{false};                         ///< true when primitives not send while there are no modifications
-   bool fHasExecs{false};                                  ///< if true, more interactive evente will be delivered from client
+   bool fHasExecs{false};                                  ///< if true, more interactive events will be delivered from client
    std::vector<std::unique_ptr<TWebSnapshot>> fPrimitives; ///< list of all primitives, drawn in the pad
 
 public:
-   TPadWebSnapshot(bool readonly = true, bool setids = true)
+   TPadWebSnapshot(bool readonly = true, bool setids = true, bool batchmode = false)
    {
       SetKind(kSubPad);
       fReadOnly = readonly;
       fSetObjectIds = setids;
+      fBatchMode = batchmode;
    }
 
    void SetActive(bool on = true) { fActive = on; }
@@ -82,6 +84,8 @@ public:
    bool IsReadOnly() const { return fReadOnly; }
 
    bool IsSetObjectIds() const { return fSetObjectIds; }
+
+   bool IsBatchMode() const { return fBatchMode; }
 
    TWebSnapshot &NewPrimitive(TObject *obj = nullptr, const std::string &opt = "");
 
@@ -99,7 +103,7 @@ protected:
    std::string fScripts;           ///< custom scripts to load
    bool fHighlightConnect{false};  ///< does HighlightConnect has connection
 public:
-   TCanvasWebSnapshot(bool readonly = true, bool setids = true) : TPadWebSnapshot(readonly, setids) {}
+   TCanvasWebSnapshot(bool readonly = true, bool setids = true, bool batchmode = false) : TPadWebSnapshot(readonly, setids, batchmode) {}
 
    void SetScripts(const std::string &src) { fScripts = src; }
    const std::string &GetScripts() const { return fScripts; }

--- a/gui/webgui6/src/TWebSnapshot.cxx
+++ b/gui/webgui6/src/TWebSnapshot.cxx
@@ -68,7 +68,7 @@ TWebSnapshot &TPadWebSnapshot::NewPrimitive(TObject *obj, const std::string &opt
 
 TPadWebSnapshot &TPadWebSnapshot::NewSubPad()
 {
-   auto res = new TPadWebSnapshot(IsReadOnly(), IsSetObjectIds());
+   auto res = new TPadWebSnapshot(IsReadOnly(), IsSetObjectIds(), IsBatchMode());
    fPrimitives.emplace_back(res);
    return *res;
 }

--- a/js/build/jsroot.js
+++ b/js/build/jsroot.js
@@ -11,7 +11,7 @@ let version_id = 'dev';
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-let version_date = '4/07/2023';
+let version_date = '5/07/2023';
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}
@@ -108351,7 +108351,8 @@ class TScatterPainter extends TGraphPainter$1 {
       scatter.fColor = obj.fColor;
       scatter.fSize = obj.fSize;
       scatter.fMargin = obj.fMargin;
-      scatter.fScale = obj.fScale;
+      scatter.fMinMarkerSize = obj.fMinMarkerSize;
+      scatter.fMaxMarkerSize = obj.fMaxMarkerSize;
       super._updateMembers(scatter.fGraph, obj.fGraph);
    }
 
@@ -108389,6 +108390,8 @@ class TScatterPainter extends TGraphPainter$1 {
       if (maxc <= minc) maxc = minc + 1;
       if (maxs <= mins) maxs = mins + 1;
 
+      let scale = (scatter.fMaxMarkerSize - scatter.fMinMarkerSize) / (maxs - mins);
+
       fpainter.zmin = minc;
       fpainter.zmax = maxc;
 
@@ -108404,7 +108407,7 @@ class TScatterPainter extends TGraphPainter$1 {
          let pnt = this.bins[i],
              grx = funcs.grx(pnt.x),
              gry = funcs.gry(pnt.y),
-             size = scatter.fScale * ((scatter.fSize[i] - mins) / (maxs - mins)),
+             size = scatter.fMinMarkerSize + scale * (scatter.fSize[i] - mins),
              color = this.fContour.getPaletteColor(this.fPalette, scatter.fColor[i]);
 
           let handle = new TAttMarkerHandler({ color, size, style: scatter.fMarkerStyle });

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -5,7 +5,7 @@ let version_id = 'dev';
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-let version_date = '4/07/2023';
+let version_date = '5/07/2023';
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}

--- a/js/modules/hist2d/TScatterPainter.mjs
+++ b/js/modules/hist2d/TScatterPainter.mjs
@@ -57,7 +57,8 @@ class TScatterPainter extends TGraphPainter {
       scatter.fColor = obj.fColor;
       scatter.fSize = obj.fSize;
       scatter.fMargin = obj.fMargin;
-      scatter.fScale = obj.fScale;
+      scatter.fMinMarkerSize = obj.fMinMarkerSize;
+      scatter.fMaxMarkerSize = obj.fMaxMarkerSize;
       super._updateMembers(scatter.fGraph, obj.fGraph);
    }
 
@@ -95,6 +96,8 @@ class TScatterPainter extends TGraphPainter {
       if (maxc <= minc) maxc = minc + 1;
       if (maxs <= mins) maxs = mins + 1;
 
+      let scale = (scatter.fMaxMarkerSize - scatter.fMinMarkerSize) / (maxs - mins);
+
       fpainter.zmin = minc;
       fpainter.zmax = maxc;
 
@@ -110,7 +113,7 @@ class TScatterPainter extends TGraphPainter {
          let pnt = this.bins[i],
              grx = funcs.grx(pnt.x),
              gry = funcs.gry(pnt.y),
-             size = scatter.fScale * ((scatter.fSize[i] - mins) / (maxs - mins)),
+             size = scatter.fMinMarkerSize + scale * (scatter.fSize[i] - mins),
              color = this.fContour.getPaletteColor(this.fPalette, scatter.fColor[i]);
 
           let handle = new TAttMarkerHandler({ color, size, style: scatter.fMarkerStyle });


### PR DESCRIPTION
Update JSROOT with `TScatter`

Also add batch mode flag when creating JSON

Data may differ when JSON created for image production or for
interactive drawing. Like interactively TF1 can fail and request new
data with saved buffers. In batch mode saved buffer must be there
to be able do fallback immediately.