### PR TITLE
[skip-ci] Add LLVM's gitignore

### DIFF
--- a/.github/workflows/llvm-diff.yml
+++ b/.github/workflows/llvm-diff.yml
@@ -14,7 +14,10 @@ jobs:
           path: root
       - name: Determine tag in fork of monorepo
         id: determine-tag
-        run: echo "tag=$(cat root/interpreter/llvm-project/llvm-project.tag)" >> $GITHUB_OUTPUT
+        run: |
+          tag_file=root/interpreter/llvm-project/llvm-project.tag
+          echo "tag=$(cat $tag_file)" >> $GITHUB_OUTPUT
+          rm $tag_file
       - name: Check out llvm-project
         uses: actions/checkout@v3
         with:
@@ -28,8 +31,8 @@ jobs:
             find . -name $d -prune -exec rm -r "{}" \;
           done
           rm -r llvm/utils/vscode
-      - name: Compare
-        run: |
-          for d in clang llvm; do
-            diff -ur llvm-project/$d root/interpreter/llvm-project/$d
+          for f in $(ls -A); do
+            [ -e ../root/interpreter/llvm-project/$f ] || rm -r $f
           done
+      - name: Compare
+        run: diff -ur llvm-project/ root/interpreter/llvm-project/

--- a/.github/workflows/llvm-diff.yml
+++ b/.github/workflows/llvm-diff.yml
@@ -28,7 +28,6 @@ jobs:
             find . -name $d -prune -exec rm -r "{}" \;
           done
           rm -r llvm/utils/vscode
-          rm llvm/.git*
       - name: Compare
         run: |
           for d in clang llvm; do

--- a/interpreter/llvm-project/.clang-format
+++ b/interpreter/llvm-project/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: LLVM

--- a/interpreter/llvm-project/.clang-tidy
+++ b/interpreter/llvm-project/.clang-tidy
@@ -1,0 +1,19 @@
+Checks: '-*,clang-diagnostic-*,llvm-*,misc-*,-misc-unused-parameters,-misc-non-private-member-variables-in-classes,-misc-no-recursion,readability-identifier-naming'
+CheckOptions:
+  - key:             readability-identifier-naming.ClassCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.EnumCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.FunctionCase
+    value:           camelBack
+  - key:             readability-identifier-naming.MemberCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.ParameterCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.UnionCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.VariableCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.IgnoreMainLikeFunctions
+    value:           1
+

--- a/interpreter/llvm-project/.gitignore
+++ b/interpreter/llvm-project/.gitignore
@@ -1,0 +1,70 @@
+#==============================================================================#
+# This file specifies intentionally untracked files that git should ignore.
+# See: http://www.kernel.org/pub/software/scm/git/docs/gitignore.html
+#
+# This file is intentionally different from the output of `git svn show-ignore`,
+# as most of those are useless.
+#==============================================================================#
+
+#==============================================================================#
+# File extensions to be ignored anywhere in the tree.
+#==============================================================================#
+# Temp files created by most text editors.
+*~
+# Merge files created by git.
+*.orig
+# Byte compiled python modules.
+*.pyc
+# vim swap files
+.*.sw?
+.sw?
+#OS X specific files.
+.DS_store
+
+# Ignore the user specified CMake presets in subproject directories.
+/*/CMakeUserPresets.json
+
+# Nested build directory
+/build*
+
+#==============================================================================#
+# Explicit files to ignore (only matches one).
+#==============================================================================#
+# Various tag programs
+/tags
+/TAGS
+/GPATH
+/GRTAGS
+/GSYMS
+/GTAGS
+/ID
+.gitusers
+autom4te.cache
+cscope.files
+cscope.out
+autoconf/aclocal.m4
+autoconf/autom4te.cache
+/compile_commands.json
+# Visual Studio built-in CMake configuration
+/CMakeSettings.json
+# CLion project configuration
+/.idea
+
+#==============================================================================#
+# Directories to ignore (do not add trailing '/'s, they skip symlinks).
+#==============================================================================#
+# VS2017 and VSCode config files.
+.vscode
+.vs
+# pythonenv for github Codespaces
+pythonenv*
+# clangd index. (".clangd" is a config file now, thus trailing slash)
+.clangd/
+.cache
+# static analyzer regression testing project files
+/clang/utils/analyzer/projects/*/CachedSource
+/clang/utils/analyzer/projects/*/PatchedSource
+/clang/utils/analyzer/projects/*/ScanBuildResults
+/clang/utils/analyzer/projects/*/RefScanBuildResults
+# automodapi puts generated documentation files here.
+/lldb/docs/python_api/

--- a/interpreter/llvm-project/llvm/.gitattributes
+++ b/interpreter/llvm-project/llvm/.gitattributes
@@ -1,0 +1,19 @@
+# binary files
+test/Object/Inputs/*.a-* binary
+test/tools/dsymutil/Inputs/*.o binary
+test/tools/dsymutil/Inputs/*.a binary
+test/tools/dsymutil/Inputs/*.i386 binary
+test/tools/dsymutil/Inputs/*.x86_64 binary
+test/tools/dsymutil/Inputs/*.armv7m binary
+test/tools/dsymutil/Inputs/*.dylib binary
+test/tools/llvm-ar/Inputs/*.lib binary
+test/tools/llvm-objdump/Inputs/*.a binary
+test/tools/llvm-rc/Inputs/* binary
+test/tools/llvm-strings/Inputs/numbers binary
+test/MC/AsmParser/incbin_abcd binary
+test/YAMLParser/spec-09-02.test binary
+
+# This file must have CRLF line endings, therefore git should treat it as
+# binary and not autoconvert line endings (for example, when core.autocrlf is
+# on).
+test/MC/AsmParser/preserve-comments-crlf.s binary

--- a/interpreter/llvm-project/llvm/.gitignore
+++ b/interpreter/llvm-project/llvm/.gitignore
@@ -1,0 +1,73 @@
+#==============================================================================#
+# This file specifies intentionally untracked files that git should ignore.
+# See: http://www.kernel.org/pub/software/scm/git/docs/gitignore.html
+#
+# This file is intentionally different from the output of `git svn show-ignore`,
+# as most of those are useless.
+#==============================================================================#
+
+#==============================================================================#
+# Nested build directory.
+#==============================================================================#
+/build
+
+#==============================================================================#
+# Explicit files to ignore (only matches one).
+#==============================================================================#
+# Various tag programs
+/tags
+/TAGS
+/GPATH
+/GRTAGS
+/GSYMS
+/GTAGS
+.gitusers
+autom4te.cache
+cscope.files
+cscope.out
+autoconf/aclocal.m4
+autoconf/autom4te.cache
+/compile_commands.json
+# Visual Studio built-in CMake configuration
+/CMakeSettings.json
+# CLion project configuration
+/.idea
+# Qt Creator project configuration
+/CMakeLists.txt.user
+
+#==============================================================================#
+# Directories to ignore (do not add trailing '/'s, they skip symlinks).
+#==============================================================================#
+# External projects that are tracked independently.
+projects/*
+!projects/*.*
+!projects/Makefile
+runtimes/*
+!runtimes/*.*
+# Sphinx build tree, if building in-source dir.
+docs/_build
+# VS2017 and VSCode config files.
+.vscode
+.vs
+
+#==============================================================================#
+# Files created in tree by the Go bindings.
+#==============================================================================#
+bindings/go/llvm/llvm_config.go
+bindings/go/llvm/workdir
+
+#==============================================================================#
+# File extensions to be ignored anywhere in the tree.
+# Placed at the end to override any previous ! patterns.
+#==============================================================================#
+# Temp files created by most text editors.
+*~
+# Merge files created by git.
+*.orig
+# Byte compiled python modules.
+*.pyc
+# vim swap files
+.*.sw?
+.sw?
+#OS X specific files.
+.DS_store


### PR DESCRIPTION
The `.gitignore` files were traditionally skipped to not exclude the `tools/clang/` directory, but this isn't necessary since adopting the monorepo. Adding them back will correctly ignore the compiled Python `pyc` files after running `check-cling`.