### PR TITLE
[cmake] find any python3 if PYTHON_EXECUTABLE not specified

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,11 @@ foreach(policy ${policy_new})
   endif()
 endforeach()
 
+# ignore JAVA_ROOT when find_package(Java 1.8 ...) called
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.27)
+  cmake_policy(SET CMP0144 OLD)
+endif()
+
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
   cmake_policy(SET CMP0135 OLD)
 endif()
@@ -176,7 +181,7 @@ function(relatedrepo_GetClosestMatch)
   cmake_parse_arguments(_ "" "REPO_NAME;ORIGIN_PREFIX;UPSTREAM_PREFIX;FETCHURL_VARIABLE;FETCHREF_VARIABLE" "" ${ARGN})
 
   set(${__FETCHURL_VARIABLE} ${__UPSTREAM_PREFIX}/${__REPO_NAME} PARENT_SCOPE)
-  
+
   if(NOT IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/.git)
     set(${__FETCHREF_VARIABLE} v${ROOT_MAJOR_VERSION}-${ROOT_MINOR_VERSION}-${ROOT_PATCH_VERSION} PARENT_SCOPE)
     return()

--- a/builtins/pcre/CMakeLists.txt
+++ b/builtins/pcre/CMakeLists.txt
@@ -15,11 +15,11 @@ endforeach()
 if(WIN32)
   if(winrtdebug)
     set(PCRE_POSTFIX $<$<CONFIG:Debug>:d>)
-    set(pcre_config "Debug")
+    set(pcre_config_kind "Debug")
   else()
-    set(pcre_config "Release")
+    set(pcre_config_kind "Release")
   endif()
-  set(pcre_build_config "--config ${pcre_config}")
+  set(pcre_config "--config")
 endif()
 
 set(PCRE_VERSION "8.43" CACHE INTERNAL "" FORCE)
@@ -52,7 +52,7 @@ ExternalProject_Add(PCRE
     -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=TRUE
 
   BUILD_COMMAND
-    ${CMAKE_COMMAND} --build <BINARY_DIR> ${pcre_build_config} --target pcre
+    ${CMAKE_COMMAND} --build <BINARY_DIR> ${pcre_config} ${pcre_config_kind} --target pcre
 
   BUILD_BYPRODUCTS
     ${PCRE_BYPRODUCTS}
@@ -66,7 +66,7 @@ ExternalProject_Get_Property(PCRE BINARY_DIR)
 set(PCRE_FOUND TRUE CACHE INTERNAL "" FORCE)
 set(PCRE_INCLUDE_DIR "${BINARY_DIR}" CACHE INTERNAL "" FORCE)
 if(WIN32)
-  set(PCRE_PCRE_LIBRARY "${BINARY_DIR}/${pcre_config}/${PCRE_LIBNAME}" CACHE INTERNAL "" FORCE)
+  set(PCRE_PCRE_LIBRARY "${BINARY_DIR}/${pcre_config_kind}/${PCRE_LIBNAME}" CACHE INTERNAL "" FORCE)
 else()
   set(PCRE_PCRE_LIBRARY "${BINARY_DIR}/${CMAKE_CFG_INTDIR}/${PCRE_LIBNAME}" CACHE INTERNAL "" FORCE)
 endif()

--- a/cmake/modules/SearchRootCoreDeps.cmake
+++ b/cmake/modules/SearchRootCoreDeps.cmake
@@ -223,6 +223,15 @@ else()
     message(WARNING "No supported Python 2 or 3 development packages were found; PyROOT will not be built.")
   endif()
 
+  # if development parts not found, one still need python executable to run some scripts
+  if(NOT PYTHON_EXECUTABLE)
+    find_package(Python3)
+    if(Python3_FOUND)
+       message(STATUS "Found python3 executable ${Python3_EXECUTABLE}, required only for ROOT compilation.")
+       set(PYTHON_EXECUTABLE "${Python3_EXECUTABLE}")
+    endif()
+  endif()
+
 endif()
 
 # Create lists of Python 2 and 3 useful variables used to build PyROOT with both versions


### PR DESCRIPTION
If development part of python3/python2 not found, try to find only executable to make ROOT compilation

Also set policy CMP0144 to 'OLD'. With new cmake 3.27 shell variable `JAVA_ROOT` will be used for `find_package(Java...`
To keep ignoring such variables, one should set policy to `OLD`