### PR TITLE
Fix an assertion failure on Windows

### DIFF
--- a/tmva/tmva/src/MethodLD.cxx
+++ b/tmva/tmva/src/MethodLD.cxx
@@ -174,7 +174,8 @@ Double_t TMVA::MethodLD::GetMvaValue( Double_t* err, Double_t* errUpper )
       (*fRegressionReturnVal)[iout] = (*(*fLDCoeff)[iout])[0] ;
 
       int icoeff=0;
-      for (std::vector<Float_t>::const_iterator it = ev->GetValues().begin();it!=ev->GetValues().end();++it){
+      std::vector<Float_t> values = ev->GetValues();
+      for (std::vector<Float_t>::const_iterator it = values.begin();it!=values.end();++it) {
          (*fRegressionReturnVal)[iout] += (*(*fLDCoeff)[iout])[++icoeff] * (*it);
       }
    }
@@ -199,7 +200,8 @@ const std::vector< Float_t >& TMVA::MethodLD::GetRegressionValues()
       (*fRegressionReturnVal)[iout] = (*(*fLDCoeff)[iout])[0] ;
 
       int icoeff = 0;
-      for (std::vector<Float_t>::const_iterator it = ev->GetValues().begin();it!=ev->GetValues().end();++it){
+      std::vector<Float_t> values = ev->GetValues();
+      for (std::vector<Float_t>::const_iterator it = values.begin();it!=values.end();++it) {
          (*fRegressionReturnVal)[iout] += (*(*fLDCoeff)[iout])[++icoeff] * (*it);
       }
    }

--- a/tmva/tmva/src/MethodLD.cxx
+++ b/tmva/tmva/src/MethodLD.cxx
@@ -173,10 +173,9 @@ Double_t TMVA::MethodLD::GetMvaValue( Double_t* err, Double_t* errUpper )
    for (Int_t iout = 0; iout<fNRegOut; iout++) {
       (*fRegressionReturnVal)[iout] = (*(*fLDCoeff)[iout])[0] ;
 
-      int icoeff=0;
-      std::vector<Float_t> values = ev->GetValues();
-      for (std::vector<Float_t>::const_iterator it = values.begin();it!=values.end();++it) {
-         (*fRegressionReturnVal)[iout] += (*(*fLDCoeff)[iout])[++icoeff] * (*it);
+      int icoeff = 0;
+      for (auto const& val : ev->GetValues()) {
+         (*fRegressionReturnVal)[iout] += (*(*fLDCoeff)[iout])[++icoeff] * val;
       }
    }
 
@@ -200,9 +199,8 @@ const std::vector< Float_t >& TMVA::MethodLD::GetRegressionValues()
       (*fRegressionReturnVal)[iout] = (*(*fLDCoeff)[iout])[0] ;
 
       int icoeff = 0;
-      std::vector<Float_t> values = ev->GetValues();
-      for (std::vector<Float_t>::const_iterator it = values.begin();it!=values.end();++it) {
-         (*fRegressionReturnVal)[iout] += (*(*fLDCoeff)[iout])[++icoeff] * (*it);
+      for (auto const& val : ev->GetValues()) {
+         (*fRegressionReturnVal)[iout] += (*(*fLDCoeff)[iout])[++icoeff] * val;
       }
    }
 


### PR DESCRIPTION
Fix  a debug assertion failure with `vector iterators incompatible` error on Windows in debug mode.
In `std::vector<Float_t>::const_iterator it = ev->GetValues().begin()`, `it` is initialised to `GetValues().begin()` and is then compared by `!=` to `GetValues().end()`. But `getValue()` returns a vector by value, not by reference, so it returns a copy, which means that every time we call `getValue()`, we get a different vector, so we get incompatible iterators. For the compiler, this does not make any difference. Type safety does not help, two iterators which belong to different container instances have the same type, so the code compiles. At run time, however, additional checks are made to ensure that two iterators that are being compared really belong to the same container object. (As explained [here](https://stackoverflow.com/questions/32978410/debug-assertion-vector-iterators-incompatible-c))
