### PR TITLE
[webcanvas] implement `TWebCanvas::SetCanvasSize`

### DIFF
--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -101,6 +101,7 @@ protected:
    UInt_t fColorsHash{0};          ///<! last hash of colors/palette
    Bool_t fTF1UseSave{kFALSE};     ///<! use save buffer for TF1/TF2, need when evaluation failed on client side
    std::vector<int> fWindowGeometry; ///<! last received window geometry
+   Bool_t fFixedSize{kFALSE};      ///<! is canvas size fixed
 
    UpdatedSignal_t fUpdatedSignal; ///<! signal emitted when canvas updated or state is changed
    PadSignal_t fActivePadChangedSignal; ///<! signal emitted when active pad changed in the canvas
@@ -230,6 +231,8 @@ public:
 
    void SetAsyncMode(Bool_t on = kTRUE) { fAsyncMode = on; }
    Bool_t IsAsyncMode() const { return fAsyncMode; }
+
+   Bool_t IsFixedSize() const { return fFixedSize; }
 
    static TString CreatePadJSON(TPad *pad, Int_t json_compression = 0, Bool_t batchmode = kFALSE);
    static TString CreateCanvasJSON(TCanvas *c, Int_t json_compression = 0, Bool_t batchmode = kFALSE);

--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -100,6 +100,7 @@ protected:
    Long64_t fColorsVersion{0};     ///<! current colors/palette version, checked every time when new snapshot created
    UInt_t fColorsHash{0};          ///<! last hash of colors/palette
    Bool_t fTF1UseSave{kFALSE};     ///<! use save buffer for TF1/TF2, need when evaluation failed on client side
+   std::vector<int> fWindowGeometry; ///<! last received window geometry
 
    UpdatedSignal_t fUpdatedSignal; ///<! signal emitted when canvas updated or state is changed
    PadSignal_t fActivePadChangedSignal; ///<! signal emitted when active pad changed in the canvas

--- a/gui/webgui6/inc/TWebPadOptions.h
+++ b/gui/webgui6/inc/TWebPadOptions.h
@@ -35,6 +35,7 @@ public:
    std::string snapid;                        ///< id of pad
    bool active{false};                        ///< if pad selected as active
    int cw{0}, ch{0};                          ///< canvas width and height in pixels
+   std::vector<int> w;                        ///< window position and size in pixels, set only for canvas
    int logx{0}, logy{0}, logz{0};             ///< pad log properties
    int gridx{0}, gridy{0};                    ///< pad grid properties
    int tickx{0}, ticky{0};                    ///< pad ticks properties

--- a/gui/webgui6/inc/TWebSnapshot.h
+++ b/gui/webgui6/inc/TWebSnapshot.h
@@ -102,6 +102,7 @@ class TCanvasWebSnapshot : public TPadWebSnapshot {
 protected:
    std::string fScripts;           ///< custom scripts to load
    bool fHighlightConnect{false};  ///< does HighlightConnect has connection
+   bool fFixedSize{false};         ///< if canvas draw size is fixed
 public:
    TCanvasWebSnapshot(bool readonly = true, bool setids = true, bool batchmode = false) : TPadWebSnapshot(readonly, setids, batchmode) {}
 
@@ -111,7 +112,10 @@ public:
    void SetHighlightConnect(bool on = true) { fHighlightConnect = on; }
    bool GetHighlightConnect() const { return fHighlightConnect; }
 
-   ClassDefOverride(TCanvasWebSnapshot, 3) // Canvas painting snapshot, used for JSROOT
+   void SetFixedSize(bool on = true) { fFixedSize = on; }
+   bool IsFixedSize() const { return fFixedSize; }
+
+   ClassDefOverride(TCanvasWebSnapshot, 4) // Canvas painting snapshot, used for JSROOT
 };
 
 

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -894,12 +894,8 @@ void TWebCanvas::ShowWebWindow(const ROOT::Experimental::RWebDisplayArgs &args)
          });
    }
 
-   auto w = Canvas()->GetWw(), h = Canvas()->GetWh();
-   if (Canvas()->TestBit(TCanvas::kMenuBar)) h += 40;
-   if (Canvas()->TestBit(TCanvas::kShowEventStatus)) h += 40;
-   if (Canvas()->TestBit(TCanvas::kShowEditor)) w += 200;
-
-   if ((w > 10) && (w < 50000) && (h > 10) && (h < 30000))
+   auto w = Canvas()->GetWindowWidth(), h = Canvas()->GetWindowHeight();
+   if ((w > 0) && (w < 50000) && (h > 0) && (h < 30000))
       fWindow->SetGeometry(w, h);
 
    if ((args.GetBrowserKind() == ROOT::Experimental::RWebDisplayArgs::kQt5) ||
@@ -920,6 +916,9 @@ void TWebCanvas::Show()
 
    ROOT::Experimental::RWebDisplayArgs args;
    args.SetWidgetKind("TCanvas");
+   args.SetSize(Canvas()->GetWindowWidth(), Canvas()->GetWindowHeight());
+   args.SetPos(Canvas()->GetWindowTopX(), Canvas()->GetWindowTopY());
+
    ShowWebWindow(args);
 }
 

--- a/js/build/jsroot.js
+++ b/js/build/jsroot.js
@@ -11,7 +11,7 @@ let version_id = 'dev';
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-let version_date = '11/07/2023';
+let version_date = '18/07/2023';
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}
@@ -1448,8 +1448,8 @@ function getMethods(typename, obj) {
    // Therefore when methods requested for given object, check also that basic methods are there
    if ((typename == clTObject) || (typename == clTNamed) || (obj?.fBits !== undefined))
       if (typeof m.TestBit === 'undefined') {
-         m.TestBit = function (f) { return (this.fBits & f) != 0; };
-         m.InvertBit = function (f) { this.fBits = this.fBits ^ (f & 0xffffff); };
+         m.TestBit = function(f) { return (this.fBits & f) != 0; };
+         m.InvertBit = function(f) { this.fBits = this.fBits ^ (f & 0xffffff); };
       }
 
    if (has_methods) return m;
@@ -8519,11 +8519,14 @@ async function _loadJSDOM() {
 /** @summary Return translate string for transform attribute of some svg element
   * @return string or null if x and y are zeros
   * @private */
-function makeTranslate(x,y) {
-   if (y) return `translate(${x},${y})`;
-   if (x) return `translate(${x})`;
-   return null;
+function makeTranslate(g, x, y) {
+   if (!isObject(g)) {
+      y = x; x = g; g = null;
+   }
+   let res = y ? `translate(${x},${y})` : (x ? `translate(${x})` : null);
+   return g ? g.attr('transform', res) : res;
 }
+
 
 /** @summary Configure special style used for highlight or dragging elements
   * @private */
@@ -9069,7 +9072,7 @@ function parseLatex(node, arg, label, curr) {
       x = Math.round(x);
       y = Math.round(y);
 
-      pos.g.attr('transform', makeTranslate(x, y));
+      makeTranslate(pos.g, x, y);
       pos.rect.x1 += x;
       pos.rect.x2 += x;
       pos.rect.y1 += y;
@@ -9089,9 +9092,7 @@ function parseLatex(node, arg, label, curr) {
       if ((nelements == 1) && !label && !curr.x && !curr.y)
          return gg;
 
-      gg = gg.append('svg:g');
-
-      return gg.attr('transform', makeTranslate(curr.x, curr.y));
+      return makeTranslate(gg.append('svg:g'), curr.x, curr.y);
    };
 
    const extractSubLabel = (check_first, lbrace, rbrace) => {
@@ -9138,11 +9139,12 @@ function parseLatex(node, arg, label, curr) {
       return sublabel;
    };
 
-   const createPath = (gg, dofill) => {
+   const createPath = (gg, d, dofill) => {
       return gg.append('svg:path')
                .style('stroke', dofill ? 'none' : (curr.color || arg.color))
                .style('stroke-width', dofill ? null : Math.max(1, Math.round(curr.fsize*(curr.font.weight ? 0.1 : 0.07))))
-               .style('fill', dofill ? (curr.color || arg.color) : 'none');
+               .style('fill', dofill ? (curr.color || arg.color) : 'none')
+               .attr('d', d ?? null);
    };
 
    const createSubPos = fscale => {
@@ -9264,15 +9266,15 @@ function parseLatex(node, arg, label, curr) {
          positionGNode(subpos, xpos, 0, true);
 
          switch(found.name) {
-            case '#check{': createPath(gg).attr('d',`M${w2},${y1-dy}L${w5},${y1}L${w8},${y1-dy}`); break;
-            case '#acute{': createPath(gg).attr('d',`M${w5},${y1}l${dy},${-dy}`); break;
-            case '#grave{': createPath(gg).attr('d',`M${w5},${y1}l${-dy},${-dy}`); break;
-            case '#dot{': createPath(gg, true).attr('d',`M${w5-dy2},${y1}${dot}`); break;
-            case '#ddot{': createPath(gg, true).attr('d',`M${w5-3*dy2},${y1}${dot} M${w5+dy2},${y1}${dot}`); break;
-            case '#tilde{': createPath(gg).attr('d',`M${w2},${y1} a${w3},${dy},0,0,1,${w3},0 a${w3},${dy},0,0,0,${w3},0`); break;
-            case '#slash{': createPath(gg).attr('d',`M${w},${y1}L0,${Math.round(subpos.rect.y2)}`); break;
-            case '#vec{': createPath(gg).attr('d',`M${w2},${y1}H${w8}M${w8-dy},${y1-dy}l${dy},${dy}l${-dy},${dy}`); break;
-            default: createPath(gg).attr('d',`M${w2},${y1}L${w5},${y1-dy}L${w8},${y1}`); // #hat{
+            case '#check{': createPath(gg, `M${w2},${y1-dy}L${w5},${y1}L${w8},${y1-dy}`); break;
+            case '#acute{': createPath(gg, `M${w5},${y1}l${dy},${-dy}`); break;
+            case '#grave{': createPath(gg, `M${w5},${y1}l${-dy},${-dy}`); break;
+            case '#dot{': createPath(gg, `M${w5-dy2},${y1}${dot}`, true); break;
+            case '#ddot{': createPath(gg, `M${w5-3*dy2},${y1}${dot} M${w5+dy2},${y1}${dot}`, true); break;
+            case '#tilde{': createPath(gg, `M${w2},${y1} a${w3},${dy},0,0,1,${w3},0 a${w3},${dy},0,0,0,${w3},0`); break;
+            case '#slash{': createPath(gg, `M${w},${y1}L0,${Math.round(subpos.rect.y2)}`); break;
+            case '#vec{': createPath(gg, `M${w2},${y1}H${w8}M${w8-dy},${y1-dy}l${dy},${dy}l${-dy},${dy}`); break;
+            default: createPath(gg, `M${w2},${y1}L${w5},${y1-dy}L${w8},${y1}`); // #hat{
          }
 
          shiftX(subpos.rect.width);
@@ -53868,7 +53870,7 @@ function createSVGRenderer(as_is, precision, doc) {
 
    rndr.originalRender = rndr.render;
 
-   rndr.render = function (scene, camera) {
+   rndr.render = function(scene, camera) {
       let originalDocument = globalThis.document;
       if (isNodeJs())
          globalThis.document = this.doc_wrapper;
@@ -54134,7 +54136,7 @@ let Handling3DDrawings = {
             if (elem.empty())
                elem = svg.insert('g', '.primitives_layer').attr('class', size.clname);
 
-            elem.attr('transform', makeTranslate(size.x, size.y));
+            makeTranslate(elem, size.x, size.y);
 
          } else {
 
@@ -60162,7 +60164,7 @@ class TAxisPainter extends ObjectPainter {
 
          if (sign_0 === (vertical ? (set_x > 0) : (set_y > 0))) {
             new_x = set_x; new_y = set_y; curr_indx = besti;
-            title_g.attr('transform', makeTranslate(new_x, new_y));
+            makeTranslate(title_g, new_x, new_y);
          }
 
       }).on('end', evnt => {
@@ -60634,10 +60636,9 @@ class TAxisPainter extends ObjectPainter {
 
          if (title_g) {
             if (!this.titleOffset && this.vertical && labelsMaxWidth)
-              title_shift_x = Math.round(-side * (labelsMaxWidth + 0.7*this.offsetScaling*this.titleSize));
-
-            title_g.attr('transform', makeTranslate(title_shift_x, title_shift_y))
-                   .property('shift_x', title_shift_x)
+               title_shift_x = Math.round(-side * (labelsMaxWidth + 0.7*this.offsetScaling*this.titleSize));
+            makeTranslate(title_g, title_shift_x, title_shift_y);
+            title_g.property('shift_x', title_shift_x)
                    .property('shift_y', title_shift_y);
          }
 
@@ -60781,7 +60782,7 @@ function addDragHandler(_painter, arg) {
       arg.x = newx; arg.y = newy; arg.width = newwidth; arg.height = newheight;
 
       if (!arg.no_transform)
-         draw_g.attr('transform', makeTranslate(newx, newy));
+         makeTranslate(draw_g, newx, newy);
 
       setPainterTooltipEnabled(painter, true);
 
@@ -65412,7 +65413,7 @@ let PadButtonsHandler = {
          btns_y = height - sz0;
       }
 
-      btns.attr('transform', makeTranslate(btns_x,btns_y));
+      makeTranslate(btns, btns_x, btns_y);
    },
 
    findPadButton(keyname) {
@@ -65910,9 +65911,9 @@ class TPadPainter extends ObjectPainter {
              posy = Math.round(rect.height * (1 - gStyle.fDateY));
          if (!is_batch && (posx < 25)) posx = 25;
          if (gStyle.fOptDate > 1) date.setTime(gStyle.fOptDate*1000);
-         dt.attr('transform', makeTranslate(posx, posy))
-           .style('text-anchor', 'start')
-           .text(date.toLocaleString('en-GB'));
+         makeTranslate(dt, posx, posy)
+            .style('text-anchor', 'start')
+            .text(date.toLocaleString('en-GB'));
       }
 
       if (!gStyle.fOptFile || !this.getItemName())
@@ -65932,12 +65933,10 @@ class TPadPainter extends ObjectPainter {
          df.remove();
       } else {
          if (df.empty()) df = info.append('text').attr('class', 'canvas_item');
-         let rect = this.getPadRect(),
-             posx = Math.round(rect.width * (1 - gStyle.fDateX)),
-             posy = Math.round(rect.height * (1 - gStyle.fDateY));
-         df.attr('transform', makeTranslate(posx, posy))
-           .style('text-anchor', 'end')
-           .text(item_name);
+         let rect = this.getPadRect();
+         makeTranslate(df, Math.round(rect.width * (1 - gStyle.fDateX)), Math.round(rect.height * (1 - gStyle.fDateY)))
+            .style('text-anchor', 'end')
+            .text(item_name);
       }
    }
 
@@ -66316,7 +66315,7 @@ class TPadPainter extends ObjectPainter {
          return this.syncDraw(true).then(() => this.drawPrimitives(0));
       }
 
-      if (indx >= this._num_primitives) {
+      if (!this.pad || (indx >= this._num_primitives)) {
          if (this._start_tm) {
             let spenttm = new Date().getTime() - this._start_tm;
             if (spenttm > 1000) console.log(`Canvas ${this.pad?.fName || '---'} drawing took ${(spenttm*1e-3).toFixed(2)}s`);
@@ -66584,26 +66583,6 @@ class TPadPainter extends ObjectPainter {
       if (this._ignore_resize)
          return false;
 
-      if (this._dbr) {
-         // special case of invoked intentially web browser resize to keep layout of canvas the same
-         clearTimeout(this._dbr.handle);
-
-         let rect = getElementRect(this.selectDom('origin'));
-
-         // chrome browser first changes width, then height, producing two different resize events
-         // therefore at least one dimension should match to wait for next resize
-         // if none of dimension matches - cancel direct browser resize
-         if ((rect.width == this._dbr.width) === (rect.height == this._dbr.height)) {
-            let func = this._dbr.func;
-            delete this._dbr;
-            delete this.enforceCanvasSize;
-            func(true);
-         } else {
-            this._dbr.setTimer(200); // check for next resize
-         }
-         return false;
-      }
-
       if (!this.iscan && this.has_canvas) return false;
 
       let sync_promise = this.syncDraw('canvas_resize');
@@ -66624,7 +66603,9 @@ class TPadPainter extends ObjectPainter {
              return getPromise(this.painters[indx].redraw(force ? 'redraw' : 'resize')).then(() => redrawNext(indx+1));
           };
 
-      return sync_promise.then(() => this.ensureBrowserSize(this.pad?.fCw, this.pad?.fCh)).then(() => {
+      // return sync_promise.then(() => this.ensureBrowserSize(this.pad?.fCw, this.pad?.fCh)).then(() => {
+
+      return sync_promise.then(() => {
 
          changed = this.createCanvasSvg(force ? 2 : 1, size);
 
@@ -66633,14 +66614,8 @@ class TPadPainter extends ObjectPainter {
                clearTimeout(this._resize_tmout);
             this._resize_tmout = setTimeout(() => {
                delete this._resize_tmout;
-               if (!this.pad) return;
-               let cw = this.getPadWidth(), ch = this.getPadHeight();
-               if ((cw > 0) && (ch > 0) && ((this.pad.fCw != cw) || (this.pad.fCh != ch))) {
-                  this.pad.fCw = cw;
-                  this.pad.fCh = ch;
-                  console.log(`RESIZED:[${cw},${ch}]`);
-                  this.sendWebsocket(`RESIZED:[${cw},${ch}]`);
-               }
+               if (isFunc(this.sendResized))
+                  this.sendResized();
             }, 1000); // long enough delay to prevent multiple occurence
          }
 
@@ -66888,36 +66863,6 @@ class TPadPainter extends ObjectPainter {
       return null;
    }
 
-   /** @summary Ensure that browser window size match to requested canvas size
-     * @desc Actively used for the first canvas drawing or after intentional layout resize when browser should be adjusted
-     * @private */
-   ensureBrowserSize(canvW, canvH, condition) {
-      if (this.enforceCanvasSize)
-         condition = true;
-
-      if (!condition || this._dbr || !canvW || !canvH || !isFunc(this.resizeBrowser) || !this.online_canvas || this.isBatchMode() || !this.use_openui || this.embed_canvas)
-         return true;
-
-      return new Promise(resolveFunc => {
-         this._dbr = { func: resolveFunc, width: canvW, height: canvH, setTimer: tmout => {
-            this._dbr.handle = setTimeout(() => {
-               if (this._dbr) {
-                  delete this._dbr;
-                  delete this.enforceCanvasSize;
-                  resolveFunc(true);
-               }
-            }, tmout);
-         }};
-
-         if (!this.resizeBrowser(canvW, canvH)) {
-            delete this._dbr;
-            delete this.enforceCanvasSize;
-            resolveFunc(true);
-         } else if (this._dbr) {
-            this._dbr.setTimer(200); // set short timer
-         }
-      });
-   }
 
    /** @summary Redraw pad snap
      * @desc Online version of drawing pad primitives
@@ -67147,7 +67092,7 @@ class TPadPainter extends ObjectPainter {
       if (this.snapid) {
          elem = { _typename: 'TWebPadOptions', snapid: this.snapid.toString(),
                   active: !!this.is_active_pad,
-                  cw: 0, ch: 0,
+                  cw: 0, ch: 0, w: [],
                   bits: 0, primitives: [],
                   logx: this.pad.fLogx, logy: this.pad.fLogy, logz: this.pad.fLogz,
                   gridx: this.pad.fGridx, gridy: this.pad.fGridy,
@@ -67161,6 +67106,7 @@ class TPadPainter extends ObjectPainter {
             elem.bits = this.getStatusBits();
             elem.cw = this.getPadWidth();
             elem.ch = this.getPadHeight();
+            elem.w = [ window.screenLeft, window.screenTop, window.outerWidth, window.outerHeight ];
          } else if (cp) {
             let cw = cp.getPadWidth(), ch = cp.getPadHeight(), rect = this.getPadRect();
             elem.cw = cw;
@@ -67996,7 +67942,12 @@ class TCanvasPainter extends TPadPainter {
              snap = parse(msg.slice(p1+1));
 
          this.syncDraw(true)
-             .then(() => this.ensureBrowserSize(snap.fSnapshot.fCw, snap.fSnapshot.fCh, !this.snapid))
+             .then(() => {
+                if (!this.snapid)
+                   this.resizeBrowser(snap.fSnapshot.fWindowWidth, snap.fSnapshot.fWindowHeight);
+                if (!this.snapid && isFunc(this.setFixedCanvasSize))
+                   this._online_fixed_size = this.setFixedCanvasSize(snap.fSnapshot.fCw, snap.fSnapshot.fCh, snap.fFixedSize);
+             })
              .then(() => this.redrawPadSnap(snap))
              .then(() => {
                 this.completeCanvasSnapDrawing();
@@ -68035,13 +67986,24 @@ class TCanvasPainter extends TPadPainter {
              on = (that[that.length-1] == '1');
          this.showSection(that.slice(0,that.length-2), on);
       } else if (msg.slice(0,5) == 'CTRL:') {
-         let obj = parse(msg.slice(5));
+         let obj = parse(msg.slice(5)), resized = false;
          if ((obj?.title !== undefined) && (typeof document !== 'undefined'))
             document.title = obj.title;
-         if (obj.x && obj.y && typeof window !== 'undefined')
+         if (obj.x && obj.y && typeof window !== 'undefined') {
             window.moveTo(obj.x, obj.y);
-         if (obj.w && obj.h && typeof window !== 'undefined')
-            window.resizeTo(obj.w, obj.h);
+            resized = true;
+         }
+         if (obj.w && obj.h) {
+            this.resizeBrowser(Number.parseInt(obj.w), Number.parseInt(obj.h));
+            resized = true;
+         }
+         if (obj.cw && obj.ch && obj.fixed_size && isFunc(this.setFixedCanvasSize)) {
+            this._online_fixed_size = this.setFixedCanvasSize(Number.parseInt(obj.cw), Number.parseInt(obj.ch), true);
+            resized = true;
+         }
+
+         if (resized)
+            this.sendResized(true);
       } else if (msg.slice(0,5) == 'EDIT:') {
          let obj_painter = this.findSnap(msg.slice(5));
          console.log(`GET EDIT ${msg.slice(5)} found ${!!obj_painter}`);
@@ -68052,6 +68014,26 @@ class TCanvasPainter extends TPadPainter {
       } else {
          console.log(`unrecognized msg ${msg}`);
       }
+   }
+
+   /** @summary Send RESIZED message to client to inform about changes in canvas/window geometry
+     * @private */
+   sendResized(force) {
+      if (!this.pad)
+         return;
+      let cw = this.getPadWidth(), ch = this.getPadHeight(),
+          wx = window.screenLeft, wy = window.screenTop,
+          ww = window.outerWidth, wh = window.outerHeight,
+          fixed = this._online_fixed_size ? 1 : 0;
+      if (!force) {
+         force = (cw > 0) && (ch > 0) && ((this.pad.fCw != cw) || (this.pad.fCh != ch));
+         if (force) {
+            this.pad.fCw = cw;
+            this.pad.fCh = ch;
+         }
+      }
+      if (force)
+         this.sendWebsocket(`RESIZED:${JSON.stringify([wx,wy,ww,wh,cw,ch,fixed])}`);
    }
 
    /** @summary Handle pad button click event */
@@ -68386,24 +68368,12 @@ class TCanvasPainter extends TPadPainter {
       return res;
    }
 
-   /** @summary resize browser window to get requested canvas sizes */
-   resizeBrowser(canvW, canvH) {
-      if (!canvW || !canvH || this.isBatchMode() || this.embed_canvas || this.batch_mode)
+   /** @summary resize browser window */
+   resizeBrowser(fullW, fullH) {
+      if (!fullW || !fullH || this.isBatchMode() || this.embed_canvas || this.batch_mode)
          return;
 
-      let rect = getElementRect(this.selectDom('origin'));
-      if (!rect.width || !rect.height) return;
-
-      let fullW = window.innerWidth - rect.width + canvW,
-          fullH = window.innerHeight - rect.height + canvH;
-
-      if ((fullW > 0) && (fullH > 0) && ((rect.width != canvW) || (rect.height != canvH))) {
-         if (this._websocket)
-            this._websocket.resizeWindow(fullW, fullH);
-         else if (isFunc(window?.resizeTo))
-            window.resizeTo(fullW, fullH);
-         return true;
-      }
+      this._websocket?.resizeWindow(fullW, fullH);
    }
 
    /** @summary draw TCanvas */
@@ -68704,7 +68674,7 @@ class TPavePainter extends ObjectPainter {
          width = Math.round((pt.fX2NDC - pt.fX1NDC) * pad_rect.width);
          height = Math.round((pt.fY2NDC - pt.fY1NDC) * pad_rect.height);
 
-         this.draw_g.attr('transform', makeTranslate(this._pave_x, this._pave_y));
+         makeTranslate(this.draw_g, this._pave_x, this._pave_y);
 
          this.createAttLine({ attr: pt, width: (brd > 0) ? pt.fLineWidth : 0 });
 
@@ -68726,8 +68696,8 @@ class TPavePainter extends ObjectPainter {
                                       .call(this.fillatt.func)
                                       .call(this.lineatt.func);
 
-            let text_g = this.draw_g.append('svg:g')
-                                    .attr('transform', makeTranslate(Math.round(width/4), Math.round(height/4)));
+            let text_g = this.draw_g.append('svg:g');
+            makeTranslate(text_g, Math.round(width/4), Math.round(height/4));
 
             return this.drawPaveText(w2, h2, arg, text_g);
          } else {
@@ -69366,7 +69336,7 @@ class TPavePainter extends ObjectPainter {
 
                if (shift > 0) {
                   this._pave_x -= shift;
-                  this.draw_g.attr('transform', makeTranslate(this._pave_x, this._pave_y));
+                  makeTranslate(this.draw_g, this._pave_x, this._pave_y);
                   palette.fX1NDC -= shift/width;
                   palette.fX2NDC -= shift/width;
                }
@@ -69374,7 +69344,7 @@ class TPavePainter extends ObjectPainter {
                let shift = Math.round((1.05 - gStyle.fTitleY)*height) - rect.y;
                if (shift > 0) {
                   this._pave_y += shift;
-                  this.draw_g.attr('transform', makeTranslate(this._pave_x, this._pave_y));
+                  makeTranslate(this.draw_g, this._pave_x, this._pave_y);
                   palette.fY1NDC -= shift/height;
                   palette.fY2NDC -= shift/height;
                }
@@ -74629,7 +74599,7 @@ let TH2Painter$2 = class TH2Painter extends THistPainter {
 
       this.createG();
 
-      this.draw_g.attr('transform', makeTranslate(Math.round(rect.x + rect.width/2), Math.round(rect.y + rect.height/2)));
+      makeTranslate(this.draw_g, Math.round(rect.x + rect.width/2), Math.round(rect.y + rect.height/2));
 
       let nbins = Math.min(this.nbinsx, this.nbinsy);
 
@@ -74765,7 +74735,7 @@ let TH2Painter$2 = class TH2Painter extends THistPainter {
 
       this.createG();
 
-      this.draw_g.attr('transform', makeTranslate(Math.round(rect.x + rect.width/2), Math.round(rect.y + rect.height/2)));
+      makeTranslate(this.draw_g, Math.round(rect.x + rect.width/2), Math.round(rect.y + rect.height/2));
 
       const chord$1 = chord()
          .padAngle(10 / innerRadius)
@@ -75270,6 +75240,161 @@ let TH2Painter$2 = class TH2Painter extends THistPainter {
    }
 
 }; // class TH2Painter
+
+function createTextGeometry(painter, lbl, size) {
+   if (isPlainText(lbl))
+      return new TextGeometry(translateLaTeX(lbl), { font: HelveticerRegularFont, size, height: 0, curveSegments: 5 });
+
+   let font_size = size * 100, geoms = [], stroke_width = 5;
+
+   class TextParseWrapper {
+
+      constructor(kind, parent) {
+         this.kind = kind ?? 'g';
+         this.childs = [];
+         this.x = 0;
+         this.y = 0;
+         this.font_size = parent?.font_size ?? font_size;
+         parent?.childs.push(this);
+      }
+
+      append(kind) {
+         if (kind == 'svg:g')
+            return new TextParseWrapper('g', this);
+         if (kind == 'svg:text')
+            return new TextParseWrapper('text', this);
+         if (kind == 'svg:path')
+            return new TextParseWrapper('path', this);
+         console.log('should create', kind);
+      }
+
+      style(name, value) {
+         // console.log(`style ${name} = ${value}`);
+         if ((name == 'stroke-width') && value)
+            stroke_width = Number.parseInt(value);
+         return this;
+      }
+
+      translate() {
+         if (this.geom) {
+            // special workaround for path elements, while 3d font is exact height, keep some space on the top
+            // let dy = this.kind == 'path' ? this.font_size*0.002 : 0;
+            this.geom.translate(this.x, this.y, 0);
+         }
+         this.childs.forEach(chld => {
+            chld.x += this.x;
+            chld.y += this.y;
+            chld.translate();
+         });
+      }
+
+      attr(name, value) {
+         // console.log(`attr ${name} = ${value}`);
+
+         const get = () => {
+                  if (!value) return '';
+                  let res = value[0];
+                  value = value.slice(1);
+                  return res;
+               }, getN = (skip) => {
+                  let p = 0;
+                  while (((value[p] >= '0') && (value[p] <= '9')) || (value[p] == '-')) p++;
+                  let res = Number.parseInt(value.slice(0, p));
+                  value = value.slice(p);
+                  if (skip) get();
+                  return res;
+               };
+
+         if ((name == 'font-size') && value) {
+            this.font_size = Number.parseInt(value);
+         } else if ((name == 'transform') && isStr(value) && (value.indexOf('translate') == 0)) {
+            let arr = value.slice(value.indexOf('(')+1, value.lastIndexOf(')')).split(',');
+            this.x += arr[0] ? Number.parseInt(arr[0])*0.01 : 0;
+            this.y -= arr[1] ? Number.parseInt(arr[1])*0.01 : 0;
+         } else if ((name == 'x') && (this.kind == 'text')) {
+            this.x += Number.parseInt(value)*0.01;
+         } else if ((name == 'y') && (this.kind == 'text')) {
+            this.y -= Number.parseInt(value)*0.01;
+         } else if ((name == 'd') && (this.kind == 'path')) {
+            if (get() != 'M') return console.error('Not starts with M');
+            let x1 = getN(true), y1 = getN(), next, pnts = [];
+
+            while (next = get()) {
+               let x2 = x1, y2 = y1;
+               switch(next) {
+                   case 'L': x2 = getN(true); y2 = getN(); break;
+                   case 'l': x2 += getN(true); y2 += getN(); break;
+                   case 'H': x2 = getN(); break;
+                   case 'h': x2 += getN(); break;
+                   case 'V': y2 = getN(); break;
+                   case 'v': y2 += getN(); break;
+                   default: console.log('not supported operator', next);
+               }
+
+               let angle = Math.atan2(y2-y1, x2-x1),
+                   dx = 0.5 * stroke_width * Math.sin(angle),
+                   dy = -0.5 * stroke_width * Math.cos(angle);
+
+               pnts.push(x1-dx, y1-dy, 0, x2-dx, y2-dy, 0, x2+dx, y2+dy, 0, x1-dx, y1-dy, 0, x2+dx, y2+dy, 0, x1+dx, y1+dy, 0);
+
+               x1 = x2; y1 = y2;
+            }
+
+            let pos = new Float32Array(pnts);
+
+            this.geom = new BufferGeometry();
+            this.geom.setAttribute('position', new BufferAttribute(pos, 3));
+            this.geom.scale(0.01, -0.01, 0.01);
+            this.geom.computeVertexNormals();
+
+            geoms.push(this.geom);
+         }
+         return this;
+      }
+
+      text(v) {
+         if (this.kind == 'text') {
+            this.geom = new TextGeometry(v, { font: HelveticerRegularFont, size: Math.round(0.01*this.font_size), height: 0, curveSegments: 5 });
+            geoms.push(this.geom);
+         }      }
+
+   }
+   let node = new TextParseWrapper,
+       arg = { font_size, latex: 1, x: 0, y: 0, text: lbl, align: [ 'start', 'top'], fast: true, font: { size: font_size, isMonospace: () => false, aver_width: 0.9 } };
+
+   produceLatex(painter, node, arg);
+
+   if (!geoms)
+      return new TextGeometry(translateLaTeX(lbl), { font: HelveticerRegularFont, size, height: 0, curveSegments: 5 });
+
+   node.translate(); // apply translate attributes
+
+   if (geoms.length == 1)
+      return geoms[0];
+
+   let total_size = 0;
+   geoms.forEach(geom => {
+      total_size += geom.getAttribute('position').array.length;
+   });
+
+   let pos = new Float32Array(total_size),
+       norm = new Float32Array(total_size),
+       indx = 0;
+
+   geoms.forEach(geom => {
+      let p1 = geom.getAttribute('position').array,
+          n1 = geom.getAttribute('normal').array;
+      for (let i = 0; i < p1.length; ++i, ++indx) {
+         pos[indx] = p1[i];
+         norm[indx] = n1[i];
+      }
+   });
+
+   let fullgeom = new BufferGeometry();
+   fullgeom.setAttribute('position', new BufferAttribute(pos, 3));
+   fullgeom.setAttribute('normal', new BufferAttribute(norm, 3));
+   return fullgeom;
+}
 
 /** @summary Text 3d axis visibility
   * @private */
@@ -75936,7 +76061,7 @@ function drawXYZ(toplevel, AxisPainter, opts) {
          let mod = xticks.get_modifier();
          if (mod?.fLabText) lbl = mod.fLabText;
 
-         let text3d = new TextGeometry(lbl, { font: HelveticerRegularFont, size: this.x_handle.labelsFont.size, height: 0, curveSegments: 5 });
+         let text3d = createTextGeometry(this, lbl, this.x_handle.labelsFont.size);
          text3d.computeBoundingBox();
          let draw_width = text3d.boundingBox.max.x - text3d.boundingBox.min.x,
              draw_height = text3d.boundingBox.max.y - text3d.boundingBox.min.y;
@@ -75967,7 +76092,7 @@ function drawXYZ(toplevel, AxisPainter, opts) {
    }
 
    if (this.x_handle.fTitle && opts.draw) {
-      const text3d = new TextGeometry(translateLaTeX(this.x_handle.fTitle), { font: HelveticerRegularFont, size: this.x_handle.titleFont.size, height: 0, curveSegments: 5 });
+      const text3d = createTextGeometry(this, this.x_handle.fTitle, this.x_handle.titleFont.size);
       text3d.computeBoundingBox();
       text3d.center = this.x_handle.titleCenter;
       text3d.opposite = this.x_handle.titleOpposite;
@@ -76111,7 +76236,7 @@ function drawXYZ(toplevel, AxisPainter, opts) {
       xcont.add(mesh);
    });
 
-   if (opts.zoom && opts.anydraw)
+   if (opts.zoom && opts.drawany)
       xcont.add(createZoomMesh('x', this.size_x3d));
    top.add(xcont);
 
@@ -76159,7 +76284,7 @@ function drawXYZ(toplevel, AxisPainter, opts) {
          let mod = yticks.get_modifier();
          if (mod?.fLabText) lbl = mod.fLabText;
 
-         const text3d = new TextGeometry(lbl, { font: HelveticerRegularFont, size: this.y_handle.labelsFont.size, height: 0, curveSegments: 5 });
+         const text3d = createTextGeometry(this, lbl, this.y_handle.labelsFont.size);
          text3d.computeBoundingBox();
          let draw_width = text3d.boundingBox.max.x - text3d.boundingBox.min.x,
              draw_height = text3d.boundingBox.max.y - text3d.boundingBox.min.y;
@@ -76187,7 +76312,7 @@ function drawXYZ(toplevel, AxisPainter, opts) {
    }
 
    if (this.y_handle.fTitle && opts.draw) {
-      const text3d = new TextGeometry(translateLaTeX(this.y_handle.fTitle), { font: HelveticerRegularFont, size: this.y_handle.titleFont.size, height: 0, curveSegments: 5 });
+      const text3d = createTextGeometry(this, this.y_handle.fTitle, this.y_handle.titleFont.size);
       text3d.computeBoundingBox();
       text3d.center = this.y_handle.titleCenter;
       text3d.opposite = this.y_handle.titleOpposite;
@@ -76247,7 +76372,7 @@ function drawXYZ(toplevel, AxisPainter, opts) {
          ycont.add(mesh);
       });
       ycont.xyid = 1;
-      if (opts.zoom && opts.anydraw)
+      if (opts.zoom && opts.drawany)
          ycont.add(createZoomMesh('y', this.size_y3d));
       top.add(ycont);
    }
@@ -76271,7 +76396,7 @@ function drawXYZ(toplevel, AxisPainter, opts) {
          let mod = zticks.get_modifier();
          if (mod?.fLabText) lbl = mod.fLabText;
 
-         let text3d = new TextGeometry(lbl, { font: HelveticerRegularFont, size: this.z_handle.labelsFont.size, height: 0, curveSegments: 5 });
+         let text3d = createTextGeometry(this, lbl, this.z_handle.labelsFont.size);
          text3d.computeBoundingBox();
          let draw_width = text3d.boundingBox.max.x - text3d.boundingBox.min.x,
              draw_height = text3d.boundingBox.max.y - text3d.boundingBox.min.y;
@@ -76357,7 +76482,7 @@ function drawXYZ(toplevel, AxisPainter, opts) {
       });
 
       if (this.z_handle.fTitle && opts.draw) {
-         let text3d = new TextGeometry(translateLaTeX(this.z_handle.fTitle), { font: HelveticerRegularFont, size: this.z_handle.titleFont.size, height: 0, curveSegments: 5 });
+         let text3d = createTextGeometry(this, this.z_handle.fTitle, this.z_handle.titleFont.size);
          text3d.computeBoundingBox();
          let draw_width = text3d.boundingBox.max.x - text3d.boundingBox.min.x,
              posz = this.z_handle.titleCenter ? (grmaxz + grminz - draw_width)/2 : (this.z_handle.titleOpposite ? grminz : grmaxz - draw_width);
@@ -77461,10 +77586,7 @@ let TH1Painter$2 = class TH1Painter extends THistPainter {
    }
 
    /** @summary Draw histogram as bars */
-   drawBars(height, pmain, funcs) {
-
-      this.createG(true);
-
+   async drawBars(funcs, height) {
       let left = this.getSelectIndex('x', 'left', -1),
           right = this.getSelectIndex('x', 'right', 1),
           histo = this.getHisto(), xaxis = histo.fXaxis,
@@ -77474,7 +77596,7 @@ let TH1Painter$2 = class TH1Painter extends THistPainter {
           side = (this.options.BarStyle > 10) ? this.options.BarStyle % 10 : 0;
 
       if (side > 4) side = 4;
-      gry2 = pmain.swap_xy ? 0 : height;
+      gry2 = funcs.swap_xy ? 0 : height;
       if (Number.isFinite(this.options.BaseLine))
          if (this.options.BaseLine >= funcs.scale_ymin)
             gry2 = Math.round(funcs.gry(this.options.BaseLine));
@@ -77494,7 +77616,7 @@ let TH1Painter$2 = class TH1Painter extends THistPainter {
          x1 = xaxis.GetBinLowEdge(i+1);
          x2 = xaxis.GetBinLowEdge(i+2);
 
-         if (pmain.logx && (x2 <= 0)) continue;
+         if (funcs.logx && (x2 <= 0)) continue;
 
          grx1 = Math.round(funcs.grx(x1));
          grx2 = Math.round(funcs.grx(x2));
@@ -77507,7 +77629,7 @@ let TH1Painter$2 = class TH1Painter extends THistPainter {
          grx1 += Math.round(histo.fBarOffset/1000*w);
          w = Math.round(histo.fBarWidth/1000*w);
 
-         if (pmain.swap_xy)
+         if (funcs.swap_xy)
             bars += `M${gry2},${grx1}h${gry1-gry2}v${w}h${gry2-gry1}z`;
          else
             bars += `M${grx1},${gry1}h${w}v${gry2-gry1}h${-w}z`;
@@ -77515,7 +77637,7 @@ let TH1Painter$2 = class TH1Painter extends THistPainter {
          if (side > 0) {
             grx2 = grx1 + w;
             w = Math.round(w * side / 10);
-            if (pmain.swap_xy) {
+            if (funcs.swap_xy) {
                barsl += `M${gry2},${grx1}h${gry1-gry2}v${w}h${gry2-gry1}z`;
                barsr += `M${gry2},${grx2}h${gry1-gry2}v${-w}h${gry2-gry1}z`;
             } else {
@@ -77527,7 +77649,7 @@ let TH1Painter$2 = class TH1Painter extends THistPainter {
          if (show_text && y) {
             let text = (y === Math.round(y)) ? y.toString() : floatToString(y, gStyle.fPaintTextFormat);
 
-            if (pmain.swap_xy)
+            if (funcs.swap_xy)
                this.drawText({ align: 12, x: Math.round(gry1 + text_size/2), y: Math.round(grx1+0.1), height: Math.round(w*0.8), text, color: text_col, latex: 0 });
             else if (text_angle)
                this.drawText({ align: 12, x: grx1+w/2, y: Math.round(gry1 - 2 - text_size/5), width: 0, height: 0, rotate: text_angle, text, color: text_col, latex: 0 });
@@ -77559,8 +77681,6 @@ let TH1Painter$2 = class TH1Painter extends THistPainter {
 
    /** @summary Draw histogram as filled errors */
    drawFilledErrors(funcs) {
-      this.createG(true);
-
       let left = this.getSelectIndex('x', 'left', -1),
           right = this.getSelectIndex('x', 'right', 1),
           histo = this.getHisto(), xaxis = histo.fXaxis,
@@ -77587,25 +77707,9 @@ let TH1Painter$2 = class TH1Painter extends THistPainter {
                  .call(this.fillatt.func);
    }
 
-   /** @summary Draw TH1 bins in SVG element
+   /** @summary Draw TH1 as hist/line/curve
      * @return Promise or scalar value */
-   draw1DBins() {
-
-      this.createHistDrawAttributes();
-
-      let pmain = this.getFramePainter(),
-          funcs = pmain.getGrFuncs(this.options.second_x, this.options.second_y),
-          width = pmain.getFrameWidth(), height = pmain.getFrameHeight();
-
-      if (!this.draw_content || (width <= 0) || (height <= 0))
-          return this.removeG();
-
-      if (this.options.Bar)
-         return this.drawBars(height, pmain, funcs);
-
-      if ((this.options.ErrorKind === 3) || (this.options.ErrorKind === 4))
-         return this.drawFilledErrors(pmain, funcs);
-
+   drawNormal(funcs, width, height) {
       let left = this.getSelectIndex('x', 'left', -1),
           right = this.getSelectIndex('x', 'right', 2),
           histo = this.getHisto(),
@@ -77665,8 +77769,6 @@ let TH1Painter$2 = class TH1Painter extends THistPainter {
 
       if (!draw_hist && !draw_any_but_hist)
          return this.removeG();
-
-      this.createG(true);
 
       if (show_text) {
          text_col = this.getColor(histo.fMarkerColor);
@@ -77942,6 +78044,32 @@ let TH1Painter$2 = class TH1Painter extends THistPainter {
 
       if (show_text)
          return this.finishTextDrawing();
+   }
+
+   /** @summary Draw TH1 bins in SVG element
+     * @return Promise or scalar value */
+   draw1DBins() {
+      this.createHistDrawAttributes();
+
+      let pmain = this.getFramePainter(),
+          funcs = pmain.getGrFuncs(this.options.second_x, this.options.second_y),
+          width = pmain.getFrameWidth(), height = pmain.getFrameHeight();
+
+      if (!this.draw_content || (width <= 0) || (height <= 0))
+          return this.removeG();
+
+      this.createG(true);
+
+      if (this.options.Bar)
+         return this.drawBars(funcs, height).then(() => {
+            if (this.options.ErrorKind === 1)
+               return this.drawNormal(funcs, width, height);
+         });
+
+      if ((this.options.ErrorKind === 3) || (this.options.ErrorKind === 4))
+         return this.drawFilledErrors(funcs);
+
+      return this.drawNormal(funcs, width, height);
    }
 
    /** @summary Provide text information (tooltips) for histogram bin */
@@ -104099,7 +104227,7 @@ async function drawText$1() {
          this.moveDrag = function(dx, dy) {
             this.pos_dx += dx;
             this.pos_dy += dy;
-            this.draw_g.attr('transform', makeTranslate(this.pos_dx, this.pos_dy));
+            makeTranslate(this.draw_g, this.pos_dx, this.pos_dy);
         };
 
       if (!this.moveEnd)
@@ -104119,7 +104247,7 @@ async function drawText$1() {
             let pos = main.convert3DtoPadNDC(text.fX, text.fY, text.fZ),
                 new_x = this.axisToSvg('x', pos.x, true),
                 new_y = this.axisToSvg('y', pos.y, true);
-            this.draw_g.attr('transform', makeTranslate(new_x - this.pos_x, new_y - this.pos_y));
+            makeTranslate(this.draw_g, new_x - this.pos_x, new_y - this.pos_y);
          };
       }
 
@@ -104164,14 +104292,13 @@ function drawPolyLine() {
 
    addMoveHandler(this);
 
-   this.dx = 0;
-   this.dy = 0;
+   this.dx = this.dy = 0;
    this.isndc = isndc;
 
-   this.moveDrag = function (dx,dy) {
+   this.moveDrag = function(dx,dy) {
       this.dx += dx;
       this.dy += dy;
-      this.draw_g.select('path').attr('transform', makeTranslate(this.dx, this.dy));
+      makeTranslate(this.draw_g.select('path'), this.dx, this.dy);
    };
 
    this.moveEnd = function(not_changed) {
@@ -104275,9 +104402,7 @@ function drawEllipse() {
    this.x = x;
    this.y = y;
 
-   this.draw_g
-      .append('svg:path')
-      .attr('transform', makeTranslate(x, y))
+   makeTranslate(this.draw_g.append('svg:path'), x, y)
       .attr('d', path)
       .call(this.lineatt.func)
       .call(this.fillatt.func);
@@ -104286,13 +104411,13 @@ function drawEllipse() {
 
    addMoveHandler(this);
 
-   this.moveDrag = function (dx,dy) {
+   this.moveDrag = function(dx,dy) {
       this.x += dx;
       this.y += dy;
-      this.draw_g.select('path').attr('transform', makeTranslate(this.x, this.y));
+      makeTranslate(this.draw_g.select('path'), this.x, this.y);
    };
 
-   this.moveEnd = function (not_changed) {
+   this.moveEnd = function(not_changed) {
       if (not_changed) return;
       let ellipse = this.getObject();
       ellipse.fX1 = this.svgToAxis('x', this.x);
@@ -104314,7 +104439,7 @@ function drawPie() {
        rx = this.axisToSvg('x', pie.fX + pie.fRadius) - xc,
        ry = this.axisToSvg('y', pie.fY + pie.fRadius) - yc;
 
-   this.draw_g.attr('transform', makeTranslate(xc, yc));
+   makeTranslate(this.draw_g, xc, yc);
 
    // Draw the slices
    let nb = pie.fPieSlices.length, total = 0,
@@ -104404,7 +104529,7 @@ function drawBox$1() {
 
    addMoveHandler(this);
 
-   this.moveStart = function (x,y) {
+   this.moveStart = function(x,y) {
       let ww = Math.abs(this.x2 - this.x1), hh = Math.abs(this.y1 - this.y2);
 
       this.c_x1 = Math.abs(x - this.x2) > ww*0.1;
@@ -104417,7 +104542,7 @@ function drawBox$1() {
          this.c_x1 = this.c_x2 = false;
    };
 
-   this.moveDrag = function (dx,dy) {
+   this.moveDrag = function(dx,dy) {
       if (this.c_x1) this.x1 += dx;
       if (this.c_x2) this.x2 += dx;
       if (this.c_y1) this.y1 += dy;
@@ -104429,7 +104554,7 @@ function drawBox$1() {
       pathes.forEach((path, i) => select(nodes[i]).attr('d', path));
    };
 
-   this.moveEnd = function (not_changed) {
+   this.moveEnd = function(not_changed) {
       if (not_changed) return;
       let box = this.getObject(), exec = '';
       if (this.c_x1) { box.fX1 = this.svgToAxis('x', this.x1); exec += `SetX1(${box.fX1});;`; }
@@ -104466,13 +104591,12 @@ function drawMarker$1() {
 
    addMoveHandler(this);
 
-   this.dx = 0;
-   this.dy = 0;
+   this.dx = this.dy = 0;
 
-   this.moveDrag = function (dx,dy) {
+   this.moveDrag = function(dx,dy) {
       this.dx += dx;
       this.dy += dy;
-      this.draw_g.select('path').attr('transform', makeTranslate(this.dx, this.dy));
+      makeTranslate(this.draw_g.select('path'), this.dx, this.dy);
    };
 
    this.moveEnd = function(not_changed) {
@@ -104509,13 +104633,12 @@ function drawPolyMarker() {
 
    addMoveHandler(this);
 
-   this.dx = 0;
-   this.dy = 0;
+   this.dx = this.dy = 0;
 
-   this.moveDrag = function (dx,dy) {
+   this.moveDrag = function(dx,dy) {
       this.dx += dx;
       this.dy += dy;
-      this.draw_g.select('path').attr('transform', makeTranslate(this.dx, this.dy));
+      makeTranslate(this.draw_g.select('path'), this.dx, this.dy);
    };
 
    this.moveEnd = function(not_changed) {
@@ -105853,7 +105976,7 @@ class TGraphPolargramPainter extends ObjectPainter {
 
       this.createG();
 
-      this.draw_g.attr('transform', makeTranslate(Math.round(rect.x + rect.width/2), Math.round(rect.y + rect.height/2)));
+      makeTranslate(this.draw_g, Math.round(rect.x + rect.width/2), Math.round(rect.y + rect.height/2));
       this.szx = rect.szx;
       this.szy = rect.szy;
 
@@ -106880,7 +107003,7 @@ let TGraphPainter$1 = class TGraphPainter extends ObjectPainter {
                        .enter()
                        .append('svg:g')
                        .attr('class', 'grpoint')
-                       .attr('transform', d => makeTranslate(d.grx1,d.gry1));
+                       .attr('transform', d => makeTranslate(d.grx1, d.gry1));
       }
 
       if (options.Bar) {
@@ -107503,7 +107626,7 @@ let TGraphPainter$1 = class TGraphPainter extends ObjectPainter {
       this.pos_dy += dy;
 
       if (this.move_binindx === undefined) {
-         this.draw_g.attr('transform', makeTranslate(this.pos_dx,this.pos_dy));
+         makeTranslate(this.draw_g, this.pos_dx, this.pos_dy);
       } else if (this.move_funcs && this.move_bin) {
          this.move_bin.x = this.move_funcs.revertAxis('x', this.move_x0 + this.pos_dx);
          this.move_bin.y = this.move_funcs.revertAxis('y', this.move_y0 + this.pos_dy);
@@ -110085,7 +110208,7 @@ class TGaxisPainter extends TAxisPainter {
    moveDrag(dx, dy) {
       this.gaxis_x += dx;
       this.gaxis_y += dy;
-      this.getG().attr('transform', makeTranslate(this.gaxis_x, this.gaxis_y));
+      makeTranslate(this.getG(), this.gaxis_x, this.gaxis_y);
    }
 
    /** @summary Drag end handle */
@@ -111996,7 +112119,7 @@ class RAxisPainter extends RObjectPainter {
                }
 
                new_x = set_x; new_y = set_y; curr_indx = besti;
-               title_g.attr('transform', makeTranslate(new_x, new_y));
+               makeTranslate(title_g, new_x, new_y);
 
           }).on('end', evnt => {
                if (!drag_rect) return;
@@ -112226,7 +112349,7 @@ class RAxisPainter extends RObjectPainter {
       return this.finishTextDrawing(label_g).then(() => {
 
         if (lbls_tilt)
-           label_g.selectAll('text').each(function () {
+           label_g.selectAll('text').each(function() {
                let txt = select(this), tr = txt.attr('transform');
                txt.attr('transform', tr + ' rotate(25)').style('text-anchor', 'start');
            });
@@ -112290,10 +112413,10 @@ class RAxisPainter extends RObjectPainter {
                          text: this.fTitle, draw_g: title_g });
       }
 
-      title_g.attr('transform', makeTranslate(title_shift_x, title_shift_y))
-             .property('basepos', title_basepos)
-             .property('shift_x', title_shift_x)
-             .property('shift_y', title_shift_y);
+      makeTranslate(title_g, title_shift_x, title_shift_y)
+                   .property('basepos', title_basepos)
+                   .property('shift_x', title_shift_x)
+                   .property('shift_y', title_shift_y);
 
       this.addTitleDrag(title_g, side);
 
@@ -114558,26 +114681,6 @@ class RPadPainter extends RObjectPainter {
       if (this._ignore_resize)
          return false;
 
-      if (this._dbr) {
-         // special case of invoked intentially web browser resize to keep layout of canvas the same
-         clearTimeout(this._dbr.handle);
-
-         let rect = getElementRect(this.selectDom('origin'));
-
-         // chrome browser first changes width, then height, producing two different resize events
-         // therefore at least one dimension should match to wait for next resize
-         // if none of dimension matches - cancel direct browser resize
-         if ((rect.width == this._dbr.width) === (rect.height == this._dbr.height)) {
-            let func = this._dbr.func;
-            delete this._dbr;
-            delete this.enforceCanvasSize;
-            func(true);
-         } else {
-            this._dbr.setTimer(200); // check for next resize
-         }
-         return false;
-      }
-
       if (!this.iscan && this.has_canvas) return false;
 
       let sync_promise = this.syncDraw('canvas_resize');
@@ -114599,7 +114702,7 @@ class RPadPainter extends RObjectPainter {
           };
 
 
-      return sync_promise.then(() => this.ensureBrowserSize(this.pad?.fWinSize[0], this.pad?.fWinSize[1])).then(() => {
+      return sync_promise.then(() => {
          changed = this.createCanvasSvg(force ? 2 : 1, size);
 
          if (changed && this.iscan && this.pad && this.online_canvas && !this.embed_canvas && !this.isBatchMode()) {
@@ -114866,39 +114969,6 @@ class RPadPainter extends RObjectPainter {
       }
 
       return null;
-   }
-
-   /** @summary Ensure that browser window size match to requested canvas size
-     * @desc Actively used for the first canvas drawing or after intentional layout resize when browser should be adjusted
-     * @private */
-   ensureBrowserSize(canvW, canvH, condition) {
-      if (this.enforceCanvasSize)
-         condition = true;
-
-      if (!condition || this._dbr || !canvW || !canvH || !isFunc(this.resizeBrowser) || !this.online_canvas || this.isBatchMode() || !this.use_openui || this.embed_canvas)
-         return true;
-
-      return new Promise(resolveFunc => {
-         this._dbr = {
-            func: resolveFunc, width: canvW, height: canvH, setTimer: tmout => {
-               this._dbr.handle = setTimeout(() => {
-                  if (this._dbr) {
-                     delete this._dbr;
-                     delete this.enforceCanvasSize;
-                     resolveFunc(true);
-                  }
-               }, tmout);
-            }
-         };
-
-         if (!this.resizeBrowser(canvW, canvH)) {
-            delete this._dbr;
-            delete this.enforceCanvasSize;
-            resolveFunc(true);
-         } else if (this._dbr) {
-            this._dbr.setTimer(200); // set short timer
-         }
-      });
    }
 
    /** @summary Redraw pad snap
@@ -115855,7 +115925,7 @@ class WebWindowHandle {
    resizeWindow(w, h) {
       if (browser$1.qt5 || browser$1.cef3)
          this.send(`RESIZE=${w},${h}`, 0);
-      else if (isFunc(window?.resizeTo))
+      else if ((typeof window !== 'undefined') && isFunc(window?.resizeTo))
          window.resizeTo(w, h);
    }
 
@@ -116351,8 +116421,10 @@ class RCanvasPainter extends RPadPainter {
              snapid = msg.slice(0,p1),
              snap = parse(msg.slice(p1+1));
          this.syncDraw(true)
-             .then(() => this.ensureBrowserSize(snap.fWinSize[0], snap.fWinSize[1], !this.snapid && snap?.fWinSize))
-             .then(() => this.redrawPadSnap(snap))
+             .then(() => {
+                if (!this.snapid && snap?.fWinSize)
+                   this.resizeBrowser(snap.fWinSize[0], snap.fWinSize[1]);
+             }).then(() => this.redrawPadSnap(snap))
              .then(() => {
                  handle.send(`SNAPDONE:${snapid}`); // send ready message back when drawing completed
                  this.confirmDraw();
@@ -116725,23 +116797,10 @@ class RCanvasPainter extends RPadPainter {
    }
 
    /** @summary resize browser window to get requested canvas sizes */
-   resizeBrowser(canvW, canvH) {
-      if (!canvW || !canvH || this.isBatchMode() || this.embed_canvas || this.batch_mode)
+   resizeBrowser(fullW, fullH) {
+      if (!fullW || !fullH || this.isBatchMode() || this.embed_canvas || this.batch_mode)
          return;
-
-      let rect = getElementRect(this.selectDom('origin'));
-      if (!rect.width || !rect.height) return;
-
-      let fullW = window.innerWidth - rect.width + canvW,
-          fullH = window.innerHeight - rect.height + canvH;
-
-      if ((fullW > 0) && (fullH > 0) && ((rect.width != canvW) || (rect.height != canvH))) {
-         if (this._websocket)
-            this._websocket.resizeWindow(fullW, fullH);
-         else if (isFunc(window?.resizeTo))
-            window.resizeTo(fullW, fullH);
-         return true;
-      }
+      this._websocket?.resizeWindow(fullW, fullH);
    }
 
    /** @summary draw RCanvas object */
@@ -116832,7 +116891,7 @@ function drawRFrameTitle(reason, drag) {
 
    this.createG();
 
-   this.draw_g.attr('transform', makeTranslate(fx, Math.round(fy-title_margin-title_height)));
+   makeTranslate(this.draw_g, fx, Math.round(fy-title_margin-title_height));
 
    let arg = { x: title_width/2, y: title_height/2, text: title.fText, latex: 1 };
 
@@ -117212,7 +117271,7 @@ class RPalettePainter extends RObjectPainter {
           }
 
           // x,y,width,height attributes used for drag functionality
-          this.draw_g.attr('transform', makeTranslate(palette_x, palette_y));
+          makeTranslate(this.draw_g, palette_x, palette_y);
       }
 
       let g_btns = this.draw_g.selectChild('.colbtns');
@@ -117463,7 +117522,7 @@ class RPavePainter extends RObjectPainter {
             pave_y = fr.y + offsety;
       }
 
-      this.draw_g.attr('transform', makeTranslate(pave_x,pave_y));
+      makeTranslate(this.draw_g, pave_x, pave_y);
 
       this.draw_g.append('svg:rect')
                  .attr('x', 0)

--- a/js/changes.md
+++ b/js/changes.md
@@ -14,6 +14,7 @@
 10. Support "pol", "cyl", "sph" and "psr" coordinates systems with lego and surf plots
 11. Use "col" as default draw option for TH2, "box2" for TH3
 12. Support "mollweide" projection for TH2
+13. Basic latex support when drawing axes labels and titles in 3D
 
 
 ## Changes in 7.4.1

--- a/js/modules/base/BasePainter.mjs
+++ b/js/modules/base/BasePainter.mjs
@@ -1,5 +1,5 @@
 import { select as d3_select } from '../d3.mjs';
-import { settings, internals, isNodeJs, isFunc, isStr, btoa_func } from '../core.mjs';
+import { settings, internals, isNodeJs, isFunc, isStr, isObject, btoa_func } from '../core.mjs';
 
 
 /** @summary Returns visible rect of element
@@ -693,11 +693,14 @@ async function _loadJSDOM() {
 /** @summary Return translate string for transform attribute of some svg element
   * @return string or null if x and y are zeros
   * @private */
-function makeTranslate(x,y) {
-   if (y) return `translate(${x},${y})`;
-   if (x) return `translate(${x})`;
-   return null;
+function makeTranslate(g, x, y) {
+   if (!isObject(g)) {
+      y = x; x = g; g = null;
+   }
+   let res = y ? `translate(${x},${y})` : (x ? `translate(${x})` : null);
+   return g ? g.attr('transform', res) : res;
 }
+
 
 /** @summary Configure special style used for highlight or dragging elements
   * @private */

--- a/js/modules/base/base3d.mjs
+++ b/js/modules/base/base3d.mjs
@@ -104,7 +104,7 @@ function createSVGRenderer(as_is, precision, doc) {
 
    rndr.originalRender = rndr.render;
 
-   rndr.render = function (scene, camera) {
+   rndr.render = function(scene, camera) {
       let originalDocument = globalThis.document;
       if (isNodeJs())
          globalThis.document = this.doc_wrapper;
@@ -370,7 +370,7 @@ let Handling3DDrawings = {
             if (elem.empty())
                elem = svg.insert('g', '.primitives_layer').attr('class', size.clname);
 
-            elem.attr('transform', makeTranslate(size.x, size.y));
+            makeTranslate(elem, size.x, size.y);
 
          } else {
 

--- a/js/modules/base/latex.mjs
+++ b/js/modules/base/latex.mjs
@@ -1,5 +1,5 @@
 import { loadScript, settings, isNodeJs, isStr, source_dir, browser } from '../core.mjs';
-import { getElementRect, _loadJSDOM, makeTranslate } from './BasePainter.mjs';
+import { getElementRect, _loadJSDOM, makeTranslate  } from './BasePainter.mjs';
 import { FontHandler } from './FontHandler.mjs';
 
 
@@ -334,7 +334,7 @@ function parseLatex(node, arg, label, curr) {
       x = Math.round(x);
       y = Math.round(y);
 
-      pos.g.attr('transform', makeTranslate(x, y));
+      makeTranslate(pos.g, x, y);
       pos.rect.x1 += x;
       pos.rect.x2 += x;
       pos.rect.y1 += y;
@@ -354,9 +354,7 @@ function parseLatex(node, arg, label, curr) {
       if ((nelements == 1) && !label && !curr.x && !curr.y)
          return gg;
 
-      gg = gg.append('svg:g');
-
-      return gg.attr('transform', makeTranslate(curr.x, curr.y));
+      return makeTranslate(gg.append('svg:g'), curr.x, curr.y);
    };
 
    const extractSubLabel = (check_first, lbrace, rbrace) => {
@@ -403,11 +401,12 @@ function parseLatex(node, arg, label, curr) {
       return sublabel;
    };
 
-   const createPath = (gg, dofill) => {
+   const createPath = (gg, d, dofill) => {
       return gg.append('svg:path')
                .style('stroke', dofill ? 'none' : (curr.color || arg.color))
                .style('stroke-width', dofill ? null : Math.max(1, Math.round(curr.fsize*(curr.font.weight ? 0.1 : 0.07))))
-               .style('fill', dofill ? (curr.color || arg.color) : 'none');
+               .style('fill', dofill ? (curr.color || arg.color) : 'none')
+               .attr('d', d ?? null);
    };
 
    const createSubPos = fscale => {
@@ -529,15 +528,15 @@ function parseLatex(node, arg, label, curr) {
          positionGNode(subpos, xpos, 0, true);
 
          switch(found.name) {
-            case '#check{': createPath(gg).attr('d',`M${w2},${y1-dy}L${w5},${y1}L${w8},${y1-dy}`); break;
-            case '#acute{': createPath(gg).attr('d',`M${w5},${y1}l${dy},${-dy}`); break;
-            case '#grave{': createPath(gg).attr('d',`M${w5},${y1}l${-dy},${-dy}`); break;
-            case '#dot{': createPath(gg, true).attr('d',`M${w5-dy2},${y1}${dot}`); break;
-            case '#ddot{': createPath(gg, true).attr('d',`M${w5-3*dy2},${y1}${dot} M${w5+dy2},${y1}${dot}`); break;
-            case '#tilde{': createPath(gg).attr('d',`M${w2},${y1} a${w3},${dy},0,0,1,${w3},0 a${w3},${dy},0,0,0,${w3},0`); break;
-            case '#slash{': createPath(gg).attr('d',`M${w},${y1}L0,${Math.round(subpos.rect.y2)}`); break;
-            case '#vec{': createPath(gg).attr('d',`M${w2},${y1}H${w8}M${w8-dy},${y1-dy}l${dy},${dy}l${-dy},${dy}`); break;
-            default: createPath(gg).attr('d',`M${w2},${y1}L${w5},${y1-dy}L${w8},${y1}`); // #hat{
+            case '#check{': createPath(gg, `M${w2},${y1-dy}L${w5},${y1}L${w8},${y1-dy}`); break;
+            case '#acute{': createPath(gg, `M${w5},${y1}l${dy},${-dy}`); break;
+            case '#grave{': createPath(gg, `M${w5},${y1}l${-dy},${-dy}`); break;
+            case '#dot{': createPath(gg, `M${w5-dy2},${y1}${dot}`, true); break;
+            case '#ddot{': createPath(gg, `M${w5-3*dy2},${y1}${dot} M${w5+dy2},${y1}${dot}`, true); break;
+            case '#tilde{': createPath(gg, `M${w2},${y1} a${w3},${dy},0,0,1,${w3},0 a${w3},${dy},0,0,0,${w3},0`); break;
+            case '#slash{': createPath(gg, `M${w},${y1}L0,${Math.round(subpos.rect.y2)}`); break;
+            case '#vec{': createPath(gg, `M${w2},${y1}H${w8}M${w8-dy},${y1-dy}l${dy},${dy}l${-dy},${dy}`); break;
+            default: createPath(gg, `M${w2},${y1}L${w5},${y1-dy}L${w8},${y1}`); // #hat{
          }
 
          shiftX(subpos.rect.width);

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -5,7 +5,7 @@ let version_id = 'dev';
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-let version_date = '11/07/2023';
+let version_date = '18/07/2023';
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}
@@ -1443,8 +1443,8 @@ function getMethods(typename, obj) {
    // Therefore when methods requested for given object, check also that basic methods are there
    if ((typename == clTObject) || (typename == clTNamed) || (obj?.fBits !== undefined))
       if (typeof m.TestBit === 'undefined') {
-         m.TestBit = function (f) { return (this.fBits & f) != 0; };
-         m.InvertBit = function (f) { this.fBits = this.fBits ^ (f & 0xffffff); };
+         m.TestBit = function(f) { return (this.fBits & f) != 0; };
+         m.InvertBit = function(f) { this.fBits = this.fBits ^ (f & 0xffffff); };
       }
 
    if (has_methods) return m;

--- a/js/modules/draw/TGaxisPainter.mjs
+++ b/js/modules/draw/TGaxisPainter.mjs
@@ -43,7 +43,7 @@ class TGaxisPainter extends TAxisPainter {
    moveDrag(dx, dy) {
       this.gaxis_x += dx;
       this.gaxis_y += dy;
-      this.getG().attr('transform', makeTranslate(this.gaxis_x, this.gaxis_y));
+      makeTranslate(this.getG(), this.gaxis_x, this.gaxis_y);
    }
 
    /** @summary Drag end handle */

--- a/js/modules/draw/TGraphPolarPainter.mjs
+++ b/js/modules/draw/TGraphPolarPainter.mjs
@@ -144,7 +144,7 @@ class TGraphPolargramPainter extends ObjectPainter {
 
       this.createG();
 
-      this.draw_g.attr('transform', makeTranslate(Math.round(rect.x + rect.width/2), Math.round(rect.y + rect.height/2)));
+      makeTranslate(this.draw_g, Math.round(rect.x + rect.width/2), Math.round(rect.y + rect.height/2));
       this.szx = rect.szx;
       this.szy = rect.szy;
 

--- a/js/modules/draw/more.mjs
+++ b/js/modules/draw/more.mjs
@@ -72,7 +72,7 @@ async function drawText() {
          this.moveDrag = function(dx, dy) {
             this.pos_dx += dx;
             this.pos_dy += dy;
-            this.draw_g.attr('transform', makeTranslate(this.pos_dx, this.pos_dy));
+            makeTranslate(this.draw_g, this.pos_dx, this.pos_dy);
         }
 
       if (!this.moveEnd)
@@ -92,7 +92,7 @@ async function drawText() {
             let pos = main.convert3DtoPadNDC(text.fX, text.fY, text.fZ),
                 new_x = this.axisToSvg('x', pos.x, true),
                 new_y = this.axisToSvg('y', pos.y, true);
-            this.draw_g.attr('transform', makeTranslate(new_x - this.pos_x, new_y - this.pos_y));
+            makeTranslate(this.draw_g, new_x - this.pos_x, new_y - this.pos_y);
          };
       }
 
@@ -137,14 +137,13 @@ function drawPolyLine() {
 
    addMoveHandler(this);
 
-   this.dx = 0;
-   this.dy = 0;
+   this.dx = this.dy = 0;
    this.isndc = isndc;
 
-   this.moveDrag = function (dx,dy) {
+   this.moveDrag = function(dx,dy) {
       this.dx += dx;
       this.dy += dy;
-      this.draw_g.select('path').attr('transform', makeTranslate(this.dx, this.dy));
+      makeTranslate(this.draw_g.select('path'), this.dx, this.dy);
    }
 
    this.moveEnd = function(not_changed) {
@@ -248,9 +247,7 @@ function drawEllipse() {
    this.x = x;
    this.y = y;
 
-   this.draw_g
-      .append('svg:path')
-      .attr('transform', makeTranslate(x, y))
+   makeTranslate(this.draw_g.append('svg:path'), x, y)
       .attr('d', path)
       .call(this.lineatt.func)
       .call(this.fillatt.func);
@@ -259,13 +256,13 @@ function drawEllipse() {
 
    addMoveHandler(this);
 
-   this.moveDrag = function (dx,dy) {
+   this.moveDrag = function(dx,dy) {
       this.x += dx;
       this.y += dy;
-      this.draw_g.select('path').attr('transform', makeTranslate(this.x, this.y));
+      makeTranslate(this.draw_g.select('path'), this.x, this.y);
    }
 
-   this.moveEnd = function (not_changed) {
+   this.moveEnd = function(not_changed) {
       if (not_changed) return;
       let ellipse = this.getObject();
       ellipse.fX1 = this.svgToAxis('x', this.x);
@@ -287,7 +284,7 @@ function drawPie() {
        rx = this.axisToSvg('x', pie.fX + pie.fRadius) - xc,
        ry = this.axisToSvg('y', pie.fY + pie.fRadius) - yc;
 
-   this.draw_g.attr('transform', makeTranslate(xc, yc));
+   makeTranslate(this.draw_g, xc, yc);
 
    // Draw the slices
    let nb = pie.fPieSlices.length, total = 0,
@@ -377,7 +374,7 @@ function drawBox() {
 
    addMoveHandler(this);
 
-   this.moveStart = function (x,y) {
+   this.moveStart = function(x,y) {
       let ww = Math.abs(this.x2 - this.x1), hh = Math.abs(this.y1 - this.y2);
 
       this.c_x1 = Math.abs(x - this.x2) > ww*0.1;
@@ -390,7 +387,7 @@ function drawBox() {
          this.c_x1 = this.c_x2 = false;
    }
 
-   this.moveDrag = function (dx,dy) {
+   this.moveDrag = function(dx,dy) {
       if (this.c_x1) this.x1 += dx;
       if (this.c_x2) this.x2 += dx;
       if (this.c_y1) this.y1 += dy;
@@ -402,7 +399,7 @@ function drawBox() {
       pathes.forEach((path, i) => d3_select(nodes[i]).attr('d', path));
    }
 
-   this.moveEnd = function (not_changed) {
+   this.moveEnd = function(not_changed) {
       if (not_changed) return;
       let box = this.getObject(), exec = '';
       if (this.c_x1) { box.fX1 = this.svgToAxis('x', this.x1); exec += `SetX1(${box.fX1});;`; }
@@ -439,13 +436,12 @@ function drawMarker() {
 
    addMoveHandler(this);
 
-   this.dx = 0;
-   this.dy = 0;
+   this.dx = this.dy = 0;
 
-   this.moveDrag = function (dx,dy) {
+   this.moveDrag = function(dx,dy) {
       this.dx += dx;
       this.dy += dy;
-      this.draw_g.select('path').attr('transform', makeTranslate(this.dx, this.dy));
+      makeTranslate(this.draw_g.select('path'), this.dx, this.dy);
    }
 
    this.moveEnd = function(not_changed) {
@@ -482,13 +478,12 @@ function drawPolyMarker() {
 
    addMoveHandler(this);
 
-   this.dx = 0;
-   this.dy = 0;
+   this.dx = this.dy = 0;
 
-   this.moveDrag = function (dx,dy) {
+   this.moveDrag = function(dx,dy) {
       this.dx += dx;
       this.dy += dy;
-      this.draw_g.select('path').attr('transform', makeTranslate(this.dx, this.dy));
+      makeTranslate(this.draw_g.select('path'), this.dx, this.dy);
    }
 
    this.moveEnd = function(not_changed) {

--- a/js/modules/draw/v7more.mjs
+++ b/js/modules/draw/v7more.mjs
@@ -164,7 +164,7 @@ class RPalettePainter extends RObjectPainter {
           }
 
           // x,y,width,height attributes used for drag functionality
-          this.draw_g.attr('transform', makeTranslate(palette_x, palette_y));
+          makeTranslate(this.draw_g, palette_x, palette_y);
       }
 
       let g_btns = this.draw_g.selectChild('.colbtns');

--- a/js/modules/gpad/RAxisPainter.mjs
+++ b/js/modules/gpad/RAxisPainter.mjs
@@ -488,7 +488,7 @@ class RAxisPainter extends RObjectPainter {
                }
 
                new_x = set_x; new_y = set_y; curr_indx = besti;
-               title_g.attr('transform', makeTranslate(new_x, new_y));
+               makeTranslate(title_g, new_x, new_y);
 
           }).on('end', evnt => {
                if (!drag_rect) return;
@@ -718,7 +718,7 @@ class RAxisPainter extends RObjectPainter {
       return this.finishTextDrawing(label_g).then(() => {
 
         if (lbls_tilt)
-           label_g.selectAll('text').each(function () {
+           label_g.selectAll('text').each(function() {
                let txt = d3_select(this), tr = txt.attr('transform');
                txt.attr('transform', tr + ' rotate(25)').style('text-anchor', 'start');
            });
@@ -782,10 +782,10 @@ class RAxisPainter extends RObjectPainter {
                          text: this.fTitle, draw_g: title_g });
       }
 
-      title_g.attr('transform', makeTranslate(title_shift_x, title_shift_y))
-             .property('basepos', title_basepos)
-             .property('shift_x', title_shift_x)
-             .property('shift_y', title_shift_y);
+      makeTranslate(title_g, title_shift_x, title_shift_y)
+                   .property('basepos', title_basepos)
+                   .property('shift_x', title_shift_x)
+                   .property('shift_y', title_shift_y);
 
       this.addTitleDrag(title_g, side);
 

--- a/js/modules/gpad/TAxisPainter.mjs
+++ b/js/modules/gpad/TAxisPainter.mjs
@@ -807,7 +807,7 @@ class TAxisPainter extends ObjectPainter {
 
          if (sign_0 === (vertical ? (set_x > 0) : (set_y > 0))) {
             new_x = set_x; new_y = set_y; curr_indx = besti;
-            title_g.attr('transform', makeTranslate(new_x, new_y));
+            makeTranslate(title_g, new_x, new_y);
          }
 
       }).on('end', evnt => {
@@ -1279,10 +1279,9 @@ class TAxisPainter extends ObjectPainter {
 
          if (title_g) {
             if (!this.titleOffset && this.vertical && labelsMaxWidth)
-              title_shift_x = Math.round(-side * (labelsMaxWidth + 0.7*this.offsetScaling*this.titleSize));
-
-            title_g.attr('transform', makeTranslate(title_shift_x, title_shift_y))
-                   .property('shift_x', title_shift_x)
+               title_shift_x = Math.round(-side * (labelsMaxWidth + 0.7*this.offsetScaling*this.titleSize));
+            makeTranslate(title_g, title_shift_x, title_shift_y);
+            title_g.property('shift_x', title_shift_x)
                    .property('shift_y', title_shift_y);
          }
 

--- a/js/modules/gpad/TCanvasPainter.mjs
+++ b/js/modules/gpad/TCanvasPainter.mjs
@@ -354,7 +354,12 @@ class TCanvasPainter extends TPadPainter {
              snap = parse(msg.slice(p1+1));
 
          this.syncDraw(true)
-             .then(() => this.ensureBrowserSize(snap.fSnapshot.fCw, snap.fSnapshot.fCh, !this.snapid))
+             .then(() => {
+                if (!this.snapid)
+                   this.resizeBrowser(snap.fSnapshot.fWindowWidth, snap.fSnapshot.fWindowHeight);
+                if (!this.snapid && isFunc(this.setFixedCanvasSize))
+                   this._online_fixed_size = this.setFixedCanvasSize(snap.fSnapshot.fCw, snap.fSnapshot.fCh, snap.fFixedSize);
+             })
              .then(() => this.redrawPadSnap(snap))
              .then(() => {
                 this.completeCanvasSnapDrawing();
@@ -393,13 +398,24 @@ class TCanvasPainter extends TPadPainter {
              on = (that[that.length-1] == '1');
          this.showSection(that.slice(0,that.length-2), on);
       } else if (msg.slice(0,5) == 'CTRL:') {
-         let obj = parse(msg.slice(5));
+         let obj = parse(msg.slice(5)), resized = false;
          if ((obj?.title !== undefined) && (typeof document !== 'undefined'))
             document.title = obj.title;
-         if (obj.x && obj.y && typeof window !== 'undefined')
+         if (obj.x && obj.y && typeof window !== 'undefined') {
             window.moveTo(obj.x, obj.y);
-         if (obj.w && obj.h && typeof window !== 'undefined')
-            window.resizeTo(obj.w, obj.h);
+            resized = true;
+         }
+         if (obj.w && obj.h) {
+            this.resizeBrowser(Number.parseInt(obj.w), Number.parseInt(obj.h));
+            resized = true;
+         }
+         if (obj.cw && obj.ch && obj.fixed_size && isFunc(this.setFixedCanvasSize)) {
+            this._online_fixed_size = this.setFixedCanvasSize(Number.parseInt(obj.cw), Number.parseInt(obj.ch), true);
+            resized = true;
+         }
+
+         if (resized)
+            this.sendResized(true);
       } else if (msg.slice(0,5) == 'EDIT:') {
          let obj_painter = this.findSnap(msg.slice(5));
          console.log(`GET EDIT ${msg.slice(5)} found ${!!obj_painter}`);
@@ -410,6 +426,26 @@ class TCanvasPainter extends TPadPainter {
       } else {
          console.log(`unrecognized msg ${msg}`);
       }
+   }
+
+   /** @summary Send RESIZED message to client to inform about changes in canvas/window geometry
+     * @private */
+   sendResized(force) {
+      if (!this.pad)
+         return;
+      let cw = this.getPadWidth(), ch = this.getPadHeight(),
+          wx = window.screenLeft, wy = window.screenTop,
+          ww = window.outerWidth, wh = window.outerHeight,
+          fixed = this._online_fixed_size ? 1 : 0;
+      if (!force) {
+         force = (cw > 0) && (ch > 0) && ((this.pad.fCw != cw) || (this.pad.fCh != ch));
+         if (force) {
+            this.pad.fCw = cw;
+            this.pad.fCh = ch;
+         }
+      }
+      if (force)
+         this.sendWebsocket(`RESIZED:${JSON.stringify([wx,wy,ww,wh,cw,ch,fixed])}`);
    }
 
    /** @summary Handle pad button click event */
@@ -744,24 +780,12 @@ class TCanvasPainter extends TPadPainter {
       return res;
    }
 
-   /** @summary resize browser window to get requested canvas sizes */
-   resizeBrowser(canvW, canvH) {
-      if (!canvW || !canvH || this.isBatchMode() || this.embed_canvas || this.batch_mode)
+   /** @summary resize browser window */
+   resizeBrowser(fullW, fullH) {
+      if (!fullW || !fullH || this.isBatchMode() || this.embed_canvas || this.batch_mode)
          return;
 
-      let rect = getElementRect(this.selectDom('origin'));
-      if (!rect.width || !rect.height) return;
-
-      let fullW = window.innerWidth - rect.width + canvW,
-          fullH = window.innerHeight - rect.height + canvH;
-
-      if ((fullW > 0) && (fullH > 0) && ((rect.width != canvW) || (rect.height != canvH))) {
-         if (this._websocket)
-            this._websocket.resizeWindow(fullW, fullH);
-         else if (isFunc(window?.resizeTo))
-            window.resizeTo(fullW, fullH);
-         return true;
-      }
+      this._websocket?.resizeWindow(fullW, fullH);
    }
 
    /** @summary draw TCanvas */

--- a/js/modules/gpad/TFramePainter.mjs
+++ b/js/modules/gpad/TFramePainter.mjs
@@ -143,7 +143,7 @@ function addDragHandler(_painter, arg) {
       arg.x = newx; arg.y = newy; arg.width = newwidth; arg.height = newheight;
 
       if (!arg.no_transform)
-         draw_g.attr('transform', makeTranslate(newx, newy));
+         makeTranslate(draw_g, newx, newy);
 
       setPainterTooltipEnabled(painter, true);
 

--- a/js/modules/hist/RPavePainter.mjs
+++ b/js/modules/hist/RPavePainter.mjs
@@ -66,7 +66,7 @@ class RPavePainter extends RObjectPainter {
             pave_y = fr.y + offsety;
       }
 
-      this.draw_g.attr('transform', makeTranslate(pave_x,pave_y));
+      makeTranslate(this.draw_g, pave_x, pave_y);
 
       this.draw_g.append('svg:rect')
                  .attr('x', 0)

--- a/js/modules/hist/TPavePainter.mjs
+++ b/js/modules/hist/TPavePainter.mjs
@@ -216,7 +216,7 @@ class TPavePainter extends ObjectPainter {
          width = Math.round((pt.fX2NDC - pt.fX1NDC) * pad_rect.width);
          height = Math.round((pt.fY2NDC - pt.fY1NDC) * pad_rect.height);
 
-         this.draw_g.attr('transform', makeTranslate(this._pave_x, this._pave_y));
+         makeTranslate(this.draw_g, this._pave_x, this._pave_y);
 
          this.createAttLine({ attr: pt, width: (brd > 0) ? pt.fLineWidth : 0 });
 
@@ -238,8 +238,8 @@ class TPavePainter extends ObjectPainter {
                                       .call(this.fillatt.func)
                                       .call(this.lineatt.func);
 
-            let text_g = this.draw_g.append('svg:g')
-                                    .attr('transform', makeTranslate(Math.round(width/4), Math.round(height/4)));
+            let text_g = this.draw_g.append('svg:g');
+            makeTranslate(text_g, Math.round(width/4), Math.round(height/4));
 
             return this.drawPaveText(w2, h2, arg, text_g);
          } else {
@@ -878,7 +878,7 @@ class TPavePainter extends ObjectPainter {
 
                if (shift > 0) {
                   this._pave_x -= shift;
-                  this.draw_g.attr('transform', makeTranslate(this._pave_x, this._pave_y));
+                  makeTranslate(this.draw_g, this._pave_x, this._pave_y);
                   palette.fX1NDC -= shift/width;
                   palette.fX2NDC -= shift/width;
                }
@@ -886,7 +886,7 @@ class TPavePainter extends ObjectPainter {
                let shift = Math.round((1.05 - gStyle.fTitleY)*height) - rect.y;
                if (shift > 0) {
                   this._pave_y += shift;
-                  this.draw_g.attr('transform', makeTranslate(this._pave_x, this._pave_y));
+                  makeTranslate(this.draw_g, this._pave_x, this._pave_y);
                   palette.fY1NDC -= shift/height;
                   palette.fY2NDC -= shift/height;
                }

--- a/js/modules/hist2d/TGraphPainter.mjs
+++ b/js/modules/hist2d/TGraphPainter.mjs
@@ -644,7 +644,7 @@ class TGraphPainter extends ObjectPainter {
                        .enter()
                        .append('svg:g')
                        .attr('class', 'grpoint')
-                       .attr('transform', d => makeTranslate(d.grx1,d.gry1));
+                       .attr('transform', d => makeTranslate(d.grx1, d.gry1));
       }
 
       if (options.Bar) {
@@ -1267,7 +1267,7 @@ class TGraphPainter extends ObjectPainter {
       this.pos_dy += dy;
 
       if (this.move_binindx === undefined) {
-         this.draw_g.attr('transform', makeTranslate(this.pos_dx,this.pos_dy));
+         makeTranslate(this.draw_g, this.pos_dx, this.pos_dy);
       } else if (this.move_funcs && this.move_bin) {
          this.move_bin.x = this.move_funcs.revertAxis('x', this.move_x0 + this.pos_dx);
          this.move_bin.y = this.move_funcs.revertAxis('y', this.move_y0 + this.pos_dy);

--- a/js/modules/hist2d/TH2Painter.mjs
+++ b/js/modules/hist2d/TH2Painter.mjs
@@ -2453,7 +2453,7 @@ class TH2Painter extends THistPainter {
 
       this.createG();
 
-      this.draw_g.attr('transform', makeTranslate(Math.round(rect.x + rect.width/2), Math.round(rect.y + rect.height/2)));
+      makeTranslate(this.draw_g, Math.round(rect.x + rect.width/2), Math.round(rect.y + rect.height/2));
 
       let nbins = Math.min(this.nbinsx, this.nbinsy);
 
@@ -2589,7 +2589,7 @@ class TH2Painter extends THistPainter {
 
       this.createG();
 
-      this.draw_g.attr('transform', makeTranslate(Math.round(rect.x + rect.width/2), Math.round(rect.y + rect.height/2)));
+      makeTranslate(this.draw_g, Math.round(rect.x + rect.width/2), Math.round(rect.y + rect.height/2));
 
       const chord = d3_chord()
          .padAngle(10 / innerRadius)

--- a/js/modules/webwindow.mjs
+++ b/js/modules/webwindow.mjs
@@ -449,7 +449,7 @@ class WebWindowHandle {
    resizeWindow(w, h) {
       if (browser.qt5 || browser.cef3)
          this.send(`RESIZE=${w},${h}`, 0);
-      else if (isFunc(window?.resizeTo))
+      else if ((typeof window !== 'undefined') && isFunc(window?.resizeTo))
          window.resizeTo(w, h);
    }
 

--- a/ui5/browser/controller/FileDialog.controller.js
+++ b/ui5/browser/controller/FileDialog.controller.js
@@ -134,10 +134,10 @@ sap.ui.define(['rootui5/panel/Controller',
 
          let tm = new Date().getTime();
 
-         if ((this._last_item === item) && ((tm - this._last_tm) < 300)) {
+         if ((this._last_item === item) && ((tm - this._last_tm) < 400)) {
             // handle double click
             delete this._last_item;
-            if ((this.kind == 'OpenFile') && !is_folder)
+            if (((this.kind == 'OpenFile') || (this.kind == 'SaveAs')) && !is_folder)
                return this.onOkPress();
             else
                return;

--- a/ui5/canv/controller/CanvasPanel.controller.js
+++ b/ui5/canv/controller/CanvasPanel.controller.js
@@ -11,7 +11,7 @@ sap.ui.define([
          // workaround, openui5 does not preserve DOM elements when calling onBeforeRendering
          let dom = this.getView().getDomRef();
          if (this.canvas_painter && dom?.children.length && !this._mainChild) {
-            this._mainChild = dom.children[0];
+            this._mainChild = dom.lastChild;
             dom.removeChild(this._mainChild);
          }
       },
@@ -52,6 +52,23 @@ sap.ui.define([
            this.resize_tmout = setTimeout(this.onResizeTimeout.bind(this), tmout);
       },
 
+      /** @summary Set fixed size for canvas container */
+      setFixedSize(w, h, on) {
+         let dom = this.getView().getDomRef();
+         if (!dom?.lastChild) return false;
+
+         if (!this.isFixedSize && !on) return false;
+
+         this.isFixedSize = w && h && on;
+
+         if (this.isFixedSize)
+            dom.lastChild.style = `position:relative;left:0px;top:0px;width:${w}px;height:${h}px`;
+         else
+            dom.lastChild.style = 'position:relative;inset:0px;height:100%;width:100%';
+
+         return this.isFixedSize;
+      },
+
       /** @summary Handle openui5 resize glitch
         * @desc onAfterRendering method does not provide valid dimension of the HTML element
         * One should wait either resize event or timeout and check if valid size is there
@@ -79,9 +96,10 @@ sap.ui.define([
             }
 
             if (dom && !dom.children.length) {
-               let d = document.createElement("div");
-               d.style = "position:relative;left:0;right:0;top:0;bottom:0;height:100%;width:100%";
+               let d = document.createElement('div');
+               d.style = 'position:relative;inset:0px;height:100%;width:100%';
                dom.appendChild(d);
+               this.isFixedSize = false;
             }
 
             if (this.canvas_painter) {

--- a/ui5/canv/view/Canvas.view.xml
+++ b/ui5/canv/view/Canvas.view.xml
@@ -82,7 +82,7 @@
                <menu>
                   <Menu itemSelected="onOptionsMenuAction">
                      <items>
-                        <MenuItem text="Interrupt"/>
+                        <MenuItem text="Auto resize" icon="{/AutoResizeIcon}" tooltip="Canvas automatically resized with web browser"/>
                      </items>
                   </Menu>
                </menu>


### PR DESCRIPTION
Implement proper handling of canvas window size and canvas drawing area size.

By default web browser with given window size/position will be started. Depending from context menu,
status line, other layout components drawing area will be reduced to some value and always adjust to that area.

With the call `TCanvas::SetCanvasSize(width,height)` one can fix drawing area to exact value, which does not change with web browser resize. One can toggle state either with context menu or by calling ``c1->SetCanvasSize(0,0)`.

All browser window position/size changes are reflected in the TCanvas members

Provide JSROOT with new resize logic, also includes support of TLatex in 3D plots
