### PR TITLE
Fixed an infinite loop bug in TDirectoryFile.cxx

### DIFF
--- a/io/io/src/TDirectoryFile.cxx
+++ b/io/io/src/TDirectoryFile.cxx
@@ -1209,16 +1209,17 @@ void TDirectoryFile::ls(Option_t *option) const
       while (lnk) {
          TKey *key = (TKey*)lnk->GetObject();
          TString s = key->GetName();
-         if (s.Index(re) == kNPOS) continue;
-         bool first = (lnk->Prev() == nullptr) || (s != lnk->Prev()->GetObject()->GetName());
-         bool hasbackup = (lnk->Next() != nullptr) && (s == lnk->Next()->GetObject()->GetName());
-         if (first)
-            if (hasbackup)
-               key->ls(true);
+         if (s.Index(re) != kNPOS) {
+            bool first = (lnk->Prev() == nullptr) || (s != lnk->Prev()->GetObject()->GetName());
+            bool hasbackup = (lnk->Next() != nullptr) && (s == lnk->Next()->GetObject()->GetName());
+            if (first)
+               if (hasbackup)
+                  key->ls(true);
+               else
+                  key->ls();
             else
-               key->ls();
-         else
-            key->ls(false);
+               key->ls(false);
+         }
          lnk = lnk->Next();
       }
    }


### PR DESCRIPTION
# This Pull request:
Fixes a bug that resulted in an infinite loop when calling TDirectoryFile::ls() with a regular expression as parameter.

## Changes or fixes:
When calling TDirectoryFile::ls() with a regular expression that not matches all keys in the file, the first not matching key resulted in an infinite loop because the increasement of the key-iterator in the last line of the loop was skipped by the continue statement.

## Checklist:
- [X] tested changes locally
