### PR TITLE
[ntuple] Correct LinkDef entries for enum classes

### DIFF
--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -5,14 +5,14 @@
 #pragma link off all functions;
 
 #pragma link C++ enum CustomEnum;
-#pragma link C++ enum class CustomEnumInt8;
-#pragma link C++ enum class CustomEnumUInt8;
-#pragma link C++ enum class CustomEnumInt16;
-#pragma link C++ enum class CustomEnumUInt16;
-#pragma link C++ enum class CustomEnumInt32;
-#pragma link C++ enum class CustomEnumUInt32;
-#pragma link C++ enum class CustomEnumInt64;
-#pragma link C++ enum class CustomEnumUInt64;
+#pragma link C++ enum CustomEnumInt8;
+#pragma link C++ enum CustomEnumUInt8;
+#pragma link C++ enum CustomEnumInt16;
+#pragma link C++ enum CustomEnumUInt16;
+#pragma link C++ enum CustomEnumInt32;
+#pragma link C++ enum CustomEnumUInt32;
+#pragma link C++ enum CustomEnumInt64;
+#pragma link C++ enum CustomEnumUInt64;
 
 #pragma link C++ class CustomStruct+;
 #pragma link C++ class DerivedA+;


### PR DESCRIPTION
This fixes `gtest-tree-ntuple-v7-test-ntuple-types` in a PCH build.