### PR TITLE
Set kMustCleanup bit for all pad primitives when streaming

### DIFF
--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -6583,9 +6583,12 @@ void TPad::Streamer(TBuffer &b)
 
          //Set the kCanDelete bit in all objects in the pad such that when the pad
          //is deleted all objects in the pad are deleted too.
+         //Also set must cleanup bit which normally set for all primitives add to pad,
+         // but may be reset in IO like TH1::Streamer does
          TIter next(fPrimitives);
          while ((obj = next())) {
             obj->SetBit(kCanDelete);
+            obj->SetBit(kMustCleanup);
          }
 
          fModified = kTRUE;


### PR DESCRIPTION
When primitive add to the pad via `TObjectt::AppendPad()` method, 
`kMustCleanup` bit is automatically set for that object. 
But when primitives read from the IO buffer,
TH1::Streamer reset `kMustCleanup` in IO.

This has side effect afterwards, when pad is deleted during ROOT shutdown and when pad has same histogram twice in list of primitives.

Replaces #13506 
