### PR TITLE
Add missing includes

### DIFF
--- a/tutorials/v7/ntuple/ntpl007_mtFill.C
+++ b/tutorials/v7/ntuple/ntpl007_mtFill.C
@@ -23,7 +23,10 @@ R__LOAD_LIBRARY(ROOTNTuple)
 
 #include <TCanvas.h>
 #include <TH1F.h>
+#include <TH2F.h>
 #include <TRandom.h>
+#include <TRandom3.h>
+#include <TStyle.h>
 #include <TSystem.h>
 
 #include <atomic>


### PR DESCRIPTION
Add several missing includes, possibly fixing a crash on Windows (x64)