### PR TITLE
[math] Fix Pearson chi2 fit for weighted histograms

### DIFF
--- a/hist/hist/inc/HFitInterface.h
+++ b/hist/hist/inc/HFitInterface.h
@@ -50,6 +50,13 @@ namespace ROOT {
          kGraph
       };
 
+      enum EChisquareType {
+         kNeyman = 0,
+         kPLikeRatio,
+         kPearson
+      };
+
+
 
       //#ifndef __CINT__  // does not link on Windows (why ??)
 
@@ -166,7 +173,7 @@ namespace ROOT {
       /**
          compute the chi2 value for an histogram given a function  (see TH1::Chisquare for the documentation)
       */
-      double Chisquare(const TH1 & h1, TF1 & f1, bool useRange, bool usePL = false);
+      double Chisquare(const TH1 & h1, TF1 & f1, bool useRange, EChisquareType type);
 
       /**
          compute the chi2 value for a graph given a function (see TGraph::Chisquare)

--- a/hist/hist/inc/HFitInterface.h
+++ b/hist/hist/inc/HFitInterface.h
@@ -45,12 +45,12 @@ namespace ROOT {
       class UnBinData;
       class SparseData;
 
-      enum EFitObjectType {
+      enum class EFitObjectType {
          kHistogram,
          kGraph
       };
 
-      enum EChisquareType {
+      enum class EChisquareType {
          kNeyman = 0,
          kPLikeRatio,
          kPearson

--- a/hist/hist/src/HFitImpl.cxx
+++ b/hist/hist/src/HFitImpl.cxx
@@ -700,7 +700,7 @@ void ROOT::Fit::FitOptionsMake(EFitObjectType type, const char *option, Foption_
    opt.ToUpper();
 
    // parse firt the specific options
-   if (type == kHistogram) {
+   if (type == EFitObjectType::kHistogram) {
 
       if (opt.Contains("WIDTH")) {
          fitOption.BinVolume = 1;  // scale content by the bin width
@@ -757,7 +757,7 @@ void ROOT::Fit::FitOptionsMake(EFitObjectType type, const char *option, Foption_
       }
    }
    // specific Graph options (need to be parsed before)
-   else if (type == kGraph) {
+   else if (type == EFitObjectType::kGraph) {
       opt.ReplaceAll("ROB", "H");
       opt.ReplaceAll("EX0", "T");
 
@@ -1029,7 +1029,7 @@ double ROOT::Fit::Chisquare(const TH1 & h1,  TF1 & f1, bool useRange, ROOT::Fit:
 }
 
 double ROOT::Fit::Chisquare(const TGraph & g, TF1 & f1, bool useRange) {
-   return HFit::ComputeChi2(g,f1, useRange, kNeyman);
+   return HFit::ComputeChi2(g,f1, useRange, ROOT::Fit::EChisquareType::kNeyman);
 }
 
 template<class FitObject>
@@ -1037,11 +1037,10 @@ double HFit::ComputeChi2(const FitObject & obj,  TF1  & f1, bool useRange, ROOT:
 
    // implement using the fitting classes
    ROOT::Fit::DataOptions opt;
-   if (type != ROOT::Fit::kNeyman) opt.fUseEmpty=true;  // use empty bin when not using Neyman chisquare (observed error)
-   if (type == ROOT::Fit::kPearson) {
-      opt.fExpErrors=true;
-      opt.fErrors1= true;  // not using actual errors
-   }
+   opt.fUseEmpty = (type != ROOT::Fit::EChisquareType::kNeyman);  // use empty bin when not using Neyman chisquare (observed error)
+   opt.fExpErrors = (type == ROOT::Fit::EChisquareType::kPearson);
+   opt.fErrors1 = (type == ROOT::Fit::EChisquareType::kPearson);  // not using observed errors in Pearson chi2
+
    ROOT::Fit::DataRange range;
    // get range of function
    if (useRange) HFit::GetFunctionRange(f1,range);
@@ -1053,7 +1052,7 @@ double HFit::ComputeChi2(const FitObject & obj,  TF1  & f1, bool useRange, ROOT:
       return -1;
    }
    ROOT::Math::WrappedMultiTF1  wf1(f1);
-   if (type == ROOT::Fit::kPLikeRatio) {
+   if (type == ROOT::Fit::EChisquareType::kPLikeRatio) {
       // use the poisson log-lokelihood (Baker-Cousins chi2)
       ROOT::Fit::PoissonLLFunction nll(data, wf1);
       return 2.* nll( f1.GetParameters() ) ;

--- a/hist/hist/src/HFitImpl.cxx
+++ b/hist/hist/src/HFitImpl.cxx
@@ -77,7 +77,7 @@ namespace HFit {
    void StoreAndDrawFitFunction(FitObject * h1, TF1 * f1, const ROOT::Fit::DataRange & range, bool, bool, const char *goption);
 
    template <class FitObject>
-   double ComputeChi2(const FitObject & h1, TF1 &f1, bool useRange, bool usePL );
+   double ComputeChi2(const FitObject & h1, TF1 &f1, bool useRange, ROOT::Fit::EChisquareType type );
 
 
 
@@ -178,6 +178,11 @@ TFitResultPtr HFit::Fit(FitObject * h1, TF1 *f1 , Foption_t & fitOption , const 
    if (fitOption.NoErrX) opt.fCoordErrors = false;  // do not use coordinate errors when requested
    if (fitOption.W1 ) opt.fErrors1 = true;
    if (fitOption.W1 > 1) opt.fUseEmpty = true; // use empty bins with weight=1
+   if (fitOption.PChi2 == 1) {
+      opt.fErrors1 = true; // we are not using errors in chi2, it is like setting = 1
+   } else if (fitOption.PChi2 == 2) {
+      opt.fErrors1 = false;  // we need the errors in weighted likelihood fit
+   }
 
    if (fitOption.BinVolume) {
       opt.fBinVolume = true; // scale by bin volume
@@ -729,7 +734,13 @@ void ROOT::Fit::FitOptionsMake(EFitObjectType type, const char *option, Foption_
       if (opt.Contains("WW")) fitOption.W1      = 2; //all bins have weight=1, even empty bins
       if (opt.Contains("L")) fitOption.Like    = 1;
       if (opt.Contains("X")) fitOption.Chi2    = 1;
-      if (opt.Contains("P")) fitOption.PChi2    = 1;
+      if (opt.Contains("P")) {
+         fitOption.PChi2    = 1;
+         if (fitOption.W1) {  // option contains also w is a weighted Pearson chi2 fit
+            fitOption.PChi2 = 2;
+            fitOption.W1 = 0;   // does not make sense to have errors=1 in Pearson chi2 fits
+         }
+      }
 
       // specific likelihood fit options
       if (fitOption.Like == 1) {
@@ -741,12 +752,8 @@ void ROOT::Fit::FitOptionsMake(EFitObjectType type, const char *option, Foption_
             opt.ReplaceAll("MULTI","");
          }
          // give precedence for likelihood options
-         if (fitOption.Chi2 == 1 || fitOption.PChi2 == 1)
+         if (fitOption.Chi2 || fitOption.PChi2 )
             Warning("Fit","Cannot use P or X option in combination of L. Ignore the chi2 option and perform a likelihood fit");
-      }
-      if (fitOption.PChi2 && fitOption.W1) {
-         Warning("FitOptionsMake", "Ignore option W or WW when used together with option P (Pearson chi2)");
-         fitOption.W1 = 0; // with Pearson chi2 W option is ignored
       }
    }
    // specific Graph options (need to be parsed before)
@@ -1016,20 +1023,25 @@ TFitResultPtr ROOT::Fit::FitObject(THnBase * s1, TF1 *f1 , Foption_t & foption ,
 
 // function to compute the simple chi2 for graphs and histograms
 
-double ROOT::Fit::Chisquare(const TH1 & h1,  TF1 & f1, bool useRange, bool usePL) {
-   return HFit::ComputeChi2(h1,f1,useRange, usePL);
+
+double ROOT::Fit::Chisquare(const TH1 & h1,  TF1 & f1, bool useRange, ROOT::Fit::EChisquareType type) {
+   return HFit::ComputeChi2(h1,f1,useRange, type);
 }
 
 double ROOT::Fit::Chisquare(const TGraph & g, TF1 & f1, bool useRange) {
-   return HFit::ComputeChi2(g,f1, useRange, false);
+   return HFit::ComputeChi2(g,f1, useRange, kNeyman);
 }
 
 template<class FitObject>
-double HFit::ComputeChi2(const FitObject & obj,  TF1  & f1, bool useRange, bool usePL ) {
+double HFit::ComputeChi2(const FitObject & obj,  TF1  & f1, bool useRange, ROOT::Fit::EChisquareType type ) {
 
    // implement using the fitting classes
    ROOT::Fit::DataOptions opt;
-   if (usePL) opt.fUseEmpty=true;
+   if (type != ROOT::Fit::kNeyman) opt.fUseEmpty=true;  // use empty bin when not using Neyman chisquare (observed error)
+   if (type == ROOT::Fit::kPearson) {
+      opt.fExpErrors=true;
+      opt.fErrors1= true;  // not using actual errors
+   }
    ROOT::Fit::DataRange range;
    // get range of function
    if (useRange) HFit::GetFunctionRange(f1,range);
@@ -1041,7 +1053,7 @@ double HFit::ComputeChi2(const FitObject & obj,  TF1  & f1, bool useRange, bool 
       return -1;
    }
    ROOT::Math::WrappedMultiTF1  wf1(f1);
-   if (usePL) {
+   if (type == ROOT::Fit::kPLikeRatio) {
       // use the poisson log-lokelihood (Baker-Cousins chi2)
       ROOT::Fit::PoissonLLFunction nll(data, wf1);
       return 2.* nll( f1.GetParameters() ) ;

--- a/hist/hist/src/HFitInterface.cxx
+++ b/hist/hist/src/HFitInterface.cxx
@@ -178,7 +178,7 @@ void FillData(BinData & dv, const TH1 * hfit, TF1 * func)
    assert( ndim > 0 );
    //typedef  BinPoint::CoordData CoordData;
    //CoordData x = CoordData( hfit->GetDimension() );
-   dv.Initialize(n,ndim);
+   dv.Initialize(n,ndim, (fitOpt.fErrors1) ? ROOT::Fit::BinData::kNoError : ROOT::Fit::BinData::kValueError);
 
    double x[3];
    double s[3];

--- a/hist/hist/src/HFitInterface.cxx
+++ b/hist/hist/src/HFitInterface.cxx
@@ -236,7 +236,10 @@ void FillData(BinData & dv, const TH1 * hfit, TF1 * func)
                if (hdim == 2)  dv.Add(  x,  x[1],  yaxis->GetBinWidth(biny) / error  );
                if (hdim == 3)  dv.Add(  x,  x[2],  zaxis->GetBinWidth(binz) / error  );
             } else {
-               dv.Add(   x,  value, error  );
+               if (fitOpt.fErrors1)
+                  dv.Add(   x,  value );
+               else
+                  dv.Add(   x,  value, error  );
                if (useBinEdges) {
                   dv.AddBinUpEdge( s );
                }

--- a/hist/hist/src/TGraph.cxx
+++ b/hist/hist/src/TGraph.cxx
@@ -1204,7 +1204,7 @@ TObject *TGraph::FindObject(const TObject *obj) const
 TFitResultPtr TGraph::Fit(TF1 *f1, Option_t *option, Option_t *goption, Axis_t rxmin, Axis_t rxmax)
 {
    Foption_t fitOption;
-   ROOT::Fit::FitOptionsMake(ROOT::Fit::kGraph, option, fitOption);
+   ROOT::Fit::FitOptionsMake(ROOT::Fit::EFitObjectType::kGraph, option, fitOption);
    // create range and minimizer options with default values
    ROOT::Fit::DataRange range(rxmin, rxmax);
    ROOT::Math::MinimizerOptions minOption;

--- a/hist/hist/src/TGraph2D.cxx
+++ b/hist/hist/src/TGraph2D.cxx
@@ -820,7 +820,7 @@ TFitResultPtr TGraph2D::Fit(TF2 *f2, Option_t *option, Option_t *)
    // internal graph2D fitting methods
    Foption_t fitOption;
    Option_t *goption = "";
-   ROOT::Fit::FitOptionsMake(ROOT::Fit::kGraph, option, fitOption);
+   ROOT::Fit::FitOptionsMake(ROOT::Fit::EFitObjectType::kGraph, option, fitOption);
 
    // create range and minimizer options with default values
    ROOT::Fit::DataRange range(2);

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -2488,9 +2488,9 @@ Double_t TH1::Chisquare(TF1 * func, Option_t *option) const
 
    TString opt(option); opt.ToUpper();
    bool useRange = opt.Contains("R");
-   ROOT::Fit::EChisquareType type = ROOT::Fit::kNeyman;  // default chi2 with observed error
-   if (opt.Contains("L")) type = ROOT::Fit::kPLikeRatio;
-   else if (opt.Contains("P")) type = ROOT::Fit::kPearson;
+   ROOT::Fit::EChisquareType type = ROOT::Fit::EChisquareType::kNeyman;  // default chi2 with observed error
+   if (opt.Contains("L")) type = ROOT::Fit::EChisquareType::kPLikeRatio;
+   else if (opt.Contains("P")) type = ROOT::Fit::EChisquareType::kPearson;
 
    return ROOT::Fit::Chisquare(*this, *func, useRange, type);
 }
@@ -4264,7 +4264,7 @@ TFitResultPtr TH1::Fit(TF1 *f1 ,Option_t *option ,Option_t *goption, Double_t xx
 {
    // implementation of Fit method is in file hist/src/HFitImpl.cxx
    Foption_t fitOption;
-   ROOT::Fit::FitOptionsMake(ROOT::Fit::kHistogram,option,fitOption);
+   ROOT::Fit::FitOptionsMake(ROOT::Fit::EFitObjectType::kHistogram,option,fitOption);
 
    // create range and minimizer options with default values
    ROOT::Fit::DataRange range(xxmin,xxmax);
@@ -4620,7 +4620,7 @@ Int_t TH1::GetQuantiles(Int_t nprobSum, Double_t *q, const Double_t *probSum)
 
 Int_t TH1::FitOptionsMake(Option_t *choptin, Foption_t &fitOption)
 {
-   ROOT::Fit::FitOptionsMake(ROOT::Fit::kHistogram, choptin,fitOption);
+   ROOT::Fit::FitOptionsMake(ROOT::Fit::EFitObjectType::kHistogram, choptin,fitOption);
    return 1;
 }
 

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -2477,6 +2477,7 @@ Double_t TH1::Chi2TestX(const TH1* h2,  Double_t &chi2, Int_t &ndf, Int_t &igood
 /// By default the full range of the histogram is used.
 /// Use option "R" for restricting the chisquare calculation to the given range of the function
 /// Use option "L" for using the chisquare based on the poisson likelihood (Baker-Cousins Chisquare)
+/// Use option "P" for using the Pearson chisquare based on the expected bin errors
 
 Double_t TH1::Chisquare(TF1 * func, Option_t *option) const
 {
@@ -2487,9 +2488,11 @@ Double_t TH1::Chisquare(TF1 * func, Option_t *option) const
 
    TString opt(option); opt.ToUpper();
    bool useRange = opt.Contains("R");
-   bool usePL = opt.Contains("L");
+   ROOT::Fit::EChisquareType type = ROOT::Fit::kNeyman;  // default chi2 with observed error
+   if (opt.Contains("L")) type = ROOT::Fit::kPLikeRatio;
+   else if (opt.Contains("P")) type = ROOT::Fit::kPearson;
 
-   return ROOT::Fit::Chisquare(*this, *func, useRange, usePL);
+   return ROOT::Fit::Chisquare(*this, *func, useRange, type);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/TMultiGraph.cxx
+++ b/hist/hist/src/TMultiGraph.cxx
@@ -702,7 +702,7 @@ TFitResultPtr TMultiGraph::Fit(TF1 *f1, Option_t *option, Option_t *goption, Axi
 {
    // internal multigraph fitting methods
    Foption_t fitOption;
-   ROOT::Fit::FitOptionsMake(ROOT::Fit::kGraph,option,fitOption);
+   ROOT::Fit::FitOptionsMake(ROOT::Fit::EFitObjectType::kGraph,option,fitOption);
 
    // create range and minimizer options with default values
    ROOT::Fit::DataRange range(rxmin,rxmax);
@@ -1596,9 +1596,9 @@ void TMultiGraph::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
    char quote = '"';
    out<<"   "<<std::endl;
-   if (gROOT->ClassSaved(TMultiGraph::Class())) 
+   if (gROOT->ClassSaved(TMultiGraph::Class()))
       out<<"   ";
-   else 
+   else
       out<<"   TMultiGraph *";
    out<<"multigraph = new TMultiGraph();"<<std::endl;
    out<<"   multigraph->SetName("<<quote<<GetName()<<quote<<");"<<std::endl;

--- a/math/mathcore/src/BinData.cxx
+++ b/math/mathcore/src/BinData.cxx
@@ -822,7 +822,9 @@ namespace ROOT {
              double y = Value(i);
              double err = Error(i);
              fSumContent += y;
-             if (y != 0 || err != 1.0)  fSumError2 += err*err;
+             if (fErrorType != kNoError) {
+               if (y != 0 || err != 1.0 )  fSumError2 += err*err;
+             }
           }
        }
        else {
@@ -836,7 +838,8 @@ namespace ROOT {
           }
        }
        // set the weight flag
-       fIsWeighted =  (fSumContent != fSumError2);
+       if (fErrorType != kNoError)
+        fIsWeighted =  (fSumContent != fSumError2);
     }
 
   } // end namespace Fit

--- a/math/mathcore/src/FitUtil.cxx
+++ b/math/mathcore/src/FitUtil.cxx
@@ -354,7 +354,6 @@ double FitUtil::EvaluateChi2(const IModelFunction &func, const BinData &data, co
          //std::cout << "using Pearson chi2 " << x[0] << "  " << 1./invError2 << "  " << fval << std::endl;
       }
 
-
 #ifdef DEBUG
       std::cout << x[0] << "  " << y << "  " << 1./invError << " params : ";
       for (unsigned int ipar = 0; ipar < func.NPar(); ++ipar)
@@ -693,7 +692,7 @@ void FitUtil::EvaluateChi2Gradient(const IModelFunction &f, const BinData &data,
    const IGradModelFunction &func = *fg;
 
 #ifdef DEBUG
-   std::cout << "\n\nFit data size = " << n << std::endl;
+   std::cout << "\n\nFit data size = " << nPoints << std::endl;
    std::cout << "evaluate chi2 using function gradient " << &func << "  " << p << std::endl;
 #endif
 


### PR DESCRIPTION
In case of a weighted histogram a weight was applied to compute the expected error for every histogram when the error is not equal to sqrt(N).  Now this is done only in case the user perform the fit using the new option "PW", otherwise it is assumed the histogram is not weighted and no correction is used for the expected error.

See also post https://root-forum.cern.ch/t/does-pearson-chi-square-fit-use-expected-error-or-observed-error-in-th1-fit/55816/3