### PR TITLE
[cmake] roottest: gracefully handle a failed `git describe`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,10 +212,10 @@ function(relatedrepo_GetClosestMatch)
   # Finally, try upstream using the closest head/tag below the parent commit of the current head
   execute_process(COMMAND ${GIT_EXECUTABLE} --git-dir=${CMAKE_CURRENT_SOURCE_DIR}/.git
                   describe --all --abbrev=0 HEAD^
-                  OUTPUT_VARIABLE closest_ref OUTPUT_STRIP_TRAILING_WHITESPACE)
-  string(REGEX REPLACE "^(heads|tags)/" "" candidate_head ${closest_ref})
+                  OUTPUT_VARIABLE closest_ref ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+  string(REGEX REPLACE "^(heads|tags)/" "" candidate_head "${closest_ref}")
   execute_process(COMMAND ${GIT_EXECUTABLE} ls-remote --heads --tags
-                  ${__UPSTREAM_PREFIX}/${__REPO_NAME} ${candidate_head} OUTPUT_VARIABLE matching_refs)
+                  ${__UPSTREAM_PREFIX}/${__REPO_NAME} "${candidate_head}" OUTPUT_VARIABLE matching_refs)
   if(NOT "${matching_refs}" STREQUAL "")
     set(${__FETCHREF_VARIABLE} ${candidate_head} PARENT_SCOPE)
     return()


### PR DESCRIPTION
`git describe` is used to find the closest head/tag to checkout (see relatedrepo_GetClosestMatch).  A failed `git describe`, which happens e.g. in shallow clones, should be handled gracefully.

As noted by @hahnjo, however, a call to `relatedrepo_GetClosestMatch()` is not even required provided that the repository was found locally, and that we are not forcing checkout.  This is for a follow-up PR though. 

## Checklist:
- [x] tested changes locally