### PR TITLE
Make TNetXNGFile::Close() reentrant

### DIFF
--- a/net/netxng/src/TNetXNGFile.cxx
+++ b/net/netxng/src/TNetXNGFile.cxx
@@ -322,6 +322,8 @@ void TNetXNGFile::Close(const Option_t */*option*/)
 {
    TFile::Close();
 
+   if (!fFile) return;
+
    XrdCl::XRootDStatus status = fFile->Close();
    if (!status.IsOK()) {
       Error("Close", "%s", status.ToStr().c_str());


### PR DESCRIPTION
Check if fFile pointer still available

Fixes #13503 