### PR TITLE
[RF][HS3] Improvements to the HS3 impelementation to bring it in line with the recent changes

### DIFF
--- a/etc/RooFitHS3_wsexportkeys.json
+++ b/etc/RooFitHS3_wsexportkeys.json
@@ -1,12 +1,4 @@
 {
-    "RooAddPdf": {
-        "type": "mixture_dist",
-        "proxies": {
-            "refCoefNorm": "coefnormset",
-            "pdfs": "summands",
-            "coefficients": "coefficients"
-        }
-    },
     "RooAddition": {
         "type": "sum",
         "proxies": {
@@ -48,13 +40,6 @@
             "sigma": "sigma"
         }
     },
-    "RooExponential": {
-        "type": "exponential_dist",
-        "proxies": {
-            "x": "x",
-            "c": "c"
-        }
-    },
     "RooGamma": {
         "type": "gamma_dist",
         "proxies": {
@@ -85,21 +70,6 @@
             "x": "x",
             "mean": "mean",
             "sigma": "sigma"
-        }
-    },
-    "RooLognormal": {
-        "type": "lognormal_dist",
-        "proxies": {
-            "x": "x",
-            "m0": "m0",
-            "k": "k"
-        }
-    },
-    "RooPoisson": {
-        "type": "poisson_dist",
-        "proxies": {
-            "x": "x",
-            "mean": "mean"
         }
     },
     "RooPower": {

--- a/etc/RooFitHS3_wsfactoryexpressions.json
+++ b/etc/RooFitHS3_wsfactoryexpressions.json
@@ -34,13 +34,6 @@
             "n"
         ]
     },
-    "exponential_dist": {
-        "class": "RooExponential",
-        "arguments": [
-            "x",
-            "c"
-        ]
-    },
     "gamma_dist": {
         "class": "RooGamma",
         "arguments": [
@@ -73,21 +66,6 @@
             "x",
             "mean",
             "sigma"
-        ]
-    },
-    "lognormal_dist": {
-        "class": "RooLognormal",
-        "arguments": [
-            "x",
-            "m0",
-            "k"
-        ]
-    },
-    "poisson_dist": {
-        "class": "RooPoisson",
-        "arguments": [
-            "x",
-            "mean"
         ]
     },
     "power_dist": {

--- a/roofit/batchcompute/inc/RooBatchCompute.h
+++ b/roofit/batchcompute/inc/RooBatchCompute.h
@@ -94,6 +94,7 @@ enum Computer {
    Johnson,
    Landau,
    Lognormal,
+   LognormalStandard,
    NegativeLogarithms,
    NormalizedPdf,
    Novosibirsk,
@@ -150,9 +151,9 @@ public:
    }
 
    virtual double reduceSum(Config const &cfg, InputArr input, size_t n) = 0;
-   virtual ReduceNLLOutput reduceNLL(Config const &cfg, std::span<const double> probas, std::span<const double> weightSpan,
-                                     std::span<const double> weights, double weightSum,
-                                     std::span<const double> binVolumes) = 0;
+   virtual ReduceNLLOutput reduceNLL(Config const &cfg, std::span<const double> probas,
+                                     std::span<const double> weightSpan, std::span<const double> weights,
+                                     double weightSum, std::span<const double> binVolumes) = 0;
 
    virtual Architecture architecture() const = 0;
    virtual std::string architectureName() const = 0;

--- a/roofit/batchcompute/inc/RooBatchCompute.h
+++ b/roofit/batchcompute/inc/RooBatchCompute.h
@@ -86,6 +86,7 @@ enum Computer {
    DstD0BG,
    ExpPoly,
    Exponential,
+   ExponentialNeg,
    Gamma,
    GaussModelExpBasis,
    Gaussian,

--- a/roofit/batchcompute/src/ComputeFunctions.cxx
+++ b/roofit/batchcompute/src/ComputeFunctions.cxx
@@ -328,9 +328,20 @@ __rooglobal__ void computeExpPoly(BatchesHandle batches)
 
 __rooglobal__ void computeExponential(BatchesHandle batches)
 {
-   Batch x = batches[0], c = batches[1];
-   for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
+   Batch x = batches[0];
+   Batch c = batches[1];
+   for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
       batches._output[i] = fast_exp(x[i] * c[i]);
+   }
+}
+
+__rooglobal__ void computeExponentialNeg(BatchesHandle batches)
+{
+   Batch x = batches[0];
+   Batch c = batches[1];
+   for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
+      batches._output[i] = fast_exp(-x[i] * c[i]);
+   }
 }
 
 __rooglobal__ void computeGamma(BatchesHandle batches)
@@ -830,6 +841,7 @@ std::vector<void (*)(BatchesHandle)> getFunctions()
            computeDstD0BG,
            computeExpPoly,
            computeExponential,
+           computeExponentialNeg,
            computeGamma,
            computeGaussModelExpBasis,
            computeGaussian,

--- a/roofit/histfactory/doc/README
+++ b/roofit/histfactory/doc/README
@@ -10,7 +10,7 @@ This package was written by
 V2 Update (Feb. 2011)
 
 The original HistFactory made models that consisted of a Poisson term for each bin.  
-In this "number counting form" the dataset has one row and the collumns corresponded to the number of 
+In this "number counting form" the dataset has one row and the columns corresponded to the number of 
 events for each bin. This led to severe performance problems in statistical tools that generated 
 pseudo-experiments and evaluated likelihood ratio test statistics.  Now the HistFactory can produce the equivalent
 model as an ExtendedPdf, with a histogram shape and an overall Poisson for the total number of events.  

--- a/roofit/histfactory/inc/RooStats/HistFactory/HistFactoryNavigation.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/HistFactoryNavigation.h
@@ -21,7 +21,7 @@ namespace RooStats {
 
     public:
 
-      /// Initialze based on an already-created HistFactory Model
+      /// Initialize based on an already-created HistFactory Model
       HistFactoryNavigation(ModelConfig* mc);
       HistFactoryNavigation(const std::string& File,
              const std::string& WorkspaceName="combined",
@@ -92,7 +92,7 @@ namespace RooStats {
 
       /// Find a node in the pdf and replace it with a new node
       /// These nodes can be functions, pdf's, RooRealVar's, etc
-      /// Will do minimial checking to make sure the replacement makes sense
+      /// Will do minimal checking to make sure the replacement makes sense
       void ReplaceNode(const std::string& ToReplace, RooAbsArg* ReplaceWith);
 
       // Set any RooRealVar's const (or not const) if they match
@@ -141,7 +141,7 @@ namespace RooStats {
       void SetPrintWidths(const std::string& channel);
 
       /// Fetch the node information for the pdf in question, and
-      /// save it in the varous collections in this class
+      /// save it in the various collections in this class
       void _GetNodes(ModelConfig* mc);
       void _GetNodes(RooAbsPdf* model, const RooArgSet* observables);
 

--- a/roofit/histfactory/src/ConfigParser.cxx
+++ b/roofit/histfactory/src/ConfigParser.cxx
@@ -220,7 +220,7 @@ std::vector< RooStats::HistFactory::Measurement > ConfigParser::GetMeasurementsF
     // and then we add them to all measurements
 
     // For now, we create this list twice
-    // simply for compatability
+    // simply for compatibility
     // std::vector< std::string > preprocessFunctions;
     std::vector< RooStats::HistFactory::PreprocessFunction > functionObjects;
 
@@ -229,7 +229,7 @@ std::vector< RooStats::HistFactory::Measurement > ConfigParser::GetMeasurementsF
       if( node->GetNodeName() == TString( "Function" ) ) {
 
    // For now, add both the objects itself and
-   // it's command string (for easy compatability)
+   // it's command string (for easy compatibility)
    RooStats::HistFactory::PreprocessFunction Func = ParseFunctionConfig( node );
    // preprocessFunctions.push_back( Func.GetCommand() );
    functionObjects.push_back( Func );
@@ -570,7 +570,7 @@ HistFactory::Channel ConfigParser::ParseChannelXMLFile( string filen ) {
 
   if( rootNode->GetNodeName() != TString( "Channel" ) ){
     cxcoutEHF << "Error: In parsing a Channel XML, "
-         << "Encounterd XML with DOCTYPE: " << rootNode->GetNodeName()
+         << "Encountered XML with DOCTYPE: " << rootNode->GetNodeName()
          << std::endl;
     cxcoutEHF << " DOCTYPE for channels must be 'Channel' "
          << " Check that your XML is properly written" << std::endl;

--- a/roofit/histfactory/src/HistFactoryNavigation.cxx
+++ b/roofit/histfactory/src/HistFactoryNavigation.cxx
@@ -488,7 +488,7 @@ namespace RooStats {
 
 
     RooAbsReal* HistFactoryNavigation::SampleFunction(const std::string& channel, const std::string& sample){
-      // Return the function object pointer cooresponding
+      // Return the function object pointer corresponding
       // to a particular sample in a particular channel
 
       std::map< std::string, std::map< std::string, RooAbsReal*> >::iterator channel_itr;

--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -207,7 +207,7 @@ namespace HistFactory{
   }
 
 
-  // We want to eliminate this interface and use the measurment directly
+  // We want to eliminate this interface and use the measurement directly
   RooFit::OwningPtr<RooWorkspace> HistoToWorkspaceFactoryFast::MakeSingleChannelModel( Measurement& measurement, Channel& channel ) {
 
     // This is a pretty light-weight wrapper function
@@ -359,7 +359,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
       // do nothing if the constraint term already exists
       if(proto.pdf(constraintName)) return;
 
-      // case systematic is uniform (asssume they are like a Gaussian but with
+      // case systematic is uniform (assume they are like a Gaussian but with
       // a large width (100 instead of 1)
       const double gaussSigma = isUniform ? 100. : 1.0;
       if (isUniform) {
@@ -481,7 +481,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
         cxcoutI(HistFactory) <<"<NormFactor Name =\""<<*nit<<"\"> is duplicated for <Sample Name=\""
             << sample.GetName() << "\">, but only one factor will be included.  \n Instead, define something like"
             << "\n\t<Function Name=\""<<*nit<<"Squared\" Expression=\""<<*nit<<"*"<<*nit<<"\" Var=\""<<*nit<<rangeNames.at(rangeIndex)
-            << "\"> \nin your top-level XML's <Measurment> entry and use <NormFactor Name=\""<<*nit<<"Squared\" in your channel XML file."<< endl;
+            << "\"> \nin your top-level XML's <Measurement> entry and use <NormFactor Name=\""<<*nit<<"Squared\" in your channel XML file."<< endl;
       }
       ++rangeIndex;
     }
@@ -883,7 +883,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
         // make list of abstract parameters that interpolate in space of variations
         RooArgList interpParams = makeInterpolationParameters(sample.GetHistoSysList(), proto);
 
-        // next, cerate the constraint terms
+        // next, create the constraint terms
         for(std::size_t i = 0; i < interpParams.size(); ++i) {
           bool isUniform = measurement.GetUniformSyst().count(sample.GetHistoSysList()[i].GetName()) > 0;
           makeGaussianConstraint(interpParams[i], proto, isUniform, constraintTermNames);
@@ -1156,7 +1156,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
 
           // Now that we have the list of ShapeSys ParamHistFunc names,
           // we create the total RooProduct
-          // we multiply the expected functio
+          // we multiply the expected function
 
           for(std::string const& name : ShapeSysNames) {
             sampleHistFuncs.push_back(proto.function(name));
@@ -1294,7 +1294,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
       observablesStr += name;
     }
 
-    // We create two sets, one for backwards compatability
+    // We create two sets, one for backwards compatibility
     // The other to make a consistent naming convention
     // between individual channels and the combined workspace
     proto.defineSet("observables", observablesStr.c_str());
@@ -1308,7 +1308,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
 
     auto model = make_unique<RooProdPdf>(
         ("model_"+channel_name).c_str(),    // MB : have changed this into conditional pdf. Much faster for toys!
-        "product of Poissons accross bins for a single channel",
+        "product of Poissons across bins for a single channel",
         constraintTerms, RooFit::Conditional(likelihoodTerms,observables));
     // can give channel a title by setting title of corresponding data histogram
     if (channel.GetData().GetHisto() && strlen(channel.GetData().GetHisto()->GetTitle())>0) {

--- a/roofit/histfactory/src/MakeModelAndMeasurementsFast.cxx
+++ b/roofit/histfactory/src/MakeModelAndMeasurementsFast.cxx
@@ -188,7 +188,7 @@ RooStats::HistFactory::MakeModelAndMeasurementFast(RooStats::HistFactory::Measur
         cxcoutPHF << "Successfully wrote channel to file" << std::endl;
       }
 
-      // Get the Paramater of Interest as a RooRealVar
+      // Get the Parameter of Interest as a RooRealVar
       RooRealVar* poi = dynamic_cast<RooRealVar*>( ws_single->var(measurement.GetPOI()));
 
       // do fit unless exportOnly requested

--- a/roofit/histfactory/src/Measurement.cxx
+++ b/roofit/histfactory/src/Measurement.cxx
@@ -443,7 +443,7 @@ void RooStats::HistFactory::Measurement::PrintXML( std::string directory, std::s
 void RooStats::HistFactory::Measurement::writeToFile( TFile* file )
 {
 
-  // Create a tempory measurement
+  // Create a temporary measurement
   // (This is the one that is actually written)
   RooStats::HistFactory::Measurement outMeas( *this );
 

--- a/roofit/histfactory/src/ParamHistFunc.cxx
+++ b/roofit/histfactory/src/ParamHistFunc.cxx
@@ -718,7 +718,7 @@ std::list<double>* ParamHistFunc::plotSamplingHint(RooAbsRealLValue& obs, double
 
   std::list<double>* hint = new std::list<double> ;
 
-  // Widen range slighty
+  // Widen range slightly
   xlo = xlo - 0.01*(xhi-xlo) ;
   xhi = xhi + 0.01*(xhi-xlo) ;
 

--- a/roofit/histfactory/src/PiecewiseInterpolation.cxx
+++ b/roofit/histfactory/src/PiecewiseInterpolation.cxx
@@ -501,7 +501,7 @@ double PiecewiseInterpolation::analyticalIntegralWN(Int_t code, const RooArgSet*
       else
    value += param->getVal()*(nominal - low->getVal());
     } else if(_interpCode.at(i)==1){
-      // pice-wise log
+      // piece-wise log
       if(param->getVal()>=0)
    value *= pow(high->getVal()/nominal, +param->getVal());
       else

--- a/roofit/histfactory/src/RooBarlowBeestonLL.cxx
+++ b/roofit/histfactory/src/RooBarlowBeestonLL.cxx
@@ -153,7 +153,7 @@ void RooStats::HistFactory::RooBarlowBeestonLL::initializeBarlowCache() {
   RooCategory* channelCat = (RooCategory*) (&simPdf->indexCat());
   for (const auto& nameIdx : *channelCat) {
 
-    // Warning: channel cat name is not necesarily the same name
+    // Warning: channel cat name is not necessarily the same name
     // as the pdf's (for example, if someone does edits)
     RooAbsPdf* channelPdf = simPdf->getPdf(nameIdx.first.c_str());
     std::string channel_name = channelPdf->GetName();

--- a/roofit/histfactory/src/Sample.cxx
+++ b/roofit/histfactory/src/Sample.cxx
@@ -298,7 +298,7 @@ void RooStats::HistFactory::Sample::PrintXML( std::ofstream& xml ) const {
 
 // Some helper functions
 // (Not strictly necessary because
-//  methods are publicly accessable)
+//  methods are publicly accessible)
 
 
 void RooStats::HistFactory::Sample::ActivateStatError() {

--- a/roofit/histfactory/test/testParamHistFunc.cxx
+++ b/roofit/histfactory/test/testParamHistFunc.cxx
@@ -56,7 +56,7 @@ TEST(ParamHistFunc, ValidateND)
    std::vector<double> resultsScalar(nEntries);
 
    // Do some things in one go:
-   //   * assing random integer values to each variable in each iteration
+   //   * assign random integer values to each variable in each iteration
    //   * fill the dataset used for batched evaluation
    //   * compute the reference result manually
    //   * compute the result with the ParamHistFunc without BatchMode

--- a/roofit/hs3/inc/RooFitHS3/JSONIO.h
+++ b/roofit/hs3/inc/RooFitHS3/JSONIO.h
@@ -39,7 +39,7 @@ public:
       return importFunction(tool, node);
    }
    // These two functions importPdf() and importFunction() are supposed to get
-   // deprecated at some point, and get superseeded by the general importArg().
+   // deprecated at some point, and get superseded by the general importArg().
    // The reason for having these functions call each other in a loop by
    // default is backwards compatibility: no matter which function is
    // overridden, it will be called eventually.

--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -181,6 +181,17 @@ public:
 
    void queueExport(RooAbsArg const &arg) { _serversToExport.push_back(&arg); }
 
+   RooFit::Detail::JSONNode &createAdHoc(const std::string &toplevel, const std::string &name);
+   RooAbsReal *importTransformed(const std::string &name, const std::string &tag, const std::string &operation_name,
+                                 const std::string &formula);
+   std::string exportTransformed(const RooAbsReal *original, const std::string &tag, const std::string &operation_name,
+                                 const std::string &formula);
+
+   void setAttribute(const std::string &obj, const std::string &attrib);
+   bool hasAttribute(const std::string &obj, const std::string &attrib);
+   std::string getStringAttribute(const std::string &obj, const std::string &attrib);
+   void setStringAttribute(const std::string &obj, const std::string &attrib, const std::string &value);
+
 private:
    template <class T>
    T *requestImpl(const std::string &objname);

--- a/roofit/hs3/src/HistFactoryJSONTool.cxx
+++ b/roofit/hs3/src/HistFactoryJSONTool.cxx
@@ -321,7 +321,7 @@ void exportMeasurement(RooStats::HistFactory::Measurement &measurement, JSONNode
    }
 
    // the data
-   auto &child1 = n.get("misc", "ROOT_internal", "combined_datas").set_map()["obsData"].set_map();
+   auto &child1 = n.get("misc", "ROOT_internal", "combined_datasets").set_map()["obsData"].set_map();
    auto &child2 = n.get("misc", "ROOT_internal", "combined_distributions").set_map()["simPdf"].set_map();
 
    child1["index_cat"] << "channelCat";

--- a/roofit/hs3/src/HistFactoryJSONTool.cxx
+++ b/roofit/hs3/src/HistFactoryJSONTool.cxx
@@ -14,13 +14,13 @@
 #include <RooFitHS3/HistFactoryJSONTool.h>
 #include <RooFit/Detail/JSONInterface.h>
 
-#include "RooStats/HistFactory/Measurement.h"
-#include "RooStats/HistFactory/Channel.h"
-#include "RooStats/HistFactory/Sample.h"
+#include <RooStats/HistFactory/Measurement.h>
+#include <RooStats/HistFactory/Channel.h>
+#include <RooStats/HistFactory/Sample.h>
 
 #include "Domains.h"
 
-#include "TH1.h"
+#include <TH1.h>
 
 using RooFit::Detail::JSONNode;
 using RooFit::Detail::JSONTree;
@@ -47,10 +47,10 @@ inline void writeAxis(JSONNode &axis, const TAxis &ax)
       axis["min"] << ax.GetXmin();
       axis["max"] << ax.GetXmax();
    } else {
-      auto &bounds = axis["bounds"];
-      bounds.set_seq();
+      auto &edges = axis["edges"];
+      edges.set_seq();
       for (int i = 0; i <= ax.GetNbins(); ++i) {
-         bounds.append_child() << ax.GetBinUpEdge(i);
+         edges.append_child() << ax.GetBinUpEdge(i);
       }
    }
 }

--- a/roofit/hs3/src/JSONFactories_HistFactory.cxx
+++ b/roofit/hs3/src/JSONFactories_HistFactory.cxx
@@ -795,7 +795,7 @@ bool tryExportHistFactory(RooJSONFactoryWSTool *tool, const std::string &pdfname
             const int i = bin.first;
             const double relerr_tot = bin.second;
             const double count = sample.hist[i - 1];
-            // this reconstruction is inherently unprecise, so we truncate it at some decimal places to make sure that
+            // this reconstruction is inherently imprecise, so we truncate it at some decimal places to make sure that
             // we don't carry around too many useless digits
             sample.histError[i - 1] = round_prec(relerr_tot * tot_yield[i] / std::sqrt(tot_yield2[i]) * count, 7);
          }

--- a/roofit/hs3/src/JSONFactories_HistFactory.cxx
+++ b/roofit/hs3/src/JSONFactories_HistFactory.cxx
@@ -51,13 +51,13 @@ inline void writeAxis(JSONNode &axis, RooRealVar const &obs)
       axis["min"] << obs.getMin();
       axis["max"] << obs.getMax();
    } else {
-      auto &bounds = axis["bounds"];
-      bounds.set_seq();
+      auto &edges = axis["edges"];
+      edges.set_seq();
       double val = binning.binLow(0);
-      bounds.append_child() << val;
+      edges.append_child() << val;
       for (int i = 0; i < binning.numBins(); ++i) {
          val = binning.binHigh(i);
-         bounds.append_child() << val;
+         edges.append_child() << val;
       }
    }
 }

--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -252,9 +252,9 @@ public:
    {
       std::string name(RooJSONFactoryWSTool::name(p));
       RooAbsReal *x = tool->requestArg<RooAbsReal>(p, "x");
-      RooAbsReal *c = tool->importTransformed(p["c"].val(), "exponential", "inverted", "-%s");
+      RooAbsReal *c = tool->requestArg<RooAbsReal>(p, "c");
 
-      tool->wsEmplace<RooExponential>(name, *x, *c);
+      tool->wsEmplace<RooExponential>(name, *x, *c, true);
       return true;
    }
 };
@@ -575,7 +575,11 @@ public:
       elem["type"] << key();
       elem["x"] << pdf->variable().GetName();
       auto &c = pdf->coefficient();
-      elem["c"] << tool->exportTransformed(&c, "exponential", "inverted", "-%s");
+      if (pdf->negateCoefficient()) {
+         elem["c"] << c.GetName();
+      } else {
+         elem["c"] << tool->exportTransformed(&c, "exponential", "inverted", "-%s");
+      }
 
       return true;
    }

--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -18,18 +18,21 @@
 #include <RooCategory.h>
 #include <RooDataHist.h>
 #include <RooExpPoly.h>
+#include <RooExponential.h>
 #include <RooFit/Detail/JSONInterface.h>
 #include <RooFitHS3/JSONIO.h>
 #include <RooFormulaVar.h>
 #include <RooGenericPdf.h>
-#include <RooMultiVarGaussian.h>
-#include <RooTFnBinding.h>
 #include <RooHistFunc.h>
 #include <RooHistPdf.h>
+#include <RooLognormal.h>
+#include <RooMultiVarGaussian.h>
+#include <RooPoisson.h>
 #include <RooPolynomial.h>
 #include <RooRealSumFunc.h>
 #include <RooRealSumPdf.h>
 #include <RooRealVar.h>
+#include <RooTFnBinding.h>
 #include <RooWorkspace.h>
 
 #include <TF1.h>
@@ -115,8 +118,11 @@ public:
    bool importArg(RooJSONFactoryWSTool *tool, const JSONNode &p) const override
    {
       std::string name(RooJSONFactoryWSTool::name(p));
-      tool->wsEmplace<RooAddPdf>(name, tool->requestArgList<RooAbsPdf>(p, "summands"),
-                                 tool->requestArgList<RooAbsReal>(p, "coefficients"));
+      auto &pdf = tool->wsEmplace<RooAddPdf>(name, tool->requestArgList<RooAbsPdf>(p, "summands"),
+                                             tool->requestArgList<RooAbsReal>(p, "coefficients"));
+      if (p.has_child("reference_observables")) {
+         pdf.fixCoefNormalization(tool->requestArgSet<RooAbsReal>(p, "reference_observables"));
+      }
       return true;
    }
 };
@@ -142,7 +148,6 @@ public:
       RooRealVar *obs = tool->requestArg<RooRealVar>(p, "observable");
 
       if (!pdf->dependsOn(*obs)) {
-         pdf->Print("t");
          RooJSONFactoryWSTool::error(std::string("pdf '") + pdf->GetName() + "' does not depend on observable '" +
                                      obs->GetName() + "' as indicated by parent RooBinSamplingPdf '" + name +
                                      "', please check!");
@@ -213,6 +218,46 @@ public:
       }
 
       tool->wsEmplace<RooPolynomial>(name, *x, coefs, lowestOrder);
+      return true;
+   }
+};
+
+class RooPoissonFactory : public RooFit::JSONIO::Importer {
+public:
+   bool importArg(RooJSONFactoryWSTool *tool, const JSONNode &p) const override
+   {
+      std::string name(RooJSONFactoryWSTool::name(p));
+      RooAbsReal *x = tool->requestArg<RooAbsReal>(p, "x");
+      RooAbsReal *mean = tool->requestArg<RooAbsReal>(p, "mean");
+      tool->wsEmplace<RooPoisson>(name, *x, *mean, !p["integer"].val_bool());
+      return true;
+   }
+};
+
+class RooLogNormalFactory : public RooFit::JSONIO::Importer {
+public:
+   bool importArg(RooJSONFactoryWSTool *tool, const JSONNode &p) const override
+   {
+      std::string name(RooJSONFactoryWSTool::name(p));
+      RooAbsReal *x = tool->requestArg<RooAbsReal>(p, "x");
+
+      RooAbsReal *m0 = tool->importTransformed(p["mu"].val(), "lognormal", "exp", "exp(%s)");
+      RooAbsReal *k = tool->importTransformed(p["sigma"].val(), "lognormal", "exp", "exp(%s)");
+
+      tool->wsEmplace<RooLognormal>(name, *x, *m0, *k);
+      return true;
+   }
+};
+
+class RooExponentialFactory : public RooFit::JSONIO::Importer {
+public:
+   bool importArg(RooJSONFactoryWSTool *tool, const JSONNode &p) const override
+   {
+      std::string name(RooJSONFactoryWSTool::name(p));
+      RooAbsReal *x = tool->requestArg<RooAbsReal>(p, "x");
+      RooAbsReal *c = tool->importTransformed(p["c"].val(), "exponential", "inverted", "-%s");
+
+      tool->wsEmplace<RooExponential>(name, *x, *c);
       return true;
    }
 };
@@ -299,6 +344,23 @@ public:
 // specialized exporter implementations
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 
+class RooAddPdfStreamer : public RooFit::JSONIO::Exporter {
+public:
+   std::string const &key() const override;
+   bool exportObject(RooJSONFactoryWSTool *, const RooAbsArg *func, JSONNode &elem) const override
+   {
+      const RooAddPdf *pdf = static_cast<const RooAddPdf *>(func);
+      elem["type"] << key();
+      RooJSONFactoryWSTool::fillSeq(elem["summands"], pdf->pdfList());
+      RooJSONFactoryWSTool::fillSeq(elem["coefficients"], pdf->coefList());
+      if (!pdf->getCoefNormalization().empty()) {
+         RooJSONFactoryWSTool::fillSeq(elem["reference_observables"], pdf->getCoefNormalization());
+      }
+      elem["extended"] << (pdf->extendMode() != RooAbsPdf::CanNotBeExtended);
+      return true;
+   }
+};
+
 class RooRealSumPdfStreamer : public RooFit::JSONIO::Exporter {
 public:
    std::string const &key() const override;
@@ -308,7 +370,7 @@ public:
       elem["type"] << key();
       RooJSONFactoryWSTool::fillSeq(elem["samples"], pdf->funcList());
       RooJSONFactoryWSTool::fillSeq(elem["coefficients"], pdf->coefList());
-      elem["extended"] << (pdf->extendMode() == RooAbsPdf::CanBeExtended);
+      elem["extended"] << (pdf->extendMode() != RooAbsPdf::CanNotBeExtended);
       return true;
    }
 };
@@ -476,6 +538,55 @@ public:
    }
 };
 
+class RooPoissonStreamer : public RooFit::JSONIO::Exporter {
+public:
+   std::string const &key() const override;
+   bool exportObject(RooJSONFactoryWSTool *, const RooAbsArg *func, JSONNode &elem) const override
+   {
+      auto *pdf = static_cast<const RooPoisson *>(func);
+      elem["type"] << key();
+      elem["x"] << pdf->getX().GetName();
+      elem["mean"] << pdf->getMean().GetName();
+      elem["integer"] << !pdf->getNoRounding();
+      return true;
+   }
+};
+
+class RooLogNormalStreamer : public RooFit::JSONIO::Exporter {
+public:
+   std::string const &key() const override;
+   bool exportObject(RooJSONFactoryWSTool *tool, const RooAbsArg *func, JSONNode &elem) const override
+   {
+      auto *pdf = static_cast<const RooLognormal *>(func);
+
+      elem["type"] << key();
+      elem["x"] << pdf->getX().GetName();
+
+      auto &m0 = pdf->getMedian();
+      auto &k = pdf->getShapeK();
+
+      elem["mu"] << tool->exportTransformed(&m0, "lognormal", "log", "log(%s)");
+      elem["sigma"] << tool->exportTransformed(&k, "lognormal", "log", "log(%s)");
+
+      return true;
+   }
+};
+
+class RooExponentialStreamer : public RooFit::JSONIO::Exporter {
+public:
+   std::string const &key() const override;
+   bool exportObject(RooJSONFactoryWSTool *tool, const RooAbsArg *func, JSONNode &elem) const override
+   {
+      auto *pdf = static_cast<const RooExponential *>(func);
+      elem["type"] << key();
+      elem["x"] << pdf->variable().GetName();
+      auto &c = pdf->coefficient();
+      elem["c"] << tool->exportTransformed(&c, "exponential", "inverted", "-%s");
+
+      return true;
+   }
+};
+
 class RooMultiVarGaussianStreamer : public RooFit::JSONIO::Exporter {
 public:
    std::string const &key() const override;
@@ -518,19 +629,23 @@ public:
       return keystring;                          \
    }
 
-template <>
-DEFINE_EXPORTER_KEY(RooFormulaArgStreamer<RooGenericPdf>, "generic_dist");
-template <>
-DEFINE_EXPORTER_KEY(RooFormulaArgStreamer<RooFormulaVar>, "generic_function");
-DEFINE_EXPORTER_KEY(RooRealSumPdfStreamer, "weighted_sum_dist");
-DEFINE_EXPORTER_KEY(RooRealSumFuncStreamer, "weighted_sum");
-DEFINE_EXPORTER_KEY(RooHistFuncStreamer, "histogram");
-DEFINE_EXPORTER_KEY(RooHistPdfStreamer, "histogram_dist");
+DEFINE_EXPORTER_KEY(RooAddPdfStreamer, "mixture_dist");
 DEFINE_EXPORTER_KEY(RooBinSamplingPdfStreamer, "binsampling");
 DEFINE_EXPORTER_KEY(RooBinWidthFunctionStreamer, "binwidth");
 DEFINE_EXPORTER_KEY(RooExpPolyStreamer, "exp_poly_dist");
+DEFINE_EXPORTER_KEY(RooExponentialStreamer, "exponential_dist");
+template <>
+DEFINE_EXPORTER_KEY(RooFormulaArgStreamer<RooFormulaVar>, "generic_function");
+template <>
+DEFINE_EXPORTER_KEY(RooFormulaArgStreamer<RooGenericPdf>, "generic_dist");
+DEFINE_EXPORTER_KEY(RooHistFuncStreamer, "histogram");
+DEFINE_EXPORTER_KEY(RooHistPdfStreamer, "histogram_dist");
+DEFINE_EXPORTER_KEY(RooLogNormalStreamer, "lognormal_dist");
+DEFINE_EXPORTER_KEY(RooMultiVarGaussianStreamer, "multivariate_normal_dist");
+DEFINE_EXPORTER_KEY(RooPoissonStreamer, "poisson_dist");
 DEFINE_EXPORTER_KEY(RooPolynomialStreamer, "polynomial_dist");
-DEFINE_EXPORTER_KEY(RooMultiVarGaussianStreamer, "multinormal_dist");
+DEFINE_EXPORTER_KEY(RooRealSumFuncStreamer, "weighted_sum");
+DEFINE_EXPORTER_KEY(RooRealSumPdfStreamer, "weighted_sum_dist");
 DEFINE_EXPORTER_KEY(RooTFnBindingStreamer, "generic_function");
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -540,30 +655,37 @@ DEFINE_EXPORTER_KEY(RooTFnBindingStreamer, "generic_function");
 STATIC_EXECUTE([]() {
    using namespace RooFit::JSONIO;
 
-   registerImporter<RooFormulaArgFactory<RooGenericPdf>>("generic_dist", false);
-   registerImporter<RooFormulaArgFactory<RooFormulaVar>>("generic_function", false);
-   registerImporter<RooBinSamplingPdfFactory>("binsampling_dist", false);
    registerImporter<RooAddPdfFactory>("mixture_dist", false);
+   registerImporter<RooBinSamplingPdfFactory>("binsampling_dist", false);
+   registerImporter<RooBinWidthFunctionFactory>("binwidth", false);
+   registerImporter<RooExpPolyFactory>("exp_poly_dist", false);
+   registerImporter<RooExponentialFactory>("exponential_dist", false);
+   registerImporter<RooFormulaArgFactory<RooFormulaVar>>("generic_function", false);
+   registerImporter<RooFormulaArgFactory<RooGenericPdf>>("generic_dist", false);
    registerImporter<RooHistFuncFactory>("histogram", false);
    registerImporter<RooHistPdfFactory>("histogram_dist", false);
-   registerImporter<RooBinWidthFunctionFactory>("binwidth", false);
+   registerImporter<RooLogNormalFactory>("lognormal_dist", false);
+   registerImporter<RooMultiVarGaussianFactory>("multivariate_normal_dist", false);
+   registerImporter<RooPoissonFactory>("poisson_dist", false);
+   registerImporter<RooPolynomialFactory>("polynomial_dist", false);
    registerImporter<RooRealSumPdfFactory>("weighted_sum_dist", false);
    registerImporter<RooRealSumFuncFactory>("weighted_sum", false);
-   registerImporter<RooExpPolyFactory>("exp_poly_dist", false);
-   registerImporter<RooPolynomialFactory>("polynomial_dist", false);
-   registerImporter<RooMultiVarGaussianFactory>("multinormal_dist", false);
 
-   registerExporter<RooBinWidthFunctionStreamer>(RooBinWidthFunction::Class(), false);
+   registerExporter<RooAddPdfStreamer>(RooAddPdf::Class(), false);
    registerExporter<RooBinSamplingPdfStreamer>(RooBinSamplingPdf::Class(), false);
+   registerExporter<RooBinWidthFunctionStreamer>(RooBinWidthFunction::Class(), false);
+   registerExporter<RooExpPolyStreamer>(RooExpPoly::Class(), false);
+   registerExporter<RooExponentialStreamer>(RooExponential::Class(), false);
+   registerExporter<RooFormulaArgStreamer<RooFormulaVar>>(RooFormulaVar::Class(), false);
+   registerExporter<RooFormulaArgStreamer<RooGenericPdf>>(RooGenericPdf::Class(), false);
    registerExporter<RooHistFuncStreamer>(RooHistFunc::Class(), false);
    registerExporter<RooHistPdfStreamer>(RooHistPdf::Class(), false);
-   registerExporter<RooFormulaArgStreamer<RooGenericPdf>>(RooGenericPdf::Class(), false);
-   registerExporter<RooFormulaArgStreamer<RooFormulaVar>>(RooFormulaVar::Class(), false);
-   registerExporter<RooRealSumPdfStreamer>(RooRealSumPdf::Class(), false);
-   registerExporter<RooRealSumFuncStreamer>(RooRealSumFunc::Class(), false);
-   registerExporter<RooExpPolyStreamer>(RooExpPoly::Class(), false);
-   registerExporter<RooPolynomialStreamer>(RooPolynomial::Class(), false);
+   registerExporter<RooLogNormalStreamer>(RooLognormal::Class(), false);
    registerExporter<RooMultiVarGaussianStreamer>(RooMultiVarGaussian::Class(), false);
+   registerExporter<RooPoissonStreamer>(RooPoisson::Class(), false);
+   registerExporter<RooPolynomialStreamer>(RooPolynomial::Class(), false);
+   registerExporter<RooRealSumFuncStreamer>(RooRealSumFunc::Class(), false);
+   registerExporter<RooRealSumPdfStreamer>(RooRealSumPdf::Class(), false);
    registerExporter<RooTFnBindingStreamer>(RooTFnBinding::Class(), false);
 });
 

--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -118,11 +118,8 @@ public:
    bool importArg(RooJSONFactoryWSTool *tool, const JSONNode &p) const override
    {
       std::string name(RooJSONFactoryWSTool::name(p));
-      auto &pdf = tool->wsEmplace<RooAddPdf>(name, tool->requestArgList<RooAbsPdf>(p, "summands"),
-                                             tool->requestArgList<RooAbsReal>(p, "coefficients"));
-      if (p.has_child("reference_observables")) {
-         pdf.fixCoefNormalization(tool->requestArgSet<RooAbsReal>(p, "reference_observables"));
-      }
+      tool->wsEmplace<RooAddPdf>(name, tool->requestArgList<RooAbsPdf>(p, "summands"),
+                                 tool->requestArgList<RooAbsReal>(p, "coefficients"));
       return true;
    }
 };
@@ -353,9 +350,6 @@ public:
       elem["type"] << key();
       RooJSONFactoryWSTool::fillSeq(elem["summands"], pdf->pdfList());
       RooJSONFactoryWSTool::fillSeq(elem["coefficients"], pdf->coefList());
-      if (!pdf->getCoefNormalization().empty()) {
-         RooJSONFactoryWSTool::fillSeq(elem["reference_observables"], pdf->getCoefNormalization());
-      }
       elem["extended"] << (pdf->extendMode() != RooAbsPdf::CanNotBeExtended);
       return true;
    }

--- a/roofit/hs3/test/testHS3SimultaneousFit.cxx
+++ b/roofit/hs3/test/testHS3SimultaneousFit.cxx
@@ -76,7 +76,8 @@ std::unique_ptr<RooFitResult> writeJSONAndFitModel(std::string &jsonStr)
    // Export before fitting to keep the prefit values
    jsonStr = RooJSONFactoryWSTool{ws}.exportJSONtoString();
 
-   return std::unique_ptr<RooFitResult>{pdf.fitTo(data, Save(), PrintLevel(-1), PrintEvalErrors(-1))};
+   return std::unique_ptr<RooFitResult>{
+      pdf.fitTo(data, Save(), PrintLevel(-1), PrintEvalErrors(-1), Minimizer("Minuit2"))};
 }
 
 std::unique_ptr<RooFitResult> readJSONAndFitModel(std::string const &jsonStr)
@@ -96,7 +97,8 @@ std::unique_ptr<RooFitResult> readJSONAndFitModel(std::string const &jsonStr)
    auto &pdf = *ws.pdf("simPdf");
    auto &data = *ws.data("obsData");
 
-   return std::unique_ptr<RooFitResult>{pdf.fitTo(data, Save(), PrintLevel(-1), PrintEvalErrors(-1))};
+   return std::unique_ptr<RooFitResult>{
+      pdf.fitTo(data, Save(), PrintLevel(-1), PrintEvalErrors(-1), Minimizer("Minuit2"))};
 }
 
 } // namespace
@@ -114,6 +116,5 @@ TEST(RooFitHS3, SimultaneousFit)
 
    // todo: also check the modelconfig for equality
 
-   // The precision is not great, needs to be understood why it is not exactly the same
-   EXPECT_TRUE(res2->isIdentical(*res1, 1e-3, 1e-3));
+   EXPECT_TRUE(res2->isIdentical(*res1));
 }

--- a/roofit/hs3/test/testHS3SimultaneousFit.cxx
+++ b/roofit/hs3/test/testHS3SimultaneousFit.cxx
@@ -60,14 +60,14 @@ std::unique_ptr<RooFitResult> writeJSONAndFitModel(std::string &jsonStr)
    x1.setBins(20);
    x2.setBins(20);
 
-   std::map<std::string, std::unique_ptr<RooAbsData>> datas;
-   datas["channel_1"] = std::unique_ptr<RooDataHist>{ws.pdf("model_1")->generateBinned(x1)};
-   datas["channel_2"] = std::unique_ptr<RooDataHist>{ws.pdf("model_2")->generateBinned(x2)};
+   std::map<std::string, std::unique_ptr<RooAbsData>> datasets;
+   datasets["channel_1"] = std::unique_ptr<RooDataHist>{ws.pdf("model_1")->generateBinned(x1)};
+   datasets["channel_2"] = std::unique_ptr<RooDataHist>{ws.pdf("model_2")->generateBinned(x2)};
 
-   datas["channel_1"]->SetName("obsData_channel_1");
-   datas["channel_2"]->SetName("obsData_channel_2");
+   datasets["channel_1"]->SetName("obsData_channel_1");
+   datasets["channel_2"]->SetName("obsData_channel_2");
 
-   RooDataSet obsData{"obsData", "obsData", {x1, x2}, Index(*ws.cat("channelCat")), Import(datas)};
+   RooDataSet obsData{"obsData", "obsData", {x1, x2}, Index(*ws.cat("channelCat")), Import(datasets)};
    ws.import(obsData);
 
    auto &pdf = *ws.pdf("simPdf");

--- a/roofit/hs3/test/testRooFitHS3.cxx
+++ b/roofit/hs3/test/testRooFitHS3.cxx
@@ -8,11 +8,13 @@
 #include <RooAddPdf.h>
 #include <RooCategory.h>
 #include <RooConstVar.h>
+#include <RooExponential.h>
 #include <RooGaussian.h>
 #include <RooGlobalFunc.h>
 #include <RooHelpers.h>
 #include <RooHistFunc.h>
 #include <RooHistPdf.h>
+#include <RooLognormal.h>
 #include <RooMultiVarGaussian.h>
 #include <RooPoisson.h>
 #include <RooProdPdf.h>
@@ -28,7 +30,7 @@
 namespace {
 
 // If the JSON files should be written out for debugging purpose.
-const bool writeJsonFiles = false;
+const bool writeJsonFiles = true;
 
 // Validate the JSON IO for a given RooAbsReal in a RooWorkspace. The workspace
 // will be written out and read back, and then the values of the old and new
@@ -172,9 +174,13 @@ TEST(RooFitHS3, RooConstVar)
 
 TEST(RooFitHS3, RooExponential)
 {
-   int status = validate({"Exponential::exponential(x[0, 10], c[-0.1], false)"});
+   int status = validate({"Exponential::exponential_1(x[0, 10], c[-0.1])"});
    EXPECT_EQ(status, 0);
-   status = validate({"Exponential::exponential(x[0, 10], c[-0.1], true)"});
+   RooWorkspace ws;
+   ws.factory("x[0, 10]");
+   ws.factory("c[-0.1]");
+   RooExponential exponential2{"exponential_2", "exponential_2", *ws.var("x"), *ws.var("c"), true};
+   status = validate(exponential2);
    EXPECT_EQ(status, 0);
 }
 
@@ -252,7 +258,14 @@ TEST(RooFitHS3, RooLandau)
 
 TEST(RooFitHS3, RooLognormal)
 {
-   int status = validate({"Lognormal::lognormal(x[0.1, 2.0], m0[0.0, 0.1, 10], k[3.0, 1.1, 10])"}, true);
+   RooWorkspace ws;
+   int status = validate({"Lognormal::lognormal_1(x[1.0, 1.1, 10], mu_2[2.0, 1.1, 10], k_1[2.0, 1.1, 5.0])"});
+   EXPECT_EQ(status, 0);
+   ws.factory("x[1.0, 1.1, 10]");
+   ws.factory("mu_2[0.7, 0.1, 2.3]");
+   ws.factory("k_2[0.7, 0.1, 1.6]");
+   RooLognormal lognormal2{"lognormal_2", "lognormal_2", *ws.var("x"), *ws.var("mu_2"), *ws.var("k_2"), true};
+   status = validate(lognormal2);
    EXPECT_EQ(status, 0);
 }
 

--- a/roofit/hs3/test/testRooFitHS3.cxx
+++ b/roofit/hs3/test/testRooFitHS3.cxx
@@ -34,7 +34,7 @@ const bool writeJsonFiles = false;
 // will be written out and read back, and then the values of the old and new
 // RooAbsReal will be compared for equality in each bin of the observable that
 // is called "x" by convention.
-int validate(RooWorkspace &ws1, std::string const &argName)
+int validate(RooWorkspace &ws1, std::string const &argName, bool exact = true)
 {
    RooWorkspace ws2;
 
@@ -58,27 +58,27 @@ int validate(RooWorkspace &ws1, std::string const &argName)
       x2.setBin(i);
       const double val1 = arg1.getVal(nset1);
       const double val2 = arg2.getVal(nset2);
-      allGood &= val1 == val2;
+      allGood &= (exact ? (val1 == val2) : std::abs(val1 - val2) < 1e-10);
    }
 
    return allGood ? 0 : 1;
 }
 
-int validate(std::vector<std::string> const &expressions)
+int validate(std::vector<std::string> const &expressions, bool exact = true)
 {
    RooWorkspace ws;
    for (std::size_t iExpr = 0; iExpr < expressions.size() - 1; ++iExpr) {
       ws.factory(expressions[iExpr]);
    }
    const std::string argName = ws.factory(expressions.back())->GetName();
-   return validate(ws, argName);
+   return validate(ws, argName, exact);
 }
 
-int validate(RooAbsArg const &arg)
+int validate(RooAbsArg const &arg, bool exact = true)
 {
    RooWorkspace ws;
    ws.import(arg, RooFit::Silence());
-   return validate(ws, arg.GetName());
+   return validate(ws, arg.GetName(), exact);
 }
 
 } // namespace
@@ -250,7 +250,7 @@ TEST(RooFitHS3, RooLandau)
 
 TEST(RooFitHS3, RooLognormal)
 {
-   int status = validate({"Lognormal::lognormal(x[0.1, 2.0], m0[0.0, 0.1, 10], k[3.0, 1.1, 10])"});
+   int status = validate({"Lognormal::lognormal(x[0.1, 2.0], m0[0.0, 0.1, 10], k[3.0, 1.1, 10])"}, true);
    EXPECT_EQ(status, 0);
 }
 

--- a/roofit/hs3/test/testRooFitHS3.cxx
+++ b/roofit/hs3/test/testRooFitHS3.cxx
@@ -172,7 +172,9 @@ TEST(RooFitHS3, RooConstVar)
 
 TEST(RooFitHS3, RooExponential)
 {
-   int status = validate({"Exponential::exponential(x[0, 10], c[-0.1])"});
+   int status = validate({"Exponential::exponential(x[0, 10], c[-0.1], false)"});
+   EXPECT_EQ(status, 0);
+   status = validate({"Exponential::exponential(x[0, 10], c[-0.1], true)"});
    EXPECT_EQ(status, 0);
 }
 

--- a/roofit/roofit/inc/RooExponential.h
+++ b/roofit/roofit/inc/RooExponential.h
@@ -23,7 +23,7 @@ class RooExponential : public RooAbsPdf {
 public:
   RooExponential() {}
   RooExponential(const char *name, const char *title,
-       RooAbsReal& _x, RooAbsReal& _c);
+       RooAbsReal& variable, RooAbsReal& coefficient, bool negateCoefficient=false);
   RooExponential(const RooExponential& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooExponential(*this,newname); }
 
@@ -36,6 +36,8 @@ public:
   /// Get the coefficient "c".
   RooAbsReal const &coefficient() const { return c.arg(); }
 
+  bool negateCoefficient() const { return _negateCoefficient; }
+
   void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
   std::string
   buildCallToAnalyticIntegral(Int_t code, const char *rangeName, RooFit::Detail::CodeSquashContext &ctx) const override;
@@ -43,13 +45,15 @@ public:
 protected:
   RooRealProxy x;
   RooRealProxy c;
+  bool _negateCoefficient = false;
 
   double evaluate() const override;
   void computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const&) const override;
   inline bool canComputeBatchWithCuda() const override { return true; }
 
 private:
-  ClassDefOverride(RooExponential,1) // Exponential PDF
+
+  ClassDefOverride(RooExponential,2) // Exponential PDF
 };
 
 #endif

--- a/roofit/roofit/inc/RooExponential.h
+++ b/roofit/roofit/inc/RooExponential.h
@@ -21,39 +21,38 @@
 
 class RooExponential : public RooAbsPdf {
 public:
-  RooExponential() {}
-  RooExponential(const char *name, const char *title,
-       RooAbsReal& variable, RooAbsReal& coefficient, bool negateCoefficient=false);
-  RooExponential(const RooExponential& other, const char* name=nullptr);
-  TObject* clone(const char* newname) const override { return new RooExponential(*this,newname); }
+   RooExponential() {}
+   RooExponential(const char *name, const char *title, RooAbsReal &variable, RooAbsReal &coefficient,
+                  bool negateCoefficient = false);
+   RooExponential(const RooExponential &other, const char *name = nullptr);
+   TObject *clone(const char *newname) const override { return new RooExponential(*this, newname); }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override;
-  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override;
+   Int_t getAnalyticalIntegral(RooArgSet &allVars, RooArgSet &analVars, const char *rangeName = nullptr) const override;
+   double analyticalIntegral(Int_t code, const char *rangeName = nullptr) const override;
 
-  /// Get the x variable.
-  RooAbsReal const &variable() const { return x.arg(); }
+   /// Get the x variable.
+   RooAbsReal const &variable() const { return x.arg(); }
 
-  /// Get the coefficient "c".
-  RooAbsReal const &coefficient() const { return c.arg(); }
+   /// Get the coefficient "c".
+   RooAbsReal const &coefficient() const { return c.arg(); }
 
-  bool negateCoefficient() const { return _negateCoefficient; }
+   bool negateCoefficient() const { return _negateCoefficient; }
 
-  void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
-  std::string
-  buildCallToAnalyticIntegral(Int_t code, const char *rangeName, RooFit::Detail::CodeSquashContext &ctx) const override;
+   void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
+   std::string buildCallToAnalyticIntegral(Int_t code, const char *rangeName,
+                                           RooFit::Detail::CodeSquashContext &ctx) const override;
 
 protected:
-  RooRealProxy x;
-  RooRealProxy c;
-  bool _negateCoefficient = false;
+   RooRealProxy x;
+   RooRealProxy c;
+   bool _negateCoefficient = false;
 
-  double evaluate() const override;
-  void computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const&) const override;
-  inline bool canComputeBatchWithCuda() const override { return true; }
+   double evaluate() const override;
+   void computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &) const override;
+   inline bool canComputeBatchWithCuda() const override { return true; }
 
 private:
-
-  ClassDefOverride(RooExponential,2) // Exponential PDF
+   ClassDefOverride(RooExponential, 2) // Exponential PDF
 };
 
 #endif

--- a/roofit/roofit/inc/RooExponential.h
+++ b/roofit/roofit/inc/RooExponential.h
@@ -16,23 +16,25 @@
 #ifndef ROO_EXPONENTIAL
 #define ROO_EXPONENTIAL
 
-#include "RooAbsPdf.h"
-#include "RooRealProxy.h"
-
-class RooRealVar;
-class RooAbsReal;
+#include <RooAbsPdf.h>
+#include <RooRealProxy.h>
 
 class RooExponential : public RooAbsPdf {
 public:
-  RooExponential() {} ;
+  RooExponential() {}
   RooExponential(const char *name, const char *title,
        RooAbsReal& _x, RooAbsReal& _c);
   RooExponential(const RooExponential& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooExponential(*this,newname); }
-  inline ~RooExponential() override { }
 
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override;
   double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override;
+
+  /// Get the x variable.
+  RooAbsReal const &variable() const { return x.arg(); }
+
+  /// Get the coefficient "c".
+  RooAbsReal const &coefficient() const { return c.arg(); }
 
   void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
   std::string

--- a/roofit/roofit/inc/RooLognormal.h
+++ b/roofit/roofit/inc/RooLognormal.h
@@ -17,7 +17,8 @@
 class RooLognormal : public RooAbsPdf {
 public:
    RooLognormal() {}
-   RooLognormal(const char *name, const char *title, RooAbsReal &_x, RooAbsReal &_m0, RooAbsReal &_k);
+   RooLognormal(const char *name, const char *title, RooAbsReal &_x, RooAbsReal &_m0, RooAbsReal &_k,
+                bool useStandardParametrization = false);
    RooLognormal(const RooLognormal &other, const char *name = nullptr);
    TObject *clone(const char *newname) const override { return new RooLognormal(*this, newname); }
 
@@ -40,17 +41,20 @@ public:
    /// Get the shape parameter.
    RooAbsReal const &getShapeK() const { return k.arg(); }
 
+   bool useStandardParametrization() const { return _useStandardParametrization; }
+
 protected:
    RooRealProxy x;  ///< the variable
    RooRealProxy m0; ///< the median, exp(mu)
    RooRealProxy k;  ///< the shape parameter, exp(sigma)
+   bool _useStandardParametrization = false;
 
    double evaluate() const override;
    void computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &) const override;
    inline bool canComputeBatchWithCuda() const override { return true; }
 
 private:
-   ClassDefOverride(RooLognormal, 1) // log-normal PDF
+   ClassDefOverride(RooLognormal, 2) // log-normal PDF
 };
 
 #endif

--- a/roofit/roofit/inc/RooLognormal.h
+++ b/roofit/roofit/inc/RooLognormal.h
@@ -11,19 +11,16 @@
 #ifndef ROO_LOGNORMAL
 #define ROO_LOGNORMAL
 
-#include "RooAbsPdf.h"
-#include "RooRealProxy.h"
-
-class RooRealVar;
+#include <RooAbsPdf.h>
+#include <RooRealProxy.h>
 
 class RooLognormal : public RooAbsPdf {
 public:
-  RooLognormal() {} ;
+  RooLognormal() {}
   RooLognormal(const char *name, const char *title,
          RooAbsReal& _x, RooAbsReal& _m0, RooAbsReal& _k);
   RooLognormal(const RooLognormal& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooLognormal(*this,newname); }
-  inline ~RooLognormal() override { }
 
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
   double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
@@ -35,11 +32,20 @@ public:
   std::string
   buildCallToAnalyticIntegral(int code, const char *rangeName, RooFit::Detail::CodeSquashContext &ctx) const override;
 
+  /// Get the x variable.
+  RooAbsReal const& getX() const { return x.arg(); }
+
+  /// Get the median parameter.
+  RooAbsReal const& getMedian() const { return m0.arg(); }
+
+  /// Get the shape parameter.
+  RooAbsReal const& getShapeK() const { return k.arg(); }
+
 protected:
 
-  RooRealProxy x ;
-  RooRealProxy m0 ;
-  RooRealProxy k ;
+  RooRealProxy x;  ///< the variable
+  RooRealProxy m0; ///< the median, exp(mu)
+  RooRealProxy k;  ///< the shape parameter, exp(sigma)
 
   double evaluate() const override ;
   void computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const&) const override;

--- a/roofit/roofit/inc/RooLognormal.h
+++ b/roofit/roofit/inc/RooLognormal.h
@@ -1,12 +1,12 @@
- /*****************************************************************************
-  * Project: RooFit                                                           *
-  * @(#)root/roofit:$Id$ *
-  *                                                                           *
-  * RooFit Lognormal PDF                                                      *
-  *                                                                           *
-  * Author: Gregory Schott and Stefan Schmitz                                 *
-  *                                                                           *
-  *****************************************************************************/
+/*****************************************************************************
+ * Project: RooFit                                                           *
+ * @(#)root/roofit:$Id$ *
+ *                                                                           *
+ * RooFit Lognormal PDF                                                      *
+ *                                                                           *
+ * Author: Gregory Schott and Stefan Schmitz                                 *
+ *                                                                           *
+ *****************************************************************************/
 
 #ifndef ROO_LOGNORMAL
 #define ROO_LOGNORMAL
@@ -16,44 +16,41 @@
 
 class RooLognormal : public RooAbsPdf {
 public:
-  RooLognormal() {}
-  RooLognormal(const char *name, const char *title,
-         RooAbsReal& _x, RooAbsReal& _m0, RooAbsReal& _k);
-  RooLognormal(const RooLognormal& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname) const override { return new RooLognormal(*this,newname); }
+   RooLognormal() {}
+   RooLognormal(const char *name, const char *title, RooAbsReal &_x, RooAbsReal &_m0, RooAbsReal &_k);
+   RooLognormal(const RooLognormal &other, const char *name = nullptr);
+   TObject *clone(const char *newname) const override { return new RooLognormal(*this, newname); }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
-  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
+   Int_t getAnalyticalIntegral(RooArgSet &allVars, RooArgSet &analVars, const char *rangeName = nullptr) const override;
+   double analyticalIntegral(Int_t code, const char *rangeName = nullptr) const override;
 
-  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, bool staticInitOK=true) const override;
-  void generateEvent(Int_t code) override;
+   Int_t getGenerator(const RooArgSet &directVars, RooArgSet &generateVars, bool staticInitOK = true) const override;
+   void generateEvent(Int_t code) override;
 
-  void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
-  std::string
-  buildCallToAnalyticIntegral(int code, const char *rangeName, RooFit::Detail::CodeSquashContext &ctx) const override;
+   void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
+   std::string
+   buildCallToAnalyticIntegral(int code, const char *rangeName, RooFit::Detail::CodeSquashContext &ctx) const override;
 
-  /// Get the x variable.
-  RooAbsReal const& getX() const { return x.arg(); }
+   /// Get the x variable.
+   RooAbsReal const &getX() const { return x.arg(); }
 
-  /// Get the median parameter.
-  RooAbsReal const& getMedian() const { return m0.arg(); }
+   /// Get the median parameter.
+   RooAbsReal const &getMedian() const { return m0.arg(); }
 
-  /// Get the shape parameter.
-  RooAbsReal const& getShapeK() const { return k.arg(); }
+   /// Get the shape parameter.
+   RooAbsReal const &getShapeK() const { return k.arg(); }
 
 protected:
+   RooRealProxy x;  ///< the variable
+   RooRealProxy m0; ///< the median, exp(mu)
+   RooRealProxy k;  ///< the shape parameter, exp(sigma)
 
-  RooRealProxy x;  ///< the variable
-  RooRealProxy m0; ///< the median, exp(mu)
-  RooRealProxy k;  ///< the shape parameter, exp(sigma)
-
-  double evaluate() const override ;
-  void computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const&) const override;
-  inline bool canComputeBatchWithCuda() const override { return true; }
+   double evaluate() const override;
+   void computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &) const override;
+   inline bool canComputeBatchWithCuda() const override { return true; }
 
 private:
-
-  ClassDefOverride(RooLognormal,1) // log-normal PDF
+   ClassDefOverride(RooLognormal, 1) // log-normal PDF
 };
 
 #endif

--- a/roofit/roofit/inc/RooPoisson.h
+++ b/roofit/roofit/inc/RooPoisson.h
@@ -35,6 +35,8 @@ public:
 
   /// Switch off/on rounding of `x` to the nearest integer.
   void setNoRounding(bool flag = true) {_noRounding = flag;}
+  bool getNoRounding() const { return _noRounding; }
+  
   /// Switch on or off protection against negative means.
   void protectNegativeMean(bool flag = true) {_protectNegative = flag;}
 

--- a/roofit/roofit/src/RooExponential.cxx
+++ b/roofit/roofit/src/RooExponential.cxx
@@ -74,12 +74,13 @@ void RooExponential::computeBatch(double *output, size_t nEvents, RooFit::Detail
    RooBatchCompute::compute(dataMap.config(this), computer, output, nEvents, {dataMap.at(x), dataMap.at(c)});
 }
 
-
-Int_t RooExponential::getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* /*rangeName*/) const
+Int_t RooExponential::getAnalyticalIntegral(RooArgSet &allVars, RooArgSet &analVars, const char * /*rangeName*/) const
 {
-  if (matchArgs(allVars,analVars,x)) return 1;
-  if (matchArgs(allVars,analVars,c)) return 2;
-  return 0 ;
+   if (matchArgs(allVars, analVars, x))
+      return 1;
+   if (matchArgs(allVars, analVars, c))
+      return 2;
+   return 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -116,8 +117,8 @@ void RooExponential::translate(RooFit::Detail::CodeSquashContext &ctx) const
 {
    // Build a call to the stateless exponential defined later.
    std::string coef;
-   if(_negateCoefficient) {
-       coef += "-";
+   if (_negateCoefficient) {
+      coef += "-";
    }
    coef += ctx.getResult(c);
    ctx.addResult(this, "std::exp(" + coef + " * " + ctx.getResult(x) + ")");

--- a/roofit/roofit/src/RooExponential.cxx
+++ b/roofit/roofit/src/RooExponential.cxx
@@ -32,38 +32,46 @@ range and values of the arguments.
 
 #include <RooFit/Detail/AnalyticalIntegrals.h>
 
+#include <algorithm>
 #include <cmath>
 
 ClassImp(RooExponential);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooExponential::RooExponential(const char *name, const char *title,
-                RooAbsReal& _x, RooAbsReal& _c) :
-  RooAbsPdf(name, title),
-  x("x","Dependent",this,_x),
-  c("c","Exponent",this,_c)
+RooExponential::RooExponential(const char *name, const char *title, RooAbsReal &variable, RooAbsReal &coefficient,
+                               bool negateCoefficient)
+   : RooAbsPdf{name, title},
+     x{"x", "Dependent", this, variable},
+     c{"c", "Exponent", this, coefficient},
+     _negateCoefficient{negateCoefficient}
 {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooExponential::RooExponential(const RooExponential& other, const char* name) :
-  RooAbsPdf(other, name), x("x",this,other.x), c("c",this,other.c)
+RooExponential::RooExponential(const RooExponential &other, const char *name)
+   : RooAbsPdf{other, name}, x{"x", this, other.x}, c{"c", this, other.c}, _negateCoefficient{other._negateCoefficient}
 {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-double RooExponential::evaluate() const{
-  return std::exp(c*x);
+double RooExponential::evaluate() const
+{
+   double coef = c;
+   if (_negateCoefficient) {
+      coef = -coef;
+   }
+   return std::exp(coef * x);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute multiple values of Exponential distribution.
-void RooExponential::computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const& dataMap) const
+void RooExponential::computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &dataMap) const
 {
-   RooBatchCompute::compute(dataMap.config(this), RooBatchCompute::Exponential, output, nEvents, {dataMap.at(x),dataMap.at(c)});
+   auto computer = _negateCoefficient ? RooBatchCompute::ExponentialNeg : RooBatchCompute::Exponential;
+   RooBatchCompute::compute(dataMap.config(this), computer, output, nEvents, {dataMap.at(x), dataMap.at(c)});
 }
 
 
@@ -76,32 +84,68 @@ Int_t RooExponential::getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analV
 
 ////////////////////////////////////////////////////////////////////////////////
 
-double RooExponential::analyticalIntegral(Int_t code, const char* rangeName) const
+double RooExponential::analyticalIntegral(Int_t code, const char *rangeName) const
 {
-  assert(code == 1 || code ==2);
+   assert(code == 1 || code == 2);
 
-  auto& constant  = code == 1 ? c : x;
-  auto& integrand = code == 1 ? x : c;
+   bool isOverX = code == 1;
 
-  return RooFit::Detail::AnalyticalIntegrals::exponentialIntegral(integrand.min(rangeName), integrand.max(rangeName), constant);
+   double coef = c;
+   if (_negateCoefficient) {
+      coef = -coef;
+   }
+
+   double constant = isOverX ? coef : x;
+   auto &integrand = isOverX ? x : c;
+
+   double min = integrand.min(rangeName);
+   double max = integrand.max(rangeName);
+
+   if (!isOverX && _negateCoefficient) {
+      std::swap(min, max);
+      min = -min;
+      max = -max;
+   }
+
+   return RooFit::Detail::AnalyticalIntegrals::exponentialIntegral(min, max, constant);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 void RooExponential::translate(RooFit::Detail::CodeSquashContext &ctx) const
 {
-   // Build a call to the stateless gaussian defined later.
-   ctx.addResult(this, "std::exp(" + ctx.getResult(c) + " * " + ctx.getResult(x) + ")");
+   // Build a call to the stateless exponential defined later.
+   std::string coef;
+   if(_negateCoefficient) {
+       coef += "-";
+   }
+   coef += ctx.getResult(c);
+   ctx.addResult(this, "std::exp(" + coef + " * " + ctx.getResult(x) + ")");
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 std::string RooExponential::buildCallToAnalyticIntegral(Int_t code, const char *rangeName,
-                                                     RooFit::Detail::CodeSquashContext &ctx) const
+                                                        RooFit::Detail::CodeSquashContext &ctx) const
 {
-   auto& constant  = code == 1 ? c : x;
-   auto& integrand = code == 1 ? x : c;
+   bool isOverX = code == 1;
 
-   return ctx.buildCall("RooFit::Detail::AnalyticalIntegrals::exponentialIntegral",
-                        integrand.min(rangeName), integrand.max(rangeName), constant);
+   std::string constant;
+   if (_negateCoefficient && isOverX) {
+      constant += "-";
+   }
+   constant += ctx.getResult(isOverX ? c : x);
+
+   auto &integrand = isOverX ? x : c;
+
+   double min = integrand.min(rangeName);
+   double max = integrand.max(rangeName);
+
+   if (!isOverX && _negateCoefficient) {
+      std::swap(min, max);
+      min = -min;
+      max = -max;
+   }
+
+   return ctx.buildCall("RooFit::Detail::AnalyticalIntegrals::exponentialIntegral", min, max, constant);
 }

--- a/roofit/roofit/src/RooLognormal.cxx
+++ b/roofit/roofit/src/RooLognormal.cxx
@@ -1,12 +1,12 @@
- /*****************************************************************************
-  * Project: RooFit                                                           *
-  * @(#)root/roofit:$Id$ *
-  *                                                                           *
-  * RooFit Lognormal PDF                                                      *
-  *                                                                           *
-  * Author: Gregory Schott and Stefan Schmitz                                 *
-  *                                                                           *
-  *****************************************************************************/
+/*****************************************************************************
+ * Project: RooFit                                                           *
+ * @(#)root/roofit:$Id$ *
+ *                                                                           *
+ * RooFit Lognormal PDF                                                      *
+ *                                                                           *
+ * Author: Gregory Schott and Stefan Schmitz                                 *
+ *                                                                           *
+ *****************************************************************************/
 
 /** \class RooLognormal
     \ingroup Roofit
@@ -16,8 +16,8 @@ RooFit Lognormal PDF. The two parameters are:
   - `k = exp(sigma)`: sigma is called the shape parameter in the TMath parameterization
 
 \f[
-  \mathrm{RooLognormal}(x \, | \, m_0, k) = \frac{1}{\sqrt{2\pi \cdot \ln(k) \cdot x}} \cdot \exp\left( \frac{-\ln^2(\frac{x}{m_0})}{2 \ln^2(k)} \right)
-\f]
+  \mathrm{RooLognormal}(x \, | \, m_0, k) = \frac{1}{\sqrt{2\pi \cdot \ln(k) \cdot x}} \cdot \exp\left(
+\frac{-\ln^2(\frac{x}{m_0})}{2 \ln^2(k)} \right) \f]
 
 The parameterization here is physics driven and differs from the ROOT::Math::lognormal_pdf() in `x,m,s,x0` with:
   - `m = log(m0)`
@@ -37,29 +37,24 @@ ClassImp(RooLognormal);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooLognormal::RooLognormal(const char *name, const char *title,
-          RooAbsReal& _x, RooAbsReal& _m0,
-          RooAbsReal& _k) :
-  RooAbsPdf(name,title),
-  x("x","Observable",this,_x),
-  m0("m0","m0",this,_m0),
-  k("k","k",this,_k)
+RooLognormal::RooLognormal(const char *name, const char *title, RooAbsReal &_x, RooAbsReal &_m0, RooAbsReal &_k)
+   : RooAbsPdf(name, title), x("x", "Observable", this, _x), m0("m0", "m0", this, _m0), k("k", "k", this, _k)
 {
-    RooHelpers::checkRangeOfParameters(this, {&_x, &_m0, &_k}, 0.);
+   RooHelpers::checkRangeOfParameters(this, {&_x, &_m0, &_k}, 0.);
 
-    auto par = dynamic_cast<const RooAbsRealLValue*>(&_k);
-    if (par && par->getMin()<=1 && par->getMax()>=1 ) {
+   auto par = dynamic_cast<const RooAbsRealLValue *>(&_k);
+   if (par && par->getMin() <= 1 && par->getMax() >= 1) {
       coutE(InputArguments) << "The parameter '" << par->GetName() << "' with range [" << par->getMin("") << ", "
-          << par->getMax() << "] of the " << this->ClassName() << " '" << this->GetName()
-          << "' can reach the unsafe value 1.0 " << ". Advise to limit its range." << std::endl;
-    }
+                            << par->getMax() << "] of the " << this->ClassName() << " '" << this->GetName()
+                            << "' can reach the unsafe value 1.0 "
+                            << ". Advise to limit its range." << std::endl;
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooLognormal::RooLognormal(const RooLognormal& other, const char* name) :
-  RooAbsPdf(other,name), x("x",this,other.x), m0("m0",this,other.m0),
-  k("k",this,other.k)
+RooLognormal::RooLognormal(const RooLognormal &other, const char *name)
+   : RooAbsPdf(other, name), x("x", this, other.x), m0("m0", this, other.m0), k("k", this, other.k)
 {
 }
 
@@ -71,10 +66,10 @@ RooLognormal::RooLognormal(const RooLognormal& other, const char* name) :
 
 double RooLognormal::evaluate() const
 {
-  double ln_k = TMath::Abs(TMath::Log(k));
-  double ln_m0 = TMath::Log(m0);
+   double ln_k = TMath::Abs(TMath::Log(k));
+   double ln_m0 = TMath::Log(m0);
 
-  return ROOT::Math::lognormal_pdf(x,ln_m0,ln_k);
+   return ROOT::Math::lognormal_pdf(x, ln_m0, ln_k);
 }
 
 void RooLognormal::translate(RooFit::Detail::CodeSquashContext &ctx) const
@@ -84,32 +79,34 @@ void RooLognormal::translate(RooFit::Detail::CodeSquashContext &ctx) const
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute multiple values of Lognormal distribution.
-void RooLognormal::computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const& dataMap) const
+void RooLognormal::computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &dataMap) const
 {
    RooBatchCompute::compute(dataMap.config(this), RooBatchCompute::Lognormal, output, nEvents,
-          {dataMap.at(x), dataMap.at(m0), dataMap.at(k)});
+                            {dataMap.at(x), dataMap.at(m0), dataMap.at(k)});
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Int_t RooLognormal::getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* /*rangeName*/) const
+Int_t RooLognormal::getAnalyticalIntegral(RooArgSet &allVars, RooArgSet &analVars, const char * /*rangeName*/) const
 {
-  if (matchArgs(allVars,analVars,x)) return 1 ;
-  return 0 ;
+   if (matchArgs(allVars, analVars, x))
+      return 1;
+   return 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-double RooLognormal::analyticalIntegral(Int_t code, const char* rangeName) const
+double RooLognormal::analyticalIntegral(Int_t code, const char *rangeName) const
 {
-  R__ASSERT(code==1) ;
+   R__ASSERT(code == 1);
 
-  static const double root2 = sqrt(2.) ;
+   static const double root2 = sqrt(2.);
 
-  double ln_k = TMath::Abs(TMath::Log(k));
-  double ret = 0.5*( RooMath::erf( TMath::Log(x.max(rangeName)/m0)/(root2*ln_k) ) - RooMath::erf( TMath::Log(x.min(rangeName)/m0)/(root2*ln_k) ) ) ;
+   double ln_k = TMath::Abs(TMath::Log(k));
+   double ret = 0.5 * (RooMath::erf(TMath::Log(x.max(rangeName) / m0) / (root2 * ln_k)) -
+                       RooMath::erf(TMath::Log(x.min(rangeName) / m0) / (root2 * ln_k)));
 
-  return ret ;
+   return ret;
 }
 
 std::string
@@ -123,26 +120,27 @@ RooLognormal::buildCallToAnalyticIntegral(int code, const char *rangeName, RooFi
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Int_t RooLognormal::getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, bool /*staticInitOK*/) const
+Int_t RooLognormal::getGenerator(const RooArgSet &directVars, RooArgSet &generateVars, bool /*staticInitOK*/) const
 {
-  if (matchArgs(directVars,generateVars,x)) return 1 ;
-  return 0 ;
+   if (matchArgs(directVars, generateVars, x))
+      return 1;
+   return 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 void RooLognormal::generateEvent(Int_t code)
 {
-  R__ASSERT(code==1) ;
+   R__ASSERT(code == 1);
 
-  double xgen ;
-  while(true) {
-    xgen = TMath::Exp(RooRandom::randomGenerator()->Gaus(TMath::Log(m0),TMath::Log(k)));
-    if (xgen<=x.max() && xgen>=x.min()) {
-      x = xgen ;
-      break;
-    }
-  }
+   double xgen;
+   while (true) {
+      xgen = TMath::Exp(RooRandom::randomGenerator()->Gaus(TMath::Log(m0), TMath::Log(k)));
+      if (xgen <= x.max() && xgen >= x.min()) {
+         x = xgen;
+         break;
+      }
+   }
 
-  return;
+   return;
 }

--- a/roofit/roofit/src/RooLognormal.cxx
+++ b/roofit/roofit/src/RooLognormal.cxx
@@ -74,8 +74,7 @@ double RooLognormal::evaluate() const
   double ln_k = TMath::Abs(TMath::Log(k));
   double ln_m0 = TMath::Log(m0);
 
-  double ret = ROOT::Math::lognormal_pdf(x,ln_m0,ln_k);
-  return ret ;
+  return ROOT::Math::lognormal_pdf(x,ln_m0,ln_k);
 }
 
 void RooLognormal::translate(RooFit::Detail::CodeSquashContext &ctx) const

--- a/roofit/roofit/src/RooLognormal.cxx
+++ b/roofit/roofit/src/RooLognormal.cxx
@@ -37,16 +37,22 @@ ClassImp(RooLognormal);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooLognormal::RooLognormal(const char *name, const char *title, RooAbsReal &_x, RooAbsReal &_m0, RooAbsReal &_k)
-   : RooAbsPdf(name, title), x("x", "Observable", this, _x), m0("m0", "m0", this, _m0), k("k", "k", this, _k)
+RooLognormal::RooLognormal(const char *name, const char *title, RooAbsReal &_x, RooAbsReal &_m0, RooAbsReal &_k,
+                           bool useStandardParametrization)
+   : RooAbsPdf{name, title},
+     x{"x", "Observable", this, _x},
+     m0{"m0", "m0", this, _m0},
+     k{"k", "k", this, _k},
+     _useStandardParametrization{useStandardParametrization}
 {
    RooHelpers::checkRangeOfParameters(this, {&_x, &_m0, &_k}, 0.);
 
    auto par = dynamic_cast<const RooAbsRealLValue *>(&_k);
-   if (par && par->getMin() <= 1 && par->getMax() >= 1) {
+   const double unsafeValue = useStandardParametrization ? 0.0 : 1.0;
+   if (par && par->getMin() <= unsafeValue && par->getMax() >= unsafeValue) {
       coutE(InputArguments) << "The parameter '" << par->GetName() << "' with range [" << par->getMin("") << ", "
                             << par->getMax() << "] of the " << this->ClassName() << " '" << this->GetName()
-                            << "' can reach the unsafe value 1.0 "
+                            << "' can reach the unsafe value " << unsafeValue << " "
                             << ". Advise to limit its range." << std::endl;
    }
 }
@@ -54,7 +60,11 @@ RooLognormal::RooLognormal(const char *name, const char *title, RooAbsReal &_x, 
 ////////////////////////////////////////////////////////////////////////////////
 
 RooLognormal::RooLognormal(const RooLognormal &other, const char *name)
-   : RooAbsPdf(other, name), x("x", this, other.x), m0("m0", this, other.m0), k("k", this, other.k)
+   : RooAbsPdf(other, name),
+     x("x", this, other.x),
+     m0("m0", this, other.m0),
+     k{"k", this, other.k},
+     _useStandardParametrization{other._useStandardParametrization}
 {
 }
 
@@ -66,22 +76,24 @@ RooLognormal::RooLognormal(const RooLognormal &other, const char *name)
 
 double RooLognormal::evaluate() const
 {
-   double ln_k = TMath::Abs(TMath::Log(k));
-   double ln_m0 = TMath::Log(m0);
+   const double ln_k = std::abs(_useStandardParametrization ? k : std::log(k));
+   const double ln_m0 = _useStandardParametrization ? m0 : std::log(m0);
 
    return ROOT::Math::lognormal_pdf(x, ln_m0, ln_k);
 }
 
 void RooLognormal::translate(RooFit::Detail::CodeSquashContext &ctx) const
 {
-   ctx.addResult(this, ctx.buildCall("RooFit::Detail::EvaluateFuncs::logNormalEvaluate", x, k, m0));
+   std::string funcName = _useStandardParametrization ? "logNormalEvaluateStandard" : "logNormalEvaluate";
+   ctx.addResult(this, ctx.buildCall("RooFit::Detail::EvaluateFuncs::" + funcName, x, k, m0));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute multiple values of Lognormal distribution.
 void RooLognormal::computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &dataMap) const
 {
-   RooBatchCompute::compute(dataMap.config(this), RooBatchCompute::Lognormal, output, nEvents,
+   auto computer = _useStandardParametrization ? RooBatchCompute::LognormalStandard : RooBatchCompute::Lognormal;
+   RooBatchCompute::compute(dataMap.config(this), computer, output, nEvents,
                             {dataMap.at(x), dataMap.at(m0), dataMap.at(k)});
 }
 
@@ -89,53 +101,45 @@ void RooLognormal::computeBatch(double *output, size_t nEvents, RooFit::Detail::
 
 Int_t RooLognormal::getAnalyticalIntegral(RooArgSet &allVars, RooArgSet &analVars, const char * /*rangeName*/) const
 {
-   if (matchArgs(allVars, analVars, x))
-      return 1;
-   return 0;
+   return matchArgs(allVars, analVars, x) ? 1 : 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-double RooLognormal::analyticalIntegral(Int_t code, const char *rangeName) const
+double RooLognormal::analyticalIntegral(Int_t /*code*/, const char *rangeName) const
 {
-   R__ASSERT(code == 1);
+   static const double root2 = std::sqrt(2.);
 
-   static const double root2 = sqrt(2.);
-
-   double ln_k = TMath::Abs(TMath::Log(k));
-   double ret = 0.5 * (RooMath::erf(TMath::Log(x.max(rangeName) / m0) / (root2 * ln_k)) -
-                       RooMath::erf(TMath::Log(x.min(rangeName) / m0) / (root2 * ln_k)));
-
-   return ret;
+   double ln_k = std::abs(_useStandardParametrization ? k : std::log(k));
+   double scaledMin = _useStandardParametrization ? std::log(x.min(rangeName)) - m0 : std::log(x.min(rangeName) / m0);
+   double scaledMax = _useStandardParametrization ? std::log(x.max(rangeName)) - m0 : std::log(x.max(rangeName) / m0);
+   return 0.5 * (RooMath::erf(scaledMax / (root2 * ln_k)) - RooMath::erf(scaledMin / (root2 * ln_k)));
 }
 
-std::string
-RooLognormal::buildCallToAnalyticIntegral(int code, const char *rangeName, RooFit::Detail::CodeSquashContext &ctx) const
+std::string RooLognormal::buildCallToAnalyticIntegral(int /*code*/, const char *rangeName,
+                                                      RooFit::Detail::CodeSquashContext &ctx) const
 {
-   R__ASSERT(code == 1);
-
-   return ctx.buildCall("RooFit::Detail::AnalyticalIntegrals::logNormalIntegral", x.min(rangeName), x.max(rangeName),
-                        m0, k);
+   std::string funcName = _useStandardParametrization ? "logNormalIntegralStandard" : "logNormalIntegral";
+   return ctx.buildCall("RooFit::Detail::AnalyticalIntegrals::" + funcName, x.min(rangeName), x.max(rangeName), m0, k);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 Int_t RooLognormal::getGenerator(const RooArgSet &directVars, RooArgSet &generateVars, bool /*staticInitOK*/) const
 {
-   if (matchArgs(directVars, generateVars, x))
-      return 1;
-   return 0;
+   return matchArgs(directVars, generateVars, x) ? 1 : 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void RooLognormal::generateEvent(Int_t code)
+void RooLognormal::generateEvent(Int_t /*code*/)
 {
-   R__ASSERT(code == 1);
+   const double ln_k = std::abs(_useStandardParametrization ? k : std::log(k));
+   const double ln_m0 = _useStandardParametrization ? m0 : std::log(m0);
 
    double xgen;
    while (true) {
-      xgen = TMath::Exp(RooRandom::randomGenerator()->Gaus(TMath::Log(m0), TMath::Log(k)));
+      xgen = std::exp(RooRandom::randomGenerator()->Gaus(ln_m0, ln_k));
       if (xgen <= x.max() && xgen >= x.min()) {
          x = xgen;
          break;

--- a/roofit/roofitcore/inc/RooAddPdf.h
+++ b/roofit/roofitcore/inc/RooAddPdf.h
@@ -33,7 +33,7 @@ class AddCacheElem;
 class RooAddPdf : public RooAbsPdf {
 public:
 
-  RooAddPdf() : _projCacheMgr(this,10) { TRACE_CREATE }
+  RooAddPdf() : _projCacheMgr(this,10) { TRACE_CREATE; }
   RooAddPdf(const char *name, const char *title=nullptr);
   RooAddPdf(const char *name, const char *title,
             RooAbsPdf& pdf1, RooAbsPdf& pdf2, RooAbsReal& coef1) ;
@@ -42,7 +42,7 @@ public:
 
   RooAddPdf(const RooAddPdf& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooAddPdf(*this,newname) ; }
-  ~RooAddPdf() override { TRACE_DESTROY }
+  ~RooAddPdf() override { TRACE_DESTROY; }
 
   bool checkObservables(const RooArgSet* nset) const override;
 
@@ -79,7 +79,7 @@ public:
   void fixCoefNormalization(const RooArgSet& refCoefNorm) ;
   void fixCoefRange(const char* rangeName) ;
 
-  const RooArgSet& getCoefNormalization() const { return _refCoefNorm ; }
+  const RooArgSet& getCoefNormalization() const;
   const char* getCoefRange() const { return _refCoefRangeName?RooNameReg::str(_refCoefRangeName):"" ; }
 
   void resetErrorCounters(Int_t resetValue=10) override;
@@ -146,6 +146,7 @@ private:
   mutable std::unique_ptr<const RooArgSet> _copyOfLastNormSet = nullptr; ///<!
 
   void finalizeConstruction();
+  void materializeRefCoefNormFromAttribute() const;
 
   ClassDefOverride(RooAddPdf,5) // PDF representing a sum of PDFs
 };

--- a/roofit/roofitcore/inc/RooFit/Detail/AnalyticalIntegrals.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/AnalyticalIntegrals.h
@@ -236,11 +236,22 @@ poissonIntegral(int code, double mu, double x, double integrandMin, double integ
 
 inline double logNormalIntegral(double xMin, double xMax, double m0, double k)
 {
-   double root2 = std::sqrt(2.);
+   const double root2 = std::sqrt(2.);
 
-   double ln_k = TMath::Abs(TMath::Log(k));
+   double ln_k = TMath::Abs(std::log(k));
    double ret =
-      0.5 * (TMath::Erf(TMath::Log(xMax / m0) / (root2 * ln_k)) - TMath::Erf(TMath::Log(xMin / m0) / (root2 * ln_k)));
+      0.5 * (TMath::Erf(std::log(xMax / m0) / (root2 * ln_k)) - TMath::Erf(std::log(xMin / m0) / (root2 * ln_k)));
+
+   return ret;
+}
+
+inline double logNormalIntegralStandard(double xMin, double xMax, double mu, double sigma)
+{
+   const double root2 = std::sqrt(2.);
+
+   double ln_k = std::abs(sigma);
+   double ret =
+      0.5 * (TMath::Erf((std::log(xMax) - mu) / (root2 * ln_k)) - TMath::Erf((std::log(xMin) - mu) / (root2 * ln_k)));
 
    return ret;
 }

--- a/roofit/roofitcore/inc/RooFit/Detail/EvaluateFuncs.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/EvaluateFuncs.h
@@ -221,11 +221,12 @@ piecewiseInterpolation(unsigned int code, double low, double high, double nomina
 
 inline double logNormalEvaluate(double x, double k, double m0)
 {
-   double ln_k = TMath::Abs(TMath::Log(k));
-   double ln_m0 = TMath::Log(m0);
+   return ROOT::Math::lognormal_pdf(x, std::log(m0), std::abs(std::log(k)));
+}
 
-   double ret = ROOT::Math::lognormal_pdf(x, ln_m0, ln_k);
-   return ret;
+inline double logNormalEvaluateStandard(double x, double sigma, double mu)
+{
+   return ROOT::Math::lognormal_pdf(x, mu, std::abs(sigma));
 }
 
 } // namespace EvaluateFuncs

--- a/roofit/roofitcore/inc/RooHelpers.h
+++ b/roofit/roofitcore/inc/RooHelpers.h
@@ -134,7 +134,7 @@ std::pair<double, double> getRangeOrBinningInterval(RooAbsArg const* arg, const 
 
 bool checkIfRangesOverlap(RooArgSet const& observables, std::vector<std::string> const& rangeNames);
 
-std::string getColonSeparatedNameString(RooArgSet const& argSet);
+std::string getColonSeparatedNameString(RooArgSet const& argSet, char delim=':');
 RooArgSet selectFromArgSet(RooArgSet const&, std::string const& names);
 
 namespace Detail {

--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -63,28 +63,32 @@ An (enforced) condition for this assumption is that each \f$ \mathrm{PDF}_i \f$ 
 
 */
 
-#include "RooAddPdf.h"
+#include <RooAddPdf.h>
 
-#include "RooAddition.h"
-#include "RooRealSumFunc.h"
+#include <RooAddGenContext.h>
+#include <RooAddition.h>
+#include <RooBatchCompute.h>
+#include <RooDataSet.h>
+#include <RooGenericPdf.h>
+#include <RooGlobalFunc.h>
+#include <RooHelpers.h>
+#include <RooProduct.h>
+#include <RooRatio.h>
+#include <RooRealConstant.h>
+#include <RooRealProxy.h>
+#include <RooRealSumFunc.h>
+#include <RooRealSumPdf.h>
+#include <RooRealVar.h>
+#include <RooRecursiveFraction.h>
+
 #include "RooAddHelpers.h"
-#include "RooAddGenContext.h"
-#include "RooBatchCompute.h"
-#include "RooDataSet.h"
-#include "RooGlobalFunc.h"
-#include "RooRealProxy.h"
-#include "RooRealVar.h"
-#include "RooRealConstant.h"
-#include "RooRealSumPdf.h"
-#include "RooRecursiveFraction.h"
-#include "RooGenericPdf.h"
-#include "RooProduct.h"
-#include "RooRatio.h"
+
+#include <ROOT/StringUtils.hxx>
 
 #include <algorithm>
 #include <memory>
-#include <sstream>
 #include <set>
+#include <sstream>
 
 ClassImp(RooAddPdf);
 
@@ -100,7 +104,7 @@ RooAddPdf::RooAddPdf(const char *name, const char *title) :
   _coefList("!coefficients","List of coefficients",this),
   _coefErrCount{_errorCount}
 {
-  TRACE_CREATE
+  TRACE_CREATE;
 }
 
 
@@ -296,7 +300,7 @@ RooAddPdf::RooAddPdf(const RooAddPdf& other, const char* name) :
 {
   _coefErrCount = _errorCount ;
   finalizeConstruction();
-  TRACE_CREATE
+  TRACE_CREATE;
 }
 
 
@@ -316,12 +320,53 @@ void RooAddPdf::fixCoefNormalization(const RooArgSet& refCoefNorm)
     return ;
   }
 
+   // Also set an attribute with this information, which is the easiest way to
+  // preserve this in the JSON IO.
+  setStringAttribute("ref_coef_norm", RooHelpers::getColonSeparatedNameString(refCoefNorm, ',').c_str());
+
   _refCoefNorm.removeAll() ;
   _refCoefNorm.add(refCoefNorm) ;
 
   _projCacheMgr.reset() ;
 }
 
+const RooArgSet &RooAddPdf::getCoefNormalization() const
+{
+   materializeRefCoefNormFromAttribute();
+   return _refCoefNorm;
+}
+
+// For the JSON IO, we are not storing the _refCoefNorm directly. Instead, it
+// is stored by names in a string attribute. This function should be called
+// internally before _refCoefNorm is used to materialize it from the attribute
+// if necessary.
+void RooAddPdf::materializeRefCoefNormFromAttribute() const
+{
+   // _refCoefNorm was already materialized
+   if (!_refCoefNorm.empty())
+      return;
+
+   std::vector<std::string> names;
+   if (auto attrib = getStringAttribute("ref_coef_norm")) {
+      names = ROOT::Split(attrib, ",", /*skipEmtpy=*/true);
+   } else {
+      return;
+   }
+
+   RooArgSet refCoefNorm;
+
+   RooArgSet serverSet;
+   RooHelpers::getSortedComputationGraph(*this, serverSet);
+   for (std::string const &name : names) {
+      if (RooAbsArg *arg = serverSet.find(name.c_str())) {
+         refCoefNorm.add(*arg);
+      } else {
+         throw std::runtime_error("Internal logic error in RooAddPdf::materializeRefCoefNormFromAttribute()");
+      }
+   }
+
+   const_cast<RooAddPdf *>(this)->fixCoefNormalization(refCoefNorm);
+}
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -365,13 +410,13 @@ AddCacheElem* RooAddPdf::getProjCache(const RooArgSet* nset, const RooArgSet* is
     return cache ;
   }
 
+  // Make sure _refCoefNorm is defined
+  materializeRefCoefNormFromAttribute();
+
   //Create new cache
   cache = new AddCacheElem{*this, _pdfList, _coefList, nset, iset, _refCoefNorm,
                            _refCoefRangeName ? RooNameReg::str(_refCoefRangeName) : "",
                            _verboseEval};
-  //std::cout << std::endl;
-  //cache->print();
-  //std::cout << std::endl;
 
   _projCacheMgr.setObj(nset,iset,cache,RooNameReg::ptr(normRange())) ;
 
@@ -415,6 +460,9 @@ std::pair<const RooArgSet*, AddCacheElem*> RooAddPdf::getNormAndCache(const RooA
   if(nset && nset->empty()) nset = nullptr;
 
   if (nset == nullptr) {
+    // Make sure _refCoefNorm is defined
+    materializeRefCoefNormFromAttribute();
+
     if (!_refCoefNorm.empty()) {
       nset = &_refCoefNorm ;
     }
@@ -580,6 +628,8 @@ bool RooAddPdf::checkObservables(const RooArgSet* nset) const
 Int_t RooAddPdf::getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars,
                 const RooArgSet* normSet, const char* rangeName) const
 {
+  // Make sure _refCoefNorm is defined
+  materializeRefCoefNormFromAttribute();
 
   RooArgSet allAnalVars(*std::unique_ptr<RooArgSet>{getObservables(allVars)}) ;
 
@@ -752,6 +802,9 @@ std::unique_ptr<RooAbsReal> RooAddPdf::createExpectedEventsFunc(const RooArgSet 
 
    RooArgList prodList;
 
+   // Make sure _refCoefNorm is defined
+   materializeRefCoefNormFromAttribute();
+
    if (!_allExtendable) {
       // If the _refCoefNorm is empty or it's equal to normSet anyway, this is not
       // a conditional pdf and we don't need to do any transformation. See also
@@ -806,6 +859,8 @@ std::unique_ptr<RooAbsReal> RooAddPdf::createExpectedEventsFunc(const RooArgSet 
 
 void RooAddPdf::selectNormalization(const RooArgSet* depSet, bool force)
 {
+  // Make sure _refCoefNorm is defined
+  materializeRefCoefNormFromAttribute();
 
   if (!force && !_refCoefNorm.empty()) {
     return ;
@@ -907,6 +962,9 @@ bool RooAddPdf::redirectServersHook(const RooAbsCollection & newServerList, bool
 std::unique_ptr<RooAbsArg>
 RooAddPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileContext &ctx) const
 {
+   // Make sure _refCoefNorm is defined
+   materializeRefCoefNormFromAttribute();
+
    auto newArg = std::unique_ptr<RooAbsReal>{static_cast<RooAbsReal *>(Clone())};
    ctx.markAsCompiled(*newArg);
 

--- a/roofit/roofitcore/src/RooHelpers.cxx
+++ b/roofit/roofitcore/src/RooHelpers.cxx
@@ -230,9 +230,9 @@ bool checkIfRangesOverlap(RooArgSet const& observables, std::vector<std::string>
 }
 
 
-/// Create a string with all sorted names of RooArgSet elements separated by colons.
+/// Create a string with all sorted names of RooArgSet elements separated by delimiters.
 /// \param[in] argSet The input RooArgSet.
-std::string getColonSeparatedNameString(RooArgSet const& argSet) {
+std::string getColonSeparatedNameString(RooArgSet const& argSet, char delim) {
 
   RooArgList tmp(argSet);
   tmp.sort();
@@ -240,7 +240,7 @@ std::string getColonSeparatedNameString(RooArgSet const& argSet) {
   std::string content;
   for(auto const& arg : tmp) {
     content += arg->GetName();
-    content += ":";
+    content += delim;
   }
   if(!content.empty()) {
     content.pop_back();

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -323,7 +323,7 @@ int RooMinimizer::minimize(const char *type, const char *alg)
    _fcn->Synchronize(_theFitter->Config().ParamsSettings());
 
    setMinimizerType(type);
-   _theFitter->Config().SetMinimizer(type, alg);
+   _theFitter->Config().SetMinimizer(_cfg.minimizerType.c_str(), alg);
 
    profileStart();
    {

--- a/roofit/roofitcore/test/testRooAbsPdf.cxx
+++ b/roofit/roofitcore/test/testRooAbsPdf.cxx
@@ -311,20 +311,18 @@ TEST_P(FitTest, ProblemsWith2DSimultaneousFit)
    // Complete model
    ws.factory("AddPdf::model({sig, sig_y, uniform2, uniform1}, {yield[100], yield, yield, yield})");
 
-   RooAbsPdf &model = *ws.pdf("model");
-
    // Define category to distinguish d0 and d0bar samples events
    RooCategory sample("sample", "sample", {{"cat0", 0}, {"cat1", 1}});
 
-   // Construct a dummy dataset
-   RooDataSet data("data", "data", RooArgSet(sample, *ws.var("x"), *ws.var("y")));
-
    // Construct a simultaneous pdf using category sample as index
    RooSimultaneous simPdf("simPdf", "simultaneous pdf", sample);
-   simPdf.addPdf(model, "cat0");
-   simPdf.addPdf(model, "cat1");
+   simPdf.addPdf(*ws.pdf("model"), "cat0");
+   simPdf.addPdf(*ws.pdf("model"), "cat1");
 
-   simPdf.fitTo(data, PrintLevel(-1), BatchMode(_batchMode));
+   // Construct a dummy dataset
+   std::unique_ptr<RooDataSet> data{simPdf.generate({sample, *ws.var("x"), *ws.var("y")})};
+
+   simPdf.fitTo(*data, PrintLevel(-1), BatchMode(_batchMode));
 }
 
 // Verifies that a server pdf gets correctly reevaluated when the normalization

--- a/roofit/roofitcore/test/testRooFuncWrapper.cxx
+++ b/roofit/roofitcore/test/testRooFuncWrapper.cxx
@@ -537,6 +537,18 @@ FactoryTestParams param8{"Lognormal",
                          1e-4,
                          /*randomizeParameters=*/true};
 
+FactoryTestParams param8p1{"LognormalStandard",
+                           [](RooWorkspace &ws) {
+                              ws.factory(
+                                 "Lognormal::model(x[1.0, 1.1, 10], mu[0.7, 0.1, 2.3], k[0.7, 0.1, 1.6], true)");
+                              ws.defineSet("observables", "x");
+                           },
+                           [](RooAbsPdf &pdf, RooAbsData &data, RooWorkspace &, std::string const &backend) {
+                              return std::unique_ptr<RooAbsReal>{pdf.createNLL(data, RooFit::BatchMode(backend))};
+                           },
+                           1e-4,
+                           /*randomizeParameters=*/true};
+
 FactoryTestParams param9{"Poisson",
                          [](RooWorkspace &ws) {
                             ws.factory("Poisson::model(x[5, 0, 10], mu[5, 0, 10])");
@@ -563,7 +575,7 @@ FactoryTestParams param10{"PoissonNoRounding",
                           /*randomizeParameters=*/true};
 
 INSTANTIATE_TEST_SUITE_P(RooFuncWrapper, FactoryTest,
-                         testing::Values(param1, param2, param3, param4, param5, param6, param7, param8, param9,
+                         testing::Values(param1, param2, param3, param4, param5, param6, param7, param8, param8p1, param9,
                                          param10),
                          [](testing::TestParamInfo<FactoryTest::ParamType> const &paramInfo) {
                             return paramInfo.param._name;

--- a/test/stressRooFit_tests.h
+++ b/test/stressRooFit_tests.h
@@ -1266,8 +1266,8 @@ public:
     RooChebychev bkg1("bkg1","Background 1",x,RooArgSet(a0,a1)) ;
 
     // Build expontential pdf
-    RooRealVar alpha("alpha","alpha",-1) ;
-    RooExponential bkg2("bkg2","Background 2",x,alpha) ;
+    RooRealVar alpha("alpha","alpha", 1) ;
+    RooExponential bkg2("bkg2","Background 2",x,alpha, true);
 
     // Sum the background components into a composite background p.d.f.
     RooRealVar bkg1frac("bkg1frac","fraction of component 1 in background",0.8,0.,1.) ;

--- a/tutorials/roofit/rf515_hfJSON.json
+++ b/tutorials/roofit/rf515_hfJSON.json
@@ -1,7 +1,7 @@
 {
     "misc": {
         "ROOT_internal": {
-            "combined_datas": {
+            "combined_datasets": {
                 "observed" : {
                     "index_cat": "channelCat",
                     "indices": [0],


### PR DESCRIPTION
# This Pull request:

Changes the parametrization of some of the PDFs and a few of their keys.

In the process, a mechanism for automatic reparametrization is introduced.

## Changes or fixes:

- the HS3 implementation of RooExponential should invert the meaning of "c", such that the JSON represenation reads "-c" rather than "c"
- RooPoisson should write out & read "noRounding" as "integer" 
- lognormal should be adjusted to adhere to the standard definition by transforming the variables 
- rename multinormal_dist to multivariate_normal_dist
- "bounds" now called "edges" for irregular binned histograms

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes # 

