### PR TITLE
[windows] Add `R__LOCKGUARD(gROOTMutex)` in `TChain.cxx`

### DIFF
--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -374,6 +374,12 @@ Int_t TChain::Add(const char *name, Long64_t nentries /* = TTree::kMaxEntries */
    Int_t nf = 0;
    std::vector<std::string> expanded_glob;
    try {
+      // the LOCKGUARD is needed on Windows to fix random crashes
+      // (due to file name corruption) with the MT part of
+      // gtest-tree-dataframe-test-datasource-root
+#ifdef _MSC_VER
+      R__LOCKGUARD(gROOTMutex);
+#endif
       expanded_glob = ROOT::Internal::TreeUtils::ExpandGlob(std::string(basename));
    } catch (const std::runtime_error &) {
       // The 'ExpandGlob' function may throw in case the directory from the glob


### PR DESCRIPTION
This fixes random failures of the `R__USE_IMT` part of the `datasource-root` test on Windows, due to file name corruptions, like for example:
```
[ RUN      ] TRootTDS.DefineSlotMT
Error in <TFile::TFile>: file C:/root-dev/build/x64/debug/tree/dataframe/test/G__NTupleStruct.vcx does not exist
[       OK ] TRootTDS.DefineSlotMT (191 ms)
[ RUN      ] TRootTDS.FromARDFMT
Error in <TFile::Init>: C:/root-dev/build/x64/debug/tree/dataframe/test/INSTALL.vcxproj not a ROOT file
C:\root-dev\git\master\tree\dataframe\test\datasource_root.cxx(175): error: Expected equality of these values:
  29.
    Which is: 29
  *max
    Which is: 23
[  FAILED  ] TRootTDS.FromARDFMT (6 ms)
```
