### PR TITLE
[webgui] provide API to create several images at once

### DIFF
--- a/gui/webdisplay/inc/ROOT/RWebDisplayHandle.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebDisplayHandle.hxx
@@ -18,6 +18,7 @@
 #include <string>
 #include <map>
 #include <memory>
+#include <vector>
 
 namespace ROOT {
 namespace Experimental {
@@ -109,6 +110,8 @@ public:
    static bool CanProduceImages(const std::string &browser = "");
 
    static bool ProduceImage(const std::string &fname, const std::string &json, int width = 800, int height = 600, const char *batch_file = nullptr);
+
+   static bool ProduceImages(const std::string &fname, const std::vector<std::string> &jsons, const std::vector<int> &widths, const std::vector<int> &heights, const char *batch_file = nullptr);
 };
 
 }

--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -928,7 +928,7 @@ try_again:
       wait_file_name = tgtfilename;
 
       if (EndsWith(".pdf"))
-         args.SetExtraArgs("--print-to-pdf="s + gSystem->UnixPathName(tgtfilename.Data()));
+         args.SetExtraArgs("--print-to-pdf-no-header --print-to-pdf="s + gSystem->UnixPathName(tgtfilename.Data()));
       else
          args.SetExtraArgs("--screenshot="s + gSystem->UnixPathName(tgtfilename.Data()));
 

--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -236,6 +236,8 @@ public:
 
    static bool ProduceImage(TPad *pad, const char *filename, Int_t width = 0, Int_t height = 0);
 
+   static bool ProduceImages(std::vector<TPad *> pads, const char *filename, Int_t width = 0, Int_t height = 0);
+
    static TCanvasImp *NewCanvas(TCanvas *c, const char *name, Int_t x, Int_t y, UInt_t width, UInt_t height);
 
    ClassDefOverride(TWebCanvas, 0) // Web-based implementation for TCanvasImp

--- a/js/files/canv_batch.htm
+++ b/js/files/canv_batch.htm
@@ -15,18 +15,18 @@
 </head>
 
 <body style="margin:0; padding:0; overflow:hidden">
-  <div id="drawing" style="width:$draw_widthpx; height:$draw_heightpx; overflow:hidden; margin:0; padding:0"></div>
 </body>
 
 <script id="data">
-   globalThis.main_object = JSROOT.parse($draw_object);
+   globalThis.main_kind = "$draw_kind";
+   globalThis.main_widths = $draw_widths;
+   globalThis.main_heights = $draw_heights;
+   globalThis.main_objects = $draw_objects;
 </script>
 
 <script>
 
    JSROOT.setBatchMode(true);
-
-   let kind = "$draw_kind";
 
    function complete() {
       if (JSROOT.browser.isFirefox && window && (typeof window.dump == "function")) {
@@ -35,22 +35,56 @@
       }
    }
 
-   JSROOT.draw("drawing", globalThis.main_object, "").then(painter => {
-      document.getElementById('data').remove();
-      if (kind == 'draw')
+   let doms = [], promises = [];
+
+   for (let i = 0; i < globalThis.main_objects.length; ++i) {
+      let dom = document.createElement('div');
+      dom.style.overflow = 'hidden';
+      dom.style.margin = '0';
+      dom.style.padding = '0';
+      dom.style.width = globalThis.main_widths[i] + 'px';
+      dom.style.height = globalThis.main_heights[i] + 'px';
+      document.body.append(dom);
+      doms.push(dom);
+   }
+
+   for (let i = 0; i < globalThis.main_objects.length; ++i) {
+      let obj = JSROOT.parse(globalThis.main_objects[i]);
+      let pr = JSROOT.draw(doms[i], obj, '');
+      promises.push(pr);
+   }
+
+   // remove data
+   document.getElementById('data').remove();
+
+   // complete drawings
+   Promise.all(promises).then(arr => {
+      // as result, got array of painters
+      if (globalThis.main_kind == 'draw')
          return complete();
 
-      painter.produceImage(true, kind).then(res => {
+      let promises2 = [];
 
-         let elem = document.getElementById('drawing');
-         elem.removeAttribute('style');
-         if (kind == 'svg') {
-            elem.innerHTML = res;
-         } else {
-            elem.innerHTML = '';
-            let img = document.createElement('img');
-            img.setAttribute('src', res);
-            elem.appendChild(img);
+      for(let i = 0; i < arr.length; ++i) {
+         let painter = arr[i],
+             pr2 = painter.produceImage(true, globalThis.main_kind);
+         promises2.push(pr2);
+      }
+
+      return Promise.all(promises2).then(arr2 => {
+         // as result, got array of images
+
+         for(let i = 0; i < arr2.length; ++i) {
+            let res = arr2[i], elem = doms[i];
+            elem.removeAttribute('style');
+            if (globalThis.main_kind == 'svg') {
+               elem.innerHTML = res;
+            } else {
+               elem.innerHTML = '';
+               let img = document.createElement('img');
+               img.setAttribute('src', res);
+               elem.appendChild(img);
+            }
          }
 
          complete();

--- a/js/files/canv_batch.htm
+++ b/js/files/canv_batch.htm
@@ -6,9 +6,7 @@
    <title>Batch production</title>
    <style>
      @media print {
-        @page { margin: 0; }
-        body { margin: 1.6cm; }
-        div.page { page-break-after: always; page-break-inside: avoid; }
+        @page { margin: 10mm; size: 210mm 297mm; }
      }
   </style>
   <script src="$jsrootsys/build/jsroot.js"></script>
@@ -44,6 +42,8 @@
       dom.style.padding = '0';
       dom.style.width = globalThis.main_widths[i] + 'px';
       dom.style.height = globalThis.main_heights[i] + 'px';
+      if (i > 0) dom.style['page-break-before'] = 'always';
+      dom.style['page-break-inside'] = 'avoid';
       document.body.append(dom);
       doms.push(dom);
    }


### PR DESCRIPTION
Using approach as before, just perform multiple `JSROOT.draw` inside
this special HTML file. When producing PDF - all these images should
be dump in single file. In all other cases correspondent number of
image files will be created.

Advantage of such approach - starting web browser and loading JSROOT
scripts happens only once.

Improve PDF generation

Simple 100 images can be generated in ~3 seconds (instead of 70s if doing one by one)