### PR TITLE
[rbrowser] provide progess handlers, use for TTree::Draw

### DIFF
--- a/gui/browserv7/inc/ROOT/RBrowser.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowser.hxx
@@ -37,6 +37,8 @@ protected:
    std::vector<std::shared_ptr<RBrowserWidget>> fWidgets; ///<!  all browser widgets
    int fWidgetCnt{0};                                     ///<! counter for created widgets
    std::string fPromptFileOutput;        ///<! file name for prompt output
+   float fLastProgressSend{0};           ///<! last value of send progress
+   long long fLastProgressSendTm{0};      ///<! time when last progress message was send
 
    std::shared_ptr<RWebWindow> fWebWindow;   ///<! web window to browser
 
@@ -50,7 +52,7 @@ protected:
    void CloseTab(const std::string &name);
 
    std::string ProcessBrowserRequest(const std::string &msg);
-   std::string ProcessDblClick(std::vector<std::string> &args);
+   std::string ProcessDblClick(unsigned connid, std::vector<std::string> &args);
    std::string NewWidgetMsg(std::shared_ptr<RBrowserWidget> &widget);
    void ProcessRunMacro(const std::string &file_path);
    void ProcessSaveFile(const std::string &fname, const std::string &content);
@@ -61,6 +63,7 @@ protected:
 
    void SendInitMsg(unsigned connid);
    void ProcessMsg(unsigned connid, const std::string &arg);
+   void SendProgress(unsigned connid, float progr);
 
    void AddInitWidget(const std::string &kind);
 

--- a/gui/browserv7/inc/ROOT/RBrowser.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowser.hxx
@@ -23,8 +23,11 @@ namespace ROOT {
 namespace Experimental {
 
 class RBrowserWidget;
+class RBrowserTimer;
 
 class RBrowser {
+
+   friend class RBrowserTimer;
 
 protected:
 
@@ -42,7 +45,9 @@ protected:
 
    std::shared_ptr<RWebWindow> fWebWindow;   ///<! web window to browser
 
-   RBrowserData  fBrowsable;                   ///<! central browsing element
+   RBrowserData  fBrowsable;                 ///<! central browsing element
+   std::unique_ptr<RBrowserTimer>    fTimer; ///<!  timer to handle postponed requests
+   std::vector<std::vector<std::string>> fPostponed; ///<! postponed messages, handled in timer
 
    std::shared_ptr<RBrowserWidget> AddWidget(const std::string &kind);
    std::shared_ptr<RBrowserWidget> AddCatchedWidget(const std::string &url, const std::string &kind);
@@ -68,6 +73,8 @@ protected:
    void AddInitWidget(const std::string &kind);
 
    void CheckWidgtesModified();
+
+   void ProcessPostponedRequests();
 
 public:
    RBrowser(bool use_rcanvas = false);

--- a/gui/browserv7/src/RBrowserRCanvasWidget.cxx
+++ b/gui/browserv7/src/RBrowserRCanvasWidget.cxx
@@ -65,6 +65,8 @@ public:
       if (!obj)
          return false;
 
+      Browsable::RProvider::ExtendProgressHandle(elem.get(), obj.get());
+
       std::shared_ptr<RPadBase> subpad = fCanvas;
 
       std::string drawopt = opt;

--- a/gui/browserv7/src/RBrowserTCanvasWidget.cxx
+++ b/gui/browserv7/src/RBrowserTCanvasWidget.cxx
@@ -142,6 +142,11 @@ public:
 
       gROOT->GetListOfCanvases()->Remove(fCanvas.get());
 
+      if ((fCanvas->GetCanvasID() == -1) && (fCanvas->GetCanvasImp() == fWebCanvas)) {
+         fCanvas->SetCanvasImp(nullptr);
+         delete fWebCanvas;
+      }
+
       fCanvas->Close();
    }
 

--- a/gui/browserv7/src/RBrowserTCanvasWidget.cxx
+++ b/gui/browserv7/src/RBrowserTCanvasWidget.cxx
@@ -176,6 +176,8 @@ public:
       if (!obj)
          return false;
 
+      Browsable::RProvider::ExtendProgressHandle(elem.get(), obj.get());
+
       std::string drawopt = opt;
 
       // first remove all objects which may belong to removed pads

--- a/tree/webviewer/inc/ROOT/RTreeViewer.hxx
+++ b/tree/webviewer/inc/ROOT/RTreeViewer.hxx
@@ -29,11 +29,13 @@ namespace ROOT {
 namespace Experimental {
 
 class RWebWindow;
-class TProgressTimer;
+class RTreeDrawMonitoring;
+class RTreeDrawInvokeTimer;
 
 class RTreeViewer {
 
-friend class TProgressTimer;
+friend class RTreeDrawMonitoring;
+friend class RTreeDrawInvokeTimer;
 
 public:
 
@@ -89,8 +91,8 @@ private:
    bool fShowHierarchy{false};             ///<! show TTree hierarchy
    RConfig fCfg;                           ///<! configuration, exchanged between client and server
    PerformDrawCallback_t fCallback;        ///<! callback invoked when tree draw performed
-   std::unique_ptr<TProgressTimer> fProgrTimer; ///<! timer used to get draw progress
    std::string fLastSendProgress;          ///<! last send progress to client
+   std::unique_ptr<RTreeDrawInvokeTimer> fTimer; ///<!  timer to invoke tree draw
 
    void WebWindowConnect(unsigned connid);
    void WebWindowCallback(unsigned connid, const std::string &arg);
@@ -103,9 +105,9 @@ private:
 
    void UpdateConfig();
 
-   void SendProgress(bool completed = false);
+   void SendProgress(Double_t nevent = 0.);
 
-   void InvokeTreeDraw(const std::string &json);
+   void InvokeTreeDraw();
 };
 
 } // namespace Experimental


### PR DESCRIPTION

![progress](https://github.com/root-project/root/assets/4936580/98687f37-f747-4f2c-ab8a-0f3b0375107d)
1. Introduce progress handlers for browsables objects
2. Provide progress information when performing `TTree::Draw`
3. Display such progress on the client side in the warning dialog - while waiting on result of double click
4. Use `TVirtualMonitoringWriter` handle to hook inside `TTree::Draw` processing loop
5. Execute long operations (like tree draw) outside of websocket data handler to let receive other messages
6. Fix cleanup problem of widgets in RBrowser - JSROOT elements were not destroyed properly