### PR TITLE
[ntuple] RNTupleSerialize: construct `std::span` from pointer + size

### DIFF
--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -1077,7 +1077,9 @@ std::uint32_t ROOT::Experimental::Internal::RNTupleSerializer::SerializeSchemaDe
       nAliasColumns = desc.GetNLogicalColumns() - desc.GetNPhysicalColumns();
    }
    const auto &onDiskFields = context.GetOnDiskFieldList();
-   std::span<const DescriptorId_t> fieldList{&(*(onDiskFields.cbegin() + fieldListOffset)), &(*onDiskFields.cend())};
+   R__ASSERT(onDiskFields.size() >= fieldListOffset);
+   std::span<const DescriptorId_t> fieldList{onDiskFields.data() + fieldListOffset,
+                                             onDiskFields.size() - fieldListOffset};
 
    auto frame = pos;
    pos += SerializeListFramePreamble(nFields, *where);


### PR DESCRIPTION
Commit 6abb8e90d9 reverts to the `std::span` pointer/pointer constructor. Unfortunately, per https://en.cppreference.com/w/cpp/container/vector/end, dereferencing the end iterator of a vector results in undefined behavior. This actually triggers an assertion on MSVC:
```
Assertion failed: can't dereference out of range vector iterator
```
Change the constructor to use pointer/size instead, which is also compatible with the original fix for libc++ in commit 6abb8e90d9.

This should fix the aforementioned assertion on Windows.

## Checklist:
- [x] tested changes locally