### PR TITLE
[cling] Cast to base element type pointer before calling copyArray

### DIFF
--- a/interpreter/cling/include/cling/Interpreter/RuntimeUniverse.h
+++ b/interpreter/cling/include/cling/Interpreter/RuntimeUniverse.h
@@ -171,16 +171,10 @@ namespace cling {
       ///\param[in] placement - where to copy
       ///\param[in] size - size of the array.
       ///
-      template <class T, class = T (*)() /*disable for arrays*/>
+      template <class T>
       void copyArray(T* src, void* placement, std::size_t size) {
         for (std::size_t i = 0; i < size; ++i)
           new ((void*)(((T*)placement) + i)) T(src[i]);
-      }
-
-      // "size" is the number of elements even for subarrays; flatten the type:
-      template <class T, std::size_t N>
-      void copyArray(const T (*src)[N], void* placement, std::size_t size) {
-        copyArray(src[0], placement, size);
       }
     } // end namespace internal
   } // end namespace runtime

--- a/interpreter/cling/lib/Interpreter/ExternalInterpreterSource.cpp
+++ b/interpreter/cling/lib/Interpreter/ExternalInterpreterSource.cpp
@@ -111,7 +111,7 @@ namespace cling {
       const Decl* To = llvm::cantFail(m_Importer->Import(declToImport));
       assert(To && "Import did not work!");
       assert((DS.empty() ||
-              DS[0].getID() == clang::diag::err_unsupported_ast_node) &&
+              DS[0].getID() != clang::diag::err_unsupported_ast_node) &&
              "Import not supported!");
 #endif
       return;

--- a/interpreter/cling/lib/Interpreter/ValueExtractionSynthesizer.cpp
+++ b/interpreter/cling/lib/Interpreter/ValueExtractionSynthesizer.cpp
@@ -295,7 +295,14 @@ namespace {
       if (const ConstantArrayType* constArray
           = dyn_cast<ConstantArrayType>(desugaredTy.getTypePtr())) {
         CallArgs.clear();
-        CallArgs.push_back(E);
+        // Get a pointer to the base element type so the instantiated copyArray
+        // template can do placement new.
+        QualType baseElementType = m_Context->getBaseElementType(desugaredTy);
+        TypeSourceInfo* TSI = m_Context->getTrivialTypeSourceInfo(
+            m_Context->getPointerType(baseElementType), noLoc);
+        Expr* srcPointer =
+            m_Sema->BuildCStyleCastExpr(noLoc, TSI, noLoc, E).get();
+        CallArgs.push_back(srcPointer);
         CallArgs.push_back(placement);
         size_t arrSize
           = m_Context->getConstantArrayElementCount(constArray);


### PR DESCRIPTION
(For context, this is important for multi-dimensional constant arrays as described in [ROOT-7016](https://sft.its.cern.ch/jira/browse/ROOT-7016) and tested in Cling's `Interfaces/evaluate.C` test. But for reasons unknown to me, the ROOT prompt now seems to have a different way of handling this case because just reverting commit https://github.com/root-project/root/commit/d97e4dca36370a1f036026cb6976416670882bc6 still works there...)

Instead of using relying on recursive templated calls, perform the type cast in the `ValueExtractionSynthesizer`. This has the advantage of avoiding an ODR violation warning in `MultipleInterpreters.C` with LLVM 16 (while unclear if that one is correct or not).