### PR TITLE
FlexibleInterpVar - protect against 0 or negative variations

### DIFF
--- a/roofit/roofitcore/inc/RooFit/Detail/EvaluateFuncs.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/EvaluateFuncs.h
@@ -156,7 +156,7 @@ inline double flexibleInterp(unsigned int code, double low, double high, double 
          return total * std::pow(low / nominal, -paramVal);
       }
 
-      return total * std::exp(interpolate6thDegree(x, std::log(low), std::log(high), std::log(nominal), boundary));
+      return total * std::exp(interpolate6thDegree(x, low<=0 ? 0. : std::log(low), high <= 0 ? : 0. : std::log(high), std::log(nominal), boundary));
    }
 
    return total;


### PR DESCRIPTION
I've discovered that some workspaces that worked fine before are broken by https://github.com/root-project/root/commit/466f3f689c578cb53d75ddeeb04472ec4d82e3ed - I am getting NaN back!

I'm concerned that there's some subtle numerical effects that the old code (in fillPolyCoef) handles that the new code does not. But at least in my specific case I think the issue is one of the variations is 0, and there's no protection in the new code for a variation being 0 or negative, unlike in the old code. 

This suggests a fix for this although I've not tested it yet ... 