### PR TITLE
[ntuple] Rename of RFieldBase internal methods

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -314,8 +314,11 @@ protected:
 
    /// Allow derived classes to call Append and Read on other (sub) fields.
    static std::size_t CallAppendOn(RFieldBase &other, const void *from) { return other.Append(from); }
-   static void ReadBy(RFieldBase &other, const RClusterIndex &clusterIndex, void *to) { other.Read(clusterIndex, to); }
-   static void ReadBy(RFieldBase &other, NTupleSize_t globalIndex, void *to) { other.Read(globalIndex, to); }
+   static void CallReadOn(RFieldBase &other, const RClusterIndex &clusterIndex, void *to)
+   {
+      other.Read(clusterIndex, to);
+   }
+   static void CallReadOn(RFieldBase &other, NTupleSize_t globalIndex, void *to) { other.Read(globalIndex, to); }
 
    /// Set a user-defined function to be called after reading a value, giving a chance to inspect and/or modify the
    /// value object.
@@ -580,7 +583,7 @@ protected:
    void GenerateValue(void *where) const final { CallGenerateValueOn(*fSubFields[0], where); }
 
    std::size_t AppendImpl(const void *from) final { return CallAppendOn(*fSubFields[0], from); }
-   void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final { ReadBy(*fSubFields[0], globalIndex, to); }
+   void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final { CallReadOn(*fSubFields[0], globalIndex, to); }
 
 public:
    REnumField(std::string_view fieldName, std::string_view enumName);
@@ -2064,7 +2067,7 @@ protected:
       fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &nItems);
       typedValue->resize(nItems);
       for (unsigned i = 0; i < nItems; ++i) {
-         ReadBy(*fSubFields[0], collectionStart + i, &typedValue->data()[i]);
+         CallReadOn(*fSubFields[0], collectionStart + i, &typedValue->data()[i]);
       }
    }
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -257,7 +257,7 @@ protected:
    /// This implementation works for types with a trivial destructor and should be overwritten otherwise.
    virtual void DestroyValue(void *objPtr, bool dtorOnly = false) const;
    /// Allow derived classes to call GenerateValue(void *) and DestroyValue on other (sub) fields.
-   static void GenerateValueBy(const RFieldBase &other, void *where) { other.GenerateValue(where); }
+   static void CallGenerateValueOn(const RFieldBase &other, void *where) { other.GenerateValue(where); }
    static void DestroyValueBy(const RFieldBase &other, void *objPtr, bool dtorOnly = false)
    {
       other.DestroyValue(objPtr, dtorOnly);
@@ -577,7 +577,7 @@ protected:
    void GenerateColumnsImpl() final {}
    void GenerateColumnsImpl(const RNTupleDescriptor & /* desc */) final {}
 
-   void GenerateValue(void *where) const final { GenerateValueBy(*fSubFields[0], where); }
+   void GenerateValue(void *where) const final { CallGenerateValueOn(*fSubFields[0], where); }
 
    std::size_t AppendImpl(const void *from) final { return AppendBy(*fSubFields[0], from); }
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final { ReadBy(*fSubFields[0], globalIndex, to); }

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -313,7 +313,7 @@ protected:
    }
 
    /// Allow derived classes to call Append and Read on other (sub) fields.
-   static std::size_t AppendBy(RFieldBase &other, const void *from) { return other.Append(from); }
+   static std::size_t CallAppendOn(RFieldBase &other, const void *from) { return other.Append(from); }
    static void ReadBy(RFieldBase &other, const RClusterIndex &clusterIndex, void *to) { other.Read(clusterIndex, to); }
    static void ReadBy(RFieldBase &other, NTupleSize_t globalIndex, void *to) { other.Read(globalIndex, to); }
 
@@ -579,7 +579,7 @@ protected:
 
    void GenerateValue(void *where) const final { CallGenerateValueOn(*fSubFields[0], where); }
 
-   std::size_t AppendImpl(const void *from) final { return AppendBy(*fSubFields[0], from); }
+   std::size_t AppendImpl(const void *from) final { return CallAppendOn(*fSubFields[0], from); }
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final { ReadBy(*fSubFields[0], globalIndex, to); }
 
 public:
@@ -2050,7 +2050,7 @@ protected:
       auto nbytes = 0;
       auto count = typedValue->size();
       for (unsigned i = 0; i < count; ++i) {
-         nbytes += AppendBy(*fSubFields[0], &typedValue->data()[i]);
+         nbytes += CallAppendOn(*fSubFields[0], &typedValue->data()[i]);
       }
       this->fNWritten += count;
       fColumns[0]->Append(&this->fNWritten);

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -258,7 +258,7 @@ protected:
    virtual void DestroyValue(void *objPtr, bool dtorOnly = false) const;
    /// Allow derived classes to call GenerateValue(void *) and DestroyValue on other (sub) fields.
    static void CallGenerateValueOn(const RFieldBase &other, void *where) { other.GenerateValue(where); }
-   static void DestroyValueBy(const RFieldBase &other, void *objPtr, bool dtorOnly = false)
+   static void CallDestroyValueOn(const RFieldBase &other, void *objPtr, bool dtorOnly = false)
    {
       other.DestroyValue(objPtr, dtorOnly);
    }

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1213,7 +1213,7 @@ std::size_t ROOT::Experimental::RClassField::AppendImpl(const void *from)
 {
    std::size_t nbytes = 0;
    for (unsigned i = 0; i < fSubFields.size(); i++) {
-      nbytes += AppendBy(*fSubFields[i], static_cast<const unsigned char *>(from) + fSubFieldsInfo[i].fOffset);
+      nbytes += CallAppendOn(*fSubFields[i], static_cast<const unsigned char *>(from) + fSubFieldsInfo[i].fOffset);
    }
    return nbytes;
 }
@@ -1446,7 +1446,7 @@ std::size_t ROOT::Experimental::RCollectionClassField::AppendImpl(const void *fr
    TVirtualCollectionProxy::TPushPop RAII(fProxy.get(), const_cast<void *>(from));
    for (auto ptr : RCollectionIterableOnce{const_cast<void *>(from), fIFuncsWrite, fProxy.get(),
                                            (fCollectionType == kSTLvector ? fItemSize : 0U)}) {
-      nbytes += AppendBy(*fSubFields[0], ptr);
+      nbytes += CallAppendOn(*fSubFields[0], ptr);
       count++;
    }
 
@@ -1598,7 +1598,7 @@ std::size_t ROOT::Experimental::RRecordField::AppendImpl(const void *from)
 {
    std::size_t nbytes = 0;
    for (unsigned i = 0; i < fSubFields.size(); ++i) {
-      nbytes += AppendBy(*fSubFields[i], static_cast<const unsigned char *>(from) + fOffsets[i]);
+      nbytes += CallAppendOn(*fSubFields[i], static_cast<const unsigned char *>(from) + fOffsets[i]);
    }
    return nbytes;
 }
@@ -1674,7 +1674,7 @@ std::size_t ROOT::Experimental::RVectorField::AppendImpl(const void *from)
    std::size_t nbytes = 0;
    auto count = typedValue->size() / fItemSize;
    for (unsigned i = 0; i < count; ++i) {
-      nbytes += AppendBy(*fSubFields[0], typedValue->data() + (i * fItemSize));
+      nbytes += CallAppendOn(*fSubFields[0], typedValue->data() + (i * fItemSize));
    }
    fNWritten += count;
    fColumns[0]->Append(&fNWritten);
@@ -1799,7 +1799,7 @@ std::size_t ROOT::Experimental::RRVecField::AppendImpl(const void *from)
    std::size_t nbytes = 0;
    auto begin = reinterpret_cast<const char *>(*beginPtr); // for pointer arithmetics
    for (std::int32_t i = 0; i < *sizePtr; ++i) {
-      nbytes += AppendBy(*fSubFields[0], begin + i * fItemSize);
+      nbytes += CallAppendOn(*fSubFields[0], begin + i * fItemSize);
    }
 
    fNWritten += *sizePtr;
@@ -2027,7 +2027,7 @@ std::size_t ROOT::Experimental::RField<std::vector<bool>>::AppendImpl(const void
    auto count = typedValue->size();
    for (unsigned i = 0; i < count; ++i) {
       bool bval = (*typedValue)[i];
-      AppendBy(*fSubFields[0], &bval);
+      CallAppendOn(*fSubFields[0], &bval);
    }
    fNWritten += count;
    fColumns[0]->Append(&fNWritten);
@@ -2126,7 +2126,7 @@ std::size_t ROOT::Experimental::RArrayField::AppendImpl(const void *from)
    std::size_t nbytes = 0;
    auto arrayPtr = static_cast<const unsigned char *>(from);
    for (unsigned i = 0; i < fArrayLength; ++i) {
-      nbytes += AppendBy(*fSubFields[0], arrayPtr + (i * fItemSize));
+      nbytes += CallAppendOn(*fSubFields[0], arrayPtr + (i * fItemSize));
    }
    return nbytes;
 }
@@ -2308,7 +2308,7 @@ std::size_t ROOT::Experimental::RVariantField::AppendImpl(const void *from)
    std::size_t nbytes = 0;
    auto index = 0;
    if (tag > 0) {
-      nbytes += AppendBy(*fSubFields[tag - 1], from);
+      nbytes += CallAppendOn(*fSubFields[tag - 1], from);
       index = fNWritten[tag - 1]++;
    }
    RColumnSwitch varSwitch(ClusterSize_t(index), tag);
@@ -2424,7 +2424,7 @@ std::size_t ROOT::Experimental::RNullableField::AppendNull()
    if (IsDense()) {
       bool mask = false;
       fPrincipalColumn->Append(&mask);
-      return 1 + AppendBy(*fSubFields[0], fDefaultItemValue->GetRawPtr());
+      return 1 + CallAppendOn(*fSubFields[0], fDefaultItemValue->GetRawPtr());
    } else {
       fPrincipalColumn->Append(&fNWritten);
       return sizeof(ClusterSize_t);
@@ -2433,7 +2433,7 @@ std::size_t ROOT::Experimental::RNullableField::AppendNull()
 
 std::size_t ROOT::Experimental::RNullableField::AppendValue(const void *from)
 {
-   auto nbytesItem = AppendBy(*fSubFields[0], from);
+   auto nbytesItem = CallAppendOn(*fSubFields[0], from);
    if (IsDense()) {
       bool mask = true;
       fPrincipalColumn->Append(&mask);

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1620,7 +1620,7 @@ void ROOT::Experimental::RRecordField::ReadInClusterImpl(const RClusterIndex &cl
 void ROOT::Experimental::RRecordField::GenerateValue(void *where) const
 {
    for (unsigned i = 0; i < fSubFields.size(); ++i) {
-      GenerateValueBy(*fSubFields[i], static_cast<unsigned char *>(where) + fOffsets[i]);
+      CallGenerateValueOn(*fSubFields[i], static_cast<unsigned char *>(where) + fOffsets[i]);
    }
 }
 
@@ -1705,7 +1705,7 @@ void ROOT::Experimental::RVectorField::ReadGlobalImpl(NTupleSize_t globalIndex, 
       typedValue->resize(nItems * fItemSize);
       if (!(fSubFields[0]->GetTraits() & kTraitTriviallyConstructible)) {
          for (std::size_t i = allDeallocated ? 0 : oldNItems; i < nItems; ++i) {
-            GenerateValueBy(*fSubFields[0], typedValue->data() + (i * fItemSize));
+            CallGenerateValueOn(*fSubFields[0], typedValue->data() + (i * fItemSize));
          }
       }
    }
@@ -1855,7 +1855,7 @@ void ROOT::Experimental::RRVecField::ReadGlobalImpl(NTupleSize_t globalIndex, vo
       // Placement new for elements that were already there before the resize
       if (needsConstruct) {
          for (std::size_t i = 0u; i < oldSize; ++i)
-            GenerateValueBy(*fSubFields[0], begin + (i * fItemSize));
+            CallGenerateValueOn(*fSubFields[0], begin + (i * fItemSize));
       }
    }
    *sizePtr = nItems;
@@ -1863,7 +1863,7 @@ void ROOT::Experimental::RRVecField::ReadGlobalImpl(NTupleSize_t globalIndex, vo
    // Placement new for new elements, if any
    if (needsConstruct) {
       for (std::size_t i = oldSize; i < nItems; ++i)
-         GenerateValueBy(*fSubFields[0], begin + (i * fItemSize));
+         CallGenerateValueOn(*fSubFields[0], begin + (i * fItemSize));
    }
 
    // Read the new values into the collection elements
@@ -2155,7 +2155,7 @@ void ROOT::Experimental::RArrayField::GenerateValue(void *where) const
 
    auto arrayPtr = reinterpret_cast<unsigned char *>(where);
    for (unsigned i = 0; i < fArrayLength; ++i) {
-      GenerateValueBy(*fSubFields[0], arrayPtr + (i * fItemSize));
+      CallGenerateValueOn(*fSubFields[0], arrayPtr + (i * fItemSize));
    }
 }
 
@@ -2326,7 +2326,7 @@ void ROOT::Experimental::RVariantField::ReadGlobalImpl(NTupleSize_t globalIndex,
    // the type list.  This happens, e.g., if the field was late added; in this case, keep the invalid tag, which makes
    // any `std::holds_alternative<T>` check fail later.
    if (R__likely(tag > 0)) {
-      GenerateValueBy(*fSubFields[tag - 1], to);
+      CallGenerateValueOn(*fSubFields[tag - 1], to);
       ReadBy(*fSubFields[tag - 1], variantIndex, to);
    }
    SetTag(to, tag);
@@ -2353,7 +2353,7 @@ void ROOT::Experimental::RVariantField::GenerateColumnsImpl(const RNTupleDescrip
 void ROOT::Experimental::RVariantField::GenerateValue(void *where) const
 {
    memset(where, 0, GetValueSize());
-   GenerateValueBy(*fSubFields[0], where);
+   CallGenerateValueOn(*fSubFields[0], where);
    SetTag(where, 1);
 }
 
@@ -2512,7 +2512,7 @@ void ROOT::Experimental::RUniquePtrField::ReadGlobalImpl(NTupleSize_t globalInde
 
    if (!isValidValue) {
       valuePtr = malloc(fSubFields[0]->GetValueSize());
-      GenerateValueBy(*fSubFields[0], valuePtr);
+      CallGenerateValueOn(*fSubFields[0], valuePtr);
       ptr->reset(reinterpret_cast<char *>(valuePtr));
    }
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1221,14 +1221,14 @@ std::size_t ROOT::Experimental::RClassField::AppendImpl(const void *from)
 void ROOT::Experimental::RClassField::ReadGlobalImpl(NTupleSize_t globalIndex, void *to)
 {
    for (unsigned i = 0; i < fSubFields.size(); i++) {
-      ReadBy(*fSubFields[i], globalIndex, static_cast<unsigned char *>(to) + fSubFieldsInfo[i].fOffset);
+      CallReadOn(*fSubFields[i], globalIndex, static_cast<unsigned char *>(to) + fSubFieldsInfo[i].fOffset);
    }
 }
 
 void ROOT::Experimental::RClassField::ReadInClusterImpl(const RClusterIndex &clusterIndex, void *to)
 {
    for (unsigned i = 0; i < fSubFields.size(); i++) {
-      ReadBy(*fSubFields[i], clusterIndex, static_cast<unsigned char *>(to) + fSubFieldsInfo[i].fOffset);
+      CallReadOn(*fSubFields[i], clusterIndex, static_cast<unsigned char *>(to) + fSubFieldsInfo[i].fOffset);
    }
 }
 
@@ -1468,7 +1468,7 @@ void ROOT::Experimental::RCollectionClassField::ReadGlobalImpl(NTupleSize_t glob
    unsigned i = 0;
    for (auto elementPtr : RCollectionIterableOnce{obj, fIFuncsRead, fProxy.get(),
                                                   (fCollectionType == kSTLvector || obj != to ? fItemSize : 0U)}) {
-      ReadBy(*fSubFields[0], collectionStart + (i++), elementPtr);
+      CallReadOn(*fSubFields[0], collectionStart + (i++), elementPtr);
    }
    if (obj != to)
       fProxy->Commit(obj);
@@ -1606,14 +1606,14 @@ std::size_t ROOT::Experimental::RRecordField::AppendImpl(const void *from)
 void ROOT::Experimental::RRecordField::ReadGlobalImpl(NTupleSize_t globalIndex, void *to)
 {
    for (unsigned i = 0; i < fSubFields.size(); ++i) {
-      ReadBy(*fSubFields[i], globalIndex, static_cast<unsigned char *>(to) + fOffsets[i]);
+      CallReadOn(*fSubFields[i], globalIndex, static_cast<unsigned char *>(to) + fOffsets[i]);
    }
 }
 
 void ROOT::Experimental::RRecordField::ReadInClusterImpl(const RClusterIndex &clusterIndex, void *to)
 {
    for (unsigned i = 0; i < fSubFields.size(); ++i) {
-      ReadBy(*fSubFields[i], clusterIndex, static_cast<unsigned char *>(to) + fOffsets[i]);
+      CallReadOn(*fSubFields[i], clusterIndex, static_cast<unsigned char *>(to) + fOffsets[i]);
    }
 }
 
@@ -1711,7 +1711,7 @@ void ROOT::Experimental::RVectorField::ReadGlobalImpl(NTupleSize_t globalIndex, 
    }
 
    for (std::size_t i = 0; i < nItems; ++i) {
-      ReadBy(*fSubFields[0], collectionStart + i, typedValue->data() + (i * fItemSize));
+      CallReadOn(*fSubFields[0], collectionStart + i, typedValue->data() + (i * fItemSize));
    }
 }
 
@@ -1868,7 +1868,7 @@ void ROOT::Experimental::RRVecField::ReadGlobalImpl(NTupleSize_t globalIndex, vo
 
    // Read the new values into the collection elements
    for (std::size_t i = 0; i < nItems; ++i) {
-      ReadBy(*fSubFields[0], collectionStart + i, begin + (i * fItemSize));
+      CallReadOn(*fSubFields[0], collectionStart + i, begin + (i * fItemSize));
    }
 }
 
@@ -2045,7 +2045,7 @@ void ROOT::Experimental::RField<std::vector<bool>>::ReadGlobalImpl(NTupleSize_t 
    typedValue->resize(nItems);
    for (unsigned i = 0; i < nItems; ++i) {
       bool bval;
-      ReadBy(*fSubFields[0], collectionStart + i, &bval);
+      CallReadOn(*fSubFields[0], collectionStart + i, &bval);
       (*typedValue)[i] = bval;
    }
 }
@@ -2135,7 +2135,7 @@ void ROOT::Experimental::RArrayField::ReadGlobalImpl(NTupleSize_t globalIndex, v
 {
    auto arrayPtr = static_cast<unsigned char *>(to);
    for (unsigned i = 0; i < fArrayLength; ++i) {
-      ReadBy(*fSubFields[0], globalIndex * fArrayLength + i, arrayPtr + (i * fItemSize));
+      CallReadOn(*fSubFields[0], globalIndex * fArrayLength + i, arrayPtr + (i * fItemSize));
    }
 }
 
@@ -2143,8 +2143,8 @@ void ROOT::Experimental::RArrayField::ReadInClusterImpl(const RClusterIndex &clu
 {
    auto arrayPtr = static_cast<unsigned char *>(to);
    for (unsigned i = 0; i < fArrayLength; ++i) {
-      ReadBy(*fSubFields[0], RClusterIndex(clusterIndex.GetClusterId(), clusterIndex.GetIndex() * fArrayLength + i),
-             arrayPtr + (i * fItemSize));
+      CallReadOn(*fSubFields[0], RClusterIndex(clusterIndex.GetClusterId(), clusterIndex.GetIndex() * fArrayLength + i),
+                 arrayPtr + (i * fItemSize));
    }
 }
 
@@ -2327,7 +2327,7 @@ void ROOT::Experimental::RVariantField::ReadGlobalImpl(NTupleSize_t globalIndex,
    // any `std::holds_alternative<T>` check fail later.
    if (R__likely(tag > 0)) {
       CallGenerateValueOn(*fSubFields[tag - 1], to);
-      ReadBy(*fSubFields[tag - 1], variantIndex, to);
+      CallReadOn(*fSubFields[tag - 1], variantIndex, to);
    }
    SetTag(to, tag);
 }
@@ -2516,7 +2516,7 @@ void ROOT::Experimental::RUniquePtrField::ReadGlobalImpl(NTupleSize_t globalInde
       ptr->reset(reinterpret_cast<char *>(valuePtr));
    }
 
-   ReadBy(*fSubFields[0], itemIndex, valuePtr);
+   CallReadOn(*fSubFields[0], itemIndex, valuePtr);
 }
 
 void ROOT::Experimental::RUniquePtrField::DestroyValue(void *objPtr, bool dtorOnly) const


### PR DESCRIPTION
Rename `...By()` methods in `RFieldBase` to `Call...On()`.

Follow-up from #13317 