### PR TITLE
[ntuple] Improvements to the RField read/write API

### DIFF
--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -151,7 +151,7 @@ public:
    void *GetImpl(Long64_t entry) final
    {
       if (entry != fLastEntry) {
-         fField->Read(entry, &fValue);
+         fField->Read(entry, fValue.GetRawPtr());
          fLastEntry = entry;
       }
       return fValue.GetRawPtr();

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -99,13 +99,12 @@ public:
    size_t GetAlignment() const final { return alignof(std::size_t); }
 
    /// Get the number of elements of the collection identified by globalIndex
-   void
-   ReadGlobalImpl(ROOT::Experimental::NTupleSize_t globalIndex, ROOT::Experimental::Detail::RFieldValue *value) final
+   void ReadGlobalImpl(ROOT::Experimental::NTupleSize_t globalIndex, void *to) final
    {
       RClusterIndex collectionStart;
       ClusterSize_t size;
       fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &size);
-      *value->Get<std::size_t>() = size;
+      *static_cast<std::size_t *>(to) = size;
    }
 
    /// Get the number of elements of the collection identified by clusterIndex

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -109,13 +109,12 @@ public:
    }
 
    /// Get the number of elements of the collection identified by clusterIndex
-   void ReadInClusterImpl(const ROOT::Experimental::RClusterIndex &clusterIndex,
-                          ROOT::Experimental::Detail::RFieldValue *value) final
+   void ReadInClusterImpl(const ROOT::Experimental::RClusterIndex &clusterIndex, void *to) final
    {
       RClusterIndex collectionStart;
       ClusterSize_t size;
       fPrincipalColumn->GetCollectionInfo(clusterIndex, &collectionStart, &size);
-      *value->Get<std::size_t>() = size;
+      *static_cast<std::size_t *>(to) = size;
    }
 };
 

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -121,14 +121,15 @@ public:
    /// TODO(jalopezg): at this point it would be nicer to distinguish between connecting a page sink and a page source
    void Connect(DescriptorId_t fieldId, RPageStorage *pageStorage, NTupleSize_t firstElementIndex = 0U);
 
-   void Append(const RColumnElementBase &element) {
+   void Append(const void *from)
+   {
       void *dst = fWritePage[fWritePageIdx].GrowUnchecked(1);
 
       if (fWritePage[fWritePageIdx].GetNElements() == fApproxNElementsPerPage / 2) {
          FlushShadowWritePage();
       }
 
-      memcpy(dst, element.GetRawContent(), fElement->GetSize());
+      memcpy(dst, from, fElement->GetSize());
       fNElements++;
 
       SwapWritePagesIfFull();
@@ -140,8 +141,7 @@ public:
       if (fWritePage[fWritePageIdx].GetNElements() + count > fApproxNElementsPerPage) {
          // TODO(jblomer): use (fewer) calls to AppendV to write the data page-by-page
          for (unsigned i = 0; i < count; ++i) {
-            unsigned char *fromUChar = const_cast<unsigned char *>(static_cast<const unsigned char *>(from));
-            Append(RColumnElementBase(fromUChar + fElement->GetSize() * i, fElement->GetSize()));
+            Append(static_cast<const unsigned char *>(from) + fElement->GetSize() * i);
          }
          return;
       }

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -166,25 +166,27 @@ public:
       SwapWritePagesIfFull();
    }
 
-   void Read(const NTupleSize_t globalIndex, RColumnElementBase *element) {
+   void Read(const NTupleSize_t globalIndex, void *to)
+   {
       if (!fReadPage.Contains(globalIndex)) {
          MapPage(globalIndex);
          R__ASSERT(fReadPage.Contains(globalIndex));
       }
       const auto elemSize = fElement->GetSize();
-      void *src = static_cast<unsigned char *>(fReadPage.GetBuffer()) +
-                  (globalIndex - fReadPage.GetGlobalRangeFirst()) * elemSize;
-      std::memcpy(element->GetRawContent(), src, elemSize);
+      void *from = static_cast<unsigned char *>(fReadPage.GetBuffer()) +
+                   (globalIndex - fReadPage.GetGlobalRangeFirst()) * elemSize;
+      std::memcpy(to, from, elemSize);
    }
 
-   void Read(const RClusterIndex &clusterIndex, RColumnElementBase *element) {
+   void Read(const RClusterIndex &clusterIndex, void *to)
+   {
       if (!fReadPage.Contains(clusterIndex)) {
          MapPage(clusterIndex);
       }
       const auto elemSize = fElement->GetSize();
-      void *src = static_cast<unsigned char *>(fReadPage.GetBuffer()) +
-                  (clusterIndex.GetIndex() - fReadPage.GetClusterRangeFirst()) * elemSize;
-      std::memcpy(element->GetRawContent(), src, elemSize);
+      void *from = static_cast<unsigned char *>(fReadPage.GetBuffer()) +
+                   (clusterIndex.GetIndex() - fReadPage.GetClusterRangeFirst()) * elemSize;
+      std::memcpy(to, from, elemSize);
    }
 
    void ReadV(const NTupleSize_t globalIndex, const ClusterSize_t::ValueType count, void *to)

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -129,7 +129,7 @@ public:
          FlushShadowWritePage();
       }
 
-      memcpy(dst, from, fElement->GetSize());
+      std::memcpy(dst, from, fElement->GetSize());
       fNElements++;
 
       SwapWritePagesIfFull();
@@ -159,7 +159,7 @@ public:
 
       void *dst = fWritePage[fWritePageIdx].GrowUnchecked(count);
 
-      memcpy(dst, from, fElement->GetSize() * count);
+      std::memcpy(dst, from, fElement->GetSize() * count);
       fNElements += count;
 
       // Note that by the very first check in AppendV, we cannot have filled more than fApproxNElementsPerPage elements

--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -585,9 +585,7 @@ public:
 #define __RCOLUMNELEMENT_SPEC_BODY(CppT, BaseT, BitsOnStorage)  \
    static constexpr std::size_t kSize = sizeof(CppT);           \
    static constexpr std::size_t kBitsOnStorage = BitsOnStorage; \
-   RColumnElement() : BaseT(kSize)                              \
-   {                                                            \
-   }                                                            \
+   RColumnElement() : BaseT(kSize) {}                           \
    bool IsMappable() const final                                \
    {                                                            \
       return kIsMappable;                                       \

--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -290,16 +290,6 @@ public:
    static std::size_t GetBitsOnStorage(EColumnType type);
    static std::string GetTypeName(EColumnType type);
 
-   /// Write one or multiple column elements into destination
-   void WriteTo(void *destination, std::size_t count) const {
-      std::memcpy(destination, fRawContent, fSize * count);
-   }
-
-   /// Set the column element or an array of elements from the memory location source
-   void ReadFrom(void *source, std::size_t count) {
-      std::memcpy(fRawContent, source, fSize * count);
-   }
-
    /// Derived, typed classes tell whether the on-storage layout is bitwise identical to the memory layout
    virtual bool IsMappable() const { R__ASSERT(false); return false; }
    virtual std::size_t GetBitsOnStorage() const { R__ASSERT(false); return 0; }

--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -248,16 +248,12 @@ namespace Detail {
 
 // clang-format off
 /**
-\class ROOT::Experimental::Detail::RColumnElement
+\class ROOT::Experimental::Detail::RColumnElementBase
 \ingroup NTuple
-\brief A column element points either to the content of an RFieldValue or into a memory mapped page.
+\brief A column element encapsulates the translation between basic C++ types and their column representation.
 
-The content pointed to by fRawContent can be a single element or the first element of an array.
 Usually the on-disk element should map bitwise to the in-memory element. Sometimes that's not the case
-though, for instance on big endian platforms and for exotic physical columns like 8 bit float.
-
-This class does not provide protection around the raw pointer, fRawContent has to be managed correctly
-by the user of this class.
+though, for instance on big endian platforms or for bools.
 */
 // clang-format on
 class RColumnElementBase {
@@ -268,16 +264,7 @@ protected:
    std::size_t fSize;
 
 public:
-   RColumnElementBase()
-     : fRawContent(nullptr)
-     , fSize(0)
-   {}
-   RColumnElementBase(void *rawContent, std::size_t size) : fRawContent(rawContent), fSize(size)
-   {}
-   RColumnElementBase(const RColumnElementBase &elemArray, std::size_t at)
-     : fRawContent(static_cast<unsigned char *>(elemArray.fRawContent) + elemArray.fSize * at)
-     , fSize(elemArray.fSize)
-   {}
+   RColumnElementBase(void *rawContent, std::size_t size) : fRawContent(rawContent), fSize(size) {}
    RColumnElementBase(const RColumnElementBase& other) = default;
    RColumnElementBase(RColumnElementBase&& other) = default;
    RColumnElementBase& operator =(const RColumnElementBase& other) = delete;
@@ -306,7 +293,6 @@ public:
       std::memcpy(destination, source, count);
    }
 
-   void *GetRawContent() const { return fRawContent; }
    std::size_t GetSize() const { return fSize; }
    std::size_t GetPackedSize(std::size_t nElements = 1U) const { return (nElements * GetBitsOnStorage() + 7) / 8; }
 };

--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -256,7 +256,8 @@ Usually the on-disk element should map bitwise to the in-memory element. Sometim
 though, for instance on big endian platforms or for bools.
 
 There is a template specialization for every valid pair of C++ type and column representation.
-These specialized child classes are responsible for packing and unpacking pages.
+These specialized child classes are responsible for overriding `Pack()` / `Unpack()` for packing / unpacking elements
+as appropriate.
 */
 // clang-format on
 class RColumnElementBase {

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -302,7 +302,7 @@ public:
          return AppendImpl(value);
 
       fPrincipalColumn->Append(value.GetRawPtr());
-      return value.fMappedElement.GetSize();
+      return fPrincipalColumn->GetElement()->GetPackedSize();
    }
 
    /// Populate a single value with data from the tree, which needs to be of the fitting type.
@@ -1036,13 +1036,10 @@ public:
 
    using Detail::RFieldBase::GenerateValue;
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final {
-      return Detail::RFieldValue(
-         Detail::RColumnElement<ClusterSize_t>(static_cast<ClusterSize_t*>(where)),
-         this, static_cast<ClusterSize_t*>(where));
+      return Detail::RFieldValue(this, static_cast<ClusterSize_t *>(where));
    }
    Detail::RFieldValue CaptureValue(void* where) final {
-      return Detail::RFieldValue(true /* captureFlag */,
-         Detail::RColumnElement<ClusterSize_t>(static_cast<ClusterSize_t*>(where)), this, where);
+      return Detail::RFieldValue(true /* captureFlag */, this, where);
    }
    size_t GetValueSize() const final { return sizeof(ClusterSize_t); }
    size_t GetAlignment() const final { return alignof(ClusterSize_t); }
@@ -1166,14 +1163,11 @@ public:
    template <typename... ArgsT>
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
    {
-      return Detail::RFieldValue(
-         Detail::RColumnElement<ClusterSize_t>(static_cast<ClusterSize_t*>(where)),
-         this, static_cast<ClusterSize_t*>(where), std::forward<ArgsT>(args)...);
+      return Detail::RFieldValue(this, static_cast<ClusterSize_t *>(where), std::forward<ArgsT>(args)...);
    }
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0); }
    Detail::RFieldValue CaptureValue(void *where) final {
-      return Detail::RFieldValue(true /* captureFlag */,
-         Detail::RColumnElement<ClusterSize_t>(static_cast<ClusterSize_t*>(where)), this, where);
+      return Detail::RFieldValue(true /* captureFlag */, this, where);
    }
    size_t GetValueSize() const final { return sizeof(ClusterSize_t); }
    size_t GetAlignment() const final { return alignof(ClusterSize_t); }
@@ -1275,14 +1269,11 @@ public:
    template <typename... ArgsT>
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
    {
-      return Detail::RFieldValue(
-         Detail::RColumnElement<bool>(static_cast<bool*>(where)),
-         this, static_cast<bool*>(where), std::forward<ArgsT>(args)...);
+      return Detail::RFieldValue(this, static_cast<bool *>(where), std::forward<ArgsT>(args)...);
    }
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, false); }
    Detail::RFieldValue CaptureValue(void *where) final {
-      return Detail::RFieldValue(true /* captureFlag */,
-         Detail::RColumnElement<bool>(static_cast<bool*>(where)), this, where);
+      return Detail::RFieldValue(true /* captureFlag */, this, where);
    }
    size_t GetValueSize() const final { return sizeof(bool); }
    size_t GetAlignment() const final { return alignof(bool); }
@@ -1328,14 +1319,11 @@ public:
    template <typename... ArgsT>
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
    {
-      return Detail::RFieldValue(
-         Detail::RColumnElement<float>(static_cast<float*>(where)),
-         this, static_cast<float*>(where), std::forward<ArgsT>(args)...);
+      return Detail::RFieldValue(this, static_cast<float *>(where), std::forward<ArgsT>(args)...);
    }
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0.0); }
    Detail::RFieldValue CaptureValue(void *where) final {
-      return Detail::RFieldValue(true /* captureFlag */,
-         Detail::RColumnElement<float>(static_cast<float*>(where)), this, where);
+      return Detail::RFieldValue(true /* captureFlag */, this, where);
    }
    size_t GetValueSize() const final { return sizeof(float); }
    size_t GetAlignment() const final { return alignof(float); }
@@ -1382,14 +1370,11 @@ public:
    template <typename... ArgsT>
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
    {
-      return Detail::RFieldValue(
-         Detail::RColumnElement<double>(static_cast<double*>(where)),
-         this, static_cast<double*>(where), std::forward<ArgsT>(args)...);
+      return Detail::RFieldValue(this, static_cast<double *>(where), std::forward<ArgsT>(args)...);
    }
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0.0); }
    Detail::RFieldValue CaptureValue(void *where) final {
-      return Detail::RFieldValue(true /* captureFlag */,
-         Detail::RColumnElement<double>(static_cast<double*>(where)), this, where);
+      return Detail::RFieldValue(true /* captureFlag */, this, where);
    }
    size_t GetValueSize() const final { return sizeof(double); }
    size_t GetAlignment() const final { return alignof(double); }
@@ -1438,14 +1423,11 @@ public:
    template <typename... ArgsT>
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where, ArgsT&&... args)
    {
-      return Detail::RFieldValue(
-         Detail::RColumnElement<char>(static_cast<char*>(where)),
-         this, static_cast<char*>(where), std::forward<ArgsT>(args)...);
+      return Detail::RFieldValue(this, static_cast<char *>(where), std::forward<ArgsT>(args)...);
    }
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where) final { return GenerateValue(where, 0); }
    Detail::RFieldValue CaptureValue(void *where) final {
-      return Detail::RFieldValue(true /* captureFlag */,
-         Detail::RColumnElement<char>(static_cast<char*>(where)), this, where);
+      return Detail::RFieldValue(true /* captureFlag */, this, where);
    }
    size_t GetValueSize() const final { return sizeof(char); }
    size_t GetAlignment() const final { return alignof(char); }
@@ -1491,14 +1473,11 @@ public:
    template <typename... ArgsT>
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where, ArgsT&&... args)
    {
-      return Detail::RFieldValue(
-         Detail::RColumnElement<std::int8_t>(static_cast<std::int8_t*>(where)),
-         this, static_cast<std::int8_t*>(where), std::forward<ArgsT>(args)...);
+      return Detail::RFieldValue(this, static_cast<std::int8_t *>(where), std::forward<ArgsT>(args)...);
    }
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where) final { return GenerateValue(where, 0); }
    Detail::RFieldValue CaptureValue(void *where) final {
-      return Detail::RFieldValue(true /* captureFlag */,
-         Detail::RColumnElement<std::int8_t>(static_cast<std::int8_t*>(where)), this, where);
+      return Detail::RFieldValue(true /* captureFlag */, this, where);
    }
    size_t GetValueSize() const final { return sizeof(std::int8_t); }
    size_t GetAlignment() const final { return alignof(std::int8_t); }
@@ -1544,14 +1523,11 @@ public:
    template <typename... ArgsT>
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where, ArgsT&&... args)
    {
-      return Detail::RFieldValue(
-         Detail::RColumnElement<std::uint8_t>(static_cast<std::uint8_t*>(where)),
-         this, static_cast<std::uint8_t*>(where), std::forward<ArgsT>(args)...);
+      return Detail::RFieldValue(this, static_cast<std::uint8_t *>(where), std::forward<ArgsT>(args)...);
    }
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where) final { return GenerateValue(where, 0); }
    Detail::RFieldValue CaptureValue(void *where) final {
-      return Detail::RFieldValue(true /* captureFlag */,
-         Detail::RColumnElement<std::uint8_t>(static_cast<std::uint8_t*>(where)), this, where);
+      return Detail::RFieldValue(true /* captureFlag */, this, where);
    }
    size_t GetValueSize() const final { return sizeof(std::uint8_t); }
    size_t GetAlignment() const final { return alignof(std::uint8_t); }
@@ -1597,14 +1573,11 @@ public:
    template <typename... ArgsT>
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
    {
-      return Detail::RFieldValue(
-         Detail::RColumnElement<std::int16_t>(static_cast<std::int16_t*>(where)),
-         this, static_cast<std::int16_t*>(where), std::forward<ArgsT>(args)...);
+      return Detail::RFieldValue(this, static_cast<std::int16_t *>(where), std::forward<ArgsT>(args)...);
    }
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0); }
    Detail::RFieldValue CaptureValue(void *where) final {
-      return Detail::RFieldValue(true /* captureFlag */,
-         Detail::RColumnElement<std::int16_t>(static_cast<std::int16_t*>(where)), this, where);
+      return Detail::RFieldValue(true /* captureFlag */, this, where);
    }
    size_t GetValueSize() const final { return sizeof(std::int16_t); }
    size_t GetAlignment() const final { return alignof(std::int16_t); }
@@ -1650,14 +1623,11 @@ public:
    template <typename... ArgsT>
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
    {
-      return Detail::RFieldValue(
-         Detail::RColumnElement<std::uint16_t>(static_cast<std::uint16_t*>(where)),
-         this, static_cast<std::uint16_t*>(where), std::forward<ArgsT>(args)...);
+      return Detail::RFieldValue(this, static_cast<std::uint16_t *>(where), std::forward<ArgsT>(args)...);
    }
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0); }
    Detail::RFieldValue CaptureValue(void *where) final {
-      return Detail::RFieldValue(true /* captureFlag */,
-         Detail::RColumnElement<std::uint16_t>(static_cast<std::uint16_t*>(where)), this, where);
+      return Detail::RFieldValue(true /* captureFlag */, this, where);
    }
    size_t GetValueSize() const final { return sizeof(std::uint16_t); }
    size_t GetAlignment() const final { return alignof(std::uint16_t); }
@@ -1703,14 +1673,11 @@ public:
    template <typename... ArgsT>
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
    {
-      return Detail::RFieldValue(
-         Detail::RColumnElement<std::int32_t>(static_cast<std::int32_t*>(where)),
-         this, static_cast<std::int32_t*>(where), std::forward<ArgsT>(args)...);
+      return Detail::RFieldValue(this, static_cast<std::int32_t *>(where), std::forward<ArgsT>(args)...);
    }
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0); }
    Detail::RFieldValue CaptureValue(void *where) final {
-      return Detail::RFieldValue(true /* captureFlag */,
-         Detail::RColumnElement<std::int32_t>(static_cast<std::int32_t*>(where)), this, where);
+      return Detail::RFieldValue(true /* captureFlag */, this, where);
    }
    size_t GetValueSize() const final { return sizeof(std::int32_t); }
    size_t GetAlignment() const final { return alignof(std::int32_t); }
@@ -1756,14 +1723,11 @@ public:
    template <typename... ArgsT>
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
    {
-      return Detail::RFieldValue(
-         Detail::RColumnElement<std::uint32_t>(static_cast<std::uint32_t*>(where)),
-         this, static_cast<std::uint32_t*>(where), std::forward<ArgsT>(args)...);
+      return Detail::RFieldValue(this, static_cast<std::uint32_t *>(where), std::forward<ArgsT>(args)...);
    }
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0); }
    Detail::RFieldValue CaptureValue(void *where) final {
-      return Detail::RFieldValue(true /* captureFlag */,
-         Detail::RColumnElement<std::uint32_t>(static_cast<std::uint32_t*>(where)), this, where);
+      return Detail::RFieldValue(true /* captureFlag */, this, where);
    }
    size_t GetValueSize() const final { return sizeof(std::uint32_t); }
    size_t GetAlignment() const final { return alignof(std::uint32_t); }
@@ -1809,14 +1773,11 @@ public:
    template <typename... ArgsT>
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
    {
-      return Detail::RFieldValue(
-         Detail::RColumnElement<std::uint64_t>(static_cast<std::uint64_t*>(where)),
-         this, static_cast<std::uint64_t*>(where), std::forward<ArgsT>(args)...);
+      return Detail::RFieldValue(this, static_cast<std::uint64_t *>(where), std::forward<ArgsT>(args)...);
    }
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0); }
    Detail::RFieldValue CaptureValue(void *where) final {
-      return Detail::RFieldValue(true /* captureFlag */,
-         Detail::RColumnElement<std::uint64_t>(static_cast<std::uint64_t*>(where)), this, where);
+      return Detail::RFieldValue(true /* captureFlag */, this, where);
    }
    size_t GetValueSize() const final { return sizeof(std::uint64_t); }
    size_t GetAlignment() const final { return alignof(std::uint64_t); }
@@ -1862,14 +1823,11 @@ public:
    template <typename... ArgsT>
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where, ArgsT&&... args)
    {
-      return Detail::RFieldValue(
-         Detail::RColumnElement<std::int64_t>(static_cast<std::int64_t*>(where)),
-         this, static_cast<std::int64_t*>(where), std::forward<ArgsT>(args)...);
+      return Detail::RFieldValue(this, static_cast<std::int64_t *>(where), std::forward<ArgsT>(args)...);
    }
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void* where) final { return GenerateValue(where, 0); }
    Detail::RFieldValue CaptureValue(void *where) final {
-      return Detail::RFieldValue(true /* captureFlag */,
-         Detail::RColumnElement<std::int64_t>(static_cast<std::int64_t*>(where)), this, where);
+      return Detail::RFieldValue(true /* captureFlag */, this, where);
    }
    size_t GetValueSize() const final { return sizeof(std::int64_t); }
    size_t GetAlignment() const final { return alignof(std::int64_t); }
@@ -2298,8 +2256,7 @@ public:
    template <typename... ArgsT>
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where, ArgsT &&...args)
    {
-      return Detail::RFieldValue(Detail::RColumnElement<std::bitset<N>>(static_cast<float *>(where)), this,
-                                 static_cast<std::bitset<N> *>(where), std::forward<ArgsT>(args)...);
+      return Detail::RFieldValue(this, static_cast<std::bitset<N> *>(where), std::forward<ArgsT>(args)...);
    }
 };
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -81,7 +81,7 @@ The field knows based on its type and the field name the type(s) and name(s) of 
 class RFieldBase {
    friend class ROOT::Experimental::RCollectionField; // to move the fields from the collection model
    friend struct ROOT::Experimental::Internal::RFieldCallbackInjector; // used for unit tests
-   using ReadCallback_t = std::function<void(RFieldValue &)>;
+   using ReadCallback_t = std::function<void(void *)>;
 
 public:
    static constexpr std::uint32_t kInvalidTypeVersion = -1U;
@@ -140,10 +140,10 @@ private:
    /// Free text set by the user
    std::string fDescription;
 
-   void InvokeReadCallbacks(RFieldValue &value)
+   void InvokeReadCallbacks(void *target)
    {
       for (const auto &func : fReadCallbacks)
-         func(value);
+         func(target);
    }
 
    /// Translate an entry index to a column element index of the principal column and viceversa.  These functions
@@ -319,7 +319,7 @@ public:
       else
          ReadGlobalImpl(globalIndex, value->GetRawPtr());
       if (R__unlikely(!fReadCallbacks.empty()))
-         InvokeReadCallbacks(*value);
+         InvokeReadCallbacks(value->GetRawPtr());
    }
 
    void Read(const RClusterIndex &clusterIndex, RFieldValue *value) {
@@ -331,7 +331,7 @@ public:
       else
          ReadInClusterImpl(clusterIndex, value->GetRawPtr());
       if (R__unlikely(!fReadCallbacks.empty()))
-         InvokeReadCallbacks(*value);
+         InvokeReadCallbacks(value->GetRawPtr());
    }
 
    /// Ensure that all received items are written from page buffers to the storage.

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -194,7 +194,7 @@ protected:
 
    /// Operations on values of complex types, e.g. ones that involve multiple columns or for which no direct
    /// column type exists.
-   virtual std::size_t AppendImpl(const RFieldValue &value);
+   virtual std::size_t AppendImpl(/* TODO: make const */ void *from);
    virtual void ReadGlobalImpl(NTupleSize_t globalIndex, void *to);
    virtual void ReadInClusterImpl(const RClusterIndex &clusterIndex, void *to)
    {
@@ -300,7 +300,7 @@ public:
    /// Returns the number of uncompressed bytes written.
    std::size_t Append(const RFieldValue& value) {
       if (~fTraits & kTraitMappable)
-         return AppendImpl(value);
+         return AppendImpl(value.GetRawPtr());
 
       fPrincipalColumn->Append(value.GetRawPtr());
       return fPrincipalColumn->GetElement()->GetPackedSize();
@@ -443,7 +443,7 @@ protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final;
    void GenerateColumnsImpl() final {}
    void GenerateColumnsImpl(const RNTupleDescriptor &) final {}
-   std::size_t AppendImpl(const Detail::RFieldValue& value) final;
+   std::size_t AppendImpl(void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
    void ReadInClusterImpl(const RClusterIndex &clusterIndex, void *to) final;
    void OnConnectPageSource() final;
@@ -559,7 +559,7 @@ protected:
    const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
-   std::size_t AppendImpl(const Detail::RFieldValue &value) final;
+   std::size_t AppendImpl(void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
 
 public:
@@ -600,7 +600,7 @@ protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const override;
    void GenerateColumnsImpl() final {}
    void GenerateColumnsImpl(const RNTupleDescriptor &) final {}
-   std::size_t AppendImpl(const Detail::RFieldValue& value) final;
+   std::size_t AppendImpl(void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
    void ReadInClusterImpl(const RClusterIndex &clusterIndex, void *to) final;
 
@@ -651,7 +651,7 @@ protected:
    const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
-   std::size_t AppendImpl(const Detail::RFieldValue& value) final;
+   std::size_t AppendImpl(void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
 
 public:
@@ -693,7 +693,7 @@ protected:
    const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
-   std::size_t AppendImpl(const Detail::RFieldValue &value) override;
+   std::size_t AppendImpl(void *from) override;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) override;
 
 public:
@@ -733,7 +733,7 @@ protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final;
    void GenerateColumnsImpl() final {}
    void GenerateColumnsImpl(const RNTupleDescriptor &) final {}
-   std::size_t AppendImpl(const Detail::RFieldValue& value) final;
+   std::size_t AppendImpl(void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
    void ReadInClusterImpl(const RClusterIndex &clusterIndex, void *to) final;
 
@@ -773,7 +773,7 @@ protected:
    const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
-   std::size_t AppendImpl(const Detail::RFieldValue &value) final;
+   std::size_t AppendImpl(void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
 
 public:
@@ -819,7 +819,7 @@ protected:
    const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
-   std::size_t AppendImpl(const Detail::RFieldValue& value) final;
+   std::size_t AppendImpl(void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
 
 public:
@@ -883,7 +883,7 @@ public:
 class RUniquePtrField : public RNullableField {
 protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final;
-   std::size_t AppendImpl(const Detail::RFieldValue &value) final;
+   std::size_t AppendImpl(void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
 
 public:
@@ -1848,7 +1848,7 @@ private:
    const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
-   std::size_t AppendImpl(const ROOT::Experimental::Detail::RFieldValue& value) final;
+   std::size_t AppendImpl(void *from) final;
    void ReadGlobalImpl(ROOT::Experimental::NTupleSize_t globalIndex, void *to) final;
 
 public:
@@ -1997,7 +1997,7 @@ protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final {
       return std::make_unique<RField>(newName);
    }
-   std::size_t AppendImpl(const Detail::RFieldValue& value) final;
+   std::size_t AppendImpl(void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
@@ -2047,8 +2047,9 @@ protected:
       auto newItemField = fSubFields[0]->Clone(fSubFields[0]->GetName());
       return std::make_unique<RField<ROOT::VecOps::RVec<ItemT>>>(newName, std::move(newItemField));
    }
-   std::size_t AppendImpl(const Detail::RFieldValue& value) final {
-      auto typedValue = value.Get<ContainerT>();
+   std::size_t AppendImpl(void *from) final
+   {
+      auto typedValue = static_cast<ContainerT *>(from);
       auto nbytes = 0;
       auto count = typedValue->size();
       for (unsigned i = 0; i < count; ++i) {

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -310,28 +310,30 @@ public:
    /// Reading copies data into the memory wrapped by the ntuple value.
    /// The fast path is conditioned by the field qualifying as simple, i.e. maps as-is to a single column and has no
    /// read callback.
-   void Read(NTupleSize_t globalIndex, RFieldValue *value) {
+   void Read(NTupleSize_t globalIndex, void *to)
+   {
       if (fIsSimple)
-         return (void)fPrincipalColumn->Read(globalIndex, value->GetRawPtr());
+         return (void)fPrincipalColumn->Read(globalIndex, to);
 
       if (fTraits & kTraitMappable)
-         fPrincipalColumn->Read(globalIndex, value->GetRawPtr());
+         fPrincipalColumn->Read(globalIndex, to);
       else
-         ReadGlobalImpl(globalIndex, value->GetRawPtr());
+         ReadGlobalImpl(globalIndex, to);
       if (R__unlikely(!fReadCallbacks.empty()))
-         InvokeReadCallbacks(value->GetRawPtr());
+         InvokeReadCallbacks(to);
    }
 
-   void Read(const RClusterIndex &clusterIndex, RFieldValue *value) {
+   void Read(const RClusterIndex &clusterIndex, void *to)
+   {
       if (fIsSimple)
-         return (void)fPrincipalColumn->Read(clusterIndex, value->GetRawPtr());
+         return (void)fPrincipalColumn->Read(clusterIndex, to);
 
       if (fTraits & kTraitMappable)
-         fPrincipalColumn->Read(clusterIndex, value->GetRawPtr());
+         fPrincipalColumn->Read(clusterIndex, to);
       else
-         ReadInClusterImpl(clusterIndex, value->GetRawPtr());
+         ReadInClusterImpl(clusterIndex, to);
       if (R__unlikely(!fReadCallbacks.empty()))
-         InvokeReadCallbacks(value->GetRawPtr());
+         InvokeReadCallbacks(to);
    }
 
    /// Ensure that all received items are written from page buffers to the storage.
@@ -2065,8 +2067,7 @@ protected:
       fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &nItems);
       typedValue->resize(nItems);
       for (unsigned i = 0; i < nItems; ++i) {
-         auto itemValue = fSubFields[0]->CaptureValue(&typedValue->data()[i]);
-         fSubFields[0]->Read(collectionStart + i, &itemValue);
+         fSubFields[0]->Read(collectionStart + i, &typedValue->data()[i]);
       }
    }
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -194,7 +194,7 @@ protected:
 
    /// Operations on values of complex types, e.g. ones that involve multiple columns or for which no direct
    /// column type exists.
-   virtual std::size_t AppendImpl(/* TODO: make const */ void *from);
+   virtual std::size_t AppendImpl(const void *from);
    virtual void ReadGlobalImpl(NTupleSize_t globalIndex, void *to);
    virtual void ReadInClusterImpl(const RClusterIndex &clusterIndex, void *to)
    {
@@ -298,7 +298,7 @@ public:
 
    /// Write the given value into columns. The value object has to be of the same type as the field.
    /// Returns the number of uncompressed bytes written.
-   std::size_t Append(/* TODO: make const */ void *from)
+   std::size_t Append(const void *from)
    {
       if (~fTraits & kTraitMappable)
          return AppendImpl(from);
@@ -444,7 +444,7 @@ protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final;
    void GenerateColumnsImpl() final {}
    void GenerateColumnsImpl(const RNTupleDescriptor &) final {}
-   std::size_t AppendImpl(void *from) final;
+   std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
    void ReadInClusterImpl(const RClusterIndex &clusterIndex, void *to) final;
    void OnConnectPageSource() final;
@@ -560,7 +560,7 @@ protected:
    const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
-   std::size_t AppendImpl(void *from) final;
+   std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
 
 public:
@@ -601,7 +601,7 @@ protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const override;
    void GenerateColumnsImpl() final {}
    void GenerateColumnsImpl(const RNTupleDescriptor &) final {}
-   std::size_t AppendImpl(void *from) final;
+   std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
    void ReadInClusterImpl(const RClusterIndex &clusterIndex, void *to) final;
 
@@ -652,7 +652,7 @@ protected:
    const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
-   std::size_t AppendImpl(void *from) final;
+   std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
 
 public:
@@ -694,7 +694,7 @@ protected:
    const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
-   std::size_t AppendImpl(void *from) override;
+   std::size_t AppendImpl(const void *from) override;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) override;
 
 public:
@@ -734,7 +734,7 @@ protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final;
    void GenerateColumnsImpl() final {}
    void GenerateColumnsImpl(const RNTupleDescriptor &) final {}
-   std::size_t AppendImpl(void *from) final;
+   std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
    void ReadInClusterImpl(const RClusterIndex &clusterIndex, void *to) final;
 
@@ -774,7 +774,7 @@ protected:
    const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
-   std::size_t AppendImpl(void *from) final;
+   std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
 
 public:
@@ -812,7 +812,7 @@ private:
 
    static std::string GetTypeList(const std::vector<Detail::RFieldBase *> &itemFields);
    /// Extracts the index from an std::variant and transforms it into the 1-based index used for the switch column
-   std::uint32_t GetTag(void *variantPtr) const;
+   std::uint32_t GetTag(const void *variantPtr) const;
    void SetTag(void *variantPtr, std::uint32_t tag) const;
 
 protected:
@@ -820,7 +820,7 @@ protected:
    const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
-   std::size_t AppendImpl(void *from) final;
+   std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
 
 public:
@@ -859,7 +859,7 @@ protected:
    void GenerateColumnsImpl(const RNTupleDescriptor &) final;
 
    std::size_t AppendNull();
-   std::size_t AppendValue(void *from);
+   std::size_t AppendValue(const void *from);
    /// Given the index of the nullable field, returns the corresponding global index of the subfield or,
    /// if it is null, returns kInvalidClusterIndex
    RClusterIndex GetItemIndex(NTupleSize_t globalIndex);
@@ -884,7 +884,7 @@ public:
 class RUniquePtrField : public RNullableField {
 protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final;
-   std::size_t AppendImpl(void *from) final;
+   std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
 
 public:
@@ -1849,7 +1849,7 @@ private:
    const RColumnRepresentations &GetColumnRepresentations() const final;
    void GenerateColumnsImpl() final;
    void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
-   std::size_t AppendImpl(void *from) final;
+   std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(ROOT::Experimental::NTupleSize_t globalIndex, void *to) final;
 
 public:
@@ -1998,7 +1998,7 @@ protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final {
       return std::make_unique<RField>(newName);
    }
-   std::size_t AppendImpl(void *from) final;
+   std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final;
 
    const RColumnRepresentations &GetColumnRepresentations() const final;
@@ -2048,9 +2048,9 @@ protected:
       auto newItemField = fSubFields[0]->Clone(fSubFields[0]->GetName());
       return std::make_unique<RField<ROOT::VecOps::RVec<ItemT>>>(newName, std::move(newItemField));
    }
-   std::size_t AppendImpl(void *from) final
+   std::size_t AppendImpl(const void *from) final
    {
-      auto typedValue = static_cast<ContainerT *>(from);
+      auto typedValue = static_cast<const ContainerT *>(from);
       auto nbytes = 0;
       auto count = typedValue->size();
       for (unsigned i = 0; i < count; ++i) {

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -298,11 +298,12 @@ public:
 
    /// Write the given value into columns. The value object has to be of the same type as the field.
    /// Returns the number of uncompressed bytes written.
-   std::size_t Append(const RFieldValue& value) {
+   std::size_t Append(/* TODO: make const */ void *from)
+   {
       if (~fTraits & kTraitMappable)
-         return AppendImpl(value.GetRawPtr());
+         return AppendImpl(from);
 
-      fPrincipalColumn->Append(value.GetRawPtr());
+      fPrincipalColumn->Append(from);
       return fPrincipalColumn->GetElement()->GetPackedSize();
    }
 
@@ -858,7 +859,7 @@ protected:
    void GenerateColumnsImpl(const RNTupleDescriptor &) final;
 
    std::size_t AppendNull();
-   std::size_t AppendValue(const Detail::RFieldValue &value);
+   std::size_t AppendValue(void *from);
    /// Given the index of the nullable field, returns the corresponding global index of the subfield or,
    /// if it is null, returns kInvalidClusterIndex
    RClusterIndex GetItemIndex(NTupleSize_t globalIndex);
@@ -2053,8 +2054,7 @@ protected:
       auto nbytes = 0;
       auto count = typedValue->size();
       for (unsigned i = 0; i < count; ++i) {
-         auto itemValue = fSubFields[0]->CaptureValue(&typedValue->data()[i]);
-         nbytes += fSubFields[0]->Append(itemValue);
+         nbytes += fSubFields[0]->Append(&typedValue->data()[i]);
       }
       this->fNWritten += count;
       fColumns[0]->Append(&this->fNWritten);

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -311,10 +311,10 @@ public:
    /// read callback.
    void Read(NTupleSize_t globalIndex, RFieldValue *value) {
       if (fIsSimple)
-         return (void)fPrincipalColumn->Read(globalIndex, &value->fMappedElement);
+         return (void)fPrincipalColumn->Read(globalIndex, value->GetRawPtr());
 
       if (fTraits & kTraitMappable)
-         fPrincipalColumn->Read(globalIndex, &value->fMappedElement);
+         fPrincipalColumn->Read(globalIndex, value->GetRawPtr());
       else
          ReadGlobalImpl(globalIndex, value);
       if (R__unlikely(!fReadCallbacks.empty()))
@@ -323,10 +323,10 @@ public:
 
    void Read(const RClusterIndex &clusterIndex, RFieldValue *value) {
       if (fIsSimple)
-         return (void)fPrincipalColumn->Read(clusterIndex, &value->fMappedElement);
+         return (void)fPrincipalColumn->Read(clusterIndex, value->GetRawPtr());
 
       if (fTraits & kTraitMappable)
-         fPrincipalColumn->Read(clusterIndex, &value->fMappedElement);
+         fPrincipalColumn->Read(clusterIndex, value->GetRawPtr());
       else
          ReadInClusterImpl(clusterIndex, value);
       if (R__unlikely(!fReadCallbacks.empty()))

--- a/tree/ntuple/v7/inc/ROOT/RFieldValue.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldValue.hxx
@@ -39,38 +39,22 @@ wrapper around the memory location, it does not own it.  Memory ownership is man
 */
 // clang-format on
 class RFieldValue {
-   friend class RFieldBase;
-
 protected:
    /// Every value is connected to a field of the corresponding type that has created the value.
    RFieldBase* fField;
    /// The memory location containing (constructed) data of a certain C++ type
    void* fRawPtr;
 
-   /// For simple types, the mapped element drills through the layers from the C++ data representation
-   /// to the primitive columns.  Otherwise, using fMappedElements is undefined.
-   /// Only RFieldBase uses fMappedElement
-   RColumnElementBase fMappedElement;
-
 public:
    RFieldValue() : fField(nullptr), fRawPtr(nullptr) {}
 
    // Constructors that wrap around existing objects; prefixed with a bool in order to help the constructor overload
    // selection.
-   RFieldValue(bool /*captureTag*/, Detail::RFieldBase* field, void* value) : fField(field), fRawPtr(value) {}
-   RFieldValue(bool /*captureTag*/, const Detail::RColumnElementBase& elem, Detail::RFieldBase* field, void* value)
-      : fField(field), fRawPtr(value), fMappedElement(elem) {}
+   RFieldValue(bool /*captureTag*/, Detail::RFieldBase *field, void *value) : fField(field), fRawPtr(value) {}
 
    // Typed constructors that initialize the given memory location
    template <typename T, typename... ArgsT>
    RFieldValue(RFieldBase* field, T* where, ArgsT&&... args) : fField(field), fRawPtr(where)
-   {
-      new (where) T(std::forward<ArgsT>(args)...);
-   }
-
-   template <typename T, typename... ArgsT>
-   RFieldValue(const Detail::RColumnElementBase& elem, Detail::RFieldBase* field, T* where, ArgsT&&... args)
-      : fField(field), fRawPtr(where), fMappedElement(elem)
    {
       new (where) T(std::forward<ArgsT>(args)...);
    }

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -413,7 +413,7 @@ public:
 
       std::size_t bytesWritten = 0;
       for (auto& value : entry) {
-         bytesWritten += value.GetField()->Append(value);
+         bytesWritten += value.GetField()->Append(value.GetRawPtr());
       }
       fUnzippedClusterSize += bytesWritten;
       fNEntries++;
@@ -480,7 +480,7 @@ public:
    void Fill() { Fill(fDefaultEntry.get()); }
    void Fill(REntry *entry) {
       for (auto &value : *entry) {
-         value.GetField()->Append(value);
+         value.GetField()->Append(value.GetRawPtr());
       }
       fOffset++;
    }

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -254,7 +254,7 @@ public:
    /// Fills a user provided entry after checking that the entry has been instantiated from the ntuple model
    void LoadEntry(NTupleSize_t index, REntry &entry) {
       for (auto& value : entry) {
-         value.GetField()->Read(index, &value);
+         value.GetField()->Read(index, value.GetRawPtr());
       }
    }
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -181,7 +181,7 @@ public:
       if constexpr (Internal::isMappable<FieldT>)
          return *fField.Map(globalIndex);
       else {
-         fField.Read(globalIndex, &fValue);
+         fField.Read(globalIndex, fValue.GetRawPtr());
          return *fValue.Get<T>();
       }
    }
@@ -191,7 +191,7 @@ public:
       if constexpr (Internal::isMappable<FieldT>)
          return *fField.Map(clusterIndex);
       else {
-         fField.Read(clusterIndex, &fValue);
+         fField.Read(clusterIndex, fValue.GetRawPtr());
          return *fValue.Get<T>();
       }
    }

--- a/tree/ntuple/v7/src/RColumn.cxx
+++ b/tree/ntuple/v7/src/RColumn.cxx
@@ -77,10 +77,10 @@ void ROOT::Experimental::Detail::RColumn::Flush()
 
    if ((fWritePage[fWritePageIdx].GetNElements() < fApproxNElementsPerPage / 2) && !fWritePage[otherIdx].IsEmpty()) {
       // Small tail page: merge with previously used page; we know that there is enough space in the shadow page
-      void *dst = fWritePage[otherIdx].GrowUnchecked(fWritePage[fWritePageIdx].GetNElements());
-      RColumnElementBase elem(fWritePage[fWritePageIdx].GetBuffer(), fWritePage[fWritePageIdx].GetElementSize());
-      elem.WriteTo(dst, fWritePage[fWritePageIdx].GetNElements());
-      fWritePage[fWritePageIdx].Reset(0);
+      auto &thisPage = fWritePage[fWritePageIdx];
+      void *dst = fWritePage[otherIdx].GrowUnchecked(thisPage.GetNElements());
+      memcpy(dst, thisPage.GetBuffer(), thisPage.GetElementSize() * thisPage.GetNElements());
+      thisPage.Reset(0);
       std::swap(fWritePageIdx, otherIdx);
    }
 

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -28,40 +28,34 @@ std::unique_ptr<ROOT::Experimental::Detail::RColumnElementBase>
 ROOT::Experimental::Detail::RColumnElementBase::Generate<void>(EColumnType type)
 {
    switch (type) {
-   case EColumnType::kIndex64: return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kIndex64>>(nullptr);
-   case EColumnType::kIndex32: return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kIndex32>>(nullptr);
-   case EColumnType::kSwitch: return std::make_unique<RColumnElement<RColumnSwitch, EColumnType::kSwitch>>(nullptr);
-   case EColumnType::kByte: return std::make_unique<RColumnElement<std::uint8_t, EColumnType::kByte>>(nullptr);
-   case EColumnType::kChar: return std::make_unique<RColumnElement<char, EColumnType::kChar>>(nullptr);
-   case EColumnType::kBit: return std::make_unique<RColumnElement<bool, EColumnType::kBit>>(nullptr);
-   case EColumnType::kReal64: return std::make_unique<RColumnElement<double, EColumnType::kReal64>>(nullptr);
-   case EColumnType::kReal32: return std::make_unique<RColumnElement<float, EColumnType::kReal32>>(nullptr);
-   case EColumnType::kInt64: return std::make_unique<RColumnElement<std::int64_t, EColumnType::kInt64>>(nullptr);
-   case EColumnType::kUInt64: return std::make_unique<RColumnElement<std::uint64_t, EColumnType::kUInt64>>(nullptr);
-   case EColumnType::kInt32: return std::make_unique<RColumnElement<std::int32_t, EColumnType::kInt32>>(nullptr);
-   case EColumnType::kUInt32: return std::make_unique<RColumnElement<std::uint32_t, EColumnType::kUInt32>>(nullptr);
-   case EColumnType::kInt16: return std::make_unique<RColumnElement<std::int16_t, EColumnType::kInt16>>(nullptr);
-   case EColumnType::kUInt16: return std::make_unique<RColumnElement<std::uint16_t, EColumnType::kUInt16>>(nullptr);
-   case EColumnType::kInt8: return std::make_unique<RColumnElement<std::int8_t, EColumnType::kInt8>>(nullptr);
-   case EColumnType::kUInt8: return std::make_unique<RColumnElement<std::uint8_t, EColumnType::kUInt8>>(nullptr);
+   case EColumnType::kIndex64: return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kIndex64>>();
+   case EColumnType::kIndex32: return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kIndex32>>();
+   case EColumnType::kSwitch: return std::make_unique<RColumnElement<RColumnSwitch, EColumnType::kSwitch>>();
+   case EColumnType::kByte: return std::make_unique<RColumnElement<std::uint8_t, EColumnType::kByte>>();
+   case EColumnType::kChar: return std::make_unique<RColumnElement<char, EColumnType::kChar>>();
+   case EColumnType::kBit: return std::make_unique<RColumnElement<bool, EColumnType::kBit>>();
+   case EColumnType::kReal64: return std::make_unique<RColumnElement<double, EColumnType::kReal64>>();
+   case EColumnType::kReal32: return std::make_unique<RColumnElement<float, EColumnType::kReal32>>();
+   case EColumnType::kInt64: return std::make_unique<RColumnElement<std::int64_t, EColumnType::kInt64>>();
+   case EColumnType::kUInt64: return std::make_unique<RColumnElement<std::uint64_t, EColumnType::kUInt64>>();
+   case EColumnType::kInt32: return std::make_unique<RColumnElement<std::int32_t, EColumnType::kInt32>>();
+   case EColumnType::kUInt32: return std::make_unique<RColumnElement<std::uint32_t, EColumnType::kUInt32>>();
+   case EColumnType::kInt16: return std::make_unique<RColumnElement<std::int16_t, EColumnType::kInt16>>();
+   case EColumnType::kUInt16: return std::make_unique<RColumnElement<std::uint16_t, EColumnType::kUInt16>>();
+   case EColumnType::kInt8: return std::make_unique<RColumnElement<std::int8_t, EColumnType::kInt8>>();
+   case EColumnType::kUInt8: return std::make_unique<RColumnElement<std::uint8_t, EColumnType::kUInt8>>();
    case EColumnType::kSplitIndex64:
-      return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kSplitIndex64>>(nullptr);
+      return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kSplitIndex64>>();
    case EColumnType::kSplitIndex32:
-      return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kSplitIndex32>>(nullptr);
-   case EColumnType::kSplitReal64: return std::make_unique<RColumnElement<double, EColumnType::kSplitReal64>>(nullptr);
-   case EColumnType::kSplitReal32: return std::make_unique<RColumnElement<float, EColumnType::kSplitReal32>>(nullptr);
-   case EColumnType::kSplitInt64:
-      return std::make_unique<RColumnElement<std::int64_t, EColumnType::kSplitInt64>>(nullptr);
-   case EColumnType::kSplitUInt64:
-      return std::make_unique<RColumnElement<std::uint64_t, EColumnType::kSplitUInt64>>(nullptr);
-   case EColumnType::kSplitInt32:
-      return std::make_unique<RColumnElement<std::int32_t, EColumnType::kSplitInt32>>(nullptr);
-   case EColumnType::kSplitUInt32:
-      return std::make_unique<RColumnElement<std::uint32_t, EColumnType::kSplitUInt32>>(nullptr);
-   case EColumnType::kSplitInt16:
-      return std::make_unique<RColumnElement<std::int16_t, EColumnType::kSplitInt16>>(nullptr);
-   case EColumnType::kSplitUInt16:
-      return std::make_unique<RColumnElement<std::uint16_t, EColumnType::kSplitUInt16>>(nullptr);
+      return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kSplitIndex32>>();
+   case EColumnType::kSplitReal64: return std::make_unique<RColumnElement<double, EColumnType::kSplitReal64>>();
+   case EColumnType::kSplitReal32: return std::make_unique<RColumnElement<float, EColumnType::kSplitReal32>>();
+   case EColumnType::kSplitInt64: return std::make_unique<RColumnElement<std::int64_t, EColumnType::kSplitInt64>>();
+   case EColumnType::kSplitUInt64: return std::make_unique<RColumnElement<std::uint64_t, EColumnType::kSplitUInt64>>();
+   case EColumnType::kSplitInt32: return std::make_unique<RColumnElement<std::int32_t, EColumnType::kSplitInt32>>();
+   case EColumnType::kSplitUInt32: return std::make_unique<RColumnElement<std::uint32_t, EColumnType::kSplitUInt32>>();
+   case EColumnType::kSplitInt16: return std::make_unique<RColumnElement<std::int16_t, EColumnType::kSplitInt16>>();
+   case EColumnType::kSplitUInt16: return std::make_unique<RColumnElement<std::uint16_t, EColumnType::kSplitUInt16>>();
    default: R__ASSERT(false);
    }
    // never here

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1186,11 +1186,11 @@ void ROOT::Experimental::RClassField::AddReadCallbacksFromIORules(const std::spa
       }
       auto func = rule->GetReadFunctionPointer();
       R__ASSERT(func != nullptr);
-      fReadCallbacks.emplace_back([func, classp](Detail::RFieldValue &value) {
+      fReadCallbacks.emplace_back([func, classp](void *target) {
          TVirtualObject oldObj{nullptr};
          oldObj.fClass = classp;
-         oldObj.fObject = value.GetRawPtr();
-         func(static_cast<char *>(value.GetRawPtr()), &oldObj);
+         oldObj.fObject = target;
+         func(static_cast<char *>(target), &oldObj);
          oldObj.fClass = nullptr; // TVirtualObject does not own the value
       });
    }

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -196,16 +196,9 @@ std::tuple<void **, std::int32_t *, std::int32_t *> GetRVecDataMembers(void *rve
    return {begin, size, capacity};
 }
 
-std::tuple<const void **, const std::int32_t *, const std::int32_t *> GetRVecDataMembers(const void *rvecPtr)
+std::tuple<const void *const *, const std::int32_t *, const std::int32_t *> GetRVecDataMembers(const void *rvecPtr)
 {
-   const void **begin = reinterpret_cast<const void **>(const_cast<void *>(rvecPtr));
-   // int32_t fSize is the second data member (after 1 void*)
-   const std::int32_t *size = reinterpret_cast<const std::int32_t *>(begin + 1);
-   R__ASSERT(*size >= 0);
-   // int32_t fCapacity is the third data member (1 int32_t after fSize)
-   const std::int32_t *capacity = size + 1;
-   R__ASSERT(*capacity >= -1);
-   return {begin, size, capacity};
+   return {GetRVecDataMembers(const_cast<void *>(rvecPtr))};
 }
 
 } // anonymous namespace

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1078,8 +1078,7 @@ std::size_t ROOT::Experimental::RField<std::string>::AppendImpl(const ROOT::Expe
 {
    auto typedValue = value.Get<std::string>();
    auto length = typedValue->length();
-   Detail::RColumnElement<char> elemChars(const_cast<char*>(typedValue->data()));
-   fColumns[1]->AppendV(elemChars, length);
+   fColumns[1]->AppendV(typedValue->data(), length);
    fIndex += length;
    fColumns[0]->Append(fElemIndex);
    return length + fColumns[0]->GetElement()->GetPackedSize();

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -2236,9 +2236,8 @@ void ROOT::Experimental::RBitsetField::ReadGlobalImpl(NTupleSize_t globalIndex, 
 {
    auto *asULongArray = value->Get<Word_t>();
    bool elementValue;
-   Detail::RColumnElement<bool> element(&elementValue);
    for (std::size_t i = 0; i < fN; ++i) {
-      fColumns[0]->Read(globalIndex * fN + i, &element);
+      fColumns[0]->Read(globalIndex * fN + i, &elementValue);
       Word_t mask = static_cast<Word_t>(1) << (i % kBitsPerWord);
       Word_t bit = static_cast<Word_t>(elementValue) << (i % kBitsPerWord);
       asULongArray[i / kBitsPerWord] = (asULongArray[i / kBitsPerWord] & ~mask) | bit;

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1095,8 +1095,7 @@ void ROOT::Experimental::RField<std::string>::ReadGlobalImpl(
       typedValue->clear();
    } else {
       typedValue->resize(nChars);
-      Detail::RColumnElement<char> elemChars(const_cast<char*>(typedValue->data()));
-      fColumns[1]->ReadV(collectionStart, nChars, &elemChars);
+      fColumns[1]->ReadV(collectionStart, nChars, const_cast<char *>(typedValue->data()));
    }
 }
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1222,10 +1222,10 @@ void ROOT::Experimental::RClassField::ReadGlobalImpl(NTupleSize_t globalIndex, D
    }
 }
 
-void ROOT::Experimental::RClassField::ReadInClusterImpl(const RClusterIndex &clusterIndex, Detail::RFieldValue *value)
+void ROOT::Experimental::RClassField::ReadInClusterImpl(const RClusterIndex &clusterIndex, void *to)
 {
    for (unsigned i = 0; i < fSubFields.size(); i++) {
-      auto memberValue = fSubFields[i]->CaptureValue(value->Get<unsigned char>() + fSubFieldsInfo[i].fOffset);
+      auto memberValue = fSubFields[i]->CaptureValue(static_cast<unsigned char *>(to) + fSubFieldsInfo[i].fOffset);
       fSubFields[i]->Read(clusterIndex, &memberValue);
    }
 }
@@ -1562,10 +1562,10 @@ void ROOT::Experimental::RRecordField::ReadGlobalImpl(NTupleSize_t globalIndex, 
    }
 }
 
-void ROOT::Experimental::RRecordField::ReadInClusterImpl(const RClusterIndex &clusterIndex, Detail::RFieldValue *value)
+void ROOT::Experimental::RRecordField::ReadInClusterImpl(const RClusterIndex &clusterIndex, void *to)
 {
    for (unsigned i = 0; i < fSubFields.size(); ++i) {
-      auto memberValue = fSubFields[i]->CaptureValue(value->Get<unsigned char>() + fOffsets[i]);
+      auto memberValue = fSubFields[i]->CaptureValue(static_cast<unsigned char *>(to) + fOffsets[i]);
       fSubFields[i]->Read(clusterIndex, &memberValue);
    }
 }
@@ -2133,9 +2133,9 @@ void ROOT::Experimental::RArrayField::ReadGlobalImpl(NTupleSize_t globalIndex, D
    }
 }
 
-void ROOT::Experimental::RArrayField::ReadInClusterImpl(const RClusterIndex &clusterIndex, Detail::RFieldValue *value)
+void ROOT::Experimental::RArrayField::ReadInClusterImpl(const RClusterIndex &clusterIndex, void *to)
 {
-   auto arrayPtr = value->Get<unsigned char>();
+   auto arrayPtr = static_cast<unsigned char *>(to);
    for (unsigned i = 0; i < fArrayLength; ++i) {
       auto itemValue = fSubFields[0]->CaptureValue(arrayPtr + (i * fItemSize));
       fSubFields[0]->Read(RClusterIndex(clusterIndex.GetClusterId(), clusterIndex.GetIndex() * fArrayLength + i),

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1774,7 +1774,7 @@ std::size_t ROOT::Experimental::RRVecField::AppendImpl(const void *from)
    auto [beginPtr, sizePtr, _] = GetRVecDataMembers(from);
 
    std::size_t nbytes = 0;
-   const char *begin = reinterpret_cast<const char *>(*beginPtr); // for pointer arithmetics
+   auto begin = reinterpret_cast<const char *>(*beginPtr); // for pointer arithmetics
    for (std::int32_t i = 0; i < *sizePtr; ++i) {
       nbytes += fSubFields[0]->Append(begin + i * fItemSize);
    }

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -678,14 +678,14 @@ TEST(RNTuple, ReadCallback)
    auto model = RNTupleModel::Create();
    auto fieldI32 = std::make_unique<RField<std::int32_t>>("i32");
    auto fieldKlass = std::make_unique<RField<CustomStruct>>("klass");
-   RFieldCallbackInjector::Inject(*fieldI32, [](RFieldValue &value) {
+   RFieldCallbackInjector::Inject(*fieldI32, [](void *target) {
       static std::int32_t expected = 0;
-      EXPECT_EQ(*value.Get<std::int32_t>(), expected++);
+      EXPECT_EQ(*static_cast<std::int32_t *>(target), expected++);
       gNCallReadCallback++;
    });
-   RFieldCallbackInjector::Inject(*fieldI32, [](RFieldValue &) { gNCallReadCallback++; });
-   RFieldCallbackInjector::Inject(*fieldKlass, [](RFieldValue &value) {
-      auto typedValue = value.Get<CustomStruct>();
+   RFieldCallbackInjector::Inject(*fieldI32, [](void *) { gNCallReadCallback++; });
+   RFieldCallbackInjector::Inject(*fieldKlass, [](void *target) {
+      auto typedValue = static_cast<CustomStruct *>(target);
       typedValue->a = 1337.0; // should change the value on the default entry
       gNCallReadCallback++;
    });

--- a/tree/ntuple/v7/test/ntuple_endian.cxx
+++ b/tree/ntuple/v7/test/ntuple_endian.cxx
@@ -97,7 +97,7 @@ public:
 
 TEST(RColumnElementEndian, ByteCopy)
 {
-   ROOT::Experimental::Detail::RColumnElement<float, EColumnType::kReal32> element(nullptr);
+   ROOT::Experimental::Detail::RColumnElement<float, EColumnType::kReal32> element;
    EXPECT_EQ(element.IsMappable(), false);
 
    RPageSinkMock sink1(element);
@@ -118,7 +118,7 @@ TEST(RColumnElementEndian, ByteCopy)
 
 TEST(RColumnElementEndian, Cast)
 {
-   ROOT::Experimental::Detail::RColumnElement<std::int64_t, EColumnType::kInt32> element(nullptr);
+   ROOT::Experimental::Detail::RColumnElement<std::int64_t, EColumnType::kInt32> element;
    EXPECT_EQ(element.IsMappable(), false);
 
    RPageSinkMock sink1(element);
@@ -143,7 +143,7 @@ TEST(RColumnElementEndian, Cast)
 
 TEST(RColumnElementEndian, Split)
 {
-   ROOT::Experimental::Detail::RColumnElement<double, EColumnType::kSplitReal64> splitElement(nullptr);
+   ROOT::Experimental::Detail::RColumnElement<double, EColumnType::kSplitReal64> splitElement;
 
    RPageSinkMock sink1(splitElement);
    unsigned char buf1[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
@@ -165,7 +165,7 @@ TEST(RColumnElementEndian, DeltaSplit)
 {
    using ClusterSize_t = ROOT::Experimental::ClusterSize_t;
 
-   ROOT::Experimental::Detail::RColumnElement<ClusterSize_t, EColumnType::kSplitIndex32> element(nullptr);
+   ROOT::Experimental::Detail::RColumnElement<ClusterSize_t, EColumnType::kSplitIndex32> element;
    EXPECT_EQ(element.IsMappable(), false);
 
    RPageSinkMock sink1(element);

--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -59,7 +59,7 @@ TYPED_TEST_SUITE(PackingIndex, PackingIndexTypes);
 
 TEST(Packing, Bitfield)
 {
-   ROOT::Experimental::Detail::RColumnElement<bool, ROOT::Experimental::EColumnType::kBit> element(nullptr);
+   ROOT::Experimental::Detail::RColumnElement<bool, ROOT::Experimental::EColumnType::kBit> element;
    element.Pack(nullptr, nullptr, 0);
    element.Unpack(nullptr, nullptr, 0);
 
@@ -94,7 +94,7 @@ TEST(Packing, RColumnSwitch)
 {
    ROOT::Experimental::Detail::RColumnElement<ROOT::Experimental::RColumnSwitch,
                                               ROOT::Experimental::EColumnType::kSwitch>
-      element(nullptr);
+      element;
    element.Pack(nullptr, nullptr, 0);
    element.Unpack(nullptr, nullptr, 0);
 
@@ -113,7 +113,7 @@ TYPED_TEST(PackingReal, SplitReal)
    using Pod_t = typename TestFixture::Helper_t::Pod_t;
    using Narrow_t = typename TestFixture::Helper_t::Narrow_t;
 
-   ROOT::Experimental::Detail::RColumnElement<Pod_t, TestFixture::Helper_t::kColumnType> element(nullptr);
+   ROOT::Experimental::Detail::RColumnElement<Pod_t, TestFixture::Helper_t::kColumnType> element;
    element.Pack(nullptr, nullptr, 0);
    element.Unpack(nullptr, nullptr, 0);
 
@@ -138,7 +138,7 @@ TYPED_TEST(PackingInt, SplitInt)
    using Pod_t = typename TestFixture::Helper_t::Pod_t;
    using Narrow_t = typename TestFixture::Helper_t::Narrow_t;
 
-   ROOT::Experimental::Detail::RColumnElement<Pod_t, TestFixture::Helper_t::kColumnType> element(nullptr);
+   ROOT::Experimental::Detail::RColumnElement<Pod_t, TestFixture::Helper_t::kColumnType> element;
    element.Pack(nullptr, nullptr, 0);
    element.Unpack(nullptr, nullptr, 0);
 
@@ -160,7 +160,7 @@ TYPED_TEST(PackingIndex, SplitIndex)
    using Pod_t = typename TestFixture::Helper_t::Pod_t;
    using Narrow_t = typename TestFixture::Helper_t::Narrow_t;
 
-   ROOT::Experimental::Detail::RColumnElement<ClusterSize_t, TestFixture::Helper_t::kColumnType> element(nullptr);
+   ROOT::Experimental::Detail::RColumnElement<ClusterSize_t, TestFixture::Helper_t::kColumnType> element;
    element.Pack(nullptr, nullptr, 0);
    element.Unpack(nullptr, nullptr, 0);
 

--- a/tree/ntuple/v7/test/rfield_vector.cxx
+++ b/tree/ntuple/v7/test/rfield_vector.cxx
@@ -139,19 +139,19 @@ TEST(RNTuple, InsideCollection)
    fieldCardinality32->ConnectPageSource(*source);
 
    auto value = field->GenerateValue();
-   field->Read(0, &value);
+   field->Read(0, value.GetRawPtr());
    auto aVec = value.Get<std::vector<float>>();
    EXPECT_EQ(1U, aVec->size());
    EXPECT_EQ(42.0, (*aVec)[0]);
    field->DestroyValue(value);
 
    auto valueCardinality64 = fieldCardinality64->GenerateValue();
-   fieldCardinality64->Read(0, &valueCardinality64);
+   fieldCardinality64->Read(0, valueCardinality64.GetRawPtr());
    EXPECT_EQ(1U, *valueCardinality64.Get<std::uint64_t>());
    fieldCardinality64->DestroyValue(valueCardinality64);
 
    auto valueCardinality32 = fieldCardinality32->GenerateValue();
-   fieldCardinality32->Read(0, &valueCardinality32);
+   fieldCardinality32->Read(0, valueCardinality32.GetRawPtr());
    EXPECT_EQ(1U, *valueCardinality32.Get<std::uint32_t>());
    fieldCardinality32->DestroyValue(valueCardinality32);
 


### PR DESCRIPTION
As discussed in the last I/O meeting, the current RFieldBase API for reading and writing is flawed.  The `RFieldBase::Read()` and `RFieldBase::Append()` methods take `RFieldValue` parameters, as thin wrappers around the target/source memory location. This is a misuse of the `RFieldValue` class and does not provide any additional benefit.

This PR changes the RFieldBase read/write APIs to use void pointers instead. It applies a similar change to the underlying `RColumn` read/write API (note that `RColumn` is supposed to be an internal API. NB: it still needs to move from `ROOT::Detail` to `ROOT::Internal`).

In a follow-up PR, the following change is foreseen:
  - Make `RFieldValue` an inner class of `RFieldBase`, i.e. `RFieldBase::RValue`
  - Make `RFieldBase::Read()` and `RFieldBase::Append()` protected
  - Call the `RFieldBase` read/write API only through `RFieldBase::RValue`
 
This would prevent random memory locations from using the RField read/write API. Only memory locations that come from a certain field (e.g., created by that field) will use the RField read/write API.