### PR TITLE
Introduce `TPad::UpdateAsync` method

### DIFF
--- a/README/ReleaseNotes/v630/index.md
+++ b/README/ReleaseNotes/v630/index.md
@@ -256,6 +256,11 @@ Some of these classes are now removed from the public interface:
   File name can include printf qualifier to code pad number. Also allows to store all pads in single PDF
   or single ROOT file. Significantly improves performance when creating many image files using web graphics.
 
+- Introduce `TCanvas::UpdateAsync` method. In case of web-based canvas triggers update of the canvas on the client side,
+  but does not wait that real update is completed. Avoids blocking of caller thread.
+  Have to be used if called from other web-based widget to avoid logical dead-locks.
+  In case of normal canvas just canvas->Update() is performed.
+
 
 ## 3D Graphics Libraries
 

--- a/core/base/inc/TVirtualPad.h
+++ b/core/base/inc/TVirtualPad.h
@@ -242,6 +242,7 @@ public:
    virtual void     ShowGuidelines(TObject *object, const Int_t event, const char mode = 'i', const bool cling = true) = 0;
    virtual TObject *WaitPrimitive(const char *pname="", const char *emode="") = 0;
    virtual void     Update() = 0;
+   virtual void     UpdateAsync() = 0;
    virtual Int_t    UtoAbsPixel(Double_t u) const = 0;
    virtual Int_t    VtoAbsPixel(Double_t v) const = 0;
    virtual Int_t    UtoPixel(Double_t u) const = 0;

--- a/core/gui/inc/TCanvasImp.h
+++ b/core/gui/inc/TCanvasImp.h
@@ -46,7 +46,7 @@ protected:
    virtual Bool_t IsLocked() { return kFALSE; }
 
    virtual Bool_t IsWeb() const { return kFALSE; }
-   virtual Bool_t PerformUpdate() { return kFALSE; }
+   virtual Bool_t PerformUpdate(Bool_t /* async */) { return kFALSE; }
    virtual TVirtualPadPainter *CreatePadPainter() { return nullptr; }
 
 public:

--- a/graf2d/gpad/inc/TCanvas.h
+++ b/graf2d/gpad/inc/TCanvas.h
@@ -220,6 +220,7 @@ public:
    virtual void      ToggleEditor();
    virtual void      ToggleToolTips();
    void              Update() override;
+   void              UpdateAsync() override;
 
    Bool_t              UseGL() const { return fUseGL; }
    void                SetSupportGL(Bool_t support) {fUseGL = support;}

--- a/graf2d/gpad/inc/TPad.h
+++ b/graf2d/gpad/inc/TPad.h
@@ -363,6 +363,8 @@ public:
 
    void              ShowGuidelines(TObject *object, const Int_t event, const char mode = 'i', const bool cling = true) override;
    void              Update() override;
+   void              UpdateAsync() override;
+
    Int_t             UtoAbsPixel(Double_t u) const override { return Int_t(fUtoAbsPixelk + u*fUtoPixel); }
    Int_t             VtoAbsPixel(Double_t v) const override { return Int_t(fVtoAbsPixelk + v*fVtoPixel); }
    Int_t             UtoPixel(Double_t u) const override;

--- a/graf2d/gpad/src/TCanvas.cxx
+++ b/graf2d/gpad/src/TCanvas.cxx
@@ -2508,7 +2508,7 @@ void TCanvas::Update()
 
    fUpdating = kTRUE;
 
-   if (!fCanvasImp->PerformUpdate()) {
+   if (!fCanvasImp->PerformUpdate(kFALSE)) {
 
       if (!IsBatch()) FeedbackMode(kFALSE); // Goto double buffer mode
 
@@ -2520,6 +2520,21 @@ void TCanvas::Update()
    }
 
    fUpdating = kFALSE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Asynchronous pad update.
+/// In case of web-based canvas triggers update of the canvas on the client side,
+/// but does not wait that real update is completed. Avoids blocking of caller thread.
+/// Have to be used if called from other web-based widget to avoid logical dead-locks.
+/// In case of normal canvas just canvas->Update() is performed.
+
+void TCanvas::UpdateAsync()
+{
+   if (IsWeb())
+      fCanvasImp->PerformUpdate(kTRUE);
+   else
+      Update();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -2830,6 +2830,18 @@ void TPad::Update()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Asynchronous pad update.
+/// In case of web-based canvas triggers update of the canvas on the client side,
+/// but does not wait that real update is completed. Avoids blocking of caller thread.
+/// Have to be used if called from other web-based widget to avoid logical dead-locks.
+/// In case of normal canvas just canvas->Update() is performed.
+
+void TPad::UpdateAsync()
+{
+   if (fCanvas) fCanvas->UpdateAsync();
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Get frame.
 
 TFrame *TPad::GetFrame()

--- a/gui/browserv7/src/RBrowserTCanvasWidget.cxx
+++ b/gui/browserv7/src/RBrowserTCanvasWidget.cxx
@@ -218,7 +218,7 @@ public:
       if (Browsable::RProvider::Draw6(pad, obj, drawopt)) {
          fObjects.emplace(pad, std::move(obj));
          pad->Modified();
-         fCanvas->Update();
+         fCanvas->UpdateAsync();
          return true;
       }
 
@@ -228,7 +228,7 @@ public:
    void CheckModified() override
    {
       if (fCanvas->IsModified())
-         fCanvas->Update();
+         fCanvas->UpdateAsync();
    }
 
 };

--- a/gui/fitpanelv7/CMakeLists.txt
+++ b/gui/fitpanelv7/CMakeLists.txt
@@ -25,9 +25,8 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTFitPanelv7
   DEPENDENCIES
     Hist
     Gpad
-    WebGui6
+    ROOTWebDisplay
     ROOTGpadv7
-    ROOTHistDraw
     ROOTHistDraw
   ${EXTRA_DICT_OPTS}
 )

--- a/gui/fitpanelv7/src/RFitPanel.cxx
+++ b/gui/fitpanelv7/src/RFitPanel.cxx
@@ -34,7 +34,6 @@
 #include "TList.h"
 #include "TVirtualPad.h"
 #include "TCanvas.h"
-#include "TWebCanvas.h"
 #include "TDirectory.h"
 #include "TBufferJSON.h"
 #include "Math/Minimizer.h"
@@ -981,15 +980,7 @@ void RFitPanel::DoPadUpdate(TPad *pad)
    if (!pad) return;
 
    pad->Modified();
-
-   auto web = dynamic_cast<TWebCanvas *> (pad->GetCanvas()->GetCanvasImp());
-
-   Bool_t iswebsync = web ? !web->IsAsyncMode() : kFALSE;
-   if (iswebsync) web->SetAsyncMode(kTRUE);
-
-   pad->Update();
-
-   if (iswebsync) web->SetAsyncMode(kFALSE);
+   pad->UpdateAsync();
 }
 
 

--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -118,7 +118,7 @@ protected:
    Bool_t IsLocked() override { return kFALSE; }
 
    Bool_t IsWeb() const override { return kTRUE; }
-   Bool_t PerformUpdate() override;
+   Bool_t PerformUpdate(Bool_t async) override;
    TVirtualPadPainter *CreatePadPainter() override;
 
    UInt_t CalculateColorsHash();

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -1884,7 +1884,7 @@ UInt_t TWebCanvas::GetWindowGeometry(Int_t &x, Int_t &y, UInt_t &w, UInt_t &h)
 /// scan all primitives in the TCanvas and subpads and convert them into
 /// the structure which will be delivered to JSROOT client
 
-Bool_t TWebCanvas::PerformUpdate()
+Bool_t TWebCanvas::PerformUpdate(Bool_t async)
 {
    Bool_t modified = CheckCanvasModified();
 
@@ -1896,7 +1896,7 @@ Bool_t TWebCanvas::PerformUpdate()
    } else {
       CheckDataToSend();
 
-      if (!fProcessingData && !IsAsyncMode())
+      if (!fProcessingData && !IsAsyncMode() && !async)
          WaitWhenCanvasPainted(fCanvVersion);
    }
 


### PR DESCRIPTION
It performs asynchronous canvas update.

In case of web-based canvas triggers update of the canvas
on the client side, but does not wait that real update is completed.
Avoids blocking of caller thread.
Have to be used if called from other web-based widget to avoid logical
dead-locks. In case of normal canvas just canvas->Update() is performed.

Use it in `RFitPanel` and `RBrowser`