### PR TITLE
Backport fixes for Cling tests [v6.28]

### DIFF
--- a/interpreter/cling/lib/Interpreter/IncrementalJIT.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalJIT.cpp
@@ -29,6 +29,10 @@
 #include <llvm/Support/TargetRegistry.h>
 #include <llvm/Target/TargetMachine.h>
 
+#ifdef __linux__
+#include <sys/stat.h>
+#endif
+
 using namespace llvm;
 using namespace llvm::orc;
 
@@ -344,6 +348,32 @@ CreateTargetMachine(const clang::CompilerInstance& CI) {
 
   return cantFail(JTMB.createTargetMachine());
 }
+
+#if defined(__linux__) && defined(__GLIBC__)
+static SymbolMap GetListOfLibcNonsharedSymbols(const LLJIT& Jit) {
+  // Inject a number of symbols that may be in libc_nonshared.a where they are
+  // not found automatically. Before DefinitionGenerators in ORCv2, this used
+  // to be done by RTDyldMemoryManager::getSymbolAddressInProcess See also the
+  // upstream issue https://github.com/llvm/llvm-project/issues/61289.
+
+  static const std::pair<const char*, const void*> NamePtrList[] = {
+      {"stat", (void*)&stat},       {"fstat", (void*)&fstat},
+      {"lstat", (void*)&lstat},     {"stat64", (void*)&stat64},
+      {"fstat64", (void*)&fstat64}, {"lstat64", (void*)&lstat64},
+      {"fstatat", (void*)&fstatat}, {"fstatat64", (void*)&fstatat64},
+      {"mknod", (void*)&mknod},     {"mknodat", (void*)&mknodat},
+  };
+
+  SymbolMap LibcNonsharedSymbols;
+  for (const auto& NamePtr : NamePtrList) {
+    auto Addr = static_cast<JITTargetAddress>(
+        reinterpret_cast<uintptr_t>(NamePtr.second));
+    LibcNonsharedSymbols[Jit.mangleAndIntern(NamePtr.first)] =
+        JITEvaluatedSymbol(Addr, JITSymbolFlags::Exported);
+  }
+  return LibcNonsharedSymbols;
+}
+#endif
 } // unnamed namespace
 
 namespace cling {
@@ -438,6 +468,12 @@ IncrementalJIT::IncrementalJIT(
                                               [&](const SymbolStringPtr &Sym) {
                                   return !m_ForbidDlSymbols.contains(*Sym); });
   Jit->getMainJITDylib().addGenerator(std::move(LibLookup));
+
+#if defined(__linux__) && defined(__GLIBC__)
+  // See comment in ListOfLibcNonsharedSymbols.
+  cantFail(Jit->getMainJITDylib().define(
+      absoluteSymbols(GetListOfLibcNonsharedSymbols(*Jit))));
+#endif
 
   // This replaces llvm::orc::ExecutionSession::logErrorsToStdErr:
   auto&& ErrorReporter = [&Executor, LinkerPrefix, Verbose](Error Err) {

--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -693,7 +693,7 @@ namespace cling {
     CodeGenerator* CG = m_IncrParser->getCodeGenerator();
     ClangInternalState* state = new ClangInternalState(
         getCI()->getASTContext(), getCI()->getPreprocessor(),
-        getLastTransaction()->getModule(), CG, name);
+        getLastTransaction()->getCompiledModule(), CG, name);
     m_StoredStates.push_back(state);
   }
 
@@ -1501,7 +1501,7 @@ namespace cling {
     T.setUnloading();
     // Clear any stored states that reference the llvm::Module.
     // Do it first in case
-    auto Module = T.getModule();
+    const auto *Module = T.getCompiledModule();
     if (Module && !m_StoredStates.empty()) {
       const auto Predicate = [&Module](const ClangInternalState* S) {
         return S->getModule() == Module;

--- a/interpreter/cling/test/CodeUnloading/PCH/VTables.C
+++ b/interpreter/cling/test/CodeUnloading/PCH/VTables.C
@@ -1,7 +1,7 @@
 // RUN: %mkdir "%T/Rel/Path" || true
 // RUN: %rm "CompGen.h.pch" && %rm "%T/Rel/Path/Relative.pch"
-// RUN: clang -x c++-header -fexceptions -fcxx-exceptions -std=c++14 -pthread %S/Inputs/CompGen.h -o CompGen.h.pch
-// RUN: clang -x c++-header -fexceptions -fcxx-exceptions -std=c++14 -pthread %S/Inputs/CompGen.h -o %T/Rel/Path/Relative.pch
+// RUN: clang -x c++-header -fexceptions -fcxx-exceptions -std=%std_cxx -pthread %S/Inputs/CompGen.h -o CompGen.h.pch
+// RUN: clang -x c++-header -fexceptions -fcxx-exceptions -std=%std_cxx -pthread %S/Inputs/CompGen.h -o %T/Rel/Path/Relative.pch
 // RUN: cat %s | %cling -I%p -Xclang -include-pch -Xclang CompGen.h.pch  2>&1 | FileCheck %s
 // RUN: cat %s | %cling -I%p -I%T/Rel/Path -include-pch Relative.pch 2>&1 | FileCheck %s
 

--- a/interpreter/cling/test/lit.cfg
+++ b/interpreter/cling/test/lit.cfg
@@ -88,6 +88,8 @@ config.substitutions.append(('%cling_obj_root', config.cling_obj_root))
 incDir = os.path.join(config.llvm_obj_root, 'tools', 'clang', 'include')
 config.substitutions.append( ('%cling', config.llvm_tools_dir + '/cling --nologo -I%s' % fixupPath(incDir)) )
 
+config.substitutions.append(('%std_cxx', 'c++' + config.cxx_standard))
+
 if platform.system() in ['Windows']:
   config.substitutions.append(('%dllexport', '"__declspec(dllexport)"'))
   config.substitutions.append(('%fPIC', ''))

--- a/interpreter/cling/test/lit.site.cfg.in
+++ b/interpreter/cling/test/lit.site.cfg.in
@@ -8,6 +8,7 @@ config.cling_obj_root = "@CLING_BINARY_DIR@"
 config.target_triple = "@TARGET_TRIPLE@"
 config.host_triple = "@TARGET_TRIPLE@"
 config.shlibext = "@TARGET_SHLIBEXT@"
+config.cxx_standard = "@CMAKE_CXX_STANDARD@"
 
 # Support substitution of the tools and libs dirs with user parameters. This is
 # used when we can't determine the tool dir at configuration time.


### PR DESCRIPTION
This makes `check-cling` clean on `v6-28-00-patches`.