### PR TITLE
[http] control used threads number, limit websocket connections

### DIFF
--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -425,7 +425,7 @@ bool RWebWindowsManager::CreateServer(bool with_http)
             }
          }
 
-         engine.Append(TString::Format("thrds=%d&websocket_timeout=%d", http_thrds, http_wstmout));
+         engine.Append(TString::Format("webgui&thrds=%d&websocket_timeout=%d", http_thrds, http_wstmout));
 
          if (http_maxage >= 0)
             engine.Append(TString::Format("&max_age=%d", http_maxage));

--- a/net/http/src/TCivetweb.h
+++ b/net/http/src/TCivetweb.h
@@ -26,6 +26,7 @@ protected:
    Int_t fNumActiveThreads{0};  ///<! number of active threads - used in request and websocket handling
    std::mutex fMutex;           ///<! mutex to read/write fNumActiveThreads
    TString fTopName;            ///<! name of top item
+   Bool_t fWebGui{kFALSE};      ///<! if server used for webgui
    Bool_t fDebug{kFALSE};       ///<! debug mode
    Bool_t fTerminating{kFALSE}; ///<! server doing shutdown and not react on requests
    Bool_t fOnlySecured{kFALSE}; ///<! if server should run only https protocol
@@ -49,6 +50,8 @@ public:
    Int_t ChangeNumActiveThrerads(int cnt = 0);
 
    const char *GetTopName() const { return fTopName.Data(); }
+
+   Bool_t IsWebGui() const { return fWebGui; }
 
    Bool_t IsDebugMode() const { return fDebug; }
 

--- a/net/http/src/TCivetweb.h
+++ b/net/http/src/TCivetweb.h
@@ -14,12 +14,17 @@
 #include "THttpEngine.h"
 #include "TString.h"
 
+#include <mutex>
+
 #include "../civetweb/civetweb.h"
 
 class TCivetweb : public THttpEngine {
 protected:
    struct mg_context *fCtx{nullptr}; ///<! civetweb context
    struct mg_callbacks fCallbacks;  ///<! call-back table for civetweb webserver
+   Int_t fNumThreads{10};       ///<! number of configured threads
+   Int_t fNumActiveThreads{0};  ///<! number of active threads - used in request and websocket handling
+   std::mutex fMutex;           ///<! mutex to read/write fNumActiveThreads
    TString fTopName;            ///<! name of top item
    Bool_t fDebug{kFALSE};       ///<! debug mode
    Bool_t fTerminating{kFALSE}; ///<! server doing shutdown and not react on requests
@@ -36,6 +41,12 @@ public:
    virtual ~TCivetweb();
 
    Bool_t Create(const char *args) override;
+
+   Int_t GetNumThreads() const { return fNumThreads; }
+
+   Int_t GetNumActiveThreads();
+
+   Int_t ChangeNumActiveThrerads(int cnt = 0);
 
    const char *GetTopName() const { return fTopName.Data(); }
 

--- a/net/http/src/TCivetweb.h
+++ b/net/http/src/TCivetweb.h
@@ -44,7 +44,7 @@ public:
 
    Int_t GetNumThreads() const { return fNumThreads; }
 
-   Int_t GetNumActiveThreads();
+   Int_t GetNumAvailableThreads();
 
    Int_t ChangeNumActiveThrerads(int cnt = 0);
 


### PR DESCRIPTION
civetweb server creates pre-coinfigured number of threads and this number cannot be change once server running.

Each active websocket consumes one thread, where all communication handling is performed. 
To avoid situation that simple http requests fails just while websockets blocked all threads number of
websocket connection will be limited by 90% of configured threads.

Issue warning message from `TCivetweb.cxx`  when websocket connection refused because of threads number like:
```
Error in <TCivetweb::WebSocketHandler>: Only 2 threads are available, reject connection request for win3. Increase WebGui.HttpThreads parameter in rootrc, now it is 7
```

