### PR TITLE
[IO] Prevent infinite loop in TFile::ls

### DIFF
--- a/io/io/src/TDirectoryFile.cxx
+++ b/io/io/src/TDirectoryFile.cxx
@@ -1209,7 +1209,10 @@ void TDirectoryFile::ls(Option_t *option) const
       while (lnk) {
          TKey *key = (TKey*)lnk->GetObject();
          TString s = key->GetName();
-         if (s.Index(re) == kNPOS) continue;
+         if (s.Index(re) == kNPOS) {
+            lnk = lnk->Next();
+            continue;
+         }
          bool first = (lnk->Prev() == nullptr) || (s != lnk->Prev()->GetObject()->GetName());
          bool hasbackup = (lnk->Next() != nullptr) && (s == lnk->Next()->GetObject()->GetName());
          if (first)

--- a/io/io/src/TDirectoryFile.cxx
+++ b/io/io/src/TDirectoryFile.cxx
@@ -1205,14 +1205,10 @@ void TDirectoryFile::ls(Option_t *option) const
 
    if (diskobj && fKeys) {
       //*-* Loop on all the keys
-      TObjLink *lnk = fKeys->FirstLink();
-      while (lnk) {
+      for (TObjLink *lnk = fKeys->FirstLink(); lnk != nullptr; lnk = lnk->Next()) {
          TKey *key = (TKey*)lnk->GetObject();
          TString s = key->GetName();
-         if (s.Index(re) == kNPOS) {
-            lnk = lnk->Next();
-            continue;
-         }
+         if (s.Index(re) == kNPOS) continue;
          bool first = (lnk->Prev() == nullptr) || (s != lnk->Prev()->GetObject()->GetName());
          bool hasbackup = (lnk->Next() != nullptr) && (s == lnk->Next()->GetObject()->GetName());
          if (first)
@@ -1222,7 +1218,6 @@ void TDirectoryFile::ls(Option_t *option) const
                key->ls();
          else
             key->ls(false);
-         lnk = lnk->Next();
       }
    }
    TROOT::DecreaseDirLevel();


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
Prevent infinite loop in TFile::ls

This bug was introduced in commit
72a3242c91b7ca3e4cf31e7a6d5ddc9638270d27
Solution found by SilentAssassinMa


## Checklist:

- [x] tested changes locally
- [ ] There is still one problem, if a TNamed that is called TIME/CLK inside a TFile, it doesnt print it when doing ls.

This PR fixes https://github.com/root-project/root/issues/8650 and https://github.com/root-project/root/issues/13182

