### PR TITLE
[RF] Fix problems with `ShapeSys` support in the HS3 HistFactory implementation

### DIFF
--- a/roofit/histfactory/inc/RooStats/HistFactory/Detail/HistFactoryImpl.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/Detail/HistFactoryImpl.h
@@ -16,9 +16,21 @@
 #include <RooGlobalFunc.h>
 #include <RooWorkspace.h>
 
+#include <ROOT/RSpan.hxx>
+
 namespace RooStats {
 namespace HistFactory {
 namespace Detail {
+
+namespace MagicConstants {
+
+constexpr double defaultGammaMin = 0;
+constexpr double defaultShapeFactorGammaMax = 1000;
+constexpr double defaultShapeSysGammaMax = 10;
+constexpr double defaultStatErrorGammaMax = 10;
+constexpr double minShapeUncertainty = 0.0;
+
+} // namespace MagicConstants
 
 template <class Arg_t, class... Params_t>
 Arg_t &getOrCreate(RooWorkspace &ws, std::string const &name, Params_t &&...params)
@@ -30,6 +42,8 @@ Arg_t &getOrCreate(RooWorkspace &ws, std::string const &name, Params_t &&...para
    ws.import(newArg, RooFit::RecycleConflictNodes(true), RooFit::Silence(true));
    return *static_cast<Arg_t *>(ws.obj(name));
 }
+
+void configureConstrainedGammas(RooArgList const &gammas, std::span<double> relSigmas, double minSigma);
 
 } // namespace Detail
 } // namespace HistFactory

--- a/roofit/histfactory/inc/RooStats/HistFactory/Detail/HistFactoryImpl.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/Detail/HistFactoryImpl.h
@@ -13,6 +13,8 @@
 #ifndef HistFactoryImplHelpers_h
 #define HistFactoryImplHelpers_h
 
+#include <RooStats/HistFactory/Systematics.h>
+
 #include <RooGlobalFunc.h>
 #include <RooWorkspace.h>
 
@@ -43,7 +45,16 @@ Arg_t &getOrCreate(RooWorkspace &ws, std::string const &name, Params_t &&...para
    return *static_cast<Arg_t *>(ws.obj(name));
 }
 
-void configureConstrainedGammas(RooArgList const &gammas, std::span<double> relSigmas, double minSigma);
+void configureConstrainedGammas(RooArgList const &gammas, std::span<const double> relSigmas, double minSigma);
+
+struct CreateGammaConstraintsOutput {
+   std::vector<std::unique_ptr<RooAbsPdf>> constraints;
+   std::vector<RooRealVar*> globalObservables;
+};
+
+CreateGammaConstraintsOutput createGammaConstraints(RooArgList const &paramList,
+                                                    std::span<const double> relSigmas, double minSigma,
+                                                    Constraint::Type type);
 
 } // namespace Detail
 } // namespace HistFactory

--- a/roofit/histfactory/inc/RooStats/HistFactory/HistoToWorkspaceFactoryFast.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/HistoToWorkspaceFactoryFast.h
@@ -90,11 +90,6 @@ namespace RooStats{
 
       TH1* MakeAbsolUncertaintyHist( const std::string& Name, const TH1* Hist );
 
-      RooArgList createGammaConstraintTerms( RooWorkspace& proto,
-                   std::vector<std::string>& constraintTerms,
-                   ParamHistFunc& paramHist, const TH1* uncertHist,
-                   Constraint::Type type, double minSigma );
-
       void ConfigureHistFactoryDataset(RooDataSet& obsData, TH1 const& nominal, RooWorkspace& proto,
                    std::vector<std::string> const& obsNameVec);
 

--- a/roofit/histfactory/inc/RooStats/HistFactory/HistoToWorkspaceFactoryFast.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/HistoToWorkspaceFactoryFast.h
@@ -90,7 +90,7 @@ namespace RooStats{
 
       TH1* MakeAbsolUncertaintyHist( const std::string& Name, const TH1* Hist );
 
-      RooArgList createStatConstraintTerms( RooWorkspace& proto,
+      RooArgList createGammaConstraintTerms( RooWorkspace& proto,
                    std::vector<std::string>& constraintTerms,
                    ParamHistFunc& paramHist, const TH1* uncertHist,
                    Constraint::Type type, double minSigma );

--- a/roofit/histfactory/src/HistFactoryImpl.cxx
+++ b/roofit/histfactory/src/HistFactoryImpl.cxx
@@ -11,3 +11,69 @@
  */
 
 #include <RooStats/HistFactory/Detail/HistFactoryImpl.h>
+
+#include <RooMsgService.h>
+#include <RooRealVar.h>
+
+namespace RooStats {
+namespace HistFactory {
+namespace Detail {
+
+/**
+ * \brief Configure constrained gamma parameters for fitting.
+ *
+ * This function configures constrained gamma parameters for fitting. If a
+ * given relative sigma is less than or equal to zero or below a threshold, the
+ * gamma parameter is set to be constant. The function also sets reasonable
+ * ranges for the gamma parameter and provides a reasonable starting point for
+ * pre-fit errors.
+ *
+ * @param gammas   The gamma parameters to be configured.
+ * @param sigmaRel The relative sigma values to be used for configuring the
+ *                 limits and errors.
+ * @param minSigma The minimum relative sigma threshold. If a relative sigma is
+ *                 below this threshold, the gamma parameter is set to be
+ *                 constant.
+ */
+void configureConstrainedGammas(RooArgList const &gammas, std::span<double> relSigmas, double minSigma)
+{
+   assert(gammas.size() == relSigmas.size());
+
+   for (std::size_t i = 0; i < gammas.size(); ++i) {
+      auto &gamma = *static_cast<RooRealVar *>(gammas.at(i));
+      double sigmaRel = relSigmas[i];
+
+      // If the sigma is zero, the parameter might as well be constant
+      if (sigmaRel <= 0) {
+         gamma.setConstant(true);
+         continue;
+      }
+
+      // Set reasonable ranges
+      gamma.setMax(1. + 5. * sigmaRel);
+      gamma.setMin(0.);
+
+      // Give reasonable starting point for pre-fit errors by setting it to the
+      // absolute sigma Mostly useful for pre-fit plotting.
+      // Note: in commit 2129c4d920 "[HF] Reduce verbosity of HistFactory."
+      // from 2020, there was a check added to do this only for Gaussian
+      // constrained parameters and for Poisson constrained parameters if they
+      // are stat errors without any justification. In the ROOT 6.30
+      // development cycle, this check got removed again to cause less surprise
+      // to the user.
+      gamma.setError(sigmaRel);
+
+      // If the sigma value is less than a supplied threshold, set the variable to
+      // constant
+      if (sigmaRel < minSigma) {
+         oocxcoutW(static_cast<TObject *>(nullptr), HistFactory)
+            << "Warning: relative sigma " << sigmaRel << " for \"" << gamma.GetName() << "\" falls below threshold of "
+            << minSigma << ". Setting: " << gamma.GetName() << " to constant" << std::endl;
+         gamma.setConstant(true);
+      }
+   }
+}
+
+} // namespace Detail
+} // namespace HistFactory
+} // namespace RooStats

--- a/roofit/histfactory/test/testHistFactory.cxx
+++ b/roofit/histfactory/test/testHistFactory.cxx
@@ -38,7 +38,7 @@
 namespace {
 
 // If the JSON files should be written out for debugging purpose.
-const bool writeJsonFiles = false;
+const bool writeJsonFiles = true;
 
 std::vector<double> getValues(RooAbsReal const &real, RooRealVar &obs, bool normalize, bool useBatchMode)
 {

--- a/roofit/histfactory/test/testHistFactory.cxx
+++ b/roofit/histfactory/test/testHistFactory.cxx
@@ -565,12 +565,9 @@ TEST_P(HFFixture, HistFactoryJSONTool)
    Res resultFromJson{pdfFromJson->fitTo(*dataFromJson, Strategy(1), Minos(*mcFromJson->GetParametersOfInterest()),
                                          GlobalObservables(globsFromJson), PrintLevel(-1), Save())};
 
-   // TODO: Of course this should also work for the ShapeSyst case!
-   if(makeModelMode != MakeModelMode::ShapeSyst) {
-      // Do also the reverse comparison to check that the set of constant parameters matches
-      EXPECT_TRUE(result->isIdentical(*resultFromJson));
-      EXPECT_TRUE(resultFromJson->isIdentical(*result));
-   }
+   // Do also the reverse comparison to check that the set of constant parameters matches
+   EXPECT_TRUE(result->isIdentical(*resultFromJson));
+   EXPECT_TRUE(resultFromJson->isIdentical(*result));
 }
 
 TEST_P(HFFixture, HS3ClosureLoop)

--- a/roofit/hs3/src/JSONFactories_HistFactory.cxx
+++ b/roofit/hs3/src/JSONFactories_HistFactory.cxx
@@ -282,7 +282,9 @@ bool importHistSample(RooJSONFactoryWSTool &tool, RooDataHist &dh, RooArgSet con
                RooJSONFactoryWSTool::readBinnedData(data["hi"], sysname + "High_" + prefixedName, varlist)));
             constraints.add(getConstraint(ws, sysname, parname));
          } else if (modtype == "shapesys") {
-            std::string funcName = prefixedName + "_" + sysname + "_" + prefixedName + "_ShapeSys";
+            std::string funcName = fprefix + "_" + sysname + "_ShapeSys";
+            erasePrefix(funcName, "model_");
+            // funName should be "<channel_name>_<sysname>_ShapeSys"
             std::vector<double> vals;
             for (const auto &v : mod["data"]["vals"].children()) {
                vals.push_back(v.val_double());
@@ -747,14 +749,8 @@ bool tryExportHistFactory(RooJSONFactoryWSTool *tool, const std::string &pdfname
             sample.useBarlowBeestonLight = true;
          } else { // other ShapeSys
             ShapeSys sys(phf->GetName());
-            erasePrefix(sys.name, "model_" + chname + "_");
             erasePrefix(sys.name, chname + "_");
-            erasePrefix(sys.name, sample.name + "_");
             eraseSuffix(sys.name, "_ShapeSys");
-            eraseSuffix(sys.name, "_" + sample.name);
-            eraseSuffix(sys.name, "_model_" + chname);
-            eraseSuffix(sys.name, "_" + chname);
-            eraseSuffix(sys.name, "_" + sample.name);
 
             for (const auto &g : phf->paramList()) {
                RooAbsPdf *constraint = findConstraint(g);


### PR DESCRIPTION
* Refactor the original HistFactory code such that pieces can be reused in the HS3 JSON IO implementation
* Fix problems with "reverse engineering" the name of the `ShapeSys` systematics from the ParamHistFunc name
* The `testHistFactory` unit test now validates full JSON roundtripping closure of workspaces with `ShapeSys`, both with Gaussian and Poisson constraints

More details in the commit descriptions