### PR TITLE
Fix execStatusBitsCheck test

### DIFF
--- a/gui/browserv7/inc/LinkDef.h
+++ b/gui/browserv7/inc/LinkDef.h
@@ -16,6 +16,7 @@
 #pragma link C++ class ROOT::Experimental::RBrowserReply+;
 
 #pragma link C++ class ROOT::Experimental::RBrowserData+;
+#pragma link C++ class ROOT::Experimental::Internal::RBrowserDataCleanup+;
 
 #pragma link C++ class ROOT::Experimental::RBrowser+;
 #pragma link C++ class ROOT::Experimental::RFileDialog+;

--- a/gui/browserv7/inc/ROOT/RBrowserData.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowserData.hxx
@@ -23,6 +23,8 @@
 #include <vector>
 #include <utility>
 
+#include <TObject.h>
+
 namespace ROOT {
 namespace Experimental {
 
@@ -30,11 +32,29 @@ class RLogChannel;
 /// Log channel for Browser diagnostics.
 RLogChannel &BrowserLog();
 
-class RBrowserDataCleanup;
+class RBrowserData;
+namespace Internal {
 
+class RBrowserDataCleanup final : public TObject {
+
+   ROOT::Experimental::RBrowserData &fData;
+
+public:
+   RBrowserDataCleanup(ROOT::Experimental::RBrowserData &_data) : fData(_data) {}
+
+   void RecursiveRemove(TObject *obj) final;
+
+   ClassDef(RBrowserDataCleanup, 0);
+};
+} // namespace Internal
+
+/** \class ROOT::Experimental::RBrowserData
+\ingroup rbrowser
+\brief Way to browse (hopefully) everything in %ROOT
+*/
 class RBrowserData {
 
-   friend class RBrowserDataCleanup;
+   friend class ROOT::Experimental::Internal::RBrowserDataCleanup;
 
    std::shared_ptr<Browsable::RElement> fTopElement;    ///<! top element
 
@@ -49,7 +69,7 @@ class RBrowserData {
    std::vector<const Browsable::RItem *> fLastSortedItems;   ///<! sorted child items, used in requests
    std::string fLastSortMethod;                          ///<! last sort method
    bool fLastSortReverse{false};                         ///<! last request reverse order
-   std::unique_ptr<RBrowserDataCleanup> fCleanupHandle;  ///<! cleanup handle for RecursiveRemove
+   std::unique_ptr<ROOT::Experimental::Internal::RBrowserDataCleanup> fCleanupHandle;  ///<! cleanup handle for RecursiveRemove
 
    void ResetLastRequestData(bool with_element);
 

--- a/gui/browserv7/src/RBrowserData.cxx
+++ b/gui/browserv7/src/RBrowserData.cxx
@@ -37,37 +37,17 @@ ROOT::Experimental::RLogChannel &ROOT::Experimental::BrowserLog() {
    return sLog;
 }
 
-namespace ROOT {
-namespace Experimental {
-
-class RBrowserDataCleanup : public TObject {
-
-   RBrowserData &fData;
-
-public:
-   RBrowserDataCleanup(RBrowserData &_data) : fData(_data) {}
-
-   void RecursiveRemove(TObject *obj) override
-   {
-      fData.RemoveFromCache(obj);
-   }
-};
+void ROOT::Experimental::Internal::RBrowserDataCleanup::RecursiveRemove(TObject *obj)
+{
+   fData.RemoveFromCache(obj);
 }
-}
-
-
-/** \class ROOT::Experimental::RBrowserData
-\ingroup rbrowser
-\brief Way to browse (hopefully) everything in %ROOT
-*/
-
 
 /////////////////////////////////////////////////////////////////////
 /// Default constructor
 
 RBrowserData::RBrowserData()
 {
-   fCleanupHandle = std::make_unique<RBrowserDataCleanup>(*this);
+   fCleanupHandle = std::make_unique<ROOT::Experimental::Internal::RBrowserDataCleanup>(*this);
    R__LOCKGUARD(gROOTMutex);
    gROOT->GetListOfCleanups()->Add(fCleanupHandle.get());
 }


### PR DESCRIPTION
RBrowserDataCleanup derives from TObject, so it is necessary to add a `ClassDef` call as per
https://root.cern/manual/io_custom_classes/#the-classdef-macro. Also, the class is for internal use, so move it to `Internal` namespace. Generate the corresponding dictionary in Linkdef.h for proper class streaming.

This seems to fix `roottest-root-core-execStatusBitsCheck` related to #13058 , but maybe the current status of these changes needs to be revisited. It seems weird to me that we need a class that depends from `TObject` in the new webgui, (especially because this adds a nasty `#include <TObject.h>` which wasn't even present before, I wonder how it compiled) but I'm maybe missing something here.