### PR TITLE
[ntuple] Throw when `RNTupleInspector` encounters inconsistent compression

### DIFF
--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -115,7 +115,9 @@ private:
    /// information will be stored in `fColumnInfo`, and the RNTuple-level information
    /// in `fCompressionSettings`, `fOnDiskSize` and `fInMemorySize`.
    ///
-   /// This method is called when the `RNTupleInspector` is initially created.
+   /// This method is called when the `RNTupleInspector` is initially created. This means that anything unexpected about
+   /// the RNTuple itself (e.g. inconsistent compression settings across clusters) will be detected here. Therefore, any
+   /// related exceptions will be thrown on creation of the inspector.
    void CollectColumnInfo();
 
    /// Recursively gather field-level information and store it in `fFieldTreeInfo`.
@@ -133,7 +135,9 @@ public:
    RNTupleInspector &operator=(RNTupleInspector &&other) = delete;
    ~RNTupleInspector() = default;
 
-   /// Create a new inspector for a given RNTuple.
+   /// Create a new inspector for a given RNTuple. When this factory method is called, all required static information
+   /// is collected from the RNTuple's fields and underlying columns are collected at ones. This means that when any
+   /// inconsistencies are encountered (e.g. inconsistent compression across clusters), it will throw an error here.
    static std::unique_ptr<RNTupleInspector> Create(std::unique_ptr<Detail::RPageSource> pageSource);
    static std::unique_ptr<RNTupleInspector> Create(RNTuple *sourceNTuple);
    static std::unique_ptr<RNTupleInspector> Create(std::string_view ntupleName, std::string_view storage);
@@ -141,7 +145,9 @@ public:
    /// Get the descriptor for the RNTuple being inspected.
    RNTupleDescriptor *GetDescriptor() const { return fDescriptor.get(); }
 
-   /// Get the compression settings of the RNTuple being inspected.
+   /// Get the compression settings of the RNTuple being inspected. Here, we assume that the compression settings are
+   /// consistent across all clusters and columns. If this is not the case, an exception will be thrown upon
+   /// `RNTupleInspector::Create`.
    int GetCompressionSettings() const { return fCompressionSettings; }
 
    /// Get the on-disk, compressed size of the RNTuple being inspected, in bytes.

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -61,8 +61,13 @@ void ROOT::Experimental::RNTupleInspector::CollectColumnInfo()
 
          if (fCompressionSettings == -1) {
             fCompressionSettings = columnRange.fCompressionSettings;
-         } else {
-            R__ASSERT(columnRange.fCompressionSettings == fCompressionSettings);
+         } else if (fCompressionSettings != columnRange.fCompressionSettings) {
+            // Note that currently all clusters and columns are compressed with the same settings and it is not yet
+            // possible to do otherwise. This measn that currently, this exception should never be thrown, but this
+            // could change in the future.
+            throw RException(R__FAIL("compression setting mismatch between column ranges (" +
+                                     std::to_string(fCompressionSettings) + " vs " +
+                                     std::to_string(columnRange.fCompressionSettings) + ")"));
          }
 
          const auto &pageRange = clusterDescriptor.GetPageRange(colId);


### PR DESCRIPTION
Instead of aborting after `R__ASSERT` fails, a proper exception is now thrown when the `RNTupleInspector` detects inconsistent compression across columns or clusters.

Additionally, this PR improves the documentation related to this.

N.B. Because at this point there is no way to have different compression across columns or clusters, no tests for checking this assumption have been added yet. When at one point this becomes possible, this should obviously be added.
