### PR TITLE
[DF][10484] Finalize actions if an exception occurs during evt loop

### DIFF
--- a/tree/dataframe/test/dataframe_helpers.cxx
+++ b/tree/dataframe/test/dataframe_helpers.cxx
@@ -710,22 +710,24 @@ TEST(RDFHelpers, ProgressHelper_Existence_ST)
 class SimpleActionHelper : public ROOT::Detail::RDF::RActionImpl<SimpleActionHelper> {
 public:
    using Result_t = int;
+
 private:
    std::shared_ptr<Result_t> fValue;
    int &fTestVal;
+
 public:
    static constexpr int fgRefVal = 42;
-   SimpleActionHelper(int &testVal):fValue(new int), fTestVal(testVal) {}
+   SimpleActionHelper(int &testVal) : fValue(new int), fTestVal(testVal) {}
    SimpleActionHelper(SimpleActionHelper &&) = default;
    SimpleActionHelper(const SimpleActionHelper &) = delete;
    std::shared_ptr<int> GetResultPtr() const { return fValue; }
    void Initialize() {}
    void InitTask(TTreeReader *, unsigned int) {}
    template <typename... ColumnTypes>
-   void Exec(unsigned int, ColumnTypes...){}
-   void Finalize() { 
-      fTestVal = SimpleActionHelper::fgRefVal;
-      }
+   void Exec(unsigned int, ColumnTypes...)
+   {
+   }
+   void Finalize() { fTestVal = SimpleActionHelper::fgRefVal; }
    std::string GetActionName() { return "SimpleAction"; }
 };
 

--- a/tree/dataframe/test/dataframe_helpers.cxx
+++ b/tree/dataframe/test/dataframe_helpers.cxx
@@ -463,13 +463,16 @@ TEST(RDFHelpers, GraphRunTimeErrors)
    const std::vector<double> xx = {-0.22}; // smaller size
    const std::vector<double> yy = {1., 2.9};
 
-   auto df =
-      RDataFrame(1).Define("xx", [&] { return xx; }).Define("yy", [&] { return yy; }).Define("x", [] { return .5; });
+   auto GetRDF = [&] {return RDataFrame(1)
+         .Define("yy", [&] { return yy; })
+         .Define("xx", [&] { return xx; })
+         .Define("x", [] { return .5; });
+   };
 
-   auto gr1 = df.Graph<std::vector<double>, std::vector<double>>("xx", "yy"); // still no error since lazy action
-   auto gr2 = df.Graph<double, std::vector<double>>("x", "yy");               // still no error since lazy action
-
+   auto gr1 = GetRDF().Graph<std::vector<double>, std::vector<double>>("xx", "yy"); // still no error since lazy action
    EXPECT_THROW(gr1.GetValue(), std::runtime_error);
+
+   auto gr2 = GetRDF().Graph<double, std::vector<double>>("x", "yy"); // still no error since lazy action
    EXPECT_THROW(gr2.GetValue(), std::runtime_error);
 }
 
@@ -557,20 +560,23 @@ TEST(RDFHelpers, GraphAsymmErrorsRunTimeErrors)
    const Ds eyl = {.8, .7};
    const Ds eyh = {.6, .5};
 
-   auto df = RDataFrame(1)
-                .Define("xx", [&] { return xx; })
-                .Define("yy", [&] { return yy; })
-                .Define("exl", [&] { return exl; })
-                .Define("exh", [&] { return exh; })
-                .Define("eyl", [&] { return eyl; })
-                .Define("eyh", [&] { return eyh; })
-                .Define("x", [] { return 3.14; }); // scalar
+   auto GetRDF = [&] {
+      return RDataFrame(1)
+         .Define("xx", [&] { return xx; })
+         .Define("yy", [&] { return yy; })
+         .Define("exl", [&] { return exl; })
+         .Define("exh", [&] { return exh; })
+         .Define("eyl", [&] { return eyl; })
+         .Define("eyh", [&] { return eyh; })
+         .Define("x", [] { return 3.14; }); // scalar
+   };
 
    // still no error since lazy action
-   auto gr1 = df.GraphAsymmErrors<Ds, Ds, Ds, Ds, Ds, Ds>("xx", "yy", "exl", "exh", "eyl", "eyh");
-   auto gr2 = df.GraphAsymmErrors<Ds, Ds, Ds, Ds, Ds, Ds>("x", "yy", "exl", "exh", "eyl", "eyh");
-
+   auto gr1 = GetRDF().GraphAsymmErrors<Ds, Ds, Ds, Ds, Ds, Ds>("xx", "yy", "exl", "exh", "eyl", "eyh");
    EXPECT_THROW(gr1.GetValue(), std::runtime_error);
+
+   // still no error since lazy action
+   auto gr2 = GetRDF().GraphAsymmErrors<Ds, Ds, Ds, Ds, Ds, Ds>("x", "yy", "exl", "exh", "eyl", "eyh");
    EXPECT_THROW(gr2.GetValue(), std::runtime_error);
 }
 
@@ -698,6 +704,48 @@ TEST(RDFHelpers, ProgressHelper_Existence_ST)
    std::cout.rdbuf(oldCoutStreamBuf);
 
    EXPECT_FALSE(strCout.str().empty());
+}
+
+// A test for #10484
+class SimpleActionHelper : public ROOT::Detail::RDF::RActionImpl<SimpleActionHelper> {
+public:
+   using Result_t = int;
+private:
+   std::shared_ptr<Result_t> fValue;
+   int &fTestVal;
+public:
+   static constexpr int fgRefVal = 42;
+   SimpleActionHelper(int &testVal):fValue(new int), fTestVal(testVal) {}
+   SimpleActionHelper(SimpleActionHelper &&) = default;
+   SimpleActionHelper(const SimpleActionHelper &) = delete;
+   std::shared_ptr<int> GetResultPtr() const { return fValue; }
+   void Initialize() {}
+   void InitTask(TTreeReader *, unsigned int) {}
+   template <typename... ColumnTypes>
+   void Exec(unsigned int, ColumnTypes...){}
+   void Finalize() { 
+      fTestVal = SimpleActionHelper::fgRefVal;
+      }
+   std::string GetActionName() { return "SimpleAction"; }
+};
+
+TEST(RDFHelpers, Cleanup_After_Exception)
+{
+   auto exceptionThrower = [](ULong64_t ievt) {
+      if (ievt == 4) {
+         throw std::invalid_argument("Time to throw.");
+      }
+      return int(0);
+   };
+
+   int testVal = 123;
+   SimpleActionHelper helper(testVal);
+   auto rdf = ROOT::RDataFrame(8).Define("dummy", exceptionThrower, {"rdfentry_"});
+   auto valRes = rdf.Book<int>(std::move(helper), {"dummy"});
+   EXPECT_THROW(valRes.GetValue(), std::invalid_argument)
+      << "An exception should have been thrown during the event loop.";
+   EXPECT_EQ(SimpleActionHelper::fgRefVal, testVal)
+      << "The Finalize method should have changed the value of testVal during the post-exception cleanup." << std::endl;
 }
 
 // The code below is a unit test for a function called `ProgressHelper_Existence_MT` in the `RDFHelpers` class.


### PR DESCRIPTION
Exceptions thrown in an event loop are caught to print a message. This catch block is leveraged to finalize all scheduled actions in order to properly deallocate memory where needed and save the partial results which are obtained.

# This Pull request:
Is work in progress and lacks a test battery
## Changes or fixes:
Allows to finalize actions scheduled in a RDF analysis in case an exception is thrown during the event loop.

## Checklist:

- [V] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #10484

