### PR TITLE
[ntuple] Bulk read optimizations for RVec

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -445,7 +445,7 @@ protected:
    static void CallReadOn(RFieldBase &other, NTupleSize_t globalIndex, void *to) { other.Read(globalIndex, to); }
 
    /// Fields may need direct access to the principal column of their sub fields, e.g. in RRevField::ReadBulk
-   static RColumn *GetPrincipleColumnOf(const RFieldBase &other) { return other.fPrincipalColumn; }
+   static RColumn *GetPrincipalColumnOf(const RFieldBase &other) { return other.fPrincipalColumn; }
 
    /// Set a user-defined function to be called after reading a value, giving a chance to inspect and/or modify the
    /// value object.

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -444,7 +444,7 @@ protected:
    }
    static void CallReadOn(RFieldBase &other, NTupleSize_t globalIndex, void *to) { other.Read(globalIndex, to); }
 
-   /// Fields may need direct access to the principal column of their sub fields, e.g. in RRevField::ReadBulk
+   /// Fields may need direct access to the principal column of their sub fields, e.g. in RRVecField::ReadBulk
    static RColumn *GetPrincipalColumnOf(const RFieldBase &other) { return other.fPrincipalColumn; }
 
    /// Set a user-defined function to be called after reading a value, giving a chance to inspect and/or modify the

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1994,7 +1994,7 @@ void ROOT::Experimental::RRVecField::GenerateValue(void *where) const
    // currently the inline buffer is left uninitialized
    void **beginPtr = new (where)(void *)(nullptr);
    std::int32_t *sizePtr = new (reinterpret_cast<void *>(beginPtr + 1)) std::int32_t(0);
-   new (sizePtr + 1) std::int32_t(0);
+   new (sizePtr + 1) std::int32_t(-1);
 }
 
 void ROOT::Experimental::RRVecField::DestroyValue(void *objPtr, bool dtorOnly) const

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -2028,7 +2028,7 @@ std::size_t ROOT::Experimental::RRVecField::ReadBulkImpl(const RBulkSpec &bulkSp
       }
    }
 
-   GetPrincipleColumnOf(*fSubFields[0])->ReadV(firstItemIndex, nItems, itemValueArray - delta);
+   GetPrincipalColumnOf(*fSubFields[0])->ReadV(firstItemIndex, nItems, itemValueArray - delta);
    return RBulkSpec::kAllSet;
 }
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1919,8 +1919,9 @@ void ROOT::Experimental::RRVecField::ReadGlobalImpl(NTupleSize_t globalIndex, vo
 
    // See "semantics of reading non-trivial objects" in RNTuple's architecture.md for details
    // on the element construction/destrution.
+   const bool owns = (*capacityPtr != -1);
    const bool needsConstruct = !(fSubFields[0]->GetTraits() & kTraitTriviallyConstructible);
-   const bool needsDestruct = !(fSubFields[0]->GetTraits() & kTraitTriviallyDestructible);
+   const bool needsDestruct = owns && !(fSubFields[0]->GetTraits() & kTraitTriviallyDestructible);
 
    // Destroy excess elements, if any
    if (needsDestruct) {
@@ -1940,7 +1941,8 @@ void ROOT::Experimental::RRVecField::ReadGlobalImpl(NTupleSize_t globalIndex, vo
       }
 
       // TODO Increment capacity by a factor rather than just enough to fit the elements.
-      free(*beginPtr);
+      if (owns)
+         free(*beginPtr);
       // We trust that malloc returns a buffer with large enough alignment.
       // This might not be the case if T in RVec<T> is over-aligned.
       *beginPtr = malloc(nItems * fItemSize);

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1941,8 +1941,10 @@ void ROOT::Experimental::RRVecField::ReadGlobalImpl(NTupleSize_t globalIndex, vo
       }
 
       // TODO Increment capacity by a factor rather than just enough to fit the elements.
-      if (owns)
+      if (owns) {
+         // *beginPtr points to the array of item values (allocated in an earlier call by the following malloc())
          free(*beginPtr);
+      }
       // We trust that malloc returns a buffer with large enough alignment.
       // This might not be the case if T in RVec<T> is over-aligned.
       *beginPtr = malloc(nItems * fItemSize);

--- a/tree/ntuple/v7/test/ntuple_bulk.cxx
+++ b/tree/ntuple/v7/test/ntuple_bulk.cxx
@@ -86,3 +86,46 @@ TEST(RNTupleBulk, Complex)
       EXPECT_FLOAT_EQ((i % 2 == 0) ? 0.0 : float(i), SArr10[i].a);
    }
 }
+
+TEST(RNTupleBulk, CardinalityField)
+{
+   using RNTupleCardinality32 = ROOT::Experimental::RNTupleCardinality<std::uint32_t>;
+   using RNTupleCardinality64 = ROOT::Experimental::RNTupleCardinality<std::uint64_t>;
+
+   FileRaii fileGuard("test_ntuple_bulk_simple.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto fldVec = model->MakeField<ROOT::RVec<int>>("vint");
+      model->AddProjectedField(std::make_unique<RField<RNTupleCardinality32>>("card32"),
+                               [](const std::string &) { return "vint"; });
+      model->AddProjectedField(std::make_unique<RField<RNTupleCardinality64>>("card64"),
+                               [](const std::string &) { return "vint"; });
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+      for (int i = 0; i < 10; ++i) {
+         fldVec->resize(i);
+         writer->Fill();
+      }
+   }
+
+   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+
+   auto fieldZero = reader->GetModel()->GetFieldZero();
+   std::unique_ptr<RFieldBase::RBulk> bulk32;
+   std::unique_ptr<RFieldBase::RBulk> bulk64;
+   for (auto &f : *fieldZero) {
+      if (f.GetName() == "card32")
+         bulk32 = std::make_unique<RFieldBase::RBulk>(f.GenerateBulk());
+      if (f.GetName() == "card64")
+         bulk64 = std::make_unique<RFieldBase::RBulk>(f.GenerateBulk());
+   }
+
+   auto mask = std::make_unique<bool[]>(10);
+   std::fill(mask.get(), mask.get() + 10, false /* the cardinality field optimization should ignore the mask */);
+
+   auto card32Arr = static_cast<std::uint32_t *>(bulk32->ReadBulk(RClusterIndex(0, 0), mask.get(), 10));
+   auto card64Arr = static_cast<std::uint64_t *>(bulk64->ReadBulk(RClusterIndex(0, 0), mask.get(), 10));
+   for (int i = 0; i < 10; ++i) {
+      EXPECT_EQ(i, card32Arr[i]);
+      EXPECT_EQ(i, card64Arr[i]);
+   }
+}


### PR DESCRIPTION
# This Pull request:

Adds optimized `BulkRead` implementations for RVec of simple types and cardinality fields. Along the way, fixes an issue with RNTuple's handling of adopted RVecs.

@eguiraud @vepadulano If RDF relies on the elements of a bulk of RVec<PoD> being all consecutively in memory, we also need to implement `BulkRead` for `RArrayAsRVecField` (#13040)

## Checklist:

- [X] tested changes locally

