### PR TITLE
[build] Format error as string in dependency_versions.py test

### DIFF
--- a/bindings/pyroot/pythonizations/test/dependency_versions.py
+++ b/bindings/pyroot/pythonizations/test/dependency_versions.py
@@ -52,15 +52,16 @@ class DependencyVersions(unittest.TestCase):
                 print('Ignore dependency {}'.format(requirement_str))
                 continue
             try:
+                print('Attempting requirement \'{}\''.format(requirement_str))
                 pkg_resources.require(requirement_str)
             except Exception as e:
-                errors.append(e)
+                errors.append(str(e))
         f.close()
         if errors:
             print()
             print('Full path to requirements.txt: {}'.format(path))
             print('Details about not matched dependencies:')
-            print('\n'.join([' - ' + e.report() for e in errors]))
+            print('\n'.join([' - ' + e for e in errors]))
             raise Exception('Found not matched dependencies declared in the requirements.txt, see test output for details')
 
 


### PR DESCRIPTION
The `report` attribute is not present in all types of errors, as seen in e.g. https://lcgapp-services.cern.ch/root-jenkins/job/root-pullrequests-build/184277/testReport/projectroot.bindings.pyroot.pythonizations/test/pyunittests_pyroot_dependency_versions/