### PR TITLE
[ntuple] Add more field-related inspector functions 

### DIFF
--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -25,6 +25,7 @@
 #include <cstdlib>
 #include <memory>
 #include <vector>
+#include <regex>
 
 namespace ROOT {
 namespace Experimental {
@@ -159,9 +160,10 @@ public:
    const RFieldTreeInfo &GetFieldTreeInfo(DescriptorId_t fieldId) const;
    const RFieldTreeInfo &GetFieldTreeInfo(std::string_view fieldName) const;
 
-   /// Get the number of fields of a given type or class present in the RNTuple.
-   /// TODO: Add regex support.
-   size_t GetFieldTypeCount(std::string_view typeName, bool includeSubFields = true) const;
+   /// Get the number of fields of a given type or class present in the RNTuple. The type name may contain regular
+   /// expression patterns in order to be able to group multiple kinds of types or classes.
+   size_t GetFieldTypeCount(const std::regex &typeNamePattern, bool includeSubFields = true) const;
+   size_t GetFieldTypeCount(std::string_view typeNamePattern, bool includeSubFields = true) const;
 
    /// Get the number of columns of a given type present in the RNTuple.
    size_t GetColumnTypeCount(EColumnType colType) const;

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -167,6 +167,14 @@ public:
 
    /// Get the number of columns of a given type present in the RNTuple.
    size_t GetColumnTypeCount(EColumnType colType) const;
+
+   /// Get the IDs of (sub-)fields whose name matches the given string. Because field names are unique by design,
+   /// providing a single field name will return a vector containing just the ID of that field. However, regular
+   /// expression patterns are supported in order to get the IDs of all fields whose name follow a certain structure.
+   const std::vector<DescriptorId_t>
+   GetFieldsByName(const std::regex &fieldNamePattern, bool includeSubFields = true) const;
+   const std::vector<DescriptorId_t>
+   GetFieldsByName(std::string_view fieldNamePattern, bool includeSubFields = true) const;
 };
 } // namespace Experimental
 } // namespace ROOT

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -162,10 +162,10 @@ public:
 
    /// Get the number of fields of a given type or class present in the RNTuple. The type name may contain regular
    /// expression patterns in order to be able to group multiple kinds of types or classes.
-   size_t GetFieldTypeCount(const std::regex &typeNamePattern, bool includeSubFields = true) const;
-   size_t GetFieldTypeCount(std::string_view typeNamePattern, bool includeSubFields = true) const
+   size_t GetFieldTypeCount(const std::regex &typeNamePattern, bool searchInSubFields = true) const;
+   size_t GetFieldTypeCount(std::string_view typeNamePattern, bool searchInSubFields = true) const
    {
-      return GetFieldTypeCount(std::regex{std::string(typeNamePattern)}, includeSubFields);
+      return GetFieldTypeCount(std::regex{std::string(typeNamePattern)}, searchInSubFields);
    }
 
    /// Get the number of columns of a given type present in the RNTuple.
@@ -175,10 +175,10 @@ public:
    /// providing a single field name will return a vector containing just the ID of that field. However, regular
    /// expression patterns are supported in order to get the IDs of all fields whose name follow a certain structure.
    const std::vector<DescriptorId_t>
-   GetFieldsByName(const std::regex &fieldNamePattern, bool includeSubFields = true) const;
-   const std::vector<DescriptorId_t> GetFieldsByName(std::string_view fieldNamePattern, bool includeSubFields = true)
+   GetFieldsByName(const std::regex &fieldNamePattern, bool searchInSubFields = true) const;
+   const std::vector<DescriptorId_t> GetFieldsByName(std::string_view fieldNamePattern, bool searchInSubFields = true)
    {
-      return GetFieldsByName(std::regex{std::string(fieldNamePattern)}, includeSubFields);
+      return GetFieldsByName(std::regex{std::string(fieldNamePattern)}, searchInSubFields);
    }
 };
 } // namespace Experimental

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -163,7 +163,10 @@ public:
    /// Get the number of fields of a given type or class present in the RNTuple. The type name may contain regular
    /// expression patterns in order to be able to group multiple kinds of types or classes.
    size_t GetFieldTypeCount(const std::regex &typeNamePattern, bool includeSubFields = true) const;
-   size_t GetFieldTypeCount(std::string_view typeNamePattern, bool includeSubFields = true) const;
+   size_t GetFieldTypeCount(std::string_view typeNamePattern, bool includeSubFields = true) const
+   {
+      return GetFieldTypeCount(std::regex{std::string(typeNamePattern)}, includeSubFields);
+   }
 
    /// Get the number of columns of a given type present in the RNTuple.
    size_t GetColumnTypeCount(EColumnType colType) const;
@@ -173,8 +176,10 @@ public:
    /// expression patterns are supported in order to get the IDs of all fields whose name follow a certain structure.
    const std::vector<DescriptorId_t>
    GetFieldsByName(const std::regex &fieldNamePattern, bool includeSubFields = true) const;
-   const std::vector<DescriptorId_t>
-   GetFieldsByName(std::string_view fieldNamePattern, bool includeSubFields = true) const;
+   const std::vector<DescriptorId_t> GetFieldsByName(std::string_view fieldNamePattern, bool includeSubFields = true)
+   {
+      return GetFieldsByName(std::regex{std::string(fieldNamePattern)}, includeSubFields);
+   }
 };
 } // namespace Experimental
 } // namespace ROOT

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -194,12 +194,6 @@ ROOT::Experimental::RNTupleInspector::GetFieldTypeCount(const std::regex &typeNa
    return typeCount;
 }
 
-size_t
-ROOT::Experimental::RNTupleInspector::GetFieldTypeCount(std::string_view typeNamePattern, bool includeSubFields) const
-{
-   return GetFieldTypeCount(std::regex{std::string(typeNamePattern)}, includeSubFields);
-}
-
 size_t ROOT::Experimental::RNTupleInspector::GetColumnTypeCount(ROOT::Experimental::EColumnType colType) const
 {
    size_t typeCount = 0;
@@ -262,10 +256,4 @@ ROOT::Experimental::RNTupleInspector::GetFieldsByName(const std::regex &fieldNam
    }
 
    return fieldIds;
-}
-
-const std::vector<ROOT::Experimental::DescriptorId_t>
-ROOT::Experimental::RNTupleInspector::GetFieldsByName(std::string_view fieldNamePattern, bool includeSubFields) const
-{
-   return GetFieldsByName(std::regex{std::string(fieldNamePattern)}, includeSubFields);
 }

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -244,3 +244,28 @@ ROOT::Experimental::RNTupleInspector::GetFieldTreeInfo(std::string_view fieldNam
 
    return GetFieldTreeInfo(fieldId);
 }
+
+const std::vector<ROOT::Experimental::DescriptorId_t>
+ROOT::Experimental::RNTupleInspector::GetFieldsByName(const std::regex &fieldNamePattern, bool includeSubFields) const
+{
+   std::vector<DescriptorId_t> fieldIds;
+
+   for (auto &[fldId, fldInfo] : fFieldTreeInfo) {
+
+      if (!includeSubFields && fldInfo.GetDescriptor().GetParentId() != fDescriptor->GetFieldZeroId()) {
+         continue;
+      }
+
+      if (std::regex_match(fldInfo.GetDescriptor().GetFieldName(), fieldNamePattern)) {
+         fieldIds.emplace_back(fldId);
+      }
+   }
+
+   return fieldIds;
+}
+
+const std::vector<ROOT::Experimental::DescriptorId_t>
+ROOT::Experimental::RNTupleInspector::GetFieldsByName(std::string_view fieldNamePattern, bool includeSubFields) const
+{
+   return GetFieldsByName(std::regex{std::string(fieldNamePattern)}, includeSubFields);
+}

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -177,12 +177,12 @@ ROOT::Experimental::RNTupleInspector::Create(std::string_view ntupleName, std::s
 }
 
 size_t
-ROOT::Experimental::RNTupleInspector::GetFieldTypeCount(const std::regex &typeNamePattern, bool includeSubFields) const
+ROOT::Experimental::RNTupleInspector::GetFieldTypeCount(const std::regex &typeNamePattern, bool searchInSubFields) const
 {
    size_t typeCount = 0;
 
    for (auto &[fldId, fldInfo] : fFieldTreeInfo) {
-      if (!includeSubFields && fldInfo.GetDescriptor().GetParentId() != fDescriptor->GetFieldZeroId()) {
+      if (!searchInSubFields && fldInfo.GetDescriptor().GetParentId() != fDescriptor->GetFieldZeroId()) {
          continue;
       }
 
@@ -240,13 +240,13 @@ ROOT::Experimental::RNTupleInspector::GetFieldTreeInfo(std::string_view fieldNam
 }
 
 const std::vector<ROOT::Experimental::DescriptorId_t>
-ROOT::Experimental::RNTupleInspector::GetFieldsByName(const std::regex &fieldNamePattern, bool includeSubFields) const
+ROOT::Experimental::RNTupleInspector::GetFieldsByName(const std::regex &fieldNamePattern, bool searchInSubFields) const
 {
    std::vector<DescriptorId_t> fieldIds;
 
    for (auto &[fldId, fldInfo] : fFieldTreeInfo) {
 
-      if (!includeSubFields && fldInfo.GetDescriptor().GetParentId() != fDescriptor->GetFieldZeroId()) {
+      if (!searchInSubFields && fldInfo.GetDescriptor().GetParentId() != fDescriptor->GetFieldZeroId()) {
          continue;
       }
 

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -176,7 +176,8 @@ ROOT::Experimental::RNTupleInspector::Create(std::string_view ntupleName, std::s
    return inspector;
 }
 
-size_t ROOT::Experimental::RNTupleInspector::GetFieldTypeCount(std::string_view typeName, bool includeSubFields) const
+size_t
+ROOT::Experimental::RNTupleInspector::GetFieldTypeCount(const std::regex &typeNamePattern, bool includeSubFields) const
 {
    size_t typeCount = 0;
 
@@ -185,12 +186,18 @@ size_t ROOT::Experimental::RNTupleInspector::GetFieldTypeCount(std::string_view 
          continue;
       }
 
-      if (typeName == fldInfo.GetDescriptor().GetTypeName()) {
+      if (std::regex_match(fldInfo.GetDescriptor().GetTypeName(), typeNamePattern)) {
          typeCount++;
       }
    }
 
    return typeCount;
+}
+
+size_t
+ROOT::Experimental::RNTupleInspector::GetFieldTypeCount(std::string_view typeNamePattern, bool includeSubFields) const
+{
+   return GetFieldTypeCount(std::regex{std::string(typeNamePattern)}, includeSubFields);
 }
 
 size_t ROOT::Experimental::RNTupleInspector::GetColumnTypeCount(ROOT::Experimental::EColumnType colType) const

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -224,6 +224,9 @@ TEST(RNTupleInspector, FieldTypeCount)
    EXPECT_EQ(1, inspector->GetFieldTypeCount("std::vector<HitUtil>"));
    EXPECT_EQ(0, inspector->GetFieldTypeCount("std::vector<HitUtil>", false));
 
+   EXPECT_EQ(2, inspector->GetFieldTypeCount("std::vector<.*>"));
+   EXPECT_EQ(0, inspector->GetFieldTypeCount("std::vector<.*>", false));
+
    EXPECT_EQ(3, inspector->GetFieldTypeCount("BaseUtil"));
    EXPECT_EQ(0, inspector->GetFieldTypeCount("BaseUtil", false));
 


### PR DESCRIPTION
With this PR, a new method `GetFieldsByName` is added to the `RNTupleInspector` and the option to get the number of fields whose type matches a certain regular expression is added. The first is useful for RNTuples where field names have certain semantic meaning (e.g. `.*AuxDyn`). The second can be used to group certain templated types (e.g. `std::vector<.*>`).

These additions are also in anticipation of a larger PR that will add functionality to get more complete statistics about a set of fields (and columns).

