### PR TITLE
[RF] Don't store reference to `RooDataSet` in RooNDKeysPdf

### DIFF
--- a/roofit/histfactory/src/HistFactoryNavigation.cxx
+++ b/roofit/histfactory/src/HistFactoryNavigation.cxx
@@ -644,7 +644,7 @@ namespace RooStats {
    RooSimultaneous* simPdf = (RooSimultaneous*) fModel;
    RooCategory* channelCat = (RooCategory*) (&simPdf->indexCat());
 
-   dataset_list.reset(data->split(*channelCat));
+   dataset_list = std::unique_ptr<TList>{data->split(*channelCat)};
 
    data = dynamic_cast<RooDataSet*>( dataset_list->FindObject(channel.c_str()) );
 

--- a/roofit/roofit/inc/RooNDKeysPdf.h
+++ b/roofit/roofit/inc/RooNDKeysPdf.h
@@ -90,11 +90,6 @@ public:
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
   double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
 
-  inline void fixShape(bool fix) {
-    createPdf(false);
-    _fixedShape=fix;
-  }
-
   TMatrixD getWeights(const int &k) const;
 
   struct BoxInfo {
@@ -117,12 +112,12 @@ protected:
 
   double evaluate() const override;
 
-  void createPdf(bool firstCall = true);
+  void createPdf(bool firstCall, RooDataSet const& data);
   void setOptions();
-  void initialize();
-  void loadDataSet(bool firstCall);
+  void initialize(RooDataSet const& data);
+  void loadDataSet(bool firstCall, RooDataSet const& data);
   void mirrorDataSet();
-  void loadWeightSet();
+  void loadWeightSet(RooDataSet const& data);
   void calculateShell(BoxInfo *bi) const;
   void calculatePreNorm(BoxInfo *bi) const;
   void sortDataIndices(BoxInfo *bi = nullptr);
@@ -138,8 +133,6 @@ protected:
     const_cast<RooNDKeysPdf*>(this)->calculateBandWidth();
   }
 
-  std::unique_ptr<RooDataSet> _ownedData{nullptr};
-  const RooDataSet* _data; //! do not persist
   mutable TString _options;
   double _widthFactor;
   double _nSigma;
@@ -207,7 +200,7 @@ protected:
 
   RooChangeTracker *_tracker{nullptr}; //
 
-  ClassDefOverride(RooNDKeysPdf, 1) // General N-dimensional non-parametric kernel estimation p.d.f
+  ClassDefOverride(RooNDKeysPdf, 2) // General N-dimensional non-parametric kernel estimation p.d.f
 };
 
 #endif

--- a/roofit/roofit/src/RooNDKeysPdf.cxx
+++ b/roofit/roofit/src/RooNDKeysPdf.cxx
@@ -70,7 +70,7 @@ ClassImp(RooNDKeysPdf);
 RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, const RooArgList &varList, const RooDataSet &data,
                            TString options, double rho, double nSigma, bool rotate, bool sortInput)
    : RooAbsPdf(name, title), _varList("varList", "List of variables", this),
-     _rhoList("rhoList", "List of rho parameters", this), _data(&data), _options(options), _widthFactor(rho),
+     _rhoList("rhoList", "List of rho parameters", this), _options(options), _widthFactor(rho),
      _nSigma(nSigma), _rotate(rotate), _sortInput(sortInput), _nAdpt(1)
 {
   // Constructor
@@ -85,7 +85,7 @@ RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, const RooArgList
     _varName.push_back(var->GetName());
   }
 
-  createPdf();
+  createPdf(true, data);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -94,7 +94,7 @@ RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, const RooArgList
 RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, const RooArgList &varList, const TH1 &hist,
                            TString options, double rho, double nSigma, bool rotate, bool sortInput)
    : RooAbsPdf(name, title), _varList("varList", "List of variables", this),
-     _rhoList("rhoList", "List of rho parameters", this), _ownedData(createDatasetFromHist(varList, hist)), _data(_ownedData.get()),
+     _rhoList("rhoList", "List of rho parameters", this),
      _options(options), _widthFactor(rho), _nSigma(nSigma), _rotate(rotate),
      _sortInput(sortInput), _nAdpt(1)
 {
@@ -108,7 +108,7 @@ RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, const RooArgList
       _varName.push_back(var->GetName());
    }
 
-   createPdf();
+   createPdf(true, *std::unique_ptr<RooDataSet>{createDatasetFromHist(varList, hist)});
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -117,7 +117,7 @@ RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, const RooArgList
 RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, const RooArgList &varList, const RooDataSet &data,
                            const TVectorD &rho, TString options, double nSigma, bool rotate, bool sortInput)
    : RooAbsPdf(name, title), _varList("varList", "List of variables", this),
-     _rhoList("rhoList", "List of rho parameters", this), _data(&data), _options(options), _widthFactor(-1.0),
+     _rhoList("rhoList", "List of rho parameters", this), _options(options), _widthFactor(-1.0),
      _nSigma(nSigma), _rotate(rotate), _sortInput(sortInput), _nAdpt(1)
 {
   for (const auto var : varList) {
@@ -146,7 +146,7 @@ RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, const RooArgList
      _rho[j] = rho[j]; /*cout<<"RooNDKeysPdf ctor, _rho["<<j<<"]="<<_rho[j]<<endl;*/
   }
 
-  createPdf(); // calls initialize ...
+  createPdf(true, data); // calls initialize ...
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -156,7 +156,7 @@ RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, const RooArgList
 RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, const RooArgList &varList, const RooDataSet &data,
                            const RooArgList &rhoList, TString options, double nSigma, bool rotate, bool sortInput)
    : RooAbsPdf(name, title), _varList("varList", "List of variables", this),
-     _rhoList("rhoList", "List of rho parameters", this), _data(&data), _options(options), _widthFactor(-1.0),
+     _rhoList("rhoList", "List of rho parameters", this), _options(options), _widthFactor(-1.0),
      _nSigma(nSigma), _rotate(rotate), _sortInput(sortInput), _nAdpt(1)
 {
    for (const auto var : varList) {
@@ -193,7 +193,7 @@ RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, const RooArgList
    _tracker = new RooChangeTracker("tracker", "track rho parameters", _rhoList, true); // check for value updates
    (void)_tracker->hasChanged(true); // first evaluation always true for new parameters (?)
 
-   createPdf();
+   createPdf(true, data);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -202,7 +202,7 @@ RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, const RooArgList
 RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, const RooArgList &varList, const TH1 &hist,
                            const RooArgList &rhoList, TString options, double nSigma, bool rotate, bool sortInput)
    : RooAbsPdf(name, title), _varList("varList", "List of variables", this),
-     _rhoList("rhoList", "List of rho parameters", this), _ownedData(createDatasetFromHist(varList, hist)), _data(_ownedData.get()),
+     _rhoList("rhoList", "List of rho parameters", this),
      _options(options), _widthFactor(-1), _nSigma(nSigma), _rotate(rotate), _sortInput(sortInput),
      _nAdpt(1)
 {
@@ -240,7 +240,7 @@ RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, const RooArgList
    _tracker = new RooChangeTracker("tracker", "track rho parameters", _rhoList, true); // check for value updates
    (void)_tracker->hasChanged(true); // first evaluation always true for new parameters (?)
 
-   createPdf();
+   createPdf(true, *std::unique_ptr<RooDataSet>{createDatasetFromHist(varList, hist)});
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -249,7 +249,7 @@ RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, const RooArgList
 RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, RooAbsReal &x, const RooDataSet &data, Mirror mirror,
                            double rho, double nSigma, bool rotate, bool sortInput)
    : RooAbsPdf(name, title), _varList("varList", "List of variables", this),
-     _rhoList("rhoList", "List of rho parameters", this), _data(&data), _options("a"), _widthFactor(rho),
+     _rhoList("rhoList", "List of rho parameters", this), _options("a"), _widthFactor(rho),
      _nSigma(nSigma), _rotate(rotate), _sortInput(sortInput), _nAdpt(1)
 {
    _varList.add(x);
@@ -262,7 +262,7 @@ RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, RooAbsReal &x, c
       _options = "m";
    }
 
-   createPdf();
+   createPdf(true, data);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -272,14 +272,14 @@ RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, RooAbsReal &x, c
 RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, RooAbsReal &x, RooAbsReal &y, const RooDataSet &data,
                            TString options, double rho, double nSigma, bool rotate, bool sortInput)
    : RooAbsPdf(name, title), _varList("varList", "List of variables", this),
-     _rhoList("rhoList", "List of rho parameters", this), _data(&data), _options(options), _widthFactor(rho),
+     _rhoList("rhoList", "List of rho parameters", this), _options(options), _widthFactor(rho),
      _nSigma(nSigma), _rotate(rotate), _sortInput(sortInput), _nAdpt(1)
 {
    _varList.add(RooArgSet(x, y));
    _varName.push_back(x.GetName());
    _varName.push_back(y.GetName());
 
-   createPdf();
+   createPdf(true, data);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -287,8 +287,7 @@ RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, RooAbsReal &x, R
 
 RooNDKeysPdf::RooNDKeysPdf(const RooNDKeysPdf &other, const char *name)
    : RooAbsPdf(other, name), _varList("varList", this, other._varList), _rhoList("rhoList", this, other._rhoList),
-     _ownedData(other._ownedData ? new RooDataSet(*other._ownedData) : nullptr),
-     _data(_ownedData ? _ownedData.get() : other._data), _options(other._options), _widthFactor(other._widthFactor),
+     _options(other._options), _widthFactor(other._widthFactor),
      _nSigma(other._nSigma), _rotate(other._rotate), _sortInput(other._sortInput),
      _nAdpt(other._nAdpt)
 {
@@ -380,24 +379,24 @@ RooNDKeysPdf::~RooNDKeysPdf()
 ////////////////////////////////////////////////////////////////////////////////
 /// evaluation order of constructor.
 
-void RooNDKeysPdf::createPdf(bool firstCall)
+void RooNDKeysPdf::createPdf(bool firstCall, RooDataSet const& data)
 {
   if (firstCall) {
     // set options
     setOptions();
     // initialization
-    initialize();
+    initialize(data);
   }
 
 
   // copy dataset, calculate sigma_i's, determine min and max event weight
-  loadDataSet(firstCall);
+  loadDataSet(firstCall, data);
 
   // mirror dataset around dataset boundaries -- does not depend on event weights
   if (_mirror) mirrorDataSet();
 
   // store indices and weights of events with high enough weights
-  loadWeightSet();
+  loadWeightSet(data);
 
   // store indices of events in variable boundaries and box shell.
 //calculateShell(&_fullBoxInfo);
@@ -451,10 +450,10 @@ void RooNDKeysPdf::setOptions()
 ////////////////////////////////////////////////////////////////////////////////
 /// initialization
 
-void RooNDKeysPdf::initialize()
+void RooNDKeysPdf::initialize(RooDataSet const& data)
 {
   _nDim      = _varList.getSize();
-  _nEvents   = (Int_t)_data->numEntries();
+  _nEvents   = (Int_t)data.numEntries();
   _nEventsM  = _nEvents;
   _fixedShape= false;
 
@@ -476,7 +475,7 @@ void RooNDKeysPdf::initialize()
 
   _d         = static_cast<double>(_nDim);
 
-  vector<double> dummy(_nDim,0.);
+  std::vector<double> dummy(_nDim,0.);
   _dataPts.resize(_nEvents,dummy);
   _weights0.resize(_nEvents,dummy);
 
@@ -521,7 +520,7 @@ void RooNDKeysPdf::initialize()
 ////////////////////////////////////////////////////////////////////////////////
 /// copy the dataset and calculate some useful variables
 
-void RooNDKeysPdf::loadDataSet(bool firstCall)
+void RooNDKeysPdf::loadDataSet(bool firstCall, RooDataSet const& data)
 {
   // first some initialization
   _nEventsW=0.;
@@ -538,7 +537,7 @@ void RooNDKeysPdf::loadDataSet(bool firstCall)
   _rotMat->Zero();
   _sigmaR->Zero();
 
-  const RooArgSet* values= _data->get();
+  const RooArgSet* values= data.get();
   vector<RooRealVar*> dVars(_nDim);
   for  (Int_t j=0; j<_nDim; j++) {
     dVars[j] = (RooRealVar*)values->find(_varName[j].c_str());
@@ -548,12 +547,12 @@ void RooNDKeysPdf::loadDataSet(bool firstCall)
   _idx.clear();
   for (Int_t i=0; i<_nEvents; i++) {
 
-    _data->get(i); // fills dVars
+    data.get(i); // fills dVars
     _idx.push_back(i);
-    vector<double>& point  = _dataPts[i];
+    std::vector<double>& point  = _dataPts[i];
     TVectorD& pointV = _dataPtsR[i];
 
-    double myweight = _data->weight(); // default is one?
+    double myweight = data.weight(); // default is one?
     if ( TMath::Abs(myweight)>_maxWeight ) { _maxWeight = TMath::Abs(myweight); }
     _nEventsW += myweight;
 
@@ -741,13 +740,13 @@ void RooNDKeysPdf::mirrorDataSet()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void RooNDKeysPdf::loadWeightSet()
+void RooNDKeysPdf::loadWeightSet(RooDataSet const& data)
 {
   _wMap.clear();
 
   for (Int_t i=0; i<_nEventsM; i++) {
-    _data->get(_idx[i]);
-    double myweight = _data->weight();
+    data.get(_idx[i]);
+    double myweight = data.weight();
     //if ( TMath::Abs(myweight)>_minWeight ) {
       _wMap[i] = myweight;
     //}

--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -25,12 +25,12 @@
 #include "RooFit/UniqueId.h"
 #include "RooFit/Detail/DataMap.h"
 
-#include "TNamed.h"
+#include <TMatrixDSym.h>
+#include <TNamed.h>
 
 #include <map>
 #include <string>
 
-class RooAbsArg;
 class RooAbsReal ;
 class RooRealVar;
 class RooAbsRealLValue;
@@ -44,8 +44,6 @@ class TH2F;
 class RooAbsBinning ;
 class Roo1DTable ;
 class RooAbsDataStore ;
-template<typename T> class TMatrixTSym;
-using TMatrixDSym = TMatrixTSym<double>;
 class RooFormulaVar;
 namespace RooFit {
 namespace TestStatistics {
@@ -65,15 +63,15 @@ public:
 
   RooAbsData& operator=(const RooAbsData& other);
   ~RooAbsData() override ;
-  virtual RooAbsData* emptyClone(const char* newName=nullptr, const char* newTitle=nullptr, const RooArgSet* vars=nullptr, const char* wgtVarName=nullptr) const = 0 ;
+  virtual RooFit::OwningPtr<RooAbsData> emptyClone(const char* newName=nullptr, const char* newTitle=nullptr, const RooArgSet* vars=nullptr, const char* wgtVarName=nullptr) const = 0 ;
 
   // Reduction methods
-  RooAbsData* reduce(const RooCmdArg& arg1,const RooCmdArg& arg2={},const RooCmdArg& arg3={},const RooCmdArg& arg4={},
+  RooFit::OwningPtr<RooAbsData> reduce(const RooCmdArg& arg1,const RooCmdArg& arg2={},const RooCmdArg& arg3={},const RooCmdArg& arg4={},
                      const RooCmdArg& arg5={},const RooCmdArg& arg6={},const RooCmdArg& arg7={},const RooCmdArg& arg8={}) ;
-  RooAbsData* reduce(const char* cut) ;
-  RooAbsData* reduce(const RooFormulaVar& cutVar) ;
-  RooAbsData* reduce(const RooArgSet& varSubset, const char* cut=nullptr) ;
-  RooAbsData* reduce(const RooArgSet& varSubset, const RooFormulaVar& cutVar) ;
+  RooFit::OwningPtr<RooAbsData> reduce(const char* cut) ;
+  RooFit::OwningPtr<RooAbsData> reduce(const RooFormulaVar& cutVar) ;
+  RooFit::OwningPtr<RooAbsData> reduce(const RooArgSet& varSubset, const char* cut=nullptr) ;
+  RooFit::OwningPtr<RooAbsData> reduce(const RooArgSet& varSubset, const RooFormulaVar& cutVar) ;
 
   RooAbsDataStore* store() { return _dstore.get(); }
   const RooAbsDataStore* store() const { return _dstore.get(); }
@@ -177,30 +175,27 @@ public:
 
   // WVE --- This needs to be public to avoid CINT problems
   struct PlotOpt {
-   PlotOpt() : cuts(""), drawOptions("P"), bins(nullptr), etype(RooAbsData::Poisson), cutRange(nullptr), histName(nullptr), histInvisible(false),
-              addToHistName(nullptr),addToWgtSelf(1.),addToWgtOther(1.),xErrorSize(1),refreshFrameNorm(false),correctForBinWidth(true),
-              scaleFactor(1.) {} ;
-   const char* cuts ;
-   Option_t* drawOptions ;
-   RooAbsBinning* bins ;
-   RooAbsData::ErrorType etype ;
-   const char* cutRange ;
-   const char* histName ;
-   bool histInvisible ;
-   const char* addToHistName ;
-   double addToWgtSelf ;
-   double addToWgtOther ;
-   double xErrorSize ;
-   bool refreshFrameNorm ;
-   bool correctForBinWidth ;
-   double scaleFactor ;
+   const char* cuts = "";
+   Option_t* drawOptions = "P";
+   RooAbsBinning* bins = nullptr;
+   RooAbsData::ErrorType etype = RooAbsData::Poisson;
+   const char* cutRange = nullptr;
+   const char* histName = nullptr;
+   bool histInvisible = false;
+   const char* addToHistName = nullptr;
+   double addToWgtSelf = 1.0;
+   double addToWgtOther = 1.0;
+   double xErrorSize = 1.0;
+   bool refreshFrameNorm = false;
+   bool correctForBinWidth = true;
+   double scaleFactor = 1.0;
   } ;
 
   // Split a dataset by a category
-  virtual TList* split(const RooAbsCategory& splitCat, bool createEmptyDataSets=false) const ;
+  virtual RooFit::OwningPtr<TList> split(const RooAbsCategory& splitCat, bool createEmptyDataSets=false) const ;
 
   // Split a dataset by categories of a RooSimultaneous
-  virtual TList* split(const RooSimultaneous& simpdf, bool createEmptyDataSets=false) const ;
+  virtual RooFit::OwningPtr<TList> split(const RooSimultaneous& simpdf, bool createEmptyDataSets=false) const ;
 
   // Fast splitting for SimMaster setData
   bool canSplitFast() const ;
@@ -252,10 +247,10 @@ public:
   double covariance(RooRealVar &x,RooRealVar &y, const char* cutSpec=nullptr, const char* cutRange=nullptr) const { return corrcov(x,y,cutSpec,cutRange,false) ; }
   double correlation(RooRealVar &x,RooRealVar &y, const char* cutSpec=nullptr, const char* cutRange=nullptr) const { return corrcov(x,y,cutSpec,cutRange,true) ; }
 
-  TMatrixDSym* covarianceMatrix(const char* cutSpec=nullptr, const char* cutRange=nullptr) const { return covarianceMatrix(*get(),cutSpec,cutRange) ; }
-  TMatrixDSym* correlationMatrix(const char* cutSpec=nullptr, const char* cutRange=nullptr) const { return correlationMatrix(*get(),cutSpec,cutRange) ; }
-  TMatrixDSym* covarianceMatrix(const RooArgList& vars, const char* cutSpec=nullptr, const char* cutRange=nullptr) const { return corrcovMatrix(vars,cutSpec,cutRange,false) ; }
-  TMatrixDSym* correlationMatrix(const RooArgList& vars, const char* cutSpec=nullptr, const char* cutRange=nullptr) const { return corrcovMatrix(vars,cutSpec,cutRange,true) ; }
+  RooFit::OwningPtr<TMatrixDSym> covarianceMatrix(const char* cutSpec=nullptr, const char* cutRange=nullptr) const { return covarianceMatrix(*get(),cutSpec,cutRange) ; }
+  RooFit::OwningPtr<TMatrixDSym> correlationMatrix(const char* cutSpec=nullptr, const char* cutRange=nullptr) const { return correlationMatrix(*get(),cutSpec,cutRange) ; }
+  RooFit::OwningPtr<TMatrixDSym> covarianceMatrix(const RooArgList& vars, const char* cutSpec=nullptr, const char* cutRange=nullptr) const { return corrcovMatrix(vars,cutSpec,cutRange,false) ; }
+  RooFit::OwningPtr<TMatrixDSym> correlationMatrix(const RooArgList& vars, const char* cutSpec=nullptr, const char* cutRange=nullptr) const { return corrcovMatrix(vars,cutSpec,cutRange,true) ; }
 
   RooRealVar* meanVar(const RooRealVar &var, const char* cutSpec=nullptr, const char* cutRange=nullptr) const ;
   RooRealVar* rmsVar(const RooRealVar &var, const char* cutSpec=nullptr, const char* cutRange=nullptr) const ;
@@ -320,7 +315,7 @@ protected:
   void initializeVars(RooArgSet const& vars);
 
   double corrcov(const RooRealVar& x, const RooRealVar& y, const char* cutSpec, const char* cutRange, bool corr) const  ;
-  TMatrixDSym* corrcovMatrix(const RooArgList& vars, const char* cutSpec, const char* cutRange, bool corr) const  ;
+  RooFit::OwningPtr<TMatrixDSym> corrcovMatrix(const RooArgList& vars, const char* cutSpec, const char* cutRange, bool corr) const  ;
 
   virtual void optimizeReadingWithCaching(RooAbsArg& arg, const RooArgSet& cacheList, const RooArgSet& keepObsList) ;
   bool allClientsCached(RooAbsArg*, const RooArgSet&) ;
@@ -343,7 +338,7 @@ protected:
   virtual void setArgStatus(const RooArgSet& set, bool active) ;
   virtual void attachCache(const RooAbsArg* newOwner, const RooArgSet& cachedVars) ;
 
-  virtual RooAbsData* reduceEng(const RooArgSet& varSubset, const RooFormulaVar* cutVar, const char* cutRange=nullptr,
+  virtual std::unique_ptr<RooAbsData> reduceEng(const RooArgSet& varSubset, const RooFormulaVar* cutVar, const char* cutRange=nullptr,
                            std::size_t nStart = 0, std::size_t = std::numeric_limits<std::size_t>::max()) = 0 ;
 
   RooRealVar* dataRealVar(const char* methodname, const RooRealVar& extVar) const ;

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -58,8 +58,8 @@ public:
   ~RooDataHist() override ;
 
   /// Return empty clone of this RooDataHist.
-  RooAbsData* emptyClone(const char* newName=nullptr, const char* newTitle=nullptr, const RooArgSet*vars=nullptr, const char* /*wgtVarName*/=nullptr) const override {
-    return new RooDataHist(newName?newName:GetName(),newTitle?newTitle:GetTitle(),vars?*vars:*get()) ;
+  RooFit::OwningPtr<RooAbsData> emptyClone(const char* newName=nullptr, const char* newTitle=nullptr, const RooArgSet*vars=nullptr, const char* /*wgtVarName*/=nullptr) const override {
+    return RooFit::Detail::owningPtr(std::make_unique<RooDataHist>(newName?newName:GetName(),newTitle?newTitle:GetTitle(),vars?*vars:*get()));
   }
 
   /// Add `wgt` to the bin content enclosed by the coordinates passed in `row`.
@@ -224,7 +224,7 @@ public:
   Int_t calcTreeIndex() const { return static_cast<Int_t>(calcTreeIndex(_vars, true)); }
 
   void initialize(const char* binningName=nullptr,bool fillTree=true) ;
-  RooAbsData* reduceEng(const RooArgSet& varSubset, const RooFormulaVar* cutVar, const char* cutRange=nullptr,
+  std::unique_ptr<RooAbsData> reduceEng(const RooArgSet& varSubset, const RooFormulaVar* cutVar, const char* cutRange=nullptr,
                   std::size_t nStart=0, std::size_t nStop=std::numeric_limits<std::size_t>::max()) override;
   double interpolateDim(int iDim, double xval, size_t centralIdx, int intOrder, bool correctForBinSize, bool cdfBoundaries) ;
   const std::vector<double>& calculatePartialBinVolume(const RooArgSet& dimSet) const ;

--- a/roofit/roofitcore/inc/RooDataSet.h
+++ b/roofit/roofitcore/inc/RooDataSet.h
@@ -93,9 +93,9 @@ public:
   }
   ~RooDataSet() override ;
 
-  RooAbsData* emptyClone(const char* newName=nullptr, const char* newTitle=nullptr, const RooArgSet* vars=nullptr, const char* wgtVarName=nullptr) const override;
+  RooFit::OwningPtr<RooAbsData> emptyClone(const char* newName=nullptr, const char* newTitle=nullptr, const RooArgSet* vars=nullptr, const char* wgtVarName=nullptr) const override;
 
-  RooDataHist* binnedClone(const char* newName=nullptr, const char* newTitle=nullptr) const ;
+  RooFit::OwningPtr<RooDataHist> binnedClone(const char* newName=nullptr, const char* newTitle=nullptr) const ;
 
   double sumEntries() const override;
   double sumEntries(const char* cutSpec, const char* cutRange=nullptr) const override;
@@ -164,7 +164,7 @@ protected:
   void initialize(const char* wgtVarName) ;
 
   // Cache copy feature is not publicly accessible
-  RooAbsData* reduceEng(const RooArgSet& varSubset, const RooFormulaVar* cutVar, const char* cutRange=nullptr,
+  std::unique_ptr<RooAbsData> reduceEng(const RooArgSet& varSubset, const RooFormulaVar* cutVar, const char* cutRange=nullptr,
                         std::size_t nStart=0, std::size_t nStop = std::numeric_limits<std::size_t>::max()) override;
   RooDataSet(RooStringView name, RooStringView title, RooDataSet *ntuple,
              const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,

--- a/roofit/roofitcore/inc/RooFit/Config.h
+++ b/roofit/roofitcore/inc/RooFit/Config.h
@@ -15,7 +15,7 @@
 
 // Define ROOFIT_MEMORY_SAFE_INTERFACES to change RooFit interfaces to be
 // memory safe.
-//#define ROOFIT_MEMORY_SAFE_INTERFACES
+// #define ROOFIT_MEMORY_SAFE_INTERFACES
 
 // The memory safe interfaces mode implies that all RooFit::OwningPtr<T> are
 // std::unique_ptr<T>.
@@ -53,6 +53,17 @@ OwningPtr<T> owningPtr(std::unique_ptr<T> &&ptr)
    return std::move(ptr);
 #else
    return ptr.release();
+#endif
+}
+
+/// internal helper to turn a std::unique_ptr<t> into an owningptr.
+template <typename T, typename U>
+OwningPtr<T> owningPtr(std::unique_ptr<U> &&ptr)
+{
+#ifdef ROOFIT_OWNING_PTR_IS_UNIQUE_PTR
+   return std::unique_ptr<T>{static_cast<T *>(ptr.release())};
+#else
+   return static_cast<T *>(ptr.release());
 #endif
 }
 

--- a/roofit/roofitcore/src/RooAbsData.cxx
+++ b/roofit/roofitcore/src/RooAbsData.cxx
@@ -109,7 +109,6 @@ observable snapshots are stored in the dataset.
 #include "RooHelpers.h"
 
 #include "ROOT/StringUtils.hxx"
-#include "TMatrixDSym.h"
 #include "TPaveText.h"
 #include "TH1.h"
 #include "TH2.h"
@@ -425,7 +424,7 @@ void RooAbsData::setDirtyProp(bool flag)
 /// <tr><td> `Title(const char* name)`   <td> Give specified title to output dataset
 /// </table>
 
-RooAbsData* RooAbsData::reduce(const RooCmdArg& arg1,const RooCmdArg& arg2,const RooCmdArg& arg3,const RooCmdArg& arg4,
+RooFit::OwningPtr<RooAbsData> RooAbsData::reduce(const RooCmdArg& arg1,const RooCmdArg& arg2,const RooCmdArg& arg3,const RooCmdArg& arg4,
                 const RooCmdArg& arg5,const RooCmdArg& arg6,const RooCmdArg& arg7,const RooCmdArg& arg8)
 {
   // Define configuration for this method
@@ -471,7 +470,7 @@ RooAbsData* RooAbsData::reduce(const RooCmdArg& arg1,const RooCmdArg& arg2,const
     varSubset.add(*get()) ;
   }
 
-  RooAbsData* ret = nullptr;
+  std::unique_ptr<RooAbsData> ret;
   if (cutSpec) {
 
     RooFormulaVar cutVarTmp(cutSpec,cutSpec,*get()) ;
@@ -489,7 +488,7 @@ RooAbsData* RooAbsData::reduce(const RooCmdArg& arg1,const RooCmdArg& arg2,const
   if (title) ret->SetTitle(title) ;
 
   ret->copyGlobalObservables(*this);
-  return ret ;
+  return RooFit::Detail::owningPtr(std::move(ret));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -498,12 +497,12 @@ RooAbsData* RooAbsData::reduce(const RooCmdArg& arg1,const RooCmdArg& arg2,const
 /// other variables, such as intermediate formula objects, use the equivalent
 /// reduce method specifying the as a RooFormulVar reference.
 
-RooAbsData* RooAbsData::reduce(const char* cut)
+RooFit::OwningPtr<RooAbsData> RooAbsData::reduce(const char* cut)
 {
   RooFormulaVar cutVar(cut,cut,*get()) ;
-  RooAbsData* ret = reduceEng(*get(),&cutVar,0,0,std::numeric_limits<std::size_t>::max()) ;
+  auto ret = reduceEng(*get(),&cutVar,0,0,std::numeric_limits<std::size_t>::max()) ;
   ret->copyGlobalObservables(*this);
-  return ret;
+  return RooFit::Detail::owningPtr(std::move(ret));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -511,11 +510,11 @@ RooAbsData* RooAbsData::reduce(const char* cut)
 /// The 'cutVar' formula variable is used to select the subset of data points to be
 /// retained in the reduced data collection.
 
-RooAbsData* RooAbsData::reduce(const RooFormulaVar& cutVar)
+RooFit::OwningPtr<RooAbsData> RooAbsData::reduce(const RooFormulaVar& cutVar)
 {
-  RooAbsData* ret = reduceEng(*get(),&cutVar,0,0,std::numeric_limits<std::size_t>::max()) ;
+  auto ret = reduceEng(*get(),&cutVar,0,0,std::numeric_limits<std::size_t>::max()) ;
   ret->copyGlobalObservables(*this);
-  return ret;
+  return RooFit::Detail::owningPtr(std::move(ret));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -526,7 +525,7 @@ RooAbsData* RooAbsData::reduce(const RooFormulaVar& cutVar)
 /// other variables, such as intermediate formula objects, use the equivalent
 /// reduce method specifying the as a RooFormulVar reference.
 
-RooAbsData* RooAbsData::reduce(const RooArgSet& varSubset, const char* cut)
+RooFit::OwningPtr<RooAbsData> RooAbsData::reduce(const RooArgSet& varSubset, const char* cut)
 {
   // Make sure varSubset doesn't contain any variable not in this dataset
   RooArgSet varSubset2(varSubset) ;
@@ -538,7 +537,7 @@ RooAbsData* RooAbsData::reduce(const RooArgSet& varSubset, const char* cut)
     }
   }
 
-  RooAbsData* ret = nullptr;
+  std::unique_ptr<RooAbsData> ret;
   if (cut && strlen(cut)>0) {
     RooFormulaVar cutVar(cut, cut, *get(), false);
     ret = reduceEng(varSubset2,&cutVar,0,0,std::numeric_limits<std::size_t>::max());
@@ -546,7 +545,7 @@ RooAbsData* RooAbsData::reduce(const RooArgSet& varSubset, const char* cut)
     ret = reduceEng(varSubset2,0,0,0,std::numeric_limits<std::size_t>::max());
   }
   ret->copyGlobalObservables(*this);
-  return ret;
+  return RooFit::Detail::owningPtr(std::move(ret));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -556,7 +555,7 @@ RooAbsData* RooAbsData::reduce(const RooArgSet& varSubset, const char* cut)
 /// The 'cutVar' formula variable is used to select the subset of data points to be
 /// retained in the reduced data collection.
 
-RooAbsData* RooAbsData::reduce(const RooArgSet& varSubset, const RooFormulaVar& cutVar)
+RooFit::OwningPtr<RooAbsData> RooAbsData::reduce(const RooArgSet& varSubset, const RooFormulaVar& cutVar)
 {
   // Make sure varSubset doesn't contain any variable not in this dataset
   RooArgSet varSubset2(varSubset) ;
@@ -568,9 +567,9 @@ RooAbsData* RooAbsData::reduce(const RooArgSet& varSubset, const RooFormulaVar& 
     }
   }
 
-  RooAbsData* ret = reduceEng(varSubset2,&cutVar,0,0,std::numeric_limits<std::size_t>::max()) ;
+  auto ret = reduceEng(varSubset2,&cutVar,0,0,std::numeric_limits<std::size_t>::max()) ;
   ret->copyGlobalObservables(*this);
-  return ret;
+  return RooFit::Detail::owningPtr(std::move(ret));
 }
 
 
@@ -963,7 +962,8 @@ double RooAbsData::corrcov(const RooRealVar &x, const RooRealVar &y, const char*
   }
 
   // Setup RooFormulaVar for cutSpec if it is present
-  RooFormula* select = cutSpec ? new RooFormula("select",cutSpec,*get()) : 0 ;
+  std::unique_ptr<RooFormula> select;
+  if (cutSpec) select = std::make_unique<RooFormula>("select",cutSpec,*get());
 
   // Calculate requested moment
   double xysum(0),xsum(0),ysum(0),x2sum(0),y2sum(0);
@@ -991,9 +991,6 @@ double RooAbsData::corrcov(const RooRealVar &x, const RooRealVar &y, const char*
     y2sum/=sumEntries(cutSpec, cutRange) ;
   }
 
-  // Cleanup
-  if (select) delete select ;
-
   // Return covariance or correlation as requested
   if (corr) {
     return (xysum-xsum*ysum)/(sqrt(x2sum-(xsum*xsum))*sqrt(y2sum-(ysum*ysum))) ;
@@ -1005,7 +1002,7 @@ double RooAbsData::corrcov(const RooRealVar &x, const RooRealVar &y, const char*
 ////////////////////////////////////////////////////////////////////////////////
 /// Return covariance matrix from data for given list of observables
 
-TMatrixDSym* RooAbsData::corrcovMatrix(const RooArgList& vars, const char* cutSpec, const char* cutRange, bool corr) const
+RooFit::OwningPtr<TMatrixDSym> RooAbsData::corrcovMatrix(const RooArgList& vars, const char* cutSpec, const char* cutRange, bool corr) const
 {
   RooArgList varList ;
   for(auto * var : static_range_cast<RooRealVar*>(vars)) {
@@ -1064,7 +1061,7 @@ TMatrixDSym* RooAbsData::corrcovMatrix(const RooArgList& vars, const char* cutSp
   }
 
   // Calculate covariance matrix
-  TMatrixDSym* C = new TMatrixDSym(varList.size()) ;
+  auto C = std::make_unique<TMatrixDSym>(varList.size()) ;
   for (std::size_t ix=0 ; ix<varList.size() ; ix++) {
     for (std::size_t iy=0 ; iy<varList.size() ; iy++) {
       (*C)(ix,iy) = xysum(ix,iy)-xsum[ix]*xsum[iy] ;
@@ -1074,7 +1071,7 @@ TMatrixDSym* RooAbsData::corrcovMatrix(const RooArgList& vars, const char* cutSp
     }
   }
 
-  return C ;
+  return RooFit::Detail::owningPtr(std::move(C));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1510,39 +1507,39 @@ SplittingSetup initSplit(RooAbsData const &data, RooAbsCategory const &splitCat)
    return setup;
 }
 
-TList *splitImpl(RooAbsData const &data, const RooAbsCategory &cloneCat, bool createEmptyDataSets,
-                 std::function<RooAbsData *(const char *label)> createEmptyData)
+RooFit::OwningPtr<TList> splitImpl(RooAbsData const &data, const RooAbsCategory &cloneCat, bool createEmptyDataSets,
+                                   std::function<std::unique_ptr<RooAbsData>(const char *label)> createEmptyData)
 {
-   auto dsetList = new TList;
+   auto dsetList = std::make_unique<TList>();
 
    // If createEmptyDataSets is true, prepopulate with empty sets corresponding to all states
    if (createEmptyDataSets) {
       for (const auto &nameIdx : cloneCat) {
-         dsetList->Add(createEmptyData(nameIdx.first.c_str()));
+         dsetList->Add(createEmptyData(nameIdx.first.c_str()).release());
       }
    }
 
-   bool isDataHist = dynamic_cast<RooDataHist const*>(&data);
+   bool isDataHist = dynamic_cast<RooDataHist const *>(&data);
 
    // Loop over dataset and copy event to matching subset
    for (Int_t i = 0; i < data.numEntries(); ++i) {
       const RooArgSet *row = data.get(i);
       auto subset = static_cast<RooAbsData *>(dsetList->FindObject(cloneCat.getCurrentLabel()));
       if (!subset) {
-         subset = createEmptyData(cloneCat.getCurrentLabel());
+         subset = createEmptyData(cloneCat.getCurrentLabel()).release();
          dsetList->Add(subset);
       }
 
       // For datasets with weight errors or sumW2, the interface to fill
       // RooDataHist and RooDataSet is not the same.
       if (isDataHist) {
-         static_cast<RooDataHist*>(subset)->add(*row, data.weight(), data.weightSquared());
+         static_cast<RooDataHist *>(subset)->add(*row, data.weight(), data.weightSquared());
       } else {
-         static_cast<RooDataSet*>(subset)->add(*row, data.weight(), data.weightError());
+         static_cast<RooDataSet *>(subset)->add(*row, data.weight(), data.weightError());
       }
    }
 
-   return dsetList;
+   return RooFit::Detail::owningPtr(std::move(dsetList));
 }
 
 } // namespace
@@ -1556,18 +1553,20 @@ TList *splitImpl(RooAbsData const &data, const RooAbsCategory &cloneCat, bool cr
 /// If createEmptyDataSets is false (default) this method only creates datasets for states
 /// which have at least one entry The caller takes ownership of the returned list and its contents
 
-TList* RooAbsData::split(const RooAbsCategory& splitCat, bool createEmptyDataSets) const
+RooFit::OwningPtr<TList> RooAbsData::split(const RooAbsCategory &splitCat, bool createEmptyDataSets) const
 {
-  SplittingSetup setup = initSplit(*this, splitCat);
+   SplittingSetup setup = initSplit(*this, splitCat);
 
-  // Something went wrong
-  if(!setup.cloneCat) return nullptr;
+   // Something went wrong
+   if (!setup.cloneCat)
+      return nullptr;
 
-  auto createEmptyData = [&](const char * label) -> RooAbsData* {
-    return emptyClone(label, label, &setup.subsetVars, setup.addWeightVar ? "weight" : nullptr);
-  };
+   auto createEmptyData = [&](const char *label) -> std::unique_ptr<RooAbsData> {
+      return std::unique_ptr<RooAbsData>{
+         emptyClone(label, label, &setup.subsetVars, setup.addWeightVar ? "weight" : nullptr)};
+   };
 
-  return splitImpl(*this, *setup.cloneCat, createEmptyDataSets, createEmptyData);
+   return splitImpl(*this, *setup.cloneCat, createEmptyDataSets, createEmptyData);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1579,40 +1578,42 @@ TList* RooAbsData::split(const RooAbsCategory& splitCat, bool createEmptyDataSet
 /// If createEmptyDataSets is false (default) this method only creates datasets for states
 /// which have at least one entry The caller takes ownership of the returned list and its contents
 
-TList* RooAbsData::split(const RooSimultaneous& simpdf, bool createEmptyDataSets) const
+RooFit::OwningPtr<TList> RooAbsData::split(const RooSimultaneous &simpdf, bool createEmptyDataSets) const
 {
-  auto& splitCat = const_cast<RooAbsCategoryLValue&>(simpdf.indexCat());
+   auto &splitCat = const_cast<RooAbsCategoryLValue &>(simpdf.indexCat());
 
-  SplittingSetup setup = initSplit(*this, splitCat);
+   SplittingSetup setup = initSplit(*this, splitCat);
 
-  // Something went wrong
-  if(!setup.cloneCat) return nullptr;
+   // Something went wrong
+   if (!setup.cloneCat)
+      return nullptr;
 
-  // Get the observables for a given pdf in the RooSimultaneous, or an empty
-  // RooArgSet if no pdf is set
-  auto getPdfObservables = [this, &simpdf](const char * label) {
-    RooArgSet obsSet;
-    if(RooAbsPdf* catPdf = simpdf.getPdf(label)) {
-      catPdf->getObservables(this->get(), obsSet);
-    }
-    return obsSet;
-  };
+   // Get the observables for a given pdf in the RooSimultaneous, or an empty
+   // RooArgSet if no pdf is set
+   auto getPdfObservables = [this, &simpdf](const char *label) {
+      RooArgSet obsSet;
+      if (RooAbsPdf *catPdf = simpdf.getPdf(label)) {
+         catPdf->getObservables(this->get(), obsSet);
+      }
+      return obsSet;
+   };
 
-  // By default, remove all category observables from the subdatasets
-  RooArgSet allObservables;
-  for( const auto& catPair : splitCat) {
-    allObservables.add(getPdfObservables(catPair.first.c_str()));
-  }
-  setup.subsetVars.remove(allObservables, true, true);
+   // By default, remove all category observables from the subdatasets
+   RooArgSet allObservables;
+   for (const auto &catPair : splitCat) {
+      allObservables.add(getPdfObservables(catPair.first.c_str()));
+   }
+   setup.subsetVars.remove(allObservables, true, true);
 
-  auto createEmptyData = [&](const char * label) -> RooAbsData* {
-    // Add in the subset only the observables corresponding to this category
-    RooArgSet subsetVarsCat(setup.subsetVars);
-    subsetVarsCat.add(getPdfObservables(label));
-    return this->emptyClone(label, label, &subsetVarsCat, setup.addWeightVar ? "weight" : nullptr);
-  };
+   auto createEmptyData = [&](const char *label) -> std::unique_ptr<RooAbsData> {
+      // Add in the subset only the observables corresponding to this category
+      RooArgSet subsetVarsCat(setup.subsetVars);
+      subsetVarsCat.add(getPdfObservables(label));
+      return std::unique_ptr<RooAbsData>{
+         this->emptyClone(label, label, &subsetVarsCat, setup.addWeightVar ? "weight" : nullptr)};
+   };
 
-  return splitImpl(*this, *setup.cloneCat, createEmptyDataSets, createEmptyData);
+   return splitImpl(*this, *setup.cloneCat, createEmptyDataSets, createEmptyData);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooAbsGenContext.cxx
+++ b/roofit/roofitcore/src/RooAbsGenContext.cxx
@@ -341,12 +341,12 @@ void RooAbsGenContext::resampleData(double& ratio)
 
   Int_t nOrig = _genData->numEntries() ;
   Int_t nTarg = Int_t(nOrig*ratio+0.5) ;
-  RooDataSet* trimmedData = (RooDataSet*) _genData->reduce(RooFit::EventRange(0,nTarg)) ;
+  std::unique_ptr<RooAbsData> trimmedData{_genData->reduce(RooFit::EventRange(0,nTarg))};
 
   cxcoutD(Generation) << "RooGenContext::resampleData*( existing production trimmed from " << nOrig << " to " << trimmedData->numEntries() << " events" << endl ;
 
   delete _genData ;
-  _genData = trimmedData ;
+  _genData = static_cast<RooDataSet*>(trimmedData.release());
 
   if (_prototype) {
     // Push back proto index by trimmed amount to force recycling of the

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -910,13 +910,13 @@ RooDataHist::RooDataHist(const RooDataHist& other, const char* newname) :
 ////////////////////////////////////////////////////////////////////////////////
 /// Implementation of RooAbsData virtual method that drives the RooAbsData::reduce() methods
 
-RooAbsData* RooDataHist::reduceEng(const RooArgSet& varSubset, const RooFormulaVar* cutVar, const char* cutRange,
+std::unique_ptr<RooAbsData> RooDataHist::reduceEng(const RooArgSet& varSubset, const RooFormulaVar* cutVar, const char* cutRange,
     std::size_t nStart, std::size_t nStop)
 {
   checkInit() ;
   RooArgSet myVarSubset;
   _vars.selectCommon(varSubset, myVarSubset);
-  RooDataHist *rdh = new RooDataHist(GetName(), GetTitle(), myVarSubset);
+  auto rdh = std::make_unique<RooDataHist>(GetName(), GetTitle(), myVarSubset);
 
   RooFormulaVar* cloneVar = nullptr;
   std::unique_ptr<RooArgSet> tmp;
@@ -927,7 +927,7 @@ RooAbsData* RooDataHist::reduceEng(const RooArgSet& varSubset, const RooFormulaV
       coutE(DataHandling) << "RooDataHist::reduceEng(" << GetName() << ") Couldn't deep-clone cut variable, abort," << endl ;
       return nullptr;
     }
-    cloneVar = (RooFormulaVar*) tmp->find(*cutVar) ;
+    cloneVar = static_cast<RooFormulaVar*>(tmp->find(*cutVar));
     cloneVar->attachDataSet(*this) ;
   }
 

--- a/roofit/roofitcore/src/RooSimultaneous.cxx
+++ b/roofit/roofitcore/src/RooSimultaneous.cxx
@@ -860,9 +860,9 @@ RooPlot* RooSimultaneous::plotOn(RooPlot *frame, RooLinkedList& cmdList) const
     projDataVars.remove(idxCatServers,true,true) ;
 
     if (!idxCompSliceSet->empty()) {
-      projDataTmp.reset( const_cast<RooAbsData*>(projData)->reduce(projDataVars,cutString) );
+      projDataTmp = std::unique_ptr<RooAbsData>{const_cast<RooAbsData*>(projData)->reduce(projDataVars,cutString)};
     } else {
-      projDataTmp.reset( const_cast<RooAbsData*>(projData)->reduce(projDataVars) );
+      projDataTmp = std::unique_ptr<RooAbsData>{const_cast<RooAbsData*>(projData)->reduce(projDataVars)};
     }
 
 

--- a/roofit/roofitcore/test/testRooDataSet.cxx
+++ b/roofit/roofitcore/test/testRooDataSet.cxx
@@ -180,16 +180,14 @@ TEST(RooDataSet, ReducingData)
       ASSERT_EQ(test_hist.Integral(), drawnEvents);
 
       // For unbinned data, reducing should be equivalent to the tree.
-      std::unique_ptr<RooDataSet> data_unbinned_reduced(
-         static_cast<RooDataSet *>(data_unbinned->reduce(RooFit::Cut(chi2_test_cut))));
+      std::unique_ptr<RooAbsData> data_unbinned_reduced{data_unbinned->reduce(RooFit::Cut(chi2_test_cut))};
       EXPECT_DOUBLE_EQ(data_unbinned_reduced->sumEntries(), test_hist.Integral());
       EXPECT_EQ(data_unbinned_reduced->numEntries(), test_hist.Integral());
 
       // When using binned data, reducing and expecting the ame number of entries as in the unbinned case is not
       // possible, since information is lost if entries to the left and right of the cut end up in the same bin.
       // Therefore, can only test <=
-      std::unique_ptr<RooDataHist> reduced_binned_data(
-         static_cast<RooDataHist *>(data->reduce(RooFit::Cut(chi2_test_cut))));
+      std::unique_ptr<RooAbsData> reduced_binned_data{data->reduce(RooFit::Cut(chi2_test_cut))};
       if (floor(chi2cutval) == chi2cutval)
          EXPECT_FLOAT_EQ(reduced_binned_data->sumEntries(), test_hist.Integral());
       else

--- a/roofit/roostats/inc/RooStats/MCMCInterval.h
+++ b/roofit/roostats/inc/RooStats/MCMCInterval.h
@@ -199,7 +199,7 @@ namespace RooStats {
 
       /// Get a clone of the markov chain on which this interval is based
       /// as a RooDataSet.  You own the returned RooDataSet*
-      virtual RooDataSet* GetChainAsDataSet(RooArgSet* whichVars = nullptr)
+      virtual RooFit::OwningPtr<RooDataSet> GetChainAsDataSet(RooArgSet* whichVars = nullptr)
       { return fChain->GetAsDataSet(whichVars); }
 
       /// Get the markov chain on which this interval is based
@@ -209,7 +209,7 @@ namespace RooStats {
 
       /// Get a clone of the markov chain on which this interval is based
       /// as a RooDataHist.  You own the returned RooDataHist*
-      virtual RooDataHist* GetChainAsDataHist(RooArgSet* whichVars = nullptr)
+      virtual RooFit::OwningPtr<RooDataHist> GetChainAsDataHist(RooArgSet* whichVars = nullptr)
       { return fChain->GetAsDataHist(whichVars); }
 
       /// Get a clone of the markov chain on which this interval is based

--- a/roofit/roostats/inc/RooStats/MarkovChain.h
+++ b/roofit/roostats/inc/RooStats/MarkovChain.h
@@ -64,11 +64,11 @@ namespace RooStats {
       /// of whichVars.  Call with whichVars = nullptr (default) to get values of
       /// all variables (including NLL value and weight);
       /// Note: caller owns the returned data set
-      virtual RooDataSet* GetAsDataSet(RooArgSet* whichVars = nullptr) const;
+      virtual RooFit::OwningPtr<RooDataSet> GetAsDataSet(RooArgSet* whichVars = nullptr) const;
 
       /// Get a clone of the markov chain on which this interval is based
       /// as a RooDataSet.  You own the returned RooDataSet*
-      virtual RooDataSet* GetAsDataSet(const RooCmdArg& arg1,
+      virtual RooFit::OwningPtr<RooDataSet> GetAsDataSet(const RooCmdArg& arg1,
                                        const RooCmdArg& arg2={}, const RooCmdArg& arg3={},
                                        const RooCmdArg& arg4={}, const RooCmdArg& arg5={},
                                        const RooCmdArg& arg6={}, const RooCmdArg& arg7={},
@@ -80,11 +80,11 @@ namespace RooStats {
       /// of whichVars.  Call with whichVars = nullptr (default) to get values of
       /// all variables (including NLL value and weight);
       /// Note: caller owns the returned data hist
-      virtual RooDataHist* GetAsDataHist(RooArgSet* whichVars = nullptr) const;
+      virtual RooFit::OwningPtr<RooDataHist> GetAsDataHist(RooArgSet* whichVars = nullptr) const;
 
       /// Get a clone of the markov chain on which this interval is based
       /// as a RooDataHist.  You own the returned RooDataHist*
-      virtual RooDataHist* GetAsDataHist(const RooCmdArg & arg1,
+      virtual RooFit::OwningPtr<RooDataHist> GetAsDataHist(const RooCmdArg & arg1,
                                          const RooCmdArg& arg2={}, const RooCmdArg& arg3={},
                                          const RooCmdArg& arg4={}, const RooCmdArg& arg5={},
                                          const RooCmdArg& arg6={}, const RooCmdArg& arg7={},

--- a/roofit/roostats/src/MCMCInterval.cxx
+++ b/roofit/roostats/src/MCMCInterval.cxx
@@ -356,14 +356,12 @@ void MCMCInterval::CreateKeysPdf()
       return;
    }
 
-   RooDataSet* chain = fChain->GetAsDataSet(SelectVars(fParameters),
-         EventRange(fNumBurnInSteps, fChain->Size()));
+   std::unique_ptr<RooDataSet> chain{fChain->GetAsDataSet(SelectVars(fParameters),
+         EventRange(fNumBurnInSteps, fChain->Size()))};
    RooArgList* paramsList = new RooArgList();
    for (Int_t i = 0; i < fDimension; i++)
       paramsList->add(*fAxes[i]);
 
-   // kbelasco: check for memory leaks with chain.  who owns it? does
-   // RooNDKeysPdf take ownership?
    fKeysPdf = new RooNDKeysPdf("keysPDF", "Keys PDF", *paramsList, *chain, "a");
    fCutoffVar = new RooRealVar("cutoff", "cutoff", 0);
    fHeaviside = new Heaviside("heaviside", "Heaviside", *fKeysPdf, *fCutoffVar);
@@ -511,8 +509,8 @@ void MCMCInterval::CreateDataHist()
       return;
    }
 
-   fDataHist = fChain->GetAsDataHist(SelectVars(fParameters),
-         EventRange(fNumBurnInSteps, fChain->Size()));
+   fDataHist = std::unique_ptr<RooDataHist>{fChain->GetAsDataHist(SelectVars(fParameters),
+         EventRange(fNumBurnInSteps, fChain->Size()))}.release();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roostats/src/MarkovChain.cxx
+++ b/roofit/roostats/src/MarkovChain.cxx
@@ -144,7 +144,7 @@ void MarkovChain::AddFast(RooArgSet& entry, double nllValue, double weight)
    //fChain->addFast(*fDataEntry);
 }
 
-RooDataSet* MarkovChain::GetAsDataSet(RooArgSet* whichVars) const
+RooFit::OwningPtr<RooDataSet> MarkovChain::GetAsDataSet(RooArgSet* whichVars) const
 {
    RooArgSet args;
    if (whichVars == nullptr) {
@@ -155,23 +155,19 @@ RooDataSet* MarkovChain::GetAsDataSet(RooArgSet* whichVars) const
       args.add(*whichVars);
    }
 
-   RooDataSet* data;
-   //data = dynamic_cast<RooDataSet*>(fChain->reduce(args));
-   data = (RooDataSet*)fChain->reduce(args);
-
-   return data;
+   return RooFit::Detail::owningPtr<RooDataSet>(std::unique_ptr<RooAbsData>{fChain->reduce(args)});
 }
 
-RooDataSet* MarkovChain::GetAsDataSet(const RooCmdArg& arg1, const RooCmdArg& arg2,
-                                      const RooCmdArg& arg3, const RooCmdArg& arg4, const RooCmdArg& arg5,
-                                      const RooCmdArg& arg6, const RooCmdArg& arg7, const RooCmdArg& arg8) const
+RooFit::OwningPtr<RooDataSet> MarkovChain::GetAsDataSet(const RooCmdArg &arg1, const RooCmdArg &arg2,
+                                                        const RooCmdArg &arg3, const RooCmdArg &arg4,
+                                                        const RooCmdArg &arg5, const RooCmdArg &arg6,
+                                                        const RooCmdArg &arg7, const RooCmdArg &arg8) const
 {
-   RooDataSet* data;
-   data = (RooDataSet*)fChain->reduce(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8);
-   return data;
+   return RooFit::Detail::owningPtr<RooDataSet>(
+      std::unique_ptr<RooAbsData>{fChain->reduce(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)});
 }
 
-RooDataHist* MarkovChain::GetAsDataHist(RooArgSet* whichVars) const
+RooFit::OwningPtr<RooDataHist> MarkovChain::GetAsDataHist(RooArgSet* whichVars) const
 {
    RooArgSet args;
    if (whichVars == nullptr) {
@@ -182,24 +178,17 @@ RooDataHist* MarkovChain::GetAsDataHist(RooArgSet* whichVars) const
       args.add(*whichVars);
    }
 
-   RooDataSet* data = (RooDataSet*)fChain->reduce(args);
-   RooDataHist* hist = data->binnedClone();
-   delete data;
-
-   return hist;
+   std::unique_ptr<RooAbsData> data{fChain->reduce(args)};
+   return RooFit::Detail::owningPtr(std::unique_ptr<RooDataHist>{static_cast<RooDataSet&>(*data).binnedClone()});
 }
 
-RooDataHist* MarkovChain::GetAsDataHist(const RooCmdArg& arg1, const RooCmdArg& arg2,
-                                        const RooCmdArg& arg3, const RooCmdArg& arg4, const RooCmdArg& arg5,
-                                        const RooCmdArg& arg6, const RooCmdArg& arg7, const RooCmdArg& arg8) const
+RooFit::OwningPtr<RooDataHist> MarkovChain::GetAsDataHist(const RooCmdArg &arg1, const RooCmdArg &arg2,
+                                                          const RooCmdArg &arg3, const RooCmdArg &arg4,
+                                                          const RooCmdArg &arg5, const RooCmdArg &arg6,
+                                                          const RooCmdArg &arg7, const RooCmdArg &arg8) const
 {
-   RooDataSet* data;
-   RooDataHist* hist;
-   data = (RooDataSet*)fChain->reduce(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8);
-   hist = data->binnedClone();
-   delete data;
-
-   return hist;
+   std::unique_ptr<RooAbsData> data{fChain->reduce(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)};
+   return RooFit::Detail::owningPtr(std::unique_ptr<RooDataHist>{static_cast<RooDataSet &>(*data).binnedClone()});
 }
 
 THnSparse* MarkovChain::GetAsSparseHist(RooAbsCollection* whichVars) const

--- a/test/stressRooFit_tests.h
+++ b/test/stressRooFit_tests.h
@@ -1747,10 +1747,10 @@ RooDataSet* makeFakeDataXY()
   // ---------------------------------------------------------------------------------------------
 
   // Make subset of experimental data with only y values
-  std::unique_ptr<RooDataSet> expDataY{static_cast<RooDataSet*>(expDataXY->reduce(y))};
+  std::unique_ptr<RooAbsData> expDataY{expDataXY->reduce(y)};
 
   // Generate 10000 events in x obtained from _conditional_ model(x|y) with y values taken from experimental data
-  std::unique_ptr<RooDataSet> data{model.generate(x,ProtoData(*expDataY))};
+  std::unique_ptr<RooDataSet> data{model.generate(x,ProtoData(static_cast<RooDataSet&>(*expDataY)))};
 
 
 
@@ -1771,13 +1771,13 @@ RooDataSet* makeFakeDataXY()
 
 
   // Speed up (and approximate) projection by using binned clone of data for projection
-  std::unique_ptr<RooAbsData> binnedDataY{expDataY->binnedClone()};
+  std::unique_ptr<RooAbsData> binnedDataY{static_cast<RooDataSet&>(*expDataY).binnedClone()};
   model.plotOn(xframe,ProjWData(*binnedDataY),LineColor(kCyan),LineStyle(kDotted),Name("Alt1")) ;
 
 
   // Show effect of projection with too coarse binning
-  ((RooRealVar*)expDataY->get()->find("y"))->setBins(5) ;
-  std::unique_ptr<RooAbsData> binnedDataY2{expDataY->binnedClone()};
+  static_cast<RooRealVar*>(expDataY->get()->find("y"))->setBins(5) ;
+  std::unique_ptr<RooAbsData> binnedDataY2{static_cast<RooDataSet&>(*expDataY).binnedClone()};
   model.plotOn(xframe,ProjWData(*binnedDataY2),LineColor(kRed),Name("Alt2")) ;
 
 
@@ -2822,7 +2822,7 @@ public:
   data->addColumn(llratio_func) ;
 
   // Extract the subset of data with large signal likelihood
-  std::unique_ptr<RooDataSet> dataSel{static_cast<RooDataSet*>(data->reduce(Cut("llratio>0.7")))};
+  std::unique_ptr<RooAbsData> dataSel{data->reduce(Cut("llratio>0.7"))};
 
   // Make plot frame
   RooPlot* frame2 = x.frame(Title("Same projection on X with LLratio(y,z)>0.7"),Bins(40)) ;
@@ -2840,11 +2840,11 @@ public:
 
   // Calculate LL ratio for each generated event and select MC events with llratio)0.7
   mcprojData->addColumn(llratio_func) ;
-  std::unique_ptr<RooDataSet> mcprojDataSel{static_cast<RooDataSet*>(mcprojData->reduce(Cut("llratio>0.7")))};
+  std::unique_ptr<RooAbsData> mcprojDataSel{mcprojData->reduce(Cut("llratio>0.7"))};
 
   // Project model on x, integrating projected observables (y,z) with Monte Carlo technique
   // on set of events with the same llratio cut as was applied to data
-  model.plotOn(frame2,ProjWData(*mcprojDataSel)) ;
+  model.plotOn(frame2,ProjWData(static_cast<RooDataSet&>(*mcprojDataSel)));
 
 
   regPlot(frame,"rf316_plot1") ;
@@ -2912,19 +2912,19 @@ public:
   // -------------------------------------------------------------
 
   // The reduce() function returns a new dataset which is a subset of the original
-  std::unique_ptr<RooDataSet> d1{static_cast<RooDataSet*>(d.reduce(RooArgSet(x,c)))};
-  std::unique_ptr<RooDataSet> d2{static_cast<RooDataSet*>(d.reduce(RooArgSet(y)))};
-  std::unique_ptr<RooDataSet> d3{static_cast<RooDataSet*>(d.reduce("y>5.17"))};
-  std::unique_ptr<RooDataSet> d4{static_cast<RooDataSet*>(d.reduce(RooArgSet(x,c),"y>5.17"))};
+  std::unique_ptr<RooAbsData> d1{d.reduce(RooArgSet(x,c))};
+  std::unique_ptr<RooAbsData> d2{d.reduce(RooArgSet(y))};
+  std::unique_ptr<RooAbsData> d3{d.reduce("y>5.17")};
+  std::unique_ptr<RooAbsData> d4{d.reduce(RooArgSet(x,c),"y>5.17")};
 
   regValue(d3->numEntries(),"rf403_nd3") ;
   regValue(d4->numEntries(),"rf403_nd4") ;
 
   // The merge() function adds two data set column-wise
-  d1->merge(d2.get()) ;
+  static_cast<RooDataSet&>(*d1).merge(static_cast<RooDataSet*>(d2.get()));
 
   // The append() function addes two datasets row-wise
-  d1->append(*d3) ;
+  static_cast<RooDataSet&>(*d1).append(static_cast<RooDataSet&>(*d3));
 
   regValue(d1->numEntries(),"rf403_nd1") ;
 
@@ -2951,7 +2951,7 @@ public:
   //
   // All reduce() methods are interfaced in RooAbsData. All reduction techniques
   // demonstrated on unbinned datasets can be applied to binned datasets as well.
-  std::unique_ptr<RooDataHist> dh2{static_cast<RooDataHist*>(dh.reduce(y,"x>0"))};
+  std::unique_ptr<RooAbsData> dh2{dh.reduce(y,"x>0")};
 
   // Add dh2 to yframe and redraw
   dh2->plotOn(yframe,LineColor(kRed),MarkerColor(kRed),Name("dh2")) ;
@@ -3181,7 +3181,7 @@ public:
   tagCat.addToRange("soso","NetTagger-2") ;
 
   // Use category range in dataset reduction specification
-  std::unique_ptr<RooDataSet> goodData{static_cast<RooDataSet*>(data->reduce(CutRange("good")))};
+  std::unique_ptr<RooAbsData> goodData{data->reduce(CutRange("good"))};
   Roo1DTable* gtable = goodData->table(tagCat) ;
 
 
@@ -3294,7 +3294,7 @@ public:
   xb->setRange("alt","x_coarse_bin1,x_coarse_bin3,x_coarse_bin5,x_coarse_bin7,x_coarse_bin9") ;
 
   // Construct subset of data matching range "alt" but only for the first 5000 events and plot it on the fram
-  std::unique_ptr<RooDataSet> dataSel{static_cast<RooDataSet*>(data->reduce(CutRange("alt"),EventRange(0,5000)))};
+  std::unique_ptr<RooAbsData> dataSel{data->reduce(CutRange("alt"),EventRange(0,5000))};
 //   dataSel->plotOn(xframe,MarkerColor(kGreen),LineColor(kGreen),Name("data_sel")) ;
 
 


### PR DESCRIPTION
It's not clear to users whether the `RooDataSet` passed to a
RooNDKeysPdf has to live as long as that pdf or not.

Right now it has to live just as long, because the RooNDKeysPdf contains
the RooDataSet by non-owning pointer. However, there was no reason for
that, because the dataset is only used in the constructor.

This commit suggests to drop this unused `_data` member of the
RooNDKeysPdf, solving potential lifetime problems: the dataset doesn't
need to live as long as the RooNDKeysPdf anymore.

With this change, it was possible to use some more of the `RooFit::OwningPtr<T>` alias in RooFit, which is done in the second commit of this PR.

