### PR TITLE
[xroofit] Use std::string to format vector::size

### DIFF
--- a/roofit/xroofit/src/xRooNLLVar.cxx
+++ b/roofit/xroofit/src/xRooNLLVar.cxx
@@ -1591,9 +1591,9 @@ void xRooNLLVar::xRooHypoPoint::Draw(Option_t *opt)
       //            }
       //        }
       title += TString::Format("%s' = %g", fPOIName(), (isAlt) ? fAltVal() : fNullVal());
-      title += TString::Format(" , N_{toys}=%lu", (isAlt) ? altToys.size() : nullToys.size());
+      title += (std::string(" , N_{toys}=") + ((isAlt) ? altToys.size() : nullToys.size()));
       if (nBadOrZero > 0)
-         title += TString::Format(" (N_{bad/0}=%lu)", nBadOrZero);
+         title += (std::string(" (N_{bad/0}=") + nBadOrZero + ')');
       title += ";";
       title += tsTitle();
       title += TString::Format(";Probability Mass");


### PR DESCRIPTION
This avoids compiler warnings on 32bit platforms such as

```
warning: format ‘%lu’ expects argument of type ‘long unsigned int’, but
argument 2 has type ‘std::vector<std::tuple<int, double, double> >::size_type’
{aka ‘unsigned int’} [-Wformat=]
```

As seen in PR https://github.com/root-project/root/pull/13243