### PR TITLE
[cling] Unify access to template_arguments

### DIFF
--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -1578,9 +1578,6 @@ bool ROOT::TMetaUtils::hasOpaqueTypedef(clang::QualType instanceType, const ROOT
           I!=E; ++I)
       {
          if (I->getKind() == clang::TemplateArgument::Type) {
-   //            std::string arg;
-   //            arg = GetQualifiedName( I->getAsType(), *clxx );
-   //            fprintf(stderr,"DEBUG: looking at %s\n", arg.c_str());
             result |= ROOT::TMetaUtils::hasOpaqueTypedef(I->getAsType(), normCtxt);
          }
       }

--- a/interpreter/cling/lib/Interpreter/ForwardDeclPrinter.cpp
+++ b/interpreter/cling/lib/Interpreter/ForwardDeclPrinter.cpp
@@ -1184,7 +1184,7 @@ namespace cling {
       {
         const TemplateSpecializationType* TST
           = static_cast<const TemplateSpecializationType*>(typ);
-        for (const TemplateArgument& TA: *TST) {
+        for (const TemplateArgument& TA : TST->template_arguments()) {
           VisitTemplateArgument(TA);
           if (m_SkipFlag) {
             skipDecl(nullptr, "template argument failed");

--- a/interpreter/cling/lib/Utils/AST.cpp
+++ b/interpreter/cling/lib/Utils/AST.cpp
@@ -274,15 +274,12 @@ namespace utils {
 
       bool mightHaveChanged = false;
       llvm::SmallVector<TemplateArgument, 4> desArgs;
-      for (TemplateSpecializationType::iterator
-             I = TST->begin(), E = TST->end();
-          I != E; ++I) {
-
+      for (const TemplateArgument& Arg : TST->template_arguments()) {
         // cheap to copy and potentially modified by
         // GetFullyQualifedTemplateArgument
-        TemplateArgument arg(*I);
-        mightHaveChanged |= GetFullyQualifiedTemplateArgument(Ctx,arg);
-        desArgs.push_back(arg);
+        TemplateArgument CopiedArg = Arg;
+        mightHaveChanged |= GetFullyQualifiedTemplateArgument(Ctx, CopiedArg);
+        desArgs.push_back(CopiedArg);
       }
 
       // If desugaring happened allocate new type in the AST.
@@ -1232,10 +1229,12 @@ namespace utils {
 
       bool mightHaveChanged = false;
       llvm::SmallVector<TemplateArgument, 4> desArgs;
+      llvm::ArrayRef<clang::TemplateArgument> template_arguments =
+          TST->template_arguments();
       unsigned int argi = 0;
-      for(TemplateSpecializationType::iterator I = TST->begin(), E = TST->end();
-          I != E; ++I, ++argi) {
-
+      for (const clang::TemplateArgument *I = template_arguments.begin(),
+                                         *E = template_arguments.end();
+           I != E; ++I, ++argi) {
         if (I->getKind() == TemplateArgument::Expression) {
           // If we have an expression, we need to replace it / desugar it
           // as it could contain unqualifed (or partially qualified or


### PR DESCRIPTION
The other methods, such as directly calling begin() and end() as well as getNumArgs() and getArgs() will go away in LLVM 16, see commit https://github.com/llvm/llvm-project/commit/1acffe81ee.