### PR TITLE
Revert "[ci] Use Ninja as build system everywhere but Windows." [skip-ci]

### DIFF
--- a/.github/workflows/root-ci-config/build_root.py
+++ b/.github/workflows/root-ci-config/build_root.py
@@ -295,9 +295,8 @@ def archive_and_upload(archive_name, prefix):
 
 @github_log_group("Configure")
 def cmake_configure(options, buildtype):
-    generator = "" if WINDOWS else "-G Ninja"
     result = subprocess_with_log(f"""
-        cmake -S '{WORKDIR}/src' -B '{WORKDIR}/build' {options} -DCMAKE_BUILD_TYPE={buildtype} {generator}
+        cmake -S '{WORKDIR}/src' -B '{WORKDIR}/build' {options} -DCMAKE_BUILD_TYPE={buildtype}
     """)
 
     if result != 0:


### PR DESCRIPTION
Ninja shows dependency issues in our build system; fix those first before switching to Ninja.

This reverts commit fcfca4ccdaf97099a180e154c60bc3c621abfafe.

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

