### PR TITLE
[ntuple] Avoid the use of `TClassEdit::ResolveTypedef()` in the creation of class members' fields

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -221,7 +221,7 @@ protected:
    /// Factory method to resurrect a field from the stored on-disk type information.  This overload takes an already
    /// normalized type name and type alias
    static RResult<std::unique_ptr<RFieldBase>>
-   Create(const std::string &fieldName, const std::string &normalizedType, const std::string &typeAlias);
+   Create(const std::string &fieldName, const std::string &canonicalType, const std::string &typeAlias);
 
 public:
    /// Iterates over the sub tree of fields in depth-first search order

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -218,6 +218,10 @@ protected:
    /// are changed to their unencoded counterparts.
    void AutoAdjustColumnTypes(const RNTupleWriteOptions &options);
 
+   /// Factory method to resurrect a field from the stored on-disk type information.  This overload takes an already
+   /// normalized type name and type alias
+   static RResult<std::unique_ptr<RFieldBase>>
+   Create(const std::string &fieldName, const std::string &normalizedType, const std::string &typeAlias);
 
 public:
    /// Iterates over the sub tree of fields in depth-first search order

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -220,6 +220,8 @@ protected:
 
    /// Factory method to resurrect a field from the stored on-disk type information.  This overload takes an already
    /// normalized type name and type alias
+   /// TODO(jalopezg): this overload may eventually be removed leaving only the `RFieldBase::Create()` that takes a
+   /// single type name
    static RResult<std::unique_ptr<RFieldBase>>
    Create(const std::string &fieldName, const std::string &canonicalType, const std::string &typeAlias);
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1172,13 +1172,14 @@ ROOT::Experimental::RClassField::RClassField(std::string_view fieldName, std::st
          continue;
       }
 
-      std::string typeName{dataMember->GetFullTypeName()};
+      std::string typeName{GetNormalizedTypeName(dataMember->GetTrueTypeName())};
+      std::string typeAlias{GetNormalizedTypeName(dataMember->GetFullTypeName())};
       // For C-style arrays, complete the type name with the size for each dimension, e.g. `int[4][2]`
       if (dataMember->Property() & kIsArray) {
          for (int dim = 0, n = dataMember->GetArrayDim(); dim < n; ++dim)
             typeName += "[" + std::to_string(dataMember->GetMaxIndex(dim)) + "]";
       }
-      auto subField = Detail::RFieldBase::Create(dataMember->GetName(), typeName).Unwrap();
+      auto subField = Detail::RFieldBase::Create(dataMember->GetName(), typeName, typeAlias).Unwrap();
       fTraits &= subField->GetTraits();
       Attach(std::move(subField),
 	     RSubFieldInfo{kDataMember, static_cast<std::size_t>(dataMember->GetOffset())});

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -251,6 +251,13 @@ ROOT::Experimental::Detail::RFieldBase::Create(const std::string &fieldName, con
 {
    auto typeAlias = GetNormalizedTypeName(typeName);
    auto normalizedType = GetNormalizedTypeName(GetCanonicalTypeName(typeAlias));
+   return R__FORWARD_RESULT(RFieldBase::Create(fieldName, normalizedType, typeAlias));
+}
+
+ROOT::Experimental::RResult<std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>>
+ROOT::Experimental::Detail::RFieldBase::Create(const std::string &fieldName, const std::string &normalizedType,
+                                               const std::string &typeAlias)
+{
    if (normalizedType.empty())
       return R__FAIL("no type name specified for Field " + fieldName);
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -250,138 +250,138 @@ ROOT::Experimental::RResult<std::unique_ptr<ROOT::Experimental::Detail::RFieldBa
 ROOT::Experimental::Detail::RFieldBase::Create(const std::string &fieldName, const std::string &typeName)
 {
    auto typeAlias = GetNormalizedTypeName(typeName);
-   auto normalizedType = GetNormalizedTypeName(GetCanonicalTypeName(typeAlias));
-   return R__FORWARD_RESULT(RFieldBase::Create(fieldName, normalizedType, typeAlias));
+   auto canonicalType = GetNormalizedTypeName(GetCanonicalTypeName(typeAlias));
+   return R__FORWARD_RESULT(RFieldBase::Create(fieldName, canonicalType, typeAlias));
 }
 
 ROOT::Experimental::RResult<std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>>
-ROOT::Experimental::Detail::RFieldBase::Create(const std::string &fieldName, const std::string &normalizedType,
+ROOT::Experimental::Detail::RFieldBase::Create(const std::string &fieldName, const std::string &canonicalType,
                                                const std::string &typeAlias)
 {
-   if (normalizedType.empty())
+   if (canonicalType.empty())
       return R__FAIL("no type name specified for Field " + fieldName);
 
-   if (auto [arrayBaseType, arraySize] = ParseArrayType(normalizedType); !arraySize.empty()) {
+   if (auto [arrayBaseType, arraySize] = ParseArrayType(canonicalType); !arraySize.empty()) {
       // TODO(jalopezg): support multi-dimensional row-major (C order) arrays in RArrayField
       if (arraySize.size() > 1)
-         return R__FAIL("multi-dimensional array type not supported " + normalizedType);
+         return R__FAIL("multi-dimensional array type not supported " + canonicalType);
       auto itemField = Create("_0", arrayBaseType).Unwrap();
       return {std::make_unique<RArrayField>(fieldName, std::move(itemField), arraySize[0])};
    }
 
    std::unique_ptr<ROOT::Experimental::Detail::RFieldBase> result;
 
-   if (normalizedType == "ROOT::Experimental::ClusterSize_t") {
+   if (canonicalType == "ROOT::Experimental::ClusterSize_t") {
       result = std::make_unique<RField<ClusterSize_t>>(fieldName);
-   } else if (normalizedType == "bool") {
+   } else if (canonicalType == "bool") {
       result = std::make_unique<RField<bool>>(fieldName);
-   } else if (normalizedType == "char") {
+   } else if (canonicalType == "char") {
       result = std::make_unique<RField<char>>(fieldName);
-   } else if (normalizedType == "std::int8_t") {
+   } else if (canonicalType == "std::int8_t") {
       result = std::make_unique<RField<std::int8_t>>(fieldName);
-   } else if (normalizedType == "std::uint8_t") {
+   } else if (canonicalType == "std::uint8_t") {
       result = std::make_unique<RField<std::uint8_t>>(fieldName);
-   } else if (normalizedType == "std::int16_t") {
+   } else if (canonicalType == "std::int16_t") {
       result = std::make_unique<RField<std::int16_t>>(fieldName);
-   } else if (normalizedType == "std::uint16_t") {
+   } else if (canonicalType == "std::uint16_t") {
       result = std::make_unique<RField<std::uint16_t>>(fieldName);
-   } else if (normalizedType == "std::int32_t") {
+   } else if (canonicalType == "std::int32_t") {
       result = std::make_unique<RField<std::int32_t>>(fieldName);
-   } else if (normalizedType == "std::uint32_t") {
+   } else if (canonicalType == "std::uint32_t") {
       result = std::make_unique<RField<std::uint32_t>>(fieldName);
-   } else if (normalizedType == "std::int64_t") {
+   } else if (canonicalType == "std::int64_t") {
       result = std::make_unique<RField<std::int64_t>>(fieldName);
-   } else if (normalizedType == "std::uint64_t") {
+   } else if (canonicalType == "std::uint64_t") {
       result = std::make_unique<RField<std::uint64_t>>(fieldName);
-   } else if (normalizedType == "float") {
+   } else if (canonicalType == "float") {
       result = std::make_unique<RField<float>>(fieldName);
-   } else if (normalizedType == "double") {
+   } else if (canonicalType == "double") {
       result = std::make_unique<RField<double>>(fieldName);
-   } else if (normalizedType == "Double32_t") {
+   } else if (canonicalType == "Double32_t") {
       result = std::make_unique<RField<double>>(fieldName);
       static_cast<RField<double> *>(result.get())->SetDouble32();
       // Prevent the type alias from being reset by returning early
       return result;
-   } else if (normalizedType == "std::string") {
+   } else if (canonicalType == "std::string") {
       result = std::make_unique<RField<std::string>>(fieldName);
-   } else if (normalizedType == "std::vector<bool>") {
+   } else if (canonicalType == "std::vector<bool>") {
       result = std::make_unique<RField<std::vector<bool>>>(fieldName);
-   } else if (normalizedType.substr(0, 12) == "std::vector<") {
-      std::string itemTypeName = normalizedType.substr(12, normalizedType.length() - 13);
+   } else if (canonicalType.substr(0, 12) == "std::vector<") {
+      std::string itemTypeName = canonicalType.substr(12, canonicalType.length() - 13);
       auto itemField = Create("_0", itemTypeName);
       result = std::make_unique<RVectorField>(fieldName, itemField.Unwrap());
-   } else if (normalizedType.substr(0, 19) == "ROOT::VecOps::RVec<") {
-      std::string itemTypeName = normalizedType.substr(19, normalizedType.length() - 20);
+   } else if (canonicalType.substr(0, 19) == "ROOT::VecOps::RVec<") {
+      std::string itemTypeName = canonicalType.substr(19, canonicalType.length() - 20);
       auto itemField = Create("_0", itemTypeName);
       result = std::make_unique<RRVecField>(fieldName, itemField.Unwrap());
-   } else if (normalizedType.substr(0, 11) == "std::array<") {
-      auto arrayDef = TokenizeTypeList(normalizedType.substr(11, normalizedType.length() - 12));
+   } else if (canonicalType.substr(0, 11) == "std::array<") {
+      auto arrayDef = TokenizeTypeList(canonicalType.substr(11, canonicalType.length() - 12));
       R__ASSERT(arrayDef.size() == 2);
       auto arrayLength = std::stoi(arrayDef[1]);
       auto itemField = Create("_0", arrayDef[0]);
       result = std::make_unique<RArrayField>(fieldName, itemField.Unwrap(), arrayLength);
-   } else if (normalizedType.substr(0, 13) == "std::variant<") {
-      auto innerTypes = TokenizeTypeList(normalizedType.substr(13, normalizedType.length() - 14));
+   } else if (canonicalType.substr(0, 13) == "std::variant<") {
+      auto innerTypes = TokenizeTypeList(canonicalType.substr(13, canonicalType.length() - 14));
       std::vector<RFieldBase *> items;
       for (unsigned int i = 0; i < innerTypes.size(); ++i) {
          items.emplace_back(Create("_" + std::to_string(i), innerTypes[i]).Unwrap().release());
       }
       result = std::make_unique<RVariantField>(fieldName, items);
-   } else if (normalizedType.substr(0, 10) == "std::pair<") {
-      auto innerTypes = TokenizeTypeList(normalizedType.substr(10, normalizedType.length() - 11));
+   } else if (canonicalType.substr(0, 10) == "std::pair<") {
+      auto innerTypes = TokenizeTypeList(canonicalType.substr(10, canonicalType.length() - 11));
       if (innerTypes.size() != 2)
          return R__FAIL("the type list for std::pair must have exactly two elements");
       std::array<std::unique_ptr<RFieldBase>, 2> items{Create("_0", innerTypes[0]).Unwrap(),
                                                        Create("_1", innerTypes[1]).Unwrap()};
       result = std::make_unique<RPairField>(fieldName, items);
-   } else if (normalizedType.substr(0, 11) == "std::tuple<") {
-      auto innerTypes = TokenizeTypeList(normalizedType.substr(11, normalizedType.length() - 12));
+   } else if (canonicalType.substr(0, 11) == "std::tuple<") {
+      auto innerTypes = TokenizeTypeList(canonicalType.substr(11, canonicalType.length() - 12));
       std::vector<std::unique_ptr<RFieldBase>> items;
       for (unsigned int i = 0; i < innerTypes.size(); ++i) {
          items.emplace_back(Create("_" + std::to_string(i), innerTypes[i]).Unwrap());
       }
       result = std::make_unique<RTupleField>(fieldName, items);
-   } else if (normalizedType.substr(0, 12) == "std::bitset<") {
-      auto size = std::stoull(normalizedType.substr(12, normalizedType.length() - 13));
+   } else if (canonicalType.substr(0, 12) == "std::bitset<") {
+      auto size = std::stoull(canonicalType.substr(12, canonicalType.length() - 13));
       result = std::make_unique<RBitsetField>(fieldName, size);
-   } else if (normalizedType.substr(0, 16) == "std::unique_ptr<") {
-      std::string itemTypeName = normalizedType.substr(16, normalizedType.length() - 17);
+   } else if (canonicalType.substr(0, 16) == "std::unique_ptr<") {
+      std::string itemTypeName = canonicalType.substr(16, canonicalType.length() - 17);
       auto itemField = Create("_0", itemTypeName).Unwrap();
       auto normalizedInnerTypeName = itemField->GetType();
       result = std::make_unique<RUniquePtrField>(fieldName, "std::unique_ptr<" + normalizedInnerTypeName + ">",
                                                  std::move(itemField));
-   } else if (normalizedType == ":Collection:") {
+   } else if (canonicalType == ":Collection:") {
       // TODO: create an RCollectionField?
       result = std::make_unique<RField<ClusterSize_t>>(fieldName);
-   } else if (normalizedType.substr(0, 39) == "ROOT::Experimental::RNTupleCardinality<") {
-      auto innerTypes = TokenizeTypeList(normalizedType.substr(39, normalizedType.length() - 40));
+   } else if (canonicalType.substr(0, 39) == "ROOT::Experimental::RNTupleCardinality<") {
+      auto innerTypes = TokenizeTypeList(canonicalType.substr(39, canonicalType.length() - 40));
       if (innerTypes.size() != 1)
-         return R__FAIL(std::string("Field ") + fieldName + " has invalid cardinality template: " + normalizedType);
+         return R__FAIL(std::string("Field ") + fieldName + " has invalid cardinality template: " + canonicalType);
       if (innerTypes[0] == "std::uint32_t") {
          result = std::make_unique<RField<RNTupleCardinality<std::uint32_t>>>(fieldName);
       } else if (innerTypes[0] == "std::uint64_t") {
          result = std::make_unique<RField<RNTupleCardinality<std::uint64_t>>>(fieldName);
       } else {
-         return R__FAIL(std::string("Field ") + fieldName + " has invalid cardinality template: " + normalizedType);
+         return R__FAIL(std::string("Field ") + fieldName + " has invalid cardinality template: " + canonicalType);
       }
    }
 
    if (!result) {
-      auto cl = TClass::GetClass(normalizedType.c_str());
+      auto cl = TClass::GetClass(canonicalType.c_str());
       if (cl != nullptr) {
          if (cl->GetCollectionProxy())
-            result = std::make_unique<RCollectionClassField>(fieldName, normalizedType);
+            result = std::make_unique<RCollectionClassField>(fieldName, canonicalType);
          else
-            result = std::make_unique<RClassField>(fieldName, normalizedType);
+            result = std::make_unique<RClassField>(fieldName, canonicalType);
       }
    }
 
    if (result) {
-      if (typeAlias != normalizedType)
+      if (typeAlias != canonicalType)
          result->fTypeAlias = typeAlias;
       return result;
    }
-   return R__FAIL(std::string("Field ") + fieldName + " has unknown type " + normalizedType);
+   return R__FAIL(std::string("Field ") + fieldName + " has unknown type " + canonicalType);
 }
 
 ROOT::Experimental::RResult<void>

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -146,7 +146,8 @@ std::tuple<std::string, std::vector<size_t>> ParseArrayType(std::string_view typ
    return std::make_tuple(std::string{typeName}, sizeVec);
 }
 
-/// Return the canonical name of a type, resolving typedefs to their underlying types if needed
+/// Return the canonical name of a type, resolving typedefs to their underlying types if needed.  A canonical type has
+/// typedefs stripped out from the type name.
 std::string GetCanonicalTypeName(const std::string &typeName)
 {
    // The following types are asummed to be canonical names; thus, do not perform `typedef` resolution on those
@@ -158,7 +159,9 @@ std::string GetCanonicalTypeName(const std::string &typeName)
 }
 
 /// Applies type name normalization rules that lead to the final name used to create a RField, e.g. transforms
-/// `unsigned int` to `std::uint32_t` or `const vector<T>` to `std::vector<T>`
+/// `unsigned int` to `std::uint32_t` or `const vector<T>` to `std::vector<T>`.  Specifically, `const` / `volatile`
+/// qualifiers are removed, integral types such as `unsigned int` or `long` are translated to fixed-length integer types
+/// (e.g. `std::uint32_t`), and `std::` is added to fully qualify known types in the `std` namespace.
 std::string GetNormalizedTypeName(const std::string &typeName)
 {
    std::string normalizedType{TClassEdit::CleanType(typeName.c_str(), /*mode=*/2)};

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -150,7 +150,7 @@ std::tuple<std::string, std::vector<size_t>> ParseArrayType(std::string_view typ
 std::string GetCanonicalTypeName(const std::string &typeName)
 {
    // The following types are asummed to be canonical names; thus, do not perform `typedef` resolution on those
-   if (typeName == "ROOT::Experimental::ClusterSize_t" ||
+   if (typeName == "ROOT::Experimental::ClusterSize_t" || typeName.substr(0, 5) == "std::" ||
        typeName.substr(0, 39) == "ROOT::Experimental::RNTupleCardinality<")
       return typeName;
 

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -1009,9 +1009,6 @@ TEST(RNTuple, TClassTemplateBased)
 
 TEST(RNTuple, TClassStlDerived)
 {
-   // For non-cxxmodules builds, cling needs to parse the header for the `SG::sgkey_t` type to be known
-   gInterpreter->ProcessLine("#include \"CustomStruct.hxx\"");
-
    FileRaii fileGuard("test_ntuple_tclass_stlderived.ntuple");
    {
       auto model = RNTupleModel::Create();


### PR DESCRIPTION
Apparently, `TClassEdit::ResolveTypedef()` is unable to resolve a typedef that aliases a fundamental data type if the `typedef` declaration is not known to cling.  In non-C++-modules builds, making it known typically involves parsing the corresponding header.

In addition, `TDataMember::GetTrueTypeName()`, however, correctly provides the information, which seems to be inconsistent behavior in ROOT meta.

This pull request is twofold: _(i)_ it cleans up the code for type name normalization, and _(ii)_ circumvents this issue by directly using the resolved type name provided by `TDataMember::GetTrueTypeName()`.

## Changes or fixes:
- Separate the internal `GetNormalizedType()` function in `GetCanonicalTypeName()` (which returns the canonical name of a type, resolving typedefs where needed) and `GetNormalizedTypeName()` (which returns the RNTuple normalized name for a type, e.g. `const vector<T>` -> `std::vector<T>`.
- Add a protected `RFieldBase::Create()` overload that takes an already normalized type name + type alias.
- Use the aforementioned overload in `RClassField` to create fields associated to data members.

## Checklist:
- [x] tested changes locally
- [x] updated the docs (if necessary)

(FYI, @Nowakus; this PR should solve the typedef issues that you were encountering)