### PR TITLE
Automatically add `override` to html with clang-tidy

### DIFF
--- a/html/inc/TClassDocOutput.h
+++ b/html/inc/TClassDocOutput.h
@@ -54,7 +54,7 @@ protected:
 
 public:
    TClassDocOutput(THtml& html, TClass* cl, TList* typedefs);
-   virtual ~TClassDocOutput();
+   ~TClassDocOutput() override;
 
    void           Class2Html(Bool_t force=kFALSE);
    Bool_t         ClassDotCharts(std::ostream & out);
@@ -64,7 +64,7 @@ public:
 
    friend class TDocParser;
 
-   ClassDef(TClassDocOutput, 0); // generates documentation web pages for a class
+   ClassDefOverride(TClassDocOutput, 0); // generates documentation web pages for a class
 };
 
 #endif // ROOT_TClassDocOutput

--- a/html/inc/TDocDirective.h
+++ b/html/inc/TDocDirective.h
@@ -44,9 +44,9 @@ protected:
    TDocDirective() {}
    TDocDirective(const char* name):
       TNamed(name, ""), fDocParser(0), fHtml(0), fDocOutput(0), fCounter(-1) {};
-   virtual ~TDocDirective() {}
+   ~TDocDirective() override {}
 
-   const char* GetName() const { return TNamed::GetName(); }
+   const char* GetName() const override { return TNamed::GetName(); }
    void GetName(TString& name) const;
    TDocParser* GetDocParser() const { return fDocParser; }
    TDocOutput* GetDocOutput() const { return fDocOutput; }
@@ -74,7 +74,7 @@ public:
 
    friend class TDocParser;
 
-   ClassDef(TDocDirective, 0); // THtml directive handler
+   ClassDefOverride(TDocDirective, 0); // THtml directive handler
 };
 
 class TDocHtmlDirective: public TDocDirective {
@@ -83,13 +83,13 @@ private:
    Bool_t  fVerbatim; // whether we are in a <pre></pre> block
 public:
    TDocHtmlDirective(): TDocDirective("HTML"), fVerbatim(kFALSE) {}
-   virtual ~TDocHtmlDirective() {}
+   ~TDocHtmlDirective() override {}
 
-   virtual void AddLine(const TSubString& line);
-   virtual const char* GetEndTag() const { return "end_html"; }
-   virtual Bool_t GetResult(TString& result);
+   void AddLine(const TSubString& line) override;
+   const char* GetEndTag() const override { return "end_html"; }
+   Bool_t GetResult(TString& result) override;
 
-   ClassDef(TDocHtmlDirective, 0); // Handler for "Begin_Html"/"End_Html" for raw HTML in documentation comments
+   ClassDefOverride(TDocHtmlDirective, 0); // Handler for "Begin_Html"/"End_Html" for raw HTML in documentation comments
 };
 
 class TDocMacroDirective: public TDocDirective {
@@ -99,24 +99,24 @@ private:
    Bool_t  fShowSource;    // whether a source tab should be created
    Bool_t  fIsFilename;    // whether the directive is a failename to be executed
 
-   virtual void AddParameter(const TString& name, const char* value = 0);
+   void AddParameter(const TString& name, const char* value = 0) override;
    TString CreateSubprocessInputFile();
 
 public:
    TDocMacroDirective():
       TDocDirective("MACRO"), fMacro(0), fNeedGraphics(kFALSE),
       fShowSource(kFALSE), fIsFilename(kTRUE) {};
-   virtual ~TDocMacroDirective();
+   ~TDocMacroDirective() override;
 
-   virtual void AddLine(const TSubString& line);
-   virtual const char* GetEndTag() const { return "end_macro"; }
-   virtual Bool_t GetResult(TString& result);
+   void AddLine(const TSubString& line) override;
+   const char* GetEndTag() const override { return "end_macro"; }
+   Bool_t GetResult(TString& result) override;
    // Delete output for the parser's current class or module.
-   virtual void DeleteOutput() const { DeleteOutputFiles(".gif"); }
+   void DeleteOutput() const override { DeleteOutputFiles(".gif"); }
 
    static void SubProcess(const TString& what, const TString& out);
 
-   ClassDef(TDocMacroDirective, 0); // Handler for "Begin_Macro"/"End_Macro" for code that is executed and that can generate an image for documentation
+   ClassDefOverride(TDocMacroDirective, 0); // Handler for "Begin_Macro"/"End_Macro" for code that is executed and that can generate an image for documentation
 };
 
 class TDocLatexDirective: public TDocDirective {
@@ -128,18 +128,18 @@ protected:
    TString      fAlignment;   // column alignment: 'l' for justify left, 'c' for center, 'r' for right
    TVirtualPad* fBBCanvas;    // canvas for bounding box determination
 
-   virtual void    CreateLatex(const char* filename);
-   virtual void    AddParameter(const TString& name, const char* value = 0);
+   virtual void CreateLatex(const char* filename);
+           void AddParameter(const TString& name, const char* value = 0) override;
    virtual void GetBoundingBox(TLatex& latex, const char* text, Float_t& width, Float_t& height);
 
 public:
    TDocLatexDirective():
       TDocDirective("LATEX"), fLatex(0), fFontSize(16),
       fSepIsRegexp(kFALSE), fBBCanvas(0) {};
-   virtual ~TDocLatexDirective();
+   ~TDocLatexDirective() override;
 
-   virtual void AddLine(const TSubString& line);
-   virtual const char* GetEndTag() const {return "end_latex";}
+   void AddLine(const TSubString& line) override;
+   const char* GetEndTag() const override {return "end_latex";}
 
    const char* GetAlignment() const {return fAlignment;}
    const char* GetSeparator() const {return fSeparator;}
@@ -147,11 +147,11 @@ public:
    Int_t  GetFontSize() const {return fFontSize;}
    TList* GetListOfLines() const;
 
-   virtual Bool_t GetResult(TString& result);
+   Bool_t GetResult(TString& result) override;
    // Delete output for the parser's current class or module.
-   virtual void DeleteOutput() const { DeleteOutputFiles(".gif"); }
+   void DeleteOutput() const override { DeleteOutputFiles(".gif"); }
 
-   ClassDef(TDocLatexDirective, 0); // Handler for "Begin_Latex"/"End_Latex" to generate an image from latex
+   ClassDefOverride(TDocLatexDirective, 0); // Handler for "Begin_Latex"/"End_Latex" to generate an image from latex
 };
 
 #endif // ROOT_TDocDirective

--- a/html/inc/TDocInfo.h
+++ b/html/inc/TDocInfo.h
@@ -49,14 +49,14 @@ public:
       fDeclFileSysName(fsdecl), fImplFileSysName(fsimpl),
       fSelected(kTRUE) { }
 
-   virtual ~TClassDocInfo()
+   ~TClassDocInfo() override
    {
       // Required since we overload TObject::Hash.
       ROOT::CallRecursiveRemoveIfNeeded(*this);
    }
 
    TDictionary *GetClass() const { return fClass; }
-   virtual const char*     GetName() const;
+           const char*     GetName() const override;
            const char*     GetHtmlFileName() const { return fHtmlFileName; }
            const char*     GetDeclFileName() const { return fDeclFileName; }
            const char*     GetImplFileName() const { return fImplFileName; }
@@ -77,12 +77,12 @@ public:
            void            SetDeclFileSysName(const char* fsname) { fDeclFileSysName = fsname; }
            void            SetImplFileSysName(const char* fsname) { fImplFileSysName = fsname; }
 
-           ULong_t         Hash() const;
+           ULong_t         Hash() const override;
 
            TList&          GetListOfTypedefs() { return fTypedefs; }
 
-   virtual Bool_t          IsSortable() const { return kTRUE; }
-   virtual Int_t           Compare(const TObject* obj) const;
+   Bool_t          IsSortable() const override { return kTRUE; }
+   Int_t           Compare(const TObject* obj) const override;
 
 private:
    TClassDocInfo();
@@ -97,7 +97,7 @@ private:
    TList                   fTypedefs; // typedefs to this class
    Bool_t                  fSelected; // selected for doc output
 
-   ClassDef(TClassDocInfo,0); // info cache for class documentation
+   ClassDefOverride(TClassDocInfo,0); // info cache for class documentation
 };
 
 //____________________________________________________________________
@@ -110,7 +110,7 @@ public:
       TNamed(name, doc), fSuper(super), fSub(0), fSelected(kTRUE) {
          if (super) super->GetSub().Add(this);
       }
-   virtual ~TModuleDocInfo() { fSub.Clear("nodelete"); fClasses.Clear("nodelete"); }
+   ~TModuleDocInfo() override { fSub.Clear("nodelete"); fClasses.Clear("nodelete"); }
 
    void        SetDoc(const char* doc) { SetTitle(doc); }
    const char* GetDoc() const { return GetTitle(); }
@@ -130,7 +130,7 @@ private:
    TList       fClasses;
    Bool_t      fSelected; // selected for doc output
 
-   ClassDef(TModuleDocInfo,0); // documentation for a group of classes
+   ClassDefOverride(TModuleDocInfo,0); // documentation for a group of classes
 };
 
 //__________________________________________________________________________
@@ -152,7 +152,7 @@ class TLibraryDocInfo: public TNamed {
    std::set<std::string> fDependencies; // dependencies on other libraries
    std::set<std::string> fModules; // modules in the library
 
-   ClassDef(TLibraryDocInfo,0); // documentation for a library
+   ClassDefOverride(TLibraryDocInfo,0); // documentation for a library
 };
 
 

--- a/html/inc/TDocOutput.h
+++ b/html/inc/TDocOutput.h
@@ -65,7 +65,7 @@ public:
    enum EFileType { kSource, kInclude, kTree, kDoc };
 
    TDocOutput(THtml& html);
-   virtual ~TDocOutput();
+   ~TDocOutput() override;
 
    virtual void   AdjustSourcePath(TString& line, const char* relpath = "../");
    void           Convert(std::istream& in, const char* infilename,
@@ -107,7 +107,7 @@ public:
                                   const char *author="", const char *copyright="");
    void           WriteLineNumbers(std::ostream& out, Long_t nLines, const TString& infileBase) const;
 
-   ClassDef(TDocOutput, 0); // generates documentation web pages
+   ClassDefOverride(TDocOutput, 0); // generates documentation web pages
 };
 
 #endif // ROOT_TDocOutput

--- a/html/inc/TDocParser.h
+++ b/html/inc/TDocParser.h
@@ -158,7 +158,7 @@ protected:
 public:
    TDocParser(TClassDocOutput& docOutput, TClass* cl);
    TDocParser(TDocOutput& docOutput);
-   virtual       ~TDocParser();
+         ~TDocParser() override;
 
    static void   AnchorFromLine(const TString& line, TString& anchor);
    void          Convert(std::ostream& out, std::istream& in, const char* relpath,
@@ -184,7 +184,7 @@ public:
    virtual void  Parse(std::ostream& out);
    static Bool_t Strip(TString& s);
 
-   ClassDef(TDocParser,0); // parser for reference documentation
+   ClassDefOverride(TDocParser,0); // parser for reference documentation
 };
 
 #endif // ROOT_TDocParser

--- a/html/inc/THtml.h
+++ b/html/inc/THtml.h
@@ -44,12 +44,12 @@ public:
    class THelperBase: public TObject {
    public:
       THelperBase(): fHtml(0) {}
-      virtual ~THelperBase();
+      ~THelperBase() override;
       void    SetOwner(THtml* html);
       THtml*  GetOwner() const { return fHtml; }
    private:
       THtml*  fHtml; // object owning the helper
-      ClassDef(THelperBase, 0); // a helper object's base class
+      ClassDefOverride(THelperBase, 0); // a helper object's base class
    };
 
    class TFileSysEntry;
@@ -61,7 +61,7 @@ public:
    class TModuleDefinition: public THelperBase {
    public:
       virtual bool GetModule(TClass* cl, TFileSysEntry* fse, TString& out_modulename) const;
-      ClassDef(TModuleDefinition, 0); // helper class to determine a class's module
+      ClassDefOverride(TModuleDefinition, 0); // helper class to determine a class's module
    };
 
    //______________________________________________________________
@@ -82,7 +82,7 @@ public:
       void SplitClassIntoDirFile(const TString& clname, TString& dir, TString& filename) const;
       void NormalizePath(TString& path) const;
       void ExpandSearchPath(TString& path) const;
-      ClassDef(TFileDefinition, 0); // helper class to determine a class's source files
+      ClassDefOverride(TFileDefinition, 0); // helper class to determine a class's source files
    };
 
    //______________________________________________________________
@@ -96,7 +96,7 @@ public:
       virtual bool GetFileNameFromInclude(const char* included, TString& out_fsname) const;
       virtual bool GetDocDir(const TString& module, TString& doc_dir) const;
    protected:
-      ClassDef(TPathDefinition, 0); // helper class to determine directory layouts
+      ClassDefOverride(TPathDefinition, 0); // helper class to determine directory layouts
    };
 
    class TFileSysDir;
@@ -107,13 +107,13 @@ public:
    public:
       TFileSysEntry(const char* name, TFileSysDir* parent):
          fName(name), fParent(parent), fLevel(parent ? parent->GetLevel() + 1 : 0) {}
-      ~TFileSysEntry()
+      ~TFileSysEntry() override
       {
          // Required since we overload TObject::Hash.
          ROOT::CallRecursiveRemoveIfNeeded(*this);
       }
-      const char* GetName() const { return fName; }
-      virtual ULong_t Hash() const { return fName.Hash(); }
+      const char* GetName() const override { return fName; }
+      ULong_t Hash() const override { return fName.Hash(); }
       virtual void GetFullName(TString& fullname, Bool_t asIncluded) const {
          if (fParent) {
             fParent->GetFullName(fullname, asIncluded);
@@ -130,7 +130,7 @@ public:
       TString      fName; // name of the element
       TFileSysDir* fParent; // parent directory
       Int_t        fLevel; // level of directory
-      ClassDef(TFileSysEntry, 0); // an entry of the local file system
+      ClassDefOverride(TFileSysEntry, 0); // an entry of the local file system
    };
 
    //______________________________________________________________
@@ -148,7 +148,7 @@ public:
    protected:
       TList fFiles;
       TList fDirs;
-      ClassDef(TFileSysDir, 0); // an directory of the local file system
+      ClassDefOverride(TFileSysDir, 0); // an directory of the local file system
    };
 
    //______________________________________________________________
@@ -158,7 +158,7 @@ public:
    public:
       TFileSysRoot(const char* name, TFileSysDB* parent):
          TFileSysDir(name, parent) {}
-      void GetFullName(TString& fullname, Bool_t asIncluded) const {
+      void GetFullName(TString& fullname, Bool_t asIncluded) const override {
          // prepend directory part of THtml::GetInputPath() only
          // if !asIncluded
          fullname = "";
@@ -166,7 +166,7 @@ public:
             fullname += fName;
       }
 
-      ClassDef(TFileSysRoot, 0); // an root directory of the local file system
+      ClassDefOverride(TFileSysRoot, 0); // an root directory of the local file system
    };
 
    //______________________________________________________________
@@ -190,7 +190,7 @@ public:
       THashTable fEntries; // hash map of all filenames without paths
       TString  fIgnorePath; // regexp of path to ignore while building entry tree
       Int_t    fMaxLevel; // maximum level of directory nesting
-      ClassDef(TFileSysDB, 0); // instance of file system data
+      ClassDefOverride(TFileSysDB, 0); // instance of file system data
    };
 
 
@@ -239,7 +239,7 @@ public:
    };
 
    THtml();
-   virtual      ~THtml();
+   ~THtml() override;
 
    static void   LoadAllLibs();
 
@@ -423,7 +423,7 @@ protected:
    mutable TFileSysDB    *fLocalFiles; // files found locally for a given source path
    Bool_t  fBatch; // Whether to enable GUI output
 
-   ClassDef(THtml,0)  //Convert class(es) into HTML file(s)
+   ClassDefOverride(THtml,0)  //Convert class(es) into HTML file(s)
 };
 
 R__EXTERN THtml *gHtml;

--- a/html/src/TDocParser.cxx
+++ b/html/src/TDocParser.cxx
@@ -40,15 +40,15 @@ namespace {
 
       static void SetClass(const TClass* cl) { fgClass = cl; }
 
-      const char* GetName() const { return fMeth->GetName(); }
-      ULong_t Hash() const { return fMeth->Hash();}
+      const char* GetName() const override { return fMeth->GetName(); }
+      ULong_t Hash() const override { return fMeth->Hash();}
       Int_t GetNargs() const { return fMeth->GetNargs(); }
-      virtual TMethod* GetMethod() const { return fMeth; }
-      Bool_t IsSortable() const { return kTRUE; }
+      TMethod* GetMethod() const override { return fMeth; }
+      Bool_t IsSortable() const override { return kTRUE; }
 
-      Int_t GetOverloadIdx() const { return fOverloadIdx; }
+      Int_t GetOverloadIdx() const override { return fOverloadIdx; }
 
-      Int_t Compare(const TObject *obj) const {
+      Int_t Compare(const TObject *obj) const override {
          const TMethodWrapperImpl* m = dynamic_cast<const TMethodWrapperImpl*>(obj);
          if (!m) return 1;
 


### PR DESCRIPTION
This commit only contains changes that were automatically generated by `clang-tidy`, plus replacing `ClassDef` with `ClassDefOverride` where appropriate.

Several directories in the ROOT repo were already treated like this.