### PR TITLE
[DF] Make it possible to convert RResultMap to RResultHandle

### DIFF
--- a/README/ReleaseNotes/v630/index.md
+++ b/README/ReleaseNotes/v630/index.md
@@ -34,6 +34,7 @@ The following people have contributed to this new version:
  Wouter Verkerke, NIKHEF/Atlas,
 
 ## Deprecation and Removal
+- `ROOT::RDF::RResultHandle::GetResultPtr` has been deprecated. Please use `RResultPtr` directly instead and only cast to `RResultHandle` in order to call `ROOT::RDF::RunGraphs`.
 - The RDataFrame factory functions `MakeCsvDataFrame`, `MakeArrowDataFrame`, `MakeNTupleDataFrame` and `MakeSqliteDataFrame` that were deprecated in v6.28 have been removed. Use `FromCSV`, `FromArrow`, `FromRNTuple` or `FromSqlite` instead.
 - The TStorage reallocation routine without a size (`TStorage::ReAlloc(void *ovp, size_t size`) and heap related routines (`TStorage::AddToHeap`, `TStorage::IsOnHeap`, `TStorage::GetHeapBegin`, `TStorage::GetHeapEnd`) that were deprecated in v6.02/00 have been removed.
 - The deprecated `Format(const char* option, int sigDigits)` option for `RooAbsPdf::paramOn()` was removed. Please use the `Format(const char* option, ...)` overload that takes command arguments.

--- a/tree/dataframe/inc/ROOT/RDF/RResultMap.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RResultMap.hxx
@@ -90,6 +90,8 @@ ROOT::RDF::Experimental::RResultMap<T> CloneResultAndAction(const ROOT::RDF::Exp
 
 namespace RDF {
 
+class RResultHandle;
+
 namespace Experimental {
 
 template <typename T>
@@ -111,6 +113,7 @@ class RResultMap {
    friend RResultMap ROOT::Internal::RDF::CloneResultAndAction<T>(const RResultMap<T> &inmap);
    friend std::unique_ptr<ROOT::Detail::RDF::RMergeableVariations<T>>
    ROOT::Detail::RDF::GetMergeableValue<T>(RResultMap<T> &rmap);
+   friend class ::ROOT::RDF::RResultHandle;
 
    // The preconditions are that results and keys have the same size, are ordered the same way, and keys are unique.
    RResultMap(std::shared_ptr<T> &&nominalResult, std::vector<std::shared_ptr<T>> &&variedResults,

--- a/tree/dataframe/inc/ROOT/RResultHandle.hxx
+++ b/tree/dataframe/inc/ROOT/RResultHandle.hxx
@@ -96,6 +96,7 @@ public:
    /// Get an RResultPtr to the encapsulated object.
    /// \tparam T Type of the action result
    template <class T>
+   R__DEPRECATED(6, 32, "Please use RResultPtr directly and only cast to RResultHandle in order to call RunGraphs.")
    RResultPtr<T> GetResultPtr()
    {
       CheckType(typeid(T));

--- a/tree/dataframe/inc/ROOT/RResultHandle.hxx
+++ b/tree/dataframe/inc/ROOT/RResultHandle.hxx
@@ -24,12 +24,21 @@
 namespace ROOT {
 namespace RDF {
 
+/// \brief A type-erased version of RResultPtr and RResultMap.
+/// RResultHandles are used to invoke ROOT::RDF::RunGraphs() and can also be useful
+/// to store result pointers of different types in the same collection. Knowledge
+/// about the actual result type will still be needed to access it.
+/// \note Varied results are stripped away when a RResultMap is converted to a RResultHandle:
+///       Only the nominal result will be accessible from the RResultHandle.
 class RResultHandle {
    ROOT::Detail::RDF::RLoopManager *fLoopManager = nullptr; //< Pointer to the loop manager
    /// Owning pointer to the action that will produce this result.
    /// Ownership is shared with RResultPtrs and RResultHandles that refer to the same result.
    std::shared_ptr<ROOT::Internal::RDF::RActionBase> fActionPtr;
    std::shared_ptr<void> fObjPtr; ///< Type erased shared pointer encapsulating the wrapped result
+   /// Owning pointer to the varied action that will produce these results if any.
+   /// Null if the RResultHandle was created from a RResultPtr, so no variations were present.
+   std::shared_ptr<ROOT::Internal::RDF::RActionBase> fVariedActionPtr;
    const std::type_info *fType = nullptr; ///< Type of the wrapped result
 
    // The ROOT::RDF::RunGraphs helper has to access the loop manager to check whether two RResultHandles belong to the same computation graph
@@ -66,6 +75,15 @@ class RResultHandle {
 public:
    template <class T>
    RResultHandle(const RResultPtr<T> &resultPtr) : fLoopManager(resultPtr.fLoopManager), fActionPtr(resultPtr.fActionPtr), fObjPtr(resultPtr.fObjPtr), fType(&typeid(T)) {}
+   template <class T>
+   RResultHandle(const Experimental::RResultMap<T> &resultMap)
+      : fLoopManager(resultMap.fLoopManager),
+        fActionPtr(resultMap.fNominalAction),
+        fObjPtr(resultMap.fMap.at("nominal")),
+        fVariedActionPtr(resultMap.fVariedAction),
+        fType(&typeid(T))
+   {
+   }
 
    RResultHandle(const RResultHandle&) = default;
    RResultHandle(RResultHandle&&) = default;
@@ -73,6 +91,7 @@ public:
 
    /// Get the pointer to the encapsulated object.
    /// Triggers event loop and execution of all actions booked in the associated RLoopManager.
+   /// If the RResultHandle was created from a RResultMap, this returns a pointer to the nominal value.
    /// \tparam T Type of the action result
    template <class T>
    T* GetPtr()
@@ -84,6 +103,7 @@ public:
 
    /// Get a const reference to the encapsulated object.
    /// Triggers event loop and execution of all actions booked in the associated RLoopManager.
+   /// If the RResultHandle was created from a RResultMap, this returns a pointer to the nominal value.
    /// \tparam T Type of the action result
    template <class T>
    const T& GetValue()
@@ -120,12 +140,12 @@ public:
 
    bool operator==(const RResultHandle &rhs) const
    {
-      return fObjPtr == rhs.fObjPtr;
+      return fObjPtr == rhs.fObjPtr && fVariedActionPtr == rhs.fVariedActionPtr;
    }
 
    bool operator!=(const RResultHandle &rhs) const
    {
-      return !(fObjPtr == rhs.fObjPtr);
+      return !(fObjPtr == rhs.fObjPtr) && fVariedActionPtr == rhs.fVariedActionPtr;
    }
 };
 

--- a/tree/dataframe/test/dataframe_vary.cxx
+++ b/tree/dataframe/test/dataframe_vary.cxx
@@ -429,6 +429,27 @@ TEST(RDFVary, VaryDisplay) // TEST instead of TEST_P because Display is single-t
       std::logic_error);
 }
 
+// Make sure we can pass RResultMaps to RunGraphs (after converting them to RResultHandle).
+TEST(RDFVary, ResultMapAndRunGraphs)
+{
+   auto m = ROOT::RDataFrame(1)
+               .Define("x", [] { return 0; })
+               .Vary(
+                  "x",
+                  [] {
+                     return ROOT::RVecI{-1, 1};
+                  },
+                  {}, 2)
+               .Max<int>("x");
+   auto mv = ROOT::RDF::Experimental::VariationsFor(m);
+   auto rh = ROOT::RDF::RResultHandle(mv);
+   ROOT::RDF::RunGraphs({rh});
+   EXPECT_EQ(rh.GetValue<int>(), 0);
+   EXPECT_EQ(mv["nominal"], 0);
+   EXPECT_EQ(&mv["nominal"], &rh.GetValue<int>());
+   EXPECT_EQ(mv["x:0"], -1);
+   EXPECT_EQ(mv["x:1"], 1);
+}
 
 /************ These tests are run in single- and multi-thread mode (they use TEST_P instead of TEST) ************/
 TEST_P(RDFVary, SimpleSum)


### PR DESCRIPTION
So that RunGraphs can be invoked from RResultMaps as well, without the need of a RResultPtr.

In order for RResultHandle's API to treat RResultPtr and RResultMap consistently, we also deprecate `RResultHandle::GetResultPtr`.