### PR TITLE
[ci] Tell docker to use 1GB /dev/shm: [skip-ci]

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -279,7 +279,7 @@ jobs:
 
     container:
       image: registry.cern.ch/root-ci/${{ matrix.image }}:buildready
-      options: '--security-opt label=disable --rm'
+      options: '--shm-size=1g --security-opt label=disable --rm'
       env:
         OS_APPLICATION_CREDENTIAL_ID: '7f5b64a265244623a3a933308569bdba'
         OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -279,7 +279,7 @@ jobs:
 
     container:
       image: registry.cern.ch/root-ci/${{ matrix.image }}:buildready
-      options: '--shm-size=1g --security-opt label=disable --rm'
+      options: '--shm-size=1g -m 16g --security-opt label=disable --rm'
       env:
         OS_APPLICATION_CREDENTIAL_ID: '7f5b64a265244623a3a933308569bdba'
         OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}


### PR DESCRIPTION
Should fix
```
WARNING:discardable_shared_memory_manager.cc(197)] Less than 64MB of free space in temporary directory for shared memory files: 62
```
and similar errors with headless chromium.
See https://stackoverflow.com/a/56941767

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

