### PR TITLE
counterpart of Python's join function in C++

### DIFF
--- a/core/foundation/inc/ROOT/StringUtils.hxx
+++ b/core/foundation/inc/ROOT/StringUtils.hxx
@@ -18,10 +18,27 @@
 
 #include <string>
 #include <vector>
+#include <numeric>
 
 namespace ROOT {
 
 std::vector<std::string> Split(std::string_view str, std::string_view delims, bool skipEmpty = false);
+
+/**
+ * \brief Concatenate a list of strings with a separator
+ * \tparm Any container of strings (vector, initializer_list, ...)
+ * \param[in] sep Separator inbetween the strings.
+ * \param[in] strings container of strings
+ * \return the sep-delimited concatenation of strings
+ */
+template <class StringCollection_t>
+std::string Join(const std::string &sep, StringCollection_t &&strings)
+{
+   if (strings.empty())
+      return "";
+   return std::accumulate(std::next(std::begin(strings)), std::end(strings), strings[0],
+                          [&sep](auto const &a, auto const &b) { return a + sep + b; });
+}
 
 } // namespace ROOT
 

--- a/core/foundation/test/testStringUtils.cxx
+++ b/core/foundation/test/testStringUtils.cxx
@@ -21,3 +21,23 @@ TEST(StringUtils, Split)
    test(",,a", {"", "", "a"}, false);
    test("", {""}, false);
 }
+
+TEST(StringUtils, Join)
+{
+   // Test that ROOT::Join behaves like str.join from Python.
+
+   auto test = [](const std::string &ref, const std::string &sep, const std::vector<std::string> &strings) {
+      auto out = ROOT::Join(sep, strings);
+      EXPECT_EQ(out, ref) << "ROOT::Join gave wrong result.";
+   };
+   test("apple,orange,banana", ",", {"apple", "orange", "banana"});
+   test("apple.orange.banana", ".", {"apple", "orange", "banana"});
+   test("apple::orange::banana", "::", {"apple", "orange", "banana"});
+   test("appleorangebanana", "", {"apple", "orange", "banana"});
+   test("apple,,banana", ",", {"apple", "", "banana"});
+   test("apple", ",", {"apple"});
+   test("", ",", {""});
+   test("", "", {""});
+   test("", "", {});
+   test("", ";;", {""});
+}


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Adds `','.join(strings)` capabilities to `TString.h`.
Right now it is as a variadic argument, but it could be expanded to std::array, std::vector or even TObjArray

## Checklist:

- [x] tested changes locally
- [X] updated the docs (if necessary)

This PR depends on https://github.com/root-project/root/pull/13243

