### PR TITLE
[RF] Add function to clear Minuit status history in RooMinimizer

### DIFF
--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -138,7 +138,13 @@ public:
 
    void saveStatus(const char *label, int status)
    {
-      _statusHistory.push_back(std::pair<std::string, int>(label, status));
+      _statusHistory.emplace_back(label, status);
+   }
+
+   /// Clears the Minuit status history.
+   void clearStatusHistory()
+   {
+      _statusHistory.clear();
    }
 
    int evalCounter() const;


### PR DESCRIPTION
As requested in this forum post:
https://root-forum.cern.ch/t/memory-leak-in-fits/56249/4
