### PR TITLE
[RF] Add documentation to `RooB*Decay` constructors

### DIFF
--- a/roofit/roofit/inc/RooBCPEffDecay.h
+++ b/roofit/roofit/inc/RooBCPEffDecay.h
@@ -37,7 +37,6 @@ public:
 
   RooBCPEffDecay(const RooBCPEffDecay& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooBCPEffDecay(*this,newname) ; }
-  ~RooBCPEffDecay() override;
 
   double coefficient(Int_t basisIndex) const override ;
 

--- a/roofit/roofit/inc/RooBCPGenDecay.h
+++ b/roofit/roofit/inc/RooBCPGenDecay.h
@@ -38,7 +38,6 @@ public:
 
   RooBCPGenDecay(const RooBCPGenDecay& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooBCPGenDecay(*this,newname) ; }
-  ~RooBCPGenDecay() override;
 
   double coefficient(Int_t basisIndex) const override ;
 

--- a/roofit/roofit/inc/RooBDecay.h
+++ b/roofit/roofit/inc/RooBDecay.h
@@ -42,7 +42,6 @@ public:
   {
     return new RooBDecay(*this,newname);
   }
-  ~RooBDecay() override;
 
   double coefficient(Int_t basisIndex) const override;
   RooFit::OwningPtr<RooArgSet> coefVars(Int_t coefIdx) const override ;

--- a/roofit/roofit/inc/RooBMixDecay.h
+++ b/roofit/roofit/inc/RooBMixDecay.h
@@ -35,7 +35,6 @@ public:
 
   RooBMixDecay(const RooBMixDecay& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooBMixDecay(*this,newname) ; }
-  ~RooBMixDecay() override;
 
   double coefficient(Int_t basisIndex) const override ;
 

--- a/roofit/roofit/src/RooBCPEffDecay.cxx
+++ b/roofit/roofit/src/RooBCPEffDecay.cxx
@@ -32,19 +32,35 @@ using namespace std;
 
 ClassImp(RooBCPEffDecay);
 
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor.
+/// \brief Constructor for RooBCPEffDecay.
+///
+/// Creates an instance of RooBCPEffDecay with the specified parameters.
+///
+/// \param[in] name         The name of the PDF.
+/// \param[in] title        The title of the PDF.
+/// \param[in] t            The time variable.
+/// \param[in] tag          The CP state category.
+/// \param[in] tau          The decay time parameter.
+/// \param[in] dm           The mixing frequency parameter.
+/// \param[in] avgMistag    The average mistag rate parameter.
+/// \param[in] CPeigenval   The CP eigen value parameter.
+/// \param[in] absLambda    The absolute value of the complex lambda parameter.
+/// \param[in] argLambda    The argument of the complex lambda parameter.
+/// \param[in] effRatio     The B0/B0bar efficiency ratio.
+/// \param[in] delMistag    Delta mistag rate parameter.
+/// \param[in] model        The resolution model.
+/// \param[in] type         The decay type.
 
 RooBCPEffDecay::RooBCPEffDecay(const char *name, const char *title,
                 RooRealVar& t, RooAbsCategory& tag,
                 RooAbsReal& tau, RooAbsReal& dm,
                 RooAbsReal& avgMistag, RooAbsReal& CPeigenval,
-                RooAbsReal& a, RooAbsReal& b,
+                RooAbsReal& absLambda, RooAbsReal& argLambda,
                 RooAbsReal& effRatio, RooAbsReal& delMistag,
                 const RooResolutionModel& model, DecayType type) :
   RooAbsAnaConvPdf(name,title,model,t),
-  _absLambda("absLambda","Absolute value of lambda",this,a),
-  _argLambda("argLambda","Arg(Lambda)",this,b),
+  _absLambda("absLambda","Absolute value of lambda",this,absLambda),
+  _argLambda("argLambda","Arg(Lambda)",this,argLambda),
   _effRatio("effRatio","B0/B0bar efficiency ratio",this,effRatio),
   _CPeigenval("CPeigenval","CP eigen value",this,CPeigenval),
   _avgMistag("avgMistag","Average mistag rate",this,avgMistag),
@@ -95,13 +111,6 @@ RooBCPEffDecay::RooBCPEffDecay(const RooBCPEffDecay& other, const char* name) :
   _basisExp(other._basisExp),
   _basisSin(other._basisSin),
   _basisCos(other._basisCos)
-{
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Destructor.
-
-RooBCPEffDecay::~RooBCPEffDecay()
 {
 }
 

--- a/roofit/roofit/src/RooBCPGenDecay.cxx
+++ b/roofit/roofit/src/RooBCPGenDecay.cxx
@@ -33,20 +33,35 @@ using namespace std;
 
 ClassImp(RooBCPGenDecay);
 
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor
+/// \brief Constructor for RooBCPGenDecay.
+///
+/// Creates an instance of RooBCPGenDecay with the specified parameters.
+///
+/// \param[in] name       The name of the PDF.
+/// \param[in] title      The title of the PDF.
+/// \param[in] t          The time variable.
+/// \param[in] tag        The CP state category.
+/// \param[in] tau        The decay time parameter.
+/// \param[in] dm         The mixing frequency parameter.
+/// \param[in] avgMistag  The average mistag rate parameter.
+/// \param[in] avgC       Coefficient of cos term.
+/// \param[in] avgS       Coefficient of sin term.
+/// \param[in] delMistag  Delta mistag rate parameter.
+/// \param[in] mu         Tag efficiency difference parameter.
+/// \param[in] model      The resolution model.
+/// \param[in] type       The decay type.
 
 RooBCPGenDecay::RooBCPGenDecay(const char *name, const char *title,
                 RooRealVar& t, RooAbsCategory& tag,
                 RooAbsReal& tau, RooAbsReal& dm,
                 RooAbsReal& avgMistag,
-                RooAbsReal& a, RooAbsReal& b,
+                RooAbsReal& avgC, RooAbsReal& avgS,
                 RooAbsReal& delMistag,
                                RooAbsReal& mu,
                 const RooResolutionModel& model, DecayType type) :
   RooAbsAnaConvPdf(name,title,model,t),
-  _avgC("C","Coefficient of cos term",this,a),
-  _avgS("S","Coefficient of sin term",this,b),
+  _avgC("C","Coefficient of cos term",this,avgC),
+  _avgS("S","Coefficient of sin term",this,avgS),
   _avgMistag("avgMistag","Average mistag rate",this,avgMistag),
   _delMistag("delMistag","Delta mistag rate",this,delMistag),
   _mu("mu","Tag efficiency difference",this,mu),
@@ -95,13 +110,6 @@ RooBCPGenDecay::RooBCPGenDecay(const RooBCPGenDecay& other, const char* name) :
   _basisExp(other._basisExp),
   _basisSin(other._basisSin),
   _basisCos(other._basisCos)
-{
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Destructor
-
-RooBCPGenDecay::~RooBCPGenDecay()
 {
 }
 

--- a/roofit/roofit/src/RooBDecay.cxx
+++ b/roofit/roofit/src/RooBDecay.cxx
@@ -21,7 +21,7 @@
 
 Most general description of B decay time distribution with effects
 of CP violation, mixing and life time differences. This function can
-be analytically convolved with any RooResolutionModel implementation
+be analytically convolved with any RooResolutionModel implementation.
 **/
 
 #include "Riostream.h"
@@ -36,7 +36,22 @@ using namespace std;
 
 ClassImp(RooBDecay);
 
-////////////////////////////////////////////////////////////////////////////////
+/// \brief Constructor for RooBDecay.
+///
+/// Creates an instance of RooBDecay with the specified parameters.
+///
+/// \param[in] name      The name of the PDF.
+/// \param[in] title     The title of the PDF.
+/// \param[in] t         The time variable.
+/// \param[in] tau       The average decay time parameter.
+/// \param[in] dgamma    The Delta Gamma parameter.
+/// \param[in] f0        The Cosh Coefficient.
+/// \param[in] f1        The Sinh Coefficient.
+/// \param[in] f2        The Cos Coefficient.
+/// \param[in] f3        The Sin Coefficient.
+/// \param[in] dm        The Delta Mass parameter.
+/// \param[in] model     The resolution model.
+/// \param[in] type      The decay type.
 
 RooBDecay::RooBDecay(const char *name, const char* title,
           RooRealVar& t, RooAbsReal& tau, RooAbsReal& dgamma,
@@ -96,13 +111,6 @@ RooBDecay::RooBDecay(const RooBDecay& other, const char* name) :
   _basisCos(other._basisCos),
   _basisSin(other._basisSin),
   _type(other._type)
-{
-}
-
-////////////////////////////////////////////////////////////////////////////////
-///Destructor
-
-RooBDecay::~RooBDecay()
 {
 }
 

--- a/roofit/roofit/src/RooBMixDecay.cxx
+++ b/roofit/roofit/src/RooBMixDecay.cxx
@@ -34,8 +34,21 @@ using namespace std;
 
 ClassImp(RooBMixDecay);
 
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor
+/// \brief Constructor for RooBMixDecay.
+///
+/// Creates an instance of RooBMixDecay with the specified parameters.
+///
+/// \param[in] name         The name of the PDF.
+/// \param[in] title        The title of the PDF.
+/// \param[in] t            The time variable.
+/// \param[in] mixState     The mixing state category.
+/// \param[in] tagFlav      The flavour of tagged B0 category.
+/// \param[in] tau          The mixing life time parameter.
+/// \param[in] dm           The mixing frequency parameter.
+/// \param[in] mistag       The mistag rate parameter.
+/// \param[in] delMistag    The delta mistag rate parameter.
+/// \param[in] model        The resolution model.
+/// \param[in] type         The decay type.
 
 RooBMixDecay::RooBMixDecay(const char *name, const char *title,
             RooRealVar& t, RooAbsCategory& mixState,
@@ -89,13 +102,6 @@ RooBMixDecay::RooBMixDecay(const RooBMixDecay& other, const char* name) :
   _genFlavFrac(other._genFlavFrac),
   _genFlavFracMix(other._genFlavFracMix),
   _genFlavFracUnmix(other._genFlavFracUnmix)
-{
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Destructor
-
-RooBMixDecay::~RooBMixDecay()
 {
 }
 


### PR DESCRIPTION
This is done to close the following Jira issue:
https://sft.its.cern.ch/jira/browse/ROOT-7994

The parameter explanations are taken from the proxy titles in the constructor initializer lists.