### PR TITLE
[ntuple] Fix RNTupleCompressor::Zip writing result to provided output buffer

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleZip.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleZip.hxx
@@ -154,6 +154,7 @@ public:
 
          szZipData += szOutBlock;
          source += szSource;
+         target += szOutBlock;
          szRemaining -= szSource;
       }
       R__ASSERT(szRemaining == 0);

--- a/tree/ntuple/v7/test/ntuple_zip.cxx
+++ b/tree/ntuple/v7/test/ntuple_zip.cxx
@@ -84,3 +84,23 @@ TEST(RNTupleZip, Large)
    decompressor.Unzip(zipBuffer.get(), szZip, N, unzipBuffer.get());
    EXPECT_EQ(data, std::string(unzipBuffer.get(), N));
 }
+
+TEST(RNTupleZip, LargeWithOutputBuffer)
+{
+   constexpr unsigned int N = kMAXZIPBUF + 32;
+   auto zipBuffer = std::make_unique<unsigned char[]>(N);
+   auto unzipBuffer = std::make_unique<char[]>(N);
+   std::string data(N, 'x');
+
+   RNTupleCompressor compressor;
+   RNTupleDecompressor decompressor;
+
+   /// Trailing byte cannot be compressed, entire buffer returns uncompressed
+   auto szZip = compressor.Zip(data.data(), kMAXZIPBUF + 1, 101, zipBuffer.get());
+   EXPECT_EQ(static_cast<unsigned int>(kMAXZIPBUF) + 1, szZip);
+
+   szZip = compressor.Zip(data.data(), data.length(), 101, zipBuffer.get());
+   EXPECT_LT(szZip, N);
+   decompressor.Unzip(zipBuffer.get(), szZip, N, unzipBuffer.get());
+   EXPECT_EQ(data, std::string(unzipBuffer.get(), N));
+}


### PR DESCRIPTION
The RNTupleCompresser::Zip overload with a specified output buffer (`Zip(const void *from, std::size_t nbytes, int compression, void *to)`) always overwrites the first block in the output buffer when compressing large files that consist of multiple blocks (i.e., when input size > 16MB).


# This Pull request:

## Changes or fixes:
- RNTupleCompresser::Zip now correctly writes the result to the provided output buffer when compressing multiple blocks
- Added a test case that tests this Zip overload with data containing multiple blocks.

## Checklist:

- [ x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

