### PR TITLE
[RF] Refactor RooIntegrator1D to use free functions

### DIFF
--- a/roofit/roofitcore/inc/RooIntegrator1D.h
+++ b/roofit/roofitcore/inc/RooIntegrator1D.h
@@ -19,6 +19,20 @@
 #include "RooAbsIntegrator.h"
 #include "RooNumIntConfig.h"
 
+#include <ROOT/RSpan.hxx>
+
+#include <functional>
+
+namespace RooFit {
+namespace Detail {
+
+std::pair<double, int> integrate1d(std::function<double(double)> func, bool doTrapezoid, int maxSteps, int minStepsZero,
+                                   int fixSteps, double epsAbs, double epsRel, bool doExtrap, double xmin, double xmax,
+                                   std::span<double> hArr, std::span<double> sArr);
+
+} // namespace Detail
+} // namespace RooFit
+
 class RooIntegrator1D : public RooAbsIntegrator {
 public:
 
@@ -27,9 +41,9 @@ public:
   RooIntegrator1D() {}
 
   RooIntegrator1D(const RooAbsFunc& function, SummationRule rule= Trapezoid,
-        Int_t maxSteps= 0, double eps= 0) ;
+        int maxSteps= 0, double eps= 0) ;
   RooIntegrator1D(const RooAbsFunc& function, double xmin, double xmax,
-        SummationRule rule= Trapezoid, Int_t maxSteps= 0, double eps= 0) ;
+        SummationRule rule= Trapezoid, int maxSteps= 0, double eps= 0) ;
 
   RooIntegrator1D(const RooAbsFunc& function, const RooNumIntConfig& config) ;
   RooIntegrator1D(const RooAbsFunc& function, double xmin, double xmax,
@@ -60,30 +74,17 @@ protected:
 
   // Integrator configuration
   SummationRule _rule;
-  Int_t _maxSteps ;      ///< Maximum number of steps
-  Int_t _minStepsZero ;  ///< Minimum number of steps to declare convergence to zero
-  Int_t _fixSteps ;      ///< Fixed number of steps
-  double _epsAbs ;     ///< Absolute convergence tolerance
-  double _epsRel ;     ///< Relative convergence tolerance
-  bool _doExtrap ;     ///< Apply conversion step?
-  enum { _nPoints = 5 };
-
-  // Numerical integrator support functions
-  double addTrapezoids(Int_t n) ;
-  double addMidpoints(Int_t n) ;
-  void extrapolate(Int_t n) ;
+  int _maxSteps ;          ///< Maximum number of steps
+  int _minStepsZero = 999; ///< Minimum number of steps to declare convergence to zero
+  int _fixSteps = 0;       ///< Fixed number of steps
+  double _epsAbs ;         ///< Absolute convergence tolerance
+  double _epsRel ;         ///< Relative convergence tolerance
+  bool _doExtrap = true;   ///< Apply conversion step?
+  double _xmin;            ///<! Lower integration bound
+  double _xmax;            ///<! Upper integration bound
 
   // Numerical integrator workspace
-  double _xmin;              ///<! Lower integration bound
-  double _xmax;              ///<! Upper integration bound
-  double _range;             ///<! Size of integration range
-  double _extrapValue;       ///<! Extrapolated value
-  double _extrapError;       ///<! Error on extrapolated value
-  std::vector<double> _h ;   ///<! Integrator workspace
-  std::vector<double> _s ;   ///<! Integrator workspace
-  std::vector<double> _c ;   ///<! Integrator workspace
-  std::vector<double> _d ;   ///<! Integrator workspace
-  double _savedResult;       ///<! Integrator workspace
+  std::vector<double> _wksp ;   ///<! Integrator workspace
 
   double* xvec(double& xx) { _x[0] = xx ; return _x.data(); }
 

--- a/roofit/roofitcore/src/RooIntegrator1D.cxx
+++ b/roofit/roofitcore/src/RooIntegrator1D.cxx
@@ -21,6 +21,20 @@
 
 RooIntegrator1D implements an adaptive one-dimensional
 numerical integration algorithm.
+
+It uses Romberg's method with trapezoids or midpoints.
+The integrand is approximated by \f$ 1, 2, 4, 8, \ldots, 2^n \f$ trapezoids, and
+Richardson series acceleration is applied to the series. For refinement step \f$ n \f$, that is
+\f[
+  R(n,m) = \frac{1}{4^m - 1} \left( 4^m R(n, m-1) - R(n-1, m-1) \right)
+\f]
+The integrator will evaluate the first six refinements (i.e. 64 points) in one go,
+apply a five-point series acceleration, and successively add more steps until the
+desired precision is reached.
+\since In ROOT 6.24, the implementation of the integrator was revised, since it often
+stopped early, not reaching the desired relative precision. The old (less accurate) integrator
+is available under the name OldIntegrator1D. If less precision is actually desired (to speed up the
+integration), a relative epsilon 5, 10 or more times higher than for the old integrator can be used.
 **/
 
 
@@ -38,17 +52,198 @@ numerical integration algorithm.
 
 #include <assert.h>
 
+namespace {
 
+constexpr static int nPoints = 5;
 
-using namespace std;
+////////////////////////////////////////////////////////////////////////////////
+/// Calculate the n-th stage of refinement of the Second Euler-Maclaurin
+/// summation rule which has the useful property of not evaluating the
+/// integrand at either of its endpoints but requires more function
+/// evaluations than the trapezoidal rule. This rule can be used with
+/// a suitable change of variables to estimate improper integrals.
+
+double addMidpoints(std::function<double(double)> const &func, double savedResult, int n, double xmin, double xmax)
+{
+   const double range = xmax - xmin;
+
+   if (n == 1) {
+      double xmid = 0.5 * (xmin + xmax);
+      return range * func(xmid);
+   }
+
+   int it = 1;
+   for (int j = 1; j < n - 1; j++) {
+      it *= 3;
+   }
+   double tnm = it;
+   double del = range / (3. * tnm);
+   double ddel = del + del;
+   double x = xmin + 0.5 * del;
+   double sum = 0;
+   for (int j = 1; j <= it; j++) {
+      sum += func(x);
+      x += ddel;
+      sum += func(x);
+      x += del;
+   }
+   return (savedResult + range * sum / tnm) / 3.;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Calculate the n-th stage of refinement of the extended trapezoidal
+/// summation rule. This is the most efficient rule for a well behaved
+/// integrands that can be evaluated over its entire range, including the
+/// endpoints.
+
+double addTrapezoids(std::function<double(double)> const &func, double savedResult, int n, double xmin, double xmax)
+{
+   const double range = xmax - xmin;
+
+   if (n == 1) {
+      // use a single trapezoid to cover the full range
+      return 0.5 * range * (func(xmin) + func(xmax));
+   }
+
+   // break the range down into several trapezoids using 2**(n-2)
+   // equally-spaced interior points
+   const int nInt = 1 << (n - 2);
+   const double del = range / nInt;
+
+   double sum = 0.;
+   // TODO Replace by batch computation
+   for (int j = 0; j < nInt; ++j) {
+      double x = xmin + (0.5 + j) * del;
+      sum += func(x);
+   }
+
+   return 0.5 * (savedResult + range * sum / nInt);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Extrapolate result to final value.
+
+std::pair<double, double> extrapolate(int n, double const *h, double const *s, double *c, double *d)
+{
+   double const *xa = &h[n - nPoints];
+   double const *ya = &s[n - nPoints];
+   int ns = 1;
+
+   double dif = std::abs(xa[1]);
+   for (int i = 1; i <= nPoints; i++) {
+      double dift = std::abs(xa[i]);
+      if (dift < dif) {
+         ns = i;
+         dif = dift;
+      }
+      c[i] = ya[i];
+      d[i] = ya[i];
+   }
+   double extrapError = 0.0;
+   double extrapValue = ya[ns--];
+   for (int m = 1; m < nPoints; m++) {
+      for (int i = 1; i <= nPoints - m; i++) {
+         double ho = xa[i];
+         double hp = xa[i + m];
+         double w = c[i + 1] - d[i];
+         double den = ho - hp;
+         if (den == 0.0) {
+            throw std::runtime_error("RooIntegrator1D::extrapolate: internal error");
+         }
+         den = w / den;
+         d[i] = hp * den;
+         c[i] = ho * den;
+      }
+      extrapError = 2 * ns < (nPoints - m) ? c[ns + 1] : d[ns--];
+      extrapValue += extrapError;
+   }
+   return {extrapValue, extrapError};
+}
+
+} // namespace
+
+namespace RooFit {
+namespace Detail {
+
+std::pair<double, int> integrate1d(std::function<double(double)> func, bool doTrapezoid, int maxSteps, int minStepsZero,
+                                   int fixSteps, double epsAbs, double epsRel, bool doExtrap, double xmin, double xmax,
+                                   std::span<double> hArr, std::span<double> sArr)
+{
+   assert(int(hArr.size()) == maxSteps + 2);
+   assert(int(sArr.size()) == maxSteps + 2);
+
+   const double range = xmax - xmin;
+
+   // Small working arrays can be on the stack
+   std::array<double, nPoints + 1> cArr = {};
+   std::array<double, nPoints + 1> dArr = {};
+
+   hArr[1] = 1.0;
+   double zeroThresh = epsAbs / range;
+   for (int j = 1; j <= maxSteps; ++j) {
+      // refine our estimate using the appropriate summation rule
+      sArr[j] =
+         doTrapezoid ? addTrapezoids(func, sArr[j - 1], j, xmin, xmax) : addMidpoints(func, sArr[j - 1], j, xmin, xmax);
+
+      if (j >= minStepsZero) {
+         bool allZero(true);
+         for (int jj = 0; jj <= j; jj++) {
+            if (sArr[j] >= zeroThresh) {
+               allZero = false;
+            }
+         }
+         if (allZero) {
+            // cout << "Roo1DIntegrator(" << this << "): zero convergence at step " << j << ", value = " << 0 <<
+            // std::endl ;
+            return {0, j};
+         }
+      }
+
+      if (fixSteps > 0) {
+
+         // Fixed step mode, return result after fixed number of steps
+         if (j == fixSteps) {
+            // cout << "returning result at fixed step " << j << std::endl ;
+            return {sArr[j], j};
+         }
+
+      } else if (j >= nPoints) {
+
+         double extrapValue = 0.0;
+         double extrapError = 0.0;
+
+         // extrapolate the results of recent refinements and check for a stable result
+         if (doExtrap) {
+            std::tie(extrapValue, extrapError) = extrapolate(j, hArr.data(), sArr.data(), cArr.data(), dArr.data());
+         } else {
+            extrapValue = sArr[j];
+            extrapError = sArr[j] - sArr[j - 1];
+         }
+
+         if (std::abs(extrapError) <= epsRel * std::abs(extrapValue)) {
+            return {extrapValue, j};
+         }
+         if (std::abs(extrapError) <= epsAbs) {
+            return {extrapValue, j};
+         }
+      }
+      // update the step size for the next refinement of the summation
+      hArr[j + 1] = doTrapezoid ? hArr[j] / 4. : hArr[j] / 9.;
+   }
+
+   return {sArr[maxSteps], maxSteps};
+}
+
+} // namespace Detail
+} // namespace RooFit
+
 
 ClassImp(RooIntegrator1D);
-;
 
 // Register this class with RooNumIntConfig
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Register RooIntegrator1D, is parameters and capabilities with RooNumIntFactory
+/// Register RooIntegrator1D, its parameters and capabilities with RooNumIntFactory.
 
 void RooIntegrator1D::registerIntegrator(RooNumIntFactory& fact)
 {
@@ -73,11 +268,11 @@ void RooIntegrator1D::registerIntegrator(RooNumIntFactory& fact)
 ////////////////////////////////////////////////////////////////////////////////
 /// Construct integrator on given function binding, using specified summation
 /// rule, maximum number of steps and conversion tolerance. The integration
-/// limits are taken from the function binding
+/// limits are taken from the function binding.
 
 RooIntegrator1D::RooIntegrator1D(const RooAbsFunc& function, SummationRule rule,
-             Int_t maxSteps, double eps) :
-  RooAbsIntegrator(function), _rule(rule), _maxSteps(maxSteps),  _minStepsZero(999), _fixSteps(0), _epsAbs(eps), _epsRel(eps), _doExtrap(true)
+             int maxSteps, double eps) :
+  RooAbsIntegrator(function), _rule(rule), _maxSteps(maxSteps),  _epsAbs(eps), _epsRel(eps)
 {
   _useIntegrandLimits= true;
   _valid= initialize();
@@ -88,18 +283,15 @@ RooIntegrator1D::RooIntegrator1D(const RooAbsFunc& function, SummationRule rule,
 /// Construct integrator on given function binding for given range,
 /// using specified summation rule, maximum number of steps and
 /// conversion tolerance. The integration limits are taken from the
-/// function binding
+/// function binding.
 
 RooIntegrator1D::RooIntegrator1D(const RooAbsFunc& function, double xmin, double xmax,
-             SummationRule rule, Int_t maxSteps, double eps) :
+             SummationRule rule, int maxSteps, double eps) :
   RooAbsIntegrator(function),
   _rule(rule),
   _maxSteps(maxSteps),
-  _minStepsZero(999),
-  _fixSteps(0),
   _epsAbs(eps),
-  _epsRel(eps),
-  _doExtrap(true)
+  _epsRel(eps)
 {
   _useIntegrandLimits= false;
   _xmin= xmin;
@@ -121,13 +313,13 @@ RooIntegrator1D::RooIntegrator1D(const RooAbsFunc& function, const RooNumIntConf
   // Extract parameters from config object
   const RooArgSet& configSet = config.getConfigSection(ClassName()) ;
   _rule = (SummationRule) configSet.getCatIndex("sumRule",Trapezoid) ;
-  _maxSteps = (Int_t) configSet.getRealValue("maxSteps",20) ;
-  _minStepsZero = (Int_t) configSet.getRealValue("minSteps",999) ;
-  _fixSteps = (Int_t) configSet.getRealValue("fixSteps",0) ;
+  _maxSteps = (int) configSet.getRealValue("maxSteps",20) ;
+  _minStepsZero = (int) configSet.getRealValue("minSteps",999) ;
+  _fixSteps = (int) configSet.getRealValue("fixSteps",0) ;
   _doExtrap = (bool) configSet.getCatIndex("extrapolation",1) ;
 
   if (_fixSteps>_maxSteps) {
-    oocoutE(nullptr,Integration) << "RooIntegrator1D::ctor() ERROR: fixSteps>maxSteps, fixSteps set to maxSteps" << endl ;
+    oocoutE(nullptr,Integration) << "RooIntegrator1D::ctor() ERROR: fixSteps>maxSteps, fixSteps set to maxSteps" << std::endl ;
     _fixSteps = _maxSteps ;
   }
 
@@ -150,9 +342,9 @@ RooIntegrator1D::RooIntegrator1D(const RooAbsFunc& function, double xmin, double
   // Extract parameters from config object
   const RooArgSet& configSet = config.getConfigSection(ClassName()) ;
   _rule = (SummationRule) configSet.getCatIndex("sumRule",Trapezoid) ;
-  _maxSteps = (Int_t) configSet.getRealValue("maxSteps",20) ;
-  _minStepsZero = (Int_t) configSet.getRealValue("minSteps",999) ;
-  _fixSteps = (Int_t) configSet.getRealValue("fixSteps",0) ;
+  _maxSteps = (int) configSet.getRealValue("maxSteps",20) ;
+  _minStepsZero = (int) configSet.getRealValue("minSteps",999) ;
+  _fixSteps = (int) configSet.getRealValue("fixSteps",0) ;
   _doExtrap = (bool) configSet.getCatIndex("extrapolation",1) ;
 
   _useIntegrandLimits= false;
@@ -188,7 +380,7 @@ bool RooIntegrator1D::initialize()
 
   // check that the integrand is a valid function
   if(!isValid()) {
-    oocoutE(nullptr,Integration) << "RooIntegrator1D::initialize: cannot integrate invalid function" << endl;
+    oocoutE(nullptr,Integration) << "RooIntegrator1D::initialize: cannot integrate invalid function" << std::endl;
     return false;
   }
 
@@ -197,10 +389,7 @@ bool RooIntegrator1D::initialize()
 
 
   // Allocate workspace for numerical integration engine
-  _h.resize(_maxSteps + 2);
-  _s.resize(_maxSteps + 2);
-  _c.resize(_nPoints + 1);
-  _d.resize(_nPoints + 1);
+  _wksp.resize(2 * _maxSteps + 4);
 
   return checkLimits();
 }
@@ -214,7 +403,7 @@ bool RooIntegrator1D::initialize()
 bool RooIntegrator1D::setLimits(double *xmin, double *xmax)
 {
   if(_useIntegrandLimits) {
-    oocoutE(nullptr,Integration) << "RooIntegrator1D::setLimits: cannot override integrand's limits" << endl;
+    oocoutE(nullptr,Integration) << "RooIntegrator1D::setLimits: cannot override integrand's limits" << std::endl;
     return false;
   }
   _xmin= *xmin;
@@ -234,9 +423,9 @@ bool RooIntegrator1D::checkLimits() const
     const_cast<double&>(_xmin) = integrand()->getMinLimit(0);
     const_cast<double&>(_xmax) = integrand()->getMaxLimit(0);
   }
-  const_cast<double&>(_range) = _xmax - _xmin;
-  if (_range < 0.) {
-    oocoutE(nullptr,Integration) << "RooIntegrator1D::checkLimits: bad range with min > max (_xmin = " << _xmin << " _xmax = " << _xmax << ")" << endl;
+  const double range = _xmax - _xmin;
+  if (range < 0.) {
+    oocoutE(nullptr,Integration) << "RooIntegrator1D::checkLimits: bad range with min > max (_xmin = " << _xmin << " _xmax = " << _xmax << ")" << std::endl;
     return false;
   }
   return (RooNumber::isInfinite(_xmin) || RooNumber::isInfinite(_xmax)) ? false : true;
@@ -244,179 +433,46 @@ bool RooIntegrator1D::checkLimits() const
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Calculate numeric integral at given set of function binding parameters
+/// Calculate numeric integral at given set of function binding parameters.
 
 double RooIntegrator1D::integral(const double *yvec)
 {
-  assert(isValid());
+   assert(isValid());
 
-  if (_range == 0.)
-    return 0.;
+   const double range = _xmax - _xmin;
 
-  // Copy yvec to xvec if provided
-  if (yvec) {
-    for (UInt_t i = 0 ; i<_function->getDimension()-1 ; i++) {
-      _x[i+1] = yvec[i] ;
-    }
-  }
+   if (range == 0.)
+      return 0.;
 
-
-  _h[1]=1.0;
-  double zeroThresh = _epsAbs/_range ;
-  for(Int_t j = 1; j <= _maxSteps; ++j) {
-    // refine our estimate using the appropriate summation rule
-    _s[j]= (_rule == Trapezoid) ? addTrapezoids(j) : addMidpoints(j);
-
-    if (j >= _minStepsZero) {
-      bool allZero(true) ;
-      for (int jj=0 ; jj<=j ; jj++) {
-        if (_s[j]>=zeroThresh) {
-          allZero=false ;
-        }
+   // Copy yvec to xvec if provided
+   if (yvec) {
+      for (unsigned int i = 0; i < _function->getDimension() - 1; i++) {
+         _x[i + 1] = yvec[i];
       }
-      if (allZero) {
-        //cout << "Roo1DIntegrator(" << this << "): zero convergence at step " << j << ", value = " << 0 << endl ;
-        return 0;
+   }
+
+   // From the working array
+   std::size_t nWorkingArr = _maxSteps + 2;
+   assert(_wksp.size() == 2 * nWorkingArr);
+   double *hArr = _wksp.data();
+   double *sArr = _wksp.data() + nWorkingArr;
+
+   double output = 0.0;
+   int steps = 0;
+
+   std::tie(output, steps) = RooFit::Detail::integrate1d(
+      [&](double x) { return integrand(xvec(x)); }, _rule == Trapezoid, _maxSteps, _minStepsZero, _fixSteps, _epsAbs,
+      _epsRel, _doExtrap, _xmin, _xmax, {hArr, nWorkingArr}, {sArr, nWorkingArr});
+
+   if (steps == _maxSteps) {
+
+      oocoutW(nullptr, Integration) << "RooIntegrator1D::integral: integral of " << _function->getName()
+                                    << " over range (" << _xmin << "," << _xmax << ") did not converge after "
+                                    << _maxSteps << " steps" << std::endl;
+      for (int j = 1; j <= _maxSteps; ++j) {
+         ooccoutW(nullptr, Integration) << "   [" << j << "] h = " << hArr[j] << " , s = " << sArr[j] << std::endl;
       }
-    }
+   }
 
-    if (_fixSteps>0) {
-
-      // Fixed step mode, return result after fixed number of steps
-      if (j==_fixSteps) {
-        //cout << "returning result at fixed step " << j << endl ;
-        return _s[j];
-      }
-
-    } else  if(j >= _nPoints) {
-
-      // extrapolate the results of recent refinements and check for a stable result
-      if (_doExtrap) {
-        extrapolate(j);
-      } else {
-        _extrapValue = _s[j] ;
-        _extrapError = _s[j]-_s[j-1] ;
-      }
-
-      if(std::abs(_extrapError) <= _epsRel*std::abs(_extrapValue)) {
-        return _extrapValue;
-      }
-      if(std::abs(_extrapError) <= _epsAbs) {
-        return _extrapValue ;
-      }
-
-    }
-    // update the step size for the next refinement of the summation
-    _h[j+1]= (_rule == Trapezoid) ? _h[j]/4. : _h[j]/9.;
-  }
-
-  oocoutW(nullptr,Integration) << "RooIntegrator1D::integral: integral of " << _function->getName() << " over range (" << _xmin << "," << _xmax << ") did not converge after "
-      << _maxSteps << " steps" << endl;
-  for(Int_t j = 1; j <= _maxSteps; ++j) {
-    ooccoutW(nullptr,Integration) << "   [" << j << "] h = " << _h[j] << " , s = " << _s[j] << endl;
-  }
-
-  return _s[_maxSteps] ;
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Calculate the n-th stage of refinement of the Second Euler-Maclaurin
-/// summation rule which has the useful property of not evaluating the
-/// integrand at either of its endpoints but requires more function
-/// evaluations than the trapezoidal rule. This rule can be used with
-/// a suitable change of variables to estimate improper integrals.
-
-double RooIntegrator1D::addMidpoints(Int_t n)
-{
-  double x,tnm,sum,del,ddel;
-  Int_t it,j;
-
-  if(n == 1) {
-    double xmid= 0.5*(_xmin + _xmax);
-    return (_savedResult= _range*integrand(xvec(xmid)));
-  }
-  else {
-    for(it=1, j=1; j < n-1; j++) it*= 3;
-    tnm= it;
-    del= _range/(3.*tnm);
-    ddel= del+del;
-    x= _xmin + 0.5*del;
-    for(sum= 0, j= 1; j <= it; j++) {
-      sum+= integrand(xvec(x));
-      x+= ddel;
-      sum+= integrand(xvec(x));
-      x+= del;
-    }
-    return (_savedResult= (_savedResult + _range*sum/tnm)/3.);
-  }
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Calculate the n-th stage of refinement of the extended trapezoidal
-/// summation rule. This is the most efficient rule for a well behaved
-/// integrands that can be evaluated over its entire range, including the
-/// endpoints.
-
-double RooIntegrator1D::addTrapezoids(Int_t n)
-{
-  if (n == 1) {
-    // use a single trapezoid to cover the full range
-    return (_savedResult= 0.5*_range*(integrand(xvec(_xmin)) + integrand(xvec(_xmax))));
-  }
-  else {
-    // break the range down into several trapezoids using 2**(n-2)
-    // equally-spaced interior points
-    const int nInt = 1 << (n-2);
-    const double del = _range/nInt;
-    const double xmin = _xmin;
-
-    double sum = 0.;
-    // TODO Replace by batch computation
-    for (int j=0; j<nInt; ++j) {
-      double x = xmin + (0.5+j)*del;
-      sum += integrand(xvec(x));
-    }
-
-    return (_savedResult= 0.5*(_savedResult + _range*sum/nInt));
-  }
-}
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Extrapolate result to final value
-
-void RooIntegrator1D::extrapolate(Int_t n)
-{
-  double *xa= &_h[n-_nPoints];
-  double *ya= &_s[n-_nPoints];
-  Int_t i,m,ns=1;
-  double den,dif,dift,ho,hp,w;
-
-  dif=std::abs(xa[1]);
-  for (i= 1; i <= _nPoints; i++) {
-    if ((dift=std::abs(xa[i])) < dif) {
-      ns=i;
-      dif=dift;
-    }
-    _c[i]=ya[i];
-    _d[i]=ya[i];
-  }
-  _extrapValue= ya[ns--];
-  for(m= 1; m < _nPoints; m++) {
-    for(i= 1; i <= _nPoints-m; i++) {
-      ho=xa[i];
-      hp=xa[i+m];
-      w=_c[i+1]-_d[i];
-      if((den=ho-hp) == 0.0) {
-   oocoutE(nullptr,Integration) << "RooIntegrator1D::extrapolate: internal error" << endl;
-      }
-      den=w/den;
-      _d[i]=hp*den;
-      _c[i]=ho*den;
-    }
-    _extrapValue += (_extrapError=(2*ns < (_nPoints-m) ? _c[ns+1] : _d[ns--]));
-  }
+   return output;
 }

--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -64,6 +64,7 @@ ROOT_ADD_GTEST(testRooPolyFunc testRooPolyFunc.cxx LIBRARIES Gpad RooFitCore)
 ROOT_ADD_GTEST(testSumW2Error testSumW2Error.cxx LIBRARIES Gpad RooFitCore)
 ROOT_ADD_GTEST(testRooHist testRooHist.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testRooHistPdf testRooHistPdf.cxx LIBRARIES RooFitCore)
+ROOT_ADD_GTEST(testRooIntegrator1D testRooIntegrator1D.cxx LIBRARIES MathCore RooFitCore)
 if (roofit_multiprocess)
   ROOT_ADD_GTEST(testTestStatisticsPlot TestStatistics/testPlot.cxx LIBRARIES RooFitMultiProcess RooFitCore RooFit
                    COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/TestStatistics/TestStatistics_ref.root)

--- a/roofit/roofitcore/test/testRooIntegrator1D.cxx
+++ b/roofit/roofitcore/test/testRooIntegrator1D.cxx
@@ -1,0 +1,365 @@
+// Tests for the RooIntegrator1D.
+// Author: Stephan Hageboeck, CERN  05/2020
+
+#include "RooRealBinding.h"
+#include "RooRealVar.h"
+#include "RooFormulaVar.h"
+#include "RooIntegrator1D.h"
+#include "RooNumIntConfig.h"
+#include "RooHelpers.h"
+#include <Math/ProbFuncMathCore.h>
+#include <Math/SpecFuncMathCore.h>
+#include <Math/Integrator.h>
+#include <TMath.h>
+#include <TStopwatch.h>
+
+#include "gtest/gtest.h"
+
+#include <numeric>
+#include <algorithm>
+
+TEST(Roo1DIntegrator, RunFormulaVar_Trapezoid)
+{
+
+   RooRealVar x("x", "x", -100, 100);
+   RooRealVar a("a", "a", 0.2, -100, 100);
+   RooRealVar b("b", "b", 0.3, -100, 100);
+   RooFormulaVar formula("formula", "0.1 + x*(a + b*x)", {x, a, b});
+   auto solution = [&x](double aVal, double bVal) {
+      auto indefInt = [=](double y) { return y * (0.1 + y * (1. / 2. * aVal + 1. / 3. * bVal * y)); };
+      return indefInt(x.getMax()) - indefInt(x.getMin());
+   };
+   RooRealBinding binding(formula, {x, a, b});
+   std::vector<double> yvals{a.getVal(), b.getVal()};
+
+   // The integrators will warn, since we let them run until maxSteps
+   RooHelpers::HijackMessageStream hijack(RooFit::WARNING, RooFit::Integration);
+
+   // Test the recursion anchors of the Romberg integration
+   {
+      RooIntegrator1D oneStep(binding, RooIntegrator1D::Trapezoid, 1, 1.E-15);
+      EXPECT_DOUBLE_EQ(oneStep.integral(yvals.data()), 0.5 * 200. * (2 * 0.1 + 2. * 0.3 * 10000.));
+      x = -100.;
+      const double left = formula.getVal();
+      x = 100.;
+      const double right = formula.getVal();
+      // Run integral again, also to make sure that setting x has no effect:
+      EXPECT_DOUBLE_EQ(oneStep.integral(yvals.data()), 0.5 * 200. * (left + right));
+
+      RooIntegrator1D twoStep(binding, RooIntegrator1D::Trapezoid, 2, 1.E-15);
+      x = 0.;
+      const double middle = formula.getVal();
+      EXPECT_DOUBLE_EQ(twoStep.integral(yvals.data()), 0.25 * 200. * (left + right) + 0.5 * 200. * middle);
+   }
+
+   // Now run many steps
+   {
+      constexpr unsigned int nSteps = 25;
+      constexpr double relEps = 1.E-50;
+      RooIntegrator1D integrator(binding, RooIntegrator1D::Trapezoid, nSteps, relEps);
+      double inputs[] = {1., 3.123};
+      double target = solution(inputs[0], inputs[1]);
+      EXPECT_LT(std::abs(integrator.integral(inputs) - target) / target, 1.E-14);
+
+      inputs[0] = a.getVal();
+      inputs[1] = b.getVal();
+      target = solution(inputs[0], inputs[1]);
+      EXPECT_LT(std::abs(integrator.integral(inputs) - target) / target, 1.E-14);
+
+      inputs[0] = 4.;
+      inputs[1] = 5.;
+      target = solution(inputs[0], inputs[1]);
+      EXPECT_LT(std::abs(integrator.integral(inputs) - target) / target, 1.E-14);
+   }
+}
+
+TEST(Roo1DIntegrator, RunQuarticFormulaVar)
+{
+   constexpr unsigned int nSteps = 25;
+   constexpr double relEps = 1.E-16;
+   RooRealVar x("x", "x", -50, 50);
+   RooRealVar a("a", "a", 0.2, -100, 100);
+   RooRealVar b("b", "b", 0.3, -100, 100);
+   RooRealVar c("c", "c", 0.4, -100, 100);
+   RooRealVar d("d", "d", 0.5, -100, 100);
+   RooFormulaVar formula("formula", "0.1 + x*(a + x*(b + x*(c + d * x)))", {x, a, b, c, d});
+   auto solution = [&x](double aVal, double bVal, double cVal, double dVal) {
+      auto indefInt = [=](double yVal) {
+         return yVal * (0.1 + yVal * (1. / 2. * aVal +
+                                      yVal * (1. / 3. * bVal + yVal * (1. / 4. * cVal + 1. / 5. * dVal * yVal))));
+      };
+      return indefInt(x.getMax()) - indefInt(x.getMin());
+   };
+   RooRealBinding binding(formula, {x});
+   RooIntegrator1D integrator(binding, RooIntegrator1D::Trapezoid, nSteps, relEps);
+
+   double target = solution(0.2, 0.3, 0.4, 0.5);
+   EXPECT_LT(std::abs(integrator.integral() - target) / target, 1.E-13);
+}
+
+/// Run numeric integrations using RooIntegrator1D and ROOT's adaptive integrator. Ensure that
+/// they reach the requested precision.
+void testConvergenceSettings(const RooFormulaVar &formula, const RooArgSet &observables,
+                             const RooArgSet &funcParameters,
+                             std::function<double(const double *pars, unsigned int nPar)> solution,
+                             const std::string &name)
+{
+   constexpr unsigned int nSteps = 25;
+   constexpr bool printDetails = false;
+   SCOPED_TRACE(std::string("Function to integrate: ") + name + "\t" + formula.GetTitle());
+
+   for (double relEps : {1.E-3, 1.E-6, 1.E-8}) {
+      SCOPED_TRACE(std::string("relEps=" + std::to_string(relEps)));
+      TStopwatch stopNew;
+      TStopwatch stopRoot;
+
+      RooRealVar &x = dynamic_cast<RooRealVar &>(*observables[0ul]);
+      RooArgSet variables(observables);
+      variables.add(funcParameters);
+      RooRealBinding binding(formula, variables);
+      RooIntegrator1D integrator(binding, RooIntegrator1D::Trapezoid, nSteps, relEps);
+
+      std::vector<double> errors;
+      std::vector<double> errorsRootInt;
+
+      RooArgSet initialParameters;
+      funcParameters.snapshot(initialParameters);
+
+      constexpr unsigned int nRun = 10000;
+      for (unsigned int i = 0; i < nRun; ++i) {
+         std::vector<double> pars;
+         for (const auto p : initialParameters) {
+            auto par = static_cast<RooRealVar *>(p);
+            pars.push_back(par->getVal() + (par->getMax() - par->getVal()) / nRun * i);
+         }
+
+         const double target = solution(pars.data(), pars.size());
+
+         stopNew.Start(false);
+         const double integral = integrator.integral(pars.data());
+         stopNew.Stop();
+         errors.push_back(std::abs((integral - target) / target));
+
+         {
+            std::vector<double> vars(1);
+            std::copy(pars.begin(), pars.end(), std::back_inserter(vars));
+            auto bindingROOTInt = [&vars, &binding](double xVal) {
+               vars[0] = xVal;
+               return binding(vars.data());
+            };
+            ROOT::Math::IntegratorOneDim rootIntegrator(bindingROOTInt, ROOT::Math::IntegrationOneDim::kADAPTIVE,
+                                                        1.E-20, relEps, 100);
+
+            stopRoot.Start(false);
+            const double rootIntegral = rootIntegrator.Integral(x.getMin(), x.getMax());
+            stopRoot.Stop();
+            errorsRootInt.push_back(std::abs((rootIntegral - target) / target));
+         }
+      }
+
+      auto mean = [](const std::vector<double> &vec) { return TMath::Mean(vec.begin(), vec.end()); };
+      auto median = [&](const std::vector<double> &vec) { return TMath::Median(vec.size(), vec.data()); };
+      auto q95_99 = [&](const std::vector<double> &vec) -> std::pair<double, double> {
+         std::vector<double> q(2);
+         std::vector<double> p(1, 0.95);
+         p.push_back(0.99);
+         TMath::Quantiles(vec.size(), q.size(), const_cast<double *>(vec.data()), q.data(), p.data(), false);
+         return {q[0], q[1]};
+      };
+
+      const auto q95_99_int1D = q95_99(errors);
+      const auto q95_99_intROOT = q95_99(errorsRootInt);
+
+      if (printDetails) {
+         std::cout << "Integrating " << name << ", relEps = " << relEps;
+         std::cout << "\n\t    \t"
+                   << "mean         \tmedian  \tq95     \tq99     \tmax";
+         const std::vector<double> *vec = &errors;
+         std::cout << "\n\tnew:\t" << mean(*vec) << "\t" << median(*vec) << "\t" << q95_99_int1D.first << "\t"
+                   << q95_99_int1D.second << "\t"
+                   << "\tt=" << stopNew.CpuTime();
+         vec = &errorsRootInt;
+         std::cout << "\n\tROOT:\t" << mean(*vec) << "\t" << median(*vec) << "\t" << q95_99_intROOT.first << "\t"
+                   << q95_99_intROOT.second << "\t"
+                   << "\tt=" << stopRoot.CpuTime();
+         std::cout << std::endl;
+      }
+
+      // Depending on the function, the integrator precision doesn't reach the
+      // actual precisiosn parameter, so we give it some headroom.
+      const double mult = 100.0;
+
+      EXPECT_LT(mean(errors), mult * relEps) << "RooIntegrator1D should reach target precision.";
+      EXPECT_LT(mean(errorsRootInt), mult * relEps) << "ROOT integrator should reach target precision.";
+
+      EXPECT_LT(q95_99_int1D.first, mult * relEps) << "95% quantile of errors exceeds relEpsilon";
+      EXPECT_LT(q95_99_int1D.second, 2. * mult * relEps) << "99% quantile of errors exceeds 2.*relEpsilon";
+
+      EXPECT_LT(q95_99_intROOT.first, mult * relEps) << "95% quantile of errors exceeds relEpsilon";
+      EXPECT_LT(q95_99_intROOT.second, 2. * mult * relEps) << "95% quantile of errors exceeds relEpsilon";
+   }
+}
+
+/// Disabled because the integrator doesn't reach the asked precision. If this
+/// behavior gets changed, this can be enabled.
+TEST(Roo1DIntegrator, ConvergenceSettings_log)
+{
+   RooRealVar x("x", "x", 0.1, 50);
+   RooRealVar a("a", "a", 0.2, -100, 1.E5);
+   RooFormulaVar formula("formula", "log(a*x)", {x, a});
+   testConvergenceSettings(
+      formula, {x}, {a},
+      [&x](const double *pars, unsigned int nPar) {
+         const double aVal = pars[0];
+         if (nPar != 1)
+            throw std::logic_error("Need npar == 1");
+
+         auto indefInt = [=](double y) { return 1. / aVal * (y * log(y) - y); };
+         return indefInt(aVal * x.getMax()) - indefInt(aVal * x.getMin());
+      },
+      "log(a*x)");
+}
+
+TEST(Roo1DIntegrator, ConvergenceSettings_pol4)
+{
+   RooRealVar x2("x", "x", -10, 10);
+   RooRealVar a2("a", "a", 0.2, -1., 1);
+   RooRealVar b2("b", "b", -0.1, -1., 1);
+   RooRealVar c2("c", "c", 0.02, -0.1, 0.1);
+   RooRealVar d2("d", "d", -0., -0.01, 0.01);
+   RooFormulaVar formula("formula", "0.1 + x*(a + x*(b + x*(c + d * x)))", {x2, a2, b2, c2, d2});
+   testConvergenceSettings(
+      formula, {x2}, {a2, b2, c2, d2},
+      [&x2](const double *pars, unsigned int nPar) {
+         const double a = pars[0];
+         const double b = pars[1];
+         const double c = pars[2];
+         const double d = pars[3];
+         if (nPar != 4)
+            throw std::logic_error("Need npar == 4");
+
+         auto indefInt = [=](double y) {
+            return y * (0.1 + y * (1. / 2. * a + y * (1. / 3. * b + y * (1. / 4. * c + 1. / 5. * d * y))));
+         };
+         return indefInt(x2.getMax()) - indefInt(x2.getMin());
+      },
+      "Polynomial 4th order");
+}
+
+/// Disabled because the integrator doesn't reach the asked precision. If this
+/// behavior gets changed, this can be enabled.
+TEST(Roo1DIntegrator, ConvergenceSettings_breitWig)
+{
+   RooRealVar x3("x", "x", 0., 100.);
+   RooRealVar a3("a", "a", 10., 100.);
+   RooRealVar b3("b", "b", 3., 10.);
+   RooFormulaVar formula("breitwigner", "ROOT::Math::breitwigner_pdf(x, b, a)", {x3, a3, b3});
+   testConvergenceSettings(
+      formula, {x3}, {a3, b3},
+      [&x3](const double *pars, unsigned int nPar) {
+         const double a = pars[0];
+         const double b = pars[1];
+         if (nPar != 2)
+            throw std::logic_error("Need npar == 2");
+
+         return ROOT::Math::breitwigner_cdf(x3.getMax(), b, a) - ROOT::Math::breitwigner_cdf(x3.getMin(), b, a);
+      },
+      "Breit-Wigner distribution");
+}
+
+TEST(Roo1DIntegrator, ConvergenceSettings_Erf)
+{
+   RooRealVar x("x", "x", -10., 10.);
+   RooRealVar m("m", "m", -5., 5.);
+   RooRealVar s("s", "s", 0.5, 10.);
+   const std::string funcStr = "ROOT::Math::gaussian_pdf(x, s, m)";
+   RooFormulaVar formula("gaus", funcStr.c_str(), {x, m, s});
+   testConvergenceSettings(
+      formula, {x}, {m, s},
+      [&x](const double *pars, unsigned int nPar) {
+         const double mVal = pars[0];
+         const double sVal = pars[1];
+         if (nPar != 2)
+            throw std::logic_error("Need npar == 2");
+
+         return ROOT::Math::gaussian_cdf(x.getMax(), sVal, mVal) - ROOT::Math::gaussian_cdf(x.getMin(), sVal, mVal);
+      },
+      "Gaussian distribution");
+}
+
+TEST(Roo1DIntegrator, RunErf_NStep)
+{
+   RooHelpers::HijackMessageStream hijack(RooFit::WARNING, RooFit::Integration);
+   constexpr double sigma = 1.3;
+   constexpr double mean = 0.2;
+
+   for (auto limits : std::initializer_list<std::pair<double, double>>{{0.1, 1.5}, {-0.3, 2.}, {2.5, 4.5}}) {
+      const double min = limits.first;
+      const double max = limits.second;
+      RooRealVar theX("theX", "x", min, max);
+      std::string funcStr =
+         std::string("ROOT::Math::gaussian_pdf(theX, ") + std::to_string(sigma) + ", " + std::to_string(mean) + ")";
+      RooFormulaVar gaus("gaus", funcStr.c_str(), theX);
+      RooRealBinding binding(gaus, theX);
+
+      double targetError = 0.;
+      for (unsigned int nSteps = 4; nSteps < 24; ++nSteps) {
+         RooIntegrator1D integrator(binding, RooIntegrator1D::Trapezoid, nSteps, 1.E-17);
+         const double integral = integrator.integral();
+
+         const double error = std::abs(
+            integral - (ROOT::Math::gaussian_cdf(max, sigma, mean) - ROOT::Math::gaussian_cdf(min, sigma, mean)));
+
+         if (nSteps == 4) {
+            targetError = error;
+         } else {
+            // Error should go down faster than 0.5^nSteps because the integrator uses series acceleration,
+            // so test if it goes down faster than 0.333^nSteps
+            targetError /= 3.;
+            // But cannot be better than double precision
+            EXPECT_LT(error, std::max(targetError, 1.E-16)) << "For step " << nSteps << " with integral=" << integral;
+         }
+         if (nSteps > 10) {
+            EXPECT_LT(error / integral, 1.E-4) << "For step " << nSteps << " with integral=" << integral;
+         }
+         if (nSteps > 15) {
+            EXPECT_LT(error / integral, 1.E-6) << "For step " << nSteps << " with integral=" << integral;
+         }
+         if (nSteps > 21) {
+            EXPECT_LT(error / integral, 1.E-8) << "For step " << nSteps << " with integral=" << integral;
+         }
+      }
+   }
+}
+
+TEST(Roo1DIntegrator, RunErf_Midpoint)
+{
+   const double min = 0, max = 1;
+   RooRealVar theX("theX", "x", min, max);
+   RooFormulaVar gaus("gaus", "ROOT::Math::gaussian_pdf(theX, 1, 0)", theX);
+   RooRealBinding binding(gaus, theX);
+   double targetError = 0.;
+
+   RooHelpers::HijackMessageStream hijack(RooFit::WARNING, RooFit::Integration);
+
+   for (unsigned int nSteps = 4; nSteps < 20; ++nSteps) {
+      RooIntegrator1D integrator(binding, RooIntegrator1D::Midpoint, nSteps, 1.E-16);
+      const double integral = integrator.integral();
+      const double error =
+         std::abs(integral - (ROOT::Math::gaussian_cdf(max, 1, 0) - ROOT::Math::gaussian_cdf(min, 1, 0)));
+      if (nSteps == 4) {
+         targetError = error;
+      } else {
+         // Error should go down faster than 2^nSteps because of series acceleration.
+         targetError /= 3.;
+         // But cannot be better than double precision
+         EXPECT_LT(error, std::max(targetError, 1.E-16)) << "For step " << nSteps << " with integral=" << integral;
+      }
+      if (nSteps > 10) {
+         EXPECT_LT(error / integral, 1.E-4) << "For step " << nSteps << " with integral=" << integral;
+      }
+      if (nSteps > 15) {
+         EXPECT_LT(error / integral, 1.E-6) << "For step " << nSteps << " with integral=" << integral;
+      }
+   }
+}


### PR DESCRIPTION
The RooIntegrator1D class is refactored such that it is a wrapper around a free function with only STL dependencies that does the Romberg integration.

This is very useful for R & D projects, because the integration code can be reused standalone outside of RooFit. This can serve as a reference when implementing and benchmarking new integration methods.