### PR TITLE
[core][skip-ci] Improve TDataMember documentation

### DIFF
--- a/core/meta/src/TDataMember.cxx
+++ b/core/meta/src/TDataMember.cxx
@@ -403,7 +403,9 @@ Int_t TDataMember::GetMaxIndex(Int_t dim) const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Get type of data member, e,g.: "class TDirectory*" -> "TDirectory".
+/// Get the decayed type name of this data member, removing `const` and `volatile` qualifiers, and pointers `*` and
+/// references `&`.  This function resolves typedefs in the type name. E.g., let `Foo_t` be a typedef to `class
+/// TDirectory`; assuming `this` is a member of type `const Foo_t*`, this function will return `TDirectory`.
 
 const char *TDataMember::GetTypeName() const
 {
@@ -412,7 +414,11 @@ const char *TDataMember::GetTypeName() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Get full type description of data member, e,g.: "class TDirectory*".
+/// Get the concrete type name of this data member, including `const` and `volatile` qualifiers.  This function does not
+/// resolve any typedef in the type name. E.g., let `Foo_t` be a typedef to `class TDirectory`; assuming `this` is a
+/// member of type `const Foo_t*`, this function will return `const Foo_t*`.
+///
+/// For the desugared type name, see TDataMember::GetTrueTypeName().
 
 const char *TDataMember::GetFullTypeName() const
 {
@@ -422,7 +428,9 @@ const char *TDataMember::GetFullTypeName() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Get full type description of data member, e,g.: "class TDirectory*".
+/// Get the desugared type name of this data member, including `const` and `volatile` qualifiers.  This function
+/// resolves typedefs in the type name. E.g., let `Foo_t` be a typedef to `class TDirectory`; assuming `this` is a
+/// member of type `const Foo_t*`, this function will return `const TDirectory*`.
 
 const char *TDataMember::GetTrueTypeName() const
 {


### PR DESCRIPTION
This pull request fixes / improves the documentation for the `TDataMember::GetXyzTypeName()` member functions.

## Checklist:
- [x] updated the docs (if necessary)