### PR TITLE
[tmva][sofie] Add options to append generated C++ code and weights

### DIFF
--- a/tmva/sofie/inc/TMVA/RModel.hxx
+++ b/tmva/sofie/inc/TMVA/RModel.hxx
@@ -118,7 +118,7 @@ public:
       std::cout << fGC;
    }
    void PrintIntermediateTensors();
-   void OutputGenerated(std::string filename = "");
+   void OutputGenerated(std::string filename = "", bool append = false);
    std::vector<std::string> GetOutputTensorNames(){
       return fOutputTensorNames;
    }


### PR DESCRIPTION
Add possibility , when generating multiple models to append the C++ generated code in a single header filer and have also all binary weights in a single ROOT file

The weights are now always written in a seprate directory in the ROOT file so they cn be distinguished in csade of separate models.

The append option is not supported for text weight files



