### PR TITLE
[RF] Rename the RooFitDriver to `RooFit::Evaluator` and make it public

### DIFF
--- a/roofit/histfactory/test/testHistFactory.cxx
+++ b/roofit/histfactory/test/testHistFactory.cxx
@@ -22,9 +22,9 @@
 #include <RooHelpers.h>
 #include <RooFitResult.h>
 #include <RooPlot.h>
+#include <RooFit/Evaluator.h>
 
 #include "../src/RooFit/BatchModeDataHelpers.h"
-#include "../src/RooFitDriver.h"
 
 #include <TROOT.h>
 #include <TFile.h>
@@ -46,15 +46,15 @@ const bool writeJsonFiles = false;
 std::vector<double> getValues(RooAbsReal const &real, RooAbsData const &data)
 {
    std::unique_ptr<RooAbsReal> clone = RooFit::Detail::compileForNormSet<RooAbsReal>(real, *data.get());
-   ROOT::Experimental::RooFitDriver driver(*clone, RooFit::BatchModeOption::Cpu);
+   RooFit::Evaluator evaluator(*clone);
    std::stack<std::vector<double>> vectorBuffers;
    auto dataSpans = RooFit::BatchModeDataHelpers::getDataSpans(data, "", nullptr, /*skipZeroWeights=*/false,
                                                                /*takeGlobalObservablesFromData=*/true, vectorBuffers);
    for (auto const &item : dataSpans) {
-      driver.setInput(item.first->GetName(), item.second, false);
+      evaluator.setInput(item.first->GetName(), item.second, false);
    }
    std::vector<double> out;
-   std::span<const double> results = driver.run();
+   std::span<const double> results = evaluator.run();
    out.assign(results.begin(), results.end());
    return out;
 }

--- a/roofit/histfactory/test/testParamHistFunc.cxx
+++ b/roofit/histfactory/test/testParamHistFunc.cxx
@@ -9,9 +9,9 @@
 #include <RooRealVar.h>
 #include <RooStats/HistFactory/ParamHistFunc.h>
 #include <RooFit/Detail/NormalizationHelpers.h>
+#include <RooFit/Evaluator.h>
 
 #include "../src/RooFit/BatchModeDataHelpers.h"
-#include "../src/RooFitDriver.h"
 
 #include <gtest/gtest.h>
 #include <array>
@@ -72,14 +72,14 @@ TEST(ParamHistFunc, ValidateND)
 
    // Get the results in BatchMode using the dataset
    std::unique_ptr<RooAbsReal> clone = RooFit::Detail::compileForNormSet<RooAbsReal>(paramHistFunc, *data.get());
-   ROOT::Experimental::RooFitDriver driver(*clone, RooFit::BatchModeOption::Cpu);
+   RooFit::Evaluator evaluator(*clone);
    std::stack<std::vector<double>> vectorBuffers;
    auto dataSpans = RooFit::BatchModeDataHelpers::getDataSpans(data, "", nullptr, /*skipZeroWeights=*/true,
                                                                /*takeGlobalObservablesFromData=*/false, vectorBuffers);
    for (auto const &item : dataSpans) {
-      driver.setInput(item.first->GetName(), item.second, false);
+      evaluator.setInput(item.first->GetName(), item.second, false);
    }
-   std::span<const double> resultsBatch = driver.run();
+   std::span<const double> resultsBatch = evaluator.run();
 
    // Validate the results
    for (std::size_t i = 0; i < nEntries; ++i) {

--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -34,6 +34,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     RooFit/Detail/CodeSquashContext.h
     RooFit/Detail/DataMap.h
     RooFit/Detail/NormalizationHelpers.h
+    RooFit/Evaluator.h
     RooFit/Floats.h
     RooFit/ModelConfig.h
     Roo1DTable.h
@@ -372,8 +373,8 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     src/RooMultiCategory.cxx
     src/RooMultiVarGaussian.cxx
     src/RooNameReg.cxx
-    src/RooFitDriver.cxx
-    src/RooFitDriverWrapper.cxx
+    src/RooFit/Evaluator.cxx
+    src/RooEvaluatorWrapper.cxx
     src/RooNLLVar.cxx
     src/RooNLLVarNew.cxx
     src/RooNormSetCache.cxx

--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -41,11 +41,6 @@ class RooAbsMoment ;
 class RooDerivative ;
 class RooVectorDataStore ;
 struct TreeReadBuffer; /// A space to attach TBranches
-namespace ROOT {
-namespace Experimental {
-class RooFitDriver ;
-}
-}
 namespace RooBatchCompute {
 struct RunContext;
 }

--- a/roofit/roofitcore/inc/RooFit/Evaluator.h
+++ b/roofit/roofitcore/inc/RooFit/Evaluator.h
@@ -11,8 +11,8 @@
  * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
  */
 
-#ifndef RooFit_RooFitDriver_h
-#define RooFit_RooFitDriver_h
+#ifndef RooFit_Evaluator_h
+#define RooFit_Evaluator_h
 
 #include <RooFit/Detail/DataMap.h>
 #include <RooHelpers.h>
@@ -24,8 +24,7 @@
 
 class RooAbsArg;
 
-namespace ROOT {
-namespace Experimental {
+namespace RooFit {
 
 namespace Detail {
 class BufferManager;
@@ -37,10 +36,10 @@ namespace Detail {
 class BufferManager;
 }
 
-class RooFitDriver {
+class Evaluator {
 public:
-   RooFitDriver(const RooAbsReal &absReal, RooFit::BatchModeOption batchMode = RooFit::BatchModeOption::Cpu);
-   ~RooFitDriver();
+   Evaluator(const RooAbsReal &absReal, bool useGPU=false);
+   ~Evaluator();
 
    std::span<const double> run();
    void setInput(std::string const &name, std::span<const double> inputArray, bool isOnDevice);
@@ -62,7 +61,7 @@ private:
 
    std::unique_ptr<Detail::BufferManager> _bufferManager;
    RooAbsReal &_topNode;
-   const RooFit::BatchModeOption _batchMode = RooFit::BatchModeOption::Off;
+   const bool _useGPU = false;
    int _nEvaluations = 0;
    bool _needToUpdateOutputSizes = false;
    RooFit::Detail::DataMap _dataMapCPU;
@@ -73,7 +72,6 @@ private:
    std::stack<RooHelpers::ChangeOperModeRAII> _changeOperModeRAIIs; // for resetting state of computation graph
 };
 
-} // end namespace Experimental
-} // end namespace ROOT
+} // end namespace RooFit
 
 #endif

--- a/roofit/roofitcore/inc/RooFit/TestStatistics/RooUnbinnedL.h
+++ b/roofit/roofitcore/inc/RooFit/TestStatistics/RooUnbinnedL.h
@@ -23,13 +23,11 @@ class RooAbsPdf;
 class RooAbsData;
 class RooArgSet;
 class RooChangeTracker;
-namespace ROOT {
-namespace Experimental {
-class RooFitDriver;
-}
-} // namespace ROOT
 
 namespace RooFit {
+
+class Evaluator;
+
 namespace TestStatistics {
 
 class RooUnbinnedL : public RooAbsL {
@@ -51,7 +49,7 @@ private:
    std::unique_ptr<RooChangeTracker> paramTracker_;
    Section lastSection_ = {0, 0}; // used for cache together with the parameter tracker
    mutable ROOT::Math::KahanSum<double> cachedResult_{0.};
-   std::shared_ptr<ROOT::Experimental::RooFitDriver> driver_; ///<! For batched evaluation
+   std::shared_ptr<RooFit::Evaluator> evaluator_; ///<! For batched evaluation
    std::stack<std::vector<double>> _vectorBuffers;            // used for preserving resources in batched evaluation
 };
 

--- a/roofit/roofitcore/src/Buffers.cxx
+++ b/roofit/roofitcore/src/Buffers.cxx
@@ -22,8 +22,7 @@ namespace CudaInterface = RooFit::Detail::CudaInterface;
 using CudaInterface::CudaStream;
 #endif
 
-namespace ROOT {
-namespace Experimental {
+namespace RooFit {
 namespace Detail {
 
 class ScalarBufferContainer {
@@ -219,5 +218,4 @@ std::unique_ptr<AbsBuffer> BufferManager::makePinnedBuffer(std::size_t size, Cud
 #endif // R__HAS_CUDA
 
 } // end namespace Detail
-} // end namespace Experimental
-} // end namespace ROOT
+} // end namespace RooFit

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -2600,7 +2600,7 @@ void RooAbsArg::setDataToken(std::size_t index)
    if (_dataToken != std::numeric_limits<std::size_t>::max()) {
       std::stringstream errMsg;
       errMsg << "The data token for \"" << GetName() << "\" is already set!"
-             << " Are you trying to evaluate the same object by multiple RooFitDriver instances?"
+             << " Are you trying to evaluate the same object by multiple RooFit::Evaluator instances?"
              << " This is not allowed.";
       throw std::runtime_error(errMsg.str());
    }

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -174,8 +174,8 @@ called for each data event.
 #include "RooFit/TestStatistics/buildLikelihood.h"
 #include "RooFit/TestStatistics/RooRealL.h"
 #include "ConstraintHelpers.h"
-#include "RooFitDriver.h"
-#include "RooFitDriverWrapper.h"
+#include "RooFit/Evaluator.h"
+#include "RooEvaluatorWrapper.h"
 #include "RooSimultaneous.h"
 #include "RooFuncWrapper.h"
 
@@ -1177,9 +1177,9 @@ RooFit::OwningPtr<RooAbsReal> RooAbsPdf::createNLL(RooAbsData& data, const RooLi
        nllWrapper = std::make_unique<RooFuncWrapper>(wrapperName.c_str(), wrapperName.c_str(), *nll, normSet, &data,
                                                      dynamic_cast<RooSimultaneous const *>(pdfClone.get()));
     } else {
-      auto driver = std::make_unique<ROOT::Experimental::RooFitDriver>(*nll, batchMode);
-      nllWrapper = std::make_unique<RooFitDriverWrapper>(*nll,
-         std::move(driver), rangeName ? rangeName : "", dynamic_cast<RooSimultaneous *>(pdfClone.get()), takeGlobalObservablesFromData);
+      auto evaluator = std::make_unique<RooFit::Evaluator>(*nll, batchMode == RooFit::BatchModeOption::Cuda);
+      nllWrapper = std::make_unique<RooEvaluatorWrapper>(*nll,
+         std::move(evaluator), rangeName ? rangeName : "", dynamic_cast<RooSimultaneous *>(pdfClone.get()), takeGlobalObservablesFromData);
       nllWrapper->setData(data, false);
     }
 

--- a/roofit/roofitcore/src/RooEvaluatorWrapper.h
+++ b/roofit/roofitcore/src/RooEvaluatorWrapper.h
@@ -12,16 +12,17 @@
  * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
  */
 
-#ifndef RooFit_RooFitDriverWrapper_h
-#define RooFit_RooFitDriverWrapper_h
+#ifndef RooFit_RooEvaluatorWrapper_h
+#define RooFit_RooEvaluatorWrapper_h
 
 #include <RooAbsData.h>
 #include "RooFit/Detail/DataMap.h"
 #include <RooGlobalFunc.h>
 #include <RooHelpers.h>
 #include <RooRealProxy.h>
+#include <RooFit/Evaluator.h>
+
 #include "RooFit/Detail/Buffers.h"
-#include "RooFitDriver.h"
 
 #include <chrono>
 #include <memory>
@@ -31,14 +32,14 @@ class RooAbsArg;
 class RooAbsCategory;
 class RooSimultaneous;
 
-class RooFitDriverWrapper final : public RooAbsReal {
+class RooEvaluatorWrapper final : public RooAbsReal {
 public:
-   RooFitDriverWrapper(RooAbsReal &topNode, std::unique_ptr<ROOT::Experimental::RooFitDriver> driver,
-                       std::string const &rangeName, RooSimultaneous const *simPdf, bool takeGlobalObservablesFromData);
+   RooEvaluatorWrapper(RooAbsReal &topNode, std::unique_ptr<RooFit::Evaluator> evaluator, std::string const &rangeName,
+                       RooSimultaneous const *simPdf, bool takeGlobalObservablesFromData);
 
-   RooFitDriverWrapper(const RooFitDriverWrapper &other, const char *name = nullptr);
+   RooEvaluatorWrapper(const RooEvaluatorWrapper &other, const char *name = nullptr);
 
-   TObject *clone(const char *newname) const override { return new RooFitDriverWrapper(*this, newname); }
+   TObject *clone(const char *newname) const override { return new RooEvaluatorWrapper(*this, newname); }
 
    double defaultErrorLevel() const override { return _topNode->defaultErrorLevel(); }
 
@@ -53,14 +54,14 @@ public:
    void printMultiline(std::ostream &os, Int_t /*contents*/, bool /*verbose*/ = false,
                        TString /*indent*/ = "") const override
    {
-      _driver->print(os);
+      _evaluator->print(os);
    }
 
 protected:
-   double evaluate() const override { return _driver ? _driver->run()[0] : 0.0; }
+   double evaluate() const override { return _evaluator ? _evaluator->run()[0] : 0.0; }
 
 private:
-   std::shared_ptr<ROOT::Experimental::RooFitDriver> _driver;
+   std::shared_ptr<RooFit::Evaluator> _evaluator;
    RooRealProxy _topNode;
    RooAbsData *_data = nullptr;
    RooArgSet _parameters;

--- a/roofit/roofitcore/src/RooFit/Detail/Buffers.h
+++ b/roofit/roofitcore/src/RooFit/Detail/Buffers.h
@@ -24,8 +24,7 @@
 
 #include <memory>
 
-namespace ROOT {
-namespace Experimental {
+namespace RooFit {
 namespace Detail {
 
 class AbsBuffer {
@@ -60,7 +59,6 @@ private:
 };
 
 } // end namespace Detail
-} // end namespace Experimental
-} // end namespace ROOT
+} // end namespace RooFit
 
 #endif

--- a/roofit/roofitcore/src/RooNLLVarNew.cxx
+++ b/roofit/roofitcore/src/RooNLLVarNew.cxx
@@ -17,9 +17,8 @@
 \ingroup Roofitcore
 
 This is a simple class designed to produce the nll values needed by the fitter.
-In contrast to the `RooNLLVar` class, any logic except the bare minimum has been
-transfered away to other classes, like the `RooFitDriver`. This class also calls
-functions from `RooBatchCompute` library to provide faster computation times.
+This class calls functions from `RooBatchCompute` library to provide faster
+computation times.
 **/
 
 #include "RooNLLVarNew.h"

--- a/roofit/roofitcore/test/testRooDataHist.cxx
+++ b/roofit/roofitcore/test/testRooDataHist.cxx
@@ -13,8 +13,7 @@
 #include "RooDataSet.h"
 #include "RooRandom.h"
 #include "RooFit/Detail/NormalizationHelpers.h"
-
-#include "../src/RooFitDriver.h"
+#include "RooFit/Evaluator.h"
 
 #include "TH1D.h"
 #include "TH2D.h"
@@ -742,9 +741,9 @@ TEST_P(WeightsTest, VectorizedWeights)
    x.setVal(0.0);
 
    std::unique_ptr<RooAbsReal> clone = RooFit::Detail::compileForNormSet<RooAbsReal>(*absReal, *data.get());
-   ROOT::Experimental::RooFitDriver driver(*clone, RooFit::BatchModeOption::Cpu);
-   driver.setInput(x.GetName(), xVals, false);
-   std::span<const double> weightsGetValues = driver.run();
+   RooFit::Evaluator evaluator(*clone);
+   evaluator.setInput(x.GetName(), xVals, false);
+   std::span<const double> weightsGetValues = evaluator.run();
 
    for (std::size_t i = 0; i < nVals; ++i) {
       EXPECT_NEAR(weightsGetVal[i], weightsGetValues[i], 1e-6);


### PR DESCRIPTION
As explained in 85c5cb4e3f, it was planned to make the RooFitDriver a public class to greatly improve the developer experience when working on the GPU backend of RooFit. Before, it was only possible to use the GPU backend in the likelihood evaluation, and with this commit it can be used from any context.

This makes it possible to run the script listed in the description of PR #13389.

To be more clear in what the new class does, which is purely focusing on the evaluation of computation graphs, it got renamed from RooFitDriver to `RooFit::Evaluator`.