### PR TITLE
[cling][NFC] Cleanup `DeclUnloader`

### DIFF
--- a/interpreter/cling/lib/Interpreter/DeclUnloader.cpp
+++ b/interpreter/cling/lib/Interpreter/DeclUnloader.cpp
@@ -65,7 +65,7 @@ namespace {
       getLink(First).setLatest(Latest);
     }
 #ifdef __clang__
-#pragma clang diagnostic push
+#pragma clang diagnostic pop
 #endif // __clang__
     };
 


### PR DESCRIPTION
This pull request moves helper functions to an anonymous namespace at the beginning of the TU.  **There are no functional changes in this PR**; instead it makes the code more readable.

The follow-up PR, which is the important thing, fixes a number of issues in the handling of instantiation of member functions of templated classes, which should fix https://github.com/root-project/root/issues/10049 and all the issues mentioned there :rocket:.

## Changes or fixes:
- Move helper functions to anonymous namespace at the beginning of the TU
- Fix unmatched `#pragma clang diagnostic push`
- Fix wrong indentation in some parts of the file

## Checklist:
- [x] tested changes locally