### PR TITLE
[ntuple] Move `R__ASSERT` out of the inlined code path

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -167,7 +167,6 @@ public:
    {
       if (!fReadPage.Contains(globalIndex)) {
          MapPage(globalIndex);
-         R__ASSERT(fReadPage.Contains(globalIndex));
       }
       const auto elemSize = fElement->GetSize();
       void *from = static_cast<unsigned char *>(fReadPage.GetBuffer()) +
@@ -188,7 +187,6 @@ public:
 
    void ReadV(const NTupleSize_t globalIndex, const ClusterSize_t::ValueType count, void *to)
    {
-      R__ASSERT(count > 0);
       if (!fReadPage.Contains(globalIndex)) {
          MapPage(globalIndex);
       }

--- a/tree/ntuple/v7/src/RColumn.cxx
+++ b/tree/ntuple/v7/src/RColumn.cxx
@@ -93,10 +93,12 @@ void ROOT::Experimental::Detail::RColumn::MapPage(const NTupleSize_t index)
 {
    fPageSource->ReleasePage(fReadPage);
    fReadPage = fPageSource->PopulatePage(fHandleSource, index);
+   R__ASSERT(fReadPage.Contains(index));
 }
 
 void ROOT::Experimental::Detail::RColumn::MapPage(const RClusterIndex &clusterIndex)
 {
    fPageSource->ReleasePage(fReadPage);
    fReadPage = fPageSource->PopulatePage(fHandleSource, clusterIndex);
+   R__ASSERT(fReadPage.Contains(clusterIndex));
 }


### PR DESCRIPTION
As measured, there is an improvement if the expansion of `R__ASSERT()` is out of the inlined code path due to slighly more compact code.
Additionally, the `R__ASSERT(count > 0)` has been removed, given that `ClusterSize_t::ValueType` is an unsigned integral type.

This was seen during the evaluation of the relative overhead of RField's post-read callbacks, which for reference I provide below.

Two different tests were carried out: _(i)_ 4 fields of type `std::uint32_t`; and _(ii)_ 2 fields of type `std::uint32_t` + 2 fields of a user-defined struct, where:
- BASE refers to the current `master` with `RFieldBase::Read()` slightly changed to not support read callbacks.
- [1] refers to the current `master` + the changes in this PR
- [2] refers to the current `master` where `RFieldBase::InvokeReadCallbacks()` is also outlined by moving it to RField.cxx

All tests used a Release `-O3` build, 40M entries and 505 compression; results in $us$, averaged over 10 executions.

_(i)_ 4 fields of type `std::uint32_t`:
```
                           | Average   | Rel. increase
---------------------------+-----------+--------------
BASE                       |  871502.4 |
No callbacks [1]           |  867523.1 | 0.9954
No callbacks [1][2]        |  878027.7 | 1.0075
1 callback                 | 1068704.3 | 1.2263
2 callbacks                | 1233821.7 | 1.4157
```
_(ii)_ 2 fields of type `std::uint32_t` + 2 user-defined structs:
```
                           | Average   | Rel. increase
---------------------------+-----------+--------------
BASE                       | 2500244.7 |
No callbacks [1]           | 2688342.6 | 1.0752
No callbacks [1][2]        | 2746363.6 | 1.0984
1 callback                 | 2883271.0 | 1.1532
2 callbacks                | 3016407.0 | 1.2064
```

As noted in test _(ii)_ for 'No callbacks [1]', non-simple fields have an overhead due to the additional branch.  Still, the change in this PR is beneficial.

## Checklist:
- [x] tested changes locally