### PR TITLE
[ntuple] Add `GetColumnsByType`

### DIFF
--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -157,6 +157,9 @@ public:
 
    const RColumnInfo &GetColumnInfo(DescriptorId_t physicalColumnId) const;
 
+   /// Get the number of columns of a given type present in the RNTuple.
+   size_t GetColumnTypeCount(EColumnType colType) const;
+
    const RFieldTreeInfo &GetFieldTreeInfo(DescriptorId_t fieldId) const;
    const RFieldTreeInfo &GetFieldTreeInfo(std::string_view fieldName) const;
 
@@ -167,9 +170,6 @@ public:
    {
       return GetFieldTypeCount(std::regex{std::string(typeNamePattern)}, searchInSubFields);
    }
-
-   /// Get the number of columns of a given type present in the RNTuple.
-   size_t GetColumnTypeCount(EColumnType colType) const;
 
    /// Get the IDs of (sub-)fields whose name matches the given string. Because field names are unique by design,
    /// providing a single field name will return a vector containing just the ID of that field. However, regular

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -160,6 +160,9 @@ public:
    /// Get the number of columns of a given type present in the RNTuple.
    size_t GetColumnTypeCount(EColumnType colType) const;
 
+   /// Get the IDs of all columns with the given type.
+   const std::vector<DescriptorId_t> GetColumnsByType(EColumnType);
+
    const RFieldTreeInfo &GetFieldTreeInfo(DescriptorId_t fieldId) const;
    const RFieldTreeInfo &GetFieldTreeInfo(std::string_view fieldName) const;
 

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -176,22 +176,16 @@ ROOT::Experimental::RNTupleInspector::Create(std::string_view ntupleName, std::s
    return inspector;
 }
 
-size_t
-ROOT::Experimental::RNTupleInspector::GetFieldTypeCount(const std::regex &typeNamePattern, bool searchInSubFields) const
+//------------------------------------------------------------------------------
+
+const ROOT::Experimental::RNTupleInspector::RColumnInfo &
+ROOT::Experimental::RNTupleInspector::GetColumnInfo(DescriptorId_t physicalColumnId) const
 {
-   size_t typeCount = 0;
-
-   for (auto &[fldId, fldInfo] : fFieldTreeInfo) {
-      if (!searchInSubFields && fldInfo.GetDescriptor().GetParentId() != fDescriptor->GetFieldZeroId()) {
-         continue;
-      }
-
-      if (std::regex_match(fldInfo.GetDescriptor().GetTypeName(), typeNamePattern)) {
-         typeCount++;
-      }
+   if (physicalColumnId > fDescriptor->GetNPhysicalColumns()) {
+      throw RException(R__FAIL("No column with physical ID " + std::to_string(physicalColumnId) + " present"));
    }
 
-   return typeCount;
+   return fColumnInfo.at(physicalColumnId);
 }
 
 size_t ROOT::Experimental::RNTupleInspector::GetColumnTypeCount(ROOT::Experimental::EColumnType colType) const
@@ -207,15 +201,7 @@ size_t ROOT::Experimental::RNTupleInspector::GetColumnTypeCount(ROOT::Experiment
    return typeCount;
 }
 
-const ROOT::Experimental::RNTupleInspector::RColumnInfo &
-ROOT::Experimental::RNTupleInspector::GetColumnInfo(DescriptorId_t physicalColumnId) const
-{
-   if (physicalColumnId > fDescriptor->GetNPhysicalColumns()) {
-      throw RException(R__FAIL("No column with physical ID " + std::to_string(physicalColumnId) + " present"));
-   }
-
-   return fColumnInfo.at(physicalColumnId);
-}
+//------------------------------------------------------------------------------
 
 const ROOT::Experimental::RNTupleInspector::RFieldTreeInfo &
 ROOT::Experimental::RNTupleInspector::GetFieldTreeInfo(DescriptorId_t fieldId) const
@@ -237,6 +223,24 @@ ROOT::Experimental::RNTupleInspector::GetFieldTreeInfo(std::string_view fieldNam
    }
 
    return GetFieldTreeInfo(fieldId);
+}
+
+size_t
+ROOT::Experimental::RNTupleInspector::GetFieldTypeCount(const std::regex &typeNamePattern, bool includeSubFields) const
+{
+   size_t typeCount = 0;
+
+   for (auto &[fldId, fldInfo] : fFieldTreeInfo) {
+      if (!includeSubFields && fldInfo.GetDescriptor().GetParentId() != fDescriptor->GetFieldZeroId()) {
+         continue;
+      }
+
+      if (std::regex_match(fldInfo.GetDescriptor().GetTypeName(), typeNamePattern)) {
+         typeCount++;
+      }
+   }
+
+   return typeCount;
 }
 
 const std::vector<ROOT::Experimental::DescriptorId_t>

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -201,6 +201,19 @@ size_t ROOT::Experimental::RNTupleInspector::GetColumnTypeCount(ROOT::Experiment
    return typeCount;
 }
 
+const std::vector<ROOT::Experimental::DescriptorId_t>
+ROOT::Experimental::RNTupleInspector::GetColumnsByType(ROOT::Experimental::EColumnType colType)
+{
+   std::vector<DescriptorId_t> colIds;
+
+   for (const auto &[colId, colInfo] : fColumnInfo) {
+      if (colInfo.GetType() == colType)
+         colIds.emplace_back(colId);
+   }
+
+   return colIds;
+}
+
 //------------------------------------------------------------------------------
 
 const ROOT::Experimental::RNTupleInspector::RFieldTreeInfo &

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -59,9 +59,7 @@ TEST(RNTupleInspector, CompressionSettings)
       ntuple->Fill();
    }
 
-   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
-   auto ntuple = file->Get<RNTuple>("ntuple");
-   auto inspector = RNTupleInspector::Create(ntuple);
+   auto inspector = RNTupleInspector::Create("ntuple", fileGuard.GetPath());
 
    EXPECT_EQ(505, inspector->GetCompressionSettings());
 }
@@ -83,9 +81,7 @@ TEST(RNTupleInspector, SizeUncompressedSimple)
       }
    }
 
-   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
-   auto ntuple = file->Get<RNTuple>("ntuple");
-   auto inspector = RNTupleInspector::Create(ntuple);
+   auto inspector = RNTupleInspector::Create("ntuple", fileGuard.GetPath());
 
    EXPECT_EQ(sizeof(int32_t) * 5, inspector->GetInMemorySize());
    EXPECT_EQ(inspector->GetOnDiskSize(), inspector->GetInMemorySize());
@@ -110,9 +106,7 @@ TEST(RNTupleInspector, SizeUncompressedComplex)
       ntuple->Fill();
    }
 
-   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
-   auto ntuple = file->Get<RNTuple>("ntuple");
-   auto inspector = RNTupleInspector::Create(ntuple);
+   auto inspector = RNTupleInspector::Create("ntuple", fileGuard.GetPath());
 
    int nIndexCols = inspector->GetColumnTypeCount(ROOT::Experimental::EColumnType::kIndex64);
    int nEntries = inspector->GetDescriptor()->GetNEntries();
@@ -140,9 +134,7 @@ TEST(RNTupleInspector, SizeCompressedInt)
       }
    }
 
-   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
-   auto ntuple = file->Get<RNTuple>("ntuple");
-   auto inspector = RNTupleInspector::Create(ntuple);
+   auto inspector = RNTupleInspector::Create("ntuple", fileGuard.GetPath());
 
    EXPECT_EQ(sizeof(int32_t) * 50, inspector->GetInMemorySize());
    EXPECT_GT(inspector->GetOnDiskSize(), 0);
@@ -171,9 +163,7 @@ TEST(RNTupleInspector, SizeCompressedComplex)
       }
    }
 
-   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
-   auto ntuple = file->Get<RNTuple>("ntuple");
-   auto inspector = RNTupleInspector::Create(ntuple);
+   auto inspector = RNTupleInspector::Create("ntuple", fileGuard.GetPath());
 
    EXPECT_GT(inspector->GetOnDiskSize(), 0);
    EXPECT_LT(inspector->GetOnDiskSize(), inspector->GetInMemorySize());
@@ -188,9 +178,7 @@ TEST(RNTupleInspector, SizeEmpty)
       RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
    }
 
-   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
-   auto ntuple = file->Get<RNTuple>("ntuple");
-   auto inspector = RNTupleInspector::Create(ntuple);
+   auto inspector = RNTupleInspector::Create("ntuple", fileGuard.GetPath());
 
    EXPECT_EQ(0, inspector->GetOnDiskSize());
    EXPECT_EQ(0, inspector->GetInMemorySize());
@@ -217,9 +205,7 @@ TEST(RNTupleInspector, ColumnInfoCompressed)
       }
    }
 
-   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
-   auto ntuple = file->Get<RNTuple>("ntuple");
-   auto inspector = RNTupleInspector::Create(ntuple);
+   auto inspector = RNTupleInspector::Create("ntuple", fileGuard.GetPath());
 
    std::uint64_t totalOnDiskSize = 0;
 
@@ -263,9 +249,7 @@ TEST(RNTupleInspector, ColumnInfoUncompressed)
       }
    }
 
-   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
-   auto ntuple = file->Get<RNTuple>("ntuple");
-   auto inspector = RNTupleInspector::Create(ntuple);
+   auto inspector = RNTupleInspector::Create("ntuple", fileGuard.GetPath());
 
    std::uint64_t colTypeSizes[] = {sizeof(std::int32_t), sizeof(double)};
 
@@ -288,9 +272,7 @@ TEST(RNTupleInspector, ColumnTypeCount)
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
    }
 
-   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
-   auto ntuple = file->Get<RNTuple>("ntuple");
-   auto inspector = RNTupleInspector::Create(ntuple);
+   auto inspector = RNTupleInspector::Create("ntuple", fileGuard.GetPath());
 
    EXPECT_EQ(2, inspector->GetColumnTypeCount(ROOT::Experimental::EColumnType::kSplitIndex64));
    EXPECT_EQ(4, inspector->GetColumnTypeCount(ROOT::Experimental::EColumnType::kSplitReal32));
@@ -318,9 +300,7 @@ TEST(RNTupleInspector, FieldInfoCompressed)
       }
    }
 
-   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
-   auto ntuple = file->Get<RNTuple>("ntuple");
-   auto inspector = RNTupleInspector::Create(ntuple);
+   auto inspector = RNTupleInspector::Create("ntuple", fileGuard.GetPath());
 
    auto topFieldInfo = inspector->GetFieldTreeInfo("object");
 
@@ -365,9 +345,7 @@ TEST(RNTupleInspector, FieldInfoUncompressed)
       }
    }
 
-   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
-   auto ntuple = file->Get<RNTuple>("ntuple");
-   auto inspector = RNTupleInspector::Create(ntuple);
+   auto inspector = RNTupleInspector::Create("ntuple", fileGuard.GetPath());
 
    auto topFieldInfo = inspector->GetFieldTreeInfo("object");
 
@@ -403,9 +381,7 @@ TEST(RNTupleInspector, FieldTypeCount)
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
    }
 
-   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
-   auto ntuple = file->Get<RNTuple>("ntuple");
-   auto inspector = RNTupleInspector::Create(ntuple);
+   auto inspector = RNTupleInspector::Create("ntuple", fileGuard.GetPath());
 
    EXPECT_EQ(1, inspector->GetFieldTypeCount("ComplexStructUtil"));
    EXPECT_EQ(1, inspector->GetFieldTypeCount("ComplexStructUtil", false));
@@ -442,9 +418,7 @@ TEST(RNTupleInspector, FieldsByName)
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
    }
 
-   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
-   auto ntuple = file->Get<RNTuple>("ntuple");
-   auto inspector = RNTupleInspector::Create(ntuple);
+   auto inspector = RNTupleInspector::Create("ntuple", fileGuard.GetPath());
 
    auto intFieldIds = inspector->GetFieldsByName("int.");
 

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -88,7 +88,6 @@ TEST(RNTupleInspector, SizeUncompressedSimple)
    auto inspector = RNTupleInspector::Create(ntuple);
 
    EXPECT_EQ(sizeof(int32_t) * 5, inspector->GetInMemorySize());
-
    EXPECT_EQ(inspector->GetOnDiskSize(), inspector->GetInMemorySize());
 }
 
@@ -197,67 +196,6 @@ TEST(RNTupleInspector, SizeEmpty)
    EXPECT_EQ(0, inspector->GetInMemorySize());
 }
 
-TEST(RNTupleInspector, FieldTypeCount)
-{
-   FileRaii fileGuard("test_ntuple_inspector_field_type_count.root");
-   {
-      auto model = RNTupleModel::Create();
-      auto nFldObject = model->MakeField<ComplexStructUtil>("object");
-      auto nFldInt1 = model->MakeField<std::int32_t>("int1");
-      auto nFldInt2 = model->MakeField<std::int32_t>("int2");
-      auto nFldInt3 = model->MakeField<std::int32_t>("int3");
-      auto nFldString1 = model->MakeField<std::string>("string1");
-      auto nFldString2 = model->MakeField<std::string>("string2");
-
-      auto writeOptions = RNTupleWriteOptions();
-      writeOptions.SetCompression(505);
-      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
-   }
-
-   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
-   auto ntuple = file->Get<RNTuple>("ntuple");
-   auto inspector = RNTupleInspector::Create(ntuple);
-
-   EXPECT_EQ(1, inspector->GetFieldTypeCount("ComplexStructUtil"));
-   EXPECT_EQ(1, inspector->GetFieldTypeCount("ComplexStructUtil", false));
-
-   EXPECT_EQ(1, inspector->GetFieldTypeCount("std::vector<HitUtil>"));
-   EXPECT_EQ(0, inspector->GetFieldTypeCount("std::vector<HitUtil>", false));
-
-   EXPECT_EQ(2, inspector->GetFieldTypeCount("std::vector<.*>"));
-   EXPECT_EQ(0, inspector->GetFieldTypeCount("std::vector<.*>", false));
-
-   EXPECT_EQ(3, inspector->GetFieldTypeCount("BaseUtil"));
-   EXPECT_EQ(0, inspector->GetFieldTypeCount("BaseUtil", false));
-
-   EXPECT_EQ(6, inspector->GetFieldTypeCount("std::int32_t"));
-   EXPECT_EQ(3, inspector->GetFieldTypeCount("std::int32_t", false));
-
-   EXPECT_EQ(4, inspector->GetFieldTypeCount("float"));
-   EXPECT_EQ(0, inspector->GetFieldTypeCount("float", false));
-}
-
-TEST(RNTupleInspector, ColumnTypeCount)
-{
-   FileRaii fileGuard("test_ntuple_inspector_column_type_count.root");
-   {
-      auto model = RNTupleModel::Create();
-      auto nFldObject = model->MakeField<ComplexStructUtil>("object");
-
-      auto writeOptions = RNTupleWriteOptions();
-      writeOptions.SetCompression(505);
-      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
-   }
-
-   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
-   auto ntuple = file->Get<RNTuple>("ntuple");
-   auto inspector = RNTupleInspector::Create(ntuple);
-
-   EXPECT_EQ(2, inspector->GetColumnTypeCount(ROOT::Experimental::EColumnType::kSplitIndex64));
-   EXPECT_EQ(4, inspector->GetColumnTypeCount(ROOT::Experimental::EColumnType::kSplitReal32));
-   EXPECT_EQ(3, inspector->GetColumnTypeCount(ROOT::Experimental::EColumnType::kSplitInt32));
-}
-
 TEST(RNTupleInspector, ColumnInfoCompressed)
 {
    FileRaii fileGuard("test_ntuple_inspector_column_info_compressed.root");
@@ -336,6 +274,27 @@ TEST(RNTupleInspector, ColumnInfoUncompressed)
       EXPECT_EQ(colInfo.GetOnDiskSize(), colInfo.GetInMemorySize());
       EXPECT_EQ(colInfo.GetOnDiskSize(), colTypeSizes[i] * 5);
    }
+}
+
+TEST(RNTupleInspector, ColumnTypeCount)
+{
+   FileRaii fileGuard("test_ntuple_inspector_column_type_count.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto nFldObject = model->MakeField<ComplexStructUtil>("object");
+
+      auto writeOptions = RNTupleWriteOptions();
+      writeOptions.SetCompression(505);
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
+   }
+
+   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
+   auto ntuple = file->Get<RNTuple>("ntuple");
+   auto inspector = RNTupleInspector::Create(ntuple);
+
+   EXPECT_EQ(2, inspector->GetColumnTypeCount(ROOT::Experimental::EColumnType::kSplitIndex64));
+   EXPECT_EQ(4, inspector->GetColumnTypeCount(ROOT::Experimental::EColumnType::kSplitReal32));
+   EXPECT_EQ(3, inspector->GetColumnTypeCount(ROOT::Experimental::EColumnType::kSplitInt32));
 }
 
 TEST(RNTupleInspector, FieldInfoCompressed)
@@ -425,6 +384,46 @@ TEST(RNTupleInspector, FieldInfoUncompressed)
 
    EXPECT_EQ(topFieldInfo.GetOnDiskSize(), subFieldOnDiskSize);
    EXPECT_EQ(topFieldInfo.GetInMemorySize(), subFieldInMemorySize);
+}
+
+TEST(RNTupleInspector, FieldTypeCount)
+{
+   FileRaii fileGuard("test_ntuple_inspector_field_type_count.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto nFldObject = model->MakeField<ComplexStructUtil>("object");
+      auto nFldInt1 = model->MakeField<std::int32_t>("int1");
+      auto nFldInt2 = model->MakeField<std::int32_t>("int2");
+      auto nFldInt3 = model->MakeField<std::int32_t>("int3");
+      auto nFldString1 = model->MakeField<std::string>("string1");
+      auto nFldString2 = model->MakeField<std::string>("string2");
+
+      auto writeOptions = RNTupleWriteOptions();
+      writeOptions.SetCompression(505);
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
+   }
+
+   std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str()));
+   auto ntuple = file->Get<RNTuple>("ntuple");
+   auto inspector = RNTupleInspector::Create(ntuple);
+
+   EXPECT_EQ(1, inspector->GetFieldTypeCount("ComplexStructUtil"));
+   EXPECT_EQ(1, inspector->GetFieldTypeCount("ComplexStructUtil", false));
+
+   EXPECT_EQ(1, inspector->GetFieldTypeCount("std::vector<HitUtil>"));
+   EXPECT_EQ(0, inspector->GetFieldTypeCount("std::vector<HitUtil>", false));
+
+   EXPECT_EQ(2, inspector->GetFieldTypeCount("std::vector<.*>"));
+   EXPECT_EQ(0, inspector->GetFieldTypeCount("std::vector<.*>", false));
+
+   EXPECT_EQ(3, inspector->GetFieldTypeCount("BaseUtil"));
+   EXPECT_EQ(0, inspector->GetFieldTypeCount("BaseUtil", false));
+
+   EXPECT_EQ(6, inspector->GetFieldTypeCount("std::int32_t"));
+   EXPECT_EQ(3, inspector->GetFieldTypeCount("std::int32_t", false));
+
+   EXPECT_EQ(4, inspector->GetFieldTypeCount("float"));
+   EXPECT_EQ(0, inspector->GetFieldTypeCount("float", false));
 }
 
 TEST(RNTupleInspector, FieldsByName)

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -279,6 +279,42 @@ TEST(RNTupleInspector, ColumnTypeCount)
    EXPECT_EQ(3, inspector->GetColumnTypeCount(ROOT::Experimental::EColumnType::kSplitInt32));
 }
 
+TEST(RNTupleInspector, ColumnsByType)
+{
+   FileRaii fileGuard("test_ntuple_inspector_columns_by_type.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto nFldInt1 = model->MakeField<std::int64_t>("int1");
+      auto nFldInt2 = model->MakeField<std::int64_t>("int2");
+      auto nFldFloat = model->MakeField<float>("float");
+      auto nFldFloatVec = model->MakeField<std::vector<float>>("floatVec");
+
+      auto writeOptions = RNTupleWriteOptions();
+      writeOptions.SetCompression(505);
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
+   }
+
+   auto inspector = RNTupleInspector::Create("ntuple", fileGuard.GetPath());
+
+   EXPECT_EQ(2U, inspector->GetColumnsByType(ROOT::Experimental::EColumnType::kSplitInt64).size());
+   for (const auto colId : inspector->GetColumnsByType(ROOT::Experimental::EColumnType::kSplitInt64)) {
+      EXPECT_EQ(ROOT::Experimental::EColumnType::kSplitInt64, inspector->GetColumnInfo(colId).GetType());
+   }
+
+   EXPECT_EQ(2U, inspector->GetColumnsByType(ROOT::Experimental::EColumnType::kSplitReal32).size());
+   for (const auto colId : inspector->GetColumnsByType(ROOT::Experimental::EColumnType::kSplitReal32)) {
+      EXPECT_EQ(ROOT::Experimental::EColumnType::kSplitReal32, inspector->GetColumnInfo(colId).GetType());
+   }
+
+   EXPECT_EQ(1U, inspector->GetColumnsByType(ROOT::Experimental::EColumnType::kSplitIndex64).size());
+   EXPECT_EQ(1U, inspector->GetColumnsByType(ROOT::Experimental::EColumnType::kSplitIndex64).size());
+   for (const auto colId : inspector->GetColumnsByType(ROOT::Experimental::EColumnType::kSplitIndex64)) {
+      EXPECT_EQ(ROOT::Experimental::EColumnType::kSplitIndex64, inspector->GetColumnInfo(colId).GetType());
+   }
+
+   EXPECT_EQ(0U, inspector->GetColumnsByType(ROOT::Experimental::EColumnType::kSplitReal64).size());
+}
+
 TEST(RNTupleInspector, FieldInfoCompressed)
 {
    FileRaii fileGuard("test_ntuple_inspector_field_info_compressed.root");


### PR DESCRIPTION
This PR adds an additional method to get the IDs of all columns with the given type. It also restructures the `RNTupleInspector` file structure to better group column- and field-related methods.

