### PR TITLE
[cmake] remove chrome workaround for Ubuntu

### DIFF
--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -332,9 +332,6 @@ set(dicttype ${ROOT_DICTTYPE})
 find_program(PERL_EXECUTABLE perl)
 set(perl ${PERL_EXECUTABLE})
 
-# --- workaround for Ubuntu 20.04, where snap chrome has problem with arguments translation, to be remove once problem fixed
-find_program(CHROME_EXECUTABLE NAMES chrome PATHS "/snap/chromium/current/usr/lib/chromium-browser/" NO_DEFAULT_PATH)
-
 find_program(CHROME_EXECUTABLE NAMES chrome.exe chromium chromium-browser chrome chrome-browser Google\ Chrome
              PATH_SUFFIXES "Google/Chrome/Application")
 if(CHROME_EXECUTABLE)


### PR DESCRIPTION
Was introduced by
https://github.com/root-project/root/commit/e7d80140e6847bbffa0765c4610c4e7d0266a0c6

Seems to be bug was resolved:

https://bugs.launchpad.net/chromium-browser/+bug/1893020
 https://bugs.launchpad.net/ubuntu/+source/chromium-browser/+bug/1894216

