### PR TITLE
[qt5web] imrpove creation and cleanup of QApplication

### DIFF
--- a/gui/qt5webdisplay/CMakeLists.txt
+++ b/gui/qt5webdisplay/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.
+# Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.
 # All rights reserved.
 #
 # For the licensing terms see $ROOTSYS/LICENSE.

--- a/gui/qt5webdisplay/rootqt5.cpp
+++ b/gui/qt5webdisplay/rootqt5.cpp
@@ -3,7 +3,7 @@
 // Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
- * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *

--- a/gui/qt5webdisplay/rootqt5.cpp
+++ b/gui/qt5webdisplay/rootqt5.cpp
@@ -19,10 +19,7 @@
 #include <QWebEngineSettings>
 #include <QWebEngineProfile>
 #include <QtGlobal>
-
-#if QT_VERSION >= 0x050C00
 #include <QWebEngineUrlScheme>
-#endif
 
 #include "TROOT.h"
 #include "TApplication.h"
@@ -42,6 +39,7 @@
 #include <ROOT/RWebWindowsManager.hxx>
 #include <ROOT/RLogger.hxx>
 
+QWebEngineUrlScheme gRootScheme("rootscheme");
 QApplication *gOwnApplication = nullptr;
 int gQt5HandleCounts = 0;
 bool gProcEvents = false;
@@ -118,14 +116,6 @@ protected:
 
             // initialize web engine only before creating QApplication
             QtWebEngine::initialize();
-
-            #if QT_VERSION >= 0x050C00
-            QWebEngineUrlScheme scheme("rootscheme");
-            scheme.setSyntax(QWebEngineUrlScheme::Syntax::HostAndPort);
-            scheme.setDefaultPort(2345);
-            scheme.setFlags(QWebEngineUrlScheme::SecureScheme);
-            QWebEngineUrlScheme::registerScheme(scheme);
-            #endif
 
             qargv[0] = gApplication->Argv(0);
             qargv[1] = nullptr;
@@ -276,7 +266,15 @@ public:
 };
 
 struct RQt5CreatorReg {
-   RQt5CreatorReg() { RQt5WebDisplayHandle::AddCreator(); }
+   RQt5CreatorReg() {
+      RQt5WebDisplayHandle::AddCreator();
+
+      gRootScheme.setSyntax(QWebEngineUrlScheme::Syntax::HostAndPort);
+      gRootScheme.setDefaultPort(2345);
+      gRootScheme.setFlags(QWebEngineUrlScheme::SecureScheme);
+      QWebEngineUrlScheme::registerScheme(gRootScheme);
+
+   }
 } newRQt5CreatorReg;
 
 }

--- a/gui/qt5webdisplay/rooturlschemehandler.cpp
+++ b/gui/qt5webdisplay/rooturlschemehandler.cpp
@@ -2,9 +2,8 @@
 // Date: 2017-06-29
 // Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
-
 /*************************************************************************
- * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -120,12 +119,12 @@ public:
       QWebEngineUrlRequestJob *req = fRequest.req();
 
       if (!req) {
-         R__LOG_ERROR(QtWebDisplayLog()) << "Qt5 request already processed path " << GetPathName() << " file " << GetFileName();
+         R__LOG_ERROR(QtWebDisplayLog()) << "Qt " << QT_VERSION_STR << " request already processed path " << GetPathName() << " file " << GetFileName();
          return;
       }
 
       if (Is404()) {
-         R__LOG_ERROR(QtWebDisplayLog()) << "Qt5 request FAIL path " << GetPathName() << " file " << GetFileName();
+         R__LOG_ERROR(QtWebDisplayLog()) << "Qt " << QT_VERSION_STR << " request FAIL path " << GetPathName() << " file " << GetFileName();
 
          req->fail(QWebEngineUrlRequestJob::UrlNotFound);
          // abort request

--- a/gui/qt5webdisplay/rooturlschemehandler.h
+++ b/gui/qt5webdisplay/rooturlschemehandler.h
@@ -3,7 +3,7 @@
 // Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
- * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *

--- a/gui/qt5webdisplay/rootwebpage.cpp
+++ b/gui/qt5webdisplay/rootwebpage.cpp
@@ -3,7 +3,7 @@
 // Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
- * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *

--- a/gui/qt5webdisplay/rootwebpage.h
+++ b/gui/qt5webdisplay/rootwebpage.h
@@ -3,7 +3,7 @@
 // Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
- * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *

--- a/gui/qt5webdisplay/rootwebview.cpp
+++ b/gui/qt5webdisplay/rootwebview.cpp
@@ -3,7 +3,7 @@
 // Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
- * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *

--- a/gui/qt5webdisplay/rootwebview.h
+++ b/gui/qt5webdisplay/rootwebview.h
@@ -3,7 +3,7 @@
 // Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
- * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *

--- a/gui/qt6webdisplay/CMakeLists.txt
+++ b/gui/qt6webdisplay/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.
+# Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.
 # All rights reserved.
 #
 # For the licensing terms see $ROOTSYS/LICENSE.

--- a/gui/qt6webdisplay/rootqt6.cpp
+++ b/gui/qt6webdisplay/rootqt6.cpp
@@ -3,7 +3,7 @@
 // Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
- * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *

--- a/gui/qt6webdisplay/rootqt6.cpp
+++ b/gui/qt6webdisplay/rootqt6.cpp
@@ -14,7 +14,6 @@
 #include <QWebEngineView>
 #include <qtwebenginecoreglobal.h>
 #include <QWebEngineDownloadRequest>
-// #include <qtwebenginequickglobal.h>
 
 #include <QThread>
 #include <QWebEngineSettings>
@@ -39,6 +38,9 @@
 
 #include <ROOT/RWebDisplayHandle.hxx>
 #include <ROOT/RLogger.hxx>
+
+QWebEngineUrlScheme gRootScheme("rootscheme");
+
 
 /** \class TQt6Timer
 \ingroup qt6webdisplay
@@ -100,12 +102,6 @@ protected:
 
             // initialize web engine only before creating QApplication
             // QtWebEngineQuick::initialize();
-
-            QWebEngineUrlScheme scheme("rootscheme");
-            scheme.setSyntax(QWebEngineUrlScheme::Syntax::HostAndPort);
-            scheme.setDefaultPort(2345);
-            scheme.setFlags(QWebEngineUrlScheme::SecureScheme);
-            QWebEngineUrlScheme::registerScheme(scheme);
 
             qargv[0] = gApplication->Argv(0);
             qargv[1] = nullptr;
@@ -246,7 +242,16 @@ public:
 };
 
 struct RQt6CreatorReg {
-   RQt6CreatorReg() { RQt6WebDisplayHandle::AddCreator(); }
+   RQt6CreatorReg()
+   {
+      RQt6WebDisplayHandle::AddCreator();
+
+      gRootScheme.setSyntax(QWebEngineUrlScheme::Syntax::HostAndPort);
+      gRootScheme.setDefaultPort(2345);
+      gRootScheme.setFlags(QWebEngineUrlScheme::SecureScheme);
+      QWebEngineUrlScheme::registerScheme(gRootScheme);
+
+   }
 } newRQt6CreatorReg;
 
 }

--- a/tutorials/webgui/qtweb/TCanvasWidget.cpp
+++ b/tutorials/webgui/qtweb/TCanvasWidget.cpp
@@ -52,11 +52,11 @@ TCanvasWidget::TCanvasWidget(QWidget *parent) : QWidget(parent)
 
    web->SetCanCreateObjects(kFALSE); // not yet create objects on server side
 
-   web->SetUpdatedHandler([=]() { emit CanvasUpdated(); });
+   web->SetUpdatedHandler([this]() { emit CanvasUpdated(); });
 
-   web->SetActivePadChangedHandler([=](TPad *pad){ emit SelectedPadChanged(pad); });
+   web->SetActivePadChangedHandler([this](TPad *pad){ emit SelectedPadChanged(pad); });
 
-   web->SetPadClickedHandler([=](TPad *pad, int x, int y) { emit PadClicked(pad,x,y); });
+   web->SetPadClickedHandler([this](TPad *pad, int x, int y) { emit PadClicked(pad,x,y); });
 
    web->SetPadDblClickedHandler([this](TPad *pad, int x, int y) { emit PadDblClicked(pad,x,y); });
 


### PR DESCRIPTION
1. Always register custom "rootcheme" to the Qt WebEngine libs before starting any widget. Was missing when QApplication was created by user
2. Correctly cleanup QApplication in qt5 - only when ROOT shutdown procedure started, it should be deleted. Requires special workaround to detect shutdown
3. Fix c++20 compiler warnings in qtweb tutorial
4. Show full qt version in error printouts
