### PR TITLE
[ntuple] fix setting field IDs for complex fields in RDF DS

### DIFF
--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -236,11 +236,14 @@ void RNTupleDS::AddField(const RNTupleDescriptor &desc, std::string_view colName
 
    // The fieldID could be the root field or the class of fieldId might not be loaded.
    // In these cases, only the inner fields are exposed as RDF columns.
-   auto fieldOrException = Detail::RFieldBase::Create("", fieldDesc.GetTypeName());
+   auto fieldOrException = Detail::RFieldBase::Create(fieldDesc.GetFieldName(), fieldDesc.GetTypeName());
    if (!fieldOrException)
       return;
    auto valueField = fieldOrException.Unwrap();
    valueField->SetOnDiskId(fieldId);
+   for (auto &f : *valueField) {
+      f.SetOnDiskId(desc.FindFieldId(f.GetName(), f.GetParent()->GetOnDiskId()));
+   }
    std::unique_ptr<Detail::RFieldBase> cardinalityField;
    // Collections get the additional "number of" RDF column (e.g. "R_rdf_sizeof_tracks")
    if (!skeinIDs.empty()) {

--- a/tree/dataframe/test/CMakeLists.txt
+++ b/tree/dataframe/test/CMakeLists.txt
@@ -90,6 +90,19 @@ endif()
 
 if(root7)
   ROOT_ADD_GTEST(datasource_ntuple datasource_ntuple.cxx LIBRARIES ROOTDataFrame)
+
+  ROOT_STANDARD_LIBRARY_PACKAGE(NTupleStruct
+                                NO_INSTALL_HEADERS
+                                HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/NTupleStruct.hxx
+                                SOURCES NTupleStruct.cxx
+                                LINKDEF NTupleStructLinkDef.h
+                                DEPENDENCIES RIO)
+  configure_file(NTupleStruct.hxx . COPYONLY)
+  if(MSVC)
+    add_custom_command(TARGET NTupleStruct POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/libNTupleStruct.dll
+                                       ${CMAKE_CURRENT_BINARY_DIR}/libNTupleStruct.dll)
+  endif()
 endif()
 
 if(sqlite)

--- a/tree/dataframe/test/NTupleStruct.cxx
+++ b/tree/dataframe/test/NTupleStruct.cxx
@@ -1,0 +1,1 @@
+#include "NTupleStruct.hxx"

--- a/tree/dataframe/test/NTupleStruct.hxx
+++ b/tree/dataframe/test/NTupleStruct.hxx
@@ -1,0 +1,11 @@
+#ifndef ROOT7_RDataFrame_Test_NTupleStruct
+#define ROOT7_RDataFrame_Test_NTupleStruct
+
+/**
+ * Used to test serialization and deserialization of classes in RNTuple with TClass
+ */
+struct Electron {
+   float pt;
+};
+
+#endif

--- a/tree/dataframe/test/NTupleStructLinkDef.h
+++ b/tree/dataframe/test/NTupleStructLinkDef.h
@@ -1,0 +1,9 @@
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class Electron + ;
+
+#endif

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -477,6 +477,7 @@ public:
 class REnumField : public Detail::RFieldBase {
 private:
    REnumField(std::string_view fieldName, std::string_view enumName, TEnum *enump);
+   REnumField(std::string_view fieldName, std::string_view enumName, std::unique_ptr<RFieldBase> intField);
 
 protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final;

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -241,7 +241,7 @@ public:
       /// The stack of nodes visited when walking down the tree of fields
       std::vector<Position> fStack;
    public:
-      using iterator = RSchemaIteratorTemplate;
+      using iterator = RSchemaIteratorTemplate<IsConstT>;
       using iterator_category = std::forward_iterator_tag;
       using difference_type = std::ptrdiff_t;
       using value_type = std::conditional_t<IsConstT, const RFieldBase, RFieldBase>;

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -228,30 +228,52 @@ protected:
 
 public:
    /// Iterates over the sub tree of fields in depth-first search order
-   class RSchemaIterator {
+   template <bool IsConstT>
+   class RSchemaIteratorTemplate {
    private:
       struct Position {
+         using FieldPtr_t = std::conditional_t<IsConstT, const RFieldBase *, RFieldBase *>;
          Position() : fFieldPtr(nullptr), fIdxInParent(-1) { }
-         Position(RFieldBase *fieldPtr, int idxInParent) : fFieldPtr(fieldPtr), fIdxInParent(idxInParent) { }
-         RFieldBase *fFieldPtr;
+         Position(FieldPtr_t fieldPtr, int idxInParent) : fFieldPtr(fieldPtr), fIdxInParent(idxInParent) {}
+         FieldPtr_t fFieldPtr;
          int fIdxInParent;
       };
       /// The stack of nodes visited when walking down the tree of fields
       std::vector<Position> fStack;
    public:
-      using iterator = RSchemaIterator;
+      using iterator = RSchemaIteratorTemplate;
       using iterator_category = std::forward_iterator_tag;
-      using value_type = RFieldBase;
       using difference_type = std::ptrdiff_t;
-      using pointer = RFieldBase*;
-      using reference = RFieldBase&;
+      using value_type = std::conditional_t<IsConstT, const RFieldBase, RFieldBase>;
+      using pointer = std::conditional_t<IsConstT, const RFieldBase *, RFieldBase *>;
+      using reference = std::conditional_t<IsConstT, const RFieldBase &, RFieldBase &>;
 
-      RSchemaIterator() { fStack.emplace_back(Position()); }
-      RSchemaIterator(pointer val, int idxInParent) { fStack.emplace_back(Position(val, idxInParent)); }
-      ~RSchemaIterator() {}
+      RSchemaIteratorTemplate() { fStack.emplace_back(Position()); }
+      RSchemaIteratorTemplate(pointer val, int idxInParent) { fStack.emplace_back(Position(val, idxInParent)); }
+      ~RSchemaIteratorTemplate() {}
       /// Given that the iterator points to a valid field which is not the end iterator, go to the next field
       /// in depth-first search order
-      void Advance();
+      void Advance()
+      {
+         auto itr = fStack.rbegin();
+         if (!itr->fFieldPtr->fSubFields.empty()) {
+            fStack.emplace_back(Position(itr->fFieldPtr->fSubFields[0].get(), 0));
+            return;
+         }
+
+         unsigned int nextIdxInParent = ++(itr->fIdxInParent);
+         while (nextIdxInParent >= itr->fFieldPtr->fParent->fSubFields.size()) {
+            if (fStack.size() == 1) {
+               itr->fFieldPtr = itr->fFieldPtr->fParent;
+               itr->fIdxInParent = -1;
+               return;
+            }
+            fStack.pop_back();
+            itr = fStack.rbegin();
+            nextIdxInParent = ++(itr->fIdxInParent);
+         }
+         itr->fFieldPtr = itr->fFieldPtr->fParent->fSubFields[nextIdxInParent].get();
+      }
 
       iterator  operator++(int) /* postfix */        { auto r = *this; Advance(); return r; }
       iterator& operator++()    /* prefix */         { Advance(); return *this; }
@@ -260,6 +282,8 @@ public:
       bool      operator==(const iterator& rh) const { return fStack.back().fFieldPtr == rh.fStack.back().fFieldPtr; }
       bool      operator!=(const iterator& rh) const { return fStack.back().fFieldPtr != rh.fStack.back().fFieldPtr; }
    };
+   using RSchemaIterator = RSchemaIteratorTemplate<false>;
+   using RConstSchemaIterator = RSchemaIteratorTemplate<true>;
 
    /// The constructor creates the underlying column objects and connects them to either a sink or a source.
    /// If `isSimple` is `true`, the trait `kTraitMappable` is automatically set on construction. However, the
@@ -392,8 +416,16 @@ public:
    /// Return the C++ type version stored in the field descriptor; only valid after a call to `ConnectPageSource()`
    std::uint32_t GetOnDiskTypeVersion() const { return fOnDiskTypeVersion; }
 
-   RSchemaIterator begin();
-   RSchemaIterator end();
+   RSchemaIterator begin()
+   {
+      return fSubFields.empty() ? RSchemaIterator(this, -1) : RSchemaIterator(fSubFields[0].get(), 0);
+   }
+   RSchemaIterator end() { return RSchemaIterator(this, -1); }
+   RConstSchemaIterator cbegin() const
+   {
+      return fSubFields.empty() ? RConstSchemaIterator(this, -1) : RConstSchemaIterator(fSubFields[0].get(), 0);
+   }
+   RConstSchemaIterator cend() const { return RConstSchemaIterator(this, -1); }
 
    virtual void AcceptVisitor(RFieldVisitor &visitor) const;
 };

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -212,24 +212,10 @@ std::tuple<const void *const *, const std::int32_t *, const std::int32_t *> GetR
 /// but we recreate them. Therefore, the on-disk IDs need to be fixed up.
 void SyncFieldIDs(const ROOT::Experimental::Detail::RFieldBase &from, ROOT::Experimental::Detail::RFieldBase &to)
 {
-   using RFieldBase = ROOT::Experimental::Detail::RFieldBase;
-   std::deque<const RFieldBase *> fromSubfields;
-   std::deque<RFieldBase *> toSubfields;
-
-   fromSubfields.emplace_back(&from);
-   toSubfields.emplace_back(&to);
-
-   while (!fromSubfields.empty()) {
-      auto sFrom = fromSubfields.front();
-      fromSubfields.pop_front();
-      auto sTo = toSubfields.front();
-      toSubfields.pop_front();
-      sTo->SetOnDiskId(sFrom->GetOnDiskId());
-
-      for (const auto f : sFrom->GetSubFields())
-         fromSubfields.emplace_back(f);
-      for (auto f : sTo->GetSubFields())
-         toSubfields.emplace_back(f);
+   auto iFrom = from.cbegin();
+   auto iTo = to.begin();
+   for (; iFrom != from.cend(); ++iFrom, ++iTo) {
+      iTo->SetOnDiskId(iFrom->GetOnDiskId());
    }
 }
 
@@ -661,48 +647,7 @@ void ROOT::Experimental::Detail::RFieldBase::AcceptVisitor(Detail::RFieldVisitor
    visitor.VisitField(*this);
 }
 
-
-ROOT::Experimental::Detail::RFieldBase::RSchemaIterator ROOT::Experimental::Detail::RFieldBase::begin()
-{
-   if (fSubFields.empty()) return RSchemaIterator(this, -1);
-   return RSchemaIterator(this->fSubFields[0].get(), 0);
-}
-
-
-ROOT::Experimental::Detail::RFieldBase::RSchemaIterator ROOT::Experimental::Detail::RFieldBase::end()
-{
-   return RSchemaIterator(this, -1);
-}
-
-
 //-----------------------------------------------------------------------------
-
-
-void ROOT::Experimental::Detail::RFieldBase::RSchemaIterator::Advance()
-{
-   auto itr = fStack.rbegin();
-   if (!itr->fFieldPtr->fSubFields.empty()) {
-      fStack.emplace_back(Position(itr->fFieldPtr->fSubFields[0].get(), 0));
-      return;
-   }
-
-   unsigned int nextIdxInParent = ++(itr->fIdxInParent);
-   while (nextIdxInParent >= itr->fFieldPtr->fParent->fSubFields.size()) {
-      if (fStack.size() == 1) {
-         itr->fFieldPtr = itr->fFieldPtr->fParent;
-         itr->fIdxInParent = -1;
-         return;
-      }
-      fStack.pop_back();
-      itr = fStack.rbegin();
-      nextIdxInParent = ++(itr->fIdxInParent);
-   }
-   itr->fFieldPtr = itr->fFieldPtr->fParent->fSubFields[nextIdxInParent].get();
-}
-
-
-//------------------------------------------------------------------------------
-
 
 std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>
 ROOT::Experimental::RFieldZero::CloneImpl(std::string_view /*newName*/) const


### PR DESCRIPTION
# This Pull request:

Fix setting the field IDs of fields with subfields in the RNTuple RDF data source. It also fixes field IDs for clones of RClassField instances.

## Checklist:

- [X] tested changes locally

This PR fixes #12852 

