### PR TITLE
[RF] Fix bugs in HistFactory component plots

### DIFF
--- a/roofit/histfactory/test/CMakeLists.txt
+++ b/roofit/histfactory/test/CMakeLists.txt
@@ -17,3 +17,4 @@ if(clad)
 endif(clad)
 
 ROOT_ADD_GTEST(testParamHistFunc testParamHistFunc.cxx LIBRARIES RooFitCore HistFactory)
+ROOT_ADD_GTEST(testHistFactoryPlotting testHistFactoryPlotting.cxx LIBRARIES RooFitCore HistFactory)

--- a/roofit/histfactory/test/testHistFactory.cxx
+++ b/roofit/histfactory/test/testHistFactory.cxx
@@ -61,6 +61,8 @@ TEST(Sample, CopyAssignment)
 
 TEST(HistFactory, Read_ROOT6_16_Model)
 {
+   RooHelpers::LocalChangeMsgLevel chmsglvl{RooFit::WARNING, 0u, RooFit::NumIntegration, true};
+
    std::string filename = "./ref_6.16_example_UsingC_channel1_meas_model.root";
    std::unique_ptr<TFile> file(TFile::Open(filename.c_str()));
    if (!file || !file->IsOpen()) {
@@ -88,6 +90,8 @@ TEST(HistFactory, Read_ROOT6_16_Model)
 
 TEST(HistFactory, Read_ROOT6_16_Combined_Model)
 {
+   RooHelpers::LocalChangeMsgLevel chmsglvl{RooFit::WARNING, 0u, RooFit::NumIntegration, true};
+
    std::string filename = "./ref_6.16_example_UsingC_combined_meas_model.root";
    std::unique_ptr<TFile> file(TFile::Open(filename.c_str()));
    if (!file || !file->IsOpen()) {

--- a/roofit/histfactory/test/testHistFactoryPlotting.cxx
+++ b/roofit/histfactory/test/testHistFactoryPlotting.cxx
@@ -1,0 +1,177 @@
+// Tests for the ParamHistFunc
+// Authors: Jonas Rembser, CERN  08/2023
+
+#include <RooStats/HistFactory/Measurement.h>
+#include <RooStats/HistFactory/MakeModelAndMeasurementsFast.h>
+#include <RooStats/HistFactory/Sample.h>
+#include <RooFit/ModelConfig.h>
+
+#include <RooCategory.h>
+#include <RooWorkspace.h>
+#include <RooSimultaneous.h>
+#include <RooRealVar.h>
+#include <RooHelpers.h>
+#include <RooPlot.h>
+
+#include <TROOT.h>
+#include <TFile.h>
+#include <TCanvas.h>
+#include <TF1.h>
+#include <TH1D.h>
+
+#include <gtest/gtest.h>
+
+void createToyHistos1D()
+{
+   // Save histograms in this root file
+   std::unique_ptr<TFile> histoFile{TFile::Open("histoFile.root", "RECREATE")};
+
+   // Set number of events in signal and background (N_Sig = N_BG = N_DATA/2)
+   int nEvents = 10000;
+
+   // Functions used to fill histograms
+   TF1 func1{"func1", "1 + 0.01 * x", 3000, 6000};                                         // background
+   TF1 func2{"func2", "0.2 * exp(-( (x-4000.)*(x-4000.)/(2.0*200.*200.) ) )", 3000, 6000}; // signal
+
+   // Histograms
+   TH1D *histoBG = new TH1D("histoBG", "background histo", 15, 3000, 6000);
+   TH1D *histoSig = new TH1D("histoSig", "signal histo", 15, 3000, 6000);
+   TH1D *histoData = new TH1D("histoData", "data histo", 15, 3000, 6000);
+
+   // define observable x
+   double x_bg;  // background
+   double x_sig; // signal
+
+   // Fill background and signal histograms
+   for (int i = 0; i < nEvents; ++i) {
+      x_bg = func1.GetRandom();
+      x_sig = func2.GetRandom();
+      histoBG->Fill(x_bg);
+      histoSig->Fill(x_sig);
+   }
+
+   // Fill data histogram
+   for (int i = 0; i < nEvents; ++i) {
+      x_bg = func1.GetRandom();
+      histoData->Fill(x_bg);
+      x_sig = func2.GetRandom();
+      histoData->Fill(x_sig);
+   }
+
+   histoFile->Write();
+}
+
+/// Test that plotting HistFactory components works correctly. Covers the
+/// problem reported in this forum post:
+/// https://root-forum.cern.ch/t/problems-plotting-individual-components-with-roofit-histfactory
+TEST(HistFactoryPlotting, ComponentSelection)
+{
+   RooHelpers::LocalChangeMsgLevel chmsglvl{RooFit::WARNING};
+
+   using namespace RooFit;
+
+   // Make histograms
+   createToyHistos1D();
+
+   // --------------------------------------
+   // Load histograms
+   // --------------------------------------
+
+   // file with histograms
+   std::string histoFileName = "histoFile.root";
+
+   // load histograms
+   std::unique_ptr<TFile> histoFile{TFile::Open(histoFileName.c_str(), "READ")};
+   std::vector<TH1 *> templateHistos;
+   templateHistos.emplace_back(histoFile->Get<TH1>("histoSig"));
+   templateHistos.emplace_back(histoFile->Get<TH1>("histoBG"));
+
+   // --------------------------------------
+   // Setup measurement & channel
+   // --------------------------------------
+
+   // -- Define the measurement
+   RooStats::HistFactory::Measurement meas("B2D0MuNu", "B2D0MuNu fit");
+
+   meas.SetExportOnly(true);    // Tells histfactory to not run the fit
+   meas.SetPOI("num_histoSig"); // set to Bogus parma. of interest
+   meas.SetLumi(1.0);
+   meas.SetLumiRelErr(0.1);
+
+   // -- Define the channel (in our case, there is only one)
+   RooStats::HistFactory::Channel B2D0MuNu("BMCorr");
+   B2D0MuNu.SetData("histoData", "histoFile.root");
+
+   // -- Add the histograms to the channel
+   for (auto const &histo : templateHistos) {
+
+      RooStats::HistFactory::Sample sample(histo->GetName(), histo->GetName(), histoFileName);
+
+      sample.SetNormalizeByTheory(false);
+      // fix normalisation
+      sample.AddNormFactor("norm_" + std::string{histo->GetName()}, 1 / histo->Integral(), 1 / histo->Integral(),
+                           1 / histo->Integral());
+      // free yield
+      sample.AddNormFactor("num_" + std::string{histo->GetName()}, histo->Integral(), 1.0, histo->Integral() * 2);
+
+      // add histograms to channel
+      B2D0MuNu.AddSample(sample);
+   }
+
+   // add channel to measurements
+   meas.AddChannel(B2D0MuNu);
+   meas.SetExportOnly(true);
+   meas.CollectHistograms();
+
+   // --------------------------------------
+   // Setting up workspace
+   // --------------------------------------
+
+   // -- Define workspace
+   std::unique_ptr<RooWorkspace> ws{RooStats::HistFactory::MakeModelAndMeasurementFast(meas)};
+
+   // Get model manually
+   auto *modelConf = static_cast<RooStats::ModelConfig *>(ws->obj("ModelConfig"));
+   auto *model = static_cast<RooSimultaneous *>(modelConf->GetPdf());
+
+   // fix the Lumi to not have it also fitted
+   RooArgSet const *nuis = modelConf->GetNuisanceParameters();
+   (static_cast<RooRealVar *>(nuis->find("Lumi")))->setConstant(true);
+   (static_cast<RooRealVar *>(nuis->find("norm_histoSig")))->setConstant(true); // fix norm
+   (static_cast<RooRealVar *>(nuis->find("norm_histoBG")))->setConstant(true);  // fix norm
+
+   auto *obs = static_cast<RooArgSet const *>(modelConf->GetObservables());
+   auto *idx = static_cast<RooCategory *>(obs->find("channelCat"));
+   RooAbsData *data = ws->data("obsData");
+   auto *obs_x = static_cast<RooRealVar *>(obs->find("obs_x_BMCorr"));
+
+   // plot data, total pdf and individual components
+   std::unique_ptr<RooPlot> frame{obs_x->frame()};
+   data->plotOn(frame.get(), DataError(RooAbsData::Poisson), MarkerSize(0.4), DrawOption("ZP"), Name("pdf_Data"));
+   model->plotOn(frame.get(), ProjWData(*idx, *data), Name("pdf_model"), LineColor(kGreen));
+   model->plotOn(frame.get(), ProjWData(*idx, *data), Name("pdf_sig"), Components("*histoSig*"), LineColor(kBlue));
+   model->plotOn(frame.get(), ProjWData(*idx, *data), Name("pdf_bg"), Components("*histoBG*"), LineColor(kRed));
+
+   auto *curveFull = static_cast<RooCurve *>(frame->findObject("pdf_model"));
+   auto *curgeSig = static_cast<RooCurve *>(frame->findObject("pdf_sig"));
+   auto *curgeBg = static_cast<RooCurve *>(frame->findObject("pdf_bg"));
+
+   for (int i = 0; i < curveFull->GetN(); ++i) {
+      double x1, x2, x3;
+      double y1, y2, y3;
+      curveFull->GetPoint(i, x1, y1);
+      curgeSig->GetPoint(i, x2, y2);
+      curgeBg->GetPoint(i, x3, y3);
+      // The points for the components should add up to the points of the full model.
+      EXPECT_DOUBLE_EQ(y2 + y3, y1);
+   }
+
+   constexpr bool makePlot = false;
+
+   if (makePlot) {
+      gROOT->SetBatch(true);
+      TCanvas c1{};
+      frame->Draw();
+      c1.SaveAs("hf_component_plot.png");
+   }
+}

--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -419,6 +419,7 @@ protected:
   friend class RooAddHelpers;
   friend class RooAddPdf;
   friend class RooAddModel;
+  friend class AddCacheElem;
   friend class RooFit::Detail::DataMap;
 
   // Hook for objects with normalization-dependent parameters interpretation

--- a/roofit/roofitcore/inc/RooBinWidthFunction.h
+++ b/roofit/roofitcore/inc/RooBinWidthFunction.h
@@ -24,34 +24,24 @@
 
 class RooBinWidthFunction : public RooAbsReal {
   static bool _enabled;
-  
-public:  
+
+public:
   static void enableClass();
   static void disableClass();
-  static bool isClassEnabled();    
-   
+  static bool isClassEnabled();
+
   /// Create an empty instance.
   RooBinWidthFunction() :
     _histFunc("HistFuncForBinWidth", "Handle to a RooHistFunc, whose bin volumes should be returned.", this,
         /*valueServer=*/true, /*shapeServer=*/true) { }
 
-  /// Create an instance.
-  /// \param name Name to identify the object.
-  /// \param title Title for e.g. plotting.
-  /// \param histFunc RooHistFunc object whose bin widths should be returned.
-  /// \param divideByBinWidth If true, return inverse bin width.
-  RooBinWidthFunction(const char* name, const char* title, const RooHistFunc& histFunc, bool divideByBinWidth) :
-    RooAbsReal(name, title),
-    _histFunc("HistFuncForBinWidth", "Handle to a RooHistFunc, whose bin volumes should be returned.", this, histFunc, /*valueServer=*/true, /*shapeServer=*/true),
-    _divideByBinWidth(divideByBinWidth) { }
+  RooBinWidthFunction(const char* name, const char* title, const RooHistFunc& histFunc, bool divideByBinWidth);
 
   /// Copy an existing object.
   RooBinWidthFunction(const RooBinWidthFunction& other, const char* newname = nullptr) :
     RooAbsReal(other, newname),
     _histFunc("HistFuncForBinWidth", this, other._histFunc),
     _divideByBinWidth(other._divideByBinWidth) { }
-
-  ~RooBinWidthFunction() override { }
 
   std::unique_ptr<RooAbsArg> compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileContext & ctx) const override;
 

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -1529,19 +1529,19 @@ void RooAbsReal::plotOnCompSelect(RooArgSet* selNodes) const
   }
 
 
-  // Add all nodes below selected nodes
+  // Add all nodes below selected nodes that are value servers
   RooArgSet tmp;
   for (const auto arg : branchNodeSet) {
     for (const auto selNode : *selNodes) {
-      if (selNode->dependsOn(*arg)) {
+      if (selNode->dependsOn(*arg, nullptr, /*valueOnly=*/true)) {
         tmp.add(*arg,true);
       }
     }
   }
 
-  // Add all nodes that depend on selected nodes
+  // Add all nodes that depend on selected nodes by value
   for (const auto arg : branchNodeSet) {
-    if (arg->dependsOn(*selNodes)) {
+    if (arg->dependsOn(*selNodes, nullptr, /*valueOnly=*/true)) {
       tmp.add(*arg,true);
     }
   }

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -2220,7 +2220,6 @@ RooPlot* RooAbsReal::plotOn(RooPlot *frame, PlotOpt o) const
       // Evaluate fractional correction integral always on full p.d.f, not component.
       GlobalSelectComponentRAII selectCompRAII(true);
       std::unique_ptr<RooAbsReal> intFrac{projection->createIntegral(*plotVar,*plotVar,o.normRangeName)};
-      _globalSelectComp = true; //It's unclear why this is done a second time. Maybe unnecessary.
       if(o.stype != RooAbsReal::Raw || this->InheritsFrom(RooAbsPdf::Class())){
         // this scaling should only be !=1  when plotting partial ranges
         // still, raw means raw

--- a/roofit/roofitcore/src/RooExtendPdf.cxx
+++ b/roofit/roofitcore/src/RooExtendPdf.cxx
@@ -119,11 +119,7 @@ double RooExtendPdf::expectedEvents(const RooArgSet* nset) const
   // Optionally multiply with fractional normalization
   if (_rangeName) {
 
-    double fracInt;
-    {
-      GlobalSelectComponentRAII globalSelComp(true);
-      fracInt = pdf.getNormObj(nset,nset,_rangeName)->getVal();
-    }
+    double fracInt = pdf.getNormObj(nset,nset,_rangeName)->getVal();
 
 
     if ( fracInt == 0. || _n == 0.) {

--- a/roofit/roofitcore/src/RooRealIntegral.cxx
+++ b/roofit/roofitcore/src/RooRealIntegral.cxx
@@ -239,13 +239,18 @@ RooRealIntegral::RooRealIntegral()
 /// The other integrations are performed numerically. The optional
 /// config object prescribes how these numeric integrations are configured.
 ///
-
+/// \Note If pdf component selection was globally overridden to always include
+/// all components (either with RooAbsReal::globalSelectComp(bool) or a
+/// RooAbsReal::GlobalSelectComponentRAII), then any created integral will
+/// ignore component selections during its lifetime. This is especially useful
+/// when creating normalization or projection integrals.
 RooRealIntegral::RooRealIntegral(const char *name, const char *title,
              const RooAbsReal& function, const RooArgSet& depList,
              const RooArgSet* funcNormSet, const RooNumIntConfig* config,
              const char* rangeName) :
   RooAbsReal(name,title),
   _valid(true),
+  _respectCompSelect{!_globalSelectComp},
   _sumList("!sumList","Categories to be summed numerically",this,false,false),
   _intList("!intList","Variables to be integrated numerically",this,false,false),
   _anaList("!anaList","Variables to be integrated analytically",this,false,false),
@@ -836,7 +841,7 @@ double RooRealIntegral::getValV(const RooArgSet* nset) const
 
 double RooRealIntegral::evaluate() const
 {
-  GlobalSelectComponentRAII selCompRAII(_globalSelectComp || !_respectCompSelect);
+  GlobalSelectComponentRAII selCompRAII(!_respectCompSelect);
 
   double retVal(0) ;
   switch (_intOperMode) {


### PR DESCRIPTION
Make component plots also work with HistFactory models and include a unit test. More detail on the fixes in the commit descriptions. There were in fact two separate bugs that resulted in this not working:

1. Wrong component (sample) selection because the same RooBinWidthFunction is used for all samples
2. Wrong normalization integrals for plots with component selection of pdfs with numeric normalization integrals

The bug affects for example the user in this forum post: https://root-forum.cern.ch/t/problems-plotting-individual-components-with-roofit-histfactory

Thanks a lot to Veronica for reporting this issue!