### PR TITLE
Introduce TCanvas::SaveAll method

### DIFF
--- a/README/ReleaseNotes/v630/index.md
+++ b/README/ReleaseNotes/v630/index.md
@@ -251,6 +251,11 @@ Some of these classes are now removed from the public interface:
   when axis zooming changes and position and index of correspondent axis label changes as well.
   `TAxis::ChangeLabel` method to change axis label by index works as before.
 
+- Introduce `TCanvas::SaveAll` method. Allows to store several pads at once into different image file formats.
+  File name can include printf qualifier to code pad number. Also allows to store all pads in single PDF
+  or single ROOT file. Significantly improves performance when creating many image files using web graphics.
+
+
 ## 3D Graphics Libraries
 
 

--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -1229,8 +1229,10 @@ void TDirectory::rmdir(const char *name)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Save object in filename,
-/// if filename is 0 or "", a file with "objectname.root" is created.
+/// if filename is `nullptr` or "", a file with "<objectname>.root" is created.
 /// The name of the key is the object name.
+/// By default new file will be created. Using option "a", one can append object
+/// to the existing ROOT file.
 /// If the operation is successful, it returns the number of bytes written to the file
 /// otherwise it returns 0.
 /// By default a message is printed. Use option "q" to not print the message.
@@ -1241,29 +1243,30 @@ void TDirectory::rmdir(const char *name)
 
 Int_t TDirectory::SaveObjectAs(const TObject *obj, const char *filename, Option_t *option) const
 {
+   // option can contain single letter args: "a" for append, "q" for quiet in any combinations
+
    if (!obj) return 0;
    Int_t nbytes = 0;
-   TString fname = filename;
-   if (!filename || !filename[0]) {
-      fname.Form("%s.root",obj->GetName());
-   }
-   TString cmd;
+   TString fname, opt = option, cmd;
+   if (filename && *filename)
+      fname = filename;
+   else
+      fname.Form("%s.root", obj->GetName());
+   opt.ToLower();
+
    if (fname.Index(".json") > 0) {
-      cmd.Form("TBufferJSON::ExportToFile(\"%s\",(TObject*) %s, \"%s\");", fname.Data(), TString::LLtoa((Longptr_t)obj, 10).Data(), (option ? option : ""));
+      cmd.Form("TBufferJSON::ExportToFile(\"%s\", (TObject *) 0x%zx, \"%s\");", fname.Data(), (size_t) obj, (option ? option : ""));
       nbytes = gROOT->ProcessLine(cmd);
    } else {
-      cmd.Form("TFile::Open(\"%s\",\"recreate\");",fname.Data());
+      cmd.Form("TFile::Open(\"%s\",\"%s\");", fname.Data(), opt.Contains("a") ? "update" : "recreate");
       TContext ctxt; // The TFile::Open will change the current directory.
       TDirectory *local = (TDirectory*)gROOT->ProcessLine(cmd);
       if (!local) return 0;
       nbytes = obj->Write();
       delete local;
    }
-   TString opt(option);
-   opt.ToLower();
-   if (!opt.Contains("q")) {
-      if (!gSystem->AccessPathName(fname.Data())) obj->Info("SaveAs", "ROOT file %s has been created", fname.Data());
-   }
+   if (!opt.Contains("q") && !gSystem->AccessPathName(fname.Data()))
+      obj->Info("SaveAs", "ROOT file %s has been created", fname.Data());
    return nbytes;
 }
 

--- a/graf2d/gpad/inc/TCanvas.h
+++ b/graf2d/gpad/inc/TCanvas.h
@@ -229,6 +229,8 @@ public:
    static TCanvas   *MakeDefCanvas();
    static Bool_t     SupportAlpha();
 
+   static Bool_t     SaveAll(std::vector<TPad *>, const char *filename, Option_t *option = "");
+
    ClassDefOverride(TCanvas,8)  //Graphics canvas
 };
 

--- a/graf2d/gpad/inc/TCanvas.h
+++ b/graf2d/gpad/inc/TCanvas.h
@@ -229,7 +229,7 @@ public:
    static TCanvas   *MakeDefCanvas();
    static Bool_t     SupportAlpha();
 
-   static Bool_t     SaveAll(std::vector<TPad *>, const char *filename, Option_t *option = "");
+   static Bool_t     SaveAll(const std::vector<TPad *>& = {}, const char *filename = "", Option_t *option = "");
 
    ClassDefOverride(TCanvas,8)  //Graphics canvas
 };

--- a/graf2d/gpad/src/TCanvas.cxx
+++ b/graf2d/gpad/src/TCanvas.cxx
@@ -2611,16 +2611,25 @@ void TCanvas::DeleteCanvasPainter()
 /// Save provided pads/canvases into the image file(s)
 /// Filename can include printf argument for image number - like "image%03d.png".
 /// In this case images: "image000.png", "image001.png", "image002.png" will be created.
-/// If pattern is not provided - it will be automatically inserted before extension
-/// In case when pdf file name provided without pattern - all images will be stored in single PDF file
-/// In case ROOT or XML file name is provided - all pads/canvases will be stored in this file as individual keys
+/// If pattern is not provided - it will be automatically inserted before extension except PDF and ROOT files.
+/// In last case PDF or ROOT file will contain all pads.
 /// Parameter option only used when output into PDF/PS files
+/// If TCanvas::SaveAll() called without arguments - all existing canvases will be stored in allcanvases.pdf file.
 
-Bool_t TCanvas::SaveAll(std::vector<TPad *> pads, const char *filename, Option_t *option)
+Bool_t TCanvas::SaveAll(const std::vector<TPad *> &pads, const char *filename, Option_t *option)
 {
    if (pads.size() == 0) {
-      ::Warning("TCanvas::SaveAll", "No pads are provided");
-      return kFALSE;
+      std::vector<TPad *> canvases;
+      TIter iter(gROOT->GetListOfCanvases());
+      while (auto c = dynamic_cast<TCanvas *>(iter()))
+         canvases.emplace_back(c);
+
+      if (canvases.size() == 0) {
+         ::Warning("TCanvas::SaveAll", "No pads are provided");
+         return kFALSE;
+      }
+
+      return TCanvas::SaveAll(canvases, filename && *filename ? filename : "allcanvases.pdf", option);
    }
 
    TString fname = filename, ext;

--- a/tutorials/graphics/saveall.C
+++ b/tutorials/graphics/saveall.C
@@ -30,8 +30,7 @@ void saveall()
 
    TCanvas::SaveAll(pads, "image.svg"); // create 100 SVG images, %d pattern will be automatically append
 
-   TCanvas::SaveAll(pads, "images.pdf"); // create one PDF file with all canvases
-
    TCanvas::SaveAll(pads, "images.root"); // create single ROOT file with all canvases
 
+   TCanvas::SaveAll(); // save all existing canvases in allcanvases.pdf file
 }

--- a/tutorials/graphics/saveall.C
+++ b/tutorials/graphics/saveall.C
@@ -1,0 +1,37 @@
+/// \file
+/// \ingroup tutorial_graphics
+/// \notebook
+/// This macro creates 100 canvases and store them in different images files using TCanvas::SaveAll() method
+/// Demonstrated how different output format can be used in batch mode.
+///
+/// \macro_code
+///
+/// \author Sergey Linev
+
+void saveall()
+{
+   gROOT->SetBatch(kTRUE); // enforce batch mode to avoid appearance of multiple canvas windows
+
+   std::vector<TPad *> pads;
+
+   for(int n = 0; n < 100; ++n) {
+      auto c = new TCanvas(TString::Format("canvas%d", n), "Canvas with histogram");
+
+      auto h1 = new TH1I(TString::Format("hist%d", n), "Histogram with random data", 100, -5., 5);
+      h1->SetDirectory(nullptr);
+      h1->FillRandom("gaus", 10000);
+
+      h1->Draw();
+
+      pads.push_back(c);
+   }
+
+   TCanvas::SaveAll(pads, "image%03d.png"); // create 100 PNG images
+
+   TCanvas::SaveAll(pads, "image.svg"); // create 100 SVG images, %d pattern will be automatically append
+
+   TCanvas::SaveAll(pads, "images.pdf"); // create one PDF file with all canvases
+
+   TCanvas::SaveAll(pads, "images.root"); // create single ROOT file with all canvases
+
+}


### PR DESCRIPTION
Allows to create images for vector of pads at once.
Using "%d" or "%03d" or any similar printf qualifier one can put image
number into the file name. Like "image%d.png".

Special handling for PDF. If qualifier in PDF file name not specified,
all provided pads will be placed into single PDF document.

Can use normal (default) and web-based image production.
Only if web display is explicitly specified with `root --web`, will run chrome browser. 

For web following formats are supported: "png", "svg", "pdf", "jpg", "jpeg", "webp".

Also extend export into ROOT file - now it is possible to append object to existing ROOT file using "a" option.
Means if "file.root" is specified, all pads will be saved into that single ROOT file.
But if file name includes printf qualifier like "file%d.root", N root files will be created. 
Same is for XML files.
