### PR TITLE
[webgui] let configure orthographic camera for lego plots

### DIFF
--- a/core/base/inc/TStyle.h
+++ b/core/base/inc/TStyle.h
@@ -146,6 +146,7 @@ private:
    Float_t       fYAxisExpXOffset;   ///< Y axis exponent label X offset
    Float_t       fYAxisExpYOffset;   ///< Y axis exponent label Y offset
    Int_t         fAxisMaxDigits;     ///< Number of digits above which the 10^N notation is used for axis
+   Bool_t        fOrthoCamera;       ///< Use orthographic camera with web display
 
 public:
    enum EPaperSize { kA4, kUSLetter };
@@ -288,6 +289,7 @@ public:
    Double_t         GetCandleBoxRange() const {return fCandleBoxRange;}
    Bool_t           GetCandleScaled() const {return fCandleScaled;}
    Bool_t           GetViolinScaled() const {return fViolinScaled;}
+   Bool_t           GetOrthoCamera() const {return fOrthoCamera;}
 
    Bool_t           IsReading() const {return fIsReading;}
    void             Paint(Option_t *option="") override;
@@ -419,11 +421,12 @@ public:
    void             SetCandleBoxRange(Double_t bRange=0.5);
    void             SetCandleScaled(Bool_t on=kFALSE) {fCandleScaled=on;}
    void             SetViolinScaled(Bool_t on=kTRUE) {fViolinScaled=on;}
+   void             SetOrthoCamera(Bool_t on=kTRUE) {fOrthoCamera=on;}
 
    void             SavePrimitive(std::ostream &out, Option_t * = "") override;
    void             SaveSource(const char *filename, Option_t *option = nullptr);
 
-   ClassDefOverride(TStyle, 21);  //A collection of all graphics attributes
+   ClassDefOverride(TStyle, 22);  //A collection of all graphics attributes
 };
 
 

--- a/core/base/src/TStyle.cxx
+++ b/core/base/src/TStyle.cxx
@@ -668,6 +668,9 @@ void TStyle::Copy(TObject &obj) const
    ((TStyle&)obj).fCandleBoxRange     = fCandleBoxRange;
    ((TStyle&)obj).fCandleScaled       = fCandleScaled;
    ((TStyle&)obj).fViolinScaled       = fViolinScaled;
+
+   ((TStyle&)obj).fOrthoCamera        = fOrthoCamera;
+
    ((TStyle&)obj).fXAxisExpXOffset    = fXAxisExpXOffset;
    ((TStyle&)obj).fXAxisExpYOffset    = fXAxisExpYOffset;
    ((TStyle&)obj).fYAxisExpXOffset    = fYAxisExpXOffset;
@@ -824,6 +827,9 @@ void TStyle::Reset(Option_t *opt)
    fCandleBoxRange      = 0.5;
    fCandleScaled = kFALSE;
    fViolinScaled = kTRUE;
+
+   fOrthoCamera = kFALSE;
+
    fXAxisExpXOffset = 0;
    fXAxisExpYOffset = 0;
    fYAxisExpXOffset = 0;
@@ -2132,6 +2138,7 @@ void TStyle::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
    out<<pre<<"tmpStyle->SetPadGridY("        <<asBool(GetPadGridY())<<");" <<std::endl;
    out<<pre<<"tmpStyle->SetPadTickX("        <<GetPadTickX()         <<");"<<std::endl;
    out<<pre<<"tmpStyle->SetPadTickY("        <<GetPadTickY()         <<");"<<std::endl;
+   out<<pre<<"tmpStyle->SetOrthoCamera("     <<asBool(GetOrthoCamera())<<");" <<std::endl;
 
    // fPaperSizeX, fPaperSizeY
    out<<pre<<"tmpStyle->SetPaperSize("      <<fPaperSizeX<<", "<<fPaperSizeY<<");"<<std::endl;

--- a/core/base/src/TStyle.cxx
+++ b/core/base/src/TStyle.cxx
@@ -2140,6 +2140,11 @@ void TStyle::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
    out<<pre<<"tmpStyle->SetPadTickY("        <<GetPadTickY()         <<");"<<std::endl;
    out<<pre<<"tmpStyle->SetOrthoCamera("     <<asBool(GetOrthoCamera())<<");" <<std::endl;
 
+   out<<pre<<"tmpStyle->SetCandleWhiskerRange("<<GetCandleWhiskerRange()<<");" <<std::endl;
+   out<<pre<<"tmpStyle->SetCandleBoxRange("  <<GetCandleBoxRange()<<");" <<std::endl;
+   out<<pre<<"tmpStyle->SetCandleScaled("    <<asBool(GetCandleScaled())<<");" <<std::endl;
+   out<<pre<<"tmpStyle->SetViolinScaled("    <<asBool(GetViolinScaled())<<");" <<std::endl;
+
    // fPaperSizeX, fPaperSizeY
    out<<pre<<"tmpStyle->SetPaperSize("      <<fPaperSizeX<<", "<<fPaperSizeY<<");"<<std::endl;
 

--- a/js/build/jsroot.js
+++ b/js/build/jsroot.js
@@ -384,6 +384,7 @@ let gStyle = {
    fCandleBoxRange: 0.5,
    fCandleScaled: false,
    fViolinScaled: true,
+   fOrthoCamera: false,
    fXAxisExpXOffset: 0,
    fXAxisExpYOffset: 0,
    fYAxisExpXOffset: 0,
@@ -58724,7 +58725,6 @@ class JSRootMenu {
       addStyleIntField('Log X', 'fOptLogx', ['off', 'on', 'log 2']);
       addStyleIntField('Log Y', 'fOptLogy', ['off', 'on', 'log 2']);
       addStyleIntField('Log Z', 'fOptLogz', ['off', 'on', 'log 2']);
-      this.addchk(gStyle.fOptTitle == 1, 'Hist title', flag => { gStyle.fOptTitle = flag ? 1 : 0; });
       this.add('endsub:');
 
       this.add('sub:Frame');
@@ -58778,6 +58778,8 @@ class JSRootMenu {
       this.add('endsub:');
 
       this.add('sub:Histogram');
+      this.addchk(gStyle.fOptTitle == 1, 'Hist title', flag => { gStyle.fOptTitle = flag ? 1 : 0; });
+      this.addchk(gStyle.fOrthoCamera, 'Orthographic camera', flag => { gStyle.fOrthoCamera = flag; });
       this.addchk(gStyle.fHistMinimumZero, 'Base0', flag => { gStyle.fHistMinimumZero = flag; }, 'when true, BAR and LEGO drawing using base = 0');
       this.add('Text format', () => this.input('Paint text format', gStyle.fPaintTextFormat).then(fmt => { gStyle.fPaintTextFormat = fmt; }));
       this.add('Time offset', () => this.input('Time offset in seconds, default is 788918400 for 1/1/1995', gStyle.fTimeOffset, 'int').then(ofset => { gStyle.fTimeOffset = ofset; }));
@@ -69896,7 +69898,7 @@ class THistDrawOptions {
               Mark: false, Same: false, Scat: false, ScatCoef: 1., Func: true,
               Arrow: false, Box: false, BoxStyle: 0,
               Text: false, TextAngle: 0, TextKind: '', Char: 0, Color: false, Contour: 0, Cjust: false,
-              Lego: 0, Surf: 0, Off: 0, Tri: 0, Proj: 0, AxisPos: 0, Ortho: false,
+              Lego: 0, Surf: 0, Off: 0, Tri: 0, Proj: 0, AxisPos: 0, Ortho: gStyle.fOrthoCamera,
               Spec: false, Pie: false, List: false, Zscale: false, Zvert: true, PadPalette: false,
               Candle: '', Violin: '', Scaled: null, Circular: 0,
               GLBox: 0, GLColor: false, Project: '', System: kCARTESIAN,
@@ -75607,7 +75609,7 @@ function create3DCamera(fp, orthographic) {
    }
 
    if (orthographic)
-      fp.camera = new OrthographicCamera(-fp.scene_width/2, fp.scene_width/2, fp.scene_height/2, -fp.scene_height/2, 0.001, 40*fp.size_z3d);
+      fp.camera = new OrthographicCamera(-1.3*fp.size_x3d, 1.3*fp.size_x3d, 2.3*fp.size_z3d, -0.7*fp.size_z3d, 0.001, 40*fp.size_z3d);
    else
       fp.camera = new PerspectiveCamera(45, fp.scene_width / fp.scene_height, 1, 40*fp.size_z3d);
 
@@ -75616,7 +75618,7 @@ function create3DCamera(fp, orthographic) {
    fp.pointLight = new PointLight(0xffffff,1);
    fp.pointLight.position.set(fp.size_x3d/2, fp.size_y3d/2, fp.size_z3d/2);
    fp.camera.add(fp.pointLight);
-   fp.lookat = new Vector3(0,0,0.8*fp.size_z3d);
+   fp.lookat = new Vector3(0,0,orthographic ? 0.3*fp.size_z3d : 0.8*fp.size_z3d);
    fp.scene.add(fp.camera);
 }
 
@@ -75626,17 +75628,15 @@ function setCameraPosition(fp, first_time) {
    let pad = fp.getPadPainter().getRootPad(true),
        max3dx = Math.max(0.75*fp.size_x3d, fp.size_z3d),
        max3dy = Math.max(0.75*fp.size_y3d, fp.size_z3d),
-       k = fp.camera.isOrthographicCamera ? 0.5 : 1;
+       kz = fp.camera.isOrthographicCamera ? 1 : 1.4;
 
    if (first_time) {
       if (max3dx === max3dy)
-         fp.camera.position.set(-1.6*max3dx*k, -3.5*max3dy*k, 1.4*fp.size_z3d);
+         fp.camera.position.set(-1.6*max3dx, -3.5*max3dy, kz*fp.size_z3d);
       else if (max3dx > max3dy)
-         fp.camera.position.set(-2*max3dx*k, -3.5*max3dy*k, 1.4*fp.size_z3d);
+         fp.camera.position.set(-2*max3dx, -3.5*max3dy, kz*fp.size_z3d);
       else
-         fp.camera.position.set(-3.5*max3dx*k, -2*max3dy*k, 1.4*fp.size_z3d);
-      if (fp.camera.isOrthographicCamera && fp.scene_width > 5 && fp.scene_height > 5)
-         fp.camera.zoom = (isNodeJs() ? 3 : 5) * fp.scene_height / fp.scene_width;
+         fp.camera.position.set(-3.5*max3dx, -2*max3dy, kz*fp.size_z3d);
    }
 
    if (pad && (first_time || !fp.zoomChangedInteractive()))
@@ -75646,9 +75646,9 @@ function setCameraPosition(fp, first_time) {
          max3dx = 3*Math.max(fp.size_x3d, fp.size_z3d);
          max3dy = 3*Math.max(fp.size_y3d, fp.size_z3d);
          let phi = (270-pad.fPhi)/180*Math.PI, theta = (pad.fTheta-10)/180*Math.PI;
-         fp.camera.position.set(max3dx*Math.cos(phi)*Math.cos(theta)*k,
-                                max3dy*Math.sin(phi)*Math.cos(theta)*k,
-                                fp.size_z3d + (max3dx+max3dy)*0.5*Math.sin(theta))*k;
+         fp.camera.position.set(max3dx*Math.cos(phi)*Math.cos(theta),
+                                max3dy*Math.sin(phi)*Math.cos(theta),
+                                fp.size_z3d + (kz-0.9)*(max3dx+max3dy)*Math.sin(theta));
          first_time = true;
       }
 

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -379,6 +379,7 @@ let gStyle = {
    fCandleBoxRange: 0.5,
    fCandleScaled: false,
    fViolinScaled: true,
+   fOrthoCamera: false,
    fXAxisExpXOffset: 0,
    fXAxisExpYOffset: 0,
    fYAxisExpXOffset: 0,

--- a/js/modules/gui/menu.mjs
+++ b/js/modules/gui/menu.mjs
@@ -755,7 +755,6 @@ class JSRootMenu {
       addStyleIntField('Log X', 'fOptLogx', ['off', 'on', 'log 2']);
       addStyleIntField('Log Y', 'fOptLogy', ['off', 'on', 'log 2']);
       addStyleIntField('Log Z', 'fOptLogz', ['off', 'on', 'log 2']);
-      this.addchk(gStyle.fOptTitle == 1, 'Hist title', flag => { gStyle.fOptTitle = flag ? 1 : 0; });
       this.add('endsub:');
 
       this.add('sub:Frame');
@@ -809,6 +808,8 @@ class JSRootMenu {
       this.add('endsub:');
 
       this.add('sub:Histogram');
+      this.addchk(gStyle.fOptTitle == 1, 'Hist title', flag => { gStyle.fOptTitle = flag ? 1 : 0; });
+      this.addchk(gStyle.fOrthoCamera, 'Orthographic camera', flag => { gStyle.fOrthoCamera = flag; });
       this.addchk(gStyle.fHistMinimumZero, 'Base0', flag => { gStyle.fHistMinimumZero = flag; }, 'when true, BAR and LEGO drawing using base = 0');
       this.add('Text format', () => this.input('Paint text format', gStyle.fPaintTextFormat).then(fmt => { gStyle.fPaintTextFormat = fmt; }));
       this.add('Time offset', () => this.input('Time offset in seconds, default is 788918400 for 1/1/1995', gStyle.fTimeOffset, 'int').then(ofset => { gStyle.fTimeOffset = ofset; }));

--- a/js/modules/hist/hist3d.mjs
+++ b/js/modules/hist/hist3d.mjs
@@ -312,7 +312,7 @@ function create3DCamera(fp, orthographic) {
    }
 
    if (orthographic)
-      fp.camera = new OrthographicCamera(-fp.scene_width/2, fp.scene_width/2, fp.scene_height/2, -fp.scene_height/2, 0.001, 40*fp.size_z3d);
+      fp.camera = new OrthographicCamera(-1.3*fp.size_x3d, 1.3*fp.size_x3d, 2.3*fp.size_z3d, -0.7*fp.size_z3d, 0.001, 40*fp.size_z3d);
    else
       fp.camera = new PerspectiveCamera(45, fp.scene_width / fp.scene_height, 1, 40*fp.size_z3d);
 
@@ -321,7 +321,7 @@ function create3DCamera(fp, orthographic) {
    fp.pointLight = new PointLight(0xffffff,1);
    fp.pointLight.position.set(fp.size_x3d/2, fp.size_y3d/2, fp.size_z3d/2);
    fp.camera.add(fp.pointLight);
-   fp.lookat = new Vector3(0,0,0.8*fp.size_z3d);
+   fp.lookat = new Vector3(0,0,orthographic ? 0.3*fp.size_z3d : 0.8*fp.size_z3d);
    fp.scene.add(fp.camera);
 }
 
@@ -331,17 +331,15 @@ function setCameraPosition(fp, first_time) {
    let pad = fp.getPadPainter().getRootPad(true),
        max3dx = Math.max(0.75*fp.size_x3d, fp.size_z3d),
        max3dy = Math.max(0.75*fp.size_y3d, fp.size_z3d),
-       k = fp.camera.isOrthographicCamera ? 0.5 : 1;
+       kz = fp.camera.isOrthographicCamera ? 1 : 1.4;
 
    if (first_time) {
       if (max3dx === max3dy)
-         fp.camera.position.set(-1.6*max3dx*k, -3.5*max3dy*k, 1.4*fp.size_z3d);
+         fp.camera.position.set(-1.6*max3dx, -3.5*max3dy, kz*fp.size_z3d);
       else if (max3dx > max3dy)
-         fp.camera.position.set(-2*max3dx*k, -3.5*max3dy*k, 1.4*fp.size_z3d);
+         fp.camera.position.set(-2*max3dx, -3.5*max3dy, kz*fp.size_z3d);
       else
-         fp.camera.position.set(-3.5*max3dx*k, -2*max3dy*k, 1.4*fp.size_z3d);
-      if (fp.camera.isOrthographicCamera && fp.scene_width > 5 && fp.scene_height > 5)
-         fp.camera.zoom = (isNodeJs() ? 3 : 5) * fp.scene_height / fp.scene_width;
+         fp.camera.position.set(-3.5*max3dx, -2*max3dy, kz*fp.size_z3d);
    }
 
    if (pad && (first_time || !fp.zoomChangedInteractive()))
@@ -351,9 +349,9 @@ function setCameraPosition(fp, first_time) {
          max3dx = 3*Math.max(fp.size_x3d, fp.size_z3d);
          max3dy = 3*Math.max(fp.size_y3d, fp.size_z3d);
          let phi = (270-pad.fPhi)/180*Math.PI, theta = (pad.fTheta-10)/180*Math.PI;
-         fp.camera.position.set(max3dx*Math.cos(phi)*Math.cos(theta)*k,
-                                max3dy*Math.sin(phi)*Math.cos(theta)*k,
-                                fp.size_z3d + (max3dx+max3dy)*0.5*Math.sin(theta))*k;
+         fp.camera.position.set(max3dx*Math.cos(phi)*Math.cos(theta),
+                                max3dy*Math.sin(phi)*Math.cos(theta),
+                                fp.size_z3d + (kz-0.9)*(max3dx+max3dy)*Math.sin(theta));
          first_time = true;
       }
 

--- a/js/modules/hist2d/THistPainter.mjs
+++ b/js/modules/hist2d/THistPainter.mjs
@@ -30,7 +30,7 @@ class THistDrawOptions {
               Mark: false, Same: false, Scat: false, ScatCoef: 1., Func: true,
               Arrow: false, Box: false, BoxStyle: 0,
               Text: false, TextAngle: 0, TextKind: '', Char: 0, Color: false, Contour: 0, Cjust: false,
-              Lego: 0, Surf: 0, Off: 0, Tri: 0, Proj: 0, AxisPos: 0, Ortho: false,
+              Lego: 0, Surf: 0, Off: 0, Tri: 0, Proj: 0, AxisPos: 0, Ortho: gStyle.fOrthoCamera,
               Spec: false, Pie: false, List: false, Zscale: false, Zvert: true, PadPalette: false,
               Candle: '', Violin: '', Scaled: null, Circular: 0,
               GLBox: 0, GLColor: false, Project: '', System: kCARTESIAN,


### PR DESCRIPTION
1. Introduce TStyle::fOrthoCamera flag
2. Use it only with JSROOT lego plots

Usage example is:
```
root --web=chrome hsimple.root -e 'gStyle->SetOrthoCamera();hpxpy->Draw("lego2")'  
```

Produce output:

![ortho](https://github.com/root-project/root/assets/4936580/a2221aa5-1c41-441a-8685-c290903fb944)
