### PR TITLE
Avoid C-Style Casts in Dictionary

### DIFF
--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -2392,7 +2392,7 @@ void ROOT::TMetaUtils::WriteAuxFunctions(std::ostream& finalString,
          finalString << args;
          finalString << " : ";
       } else {
-         finalString << "::new((::ROOT::Internal::TOperatorNewHelper*)p) ";
+         finalString << "::new(static_cast<::ROOT::Internal::TOperatorNewHelper*>(p)) ";
          finalString << classname.c_str();
          finalString << args;
          finalString << " : ";
@@ -2412,7 +2412,7 @@ void ROOT::TMetaUtils::WriteAuxFunctions(std::ostream& finalString,
             finalString << classname.c_str();
             finalString << "[nElements] : ";
          } else {
-            finalString << "::new((::ROOT::Internal::TOperatorNewHelper*)p) ";
+            finalString << "::new(static_cast<::ROOT::Internal::TOperatorNewHelper*>(p)) ";
             finalString << classname.c_str();
             finalString << "[nElements] : ";
          }


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

We compile our code (including the dictionaries) with warnings about C-Style casts. We would like to also reduce the warnings about the dictionaries.

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)