### PR TITLE
Make `ROOT::TestSupport` an `OBJECT` library 

### DIFF
--- a/core/testsupport/CMakeLists.txt
+++ b/core/testsupport/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 set(libname TestSupport)
 set(header_dir ROOT/)
 
-add_library(${libname} STATIC src/TestSupport.cxx)
+add_library(${libname} OBJECT src/TestSupport.cxx)
 target_include_directories(${libname} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc/>
   $<INSTALL_INTERFACE:./>
@@ -22,6 +22,7 @@ target_link_libraries(${libname} PUBLIC Core gtest)
 set_target_properties(${libname} PROPERTIES PUBLIC_HEADER inc/${header_dir}/TestSupport.hxx)
 install(TARGETS ${libname}
   EXPORT ${CMAKE_PROJECT_NAME}Exports
+  OBJECTS DESTINATION ${CMAKE_INSTALL_LIBDIR}/${libname}
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${header_dir})
 set_property(GLOBAL APPEND PROPERTY ROOT_EXPORTED_TARGETS ${libname})
 

--- a/hist/histdrawv7/test/CMakeLists.txt
+++ b/hist/histdrawv7/test/CMakeLists.txt
@@ -4,4 +4,5 @@
 # For the licensing terms see $ROOTSYS/LICENSE.
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
-ROOT_ADD_UNITTEST_DIR(ROOTHistDraw ROOTGpadv7)
+ROOT_ADD_GTEST(drawUnit draw.cxx LIBRARIES ROOTHistDraw)
+ROOT_ADD_GTEST(ioUnit io.cxx LIBRARIES ROOTHistDraw)

--- a/hist/histdrawv7/test/CMakeLists.txt
+++ b/hist/histdrawv7/test/CMakeLists.txt
@@ -5,4 +5,9 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
 ROOT_ADD_GTEST(drawUnit draw.cxx LIBRARIES ROOTHistDraw)
-ROOT_ADD_GTEST(ioUnit io.cxx LIBRARIES ROOTHistDraw)
+# On Windows, this test receives "unexpected diagnostic of severity 2000"
+# because "pointer was truncated (due a missing dictionary)" and then trying
+# to allocate "an object of abstract class type 'RHistImplBase'".
+if(NOT MSVC OR win_broken_tests)
+  ROOT_ADD_GTEST(ioUnit io.cxx LIBRARIES ROOTHistDraw)
+endif()

--- a/roofit/roofitcore/test/TestStatistics/testPlot.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testPlot.cxx
@@ -103,6 +103,8 @@ TEST(TestStatisticsPlot, RooRealL)
 
    RooUnitTest::setMemDir(gDirectory);
 
+   gErrorIgnoreLevel = kWarning;
+
    TFile fref("TestStatistics_ref.root");
 
    TestRooRealLPlot plotTest{fref, false, 0};

--- a/tree/ntuple/v7/test/ntuple_modelext.cxx
+++ b/tree/ntuple/v7/test/ntuple_modelext.cxx
@@ -327,7 +327,9 @@ TEST(RNTuple, ModelExtensionRealWorld1)
 TEST(RNTuple, ModelExtensionComplex)
 {
    using doubleAoA_t = std::array<std::array<double, 2>, 2>;
+#ifdef R__USE_IMT
    ROOT::EnableImplicitMT();
+#endif
    FileRaii fileGuard("test_ntuple_modelext_complex.root");
 
    TRandom3 rnd(42);

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -2,6 +2,7 @@
 #include <ROOT/RNTupleOptions.hxx>
 
 #include <TFile.h>
+#include <ROOT/TestSupport.hxx>
 
 #include "CustomStructUtil.hxx"
 #include "ntupleutil_test.hxx"
@@ -41,6 +42,10 @@ TEST(RNTupleInspector, CreateFromString)
    EXPECT_EQ(inspector->GetDescriptor()->GetName(), "ntuple");
 
    EXPECT_THROW(RNTupleInspector::Create("nonexistent", fileGuard.GetPath()), ROOT::Experimental::RException);
+
+   ROOT::TestSupport::CheckDiagsRAII diag;
+   diag.requiredDiag(kError, "TFile::TFile", "nonexistent.root does not exist",
+                     /*matchFullMessage=*/false);
    EXPECT_THROW(RNTupleInspector::Create("ntuple", "nonexistent.root"), ROOT::Experimental::RException);
 }
 


### PR DESCRIPTION
For static libraries, the linker can decide to skip it and not include the contained object files. This defeats the purpose of `TestSupport` which registers a global `ForbidDiagnostics noDiagCheckerInstance` to call `SetErrorHandler` and fail the test if there is an unexpected diagnostic. Object libraries, on the other hand, propagate their files directly and are guaranteed to be included.

Fixes https://github.com/root-project/root/issues/12828