### PR TITLE
[RF] Sort the lists before merging

### DIFF
--- a/roofit/roofitcore/src/RooRealSumPdf.cxx
+++ b/roofit/roofitcore/src/RooRealSumPdf.cxx
@@ -697,6 +697,9 @@ std::list<double>* RooRealSumPdf::plotSamplingHint(RooArgList const& funcList, R
 
    auto* newSumHint = new std::list<double>(sumHint->size()+funcHint->size()) ;
 
+   // the lists must be sorted before merging them
+   funcHint->sort();
+   sumHint->sort();
    // Merge hints into temporary array
    merge(funcHint->begin(),funcHint->end(),sumHint->begin(),sumHint->end(),newSumHint->begin()) ;
 


### PR DESCRIPTION
According to the [documentation](https://en.cppreference.com/w/cpp/container/list/merge), the lists need to be sorted before merging them. This fixes a `Debug Assertion Failed! Expression sequence not ordered` error on Windows.