### PR TITLE
[RF][HS3] RooFormulaVar at syntax bug

### DIFF
--- a/README/ReleaseNotes/v630/index.md
+++ b/README/ReleaseNotes/v630/index.md
@@ -43,6 +43,7 @@ The following people have contributed to this new version:
 - The `RooAbsString` that was only an alias for `RooStringVar` got removed.
 - The `RooDataWeightedAverage` is now deprecated and will be removed in 6.32. It was only supposed to be an implementation detail of RooFits plotting that is now not necessary anymore.
 - The `RooSpan` class was removed and its place in the implementation details of RooFit is now taken by `std::span`.
+- The `RooAbsArg::isCloneOf()` and `RooAbsArg::getCloningAncestors()` member functions were removed because they didn't work (always returned `false` and an empty list respectively)
 
 ## Core Libraries
 

--- a/roofit/histfactory/test/testHistFactory.cxx
+++ b/roofit/histfactory/test/testHistFactory.cxx
@@ -262,7 +262,6 @@ public:
          meas.AddConstantParam("alpha_syst2");
          meas.AddConstantParam("alpha_syst3");
          meas.AddConstantParam("alpha_syst4");
-         meas.AddConstantParam("alpha_SignalShape");
       }
 
       meas.SetExportOnly(true);
@@ -285,7 +284,7 @@ public:
       _systNames.insert("alpha_syst1");
 
       signal.AddNormFactor("SigXsecOverSM", 1, 0, 3);
-      if (makeModelMode != MakeModelMode::Simple) {
+      if (makeModelMode == MakeModelMode::HistoSyst) {
          signal.AddHistoSys("SignalShape", "shapeUnc_sigDo", _inputFile, "", "shapeUnc_sigUp", _inputFile, "");
          _systNames.insert("alpha_SignalShape");
       }
@@ -440,7 +439,7 @@ TEST_P(HFFixture, Evaluation)
       << "Integral over PDF range should be 1.";
 
    // Test that shape uncertainties have an effect:
-   if (makeModelMode != MakeModelMode::Simple) {
+   if (makeModelMode == MakeModelMode::HistoSyst) {
       auto var = ws->var("alpha_SignalShape");
       ASSERT_NE(var, nullptr);
 
@@ -496,7 +495,7 @@ TEST_P(HFFixture, BatchEvaluation)
       << "Integral over PDF range should be 1.";
 
    // Test that shape uncertainties have an effect:
-   if (makeModelMode != MakeModelMode::Simple) {
+   if (makeModelMode == MakeModelMode::HistoSyst) {
       auto var = ws->var("alpha_SignalShape");
       ASSERT_NE(var, nullptr);
 
@@ -743,7 +742,6 @@ TEST_P(HFFixtureFit, Fit)
          checkParam("alpha_syst4", 0., 1.E-2);
          checkParam("gamma_stat_channel1_bin_0", 1.09, 1.E-2); // This should be pulled
          checkParam("gamma_stat_channel1_bin_1", 1., 1.E-2);
-         checkParam("alpha_SignalShape", 0., 1.E-2);
       }
    }
 

--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -415,9 +415,12 @@ public:
       TString expression(pdf->expression());
       for (size_t i = 0; i < pdf->nParameters(); ++i) {
          RooAbsArg *par = pdf->getParameter(i);
-         std::stringstream ss;
-         ss << "x[" << i << "]";
-         expression.ReplaceAll(ss.str().c_str(), par->GetName());
+         std::stringstream ss_1;
+         ss_1 << "x[" << i << "]";
+         std::stringstream ss_2;
+         ss_2 << "@" << i << "";
+         expression.ReplaceAll(ss_1.str().c_str(), par->GetName());
+         expression.ReplaceAll(ss_2.str().c_str(), par->GetName());
       }
       elem["expression"] << expression.Data();
       return true;

--- a/roofit/hs3/test/testRooFitHS3.cxx
+++ b/roofit/hs3/test/testRooFitHS3.cxx
@@ -27,7 +27,7 @@
 namespace {
 
 // If the JSON files should be written out for debugging purpose.
-const bool writeJsonFiles = false;
+const bool writeJsonFiles = true;
 
 // Validate the JSON IO for a given RooAbsReal in a RooWorkspace. The workspace
 // will be written out and read back, and then the values of the old and new
@@ -189,7 +189,20 @@ TEST(RooFitHS3, RooGenericPdf)
 
    // At this point, only basic arithmetic operations with +, -, * and / are
    // defined in the HS3 standard.
-   int status = validate({"x[0, 10]", "c[5]", "a[1.0, 0.1, 10]", "EXPR::genericPdf('a * x + c', {x, a, c})"});
+   int status = validate({"x[0, 10]", "c[5]", "a[1.0, 0.1, 10]", "EXPR::genericPdf1('a * x + c', {x, a, c})"});
+   EXPECT_EQ(status, 0);
+
+   // Test that it also works with index notation builtin to TFormula
+   status = validate({"x[0, 10]", "c[5]", "a[1.0, 0.1, 10]", "EXPR::genericPdf2('x[1] * x[0] + x[2]', {x, a, c})"});
+   EXPECT_EQ(status, 0);
+
+   // Test for ordinal notation
+   status = validate({"x[0, 10]", "c[5]", "a[1.0, 0.1, 10]", "EXPR::genericPdf3('@1 * @0 + @2', {x, a, c})"});
+   EXPECT_EQ(status, 0);
+
+   // Test for variable names with numbers and extra whitespaces in it
+   status = validate({"m_001_mu[1.0, 0.1, 10]", "x[0, 5]", "m_003_mu[5]",
+                      "EXPR::genericPdf4('@0   *  2  *      @1 +   @2', {m_001_mu, x, m_003_mu})"});
    EXPECT_EQ(status, 0);
 }
 

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -696,7 +696,7 @@ private:
   // Debug stuff
   static bool _verboseDirty ; // Static flag controlling verbose messaging for dirty state changes
   static bool _inhibitDirty ; // Static flag controlling global inhibit of dirty state propagation
-  bool _deleteWatch ; //! Delete watch flag
+  bool _deleteWatch = false; //! Delete watch flag
 
   bool inhibitDirty() const ;
 
@@ -712,28 +712,28 @@ private:
  protected:
 
 
-  mutable bool _valueDirty ;  // Flag set if value needs recalculating because input values modified
-  mutable bool _shapeDirty ;  // Flag set if value needs recalculating because input shapes modified
+  mutable bool _valueDirty = true;  // Flag set if value needs recalculating because input values modified
+  mutable bool _shapeDirty = true;  // Flag set if value needs recalculating because input shapes modified
 
-  mutable OperMode _operMode ; // Dirty state propagation mode
+  mutable OperMode _operMode = Auto; // Dirty state propagation mode
   mutable bool _fast = false; // Allow fast access mode in getVal() and proxies
 
   // Owned components
-  RooArgSet* _ownedComponents ; //! Set of owned component
+  RooArgSet* _ownedComponents = nullptr; //! Set of owned component
 
-  mutable bool _prohibitServerRedirect ; //! Prohibit server redirects -- Debugging tool
+  mutable bool _prohibitServerRedirect = false; //! Prohibit server redirects -- Debugging tool
 
   mutable RooExpensiveObjectCache* _eocache{nullptr}; //! Pointer to global cache manager for any expensive components created by this object
 
-  mutable const TNamed * _namePtr ; //! De-duplicated name pointer. This will be equal for all objects with the same name.
-  bool _isConstant ; //! Cached isConstant status
+  mutable const TNamed * _namePtr = nullptr; //! De-duplicated name pointer. This will be equal for all objects with the same name.
+  bool _isConstant = false; //! Cached isConstant status
 
-  mutable bool _localNoInhibitDirty ; //! Prevent 'AlwaysDirty' mode for this node
+  mutable bool _localNoInhibitDirty = false; //! Prevent 'AlwaysDirty' mode for this node
 
 /*   RooArgSet _leafNodeCache ; //! Cached leaf nodes */
 /*   RooArgSet _branchNodeCache //! Cached branch nodes     */
 
-  mutable RooWorkspace *_myws; //! In which workspace do I live, if any
+  mutable RooWorkspace *_myws = nullptr; //! In which workspace do I live, if any
 
   std::size_t _dataToken = std::numeric_limits<std::size_t>::max(); //! Set by the RooFitDriver for this arg to retrieve its result in the run context
 

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -16,17 +16,18 @@
 #ifndef ROO_ABS_ARG
 #define ROO_ABS_ARG
 
-#include "TNamed.h"
-#include "TObjArray.h"
-#include "TRefArray.h"
-#include "RooPrintable.h"
-#include "RooSTLRefCountList.h"
-#include "RooAbsCache.h"
-#include "RooNameReg.h"
-#include "RooLinkedListIter.h"
+#include <RooAbsCache.h>
 #include <RooFit/Config.h>
 #include <RooFit/Detail/NormalizationHelpers.h>
+#include <RooLinkedListIter.h>
+#include <RooNameReg.h>
+#include <RooPrintable.h>
+#include <RooSTLRefCountList.h>
 #include <RooStringView.h>
+
+#include <TNamed.h>
+#include <TObjArray.h>
+#include <TRefArray.h>
 
 #include <deque>
 #include <iostream>
@@ -99,7 +100,6 @@ public:
   virtual bool isDerived() const {
     return true ;
   }
-  bool isCloneOf(const RooAbsArg& other) const ;
 
   /// Check whether this object depends on values from an element in the `serverList`.
   ///
@@ -364,7 +364,6 @@ public:
   inline bool isConstant() const {
     return _isConstant ; //getAttribute("Constant") ;
   }
-  RooLinkedList getCloningAncestors() const ;
 
   // Sorting
   Int_t Compare(const TObject* other) const override ;

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -66,37 +66,33 @@ for single nodes.
 
 */
 
-#include "TBuffer.h"
-#include "TClass.h"
-#include "TVirtualStreamerInfo.h"
-#include "strlcpy.h"
+#include <RooAbsArg.h>
 
-#include "RooSecondMoment.h"
-#include "RooWorkspace.h"
+#include <RooAbsCategoryLValue.h>
+#include <RooAbsData.h>
+#include <RooAbsDataStore.h>
+#include <RooArgProxy.h>
+#include <RooArgSet.h>
+#include <RooConstVar.h>
+#include <RooExpensiveObjectCache.h>
+#include <RooHelpers.h>
+#include <RooListProxy.h>
+#include <RooMsgService.h>
+#include <RooRealIntegral.h>
+#include <RooResolutionModel.h>
+#include <RooSetProxy.h>
+#include <RooTrace.h>
+#include <RooTreeDataStore.h>
+#include <RooVectorDataStore.h>
+#include <RooWorkspace.h>
 
-#include "RooMsgService.h"
-#include "RooAbsArg.h"
-#include "RooArgSet.h"
-#include "RooArgProxy.h"
-#include "RooSetProxy.h"
-#include "RooListProxy.h"
-#include "RooAbsData.h"
-#include "RooAbsCategoryLValue.h"
-#include "RooTrace.h"
-#include "RooRealIntegral.h"
-#include "RooConstVar.h"
-#include "RooExpensiveObjectCache.h"
-#include "RooAbsDataStore.h"
-#include "RooResolutionModel.h"
-#include "RooVectorDataStore.h"
-#include "RooTreeDataStore.h"
-#include "RooHelpers.h"
+#include <TBuffer.h>
+#include <TClass.h>
+#include <TVirtualStreamerInfo.h>
 
 #include <algorithm>
 #include <cstring>
 #include <fstream>
-#include <iostream>
-#include <memory>
 #include <sstream>
 
 using namespace std;
@@ -218,15 +214,6 @@ void RooAbsArg::setDirtyInhibit(bool flag)
 void RooAbsArg::verboseDirty(bool flag)
 {
   _verboseDirty = flag ;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Check if this object was created as a clone of 'other'
-
-bool RooAbsArg::isCloneOf(const RooAbsArg& other) const
-{
-  return (getAttribute(Form("CloneOf(%zx)",(size_t)&other)) ||
-     other.getAttribute(Form("CloneOf(%zx)",(size_t)this))) ;
 }
 
 
@@ -2167,30 +2154,6 @@ RooAbsCache* RooAbsArg::getCache(Int_t index) const
 RooFit::OwningPtr<RooArgSet> RooAbsArg::getVariables(bool stripDisconnected) const
 {
   return getParameters(RooArgSet(),stripDisconnected) ;
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Return ancestors in cloning chain of this RooAbsArg. NOTE: Returned pointers
-/// are not guaranteed to be 'live', so do not dereference without proper caution
-
-RooLinkedList RooAbsArg::getCloningAncestors() const
-{
-  RooLinkedList retVal ;
-
-  set<string>::const_iterator iter= _boolAttrib.begin() ;
-  while(iter != _boolAttrib.end()) {
-    if (TString(*iter).BeginsWith("CloneOf(")) {
-      char buf[128] ;
-      strlcpy(buf,iter->c_str(),128) ;
-      strtok(buf,"(") ;
-      char* ptrToken = strtok(nullptr,")") ;
-      RooAbsArg* ptr = (RooAbsArg*) strtoll(ptrToken,nullptr,16) ;
-      retVal.Add(ptr) ;
-    }
-  }
-
-  return retVal ;
 }
 
 


### PR DESCRIPTION
# This Pull request:

Fixes a problem where RooFormulaVar instances using the `@1`, `@2` syntax were not properly exported.

## Changes or fixes:

Variables referenced by `@N` in the expression of RooFormulaVar or RooGenericPdf are now replaced by the variable names upon export.

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

