### PR TITLE
Added support for GDML read/write of scaled solids.

### DIFF
--- a/geom/gdml/inc/TGDMLParse.h
+++ b/geom/gdml/inc/TGDMLParse.h
@@ -165,6 +165,7 @@ private:
    XMLNodePointer_t  Reflection(TXMLEngine* gdml, XMLNodePointer_t node, XMLAttrPointer_t attr);
    XMLNodePointer_t  Ellipsoid(TXMLEngine* gdml, XMLNodePointer_t node, XMLAttrPointer_t attr);
    XMLNodePointer_t  Tessellated(TXMLEngine* gdml, XMLNodePointer_t node, XMLAttrPointer_t attr);
+   XMLNodePointer_t  ScaledSolid(TXMLEngine* gdml, XMLNodePointer_t node, XMLAttrPointer_t attr);
 
    //'structure' section
    XMLNodePointer_t  VolProcess(TXMLEngine* gdml, XMLNodePointer_t node);

--- a/geom/gdml/inc/TGDMLWrite.h
+++ b/geom/gdml/inc/TGDMLWrite.h
@@ -197,6 +197,7 @@ private:
    XMLNodePointer_t CreateXtrusionN(TGeoXtru * geoShape);
    XMLNodePointer_t CreateEllipsoidN(TGeoCompositeShape * geoShape, TString elName);
    XMLNodePointer_t CreateElConeN(TGeoScaledShape * geoShape);
+   XMLNodePointer_t CreateScaledN(TGeoScaledShape * geoShape);
    XMLNodePointer_t CreateTessellatedN(TGeoTessellated * geoShape);
    XMLNodePointer_t CreateOpticalSurfaceN(TGeoOpticalSurface * geoSurf);
    XMLNodePointer_t CreateSkinSurfaceN(TGeoSkinSurface * geoSurf);


### PR DESCRIPTION
# This Pull request:
Adds GDML support for `scaledSolid` tag
## Changes or fixes:
Given that Geant4 supports the `scaledSolid` tag, all TGeo scaled solids are exported using this tag now. Below is a snapshot of the solids produced after importing the Geant4 persistency example `examples/extended/persistency/gdml/G01/scaledSolids.gdml` <img src="https://github.com/root-project/root/assets/18400453/dd95e08f-a3b7-47c1-8e86-844a66aae167" width="600">

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #13194

