### PR TITLE
[cling] Fix test MultipleInterpreters.C

### DIFF
--- a/interpreter/cling/lib/Interpreter/Value.cpp
+++ b/interpreter/cling/lib/Interpreter/Value.cpp
@@ -146,7 +146,7 @@ namespace cling {
                                                   const clang::ASTContext &C) {
     using namespace clang;
 
-    if (C.hasSameType(QT, C.VoidTy))
+    if (QT->isVoidType())
       return Value::kVoid;
 
     if (const auto *ET = dyn_cast<EnumType>(QT.getTypePtr()))

--- a/interpreter/cling/lib/Interpreter/Value.cpp
+++ b/interpreter/cling/lib/Interpreter/Value.cpp
@@ -142,8 +142,7 @@ namespace cling {
       AllocatedValue::getFromPayload(m_Storage.m_Ptr)->Retain();
   }
 
-  static Value::TypeKind getCorrespondingTypeKind(clang::QualType QT,
-                                                  const clang::ASTContext &C) {
+  static Value::TypeKind getCorrespondingTypeKind(clang::QualType QT) {
     using namespace clang;
 
     if (QT->isVoidType())
@@ -170,7 +169,7 @@ namespace cling {
   }
 
   Value::Value(clang::QualType clangTy, Interpreter& Interp):
-    m_TypeKind(getCorrespondingTypeKind(clangTy, Interp.getCI()->getASTContext())),
+    m_TypeKind(getCorrespondingTypeKind(clangTy)),
     m_Type(clangTy.getAsOpaquePtr()), // FIXME: What if clangTy is freed?
     m_Interpreter(&Interp) {
     if (m_TypeKind == Value::kPtrOrObjTy) {

--- a/interpreter/cling/test/MultipleInterpreters/MultipleInterpreters.C
+++ b/interpreter/cling/test/MultipleInterpreters/MultipleInterpreters.C
@@ -33,5 +33,9 @@ const char* argV[1] = {"cling"};
   ChildInterp.declare("void foo(int i){ printf(\"foo(int) = %d\\n\", i); }\n");
   ChildInterp.echo("foo()"); //CHECK: (int) 42
   ChildInterp.execute("foo(1)"); //CHECK: foo(int) = 1
+
+  // The following should not crash, even if the child interpreter has a
+  // different ASTContext.VoidTy.
+  ChildInterp.echo("(void)1");
 }
 .q

--- a/interpreter/cling/test/MultipleInterpreters/MultipleInterpreters.C
+++ b/interpreter/cling/test/MultipleInterpreters/MultipleInterpreters.C
@@ -32,6 +32,6 @@ const char* argV[1] = {"cling"};
   cling::Interpreter ChildInterp(*gCling, 1, argV);
   ChildInterp.declare("void foo(int i){ printf(\"foo(int) = %d\\n\", i); }\n");
   ChildInterp.echo("foo()"); //CHECK: (int) 42
-  ChildInterp.echo("foo(1)"); //CHECK: foo(int) = 1
+  ChildInterp.execute("foo(1)"); //CHECK: foo(int) = 1
 }
 .q


### PR DESCRIPTION
The return type of `foo(int)` is `void`, which causes an assertion failure in `lib/Interpreter/Value.cpp:163`: "Type not supported".