### PR TITLE
Automatically adjust C++ version of PCH in Cling's test

### DIFF
--- a/interpreter/cling/test/CodeUnloading/PCH/VTables.C
+++ b/interpreter/cling/test/CodeUnloading/PCH/VTables.C
@@ -1,7 +1,7 @@
 // RUN: %mkdir "%T/Rel/Path" || true
 // RUN: %rm "CompGen.h.pch" && %rm "%T/Rel/Path/Relative.pch"
-// RUN: clang -x c++-header -fexceptions -fcxx-exceptions -std=c++14 -pthread %S/Inputs/CompGen.h -o CompGen.h.pch
-// RUN: clang -x c++-header -fexceptions -fcxx-exceptions -std=c++14 -pthread %S/Inputs/CompGen.h -o %T/Rel/Path/Relative.pch
+// RUN: clang -x c++-header -fexceptions -fcxx-exceptions -std=%std_cxx -pthread %S/Inputs/CompGen.h -o CompGen.h.pch
+// RUN: clang -x c++-header -fexceptions -fcxx-exceptions -std=%std_cxx -pthread %S/Inputs/CompGen.h -o %T/Rel/Path/Relative.pch
 // RUN: cat %s | %cling -I%p -Xclang -include-pch -Xclang CompGen.h.pch  2>&1 | FileCheck %s
 // RUN: cat %s | %cling -I%p -I%T/Rel/Path -include-pch Relative.pch 2>&1 | FileCheck %s
 

--- a/interpreter/cling/test/lit.cfg
+++ b/interpreter/cling/test/lit.cfg
@@ -69,18 +69,6 @@ llvm_config.with_system_environment(
 config.substitutions.append(('%PATH%', config.environment['PATH']))
 
 
-# For each occurrence of a clang tool name, replace it with the full path to
-# the build directory holding that tool.  We explicitly specify the directories
-# to search to ensure that we get the tools just built and not some random
-# tools that might happen to be in the user's PATH.
-tool_dirs = [config.llvm_tools_dir]
-
-tools = [
-    'c-index-test', 'clang-diff', 'clang-format', 'clang-tblgen', 'opt'
-]
-
-llvm_config.add_tool_substitutions(tools, tool_dirs)
-
 # We want to invoke the system clang. Or not?
 config.substitutions = [x for x in config.substitutions if x[0] != ' clang ']
 

--- a/interpreter/cling/test/lit.cfg
+++ b/interpreter/cling/test/lit.cfg
@@ -76,6 +76,8 @@ config.substitutions.append(('%cling_obj_root', config.cling_obj_root))
 incDir = os.path.join(config.llvm_obj_root, 'tools', 'clang', 'include')
 config.substitutions.append( ('%cling', config.llvm_tools_dir + '/cling --nologo -I%s' % fixupPath(incDir)) )
 
+config.substitutions.append(('%std_cxx', 'c++' + config.cxx_standard))
+
 if platform.system() in ['Windows']:
   config.substitutions.append(('%dllexport', '"__declspec(dllexport)"'))
   config.substitutions.append(('%fPIC', ''))

--- a/interpreter/cling/test/lit.site.cfg.in
+++ b/interpreter/cling/test/lit.site.cfg.in
@@ -8,6 +8,7 @@ config.cling_obj_root = "@CLING_BINARY_DIR@"
 config.target_triple = "@TARGET_TRIPLE@"
 config.host_triple = "@TARGET_TRIPLE@"
 config.shlibext = "@TARGET_SHLIBEXT@"
+config.cxx_standard = "@CMAKE_CXX_STANDARD@"
 
 # Support substitution of the tools and libs dirs with user parameters. This is
 # used when we can't determine the tool dir at configuration time.


### PR DESCRIPTION
This fixes `test/CodeUnloading/PCH/VTables.C` with C++17 and later.