### PR TITLE
[DF] Add systematic variations to HiggsToFourLeptons tutorials

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -176,6 +176,7 @@ if(NOT xrootd)
   set(xrootd_veto dataframe/df101_h1Analysis.C
                   dataframe/df102_NanoAODDimuonAnalysis.C
                   dataframe/df103_NanoAODHiggsAnalysis.C
+                  dataframe/df106_HiggsToFourLeptons.C
                   tmva/tmva103_Application.C
                   dataframe/df033_Describe.py
                   dataframe/df102_NanoAODDimuonAnalysis.py

--- a/tutorials/dataframe/df106_HiggsToFourLeptons.C
+++ b/tutorials/dataframe/df106_HiggsToFourLeptons.C
@@ -1,0 +1,284 @@
+/// \file
+/// \ingroup tutorial_dataframe
+/// \notebook -draw
+/// The Higgs to four lepton analysis from the ATLAS Open Data release of 2020, with RDataFrame.
+///
+/// This tutorial is the Higgs to four lepton analysis from the ATLAS Open Data release in 2020
+/// (http://opendata.atlas.cern/release/2020/documentation/). The data was taken with the ATLAS detector
+/// during 2016 at a center-of-mass energy of 13 TeV. The decay of the Standard Model Higgs boson
+/// to two Z bosons and subsequently to four leptons is called the "golden channel". The selection leads
+/// to a narrow invariant mass peak on top a relatively smooth and small background, revealing
+/// the Higgs at 125 GeV.
+/// The analysis is translated to an RDataFrame workflow processing about 300 MB of simulated events and data.
+///
+/// Lepton selection efficiency corrections ("scale factors") are applied to simulated samples to correct for the
+/// differences in the trigger, reconstruction, and identification efficiencies in simulation compared to real data.
+/// Systematic uncertainties for those scale factors are evaluated and the Vary function of RDataFrame is used to
+/// propagate the variations to the final four leptons mass distribution.
+///
+///
+/// \macro_code
+/// \macro_image
+/// \date March 2020
+/// \author Stefan Wunsch (KIT, CERN)
+/// \date August 2022
+/// \author Julia Mathe (CERN)
+/// \date August 2023
+/// \author Marta Czurylo (CERN)
+
+#include <Math/Vector4D.h>
+#include <Math/Interpolator.h>
+#include <ROOT/RDFHelpers.hxx>
+#include <ROOT/RDataFrame.hxx>
+#include <ROOT/RVec.hxx>
+#include <TCanvas.h>
+#include <TH1D.h>
+#include <THStack.h>
+#include <TLatex.h>
+#include <TLegend.h>
+#include <TProfile.h>
+#include <TStyle.h>
+
+using namespace ROOT::VecOps;
+using PtEtaPhiEVectorF = ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<float>>;
+using ROOT::RVecF;
+using ROOT::RDF::RSampleInfo;
+using namespace ROOT::RDF::Experimental;
+
+// Define functions needed in the analysis
+// Select events for the analysis
+bool GoodElectronsAndMuons(const ROOT::RVecI &type, const RVecF &pt, const RVecF &eta, const RVecF &phi, const RVecF &e,
+                           const RVecF &trackd0pv, const RVecF &tracksigd0pv, const RVecF &z0)
+{
+   for (size_t i = 0; i < type.size(); i++) {
+      PtEtaPhiEVectorF p(0.001 * pt[i], eta[i], phi[i], 0.001 * e[i]);
+      if (type[i] == 11) {
+         if (pt[i] < 7000 || abs(eta[i]) > 2.47 || abs(trackd0pv[i] / tracksigd0pv[i]) > 5 ||
+             abs(z0[i] * sin(p.Theta())) > 0.5)
+            return false;
+      } else {
+         if (abs(trackd0pv[i] / tracksigd0pv[i]) > 5 || abs(z0[i] * sin(p.Theta())) > 0.5)
+            return false;
+      }
+   }
+   return true;
+}
+
+// Compute the invariant mass of a four-lepton-system.
+float ComputeInvariantMass(const RVecF &pt, const RVecF &eta, const RVecF &phi, const RVecF &e)
+{
+   PtEtaPhiEVectorF p1(pt[0], eta[0], phi[0], e[0]);
+   PtEtaPhiEVectorF p2(pt[1], eta[1], phi[1], e[1]);
+   PtEtaPhiEVectorF p3(pt[2], eta[2], phi[2], e[2]);
+   PtEtaPhiEVectorF p4(pt[3], eta[3], phi[3], e[3]);
+   return 0.001 * (p1 + p2 + p3 + p4).M();
+}
+
+void df106_HiggsToFourLeptons()
+{
+
+   // Enable Multithreading
+   ROOT::EnableImplicitMT();
+
+   // Create the RDataFrame from the spec json file. The df106_HiggsToFourLeptons_spec.json is provided in the same
+   // folder as this tutorial
+   std::string dataset_spec = gROOT->GetTutorialsDir() + std::string("/dataframe/df106_HiggsToFourLeptons_spec.json");
+   ROOT::RDataFrame df = ROOT::RDF::Experimental::FromSpec(dataset_spec);
+
+   // Add the ProgressBar feature
+   ROOT::RDF::Experimental::AddProgressbar(df);
+
+   // Perform the analysis
+   // Access metadata information that is stored in the JSON config file of the RDataFrame
+   // The metadata contained in the JSON file is accessible within a `DefinePerSample` call, through the `RDFSampleInfo`
+   // class
+   auto df_analysis =
+      df.DefinePerSample("xsecs", [](unsigned int slot, const RSampleInfo &id) { return id.GetD("xsecs"); })
+         .DefinePerSample("lumi", [](unsigned int slot, const RSampleInfo &id) { return id.GetD("lumi"); })
+         .DefinePerSample("sumws", [](unsigned int slot, const RSampleInfo &id) { return id.GetD("sumws"); })
+         .DefinePerSample("sample_category",
+                          [](unsigned int slot, const RSampleInfo &id) { return id.GetS("sample_category"); })
+         // Apply an MC correction for the ZZ decay due to missing gg->ZZ process
+         .DefinePerSample("scale",
+                          [](unsigned int slot, const ROOT::RDF::RSampleInfo &id) {
+                             return id.Contains("mc_363490.llll.4lep.root") ? 1.3f : 1.0f;
+                          })
+         // Select electron or muon trigger
+         .Filter("trigE || trigM")
+         // Select events with exactly four good leptons conserving charge and lepton numbers
+         // Note that all collections are RVecs and good_lep is the mask for the good leptons.
+         // The lepton types are PDG numbers and set to 11 or 13 for an electron or muon
+         // irrespective of the charge.
+         .Define("good_lep",
+                 "abs(lep_eta) < 2.5 && lep_pt > 5000 && lep_ptcone30 / lep_pt < 0.3 && lep_etcone20 / lep_pt < 0.3")
+         .Filter("Sum(good_lep) == 4")
+         .Filter("Sum(lep_charge[good_lep]) == 0")
+         .Define("goodlep_sumtypes", "Sum(lep_type[good_lep])")
+         .Filter("goodlep_sumtypes == 44 || goodlep_sumtypes == 52 || goodlep_sumtypes == 48")
+         // Apply additional cuts depending on lepton flavour
+         .Filter(
+            "GoodElectronsAndMuons(lep_type[good_lep], lep_pt[good_lep], lep_eta[good_lep], lep_phi[good_lep], "
+            "lep_E[good_lep], lep_trackd0pvunbiased[good_lep], lep_tracksigd0pvunbiased[good_lep], lep_z0[good_lep])")
+         // Create new columns with the kinematics of good leptons
+         .Define("goodlep_pt", "lep_pt[good_lep]")
+         .Define("goodlep_eta", "lep_eta[good_lep]")
+         .Define("goodlep_phi", "lep_phi[good_lep]")
+         .Define("goodlep_E", "lep_E[good_lep]")
+         .Define("goodlep_type", "lep_type[good_lep]")
+         // Select leptons with high transverse momentum
+         .Filter("goodlep_pt[0] > 25000 && goodlep_pt[1] > 15000 && goodlep_pt[2] > 10000")
+         // Compute invariant mass
+         .Define("m4l", "ComputeInvariantMass(goodlep_pt, goodlep_eta, goodlep_phi, goodlep_E)")
+         // Reweighting of the samples is different for "data" and "MC"
+         .DefinePerSample("reweighting", [](unsigned int slot, const RSampleInfo &id) { return id.Contains("mc"); });
+
+   // Define the weight column (scale factor) for the MC samples
+   auto df_mc = df_analysis.Filter("reweighting == true")
+                   .Define("weight", ("scaleFactor_ELE * scaleFactor_MUON * scaleFactor_LepTRIGGER * "
+                                      "scaleFactor_PILEUP * mcWeight * scale * xsecs / sumws * lumi"));
+
+   // Book histograms for individual MC samples
+   auto df_higgs = df_mc.Filter(R"(sample_category == "higgs")")
+                      .Histo1D<float>(ROOT::RDF::TH1DModel("higgs", "m4l", 24, 80, 170), "m4l", "weight");
+   auto df_zz = df_mc.Filter("sample_category == \"zz\"")
+                   .Histo1D<float>(ROOT::RDF::TH1DModel("zz", "m4l", 24, 80, 170), "m4l", "weight");
+   auto df_other = df_mc.Filter("sample_category == \"other\"")
+                      .Histo1D<float>(ROOT::RDF::TH1DModel("other", "m4l", 24, 80, 170), "m4l", "weight");
+
+   // Book the invariant mass histogram for the data
+   auto df_h_mass_data = df_analysis.Filter("reweighting == false")
+                            .Filter("sample_category == \"data\"")
+                            .Define("weight_", []() { return 1; })
+                            .Histo1D<float>(ROOT::RDF::TH1DModel("data", "m4l", 24, 80, 170), "m4l", "weight_");
+
+   // Evaluate the systematic uncertainty
+
+   // The systematic uncertainty in this analysis is the MC scale factor uncertainty that depends on lepton
+   // kinematics such as pT or pseudorapidity.
+   // Muons uncertainties are negligible, as stated in https://atlas.web.cern.ch/Atlas/GROUPS/PHYSICS/PAPERS/MUON
+   // Electrons uncertainties are evaluated based on the plots available in https://doi.org/10.48550/arXiv.1908.0
+   // The uncertainties are linearly interpolated to cover a range of pT values covered by the analysis.
+   const std::vector<double> x{5.50e3, 5.52e3, 12.54e3, 17.43e3, 22.40e3, 27.48e3, 30e3, 10000e3};
+   const std::vector<double> y{0.06628, 0.06395, 0.06396, 0.03372, 0.02441, 0.01403, 0, 0};
+   unsigned int N = x.size();
+   ROOT::Math::Interpolator inter(N, ROOT::Math::Interpolation::kLINEAR);
+   inter.SetData(x, y);
+
+   //  Use the Vary method to add the systematic variations to the total MC scale factor ("weight") of the analysis
+   //  The input consists of the input column to be varied and the lambda function to compute the systematic variations.
+   //  The new output columns contain the varied values of the input column.
+   auto df_with_variations_mc =
+      df_mc
+         .Vary("weight",
+               [&inter](double x, const RVecF &pt, const RVec<unsigned int> &type) {
+                  const auto v = Mean(Map(pt[type == 11], [&inter](auto p) { return inter.Eval(p); }));
+                  return RVec<double>{(1 + v) * x, (1 - v) * x};
+               },
+               {"weight", "goodlep_pt", "goodlep_type"}, {"up", "down"})
+         .Histo1D<float>(ROOT::RDF::TH1DModel("Invariant Mass", "m4l", 24, 80, 170), "m4l", "weight");
+
+   // Create the total MC scale factor histograms: "nominal", "weight:up" and "weight:down".
+   auto histos_mc = VariationsFor(df_with_variations_mc);
+
+   // Evaluate the total MC uncertainty based on the variations. Note, in this case the uncertainties are symmetric.
+   for (unsigned int i = 0; i < histos_mc["nominal"].GetXaxis()->GetNbins(); i++) {
+      histos_mc["nominal"].SetBinError(
+         i, (histos_mc["weight:up"].GetBinContent(i) - histos_mc["nominal"].GetBinContent(i)));
+   }
+
+   // Make the plot of the data, individual MC contributions and the total MC scale factor systematic variations.
+   gROOT->SetStyle("ATLAS");
+
+   // Create canvas with pad
+   auto c = new TCanvas("c", " ", 600, 600);
+   auto pad = new TPad("upper_pad", "", 0, 0, 1, 1);
+   pad->SetTickx(0);
+   pad->SetTicky(0);
+   pad->Draw();
+   pad->cd();
+
+   // Draw stack with MC contributions
+   auto stack = new THStack("stack", "");
+   auto h_other = df_other.GetPtr();
+   h_other->SetFillColor(kViolet - 9);
+   stack->Add(h_other);
+   auto h_zz = df_zz.GetPtr();
+   h_zz->SetFillColor(kAzure - 9);
+   stack->Add(h_zz);
+   auto h_higgs = df_higgs.GetPtr();
+   h_higgs->SetFillColor(kRed + 2);
+   stack->Add(h_higgs);
+
+   stack->Draw("HIST");
+   stack->GetHistogram()->SetTitle("");
+   stack->GetHistogram()->GetXaxis()->SetLabelSize(0.035);
+   stack->GetHistogram()->GetXaxis()->SetTitleSize(0.045);
+   stack->GetHistogram()->GetXaxis()->SetTitleOffset(1.3);
+   stack->GetHistogram()->GetXaxis()->SetTitle("m_{4l}^{H#rightarrow ZZ} [GeV]");
+   stack->GetHistogram()->GetYaxis()->SetLabelSize(0.035);
+   stack->GetHistogram()->GetYaxis()->SetTitleSize(0.045);
+   stack->GetHistogram()->GetYaxis()->SetTitle("Events");
+   stack->SetMaximum(35);
+   stack->GetHistogram()->GetYaxis()->ChangeLabel(1, -1, 0);
+   stack->DrawClone(
+      "HIST"); // DrawClone() method is necessary to draw a TObject in case the original object goes out of scope
+
+   // Draw MC scale factor and variations
+   histos_mc["nominal"].SetStats(0);
+   histos_mc["nominal"].SetFillColor(kBlack);
+   histos_mc["nominal"].SetFillStyle(3254);
+   histos_mc["nominal"].DrawClone("E2 sames");
+   histos_mc["weight:up"].SetLineColor(kGreen + 2);
+   histos_mc["weight:up"].SetStats(0);
+   histos_mc["weight:up"].DrawClone("HIST sames");
+   histos_mc["weight:down"].SetLineColor(kBlue + 2);
+   histos_mc["weight:down"].SetStats();
+   histos_mc["weight:down"].DrawClone("HIST sames");
+
+   // Draw data histogram
+   auto h_data = df_h_mass_data.GetPtr();
+   h_data->SetMarkerStyle(20);
+   h_data->SetMarkerSize(1.);
+   h_data->SetLineWidth(2);
+   h_data->SetLineColor(kBlack);
+   h_data->SetStats(0);
+   h_data->DrawClone("E sames");
+
+   // Add legend
+   TLegend legend(0.57, 0.65, 0.94, 0.94);
+   legend.SetTextFont(42);
+   legend.SetFillStyle(0);
+   legend.SetBorderSize(0);
+   legend.SetTextSize(0.025);
+   legend.SetTextAlign(32);
+   legend.AddEntry(h_data, "Data", "lep");
+   legend.AddEntry(h_higgs, "Higgs MC", "f");
+   legend.AddEntry(h_zz, "ZZ MC", "f");
+   legend.AddEntry(h_other, "Other MC", "f");
+   legend.AddEntry(&(histos_mc["weight:down"]), "Total MC Variations Down", "l");
+   legend.AddEntry(&(histos_mc["weight:up"]), "Total MC Variations Up", "l");
+   legend.AddEntry(&(histos_mc["nominal"]), "Total MC Uncertainty", "f");
+   legend.DrawClone("Same");
+
+   // Add ATLAS label
+   TLatex atlas_label;
+   atlas_label.SetTextFont(70);
+   atlas_label.SetTextSize(0.04);
+   atlas_label.DrawLatexNDC(0.19, 0.85, "ATLAS");
+   TLatex data_label;
+   data_label.SetTextFont(42);
+   data_label.DrawLatexNDC(0.19 + 0.13, 0.85, "Open Data");
+   TLatex header;
+   data_label.SetTextFont(42);
+   header.SetTextSize(0.035);
+   header.DrawLatexNDC(0.21, 0.8, "#sqrt{s} = 13 TeV, 10 fb^{-1}");
+
+   // Save the plot.
+   c->SaveAs("df106_HiggsToFourLeptons_cpp.png");
+   std::cout << "Saved figure to df106_HiggsToFourLeptons_cpp.png" << std::endl;
+}
+
+int main()
+{
+   df106_HiggsToFourLeptons();
+}

--- a/tutorials/dataframe/df106_HiggsToFourLeptons.py
+++ b/tutorials/dataframe/df106_HiggsToFourLeptons.py
@@ -9,8 +9,8 @@
 ## to two Z bosons and subsequently to four leptons is called the "golden channel". The selection leads
 ## to a narrow invariant mass peak on top a relatively smooth and small background, revealing
 ## the Higgs at 125 GeV.
-##
-## The analysis is translated to a RDataFrame workflow processing about 300 MB of simulated events and data.
+## Systematic errors for the MC scale factors are computed and the Vary function of RDataFrame is used for plotting.
+## The analysis is translated to an RDataFrame workflow processing about 300 MB of simulated events and data.
 ##
 ## \macro_image
 ## \macro_code
@@ -18,38 +18,51 @@
 ##
 ## \date March 2020
 ## \author Stefan Wunsch (KIT, CERN)
-## \date May 2023
+## \date July 2022
+## \author Julia Mathe (CERN)
+## \date August 2023
 ## \author Marta Czurylo (CERN)
 
 import ROOT
 import os
 
+# Enable Multi-threaded mode
+ROOT.EnableImplicitMT()
+
 # Create the RDataFrame from the spec json file. The df106_HiggsToFourLeptons_spec.json is provided in the same folder as this tutorial
-
-my_spec = os.path.join(ROOT.gROOT.GetTutorialsDir(), "dataframe", "df106_HiggsToFourLeptons_spec.json")
-
-df = ROOT.RDF.Experimental.FromSpec(my_spec) # Creates a single dataframe for all the samples
-
-# Access metadata information that is stored in the JSON config file of the RDataFrame
-# The metadata contained in the JSON file is accessible within a `DefinePerSample` call, through the `RDFSampleInfo` class
+dataset_spec = os.path.join(ROOT.gROOT.GetTutorialsDir(), "dataframe", "df106_HiggsToFourLeptons_spec.json")
+df = ROOT.RDF.Experimental.FromSpec(dataset_spec)  # Creates a single dataframe for all the samples
 
 # Add the ProgressBar feature
+ROOT.RDF.Experimental.AddProgressbar(df)
 
-ROOT.RDF.Experimental.AddProgressbar(df) 
-
+# Access metadata information that is stored in the JSON config file of the RDataFrame.
+# The metadata contained in the JSON file is accessible within a `DefinePerSample` call, through the `RDFSampleInfo` class.
 df = df.DefinePerSample("xsecs", 'rdfsampleinfo_.GetD("xsecs")')
-df = df.DefinePerSample("lumi", 'rdfsampleinfo_.GetD("lumi")') 
+df = df.DefinePerSample("lumi", 'rdfsampleinfo_.GetD("lumi")')
 df = df.DefinePerSample("sumws", 'rdfsampleinfo_.GetD("sumws")')
 df = df.DefinePerSample("sample_category", 'rdfsampleinfo_.GetS("sample_category")')
 
-# Select events for the analysis
+# We must further apply an MC correction for the ZZ decay due to missing gg->ZZ processes.
+ROOT.gInterpreter.Declare(
+    """
+float scale(unsigned int slot, const ROOT::RDF::RSampleInfo &id){
+                return id.Contains("mc_363490.llll.4lep.root") ? 1.3f : 1.0f;
+}
+"""
+)
 
-ROOT.gInterpreter.Declare("""
-using cRVecF = const ROOT::RVecF &;
-bool GoodElectronsAndMuons(const ROOT::RVecI & type, cRVecF pt, cRVecF eta, cRVecF phi, cRVecF e, cRVecF trackd0pv, cRVecF tracksigd0pv, cRVecF z0)
+df = df.DefinePerSample("scale", "scale(rdfslot_, rdfsampleinfo_)")
+
+# Select events for the analysis
+ROOT.gInterpreter.Declare(
+    """
+using ROOT::RVecF;
+using ROOT::RVecI;
+bool GoodElectronsAndMuons(const RVecI &type, const RVecF &pt, const RVecF &eta, const RVecF &phi, const RVecF &e, const RVecF &trackd0pv, const RVecF &tracksigd0pv, const RVecF &z0)
 {
     for (size_t i = 0; i < type.size(); i++) {
-        ROOT::Math::PtEtaPhiEVector p(pt[i] / 1000.0, eta[i], phi[i], e[i] / 1000.0);
+        ROOT::Math::PtEtaPhiEVector p(0.001*pt[i], eta[i], phi[i], 0.001*e[i]);
         if (type[i] == 11) {
             if (pt[i] < 7000 || abs(eta[i]) > 2.47 || abs(trackd0pv[i] / tracksigd0pv[i]) > 5 || abs(z0[i] * sin(p.Theta())) > 0.5) return false;
         } else {
@@ -58,7 +71,8 @@ bool GoodElectronsAndMuons(const ROOT::RVecI & type, cRVecF pt, cRVecF eta, cRVe
     }
     return true;
 }
-""")
+"""
+)
 
 # Select electron or muon trigger
 df = df.Filter("trigE || trigM")
@@ -68,71 +82,153 @@ df = df.Filter("trigE || trigM")
 # The lepton types are PDG numbers and set to 11 or 13 for an electron or muon
 # irrespective of the charge.
 
-df = df.Define("good_lep", "abs(lep_eta) < 2.5 && lep_pt > 5000 && lep_ptcone30 / lep_pt < 0.3 && lep_etcone20 / lep_pt < 0.3")\
-       .Filter("Sum(good_lep) == 4")\
-       .Filter("Sum(lep_charge[good_lep]) == 0")\
-       .Define("goodlep_sumtypes", "Sum(lep_type[good_lep])")\
-       .Filter("goodlep_sumtypes == 44 || goodlep_sumtypes == 52 || goodlep_sumtypes == 48")
+df = (
+    df.Define(
+        "good_lep",
+        "abs(lep_eta) < 2.5 && lep_pt > 5000 && lep_ptcone30 / lep_pt < 0.3 && lep_etcone20 / lep_pt < 0.3",
+    )
+    .Filter("Sum(good_lep) == 4")
+    .Filter("Sum(lep_charge[good_lep]) == 0")
+    .Define("goodlep_sumtypes", "Sum(lep_type[good_lep])")
+    .Filter("goodlep_sumtypes == 44 || goodlep_sumtypes == 52 || goodlep_sumtypes == 48")
+)
 
 # Apply additional cuts depending on lepton flavour
-df = df.Filter("GoodElectronsAndMuons(lep_type[good_lep], lep_pt[good_lep], lep_eta[good_lep], lep_phi[good_lep], lep_E[good_lep], lep_trackd0pvunbiased[good_lep], lep_tracksigd0pvunbiased[good_lep], lep_z0[good_lep])")
+df = df.Filter(
+    "GoodElectronsAndMuons(lep_type[good_lep], lep_pt[good_lep], lep_eta[good_lep], lep_phi[good_lep], lep_E[good_lep], lep_trackd0pvunbiased[good_lep], lep_tracksigd0pvunbiased[good_lep], lep_z0[good_lep])"
+)
 
 # Create new columns with the kinematics of good leptons
-df = df.Define("goodlep_pt", "lep_pt[good_lep]")\
-       .Define("goodlep_eta", "lep_eta[good_lep]")\
-       .Define("goodlep_phi", "lep_phi[good_lep]")\
-       .Define("goodlep_E", "lep_E[good_lep]")
+df = (
+    df.Define("goodlep_pt", "lep_pt[good_lep]")
+    .Define("goodlep_eta", "lep_eta[good_lep]")
+    .Define("goodlep_phi", "lep_phi[good_lep]")
+    .Define("goodlep_E", "lep_E[good_lep]")
+    .Define("goodlep_type", "lep_type[good_lep]")
+)
 
 # Select leptons with high transverse momentum
 df = df.Filter("goodlep_pt[0] > 25000 && goodlep_pt[1] > 15000 && goodlep_pt[2] > 10000")
 
 # Reweighting of the samples is different for "data" and "MC". This is the function to add reweighting for MC samples
-ROOT.gInterpreter.Declare("""
-double weights(float scaleFactor_1, float scaleFactor_2, float scaleFactor_3, float scaleFactor_4, float mcWeight_, double xsecs_, double sumws_, double lumi_)
+ROOT.gInterpreter.Declare(
+    """
+double weights(float scaleFactor_1, float scaleFactor_2, float scaleFactor_3, float scaleFactor_4, float scale, float mcWeight, double xsecs, double sumws, double lumi)
 {
-    double weight_ = scaleFactor_1 * scaleFactor_2 * scaleFactor_3 * scaleFactor_4 * mcWeight_ * xsecs_/sumws_ * lumi_;
-    return (weight_);
+    return scaleFactor_1 * scaleFactor_2 * scaleFactor_3 * scaleFactor_4 * scale * mcWeight * xsecs / sumws * lumi;
 }
-""")
+"""
+)
 
-# Use DefinePerSample to define which samples need reweighting
-df = df.DefinePerSample("reweighting", 'rdfsampleinfo_.Contains("mc")')
-df = df.Define("weight", 'double x; if (reweighting) {return weights(scaleFactor_ELE, scaleFactor_MUON, scaleFactor_LepTRIGGER, scaleFactor_PILEUP, mcWeight, xsecs, sumws, lumi);} else {return 1.;}')
-                        
-# Compute invariant mass of the four lepton system and make a histogram
-ROOT.gInterpreter.Declare("""
-float ComputeInvariantMass(cRVecF pt, cRVecF eta, cRVecF phi, cRVecF e)
+# Use DefinePerSample to define which samples are MC and hence need reweighting
+df = df.DefinePerSample("isMC", 'rdfsampleinfo_.Contains("mc")')
+df = df.Define(
+    "weight",
+    "double x; return isMC ? weights(scaleFactor_ELE, scaleFactor_MUON, scaleFactor_LepTRIGGER, scaleFactor_PILEUP, scale, mcWeight, xsecs, sumws, lumi) :  1.;",
+)
+
+# Compute invariant mass of the four lepton system
+ROOT.gInterpreter.Declare(
+    """
+float ComputeInvariantMass(RVecF pt, RVecF eta, RVecF phi, RVecF e)
 {
-    ROOT::Math::PtEtaPhiEVector p1(pt[0], eta[0], phi[0], e[0]);
-    ROOT::Math::PtEtaPhiEVector p2(pt[1], eta[1], phi[1], e[1]);
-    ROOT::Math::PtEtaPhiEVector p3(pt[2], eta[2], phi[2], e[2]);
-    ROOT::Math::PtEtaPhiEVector p4(pt[3], eta[3], phi[3], e[3]);
-    return (p1 + p2 + p3 + p4).M() / 1000;
+    ROOT::Math::PtEtaPhiEVector p1{pt[0], eta[0], phi[0], e[0]};
+    ROOT::Math::PtEtaPhiEVector p2{pt[1], eta[1], phi[1], e[1]};
+    ROOT::Math::PtEtaPhiEVector p3{pt[2], eta[2], phi[2], e[2]};
+    ROOT::Math::PtEtaPhiEVector p4{pt[3], eta[3], phi[3], e[3]};
+    return 0.001 * (p1 + p2 + p3 + p4).M();
 }
-""")
+"""
+)
+
 df = df.Define("m4l", "ComputeInvariantMass(goodlep_pt, goodlep_eta, goodlep_phi, goodlep_E)")
 
 # Book histograms for the four different samples: data, higgs, zz and other (this is specific to this particular analysis)
-histos = [] 
+histos = []
 for sample_category in ["data", "higgs", "zz", "other"]:
-    histos.append(df.Filter(f"sample_category == \"{sample_category}\"").Histo1D(ROOT.RDF.TH1DModel(f"{sample_category}", "m4l", 24, 80, 170), "m4l", "weight"))
+    histos.append(
+        df.Filter(f'sample_category == "{sample_category}"').Histo1D(
+            ROOT.RDF.TH1DModel(f"{sample_category}", "m4l", 24, 80, 170),
+            "m4l",
+            "weight",
+        )
+    )
 
+# Evaluate the systematic uncertainty
 
-h_data = histos[0].GetValue()
-h_higgs = histos[1].GetValue()
-h_zz = histos[2].GetValue()
-h_other = histos[3].GetValue()
+# The systematic uncertainty in this analysis is the MC scale factor uncertainty that depends on lepton
+# kinematics such as pT or pseudorapidity.
+# Muons uncertainties are negligible, as stated in https://atlas.web.cern.ch/Atlas/GROUPS/PHYSICS/PAPERS/MUON-2018-03/.
+# Electrons uncertainties are evaluated based on the plots available in https://doi.org/10.48550/arXiv.1908.00005.
+# The uncertainties are linearly interpolated to cover a range of pT values covered by the analysis.
 
-# Apply MC correction for ZZ due to missing gg->ZZ process
-h_zz.Scale(1.3) 
+# Create a VaryHelper to interpolate the available data.
+ROOT.gInterpreter.Declare(
+    """   
+using namespace ROOT::VecOps;
+using namespace ROOT::Math;
 
-# Create the plot
+class VaryHelper 
+{
+    std::vector<double> x = {5.50 * 10e2, 5.52 * 10e2, 12.54 * 10e2, 17.43 * 10e2, 22.40 * 10e2, 27.48 * 10e2, 30 * 10e2, 10000 * 10e2};
+    std::vector<double> y = {0.06628, 0.06395, 0.06396, 0.03372, 0.02441, 0.01403, 0., 0.};
+    Interpolator inter;
+public:
+    VaryHelper() : inter(x, y, Interpolation::kLINEAR) {}
+
+    RVec<double> operator()(const double &w, const RVecF &pt, const RVec<unsigned int> &type)
+    {
+        const auto v = Mean(Map(pt[type == 11], [this](auto p) 
+        {return this->inter.Eval(p); })
+        );                                                                                              
+        return RVec<double>{(1 + v) * w, (1 - v) * w};
+    }
+};
+
+VaryHelper variationsFactory;
+"""
+)
+
+# Use the Vary method to add the systematic variations to the total MC scale factor ("weight") of the analysis.
+df_variations_mc = (
+    df.Filter("isMC == true")
+    .Vary("weight", "variationsFactory(weight, goodlep_pt, goodlep_type)", ["up", "down"])
+    .Histo1D(ROOT.RDF.TH1DModel("Invariant Mass", "m4l", 24, 80, 170), "m4l", "weight")
+)
+histos_mc = ROOT.RDF.Experimental.VariationsFor(df_variations_mc)
+
+# We reached the end of the analysis part. We now evaluate the total MC uncertainty based on the variations.
+# No computation graph was triggered yet, we trigger the computation graph for all histograms at once now,
+# by calling 'histos_mc["nominal"].GetXaxis()'.
+# Note, in this case the uncertainties are symmetric.
+for i in range(0, histos_mc["nominal"].GetXaxis().GetNbins()):
+    (
+        histos_mc["nominal"].SetBinError(
+            i, (histos_mc["weight:up"].GetBinContent(i) - histos_mc["nominal"].GetBinContent(i))
+        )
+    )
+
+# Make the plot of the data, individual MC contributions and the total MC scale factor systematic variations.
 
 # Set styles
 ROOT.gROOT.SetStyle("ATLAS")
 
+
+# Function to add ATLAS label
+def draw_atlas_label():
+    text = ROOT.TLatex()
+    text.SetNDC()
+    text.SetTextFont(72)
+    text.SetTextSize(0.04)
+    text.DrawLatex(0.19, 0.85, "ATLAS")
+    text.SetTextFont(42)
+    text.DrawLatex(0.19 + 0.15, 0.85, "Open Data")
+    text.SetTextSize(0.035)
+    text.DrawLatex(0.21, 0.80, "#sqrt{s} = 13 TeV, 10 fb^{-1}")
+
+
 # Create canvas with pad
-c = ROOT.TCanvas("c", "", 600, 600)
+c1 = ROOT.TCanvas("c", "", 600, 600)
 pad = ROOT.TPad("upper_pad", "", 0, 0, 1, 1)
 pad.SetTickx(False)
 pad.SetTicky(False)
@@ -140,13 +236,19 @@ pad.Draw()
 pad.cd()
 
 # Draw stack with MC contributions
-
 stack = ROOT.THStack()
 
-for h, color in zip([h_other, h_zz, h_higgs], [(155, 152, 204), (100, 192, 232), (191, 34, 41)]):
+# Retrieve values of the data and MC histograms in order to plot them.
+# Note: GetValue() action operation is performed after all lazy actions of the RDF were defined first.
+h_data = histos[0].GetValue()
+h_higgs = histos[1].GetValue()
+h_zz = histos[2].GetValue()
+h_other = histos[3].GetValue()
+
+for h, color in zip([h_other, h_zz, h_higgs], [ROOT.kViolet - 9, ROOT.kAzure - 9, ROOT.kRed + 2]):
     h.SetLineWidth(1)
     h.SetLineColor(1)
-    h.SetFillColor(ROOT.TColor.GetColor(*color))
+    h.SetFillColor(color)
     stack.Add(h)
 
 stack.Draw("HIST")
@@ -154,42 +256,54 @@ stack.GetXaxis().SetLabelSize(0.04)
 stack.GetXaxis().SetTitleSize(0.045)
 stack.GetXaxis().SetTitleOffset(1.3)
 stack.GetXaxis().SetTitle("m_{4l}^{H#rightarrow ZZ} [GeV]")
-stack.GetYaxis().SetTitle("Events")
 stack.GetYaxis().SetLabelSize(0.04)
 stack.GetYaxis().SetTitleSize(0.045)
-stack.SetMaximum(33)
+stack.GetYaxis().SetTitle("Events")
+stack.SetMaximum(35)
 stack.GetYaxis().ChangeLabel(1, -1, 0)
+stack.DrawClone(
+    "HIST"
+)  # DrawClone() method is necessary to draw a TObject in case the original object goes out of scope, needed for the interactive root session
 
+# Draw MC scale factor and variations
+histos_mc["nominal"].SetStats(0)
+histos_mc["nominal"].SetFillColor(ROOT.kBlack)
+histos_mc["nominal"].SetFillStyle(3254)
+histos_mc["nominal"].DrawClone("E2 sames")
+histos_mc["weight:up"].SetStats(0)
+histos_mc["weight:up"].SetLineColor(ROOT.kGreen + 2)
+histos_mc["weight:up"].DrawClone("HIST SAME")
+histos_mc["weight:down"].SetLineColor(ROOT.kBlue + 2)
+histos_mc["weight:down"].SetStats(0)
+histos_mc["weight:down"].DrawClone("HIST SAME")
+
+# Draw data histogram
 h_data.SetMarkerStyle(20)
 h_data.SetMarkerSize(1.2)
 h_data.SetLineWidth(2)
 h_data.SetLineColor(ROOT.kBlack)
-h_data.Draw("E SAME") #draw data with errorbars 
+h_data.DrawClone("E SAME")  # Draw raw data with errorbars
 
 # Add legend
-legend = ROOT.TLegend(0.60, 0.65, 0.92, 0.92)
+legend = ROOT.TLegend(0.57, 0.65, 0.94, 0.94)
 legend.SetTextFont(42)
 legend.SetFillStyle(0)
 legend.SetBorderSize(0)
-legend.SetTextSize(0.04)
+legend.SetTextSize(0.025)
 legend.SetTextAlign(32)
-legend.AddEntry(h_data, "Data" ,"lep")
-legend.AddEntry(h_higgs, "Higgs", "f")
-legend.AddEntry(h_zz, "ZZ", "f")
-legend.AddEntry(h_other, "Other", "f")
+legend.AddEntry(h_data, "Data", "lep")
+legend.AddEntry(h_higgs, "Higgs MC", "f")
+legend.AddEntry(h_zz, "ZZ MC", "f")
+legend.AddEntry(h_other, "Other MC", "f")
+legend.AddEntry((histos_mc["weight:down"]), "Total MC Variations Down", "l")
+legend.AddEntry((histos_mc["weight:up"]), "Total MC Variations Up", "l")
+legend.AddEntry((histos_mc["nominal"]), "Total MC Uncertainty", "f")
 legend.Draw("SAME")
 
-# Add ATLAS label
-text = ROOT.TLatex()
-text.SetNDC()
-text.SetTextFont(72)
-text.SetTextSize(0.045)
-text.DrawLatex(0.21, 0.86, "ATLAS")
-text.SetTextFont(42)
-text.DrawLatex(0.21 + 0.16, 0.86, "Open Data")
-text.SetTextSize(0.04)
-text.DrawLatex(0.21, 0.80, "#sqrt{s} = 13 TeV, 10 fb^{-1}")
+draw_atlas_label()
+
+c1.Update()
 
 # Save the plot
-c.SaveAs("df106_HiggsToFourLeptons.png")
-print("Saved figure to df106_HiggsToFourLeptons.png")
+c1.SaveAs("df106_HiggsToFourLeptons_python.png")
+print("Saved figure to df106_HiggsToFourLeptons_python.png")


### PR DESCRIPTION
This PR is based on PR #11200. 
The systematic variations in the Higgs to four leptons tutorial are implemented. The improved plot shows the up and down variations of the total Monte Carlo weight (scale factor) on top of what was previously shown. Now the C++ version of the full tutorial is also available.

I decided to rename the tutorial from df106_HiggsToFourLeptons.py to df106_HiggsToFourLeptons_withVaariations.py but it's just a suggestion, I can change it back to what it was. 

Note (I suppose only relevant since I run it on Mac ARM)- in order to use the Interpolator I built root with `-Dbuiltin_gsl=ON` option. 
![df106_HiggsToFourLeptons_python](https://github.com/root-project/root/assets/80402204/e273ae21-fbf3-4813-8d23-99ee59c4b431)

