### PR TITLE
[HS3][RF] fixed ordering bug in datasets

### DIFF
--- a/roofit/histfactory/inc/RooStats/HistFactory/HistoToWorkspaceFactoryFast.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/HistoToWorkspaceFactoryFast.h
@@ -57,10 +57,10 @@ namespace RooStats{
                       RooWorkspace* ws_single,
                       Measurement& measurement );
 
-      RooWorkspace* MakeSingleChannelModel( Measurement& measurement, Channel& channel );
-      RooWorkspace*  MakeCombinedModel(std::vector<std::string>, std::vector<std::unique_ptr<RooWorkspace>>&);
+      RooFit::OwningPtr<RooWorkspace> MakeSingleChannelModel( Measurement& measurement, Channel& channel );
+      RooFit::OwningPtr<RooWorkspace>  MakeCombinedModel(std::vector<std::string>, std::vector<std::unique_ptr<RooWorkspace>>&);
 
-      static RooWorkspace* MakeCombinedModel( Measurement& measurement );
+      static RooFit::OwningPtr<RooWorkspace> MakeCombinedModel( Measurement& measurement );
       static void PrintCovarianceMatrix(RooFitResult* result, RooArgSet* params,
                std::string filename);
 
@@ -68,21 +68,21 @@ namespace RooStats{
 
     protected:
 
-       void AddConstraintTerms(RooWorkspace* proto, Measurement& measurement, std::string prefix, std::string interpName,
+       void AddConstraintTerms(RooWorkspace& proto, Measurement& measurement, std::string prefix, std::string interpName,
                std::vector<OverallSys>& systList,
                std::vector<std::string>& likelihoodTermNames,
                std::vector<std::string>& totSystTermNames);
 
-      std::unique_ptr<RooProduct> CreateNormFactor(RooWorkspace* proto, std::string& channel,
+      std::unique_ptr<RooProduct> CreateNormFactor(RooWorkspace& proto, std::string& channel,
             std::string& sigmaEpsilon, Sample& sample, bool doRatio);
 
-      RooWorkspace* MakeSingleChannelWorkspace(Measurement& measurement, Channel& channel);
+      std::unique_ptr<RooWorkspace> MakeSingleChannelWorkspace(Measurement& measurement, Channel& channel);
 
-      void MakeTotalExpected(RooWorkspace* proto, const std::string& totName,
+      void MakeTotalExpected(RooWorkspace& proto, const std::string& totName,
               const std::vector<RooProduct*>& sampleScaleFactors,
               std::vector<std::vector<RooAbsArg*>>&  sampleHistFuncs) const;
 
-      RooHistFunc* MakeExpectedHistFunc(const TH1* hist, RooWorkspace* proto, std::string prefix,
+      RooHistFunc* MakeExpectedHistFunc(const TH1* hist, RooWorkspace& proto, std::string prefix,
           const RooArgList& observables) const;
 
       std::unique_ptr<TH1> MakeScaledUncertaintyHist(const std::string& Name,
@@ -90,7 +90,7 @@ namespace RooStats{
 
       TH1* MakeAbsolUncertaintyHist( const std::string& Name, const TH1* Hist );
 
-      RooArgList createStatConstraintTerms( RooWorkspace* proto,
+      RooArgList createStatConstraintTerms( RooWorkspace& proto,
                    std::vector<std::string>& constraintTerms,
                    ParamHistFunc& paramHist, const TH1* uncertHist,
                    Constraint::Type type, double minSigma );
@@ -114,7 +114,7 @@ namespace RooStats{
       std::vector<std::string> fPreprocessFunctions;
       const Configuration fCfg;
 
-      RooArgList createObservables(const TH1 *hist, RooWorkspace *proto) const;
+      RooArgList createObservables(const TH1 *hist, RooWorkspace &proto) const;
 
       ClassDefOverride(RooStats::HistFactory::HistoToWorkspaceFactoryFast,3)
     };

--- a/roofit/histfactory/inc/RooStats/HistFactory/MakeModelAndMeasurementsFast.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/MakeModelAndMeasurementsFast.h
@@ -17,7 +17,7 @@ class TFile;
 namespace RooStats{
   namespace HistFactory{
 
-    RooWorkspace* MakeModelAndMeasurementFast(
+      RooFit::OwningPtr<RooWorkspace> MakeModelAndMeasurementFast(
             RooStats::HistFactory::Measurement& measurement,
             HistoToWorkspaceFactoryFast::Configuration const& cfg={}
     );

--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -166,7 +166,7 @@ namespace HistFactory{
 
     // Create a SnapShot of the nominal values
     std::string SnapShotName = "NominalParamValues";
-    ws_single->saveSnapshot(SnapShotName.c_str(), ws_single->allVars());
+    ws_single->saveSnapshot(SnapShotName, ws_single->allVars());
 
     for( unsigned int i=0; i<measurement.GetAsimovDatasets().size(); ++i) {
 
@@ -329,7 +329,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
     RooHistFunc histFunc(prefix.c_str(),"",observables,histDHist,0);
 
     proto->import(histFunc, RecycleConflictNodes());
-    auto histFuncInWS = static_cast<RooHistFunc*>(proto->arg(prefix.c_str()));
+    auto histFuncInWS = static_cast<RooHistFunc*>(proto->arg(prefix));
 
     return histFuncInWS;
   }
@@ -390,8 +390,8 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
       std::string str = prefix + "_" + std::to_string(j);
 
       const HistoSys& histoSys = histoSysList.at(j);
-      auto lowDHist = std::make_unique<RooDataHist>((str+"lowDHist").c_str(),"",obsList, histoSys.GetHistoLow());
-      auto highDHist = std::make_unique<RooDataHist>((str+"highDHist").c_str(),"",obsList, histoSys.GetHistoHigh());
+      auto lowDHist = std::make_unique<RooDataHist>(str+"lowDHist","",obsList, histoSys.GetHistoLow());
+      auto highDHist = std::make_unique<RooDataHist>(str+"highDHist","",obsList, histoSys.GetHistoHigh());
       lowSet.addOwned(std::make_unique<RooHistFunc>((str+"low").c_str(),"",obsList,std::move(lowDHist),0));
       highSet.addOwned(std::make_unique<RooHistFunc>((str+"high").c_str(),"",obsList,std::move(highDHist),0));
     }
@@ -407,7 +407,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
 
     proto->import(interp, RecycleConflictNodes()); // individual params have already been imported in first loop of this function
 
-    return proto->arg(prefix.c_str());
+    return proto->arg(prefix);
   }
 
   }
@@ -422,7 +422,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
 
 
     string overallNorm_times_sigmaEpsilon = sample.GetName() + "_" + channel + "_scaleFactors";
-    auto sigEps = proto->arg(sigmaEpsilon.c_str());
+    auto sigEps = proto->arg(sigmaEpsilon);
     assert(sigEps);
     auto normFactor = std::make_unique<RooProduct>(overallNorm_times_sigmaEpsilon.c_str(), overallNorm_times_sigmaEpsilon.c_str(), RooArgList(*sigEps));
 
@@ -453,7 +453,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
 
 
       for (const auto& name : prodNames) {
-        auto arg = proto->arg(name.c_str());
+        auto arg = proto->arg(name);
         assert(arg);
         normFactor->addTerm(arg);
       }
@@ -507,18 +507,18 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
          }
          double tauVal = 1./(relerr*relerr);
          double sqtau = 1./relerr;
-         RooAbsArg * beta = proto->factory(TString::Format("beta_%s[1,0,10]",name) );
+         RooAbsArg * beta = proto->factory(TString::Format("beta_%s[1,0,10]",name).Data() );
          // the global observable (y_s)
-         RooAbsArg * yvar = proto->factory(TString::Format("nom_%s[%f,0,10]",beta->GetName(),tauVal)) ;
+         RooAbsArg * yvar = proto->factory(TString::Format("nom_%s[%f,0,10]",beta->GetName(),tauVal).Data()) ;
          // the rate of the gamma distribution (theta)
-         RooAbsArg * theta = proto->factory(TString::Format("theta_%s[%f]",name,1./tauVal));
+         RooAbsArg * theta = proto->factory(TString::Format("theta_%s[%f]",name,1./tauVal).Data());
          // find alpha as function of beta
-         RooAbsArg* alphaOfBeta = proto->factory(TString::Format("PolyVar::alphaOfBeta_%s(beta_%s,{%f,%f})",name,name,-sqtau,sqtau));
+         RooAbsArg* alphaOfBeta = proto->factory(TString::Format("PolyVar::alphaOfBeta_%s(beta_%s,{%f,%f})",name,name,-sqtau,sqtau).Data());
 
          // add now the constraint itself  Gamma_beta_constraint(beta, y+1, tau, 0 )
          // build the gamma parameter k = as y_s + 1
-         RooAbsArg * kappa = proto->factory(TString::Format("sum::k_%s(%s,1.)",name,yvar->GetName()) );
-         RooAbsArg * gamma = proto->factory(TString::Format("Gamma::%sConstraint(%s, %s, %s, 0.0)",beta->GetName(),beta->GetName(), kappa->GetName(), theta->GetName() ) );
+         RooAbsArg * kappa = proto->factory(TString::Format("sum::k_%s(%s,1.)",name,yvar->GetName()).Data());
+         RooAbsArg * gamma = proto->factory(TString::Format("Gamma::%sConstraint(%s, %s, %s, 0.0)",beta->GetName(),beta->GetName(), kappa->GetName(), theta->GetName() ).Data() );
          if (RooMsgService::instance().isActive(static_cast<TObject*>(nullptr), RooFit::HistFactory, RooFit::DEBUG)) {
            alphaOfBeta->Print("t");
            gamma->Print("t");
@@ -551,16 +551,16 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
             double relerr = meas.GetLogNormSyst().find(sys.GetName() )->second;
             double tauVal = 1./relerr;
             std::string tauName = "tau_" + sys.GetName();
-            proto->factory(TString::Format("%s[%f]",tauName.c_str(),tauVal ) );
+            proto->factory(TString::Format("%s[%f]",tauName.c_str(),tauVal ).Data());
             double kappaVal = 1. + relerr;
             std::string kappaName = "kappa_" + sys.GetName();
-            proto->factory(TString::Format("%s[%f]",kappaName.c_str(),kappaVal ) );
+            proto->factory(TString::Format("%s[%f]",kappaName.c_str(),kappaVal ).Data());
             const char * alphaName = alpha->GetName();
 
             std::string alphaOfBetaName = "alphaOfBeta_" + sys.GetName();
             RooAbsArg * alphaOfBeta = proto->factory(TString::Format("expr::%s('%s*(pow(%s,%s)-1.)',%s,%s,%s)",alphaOfBetaName.c_str(),
                                                                      tauName.c_str(),kappaName.c_str(),alphaName,
-                                                                     tauName.c_str(),kappaName.c_str(),alphaName ) );
+                                                                     tauName.c_str(),kappaName.c_str(),alphaName ).Data());
 
             cxcoutI(HistFactory) << "Added a log-normal constraint for " << name << std::endl;
             if (RooMsgService::instance().isActive(static_cast<TObject*>(nullptr), RooFit::HistFactory, RooFit::DEBUG))
@@ -621,7 +621,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
     const std::string binWidthFunctionName = totName + "_binWidth";
     RooBinWidthFunction binWidth(binWidthFunctionName.c_str(), "Divide by bin width to obtain probability density", *firstHistFunc, true);
     proto->import(binWidth);
-    auto binWidthWS = proto->function(binWidthFunctionName.c_str());
+    auto binWidthWS = proto->function(binWidthFunctionName);
     assert(binWidthWS);
 
     // Loop through samples and create products of their functions:
@@ -649,7 +649,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
 
         RooProduct shapeProduct(name.c_str(), thisSampleHistFuncs.front()->GetTitle(), RooArgSet(thisSampleHistFuncs.begin(), thisSampleHistFuncs.end()));
         proto->import(shapeProduct, RecycleConflictNodes());
-        shapeList.add(*proto->function(name.c_str()));
+        shapeList.add(*proto->function(name));
       }
     }
 
@@ -951,7 +951,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
           // Next, try to get the common ParamHistFunc (it may have been
           // created by another sample in this channel)
           // or create it if it doesn't yet exist:
-          ParamHistFunc* paramHist = dynamic_cast<ParamHistFunc*>( proto->function(statFuncName.c_str()) );
+          ParamHistFunc* paramHist = dynamic_cast<ParamHistFunc*>( proto->function(statFuncName) );
           if( paramHist == nullptr ) {
 
             // Get a RooArgSet of the observables:
@@ -977,7 +977,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
 
             proto->import( statUncertFunc, RecycleConflictNodes() );
 
-            paramHist = (ParamHistFunc*) proto->function( statFuncName.c_str() );
+            paramHist = (ParamHistFunc*) proto->function( statFuncName );
           }
 
           // apply stat function to sample
@@ -1005,7 +1005,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
           for(ShapeFactor& shapeFactor : sample.GetShapeFactorList()) {
 
             std::string funcName = channel_name + "_" + shapeFactor.GetName() + "_shapeFactor";
-            ParamHistFunc* paramHist = (ParamHistFunc*) proto->function( funcName.c_str() );
+            ParamHistFunc* paramHist = (ParamHistFunc*) proto->function( funcName );
             if( paramHist == nullptr ) {
 
               RooArgList theObservables;
@@ -1044,7 +1044,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
               }
 
               proto->import( shapeFactorFunc, RecycleConflictNodes() );
-              paramHist = (ParamHistFunc*) proto->function( funcName.c_str() );
+              paramHist = (ParamHistFunc*) proto->function( funcName );
 
             } // End: Create ShapeFactor ParamHistFunc
 
@@ -1085,7 +1085,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
 
             std::string funcName = channel_name + "_" + shapeSys.GetName() + "_ShapeSys";
             ShapeSysNames.push_back( funcName );
-            ParamHistFunc* paramHist = (ParamHistFunc*) proto->function( funcName.c_str() );
+            ParamHistFunc* paramHist = (ParamHistFunc*) proto->function( funcName );
             if( paramHist == nullptr ) {
 
               //std::string funcParams = "gamma_" + it->shapeFactorName;
@@ -1107,7 +1107,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
                   theObservables, shapeFactorParams );
 
               proto->import( shapeFactorFunc, RecycleConflictNodes() );
-              paramHist = (ParamHistFunc*) proto->function( funcName.c_str() );
+              paramHist = (ParamHistFunc*) proto->function( funcName );
 
             } // End: Create ShapeFactor ParamHistFunc
 
@@ -1190,7 +1190,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
 
       // Using this TH1* of fractinal stat errors,
       // create a set of constraint terms:
-      ParamHistFunc* chanStatUncertFunc = (ParamHistFunc*) proto->function( statFuncName.c_str() );
+      ParamHistFunc* chanStatUncertFunc = (ParamHistFunc*) proto->function( statFuncName );
       cxcoutI(HistFactory) << "About to create Constraint Terms from: "
           << chanStatUncertFunc->GetName()
           << " params: " << chanStatUncertFunc->paramList()
@@ -1240,7 +1240,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
     //////////////////////////////////////
     // final proto model
     for(unsigned int i=0; i<constraintTermNames.size(); ++i){
-      RooAbsArg* proto_arg = (proto->arg(constraintTermNames[i].c_str()));
+      RooAbsArg* proto_arg = (proto->arg(constraintTermNames[i]));
       if( proto_arg==nullptr ) {
         cxcoutF(HistFactory) << "Error: Cannot find arg set: " << constraintTermNames.at(i)
             << " in workspace: " << proto->GetName() << std::endl;
@@ -1250,7 +1250,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
       //  constraintTerms.add(* proto_arg(proto->arg(constraintTermNames[i].c_str())) );
     }
     for(unsigned int i=0; i<likelihoodTermNames.size(); ++i){
-      RooAbsArg* proto_arg = (proto->arg(likelihoodTermNames[i].c_str()));
+      RooAbsArg* proto_arg = (proto->arg(likelihoodTermNames[i]));
       if( proto_arg==nullptr ) {
         cxcoutF(HistFactory) << "Error: Cannot find arg set: " << likelihoodTermNames.at(i)
             << " in workspace: " << proto->GetName() << std::endl;
@@ -1340,7 +1340,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
       }
 
       // THis works and is natural, but the memory size of the simultaneous dataset grows exponentially with channels
-      RooDataSet dataset{dataName.c_str(), "", *proto->set("observables"), RooFit::WeightVar("weightVar")};
+      RooDataSet dataset{dataName, "", *proto->set("observables"), RooFit::WeightVar("weightVar")};
       ConfigureHistFactoryDataset( dataset, *mnominal, *proto, fObsNameVec );
       proto->import(dataset);
 

--- a/roofit/histfactory/src/MakeModelAndMeasurementsFast.cxx
+++ b/roofit/histfactory/src/MakeModelAndMeasurementsFast.cxx
@@ -417,7 +417,7 @@ void RooStats::HistFactory::FitModel(RooWorkspace * combined, std::string data_n
       return;
     }
 
-    RooAbsData* simData = combined->data(data_name.c_str());
+    RooAbsData* simData = combined->data(data_name);
     if(!simData){
       cxcoutEHF << "no data " << data_name << " exiting" << std::endl;
       return;

--- a/roofit/histfactory/src/ParamHistFunc.cxx
+++ b/roofit/histfactory/src/ParamHistFunc.cxx
@@ -478,10 +478,10 @@ RooArgList ParamHistFunc::createParamSet(const std::string& Prefix, Int_t numBin
     VarNameStream << Prefix << "_bin_" << i;
     std::string VarName = VarNameStream.str();
 
-    RooRealVar* gamma = new RooRealVar( VarName.c_str(), VarName.c_str(),
-               gamma_nominal, gamma_min, gamma_max );
+    auto gamma = std::make_unique<RooRealVar>(VarName.c_str(), VarName.c_str(),
+               gamma_nominal, gamma_min, gamma_max);
     gamma->setConstant( false );
-    paramSet.add( *gamma );
+    paramSet.addOwned(std::move(gamma));
 
   }
 
@@ -664,7 +664,7 @@ Int_t ParamHistFunc::getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& anal
   cache = new CacheElem ;
 
   // Store cache element
-  Int_t code = _normIntMgr.setObj(normSet,&analVars,(RooAbsCacheElement*)cache,nullptr) ;
+  Int_t code = _normIntMgr.setObj(normSet,&analVars,cache,nullptr) ;
 
   return code+1 ;
 

--- a/roofit/histfactory/test/testHistFactory.cxx
+++ b/roofit/histfactory/test/testHistFactory.cxx
@@ -322,7 +322,7 @@ public:
       meas.CollectHistograms();
 
       // Now, create the measurement
-      ws.reset(MakeModelAndMeasurementFast(meas));
+      ws = std::unique_ptr<RooWorkspace>(MakeModelAndMeasurementFast(meas));
 
       EXPECT_TRUE(hijackW.str().empty()) << "Warnings logged for HistFactory:\n" << hijackW.str();
    }

--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -116,7 +116,7 @@ public:
    template <class Obj_t, typename... Args_t>
    Obj_t &wsEmplace(RooStringView name, Args_t &&...args)
    {
-      return wsImport(Obj_t(name, name, std::forward<Args_t>(args)...));
+      return wsImport(Obj_t(name.c_str(), name.c_str(), std::forward<Args_t>(args)...));
    }
 
    [[noreturn]] static void error(const char *s);

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -757,7 +757,7 @@ void combineDatasets(const JSONNode &rootnode, std::vector<std::unique_ptr<RooAb
          indexCat.defineType(labels[iChannel], indices[iChannel]);
       }
 
-      auto combined = std::make_unique<RooDataSet>(combinedName.c_str(), combinedName.c_str(), allVars,
+      auto combined = std::make_unique<RooDataSet>(combinedName, combinedName, allVars,
                                                    RooFit::Import(dsMap), RooFit::Index(indexCat));
       datas.emplace_back(std::move(combined));
    }
@@ -1510,7 +1510,7 @@ RooJSONFactoryWSTool::readBinnedData(const JSONNode &n, const std::string &name,
       errMsg << "inconsistent bin numbers: contents=" << contents.num_children() << ", bins=" << bins.size();
       RooJSONFactoryWSTool::error(errMsg.str());
    }
-   auto dh = std::make_unique<RooDataHist>(name.c_str(), name.c_str(), vars);
+   auto dh = std::make_unique<RooDataHist>(name, name, vars);
    std::vector<double> contentVals;
    contentVals.reserve(contents.num_children());
    for (auto const &cont : contents.children()) {

--- a/roofit/multiprocess/test/utils.h
+++ b/roofit/multiprocess/test/utils.h
@@ -77,7 +77,7 @@ generate_ND_gaussian_pdf_nll(RooWorkspace &w, unsigned int n, unsigned long N_ev
       {
          std::ostringstream os;
          os << "x" << ix;
-         obs_set.add(*w.arg(os.str().c_str()));
+         obs_set.add(*w.arg(os.str()));
       }
    }
 
@@ -94,7 +94,7 @@ generate_ND_gaussian_pdf_nll(RooWorkspace &w, unsigned int n, unsigned long N_ev
       RooRealVar a(os.str().c_str(), os2.str().c_str(), N_events / 10, 0., 10 * N_events);
       w.import(a);
       // gather in count_set
-      count_set.add(*w.arg(os.str().c_str()));
+      count_set.add(*w.arg(os.str()));
    }
    // ... and for the uniform background components
    for (unsigned ix = 0; ix < n; ++ix) {
@@ -104,7 +104,7 @@ generate_ND_gaussian_pdf_nll(RooWorkspace &w, unsigned int n, unsigned long N_ev
       RooRealVar a(os.str().c_str(), os2.str().c_str(), N_events / 10, 0., 10 * N_events);
       w.import(a);
       // gather in count_set
-      count_set.add(*w.arg(os.str().c_str()));
+      count_set.add(*w.arg(os.str()));
    }
 
    RooAddPdf *sum = new RooAddPdf("sum", "gaussians+uniforms", pdf_set, count_set);
@@ -120,12 +120,12 @@ generate_ND_gaussian_pdf_nll(RooWorkspace &w, unsigned int n, unsigned long N_ev
       {
          std::ostringstream os;
          os << "m" << ix;
-         dynamic_cast<RooRealVar *>(w.arg(os.str().c_str()))->setVal(RooRandom::randomGenerator()->Gaus(0, 2));
+         dynamic_cast<RooRealVar *>(w.arg(os.str()))->setVal(RooRandom::randomGenerator()->Gaus(0, 2));
       }
       {
          std::ostringstream os;
          os << "s" << ix;
-         dynamic_cast<RooRealVar *>(w.arg(os.str().c_str()))
+         dynamic_cast<RooRealVar *>(w.arg(os.str()))
             ->setVal(0.1 + std::abs(RooRandom::randomGenerator()->Gaus(0, 2)));
       }
    }
@@ -139,12 +139,12 @@ generate_ND_gaussian_pdf_nll(RooWorkspace &w, unsigned int n, unsigned long N_ev
       {
          std::ostringstream os;
          os << "m" << ix;
-         all_values->add(*w.arg(os.str().c_str()));
+         all_values->add(*w.arg(os.str()));
       }
       {
          std::ostringstream os;
          os << "s" << ix;
-         all_values->add(*w.arg(os.str().c_str()));
+         all_values->add(*w.arg(os.str()));
       }
    }
 

--- a/roofit/roofit/src/RooLagrangianMorphFunc.cxx
+++ b/roofit/roofit/src/RooLagrangianMorphFunc.cxx
@@ -805,9 +805,9 @@ void collectHistograms(const char *name, TDirectory *file, std::map<std::string,
          RooArgSet vars;
          vars.add(var);
 
-         auto dh = std::make_unique<RooDataHist>(histname, histname, vars, hist.get());
+         auto dh = std::make_unique<RooDataHist>(histname.Data(), histname.Data(), vars, hist.get());
          // add it to the list
-         auto hf = std::make_unique<RooHistFunc>(funcname, funcname, var, std::move(dh));
+         auto hf = std::make_unique<RooHistFunc>(funcname.Data(), funcname.Data(), var, std::move(dh));
          int idx = physics.getSize();
          list_hf[sample] = idx;
          physics.addOwned(std::move(hf));
@@ -3078,7 +3078,7 @@ std::string LMIFace::create(RooFactoryWSTool &ft, const char * /*typeName*/, con
          for (const auto &subarg : subargs) {
             std::vector<std::string> parts = ROOT::Split(subarg, "=");
             if (parts.size() == 2) {
-               ft.ws().arg(parts[0].c_str())->setAttribute("NewPhysics", atoi(parts[1].c_str()));
+               ft.ws().arg(parts[0])->setAttribute("NewPhysics", atoi(parts[1].c_str()));
             } else
                throw std::string(Form("%s::create() ERROR: unknown token %s encountered, check input provided for %s",
                                       instanceName, subarg.c_str(), args[i].c_str()));

--- a/roofit/roofit/src/RooParamHistFunc.cxx
+++ b/roofit/roofit/src/RooParamHistFunc.cxx
@@ -246,9 +246,8 @@ Int_t RooParamHistFunc::getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& a
                   const RooArgSet* /*normSet*/, const char* /*rangeName*/) const
 {
   // Simplest scenario, integrate over all dependents
-  RooAbsCollection *allVarsCommon = allVars.selectCommon(_x) ;
-  bool intAllObs = (allVarsCommon->getSize()==_x.getSize()) ;
-  delete allVarsCommon ;
+  std::unique_ptr<RooAbsCollection> allVarsCommon{allVars.selectCommon(_x)};
+  bool intAllObs = (allVarsCommon->size()==_x.size()) ;
   if (intAllObs && matchArgs(allVars,analVars,_x)) {
     return 1 ;
   }

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -265,7 +265,8 @@ private:
   void initializeAsymErrArrays() const;
   VarInfo const& getVarInfo();
 
-  static std::unique_ptr<RooAbsDataStore> makeDefaultDataStore(const char* name, const char* title, RooArgSet const& vars);
+  static std::unique_ptr<RooAbsDataStore>
+  makeDefaultDataStore(RooStringView name, RooStringView title, RooArgSet const &vars);
 
   VarInfo _varInfo; ///<!
   std::vector<double> _interpolationBuffer; ///<! Buffer to contain values used for weight interpolation

--- a/roofit/roofitcore/inc/RooStringView.h
+++ b/roofit/roofitcore/inc/RooStringView.h
@@ -19,7 +19,7 @@
 #include <string>
 
 /// The RooStringView is a wrapper around a C-syle string that can also be
-/// constructed from a `std::string` or a Tstring. As such, it serves as a
+/// constructed from a `std::string` or a TString. As such, it serves as a
 /// drop-in replacement for `const char*` in public RooFit interfaces, keeping
 /// the possibility to pass a C-style string without copying but also accepting
 /// a `std::string`.
@@ -31,6 +31,7 @@ public:
    RooStringView(std::string const &str) : _cstr{str.c_str()} {}
    // If the string is a temporary, we have to store it ourselves, otherwise the C-style string would be invalid.
    RooStringView(std::string &&str) : _strp{std::make_shared<std::string>(std::move(str))}, _cstr{_strp->c_str()} {}
+   const char * c_str() const { return _cstr; }
    operator const char *() { return _cstr; }
    operator std::string_view() { return _cstr; }
 

--- a/roofit/roofitcore/src/ModelConfig.cxx
+++ b/roofit/roofitcore/src/ModelConfig.cxx
@@ -237,7 +237,7 @@ void ModelConfig::SetSnapshot(const RooArgSet &set)
    if (!fSnapshotName.empty())
       fSnapshotName += "_";
    fSnapshotName += "snapshot";
-   GetWS()->saveSnapshot(fSnapshotName.c_str(), set, true); // import also the given parameter values
+   GetWS()->saveSnapshot(fSnapshotName, set, true); // import also the given parameter values
    DefineSetInWS(fSnapshotName.c_str(), set);
 }
 
@@ -253,9 +253,9 @@ const RooArgSet *ModelConfig::GetSnapshot() const
       return nullptr;
    // calling loadSnapshot will also copy the current parameter values in the workspaces
    // since we do not want to change the model parameters - we restore the previous ones
-   if (!GetWS()->set(fSnapshotName.c_str()))
+   if (!GetWS()->set(fSnapshotName))
       return nullptr;
-   RooArgSet snapshotVars(*GetWS()->set(fSnapshotName.c_str()));
+   RooArgSet snapshotVars(*GetWS()->set(fSnapshotName));
    if (snapshotVars.empty())
       return nullptr;
    // make my snapshot which will contain a copy of the snapshot variables

--- a/roofit/roofitcore/src/RooAbsStudy.cxx
+++ b/roofit/roofitcore/src/RooAbsStudy.cxx
@@ -81,7 +81,7 @@ void RooAbsStudy::registerSummaryOutput(const RooArgSet& allVars, const RooArgSe
 
   std::string name = std::string(GetName()) + "_summary_data";
   std::string title = std::string(GetTitle()) + " Summary Data";
-  _summaryData = new RooDataSet(name.c_str(),title.c_str(),allVars,RooFit::StoreError(varsWithError),RooFit::StoreAsymError(varsWithAsymError)) ;
+  _summaryData = new RooDataSet(name,title,allVars,RooFit::StoreError(varsWithError),RooFit::StoreAsymError(varsWithAsymError)) ;
 }
 
 

--- a/roofit/roofitcore/src/RooCustomizer.cxx
+++ b/roofit/roofitcore/src/RooCustomizer.cxx
@@ -683,7 +683,7 @@ std::string CustIFace::create(RooFactoryWSTool& ft, const char* typeName, const 
   }
 
   // Check that first arg exists as RooAbsArg
-  RooAbsArg* arg = ft.ws().arg(args[0].c_str()) ;
+  RooAbsArg* arg = ft.ws().arg(args[0]) ;
   if (!arg) {
     throw string(Form("RooCustomizer::CustIFace::create() ERROR: input RooAbsArg %s does not exist",args[0].c_str())) ;
   }

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -88,11 +88,12 @@ RooDataHist::RooDataHist()
 }
 
 
-std::unique_ptr<RooAbsDataStore> RooDataHist::makeDefaultDataStore(const char* name, const char* title, RooArgSet const& vars)
+std::unique_ptr<RooAbsDataStore>
+RooDataHist::makeDefaultDataStore(RooStringView name, RooStringView title, RooArgSet const &vars)
 {
-  return RooAbsData::defaultStorageType == RooAbsData::Tree
-      ? static_cast<std::unique_ptr<RooAbsDataStore>>(std::make_unique<RooTreeDataStore>(name, title, vars))
-      : static_cast<std::unique_ptr<RooAbsDataStore>>(std::make_unique<RooVectorDataStore>(name, title, vars));
+   return RooAbsData::defaultStorageType == RooAbsData::Tree
+             ? static_cast<std::unique_ptr<RooAbsDataStore>>(std::make_unique<RooTreeDataStore>(name, title, vars))
+             : static_cast<std::unique_ptr<RooAbsDataStore>>(std::make_unique<RooVectorDataStore>(name, title, vars));
 }
 
 

--- a/roofit/roofitcore/src/RooFactoryWSTool.cxx
+++ b/roofit/roofitcore/src/RooFactoryWSTool.cxx
@@ -890,7 +890,7 @@ RooAbsArg* RooFactoryWSTool::process(const char* expr)
     ws().commitTransaction() ;
   }
 
-  return !out.empty() ? ws().arg(out.c_str()) : nullptr ;
+  return !out.empty() ? ws().arg(out) : nullptr ;
 }
 
 
@@ -1107,7 +1107,7 @@ std::string RooFactoryWSTool::processSingleExpression(const char* arg)
    while(true) {
      autoname = Form("gobj%d",globCounter) ;
      globCounter++ ;
-     if (!ws().arg(autoname.c_str())) {
+     if (!ws().arg(autoname)) {
        break ;
      }
    }

--- a/roofit/roofitcore/src/RooGenFitStudy.cxx
+++ b/roofit/roofitcore/src/RooGenFitStudy.cxx
@@ -94,7 +94,7 @@ bool RooGenFitStudy::attach(RooWorkspace& w)
 {
   bool ret = false ;
 
-  RooAbsPdf* pdf = w.pdf(_genPdfName.c_str()) ;
+  RooAbsPdf* pdf = w.pdf(_genPdfName) ;
   if (pdf) {
     _genPdf = pdf ;
   } else {
@@ -108,7 +108,7 @@ bool RooGenFitStudy::attach(RooWorkspace& w)
     ret = true ;
   }
 
-  pdf = w.pdf(_fitPdfName.c_str()) ;
+  pdf = w.pdf(_fitPdfName) ;
   if (pdf) {
     _fitPdf = pdf ;
   } else {

--- a/roofit/roofitcore/src/RooHistFunc.cxx
+++ b/roofit/roofitcore/src/RooHistFunc.cxx
@@ -466,7 +466,7 @@ bool RooHistFunc::importWorkspaceHook(RooWorkspace& ws)
           coutE(ObjectHandling) << " RooHistPdf::importWorkspaceHook(" << GetName() << ") unable to import clone of underlying RooDataHist with unique name " << uniqueName << ", abort" << std::endl ;
           return true ;
         }
-        _dataHist = (RooDataHist*) ws.embeddedData(uniqueName.c_str()) ;
+        _dataHist = (RooDataHist*) ws.embeddedData(uniqueName) ;
       }
 
     } else {
@@ -478,7 +478,7 @@ bool RooHistFunc::importWorkspaceHook(RooWorkspace& ws)
         coutE(ObjectHandling) << " RooHistPdf::importWorkspaceHook(" << GetName() << ") unable to import clone of underlying RooDataHist with unique name " << uniqueName << ", abort" << std::endl ;
         return true ;
       }
-      _dataHist = static_cast<RooDataHist*>(ws.embeddedData(uniqueName.c_str()));
+      _dataHist = static_cast<RooDataHist*>(ws.embeddedData(uniqueName));
 
     }
     return false ;

--- a/roofit/roofitcore/src/RooHistPdf.cxx
+++ b/roofit/roofitcore/src/RooHistPdf.cxx
@@ -638,7 +638,7 @@ bool RooHistPdf::importWorkspaceHook(RooWorkspace& ws)
      coutE(ObjectHandling) << " RooHistPdf::importWorkspaceHook(" << GetName() << ") unable to import clone of underlying RooDataHist with unique name " << uniqueName << ", abort" << std::endl ;
      return true ;
    }
-   _dataHist = (RooDataHist*) ws.embeddedData(uniqueName.c_str()) ;
+   _dataHist = (RooDataHist*) ws.embeddedData(uniqueName) ;
       }
 
     } else {
@@ -650,7 +650,7 @@ bool RooHistPdf::importWorkspaceHook(RooWorkspace& ws)
    coutE(ObjectHandling) << " RooHistPdf::importWorkspaceHook(" << GetName() << ") unable to import clone of underlying RooDataHist with unique name " << uniqueName << ", abort" << std::endl ;
    return true ;
       }
-      _dataHist = static_cast<RooDataHist*>(ws.embeddedData(uniqueName.c_str()));
+      _dataHist = static_cast<RooDataHist*>(ws.embeddedData(uniqueName));
 
     }
     return false ;

--- a/roofit/roofitcore/src/RooMCStudy.cxx
+++ b/roofit/roofitcore/src/RooMCStudy.cxx
@@ -263,7 +263,7 @@ RooMCStudy::RooMCStudy(const RooAbsPdf& model, const RooArgSet& observables,
     fpdName= "fitParData_" + std::string(_fitModel->GetName()) + "_" + std::string(_genModel->GetName());
   }
 
-  _fitParData = std::make_unique<RooDataSet>(fpdName.c_str(),"Fit Parameters DataSet",tmp2);
+  _fitParData = std::make_unique<RooDataSet>(fpdName,"Fit Parameters DataSet",tmp2);
   tmp2.setAttribAll("StoreError",false) ;
   tmp2.setAttribAll("StoreAsymError",false) ;
 

--- a/roofit/roofitcore/src/RooSimGenContext.cxx
+++ b/roofit/roofitcore/src/RooSimGenContext.cxx
@@ -208,7 +208,7 @@ RooDataSet* RooSimGenContext::createDataSet(const char* name, const char* title,
       std::unique_ptr<RooArgSet> sliceObs{slicePdf->getObservables(obs)};
       std::string sliceName = Form("%s_slice_%s", name, nameIdx.first.c_str());
       std::string sliceTitle = Form("%s (index slice %s)", title, nameIdx.first.c_str());
-      dmap[nameIdx.first] = new RooDataSet(sliceName.c_str(),sliceTitle.c_str(),*sliceObs);
+      dmap[nameIdx.first] = new RooDataSet(sliceName,sliceTitle,*sliceObs);
     }
     _protoData = new RooDataSet(name, title, obs, Index((RooCategory&)*_idxCat), Link(dmap), OwnLinked()) ;
   }

--- a/roofit/roofitcore/src/RooSimWSTool.cxx
+++ b/roofit/roofitcore/src/RooSimWSTool.cxx
@@ -262,7 +262,7 @@ std::unique_ptr<RooSimWSTool::ObjBuildConfig> RooSimWSTool::validateConfig(Build
       RooArgSet splitCatSet ;
       list<string>::iterator catiter ;
       for (catiter = pariter->second.first.begin() ; catiter!=pariter->second.first.end() ; ++catiter) {
-   RooAbsCategory* cat = _ws->catfunc(catiter->c_str()) ;
+   RooAbsCategory* cat = _ws->catfunc(*catiter) ;
    if (!cat) {
      oocoutE(nullptr, ObjectHandling) << "RooSimWSTool::build() ERROR: associated workspace " << _ws->GetName()
             << " does not contain a category named " << catiter->c_str()
@@ -453,7 +453,7 @@ RooSimultaneous* RooSimWSTool::executeBuild(const char* simPdfName, ObjBuildConf
       string splitName = makeSplitName(splitCatSetTmp) ;
 
       // If composite split object does not exist yet, create it now
-      RooAbsCategory* splitCat = _ws->catfunc(splitName.c_str()) ;
+      RooAbsCategory* splitCat = _ws->catfunc(splitName) ;
       if (!splitCat) {
    auto splitCatOwner = std::make_unique<RooMultiCategory>(splitName.c_str(),splitName.c_str(),splitCatSetTmp);
    splitCat = splitCatOwner.get();
@@ -481,15 +481,13 @@ RooSimultaneous* RooSimWSTool::executeBuild(const char* simPdfName, ObjBuildConf
      if (splitIter->second.second == typeName) continue ;
 
      // Construct name of split leaf
-     TString splitLeafName(splitIter->first->GetName()) ;
-     splitLeafName.Append("_") ;
-     splitLeafName.Append(typeName) ;
+     std::string splitLeafName = std::string{splitIter->first->GetName()} + "_" + typeName;
 
      // Check if split leaf already exists
      RooAbsArg* splitLeaf = _ws->fundArg(splitLeafName) ;
      if (!splitLeaf) {
        // If not create it now
-       splitLeaf = (RooAbsArg*) splitIter->first->clone(splitLeafName) ;
+       splitLeaf = (RooAbsArg*) splitIter->first->clone(splitLeafName.c_str());
        _ws->import(*splitLeaf,RooFit::Silence(!verbose)) ;
      }
      fracLeafList.add(*splitLeaf) ;

--- a/roofit/roofitcore/src/RooSimultaneous.cxx
+++ b/roofit/roofitcore/src/RooSimultaneous.cxx
@@ -357,7 +357,7 @@ RooSimultaneous::~RooSimultaneous()
 
 RooAbsPdf* RooSimultaneous::getPdf(RooStringView catName) const
 {
-  RooRealProxy* proxy = static_cast<RooRealProxy*>(_pdfProxyList.FindObject(catName));
+  RooRealProxy* proxy = static_cast<RooRealProxy*>(_pdfProxyList.FindObject(catName.c_str()));
   return proxy ? static_cast<RooAbsPdf*>(proxy->absArg()) : nullptr;
 }
 

--- a/roofit/roofitcore/src/RooTreeDataStore.cxx
+++ b/roofit/roofitcore/src/RooTreeDataStore.cxx
@@ -327,7 +327,7 @@ void RooTreeDataStore::initialize()
 void RooTreeDataStore::createTree(RooStringView name, RooStringView title)
 {
   if (!_tree) {
-    _tree = new TTree(name,title);
+    _tree = new TTree(name.c_str(),title.c_str());
     _tree->ResetBit(kCanDelete);
     _tree->ResetBit(kMustCleanup);
     _tree->SetDirectory(nullptr);
@@ -345,7 +345,7 @@ void RooTreeDataStore::createTree(RooStringView name, RooStringView title)
   }
 
   if (!_cacheTree) {
-    _cacheTree = new TTree(TString{static_cast<const char*>(name)} + "_cacheTree", TString{static_cast<const char*>(title)});
+    _cacheTree = new TTree(TString{name.c_str()} + "_cacheTree", TString{title.c_str()});
     _cacheTree->SetDirectory(nullptr) ;
     gDirectory->RecursiveRemove(_cacheTree) ;
   }

--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -957,7 +957,7 @@ bool RooWorkspace::extendSet(const char* name, const char* newContents)
 
 const RooArgSet* RooWorkspace::set(RooStringView name)
 {
-  std::map<string,RooArgSet>::iterator i = _namedSets.find(static_cast<const char*>(name));
+  std::map<string,RooArgSet>::iterator i = _namedSets.find(name.c_str());
   return (i!=_namedSets.end()) ? &(i->second) : nullptr;
 }
 
@@ -1150,13 +1150,13 @@ bool RooWorkspace::saveSnapshot(RooStringView name, const RooArgSet& params, boo
   auto snapshot = new RooArgSet;
   actualParams.snapshot(*snapshot);
 
-  snapshot->setName(name) ;
+  snapshot->setName(name.c_str()) ;
 
   if (importValues) {
     snapshot->assign(params) ;
   }
 
-  if (std::unique_ptr<RooArgSet> oldSnap{static_cast<RooArgSet*>(_snapshots.FindObject(name))}) {
+  if (std::unique_ptr<RooArgSet> oldSnap{static_cast<RooArgSet*>(_snapshots.FindObject(name.c_str()))}) {
     coutI(ObjectHandling) << "RooWorkspace::saveSnaphot(" << GetName() << ") replacing previous snapshot with name " << name << endl ;
     _snapshots.Remove(oldSnap.get()) ;
   }
@@ -1207,7 +1207,7 @@ const RooArgSet* RooWorkspace::getSnapshot(const char* name) const
 
 RooAbsPdf* RooWorkspace::pdf(RooStringView name) const
 {
-  return dynamic_cast<RooAbsPdf*>(_allOwnedNodes.find(name)) ;
+  return dynamic_cast<RooAbsPdf*>(_allOwnedNodes.find(name.c_str())) ;
 }
 
 
@@ -1216,7 +1216,7 @@ RooAbsPdf* RooWorkspace::pdf(RooStringView name) const
 
 RooAbsReal* RooWorkspace::function(RooStringView name) const
 {
-  return dynamic_cast<RooAbsReal*>(_allOwnedNodes.find(name)) ;
+  return dynamic_cast<RooAbsReal*>(_allOwnedNodes.find(name.c_str())) ;
 }
 
 
@@ -1225,7 +1225,7 @@ RooAbsReal* RooWorkspace::function(RooStringView name) const
 
 RooRealVar* RooWorkspace::var(RooStringView name) const
 {
-  return dynamic_cast<RooRealVar*>(_allOwnedNodes.find(name)) ;
+  return dynamic_cast<RooRealVar*>(_allOwnedNodes.find(name.c_str())) ;
 }
 
 
@@ -1234,7 +1234,7 @@ RooRealVar* RooWorkspace::var(RooStringView name) const
 
 RooCategory* RooWorkspace::cat(RooStringView name) const
 {
-  return dynamic_cast<RooCategory*>(_allOwnedNodes.find(name)) ;
+  return dynamic_cast<RooCategory*>(_allOwnedNodes.find(name.c_str())) ;
 }
 
 
@@ -1243,7 +1243,7 @@ RooCategory* RooWorkspace::cat(RooStringView name) const
 
 RooAbsCategory* RooWorkspace::catfunc(RooStringView name) const
 {
-  return dynamic_cast<RooAbsCategory*>(_allOwnedNodes.find(name)) ;
+  return dynamic_cast<RooAbsCategory*>(_allOwnedNodes.find(name.c_str())) ;
 }
 
 
@@ -1253,7 +1253,7 @@ RooAbsCategory* RooWorkspace::catfunc(RooStringView name) const
 
 RooAbsArg* RooWorkspace::arg(RooStringView name) const
 {
-  return _allOwnedNodes.find(name) ;
+  return _allOwnedNodes.find(name.c_str()) ;
 }
 
 
@@ -1302,7 +1302,7 @@ RooAbsArg* RooWorkspace::fundArg(RooStringView name) const
 
 RooAbsData* RooWorkspace::data(RooStringView name) const
 {
-  return (RooAbsData*)_dataList.FindObject(name) ;
+  return (RooAbsData*)_dataList.FindObject(name.c_str()) ;
 }
 
 
@@ -1311,7 +1311,7 @@ RooAbsData* RooWorkspace::data(RooStringView name) const
 
 RooAbsData* RooWorkspace::embeddedData(RooStringView name) const
 {
-  return (RooAbsData*)_embeddedDataList.FindObject(name) ;
+  return (RooAbsData*)_embeddedDataList.FindObject(name.c_str()) ;
 }
 
 
@@ -2020,7 +2020,7 @@ TObject* RooWorkspace::obj(RooStringView name) const
 TObject* RooWorkspace::genobj(RooStringView name)  const
 {
   // Find object by name
-  TObject* gobj = _genObjects.FindObject(name) ;
+  TObject* gobj = _genObjects.FindObject(name.c_str()) ;
 
   // Exit here if not found
   if (!gobj) return nullptr;
@@ -2077,7 +2077,7 @@ RooFactoryWSTool& RooWorkspace::factory()
 /// \copydoc RooFactoryWSTool::process(const char*)
 RooAbsArg* RooWorkspace::factory(RooStringView expr)
 {
-  return factory().process(expr) ;
+  return factory().process(expr.c_str()) ;
 }
 
 

--- a/roofit/roostats/src/HLFactory.cxx
+++ b/roofit/roostats/src/HLFactory.cxx
@@ -198,8 +198,7 @@ RooAbsPdf* HLFactory::GetTotSigBkgPdf(){
         return nullptr;
 
     if (fSigBkgPdfNames.GetSize()==1){
-        TString name(((TObjString*)fSigBkgPdfNames.At(0))->String());
-        fComboSigBkgPdf=fWs->pdf(name);
+        fComboSigBkgPdf=fWs->pdf(static_cast<TObjString*>(fSigBkgPdfNames.At(0))->String().Data());
         return fComboSigBkgPdf;
         }
 
@@ -209,18 +208,18 @@ RooAbsPdf* HLFactory::GetTotSigBkgPdf(){
     RooArgList pdfs("pdfs");
 
     for(auto * ostring : static_range_cast<TObjString*>(fSigBkgPdfNames)) {
-        pdfs.add( *(fWs->pdf(ostring->String())) );
+        pdfs.add( *(fWs->pdf(ostring->String().Data())) );
     }
 
-    TString name(GetName());
+    std::string name(GetName());
     name+="_sigbkg";
 
-    TString title(GetName());
+    std::string title(GetName());
     title+="_sigbkg";
 
     fComboSigBkgPdf=
-      new RooSimultaneous(name,
-                          title,
+      new RooSimultaneous(name.c_str(),
+                          title.c_str(),
                           pdfs,
                           *fComboCat);
 
@@ -244,7 +243,7 @@ RooAbsPdf* HLFactory::GetTotBkgPdf(){
         return nullptr;
 
     if (fBkgPdfNames.GetSize()==1){
-        fComboBkgPdf=fWs->pdf(((TObjString*)fBkgPdfNames.First())->String());
+        fComboBkgPdf=fWs->pdf(static_cast<TObjString*>(fBkgPdfNames.First())->String().Data());
         return fComboBkgPdf;
         }
 
@@ -254,7 +253,7 @@ RooAbsPdf* HLFactory::GetTotBkgPdf(){
     RooArgList pdfs("pdfs");
 
     for(auto * ostring : static_range_cast<TObjString*>(fBkgPdfNames)) {
-        pdfs.add( *(fWs->pdf(ostring->String())) );
+        pdfs.add( *fWs->pdf(ostring->String().Data()) );
     }
 
     TString name(GetName());
@@ -289,7 +288,7 @@ RooDataSet* HLFactory::GetTotDataSet(){
         return nullptr;
 
     if (fDatasetsNames.GetSize()==1){
-        fComboDataset=(RooDataSet*)fWs->data(((TObjString*)fDatasetsNames.First())->String());
+        fComboDataset=(RooDataSet*)fWs->data(static_cast<TObjString*>(fDatasetsNames.First())->String().Data());
         return fComboDataset;
         }
 
@@ -301,7 +300,7 @@ RooDataSet* HLFactory::GetTotDataSet(){
     TObjString* ostring;
     ostring = static_cast<TObjString*>(*it);
     ++it;
-    fComboDataset = (RooDataSet*) fWs->data(ostring->String()) ;
+    fComboDataset = (RooDataSet*) fWs->data(ostring->String().Data()) ;
     if (!fComboDataset) return nullptr;
     fComboDataset->Print();
     TString dataname(GetName());
@@ -312,7 +311,7 @@ RooDataSet* HLFactory::GetTotDataSet(){
     for(; it != fDatasetsNames.end() ; ++it) {
         ostring = static_cast<TObjString*>(*it);
         catindex++;
-        RooDataSet * data = (RooDataSet*)fWs->data(ostring->String());
+        RooDataSet * data = (RooDataSet*)fWs->data(ostring->String().Data());
         if (!data) return nullptr;
         RooDataSet* dummy = new RooDataSet(*data,"");
         fComboCat->setIndex(catindex);
@@ -564,7 +563,7 @@ int HLFactory::fParseLine(TString& line){
          nequals>0 &&    // It is a cat like "tag[B0=1,B0bar=-1]"
          ! line.Contains("(") &&
          ! line.Contains(")"))) {
-      fWs->factory(line);
+      fWs->factory(line.Data());
       return 0;
       }
 
@@ -625,13 +624,13 @@ int HLFactory::fParseLine(TString& line){
             std::cout << "DEBUG: new_line: " << new_line.Data() << std::endl;
             }
 
-        fWs->factory(new_line);
+        fWs->factory(new_line.Data());
 
         return 0;
         }
 
     else { // In case we do not know what to do we pipe it..
-        fWs->factory(line);
+        fWs->factory(line.Data());
         }
 
     return 0;

--- a/roofit/xroofit/src/xRooFit.cxx
+++ b/roofit/xroofit/src/xRooFit.cxx
@@ -281,7 +281,7 @@ xRooFit::generateFrom(RooAbsPdf &pdf, const std::shared_ptr<const RooFitResult> 
          // do subpdf's individually
          _obs->add(w);
          _out.first.reset(new RooDataSet(
-            uuid, TString::Format("%s %s", _pdf->GetTitle(), (expected) ? "Expected" : "Toy"), *_obs, "weightVar"));
+            uuid.Data(), TString::Format("%s %s", _pdf->GetTitle(), (expected) ? "Expected" : "Toy").Data(), *_obs, "weightVar"));
 
          for (auto &c : s->indexCat()) {
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6, 22, 00)

--- a/roofit/xroofit/src/xRooNode.cxx
+++ b/roofit/xroofit/src/xRooNode.cxx
@@ -1235,7 +1235,7 @@ xRooNode xRooNode::Add(const xRooNode &child, Option_t *opt)
       TString fac(child.GetName());
       if (!fac.Contains("["))
          fac += "[1]";
-      return xRooNode(*fParent->get<RooWorkspace>()->factory(fac), fParent);
+      return xRooNode(*fParent->get<RooWorkspace>()->factory(fac.Data()), fParent);
    } else if (strcmp(GetName(), ".datasets()") == 0) {
       // create a dataset - only allowed for pdfs or workspaces
       if (auto _ws = ws(); _ws && fParent) {
@@ -2175,7 +2175,7 @@ xRooNode xRooNode::Multiply(const xRooNode &child, Option_t *opt)
          return out;
       } else if (sOpt == "func" && ws()) {
          // need to get way to get dependencies .. can't pass all as causes circular dependencies issues.
-         if (auto arg = ws()->factory(TString("expr::") + child.GetName())) {
+         if (auto arg = ws()->factory(std::string("expr::") + child.GetName())) {
             auto out = Multiply(*arg);
             if (get() /* can happen this is null if on a bin node with no shapeFactors*/)
                Info("Multiply", "Scaled %s by new func factor %s",
@@ -3638,7 +3638,7 @@ std::shared_ptr<TObject> xRooNode::convertForAcquisition(xRooNode &acquirer, con
    } else if (!get() && sName.BeginsWith("factory:") && acquirer.ws()) {
       TString s(sName);
       s = TString(s(8, s.Length()));
-      fComp.reset(acquirer.ws()->factory(s), [](TObject *) {});
+      fComp.reset(acquirer.ws()->factory(s.Data()), [](TObject *) {});
       return fComp;
    }
 

--- a/test/stressRooStats_tests.h
+++ b/test/stressRooStats_tests.h
@@ -252,7 +252,7 @@ public:
 
          // Create Poisson model and dataset
          RooWorkspace* w = new RooWorkspace("w");
-         w->factory(TString::Format("Poisson::poiss(x[%d,0,1000], mean[0,1000])", fObsValue));
+         w->factory(TString::Format("Poisson::poiss(x[%d,0,1000], mean[0,1000])", fObsValue).Data());
          RooDataSet *data = new RooDataSet("data", "data", *w->var("x"));
          data->add(*w->var("x"));
 
@@ -616,7 +616,7 @@ public:
          w->factory("Uniform::prior(mean)");
          w->import(*(new RooCFunction1PdfBinding<Double_t, Double_t>("priorInv", "priorInv", &priorInv, *w->var("mean"))));
          w->import(*(new RooCFunction1PdfBinding<Double_t, Double_t>("priorInvSqrt", "priorInvSqrt", priorInvSqrt, *w->var("mean"))));
-         w->factory(TString::Format("Gamma::priorGamma(mean, %lf, %lf, 0)", gammaShape, gammaRate));
+         w->factory(TString::Format("Gamma::priorGamma(mean, %lf, %lf, 0)", gammaShape, gammaRate).Data());
 
          // build argument sets and data set
          w->defineSet("obs", "x");
@@ -1792,8 +1792,8 @@ public:
          // Make model for prototype on/off problem
          // Pois(x | s+b) * Pois(y | tau b )
          RooWorkspace* w = new RooWorkspace("w");
-         w->factory(TString::Format("Poisson::on_pdf(x[%d,0,500],sum::splusb(sig[0,0,100],bkg[100,0,300]))", xValue));
-         w->factory(TString::Format("Poisson::off_pdf(y[%d,0,500],prod::taub(tau[%lf],bkg))", yValue, tauValue));
+         w->factory(TString::Format("Poisson::on_pdf(x[%d,0,500],sum::splusb(sig[0,0,100],bkg[100,0,300]))", xValue).Data());
+         w->factory(TString::Format("Poisson::off_pdf(y[%d,0,500],prod::taub(tau[%lf],bkg))", yValue, tauValue).Data());
          w->factory("PROD::prod_pdf(on_pdf, off_pdf)");
 
          w->var("x")->setVal(xValue);

--- a/tutorials/roofit/rf711_lagrangianmorph.C
+++ b/tutorials/roofit/rf711_lagrangianmorph.C
@@ -74,9 +74,9 @@ void rf711_lagrangianmorph()
    auto morph_hist_0p25 = morphfunc.createTH1("morph_cHq3=0.25");
    morphfunc.setParameter("cHq3", 0.5);
    auto morph_hist_0p5 = morphfunc.createTH1("morph_cHq3=0.5");
-   RooDataHist morph_datahist_0p01("morph_dh_cHq3=0.01", "", RooArgList(obsvar), morph_hist_0p01);
-   RooDataHist morph_datahist_0p25("morph_dh_cHq3=0.25", "", RooArgList(obsvar), morph_hist_0p25);
-   RooDataHist morph_datahist_0p5("morph_dh_cHq3=0.5", "", RooArgList(obsvar), morph_hist_0p5);
+   RooDataHist morph_datahist_0p01("morph_dh_cHq3=0.01", "", {obsvar}, morph_hist_0p01);
+   RooDataHist morph_datahist_0p25("morph_dh_cHq3=0.25", "", {obsvar}, morph_hist_0p25);
+   RooDataHist morph_datahist_0p5("morph_dh_cHq3=0.5", "", {obsvar}, morph_hist_0p5);
 
    // E x t r a c t  i n p u t  t e m p l a t e s
    // f o r  p l o t t i n g
@@ -94,9 +94,9 @@ void rf711_lagrangianmorph()
    input_hist2->SetDirectory(NULL);
    file->Close();
 
-   RooDataHist input_dh0(samplelist[0].c_str(), "", RooArgList(obsvar), input_hist0);
-   RooDataHist input_dh1(samplelist[1].c_str(), "", RooArgList(obsvar), input_hist1);
-   RooDataHist input_dh2(samplelist[2].c_str(), "", RooArgList(obsvar), input_hist2);
+   RooDataHist input_dh0(samplelist[0], "", {obsvar}, input_hist0);
+   RooDataHist input_dh1(samplelist[1], "", {obsvar}, input_hist1);
+   RooDataHist input_dh2(samplelist[2], "", {obsvar}, input_hist2);
 
    auto frame0 = obsvar.frame(Title("Input templates for p_{T}^{V}"));
    input_dh0.plotOn(frame0, Name(samplelist[0].c_str()), LineColor(kBlack), MarkerColor(kBlack), MarkerSize(1));


### PR DESCRIPTION
# This Pull request:

Fixes a bug that can lead to datasets and distributions being wrongly ordered in HS3 JSON files.

## Changes or fixes:

Use the name of the split datasets rather than their index to decide the ordering.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

