### PR TITLE
Changed filters used by RBatchGenerator to a single string

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tmva/_batchgenerator.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tmva/_batchgenerator.py
@@ -205,13 +205,15 @@ class BaseGenerator:
         # cling via cppyy) and the I/O thread.
         EnableThreadSafety()
 
+        expanded_filter = " && ".join(["(" + fltr + ")" for fltr in filters])
+
         self.generator = TMVA.Experimental.Internal.RBatchGenerator(template)(
             tree_name,
             file_name,
             chunk_size,
             batch_size,
             self.given_columns,
-            filters,
+            expanded_filter,
             max_vec_sizes_list,
             vec_padding,
             validation_split,

--- a/tmva/tmva/inc/TMVA/RBatchGenerator.hxx
+++ b/tmva/tmva/inc/TMVA/RBatchGenerator.hxx
@@ -29,7 +29,7 @@ private:
    std::string fTreeName;
 
    std::vector<std::string> fCols;
-   std::vector<std::string> fFilters;
+   std::string fFilters;
 
    std::size_t fChunkSize;
    std::size_t fMaxChunks;
@@ -65,10 +65,10 @@ private:
 
 public:
    RBatchGenerator(const std::string &treeName, const std::string &fileName, const std::size_t chunkSize,
-                   const std::size_t batchSize, const std::vector<std::string> &cols,
-                   const std::vector<std::string> &filters = {}, const std::vector<std::size_t> &vecSizes = {},
-                   const float vecPadding = 0.0, const float validationSplit = 0.0, const std::size_t maxChunks = 0,
-                   const std::size_t numColumns = 0, bool shuffle = true)
+                   const std::size_t batchSize, const std::vector<std::string> &cols, const std::string &filters = "",
+                   const std::vector<std::size_t> &vecSizes = {}, const float vecPadding = 0.0,
+                   const float validationSplit = 0.0, const std::size_t maxChunks = 0, const std::size_t numColumns = 0,
+                   bool shuffle = true)
       : fTreeName(treeName),
         fFileName(fileName),
         fChunkSize(chunkSize),

--- a/tmva/tmva/inc/TMVA/RChunkLoader.hxx
+++ b/tmva/tmva/inc/TMVA/RChunkLoader.hxx
@@ -120,7 +120,7 @@ private:
    std::size_t fNumColumns;
 
    std::vector<std::string> fCols;
-   std::vector<std::string> fFilters;
+   std::string fFilters;
 
    std::vector<std::size_t> fVecSizes;
    std::size_t fVecPadding;
@@ -135,7 +135,7 @@ public:
    /// \param vecSizes
    /// \param vecPadding
    RChunkLoader(const std::string &treeName, const std::string &fileName, const std::size_t chunkSize,
-                const std::vector<std::string> &cols, const std::vector<std::string> &filters = {},
+                const std::vector<std::string> &cols, const std::string &filters = "",
                 const std::vector<std::size_t> &vecSizes = {}, const float vecPadding = 0.0)
       : fTreeName(treeName),
         fFileName(fileName),
@@ -184,11 +184,7 @@ private:
    std::pair<std::size_t, std::size_t> loadFiltered(ROOT::RDataFrame &x_rdf, RChunkLoaderFunctor<Args...> &func)
    {
       // Add the given filters to the RDataFrame
-      auto x_filter = x_rdf.Filter(fFilters[0], "RBatchGenerator_Filter_0");
-      for (auto i = 1; i < fFilters.size(); i++) {
-         auto name = "RBatchGenerator_Filter_" + std::to_string(i);
-         x_filter = x_filter.Filter(fFilters[i], name);
-      }
+      auto x_filter = x_rdf.Filter(fFilters, "RBatchGenerator_Filter");
 
       // add range to the DataFrame
       auto x_ranged = x_filter.Range(fChunkSize);


### PR DESCRIPTION
Changed the internal handeling of filters in RBatchGenerator. 
Instead of adding a new filter for each filter, the filters are concatenated to a string and applied as a single filter 
Note: The Python interface of the RBatchGenerator does not change.

