### PR TITLE
The TRI1/2 TGraph2D options produced artifacts.

### DIFF
--- a/hist/hist/src/TGraph2D.cxx
+++ b/hist/hist/src/TGraph2D.cxx
@@ -1065,8 +1065,8 @@ TH2D *TGraph2D::GetHistogram(Option_t *option)
    }
 
    // Option "empty" is selected. An empty histogram is returned.
+   Double_t hzmax, hzmin;
    if (empty) {
-      Double_t hzmax, hzmin;
       if (fMinimum != -1111) {
          hzmin = fMinimum;
       } else {
@@ -1111,6 +1111,10 @@ TH2D *TGraph2D::GetHistogram(Option_t *option)
       }
    }
 
+   hzmin = GetZminE();
+   hzmax = GetZmaxE();
+   if (hzmin < fHistogram->GetMinimum()) fHistogram->SetMinimum(hzmin);
+   if (hzmax > fHistogram->GetMaximum()) fHistogram->SetMaximum(hzmax);
 
    if (fMinimum != -1111) fHistogram->SetMinimum(fMinimum);
    if (fMaximum != -1111) fHistogram->SetMaximum(fMaximum);

--- a/hist/histpainter/src/TGraph2DPainter.cxx
+++ b/hist/histpainter/src/TGraph2DPainter.cxx
@@ -1176,13 +1176,16 @@ void TGraph2DPainter::PaintTriangles_old(Option_t *option)
    fGraph2D->SetLineColor(fGraph2D->GetLineColor());
    fGraph2D->TAttLine::Modify();
    int lst = fGraph2D->GetLineStyle();
-   for (it=0; it<fNdt; it++) {
+   Double_t zmin = gCurrentHist->GetMinimum();
+   Double_t zmax = gCurrentHist->GetMaximum();
+    for (it=0; it<fNdt; it++) {
       t[0] = fPTried[order[it]];
       t[1] = fNTried[order[it]];
       t[2] = fMTried[order[it]];
       for (Int_t k=0; k<3; k++) {
          if(fX[t[k]-1] < fXmin || fX[t[k]-1] > fXmax) goto endloop;
          if(fY[t[k]-1] < fYmin || fY[t[k]-1] > fYmax) goto endloop;
+         if(fZ[t[k]-1] < zmin  || fZ[t[k]-1] > zmax)  goto endloop;
          temp1[0] = fX[t[k]-1];
          temp1[1] = fY[t[k]-1];
          temp1[2] = fZ[t[k]-1];
@@ -1331,6 +1334,8 @@ void TGraph2DPainter::PaintTriangles_new(Option_t *option)
    fGraph2D->SetLineColor(fGraph2D->GetLineColor());
    fGraph2D->TAttLine::Modify();
    int lst = fGraph2D->GetLineStyle();
+   Double_t zmin = gCurrentHist->GetMinimum();
+   Double_t zmax = gCurrentHist->GetMaximum();
    for (const auto & it : dist) {
       p[0] = it.second->idx[0];
       p[1] = it.second->idx[1];
@@ -1338,6 +1343,7 @@ void TGraph2DPainter::PaintTriangles_new(Option_t *option)
       for (Int_t k=0; k<3; k++) {
          if(fX[p[k]] < fXmin || fX[p[k]] > fXmax) goto endloop;
          if(fY[p[k]] < fYmin || fY[p[k]] > fYmax) goto endloop;
+         if(fZ[p[k]] < zmin  || fZ[p[k]] > zmax)  goto endloop;
          temp1[0] = fX[p[k]];
          temp1[1] = fY[p[k]];
          temp1[2] = fZ[p[k]];


### PR DESCRIPTION
This Pull request fixes this issue:
https://github.com/root-project/root/issues/13424

Along the Z axis, there was no check to drop, at drawing time, the triangles having at least one vertex smaller than the minimum of the underlying histogram or greater than the maximum of the underlying histogram. This produced the artifacts reported in the issue. Also, The minimum and maximum of the underlying histogram might be respectively bigger or smaller than the real minimum and maximum of the points. A fix is done also for that too.
