### PR TITLE
[PyROOT][9058] Implement TPython::ExecScript for Python 3

### DIFF
--- a/bindings/tpython/src/TPython.cxx
+++ b/bindings/tpython/src/TPython.cxx
@@ -366,6 +366,7 @@ void TPython::ExecScript(const char *name, int argc, const char **argv)
    // create and set (add progam name) the new command line
    argc += 1;
 #if PY_VERSION_HEX < 0x03000000
+   // This is a legacy implementation for Python 2
    const char **argv2 = new const char *[argc];
    for (int i = 1; i < argc; ++i)
       argv2[i] = argv[i - 1];
@@ -373,17 +374,75 @@ void TPython::ExecScript(const char *name, int argc, const char **argv)
    PySys_SetArgv(argc, const_cast<char **>(argv2));
    delete[] argv2;
 #else
-// TODO: fix this to work like above ...
-   (void)argc;
-   (void)argv;
-#endif
+   // This is a common block for Python 3. We prefer using objects to automatize memory management and not introduce
+   // even more preprocessor branching for deletion at the end of the method.
+   // FUTURE IMPROVEMENT ONCE OLD PYTHON VERSIONS ARE NOT SUPPORTED BY ROOT:
+   // Right now we use C++ objects to automatize memory management. One could use RAAI and the Python memory allocation
+   // API (PEP 445) once some old Python version is deprecated in ROOT. That new feature is available since version 3.4
+   // and the preprocessor branching to also support that would be so complicated to make the code unreadable.
+   std::vector<std::wstring> argv2;
+   argv2.reserve(argc);
+   argv2.emplace_back(name, &name[strlen(name)]);
+
+   for (int i = 1; i < argc; ++i) {
+      auto iarg = argv[i - 1];
+      argv2.emplace_back(iarg, &iarg[strlen(iarg)]);
+   }
+
+#if PY_VERSION_HEX < 0x03080000
+   // Before version 3.8, the code is one simple line
+   wchar_t *argv2_arr[argc];
+   for (int i = 0; i < argc; ++i) {
+      argv2_arr[i] = const_cast<wchar_t *>(argv2[i].c_str());
+   }
+   PySys_SetArgv(argc, argv2_arr);
+
+#else
+   // Here we comply to "PEP 587 – Python Initialization Configuration" to avoid deprecation warnings at compile time.
+   class PyConfigHelperRAAI {
+   public:
+      PyConfigHelperRAAI(const std::vector<std::wstring> &argv2)
+      {
+         PyConfig_InitPythonConfig(&fConfig);
+         fConfig.parse_argv = 1;
+         UpdateArgv(argv2);
+         InitFromConfig();
+      }
+      ~PyConfigHelperRAAI() { PyConfig_Clear(&fConfig); }
+
+   private:
+      void InitFromConfig() { Py_InitializeFromConfig(&fConfig); };
+      void UpdateArgv(const std::vector<std::wstring> &argv2)
+      {
+         auto WideStringListAppendHelper = [](PyWideStringList *wslist, const wchar_t *wcstr) {
+            PyStatus append_status = PyWideStringList_Append(wslist, wcstr);
+            if (PyStatus_IsError(append_status)) {
+               std::wcerr << "Error: could not append element " << wcstr << " to arglist - " << append_status.err_msg
+                          << std::endl;
+            }
+         };
+         WideStringListAppendHelper(&fConfig.argv, Py_GetProgramName());
+         for (const auto &iarg : argv2) {
+            WideStringListAppendHelper(&fConfig.argv, iarg.c_str());
+         }
+      }
+      PyConfig fConfig;
+   };
+
+   PyConfigHelperRAAI pych(argv2);
+
+#endif // of the else branch of PY_VERSION_HEX < 0x03080000
+#endif // PY_VERSION_HEX < 0x03000000
 
    // actual script execution
    PyObject *gbl = PyDict_Copy(gMainDict);
    PyObject *result = // PyRun_FileEx closes fp (b/c of last argument "1")
       PyRun_FileEx(fp, const_cast<char *>(name), Py_file_input, gbl, gbl, 1);
-   if (!result)
+   if (!result) {
+      std::cerr << "An error occurred executing file " << name << std::endl;
       PyErr_Print();
+   }
+
    Py_XDECREF(result);
    Py_DECREF(gbl);
 


### PR DESCRIPTION
Two implementations are provided, i.e. for Python versions older than 3.8, for which PEP 587 is not in force, and newer.

# This Pull request:

## Changes or fixes:
Implements TPython::ExecFile for Python 3

## Checklist:

- [v] tested changes locally
- [] updated the docs (if necessary)

This PR fixes #9058 

