### PR TITLE
[WIP] TClass::GetClass: no interpreter lookups for fundamental types

### DIFF
--- a/core/foundation/inc/TClassEdit.h
+++ b/core/foundation/inc/TClassEdit.h
@@ -180,6 +180,8 @@ namespace TClassEdit {
    ROOT::ESTLType STLKind(std::string_view type);    //Kind of stl container
    inline ROOT::ESTLType STLKind(ROOT::Internal::TStringView type) { return STLKind(std::string_view(type)); }
    int         STLArgs   (int kind);            //Min number of arguments without allocator
+   void RemoveStd(std::string &name, size_t pos = 0);
+   void RemoveStd(std::string_view &name);
    std::string ResolveTypedef(const char *tname, bool resolveAll = false);
    std::string ShortType (const char *typeDesc, int mode);
    std::string InsertStd(const char *tname);

--- a/core/foundation/src/TClassEdit.cxx
+++ b/core/foundation/src/TClassEdit.cxx
@@ -112,7 +112,7 @@ static size_t StdLen(const std::string_view name)
 /// Remove std:: and any potential inline namespace (well compiler detail
 /// namespace.
 
-static void RemoveStd(std::string &name, size_t pos = 0)
+void TClassEdit::RemoveStd(std::string &name, size_t pos)
 {
    size_t len = StdLen({name.data()+pos,name.length()-pos});
    if (len) {
@@ -124,7 +124,7 @@ static void RemoveStd(std::string &name, size_t pos = 0)
 /// Remove std:: and any potential inline namespace (well compiler detail
 /// namespace.
 
-static void RemoveStd(std::string_view &name)
+void TClassEdit::RemoveStd(std::string_view &name)
 {
    size_t len = StdLen(name);
    if (len) {

--- a/core/meta/test/testTClass.cxx
+++ b/core/meta/test/testTClass.cxx
@@ -1,6 +1,9 @@
 #include "TClass.h"
 #include "THashTable.h"
 #include "TInterpreter.h"
+#include "TSystem.h"
+
+#include <ROOT/TSeq.hxx>
 
 #include "gtest/gtest.h"
 
@@ -21,4 +24,25 @@ TEST(TClass, DictCheck)
    }
 
    EXPECT_STREQ(errMsg.c_str(), "Missing dictionary for C, ") << errMsg;
+}
+
+// This test is for issue #9029
+TEST(TClass, GetClassWithFundType)
+{
+   ProcInfo_t info;
+   gSystem->GetProcInfo(&info);
+   auto start_mem = info.fMemResident;
+
+   constexpr auto name = "std::vector<int>::value_type";
+   TClass *cl = nullptr;
+   for (auto i : ROOT::TSeqI(8192)) {
+      cl = TClass::GetClass(name);
+      i = (int)i; // avoids unused variable warning
+   }
+
+   gSystem->GetProcInfo(&info);
+   auto end_mem = info.fMemResident;
+
+   EXPECT_TRUE(nullptr == cl);
+   EXPECT_NEAR(start_mem, end_mem, 16384);
 }


### PR DESCRIPTION
Add yet another fence in TClass::GetClass to avoid lookups and memory consumption. This PR aims to fix #9029. Give the sophisticated implementation of TClass::GetClass, perhaps it would be good to collect some feedback, especially by @pcanal .

# This Pull request:
This PR avoids lookups and parsing in some cases.
One of the principles of the TClass::GetClass method implementation is to avoid as much as possible. 

## Changes or fixes:
This commit adds yet another fence in TClass::GetClass, checking if the name in input is the name of a known fundamental type or typedef to it.
In order to avoid code duplication, a routine previously available within the implementation of TClassEdit has been made available with a public API.

## Checklist:

- [v ] tested changes locally
- [v ] updated the docs (if necessary)

This PR fixes #9029


