### PR TITLE
[windows] Make `OpenDirectory` and `GetDirEntry` thread safe

### DIFF
--- a/core/winnt/inc/TWinNTSystem.h
+++ b/core/winnt/inc/TWinNTSystem.h
@@ -76,13 +76,11 @@ private:
    int               fNbGroups{0};               // Number of groups on local computer
    int               fActUser{-1};               // Index of actual user in User list
    Bool_t            fGroupsInitDone{kFALSE};    // Flag used for Users and Groups initialization
-   Bool_t            fFirstFile{kFALSE};         // Flag used by OpenDirectory/GetDirEntry
 
    HANDLE            fhProcess;                  // Handle of the current process
    void             *fGUIThreadHandle{nullptr};  // handle of GUI server (aka command) thread
    ULong_t           fGUIThreadId{0};            // id of GUI server (aka command) thread
    std::string       fDirNameBuffer;             // The string buffer to hold path name
-   WIN32_FIND_DATA   fFindFileData;              // Structure to look for files (aka OpenDir under UNIX)
 
    Bool_t            DispatchTimers(Bool_t mode);
    Bool_t            CheckDescriptors();

--- a/core/winnt/src/TWinNTSystem.cxx
+++ b/core/winnt/src/TWinNTSystem.cxx
@@ -1930,11 +1930,11 @@ void TWinNTSystem::FreeDirectory(void *dirp)
 {
    if (!dirp)
       return;
-   auto tsfd = static_cast<FindFileData_t *>(dirp);
    if (TSystem *helper = FindHelper(0, dirp)) {
       helper->FreeDirectory(dirp);
       return;
    }
+   auto tsfd = static_cast<FindFileData_t *>(dirp);
    ::FindClose(tsfd->fSearchFile);
    delete tsfd;
 }
@@ -1946,10 +1946,10 @@ const char *TWinNTSystem::GetDirEntry(void *dirp)
 {
    if (!dirp)
       return nullptr;
-   auto tsfd = static_cast<FindFileData_t *>(dirp);
    if (TSystem *helper = FindHelper(0, dirp)) {
       return helper->GetDirEntry(dirp);
    }
+   auto tsfd = static_cast<FindFileData_t *>(dirp);
    if (tsfd->fFirstFile) {
       // when calling TWinNTSystem::OpenDirectory(), the fFindFileData
       // structure is filled by a call to FindFirstFile().
@@ -2092,7 +2092,6 @@ void *TWinNTSystem::OpenDirectory(const char *fdir)
    }
 
    if (finfo.st_mode & S_IFDIR) {
-      FindFileData_t *dirp = new FindFileData_t;
       strlcpy(entry, dir,nche);
       if (!(entry[strlen(dir)-1] == '/' || entry[strlen(dir)-1] == '\\' )) {
          strlcat(entry,"\\",nche);
@@ -2101,6 +2100,7 @@ void *TWinNTSystem::OpenDirectory(const char *fdir)
          entry[strlen(dir)-1] = '\0';
       strlcat(entry,"*",nche);
 
+      FindFileData_t *dirp = new FindFileData_t;
       dirp->fSearchFile = ::FindFirstFile(entry, &dirp->fFindFileData);
       if (dirp->fSearchFile == INVALID_HANDLE_VALUE) {
          ((TWinNTSystem *)gSystem)->Error( "Unable to find' for reading:", entry);
@@ -2108,9 +2108,9 @@ void *TWinNTSystem::OpenDirectory(const char *fdir)
          delete [] dir;
          return nullptr;
       }
+      dirp->fFirstFile = kTRUE;
       delete [] entry;
       delete [] dir;
-      dirp->fFirstFile = kTRUE;
       return dirp;
    }
 

--- a/core/winnt/src/TWinNTSystem.cxx
+++ b/core/winnt/src/TWinNTSystem.cxx
@@ -1936,7 +1936,7 @@ void TWinNTSystem::FreeDirectory(void *dirp)
    }
    auto tsfd = static_cast<FindFileData_t *>(dirp);
    ::FindClose(tsfd->fSearchFile);
-   delete tsfd;
+   delete dirp;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/winnt/src/TWinNTSystem.cxx
+++ b/core/winnt/src/TWinNTSystem.cxx
@@ -2103,6 +2103,7 @@ void *TWinNTSystem::OpenDirectory(const char *fdir)
       FindFileData_t *dirp = new FindFileData_t;
       dirp->fSearchFile = ::FindFirstFile(entry, &dirp->fFindFileData);
       if (dirp->fSearchFile == INVALID_HANDLE_VALUE) {
+         delete dirp;
          ((TWinNTSystem *)gSystem)->Error( "Unable to find' for reading:", entry);
          delete [] entry;
          delete [] dir;

--- a/core/winnt/src/TWinNTSystem.cxx
+++ b/core/winnt/src/TWinNTSystem.cxx
@@ -1931,8 +1931,8 @@ void TWinNTSystem::FreeDirectory(void *dirp)
    if (!dirp)
       return;
    auto tsfd = static_cast<FindFileData_t *>(dirp);
-   if (TSystem *helper = FindHelper(0, tsfd->fSearchFile)) {
-      helper->FreeDirectory(tsfd->fSearchFile);
+   if (TSystem *helper = FindHelper(0, dirp)) {
+      helper->FreeDirectory(dirp);
       return;
    }
    ::FindClose(tsfd->fSearchFile);
@@ -1947,8 +1947,8 @@ const char *TWinNTSystem::GetDirEntry(void *dirp)
    if (!dirp)
       return nullptr;
    auto tsfd = static_cast<FindFileData_t *>(dirp);
-   if (TSystem *helper = FindHelper(0, tsfd->fSearchFile)) {
-      return helper->GetDirEntry(tsfd->fSearchFile);
+   if (TSystem *helper = FindHelper(0, dirp)) {
+      return helper->GetDirEntry(dirp);
    }
    if (tsfd->fFirstFile) {
       // when calling TWinNTSystem::OpenDirectory(), the fFindFileData


### PR DESCRIPTION
Create a struct holding the flag, `HANDLE`, and `WIN32_FIND_DATA` used by `OpenDirectory`, `GetDirEntry`, and `FreeDirectory`, so each thread creates its own instance of it. This fixes randome failures in mutithreaded applications on Windows, like for example in the `R__USE_IMT` part of the `datasource-root` test:
```
[ RUN      ] TRootTDS.DefineSlotMT
Error in <TFile::TFile>: file C:/root-dev/build/x64/debug/tree/dataframe/test/G__NTupleStruct.vcx does not exist
[       OK ] TRootTDS.DefineSlotMT (191 ms)
[ RUN      ] TRootTDS.FromARDFMT
Error in <TFile::Init>: C:/root-dev/build/x64/debug/tree/dataframe/test/INSTALL.vcxproj not a ROOT file
C:\root-dev\git\master\tree\dataframe\test\datasource_root.cxx(175): error: Expected equality of these values:
  29.
    Which is: 29
  *max
    Which is: 23
[  FAILED  ] TRootTDS.FromARDFMT (6 ms)
```
