### PR TITLE
Fix CMake configuration without Python

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -77,7 +77,7 @@ if(NOT clad)
   set(clad_veto fit/minuit2GausFit.C)
 endif()
 
-if (${PYTHON_VERSION_STRING_Development_Main} VERSION_LESS 3.8)
+if (PYTHON_VERSION_STRING_Development_Main VERSION_LESS 3.8)
   list(APPEND dataframe_veto tmva/RBatchGenerator_NumPy.py)
   list(APPEND dataframe_veto tmva/RBatchGenerator_TensorFlow.py)
   list(APPEND dataframe_veto tmva/RBatchGenerator_PyTorch.py)


### PR DESCRIPTION
In that case `PYTHON_VERSION_STRING_Development_Main` is not set:
```
CMake Error at tutorials/CMakeLists.txt:80 (if):
  if given arguments:

    "VERSION_LESS" "3.8"

  Unknown arguments specified
```