### PR TITLE
[DF] Shorten RDF unit tests

### DIFF
--- a/tree/dataframe/test/CMakeLists.txt
+++ b/tree/dataframe/test/CMakeLists.txt
@@ -32,7 +32,7 @@ ROOT_ADD_GTEST(dataframe_redefine dataframe_redefine.cxx LIBRARIES ROOTDataFrame
 ROOT_ADD_GTEST(dataframe_definepersample dataframe_definepersample.cxx LIBRARIES ROOTDataFrame)
 
 if(NOT MSVC OR win_broken_tests)
-  ROOT_ADD_GTEST(dataframe_simple dataframe_simple.cxx LIBRARIES ROOTDataFrame)
+  ROOT_ADD_GTEST(dataframe_simple dataframe_simple.cxx LIBRARIES ROOTDataFrame GenVector)
   target_include_directories(dataframe_simple PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
   ROOT_GENERATE_DICTIONARY(DataFrameSimpleDict ${CMAKE_CURRENT_SOURCE_DIR}/MaxSlotHelper.h ${CMAKE_CURRENT_SOURCE_DIR}/SimpleFiller.h MODULE dataframe_simple
                            LINKDEF DataFrameSimpleLinkDef.h OPTIONS -inlineInputHeader DEPENDENCIES ROOTDataFrame Hist)

--- a/tree/dataframe/test/dataframe_helpers.cxx
+++ b/tree/dataframe/test/dataframe_helpers.cxx
@@ -683,14 +683,17 @@ TEST(RunGraphs, AlreadyRun)
                        "Got 4 handles from which 2 link to results which are already ready.");
 }
 
+int ret42 () {return 42;}
+int ret1 () {return 1;}
+
 TEST(RDFHelpers, ProgressHelper_Existence_ST)
 {
    // Redirect cout.
    std::streambuf *oldCoutStreamBuf = std::cout.rdbuf();
    std::ostringstream strCout;
    std::cout.rdbuf(strCout.rdbuf());
-   auto d_write_1 = ROOT::RDataFrame(10000000).Define("x", "42").Snapshot("tree", "fh1.root");
-   auto d_write_2 = ROOT::RDataFrame(10000000).Define("y", "1").Snapshot("tree", "fh2.root");
+   auto d_write_1 = ROOT::RDataFrame(10000).Define("x", ret42).Snapshot<int>("tree", "fh1.root", {"x"});
+   auto d_write_2 = ROOT::RDataFrame(10000).Define("y", ret1).Snapshot<int>("tree", "fh2.root", {"y"});
    ROOT::RDF::RNode d = ROOT::RDataFrame("tree", {"fh1.root", "fh2.root"});
    ROOT::RDF::Experimental::AddProgressbar(d);
    d.Count().GetValue();
@@ -711,8 +714,8 @@ TEST(RDFHelpers, ProgressHelper_Existence_MT)
    std::streambuf *oldCoutStreamBuf = std::cout.rdbuf();
    std::ostringstream strCout;
    std::cout.rdbuf(strCout.rdbuf());
-   auto d_write_1 = ROOT::RDataFrame(10000000).Define("x", "42").Snapshot("tree", "fh1.root");
-   auto d_write_2 = ROOT::RDataFrame(10000000).Define("y", "1").Snapshot("tree", "fh2.root");
+   auto d_write_1 = ROOT::RDataFrame(10000).Define("x", ret42).Snapshot<int>("tree", "fh1.root", {"x"});
+   auto d_write_2 = ROOT::RDataFrame(10000).Define("y", ret1).Snapshot<int>("tree", "fh2.root", {"y"});
    ROOT::RDF::RNode d = ROOT::RDataFrame("tree", {"fh1.root", "fh2.root"});
    ROOT::RDF::Experimental::AddProgressbar(d);
    d.Count().GetValue();
@@ -729,7 +732,7 @@ TEST(RDFHelpers, ProgressHelper_existence_singleTTreeInput)
    std::streambuf *oldCoutStreamBuf = std::cout.rdbuf();
    std::ostringstream strCout;
    std::cout.rdbuf(strCout.rdbuf());
-   auto d_write_1 = ROOT::RDataFrame(10000000).Define("x", "42").Snapshot("tree", "fh1.root");
+   auto d_write_1 = ROOT::RDataFrame(10000).Define("x", ret42).Snapshot<int>("tree", "fh1.root", {"x"});
    ROOT::RDF::RNode d = ROOT::RDataFrame("tree", {"fh1.root"});
    ROOT::RDF::Experimental::AddProgressbar(d);
    d.Count().GetValue();

--- a/tree/dataframe/test/dataframe_simple.cxx
+++ b/tree/dataframe/test/dataframe_simple.cxx
@@ -13,6 +13,7 @@
 #include <TFile.h>
 #include <TGraph.h>
 #include <TInterpreter.h>
+#include <Math/Vector4D.h>
 #include <TRandom.h>
 #include <TROOT.h>
 #include <TSystem.h>
@@ -102,7 +103,7 @@ TEST_P(RDFSimpleTests, CreateZeroEntriesWithBranches)
    }
    RDataFrame tdf(treename, filename);
    auto c = tdf.Count();
-   auto m = tdf.Mean("b1");
+   auto m = tdf.Mean<double>("b1");
    EXPECT_EQ(0U, *c);
    EXPECT_DOUBLE_EQ(0., *m);
 }
@@ -148,7 +149,7 @@ TEST_P(RDFSimpleTests, Define_lambda)
 {
    RDataFrame tdf(10);
    auto d = tdf.Define("i", []() { return 1; });
-   auto m = d.Mean("i");
+   auto m = d.Mean<int>("i");
    EXPECT_DOUBLE_EQ(1., *m);
 }
 
@@ -161,7 +162,7 @@ TEST_P(RDFSimpleTests, Define_function)
 {
    RDataFrame tdf(10);
    auto d = tdf.Define("i", DefineFunction);
-   auto m = d.Mean("i");
+   auto m = d.Mean<int>("i");
    EXPECT_DOUBLE_EQ(1., *m);
 }
 
@@ -174,7 +175,7 @@ TEST_P(RDFSimpleTests, Define_functor)
    RDataFrame tdf(10);
    DefineStruct def;
    auto d = tdf.Define("i", def);
-   auto m = d.Mean("i");
+   auto m = d.Mean<int>("i");
    EXPECT_DOUBLE_EQ(1., *m);
 }
 
@@ -343,7 +344,7 @@ TEST_P(RDFSimpleTests, Define_jitted_Filter_complex_array)
 TEST_P(RDFSimpleTests, DefineSlotConsistency)
 {
    RDataFrame df(8);
-   auto m = df.DefineSlot("x", [](unsigned int) { return 1.; }).Max("x");
+   auto m = df.DefineSlot("x", [](unsigned int) { return 1.; }).Max<double>("x");
    EXPECT_DOUBLE_EQ(1., *m);
 }
 
@@ -354,7 +355,7 @@ TEST_P(RDFSimpleTests, DefineSlot)
       values[i] = i;
    RDataFrame df(NSLOTS);
    auto ddf = df.DefineSlot("s", [values](unsigned int slot) { return values[slot]; });
-   auto m = ddf.Max("s");
+   auto m = ddf.Max<int>("s");
    EXPECT_EQ(*m, NSLOTS - 1); // no matter the order of processing, the higher slot number is always taken at least once
 }
 
@@ -436,11 +437,11 @@ TEST_P(RDFSimpleTests, GetNRuns)
    RDataFrame df(3);
    EXPECT_EQ(df.GetNRuns(), 0u);
 
-   auto sum1 = df.Sum("rdfentry_");
+   auto sum1 = df.Sum<ULong64_t>("rdfentry_");
    sum1.GetValue();
    EXPECT_EQ(df.GetNRuns(), 1u);
 
-   auto sum2 = df.Sum("rdfentry_");
+   auto sum2 = df.Sum<ULong64_t>("rdfentry_");
    sum2.GetValue();
    EXPECT_EQ(df.GetNRuns(), 2u);
 }
@@ -665,7 +666,7 @@ public:
       ROOT::RDataFrame d(samples.size());
       return *d.DefineSlotEntry("x", [this](unsigned int /*slot*/, ULong64_t entry) {
                   return samples[entry];
-               }).StdDev("x");
+               }).StdDev<double>("x");
    }
 };
 
@@ -715,21 +716,21 @@ TEST_P(RDFSimpleTests, StandardDeviationCollections)
 TEST_P(RDFSimpleTests, StandardDeviationZero)
 {
    RDataFrame rd1(8);
-   auto stdDev = rd1.Define("b1", []() { return 0; }).StdDev("b1");
+   auto stdDev = rd1.Define("b1", []() { return 0; }).StdDev<int>("b1");
    EXPECT_DOUBLE_EQ(*stdDev, 0);
 }
 
 TEST_P(RDFSimpleTests, StandardDeviationOne)
 {
    RDataFrame rd1(1);
-   auto stdDev = rd1.Define("b1", []() { return 1; }).StdDev("b1");
+   auto stdDev = rd1.Define("b1", []() { return 1; }).StdDev<int>("b1");
    EXPECT_DOUBLE_EQ(*stdDev, 0);
 }
 
 TEST_P(RDFSimpleTests, StandardDeviationEmpty)
 {
    RDataFrame rd1(0);
-   auto stdDev = rd1.Define("b1", []() { return 0; }).StdDev("b1");
+   auto stdDev = rd1.Define("b1", []() { return 0; }).StdDev<int>("b1");
    EXPECT_DOUBLE_EQ(*stdDev, 0);
 }
 
@@ -743,11 +744,17 @@ TEST(RDFSimpleTests, SumOfStrings)
 }
 */
 
+template <typename T>
+T KahanHelper(ULong64_t i)
+{
+   return T(i + 1);
+}
+
 TEST_P(RDFSimpleTests, KahanSum_Double)
 {
    constexpr std::uint64_t N = 1e7;
    ROOT::RDataFrame d(N);
-   auto df = d.Define("x", "double(rdfentry_ +1)");
+   auto df = d.Define("x", KahanHelper<double>, {"rdfentry_"});
    double true_sum = (N + 1.0) / 2.0;
    EXPECT_DOUBLE_EQ(*df.Sum<double>({"x"}) / N, true_sum);
 }
@@ -756,7 +763,7 @@ TEST_P(RDFSimpleTests, KahanSum_Float)
 {
    constexpr std::uint64_t N = 1e7;
    ROOT::RDataFrame d(N);
-   auto df = d.Define("x", "float(rdfentry_ +1)");
+   auto df = d.Define("x", KahanHelper<float>, {"rdfentry_"});
    float true_sum = (N + 1.0) / 2.0;
    EXPECT_FLOAT_EQ(*df.Sum<float>({"x"}) / N, true_sum);
 }
@@ -765,7 +772,7 @@ TEST_P(RDFSimpleTests, KahanMean_Double)
 {
    constexpr std::uint64_t N = 1e7;
    ROOT::RDataFrame d(N);
-   auto df = d.Define("x", "double(rdfentry_ +1)");
+   auto df = d.Define("x", KahanHelper<double>, {"rdfentry_"});
    double true_sum = (N + 1.0) / 2.0;
    EXPECT_DOUBLE_EQ(*df.Mean<double>({"x"}), true_sum);
 }
@@ -774,7 +781,7 @@ TEST_P(RDFSimpleTests, KahanMean_Float)
 {
    constexpr std::uint64_t N = 1e7;
    ROOT::RDataFrame d(N);
-   auto df = d.Define("x", "float(rdfentry_ +1)");
+   auto df = d.Define("x", KahanHelper<float>, {"rdfentry_"});
    float true_sum = (N + 1.0) / 2.0;
    EXPECT_FLOAT_EQ(*df.Mean<float>({"x"}), true_sum);
 }
@@ -782,9 +789,11 @@ TEST_P(RDFSimpleTests, KahanMean_Float)
 TEST(RDFSimpleTests, GenVector)
 {
    // The leading underscore of "_hh" tests against ROOT-10305.
+   using MVector = ROOT::Math::PtEtaPhiMVector;
    ROOT::RDataFrame t(1);
-   auto aa = t.Define("_hh", "ROOT::Math::PtEtaPhiMVector(1,1,1,1)").Define("h", "_hh.Rapidity()");
-   auto m = aa.Mean("h");
+   auto aa = t.Define("_hh", []() { return MVector(1, 1, 1, 1); })
+              .Define("h", [](MVector &v) { return v.Rapidity(); }, {"_hh"});
+   auto m = aa.Mean<double>("h");
    EXPECT_TRUE(0 != *m);
 }
 
@@ -792,9 +801,9 @@ TEST(RDFSimpleTests, AutomaticNamesOfHisto1DAndGraph)
 {
    auto df = RDataFrame(1).Define("x", [](){return 1;})
                           .Define("y", [](){return 1;});
-   auto hx = df.Histo1D("x");
-   auto hxy = df.Histo1D("x", "y");
-   auto gxy = df.Graph("x", "y");
+   auto hx = df.Histo1D<int>("x");
+   auto hxy = df.Histo1D<int, int>("x", "y");
+   auto gxy = df.Graph<int, int>("x", "y");
 
    EXPECT_STREQ(hx->GetName(), "x");
    EXPECT_STREQ(hx->GetTitle(), "x");
@@ -1003,7 +1012,7 @@ TEST_P(RDFSimpleTests, ChainWithDifferentTreeNames)
 
    // pass chain to RDF and process trees with different names
    ROOT::RDataFrame df2(c);
-   EXPECT_DOUBLE_EQ(*df2.Mean("x"), 2);
+   EXPECT_DOUBLE_EQ(*df2.Mean<int>("x"), 2);
 
    gSystem->Unlink(fname1);
    gSystem->Unlink(fname2);


### PR DESCRIPTION
Reduce duration of DF unit tests, eliminating jitting in favor of compilation where possible and optimizing obvious parameters, all without loosing any coverage.

# This Pull request:

## Changes or fixes:
The df battery of unit tests now runs a few minutes faster than before.


## Checklist:

- [v] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

