### PR TITLE
[cmake] Bump minimum CMake version

### DIFF
--- a/cmake/scripts/RootUseFile.cmake.in
+++ b/cmake/scripts/RootUseFile.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 #---Define the Standard macros for ROOT-----------------------------------------------------------
 include(${CMAKE_CURRENT_LIST_DIR}/RootMacros.cmake)

--- a/graf2d/asimage/src/libAfterImage/CMakeLists.txt
+++ b/graf2d/asimage/src/libAfterImage/CMakeLists.txt
@@ -11,7 +11,7 @@ if(WIN32)
   # to keep the old way of selecting the runtime library with the -MD/-MDd compiler flag
   cmake_policy(SET CMP0091 OLD)
 else()
-  cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+  cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 endif()
 
 SET(LIB_NAME libAfterImage)
@@ -55,4 +55,3 @@ SET(SRC_FILES
 ADD_LIBRARY(${LIB_NAME} STATIC ${H_FILES} ${SRC_FILES})
 
 install(TARGETS ${LIB_NAME} DESTINATION ${LIB_DESTINATION})
-

--- a/math/genetic/test/CMakeLists.txt
+++ b/math/genetic/test/CMakeLists.txt
@@ -5,7 +5,7 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
 if(NOT DEFINED ROOT_SOURCE_DIR)
-   cmake_minimum_required(VERSION 3.9)
+   cmake_minimum_required(VERSION 3.10)
    project(genetic-tests)
    find_package(ROOT REQUIRED)
    include(${ROOT_USE_FILE})

--- a/math/minuit2/CMakeLists.txt
+++ b/math/minuit2/CMakeLists.txt
@@ -4,7 +4,7 @@
 # For the licensing terms see $ROOTSYS/LICENSE.
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 if(NOT CMAKE_PROJECT_NAME STREQUAL ROOT)
   project(Minuit2 LANGUAGES CXX)

--- a/math/minuit2/StandAlone.cmake
+++ b/math/minuit2/StandAlone.cmake
@@ -1,6 +1,6 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.10)
 
-# Tested with and supporting policies up to the following CMake version. 
+# Tested with and supporting policies up to the following CMake version.
 # Not using ... syntax due to parser bug in MSVC's built-in CMake server mode.
 if(${CMAKE_VERSION} VERSION_LESS 3.12)
     cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
@@ -126,7 +126,7 @@ export(PACKAGE Minuit2)
 # Only add tests and docs if this is the main project
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     enable_testing()
-    
+
     # Make adding tests cleaner using this macro
     macro(add_minuit2_test TESTNAME)
         add_executable(${TESTNAME} ${ARGN})
@@ -207,4 +207,3 @@ set(CPACK_SOURCE_IGNORE_FILES
     /Pipfile.*$
 )
 include(CPack)
-

--- a/math/minuit2/examples/simple/CMakeLists.txt
+++ b/math/minuit2/examples/simple/CMakeLists.txt
@@ -4,7 +4,7 @@
 # For the licensing terms see $ROOTSYS/LICENSE.
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.10)
 # This is a test of the Minuit2 CMake build system.
 
 project(Quad1F LANGUAGES CXX)

--- a/math/minuit2/test/CMakeLists.txt
+++ b/math/minuit2/test/CMakeLists.txt
@@ -5,7 +5,7 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
 if(NOT DEFINED ROOT_SOURCE_DIR)
-   cmake_minimum_required(VERSION 3.9)
+   cmake_minimum_required(VERSION 3.10)
    project(minuit2_tests)
    find_package(ROOT REQUIRED)
    include(${ROOT_USE_FILE})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,7 +9,7 @@
 # using the ROOT libraries on all supported platforms.
 #
 # Author: Pere Mato, 25/10/2010
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 project(test)
 

--- a/test/RootShower/CMakeLists.txt
+++ b/test/RootShower/CMakeLists.txt
@@ -4,7 +4,7 @@
 # For the licensing terms see $ROOTSYS/LICENSE.
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 project(RootShower)
 

--- a/test/periodic/CMakeLists.txt
+++ b/test/periodic/CMakeLists.txt
@@ -4,7 +4,7 @@
 # For the licensing terms see $ROOTSYS/LICENSE.
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 project(periodic)
 

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 # CMakeLists.txt for the ROOT tutorials programs.
 # Author: Pere Mato, 25/10/2010
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 project(tutorials)
 

--- a/tutorials/tree/dictionary/CMakeLists.txt
+++ b/tutorials/tree/dictionary/CMakeLists.txt
@@ -12,7 +12,7 @@
 #####################################################################################################################
 
 # CMakeLists.txt that creates a library with dictionary and a main program
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 project(treeUsingCustomClass)
 

--- a/tutorials/webgui/qtweb/CMakeLists.txt
+++ b/tutorials/webgui/qtweb/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 project(qtweb)
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

With CMake `3.27` I get this warning:
```
CMake Deprecation Warning at interpreter/cling/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

Thus I bumped the minimum required CMake version to `3.10`, which is the version included in Ubuntu 18.04 LTS. In theory `3.6` would also work, but `3.10` gives a bit of margin for the future. The version in cling is synced with LLVM.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)
