### PR TITLE
[RF] Fix to empty `_normSet` check in RooAddPdf createExpectedEventsFunc

### DIFF
--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -764,7 +764,7 @@ std::unique_ptr<RooAbsReal> RooAddPdf::createExpectedEventsFunc(const RooArgSet 
 
       // Optionally multiply with fractional normalization. I this case, we
       // replace the original factor stored in "out".
-      if (_normRange) {
+      if (!_normRange.IsNull()) {
          std::unique_ptr<RooAbsReal> owner;
          RooArgList terms;
          // The integrals own each other in a chain. We do this because it's
@@ -934,7 +934,7 @@ RooAddPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileCo
    //   1. p(x, y) = p(x | y) * p(y)
    //   2. p(y) = Integral of p(x, y) over x
    //
-   // We conculde:
+   // We conclude:
    //                      p(x, y)
    //   p(x | y) = --------------------------
    //              Integral of p(x, y) over x


### PR DESCRIPTION
The `if (_normSet)` did not behave as intended, because the `RooAbsPdf::_normSet` member is a TString, and not a `char*`. And TStrings always convert to `true` booleans, even if they are empty. This commit fixes the empty normalization range check by using `TString::IsNull()` instead.

This fix helps to benchmark RooAddPdfs with the new `codegen` backend, because it avoids the creation of unnecessary normalization integrals that codegen can't handle.

This is a follow-up to 74e3099.