### PR TITLE
Fix another assertion failure on Windows

### DIFF
--- a/tmva/tmva/inc/TMVA/RTensor.hxx
+++ b/tmva/tmva/inc/TMVA/RTensor.hxx
@@ -228,7 +228,7 @@ public:
       fSize = Internal::GetSizeFromShape(shape);
       fStrides = Internal::ComputeStridesFromShape(shape, layout);
       fContainer = std::make_shared<Container_t>(fSize);
-      fData = &(*fContainer->begin());
+      fData = fContainer->data();
    }
 
    // Access elements

--- a/tmva/tmva/inc/TMVA/RTensor.hxx
+++ b/tmva/tmva/inc/TMVA/RTensor.hxx
@@ -214,7 +214,7 @@ public:
    {
       fSize = Internal::GetSizeFromShape(shape);
       fStrides = Internal::ComputeStridesFromShape(shape, layout);
-      fData = fContainer->data();
+      fData = &(*container->begin());
    }
 
    /// \brief Construct a tensor owning data initialized with new container

--- a/tmva/tmva/inc/TMVA/RTensor.hxx
+++ b/tmva/tmva/inc/TMVA/RTensor.hxx
@@ -214,7 +214,7 @@ public:
    {
       fSize = Internal::GetSizeFromShape(shape);
       fStrides = Internal::ComputeStridesFromShape(shape, layout);
-      fData = &(*container->begin());
+      fData = fContainer->data();
    }
 
    /// \brief Construct a tensor owning data initialized with new container


### PR DESCRIPTION
Fix a debug assertion failure `can't dereference value-initialized vector iterator` 
With and empty vector, `vector::begin() == vector::end()` and one cannot dereference end(), [as explained in the standard](https://en.cppreference.com/w/cpp/container/vector/end):
> end() returns an iterator to the element following the last element of the vector. This element acts as a placeholder; attempting to access it results in undefined behavior.
