### PR TITLE
[PyROOT][RF] Feature to import datasets and modelConfig using JSON I/O and a new tutorial

### DIFF
--- a/bindings/pyroot/pythonizations/test/roofit.py
+++ b/bindings/pyroot/pythonizations/test/roofit.py
@@ -846,6 +846,116 @@ class RooWorkspace_test(unittest.TestCase):
         self.assertEqual(ws["gauss"].getMean(), ws["mean"])
         self.assertEqual(ws["gauss"].getSigma(), ws["sigma"])
 
+    def test_set_item_using_dictionary_histfactory(self):
+        """Build a single-channel HistFactory model by assigning JSON-backed
+        dictionaries to the workspace, analogous to the hf_001.C tutorial.
+        Covers the import of variables, constraints, binned datasets,
+        histfactory distributions and model configs via
+        RooJSONFactoryWSTool::importJSONElement.
+        """
+        ws = ROOT.RooWorkspace()
+
+        # Add the variables to the workspace
+        ws["Lumi"] = {"max": 10.0, "min": 0.0, "value": 1.0}
+        ws["nominalLumi"] = {"max": 2.0, "min": 0.0, "value": 1.0}
+
+        # Add the constraint variable
+        ws["lumiConstraint"] = {
+            "mean": "nominalLumi",
+            "sigma": 0.1,
+            "type": "gaussian_dist",
+            "x": "Lumi",
+        }
+
+        # Add data channels to the workspace
+        axes = [{"max": 2.0, "min": 1.0, "name": "obs_x_channel1", "nbins": 2}]
+        ws["obsData_channel1"] = {"axes": axes, "contents": [122, 112], "type": "binned"}
+        ws["asimovData_channel1"] = {"axes": axes, "contents": [120, 110], "type": "binned"}
+
+        # Specify the model inside the workspace by adding samples with
+        # constraints, datasets and modifiers
+        lumi_modifier = {
+            "constraint_name": "lumiConstraint",
+            "name": "Lumi",
+            "parameter": "Lumi",
+            "type": "normfactor",
+        }
+        staterror_modifier = {"constraint": "Poisson", "name": "staterror", "type": "staterror"}
+
+        def normsys_modifier(name):
+            return {
+                "constraint": "Gauss",
+                "data": {"hi": 1.05, "lo": 0.95},
+                "name": name,
+                "parameter": "alpha_" + name,
+                "type": "normsys",
+            }
+
+        ws["model_channel1"] = {
+            "axes": axes,
+            "samples": [
+                {
+                    "data": {"contents": [100, 0], "errors": [5, 0]},
+                    "modifiers": [lumi_modifier, normsys_modifier("syst2"), staterror_modifier],
+                    "name": "background1",
+                },
+                {
+                    "data": {"contents": [0, 100], "errors": [0, 10]},
+                    "modifiers": [lumi_modifier, normsys_modifier("syst3"), staterror_modifier],
+                    "name": "background2",
+                },
+                {
+                    "data": {"contents": [20, 10]},
+                    "modifiers": [
+                        lumi_modifier,
+                        {"name": "SigXsecOverSM", "parameter": "SigXsecOverSM", "type": "normfactor"},
+                        normsys_modifier("syst1"),
+                    ],
+                    "name": "signal",
+                },
+            ],
+            "type": "histfactory_dist",
+        }
+
+        # Configure the model by specifying the pdf and parameter of interest
+        ws["ModelConfig"] = {"pdfName": "model_channel1", "poi": "SigXsecOverSM"}
+
+        # Check that the variables were imported correctly
+        self.assertAlmostEqual(ws["Lumi"].getVal(), 1.0)
+        self.assertAlmostEqual(ws["Lumi"].getMin(), 0.0)
+        self.assertAlmostEqual(ws["Lumi"].getMax(), 10.0)
+
+        # Check that the constraint pdf was imported correctly
+        lumi_constraint = ws.pdf("lumiConstraint")
+        self.assertTrue(lumi_constraint)
+        self.assertEqual(lumi_constraint.getX(), ws["Lumi"])
+        self.assertEqual(lumi_constraint.getMean(), ws["nominalLumi"])
+
+        # Check that the binned datasets were imported correctly
+        obs_data = ws.data("obsData_channel1")
+        self.assertTrue(obs_data)
+        self.assertEqual(obs_data.numEntries(), 2)
+        self.assertAlmostEqual(obs_data.sumEntries(), 234.0)
+        asimov_data = ws.data("asimovData_channel1")
+        self.assertTrue(asimov_data)
+        self.assertAlmostEqual(asimov_data.sumEntries(), 230.0)
+
+        # Check that the histfactory pdf was imported correctly, together with
+        # the model parameters implied by the modifiers
+        pdf = ws.pdf("model_channel1")
+        self.assertTrue(pdf)
+        params = pdf.getParameters(obs_data.get())
+        for name in ["Lumi", "SigXsecOverSM", "alpha_syst1", "alpha_syst2", "alpha_syst3"]:
+            self.assertIn(name, params)
+
+        # Check that the model config was imported correctly
+        model_config = ws.obj("ModelConfig")
+        self.assertTrue(model_config)
+        self.assertEqual(model_config.GetPdf(), pdf)
+        poi = model_config.GetParametersOfInterest()
+        self.assertEqual(poi.size(), 1)
+        self.assertIn("SigXsecOverSM", poi)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -35,6 +35,7 @@ class Domains;
 namespace RooStats {
 class ModelConfig;
 }
+class RooRealVar;
 
 class RooJSONFactoryWSTool {
 public:
@@ -187,6 +188,8 @@ public:
    {
       return node.get("misc", "ROOT_internal", keys...);
    }
+
+   static void exportAxis(RooFit::Detail::JSONNode &obsNode, RooRealVar const &var);
 
    static void
    exportHisto(RooArgSet const &vars, std::size_t n, double const *contents, RooFit::Detail::JSONNode &output);

--- a/roofit/hs3/src/Domains.cxx
+++ b/roofit/hs3/src/Domains.cxx
@@ -62,15 +62,6 @@ void Domains::populate(RooWorkspace &ws) const
    }
 }
 
-void Domains::readVariable(const char *name, double min, double max)
-{
-   readVariable(name, min, max, defaultDomainName);
-}
-void Domains::readVariable(const char *name, double min, double max, const char *domain)
-{
-   _map[domain].readVariable(name, min, max);
-}
-
 void Domains::readVariable(RooRealVar const &var)
 {
    _map[defaultDomainName].readVariable(var.GetName(), var.getBinning());
@@ -161,19 +152,6 @@ void Domains::ProductDomain::readVariable(const char *name, RooAbsBinning const 
    elem.hasMax = true;
    elem.max = binning.highBound();
    readBinning(elem, binning);
-}
-
-void Domains::ProductDomain::readVariable(const char *name, double min, double max)
-{
-   auto &elem = _map[name];
-
-   elem.hasMin = true;
-   elem.min = min;
-   elem.hasMax = true;
-   elem.max = max;
-   elem.hasNBins = false;
-   elem.nBins = 0;
-   elem.edges.clear();
 }
 
 void Domains::ProductDomain::applyBinning(RooRealVar &var, ProductDomainElement const &elem, const char *name)

--- a/roofit/hs3/src/Domains.h
+++ b/roofit/hs3/src/Domains.h
@@ -34,9 +34,6 @@ namespace Detail {
 
 class Domains {
 public:
-   void readVariable(const char *name, double min, double max, const char *domain);
-   void readVariable(const char *name, double min, double max);
-
    void readVariable(RooRealVar const &);
    void writeVariable(RooRealVar &) const;
 
@@ -51,7 +48,6 @@ public:
    public:
       void readVariable(const RooRealVar &);
       void readVariable(const char *name, RooAbsBinning const &binning);
-      void readVariable(const char *name, double min, double max);
       void writeVariable(RooRealVar &) const;
 
       void readJSON(RooFit::Detail::JSONNode const &);

--- a/roofit/hs3/src/JSONFactories_HistFactory.cxx
+++ b/roofit/hs3/src/JSONFactories_HistFactory.cxx
@@ -46,25 +46,6 @@ using namespace RooStats::HistFactory::Detail::MagicConstants;
 
 namespace {
 
-inline void writeAxis(JSONNode &axis, RooRealVar const &obs)
-{
-   auto &binning = obs.getBinning();
-   if (binning.isUniform()) {
-      axis["nbins"] << obs.numBins();
-      axis["min"] << obs.getMin();
-      axis["max"] << obs.getMax();
-   } else {
-      auto &edges = axis["edges"];
-      edges.set_seq();
-      double val = binning.binLow(0);
-      edges.append_child() << val;
-      for (int i = 0; i < binning.numBins(); ++i) {
-         val = binning.binHigh(i);
-         edges.append_child() << val;
-      }
-   }
-}
-
 double round_prec(double d, int nSig)
 {
    if (d == 0.0)
@@ -1270,11 +1251,7 @@ bool exportChannel(RooJSONFactoryWSTool *tool, const Channel &channel, JSONNode 
       if (!observablesWritten) {
          auto &output = elem["axes"].set_seq();
          for (auto *obs : static_range_cast<RooRealVar *>(*channel.varSet)) {
-            auto &out = output.append_child().set_map();
-            std::string name = obs->GetName();
-            RooJSONFactoryWSTool::testValidName(name, false);
-            out["name"] << name;
-            writeAxis(out, *obs);
+            RooJSONFactoryWSTool::exportAxis(output.append_child().set_map(), *obs);
          }
          observablesWritten = true;
       }

--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -1054,33 +1054,12 @@ public:
       elem["type"] << key();
       RooJSONFactoryWSTool::fillSeq(elem["variables"], pdf->dataVars());
       RooJSONFactoryWSTool::fillSeq(elem["parameters"], pdf->paramList());
-      writeBinningInfo(pdf, elem);
-      return true;
-   }
-
-private:
-   void writeBinningInfo(const ParamHistFunc *pdf, JSONNode &elem) const
-   {
       auto &observablesNode = elem["axes"].set_seq();
       // axes have to be ordered to get consistent bin indices
       for (auto *var : static_range_cast<RooRealVar *>(pdf->dataVars())) {
-         std::string name = var->GetName();
-         RooJSONFactoryWSTool::testValidName(name, false);
-         JSONNode &obsNode = observablesNode.append_child().set_map();
-         obsNode["name"] << name;
-         auto const &binning = var->getBinning();
-         if (binning.isUniform()) {
-            obsNode["min"] << var->getMin();
-            obsNode["max"] << var->getMax();
-            obsNode["nbins"] << var->getBins();
-         } else {
-            auto &edges = obsNode["edges"].set_seq();
-            edges.append_child() << binning.binLow(0);
-            for (int i = 0; i < binning.numBins(); ++i) {
-               edges.append_child() << binning.binHigh(i);
-            }
-         }
+         RooJSONFactoryWSTool::exportAxis(observablesNode.append_child().set_map(), *var);
       }
+      return true;
    }
 };
 

--- a/roofit/hs3/src/JSONIOUtils.cxx
+++ b/roofit/hs3/src/JSONIOUtils.cxx
@@ -15,13 +15,6 @@ bool endsWith(std::string_view str, std::string_view suffix)
    return str.size() >= suffix.size() && 0 == str.compare(str.size() - suffix.size(), suffix.size(), suffix);
 }
 
-std::string removePrefix(std::string_view str, std::string_view prefix)
-{
-   std::string out;
-   out += str;
-   out = out.substr(prefix.length());
-   return out;
-}
 std::string removeSuffix(std::string_view str, std::string_view suffix)
 {
    std::string out;

--- a/roofit/hs3/src/JSONIOUtils.h
+++ b/roofit/hs3/src/JSONIOUtils.h
@@ -6,7 +6,6 @@
 
 bool startsWith(std::string_view str, std::string_view prefix);
 bool endsWith(std::string_view str, std::string_view suffix);
-std::string removePrefix(std::string_view str, std::string_view prefix);
 std::string removeSuffix(std::string_view str, std::string_view suffix);
 std::unique_ptr<RooFit::Detail::JSONTree> varJSONString(const RooFit::Detail::JSONNode &treeRoot);
 

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -2429,17 +2429,43 @@ bool RooJSONFactoryWSTool::importYML(std::string const &filename)
 
 void RooJSONFactoryWSTool::importJSONElement(const std::string &name, const std::string &jsonString)
 {
+   // Create the JSON Tree from the string
    std::unique_ptr<RooFit::Detail::JSONTree> tree = RooFit::Detail::JSONTree::create(jsonString);
    JSONNode &n = tree->rootnode();
+
+   // If the objects containts a parameter of interest, import it as a modelConfig
+   if (n.find("poi")) {
+
+      RooStats::ModelConfig modelConfig{"ModelConfig"};
+      std::string poi = n.find("poi")->val();
+      std::string pdname = n.find("pdfName")->val();
+      modelConfig.SetWS(_workspace);
+      modelConfig.SetPdf(pdname.c_str());
+      modelConfig.SetParametersOfInterest(_workspace.argSet(poi));
+      _workspace.import(modelConfig);
+
+      return;
+   }
+
    n["name"] << name;
 
    bool isVariable = true;
+   bool isData = false;
+   // Check for the type of object, if it doesn't contain a type, it must be a variable
    if (n.find("type")) {
       isVariable = false;
+      std::string elementType = n.find("type")->val();
+      if (elementType == "binned" || elementType == "unbinned") {
+         isData = true;
+      }
    }
 
+   // Import the object to the workspace
    if (isVariable) {
       this->importVariableElement(n);
+   } else if (isData) {
+      auto absData = loadData(n, _workspace);
+      _workspace.import(*absData);
    } else {
       this->importFunction(n, false);
    }

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -143,46 +143,6 @@ bool matches(const RooJSONFactoryWSTool::CombinedData &data, const RooSimultaneo
 }
 
 /**
- * @struct Var
- * @brief Structure to store variable information.
- *
- * This structure represents variable information such as the number of bins, minimum and maximum values,
- * and a vector of binning edges for a variable.
- */
-struct Var {
-   int nbins;                 // Number of bins
-   double min;                // Minimum value
-   double max;                // Maximum value
-   std::vector<double> edges; // Vector of edges
-
-   /**
-    * @brief Constructor for Var.
-    * @param n Number of bins.
-    */
-   Var(int n) : nbins(n), min(0), max(n) {}
-};
-
-void exportAxis(JSONNode &obsNode, RooRealVar const &var)
-{
-   std::string name = var.GetName();
-   RooJSONFactoryWSTool::testValidName(name, false);
-   obsNode["name"] << name;
-
-   auto const &binning = var.getBinning();
-   if (binning.isUniform()) {
-      obsNode["min"] << var.getMin();
-      obsNode["max"] << var.getMax();
-      obsNode["nbins"] << var.getBins();
-   } else {
-      auto &edges = obsNode["edges"].set_seq();
-      edges.append_child() << binning.binLow(0);
-      for (int i = 0; i < binning.numBins(); ++i) {
-         edges.append_child() << binning.binHigh(i);
-      }
-   }
-}
-
-/**
  * @brief Check if a string represents a valid number.
  *
  * This function checks whether the provided string 'str' represents a valid number.
@@ -1412,6 +1372,33 @@ void RooJSONFactoryWSTool::importFunction(const std::string &jsonString, bool im
 }
 
 /**
+ * @brief Export the name and binning of a RooRealVar to a JSONNode.
+ *
+ * @param obsNode The JSONNode to which the axis information will be exported.
+ * @param var The RooRealVar representing the axis to be exported.
+ * @return void
+ */
+void RooJSONFactoryWSTool::exportAxis(JSONNode &obsNode, RooRealVar const &var)
+{
+   std::string name = var.GetName();
+   RooJSONFactoryWSTool::testValidName(name, false);
+   obsNode["name"] << name;
+
+   auto const &binning = var.getBinning();
+   if (binning.isUniform()) {
+      obsNode["min"] << var.getMin();
+      obsNode["max"] << var.getMax();
+      obsNode["nbins"] << var.getBins();
+   } else {
+      auto &edges = obsNode["edges"].set_seq();
+      edges.append_child() << binning.binLow(0);
+      for (int i = 0; i < binning.numBins(); ++i) {
+         edges.append_child() << binning.binHigh(i);
+      }
+   }
+}
+
+/**
  * @brief Export histogram data to a JSONNode.
  *
  * This function exports histogram data, represented by the provided variables and contents, to a JSONNode.
@@ -1428,24 +1415,7 @@ void RooJSONFactoryWSTool::exportHisto(RooArgSet const &vars, std::size_t n, dou
    auto &observablesNode = output["axes"].set_seq();
    // axes have to be ordered to get consistent bin indices
    for (auto *var : static_range_cast<RooRealVar *>(vars)) {
-      std::string name = var->GetName();
-      RooJSONFactoryWSTool::testValidName(name, false);
-      JSONNode &obsNode = observablesNode.append_child().set_map();
-      obsNode["name"] << name;
-      if (var->getBinning().isUniform()) {
-         obsNode["min"] << var->getMin();
-         obsNode["max"] << var->getMax();
-         obsNode["nbins"] << var->getBins();
-      } else {
-         auto &edges = obsNode["edges"];
-         edges.set_seq();
-         double val = var->getBinning().binLow(0);
-         edges.append_child() << val;
-         for (int i = 0; i < var->getBinning().numBins(); ++i) {
-            val = var->getBinning().binHigh(i);
-            edges.append_child() << val;
-         }
-      }
+      exportAxis(observablesNode.append_child().set_map(), *var);
    }
 
    return exportArray(n, contents, output["contents"]);


### PR DESCRIPTION
# This Pull request: 

- Adds the feature to import datasets and modelConfigs to RooWorkspace using the `RooJSONFactoryWSTool`.
- Adds a new Pythonic tutorial for fitting and plotting using single-channel data

## Changes:

- `RooJSONFactoryWSTool` to import binned & unbinned datasets and modelConfigs
-  Adds a `FitModelAndPlot` overload to perform measurement using RooWorkspace
-  A new tutorial `hf101.py`

## Checklist:

- [x] tested changes locally
- [x] updated the docs 

