### PR TITLE
[cling] fix unsafe mix of type warning in Diagnostic.cpp

### DIFF
--- a/interpreter/cling/lib/Utils/Diagnostics.cpp
+++ b/interpreter/cling/lib/Utils/Diagnostics.cpp
@@ -34,7 +34,7 @@ namespace {
 DiagnosticsStore::DiagnosticsStore(clang::DiagnosticsEngine& Diags, bool Own,
                                     bool Report, bool Reset) :
   DiagnosticsOverride(Diags, Own),
-  m_Flags(Report | (Reset << 1)) {
+  m_Flags((Report ? kReport : 0) | (Reset ? kReset : 0)) {
 }
 
 DiagnosticsStore::~DiagnosticsStore() {


### PR DESCRIPTION
Warning appears when building on Windows:

```
Diagnostics.cpp
C:\git\root\interpreter\cling\lib\Utils\Diagnostics.cpp(37,27): warning
C4805: '|': unsafe mix of type 'bool' and type
'int' in operation
[C:\Soft\root_64\interpreter\cling\lib\Utils\obj.clingUtils.vcxproj]
```
