### PR TITLE
[dictgen] remove -Wno-noexcept-type quirk for old clang versions

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -3031,10 +3031,6 @@ static void CheckForMinusW(std::string arg,
 
    if (arg.find(pattern) != 0)
       return;
-   if (arg == "-Wno-noexcept-type") {
-      // GCC7 warning not supported by clang 3.9
-      return;
-   }
 
    ROOT::TMetaUtils::ReplaceAll(arg, pattern, "#pragma clang diagnostic ignored \"-W");
    arg += "\"";


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Removes a -W quirk for old clang version, has since been added to clang: https://releases.llvm.org/13.0.0/tools/clang/docs/DiagnosticsReference.html#wnoexcept-type

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

