### PR TITLE
Backport CEF and Arrow fixes [6.28][skip-ci]

### DIFF
--- a/gui/cefdisplay/src/gui_handler.cxx
+++ b/gui/cefdisplay/src/gui_handler.cxx
@@ -273,8 +273,11 @@ public:
 
       return true;
    }
-
+#if CEF_VERSION_MAJOR > 114
+   void GetResponseHeaders(CefRefPtr<CefResponse> response, int64_t &response_length, CefString &redirectUrl) override
+#else
    void GetResponseHeaders(CefRefPtr<CefResponse> response, int64 &response_length, CefString &redirectUrl) override
+#endif
    {
       CEF_REQUIRE_IO_THREAD();
 


### PR DESCRIPTION
Now CEF uses standard types like `int64_t` instead of `int64`

