### PR TITLE
Delete the object held by gROOT after we reset the globals.

### DIFF
--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -1129,11 +1129,13 @@ namespace {
 
 void TROOT::CloseFiles()
 {
+   // Close files without deleting the objects (`ResetGlobals` will be called
+   // next; see `EndOfProcessCleanups()` below.)
    if (fFiles && fFiles->First()) {
       R__ListSlowClose(static_cast<TList*>(fFiles));
    }
    // and Close TROOT itself.
-   Close("slow");
+   Close("nodelete");
    // Now sockets.
    if (fSockets && fSockets->First()) {
       if (nullptr==fCleanups->FindObject(fSockets) ) {
@@ -1212,14 +1214,17 @@ void TROOT::EndOfProcessCleanups()
    CloseFiles();
 
    if (gInterpreter) {
+      // This might delete some of the objects 'held' by the TFiles (hence
+      // `CloseFiles` must not delete them)
       gInterpreter->ResetGlobals();
    }
 
-   // Now delete the objects 'held' by the TFiles so that it
+   // Now delete the objects still 'held' by the TFiles so that it
    // is done before the tear down of the libraries.
    if (fClosedObjects && fClosedObjects->First()) {
       R__ListSlowDeleteContent(static_cast<TList*>(fClosedObjects));
    }
+   fList->Delete("slow");
 
    // Now a set of simpler things to delete.  See the same ordering in
    // TROOT::~TROOT


### PR DESCRIPTION
For example this allows unique_ptr to be deleted first and thus inform TROOT if need be

Fix #13462