### PR TITLE
Improve `TWebCanvas` communication, more use of control messages

### DIFF
--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -30,8 +30,11 @@ class TPadWebSnapshot;
 class TWebPS;
 class TObjLink;
 class TExec;
+class TWebCanvasTimer;
 
 class TWebCanvas : public TCanvasImp {
+
+friend class TWebCanvasTimer;
 
 public:
    /// Function type for signals, invoked when canvas drawing or update is completed
@@ -76,6 +79,7 @@ protected:
    };
 
    std::vector<WebConn> fWebConn;  ///<! connections
+   TWebCanvasTimer *fTimer{nullptr}; ///<! timer to submit control messages
 
    std::map<TPad*, PadStatus> fPadsStatus; ///<! map of pads in canvas and their status flags
 
@@ -131,7 +135,7 @@ protected:
 
    void AddCtrlMsg(unsigned connid, const std::string &key, const std::string &value, Bool_t send_immediately = kFALSE);
 
-   void CheckDataToSend(unsigned connid = 0);
+   void CheckDataToSend(unsigned connid, Bool_t only_ctrl);
 
    Bool_t WaitWhenCanvasPainted(Long64_t ver);
 
@@ -161,7 +165,7 @@ protected:
 
 public:
    TWebCanvas(TCanvas *c, const char *name, Int_t x, Int_t y, UInt_t width, UInt_t height, Bool_t readonly = kTRUE);
-   ~TWebCanvas() override = default;
+   ~TWebCanvas() override;
 
    void ShowWebWindow(const ROOT::Experimental::RWebDisplayArgs &user_args = "");
 

--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -195,11 +195,11 @@ public:
    void   SetWindowSize(UInt_t w, UInt_t h) override;
    void   SetWindowTitle(const char *newTitle) override;
    void   SetCanvasSize(UInt_t w, UInt_t h) override;
+   void   Iconify() override;
+   void   RaiseWindow() override;
 
    /*
-      virtual void   Iconify() { }
       virtual void   SetStatusText(const char *text = 0, Int_t partidx = 0);
-      virtual void   RaiseWindow();
       virtual void   ReallyDelete();
     */
 

--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -131,11 +131,11 @@ protected:
 
    void CheckCanvasModified(bool force_modified = false);
 
-   Bool_t AddToSendQueue(unsigned connid, const std::string &msg);
+   void AddCtrlMsg(unsigned connid, const std::string &key, const std::string &value);
 
-   void AddCtrlMsg(unsigned connid, const std::string &key, const std::string &value, Bool_t send_immediately = kFALSE);
+   void AddSendQueue(unsigned connid, const std::string &msg);
 
-   void CheckDataToSend(unsigned connid, Bool_t only_ctrl);
+   void CheckDataToSend(unsigned connid = 0);
 
    Bool_t WaitWhenCanvasPainted(Long64_t ver);
 

--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -57,7 +57,9 @@ protected:
       Long64_t fSendVersion{0};        ///<! canvas version send to the client
       Long64_t fDrawVersion{0};        ///<! canvas version drawn (confirmed) by client
       UInt_t fLastSendHash{0};         ///<! hash of last send draw message, avoid looping
+      std::map<std::string, std::string> fCtrl; ///<! different ctrl parameters which can be send at once
       std::queue<std::string> fSend;   ///<! send queue, processed after sending draw data
+
       WebConn(unsigned id) : fConnId(id) {}
       void reset()
       {
@@ -76,8 +78,6 @@ protected:
    std::vector<WebConn> fWebConn;  ///<! connections
 
    std::map<TPad*, PadStatus> fPadsStatus; ///<! map of pads in canvas and their status flags
-
-   std::map<std::string, std::string> fCtrlMsgs; ///<! different ctrl messages which can be send with next update
 
    std::shared_ptr<ROOT::Experimental::RWebWindow> fWindow; ///!< configured display
 
@@ -128,6 +128,8 @@ protected:
    void CheckCanvasModified(bool force_modified = false);
 
    Bool_t AddToSendQueue(unsigned connid, const std::string &msg);
+
+   void AddCtrlMsg(unsigned connid, const std::string &key, const std::string &value, Bool_t send_immediately = kFALSE);
 
    void CheckDataToSend(unsigned connid = 0);
 

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -1064,7 +1064,6 @@ void TWebCanvas::SetCanvasSize(UInt_t cw, UInt_t ch)
    fFixedSize = kTRUE;
    AddCtrlMsg(0, "cw"s, std::to_string(cw));
    AddCtrlMsg(0, "ch"s, std::to_string(ch));
-   AddCtrlMsg(0, "fixed_size"s, "true"s);
    if ((cw > 0) && (ch > 0)) {
       Canvas()->fCw = cw;
       Canvas()->fCh = ch;
@@ -1073,6 +1072,22 @@ void TWebCanvas::SetCanvasSize(UInt_t cw, UInt_t ch)
       Canvas()->fCw = Canvas()->fWindowWidth;
       Canvas()->fCh = Canvas()->fWindowHeight;
    }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+/// Iconify browser window
+
+void TWebCanvas::Iconify()
+{
+   AddCtrlMsg(0, "winstate"s, "iconify"s);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+/// Raise browser window
+
+void TWebCanvas::RaiseWindow()
+{
+   AddCtrlMsg(0, "winstate"s, "raise"s);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -987,8 +987,7 @@ void TWebCanvas::Show()
 
 void TWebCanvas::ShowCmd(const std::string &arg, Bool_t show)
 {
-   if (AddToSendQueue(0, "SHOW:"s + arg + (show ? ":1"s : ":0"s)))
-      CheckDataToSend(0, kTRUE);
+   AddCtrlMsg(0, arg, show ? "1"s : "0"s);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -1000,8 +999,7 @@ void TWebCanvas::ActivateInEditor(TPad *pad, TObject *obj)
 
    UInt_t hash = TString::Hash(&obj, sizeof(obj));
 
-   if (AddToSendQueue(0, "EDIT:"s + std::to_string(hash)))
-      CheckDataToSend(0, kTRUE);
+   AddCtrlMsg(0, "edit"s, std::to_string(hash));
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/js/build/jsroot.js
+++ b/js/build/jsroot.js
@@ -67981,35 +67981,44 @@ class TCanvasPainter extends TPadPainter {
              hist = parse(msg.slice(7));
          this.websocketTimeout(`proj${kind}`, 'reset');
          this.drawProjection(kind, hist);
-      } else if (msg.slice(0,5) == 'SHOW:') {
-         let that = msg.slice(5),
-             on = (that[that.length-1] == '1');
-         this.showSection(that.slice(0,that.length-2), on);
       } else if (msg.slice(0,5) == 'CTRL:') {
-         let obj = parse(msg.slice(5)), resized = false;
-         if ((obj?.title !== undefined) && (typeof document !== 'undefined'))
-            document.title = obj.title;
-         if (obj.x && obj.y && typeof window !== 'undefined') {
-            window.moveTo(obj.x, obj.y);
+         let ctrl = parse(msg.slice(5)), resized = false;
+         if ((ctrl?.title !== undefined) && (typeof document !== 'undefined'))
+            document.title = ctrl.title;
+         if (ctrl.x && ctrl.y && typeof window !== 'undefined') {
+            window.moveTo(ctrl.x, ctrl.y);
             resized = true;
          }
-         if (obj.w && obj.h) {
-            this.resizeBrowser(Number.parseInt(obj.w), Number.parseInt(obj.h));
+         if (ctrl.w && ctrl.h) {
+            this.resizeBrowser(Number.parseInt(ctrl.w), Number.parseInt(ctrl.h));
             resized = true;
          }
-         if (obj.cw && obj.ch && obj.fixed_size && isFunc(this.setFixedCanvasSize)) {
-            this._online_fixed_size = this.setFixedCanvasSize(Number.parseInt(obj.cw), Number.parseInt(obj.ch), true);
+         if (ctrl.cw && ctrl.ch && isFunc(this.setFixedCanvasSize)) {
+            this._online_fixed_size = this.setFixedCanvasSize(Number.parseInt(ctrl.cw), Number.parseInt(ctrl.ch), true);
             resized = true;
+         }
+         let kinds = ['Menu', 'StatusBar', 'Editor', 'ToolBar', 'ToolTips'];
+         kinds.forEach(kind => {
+            if (ctrl[kind] !== undefined)
+               this.showSection(kind, ctrl[kind] == '1');
+         });
+
+         if (ctrl.edit) {
+            let obj_painter = this.findSnap(ctrl.edit);
+            if (obj_painter)
+               this.showSection('Editor', true)
+                   .then(() => this.producePadEvent('select', obj_painter.getPadPainter(), obj_painter));
+         }
+
+         if (ctrl.winstate && typeof window !== 'undefined') {
+            if (ctrl.winstate == 'iconify')
+               window.blur();
+            else
+               window.focus();
          }
 
          if (resized)
             this.sendResized(true);
-      } else if (msg.slice(0,5) == 'EDIT:') {
-         let obj_painter = this.findSnap(msg.slice(5));
-         if (obj_painter)
-            this.showSection('Editor', true)
-                .then(() => this.producePadEvent('select', obj_painter.getPadPainter(), obj_painter));
-
       } else {
          console.log(`unrecognized msg ${msg}`);
       }
@@ -68290,7 +68299,7 @@ class TCanvasPainter extends TPadPainter {
       }
 
       if (msg) {
-         console.log(`Sending ${msg.length} ${msg.slice(0,40)}`);
+         // console.log(`Sending ${msg.length} ${msg.slice(0,40)}`);
          this._websocket.send(msg);
       } else {
          console.log(`Unprocessed changes ${kind} for painter of ${painter?.getObject()?._typename} subelem ${subelem}`);

--- a/js/modules/gpad/TCanvasPainter.mjs
+++ b/js/modules/gpad/TCanvasPainter.mjs
@@ -392,35 +392,44 @@ class TCanvasPainter extends TPadPainter {
              hist = parse(msg.slice(7));
          this.websocketTimeout(`proj${kind}`, 'reset');
          this.drawProjection(kind, hist);
-      } else if (msg.slice(0,5) == 'SHOW:') {
-         let that = msg.slice(5),
-             on = (that[that.length-1] == '1');
-         this.showSection(that.slice(0,that.length-2), on);
       } else if (msg.slice(0,5) == 'CTRL:') {
-         let obj = parse(msg.slice(5)), resized = false;
-         if ((obj?.title !== undefined) && (typeof document !== 'undefined'))
-            document.title = obj.title;
-         if (obj.x && obj.y && typeof window !== 'undefined') {
-            window.moveTo(obj.x, obj.y);
+         let ctrl = parse(msg.slice(5)), resized = false;
+         if ((ctrl?.title !== undefined) && (typeof document !== 'undefined'))
+            document.title = ctrl.title;
+         if (ctrl.x && ctrl.y && typeof window !== 'undefined') {
+            window.moveTo(ctrl.x, ctrl.y);
             resized = true;
          }
-         if (obj.w && obj.h) {
-            this.resizeBrowser(Number.parseInt(obj.w), Number.parseInt(obj.h));
+         if (ctrl.w && ctrl.h) {
+            this.resizeBrowser(Number.parseInt(ctrl.w), Number.parseInt(ctrl.h));
             resized = true;
          }
-         if (obj.cw && obj.ch && obj.fixed_size && isFunc(this.setFixedCanvasSize)) {
-            this._online_fixed_size = this.setFixedCanvasSize(Number.parseInt(obj.cw), Number.parseInt(obj.ch), true);
+         if (ctrl.cw && ctrl.ch && isFunc(this.setFixedCanvasSize)) {
+            this._online_fixed_size = this.setFixedCanvasSize(Number.parseInt(ctrl.cw), Number.parseInt(ctrl.ch), true);
             resized = true;
+         }
+         let kinds = ['Menu', 'StatusBar', 'Editor', 'ToolBar', 'ToolTips'];
+         kinds.forEach(kind => {
+            if (ctrl[kind] !== undefined)
+               this.showSection(kind, ctrl[kind] == '1');
+         });
+
+         if (ctrl.edit) {
+            let obj_painter = this.findSnap(ctrl.edit);
+            if (obj_painter)
+               this.showSection('Editor', true)
+                   .then(() => this.producePadEvent('select', obj_painter.getPadPainter(), obj_painter));
+         }
+
+         if (ctrl.winstate && typeof window !== 'undefined') {
+            if (ctrl.winstate == 'iconify')
+               window.blur();
+            else
+               window.focus();
          }
 
          if (resized)
             this.sendResized(true);
-      } else if (msg.slice(0,5) == 'EDIT:') {
-         let obj_painter = this.findSnap(msg.slice(5));
-         if (obj_painter)
-            this.showSection('Editor', true)
-                .then(() => this.producePadEvent('select', obj_painter.getPadPainter(), obj_painter));
-
       } else {
          console.log(`unrecognized msg ${msg}`);
       }
@@ -701,7 +710,7 @@ class TCanvasPainter extends TPadPainter {
       }
 
       if (msg) {
-         console.log(`Sending ${msg.length} ${msg.slice(0,40)}`);
+         // console.log(`Sending ${msg.length} ${msg.slice(0,40)}`);
          this._websocket.send(msg);
       } else {
          console.log(`Unprocessed changes ${kind} for painter of ${painter?.getObject()?._typename} subelem ${subelem}`);


### PR DESCRIPTION
1. Introduce special timer to send data to clients. If not everything can be send at once, after short timeout will be tried again
2. Extend functionality of control message, manage it per connection. All special messages like enabling editor, moving web browser, enable/disable tooltip - all belong now to control message
3. Change message priority, try to send as much as possible. First one sends control message, then specially requests for menu or projection and finally update for canvas drawing.
4. Implement `Raise() / Iconify()` methods, they fully depend on the web browser
