### PR TITLE
Fix illegal usage of Form function in hist/hist classes

### DIFF
--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -2509,7 +2509,8 @@ void TF1::InitStandardFunctions()
       f1 = new TF1("expo", "expo", -1, 1);
       f1->SetParameters(1, 1);
       for (Int_t i = 0; i < 10; i++) {
-         f1 = new TF1(Form("pol%d", i), Form("pol%d", i), -1, 1);
+         auto f1name = TString::Format("pol%d", i);
+         f1 = new TF1(f1name.Data(), f1name.Data(), -1, 1);
          f1->SetParameters(1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
          // create also chebyshev polynomial
          // (note polynomial object will not be deleted)

--- a/hist/hist/src/TF12.cxx
+++ b/hist/hist/src/TF12.cxx
@@ -191,8 +191,8 @@ void TF12::SetXY(Double_t xy)
 {
    fXY = xy;
    if (!fF2) return;
-   if (fCase == 0) SetTitle(Form("%s (y=%g)",fF2->GetTitle(),xy));
-   else            SetTitle(Form("%s (x=%g)",fF2->GetTitle(),xy));
+   if (fCase == 0) SetTitle(TString::Format("%s (y=%g)",fF2->GetTitle(),xy));
+   else            SetTitle(TString::Format("%s (x=%g)",fF2->GetTitle(),xy));
    if (fHistogram) fHistogram->SetTitle(GetTitle());
    if (gPad) gPad->Modified();
 }

--- a/hist/hist/src/TFormula_v5.cxx
+++ b/hist/hist/src/TFormula_v5.cxx
@@ -2409,7 +2409,8 @@ Int_t TFormula::Compile(const char *expression)
       }
       // if formula is a polynom, set parameter names
       if (GetNumber() == 300+fNpar) {
-         for (i=0;i<fNpar;i++) SetParName(i,Form("p%d",i));
+         for (i=0;i<fNpar;i++)
+            SetParName(i, TString::Format("p%d",i));
       }
       // if formula is a landau, set parameter names
       if (GetNumber() == 400) {

--- a/hist/hist/src/TFractionFitter.cxx
+++ b/hist/hist/src/TFractionFitter.cxx
@@ -209,7 +209,7 @@ fFitDone(kFALSE), fChisquare(0), fPlot(0)  {
    for (par = 0; par < fNpar; ++par) {
       fMCs.Add(MCs->At(par));
       // Histogram containing template prediction
-      TString s = Form("Prediction for MC sample %i",par);
+      TString s = TString::Format("Prediction for MC sample %i",par);
       TH1* pred = (TH1*) ((TH1*)MCs->At(par))->Clone(s);
       // TFractionFitter manages these histograms
       pred->SetDirectory(0);

--- a/hist/hist/src/TGraphTime.cxx
+++ b/hist/hist/src/TGraphTime.cxx
@@ -191,9 +191,9 @@ void TGraphTime::SaveAnimatedGif(const char *filename) const
          }
          gPad->Update();
          if (filename && strlen(filename) > 0)
-            gPad->Print(Form("%s+", filename));
+            gPad->Print(TString::Format("%s+", filename));
          else
-            gPad->Print(Form("%s+", GetName()));
+            gPad->Print(TString::Format("%s+", GetName()));
          if (fSleepTime > 0)
             gSystem->Sleep(fSleepTime);
       }

--- a/hist/hist/src/THnBase.cxx
+++ b/hist/hist/src/THnBase.cxx
@@ -1186,7 +1186,7 @@ THnBase* THnBase::RebinBase(const Int_t* group) const
    Int_t ndim = GetNdimensions();
    TString name(GetName());
    for (Int_t d = 0; d < ndim; ++d)
-      name += Form("_%d", group[d]);
+      name += TString::Format("_%d", group[d]);
 
 
    TString title(GetTitle());
@@ -1194,10 +1194,10 @@ THnBase* THnBase::RebinBase(const Int_t* group) const
    if (posInsert == kNPOS) {
       title += " rebin ";
       for (Int_t d = 0; d < ndim; ++d)
-         title += Form("{%d}", group[d]);
+         title += TString::Format("{%d}", group[d]);
    } else {
       for (Int_t d = ndim - 1; d >= 0; --d)
-         title.Insert(posInsert, Form("{%d}", group[d]));
+         title.Insert(posInsert, TString::Format("{%d}", group[d]));
       title.Insert(posInsert, " rebin ");
    }
 

--- a/hist/hist/src/TMultiDimFit.cxx
+++ b/hist/hist/src/TMultiDimFit.cxx
@@ -1069,7 +1069,7 @@ void TMultiDimFit::Fit(Option_t *option)
    for (i = 0; i < fNCoefficients; i++) {
       Double_t startVal = fCoefficients(i);
       Double_t startErr = fCoefficientsRMS(i);
-      fFitter->SetParameter(i, (char *)TString::Format("coeff%02d",i).Data(),
+      fFitter->SetParameter(i, TString::Format("coeff%02d",i).Data(),
                             startVal, startErr, 0, 0);
    }
 
@@ -1080,12 +1080,17 @@ void TMultiDimFit::Fit(Option_t *option)
 
    for (i = 0; i < fNCoefficients; i++) {
       Double_t val = 0, err = 0, low = 0, high = 0;
-      fFitter->GetParameter(i, (char *)TString::Format("coeff%02d",i).Data(),
+
+      // use big enough string buffer to get variable name which is not used
+      char namebuf[512];
+      fFitter->GetParameter(i, namebuf,
                             val, err, low, high);
+      (void) namebuf;
       fCoefficients(i)    = val;
       fCoefficientsRMS(i) = err;
    }
    delete [] x;
+   delete [] arglist;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/TMultiDimFit.cxx
+++ b/hist/hist/src/TMultiDimFit.cxx
@@ -1970,7 +1970,7 @@ void TMultiDimFit::MakeRealCode(const char *filename,
    TString prefix;
    const char *cv_qual  = isMethod ? "" : "static ";
    if (isMethod)
-      prefix = TString::Format("%s::", classname);
+      prefix.Form("%s::", classname);
 
    std::ofstream outFile(filename,std::ios::out|std::ios::trunc);
    if (!outFile) {

--- a/hist/hist/src/TMultiDimFit.cxx
+++ b/hist/hist/src/TMultiDimFit.cxx
@@ -1069,7 +1069,7 @@ void TMultiDimFit::Fit(Option_t *option)
    for (i = 0; i < fNCoefficients; i++) {
       Double_t startVal = fCoefficients(i);
       Double_t startErr = fCoefficientsRMS(i);
-      fFitter->SetParameter(i, Form("coeff%02d",i),
+      fFitter->SetParameter(i, (char *)TString::Format("coeff%02d",i).Data(),
                             startVal, startErr, 0, 0);
    }
 
@@ -1080,7 +1080,7 @@ void TMultiDimFit::Fit(Option_t *option)
 
    for (i = 0; i < fNCoefficients; i++) {
       Double_t val = 0, err = 0, low = 0, high = 0;
-      fFitter->GetParameter(i, Form("coeff%02d",i),
+      fFitter->GetParameter(i, (char *)TString::Format("coeff%02d",i).Data(),
                             val, err, low, high);
       fCoefficients(i)    = val;
       fCoefficientsRMS(i) = err;
@@ -1425,7 +1425,7 @@ void TMultiDimFit::MakeCoefficients()
 
          if (TESTBIT(fHistogramMask,HIST_RX))
             for (j = 0; j < fNVariables; j++)
-               ((TH2D*)fHistograms->FindObject(Form("res_x_%d",j)))
+               ((TH2D*)fHistograms->FindObject(TString::Format("res_x_%d",j)))
                ->Fill(fVariables(i * fNVariables + j),fResiduals(i));
       }
    } // If histograms
@@ -1607,9 +1607,9 @@ void TMultiDimFit::MakeHistograms(Option_t *option)
    if (opt.Contains("x") || opt.Contains("a")) {
       SETBIT(fHistogramMask,HIST_XORIG);
       for (i = 0; i < fNVariables; i++)
-         if (!fHistograms->FindObject(Form("x_%d_orig",i)))
-            fHistograms->Add(new TH1D(Form("x_%d_orig",i),
-                                      Form("Original variable # %d",i),
+         if (!fHistograms->FindObject(TString::Format("x_%d_orig",i)))
+            fHistograms->Add(new TH1D(TString::Format("x_%d_orig",i),
+                                      TString::Format("Original variable # %d",i),
                                       fBinVarX, fMinVariables(i),
                                       fMaxVariables(i)));
    }
@@ -1626,9 +1626,9 @@ void TMultiDimFit::MakeHistograms(Option_t *option)
    if (opt.Contains("n") || opt.Contains("a")) {
       SETBIT(fHistogramMask,HIST_XNORM);
       for (i = 0; i < fNVariables; i++)
-         if (!fHistograms->FindObject(Form("x_%d_norm",i)))
-            fHistograms->Add(new TH1D(Form("x_%d_norm",i),
-                                      Form("Normalized variable # %d",i),
+         if (!fHistograms->FindObject(TString::Format("x_%d_norm",i)))
+            fHistograms->Add(new TH1D(TString::Format("x_%d_norm",i),
+                                      TString::Format("Normalized variable # %d",i),
                                       fBinVarX, -1,1));
    }
 
@@ -1645,9 +1645,9 @@ void TMultiDimFit::MakeHistograms(Option_t *option)
    if (opt.Contains("r1") || opt.Contains("a")) {
       SETBIT(fHistogramMask,HIST_RX);
       for (i = 0; i < fNVariables; i++)
-         if (!fHistograms->FindObject(Form("res_x_%d",i)))
-            fHistograms->Add(new TH2D(Form("res_x_%d",i),
-                                      Form("Computed residual versus x_%d", i),
+         if (!fHistograms->FindObject(TString::Format("res_x_%d",i)))
+            fHistograms->Add(new TH2D(TString::Format("res_x_%d",i),
+                                      TString::Format("Computed residual versus x_%d", i),
                                       fBinVarX, -1,    1,
                                       fBinVarY,
                                       fMinQuantity - fMeanQuantity,
@@ -1738,7 +1738,7 @@ void TMultiDimFit::MakeHistograms(Option_t *option)
 
 void TMultiDimFit::MakeMethod(const Char_t* classname, Option_t* option)
 {
-   MakeRealCode(Form("%sMDF.cxx", classname), classname, option);
+   MakeRealCode(TString::Format("%sMDF.cxx", classname), classname, option);
 }
 
 
@@ -1770,7 +1770,7 @@ void TMultiDimFit::MakeNormalized()
 
          // Fill histograms of original independent variables
          if (TESTBIT(fHistogramMask,HIST_XORIG))
-            ((TH1D*)fHistograms->FindObject(Form("x_%d_orig",j)))
+            ((TH1D*)fHistograms->FindObject(TString::Format("x_%d_orig",j)))
             ->Fill(fVariables(k));
 
          // Normalise independent variables
@@ -1778,7 +1778,7 @@ void TMultiDimFit::MakeNormalized()
 
          // Fill histograms of normalised independent variables
          if (TESTBIT(fHistogramMask,HIST_XNORM))
-            ((TH1D*)fHistograms->FindObject(Form("x_%d_norm",j)))
+            ((TH1D*)fHistograms->FindObject(TString::Format("x_%d_norm",j)))
             ->Fill(fVariables(k));
 
       }
@@ -1962,8 +1962,8 @@ void TMultiDimFit::MakeRealCode(const char *filename,
    Int_t i, j;
 
    Bool_t  isMethod     = (classname[0] == '\0' ? kFALSE : kTRUE);
-   const char *prefix   = (isMethod ? Form("%s::", classname) : "");
-   const char *cv_qual  = (isMethod ? "" : "static ");
+   TString prefix       = isMethod ? TString::Format("%s::", classname) : TString("");
+   const char *cv_qual  = isMethod ? "" : "static ";
 
    std::ofstream outFile(filename,std::ios::out|std::ios::trunc);
    if (!outFile) {

--- a/hist/hist/src/TMultiDimFit.cxx
+++ b/hist/hist/src/TMultiDimFit.cxx
@@ -1962,8 +1962,10 @@ void TMultiDimFit::MakeRealCode(const char *filename,
    Int_t i, j;
 
    Bool_t  isMethod     = (classname[0] == '\0' ? kFALSE : kTRUE);
-   TString prefix       = isMethod ? TString::Format("%s::", classname) : TString("");
+   TString prefix;
    const char *cv_qual  = isMethod ? "" : "static ";
+   if (isMethod)
+      prefix = TString::Format("%s::", classname);
 
    std::ofstream outFile(filename,std::ios::out|std::ios::trunc);
    if (!outFile) {

--- a/hist/hist/src/TPrincipal.cxx
+++ b/hist/hist/src/TPrincipal.cxx
@@ -894,9 +894,11 @@ void TPrincipal::MakePrincipals()
 void TPrincipal::MakeRealCode(const char *filename, const char *classname,
                               Option_t *)
 {
-   Bool_t  isMethod = (classname[0] == '\0' ? kFALSE : kTRUE);
-   TString prefix   = isMethod ? TString::Format("%s::", classname) : TString("");
+   Bool_t  isMethod = classname[0] == '\0' ? kFALSE : kTRUE;
+   TString prefix;
    const char *cv_qual  = isMethod ? "" : "static ";
+   if (isMethod)
+      prefix = TString::Format("%s::", classname);
 
    std::ofstream outFile(filename,std::ios::out|std::ios::trunc);
    if (!outFile) {

--- a/hist/hist/src/TPrincipal.cxx
+++ b/hist/hist/src/TPrincipal.cxx
@@ -622,15 +622,15 @@ void TPrincipal::MakeHistograms(const char *name, Option_t *opt)
       fHistograms = new TList;
 
    // Don't create the histograms if they are already in the TList.
-   if (makeX && fHistograms->FindObject(Form("%s_x000",name)))
+   if (makeX && fHistograms->FindObject(TString::Format("%s_x000",name)))
       makeX = kFALSE;
-   if (makeD && fHistograms->FindObject(Form("%s_d000",name)))
+   if (makeD && fHistograms->FindObject(TString::Format("%s_d000",name)))
       makeD = kFALSE;
-   if (makeP && fHistograms->FindObject(Form("%s_p000",name)))
+   if (makeP && fHistograms->FindObject(TString::Format("%s_p000",name)))
       makeP = kFALSE;
-   if (makeE && fHistograms->FindObject(Form("%s_e",name)))
+   if (makeE && fHistograms->FindObject(TString::Format("%s_e",name)))
       makeE = kFALSE;
-   if (makeS && fHistograms->FindObject(Form("%s_s",name)))
+   if (makeS && fHistograms->FindObject(TString::Format("%s_s",name)))
       makeS = kFALSE;
 
    TH1F **hX  = 0;
@@ -650,15 +650,15 @@ void TPrincipal::MakeHistograms(const char *name, Option_t *opt)
       hP = new TH1F * [fNumberOfVariables];
 
    if (makeE){
-      hE = new TH1F(Form("%s_e",name), "Eigenvalues of Covariance matrix",
-         fNumberOfVariables,0,fNumberOfVariables);
+      hE = new TH1F(TString::Format("%s_e",name), "Eigenvalues of Covariance matrix",
+                    fNumberOfVariables,0,fNumberOfVariables);
       hE->SetXTitle("Eigenvalue");
       fHistograms->Add(hE);
    }
 
    if (makeS) {
-      hS = new TH1F(Form("%s_s",name),"E_{N}",
-         fNumberOfVariables-1,1,fNumberOfVariables);
+      hS = new TH1F(TString::Format("%s_s",name),"E_{N}",
+                    fNumberOfVariables-1,1,fNumberOfVariables);
       hS->SetXTitle("N");
       hS->SetYTitle("#sum_{i=1}^{M} (x_{i} - x'_{N,i})^{2}");
       fHistograms->Add(hS);
@@ -672,9 +672,9 @@ void TPrincipal::MakeHistograms(const char *name, Option_t *opt)
          Double_t xlowb  = fMeanValues(i) - 4 * fSigmas(i);
          Double_t xhighb = fMeanValues(i) + 4 * fSigmas(i);
          Int_t    xbins  = (fNumberOfDataPoints > 0 && fNumberOfDataPoints < 100 ? 1 : fNumberOfDataPoints/100);
-         hX[i]           = new TH1F(Form("%s_x%03d", name, i),
-            Form("Pattern space, variable %d", i),
-            xbins,xlowb,xhighb);
+         hX[i]           = new TH1F(TString::Format("%s_x%03d", name, i),
+                                    TString::Format("Pattern space, variable %d", i),
+                                    xbins,xlowb,xhighb);
          hX[i]->SetXTitle(Form("x_{%d}",i));
          fHistograms->Add(hX[i]);
       }
@@ -684,14 +684,11 @@ void TPrincipal::MakeHistograms(const char *name, Option_t *opt)
          Double_t dlowb  = 0;
          Double_t dhighb = 20;
          Int_t    dbins  = (fNumberOfDataPoints > 0 && fNumberOfDataPoints < 100 ? 1 : fNumberOfDataPoints/100);
-         hD[i]           = new TH2F(Form("%s_d%03d", name, i),
-            Form("Distance from pattern to "
-            "feature space, variable %d", i),
-            dbins,dlowb,dhighb,
-            fNumberOfVariables-1,
-            1,
-            fNumberOfVariables);
-         hD[i]->SetXTitle(Form("|x_{%d} - x'_{%d,N}|/#sigma_{%d}",i,i,i));
+         hD[i]           = new TH2F(TString::Format("%s_d%03d", name, i),
+                                    TString::Format("Distance from pattern to feature space, variable %d", i),
+                                    dbins,dlowb,dhighb,
+                                    fNumberOfVariables-1, 1, fNumberOfVariables);
+         hD[i]->SetXTitle(TString::Format("|x_{%d} - x'_{%d,N}|/#sigma_{%d}",i,i,i));
          hD[i]->SetYTitle("N");
          fHistograms->Add(hD[i]);
       }
@@ -704,10 +701,10 @@ void TPrincipal::MakeHistograms(const char *name, Option_t *opt)
          Double_t plowb   = -10 * TMath::Sqrt(et);
          Double_t phighb  = -plowb;
          Int_t    pbins   = 100;
-         hP[i]            = new TH1F(Form("%s_p%03d", name, i),
-            Form("Feature space, variable %d", i),
-            pbins,plowb,phighb);
-         hP[i]->SetXTitle(Form("p_{%d}",i));
+         hP[i]            = new TH1F(TString::Format("%s_p%03d", name, i),
+                                     TString::Format("Feature space, variable %d", i),
+                                     pbins,plowb,phighb);
+         hP[i]->SetXTitle(TString::Format("p_{%d}",i));
          fHistograms->Add(hP[i]);
       }
 
@@ -862,7 +859,7 @@ void TPrincipal::MakeNormalised()
 void TPrincipal::MakeMethods(const char *classname, Option_t *opt)
 {
 
-   MakeRealCode(Form("%sPCA.cxx", classname), classname, opt);
+   MakeRealCode(TString::Format("%sPCA.cxx", classname), classname, opt);
 }
 
 
@@ -898,8 +895,8 @@ void TPrincipal::MakeRealCode(const char *filename, const char *classname,
                               Option_t *)
 {
    Bool_t  isMethod = (classname[0] == '\0' ? kFALSE : kTRUE);
-   const char *prefix   = (isMethod ? Form("%s::", classname) : "");
-   const char *cv_qual  = (isMethod ? "" : "static ");
+   TString prefix   = isMethod ? TString::Format("%s::", classname) : TString("");
+   const char *cv_qual  = isMethod ? "" : "static ";
 
    std::ofstream outFile(filename,std::ios::out|std::ios::trunc);
    if (!outFile) {

--- a/hist/hist/src/TPrincipal.cxx
+++ b/hist/hist/src/TPrincipal.cxx
@@ -898,7 +898,7 @@ void TPrincipal::MakeRealCode(const char *filename, const char *classname,
    TString prefix;
    const char *cv_qual  = isMethod ? "" : "static ";
    if (isMethod)
-      prefix = TString::Format("%s::", classname);
+      prefix.Form("%s::", classname);
 
    std::ofstream outFile(filename,std::ios::out|std::ios::trunc);
    if (!outFile) {


### PR DESCRIPTION
It is not allowed to call
```
new TH1I(Form("name%d",i), Form("title%d",i), ...)
```
It is not allowed to store return value of Form() function and use it for a longer time.

There were several places like that
