### PR TITLE
[RF] Consistent RooCmdArg names for all `RooFit::Import()` overloads

### DIFF
--- a/roofit/roofitcore/src/RooGlobalFunc.cxx
+++ b/roofit/roofitcore/src/RooGlobalFunc.cxx
@@ -294,11 +294,11 @@ RooCmdArg Index(RooCategory &icat)
 }
 RooCmdArg Import(const char *state, TH1 &histo)
 {
-   return RooCmdArg("ImportHistoSlice", 0, 0, 0, 0, state, nullptr, &histo, nullptr);
+   return RooCmdArg("ImportDataSlice", 0, 0, 0, 0, state, nullptr, &histo, nullptr);
 }
 RooCmdArg Import(const char *state, RooDataHist &dhist)
 {
-   return RooCmdArg("ImportDataHistSlice", 0, 0, 0, 0, state, nullptr, &dhist, nullptr);
+   return RooCmdArg("ImportDataSlice", 0, 0, 0, 0, state, nullptr, &dhist, nullptr);
 }
 RooCmdArg Import(TH1 &histo, bool importDensity)
 {
@@ -307,11 +307,11 @@ RooCmdArg Import(TH1 &histo, bool importDensity)
 
 RooCmdArg Import(const std::map<std::string, RooDataHist *> &arg)
 {
-   return processMap("ImportDataHistSliceMany", processImportItem<RooDataHist>, arg);
+   return processMap("ImportDataSliceMany", processImportItem<RooDataHist>, arg);
 }
 RooCmdArg Import(const std::map<std::string, TH1 *> &arg)
 {
-   return processMap("ImportHistoSliceMany", processImportItem<TH1>, arg);
+   return processMap("ImportDataSliceMany", processImportItem<TH1>, arg);
 }
 
 // RooDataSet::ctor arguments


### PR DESCRIPTION
There are different overloads of `RooFit::Import()` for importing different object types to RooFit dataset classes.

However, they return a `RooCmdArg` that is named after the type of the imported object. That causes some inconsistencies. For example, if you import a map of `std::unique_ptr<RooDataHist>`, the name will be different than for `RooDataHist*` because there is a special overload for the latter.

It is better to fixup this inconsistency, and then disentangle the different types in the functions that consume these `RooFit::Import()` command arguments.

This caused some trouble when importing RooDataHists into a combined dataset, which is why this fix is coming now.

These changes are covered by the tutorial tests.