### PR TITLE
[ntuple] Add chain support for RDF data source

### DIFF
--- a/tree/dataframe/inc/ROOT/RNTupleDS.hxx
+++ b/tree/dataframe/inc/ROOT/RNTupleDS.hxx
@@ -45,29 +45,49 @@ class RNTupleColumnReader;
 }
 
 class RNTupleDS final : public ROOT::RDF::RDataSource {
-   /// Clones of the first source, one for each slot
-   std::vector<std::unique_ptr<ROOT::Experimental::Detail::RPageSource>> fSources;
+   friend class Internal::RNTupleColumnReader;
+
+   /// The PrepareNextRanges() method populates the fNextRanges list with REntryRange records.
+   /// The GetEntryRanges() swaps fNextRanges and fCurrentRanges and uses the list of
+   /// REntryRange records to return the list of ranges ready to use by the RDF loop manager.
+   struct REntryRange {
+      std::unique_ptr<ROOT::Experimental::Detail::RPageSource> fSource;
+      ULong64_t fFirstEntry = 0; ///< First entry index in fSource
+      /// End entry index in fSource, e.g. the number of entries in the range is fLastEntry - fFirstEntry
+      ULong64_t fLastEntry = 0;
+   };
+
+   /// The first source is used to extract the schema and build the prototype fields
+   std::unique_ptr<ROOT::Experimental::Detail::RPageSource> fPrincipalSource;
 
    /// The data source may be constructed with an ntuple name and a list of files
    std::string fNTupleName;
    std::vector<std::string> fFileNames;
-   std::size_t fNextFileIndex = 0;
+   std::size_t fNextFileIndex = 0; ///< Index into fFileNames to the next file to process
 
    /// We prepare a prototype field for every column. If a column reader is actually requested
    /// in GetColumnReaders(), we move a clone of the field into a new column reader for RDataFrame.
    /// Only the clone connects to the backing page store and acquires I/O resources.
-   std::vector<std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>> fFieldPrototypes;
+   /// The field IDs are set in the context of the first source and used as keys in fFieldId2QualifiedName.
+   std::vector<std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>> fProtoFields;
+   /// Connects the IDs of active proto fields and their subfields to their fully qualified name (a.b.c.d).
+   /// This enables the column reader to rewire the field IDs when the file changes (chain),
+   /// using the fully qualified name as a search key in the descriptor of the other page sources.
+   std::unordered_map<ROOT::Experimental::DescriptorId_t, std::string> fFieldId2QualifiedName;
    std::vector<std::string> fColumnNames;
    std::vector<std::string> fColumnTypes;
-   /// List of column readers returned by GetColumnReaders()
-   std::vector<ROOT::Experimental::Internal::RNTupleColumnReader *> fActiveColumnReaders;
-   /// Connects the IDs of active fields and their subfields to their fully qualified name (a.b.c.d).
-   /// This enables us to reset the field IDs when the file changes (chain).
-   std::unordered_map<ROOT::Experimental::DescriptorId_t, std::string> fFieldId2QualifiedName;
+   /// List of column readers returned by GetColumnReaders() organized by slot. Used to reconnect readers
+   /// to new page sources when the files in the chain change.
+   std::vector<std::vector<Internal::RNTupleColumnReader *>> fActiveColumnReaders;
 
-   unsigned fNSlots = 0;
-   bool fHasSeenAllRanges = false;
-   ULong64_t fSeenEntries = 0; ///< The number of entries so far returned by GetEntryRanges()
+   unsigned int fNSlots = 0;
+   ULong64_t fSeenEntries = 0;              ///< The number of entries so far returned by GetEntryRanges()
+   std::vector<REntryRange> fCurrentRanges; ///< Basis for the ranges returned by the last GetEntryRanges() call
+   std::vector<REntryRange> fNextRanges;    ///< Basis for the ranges returned by the next GetEntryRanges() call
+   /// Maps the first entries from the ranges of the last GetEntryRanges() call to their corresponding index in
+   /// the fCurrentRanges vectors.  This is necessary because the returned ranges get distributed arbitrarily
+   /// onto slots.  In the InitSlot method, the column readers use this map to find the correct range to connect to.
+   std::unordered_map<ULong64_t, std::size_t> fFirstEntry2RangeIdx;
 
    /// Provides the RDF column "colName" given the field identified by fieldID. For records and collections,
    /// AddField recurses into the sub fields. The skeinIDs is the list of field IDs of the outer collections
@@ -82,8 +102,11 @@ class RNTupleDS final : public ROOT::RDF::RDataSource {
                  DescriptorId_t fieldId,
                  std::vector<DescriptorId_t> skeinIDs);
 
-   /// Re-attach all active column readers to fFileNames[fNextFileIndex]
-   void SwitchFile();
+   /// Populates fNextRanges with the next set of entry ranges. Opens files from the chain as necessary
+   /// and aligns ranges with cluster boundaries for scheduling the tail of files.
+   /// Upon return, the fNextRanges list is ordered.  It has usually fNSlots elements; fewer if there
+   /// is not enough work to give at least one cluster to every slot.
+   void PrepareNextRanges();
 
 public:
    explicit RNTupleDS(std::unique_ptr<ROOT::Experimental::Detail::RPageSource> pageSource);
@@ -100,6 +123,8 @@ public:
    bool SetEntry(unsigned int slot, ULong64_t entry) final;
 
    void Initialize() final;
+   void InitSlot(unsigned int slot, ULong64_t firstEntry) final;
+   void FinalizeSlot(unsigned int slot) final;
    void Finalize() final;
 
    std::unique_ptr<ROOT::Detail::RDF::RColumnReaderBase>

--- a/tree/dataframe/inc/ROOT/RNTupleDS.hxx
+++ b/tree/dataframe/inc/ROOT/RNTupleDS.hxx
@@ -47,10 +47,10 @@ class RNTupleColumnReader;
 class RNTupleDS final : public ROOT::RDF::RDataSource {
    friend class Internal::RNTupleColumnReader;
 
-   /// The PrepareNextRanges() method populates the fNextRanges list with REntryRange records.
+   /// The PrepareNextRanges() method populates the fNextRanges list with REntryRangeDS records.
    /// The GetEntryRanges() swaps fNextRanges and fCurrentRanges and uses the list of
-   /// REntryRange records to return the list of ranges ready to use by the RDF loop manager.
-   struct REntryRange {
+   /// REntryRangeDS records to return the list of ranges ready to use by the RDF loop manager.
+   struct REntryRangeDS {
       std::unique_ptr<ROOT::Experimental::Detail::RPageSource> fSource;
       ULong64_t fFirstEntry = 0; ///< First entry index in fSource
       /// End entry index in fSource, e.g. the number of entries in the range is fLastEntry - fFirstEntry
@@ -59,7 +59,7 @@ class RNTupleDS final : public ROOT::RDF::RDataSource {
 
    /// The first source is used to extract the schema and build the prototype fields. The page source
    /// is used to extract a clone of the descriptor to fPrincipalDescriptor. Afterwards it is moved
-   /// into the first REntryRange.
+   /// into the first REntryRangeDS.
    std::unique_ptr<Detail::RPageSource> fPrincipalSource;
    /// A clone of the first pages source's descriptor.
    std::unique_ptr<RNTupleDescriptor> fPrincipalDescriptor;
@@ -85,9 +85,9 @@ class RNTupleDS final : public ROOT::RDF::RDataSource {
    std::vector<std::vector<Internal::RNTupleColumnReader *>> fActiveColumnReaders;
 
    unsigned int fNSlots = 0;
-   ULong64_t fSeenEntries = 0;              ///< The number of entries so far returned by GetEntryRanges()
-   std::vector<REntryRange> fCurrentRanges; ///< Basis for the ranges returned by the last GetEntryRanges() call
-   std::vector<REntryRange> fNextRanges;    ///< Basis for the ranges populated by the PrepareNextRanges() call
+   ULong64_t fSeenEntries = 0;                ///< The number of entries so far returned by GetEntryRanges()
+   std::vector<REntryRangeDS> fCurrentRanges; ///< Basis for the ranges returned by the last GetEntryRanges() call
+   std::vector<REntryRangeDS> fNextRanges;    ///< Basis for the ranges populated by the PrepareNextRanges() call
    /// Maps the first entries from the ranges of the last GetEntryRanges() call to their corresponding index in
    /// the fCurrentRanges vectors.  This is necessary because the returned ranges get distributed arbitrarily
    /// onto slots.  In the InitSlot method, the column readers use this map to find the correct range to connect to.

--- a/tree/dataframe/inc/ROOT/RNTupleDS.hxx
+++ b/tree/dataframe/inc/ROOT/RNTupleDS.hxx
@@ -57,8 +57,12 @@ class RNTupleDS final : public ROOT::RDF::RDataSource {
       ULong64_t fLastEntry = 0;
    };
 
-   /// The first source is used to extract the schema and build the prototype fields
-   std::unique_ptr<ROOT::Experimental::Detail::RPageSource> fPrincipalSource;
+   /// The first source is used to extract the schema and build the prototype fields. The page source
+   /// is used to extract a clone of the descriptor to fPrincipalDescriptor. Afterwards it is moved
+   /// into the first REntryRange.
+   std::unique_ptr<Detail::RPageSource> fPrincipalSource;
+   /// A clone of the first pages source's descriptor.
+   std::unique_ptr<RNTupleDescriptor> fPrincipalDescriptor;
 
    /// The data source may be constructed with an ntuple name and a list of files
    std::string fNTupleName;

--- a/tree/dataframe/inc/ROOT/RNTupleDS.hxx
+++ b/tree/dataframe/inc/ROOT/RNTupleDS.hxx
@@ -87,7 +87,7 @@ class RNTupleDS final : public ROOT::RDF::RDataSource {
    unsigned int fNSlots = 0;
    ULong64_t fSeenEntries = 0;              ///< The number of entries so far returned by GetEntryRanges()
    std::vector<REntryRange> fCurrentRanges; ///< Basis for the ranges returned by the last GetEntryRanges() call
-   std::vector<REntryRange> fNextRanges;    ///< Basis for the ranges returned by the next GetEntryRanges() call
+   std::vector<REntryRange> fNextRanges;    ///< Basis for the ranges populated by the PrepareNextRanges() call
    /// Maps the first entries from the ranges of the last GetEntryRanges() call to their corresponding index in
    /// the fCurrentRanges vectors.  This is necessary because the returned ranges get distributed arbitrarily
    /// onto slots.  In the InitSlot method, the column readers use this map to find the correct range to connect to.

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -124,14 +124,14 @@ class RNTupleColumnReader : public ROOT::Detail::RDF::RColumnReaderBase {
    /// For chains, the logical entry and the physical entry in any particular file can be different.
    /// The entry offset stores the logical entry number (sum of all previous physical entries) when a file of the corresponding
    /// data source was opened.
-   ULong64_t fEntryOffset = 0;
+   Long64_t fEntryOffset = 0;
 
 public:
    RNTupleColumnReader(RNTupleDS *ds, RFieldBase *protoField) : fDataSource(ds), fProtoField(protoField) {}
    ~RNTupleColumnReader() = default;
 
    /// Connect the field and its subfields to the page source
-   void Connect(RPageSource &source, ULong64_t entryOffset)
+   void Connect(RPageSource &source, Long64_t entryOffset)
    {
       assert(fLastEntry == -1);
       fEntryOffset = entryOffset;

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -121,7 +121,7 @@ class RNTupleColumnReader : public ROOT::Detail::RDF::RColumnReaderBase {
    void *fValuePtr = nullptr;                  ///< Used to reuse the object created by fValue when reconnecting sources
    Long64_t fLastEntry = -1;                   ///< Last entry number that was read
    /// For chains, the logical entry and the physical entry in any particular file can be different.
-   /// The entry offset stores the logical entry number (sum of all previous entries) when file of the corresponding
+   /// The entry offset stores the logical entry number (sum of all previous physical entries) when a file of the corresponding
    /// data source was opened.
    ULong64_t fEntryOffset = 0;
 

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -25,6 +25,7 @@
 
 #include <TError.h>
 
+#include <cassert>
 #include <string>
 #include <vector>
 #include <typeinfo>
@@ -132,7 +133,7 @@ public:
    /// Connect the field and its subfields to the page source
    void Connect(RPageSource &source, ULong64_t entryOffset)
    {
-      R__ASSERT(fLastEntry == -1);
+      assert(fLastEntry == -1);
       fEntryOffset = entryOffset;
 
       // Create a new, real field from the prototype and set its field ID in the context of the given page source
@@ -344,7 +345,7 @@ bool RNTupleDS::SetEntry(unsigned int, ULong64_t)
 
 void RNTupleDS::PrepareNextRanges()
 {
-   R__ASSERT(fNextRanges.empty());
+   assert(fNextRanges.empty());
    auto nFiles = fFileNames.empty() ? 1 : fFileNames.size();
    auto nRemainingFiles = nFiles - fNextFileIndex;
    if (nRemainingFiles == 0)
@@ -357,7 +358,7 @@ void RNTupleDS::PrepareNextRanges()
 
          if (fPrincipalSource) {
             // Avoid reopening the first file, which has been opened already to read the schema
-            R__ASSERT(fNextFileIndex == 0);
+            assert(fNextFileIndex == 0);
             std::swap(fPrincipalSource, range.fSource);
          } else {
             range.fSource = Detail::RPageSource::Create(fNTupleName, fFileNames[fNextFileIndex]);
@@ -383,7 +384,7 @@ void RNTupleDS::PrepareNextRanges()
       std::unique_ptr<Detail::RPageSource> source;
       if (fPrincipalSource) {
          // Avoid reopening the first file, which has been opened already to read the schema
-         R__ASSERT(fNextFileIndex == 0);
+         assert(fNextFileIndex == 0);
          std::swap(source, fPrincipalSource);
       } else {
          source = Detail::RPageSource::Create(fNTupleName, fFileNames[fNextFileIndex]);
@@ -421,7 +422,7 @@ void RNTupleDS::PrepareNextRanges()
       for (; iSlot < N; ++iSlot) {
          auto start = rangesByCluster[iRange].first;
          iRange += nClustersPerSlot + static_cast<int>(iSlot < remainder);
-         R__ASSERT(iRange > 0);
+         assert(iRange > 0);
          auto end = rangesByCluster[iRange - 1].second;
 
          REntryRangeDS range;
@@ -445,7 +446,7 @@ std::vector<std::pair<ULong64_t, ULong64_t>> RNTupleDS::GetEntryRanges()
    std::vector<std::pair<ULong64_t, ULong64_t>> ranges;
    if (fNextRanges.empty())
       return ranges;
-   R__ASSERT(fNextRanges.size() <= fNSlots);
+   assert(fNextRanges.size() <= fNSlots);
 
    // We need to distinguish between single threaded and multi-threaded runs.
    // In single threaded mode, InitSlot is only called once and column readers have to be rewired
@@ -533,7 +534,7 @@ void RNTupleDS::Initialize()
    fSeenEntries = 0;
    fNextFileIndex = 0;
    if (!fCurrentRanges.empty() && (fFileNames.size() <= fNSlots)) {
-      R__ASSERT(fNextRanges.empty());
+      assert(fNextRanges.empty());
       std::swap(fCurrentRanges, fNextRanges);
       fNextFileIndex = std::max(fFileNames.size(), std::size_t(1));
    } else {
@@ -552,8 +553,8 @@ void RNTupleDS::Finalize()
 
 void RNTupleDS::SetNSlots(unsigned int nSlots)
 {
-   R__ASSERT(fNSlots == 0);
-   R__ASSERT(nSlots > 0);
+   assert(fNSlots == 0);
+   assert(nSlots > 0);
    fNSlots = nSlots;
    fActiveColumnReaders.resize(fNSlots);
 }

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -311,7 +311,7 @@ RNTupleDS::RNTupleDS(std::string_view ntupleName, const std::vector<std::string>
 
 RDF::RDataSource::Record_t RNTupleDS::GetColumnReadersImpl(std::string_view /* name */, const std::type_info & /* ti */)
 {
-   // This datasource uses the GetColumnReaders2 API
+   // This datasource uses the newer GetColumnReaders() API
    return {};
 }
 

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -353,7 +353,7 @@ void RNTupleDS::PrepareNextRanges()
    // Easy work scheduling: one file per slot. We skip empty files (files without entries).
    if (nRemainingFiles >= fNSlots) {
       while ((fNextRanges.size() < fNSlots) && (fNextFileIndex < nFiles)) {
-         REntryRange range;
+         REntryRangeDS range;
 
          if (fPrincipalSource) {
             // Avoid reopening the first file, which has been opened already to read the schema
@@ -424,7 +424,7 @@ void RNTupleDS::PrepareNextRanges()
          R__ASSERT(iRange > 0);
          auto end = rangesByCluster[iRange - 1].second;
 
-         REntryRange range;
+         REntryRangeDS range;
          // The last range for this file just takes the already opened page source. All previous ranges clone.
          if (iSlot == N - 1) {
             range.fSource = std::move(source);
@@ -463,10 +463,10 @@ std::vector<std::pair<ULong64_t, ULong64_t>> RNTupleDS::GetEntryRanges()
    std::swap(fCurrentRanges, fNextRanges);
    PrepareNextRanges();
 
-   // Create ranges for the RDF loop manager from the list of REntryRange records.
-   // The entry ranges that are relative to the page source in REntryRange are translated into absolute
+   // Create ranges for the RDF loop manager from the list of REntryRangeDS records.
+   // The entry ranges that are relative to the page source in REntryRangeDS are translated into absolute
    // entry ranges, given the current state of the entry cursor.
-   // We remember the connection from first absolute entry index of a range to its REntryRange record
+   // We remember the connection from first absolute entry index of a range to its REntryRangeDS record
    // so that we can properly rewire the column reader in InitSlot
    fFirstEntry2RangeIdx.clear();
    ULong64_t nEntriesPerSource = 0;

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -140,6 +140,7 @@ public:
       fField = fProtoField->Clone(fProtoField->GetName());
       {
          auto descGuard = source.GetSharedDescriptorGuard();
+         // Set the on-disk field IDs for the field and the subfield
          fField->SetOnDiskId(
             descGuard->FindFieldId(fDataSource->fFieldId2QualifiedName.at(fProtoField->GetOnDiskId())));
          auto iProto = fProtoField->cbegin();
@@ -154,10 +155,12 @@ public:
          f.ConnectPageSource(source);
 
       if (fValuePtr) {
+         // When the reader reconnects to a new file, the fValuePtr is already set
          fValue = std::make_unique<RFieldBase::RValue>(fField->BindValue(fValuePtr));
          fValue->TakeOwnership();
          fValuePtr = nullptr;
       } else {
+         // For the first file, create a new object for this field (reader)
          fValue = std::make_unique<RFieldBase::RValue>(fField->GenerateValue());
       }
    }

--- a/tree/dataframe/test/datasource_ntuple.cxx
+++ b/tree/dataframe/test/datasource_ntuple.cxx
@@ -151,6 +151,10 @@ static void ChainTest(const std::string &name, const std::string &fname)
    auto df2 = ROOT::RDataFrame(std::make_unique<RNTupleDS>(name, std::vector<std::string>{fname, fname}));
    EXPECT_DOUBLE_EQ(84.0, df2.Sum<float>("pt").GetValue());
 
+   std::vector<std::string> fileNames(1000, fname);
+   auto df1000 = ROOT::RDataFrame(std::make_unique<RNTupleDS>(name, fileNames));
+   EXPECT_DOUBLE_EQ(42000.0, df1000.Sum<float>("pt").GetValue());
+
    class FileRAII {
    private:
       std::string fPath;

--- a/tree/dataframe/test/datasource_ntuple.cxx
+++ b/tree/dataframe/test/datasource_ntuple.cxx
@@ -99,7 +99,8 @@ TEST_F(RNTupleDSTest, CardinalityColumn)
    EXPECT_EQ(3, *max_rvec2);
 }
 
-void ReadTest(const std::string &name, const std::string &fname) {
+static void ReadTest(const std::string &name, const std::string &fname)
+{
    auto df = ROOT::RDF::Experimental::FromRNTuple(name, fname);
 
    auto count = df.Count();
@@ -142,9 +143,74 @@ void ReadTest(const std::string &name, const std::string &fname) {
    EXPECT_FLOAT_EQ(2. * 137.0, sumVecElectronPt.GetValue());
 }
 
+static void ChainTest(const std::string &name, const std::string &fname)
+{
+   auto df1 = ROOT::RDataFrame(std::make_unique<RNTupleDS>(name, std::vector<std::string>{fname}));
+   EXPECT_DOUBLE_EQ(42.0, df1.Sum<float>("pt").GetValue());
+
+   auto df2 = ROOT::RDataFrame(std::make_unique<RNTupleDS>(name, std::vector<std::string>{fname, fname}));
+   EXPECT_DOUBLE_EQ(84.0, df2.Sum<float>("pt").GetValue());
+
+   class FileRAII {
+   private:
+      std::string fPath;
+
+   public:
+      explicit FileRAII(const std::string &path) : fPath(path) {}
+      FileRAII(const FileRAII &) = delete;
+      FileRAII &operator=(const FileRAII &) = delete;
+      ~FileRAII() { std::remove(fPath.c_str()); }
+      std::string GetPath() const { return fPath; }
+   };
+
+   FileRAII guardFile1("RNTupleDS_test_chain_1.root");
+   FileRAII guardFile2("RNTupleDS_test_chain_2.root");
+   FileRAII guardFile3("RNTupleDS_test_chain_3.root");
+
+   {
+      auto model = RNTupleModel::Create();
+      auto fldElectron = model->MakeField<Electron>("e");
+      auto writer = RNTupleWriter::Recreate(std::move(model), "chain", guardFile1.GetPath());
+      fldElectron->pt = 1.0;
+      writer->Fill();
+   }
+   {
+      auto model = RNTupleModel::Create();
+      // Add dummy field to ensure that the Electron fields in the files have different field IDs
+      model->MakeField<int>("dummy1");
+      auto fldElectron = model->MakeField<Electron>("e");
+      auto writer = RNTupleWriter::Recreate(std::move(model), "chain", guardFile2.GetPath());
+      // empty file in chain, no entries
+   }
+   {
+      auto model = RNTupleModel::Create();
+      model->MakeField<int>("dummy1");
+      model->MakeField<int>("dummy2");
+      auto fldElectron = model->MakeField<Electron>("e");
+      auto writer = RNTupleWriter::Recreate(std::move(model), "chain", guardFile3.GetPath());
+      fldElectron->pt = 2.0;
+      writer->Fill();
+      fldElectron->pt = 3.0;
+      writer->Fill();
+   }
+
+   auto df3 = ROOT::RDataFrame(std::make_unique<RNTupleDS>(
+      "chain", std::vector<std::string>{guardFile1.GetPath(), guardFile2.GetPath(), guardFile3.GetPath()}));
+   auto sumElectronPt =
+      df3.Aggregate([](float &acc, const Electron &e) { acc += e.pt; }, [](float a, float b) { return a + b; }, "e");
+   EXPECT_FLOAT_EQ(6.0, sumElectronPt.GetValue());
+   // Trigger the event loop again
+   EXPECT_FLOAT_EQ(6.0, sumElectronPt.GetValue());
+}
+
 TEST_F(RNTupleDSTest, Read)
 {
    ReadTest(fNtplName, fFileName);
+}
+
+TEST_F(RNTupleDSTest, Chain)
+{
+   ChainTest(fNtplName, fFileName);
 }
 
 #ifdef R__USE_IMT
@@ -158,5 +224,12 @@ TEST_F(RNTupleDSTest, ReadMT)
    IMTRAII _;
 
    ReadTest(fNtplName, fFileName);
+}
+
+TEST_F(RNTupleDSTest, ChainMT)
+{
+   IMTRAII _;
+
+   ChainTest(fNtplName, fFileName);
 }
 #endif

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -181,6 +181,7 @@ public:
          std::swap(result, fObjPtr);
          return static_cast<T *>(result);
       }
+      void TakeOwnership() { fIsOwning = true; }
 
       std::size_t Append() { return fField->Append(fObjPtr); }
       void Read(NTupleSize_t globalIndex) { fField->Read(globalIndex, fObjPtr); }


### PR DESCRIPTION
Adds a new constructor to the RNTuple RDF data source that takes an ntuple name and a list of files. The data source then treats these files as a chain.

Slightly simplifies the prototype construction in the RNTuple data source: instead of constructing full column reader prototypes, only the corresponding field prototypes are constructed.

Multi-threaded work scheduling is as follows:

- As long as there are more files than slots: every slots get a file
- For the tail: slots get distributed over the remaining files and align on cluster boundaries

Some optimizations for follow-up PRs:

- Load the next ranges in the background. In particular that would open the next batch of files in the backgound
- Clone page sources without reopening the file
- The next set of ranges currently gives up to number of slots ranges. However, it would make more sense to use resource constraints such as available memory or number of open file descriptors as a limit and let slots work on more ranges at a time.