### PR TITLE
Correct documentation options for TDavixFile when using Amazon S3

### DIFF
--- a/net/davix/inc/TDavixFile.h
+++ b/net/davix/inc/TDavixFile.h
@@ -88,12 +88,12 @@ public:
     ///
     /// TDavixFile supports several options :
     ///
-    ///  - GRID_MODE=yes    : enable the grid authentication and CA support
-    ///  - CA_CHECK=no      : remove all the certificate authority check, this option can create a security vulnerability
-    ///  - S3_SECKEY=string : Amazon S3 secret token
-    ///  - S3_ACCKEY=string : Amazon S3 access token
-    ///  - S3_REGION=string : Amazon S3 region. Optional, if provided, davix will use v4 signatures.
-    ///  - S3_TOKEN=string  : Amazon STS temporary credentials token.
+    ///  - GRID_MODE=yes   : enable the grid authentication and CA support
+    ///  - CA_CHECK=no     : remove all the certificate authority check, this option can create a security vulnerability
+    ///  - S3SECKEY=string : Amazon S3 secret token
+    ///  - S3ACCKEY=string : Amazon S3 access token
+    ///  - S3REGION=string : Amazon S3 region. Optional, if provided, davix will use v4 signatures.
+    ///  - S3TOKEN=string  : Amazon STS temporary credentials token.
     ///
     /// Several parameters can be used if separated with whitespace
 


### PR DESCRIPTION
# This Pull request:

Fixes to TDavixFile documentation when accessing files on Amazon S3.  The options suggested do not work.  Instead the options must be used without the underscore.

e.g. 

"S3_SECKEY" -> "S3SECKEY"
"S3_ACCKEY" -> "S3ACCKEY"
"S3_TOKEN" -> "S3TOKEN"
etc.

You can see the source code here: https://github.com/root-project/root/blob/4e8c577dfd6a19d7c38a74e3074b406a598bf76a/net/davix/src/TDavixFile.cxx#L69

where they are defined without the underscore.

```c
const char* s3_seckey_opt = "s3seckey=";
const char* s3_acckey_opt = "s3acckey=";
const char* s3_region_opt = "s3region=";
const char* s3_token_opt = "s3token=";
const char* s3_alternate_opt = "s3alternate=";
```

For example, this works:

```
const std::string options("S3SECKEY=" + aws_secret_access_key + " " 
        + "S3ACCKEY=" + aws_access_key_id + " "
        + "S3TOKEN=" + aws_session_token);

TFile::Open(input_filename.c_str(), (options + " READ").c_str()) );
```

## Changes or fixes:

TDavixFile documentation.

## Checklist:

- [y] tested changes locally
- [y] updated the docs (if necessary)

