### PR TITLE
[RF] Restore FlexibleInterpVar interpolation for interpCode=4

### DIFF
--- a/roofit/histfactory/src/FlexibleInterpVar.cxx
+++ b/roofit/histfactory/src/FlexibleInterpVar.cxx
@@ -197,20 +197,25 @@ double FlexibleInterpVar::evaluate() const
 {
    double total(_nominal);
    for (std::size_t i = 0; i < _paramList.size(); ++i) {
-      if (_interpCode[i] < 0 || _interpCode[i] > 4) {
+      int code = _interpCode[i];
+      if (code < 0 || code > 4) {
          coutE(InputArguments) << "FlexibleInterpVar::evaluate ERROR:  param " << i
                                << " with unknown interpolation code" << std::endl;
       }
+      // To get consistent codes with the PiecewiseInterpolation
+      if (code == 4) {
+         code = 5;
+      }
       double paramVal = static_cast<const RooAbsReal *>(&_paramList[i])->getVal();
-      total = RooFit::Detail::EvaluateFuncs::flexibleInterp(
-         _interpCode[i], _low[i], _high[i], _interpBoundary, _nominal, paramVal, total);
+      total += RooFit::Detail::EvaluateFuncs::flexibleInterp(code, _low[i], _high[i], _interpBoundary, _nominal,
+                                                             paramVal, total);
    }
 
-  if(total<=0) {
-     total= TMath::Limits<double>::Min();
-  }
+   if (total <= 0) {
+      total = TMath::Limits<double>::Min();
+   }
 
-  return total;
+   return total;
 }
 
 void FlexibleInterpVar::translate(RooFit::Detail::CodeSquashContext &ctx) const
@@ -221,10 +226,19 @@ void FlexibleInterpVar::translate(RooFit::Detail::CodeSquashContext &ctx) const
    ctx.addToCodeBody(this, "double " + resName + " = " + std::to_string(_nominal) + ";\n");
    std::string code = "";
    for (std::size_t i = 0; i < n; ++i) {
-      code += resName + " = " +
-              ctx.buildCall("RooFit::Detail::EvaluateFuncs::flexibleInterp", _interpCode[i],
-                            _low[i], _high[i], _interpBoundary,
-                            _nominal, _paramList[i], resName) +
+
+      int interpCode = _interpCode[i];
+      if (interpCode < 0 || interpCode > 4) {
+         coutE(InputArguments) << "FlexibleInterpVar::evaluate ERROR:  param " << i
+                               << " with unknown interpolation code" << std::endl;
+      }
+      // To get consistent codes with the PiecewiseInterpolation
+      if (interpCode == 4) {
+         interpCode = 5;
+      }
+      code += resName + " += " +
+              ctx.buildCall("RooFit::Detail::EvaluateFuncs::flexibleInterp", interpCode, _low[i], _high[i],
+                            _interpBoundary, _nominal, _paramList[i], resName) +
               ";\n";
    }
    code += resName + " = " + resName + " <= 0 ? TMath::Limits<double>::Min() : " + resName + ";\n";
@@ -232,25 +246,29 @@ void FlexibleInterpVar::translate(RooFit::Detail::CodeSquashContext &ctx) const
    ctx.addResult(this, resName);
 }
 
-void FlexibleInterpVar::computeBatch(double* output, size_t /*nEvents*/, RooFit::Detail::DataMap const& dataMap) const
+void FlexibleInterpVar::computeBatch(double *output, size_t /*nEvents*/, RooFit::Detail::DataMap const &dataMap) const
 {
-  double total(_nominal) ;
+   double total(_nominal);
 
-  for (std::size_t i = 0; i < _paramList.size(); ++i) {
-     if (_interpCode[i] < 0 || _interpCode[i] > 4) {
-        coutE(InputArguments) << "FlexibleInterpVar::evaluate ERROR:  param " << i << " with unknown interpolation code"
-                              << std::endl;
-     }
-     total = RooFit::Detail::EvaluateFuncs::flexibleInterp(_interpCode[i], _low[i],
-                                                                          _high[i], _interpBoundary, _nominal,
-                                                                          dataMap.at(&_paramList[i])[0], total);
-  }
+   for (std::size_t i = 0; i < _paramList.size(); ++i) {
+      int code = _interpCode[i];
+      if (code < 0 || code > 4) {
+         coutE(InputArguments) << "FlexibleInterpVar::evaluate ERROR:  param " << i
+                               << " with unknown interpolation code" << std::endl;
+      }
+      // To get consistent codes with the PiecewiseInterpolation
+      if (code == 4) {
+         code = 5;
+      }
+      total += RooFit::Detail::EvaluateFuncs::flexibleInterp(code, _low[i], _high[i], _interpBoundary, _nominal,
+                                                             dataMap.at(&_paramList[i])[0], total);
+   }
 
-  if(total<=0) {
-     total= TMath::Limits<double>::Min();
-  }
+   if (total <= 0) {
+      total = TMath::Limits<double>::Min();
+   }
 
-  output[0] = total;
+   output[0] = total;
 }
 
 void FlexibleInterpVar::printMultiline(std::ostream& os, Int_t contents,

--- a/roofit/histfactory/src/PiecewiseInterpolation.cxx
+++ b/roofit/histfactory/src/PiecewiseInterpolation.cxx
@@ -43,7 +43,7 @@ using namespace std;
 ClassImp(PiecewiseInterpolation);
 ;
 
-using RooFit::Detail::EvaluateFuncs::piecewiseInterpolation;
+using RooFit::Detail::EvaluateFuncs::flexibleInterp;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -192,7 +192,7 @@ double PiecewiseInterpolation::evaluate() const
       coutE(InputArguments) << "PiecewiseInterpolation::evaluate ERROR:  " << param->GetName()
                  << " with unknown interpolation code" << icode << endl ;
     }
-    sum = piecewiseInterpolation(icode, low->getVal(), high->getVal(), nominal, param->getVal(), sum);
+    sum += flexibleInterp(icode, low->getVal(), high->getVal(), 1.0, nominal, param->getVal(), sum);
   }
 
   if(_positiveDefinite && (sum<0)){
@@ -221,14 +221,10 @@ void PiecewiseInterpolation::translate(RooFit::Detail::CodeSquashContext &ctx) c
                                << " with unknown interpolation code" << _interpCode[i] << endl;
       }
       std::string funcCall;
-      if (_interpCode[i] < 4)
-         funcCall = ctx.buildCall("RooFit::Detail::EvaluateFuncs::flexibleInterp", _interpCode[i], 0,
-                                  _lowSet[i], _highSet[i], 1, _nominal, _paramSet[i], resName);
-      else
-         funcCall = ctx.buildCall("RooFit::Detail::EvaluateFuncs::piecewiseInterpolation", _interpCode[i],
-                                  _lowSet[i], _highSet[i], _nominal, _paramSet[i], resName);
+       funcCall = ctx.buildCall("RooFit::Detail::EvaluateFuncs::flexibleInterp", _interpCode[i], _lowSet[i],
+                                _highSet[i], 1.0, _nominal, _paramSet[i], resName);
 
-      code += resName + " = " + funcCall + ";\n";
+      code += resName + " += " + funcCall + ";\n";
    }
    if (_positiveDefinite)
       code += resName + " = " + resName + " < 0 ? 0 : " + resName + ";\n";
@@ -260,7 +256,7 @@ void PiecewiseInterpolation::computeBatch(double* sum, size_t /*size*/, RooFit::
     }
 
     for (unsigned int j=0; j < nominal.size(); ++j) {
-       sum[j] = piecewiseInterpolation(icode, low[j], high[j], nominal[j], param, sum[j]);
+       sum[j] += flexibleInterp(icode, low[j], high[j], 1.0, nominal[j], param, sum[j]);
     }
   }
 


### PR DESCRIPTION
I haven't restored the coefficient caching at this time, however. The new interpolation is put in interpCode=5. Added option to use PiecewiseInterpolation with interpCode=5 which correspondings to FIV InterpCode=4 (confusing, I know!)

# This Pull request:

## Changes or fixes:


## Checklist:

- [ x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

