### PR TITLE
[RF] Make plotting of histograms work for all orders of magnitude

### DIFF
--- a/roofit/roofit/inc/RooParametricStepFunction.h
+++ b/roofit/roofit/inc/RooParametricStepFunction.h
@@ -15,12 +15,12 @@
 #ifndef ROO_PARAMETRIC_STEP_FUNCTION
 #define ROO_PARAMETRIC_STEP_FUNCTION
 
-#include "TArrayD.h"
-#include "RooAbsPdf.h"
-#include "RooRealProxy.h"
-#include "RooListProxy.h"
+#include <RooRealProxy.h>
+#include <RooListProxy.h>
+#include <RooAbsPdf.h>
 
-class RooRealVar;
+#include <TArrayD.h>
+
 class RooArgList ;
 
 class RooParametricStepFunction : public RooAbsPdf {
@@ -29,7 +29,7 @@ public:
    RooParametricStepFunction() {}
 
   RooParametricStepFunction(const char *name, const char *title,
-      RooAbsReal& x, const RooArgList& coefList, TArrayD& limits, Int_t nBins=1) ;
+      RooAbsReal& x, const RooArgList& coefList, TArrayD const& limits, Int_t nBins=1) ;
 
   RooParametricStepFunction(const RooParametricStepFunction& other, const char* name = nullptr);
   TObject* clone(const char* newname) const override { return new RooParametricStepFunction(*this, newname); }

--- a/roofit/roofit/inc/RooParametricStepFunction.h
+++ b/roofit/roofit/inc/RooParametricStepFunction.h
@@ -39,6 +39,8 @@ public:
   Int_t getnBins() const { return _nBins; }
   double* getLimits() { return _limits.GetArray(); }
 
+  std::list<double>* plotSamplingHint(RooAbsRealLValue& obs, double xlo, double xhi) const override ;
+
 protected:
 
   double lastBinValue() const ;

--- a/roofit/roofit/inc/RooStepFunction.h
+++ b/roofit/roofit/inc/RooStepFunction.h
@@ -17,18 +17,16 @@
 #ifndef ROO_STEP_FUNCTION
 #define ROO_STEP_FUNCTION
 
-#include "TArrayD.h"
-#include "RooAbsReal.h"
-#include "RooRealProxy.h"
-#include "RooListProxy.h"
+#include <RooAbsReal.h>
+#include <RooListProxy.h>
+#include <RooRealProxy.h>
 
-class RooRealVar;
 class RooArgList ;
 
 class RooStepFunction : public RooAbsReal {
  public:
 
-  RooStepFunction() ;
+  RooStepFunction() {}
   RooStepFunction(const char *name, const char *title,
         RooAbsReal& x, const RooArgList& coefList, const RooArgList& limits, bool interpolate=false) ;
 
@@ -47,7 +45,7 @@ class RooStepFunction : public RooAbsReal {
   RooRealProxy _x;
   RooListProxy _coefList ;
   RooListProxy _boundaryList ;
-  bool       _interpolate ;
+  bool       _interpolate = false;
 
   ClassDefOverride(RooStepFunction,1) //  Step Function
 };

--- a/roofit/roofit/inc/RooStepFunction.h
+++ b/roofit/roofit/inc/RooStepFunction.h
@@ -36,6 +36,8 @@ class RooStepFunction : public RooAbsReal {
   const RooArgList& coefficients() { return _coefList; }
   const RooArgList& boundaries() { return _boundaryList; }
 
+  std::list<double>* plotSamplingHint(RooAbsRealLValue& obs, double xlo, double xhi) const override ;
+
  protected:
 
   double evaluate() const override;

--- a/roofit/roofit/src/RooParametricStepFunction.cxx
+++ b/roofit/roofit/src/RooParametricStepFunction.cxx
@@ -80,6 +80,7 @@ xframe->Draw();
 
 #include <RooParametricStepFunction.h>
 
+#include <RooCurve.h>
 #include <RooRealVar.h>
 
 ClassImp(RooParametricStepFunction);
@@ -220,4 +221,19 @@ double RooParametricStepFunction::evaluate() const
   }
   return value;
 
+}
+
+
+std::list<double>* RooParametricStepFunction::plotSamplingHint(RooAbsRealLValue& obs, double xlo, double xhi) const
+{
+   if(obs.namePtr() != _x->namePtr()) {
+      return nullptr;
+   }
+
+  // Retrieve position of all bin boundaries
+  std::span<const double> boundaries{_limits.GetArray(), static_cast<std::size_t>(_limits.GetSize())};
+
+  // Use the helper function from RooCurve to make sure to get sampling hints
+  // that work with the RooFitPlotting.
+  return RooCurve::plotSamplingHintForBinBoundaries(boundaries, xlo, xhi);
 }

--- a/roofit/roofit/src/RooParametricStepFunction.cxx
+++ b/roofit/roofit/src/RooParametricStepFunction.cxx
@@ -78,15 +78,9 @@ xframe->Draw();
 ~~~
 */
 
-#include "Riostream.h"
-#include "TArrayD.h"
-#include <cmath>
+#include <RooParametricStepFunction.h>
 
-#include "RooParametricStepFunction.h"
-#include "RooRealVar.h"
-#include "RooArgList.h"
-
-#include "TError.h"
+#include <RooRealVar.h>
 
 ClassImp(RooParametricStepFunction);
 
@@ -94,7 +88,7 @@ ClassImp(RooParametricStepFunction);
 /// Constructor
 
 RooParametricStepFunction::RooParametricStepFunction(const char* name, const char* title,
-              RooAbsReal& x, const RooArgList& coefList, TArrayD& limits, Int_t nBins) :
+              RooAbsReal& x, const RooArgList& coefList, TArrayD const& limits, Int_t nBins) :
   RooAbsPdf(name, title),
   _x("x", "Dependent", this, x),
   _coefList("coefList","List of coefficients",this),
@@ -110,9 +104,11 @@ RooParametricStepFunction::RooParametricStepFunction(const char* name, const cha
 
   for (auto *coef : coefList) {
     if (!dynamic_cast<RooAbsReal*>(coef)) {
-      std::cout << "RooParametricStepFunction::ctor(" << GetName() << ") ERROR: coefficient " << coef->GetName()
-                << " is not of type RooAbsReal" << std::endl ;
-      R__ASSERT(0) ;
+      std::stringstream errorMsg;
+      errorMsg << "RooParametricStepFunction::ctor(" << GetName() << ") ERROR: coefficient " << coef->GetName()
+                << " is not of type RooAbsReal";
+      coutE(InputArguments) << errorMsg.str() << std::endl;
+      throw std::invalid_argument(errorMsg.str().c_str());
     }
     _coefList.add(*coef) ;
   }
@@ -144,10 +140,8 @@ Int_t RooParametricStepFunction::getAnalyticalIntegral(RooArgSet& allVars, RooAr
 
 ////////////////////////////////////////////////////////////////////////////////
 
-double RooParametricStepFunction::analyticalIntegral(Int_t code, const char* rangeName) const
+double RooParametricStepFunction::analyticalIntegral(Int_t /*code*/, const char* rangeName) const
 {
-  R__ASSERT(code==1) ;
-
   // Case without range is trivial: p.d.f is by construction normalized
   if (!rangeName) {
     return 1.0 ;
@@ -210,20 +204,10 @@ double RooParametricStepFunction::evaluate() const
    // in Bin i-1 (starting with Bin 0)
    if (i<_nBins) {
      // not in last Bin
-     RooRealVar* tmp = (RooRealVar*) _coefList.at(i-1);
-     value =  tmp->getVal();
+     value = static_cast<RooRealVar*>(_coefList.at(i-1))->getVal();
      break;
    } else {
-     // in last Bin
-     double sum(0.);
-     double binSize(0.);
-     for (Int_t j=1;j<_nBins;j++){
-       RooRealVar* tmp = (RooRealVar*) _coefList.at(j-1);
-       binSize = _limits[j] - _limits[j-1];
-       sum = sum + tmp->getVal()*binSize;
-     }
-     binSize = _limits[_nBins] - _limits[_nBins-1];
-     value = (1.0 - sum)/binSize;
+     value = lastBinValue();
      if (value<=0.0){
        value = 0.000001;
        //       cout << "RooParametricStepFunction: sum of values gt 1.0 -- beware!!" <<endl;

--- a/roofit/roofit/src/RooStepFunction.cxx
+++ b/roofit/roofit/src/RooStepFunction.cxx
@@ -30,10 +30,11 @@ but a not-normalized function (RooAbsReal)
 
 #include <RooStepFunction.h>
 
-#include <RooRealVar.h>
 #include <RooArgList.h>
+#include <RooCurve.h>
 #include <RooMsgService.h>
 #include <RooMath.h>
+#include <RooRealVar.h>
 
 ClassImp(RooStepFunction);
 
@@ -139,4 +140,23 @@ double RooStepFunction::evaluate() const
     }
     return 0;
   }
+}
+
+
+std::list<double> *RooStepFunction::plotSamplingHint(RooAbsRealLValue &obs, double xlo, double xhi) const
+{
+   if (obs.namePtr() != _x->namePtr()) {
+      return nullptr;
+   }
+
+   // Retrieve position of all bin boundaries
+   std::vector<double> boundaries;
+   boundaries.reserve(_boundaryList.size());
+   for (auto *boundary : static_range_cast<RooAbsReal *>(_boundaryList)) {
+      boundaries.push_back(boundary->getVal());
+   }
+
+   // Use the helper function from RooCurve to make sure to get sampling hints
+   // that work with the RooFitPlotting.
+   return RooCurve::plotSamplingHintForBinBoundaries(boundaries, xlo, xhi);
 }

--- a/roofit/roofit/src/RooStepFunction.cxx
+++ b/roofit/roofit/src/RooStepFunction.cxx
@@ -28,27 +28,14 @@ Note that in contrast to RooParametricStepFunction, a RooStepFunction is NOT a P
 but a not-normalized function (RooAbsReal)
 **/
 
-#include "Riostream.h"
-#include "TArrayD.h"
-#include <cmath>
+#include <RooStepFunction.h>
 
-#include "RooStepFunction.h"
-#include "RooRealVar.h"
-#include "RooArgList.h"
-#include "RooMsgService.h"
-#include "RooMath.h"
-
-using namespace std;
+#include <RooRealVar.h>
+#include <RooArgList.h>
+#include <RooMsgService.h>
+#include <RooMath.h>
 
 ClassImp(RooStepFunction);
-
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor
-
-RooStepFunction::RooStepFunction()
-{
-  _interpolate = false ;
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor
@@ -63,8 +50,8 @@ RooStepFunction::RooStepFunction(const char* name, const char* title,
 {
   for (auto *coef : coefList) {
     if (!dynamic_cast<RooAbsReal*>(coef)) {
-      cout << "RooStepFunction::ctor(" << GetName() << ") ERROR: coefficient " << coef->GetName()
-      << " is not of type RooAbsReal" << endl ;
+      std::cout << "RooStepFunction::ctor(" << GetName() << ") ERROR: coefficient " << coef->GetName()
+      << " is not of type RooAbsReal" << std::endl ;
       assert(0) ;
     }
     _coefList.add(*coef) ;
@@ -72,16 +59,16 @@ RooStepFunction::RooStepFunction(const char* name, const char* title,
 
   for (auto *boundary : boundaryList) {
     if (!dynamic_cast<RooAbsReal*>(boundary)) {
-      cout << "RooStepFunction::ctor(" << GetName() << ") ERROR: boundary " << boundary->GetName()
-      << " is not of type RooAbsReal" << endl ;
+      std::cout << "RooStepFunction::ctor(" << GetName() << ") ERROR: boundary " << boundary->GetName()
+      << " is not of type RooAbsReal" << std::endl;
       assert(0) ;
     }
     _boundaryList.add(*boundary) ;
   }
 
-  if (_boundaryList.getSize()!=_coefList.getSize()+1) {
-    coutE(InputArguments) << "RooStepFunction::ctor(" << GetName() << ") ERROR: Number of boundaries must be number of coefficients plus 1" << endl ;
-    throw string("RooStepFunction::ctor() ERROR: Number of boundaries must be number of coefficients plus 1") ;
+  if (_boundaryList.size()!=_coefList.size()+1) {
+    coutE(InputArguments) << "RooStepFunction::ctor(" << GetName() << ") ERROR: Number of boundaries must be number of coefficients plus 1" << std::endl ;
+    throw std::invalid_argument("RooStepFunction::ctor() ERROR: Number of boundaries must be number of coefficients plus 1") ;
   }
 
 }
@@ -100,12 +87,12 @@ RooStepFunction::RooStepFunction(const RooStepFunction& other, const char* name)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Transfer contents to vector for use below
+/// Transfer contents to std::vector for use below
 
 double RooStepFunction::evaluate() const
 {
-  vector<double> b(_boundaryList.getSize()) ;
-  vector<double> c(_coefList.getSize()+3) ;
+  std::vector<double> b(_boundaryList.size()) ;
+  std::vector<double> c(_coefList.size()+3) ;
   Int_t nb(0) ;
   for (auto * boundary : static_range_cast<RooAbsReal*>(_boundaryList)) {
     b[nb++] = boundary->getVal() ;
@@ -136,7 +123,7 @@ double RooStepFunction::evaluate() const
 
     // Make array of (0,coefficient values,0)
     Int_t nc(0) ;
-    vector<double> y(_coefList.size()+3) ;
+    std::vector<double> y(_coefList.size()+3) ;
     y[nc++] = 0 ;
     for(auto * coef : static_range_cast<RooAbsReal*>(_coefList)) {
       y[nc++] = coef->getVal() ;

--- a/roofit/roofitcore/inc/RooCurve.h
+++ b/roofit/roofitcore/inc/RooCurve.h
@@ -16,11 +16,15 @@
 #ifndef ROO_CURVE
 #define ROO_CURVE
 
-#include "TGraph.h"
-#include "RooPlotable.h"
+#include <RooPlotable.h>
+
+#include <ROOT/RSpan.hxx>
+
+#include <TGraph.h>
+#include <TMatrixDfwd.h>
+
 #include <list>
 #include <vector>
-#include "TMatrixDfwd.h"
 
 class RooAbsReal;
 class RooRealVar;
@@ -71,6 +75,8 @@ public:
   RooCurve* makeErrorBand(const std::vector<RooCurve*>& variations, double Z=1) const ;
   RooCurve* makeErrorBand(const std::vector<RooCurve*>& plusVar, const std::vector<RooCurve*>& minusVar, const TMatrixD& V, double Z=1) const ;
 
+  static std::list<double>* plotSamplingHintForBinBoundaries(std::span<const double> boundaries, double xlo, double xhi);
+
 protected:
 
   void calcBandInterval(const std::vector<RooCurve*>& variations,Int_t i,double Z,double& lo, double& hi, bool approxGauss) const ;
@@ -83,12 +89,19 @@ protected:
        Int_t numee=0, bool doEEVal=false, double eeVal=0.0,std::list<double>* samplingHint=nullptr) ;
   void addRange(const RooAbsFunc& func, double x1, double x2, double y1,
       double y2, double minDy, double minDx,
-      Int_t numee=0, bool doEEVal=false, double eeVal=0.0);
+      int numee, bool doEEVal, double eeVal, double epsilon);
 
 
   void shiftCurveToZero();
 
   bool _showProgress = false; ///<! Show progress indication when adding points
+
+private:
+  /// The distance between two points x1 and x2 relative to the full plot range
+  /// below which two points are considered identical. No further sampling
+  /// points will be added to the curve when the distance between two sampling
+  /// points falls below this threshold.
+  static constexpr double relativeXEpsilon() { return 1e-9; }
 
   ClassDefOverride(RooCurve,1) // 1-dimensional smooth curve for use in RooPlots
 };

--- a/roofit/roofitcore/src/RooHistPdf.cxx
+++ b/roofit/roofitcore/src/RooHistPdf.cxx
@@ -28,6 +28,7 @@ discrete dimensions.
 #include "Riostream.h"
 
 #include "RooHistPdf.h"
+#include "RooCurve.h"
 #include "RooDataHist.h"
 #include "RooMsgService.h"
 #include "RooRealVar.h"
@@ -511,26 +512,11 @@ std::list<double>* RooHistPdf::plotSamplingHint(RooDataHist const& dataHist,
   // Retrieve position of all bin boundaries
 
   const RooAbsBinning* binning = lval->getBinningPtr(nullptr);
-  std::span<double> boundaries{binning->array(), static_cast<std::size_t>(binning->numBoundaries())};
+  std::span<const double> boundaries{binning->array(), static_cast<std::size_t>(binning->numBoundaries())};
 
-  auto hint = new std::list<double> ;
-
-  const double delta = (xhi-xlo)*1e-8 ;
-
-  // Sample points right next to the plot limits
-  hint->push_back(xlo + delta);
-  hint->push_back(xhi - delta);
-
-  // Sample points very close to the left and right of the bin boundaries that
-  // are strictly in between the plot limits.
-  for (const double x : boundaries) {
-    if (x - xlo > delta && xhi - x > delta) {
-      hint->push_back(x - delta);
-      hint->push_back(x + delta);
-    }
-  }
-
-  return hint ;
+  // Use the helper function from RooCurve to make sure to get sampling hints
+  // that work with the RooFitPlotting.
+  return RooCurve::plotSamplingHintForBinBoundaries(boundaries, xlo, xhi);
 }
 
 


### PR DESCRIPTION
The RooFit plotting did not work well for variables of small orders of
magnitude, because there was a hardcoded check with an absolute value to
see if two points are considered the same: `x2 - x1 < 1e-20`. If this
condition is true, the point at x2 was not plotted. This meant that some
points that were actually different were skipped.

The fix is to change this condition to a relative one, considering xmin
and xmax. The code to generate sampling hints for histograms was also
moved inside RooCurve, such that it's easier to syncronize the relevant
magic constants.

Here is a demo of a plot that didn't work before but now works:

```C++
void repro()
{

   int nBins = 4;

   double scale = 1e-31;

   double xmin = 0. * scale;
   double xmax = 1. * scale;
   double binWidth = (xmax - xmin) / nBins;

   // Fill the bin boundaries
   std::vector<double> binBoundaries(nBins + 1);
   for (int i = 0; i <= nBins; ++i) {
      binBoundaries[i] = i * binWidth;
   }

   // The RooParametricStepFunction needs a TArrayD
   TArrayD step_edges{int(binBoundaries.size()), binBoundaries.data()};

   RooRealVar Gamma("Gamma", "Gamma", xmin, xmax);

   RooArgList step_values;
   step_values.addOwned(std::make_unique<RooRealVar>("coef1", "coef1", 0.0 / scale, 0.0, 1.0 / scale));
   step_values.addOwned(std::make_unique<RooRealVar>("coef2", "coef2", 0.1 / scale, 0.0, 1.0 / scale));
   step_values.addOwned(std::make_unique<RooRealVar>("coef3", "coef3", 0.1 / scale, 0.0, 1.0 / scale));

   RooParametricStepFunction prior("prior", "Prior for decay rate", Gamma, step_values, step_edges, nBins);

   RooPlot *xframe = Gamma.frame(xmin, xmax);

   prior.plotOn(xframe);

   auto c1 = new TCanvas();

   xframe->Draw();

   c1->SaveAs("plot.png");
}
```

This bugfix was inspired by the following forum post:
https://root-forum.cern.ch/t/rooparametricstepfunction/55820