### PR TITLE
Fix dataframe helpers on Windows

### DIFF
--- a/tree/dataframe/src/RDFHelpers.cxx
+++ b/tree/dataframe/src/RDFHelpers.cxx
@@ -46,10 +46,12 @@
 int get_tty_size()
 {
 #if defined(_WIN32) || defined(_WIN64)
+   if (!_isatty(_fileno(stdout)))
+      return 0;
    int width = 0;
    CONSOLE_SCREEN_BUFFER_INFO csbi;
-   GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi);
-   width = (int)(csbi.srWindow.Right - csbi.srWindow.Left + 1);
+   if (GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi))
+      width = (int)(csbi.srWindow.Right - csbi.srWindow.Left + 1);
    return width;
 #elif defined(__linux__)
    int width = 0;
@@ -148,7 +150,7 @@ ProgressHelper::ProgressHelper(std::size_t increment, unsigned int totalFiles, u
      fBarWidth{progressBarWidth = int(get_tty_size() / 4)},
      fTotalFiles{totalFiles},
 #if defined(_WIN32) || defined(_WIN64)
-     fIsTTY{_isatty(_fileno(stdout)) == 1},
+     fIsTTY{_isatty(_fileno(stdout)) != 0},
      fUseShellColours{false && useColors}
 #else
      fIsTTY{isatty(fileno(stdout)) == 1},

--- a/tree/dataframe/test/dataframe_helpers.cxx
+++ b/tree/dataframe/test/dataframe_helpers.cxx
@@ -689,9 +689,9 @@ TEST(RDFHelpers, ProgressHelper_Existence_ST)
    std::streambuf *oldCoutStreamBuf = std::cout.rdbuf();
    std::ostringstream strCout;
    std::cout.rdbuf(strCout.rdbuf());
-   auto d_write_1 = ROOT::RDataFrame(10000000).Define("x", "42").Snapshot("tree", "f1.root");
-   auto d_write_2 = ROOT::RDataFrame(10000000).Define("y", "1").Snapshot("tree", "f2.root");
-   ROOT::RDF::RNode d = ROOT::RDataFrame("tree", {"f1.root", "f2.root"});
+   auto d_write_1 = ROOT::RDataFrame(10000000).Define("x", "42").Snapshot("tree", "fh1.root");
+   auto d_write_2 = ROOT::RDataFrame(10000000).Define("y", "1").Snapshot("tree", "fh2.root");
+   ROOT::RDF::RNode d = ROOT::RDataFrame("tree", {"fh1.root", "fh2.root"});
    ROOT::RDF::Experimental::AddProgressbar(d);
    d.Count().GetValue();
    // Restore old cout.
@@ -711,9 +711,9 @@ TEST(RDFHelpers, ProgressHelper_Existence_MT)
    std::streambuf *oldCoutStreamBuf = std::cout.rdbuf();
    std::ostringstream strCout;
    std::cout.rdbuf(strCout.rdbuf());
-   auto d_write_1 = ROOT::RDataFrame(10000000).Define("x", "42").Snapshot("tree", "f1.root");
-   auto d_write_2 = ROOT::RDataFrame(10000000).Define("y", "1").Snapshot("tree", "f2.root");
-   ROOT::RDF::RNode d = ROOT::RDataFrame("tree", {"f1.root", "f2.root"});
+   auto d_write_1 = ROOT::RDataFrame(10000000).Define("x", "42").Snapshot("tree", "fh1.root");
+   auto d_write_2 = ROOT::RDataFrame(10000000).Define("y", "1").Snapshot("tree", "fh2.root");
+   ROOT::RDF::RNode d = ROOT::RDataFrame("tree", {"fh1.root", "fh2.root"});
    ROOT::RDF::Experimental::AddProgressbar(d);
    d.Count().GetValue();
    // Restore old cout.
@@ -729,8 +729,8 @@ TEST(RDFHelpers, ProgressHelper_existence_singleTTreeInput)
    std::streambuf *oldCoutStreamBuf = std::cout.rdbuf();
    std::ostringstream strCout;
    std::cout.rdbuf(strCout.rdbuf());
-   auto d_write_1 = ROOT::RDataFrame(10000000).Define("x", "42").Snapshot("tree", "f1.root");
-   ROOT::RDF::RNode d = ROOT::RDataFrame("tree", {"f1.root"});
+   auto d_write_1 = ROOT::RDataFrame(10000000).Define("x", "42").Snapshot("tree", "fh1.root");
+   ROOT::RDF::RNode d = ROOT::RDataFrame("tree", {"fh1.root"});
    ROOT::RDF::Experimental::AddProgressbar(d);
    d.Count().GetValue();
    // Restore old cout.


### PR DESCRIPTION
 - make get_tty_size() returning 0 when called without terminal (e.g. when redirecting output)
 - check for nonzero return value of `_isatty()`. According to the doc, `_isatty` returns a nonzero value if the descriptor is associated with a character device. Otherwise, `_isatty` returns 0.
 - in `dataframe_helpers.cxx`, don't use `f1.root` and `f2.root`, they are already used in `dataframe_nodes.cxx` and might conflict when running tests concurrently

This fixes the following errors on Windows:
```
unknown file: error: C++ exception with description "string too long" thrown in the test body.
[  FAILED  ] RDFHelpers.ProgressHelper_Existence_ST (5009 ms)
[ RUN      ] RDFHelpers.ProgressHelper_Existence_MT
C:\ROOT-CI\src\core\testsupport\src\TestSupport.cxx(77): error: Failed
Received unexpected diagnostic of severity 5000 at 'TFile::TFile' reading 'could not delete C:\ROOT-CI\build\tree\dataframe\test\f2.root (errno: 13) Permission denied'.
```
