### PR TITLE
[REve] Propagate transparency of REveGeoShape to the renderer

### DIFF
--- a/tutorials/eve7/event_demo.C
+++ b/tutorials/eve7/event_demo.C
@@ -161,6 +161,7 @@ void makeGeometryScene()
    b1->SetShape(new TGeoTube(kR_min, kR_max, kZ_d));
    b1->SetMainColor(kCyan);
    b1->SetNSegments(80);
+   b1->SetMainTransparency(70);
    eveMng->GetGlobalScene()->AddElement(b1);
 
    // Debug of surface fill in RPhi (index buffer screwed).

--- a/tutorials/eve7/geom_cms.C
+++ b/tutorials/eve7/geom_cms.C
@@ -27,6 +27,7 @@ void makeEveGeoShape(TGeoNode* n, REX::REveTrans& trans, REX::REveElement* holde
    b1s->RefMainTrans().SetFrom(trans.Array());
    b1s->SetShape(gss);
    b1s->SetMainColor(kCyan);
+   b1s->SetMainTransparency(30);
    holder->AddElement(b1s);
 }
 

--- a/ui5/eve7/lib/EveElements.js
+++ b/ui5/eve7/lib/EveElements.js
@@ -1230,9 +1230,10 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(/*EveManager*/) {
          let geom = this.makeEveGeometry(rnr_data);
 
          let fcol = EVE.JSR.getColor(egs.fFillColor);
+         let mop = 1 - egs.fMainTransparency/100;
 
          let material = new THREE.MeshPhongMaterial({// side: THREE.DoubleSide,
-                             depthWrite: false, color:fcol, transparent: true, opacity: 0.2 });
+                             depthWrite: false, color:fcol, transparent: true, opacity: mop });
 
          let mesh = new THREE.Mesh(geom, material);
 
@@ -1251,9 +1252,10 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(/*EveManager*/) {
          let ib_len = rnr_data.idxBuff.length;
 
          let fcol = EVE.JSR.getColor(psp.fMainColor);
+         let mop = Math.min( 1, 1.3 *(1 - psp.fMainTransparency/100));
          var line_mat = new THREE.LineBasicMaterial({color:fcol });
          var mesh_mat = new THREE.MeshBasicMaterial({ side: THREE.DoubleSide, depthWrite: false,
-                                                      color:fcol, transparent: true, opacity: 0.4 });
+                                                      color:fcol, transparent: true, opacity: mop });
 
          for (let ib_pos = 0; ib_pos < ib_len; )
          {

--- a/ui5/eve7/lib/EveElements.js
+++ b/ui5/eve7/lib/EveElements.js
@@ -1252,7 +1252,7 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(/*EveManager*/) {
          let ib_len = rnr_data.idxBuff.length;
 
          let fcol = EVE.JSR.getColor(psp.fMainColor);
-         let mop = Math.min( 1, 1.3 *(1 - psp.fMainTransparency/100));
+         let mop = Math.min( 1, 1 - psp.fMainTransparency/100);
          var line_mat = new THREE.LineBasicMaterial({color:fcol });
          var mesh_mat = new THREE.MeshBasicMaterial({ side: THREE.DoubleSide, depthWrite: false,
                                                       color:fcol, transparent: true, opacity: mop });

--- a/ui5/eve7/lib/EveElementsRCore.js
+++ b/ui5/eve7/lib/EveElementsRCore.js
@@ -1376,8 +1376,9 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function (EveManager)
          let geom = this.makeEveGeometry(rnr_data, false);
 
          let fcol = RcCol(egs.fFillColor);
+         let mop = 1 - egs.fMainTransparency/100;
 
-         let mat = this.RcFancyMaterial(fcol, 0.2);
+         let mat = this.RcFancyMaterial(fcol, mop);
          mat.side = RC.FRONT_AND_BACK_SIDE;
          mat.shininess = 50;
          mat.normalFlat = true;
@@ -1401,11 +1402,12 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function (EveManager)
          let ib_len = rnr_data.idxBuff.length;
 
          let fcol = RcCol(psp.fMainColor);
+         let mop = Math.min( 1, 1.3 *(1 - psp.fMainTransparency/100));
 
-         let material = this.RcFlatMaterial(fcol, 0.4);
+         let material = this.RcFlatMaterial(fcol, mop);
          material.side = RC.FRONT_AND_BACK_SIDE;
 
-         let line_mat = this.RcLineMaterial(fcol);
+         let line_mat = this.RcLineMaterial(fcol, mop);
 
          let meshes = [];
          for (let ib_pos = 0; ib_pos < ib_len;)

--- a/ui5/eve7/lib/EveElementsRCore.js
+++ b/ui5/eve7/lib/EveElementsRCore.js
@@ -1402,7 +1402,7 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function (EveManager)
          let ib_len = rnr_data.idxBuff.length;
 
          let fcol = RcCol(psp.fMainColor);
-         let mop = Math.min( 1, 1.3 *(1 - psp.fMainTransparency/100));
+         let mop = Math.min( 1, 1 - psp.fMainTransparency/100);
 
          let material = this.RcFlatMaterial(fcol, mop);
          material.side = RC.FRONT_AND_BACK_SIDE;


### PR DESCRIPTION
### This Pull request:
Sets main transparency of REveGeoShapes in three.js and RenderCore viewer.

### Changes or fixes:
The change fixes ignored transparency of REveGeoShape.


