### PR TITLE
[RF] Improve documentation of `RooAbsData::split()`

### DIFF
--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -356,6 +356,8 @@ protected:
   mutable const TNamed * _namePtr = nullptr; ///<! De-duplicated name pointer. This will be equal for all objects with the same name.
 
 private:
+  void copyImpl(const RooAbsData& other, const char* newname);
+
   void copyGlobalObservables(const RooAbsData& other);
 
   const RooFit::UniqueId<RooAbsData> _uniqueId; ///<!


### PR DESCRIPTION
In https://github.com/root-project/root/issues/13087, it was noted that `RooAbsData::split()` does not split
observables. However, there is already one overload of this function to
do this, taking a RooSimultaneous as an input to know what the
observables are. This PR improves the docs of `RooAbsData::split()` by
adding a comment that links to this other overload, such that it is
easier to find.

Closes https://github.com/root-project/root/issues/13087.
