### PR TITLE
[RF] Give example for multiple categories plot in rf501_simultaneouspdf

### DIFF
--- a/roofit/roofitcore/src/RooGlobalFunc.cxx
+++ b/roofit/roofitcore/src/RooGlobalFunc.cxx
@@ -103,6 +103,24 @@ RooCmdArg Slice(const RooArgSet &sliceSet)
 }
 RooCmdArg Slice(RooCategory &cat, const char *label)
 {
+   // We don't support adding multiple slices for a single category by
+   // concatenating labels with a comma. Users were trying to do that, and were
+   // surprised it did not work. So we explicitly check if there is a comma,
+   // and if there is, we will give some helpful advice on how to get to the
+   // desired plot.
+   std::string lbl{label};
+   if (lbl.find(',') != std::string::npos) {
+      std::stringstream errorMsg;
+      errorMsg << "RooFit::Slice(): you tried to pass a comma-separated list of state labels \"" << label
+               << "\" for a given category, but selecting multiple slices like this is not supported!"
+               << " If you want to make a plot of multiple slices, use the ProjWData() command where you pass a "
+                  "dataset that includes "
+                  "the desired slices. If the slices are a subset of all slices, then you can create such a dataset "
+                  "with RooAbsData::reduce(RooFit::Cut(\"cat==cat::label_1 || cat==cat::label_2 || ...\")). You can "
+                  "find some examples in the rf501_simultaneouspdf tutorial.";
+      oocoutE(nullptr, InputArguments) << errorMsg.str() << std::endl;
+      throw std::invalid_argument(errorMsg.str().c_str());
+   }
    return RooCmdArg("SliceCat", 0, 0, 0, 0, label, nullptr, &cat, nullptr);
 }
 RooCmdArg Slice(std::map<RooCategory *, std::string> const &arg)

--- a/tutorials/roofit/rf501_simultaneouspdf.C
+++ b/tutorials/roofit/rf501_simultaneouspdf.C
@@ -66,7 +66,7 @@ void rf501_simultaneouspdf()
    // ---------------------------------------------------------------
 
    // Generate 1000 events in x and y from model
-   std::unique_ptr<RooDataSet> data{model.generate({x}, 100)};
+   std::unique_ptr<RooDataSet> data{model.generate({x}, 1000)};
    std::unique_ptr<RooDataSet> data_ctl{model_ctl.generate({x}, 2000)};
 
    // C r e a t e   i n d e x   c a t e g o r y   a n d   j o i n   s a m p l e s
@@ -99,7 +99,7 @@ void rf501_simultaneouspdf()
    // ----------------------------------------------------------------
 
    // Make a frame for the physics sample
-   RooPlot *frame1 = x.frame(Bins(30), Title("Physics sample"));
+   RooPlot *frame1 = x.frame(Title("Physics sample"));
 
    // Plot all data tagged as physics sample
    combData.plotOn(frame1, Cut("sample==sample::physics"));
@@ -114,21 +114,35 @@ void rf501_simultaneouspdf()
    simPdf.plotOn(frame1, Slice(sample, "physics"), ProjWData(sample, combData));
    simPdf.plotOn(frame1, Slice(sample, "physics"), Components("px"), ProjWData(sample, combData), LineStyle(kDashed));
 
-   // The same plot for the control sample slice
+   // The same plot for the control sample slice. We do this with a different
+   // approach this time, for illustration purposes. Here, we are slicing the
+   // dataset and then use the data slice for the projection, because then the
+   // RooFit::Slice() becomes unnecessary. This approach is more general,
+   // because you can plot sums of slices by using logical or in the Cut()
+   // command.
    RooPlot *frame2 = x.frame(Bins(30), Title("Control sample"));
-   combData.plotOn(frame2, Cut("sample==sample::control"));
-   simPdf.plotOn(frame2, Slice(sample, "control"), ProjWData(sample, combData));
-   simPdf.plotOn(frame2, Slice(sample, "control"), Components("px_ctl"), ProjWData(sample, combData),
+   std::unique_ptr<RooAbsData> slicedData{combData.reduce(Cut("sample==sample::control"))};
+   slicedData->plotOn(frame2);
+   simPdf.plotOn(frame2, ProjWData(sample, *slicedData));
+   simPdf.plotOn(frame2, Components("px_ctl"), ProjWData(sample, *slicedData), LineStyle(kDashed));
+
+   // The same plot for all the phase space. Here, we can just use the original
+   // combined dataset.
+   RooPlot *frame3 = x.frame(Title("Both samples"));
+   combData.plotOn(frame3);
+   simPdf.plotOn(frame3, ProjWData(sample, combData));
+   simPdf.plotOn(frame3, Components("px,px_ctl"), ProjWData(sample, combData),
                  LineStyle(kDashed));
 
-   TCanvas *c = new TCanvas("rf501_simultaneouspdf", "rf403_simultaneouspdf", 800, 400);
-   c->Divide(2);
-   c->cd(1);
-   gPad->SetLeftMargin(0.15);
-   frame1->GetYaxis()->SetTitleOffset(1.4);
-   frame1->Draw();
-   c->cd(2);
-   gPad->SetLeftMargin(0.15);
-   frame2->GetYaxis()->SetTitleOffset(1.4);
-   frame2->Draw();
+   TCanvas *c = new TCanvas("rf501_simultaneouspdf", "rf403_simultaneouspdf", 1200, 400);
+   c->Divide(3);
+   auto draw = [&](int i, RooPlot & frame) {
+      c->cd(i);
+      gPad->SetLeftMargin(0.15);
+      frame.GetYaxis()->SetTitleOffset(1.4);
+      frame.Draw();
+   };
+   draw(1, *frame1);
+   draw(2, *frame2);
+   draw(3, *frame3);
 }


### PR DESCRIPTION
Also, throw an exception with a helpful error message if the user attempts to use `RooFit::Slice()` with a comma-separates list of category states, which is not supported.

This addresses a question on the forum:
https://root-forum.cern.ch/t/plotting-two-categories-of-simultaneous-fit-in-a-single-plot/56250