### PR TITLE
[ntuple] Simplify `RPageSourceDaos::LoadClusters()`

### DIFF
--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -678,22 +678,18 @@ ROOT::Experimental::Detail::RPageSourceDaos::LoadClusters(std::span<RCluster::RK
       std::uint64_t fSize = 0;
    };
 
-   std::vector<std::unique_ptr<ROOT::Experimental::Detail::RCluster>> clusters;
-   RDaosContainer::MultiObjectRWOperation_t readRequests;
-   int64_t szPayload = 0;
-   unsigned nPages = 0;
-
-   for (unsigned i = 0; i < clusterKeys.size(); ++i) {
-      const auto &clusterKey = clusterKeys[i];
+   // Prepares read requests for a single cluster; `readRequests` is modified by this function.  Requests are coalesced
+   // by OID and distribution key.
+   // TODO(jalopezg): this may be a private member function; that, however, requires additional changes given that
+   // `RDaosContainer::MultiObjectRWOperation_t` cannot be forward-declared
+   auto fnPrepareSingleCluster = [&](const RCluster::RKey &clusterKey,
+                                     RDaosContainer::MultiObjectRWOperation_t &readRequests) {
       auto clusterId = clusterKey.fClusterId;
-      auto cluster = std::make_unique<RCluster>(clusterId);
-
       // Group page locators by their position in the object store; with caging enabled, this facilitates the
       // processing of cages' requests together into a single IOV to be populated.
-      std::unordered_map<std::uint32_t, std::vector<RDaosSealedPageLocator>> onDiskClusterPages;
+      std::unordered_map<std::uint32_t, std::vector<RDaosSealedPageLocator>> onDiskPages;
 
-      unsigned clusterBufSz = 0;
-      fCounters->fNClusterLoaded.Inc();
+      unsigned clusterBufSz = 0, nPages = 0;
       {
          auto descriptorGuard = GetSharedDescriptorGuard();
          const auto &clusterDesc = descriptorGuard->GetClusterDescriptor(clusterId);
@@ -706,7 +702,7 @@ ROOT::Experimental::Detail::RPageSourceDaos::LoadClusters(std::span<RCluster::RK
                const auto &pageLocator = pageInfo.fLocator;
                uint32_t position, offset;
                std::tie(position, offset) = DecodeDaosPagePosition(pageLocator.GetPosition<RNTupleLocatorObject64>());
-               auto [itLoc, _] = onDiskClusterPages.emplace(position, std::vector<RDaosSealedPageLocator>());
+               auto [itLoc, _] = onDiskPages.emplace(position, std::vector<RDaosSealedPageLocator>());
 
                itLoc->second.push_back(
                   {clusterId, physicalColumnId, columnPageCount, position, offset, pageLocator.fBytesOnStorage});
@@ -716,21 +712,19 @@ ROOT::Experimental::Detail::RPageSourceDaos::LoadClusters(std::span<RCluster::RK
             nPages += columnPageCount;
          }
       }
-      szPayload += clusterBufSz;
 
       auto clusterBuffer = new unsigned char[clusterBufSz];
       auto pageMap = std::make_unique<ROnDiskPageMapHeap>(std::unique_ptr<unsigned char[]>(clusterBuffer));
 
       auto cageBuffer = clusterBuffer;
       // Fill the cluster page map and the read requests for the RDaosContainer::ReadV() call
-      for (auto &[cageIndex, pageVec] : onDiskClusterPages) {
+      for (auto &[cageIndex, pageVec] : onDiskPages) {
          auto columnId = pageVec[0].fColumnId; // All pages in a cage belong to the same column
          std::size_t cageSz = 0;
 
          for (auto &s : pageVec) {
             assert(columnId == s.fColumnId);
             assert(cageIndex == s.fPosition);
-
             // Register the on disk pages in a page map
             ROnDiskPage::Key key(s.fColumnId, s.fPageNo);
             pageMap->Register(key, ROnDiskPage(cageBuffer + s.fCageOffset, s.fSize));
@@ -748,14 +742,23 @@ ROOT::Experimental::Detail::RPageSourceDaos::LoadClusters(std::span<RCluster::RK
 
          cageBuffer += cageSz;
       }
+      fCounters->fNPageLoaded.Add(nPages);
+      fCounters->fSzReadPayload.Add(clusterBufSz);
 
+      auto cluster = std::make_unique<RCluster>(clusterId);
       cluster->Adopt(std::move(pageMap));
       for (auto colId : clusterKey.fPhysicalColumnSet)
          cluster->SetColumnAvailable(colId);
-      clusters.emplace_back(std::move(cluster));
+      return cluster;
+   };
+
+   fCounters->fNClusterLoaded.Add(clusterKeys.size());
+
+   std::vector<std::unique_ptr<ROOT::Experimental::Detail::RCluster>> clusters;
+   RDaosContainer::MultiObjectRWOperation_t readRequests;
+   for (auto key : clusterKeys) {
+      clusters.emplace_back(fnPrepareSingleCluster(key, readRequests));
    }
-   fCounters->fNPageLoaded.Add(nPages);
-   fCounters->fSzReadPayload.Add(szPayload);
 
    {
       RNTupleAtomicTimer timer(fCounters->fTimeWallRead, fCounters->fTimeCpuRead);
@@ -763,7 +766,7 @@ ROOT::Experimental::Detail::RPageSourceDaos::LoadClusters(std::span<RCluster::RK
          throw ROOT::Experimental::RException(R__FAIL("ReadV: error" + std::string(d_errstr(err))));
    }
    fCounters->fNReadV.Inc();
-   fCounters->fNRead.Add(nPages);
+   fCounters->fNRead.Add(readRequests.size());
 
    return clusters;
 }


### PR DESCRIPTION
This pull request simplifies the implementation of `RPageSourceDaos::LoadClusters()` as a prior step to handling the population of the page zero.

A follow-up PR factors out common code for handling `kTypePageZero` locators in storage backends + enables their population in the DAOS backend.

## Checklist:
- [x] tested changes locally