### PR TITLE
[cling] Stop using triple substrings in UNSUPPORTED

### DIFF
--- a/interpreter/cling/test/Driver/CommandHistory.C
+++ b/interpreter/cling/test/Driver/CommandHistory.C
@@ -10,7 +10,7 @@
 // RUN: %rm /tmp/__testing_cling_history
 // RUN: cat %s | env --unset=CLING_NOHISTORY CLING_HISTSIZE=8 CLING_HISTFILE="/tmp/__testing_cling_history" %cling - 2>&1
 // RUN: diff /tmp/__testing_cling_history "%S/Inputs/cling_history"
-// REQUIRES: not_system-windows
+// UNSUPPORTED: system-windows
 
 #include <iostream>
 

--- a/interpreter/cling/test/Driver/CurrentDirRm.C
+++ b/interpreter/cling/test/Driver/CurrentDirRm.C
@@ -11,7 +11,7 @@
 // RUN: cd "%T/Remove"
 // RUN: %rmdir "%T/Remove"
 // RUN: %cling %s -Xclang -verify 2>&1 | FileCheck %s
-// REQUIRES: not_system-windows
+// UNSUPPORTED: system-windows
 
 extern "C" {
   int printf(const char*, ...);

--- a/interpreter/cling/test/Driver/Gnu.C
+++ b/interpreter/cling/test/Driver/Gnu.C
@@ -10,7 +10,7 @@
 // RUN: cat %s | %cling -D__STRICT_ANSI__ -std=gnu++11 -Xclang -verify 2>&1 | FileCheck %s
 // RUN: cat %s | %cling -D__STRICT_ANSI__ -std=gnu++14 -Xclang -verify 2>&1 | FileCheck %s
 // RUN: cat %s | %cling -D__STRICT_ANSI__ -std=gnu++1z -Xclang -verify 2>&1 | FileCheck %s
-// REQUIRES: not_system-windows
+// UNSUPPORTED: system-windows
 
 #ifdef __cplusplus
 extern "C" int printf(const char*, ...);

--- a/interpreter/cling/test/Driver/StartupFile.C
+++ b/interpreter/cling/test/Driver/StartupFile.C
@@ -7,7 +7,7 @@
 //------------------------------------------------------------------------------
 
 // RUN: cat %s | env CLING_HOME="%S/Inputs" %cling %s 2>&1 | FileCheck %s
-// REQUIRES: not_system-windows
+// UNSUPPORTED: system-windows
 
 // CHECK: Startup file ran, magic # was 43210
 

--- a/interpreter/cling/test/DynamicLibraryManager/cached_realpath.C
+++ b/interpreter/cling/test/DynamicLibraryManager/cached_realpath.C
@@ -6,7 +6,7 @@
 // LICENSE.TXT for details.
 //------------------------------------------------------------------------------
 
-// REQUIRES: not_system-windows
+// UNSUPPORTED: system-windows
 
 // RUN: %rm -fr %t-dir
 // RUN: %mkdir %t-dir

--- a/interpreter/cling/test/DynamicLibraryManager/callable_lib_L_AB_subst.C
+++ b/interpreter/cling/test/DynamicLibraryManager/callable_lib_L_AB_subst.C
@@ -6,7 +6,7 @@
 // LICENSE.TXT for details.
 //------------------------------------------------------------------------------
 
-// UNSUPPORTED: macos
+// UNSUPPORTED: system-darwin
 // RUN: mkdir -p %t-dir/rlib
 // RUN: mkdir -p %t-dir/lib
 // RUN: %clang -shared -DCLING_EXPORT=%dllexport %S/call_lib_A.c -o%t-dir/rlib/libcall_lib_A%shlibext

--- a/interpreter/cling/test/DynamicLibraryManager/callable_lib_L_AB_subst1.C
+++ b/interpreter/cling/test/DynamicLibraryManager/callable_lib_L_AB_subst1.C
@@ -6,7 +6,7 @@
 // LICENSE.TXT for details.
 //------------------------------------------------------------------------------
 
-// UNSUPPORTED: windows, linux
+// UNSUPPORTED: system-windows, system-linux
 // RUN: mkdir -p %t-dir/rlib
 // RUN: mkdir -p %t-dir/lib
 // RUN: %clang -shared -DCLING_EXPORT=%dllexport %S/call_lib_A.c -o%t-dir/rlib/libcall_lib_A%shlibext

--- a/interpreter/cling/test/DynamicLibraryManager/callable_lib_L_AB_subst2.C
+++ b/interpreter/cling/test/DynamicLibraryManager/callable_lib_L_AB_subst2.C
@@ -6,7 +6,7 @@
 // LICENSE.TXT for details.
 //------------------------------------------------------------------------------
 
-// UNSUPPORTED: windows, linux
+// UNSUPPORTED: system-windows, system-linux
 // RUN: mkdir -p %t-dir/rlib
 // RUN: mkdir -p %t-dir/lib
 // RUN: %clang -shared -DCLING_EXPORT=%dllexport %S/call_lib_A.c -o%t-dir/rlib/libcall_lib_A%shlibext

--- a/interpreter/cling/test/DynamicLibraryManager/callable_lib_L_AB_subst3.C
+++ b/interpreter/cling/test/DynamicLibraryManager/callable_lib_L_AB_subst3.C
@@ -6,7 +6,7 @@
 // LICENSE.TXT for details.
 //------------------------------------------------------------------------------
 
-// UNSUPPORTED: windows
+// UNSUPPORTED: system-windows
 // RUN: mkdir -p %t-dir/rlib
 // RUN: mkdir -p %t-dir/lib
 // RUN: %clang -shared -DCLING_EXPORT=%dllexport %S/call_lib_A.c -o%t-dir/rlib/libcall_lib_A%shlibext

--- a/interpreter/cling/test/DynamicLibraryManager/callable_lib_L_AB_subst4.C
+++ b/interpreter/cling/test/DynamicLibraryManager/callable_lib_L_AB_subst4.C
@@ -6,7 +6,7 @@
 // LICENSE.TXT for details.
 //------------------------------------------------------------------------------
 
-// UNSUPPORTED: windows
+// UNSUPPORTED: system-windows
 // RUN: mkdir -p %t-dir/rlib
 // RUN: mkdir -p %t-dir/lib
 // RUN: %clang -shared -DCLING_EXPORT=%dllexport %S/call_lib_A.c -o%t-dir/rlib/libcall_lib_A%shlibext

--- a/interpreter/cling/test/DynamicLibraryManager/pie.C
+++ b/interpreter/cling/test/DynamicLibraryManager/pie.C
@@ -6,7 +6,7 @@
 // LICENSE.TXT for details.
 //------------------------------------------------------------------------------
 
-// REQUIRES: not_system-windows
+// UNSUPPORTED: system-windows
 
 // RUN: mkdir -p %t-dir/lib
 // RUN: %clang -shared -DCLING_EXPORT=%dllexport %S/call_lib_A.c -o%t-dir/lib/libcall_lib_A%shlibext

--- a/interpreter/cling/test/lit.cfg
+++ b/interpreter/cling/test/lit.cfg
@@ -109,10 +109,6 @@ config.substitutions.append(('%shlibext', config.shlibext))
 if platform.system() not in ['Windows'] or lit_config.getBashPath() != '':
     config.available_features.add('shell')
 
-# Filter-out tests not supposed to run on Windows
-if platform.system() not in ['Windows']:
-    config.available_features.add('not_system-windows')
-
 # ROOT adds features that "heal" some of cling's tests; need to detect
 # vanilla vs cling-as-part-of-ROOT. The latter has no `lib/UserInterface/textinput/`:
 if os.path.isdir(os.path.join(config.cling_src_root, 'lib', 'UserInterface', 'textinput')):


### PR DESCRIPTION
With LLVM 16 and https://reviews.llvm.org/D141007, this will not be
supported anymore. As a replacement, use `system-{darwin,linux,windows}`.

Also replace `REQUIRES: not_system-windows` by `UNSUPPORTED: system-windows`.