### PR TITLE
[test] Fix number of iterations in `InterpreterStress::stressSTLDict()`

### DIFF
--- a/test/stressInterpreter.cxx
+++ b/test/stressInterpreter.cxx
@@ -219,7 +219,7 @@ bool InterpreterStress::stressSTLDict() {
    using namespace std;
 
    bool allres = true;
-   for (Int_t i = 1; i < fNtimes; ++i) {
+   for (Int_t i = 0; i < fNtimes; ++i) {
       int res = 3;
       TInterpreter::EErrorCode interpError = TInterpreter::kNoError;
       TString cmd
@@ -257,7 +257,7 @@ bool InterpreterStress::stressSTLDict() {
       }
    }
 #ifdef ClingWorkAroundDeletedSourceFile
-   for (Int_t i = 1; i < fNtimes; ++i) {
+   for (Int_t i = 0; i < fNtimes; ++i) {
       TString tmpfilename = TString::Format("stressInterpreter_tmp%d.C", i);
       gSystem->Unlink(tmpfilename);
    }


### PR DESCRIPTION
It's not important, but I discovered by chance that `InterpreterStress::stressSTLDict()` was doing one iteration less than expected.  Fix that.

## Checklist:
- [x] tested changes locally