### PR TITLE
Fix a debug assertion failure on Windows when running stressgraphics

### DIFF
--- a/core/base/src/Stringio.cxx
+++ b/core/base/src/Stringio.cxx
@@ -136,8 +136,8 @@ std::istream& TString::ReadToken(std::istream& strm)
    UInt_t wid = strm.width(0);
    char c='\0';
    Int_t hitSpace = 0;
-   while ((wid == 0 || Length() < (Int_t)wid) &&
-          strm.get(c).good() && (hitSpace = isspace(static_cast<unsigned char>(c))) == 0) {
+   while ((wid == 0 || Length() < (Int_t)wid) && strm.get(c).good() &&
+          (hitSpace = isspace(static_cast<unsigned char>(c))) == 0) {
       // Check for overflow:
       Ssiz_t len = Length();
       Ssiz_t cap = Capacity();

--- a/core/base/src/Stringio.cxx
+++ b/core/base/src/Stringio.cxx
@@ -137,7 +137,7 @@ std::istream& TString::ReadToken(std::istream& strm)
    char c='\0';
    Int_t hitSpace = 0;
    while ((wid == 0 || Length() < (Int_t)wid) &&
-          strm.get(c).good() && (hitSpace = isspace((Int_t)c)) == 0) {
+          strm.get(c).good() && (hitSpace = isspace(static_cast<unsigned char>(c))) == 0) {
       // Check for overflow:
       Ssiz_t len = Length();
       Ssiz_t cap = Capacity();


### PR DESCRIPTION
Apply changes suggested in the `Notes` section of the `isspace` [C++ standard](https://en.cppreference.com/w/cpp/string/byte/isspace) This fixes the following error when reading the character `'ò' (-14 )` in stressgraphics:
```
Debug Assertion Failed!
Program:
C:\root-dev\build\x86\debug_test\test\Debug\stressGraphics.exe
File: minkernel\crts\ucrt\src\appcrt\convert\isctype.cpp
Line 36
Expression c > = -1 && c < = 255
```

From `isspace((Int_t)c)`, in `core\base\src\Stringio.cxx`, in `std::istream& TString::ReadToken(std::istream& strm)`:
```
   while ((wid == 0 || Length() < (Int_t)wid) &&
          strm.get(c).good() && (hitSpace = isspace((Int_t)c)) == 0) {
```
