### PR TITLE
[REve] Remove the limit of REveDataCollection table suggestions

### DIFF
--- a/graf3d/eve7/src/REveDataCollection.cxx
+++ b/graf3d/eve7/src/REveDataCollection.cxx
@@ -379,6 +379,9 @@ void  REveDataCollection::StreamPublicMethods(nlohmann::json &j) const
       if (meth->GetListOfMethodArgs()->GetLast() > 1)
          continue;
 
+      if (strcmp(meth->GetReturnTypeName(),"void") == 0)
+         continue;
+
       TString ms;
       TMethodArg *ma;
       TIter next_ma(meth->GetListOfMethodArgs());

--- a/ui5/eve7/controller/EveTable.controller.js
+++ b/ui5/eve7/controller/EveTable.controller.js
@@ -426,6 +426,7 @@ sap.ui.define([
                let oModel = new JSONModel();
                let oSuggestionData = this.eveTable.fPublicFunctions;
                oModel.setData(oSuggestionData);
+               oModel.setSizeLimit(10000);// default limit is 100
                exprIn.setModel(oModel);
                exprIn.bindAggregation("suggestionRows", "/", oTableItemTemplate);
 


### PR DESCRIPTION
In the REveDataTable list of suggestion was limited to 100. The limit was inherited with openui5 input widget.

In  REveDataCollection::StreamPublicMethods suggestion list is created with TClass::GetListOfAllPublicMethods() where void functions are omitted.
