### PR TITLE
[ntuple] API improvements, skimming tutorial stub

### DIFF
--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -145,7 +145,7 @@ public:
          fValue.Read(entry);
          fLastEntry = entry;
       }
-      return fValue.Get<void>();
+      return fValue.GetAs<void>();
    }
 };
 

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -145,7 +145,7 @@ public:
          fValue.Read(entry);
          fLastEntry = entry;
       }
-      return fValue.GetRawPtr();
+      return fValue.Get<void>();
    }
 };
 

--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -75,7 +75,7 @@ public:
    REntry &operator=(REntry &&other) = default;
    ~REntry() = default;
 
-   void CaptureValueUnsafe(std::string_view fieldName, void *where);
+   void BindValue(std::string_view fieldName, void *where);
 
    template <typename T>
    T *Get(std::string_view fieldName) const

--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -98,10 +98,16 @@ public:
    void BindRaw(std::string_view fieldName, void *where);
 
    template <typename T>
-   std::shared_ptr<T> GetShared(std::string_view /* fieldName */) const
+   std::shared_ptr<T> GetShared(std::string_view fieldName) const
    {
-      // TODO
-      return std::shared_ptr<T>(new T());
+      for (std::size_t i = 0; i < fValues.size(); ++i) {
+         if (fValues[i].GetField().GetName() != fieldName)
+            continue;
+         if (!fValuePtrs[i])
+            throw RException(R__FAIL("invalid attempt to get shared pointer of raw value: " + std::string(fieldName)));
+         return static_cast<std::shared_ptr<T>>(fValuePtrs[i]);
+      }
+      throw RException(R__FAIL("invalid field name: " + std::string(fieldName)));
    }
 
    template <typename T>

--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -76,7 +76,7 @@ public:
    REntry &operator=(REntry &&other) = default;
    ~REntry() = default;
 
-   void BindValue(std::string_view fieldName, void *where);
+   void BindRaw(std::string_view fieldName, void *where);
 
    template <typename T>
    std::shared_ptr<T> GetShared(std::string_view /* fieldName */) const

--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -46,7 +46,7 @@ class REntry {
    friend class RNTupleReader;
    friend class RNTupleWriter;
 
-   /// The entry must be linked to a specific model (or one if its clones), identified by a model ID
+   /// The entry must be linked to a specific model, identified by a model ID
    std::uint64_t fModelId = 0;
    /// Corresponds to the top-level fields of the linked model
    std::vector<Detail::RFieldBase::RValue> fValues;
@@ -95,6 +95,7 @@ public:
    REntry &operator=(REntry &&other) = default;
    ~REntry() = default;
 
+   /// For use with frameworks, sets an unmanaged, raw pointer address for a field
    void BindRaw(std::string_view fieldName, void *where);
 
    template <typename T>

--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -93,7 +93,7 @@ public:
             continue;
 
          if constexpr (std::is_void_v<T>)
-            return v.GetRawPtr();
+            return v.Get<void>();
 
          if (v.GetField().GetType() != RField<T>::TypeName())
             throw RException(R__FAIL("type mismatch in REntry::GetRaw()"));

--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -105,11 +105,11 @@ public:
             continue;
 
          if constexpr (std::is_void_v<T>)
-            return v.Get<void>();
+            return v.GetAs<void>();
 
          if (v.GetField().GetType() != RField<T>::TypeName())
             throw RException(R__FAIL("type mismatch in REntry::GetValueAs()"));
-         return v.Get<T>();
+         return v.GetAs<T>();
       }
       throw RException(R__FAIL("invalid field name: " + std::string(fieldName)));
    }

--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -68,7 +68,7 @@ class REntry {
    }
 
 public:
-   using Iterator_t = decltype(fValues)::iterator;
+   using ConstIterator_t = decltype(fValues)::const_iterator;
 
    REntry(const REntry &other) = delete;
    REntry &operator=(const REntry &other) = delete;
@@ -104,8 +104,24 @@ public:
 
    std::uint64_t GetModelId() const { return fModelId; }
 
-   Iterator_t begin() { return fValues.begin(); }
-   Iterator_t end() { return fValues.end(); }
+   void Read(NTupleSize_t index)
+   {
+      for (auto &v : fValues) {
+         v.Read(index);
+      }
+   }
+
+   std::size_t Append()
+   {
+      std::size_t bytesWritten = 0;
+      for (auto &v : fValues) {
+         bytesWritten += v.Append();
+      }
+      return bytesWritten;
+   }
+
+   ConstIterator_t begin() const { return fValues.cbegin(); }
+   ConstIterator_t end() const { return fValues.cend(); }
 };
 
 } // namespace Experimental

--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -89,13 +89,13 @@ public:
    T *GetRaw(std::string_view fieldName) const
    {
       for (auto& v : fValues) {
-         if (v.GetField()->GetName() != fieldName)
+         if (v.GetField().GetName() != fieldName)
             continue;
 
          if constexpr (std::is_void_v<T>)
             return v.GetRawPtr();
 
-         if (v.GetField()->GetType() != RField<T>::TypeName())
+         if (v.GetField().GetType() != RField<T>::TypeName())
             throw RException(R__FAIL("type mismatch in REntry::GetRaw()"));
          return v.Get<T>();
       }

--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -41,7 +41,10 @@ that are associated to values are managed.
 */
 // clang-format on
 class REntry {
+   friend class RCollectionNTupleWriter;
    friend class RNTupleModel;
+   friend class RNTupleReader;
+   friend class RNTupleWriter;
 
    /// The entry must be linked to a specific model (or one if its clones), identified by a model ID
    std::uint64_t fModelId = 0;
@@ -65,6 +68,22 @@ class REntry {
       fValues.emplace_back(field->BindValue(ptr.get()));
       fValuePtrs.emplace_back(ptr);
       return ptr;
+   }
+
+   void Read(NTupleSize_t index)
+   {
+      for (auto &v : fValues) {
+         v.Read(index);
+      }
+   }
+
+   std::size_t Append()
+   {
+      std::size_t bytesWritten = 0;
+      for (auto &v : fValues) {
+         bytesWritten += v.Append();
+      }
+      return bytesWritten;
    }
 
 public:
@@ -103,22 +122,6 @@ public:
    }
 
    std::uint64_t GetModelId() const { return fModelId; }
-
-   void Read(NTupleSize_t index)
-   {
-      for (auto &v : fValues) {
-         v.Read(index);
-      }
-   }
-
-   std::size_t Append()
-   {
-      std::size_t bytesWritten = 0;
-      for (auto &v : fValues) {
-         bytesWritten += v.Append();
-      }
-      return bytesWritten;
-   }
 
    ConstIterator_t begin() const { return fValues.cbegin(); }
    ConstIterator_t end() const { return fValues.cend(); }

--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -122,6 +122,7 @@ public:
    }
 
    std::uint64_t GetModelId() const { return fModelId; }
+   bool IsManaged(std::string_view fieldName) const;
 
    ConstIterator_t begin() const { return fValues.cbegin(); }
    ConstIterator_t end() const { return fValues.cend(); }

--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -98,20 +98,7 @@ public:
    void BindRaw(std::string_view fieldName, void *where);
 
    template <typename T>
-   std::shared_ptr<T> GetShared(std::string_view fieldName) const
-   {
-      for (std::size_t i = 0; i < fValues.size(); ++i) {
-         if (fValues[i].GetField().GetName() != fieldName)
-            continue;
-         if (!fValuePtrs[i])
-            throw RException(R__FAIL("invalid attempt to get shared pointer of raw value: " + std::string(fieldName)));
-         return static_cast<std::shared_ptr<T>>(fValuePtrs[i]);
-      }
-      throw RException(R__FAIL("invalid field name: " + std::string(fieldName)));
-   }
-
-   template <typename T>
-   T *GetRaw(std::string_view fieldName) const
+   T *GetValueAs(std::string_view fieldName) const
    {
       for (auto& v : fValues) {
          if (v.GetField().GetName() != fieldName)
@@ -121,7 +108,7 @@ public:
             return v.Get<void>();
 
          if (v.GetField().GetType() != RField<T>::TypeName())
-            throw RException(R__FAIL("type mismatch in REntry::GetRaw()"));
+            throw RException(R__FAIL("type mismatch in REntry::GetValueAs()"));
          return v.Get<T>();
       }
       throw RException(R__FAIL("invalid field name: " + std::string(fieldName)));

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -606,7 +606,8 @@ public:
    std::size_t GetNRepetitions() const { return fNRepetitions; }
    NTupleSize_t GetNElements() const { return fPrincipalColumn->GetNElements(); }
    RFieldBase *GetParent() const { return fParent; }
-   std::vector<RFieldBase *> GetSubFields() const;
+   std::vector<RFieldBase *> GetSubFields();
+   std::vector<const RFieldBase *> GetSubFields() const;
    bool IsSimple() const { return fIsSimple; }
    /// Get the field's description
    std::string GetDescription() const { return fDescription; }

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -1391,7 +1391,7 @@ public:
 class RCollectionField : public ROOT::Experimental::Detail::RFieldBase {
 private:
    /// Save the link to the collection ntuple in order to reset the offset counter when committing the cluster
-   std::shared_ptr<RCollectionNTupleWriter> fCollectionNTuple;
+   std::shared_ptr<RCollectionNTupleWriter> fCollectionWriter;
 
 protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final;
@@ -1404,9 +1404,8 @@ protected:
 
 public:
    static std::string TypeName() { return ""; }
-   RCollectionField(std::string_view name,
-                    std::shared_ptr<RCollectionNTupleWriter> collectionNTuple,
-                    std::unique_ptr<RNTupleModel> collectionModel);
+   RCollectionField(std::string_view name, std::shared_ptr<RCollectionNTupleWriter> collectionWriter,
+                    std::unique_ptr<RFieldBase> collectionMotherField);
    RCollectionField(RCollectionField&& other) = default;
    RCollectionField& operator =(RCollectionField&& other) = default;
    ~RCollectionField() override = default;

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -170,7 +170,7 @@ public:
       }
       ~RValue() { DestroyIfOwning(); }
 
-      RValue GetNonOwningCopy() { return RValue(fField, fObjPtr, false); }
+      RValue GetNonOwningCopy() const { return RValue(fField, fObjPtr, false); }
 
       template <typename T>
       void *Release()

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -192,7 +192,7 @@ public:
       }
 
       template <typename T>
-      T *Get() const
+      T *GetAs() const
       {
          return static_cast<T *>(fObjPtr);
       }

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -196,7 +196,6 @@ public:
       {
          return static_cast<T *>(fObjPtr);
       }
-      void *GetRawPtr() const { return fObjPtr; }
       const RFieldBase &GetField() const { return *fField; }
    }; // class RValue
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -143,7 +143,7 @@ public:
 
    private:
       RFieldBase *fField = nullptr; ///< The field that created the RValue
-      /// Created by RFieldBase::GenerateValue() or a non-owning pointer from SplitValue() or BindValue()
+      /// Created by RFieldBase::GenerateValue() or a non-owning pointer from SplitValue(), BindValue(), or BindRaw()
       void *fObjPtr = nullptr;
       bool fIsOwning = false; ///< If true, fObjPtr is destroyed in the destructor
 
@@ -184,6 +184,12 @@ public:
       std::size_t Append() { return fField->Append(fObjPtr); }
       void Read(NTupleSize_t globalIndex) { fField->Read(globalIndex, fObjPtr); }
       void Read(const RClusterIndex &clusterIndex) { fField->Read(clusterIndex, fObjPtr); }
+      void BindRaw(void *objPtr)
+      {
+         DestroyIfOwning();
+         fObjPtr = objPtr;
+         fIsOwning = false;
+      }
 
       template <typename T>
       T *Get() const
@@ -191,7 +197,7 @@ public:
          return static_cast<T *>(fObjPtr);
       }
       void *GetRawPtr() const { return fObjPtr; }
-      RFieldBase *GetField() const { return fField; }
+      const RFieldBase &GetField() const { return *fField; }
    }; // class RValue
 
    /// Similar to RValue but manages an array of consecutive values. Bulks have to come from the same cluster.

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -633,6 +633,14 @@ public:
    /// Return the C++ type version stored in the field descriptor; only valid after a call to `ConnectPageSource()`
    std::uint32_t GetOnDiskTypeVersion() const { return fOnDiskTypeVersion; }
 
+   /// Returns zero for equivalent field (trees), -1 otherwise. Fields are equivalent if
+   ///   - they have the same name
+   ///   - they have the same type and type version
+   ///   - their subfields are equivalent and in the same order
+   /// We may use the return value in the future to give more fine-grained information
+   /// about the differences between the fields.
+   int Compare(const RFieldBase &other) const;
+
    RSchemaIterator begin()
    {
       return fSubFields.empty() ? RSchemaIterator(this, -1) : RSchemaIterator(fSubFields[0].get(), 0);

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -600,6 +600,7 @@ public:
    std::string GetName() const { return fName; }
    /// Returns the field name and parent field names separated by dots ("grandparent.parent.child")
    std::string GetQualifiedFieldName() const;
+   bool IsTopLevelField() const;
    std::string GetType() const { return fType; }
    std::string GetTypeAlias() const { return fTypeAlias; }
    ENTupleStructure GetStructure() const { return fStructure; }

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -605,7 +605,7 @@ public:
    ENTupleStructure GetStructure() const { return fStructure; }
    std::size_t GetNRepetitions() const { return fNRepetitions; }
    NTupleSize_t GetNElements() const { return fPrincipalColumn->GetNElements(); }
-   RFieldBase *GetParent() const { return fParent; }
+   const RFieldBase *GetParent() const { return fParent; }
    std::vector<RFieldBase *> GetSubFields();
    std::vector<const RFieldBase *> GetSubFields() const;
    bool IsSimple() const { return fIsSimple; }

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -126,6 +126,16 @@ private:
    RNTupleReader *GetDisplayReader();
    void InitPageSource();
 
+   void inline EnsureModel()
+   {
+      if (R__likely(fModel))
+         return;
+
+      fModel = fSource->GetSharedDescriptorGuard()->GenerateModel();
+      ConnectModel(*fModel);
+      fDefaultEntry = fModel->GetDefaultEntry().lock();
+   }
+
 public:
    // Browse through the entries
    class RIterator {
@@ -248,11 +258,7 @@ public:
    /// On I/O errors, raises an exception.
    void LoadEntry(NTupleSize_t index) {
       // TODO(jblomer): can be templated depending on the factory method / constructor
-      if (R__unlikely(!fModel)) {
-         fModel = fSource->GetSharedDescriptorGuard()->GenerateModel();
-         ConnectModel(*fModel);
-         fDefaultEntry = fModel->GetDefaultEntry().lock();
-      }
+      EnsureModel();
       LoadEntry(index, *fDefaultEntry);
    }
    /// Fills a user provided entry after checking that the entry has been instantiated from the ntuple model

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -426,6 +426,7 @@ public:
    void CommitCluster(bool commitClusterGroup = false);
 
    std::weak_ptr<REntry> CreateEntry(REntry *linkedEntry = nullptr) { return fModel->CreateEntry(linkedEntry); }
+   std::weak_ptr<REntry> CreateBareEntry(REntry *linkedEntry = nullptr) { return fModel->CreateBareEntry(linkedEntry); }
 
    void EnableMetrics() { fMetrics.Enable(); }
    const Detail::RNTupleMetrics &GetMetrics() const { return fMetrics; }

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -256,11 +256,7 @@ public:
       LoadEntry(index, *fDefaultEntry);
    }
    /// Fills a user provided entry after checking that the entry has been instantiated from the ntuple model
-   void LoadEntry(NTupleSize_t index, REntry &entry) {
-      for (auto& value : entry) {
-         value.Read(index);
-      }
-   }
+   void LoadEntry(NTupleSize_t index, REntry &entry) { entry.Read(index); }
 
    /// Returns an iterator over the entry indices of the RNTuple.
    ///
@@ -417,10 +413,7 @@ public:
       if (R__unlikely(entry.GetModelId() != fModel->GetModelId()))
          throw RException(R__FAIL("mismatch between entry and model"));
 
-      std::size_t bytesWritten = 0;
-      for (auto& value : entry) {
-         bytesWritten += value.Append();
-      }
+      const std::size_t bytesWritten = entry.Append();
       fUnzippedClusterSize += bytesWritten;
       fNEntries++;
       if ((fUnzippedClusterSize >= fMaxUnzippedClusterSize) || (fUnzippedClusterSize >= fUnzippedClusterSizeEst))
@@ -493,9 +486,7 @@ public:
    void Fill() { Fill(*fCreatedEntries[fDefaultEntryIdx]); }
    void Fill(REntry &entry)
    {
-      for (auto &value : entry) {
-         value.Append();
-      }
+      entry.Append();
       fOffset++;
    }
 

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -397,7 +397,7 @@ private:
    std::unique_ptr<Detail::RPageStorage::RTaskScheduler> fZipTasks;
    std::unique_ptr<Detail::RPageSink> fSink;
    /// Needs to be destructed before fSink
-   std::unique_ptr<RNTupleModel> fModel;
+   std::shared_ptr<RNTupleModel> fModel;
    /// Caches a shared pointer of fModel's default entry if it is not bare
    std::shared_ptr<REntry> fDefaultEntry;
    std::shared_ptr<Detail::RNTupleMetrics> fMetrics;
@@ -462,7 +462,15 @@ public:
    void EnableMetrics() { fMetrics->Enable(); }
    std::shared_ptr<const Detail::RNTupleMetrics> GetMetrics() const { return fMetrics; }
 
-   const RNTupleModel *GetModel() const { return fModel.get(); }
+   std::weak_ptr<const RNTupleModel> GetModel() const { return fModel; }
+   // TODO(jblomer): return as shared ptr
+   template <typename T>
+   T *GetDefaultValueAs(std::string_view fieldName)
+   {
+      if (!fDefaultEntry)
+         throw RException(R__FAIL("invalid attempt to get default value of a writer with a bare model"));
+      return fDefaultEntry->GetRaw<T>(fieldName);
+   }
 
    /// Get a `RNTupleModel::RUpdater` that provides limited support for incremental updates to the underlying
    /// model, e.g. addition of new fields.

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -220,7 +220,7 @@ public:
       EnsureModel();
       if (!fDefaultEntry)
          throw RException(R__FAIL("invalid attempt to get default value of a reader with a bare model"));
-      return fDefaultEntry->GetRaw<T>(fieldName);
+      return fDefaultEntry->GetValueAs<T>(fieldName);
    }
    NTupleSize_t GetNEntries() const { return fSource->GetNEntries(); }
 
@@ -469,7 +469,7 @@ public:
    {
       if (!fDefaultEntry)
          throw RException(R__FAIL("invalid attempt to get default value of a writer with a bare model"));
-      return fDefaultEntry->GetRaw<T>(fieldName);
+      return fDefaultEntry->GetValueAs<T>(fieldName);
    }
 
    /// Get a `RNTupleModel::RUpdater` that provides limited support for incremental updates to the underlying

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -122,7 +122,7 @@ private:
    std::unique_ptr<RNTupleDescriptor> fCachedDescriptor;
    Detail::RNTupleMetrics fMetrics;
 
-   void ConnectModel(const RNTupleModel &model);
+   void ConnectModel(RNTupleModel &model);
    RNTupleReader *GetDisplayReader();
    void InitPageSource();
 

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -264,6 +264,12 @@ public:
    /// Fills a user provided entry after checking that the entry has been instantiated from the ntuple model
    void LoadEntry(NTupleSize_t index, REntry &entry) { entry.Read(index); }
 
+   Detail::RFieldBase::RBulk GenerateBulk(std::string_view fieldName)
+   {
+      EnsureModel();
+      return fModel->GenerateBulk(fieldName);
+   }
+
    /// Returns an iterator over the entry indices of the RNTuple.
    ///
    /// **Example: iterate over all entries and print each entry in JSON format**

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -119,7 +119,7 @@ private:
    /// descriptor.  Using the descriptor's generation number, we know if the cached descriptor is stale.
    /// Retrieving descriptor data from an RNTupleReader is supposed to be for testing and information purposes,
    /// not on a hot code path.
-   std::unique_ptr<RNTupleDescriptor> fCachedDescriptor;
+   std::shared_ptr<RNTupleDescriptor> fCachedDescriptor;
    Detail::RNTupleMetrics fMetrics;
 
    void ConnectModel(RNTupleModel &model);
@@ -217,7 +217,7 @@ public:
 
    /// Returns a cached copy of the page source descriptor. The returned pointer remains valid until the next call
    /// to LoadEntry or to any of the views returned from the reader.
-   const RNTupleDescriptor *GetDescriptor();
+   std::shared_ptr<const RNTupleDescriptor> GetDescriptor();
 
    /// Prints a detailed summary of the ntuple, including a list of fields.
    ///

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -425,7 +425,7 @@ public:
    /// Ensure that the data from the so far seen Fill calls has been written to storage
    void CommitCluster(bool commitClusterGroup = false);
 
-   std::unique_ptr<REntry> CreateEntry() { return fModel->CreateEntry(); }
+   std::weak_ptr<REntry> CreateEntry(REntry *linkedEntry = nullptr) { return fModel->CreateEntry(linkedEntry); }
 
    void EnableMetrics() { fMetrics.Enable(); }
    const Detail::RNTupleMetrics &GetMetrics() const { return fMetrics; }

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -83,10 +83,11 @@ public:
 \ingroup NTuple
 \brief An RNTuple that is used to read data from storage
 
-An input ntuple provides data from storage as C++ objects. The ntuple model can be created from the data on storage
-or it can be imposed by the user. The latter case allows users to read into a specialized ntuple model that covers
-only a subset of the fields in the ntuple. The ntuple model is used when reading complete entries.
-Individual fields can be read as well by instantiating a tree view.
+The reader provides an API for iterating through an RNTuple data set. The ntuple model can be created from the data on
+storage or it can be imposed by the user. The latter case allows users to read into a specialized ntuple model that
+covers only a subset of the fields in the ntuple.
+
+The model is used when reading complete entries; individual fields can be read as well by instantiating a view.
 
 ~~~ {.cpp}
 #include <ROOT/RNTuple.hxx>
@@ -382,10 +383,9 @@ public:
 \ingroup NTuple
 \brief An RNTuple that gets filled with entries (data) and writes them to storage
 
-An output ntuple can be filled with entries. The caller has to make sure that the data that gets filled into an ntuple
-is not modified for the time of the Fill() call. The fill call serializes the C++ object into the column format and
-writes data into the corresponding column page buffers.  Writing of the buffers to storage is deferred and can be
-triggered by Flush() or by destructing the ntuple.  On I/O errors, an exception is thrown.
+A writer can fill entries into an ntuple. The fill call serializes the C++ object into the column format and
+writes data into the corresponding column page buffers.  Writing of the buffers to storage is deferred and scheduled
+internally.  The written data are committed when the writer is destructed.  On I/O errors, an exception is thrown.
 */
 // clang-format on
 class RNTupleWriter {

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -120,7 +120,7 @@ private:
    /// Retrieving descriptor data from an RNTupleReader is supposed to be for testing and information purposes,
    /// not on a hot code path.
    std::shared_ptr<RNTupleDescriptor> fCachedDescriptor;
-   Detail::RNTupleMetrics fMetrics;
+   std::shared_ptr<Detail::RNTupleMetrics> fMetrics;
 
    void ConnectModel(RNTupleModel &model);
    RNTupleReader *GetDisplayReader();
@@ -372,8 +372,8 @@ public:
    /// }
    /// ntuple->PrintInfo(ENTupleInfo::kMetrics);
    /// ~~~
-   void EnableMetrics() { fMetrics.Enable(); }
-   const Detail::RNTupleMetrics &GetMetrics() const { return fMetrics; }
+   void EnableMetrics() { fMetrics->Enable(); }
+   std::shared_ptr<const Detail::RNTupleMetrics> GetMetrics() const { return fMetrics; }
 };
 
 // clang-format off
@@ -400,7 +400,7 @@ private:
    std::unique_ptr<RNTupleModel> fModel;
    /// Caches a shared pointer of fModel's default entry if it is not bare
    std::shared_ptr<REntry> fDefaultEntry;
-   Detail::RNTupleMetrics fMetrics;
+   std::shared_ptr<Detail::RNTupleMetrics> fMetrics;
    NTupleSize_t fLastCommitted = 0;
    NTupleSize_t fLastCommittedClusterGroup = 0;
    NTupleSize_t fNEntries = 0;
@@ -459,8 +459,8 @@ public:
    std::weak_ptr<REntry> CreateEntry(REntry *linkedEntry = nullptr) { return fModel->CreateEntry(linkedEntry); }
    std::weak_ptr<REntry> CreateBareEntry(REntry *linkedEntry = nullptr) { return fModel->CreateBareEntry(linkedEntry); }
 
-   void EnableMetrics() { fMetrics.Enable(); }
-   const Detail::RNTupleMetrics &GetMetrics() const { return fMetrics; }
+   void EnableMetrics() { fMetrics->Enable(); }
+   std::shared_ptr<const Detail::RNTupleMetrics> GetMetrics() const { return fMetrics; }
 
    const RNTupleModel *GetModel() const { return fModel.get(); }
 

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -213,6 +213,12 @@ public:
    ~RNTupleReader();
 
    const RNTupleModel *GetModel();
+   // TODO(jblomer): return as shared ptr
+   template <typename T>
+   T *GetDefaultValueAs(std::string_view fieldName)
+   {
+      return GetModel()->GetDefaultEntry().lock()->GetRaw<T>(fieldName);
+   }
    NTupleSize_t GetNEntries() const { return fSource->GetNEntries(); }
 
    /// Returns a cached copy of the page source descriptor. The returned pointer remains valid until the next call

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -202,7 +202,7 @@ public:
    std::unique_ptr<RNTupleReader> Clone() { return std::make_unique<RNTupleReader>(fSource->Clone()); }
    ~RNTupleReader();
 
-   RNTupleModel *GetModel();
+   const RNTupleModel *GetModel();
    NTupleSize_t GetNEntries() const { return fSource->GetNEntries(); }
 
    /// Returns a cached copy of the page source descriptor. The returned pointer remains valid until the next call

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -333,15 +333,6 @@ public:
    /// Projected fields can only be used for models used to write data.
    RResult<void> AddProjectedField(std::unique_ptr<Detail::RFieldBase> field,
                                    std::function<std::string(const std::string &)> mapping);
-
-   // TODO(jblomer): return shared ptr
-   template <typename T>
-   T *Get(std::string_view fieldName) const
-   {
-      EnsureNotBare();
-      return GetDefaultEntryPtr()->GetRaw<T>(fieldName);
-   }
-
    const RProjectedFields &GetProjectedFields() const { return *fProjectedFields; }
 
    void Freeze();

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -179,9 +179,14 @@ private:
    std::string fDescription;
    /// The set of projected top-level fields
    std::unique_ptr<RProjectedFields> fProjectedFields;
-   /// Upon freezing, every model has a unique ID to distingusish it from other models.  Cloning preserves the ID.
-   /// Entries are linked to models via the ID.
+   /// Upon freezing, every model has a unique ID to distingusish it from other models.
+   /// Entries are linked to models via the ID.  Unfreezing and re-freezing will update the model id and
+   /// thus invalidate existing entries. Cloning will also update the model id because the cloned model
+   /// as new fields so that existing entries cannot be used with the clone.
    std::uint64_t fModelId = 0;
+
+   /// Returns a new, unique ID
+   static std::uint64_t GetNewModelId();
 
    /// Checks that user-provided field names are valid in the context
    /// of this NTuple model. Throws an RException for invalid names.

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -348,7 +348,7 @@ public:
       return CreateEntryImpl(false /* isBare */, linkedEntry);
    }
    /// In a bare entry, all values not covered by the linked entry point to nullptr.
-   /// The resulting entry shall use CaptureValueUnsafe() in order set memory addresses to be serialized / deserialized
+   /// The resulting entry shall use BindValue() in order set memory addresses to be serialized / deserialized
    std::weak_ptr<REntry> CreateBareEntry(REntry *linkedEntry = nullptr)
    {
       return CreateEntryImpl(true /* isBare */, linkedEntry);

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -71,8 +71,12 @@ struct RNTupleModelChangeset {
 \brief The RNTupleModel encapulates the schema of an ntuple.
 
 The ntuple model comprises a collection of hierarchically organized fields. From a model, "entries"
-can be extracted. For convenience, the model provides a default entry. Models have a unique model identifier
-that faciliates checking whether entries are compatible with it (i.e.: have been extracted from that model).
+can be extracted. For convenience, the model provides a default entry unless it is created as a "bare model".
+Models have a unique model identifier that faciliates checking whether entries are compatible with it
+(i.e.: have been extracted from that model).
+
+A model is subject to a state transition during its lifetime: it starts in a building state, in which fields can be
+added and modified.  Once the schema is finalized, the model gets frozen.  Only frozen models can create entries.
 */
 // clang-format on
 class RNTupleModel {
@@ -191,7 +195,7 @@ private:
    std::unique_ptr<RFieldZero> fFieldZero;
    /// Entries handed out by CreateEntry or CreateBareEntry are owned and tracked by the model.
    /// Callers retrieve a weak pointer to the corresponding entry.  This ensures that entries
-   /// get destructed while the model is still alive (the entry's values may use the model's fields to
+   /// get destructed while the model is still alive (the entry's values may use the model's fields
    /// for destruction).
    std::vector<std::shared_ptr<REntry>> fCreatedEntries;
    /// A model that is not bare contains a default entry, whose values can be used during the construction phase.
@@ -206,7 +210,7 @@ private:
    /// Upon freezing, every model has a unique ID to distingusish it from other models.
    /// Entries are linked to models via the ID.  Unfreezing and re-freezing will update the model id and
    /// thus invalidate existing entries. Cloning will also update the model id because the cloned model
-   /// as new fields so that existing entries cannot be used with the clone.
+   /// has new fields so that existing entries cannot be used with the clone.
    std::uint64_t fModelId = 0;
 
    /// Returns a new, unique ID
@@ -352,8 +356,8 @@ public:
    /// is destructed, there must be no remaining shared pointers to any of its entries.
    /// An entry can only be returned from a frozen model. Unfreezing and refreezing invalidates existing entries.
    ///
-   /// If a linked entry is given, create entry will use the memory location of the linked
-   /// entries for identical fields.  Fields that don't mach any of the linked entry ones
+   /// If a linked entry is given, CreateEntry will use the memory location of the linked
+   /// entry's values for identical fields.  Fields that don't mach any of the linked entry ones
    /// are handled as if no linked entry was given.  If the linked entry contains a field
    /// with the same name than this entry but a different type, the linked entry's field
    /// is ignored.

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -361,7 +361,6 @@ public:
    std::weak_ptr<REntry> GetDefaultEntry() const;
 
    Detail::RFieldBase::RBulk GenerateBulk(std::string_view fieldName);
-   void CommitCluster();
 
    bool HasField(std::string_view fieldName) const { return FindField(fieldName) != nullptr; }
    Detail::RFieldBase &GetField(std::string_view fieldName);

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -219,6 +219,9 @@ private:
    RNTupleModel();
 
 public:
+   using Iterator_t = Detail::RFieldBase::RSchemaIterator;
+   using ConstIterator_t = Detail::RFieldBase::RConstSchemaIterator;
+
    RNTupleModel(const RNTupleModel&) = delete;
    RNTupleModel& operator =(const RNTupleModel&) = delete;
    ~RNTupleModel();
@@ -368,6 +371,21 @@ public:
 
    std::string GetDescription() const { return fDescription; }
    void SetDescription(std::string_view description);
+
+   ConstIterator_t cbegin() const { return fFieldZero->cbegin(); }
+   ConstIterator_t cend() const { return fFieldZero->cend(); }
+   ConstIterator_t begin() const { return cbegin(); }
+   ConstIterator_t end() const { return cend(); }
+   Iterator_t begin()
+   {
+      EnsureNotFrozen();
+      return fFieldZero->begin();
+   }
+   Iterator_t end()
+   {
+      EnsureNotFrozen();
+      return fFieldZero->end();
+   }
 };
 
 } // namespace Experimental

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -334,6 +334,7 @@ public:
    RResult<void> AddProjectedField(std::unique_ptr<Detail::RFieldBase> field,
                                    std::function<std::string(const std::string &)> mapping);
 
+   // TODO(jblomer): return shared ptr
    template <typename T>
    T *Get(std::string_view fieldName) const
    {

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -158,7 +158,7 @@ public:
       void AddField(const NameWithDescription_t &fieldNameDesc, T *fromWhere)
       {
          fOpenChangeset.fModel.AddField<T>(fieldNameDesc, fromWhere);
-         auto fieldZero = fOpenChangeset.fModel.GetFieldZero();
+         auto fieldZero = fOpenChangeset.fModel.fFieldZero.get();
          auto it = std::find_if(fieldZero->begin(), fieldZero->end(),
                                 [&](const auto &f) { return f.GetName() == fieldNameDesc.fName; });
          R__ASSERT(it != fieldZero->end());
@@ -360,7 +360,6 @@ public:
    }
    std::weak_ptr<REntry> GetDefaultEntry() const;
 
-   RFieldZero *GetFieldZero() const { return fFieldZero.get(); }
    Detail::RFieldBase::RBulk GenerateBulk(std::string_view fieldName);
    void CommitCluster();
 
@@ -368,6 +367,9 @@ public:
    Detail::RFieldBase &GetField(std::string_view fieldName);
    const Detail::RFieldBase &GetField(std::string_view fieldName) const;
    const Detail::RFieldBase &GetConstField(std::string_view fieldName) const { return GetField(fieldName); }
+   const RFieldZero &GetFieldZero() const { return *fFieldZero; }
+   // TODO(jblomer): remove me
+   RFieldZero *GetFieldZeroPtr() { return fFieldZero.get(); }
 
    std::string GetDescription() const { return fDescription; }
    void SetDescription(std::string_view description);

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -358,6 +358,7 @@ public:
    std::weak_ptr<REntry> GetDefaultEntry() const;
 
    RFieldZero *GetFieldZero() const { return fFieldZero.get(); }
+   bool HasField(std::string_view fieldName) const { return FindField(fieldName) != nullptr; }
    const Detail::RFieldBase &GetField(std::string_view fieldName) const;
    const Detail::RFieldBase &GetConstField(std::string_view fieldName) const { return GetField(fieldName); }
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -316,7 +316,7 @@ public:
    T *Get(std::string_view fieldName) const
    {
       EnsureNotBare();
-      return GetDefaultEntryPtr()->Get<T>(fieldName);
+      return GetDefaultEntryPtr()->GetRaw<T>(fieldName);
    }
 
    const RProjectedFields &GetProjectedFields() const { return *fProjectedFields; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -359,6 +359,7 @@ public:
 
    RFieldZero *GetFieldZero() const { return fFieldZero.get(); }
    bool HasField(std::string_view fieldName) const { return FindField(fieldName) != nullptr; }
+   Detail::RFieldBase &GetField(std::string_view fieldName);
    const Detail::RFieldBase &GetField(std::string_view fieldName) const;
    const Detail::RFieldBase &GetConstField(std::string_view fieldName) const { return GetField(fieldName); }
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -358,6 +358,8 @@ public:
    std::weak_ptr<REntry> GetDefaultEntry() const;
 
    RFieldZero *GetFieldZero() const { return fFieldZero.get(); }
+   Detail::RFieldBase::RBulk GenerateBulk(std::string_view fieldName);
+
    bool HasField(std::string_view fieldName) const { return FindField(fieldName) != nullptr; }
    Detail::RFieldBase &GetField(std::string_view fieldName);
    const Detail::RFieldBase &GetField(std::string_view fieldName) const;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -359,6 +359,7 @@ public:
 
    RFieldZero *GetFieldZero() const { return fFieldZero.get(); }
    Detail::RFieldBase::RBulk GenerateBulk(std::string_view fieldName);
+   void CommitCluster();
 
    bool HasField(std::string_view fieldName) const { return FindField(fieldName) != nullptr; }
    Detail::RFieldBase &GetField(std::string_view fieldName);

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -368,8 +368,10 @@ public:
    const Detail::RFieldBase &GetField(std::string_view fieldName) const;
    const Detail::RFieldBase &GetConstField(std::string_view fieldName) const { return GetField(fieldName); }
    const RFieldZero &GetFieldZero() const { return *fFieldZero; }
-   // TODO(jblomer): remove me
-   RFieldZero *GetFieldZeroPtr() { return fFieldZero.get(); }
+
+   // Only used by the RNTuple reader and writer and by RNTupleDescriptor::GenerateModel in order to
+   // set the on-disk field IDs and to connect the sub fields.
+   RFieldZero &GetMutableFieldZero() { return *fFieldZero; }
 
    std::string GetDescription() const { return fDescription; }
    void SetDescription(std::string_view description);

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -214,6 +214,8 @@ private:
    /// the objects are generated if isBare is false, or nullptr otherwise.
    std::weak_ptr<REntry> CreateEntryImpl(bool isBare, REntry *linkedEntry = nullptr);
 
+   Detail::RFieldBase *FindField(std::string_view fieldName) const;
+
    RNTupleModel();
 
 public:
@@ -356,7 +358,8 @@ public:
    std::weak_ptr<REntry> GetDefaultEntry() const;
 
    RFieldZero *GetFieldZero() const { return fFieldZero.get(); }
-   const Detail::RFieldBase *GetField(std::string_view fieldName) const;
+   const Detail::RFieldBase &GetField(std::string_view fieldName) const;
+   const Detail::RFieldBase &GetConstField(std::string_view fieldName) const { return GetField(fieldName); }
 
    std::string GetDescription() const { return fDescription; }
    void SetDescription(std::string_view description);

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -182,7 +182,7 @@ public:
          return *fField.Map(globalIndex);
       else {
          fValue.Read(globalIndex);
-         return *fValue.Get<T>();
+         return *fValue.GetAs<T>();
       }
    }
 
@@ -192,7 +192,7 @@ public:
          return *fField.Map(clusterIndex);
       else {
          fValue.Read(clusterIndex);
-         return *fValue.Get<T>();
+         return *fValue.GetAs<T>();
       }
    }
 

--- a/tree/ntuple/v7/src/REntry.cxx
+++ b/tree/ntuple/v7/src/REntry.cxx
@@ -23,7 +23,7 @@ void ROOT::Experimental::REntry::AddValue(Detail::RFieldBase::RValue &&value)
    fValues.emplace_back(std::move(value));
 }
 
-void ROOT::Experimental::REntry::BindValue(std::string_view fieldName, void *where)
+void ROOT::Experimental::REntry::BindRaw(std::string_view fieldName, void *where)
 {
    for (std::size_t i = 0; i < fValues.size(); ++i) {
       if (fValues[i].GetField().GetName() != fieldName)

--- a/tree/ntuple/v7/src/REntry.cxx
+++ b/tree/ntuple/v7/src/REntry.cxx
@@ -26,9 +26,9 @@ void ROOT::Experimental::REntry::AddValue(Detail::RFieldBase::RValue &&value)
 void ROOT::Experimental::REntry::BindValue(std::string_view fieldName, void *where)
 {
    for (std::size_t i = 0; i < fValues.size(); ++i) {
-      if (fValues[i].GetField()->GetName() != fieldName)
+      if (fValues[i].GetField().GetName() != fieldName)
          continue;
-      fValues[i] = fValues[i].GetField()->BindValue(where);
+      fValues[i].BindRaw(where);
       return;
    }
    throw RException(R__FAIL("invalid field name: " + std::string(fieldName)));

--- a/tree/ntuple/v7/src/REntry.cxx
+++ b/tree/ntuple/v7/src/REntry.cxx
@@ -21,6 +21,7 @@
 void ROOT::Experimental::REntry::AddValue(Detail::RFieldBase::RValue &&value)
 {
    fValues.emplace_back(std::move(value));
+   fValuePtrs.emplace_back(nullptr);
 }
 
 void ROOT::Experimental::REntry::BindRaw(std::string_view fieldName, void *where)
@@ -30,6 +31,16 @@ void ROOT::Experimental::REntry::BindRaw(std::string_view fieldName, void *where
          continue;
       fValues[i].BindRaw(where);
       return;
+   }
+   throw RException(R__FAIL("invalid field name: " + std::string(fieldName)));
+}
+
+bool ROOT::Experimental::REntry::IsManaged(std::string_view fieldName) const
+{
+   for (std::size_t i = 0; i < fValues.size(); ++i) {
+      if (fValues[i].GetField().GetName() != fieldName)
+         continue;
+      return static_cast<bool>(fValuePtrs[i]);
    }
    throw RException(R__FAIL("invalid field name: " + std::string(fieldName)));
 }

--- a/tree/ntuple/v7/src/REntry.cxx
+++ b/tree/ntuple/v7/src/REntry.cxx
@@ -23,7 +23,7 @@ void ROOT::Experimental::REntry::AddValue(Detail::RFieldBase::RValue &&value)
    fValues.emplace_back(std::move(value));
 }
 
-void ROOT::Experimental::REntry::CaptureValueUnsafe(std::string_view fieldName, void *where)
+void ROOT::Experimental::REntry::BindValue(std::string_view fieldName, void *where)
 {
    for (std::size_t i = 0; i < fValues.size(); ++i) {
       if (fValues[i].GetField()->GetName() != fieldName)

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1477,7 +1477,7 @@ ROOT::Experimental::RClassField::SplitValue(const RValue &value) const
 {
    std::vector<RValue> result;
    for (unsigned i = 0; i < fSubFields.size(); i++) {
-      result.emplace_back(fSubFields[i]->BindValue(value.Get<unsigned char>() + fSubFieldsInfo[i].fOffset));
+      result.emplace_back(fSubFields[i]->BindValue(value.GetAs<unsigned char>() + fSubFieldsInfo[i].fOffset));
    }
    return result;
 }
@@ -1552,7 +1552,7 @@ std::vector<ROOT::Experimental::Detail::RFieldBase::RValue>
 ROOT::Experimental::REnumField::SplitValue(const RValue &value) const
 {
    std::vector<RValue> result;
-   result.emplace_back(fSubFields[0]->BindValue(value.Get<void>()));
+   result.emplace_back(fSubFields[0]->BindValue(value.GetAs<void>()));
    return result;
 }
 
@@ -1735,8 +1735,8 @@ std::vector<ROOT::Experimental::Detail::RFieldBase::RValue>
 ROOT::Experimental::RProxiedCollectionField::SplitValue(const RValue &value) const
 {
    std::vector<RValue> result;
-   TVirtualCollectionProxy::TPushPop RAII(fProxy.get(), value.Get<void>());
-   for (auto ptr : RCollectionIterableOnce{value.Get<void>(), fIFuncsWrite, fProxy.get(),
+   TVirtualCollectionProxy::TPushPop RAII(fProxy.get(), value.GetAs<void>());
+   for (auto ptr : RCollectionIterableOnce{value.GetAs<void>(), fIFuncsWrite, fProxy.get(),
                                            (fCollectionType == kSTLvector ? fItemSize : 0U)}) {
       result.emplace_back(fSubFields[0]->BindValue(ptr));
    }
@@ -1852,7 +1852,7 @@ ROOT::Experimental::RRecordField::SplitValue(const RValue &value) const
 {
    std::vector<RValue> result;
    for (unsigned i = 0; i < fSubFields.size(); ++i) {
-      result.emplace_back(fSubFields[i]->BindValue(value.Get<unsigned char>() + fOffsets[i]));
+      result.emplace_back(fSubFields[i]->BindValue(value.GetAs<unsigned char>() + fOffsets[i]));
    }
    return result;
 }
@@ -1978,7 +1978,7 @@ void ROOT::Experimental::RVectorField::DestroyValue(void *objPtr, bool dtorOnly)
 std::vector<ROOT::Experimental::Detail::RFieldBase::RValue>
 ROOT::Experimental::RVectorField::SplitValue(const RValue &value) const
 {
-   auto vec = value.Get<std::vector<char>>();
+   auto vec = value.GetAs<std::vector<char>>();
    R__ASSERT((vec->size() % fItemSize) == 0);
    auto nItems = vec->size() / fItemSize;
    std::vector<RValue> result;
@@ -2229,7 +2229,7 @@ void ROOT::Experimental::RRVecField::DestroyValue(void *objPtr, bool dtorOnly) c
 std::vector<ROOT::Experimental::Detail::RFieldBase::RValue>
 ROOT::Experimental::RRVecField::SplitValue(const RValue &value) const
 {
-   auto [beginPtr, sizePtr, _] = GetRVecDataMembers(value.Get<void>());
+   auto [beginPtr, sizePtr, _] = GetRVecDataMembers(value.GetAs<void>());
 
    std::vector<RValue> result;
    char *begin = reinterpret_cast<char *>(*beginPtr); // for pointer arithmetics
@@ -2369,7 +2369,7 @@ ROOT::Experimental::RField<std::vector<bool>>::SplitValue(const RValue &value) c
    const static bool trueValue = true;
    const static bool falseValue = false;
 
-   auto typedValue = value.Get<std::vector<bool>>();
+   auto typedValue = value.GetAs<std::vector<bool>>();
    auto count = typedValue->size();
    std::vector<RValue> result;
    for (unsigned i = 0; i < count; ++i) {
@@ -2466,7 +2466,7 @@ void ROOT::Experimental::RArrayField::DestroyValue(void *objPtr, bool dtorOnly) 
 std::vector<ROOT::Experimental::Detail::RFieldBase::RValue>
 ROOT::Experimental::RArrayField::SplitValue(const RValue &value) const
 {
-   auto arrayPtr = value.Get<unsigned char>();
+   auto arrayPtr = value.GetAs<unsigned char>();
    std::vector<RValue> result;
    for (unsigned i = 0; i < fArrayLength; ++i) {
       result.emplace_back(fSubFields[0]->BindValue(arrayPtr + (i * fItemSize)));
@@ -2732,7 +2732,7 @@ std::size_t ROOT::Experimental::RNullableField::AppendNull()
    if (IsDense()) {
       bool mask = false;
       fPrincipalColumn->Append(&mask);
-      return 1 + CallAppendOn(*fSubFields[0], fDefaultItemValue->Get<void>());
+      return 1 + CallAppendOn(*fSubFields[0], fDefaultItemValue->GetAs<void>());
    } else {
       fPrincipalColumn->Append(&fNWritten);
       return sizeof(ClusterSize_t);
@@ -2841,7 +2841,7 @@ std::vector<ROOT::Experimental::Detail::RFieldBase::RValue>
 ROOT::Experimental::RUniquePtrField::SplitValue(const RValue &value) const
 {
    std::vector<RValue> result;
-   auto ptr = value.Get<std::unique_ptr<char>>();
+   auto ptr = value.GetAs<std::unique_ptr<char>>();
    if (*ptr) {
       result.emplace_back(fSubFields[0]->BindValue(ptr->get()));
    }
@@ -3044,7 +3044,7 @@ std::vector<ROOT::Experimental::Detail::RFieldBase::RValue>
 ROOT::Experimental::RAtomicField::SplitValue(const RValue &value) const
 {
    std::vector<RValue> result;
-   result.emplace_back(fSubFields[0]->BindValue(value.Get<void>()));
+   result.emplace_back(fSubFields[0]->BindValue(value.GetAs<void>()));
    return result;
 }
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -344,6 +344,11 @@ std::string ROOT::Experimental::Detail::RFieldBase::GetQualifiedFieldName() cons
    return result;
 }
 
+bool ROOT::Experimental::Detail::RFieldBase::IsTopLevelField() const
+{
+   return dynamic_cast<RFieldZero *>(fParent) != nullptr;
+}
+
 ROOT::Experimental::RResult<std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>>
 ROOT::Experimental::Detail::RFieldBase::Create(const std::string &fieldName, const std::string &typeName)
 {

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -2973,18 +2973,15 @@ void ROOT::Experimental::RTupleField::DestroyValue(void *objPtr, bool dtorOnly) 
 
 //------------------------------------------------------------------------------
 
-ROOT::Experimental::RCollectionField::RCollectionField(
-   std::string_view name,
-   std::shared_ptr<RCollectionNTupleWriter> collectionNTuple,
-   std::unique_ptr<RNTupleModel> collectionModel)
-   : RFieldBase(name, "", ENTupleStructure::kCollection, true /* isSimple */)
-   , fCollectionNTuple(collectionNTuple)
+ROOT::Experimental::RCollectionField::RCollectionField(std::string_view name,
+                                                       std::shared_ptr<RCollectionNTupleWriter> collectionWriter,
+                                                       std::unique_ptr<RFieldBase> collectionMotherField)
+   : RFieldBase(name, "", ENTupleStructure::kCollection, true /* isSimple */), fCollectionWriter(collectionWriter)
 {
-   for (unsigned i = 0; i < collectionModel->GetFieldZeroPtr()->fSubFields.size(); ++i) {
-      auto &subField = collectionModel->GetFieldZeroPtr()->fSubFields[i];
-      Attach(std::move(subField));
+   const std::size_t N = collectionMotherField->fSubFields.size();
+   for (std::size_t i = 0; i < N; ++i) {
+      Attach(std::move(collectionMotherField->fSubFields[i]));
    }
-   SetDescription(collectionModel->GetDescription());
 }
 
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
@@ -3011,17 +3008,16 @@ void ROOT::Experimental::RCollectionField::GenerateColumnsImpl(const RNTupleDesc
 std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>
 ROOT::Experimental::RCollectionField::CloneImpl(std::string_view newName) const
 {
-   auto result = std::make_unique<RCollectionField>(newName, fCollectionNTuple, RNTupleModel::Create());
+   auto mother = std::make_unique<RFieldZero>();
    for (auto& f : fSubFields) {
-      auto clone = f->Clone(f->GetName());
-      result->Attach(std::move(clone));
+      mother->Attach(f->Clone(f->GetName()));
    }
-   return result;
+   return std::make_unique<RCollectionField>(newName, fCollectionWriter, std::move(mother));
 }
 
 void ROOT::Experimental::RCollectionField::CommitClusterImpl()
 {
-   *fCollectionNTuple->GetOffsetPtr() = 0;
+   *fCollectionWriter->GetOffsetPtr() = 0;
 }
 
 //------------------------------------------------------------------------------

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -336,7 +336,7 @@ ROOT::Experimental::Detail::RFieldBase::~RFieldBase()
 std::string ROOT::Experimental::Detail::RFieldBase::GetQualifiedFieldName() const
 {
    std::string result = GetName();
-   RFieldBase *parent = GetParent();
+   auto parent = GetParent();
    while (parent && !parent->GetName().empty()) {
       result = parent->GetName() + "." + result;
       parent = parent->GetParent();

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -790,6 +790,26 @@ void ROOT::Experimental::Detail::RFieldBase::ConnectPageSource(RPageSource &page
    fState = EState::kConnectedToSource;
 }
 
+int ROOT::Experimental::Detail::RFieldBase::Compare(const RFieldBase &other) const
+{
+   if (GetName() != other.GetName())
+      return -1;
+   if (GetType() != other.GetType())
+      return -1;
+   if (GetFieldVersion() != other.GetFieldVersion() || GetTypeVersion() != other.GetTypeVersion())
+      return -1;
+   auto mySubFields = GetSubFields();
+   auto otherSubFields = other.GetSubFields();
+   if (mySubFields.size() != otherSubFields.size())
+      return -1;
+   for (std::size_t i = 0; i < mySubFields.size(); ++i) {
+      if (mySubFields[i]->Compare(*otherSubFields[i]) != 0) {
+         return -1;
+      }
+   }
+
+   return 0;
+}
 
 void ROOT::Experimental::Detail::RFieldBase::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1538,7 +1538,7 @@ std::vector<ROOT::Experimental::Detail::RFieldBase::RValue>
 ROOT::Experimental::REnumField::SplitValue(const RValue &value) const
 {
    std::vector<RValue> result;
-   result.emplace_back(fSubFields[0]->BindValue(value.GetRawPtr()));
+   result.emplace_back(fSubFields[0]->BindValue(value.Get<void>()));
    return result;
 }
 
@@ -1721,8 +1721,8 @@ std::vector<ROOT::Experimental::Detail::RFieldBase::RValue>
 ROOT::Experimental::RProxiedCollectionField::SplitValue(const RValue &value) const
 {
    std::vector<RValue> result;
-   TVirtualCollectionProxy::TPushPop RAII(fProxy.get(), value.GetRawPtr());
-   for (auto ptr : RCollectionIterableOnce{value.GetRawPtr(), fIFuncsWrite, fProxy.get(),
+   TVirtualCollectionProxy::TPushPop RAII(fProxy.get(), value.Get<void>());
+   for (auto ptr : RCollectionIterableOnce{value.Get<void>(), fIFuncsWrite, fProxy.get(),
                                            (fCollectionType == kSTLvector ? fItemSize : 0U)}) {
       result.emplace_back(fSubFields[0]->BindValue(ptr));
    }
@@ -2215,7 +2215,7 @@ void ROOT::Experimental::RRVecField::DestroyValue(void *objPtr, bool dtorOnly) c
 std::vector<ROOT::Experimental::Detail::RFieldBase::RValue>
 ROOT::Experimental::RRVecField::SplitValue(const RValue &value) const
 {
-   auto [beginPtr, sizePtr, _] = GetRVecDataMembers(value.GetRawPtr());
+   auto [beginPtr, sizePtr, _] = GetRVecDataMembers(value.Get<void>());
 
    std::vector<RValue> result;
    char *begin = reinterpret_cast<char *>(*beginPtr); // for pointer arithmetics
@@ -2718,7 +2718,7 @@ std::size_t ROOT::Experimental::RNullableField::AppendNull()
    if (IsDense()) {
       bool mask = false;
       fPrincipalColumn->Append(&mask);
-      return 1 + CallAppendOn(*fSubFields[0], fDefaultItemValue->GetRawPtr());
+      return 1 + CallAppendOn(*fSubFields[0], fDefaultItemValue->Get<void>());
    } else {
       fPrincipalColumn->Append(&fNWritten);
       return sizeof(ClusterSize_t);
@@ -3034,7 +3034,7 @@ std::vector<ROOT::Experimental::Detail::RFieldBase::RValue>
 ROOT::Experimental::RAtomicField::SplitValue(const RValue &value) const
 {
    std::vector<RValue> result;
-   result.emplace_back(fSubFields[0]->BindValue(value.GetRawPtr()));
+   result.emplace_back(fSubFields[0]->BindValue(value.Get<void>()));
    return result;
 }
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -2980,8 +2980,8 @@ ROOT::Experimental::RCollectionField::RCollectionField(
    : RFieldBase(name, "", ENTupleStructure::kCollection, true /* isSimple */)
    , fCollectionNTuple(collectionNTuple)
 {
-   for (unsigned i = 0; i < collectionModel->GetFieldZero()->fSubFields.size(); ++i) {
-      auto& subField = collectionModel->GetFieldZero()->fSubFields[i];
+   for (unsigned i = 0; i < collectionModel->GetFieldZeroPtr()->fSubFields.size(); ++i) {
+      auto &subField = collectionModel->GetFieldZeroPtr()->fSubFields[i];
       Attach(std::move(subField));
    }
    SetDescription(collectionModel->GetDescription());

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -608,10 +608,19 @@ ROOT::Experimental::Detail::RFieldBase::EntryToColumnElementIndex(ROOT::Experime
    return result;
 }
 
-std::vector<ROOT::Experimental::Detail::RFieldBase *> ROOT::Experimental::Detail::RFieldBase::GetSubFields() const
+std::vector<ROOT::Experimental::Detail::RFieldBase *> ROOT::Experimental::Detail::RFieldBase::GetSubFields()
 {
    std::vector<RFieldBase *> result;
    result.reserve(fSubFields.size());
+   for (const auto &f : fSubFields) {
+      result.emplace_back(f.get());
+   }
+   return result;
+}
+
+std::vector<const ROOT::Experimental::Detail::RFieldBase *> ROOT::Experimental::Detail::RFieldBase::GetSubFields() const
+{
+   std::vector<const RFieldBase *> result;
    for (const auto &f : fSubFields) {
       result.emplace_back(f.get());
    }

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -159,7 +159,7 @@ void ROOT::Experimental::RPrintValueVisitor::VisitBoolField(const RField<bool> &
 {
    PrintIndent();
    PrintName(field);
-   if (*fValue.Get<bool>())
+   if (*fValue.GetAs<bool>())
       fOutput << "true";
    else
       fOutput << "false";
@@ -170,7 +170,7 @@ void ROOT::Experimental::RPrintValueVisitor::VisitDoubleField(const RField<doubl
 {
    PrintIndent();
    PrintName(field);
-   fOutput << *fValue.Get<double>();
+   fOutput << *fValue.GetAs<double>();
 }
 
 
@@ -178,7 +178,7 @@ void ROOT::Experimental::RPrintValueVisitor::VisitFloatField(const RField<float>
 {
    PrintIndent();
    PrintName(field);
-   fOutput << *fValue.Get<float>();
+   fOutput << *fValue.GetAs<float>();
 }
 
 void ROOT::Experimental::RPrintValueVisitor::VisitByteField(const RField<std::byte> &field)
@@ -186,7 +186,7 @@ void ROOT::Experimental::RPrintValueVisitor::VisitByteField(const RField<std::by
    PrintIndent();
    PrintName(field);
    char prev = std::cout.fill();
-   fOutput << "0x" << std::setw(2) << std::setfill('0') << std::hex << (*fValue.Get<unsigned char>() & 0xff);
+   fOutput << "0x" << std::setw(2) << std::setfill('0') << std::hex << (*fValue.GetAs<unsigned char>() & 0xff);
    fOutput << std::resetiosflags(std::ios_base::basefield);
    std::cout.fill(prev);
 }
@@ -195,35 +195,35 @@ void ROOT::Experimental::RPrintValueVisitor::VisitCharField(const RField<char> &
 {
    PrintIndent();
    PrintName(field);
-   fOutput << *fValue.Get<char>();
+   fOutput << *fValue.GetAs<char>();
 }
 
 void ROOT::Experimental::RPrintValueVisitor::VisitInt8Field(const RField<std::int8_t> &field)
 {
    PrintIndent();
    PrintName(field);
-   fOutput << *fValue.Get<std::int8_t>();
+   fOutput << *fValue.GetAs<std::int8_t>();
 }
 
 void ROOT::Experimental::RPrintValueVisitor::VisitInt16Field(const RField<std::int16_t> &field)
 {
    PrintIndent();
    PrintName(field);
-   fOutput << *fValue.Get<std::int16_t>();
+   fOutput << *fValue.GetAs<std::int16_t>();
 }
 
 void ROOT::Experimental::RPrintValueVisitor::VisitIntField(const RField<int> &field)
 {
    PrintIndent();
    PrintName(field);
-   fOutput << *fValue.Get<int>();
+   fOutput << *fValue.GetAs<int>();
 }
 
 void ROOT::Experimental::RPrintValueVisitor::VisitInt64Field(const RField<std::int64_t> &field)
 {
    PrintIndent();
    PrintName(field);
-   fOutput << *fValue.Get<std::int64_t>();
+   fOutput << *fValue.GetAs<std::int64_t>();
 }
 
 void ROOT::Experimental::RPrintValueVisitor::VisitStringField(const RField<std::string> &field)
@@ -231,28 +231,28 @@ void ROOT::Experimental::RPrintValueVisitor::VisitStringField(const RField<std::
    PrintIndent();
    PrintName(field);
    // TODO(jblomer): escape double quotes
-   fOutput << "\"" << *fValue.Get<std::string>() << "\"";
+   fOutput << "\"" << *fValue.GetAs<std::string>() << "\"";
 }
 
 void ROOT::Experimental::RPrintValueVisitor::VisitUInt8Field(const RField<std::uint8_t> &field)
 {
    PrintIndent();
    PrintName(field);
-   fOutput << static_cast<int>(*fValue.Get<std::uint8_t>());
+   fOutput << static_cast<int>(*fValue.GetAs<std::uint8_t>());
 }
 
 void ROOT::Experimental::RPrintValueVisitor::VisitUInt16Field(const RField<std::uint16_t> &field)
 {
    PrintIndent();
    PrintName(field);
-   fOutput << *fValue.Get<std::uint16_t>();
+   fOutput << *fValue.GetAs<std::uint16_t>();
 }
 
 void ROOT::Experimental::RPrintValueVisitor::VisitUInt32Field(const RField<std::uint32_t> &field)
 {
    PrintIndent();
    PrintName(field);
-   fOutput << *fValue.Get<std::uint32_t>();
+   fOutput << *fValue.GetAs<std::uint32_t>();
 }
 
 
@@ -260,7 +260,7 @@ void ROOT::Experimental::RPrintValueVisitor::VisitUInt64Field(const RField<std::
 {
    PrintIndent();
    PrintName(field);
-   fOutput << *fValue.Get<std::uint64_t>();
+   fOutput << *fValue.GetAs<std::uint64_t>();
 }
 
 void ROOT::Experimental::RPrintValueVisitor::VisitCardinalityField(const RCardinalityField &field)
@@ -268,11 +268,11 @@ void ROOT::Experimental::RPrintValueVisitor::VisitCardinalityField(const RCardin
    PrintIndent();
    PrintName(field);
    if (field.As32Bit()) {
-      fOutput << *fValue.Get<std::uint32_t>();
+      fOutput << *fValue.GetAs<std::uint32_t>();
       return;
    }
    if (field.As64Bit()) {
-      fOutput << *fValue.Get<std::uint64_t>();
+      fOutput << *fValue.GetAs<std::uint64_t>();
       return;
    }
    R__ASSERT(false && "unsupported cardinality size type");
@@ -281,7 +281,7 @@ void ROOT::Experimental::RPrintValueVisitor::VisitCardinalityField(const RCardin
 void ROOT::Experimental::RPrintValueVisitor::VisitBitsetField(const RBitsetField &field)
 {
    constexpr auto nBitsULong = sizeof(unsigned long) * 8;
-   const auto *asULongArray = fValue.Get<unsigned long>();
+   const auto *asULongArray = fValue.GetAs<unsigned long>();
 
    PrintIndent();
    PrintName(field);

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -136,7 +136,7 @@ void ROOT::Experimental::RPrintValueVisitor::PrintCollection(const Detail::RFiel
       options.fPrintSingleLine = true;
       options.fPrintName = false;
       RPrintValueVisitor elemVisitor(iValue->GetNonOwningCopy(), fOutput, 0 /* level */, options);
-      iValue->GetField()->AcceptVisitor(elemVisitor);
+      iValue->GetField().AcceptVisitor(elemVisitor);
 
       if (++iValue == elems.end())
          break;
@@ -316,7 +316,7 @@ void ROOT::Experimental::RPrintValueVisitor::VisitClassField(const RClassField &
       RPrintOptions options;
       options.fPrintSingleLine = fPrintOptions.fPrintSingleLine;
       RPrintValueVisitor visitor(iValue->GetNonOwningCopy(), fOutput, fLevel + 1, options);
-      iValue->GetField()->AcceptVisitor(visitor);
+      iValue->GetField().AcceptVisitor(visitor);
 
       if (++iValue == elems.end()) {
          if (!fPrintOptions.fPrintSingleLine)
@@ -346,7 +346,7 @@ void ROOT::Experimental::RPrintValueVisitor::VisitRecordField(const RRecordField
       RPrintOptions options;
       options.fPrintSingleLine = fPrintOptions.fPrintSingleLine;
       RPrintValueVisitor visitor(iValue->GetNonOwningCopy(), fOutput, fLevel + 1, options);
-      iValue->GetField()->AcceptVisitor(visitor);
+      iValue->GetField().AcceptVisitor(visitor);
 
       if (++iValue == elems.end()) {
          if (!fPrintOptions.fPrintSingleLine)
@@ -374,7 +374,7 @@ void ROOT::Experimental::RPrintValueVisitor::VisitNullableField(const RNullableF
       options.fPrintSingleLine = true;
       options.fPrintName = false;
       RPrintValueVisitor visitor(elems[0].GetNonOwningCopy(), fOutput, fLevel, options);
-      elems[0].GetField()->AcceptVisitor(visitor);
+      elems[0].GetField().AcceptVisitor(visitor);
    }
 }
 
@@ -387,7 +387,7 @@ void ROOT::Experimental::RPrintValueVisitor::VisitEnumField(const REnumField &fi
    options.fPrintSingleLine = true;
    options.fPrintName = false;
    RPrintValueVisitor visitor(intValue.GetNonOwningCopy(), fOutput, fLevel, options);
-   intValue.GetField()->AcceptVisitor(visitor);
+   intValue.GetField().AcceptVisitor(visitor);
 }
 
 void ROOT::Experimental::RPrintValueVisitor::VisitAtomicField(const RAtomicField &field)
@@ -399,7 +399,7 @@ void ROOT::Experimental::RPrintValueVisitor::VisitAtomicField(const RAtomicField
    options.fPrintSingleLine = true;
    options.fPrintName = false;
    RPrintValueVisitor visitor(itemValue.GetNonOwningCopy(), fOutput, fLevel, options);
-   itemValue.GetField()->AcceptVisitor(visitor);
+   itemValue.GetField().AcceptVisitor(visitor);
 }
 
 void ROOT::Experimental::RPrintValueVisitor::VisitProxiedCollectionField(const RProxiedCollectionField &field)

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -338,7 +338,8 @@ void ROOT::Experimental::RNTupleWriter::CommitCluster(bool commitClusterGroup)
    {
       throw RException(R__FAIL("invalid attempt to write a cluster > 512MiB with 'small clusters' option enabled"));
    }
-   fModel->CommitCluster();
+   for (auto &f : fModel->GetMutableFieldZero())
+      f.CommitCluster();
    fNBytesCommitted += fSink->CommitCluster(fNEntries);
    fNBytesFilled += fUnzippedClusterSize;
 

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -285,7 +285,7 @@ ROOT::Experimental::RNTupleWriter::RNTupleWriter(std::unique_ptr<ROOT::Experimen
       fSink->SetTaskScheduler(fZipTasks.get());
    }
 #endif
-   fSink->Create(*fModel.get());
+   fSink->Create(*fModel);
    fMetrics->ObserveMetrics(fSink->GetMetrics());
 
    const auto &writeOpts = fSink->GetWriteOptions();

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -242,7 +242,7 @@ void ROOT::Experimental::RNTupleReader::Show(NTupleSize_t index, std::ostream &o
    for (auto iValue = entry->begin(); iValue != entry->end();) {
       output << std::endl;
       RPrintValueVisitor visitor(iValue->GetNonOwningCopy(), output, 1 /* level */);
-      iValue->GetField()->AcceptVisitor(visitor);
+      iValue->GetField().AcceptVisitor(visitor);
 
       if (++iValue == entry->end()) {
          output << std::endl;

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -251,12 +251,12 @@ void ROOT::Experimental::RNTupleReader::Show(NTupleSize_t index, std::ostream &o
    output << "}" << std::endl;
 }
 
-const ROOT::Experimental::RNTupleDescriptor *ROOT::Experimental::RNTupleReader::GetDescriptor()
+std::shared_ptr<const ROOT::Experimental::RNTupleDescriptor> ROOT::Experimental::RNTupleReader::GetDescriptor()
 {
    auto descriptorGuard = fSource->GetSharedDescriptorGuard();
    if (!fCachedDescriptor || fCachedDescriptor->GetGeneration() != descriptorGuard->GetGeneration())
       fCachedDescriptor = descriptorGuard->Clone();
-   return fCachedDescriptor.get();
+   return fCachedDescriptor;
 }
 
 //------------------------------------------------------------------------------

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -151,7 +151,7 @@ ROOT::Experimental::RNTupleReader::OpenFriends(std::span<ROpenSpec> ntuples)
    return std::make_unique<RNTupleReader>(std::make_unique<Detail::RPageSourceFriends>("_friends", sources));
 }
 
-ROOT::Experimental::RNTupleModel *ROOT::Experimental::RNTupleReader::GetModel()
+const ROOT::Experimental::RNTupleModel *ROOT::Experimental::RNTupleReader::GetModel()
 {
    if (!fModel) {
       fModel = fSource->GetSharedDescriptorGuard()->GenerateModel();

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -89,12 +89,14 @@ void ROOT::Experimental::RNTupleReader::InitPageSource()
    }
 #endif
    fSource->Attach();
-   fMetrics.ObserveMetrics(fSource->GetMetrics());
+   fMetrics->ObserveMetrics(fSource->GetMetrics());
 }
 
 ROOT::Experimental::RNTupleReader::RNTupleReader(std::unique_ptr<ROOT::Experimental::RNTupleModel> model,
                                                  std::unique_ptr<ROOT::Experimental::Detail::RPageSource> source)
-   : fSource(std::move(source)), fModel(std::move(model)), fMetrics("RNTupleReader")
+   : fSource(std::move(source)),
+     fModel(std::move(model)),
+     fMetrics(std::make_shared<Detail::RNTupleMetrics>("RNTupleReader"))
 {
    if (!fSource) {
       throw RException(R__FAIL("null source"));
@@ -113,7 +115,7 @@ ROOT::Experimental::RNTupleReader::RNTupleReader(std::unique_ptr<ROOT::Experimen
 }
 
 ROOT::Experimental::RNTupleReader::RNTupleReader(std::unique_ptr<ROOT::Experimental::Detail::RPageSource> source)
-   : fSource(std::move(source)), fModel(nullptr), fMetrics("RNTupleReader")
+   : fSource(std::move(source)), fModel(nullptr), fMetrics(std::make_shared<Detail::RNTupleMetrics>("RNTupleReader"))
 {
    if (!fSource) {
       throw RException(R__FAIL("null source"));
@@ -216,7 +218,7 @@ void ROOT::Experimental::RNTupleReader::PrintInfo(const ENTupleInfo what, std::o
       break;
    }
    case ENTupleInfo::kStorageDetails: fSource->GetSharedDescriptorGuard()->PrintInfo(output); break;
-   case ENTupleInfo::kMetrics: fMetrics.Print(output); break;
+   case ENTupleInfo::kMetrics: fMetrics->Print(output); break;
    default:
       // Unhandled case, internal error
       R__ASSERT(false);
@@ -264,7 +266,9 @@ std::shared_ptr<const ROOT::Experimental::RNTupleDescriptor> ROOT::Experimental:
 
 ROOT::Experimental::RNTupleWriter::RNTupleWriter(std::unique_ptr<ROOT::Experimental::RNTupleModel> model,
                                                  std::unique_ptr<ROOT::Experimental::Detail::RPageSink> sink)
-   : fSink(std::move(sink)), fModel(std::move(model)), fMetrics("RNTupleWriter")
+   : fSink(std::move(sink)),
+     fModel(std::move(model)),
+     fMetrics(std::make_shared<Detail::RNTupleMetrics>("RNTupleWriter"))
 {
    if (!fModel) {
       throw RException(R__FAIL("null model"));
@@ -282,7 +286,7 @@ ROOT::Experimental::RNTupleWriter::RNTupleWriter(std::unique_ptr<ROOT::Experimen
    }
 #endif
    fSink->Create(*fModel.get());
-   fMetrics.ObserveMetrics(fSink->GetMetrics());
+   fMetrics->ObserveMetrics(fSink->GetMetrics());
 
    const auto &writeOpts = fSink->GetWriteOptions();
    fMaxUnzippedClusterSize = writeOpts.GetMaxUnzippedClusterSize();

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -66,9 +66,10 @@ void ROOT::Experimental::RNTupleImtTaskScheduler::Wait()
 
 void ROOT::Experimental::RNTupleReader::ConnectModel(RNTupleModel &model)
 {
+   auto &fieldZero = RNTupleModel::RFieldProxy::GetFieldZeroOf(model);
    // We must not use the descriptor guard to prevent recursive locking in field.ConnectPageSource
-   model.GetMutableFieldZero().SetOnDiskId(fSource->GetSharedDescriptorGuard()->GetFieldZeroId());
-   for (auto &field : model.GetMutableFieldZero()) {
+   fieldZero.SetOnDiskId(fSource->GetSharedDescriptorGuard()->GetFieldZeroId());
+   for (auto &field : fieldZero) {
       // If the model has been created from the descritor, the on-disk IDs are already set.
       // User-provided models instead need to find their corresponding IDs in the descriptor.
       if (field.GetOnDiskId() == kInvalidDescriptorId) {
@@ -338,7 +339,7 @@ void ROOT::Experimental::RNTupleWriter::CommitCluster(bool commitClusterGroup)
    {
       throw RException(R__FAIL("invalid attempt to write a cluster > 512MiB with 'small clusters' option enabled"));
    }
-   for (auto &f : fModel->GetMutableFieldZero())
+   for (auto &f : RNTupleModel::RFieldProxy::GetFieldZeroOf(*fModel))
       f.CommitCluster();
    fNBytesCommitted += fSink->CommitCluster(fNEntries);
    fNBytesFilled += fUnzippedClusterSize;

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -108,7 +108,8 @@ ROOT::Experimental::RNTupleReader::RNTupleReader(std::unique_ptr<ROOT::Experimen
    fModel->Freeze();
    InitPageSource();
    ConnectModel(*fModel);
-   fDefaultEntry = fModel->GetDefaultEntry().lock();
+   if (!fModel->IsBare())
+      fDefaultEntry = fModel->GetDefaultEntry().lock();
 }
 
 ROOT::Experimental::RNTupleReader::RNTupleReader(std::unique_ptr<ROOT::Experimental::Detail::RPageSource> source)
@@ -152,10 +153,10 @@ ROOT::Experimental::RNTupleReader::OpenFriends(std::span<ROpenSpec> ntuples)
    return std::make_unique<RNTupleReader>(std::make_unique<Detail::RPageSourceFriends>("_friends", sources));
 }
 
-const ROOT::Experimental::RNTupleModel *ROOT::Experimental::RNTupleReader::GetModel()
+std::weak_ptr<const ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleReader::GetModel()
 {
    EnsureModel();
-   return fModel.get();
+   return fModel;
 }
 
 void ROOT::Experimental::RNTupleReader::PrintInfo(const ENTupleInfo what, std::ostream &output)
@@ -232,7 +233,7 @@ ROOT::Experimental::RNTupleReader *ROOT::Experimental::RNTupleReader::GetDisplay
 void ROOT::Experimental::RNTupleReader::Show(NTupleSize_t index, std::ostream &output)
 {
    auto reader = GetDisplayReader();
-   auto entry = reader->GetModel()->GetDefaultEntry().lock();
+   auto entry = reader->GetModel().lock()->GetDefaultEntry().lock();
 
    reader->LoadEntry(index);
    output << "{";

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -153,11 +153,7 @@ ROOT::Experimental::RNTupleReader::OpenFriends(std::span<ROpenSpec> ntuples)
 
 const ROOT::Experimental::RNTupleModel *ROOT::Experimental::RNTupleReader::GetModel()
 {
-   if (!fModel) {
-      fModel = fSource->GetSharedDescriptorGuard()->GenerateModel();
-      ConnectModel(*fModel);
-      fDefaultEntry = fModel->GetDefaultEntry().lock();
-   }
+   EnsureModel();
    return fModel.get();
 }
 

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -338,9 +338,7 @@ void ROOT::Experimental::RNTupleWriter::CommitCluster(bool commitClusterGroup)
    {
       throw RException(R__FAIL("invalid attempt to write a cluster > 512MiB with 'small clusters' option enabled"));
    }
-   for (auto &field : *fModel->GetFieldZero()) {
-      field.CommitCluster();
-   }
+   fModel->CommitCluster();
    fNBytesCommitted += fSink->CommitCluster(fNEntries);
    fNBytesFilled += fUnzippedClusterSize;
 

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -67,8 +67,8 @@ void ROOT::Experimental::RNTupleImtTaskScheduler::Wait()
 void ROOT::Experimental::RNTupleReader::ConnectModel(RNTupleModel &model)
 {
    // We must not use the descriptor guard to prevent recursive locking in field.ConnectPageSource
-   model.GetFieldZeroPtr()->SetOnDiskId(fSource->GetSharedDescriptorGuard()->GetFieldZeroId());
-   for (auto &field : *model.GetFieldZeroPtr()) {
+   model.GetMutableFieldZero().SetOnDiskId(fSource->GetSharedDescriptorGuard()->GetFieldZeroId());
+   for (auto &field : model.GetMutableFieldZero()) {
       // If the model has been created from the descritor, the on-disk IDs are already set.
       // User-provided models instead need to find their corresponding IDs in the descriptor.
       if (field.GetOnDiskId() == kInvalidDescriptorId) {

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -64,11 +64,11 @@ void ROOT::Experimental::RNTupleImtTaskScheduler::Wait()
 
 //------------------------------------------------------------------------------
 
-void ROOT::Experimental::RNTupleReader::ConnectModel(const RNTupleModel &model)
+void ROOT::Experimental::RNTupleReader::ConnectModel(RNTupleModel &model)
 {
    // We must not use the descriptor guard to prevent recursive locking in field.ConnectPageSource
-   model.GetFieldZero()->SetOnDiskId(fSource->GetSharedDescriptorGuard()->GetFieldZeroId());
-   for (auto &field : *model.GetFieldZero()) {
+   model.GetFieldZeroPtr()->SetOnDiskId(fSource->GetSharedDescriptorGuard()->GetFieldZeroId());
+   for (auto &field : *model.GetFieldZeroPtr()) {
       // If the model has been created from the descritor, the on-disk IDs are already set.
       // User-provided models instead need to find their corresponding IDs in the descriptor.
       if (field.GetOnDiskId() == kInvalidDescriptorId) {
@@ -197,7 +197,7 @@ void ROOT::Experimental::RNTupleReader::PrintInfo(const ENTupleInfo what, std::o
       RPrintSchemaVisitor printVisitor(output);
 
       // Note that we do not need to connect the model, we are only looking at its tree of fields
-      fullModel->GetFieldZero()->AcceptVisitor(prepVisitor);
+      fullModel->GetFieldZero().AcceptVisitor(prepVisitor);
 
       printVisitor.SetFrameSymbol(frameSymbol);
       printVisitor.SetWidth(width);
@@ -207,7 +207,7 @@ void ROOT::Experimental::RNTupleReader::PrintInfo(const ENTupleInfo what, std::o
       for (int i = 0; i < width; ++i)
          output << frameSymbol;
       output << std::endl;
-      fullModel->GetFieldZero()->AcceptVisitor(printVisitor);
+      fullModel->GetFieldZero().AcceptVisitor(printVisitor);
       for (int i = 0; i < width; ++i)
          output << frameSymbol;
       output << std::endl;

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -433,8 +433,9 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleDescriptor::DropClu
 
 std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleDescriptor::GenerateModel() const
 {
-   auto model = RNTupleModel::Create();
-   model->GetMutableFieldZero().SetOnDiskId(GetFieldZeroId());
+   auto fieldZero = std::make_unique<RFieldZero>();
+   fieldZero->SetOnDiskId(GetFieldZeroId());
+   auto model = RNTupleModel::Create(std::move(fieldZero));
    for (const auto &topDesc : GetTopLevelFields())
       model->AddField(topDesc.CreateField(*this));
    model->Freeze();

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -434,7 +434,7 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleDescriptor::DropClu
 std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleDescriptor::GenerateModel() const
 {
    auto model = RNTupleModel::Create();
-   model->GetFieldZero()->SetOnDiskId(GetFieldZeroId());
+   model->GetFieldZeroPtr()->SetOnDiskId(GetFieldZeroId());
    for (const auto &topDesc : GetTopLevelFields())
       model->AddField(topDesc.CreateField(*this));
    model->Freeze();

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -434,7 +434,7 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleDescriptor::DropClu
 std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleDescriptor::GenerateModel() const
 {
    auto model = RNTupleModel::Create();
-   model->GetFieldZeroPtr()->SetOnDiskId(GetFieldZeroId());
+   model->GetMutableFieldZero().SetOnDiskId(GetFieldZeroId());
    for (const auto &topDesc : GetTopLevelFields())
       model->AddField(topDesc.CreateField(*this));
    model->Freeze();

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -354,7 +354,7 @@ ROOT::Experimental::RNTupleModel::CreateEntryImpl(bool isBare, REntry *linkedEnt
       if (linkedEntry) {
          bool isLinked = false;
          for (const auto &v : *linkedEntry) {
-            if (f->Compare(*v.GetField()) != 0)
+            if (f->Compare(v.GetField()) != 0)
                continue;
 
             entry->AddValue(f->BindValue(v.GetRawPtr()));

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -236,7 +236,7 @@ std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleMod
    if (fDefaultEntryIdx != kInvalidDefaultEntryIdx) {
       cloneModel->fCreatedEntries.emplace_back(std::shared_ptr<REntry>(new REntry(cloneModel->fModelId)));
       cloneModel->fDefaultEntryIdx = 0;
-      for (const auto &f : cloneModel->fFieldZero->GetSubFields()) {
+      for (auto &f : cloneModel->fFieldZero->GetSubFields()) {
          cloneModel->fCreatedEntries[0]->AddValue(f->GenerateValue());
       }
    }
@@ -350,7 +350,7 @@ ROOT::Experimental::RNTupleModel::CreateEntryImpl(bool isBare, REntry *linkedEnt
       throw RException(R__FAIL("invalid attempt to create entry of unfrozen model"));
 
    auto entry = std::shared_ptr<REntry>(new REntry(fModelId));
-   for (const auto &f : fFieldZero->GetSubFields()) {
+   for (auto &f : fFieldZero->GetSubFields()) {
       if (linkedEntry) {
          bool isLinked = false;
          for (const auto &v : *linkedEntry) {

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -401,15 +401,6 @@ ROOT::Experimental::Detail::RFieldBase::RBulk ROOT::Experimental::RNTupleModel::
    return f->GenerateBulk();
 }
 
-void ROOT::Experimental::RNTupleModel::CommitCluster()
-{
-   if (!IsFrozen())
-      throw RException(R__FAIL("invalid attempt commit fields of unfrozen model"));
-
-   for (auto &f : *fFieldZero)
-      f.CommitCluster();
-}
-
 void ROOT::Experimental::RNTupleModel::Unfreeze()
 {
    if (!IsFrozen())

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -314,7 +314,6 @@ std::shared_ptr<ROOT::Experimental::RCollectionNTupleWriter> ROOT::Experimental:
    if (!collectionModel) {
       throw RException(R__FAIL("null collectionModel"));
    }
-   collectionModel->Freeze();
 
    auto collectionWriter = std::shared_ptr<RCollectionNTupleWriter>(new RCollectionNTupleWriter());
 
@@ -323,7 +322,8 @@ std::shared_ptr<ROOT::Experimental::RCollectionNTupleWriter> ROOT::Experimental:
    }
    collectionWriter->fDefaultEntryIdx = collectionModel->fDefaultEntryIdx;
 
-   auto field = std::make_unique<RCollectionField>(fieldName, collectionWriter, std::move(collectionModel));
+   auto field = std::make_unique<RCollectionField>(fieldName, collectionWriter, std::move(collectionModel->fFieldZero));
+   field->SetDescription(collectionModel->GetDescription());
 
    if (!IsBare()) {
       GetDefaultEntryPtr()->AddValue(field->BindValue(collectionWriter->GetOffsetPtr()));

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -375,7 +375,7 @@ ROOT::Experimental::RNTupleModel::CreateEntryImpl(bool isBare, REntry *linkedEnt
             if (f->Compare(v.GetField()) != 0)
                continue;
 
-            entry->AddValue(f->BindValue(v.Get<void>()));
+            entry->AddValue(f->BindValue(v.GetAs<void>()));
             isLinked = true;
             break;
          }

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -401,6 +401,15 @@ ROOT::Experimental::Detail::RFieldBase::RBulk ROOT::Experimental::RNTupleModel::
    return f->GenerateBulk();
 }
 
+void ROOT::Experimental::RNTupleModel::CommitCluster()
+{
+   if (!IsFrozen())
+      throw RException(R__FAIL("invalid attempt commit fields of unfrozen model"));
+
+   for (auto &f : *fFieldZero)
+      f.CommitCluster();
+}
+
 void ROOT::Experimental::RNTupleModel::Unfreeze()
 {
    if (!IsFrozen())

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -389,6 +389,18 @@ ROOT::Experimental::RNTupleModel::CreateEntryImpl(bool isBare, REntry *linkedEnt
    return entry;
 }
 
+ROOT::Experimental::Detail::RFieldBase::RBulk ROOT::Experimental::RNTupleModel::GenerateBulk(std::string_view fieldName)
+{
+   if (!IsFrozen())
+      throw RException(R__FAIL("invalid attempt to create bulk of unfrozen model"));
+
+   auto f = FindField(fieldName);
+   if (!f)
+      throw RException(R__FAIL("invalid field name: " + std::string(fieldName)));
+
+   return f->GenerateBulk();
+}
+
 void ROOT::Experimental::RNTupleModel::Unfreeze()
 {
    if (!IsFrozen())

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -333,6 +333,16 @@ std::shared_ptr<ROOT::Experimental::RCollectionNTupleWriter> ROOT::Experimental:
    return collectionWriter;
 }
 
+ROOT::Experimental::Detail::RFieldBase &ROOT::Experimental::RNTupleModel::GetField(std::string_view fieldName)
+{
+   EnsureNotFrozen();
+   auto f = FindField(fieldName);
+   if (!f)
+      throw RException(R__FAIL("invalid field: " + std::string(fieldName)));
+
+   return *f;
+}
+
 const ROOT::Experimental::Detail::RFieldBase &
 ROOT::Experimental::RNTupleModel::GetField(std::string_view fieldName) const
 {

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -213,13 +213,13 @@ std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleMod
 {
    auto cloneModel = std::unique_ptr<RNTupleModel>(new RNTupleModel());
    auto cloneFieldZero = fFieldZero->Clone("");
-   cloneModel->fModelId = fModelId;
+   cloneModel->fModelId = (fModelId == 0) ? 0 : GetNewModelId();
    cloneModel->fFieldZero = std::unique_ptr<RFieldZero>(static_cast<RFieldZero *>(cloneFieldZero.release()));
    cloneModel->fFieldNames = fFieldNames;
    cloneModel->fDescription = fDescription;
    cloneModel->fProjectedFields = fProjectedFields->Clone(cloneModel.get());
    if (fDefaultEntry) {
-      cloneModel->fDefaultEntry = std::unique_ptr<REntry>(new REntry(fModelId));
+      cloneModel->fDefaultEntry = std::unique_ptr<REntry>(new REntry(cloneModel->fModelId));
       for (const auto &f : cloneModel->fFieldZero->GetSubFields()) {
          cloneModel->fDefaultEntry->AddValue(f->GenerateValue());
       }
@@ -347,13 +347,18 @@ void ROOT::Experimental::RNTupleModel::Unfreeze()
    fModelId = 0;
 }
 
+std::uint64_t ROOT::Experimental::RNTupleModel::GetNewModelId()
+{
+   static std::atomic<std::uint64_t> gLastModelId = 0;
+   return ++gLastModelId;
+}
+
 void ROOT::Experimental::RNTupleModel::Freeze()
 {
    if (IsFrozen())
       return;
 
-   static std::atomic<std::uint64_t> gLastModelId = 0;
-   fModelId = ++gLastModelId;
+   fModelId = GetNewModelId();
    if (fDefaultEntry)
       fDefaultEntry->fModelId = fModelId;
 }

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -133,7 +133,7 @@ ROOT::Experimental::RNTupleModel::RProjectedFields::Clone(const RNTupleModel *ne
    for (const auto &[k, v] : fFieldMap) {
       for (const auto &f : *clone->GetFieldZero()) {
          if (f.GetQualifiedFieldName() == k->GetQualifiedFieldName()) {
-            clone->fFieldMap[&f] = clone->fModel->GetField(v->GetQualifiedFieldName());
+            clone->fFieldMap[&f] = clone->fModel->FindField(v->GetQualifiedFieldName());
             break;
          }
       }
@@ -243,6 +243,26 @@ std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleMod
    return cloneModel;
 }
 
+ROOT::Experimental::Detail::RFieldBase *ROOT::Experimental::RNTupleModel::FindField(std::string_view fieldName) const
+{
+   if (fieldName.empty())
+      return nullptr;
+
+   auto *field = static_cast<ROOT::Experimental::Detail::RFieldBase *>(fFieldZero.get());
+   for (auto subfieldName : ROOT::Split(fieldName, ".")) {
+      const auto subfields = field->GetSubFields();
+      auto it =
+         std::find_if(subfields.begin(), subfields.end(), [&](const auto *f) { return f->GetName() == subfieldName; });
+      if (it != subfields.end()) {
+         field = *it;
+      } else {
+         field = nullptr;
+         break;
+      }
+   }
+
+   return field;
+}
 
 void ROOT::Experimental::RNTupleModel::AddField(std::unique_ptr<Detail::RFieldBase> field)
 {
@@ -266,12 +286,12 @@ ROOT::Experimental::RNTupleModel::AddProjectedField(std::unique_ptr<Detail::RFie
    auto fieldName = field->GetName();
 
    RProjectedFields::FieldMap_t fieldMap;
-   auto sourceField = GetField(mapping(fieldName));
+   auto sourceField = FindField(mapping(fieldName));
    if (!sourceField)
       return R__FAIL("no such field: " + mapping(fieldName));
    fieldMap[field.get()] = sourceField;
    for (const auto &subField : *field) {
-      sourceField = GetField(mapping(subField.GetQualifiedFieldName()));
+      sourceField = FindField(mapping(subField.GetQualifiedFieldName()));
       if (!sourceField)
          return R__FAIL("no such field: " + mapping(fieldName));
       fieldMap[&subField] = sourceField;
@@ -313,26 +333,14 @@ std::shared_ptr<ROOT::Experimental::RCollectionNTupleWriter> ROOT::Experimental:
    return collectionWriter;
 }
 
-const ROOT::Experimental::Detail::RFieldBase *
+const ROOT::Experimental::Detail::RFieldBase &
 ROOT::Experimental::RNTupleModel::GetField(std::string_view fieldName) const
 {
-   if (fieldName.empty())
-      return nullptr;
+   auto f = FindField(fieldName);
+   if (!f)
+      throw RException(R__FAIL("invalid field: " + std::string(fieldName)));
 
-   auto *field = static_cast<ROOT::Experimental::Detail::RFieldBase *>(fFieldZero.get());
-   for (auto subfieldName : ROOT::Split(fieldName, ".")) {
-      const auto subfields = field->GetSubFields();
-      auto it =
-         std::find_if(subfields.begin(), subfields.end(), [&](const auto *f) { return f->GetName() == subfieldName; });
-      if (it != subfields.end()) {
-         field = *it;
-      } else {
-         field = nullptr;
-         break;
-      }
-   }
-
-   return field;
+   return *f;
 }
 
 std::weak_ptr<ROOT::Experimental::REntry> ROOT::Experimental::RNTupleModel::GetDefaultEntry() const

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -357,7 +357,7 @@ ROOT::Experimental::RNTupleModel::CreateEntryImpl(bool isBare, REntry *linkedEnt
             if (f->Compare(v.GetField()) != 0)
                continue;
 
-            entry->AddValue(f->BindValue(v.GetRawPtr()));
+            entry->AddValue(f->BindValue(v.Get<void>()));
             isLinked = true;
             break;
          }

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -401,7 +401,7 @@ void ROOT::Experimental::Detail::RPageSink::Create(RNTupleModel &model)
    fDescriptorBuilder.SetNTuple(fNTupleName, model.GetDescription());
    const auto &descriptor = fDescriptorBuilder.GetDescriptor();
 
-   auto &fieldZero = *model.GetFieldZero();
+   auto &fieldZero = *model.GetFieldZeroPtr();
    fDescriptorBuilder.AddField(RFieldDescriptorBuilder::FromField(fieldZero).FieldId(0).MakeDescriptor().Unwrap());
    fieldZero.SetOnDiskId(0);
    model.GetProjectedFields().GetFieldZero()->SetOnDiskId(0);

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -401,7 +401,7 @@ void ROOT::Experimental::Detail::RPageSink::Create(RNTupleModel &model)
    fDescriptorBuilder.SetNTuple(fNTupleName, model.GetDescription());
    const auto &descriptor = fDescriptorBuilder.GetDescriptor();
 
-   auto &fieldZero = model.GetMutableFieldZero();
+   auto &fieldZero = RNTupleModel::RFieldProxy::GetFieldZeroOf(model);
    fDescriptorBuilder.AddField(RFieldDescriptorBuilder::FromField(fieldZero).FieldId(0).MakeDescriptor().Unwrap());
    fieldZero.SetOnDiskId(0);
    model.GetProjectedFields().GetFieldZero()->SetOnDiskId(0);

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -401,7 +401,7 @@ void ROOT::Experimental::Detail::RPageSink::Create(RNTupleModel &model)
    fDescriptorBuilder.SetNTuple(fNTupleName, model.GetDescription());
    const auto &descriptor = fDescriptorBuilder.GetDescriptor();
 
-   auto &fieldZero = *model.GetFieldZeroPtr();
+   auto &fieldZero = model.GetMutableFieldZero();
    fDescriptorBuilder.AddField(RFieldDescriptorBuilder::FromField(fieldZero).FieldId(0).MakeDescriptor().Unwrap());
    fieldZero.SetOnDiskId(0);
    model.GetProjectedFields().GetFieldZero()->SetOnDiskId(0);

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -640,7 +640,7 @@ TEST(RNTuple, BareEntry)
       auto e2 = writer->CreateBareEntry().lock();
       EXPECT_EQ(nullptr, e2->Get<float>("pt"));
       float pt = 2.0;
-      e2->CaptureValueUnsafe("pt", &pt);
+      e2->BindValue("pt", &pt);
 
       writer->Fill(*e1);
       writer->Fill(*e2);

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -631,7 +631,7 @@ TEST(RNTuple, BareEntry)
    FileRaii fileGuard("test_ntuple_bare_entry.root");
    {
       auto writer = RNTupleWriter::Recreate(std::move(m), "ntpl", fileGuard.GetPath());
-      const auto model = writer->GetModel();
+      auto model = writer->GetModel().lock();
       try {
          model->GetDefaultEntry();
          FAIL() << "accessing default entry of bare model should throw";
@@ -639,10 +639,11 @@ TEST(RNTuple, BareEntry)
          EXPECT_THAT(err.what(), testing::HasSubstr("invalid attempt to use default entry of bare model"));
       }
       try {
-         model->Get<float>("pt");
+         writer->GetDefaultValueAs<float>("pt");
          FAIL() << "accessing default entry of bare model should throw";
       } catch (const RException &err) {
-         EXPECT_THAT(err.what(), testing::HasSubstr("invalid attempt to use default entry of bare model"));
+         EXPECT_THAT(err.what(),
+                     testing::HasSubstr("invalid attempt to get default value of a writer with a bare model"));
       }
 
       auto e1 = writer->CreateEntry().lock();

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -99,6 +99,7 @@ TEST(RNTuple, WriteRead)
    wrKlass->s = "abc";
 
    auto modelRead = modelWrite->Clone();
+   modelRead->Freeze();
 
    {
       RNTupleWriter ntuple(std::move(modelWrite),
@@ -106,13 +107,15 @@ TEST(RNTuple, WriteRead)
       ntuple.Fill();
    }
 
-   auto rdSignal = modelRead->Get<bool>("signal");
-   auto rdPt = modelRead->Get<float>("pt");
-   auto rdEnergy = modelRead->Get<float>("energy");
-   auto rdTag = modelRead->Get<std::string>("tag");
-   auto rdJets = modelRead->Get<std::vector<float>>("jets");
-   auto rdNnlo = modelRead->Get<std::vector<std::vector<float>>>("nnlo");
-   auto rdKlass = modelRead->Get<CustomStruct>("klass");
+   auto entry = modelRead->GetDefaultEntry().lock();
+   auto rdSignal = entry->GetRaw<bool>("signal");
+   auto rdPt = entry->GetRaw<float>("pt");
+   auto rdEnergy = entry->GetRaw<float>("energy");
+   auto rdTag = entry->GetRaw<std::string>("tag");
+   auto rdJets = entry->GetRaw<std::vector<float>>("jets");
+   auto rdNnlo = entry->GetRaw<std::vector<std::vector<float>>>("nnlo");
+   auto rdKlass = entry->GetRaw<CustomStruct>("klass");
+   entry = nullptr;
 
    RNTupleReader ntuple(std::move(modelRead),
       std::make_unique<RPageSourceFile>("myNTuple", fileGuard.GetPath(), RNTupleReadOptions()));
@@ -197,6 +200,7 @@ TEST(RNTuple, Clusters)
    wrFourVec->at(3) = 3.0;
 
    auto modelRead = modelWrite->Clone();
+   modelRead->Freeze();
 
    {
       RNTupleWriter ntuple(std::move(modelWrite),
@@ -215,10 +219,12 @@ TEST(RNTuple, Clusters)
       ntuple.Fill();
    }
 
-   auto rdPt = modelRead->Get<float>("pt");
-   auto rdTag = modelRead->Get<std::string>("tag");
-   auto rdNnlo = modelRead->Get<std::vector<std::vector<float>>>("nnlo");
-   auto rdFourVec = modelRead->Get<std::array<float, 4>>("fourVec");
+   auto entry = modelRead->GetDefaultEntry().lock();
+   auto rdPt = entry->GetRaw<float>("pt");
+   auto rdTag = entry->GetRaw<std::string>("tag");
+   auto rdNnlo = entry->GetRaw<std::vector<std::vector<float>>>("nnlo");
+   auto rdFourVec = entry->GetRaw<std::array<float, 4>>("fourVec");
+   entry = nullptr;
 
    RNTupleReader ntuple(std::move(modelRead),
       std::make_unique<RPageSourceFile>("myNTuple", fileGuard.GetPath(), RNTupleReadOptions()));

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -570,7 +570,7 @@ TEST(RNTuple, ModelId)
    EXPECT_NE(m1->GetModelId(), m2->GetModelId());
 
    auto m2c = m2->Clone();
-   EXPECT_EQ(m2->GetModelId(), m2c->GetModelId());
+   EXPECT_NE(m2->GetModelId(), m2c->GetModelId());
 }
 
 TEST(RNTuple, Entry)

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -406,16 +406,26 @@ TEST(RNTupleModel, GetField)
    auto m = RNTupleModel::Create();
    m->MakeField<int>("x");
    m->MakeField<CustomStruct>("cs");
-   EXPECT_EQ(m->GetField("x")->GetName(), "x");
-   EXPECT_EQ(m->GetField("x")->GetType(), "std::int32_t");
-   EXPECT_EQ(m->GetField("cs.v1")->GetName(), "v1");
-   EXPECT_EQ(m->GetField("cs.v1")->GetType(), "std::vector<float>");
-   EXPECT_EQ(m->GetField("nonexistent"), nullptr);
-   EXPECT_EQ(m->GetField(""), nullptr);
+   EXPECT_EQ(m->GetField("x").GetName(), "x");
+   EXPECT_EQ(m->GetField("x").GetType(), "std::int32_t");
+   EXPECT_EQ(m->GetField("cs.v1").GetName(), "v1");
+   EXPECT_EQ(m->GetField("cs.v1").GetType(), "std::vector<float>");
+   try {
+      m->GetField("nonexistent");
+      FAIL() << "invalid field name should throw";
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("invalid field"));
+   }
+   try {
+      m->GetField("");
+      FAIL() << "empty field name should throw";
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("invalid field"));
+   }
    EXPECT_EQ("", m->GetFieldZero()->GetQualifiedFieldName());
-   EXPECT_EQ("x", m->GetField("x")->GetQualifiedFieldName());
-   EXPECT_EQ("cs", m->GetField("cs")->GetQualifiedFieldName());
-   EXPECT_EQ("cs.v1", m->GetField("cs.v1")->GetQualifiedFieldName());
+   EXPECT_EQ("x", m->GetField("x").GetQualifiedFieldName());
+   EXPECT_EQ("cs", m->GetField("cs").GetQualifiedFieldName());
+   EXPECT_EQ("cs.v1", m->GetField("cs.v1").GetQualifiedFieldName());
 }
 
 TEST(RNTuple, EmptyString)

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -640,7 +640,7 @@ TEST(RNTuple, BareEntry)
       auto e2 = writer->CreateBareEntry().lock();
       EXPECT_EQ(nullptr, e2->GetRaw<float>("pt"));
       float pt = 2.0;
-      e2->BindValue("pt", &pt);
+      e2->BindRaw("pt", &pt);
 
       writer->Fill(*e1);
       writer->Fill(*e2);

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -22,19 +22,19 @@ TEST(RNTuple, ReconstructModel)
 
    auto modelReconstructed = source.GetSharedDescriptorGuard()->GenerateModel();
    try {
-      modelReconstructed->GetDefaultEntry().lock()->Get<float>("xyz");
+      modelReconstructed->GetDefaultEntry().lock()->GetRaw<float>("xyz");
       FAIL() << "invalid field name should throw";
    } catch (const RException &err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("invalid field name"));
    }
-   auto vecPtr = modelReconstructed->GetDefaultEntry().lock()->Get<std::vector<std::vector<float>>>("nnlo");
+   auto vecPtr = modelReconstructed->GetDefaultEntry().lock()->GetRaw<std::vector<std::vector<float>>>("nnlo");
    EXPECT_TRUE(vecPtr != nullptr);
    // Don't crash
    vecPtr->push_back(std::vector<float>{1.0});
-   auto array = modelReconstructed->GetDefaultEntry().lock()->Get<std::array<double, 2>>("array");
+   auto array = modelReconstructed->GetDefaultEntry().lock()->GetRaw<std::array<double, 2>>("array");
    EXPECT_TRUE(array != nullptr);
    auto variant =
-      modelReconstructed->GetDefaultEntry().lock()->Get<std::variant<double, std::variant<std::string, double>>>(
+      modelReconstructed->GetDefaultEntry().lock()->GetRaw<std::variant<double, std::variant<std::string, double>>>(
          "variant");
    EXPECT_TRUE(variant != nullptr);
 }
@@ -635,10 +635,10 @@ TEST(RNTuple, BareEntry)
       }
 
       auto e1 = writer->CreateEntry().lock();
-      ASSERT_NE(nullptr, e1->Get<float>("pt"));
-      *(e1->Get<float>("pt")) = 1.0;
+      ASSERT_NE(nullptr, e1->GetRaw<float>("pt"));
+      *(e1->GetRaw<float>("pt")) = 1.0;
       auto e2 = writer->CreateBareEntry().lock();
-      EXPECT_EQ(nullptr, e2->Get<float>("pt"));
+      EXPECT_EQ(nullptr, e2->GetRaw<float>("pt"));
       float pt = 2.0;
       e2->BindValue("pt", &pt);
 
@@ -649,9 +649,9 @@ TEST(RNTuple, BareEntry)
    auto ntuple = RNTupleReader::Open("ntpl", fileGuard.GetPath());
    ASSERT_EQ(2U, ntuple->GetNEntries());
    ntuple->LoadEntry(0);
-   EXPECT_EQ(1.0, *ntuple->GetModel()->GetDefaultEntry().lock()->Get<float>("pt"));
+   EXPECT_EQ(1.0, *ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<float>("pt"));
    ntuple->LoadEntry(1);
-   EXPECT_EQ(2.0, *ntuple->GetModel()->GetDefaultEntry().lock()->Get<float>("pt"));
+   EXPECT_EQ(2.0, *ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<float>("pt"));
 }
 
 namespace ROOT::Experimental::Internal {
@@ -703,7 +703,7 @@ TEST(RNTuple, ReadCallback)
    model->AddField(std::move(fieldKlass));
 
    auto ntuple = RNTupleReader::Open(std::move(model), "f", fileGuard.GetPath());
-   auto rdKlass = ntuple->GetModel()->GetDefaultEntry().lock()->Get<CustomStruct>("klass");
+   auto rdKlass = ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<CustomStruct>("klass");
    EXPECT_EQ(2U, ntuple->GetNEntries());
    ntuple->LoadEntry(0);
    EXPECT_EQ(1337.0, rdKlass->a);

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -422,7 +422,7 @@ TEST(RNTupleModel, GetField)
    } catch (const RException &err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("invalid field"));
    }
-   EXPECT_EQ("", m->GetFieldZero()->GetQualifiedFieldName());
+   EXPECT_EQ("", m->GetFieldZero().GetQualifiedFieldName());
    EXPECT_EQ("x", m->GetField("x").GetQualifiedFieldName());
    EXPECT_EQ("cs", m->GetField("cs").GetQualifiedFieldName());
    EXPECT_EQ("cs.v1", m->GetField("cs.v1").GetQualifiedFieldName());

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -23,19 +23,19 @@ TEST(RNTuple, ReconstructModel)
 
    auto modelReconstructed = source.GetSharedDescriptorGuard()->GenerateModel();
    try {
-      modelReconstructed->GetDefaultEntry().lock()->GetRaw<float>("xyz");
+      modelReconstructed->GetDefaultEntry().lock()->GetValueAs<float>("xyz");
       FAIL() << "invalid field name should throw";
    } catch (const RException &err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("invalid field name"));
    }
-   auto vecPtr = modelReconstructed->GetDefaultEntry().lock()->GetRaw<std::vector<std::vector<float>>>("nnlo");
+   auto vecPtr = modelReconstructed->GetDefaultEntry().lock()->GetValueAs<std::vector<std::vector<float>>>("nnlo");
    EXPECT_TRUE(vecPtr != nullptr);
    // Don't crash
    vecPtr->push_back(std::vector<float>{1.0});
-   auto array = modelReconstructed->GetDefaultEntry().lock()->GetRaw<std::array<double, 2>>("array");
+   auto array = modelReconstructed->GetDefaultEntry().lock()->GetValueAs<std::array<double, 2>>("array");
    EXPECT_TRUE(array != nullptr);
    auto variant =
-      modelReconstructed->GetDefaultEntry().lock()->GetRaw<std::variant<double, std::variant<std::string, double>>>(
+      modelReconstructed->GetDefaultEntry().lock()->GetValueAs<std::variant<double, std::variant<std::string, double>>>(
          "variant");
    EXPECT_TRUE(variant != nullptr);
 }
@@ -108,13 +108,13 @@ TEST(RNTuple, WriteRead)
    }
 
    auto entry = modelRead->GetDefaultEntry().lock();
-   auto rdSignal = entry->GetRaw<bool>("signal");
-   auto rdPt = entry->GetRaw<float>("pt");
-   auto rdEnergy = entry->GetRaw<float>("energy");
-   auto rdTag = entry->GetRaw<std::string>("tag");
-   auto rdJets = entry->GetRaw<std::vector<float>>("jets");
-   auto rdNnlo = entry->GetRaw<std::vector<std::vector<float>>>("nnlo");
-   auto rdKlass = entry->GetRaw<CustomStruct>("klass");
+   auto rdSignal = entry->GetValueAs<bool>("signal");
+   auto rdPt = entry->GetValueAs<float>("pt");
+   auto rdEnergy = entry->GetValueAs<float>("energy");
+   auto rdTag = entry->GetValueAs<std::string>("tag");
+   auto rdJets = entry->GetValueAs<std::vector<float>>("jets");
+   auto rdNnlo = entry->GetValueAs<std::vector<std::vector<float>>>("nnlo");
+   auto rdKlass = entry->GetValueAs<CustomStruct>("klass");
    entry = nullptr;
 
    RNTupleReader ntuple(std::move(modelRead),
@@ -220,10 +220,10 @@ TEST(RNTuple, Clusters)
    }
 
    auto entry = modelRead->GetDefaultEntry().lock();
-   auto rdPt = entry->GetRaw<float>("pt");
-   auto rdTag = entry->GetRaw<std::string>("tag");
-   auto rdNnlo = entry->GetRaw<std::vector<std::vector<float>>>("nnlo");
-   auto rdFourVec = entry->GetRaw<std::array<float, 4>>("fourVec");
+   auto rdPt = entry->GetValueAs<float>("pt");
+   auto rdTag = entry->GetValueAs<std::string>("tag");
+   auto rdNnlo = entry->GetValueAs<std::vector<std::vector<float>>>("nnlo");
+   auto rdFourVec = entry->GetValueAs<std::array<float, 4>>("fourVec");
    entry = nullptr;
 
    RNTupleReader ntuple(std::move(modelRead),
@@ -653,10 +653,10 @@ TEST(RNTuple, BareEntry)
       }
 
       auto e1 = writer->CreateEntry().lock();
-      ASSERT_NE(nullptr, e1->GetRaw<float>("pt"));
-      *(e1->GetRaw<float>("pt")) = 1.0;
+      ASSERT_NE(nullptr, e1->GetValueAs<float>("pt"));
+      *(e1->GetValueAs<float>("pt")) = 1.0;
       auto e2 = writer->CreateBareEntry().lock();
-      EXPECT_EQ(nullptr, e2->GetRaw<float>("pt"));
+      EXPECT_EQ(nullptr, e2->GetValueAs<float>("pt"));
       float pt = 2.0;
       e2->BindRaw("pt", &pt);
 

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -171,8 +171,8 @@ TEST(RNTuple, FileAnchor)
    EXPECT_EQ(1U, readerA->GetNEntries());
    EXPECT_EQ(1U, readerB->GetNEntries());
 
-   auto a = readerA->GetModel()->Get<int>("a");
-   auto b = readerB->GetModel()->Get<int>("b");
+   auto a = readerA->GetDefaultValueAs<int>("a");
+   auto b = readerB->GetDefaultValueAs<int>("b");
    readerA->LoadEntry(0);
    readerB->LoadEntry(0);
    EXPECT_EQ(42, *a);
@@ -660,9 +660,9 @@ TEST(RNTuple, BareEntry)
    auto ntuple = RNTupleReader::Open("ntpl", fileGuard.GetPath());
    ASSERT_EQ(2U, ntuple->GetNEntries());
    ntuple->LoadEntry(0);
-   EXPECT_EQ(1.0, *ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<float>("pt"));
+   EXPECT_EQ(1.0, *ntuple->GetDefaultValueAs<float>("pt"));
    ntuple->LoadEntry(1);
-   EXPECT_EQ(2.0, *ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<float>("pt"));
+   EXPECT_EQ(2.0, *ntuple->GetDefaultValueAs<float>("pt"));
 }
 
 namespace ROOT::Experimental::Internal {
@@ -714,7 +714,7 @@ TEST(RNTuple, ReadCallback)
    model->AddField(std::move(fieldKlass));
 
    auto ntuple = RNTupleReader::Open(std::move(model), "f", fileGuard.GetPath());
-   auto rdKlass = ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<CustomStruct>("klass");
+   auto rdKlass = ntuple->GetDefaultValueAs<CustomStruct>("klass");
    EXPECT_EQ(2U, ntuple->GetNEntries());
    ntuple->LoadEntry(0);
    EXPECT_EQ(1337.0, rdKlass->a);

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -9,6 +9,7 @@ TEST(RNTuple, ReconstructModel)
    auto fieldKlass = model->MakeField<CustomStruct>("klass");
    auto fieldArray = model->MakeField<std::array<double, 2>>("array");
    auto fieldVariant = model->MakeField<std::variant<double, std::variant<std::string, double>>>("variant");
+   model->Freeze();
    {
       RPageSinkFile sink("myNTuple", fileGuard.GetPath(), RNTupleWriteOptions());
       sink.Create(*model.get());

--- a/tree/ntuple/v7/test/ntuple_extended.cxx
+++ b/tree/ntuple/v7/test/ntuple_extended.cxx
@@ -235,7 +235,7 @@ TEST(RNTuple, LargeFile2)
    {
       auto reader = RNTupleReader::Open("small", fileGuard.GetPath());
       reader->LoadEntry(0);
-      EXPECT_EQ(42.0f, *reader->GetModel()->GetDefaultEntry().lock()->Get<float>("pt"));
+      EXPECT_EQ(42.0f, *reader->GetModel()->GetDefaultEntry().lock()->GetRaw<float>("pt"));
 
       reader = RNTupleReader::Open("large", fileGuard.GetPath());
       auto viewE = reader->GetView<double>("E");
@@ -256,7 +256,7 @@ TEST(RNTuple, LargeFile2)
 
       auto reader = RNTupleReader::Open(f->Get<RNTuple>("small"));
       reader->LoadEntry(0);
-      EXPECT_EQ(42.0f, *reader->GetModel()->GetDefaultEntry().lock()->Get<float>("pt"));
+      EXPECT_EQ(42.0f, *reader->GetModel()->GetDefaultEntry().lock()->GetRaw<float>("pt"));
 
       reader = RNTupleReader::Open(f->Get<RNTuple>("large"));
       auto viewE = reader->GetView<double>("E");

--- a/tree/ntuple/v7/test/ntuple_extended.cxx
+++ b/tree/ntuple/v7/test/ntuple_extended.cxx
@@ -235,7 +235,7 @@ TEST(RNTuple, LargeFile2)
    {
       auto reader = RNTupleReader::Open("small", fileGuard.GetPath());
       reader->LoadEntry(0);
-      EXPECT_EQ(42.0f, *reader->GetModel()->GetDefaultEntry().lock()->GetRaw<float>("pt"));
+      EXPECT_EQ(42.0f, *reader->GetDefaultValueAs<float>("pt"));
 
       reader = RNTupleReader::Open("large", fileGuard.GetPath());
       auto viewE = reader->GetView<double>("E");
@@ -256,7 +256,7 @@ TEST(RNTuple, LargeFile2)
 
       auto reader = RNTupleReader::Open(f->Get<RNTuple>("small"));
       reader->LoadEntry(0);
-      EXPECT_EQ(42.0f, *reader->GetModel()->GetDefaultEntry().lock()->GetRaw<float>("pt"));
+      EXPECT_EQ(42.0f, *reader->GetDefaultValueAs<float>("pt"));
 
       reader = RNTupleReader::Open(f->Get<RNTuple>("large"));
       auto viewE = reader->GetView<double>("E");

--- a/tree/ntuple/v7/test/ntuple_extended.cxx
+++ b/tree/ntuple/v7/test/ntuple_extended.cxx
@@ -235,7 +235,7 @@ TEST(RNTuple, LargeFile2)
    {
       auto reader = RNTupleReader::Open("small", fileGuard.GetPath());
       reader->LoadEntry(0);
-      EXPECT_EQ(42.0f, *reader->GetModel()->GetDefaultEntry()->Get<float>("pt"));
+      EXPECT_EQ(42.0f, *reader->GetModel()->GetDefaultEntry().lock()->Get<float>("pt"));
 
       reader = RNTupleReader::Open("large", fileGuard.GetPath());
       auto viewE = reader->GetView<double>("E");
@@ -256,7 +256,7 @@ TEST(RNTuple, LargeFile2)
 
       auto reader = RNTupleReader::Open(f->Get<RNTuple>("small"));
       reader->LoadEntry(0);
-      EXPECT_EQ(42.0f, *reader->GetModel()->GetDefaultEntry()->Get<float>("pt"));
+      EXPECT_EQ(42.0f, *reader->GetModel()->GetDefaultEntry().lock()->Get<float>("pt"));
 
       reader = RNTupleReader::Open(f->Get<RNTuple>("large"));
       auto viewE = reader->GetView<double>("E");

--- a/tree/ntuple/v7/test/ntuple_friends.cxx
+++ b/tree/ntuple/v7/test/ntuple_friends.cxx
@@ -26,9 +26,9 @@ TEST(RPageStorageFriends, Empty)
    std::span<RNTupleReader::ROpenSpec> ntuples;
    auto reader = RNTupleReader::OpenFriends(ntuples);
    EXPECT_EQ(0u, reader->GetNEntries());
-   EXPECT_EQ(0u, reader->GetModel()->GetFieldZero().GetOnDiskId());
-   EXPECT_EQ(0u, std::distance(reader->GetModel()->GetDefaultEntry().lock()->begin(),
-                               reader->GetModel()->GetDefaultEntry().lock()->end()));
+   EXPECT_EQ(0u, reader->GetModel().lock()->GetFieldZero().GetOnDiskId());
+   EXPECT_EQ(0u, std::distance(reader->GetModel().lock()->GetDefaultEntry().lock()->begin(),
+                               reader->GetModel().lock()->GetDefaultEntry().lock()->end()));
    EXPECT_EQ(0u, reader->GetDescriptor()->GetNLogicalColumns());
    EXPECT_EQ(0u, reader->GetDescriptor()->GetNPhysicalColumns());
    EXPECT_EQ(1u, reader->GetDescriptor()->GetNFields()); // The zero field

--- a/tree/ntuple/v7/test/ntuple_friends.cxx
+++ b/tree/ntuple/v7/test/ntuple_friends.cxx
@@ -26,7 +26,7 @@ TEST(RPageStorageFriends, Empty)
    std::span<RNTupleReader::ROpenSpec> ntuples;
    auto reader = RNTupleReader::OpenFriends(ntuples);
    EXPECT_EQ(0u, reader->GetNEntries());
-   EXPECT_EQ(0u, reader->GetModel()->GetFieldZero()->GetOnDiskId());
+   EXPECT_EQ(0u, reader->GetModel()->GetFieldZero().GetOnDiskId());
    EXPECT_EQ(0u, std::distance(reader->GetModel()->GetDefaultEntry().lock()->begin(),
                                reader->GetModel()->GetDefaultEntry().lock()->end()));
    EXPECT_EQ(0u, reader->GetDescriptor()->GetNLogicalColumns());

--- a/tree/ntuple/v7/test/ntuple_friends.cxx
+++ b/tree/ntuple/v7/test/ntuple_friends.cxx
@@ -27,8 +27,8 @@ TEST(RPageStorageFriends, Empty)
    auto reader = RNTupleReader::OpenFriends(ntuples);
    EXPECT_EQ(0u, reader->GetNEntries());
    EXPECT_EQ(0u, reader->GetModel()->GetFieldZero()->GetOnDiskId());
-   EXPECT_EQ(0u, std::distance(reader->GetModel()->GetDefaultEntry()->begin(),
-                               reader->GetModel()->GetDefaultEntry()->end()));
+   EXPECT_EQ(0u, std::distance(reader->GetModel()->GetDefaultEntry().lock()->begin(),
+                               reader->GetModel()->GetDefaultEntry().lock()->end()));
    EXPECT_EQ(0u, reader->GetDescriptor()->GetNLogicalColumns());
    EXPECT_EQ(0u, reader->GetDescriptor()->GetNPhysicalColumns());
    EXPECT_EQ(1u, reader->GetDescriptor()->GetNFields()); // The zero field

--- a/tree/ntuple/v7/test/ntuple_metrics.cxx
+++ b/tree/ntuple/v7/test/ntuple_metrics.cxx
@@ -99,15 +99,14 @@ TEST(Metrics, RNTupleWriter)
    auto int_field = model->MakeField<int>("ints");
    auto float_field = model->MakeField<float>("floats");
    auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", rootFileName);
-   EXPECT_FALSE(ntuple->GetMetrics().IsEnabled());
+   EXPECT_FALSE(ntuple->GetMetrics()->IsEnabled());
    ntuple->EnableMetrics();
-   EXPECT_TRUE(ntuple->GetMetrics().IsEnabled());
+   EXPECT_TRUE(ntuple->GetMetrics()->IsEnabled());
    *int_field = 0;
    *float_field = 10.0;
    ntuple->Fill();
    ntuple->CommitCluster();
-   auto* page_counter = ntuple->GetMetrics().GetCounter(
-      "RNTupleWriter.RPageSinkBuf.RPageSinkFile.nPageCommitted");
+   auto *page_counter = ntuple->GetMetrics()->GetCounter("RNTupleWriter.RPageSinkBuf.RPageSinkFile.nPageCommitted");
    ASSERT_FALSE(page_counter == nullptr);
    // one page for the int field, one for the float field
    EXPECT_EQ(2, page_counter->GetValueAsInt());

--- a/tree/ntuple/v7/test/ntuple_minifile.cxx
+++ b/tree/ntuple/v7/test/ntuple_minifile.cxx
@@ -248,7 +248,7 @@ TEST(MiniFile, FailOnForwardIncompatibility)
       auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
       ASSERT_EQ(1U, reader->GetNEntries());
       reader->LoadEntry(0);
-      EXPECT_EQ(42.0, *(reader->GetModel()->GetDefaultEntry().lock()->Get<float>("pt")));
+      EXPECT_EQ(42.0, *(reader->GetModel()->GetDefaultEntry().lock()->GetRaw<float>("pt")));
    }
 
    // Fix the version numbers in the header

--- a/tree/ntuple/v7/test/ntuple_minifile.cxx
+++ b/tree/ntuple/v7/test/ntuple_minifile.cxx
@@ -248,7 +248,7 @@ TEST(MiniFile, FailOnForwardIncompatibility)
       auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
       ASSERT_EQ(1U, reader->GetNEntries());
       reader->LoadEntry(0);
-      EXPECT_EQ(42.0, *(reader->GetModel()->GetDefaultEntry().lock()->GetRaw<float>("pt")));
+      EXPECT_EQ(42.0, *(reader->GetDefaultValueAs<float>("pt")));
    }
 
    // Fix the version numbers in the header

--- a/tree/ntuple/v7/test/ntuple_minifile.cxx
+++ b/tree/ntuple/v7/test/ntuple_minifile.cxx
@@ -248,7 +248,7 @@ TEST(MiniFile, FailOnForwardIncompatibility)
       auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
       ASSERT_EQ(1U, reader->GetNEntries());
       reader->LoadEntry(0);
-      EXPECT_EQ(42.0, *(reader->GetModel()->GetDefaultEntry()->Get<float>("pt")));
+      EXPECT_EQ(42.0, *(reader->GetModel()->GetDefaultEntry().lock()->Get<float>("pt")));
    }
 
    // Fix the version numbers in the header

--- a/tree/ntuple/v7/test/ntuple_modelext.cxx
+++ b/tree/ntuple/v7/test/ntuple_modelext.cxx
@@ -28,9 +28,9 @@ struct RFieldBaseTest : public ROOT::Experimental::Detail::RFieldBase {
    }
 };
 
-std::size_t GetFirstEntry(const RFieldBase *f)
+std::size_t GetFirstEntry(const RFieldBase &f)
 {
-   return static_cast<const RFieldBaseTest *>(f)->GetFirstEntry();
+   return static_cast<const RFieldBaseTest &>(f).GetFirstEntry();
 }
 } // anonymous namespace
 

--- a/tree/ntuple/v7/test/ntuple_modelext.cxx
+++ b/tree/ntuple/v7/test/ntuple_modelext.cxx
@@ -86,27 +86,27 @@ TEST(RNTuple, ModelExtensionInvalidUse)
       auto model = RNTupleModel::Create();
       auto fieldPt = model->MakeField<float>("pt", 42.0);
 
-      auto ntuple = RNTupleWriter::Recreate(std::move(model), "myNTuple", fileGuard.GetPath());
-      auto entry = ntuple->GetModel()->CreateEntry();
+      auto writer = RNTupleWriter::Recreate(std::move(model), "myNTuple", fileGuard.GetPath());
+      auto entry = writer->CreateEntry();
 
-      auto modelUpdater = ntuple->CreateModelUpdater();
+      auto modelUpdater = writer->CreateModelUpdater();
       modelUpdater->BeginUpdate();
       double d;
       modelUpdater->AddField<double>("d", &d);
       // Cannot fill if the model is not frozen
-      EXPECT_THROW(ntuple->Fill(), ROOT::Experimental::RException);
+      EXPECT_THROW(writer->Fill(), ROOT::Experimental::RException);
       // Trying to create an entry should throw if model is not frozen
-      EXPECT_THROW((void)ntuple->GetModel()->CreateEntry(), ROOT::Experimental::RException);
+      EXPECT_THROW((void)writer->CreateEntry(), ROOT::Experimental::RException);
       modelUpdater->CommitUpdate();
 
       // Using an entry that does not match the model should throw
-      EXPECT_THROW(ntuple->Fill(*entry), ROOT::Experimental::RException);
+      EXPECT_THROW(writer->Fill(*entry.lock()), ROOT::Experimental::RException);
 
-      ntuple->Fill();
-      auto entry2 = ntuple->GetModel()->CreateEntry();
-      ntuple->Fill(*entry2);
+      writer->Fill();
+      auto entry2 = writer->CreateEntry();
+      writer->Fill(*entry2.lock());
 
-      ntuple->Fill();
+      writer->Fill();
    }
 
    auto ntuple = RNTupleReader::Open("myNTuple", fileGuard.GetPath());

--- a/tree/ntuple/v7/test/ntuple_modelext.cxx
+++ b/tree/ntuple/v7/test/ntuple_modelext.cxx
@@ -62,8 +62,8 @@ TEST(RNTuple, ModelExtensionSimple)
    auto ntuple = RNTupleReader::Open("myNTuple", fileGuard.GetPath());
    EXPECT_EQ(4U, ntuple->GetNEntries());
    EXPECT_EQ(4U, ntuple->GetDescriptor()->GetNFields());
-   EXPECT_EQ(0U, GetFirstEntry(ntuple->GetModel()->GetField("pt")));
-   EXPECT_EQ(2U, GetFirstEntry(ntuple->GetModel()->GetField("array")));
+   EXPECT_EQ(0U, GetFirstEntry(ntuple->GetModel().lock()->GetField("pt")));
+   EXPECT_EQ(2U, GetFirstEntry(ntuple->GetModel().lock()->GetField("array")));
 
    auto pt = ntuple->GetView<float>("pt");
    auto array = ntuple->GetView<std::array<double, 2>>("array");
@@ -160,11 +160,11 @@ TEST(RNTuple, ModelExtensionMultiple)
    auto ntuple = RNTupleReader::Open("myNTuple", fileGuard.GetPath());
    EXPECT_EQ(5U, ntuple->GetNEntries());
    EXPECT_EQ(7U, ntuple->GetDescriptor()->GetNFields());
-   EXPECT_EQ(0U, GetFirstEntry(ntuple->GetModel()->GetField("pt")));
-   EXPECT_EQ(3U, GetFirstEntry(ntuple->GetModel()->GetField("vec")));
-   EXPECT_EQ(3U, GetFirstEntry(ntuple->GetModel()->GetField("f")));
-   EXPECT_EQ(3U, GetFirstEntry(ntuple->GetModel()->GetField("u8")));
-   EXPECT_EQ(3U, GetFirstEntry(ntuple->GetModel()->GetField("str")));
+   EXPECT_EQ(0U, GetFirstEntry(ntuple->GetModel().lock()->GetField("pt")));
+   EXPECT_EQ(3U, GetFirstEntry(ntuple->GetModel().lock()->GetField("vec")));
+   EXPECT_EQ(3U, GetFirstEntry(ntuple->GetModel().lock()->GetField("f")));
+   EXPECT_EQ(3U, GetFirstEntry(ntuple->GetModel().lock()->GetField("u8")));
+   EXPECT_EQ(3U, GetFirstEntry(ntuple->GetModel().lock()->GetField("str")));
 
    auto pt = ntuple->GetView<float>("pt");
    auto vec = ntuple->GetView<std::vector<std::uint32_t>>("vec");

--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -210,7 +210,7 @@ TEST(Packing, OnDiskEncoding)
       RNTupleWriteOptions options;
       options.SetCompression(0);
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), options);
-      auto e = writer->CreateEntry();
+      auto e = writer->CreateEntry().lock();
 
       *e->Get<std::int16_t>("int16") = 1;
       *e->Get<std::int32_t>("int32") = 0x00010203;

--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -297,7 +297,7 @@ TEST(Packing, OnDiskEncoding)
    EXPECT_EQ(memcmp(sealedPage.fBuffer, expIndex64, sizeof(expIndex64)), 0);
 
    auto reader = RNTupleReader(std::move(source));
-   EXPECT_EQ(EColumnType::kIndex64, reader.GetModel()->GetField("str")->GetColumnRepresentative()[0]);
+   EXPECT_EQ(EColumnType::kIndex64, reader.GetModel()->GetField("str").GetColumnRepresentative()[0]);
    EXPECT_EQ(2u, reader.GetNEntries());
    auto viewStr = reader.GetView<std::string>("str");
    EXPECT_EQ(std::string("abc"), viewStr(0));

--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -212,31 +212,31 @@ TEST(Packing, OnDiskEncoding)
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), options);
       auto e = writer->CreateEntry().lock();
 
-      *e->Get<std::int16_t>("int16") = 1;
-      *e->Get<std::int32_t>("int32") = 0x00010203;
-      *e->Get<std::int64_t>("int64") = 0x0001020304050607L;
-      *e->Get<std::uint16_t>("uint16") = 1;
-      *e->Get<std::uint32_t>("uint32") = 0x00010203;
-      *e->Get<std::uint64_t>("uint64") = 0x0001020304050607L;
-      *e->Get<float>("float") = std::nextafterf(1.f, 2.f); // 0 01111111 00000000000000000000001 == 0x3f800001
-      *e->Get<double>("double") = std::nextafter(1., 2.);  // 0x3ff0 0000 0000 0001
-      *e->Get<ClusterSize_t>("index32") = 39916801;        // 0x0261 1501
-      *e->Get<ClusterSize_t>("index64") = 0x0706050403020100L;
-      e->Get<std::string>("str")->assign("abc");
+      *e->GetRaw<std::int16_t>("int16") = 1;
+      *e->GetRaw<std::int32_t>("int32") = 0x00010203;
+      *e->GetRaw<std::int64_t>("int64") = 0x0001020304050607L;
+      *e->GetRaw<std::uint16_t>("uint16") = 1;
+      *e->GetRaw<std::uint32_t>("uint32") = 0x00010203;
+      *e->GetRaw<std::uint64_t>("uint64") = 0x0001020304050607L;
+      *e->GetRaw<float>("float") = std::nextafterf(1.f, 2.f); // 0 01111111 00000000000000000000001 == 0x3f800001
+      *e->GetRaw<double>("double") = std::nextafter(1., 2.);  // 0x3ff0 0000 0000 0001
+      *e->GetRaw<ClusterSize_t>("index32") = 39916801;        // 0x0261 1501
+      *e->GetRaw<ClusterSize_t>("index64") = 0x0706050403020100L;
+      e->GetRaw<std::string>("str")->assign("abc");
 
       writer->Fill(*e);
 
-      *e->Get<std::int16_t>("int16") = -3;
-      *e->Get<std::int32_t>("int32") = -0x04050607;
-      *e->Get<std::int64_t>("int64") = -0x08090a0b0c0d0e0fL;
-      *e->Get<std::uint16_t>("uint16") = 2;
-      *e->Get<std::uint32_t>("uint32") = 0x04050607;
-      *e->Get<std::uint64_t>("uint64") = 0x08090a0b0c0d0e0fL;
-      *e->Get<float>("float") = std::nextafterf(1.f, 0.f);            // 0 01111110 11111111111111111111111 = 0x3f7fffff
-      *e->Get<double>("double") = std::numeric_limits<double>::max(); // 0x7fef ffff ffff ffff
-      *e->Get<ClusterSize_t>("index32") = 39916808;                   // d(previous) == 7
-      *e->Get<ClusterSize_t>("index64") = 0x070605040302010DL;        // d(previous) == 13
-      e->Get<std::string>("str")->assign("de");
+      *e->GetRaw<std::int16_t>("int16") = -3;
+      *e->GetRaw<std::int32_t>("int32") = -0x04050607;
+      *e->GetRaw<std::int64_t>("int64") = -0x08090a0b0c0d0e0fL;
+      *e->GetRaw<std::uint16_t>("uint16") = 2;
+      *e->GetRaw<std::uint32_t>("uint32") = 0x04050607;
+      *e->GetRaw<std::uint64_t>("uint64") = 0x08090a0b0c0d0e0fL;
+      *e->GetRaw<float>("float") = std::nextafterf(1.f, 0.f); // 0 01111110 11111111111111111111111 = 0x3f7fffff
+      *e->GetRaw<double>("double") = std::numeric_limits<double>::max(); // 0x7fef ffff ffff ffff
+      *e->GetRaw<ClusterSize_t>("index32") = 39916808;                   // d(previous) == 7
+      *e->GetRaw<ClusterSize_t>("index64") = 0x070605040302010DL;        // d(previous) == 13
+      e->GetRaw<std::string>("str")->assign("de");
 
       writer->Fill(*e);
    }

--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -212,31 +212,31 @@ TEST(Packing, OnDiskEncoding)
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), options);
       auto e = writer->CreateEntry().lock();
 
-      *e->GetRaw<std::int16_t>("int16") = 1;
-      *e->GetRaw<std::int32_t>("int32") = 0x00010203;
-      *e->GetRaw<std::int64_t>("int64") = 0x0001020304050607L;
-      *e->GetRaw<std::uint16_t>("uint16") = 1;
-      *e->GetRaw<std::uint32_t>("uint32") = 0x00010203;
-      *e->GetRaw<std::uint64_t>("uint64") = 0x0001020304050607L;
-      *e->GetRaw<float>("float") = std::nextafterf(1.f, 2.f); // 0 01111111 00000000000000000000001 == 0x3f800001
-      *e->GetRaw<double>("double") = std::nextafter(1., 2.);  // 0x3ff0 0000 0000 0001
-      *e->GetRaw<ClusterSize_t>("index32") = 39916801;        // 0x0261 1501
-      *e->GetRaw<ClusterSize_t>("index64") = 0x0706050403020100L;
-      e->GetRaw<std::string>("str")->assign("abc");
+      *e->GetValueAs<std::int16_t>("int16") = 1;
+      *e->GetValueAs<std::int32_t>("int32") = 0x00010203;
+      *e->GetValueAs<std::int64_t>("int64") = 0x0001020304050607L;
+      *e->GetValueAs<std::uint16_t>("uint16") = 1;
+      *e->GetValueAs<std::uint32_t>("uint32") = 0x00010203;
+      *e->GetValueAs<std::uint64_t>("uint64") = 0x0001020304050607L;
+      *e->GetValueAs<float>("float") = std::nextafterf(1.f, 2.f); // 0 01111111 00000000000000000000001 == 0x3f800001
+      *e->GetValueAs<double>("double") = std::nextafter(1., 2.);  // 0x3ff0 0000 0000 0001
+      *e->GetValueAs<ClusterSize_t>("index32") = 39916801;        // 0x0261 1501
+      *e->GetValueAs<ClusterSize_t>("index64") = 0x0706050403020100L;
+      e->GetValueAs<std::string>("str")->assign("abc");
 
       writer->Fill(*e);
 
-      *e->GetRaw<std::int16_t>("int16") = -3;
-      *e->GetRaw<std::int32_t>("int32") = -0x04050607;
-      *e->GetRaw<std::int64_t>("int64") = -0x08090a0b0c0d0e0fL;
-      *e->GetRaw<std::uint16_t>("uint16") = 2;
-      *e->GetRaw<std::uint32_t>("uint32") = 0x04050607;
-      *e->GetRaw<std::uint64_t>("uint64") = 0x08090a0b0c0d0e0fL;
-      *e->GetRaw<float>("float") = std::nextafterf(1.f, 0.f); // 0 01111110 11111111111111111111111 = 0x3f7fffff
-      *e->GetRaw<double>("double") = std::numeric_limits<double>::max(); // 0x7fef ffff ffff ffff
-      *e->GetRaw<ClusterSize_t>("index32") = 39916808;                   // d(previous) == 7
-      *e->GetRaw<ClusterSize_t>("index64") = 0x070605040302010DL;        // d(previous) == 13
-      e->GetRaw<std::string>("str")->assign("de");
+      *e->GetValueAs<std::int16_t>("int16") = -3;
+      *e->GetValueAs<std::int32_t>("int32") = -0x04050607;
+      *e->GetValueAs<std::int64_t>("int64") = -0x08090a0b0c0d0e0fL;
+      *e->GetValueAs<std::uint16_t>("uint16") = 2;
+      *e->GetValueAs<std::uint32_t>("uint32") = 0x04050607;
+      *e->GetValueAs<std::uint64_t>("uint64") = 0x08090a0b0c0d0e0fL;
+      *e->GetValueAs<float>("float") = std::nextafterf(1.f, 0.f); // 0 01111110 11111111111111111111111 = 0x3f7fffff
+      *e->GetValueAs<double>("double") = std::numeric_limits<double>::max(); // 0x7fef ffff ffff ffff
+      *e->GetValueAs<ClusterSize_t>("index32") = 39916808;                   // d(previous) == 7
+      *e->GetValueAs<ClusterSize_t>("index64") = 0x070605040302010DL;        // d(previous) == 13
+      e->GetValueAs<std::string>("str")->assign("de");
 
       writer->Fill(*e);
    }

--- a/tree/ntuple/v7/test/ntuple_packing.cxx
+++ b/tree/ntuple/v7/test/ntuple_packing.cxx
@@ -297,7 +297,7 @@ TEST(Packing, OnDiskEncoding)
    EXPECT_EQ(memcmp(sealedPage.fBuffer, expIndex64, sizeof(expIndex64)), 0);
 
    auto reader = RNTupleReader(std::move(source));
-   EXPECT_EQ(EColumnType::kIndex64, reader.GetModel()->GetField("str").GetColumnRepresentative()[0]);
+   EXPECT_EQ(EColumnType::kIndex64, reader.GetModel().lock()->GetField("str").GetColumnRepresentative()[0]);
    EXPECT_EQ(2u, reader.GetNEntries());
    auto viewStr = reader.GetView<std::string>("str");
    EXPECT_EQ(std::string("abc"), viewStr(0));

--- a/tree/ntuple/v7/test/ntuple_show.cxx
+++ b/tree/ntuple/v7/test/ntuple_show.cxx
@@ -456,9 +456,9 @@ TEST(RNTupleShow, RVecTypeErased)
 
       auto writer = RNTupleWriter::Recreate(std::move(m), ntupleName, rootFileName);
       auto entry = writer->CreateBareEntry().lock();
-      entry->BindValue("intVec", &intVec);
-      entry->BindValue("floatVecVec", &floatVecVec);
-      entry->BindValue("customStructVec", &customStructVec);
+      entry->BindRaw("intVec", &intVec);
+      entry->BindRaw("floatVecVec", &floatVecVec);
+      entry->BindRaw("customStructVec", &customStructVec);
 
       writer->Fill(*entry);
       intVec.emplace_back(4);

--- a/tree/ntuple/v7/test/ntuple_show.cxx
+++ b/tree/ntuple/v7/test/ntuple_show.cxx
@@ -456,9 +456,9 @@ TEST(RNTupleShow, RVecTypeErased)
 
       auto writer = RNTupleWriter::Recreate(std::move(m), ntupleName, rootFileName);
       auto entry = writer->CreateBareEntry().lock();
-      entry->CaptureValueUnsafe("intVec", &intVec);
-      entry->CaptureValueUnsafe("floatVecVec", &floatVecVec);
-      entry->CaptureValueUnsafe("customStructVec", &customStructVec);
+      entry->BindValue("intVec", &intVec);
+      entry->BindValue("floatVecVec", &floatVecVec);
+      entry->BindValue("customStructVec", &customStructVec);
 
       writer->Fill(*entry);
       intVec.emplace_back(4);

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -71,7 +71,7 @@ TEST(RNTuple, Basics)
 
    auto ntuple = RNTupleReader::Open("f", fileGuard.GetPath());
    EXPECT_EQ(3U, ntuple->GetNEntries());
-   auto rdPt = ntuple->GetModel()->GetDefaultEntry().lock()->Get<float>("pt");
+   auto rdPt = ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<float>("pt");
 
    ntuple->LoadEntry(0);
    EXPECT_EQ(42.0, *rdPt);
@@ -110,7 +110,7 @@ TEST(RNTuple, Extended)
    }
 
    auto ntuple = RNTupleReader::Open("f", fileGuard.GetPath());
-   auto rdVector = ntuple->GetModel()->GetDefaultEntry().lock()->Get<std::vector<double>>("vector");
+   auto rdVector = ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<std::vector<double>>("vector");
 
    double chksumRead = 0.0;
    for (auto entryId : *ntuple) {
@@ -519,7 +519,7 @@ TEST(RPageSink, MultipleClusterGroups)
    EXPECT_EQ(2U, ntuple->GetDescriptor()->GetNClusterGroups());
    EXPECT_EQ(3U, ntuple->GetDescriptor()->GetNClusters());
    EXPECT_EQ(3U, ntuple->GetNEntries());
-   auto rdPt = ntuple->GetModel()->GetDefaultEntry().lock()->Get<float>("pt");
+   auto rdPt = ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<float>("pt");
 
    ntuple->LoadEntry(0);
    EXPECT_EQ(42.0, *rdPt);

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -318,8 +318,7 @@ TEST(RPageSinkBuf, Basics)
          if (i && i % 30000 == 0) {
             ntupleBuf->CommitCluster();
             ntuple->CommitCluster();
-            auto *parallel_zip = ntupleBuf->GetMetrics().GetCounter(
-               "RNTupleWriter.RPageSinkBuf.ParallelZip");
+            auto *parallel_zip = ntupleBuf->GetMetrics()->GetCounter("RNTupleWriter.RPageSinkBuf.ParallelZip");
             ASSERT_FALSE(parallel_zip == nullptr);
             EXPECT_EQ(0, parallel_zip->GetValueAsInt());
          }
@@ -398,8 +397,7 @@ TEST(RPageSinkBuf, ParallelZip) {
          ntuple->Fill();
          if (i && i % 15000 == 0) {
             ntuple->CommitCluster();
-            auto *parallel_zip = ntuple->GetMetrics().GetCounter(
-               "RNTupleWriter.RPageSinkBuf.ParallelZip");
+            auto *parallel_zip = ntuple->GetMetrics()->GetCounter("RNTupleWriter.RPageSinkBuf.ParallelZip");
             ASSERT_FALSE(parallel_zip == nullptr);
 #ifdef R__USE_IMT
             EXPECT_EQ(1, parallel_zip->GetValueAsInt());

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -71,7 +71,7 @@ TEST(RNTuple, Basics)
 
    auto ntuple = RNTupleReader::Open("f", fileGuard.GetPath());
    EXPECT_EQ(3U, ntuple->GetNEntries());
-   auto rdPt = ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<float>("pt");
+   auto rdPt = ntuple->GetDefaultValueAs<float>("pt");
 
    ntuple->LoadEntry(0);
    EXPECT_EQ(42.0, *rdPt);
@@ -110,7 +110,7 @@ TEST(RNTuple, Extended)
    }
 
    auto ntuple = RNTupleReader::Open("f", fileGuard.GetPath());
-   auto rdVector = ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<std::vector<double>>("vector");
+   auto rdVector = ntuple->GetDefaultValueAs<std::vector<double>>("vector");
 
    double chksumRead = 0.0;
    for (auto entryId : *ntuple) {
@@ -519,7 +519,7 @@ TEST(RPageSink, MultipleClusterGroups)
    EXPECT_EQ(2U, ntuple->GetDescriptor()->GetNClusterGroups());
    EXPECT_EQ(3U, ntuple->GetDescriptor()->GetNClusters());
    EXPECT_EQ(3U, ntuple->GetNEntries());
-   auto rdPt = ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<float>("pt");
+   auto rdPt = ntuple->GetDefaultValueAs<float>("pt");
 
    ntuple->LoadEntry(0);
    EXPECT_EQ(42.0, *rdPt);

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -71,7 +71,7 @@ TEST(RNTuple, Basics)
 
    auto ntuple = RNTupleReader::Open("f", fileGuard.GetPath());
    EXPECT_EQ(3U, ntuple->GetNEntries());
-   auto rdPt = ntuple->GetModel()->GetDefaultEntry()->Get<float>("pt");
+   auto rdPt = ntuple->GetModel()->GetDefaultEntry().lock()->Get<float>("pt");
 
    ntuple->LoadEntry(0);
    EXPECT_EQ(42.0, *rdPt);
@@ -110,7 +110,7 @@ TEST(RNTuple, Extended)
    }
 
    auto ntuple = RNTupleReader::Open("f", fileGuard.GetPath());
-   auto rdVector = ntuple->GetModel()->GetDefaultEntry()->Get<std::vector<double>>("vector");
+   auto rdVector = ntuple->GetModel()->GetDefaultEntry().lock()->Get<std::vector<double>>("vector");
 
    double chksumRead = 0.0;
    for (auto entryId : *ntuple) {
@@ -519,7 +519,7 @@ TEST(RPageSink, MultipleClusterGroups)
    EXPECT_EQ(2U, ntuple->GetDescriptor()->GetNClusterGroups());
    EXPECT_EQ(3U, ntuple->GetDescriptor()->GetNClusters());
    EXPECT_EQ(3U, ntuple->GetNEntries());
-   auto rdPt = ntuple->GetModel()->GetDefaultEntry()->Get<float>("pt");
+   auto rdPt = ntuple->GetModel()->GetDefaultEntry().lock()->Get<float>("pt");
 
    ntuple->LoadEntry(0);
    EXPECT_EQ(42.0, *rdPt);

--- a/tree/ntuple/v7/test/ntuple_storage_daos.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage_daos.cxx
@@ -66,7 +66,7 @@ TEST_F(RPageStorageDaos, Basics)
 
    auto ntuple = RNTupleReader::Open(ntupleName, daosUri);
    EXPECT_EQ(3U, ntuple->GetNEntries());
-   auto rdPt = ntuple->GetModel()->GetDefaultEntry()->Get<float>("pt");
+   auto rdPt = ntuple->GetModel()->GetDefaultEntry().lock()->Get<float>("pt");
 
    ntuple->LoadEntry(0);
    EXPECT_EQ(42.0, *rdPt);
@@ -107,7 +107,7 @@ TEST_F(RPageStorageDaos, Extended)
    RNTupleReadOptions options;
    options.SetClusterBunchSize(5);
    auto ntuple = RNTupleReader::Open(ntupleName, daosUri, options);
-   auto rdVector = ntuple->GetModel()->GetDefaultEntry()->Get<std::vector<double>>("vector");
+   auto rdVector = ntuple->GetModel()->GetDefaultEntry().lock()->Get<std::vector<double>>("vector");
 
    double chksumRead = 0.0;
    for (auto entryId : *ntuple) {
@@ -189,14 +189,14 @@ TEST_F(RPageStorageDaos, MultipleNTuplesPerContainer)
       EXPECT_EQ(3U, ntuple2->GetNEntries());
 
       {
-         auto rdPt = ntuple1->GetModel()->GetDefaultEntry()->Get<float>("pt");
+         auto rdPt = ntuple1->GetModel()->GetDefaultEntry().lock()->Get<float>("pt");
          ntuple1->LoadEntry(0);
          EXPECT_EQ(34.0, *rdPt);
          ntuple1->LoadEntry(1);
          EXPECT_EQ(160.0, *rdPt);
       }
       {
-         auto rdPt = ntuple2->GetModel()->GetDefaultEntry()->Get<float>("pt");
+         auto rdPt = ntuple2->GetModel()->GetDefaultEntry().lock()->Get<float>("pt");
          ntuple2->LoadEntry(0);
          EXPECT_EQ(81.0, *rdPt);
          ntuple2->LoadEntry(1);
@@ -248,7 +248,7 @@ TEST_F(RPageStorageDaos, CagedPages)
       options.SetClusterCache(RNTupleReadOptions::EClusterCache::kOn);
       options.SetClusterBunchSize(5);
       auto ntuple = RNTupleReader::Open(ntupleName, daosUri, options);
-      auto rdVector = ntuple->GetModel()->GetDefaultEntry()->Get<std::vector<double>>("vector");
+      auto rdVector = ntuple->GetModel()->GetDefaultEntry().lock()->Get<std::vector<double>>("vector");
 
       double chksumRead = 0.0;
       for (auto entryId : *ntuple) {

--- a/tree/ntuple/v7/test/ntuple_storage_daos.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage_daos.cxx
@@ -66,7 +66,7 @@ TEST_F(RPageStorageDaos, Basics)
 
    auto ntuple = RNTupleReader::Open(ntupleName, daosUri);
    EXPECT_EQ(3U, ntuple->GetNEntries());
-   auto rdPt = ntuple->GetModel()->GetDefaultEntry().lock()->Get<float>("pt");
+   auto rdPt = ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<float>("pt");
 
    ntuple->LoadEntry(0);
    EXPECT_EQ(42.0, *rdPt);
@@ -107,7 +107,7 @@ TEST_F(RPageStorageDaos, Extended)
    RNTupleReadOptions options;
    options.SetClusterBunchSize(5);
    auto ntuple = RNTupleReader::Open(ntupleName, daosUri, options);
-   auto rdVector = ntuple->GetModel()->GetDefaultEntry().lock()->Get<std::vector<double>>("vector");
+   auto rdVector = ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<std::vector<double>>("vector");
 
    double chksumRead = 0.0;
    for (auto entryId : *ntuple) {
@@ -189,14 +189,14 @@ TEST_F(RPageStorageDaos, MultipleNTuplesPerContainer)
       EXPECT_EQ(3U, ntuple2->GetNEntries());
 
       {
-         auto rdPt = ntuple1->GetModel()->GetDefaultEntry().lock()->Get<float>("pt");
+         auto rdPt = ntuple1->GetModel()->GetDefaultEntry().lock()->GetRaw<float>("pt");
          ntuple1->LoadEntry(0);
          EXPECT_EQ(34.0, *rdPt);
          ntuple1->LoadEntry(1);
          EXPECT_EQ(160.0, *rdPt);
       }
       {
-         auto rdPt = ntuple2->GetModel()->GetDefaultEntry().lock()->Get<float>("pt");
+         auto rdPt = ntuple2->GetModel()->GetDefaultEntry().lock()->GetRaw<float>("pt");
          ntuple2->LoadEntry(0);
          EXPECT_EQ(81.0, *rdPt);
          ntuple2->LoadEntry(1);
@@ -248,7 +248,7 @@ TEST_F(RPageStorageDaos, CagedPages)
       options.SetClusterCache(RNTupleReadOptions::EClusterCache::kOn);
       options.SetClusterBunchSize(5);
       auto ntuple = RNTupleReader::Open(ntupleName, daosUri, options);
-      auto rdVector = ntuple->GetModel()->GetDefaultEntry().lock()->Get<std::vector<double>>("vector");
+      auto rdVector = ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<std::vector<double>>("vector");
 
       double chksumRead = 0.0;
       for (auto entryId : *ntuple) {

--- a/tree/ntuple/v7/test/ntuple_storage_daos.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage_daos.cxx
@@ -66,7 +66,7 @@ TEST_F(RPageStorageDaos, Basics)
 
    auto ntuple = RNTupleReader::Open(ntupleName, daosUri);
    EXPECT_EQ(3U, ntuple->GetNEntries());
-   auto rdPt = ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<float>("pt");
+   auto rdPt = ntuple->GetDefaultValueAs<float>("pt");
 
    ntuple->LoadEntry(0);
    EXPECT_EQ(42.0, *rdPt);
@@ -107,7 +107,7 @@ TEST_F(RPageStorageDaos, Extended)
    RNTupleReadOptions options;
    options.SetClusterBunchSize(5);
    auto ntuple = RNTupleReader::Open(ntupleName, daosUri, options);
-   auto rdVector = ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<std::vector<double>>("vector");
+   auto rdVector = ntuple->GetDefaultValueAs<std::vector<double>>("vector");
 
    double chksumRead = 0.0;
    for (auto entryId : *ntuple) {
@@ -189,14 +189,14 @@ TEST_F(RPageStorageDaos, MultipleNTuplesPerContainer)
       EXPECT_EQ(3U, ntuple2->GetNEntries());
 
       {
-         auto rdPt = ntuple1->GetModel()->GetDefaultEntry().lock()->GetRaw<float>("pt");
+         auto rdPt = ntuple1->GetDefaultValueAs<float>("pt");
          ntuple1->LoadEntry(0);
          EXPECT_EQ(34.0, *rdPt);
          ntuple1->LoadEntry(1);
          EXPECT_EQ(160.0, *rdPt);
       }
       {
-         auto rdPt = ntuple2->GetModel()->GetDefaultEntry().lock()->GetRaw<float>("pt");
+         auto rdPt = ntuple2->GetDefaultValueAs<float>("pt");
          ntuple2->LoadEntry(0);
          EXPECT_EQ(81.0, *rdPt);
          ntuple2->LoadEntry(1);
@@ -248,7 +248,7 @@ TEST_F(RPageStorageDaos, CagedPages)
       options.SetClusterCache(RNTupleReadOptions::EClusterCache::kOn);
       options.SetClusterBunchSize(5);
       auto ntuple = RNTupleReader::Open(ntupleName, daosUri, options);
-      auto rdVector = ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<std::vector<double>>("vector");
+      auto rdVector = ntuple->GetDefaultValueAs<std::vector<double>>("vector");
 
       double chksumRead = 0.0;
       for (auto entryId : *ntuple) {

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -75,8 +75,8 @@ TEST(RNTuple, EnumBasics)
    auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
    EXPECT_EQ(1, reader->GetNEntries());
    reader->LoadEntry(0);
-   EXPECT_EQ(kCustomEnumVal, *reader->GetModel()->GetDefaultEntry().lock()->GetRaw<CustomEnum>("e"));
-   auto ptrStructWithEnums = reader->GetModel()->GetDefaultEntry().lock()->GetRaw<StructWithEnums>("swe");
+   EXPECT_EQ(kCustomEnumVal, *reader->GetDefaultValueAs<CustomEnum>("e"));
+   auto ptrStructWithEnums = reader->GetDefaultValueAs<StructWithEnums>("swe");
    EXPECT_EQ(42, ptrStructWithEnums->a);
    EXPECT_EQ(137, ptrStructWithEnums->b);
    EXPECT_EQ(kCustomEnumVal, ptrStructWithEnums->e);
@@ -124,7 +124,7 @@ TYPED_TEST(EnumClass, Widths)
    }
 
    auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
-   auto ptrEnum = reader->GetModel()->GetDefaultEntry().lock()->GetRaw<ThisEnum_t>("e");
+   auto ptrEnum = reader->GetDefaultValueAs<ThisEnum_t>("e");
    reader->LoadEntry(0);
    EXPECT_EQ(static_cast<ThisEnum_t>(0), *ptrEnum);
    reader->LoadEntry(1);
@@ -387,7 +387,7 @@ TEST(RNTuple, StdSet)
    }
 
    ntuple->LoadEntry(0);
-   auto mySet2 = ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<std::set<std::pair<int, CustomStruct>>>("mySet2");
+   auto mySet2 = ntuple->GetDefaultValueAs<std::set<std::pair<int, CustomStruct>>>("mySet2");
    auto pairSet =
       std::set<std::pair<int, CustomStruct>>({std::make_pair(0, CustomStruct{6.f, {7.f, 8.f}, {{9.f}, {10.f}}, "foo"}),
                                               std::make_pair(1, CustomStruct{2.f, {3.f, 4.f}, {{5.f}, {6.f}}, "bar"})});
@@ -440,14 +440,10 @@ TEST(RNTuple, Int64)
    EXPECT_EQ(ROOT::Experimental::EColumnType::kSplitUInt64,
              (*desc->GetColumnIterable(desc->FindFieldId("i4")).begin()).GetModel().GetType());
    reader->LoadEntry(0);
-   EXPECT_EQ(std::numeric_limits<std::int64_t>::max() - 137,
-             *reader->GetModel()->GetDefaultEntry().lock()->GetRaw<std::int64_t>("i1"));
-   EXPECT_EQ(std::numeric_limits<std::int64_t>::max() - 138,
-             *reader->GetModel()->GetDefaultEntry().lock()->GetRaw<std::int64_t>("i2"));
-   EXPECT_EQ(std::numeric_limits<std::uint64_t>::max() - 42,
-             *reader->GetModel()->GetDefaultEntry().lock()->GetRaw<std::uint64_t>("i3"));
-   EXPECT_EQ(std::numeric_limits<std::uint64_t>::max() - 43,
-             *reader->GetModel()->GetDefaultEntry().lock()->GetRaw<std::uint64_t>("i4"));
+   EXPECT_EQ(std::numeric_limits<std::int64_t>::max() - 137, *reader->GetDefaultValueAs<std::int64_t>("i1"));
+   EXPECT_EQ(std::numeric_limits<std::int64_t>::max() - 138, *reader->GetDefaultValueAs<std::int64_t>("i2"));
+   EXPECT_EQ(std::numeric_limits<std::uint64_t>::max() - 42, *reader->GetDefaultValueAs<std::uint64_t>("i3"));
+   EXPECT_EQ(std::numeric_limits<std::uint64_t>::max() - 43, *reader->GetDefaultValueAs<std::uint64_t>("i4"));
 }
 
 TEST(RNTuple, Int32)
@@ -496,14 +492,10 @@ TEST(RNTuple, Int32)
    EXPECT_EQ(ROOT::Experimental::EColumnType::kSplitUInt32,
              (*desc->GetColumnIterable(desc->FindFieldId("i4")).begin()).GetModel().GetType());
    reader->LoadEntry(0);
-   EXPECT_EQ(std::numeric_limits<std::int32_t>::max() - 137,
-             *reader->GetModel()->GetDefaultEntry().lock()->GetRaw<std::int32_t>("i1"));
-   EXPECT_EQ(std::numeric_limits<std::int32_t>::max() - 138,
-             *reader->GetModel()->GetDefaultEntry().lock()->GetRaw<std::int32_t>("i2"));
-   EXPECT_EQ(std::numeric_limits<std::uint32_t>::max() - 42,
-             *reader->GetModel()->GetDefaultEntry().lock()->GetRaw<std::uint32_t>("i3"));
-   EXPECT_EQ(std::numeric_limits<std::uint32_t>::max() - 43,
-             *reader->GetModel()->GetDefaultEntry().lock()->GetRaw<std::uint32_t>("i4"));
+   EXPECT_EQ(std::numeric_limits<std::int32_t>::max() - 137, *reader->GetDefaultValueAs<std::int32_t>("i1"));
+   EXPECT_EQ(std::numeric_limits<std::int32_t>::max() - 138, *reader->GetDefaultValueAs<std::int32_t>("i2"));
+   EXPECT_EQ(std::numeric_limits<std::uint32_t>::max() - 42, *reader->GetDefaultValueAs<std::uint32_t>("i3"));
+   EXPECT_EQ(std::numeric_limits<std::uint32_t>::max() - 43, *reader->GetDefaultValueAs<std::uint32_t>("i4"));
 }
 
 TEST(RNTuple, Int16)
@@ -554,14 +546,10 @@ TEST(RNTuple, Int16)
    EXPECT_EQ(ROOT::Experimental::EColumnType::kSplitUInt16,
              (*desc->GetColumnIterable(desc->FindFieldId("i4")).begin()).GetModel().GetType());
    reader->LoadEntry(0);
-   EXPECT_EQ(std::numeric_limits<std::int16_t>::max() - 137,
-             *reader->GetModel()->GetDefaultEntry().lock()->GetRaw<std::int16_t>("i1"));
-   EXPECT_EQ(std::numeric_limits<std::int16_t>::max() - 138,
-             *reader->GetModel()->GetDefaultEntry().lock()->GetRaw<std::int16_t>("i2"));
-   EXPECT_EQ(std::numeric_limits<std::uint16_t>::max() - 42,
-             *reader->GetModel()->GetDefaultEntry().lock()->GetRaw<std::uint16_t>("i3"));
-   EXPECT_EQ(std::numeric_limits<std::uint16_t>::max() - 43,
-             *reader->GetModel()->GetDefaultEntry().lock()->GetRaw<std::uint16_t>("i4"));
+   EXPECT_EQ(std::numeric_limits<std::int16_t>::max() - 137, *reader->GetDefaultValueAs<std::int16_t>("i1"));
+   EXPECT_EQ(std::numeric_limits<std::int16_t>::max() - 138, *reader->GetDefaultValueAs<std::int16_t>("i2"));
+   EXPECT_EQ(std::numeric_limits<std::uint16_t>::max() - 42, *reader->GetDefaultValueAs<std::uint16_t>("i3"));
+   EXPECT_EQ(std::numeric_limits<std::uint16_t>::max() - 43, *reader->GetDefaultValueAs<std::uint16_t>("i4"));
 }
 
 TEST(RNTuple, Char)
@@ -592,7 +580,7 @@ TEST(RNTuple, Byte)
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
    EXPECT_EQ(1u, reader->GetNEntries());
    reader->LoadEntry(0);
-   EXPECT_EQ(std::byte{137}, *reader->GetModel()->GetDefaultEntry().lock()->GetRaw<std::byte>("b"));
+   EXPECT_EQ(std::byte{137}, *reader->GetDefaultValueAs<std::byte>("b"));
 }
 
 TEST(RNTuple, Int8_t)
@@ -630,8 +618,8 @@ TEST(RNTuple, Double)
    EXPECT_EQ(ROOT::Experimental::EColumnType::kSplitReal64,
              (*desc->GetColumnIterable(desc->FindFieldId("d2")).begin()).GetModel().GetType());
    reader->LoadEntry(0);
-   EXPECT_DOUBLE_EQ(1.0, *reader->GetModel()->GetDefaultEntry().lock()->GetRaw<double>("d1"));
-   EXPECT_DOUBLE_EQ(2.0, *reader->GetModel()->GetDefaultEntry().lock()->GetRaw<double>("d2"));
+   EXPECT_DOUBLE_EQ(1.0, *reader->GetDefaultValueAs<double>("d1"));
+   EXPECT_DOUBLE_EQ(2.0, *reader->GetDefaultValueAs<double>("d2"));
 }
 
 TEST(RNTuple, Float)
@@ -663,8 +651,8 @@ TEST(RNTuple, Float)
    EXPECT_EQ(ROOT::Experimental::EColumnType::kSplitReal32,
              (*desc->GetColumnIterable(desc->FindFieldId("f2")).begin()).GetModel().GetType());
    reader->LoadEntry(0);
-   EXPECT_FLOAT_EQ(1.0, *reader->GetModel()->GetDefaultEntry().lock()->GetRaw<float>("f1"));
-   EXPECT_FLOAT_EQ(2.0, *reader->GetModel()->GetDefaultEntry().lock()->GetRaw<float>("f2"));
+   EXPECT_FLOAT_EQ(1.0, *reader->GetDefaultValueAs<float>("f1"));
+   EXPECT_FLOAT_EQ(2.0, *reader->GetDefaultValueAs<float>("f2"));
 }
 
 TEST(RNTuple, StdAtomic)
@@ -726,8 +714,8 @@ TEST(RNTuple, Bitset)
 
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
    EXPECT_EQ(std::string("std::bitset<66>"), reader->GetModel()->GetField("f1").GetType());
-   auto bs1 = reader->GetModel()->GetDefaultEntry().lock()->GetRaw<std::bitset<66>>("f1");
-   auto bs2 = reader->GetModel()->GetDefaultEntry().lock()->GetRaw<std::bitset<8>>("f2");
+   auto bs1 = reader->GetDefaultValueAs<std::bitset<66>>("f1");
+   auto bs2 = reader->GetDefaultValueAs<std::bitset<8>>("f2");
    reader->LoadEntry(0);
    EXPECT_EQ("000000000000000000000000000000000000000000000000000000000000000000", bs1->to_string());
    EXPECT_EQ("10101010", bs2->to_string());
@@ -1008,8 +996,8 @@ TEST(RNTuple, Double32)
    EXPECT_EQ("", reader->GetModel()->GetField("d1").GetTypeAlias());
    EXPECT_EQ(EColumnType::kSplitReal32, reader->GetModel()->GetField("d2").GetColumnRepresentative()[0]);
    EXPECT_EQ("Double32_t", reader->GetModel()->GetField("d2").GetTypeAlias());
-   auto d1 = reader->GetModel()->GetDefaultEntry().lock()->GetRaw<double>("d1");
-   auto d2 = reader->GetModel()->GetDefaultEntry().lock()->GetRaw<double>("d2");
+   auto d1 = reader->GetDefaultValueAs<double>("d1");
+   auto d2 = reader->GetDefaultValueAs<double>("d2");
    reader->LoadEntry(0);
    EXPECT_DOUBLE_EQ(0.0, *d1);
    EXPECT_DOUBLE_EQ(*d1, *d2);
@@ -1060,7 +1048,7 @@ TEST(RNTuple, Double32Extended)
    }
 
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
-   auto obj = reader->GetModel()->GetDefaultEntry().lock()->GetRaw<LowPrecisionFloats>("obj");
+   auto obj = reader->GetDefaultValueAs<LowPrecisionFloats>("obj");
    EXPECT_EQ("Double32_t", reader->GetModel()->GetField("obj").GetSubFields()[1]->GetTypeAlias());
    EXPECT_EQ("Double32_t", reader->GetModel()->GetField("obj").GetSubFields()[2]->GetSubFields()[0]->GetTypeAlias());
    EXPECT_DOUBLE_EQ(0.0, obj->a);
@@ -1210,7 +1198,7 @@ TEST(RNTuple, IOConstructor)
 
    auto ntuple = RNTupleReader::Open("f", fileGuard.GetPath());
    EXPECT_EQ(1U, ntuple->GetNEntries());
-   auto obj = ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<IOConstructor>("obj");
+   auto obj = ntuple->GetDefaultValueAs<IOConstructor>("obj");
    EXPECT_EQ(7, obj->a);
 }
 
@@ -1233,7 +1221,7 @@ TEST(RNTuple, TClassTemplateBased)
    auto reader = RNTupleReader::Open("f", fileGuard.GetPath());
 
    EXPECT_EQ("EdmWrapper<CustomStruct>", reader->GetModel()->GetField("klass").GetType());
-   auto object = reader->GetModel()->GetDefaultEntry().lock()->GetRaw<EdmWrapper<CustomStruct>>("klass");
+   auto object = reader->GetDefaultValueAs<EdmWrapper<CustomStruct>>("klass");
    reader->LoadEntry(0);
    EXPECT_TRUE(object->fIsPresent);
    reader->LoadEntry(1);

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -430,7 +430,7 @@ TEST(RNTuple, Int64)
    }
 
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
-   const auto *desc = reader->GetDescriptor();
+   const auto desc = reader->GetDescriptor();
    EXPECT_EQ(ROOT::Experimental::EColumnType::kInt64,
              (*desc->GetColumnIterable(desc->FindFieldId("i1")).begin()).GetModel().GetType());
    EXPECT_EQ(ROOT::Experimental::EColumnType::kSplitInt64,
@@ -486,7 +486,7 @@ TEST(RNTuple, Int32)
    }
 
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
-   const auto *desc = reader->GetDescriptor();
+   const auto desc = reader->GetDescriptor();
    EXPECT_EQ(ROOT::Experimental::EColumnType::kInt32,
              (*desc->GetColumnIterable(desc->FindFieldId("i1")).begin()).GetModel().GetType());
    EXPECT_EQ(ROOT::Experimental::EColumnType::kSplitInt32,
@@ -544,7 +544,7 @@ TEST(RNTuple, Int16)
    }
 
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
-   const auto *desc = reader->GetDescriptor();
+   const auto desc = reader->GetDescriptor();
    EXPECT_EQ(ROOT::Experimental::EColumnType::kInt16,
              (*desc->GetColumnIterable(desc->FindFieldId("i1")).begin()).GetModel().GetType());
    EXPECT_EQ(ROOT::Experimental::EColumnType::kSplitInt16,
@@ -624,7 +624,7 @@ TEST(RNTuple, Double)
    }
 
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
-   const auto *desc = reader->GetDescriptor();
+   const auto desc = reader->GetDescriptor();
    EXPECT_EQ(ROOT::Experimental::EColumnType::kReal64,
              (*desc->GetColumnIterable(desc->FindFieldId("d1")).begin()).GetModel().GetType());
    EXPECT_EQ(ROOT::Experimental::EColumnType::kSplitReal64,
@@ -657,7 +657,7 @@ TEST(RNTuple, Float)
    }
 
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
-   const auto *desc = reader->GetDescriptor();
+   const auto desc = reader->GetDescriptor();
    EXPECT_EQ(ROOT::Experimental::EColumnType::kReal32,
              (*desc->GetColumnIterable(desc->FindFieldId("f1")).begin()).GetModel().GetType());
    EXPECT_EQ(ROOT::Experimental::EColumnType::kSplitReal32,

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -419,7 +419,7 @@ TEST(RNTuple, Int64)
 
    {
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
-      auto e = writer->CreateEntry();
+      auto e = writer->CreateEntry().lock();
       *e->Get<std::int64_t>("i1") = std::numeric_limits<std::int64_t>::max() - 137;
       *e->Get<std::int64_t>("i2") = std::numeric_limits<std::int64_t>::max() - 138;
       *e->Get<std::uint64_t>("i3") = std::numeric_limits<std::uint64_t>::max() - 42;
@@ -475,7 +475,7 @@ TEST(RNTuple, Int32)
 
    {
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
-      auto e = writer->CreateEntry();
+      auto e = writer->CreateEntry().lock();
       *e->Get<std::int32_t>("i1") = std::numeric_limits<std::int32_t>::max() - 137;
       *e->Get<std::int32_t>("i2") = std::numeric_limits<std::int32_t>::max() - 138;
       *e->Get<std::uint32_t>("i3") = std::numeric_limits<std::uint32_t>::max() - 42;
@@ -533,7 +533,7 @@ TEST(RNTuple, Int16)
 
    {
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
-      auto e = writer->CreateEntry();
+      auto e = writer->CreateEntry().lock();
       *e->Get<std::int16_t>("i1") = std::numeric_limits<std::int16_t>::max() - 137;
       *e->Get<std::int16_t>("i2") = std::numeric_limits<std::int16_t>::max() - 138;
       *e->Get<std::uint16_t>("i3") = std::numeric_limits<std::uint16_t>::max() - 42;
@@ -615,7 +615,7 @@ TEST(RNTuple, Double)
 
    {
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
-      auto e = writer->CreateEntry();
+      auto e = writer->CreateEntry().lock();
       *e->Get<double>("d1") = 1.0;
       *e->Get<double>("d2") = 2.0;
       writer->Fill(*e);
@@ -648,7 +648,7 @@ TEST(RNTuple, Float)
 
    {
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
-      auto e = writer->CreateEntry();
+      auto e = writer->CreateEntry().lock();
       *e->Get<float>("f1") = 1.0;
       *e->Get<float>("f2") = 2.0;
       writer->Fill(*e);

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -713,7 +713,7 @@ TEST(RNTuple, Bitset)
    }
 
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
-   EXPECT_EQ(std::string("std::bitset<66>"), reader->GetModel()->GetField("f1").GetType());
+   EXPECT_EQ(std::string("std::bitset<66>"), reader->GetModel().lock()->GetField("f1").GetType());
    auto bs1 = reader->GetDefaultValueAs<std::bitset<66>>("f1");
    auto bs2 = reader->GetDefaultValueAs<std::bitset<8>>("f2");
    reader->LoadEntry(0);
@@ -828,14 +828,14 @@ TYPED_TEST(UniquePtr, Basics)
    }
 
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
-   auto model = reader->GetModel();
+   auto model = reader->GetModel().lock();
    EXPECT_EQ("std::unique_ptr<bool>", model->GetField("PBool").GetType());
    EXPECT_EQ(std::string("std::unique_ptr<CustomStruct>"), model->GetField("PCustomStruct").GetType());
    EXPECT_EQ(std::string("std::unique_ptr<IOConstructor>"), model->GetField("PIOConstructor").GetType());
    EXPECT_EQ(std::string("std::unique_ptr<std::unique_ptr<std::string>>"), model->GetField("PPString").GetType());
    EXPECT_EQ(std::string("std::unique_ptr<std::array<char,2>>"), model->GetField("PArray").GetType());
 
-   auto entry = reader->GetModel()->GetDefaultEntry().lock();
+   auto entry = model->GetDefaultEntry().lock();
    auto pBool = entry->GetRaw<std::unique_ptr<bool>>("PBool");
    auto pCustomStruct = entry->GetRaw<std::unique_ptr<CustomStruct>>("PCustomStruct");
    auto pIOConstructor = entry->GetRaw<std::unique_ptr<IOConstructor>>("PIOConstructor");
@@ -992,10 +992,10 @@ TEST(RNTuple, Double32)
    }
 
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
-   EXPECT_EQ(EColumnType::kReal32, reader->GetModel()->GetField("d1").GetColumnRepresentative()[0]);
-   EXPECT_EQ("", reader->GetModel()->GetField("d1").GetTypeAlias());
-   EXPECT_EQ(EColumnType::kSplitReal32, reader->GetModel()->GetField("d2").GetColumnRepresentative()[0]);
-   EXPECT_EQ("Double32_t", reader->GetModel()->GetField("d2").GetTypeAlias());
+   EXPECT_EQ(EColumnType::kReal32, reader->GetModel().lock()->GetField("d1").GetColumnRepresentative()[0]);
+   EXPECT_EQ("", reader->GetModel().lock()->GetField("d1").GetTypeAlias());
+   EXPECT_EQ(EColumnType::kSplitReal32, reader->GetModel().lock()->GetField("d2").GetColumnRepresentative()[0]);
+   EXPECT_EQ("Double32_t", reader->GetModel().lock()->GetField("d2").GetTypeAlias());
    auto d1 = reader->GetDefaultValueAs<double>("d1");
    auto d2 = reader->GetDefaultValueAs<double>("d2");
    reader->LoadEntry(0);
@@ -1049,8 +1049,9 @@ TEST(RNTuple, Double32Extended)
 
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
    auto obj = reader->GetDefaultValueAs<LowPrecisionFloats>("obj");
-   EXPECT_EQ("Double32_t", reader->GetModel()->GetField("obj").GetSubFields()[1]->GetTypeAlias());
-   EXPECT_EQ("Double32_t", reader->GetModel()->GetField("obj").GetSubFields()[2]->GetSubFields()[0]->GetTypeAlias());
+   EXPECT_EQ("Double32_t", reader->GetModel().lock()->GetField("obj").GetSubFields()[1]->GetTypeAlias());
+   EXPECT_EQ("Double32_t",
+             reader->GetModel().lock()->GetField("obj").GetSubFields()[2]->GetSubFields()[0]->GetTypeAlias());
    EXPECT_DOUBLE_EQ(0.0, obj->a);
    EXPECT_DOUBLE_EQ(1.0, obj->b);
    EXPECT_DOUBLE_EQ(2.0, obj->c[0]);
@@ -1220,7 +1221,7 @@ TEST(RNTuple, TClassTemplateBased)
 
    auto reader = RNTupleReader::Open("f", fileGuard.GetPath());
 
-   EXPECT_EQ("EdmWrapper<CustomStruct>", reader->GetModel()->GetField("klass").GetType());
+   EXPECT_EQ("EdmWrapper<CustomStruct>", reader->GetModel().lock()->GetField("klass").GetType());
    auto object = reader->GetDefaultValueAs<EdmWrapper<CustomStruct>>("klass");
    reader->LoadEntry(0);
    EXPECT_TRUE(object->fIsPresent);

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -418,10 +418,10 @@ TEST(RNTuple, Int64)
    {
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
       auto e = writer->CreateEntry().lock();
-      *e->GetRaw<std::int64_t>("i1") = std::numeric_limits<std::int64_t>::max() - 137;
-      *e->GetRaw<std::int64_t>("i2") = std::numeric_limits<std::int64_t>::max() - 138;
-      *e->GetRaw<std::uint64_t>("i3") = std::numeric_limits<std::uint64_t>::max() - 42;
-      *e->GetRaw<std::uint64_t>("i4") = std::numeric_limits<std::uint64_t>::max() - 43;
+      *e->GetValueAs<std::int64_t>("i1") = std::numeric_limits<std::int64_t>::max() - 137;
+      *e->GetValueAs<std::int64_t>("i2") = std::numeric_limits<std::int64_t>::max() - 138;
+      *e->GetValueAs<std::uint64_t>("i3") = std::numeric_limits<std::uint64_t>::max() - 42;
+      *e->GetValueAs<std::uint64_t>("i4") = std::numeric_limits<std::uint64_t>::max() - 43;
       writer->Fill(*e);
    }
 
@@ -470,10 +470,10 @@ TEST(RNTuple, Int32)
    {
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
       auto e = writer->CreateEntry().lock();
-      *e->GetRaw<std::int32_t>("i1") = std::numeric_limits<std::int32_t>::max() - 137;
-      *e->GetRaw<std::int32_t>("i2") = std::numeric_limits<std::int32_t>::max() - 138;
-      *e->GetRaw<std::uint32_t>("i3") = std::numeric_limits<std::uint32_t>::max() - 42;
-      *e->GetRaw<std::uint32_t>("i4") = std::numeric_limits<std::uint32_t>::max() - 43;
+      *e->GetValueAs<std::int32_t>("i1") = std::numeric_limits<std::int32_t>::max() - 137;
+      *e->GetValueAs<std::int32_t>("i2") = std::numeric_limits<std::int32_t>::max() - 138;
+      *e->GetValueAs<std::uint32_t>("i3") = std::numeric_limits<std::uint32_t>::max() - 42;
+      *e->GetValueAs<std::uint32_t>("i4") = std::numeric_limits<std::uint32_t>::max() - 43;
       writer->Fill(*e);
    }
 
@@ -524,10 +524,10 @@ TEST(RNTuple, Int16)
    {
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
       auto e = writer->CreateEntry().lock();
-      *e->GetRaw<std::int16_t>("i1") = std::numeric_limits<std::int16_t>::max() - 137;
-      *e->GetRaw<std::int16_t>("i2") = std::numeric_limits<std::int16_t>::max() - 138;
-      *e->GetRaw<std::uint16_t>("i3") = std::numeric_limits<std::uint16_t>::max() - 42;
-      *e->GetRaw<std::uint16_t>("i4") = std::numeric_limits<std::uint16_t>::max() - 43;
+      *e->GetValueAs<std::int16_t>("i1") = std::numeric_limits<std::int16_t>::max() - 137;
+      *e->GetValueAs<std::int16_t>("i2") = std::numeric_limits<std::int16_t>::max() - 138;
+      *e->GetValueAs<std::uint16_t>("i3") = std::numeric_limits<std::uint16_t>::max() - 42;
+      *e->GetValueAs<std::uint16_t>("i4") = std::numeric_limits<std::uint16_t>::max() - 43;
       writer->Fill(*e);
    }
 
@@ -602,8 +602,8 @@ TEST(RNTuple, Double)
    {
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
       auto e = writer->CreateEntry().lock();
-      *e->GetRaw<double>("d1") = 1.0;
-      *e->GetRaw<double>("d2") = 2.0;
+      *e->GetValueAs<double>("d1") = 1.0;
+      *e->GetValueAs<double>("d2") = 2.0;
       writer->Fill(*e);
    }
 
@@ -635,8 +635,8 @@ TEST(RNTuple, Float)
    {
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
       auto e = writer->CreateEntry().lock();
-      *e->GetRaw<float>("f1") = 1.0;
-      *e->GetRaw<float>("f2") = 2.0;
+      *e->GetValueAs<float>("f1") = 1.0;
+      *e->GetValueAs<float>("f2") = 2.0;
       writer->Fill(*e);
    }
 
@@ -833,11 +833,11 @@ TYPED_TEST(UniquePtr, Basics)
    EXPECT_EQ(std::string("std::unique_ptr<std::array<char,2>>"), model->GetField("PArray").GetType());
 
    auto entry = model->GetDefaultEntry().lock();
-   auto pBool = entry->GetRaw<std::unique_ptr<bool>>("PBool");
-   auto pCustomStruct = entry->GetRaw<std::unique_ptr<CustomStruct>>("PCustomStruct");
-   auto pIOConstructor = entry->GetRaw<std::unique_ptr<IOConstructor>>("PIOConstructor");
-   auto ppString = entry->GetRaw<std::unique_ptr<std::unique_ptr<std::string>>>("PPString");
-   auto pArray = entry->GetRaw<std::unique_ptr<std::array<char, 2>>>("PArray");
+   auto pBool = entry->GetValueAs<std::unique_ptr<bool>>("PBool");
+   auto pCustomStruct = entry->GetValueAs<std::unique_ptr<CustomStruct>>("PCustomStruct");
+   auto pIOConstructor = entry->GetValueAs<std::unique_ptr<IOConstructor>>("PIOConstructor");
+   auto ppString = entry->GetValueAs<std::unique_ptr<std::unique_ptr<std::string>>>("PPString");
+   auto pArray = entry->GetValueAs<std::unique_ptr<std::array<char, 2>>>("PArray");
 
    reader->LoadEntry(0);
    EXPECT_TRUE(*(pBool->get()));

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -186,8 +186,8 @@ TEST(RNTuple, ArrayField)
       model->AddField(RFieldBase::Create("array2", "unsigned char[4]").Unwrap());
 
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
-      auto array1_field = ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<float[2]>("array1");
-      auto array2_field = ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<unsigned char[4]>("array2");
+      auto array1_field = ntuple->GetDefaultValueAs<float[2]>("array1");
+      auto array2_field = ntuple->GetDefaultValueAs<unsigned char[4]>("array2");
       for (int i = 0; i < 2; i++) {
          new (struct_field.get()) StructWithArrays({{'n', 't', 'p', 'l'}, {1.0, 42.0}});
          new (array1_field) float[2]{0.0f, static_cast<float>(i)};
@@ -239,8 +239,7 @@ TEST(RNTuple, StdPair)
       model->AddField(std::move(myPair2));
 
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "pair_ntuple", fileGuard.GetPath());
-      auto pair_field2 =
-         ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<std::pair<double, std::string>>("myPair2");
+      auto pair_field2 = ntuple->GetDefaultValueAs<std::pair<double, std::string>>("myPair2");
       for (int i = 0; i < 2; i++) {
          *pair_field = {static_cast<double>(i), std::to_string(i)};
          *pair_field2 = {static_cast<double>(i + 1), std::to_string(i + 1)};
@@ -289,11 +288,8 @@ TEST(RNTuple, StdTuple)
       model->AddField(std::move(myTuple3));
 
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "tuple_ntuple", fileGuard.GetPath());
-      auto tuple_field2 =
-         ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<std::tuple<char, float, std::string, char>>("myTuple2");
-      auto tuple_field3 =
-         ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<std::tuple<int32_t, std::tuple<std::string, char>>>(
-            "myTuple3");
+      auto tuple_field2 = ntuple->GetDefaultValueAs<std::tuple<char, float, std::string, char>>("myTuple2");
+      auto tuple_field3 = ntuple->GetDefaultValueAs<std::tuple<int32_t, std::tuple<std::string, char>>>("myTuple3");
       for (int i = 0; i < 2; i++) {
          *tuple_field = {'A' + i, static_cast<float>(i), std::to_string(i), '0' + i};
          *tuple_field2 = {'B' + i, static_cast<float>(i), std::to_string(i), '1' + i};
@@ -355,8 +351,8 @@ TEST(RNTuple, StdSet)
       model->AddField(std::move(mySet4));
 
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "set_ntuple", fileGuard.GetPath());
-      auto set_field3 = ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<std::set<std::string>>("mySet3");
-      auto set_field4 = ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<std::set<std::set<char>>>("mySet4");
+      auto set_field3 = ntuple->GetDefaultValueAs<std::set<std::string>>("mySet3");
+      auto set_field4 = ntuple->GetDefaultValueAs<std::set<std::set<char>>>("mySet4");
       for (int i = 0; i < 2; i++) {
          *set_field = {static_cast<float>(i), 3.14, 0.42};
          *set_field2 = {std::make_pair(i, CustomStruct{6.f, {7.f, 8.f}, {{9.f}, {10.f}}, "foo"}),
@@ -671,7 +667,7 @@ TEST(RNTuple, StdAtomic)
       model->AddField(RFieldBase::Create("f2", "std::atomic<float>").Unwrap());
 
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
-      auto f2 = writer->GetModel()->GetDefaultEntry().lock()->GetRaw<std::atomic<float>>("f2");
+      auto f2 = writer->GetDefaultValueAs<std::atomic<float>>("f2");
       for (int i = 0; i < 2; i++) {
          *f1 = i % 2 == 0;
          *f2 = static_cast<float>(i);
@@ -772,32 +768,33 @@ TYPED_TEST(UniquePtr, Basics)
       EXPECT_EQ(std::string("std::unique_ptr<std::array<char,2>>"), model->GetField("PArray").GetType());
 
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
+      auto modelInWriter = writer->GetModel().lock();
 
       if constexpr (std::is_same_v<typename TestFixture::Tag_t, RTagNullableFieldDefault>) {
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PBool")).IsDense());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PCustomStruct")).IsSparse());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PArray")).IsDense());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(modelInWriter->GetField("PBool")).IsDense());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(modelInWriter->GetField("PCustomStruct")).IsSparse());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(modelInWriter->GetField("PArray")).IsDense());
       }
       if constexpr (std::is_same_v<typename TestFixture::Tag_t, RTagNullableFieldSparse>) {
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PBool")).IsSparse());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PCustomStruct")).IsSparse());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PIOConstructor")).IsSparse());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PPString")).IsSparse());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PArray")).IsSparse());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(modelInWriter->GetField("PBool")).IsSparse());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(modelInWriter->GetField("PCustomStruct")).IsSparse());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(modelInWriter->GetField("PIOConstructor")).IsSparse());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(modelInWriter->GetField("PPString")).IsSparse());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(modelInWriter->GetField("PArray")).IsSparse());
       }
       if constexpr (std::is_same_v<typename TestFixture::Tag_t, RTagNullableFieldDense>) {
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PBool")).IsDense());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PCustomStruct")).IsDense());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PIOConstructor")).IsDense());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PPString")).IsDense());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PArray")).IsDense());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(modelInWriter->GetField("PBool")).IsDense());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(modelInWriter->GetField("PCustomStruct")).IsDense());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(modelInWriter->GetField("PIOConstructor")).IsDense());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(modelInWriter->GetField("PPString")).IsDense());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(modelInWriter->GetField("PArray")).IsDense());
       }
 
-      auto pBool = writer->GetModel()->Get<std::unique_ptr<bool>>("PBool");
-      auto pCustomStruct = writer->GetModel()->Get<std::unique_ptr<CustomStruct>>("PCustomStruct");
-      auto pIOConstructor = writer->GetModel()->Get<std::unique_ptr<IOConstructor>>("PIOConstructor");
-      auto ppString = writer->GetModel()->Get<std::unique_ptr<std::unique_ptr<std::string>>>("PPString");
-      auto pArray = writer->GetModel()->Get<std::unique_ptr<std::array<char, 2>>>("PArray");
+      auto pBool = writer->GetDefaultValueAs<std::unique_ptr<bool>>("PBool");
+      auto pCustomStruct = writer->GetDefaultValueAs<std::unique_ptr<CustomStruct>>("PCustomStruct");
+      auto pIOConstructor = writer->GetDefaultValueAs<std::unique_ptr<IOConstructor>>("PIOConstructor");
+      auto ppString = writer->GetDefaultValueAs<std::unique_ptr<std::unique_ptr<std::string>>>("PPString");
+      auto pArray = writer->GetDefaultValueAs<std::unique_ptr<std::array<char, 2>>>("PArray");
 
       *pBool = std::make_unique<bool>(true);
       EXPECT_EQ(nullptr, pCustomStruct->get());
@@ -918,8 +915,8 @@ TEST(RNTuple, Casting)
    modelA->AddField(std::move(fldF));
    {
       auto writer = RNTupleWriter::Recreate(std::move(modelA), "ntuple", fileGuard.GetPath());
-      *writer->GetModel()->GetDefaultEntry().lock()->GetRaw<std::int32_t>("i1") = 42;
-      *writer->GetModel()->GetDefaultEntry().lock()->GetRaw<std::int32_t>("i2") = 137;
+      *writer->GetDefaultValueAs<std::int32_t>("i1") = 42;
+      *writer->GetDefaultValueAs<std::int32_t>("i2") = 137;
       writer->Fill();
    }
 
@@ -969,8 +966,8 @@ TEST(RNTuple, Double32)
 
    {
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
-      auto d1 = writer->GetModel()->GetDefaultEntry().lock()->GetRaw<double>("d1");
-      auto d2 = writer->GetModel()->GetDefaultEntry().lock()->GetRaw<double>("d2");
+      auto d1 = writer->GetDefaultValueAs<double>("d1");
+      auto d2 = writer->GetDefaultValueAs<double>("d2");
       *d1 = 0.0;
       *d2 = 0.0;
       writer->Fill();
@@ -1318,9 +1315,9 @@ TEST(RNTuple, TVirtualCollectionProxy)
       auto fieldNested = model->MakeField<StructUsingCollectionProxy<StructUsingCollectionProxy<float>>>("nested");
 
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "f", fileGuard.GetPath());
-      auto fieldC = ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<StructUsingCollectionProxy<char>>("C");
-      auto fieldF = ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<StructUsingCollectionProxy<float>>("F");
-      auto fieldS = ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<StructUsingCollectionProxy<CustomStruct>>("S");
+      auto fieldC = ntuple->GetDefaultValueAs<StructUsingCollectionProxy<char>>("C");
+      auto fieldF = ntuple->GetDefaultValueAs<StructUsingCollectionProxy<float>>("F");
+      auto fieldS = ntuple->GetDefaultValueAs<StructUsingCollectionProxy<CustomStruct>>("S");
       for (unsigned i = 0; i < 1000; ++i) {
          if ((i % 100) == 0) {
             fieldC->v.clear();

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -63,7 +63,7 @@ TEST(RNTuple, EnumBasics)
    auto ptrEnum = model->MakeField<CustomEnum>("e");
    model->MakeField<StructWithEnums>("swe");
 
-   EXPECT_EQ(model->GetField("e")->GetType(), f->GetType());
+   EXPECT_EQ(model->GetField("e").GetType(), f->GetType());
 
    FileRaii fileGuard("test_ntuple_enum_basics.root");
    {
@@ -709,8 +709,8 @@ TEST(RNTuple, Bitset)
    auto model = RNTupleModel::Create();
 
    auto f1 = model->MakeField<std::bitset<66>>("f1");
-   EXPECT_EQ(std::string("std::bitset<66>"), model->GetField("f1")->GetType());
-   EXPECT_EQ(sizeof(std::bitset<66>), model->GetField("f1")->GetValueSize());
+   EXPECT_EQ(std::string("std::bitset<66>"), model->GetField("f1").GetType());
+   EXPECT_EQ(sizeof(std::bitset<66>), model->GetField("f1").GetValueSize());
    auto f2 = model->MakeField<std::bitset<8>>("f2", "10101010");
 
    {
@@ -725,7 +725,7 @@ TEST(RNTuple, Bitset)
    }
 
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
-   EXPECT_EQ(std::string("std::bitset<66>"), reader->GetModel()->GetField("f1")->GetType());
+   EXPECT_EQ(std::string("std::bitset<66>"), reader->GetModel()->GetField("f1").GetType());
    auto bs1 = reader->GetModel()->GetDefaultEntry().lock()->GetRaw<std::bitset<66>>("f1");
    auto bs2 = reader->GetModel()->GetDefaultEntry().lock()->GetRaw<std::bitset<8>>("f2");
    reader->LoadEntry(0);
@@ -777,32 +777,32 @@ TYPED_TEST(UniquePtr, Basics)
       AddUniquePtrField<std::unique_ptr<std::string>, typename TestFixture::Tag_t>(*model, "PPString");
       AddUniquePtrField<std::array<char, 2>, typename TestFixture::Tag_t>(*model, "PArray");
 
-      EXPECT_EQ("std::unique_ptr<bool>", model->GetField("PBool")->GetType());
-      EXPECT_EQ(std::string("std::unique_ptr<CustomStruct>"), model->GetField("PCustomStruct")->GetType());
-      EXPECT_EQ(std::string("std::unique_ptr<IOConstructor>"), model->GetField("PIOConstructor")->GetType());
-      EXPECT_EQ(std::string("std::unique_ptr<std::unique_ptr<std::string>>"), model->GetField("PPString")->GetType());
-      EXPECT_EQ(std::string("std::unique_ptr<std::array<char,2>>"), model->GetField("PArray")->GetType());
+      EXPECT_EQ("std::unique_ptr<bool>", model->GetField("PBool").GetType());
+      EXPECT_EQ(std::string("std::unique_ptr<CustomStruct>"), model->GetField("PCustomStruct").GetType());
+      EXPECT_EQ(std::string("std::unique_ptr<IOConstructor>"), model->GetField("PIOConstructor").GetType());
+      EXPECT_EQ(std::string("std::unique_ptr<std::unique_ptr<std::string>>"), model->GetField("PPString").GetType());
+      EXPECT_EQ(std::string("std::unique_ptr<std::array<char,2>>"), model->GetField("PArray").GetType());
 
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
 
       if constexpr (std::is_same_v<typename TestFixture::Tag_t, RTagNullableFieldDefault>) {
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField *>(writer->GetModel()->GetField("PBool"))->IsDense());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField *>(writer->GetModel()->GetField("PCustomStruct"))->IsSparse());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField *>(writer->GetModel()->GetField("PArray"))->IsDense());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PBool")).IsDense());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PCustomStruct")).IsSparse());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PArray")).IsDense());
       }
       if constexpr (std::is_same_v<typename TestFixture::Tag_t, RTagNullableFieldSparse>) {
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField *>(writer->GetModel()->GetField("PBool"))->IsSparse());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField *>(writer->GetModel()->GetField("PCustomStruct"))->IsSparse());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField *>(writer->GetModel()->GetField("PIOConstructor"))->IsSparse());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField *>(writer->GetModel()->GetField("PPString"))->IsSparse());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField *>(writer->GetModel()->GetField("PArray"))->IsSparse());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PBool")).IsSparse());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PCustomStruct")).IsSparse());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PIOConstructor")).IsSparse());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PPString")).IsSparse());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PArray")).IsSparse());
       }
       if constexpr (std::is_same_v<typename TestFixture::Tag_t, RTagNullableFieldDense>) {
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField *>(writer->GetModel()->GetField("PBool"))->IsDense());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField *>(writer->GetModel()->GetField("PCustomStruct"))->IsDense());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField *>(writer->GetModel()->GetField("PIOConstructor"))->IsDense());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField *>(writer->GetModel()->GetField("PPString"))->IsDense());
-         EXPECT_TRUE(dynamic_cast<const RUniquePtrField *>(writer->GetModel()->GetField("PArray"))->IsDense());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PBool")).IsDense());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PCustomStruct")).IsDense());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PIOConstructor")).IsDense());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PPString")).IsDense());
+         EXPECT_TRUE(dynamic_cast<const RUniquePtrField &>(writer->GetModel()->GetField("PArray")).IsDense());
       }
 
       auto pBool = writer->GetModel()->Get<std::unique_ptr<bool>>("PBool");
@@ -841,11 +841,11 @@ TYPED_TEST(UniquePtr, Basics)
 
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
    auto model = reader->GetModel();
-   EXPECT_EQ("std::unique_ptr<bool>", model->GetField("PBool")->GetType());
-   EXPECT_EQ(std::string("std::unique_ptr<CustomStruct>"), model->GetField("PCustomStruct")->GetType());
-   EXPECT_EQ(std::string("std::unique_ptr<IOConstructor>"), model->GetField("PIOConstructor")->GetType());
-   EXPECT_EQ(std::string("std::unique_ptr<std::unique_ptr<std::string>>"), model->GetField("PPString")->GetType());
-   EXPECT_EQ(std::string("std::unique_ptr<std::array<char,2>>"), model->GetField("PArray")->GetType());
+   EXPECT_EQ("std::unique_ptr<bool>", model->GetField("PBool").GetType());
+   EXPECT_EQ(std::string("std::unique_ptr<CustomStruct>"), model->GetField("PCustomStruct").GetType());
+   EXPECT_EQ(std::string("std::unique_ptr<IOConstructor>"), model->GetField("PIOConstructor").GetType());
+   EXPECT_EQ(std::string("std::unique_ptr<std::unique_ptr<std::string>>"), model->GetField("PPString").GetType());
+   EXPECT_EQ(std::string("std::unique_ptr<std::array<char,2>>"), model->GetField("PArray").GetType());
 
    auto entry = reader->GetModel()->GetDefaultEntry().lock();
    auto pBool = entry->GetRaw<std::unique_ptr<bool>>("PBool");
@@ -1004,10 +1004,10 @@ TEST(RNTuple, Double32)
    }
 
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
-   EXPECT_EQ(EColumnType::kReal32, reader->GetModel()->GetField("d1")->GetColumnRepresentative()[0]);
-   EXPECT_EQ("", reader->GetModel()->GetField("d1")->GetTypeAlias());
-   EXPECT_EQ(EColumnType::kSplitReal32, reader->GetModel()->GetField("d2")->GetColumnRepresentative()[0]);
-   EXPECT_EQ("Double32_t", reader->GetModel()->GetField("d2")->GetTypeAlias());
+   EXPECT_EQ(EColumnType::kReal32, reader->GetModel()->GetField("d1").GetColumnRepresentative()[0]);
+   EXPECT_EQ("", reader->GetModel()->GetField("d1").GetTypeAlias());
+   EXPECT_EQ(EColumnType::kSplitReal32, reader->GetModel()->GetField("d2").GetColumnRepresentative()[0]);
+   EXPECT_EQ("Double32_t", reader->GetModel()->GetField("d2").GetTypeAlias());
    auto d1 = reader->GetModel()->GetDefaultEntry().lock()->GetRaw<double>("d1");
    auto d2 = reader->GetModel()->GetDefaultEntry().lock()->GetRaw<double>("d2");
    reader->LoadEntry(0);
@@ -1061,8 +1061,8 @@ TEST(RNTuple, Double32Extended)
 
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
    auto obj = reader->GetModel()->GetDefaultEntry().lock()->GetRaw<LowPrecisionFloats>("obj");
-   EXPECT_EQ("Double32_t", reader->GetModel()->GetField("obj")->GetSubFields()[1]->GetTypeAlias());
-   EXPECT_EQ("Double32_t", reader->GetModel()->GetField("obj")->GetSubFields()[2]->GetSubFields()[0]->GetTypeAlias());
+   EXPECT_EQ("Double32_t", reader->GetModel()->GetField("obj").GetSubFields()[1]->GetTypeAlias());
+   EXPECT_EQ("Double32_t", reader->GetModel()->GetField("obj").GetSubFields()[2]->GetSubFields()[0]->GetTypeAlias());
    EXPECT_DOUBLE_EQ(0.0, obj->a);
    EXPECT_DOUBLE_EQ(1.0, obj->b);
    EXPECT_DOUBLE_EQ(2.0, obj->c[0]);
@@ -1232,8 +1232,7 @@ TEST(RNTuple, TClassTemplateBased)
 
    auto reader = RNTupleReader::Open("f", fileGuard.GetPath());
 
-   auto fieldObject = reader->GetModel()->GetField("klass");
-   EXPECT_EQ("EdmWrapper<CustomStruct>", fieldObject->GetType());
+   EXPECT_EQ("EdmWrapper<CustomStruct>", reader->GetModel()->GetField("klass").GetType());
    auto object = reader->GetModel()->GetDefaultEntry().lock()->GetRaw<EdmWrapper<CustomStruct>>("klass");
    reader->LoadEntry(0);
    EXPECT_TRUE(object->fIsPresent);

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -29,6 +29,28 @@ TEST(RNTuple, TypeName) {
       (ROOT::Experimental::RField<std::tuple<std::tuple<char, CustomStruct, char>, int>>::TypeName().c_str()));
 }
 
+TEST(RNTuple, FieldCompare)
+{
+   auto f1 = RFieldBase::Create("f", "int").Unwrap();
+   auto f2 = RFieldBase::Create("f", "int").Unwrap();
+   EXPECT_EQ(0, f1->Compare(*f2));
+
+   auto f3 = RFieldBase::Create("g", "int").Unwrap();
+   EXPECT_EQ(-1, f1->Compare(*f3));
+   auto f4 = RFieldBase::Create("f", "float").Unwrap();
+   EXPECT_EQ(-1, f1->Compare(*f4));
+
+   auto f5 = RFieldBase::Create("f", "CustomStruct").Unwrap();
+   auto f6 = RFieldBase::Create("f", "CustomStruct").Unwrap();
+   EXPECT_EQ(0, f5->Compare(*f6));
+
+   auto f7 = RFieldBase::Create("f", "std::vector<int>").Unwrap();
+   auto f8 = RFieldBase::Create("f", "std::vector<int>").Unwrap();
+   EXPECT_EQ(0, f7->Compare(*f8));
+   auto f9 = RFieldBase::Create("f", "std::vector<float>").Unwrap();
+   EXPECT_EQ(-1, f7->Compare(*f9));
+}
+
 TEST(RNTuple, EnumBasics)
 {
    // Needs fix of TEnum

--- a/tree/ntuple/v7/test/rfield_blob.cxx
+++ b/tree/ntuple/v7/test/rfield_blob.cxx
@@ -23,7 +23,7 @@ TEST(RField, Blob)
    auto reader = RNTupleReader::Open("f", fileGuard.GetPath());
    ASSERT_EQ(1U, reader->GetNEntries());
    reader->LoadEntry(0);
-   auto fldBlob = reader->GetModel()->GetDefaultEntry()->Get<std::vector<std::byte>>("blob");
+   auto fldBlob = reader->GetModel()->GetDefaultEntry().lock()->Get<std::vector<std::byte>>("blob");
    TMemFile f("buffer", TMemFile::ZeroCopyView_t(reinterpret_cast<char *>(fldBlob->data()), fldBlob->size()));
    auto str = f.Get<std::string>("string");
    EXPECT_EQ("x", *str);

--- a/tree/ntuple/v7/test/rfield_blob.cxx
+++ b/tree/ntuple/v7/test/rfield_blob.cxx
@@ -23,7 +23,7 @@ TEST(RField, Blob)
    auto reader = RNTupleReader::Open("f", fileGuard.GetPath());
    ASSERT_EQ(1U, reader->GetNEntries());
    reader->LoadEntry(0);
-   auto fldBlob = reader->GetModel()->GetDefaultEntry().lock()->GetRaw<std::vector<std::byte>>("blob");
+   auto fldBlob = reader->GetDefaultValueAs<std::vector<std::byte>>("blob");
    TMemFile f("buffer", TMemFile::ZeroCopyView_t(reinterpret_cast<char *>(fldBlob->data()), fldBlob->size()));
    auto str = f.Get<std::string>("string");
    EXPECT_EQ("x", *str);

--- a/tree/ntuple/v7/test/rfield_blob.cxx
+++ b/tree/ntuple/v7/test/rfield_blob.cxx
@@ -23,7 +23,7 @@ TEST(RField, Blob)
    auto reader = RNTupleReader::Open("f", fileGuard.GetPath());
    ASSERT_EQ(1U, reader->GetNEntries());
    reader->LoadEntry(0);
-   auto fldBlob = reader->GetModel()->GetDefaultEntry().lock()->Get<std::vector<std::byte>>("blob");
+   auto fldBlob = reader->GetModel()->GetDefaultEntry().lock()->GetRaw<std::vector<std::byte>>("blob");
    TMemFile f("buffer", TMemFile::ZeroCopyView_t(reinterpret_cast<char *>(fldBlob->data()), fldBlob->size()));
    auto str = f.Get<std::string>("string");
    EXPECT_EQ("x", *str);

--- a/tree/ntuple/v7/test/rfield_variant.cxx
+++ b/tree/ntuple/v7/test/rfield_variant.cxx
@@ -8,8 +8,6 @@ TEST(RNTuple, Variant)
    auto wrVariant = modelWrite->MakeField<std::variant<double, int>>("variant");
    *wrVariant = 2.0;
 
-   auto modelRead = std::unique_ptr<RNTupleModel>(modelWrite->Clone());
-
    {
       RNTupleWriter ntuple(std::move(modelWrite),
          std::make_unique<RPageSinkFile>("myNTuple", fileGuard.GetPath(), RNTupleWriteOptions()));
@@ -20,16 +18,15 @@ TEST(RNTuple, Variant)
       *wrVariant = 8.0;
       ntuple.Fill();
    }
-   auto rdVariant = modelRead->Get<std::variant<double, int>>("variant");
 
-   RNTupleReader ntuple(std::move(modelRead),
-      std::make_unique<RPageSourceFile>("myNTuple", fileGuard.GetPath(), RNTupleReadOptions()));
-   EXPECT_EQ(3U, ntuple.GetNEntries());
+   auto reader = RNTupleReader::Open("myNTuple", fileGuard.GetPath());
+   auto rdVariant = reader->GetDefaultValueAs<std::variant<double, int>>("variant");
+   EXPECT_EQ(3U, reader->GetNEntries());
 
-   ntuple.LoadEntry(0);
+   reader->LoadEntry(0);
    EXPECT_EQ(2.0, *std::get_if<double>(rdVariant));
-   ntuple.LoadEntry(1);
+   reader->LoadEntry(1);
    EXPECT_EQ(4, *std::get_if<int>(rdVariant));
-   ntuple.LoadEntry(2);
+   reader->LoadEntry(2);
    EXPECT_EQ(8.0, *std::get_if<double>(rdVariant));
 }

--- a/tree/ntuple/v7/test/rfield_vector.cxx
+++ b/tree/ntuple/v7/test/rfield_vector.cxx
@@ -221,7 +221,7 @@ TEST(RNTuple, RVecTypeErased)
 
       auto w = RNTupleWriter::Recreate(std::move(m), "r", fileGuard.GetPath());
       auto e = w->CreateBareEntry().lock();
-      e->CaptureValueUnsafe("v", (void *)&rvec);
+      e->BindValue("v", (void *)&rvec);
 
       w->Fill(*e);
       rvec.clear();

--- a/tree/ntuple/v7/test/rfield_vector.cxx
+++ b/tree/ntuple/v7/test/rfield_vector.cxx
@@ -215,19 +215,20 @@ TEST(RNTuple, RVecTypeErased)
    {
       ROOT::RVecI rvec = {1, 2, 3};
 
-      auto m = RNTupleModel::Create();
+      auto m = RNTupleModel::CreateBare();
       auto field = RFieldBase::Create("v", "ROOT::VecOps::RVec<int>").Unwrap();
       m->AddField(std::move(field));
-      m->Freeze();
-      m->GetDefaultEntry()->CaptureValueUnsafe("v", (void *)&rvec);
 
       auto w = RNTupleWriter::Recreate(std::move(m), "r", fileGuard.GetPath());
-      w->Fill();
+      auto e = w->CreateBareEntry().lock();
+      e->CaptureValueUnsafe("v", (void *)&rvec);
+
+      w->Fill(*e);
       rvec.clear();
       rvec.push_back(42);
-      w->Fill();
+      w->Fill(*e);
       rvec.clear();
-      w->Fill();
+      w->Fill(*e);
    }
 
    // read back RVec with type-erased API
@@ -359,7 +360,7 @@ TEST(RNTuple, ComplexVector)
    ComplexStruct::SetNCallDestructor(0);
    {
       auto ntuple = RNTupleReader::Open("T", fileGuard.GetPath());
-      auto rdV = ntuple->GetModel()->GetDefaultEntry()->Get<std::vector<ComplexStruct>>("v");
+      auto rdV = ntuple->GetModel()->GetDefaultEntry().lock()->Get<std::vector<ComplexStruct>>("v");
 
       ntuple->LoadEntry(0);
       EXPECT_EQ(0, ComplexStruct::GetNCallConstructor());
@@ -402,7 +403,7 @@ TEST(RNTuple, ComplexRVec)
    ComplexStruct::SetNCallDestructor(0);
    {
       auto ntuple = RNTupleReader::Open("T", fileGuard.GetPath());
-      auto rdV = ntuple->GetModel()->GetDefaultEntry()->Get<ROOT::RVec<ComplexStruct>>("v");
+      auto rdV = ntuple->GetModel()->GetDefaultEntry().lock()->Get<ROOT::RVec<ComplexStruct>>("v");
 
       ntuple->LoadEntry(0);
       EXPECT_EQ(0, ComplexStruct::GetNCallConstructor());

--- a/tree/ntuple/v7/test/rfield_vector.cxx
+++ b/tree/ntuple/v7/test/rfield_vector.cxx
@@ -233,7 +233,7 @@ TEST(RNTuple, RVecTypeErased)
 
    // read back RVec with type-erased API
    auto r = RNTupleReader::Open("r", fileGuard.GetPath());
-   auto v = r->GetModel()->Get<ROOT::RVec<int>>("v");
+   auto v = r->GetDefaultValueAs<ROOT::RVec<int>>("v");
 
    r->LoadEntry(0);
    EXPECT_EQ(v->size(), 3);

--- a/tree/ntuple/v7/test/rfield_vector.cxx
+++ b/tree/ntuple/v7/test/rfield_vector.cxx
@@ -140,17 +140,17 @@ TEST(RNTuple, InsideCollection)
 
    auto value = field->GenerateValue();
    value.Read(0);
-   auto aVec = value.Get<std::vector<float>>();
+   auto aVec = value.GetAs<std::vector<float>>();
    EXPECT_EQ(1U, aVec->size());
    EXPECT_EQ(42.0, (*aVec)[0]);
 
    auto valueCardinality64 = fieldCardinality64->GenerateValue();
    valueCardinality64.Read(0);
-   EXPECT_EQ(1U, *valueCardinality64.Get<std::uint64_t>());
+   EXPECT_EQ(1U, *valueCardinality64.GetAs<std::uint64_t>());
 
    auto valueCardinality32 = fieldCardinality32->GenerateValue();
    valueCardinality32.Read(0);
-   EXPECT_EQ(1U, *valueCardinality32.Get<std::uint32_t>());
+   EXPECT_EQ(1U, *valueCardinality32.GetAs<std::uint32_t>());
 
    // TODO: test reading of "klassVec.v1"
 }

--- a/tree/ntuple/v7/test/rfield_vector.cxx
+++ b/tree/ntuple/v7/test/rfield_vector.cxx
@@ -221,7 +221,7 @@ TEST(RNTuple, RVecTypeErased)
 
       auto w = RNTupleWriter::Recreate(std::move(m), "r", fileGuard.GetPath());
       auto e = w->CreateBareEntry().lock();
-      e->BindValue("v", (void *)&rvec);
+      e->BindRaw("v", (void *)&rvec);
 
       w->Fill(*e);
       rvec.clear();

--- a/tree/ntuple/v7/test/rfield_vector.cxx
+++ b/tree/ntuple/v7/test/rfield_vector.cxx
@@ -292,20 +292,17 @@ TEST(RNTuple, BoolVector)
    wrBoolRVec->push_back(true);
    wrBoolRVec->push_back(false);
 
-   auto modelRead = modelWrite->Clone();
-
    {
       RNTupleWriter ntuple(std::move(modelWrite),
          std::make_unique<RPageSinkFile>("myNTuple", fileGuard.GetPath(), RNTupleWriteOptions()));
       ntuple.Fill();
    }
 
-   auto rdBoolStdVec = modelRead->Get<std::vector<bool>>("boolStdVec");
-   auto rdBoolRVec = modelRead->Get<ROOT::RVec<bool>>("boolRVec");
-   RNTupleReader ntuple(std::move(modelRead),
-      std::make_unique<RPageSourceFile>("myNTuple", fileGuard.GetPath(), RNTupleReadOptions()));
-   EXPECT_EQ(1U, ntuple.GetNEntries());
-   ntuple.LoadEntry(0);
+   auto reader = RNTupleReader::Open("myNTuple", fileGuard.GetPath());
+   EXPECT_EQ(1U, reader->GetNEntries());
+   auto rdBoolStdVec = reader->GetDefaultValueAs<std::vector<bool>>("boolStdVec");
+   auto rdBoolRVec = reader->GetDefaultValueAs<ROOT::RVec<bool>>("boolRVec");
+   reader->LoadEntry(0);
 
    EXPECT_EQ(4U, rdBoolStdVec->size());
    EXPECT_TRUE((*rdBoolStdVec)[0]);

--- a/tree/ntuple/v7/test/rfield_vector.cxx
+++ b/tree/ntuple/v7/test/rfield_vector.cxx
@@ -360,7 +360,7 @@ TEST(RNTuple, ComplexVector)
    ComplexStruct::SetNCallDestructor(0);
    {
       auto ntuple = RNTupleReader::Open("T", fileGuard.GetPath());
-      auto rdV = ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<std::vector<ComplexStruct>>("v");
+      auto rdV = ntuple->GetDefaultValueAs<std::vector<ComplexStruct>>("v");
 
       ntuple->LoadEntry(0);
       EXPECT_EQ(0, ComplexStruct::GetNCallConstructor());
@@ -403,7 +403,7 @@ TEST(RNTuple, ComplexRVec)
    ComplexStruct::SetNCallDestructor(0);
    {
       auto ntuple = RNTupleReader::Open("T", fileGuard.GetPath());
-      auto rdV = ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<ROOT::RVec<ComplexStruct>>("v");
+      auto rdV = ntuple->GetDefaultValueAs<ROOT::RVec<ComplexStruct>>("v");
 
       ntuple->LoadEntry(0);
       EXPECT_EQ(0, ComplexStruct::GetNCallConstructor());

--- a/tree/ntuple/v7/test/rfield_vector.cxx
+++ b/tree/ntuple/v7/test/rfield_vector.cxx
@@ -360,7 +360,7 @@ TEST(RNTuple, ComplexVector)
    ComplexStruct::SetNCallDestructor(0);
    {
       auto ntuple = RNTupleReader::Open("T", fileGuard.GetPath());
-      auto rdV = ntuple->GetModel()->GetDefaultEntry().lock()->Get<std::vector<ComplexStruct>>("v");
+      auto rdV = ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<std::vector<ComplexStruct>>("v");
 
       ntuple->LoadEntry(0);
       EXPECT_EQ(0, ComplexStruct::GetNCallConstructor());
@@ -403,7 +403,7 @@ TEST(RNTuple, ComplexRVec)
    ComplexStruct::SetNCallDestructor(0);
    {
       auto ntuple = RNTupleReader::Open("T", fileGuard.GetPath());
-      auto rdV = ntuple->GetModel()->GetDefaultEntry().lock()->Get<ROOT::RVec<ComplexStruct>>("v");
+      auto rdV = ntuple->GetModel()->GetDefaultEntry().lock()->GetRaw<ROOT::RVec<ComplexStruct>>("v");
 
       ntuple->LoadEntry(0);
       EXPECT_EQ(0, ComplexStruct::GetNCallConstructor());

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -176,7 +176,7 @@ private:
       RImportLeafCountCollection &operator=(RImportLeafCountCollection &&other) = default;
       std::unique_ptr<RNTupleModel> fCollectionModel;             ///< The model for the collection itself
       std::shared_ptr<RCollectionNTupleWriter> fCollectionWriter; ///< Used to fill the collection elements per event
-      std::unique_ptr<REntry> fCollectionEntry; ///< Keeps the memory location of the collection members
+      std::shared_ptr<REntry> fCollectionEntry; ///< Keeps the memory location of the collection members
       /// The number of elements for the collection for a particular event. Used as a destination for SetBranchAddress()
       /// of the count leaf
       std::unique_ptr<Int_t> fCountVal;
@@ -228,7 +228,7 @@ private:
    std::unique_ptr<RProgressCallback> fProgressCallback;
 
    std::unique_ptr<RNTupleModel> fModel;
-   std::unique_ptr<REntry> fEntry;
+   std::shared_ptr<REntry> fEntry;
    std::vector<RImportBranch> fImportBranches;
    std::vector<RImportField> fImportFields;
    /// Maps the count leaf to the information about the corresponding untyped collection

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -322,7 +322,7 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSc
       auto &countLeafName = p.first;
       auto &c = p.second;
       c.fCollectionModel->Freeze();
-      c.fCollectionEntry = c.fCollectionModel->CreateBareEntry();
+      c.fCollectionEntry = c.fCollectionModel->CreateBareEntry().lock();
       for (auto idx : c.fImportFieldIndexes) {
          const auto name = fImportFields[idx].fField->GetName();
          const auto buffer = fImportFields[idx].fFieldBuffer;
@@ -350,7 +350,7 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSc
    }
 
    fModel->Freeze();
-   fEntry = fModel->CreateBareEntry();
+   fEntry = fModel->CreateBareEntry().lock();
    for (const auto &f : fImportFields) {
       if (f.fIsInUntypedCollection)
          continue;

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -250,7 +250,7 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSc
          if (isCString) {
             branchBufferSize = l->GetMaximum();
             f.fValue = std::make_unique<Detail::RFieldBase::RValue>(field->GenerateValue());
-            f.fFieldBuffer = f.fValue->GetRawPtr();
+            f.fFieldBuffer = f.fValue->Get<void>();
             fImportTransformations.emplace_back(
                std::make_unique<RCStringTransformation>(fImportBranches.size(), fImportFields.size()));
          } else {
@@ -270,7 +270,7 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSc
             recordItems.emplace_back(std::move(field));
          } else if (isLeafCountArray) {
             f.fValue = std::make_unique<Detail::RFieldBase::RValue>(field->GenerateValue());
-            f.fFieldBuffer = f.fValue->GetRawPtr();
+            f.fFieldBuffer = f.fValue->Get<void>();
             f.fIsInUntypedCollection = true;
             const std::string countleafName = countleaf->GetName();
             fLeafCountCollections[countleafName].fCollectionModel->AddField(std::move(field));

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -326,7 +326,7 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSc
       for (auto idx : c.fImportFieldIndexes) {
          const auto name = fImportFields[idx].fField->GetName();
          const auto buffer = fImportFields[idx].fFieldBuffer;
-         c.fCollectionEntry->BindValue(name, buffer);
+         c.fCollectionEntry->BindRaw(name, buffer);
       }
       c.fFieldName = "_collection" + std::to_string(iLeafCountCollection);
       c.fCollectionWriter = fModel->MakeCollection(c.fFieldName, std::move(c.fCollectionModel));
@@ -354,10 +354,10 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSc
    for (const auto &f : fImportFields) {
       if (f.fIsInUntypedCollection)
          continue;
-      fEntry->BindValue(f.fField->GetName(), f.fFieldBuffer);
+      fEntry->BindRaw(f.fField->GetName(), f.fFieldBuffer);
    }
    for (const auto &[_, c] : fLeafCountCollections) {
-      fEntry->BindValue(c.fFieldName, c.fCollectionWriter->GetOffsetPtr());
+      fEntry->BindRaw(c.fFieldName, c.fCollectionWriter->GetOffsetPtr());
    }
 
    if (!fIsQuiet)

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -250,7 +250,7 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSc
          if (isCString) {
             branchBufferSize = l->GetMaximum();
             f.fValue = std::make_unique<Detail::RFieldBase::RValue>(field->GenerateValue());
-            f.fFieldBuffer = f.fValue->Get<void>();
+            f.fFieldBuffer = f.fValue->GetAs<void>();
             fImportTransformations.emplace_back(
                std::make_unique<RCStringTransformation>(fImportBranches.size(), fImportFields.size()));
          } else {
@@ -270,7 +270,7 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSc
             recordItems.emplace_back(std::move(field));
          } else if (isLeafCountArray) {
             f.fValue = std::make_unique<Detail::RFieldBase::RValue>(field->GenerateValue());
-            f.fFieldBuffer = f.fValue->Get<void>();
+            f.fFieldBuffer = f.fValue->GetAs<void>();
             f.fIsInUntypedCollection = true;
             const std::string countleafName = countleaf->GetName();
             fLeafCountCollections[countleafName].fCollectionModel->AddField(std::move(field));

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -326,7 +326,7 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSc
       for (auto idx : c.fImportFieldIndexes) {
          const auto name = fImportFields[idx].fField->GetName();
          const auto buffer = fImportFields[idx].fFieldBuffer;
-         c.fCollectionEntry->CaptureValueUnsafe(name, buffer);
+         c.fCollectionEntry->BindValue(name, buffer);
       }
       c.fFieldName = "_collection" + std::to_string(iLeafCountCollection);
       c.fCollectionWriter = fModel->MakeCollection(c.fFieldName, std::move(c.fCollectionModel));
@@ -354,10 +354,10 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSc
    for (const auto &f : fImportFields) {
       if (f.fIsInUntypedCollection)
          continue;
-      fEntry->CaptureValueUnsafe(f.fField->GetName(), f.fFieldBuffer);
+      fEntry->BindValue(f.fField->GetName(), f.fFieldBuffer);
    }
    for (const auto &[_, c] : fLeafCountCollections) {
-      fEntry->CaptureValueUnsafe(c.fFieldName, c.fCollectionWriter->GetOffsetPtr());
+      fEntry->BindValue(c.fFieldName, c.fCollectionWriter->GetOffsetPtr());
    }
 
    if (!fIsQuiet)

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -399,7 +399,7 @@ void ROOT::Experimental::RNTupleImporter::Import()
                if (!result)
                   throw RException(R__FORWARD_ERROR(result));
             }
-            c.fCollectionWriter->Fill(c.fCollectionEntry.get());
+            c.fCollectionWriter->Fill(*c.fCollectionEntry);
          }
          for (auto &t : c.fTransformations)
             t->ResetEntry();

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -159,17 +159,17 @@ TEST(RNTupleImporter, Simple)
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
    EXPECT_EQ(1U, reader->GetNEntries());
    reader->LoadEntry(0);
-   EXPECT_TRUE(*reader->GetModel()->Get<bool>("myBool"));
-   EXPECT_EQ(-8, *reader->GetModel()->Get<char>("myInt8"));
-   EXPECT_EQ(8U, *reader->GetModel()->Get<std::uint8_t>("myUInt8"));
-   EXPECT_EQ(-16, *reader->GetModel()->Get<std::int16_t>("myInt16"));
-   EXPECT_EQ(16U, *reader->GetModel()->Get<std::uint16_t>("myUInt16"));
-   EXPECT_EQ(-32, *reader->GetModel()->Get<std::int32_t>("myInt32"));
-   EXPECT_EQ(32U, *reader->GetModel()->Get<std::uint32_t>("myUInt32"));
-   EXPECT_EQ(-64, *reader->GetModel()->Get<std::int64_t>("myInt64"));
-   EXPECT_EQ(64U, *reader->GetModel()->Get<std::uint64_t>("myUInt64"));
-   EXPECT_FLOAT_EQ(32.0, *reader->GetModel()->Get<float>("myFloat"));
-   EXPECT_FLOAT_EQ(64.0, *reader->GetModel()->Get<double>("myDouble"));
+   EXPECT_TRUE(*reader->GetDefaultValueAs<bool>("myBool"));
+   EXPECT_EQ(-8, *reader->GetDefaultValueAs<char>("myInt8"));
+   EXPECT_EQ(8U, *reader->GetDefaultValueAs<std::uint8_t>("myUInt8"));
+   EXPECT_EQ(-16, *reader->GetDefaultValueAs<std::int16_t>("myInt16"));
+   EXPECT_EQ(16U, *reader->GetDefaultValueAs<std::uint16_t>("myUInt16"));
+   EXPECT_EQ(-32, *reader->GetDefaultValueAs<std::int32_t>("myInt32"));
+   EXPECT_EQ(32U, *reader->GetDefaultValueAs<std::uint32_t>("myUInt32"));
+   EXPECT_EQ(-64, *reader->GetDefaultValueAs<std::int64_t>("myInt64"));
+   EXPECT_EQ(64U, *reader->GetDefaultValueAs<std::uint64_t>("myUInt64"));
+   EXPECT_FLOAT_EQ(32.0, *reader->GetDefaultValueAs<float>("myFloat"));
+   EXPECT_FLOAT_EQ(64.0, *reader->GetDefaultValueAs<double>("myDouble"));
 }
 
 TEST(RNTupleImporter, FieldName)
@@ -192,7 +192,7 @@ TEST(RNTupleImporter, FieldName)
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
    EXPECT_EQ(1U, reader->GetNEntries());
    reader->LoadEntry(0);
-   EXPECT_EQ(42, *reader->GetModel()->Get<std::int32_t>("a"));
+   EXPECT_EQ(42, *reader->GetDefaultValueAs<std::int32_t>("a"));
 }
 
 TEST(RNTupleImporter, ConvertDotsInBranchNames)
@@ -217,7 +217,7 @@ TEST(RNTupleImporter, ConvertDotsInBranchNames)
    importer->Import();
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
    reader->LoadEntry(0);
-   EXPECT_EQ(42, *reader->GetModel()->Get<std::int32_t>("a_a"));
+   EXPECT_EQ(42, *reader->GetDefaultValueAs<std::int32_t>("a_a"));
 }
 
 TEST(RNTupleImporter, CString)
@@ -245,11 +245,11 @@ TEST(RNTupleImporter, CString)
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
    EXPECT_EQ(3U, reader->GetNEntries());
    reader->LoadEntry(0);
-   EXPECT_EQ(std::string("R"), *reader->GetModel()->Get<std::string>("myString"));
+   EXPECT_EQ(std::string("R"), *reader->GetDefaultValueAs<std::string>("myString"));
    reader->LoadEntry(1);
-   EXPECT_EQ(std::string(""), *reader->GetModel()->Get<std::string>("myString"));
+   EXPECT_EQ(std::string(""), *reader->GetDefaultValueAs<std::string>("myString"));
    reader->LoadEntry(2);
-   EXPECT_EQ(std::string("ROOT RNTuple"), *reader->GetModel()->Get<std::string>("myString"));
+   EXPECT_EQ(std::string("ROOT RNTuple"), *reader->GetDefaultValueAs<std::string>("myString"));
 }
 
 TEST(RNTupleImporter, Leaflist)
@@ -469,14 +469,14 @@ TEST(RNTupleImporter, STL)
    EXPECT_EQ(1U, reader->GetNEntries());
    reader->LoadEntry(0);
 
-   auto vec = reader->GetModel()->Get<std::vector<float>>("vec");
+   auto vec = reader->GetDefaultValueAs<std::vector<float>>("vec");
    EXPECT_EQ(2U, vec->size());
    EXPECT_FLOAT_EQ(1.0, vec->at(0));
    EXPECT_FLOAT_EQ(2.0, vec->at(1));
-   auto pair = reader->GetModel()->Get<std::pair<float, float>>("pair");
+   auto pair = reader->GetDefaultValueAs<std::pair<float, float>>("pair");
    EXPECT_FLOAT_EQ(3.0, pair->first);
    EXPECT_FLOAT_EQ(4.0, pair->second);
-   auto tuple = reader->GetModel()->Get<std::tuple<int, float, bool>>("tuple");
+   auto tuple = reader->GetDefaultValueAs<std::tuple<int, float, bool>>("tuple");
    EXPECT_EQ(5, std::get<0>(*tuple));
    EXPECT_FLOAT_EQ(6.0, std::get<1>(*tuple));
    EXPECT_TRUE(std::get<2>(*tuple));
@@ -510,7 +510,7 @@ TEST(RNTupleImporter, CustomClass)
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
    EXPECT_EQ(1U, reader->GetNEntries());
    reader->LoadEntry(0);
-   auto object = reader->GetModel()->Get<CustomStructUtil>("object");
+   auto object = reader->GetDefaultValueAs<CustomStructUtil>("object");
    EXPECT_EQ(13, object->base);
    EXPECT_FLOAT_EQ(1.0, object->a);
    EXPECT_EQ(2U, object->v1.size());
@@ -552,7 +552,7 @@ TEST(RNTupleImporter, ComplexClass)
 
       auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
       EXPECT_EQ(3U, reader->GetNEntries());
-      auto object = reader->GetModel()->Get<ComplexStructUtil>("object");
+      auto object = reader->GetDefaultValueAs<ComplexStructUtil>("object");
       ComplexStructUtil reference;
       reader->LoadEntry(0);
       reference.Init1();
@@ -594,7 +594,7 @@ TEST(RNTupleImporter, CollectionProxyClass)
 
       auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
       EXPECT_EQ(1U, reader->GetNEntries());
-      auto objectVec = reader->GetModel()->Get<std::vector<BaseUtil>>("objectVec");
+      auto objectVec = reader->GetDefaultValueAs<std::vector<BaseUtil>>("objectVec");
 
       reader->LoadEntry(0);
       EXPECT_EQ(3, objectVec->size());

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -249,8 +249,8 @@ TEST(RNTupleInspector, ColumnInfoUncompressed)
       auto e = ntuple->CreateEntry().lock();
 
       for (int i = 0; i < 5; ++i) {
-         *e->GetRaw<std::int32_t>("int32") = i;
-         *e->GetRaw<double>("splitReal64") = i;
+         *e->GetValueAs<std::int32_t>("int32") = i;
+         *e->GetValueAs<double>("splitReal64") = i;
          ntuple->Fill(*e);
       }
    }

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -249,8 +249,8 @@ TEST(RNTupleInspector, ColumnInfoUncompressed)
       auto e = ntuple->CreateEntry().lock();
 
       for (int i = 0; i < 5; ++i) {
-         *e->Get<std::int32_t>("int32") = i;
-         *e->Get<double>("splitReal64") = i;
+         *e->GetRaw<std::int32_t>("int32") = i;
+         *e->GetRaw<double>("splitReal64") = i;
          ntuple->Fill(*e);
       }
    }

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -246,9 +246,9 @@ TEST(RNTupleInspector, ColumnInfoUncompressed)
       auto writeOptions = RNTupleWriteOptions();
       writeOptions.SetCompression(0);
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
+      auto e = ntuple->CreateEntry().lock();
 
       for (int i = 0; i < 5; ++i) {
-         auto e = ntuple->CreateEntry();
          *e->Get<std::int32_t>("int32") = i;
          *e->Get<double>("splitReal64") = i;
          ntuple->Fill(*e);

--- a/tutorials/v7/ntuple/ntpl003_lhcbOpenData.C
+++ b/tutorials/v7/ntuple/ntpl003_lhcbOpenData.C
@@ -76,9 +76,9 @@ void Convert() {
    }
 
    // The new ntuple takes ownership of the model
-   auto ntuple = RNTupleWriter::Recreate(std::move(model), "DecayTree", kNTupleFileName);
+   auto writer = RNTupleWriter::Recreate(std::move(model), "DecayTree", kNTupleFileName);
 
-   auto entry = ntuple->GetModel()->CreateEntry();
+   auto entry = writer->CreateEntry().lock();
    for (auto b : TRangeDynCast<TBranch>(*tree->GetListOfBranches())) {
       auto l = static_cast<TLeaf *>(b->GetListOfLeaves()->First());
       // We connect the model's default entry's memory location for the new field to the branch, so that we can
@@ -90,7 +90,7 @@ void Convert() {
    auto nEntries = tree->GetEntries();
    for (decltype(nEntries) i = 0; i < nEntries; ++i) {
       tree->GetEntry(i);
-      ntuple->Fill(*entry);
+      writer->Fill(*entry);
 
       if (i && i % 100000 == 0)
          std::cout << "Wrote " << i << " entries" << std::endl;

--- a/tutorials/v7/ntuple/ntpl003_lhcbOpenData.C
+++ b/tutorials/v7/ntuple/ntpl003_lhcbOpenData.C
@@ -83,7 +83,7 @@ void Convert() {
       auto l = static_cast<TLeaf *>(b->GetListOfLeaves()->First());
       // We connect the model's default entry's memory location for the new field to the branch, so that we can
       // fill the ntuple with the data read from the TTree
-      void *fieldDataPtr = entry->GetRaw<void>(l->GetName());
+      void *fieldDataPtr = entry->GetValueAs<void>(l->GetName());
       tree->SetBranchAddress(b->GetName(), fieldDataPtr);
    }
 

--- a/tutorials/v7/ntuple/ntpl003_lhcbOpenData.C
+++ b/tutorials/v7/ntuple/ntpl003_lhcbOpenData.C
@@ -83,7 +83,7 @@ void Convert() {
       auto l = static_cast<TLeaf *>(b->GetListOfLeaves()->First());
       // We connect the model's default entry's memory location for the new field to the branch, so that we can
       // fill the ntuple with the data read from the TTree
-      void *fieldDataPtr = entry->GetRawPtr(l->GetName());
+      void *fieldDataPtr = entry->GetRaw<void>(l->GetName());
       tree->SetBranchAddress(b->GetName(), fieldDataPtr);
    }
 

--- a/tutorials/v7/ntuple/ntpl005_introspection.C
+++ b/tutorials/v7/ntuple/ntpl005_introspection.C
@@ -127,8 +127,8 @@ void ntpl005_introspection() {
    auto retval = gSystem->GetPathInfo(kNTupleFileName, fileStat);
    assert(retval == 0);
    float fileSize = static_cast<float>(fileStat.fSize);
-   float nbytesRead = ntuple->GetMetrics().GetCounter("RNTupleReader.RPageSourceFile.szReadPayload")->GetValueAsInt() +
-                      ntuple->GetMetrics().GetCounter("RNTupleReader.RPageSourceFile.szReadOverhead")->GetValueAsInt();
+   float nbytesRead = ntuple->GetMetrics()->GetCounter("RNTupleReader.RPageSourceFile.szReadPayload")->GetValueAsInt() +
+                      ntuple->GetMetrics()->GetCounter("RNTupleReader.RPageSourceFile.szReadOverhead")->GetValueAsInt();
 
    std::cout << "File size:      " << fileSize / 1024. / 1024. << " MiB" << std::endl;
    std::cout << "Read from file: " << nbytesRead / 1024. / 1024. << " MiB" << std::endl;

--- a/tutorials/v7/ntuple/ntpl007_mtFill.C
+++ b/tutorials/v7/ntuple/ntpl007_mtFill.C
@@ -63,10 +63,10 @@ void FillData(std::shared_ptr<REntry> entry, RNTupleWriter *ntuple)
    auto prng = std::make_unique<TRandom3>();
    prng->SetSeed();
 
-   auto id = entry->GetRaw<std::uint32_t>("id");
-   auto vpx = entry->GetRaw<std::vector<float>>("vpx");
-   auto vpy = entry->GetRaw<std::vector<float>>("vpy");
-   auto vpz = entry->GetRaw<std::vector<float>>("vpz");
+   auto id = entry->GetValueAs<std::uint32_t>("id");
+   auto vpx = entry->GetValueAs<std::vector<float>>("vpx");
+   auto vpy = entry->GetValueAs<std::vector<float>>("vpy");
+   auto vpz = entry->GetValueAs<std::vector<float>>("vpz");
 
    for (int i = 0; i < kNEventsPerThread; i++) {
       vpx->clear();

--- a/tutorials/v7/ntuple/ntpl007_mtFill.C
+++ b/tutorials/v7/ntuple/ntpl007_mtFill.C
@@ -63,10 +63,10 @@ void FillData(std::shared_ptr<REntry> entry, RNTupleWriter *ntuple)
    auto prng = std::make_unique<TRandom3>();
    prng->SetSeed();
 
-   auto id = entry->Get<std::uint32_t>("id");
-   auto vpx = entry->Get<std::vector<float>>("vpx");
-   auto vpy = entry->Get<std::vector<float>>("vpy");
-   auto vpz = entry->Get<std::vector<float>>("vpz");
+   auto id = entry->GetRaw<std::uint32_t>("id");
+   auto vpx = entry->GetRaw<std::vector<float>>("vpx");
+   auto vpy = entry->GetRaw<std::vector<float>>("vpy");
+   auto vpz = entry->GetRaw<std::vector<float>>("vpz");
 
    for (int i = 0; i < kNEventsPerThread; i++) {
       vpx->clear();

--- a/tutorials/v7/ntuple/ntpl009_skim.C
+++ b/tutorials/v7/ntuple/ntpl009_skim.C
@@ -82,8 +82,8 @@ void ntpl009_skim()
    auto writer = RNTupleWriter::Recreate(std::move(skimModel), kNTupleOutputName, kNTupleOutputFileName);
    auto skimEntry = writer->CreateEntry(inputEntry.get()).lock();
 
-   auto pRand = inputEntry->GetRaw<float>("rand");
-   auto pSkip = skimEntry->GetRaw<std::uint16_t>("skip");
+   auto pRand = inputEntry->GetValueAs<float>("rand");
+   auto pSkip = skimEntry->GetValueAs<std::uint16_t>("skip");
    for (unsigned int i = 0; i < reader->GetNEntries(); ++i) {
 
       reader->LoadEntry(i);

--- a/tutorials/v7/ntuple/ntpl009_skim.C
+++ b/tutorials/v7/ntuple/ntpl009_skim.C
@@ -72,7 +72,7 @@ void ntpl009_skim()
    Write();
 
    auto reader = RNTupleReader::Open(kNTupleInputName, kNTupleInputFileName);
-   const auto inputModel = reader->GetModel();
+   auto inputModel = reader->GetModel().lock();
    auto inputEntry = inputModel->GetDefaultEntry().lock();
 
    auto skimModel = inputModel->Clone();

--- a/tutorials/v7/ntuple/ntpl009_skim.C
+++ b/tutorials/v7/ntuple/ntpl009_skim.C
@@ -1,0 +1,97 @@
+/// \file
+/// \ingroup tutorial_ntuple
+/// \notebook
+/// Example of converting data stored in a TTree into an RNTuple
+///
+/// \macro_image
+/// \macro_code
+///
+/// \date December 2022
+/// \author The ROOT Team
+
+// NOTE: The RNTuple classes are experimental at this point.
+// Functionality, interface, and data format is still subject to changes.
+// Do not use for real data!
+
+#include <ROOT/RNTuple.hxx>
+#include <ROOT/RNTupleModel.hxx>
+
+#include <TRandom.h>
+
+#include <cstdint>
+
+// Import classes from experimental namespace for the time being.
+using RNTuple = ROOT::Experimental::RNTuple;
+using RNTupleModel = ROOT::Experimental::RNTupleModel;
+using RNTupleReader = ROOT::Experimental::RNTupleReader;
+using RNTupleWriter = ROOT::Experimental::RNTupleWriter;
+
+// Input and output.
+constexpr char const *kNTupleInputName = "ntpl";
+constexpr char const *kNTupleInputFileName = "ntpl009_input.root";
+constexpr char const *kNTupleOutputName = "ntpl_skim";
+constexpr char const *kNTupleOutputFileName = "ntpl009_skim.root";
+constexpr int kNEvents = 25000;
+
+static void Write()
+{
+   auto model = RNTupleModel::Create();
+
+   auto fldVpx = model->MakeField<std::vector<float>>("vpx");
+   auto fldVpy = model->MakeField<std::vector<float>>("vpy");
+   auto fldVpz = model->MakeField<std::vector<float>>("vpz");
+   auto fldRand = model->MakeField<float>("rand");
+
+   auto writer = RNTupleWriter::Recreate(std::move(model), kNTupleInputName, kNTupleInputFileName);
+
+   gRandom->SetSeed();
+   for (int i = 0; i < kNEvents; i++) {
+      int npx = static_cast<int>(gRandom->Rndm(1) * 15);
+
+      fldVpx->clear();
+      fldVpy->clear();
+      fldVpz->clear();
+
+      for (int j = 0; j < npx; ++j) {
+         float px, py, pz;
+         gRandom->Rannor(px, py);
+         pz = px * px + py * py;
+
+         fldVpx->emplace_back(px);
+         fldVpy->emplace_back(py);
+         fldVpz->emplace_back(pz);
+      }
+      *fldRand = gRandom->Rndm(1);
+
+      writer->Fill();
+   }
+}
+
+void ntpl009_skim()
+{
+   Write();
+
+   auto reader = RNTupleReader::Open(kNTupleInputName, kNTupleInputFileName);
+   const auto inputModel = reader->GetModel();
+   auto inputEntry = inputModel->GetDefaultEntry().lock();
+
+   auto skimModel = inputModel->Clone();
+   skimModel->Unfreeze();
+   skimModel->MakeField<std::uint16_t>("skip", 0);
+
+   auto writer = RNTupleWriter::Recreate(std::move(skimModel), kNTupleOutputName, kNTupleOutputFileName);
+   auto skimEntry = writer->CreateEntry(inputEntry.get()).lock();
+
+   auto pRand = inputEntry->Get<float>("rand");
+   auto pSkip = skimEntry->Get<std::uint16_t>("skip");
+   for (unsigned int i = 0; i < reader->GetNEntries(); ++i) {
+
+      reader->LoadEntry(i);
+      if (*pRand < 0.7) {
+         (*pSkip)++;
+         continue;
+      }
+      writer->Fill(*skimEntry);
+      *pSkip = 0;
+   }
+}

--- a/tutorials/v7/ntuple/ntpl009_skim.C
+++ b/tutorials/v7/ntuple/ntpl009_skim.C
@@ -82,8 +82,8 @@ void ntpl009_skim()
    auto writer = RNTupleWriter::Recreate(std::move(skimModel), kNTupleOutputName, kNTupleOutputFileName);
    auto skimEntry = writer->CreateEntry(inputEntry.get()).lock();
 
-   auto pRand = inputEntry->Get<float>("rand");
-   auto pSkip = skimEntry->Get<std::uint16_t>("skip");
+   auto pRand = inputEntry->GetRaw<float>("rand");
+   auto pSkip = skimEntry->GetRaw<std::uint16_t>("skip");
    for (unsigned int i = 0; i < reader->GetNEntries(); ++i) {
 
       reader->LoadEntry(i);


### PR DESCRIPTION
# This Pull request:

Adds a tutorial that shows how to create a derived data set with a subset of the columns and row of the input data set.

Working on the tutorial triggered several improvements to the RNTuple API:

- RNTupleModel takes ownership of entries and returns weak pointers to them (entries need to be destructed before the model and with it its fields are destructed).
- Several safety improvements: make members `const` or private
- Add `RFieldBase::Compare()`
- Several minor improvements

This PR triggers several follow-up PRs, e.g.
  - `RBulk` should be returned as weak pointers like entries.
  - `RFieldBase::RValue` should use shared pointers, not raw pointers
  - There should be read support for projected fields to complete the skimming tutorial

Nevertheless, the PR is already rather large and it does seem to make sense to review it as is.

## Changes or fixes:

Changes to the following APIs: `RNTupleReader`, `RNTupleWriter`, `RNTupleModel`, `REntry`.

## Checklist:

- [x] tested changes locally
- [x] updated the docs
- [ ] ping known users about the changes

