### PR TITLE
[tmva] Disable RBatchGenerator tutorials

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -472,6 +472,13 @@ set(all_veto hsimple.C
              ${clad_veto}
              )
 
+# These tutorials seem to trigger segfaults related to TClass* and RDataFrame
+# JITting on many platforms. Disable for now and revert once the issue is fixed
+list(APPEND all_veto tmva/RBatchGenerator_NumPy.py)
+list(APPEND all_veto tmva/RBatchGenerator_TensorFlow.py)
+list(APPEND all_veto tmva/RBatchGenerator_PyTorch.py)
+list(APPEND all_veto tmva/RBatchGenerator_filters_vectors.py)
+
 file(GLOB_RECURSE tutorials RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.C)
 if(root7 AND webgui)
   file(GLOB_RECURSE tutorials_v7 RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} v7/*.cxx)


### PR DESCRIPTION
They currently trigger segfaults in TClass*/cling of the like:

```
RAssertion failed: ((*I)->isCompleted() && "Nested transaction not completed!?"), function endTransaction, file IncrementalParser.cpp, line 511.
 *** Break *** abort
Error in <TClingCallFunc::make_dtor_wrapper>: Failed to compile
  ==== SOURCE BEGIN ====
__attribute__((used)) extern "C" void __dtor_32(void* obj, unsigned long nary, int withFree)
{
   if (withFree) {
      if (!nary) {
         delete (TMVA::Experimental::Internal::RBatchGenerator<float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &>*) obj;
      }
      else {
         delete[] (TMVA::Experimental::Internal::RBatchGenerator<float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &>*) obj;
      }
   }
   else {
      typedef TMVA::Experimental::Internal::RBatchGenerator<float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &, float &> Nm;
if (!nary) {
         ((Nm*)obj)->~Nm();
      }
      else {
         do {
            (((Nm*)obj)+(--nary))->~Nm();
         } while (nary);
      }
   }
```

```
[/Users/sftnight/build/workspace/root-pullrequests-build/build/lib/libCling.6.29.01.so] KeepNParams(clang::QualType&, clang::QualType const&, cling::Interpreter const&, ROOT::TMetaUtils::TNormalizedCtxt const&) /Users/sftnight/build/workspace/root-pullrequests-build/root/core/clingutils/src/TClingUtils.cxx:3926
[/Users/sftnight/build/workspace/root-pullrequests-build/build/lib/libCling.6.29.01.so] RecurseKeepNParams(clang::TemplateArgument&, clang::TemplateArgument const&, cling::Interpreter const&, ROOT::TMetaUtils::TNormalizedCtxt const&, clang::ASTContext const&) /Users/sftnight/build/workspace/root-pullrequests-build/root/core/clingutils/src/TClingUtils.cxx:3717
[/Users/sftnight/build/workspace/root-pullrequests-build/build/lib/libCling.6.29.01.so] KeepNParams(clang::QualType&, clang::QualType const&, cling::Interpreter const&, ROOT::TMetaUtils::TNormalizedCtxt const&) /Users/sftnight/build/workspace/root-pullrequests-build/root/core/clingutils/src/TClingUtils.cxx:3907
[/Users/sftnight/build/workspace/root-pullrequests-build/build/lib/libCling.6.29.01.so] ROOT::TMetaUtils::GetNormalizedType(clang::QualType const&, cling::Interpreter const&, ROOT::TMetaUtils::TNormalizedCtxt const&) /Users/sftnight/build/workspace/root-pullrequests-build/root/core/clingutils/src/TClingUtils.cxx:3982
[/Users/sftnight/build/workspace/root-pullrequests-build/build/lib/libCling.6.29.01.so] ROOT::TMetaUtils::GetNormalizedName(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, clang::QualType const&, cling::Interpreter const&, ROOT::TMetaUtils::TNormalizedCtxt const&) /Users/sftnight/build/workspace/root-pullrequests-build/root/core/clingutils/src/TClingUtils.cxx:4003
[/Users/sftnight/build/workspace/root-pullrequests-build/build/lib/libCling.6.29.01.so] TClingDataMemberInfo::TypeTrueName(ROOT::TMetaUtils::TNormalizedCtxt const&) const /Users/sftnight/build/workspace/root-pullrequests-build/root/core/metacling/src/TClingDataMemberInfo.cxx:609
[/Users/sftnight/build/workspace/root-pullrequests-build/build/lib/libCling.6.29.01.so] TCling::DataMemberInfo_TypeTrueName(DataMemberInfo_t*) const /Users/sftnight/build/workspace/root-pullrequests-build/root/core/metacling/src/TCling.cxx:8611
[/Users/sftnight/build/workspace/root-pullrequests-build/build/lib/libCling.6.29.01.so] TCling::DeepAutoLoadImpl(char const*, std::__1::unordered_set<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >&, bool) /Users/sftnight/build/workspace/root-pullrequests-build/root/core/metacling/src/TCling.cxx:6181
[/Users/sftnight/build/workspace/root-pullrequests-build/build/lib/libCling.6.29.01.so] TCling::AutoLoad(char const*, bool) /Users/sftnight/build/workspace/root-pullrequests-build/root/core/metacling/src/TCling.cxx:6260
[/Users/sftnight/build/workspace/root-pullrequests-build/build/lib/libCore.6.29.01.so] TClass::GetClass(char const*, bool, bool, unsigned long, unsigned long) /Users/sftnight/build/workspace/root-pullrequests-build/root/core/meta/src/TClass.cxx:3104
[/Users/sftnight/build/workspace/root-pullrequests-build/build/lib/libCore.6.29.01.so] TClass::GetClass(char const*, bool, bool) /Users/sftnight/build/workspace/root-pullrequests-build/root/core/meta/src/TClass.cxx:2970
[/Users/sftnight/build/workspace/root-pullrequests-build/build/lib/libcppyy_backend3_9.6.29.01.so] Cppyy::GetScope(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) /Users/sftnight/build/workspace/root-pullrequests-build/root/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx:541
[/Users/sftnight/build/workspace/root-pullrequests-build/build/lib/libcppyy3_9.6.29.01.so] CPyCppyy::CreateExecutor(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) /Users/sftnight/build/workspace/root-pullrequests-build/root/bindings/pyroot/cppyy/CPyCppyy/src/Executors.cxx:816
[/Users/sftnight/build/workspace/root-pullrequests-build/build/lib/libcppyy3_9.6.29.01.so] CPyCppyy::CPPMethod::InitExecutor_(CPyCppyy::Executor*&, CPyCppyy::CallContext*) /Users/sftnight/build/workspace/root-pullrequests-build/root/bindings/pyroot/cppyy/CPyCppyy/src/CPPMethod.cxx:196
[/Users/sftnight/build/workspace/root-pullrequests-build/build/lib/libcppyy3_9.6.29.01.so] CPyCppyy::CPPMethod::Initialize(CPyCppyy::CallContext*) /Users/sftnight/build/workspace/root-pullrequests-build/root/bindings/pyroot/cppyy/CPyCppyy/src/CPPMethod.cxx:600
[/Users/sftnight/build/workspace/root-pullrequests-build/build/lib/libcppyy3_9.6.29.01.so] CPyCppyy::CPPMethod::Call(CPyCppyy::CPPInstance*&, _object*, _object*, CPyCppyy::CallContext*) /Users/sftnight/build/workspace/root-pullrequests-build/root/bindings/pyroot/cppyy/CPyCppyy/src/CPPMethod.cxx:807
[/Users/sftnight/build/workspace/root-pullrequests-build/build/lib/libcppyy3_9.6.29.01.so] CPyCppyy::(anonymous namespace)::mp_call(CPyCppyy::CPPOverload*, _object*, _object*) /Users/sftnight/build/workspace/root-pullrequests-build/root/bindings/pyroot/cppyy/CPyCppyy/src/CPPOverload.cxx:567
```
