### PR TITLE
[ntuple] Fix iteration of proxied array-backed collections

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -496,7 +496,9 @@ private:
          void Advance()
          {
             auto fnNext_Contig = [&]() {
-               auto &iter = *static_cast<unsigned char **>(fIterator), p = iter;
+               // Array-backed collections (e.g. kSTLvector) directly use the pointer-to-iterator-data as a
+               // pointer-to-element, thus saving an indirection level (see documentation for TVirtualCollectionProxy)
+               auto &iter = reinterpret_cast<unsigned char *&>(fIterator), p = iter;
                iter += fOwner.fStride;
                return p;
             };

--- a/tree/ntuple/v7/test/SimpleCollectionProxy.hxx
+++ b/tree/ntuple/v7/test/SimpleCollectionProxy.hxx
@@ -17,8 +17,15 @@ class SimpleCollectionProxy : public TVirtualCollectionProxy {
    {
       static_assert(sizeof(IteratorData) <= TVirtualCollectionProxy::fgIteratorArenaSize);
       auto &vec = static_cast<CollectionT *>(collection)->v;
-      static_cast<IteratorData *>(*begin_arena)->ptr = &(*vec.begin());
-      static_cast<IteratorData *>(*end_arena)->ptr = &(*vec.end());
+      if constexpr (CollectionKind == ROOT::kSTLvector) {
+         // An iterator on an array-backed container is just a pointer; thus, it can be directly stored in `*xyz_arena`,
+         // saving one dereference (see TVirtualCollectionProxy documentation)
+         *begin_arena = &(*vec.begin());
+         *end_arena = &(*vec.end());
+      } else {
+         static_cast<IteratorData *>(*begin_arena)->ptr = &(*vec.begin());
+         static_cast<IteratorData *>(*end_arena)->ptr = &(*vec.end());
+      }
    }
 
    static void *Func_Next(void *iter, const void *end)


### PR DESCRIPTION
Per the last ROOT I/O meeting (where the correct use of iterators to array-backed collections, e.g. `std::vector<T>`): an iterator on an array-backed container is just a pointer; thus, it can be directly stored in `*xyz_arena`, saving one dereference (see [here](https://github.com/root-project/root/blob/master/io/io/inc/TVirtualCollectionIterators.h#L34)).

This pull request, fixes both the implementation of `RCollectionIterableOnce` and the unit test.  As a result, this PR should fix the use case in PR #12948.

Given that this behavior was not documented at all, a follow-up PR will update the documentation for `TVirtualCollectionProxy`.

## Checklist:
- [x] tested changes locally
- [x] updated the docs (if necessary)