### PR TITLE
[RF] Change precision for comparisons in `testLikelihoodJob` and `testRooAbsL`

### DIFF
--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cxx
@@ -32,12 +32,7 @@
 
 #include <stdexcept> // runtime_error
 
-#include "gtest/gtest.h"
-
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TEST_SUITE_P
-#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
-#endif
+#include "../gtest_wrapper.h"
 
 #include "../test_lib.h" // generate_1D_gaussian_pdf_nll
 

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodJob.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodJob.cxx
@@ -29,12 +29,7 @@
 
 #include <stdexcept> // runtime_error
 
-#include "gtest/gtest.h"
-
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TEST_SUITE_P
-#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
-#endif
+#include "../gtest_wrapper.h"
 
 #include "../test_lib.h" // generate_1D_gaussian_pdf_nll
 

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodJob.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodJob.cxx
@@ -167,7 +167,7 @@ TEST_F(LikelihoodJobBinnedDatasetTest, UnbinnedPdf)
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
 
-   EXPECT_EQ(nll0, nll1.Sum());
+   EXPECT_DOUBLE_EQ(nll0, nll1.Sum());
 }
 
 TEST_F(LikelihoodJobBinnedDatasetTest, BinnedNLL)
@@ -234,7 +234,7 @@ TEST_F(LikelihoodJobTest, SimBinned)
    nll_ts->evaluate();
    auto nll1 = nll_ts->getResult();
 
-   EXPECT_EQ(nll0, nll1.Sum());
+   EXPECT_DOUBLE_EQ(nll0, nll1.Sum());
 }
 
 TEST_F(LikelihoodJobTest, BinnedConstrained)

--- a/roofit/roofitcore/test/TestStatistics/testRooAbsL.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testRooAbsL.cxx
@@ -216,7 +216,12 @@ TEST_F(BinnedDatasetTest, EventSections)
    auto whole = likelihood->evaluatePartition({0, 1}, 0, 0);
    auto part1 = likelihood->evaluatePartition({0, 0.5}, 0, 0);
    auto part2 = likelihood->evaluatePartition({0.5, 1}, 0, 0);
-   EXPECT_EQ(whole.Sum(), (part1 + part2).Sum());
+
+   // We cannot EXPECT_EQ in this test, because we compare actually different
+   // calculations. The multiple additions and FMA operations involved in the
+   // calculation of the multiple parts introduces different rounding errors
+   // on the CPU level than the single calculation over all events at once.
+   EXPECT_DOUBLE_EQ(whole.Sum(), (part1 + part2).Sum());
 }
 
 TEST_F(SimBinnedConstrainedTest, EventSections)
@@ -230,13 +235,17 @@ TEST_F(SimBinnedConstrainedTest, EventSections)
    auto whole = likelihood->evaluatePartition({0, 1}, 0, likelihood->getNComponents());
    auto part1 = likelihood->evaluatePartition({0, 0.5}, 0, likelihood->getNComponents());
    auto part2 = likelihood->evaluatePartition({0.5, 1}, 0, likelihood->getNComponents());
-   EXPECT_EQ(whole.Sum(), (part1 + part2).Sum());
+
+   // See comment in first EventSections test for explanation on why no EXPECT_EQ.
+   EXPECT_DOUBLE_EQ(whole.Sum(), (part1 + part2).Sum());
 
    auto part1of4 = likelihood->evaluatePartition({0, 0.25}, 0, likelihood->getNComponents());
    auto part2of4 = likelihood->evaluatePartition({0.25, 0.5}, 0, likelihood->getNComponents());
    auto part3of4 = likelihood->evaluatePartition({0.5, 0.75}, 0, likelihood->getNComponents());
    auto part4of4 = likelihood->evaluatePartition({0.75, 1}, 0, likelihood->getNComponents());
-   EXPECT_EQ(whole.Sum(), (part1of4 + part2of4 + part3of4 + part4of4).Sum());
+
+   // See comment in first EventSections test for explanation on why no EXPECT_EQ.
+   EXPECT_DOUBLE_EQ(whole.Sum(), (part1of4 + part2of4 + part3of4 + part4of4).Sum());
 }
 
 TEST_F(RooAbsLTest, SubEventSections)
@@ -256,19 +265,22 @@ TEST_F(RooAbsLTest, SubEventSections)
       nine_parts += likelihood->evaluatePartition({static_cast<double>(ix) / 9, static_cast<double>(ix + 1) / 9}, 0,
                                                   likelihood->getNComponents());
    }
-   EXPECT_EQ(whole.Sum(), nine_parts.Sum());
+   // See comment in first EventSections test for explanation on why no EXPECT_EQ.
+   EXPECT_DOUBLE_EQ(whole.Sum(), nine_parts.Sum());
 
    for (std::size_t ix = 0; ix < 11; ++ix) {
       eleven_parts += likelihood->evaluatePartition({static_cast<double>(ix) / 11, static_cast<double>(ix + 1) / 11}, 0,
                                                     likelihood->getNComponents());
    }
-   EXPECT_EQ(whole.Sum(), eleven_parts.Sum());
+   // See comment in first EventSections test for explanation on why no EXPECT_EQ.
+   EXPECT_DOUBLE_EQ(whole.Sum(), eleven_parts.Sum());
 
    for (std::size_t ix = 0; ix < 20; ++ix) {
       twenty_parts += likelihood->evaluatePartition({static_cast<double>(ix) / 20, static_cast<double>(ix + 1) / 20}, 0,
                                                     likelihood->getNComponents());
    }
-   EXPECT_EQ(whole.Sum(), twenty_parts.Sum());
+   // See comment in first EventSections test for explanation on why no EXPECT_EQ.
+   EXPECT_DOUBLE_EQ(whole.Sum(), twenty_parts.Sum());
 }
 
 TEST_F(SimBinnedConstrainedTest, SubEventSections)
@@ -292,10 +304,7 @@ TEST_F(SimBinnedConstrainedTest, SubEventSections)
          {static_cast<double>(ix) / N_events_total, static_cast<double>(ix + 1) / N_events_total}, 0,
          likelihood->getNComponents());
    }
-   // We cannot EXPECT_EQ in this test, because we compare actually different
-   // calculations. The multiple additions and FMA operations involved in the
-   // calculation of the multiple parts introduces different rounding errors
-   // on the CPU level than the single calculation over all events at once.
+   // See comment in first EventSections test for explanation on why no EXPECT_EQ.
    EXPECT_DOUBLE_EQ(whole.Sum(), N_events_total_parts.Sum());
 
    // now let's do it again over a number of sections 3 times the number of events
@@ -306,5 +315,6 @@ TEST_F(SimBinnedConstrainedTest, SubEventSections)
          {static_cast<double>(ix) / (3 * N_events_total), static_cast<double>(ix + 1) / (3 * N_events_total)}, 0,
          likelihood->getNComponents());
    }
+   // See comment in BinnedDatasetTest.EventSections for explanation on why no EXPECT_EQ.
    EXPECT_DOUBLE_EQ(whole.Sum(), thrice_N_events_total_parts.Sum());
 }

--- a/roofit/roofitcore/test/TestStatistics/testRooRealL.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testRooRealL.cxx
@@ -33,12 +33,7 @@
 
 #include <algorithm> // count_if
 
-#include <gtest/gtest.h>
-
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TEST_SUITE_P
-#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
-#endif
+#include "../gtest_wrapper.h"
 
 class RooRealL : public ::testing::TestWithParam<std::tuple<std::size_t>> {};
 

--- a/roofit/roofitcore/test/gtest_wrapper.h
+++ b/roofit/roofitcore/test/gtest_wrapper.h
@@ -1,0 +1,6 @@
+#include <gtest/gtest.h>
+
+// Backward compatibility for gtest version < 1.10.0
+#ifndef INSTANTIATE_TEST_SUITE_P
+#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
+#endif

--- a/roofit/roofitcore/test/testNaNPacker.cxx
+++ b/roofit/roofitcore/test/testNaNPacker.cxx
@@ -12,12 +12,7 @@
 #include <RooRealSumPdf.h>
 #include <RooRealVar.h>
 
-#include <gtest/gtest.h>
-
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TEST_SUITE_P
-#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
-#endif
+#include "gtest_wrapper.h"
 
 #include <cmath>
 #include <cstdint>

--- a/roofit/roofitcore/test/testProxiesAndCategories.cxx
+++ b/roofit/roofitcore/test/testProxiesAndCategories.cxx
@@ -14,12 +14,7 @@
 #include "TFile.h"
 #include "TMemFile.h"
 
-#include "gtest/gtest.h"
-
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TEST_SUITE_P
-#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
-#endif
+#include "gtest_wrapper.h"
 
 TEST(RooCategory, CategoryDefineMultiState) {
   RooCategory myCat("myCat", "A category", { {"0Lep", 0}, {"1Lep", 1}, {"2Lep", 2}, {"3Lep", 3} });

--- a/roofit/roofitcore/test/testRooAbsPdf.cxx
+++ b/roofit/roofitcore/test/testRooAbsPdf.cxx
@@ -22,12 +22,7 @@
 #include <TClass.h>
 #include <TRandom.h>
 
-#include <gtest/gtest.h>
-
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TEST_SUITE_P
-#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
-#endif
+#include "gtest_wrapper.h"
 
 #include <memory>
 

--- a/roofit/roofitcore/test/testRooAddPdf.cxx
+++ b/roofit/roofitcore/test/testRooAddPdf.cxx
@@ -14,12 +14,7 @@
 
 #include <RooStats/SPlot.h>
 
-#include <gtest/gtest.h>
-
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TEST_SUITE_P
-#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
-#endif
+#include "gtest_wrapper.h"
 
 #include <memory>
 

--- a/roofit/roofitcore/test/testRooBinSamplingPdf.cxx
+++ b/roofit/roofitcore/test/testRooBinSamplingPdf.cxx
@@ -11,12 +11,7 @@
 #include <RooRandom.h>
 #include <RooRealVar.h>
 
-#include <gtest/gtest.h>
-
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TEST_SUITE_P
-#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
-#endif
+#include "gtest_wrapper.h"
 
 #include <memory>
 

--- a/roofit/roofitcore/test/testRooDataHist.cxx
+++ b/roofit/roofitcore/test/testRooDataHist.cxx
@@ -18,12 +18,7 @@
 #include "TMath.h"
 #include "TFile.h"
 
-#include "gtest/gtest.h"
-
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TEST_SUITE_P
-#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
-#endif
+#include "gtest_wrapper.h"
 
 #include <algorithm>
 #include <memory>

--- a/roofit/roofitcore/test/testRooFuncWrapper.cxx
+++ b/roofit/roofitcore/test/testRooFuncWrapper.cxx
@@ -42,12 +42,7 @@
 #include <functional>
 #include <random>
 
-#include <gtest/gtest.h>
-
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TEST_SUITE_P
-#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
-#endif
+#include "gtest_wrapper.h"
 
 namespace {
 

--- a/roofit/roofitcore/test/testRooProdPdf.cxx
+++ b/roofit/roofitcore/test/testRooProdPdf.cxx
@@ -16,12 +16,7 @@
 
 #include <Math/PdfFuncMathCore.h>
 
-#include <gtest/gtest.h>
-
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TEST_SUITE_P
-#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
-#endif
+#include "gtest_wrapper.h"
 
 #include <memory>
 #include <sstream>

--- a/roofit/roofitcore/test/testRooRealIntegral.cxx
+++ b/roofit/roofitcore/test/testRooRealIntegral.cxx
@@ -17,14 +17,9 @@
 
 #include <ROOT/StringUtils.hxx>
 
-#include <gtest/gtest.h>
-
 #include "../src/RooGenProdProj.h"
 
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TEST_SUITE_P
-#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
-#endif
+#include "gtest_wrapper.h"
 
 #include <memory>
 

--- a/roofit/roofitcore/test/testTestStatistics.cxx
+++ b/roofit/roofitcore/test/testTestStatistics.cxx
@@ -20,12 +20,7 @@
 #include <RooRealVar.h>
 #include <RooWorkspace.h>
 
-#include <gtest/gtest.h>
-
-// Backward compatibility for gtest version < 1.10.0
-#ifndef INSTANTIATE_TEST_SUITE_P
-#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
-#endif
+#include "gtest_wrapper.h"
 
 #include <memory>
 #include <cmath>


### PR DESCRIPTION
Closes #12832.

There is also a commit that reduces code duplication in the unit tests by adding one single header where the gtest backwards compatibility changes are made.