### PR TITLE
[RF] Improve the implementation of the RooBatchCompute CUDA version

### DIFF
--- a/roofit/batchcompute/src/Batches.h
+++ b/roofit/batchcompute/src/Batches.h
@@ -67,24 +67,19 @@ public:
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 class Batches {
-private:
+public:
 #ifdef __CUDACC__
    // In the GPU case, we used fixed-size buffers to pass around input arrays by value.
    Batch _arrays[maxParams];
    double _extraArgs[maxExtraArgs];
 #else
-   std::vector<Batch> _arrays;
-   double *const _extraArgs = nullptr;
+   Batch *_arrays;
+   double *_extraArgs = nullptr;
 #endif // #ifdef __CUDACC__
    std::size_t _nEvents = 0;
    std::size_t _nBatches = 0;
    std::size_t _nExtraArgs = 0;
-
-public:
    RestrictArr _output = nullptr;
-
-   Batches(RestrictArr output, std::size_t nEvents, const VarVector &vars, ArgVector &extraArgs,
-           double *buffer = nullptr);
 
    __roodevice__ std::size_t getNEvents() const { return _nEvents; }
    __roodevice__ std::size_t getNExtraArgs() const { return _nExtraArgs; }

--- a/roofit/batchcompute/src/Batches.h
+++ b/roofit/batchcompute/src/Batches.h
@@ -29,23 +29,16 @@ so that they can contain data for every kind of compute function.
 
 namespace RooBatchCompute {
 
-#ifdef __CUDACC__
-// In the CPU case we use std::vector instead of fixed size arrays to pass
-// around data, so no maximum size variables are necessary.
-constexpr std::size_t maxParams = 8;
-constexpr std::size_t maxExtraArgs = 16;
-#endif // #ifdef __CUDACC__
 constexpr std::size_t bufferSize = 64;
 
 namespace RF_ARCH {
 
 class Batch {
-private:
+public:
    double _scalar = 0;
    const double *__restrict _array = nullptr;
    bool _isVector = false;
 
-public:
    Batch() = default;
    inline Batch(InputArr array, bool isVector) : _scalar{array[0]}, _array{array}, _isVector{isVector} {}
 
@@ -68,14 +61,8 @@ public:
 
 class Batches {
 public:
-#ifdef __CUDACC__
-   // In the GPU case, we used fixed-size buffers to pass around input arrays by value.
-   Batch _arrays[maxParams];
-   double _extraArgs[maxExtraArgs];
-#else
-   Batch *_arrays;
+   Batch *_arrays = nullptr;
    double *_extraArgs = nullptr;
-#endif // #ifdef __CUDACC__
    std::size_t _nEvents = 0;
    std::size_t _nBatches = 0;
    std::size_t _nExtraArgs = 0;

--- a/roofit/batchcompute/src/Batches.h
+++ b/roofit/batchcompute/src/Batches.h
@@ -86,16 +86,6 @@ public:
    Batches(RestrictArr output, std::size_t nEvents, const VarVector &vars, ArgVector &extraArgs,
            double *buffer = nullptr);
 
-#ifdef __CUDACC__
-#else
-   // As we don't pass around Batches by value in the CPU case, delete copying
-   // and moving so it's not done accidentally.
-   Batches(const Batches &) = delete;
-   Batches &operator=(const Batches &) = delete;
-   Batches(Batches &&) = delete;
-   Batches &operator=(Batches &&) = delete;
-#endif // #ifdef __CUDACC__
-
    __roodevice__ std::size_t getNEvents() const { return _nEvents; }
    __roodevice__ std::size_t getNExtraArgs() const { return _nExtraArgs; }
    __roodevice__ double extraArg(std::size_t i) const { return _extraArgs[i]; }
@@ -110,13 +100,10 @@ public:
    }
 }; // end class Batches
 
-#ifdef __CUDACC__
-// In the GPU case, we have to pass the Batches object to the compute functions by value.
-using BatchesHandle = Batches;
-#else
+// Defines the actual argument type of the compute funciton.
 using BatchesHandle = Batches &;
-#endif // #ifdef __CUDACC__
 
 } // End namespace RF_ARCH
 } // end namespace RooBatchCompute
+
 #endif // #ifdef ROOFIT_BATCHCOMPUTE_BATCHES_H

--- a/roofit/batchcompute/src/Batches.h
+++ b/roofit/batchcompute/src/Batches.h
@@ -35,27 +35,25 @@ namespace RF_ARCH {
 
 class Batch {
 public:
-   double _scalar = 0;
    const double *__restrict _array = nullptr;
    bool _isVector = false;
 
    Batch() = default;
-   inline Batch(InputArr array, bool isVector) : _scalar{array[0]}, _array{array}, _isVector{isVector} {}
+   inline Batch(InputArr array, bool isVector) : _array{array}, _isVector{isVector} {}
 
    __roodevice__ constexpr bool isItVector() const { return _isVector; }
-   inline void set(double scalar, InputArr array, bool isVector)
+   inline void set(InputArr array, bool isVector)
    {
-      _scalar = scalar;
       _array = array;
       _isVector = isVector;
    }
    inline void advance(std::size_t _nEvents) { _array += _isVector * _nEvents; }
 #ifdef __CUDACC__
-   __roodevice__ constexpr double operator[](std::size_t i) const noexcept { return _isVector ? _array[i] : _scalar; }
+   __roodevice__ constexpr double operator[](std::size_t i) const noexcept { return _isVector ? _array[i] : _array[0]; }
 #else
    constexpr double operator[](std::size_t i) const noexcept { return _array[i]; }
 #endif // #ifdef __CUDACC__
-};     // end class Batch
+};
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -80,7 +78,7 @@ public:
          _arrays[i].advance(nEvents);
       _output += nEvents;
    }
-}; // end class Batches
+};
 
 // Defines the actual argument type of the compute funciton.
 using BatchesHandle = Batches &;

--- a/roofit/batchcompute/src/RooBatchCompute.cxx
+++ b/roofit/batchcompute/src/RooBatchCompute.cxx
@@ -39,6 +39,38 @@ This file contains the code for cpu computations using the RooBatchCompute libra
 namespace RooBatchCompute {
 namespace RF_ARCH {
 
+namespace {
+
+void fillBatches(Batches &batches, RestrictArr output, size_t nEvents, std::size_t nBatches, ArgVector &extraArgs)
+{
+   batches._extraArgs = extraArgs.data();
+   batches._nEvents = nEvents;
+   batches._nBatches = nBatches;
+   batches._nExtraArgs = extraArgs.size();
+   batches._output = output;
+}
+
+void fillArrays(std::vector<Batch> &arrays, const VarVector &vars, double *buffer)
+{
+
+   arrays.resize(vars.size());
+   for (size_t i = 0; i < vars.size(); i++) {
+      const std::span<const double> &span = vars[i];
+      if (span.empty()) {
+         std::stringstream ss;
+         ss << "The span number " << i << " passed to Batches::Batches() is empty!";
+         throw std::runtime_error(ss.str());
+      } else if (span.size() > 1)
+         arrays[i].set(span.data()[0], span.data(), true);
+      else {
+         std::fill_n(&buffer[i * bufferSize], bufferSize, span.data()[0]);
+         arrays[i].set(span.data()[0], &buffer[i * bufferSize], false);
+      }
+   }
+}
+
+} // namespace
+
 std::vector<void (*)(BatchesHandle)> getFunctions();
 
 /// This class overrides some RooBatchComputeInterface functions, for the
@@ -78,7 +110,7 @@ public:
    \param nEvents The number of events to be processed.
    \param vars A std::vector containing pointers to the variables involved in the computation.
    \param extraArgs An optional std::vector containing extra double values that may participate in the computation. **/
-   void compute(Config const&, Computer computer, RestrictArr output, size_t nEvents, const VarVector &vars,
+   void compute(Config const &, Computer computer, RestrictArr output, size_t nEvents, const VarVector &vars,
                 ArgVector &extraArgs) override
    {
       static std::vector<double> buffer;
@@ -96,7 +128,11 @@ public:
          auto task = [&](std::size_t idx) -> int {
             // Fill a std::vector<Batches> with the same object and with ~nEvents/nThreads
             // Then advance every object but the first to split the work between threads
-            Batches batches(output, nEventsPerThread, vars, extraArgs, buffer.data());
+            Batches batches;
+            std::vector<Batch> arrays;
+            fillBatches(batches, output, nEventsPerThread, vars.size(), extraArgs);
+            fillArrays(arrays, vars, buffer.data());
+            batches._arrays = arrays.data();
             batches.advance(batches.getNEvents() * idx);
 
             // Set the number of events of the last Batches object as the remaining events
@@ -124,7 +160,11 @@ public:
       } else {
          // Fill a std::vector<Batches> with the same object and with ~nEvents/nThreads
          // Then advance every object but the first to split the work between threads
-         Batches batches(output, nEvents, vars, extraArgs, buffer.data());
+         Batches batches;
+         std::vector<Batch> arrays;
+         fillBatches(batches, output, nEvents, vars.size(), extraArgs);
+         fillArrays(arrays, vars, buffer.data());
+         batches._arrays = arrays.data();
 
          std::size_t events = batches.getNEvents();
          batches.setNEvents(bufferSize);
@@ -138,8 +178,8 @@ public:
       }
    }
    /// Return the sum of an input array
-   double reduceSum(Config const&, InputArr input, size_t n) override;
-   ReduceNLLOutput reduceNLL(Config const&, std::span<const double> probas, std::span<const double> weightSpan,
+   double reduceSum(Config const &, InputArr input, size_t n) override;
+   ReduceNLLOutput reduceNLL(Config const &, std::span<const double> probas, std::span<const double> weightSpan,
                              std::span<const double> weights, double weightSum,
                              std::span<const double> binVolumes) override;
 }; // End class RooBatchComputeClass
@@ -167,12 +207,12 @@ inline std::pair<double, double> getLog(double prob, ReduceNLLOutput &out)
 
 } // namespace
 
-double RooBatchComputeClass::reduceSum(Config const&, InputArr input, size_t n)
+double RooBatchComputeClass::reduceSum(Config const &, InputArr input, size_t n)
 {
    return ROOT::Math::KahanSum<double, 4u>::Accumulate(input, input + n).Sum();
 }
 
-ReduceNLLOutput RooBatchComputeClass::reduceNLL(Config const&, std::span<const double> probas,
+ReduceNLLOutput RooBatchComputeClass::reduceNLL(Config const &, std::span<const double> probas,
                                                 std::span<const double> weightSpan, std::span<const double> weights,
                                                 double weightSum, std::span<const double> binVolumes)
 {
@@ -210,38 +250,6 @@ ReduceNLLOutput RooBatchComputeClass::reduceNLL(Config const&, std::span<const d
 
 /// Static object to trigger the constructor which overwrites the dispatch pointer.
 static RooBatchComputeClass computeObj;
-
-/** Construct a Batches object
-\param output The array where the computation results are stored.
-\param nEvents The number of events to be processed.
-\param vars A std::vector containing pointers to the variables involved in the computation.
-\param extraArgs An optional std::vector containing extra double values that may participate in the computation.
-\param buffer A 2D array that is used as a buffer for scalar variables.
-For every scalar parameter a buffer (one row of the buffer) is filled with copies of the scalar
-value, so that it behaves as a batch and facilitates auto-vectorization. The Batches object can be
-passed by value to a compute function to perform efficient computations. **/
-Batches::Batches(RestrictArr output, size_t nEvents, const VarVector &vars, ArgVector &extraArgs, double *buffer)
-   : _extraArgs{extraArgs.data()},
-     _nEvents(nEvents),
-     _nBatches(vars.size()),
-     _nExtraArgs(extraArgs.size()),
-     _output(output)
-{
-   _arrays.resize(vars.size());
-   for (size_t i = 0; i < vars.size(); i++) {
-      const std::span<const double> &span = vars[i];
-      if (span.empty()) {
-         std::stringstream ss;
-         ss << "The span number " << i << " passed to Batches::Batches() is empty!";
-         throw std::runtime_error(ss.str());
-      } else if (span.size() > 1)
-         _arrays[i].set(span.data()[0], span.data(), true);
-      else {
-         std::fill_n(&buffer[i * bufferSize], bufferSize, span.data()[0]);
-         _arrays[i].set(span.data()[0], &buffer[i * bufferSize], false);
-      }
-   }
-}
 
 } // End namespace RF_ARCH
 } // End namespace RooBatchCompute

--- a/roofit/batchcompute/src/RooBatchCompute.cxx
+++ b/roofit/batchcompute/src/RooBatchCompute.cxx
@@ -61,10 +61,10 @@ void fillArrays(std::vector<Batch> &arrays, const VarVector &vars, double *buffe
          ss << "The span number " << i << " passed to Batches::Batches() is empty!";
          throw std::runtime_error(ss.str());
       } else if (span.size() > 1)
-         arrays[i].set(span.data()[0], span.data(), true);
+         arrays[i].set(span.data(), true);
       else {
          std::fill_n(&buffer[i * bufferSize], bufferSize, span.data()[0]);
-         arrays[i].set(span.data()[0], &buffer[i * bufferSize], false);
+         arrays[i].set(&buffer[i * bufferSize], false);
       }
    }
 }


### PR DESCRIPTION
These changes achieve two things:

   1. Performance improvement of CUDA backend by factor two by better organizing the copies from host to device
   2. Avoid the hardcoded maximum number of input variables for the compute function, which was a problem for RooAddPdfs with many components.

More detail in the commit descriptions.

Here are the reproduced CHEP 2023 plots with this PR:

![benchRooFitBackends](https://github.com/root-project/root/assets/6578603/785828ac-5265-449a-833f-ff9ea018c649)




The older benchmark results can be found in this CHEP presentation:
https://indico.jlab.org/event/459/contributions/11570/attachments/9440/13688/roofit_heterogeneous_chep_2023_with_transitions.pdf
