### PR TITLE
[mathcore] Fix return of FitResult::ParameterBounds as doc says.

### DIFF
--- a/math/mathcore/src/FitResult.cxx
+++ b/math/mathcore/src/FitResult.cxx
@@ -376,7 +376,7 @@ bool FitResult::ParameterBounds(unsigned int ipar, double & lower, double & uppe
    assert(itr->second < fParamBounds.size() );
    lower = fParamBounds[itr->second].first;
    upper = fParamBounds[itr->second].second;
-   return false;
+   return true;
 }
 
 std::string FitResult::ParName(unsigned int ipar) const {


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

