### PR TITLE
[RF] Allow BinnedLikelihood to be used without requiring it to be in a RooSimultaneous

### DIFF
--- a/roofit/roofitcore/inc/RooAbsOptTestStatistic.h
+++ b/roofit/roofitcore/inc/RooAbsOptTestStatistic.h
@@ -29,7 +29,6 @@ class RooAbsOptTestStatistic : public RooAbsTestStatistic {
 public:
 
   // Constructors, assignment etc
-  RooAbsOptTestStatistic() ;
   RooAbsOptTestStatistic(const char *name, const char *title, RooAbsReal& real, RooAbsData& data,
                          const RooArgSet& projDeps,
                          RooAbsTestStatistic::Configuration const& cfg);
@@ -75,20 +74,20 @@ protected:
   void optimizeCaching() ;
   void optimizeConstantTerms(bool,bool=true) ;
 
-  RooArgSet*  _normSet ;           ///< Pointer to set with observables used for normalization
-  RooArgSet*  _funcCloneSet ;      ///< Set owning all components of internal clone of input function
-  RooAbsData* _dataClone{nullptr}; ///< Pointer to internal clone if input data
-  RooAbsReal* _funcClone ;   ///< Pointer to internal clone of input function
-  RooArgSet*  _projDeps ;    ///< Set of projected observable
-  bool      _ownData  ;    ///< Do we own the dataset
-  bool      _sealed ;      ///< Is test statistic sealed -- i.e. no access to data
+  RooArgSet*  _normSet = nullptr;           ///< Pointer to set with observables used for normalization
+  RooArgSet*  _funcCloneSet = nullptr;      ///< Set owning all components of internal clone of input function
+  RooAbsData* _dataClone = nullptr; ///< Pointer to internal clone if input data
+  RooAbsReal* _funcClone = nullptr;   ///< Pointer to internal clone of input function
+  RooArgSet*  _projDeps = nullptr;    ///< Set of projected observable
+  bool      _ownData = false;    ///< Do we own the dataset
+  bool      _sealed = false;      ///< Is test statistic sealed -- i.e. no access to data
   TString     _sealNotice ;  ///< User-defined notice shown when reading a sealed likelihood
-  RooArgSet*  _funcObsSet ;  ///< List of observables in the pdf expression
+  RooArgSet*  _funcObsSet = nullptr;  ///< List of observables in the pdf expression
   RooArgSet   _cachedNodes ; ///<! List of nodes that are cached as constant expressions
 
-  RooAbsReal* _origFunc ;  ///< Original function
-  RooAbsData* _origData ;  ///< Original data
-  bool      _optimized ; ///<!
+  RooAbsReal* _origFunc = nullptr;  ///< Original function
+  RooAbsData* _origData = nullptr;  ///< Original data
+  bool      _optimized = false; ///<!
   double      _integrateBinsPrecision{-1.}; // Precision for finer sampling of bins.
 
   ClassDefOverride(RooAbsOptTestStatistic,0) // Abstract base class for optimized test statistics

--- a/roofit/roofitcore/inc/RooAbsTestStatistic.h
+++ b/roofit/roofitcore/inc/RooAbsTestStatistic.h
@@ -54,7 +54,6 @@ public:
   };
 
   // Constructors, assignment etc
-  RooAbsTestStatistic() {}
   RooAbsTestStatistic(const char *name, const char *title, RooAbsReal& real, RooAbsData& data,
                       const RooArgSet& projDeps, Configuration const& cfg);
   RooAbsTestStatistic(const RooAbsTestStatistic& other, const char* name=nullptr);

--- a/roofit/roofitcore/inc/RooDataWeightedAverage.h
+++ b/roofit/roofitcore/inc/RooDataWeightedAverage.h
@@ -23,10 +23,6 @@ class RooDataWeightedAverage : public RooAbsOptTestStatistic {
 public:
 
   // Constructors, assignment etc
-  RooDataWeightedAverage() {
-    // Default constructor
-  } ;
-
   RooDataWeightedAverage(const char *name, const char *title, RooAbsReal& real, RooAbsData& data, const RooArgSet& projDeps,
                          RooAbsTestStatistic::Configuration const& cfg, bool showProgress=false) ;
 

--- a/roofit/roofitcore/inc/RooHelpers.h
+++ b/roofit/roofitcore/inc/RooHelpers.h
@@ -157,7 +157,7 @@ struct BinnedLOutput {
     bool isBinnedL = false;
 };
 
-BinnedLOutput getBinnedL(RooAbsPdf &pdf);
+BinnedLOutput getBinnedL(RooAbsPdf const &pdf);
 
 void getSortedComputationGraph(RooAbsArg const &func, RooArgSet &out);
 

--- a/roofit/roofitcore/inc/RooNLLVar.h
+++ b/roofit/roofitcore/inc/RooNLLVar.h
@@ -31,7 +31,6 @@ class RooNLLVar : public RooAbsOptTestStatistic {
 public:
 
   // Constructors, assignment etc
-  RooNLLVar();
   RooNLLVar(const char *name, const char* title, RooAbsPdf& pdf, RooAbsData& data,
        const RooCmdArg& arg1={}, const RooCmdArg& arg2={},const RooCmdArg& arg3={},
        const RooCmdArg& arg4={}, const RooCmdArg& arg5={},const RooCmdArg& arg6={},

--- a/roofit/roofitcore/inc/RooXYChi2Var.h
+++ b/roofit/roofitcore/inc/RooXYChi2Var.h
@@ -30,7 +30,6 @@ class RooXYChi2Var : public RooAbsOptTestStatistic {
 public:
 
   // Constructors, assignment etc
-  RooXYChi2Var() ;
   RooXYChi2Var(const char *name, const char* title, RooAbsReal& func, RooDataSet& data, bool integrate=false) ;
   RooXYChi2Var(const char *name, const char* title, RooAbsReal& func, RooDataSet& data, RooRealVar& yvar, bool integrate=false) ;
   RooXYChi2Var(const char *name, const char* title, RooAbsPdf& extPdf, RooDataSet& data, bool integrate=false) ;

--- a/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
@@ -66,31 +66,6 @@ parallelized calculation of test statistics.
 using namespace std;
 
 ClassImp(RooAbsOptTestStatistic);
-;
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Default Constructor
-
-RooAbsOptTestStatistic:: RooAbsOptTestStatistic()
-{
-  // Initialize all non-persisted data members
-
-  _funcObsSet = 0 ;
-  _funcCloneSet = 0 ;
-  _funcClone = 0 ;
-
-  _normSet = 0 ;
-  _projDeps = 0 ;
-
-  _origFunc = 0 ;
-  _origData = 0 ;
-
-  _ownData = true ;
-  _sealed = false ;
-  _optimized = false ;
-}
-
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -118,66 +93,41 @@ RooAbsOptTestStatistic:: RooAbsOptTestStatistic()
 /// - cloneInputData Not used. Data is always cloned.
 /// - integrateOverBinsPrecision If > 0, PDF in binned fits are integrated over the bins. This sets the precision. If = 0,
 ///   only unbinned PDFs fit to RooDataHist are integrated. If < 0, PDFs are never integrated.
-RooAbsOptTestStatistic::RooAbsOptTestStatistic(const char *name, const char *title, RooAbsReal& real,
-                                               RooAbsData& indata, const RooArgSet& projDeps,
-                                               RooAbsTestStatistic::Configuration const& cfg) :
-  RooAbsTestStatistic(name,title,real,indata,projDeps,cfg),
-  _projDeps(0),
-  _sealed(false),
-  _optimized(false),
-  _integrateBinsPrecision(cfg.integrateOverBinsPrecision)
+RooAbsOptTestStatistic::RooAbsOptTestStatistic(const char *name, const char *title, RooAbsReal &real,
+                                               RooAbsData &indata, const RooArgSet &projDeps,
+                                               RooAbsTestStatistic::Configuration const &cfg)
+   : RooAbsTestStatistic(name, title, real, indata, projDeps, cfg),
+     _integrateBinsPrecision(cfg.integrateOverBinsPrecision)
 {
-  // Don't do a thing in master mode
+   // Don't do a thing in master mode
+   if (operMode() != Slave) {
+      return;
+   }
 
-  if (operMode()!=Slave) {
-    _funcObsSet = 0 ;
-    _funcCloneSet = 0 ;
-    _funcClone = 0 ;
-    _normSet = 0 ;
-    _projDeps = 0 ;
-    _origFunc = 0 ;
-    _origData = 0 ;
-    _ownData = false ;
-    _sealed = false ;
-    return ;
-  }
-
-  _origFunc = 0 ; //other._origFunc ;
-  _origData = 0 ; // other._origData ;
-
-  initSlave(real, indata, projDeps, _rangeName.c_str(), _addCoefRangeName.c_str()) ;
+   initSlave(real, indata, projDeps, _rangeName.c_str(), _addCoefRangeName.c_str());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy constructor
 
-RooAbsOptTestStatistic::RooAbsOptTestStatistic(const RooAbsOptTestStatistic& other, const char* name) :
-  RooAbsTestStatistic(other,name), _sealed(other._sealed), _sealNotice(other._sealNotice), _optimized(false),
-  _integrateBinsPrecision(other._integrateBinsPrecision)
+RooAbsOptTestStatistic::RooAbsOptTestStatistic(const RooAbsOptTestStatistic &other, const char *name)
+   : RooAbsTestStatistic(other, name),
+     _sealed(other._sealed),
+     _sealNotice(other._sealNotice),
+     _integrateBinsPrecision(other._integrateBinsPrecision)
 {
-  // Don't do a thing in master mode
-  if (operMode()!=Slave) {
+   // Don't do a thing in master mode
+   if (operMode() != Slave) {
 
-    _funcObsSet = 0 ;
-    _funcCloneSet = 0 ;
-    _funcClone = 0 ;
-    _normSet = nullptr;
-    if(other._normSet) {
-      _normSet = new RooArgSet;
-      other._normSet->snapshot(*_normSet);
-    }
-    _projDeps = 0 ;
-    _origFunc = 0 ;
-    _origData = 0 ;
-    _ownData = false ;
-    return ;
-  }
+      if (other._normSet) {
+         _normSet = new RooArgSet;
+         other._normSet->snapshot(*_normSet);
+      }
+      return;
+   }
 
-  _origFunc = 0 ; //other._origFunc ;
-  _origData = 0 ; // other._origData ;
-  _projDeps = 0 ;
-
-  initSlave(*other._funcClone,*other._dataClone,other._projDeps?*other._projDeps:RooArgSet(),other._rangeName.c_str(),other._addCoefRangeName.c_str()) ;
+   initSlave(*other._funcClone, *other._dataClone, other._projDeps ? *other._projDeps : RooArgSet(),
+             other._rangeName.c_str(), other._addCoefRangeName.c_str());
 }
 
 

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1177,6 +1177,9 @@ RooFit::OwningPtr<RooAbsReal> RooAbsPdf::createNLL(RooAbsData& data, const RooLi
     return RooFit::Detail::owningPtr(std::move(nllWrapper));
   }
 
+  auto binnedLInfo = RooHelpers::getBinnedL(*this);
+  RooAbsPdf &actualPdf = binnedLInfo.binnedPdf ? *binnedLInfo.binnedPdf : *this;
+
   // Construct NLL
   RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CollectErrors) ;
   std::unique_ptr<RooAbsReal> nll ;
@@ -1188,10 +1191,10 @@ RooFit::OwningPtr<RooAbsReal> RooAbsPdf::createNLL(RooAbsData& data, const RooLi
   cfg.splitCutRange = static_cast<bool>(splitRange);
   cfg.cloneInputData = static_cast<bool>(cloneData);
   cfg.integrateOverBinsPrecision = pc.getDouble("IntegrateBins");
-  cfg.binnedL = false;
+  cfg.binnedL = binnedLInfo.isBinnedL;
   cfg.takeGlobalObservablesFromData = takeGlobalObservablesFromData;
   cfg.rangeName = rangeName ? rangeName : "";
-  auto nllVar = std::make_unique<RooNLLVar>(baseName.c_str(),"-log(likelihood)",*this,data,projDeps, ext, cfg);
+  auto nllVar = std::make_unique<RooNLLVar>(baseName.c_str(),"-log(likelihood)",actualPdf,data,projDeps, ext, cfg);
   nllVar->enableBinOffsetting(offset == RooFit::OffsetMode::Bin);
   nll = std::move(nllVar);
   RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::PrintErrors) ;

--- a/roofit/roofitcore/src/RooAbsTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsTestStatistic.cxx
@@ -501,12 +501,13 @@ void RooAbsTestStatistic::initSimMode(RooSimultaneous* simpdf, RooAbsData* data,
 
       // Servers may have been redirected between instantiation and (deferred) initialization
 
-      auto actualParams = binnedInfo.binnedPdf ? binnedInfo.binnedPdf->getParameters(dset) : pdf->getParameters(dset);
-      RooArgSet* selTargetParams = (RooArgSet*) _paramSet.selectCommon(*actualParams);
+      RooAbsArg &actualPdf = binnedInfo.binnedPdf ? *binnedInfo.binnedPdf : *pdf;
+      RooArgSet actualParams;
+      actualPdf.getParameters(dset->get(), actualParams);
+      RooArgSet selTargetParams;
+      _paramSet.selectCommon(actualParams, selTargetParams);
 
-      _gofArray.back()->recursiveRedirectServers(*selTargetParams);
-
-      delete selTargetParams;
+      _gofArray.back()->recursiveRedirectServers(selTargetParams);
     }
   }
   for(auto& gof : _gofArray) {

--- a/roofit/roofitcore/src/RooAbsTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsTestStatistic.cxx
@@ -473,6 +473,7 @@ void RooAbsTestStatistic::initSimMode(RooSimultaneous* simpdf, RooAbsData* data,
       // *** START HERE
       // WVE HACK determine if we have a RooRealSumPdf and then treat it like a binned likelihood
       auto binnedInfo = RooHelpers::getBinnedL(*pdf);
+      RooAbsReal &actualPdf = binnedInfo.binnedPdf ? *binnedInfo.binnedPdf : *pdf;
       // WVE END HACK
       // Below here directly pass binnedPdf instead of PROD(binnedPdf,constraints) as constraints are evaluated elsewhere anyway
       // and omitting them reduces model complexity and associated handling/cloning times
@@ -491,7 +492,7 @@ void RooAbsTestStatistic::initSimMode(RooSimultaneous* simpdf, RooAbsData* data,
       }
       cfg.rangeName = RooHelpers::getRangeNameForSimComponent(rangeName, _splitRange, catName);
       cfg.nCPU = _nCPU;
-      _gofArray.emplace_back(create(catName.c_str(),catName.c_str(),(binnedInfo.binnedPdf?*binnedInfo.binnedPdf:*pdf),*dset,*projDeps,cfg));
+      _gofArray.emplace_back(create(catName.c_str(),catName.c_str(),actualPdf,*dset,*projDeps,cfg));
       // *** END HERE
 
       // Fill per-component split mode with Bulk Partition for now so that Auto will map to bulk-splitting of all components
@@ -501,7 +502,6 @@ void RooAbsTestStatistic::initSimMode(RooSimultaneous* simpdf, RooAbsData* data,
 
       // Servers may have been redirected between instantiation and (deferred) initialization
 
-      RooAbsArg &actualPdf = binnedInfo.binnedPdf ? *binnedInfo.binnedPdf : *pdf;
       RooArgSet actualParams;
       actualPdf.getParameters(dset->get(), actualParams);
       RooArgSet selTargetParams;

--- a/roofit/roofitcore/src/RooHelpers.cxx
+++ b/roofit/roofitcore/src/RooHelpers.cxx
@@ -277,20 +277,21 @@ std::string getRangeNameForSimComponent(std::string const& rangeName, bool split
    return rangeName;
 }
 
-BinnedLOutput getBinnedL(RooAbsPdf &pdf)
+BinnedLOutput getBinnedL(RooAbsPdf const &pdf)
 {
    if (pdf.getAttribute("BinnedLikelihood") && pdf.IsA()->InheritsFrom(RooRealSumPdf::Class())) {
       // Simplest case: top-level of component is a RooRealSumPdf
-      return {&pdf, true};
+      return {const_cast<RooAbsPdf *>(&pdf), true};
    } else if (pdf.IsA()->InheritsFrom(RooProdPdf::Class())) {
       // Default case: top-level pdf is a product of RooRealSumPdf and other pdfs
-      for (RooAbsArg *component : static_cast<RooProdPdf &>(pdf).pdfList()) {
+      for (RooAbsArg *component : static_cast<RooProdPdf const &>(pdf).pdfList()) {
          if (component->getAttribute("BinnedLikelihood") && component->IsA()->InheritsFrom(RooRealSumPdf::Class())) {
             return {static_cast<RooAbsPdf *>(component), true};
          }
          if (component->getAttribute("MAIN_MEASUREMENT")) {
-           // not really a binned pdf, but this prevents a (potentially) long list of subsidiary measurements to be passed to the slave calculator
-           return {static_cast<RooAbsPdf *>(component), false};
+            // not really a binned pdf, but this prevents a (potentially) long list of subsidiary measurements to be
+            // passed to the slave calculator
+            return {static_cast<RooAbsPdf *>(component), false};
          }
       }
    }

--- a/roofit/roofitcore/src/RooNLLVar.cxx
+++ b/roofit/roofitcore/src/RooNLLVar.cxx
@@ -70,7 +70,6 @@ namespace {
 
 ClassImp(RooNLLVar)
 
-RooNLLVar::RooNLLVar() {}
 RooNLLVar::~RooNLLVar() {}
 
 RooArgSet RooNLLVar::_emptySet ;

--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -2406,6 +2406,13 @@ private:
 std::unique_ptr<RooAbsArg>
 RooProdPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileContext &ctx) const
 {
+   if (ctx.likelihoodMode()) {
+      auto binnedInfo = RooHelpers::getBinnedL(*this);
+      if (binnedInfo.binnedPdf && binnedInfo.binnedPdf != this) {
+         return binnedInfo.binnedPdf->compileForNormSet(normSet, ctx);
+      }
+   }
+
    std::unique_ptr<RooProdPdf> prodPdfClone{static_cast<RooProdPdf *>(this->Clone())};
    ctx.markAsCompiled(*prodPdfClone);
 

--- a/roofit/roofitcore/src/RooRealSumPdf.cxx
+++ b/roofit/roofitcore/src/RooRealSumPdf.cxx
@@ -785,12 +785,39 @@ void RooRealSumPdf::printMetaArgs(RooArgList const& funcList, RooArgList const& 
   os << " " ;
 }
 
-std::unique_ptr<RooAbsArg> RooRealSumPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileContext & ctx) const
+std::unique_ptr<RooAbsArg>
+RooRealSumPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileContext &ctx) const
 {
-   if(normSet.empty() || selfNormalized()) {
+   if (normSet.empty() || selfNormalized()) {
       return RooAbsPdf::compileForNormSet({}, ctx);
    }
-   std::unique_ptr<RooAbsPdf> pdfClone(static_cast<RooAbsPdf*>(this->Clone()));
+   std::unique_ptr<RooAbsPdf> pdfClone(static_cast<RooAbsPdf *>(this->Clone()));
+
+   if (ctx.likelihoodMode() && pdfClone->getAttribute("BinnedLikelihood")) {
+
+      // This has to be done before compiling the servers, such that the
+      // RooBinWidthFunctions know to disable themselves.
+      ctx.setBinnedLikelihoodMode(true);
+
+      ctx.markAsCompiled(*pdfClone);
+      ctx.compileServers(*pdfClone, {});
+
+      pdfClone->setAttribute("BinnedLikelihoodActive");
+      // If this is a binned likelihood, we're flagging it in the context.
+      // Then, the RooBinWidthFunctions know that they should not put
+      // themselves in the computation graph. Like this, the pdf values can
+      // directly be interpreted as yields, without multiplying them with the
+      // bin widths again in the NLL. However, the NLL class has to be careful
+      // to only skip the bin with multiplication when there actually were
+      // RooBinWidthFunctions! This is not the case for old workspace before
+      // ROOT 6.26. Therefore, we use the "BinnedLikelihoodActiveYields"
+      // attribute to let the NLL know what it should do.
+      if (ctx.binWidthFuncFlag()) {
+         pdfClone->setAttribute("BinnedLikelihoodActiveYields");
+      }
+      return pdfClone;
+   }
+
    ctx.compileServers(*pdfClone, {});
 
    RooArgSet depList;
@@ -800,7 +827,7 @@ std::unique_ptr<RooAbsArg> RooRealSumPdf::compileForNormSet(RooArgSet const &nor
 
    // The direct servers are this pdf and the normalization integral, which
    // don't need to be compiled further.
-   for(RooAbsArg * server : newArg->servers()) {
+   for (RooAbsArg *server : newArg->servers()) {
       ctx.markAsCompiled(*server);
    }
    ctx.markAsCompiled(*newArg);

--- a/roofit/roofitcore/src/RooSimultaneous.cxx
+++ b/roofit/roofitcore/src/RooSimultaneous.cxx
@@ -1201,37 +1201,16 @@ RooSimultaneous::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::Com
 
       prefixArgs(pdfClone.get(), prefix, normSet);
 
-      auto binnedInfo = RooHelpers::getBinnedL(*pdfClone);
-
-      RooAbsPdf &pdf = binnedInfo.binnedPdf ? *binnedInfo.binnedPdf : *pdfClone;
-
-      if (binnedInfo.isBinnedL) {
-         pdf.setAttribute("BinnedLikelihoodActive");
-      }
-
       std::unique_ptr<RooArgSet> pdfNormSet(
-         static_cast<RooArgSet *>(std::unique_ptr<RooArgSet>(pdf.getVariables())->selectByAttrib("__obs__", true)));
+         static_cast<RooArgSet *>(std::unique_ptr<RooArgSet>(pdfClone->getVariables())->selectByAttrib("__obs__", true)));
 
       if (rangeName) {
-         pdf.setNormRange(RooHelpers::getRangeNameForSimComponent(rangeName, splitRange, catName).c_str());
+         pdfClone->setNormRange(RooHelpers::getRangeNameForSimComponent(rangeName, splitRange, catName).c_str());
       }
 
-      // If this is a binned likelihood, we're flagging it in the context.
-      // Then, the RooBinWidthFunctions know that they should not put
-      // themselves in the computation graph. Like this, the pdf values can
-      // directly be interpreted as yields, without multiplying them with the
-      // bin widths again in the NLL. However, the NLL class has to be careful
-      // to only skip the bin with multiplication when there actually were
-      // RooBinWidthFunctions! This is not the case for old workspace before
-      // ROOT 6.26. Therefore, we use the "BinnedLikelihoodActiveYields"
-      // attribute to let the NLL know what it should do.
       RooFit::Detail::CompileContext pdfContext{*pdfNormSet};
       pdfContext.setLikelihoodMode(ctx.likelihoodMode());
-      pdfContext.setBinnedLikelihoodMode(ctx.likelihoodMode() && binnedInfo.isBinnedL);
-      auto *pdfFinal = pdfContext.compile(pdf, *newSimPdf, *pdfNormSet);
-      if(pdfContext.binWidthFuncFlag()) {
-         pdfFinal->setAttribute("BinnedLikelihoodActiveYields");
-      }
+      auto *pdfFinal = pdfContext.compile(*pdfClone, *newSimPdf, *pdfNormSet);
 
       pdfFinal->fixAddCoefNormalization(*pdfNormSet, false);
 

--- a/roofit/roofitcore/src/RooXYChi2Var.cxx
+++ b/roofit/roofitcore/src/RooXYChi2Var.cxx
@@ -47,7 +47,7 @@
 using namespace std;
 
 ClassImp(RooXYChi2Var);
-;
+
 
 namespace {
   RooAbsTestStatistic::Configuration makeRooAbsTestStatisticCfg() {
@@ -55,14 +55,6 @@ namespace {
     cfg.verbose = false;
     return cfg;
   }
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// coverity[UNINIT_CTOR]
-
-RooXYChi2Var::RooXYChi2Var()
-{
 }
 
 


### PR DESCRIPTION
At the moment the BinnedLikelihood feature only becomes active when doing an initSimMode inside a RooAbsTestStatistic. This change, I think, will allow for RooNLLVar to be used directly on a RooRealSumPdf and still get the BinnedLikelihood behaviour.