### PR TITLE
[RF] Avoid double counting norm integrals in RooAddPdf with BatchMode

### DIFF
--- a/roofit/roofitcore/src/RooAddModel.cxx
+++ b/roofit/roofitcore/src/RooAddModel.cxx
@@ -377,8 +377,7 @@ double RooAddModel::evaluate() const
   return value ;
 }
 
-void RooAddModel::computeBatch(double *output, size_t nEvents,
-                               RooFit::Detail::DataMap const &dataMap) const
+void RooAddModel::computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &dataMap) const
 {
    // Like many other functions in this class, the implementation was copy-pasted from the RooAddPdf
    RooBatchCompute::Config config = dataMap.config(this);
@@ -402,11 +401,8 @@ void RooAddModel::computeBatch(double *output, size_t nEvents,
 
    RooBatchCompute::VarVector pdfs;
    RooBatchCompute::ArgVector coefs;
-   const RooArgSet *nset = nullptr;
    AddCacheElem *cache = getProjCache(nullptr);
-   // We don't sync the coefficient values from the _coefList to the _coefCache
-   // because we have already done it using the dataMap.
-   updateCoefficients(*cache, nset);
+   updateCoefficients(*cache, nullptr);
 
    for (unsigned int pdfNo = 0; pdfNo < _pdfList.size(); ++pdfNo) {
       auto pdf = static_cast<RooAbsPdf *>(&_pdfList[pdfNo]);

--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -526,12 +526,10 @@ void RooAddPdf::computeBatch(double* output, size_t nEvents, RooFit::Detail::Dat
 
   RooBatchCompute::VarVector pdfs;
   RooBatchCompute::ArgVector coefs;
-  auto normAndCache = getNormAndCache(nullptr);
-  const RooArgSet* nset = normAndCache.first;
-  AddCacheElem* cache = normAndCache.second;
+  AddCacheElem* cache = getProjCache(nullptr);
   // We don't sync the coefficient values from the _coefList to the _coefCache
   // because we have already done it using the dataMap.
-  updateCoefficients(*cache, nset, /*syncCoefValues=*/false);
+  updateCoefficients(*cache, nullptr, /*syncCoefValues=*/false);
 
   for (unsigned int pdfNo = 0; pdfNo < _pdfList.size(); ++pdfNo)
   {


### PR DESCRIPTION
If you add components where each component only depends on a subset of the union set of the observables, the RooAddPdf should understand that the component is uniform in the missing observables. This is validated in a new unit test for both the getVal() interface and evaluation with the RooFit::Evaluator.

To make this work, the projection integrals are evaluated for no specific normalization set in `RooAddPdf::computeBatch()` the supplementary normalization terms are already included in `RooAddPdf::compileForNormSet()` and they should not be double counted.

This commit also makes the RooAddPdf tests less verbose by using more the RooWorkspace.