### PR TITLE
Allow geometry transparency at the volume level

### DIFF
--- a/geom/geom/inc/TGeoVolume.h
+++ b/geom/geom/inc/TGeoVolume.h
@@ -205,7 +205,7 @@ public:
    void RemoveNode(TGeoNode *node);
    TGeoNode *ReplaceNode(TGeoNode *nodeorig, TGeoShape *newshape = nullptr, TGeoMatrix *newpos = nullptr,
                          TGeoMedium *newmed = nullptr);
-   void ResetTransparency(Char_t transparency = -1);
+   void ResetTransparency(Char_t transparency = -1); // *MENU*
    void SaveAs(const char *filename, Option_t *option = "") const override; // *MENU*
    void SavePrimitive(std::ostream &out, Option_t *option = "") override;
    void SelectVolume(Bool_t clear = kFALSE);

--- a/geom/geom/inc/TGeoVolume.h
+++ b/geom/geom/inc/TGeoVolume.h
@@ -205,6 +205,7 @@ public:
    void RemoveNode(TGeoNode *node);
    TGeoNode *ReplaceNode(TGeoNode *nodeorig, TGeoShape *newshape = nullptr, TGeoMatrix *newpos = nullptr,
                          TGeoMedium *newmed = nullptr);
+   void ResetTransparency(Char_t transparency = -1);
    void SaveAs(const char *filename, Option_t *option = "") const override; // *MENU*
    void SavePrimitive(std::ostream &out, Option_t *option = "") override;
    void SelectVolume(Bool_t clear = kFALSE);
@@ -373,6 +374,13 @@ inline Char_t TGeoVolume::GetTransparency() const
 }
 
 inline void TGeoVolume::SetTransparency(Char_t transparency)
+{
+   if (fMedium)  {
+      fMedium->GetMaterial()->SetTransparency(transparency);
+   }
+}
+
+inline void TGeoVolume::ResetTransparency(Char_t transparency)
 {
    fTransparency = transparency;
 }

--- a/geom/geom/inc/TGeoVolume.h
+++ b/geom/geom/inc/TGeoVolume.h
@@ -55,6 +55,7 @@ protected:
    Int_t fNumber;                 //  volume serial number in the list of volumes
    Int_t fNtotal;                 // total number of physical nodes
    Int_t fRefCount;               // reference counter
+   Char_t fTransparency;          // transparency setting
    TGeoExtension *fUserExtension; //! Transient user-defined extension to volumes
    TGeoExtension *fFWExtension;   //! Transient framework-defined extension to volumes
 
@@ -185,7 +186,7 @@ public:
    Bool_t GetOptimalVoxels() const;
    Option_t *GetOption() const override { return fOption.Data(); }
    const char *GetPointerName() const;
-   Char_t GetTransparency() const { return !fMedium ? 0 : fMedium->GetMaterial()->GetTransparency(); }
+   Char_t GetTransparency() const;
    TGeoShape *GetShape() const { return fShape; }
    void GrabFocus(); // *MENU*
    void Gsord(Int_t /*iaxis*/) {}
@@ -225,11 +226,7 @@ public:
    }
    void SetOverlappingCandidate(Bool_t flag) { TObject::SetBit(kVolumeOC, flag); }
    void SetShape(const TGeoShape *shape);
-   void SetTransparency(Char_t transparency = 0)
-   {
-      if (fMedium)
-         fMedium->GetMaterial()->SetTransparency(transparency);
-   } // *MENU*
+   void SetTransparency(Char_t transparency = 0); // *MENU*
    void SetField(TObject *field) { fField = field; }
    void SetOption(const char *option);
    void SetAttVisibility(Bool_t vis) { TGeoAtt::SetVisibility(vis); }
@@ -255,7 +252,7 @@ public:
    Double_t Weight(Double_t precision = 0.01, Option_t *option = "va"); // *MENU*
    Double_t WeightA() const;
 
-   ClassDefOverride(TGeoVolume, 6) // geometry volume descriptor
+   ClassDefOverride(TGeoVolume, 7)              // geometry volume descriptor
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -366,6 +363,18 @@ inline Int_t TGeoVolume::GetNdaughters() const
    if (!fNodes)
       return 0;
    return (fNodes->GetEntriesFast());
+}
+
+inline Char_t TGeoVolume::GetTransparency() const
+{
+   // If the transparency is (-1), the old default handling is applied
+   if ( fTransparency >= 0 ) return fTransparency;
+   return !fMedium ? 0 : fMedium->GetMaterial()->GetTransparency();
+}
+
+inline void TGeoVolume::SetTransparency(Char_t transparency)
+{
+   fTransparency = transparency;
 }
 
 #endif

--- a/geom/geom/src/TGeoVolume.cxx
+++ b/geom/geom/src/TGeoVolume.cxx
@@ -465,6 +465,7 @@ TGeoVolume::TGeoVolume()
    fRefCount = 0;
    fUserExtension = 0;
    fFWExtension = 0;
+   fTransparency = -1;
    TObject::ResetBit(kVolumeImportNodes);
 }
 
@@ -497,6 +498,7 @@ TGeoVolume::TGeoVolume(const char *name, const TGeoShape *shape, const TGeoMediu
    fRefCount = 0;
    fUserExtension = 0;
    fFWExtension = 0;
+   fTransparency = -1;
    if (fGeoManager)
       fNumber = fGeoManager->AddVolume(this);
    TObject::ResetBit(kVolumeImportNodes);


### PR DESCRIPTION
# This Pull request:
This Pull request allows to set in TGeo the transparency of objects at the level of individual TGeoVolume instances.

ROOT was attributing the volume transparency to the material of the volume.
This is not always the desired behavior. The PR preserves the current functionality if the transparency level is not
explicitly set to the volume instance. 
Improved functionality: If the transparency level is set directly to the volume instance, the volume transparency 
takes precedence over the material transparency. The default behavior can be restored by setting a transparency 
level of -1 to the volume.

## Changes or fixes:
Improves the flexibility to set transparency to geometry volumes.

## Checklist:

- [xxx] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

