### PR TITLE
[ntuple] Speed up reading/writing of simple vectors

### DIFF
--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -2006,7 +2006,7 @@ void ROOT::Experimental::RRVecField::ReadGlobalImpl(NTupleSize_t globalIndex, vo
          CallGenerateValueOn(*fSubFields[0], begin + (i * fItemSize));
    }
 
-   if (fSubFields[0]->IsSimple()) {
+   if (fSubFields[0]->IsSimple() && nItems) {
       GetPrincipalColumnOf(*fSubFields[0])->ReadV(collectionStart, nItems, begin);
       return;
    }

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -2006,6 +2006,11 @@ void ROOT::Experimental::RRVecField::ReadGlobalImpl(NTupleSize_t globalIndex, vo
          CallGenerateValueOn(*fSubFields[0], begin + (i * fItemSize));
    }
 
+   if (fSubFields[0]->IsSimple()) {
+      GetPrincipalColumnOf(*fSubFields[0])->ReadV(collectionStart, nItems, begin);
+      return;
+   }
+
    // Read the new values into the collection elements
    for (std::size_t i = 0; i < nItems; ++i) {
       CallReadOn(*fSubFields[0], collectionStart + i, begin + (i * fItemSize));


### PR DESCRIPTION
For RVecs of simple types, do a vector read of the item's principal columns instead of reading items one by one.