### PR TITLE
minuit2: missing header

### DIFF
--- a/math/minuit2/src/CMakeLists.txt
+++ b/math/minuit2/src/CMakeLists.txt
@@ -71,6 +71,7 @@ set(MINUIT2_HEADERS
     MnLineSearch.h
     MnMachinePrecision.h
     MnMatrix.h
+    MnMatrixfwd.h
     MnMigrad.h
     MnMinimize.h
     MnMinos.h


### PR DESCRIPTION
Installing missing header MnMatrixfwd.h when building standalone Minuit2.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
