### PR TITLE
[windows] Export several potentially missing symbols

### DIFF
--- a/core/metacling/src/CMakeLists.txt
+++ b/core/metacling/src/CMakeLists.txt
@@ -129,6 +129,14 @@ if(MSVC)
       __std_terminate
       cling_runtime_internal_throwIfInvalidPointer
   )
+  if(MSVC_VERSION GREATER_EQUAL 1936)
+    set(cling_exports ${cling_exports}
+        __std_find_trivial_1
+        __std_find_trivial_2
+        __std_find_trivial_4
+        __std_find_trivial_8
+    )
+  endif()
   if(CMAKE_CXX_STANDARD GREATER 14)
     set(cling_exports ${cling_exports}
       _Smtx_lock_shared


### PR DESCRIPTION
This fixes the following type of error with recent versions of Visual Studio (v17.6):
```
800: Processing C:/root-dev/git/debug/tutorials/roofit/rf614_binned_fit_problems.C...
800: IncrementalExecutor::executeFunction: symbol '__std_find_trivial_8' unresolved while linking [cling interface function]!
800: You are probably missing the definition of __std_find_trivial_8
800: Maybe you need to load the corresponding shared library?
```
