### PR TITLE
[ntuple] Fix typo in `RPageSource::PrepareLoadCluster` signature

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -425,7 +425,7 @@ protected:
    /// commonly used as part of `LoadClusters()` in derived classes.
    void PrepareLoadCluster(
       const RCluster::RKey &clusterKey, ROnDiskPageMap &pageZeroMap,
-      std::function<void(DescriptorId_t, NTupleSize_t, RClusterDescriptor::RPageRange::RPageInfo)> perPageFunc);
+      std::function<void(DescriptorId_t, NTupleSize_t, const RClusterDescriptor::RPageRange::RPageInfo &)> perPageFunc);
 
    /// Enables the default set of metrics provided by RPageSource. `prefix` will be used as the prefix for
    /// the counters registered in the internal RNTupleMetrics object.

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -178,7 +178,7 @@ ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageSource::Unsea
 
 void ROOT::Experimental::Detail::RPageSource::PrepareLoadCluster(
    const RCluster::RKey &clusterKey, ROnDiskPageMap &pageZeroMap,
-   std::function<void(DescriptorId_t, NTupleSize_t, RClusterDescriptor::RPageRange::RPageInfo)> perPageFunc)
+   std::function<void(DescriptorId_t, NTupleSize_t, const RClusterDescriptor::RPageRange::RPageInfo &)> perPageFunc)
 {
    auto descriptorGuard = GetSharedDescriptorGuard();
    const auto &clusterDesc = descriptorGuard->GetClusterDescriptor(clusterKey.fClusterId);


### PR DESCRIPTION
Commit 2b54b792fc (added by PR #13388) changed the type of the third argument to `std::function`. However, the correct type should be
```
std::function<void(DescriptorId_t, NTupleSize_t,
                   const RClusterDescriptor::RPageRange::RPageInfo &)> perPageFunc)
```
Otherwise, passing by value incurs in an extra copy in `std::function<...>::operator()`.

## Checklist:
- [x] tested changes locally