### PR TITLE
[ntuple] Bump release candidate tag to RC2

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
@@ -57,7 +57,7 @@ public:
    /// In order to handle changes to the serialization routine in future ntuple versions
    static constexpr std::uint16_t kEnvelopeCurrentVersion = 1;
    static constexpr std::uint16_t kEnvelopeMinVersion     = 1;
-   static constexpr std::uint32_t kReleaseCandidateTag    = 1;
+   static constexpr std::uint32_t kReleaseCandidateTag    = 2;
 
    static constexpr std::uint16_t kFlagRepetitiveField = 0x01;
 

--- a/tree/ntuple/v7/test/ntuple_storage_daos.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage_daos.cxx
@@ -26,7 +26,7 @@ protected:
       // Initialized at the start of each test to expect diagnostic messages from TestSupport
       fRootDiags.requiredDiag(kWarning, "ROOT::Experimental::Detail::RPageSinkDaos::RPageSinkDaos",
                               "The DAOS backend is experimental and still under development.", false);
-      fRootDiags.requiredDiag(kWarning, "[ROOT.NTuple]", "Pre-release format version: RC 1", false);
+      fRootDiags.requiredDiag(kWarning, "[ROOT.NTuple]", "Pre-release format version: RC", false);
       fRootDiags.optionalDiag(kWarning, "in int daos_init()",
                               "This RNTuple build uses libdaos_mock. Use only for testing!");
    }

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -1369,7 +1369,7 @@ TEST(RNTuple, TClassReadRules)
    diags.requiredDiag(kWarning, "[ROOT.NTuple]", "ignoring I/O customization rule with non-transient member: a", false);
    diags.requiredDiag(kWarning, "ROOT::Experimental::Detail::RPageSinkFile::RPageSinkFile",
                       "The RNTuple file format will change.", false);
-   diags.requiredDiag(kWarning, "[ROOT.NTuple]", "Pre-release format version: RC 1", false);
+   diags.requiredDiag(kWarning, "[ROOT.NTuple]", "Pre-release format version: RC", false);
 
    FileRaii fileGuard("test_ntuple_tclassrules.ntuple");
    char c[4] = {'R', 'O', 'O', 'T'};


### PR DESCRIPTION
As discussed in #12376, the release candidate tag was to be bumped to RC2 after late model extension + split encoding is available.  In principle, it's safe to do it now.

## Checklist:
- [x] tested changes locally