### PR TITLE
[ntuple] Faster iteration of array-backed proxied collections

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -481,7 +481,8 @@ private:
          TVirtualCollectionProxy::DeleteTwoIterators_t fDeleteTwoIterators;
          TVirtualCollectionProxy::Next_t fNext;
       };
-      static RIteratorFuncs GetIteratorFuncs(TVirtualCollectionProxy *proxy, bool readOnly);
+      static RIteratorFuncs GetIteratorFuncs(TVirtualCollectionProxy *proxy, bool readFromDisk);
+
    private:
       class RIterator {
          const RCollectionIterableOnce &fOwner;
@@ -541,7 +542,8 @@ private:
    std::unique_ptr<TVirtualCollectionProxy> fProxy;
    Int_t fProperties;
    Int_t fCollectionType;
-   /// Two sets of functions to operate on iterators, to be used depending on the access type
+   /// Two sets of functions to operate on iterators, to be used depending on the access type.  The direction preserves
+   /// the meaning from TVirtualCollectionProxy, i.e. read from disk / write to disk, respectively
    RCollectionIterableOnce::RIteratorFuncs fIFuncsRead;
    RCollectionIterableOnce::RIteratorFuncs fIFuncsWrite;
    std::size_t fItemSize;


### PR DESCRIPTION
This pull request is a follow-up of #13197, improving the implementation of the internal class `RCollectionClassField::RCollectionIterableOnce`.

## Changes or fixes:
- Allow for faster iteration of elements in a collection whose elements are guaranteed to be contiguous in memory (e.g. a vector), i.e. the address of each element is known given the base pointer.  For such cases, a non-zero value for the `stride` argument can be provided, thus avoiding an indirect call on each `operator++` call.
- Fix and clarify the use of read/write iterators on a proxied collection.  The meaning of the `read` argument in many
TVirtualCollectionProxy functions is "read from disk", i.e. write in memory.

This should improve the situation for the PR introducing support for `std::set<T>` fields (#12948).

## Checklist:
- [x] tested changes locally
- [x] updated the docs (if necessary)