### PR TITLE
Let enable autoresize mode again for TCanvas

### DIFF
--- a/graf2d/gpad/src/TCanvas.cxx
+++ b/graf2d/gpad/src/TCanvas.cxx
@@ -1964,13 +1964,15 @@ void TCanvas::SetBatch(Bool_t batch)
 /// the scroll bars. The Width and Height in this method are different from those
 /// given in the TCanvas constructors where these two dimension include the size
 /// of the window decoration whereas they do not in this method.
+/// When both ww==0 and wh==0, auto resize mode will be enabled again and
+/// canvas drawing area will automatically fit available window size
 
 void TCanvas::SetCanvasSize(UInt_t ww, UInt_t wh)
 {
    if (fCanvasImp) {
-      fCanvasImp->SetCanvasSize(ww, wh);
       fCw = ww;
       fCh = wh;
+      fCanvasImp->SetCanvasSize(ww, wh);
       TContext ctxt(this, kTRUE);
       ResizePad();
    }

--- a/gui/gui/src/TRootCanvas.cxx
+++ b/gui/gui/src/TRootCanvas.cxx
@@ -503,7 +503,7 @@ void TRootCanvas::CreateCanvas(const char *name)
    fToolDock->EnableHide(kFALSE);
    AddFrame(fToolDock, fDockLayout = new TGLayoutHints(kLHintsExpandX));
 
-   // will alocate it later
+   // will allocate it later
    fToolBar = 0;
    fVertical1 = 0;
    fVertical2 = 0;
@@ -1260,14 +1260,21 @@ Int_t TRootCanvas::InitWindow()
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Set size of canvas container. Units in pixels.
+/// If w==0 and h==0, set autofit mode
 
 void TRootCanvas::SetCanvasSize(UInt_t w, UInt_t h)
 {
    // turn off autofit, we want to stay at the given size
-   fAutoFit = kFALSE;
-   fOptionMenu->UnCheckEntry(kOptionAutoResize);
    int opt = fCanvasContainer->GetOptions();
-   opt |= kFixedSize;    // turn on fixed size mode
+   if (!w && !h) {
+      fAutoFit = kTRUE;
+      fOptionMenu->CheckEntry(kOptionAutoResize);
+      opt &= ~kFixedSize;    // turn off fixed size mode
+   } else {
+      fAutoFit = kFALSE;
+      fOptionMenu->UnCheckEntry(kOptionAutoResize);
+      opt |= kFixedSize;    // turn on fixed size mode
+   }
    fCanvasContainer->ChangeOptions(opt);
    fCanvasContainer->SetWidth(w);
    fCanvasContainer->SetHeight(h);


### PR DESCRIPTION
Currently after `c1->SetCanvasSize(800,700)` area for painting is fixed-size. If necessary, gui shows scrollbars.
There was no method to switch this mode back - only via canvas context menu.

I propose to use `c1->SetCanvasSize(0,0)` to enable autofit mode again. 

Also minimize usage of `gVirtualX` with web-based canvas. 
The only exception - usage of  `gVirtualX->IsCmdThread()`.