### PR TITLE
[cmake] Remove deprecated options cxx11/14/17

### DIFF
--- a/cmake/modules/CheckCompiler.cmake
+++ b/cmake/modules/CheckCompiler.cmake
@@ -172,23 +172,6 @@ set(CMAKE_CXX_STANDARD ${CXX_STANDARD_STRING} CACHE STRING "")
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_CXX_EXTENSIONS FALSE CACHE BOOL "")
 
-if(cxx11 OR cxx14 OR cxx17)
-  message(DEPRECATION "Options cxx11/14/17 are deprecated. Please use CMAKE_CXX_STANDARD instead.")
-
-  # for backward compatibility
-  if(cxx17)
-    set(CMAKE_CXX_STANDARD 17 CACHE STRING "" FORCE)
-  elseif(cxx14)
-    set(CMAKE_CXX_STANDARD 14 CACHE STRING "" FORCE)
-  elseif(cxx11)
-    set(CMAKE_CXX_STANDARD 11 CACHE STRING "" FORCE)
-  endif()
-
-  unset(cxx17 CACHE)
-  unset(cxx14 CACHE)
-  unset(cxx11 CACHE)
-endif()
-
 if(NOT CMAKE_CXX_STANDARD MATCHES "17|20")
   message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD}. Supported standards are: 17, 20.")
 endif()

--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -408,7 +408,7 @@ if(NOT webgui)
 endif()
 
 #---Removed options------------------------------------------------------------
-foreach(opt afdsmgrd afs alien bonjour castor chirp geocad glite globus hdfs ios
+foreach(opt afdsmgrd afs alien bonjour castor chirp cxx11 cxx14 cxx17 geocad glite globus hdfs ios
             krb5 ldap memstat qt qtgsi rfio ruby sapdb srp table python vmc)
   if(${opt})
     message(FATAL_ERROR ">>> Option '${opt}' is no longer supported in ROOT ${ROOT_VERSION}.")


### PR DESCRIPTION
They were deprecated since commit 82763af605b in 2018 and don't make much sense anymore after ROOT requires C++17.