### PR TITLE
[v6.28][backport][windows] Make `OpenDirectory` and `GetDirEntry` thread safe (#13472)

### DIFF
--- a/core/winnt/inc/TWinNTSystem.h
+++ b/core/winnt/inc/TWinNTSystem.h
@@ -76,13 +76,11 @@ private:
    int               fNbGroups{0};               // Number of groups on local computer
    int               fActUser{-1};               // Index of actual user in User list
    Bool_t            fGroupsInitDone{kFALSE};    // Flag used for Users and Groups initialization
-   Bool_t            fFirstFile{kFALSE};         // Flag used by OpenDirectory/GetDirEntry
 
    HANDLE            fhProcess;                  // Handle of the current process
    void             *fGUIThreadHandle{nullptr};  // handle of GUI server (aka command) thread
    ULong_t           fGUIThreadId{0};            // id of GUI server (aka command) thread
    std::string       fDirNameBuffer;             // The string buffer to hold path name
-   WIN32_FIND_DATA   fFindFileData;              // Structure to look for files (aka OpenDir under UNIX)
 
    Bool_t            DispatchTimers(Bool_t mode);
    Bool_t            CheckDescriptors();


### PR DESCRIPTION
* [windows] Make `OpenDirectory` and `GetDirEntry` thread safe

Create a struct holding the flag, `HANDLE`, and `WIN32_FIND_DATA` used by `OpenDirectory`, `GetDirEntry`, and `FreeDirectory`, so each thread creates its own instance of it. This fixes randome failures in mutithreaded applications on Windows, like for example in the `R__USE_IMT` part of the `datasource-root` test:
```
[ RUN      ] TRootTDS.DefineSlotMT
Error in <TFile::TFile>: file C:/root-dev/build/x64/debug/tree/dataframe/test/G__NTupleStruct.vcx does not exist
[       OK ] TRootTDS.DefineSlotMT (191 ms)
[ RUN      ] TRootTDS.FromARDFMT
Error in <TFile::Init>: C:/root-dev/build/x64/debug/tree/dataframe/test/INSTALL.vcxproj not a ROOT file
C:\root-dev\git\master\tree\dataframe\test\datasource_root.cxx(175): error: Expected equality of these values:
  29.
    Which is: 29
  *max
    Which is: 23
[  FAILED  ] TRootTDS.FromARDFMT (6 ms)
```

* Adress the comments from Axel

* Pass the correct pointer to the helper

* Cosmetics

* Update core/winnt/src/TWinNTSystem.cxx

Prevent possible memory leak

* Update core/winnt/src/TWinNTSystem.cxx
