### PR TITLE
[ntuple] Fix `ReadGlobalImpl()` for proxied collections using a staging area

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -527,6 +527,7 @@ private:
 
    std::unique_ptr<TVirtualCollectionProxy> fProxy;
    Int_t fProperties;
+   Int_t fCollectionType;
    /// Two sets of functions to operate on iterators, to be used depending on the access type
    RCollectionIterableOnce::RIteratorFuncs fIFuncsRead;
    RCollectionIterableOnce::RIteratorFuncs fIFuncsWrite;

--- a/tree/ntuple/v7/test/SimpleCollectionProxy.hxx
+++ b/tree/ntuple/v7/test/SimpleCollectionProxy.hxx
@@ -5,7 +5,7 @@
 
 namespace {
 /// Simple collection proxy for `StructUsingCollectionProxy<T>`
-template <typename CollectionT>
+template <typename CollectionT, Int_t CollectionKind = ROOT::kSTLvector>
 class SimpleCollectionProxy : public TVirtualCollectionProxy {
    /// The internal representation of an iterator, which in this simple test only contains a pointer to an element
    struct IteratorData {
@@ -40,10 +40,13 @@ public:
       : TVirtualCollectionProxy(TClass::GetClass(ROOT::Internal::GetDemangledTypeName(typeid(CollectionT)).c_str()))
    {
    }
-   SimpleCollectionProxy(const SimpleCollectionProxy &) : SimpleCollectionProxy() {}
+   SimpleCollectionProxy(const SimpleCollectionProxy<CollectionT, CollectionKind> &) : SimpleCollectionProxy() {}
 
-   TVirtualCollectionProxy *Generate() const override { return new SimpleCollectionProxy<CollectionT>(*this); }
-   Int_t GetCollectionType() const override { return ROOT::kSTLvector; }
+   TVirtualCollectionProxy *Generate() const override
+   {
+      return new SimpleCollectionProxy<CollectionT, CollectionKind>(*this);
+   }
+   Int_t GetCollectionType() const override { return CollectionKind; }
    ULong_t GetIncrement() const override { return sizeof(typename CollectionT::ValueType); }
    UInt_t Sizeof() const override { return sizeof(CollectionT); }
    Bool_t HasPointers() const override { return kFALSE; }

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -1050,7 +1050,8 @@ TEST(RNTuple, TClassStlDerived)
 TEST(RNTuple, TVirtualCollectionProxy)
 {
    SimpleCollectionProxy<StructUsingCollectionProxy<char>> proxyC;
-   SimpleCollectionProxy<StructUsingCollectionProxy<float>> proxyF;
+   // Exposing as a non-vector forces iteration over collection elements in `ReadGlobalImpl()`
+   SimpleCollectionProxy<StructUsingCollectionProxy<float>, ROOT::kSTLdeque> proxyF;
    SimpleCollectionProxy<StructUsingCollectionProxy<CustomStruct>> proxyS;
    SimpleCollectionProxy<StructUsingCollectionProxy<StructUsingCollectionProxy<float>>> proxyNested;
 


### PR DESCRIPTION
This follow-up PR further improved the situation after #12380.

In particular, the staging area of a collection cannot (apparently) be iterated -- see
https://github.com/root-project/root/blob/master/io/io/src/TGenCollectionProxy.cxx#L1573.
Other uses in the ROOT repository rely on `TVirtualCollectionProxy::At()`.  However, we can instead exploit the fact that the staging area is backed by an array, i.e. the elements are contiguous in memory.

Use this optimization also for `kSTLvector` collections, which was a TODO anyways.

This should also provide an advantage/simplification to PR #12948.

## Checklist:
- [x] tested changes locally
- [x] updated the docs (if necessary)