### PR TITLE
Fixes an assertion "can't dereference invalidated vector iterator"

### DIFF
--- a/math/minuit2/src/MnContours.cxx
+++ b/math/minuit2/src/MnContours.cxx
@@ -193,8 +193,8 @@ ContoursError MnContours::Contour(unsigned int px, unsigned int py, unsigned int
          result.emplace_back(xmidcr + (aopt)*xdircr, ymidcr + (aopt)*ydircr);
          print.Info(result.back());
       } else {
-         result.insert(idist2, {xmidcr + (aopt)*xdircr, ymidcr + (aopt)*ydircr});
          print.Info(*idist2);
+         result.insert(idist2, {xmidcr + (aopt)*xdircr, ymidcr + (aopt)*ydircr});
       }
    }
 


### PR DESCRIPTION
Print info before inserting a value in the vector (therefore invalidating the iterator). This fixes a debug assertion failure "can't dereference invalidated vector iterator", as explained [in the standard](https://en.cppreference.com/w/cpp/container/vector/insert):
> Causes reallocation if the new size() is greater than the old capacity(). If the new size() is greater than capacity(), all iterators and references are invalidated.
