### PR TITLE
Add GraphAsymmErrors to DistRDF operations

### DIFF
--- a/bindings/experimental/distrdf/python/DistRDF/Operation.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Operation.py
@@ -95,6 +95,7 @@ SUPPORTED_OPERATIONS: Dict[str, Union[Action, InstantAction, Transformation]] = 
     "DefinePerSample": Transformation,
     "Filter": Transformation,
     "Graph": Action,
+    "GraphAsymmErrors": Action,
     "Histo1D": Histo,
     "Histo2D": Histo,
     "Histo3D": Histo,

--- a/tree/dataframe/inc/LinkDef.h
+++ b/tree/dataframe/inc/LinkDef.h
@@ -55,6 +55,7 @@
 #pragma link C++ class ROOT::Detail::RDF::RMergeableValue<TH3D>+;
 #pragma link C++ class ROOT::Detail::RDF::RMergeableValue<THnD>+;
 #pragma link C++ class ROOT::Detail::RDF::RMergeableValue<TGraph>+;
+#pragma link C++ class ROOT::Detail::RDF::RMergeableValue<TGraphAsymmErrors>+;
 #pragma link C++ class ROOT::Detail::RDF::RMergeableValue<TStatistic>+;
 #pragma link C++ class ROOT::Detail::RDF::RMergeableValue<TProfile>+;
 #pragma link C++ class ROOT::Detail::RDF::RMergeableValue<TProfile2D>+;


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
GraphAsymmErrors was missing from the list of allowed operations for DistRDF
This PR fixes #13588

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

