### PR TITLE
Reimplement TGraph::Sort using std::stable_sort

### DIFF
--- a/hist/hist/inc/TGraph.h
+++ b/hist/hist/inc/TGraph.h
@@ -53,6 +53,7 @@ protected:
 
    static void        SwapValues(Double_t* arr, Int_t pos1, Int_t pos2);
    virtual void       SwapPoints(Int_t pos1, Int_t pos2);
+   virtual void       UpdateArrays(const std::vector<Int_t> &sorting_indices, Int_t numSortedPoints, Int_t low);
 
    virtual Double_t **Allocate(Int_t newsize);
    Double_t         **AllocateArrays(Int_t Narrays, Int_t arraySize);

--- a/hist/hist/inc/TGraphAsymmErrors.h
+++ b/hist/hist/inc/TGraphAsymmErrors.h
@@ -32,6 +32,7 @@ protected:
    Double_t    *fEYhigh{nullptr};       ///<[fNpoints] array of Y high errors
 
    void       SwapPoints(Int_t pos1, Int_t pos2) override;
+   void       UpdateArrays(const std::vector<Int_t> &sorting_indices, Int_t numSortedPoints, Int_t low) override;
 
    Double_t** Allocate(Int_t size) override;
    void       CopyAndRelease(Double_t **newarrays,

--- a/hist/hist/inc/TGraphBentErrors.h
+++ b/hist/hist/inc/TGraphBentErrors.h
@@ -36,6 +36,7 @@ protected:
    Double_t    *fEYhighd;      ///<[fNpoints] array of Y high displacements
 
    void       SwapPoints(Int_t pos1, Int_t pos2) override;
+   void       UpdateArrays(const std::vector<Int_t> &sorting_indices, Int_t numSortedPoints, Int_t low) override;
 
    Double_t** Allocate(Int_t size) override;
    void       CopyAndRelease(Double_t **newarrays,

--- a/hist/hist/inc/TGraphErrors.h
+++ b/hist/hist/inc/TGraphErrors.h
@@ -30,6 +30,7 @@ protected:
    Double_t    *fEY{nullptr};    ///<[fNpoints] array of Y errors
 
    void       SwapPoints(Int_t pos1, Int_t pos2) override;
+   void       UpdateArrays(const std::vector<Int_t> &sorting_indices, Int_t numSortedPoints, Int_t low) override;
 
    Double_t** Allocate(Int_t size) override;
    void       CopyAndRelease(Double_t **newarrays,

--- a/hist/hist/inc/TGraphMultiErrors.h
+++ b/hist/hist/inc/TGraphMultiErrors.h
@@ -51,6 +51,7 @@ protected:
    void CalcYErrorsSum() const;
    Bool_t DoMerge(const TGraph *tg) override;
    void SwapPoints(Int_t pos1, Int_t pos2) override;
+   void UpdateArrays(const std::vector<Int_t> &sorting_indices, Int_t numSortedPoints, Int_t low) override;
 
 public:
    enum ESummationModes {

--- a/hist/hist/src/TGraph.cxx
+++ b/hist/hist/src/TGraph.cxx
@@ -39,6 +39,7 @@
 #include <iostream>
 #include <fstream>
 #include <cstring>
+#include <numeric>
 
 #include "HFitInterface.h"
 #include "Fit/DataRange.h"
@@ -2455,36 +2456,31 @@ Double_t **TGraph::ShrinkAndCopy(Int_t size, Int_t oend)
 ///   graph->Sort(&CompareErrors, kFALSE);
 /// ~~~
 
-void TGraph::Sort(Bool_t (*greaterfunc)(const TGraph*, Int_t, Int_t) /*=TGraph::CompareX()*/,
-                  Bool_t ascending /*=kTRUE*/, Int_t low /* =0 */, Int_t high /* =-1111 */)
+void TGraph::Sort(Bool_t (*greaterfunc)(const TGraph *, Int_t, Int_t) /*=TGraph::CompareX()*/,
+                  Bool_t ascending /*=kTRUE*/, Int_t low /*=0*/, Int_t high /*=-1111*/)
 {
-
    // set the bit in case of an ascending =sort in X
-   if (greaterfunc == TGraph::CompareX && ascending  && low == 0 && high == -1111)
+   if (greaterfunc == TGraph::CompareX && ascending && low == 0 && high == -1111)
       SetBit(TGraph::kIsSortedX);
 
-   if (high == -1111) high = GetN() - 1;
-   //  Termination condition
-   if (high <= low) return;
+   if (high == -1111)
+      high = fNpoints - 1;
 
-   int left, right;
-   left = low; // low is the pivot element
-   right = high;
-   while (left < right) {
-      // move left while item < pivot
-      while (left <= high && greaterfunc(this, left, low) != ascending)
-         left++;
-      // move right while item > pivot
-      while (right > low && greaterfunc(this, right, low) == ascending)
-         right--;
-      if (left < right && left < high && right > low)
-         SwapPoints(left, right);
-   }
-   // right is final position for the pivot
-   if (right > low)
-      SwapPoints(low, right);
-   Sort(greaterfunc, ascending, low, right - 1);
-   Sort(greaterfunc, ascending, right + 1, high);
+   // Create a vector to store the indices of the graph data points.
+   // We use std::vector<Int_t> instead of std::vector<ULong64_t> to match the input type
+   // required by the comparison operator's signature provided as `greaterfunc`
+   std::vector<Int_t> sorting_indices(fNpoints);
+   std::iota(sorting_indices.begin(), sorting_indices.end(), 0);
+
+   // Sort the indices using the provided comparison function
+   // We use std::stable_sort here because the libc++ implementation of std::sort
+   // is not standard-compliant until LLVM 14 which caused errors on the mac nodes
+   // of our CI, related issue: https://github.com/llvm/llvm-project/issues/21211
+   std::stable_sort(sorting_indices.begin() + low, sorting_indices.begin() + high + 1,
+             [&](const auto &left, const auto &right) { return greaterfunc(this, left, right) != ascending; });
+
+   Int_t numSortedPoints = high - low + 1;
+   UpdateArrays(sorting_indices, numSortedPoints, low);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2561,6 +2557,25 @@ void TGraph::SwapPoints(Int_t pos1, Int_t pos2)
 {
    SwapValues(fX, pos1, pos2);
    SwapValues(fY, pos1, pos2);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Update the fX and fY arrays with the sorted values.
+
+void TGraph::UpdateArrays(const std::vector<Int_t> &sorting_indices, Int_t numSortedPoints, Int_t low)
+{
+   std::vector<Double_t> fXSorted(numSortedPoints);
+   std::vector<Double_t> fYSorted(numSortedPoints);
+
+   // Fill the sorted X and Y values based on the sorted indices
+   std::generate(fXSorted.begin(), fXSorted.end(),
+                 [begin = low, &sorting_indices, this]() mutable { return fX[sorting_indices[begin++]]; });
+   std::generate(fYSorted.begin(), fYSorted.end(),
+                 [begin = low, &sorting_indices, this]() mutable { return fY[sorting_indices[begin++]]; });
+
+   // Copy the sorted X and Y values back to the original arrays
+   std::copy(fXSorted.begin(), fXSorted.end(), fX + low);
+   std::copy(fYSorted.begin(), fYSorted.end(), fY + low);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/TGraphAsymmErrors.cxx
+++ b/hist/hist/src/TGraphAsymmErrors.cxx
@@ -1456,3 +1456,32 @@ void TGraphAsymmErrors::SwapPoints(Int_t pos1, Int_t pos2)
    SwapValues(fEYhigh, pos1, pos2);
    TGraph::SwapPoints(pos1, pos2);
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// Update the fX, fY, fEXlow, fEXhigh, fEYlow and fEYhigh arrays with the sorted values.
+
+void TGraphAsymmErrors::UpdateArrays(const std::vector<Int_t> &sorting_indices, Int_t numSortedPoints, Int_t low)
+{
+   std::vector<Double_t> fEXlowSorted(numSortedPoints);
+   std::vector<Double_t> fEXhighSorted(numSortedPoints);
+   std::vector<Double_t> fEYlowSorted(numSortedPoints);
+   std::vector<Double_t> fEYhighSorted(numSortedPoints);
+
+   // Fill the sorted X and Y error values based on the sorted indices
+   std::generate(fEXlowSorted.begin(), fEXlowSorted.end(),
+                 [begin = low, &sorting_indices, this]() mutable { return fEXlow[sorting_indices[begin++]]; });
+   std::generate(fEXhighSorted.begin(), fEXhighSorted.end(),
+                 [begin = low, &sorting_indices, this]() mutable { return fEXhigh[sorting_indices[begin++]]; });
+   std::generate(fEYlowSorted.begin(), fEYlowSorted.end(),
+                 [begin = low, &sorting_indices, this]() mutable { return fEYlow[sorting_indices[begin++]]; });
+   std::generate(fEYhighSorted.begin(), fEYhighSorted.end(),
+                 [begin = low, &sorting_indices, this]() mutable { return fEYhigh[sorting_indices[begin++]]; });
+
+   // Copy the sorted X and Y error values back to the original arrays
+   std::copy(fEXlowSorted.begin(), fEXlowSorted.end(), fEXlow + low);
+   std::copy(fEXhighSorted.begin(), fEXhighSorted.end(), fEXhigh + low);
+   std::copy(fEYlowSorted.begin(), fEYlowSorted.end(), fEYlow + low);
+   std::copy(fEYhighSorted.begin(), fEYhighSorted.end(), fEYhigh + low);
+
+   TGraph::UpdateArrays(sorting_indices, numSortedPoints, low);
+}

--- a/hist/hist/src/TGraphBentErrors.cxx
+++ b/hist/hist/src/TGraphBentErrors.cxx
@@ -648,3 +648,52 @@ void TGraphBentErrors::SwapPoints(Int_t pos1, Int_t pos2)
 
    TGraph::SwapPoints(pos1, pos2);
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// Update the fX, fY, fEXlow, fEXhigh, fEXlowd, fEXhighd, fEYlow, fEYhigh, fEYlowd,  
+/// and fEYhighd arrays with the sorted values.
+
+void TGraphBentErrors::UpdateArrays(const std::vector<Int_t> &sorting_indices, Int_t numSortedPoints, Int_t low)
+{
+   std::vector<Double_t> fEXlowSorted(numSortedPoints);
+   std::vector<Double_t> fEXhighSorted(numSortedPoints);
+   std::vector<Double_t> fEXlowdSorted(numSortedPoints);
+   std::vector<Double_t> fEXhighdSorted(numSortedPoints);
+
+   std::vector<Double_t> fEYlowSorted(numSortedPoints);
+   std::vector<Double_t> fEYhighSorted(numSortedPoints);
+   std::vector<Double_t> fEYlowdSorted(numSortedPoints);
+   std::vector<Double_t> fEYhighdSorted(numSortedPoints);
+
+   // Fill the sorted X and Y error values based on the sorted indices
+   std::generate(fEXlowSorted.begin(), fEXlowSorted.end(),
+                 [begin = low, &sorting_indices, this]() mutable { return fEXlow[sorting_indices[begin++]]; });
+   std::generate(fEXhighSorted.begin(), fEXhighSorted.end(),
+                 [begin = low, &sorting_indices, this]() mutable { return fEXhigh[sorting_indices[begin++]]; });
+   std::generate(fEXlowdSorted.begin(), fEXlowdSorted.end(),
+                 [begin = low, &sorting_indices, this]() mutable { return fEXlowd[sorting_indices[begin++]]; });
+   std::generate(fEXhighdSorted.begin(), fEXhighdSorted.end(),
+                 [begin = low, &sorting_indices, this]() mutable { return fEXhighd[sorting_indices[begin++]]; });
+
+   std::generate(fEYlowSorted.begin(), fEYlowSorted.end(),
+                 [begin = low, &sorting_indices, this]() mutable { return fEYlow[sorting_indices[begin++]]; });
+   std::generate(fEYhighSorted.begin(), fEYhighSorted.end(),
+                 [begin = low, &sorting_indices, this]() mutable { return fEYhigh[sorting_indices[begin++]]; });
+   std::generate(fEYlowdSorted.begin(), fEYlowdSorted.end(),
+                 [begin = low, &sorting_indices, this]() mutable { return fEYlowd[sorting_indices[begin++]]; });
+   std::generate(fEYhighdSorted.begin(), fEYhighdSorted.end(),
+                 [begin = low, &sorting_indices, this]() mutable { return fEYhighd[sorting_indices[begin++]]; });
+
+   // Copy the sorted X and Y error values back to the original arrays
+   std::copy(fEXlowSorted.begin(), fEXlowSorted.end(), fEXlow + low);
+   std::copy(fEXhighSorted.begin(), fEXhighSorted.end(), fEXhigh + low);
+   std::copy(fEXlowdSorted.begin(), fEXlowdSorted.end(), fEXlowd + low);
+   std::copy(fEXhighdSorted.begin(), fEXhighdSorted.end(), fEXhighd + low);
+
+   std::copy(fEYlowSorted.begin(), fEYlowSorted.end(), fEYlow + low);
+   std::copy(fEYhighSorted.begin(), fEYhighSorted.end(), fEYhigh + low);
+   std::copy(fEYlowdSorted.begin(), fEYlowdSorted.end(), fEYlowd + low);
+   std::copy(fEYhighdSorted.begin(), fEYhighdSorted.end(), fEYhighd + low);
+
+   TGraph::UpdateArrays(sorting_indices, numSortedPoints, low);
+}

--- a/hist/hist/src/TGraphErrors.cxx
+++ b/hist/hist/src/TGraphErrors.cxx
@@ -842,7 +842,6 @@ void TGraphErrors::Streamer(TBuffer &b)
    }
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Swap points.
 
@@ -851,4 +850,25 @@ void TGraphErrors::SwapPoints(Int_t pos1, Int_t pos2)
    SwapValues(fEX, pos1, pos2);
    SwapValues(fEY, pos1, pos2);
    TGraph::SwapPoints(pos1, pos2);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Update the fX, fY, fEX, and fEY arrays with the sorted values.
+
+void TGraphErrors::UpdateArrays(const std::vector<Int_t> &sorting_indices, Int_t numSortedPoints, Int_t low)
+{
+   std::vector<Double_t> fEXSorted(numSortedPoints);
+   std::vector<Double_t> fEYSorted(numSortedPoints);
+
+   // Fill the sorted X and Y error values based on the sorted indices
+   std::generate(fEXSorted.begin(), fEXSorted.end(),
+                 [begin = low, &sorting_indices, this]() mutable { return fEX[sorting_indices[begin++]]; });
+   std::generate(fEYSorted.begin(), fEYSorted.end(),
+                 [begin = low, &sorting_indices, this]() mutable { return fEY[sorting_indices[begin++]]; });
+
+   // Copy the sorted X and Y error values back to the original arrays
+   std::copy(fEXSorted.begin(), fEXSorted.end(), fEX + low);
+   std::copy(fEYSorted.begin(), fEYSorted.end(), fEY + low);
+
+   TGraph::UpdateArrays(sorting_indices, numSortedPoints, low);
 }

--- a/hist/hist/src/TGraphMultiErrors.cxx
+++ b/hist/hist/src/TGraphMultiErrors.cxx
@@ -880,6 +880,38 @@ void TGraphMultiErrors::SwapPoints(Int_t pos1, Int_t pos2)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Update the fX, fY, fExL, fExH, fEyL and fEyH arrays with the sorted values.
+
+void TGraphMultiErrors::UpdateArrays(const std::vector<Int_t> &sorting_indices, Int_t numSortedPoints, Int_t low)
+{
+   std::vector<Double_t> fExLSorted(numSortedPoints);
+   std::vector<Double_t> fExHSorted(numSortedPoints);
+
+   std::generate(fExLSorted.begin(), fExLSorted.end(),
+                 [begin = low, &sorting_indices, this]() mutable { return fExL[sorting_indices[begin++]]; });
+   std::generate(fExHSorted.begin(), fExHSorted.end(),
+                 [begin = low, &sorting_indices, this]() mutable { return fExH[sorting_indices[begin++]]; });
+
+   std::copy(fExLSorted.begin(), fExLSorted.end(), fExL + low);
+   std::copy(fExHSorted.begin(), fExHSorted.end(), fExH + low);
+
+   for (Int_t j = 0; j < fNYErrors; j++) {
+      std::vector<Double_t> fEyLSorted(numSortedPoints);
+      std::vector<Double_t> fEyHSorted(numSortedPoints);
+
+      std::generate(fEyLSorted.begin(), fEyLSorted.end(),
+                  [begin = low, &sorting_indices, &j, this]() mutable { return fEyL[j].GetArray()[sorting_indices[begin++]]; });
+      std::generate(fEyHSorted.begin(), fEyHSorted.end(),
+                  [begin = low, &sorting_indices, &j, this]() mutable { return fEyL[j].GetArray()[sorting_indices[begin++]]; });
+
+      std::copy(fEyLSorted.begin(), fEyLSorted.end(), fEyL[j].GetArray() + low);
+      std::copy(fEyHSorted.begin(), fEyHSorted.end(), fEyL[j].GetArray() + low);
+   }
+
+   TGraph::UpdateArrays(sorting_indices, numSortedPoints, low);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Add a new y error to the graph and fill it with the values from `eyL` and `eyH`
 
 void TGraphMultiErrors::AddYError(Int_t np, const Double_t *eyL, const Double_t *eyH)

--- a/hist/hist/test/CMakeLists.txt
+++ b/hist/hist/test/CMakeLists.txt
@@ -17,6 +17,7 @@ ROOT_ADD_GTEST(TGraphMultiErrorsTests TGraphMultiErrorsTests.cxx LIBRARIES Hist 
 ROOT_ADD_GTEST(test_TF123_Moments test_TF123_Moments.cxx LIBRARIES Hist)
 ROOT_ADD_GTEST(test_THBinIterator test_THBinIterator.cxx LIBRARIES Hist)
 ROOT_ADD_GTEST(testTMultiGraphGetHistogram test_TMultiGraph_GetHistogram.cxx LIBRARIES Hist Gpad)
+ROOT_ADD_GTEST(testTGraphSorting test_TGraph_sorting.cxx LIBRARIES Hist)
 
 if(fftw3)
   ROOT_ADD_GTEST(testTF1 test_tf1.cxx LIBRARIES Hist)

--- a/hist/hist/test/test_TGraph_sorting.cxx
+++ b/hist/hist/test/test_TGraph_sorting.cxx
@@ -1,0 +1,155 @@
+#include "gtest/gtest.h"
+#include "TGraph.h"
+#include "TGraphErrors.h"
+#include "TGraphAsymmErrors.h"
+#include "TGraphMultiErrors.h"
+#include "TGraphBentErrors.h"
+
+#include <vector>
+
+TEST(TGraphSortTest, TGraphSortingTest)
+{
+   const int numEntries = 1000000;
+   std::vector<Double_t> x(numEntries);
+   std::vector<Double_t> y(numEntries);
+
+   // Initialize the graph data with unsorted data
+   for (int i = 0; i < numEntries; i++) {
+      x[i] = numEntries - i;
+      y[i] = x[i] * x[i];
+   }
+
+   TGraph graph(numEntries, x.data(), y.data());
+
+   graph.Sort();
+
+   // Check if the graph x values are sorted
+   bool isSorted = std::is_sorted(graph.GetX(), graph.GetX() + numEntries);
+
+   ASSERT_TRUE(isSorted);
+}
+
+TEST(TGraphSortTest, TGraphErrorsSortingTest)
+{
+    const int numEntries = 1000000;
+    std::vector<Double_t> x(numEntries);
+    std::vector<Double_t> y(numEntries);
+    std::vector<Double_t> errors(numEntries);
+
+    // Initialize the graph data with unsorted data
+    for (int i = 0; i < numEntries; i++) {
+        x[i] = numEntries - i;
+        y[i] = x[i] * x[i];
+        errors[i] = 1.0 / (i + 1);
+    }
+
+    TGraphErrors graphErr(numEntries, x.data(), y.data(), errors.data(), errors.data());
+
+    graphErr.Sort();
+
+    // Check if the graph x values are sorted
+    bool isValSorted = std::is_sorted(graphErr.GetX(), graphErr.GetX() + numEntries);
+
+    // Check if the graph errors are sorted based on the sorted values
+    bool isErrSorted = std::is_sorted(graphErr.GetEX(), graphErr.GetEX() + numEntries);
+
+    ASSERT_TRUE(isValSorted);
+    ASSERT_TRUE(isErrSorted);
+}
+
+TEST(TGraphSortTest, TGraphAsymmErrorsSortingTest)
+{
+    const int numEntries = 1000000;
+    std::vector<Double_t> x(numEntries);
+    std::vector<Double_t> y(numEntries);
+    std::vector<Double_t> elow(numEntries);
+    std::vector<Double_t> ehigh(numEntries);
+
+    // Initialize the graph data with unsorted data
+    for (int i = 0; i < numEntries; i++) {
+        x[i] = numEntries - i;
+        y[i] = x[i] * x[i];
+        elow[i] = 1.0 / (i + 1);
+        ehigh[i] = 2.0 / (i + 1);
+        
+    }
+
+    TGraphAsymmErrors graphAsymmErr(numEntries, x.data(), y.data(), elow.data(), ehigh.data(), elow.data(), ehigh.data());
+
+    graphAsymmErr.Sort();
+
+    // Check if the graph x values are sorted
+    bool isValSorted = std::is_sorted(graphAsymmErr.GetX(), graphAsymmErr.GetX() + numEntries);
+
+    // Check if the graph errors are sorted based on the sorted values
+    bool isErrSorted = std::is_sorted(graphAsymmErr.GetEYlow(), graphAsymmErr.GetEYlow() + numEntries);
+
+    ASSERT_TRUE(isValSorted);
+    ASSERT_TRUE(isErrSorted);
+}
+
+TEST(TGraphSortTest, TGraphBentErrorsSortingTest)
+{
+    const int numEntries = 1000000;
+    std::vector<Double_t> x(numEntries);
+    std::vector<Double_t> y(numEntries);
+    std::vector<Double_t> elow(numEntries);
+    std::vector<Double_t> ehigh(numEntries);
+    std::vector<Double_t> elowd(numEntries);
+    std::vector<Double_t> ehighd(numEntries);
+
+    // Initialize the graph data with unsorted data
+    for (int i = 0; i < numEntries; i++) {
+        x[i] = numEntries - i;
+        y[i] = x[i] * x[i];
+        elow[i] = 1.0 / (i + 1);
+        ehigh[i] = 2.0 / (i + 1);
+        elowd[i] = 3.0 / (i + 1);
+        ehighd[i] = 0.5 * i;
+    }
+
+    TGraphBentErrors graphBentErr(numEntries, x.data(), y.data(), elow.data(), ehigh.data(), elowd.data(), ehighd.data(), elow.data(), ehigh.data(), elowd.data(), ehighd.data());
+
+    graphBentErr.Sort();
+
+    // Check if the graph x values are sorted
+    bool isValSorted = std::is_sorted(graphBentErr.GetX(), graphBentErr.GetX() + numEntries);
+
+    // Check if the graph errors are sorted based on the sorted values
+    bool isErrSorted = std::is_sorted(graphBentErr.GetEXlow(), graphBentErr.GetEXlow() + numEntries);
+    bool isErrdSorted = std::is_sorted(graphBentErr.GetEYhighd(), graphBentErr.GetEYhighd() + numEntries);
+
+    ASSERT_TRUE(isValSorted);
+    ASSERT_TRUE(isErrSorted);
+    ASSERT_FALSE(isErrdSorted);
+}
+
+TEST(TGraphSortTest, TGraphMultiErrorsSortingTest)
+{
+    const int numEntries = 1000000;
+    std::vector<Double_t> x(numEntries);
+    std::vector<Double_t> y(numEntries);
+    std::vector<Double_t> elow(numEntries);
+    std::vector<Double_t> ehigh(numEntries);
+
+    // Initialize the graph data with unsorted data
+    for (int i = 0; i < numEntries; i++) {
+        x[i] = numEntries - i;
+        y[i] = x[i] * x[i];
+        elow[i] = 1.0 / (i + 1);
+        ehigh[i] = 2.0 / (i + 1);
+    }
+
+    TGraphMultiErrors graphMultiErr(numEntries, x.data(), y.data(), elow.data(), ehigh.data(), elow.data(), ehigh.data());
+
+    graphMultiErr.Sort();
+
+    // Check if the graph x values are sorted
+    bool isValSorted = std::is_sorted(graphMultiErr.GetX(), graphMultiErr.GetX() + numEntries);
+
+    // Check if the graph errors are sorted based on the sorted values
+    bool isErrSorted = std::is_sorted(graphMultiErr.GetEXlow(), graphMultiErr.GetEXlow() + numEntries);
+
+    ASSERT_TRUE(isValSorted);
+    ASSERT_TRUE(isErrSorted);
+}


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
Reimplement the TGraph::Sort function using std::sort to avoid a segmentation fault when used with a large number of entries.

It's also faster, ex. for a `10000 points`:
```
BEFORE CHANGES -> Sort execution time: 148100 microseconds

AFTER CHANGES -> Sort execution time: 7065 microseconds
```
## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #13632

