### PR TITLE
[core] Do not provide our own strlcpy if glibc >= 2.38 (v6.28)

### DIFF
--- a/core/foundation/inc/ROOT/RConfig.hxx
+++ b/core/foundation/inc/ROOT/RConfig.hxx
@@ -146,6 +146,9 @@
 #      define R__USESTHROW
 #      define R__SEEK64
 #   endif
+#   if __GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 38)
+#      define HAS_STRLCPY
+#   endif
 #endif
 
 #if defined(linux) && defined(__i386__)


### PR DESCRIPTION
Since version 2.38, glibc provides strlcpy and strlcat. No need to provide our own.

In fact ROOT's definitions clash with glibc's: the latter are marked `noexcept`.