### PR TITLE
[cmake] Remove faulty GTEST_INCLUDE_DIRS

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -2057,7 +2057,6 @@ if (builtin_gtest)
     add_library(${lib} IMPORTED STATIC GLOBAL)
     set_target_properties(${lib} PROPERTIES
       IMPORTED_LOCATION "${_G_LIBRARY_PATH}${CMAKE_STATIC_LIBRARY_PREFIX}${lib}${CMAKE_STATIC_LIBRARY_SUFFIX}"
-      INTERFACE_INCLUDE_DIRECTORIES "${GTEST_INCLUDE_DIRS}"
     )
     add_dependencies(${lib} googletest)
     if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND


### PR DESCRIPTION
If `builtin_gtest` was initially off (since commit 28ddffca94), we first try to look for an installed version of GTest. If not found, this falls back to `builtin_gtest`, but also sets `GTEST_INCLUDE_DIRS` to `GTEST_INCLUDE_DIRS-NOTFOUND`, which is not a valid value to have in `INTERFACE_INCLUDE_DIRECTORIES`.