### PR TITLE
Fixes to `rootcling`'s handling of (unnamed) enums

### DIFF
--- a/core/dictgen/src/SelectionRules.cxx
+++ b/core/dictgen/src/SelectionRules.cxx
@@ -432,9 +432,9 @@ bool SelectionRules::GetDeclName(const clang::Decl* D, std::string& name, std::s
    // the identifier is NULL for some special methods like constructors, destructors and operators
    if (N->getIdentifier() || N->isCXXClassMember()) {
       name = N->getNameAsString();
+      llvm::raw_string_ostream stream(qual_name);
+      N->getNameForDiagnostic(stream,N->getASTContext().getPrintingPolicy(),true);
    }
-   llvm::raw_string_ostream stream(qual_name);
-   N->getNameForDiagnostic(stream,N->getASTContext().getPrintingPolicy(),true);
    return true;
 }
 

--- a/core/dictgen/src/SelectionRules.cxx
+++ b/core/dictgen/src/SelectionRules.cxx
@@ -430,11 +430,8 @@ bool SelectionRules::GetDeclName(const clang::Decl* D, std::string& name, std::s
       return false;
 
    // the identifier is NULL for some special methods like constructors, destructors and operators
-   if (N->getIdentifier()) {
+   if (N->getIdentifier() || N->isCXXClassMember()) {
       name = N->getNameAsString();
-   }
-   else if (N->isCXXClassMember()) { // for constructors, destructors, operator=, etc. methods
-      name =  N->getNameAsString(); // we use this (unefficient) method to Get the name in that case
    }
    llvm::raw_string_ostream stream(qual_name);
    N->getNameForDiagnostic(stream,N->getASTContext().getPrintingPolicy(),true);

--- a/io/rootpcm/src/rootclingIO.cxx
+++ b/io/rootpcm/src/rootclingIO.cxx
@@ -241,9 +241,9 @@ bool CloseStreamerInfoROOTFile(bool writeEmptyRootPCM)
    TObjArray enums(gEnumsToStore.size());
    for (const auto & enumname : gEnumsToStore) {
       TEnum *en = nullptr;
-      const size_t lastSepPos = enumname.find_last_of("::");
+      const size_t lastSepPos = enumname.rfind("::");
       if (lastSepPos != std::string::npos) {
-         const std::string nsName = enumname.substr(0, lastSepPos - 1);
+         const std::string nsName = enumname.substr(0, lastSepPos);
          TClass *tclassInstance = TClass::GetClass(nsName.c_str());
          if (!tclassInstance) {
             Error("CloseStreamerInfoROOTFile", "Cannot find TClass instance for namespace %s.", nsName.c_str());
@@ -256,7 +256,7 @@ bool CloseStreamerInfoROOTFile(bool writeEmptyRootPCM)
             Error("CloseStreamerInfoROOTFile", "TClass instance for namespace %s does not have any enum associated. This is an inconsistency.", nsName.c_str());
             return false;
          }
-         const std::string unqualifiedEnumName = enumname.substr(lastSepPos + 1);
+         const std::string unqualifiedEnumName = enumname.substr(lastSepPos + 2);
          en = (TEnum *)enumListPtr->FindObject(unqualifiedEnumName.c_str());
          if (en) en->SetTitle(nsName.c_str());
       } else {


### PR DESCRIPTION
Found while debugging `roottest-root-multicore-tsenums` with LLVM 16.