### PR TITLE
std.modulemap: Make bits/invoke.h optional [v6.28]

### DIFF
--- a/interpreter/cling/include/cling/std.modulemap
+++ b/interpreter/cling/include/cling/std.modulemap
@@ -456,7 +456,7 @@ module "std" [system] {
     export *
     header "bits/exception_defines.h"
   }
-  module "bits_invoke_h" {
+  module "bits_invoke_h" [optional] {
     export *
     export bits_move_h
     header "bits/invoke.h"


### PR DESCRIPTION
It only appears in GCC 7, but C++14 is already supported since GCC 6 and users want to build ROOT 6.28 using that compiler.

Fixes #13453

**Note:** This is *not* a backport because we require C++17 in `master`, so support for GCC 6 is not needed there.