### PR TITLE
[ci] Build in home directory [skip-ci]

### DIFF
--- a/.github/workflows/root-ci-config/build_root.py
+++ b/.github/workflows/root-ci-config/build_root.py
@@ -44,7 +44,7 @@ except:
     CONNECTION = None
 
 WINDOWS = (os.name == 'nt')
-WORKDIR = '/tmp/workspace' if not WINDOWS else 'C:/ROOT-CI'
+WORKDIR = (os.environ['HOME'] + '/ROOT-CI') if not WINDOWS else 'C:/ROOT-CI'
 COMPRESSIONLEVEL = 6 if not WINDOWS else 1
 
 

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -136,7 +136,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name:  Test Results ${{ matrix.platform }} ${{ matrix.arch }} ${{ matrix.config }}
-          path: /tmp/workspace/build/TestResults.xml
+          path: /Users/sftnight/ROOT-CI/build/TestResults.xml
 
 
   build-windows:
@@ -331,7 +331,7 @@ jobs:
 
       - uses: root-project/gcc-problem-matcher-improved@main
         with:
-          build-directory: /tmp/workspace/src/
+          build-directory: /github/home/ROOT-CI/src/
 
       - name: Pull Request Build
         if: github.event_name == 'pull_request'
@@ -383,7 +383,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name:  Test Results ${{ matrix.image }} ${{ matrix.config }}
-          path: /tmp/workspace/build/TestResults.xml
+          path: /github/home/ROOT-CI/build/TestResults.xml
 
   event_file:
     if: github.repository_owner == 'root-project' || github.event_name == 'pull_request'


### PR DESCRIPTION
The `/tmp` area in macOS seems to be restricted in size, failing jobs when upgrading to LLVM 16.