### PR TITLE
Implement options for Honeycomb

### DIFF
--- a/hist/hist/inc/TH2Poly.h
+++ b/hist/hist/inc/TH2Poly.h
@@ -108,7 +108,7 @@ public:
    Double_t     GetMinimum(Double_t minval) const override;
    Bool_t       GetNewBinAdded() const{return fNewBinAdded;}
    Int_t        GetNumberOfBins() const{return fNcells-kNOverflow;}
-   void         Honeycomb(Double_t xstart, Double_t ystart, Double_t a, Int_t k, Int_t s);
+   void         Honeycomb(Double_t xstart, Double_t ystart, Double_t a, Int_t k, Int_t s, Option_t* option = "v");
    Double_t     Integral(Option_t* option = "") const override;
    Long64_t     Merge(TCollection *) override;
    void Reset(Option_t *option) override;

--- a/hist/hist/src/TH2Poly.cxx
+++ b/hist/hist/src/TH2Poly.cxx
@@ -934,50 +934,84 @@ Double_t TH2Poly::GetMinimum(Double_t minval) const
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Bins the histogram using a honeycomb structure
+/// If the option "v" is specified, the hexagons are drawn "vertically" (default).
+/// If the option "h" is selected they are drawn "horizontally".
 
 void TH2Poly::Honeycomb(Double_t xstart, Double_t ystart, Double_t a,
-                     Int_t k, Int_t s)
+                     Int_t k, Int_t s, Option_t* option)
 {
-   // Add the bins
+   TString opt = option;
+   opt.ToLower();
    Double_t numberOfHexagonsInTheRow;
    Double_t x[6], y[6];
-   Double_t xloop, yloop, xtemp;
-   xloop = xstart; yloop = ystart + a/2.0;
-   for (int sCounter = 0; sCounter < s; sCounter++) {
+   Double_t xloop = xstart, yloop, xtemp, ytemp;
 
-      xtemp = xloop; // Resets the temp variable
+   // Add the bins
+   if (opt.Contains("v")) {
+      yloop = ystart + a/2.0;
+      for (int sCounter = 0; sCounter < s; sCounter++) {
+         xtemp = xloop;
+         // Determine the number of hexagons in that row
+         if(sCounter%2 == 0){numberOfHexagonsInTheRow = k;}
+         else{numberOfHexagonsInTheRow = k - 1;}
 
-      // Determine the number of hexagons in that row
-      if(sCounter%2 == 0){numberOfHexagonsInTheRow = k;}
-      else{numberOfHexagonsInTheRow = k - 1;}
-
-      for (int kCounter = 0; kCounter <  numberOfHexagonsInTheRow; kCounter++) {
-
-         // Go around the hexagon
-         x[0] = xtemp;
-         y[0] = yloop;
-         x[1] = x[0];
-         y[1] = y[0] + a;
-         x[2] = x[1] + a*TMath::Sqrt(3)/2.0;
-         y[2] = y[1] + a/2.0;
-         x[3] = x[2] + a*TMath::Sqrt(3)/2.0;
-         y[3] = y[1];
-         x[4] = x[3];
-         y[4] = y[0];
-         x[5] = x[2];
-         y[5] = y[4] - a/2.0;
-
-         this->AddBin(6, x, y);
-
-         // Go right
-         xtemp += a*TMath::Sqrt(3);
+         for (int kCounter = 0; kCounter <  numberOfHexagonsInTheRow; kCounter++) {
+            // Go around the hexagon
+            x[0] = xtemp;
+            y[0] = yloop;
+            x[1] = x[0];
+            y[1] = y[0] + a;
+            x[2] = x[1] + a*TMath::Sqrt(3)/2.0;
+            y[2] = y[1] + a/2.0;
+            x[3] = x[2] + a*TMath::Sqrt(3)/2.0;
+            y[3] = y[1];
+            x[4] = x[3];
+            y[4] = y[0];
+            x[5] = x[2];
+            y[5] = y[4] - a/2.0;
+            this->AddBin(6, x, y);
+            // Go right
+            xtemp += a*TMath::Sqrt(3);
+         }
+         // Increment the starting position
+         if (sCounter%2 == 0) xloop += a*TMath::Sqrt(3)/2.0;
+         else                 xloop -= a*TMath::Sqrt(3)/2.0;
+         yloop += 1.5*a;
       }
-
-      // Increment the starting position
-      if (sCounter%2 == 0) xloop += a*TMath::Sqrt(3)/2.0;
-      else                 xloop -= a*TMath::Sqrt(3)/2.0;
-      yloop += 1.5*a;
+   } else if (opt.Contains("h")) {
+      yloop = ystart + a*TMath::Sqrt(3)/2.0;
+      for (int sCounter = 0; sCounter < s; sCounter++) {
+         ytemp = yloop;
+         // Determine the number of hexagons in that row
+         if(sCounter%2 == 0){numberOfHexagonsInTheRow = k;}
+         else{numberOfHexagonsInTheRow = k - 1;}
+         for (int kCounter = 0; kCounter <  numberOfHexagonsInTheRow; kCounter++) {
+            // Go around the hexagon
+            x[0] = xloop;
+            y[0] = ytemp;
+            x[1] = x[0] + a/2.0;
+            y[1] = y[0] + a*TMath::Sqrt(3)/2.0;
+            x[2] = x[1] + a;
+            y[2] = y[1];
+            x[3] = x[2] + a/2.0;
+            y[3] = y[0];
+            x[4] = x[2];
+            y[4] = y[3] - a*TMath::Sqrt(3)/2.0;
+            x[5] = x[1];
+            y[5] = y[4];
+            this->AddBin(6, x, y);
+            // Go up
+            ytemp += a*TMath::Sqrt(3);
+         }
+         // Increment the starting position
+         if (sCounter%2 == 0) yloop += a*TMath::Sqrt(3)/2.0;
+         else                 yloop -= a*TMath::Sqrt(3)/2.0;
+         xloop += 1.5*a;
+      }
+   } else {
+      Error("Honeycomb","Unknown option");
    }
+
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/TH2Poly.cxx
+++ b/hist/hist/src/TH2Poly.cxx
@@ -937,8 +937,7 @@ Double_t TH2Poly::GetMinimum(Double_t minval) const
 /// If the option "v" is specified, the hexagons are drawn "vertically" (default).
 /// If the option "h" is selected they are drawn "horizontally".
 
-void TH2Poly::Honeycomb(Double_t xstart, Double_t ystart, Double_t a,
-                     Int_t k, Int_t s, Option_t* option)
+void TH2Poly::Honeycomb(Double_t xstart, Double_t ystart, Double_t a, Int_t k, Int_t s, Option_t* option)
 {
    TString opt = option;
    opt.ToLower();
@@ -948,22 +947,24 @@ void TH2Poly::Honeycomb(Double_t xstart, Double_t ystart, Double_t a,
 
    // Add the bins
    if (opt.Contains("v")) {
-      yloop = ystart + a/2.0;
+      yloop = ystart + a / 2.0;
       for (int sCounter = 0; sCounter < s; sCounter++) {
          xtemp = xloop;
          // Determine the number of hexagons in that row
-         if(sCounter%2 == 0){numberOfHexagonsInTheRow = k;}
-         else{numberOfHexagonsInTheRow = k - 1;}
+         if (sCounter%2 == 0)
+            numberOfHexagonsInTheRow = k;
+         else
+            numberOfHexagonsInTheRow = k - 1;
 
-         for (int kCounter = 0; kCounter <  numberOfHexagonsInTheRow; kCounter++) {
+         for (int kCounter = 0; kCounter < numberOfHexagonsInTheRow; kCounter++) {
             // Go around the hexagon
             x[0] = xtemp;
             y[0] = yloop;
             x[1] = x[0];
             y[1] = y[0] + a;
-            x[2] = x[1] + a*TMath::Sqrt(3)/2.0;
-            y[2] = y[1] + a/2.0;
-            x[3] = x[2] + a*TMath::Sqrt(3)/2.0;
+            x[2] = x[1] + a * TMath::Sqrt(3) / 2.0;
+            y[2] = y[1] + a / 2.0;
+            x[3] = x[2] + a * TMath::Sqrt(3) / 2.0;
             y[3] = y[1];
             x[4] = x[3];
             y[4] = y[0];
@@ -971,45 +972,51 @@ void TH2Poly::Honeycomb(Double_t xstart, Double_t ystart, Double_t a,
             y[5] = y[4] - a/2.0;
             this->AddBin(6, x, y);
             // Go right
-            xtemp += a*TMath::Sqrt(3);
+            xtemp += a * TMath::Sqrt(3);
          }
          // Increment the starting position
-         if (sCounter%2 == 0) xloop += a*TMath::Sqrt(3)/2.0;
-         else                 xloop -= a*TMath::Sqrt(3)/2.0;
-         yloop += 1.5*a;
+         if (sCounter%2 == 0)
+            xloop += a * TMath::Sqrt(3) / 2.0;
+         else
+            xloop -= a * TMath::Sqrt(3) / 2.0;
+         yloop += 1.5 * a;
       }
    } else if (opt.Contains("h")) {
       yloop = ystart + a*TMath::Sqrt(3)/2.0;
       for (int sCounter = 0; sCounter < s; sCounter++) {
          ytemp = yloop;
          // Determine the number of hexagons in that row
-         if(sCounter%2 == 0){numberOfHexagonsInTheRow = k;}
-         else{numberOfHexagonsInTheRow = k - 1;}
-         for (int kCounter = 0; kCounter <  numberOfHexagonsInTheRow; kCounter++) {
+         if (sCounter%2 == 0)
+            numberOfHexagonsInTheRow = k;
+         else
+            numberOfHexagonsInTheRow = k - 1;
+         for (int kCounter = 0; kCounter < numberOfHexagonsInTheRow; kCounter++) {
             // Go around the hexagon
             x[0] = xloop;
             y[0] = ytemp;
             x[1] = x[0] + a/2.0;
-            y[1] = y[0] + a*TMath::Sqrt(3)/2.0;
+            y[1] = y[0] + a * TMath::Sqrt(3) / 2.0;
             x[2] = x[1] + a;
             y[2] = y[1];
             x[3] = x[2] + a/2.0;
             y[3] = y[0];
             x[4] = x[2];
-            y[4] = y[3] - a*TMath::Sqrt(3)/2.0;
+            y[4] = y[3] - a * TMath::Sqrt(3) / 2.0;
             x[5] = x[1];
             y[5] = y[4];
             this->AddBin(6, x, y);
             // Go up
-            ytemp += a*TMath::Sqrt(3);
+            ytemp += a * TMath::Sqrt(3);
          }
          // Increment the starting position
-         if (sCounter%2 == 0) yloop += a*TMath::Sqrt(3)/2.0;
-         else                 yloop -= a*TMath::Sqrt(3)/2.0;
-         xloop += 1.5*a;
+         if (sCounter%2 == 0)
+            yloop += a * TMath::Sqrt(3) / 2.0;
+         else
+            yloop -= a * TMath::Sqrt(3) / 2.0;
+         xloop += 1.5 * a;
       }
    } else {
-      Error("Honeycomb","Unknown option");
+      Error("Honeycomb", "Unknown option");
    }
 
 }

--- a/tutorials/hist/th2polyHoneycomb.C
+++ b/tutorials/hist/th2polyHoneycomb.C
@@ -11,14 +11,25 @@
 /// \author  Olivier Couet
 
 void th2polyHoneycomb(){
-   TH2Poly *hc = new TH2Poly();
-   hc->SetTitle("Honeycomb example");
-   hc->Honeycomb(0,0,.1,25,25);
+   TCanvas *C = new TCanvas("C","C",1200,600);
+   C->Divide(2,1);
 
-   TRandom ran;
-   for (int i = 0; i<30000; i++) {
-      hc->Fill(ran.Gaus(2.,1), ran.Gaus(2.,1));
-   }
+   TH2Poly *hc1 = new TH2Poly();
+   hc1->Honeycomb(0,0,.1,5,5);
+   hc1->SetTitle("Option V (default)");
+   hc1->SetStats(0);
+   hc1->Fill(.1, .1, 15.);
+   hc1->Fill(.4, .4, 10.);
+   hc1->Fill(.5, .5, 20.);
 
-   hc->Draw("colz");
+   TH2Poly *hc2 = new TH2Poly();
+   hc2->Honeycomb(0,0,.1,5,5,"h");
+   hc2->SetTitle("Option H");
+   hc2->SetStats(0);
+   hc2->Fill(.1, .1, 15.);
+   hc2->Fill(.4, .4, 10.);
+   hc2->Fill(.5, .5, 20.);
+
+   C->cd(1)->SetGrid(); hc1->Draw("colz L");
+   C->cd(2)->SetGrid(); hc2->Draw("colz L");
 }

--- a/tutorials/hist/th2polyHoneycomb.C
+++ b/tutorials/hist/th2polyHoneycomb.C
@@ -11,11 +11,11 @@
 /// \author  Olivier Couet
 
 void th2polyHoneycomb(){
-   TCanvas *C = new TCanvas("C","C",1200,600);
+   TCanvas *C = new TCanvas("C", "C", 1200, 600);
    C->Divide(2,1);
 
    TH2Poly *hc1 = new TH2Poly();
-   hc1->Honeycomb(0,0,.1,5,5);
+   hc1->Honeycomb(0, 0, .1, 5, 5);
    hc1->SetTitle("Option V (default)");
    hc1->SetStats(0);
    hc1->Fill(.1, .1, 15.);
@@ -23,13 +23,15 @@ void th2polyHoneycomb(){
    hc1->Fill(.5, .5, 20.);
 
    TH2Poly *hc2 = new TH2Poly();
-   hc2->Honeycomb(0,0,.1,5,5,"h");
+   hc2->Honeycomb(0, 0, .1, 5, 5, "h");
    hc2->SetTitle("Option H");
    hc2->SetStats(0);
    hc2->Fill(.1, .1, 15.);
    hc2->Fill(.4, .4, 10.);
    hc2->Fill(.5, .5, 20.);
 
-   C->cd(1)->SetGrid(); hc1->Draw("colz L");
-   C->cd(2)->SetGrid(); hc2->Draw("colz L");
+   C->cd(1)->SetGrid();
+   hc1->Draw("colz L");
+   C->cd(2)->SetGrid();
+   hc2->Draw("colz L");
 }


### PR DESCRIPTION
New parameter `option` for Honeycomb.

- If the option "v" is specified, the hexagons are drawn "vertically" (default).
- If the option "h" is selected they are drawn "horizontally".

The option "h" has been suggested by Sam Liechty in this forum thread:

https://root-forum.cern.ch/t/rotate-a-figure-90-degrees/55623/7

Thanks Sam !
