### PR TITLE
[RF][PyROOT] Fix memory leaks with RooFit command arguments in PyROOT

### DIFF
--- a/bindings/pyroot/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/CMakeLists.txt
@@ -43,6 +43,7 @@ if(roofit)
         ROOT/_pythonization/_roofit/_roogenfitstudy.py
         ROOT/_pythonization/_roofit/_rooglobalfunc.py
         ROOT/_pythonization/_roofit/_roojsonfactorywstool.py
+        ROOT/_pythonization/_roofit/_roolinkedlist.py
         ROOT/_pythonization/_roofit/_roomcstudy.py
         ROOT/_pythonization/_roofit/_roomsgservice.py
         ROOT/_pythonization/_roofit/_roonllvar.py

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/__init__.py
@@ -48,6 +48,7 @@ from ._rooglobalfunc import (
     MarkerStyle,
 )
 from ._roojsonfactorywstool import RooJSONFactoryWSTool
+from ._roolinkedlist import RooLinkedList
 from ._roomcstudy import RooMCStudy
 from ._roomsgservice import RooMsgService
 from ._roonllvar import RooNLLVar
@@ -79,6 +80,7 @@ python_classes = [
     RooDecay,
     RooGenFitStudy,
     RooJSONFactoryWSTool,
+    RooLinkedList,
     RooMCStudy,
     RooMsgService,
     RooNLLVar,

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roolinkedlist.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roolinkedlist.py
@@ -1,0 +1,30 @@
+# Authors:
+# * Jonas Rembser 09/2023
+
+################################################################################
+# Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+
+class RooLinkedList(object):
+
+    def Add(self, arg):
+        # The Add() method is only changed for the sake of changing the memory
+        # policy of the cppyy overload. The signature of the original C++
+        # function is RooLinkedList::Add(RooAbsArg *arg). PyROOT is wrongly
+        # interpreting this as the RooLinkedList taking ownership of the
+        # RooAbsArg. This results in a memory leak because nobody feels
+        # responsible for deleting the arg. This can be fixed by setting the
+        # memory policy of the method to "strict" and not to "heuristic".
+        #
+        # This might become unnecessary in the future if it is decided to set
+        # the global memory policy to "strict" in _facade.py.
+
+        import ROOT
+
+        self._Add.__mempolicy__ = ROOT.kMemoryStrict
+        return self._Add(arg)


### PR DESCRIPTION
PyROOT is wrongly interpreting the signature of
`RooLinkedList::Add(RooAbsArg *arg)` as the RooLinkedList taking ownership of the RooAbsArg. This results in a memory leak because nobody feels responsible for deleting the arg. This can be fixed by setting the memory policy of the method to "strict" and not to "heuristic" in the pythonizations.

This pythonization might become unnecessary in the future if it is decided to set the global memory policy to "strict" in _facade.py.

Reproducer of the original problem: the first code snippet in this forum post:
https://root-forum.cern.ch/t/memory-leak-in-fits/56249

This PR is only a hot-fix to the problem. The more sustainable solution will be provided by another PR that disables the heuristic memory management:
https://github.com/root-project/root/pull/13593
