### PR TITLE
[foundation] Remove leftover `gErrorMutex`:

### DIFF
--- a/core/foundation/src/TError.cxx
+++ b/core/foundation/src/TError.cxx
@@ -28,9 +28,6 @@ to be replaced by the proper DefaultErrorHandler()
 #include <cerrno>
 #include <string>
 
-// Deprecated
-TVirtualMutex *gErrorMutex = nullptr;
-
 Int_t  gErrorIgnoreLevel     = kUnset;
 Int_t  gErrorAbortLevel      = kSysError+1;
 Bool_t gPrintViaErrorHandler = kFALSE;


### PR DESCRIPTION
I had apparently overlooked that in 5455bbc3b5210bb73fffd0c6a3ab8833bf1dbfec.

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

