### PR TITLE
[rbrowser] Make fCleanupHandle a pointer to TObject

### DIFF
--- a/gui/browserv7/inc/LinkDef.h
+++ b/gui/browserv7/inc/LinkDef.h
@@ -16,7 +16,6 @@
 #pragma link C++ class ROOT::Experimental::RBrowserReply+;
 
 #pragma link C++ class ROOT::Experimental::RBrowserData+;
-#pragma link C++ class ROOT::Experimental::Internal::RBrowserDataCleanup+;
 
 #pragma link C++ class ROOT::Experimental::RBrowser+;
 #pragma link C++ class ROOT::Experimental::RFileDialog+;

--- a/gui/browserv7/inc/ROOT/RBrowserData.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowserData.hxx
@@ -49,7 +49,7 @@ class RBrowserData {
    std::vector<const Browsable::RItem *> fLastSortedItems;   ///<! sorted child items, used in requests
    std::string fLastSortMethod;                          ///<! last sort method
    bool fLastSortReverse{false};                         ///<! last request reverse order
-   std::unique_ptr<RBrowserDataCleanup> fCleanupHandle;  ///<! cleanup handle for RecursiveRemove
+   std::unique_ptr<TObject> fCleanupHandle;              ///<! cleanup handle for RecursiveRemove
 
    void ResetLastRequestData(bool with_element);
 

--- a/gui/browserv7/inc/ROOT/RBrowserData.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowserData.hxx
@@ -18,8 +18,6 @@
 #include <ROOT/RBrowserRequest.hxx>
 #include <ROOT/RBrowserReply.hxx>
 
-#include "TObject.h"
-
 #include <memory>
 #include <string>
 #include <vector>
@@ -32,13 +30,11 @@ class RLogChannel;
 /// Log channel for Browser diagnostics.
 RLogChannel &BrowserLog();
 
-namespace Internal {
 class RBrowserDataCleanup;
-}
 
 class RBrowserData {
 
-   friend class Internal::RBrowserDataCleanup;
+   friend class RBrowserDataCleanup;
 
    std::shared_ptr<Browsable::RElement> fTopElement;    ///<! top element
 
@@ -53,7 +49,7 @@ class RBrowserData {
    std::vector<const Browsable::RItem *> fLastSortedItems;   ///<! sorted child items, used in requests
    std::string fLastSortMethod;                          ///<! last sort method
    bool fLastSortReverse{false};                         ///<! last request reverse order
-   std::unique_ptr<Internal::RBrowserDataCleanup> fCleanupHandle; ///<! cleanup handle for RecursiveRemove
+   std::unique_ptr<RBrowserDataCleanup> fCleanupHandle;  ///<! cleanup handle for RecursiveRemove
 
    void ResetLastRequestData(bool with_element);
 
@@ -90,19 +86,6 @@ public:
 
 };
 
-namespace Internal {
-class RBrowserDataCleanup : public TObject {
-
-   RBrowserData &fData;
-
-public:
-   RBrowserDataCleanup(RBrowserData &_data) : fData(_data) {}
-
-   void RecursiveRemove(TObject *obj) override { fData.RemoveFromCache(obj); }
-
-   ClassDefOverride(RBrowserDataCleanup, 0)
-};
-} // namespace Internal
 
 } // namespace Experimental
 } // namespace ROOT

--- a/gui/browserv7/src/RBrowserData.cxx
+++ b/gui/browserv7/src/RBrowserData.cxx
@@ -37,6 +37,25 @@ ROOT::Experimental::RLogChannel &ROOT::Experimental::BrowserLog() {
    return sLog;
 }
 
+namespace ROOT {
+namespace Experimental {
+
+class RBrowserDataCleanup : public TObject {
+
+   RBrowserData &fData;
+
+public:
+   RBrowserDataCleanup(RBrowserData &_data) : fData(_data) {}
+
+   void RecursiveRemove(TObject *obj) override
+   {
+      fData.RemoveFromCache(obj);
+   }
+};
+}
+}
+
+
 /** \class ROOT::Experimental::RBrowserData
 \ingroup rbrowser
 \brief Way to browse (hopefully) everything in %ROOT
@@ -48,7 +67,7 @@ ROOT::Experimental::RLogChannel &ROOT::Experimental::BrowserLog() {
 
 RBrowserData::RBrowserData()
 {
-   fCleanupHandle = std::make_unique<Internal::RBrowserDataCleanup>(*this);
+   fCleanupHandle = std::make_unique<RBrowserDataCleanup>(*this);
    R__LOCKGUARD(gROOTMutex);
    gROOT->GetListOfCleanups()->Add(fCleanupHandle.get());
 }


### PR DESCRIPTION
This also fixes the test `roottest-root-core-execStatusBitsCheck` when building with `runtime_cxxmodules=OFF`.

Closes https://github.com/root-project/root/issues/13058