### PR TITLE
[cmake] relatedrepo_GetClosestMatch: fix well-known branch regex

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,7 +194,7 @@ function(relatedrepo_GetClosestMatch)
 
   # `current_head` is a well-known branch, e.g. master, or v6-28-00-patches.  Use the matching branch
   # upstream as the fork repository may be out-of-sync
-  string(REGEX MATCH "(master|latest-stable|v[0-9]+-[0-9]+-[0-9]+(-patches)?)" known_head ${current_head})
+  string(REGEX MATCH "^(master|latest-stable|v[0-9]+-[0-9]+-[0-9]+(-patches)?)$" known_head ${current_head})
   if(NOT "${known_head}" STREQUAL "")
     if("${current_head}" STREQUAL "latest-stable")
       # Resolve the 'latest-stable' branch to the latest merged head/tag


### PR DESCRIPTION
Well-known branch names, e.g. `master` or `v6-28-00-patches` always use the equivalent upstream roottest branch.  However, we should be careful not to match a substring.  Concretely, before this patch, `master-14449` was incorrectly taken as a well-known branch causing the error below.
```
Cloning into 'roottest'...
fatal: Remote branch master-13449 not found in upstream origin
CMake Error at CMakeLists.txt:780 (message): Expected roottest at 'C:/ROOT-CI/src/roottest' (not a directory?)
```

## Checklist:
- [x] tested changes locally