### PR TITLE
[cling] Skip IncrementalExecutor for CUDADevice

### DIFF
--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -257,7 +257,7 @@ namespace cling {
     if (!m_LookupHelper)
       return;
 
-    if (!isInSyntaxOnlyMode()) {
+    if (!isInSyntaxOnlyMode() && !m_Opts.CompilerOpts.CUDADevice) {
       m_Executor.reset(new IncrementalExecutor(SemaRef.Diags, *getCI(),
         extraLibHandle, m_Opts.Verbose()));
 


### PR DESCRIPTION
We don't need it, and with the upgrade to LLVM 16 the NVPTX target (correctly) errors that there is no (direct) JIT execution support.