### PR TITLE
[RF] Generalize RooMultiVarGaussian to be constructed from TMatrixDBase

### DIFF
--- a/roofit/roofitcore/inc/RooMultiVarGaussian.h
+++ b/roofit/roofitcore/inc/RooMultiVarGaussian.h
@@ -32,10 +32,10 @@ class RooMultiVarGaussian : public RooAbsPdf {
 public:
 
   RooMultiVarGaussian() {} ;
-  RooMultiVarGaussian(const char *name, const char *title, const RooArgList& xvec, const RooArgList& mu, const TMatrixDSym& covMatrix) ;
+  RooMultiVarGaussian(const char *name, const char *title, const RooArgList& xvec, const RooArgList& mu, const TMatrixDBase& covMatrix) ;
   RooMultiVarGaussian(const char *name, const char *title, const RooArgList& xvec, const RooFitResult& fr, bool reduceToConditional=true) ;
-  RooMultiVarGaussian(const char *name, const char *title, const RooArgList& xvec, const TVectorD& mu, const TMatrixDSym& covMatrix) ;
-  RooMultiVarGaussian(const char *name, const char *title, const RooArgList& xvec,const TMatrixDSym& covMatrix) ;
+  RooMultiVarGaussian(const char *name, const char *title, const RooArgList& xvec, const TVectorD& mu, const TMatrixDBase& covMatrix) ;
+  RooMultiVarGaussian(const char *name, const char *title, const RooArgList& xvec,const TMatrixDBase& covMatrix) ;
   void setAnaIntZ(double z) { _z = z ; }
 
   RooMultiVarGaussian(const RooMultiVarGaussian& other, const char* name=nullptr) ;


### PR DESCRIPTION
So far, the RooMultiVarGaussian required a TMatrixDSym as an input for the covariance matrix, but it would be more convenient to accept the TMatrixDBase class such that questions like on this forum post don't even come up:

https://root-forum.cern.ch/t/multivariate-gaussian-object-creation/55721

The only logic that needs to be added is if the input matrix is symmetric, and an exception will be thrown if it is not.

This change doesn't break backwards compatibility