### PR TITLE
[qt5web] Avoid clang warnings

### DIFF
--- a/gui/qt5webdisplay/rootqt5.cpp
+++ b/gui/qt5webdisplay/rootqt5.cpp
@@ -71,7 +71,6 @@ protected:
    RootWebView *fView{nullptr};  ///< pointer on widget, need to release when handle is destroyed
 
    class Qt5Creator : public Creator {
-      int fCounter{0}; ///< counter used to number handlers
       QApplication *qapp{nullptr};  ///< created QApplication
       int qargc{1};                 ///< arg counter
       char *qargv[2];               ///< arg values

--- a/gui/qt5webdisplay/rootwebview.h
+++ b/gui/qt5webdisplay/rootwebview.h
@@ -39,7 +39,7 @@ public:
    RootWebView(QWidget *parent = nullptr, unsigned width = 0, unsigned height = 0, int x = -1, int y = -1);
    virtual ~RootWebView() = default;
 
-   virtual QSize  sizeHint() const;
+   QSize  sizeHint() const override;
 };
 
 #endif


### PR DESCRIPTION
This commit should fix these compiler warnings seen in the CI: https://lcgapp-services.cern.ch/root-jenkins/view/ROOT%20Nightly/job/root-nightly-master/LABEL=ROOT-ubuntu2004-clang,SPEC=soversion,V=master/lastBuild/parsed_console/