### PR TITLE
Correct GL drawing for scaled shapes

### DIFF
--- a/core/base/inc/TBuffer3D.h
+++ b/core/base/inc/TBuffer3D.h
@@ -89,6 +89,7 @@ public:
    Short_t     fTransparency;    // Percentage transparency [0,100]
    Bool_t      fLocalFrame;      // True = Local, False = Master reference frame
    Bool_t      fReflection;      // Matrix is reflection
+   Bool_t      fScaled;          // The shape is scaled
    Double_t    fLocalMaster[16]; // Local->Master Matrix - identity if master frame
 
    // SECTION: kBoundingBox

--- a/core/base/src/TBuffer3D.cxx
+++ b/core/base/src/TBuffer3D.cxx
@@ -250,6 +250,7 @@ void TBuffer3D::Init()
    fTransparency  = 0;
    fLocalFrame    = kFALSE;
    fReflection    = kFALSE;
+   fScaled        = kFALSE;
    SetLocalMasterIdentity();
 
    // Reset bounding box

--- a/geom/geom/src/TGeoScaledShape.cxx
+++ b/geom/geom/src/TGeoScaledShape.cxx
@@ -196,6 +196,7 @@ TGeoVolume *TGeoScaledShape::Divide(TGeoVolume * /*voldiv*/, const char *divname
 const TBuffer3D & TGeoScaledShape::GetBuffer3D(Int_t reqSections, Bool_t localFrame) const
 {
    TBuffer3D &buffer = (TBuffer3D &)fShape->GetBuffer3D(reqSections, localFrame);
+   buffer.fScaled = kTRUE;
 
 //   TGeoBBox::FillBuffer3D(buffer, reqSections, localFrame);
    Double_t halfLengths[3] = { fDX, fDY, fDZ };

--- a/graf3d/gl/src/TGLScenePad.cxx
+++ b/graf3d/gl/src/TGLScenePad.cxx
@@ -597,6 +597,11 @@ Int_t TGLScenePad::ValidateObjectBuffer(const TBuffer3D& buffer, Bool_t includeR
    {
       needRaw = kTRUE;
    }
+   // 6. The shape is scaled
+   else if (buffer.fScaled)
+   {
+      needRaw = kTRUE;
+   }
 
    if (needRaw && !buffer.SectionsValid(TBuffer3D::kRawSizes|TBuffer3D::kRaw)) {
       return TBuffer3D::kRawSizes|TBuffer3D::kRaw;


### PR DESCRIPTION
# This Pull request:
Fixes GL drawing for scaled shapes which are normally optimized to use GL primitives and appeared un-scaled (e.g. tubes)

## Changes or fixes:
Added new flag `TBuffer3D::fScaled` set by `TGeoScaledShape::GetBuffer3D` and used by the viewer to decide if `TBuffer3D::kRaw` section needs to be filled/used

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

