### PR TITLE
[ntuple] Minor safety improvements to the RField API

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -100,6 +100,15 @@ public:
 
    using ColumnRepresentation_t = std::vector<EColumnType>;
 
+   /// During its lifetime, a field undergoes the following possible state transitions:
+   ///
+   ///  [*] --> Unconnected --> ConnectedToSink ----
+   ///               |      |                      |
+   ///               |      --> ConnectedToSource ---> [*]
+   ///               |                             |
+   ///               -------------------------------
+   enum class EState { kUnconnected, kConnectedToSink, kConnectedToSource };
+
    /// Some fields have multiple possible column representations, e.g. with or without split encoding.
    /// All column representations supported for writing also need to be supported for reading. In addition,
    /// fields can support extra column representations for reading only, e.g. a 64bit integer reading from a
@@ -278,6 +287,8 @@ private:
    DescriptorId_t fOnDiskId = kInvalidDescriptorId;
    /// Free text set by the user
    std::string fDescription;
+   /// Changed by ConnectTo[Sink,Source], reset by Clone()
+   EState fState = EState::kUnconnected;
 
    void InvokeReadCallbacks(void *target)
    {
@@ -583,10 +594,11 @@ public:
    bool IsSimple() const { return fIsSimple; }
    /// Get the field's description
    std::string GetDescription() const { return fDescription; }
-   void SetDescription(std::string_view description) { fDescription = std::string(description); }
+   void SetDescription(std::string_view description);
+   EState GetState() const { return fState; }
 
    DescriptorId_t GetOnDiskId() const { return fOnDiskId; }
-   void SetOnDiskId(DescriptorId_t id) { fOnDiskId = id; }
+   void SetOnDiskId(DescriptorId_t id);
 
    /// Returns the fColumnRepresentative pointee or, if unset, the field's default representative
    const ColumnRepresentation_t &GetColumnRepresentative() const;

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -465,6 +465,9 @@ protected:
    size_t AddReadCallback(ReadCallback_t func);
    void RemoveReadCallback(size_t idx);
 
+   /// Add a new subfield to the list of nested fields
+   void Attach(std::unique_ptr<Detail::RFieldBase> child);
+
    /// Called by `ConnectPageSource()` only once connected; derived classes may override this
    /// as appropriate
    virtual void OnConnectPageSource() {}
@@ -578,9 +581,6 @@ public:
    /// Perform housekeeping tasks for global to cluster-local index translation
    virtual void CommitCluster() {}
 
-   /// Add a new subfield to the list of nested fields
-   void Attach(std::unique_ptr<Detail::RFieldBase> child);
-
    std::string GetName() const { return fName; }
    /// Returns the field name and parent field names separated by dots ("grandparent.parent.child")
    std::string GetQualifiedFieldName() const;
@@ -651,6 +651,7 @@ protected:
 public:
    RFieldZero() : Detail::RFieldBase("", "", ENTupleStructure::kRecord, false /* isSimple */) { }
 
+   using Detail::RFieldBase::Attach;
    using Detail::RFieldBase::GenerateValue;
    size_t GetValueSize() const final { return 0; }
    size_t GetAlignment() const final { return 0; }

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -641,7 +641,8 @@ public:
 
 
 
-/// The container field for an ntuple model, which itself has no physical representation
+/// The container field for an ntuple model, which itself has no physical representation.
+/// Therefore, the zero field must not be connected to a page source or sink.
 class RFieldZero : public Detail::RFieldBase {
 protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const override;

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -602,12 +602,12 @@ std::vector<ROOT::Experimental::Detail::RFieldBase *> ROOT::Experimental::Detail
    return result;
 }
 
-
-void ROOT::Experimental::Detail::RFieldBase::Flush() const
+void ROOT::Experimental::Detail::RFieldBase::CommitCluster()
 {
    for (auto& column : fColumns) {
       column->Flush();
    }
+   CommitClusterImpl();
 }
 
 void ROOT::Experimental::Detail::RFieldBase::SetDescription(std::string_view description)
@@ -1229,11 +1229,6 @@ void ROOT::Experimental::RField<std::string>::ReadGlobalImpl(ROOT::Experimental:
    }
 }
 
-void ROOT::Experimental::RField<std::string>::CommitCluster()
-{
-   fIndex = 0;
-}
-
 void ROOT::Experimental::RField<std::string>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitStringField(*this);
@@ -1669,11 +1664,6 @@ ROOT::Experimental::RProxiedCollectionField::SplitValue(const RValue &value) con
    return result;
 }
 
-void ROOT::Experimental::RProxiedCollectionField::CommitCluster()
-{
-   fNWritten = 0;
-}
-
 void ROOT::Experimental::RProxiedCollectionField::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitProxiedCollectionField(*this);
@@ -1906,11 +1896,6 @@ ROOT::Experimental::RVectorField::SplitValue(const RValue &value) const
       result.emplace_back(fSubFields[0]->BindValue(vec->data() + (i * fItemSize)));
    }
    return result;
-}
-
-void ROOT::Experimental::RVectorField::CommitCluster()
-{
-   fNWritten = 0;
 }
 
 void ROOT::Experimental::RVectorField::AcceptVisitor(Detail::RFieldVisitor &visitor) const
@@ -2212,11 +2197,6 @@ size_t ROOT::Experimental::RRVecField::GetAlignment() const
    // the alignment of an RVec<T> is the largest among the alignments of its data members
    // (including the inline buffer which has the same alignment as the RVec::value_type)
    return std::max({alignof(void *), alignof(std::int32_t), fSubFields[0]->GetAlignment()});
-}
-
-void ROOT::Experimental::RRVecField::CommitCluster()
-{
-   fNWritten = 0;
 }
 
 void ROOT::Experimental::RRVecField::AcceptVisitor(Detail::RFieldVisitor &visitor) const
@@ -2583,7 +2563,7 @@ size_t ROOT::Experimental::RVariantField::GetValueSize() const
    return fMaxItemSize + fMaxAlignment;  // TODO: fix for more than 255 items
 }
 
-void ROOT::Experimental::RVariantField::CommitCluster()
+void ROOT::Experimental::RVariantField::CommitClusterImpl()
 {
    std::fill(fNWritten.begin(), fNWritten.end(), 0);
 }
@@ -2937,7 +2917,7 @@ ROOT::Experimental::RCollectionField::CloneImpl(std::string_view newName) const
    return result;
 }
 
-
-void ROOT::Experimental::RCollectionField::CommitCluster() {
+void ROOT::Experimental::RCollectionField::CommitClusterImpl()
+{
    *fCollectionNTuple->GetOffsetPtr() = 0;
 }

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -574,6 +574,8 @@ ROOT::Experimental::Detail::RFieldBase::SplitValue(const RValue & /*value*/) con
 void ROOT::Experimental::Detail::RFieldBase::Attach(
    std::unique_ptr<ROOT::Experimental::Detail::RFieldBase> child)
 {
+   // Note that during a model update, new fields will be attached to the zero field. The zero field, however,
+   // does not change its inital state because only its sub fields get connected by RPageSink::UpdateSchema.
    if (fState != EState::kUnconnected)
       throw RException(R__FAIL("invalid attempt to attach subfield to already connected field"));
    child->fParent = this;

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -720,6 +720,8 @@ void ROOT::Experimental::Detail::RFieldBase::AutoAdjustColumnTypes(const RNTuple
 
 void ROOT::Experimental::Detail::RFieldBase::ConnectPageSink(RPageSink &pageSink, NTupleSize_t firstEntry)
 {
+   if (dynamic_cast<ROOT::Experimental::RFieldZero *>(this))
+      throw RException(R__FAIL("invalid attempt to connect zero field to page sink"));
    if (fState != EState::kUnconnected)
       throw RException(R__FAIL("invalid attempt to connect an already connected field to a page sink"));
 
@@ -739,6 +741,8 @@ void ROOT::Experimental::Detail::RFieldBase::ConnectPageSink(RPageSink &pageSink
 
 void ROOT::Experimental::Detail::RFieldBase::ConnectPageSource(RPageSource &pageSource)
 {
+   if (dynamic_cast<ROOT::Experimental::RFieldZero *>(this))
+      throw RException(R__FAIL("invalid attempt to connect zero field to page source"));
    if (fState != EState::kUnconnected)
       throw RException(R__FAIL("invalid attempt to connect an already connected field to a page source"));
 

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -339,7 +339,6 @@ void ROOT::Experimental::RNTupleWriter::CommitCluster(bool commitClusterGroup)
       throw RException(R__FAIL("invalid attempt to write a cluster > 512MiB with 'small clusters' option enabled"));
    }
    for (auto &field : *fModel->GetFieldZero()) {
-      field.Flush();
       field.CommitCluster();
    }
    fNBytesCommitted += fSink->CommitCluster(fNEntries);


### PR DESCRIPTION
# This Pull request:

- Makes the state transition of a field during its lifetime explicit
- Adds state checks to some of the methods
- Removes `RFieldBase::Flush()`

- [X] tested changes locally

