### PR TITLE
[webgui] correctly use python processing thread in web widgets

### DIFF
--- a/bindings/pyroot/pythonizations/src/RPyROOTApplication.cxx
+++ b/bindings/pyroot/pythonizations/src/RPyROOTApplication.cxx
@@ -22,6 +22,8 @@
 #include "TError.h"
 #include "Getline.h"
 #include "TVirtualMutex.h"
+#include "TVirtualPad.h"
+#include "TROOT.h"
 
 ////////////////////////////////////////////////////////////////////////////
 /// \brief Create an RPyROOTApplication.
@@ -150,9 +152,9 @@ void PyROOT::RPyROOTApplication::InitROOTMessageCallback()
 PyObject *PyROOT::RPyROOTApplication::InitApplication(PyObject * /*self*/, PyObject *args)
 {
    int argc = PyTuple_GET_SIZE(args);
-   if (argc == 1) { 
-      PyObject *ignoreCmdLineOpts = PyTuple_GetItem(args, 0); 
-      
+   if (argc == 1) {
+      PyObject *ignoreCmdLineOpts = PyTuple_GetItem(args, 0);
+
       if (!PyBool_Check(ignoreCmdLineOpts)) {
          PyErr_SetString(PyExc_TypeError, "Expected boolean type as argument.");
          return nullptr;
@@ -197,6 +199,8 @@ static int EventInputHook()
    // This method is supposed to be called from CPython's command line and
    // drives the GUI
    PyEval_RestoreThread(sInputHookEventThreadState);
+   if (gROOT->IsWebDisplay() && gPad)
+      gPad->UpdateAsync();
    gSystem->ProcessEvents();
    PyEval_SaveThread();
 

--- a/gui/browserv7/src/RBrowser.cxx
+++ b/gui/browserv7/src/RBrowser.cxx
@@ -699,7 +699,8 @@ void RBrowser::SendInitMsg(unsigned connid)
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-/// Return the current directory of ROOT
+/// Send generic progress message to the web window
+/// Should show progress bar on client side
 
 void RBrowser::SendProgress(unsigned connid, float progr)
 {

--- a/gui/webdisplay/inc/ROOT/RWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindow.hxx
@@ -135,6 +135,7 @@ private:
    std::string fPanelName;                          ///<! panel name which should be shown in the window
    unsigned fId{0};                                 ///<! unique identifier
    bool fUseServerThreads{false};                   ///<! indicates that server thread is using, no special window thread
+   bool fUseProcessEvents{false};                   ///<! all window functionality will run through process events
    bool fProcessMT{false};                          ///<! if window event processing performed in dedicated thread
    bool fSendMT{false};                             ///<! true is special threads should be used for sending data
    std::shared_ptr<RWebWindowWSHandler> fWSHandler; ///<! specialize websocket handler for all incoming connections
@@ -223,8 +224,6 @@ private:
    unsigned MakeHeadless(bool create_new = false);
 
    unsigned FindHeadlessConnection();
-
-   void CheckThreadAssign();
 
    static std::function<bool(const std::shared_ptr<RWebWindow> &, unsigned, const std::string &)> gStartDialogFunc;
 

--- a/gui/webdisplay/inc/ROOT/RWebWindowsManager.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindowsManager.hxx
@@ -69,8 +69,6 @@ private:
 
    bool CreateServer(bool with_http = false);
 
-   void AssignWindowThreadId(RWebWindow &win);
-
    bool InformListener(const std::string &msg);
 
 public:

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -1060,9 +1060,7 @@ void RWebWindow::CheckDataToSend(bool only_once)
 
 void RWebWindow::Sync()
 {
-   // do not invoke callbacks from sync method, only server process events is relevant
-   if (!fUseProcessEvents)
-      InvokeCallbacks();
+   InvokeCallbacks();
 
    CheckDataToSend();
 

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -676,16 +676,6 @@ std::string RWebWindow::GetConnToken() const
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
-/// Internal method to verify and thread id has to be assigned from manager again
-/// Special case when ProcessMT was enabled just until thread id will be assigned
-
-void RWebWindow::CheckThreadAssign()
-{
-   if (fProcessMT && fMgr->fExternalProcessEvents)
-      fMgr->AssignWindowThreadId(*this);
-}
-
-//////////////////////////////////////////////////////////////////////////////////////////
 /// Processing of websockets call-backs, invoked from RWebWindowWSHandler
 /// Method invoked from http server thread, therefore appropriate mutex must be used on all relevant data
 
@@ -855,6 +845,7 @@ bool RWebWindow::ProcessWS(THttpCallArg &arg)
    if (nchannel == 0) {
       // special system channel
       if ((cdata.compare(0, 6, "READY=") == 0) && !conn->fReady) {
+
          std::string key = cdata.substr(6);
 
          if (key.empty() && IsNativeOnlyConn()) {
@@ -1069,7 +1060,9 @@ void RWebWindow::CheckDataToSend(bool only_once)
 
 void RWebWindow::Sync()
 {
-   InvokeCallbacks();
+   // do not invoke callbacks from sync method, only server process events is relevant
+   if (!fUseProcessEvents)
+      InvokeCallbacks();
 
    CheckDataToSend();
 
@@ -1479,6 +1472,7 @@ void RWebWindow::SendBinary(unsigned connid, const void *data, std::size_t len)
 void RWebWindow::AssignThreadId()
 {
    fUseServerThreads = false;
+   fUseProcessEvents = false;
    fProcessMT = false;
    fCallbacksThrdIdSet = true;
    fCallbacksThrdId = std::this_thread::get_id();
@@ -1500,6 +1494,7 @@ void RWebWindow::AssignThreadId()
 void RWebWindow::UseServerThreads()
 {
    fUseServerThreads = true;
+   fUseProcessEvents = false;
    fCallbacksThrdIdSet = false;
    fProcessMT = true;
 }
@@ -1564,7 +1559,8 @@ void RWebWindow::StopThread()
 
 void RWebWindow::SetDataCallBack(WebWindowDataCallback_t func)
 {
-   if (!fUseServerThreads) AssignThreadId();
+   if (!fUseServerThreads && !fUseProcessEvents)
+      AssignThreadId();
    fDataCallback = func;
 }
 
@@ -1573,7 +1569,8 @@ void RWebWindow::SetDataCallBack(WebWindowDataCallback_t func)
 
 void RWebWindow::SetConnectCallBack(WebWindowConnectCallback_t func)
 {
-   if (!fUseServerThreads) AssignThreadId();
+   if (!fUseServerThreads && !fUseProcessEvents)
+      AssignThreadId();
    fConnCallback = func;
 }
 
@@ -1582,7 +1579,8 @@ void RWebWindow::SetConnectCallBack(WebWindowConnectCallback_t func)
 
 void RWebWindow::SetDisconnectCallBack(WebWindowConnectCallback_t func)
 {
-   if (!fUseServerThreads) AssignThreadId();
+   if (!fUseServerThreads && !fUseProcessEvents)
+      AssignThreadId();
    fDisconnCallback = func;
 }
 
@@ -1600,7 +1598,8 @@ void RWebWindow::SetClearOnClose(const std::shared_ptr<void> &handle)
 
 void RWebWindow::SetCallBacks(WebWindowConnectCallback_t conn, WebWindowDataCallback_t data, WebWindowConnectCallback_t disconn)
 {
-   if (!fUseServerThreads) AssignThreadId();
+   if (!fUseServerThreads && !fUseProcessEvents)
+      AssignThreadId();
    fConnCallback = conn;
    fDataCallback = data;
    fDisconnCallback = disconn;

--- a/gui/webdisplay/src/RWebWindowWSHandler.hxx
+++ b/gui/webdisplay/src/RWebWindowWSHandler.hxx
@@ -127,9 +127,7 @@ public:
    Bool_t ProcessWS(THttpCallArg *arg) override
    {
       if (!arg || IsDisabled()) return kFALSE;
-      auto res = fWindow.ProcessWS(*arg);
-      fWindow.CheckThreadAssign();
-      return res;
+      return fWindow.ProcessWS(*arg);
    }
 
    /// Allow processing of WS actions in arbitrary thread

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -123,6 +123,8 @@ void RWebWindowsManager::AssignMainThrd()
 RWebWindowsManager::RWebWindowsManager()
 {
    fExternalProcessEvents = RWebWindowWSHandler::GetBoolEnv("WebGui.ExternalProcessEvents") == 1;
+   if (fExternalProcessEvents)
+      RWebWindowsManager::AssignMainThrd();
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -480,9 +482,12 @@ std::shared_ptr<RWebWindow> RWebWindowsManager::CreateWindow()
    }
 
    if (fExternalProcessEvents) {
-      // special mode when window communication done in THttpServer::ProcessRequests
-      // used only with python which has to provide such special thread
+      // special mode when window communication performed in THttpServer::ProcessRequests
+      // used only with python which create special thread - but is has to be ignored!!!
+      // therefore use main thread id to detect callbacks which are invoked only from that main thread
       win->fUseProcessEvents = true;
+      win->fCallbacksThrdIdSet = gWebWinMainThrdSet;
+      win->fCallbacksThrdId = gWebWinMainThrd;
    } else if (IsUseHttpThread())
       win->UseServerThreads();
 

--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -143,9 +143,9 @@ protected:
 
    virtual Bool_t IsJSSupportedClass(TObject *obj, Bool_t many_primitives = kFALSE);
 
-   Bool_t IsFirstConn(unsigned connid) const { return (connid != 0) && (fWebConn.size() > 0) && (fWebConn[0].fConnId == connid); }
+   Bool_t IsFirstConn(unsigned connid) const { return (connid != 0) && (fWebConn.size() > 1) && (fWebConn[1].fConnId == connid); }
 
-   Bool_t IsFirstDrawn() const { return (fWebConn.size() > 0) && (fWebConn[0].fDrawVersion > 0); }
+   Bool_t IsFirstDrawn() const { return (fWebConn.size() > 1) && (fWebConn[1].fDrawVersion > 0); }
 
    void ShowCmd(const std::string &arg, Bool_t show);
 

--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -64,6 +64,8 @@ protected:
       std::queue<std::string> fSend;   ///<! send queue, processed after sending draw data
 
       WebConn(unsigned id) : fConnId(id) {}
+      bool is_batch() const { return fConnId == 0; }
+      bool match(unsigned id) const { return !is_batch() && ((fConnId == id) || (id == 0)); }
       void reset()
       {
          fCheckedVersion = fSendVersion = fDrawVersion = 0;
@@ -135,7 +137,7 @@ protected:
 
    void AddSendQueue(unsigned connid, const std::string &msg);
 
-   void CheckDataToSend(unsigned connid = 0);
+   Bool_t CheckDataToSend(unsigned connid = 0);
 
    Bool_t WaitWhenCanvasPainted(Long64_t ver);
 

--- a/net/http/inc/THttpServer.h
+++ b/net/http/inc/THttpServer.h
@@ -36,6 +36,7 @@ protected:
    std::unique_ptr<TRootSniffer> fSniffer; ///<! sniffer provides access to ROOT objects hierarchy
    Bool_t fTerminated{kFALSE};          ///<! termination flag, disables all requests processing
    Long_t fMainThrdId{0};               ///<! id of the thread for processing requests
+   Long_t fProcessingThrdId{0};         ///<! id of the thread where events are recently processing
    Bool_t fOwnThread{kFALSE};           ///<! true when specialized thread allocated for processing requests
    std::thread fThrd;                   ///<! own thread
    Bool_t fWSOnly{kFALSE};              ///<! when true, handle only websockets / longpoll engine

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -37,17 +37,51 @@
 #include <fstream>
 #include <memory>
 #include <string>
+#include <thread>
 
 class THttpTimer : public TTimer {
+   Long_t fNormalTmout{0};
+   Bool_t fSlow{kFALSE};
+   Int_t fSlowCnt{0};
+
 public:
    THttpServer &fServer; ///!< server processing requests
 
    /// constructor
-   THttpTimer(Long_t milliSec, Bool_t mode, THttpServer &serv) : TTimer(milliSec, mode), fServer(serv) {}
+   THttpTimer(Long_t milliSec, Bool_t mode, THttpServer &serv) : TTimer(milliSec, mode), fNormalTmout(milliSec), fServer(serv) {}
+
+   void SetSlow(Bool_t flag)
+   {
+      fSlow = flag;
+      fSlowCnt = 0;
+      Long_t ms = fNormalTmout;
+      if (fSlow) {
+         if (ms < 100)
+            ms = 500;
+         else if (ms < 500)
+            ms = 3000;
+         else
+            ms = 10000;
+      }
+
+      SetTime(ms);
+   }
+   Bool_t IsSlow() const { return fSlow; }
 
    /// timeout handler
    /// used to process http requests in main ROOT thread
-   void Timeout() override { fServer.ProcessRequests(); }
+   void Timeout() override
+   {
+      Int_t nprocess = fServer.ProcessRequests();
+
+      if (nprocess > 0) {
+         fSlowCnt = 0;
+         if (IsSlow())
+            SetSlow(kFALSE);
+      } else if (!IsSlow() && (fSlowCnt++ > 10)) {
+           SetSlow(kTRUE);
+      }
+   }
 };
 
 
@@ -610,6 +644,9 @@ Bool_t THttpServer::ExecuteHttp(std::shared_ptr<THttpCallArg> arg)
       return kTRUE;
    }
 
+   if (fTimer && fTimer->IsSlow())
+      fTimer->SetSlow(kFALSE);
+
    // add call arg to the list
    std::unique_lock<std::mutex> lk(fMutex);
    fArgs.push(arg);
@@ -644,6 +681,8 @@ Bool_t THttpServer::SubmitHttp(std::shared_ptr<THttpCallArg> arg, Bool_t can_run
       return kTRUE;
    }
 
+   printf("Calling SubmitHttp\n");
+
    // add call arg to the list
    std::unique_lock<std::mutex> lk(fMutex);
    fArgs.push(arg);
@@ -662,13 +701,20 @@ Bool_t THttpServer::SubmitHttp(std::shared_ptr<THttpCallArg> arg, Bool_t can_run
 
 Int_t THttpServer::ProcessRequests()
 {
-   if (fMainThrdId == 0)
-      fMainThrdId = TThread::SelfId();
+   auto id = TThread::SelfId();
 
-   if (fMainThrdId != TThread::SelfId()) {
-      Error("ProcessRequests", "Should be called only from main ROOT thread");
+   if (fMainThrdId != id) {
+      if (fMainThrdId)
+         Error("ProcessRequests", "Changing main thread to %ld", (long)id);
+      fMainThrdId = id;
+   }
+
+   if (fProcessingThrdId) {
+      Error("ProcessRequests", "Processing already running from %ld thread", (long) fProcessingThrdId);
       return 0;
    }
+
+   fProcessingThrdId = id;
 
    Int_t cnt = 0;
 
@@ -714,6 +760,8 @@ Int_t THttpServer::ProcessRequests()
          engine->Terminate();
       engine->Process();
    }
+
+   fProcessingThrdId = 0;
 
    return cnt;
 }
@@ -1150,6 +1198,10 @@ Bool_t THttpServer::ExecuteWS(std::shared_ptr<THttpCallArg> &arg, Bool_t externa
       handler = dynamic_cast<THttpWSHandler *>(fSniffer->FindTObjectInHierarchy(arg->fPathName.Data()));
 
    if (external_thrd && (!handler || !handler->AllowMTProcess())) {
+
+      if (fTimer && fTimer->IsSlow())
+         fTimer->SetSlow(kFALSE);
+
       std::unique_lock<std::mutex> lk(fMutex);
       fArgs.push(arg);
       // and now wait until request is processed


### PR DESCRIPTION
pyROOT uses special thread for events processing, where `gSystem->ProcessEvents()` are called.
Both in script and interactive mode.

Problem that thread id is not known from beginning and changing once when running python in script mode.

Therefore special mode is now implemented, which simply uses `gSystem->ProcessEvents()` calls to allow processing
of web-windows communication. RWebWindow simply "trust" that ProcessEvents will not be called concurrently.

Also improve timeout handling in THttpServer and in TWebCanvas. Both using special timers to process their events.
While it is not always possible `TurnOn/TurnOff` timers (it fails from inside timeout handler), just increase/decrease timeout interval, but always let run timer.


