### PR TITLE
Change naming of classes in DistRDF.Proxy

### DIFF
--- a/bindings/experimental/distrdf/python/DistRDF/Backends/Utils.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Backends/Utils.py
@@ -236,7 +236,7 @@ def _(mergeable: ROOT.Detail.RDF.RMergeableVariationsBase, node, backend):
     Connects the final value after distributed computation to the corresponding
     DistRDF node.
     In this overload, the node stores the reference to the mergeable variations
-    directly. It is then responsibility of the VariationsProxy object to access
+    directly. It is then responsibility of the ResultMapProxy object to access
     the specific varied object asked by the user, calling the right method of
     the RMergeableVariations class.
     """

--- a/bindings/experimental/distrdf/python/DistRDF/DataFrame.py
+++ b/bindings/experimental/distrdf/python/DistRDF/DataFrame.py
@@ -35,7 +35,7 @@ class RDataFrame(object):
 
         self._headnode = headnode
 
-        self._headproxy = Proxy.TransformationProxy(self._headnode)
+        self._headproxy = Proxy.NodeProxy(self._headnode)
 
     def __dir__(self) -> List[str]:
         opdir: List[str] = [

--- a/bindings/experimental/distrdf/python/DistRDF/__init__.py
+++ b/bindings/experimental/distrdf/python/DistRDF/__init__.py
@@ -22,7 +22,7 @@ from typing import Iterable, TYPE_CHECKING
 from DistRDF.Backends import build_backends_submodules
 
 if TYPE_CHECKING:
-    from DistRDF.Proxy import ActionProxy, VariationsProxy
+    from DistRDF.Proxy import ResultPtrProxy, ResultMapProxy
 
 logger = logging.getLogger(__name__)
 
@@ -128,7 +128,7 @@ def RunGraphs(proxies: Iterable) -> int:
     return len(uniqueproxies)
 
 
-def VariationsFor(actionproxy: ActionProxy) -> VariationsProxy:
+def VariationsFor(actionproxy: ResultPtrProxy) -> ResultMapProxy:
     """
     Equivalent of ROOT.RDF.Experimental.VariationsFor in distributed mode.
     """

--- a/bindings/experimental/distrdf/test/test_callable_generator.py
+++ b/bindings/experimental/distrdf/test/test_callable_generator.py
@@ -70,7 +70,7 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
         # Head node
         hn = create_dummy_headnode(1)
         hn.backend = ComputationGraphGeneratorTest.TestBackend()
-        node = Proxy.TransformationProxy(hn)
+        node = Proxy.NodeProxy(hn)
         # Set of operations to build the graph
         n1 = node.Define()
         n2 = node.Filter().Filter()
@@ -103,7 +103,7 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
         # Head node
         hn = create_dummy_headnode(1)
         hn.backend = ComputationGraphGeneratorTest.TestBackend()
-        node = Proxy.TransformationProxy(hn)
+        node = Proxy.NodeProxy(hn)
 
         # Set of operations to build the graph
         n1 = node.Define()
@@ -148,7 +148,7 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
         # Head node
         hn = create_dummy_headnode(1)
         hn.backend = ComputationGraphGeneratorTest.TestBackend()
-        node = Proxy.TransformationProxy(hn)
+        node = Proxy.NodeProxy(hn)
 
         # Graph nodes
         n1 = node.Define()
@@ -185,7 +185,7 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
         # Head node
         hn = create_dummy_headnode(1)
         hn.backend = ComputationGraphGeneratorTest.TestBackend()
-        node = Proxy.TransformationProxy(hn)
+        node = Proxy.NodeProxy(hn)
 
         # Graph nodes
         n1 = node.Define()
@@ -222,7 +222,7 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
         # Head node
         hn = create_dummy_headnode(1)
         hn.backend = ComputationGraphGeneratorTest.TestBackend()
-        node = Proxy.TransformationProxy(hn)
+        node = Proxy.NodeProxy(hn)
 
         # Graph nodes
         n1 = node.Define()
@@ -261,7 +261,7 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
         # Head node
         hn = create_dummy_headnode(1)
         hn.backend = ComputationGraphGeneratorTest.TestBackend()
-        node = Proxy.TransformationProxy(hn)
+        node = Proxy.NodeProxy(hn)
 
         # Graph nodes
         n1 = node.Define()
@@ -303,7 +303,7 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
         # Head node
         hn = create_dummy_headnode(1)
         hn.backend = ComputationGraphGeneratorTest.TestBackend()
-        node = Proxy.TransformationProxy(hn)
+        node = Proxy.NodeProxy(hn)
 
         # Graph nodes
         n1 = node.Define()
@@ -337,7 +337,7 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
         # Head node
         hn = create_dummy_headnode(1)
         hn.backend = ComputationGraphGeneratorTest.TestBackend()
-        node = Proxy.TransformationProxy(hn)
+        node = Proxy.NodeProxy(hn)
         # Create three branches
         n1 = node.Define()
         n2 = node.Filter()

--- a/bindings/experimental/distrdf/test/test_node.py
+++ b/bindings/experimental/distrdf/test/test_node.py
@@ -42,7 +42,7 @@ class OperationReadTest(unittest.TestCase):
         """Function names are read accurately."""
         hn = create_dummy_headnode(1)
         hn.backend = TestBackend()
-        node = Proxy.TransformationProxy(hn)
+        node = Proxy.NodeProxy(hn)
         func = node.Define  # noqa: avoid PEP8 F841
         self.assertEqual(node._new_op_name, "Define")
 
@@ -50,7 +50,7 @@ class OperationReadTest(unittest.TestCase):
         """Arguments (unnamed) are read accurately."""
         hn = create_dummy_headnode(1)
         hn.backend = TestBackend()
-        node = Proxy.TransformationProxy(hn)
+        node = Proxy.NodeProxy(hn)
         newNode = node.Define(1, "b", a="1", b=2)
         self.assertEqual(newNode.operation.args, [1, "b"])
 
@@ -58,7 +58,7 @@ class OperationReadTest(unittest.TestCase):
         """Named arguments are read accurately."""
         hn = create_dummy_headnode(1)
         hn.backend = TestBackend()
-        node = Proxy.TransformationProxy(hn)
+        node = Proxy.NodeProxy(hn)
         newNode = node.Define(1, "b", a="1", b=2)
         self.assertEqual(newNode.operation.kwargs, {"a": "1", "b": 2})
 
@@ -66,25 +66,25 @@ class OperationReadTest(unittest.TestCase):
 class NodeReturnTest(unittest.TestCase):
     """
     A series of test cases to check that right objects are returned for a node
-    (Proxy.ActionProxy, Proxy.TransformationProxy or Node).
+    (Proxy.ResultPtrProxy, Proxy.NodeProxy or Node).
     """
 
     def test_action_proxy_return(self):
         """Proxy objects are returned for action nodes."""
         hn = create_dummy_headnode(1)
         hn.backend = TestBackend()
-        node = Proxy.TransformationProxy(hn)
+        node = Proxy.NodeProxy(hn)
         newNode = node.Count()
-        self.assertIsInstance(newNode, Proxy.ActionProxy)
+        self.assertIsInstance(newNode, Proxy.ResultPtrProxy)
         self.assertIsInstance(newNode.proxied_node, Node.Node)
 
     def test_transformation_proxy_return(self):
         """Node objects are returned for transformation nodes."""
         hn = create_dummy_headnode(1)
         hn.backend = TestBackend()
-        node = Proxy.TransformationProxy(hn)
+        node = Proxy.NodeProxy(hn)
         newNode = node.Define(1)
-        self.assertIsInstance(newNode, Proxy.TransformationProxy)
+        self.assertIsInstance(newNode, Proxy.NodeProxy)
         self.assertIsInstance(newNode.proxied_node, Node.Node)
 
 

--- a/bindings/experimental/distrdf/test/test_proxy.py
+++ b/bindings/experimental/distrdf/test/test_proxy.py
@@ -30,24 +30,24 @@ class TypeReturnTest(unittest.TestCase):
 
     def test_type_return_transformation(self):
         """
-        TransformationProxy object is of type `DistRDF.TransformationProxy` and
+        NodeProxy object is of type `DistRDF.NodeProxy` and
         wraps a node object.
         """
         node = create_dummy_headnode(1)
         node.backend = None
-        proxy = Proxy.TransformationProxy(node)
-        self.assertIsInstance(proxy, Proxy.TransformationProxy)
+        proxy = Proxy.NodeProxy(node)
+        self.assertIsInstance(proxy, Proxy.NodeProxy)
         self.assertIsInstance(proxy.proxied_node, Node.Node)
 
     def test_type_return_action(self):
         """
-        ActionProxy object is of type `DistRDF.ActionProxy` and
+        ResultPtrProxy object is of type `DistRDF.ResultPtrProxy` and
         wraps a node object.
         """
         node = create_dummy_headnode(1)
         node.backend = None
-        proxy = Proxy.ActionProxy(node)
-        self.assertIsInstance(proxy, Proxy.ActionProxy)
+        proxy = Proxy.ResultPtrProxy(node)
+        self.assertIsInstance(proxy, Proxy.ResultPtrProxy)
         self.assertIsInstance(proxy.proxied_node, Node.Node)
 
 
@@ -81,10 +81,10 @@ class AttrReadTest(unittest.TestCase):
             pass
 
     def test_attr_simple_action(self):
-        """ActionProxy object reads the right input attribute."""
+        """ResultPtrProxy object reads the right input attribute."""
         node = create_dummy_headnode(1)
         node.backend = None
-        proxy = Proxy.ActionProxy(node)
+        proxy = Proxy.ResultPtrProxy(node)
         func = proxy.attr
 
         self.assertEqual(proxy._cur_attr, "attr")
@@ -92,12 +92,12 @@ class AttrReadTest(unittest.TestCase):
 
     def test_supported_transformation(self):
         """
-        TransformationProxy object reads the right input attributes,
+        NodeProxy object reads the right input attributes,
         returning the methods of the proxied node.
         """
         node = create_dummy_headnode(1)
         node.backend = AttrReadTest.TestBackend()
-        proxy = Proxy.TransformationProxy(node)
+        proxy = Proxy.NodeProxy(node)
 
         transformations = {
             "Define": ["x", "1"],
@@ -107,19 +107,19 @@ class AttrReadTest(unittest.TestCase):
         for transformation, args in transformations.items():
             newProxy = getattr(proxy, transformation)(*args)
             self.assertEqual(proxy.proxied_node._new_op_name, transformation)
-            self.assertIsInstance(newProxy, Proxy.TransformationProxy)
+            self.assertIsInstance(newProxy, Proxy.NodeProxy)
             self.assertEqual(newProxy.proxied_node.operation.name,
                              transformation)
             self.assertEqual(newProxy.proxied_node.operation.args, args)
 
     def test_node_attr_transformation(self):
         """
-        When a node attribute is called on a TransformationProxy object, it
+        When a node attribute is called on a NodeProxy object, it
         correctly returns the attribute of the proxied node.
         """
         node = create_dummy_headnode(1)
         node.backend = AttrReadTest.TestBackend()
-        proxy = Proxy.TransformationProxy(node)
+        proxy = Proxy.NodeProxy(node)
 
         node_attributes = [
             "get_head",
@@ -138,11 +138,11 @@ class AttrReadTest(unittest.TestCase):
     def test_undefined_attr_transformation(self):
         """
         When a non-defined Node class attribute is called on a
-        TransformationProxy object, it raises an AttributeError.
+        NodeProxy object, it raises an AttributeError.
         """
         node = create_dummy_headnode(1)
         node.backend = None
-        proxy = Proxy.TransformationProxy(node)
+        proxy = Proxy.NodeProxy(node)
         with self.assertRaises(AttributeError):
             proxy.attribute
 
@@ -155,7 +155,7 @@ class AttrReadTest(unittest.TestCase):
         """
         node = create_dummy_headnode(1)
         node.backend = None
-        proxy = Proxy.TransformationProxy(node)
+        proxy = Proxy.NodeProxy(node)
         self.assertTrue(node.has_user_references)
         proxy = None  # noqa: avoid PEP8 F841
         self.assertFalse(node.has_user_references)
@@ -169,7 +169,7 @@ class AttrReadTest(unittest.TestCase):
         node = create_dummy_headnode(1)
         node.backend = None
         node.value = t
-        proxy = Proxy.ActionProxy(node)
+        proxy = Proxy.ResultPtrProxy(node)
 
         self.assertEqual(proxy.val(21), 144)
 
@@ -207,7 +207,7 @@ class GetValueTests(unittest.TestCase):
         """
         node = create_dummy_headnode(1)
         node.backend = None
-        proxy = Proxy.ActionProxy(node)
+        proxy = Proxy.ResultPtrProxy(node)
         node.value = 5
 
         self.assertEqual(proxy.GetValue(), 5)


### PR DESCRIPTION
The new names should better represent the part of the computation graph each proxy refers to.