### PR TITLE
[tmva] Fix many places when `Form` was illegaly used

### DIFF
--- a/tmva/tmva/inc/TMVA/NeuralNet.icc
+++ b/tmva/tmva/inc/TMVA/NeuralNet.icc
@@ -902,7 +902,7 @@ template <typename LAYERDATA>
 
                 if ((int)cycleCount % 10 == 0) {
 
-                   TString convText = Form( "(train/test/epo/conv/maxco): %.3g/%.3g/%d/%d/%d",
+                   TString convText = TString::Format( "(train/test/epo/conv/maxco): %.3g/%.3g/%d/%d/%d",
                                             trainError,
                                             testError,
                                             (int)cycleCount,
@@ -915,7 +915,7 @@ template <typename LAYERDATA>
             while (true);
             settings.endTrainCycle (trainError);
 
-            TString convText = Form( "(train/test/epoch): %.4g/%.4g/%d", trainError, testError, (int)cycleCount);
+            TString convText = TString::Format( "(train/test/epoch): %.4g/%.4g/%d", trainError, testError, (int)cycleCount);
             double progress = 100*(double)settings.maxConvergenceCount() /(double)settings.convergenceSteps ();
             settings.cycle (progress, convText);
 

--- a/tmva/tmva/src/Classification.cxx
+++ b/tmva/tmva/src/Classification.cxx
@@ -129,9 +129,9 @@ void TMVA::Experimental::ClassificationResult::Show()
    fLogger << kINFO << "DataSet              MVA                            :" << Endl;
    fLogger << kINFO << "Name:                Method/Title:    ROC-integ     :" << Endl;
    fLogger << kINFO << hLine << Endl;
-   fLogger << kINFO << Form("%-20s %-15s  %#1.3f         :", fDataLoaderName.Data(),
-                            Form("%s/%s", fMethod.GetValue<TString>("MethodName").Data(),
-                                 fMethod.GetValue<TString>("MethodTitle").Data()),
+   fLogger << kINFO << TString::Format("%-20s %-15s  %#1.3f         :", fDataLoaderName.Data(),
+                                 TString::Format("%s/%s", fMethod.GetValue<TString>("MethodName").Data(),
+                                 fMethod.GetValue<TString>("MethodTitle").Data()).Data(),
                             GetROCIntegral())
            << Endl;
    fLogger << kINFO << hLine << Endl;
@@ -149,8 +149,8 @@ void TMVA::Experimental::ClassificationResult::Show()
 TGraph *TMVA::Experimental::ClassificationResult::GetROCGraph(UInt_t iClass, TMVA::Types::ETreeType type)
 {
    TGraph *roc = GetROC(iClass, type)->GetROCCurve();
-   roc->SetName(Form("%s/%s", GetMethodName().Data(), GetMethodTitle().Data()));
-   roc->SetTitle(Form("%s/%s", GetMethodName().Data(), GetMethodTitle().Data()));
+   roc->SetName(TString::Format("%s/%s", GetMethodName().Data(), GetMethodTitle().Data()).Data());
+   roc->SetTitle(TString::Format("%s/%s", GetMethodName().Data(), GetMethodTitle().Data()).Data());
    roc->GetXaxis()->SetTitle(" Signal Efficiency ");
    roc->GetYaxis()->SetTitle(" Background Rejection ");
    return roc;
@@ -271,8 +271,8 @@ void TMVA::Experimental::Classification::Evaluate()
          auto methodtitle = fMethods[workerID].GetValue<TString>("MethodTitle");
          auto meth = GetMethod(methodname, methodtitle);
          if (!IsSilentFile()) {
-            auto fname = Form(".%s%s%s.root", fDataLoader->GetName(), methodname.Data(), methodtitle.Data());
-            auto f = new TFile(fname, "RECREATE");
+            auto fname = TString::Format(".%s%s%s.root", fDataLoader->GetName(), methodname.Data(), methodtitle.Data());
+            auto f = new TFile(fname.Data(), "RECREATE");
             f->mkdir(fDataLoader->GetName());
             SetFile(f);
             meth->SetFile(f);
@@ -302,15 +302,16 @@ void TMVA::Experimental::Classification::Evaluate()
    Log() << kINFO << hLine << Endl;
    for (auto &r : fResults) {
 
-      Log() << kINFO << Form("%-20s %-15s  %#1.3f         :", r.GetDataLoaderName().Data(),
-                             Form("%s/%s", r.GetMethodName().Data(), r.GetMethodTitle().Data()), r.GetROCIntegral())
+      Log() << kINFO << TString::Format("%-20s %-15s  %#1.3f         :", r.GetDataLoaderName().Data(),
+                                TString::Format("%s/%s", r.GetMethodName().Data(), r.GetMethodTitle().Data()).Data(),
+                                r.GetROCIntegral())
             << Endl;
    }
    Log() << kINFO << hLine << Endl;
 
    Log() << kINFO << "-----------------------------------------------------" << Endl;
    Log() << kHEADER << "Evaluation done." << Endl << Endl;
-   Log() << kINFO << Form("Jobs = %d Real Time = %lf ", fJobs, fTimer.RealTime()) << Endl;
+   Log() << kINFO << TString::Format("Jobs = %d Real Time = %lf ", fJobs, fTimer.RealTime()) << Endl;
    Log() << kINFO << "-----------------------------------------------------" << Endl;
    Log() << kINFO << "Evaluation done." << Endl;
    TMVA::gConfig().SetSilent(kTRUE);
@@ -338,10 +339,10 @@ void TMVA::Experimental::Classification::TrainMethod(TString methodname, TString
    auto method = GetMethod(methodname, methodtitle);
    if (!method) {
       Log() << kFATAL
-            << Form("Trying to train method %s %s that maybe is not booked.", methodname.Data(), methodtitle.Data())
+            << TString::Format("Trying to train method %s %s that maybe is not booked.", methodname.Data(), methodtitle.Data())
             << Endl;
    }
-   Log() << kHEADER << gTools().Color("bold") << Form("Training method %s %s", methodname.Data(), methodtitle.Data())
+   Log() << kHEADER << gTools().Color("bold") << TString::Format("Training method %s %s", methodname.Data(), methodtitle.Data())
          << gTools().Color("reset") << Endl;
 
    Event::SetIsTraining(kTRUE);
@@ -527,7 +528,7 @@ void TMVA::Experimental::Classification::TestMethod(TString methodname, TString 
    auto method = GetMethod(methodname, methodtitle);
    if (!method) {
       Log() << kFATAL
-            << Form("Trying to train method %s %s that maybe is not booked.", methodname.Data(), methodtitle.Data())
+            << TString::Format("Trying to train method %s %s that maybe is not booked.", methodname.Data(), methodtitle.Data())
             << Endl;
    }
 
@@ -743,54 +744,54 @@ void TMVA::Experimental::Classification::TestMethod(TString methodname, TString 
 
             if (nmeth > 1) {
                Log() << kINFO << Endl;
-               Log() << kINFO << Form("Dataset[%s] : ", method->fDataSetInfo.GetName())
+               Log() << kINFO << TString::Format("Dataset[%s] : ", method->fDataSetInfo.GetName())
                      << "Inter-MVA correlation matrix (signal):" << Endl;
                gTools().FormattedOutput(mvaMatS, *theVars, Log());
                Log() << kINFO << Endl;
 
-               Log() << kINFO << Form("Dataset[%s] : ", method->fDataSetInfo.GetName())
+               Log() << kINFO << TString::Format("Dataset[%s] : ", method->fDataSetInfo.GetName())
                      << "Inter-MVA correlation matrix (background):" << Endl;
                gTools().FormattedOutput(mvaMatB, *theVars, Log());
                Log() << kINFO << Endl;
             }
 
-            Log() << kINFO << Form("Dataset[%s] : ", method->fDataSetInfo.GetName())
+            Log() << kINFO << TString::Format("Dataset[%s] : ", method->fDataSetInfo.GetName())
                   << "Correlations between input variables and MVA response (signal):" << Endl;
             gTools().FormattedOutput(varmvaMatS, theInputVars, *theVars, Log());
             Log() << kINFO << Endl;
 
-            Log() << kINFO << Form("Dataset[%s] : ", method->fDataSetInfo.GetName())
+            Log() << kINFO << TString::Format("Dataset[%s] : ", method->fDataSetInfo.GetName())
                   << "Correlations between input variables and MVA response (background):" << Endl;
             gTools().FormattedOutput(varmvaMatB, theInputVars, *theVars, Log());
             Log() << kINFO << Endl;
          } else
-            Log() << kWARNING << Form("Dataset[%s] : ", method->fDataSetInfo.GetName())
+            Log() << kWARNING << TString::Format("Dataset[%s] : ", method->fDataSetInfo.GetName())
                   << "<TestAllMethods> cannot compute correlation matrices" << Endl;
 
          //              print overlap matrices
-         Log() << kINFO << Form("Dataset[%s] : ", method->fDataSetInfo.GetName())
+         Log() << kINFO << TString::Format("Dataset[%s] : ", method->fDataSetInfo.GetName())
                << "The following \"overlap\" matrices contain the fraction of events for which " << Endl;
-         Log() << kINFO << Form("Dataset[%s] : ", method->fDataSetInfo.GetName())
+         Log() << kINFO << TString::Format("Dataset[%s] : ", method->fDataSetInfo.GetName())
                << "the MVAs 'i' and 'j' have returned conform answers about \"signal-likeness\"" << Endl;
-         Log() << kINFO << Form("Dataset[%s] : ", method->fDataSetInfo.GetName())
+         Log() << kINFO << TString::Format("Dataset[%s] : ", method->fDataSetInfo.GetName())
                << "An event is signal-like, if its MVA output exceeds the following value:" << Endl;
          gTools().FormattedOutput(rvec, *theVars, "Method", "Cut value", Log());
-         Log() << kINFO << Form("Dataset[%s] : ", method->fDataSetInfo.GetName())
+         Log() << kINFO << TString::Format("Dataset[%s] : ", method->fDataSetInfo.GetName())
                << "which correspond to the working point: eff(signal) = 1 - eff(background)" << Endl;
 
          //              give notice that cut method has been excluded from this test
          if (nmeth != 1)
-            Log() << kINFO << Form("Dataset[%s] : ", method->fDataSetInfo.GetName())
+            Log() << kINFO << TString::Format("Dataset[%s] : ", method->fDataSetInfo.GetName())
                   << "Note: no correlations and overlap with cut method are provided at present" << Endl;
 
          if (nmeth > 1) {
             Log() << kINFO << Endl;
-            Log() << kINFO << Form("Dataset[%s] : ", method->fDataSetInfo.GetName())
+            Log() << kINFO << TString::Format("Dataset[%s] : ", method->fDataSetInfo.GetName())
                   << "Inter-MVA overlap matrix (signal):" << Endl;
             gTools().FormattedOutput(*overlapS, *theVars, Log());
             Log() << kINFO << Endl;
 
-            Log() << kINFO << Form("Dataset[%s] : ", method->fDataSetInfo.GetName())
+            Log() << kINFO << TString::Format("Dataset[%s] : ", method->fDataSetInfo.GetName())
                   << "Inter-MVA overlap matrix (background):" << Endl;
             gTools().FormattedOutput(*overlapB, *theVars, Log());
          }
@@ -853,11 +854,11 @@ void TMVA::Experimental::Classification::TestMethod(TString methodname, TString 
                // cannot compute separation/significance -> no MVA (usually for Cuts)
                fResult.fROCIntegral = effArea[k][i];
                Log() << kINFO
-                     << Form("%-13s %-15s: %#1.3f", fDataLoader->GetName(), methodName.Data(), fResult.fROCIntegral)
+                     << TString::Format("%-13s %-15s: %#1.3f", fDataLoader->GetName(), methodName.Data(), fResult.fROCIntegral)
                      << Endl;
             } else {
                fResult.fROCIntegral = rocIntegral;
-               Log() << kINFO << Form("%-13s %-15s: %#1.3f", datasetName.Data(), methodName.Data(), rocIntegral)
+               Log() << kINFO << TString::Format("%-13s %-15s: %#1.3f", datasetName.Data(), methodName.Data(), rocIntegral)
                      << Endl;
             }
          }
@@ -881,8 +882,8 @@ void TMVA::Experimental::Classification::TestMethod(TString methodname, TString 
             if (k == 1)
                mname[k][i].ReplaceAll("Variable_", "");
 
-            Log() << kINFO << Form("%-20s %-15s: %#1.3f (%#1.3f)       %#1.3f (%#1.3f)      %#1.3f (%#1.3f)",
-                                   method->fDataSetInfo.GetName(), (const char *)mname[k][i], eff01[k][i],
+            Log() << kINFO << TString::Format("%-20s %-15s: %#1.3f (%#1.3f)       %#1.3f (%#1.3f)      %#1.3f (%#1.3f)",
+                                   method->fDataSetInfo.GetName(), mname[k][i].Data(), eff01[k][i],
                                    trainEff01[k][i], eff10[k][i], trainEff10[k][i], eff30[k][i], trainEff30[k][i])
                   << Endl;
          }
@@ -997,7 +998,7 @@ TMVA::Experimental::Classification::GetROC(TMVA::MethodBase *method, UInt_t iCla
 
    UInt_t nClasses = method->DataInfo().GetNClasses();
    if (this->fAnalysisType == Types::kMulticlass && iClass >= nClasses) {
-      Log() << kERROR << Form("Given class number (iClass = %i) does not exist. There are %i classes in dataset.",
+      Log() << kERROR << TString::Format("Given class number (iClass = %i) does not exist. There are %i classes in dataset.",
                               iClass, nClasses)
             << Endl;
       return nullptr;
@@ -1075,7 +1076,7 @@ Double_t TMVA::Experimental::Classification::GetROCIntegral(TString methodname, 
    TMVA::ROCCurve *rocCurve = GetROC(methodname, methodtitle, iClass);
    if (!rocCurve) {
       Log() << kFATAL
-            << Form("ROCCurve object was not created in MethodName = %s MethodTitle = %s not found with Dataset = %s ",
+            << TString::Format("ROCCurve object was not created in MethodName = %s MethodTitle = %s not found with Dataset = %s ",
                     methodname.Data(), methodtitle.Data(), fDataLoader->GetName())
             << Endl;
       return 0;
@@ -1130,20 +1131,20 @@ void TMVA::Experimental::Classification::MergeFiles()
 {
 
    auto dsdir = fFile->mkdir(fDataLoader->GetName()); // dataset dir
-   TTree *TrainTree = 0;
-   TTree *TestTree = 0;
-   TFile *ifile = 0;
-   TFile *ofile = 0;
+   TTree *TrainTree = nullptr;
+   TTree *TestTree = nullptr;
+   TFile *ifile = nullptr;
+   TFile *ofile = nullptr;
    for (UInt_t i = 0; i < fMethods.size(); i++) {
       auto methodname = fMethods[i].GetValue<TString>("MethodName");
       auto methodtitle = fMethods[i].GetValue<TString>("MethodTitle");
-      auto fname = Form(".%s%s%s.root", fDataLoader->GetName(), methodname.Data(), methodtitle.Data());
-      TDirectoryFile *ds = 0;
+      auto fname = TString::Format(".%s%s%s.root", fDataLoader->GetName(), methodname.Data(), methodtitle.Data());
+      TDirectoryFile *ds = nullptr;
       if (i == 0) {
-         ifile = new TFile(fname);
+         ifile = new TFile(fname.Data());
          ds = (TDirectoryFile *)ifile->Get(fDataLoader->GetName());
       } else {
-         ofile = new TFile(fname);
+         ofile = new TFile(fname.Data());
          ds = (TDirectoryFile *)ofile->Get(fDataLoader->GetName());
       }
       auto tmptrain = (TTree *)ds->Get("TrainTree");
@@ -1151,10 +1152,10 @@ void TMVA::Experimental::Classification::MergeFiles()
       fFile->cd();
       fFile->cd(fDataLoader->GetName());
 
-      auto methdirname = Form("Method_%s", methodtitle.Data());
-      auto methdir = dsdir->mkdir(methdirname, methdirname);
+      auto methdirname = TString::Format("Method_%s", methodtitle.Data());
+      auto methdir = dsdir->mkdir(methdirname.Data(), methdirname.Data());
       auto methdirbase = methdir->mkdir(methodtitle.Data(), methodtitle.Data());
-      auto mfdir = (TDirectoryFile *)ds->Get(methdirname);
+      auto mfdir = (TDirectoryFile *)ds->Get(methdirname.Data());
       auto mfdirbase = (TDirectoryFile *)mfdir->Get(methodtitle.Data());
 
       CopyFrom(mfdirbase, (TFile *)methdirbase);
@@ -1188,7 +1189,7 @@ void TMVA::Experimental::Classification::MergeFiles()
    for (UInt_t i = 0; i < fMethods.size(); i++) {
       auto methodname = fMethods[i].GetValue<TString>("MethodName");
       auto methodtitle = fMethods[i].GetValue<TString>("MethodTitle");
-      auto fname = Form(".%s%s%s.root", fDataLoader->GetName(), methodname.Data(), methodtitle.Data());
-      gSystem->Unlink(fname);
+      auto fname = TString::Format(".%s%s%s.root", fDataLoader->GetName(), methodname.Data(), methodtitle.Data());
+      gSystem->Unlink(fname.Data());
    }
 }

--- a/tmva/tmva/src/CrossValidation.cxx
+++ b/tmva/tmva/src/CrossValidation.cxx
@@ -157,12 +157,12 @@ void TMVA::CrossValidationResult::Print() const
    MsgLogger fLogger("CrossValidation");
    fLogger << kHEADER << " ==== Results ====" << Endl;
    for(auto &item:fROCs) {
-      fLogger << kINFO << Form("Fold  %i ROC-Int : %.4f",item.first,item.second) << std::endl;
+      fLogger << kINFO << TString::Format("Fold  %i ROC-Int : %.4f",item.first,item.second) << std::endl;
    }
 
    fLogger << kINFO << "------------------------" << Endl;
-   fLogger << kINFO << Form("Average ROC-Int : %.4f",GetROCAverage()) << Endl;
-   fLogger << kINFO << Form("Std-Dev ROC-Int : %.4f",GetROCStandardDeviation()) << Endl;
+   fLogger << kINFO << TString::Format("Average ROC-Int : %.4f",GetROCAverage()) << Endl;
+   fLogger << kINFO << TString::Format("Std-Dev ROC-Int : %.4f",GetROCStandardDeviation()) << Endl;
 
    TMVA::gConfig().SetSilent(kTRUE);
 }
@@ -403,11 +403,11 @@ void TMVA::CrossValidation::ParseOptions()
       fOutputFactoryOptions += "!V:";
    }
 
-   fCvFactoryOptions += Form("VerboseLevel=%s:", fVerboseLevel.Data());
-   fOutputFactoryOptions += Form("VerboseLevel=%s:", fVerboseLevel.Data());
+   fCvFactoryOptions += TString::Format("VerboseLevel=%s:", fVerboseLevel.Data());
+   fOutputFactoryOptions += TString::Format("VerboseLevel=%s:", fVerboseLevel.Data());
 
-   fCvFactoryOptions += Form("AnalysisType=%s:", fAnalysisTypeStr.Data());
-   fOutputFactoryOptions += Form("AnalysisType=%s:", fAnalysisTypeStr.Data());
+   fCvFactoryOptions += TString::Format("AnalysisType=%s:", fAnalysisTypeStr.Data());
+   fOutputFactoryOptions += TString::Format("AnalysisType=%s:", fAnalysisTypeStr.Data());
 
    if (!fDrawProgressBar) {
       fCvFactoryOptions += "!DrawProgressBar:";
@@ -415,8 +415,8 @@ void TMVA::CrossValidation::ParseOptions()
    }
 
    if (fTransformations != "") {
-      fCvFactoryOptions += Form("Transformations=%s:", fTransformations.Data());
-      fOutputFactoryOptions += Form("Transformations=%s:", fTransformations.Data());
+      fCvFactoryOptions += TString::Format("Transformations=%s:", fTransformations.Data());
+      fOutputFactoryOptions += TString::Format("Transformations=%s:", fTransformations.Data());
    }
 
    if (fCorrelations) {
@@ -436,8 +436,8 @@ void TMVA::CrossValidation::ParseOptions()
    }
 
    if (fSilent) {
-      fCvFactoryOptions += Form("Silent:");
-      fOutputFactoryOptions += Form("Silent:");
+      fCvFactoryOptions += "Silent:";
+      fOutputFactoryOptions += "Silent:";
    }
 
    // CE specific options
@@ -643,7 +643,7 @@ void TMVA::CrossValidation::Evaluate()
 
       // Serialise the cross evaluated method
       TString options =
-         Form("SplitExpr=%s:NumFolds=%i"
+         TString::Format("SplitExpr=%s:NumFolds=%i"
               ":EncapsulatedMethodName=%s"
               ":EncapsulatedMethodTypeName=%s"
               ":OutputEnsembling=%s",

--- a/tmva/tmva/src/DataInputHandler.cxx
+++ b/tmva/tmva/src/DataInputHandler.cxx
@@ -153,7 +153,8 @@ TTree* TMVA::DataInputHandler::ReadInputTree( const TString& dataFile )
 {
    TTree* tr = new TTree( "tmp", dataFile );
    std::ifstream in(dataFile);
-   tr->SetDirectory(0); Log() << kWARNING << "Watch out, I (Helge) made the Tree not associated to the current directory .. Hopefully that does not have unwanted consequences" << Endl;
+   tr->SetDirectory(nullptr); 
+   Log() << kWARNING << "Watch out, I (Helge) made the Tree not associated to the current directory .. Hopefully that does not have unwanted consequences" << Endl;
    if (!in.good()) Log() << kFATAL << "Could not open file: " << dataFile << Endl;
    in.close();
 

--- a/tmva/tmva/src/DataLoader.cxx
+++ b/tmva/tmva/src/DataLoader.cxx
@@ -195,7 +195,7 @@ TMVA::DataLoader* TMVA::DataLoader::VarTransform(TString trafoDefinition)
 TTree* TMVA::DataLoader::CreateEventAssignTrees( const TString& name )
 {
    TTree * assignTree = new TTree( name, name );
-   assignTree->SetDirectory(0);
+   assignTree->SetDirectory(nullptr);
    assignTree->Branch( "type",   &fATreeType,   "ATreeType/I" );
    assignTree->Branch( "weight", &fATreeWeight, "ATreeWeight/F" );
 

--- a/tmva/tmva/src/DataLoader.cxx
+++ b/tmva/tmva/src/DataLoader.cxx
@@ -292,8 +292,8 @@ void TMVA::DataLoader::AddEvent( const TString& className, Types::ETreeType tt,
    }
 
    if (fTrainAssignTree[clIndex]==0) { // does not exist yet
-      fTrainAssignTree[clIndex] = CreateEventAssignTrees( Form("TrainAssignTree_%s", className.Data()) );
-      fTestAssignTree[clIndex]  = CreateEventAssignTrees( Form("TestAssignTree_%s",  className.Data()) );
+      fTrainAssignTree[clIndex] = CreateEventAssignTrees( TString::Format("TrainAssignTree_%s", className.Data()).Data() );
+      fTestAssignTree[clIndex]  = CreateEventAssignTrees( TString::Format("TestAssignTree_%s",  className.Data()).Data() );
    }
 
    fATreeType   = clIndex;
@@ -607,8 +607,8 @@ void TMVA::DataLoader::PrepareTrainingAndTestTree( const TCut& cut,
 
    AddCut( cut  );
 
-   DefaultDataSetInfo().SetSplitOptions( Form("nTrain_Signal=%i:nTrain_Background=%i:nTest_Signal=%i:nTest_Background=%i:%s",
-                                              NsigTrain, NbkgTrain, NsigTest, NbkgTest, otherOpt.Data()) );
+   DefaultDataSetInfo().SetSplitOptions( TString::Format("nTrain_Signal=%i:nTrain_Background=%i:nTest_Signal=%i:nTest_Background=%i:%s",
+                                              NsigTrain, NbkgTrain, NsigTest, NbkgTest, otherOpt.Data()).Data() );
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -621,8 +621,8 @@ void TMVA::DataLoader::PrepareTrainingAndTestTree( const TCut& cut, Int_t Ntrain
 
    AddCut( cut  );
 
-   DefaultDataSetInfo().SetSplitOptions( Form("nTrain_Signal=%i:nTrain_Background=%i:nTest_Signal=%i:nTest_Background=%i:SplitMode=Random:EqualTrainSample:!V",
-                                              Ntrain, Ntrain, Ntest, Ntest) );
+   DefaultDataSetInfo().SetSplitOptions( TString::Format("nTrain_Signal=%i:nTrain_Background=%i:nTest_Signal=%i:nTest_Background=%i:SplitMode=Random:EqualTrainSample:!V",
+                                              Ntrain, Ntrain, Ntest, Ntest).Data() );
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/src/DataSet.cxx
+++ b/tmva/tmva/src/DataSet.cxx
@@ -172,13 +172,13 @@ Long64_t TMVA::DataSet::GetNClassEvents( Int_t type, UInt_t classNumber )
    }
    catch (std::out_of_range &) {
       ClassInfo* ci = fdsi->GetClassInfo( classNumber );
-      Log() << kFATAL << Form("Dataset[%s] : ",fdsi->GetName()) << "No " << (type==0?"training":(type==1?"testing":"_unknown_type_"))
+      Log() << kFATAL << TString::Format("Dataset[%s] : ",fdsi->GetName()) << "No " << (type==0?"training":(type==1?"testing":"_unknown_type_"))
             << " events for class " << (ci==NULL?"_no_name_known_":ci->GetName()) << " (index # "<<classNumber<<")"
             << " available. Check if all class names are spelled correctly and if events are"
             << " passing the selection cuts." << Endl;
    }
    catch (...) {
-      Log() << kFATAL << Form("Dataset[%s] : ",fdsi->GetName()) << "ERROR/CAUGHT : DataSet/GetNClassEvents, .. unknown error" << Endl;
+      Log() << kFATAL << TString::Format("Dataset[%s] : ",fdsi->GetName()) << "ERROR/CAUGHT : DataSet/GetNClassEvents, .. unknown error" << Endl;
    }
    return 0;
 }
@@ -320,19 +320,19 @@ void TMVA::DataSet::DeleteResults( const TString & resultsName,
    if (fResults.empty()) return;
 
    if (UInt_t(type) > fResults.size()){
-      Log()<<kFATAL<< Form("Dataset[%s] : ",fdsi->GetName()) << "you asked for an Treetype (training/testing/...)"
+      Log()<<kFATAL<< TString::Format("Dataset[%s] : ",fdsi->GetName()) << "you asked for an Treetype (training/testing/...)"
            << " whose index " << type << " does not exist " << Endl;
    }
    std::map< TString, Results* >& resultsForType = fResults[UInt_t(type)];
    std::map< TString, Results* >::iterator it = resultsForType.find(resultsName);
    if (it!=resultsForType.end()) {
-      Log() << kDEBUG << Form("Dataset[%s] : ",fdsi->GetName()) << " Delete Results previous existing result:" << resultsName
+      Log() << kDEBUG << TString::Format("Dataset[%s] : ",fdsi->GetName()) << " Delete Results previous existing result:" << resultsName
             << " of type " << type << Endl;
       delete it->second;
       resultsForType.erase(it->first);
    }
    else {
-      Log() << kINFO << Form("Dataset[%s] : ",fdsi->GetName()) << "could not fine Result class of " << resultsName
+      Log() << kINFO << TString::Format("Dataset[%s] : ",fdsi->GetName()) << "could not fine Result class of " << resultsName
             << " of type " << type << " which I should have deleted" << Endl;
    }
 }
@@ -346,7 +346,7 @@ void TMVA::DataSet::DeleteAllResults(Types::ETreeType type,
    if (fResults.empty()) return;
 
    if (UInt_t(type) > fResults.size()){
-      Log()<<kFATAL<< Form("Dataset[%s] : ",fdsi->GetName()) << "you asked for an Treetype (training/testing/...)"
+      Log()<<kFATAL<< TString::Format("Dataset[%s] : ",fdsi->GetName()) << "you asked for an Treetype (training/testing/...)"
            << " whose index " << type << " does not exist " << Endl;
    }
 
@@ -355,7 +355,7 @@ void TMVA::DataSet::DeleteAllResults(Types::ETreeType type,
    for (auto && it : resultsForType) {
       auto & resultsName = it.first;
 
-      Log() << kDEBUG << Form("Dataset[%s] : ", fdsi->GetName())
+      Log() << kDEBUG << TString::Format("Dataset[%s] : ", fdsi->GetName())
                       << " DeleteAllResults previous existing result: "
                       << resultsName << " of type " << type << Endl;
 
@@ -512,7 +512,7 @@ void TMVA::DataSet::CreateSampling() const
    if (!fSampling.at(treeIdx) ) return;
 
    if (fSamplingRandom == 0 )
-      Log() << kFATAL<< Form("Dataset[%s] : ",fdsi->GetName())
+      Log() << kFATAL<< TString::Format("Dataset[%s] : ",fdsi->GetName())
             << "no random generator present for creating a random/importance sampling (initialized?)" << Endl;
 
    // delete the previous selection
@@ -583,7 +583,7 @@ void TMVA::DataSet::EventResult( Bool_t successful, Long64_t evtNumber )
    }
    for ( Long64_t iEvt = start; iEvt <= stop; iEvt++ ){
       if (Long64_t(fSamplingEventList.at(fCurrentTreeIdx).size()) < iEvt) {
-         Log() << kWARNING << Form("Dataset[%s] : ",fdsi->GetName()) << "event number (" << iEvt
+         Log() << kWARNING << TString::Format("Dataset[%s] : ",fdsi->GetName()) << "event number (" << iEvt
                << ") larger than number of sampled events ("
                << fSamplingEventList.at(fCurrentTreeIdx).size() << " of tree " << fCurrentTreeIdx << ")" << Endl;
          return;
@@ -608,7 +608,7 @@ void TMVA::DataSet::EventResult( Bool_t successful, Long64_t evtNumber )
 
 TTree* TMVA::DataSet::GetTree( Types::ETreeType type )
 {
-   Log() << kDEBUG << Form("Dataset[%s] : ",fdsi->GetName()) << "GetTree(" << ( type==Types::kTraining ? "training" : "testing" ) << ")" << Endl;
+   Log() << kDEBUG << TString::Format("Dataset[%s] : ",fdsi->GetName()) << "GetTree(" << ( type==Types::kTraining ? "training" : "testing" ) << ")" << Endl;
 
    // the dataset does not hold the tree, this function returns a new tree every time it is called
 
@@ -619,7 +619,7 @@ TTree* TMVA::DataSet::GetTree( Types::ETreeType type )
    SetCurrentType(type);
    const UInt_t t = TreeIndex(type);
    if (fResults.size() <= t) {
-      Log() << kWARNING << Form("Dataset[%s] : ",fdsi->GetName()) << "No results for treetype " << ( type==Types::kTraining ? "training" : "testing" )
+      Log() << kWARNING << TString::Format("Dataset[%s] : ",fdsi->GetName()) << "No results for treetype " << ( type==Types::kTraining ? "training" : "testing" )
             << " found. Size=" << fResults.size() << Endl;
    }
 
@@ -650,14 +650,14 @@ TTree* TMVA::DataSet::GetTree( Types::ETreeType type )
    // create all branches for the variables
    Int_t n = 0;
    Int_t ivar_array = 0;
-   Int_t arraySize = -1; 
+   Int_t arraySize = -1;
    for (std::vector<VariableInfo>::const_iterator itVars = fdsi->GetVariableInfos().begin();
         itVars != fdsi->GetVariableInfos().end(); ++itVars) {
 
       // has to be changed to take care of types different than float: TODO
-      if (!itVars->TestBit(DataSetInfo::kIsArrayVariable) ) 
+      if (!itVars->TestBit(DataSetInfo::kIsArrayVariable) )
          tree->Branch( (*itVars).GetInternalName(), &varVals[n], (*itVars).GetInternalName()+TString("/F") );
-      else { 
+      else {
          // variable is an array
          if (ivar_array == 0) {
             TString name = (*itVars).GetInternalName();
@@ -666,9 +666,9 @@ TTree* TMVA::DataSet::GetTree( Types::ETreeType type )
             tree->Branch(name, &varVals[n], name + TString::Format("[%d]/F", arraySize));
             Log() << kDEBUG << "creating branch for array " << name << " with size " << arraySize << Endl;
          }
-         ivar_array++; 
+         ivar_array++;
          if (ivar_array == arraySize)
-            ivar_array = 0; 
+            ivar_array = 0;
       }
       n++;
    }
@@ -697,8 +697,9 @@ TTree* TMVA::DataSet::GetTree( Types::ETreeType type )
         itMethod != fResults.at(t).end(); ++itMethod) {
 
 
-      Log() << kDEBUG << Form("Dataset[%s] : ",fdsi->GetName()) << "analysis type: " << (itMethod->second->GetAnalysisType()==Types::kRegression ? "Regression" :
-                                                                                        (itMethod->second->GetAnalysisType()==Types::kMulticlass ? "Multiclass" : "Classification" )) << Endl;
+      Log() << kDEBUG << TString::Format("Dataset[%s] : ",fdsi->GetName())
+            << "analysis type: " << (itMethod->second->GetAnalysisType()==Types::kRegression ? "Regression" :
+                                    (itMethod->second->GetAnalysisType()==Types::kMulticlass ? "Multiclass" : "Classification" )) << Endl;
 
       if (itMethod->second->GetAnalysisType() == Types::kClassification) {
          // classification
@@ -712,7 +713,7 @@ TTree* TMVA::DataSet::GetTree( Types::ETreeType type )
             leafList.Append( fdsi->GetClassInfo( iCls )->GetName() );
             leafList.Append( "/F" );
          }
-         Log() << kDEBUG << Form("Dataset[%s] : ",fdsi->GetName()) << "itMethod->first " << itMethod->first <<  "    LEAFLIST: "
+         Log() << kDEBUG << TString::Format("Dataset[%s] : ",fdsi->GetName()) << "itMethod->first " << itMethod->first <<  "    LEAFLIST: "
                << leafList << "    itMethod->second " << itMethod->second <<  Endl;
          tree->Branch( itMethod->first, (metVals[n]), leafList );
       }
@@ -725,12 +726,12 @@ TTree* TMVA::DataSet::GetTree( Types::ETreeType type )
             //            leafList.Append( fdsi->GetTargetInfo( iTgt ).GetLabel() );
             leafList.Append( "/F" );
          }
-         Log() << kDEBUG << Form("Dataset[%s] : ",fdsi->GetName()) << "itMethod->first " << itMethod->first <<  "    LEAFLIST: "
+         Log() << kDEBUG << TString::Format("Dataset[%s] : ",fdsi->GetName()) << "itMethod->first " << itMethod->first <<  "    LEAFLIST: "
                << leafList << "    itMethod->second " << itMethod->second <<  Endl;
          tree->Branch( itMethod->first, (metVals[n]), leafList );
       }
       else {
-         Log() << kWARNING << Form("Dataset[%s] : ",fdsi->GetName()) << "Unknown analysis type for result found when writing TestTree." << Endl;
+         Log() << kWARNING << TString::Format("Dataset[%s] : ",fdsi->GetName()) << "Unknown analysis type for result found when writing TestTree." << Endl;
       }
       n++;
 
@@ -806,7 +807,7 @@ TTree* TMVA::DataSet::GetTree( Types::ETreeType type )
       tree->Fill();
    }
 
-   Log() << kHEADER //<< Form("[%s] : ",fdsi.GetName())
+   Log() << kHEADER //<< TString::Format("[%s] : ",fdsi.GetName())
     << "Created tree '" << tree->GetName() << "' with " << tree->GetEntries() << " events" << Endl << Endl;
 
    SetCurrentType(savedType);

--- a/tmva/tmva/src/DataSet.cxx
+++ b/tmva/tmva/src/DataSet.cxx
@@ -62,7 +62,7 @@ TMVA::DataSet::DataSet(const DataSetInfo& dsi)
      fCurrentTreeIdx(0),
      fCurrentEventIdx(0),
      fHasNegativeEventWeights(kFALSE),
-     fLogger( new MsgLogger(TString(TString("Dataset:")+dsi.GetName()).Data()) ),
+     fLogger( new MsgLogger((TString("Dataset:")+dsi.GetName()).Data()) ),
      fTrainingBlockSize(0)
 {
 
@@ -94,7 +94,7 @@ TMVA::DataSet::DataSet()
      fCurrentTreeIdx(0),
      fCurrentEventIdx(0),
      fHasNegativeEventWeights(kFALSE),
-     fLogger( new MsgLogger(TString(TString("Dataset:")+GetName()).Data()) ),
+     fLogger( new MsgLogger((TString("Dataset:")+GetName()).Data()) ),
      fTrainingBlockSize(0)
 {
 

--- a/tmva/tmva/src/DataSetFactory.cxx
+++ b/tmva/tmva/src/DataSetFactory.cxx
@@ -354,7 +354,7 @@ void TMVA::DataSetFactory::ChangeToNewTree( TreeInfo& tinfo, const DataSetInfo &
    for (formIt = fTargetFormulas.begin(), formItEnd = fTargetFormulas.end(); formIt!=formItEnd; ++formIt) if (*formIt) delete *formIt;
    fTargetFormulas.clear();
    for (UInt_t i=0; i<dsi.GetNTargets(); i++) {
-      ttf = new TTreeFormula( Form( "Formula%s", dsi.GetTargetInfo(i).GetInternalName().Data() ),
+      ttf = new TTreeFormula( TString::Format( "Formula%s", dsi.GetTargetInfo(i).GetInternalName().Data() ),
                               dsi.GetTargetInfo(i).GetExpression().Data(), tr );
       CheckTTreeFormula( ttf, dsi.GetTargetInfo(i).GetExpression(), hasDollar );
       fTargetFormulas.push_back( ttf );
@@ -367,7 +367,7 @@ void TMVA::DataSetFactory::ChangeToNewTree( TreeInfo& tinfo, const DataSetInfo &
    for (formIt = fSpectatorFormulas.begin(), formItEnd = fSpectatorFormulas.end(); formIt!=formItEnd; ++formIt) if (*formIt) delete *formIt;
    fSpectatorFormulas.clear();
    for (UInt_t i=0; i<dsi.GetNSpectators(); i++) {
-      ttf = new TTreeFormula( Form( "Formula%s", dsi.GetSpectatorInfo(i).GetInternalName().Data() ),
+      ttf = new TTreeFormula( TString::Format( "Formula%s", dsi.GetSpectatorInfo(i).GetInternalName().Data() ),
                               dsi.GetSpectatorInfo(i).GetExpression().Data(), tr );
       CheckTTreeFormula( ttf, dsi.GetSpectatorInfo(i).GetExpression(), hasDollar );
       fSpectatorFormulas.push_back( ttf );

--- a/tmva/tmva/src/DecisionTreeNode.cxx
+++ b/tmva/tmva/src/DecisionTreeNode.cxx
@@ -462,7 +462,7 @@ void TMVA::DecisionTreeNode::ReadAttributes(void* node, UInt_t /* tmva_Version_C
       this->SetNFisherCoeff(nCoef);
       Double_t tmp;
       for (Int_t i=0; i< (Int_t) this->GetNFisherCoeff(); i++) {
-         gTools().ReadAttr(node, Form("fC%d",i),  tmp          );
+         gTools().ReadAttr(node, TString::Format("fC%d",i).Data(),  tmp);
          this->SetFisherCoeff(i,tmp);
       }
    }else{
@@ -493,7 +493,7 @@ void TMVA::DecisionTreeNode::AddAttributesToNode(void* node) const
 {
    gTools().AddAttr(node, "NCoef", GetNFisherCoeff());
    for (Int_t i=0; i< (Int_t) this->GetNFisherCoeff(); i++)
-      gTools().AddAttr(node, Form("fC%d",i),  this->GetFisherCoeff(i));
+      gTools().AddAttr(node, TString::Format("fC%d",i).Data(),  this->GetFisherCoeff(i));
 
    gTools().AddAttr(node, "IVar",  GetSelector());
    gTools().AddAttr(node, "Cut",   GetCutValue());

--- a/tmva/tmva/src/Factory.cxx
+++ b/tmva/tmva/src/Factory.cxx
@@ -2628,7 +2628,7 @@ TH1F *TMVA::Factory::GetImportance(const int nbits, std::vector<Double_t> import
    vih1->GetYaxis()->SetTitleOffset(1.24);
 
    vih1->GetYaxis()->SetRangeUser(-7, 50);
-   vih1->SetDirectory(0);
+   vih1->SetDirectory(nullptr);
 
    //   vih1->Draw("B");
    return vih1;

--- a/tmva/tmva/src/Factory.cxx
+++ b/tmva/tmva/src/Factory.cxx
@@ -967,7 +967,7 @@ TGraph *TMVA::Factory::GetROCCurve(TString datasetname, TString theMethodName, B
    if (setTitles) {
       graph->GetYaxis()->SetTitle("Background rejection (Specificity)");
       graph->GetXaxis()->SetTitle("Signal efficiency (Sensitivity)");
-      graph->SetTitle(Form("Signal efficiency vs. Background rejection (%s)", theMethodName.Data()));
+      graph->SetTitle(TString::Format("Signal efficiency vs. Background rejection (%s)", theMethodName.Data()).Data());
    }
 
    return graph;
@@ -1081,8 +1081,8 @@ TCanvas *TMVA::Factory::GetROCCurve(TString datasetname, UInt_t iClass, Types::E
       return 0;
    }
 
-   TString name = Form("ROCCurve %s class %i", datasetname.Data(), iClass);
-   TCanvas *canvas = new TCanvas(name, "ROC Curve", 200, 10, 700, 500);
+   TString name = TString::Format("ROCCurve %s class %i", datasetname.Data(), iClass);
+   TCanvas *canvas = new TCanvas(name.Data(), "ROC Curve", 200, 10, 700, 500);
    canvas->SetGrid();
 
    TMultiGraph *multigraph = this->GetROCCurveAsMultiGraph(datasetname, iClass, type);
@@ -1093,14 +1093,14 @@ TCanvas *TMVA::Factory::GetROCCurve(TString datasetname, UInt_t iClass, Types::E
       multigraph->GetYaxis()->SetTitle("Background rejection (Specificity)");
       multigraph->GetXaxis()->SetTitle("Signal efficiency (Sensitivity)");
 
-      TString titleString = Form("Signal efficiency vs. Background rejection");
+      TString titleString = TString::Format("Signal efficiency vs. Background rejection");
       if (this->fAnalysisType == Types::kMulticlass) {
-         titleString = Form("%s (Class=%i)", titleString.Data(), iClass);
+         titleString = TString::Format("%s (Class=%i)", titleString.Data(), iClass);
       }
 
       // Workaround for TMultigraph not drawing title correctly.
-      multigraph->GetHistogram()->SetTitle(titleString);
-      multigraph->SetTitle(titleString);
+      multigraph->GetHistogram()->SetTitle(titleString.Data());
+      multigraph->SetTitle(titleString.Data());
 
       canvas->BuildLegend(0.15, 0.15, 0.35, 0.3, "MVA Method");
    }
@@ -1914,15 +1914,15 @@ void TMVA::Factory::EvaluateAllMethods(void)
 
          //    TString header = "DataSet Name     MVA Method     ";
          //    for (UInt_t icls = 0; icls < theMethod->fDataSetInfo.GetNClasses(); ++icls) {
-         //       header += Form("%-12s ", theMethod->fDataSetInfo.GetClassInfo(icls)->GetName());
+         //       header += TString::Format("%-12s ", theMethod->fDataSetInfo.GetClassInfo(icls)->GetName());
          //    }
 
          //    Log() << kINFO << header << Endl;
          //    Log() << kINFO << hLine << Endl;
          //    for (Int_t i = 0; i < nmeth_used[0]; i++) {
-         //       TString res = Form("[%-14s] %-15s", theMethod->fDataSetInfo.GetName(), (const char *)mname[0][i]);
+         //       TString res = TString::Format("[%-14s] %-15s", theMethod->fDataSetInfo.GetName(), mname[0][i].Data());
          //       for (UInt_t icls = 0; icls < theMethod->fDataSetInfo.GetNClasses(); ++icls) {
-         //          res += Form("%#1.3f        ", (multiclass_testEff[i][icls]) * (multiclass_testPur[i][icls]));
+         //          res += TString::Format("%#1.3f        ", (multiclass_testEff[i][icls]) * (multiclass_testPur[i][icls]));
          //       }
          //       Log() << kINFO << res << Endl;
          //    }
@@ -1933,10 +1933,10 @@ void TMVA::Factory::EvaluateAllMethods(void)
 
          // --- 1 vs Rest ROC AUC, signal efficiency @ given background efficiency
          // --------------------------------------------------------------------
-         TString header1 = Form("%-15s%-15s%-15s%-15s%-15s%-15s", "Dataset", "MVA Method", "ROC AUC", "Sig eff@B=0.01",
-                                "Sig eff@B=0.10", "Sig eff@B=0.30");
-         TString header2 = Form("%-15s%-15s%-15s%-15s%-15s%-15s", "Name:", "/ Class:", "test  (train)", "test  (train)",
-                                "test  (train)", "test  (train)");
+         TString header1 = TString::Format("%-15s%-15s%-15s%-15s%-15s%-15s", "Dataset", "MVA Method", "ROC AUC", "Sig eff@B=0.01",
+                                           "Sig eff@B=0.10", "Sig eff@B=0.30");
+         TString header2 = TString::Format("%-15s%-15s%-15s%-15s%-15s%-15s", "Name:", "/ Class:", "test  (train)", "test  (train)",
+                                           "test  (train)", "test  (train)");
          Log() << kINFO << Endl;
          Log() << kINFO << "1-vs-rest performance metrics per class" << Endl;
          Log() << kINFO << hLine << Endl;
@@ -1964,7 +1964,7 @@ void TMVA::Factory::EvaluateAllMethods(void)
                }
 
                Log() << kINFO << Endl;
-               TString row = Form("%-15s%-15s", datasetName.Data(), mvaName.Data());
+               TString row = TString::Format("%-15s%-15s", datasetName.Data(), mvaName.Data());
                Log() << kINFO << row << Endl;
                Log() << kINFO << "------------------------------" << Endl;
 
@@ -1983,11 +1983,11 @@ void TMVA::Factory::EvaluateAllMethods(void)
                   const Double_t effB01Test = rocCurveTest->GetEffSForEffB(0.01);
                   const Double_t effB10Test = rocCurveTest->GetEffSForEffB(0.10);
                   const Double_t effB30Test = rocCurveTest->GetEffSForEffB(0.30);
-                  const TString rocaucCmp = Form("%5.3f (%5.3f)", rocaucTest, rocaucTrain);
-                  const TString effB01Cmp = Form("%5.3f (%5.3f)", effB01Test, effB01Train);
-                  const TString effB10Cmp = Form("%5.3f (%5.3f)", effB10Test, effB10Train);
-                  const TString effB30Cmp = Form("%5.3f (%5.3f)", effB30Test, effB30Train);
-                  row = Form("%-15s%-15s%-15s%-15s%-15s%-15s", "", className.Data(), rocaucCmp.Data(), effB01Cmp.Data(),
+                  const TString rocaucCmp = TString::Format("%5.3f (%5.3f)", rocaucTest, rocaucTrain);
+                  const TString effB01Cmp = TString::Format("%5.3f (%5.3f)", effB01Test, effB01Train);
+                  const TString effB10Cmp = TString::Format("%5.3f (%5.3f)", effB10Test, effB10Train);
+                  const TString effB30Cmp = TString::Format("%5.3f (%5.3f)", effB30Test, effB30Train);
+                  row = TString::Format("%-15s%-15s%-15s%-15s%-15s%-15s", "", className.Data(), rocaucCmp.Data(), effB01Cmp.Data(),
                              effB10Cmp.Data(), effB30Cmp.Data());
                   Log() << kINFO << row << Endl;
 
@@ -2009,27 +2009,27 @@ void TMVA::Factory::EvaluateAllMethods(void)
 
             // TODO: Ensure matrices are same size.
 
-            TString header = Form(" %-14s", " ");
-            TString headerInfo = Form(" %-14s", " ");
-            ;
+            TString header = TString::Format(" %-14s", " ");
+            TString headerInfo = TString::Format(" %-14s", " ");
+
             for (UInt_t iCol = 0; iCol < numClasses; ++iCol) {
-               header += Form(" %-14s", classnames[iCol].Data());
-               headerInfo += Form(" %-14s", " test (train)");
+               header += TString::Format(" %-14s", classnames[iCol].Data());
+               headerInfo += TString::Format(" %-14s", " test (train)");
             }
             stream << kINFO << header << Endl;
             stream << kINFO << headerInfo << Endl;
 
             for (UInt_t iRow = 0; iRow < numClasses; ++iRow) {
-               stream << kINFO << Form(" %-14s", classnames[iRow].Data());
+               stream << kINFO << TString::Format(" %-14s", classnames[iRow].Data());
 
                for (UInt_t iCol = 0; iCol < numClasses; ++iCol) {
                   if (iCol == iRow) {
-                     stream << kINFO << Form(" %-14s", "-");
+                     stream << kINFO << TString::Format(" %-14s", "-");
                   } else {
                      Double_t trainValue = matTraining[iRow][iCol];
                      Double_t testValue = matTesting[iRow][iCol];
-                     TString entry = Form("%-5.3f (%-5.3f)", testValue, trainValue);
-                     stream << kINFO << Form(" %-14s", entry.Data());
+                     TString entry = TString::Format("%-5.3f (%-5.3f)", testValue, trainValue);
+                     stream << kINFO << TString::Format(" %-14s", entry.Data());
                   }
                }
                stream << kINFO << Endl;

--- a/tmva/tmva/src/MethodANNBase.cxx
+++ b/tmva/tmva/src/MethodANNBase.cxx
@@ -962,8 +962,8 @@ void TMVA::MethodANNBase::CreateWeightMonitoringHists( const TString& bulkname,
       Int_t numNeurons1 = layer1->GetEntriesFast();
       Int_t numNeurons2 = layer2->GetEntriesFast();
 
-      TString name = Form("%s%i%i", bulkname.Data(), i, i+1);
-      hist = new TH2F(name + "", name + "",
+      TString name = TString::Format("%s%i%i", bulkname.Data(), i, i+1);
+      hist = new TH2F(name.Data(), name.Data(),
                       numNeurons1, 0, numNeurons1, numNeurons2, 0, numNeurons2);
 
       for (Int_t j = 0; j < numNeurons1; j++) {
@@ -992,7 +992,7 @@ void TMVA::MethodANNBase::CreateWeightMonitoringHists( const TString& bulkname,
 
 void TMVA::MethodANNBase::WriteMonitoringHistosToFile() const
 {
-   PrintMessage(Form("Write special histos to file: %s", BaseDir()->GetPath()), kTRUE);
+   PrintMessage(TString::Format("Write special histos to file: %s", BaseDir()->GetPath()).Data(), kTRUE);
 
    if (fEstimatorHistTrain) fEstimatorHistTrain->Write();
    if (fEstimatorHistTest ) fEstimatorHistTest ->Write();
@@ -1003,11 +1003,11 @@ void TMVA::MethodANNBase::WriteMonitoringHistosToFile() const
    // now save all the epoch-wise monitoring information
    static std::atomic<int> epochMonitoringDirectoryNumber{0};
    int epochVal = epochMonitoringDirectoryNumber++;
-   TDirectory* epochdir = NULL;
+   TDirectory* epochdir = nullptr;
    if( epochVal == 0 )
       epochdir = BaseDir()->mkdir( "EpochMonitoring" );
    else
-      epochdir = BaseDir()->mkdir( Form("EpochMonitoring_%4d",epochVal) );
+      epochdir = BaseDir()->mkdir( TString::Format("EpochMonitoring_%4d",epochVal).Data() );
 
    epochdir->cd();
    for (std::vector<TH1*>::const_iterator it = fEpochMonHistS.begin(); it != fEpochMonHistS.end(); ++it) {

--- a/tmva/tmva/src/MethodBDT.cxx
+++ b/tmva/tmva/src/MethodBDT.cxx
@@ -522,7 +522,7 @@ void TMVA::MethodBDT::ProcessOptions()
             << Endl;
       Log() << kWARNING << "Note also that explicitly setting *nEventsMin* so far OVERWRITES the option recommended \n"
             << " *MinNodeSize* = " << fMinNodeSizeS << " option !!" << Endl ;
-      fMinNodeSizeS = Form("%F3.2",fMinNodeSize);
+      fMinNodeSizeS = TString::Format("%F3.2",fMinNodeSize);
 
    }else{
       SetMinNodeSize(fMinNodeSizeS);
@@ -1199,10 +1199,9 @@ void TMVA::MethodBDT::Train()
 
    // book monitoring histograms (for AdaBost only)
 
-   TH1* h = new TH1F(Form("%s_BoostWeight",DataInfo().GetName()),hname,nBins,xMin,xMax);
-   TH1* nodesBeforePruningVsTree = new TH1I(Form("%s_NodesBeforePruning",DataInfo().GetName()),"nodes before pruning",fNTrees,0,fNTrees);
-   TH1* nodesAfterPruningVsTree = new TH1I(Form("%s_NodesAfterPruning",DataInfo().GetName()),"nodes after pruning",fNTrees,0,fNTrees);
-
+   TH1* h = new TH1F(TString::Format("%s_BoostWeight",DataInfo().GetName()).Data(),hname,nBins,xMin,xMax);
+   TH1* nodesBeforePruningVsTree = new TH1I(TString::Format("%s_NodesBeforePruning",DataInfo().GetName()).Data(),"nodes before pruning",fNTrees,0,fNTrees);
+   TH1* nodesAfterPruningVsTree = new TH1I(TString::Format("%s_NodesAfterPruning",DataInfo().GetName()).Data(),"nodes after pruning",fNTrees,0,fNTrees);
 
 
    if(!DoMulticlass()){
@@ -1273,10 +1272,10 @@ void TMVA::MethodBDT::Train()
      fIPyCurrentIter = itree;
       timer.DrawProgressBar( itree );
       // Results* results = Data()->GetResults(GetMethodName(), Types::kTraining, GetAnalysisType());
-      // TH1 *hxx = new TH1F(Form("swdist%d",itree),Form("swdist%d",itree),10000,0,15);
-      // results->Store(hxx,Form("swdist%d",itree));
-      // TH1 *hxy = new TH1F(Form("bwdist%d",itree),Form("bwdist%d",itree),10000,0,15);
-      // results->Store(hxy,Form("bwdist%d",itree));
+      // TH1 *hxx = new TH1F(TString::Format("swdist%d",itree),TString::Format("swdist%d",itree),10000,0,15);
+      // results->Store(hxx,TString::Format("swdist%d",itree));
+      // TH1 *hxy = new TH1F(TString::Format("bwdist%d",itree),TString::Format("bwdist%d",itree),10000,0,15);
+      // results->Store(hxy,TString::Format("bwdist%d",itree));
       // for (Int_t iev=0; iev<fEventSample.size(); iev++) {
       //    if (fEventSample[iev]->GetClass()!=0) hxy->Fill((fEventSample[iev])->GetWeight());
       //    else          hxx->Fill((fEventSample[iev])->GetWeight());
@@ -1781,8 +1780,8 @@ void TMVA::MethodBDT::BoostMonitor(Int_t iTree)
    std::vector<TH1F*> hS;
    std::vector<TH1F*> hB;
    for (UInt_t ivar=0; ivar<GetNvar(); ivar++){
-      hS.push_back(new TH1F(Form("SigVar%dAtTree%d",ivar,iTree),Form("SigVar%dAtTree%d",ivar,iTree),100,DataInfo().GetVariableInfo(ivar).GetMin(),DataInfo().GetVariableInfo(ivar).GetMax()));
-      hB.push_back(new TH1F(Form("BkgVar%dAtTree%d",ivar,iTree),Form("BkgVar%dAtTree%d",ivar,iTree),100,DataInfo().GetVariableInfo(ivar).GetMin(),DataInfo().GetVariableInfo(ivar).GetMax()));
+      hS.push_back(new TH1F(TString::Format("SigVar%dAtTree%d",ivar,iTree).Data(),TString::Format("SigVar%dAtTree%d",ivar,iTree).Data(),100,DataInfo().GetVariableInfo(ivar).GetMin(),DataInfo().GetVariableInfo(ivar).GetMax()));
+      hB.push_back(new TH1F(TString::Format("BkgVar%dAtTree%d",ivar,iTree).Data(),TString::Format("BkgVar%dAtTree%d",ivar,iTree).Data(),100,DataInfo().GetVariableInfo(ivar).GetMin(),DataInfo().GetVariableInfo(ivar).GetMax()));
       results->Store(hS.back(),hS.back()->GetTitle());
       results->Store(hB.back(),hB.back()->GetTitle());
    }
@@ -1791,8 +1790,8 @@ void TMVA::MethodBDT::BoostMonitor(Int_t iTree)
    for (UInt_t iev=0; iev < fEventSample.size(); iev++){
       if (fEventSample[iev]->GetBoostWeight() > max) max = 1.01*fEventSample[iev]->GetBoostWeight();
    }
-   TH1F *tmpBoostWeightsS = new TH1F(Form("BoostWeightsInTreeS%d",iTree),Form("BoostWeightsInTreeS%d",iTree),100,0.,max);
-   TH1F *tmpBoostWeightsB = new TH1F(Form("BoostWeightsInTreeB%d",iTree),Form("BoostWeightsInTreeB%d",iTree),100,0.,max);
+   TH1F *tmpBoostWeightsS = new TH1F(TString::Format("BoostWeightsInTreeS%d",iTree).Data(),TString::Format("BoostWeightsInTreeS%d",iTree).Data(),100,0.,max);
+   TH1F *tmpBoostWeightsB = new TH1F(TString::Format("BoostWeightsInTreeB%d",iTree).Data(),TString::Format("BoostWeightsInTreeB%d",iTree).Data(),100,0.,max);
    results->Store(tmpBoostWeightsS,tmpBoostWeightsS->GetTitle());
    results->Store(tmpBoostWeightsB,tmpBoostWeightsB->GetTitle());
 
@@ -2313,14 +2312,14 @@ void TMVA::MethodBDT::AddWeightsXMLTo( void* parent ) const
 
    if (fDoPreselection){
       for (UInt_t ivar=0; ivar<GetNvar(); ivar++){
-         gTools().AddAttr( wght, Form("PreselectionLowBkgVar%d",ivar),      fIsLowBkgCut[ivar]);
-         gTools().AddAttr( wght, Form("PreselectionLowBkgVar%dValue",ivar), fLowBkgCut[ivar]);
-         gTools().AddAttr( wght, Form("PreselectionLowSigVar%d",ivar),      fIsLowSigCut[ivar]);
-         gTools().AddAttr( wght, Form("PreselectionLowSigVar%dValue",ivar), fLowSigCut[ivar]);
-         gTools().AddAttr( wght, Form("PreselectionHighBkgVar%d",ivar),     fIsHighBkgCut[ivar]);
-         gTools().AddAttr( wght, Form("PreselectionHighBkgVar%dValue",ivar),fHighBkgCut[ivar]);
-         gTools().AddAttr( wght, Form("PreselectionHighSigVar%d",ivar),     fIsHighSigCut[ivar]);
-         gTools().AddAttr( wght, Form("PreselectionHighSigVar%dValue",ivar),fHighSigCut[ivar]);
+         gTools().AddAttr( wght, TString::Format("PreselectionLowBkgVar%d",ivar).Data(),      fIsLowBkgCut[ivar]);
+         gTools().AddAttr( wght, TString::Format("PreselectionLowBkgVar%dValue",ivar).Data(), fLowBkgCut[ivar]);
+         gTools().AddAttr( wght, TString::Format("PreselectionLowSigVar%d",ivar).Data(),      fIsLowSigCut[ivar]);
+         gTools().AddAttr( wght, TString::Format("PreselectionLowSigVar%dValue",ivar).Data(), fLowSigCut[ivar]);
+         gTools().AddAttr( wght, TString::Format("PreselectionHighBkgVar%d",ivar).Data(),     fIsHighBkgCut[ivar]);
+         gTools().AddAttr( wght, TString::Format("PreselectionHighBkgVar%dValue",ivar).Data(),fHighBkgCut[ivar]);
+         gTools().AddAttr( wght, TString::Format("PreselectionHighSigVar%d",ivar).Data(),     fIsHighSigCut[ivar]);
+         gTools().AddAttr( wght, TString::Format("PreselectionHighSigVar%dValue",ivar).Data(),fHighSigCut[ivar]);
       }
    }
 
@@ -2349,7 +2348,7 @@ void TMVA::MethodBDT::ReadWeightsFromXML(void* parent) {
    Float_t boostWeight;
 
 
-   if (gTools().HasAttr( parent, Form("PreselectionLowBkgVar%d",0))) {
+   if (gTools().HasAttr( parent, TString::Format("PreselectionLowBkgVar%d",0).Data())) {
       fIsLowBkgCut.resize(GetNvar());
       fLowBkgCut.resize(GetNvar());
       fIsLowSigCut.resize(GetNvar());
@@ -2362,21 +2361,21 @@ void TMVA::MethodBDT::ReadWeightsFromXML(void* parent) {
       Bool_t tmpBool;
       Double_t tmpDouble;
       for (UInt_t ivar=0; ivar<GetNvar(); ivar++){
-         gTools().ReadAttr( parent, Form("PreselectionLowBkgVar%d",ivar), tmpBool);
+         gTools().ReadAttr( parent, TString::Format("PreselectionLowBkgVar%d",ivar).Data(), tmpBool);
          fIsLowBkgCut[ivar]=tmpBool;
-         gTools().ReadAttr( parent, Form("PreselectionLowBkgVar%dValue",ivar), tmpDouble);
+         gTools().ReadAttr( parent, TString::Format("PreselectionLowBkgVar%dValue",ivar).Data(), tmpDouble);
          fLowBkgCut[ivar]=tmpDouble;
-         gTools().ReadAttr( parent, Form("PreselectionLowSigVar%d",ivar), tmpBool);
+         gTools().ReadAttr( parent, TString::Format("PreselectionLowSigVar%d",ivar).Data(), tmpBool);
          fIsLowSigCut[ivar]=tmpBool;
-         gTools().ReadAttr( parent, Form("PreselectionLowSigVar%dValue",ivar), tmpDouble);
+         gTools().ReadAttr( parent, TString::Format("PreselectionLowSigVar%dValue",ivar).Data(), tmpDouble);
          fLowSigCut[ivar]=tmpDouble;
-         gTools().ReadAttr( parent, Form("PreselectionHighBkgVar%d",ivar), tmpBool);
+         gTools().ReadAttr( parent, TString::Format("PreselectionHighBkgVar%d",ivar).Data(), tmpBool);
          fIsHighBkgCut[ivar]=tmpBool;
-         gTools().ReadAttr( parent, Form("PreselectionHighBkgVar%dValue",ivar), tmpDouble);
+         gTools().ReadAttr( parent, TString::Format("PreselectionHighBkgVar%dValue",ivar).Data(), tmpDouble);
          fHighBkgCut[ivar]=tmpDouble;
-         gTools().ReadAttr( parent, Form("PreselectionHighSigVar%d",ivar),tmpBool);
+         gTools().ReadAttr( parent, TString::Format("PreselectionHighSigVar%d",ivar).Data(),tmpBool);
          fIsHighSigCut[ivar]=tmpBool;
-         gTools().ReadAttr( parent, Form("PreselectionHighSigVar%dValue",ivar), tmpDouble);
+         gTools().ReadAttr( parent, TString::Format("PreselectionHighSigVar%dValue",ivar).Data(), tmpDouble);
          fHighSigCut[ivar]=tmpDouble;
       }
    }

--- a/tmva/tmva/src/MethodBase.cxx
+++ b/tmva/tmva/src/MethodBase.cxx
@@ -2235,7 +2235,7 @@ void TMVA::MethodBase::CreateMVAPdfs()
 
    if (DataInfo().GetNClasses() == 2) { // TODO: this is an ugly hack.. adapt this to new framework
       Log() << kINFO<<Form("Dataset[%s] : ",DataInfo().GetName())
-            << Form( "<CreateMVAPdfs> Separation from histogram (PDF): %1.3f (%1.3f)",
+            << TString::Format( "<CreateMVAPdfs> Separation from histogram (PDF): %1.3f (%1.3f)",
                      GetSeparation( histMVAPdfS, histMVAPdfB ), GetSeparation( fMVAPdfS, fMVAPdfB ) )
             << Endl;
    }

--- a/tmva/tmva/src/MethodBase.cxx
+++ b/tmva/tmva/src/MethodBase.cxx
@@ -1159,13 +1159,11 @@ void TMVA::MethodBase::TestClassification()
    // classifier response distributions for training sample
    // MVA plots used for graphics representation (signal)
    TString TestvarName;
-   if(IsSilentFile())
-      {
-         TestvarName=Form("[%s]%s",DataInfo().GetName(),GetTestvarName().Data());
-      }else
-      {
-         TestvarName=GetTestvarName();
-      }
+   if(IsSilentFile()) {
+      TestvarName = TString::Format("[%s]%s",DataInfo().GetName(),GetTestvarName().Data());
+   } else {
+      TestvarName=GetTestvarName();
+   }
    TH1* mva_s = new TH1D( TestvarName + "_S",TestvarName + "_S", fNbinsMVAoutput, fXmin, sxmax );
    TH1* mva_b = new TH1D( TestvarName + "_B",TestvarName + "_B", fNbinsMVAoutput, fXmin, sxmax );
    mvaRes->Store(mva_s, "MVA_S");
@@ -1927,7 +1925,7 @@ void TMVA::MethodBase::ReadClassesFromXML( void* clsnode )
    void* ch = gTools().GetChild(clsnode);
    if (!ch) {
       for (UInt_t icls = 0; icls<readNCls;++icls) {
-         TString classname = Form("class%i",icls);
+         TString classname = TString::Format("class%i",icls);
          DataInfo().AddClass(classname);
 
       }
@@ -2034,17 +2032,17 @@ TDirectory *TMVA::MethodBase::MethodBaseDir() const
    if (!factoryBaseDir) return nullptr;
    fMethodBaseDir = factoryBaseDir->GetDirectory(datasetName);
    if (!fMethodBaseDir) {
-      fMethodBaseDir = factoryBaseDir->mkdir(datasetName, Form("Base directory for dataset %s", datasetName));
+      fMethodBaseDir = factoryBaseDir->mkdir(datasetName, TString::Format("Base directory for dataset %s", datasetName).Data());
       if (!fMethodBaseDir) {
          Log() << kFATAL << "Can not create dir " << datasetName;
       }
    }
-   TString methodTypeDir = Form("Method_%s", GetMethodTypeName().Data());
+   TString methodTypeDir = TString::Format("Method_%s", GetMethodTypeName().Data());
    fMethodBaseDir = fMethodBaseDir->GetDirectory(methodTypeDir.Data());
 
    if (!fMethodBaseDir) {
       TDirectory *datasetDir = factoryBaseDir->GetDirectory(datasetName);
-      TString methodTypeDirHelpStr = Form("Directory for all %s methods", GetMethodTypeName().Data());
+      TString methodTypeDirHelpStr = TString::Format("Directory for all %s methods", GetMethodTypeName().Data());
       fMethodBaseDir = datasetDir->mkdir(methodTypeDir.Data(), methodTypeDirHelpStr);
       Log() << kDEBUG << Form("Dataset[%s] : ", datasetName) << " Base Directory for " << GetMethodName()
             << " does not exist yet--> created it" << Endl;
@@ -3374,7 +3372,7 @@ TString TMVA::MethodBase::GetTrainingTMVAVersionString() const
    UInt_t b = GetTrainingTMVAVersionCode() & 0x00ff00; b>>=8;
    UInt_t c = GetTrainingTMVAVersionCode() & 0x0000ff;
 
-   return TString(Form("%i.%i.%i",a,b,c));
+   return TString::Format("%i.%i.%i",a,b,c);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -3386,7 +3384,7 @@ TString TMVA::MethodBase::GetTrainingROOTVersionString() const
    UInt_t b = GetTrainingROOTVersionCode() & 0x00ff00; b>>=8;
    UInt_t c = GetTrainingROOTVersionCode() & 0x0000ff;
 
-   return TString(Form("%i.%02i/%02i",a,b,c));
+   return TString::Format("%i.%02i/%02i",a,b,c);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/src/MethodBoost.cxx
+++ b/tmva/tmva/src/MethodBoost.cxx
@@ -350,7 +350,7 @@ void TMVA::MethodBoost::CheckSetup()
 
 void TMVA::MethodBoost::Train()
 {
-   TDirectory* methodDir( 0 );
+   TDirectory* methodDir = nullptr;
    TString     dirName,dirTitle;
    Int_t       StopCounter=0;
    Results* results = Data()->GetResults(GetMethodName(), Types::kTraining, GetAnalysisType());
@@ -390,7 +390,7 @@ void TMVA::MethodBoost::Train()
       if (fCurrentMethodIdx>0) TMVA::MsgLogger::InhibitOutput();
 
       IMethod *method = ClassifierFactory::Instance().Create(
-         fBoostedMethodName.Data(), GetJobName(), Form("%s_B%04i", fBoostedMethodTitle.Data(), fCurrentMethodIdx),
+         fBoostedMethodName.Data(), GetJobName(), TString::Format("%s_B%04i", fBoostedMethodTitle.Data(), fCurrentMethodIdx),
          DataInfo(), fBoostedMethodOptions);
       TMVA::MsgLogger::EnableOutput();
 
@@ -427,9 +427,9 @@ void TMVA::MethodBoost::Train()
       if(!IsSilentFile())
       {
         if (fMonitorBoostedMethod) {
-            methodDir=GetFile()->GetDirectory(dirName=Form("%s_B%04i",fBoostedMethodName.Data(),fCurrentMethodIdx));
-            if (methodDir==0) {
-                methodDir=BaseDir()->mkdir(dirName,dirTitle=Form("Directory Boosted %s #%04i", fBoostedMethodName.Data(),fCurrentMethodIdx));
+            methodDir = GetFile()->GetDirectory(dirName=TString::Format("%s_B%04i",fBoostedMethodName.Data(),fCurrentMethodIdx));
+            if (!methodDir) {
+                methodDir = BaseDir()->mkdir(dirName,dirTitle=TString::Format("Directory Boosted %s #%04i", fBoostedMethodName.Data(),fCurrentMethodIdx));
             }
             fCurrentMethod->SetMethodDir(methodDir);
             fCurrentMethod->BaseDir()->cd();
@@ -554,12 +554,12 @@ void TMVA::MethodBoost::CreateMVAHistorgrams()
 
    // creating all the histograms
    for (UInt_t imtd=0; imtd<fBoostNum; imtd++) {
-      fTrainSigMVAHist .push_back( new TH1F( Form("MVA_Train_S_%04i",imtd), "MVA_Train_S",        fNbins, xmin, xmax ) );
-      fTrainBgdMVAHist .push_back( new TH1F( Form("MVA_Train_B%04i", imtd), "MVA_Train_B",        fNbins, xmin, xmax ) );
-      fBTrainSigMVAHist.push_back( new TH1F( Form("MVA_BTrain_S%04i",imtd), "MVA_BoostedTrain_S", fNbins, xmin, xmax ) );
-      fBTrainBgdMVAHist.push_back( new TH1F( Form("MVA_BTrain_B%04i",imtd), "MVA_BoostedTrain_B", fNbins, xmin, xmax ) );
-      fTestSigMVAHist  .push_back( new TH1F( Form("MVA_Test_S%04i",  imtd), "MVA_Test_S",         fNbins, xmin, xmax ) );
-      fTestBgdMVAHist  .push_back( new TH1F( Form("MVA_Test_B%04i",  imtd), "MVA_Test_B",         fNbins, xmin, xmax ) );
+      fTrainSigMVAHist .push_back( new TH1F( TString::Format("MVA_Train_S_%04i",imtd).Data(), "MVA_Train_S",        fNbins, xmin, xmax ) );
+      fTrainBgdMVAHist .push_back( new TH1F( TString::Format("MVA_Train_B%04i", imtd).Data(), "MVA_Train_B",        fNbins, xmin, xmax ) );
+      fBTrainSigMVAHist.push_back( new TH1F( TString::Format("MVA_BTrain_S%04i",imtd).Data(), "MVA_BoostedTrain_S", fNbins, xmin, xmax ) );
+      fBTrainBgdMVAHist.push_back( new TH1F( TString::Format("MVA_BTrain_B%04i",imtd).Data(), "MVA_BoostedTrain_B", fNbins, xmin, xmax ) );
+      fTestSigMVAHist  .push_back( new TH1F( TString::Format("MVA_Test_S%04i",  imtd).Data(), "MVA_Test_S",         fNbins, xmin, xmax ) );
+      fTestBgdMVAHist  .push_back( new TH1F( TString::Format("MVA_Test_B%04i",  imtd).Data(), "MVA_Test_B",         fNbins, xmin, xmax ) );
    }
 }
 
@@ -704,18 +704,18 @@ void TMVA::MethodBoost::FindMVACut(MethodBase *method)
    }
    maxMVA = maxMVA+(maxMVA-minMVA)/nBins;
 
-   TH1D *mvaS  = new TH1D(Form("MVAS_%d",fCurrentMethodIdx) ,"",nBins,minMVA,maxMVA);
-   TH1D *mvaB  = new TH1D(Form("MVAB_%d",fCurrentMethodIdx) ,"",nBins,minMVA,maxMVA);
-   TH1D *mvaSC = new TH1D(Form("MVASC_%d",fCurrentMethodIdx),"",nBins,minMVA,maxMVA);
-   TH1D *mvaBC = new TH1D(Form("MVABC_%d",fCurrentMethodIdx),"",nBins,minMVA,maxMVA);
+   TH1D *mvaS  = new TH1D(TString::Format("MVAS_%d",fCurrentMethodIdx) ,"",nBins,minMVA,maxMVA);
+   TH1D *mvaB  = new TH1D(TString::Format("MVAB_%d",fCurrentMethodIdx) ,"",nBins,minMVA,maxMVA);
+   TH1D *mvaSC = new TH1D(TString::Format("MVASC_%d",fCurrentMethodIdx),"",nBins,minMVA,maxMVA);
+   TH1D *mvaBC = new TH1D(TString::Format("MVABC_%d",fCurrentMethodIdx),"",nBins,minMVA,maxMVA);
 
 
    Results* results = Data()->GetResults(GetMethodName(), Types::kTraining, GetAnalysisType());
    if (fDetailedMonitoring){
-      results->Store(mvaS, Form("MVAS_%d",fCurrentMethodIdx));
-      results->Store(mvaB, Form("MVAB_%d",fCurrentMethodIdx));
-      results->Store(mvaSC,Form("MVASC_%d",fCurrentMethodIdx));
-      results->Store(mvaBC,Form("MVABC_%d",fCurrentMethodIdx));
+      results->Store(mvaS, TString::Format("MVAS_%d",fCurrentMethodIdx));
+      results->Store(mvaB, TString::Format("MVAB_%d",fCurrentMethodIdx));
+      results->Store(mvaSC,TString::Format("MVASC_%d",fCurrentMethodIdx));
+      results->Store(mvaBC,TString::Format("MVABC_%d",fCurrentMethodIdx));
    }
 
    for (Long64_t ievt=0; ievt<Data()->GetNEvents(); ievt++) {
@@ -1350,10 +1350,10 @@ void TMVA::MethodBoost::MonitorBoost( Types::EBoostStage stage , UInt_t methodIn
       if (fDetailedMonitoring){
          // the following code is useful only for 2D examples - mainly illustration for debug/educational purposes:
          if (DataInfo().GetNVariables() == 2) {
-            results->Store(new TH2F(Form("EventDistSig_%d",methodIndex),Form("EventDistSig_%d",methodIndex),100,0,7,100,0,7));
-            results->GetHist(Form("EventDistSig_%d",methodIndex))->SetMarkerColor(4);
-            results->Store(new TH2F(Form("EventDistBkg_%d",methodIndex),Form("EventDistBkg_%d",methodIndex),100,0,7,100,0,7));
-            results->GetHist(Form("EventDistBkg_%d",methodIndex))->SetMarkerColor(2);
+            results->Store(new TH2F(TString::Format("EventDistSig_%d",methodIndex),TString::Format("EventDistSig_%d",methodIndex),100,0,7,100,0,7));
+            results->GetHist(TString::Format("EventDistSig_%d",methodIndex))->SetMarkerColor(4);
+            results->Store(new TH2F(TString::Format("EventDistBkg_%d",methodIndex),TString::Format("EventDistBkg_%d",methodIndex),100,0,7,100,0,7));
+            results->GetHist(TString::Format("EventDistBkg_%d",methodIndex))->SetMarkerColor(2);
 
             Data()->SetCurrentType(Types::kTraining);
             for (Long64_t ievt=0; ievt<GetNEvents(); ievt++) {
@@ -1363,8 +1363,8 @@ void TMVA::MethodBoost::MonitorBoost( Types::EBoostStage stage , UInt_t methodIn
                Float_t v1= ev->GetValue(1);
                //         if (ievt<3) std::cout<<ievt<<" var0="<<v0<<" var1="<<v1<<" weight="<<w<<std::endl;
                TH2* h;
-               if (DataInfo().IsSignal(ev)) h=results->GetHist2D(Form("EventDistSig_%d",methodIndex));
-               else                         h=results->GetHist2D(Form("EventDistBkg_%d",methodIndex));
+               if (DataInfo().IsSignal(ev)) h = results->GetHist2D(TString::Format("EventDistSig_%d",methodIndex));
+               else                         h = results->GetHist2D(TString::Format("EventDistBkg_%d",methodIndex));
                if (h) h->Fill(v0,v1,w);
             }
          }

--- a/tmva/tmva/src/MethodCategory.cxx
+++ b/tmva/tmva/src/MethodCategory.cxx
@@ -163,10 +163,10 @@ TMVA::IMethod* TMVA::MethodCategory::AddMethod( const TCut& theCut,
 
 
    // set or create correct method base dir for added method
-   const TString dirName(Form("Method_%s",method->GetMethodTypeName().Data()));
+   const TString dirName = TString::Format("Method_%s",method->GetMethodTypeName().Data());
    TDirectory * dir = BaseDir()->GetDirectory(dirName);
    if (dir != 0) method->SetMethodBaseDir( dir );
-   else method->SetMethodBaseDir( BaseDir()->mkdir(dirName,Form("Directory for all %s methods", method->GetMethodTypeName().Data())) );
+   else method->SetMethodBaseDir( BaseDir()->mkdir(dirName,  TString::Format("Directory for all %s methods", method->GetMethodTypeName().Data())) );
 
    // method->SetBaseDir(eigenes base dir, gucken ob Fisher dir existiert, sonst erzeugen )
 
@@ -187,8 +187,8 @@ TMVA::IMethod* TMVA::MethodCategory::AddMethod( const TCut& theCut,
    UInt_t newSpectatorIndex = primaryDSI.GetSpectatorInfos().size();
    fCategorySpecIdx.push_back(newSpectatorIndex);
 
-   primaryDSI.AddSpectator( Form("%s_cat%i:=%s", GetName(),(int)fMethods.size(),theCut.GetTitle()),
-                            Form("%s:%s",GetName(),method->GetName()),
+   primaryDSI.AddSpectator( TString::Format("%s_cat%i:=%s", GetName(),(int)fMethods.size(),theCut.GetTitle()).Data(),
+                            TString::Format("%s:%s",GetName(),method->GetName()).Data(),
                             "pass", 0, 0, 'C' );
 
    return method;
@@ -342,7 +342,7 @@ void TMVA::MethodCategory::InitCircularTree(const DataSetInfo& dsi)
       // The add-then-remove can lead to  a problem if gDirectory points to the same directory (for example
       // gROOT) in the current thread and another one (and both try to add to the directory at the same time).
       TDirectory::TContext ctxt(nullptr);
-      fCatTree = new TTree(Form("Circ%s",GetMethodName().Data()),"Circular Tree for categorization");
+      fCatTree = new TTree(TString::Format("Circ%s",GetMethodName().Data()).Data(),"Circular Tree for categorization");
       fCatTree->SetCircular(1);
    }
 
@@ -357,7 +357,7 @@ void TMVA::MethodCategory::InitCircularTree(const DataSetInfo& dsi)
    }
 
    for(UInt_t cat=0; cat!=fCategoryCuts.size(); ++cat) {
-      fCatFormulas.push_back(new TTreeFormula(Form("Category_%i",cat), fCategoryCuts[cat].GetTitle(), fCatTree));
+      fCatFormulas.push_back(new TTreeFormula(TString::Format("Category_%i",cat).Data(), fCategoryCuts[cat].GetTitle(), fCatTree));
    }
 }
 
@@ -514,7 +514,7 @@ void TMVA::MethodCategory::ReadWeightsFromXML( void* wghtnode )
       // find the spectator index
       std::vector<VariableInfo>& spectators=primaryDSI.GetSpectatorInfos();
       std::vector<VariableInfo>::iterator itrVarInfo;
-      TString specName= Form("%s_cat%i", GetName(),(int)fCategorySpecIdx.size()+1);
+      TString specName= TString::Format("%s_cat%i", GetName(),(int)fCategorySpecIdx.size()+1);
 
       for (itrVarInfo = spectators.begin(); itrVarInfo != spectators.end(); ++itrVarInfo, ++counter) {
          if((specName==itrVarInfo->GetLabel()) || (specName==itrVarInfo->GetExpression())) {

--- a/tmva/tmva/src/MethodCompositeBase.cxx
+++ b/tmva/tmva/src/MethodCompositeBase.cxx
@@ -228,8 +228,8 @@ void TMVA::MethodCompositeBase::ReadWeightsFromXML( void* wghtnode )
 void  TMVA::MethodCompositeBase::ReadWeightsFromStream( std::istream& istr )
 {
    TString var, dummy;
-   TString methodName, methodTitle=GetMethodName(),
-      jobName=GetJobName(),optionString=GetOptions();
+   TString methodName, methodTitle = GetMethodName(),
+      jobName=GetJobName(),optionString = GetOptions();
    UInt_t methodNum; Double_t methodWeight;
    // and read the Weights (BDT coefficients)
    // coverity[tainted_data_argument]
@@ -254,8 +254,9 @@ void  TMVA::MethodCompositeBase::ReadWeightsFromStream( std::istream& istr )
          istr >> dummy >> optionString;
          if (GetMethodType() == Types::kBoost)
             ((TMVA::MethodBoost*)this)->BookMethod( Types::Instance().GetMethodType( methodName), methodTitle,  optionString );
+      } else {
+         methodTitle = TString::Format("%s (%04i)",GetMethodName().Data(),fCurrentMethodIdx);
       }
-      else methodTitle=Form("%s (%04i)",GetMethodName().Data(),fCurrentMethodIdx);
       fMethods.push_back(
          ClassifierFactory::Instance().Create(methodName.Data(), jobName, methodTitle, DataInfo(), optionString));
       fMethodWeight.push_back( methodWeight );

--- a/tmva/tmva/src/MethodCrossValidation.cxx
+++ b/tmva/tmva/src/MethodCrossValidation.cxx
@@ -118,7 +118,7 @@ TString TMVA::MethodCrossValidation::GetWeightFileNameForFold(UInt_t iFold) cons
             << "Should be < " << fNumFolds << "." << Endl;
    }
 
-   TString foldStr = Form("fold%i", iFold + 1);
+   TString foldStr = TString::Format("fold%i", iFold + 1);
    TString fileDir = gSystem->GetDirName(GetWeightFileName());
    TString weightfile = fileDir + "/" + fJobName + "_" + fEncapsulatedMethodName + "_" + foldStr + ".weights.xml";
 

--- a/tmva/tmva/src/MethodCuts.cxx
+++ b/tmva/tmva/src/MethodCuts.cxx
@@ -623,7 +623,7 @@ void  TMVA::MethodCuts::Train( void )
    delete fEffBvsSLocal;
    fEffBvsSLocal = new TH1F( GetTestvarName() + "_effBvsSLocal",
                              TString(GetName()) + " efficiency of B vs S", fNbins, 0.0, 1.0 );
-   fEffBvsSLocal->SetDirectory(0); // it's local
+   fEffBvsSLocal->SetDirectory(nullptr); // it's local
 
    // init
    for (Int_t ibin=1; ibin<=fNbins; ibin++) fEffBvsSLocal->SetBinContent( ibin, -0.1 );
@@ -1265,7 +1265,7 @@ void  TMVA::MethodCuts::ReadWeightsFromStream( std::istream& istr )
    if (fEffBvsSLocal != 0) delete fEffBvsSLocal;
    fEffBvsSLocal = new TH1F( GetTestvarName() + "_effBvsSLocal",
                              TString(GetName()) + " efficiency of B vs S", fNbins, 0.0, 1.0 );
-   fEffBvsSLocal->SetDirectory(0); // it's local
+   fEffBvsSLocal->SetDirectory(nullptr); // it's local
 
    for (Int_t ibin=0; ibin<fNbins; ibin++) {
       istr >> tmpbin >> tmpeffS >> tmpeffB;
@@ -1366,7 +1366,7 @@ void TMVA::MethodCuts::ReadWeightsFromXML( void* wghtnode )
    delete fEffBvsSLocal;
    fEffBvsSLocal = new TH1F( GetTestvarName() + "_effBvsSLocal",
                              TString(GetName()) + " efficiency of B vs S", fNbins, 0.0, 1.0 );
-   fEffBvsSLocal->SetDirectory(0); // it's local
+   fEffBvsSLocal->SetDirectory(nullptr); // it's local
    for (Int_t ibin=1; ibin<=fNbins; ibin++) fEffBvsSLocal->SetBinContent( ibin, -0.1 ); // Init
 
    fCutMin = new Double_t*[GetNvar()];

--- a/tmva/tmva/src/MethodCuts.cxx
+++ b/tmva/tmva/src/MethodCuts.cxx
@@ -1294,7 +1294,7 @@ void TMVA::MethodCuts::AddWeightsXMLTo( void* parent ) const
    gTools().AddAttr( wght, "OptimisationMethod", (Int_t)fEffMethod);
    gTools().AddAttr( wght, "FitMethod",          (Int_t)fFitMethod );
    gTools().AddAttr( wght, "nbins",              fNbins );
-   gTools().AddComment( wght, Form( "Below are the optimised cuts for %i variables: Format: ibin(hist) effS effB cutMin[ivar=0] cutMax[ivar=0] ... cutMin[ivar=n-1] cutMax[ivar=n-1]", GetNvar() ) );
+   gTools().AddComment( wght, TString::Format( "Below are the optimised cuts for %i variables: Format: ibin(hist) effS effB cutMin[ivar=0] cutMax[ivar=0] ... cutMin[ivar=n-1] cutMax[ivar=n-1]", GetNvar() ) );
 
    // NOTE: The signal efficiency written out into
    //       the weight file does not correspond to the center of the bin within which the
@@ -1315,8 +1315,8 @@ void TMVA::MethodCuts::AddWeightsXMLTo( void* parent ) const
       gTools().AddAttr( binxml, "effB", fEffBvsSLocal->GetBinContent( ibin + 1 ) );
       void* cutsxml = gTools().AddChild( binxml, "Cuts" );
       for (UInt_t ivar=0; ivar<GetNvar(); ivar++) {
-         gTools().AddAttr( cutsxml, Form( "cutMin_%i", ivar ), cutsMin[ivar] );
-         gTools().AddAttr( cutsxml, Form( "cutMax_%i", ivar ), cutsMax[ivar] );
+         gTools().AddAttr( cutsxml, TString::Format( "cutMin_%i", ivar ), cutsMin[ivar] );
+         gTools().AddAttr( cutsxml, TString::Format( "cutMax_%i", ivar ), cutsMax[ivar] );
       }
    }
 }
@@ -1398,8 +1398,8 @@ void TMVA::MethodCuts::ReadWeightsFromXML( void* wghtnode )
       fEffBvsSLocal->SetBinContent( tmpbin, tmpeffB );
       void* ct = gTools().GetChild(ch);
       for (UInt_t ivar=0; ivar<GetNvar(); ivar++) {
-         gTools().ReadAttr( ct, Form( "cutMin_%i", ivar ), fCutMin[ivar][tmpbin-1] );
-         gTools().ReadAttr( ct, Form( "cutMax_%i", ivar ), fCutMax[ivar][tmpbin-1] );
+         gTools().ReadAttr( ct, TString::Format( "cutMin_%i", ivar ), fCutMin[ivar][tmpbin-1] );
+         gTools().ReadAttr( ct, TString::Format( "cutMax_%i", ivar ), fCutMax[ivar][tmpbin-1] );
       }
       ch = gTools().GetNextChild(ch, "Bin");
    }

--- a/tmva/tmva/src/MethodCuts.cxx
+++ b/tmva/tmva/src/MethodCuts.cxx
@@ -669,16 +669,16 @@ void  TMVA::MethodCuts::Train( void )
 
       switch (fFitMethod) {
       case kUseGeneticAlgorithm:
-         fitter = new GeneticFitter( *this, Form("%sFitter_GA",     GetName()), ranges, GetOptions() );
+         fitter = new GeneticFitter( *this, TString::Format("%sFitter_GA",     GetName()), ranges, GetOptions() );
          break;
       case kUseMonteCarlo:
-         fitter = new MCFitter     ( *this, Form("%sFitter_MC",     GetName()), ranges, GetOptions() );
+         fitter = new MCFitter     ( *this, TString::Format("%sFitter_MC",     GetName()), ranges, GetOptions() );
          break;
       case kUseMinuit:
-         fitter = new MinuitFitter ( *this, Form("%sFitter_MINUIT", GetName()), ranges, GetOptions() );
+         fitter = new MinuitFitter ( *this, TString::Format("%sFitter_MINUIT", GetName()), ranges, GetOptions() );
          break;
       case kUseSimulatedAnnealing:
-         fitter = new SimulatedAnnealingFitter( *this, Form("%sFitter_SA", GetName()), ranges, GetOptions() );
+         fitter = new SimulatedAnnealingFitter( *this, TString::Format("%sFitter_SA", GetName()), ranges, GetOptions() );
          break;
       default:
          Log() << kFATAL << "Wrong fit method: " << fFitMethod << Endl;

--- a/tmva/tmva/src/MethodFDA.cxx
+++ b/tmva/tmva/src/MethodFDA.cxx
@@ -189,14 +189,14 @@ void TMVA::MethodFDA::CreateFormula()
 
    // replace the parameters "(i)" by the TFormula style "[i]"
    for (UInt_t ipar=0; ipar<fNPars; ipar++) {
-      fFormulaStringT.ReplaceAll( Form("(%i)",ipar), Form("[%i]",ipar) );
+      fFormulaStringT.ReplaceAll( TString::Format("(%i)",ipar), TString::Format("[%i]",ipar) );
    }
 
    // sanity check, there should be no "(i)", with 'i' a number anymore
    for (Int_t ipar=fNPars; ipar<1000; ipar++) {
-      if (fFormulaStringT.Contains( Form("(%i)",ipar) ))
+      if (fFormulaStringT.Contains( TString::Format("(%i)",ipar) ))
          Log() << kFATAL
-               << "<CreateFormula> Formula contains expression: \"" << Form("(%i)",ipar) << "\", "
+               << "<CreateFormula> Formula contains expression: \"" << TString::Format("(%i)",ipar) << "\", "
                << "which cannot be attributed to a parameter; "
                << "it may be that the number of variable ranges given via \"ParRanges\" "
                << "does not match the number of parameters in the formula expression, please verify!"
@@ -205,14 +205,14 @@ void TMVA::MethodFDA::CreateFormula()
 
    // write the variables "xi" as additional parameters "[npar+i]"
    for (Int_t ivar=GetNvar()-1; ivar >= 0; ivar--) {
-      fFormulaStringT.ReplaceAll( Form("x%i",ivar), Form("[%i]",ivar+fNPars) );
+      fFormulaStringT.ReplaceAll( TString::Format("x%i",ivar), TString::Format("[%i]",ivar+fNPars) );
    }
 
    // sanity check, there should be no "xi", with 'i' a number anymore
    for (UInt_t ivar=GetNvar(); ivar<1000; ivar++) {
-      if (fFormulaStringT.Contains( Form("x%i",ivar) ))
+      if (fFormulaStringT.Contains( TString::Format("x%i",ivar) ))
          Log() << kFATAL
-               << "<CreateFormula> Formula contains expression: \"" << Form("x%i",ivar) << "\", "
+               << "<CreateFormula> Formula contains expression: \"" << TString::Format("x%i",ivar) << "\", "
                << "which cannot be attributed to an input variable" << Endl;
    }
 
@@ -301,18 +301,18 @@ void TMVA::MethodFDA::ProcessOptions()
    // create minimiser
    fConvergerFitter = (IFitterTarget*)this;
    if (fConverger == "MINUIT") {
-      fConvergerFitter = new MinuitFitter( *this, Form("%s_Converger_Minuit", GetName()), fParRange, GetOptions() );
+      fConvergerFitter = new MinuitFitter( *this, TString::Format("%s_Converger_Minuit", GetName()), fParRange, GetOptions() );
       SetOptions(dynamic_cast<Configurable*>(fConvergerFitter)->GetOptions());
    }
 
    if(fFitMethod == "MC")
-      fFitter = new MCFitter( *fConvergerFitter, Form("%s_Fitter_MC", GetName()), fParRange, GetOptions() );
+      fFitter = new MCFitter( *fConvergerFitter, TString::Format("%s_Fitter_MC", GetName()), fParRange, GetOptions() );
    else if (fFitMethod == "GA")
-      fFitter = new GeneticFitter( *fConvergerFitter, Form("%s_Fitter_GA", GetName()), fParRange, GetOptions() );
+      fFitter = new GeneticFitter( *fConvergerFitter, TString::Format("%s_Fitter_GA", GetName()), fParRange, GetOptions() );
    else if (fFitMethod == "SA")
-      fFitter = new SimulatedAnnealingFitter( *fConvergerFitter, Form("%s_Fitter_SA", GetName()), fParRange, GetOptions() );
+      fFitter = new SimulatedAnnealingFitter( *fConvergerFitter, TString::Format("%s_Fitter_SA", GetName()), fParRange, GetOptions() );
    else if (fFitMethod == "MINUIT")
-      fFitter = new MinuitFitter( *fConvergerFitter, Form("%s_Fitter_Minuit", GetName()), fParRange, GetOptions() );
+      fFitter = new MinuitFitter( *fConvergerFitter, TString::Format("%s_Fitter_Minuit", GetName()), fParRange, GetOptions() );
    else {
       Log() << kFATAL << "<Train> Do not understand fit method:" << fFitMethod << Endl;
    }
@@ -423,7 +423,7 @@ void TMVA::MethodFDA::PrintResults( const TString& fitter, std::vector<Double_t>
    Log() << kINFO;
    Log() << kHEADER << "Results for parameter fit using \"" << fitter << "\" fitter:" << Endl;
    std::vector<TString>  parNames;
-   for (UInt_t ipar=0; ipar<pars.size(); ipar++) parNames.push_back( Form("Par(%i)",ipar ) );
+   for (UInt_t ipar=0; ipar<pars.size(); ipar++) parNames.push_back( TString::Format("Par(%i)",ipar ) );
    gTools().FormattedOutput( pars, parNames, "Parameter" , "Fit result", Log(), "%g" );
    Log() << "Discriminator expression: \"" << fFormulaStringP << "\"" << Endl;
    Log() << "Value of estimator at minimum: " << estimator << Endl;
@@ -690,12 +690,12 @@ void TMVA::MethodFDA::MakeClassSpecific( std::ostream& fout, const TString& clas
    // replace parameters
    TString str = fFormulaStringT;
    for (UInt_t ipar=0; ipar<fNPars; ipar++) {
-      str.ReplaceAll( Form("[%i]", ipar), Form("fParameter[%i]", ipar) );
+      str.ReplaceAll( TString::Format("[%i]", ipar), TString::Format("fParameter[%i]", ipar) );
    }
 
    // replace input variables
    for (UInt_t ivar=0; ivar<GetNvar(); ivar++) {
-      str.ReplaceAll( Form("[%i]", ivar+fNPars), Form("inputValues[%i]", ivar) );
+      str.ReplaceAll( TString::Format("[%i]", ivar+fNPars), TString::Format("inputValues[%i]", ivar) );
    }
 
    fout << "   double retval = " << str << ";" << std::endl;

--- a/tmva/tmva/src/MethodKNN.cxx
+++ b/tmva/tmva/src/MethodKNN.cxx
@@ -686,7 +686,7 @@ void TMVA::MethodKNN::WriteWeightsToStream(TFile &rf) const
 
    kNN::Event *event = new kNN::Event();
    TTree *tree = new TTree("knn", "event tree");
-   tree->SetDirectory(0);
+   tree->SetDirectory(nullptr);
    tree->Branch("event", "TMVA::kNN::Event", &event);
 
    Double_t size = 0.0;

--- a/tmva/tmva/src/MethodLikelihood.cxx
+++ b/tmva/tmva/src/MethodLikelihood.cxx
@@ -254,13 +254,13 @@ void TMVA::MethodLikelihood::DeclareOptions()
    fDefaultPDFLik->ParseOptions();
    updatedOptions = fDefaultPDFLik->GetOptions();
    for (UInt_t ivar = 0; ivar< DataInfo().GetNVariables(); ivar++) {
-      (*fPDFSig)[ivar] = new PDF( Form("%s PDF Sig[%d]", GetName(), ivar), updatedOptions,
-                                  Form("Sig[%d]",ivar), fDefaultPDFLik );
+      (*fPDFSig)[ivar] = new PDF( TString::Format("%s PDF Sig[%d]", GetName(), ivar), updatedOptions,
+                                  TString::Format("Sig[%d]",ivar), fDefaultPDFLik );
       (*fPDFSig)[ivar]->DeclareOptions();
       (*fPDFSig)[ivar]->ParseOptions();
       updatedOptions = (*fPDFSig)[ivar]->GetOptions();
-      (*fPDFBgd)[ivar] = new PDF( Form("%s PDF Bkg[%d]", GetName(), ivar), updatedOptions,
-                                  Form("Bkg[%d]",ivar), fDefaultPDFLik );
+      (*fPDFBgd)[ivar] = new PDF( TString::Format("%s PDF Bkg[%d]", GetName(), ivar), updatedOptions,
+                                  TString::Format("Bkg[%d]",ivar), fDefaultPDFLik );
       (*fPDFBgd)[ivar]->DeclareOptions();
       (*fPDFBgd)[ivar]->ParseOptions();
       updatedOptions = (*fPDFBgd)[ivar]->GetOptions();
@@ -380,10 +380,12 @@ void TMVA::MethodLikelihood::Train( void )
          Int_t nbinsS = (*fPDFSig)[ivar]->GetHistNBins( minNEvt );
          Int_t nbinsB = (*fPDFBgd)[ivar]->GetHistNBins( minNEvt );
 
-         (*fHistSig)[ivar] = new TH1F( Form("%s_%s_%s_sig",DataInfo().GetName(),GetMethodName().Data(),var.Data()),
-                                       Form("%s_%s_%s signal training",DataInfo().GetName(),GetMethodName().Data(),var.Data()), nbinsS, xmin[ivar], xmax[ivar] );
-         (*fHistBgd)[ivar] = new TH1F( Form("%s_%s_%s_bgd",DataInfo().GetName(),GetMethodName().Data(),var.Data()),
-                                       Form("%s_%s_%s background training",DataInfo().GetName(),GetMethodName().Data(),var.Data()), nbinsB, xmin[ivar], xmax[ivar] );
+         (*fHistSig)[ivar] = new TH1F( TString::Format("%s_%s_%s_sig",DataInfo().GetName(),GetMethodName().Data(),var.Data()),
+                                       TString::Format("%s_%s_%s signal training",DataInfo().GetName(),GetMethodName().Data(),var.Data()),
+                                       nbinsS, xmin[ivar], xmax[ivar] );
+         (*fHistBgd)[ivar] = new TH1F( TString::Format("%s_%s_%s_bgd",DataInfo().GetName(),GetMethodName().Data(),var.Data()),
+                                       TString::Format("%s_%s_%s background training",DataInfo().GetName(),GetMethodName().Data(),var.Data()),
+                                       nbinsB, xmin[ivar], xmax[ivar] );
       }
    }
 
@@ -565,7 +567,7 @@ void TMVA::MethodLikelihood::WriteOptionsToStream( std::ostream& o, const TStrin
    }
    for (UInt_t ivar = 0; ivar < fPDFSig->size(); ivar++) {
       if ((*fPDFSig)[ivar] != 0) {
-         o << prefix << std::endl << prefix << Form("#Signal[%d] Likelihood PDF Options:",ivar) << std::endl << prefix << std::endl;
+         o << prefix << std::endl << prefix << TString::Format("#Signal[%d] Likelihood PDF Options:",ivar) << std::endl << prefix << std::endl;
          (*fPDFSig)[ivar]->WriteOptionsToStream( o, prefix );
       }
       if ((*fPDFBgd)[ivar] != 0) {

--- a/tmva/tmva/src/MethodLikelihood.cxx
+++ b/tmva/tmva/src/MethodLikelihood.cxx
@@ -616,8 +616,8 @@ const TMVA::Ranking* TMVA::MethodLikelihood::CreateRanking()
       // this variable should not be used
       fDropVariable = ivar;
 
-      TString nameS = Form( "rS_%i", ivar+1 );
-      TString nameB = Form( "rB_%i", ivar+1 );
+      TString nameS = TString::Format( "rS_%i", ivar+1 );
+      TString nameB = TString::Format( "rB_%i", ivar+1 );
       TH1* rS = new TH1F( nameS, nameS, 80, 0, 1 );
       TH1* rB = new TH1F( nameB, nameB, 80, 0, 1 );
 
@@ -724,8 +724,8 @@ void  TMVA::MethodLikelihood::ReadWeightsFromStream( TFile& rf )
    Bool_t addDirStatus = TH1::AddDirectoryStatus();
    TH1::AddDirectory(0); // this avoids the binding of the hists in TMVA::PDF to the current ROOT file
    for (UInt_t ivar=0; ivar<GetNvar(); ivar++){
-      (*fPDFSig)[ivar] = (TMVA::PDF*)rf.Get( Form( "PDF_%s_S", GetInputVar( ivar ).Data() ) );
-      (*fPDFBgd)[ivar] = (TMVA::PDF*)rf.Get( Form( "PDF_%s_B", GetInputVar( ivar ).Data() ) );
+      (*fPDFSig)[ivar] = (TMVA::PDF*)rf.Get( TString::Format( "PDF_%s_S", GetInputVar( ivar ).Data() ) );
+      (*fPDFBgd)[ivar] = (TMVA::PDF*)rf.Get( TString::Format( "PDF_%s_B", GetInputVar( ivar ).Data() ) );
    }
    TH1::AddDirectory(addDirStatus);
 }

--- a/tmva/tmva/src/MethodMLP.cxx
+++ b/tmva/tmva/src/MethodMLP.cxx
@@ -638,7 +638,7 @@ void TMVA::MethodMLP::BFGSMinimize( Int_t nEpochs )
       }
 
       // draw progress
-      TString convText = Form( "<D^2> (train/test/epoch): %.4g/%.4g/%d", trainE, testE,i  ); //zjh
+      TString convText = TString::Format( "<D^2> (train/test/epoch): %.4g/%.4g/%d", trainE, testE,i  ); //zjh
       if (fSteps > 0) {
          Float_t progress = 0;
          if (Float_t(i)/nEpochs < fSamplingEpoch)
@@ -1120,7 +1120,7 @@ void TMVA::MethodMLP::BackPropagationMinimize(Int_t nEpochs)
       }
 
       // draw progress bar (add convergence value)
-      TString convText = Form( "<D^2> (train/test): %.4g/%.4g", trainE, testE );
+      TString convText = TString::Format( "<D^2> (train/test): %.4g/%.4g", trainE, testE );
       if (fSteps > 0) {
          Float_t progress = 0;
          if (Float_t(i)/nEpochs < fSamplingEpoch)

--- a/tmva/tmva/src/MethodMLP.cxx
+++ b/tmva/tmva/src/MethodMLP.cxx
@@ -301,7 +301,7 @@ Double_t TMVA::MethodMLP::CalculateEstimator( Types::ETreeType treeType, Int_t i
 
    // if epochs are counted create monitoring histograms (only available for classification)
    TString type  = (treeType == Types::kTraining ? "train" : "test");
-   TString name  = Form("convergencetest___mlp_%s_epoch_%04i", type.Data(), iEpoch);
+   TString name  = TString::Format("convergencetest___mlp_%s_epoch_%04i", type.Data(), iEpoch);
    TString nameB = name + "_B";
    TString nameS = name + "_S";
    Int_t   nbin  = 100;
@@ -425,7 +425,7 @@ Double_t TMVA::MethodMLP::CalculateEstimator( Types::ETreeType treeType, Int_t i
 
    // provide epoch-wise monitoring
    if (fEpochMon && iEpoch >= 0 && !DoRegression() && treeType == Types::kTraining) {
-      CreateWeightMonitoringHists( Form("epochmonitoring___epoch_%04i_weights_hist", iEpoch), &fEpochMonHistW );
+      CreateWeightMonitoringHists( TString::Format("epochmonitoring___epoch_%04i_weights_hist", iEpoch), &fEpochMonHistW );
    }
 
    return estimator;
@@ -1618,7 +1618,7 @@ void TMVA::MethodMLP::MinuitMinimize()
 
    // init parameters
    for (Int_t ipar=0; ipar < fNumberOfWeights; ipar++) {
-      TString parName = Form("w%i", ipar);
+      TString parName = TString::Format("w%i", ipar);
       tfitter->SetParameter( ipar,
                              parName, w[ipar], 0.1, 0, 0 );
    }

--- a/tmva/tmva/src/MethodPDEFoam.cxx
+++ b/tmva/tmva/src/MethodPDEFoam.cxx
@@ -369,7 +369,7 @@ void TMVA::MethodPDEFoam::CalcXminXmax()
    // the range
    TH1F **range_h = new TH1F*[kDim];
    for (UInt_t dim=0; dim<kDim; dim++) {
-      range_h[dim]  = new TH1F(Form("range%i", dim), "range", rangehistbins, xmin[dim], xmax[dim]);
+      range_h[dim]  = new TH1F(TString::Format("range%i", dim), "range", rangehistbins, xmin[dim], xmax[dim]);
    }
 
    // fill all testing events into histos
@@ -557,7 +557,7 @@ void TMVA::MethodPDEFoam::TrainMultiClassification()
 {
    for (UInt_t iClass=0; iClass<DataInfo().GetNClasses(); ++iClass) {
 
-      fFoam.push_back( InitFoam(Form("MultiClassFoam%u",iClass), kMultiClass, iClass) );
+      fFoam.push_back( InitFoam(TString::Format("MultiClassFoam%u",iClass), kMultiClass, iClass) );
 
       Log() << kVERBOSE << "Filling binary search tree of multiclass foam "
             << iClass << " with events" << Endl;
@@ -1430,7 +1430,7 @@ void TMVA::MethodPDEFoam::ReadFoamsFromFile()
          else {
             // load multiclass foams
             for (UInt_t iClass=0; iClass<DataInfo().GetNClasses(); ++iClass) {
-               fFoam.push_back(ReadClonedFoamFromFile(rootFile, Form("MultiClassFoam%u",iClass)));
+               fFoam.push_back(ReadClonedFoamFromFile(rootFile, TString::Format("MultiClassFoam%u",iClass)));
             }
          }
       }

--- a/tmva/tmva/src/MethodRuleFit.cxx
+++ b/tmva/tmva/src/MethodRuleFit.cxx
@@ -704,7 +704,7 @@ void TMVA::MethodRuleFit::MakeClassRuleCuts( std::ostream& fout ) const
          }
       }
       fout << ") rval+=" << std::setprecision(10) << (*rules)[ir]->GetCoefficient() << ";" << std::flush;
-      fout << "   // importance = " << Form("%3.3f",impr) << std::endl;
+      fout << "   // importance = " << TString::Format("%3.3f",impr) << std::endl;
    }
    fout << std::setprecision(dp);
 }
@@ -737,7 +737,7 @@ void TMVA::MethodRuleFit::MakeClassLinear( std::ostream& fout ) const
               << "*std::min( double(" << std::setprecision(10) << rens->GetLinDP(il)
               << "), std::max( double(inputValues[" << il << "]), double(" << std::setprecision(10) << rens->GetLinDM(il) << ")));"
               << std::flush;
-         fout << "   // importance = " << Form("%3.3f",imp) << std::endl;
+         fout << "   // importance = " << TString::Format("%3.3f",imp) << std::endl;
       }
    }
 }

--- a/tmva/tmva/src/MethodTMlpANN.cxx
+++ b/tmva/tmva/src/MethodTMlpANN.cxx
@@ -154,7 +154,7 @@ void TMVA::MethodTMlpANN::CreateMLPOptions( TString layerSpec )
       int nNodes = 0;
       if (sToAdd.BeginsWith("N")) { sToAdd.Remove(0,1); nNodes = GetNvar(); }
       nNodes += atoi(sToAdd);
-      fHiddenLayer = Form( "%s%i:", (const char*)fHiddenLayer, nNodes );
+      fHiddenLayer = TString::Format( "%s%i:", (const char*)fHiddenLayer, nNodes );
    }
 
    // set input vars

--- a/tmva/tmva/src/MethodTMlpANN.cxx
+++ b/tmva/tmva/src/MethodTMlpANN.cxx
@@ -269,8 +269,9 @@ void TMVA::MethodTMlpANN::Train( void )
    localTrainingTree->Branch( "weight",     &weight,      "weight/F",      basketsize );
 
    for (UInt_t ivar=0; ivar<GetNvar(); ivar++) {
-      const char* myVar = GetInternalVarName(ivar).Data();
-      localTrainingTree->Branch( myVar, &vArr[ivar], Form("Var%02i/F", ivar), basketsize );
+      TString myVar = GetInternalVarName(ivar);
+      TString myTyp = TString::Format("Var%02i/F", ivar);
+      localTrainingTree->Branch( myVar.Data(), &vArr[ivar], myTyp.Data(), basketsize );
    }
 
    for (UInt_t ievt=0; ievt<Data()->GetNEvents(); ievt++) {
@@ -305,7 +306,7 @@ void TMVA::MethodTMlpANN::Train( void )
    // localTrainingTree->Print();
 
    // create NN
-   if (fMLP != 0) { delete fMLP; fMLP = 0; }
+   if (fMLP) { delete fMLP; fMLP = nullptr; }
    fMLP = new TMultiLayerPerceptron( fMLPBuildOptions.Data(),
                                      localTrainingTree,
                                      trainList,
@@ -352,12 +353,12 @@ void TMVA::MethodTMlpANN::AddWeightsXMLTo( void* parent ) const
    std::ifstream inf( tmpfile.Data() );
    char temp[256];
    TString data("");
-   void *ch=NULL;
+   void *ch = nullptr;
    while (inf.getline(temp,256)) {
       TString dummy(temp);
       //std::cout << dummy << std::endl; // remove annoying debug printout with std::cout
       if (dummy.BeginsWith('#')) {
-         if (ch!=0) gTools().AddRawLine( ch, data.Data() );
+         if (ch) gTools().AddRawLine( ch, data.Data() );
          dummy = dummy.Strip(TString::kLeading, '#');
          dummy = dummy(0,dummy.First(' '));
          ch = gTools().AddChild(wght, dummy);
@@ -366,7 +367,7 @@ void TMVA::MethodTMlpANN::AddWeightsXMLTo( void* parent ) const
       }
       data += (dummy + " ");
    }
-   if (ch != 0) gTools().AddRawLine( ch, data.Data() );
+   if (ch) gTools().AddRawLine( ch, data.Data() );
 
    inf.close();
 }
@@ -424,11 +425,12 @@ void  TMVA::MethodTMlpANN::ReadWeightsFromXML( void* wghtnode )
    TTree * dummyTree = new TTree("dummy","Empty dummy tree", 1);
    for (UInt_t ivar = 0; ivar<Data()->GetNVariables(); ivar++) {
       TString vn = DataInfo().GetVariableInfo(ivar).GetInternalName();
-      dummyTree->Branch(Form("%s",vn.Data()), d+ivar, Form("%s/D",vn.Data()));
+      TString vt = TString::Format("%s/D", vn.Data());
+      dummyTree->Branch(vn.Data(), d+ivar, vt.Data());
    }
    dummyTree->Branch("type", &type, "type/I");
 
-   if (fMLP != 0) { delete fMLP; fMLP = 0; }
+   if (fMLP) { delete fMLP; fMLP = nullptr; }
    fMLP = new TMultiLayerPerceptron( fMLPBuildOptions.Data(), dummyTree );
    fMLP->LoadWeights( fname );
 }
@@ -447,17 +449,18 @@ void  TMVA::MethodTMlpANN::ReadWeightsFromStream( std::istream& istr )
    // the MLP is already build
    Log() << kINFO << "Load TMLP weights into " << fMLP << Endl;
 
-   Double_t* d = new Double_t[Data()->GetNVariables()] ;
+   Double_t *d = new Double_t[Data()->GetNVariables()] ;
    Int_t type;
    gROOT->cd();
    TTree * dummyTree = new TTree("dummy","Empty dummy tree", 1);
    for (UInt_t ivar = 0; ivar<Data()->GetNVariables(); ivar++) {
       TString vn = DataInfo().GetVariableInfo(ivar).GetLabel();
-      dummyTree->Branch(Form("%s",vn.Data()), d+ivar, Form("%s/D",vn.Data()));
+      TString vt = TString::Format("%s/D", vn.Data());
+      dummyTree->Branch(vn.Data(), d+ivar, vt.Data());
    }
    dummyTree->Branch("type", &type, "type/I");
 
-   if (fMLP != 0) { delete fMLP; fMLP = 0; }
+   if (fMLP) { delete fMLP; fMLP = nullptr; }
    fMLP = new TMultiLayerPerceptron( fMLPBuildOptions.Data(), dummyTree );
 
    fMLP->LoadWeights( "./TMlp.nn.weights.temp" );

--- a/tmva/tmva/src/MinuitFitter.cxx
+++ b/tmva/tmva/src/MinuitFitter.cxx
@@ -145,7 +145,7 @@ Double_t TMVA::MinuitFitter::Run( std::vector<Double_t>& pars )
 
    // define fit parameters
    for (Int_t ipar=0; ipar<fNpars; ipar++) {
-      fMinWrap->SetParameter( ipar, Form( "Par%i",ipar ),
+      fMinWrap->SetParameter( ipar, TString::Format( "Par%i",ipar ),
                               pars[ipar], fRanges[ipar]->GetWidth()/100.0,
                               fRanges[ipar]->GetMin(), fRanges[ipar]->GetMax() );
       if (fRanges[ipar]->GetWidth() == 0.0) fMinWrap->FixParameter( ipar );

--- a/tmva/tmva/src/PDEFoam.cxx
+++ b/tmva/tmva/src/PDEFoam.cxx
@@ -1291,12 +1291,12 @@ TH2D* TMVA::PDEFoam::Project2( Int_t idim1, Int_t idim2, ECellValue cell_value, 
    }
 
    // create result histogram
-   TString hname(Form("h_%d_vs_%d",idim1,idim2));
+   TString hname = TString::Format("h_%d_vs_%d",idim1,idim2);
 
    // if histogram with this name already exists, delete it
-   TH2D* h1=(TH2D*)gDirectory->Get(hname.Data());
+   TH2D* h1 = (TH2D*)gDirectory->Get(hname.Data());
    if (h1) delete h1;
-   h1= new TH2D(hname.Data(), Form("var%d vs var%d",idim1,idim2), nbin, fXmin[idim1], fXmax[idim1], nbin, fXmin[idim2], fXmax[idim2]);
+   h1 = new TH2D(hname.Data(), TString::Format("var%d vs var%d",idim1,idim2).Data(), nbin, fXmin[idim1], fXmax[idim1], nbin, fXmin[idim2], fXmax[idim2]);
 
    if (!h1) Log() << kFATAL << "ERROR: Can not create histo" << hname << Endl;
 

--- a/tmva/tmva/src/PDEFoamDecisionTree.cxx
+++ b/tmva/tmva/src/PDEFoamDecisionTree.cxx
@@ -134,14 +134,14 @@ void TMVA::PDEFoamDecisionTree::Explore(PDEFoamCell *cell)
    hsig_unw.reserve(fDim);
    hbkg_unw.reserve(fDim);
    for (Int_t idim = 0; idim < fDim; idim++) {
-      hsig.push_back(new TH1D(Form("hsig_%i", idim),
-                              Form("signal[%i]", idim), fNBin, fXmin[idim], fXmax[idim]));
-      hbkg.push_back(new TH1D(Form("hbkg_%i", idim),
-                              Form("background[%i]", idim), fNBin, fXmin[idim], fXmax[idim]));
-      hsig_unw.push_back(new TH1D(Form("hsig_unw_%i", idim),
-                                  Form("signal_unw[%i]", idim), fNBin, fXmin[idim], fXmax[idim]));
-      hbkg_unw.push_back(new TH1D(Form("hbkg_unw_%i", idim),
-                                  Form("background_unw[%i]", idim), fNBin, fXmin[idim], fXmax[idim]));
+      hsig.push_back(new TH1D(TString::Format("hsig_%i", idim),
+                              TString::Format("signal[%i]", idim), fNBin, fXmin[idim], fXmax[idim]));
+      hbkg.push_back(new TH1D(TString::Format("hbkg_%i", idim),
+                              TString::Format("background[%i]", idim), fNBin, fXmin[idim], fXmax[idim]));
+      hsig_unw.push_back(new TH1D(TString::Format("hsig_unw_%i", idim),
+                                  TString::Format("signal_unw[%i]", idim), fNBin, fXmin[idim], fXmax[idim]));
+      hbkg_unw.push_back(new TH1D(TString::Format("hbkg_unw_%i", idim),
+                                  TString::Format("background_unw[%i]", idim), fNBin, fXmin[idim], fXmax[idim]));
    }
 
    // get cell position and size

--- a/tmva/tmva/src/PDEFoamDiscriminant.cxx
+++ b/tmva/tmva/src/PDEFoamDiscriminant.cxx
@@ -191,12 +191,12 @@ TH2D* TMVA::PDEFoamDiscriminant::Project2(Int_t idim1, Int_t idim2, ECellValue c
    }
 
    // create result histogram
-   TString hname(Form("h_%d_vs_%d", idim1, idim2));
+   TString hname = TString::Format("h_%d_vs_%d", idim1, idim2);
 
    // if histogram with this name already exists, delete it
    TH2D* h1 = (TH2D*)gDirectory->Get(hname.Data());
    if (h1) delete h1;
-   h1 = new TH2D(hname.Data(), Form("var%d vs var%d", idim1, idim2), nbin, fXmin[idim1], fXmax[idim1], nbin, fXmin[idim2], fXmax[idim2]);
+   h1 = new TH2D(hname.Data(), TString::Format("var%d vs var%d", idim1, idim2).Data(), nbin, fXmin[idim1], fXmax[idim1], nbin, fXmin[idim2], fXmax[idim2]);
 
    if (!h1) Log() << kFATAL << "ERROR: Can not create histo" << hname << Endl;
    if (cell_value == kValue)

--- a/tmva/tmva/src/PDF.cxx
+++ b/tmva/tmva/src/PDF.cxx
@@ -819,24 +819,24 @@ void TMVA::PDF::FindBinInverse( const TH1* histogram, Int_t& lowerBin, Int_t& hi
 
 void TMVA::PDF::DeclareOptions()
 {
-   DeclareOptionRef( fNsmooth, Form("NSmooth%s",fSuffix.Data()),
+   DeclareOptionRef( fNsmooth, TString::Format("NSmooth%s",fSuffix.Data()),
                      "Number of smoothing iterations for the input histograms" );
-   DeclareOptionRef( fMinNsmooth, Form("MinNSmooth%s",fSuffix.Data()),
+   DeclareOptionRef( fMinNsmooth, TString::Format("MinNSmooth%s",fSuffix.Data()),
                      "Min number of smoothing iterations, for bins with most data" );
 
-   DeclareOptionRef( fMaxNsmooth, Form("MaxNSmooth%s",fSuffix.Data()),
+   DeclareOptionRef( fMaxNsmooth, TString::Format("MaxNSmooth%s",fSuffix.Data()),
                      "Max number of smoothing iterations, for bins with least data" );
 
-   DeclareOptionRef( fHistAvgEvtPerBin, Form("NAvEvtPerBin%s",fSuffix.Data()),
+   DeclareOptionRef( fHistAvgEvtPerBin, TString::Format("NAvEvtPerBin%s",fSuffix.Data()),
                      "Average number of events per PDF bin" );
 
-   DeclareOptionRef( fHistDefinedNBins, Form("Nbins%s",fSuffix.Data()),
+   DeclareOptionRef( fHistDefinedNBins, TString::Format("Nbins%s",fSuffix.Data()),
                      "Defined number of bins for the histogram from which the PDF is created" );
 
-   DeclareOptionRef( fCheckHist, Form("CheckHist%s",fSuffix.Data()),
+   DeclareOptionRef( fCheckHist, TString::Format("CheckHist%s",fSuffix.Data()),
                      "Whether or not to check the source histogram of the PDF" );
 
-   DeclareOptionRef( fInterpolateString, Form("PDFInterpol%s",fSuffix.Data()),
+   DeclareOptionRef( fInterpolateString, TString::Format("PDFInterpol%s",fSuffix.Data()),
                      "Interpolation method for reference histograms (e.g. Spline2 or KDE)" );
    AddPreDefVal(TString("Spline0")); // take histogram
    AddPreDefVal(TString("Spline1")); // linear interpolation between bins
@@ -845,17 +845,17 @@ void TMVA::PDF::DeclareOptions()
    AddPreDefVal(TString("Spline5")); // fifth order polynom interpolation
    AddPreDefVal(TString("KDE"));     // use kernel density estimator
 
-   DeclareOptionRef( fKDEtypeString, Form("KDEtype%s",fSuffix.Data()), "KDE kernel type (1=Gauss)" );
+   DeclareOptionRef( fKDEtypeString, TString::Format("KDEtype%s",fSuffix.Data()), "KDE kernel type (1=Gauss)" );
    AddPreDefVal(TString("Gauss"));
 
-   DeclareOptionRef( fKDEiterString, Form("KDEiter%s",fSuffix.Data()), "Number of iterations (1=non-adaptive, 2=adaptive)" );
+   DeclareOptionRef( fKDEiterString, TString::Format("KDEiter%s",fSuffix.Data()), "Number of iterations (1=non-adaptive, 2=adaptive)" );
    AddPreDefVal(TString("Nonadaptive"));
    AddPreDefVal(TString("Adaptive"));
 
-   DeclareOptionRef( fFineFactor , Form("KDEFineFactor%s",fSuffix.Data()),
+   DeclareOptionRef( fFineFactor , TString::Format("KDEFineFactor%s",fSuffix.Data()),
                      "Fine tuning factor for Adaptive KDE: Factor to multiply the width of the kernel");
 
-   DeclareOptionRef( fBorderMethodString, Form("KDEborder%s",fSuffix.Data()),
+   DeclareOptionRef( fBorderMethodString, TString::Format("KDEborder%s",fSuffix.Data()),
                      "Border effects treatment (1=no treatment , 2=kernel renormalization, 3=sample mirroring)" );
    AddPreDefVal(TString("None"));
    AddPreDefVal(TString("Renorm"));

--- a/tmva/tmva/src/PDF.cxx
+++ b/tmva/tmva/src/PDF.cxx
@@ -291,8 +291,8 @@ void TMVA::PDF::BuildPDF( const TH1* hist )
    fHist        ->SetTitle( fHist->GetName() );
 
    // do not store in current target file
-   fHistOriginal->SetDirectory(0);
-   fHist        ->SetDirectory(0);
+   fHistOriginal->SetDirectory(nullptr);
+   fHist        ->SetDirectory(nullptr);
    fUseHistogram = kFALSE;
 
    if (fInterpolMethod == PDF::kKDE) BuildKDEPDF();
@@ -377,7 +377,7 @@ void TMVA::PDF::BuildSplinePDF()
    if (fNormalize)
       if (integral>0) fPDFHist->Scale( 1.0/integral );
 
-   fPDFHist->SetDirectory(0);
+   fPDFHist->SetDirectory(nullptr);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -447,7 +447,7 @@ void TMVA::PDF::BuildKDEPDF()
    // normalize
    if (fNormalize)
       if (integral>0) fPDFHist->Scale( 1.0/integral );
-   fPDFHist->SetDirectory(0);
+   fPDFHist->SetDirectory(nullptr);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -544,7 +544,7 @@ void TMVA::PDF::FillSplineToHist()
          fPDFHist->SetBinContent( bin, TMath::Max(y, fgEpsilon) );
       }
    }
-   fPDFHist->SetDirectory(0);
+   fPDFHist->SetDirectory(nullptr);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -986,7 +986,7 @@ void TMVA::PDF::ReadXML( void* pdfnode )
    TH1* newhist = 0;
    if (hasEquidistantBinning) {
       newhist = new TH1F( hname, hname, nbins, xmin, xmax );
-      newhist->SetDirectory(0);
+      newhist->SetDirectory(nullptr);
       const char* content = gTools().GetContent(histch);
       std::stringstream s(content);
       Double_t val;
@@ -1010,7 +1010,7 @@ void TMVA::PDF::ReadXML( void* pdfnode )
       std::stringstream sb(binString);
       for (UInt_t i=0; i<=nbins; i++) sb >> binns[i];
       newhist =  new TH1F( hname, hname, nbins, binns.GetMatrixArray() );
-      newhist->SetDirectory(0);
+      newhist->SetDirectory(nullptr);
       for (UInt_t i=0; i<nbins; i++) {
          s >> val;
          newhist->SetBinContent(i+1,val);
@@ -1024,7 +1024,7 @@ void TMVA::PDF::ReadXML( void* pdfnode )
    fHistOriginal = newhist;
    fHist = (TH1F*)fHistOriginal->Clone( hnameSmooth );
    fHist->SetTitle( hnameSmooth );
-   fHist->SetDirectory(0);
+   fHist->SetDirectory(nullptr);
 
    if (fInterpolMethod == PDF::kKDE) BuildKDEPDF();
    else                              BuildSplinePDF();
@@ -1111,7 +1111,7 @@ std::istream& TMVA::operator>> ( std::istream& istr, PDF& pdf )
       std::exit(1);
    }
    TH1* newhist = new TH1F( hname,hname, nbins, xmin, xmax );
-   newhist->SetDirectory(0);
+   newhist->SetDirectory(nullptr);
    Float_t val;
    for (Int_t i=0; i<nbins; i++) {
       istr >> val;
@@ -1122,7 +1122,7 @@ std::istream& TMVA::operator>> ( std::istream& istr, PDF& pdf )
    pdf.fHistOriginal = newhist;
    pdf.fHist = (TH1F*)pdf.fHistOriginal->Clone( hnameSmooth );
    pdf.fHist->SetTitle( hnameSmooth );
-   pdf.fHist->SetDirectory(0);
+   pdf.fHist->SetDirectory(nullptr);
 
    if (pdf.fMinNsmooth>=0) pdf.BuildSplinePDF();
    else {

--- a/tmva/tmva/src/PDF.cxx
+++ b/tmva/tmva/src/PDF.cxx
@@ -616,14 +616,14 @@ void TMVA::PDF::ValidatePDF( TH1* originalHist ) const
    }
 
    Log() << kDEBUG << "Validation result for PDF \"" << originalHist->GetTitle() << "\"" << ": " << Endl;
-   Log() << kDEBUG << Form( "    chi2/ndof(!=0) = %.1f/%i = %.2f (Prob = %.2f)",
+   Log() << kDEBUG << TString::Format( "    chi2/ndof(!=0) = %.1f/%i = %.2f (Prob = %.2f)",
                   chi2, ndof, chi2/ndof, TMath::Prob( chi2, ndof ) ) << Endl;
    if ((1.0 - TMath::Prob( chi2, ndof )) > 0.9999994) {
       Log() << kDEBUG << "Comparison of the original histogram \"" << originalHist->GetTitle() << "\"" << Endl;
       Log() << kDEBUG << "with the corresponding PDF gave a chi2/ndof of " << chi2/ndof << "," << Endl;
       Log() << kDEBUG << "which corresponds to a deviation of more than 5 sigma! Please check!" << Endl;
    }
-   Log() << kDEBUG << Form( "    #bins-found(#expected-bins) deviating > [1,2,3,6] sigmas: " \
+   Log() << kDEBUG << TString::Format( "    #bins-found(#expected-bins) deviating > [1,2,3,6] sigmas: " \
                   "[%i(%i),%i(%i),%i(%i),%i(%i)]",
                   nc1, Int_t(TMath::Prob(1.0,1)*ndof), nc2, Int_t(TMath::Prob(4.0,1)*ndof),
                   nc3, Int_t(TMath::Prob(9.0,1)*ndof), nc6, Int_t(TMath::Prob(36.0,1)*ndof) ) << Endl;

--- a/tmva/tmva/src/ROCCalc.cxx
+++ b/tmva/tmva/src/ROCCalc.cxx
@@ -484,10 +484,10 @@ TH1* TMVA::ROCCalc::GetSignificance( Int_t nStot, Int_t nBtot)
         tl.SetNDC();
         tl.SetTextSize( 0.033 );
         Int_t maxbin = fSignificance->GetMaximumBin();
-        line1 = tl.DrawLatex( 0.15, 0.23, Form("For %1.0f signal and %1.0f background", nStot, nBtot));
+        line1 = tl.DrawLatex( 0.15, 0.23, TString::Format("For %1.0f signal and %1.0f background", nStot, nBtot));
         tl.DrawLatex( 0.15, 0.19, "events the maximum S/Sqrt(S+B) is");
 
-        line2 = tl.DrawLatex( 0.15, 0.15, Form("%4.2f when cutting at %5.2f",
+        line2 = tl.DrawLatex( 0.15, 0.15, TString::Format("%4.2f when cutting at %5.2f",
         maxSig,
         fSignificance->GetXaxis()->GetBinCenter(maxbin)) );
    */

--- a/tmva/tmva/src/Ranking.cxx
+++ b/tmva/tmva/src/Ranking.cxx
@@ -126,9 +126,9 @@ void TMVA::Ranking::Print() const
    Log() << kINFO << hline << Endl;
    for (std::vector<Rank>::const_iterator ir = fRanking.begin(); ir != fRanking.end(); ++ir ) {
       Log() << kINFO
-            << Form( "%4i : ",(*ir).GetRank() )
+            << TString::Format( "%4i : ",(*ir).GetRank() )
             << std::setw(TMath::Max(maxL+0,9)) << (*ir).GetVariable().Data()
-            << Form( " : %3.3e", (*ir).GetRankValue() ) << Endl;
+            << TString::Format( " : %3.3e", (*ir).GetRankValue() ) << Endl;
    }
    Log() << kINFO << hline << Endl;
 }

--- a/tmva/tmva/src/Results.cxx
+++ b/tmva/tmva/src/Results.cxx
@@ -87,19 +87,19 @@ void TMVA::Results::Store( TObject* obj, const char* alias )
 {
    TListIter l(fStorage);
    // check if object is already in list
-   while (void* p = (void*)l()) {
-      if(p==obj)
-         *fLogger << kFATAL << "Histogram pointer " << p << " already exists in results storage" << Endl;
+   while (auto p = l()) {
+      if(p == obj)
+         *fLogger << kFATAL << "Histogram pointer " << (void *) p << " already exists in results storage" << Endl;
    }
 
-   TString as(obj->GetName());
-   if (alias!=0) as=TString(alias);
+   TString as = obj->GetName();
+   if (alias) as=TString(alias);
    if (fHistAlias->find(as) != fHistAlias->end()) {
       // alias exists
       *fLogger << kFATAL << "Alias " << as << " already exists in results storage" << Endl;
    }
    if( obj->InheritsFrom(TH1::Class()) ) {
-      ((TH1*)obj)->SetDirectory(0);
+      ((TH1*)obj)->SetDirectory(nullptr);
    }
    fStorage->Add( obj );
    fHistAlias->insert(std::pair<TString, TObject*>(as,obj));

--- a/tmva/tmva/src/Results.cxx
+++ b/tmva/tmva/src/Results.cxx
@@ -54,7 +54,7 @@ TMVA::Results::Results( const DataSetInfo* dsi, TString resultsName )
      fDsi(dsi),
      fStorage( new TList() ),
      fHistAlias( new std::map<TString, TObject*> ),
-     fLogger( new MsgLogger(Form("Results%s",resultsName.Data()), kINFO) )
+     fLogger( new MsgLogger(TString::Format("Results%s",resultsName.Data()).Data(), kINFO) )
 {
    fStorage->SetOwner();
 }

--- a/tmva/tmva/src/ResultsClassification.cxx
+++ b/tmva/tmva/src/ResultsClassification.cxx
@@ -51,7 +51,7 @@ namespace TMVA {
 TMVA::ResultsClassification::ResultsClassification( const DataSetInfo* dsi, TString resultsName  )
    : Results( dsi,resultsName  ),
      fRet(1),
-     fLogger( new MsgLogger(Form("ResultsClassification%s",resultsName.Data()) , kINFO) )
+     fLogger( new MsgLogger(TString::Format("ResultsClassification%s",resultsName.Data()).Data() , kINFO) )
 {
 }
 

--- a/tmva/tmva/src/ResultsMulticlass.cxx
+++ b/tmva/tmva/src/ResultsMulticlass.cxx
@@ -58,7 +58,7 @@ Class which takes the results of a multiclass classification
 TMVA::ResultsMulticlass::ResultsMulticlass( const DataSetInfo* dsi, TString resultsName  )
    : Results( dsi, resultsName  ),
      IFitterTarget(),
-     fLogger( new MsgLogger(Form("ResultsMultiClass%s",resultsName.Data()) , kINFO) ),
+     fLogger( new MsgLogger(TString::Format("ResultsMultiClass%s",resultsName.Data()).Data() , kINFO) ),
      fClassToOptimize(0),
      fAchievableEff(dsi->GetNClasses()),
      fAchievablePur(dsi->GetNClasses()),
@@ -256,8 +256,8 @@ void TMVA::ResultsMulticlass::CreateMulticlassPerformanceHistos(TString prefix)
    for (size_t iClass = 0; iClass < numClasses; ++iClass) {
 
       TString className = dsi->GetClassInfo(iClass)->GetName();
-      TString name = Form("%s_rejBvsS_%s", prefix.Data(), className.Data());
-      TString title = Form("%s_%s", prefix.Data(), className.Data());
+      TString name = TString::Format("%s_rejBvsS_%s", prefix.Data(), className.Data());
+      TString title = TString::Format("%s_%s", prefix.Data(), className.Data());
 
       // Histograms are already generated, skip.
       if ( DoesExist(name) ) {
@@ -337,8 +337,8 @@ void TMVA::ResultsMulticlass::CreateMulticlassPerformanceHistos(TString prefix)
          // Style ROC Curve
          TString iClassName = dsi->GetClassInfo(iClass)->GetName();
          TString jClassName = dsi->GetClassInfo(jClass)->GetName();
-         TString name = Form("%s_1v1rejBvsS_%s_vs_%s", prefix.Data(), iClassName.Data(), jClassName.Data());
-         TString title = Form("%s_%s_vs_%s", prefix.Data(), iClassName.Data(), jClassName.Data());
+         TString name = TString::Format("%s_1v1rejBvsS_%s_vs_%s", prefix.Data(), iClassName.Data(), jClassName.Data());
+         TString title = TString::Format("%s_%s_vs_%s", prefix.Data(), iClassName.Data(), jClassName.Data());
          rocGraph->SetName(name);
          rocGraph->SetTitle(title);
 
@@ -365,10 +365,10 @@ void  TMVA::ResultsMulticlass::CreateMulticlassHistos( TString prefix, Int_t nbi
    for (UInt_t iCls = 0; iCls < dsi->GetNClasses(); iCls++) {
       histos.push_back(std::vector<TH1F*>(0));
       for (UInt_t jCls = 0; jCls < dsi->GetNClasses(); jCls++) {
-         TString name(Form("%s_%s_prob_for_%s",prefix.Data(),
+         TString name = TString::Format("%s_%s_prob_for_%s",prefix.Data(),
                            dsi->GetClassInfo( jCls )->GetName(),
-                           dsi->GetClassInfo( iCls )->GetName()));
-         
+                           dsi->GetClassInfo( iCls )->GetName());
+
          // Histograms are already generated, skip.
          if ( DoesExist(name) ) {
             return;
@@ -400,9 +400,9 @@ void  TMVA::ResultsMulticlass::CreateMulticlassHistos( TString prefix, Int_t nbi
    for (UInt_t iCls = 0; iCls < dsi->GetNClasses(); iCls++) {
    histos_highbin.push_back(std::vector<TH1F*>(0));
    for (UInt_t jCls = 0; jCls < dsi->GetNClasses(); jCls++) {
-   TString name(Form("%s_%s_prob_for_%s_HIGHBIN",prefix.Data(),
+   TString name = TString::Format("%s_%s_prob_for_%s_HIGHBIN",prefix.Data(),
    dsi->GetClassInfo( jCls )->GetName().Data(),
-   dsi->GetClassInfo( iCls )->GetName().Data()));
+   dsi->GetClassInfo( iCls )->GetName().Data());
    histos_highbin.at(iCls).push_back(new TH1F(name,name,nbins_high,xmin,xmax));
    }
    }

--- a/tmva/tmva/src/ResultsRegression.cxx
+++ b/tmva/tmva/src/ResultsRegression.cxx
@@ -50,7 +50,7 @@ Class that is the base-class for a vector of result
 
 TMVA::ResultsRegression::ResultsRegression( const DataSetInfo* dsi, TString resultsName  )
    : Results( dsi, resultsName  ),
-     fLogger( new MsgLogger(Form("ResultsRegression%s",resultsName.Data()) , kINFO) )
+     fLogger( new MsgLogger(TString::Format("ResultsRegression%s",resultsName.Data()).Data() , kINFO) )
 {
 }
 
@@ -77,7 +77,7 @@ TH1F*  TMVA::ResultsRegression::QuadraticDeviation( UInt_t tgtNum , Bool_t trunc
    DataSet* ds = GetDataSet();
    ds->SetCurrentType( GetTreeType() );
    const DataSetInfo* dsi = GetDataSetInfo();
-   TString name( Form("tgt_%d",tgtNum) );
+   TString name = TString::Format("tgt_%d",tgtNum);
    VariableInfo vinf = dsi->GetTargetInfo(tgtNum);
    Float_t xmin=0., xmax=0.;
    if (truncate){
@@ -95,7 +95,7 @@ TH1F*  TMVA::ResultsRegression::QuadraticDeviation( UInt_t tgtNum , Bool_t trunc
    xmax *= 1.1;
    Int_t nbins = 500;
    TH1F* h = new TH1F( name, name, nbins, xmin, xmax);
-   h->SetDirectory(0);
+   h->SetDirectory(nullptr);
    h->GetXaxis()->SetTitle("Quadratic Deviation");
    h->GetYaxis()->SetTitle("Weighted Entries");
 
@@ -117,7 +117,7 @@ TH2F*  TMVA::ResultsRegression::DeviationAsAFunctionOf( UInt_t varNum, UInt_t tg
    DataSet* ds = GetDataSet();
    ds->SetCurrentType( GetTreeType() );
 
-   TString name( Form("tgt_%d_var_%d",tgtNum, varNum) );
+   TString name = TString::Format("tgt_%d_var_%d",tgtNum, varNum);
    const DataSetInfo* dsi = GetDataSetInfo();
    Float_t xmin, xmax;
    Bool_t takeTargets = kFALSE;
@@ -208,7 +208,7 @@ void  TMVA::ResultsRegression::CreateDeviationHistograms( TString prefix )
    for (UInt_t ivar = 0; ivar < dsi->GetNVariables(); ivar++) {
       for (UInt_t itgt = 0; itgt < dsi->GetNTargets(); itgt++) {
          TH2F* h = DeviationAsAFunctionOf( ivar, itgt );
-         TString name( Form("%s_reg_var%d_rtgt%d",prefix.Data(),ivar,itgt) );
+         TString name = TString::Format("%s_reg_var%d_rtgt%d",prefix.Data(),ivar,itgt);
          h->SetName( name );
          h->SetTitle( name );
          Store( h );
@@ -218,7 +218,7 @@ void  TMVA::ResultsRegression::CreateDeviationHistograms( TString prefix )
    for (UInt_t ivar = 0; ivar < dsi->GetNTargets(); ivar++) {
       for (UInt_t itgt = 0; itgt < dsi->GetNTargets(); itgt++) {
          TH2F* h = DeviationAsAFunctionOf( dsi->GetNVariables()+ivar, itgt );
-         TString name( Form("%s_reg_tgt%d_rtgt%d",prefix.Data(),ivar,itgt) );
+         TString name = TString::Format("%s_reg_tgt%d_rtgt%d",prefix.Data(),ivar,itgt);
          h->SetName( name );
          h->SetTitle( name );
          Store( h );
@@ -228,7 +228,7 @@ void  TMVA::ResultsRegression::CreateDeviationHistograms( TString prefix )
    Log() << kINFO << "Create regression average deviation" << Endl;
    for (UInt_t itgt = 0; itgt < dsi->GetNTargets(); itgt++) {
       TH1F* h =  QuadraticDeviation(itgt);
-      TString name( Form("%s_Quadr_Deviation_target_%d_",prefix.Data(),itgt) );
+      TString name = TString::Format("%s_Quadr_Deviation_target_%d_",prefix.Data(),itgt);
       h->SetName( name );
       h->SetTitle( name );
       Double_t yq[1], xq[]={0.9};
@@ -236,7 +236,7 @@ void  TMVA::ResultsRegression::CreateDeviationHistograms( TString prefix )
       Store( h );
 
       TH1F* htrunc = QuadraticDeviation(itgt, true, yq[0]);
-      TString name2( Form("%s_Quadr_Dev_best90perc_target_%d_",prefix.Data(),itgt) );
+      TString name2 = TString::Format("%s_Quadr_Dev_best90perc_target_%d_",prefix.Data(),itgt);
       htrunc->SetName( name2 );
       htrunc->SetTitle( name2 );
       Store( htrunc );

--- a/tmva/tmva/src/ResultsRegression.cxx
+++ b/tmva/tmva/src/ResultsRegression.cxx
@@ -178,7 +178,7 @@ TH2F*  TMVA::ResultsRegression::DeviationAsAFunctionOf( UInt_t varNum, UInt_t tg
 
 
    TH2F* h = new TH2F( name, name, nxbins, xmin, xmax, nybins, ymin, ymax );
-   h->SetDirectory(0);
+   h->SetDirectory(nullptr);
 
    h->GetXaxis()->SetTitle( (takeTargets ? dsi->GetTargetInfo(varNum).GetTitle() : dsi->GetVariableInfo(varNum).GetTitle() ) );
    TString varName( dsi->GetTargetInfo(tgtNum).GetTitle() );

--- a/tmva/tmva/src/RuleEnsemble.cxx
+++ b/tmva/tmva/src/RuleEnsemble.cxx
@@ -674,8 +674,8 @@ void TMVA::RuleEnsemble::MakeLinearTerms()
       {
             if (fLinPDFB[v]) delete fLinPDFB[v];
             if (fLinPDFS[v]) delete fLinPDFS[v];
-            fLinPDFB[v] = new TH1F(Form("bkgvar%d",v),"bkg temphist",40,fLinDM[v],fLinDP[v]);
-            fLinPDFS[v] = new TH1F(Form("sigvar%d",v),"sig temphist",40,fLinDM[v],fLinDP[v]);
+            fLinPDFB[v] = new TH1F(TString::Format("bkgvar%d",v),"bkg temphist",40,fLinDM[v],fLinDP[v]);
+            fLinPDFS[v] = new TH1F(TString::Format("sigvar%d",v),"sig temphist",40,fLinDM[v],fLinDP[v]);
             fLinPDFB[v]->Sumw2();
             fLinPDFS[v]->Sumw2();
       }
@@ -1025,7 +1025,7 @@ void TMVA::RuleEnsemble::Print() const
          //    if (pind==0) impref =
          //         Log() << kmtype << "Rule #" <<
          //         Log() << kmtype << *fRules[ind] << Endl;
-         fRules[ind]->PrintLogger(Form("Rule %4d : ",pind+1));
+         fRules[ind]->PrintLogger(TString::Format("Rule %4d : ",pind+1));
          pind++;
          if (pind==printN) {
             if (nrules==printN) {

--- a/tmva/tmva/src/RuleFitParams.cxx
+++ b/tmva/tmva/src/RuleFitParams.cxx
@@ -195,10 +195,10 @@ void TMVA::RuleFitParams::InitNtuple()
    fNTLinCoeff = (fNLinear>0 ? new Double_t[fNLinear] : 0);
 
    for (UInt_t i=0; i<fNRules; i++) {
-      fGDNtuple->Branch(Form("a%d",i+1),&fNTCoeff[i],Form("a%d/D",i+1));
+      fGDNtuple->Branch(TString::Format("a%d",i+1).Data(),&fNTCoeff[i],TString::Format("a%d/D",i+1).Data());
    }
    for (UInt_t i=0; i<fNLinear; i++) {
-      fGDNtuple->Branch(Form("b%d",i+1),&fNTLinCoeff[i],Form("b%d/D",i+1));
+      fGDNtuple->Branch(TString::Format("b%d",i+1).Data(),&fNTLinCoeff[i],TString::Format("b%d/D",i+1).Data());
    }
 }
 

--- a/tmva/tmva/src/Timer.cxx
+++ b/tmva/tmva/src/Timer.cxx
@@ -262,20 +262,20 @@ void TMVA::Timer::DrawProgressBar( Int_t icounts, const TString& comment  )
 TString TMVA::Timer::SecToText( Double_t seconds, Bool_t Scientific ) const
 {
    TString out = "";
-   if      (Scientific    ) out = Form( "%.3g sec", seconds );
+   if      (Scientific    ) out = TString::Format( "%.3g sec", seconds );
    else if (seconds <  0  ) out = "unknown";
-   else if (seconds <= 300) out = Form( "%i sec", Int_t(seconds) );
+   else if (seconds <= 300) out = TString::Format( "%i sec", Int_t(seconds) );
    else {
       if (seconds > 3600) {
          Int_t h = Int_t(seconds/3600);
-         if (h <= 1) out = Form( "%i hr : ", h );
-         else        out = Form( "%i hrs : ", h );
+         if (h <= 1) out = TString::Format( "%i hr : ", h );
+         else        out = TString::Format( "%i hrs : ", h );
 
          seconds = Int_t(seconds)%3600;
       }
       Int_t m = Int_t(seconds/60);
-      if (m <= 1) out += Form( "%i min", m );
-      else        out += Form( "%i mins", m );
+      if (m <= 1) out += TString::Format( "%i min", m );
+      else        out += TString::Format( "%i mins", m );
    }
 
    return (fColourfulOutput) ? gTools().Color("red") + out + gTools().Color("reset") : out;

--- a/tmva/tmva/src/Tools.cxx
+++ b/tmva/tmva/src/Tools.cxx
@@ -1331,7 +1331,7 @@ void TMVA::Tools::ROOTVersionMessage( MsgLogger& logger )
    Int_t   iday   = idatqq%100;
    Int_t   imonth = (idatqq/100)%100;
    Int_t   iyear  = (idatqq/10000);
-   TString versionDate = Form("%s %d, %4d",months[imonth-1],iday,iyear);
+   TString versionDate = TString::Format("%s %d, %4d",months[imonth-1],iday,iyear);
 
    logger << kHEADER ;
    logger << "You are running ROOT Version: " << gROOT->GetVersion() << ", " << versionDate << Endl;
@@ -1756,7 +1756,7 @@ Double_t TMVA::Tools::RMS(Long64_t n, const T *a, const Double_t *w)
 
 TH1* TMVA::Tools::GetCumulativeDist( TH1* h)
 {
-   TH1* cumulativeDist= (TH1*) h->Clone(Form("%sCumul",h->GetTitle()));
+   TH1* cumulativeDist= (TH1*) h->Clone(TString::Format("%sCumul",h->GetTitle()));
    //cumulativeDist->Smooth(5); // with this, I get less beautiful ROC curves, hence out!
 
    Float_t partialSum = 0;

--- a/tmva/tmva/src/Tools.cxx
+++ b/tmva/tmva/src/Tools.cxx
@@ -969,7 +969,7 @@ void TMVA::Tools::FormattedOutput( const TMatrixD& M, const std::vector<TString>
    for (UInt_t irow=0; irow<nvar; irow++) {
       logger << setw(maxL) << V[irow] << ":";
       for (UInt_t icol=0; icol<nvar; icol++) {
-         logger << setw(vLengths[icol]+1) << Form( "%+1.3f", M(irow,icol) );
+         logger << setw(vLengths[icol]+1) << TString::Format( "%+1.3f", M(irow,icol) );
       }
       logger << Endl;
    }
@@ -1024,7 +1024,7 @@ void TMVA::Tools::FormattedOutput( const TMatrixD& M,
    for (UInt_t irow=0; irow<nvvar; irow++) {
       logger << setw(maxL) << vert[irow] << ":";
       for (UInt_t icol=0; icol<nhvar; icol++) {
-         logger << setw(hLengths[icol]+1) << Form( "%+1.3f", M(irow,icol) );
+         logger << setw(hLengths[icol]+1) << TString::Format( "%+1.3f", M(irow,icol) );
       }
       logger << Endl;
    }
@@ -1048,7 +1048,7 @@ TString TMVA::Tools::GetXTitleWithUnit( const TString& title, const TString& uni
 TString TMVA::Tools::GetYTitleWithUnit( const TH1& h, const TString& unit, Bool_t normalised )
 {
    TString retval = ( normalised ? "(1/N) " : "" );
-   retval += Form( "dN_{ }/^{ }%.3g %s", h.GetXaxis()->GetBinWidth(1), unit.Data() );
+   retval += TString::Format( "dN_{ }/^{ }%.3g %s", h.GetXaxis()->GetBinWidth(1), unit.Data() );
    return retval;
 }
 
@@ -1233,7 +1233,7 @@ TString TMVA::Tools::StringFromInt( Long_t i )
 TString TMVA::Tools::StringFromDouble( Double_t d )
 {
    std::stringstream s;
-   s << Form( "%5.8e", d );
+   s << TString::Format( "%5.8e", d );
    return TString(s.str().c_str());
 }
 
@@ -1248,7 +1248,7 @@ void TMVA::Tools::WriteTMatrixDToXML( void* node, const char* name, TMatrixD* ma
    std::stringstream s;
    for (Int_t row = 0; row<mat->GetNrows(); row++) {
       for (Int_t col = 0; col<mat->GetNcols(); col++) {
-         s << Form( "%5.15e ", (*mat)[row][col] );
+         s << TString::Format( "%5.15e ", (*mat)[row][col] );
       }
    }
    xmlengine().AddRawLine( matnode, s.str().c_str() );

--- a/tmva/tmva/src/TransformationHandler.cxx
+++ b/tmva/tmva/src/TransformationHandler.cxx
@@ -777,7 +777,7 @@ void TMVA::TransformationHandler::PlotVariables (const std::vector<Event*>& even
       for (Int_t cls = 0; cls < ncls; cls++) {
          if (hVars.at(cls).at(i) != 0) {
             hVars.at(cls).at(i)->Write();
-            hVars.at(cls).at(i)->SetDirectory(0);
+            hVars.at(cls).at(i)->SetDirectory(nullptr);
             delete hVars.at(cls).at(i);
          }
       }
@@ -797,12 +797,12 @@ void TMVA::TransformationHandler::PlotVariables (const std::vector<Event*>& even
             for (Int_t cls = 0; cls < ncls; cls++) {
                if (mycorr.at(cls).at(i).at(j) != 0 ) {
                   mycorr.at(cls).at(i).at(j)->Write();
-                  mycorr.at(cls).at(i).at(j)->SetDirectory(0);
+                  mycorr.at(cls).at(i).at(j)->SetDirectory(nullptr);
                   delete mycorr.at(cls).at(i).at(j);
                }
                if (myprof.at(cls).at(i).at(j) != 0) {
                   myprof.at(cls).at(i).at(j)->Write();
-                  myprof.at(cls).at(i).at(j)->SetDirectory(0);
+                  myprof.at(cls).at(i).at(j)->SetDirectory(nullptr);
                   delete myprof.at(cls).at(i).at(j);
                }
             }

--- a/tmva/tmva/src/TransformationHandler.cxx
+++ b/tmva/tmva/src/TransformationHandler.cxx
@@ -591,9 +591,9 @@ void TMVA::TransformationHandler::PlotVariables (const std::vector<Event*>& even
                      Double_t rymax = fVariableStats.at(fNumC-1).at( ( v_t*nvar )+j).fMax;
 
                      // scatter plot
-                     TH2F* h2 = new TH2F( Form( "scat_%s_vs_%s_%s%s" , myVarj.Data(), myVari.Data(),
+                     TH2F* h2 = new TH2F( TString::Format( "scat_%s_vs_%s_%s%s" , myVarj.Data(), myVari.Data(),
                                                 className.Data(), transfType.Data() ),
-                                          Form( "%s versus %s (%s)%s", infoj.GetTitle(), info.GetTitle(),
+                                          TString::Format( "%s versus %s (%s)%s", infoj.GetTitle(), info.GetTitle(),
                                                 className.Data(), transfType.Data() ),
                                           nbins2D, rxmin , rxmax,
                                           nbins2D, rymin , rymax );
@@ -603,10 +603,10 @@ void TMVA::TransformationHandler::PlotVariables (const std::vector<Event*>& even
                      mycorr.at(cls).at((var_tgt*nvar)+ivar).at((v_t*nvar)+j) = h2;
 
                      // profile plot
-                     TProfile* p = new TProfile( Form( "prof_%s_vs_%s_%s%s", myVarj.Data(),
+                     TProfile* p = new TProfile( TString::Format( "prof_%s_vs_%s_%s%s", myVarj.Data(),
                                                        myVari.Data(), className.Data(),
                                                        transfType.Data() ),
-                                                 Form( "profile %s versus %s (%s)%s",
+                                                 TString::Format( "profile %s versus %s (%s)%s",
                                                        infoj.GetTitle(), info.GetTitle(),
                                                        className.Data(), transfType.Data() ), nbins1D,
                                                  rxmin, rxmax );

--- a/tmva/tmva/src/TransformationHandler.cxx
+++ b/tmva/tmva/src/TransformationHandler.cxx
@@ -552,7 +552,7 @@ void TMVA::TransformationHandler::PlotVariables (const std::vector<Event*>& even
                Int_t xmax = TMath::Nint( GetMax( ( var_tgt*nvar )+ivar) + 1 );
                Int_t nbins = xmax - xmin;
 
-               h = new TH1F( Form("%s__%s%s", myVari.Data(), className.Data(), transfType.Data()),
+               h = new TH1F( TString::Format("%s__%s%s", myVari.Data(), className.Data(), transfType.Data()).Data(),
                              info.GetTitle(), nbins, xmin, xmax );
             }
             else {
@@ -566,7 +566,7 @@ void TMVA::TransformationHandler::PlotVariables (const std::vector<Event*>& even
                // safety margin for values equal to the maximum within the histogram
                xmax += (xmax - xmin)/nbins1D;
 
-               h = new TH1F( Form("%s__%s%s", myVari.Data(), className.Data(), transfType.Data()),
+               h = new TH1F( TString::Format("%s__%s%s", myVari.Data(), className.Data(), transfType.Data()).Data(),
                              info.GetTitle(), nbins1D, xmin, xmax );
             }
 
@@ -751,9 +751,9 @@ void TMVA::TransformationHandler::PlotVariables (const std::vector<Event*>& even
 
       TString uniqueOutputDir = outputDir;
       Int_t counter = 0;
-      TObject* o = NULL;
-      while( (o = fRootBaseDir->FindObject(uniqueOutputDir)) != 0 ){
-         uniqueOutputDir = outputDir+Form("_%d",counter);
+      TObject* o = nullptr;
+      while( (o = fRootBaseDir->FindObject(uniqueOutputDir)) != nullptr ){
+         uniqueOutputDir = outputDir + TString::Format("_%d",counter);
          Log() << kINFO << "A " << o->ClassName() << " with name " << o->GetName() << " already exists in "
                << fRootBaseDir->GetPath() << ", I will try with "<<uniqueOutputDir<<"." << Endl;
          ++counter;

--- a/tmva/tmva/src/VariableDecorrTransform.cxx
+++ b/tmva/tmva/src/VariableDecorrTransform.cxx
@@ -143,13 +143,13 @@ std::vector<TString>* TMVA::VariableDecorrTransform::GetTransformationStrings( I
 
          switch( type ) {
          case 'v':
-            str += Form( "%10.5g*[%s]", TMath::Abs((*m)(ivar,jvar)), Variables()[idx].GetLabel().Data() );
+            str += TString::Format( "%10.5g*[%s]", TMath::Abs((*m)(ivar,jvar)), Variables()[idx].GetLabel().Data() );
             break;
          case 't':
-            str += Form( "%10.5g*[%s]", TMath::Abs((*m)(ivar,jvar)), Targets()[idx].GetLabel().Data() );
+            str += TString::Format( "%10.5g*[%s]", TMath::Abs((*m)(ivar,jvar)), Targets()[idx].GetLabel().Data() );
             break;
          case 's':
-            str += Form( "%10.5g*[%s]", TMath::Abs((*m)(ivar,jvar)), Spectators()[idx].GetLabel().Data() );
+            str += TString::Format( "%10.5g*[%s]", TMath::Abs((*m)(ivar,jvar)), Spectators()[idx].GetLabel().Data() );
             break;
          default:
             Log() << kFATAL << "VariableDecorrTransform::GetTransformationStrings : unknown type '" << type << "'." << Endl;

--- a/tmva/tmva/src/VariableGaussTransform.cxx
+++ b/tmva/tmva/src/VariableGaussTransform.cxx
@@ -371,7 +371,7 @@ void TMVA::VariableGaussTransform::GetCumulativeDist( const std::vector< Event*>
                                                 TString::Format("Cumulative_Var%d_cls%d",ivar,icls),
                                                 nbins[icls][ivar] -1, // class icls
                                                 binnings);
-         fCumulativeDist[ivar][icls]->SetDirectory(0);
+         fCumulativeDist[ivar][icls]->SetDirectory(nullptr);
          delete [] binnings;
       }
    }
@@ -590,7 +590,7 @@ void TMVA::VariableGaussTransform::ReadTransformationFromStream( std::istream& i
          if ( histToRead !=0 ) delete histToRead;
          // recreate the cumulative histogram to be filled with the values read
          histToRead = new TH1F( hname, hname, nbins, Binnings );
-         histToRead->SetDirectory(0);
+         histToRead->SetDirectory(nullptr);
          fCumulativeDist[ivar][type]=histToRead;
 
          istr >> devnullS; // read the line "BinContent" ..

--- a/tmva/tmva/src/VariableGaussTransform.cxx
+++ b/tmva/tmva/src/VariableGaussTransform.cxx
@@ -364,11 +364,11 @@ void TMVA::VariableGaussTransform::GetCumulativeDist( const std::vector< Event*>
             binnings[k] = vsForBinning[icls][ivar][k];
          }
          fCumulativeDist[ivar].resize(numDist);
-         if (0 != fCumulativeDist[ivar][icls] ) {
+         if (fCumulativeDist[ivar][icls] ) {
             delete fCumulativeDist[ivar][icls];
          }
-         fCumulativeDist[ivar][icls] = new TH1F(Form("Cumulative_Var%d_cls%d",ivar,icls),
-                                                Form("Cumulative_Var%d_cls%d",ivar,icls),
+         fCumulativeDist[ivar][icls] = new TH1F(TString::Format("Cumulative_Var%d_cls%d",ivar,icls),
+                                                TString::Format("Cumulative_Var%d_cls%d",ivar,icls),
                                                 nbins[icls][ivar] -1, // class icls
                                                 binnings);
          fCumulativeDist[ivar][icls]->SetDirectory(0);
@@ -428,7 +428,7 @@ void TMVA::VariableGaussTransform::GetCumulativeDist( const std::vector< Event*>
             (fCumulativeDist[ivar][icls])->SetBinContent(ibin,sum/total);
          }
          // create PDf
-         fCumulativePDF[ivar].push_back(new PDF( Form("GaussTransform var%d cls%d",ivar,icls),  fCumulativeDist[ivar][icls], PDF::kSpline1, fPdfMinSmooth, fPdfMaxSmooth,kFALSE,kFALSE));
+         fCumulativePDF[ivar].push_back(new PDF( TString::Format("GaussTransform var%d cls%d",ivar,icls),  fCumulativeDist[ivar][icls], PDF::kSpline1, fPdfMinSmooth, fPdfMaxSmooth,kFALSE,kFALSE));
       }
    }
 }
@@ -482,7 +482,7 @@ void TMVA::VariableGaussTransform::AttachXMLTo(void* parent) {
          Log() << kFATAL << "Cumulative histograms for variable " << ivar << " don't exist, can't write it to weight file" << Endl;
 
       for (UInt_t icls=0; icls<fCumulativePDF[ivar].size(); icls++){
-         void* pdfxml = gTools().AddChild( varxml, Form("CumulativePDF_cls%d",icls));
+         void* pdfxml = gTools().AddChild( varxml, TString::Format("CumulativePDF_cls%d",icls));
          (fCumulativePDF[ivar][icls])->AddXMLTo(pdfxml);
       }
    }

--- a/tmva/tmva/src/VariableImportance.cxx
+++ b/tmva/tmva/src/VariableImportance.cxx
@@ -173,7 +173,7 @@ TH1F* TMVA::VariableImportance::GetImportance(const UInt_t nbits,std::vector<Flo
     vihist->GetYaxis()->SetTitleOffset(1.24);
 
     vihist->GetYaxis()->SetRangeUser(-7, 50);
-    vihist->SetDirectory(0);
+    vihist->SetDirectory(nullptr);
 
     return vihist;
 }

--- a/tmva/tmva/src/VariableInfo.cxx
+++ b/tmva/tmva/src/VariableInfo.cxx
@@ -148,7 +148,7 @@ TMVA::VariableInfo& TMVA::VariableInfo::operator=(const VariableInfo& rhs)
 void TMVA::VariableInfo::WriteToStream( std::ostream& o ) const
 {
    UInt_t nc = TMath::Max( 30, TMath::Max( GetExpression().Length()+1, GetInternalName().Length()+1 ) );
-   TString expBr(Form("\'%s\'",GetExpression().Data()));
+   TString expBr = TString::Format("\'%s\'",GetExpression().Data());
    o << std::setw(nc) << GetExpression();
    o << std::setw(nc) << GetInternalName();
    o << std::setw(nc) << GetLabel();
@@ -202,7 +202,7 @@ void TMVA::VariableInfo::AddToXML( void* varnode )
    typeStr[0] = GetVarType();
    // in case of array variables, add "[]" to the type string: e.g. F[]
    if (TestBit(DataSetInfo::kIsArrayVariable))
-      typeStr += "[]"; 
+      typeStr += "[]";
    gTools().AddAttr(varnode, "Type", typeStr);
    gTools().AddAttr( varnode, "Min", gTools().StringFromDouble(GetMin()) );
    gTools().AddAttr( varnode, "Max", gTools().StringFromDouble(GetMax()) );
@@ -224,7 +224,7 @@ void TMVA::VariableInfo::ReadFromXML( void* varnode )
    gTools().ReadAttr( varnode, "Max",        fXmaxNorm );
 
    SetVarType(type[0]);
-   // detect variables from array 
+   // detect variables from array
    if (type.Contains("[]"))
       SetBit(DataSetInfo::kIsArrayVariable);
 }

--- a/tmva/tmva/src/VariableNormalizeTransform.cxx
+++ b/tmva/tmva/src/VariableNormalizeTransform.cxx
@@ -288,8 +288,8 @@ std::vector<TString>* TMVA::VariableNormalizeTransform::GetTransformationStrings
       TString str("");
       VariableInfo& varInfo = (type=='v'?fDsi.GetVariableInfo(idx):(type=='t'?fDsi.GetTargetInfo(idx):fDsi.GetSpectatorInfo(idx)));
 
-      if (offset < 0) str = Form( "2*%g*([%s] + %g) - 1", scale, varInfo.GetLabel().Data(), -offset );
-      else            str = Form( "2*%g*([%s] - %g) - 1", scale, varInfo.GetLabel().Data(),  offset );
+      if (offset < 0) str = TString::Format( "2*%g*([%s] + %g) - 1", scale, varInfo.GetLabel().Data(), -offset );
+      else            str = TString::Format( "2*%g*([%s] - %g) - 1", scale, varInfo.GetLabel().Data(),  offset );
       (*strVec)[iinp] = str;
 
       ++iinp;

--- a/tmva/tmva/test/DNN/CNN/MakeImageData.h
+++ b/tmva/tmva/test/DNN/CNN/MakeImageData.h
@@ -19,8 +19,8 @@ void makeImages(int n = 10000, int npx = 8, int npy = 8, TString fileName = "ima
    TTree bkg("bkg","bkg");
    TFile f(fileName,"RECREATE");
 
-   bkg.Branch("ximage",x1.data(),Form("ximage[%d]/F",np));
-   sgn.Branch("ximage",x2.data(),Form("ximage[%d]/F",np));
+   bkg.Branch("ximage",x1.data(),TString::Format("ximage[%d]/F",np).Data());
+   sgn.Branch("ximage",x2.data(),TString::Format("ximage[%d]/F",np).Data());
 
    sgn.SetDirectory(&f);
    bkg.SetDirectory(&f);

--- a/tmva/tmva/test/crossvalidation/TestCrossValidationIntVar.cxx
+++ b/tmva/tmva/test/crossvalidation/TestCrossValidationIntVar.cxx
@@ -71,15 +71,15 @@ std::pair<std::string, double> runCrossValidation(UInt_t numWorkers)
    dataloader->AddVariable("y", 'D');
    dataloader->AddSpectator("EventNumber", 'I');
 
-   TString dataloaderOptions = Form("SplitMode=Block:nTrain_Signal=%i"
-                                    ":nTrain_Background=%i:!V",
-                                    NUM_EVENTS_SIG, NUM_EVENTS_BKG);
+   TString dataloaderOptions = TString::Format("SplitMode=Block:nTrain_Signal=%i"
+                                               ":nTrain_Background=%i:!V",
+                                               NUM_EVENTS_SIG, NUM_EVENTS_BKG);
    dataloader->PrepareTrainingAndTestTree("", dataloaderOptions);
 
    // TMVA::CrossValidation takes ownership of dataloader
    std::string splitExpr = "UInt_t([EventNumber])%UInt_t([NumFolds])";
    TMVA::CrossValidation cv{"test_cv_intvar", dataloader,
-                            Form("!Silent:AnalysisType=Classification"
+                                 TString::Format("!Silent:AnalysisType=Classification"
                                  ":NumWorkerProcs=%i:NumFolds=%i"
                                  ":SplitType=Deterministic:SplitExpr=%s",
                                  numWorkers, NUM_FOLDS, splitExpr.c_str())};

--- a/tmva/tmva/test/crossvalidation/TestCrossValidationMultiProc.cxx
+++ b/tmva/tmva/test/crossvalidation/TestCrossValidationMultiProc.cxx
@@ -71,15 +71,15 @@ std::pair<std::string, double> runCrossValidation(UInt_t numWorkers)
    dataloader->AddVariable("y", 'D');
    dataloader->AddSpectator("EventNumber", 'I');
 
-   TString dataloaderOptions = Form("SplitMode=Block:nTrain_Signal=%i"
+   TString dataloaderOptions = TString::Format("SplitMode=Block:nTrain_Signal=%i"
                                     ":nTrain_Background=%i:!V",
                                     NUM_EVENTS_SIG, NUM_EVENTS_BKG);
    dataloader->PrepareTrainingAndTestTree("", dataloaderOptions);
 
    // TMVA::CrossValidation takes ownership of dataloader
    std::string splitExpr = "UInt_t([EventNumber])%UInt_t([NumFolds])";
-   TMVA::CrossValidation cv{Form("%i-proc", numWorkers), dataloader,
-                            Form("!Silent:AnalysisType=Classification"
+   TMVA::CrossValidation cv{TString::Format("%i-proc", numWorkers), dataloader,
+                            TString::Format("!Silent:AnalysisType=Classification"
                                  ":NumWorkerProcs=%i:NumFolds=%i"
                                  ":SplitType=Deterministic:SplitExpr=%s",
                                  numWorkers, NUM_FOLDS, splitExpr.c_str())};

--- a/tmva/tmva/test/crossvalidation/TestCrossValidationSplitting.cxx
+++ b/tmva/tmva/test/crossvalidation/TestCrossValidationSplitting.cxx
@@ -300,7 +300,7 @@ TEST(CrossValidationSplitting, TrainingSetSplitOnSpectator)
    d->AddVariable("x", 'D');
    d->AddSpectator("id", "id", "");
    d->PrepareTrainingAndTestTree(
-      "", Form("SplitMode=Block:nTrain_Signal=%i:nTrain_Background=%i:!V", nPointsSig, nPointsBkg));
+      "", TString::Format("SplitMode=Block:nTrain_Signal=%i:nTrain_Background=%i:!V", nPointsSig, nPointsBkg));
 
    d->GetDataSetInfo().GetDataSet(); // Force creation of dataset.
    TMVA::MsgLogger::EnableOutput();
@@ -338,7 +338,7 @@ TEST(CrossValidationSplitting, TrainingSetSplitOnSpectator2)
    d->AddVariable("x", 'D');
    d->AddSpectator("id", "id", "");
    d->PrepareTrainingAndTestTree(
-      "", Form("SplitMode=Block:nTrain_Signal=%i:nTrain_Background=%i:!V", nPointsSig, nPointsBkg));
+      "", TString::Format("SplitMode=Block:nTrain_Signal=%i:nTrain_Background=%i:!V", nPointsSig, nPointsBkg));
 
    d->GetDataSetInfo().GetDataSet(); // Force creation of dataset.
    TMVA::MsgLogger::EnableOutput();
@@ -374,7 +374,7 @@ TEST(CrossValidationSplitting, TrainingSetSplitRandomStratified)
    d->AddVariable("x", 'D');
    d->AddSpectator("id", "id", "");
    d->PrepareTrainingAndTestTree(
-      "", Form("SplitMode=Block:nTrain_Signal=%i:nTrain_Background=%i:!V", nPointsSig, nPointsBkg));
+      "", TString::Format("SplitMode=Block:nTrain_Signal=%i:nTrain_Background=%i:!V", nPointsSig, nPointsBkg));
 
    d->GetDataSetInfo().GetDataSet(); // Force creation of dataset.
    TMVA::MsgLogger::EnableOutput();

--- a/tmva/tmvagui/src/BDT.cxx
+++ b/tmva/tmvagui/src/BDT.cxx
@@ -67,7 +67,7 @@ TMVA::StatDialogBDT::StatDialogBDT(TString dataset, const TGWindow* p, TString w
    // main frame
    fMain = new TGMainFrame(p, totalWidth, totalHeight, kMainFrame | kVerticalFrame);
 
-   TGLabel *sigLab = new TGLabel( fMain, Form( "Decision tree [%i-%i]",0,fNtrees-1 ) );
+   TGLabel *sigLab = new TGLabel( fMain, TString::Format( "Decision tree [%i-%i]",0,fNtrees-1 ) );
    fMain->AddFrame(sigLab, new TGLayoutHints(kLHintsLeft | kLHintsTop,5,5,5,5));
 
    fInput = new TGNumberEntry(fMain, (Double_t) fItree,5,-1,(TGNumberFormat::EStyle) 5);
@@ -194,9 +194,9 @@ void TMVA::StatDialogBDT::DrawNode( TMVA::DecisionTreeNode *n,
 
    if (n->GetNodeType() == 0){
       if (n->GetCutType()){
-         t->AddText(TString(vars[n->GetSelector()]+">"+=::Form("%5.3g",n->GetCutValue())));
+         t->AddText(vars[n->GetSelector()] + ">" + TString::Format("%5.3g",n->GetCutValue()));
       }else{
-         t->AddText(TString(vars[n->GetSelector()]+"<"+=::Form("%5.3g",n->GetCutValue())));
+         t->AddText(vars[n->GetSelector()] + "<" + TString::Format("%5.3g",n->GetCutValue()));
       }
    }
 
@@ -318,8 +318,8 @@ void TMVA::StatDialogBDT::DrawTree( Int_t itree )
 
    Int_t   canvasColor = TMVAStyle->GetCanvasColor(); // backup
 
-   TString cbuffer = Form( "Reading weight file: %s", fWfile.Data() );
-   TString tbuffer = Form( "Decision Tree no.: %d", itree );
+   TString cbuffer = TString::Format( "Reading weight file: %s", fWfile.Data() );
+   TString tbuffer = TString::Format( "Decision Tree no.: %d", itree );
    if (!fCanvas) fCanvas = new TCanvas( "c1", cbuffer, 200, 0, 1000, 600 );
    else          fCanvas->Clear();
    fCanvas->Draw();
@@ -359,7 +359,7 @@ void TMVA::StatDialogBDT::DrawTree( Int_t itree )
 
 
    fCanvas->Update();
-   TString fname = fDataset+Form("/plots/%s_%i", fMethName.Data(), itree );
+   TString fname = fDataset + TString::Format("/plots/%s_%i", fMethName.Data(), itree);
    cout << "--- Creating image: " << fname << endl;
    TMVAGlob::imgconv( fCanvas, fname );
 
@@ -422,7 +422,7 @@ void TMVA::BDT(TString dataset, const TString& fin  )
       TString fname = path[im];
       if (fname[fname.Length()-1] != '/') fname += "/";
       fname += wfile[im];
-      TString macro = Form( "TMVA::BDT(\"%s\",0,\"%s\",\"%s\")",dataset.Data(), fname.Data(), methname[im].Data() );
+      TString macro = TString::Format( "TMVA::BDT(\"%s\",0,\"%s\",\"%s\")",dataset.Data(), fname.Data(), methname[im].Data() );
       cbar->AddButton( fname, macro, "Plot decision trees from this weight file", "button" );
    }
 

--- a/tmva/tmvagui/src/BDTControlPlots.cxx
+++ b/tmva/tmvagui/src/BDTControlPlots.cxx
@@ -13,10 +13,10 @@ void TMVA::BDTControlPlots(TString dataset, TString fin , Bool_t useTMVAStyle  )
 {
    // set style and remove existing canvas'
    TMVAGlob::Initialize( useTMVAStyle );
-  
+
    // checks if file with name "fin" is already open, and if not opens one
-   TFile* file = TMVAGlob::OpenFile( fin );  
-   
+   TFile* file = TMVAGlob::OpenFile( fin );
+
    if (file == NULL) {
       cout << "Problems with input file, tried to open " << fin << " but somehow did not succeed .." << endl;
       return;
@@ -51,8 +51,8 @@ void TMVA::bdtcontrolplots(TString dataset, TDirectory *bdtdir ) {
    char cn2[bufferSize];
    const TString titName = bdtdir->GetName();
    snprintf( cn, bufferSize, "cv_%s", titName.Data() );
-   TCanvas *c = new TCanvas( cn,  Form( "%s Control Plots", titName.Data() ),
-                             width, height ); 
+   TCanvas *c = new TCanvas( cn,  TString::Format( "%s Control Plots", titName.Data() ),
+                             width, height );
    c->Divide(3,2);
 
 
@@ -63,10 +63,10 @@ void TMVA::bdtcontrolplots(TString dataset, TDirectory *bdtdir ) {
    Bool_t BoostMonitorIsDone=kFALSE;
 
    for (Int_t i=0; i<nPlots; i++){
-      Int_t color = 4; 
+      Int_t color = 4;
       c->cd(i+1);
       TH1 *h = (TH1*) bdtdir->Get(hname[i]);
-      
+
       if (h){
          h->SetMaximum(h->GetMaximum()*1.3);
          h->SetMinimum( 0 );
@@ -95,25 +95,25 @@ void TMVA::bdtcontrolplots(TString dataset, TDirectory *bdtdir ) {
          c->Update();
       }
    }
-   
-   
+
+
    TCanvas *c2 = NULL;
    if (BoostMonitorIsDone){
       snprintf( cn2, bufferSize, "cv2_%s", titName.Data() );
-      c2 = new TCanvas( cn2,  Form( "%s BoostWeights", titName.Data() ),
-                        1200, 1200 ); 
+      c2 = new TCanvas( cn2,  TString::Format( "%s BoostWeights", titName.Data() ),
+                        1200, 1200 );
       c2->Divide(5,5);
       Int_t ipad=1;
-      
+
       TIter keys( bdtdir->GetListOfKeys() );
       TKey *key;
       //      gDirectory->ls();
       while ( (key = (TKey*)keys.Next()) && ipad < 26) {
          TObject *obj=key->ReadObj();
-         if (obj->IsA()->InheritsFrom(TH1::Class())){   
+         if (obj->IsA()->InheritsFrom(TH1::Class())){
             TH1F *hx = (TH1F*)obj;
-            TString hhname_(Form("%s",obj->GetTitle()));
-            if (hhname_.Contains("BoostWeightsInTreeB")){ 
+            TString hhname_ = obj->GetTitle();
+            if (hhname_.Contains("BoostWeightsInTreeB")){
                c2->cd(ipad++);
                hx->SetLineColor(4);
                hx->Draw();
@@ -127,35 +127,35 @@ void TMVA::bdtcontrolplots(TString dataset, TDirectory *bdtdir ) {
             c2->Update();
          }
       }
-               
+
    }
 
    // write to file
-   TString fname = dataset+Form( "/plots/%s_ControlPlots", titName.Data() );
+   TString fname = dataset+TString::Format( "/plots/%s_ControlPlots", titName.Data() );
    TMVAGlob::imgconv( c, fname );
-   
+
    if (c2){
-      fname = dataset+Form( "/plots/%s_ControlPlots2", titName.Data() );
+      fname = dataset+TString::Format( "/plots/%s_ControlPlots2", titName.Data() );
       TMVAGlob::imgconv( c2, fname );
    }
 
    TCanvas *c3 = NULL;
    if (BoostMonitorIsDone){
       snprintf( cn2, bufferSize, "cv3_%s", titName.Data() );
-      c3 = new TCanvas( cn2,  Form( "%s Variables", titName.Data() ),
-                        1200, 1200 ); 
+      c3 = new TCanvas( cn2,  TString::Format( "%s Variables", titName.Data() ),
+                        1200, 1200 );
       c3->Divide(5,5);
       Int_t ipad=1;
-      
+
       TIter keys( bdtdir->GetListOfKeys() );
       TKey *key;
       //      gDirectory->ls();
       while ( (key = (TKey*)keys.Next()) && ipad < 26) {
          TObject *obj=key->ReadObj();
-         if (obj->IsA()->InheritsFrom(TH1::Class())){   
+         if (obj->IsA()->InheritsFrom(TH1::Class())){
             TH1F *hx = (TH1F*)obj;
-            TString hname_(Form("%s",obj->GetTitle()));
-            if (hname_.Contains("SigVar0AtTree")){ 
+            TString hname_ = obj->GetTitle();
+            if (hname_.Contains("SigVar0AtTree")){
                c3->cd(ipad++);
                hx->SetLineColor(4);
                hx->Draw();
@@ -169,7 +169,7 @@ void TMVA::bdtcontrolplots(TString dataset, TDirectory *bdtdir ) {
             c3->Update();
          }
       }
-               
+
    }
 
 

--- a/tmva/tmvagui/src/BDT_Reg.cxx
+++ b/tmva/tmvagui/src/BDT_Reg.cxx
@@ -26,17 +26,17 @@ std::vector<TControlBar*> TMVA::BDTReg_Global__cbar;
 
 TMVA::StatDialogBDTReg* TMVA::StatDialogBDTReg::fThis = 0;
 
-void TMVA::StatDialogBDTReg::SetItree() 
+void TMVA::StatDialogBDTReg::SetItree()
 {
    fItree = Int_t(fInput->GetNumber());
 }
 
-void TMVA::StatDialogBDTReg::Redraw() 
+void TMVA::StatDialogBDTReg::Redraw()
 {
    UpdateCanvases();
 }
 
-void TMVA::StatDialogBDTReg::Close() 
+void TMVA::StatDialogBDTReg::Close()
 {
    delete this;
 }
@@ -65,7 +65,7 @@ TMVA::StatDialogBDTReg::StatDialogBDTReg(TString dataset, const TGWindow* p, TSt
    // main frame
    fMain = new TGMainFrame(p, totalWidth, totalHeight, kMainFrame | kVerticalFrame);
 
-   TGLabel *sigLab = new TGLabel( fMain, Form( "Regression tree [%i-%i]",0,fNtrees-1 ) );
+   TGLabel *sigLab = new TGLabel( fMain, TString::Format( "Regression tree [%i-%i]",0,fNtrees-1 ) );
    fMain->AddFrame(sigLab, new TGLayoutHints(kLHintsLeft | kLHintsTop,5,5,5,5));
 
    fInput = new TGNumberEntry(fMain, (Double_t) fItree,5,-1,(TGNumberFormat::EStyle) 5);
@@ -80,7 +80,7 @@ TMVA::StatDialogBDTReg::StatDialogBDTReg(TString dataset, const TGWindow* p, TSt
 
    fDrawButton = new TGTextButton(fButtons,"&Draw");
    fButtons->AddFrame(fDrawButton, new TGLayoutHints(kLHintsRight | kLHintsTop,15));
-  
+
    fMain->AddFrame(fButtons,new TGLayoutHints(kLHintsLeft | kLHintsBottom,5,5,5,5));
 
    fMain->SetWindowName("Regression tree");
@@ -90,15 +90,15 @@ TMVA::StatDialogBDTReg::StatDialogBDTReg(TString dataset, const TGWindow* p, TSt
    fMain->MapWindow();
 
    fInput->Connect("ValueSet(Long_t)","TMVA::StatDialogBDTReg",this, "SetItree()");
-   
+
    // doesn't seem to exist .. gives an 'error message' and seems to work just fine without ... :)
    //   fDrawButton->Connect("Clicked()","TGNumberEntry",fInput, "ValueSet(Long_t)");
-   fDrawButton->Connect("Clicked()", "TMVA::StatDialogBDTReg", this, "Redraw()");   
+   fDrawButton->Connect("Clicked()", "TMVA::StatDialogBDTReg", this, "Redraw()");
 
    fCloseButton->Connect("Clicked()", "TMVA::StatDialogBDTReg", this, "Close()");
 }
 
-void TMVA::StatDialogBDTReg::UpdateCanvases() 
+void TMVA::StatDialogBDTReg::UpdateCanvases()
 {
    DrawTree( fItree );
 }
@@ -111,24 +111,24 @@ void TMVA::StatDialogBDTReg::GetNtrees()
          std::cout << "*** ERROR: Weight file: " << fWfile << " does not exist" << std::endl;
          return;
       }
-   
+
       TString dummy = "";
-      
+
       // read total number of trees, and check whether requested tree is in range
       Int_t nc = 0;
-      while (!dummy.Contains("NTrees")) { 
-         fin >> dummy; 
-         nc++; 
+      while (!dummy.Contains("NTrees")) {
+         fin >> dummy;
+         nc++;
          if (nc > 200) {
             std::cout << std::endl;
-            std::cout << "*** Huge problem: could not locate term \"NTrees\" in BDT weight file: " 
+            std::cout << "*** Huge problem: could not locate term \"NTrees\" in BDT weight file: "
                       << fWfile << std::endl;
             std::cout << "==> panic abort (please contact the TMVA authors)" << std::endl;
             std::cout << std::endl;
             exit(1);
          }
       }
-      fin >> dummy; 
+      fin >> dummy;
       fNtrees = dummy.ReplaceAll("\"","").Atoi();
       fin.close();
    }
@@ -153,9 +153,9 @@ void TMVA::StatDialogBDTReg::GetNtrees()
 /// recursively puts an entries in the histogram for the node and its daughters
 ///
 
-void TMVA::StatDialogBDTReg::DrawNode( TMVA::DecisionTreeNode *n, 
-                                       Double_t x, Double_t y, 
-                                       Double_t xscale,  Double_t yscale, TString * vars) 
+void TMVA::StatDialogBDTReg::DrawNode( TMVA::DecisionTreeNode *n,
+                                       Double_t x, Double_t y,
+                                       Double_t xscale,  Double_t yscale, TString * vars)
 {
    Float_t xsize=xscale*1.5;
    Float_t ysize=yscale/3;
@@ -191,9 +191,9 @@ void TMVA::StatDialogBDTReg::DrawNode( TMVA::DecisionTreeNode *n,
 
    if (n->GetNodeType() == 0){
       if (n->GetCutType()){
-         t->AddText(TString(vars[n->GetSelector()]+">"+=::Form("%5.3g",n->GetCutValue())));
+         t->AddText(vars[n->GetSelector()] + ">" + TString::Format("%5.3g",n->GetCutValue()));
       }else{
-         t->AddText(TString(vars[n->GetSelector()]+"<"+=::Form("%5.3g",n->GetCutValue())));
+         t->AddText(vars[n->GetSelector()] + "<" + TString::Format("%5.3g",n->GetCutValue()));
       }
    }
 
@@ -218,15 +218,15 @@ TMVA::DecisionTree* TMVA::StatDialogBDTReg::ReadTree( TString* &vars, Int_t itre
          return 0;
       }
       TString dummy = "";
-      
+
       if (itree >= fNtrees) {
-         std::cout << "*** ERROR: requested decision tree: " << itree 
+         std::cout << "*** ERROR: requested decision tree: " << itree
                    << ", but number of trained trees only: " << fNtrees << std::endl;
          delete d;
          d = nullptr;
          return 0;
       }
-      
+
       // file header with name
       while (!dummy.Contains("#VAR")) fin >> dummy;
       fin >> dummy >> dummy >> dummy; // the rest of header line
@@ -234,12 +234,12 @@ TMVA::DecisionTree* TMVA::StatDialogBDTReg::ReadTree( TString* &vars, Int_t itre
       // number of variables
       Int_t nVars;
       fin >> dummy >> nVars;
-      
+
       // variable mins and maxes
       vars = new TString[nVars+1];
       for (Int_t i = 0; i < nVars; i++) fin >> vars[i] >> dummy >> dummy >> dummy >> dummy;
       vars[nVars]="FisherCrit";
-      
+
       char buffer[20];
       char line[256];
       snprintf(buffer, 20, "Tree %d",itree);
@@ -250,12 +250,12 @@ TMVA::DecisionTree* TMVA::StatDialogBDTReg::ReadTree( TString* &vars, Int_t itre
       }
 
       d->Read(fin);
-      
+
       fin.close();
    }
    else{
       if (itree >= fNtrees) {
-         std::cout << "*** ERROR: requested decision tree: " << itree 
+         std::cout << "*** ERROR: requested decision tree: " << itree
                    << ", but number of trained trees only: " << fNtrees << std::endl;
          delete d;
          d = nullptr;
@@ -269,7 +269,7 @@ TMVA::DecisionTree* TMVA::StatDialogBDTReg::ReadTree( TString* &vars, Int_t itre
          TString nodeName = TString( TMVA::gTools().xmlengine().GetNodeName(ch) );
          if(nodeName=="Variables"){
             TMVA::gTools().ReadAttr( ch, "NVar", nVars);
-            vars = new TString[nVars+1]; 
+            vars = new TString[nVars+1];
             void* varnode =  TMVA::gTools().xmlengine().GetChild(ch);
             for (Int_t i = 0; i < nVars; i++){
                TMVA::gTools().ReadAttr( varnode, "Expression", vars[i]);
@@ -291,7 +291,7 @@ TMVA::DecisionTree* TMVA::StatDialogBDTReg::ReadTree( TString* &vars, Int_t itre
 
 void TMVA::StatDialogBDTReg::DrawTree( Int_t itree )
 {
-   TString *vars;   
+   TString *vars;
 
    TMVA::DecisionTree* d = ReadTree( vars, itree );
    if (d == 0) return;
@@ -304,18 +304,18 @@ void TMVA::StatDialogBDTReg::DrawTree( Int_t itree )
    TStyle* TMVAStyle   = gROOT->GetStyle("Plain"); // our style is based on Plain
    Int_t   canvasColor = TMVAStyle->GetCanvasColor(); // backup
 
-   TString cbuffer = Form( "Reading weight file: %s", fWfile.Data() );
-   TString tbuffer = Form( "Regression Tree no.: %d", itree );
-   if (!fCanvas) fCanvas = new TCanvas( "c1", cbuffer, 200, 0, 1000, 600 ); 
+   TString cbuffer = TString::Format( "Reading weight file: %s", fWfile.Data() );
+   TString tbuffer = TString::Format( "Regression Tree no.: %d", itree );
+   if (!fCanvas) fCanvas = new TCanvas( "c1", cbuffer, 200, 0, 1000, 600 );
    else          fCanvas->Clear();
-   fCanvas->Draw();   
+   fCanvas->Draw();
    DrawNode( (TMVA::DecisionTreeNode*)d->GetRoot(), 0.5, 1.-0.5*ystep, 0.25, ystep ,vars);
-  
+
    // make the legend
    Double_t yup=0.99;
    Double_t ydown=yup-ystep/2.5;
    Double_t dy= ystep/2.5 * 0.2;
- 
+
    TPaveText *whichTree = new TPaveText(0.85,ydown,0.98,yup, "NDC");
    whichTree->SetBorderSize(1);
    whichTree->SetFillStyle(1001);
@@ -353,13 +353,13 @@ void TMVA::StatDialogBDTReg::DrawTree( Int_t itree )
      backgroundleaf->Draw();
    */
    fCanvas->Update();
-   TString fname = fDataset+Form("/plots/%s_%i", fMethName.Data(), itree );
+   TString fname = fDataset + TString::Format("/plots/%s_%i", fMethName.Data(), itree);
    std::cout << "--- Creating image: " << fname << std::endl;
-   TMVAGlob::imgconv( fCanvas, fname );   
+   TMVAGlob::imgconv( fCanvas, fname );
 
    TMVAStyle->SetCanvasColor( canvasColor );
-}   
-      
+}
+
 // ========================================================================================
 
 // intermediate GUI
@@ -368,10 +368,10 @@ void TMVA::BDT_Reg(TString dataset, const TString& fin )
    // --- read the available BDT weight files
 
    // destroy all open cavases
-   TMVAGlob::DestroyCanvases(); 
+   TMVAGlob::DestroyCanvases();
 
    // checks if file with name "fin" is already open, and if not opens one
-   TFile* file = TMVAGlob::OpenFile( fin );  
+   TFile* file = TMVAGlob::OpenFile( fin );
 
    TDirectory* dir = file->GetDirectory(dataset.Data())->GetDirectory( "Method_BDT" );
    if (!dir) {
@@ -381,14 +381,14 @@ void TMVA::BDT_Reg(TString dataset, const TString& fin )
 
    // read all directories
    TIter next( dir->GetListOfKeys() );
-   TKey *key(0);   
-   std::vector<TString> methname;   
-   std::vector<TString> path;   
-   std::vector<TString> wfile;   
+   TKey *key(0);
+   std::vector<TString> methname;
+   std::vector<TString> path;
+   std::vector<TString> wfile;
    while ((key = (TKey*)next())) {
       TDirectory* mdir = dir->GetDirectory( key->GetName() );
       if (!mdir) {
-         std::cout << "*** Error in macro \"BDT_Reg.C\": cannot find sub-directory: " << key->GetName() 
+         std::cout << "*** Error in macro \"BDT_Reg.C\": cannot find sub-directory: " << key->GetName()
                    << " in directory: " << dir->GetName() << std::endl;
          return;
       }
@@ -415,15 +415,15 @@ void TMVA::BDT_Reg(TString dataset, const TString& fin )
       TString fname = path[im];
       if (fname[fname.Length()-1] != '/') fname += "/";
       fname += wfile[im];
-      TString macro = Form( "TMVA::BDT_Reg(\"%s\",0,\"%s\",\"%s\")",dataset.Data(), fname.Data(), methname[im].Data() );
+      TString macro = TString::Format( "TMVA::BDT_Reg(\"%s\",0,\"%s\",\"%s\")",dataset.Data(), fname.Data(), methname[im].Data() );
       cbar->AddButton( fname, macro, "Plot decision trees from this weight file", "button" );
    }
 
-   // set the style 
+   // set the style
    cbar->SetTextColor("blue");
 
    // draw
-   cbar->Show();   
+   cbar->Show();
 }
 
 void TMVA::BDTReg_DeleteTBar(int i)
@@ -438,11 +438,11 @@ void TMVA::BDTReg_DeleteTBar(int i)
 
 // input: - No. of tree
 //        - the weight file from which the tree is read
-void TMVA::BDT_Reg(TString dataset, Int_t itree, TString wfile , TString methName, Bool_t useTMVAStyle  ) 
+void TMVA::BDT_Reg(TString dataset, Int_t itree, TString wfile , TString methName, Bool_t useTMVAStyle  )
 {
    // destroy possibly existing dialog windows and/or canvases
    StatDialogBDTReg::Delete();
-   TMVAGlob::DestroyCanvases(); 
+   TMVAGlob::DestroyCanvases();
    if(wfile=="")
       wfile = dataset+"/weights/TMVARegression_BDT.weights.xml";
 

--- a/tmva/tmvagui/src/BoostControlPlots.cxx
+++ b/tmva/tmvagui/src/BoostControlPlots.cxx
@@ -44,7 +44,7 @@ void TMVA::boostcontrolplots(TString dataset, TDirectory *boostdir ) {
    char cn[100];
    const TString titName = boostdir->GetName();
    snprintf( cn, 100, "cv_%s", titName.Data() );
-   TCanvas *c = new TCanvas( cn,  Form( "%s Control Plots", titName.Data() ),
+   TCanvas *c = new TCanvas( cn,  TString::Format( "%s Control Plots", titName.Data() ),
                              width, height ); 
    c->Divide(2,4);
 
@@ -132,7 +132,7 @@ void TMVA::boostcontrolplots(TString dataset, TDirectory *boostdir ) {
    }
 
    // write to file
-   TString fname = dataset+Form( "/plots/%s_ControlPlots", titName.Data() );
+   TString fname = dataset+TString::Format( "/plots/%s_ControlPlots", titName.Data() );
    TMVAGlob::imgconv( c, fname );
 
 }

--- a/tmva/tmvagui/src/CorrGui.cxx
+++ b/tmva/tmvagui/src/CorrGui.cxx
@@ -83,9 +83,9 @@ void TMVA::CorrGui(TString dataset,  TString fin, TString dirName , TString titl
   
    for (Int_t ic=0;ic<it;ic++) {    
       cbar->AddButton( (Var[ic].Contains("_target") ? 
-                        Form( "      Target: %s      ", Var[ic].ReplaceAll("_target","").Data()) : 
-                        Form( "      Variable: %s      ", Var[ic].Data())),
-                       Form( "TMVA::correlationscatters(\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",%i)",dataset.Data(),fin.Data(), Var[ic].Data(), dirName.Data(), title.Data(), (Int_t)isRegression ),
+                        TString::Format( "      Target: %s      ", Var[ic].ReplaceAll("_target","").Data()) : 
+                        TString::Format( "      Variable: %s      ", Var[ic].Data())),
+                       TString::Format( "TMVA::correlationscatters(\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",%i)",dataset.Data(),fin.Data(), Var[ic].Data(), dirName.Data(), title.Data(), (Int_t)isRegression ),
                        buttonType );
    }
 

--- a/tmva/tmvagui/src/CorrGuiMultiClass.cxx
+++ b/tmva/tmvagui/src/CorrGuiMultiClass.cxx
@@ -49,8 +49,8 @@ void TMVA::CorrGuiMultiClass(TString dataset,  TString fin , TString dirName , T
 
    std::vector<TString>::const_iterator iter = names.begin();
    for (; iter != names.end(); ++iter) {    
-      cbar->AddButton( Form( "      Variable: %s      ", (*iter).Data()),
-                       Form( "TMVA::correlationscattersMultiClass(\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",%i)",
+      cbar->AddButton( TString::Format( "      Variable: %s      ", (*iter).Data()),
+                       TString::Format( "TMVA::correlationscattersMultiClass(\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",%i)",
                              dataset.Data(), fin.Data(), (*iter).Data(), dirName.Data(), title.Data(), (Int_t)isRegression ),
                        buttonType );
    }

--- a/tmva/tmvagui/src/MovieMaker.cxx
+++ b/tmva/tmvagui/src/MovieMaker.cxx
@@ -51,7 +51,7 @@ void TMVA::DrawNetworkMovie(TString dataset, TFile* file, const TString& methodT
       epochList.push_back( es );
 
       // create bulk file name
-      TString bulkname  = Form( "epochmonitoring___epoch_%s_weights_hist", es.Data() );
+      TString bulkname  = TString::Format( "epochmonitoring___epoch_%s_weights_hist", es.Data() );
 
       // draw the network
       if (ic <= 60) draw_network(dataset, file, epochDir, bulkname, kTRUE, es );
@@ -106,11 +106,11 @@ void TMVA::DrawMLPoutputMovie(TString dataset, TFile* file, const TString& metho
 
       // create canvas
       countCanvas++;
-      TString ctitle = Form("TMVA response %s",methodTitle.Data());
-      c = new TCanvas( Form("canvas%d", countCanvas), ctitle, 0, 0, width, (Int_t)width*0.78 );
+      TString ctitle = TString::Format("TMVA response %s",methodTitle.Data());
+      c = new TCanvas( TString::Format("canvas%d", countCanvas), ctitle, 0, 0, width, (Int_t)width*0.78 );
 
       TH1F* sig = (TH1F*)titkeyTit->ReadObj();
-      sig->SetTitle( Form("TMVA response for classifier: %s", methodTitle.Data()) );
+      sig->SetTitle( TString::Format("TMVA response for classifier: %s", methodTitle.Data()) );
 
       TString dataType = (name.Contains("_train_") ? "(training sample)" : "(test sample)");
 
@@ -186,7 +186,7 @@ void TMVA::DrawMLPoutputMovie(TString dataset, TFile* file, const TString& metho
       t.SetTextSize( 0.04 );
       t.SetTextColor( 1 );
       t.SetTextAlign( 31 );
-      t.DrawTextNDC( 1 - c->GetRightMargin(), 1 - c->GetTopMargin() + 0.015, Form( "Epoch: %i", epoch) );
+      t.DrawTextNDC( 1 - c->GetRightMargin(), 1 - c->GetTopMargin() + 0.015, TString::Format( "Epoch: %i", epoch) );
 
       // overlay signal and background histograms
       sig->Draw("samehist");

--- a/tmva/tmvagui/src/PlotFoams.cxx
+++ b/tmva/tmvagui/src/PlotFoams.cxx
@@ -27,15 +27,15 @@ void TMVA::PlotFoams( TString fileName,
    TControlBar* cbar = new TControlBar( "vertical", "Choose cell value for plot:", 50, 50 );
    if ((gDirectory->Get("SignalFoam") && gDirectory->Get("BgFoam")) ||
        gDirectory->Get("MultiTargetRegressionFoam")) {
-      TString macro = Form( "TMVA::Plot(\"%s\",%s, \"Event density\", %s)",
+      TString macro = TString::Format( "TMVA::Plot(\"%s\",%s, \"Event density\", %s)",
                             fileName.Data(), "TMVA::kValueDensity", (useTMVAStyle ? "kTRUE" : "kFALSE") );
       cbar->AddButton( "Event density", macro, "Plot event density", "button" );
    } else if (gDirectory->Get("DiscrFoam") || gDirectory->Get("MultiClassFoam0")){
-      TString macro = Form( "TMVA::Plot(\"%s\", %s, \"Discriminator\", %s)",
+      TString macro = TString::Format( "TMVA::Plot(\"%s\", %s, \"Discriminator\", %s)",
                             fileName.Data(), "TMVA::kValue", (useTMVAStyle ? "kTRUE" : "kFALSE") );
       cbar->AddButton( "Discriminator", macro, "Plot discriminator", "button" );
    } else if (gDirectory->Get("MonoTargetRegressionFoam")){
-      TString macro = Form( "TMVA::Plot(\"%s\", %s, \"Target\", %s)",
+      TString macro = TString::Format( "TMVA::Plot(\"%s\", %s, \"Target\", %s)",
                             fileName.Data(), "TMVA::kValue",  (useTMVAStyle ? "kTRUE" : "kFALSE") );
       cbar->AddButton( "Target", macro, "Plot target", "button" );
    } else {
@@ -43,13 +43,13 @@ void TMVA::PlotFoams( TString fileName,
       return;
    }
 
-   TString macro_rms = Form( "TMVA::Plot(\"%s\", %s, \"Variance\", %s)",
+   TString macro_rms = TString::Format( "TMVA::Plot(\"%s\", %s, \"Variance\", %s)",
                              fileName.Data(), "TMVA::kRms", (useTMVAStyle ? "kTRUE" : "kFALSE") );
    cbar->AddButton( "Variance", macro_rms, "Plot variance", "button" );
-   TString macro_rms_ov_mean = Form( "TMVA::Plot(\"%s\", %s, \"Variance/Mean\", %s)",
+   TString macro_rms_ov_mean = TString::Format( "TMVA::Plot(\"%s\", %s, \"Variance/Mean\", %s)",
                                      fileName.Data(), "TMVA::kRmsOvMean", (useTMVAStyle ? "kTRUE" : "kFALSE") );
    cbar->AddButton( "Variance/Mean", macro_rms_ov_mean, "Plot variance over mean", "button" );
-   TString macro_cell_tree = Form( "TMVA::PlotCellTree(\"%s\", \"Cell tree\", %s)",
+   TString macro_cell_tree = TString::Format( "TMVA::PlotCellTree(\"%s\", \"Cell tree\", %s)",
                                    fileName.Data(), (useTMVAStyle ? "kTRUE" : "kFALSE") );
    cbar->AddButton( "Cell tree", macro_cell_tree, "Plot cell tree", "button" );
 
@@ -82,8 +82,8 @@ void TMVA::Plot(TString fileName, TMVA::ECellValue cv, TString cv_long, bool use
    } else if (MultiClassFoam0) {
       UInt_t cls = 0;
       TMVA::PDEFoam *fm = NULL;
-      while ((fm = (TMVA::PDEFoam*) gDirectory->Get(Form("MultiClassFoam%u", cls)))) {
-         foam_list.Add(new TPair(fm, new TObjString(Form("Discriminator Foam %u",cls))));
+      while ((fm = (TMVA::PDEFoam*) gDirectory->Get(TString::Format("MultiClassFoam%u", cls)))) {
+         foam_list.Add(new TPair(fm, new TObjString(TString::Format("Discriminator Foam %u",cls))));
          cls++;
       }
    } else if (MonoTargetRegressionFoam) {
@@ -131,21 +131,21 @@ void TMVA::Plot1DimFoams(TList& foam_list, TMVA::ECellValue cell_value,
 
    // loop over all foams and draw the histogram
    TListIter it(&foam_list);
-   TPair* fm_pair = NULL;    // the (foam, caption) pair
+   TPair* fm_pair = nullptr;    // the (foam, caption) pair
    while ((fm_pair = (TPair*) it())) {
       TMVA::PDEFoam* foam = (TMVA::PDEFoam*) fm_pair->Key();
       if (!foam) continue;
       TString foam_caption(((TObjString*) fm_pair->Value())->String());
       TString variable_name(foam->GetVariableName(0)->String());
 
-      canvas = new TCanvas(Form("canvas_%p",foam),
+      canvas = new TCanvas(TString::Format("canvas_%p",foam),
                            "1-dimensional PDEFoam", 400, 400);
 
       projection = foam->Draw1Dim(cell_value, 100, kernel);
       projection->SetTitle(cell_value_description + " of " + foam_caption
                            + ";" + variable_name);
       projection->Draw();
-      projection->SetDirectory(0);
+      projection->SetDirectory(nullptr);
 
       canvas->Update();
    }
@@ -157,8 +157,8 @@ void TMVA::PlotNDimFoams(TList& foam_list, TMVA::ECellValue cell_value,
                          TMVA::PDEFoamKernelBase* kernel)
 {
    // draw 2 dimensional PDEFoam projections
-   TCanvas* canvas = NULL;
-   TH2D* projection = NULL;
+   TCanvas* canvas = nullptr;
+   TH2D* projection = nullptr;
 
    // loop over all foams and draw the projection
    TListIter it(&foam_list);
@@ -173,12 +173,12 @@ void TMVA::PlotNDimFoams(TList& foam_list, TMVA::ECellValue cell_value,
       for (Int_t i = 0; i < kDim; ++i) {
          for (Int_t k = i + 1; k < kDim; ++k) {
 
-            canvas = new TCanvas(Form("canvas_%p_%i:%i", foam, i, k),
-                                 Form("Foam projections %i:%i", i, k),
+            canvas = new TCanvas(TString::Format("canvas_%p_%i:%i", foam, i, k),
+                                 TString::Format("Foam projections %i:%i", i, k),
                                  (Int_t)(400/(1.-0.2)), 400);
             canvas->SetRightMargin(0.2);
 
-            TString title = Form("%s of %s: Projection %s:%s;%s;%s",
+            TString title = TString::Format("%s of %s: Projection %s:%s;%s;%s",
                                  cell_value_description.Data(),
                                  foam_caption.Data(),
                                  foam->GetVariableName(i)->String().Data(),
@@ -189,7 +189,7 @@ void TMVA::PlotNDimFoams(TList& foam_list, TMVA::ECellValue cell_value,
             projection = foam->Project2(i, k, cell_value, kernel);
             projection->SetTitle(title);
             projection->Draw("COLZ");
-            projection->SetDirectory(0);
+            projection->SetDirectory(nullptr);
 
             canvas->Update();
          }
@@ -209,8 +209,8 @@ void TMVA::PlotCellTree(TString fileName, TString cv_long, bool useTMVAStyle )
 
    // find foams
    TListIter foamIter(gDirectory->GetListOfKeys());
-   TKey *foam_key = NULL; // the foam key
-   TCanvas *canv = NULL;  // the canvas
+   TKey *foam_key = nullptr; // the foam key
+   TCanvas *canv = nullptr;  // the canvas
    while ((foam_key = (TKey*) foamIter())) {
       TString name(foam_key->GetName());
       TString class_name(foam_key->GetClassName());
@@ -220,8 +220,8 @@ void TMVA::PlotCellTree(TString fileName, TString cv_long, bool useTMVAStyle )
 
       // read the foam
       TMVA::PDEFoam *foam = (TMVA::PDEFoam*) foam_key->ReadObj();
-      canv = new TCanvas(Form("canvas_%s",name.Data()),
-                         Form("%s of %s",cv_long.Data(),name.Data()), 640, 480);
+      canv = new TCanvas(TString::Format("canvas_%s",name.Data()),
+                         TString::Format("%s of %s",cv_long.Data(),name.Data()), 640, 480);
       canv->cd();
       // get cell tree depth
       const UInt_t   depth = foam->GetRootCell()->GetTreeDepth();
@@ -260,12 +260,12 @@ void TMVA::DrawCell( TMVA::PDEFoamCell *cell, TMVA::PDEFoam *foam,
    t->SetFillStyle(1);
 
    // draw all cell elements
-   t->AddText( Form("Intg=%.5f", cell->GetIntg()) );
-   t->AddText( Form("Var=%.5f", cell->GetDriv()) );
+   t->AddText( TString::Format("Intg=%.5f", cell->GetIntg()) );
+   t->AddText( TString::Format("Var=%.5f", cell->GetDriv()) );
    TVectorD *vec = (TVectorD*) cell->GetElement();
    if (vec) {
       for (Int_t i = 0; i < vec->GetNrows(); ++i)
-         t->AddText( Form("E[%i]=%.5f", i, (*vec)[i]) );
+         t->AddText( TString::Format("E[%i]=%.5f", i, (*vec)[i]) );
    }
 
    if (cell->GetStat() != 1) {
@@ -278,8 +278,8 @@ void TMVA::DrawCell( TMVA::PDEFoamCell *cell, TMVA::PDEFoam *foam,
       cell->GetHcub(cellPosi, cellSize);
       Int_t    kBest = cell->GetBest(); // best division variable
       Double_t xBest = cell->GetXdiv(); // best division point
-      t->AddText( Form("dim=%i", kBest) );
-      t->AddText( Form("cut=%.5g", foam->VarTransformInvers(kBest,cellPosi[kBest] + xBest*cellSize[kBest])) );
+      t->AddText( TString::Format("dim=%i", kBest) );
+      t->AddText( TString::Format("cut=%.5g", foam->VarTransformInvers(kBest,cellPosi[kBest] + xBest*cellSize[kBest])) );
    } else {
       t->SetFillColor( TColor::GetColor("#DD0033") );
       t->SetTextColor( TColor::GetColor("#FFFFFF") );

--- a/tmva/tmvagui/src/TMVAGui.cxx
+++ b/tmva/tmvagui/src/TMVAGui.cxx
@@ -98,7 +98,7 @@ void TMVA::TMVAGui( const char* fName  , TString dataset)
             {
                TKey *key=(TKey*)file->GetListOfKeys()->At(i);
                dataset=key->GetName();
-               bar->AddButton(dataset.Data(),Form("TMVA::TMVAGui(\"%s\",\"%s\")",fName,dataset.Data()),dataset.Data());
+               bar->AddButton(dataset.Data(), TString::Format("TMVA::TMVAGui(\"%s\",\"%s\")",fName,dataset.Data()),dataset.Data());
             }
 
          bar->AddSeparator();
@@ -137,13 +137,13 @@ void TMVA::TMVAGui( const char* fName  , TString dataset)
    char ch = 'a';
    while ((str = (TObjString*)it())) {
       TString tmp   = str->GetString();
-      TString title = Form( "Input variables '%s'-transformed (training sample)",
+      TString title = TString::Format( "Input variables '%s'-transformed (training sample)",
                             tmp.ReplaceAll("InputVariables_","").Data() );
       if (tmp.Contains( "Id" )) title = "Input variables (training sample)";
       ActionButton( cbar,
-                    Form( "(%i%c) %s", ic, ch++, title.Data() ),
-                    Form( "TMVA::variables(\"%s\",\"%s\",\"%s\",\"%s\")",dataset.Data(), fName, str->GetString().Data(), title.Data() ),
-                    Form( "Plots all '%s'-transformed input variables (macro variables(...))", str->GetString().Data() ),
+                    TString::Format( "(%i%c) %s", ic, ch++, title.Data() ),
+                    TString::Format( "TMVA::variables(\"%s\",\"%s\",\"%s\",\"%s\")",dataset.Data(), fName, str->GetString().Data(), title.Data() ),
+                    TString::Format( "Plots all '%s'-transformed input variables (macro variables(...))", str->GetString().Data() ),
                     buttonType, str->GetString() );
    }
    ic++;
@@ -152,154 +152,154 @@ void TMVA::TMVAGui( const char* fName  , TString dataset)
    it.Reset(); ch = 'a';
    while ((str = (TObjString*)it())) {
       TString tmp   = str->GetString();
-      TString title = Form( "Input variable correlations '%s'-transformed (scatter profiles)",
+      TString title = TString::Format( "Input variable correlations '%s'-transformed (scatter profiles)",
                             tmp.ReplaceAll("InputVariables_","").Data() );
       if (tmp.Contains( "Id" )) title = "Input variable correlations (scatter profiles)";
       ActionButton( cbar,
-                    Form( "(%i%c) %s", ic, ch++, title.Data() ),
-                    Form( "TMVA::CorrGui(\"%s\",\"%s\",\"%s\",\"%s\")",dataset.Data(), fName, str->GetString().Data(), title.Data() ),
-                    Form( "Plots all correlation profiles between '%s'-transformed input variables (macro CorrGui(...))",
+                    TString::Format( "(%i%c) %s", ic, ch++, title.Data() ),
+                    TString::Format( "TMVA::CorrGui(\"%s\",\"%s\",\"%s\",\"%s\")",dataset.Data(), fName, str->GetString().Data(), title.Data() ),
+                    TString::Format( "Plots all correlation profiles between '%s'-transformed input variables (macro CorrGui(...))",
                           str->GetString().Data() ),
                     buttonType, str->GetString() );
    }
 
    TString title;
    // coefficients
-   title =Form( "(%i) Input Variable Linear Correlation Coefficients", ++ic );
+   title = TString::Format( "(%i) Input Variable Linear Correlation Coefficients", ++ic );
    ActionButton( cbar,
                  title,
-                 Form( "TMVA::correlations(\"%s\",\"%s\")",dataset.Data(), fName ),
+                 TString::Format( "TMVA::correlations(\"%s\",\"%s\")",dataset.Data(), fName ),
                  "Plots signal and background correlation summaries for all input variables (macro correlations.C)",
                  buttonType );
 
-   title =Form( "(%ia) Classifier Output Distributions (test sample)", ++ic );
+   title =TString::Format( "(%ia) Classifier Output Distributions (test sample)", ++ic );
    ActionButton( cbar,
                  title,
-                 Form( "TMVA::mvas(\"%s\",\"%s\",  TMVA::kMVAType)",dataset.Data(), fName ),
+                 TString::Format( "TMVA::mvas(\"%s\",\"%s\",  TMVA::kMVAType)",dataset.Data(), fName ),
                  "Plots the output of each classifier for the test data (macro mvas(...,0))",
                  buttonType, defaultRequiredClassifier );
 
-   title =Form( "(%ib) Classifier Output Distributions (test and training samples superimposed)", ic );
+   title =TString::Format( "(%ib) Classifier Output Distributions (test and training samples superimposed)", ic );
    ActionButton( cbar,
                  title,
-                 Form( "TMVA::mvas(\"%s\",\"%s\",  TMVA::kCompareType )",dataset.Data(), fName),
+                 TString::Format( "TMVA::mvas(\"%s\",\"%s\",  TMVA::kCompareType )",dataset.Data(), fName),
                  "Plots the output of each classifier for the test (histograms) and training (dots) data (macro mvas(...,3))",
                  buttonType, defaultRequiredClassifier );
 
-   title = Form( "(%ic) Classifier Probability Distributions (test sample)", ic );
+   title = TString::Format( "(%ic) Classifier Probability Distributions (test sample)", ic );
    ActionButton( cbar,
                  title,
-                 Form( "TMVA::mvas(\"%s\",\"%s\", TMVA::kProbaType)",dataset.Data(), fName ),
+                 TString::Format( "TMVA::mvas(\"%s\",\"%s\", TMVA::kProbaType)",dataset.Data(), fName ),
                  "Plots the probability of each classifier for the test data (macro mvas(...,1))",
                  buttonType, defaultRequiredClassifier );
 
-   title =Form( "(%id) Classifier Rarity Distributions (test sample)", ic );
+   title =TString::Format( "(%id) Classifier Rarity Distributions (test sample)", ic );
    ActionButton( cbar,
                  title,
-                 Form( "TMVA::mvas(\"%s\",\"%s\", TMVA::kRarityType)",dataset.Data(), fName ),
+                 TString::Format( "TMVA::mvas(\"%s\",\"%s\", TMVA::kRarityType)",dataset.Data(), fName ),
                  "Plots the Rarity of each classifier for the test data (macro mvas(...,2)) - background distribution should be uniform",
                  buttonType, defaultRequiredClassifier );
 
-   title =Form( "(%ia) Classifier Cut Efficiencies", ++ic );
+   title =TString::Format( "(%ia) Classifier Cut Efficiencies", ++ic );
    ActionButton( cbar,
                  title,
-                 Form( "TMVA::mvaeffs(\"%s\",\"%s\")",dataset.Data(), fName ),
+                 TString::Format( "TMVA::mvaeffs(\"%s\",\"%s\")",dataset.Data(), fName ),
                  "Plots signal and background efficiencies versus cut on classifier output (macro mvaeffs.cxx)",
                  buttonType, defaultRequiredClassifier );
 
-   title = Form( "(%ib) Classifier Background Rejection vs Signal Efficiency (ROC curve)", ic );
+   title = TString::Format( "(%ib) Classifier Background Rejection vs Signal Efficiency (ROC curve)", ic );
    ActionButton( cbar,
                  title,
-                 Form( "TMVA::efficiencies(\"%s\",\"%s\")",dataset.Data(), fName ),
+                 TString::Format( "TMVA::efficiencies(\"%s\",\"%s\")",dataset.Data(), fName ),
                  "Plots background rejection vs signal efficiencies (macro efficiencies.cxx) [\"ROC\" stands for \"Receiver Operation Characteristics\"]",
                  buttonType, defaultRequiredClassifier );
 
-   title = Form( "(%ib) Classifier 1/(Backgr. Efficiency) vs Signal Efficiency (ROC curve)", ic );
+   title = TString::Format( "(%ib) Classifier 1/(Backgr. Efficiency) vs Signal Efficiency (ROC curve)", ic );
    ActionButton( cbar,
                  title,
-                 Form( "TMVA::efficiencies(\"%s\",\"%s\",%d)",dataset.Data(), fName, 3 ),
+                 TString::Format( "TMVA::efficiencies(\"%s\",\"%s\",%d)",dataset.Data(), fName, 3 ),
                  "Plots 1/(background eff.)  vs signal efficiencies (macro efficiencies.cxx) [\"ROC\" stands for \"Receiver Operation Characteristics\"]",
                  buttonType, defaultRequiredClassifier );
 
-   title = Form( "(%i) Parallel Coordinates (requires ROOT-version >= 5.17)", ++ic );
+   title = TString::Format( "(%i) Parallel Coordinates (requires ROOT-version >= 5.17)", ++ic );
    ActionButton( cbar,
                  title,
-                 Form( "TMVA::paracoor(\"%s\",\"%s\")",dataset.Data(), fName ),
+                 TString::Format( "TMVA::paracoor(\"%s\",\"%s\")",dataset.Data(), fName ),
                  "Plots parallel coordinates for classifiers and input variables (macro paracoor.cxx, requires ROOT >= 5.17)",
                  buttonType, defaultRequiredClassifier );
 
-   title =Form( "(%i) PDFs of Classifiers (requires \"CreateMVAPdfs\" option set)", ++ic );
+   title =TString::Format( "(%i) PDFs of Classifiers (requires \"CreateMVAPdfs\" option set)", ++ic );
    ActionButton( cbar,
                  title,
-                 Form( "TMVA::probas(\"%s\",\"%s\")",dataset.Data(), fName ),
+                 TString::Format( "TMVA::probas(\"%s\",\"%s\")",dataset.Data(), fName ),
                  "Plots the PDFs of the classifier output distributions for signal and background - if requested (macro probas.cxx)",
                  buttonType, defaultRequiredClassifier );
 
-   title = Form( "(%i) Training History", ++ic );
+   title = TString::Format( "(%i) Training History", ++ic );
    ActionButton( cbar,
                  title,
-                 Form( "TMVA::training_history(\"%s\",\"%s\")",dataset.Data(), fName ),
+                 TString::Format( "TMVA::training_history(\"%s\",\"%s\")",dataset.Data(), fName ),
                  "Plot training history of classifiers with multiple passed (eg Neural Networks) ",
                  buttonType, defaultRequiredClassifier );
 
-   title = Form( "(%i) Likelihood Reference Distributiuons", ++ic);
+   title = TString::Format( "(%i) Likelihood Reference Distributiuons", ++ic);
    ActionButton( cbar,
                  title,
-                 Form( "TMVA::likelihoodrefs(\"%s\",\"%s\")",dataset.Data(), fName ),
+                 TString::Format( "TMVA::likelihoodrefs(\"%s\",\"%s\")",dataset.Data(), fName ),
                  "Plots to verify the likelihood reference distributions (macro likelihoodrefs.cxx)",
                  buttonType, "Likelihood" );
 
-   title = Form( "(%ia) Network Architecture (MLP)", ++ic );
-   TString call = Form( "TMVA::network(\"%s\",\"%s\")", dataset.Data(),fName );
+   title = TString::Format( "(%ia) Network Architecture (MLP)", ++ic );
+   TString call = TString::Format( "TMVA::network(\"%s\",\"%s\")", dataset.Data(),fName );
    ActionButton( cbar,
                  title,
                  call,
                  "Plots the MLP weights (macro network.cxx)",
                  buttonType, "MLP" );
 
-   title = Form( "(%ib) Network Convergence Test (MLP)", ic );
+   title = TString::Format( "(%ib) Network Convergence Test (MLP)", ic );
    ActionButton( cbar,
                  title,
-                 Form( "TMVA::annconvergencetest(\"%s\",\"%s\")",dataset.Data(), fName ),
+                 TString::Format( "TMVA::annconvergencetest(\"%s\",\"%s\")",dataset.Data(), fName ),
                  "Plots error estimator versus training epoch for training and test samples (macro annconvergencetest.C)",
                  buttonType, "MLP" );
 
-   title = Form( "(%i) Decision Trees (BDT)", ++ic );
+   title = TString::Format( "(%i) Decision Trees (BDT)", ++ic );
    ActionButton( cbar,
                  title,
-                 Form( "TMVA::BDT(\"%s\",\"%s\")",dataset.Data() , fName ),
+                 TString::Format( "TMVA::BDT(\"%s\",\"%s\")",dataset.Data() , fName ),
                  "Plots the Decision Trees trained by BDT algorithms (macro BDT(itree,...))",
                  buttonType, "BDT" );
 
-   title = Form( "(%i) Decision Tree Control Plots (BDT)", ++ic );
+   title = TString::Format( "(%i) Decision Tree Control Plots (BDT)", ++ic );
    ActionButton( cbar,
                  title,
-                 Form( "TMVA::BDTControlPlots(\"%s\",\"%s\")",dataset.Data() , fName ),
+                 TString::Format( "TMVA::BDTControlPlots(\"%s\",\"%s\")",dataset.Data() , fName ),
                  "Plots to monitor boosting and pruning of decision trees (macro BDTControlPlots.cxx)",
                  buttonType, "BDT" );
    //    ActionButton( cbar,
-   //                  Form( "(%i) Rule Ensemble Importance Plots (RuleFit)", ++ic ),
-   //                  Form( "TMVA::rulevis(\"%s\",0)", fName ),
+   //                  TString::Format( "(%i) Rule Ensemble Importance Plots (RuleFit)", ++ic ),
+   //                  TString::Format( "TMVA::rulevis(\"%s\",0)", fName ),
    //                  "Plots all input variables with rule ensemble weights, including linear terms (macro rulevis.cxx)",
    //                  buttonType, "RuleFit" );
 
-   title = Form( "(%i) Plot Foams (PDEFoam)", ++ic );
+   title = TString::Format( "(%i) Plot Foams (PDEFoam)", ++ic );
    ActionButton( cbar,
                  title,
-                 Form("TMVA::PlotFoams(\"%s/weights/TMVAClassification_PDEFoam.weights_foams.root\")",dataset.Data()),
+                 TString::Format("TMVA::PlotFoams(\"%s/weights/TMVAClassification_PDEFoam.weights_foams.root\")",dataset.Data()),
                  "Plot Foams (macro PlotFoams.cxx)",
                  buttonType, "PDEFoam" );
 
-   title = Form( "(%i) General Boost Control Plots", ++ic );
+   title = TString::Format( "(%i) General Boost Control Plots", ++ic );
    ActionButton( cbar,
                  title,
-                 Form( "TMVA::BoostControlPlots(\"%s\",\"%s\")",dataset.Data() , fName ),
+                 TString::Format( "TMVA::BoostControlPlots(\"%s\",\"%s\")",dataset.Data() , fName ),
                  "Plots to monitor boosting of general classifiers (macro BoostControlPlots)",
                  buttonType, "Boost" );
 
    cbar->AddSeparator();
 
-   cbar->AddButton( Form( "(%i) Quit", ++ic ),   ".q", "Quit", buttonType );
+   cbar->AddButton( TString::Format( "(%i) Quit", ++ic ),   ".q", "Quit", buttonType );
 
    // set the style
    cbar->SetTextColor("black");

--- a/tmva/tmvagui/src/TMVAMultiClassGui.cxx
+++ b/tmva/tmvagui/src/TMVAMultiClassGui.cxx
@@ -100,7 +100,7 @@ void TMVA::TMVAMultiClassGui(const char* fName ,TString dataset)
             {
                TKey *key=(TKey*)file->GetListOfKeys()->At(i);
                dataset=key->GetName();
-               bar->AddButton(dataset.Data(),Form("TMVA::TMVAMultiClassGui(\"%s\",\"%s\")",fName,dataset.Data()),dataset.Data());
+               bar->AddButton(dataset.Data(),TString::Format("TMVA::TMVAMultiClassGui(\"%s\",\"%s\")",fName,dataset.Data()),dataset.Data());
             }
        
          bar->AddSeparator();
@@ -110,7 +110,7 @@ void TMVA::TMVAMultiClassGui(const char* fName ,TString dataset)
          bar->SetTextColor("black");
          bar->Show();
          gROOT->SaveContext();
-         return ;
+         return;
       }
    
    // find all references   
@@ -139,13 +139,13 @@ void TMVA::TMVAMultiClassGui(const char* fName ,TString dataset)
    char ch = 'a';
    while ((str = (TObjString*)it())) {
       TString tmp   = str->GetString();
-      TString title = Form( "Input variables '%s'-transformed (training sample)", 
+      TString title = TString::Format( "Input variables '%s'-transformed (training sample)", 
                             tmp.ReplaceAll("InputVariables_","").Data() );
       if (tmp.Contains( "Id" )) title = "Input variables (training sample)";
       MultiClassActionButton( cbar, 
-                              Form( "(%i%c) %s", ic, ch++, title.Data() ),
-                              Form( "TMVA::variablesMultiClass(\"%s\",\"%s\",\"%s\",\"%s\")",dataset.Data(), fName, str->GetString().Data(), title.Data() ),
-                              Form( "Plots all '%s'-transformed input variables (macro variablesMultiClass(...))", str->GetString().Data() ),
+                              TString::Format( "(%i%c) %s", ic, ch++, title.Data() ),
+                              TString::Format( "TMVA::variablesMultiClass(\"%s\",\"%s\",\"%s\",\"%s\")",dataset.Data(), fName, str->GetString().Data(), title.Data() ),
+                              TString::Format( "Plots all '%s'-transformed input variables (macro variablesMultiClass(...))", str->GetString().Data() ),
                               buttonType, str->GetString() );
    }      
    ic++;
@@ -154,162 +154,162 @@ void TMVA::TMVAMultiClassGui(const char* fName ,TString dataset)
    it.Reset(); ch = 'a';
    while ((str = (TObjString*)it())) {
       TString tmp   = str->GetString();
-      TString title = Form( "Input variable correlations '%s'-transformed (scatter profiles)", 
+      TString title = TString::Format( "Input variable correlations '%s'-transformed (scatter profiles)", 
                             tmp.ReplaceAll("InputVariables_","").Data() );
       if (tmp.Contains( "Id" )) title = "Input variable correlations (scatter profiles)";
       MultiClassActionButton( cbar, 
-                              Form( "(%i%c) %s", ic, ch++, title.Data() ),
-                              Form( "TMVA::CorrGuiMultiClass(\"%s\",\"%s\",\"%s\",\"%s\")",dataset.Data() , fName, str->GetString().Data(), title.Data() ),
-                              Form( "Plots all correlation profiles between '%s'-transformed input variables (macro CorrGuiMultiClass(...))", 
+                              TString::Format( "(%i%c) %s", ic, ch++, title.Data() ),
+                              TString::Format( "TMVA::CorrGuiMultiClass(\"%s\",\"%s\",\"%s\",\"%s\")",dataset.Data() , fName, str->GetString().Data(), title.Data() ),
+                              TString::Format( "Plots all correlation profiles between '%s'-transformed input variables (macro CorrGuiMultiClass(...))", 
                                     str->GetString().Data() ),
                               buttonType, str->GetString() );
    }      
    
    TString title;
    // coefficients
-   title =Form( "(%i) Input Variable Linear Correlation Coefficients", ++ic );
+   title =TString::Format( "(%i) Input Variable Linear Correlation Coefficients", ++ic );
    MultiClassActionButton( cbar,  
                            title,
-                           Form( "TMVA::correlationsMultiClass(\"%s\",\"%s\")",dataset.Data(), fName ),
+                           TString::Format( "TMVA::correlationsMultiClass(\"%s\",\"%s\")",dataset.Data(), fName ),
                            "Plots signal and background correlation summaries for all input variables (macro correlationsMultiClass.cxx)", 
                            buttonType );
 
-   title =Form( "(%ia) Classifier Output Distributions (test sample)", ++ic );
+   title =TString::Format( "(%ia) Classifier Output Distributions (test sample)", ++ic );
    MultiClassActionButton( cbar,  
                            title,
-                           Form( "TMVA::mvasMulticlass(\"%s\",\"%s\",TMVA::kMVAType)",dataset.Data() , fName ),
+                           TString::Format( "TMVA::mvasMulticlass(\"%s\",\"%s\",TMVA::kMVAType)",dataset.Data() , fName ),
                            "Plots the output of each classifier for the test data (macro mvas(...,0))",
                            buttonType, defaultRequiredClassifier );
 
-   title =Form( "(%ib) Classifier Output Distributions (test and training samples superimposed)", ic );
+   title =TString::Format( "(%ib) Classifier Output Distributions (test and training samples superimposed)", ic );
    MultiClassActionButton( cbar,  
                            title,
-                           Form( "TMVA::mvasMulticlass(\"%s\",\"%s\",TMVA::kCompareType)",dataset.Data(), fName ),
+                           TString::Format( "TMVA::mvasMulticlass(\"%s\",\"%s\",TMVA::kCompareType)",dataset.Data(), fName ),
                            "Plots the output of each classifier for the test (histograms) and training (dots) data (macro mvas(...,3))",
                            buttonType, defaultRequiredClassifier );
    /*
-     title = Form( "(%ic) Classifier Probability Distributions (test sample)", ic );
+     title = TString::Format( "(%ic) Classifier Probability Distributions (test sample)", ic );
      MultiClassActionButton( cbar,
-     Form( "(%ic) Classifier Probability Distributions (test sample)", ic ),
-     Form( "TMVA::mvas(\"%s\",TMVA::kProbaType)", fName ),
+     TString::Format( "(%ic) Classifier Probability Distributions (test sample)", ic ),
+     TString::Format( "TMVA::mvas(\"%s\",TMVA::kProbaType)", fName ),
      "Plots the probability of each classifier for the test data (macro mvas(...,1))",
      buttonType, defaultRequiredClassifier );
 
-     title =Form( "(%id) Classifier Rarity Distributions (test sample)", ic );
+     title =TString::Format( "(%id) Classifier Rarity Distributions (test sample)", ic );
      MultiClassActionButton( cbar,
-     Form( "(%id) Classifier Rarity Distributions (test sample)", ic ),
-     Form( "TMVA::mvas(\"%s\",TMVA::kRarityType)", fName ),
+     TString::Format( "(%id) Classifier Rarity Distributions (test sample)", ic ),
+     TString::Format( "TMVA::mvas(\"%s\",TMVA::kRarityType)", fName ),
      "Plots the Rarity of each classifier for the test data (macro mvas(...,2)) - background distribution should be
      uniform", buttonType, defaultRequiredClassifier );
 
 
-     title =Form( "(%ia) Classifier Cut Efficiencies", ++ic );
+     title =TString::Format( "(%ia) Classifier Cut Efficiencies", ++ic );
      MultiClassActionButton( cbar,
      title,
-     Form( "TMVA::mvaeffs(\"%s\")", fName ),
+     TString::Format( "TMVA::mvaeffs(\"%s\")", fName ),
      "Plots signal and background efficiencies versus cut on classifier output (macro mvaeffs.cxx)",
      buttonType, defaultRequiredClassifier );
     */
 
-   title = Form("(%i) Classifier Backgr. Rej. vs Sig. Eff. (1-vs-rest ROC curves)", ++ic);
+   title = TString::Format("(%i) Classifier Backgr. Rej. vs Sig. Eff. (1-vs-rest ROC curves)", ++ic);
    MultiClassActionButton(
-      cbar, title, Form("TMVA::efficienciesMulticlass1vsRest(\"%s\", \"%s\")", dataset.Data(), fName),
+      cbar, title, TString::Format("TMVA::efficienciesMulticlass1vsRest(\"%s\", \"%s\")", dataset.Data(), fName),
       "Plots background rejection vs signal efficiencies (macro efficienciesMulticlass.cxx) [\"ROC\" stands "
       "for \"Receiver Operation Characteristics\"]",
       buttonType, defaultRequiredClassifier);
 
-   // title = Form("(%i) Classifier (1/Backgr. Rejection) vs Sig. Eff. (1-vs-rest ROC curve)", ++ic);
-   // MultiClassActionButton(cbar, title, Form("TMVA::efficienciesMulticlass(\"%s\", \"%s\")", dataset.Data(), fName),
+   // title = TString::Format("(%i) Classifier (1/Backgr. Rejection) vs Sig. Eff. (1-vs-rest ROC curve)", ++ic);
+   // MultiClassActionButton(cbar, title, TString::Format("TMVA::efficienciesMulticlass(\"%s\", \"%s\")", dataset.Data(), fName),
    //                        "Plots background rejection vs signal efficiencies (macro efficiencies.cxx) [\"ROC\" stands
    //                        "
    //                        "for \"Receiver Operation Characteristics\"]",
    //                        buttonType, defaultRequiredClassifier);
 
-   title = Form("(%i) Classifier Backgr. Rej. vs Sig. Eff. (1-vs-1 ROC curves)", ++ic);
+   title = TString::Format("(%i) Classifier Backgr. Rej. vs Sig. Eff. (1-vs-1 ROC curves)", ++ic);
    MultiClassActionButton(
-      cbar, title, Form("TMVA::efficienciesMulticlass1vs1(\"%s\", \"%s\")", dataset.Data(), fName),
+      cbar, title, TString::Format("TMVA::efficienciesMulticlass1vs1(\"%s\", \"%s\")", dataset.Data(), fName),
       "Plots background rejection vs signal efficiencies (macro efficienciesMulticlass.cxx) [\"ROC\" stands "
       "for \"Receiver Operation Characteristics\"]",
       buttonType, defaultRequiredClassifier);
 
-   // title = Form("(%i) Classifier (1/Backgr. Rejection) vs Sig. Eff. (1-vs-1 ROC curve)", ++ic);
-   // MultiClassActionButton(cbar, title, Form("TMVA::efficienciesMulticlass(\"%s\", \"%s\")", dataset.Data(), fName),
+   // title = TString::Format("(%i) Classifier (1/Backgr. Rejection) vs Sig. Eff. (1-vs-1 ROC curve)", ++ic);
+   // MultiClassActionButton(cbar, title, TString::Format("TMVA::efficienciesMulticlass(\"%s\", \"%s\")", dataset.Data(), fName),
    //                        "Plots background rejection vs signal efficiencies (macro efficiencies.cxx) [\"ROC\" stands
    //                        "
    //                        "for \"Receiver Operation Characteristics\"]",
    //                        buttonType, defaultRequiredClassifier);
 
    /*
-   title = Form( "(%i) Parallel Coordinates (requires ROOT-version >= 5.17)", ++ic );
+   title = TString::Format( "(%i) Parallel Coordinates (requires ROOT-version >= 5.17)", ++ic );
    MultiClassActionButton( cbar,
    title,
-   Form( "TMVA::paracoor(\"%s\")", fName ),
+   TString::Format( "TMVA::paracoor(\"%s\")", fName ),
    "Plots parallel coordinates for classifiers and input variables (macro paracoor.cxx, requires ROOT >= 5.17)",
    buttonType, defaultRequiredClassifier );
 
-   title =Form( "(%i) PDFs of Classifiers (requires \"CreateMVAPdfs\" option set)", ++ic );
+   title =TString::Format( "(%i) PDFs of Classifiers (requires \"CreateMVAPdfs\" option set)", ++ic );
    MultiClassActionButton( cbar,
    title,
-   Form( "TMVA::probas(\"%s\")", fName ),
+   TString::Format( "TMVA::probas(\"%s\")", fName ),
    "Plots the PDFs of the classifier output distributions for signal and background - if requested (macro probas.cxx)",
    buttonType, defaultRequiredClassifier );
 
-   title = Form( "(%i) Likelihood Reference Distributiuons", ++ic);
+   title = TString::Format( "(%i) Likelihood Reference Distributiuons", ++ic);
    MultiClassActionButton( cbar,
    title,
-   Form( "TMVA::likelihoodrefs(\"%s\")", fName ),
+   TString::Format( "TMVA::likelihoodrefs(\"%s\")", fName ),
    "Plots to verify the likelihood reference distributions (macro likelihoodrefs.cxx)",
    buttonType, "Likelihood" );
  */
 
-   title = Form( "(%ia) Network Architecture (MLP)", ++ic );
-   TString call = Form( "TMVA::network(\"%s\",\"%s\")",dataset.Data() , fName );
+   title = TString::Format( "(%ia) Network Architecture (MLP)", ++ic );
+   TString call = TString::Format( "TMVA::network(\"%s\",\"%s\")",dataset.Data() , fName );
    MultiClassActionButton( cbar,  
                            title,
                            call, 
                            "Plots the MLP weights (macro network.cxx)",
                            buttonType, "MLP" );
 
-   title = Form( "(%ib) Network Convergence Test (MLP)", ic );
+   title = TString::Format( "(%ib) Network Convergence Test (MLP)", ic );
    MultiClassActionButton( cbar,  
                            title,
-                           Form( "TMVA::annconvergencetest(\"%s\",\"%s\")",dataset.Data() , fName ), 
+                           TString::Format( "TMVA::annconvergencetest(\"%s\",\"%s\")",dataset.Data() , fName ), 
                            "Plots error estimator versus training epoch for training and test samples (macro annconvergencetest.cxx)",
                            buttonType, "MLP" );
 
-   title = Form( "(%i) Decision Trees (BDT)", ++ic );
+   title = TString::Format( "(%i) Decision Trees (BDT)", ++ic );
    MultiClassActionButton( cbar,  
                            title,
-                           Form( "TMVA::BDT(\"%s\",\"%s\")",dataset.Data() , fName ),
+                           TString::Format( "TMVA::BDT(\"%s\",\"%s\")",dataset.Data() , fName ),
                            "Plots the Decision Trees trained by BDT algorithms (macro BDT(itree,...))",
                            buttonType, "BDT" );
 
    /*
-     title = Form( "(%i) Decision Tree Control Plots (BDT)", ++ic );
+     title = TString::Format( "(%i) Decision Tree Control Plots (BDT)", ++ic );
      MultiClassActionButton( cbar,  
      title,
-     Form( "TMVA::BDTControlPlots(\"%s\")", fName ),
+     TString::Format( "TMVA::BDTControlPlots(\"%s\")", fName ),
      "Plots to monitor boosting and pruning of decision trees (macro BDTControlPlots.cxx)",
      buttonType, "BDT" );
 
    */
-   title = Form( "(%i) Plot Foams (PDEFoam)", ++ic );
+   title = TString::Format( "(%i) Plot Foams (PDEFoam)", ++ic );
    MultiClassActionButton( cbar,  
                            title,
-                           Form("TMVA::PlotFoams(\"%s/weights/TMVAMulticlass_PDEFoam.weights_foams.root\")",dataset.Data()),
+                           TString::Format("TMVA::PlotFoams(\"%s/weights/TMVAMulticlass_PDEFoam.weights_foams.root\")",dataset.Data()),
                            "Plot Foams (macro PlotFoams.cxx)",
                            buttonType, "PDEFoam" );
    /*
-     title = Form( "(%i) General Boost Control Plots", ++ic );
+     title = TString::Format( "(%i) General Boost Control Plots", ++ic );
      MultiClassActionButton( cbar,  
      title,
-     Form( "TMVA::BoostControlPlots(\"%s\")", fName ),
+     TString::Format( "TMVA::BoostControlPlots(\"%s\")", fName ),
      "Plots to monitor boosting of general classifiers (macro BoostControlPlots.cxx)",
      buttonType, "Boost" );
    */
    cbar->AddSeparator();
 
-   cbar->AddButton( Form( "(%i) Quit", ++ic ),   ".q", "Quit", buttonType );
+   cbar->AddButton( TString::Format( "(%i) Quit", ++ic ),   ".q", "Quit", buttonType );
 
    // set the style 
    cbar->SetTextColor("black");

--- a/tmva/tmvagui/src/TMVARegGui.cxx
+++ b/tmva/tmvagui/src/TMVARegGui.cxx
@@ -96,7 +96,7 @@ void TMVA::TMVARegGui( const char* fName ,TString dataset)
             {
                TKey *key=(TKey*)file->GetListOfKeys()->At(i);
                dataset=key->GetName();
-               bar->AddButton(dataset.Data(),Form("TMVA::TMVARegGui(\"%s\",\"%s\")",fName,dataset.Data()),dataset.Data());
+               bar->AddButton(dataset.Data(),TString::Format("TMVA::TMVARegGui(\"%s\",\"%s\")",fName,dataset.Data()),dataset.Data());
             }
        
          bar->AddSeparator();
@@ -122,7 +122,7 @@ void TMVA::TMVARegGui( const char* fName ,TString dataset)
    // create the control bar
    TControlBar* cbar = new TControlBar( "vertical", "TMVA Plotting Macros for Regression", 0, 0 );
 
-   const TString buttonType( "button" );
+   const TString buttonType = "button";
 
    // configure buttons   
    Int_t ic = 1;
@@ -130,17 +130,17 @@ void TMVA::TMVARegGui( const char* fName ,TString dataset)
    // find all input variables types
    TList* keylist = RegGuiGetKeyList( "InputVariables" );
    TListIter it( keylist );
-   TObjString* str = 0;
+   TObjString* str = nullptr;
    char ch = 'a';
    while ( (str = (TObjString*)it()) ) {
       TString tmp   = str->GetString();
-      TString title = Form( "Input variables and target(s) '%s'-transformed (training sample)", 
+      TString title = TString::Format( "Input variables and target(s) '%s'-transformed (training sample)", 
                             tmp.ReplaceAll("InputVariables_","").Data() );
       if (tmp.Contains( "Id" )) title = "Input variables and target(s) (training sample)";
       RegGuiActionButton( cbar, 
-                          Form( "    (%i%c) %s    ", ic, ch++, title.Data() ),
-                          Form( "TMVA::variables(\"%s\",\"%s\",\"%s\",\"%s\",kTRUE)",dataset.Data() , fName, str->GetString().Data(), title.Data() ),
-                          Form( "Plots all '%s'-transformed input variables and target(s) (macro variables(...))", 
+                          TString::Format( "    (%i%c) %s    ", ic, ch++, title.Data() ),
+                          TString::Format( "TMVA::variables(\"%s\",\"%s\",\"%s\",\"%s\",kTRUE)",dataset.Data() , fName, str->GetString().Data(), title.Data() ),
+                          TString::Format( "Plots all '%s'-transformed input variables and target(s) (macro variables(...))", 
                                 str->GetString().Data() ),
                           buttonType, str->GetString() );
    }      
@@ -150,87 +150,87 @@ void TMVA::TMVARegGui( const char* fName ,TString dataset)
    it.Reset(); ch = 'a';
    while ( (str = (TObjString*)it()) ) {
       TString tmp   = str->GetString();
-      TString title = Form( "Input variable correlations '%s'-transformed (scatter profiles)", 
+      TString title = TString::Format( "Input variable correlations '%s'-transformed (scatter profiles)", 
                             tmp.ReplaceAll("InputVariables_","").Data() );
       if (tmp.Contains( "Id" )) title = "Input variable correlations (scatter profiles)";
       RegGuiActionButton( cbar, 
-                          Form( "(%i%c) %s", ic, ch++, title.Data() ),
-                          Form( "TMVA::CorrGui(\"%s\",\"%s\",\"%s\",\"%s\",kTRUE)",dataset.Data() , fName, str->GetString().Data(), title.Data() ),
-                          Form( "Plots all correlation profiles between '%s'-transformed input variables (macro CorrGui(...))", 
+                          TString::Format( "(%i%c) %s", ic, ch++, title.Data() ),
+                          TString::Format( "TMVA::CorrGui(\"%s\",\"%s\",\"%s\",\"%s\",kTRUE)",dataset.Data() , fName, str->GetString().Data(), title.Data() ),
+                          TString::Format( "Plots all correlation profiles between '%s'-transformed input variables (macro CorrGui(...))", 
                                 str->GetString().Data() ),
                           buttonType, str->GetString() );
    }      
    
    // coefficients
    RegGuiActionButton( cbar,  
-                       Form( "(%i) Input Variable Linear Correlation Coefficients", ++ic ),
-                       Form( "TMVA::correlations(\"%s\",\"%s\",kTRUE)",dataset.Data(), fName ),
+                       TString::Format( "(%i) Input Variable Linear Correlation Coefficients", ++ic ),
+                       TString::Format( "TMVA::correlations(\"%s\",\"%s\",kTRUE)",dataset.Data(), fName ),
                        "Plots signal and background correlation summaries for all input variables (macro correlations.cxx)", 
                        buttonType );
 
    RegGuiActionButton( cbar,  
-                       Form( "(%ia) Regression Output Deviation versus Target (test sample)", ++ic ),
-                       Form( "TMVA::deviations(\"%s\",\"%s\",TMVA::kMVAType,kTRUE)",dataset.Data(), fName ),
+                       TString::Format( "(%ia) Regression Output Deviation versus Target (test sample)", ++ic ),
+                       TString::Format( "TMVA::deviations(\"%s\",\"%s\",TMVA::kMVAType,kTRUE)",dataset.Data(), fName ),
                        "Plots the deviation between regression output and target versus target on test data (macro deviations(...,0))",
                        buttonType, defaultRequiredClassifier );
 
    RegGuiActionButton( cbar,  
-                       Form( "(%ib) Regression Output Deviation versus Target (training sample)", ic ),
-                       Form( "TMVA::deviations(\"%s\",\"%s\",TMVA::kCompareType,kTRUE)",dataset.Data() , fName ),
+                       TString::Format( "(%ib) Regression Output Deviation versus Target (training sample)", ic ),
+                       TString::Format( "TMVA::deviations(\"%s\",\"%s\",TMVA::kCompareType,kTRUE)",dataset.Data() , fName ),
                        "Plots the deviation between regression output and target versus target on test data (macro deviations(...,0))",
                        buttonType, defaultRequiredClassifier );
 
    RegGuiActionButton( cbar,  
-                       Form( "(%ic) Regression Output Deviation versus Input Variables (test sample)", ic ),
-                       Form( "TMVA::deviations(\"%s\",\"%s\",TMVA::kMVAType,kFALSE)",dataset.Data(), fName ),
+                       TString::Format( "(%ic) Regression Output Deviation versus Input Variables (test sample)", ic ),
+                       TString::Format( "TMVA::deviations(\"%s\",\"%s\",TMVA::kMVAType,kFALSE)",dataset.Data(), fName ),
                        "Plots the deviation between regression output and target versus target on test data (macro deviations(...,0))",
                        buttonType, defaultRequiredClassifier );
 
    RegGuiActionButton( cbar,  
-                       Form( "   (%id) Regression Output Deviation versus Input Variables (training sample)   ", ic ),
-                       Form( "TMVA::deviations(\"%s\",\"%s\",TMVA::kCompareType,kFALSE)",dataset.Data() , fName ),
+                       TString::Format( "   (%id) Regression Output Deviation versus Input Variables (training sample)   ", ic ),
+                       TString::Format( "TMVA::deviations(\"%s\",\"%s\",TMVA::kCompareType,kFALSE)",dataset.Data() , fName ),
                        "Plots the deviation between regression output and target versus target on test data (macro deviations(...,0))",
                        buttonType, defaultRequiredClassifier );
 
    RegGuiActionButton( cbar,  
-                       Form( "(%i) Summary of Average Regression Deviations ", ++ic ),
-                       Form( "TMVA::regression_averagedevs(\"%s\",\"%s\")",dataset.Data() , fName ),
+                       TString::Format( "(%i) Summary of Average Regression Deviations ", ++ic ),
+                       TString::Format( "TMVA::regression_averagedevs(\"%s\",\"%s\")",dataset.Data() , fName ),
                        "Plot Summary of average deviations: MVAvalue - target (macro regression_averagedevs.cxx)",
                        buttonType );
 
    RegGuiActionButton( cbar,  
-                       Form( "(%ia) Network Architecture", ++ic ),
-                       Form( "TMVA::network(\"%s\",\"%s\")",dataset.Data(), fName ), 
+                       TString::Format( "(%ia) Network Architecture", ++ic ),
+                       TString::Format( "TMVA::network(\"%s\",\"%s\")",dataset.Data(), fName ), 
                        "Plots the MLP weights (macro network.cxx)",
                        buttonType, "MLP" );
 
    RegGuiActionButton( cbar,  
-                       Form( "(%ib) Network Convergence Test", ic ),
-                       Form( "TMVA::annconvergencetest(\"%s\",\"%s\")",dataset.Data() , fName ), 
+                       TString::Format( "(%ib) Network Convergence Test", ic ),
+                       TString::Format( "TMVA::annconvergencetest(\"%s\",\"%s\")",dataset.Data() , fName ), 
                        "Plots error estimator versus training epoch for training and test samples (macro annconvergencetest.cxx)",
                        buttonType, "MLP" );
 
    RegGuiActionButton( cbar,  
-                       Form( "(%i) Plot Foams", ++ic ),
-                       Form("TMVA::PlotFoams(\"%s/weights/TMVARegression_PDEFoam.weights_foams.root\")",dataset.Data()),
+                       TString::Format( "(%i) Plot Foams", ++ic ),
+                       TString::Format("TMVA::PlotFoams(\"%s/weights/TMVARegression_PDEFoam.weights_foams.root\")",dataset.Data()),
                        "Plot Foams (macro PlotFoams.cxx)",
                        buttonType, "PDEFoam" );
 
    RegGuiActionButton( cbar,  
-                       Form( "(%i) Regression Trees (BDT)", ++ic ),
-                       Form( "TMVA::BDT_Reg(\"%s\",\"%s\")",dataset.Data() , fName ),
+                       TString::Format( "(%i) Regression Trees (BDT)", ++ic ),
+                       TString::Format( "TMVA::BDT_Reg(\"%s\",\"%s\")",dataset.Data() , fName ),
                        "Plots the Regression Trees trained by BDT algorithms (macro BDT_Reg(itree,...))",
                        buttonType, "BDT" );
 
    RegGuiActionButton( cbar,  
-                       Form( "(%i) Regression Tree Control Plots (BDT)", ++ic ),
-                       Form( "TMVA::BDTControlPlots(\"%s\",\"%s\")",dataset.Data(), fName ),
+                       TString::Format( "(%i) Regression Tree Control Plots (BDT)", ++ic ),
+                       TString::Format( "TMVA::BDTControlPlots(\"%s\",\"%s\")",dataset.Data(), fName ),
                        "Plots to monitor boosting and pruning of regression trees (macro BDTControlPlots.cxx)",
                        buttonType, "BDT" );
 
    cbar->AddSeparator();
 
-   cbar->AddButton( Form( "(%i) Quit", ++ic ),   ".q", "Quit", buttonType );
+   cbar->AddButton( TString::Format( "(%i) Quit", ++ic ),   ".q", "Quit", buttonType );
 
    // set the style 
    cbar->SetTextColor("black");

--- a/tmva/tmvagui/src/annconvergencetest.cxx
+++ b/tmva/tmvagui/src/annconvergencetest.cxx
@@ -1,10 +1,10 @@
 #include "TMVA/annconvergencetest.h"
 
 
-// this macro serves to assess the convergence of the MLP ANN. 
+// this macro serves to assess the convergence of the MLP ANN.
 // It compares the error estimator for the training and testing samples.
-// If overtraining occurred, the estimator for the training sample should 
-// monotoneously decrease, while the estimator of the testing sample should 
+// If overtraining occurred, the estimator for the training sample should
+// monotoneously decrease, while the estimator of the testing sample should
 // show a minimum after which it increases.
 
 // input: - Input file (result from TMVA),
@@ -15,9 +15,10 @@ void TMVA::annconvergencetest(TString dataset, TDirectory *lhdir )
    TString jobName = lhdir->GetName();
    static int icanvas = -1;
    icanvas++;
-   TCanvas* c = new TCanvas( Form("MLPConvergenceTest_%s",jobName.Data()), Form("MLP Convergence Test, %s",jobName.Data()), 
+   TCanvas* c = new TCanvas( TString::Format("MLPConvergenceTest_%s",jobName.Data()),
+                             TString::Format("MLP Convergence Test, %s",jobName.Data()),
                              100 + (icanvas)*40, 0 + (icanvas+1)*20, 600, 580*0.8  );
-  
+
    TH1* estimatorHistTrain = (TH1*)lhdir->Get( "estimatorHistTrain" );
    TH1* estimatorHistTest  = (TH1*)lhdir->Get( "estimatorHistTest"  );
 
@@ -32,7 +33,7 @@ void TMVA::annconvergencetest(TString dataset, TDirectory *lhdir )
    estimatorHistTrain->SetLineColor( 2 );
    estimatorHistTrain->SetLineWidth( 2 );
    estimatorHistTrain->SetTitle( TString("MLP Convergence Test") );
-  
+
    estimatorHistTest->SetLineColor( 4 );
    estimatorHistTest->SetLineWidth( 2 );
 
@@ -45,7 +46,7 @@ void TMVA::annconvergencetest(TString dataset, TDirectory *lhdir )
    estimatorHistTest ->Draw("samehist");
 
    // need a legend
-   TLegend *legend= new TLegend( 1 - c->GetRightMargin() - 0.45, 1-c->GetTopMargin() - 0.20, 
+   TLegend *legend= new TLegend( 1 - c->GetRightMargin() - 0.45, 1-c->GetTopMargin() - 0.20,
                                  1 - c->GetRightMargin() - 0.05, 1-c->GetTopMargin() - 0.05 );
 
    legend->AddEntry(estimatorHistTrain,"Training Sample","l");
@@ -65,13 +66,13 @@ void TMVA::annconvergencetest(TString dataset, TString fin , Bool_t useTMVAStyle
 {
    // set style and remove existing canvas'
    TMVAGlob::Initialize( useTMVAStyle );
-  
+
    // checks if file with name "fin" is already open, and if not opens one
-   TFile* file = TMVAGlob::OpenFile( fin );  
+   TFile* file = TMVAGlob::OpenFile( fin );
 
    // get all titles of the method likelihood
    TList titles;
-   TString metmlp="Method_MLP"; 
+   TString metmlp="Method_MLP";
    UInt_t ninst = TMVAGlob::GetListOfTitles(metmlp,titles,file->GetDirectory(dataset.Data()));
    if (ninst==0) {
       cout << "Could not locate directory 'Method_MLP' in file " << fin << endl;

--- a/tmva/tmvagui/src/compareanapp.cxx
+++ b/tmva/tmvagui/src/compareanapp.cxx
@@ -7,7 +7,7 @@
 //TString DerivedPlotName = "Proba";
 TString DerivedPlotName = "Rarity";
 
-void TMVA::compareanapp( TString finAn , TString finApp , 
+void TMVA::compareanapp( TString finAn , TString finApp ,
                          HistType htype , bool useTMVAStyle )
 {
    cout << "=== Compare histograms of two files ===" << endl;
@@ -21,7 +21,7 @@ void TMVA::compareanapp( TString finAn , TString finApp ,
    const Bool_t Draw_CFANN_Logy = kFALSE;
    const Bool_t Save_Images     = kTRUE;
 
-   TFile* file    = TMVAGlob::OpenFile( finAn );  
+   TFile* file    = TMVAGlob::OpenFile( finAn );
    TFile* fileApp = new TFile( finApp );
    file->cd();
 
@@ -33,7 +33,7 @@ void TMVA::compareanapp( TString finAn , TString finApp ,
 
    TList methods;
    TIter next(&methods);
-   TKey *key;   
+   TKey *key;
    while ( (key = (TKey*)next()) ) {
 
       TString dirname = ((TDirectory*)key->ReadObj())->GetName();
@@ -41,7 +41,7 @@ void TMVA::compareanapp( TString finAn , TString finApp ,
          cout << "--- Found directory: " << dirname << " --> ignoring" << endl;
          continue;
       }
-      cout << "--- Found directory: " << dirname 
+      cout << "--- Found directory: " << dirname
            << " --> going in" << endl;
 
       TString methodName;
@@ -70,67 +70,67 @@ void TMVA::compareanapp( TString finAn , TString finApp ,
          if (sig==0 || bgd==0) continue;
 
          // chop off useless stuff
-         sig->SetTitle( Form("TMVA output for classifier: %s", methodTitle.Data()) );
-         if      (htype == kProbaType) 
-            sig->SetTitle( Form("TMVA probability for classifier: %s", methodTitle.Data()) );
-         else if (htype == kRarityType) 
-            sig->SetTitle( Form("TMVA Rarity for classifier: %s", methodTitle.Data()) );
-         
+         sig->SetTitle( TString::Format("TMVA output for classifier: %s", methodTitle.Data()) );
+         if (htype == kProbaType)
+            sig->SetTitle( TString::Format("TMVA probability for classifier: %s", methodTitle.Data()) );
+         else if (htype == kRarityType)
+            sig->SetTitle( TString::Format("TMVA Rarity for classifier: %s", methodTitle.Data()) );
+
          // create new canvas
-         TString ctitle = ((htype == TMVA::kMVAType) ? 
-                           Form("TMVA output %s",methodTitle.Data()) : 
-                           (htype == kProbaType) ? 
-                           Form("TMVA probability %s",methodTitle.Data()) :
-                           Form("TMVA rarity %s",methodTitle.Data()));
+         TString ctitle = ((htype == TMVA::kMVAType) ?
+                           TString::Format("TMVA output %s",methodTitle.Data()) :
+                           (htype == kProbaType) ?
+                           TString::Format("TMVA probability %s",methodTitle.Data()) :
+                           TString::Format("TMVA rarity %s",methodTitle.Data()));
 
-         TString cname = ((htype == TMVA::kMVAType) ? 
-                          Form("output_%s",methodTitle.Data()) : 
-                          (htype == kProbaType) ? 
-                          Form("probability_%s",methodTitle.Data()) :
-                          Form("rarity_%s",methodTitle.Data()));
+         TString cname = ((htype == TMVA::kMVAType) ?
+                          TString::Format("output_%s",methodTitle.Data()) :
+                          (htype == kProbaType) ?
+                          TString::Format("probability_%s",methodTitle.Data()) :
+                          TString::Format("rarity_%s",methodTitle.Data()));
 
-         TCanvas* c = new TCanvas( Form("canvas%d", countCanvas+1), ctitle, 
-                                   countCanvas*50+200, countCanvas*20, width, width*0.78 ); 
-          
+         TCanvas* c = new TCanvas( TString::Format("canvas%d", countCanvas+1), ctitle,
+                                   countCanvas*50+200, countCanvas*20, width, width*0.78 );
+
          // set the histogram style
          TMVAGlob::SetSignalAndBackgroundStyle( sig, bgd );
-         
+
          // normalise both signal and background
          TMVAGlob::NormalizeHists( sig, bgd );
-         
+
          // frame limits (choose judicuous x range)
          Float_t nrms = 4;
-         Float_t xmin = TMath::Max( TMath::Min(sig->GetMean() - nrms*sig->GetRMS(), 
+         Float_t xmin = TMath::Max( TMath::Min(sig->GetMean() - nrms*sig->GetRMS(),
                                                bgd->GetMean() - nrms*bgd->GetRMS() ),
                                     sig->GetXaxis()->GetXmin() );
-         Float_t xmax = TMath::Min( TMath::Max(sig->GetMean() + nrms*sig->GetRMS(), 
+         Float_t xmax = TMath::Min( TMath::Max(sig->GetMean() + nrms*sig->GetRMS(),
                                                bgd->GetMean() + nrms*bgd->GetRMS() ),
                                     sig->GetXaxis()->GetXmax() );
          Float_t ymin = 0;
          Float_t ymax = TMath::Max( sig->GetMaximum(), bgd->GetMaximum() )*1.2 ;
-         
+
          if (Draw_CFANN_Logy && methodName == "CFANN") ymin = 0.01;
-         
+
          // build a frame
          Int_t nb = 500;
-         TH2F* frame = new TH2F( TString("frame") + methodTitle, sig->GetTitle(), 
+         TH2F* frame = new TH2F( TString("frame") + methodTitle, sig->GetTitle(),
                                  nb, xmin, xmax, nb, ymin, ymax );
          frame->GetXaxis()->SetTitle(methodTitle);
          if      (htype == kProbaType ) frame->GetXaxis()->SetTitle( "Signal probability" );
          else if (htype == kRarityType) frame->GetXaxis()->SetTitle( "Signal rarity" );
          frame->GetYaxis()->SetTitle("Normalized");
          TMVAGlob::SetFrameStyle( frame );
-         
+
          // eventually: draw the frame
-         frame->Draw();  
-         
+         frame->Draw();
+
          c->GetPad(0)->SetLeftMargin( 0.105 );
          frame->GetYaxis()->SetTitleOffset( 1.2 );
-         
+
          if (Draw_CFANN_Logy && methodName == "CFANN") c->SetLogy();
-         
-         // Draw legend               
-         TLegend *legend= new TLegend( c->GetLeftMargin(), 1 - c->GetTopMargin() - 0.12, 
+
+         // Draw legend
+         TLegend *legend= new TLegend( c->GetLeftMargin(), 1 - c->GetTopMargin() - 0.12,
                                        c->GetLeftMargin() + 0.3, 1 - c->GetTopMargin() );
          legend->SetFillStyle( 1 );
          legend->AddEntry(sig,"Signal","F");
@@ -143,10 +143,10 @@ void TMVA::compareanapp( TString finAn , TString finApp ,
          sig->Draw("samehist");
          bgd->Draw("samehist");
 
-         // retrieve corresponding histogram from TMVApp.root   
+         // retrieve corresponding histogram from TMVApp.root
          TString hStem(hname);
          cout << "--- Searching for histogram: " << hStem.Data() << " in application file" << endl;
-         
+
          TH1* testHist = (TH1*)fileApp->Get( hStem );
          if (testHist != 0) {
             cout << "--> Found application histogram: " << testHist->GetName() << " --> superimpose it" << endl;
@@ -156,30 +156,30 @@ void TMVA::compareanapp( TString finAn , TString finApp ,
             testHist->SetLineColor( 1 );
             testHist->Draw("samehist");
          }
-         
+
          // redraw axes
          frame->Draw("sameaxis");
-         
+
          // text for overflows
          Int_t    nbin = sig->GetNbinsX();
          Double_t dxu  = sig->GetBinWidth(0);
          Double_t dxo  = sig->GetBinWidth(nbin+1);
-         TString uoflow = Form( "U/O-flow (S,B): (%.1f, %.1f)%% / (%.1f, %.1f)%%", 
+         TString uoflow = TString::Format( "U/O-flow (S,B): (%.1f, %.1f)%% / (%.1f, %.1f)%%",
                                 sig->GetBinContent(0)*dxu*100, bgd->GetBinContent(0)*dxu*100,
                                 sig->GetBinContent(nbin+1)*dxo*100, bgd->GetBinContent(nbin+1)*dxo*100 );
          TText* t = new TText( 0.975, 0.115, uoflow );
          t->SetNDC();
          t->SetTextSize( 0.030 );
          t->SetTextAngle( 90 );
-         t->AppendPad();    
-         
+         t->AppendPad();
+
          // save canvas to file
          c->Update();
          TMVAGlob::plot_logo();
          if (Save_Images) {
-            if      (htype == TMVA::kMVAType)   TMVAGlob::imgconv( c, Form("plots/mva_%s",    methodTitle.Data()) );
-            else if (htype == TMVA::kProbaType) TMVAGlob::imgconv( c, Form("plots/proba_%s",  methodTitle.Data()) ); 
-            else                         TMVAGlob::imgconv( c, Form("plots/rarity_%s", methodTitle.Data()) ); 
+            if      (htype == TMVA::kMVAType)   TMVAGlob::imgconv( c, TString::Format("plots/mva_%s",    methodTitle.Data()) );
+            else if (htype == TMVA::kProbaType) TMVAGlob::imgconv( c, TString::Format("plots/proba_%s",  methodTitle.Data()) );
+            else                         TMVAGlob::imgconv( c, TString::Format("plots/rarity_%s", methodTitle.Data()) );
          }
          countCanvas++;
       }

--- a/tmva/tmvagui/src/correlations.cxx
+++ b/tmva/tmvagui/src/correlations.cxx
@@ -36,7 +36,7 @@ void TMVA::correlations(TString dataset, TString fin , Bool_t isRegression ,
       }
 
       TCanvas* c = new TCanvas( hName[ic], 
-                                Form("Correlations between MVA input variables (%s)", 
+                                TString::Format("Correlations between MVA input variables (%s)", 
                                      (isRegression ? "" : (ic==0 ? "signal" : "background"))), 
                                 ic*(width+5)+200, 0, width, width ); 
       Float_t newMargin1 = 0.13;

--- a/tmva/tmvagui/src/correlationsMultiClass.cxx
+++ b/tmva/tmvagui/src/correlationsMultiClass.cxx
@@ -37,7 +37,7 @@ void TMVA::correlationsMultiClass(TString dataset, TString fin , Bool_t /* isReg
       }
 
       TCanvas* c = new TCanvas( hnames[ic], 
-                                Form("Correlations between MVA input variables (%s)", 
+                                TString::Format("Correlations between MVA input variables (%s)", 
                                      classnames[ic].Data()), 
                                 ic*(width+5)+200, 0, width, width ); 
       Float_t newMargin1 = 0.13;

--- a/tmva/tmvagui/src/correlationscatters.cxx
+++ b/tmva/tmvagui/src/correlationscatters.cxx
@@ -10,7 +10,7 @@
 // input: - Input file (result from TMVA),
 //        - normal/decorrelated/PCA
 //        - use of TMVA plotting TStyle
-void TMVA::correlationscatters(TString dataset, TString fin , TString var, 
+void TMVA::correlationscatters(TString dataset, TString fin , TString var,
                                TString dirName_, TString /*title */ ,
                                Bool_t isRegression ,
                                Bool_t useTMVAStyle  )
@@ -24,16 +24,16 @@ void TMVA::correlationscatters(TString dataset, TString fin , TString var,
    if (extension == "") extension = "_Id"; // use 'Id' for 'idendtity transform'
 
    var.ReplaceAll( extension, "" );
-   cout << "Called macro \"correlationscatters\" for variable: \"" << var 
-        << "\", transformation type \"" << dirName_ 
+   cout << "Called macro \"correlationscatters\" for variable: \"" << var
+        << "\", transformation type \"" << dirName_
         << "\" (extension: \"" << extension << "\")" << endl;
 
    // checks if file with name "fin" is already open, and if not opens one
-   TFile* file = TMVAGlob::OpenFile( fin );  
+   TFile* file = TMVAGlob::OpenFile( fin );
 
    TString dirName = dirName_ + "/CorrelationPlots";
-  
-   // find out number of input variables   
+
+   // find out number of input variables
    TDirectory* vardir = (TDirectory*)file->GetDirectory(dataset.Data())->Get("InputVariables_Id");
    if (!vardir) {
       cout << "ERROR: no such directory: \"InputVariables\"" << endl;
@@ -50,7 +50,7 @@ void TMVA::correlationscatters(TString dataset, TString fin , TString var,
 
    TListIter keyIt(dir->GetListOfKeys());
    Int_t noPlots = noVars - 1;
-   
+
    cout << "noPlots: " << noPlots << " --> noVars: " << noVars << endl;
    if (noVars != Int_t(noVars)) {
       cout << "*** Warning: problem in inferred number of variables ... not an integer *** " << endl;
@@ -74,7 +74,7 @@ void TMVA::correlationscatters(TString dataset, TString fin , TString var,
    default:
       xPad = 3; yPad = 2; width = 800; height = 0.55*width; break;
    }
-   Int_t noPadPerCanv = xPad * yPad ;   
+   Int_t noPadPerCanv = xPad * yPad ;
 
    // counter variables
    Int_t countCanvas = 0;
@@ -89,7 +89,7 @@ void TMVA::correlationscatters(TString dataset, TString fin , TString var,
       TCanvas* canv = 0;
 
       Int_t countPad    = 0;
-   
+
       while ( (key = (TKey*)next()) ) {
 
          if (key->GetCycle() != 1) continue;
@@ -101,22 +101,22 @@ void TMVA::correlationscatters(TString dataset, TString fin , TString var,
          TString hname = scat->GetName();
 
          // check for all signal histograms
-         if (! (hname.EndsWith( thename[itype] + extension ) && 
+         if (! (hname.EndsWith( thename[itype] + extension ) &&
                 hname.Contains( TString("_") + var + "_" ) && hname.BeginsWith("scat_")) ) {
             scat->Delete();
-            continue; 
+            continue;
          }
 
          // found a new signal plot
-            
+
          // create new canvas
          if (countPad%noPadPerCanv==0) {
             ++countCanvas;
             TString ext = extension; ext.Remove( 0, 1 );
-            canv = new TCanvas( Form("canvas%d", countCanvas), 
-                                Form("Correlation profiles for '%s'-transformed %s variables", 
+            canv = new TCanvas( TString::Format("canvas%d", countCanvas),
+                                TString::Format("Correlation profiles for '%s'-transformed %s variables",
                                      ext.Data(), (isRegression ? "" : (itype==0) ? "signal" : "background")),
-                                countCanvas*50+200, countCanvas*20, width, height ); 
+                                countCanvas*50+200, countCanvas*20, width, height );
             canv->Divide(xPad,yPad);
          }
 
@@ -136,15 +136,15 @@ void TMVA::correlationscatters(TString dataset, TString fin , TString var,
          // this is set but not stored during plot creation in MVA_Factory
          TMVAGlob::SetSignalAndBackgroundStyle( scat, prof );
 
-         // chop off "signal" 
+         // chop off "signal"
          TMVAGlob::SetFrameStyle( scat, 1.2 );
 
          // normalise both signal and background
          scat->Scale( 1.0/scat->GetSumOfWeights() );
 
-         // finally plot and overlay       
+         // finally plot and overlay
          scat->SetMarkerColor(  4);
-         scat->Draw("col");      
+         scat->Draw("col");
          prof->SetMarkerColor( gConfig().fVariablePlotting.fUsePaperStyle ? 1 : 2  );
          prof->SetMarkerSize( 0.2 );
          prof->SetLineColor( gConfig().fVariablePlotting.fUsePaperStyle ? 1 : 2 );
@@ -159,7 +159,7 @@ void TMVA::correlationscatters(TString dataset, TString fin , TString var,
          if (countPad%noPadPerCanv==0) {
             canv->Update();
 
-            TString fname = Form( "%s/plots/correlationscatter_%s_%s_c%i",dataset.Data(),var.Data(), extension.Data(), countCanvas );
+            TString fname = TString::Format( "%s/plots/correlationscatter_%s_%s_c%i",dataset.Data(),var.Data(), extension.Data(), countCanvas );
             TMVAGlob::plot_logo();
             TMVAGlob::imgconv( canv, fname );
          }
@@ -167,7 +167,7 @@ void TMVA::correlationscatters(TString dataset, TString fin , TString var,
       if (countPad%noPadPerCanv!=0) {
          canv->Update();
 
-         TString fname = Form( "%s/plots/correlationscatter_%s_%s_c%i",dataset.Data(),var.Data(), extension.Data(), countCanvas );
+         TString fname = TString::Format( "%s/plots/correlationscatter_%s_%s_c%i",dataset.Data(),var.Data(), extension.Data(), countCanvas );
          TMVAGlob::plot_logo();
          TMVAGlob::imgconv( canv, fname );
       }

--- a/tmva/tmvagui/src/correlationscattersMultiClass.cxx
+++ b/tmva/tmvagui/src/correlationscattersMultiClass.cxx
@@ -10,30 +10,30 @@
 // input: - Input file (result from TMVA),
 //        - normal/decorrelated/PCA
 //        - use of TMVA plotting TStyle
-void TMVA::correlationscattersMultiClass(TString dataset, TString fin , TString var, 
+void TMVA::correlationscattersMultiClass(TString dataset, TString fin , TString var,
                                          TString dirName_ , TString /*title*/,
                                          Bool_t /*isRegression */,
                                          Bool_t useTMVAStyle )
 {
    // set style and remove existing canvas'
    TMVAGlob::Initialize( useTMVAStyle );
-   
+
    TString extension = dirName_;
    extension.ReplaceAll( "InputVariables", "" );
    extension.ReplaceAll( " ", "" );
    if (extension == "") extension = "_Id"; // use 'Id' for 'idendtity transform'
 
    var.ReplaceAll( extension, "" );
-   cout << "Called macro \"correlationscattersMultiClass\" for variable: \"" << var 
-        << "\", transformation type \"" << dirName_ 
+   cout << "Called macro \"correlationscattersMultiClass\" for variable: \"" << var
+        << "\", transformation type \"" << dirName_
         << "\" (extension: \"" << extension << "\")" << endl;
 
    // checks if file with name "fin" is already open, and if not opens one
-   TFile* file = TMVAGlob::OpenFile( fin );  
+   TFile* file = TMVAGlob::OpenFile( fin );
 
    TString dirName = dirName_ + "/CorrelationPlots";
-  
-   // find out number of input variables   
+
+   // find out number of input variables
    TDirectory* vardir = (TDirectory*)file->GetDirectory(dataset.Data())->Get( "InputVariables_Id" );
    if (!vardir) {
       cout << "ERROR: no such directory: \"InputVariables\"" << endl;
@@ -50,7 +50,7 @@ void TMVA::correlationscattersMultiClass(TString dataset, TString fin , TString 
 
    TListIter keyIt(dir->GetListOfKeys());
    Int_t noPlots = noVars - 1;
-   
+
    cout << "noPlots: " << noPlots << " --> noVars: " << noVars << endl;
    if (noVars != Int_t(noVars)) {
       cout << "*** Warning: problem in inferred number of variables ... not an integer *** " << endl;
@@ -74,7 +74,7 @@ void TMVA::correlationscattersMultiClass(TString dataset, TString fin , TString 
    default:
       xPad = 3; yPad = 2; width = 800; height = 0.55*width; break;
    }
-   Int_t noPadPerCanv = xPad * yPad ;   
+   Int_t noPadPerCanv = xPad * yPad ;
 
    // counter variables
    Int_t countCanvas = 0;
@@ -91,7 +91,7 @@ void TMVA::correlationscattersMultiClass(TString dataset, TString fin , TString 
       TCanvas* canv = 0;
 
       Int_t countPad    = 0;
-   
+
       while ( (key = (TKey*)next()) ) {
 
          if (key->GetCycle() != 1) continue;
@@ -101,25 +101,25 @@ void TMVA::correlationscattersMultiClass(TString dataset, TString fin , TString 
          if (!cl->InheritsFrom("TH1")) continue;
          TH1 *scat = (TH1*)key->ReadObj();
          TString hname = scat->GetName();
-         
+
          //std::cout << classnames[itype] << " " << extension << "" << hname << " " << var << std::endl;
          // check for scatter plots
-         if (! (hname.EndsWith( classnames[itype] + extension ) && 
+         if (! (hname.EndsWith( classnames[itype] + extension ) &&
                 hname.Contains( TString("_") + var + "_" ) && hname.BeginsWith("scat_")) ) {
             scat->Delete();
-            continue; 
+            continue;
          }
 
          // found a new signal plot
-            
+
          // create new canvas
          if (countPad%noPadPerCanv==0) {
             ++countCanvas;
             TString ext = extension; ext.Remove( 0, 1 );
-            canv = new TCanvas( Form("canvas%d", countCanvas), 
-                                Form("Correlation profiles for '%s'-transformed variables (%s)", 
+            canv = new TCanvas( TString::Format("canvas%d", countCanvas),
+                                TString::Format("Correlation profiles for '%s'-transformed variables (%s)",
                                      ext.Data(), classnames[itype].Data()),
-                                countCanvas*50+200, countCanvas*20, width, height ); 
+                                countCanvas*50+200, countCanvas*20, width, height );
             canv->Divide(xPad,yPad);
          }
 
@@ -139,17 +139,17 @@ void TMVA::correlationscattersMultiClass(TString dataset, TString fin , TString 
          // this is set but not stored during plot creation in MVA_Factory
          TMVAGlob::SetSignalAndBackgroundStyle( scat, prof );
 
-         // chop off "signal" 
+         // chop off "signal"
          TMVAGlob::SetFrameStyle( scat, 1.2 );
 
          // normalise both signal and background
          scat->Scale( 1.0/scat->GetSumOfWeights() );
 
-         // finally plot and overlay       
+         // finally plot and overlay
          // Float_t sc = 1.1;
          // if (countPad==2) sc = 1.3;
          scat->SetMarkerColor(  4);
-         scat->Draw("col");      
+         scat->Draw("col");
          prof->SetMarkerColor( gConfig().fVariablePlotting.fUsePaperStyle ? 1 : 2  );
          prof->SetMarkerSize( 0.2 );
          prof->SetLineColor( gConfig().fVariablePlotting.fUsePaperStyle ? 1 : 2 );
@@ -164,7 +164,7 @@ void TMVA::correlationscattersMultiClass(TString dataset, TString fin , TString 
          if (countPad%noPadPerCanv==0) {
             canv->Update();
 
-            TString fname = dataset+Form( "/plots/correlationscatter_%s_%s_c%i",var.Data(), extension.Data(), countCanvas );
+            TString fname = dataset+TString::Format( "/plots/correlationscatter_%s_%s_c%i",var.Data(), extension.Data(), countCanvas );
             TMVAGlob::plot_logo();
             TMVAGlob::imgconv( canv, fname );
          }
@@ -172,7 +172,7 @@ void TMVA::correlationscattersMultiClass(TString dataset, TString fin , TString 
       if (countPad%noPadPerCanv!=0) {
          canv->Update();
 
-         TString fname = dataset+Form( "/plots/correlationscatter_%s_%s_c%i",var.Data(), extension.Data(), countCanvas );
+         TString fname = dataset+TString::Format( "/plots/correlationscatter_%s_%s_c%i",var.Data(), extension.Data(), countCanvas );
          TMVAGlob::plot_logo();
          TMVAGlob::imgconv( canv, fname );
       }

--- a/tmva/tmvagui/src/deviations.cxx
+++ b/tmva/tmvagui/src/deviations.cxx
@@ -12,7 +12,7 @@
 
 // input: - Input file (result from TMVA)
 //        - use of TMVA plotting TStyle
-void TMVA::deviations(TString dataset, TString fin, 
+void TMVA::deviations(TString dataset, TString fin,
                       HistType htype , Bool_t showTarget, Bool_t useTMVAStyle  )
 {
    // set style and remove existing canvas'
@@ -20,7 +20,7 @@ void TMVA::deviations(TString dataset, TString fin,
    gStyle->SetNumberContours(999);
 
    // checks if file with name "fin" is already open, and if not opens one
-   TFile* file = TMVAGlob::OpenFile( fin );  
+   TFile* file = TMVAGlob::OpenFile( fin );
 
    // define Canvas layout here!
    const Int_t width = 650;   // size of canvas
@@ -35,7 +35,7 @@ void TMVA::deviations(TString dataset, TString fin,
    //    TList* methods = new TMap();
 
    TIter next(file->GetDirectory(dataset.Data())->GetListOfKeys());
-   TKey *key(0);   
+   TKey *key(0);
    while ((key = (TKey*)next())) {
 
       if (!TString(key->GetName()).BeginsWith("Method_")) continue;
@@ -60,7 +60,7 @@ void TMVA::deviations(TString dataset, TString fin,
          TObjString *jN = new TObjString( titDir->GetName() );
          if (!jobNames->Contains( jN )) jobNames->Add( jN );
          else delete jN;
-            
+
          TString methodTitle;
          TMVAGlob::GetMethodTitle(methodTitle,titDir);
 
@@ -72,16 +72,16 @@ void TMVA::deviations(TString dataset, TString fin,
          while ((dirKey = (TKey*)dirKeyIt())){
             if (dirKey->ReadObj()->InheritsFrom("TH2F")) {
                TString s(dirKey->ReadObj()->GetName());
-               if (s.Contains("_reg_") && 
-                   ( (showTarget && s.Contains("_tgt")) || (!showTarget && !s.Contains("_tgt")) ) && 
+               if (s.Contains("_reg_") &&
+                   ( (showTarget && s.Contains("_tgt")) || (!showTarget && !s.Contains("_tgt")) ) &&
                    s.Contains( (htype == kCompareType ? "train" : "test" ))) {
-                  c[countCanvas] = new TCanvas( Form("canvas%d", countCanvas+1), 
-                                                Form( "Regression output deviation versus %s for method: %s",
+                  c[countCanvas] = new TCanvas( TString::Format("canvas%d", countCanvas+1),
+                                                TString::Format( "Regression output deviation versus %s for method: %s",
                                                       (showTarget ? "target" : "input variables"), methodName.Data() ),
-                                                countCanvas*50+100, (countCanvas+1)*20, width, (Int_t)width*0.72 ); 
+                                                countCanvas*50+100, (countCanvas+1)*20, width, (Int_t)width*0.72 );
                   c[countCanvas]->SetRightMargin(0.10); // leave space for border
                   TH1* h = (TH1*)dirKey->ReadObj();
-                  h->SetTitle( Form("Output deviation for method: %s (%s sample)", 
+                  h->SetTitle( TString::Format("Output deviation for method: %s (%s sample)",
                                     hname.Data(), (htype == kCompareType ? "training" : "test" )) );
                   //                                    methodName.Data(), (htype == kCompareType ? "training" : "test" )) );
                   h->Draw("colz");
@@ -94,9 +94,9 @@ void TMVA::deviations(TString dataset, TString fin,
                   TMVAGlob::plot_logo(1.058);
                   c[countCanvas]->Update();
 
-                  TString fname = Form( "%s/plots/deviation_%s_%s_%s_c%i", 
+                  TString fname = TString::Format( "%s/plots/deviation_%s_%s_%s_c%i",
                                         dataset.Data(),
-                                        methodName.Data(), 
+                                        methodName.Data(),
                                         (showTarget ? "target" : "vars"),
                                         (htype == kCompareType ? "training" : "test" ), countPlots );
                   TMVAGlob::imgconv( c[countCanvas], fname );
@@ -105,7 +105,7 @@ void TMVA::deviations(TString dataset, TString fin,
                   countCanvas++;
                }
             }
-         }         
+         }
       }
    }
 }

--- a/tmva/tmvagui/src/efficienciesMulticlass.cxx
+++ b/tmva/tmvagui/src/efficienciesMulticlass.cxx
@@ -227,7 +227,7 @@ void TMVA::plotEfficienciesMulticlass(roccurvelist_t rocCurves, classcanvasmap_t
          plotWrapper->addGraph(h);
          plotWrapper->addLegendEntry(methodTitle, h);
       } catch (const std::out_of_range &) {
-         cout << Form("ERROR: Class %s discovered among plots but was not found by TMVAMulticlassGui. Skipping.",
+         cout << TString::Format("ERROR: Class %s discovered among plots but was not found by TMVAMulticlassGui. Skipping.",
                       classname.Data())
               << endl;
       }
@@ -280,8 +280,8 @@ void TMVA::plotEfficienciesMulticlass1vsRest(TString dataset, EEfficiencyPlotTyp
 
    classcanvasmap_t classCanvasMap;
    for (auto &classname : classnames) {
-      TString name = Form("roc_%s_vs_rest", classname.Data());
-      TString title = Form("ROC Curve %s vs rest", classname.Data());
+      TString name = TString::Format("roc_%s_vs_rest", classname.Data());
+      TString title = TString::Format("ROC Curve %s vs rest", classname.Data());
       EfficiencyPlotWrapper *plotWrapper = new EfficiencyPlotWrapper(name, title, dataset, iPlot++);
       classCanvasMap.emplace(classname.Data(), plotWrapper);
    }
@@ -316,8 +316,8 @@ void TMVA::efficienciesMulticlass1vs1(TString dataset, TString fin)
 
    // configure buttons
    for (auto &classname : classnames) {
-      cbar->AddButton(Form("Class: %s", classname.Data()),
-                      Form("TMVA::plotEfficienciesMulticlass1vs1(\"%s\", \"%s\", \"%s\")", dataset.Data(), fin.Data(),
+      cbar->AddButton(TString::Format("Class: %s", classname.Data()),
+                      TString::Format("TMVA::plotEfficienciesMulticlass1vs1(\"%s\", \"%s\", \"%s\")", dataset.Data(), fin.Data(),
                            classname.Data()),
                       BUTTON_TYPE);
    }
@@ -353,7 +353,7 @@ void TMVA::plotEfficienciesMulticlass1vs1(TString dataset, TString fin, TString 
    size_t iPlot = 0;
 
    TString methodPrefix = "MVA_";
-   TString graphNameRef = Form("_1v1rejBvsS_%s_vs_", baseClassname.Data());
+   TString graphNameRef = TString::Format("_1v1rejBvsS_%s_vs_", baseClassname.Data());
 
    TFile *file = TMVAGlob::OpenFile(fin);
    if (file == nullptr) {
@@ -369,8 +369,8 @@ void TMVA::plotEfficienciesMulticlass1vs1(TString dataset, TString fin, TString 
          continue;
       }
 
-      TString name = Form("1v1roc_%s_vs_%s", baseClassname.Data(), classname.Data());
-      TString title = Form("ROC Curve %s (Sig) vs %s (Bkg)", baseClassname.Data(), classname.Data());
+      TString name = TString::Format("1v1roc_%s_vs_%s", baseClassname.Data(), classname.Data());
+      TString title = TString::Format("ROC Curve %s (Sig) vs %s (Bkg)", baseClassname.Data(), classname.Data());
       EfficiencyPlotWrapper *plotWrapper = new EfficiencyPlotWrapper(name, title, dataset, iPlot++);
       classCanvasMap.emplace(classname.Data(), plotWrapper);
    }
@@ -474,7 +474,7 @@ TCanvas *EfficiencyPlotWrapper::newEfficiencyCanvas(TString name, TString title,
    Double_t y1 = 0.0;
    Double_t y2 = 1.0;
 
-   TH1F *frame = new TH1F(Form("%s_%s", title.Data(), "frame"), title, 500, x1, x2);
+   TH1F *frame = new TH1F(TString::Format("%s_frame", title.Data()), title, 500, x1, x2);
    frame->SetMinimum(y1);
    frame->SetMaximum(y2);
 

--- a/tmva/tmvagui/src/likelihoodrefs.cxx
+++ b/tmva/tmvagui/src/likelihoodrefs.cxx
@@ -47,7 +47,7 @@ void TMVA::likelihoodrefs(TString dataset, TDirectory *lhdir ) {
                snprintf( cn, 20, "cv%d_%s", ic+1, titName.Data() );
                ++ic;
                TString n = hname;
-               c[ic] = new TCanvas( cn, Form( "%s reference for variable: %s", 
+               c[ic] = new TCanvas( cn, TString::Format( "%s reference for variable: %s", 
                                               titName.Data(),(n.ReplaceAll("_sig","")).Data() ), 
                                     ic*50+50, ic*20, width, height ); 
                c[ic]->Divide(2,1);
@@ -108,7 +108,7 @@ void TMVA::likelihoodrefs(TString dataset, TDirectory *lhdir ) {
             b = 0;
             TString pname = hname; pname.ReplaceAll("_nice","");            
             for (int i=0; i<= 5; i++) {
-               TString hspline = pname + Form( "_smoothed_hist_from_spline%i", i );
+               TString hspline = pname + TString::Format( "_smoothed_hist_from_spline%i", i );
                h = (TH1F*)lhdir->Get( hspline );
                if (h) {
                   b = (TH1F*)lhdir->Get( hspline.ReplaceAll("_sig","_bgd") );
@@ -158,7 +158,7 @@ void TMVA::likelihoodrefs(TString dataset, TDirectory *lhdir ) {
             c[ic]->Update();
 
             // write to file
-            TString fname = Form( "%s/plots/%s_refs_c%i",dataset.Data(), titName.Data(), ic+1 );
+            TString fname = TString::Format( "%s/plots/%s_refs_c%i",dataset.Data(), titName.Data(), ic+1 );
             TMVAGlob::imgconv( c[ic], fname );
             //c[ic]->Update();
 

--- a/tmva/tmvagui/src/mvaeffs.cxx
+++ b/tmva/tmvagui/src/mvaeffs.cxx
@@ -58,7 +58,7 @@ void TMVA::MethodInfo::SetResultHists()
    effpurS = new TH1F(epname, epname, nbins, low, high);
 
    // chop off useless stuff
-   sigE->SetTitle( Form("Cut efficiencies for %s classifier", methodTitle.Data()) );
+   sigE->SetTitle( TString::Format("Cut efficiencies for %s classifier", methodTitle.Data()) );
 
    // set the histogram style
    TMVAGlob::SetSignalAndBackgroundStyle( sigE, bgdE );
@@ -253,7 +253,7 @@ void TMVA::StatDialogMVAEffs::UpdateSignificanceHists()
    MethodInfo* info(0);
    TString cname = "Classifier";
    if (cname.Length() >  maxLenTitle)  maxLenTitle = cname.Length();
-   TString str = Form( "%*s   (  #signal, #backgr.)  Optimal-cut  %s      NSig      NBkg   EffSig   EffBkg",
+   TString str = TString::Format( "%*s   (  #signal, #backgr.)  Optimal-cut  %s      NSig      NBkg   EffSig   EffBkg",
                        maxLenTitle, cname.Data(), GetFormulaString().Data() );
    cout << "--- " << setfill('=') << setw(str.Length()) << "" << setfill(' ') << endl;
    cout << "--- " << str << endl;
@@ -351,12 +351,12 @@ void TMVA::StatDialogMVAEffs::DrawHistograms()
    Int_t signifColor = TColor::GetColor( "#00aa00" );
 
    TIter next(fInfoList);
-   MethodInfo* info(0);
+   MethodInfo* info = nullptr;
    while ( (info = (MethodInfo*)next()) ) {
 
       // create new canvas
-      TCanvas *c = new TCanvas( Form("canvas%d", countCanvas+1),
-                                Form("Cut efficiencies for %s classifier",info->methodTitle.Data()),
+      TCanvas *c = new TCanvas( TString::Format("canvas%d", countCanvas+1),
+                                TString::Format("Cut efficiencies for %s classifier",info->methodTitle.Data()),
                                 countCanvas*50+200, countCanvas*20, width, Int_t(width*0.78) );
       info->canvas = c;
 
@@ -431,17 +431,17 @@ void TMVA::StatDialogMVAEffs::DrawHistograms()
       tl.SetNDC();
       tl.SetTextSize( 0.033 );
       Int_t maxbin = info->sSig->GetMaximumBin();
-      info->line1 = tl.DrawLatex( 0.15, 0.23, Form("For %1.0f signal and %1.0f background", fNSignal, fNBackground));
+      info->line1 = tl.DrawLatex( 0.15, 0.23, TString::Format("For %1.0f signal and %1.0f background", fNSignal, fNBackground));
       tl.DrawLatex( 0.15, 0.19, "events the maximum "+GetLatexFormula()+" is");
 
       if (info->maxSignificanceErr > 0) {
-         info->line2 = tl.DrawLatex( 0.15, 0.15, Form("%5.2f +- %4.2f when cutting at %5.2f",
+         info->line2 = tl.DrawLatex( 0.15, 0.15, TString::Format("%5.2f +- %4.2f when cutting at %5.2f",
                                                       info->maxSignificance,
                                                       info->maxSignificanceErr,
                                                       info->sSig->GetXaxis()->GetBinCenter(maxbin)) );
       }
       else {
-         info->line2 = tl.DrawLatex( 0.15, 0.15, Form("%4.2f when cutting at %5.2f",
+         info->line2 = tl.DrawLatex( 0.15, 0.15, TString::Format("%4.2f when cutting at %5.2f",
                                                       info->maxSignificance,
                                                       info->sSig->GetXaxis()->GetBinCenter(maxbin)) );
       }
@@ -471,7 +471,7 @@ void TMVA::StatDialogMVAEffs::DrawHistograms()
       const Bool_t Save_Images = kTRUE;
 
       if (Save_Images) {
-         TMVAGlob::imgconv( c, Form("%s/plots/mvaeffs_%s",dataset.Data(), info->methodTitle.Data()) );
+         TMVAGlob::imgconv( c, TString::Format("%s/plots/mvaeffs_%s",dataset.Data(), info->methodTitle.Data()) );
       }
       countCanvas++;
    }
@@ -481,24 +481,24 @@ void TMVA::StatDialogMVAEffs::PrintResults( const MethodInfo* info )
 {
    Int_t maxbin = info->sSig->GetMaximumBin();
    if (info->line1 !=0 )
-      info->line1->SetText( 0.15, 0.23, Form("For %1.0f signal and %1.0f background", fNSignal, fNBackground));
+      info->line1->SetText( 0.15, 0.23, TString::Format("For %1.0f signal and %1.0f background", fNSignal, fNBackground));
 
    if (info->line2 !=0 ) {
       if (info->maxSignificanceErr > 0) {
-         info->line2->SetText( 0.15, 0.15, Form("%3.2g +- %3.2g when cutting at %3.2g",
+         info->line2->SetText( 0.15, 0.15, TString::Format("%3.2g +- %3.2g when cutting at %3.2g",
                                                 info->maxSignificance,
                                                 info->maxSignificanceErr,
                                                 info->sSig->GetXaxis()->GetBinCenter(maxbin)) );
       }
       else {
-         info->line2->SetText( 0.15, 0.15, Form("%3.4f when cutting at %3.4f", info->maxSignificance,
+         info->line2->SetText( 0.15, 0.15, TString::Format("%3.4f when cutting at %3.4f", info->maxSignificance,
                                                 info->sSig->GetXaxis()->GetBinCenter(maxbin)) );
       }
 
    }
 
    if (info->maxSignificanceErr <= 0) {
-      TString opt = Form( "%%%is:  (%%9.8g,%%9.8g)    %%9.4f   %%10.6g  %%8.7g  %%8.7g %%8.4g %%8.4g",
+      TString opt = TString::Format( "%%%is:  (%%9.8g,%%9.8g)    %%9.4f   %%10.6g  %%8.7g  %%8.7g %%8.4g %%8.4g",
                           maxLenTitle );
       cout << "--- "
            << Form( opt.Data(),
@@ -512,7 +512,7 @@ void TMVA::StatDialogMVAEffs::PrintResults( const MethodInfo* info )
            << endl;
    }
    else {
-      TString opt = Form( "%%%is:  (%%9.8g,%%9.8g)    %%9.4f   (%%8.3g  +-%%6.3g)  %%8.7g  %%8.7g %%8.4g %%8.4g",
+      TString opt = TString::Format( "%%%is:  (%%9.8g,%%9.8g)    %%9.4f   (%%8.3g  +-%%6.3g)  %%8.7g  %%8.7g %%8.4g %%8.4g",
                           maxLenTitle );
       cout << "--- "
            << Form( opt.Data(),

--- a/tmva/tmvagui/src/mvas.cxx
+++ b/tmva/tmvagui/src/mvas.cxx
@@ -22,7 +22,7 @@ void TMVA::mvas(TString dataset, TString fin, HistType htype, Bool_t useTMVAStyl
    const Bool_t Save_Images = kTRUE;
 
    // checks if file with name "fin" is already open, and if not opens one
-   TFile* file = TMVAGlob::OpenFile( fin );  
+   TFile* file = TMVAGlob::OpenFile( fin );
 
    // define Canvas layout here!
    const Int_t width = 600;   // size of canvas
@@ -35,7 +35,7 @@ void TMVA::mvas(TString dataset, TString fin, HistType htype, Bool_t useTMVAStyl
 
    // search for the right histograms in full list of keys
    TIter next(file->GetDirectory(dataset.Data())->GetListOfKeys());
-   TKey *key(0);   
+   TKey *key(0);
    while ((key = (TKey*)next())) {
 
       if (!TString(key->GetName()).BeginsWith("Method_")) continue;
@@ -64,13 +64,13 @@ void TMVA::mvas(TString dataset, TString fin, HistType htype, Bool_t useTMVAStyl
          TH1* bgd = dynamic_cast<TH1*>(titDir->Get( hname + "_B" ));
 
          if (sig==0 || bgd==0) {
-            if     (htype == kMVAType)     
+            if     (htype == kMVAType)
                cout << ":\t mva distribution not available (this is normal for Cut classifier)" << endl;
-            else if(htype == kProbaType)   
+            else if(htype == kProbaType)
                cout << ":\t probability distribution not available" << endl;
-            else if(htype == kRarityType)  
+            else if(htype == kRarityType)
                cout << ":\t rarity distribution not available" << endl;
-            else if(htype == kCompareType) 
+            else if(htype == kCompareType)
                cout << ":\t overtraining check not available" << endl;
             else cout << endl;
             continue;
@@ -78,67 +78,67 @@ void TMVA::mvas(TString dataset, TString fin, HistType htype, Bool_t useTMVAStyl
 
          cout << " containing " << hname << "_S/_B" << endl;
          // chop off useless stuff
-         sig->SetTitle( Form("TMVA response for classifier: %s", methodTitle.Data()) );
-         if      (htype == kProbaType) 
-            sig->SetTitle( Form("TMVA probability for classifier: %s", methodTitle.Data()) );
-         else if (htype == kRarityType) 
-            sig->SetTitle( Form("TMVA Rarity for classifier: %s", methodTitle.Data()) );
-         else if (htype == kCompareType) 
-            sig->SetTitle( Form("TMVA overtraining check for classifier: %s", methodTitle.Data()) );
-         
+         sig->SetTitle( TString::Format("TMVA response for classifier: %s", methodTitle.Data()) );
+         if      (htype == kProbaType)
+            sig->SetTitle( TString::Format("TMVA probability for classifier: %s", methodTitle.Data()) );
+         else if (htype == kRarityType)
+            sig->SetTitle( TString::Format("TMVA Rarity for classifier: %s", methodTitle.Data()) );
+         else if (htype == kCompareType)
+            sig->SetTitle( TString::Format("TMVA overtraining check for classifier: %s", methodTitle.Data()) );
+
          // create new canvas
-         TString ctitle = ((htype == kMVAType) ? 
-                           Form("TMVA response %s",methodTitle.Data()) : 
-                           (htype == kProbaType) ? 
-                           Form("TMVA probability %s",methodTitle.Data()) :
-                           (htype == kCompareType) ? 
-                           Form("TMVA comparison %s",methodTitle.Data()) :
-                           Form("TMVA Rarity %s",methodTitle.Data()));
-         
-         c = new TCanvas( Form("canvas%d", countCanvas+1), ctitle, 
-                          countCanvas*50+200, countCanvas*20, width, (Int_t)width*0.78 ); 
-    
+         TString ctitle = ((htype == kMVAType) ?
+                           TString::Format("TMVA response %s",methodTitle.Data()) :
+                           (htype == kProbaType) ?
+                           TString::Format("TMVA probability %s",methodTitle.Data()) :
+                           (htype == kCompareType) ?
+                           TString::Format("TMVA comparison %s",methodTitle.Data()) :
+                           TString::Format("TMVA Rarity %s",methodTitle.Data()));
+
+         c = new TCanvas( TString::Format("canvas%d", countCanvas+1), ctitle,
+                          countCanvas*50+200, countCanvas*20, width, (Int_t)width*0.78 );
+
          // set the histogram style
          TMVAGlob::SetSignalAndBackgroundStyle( sig, bgd );
-         
+
          // normalise both signal and background
          TMVAGlob::NormalizeHists( sig, bgd );
-         
+
          // frame limits (choose judicuous x range)
          Float_t nrms = 10;
          cout << "--- Mean and RMS (S): " << sig->GetMean() << ", " << sig->GetRMS() << endl;
          cout << "--- Mean and RMS (B): " << bgd->GetMean() << ", " << bgd->GetRMS() << endl;
-         Float_t xmin = TMath::Max( TMath::Min(sig->GetMean() - nrms*sig->GetRMS(), 
+         Float_t xmin = TMath::Max( TMath::Min(sig->GetMean() - nrms*sig->GetRMS(),
                                                bgd->GetMean() - nrms*bgd->GetRMS() ),
                                     sig->GetXaxis()->GetXmin() );
-         Float_t xmax = TMath::Min( TMath::Max(sig->GetMean() + nrms*sig->GetRMS(), 
+         Float_t xmax = TMath::Min( TMath::Max(sig->GetMean() + nrms*sig->GetRMS(),
                                                bgd->GetMean() + nrms*bgd->GetRMS() ),
                                     sig->GetXaxis()->GetXmax() );
          Float_t ymin = 0;
          Float_t maxMult = (htype == kCompareType) ? 1.3 : 1.2;
          Float_t ymax = TMath::Max( sig->GetMaximum(), bgd->GetMaximum() )*maxMult;
-   
+
          // build a frame
          Int_t nb = 500;
          TString hFrameName(TString("frame") + methodTitle);
          TObject *o = gROOT->FindObject(hFrameName);
          if(o) delete o;
-         TH2F* frame = new TH2F( hFrameName, sig->GetTitle(), 
+         TH2F* frame = new TH2F( hFrameName, sig->GetTitle(),
                                  nb, xmin, xmax, nb, ymin, ymax );
          frame->GetXaxis()->SetTitle( methodTitle + ((htype == kMVAType || htype == kCompareType) ? " response" : "") );
          if      (htype == kProbaType  ) frame->GetXaxis()->SetTitle( "Signal probability" );
          else if (htype == kRarityType ) frame->GetXaxis()->SetTitle( "Signal rarity" );
          frame->GetYaxis()->SetTitle("(1/N) dN^{ }/^{ }dx");
          TMVAGlob::SetFrameStyle( frame );
-   
+
          // eventually: draw the frame
-         frame->Draw();  
-    
+         frame->Draw();
+
          c->GetPad(0)->SetLeftMargin( 0.105 );
          frame->GetYaxis()->SetTitleOffset( 1.2 );
 
-         // Draw legend               
-         TLegend *legend= new TLegend( c->GetLeftMargin(), 1 - c->GetTopMargin() - 0.12, 
+         // Draw legend
+         TLegend *legend= new TLegend( c->GetLeftMargin(), 1 - c->GetTopMargin() - 0.12,
                                        c->GetLeftMargin() + (htype == kCompareType ? 0.40 : 0.3), 1 - c->GetTopMargin() );
          legend->SetFillStyle( 1 );
          legend->AddEntry(sig,TString("Signal")     + ((htype == kCompareType) ? " (test sample)" : ""), "F");
@@ -150,7 +150,7 @@ void TMVA::mvas(TString dataset, TString fin, HistType htype, Bool_t useTMVAStyl
          // overlay signal and background histograms
          sig->Draw("samehist");
          bgd->Draw("samehist");
-   
+
          if (htype == kCompareType) {
             // if overtraining check, load additional histograms
             TH1* sigOv = 0;
@@ -159,7 +159,7 @@ void TMVA::mvas(TString dataset, TString fin, HistType htype, Bool_t useTMVAStyl
             TString ovname = hname += "_Train";
             sigOv = dynamic_cast<TH1*>(titDir->Get( ovname + "_S" ));
             bgdOv = dynamic_cast<TH1*>(titDir->Get( ovname + "_B" ));
-      
+
             if (sigOv == 0 || bgdOv == 0) {
                cout << "+++ Problem in \"mvas.C\": overtraining check histograms do not exist" << endl;
             }
@@ -185,7 +185,7 @@ void TMVA::mvas(TString dataset, TString fin, HistType htype, Bool_t useTMVAStyl
             sigOv->SetLineWidth( 1 );
             sigOv->SetLineColor( col );
             sigOv->Draw("e1same");
-      
+
             col = bgd->GetLineColor();
             bgdOv->SetMarkerColor( col );
             bgdOv->SetMarkerSize( 0.7 );
@@ -196,7 +196,7 @@ void TMVA::mvas(TString dataset, TString fin, HistType htype, Bool_t useTMVAStyl
 
             ymax = TMath::Max( ymax, float(TMath::Max( sigOv->GetMaximum(), bgdOv->GetMaximum() )*maxMult ));
             frame->GetYaxis()->SetLimits( 0, ymax );
-      
+
             // for better visibility, plot thinner lines
             sig->SetLineWidth( 1 );
             bgd->SetLineWidth( 1 );
@@ -207,9 +207,9 @@ void TMVA::mvas(TString dataset, TString fin, HistType htype, Bool_t useTMVAStyl
             Double_t kolB = bgd->KolmogorovTest( bgdOv, "X" );
             cout << "--- Goodness of signal (background) consistency: " << kolS << " (" << kolB << ")" << endl;
 
-            TString probatext = Form( "Kolmogorov-Smirnov test: signal (background) probability = %5.3g (%5.3g)", kolS, kolB );
+            TString probatext = TString::Format( "Kolmogorov-Smirnov test: signal (background) probability = %5.3g (%5.3g)", kolS, kolB );
             TText* tt = new TText( 0.12, 0.74, probatext );
-            tt->SetNDC(); tt->SetTextSize( 0.032 ); tt->AppendPad(); 
+            tt->SetNDC(); tt->SetTextSize( 0.032 ); tt->AppendPad();
          }
 
          // redraw axes
@@ -219,15 +219,15 @@ void TMVA::mvas(TString dataset, TString fin, HistType htype, Bool_t useTMVAStyl
          Int_t    nbin = sig->GetNbinsX();
          Double_t dxu  = sig->GetBinWidth(0);
          Double_t dxo  = sig->GetBinWidth(nbin+1);
-         TString uoflow = Form( "U/O-flow (S,B): (%.1f, %.1f)%% / (%.1f, %.1f)%%", 
+         TString uoflow = TString::Format( "U/O-flow (S,B): (%.1f, %.1f)%% / (%.1f, %.1f)%%",
                                 sig->GetBinContent(0)*dxu*100, bgd->GetBinContent(0)*dxu*100,
                                 sig->GetBinContent(nbin+1)*dxo*100, bgd->GetBinContent(nbin+1)*dxo*100 );
          TText* t = new TText( 0.975, 0.115, uoflow );
          t->SetNDC();
          t->SetTextSize( 0.030 );
          t->SetTextAngle( 90 );
-         t->AppendPad();    
-   
+         t->AppendPad();
+
          // update canvas
          c->Update();
 
@@ -235,13 +235,13 @@ void TMVA::mvas(TString dataset, TString fin, HistType htype, Bool_t useTMVAStyl
 
          TMVAGlob::plot_logo(1.058);
          if (Save_Images) {
-            if      (htype == kMVAType)     TMVAGlob::imgconv( c, Form("%s/plots/mva_%s",dataset.Data(),     methodTitle.Data()) );
-            else if (htype == kProbaType)   TMVAGlob::imgconv( c, Form("%s/plots/proba_%s",dataset.Data(),   methodTitle.Data()) ); 
-            else if (htype == kCompareType) TMVAGlob::imgconv( c, Form("%s/plots/overtrain_%s",dataset.Data(), methodTitle.Data()) ); 
-            else                           TMVAGlob::imgconv( c, Form("%s/plots/rarity_%s",dataset.Data(), methodTitle.Data()) ); 
+            if      (htype == kMVAType)     TMVAGlob::imgconv( c, TString::Format("%s/plots/mva_%s",dataset.Data(),     methodTitle.Data()) );
+            else if (htype == kProbaType)   TMVAGlob::imgconv( c, TString::Format("%s/plots/proba_%s",dataset.Data(),   methodTitle.Data()) );
+            else if (htype == kCompareType) TMVAGlob::imgconv( c, TString::Format("%s/plots/overtrain_%s",dataset.Data(), methodTitle.Data()) );
+            else                            TMVAGlob::imgconv( c, TString::Format("%s/plots/rarity_%s",dataset.Data(), methodTitle.Data()) );
          }
          countCanvas++;
-         
+
       }
       cout << "";
    }

--- a/tmva/tmvagui/src/mvasMulticlass.cxx
+++ b/tmva/tmvagui/src/mvasMulticlass.cxx
@@ -91,15 +91,15 @@ void TMVA::mvasMulticlass(TString dataset, TString fin , HistType htype , Bool_t
 
 
             // chop off useless stuff
-            ((TH1*)hists.First())->SetTitle( Form("TMVA response for classifier: %s", methodTitle.Data() ));
+            ((TH1*)hists.First())->SetTitle( TString::Format("TMVA response for classifier: %s", methodTitle.Data() ));
 
             // create new canvas
             //cout << "Create canvas..." << endl;
             TString ctitle = ((htype == kMVAType) ?
-                              Form("TMVA response for class %s %s", classnames.at(icls).Data(),methodTitle.Data()) :
-                              Form("TMVA comparison for class %s %s", classnames.at(icls).Data(),methodTitle.Data())) ;
+                              TString::Format("TMVA response for class %s %s", classnames.at(icls).Data(),methodTitle.Data()) :
+                              TString::Format("TMVA comparison for class %s %s", classnames.at(icls).Data(),methodTitle.Data())) ;
 
-            c = new TCanvas( Form("canvas%d", countCanvas+1), ctitle,
+            c = new TCanvas( TString::Format("canvas%d", countCanvas+1), ctitle,
                              countCanvas*50+200, countCanvas*20, width, (Int_t)width*0.78 );
 
             // set the histogram style
@@ -226,7 +226,7 @@ void TMVA::mvasMulticlass(TString dataset, TString fin , HistType htype , Bool_t
                for(Int_t j=0; j<othists.GetEntriesFast(); ++j){
                   Float_t kol = ((TH1*)hists[j])->KolmogorovTest(((TH1*)othists[j]),"X");
                   cout <<  classnames.at(j) << ": " << kol  << endl;
-                  //probatext.Append(classnames.at(j)+Form(" %.3f ",kol));
+                  //probatext.Append(classnames.at(j)+TString::Format(" %.3f ",kol));
                }
 
 
@@ -244,7 +244,7 @@ void TMVA::mvasMulticlass(TString dataset, TString fin , HistType htype , Bool_t
             //Int_t    nbin = sig->GetNbinsX();
             //Double_t dxu  = sig->GetBinWidth(0);
             //Double_t dxo  = sig->GetBinWidth(nbin+1);
-            //TString uoflow = Form( "U/O-flow (S,B): (%.1f, %.1f)%% / (%.1f, %.1f)%%",
+            //TString uoflow = TString::Format( "U/O-flow (S,B): (%.1f, %.1f)%% / (%.1f, %.1f)%%",
             //                       sig->GetBinContent(0)*dxu*100, bgd->GetBinContent(0)*dxu*100,
             //                      sig->GetBinContent(nbin+1)*dxo*100, bgd->GetBinContent(nbin+1)*dxo*100 );
             //TText* t = new TText( 0.975, 0.115, uoflow );
@@ -260,8 +260,8 @@ void TMVA::mvasMulticlass(TString dataset, TString fin , HistType htype , Bool_t
 
             TMVAGlob::plot_logo(1.058);
             if (Save_Images) {
-               if      (htype == kMVAType)     TMVAGlob::imgconv( c, Form("%s/plots/mva_%s_%s",dataset.Data(),classnames.at(icls).Data(), methodTitle.Data()) );
-               else if      (htype == kCompareType)     TMVAGlob::imgconv( c, Form("%s/plots/overtrain_%s_%s",dataset.Data(),classnames.at(icls).Data(), methodTitle.Data()) );
+               if      (htype == kMVAType)     TMVAGlob::imgconv( c, TString::Format("%s/plots/mva_%s_%s",dataset.Data(),classnames.at(icls).Data(), methodTitle.Data()) );
+               else if      (htype == kCompareType)     TMVAGlob::imgconv( c, TString::Format("%s/plots/overtrain_%s_%s",dataset.Data(),classnames.at(icls).Data(), methodTitle.Data()) );
 
             }
             countCanvas++;

--- a/tmva/tmvagui/src/mvaweights.cxx
+++ b/tmva/tmvagui/src/mvaweights.cxx
@@ -22,8 +22,8 @@ void TMVA::mvaweights( TString fin , Bool_t useTMVAStyle )
    // switches
    const Bool_t Save_Images     = kTRUE;
 
-   // checks if file with name "fin" is already open, and if not opens one   
-   TFile* file = TMVAGlob::OpenFile( fin );  
+   // checks if file with name "fin" is already open, and if not opens one
+   TFile* file = TMVAGlob::OpenFile( fin );
    if (!file) {
       cout << "Cannot open flie: " << fin << endl;
       return;
@@ -37,7 +37,7 @@ void TMVA::mvaweights( TString fin , Bool_t useTMVAStyle )
 
    // counter variables
    Int_t countCanvas = 0;
-   
+
    // retrieve trees
    TTree *tree = (TTree*)file->Get( "TestTree" );
 
@@ -46,26 +46,26 @@ void TMVA::mvaweights( TString fin , Bool_t useTMVAStyle )
    for (Int_t imva=0; imva<branches->GetEntries(); imva++) {
       TBranch* b = (TBranch*)(*branches)[imva];
       TString methodS = b->GetName();
-      cout << "Use MVA output of Method " << methodS <<endl; 
-      
+      cout << "Use MVA output of Method " << methodS <<endl;
+
       if (!methodS.BeginsWith("MVA_") || methodS.EndsWith("_Proba")) continue;
       if (methodS.Contains("Cuts") ) continue;
-      
+
       methodS.Remove(0,4);
-      cout << "--- Found variable: \"" << methodS << "\"" << endl;      
-      
+      cout << "--- Found variable: \"" << methodS << "\"" << endl;
+
       // create new canvas
-      TString cname = Form("TMVA output %s",methodS.Data());
-      c = new TCanvas( Form("canvas%d", countCanvas+1), cname, 
-                       countCanvas*50+200, countCanvas*20, width, width*1.0 ); 
+      TString cname = TString::Format("TMVA output %s",methodS.Data());
+      c = new TCanvas( TString::Format("canvas%d", countCanvas+1), cname,
+                       countCanvas*50+200, countCanvas*20, width, width*1.0 );
       c->Divide( 1, 1 );
-          
+
       // set the histogram style
       Float_t xmin = tree->GetMinimum( varx );
       Float_t xmax = tree->GetMaximum( varx );
       Float_t ymin = tree->GetMinimum( vary );
       Float_t ymax = tree->GetMaximum( vary );
-      
+
       Int_t nbin = 100;
       TH2F* frame   = new TH2F( "frame",  "frame",  nbin, xmin, xmax, nbin, ymin, ymax );
       TH2F* frameS  = new TH2F( "DataS",  "DataS",  nbin, xmin, xmax, nbin, ymin, ymax );
@@ -76,31 +76,31 @@ void TMVA::mvaweights( TString fin , Bool_t useTMVAStyle )
       Int_t nbinC = 20;
       TH2F* refS = new TH2F( "RefS", "RefS", nbinC, xmin, xmax, nbinC, ymin, ymax );
       TH2F* refB = new TH2F( "RefB", "RefB", nbinC, xmin, xmax, nbinC, ymin, ymax );
-      
-      Float_t mvaMin = tree->GetMinimum( Form( "MVA_%s", methodS.Data() ) );
-      Float_t mvaMax = tree->GetMaximum( Form( "MVA_%s", methodS.Data() ) );
+
+      Float_t mvaMin = tree->GetMinimum( TString::Format( "MVA_%s", methodS.Data() ) );
+      Float_t mvaMax = tree->GetMaximum( TString::Format( "MVA_%s", methodS.Data() ) );
 
       // project trees
-      TString expr = Form( "((MVA_%s-(%f))/(%f-(%f)))", methodS.Data(), mvaMin, mvaMax, mvaMin );
+      TString expr = TString::Format( "((MVA_%s-(%f))/(%f-(%f)))", methodS.Data(), mvaMin, mvaMax, mvaMin );
       cout << "Expression = " << expr << endl;
-      tree->Project( "DataS", Form( "%s:%s", vary.Data(), varx.Data() ), 
-                     Form( "%s*(type==1)", expr.Data() ) );
-      tree->Project( "DataB", Form( "%s:%s", vary.Data(), varx.Data() ), 
-                     Form( "%s*(type==0)", expr.Data() ) );
-      tree->Project( "DataRS", Form( "%s:%s", vary.Data(), varx.Data() ), 
+      tree->Project( "DataS", TString::Format( "%s:%s", vary.Data(), varx.Data() ),
+                     TString::Format( "%s*(type==1)", expr.Data() ) );
+      tree->Project( "DataB", TString::Format( "%s:%s", vary.Data(), varx.Data() ),
+                     TString::Format( "%s*(type==0)", expr.Data() ) );
+      tree->Project( "DataRS", TString::Format( "%s:%s", vary.Data(), varx.Data() ),
                      "type==1" );
-      tree->Project( "DataRB", Form( "%s:%s", vary.Data(), varx.Data() ), 
+      tree->Project( "DataRB", TString::Format( "%s:%s", vary.Data(), varx.Data() ),
                      "type==0" );
-      tree->Project( "RefS", Form( "%s:%s", vary.Data(), varx.Data() ), 
+      tree->Project( "RefS", TString::Format( "%s:%s", vary.Data(), varx.Data() ),
                      "type==1", "", 500000  );
-      tree->Project( "RefB", Form( "%s:%s", vary.Data(), varx.Data() ), 
+      tree->Project( "RefB", TString::Format( "%s:%s", vary.Data(), varx.Data() ),
                      "type==0", "", 500000, 10000 );
 
       Float_t zminS = frameS->GetMinimum();
       Float_t zmaxS = frameS->GetMaximum();
       Float_t zminB = frameB->GetMinimum();
       Float_t zmaxB = frameB->GetMaximum();
-      // normalise      
+      // normalise
       for (Int_t i=1; i<=nbin; i++) {
          for (Int_t j=1; j<=nbin; j++) {
             // signal
@@ -125,7 +125,7 @@ void TMVA::mvaweights( TString fin , Bool_t useTMVAStyle )
       zmaxS = frameS->GetMaximum();
       zminB = frameB->GetMinimum();
       zmaxB = frameB->GetMaximum();
-      // renormalise      
+      // renormalise
       for (Int_t i=1; i<=nbin; i++) {
          for (Int_t j=1; j<=nbin; j++) {
             // signal
@@ -145,9 +145,9 @@ void TMVA::mvaweights( TString fin , Bool_t useTMVAStyle )
       frameS->SetMaximum( +1.0 );
       frameB->SetMinimum( -1.0 );
       frameB->SetMaximum( +1.0 );
-      
+
       // axis labels
-      frame->SetTitle( Form( "Signal and background distributions weighted by %s output", 
+      frame->SetTitle( TString::Format( "Signal and background distributions weighted by %s output",
                              methodS.Data() ) );
       frame->SetTitleSize( 0.08 );
       frame->GetXaxis()->SetTitle( varx );
@@ -184,7 +184,7 @@ void TMVA::mvaweights( TString fin , Bool_t useTMVAStyle )
       // set style
       refS->SetMarkerSize( 0.2 );
       refS->SetMarkerColor( 104 );
-      
+
       refB->SetMarkerSize( 0.2 );
       refB->SetMarkerColor( 102 );
 
@@ -207,17 +207,17 @@ void TMVA::mvaweights( TString fin , Bool_t useTMVAStyle )
 
       // and plot
       c->cd(1);
-      
+
       frame->Draw();
       frameS->Draw( "contsame" );
       refS->Draw( "cont3same" );
-      refB->Draw( "cont3same" );  
+      refB->Draw( "cont3same" );
       //      frameB->Draw( "colzsame" );
 
       // save canvas to file
       c->Update();
       if (Save_Images) {
-         TMVAGlob::imgconv( c, Form("plots/mvaweights_%s",   methodS.Data()) );
+         TMVAGlob::imgconv( c, TString::Format("plots/mvaweights_%s",   methodS.Data()) );
       }
       countCanvas++;
    }

--- a/tmva/tmvagui/src/network.cxx
+++ b/tmva/tmvagui/src/network.cxx
@@ -52,8 +52,8 @@ void TMVA::draw_network(TString dataset, TFile* f, TDirectory* d, const TString&
    Int_t ixc = 100 + (icanvas)*40;
    Int_t iyc =   0 + (icanvas+1)*20;
    if (MovieMode) ixc = iyc = 0;
-   TString canvasnumber =  Form( "c%i", icanvas );
-   TString canvastitle = Form("Neural Network Layout for: %s", d->GetName());
+   TString canvasnumber =  TString::Format( "c%i", icanvas );
+   TString canvastitle = TString::Format("Neural Network Layout for: %s", d->GetName());
    TCanvas* c = new TCanvas( canvasnumber, canvastitle,
                              ixc, 0 + (icanvas+1)*20, 1000, 650  );
    icanvas++;
@@ -135,7 +135,7 @@ void TMVA::draw_network(TString dataset, TFile* f, TDirectory* d, const TString&
       t.SetTextColor( 0 );
       t.SetTextAlign( 31 );
       t.DrawTextNDC( 1 - c->GetRightMargin(), 1 - c->GetTopMargin() - 0.033,
-                      Form( "Epoch: %s", epoch.Data() ) );
+                      TString::Format( "Epoch: %s", epoch.Data() ) );
    }
 
    // ============================================================
@@ -178,7 +178,7 @@ void TMVA::draw_layer_labels(Int_t nLayers)
    Double_t margY = LABEL_HEIGHT - height;
 
    for (Int_t i = 0; i < nLayers; i++) {
-      TString label = Form("Layer %i", i);
+      TString label = TString::Format("Layer %i", i);
       if (i == nLayers-1) label = "Output layer";
       Double_t cx = i*(1.0-LABEL_WIDTH)/nLayers+1.0/(2.0*nLayers)+LABEL_WIDTH;
       Double_t x1 = cx-0.8*effWidth/2.0;
@@ -186,7 +186,7 @@ void TMVA::draw_layer_labels(Int_t nLayers)
       Double_t y1 = margY;
       Double_t y2 = margY + height;
 
-      TPaveLabel *p = new TPaveLabel(x1, y1, x2, y2, label+"", "br");
+      TPaveLabel *p = new TPaveLabel(x1, y1, x2, y2, label, "br");
       p->SetFillColor(gStyle->GetTitleFillColor());
       p->SetTextColor(gStyle->GetTitleTextColor());
       p->SetFillStyle(1001);
@@ -309,8 +309,8 @@ void TMVA::draw_activation(TCanvas* c, Double_t cx, Double_t cy,
 
    radx *= 0.7;
    rady *= 0.7;
-   TString name = Form("activation%f%f", cx, cy);
-   TPad* p = new TPad(name+"", name+"", cx-radx, cy-rady, cx+radx, cy+rady);
+   TString name = TString::Format("activation%f%f", cx, cy);
+   TPad* p = new TPad(name, name, cx-radx, cy-rady, cx+radx, cy+rady);
 
    p->Draw();
    p->cd();

--- a/tmva/tmvagui/src/paracoor.cxx
+++ b/tmva/tmvagui/src/paracoor.cxx
@@ -18,7 +18,7 @@ void TMVA::paracoor(TString dataset, TString fin , Bool_t useTMVAStyle )
    TMVAGlob::Initialize( useTMVAStyle );
 
    // checks if file with name "fin" is already open, and if not opens one
-   TFile* file = TMVAGlob::OpenFile( fin );  
+   TFile* file = TMVAGlob::OpenFile( fin );
    TTree* tree = (TTree*)file->GetDirectory(dataset.Data())->Get("TestTree");
    if(!tree) {
       cout << "--- No TestTree saved in ROOT file. Parallel coordinates will not be plotted" << endl;
@@ -28,13 +28,13 @@ void TMVA::paracoor(TString dataset, TString fin , Bool_t useTMVAStyle )
    // first get list of leaves in tree
    TObjArray* leafList = tree->GetListOfLeaves();
    vector<TString> vars;
-   vector<TString> mvas;   
+   vector<TString> mvas;
    for (Int_t iar=0; iar<leafList->GetSize(); iar++) {
       TLeaf* leaf = (TLeaf*)leafList->At(iar);
       if (leaf != 0) {
          TString leafName = leaf->GetName();
          if (leafName != "type" && leafName != "weight"  && leafName != "boostweight" &&
-             leafName != "class" && leafName != "className" && leafName != "classID" && 
+             leafName != "class" && leafName != "className" && leafName != "classID" &&
              !leafName.Contains("prob_")) {
             // is MVA ?
             if (TMVAGlob::ExistMethodName( leafName,file->GetDirectory(dataset.Data()) )) {
@@ -49,7 +49,7 @@ void TMVA::paracoor(TString dataset, TString fin , Bool_t useTMVAStyle )
 
    cout << "--- Found: " << vars.size() << " variables" << endl;
    cout << "--- Found: " << mvas.size() << " MVA(s)" << endl;
-   
+
 
    TString type[2] = { "Signal", "Background" };
    for (UInt_t imva=0; imva<mvas.size(); imva++) {
@@ -64,11 +64,11 @@ void TMVA::paracoor(TString dataset, TString fin , Bool_t useTMVAStyle )
 
          // create canvas
          TString mvashort = mvas[imva]; mvashort.ReplaceAll("MVA_","");
-         auto c1 = new TCanvas( Form( "c1_%i_%s",itype,mvashort.Data() ),
-                           Form( "Parallel coordinate representation for %s and input variables (%s events)", 
-                                 mvashort.Data(), type[itype].Data() ), 
-                           50*(itype), 50*(itype), 750, 500 );      
-         tree->Draw( varstr.Data(), Form("classID==%i",1-itype) , "para" );
+         auto c1 = new TCanvas( TString::Format( "c1_%i_%s",itype,mvashort.Data() ),
+                           TString::Format( "Parallel coordinate representation for %s and input variables (%s events)",
+                                 mvashort.Data(), type[itype].Data() ),
+                           50*(itype), 50*(itype), 750, 500 );
+         tree->Draw( varstr.Data(), TString::Format("classID==%i",1-itype) , "para" );
          c1->ToggleEditor();
          gStyle->SetOptTitle(0);
 
@@ -100,12 +100,12 @@ void TMVA::paracoor(TString dataset, TString fin , Bool_t useTMVAStyle )
             parrange->SetLineColor( ivar == 0 ? 2 : ivar == 1 ? 5 : 6 );
             var->AddRange( parrange );
 
-            para->AddSelection( Form("%i",ivar) );
+            para->AddSelection( TString::Format("%i",ivar) );
          }
 
          c1->Update();
 
-         TString fname = Form( "%s/plots/paracoor_c%i_%s",dataset.Data(), imva, itype == 0 ? "S" : "B" );
+         TString fname = TString::Format( "%s/plots/paracoor_c%i_%s",dataset.Data(), imva, itype == 0 ? "S" : "B" );
          TMVAGlob::imgconv( c1, fname );
       }
    }

--- a/tmva/tmvagui/src/probas.cxx
+++ b/tmva/tmvagui/src/probas.cxx
@@ -30,7 +30,7 @@ void TMVA::probas(TString dataset, TString fin , Bool_t useTMVAStyle  )
    const Bool_t Save_Images     = kTRUE;
 
    // checks if file with name "fin" is already open, and if not opens one
-   TFile* file = TMVAGlob::OpenFile( fin );  
+   TFile* file = TMVAGlob::OpenFile( fin );
 
    const Int_t width = 600;   // size of canvas
 
@@ -58,7 +58,7 @@ void TMVA::probas(TString dataset, TString fin , Bool_t useTMVAStyle  )
    char fname[fnameSize];
    TH1* sig(0);
    TH1* bgd(0);
-   
+
 
    while ( (key = (TKey*)next()) ) {
       TDirectory * mDir = (TDirectory*)key->ReadObj();
@@ -73,7 +73,7 @@ void TMVA::probas(TString dataset, TString fin , Bool_t useTMVAStyle  )
       TIter nextTitle(&titles);
       TKey *instkey;
       TDirectory *instDir;
-      
+
       // iterate over all classifiers
       while ( (instkey = (TKey *)nextTitle()) ) {
          instDir = (TDirectory *)instkey->ReadObj();
@@ -88,9 +88,9 @@ void TMVA::probas(TString dataset, TString fin , Bool_t useTMVAStyle  )
          while ( (hkey = (TKey*)nextInDir()) ) {
             TH1 *th1 = (TH1*)hkey->ReadObj();
             TString hname= th1->GetName();
-            if (hname.Contains( suffixSig ) && !hname.Contains( "Cut") && 
+            if (hname.Contains( suffixSig ) && !hname.Contains( "Cut") &&
                 !hname.Contains("original") && !hname.Contains("smoothed")) {
-               // retrieve corresponding signal and background histograms   
+               // retrieve corresponding signal and background histograms
                TString hnameS = hname;
                TString hnameB = hname; hnameB.ReplaceAll("_S","_B");
 
@@ -104,11 +104,11 @@ void TMVA::probas(TString dataset, TString fin , Bool_t useTMVAStyle  )
 
                TH1* sigF(0);
                TH1* bkgF(0);
-               
+
                for (int i=0; i<= 5; i++) {
-                  TString hspline = hnameS + Form("_smoothed_hist_from_spline%i",i);
+                  TString hspline = hnameS + TString::Format("_smoothed_hist_from_spline%i",i);
                   sigF = (TH1*)instDir->Get( hspline );
-            
+
                   if (sigF) {
                      bkgF = (TH1*)instDir->Get( hspline.ReplaceAll("_tr_S","_tr_B") );
                      break;
@@ -117,12 +117,12 @@ void TMVA::probas(TString dataset, TString fin , Bool_t useTMVAStyle  )
                if (!sigF){
                   TString hspline = hnameS + TString("_smoothed_hist_from_KDE");
                   sigF = (TH1*)instDir->Get( hspline );
-                  
+
                   if (sigF) {
                      bkgF = (TH1*)instDir->Get( hspline.ReplaceAll("_tr_S","_tr_B") );
                   }
                }
-              
+
                if ((sigF == NULL || bkgF == NULL) &&!hname.Contains("hist") ) {
                   cout << "*** probas.C: big troubles - did not find probability histograms" << endl;
                   return;
@@ -132,48 +132,48 @@ void TMVA::probas(TString dataset, TString fin , Bool_t useTMVAStyle  )
 
                   // check that exist
                   if (NULL != sigF && NULL != bkgF && NULL!=sig && NULL!=bgd) {
-          
+
                      found = kTRUE;
                      // chop off useless stuff
                      sig->SetTitle( TString("TMVA output for classifier: ") + methodTitle );
-            
+
                      // create new canvas
                      cout << "--- Book canvas no: " << countCanvas << endl;
                      char cn[20];
                      snprintf( cn, 20, "canvas%d", countCanvas+1 );
-                     c = new TCanvas( cn, Form("TMVA Output Fit Variables %s",methodTitle.Data()), 
-                                      countCanvas*50+200, countCanvas*20, width, width*0.78 ); 
-            
+                     c = new TCanvas( cn, TString::Format("TMVA Output Fit Variables %s",methodTitle.Data()),
+                                      countCanvas*50+200, countCanvas*20, width, width*0.78 );
+
                      // set the histogram style
                      TMVAGlob::SetSignalAndBackgroundStyle( sig, bgd );
                      TMVAGlob::SetSignalAndBackgroundStyle( sigF, bkgF );
-            
+
                      // frame limits (choose judicuous x range)
                      Float_t nrms = 4;
-                     Float_t xmin = TMath::Max( TMath::Min(sig->GetMean() - nrms*sig->GetRMS(), 
+                     Float_t xmin = TMath::Max( TMath::Min(sig->GetMean() - nrms*sig->GetRMS(),
                                                            bgd->GetMean() - nrms*bgd->GetRMS() ),
                                                 sig->GetXaxis()->GetXmin() );
-                     Float_t xmax = TMath::Min( TMath::Max(sig->GetMean() + nrms*sig->GetRMS(), 
+                     Float_t xmax = TMath::Min( TMath::Max(sig->GetMean() + nrms*sig->GetRMS(),
                                                            bgd->GetMean() + nrms*bgd->GetRMS() ),
                                                 sig->GetXaxis()->GetXmax() );
                      Float_t ymin = 0;
                      Float_t ymax = TMath::Max( sig->GetMaximum(), bgd->GetMaximum() )*1.5;
-            
+
                      if (Draw_CFANN_Logy && methodName == "CFANN") ymin = 0.01;
-            
+
                      // build a frame
                      Int_t nb = 500;
-                     TH2F* frame = new TH2F( TString("frame") + sig->GetName() + "_proba", sig->GetTitle(), 
+                     TH2F* frame = new TH2F( TString("frame") + sig->GetName() + "_proba", sig->GetTitle(),
                                              nb, xmin, xmax, nb, ymin, ymax );
                      frame->GetXaxis()->SetTitle(methodTitle);
                      frame->GetYaxis()->SetTitle("Normalized");
                      TMVAGlob::SetFrameStyle( frame );
-            
+
                      // eventually: draw the frame
-                     frame->Draw();  
-            
+                     frame->Draw();
+
                      if (Draw_CFANN_Logy && methodName == "CFANN") c->SetLogy();
-            
+
                      // overlay signal and background histograms
                      sig->SetMarkerColor( TMVAGlob::getSignalLine() );
                      sig->SetMarkerSize( 0.7 );
@@ -187,17 +187,17 @@ void TMVA::probas(TString dataset, TString fin , Bool_t useTMVAStyle  )
 
                      sig->Draw("samee");
                      bgd->Draw("samee");
-            
+
                      sigF->SetFillStyle( 0 );
                      bkgF->SetFillStyle( 0 );
                      sigF->Draw("samehist");
                      bkgF->Draw("samehist");
-            
+
                      // redraw axes
                      frame->Draw("sameaxis");
-            
-                     // Draw legend               
-                     TLegend *legend= new TLegend( c->GetLeftMargin(), 1 - c->GetTopMargin() - 0.2, 
+
+                     // Draw legend
+                     TLegend *legend= new TLegend( c->GetLeftMargin(), 1 - c->GetTopMargin() - 0.2,
                                                    c->GetLeftMargin() + 0.4, 1 - c->GetTopMargin() );
                      legend->AddEntry(sig,"Signal data","P");
                      legend->AddEntry(sigF,"Signal PDF","L");
@@ -206,7 +206,7 @@ void TMVA::probas(TString dataset, TString fin , Bool_t useTMVAStyle  )
                      legend->Draw("same");
                      legend->SetBorderSize(1);
                      legend->SetMargin( 0.3 );
-            
+
                      // save canvas to file
                      c->Update();
                      TMVAGlob::plot_logo();
@@ -216,11 +216,11 @@ void TMVA::probas(TString dataset, TString fin , Bool_t useTMVAStyle  )
                   }
                }
             }
-            
+
          }
          if(!found){
             cout << "--- No PDFs found for method " << methodTitle << ". Did you request \"CreateMVAPdfs\" in the option string?" << endl;
          }
-      }    
+      }
    }
 }

--- a/tmva/tmvagui/src/regression_averagedevs.cxx
+++ b/tmva/tmvagui/src/regression_averagedevs.cxx
@@ -40,8 +40,8 @@ void TMVA::regression_averagedevs(TString dataset,TString fin, Int_t Nevt, Bool_
       if (debug) cout << "loop targets " << itrgt<<endl;
       TString xtit = "Method";
       TString ytit = "Average Quadratic Deviation";
-      TString ftit = ytit + " versus " + xtit + Form(" for target %d",itrgt);
-      c = new TCanvas( Form("c%d",itrgt), ftit , 50+20*itrgt, 10*itrgt, 750, 650 );
+      TString ftit = ytit + " versus " + xtit + TString::Format(" for target %d",itrgt);
+      c = new TCanvas( TString::Format("c%d",itrgt), ftit , 50+20*itrgt, 10*itrgt, 750, 650 );
 
       // global style settings
       c->SetGrid();
@@ -50,7 +50,7 @@ void TMVA::regression_averagedevs(TString dataset,TString fin, Int_t Nevt, Bool_
       c->SetTopMargin(0.28);
       c->SetBottomMargin(0.1);
 
-      TString hNameRef(Form("regression_average_devs_target%d",itrgt));
+      TString hNameRef = TString::Format("regression_average_devs_target%d",itrgt);
 
       const Int_t maxMethods = 100;
       //     const Int_t maxTargets = 100;
@@ -76,7 +76,7 @@ void TMVA::regression_averagedevs(TString dataset,TString fin, Int_t Nevt, Bool_
             if (histKey->ReadObj()->InheritsFrom("TH1F") ){
                TString s(histKey->ReadObj()->GetName());
                if( !s.Contains("Quadr_Dev") ) continue;
-               if( !s.Contains(Form("target_%d_",itrgt))) continue;
+               if( !s.Contains(TString::Format("target_%d_",itrgt))) continue;
                Int_t ihist = 0 ;
                if( !s.Contains("best90perc") && s.Contains("train")) ihist=0;
                if( s.Contains("best90perc") && s.Contains("train")) ihist=1;
@@ -95,7 +95,7 @@ void TMVA::regression_averagedevs(TString dataset,TString fin, Int_t Nevt, Bool_
          }
          nMethods++;
       }
-      TH1F* haveragedevs= new TH1F(Form("haveragedevs%d",itrgt),ftit,nMethods,0.,nMethods);
+      TH1F* haveragedevs= new TH1F(TString::Format("haveragedevs%d",itrgt),ftit,nMethods,0.,nMethods);
       for (int i=0;i<nMethods;i++) haveragedevs->GetXaxis()->SetBinLabel(i+1, mvaNames[i]);
       haveragedevs->SetStats(0);
       TGraphErrors* graphTrainAv= new TGraphErrors(nMethods,x[0],m[0],ex[0],em[0]);
@@ -126,18 +126,18 @@ void TMVA::regression_averagedevs(TString dataset,TString fin, Int_t Nevt, Bool_
       TH1F *hr = c->DrawFrame(-1.,0.,nMethods+1, xmax);
       cout << endl;
       cout << "Training: Average Deviation between target " << itrgt <<" and estimate" << endl;
-      cout << Form("%-15s%-15s%-15s", "Method","Average Dev.","trunc. Aver.(90%)") <<endl;
+      cout << TString::Format("%-15s%-15s%-15s", "Method","Average Dev.","trunc. Aver.(90%)") <<endl;
       for (int i=0;i<nMethods;i++){
-         cout << Form("%-15s:%#10.3g%#10.3g",
+         cout << TString::Format("%-15s:%#10.3g%#10.3g",
                       (const char*)mvaNames[i], m[0][i],m[1][i])<<endl;
          //       cout << mvaNames[i] << "  " << m[0][i]<< "  "<< m[1][i]<<endl;
          hr->GetXaxis()->SetBinLabel(i+1," ");
       }
       cout << endl;
       cout << "Testing: Average Deviation between target " << itrgt <<" and estimate" << endl;
-      cout << Form("%-15s%-15s%-15s", "Method","Average Dev.","trunc. Aver.(90%)") <<endl;
+      cout << TString::Format("%-15s%-15s%-15s", "Method","Average Dev.","trunc. Aver.(90%)") <<endl;
       for (int i=0;i<nMethods;i++){
-         cout << Form("%-15s:%#10.3g%#10.3g",
+         cout << TString::Format("%-15s:%#10.3g%#10.3g",
                       (const char*)mvaNames[i], m[2][i],m[3][i])<<endl;
          //cout << mvaNames[i] << "  " << m[2][i]<< "  "<< m[3][i]<<endl;
       }

--- a/tmva/tmvagui/src/rulevisCorr.cxx
+++ b/tmva/tmvagui/src/rulevisCorr.cxx
@@ -275,7 +275,7 @@ void TMVA::rulevisCorr( TDirectory *rfdir, TDirectory *vardir, TDirectory *corrd
          // save canvas to file
          if (countPad > noPad) {
             c[countCanvas]->Update();
-            TString fname = Form( "plots/%s_c%i", outputName.Data(), countCanvas+1 );
+            TString fname = TString::Format( "plots/%s_c%i", outputName.Data(), countCanvas+1 );
             TMVAGlob::imgconv( c[countCanvas], fname );
             //        TMVAGlob::plot_logo(); // don't understand why this doesn't work ... :-(
             countCanvas++;
@@ -285,7 +285,7 @@ void TMVA::rulevisCorr( TDirectory *rfdir, TDirectory *vardir, TDirectory *corrd
 
    if (countPad <= noPad) {
       c[countCanvas]->Update();
-      TString fname = Form( "plots/%s_c%i", outfname[type].Data(), countCanvas+1 );
+      TString fname = TString::Format( "plots/%s_c%i", outfname[type].Data(), countCanvas+1 );
       TMVAGlob::imgconv( c[countCanvas], fname );
    }
 }

--- a/tmva/tmvagui/src/rulevisHists.cxx
+++ b/tmva/tmvagui/src/rulevisHists.cxx
@@ -250,7 +250,7 @@ void TMVA::rulevisHists( TDirectory *rfdir, TDirectory *vardir, TDirectory *corr
          // save canvas to file
          if (countPad > noPad) {
             c[countCanvas]->Update();
-            TString fname = Form( "plots/%s_c%i", outputName.Data(), countCanvas+1 );
+            TString fname = TString::Format( "plots/%s_c%i", outputName.Data(), countCanvas+1 );
             TMVAGlob::imgconv( c[countCanvas], fname );
             //        TMVAGlob::plot_logo(); // don't understand why this doesn't work ... :-(
             countCanvas++;
@@ -260,7 +260,7 @@ void TMVA::rulevisHists( TDirectory *rfdir, TDirectory *vardir, TDirectory *corr
 
    if (countPad <= noPad) {
       c[countCanvas]->Update();
-      TString fname = Form( "plots/%s_c%i", outputName.Data(), countCanvas+1 );
+      TString fname = TString::Format( "plots/%s_c%i", outputName.Data(), countCanvas+1 );
       TMVAGlob::imgconv( c[countCanvas], fname );
    }
    delete[] c;

--- a/tmva/tmvagui/src/tmvaglob.cxx
+++ b/tmva/tmvagui/src/tmvaglob.cxx
@@ -255,8 +255,8 @@ TImage * TMVA::TMVAGlob::findImage(const char * imageName)
    //TString tutorialPath = "$ROOTSYS/tutorials/tmva"; // look for the image in here
    TString tutorialPath = getenv ("ROOTSYS");
    tutorialPath+="/tutorials/tmva";
-   TImage *img(0);
-   TString fullName = Form("%s/%s", tutorialPath.Data(), imageName);
+   TImage *img = nullptr;
+   TString fullName = TString::Format("%s/%s", tutorialPath.Data(), imageName);
    Bool_t fileFound = ! gSystem->AccessPathName(fullName);
 
    if(fileFound) {

--- a/tmva/tmvagui/src/variables.cxx
+++ b/tmva/tmvagui/src/variables.cxx
@@ -81,7 +81,7 @@ void TMVA::variables(TString dataset, TString fin, TString dirName , TString tit
       // create new canvas
       if (countPad%noPadPerCanv==0) {
          ++countCanvas;
-         canv = new TCanvas( Form("canvas%d", countCanvas), title,
+         canv = new TCanvas( TString::Format("canvas%d", countCanvas), title,
                              countCanvas*50+50, countCanvas*20, width, height );
          canv->Divide(xPad,yPad);
          canv->Draw();
@@ -152,11 +152,11 @@ void TMVA::variables(TString dataset, TString fin, TString dirName , TString tit
       Double_t dxo  = sig->GetBinWidth(nbin+1);
       TString uoflow = "";
       if (isRegression) {
-         uoflow = Form( "U/O-flow: %.1f%% / %.1f%%", 
+         uoflow = TString::Format( "U/O-flow: %.1f%% / %.1f%%", 
                         sig->GetBinContent(0)*dxu*100, sig->GetBinContent(nbin+1)*dxo*100 );
       }
       else {
-         uoflow = Form( "U/O-flow (S,B): (%.1f, %.1f)%% / (%.1f, %.1f)%%", 
+         uoflow = TString::Format( "U/O-flow (S,B): (%.1f, %.1f)%% / (%.1f, %.1f)%%", 
                         sig->GetBinContent(0)*dxu*100, bgd->GetBinContent(0)*dxu*100,
                         sig->GetBinContent(nbin+1)*dxo*100, bgd->GetBinContent(nbin+1)*dxo*100 );
       }
@@ -169,7 +169,7 @@ void TMVA::variables(TString dataset, TString fin, TString dirName , TString tit
 
       // save canvas to file
       if (countPad%noPadPerCanv==0) {
-         TString fname = Form( "%s/plots/%s_c%i",dataset.Data(), outfname.Data(), countCanvas );
+         TString fname = TString::Format( "%s/plots/%s_c%i",dataset.Data(), outfname.Data(), countCanvas );
          TMVAGlob::plot_logo();
          TMVAGlob::imgconv( canv, fname );
          createNewFig = kFALSE;
@@ -180,7 +180,7 @@ void TMVA::variables(TString dataset, TString fin, TString dirName , TString tit
    }
    
    if (createNewFig) {
-      TString fname = Form( "%s/plots/%s_c%i",dataset.Data(), outfname.Data(), countCanvas );
+      TString fname = TString::Format( "%s/plots/%s_c%i",dataset.Data(), outfname.Data(), countCanvas );
       TMVAGlob::plot_logo();
       TMVAGlob::imgconv( canv, fname );
       createNewFig = kFALSE;

--- a/tmva/tmvagui/src/variablesMultiClass.cxx
+++ b/tmva/tmvagui/src/variablesMultiClass.cxx
@@ -63,7 +63,7 @@ void TMVA::variablesMultiClass(TString dataset, TString fin , TString dirName , 
    Int_t countPad    = 0;
 
    // loop over all objects in directory
-   TCanvas* canv = 0;
+   TCanvas* canv = nullptr;
    Bool_t   createNewFig = kFALSE;
    TIter next(dir->GetListOfKeys());
     
@@ -96,7 +96,7 @@ void TMVA::variablesMultiClass(TString dataset, TString fin , TString dirName , 
       //create new canvas
       if (countPad%noPadPerCanv==0) {
          ++countCanvas;
-         canv = new TCanvas( Form("canvas%d", countCanvas), title,
+         canv = new TCanvas( TString::Format("canvas%d", countCanvas), title,
                              countCanvas*50+50, countCanvas*20, width, height );
          canv->Divide(xPad,yPad);
          canv->Draw();
@@ -107,7 +107,7 @@ void TMVA::variablesMultiClass(TString dataset, TString fin , TString dirName , 
       TObjArray hists;
       for(; classiter!=classnames.end(); ++classiter){
          //assemble histogram names
-         TString hname(*variter + "__" + *classiter + "_" + tmp);
+         TString hname = *variter + "__" + *classiter + "_" + tmp;
          TH1 *hist = (TH1*)dir->Get(hname);
          //cout << "Looking for histgram " << hname << endl;
          if (hist == NULL) {
@@ -184,7 +184,7 @@ void TMVA::variablesMultiClass(TString dataset, TString fin , TString dirName , 
       for(Int_t i=0; i<hists.GetEntriesFast(); ++i, ++classiter){
          if(((TH1*)hists[i])->GetBinContent(0)!=0 || ((TH1*)hists[i])->GetBinContent(nbin+1)!=0){
             uoflow += *classiter;
-            uoflow += Form( " U/O-flow:  %.1f / %.1f %%", 
+            uoflow += TString::Format( " U/O-flow:  %.1f / %.1f %%", 
                             ((TH1*)hists[i])->GetBinContent(0)*dxu*100, ((TH1*)hists[i])->GetBinContent(nbin+1)*dxo*100);
          }
       }
@@ -198,7 +198,7 @@ void TMVA::variablesMultiClass(TString dataset, TString fin , TString dirName , 
       
       // save canvas to file
       if (countPad%noPadPerCanv==0) {
-         TString fname = dataset+Form( "/plots/%s_c%i", outfname.Data(), countCanvas );
+         TString fname = dataset+TString::Format( "/plots/%s_c%i", outfname.Data(), countCanvas );
          TMVAGlob::plot_logo();
          TMVAGlob::imgconv( canv, fname );
          createNewFig = kFALSE;
@@ -209,7 +209,7 @@ void TMVA::variablesMultiClass(TString dataset, TString fin , TString dirName , 
    } 
    
    if (createNewFig) {
-      TString fname = dataset+Form( "/plots/%s_c%i", outfname.Data(), countCanvas );
+      TString fname = dataset+TString::Format( "/plots/%s_c%i", outfname.Data(), countCanvas );
       TMVAGlob::plot_logo();
       TMVAGlob::imgconv( canv, fname );
       createNewFig = kFALSE;


### PR DESCRIPTION
Typical example is:

```
auto h1 = new TH1I(Form("name%d",i),Form("title%d",i), 100, 0, 100);
```

Similar interface was used when creating branches.

Extreme case when:

```
Form("%s_somthing", Form("incpsulated%d", cnt));
```

In all these places use `TString::Format` instead which returns `TString` instance.

Do same in `tmva/tests` and `tmva/tmvagui`.


Fixes: https://github.com/root-project/root/issues/13136


