### PR TITLE
[interpreter] Add builtin_llvm's CMake modules [v6.28]

### DIFF
--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -245,6 +245,7 @@ if(builtin_llvm)
     ${CMAKE_BINARY_DIR}/interpreter/llvm/src/include
     CACHE STRING "LLVM include directories."
     )
+  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/llvm/src/cmake/modules")
   #---Set into parent scope LLVM_VERSION --------------------------------------------------------------
   set(llvmconfigfile "${CMAKE_CURRENT_SOURCE_DIR}/llvm/src/CMakeLists.txt")
   file(READ ${llvmconfigfile} _filestr)


### PR DESCRIPTION
This was naturally available before commit 92807f3591 (backported in commit 281a162ace) from LLVM's configuration file.

Fixes #13597, applies https://github.com/root-project/root/pull/13598 to `v6-28-00-patches` with the old, pre-monorepo path.