### PR TITLE
[ntuple] Do not memset() a buffer that will be overwritten

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -54,9 +54,7 @@ private:
          explicit RPageZipItem(RPage page)
             : fPage(page), fBuf(nullptr) {}
          bool IsSealed() const { return fSealedPage != nullptr; }
-         void AllocateSealedPageBuf() {
-            fBuf = std::make_unique<unsigned char[]>(fPage.GetNBytes());
-         }
+         void AllocateSealedPageBuf() { fBuf = std::unique_ptr<unsigned char[]>(new unsigned char[fPage.GetNBytes()]); }
       };
    public:
       RColumnBuf() = default;

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -584,7 +584,7 @@ ROOT::Experimental::Detail::RPageSourceDaos::PopulatePageFromCluster(ColumnHandl
             R__FAIL("accessing caged pages is only supported in conjunction with cluster cache"));
       }
 
-      directReadBuffer = std::make_unique<unsigned char[]>(bytesOnStorage);
+      directReadBuffer = std::unique_ptr<unsigned char[]>(new unsigned char[bytesOnStorage]);
       RDaosKey daosKey = GetPageDaosKey<kDefaultDaosMapping>(
          fNTupleIndex, clusterId, columnId, pageInfo.fLocator.GetPosition<RNTupleLocatorObject64>().fLocation);
       fDaosContainer->ReadSingleAkey(directReadBuffer.get(), bytesOnStorage, daosKey.fOid, daosKey.fDkey,

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -342,7 +342,7 @@ ROOT::Experimental::Detail::RPageSourceFile::PopulatePageFromCluster(ColumnHandl
    }
 
    if (fOptions.GetClusterCache() == RNTupleReadOptions::EClusterCache::kOff) {
-      directReadBuffer = std::make_unique<unsigned char[]>(bytesOnStorage);
+      directReadBuffer = std::unique_ptr<unsigned char[]>(new unsigned char[bytesOnStorage]);
       fReader.ReadBuffer(directReadBuffer.get(), bytesOnStorage, pageInfo.fLocator.GetPosition<std::uint64_t>());
       fCounters->fNPageLoaded.Inc();
       fCounters->fNRead.Inc();


### PR DESCRIPTION
`std::make_unique<unsigned char[]>()` has the side effect of zero- initializing the allocated buffer.  In the replaced cases, all bytes in the buffer are overwritten after the allocation.

Overhead of this initialization has been measured to be around 5-7% in a tight loop that allocates and uses 100k 64KiB buffers.  One occurrence in [`UnsealPage()`](https://github.com/root-project/root/blob/master/tree/ntuple/v7/src/RPageStorage.cxx#L153) is not changed by this PR, as that case is addressed in PR #13208.

This commit uses `std::unique_ptr<unsigned char[]>(new unsigned char[N])` instead for the cases in which that overhead matters. C++20 offers [`std::make_unique_for_overwrite<T>()`](https://en.cppreference.com/w/cpp/memory/unique_ptr/make_unique), which might be used in the future instead.

## Checklist:
- [x] tested changes locally