### PR TITLE
[RF] Modernize RooNormSetCache to fix invalid iterator dereferencing 

### DIFF
--- a/roofit/roofitcore/inc/RooCacheManager.h
+++ b/roofit/roofitcore/inc/RooCacheManager.h
@@ -167,7 +167,7 @@ RooCacheManager<T>::RooCacheManager(const RooCacheManager& other, RooAbsArg* own
 
   Int_t i ;
   for (i=0 ; i<other._size ; i++) {
-    _nsetCache[i].initialize(other._nsetCache[i]) ;
+    _nsetCache[i] = other._nsetCache[i];
     _object[i] = nullptr ;
   }
 


### PR DESCRIPTION
Re-implement the RooNormSetCache with the appropriate STL containers. In particular, it now uses `std::set` and `std::deque` instead of `std::map` and `std::vector`, which was not efficient for the round-robin replacement.

This change was motivated because it could happen in the past that the round-robin replacement was dereferencing invalid iterators.
