### PR TITLE
[math] Avoid warnings from Vc.h from deprecated enum comparisons

### DIFF
--- a/math/mathcore/inc/Math/Types.h
+++ b/math/mathcore/inc/Math/Types.h
@@ -12,6 +12,9 @@
 #pragma GCC diagnostic ignored "-Warray-bounds"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#if (__cplusplus >= 202002L) // only for C++20
+#pragma GCC diagnostic ignored "-Wdeprecated-enum-enum-conversion"
+#endif
 
 #ifdef __clang__
 #pragma clang diagnostic ignored "-Wconditional-uninitialized"


### PR DESCRIPTION
Similar to 736644bce3b, ignoring some warnings from `Vc` that will not be fixed upstream for the foreseeable time because `Vc` is in maintainance mode.

