### PR TITLE
Automatically add `override` to montecarlo with clang-tidy

### DIFF
--- a/montecarlo/eg/inc/TAttParticle.h
+++ b/montecarlo/eg/inc/TAttParticle.h
@@ -47,7 +47,7 @@ public:
                 Double_t DecayWidth, Double_t Charge, const char *Type,
                 Int_t MCnumber, Int_t granularity=90,
                 Double_t LowerCutOff=1.e-5, Double_t HighCutOff=1.e4);
-   virtual ~TAttParticle();
+   ~TAttParticle() override;
    static  THashList     *fgList;
    static  Int_t          ConvertISAtoPDG(Int_t isaNumber);
    static  void           DefinePDG();
@@ -62,11 +62,11 @@ public:
    static  TAttParticle  *GetParticle(Int_t mcnumber);
    virtual const char    *GetParticleType() const { return fParticleType.Data(); }
    virtual Bool_t         GetStable() const { return fPDGStable; }
-   virtual void           Print(Option_t *option="") const ;
+   void           Print(Option_t *option="") const override ;
    virtual Double_t       SampleMass() const ;
    virtual Double_t       SampleMass(Double_t widthcut) const ;
 
-   ClassDef(TAttParticle,1)  //Particle definition
+   ClassDefOverride(TAttParticle,1)  //Particle definition
 };
 
 #endif

--- a/montecarlo/eg/inc/TDatabasePDG.h
+++ b/montecarlo/eg/inc/TDatabasePDG.h
@@ -40,7 +40,7 @@ protected:
 public:
 
    TDatabasePDG();
-   virtual ~TDatabasePDG();
+   ~TDatabasePDG() override;
 
    static TDatabasePDG*  Instance();
 
@@ -71,15 +71,15 @@ public:
 
    const THashList *ParticleList() const { return fParticleList; }
 
-   virtual void   Print(Option_t *opt = "") const;
+   void   Print(Option_t *opt = "") const override;
 
-   Bool_t IsFolder() const { return kTRUE; }
-   virtual void   Browse(TBrowser* b);
+   Bool_t IsFolder() const override { return kTRUE; }
+   void   Browse(TBrowser* b) override;
 
    virtual void   ReadPDGTable (const char *filename = "");
    virtual Int_t  WritePDGTable(const char *filename);
 
-   ClassDef(TDatabasePDG, 3);  // PDG particle database
+   ClassDefOverride(TDatabasePDG, 3);  // PDG particle database
 };
 
 #endif

--- a/montecarlo/eg/inc/TDecayChannel.h
+++ b/montecarlo/eg/inc/TDecayChannel.h
@@ -36,7 +36,7 @@ public:
                  Int_t     NDaughters,
                  Int_t*    DaughterPdgCode);
 
-   virtual ~TDecayChannel();
+   ~TDecayChannel() override;
    // ****** accessors
 
    Int_t     Number                () { return fNumber; }
@@ -45,7 +45,7 @@ public:
    Double_t  BranchingRatio        () { return fBranchingRatio; }
    Int_t     DaughterPdgCode(Int_t i) { return fDaughters.fArray[i]; }
 
-   ClassDef(TDecayChannel,1)   // Class describing a particle decay channel
+   ClassDefOverride(TDecayChannel,1)   // Class describing a particle decay channel
 };
 
 #endif

--- a/montecarlo/eg/inc/TGenerator.h
+++ b/montecarlo/eg/inc/TGenerator.h
@@ -75,7 +75,7 @@
 //       MyGenerator(const MyGenerator& o) { ... }                      //
 //       MyGenerator& operator=(const MyGenerator& o) { ... }           //
 //       static MyGenerator* fgInstance;                                //
-//       ClassDef(MyGenerator,0);                                       //
+//       ClassDefOverride(MyGenerator,0);                               //
 //     };                                                               //
 //                                                                      //
 // Having multiple objects accessing the same common blocks is not      //
@@ -107,7 +107,7 @@
 //       ...                                                            //
 //     protected:                                                       //
 //       TGenerator* fGenerator;                                        //
-//       ClassDef(MyRun,0);                                             //
+//       ClassDefOverride(MyRun,0);                                     //
 //     };                                                               //
 //                                                                      //
 //     // Config.C                                                      //
@@ -162,21 +162,21 @@ public:
 
    TGenerator(): fPtCut(0), fShowNeutrons(kTRUE), fParticles(0) { } //Used by Dictionary
    TGenerator(const char *name, const char *title="Generator class");
-   virtual ~TGenerator();
-   virtual void            Browse(TBrowser *b);
-   virtual Int_t           DistancetoPrimitive(Int_t px, Int_t py);
-   virtual void            Draw(Option_t *option="");
-   virtual void            ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   ~TGenerator() override;
+           void            Browse(TBrowser *b) override;
+           Int_t           DistancetoPrimitive(Int_t px, Int_t py) override;
+           void            Draw(Option_t *option="") override;
+           void            ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
    virtual void            GenerateEvent();
    virtual Double_t        GetParameter(const char* /*name*/) const { return 0.; }
    virtual Int_t           ImportParticles(TClonesArray *particles, Option_t *option="");
    virtual TObjArray      *ImportParticles(Option_t *option="");
    virtual TParticle      *GetParticle(Int_t i) const;
-   Int_t                   GetNumberOfParticles() const;
+           Int_t           GetNumberOfParticles() const;
    virtual TObjArray      *GetListOfParticles() const {return fParticles;}
    virtual TObjArray      *GetPrimaries(Option_t *option="") {return ImportParticles(option);}
-   Float_t                 GetPtCut() const {return fPtCut;}
-   virtual void            Paint(Option_t *option="");
+           Float_t         GetPtCut() const {return fPtCut;}
+           void            Paint(Option_t *option="") override;
    virtual void            SetParameter(const char* /*name*/,Double_t /*val*/){}
    virtual void            SetPtCut(Float_t ptcut=0); // *MENU*
    virtual void            SetViewRadius(Float_t rbox = 1000); // *MENU*
@@ -184,7 +184,7 @@ public:
                                        ,Float_t xmax=10000,Float_t ymax=10000,Float_t zmax=10000);  // *MENU*
    virtual void            ShowNeutrons(Bool_t show=1); // *MENU*
 
-   ClassDef(TGenerator,1)  //Event generator interface abstract baseclass
+   ClassDefOverride(TGenerator,1); //Event generator interface abstract baseclass
 };
 
 #endif

--- a/montecarlo/eg/inc/TParticle.h
+++ b/montecarlo/eg/inc/TParticle.h
@@ -71,7 +71,7 @@ public:
 
    TParticle(const TParticle &part);
 
-   virtual ~TParticle();
+   ~TParticle() override;
 
    TParticle& operator=(const TParticle&);
 
@@ -170,16 +170,16 @@ public:
 
              // ****** overloaded functions of TObject
 
-   virtual void      Paint(Option_t *option = "");
-   virtual void      Print(Option_t *option = "") const;
-   virtual void      Sizeof3D() const;
-   virtual Int_t     DistancetoPrimitive(Int_t px, Int_t py);
-   virtual void      ExecuteEvent(Int_t event, Int_t px, Int_t py);
-   virtual const     char *GetName() const;
-   virtual const     char *GetTitle() const;
+   void      Paint(Option_t *option = "") override;
+   void      Print(Option_t *option = "") const override;
+   void      Sizeof3D() const override;
+   Int_t     DistancetoPrimitive(Int_t px, Int_t py) override;
+   void      ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
+   const     char *GetName() const override;
+   const     char *GetTitle() const override;
 
 
-   ClassDef(TParticle,2)  // TParticle vertex particle information
+   ClassDefOverride(TParticle,2)  // TParticle vertex particle information
 };
 
 #endif

--- a/montecarlo/eg/inc/TParticleClassPDG.h
+++ b/montecarlo/eg/inc/TParticleClassPDG.h
@@ -36,7 +36,7 @@ public:
    // ****** constructors  and destructor
 
    TParticleClassPDG(const char* name = 0);
-   virtual ~TParticleClassPDG();
+   ~TParticleClassPDG() override;
    // ****** access methods
 
    Int_t   GetNParticles () {
@@ -55,12 +55,12 @@ public:
 
    // ****** overloaded methods of TObject
 
-   virtual void    Print(Option_t* opt="") const; // *MENU*
+   void    Print(Option_t* opt="") const override; // *MENU*
 
-   Bool_t IsFolder() const { return kTRUE; }
-   virtual void   Browse(TBrowser* b);
+   Bool_t IsFolder() const override { return kTRUE; }
+   void   Browse(TBrowser* b) override;
 
-   ClassDef(TParticleClassPDG,1)  // PDG static particle definition
+   ClassDefOverride(TParticleClassPDG,1)  // PDG static particle definition
 };
 
 #endif

--- a/montecarlo/eg/inc/TParticlePDG.h
+++ b/montecarlo/eg/inc/TParticlePDG.h
@@ -60,7 +60,7 @@ public:
                 const char* ParticleClass, Int_t PdgCode, Int_t Anti,
                 Int_t TrackingCode);
 
-   virtual ~TParticlePDG();
+   ~TParticlePDG() override;
    // ****** access methods
 
    Int_t           PdgCode      () const { return fPdgCode; }
@@ -105,9 +105,9 @@ public:
 
    virtual void  PrintDecayChannel(TDecayChannel* dc, Option_t* opt = "") const;
 
-   virtual void  Print(Option_t* opt = "") const; // *MENU*
+   void  Print(Option_t* opt = "") const override; // *MENU*
 
-   ClassDef(TParticlePDG,2)  // PDG static particle definition
+   ClassDefOverride(TParticlePDG,2)  // PDG static particle definition
 };
 
 #endif

--- a/montecarlo/eg/inc/TPrimary.h
+++ b/montecarlo/eg/inc/TPrimary.h
@@ -52,12 +52,12 @@ public:
             Double_t px, Double_t py, Double_t pz,
             Double_t etot, Double_t vx, Double_t vy, Double_t vz,
             Double_t time, Double_t timend, const char *type = "");
-   virtual ~TPrimary();
-   virtual Int_t         DistancetoPrimitive(Int_t px, Int_t py);
-   virtual void          ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   ~TPrimary() override;
+           Int_t         DistancetoPrimitive(Int_t px, Int_t py) override;
+           void          ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
    virtual const TAttParticle  *GetParticle() const;
-   virtual const char   *GetName() const;
-   virtual const char   *GetTitle() const;
+           const char   *GetName() const override;
+           const char   *GetTitle() const override;
    virtual Int_t         GetFirstMother() const { return fFirstMother; }
    virtual Int_t         GetSecondMother() const { return fSecondMother; }
    virtual Int_t         GetGeneration() const { return fGeneration; }
@@ -71,11 +71,11 @@ public:
    virtual Double_t      GetTime() const { return fTime; }
    virtual Double_t      GetTimeEnd() const { return fTimeEnd; }
    virtual const char   *GetType() const { return fType.Data(); }
-   virtual void          Paint(Option_t *option = "");
-   virtual void          Print(Option_t *option = "") const;
-   virtual void          Sizeof3D() const;
+           void          Paint(Option_t *option = "") override;
+           void          Print(Option_t *option = "") const override;
+           void          Sizeof3D() const override;
 
-   ClassDef(TPrimary,1)  //TPrimary vertex particle information
+   ClassDefOverride(TPrimary,1); //TPrimary vertex particle information
 };
 
 #endif

--- a/montecarlo/eg/inc/TVirtualMCDecayer.h
+++ b/montecarlo/eg/inc/TVirtualMCDecayer.h
@@ -24,7 +24,7 @@ class TVirtualMCDecayer : public TObject {
 public:
 //
    TVirtualMCDecayer() {;}
-   virtual ~TVirtualMCDecayer(){;}
+   ~TVirtualMCDecayer() override{;}
 
    /// Initialize the decayer
    virtual void    Init()                                     =0;
@@ -54,7 +54,7 @@ public:
    /// SetDecayTableFile.
    virtual void    ReadDecayTable()                           =0;
  
-   ClassDef(TVirtualMCDecayer,1) // Particle Decayer Base Class
+   ClassDefOverride(TVirtualMCDecayer,1) // Particle Decayer Base Class
 };
 
 #endif

--- a/montecarlo/eg/src/TGenerator.cxx
+++ b/montecarlo/eg/src/TGenerator.cxx
@@ -78,7 +78,7 @@ class a singleton.  That is, something like
       MyGenerator(const MyGenerator& o) { ... }                      
       MyGenerator& operator=(const MyGenerator& o) { ... }           
       static MyGenerator* fgInstance;                                
-      ClassDef(MyGenerator,0);                                       
+      ClassDefOverride(MyGenerator,0);                                       
     };                                                               
 \endverbatim
                                                                      
@@ -112,7 +112,7 @@ ly used in compiled code:
       ...                                                            
     protected:                                                       
       TGenerator* fGenerator;                                        
-      ClassDef(MyRun,0);                                             
+      ClassDefOverride(MyRun,0);                                             
     };                                                               
                                                                      
     // Config.C                                                      

--- a/montecarlo/pythia6/inc/TMCParticle.h
+++ b/montecarlo/pythia6/inc/TMCParticle.h
@@ -69,7 +69,7 @@ public:
                fLifetime(lifetime) { }
 
 
-   virtual             ~TMCParticle() { }
+               ~TMCParticle() override { }
 
    Int_t       GetKS() const {return fKS;}
    Int_t       GetKF() const {return fKF;}
@@ -88,7 +88,7 @@ public:
    Float_t     GetVz() const {return fVz;}
    Float_t     GetTime() const {return fTime;}
    Float_t     GetLifetime() const {return fLifetime;}
-   virtual const char     *GetName() const;
+   const char     *GetName() const override;
 
    virtual void        SetKS(Int_t kS) {fKS=kS;}
    virtual void        SetKF(Int_t kF) {fKF=kF;}
@@ -109,9 +109,9 @@ public:
    virtual void        SetLifetime(Float_t lifetime) {fLifetime=lifetime;}
 
 
-   virtual void        ls(Option_t* option) const;
+   void        ls(Option_t* option) const override;
 
-   ClassDef(TMCParticle,1)  // LUJETS particles data record.
+   ClassDefOverride(TMCParticle,1)  // LUJETS particles data record.
 };
 
 #endif

--- a/montecarlo/pythia6/inc/TPythia6.h
+++ b/montecarlo/pythia6/inc/TPythia6.h
@@ -121,7 +121,7 @@ protected:
 public:
    // ****** constructors and destructor
    TPythia6();
-   virtual ~TPythia6();
+   ~TPythia6() override;
 
    static TPythia6 *Instance();
 
@@ -293,12 +293,12 @@ public:
 
    // ****** TPYTHIA routines
 
-   void             GenerateEvent();
+   void             GenerateEvent() override;
 
    void             Initialize(const char *frame, const char *beam, const char *target, float win);
 
-   Int_t            ImportParticles(TClonesArray *particles, Option_t *option="");
-   TObjArray       *ImportParticles(Option_t *option="");
+   Int_t            ImportParticles(TClonesArray *particles, Option_t *option="") override;
+   TObjArray       *ImportParticles(Option_t *option="") override;
 
    void             OpenFortranFile(int lun, char* name);
    void             CloseFortranFile(int lun);
@@ -324,7 +324,7 @@ public:
    void             Pyupda(int mupda, int lun);
    void             SetupTest();
 
-   ClassDef(TPythia6,0)  //Interface to Pythia6.1 Event Generator
+   ClassDefOverride(TPythia6,0)  //Interface to Pythia6.1 Event Generator
 };
 
 #endif

--- a/montecarlo/pythia6/inc/TPythia6Decayer.h
+++ b/montecarlo/pythia6/inc/TPythia6Decayer.h
@@ -72,18 +72,18 @@ protected:
 
 public:
    TPythia6Decayer();
-   virtual ~TPythia6Decayer() { }
-   virtual void    Init();
-   virtual void    Decay(Int_t idpart, TLorentzVector* p);
-   virtual Int_t   ImportParticles(TClonesArray *particles);
-   virtual void    SetForceDecay(Int_t type);
-   virtual void    ForceDecay();
+   ~TPythia6Decayer() override { }
+   void    Init() override;
+   void    Decay(Int_t idpart, TLorentzVector* p) override;
+   Int_t   ImportParticles(TClonesArray *particles) override;
+   void    SetForceDecay(Int_t type) override;
+   void    ForceDecay() override;
    void ForceParticleDecay(Int_t particle, Int_t* products,
                            Int_t* mult, Int_t npart);
    void ForceParticleDecay(Int_t particle, Int_t product, Int_t mult);
-   virtual Float_t GetPartialBranchingRatio(Int_t ipart);
-   virtual Float_t GetLifetime(Int_t kf);
-   virtual void    ReadDecayTable();
+   Float_t GetPartialBranchingRatio(Int_t ipart) override;
+   Float_t GetLifetime(Int_t kf) override;
+   void    ReadDecayTable() override;
    // Extension member functions
    virtual void    SetDecayTableFile(const char* name);
    virtual void    WriteDecayTable();
@@ -91,7 +91,7 @@ public:
 
    static  TPythia6Decayer *Instance();
 
-   ClassDef(TPythia6Decayer,1) // Particle Decayer Base Class
+   ClassDefOverride(TPythia6Decayer,1) // Particle Decayer Base Class
 };
 
 inline void TPythia6Decayer::SetDecayTableFile(const char *name)

--- a/montecarlo/pythia8/inc/TPythia8.h
+++ b/montecarlo/pythia8/inc/TPythia8.h
@@ -84,14 +84,14 @@ protected:
 public:
    TPythia8(bool printBanner = true);
    TPythia8(const char *xmlDir, bool printBanner = true);
-   virtual ~TPythia8();
+   ~TPythia8() override;
    static TPythia8        *Instance();
    Pythia8::Pythia        *Pythia8() {return fPythia;}
 
    // Interface
-   virtual void            GenerateEvent();
-   virtual Int_t           ImportParticles(TClonesArray *particles, Option_t *option="");
-   virtual TObjArray      *ImportParticles(Option_t *option="");
+   void            GenerateEvent() override;
+   Int_t           ImportParticles(TClonesArray *particles, Option_t *option="") override;
+   TObjArray      *ImportParticles(Option_t *option="") override;
 
    // Others
    void                    ReadString(const char* string) const;
@@ -107,7 +107,7 @@ public:
    void                    EventListing() const;
    Int_t                   GetN() const;
 
-   ClassDef(TPythia8, 1)   // Interface class of Pythia8
+   ClassDefOverride(TPythia8, 1)   // Interface class of Pythia8
 };
 
 #endif

--- a/montecarlo/pythia8/inc/TPythia8Decayer.h
+++ b/montecarlo/pythia8/inc/TPythia8Decayer.h
@@ -16,15 +16,15 @@ class TPythia8;
 class TPythia8Decayer : public TVirtualMCDecayer {
 public:
    TPythia8Decayer();
-   virtual ~TPythia8Decayer(){;}
-   virtual void    Init();
-   virtual void    Decay(Int_t pdg, TLorentzVector* p);
-   virtual Int_t   ImportParticles(TClonesArray *particles);
-   virtual void    SetForceDecay(Int_t type);
-   virtual void    ForceDecay();
-   virtual Float_t GetPartialBranchingRatio(Int_t ipart);
-   virtual Float_t GetLifetime(Int_t kf);
-   virtual void    ReadDecayTable();
+   ~TPythia8Decayer() override{;}
+   void    Init() override;
+   void    Decay(Int_t pdg, TLorentzVector* p) override;
+   Int_t   ImportParticles(TClonesArray *particles) override;
+   void    SetForceDecay(Int_t type) override;
+   void    ForceDecay() override;
+   Float_t GetPartialBranchingRatio(Int_t ipart) override;
+   Float_t GetLifetime(Int_t kf) override;
+   void    ReadDecayTable() override;
 
    virtual void    SetDebugLevel(Int_t debug) {fDebug = debug;}
 protected:
@@ -34,7 +34,7 @@ private:
    TPythia8* fPythia8;          // Pointer to pythia8
    Int_t     fDebug;            // Debug level
 
-   ClassDef(TPythia8Decayer, 1) // Particle Decayer using Pythia8
+   ClassDefOverride(TPythia8Decayer, 1) // Particle Decayer using Pythia8
 
 };
 #endif


### PR DESCRIPTION
This commit only contains changes that were automatically generated by `clang-tidy`, plus replacing `ClassDef` with `ClassDefOverride` where appropriate.

Several directories in the ROOT repo were already treated like this.