### PR TITLE
[ntuple,daos] RPageSourceDaos: populate the page zero from `kTypePageZero` locators

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -420,6 +420,30 @@ protected:
    /// `RPageAllocatorHeap`; use `RPageAllocatorHeap::DeletePage()` to deallocate returned pages.
    RPage UnsealPage(const RSealedPage &sealedPage, const RColumnElementBase &element, DescriptorId_t physicalColumnId);
 
+   /// Prepare a page range read for the column set in `clusterKey`.  Specifically, pages referencing the
+   /// `kTypePageZero` locator are filled in `pageZeroMap`; otherwise, `perPageFunc` is called for each page. This is
+   /// commonly used as part of `LoadClusters()` in derived classes.
+   template <typename PerPageFuncT>
+   void PrepareLoadCluster(const RCluster::RKey &clusterKey, ROnDiskPageMap &pageZeroMap, PerPageFuncT perPageFunc)
+   {
+      auto descriptorGuard = GetSharedDescriptorGuard();
+      const auto &clusterDesc = descriptorGuard->GetClusterDescriptor(clusterKey.fClusterId);
+      for (auto physicalColumnId : clusterKey.fPhysicalColumnSet) {
+         const auto &pageRange = clusterDesc.GetPageRange(physicalColumnId);
+         NTupleSize_t pageNo = 0;
+         for (const auto &pageInfo : pageRange.fPageInfos) {
+            if (pageInfo.fLocator.fType == RNTupleLocator::kTypePageZero) {
+               pageZeroMap.Register(
+                  ROnDiskPage::Key{physicalColumnId, pageNo},
+                  ROnDiskPage(const_cast<void *>(RPage::GetPageZeroBuffer()), pageInfo.fLocator.fBytesOnStorage));
+            } else {
+               perPageFunc(physicalColumnId, pageNo, pageInfo);
+            }
+            ++pageNo;
+         }
+      }
+   }
+
    /// Enables the default set of metrics provided by RPageSource. `prefix` will be used as the prefix for
    /// the counters registered in the internal RNTupleMetrics object.
    /// A subclass using the default set of metrics is responsible for updating the counters

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -423,26 +423,9 @@ protected:
    /// Prepare a page range read for the column set in `clusterKey`.  Specifically, pages referencing the
    /// `kTypePageZero` locator are filled in `pageZeroMap`; otherwise, `perPageFunc` is called for each page. This is
    /// commonly used as part of `LoadClusters()` in derived classes.
-   template <typename PerPageFuncT>
-   void PrepareLoadCluster(const RCluster::RKey &clusterKey, ROnDiskPageMap &pageZeroMap, PerPageFuncT perPageFunc)
-   {
-      auto descriptorGuard = GetSharedDescriptorGuard();
-      const auto &clusterDesc = descriptorGuard->GetClusterDescriptor(clusterKey.fClusterId);
-      for (auto physicalColumnId : clusterKey.fPhysicalColumnSet) {
-         const auto &pageRange = clusterDesc.GetPageRange(physicalColumnId);
-         NTupleSize_t pageNo = 0;
-         for (const auto &pageInfo : pageRange.fPageInfos) {
-            if (pageInfo.fLocator.fType == RNTupleLocator::kTypePageZero) {
-               pageZeroMap.Register(
-                  ROnDiskPage::Key{physicalColumnId, pageNo},
-                  ROnDiskPage(const_cast<void *>(RPage::GetPageZeroBuffer()), pageInfo.fLocator.fBytesOnStorage));
-            } else {
-               perPageFunc(physicalColumnId, pageNo, pageInfo);
-            }
-            ++pageNo;
-         }
-      }
-   }
+   void PrepareLoadCluster(
+      const RCluster::RKey &clusterKey, ROnDiskPageMap &pageZeroMap,
+      std::function<void(DescriptorId_t, NTupleSize_t, RClusterDescriptor::RPageRange::RPageInfo)> perPageFunc);
 
    /// Enables the default set of metrics provided by RPageSource. `prefix` will be used as the prefix for
    /// the counters registered in the internal RNTupleMetrics object.


### PR DESCRIPTION
Per #12676, all storage backends should be able to populate the page zero from `kTypePageZero` locators.  This pull request adds the missing pieces in the DAOS backend.

## Changes or fixes:
- Add the `RPageStorage::PrepareLoadCluster()` helper which can be used in the implementation of `LoadClusters()` in derived classes to prepare the read of page ranges.  This function takes care of filling zero pages in the given `ROnDiskPageMap`.
- Add the missing pieces in `RPageSourceDaos`.

## Checklist:
- [x] tested changes locally

This PR fixes #12960.