### PR TITLE
[RF] Make extended fit default of RooAbsPdf::fitChi2() same as in fitTo

### DIFF
--- a/README/ReleaseNotes/v630/index.md
+++ b/README/ReleaseNotes/v630/index.md
@@ -247,6 +247,13 @@ Some of these classes are now removed from the public interface:
 6. The `RooRealAnalytic`, which was an implementation detail of the
    `RooRealIntegral` class.
 
+### Consistent default for `Extended()` command in RooAbsPdf::fitTo() and RooAbsPdf::chi2FitTo()
+
+If no `RooFit::Extended()` command argument is passed, `RooAbsPdf::chi2FitTo()`
+method now does an extended fit by default if the pdf is extendible. This makes
+the behavior consistent with `RooAbsPdf::fitTo()`. Same applies to
+`RooAbsPdf::createChi2()`.
+
 ## 2D Graphics Libraries
 
 - Introduce `TAxis::ChangeLabelByValue` to set custom label defined by axis value. It works also

--- a/roofit/batchcompute/README.md
+++ b/roofit/batchcompute/README.md
@@ -1,24 +1,24 @@
 ## RooBatchCompute Library
 _Contains optimized computation functions for PDFs that enable significantly faster fittings._
-#### Note: This library is still at an experimental stage. Tests are being conducted continiously to ensure correctness of the results, but the interfaces and the instructions on how to use might change.
+#### Note: This library is still at an experimental stage. Tests are being conducted continuously to ensure correctness of the results, but the interfaces and the instructions on how to use might change.
 
 ### Purpose
-While fitting, a significant amount of time and processing power is spent on computing the probability function for every event and PDF involved in the fitting model. To speed up this process, roofit can use the computation functions provided in this library. The functions provided here process whole data arrays (batches) instead of a single event at a time, as in the legacy evaluate() function in roofit. In addition, the code is written in a manner that allows for compiler optimizations, notably auto-vectorization. This library is compiled multiple times for different [vector instuction set architectures](https://en.wikipedia.org/wiki/SIMD) and the optimal code is executed during runtime, as a result of an automatic hardware detection mechanism that this library contains. **As a result, fits can benefit by a speedup of 3x-16x.**
+While fitting, a significant amount of time and processing power is spent on computing the probability function for every event and PDF involved in the fitting model. To speed up this process, roofit can use the computation functions provided in this library. The functions provided here process whole data arrays (batches) instead of a single event at a time, as in the legacy evaluate() function in roofit. In addition, the code is written in a manner that allows for compiler optimizations, notably auto-vectorization. This library is compiled multiple times for different [vector instruction set architectures](https://en.wikipedia.org/wiki/SIMD) and the optimal code is executed during runtime, as a result of an automatic hardware detection mechanism that this library contains. **As a result, fits can benefit by a speedup of 3x-16x.**
 
 As of ROOT v6.26, RooBatchComputes also provides multithread and [CUDA](https://en.wikipedia.org/wiki/CUDA) instances of the computation functions, resulting in even greater improvements for fitting times.
 
 ### How to use
-This library is an internal component of RooFit, so users are not supposed to actively interact with it. Instead, they can benefit from significantly faster times for fitting by calling `fitTo()` and providing a `BatchMode("cpu")` or a `BatchMode("cuda")` option. 
+This library is an internal component of RooFit, so users are not supposed to actively interact with it. Instead, they can benefit from significantly faster times for fitting by calling `fitTo()` and providing a `BatchMode("cpu")` or a `BatchMode("cuda")` option.
 ```c++
   // fit using the most efficient library that the computer's CPU can support
-  RooMyPDF.fitTo(data, BatchMode("cpu")); 
-  
+  RooMyPDF.fitTo(data, BatchMode("cpu"));
+
   // fit using the CUDA library along with the most efficient library that the computer's CPU can support
-  RooMyPDF.fitTo(data, BatchMode("cuda")); 
+  RooMyPDF.fitTo(data, BatchMode("cuda"));
 ```
 **Note: In case the system does not support vector instructions, the `RooBatchCompute::Cpu` option is guaranteed to work properly by using a generic CPU library. In contrast, users must first make sure that their system supports CUDA in order to use the `RooBatchCompute::Cuda` option. If this is not the case, an exception will be thrown.**
 
-If `"cuda"` is selected, RooFit will launch CUDA kernels for computing likelihoods and potentially other intense computations. At the same time, the most efficent CPU library loaded will also handle parts of the computations in parallel with the GPU (or potentially, if it's faster, all of them), thus gaining full advantage of the available hardware. For this purpose `RooFitDriver`, a newly created RooFit class (in roofitcore) takes over the task of analyzing the computations and assigning each to the correct piece of hardware, taking into consideration the performance boost or penalty that may arise with every method of computing.
+If `"cuda"` is selected, RooFit will launch CUDA kernels for computing likelihoods and potentially other intense computations. At the same time, the most efficient CPU library loaded will also handle parts of the computations in parallel with the GPU (or potentially, if it's faster, all of them), thus gaining full advantage of the available hardware. For this purpose `RooFitDriver`, a newly created RooFit class (in roofitcore) takes over the task of analyzing the computations and assigning each to the correct piece of hardware, taking into consideration the performance boost or penalty that may arise with every method of computing.
 
 #### Multithread computations
 The CPU instance of the computing library can furthermore execute multithread computations. This also applies for computations handled by the CPU in the `"cuda"` mode. To use them, one needs to set the desired number of parallel tasks before calling `fitTo()` as shown below:
@@ -28,7 +28,7 @@ The CPU instance of the computing library can furthermore execute multithread co
 ```
 
 ### User-made PDFs
-The easiest and most efficient way of accelerating your PDFs is to request their addition to the official RooFit by submiting a ticket [here](https://github.com/root-project/root/issues/new). The ROOT team will gladly assist you and take care of the details.
+The easiest and most efficient way of accelerating your PDFs is to request their addition to the official RooFit by submitting a ticket [here](https://github.com/root-project/root/issues/new). The ROOT team will gladly assist you and take care of the details.
 
 While your code is integrated, you are able to significantly improve the speed of fitting (but not take full advantage of the RooBatchCompute library), at least by using the batch evaluation feature.
 To make use of it, one should override `RooAbsReal::computeBatch()`
@@ -44,10 +44,10 @@ void RooMyPDF::computeBatch(RooBatchCompute::RooBatchComputeInterface*, double* 
   std::span<const double> span1 = dataMap.at(&*proxyVar1);
   // or: auto span1 = dataMap.at(&*proxyVar1);
   std::span<const double> span2 = dataMap.at(&*proxyVar2);
-  
+
   // let's assume c is a scalar parameter of the PDF. In this case the dataMap contains a std::span with only one value.
   std::span<const double> scalar = dataMap.at(&*c);
-  
+
   // Perform computations in a for-loop
   // Use VDT if possible to facilitate auto-vectorization
   for (size_t i=0; i<nEvents; ++i) {
@@ -55,4 +55,4 @@ void RooMyPDF::computeBatch(RooBatchCompute::RooBatchComputeInterface*, double* 
   }
 }
 ```
-Make sure to add the `computeBatch()` function signature in the header `RooMyPDF.h` and mark it as `override` to ensure that you have successfully overriden the method. As a final note, always remember to append `RooBatchCompute::` to the classes defined in the RooBatchCompute library, or write `using namespace RooBatchCompute`.
+Make sure to add the `computeBatch()` function signature in the header `RooMyPDF.h` and mark it as `override` to ensure that you have successfully overridden the method. As a final note, always remember to append `RooBatchCompute::` to the classes defined in the RooBatchCompute library, or write `using namespace RooBatchCompute`.

--- a/roofit/batchcompute/res/RooHeterogeneousMath.h
+++ b/roofit/batchcompute/res/RooHeterogeneousMath.h
@@ -42,7 +42,7 @@ __roodevice__ __roohost__ static inline void cexp(double &re, double &im)
    // exp(z) for the x87 coprocessor; other platforms have the default
    // routines as fallback implementation, and compilers other than gcc on
    // x86_64 generate better code with the default routines; also avoid
-   // the inline assembly code when the copiler is not optimising code, or
+   // the inline assembly code when the compiler is not optimising code, or
    // is optimising for code size
    // (we insist on __unix__ here, since the assemblers on other OSs
    // typically do not speak AT&T syntax as gas does...)
@@ -234,7 +234,7 @@ faddeeva_smabmq_impl(T zre, T zim, const T tm, const T (&a)[N], const T (&npi)[N
       // norm of denominator
       const T norm = wk * wk + reimtmzm22;
       const T f = T(2) * tm * a[i] / norm;
-      // sum += a[i] * numer / wk
+      // sum += a[i] * numerator / wk
       sumre -= f * (numertmz[j] * wk + numertmz[j + 1] * reimtmzm2);
       sumim -= f * (numertmz[j + 1] * wk - numertmz[j] * reimtmzm2);
    }

--- a/roofit/batchcompute/src/Batches.h
+++ b/roofit/batchcompute/src/Batches.h
@@ -80,7 +80,7 @@ public:
    }
 };
 
-// Defines the actual argument type of the compute funciton.
+// Defines the actual argument type of the compute function.
 using BatchesHandle = Batches &;
 
 } // End namespace RF_ARCH

--- a/roofit/batchcompute/src/ComputeFunctions.cxx
+++ b/roofit/batchcompute/src/ComputeFunctions.cxx
@@ -606,7 +606,7 @@ __rooglobal__ void computeNovosibirsk(BatchesHandle batches)
       batches._output[i] -= 2.0 / xi / xi * asinh * asinh;
    }
 
-   // faster if you exponentiate in a seperate loop (dark magic!)
+   // faster if you exponentiate in a separate loop (dark magic!)
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
       batches._output[i] = fast_exp(batches._output[i]);
 }

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -381,7 +381,7 @@ public:
     return true ;
   }
   virtual bool hasRange(const char*) const {
-    // Has this argument a defined range (dummy interface always returns flase)
+    // Has this argument a defined range (dummy interface always returns false)
     return false ;
   }
 
@@ -531,7 +531,7 @@ public:
   //   * passing an initializer list
   // Before, there was only an overload taking a RooArg set, which caused an
   // implicit creation of a RooArgSet when a RooArgList was passed. This needs
-  // to be avoided, because if the passed RooArgList is owning the argumnets,
+  // to be avoided, because if the passed RooArgList is owning the arguments,
   // this information will be lost with the copy. The solution is to have one
   // overload that takes a general RooAbsCollection, and one overload for
   // RooArgList that is invoked in the case of passing an initializer list.

--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -203,9 +203,7 @@ public:
   }
 
   // Chi^2 fits to histograms
-  using RooAbsReal::chi2FitTo ;
   using RooAbsReal::createChi2 ;
-  RooFit::OwningPtr<RooFitResult> chi2FitTo(RooDataHist& data, const RooLinkedList& cmdList) override ;
   RooFit::OwningPtr<RooAbsReal> createChi2(RooDataHist& data, const RooCmdArg& arg1={},  const RooCmdArg& arg2={},
              const RooCmdArg& arg3={},  const RooCmdArg& arg4={}, const RooCmdArg& arg5={},
              const RooCmdArg& arg6={},  const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) override ;
@@ -213,6 +211,13 @@ public:
   // Chi^2 fits to X-Y datasets
   RooFit::OwningPtr<RooAbsReal> createChi2(RooDataSet& data, const RooLinkedList& cmdList) override ;
 
+  /// \cond ROOFIT_INTERNAL
+  std::string createChi2DataHistCmdArgs() const override
+  {
+     return "Range,RangeWithName,NumCPU,Optimize,ProjectedObservables,"
+            "AddCoefRange,SplitRange,DataError,Extended,IntegrateBins";
+  }
+  /// \endcond ROOFIT_INTERNAL
 
   // Constraint management
   virtual RooArgSet* getConstraints(const RooArgSet& /*observables*/, RooArgSet& /*constrainedParams*/,
@@ -278,7 +283,7 @@ public:
   /// Return expected number of events to be used in calculation of extended
   /// likelihood. This function should not be overridden, as it just redirects
   /// to the actual virtual function but takes a RooArgSet reference instead of
-  /// pointer (\see expectedEvents(const RooArgSet*) const).
+  /// pointer. \see expectedEvents(const RooArgSet*) const
   double expectedEvents(const RooArgSet& nset) const {
     return expectedEvents(&nset) ;
   }

--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -386,7 +386,7 @@ protected:
 
   mutable Int_t _errorCount ;        ///< Number of errors remaining to print
   mutable Int_t _traceCount ;        ///< Number of traces remaining to print
-  mutable Int_t _negCount ;          ///< Number of negative probablities remaining to print
+  mutable Int_t _negCount ;          ///< Number of negative probabilities remaining to print
 
   bool _selectComp ;               ///< Component selection flag for RooAbsPdf::plotCompOn
 

--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -396,6 +396,11 @@ private:
   int calcAsymptoticCorrectedCovariance(RooMinimizer& minimizer, RooAbsData const& data);
   int calcSumW2CorrectedCovariance(RooMinimizer& minimizer, RooAbsReal & nll) const;
 
+  friend class RooAbsReal;
+  friend class RooChi2Var;
+  static constexpr int extendedFitDefault = 2; // implementation detail to avoid magic numbers
+  bool interpretExtendedCmdArg(int extendedCmdArg) const;
+
   ClassDefOverride(RooAbsPdf,5) // Abstract PDF with normalization support
 };
 

--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -195,6 +195,12 @@ public:
                const RooCmdArg& arg3={},  const RooCmdArg& arg4={}, const RooCmdArg& arg5={},
                const RooCmdArg& arg6={},  const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;
 
+  /// \cond ROOFIT_INTERNAL
+  /// If the overriding classes support more command args in the createChi2()
+  /// overload for RooDataHist, they can override this (like RooAbsPdf).
+  virtual std::string createChi2DataHistCmdArgs() const {return "Range,RangeWithName,NumCPU,Optimize,IntegrateBins"; }
+  /// \endcond ROOFIT_INTERNAL
+
 
   virtual RooFit::OwningPtr<RooAbsReal> createProfile(const RooArgSet& paramsOfInterest) ;
 

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -27,7 +27,7 @@ a computation graph models an expression tree that can be evaluated.
 Therefore, RooAbsArg provides functionality to connect objects of type RooAbsArg into
 a computation graph to pass values between those objects.
 A value can e.g. be a real-valued number, (instances of RooAbsReal), or an integer, that is,
-catgory index (instances of RooAbsCategory). The third subclass of RooAbsArg is RooStringVar,
+category index (instances of RooAbsCategory). The third subclass of RooAbsArg is RooStringVar,
 but it is rarely used.
 
 The "shapes" that a RooAbsArg can possess can e.g. be the definition
@@ -545,7 +545,7 @@ RooFit::OwningPtr<RooArgSet> RooAbsArg::getParameters(const RooAbsData* set, boo
 }
 
 
-/// Return the parameters of this p.d.f when used in conjuction with dataset 'data'.
+/// Return the parameters of this p.d.f when used in conjunction with dataset 'data'.
 RooFit::OwningPtr<RooArgSet> RooAbsArg::getParameters(const RooAbsData& data, bool stripDisconnected) const
 {
   return getParameters(&data,stripDisconnected) ;
@@ -613,7 +613,7 @@ void RooAbsArg::addParameters(RooAbsCollection& params, const RooArgSet* nset, b
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Obtain an estimate of the number of parameters of the function and its daughters.
-/// Calling `addParamters` for large functions (NLL) can cause many reallocations of
+/// Calling `addParameters` for large functions (NLL) can cause many reallocations of
 /// `params` due to the recursive behaviour. This utility function aims to pre-compute
 /// the total number of parameters, so that enough memory is reserved.
 /// The estimate is not fully accurate (overestimate) as there is no equivalent to `getParametersHook`.
@@ -1147,7 +1147,7 @@ bool RooAbsArg::callRedirectServersHook(RooAbsCollection const &newSet, bool mus
 ////////////////////////////////////////////////////////////////////////////////
 /// Replace some servers of this object. If there are proxies that correspond
 /// to the replaced servers, these proxies are adjusted as well.
-/// \param[in] replacements Map that specifiecs which args replace which servers.
+/// \param[in] replacements Map that specifies which args replace which servers.
 bool RooAbsArg::redirectServers(std::unordered_map<RooAbsArg *, RooAbsArg *> const &replacements)
 {
    bool ret(false);
@@ -1322,7 +1322,7 @@ bool RooAbsArg::redirectServersHook(const RooAbsCollection & /*newServerList*/, 
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Register an RooArgProxy in the proxy list. This function is called by owned
-/// proxies upon creation. After registration, this arg wil forward pointer
+/// proxies upon creation. After registration, this arg will forward pointer
 /// changes from serverRedirects and updates in cached normalization sets
 /// to the proxies immediately after they occur. The proxied argument is
 /// also added as value and/or shape server
@@ -1367,7 +1367,7 @@ void RooAbsArg::unRegisterProxy(RooArgProxy& proxy)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Register an RooSetProxy in the proxy list. This function is called by owned
-/// proxies upon creation. After registration, this arg wil forward pointer
+/// proxies upon creation. After registration, this arg will forward pointer
 /// changes from serverRedirects and updates in cached normalization sets
 /// to the proxies immediately after they occur.
 
@@ -1402,7 +1402,7 @@ void RooAbsArg::unRegisterProxy(RooSetProxy& proxy)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Register an RooListProxy in the proxy list. This function is called by owned
-/// proxies upon creation. After registration, this arg wil forward pointer
+/// proxies upon creation. After registration, this arg will forward pointer
 /// changes from serverRedirects and updates in cached normalization sets
 /// to the proxies immediately after they occur.
 
@@ -1543,9 +1543,9 @@ void RooAbsArg::printClassName(ostream& os) const
 }
 
 
+/// Print address of this RooAbsArg.
 void RooAbsArg::printAddress(ostream& os) const
 {
-  // Print addrss of this RooAbsArg
   os << this ;
 }
 
@@ -2149,7 +2149,7 @@ RooAbsCache* RooAbsArg::getCache(Int_t index) const
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return RooArgSet with all variables (tree leaf nodes of expresssion tree)
+/// Return RooArgSet with all variables (tree leaf nodes of expression tree)
 
 RooFit::OwningPtr<RooArgSet> RooAbsArg::getVariables(bool stripDisconnected) const
 {
@@ -2539,7 +2539,7 @@ std::unique_ptr<RooAbsArg> RooAbsArg::compileForNormSet(RooArgSet const & normSe
 /// to form the C++ code that AD tools can understand. Any class that wants to support AD, has to
 /// implement this function.
 ///
-/// \param[in] ctx An object to manage auxilary information for code-squashing. Also takes the
+/// \param[in] ctx An object to manage auxiliary information for code-squashing. Also takes the
 /// code string that this class outputs into the squashed code through the 'addToCodeBody' function.
 void RooAbsArg::translate(RooFit::Detail::CodeSquashContext & /*ctx*/) const
 {

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -897,7 +897,15 @@ double RooAbsPdf::extendedTerm(RooAbsData const& data, bool weightSquared, bool 
 /// <tr><th> Type of CmdArg    <th>    Effect on nll
 /// <tr><td> `ConditionalObservables(Args_t &&... argsOrArgSet)`  <td>  Do not normalize PDF over listed observables.
 //                                                  Arguments can either be multiple RooRealVar or a single RooArgSet containing them.
-/// <tr><td> `Extended(bool flag)`           <td> Add extended likelihood term, off by default
+/// <tr><td> `Extended(bool flag)` <td> Include the extended likelihood term, i.e., a Poisson term constraining the models predicted number of events.
+///                                     - If you don't pass this command, an extended fit will be done by default if the pdf makes a prediction on the number of events
+///                                       (in RooFit jargon, "if the pdf can be extended").
+///                                     - Passing `Extended(true)` when the the pdf makes no prediction on the expected number of events will result in error messages,
+///                                       and no extended term is added after all.
+///                                     - There are cases where the fit **must** be done with an extended term. This happens for example when you have a RooAddPdf
+///                                       where the coefficients represent component yields. If the extended term is not included, these coefficients will not be
+///                                       well-defined, as the RooAddPdf always normalizes itself. If you pass `Extended(false)` in such a case, an error will be
+///                                       printed and you'll most likely get garbage results.
 /// <tr><td> `Range(const char* name)`         <td> Fit only data inside range with given name
 /// <tr><td> `Range(double lo, double hi)` <td> Fit only data inside given range. A range named "fit" is created on the fly on all observables.
 ///                                               Multiple comma separated range names can be specified.

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -63,7 +63,7 @@ PDFs can advertise one or more (partial) analytical integrals of
 their function, and these will be used by RooRealIntegral, if it
 determines that this is safe (i.e., no hidden Jacobian terms,
 multiplication with other PDFs that have one or more dependents in
-commen etc).
+common, etc).
 
 #### Implementing analytical integrals
 To implement analytical integrals, two functions must be implemented. First,
@@ -256,7 +256,7 @@ void resetFitrangeAttributes(RooAbsArg& pdf, RooAbsData const& data, std::string
    // Clear possible range attributes from previous fits.
    pdf.removeStringAttribute("fitrange");
 
-   // No fitrange was speficied, so we do nothing. Or "SplitRange" is used, and
+   // No fitrange was specified, so we do nothing. Or "SplitRange" is used, and
    // then there are no uniquely defined ranges for the observables (as they
    // are different in each category).
    if(!rangeName || splitRange) return;
@@ -793,7 +793,7 @@ void RooAbsPdf::getLogProbabilities(std::span<const double> pdfValues, double * 
 /// weighted by the effective weight \f$ \sum w_{i}^2 / \sum w_{i} \f$ in the likelihood.
 /// Since here we compute the likelihood with the weight square, we need to multiply by the
 /// square of the effective weight:
-///   - \f$ W_\mathrm{expect}   = N_\mathrm{expect} \cdot \sum w_{i} / \sum w_{i}^2 \f$ : effective expected entrie
+///   - \f$ W_\mathrm{expect}   = N_\mathrm{expect} \cdot \sum w_{i} / \sum w_{i}^2 \f$ : effective expected entries
 ///   - \f$ W_\mathrm{observed} = \sum w_{i} \cdot \sum w_{i} / \sum w_{i}^2 \f$        : effective observed entries
 ///
 /// The extended term for the likelihood weighted by the square of the weight will be then:
@@ -871,7 +871,7 @@ double RooAbsPdf::extendedTerm(double sumEntries, double expected, double sumEnt
 /// \param[in] weightSquared If set to `true`, the extended term will be scaled by
 ///            the ratio of squared event weights over event weights:
 ///            \f$ \sum w_{i}^2 / \sum w_{i} \f$.
-///            Indended to be used by fits with the `SumW2Error()` option that
+///            Intended to be used by fits with the `SumW2Error()` option that
 ///            can be passed to RooAbsPdf::fitTo(RooAbsData&, const RooLinkedList&)
 ///            (see the documentation of said function to learn more about the
 ///            interpretation of fits with squared weights).
@@ -909,7 +909,7 @@ double RooAbsPdf::extendedTerm(RooAbsData const& data, bool weightSquared, bool 
 ///   <tr><td> 1 = RooFit::Interleave <td> Process event i%N in process N. Recommended for binned data with
 ///                     a substantial number of zero-bins, which will be distributed across processes more equitably in this strategy
 ///   <tr><td> 2 = RooFit::SimComponents <td> Process each component likelihood of a RooSimultaneous fully in a single process
-///                     and distribute components over processes. This approach can be benificial if normalization calculation time
+///                     and distribute components over processes. This approach can be beneficial if normalization calculation time
 ///                     dominates the total computation time of a component (since the normalization calculation must be performed
 ///                     in each process in strategies 0 and 1. However beware that if the RooSimultaneous components do not share many
 ///                     parameters this strategy is inefficient: as most minuit-induced likelihood calculations involve changing
@@ -1070,7 +1070,7 @@ RooFit::OwningPtr<RooAbsReal> RooAbsPdf::createNLL(RooAbsData& data, const RooLi
   auto offset = static_cast<RooFit::OffsetMode>(pc.getInt("doOffset"));
 
   if(offset == RooFit::OffsetMode::Bin && dynamic_cast<RooDataSet*>(&data)) {
-    coutE(Minimization) << "The Offset(\"bin\") option doesn't suppot fits to RooDataSet yet, only to RooDataHist."
+    coutE(Minimization) << "The Offset(\"bin\") option doesn't support fits to RooDataSet yet, only to RooDataHist."
                            " Falling back to no offsetting."  << endl;
     offset = RooFit::OffsetMode::None;
   }
@@ -1384,7 +1384,7 @@ int RooAbsPdf::calcSumW2CorrectedCovariance(RooMinimizer &minimizer, RooAbsReal 
       }
    }
    matC.Similarity(matV);
-   // C now contiains V C^-1 V
+   // C now contains V C^-1 V
    // Propagate corrected errors to parameters objects
    minimizer.applyCovarianceMatrix(matC);
 
@@ -1398,7 +1398,7 @@ int RooAbsPdf::calcSumW2CorrectedCovariance(RooMinimizer &minimizer, RooAbsReal 
 /// If you are looking for a function that combines likelihood creation with
 /// fitting, see RooAbsPdf::fitTo.
 /// \param[in] nll The negative log-likelihood variable to minimize.
-/// \param[in] data The dataset that was als used for the NLL. It's a necessary
+/// \param[in] data The dataset that was also used for the NLL. It's a necessary
 ///            parameter because it is used in the asymptotic error correction.
 /// \param[in] cfg Configuration struct with all the configuration options for
 ///            the RooMinimizer. These are a subset of the options that you can
@@ -1514,7 +1514,7 @@ std::unique_ptr<RooFitResult> RooAbsPdf::minimizeNLL(RooAbsReal & nll,
 ///   <tr><td> 1 = RooFit::Interleave <td> Process event i%N in process N. Recommended for binned data with
 ///                     a substantial number of zero-bins, which will be distributed across processes more equitably in this strategy
 ///   <tr><td> 2 = RooFit::SimComponents <td> Process each component likelihood of a RooSimultaneous fully in a single process
-///                     and distribute components over processes. This approach can be benificial if normalization calculation time
+///                     and distribute components over processes. This approach can be beneficial if normalization calculation time
 ///                     dominates the total computation time of a component (since the normalization calculation must be performed
 ///                     in each process in strategies 0 and 1. However beware that if the RooSimultaneous components do not share many
 ///                     parameters this strategy is inefficient: as most minuit-induced likelihood calculations involve changing
@@ -1570,7 +1570,7 @@ std::unique_ptr<RooFitResult> RooAbsPdf::minimizeNLL(RooAbsReal & nll,
 /// <tr><td> `Minos(const RooArgSet& set)`     <td>  Only run MINOS on given subset of arguments
 /// <tr><td> `Save(bool flag)`               <td>  Flag controls if RooFitResult object is produced and returned, off by default
 /// <tr><td> `Strategy(Int_t flag)`            <td>  Set Minuit strategy (0 to 2, default is 1)
-/// <tr><td> `MaxCalls(int n)`              <td> Change maximum number of likelihood function calss from MINUIT (if `n <= 0`, the default of 500 * #%parameters is used)
+/// <tr><td> `MaxCalls(int n)`              <td> Change maximum number of likelihood function calls from MINUIT (if `n <= 0`, the default of 500 * #%parameters is used)
 /// <tr><td> `EvalErrorWall(bool flag=true)`    <td>  When parameters are in disallowed regions (e.g. PDF is negative), return very high value to fitter
 ///                                                  to force it out of that region. This can, however, mean that the fitter gets lost in this region. If
 ///                                                  this happens, try switching it off.
@@ -1697,8 +1697,8 @@ RooFit::OwningPtr<RooFitResult> RooAbsPdf::fitTo(RooAbsData& data, const RooLink
 
   // TimingAnalysis works only for RooSimultaneous.
   if (pc.getInt("timingAnalysis") && !this->InheritsFrom("RooSimultaneous") ) {
-     coutW(Minimization) << "The timingAnalysis feature was built for minimization with RooSimulteneous "
-                            "and is not implemented for other PDF's. Please create a RooSimultenous to "
+     coutW(Minimization) << "The timingAnalysis feature was built for minimization with RooSimultaneous "
+                            "and is not implemented for other PDF's. Please create a RooSimultaneous to "
                             "enable this feature."  << endl;
   }
 
@@ -1707,7 +1707,7 @@ RooFit::OwningPtr<RooFitResult> RooAbsPdf::fitTo(RooAbsData& data, const RooLink
   Int_t optConst = pc.getInt("optConst") ;
 
   if (optConst > 1) {
-    // optConst >= 2 is pre-computating values, which are never used when
+    // optConst >= 2 is pre-computing values, which are never used when
     // the batchMode is on. This just wastes time.
 
     RooCmdConfig conf("RooAbsPdf::fitTo(" + std::string(GetName()) + ")");
@@ -2341,7 +2341,7 @@ Int_t* RooAbsPdf::randomizeProtoOrder(Int_t nProto, Int_t, bool resampleProto) c
 /// and return a code that specifies the generator algorithm we will use. A code of
 /// zero indicates that we cannot generate any of the directVars (in this case, nothing
 /// should be added to generatedVars). Any non-zero codes will be passed to our generateEvent()
-/// implementation, but otherwise its value is arbitrary. The default implemetation of
+/// implementation, but otherwise its value is arbitrary. The default implementation of
 /// this method returns zero. Subclasses will usually implement this method using the
 /// matchArgs() methods to advertise the algorithms they provide.
 
@@ -2697,7 +2697,7 @@ void removeRangeOverlap(std::vector<std::pair<double, double>>& ranges) {
 /// <tr><td> `Name(const chat* name)`           <td>  Give curve specified name in frame. Useful if curve is to be referenced later
 /// <tr><td> `Asymmetry(const RooCategory& c)`  <td>  Show the asymmetry of the PDF in given two-state category
 ///               \f$ \frac{F(+)-F(-)}{F(+)+F(-)} \f$ rather than the PDF projection. Category must have two
-///               states with indices -1 and +1 or three states with indeces -1,0 and +1.
+///               states with indices -1 and +1 or three states with indices -1,0 and +1.
 /// <tr><td> `ShiftToZero(bool flag)`         <td>  Shift entire curve such that lowest visible point is at exactly zero.
 ///               Mostly useful when plotting -log(L) or \f$ \chi^2 \f$ distributions
 /// <tr><td> `AddTo(const char* name, double_t wgtSelf, double_t wgtOther)`  <td>  Create a projection of this PDF onto the x-axis, but
@@ -2931,7 +2931,7 @@ RooPlot* RooAbsPdf::plotOn(RooPlot* frame, RooLinkedList& cmdList) const
 
         if (oldSize != rangeLim.size() && !pc.hasProcessed("NormRange")) {
           // User gave overlapping ranges. This leads to double-counting events and integrals, and must
-          // therefore be avoided. If a NormRange has been given, the overlap is alreay gone.
+          // therefore be avoided. If a NormRange has been given, the overlap is already gone.
           // It's safe to plot even with overlap now.
           coutE(Plotting) << "Requested plot/integration ranges overlap. For correct plotting, new ranges "
               "will be defined." << std::endl;

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -858,9 +858,9 @@ double RooAbsPdf::extendedTerm(double sumEntries, double expected, double sumEnt
 /// of this PDF for the given number of observed events.
 ///
 /// This function is a wrapper around
-/// RooAbsPdf::extendedTerm(double, const RooArgSet*, double, bool), where the
-/// number of observed events and observables to be used as the normalization
-/// set for the pdf is extracted from a RooAbsData.
+/// RooAbsPdf::extendedTerm(double, RooArgSet const *, double, bool) const,
+/// where the number of observed events and observables to be used as the
+/// normalization set for the pdf is extracted from a RooAbsData.
 ///
 /// For successful operation, the PDF implementation must indicate that
 /// it is extendable by overloading `canBeExtended()`, and must
@@ -875,7 +875,7 @@ double RooAbsPdf::extendedTerm(double sumEntries, double expected, double sumEnt
 ///            can be passed to RooAbsPdf::fitTo(RooAbsData&, const RooLinkedList&)
 ///            (see the documentation of said function to learn more about the
 ///            interpretation of fits with squared weights).
-/// \param[in] doOffset See RooAbsPdf::extendedTerm(double, RooArgSet const*, double bool).
+/// \param[in] doOffset See RooAbsPdf::extendedTerm(double, RooArgSet const*, double, bool) const.
 
 double RooAbsPdf::extendedTerm(RooAbsData const& data, bool weightSquared, bool doOffset) const {
   double sumW = data.sumEntries();
@@ -1786,26 +1786,6 @@ RooFit::OwningPtr<RooFitResult> RooAbsPdf::fitTo(RooAbsData& data, const RooLink
   cfg.timingAnalysis = pc.getInt("timingAnalysis");
   return RooFit::Detail::owningPtr(minimizeNLL(*nll, data, cfg));
 }
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Calls RooAbsPdf::createChi2(RooDataSet& data, const RooLinkedList& cmdList) and returns fit result.
-
-RooFit::OwningPtr<RooFitResult> RooAbsPdf::chi2FitTo(RooDataHist& data, const RooLinkedList& cmdList)
-{
-  // Select the pdf-specific commands
-  RooCmdConfig pc("RooAbsPdf::chi2FitTo(" + std::string(GetName()) + ")");
-
-  // Pull arguments to be passed to chi2 construction from list
-  RooLinkedList fitCmdList(cmdList) ;
-  RooLinkedList chi2CmdList = pc.filterCmdList(fitCmdList,"Range,RangeWithName,NumCPU,Optimize,ProjectedObservables,AddCoefRange,SplitRange,DataError,Extended,IntegrateBins") ;
-
-  std::unique_ptr<RooAbsReal> chi2{createChi2(data,chi2CmdList)};
-  return chi2FitDriver(*chi2,fitCmdList) ;
-}
-
-
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -11,7 +11,7 @@
  *                                                                           *
  * Redistribution and use in source and binary forms,                        *
  * with or without modification, are permitted according to the terms        *
- * std::listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
  *****************************************************************************/
 
 //////////////////////////////////////////////////////////////////////////////
@@ -107,7 +107,7 @@
 
 namespace {
 
-// Internal helper RooAbsFunc that evalutes the scaled data-weighted average of
+// Internal helper RooAbsFunc that evaluates the scaled data-weighted average of
 // given RooAbsReal as a function of a single variable using the RooFit::Evaluator.
 class ScaledDataWeightedAverage : public RooAbsFunc {
 public:
@@ -496,7 +496,7 @@ RooFit::OwningPtr<RooAbsReal> RooAbsReal::createProfile(const RooArgSet& paramsO
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Create an object that represents the integral of the function over one or more observables std::listed in `iset`.
+/// Create an object that represents the integral of the function over one or more observables listed in `iset`.
 /// The actual integration calculation is only performed when the returned object is evaluated. The name
 /// of the integral object is automatically constructed from the name of the input function, the variables
 /// it integrates and the range integrates over.
@@ -544,7 +544,7 @@ RooFit::OwningPtr<RooAbsReal> RooAbsReal::createIntegral(const RooArgSet& iset, 
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Create an object that represents the integral of the function over one or more observables std::listed in iset.
+/// Create an object that represents the integral of the function over one or more observables listed in iset.
 /// The actual integration calculation is only performed when the return object is evaluated. The name
 /// of the integral object is automatically constructed from the name of the input function, the variables
 /// it integrates and the range integrates over. If nset is specified the integrand is request
@@ -643,7 +643,7 @@ RooFit::OwningPtr<RooAbsReal> RooAbsReal::createIntObj(const RooArgSet& iset2, c
       integral->addOwnedComponents(std::move(innerIntegral));
     }
 
-    // Remove already integrated observables from to-do std::list
+    // Remove already integrated observables from to-do list
     iset.remove(innerSet) ;
 
     // Send info message on recursion if needed
@@ -704,7 +704,7 @@ RooFit::OwningPtr<RooAbsReal> RooAbsReal::createIntObj(const RooArgSet& iset2, c
 
 void RooAbsReal::findInnerMostIntegration(const RooArgSet& allObs, RooArgSet& innerObs, const char* rangeName) const
 {
-  // Make std::lists of
+  // Make lists of
   // a) integrated observables with fixed ranges,
   // b) integrated observables with parameterized ranges depending on other integrated observables
   // c) integrated observables used in definition of any parameterized ranges of integrated observables
@@ -736,11 +736,11 @@ void RooAbsReal::findInnerMostIntegration(const RooArgSet& allObs, RooArgSet& in
     }
   }
 
-  // Make std::list of fixed-range observables that are _not_ involved in the parameterization of ranges of other observables
+  // Make list of fixed-range observables that are _not_ involved in the parameterization of ranges of other observables
   RooArgSet obsWithFixedRangeNP(obsWithFixedRange) ;
   obsWithFixedRangeNP.remove(obsServingAsRangeParams) ;
 
-  // Make std::list of param-range observables that are _not_ involved in the parameterization of ranges of other observables
+  // Make list of param-range observables that are _not_ involved in the parameterization of ranges of other observables
   RooArgSet obsWithParamRangeNP(obsWithParamRange) ;
   obsWithParamRangeNP.remove(obsServingAsRangeParams) ;
 
@@ -856,7 +856,7 @@ const RooAbsReal *RooAbsReal::createPlotProjection(const RooArgSet &dependentVar
 
 
   // Check that the dependents are all fundamental. Filter out any that we
-  // do not depend on, and make substitutions by name in our leaf std::list.
+  // do not depend on, and make substitutions by name in our leaf list.
   // Check for overlaps with the projection variables.
   for (const auto arg : dependentVars) {
     if(!arg->isFundamental() && !dynamic_cast<const RooAbsLValue*>(arg)) {
@@ -898,7 +898,7 @@ const RooAbsReal *RooAbsReal::createPlotProjection(const RooArgSet &dependentVar
     }
   }
 
-  // Remove the projected variables from the std::list of leaf nodes, if necessary.
+  // Remove the projected variables from the list of leaf nodes, if necessary.
   if(nullptr != projectedVars) leafNodes.remove(*projectedVars,true);
 
   // Make a deep-clone of ourself so later operations do not disturb our original state
@@ -909,7 +909,7 @@ const RooAbsReal *RooAbsReal::createPlotProjection(const RooArgSet &dependentVar
   }
   RooAbsReal *theClone= (RooAbsReal*)cloneSet->find(GetName());
 
-  // The remaining entries in our std::list of leaf nodes are the external
+  // The remaining entries in our list of leaf nodes are the external
   // dependents (x) and parameters (p) of the projection. Patch them back
   // into the theClone. This orphans the nodes they replace, but the orphans
   // are still in the cloneList and so will be cleaned up eventually.
@@ -973,7 +973,7 @@ const RooAbsReal *RooAbsReal::createPlotProjection(const RooArgSet &dependentVar
 /// be any TH1 subclass, and therefore of arbitrary
 /// dimension. Variables are matched with the (x,y,...) dimensions of
 /// the input histogram according to the order in which they appear
-/// in the input plotVars std::list. If scaleForDensity is true the
+/// in the input plotVars list. If scaleForDensity is true the
 /// histogram is filled with a the functions density rather than
 /// the functions value (i.e. the value at the bin center is multiplied
 /// with bin volume)
@@ -997,7 +997,7 @@ TH1 *RooAbsReal::fillHistogram(TH1 *hist, const RooArgList &plotVars,
 
 
   // Check that the plot variables are all actually RooRealVars and print a warning if we do not
-  // explicitly depend on one of them. Fill a set (not std::list!) of cloned plot variables.
+  // explicitly depend on one of them. Fill a set (not list!) of cloned plot variables.
   RooArgSet plotClones;
   for(Int_t index= 0; index < plotVars.getSize(); index++) {
     const RooAbsArg *var= plotVars.at(index);
@@ -1221,7 +1221,7 @@ TH1* RooAbsReal::createHistogram(RooStringView varNameList, Int_t xbins, Int_t y
     if(varNames[iVar].empty()) continue;
     if(iVar >= 3) {
       std::stringstream errMsg;
-      errMsg << "RooAbsPdf::createHistogram(" << GetName() << ") ERROR more than three variable names passed, but maxumum number of supported variables is three";
+      errMsg << "RooAbsPdf::createHistogram(" << GetName() << ") ERROR more than three variable names passed, but maximum number of supported variables is three";
       coutE(Plotting) << errMsg.str() << std::endl;
       throw std::invalid_argument(errMsg.str());
     }
@@ -1235,7 +1235,7 @@ TH1* RooAbsReal::createHistogram(RooStringView varNameList, Int_t xbins, Int_t y
     histVars[iVar] = var;
   }
 
-  // Construct std::list of named arguments to pass to the implementation version of createHistogram()
+  // Construct list of named arguments to pass to the implementation version of createHistogram()
 
   RooLinkedList argList ;
   if (xbins>0) {
@@ -1253,7 +1253,7 @@ TH1* RooAbsReal::createHistogram(RooStringView varNameList, Int_t xbins, Int_t y
   // Call implementation function
   TH1* result = createHistogram(GetName(), *histVars[0], argList) ;
 
-  // Delete temporary std::list of RooCmdArgs
+  // Delete temporary list of RooCmdArgs
   argList.Delete() ;
 
   return result ;
@@ -1266,7 +1266,7 @@ TH1* RooAbsReal::createHistogram(RooStringView varNameList, Int_t xbins, Int_t y
 ///
 /// \param[in] name  Name of the ROOT histogram
 /// \param[in] xvar  Observable to be std::mapped on x axis of ROOT histogram
-/// \param[in] arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8  Arguments according to std::list below
+/// \param[in] arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8  Arguments according to list below
 /// \return TH1 *, one of TH{1,2,3}. The caller takes ownership.
 ///
 /// <table>
@@ -1462,7 +1462,7 @@ TH1* RooAbsReal::createHistogram(const char *name, const RooAbsRealLValue& xvar,
 /// Helper function for plotting of composite p.d.fs. Given
 /// a set of selected components that should be plotted,
 /// find all nodes that (in)directly depend on these selected
-/// nodes. Mark all directly and indirecty selected nodes
+/// nodes. Mark all directly and indirectly selected nodes
 /// as 'selected' using the selectComp() method
 
 void RooAbsReal::plotOnCompSelect(RooArgSet* selNodes) const
@@ -1538,7 +1538,7 @@ void RooAbsReal::plotOnCompSelect(RooArgSet* selNodes) const
 /// This function takes the following named arguments
 /// <table>
 /// <tr><th><th> Projection control
-/// <tr><td> `Slice(const RooArgSet& set)`     <td> Override default projection behaviour by omitting observables std::listed
+/// <tr><td> `Slice(const RooArgSet& set)`     <td> Override default projection behaviour by omitting observables listed
 ///                                    in set from the projection, i.e. by not integrating over these.
 ///                                    Slicing is usually only sensible in discrete observables, by e.g. creating a slice
 ///                                    of the PDF at the current value of the category observable.
@@ -1549,7 +1549,7 @@ void RooAbsReal::plotOnCompSelect(RooArgSet* selNodes) const
 ///                                    Slice(std::map<RooCategory*, std::string> const&) argument explained below.
 ///
 /// <tr><td> `Slice(std::map<RooCategory*, std::string> const&)`        <td> Omits multiple categories from the projection, as explianed above.
-///                                    Can be used with initializer std::lists for convenience, e.g.
+///                                    Can be used with initializer lists for convenience, e.g.
 /// ```{.cpp}
 ///   pdf.plotOn(frame, Slice({{&tagCategory, "2tag"}, {&jetCategory, "3jet"}});
 /// ```
@@ -1563,7 +1563,7 @@ void RooAbsReal::plotOnCompSelect(RooArgSet* selNodes) const
 ///
 /// <tr><td> `ProjWData(const RooArgSet& s, const RooAbsData& d)`   <td> As above but only consider subset 's' of observables in dataset 'd' for projection through data averaging
 ///
-/// <tr><td> `ProjectionRange(const char* rn)` <td> Override default range of projection integrals to a different range speficied by given range name.
+/// <tr><td> `ProjectionRange(const char* rn)` <td> Override default range of projection integrals to a different range specified by given range name.
 ///                                    This technique allows you to project a finite width slice in a real-valued observable
 ///
 /// <tr><td> `NumCPU(Int_t ncpu)`              <td> Number of CPUs to use simultaneously to calculate data-weighted projections (only in combination with ProjWData)
@@ -1586,7 +1586,7 @@ void RooAbsReal::plotOnCompSelect(RooArgSet* selNodes) const
 ///
 /// <tr><td> `Asymmetry(const RooCategory& c)` <td> Show the asymmetry of the PDF in given two-state category [F(+)-F(-)] / [F(+)+F(-)] rather than
 ///                                    the PDF projection. Category must have two states with indices -1 and +1 or three states with
-///                                    indeces -1,0 and +1.
+///                                    indices -1,0 and +1.
 ///
 /// <tr><td> `ShiftToZero(bool flag)`        <td> Shift entire curve such that lowest visible point is at exactly zero. Mostly useful when plotting \f$ -\log(L) \f$ or \f$ \chi^2 \f$ distributions
 ///
@@ -1782,7 +1782,7 @@ RooPlot* RooAbsReal::plotOn(RooPlot* frame, RooLinkedList& argList) const
   const RooAbsCategoryLValue* asymCat = (const RooAbsCategoryLValue*) pc.getObject("asymCat") ;
 
 
-  // Look for category slice arguments and add them to the master slice std::list if found
+  // Look for category slice arguments and add them to the master slice list if found
   const char* sliceCatState = pc.getString("sliceCatState",nullptr,true) ;
   const RooLinkedList& sliceCatList = pc.getObjectList("sliceCatList") ;
   if (sliceCatState) {
@@ -1925,7 +1925,7 @@ RooPlot* RooAbsReal::plotOn(RooPlot* frame, RooLinkedList& argList) const
 /// of the scale factor is unique for generic real functions, for PDFs there are various interpretations
 /// possible, which can be selection with 'stype' (see RooAbsPdf::plotOn() for details).
 ///
-/// The default projection behaviour can be overriden by supplying an optional set of dependents
+/// The default projection behaviour can be overridden by supplying an optional set of dependents
 /// to project. For most cases, plotSliceOn() and plotProjOn() provide a more intuitive interface
 /// to modify the default projection behaviour.
 //_____________________________________________________________________________
@@ -1953,7 +1953,7 @@ RooPlot* RooAbsReal::plotOn(RooPlot *frame, PlotOpt o) const
 
   cxcoutD(Plotting) << "RooAbsReal::plotOn(" << GetName() << ") ProjDataVars = " << projDataVars << std::endl ;
 
-  // Make std::list of variables to be projected
+  // Make list of variables to be projected
   RooArgSet projectedVars ;
   RooArgSet sliceSet ;
   if (o.projSet) {
@@ -1961,7 +1961,7 @@ RooPlot* RooAbsReal::plotOn(RooPlot *frame, PlotOpt o) const
     makeProjectionSet(frame->getPlotVar(),o.projSet,projectedVars,false) ;
     cxcoutD(Plotting) << "RooAbsReal::plotOn(" << GetName() << ") calculated projectedVars = " << *o.projSet << std::endl ;
 
-    // Print std::list of non-projected variables
+    // Print list of non-projected variables
     if (frame->getNormVars()) {
       RooArgSet sliceSetTmp;
       getObservables(frame->getNormVars(), sliceSetTmp) ;
@@ -2297,7 +2297,7 @@ RooPlot* RooAbsReal::plotAsymOn(RooPlot *frame, const RooAbsCategoryLValue& asym
   // Otherwise no projections are performed,
   //
   // The asymmetry function can be multiplied with an optional scale factor. The default projection
-  // behaviour can be overriden by supplying an optional set of dependents to project.
+  // behaviour can be overridden by supplying an optional set of dependents to project.
 
   // Sanity checks
   if (plotSanityChecks(frame)) return frame ;
@@ -2327,13 +2327,13 @@ RooPlot* RooAbsReal::plotAsymOn(RooPlot *frame, const RooAbsCategoryLValue& asym
     return frame ;
   }
 
-  // Make std::list of variables to be projected
+  // Make list of variables to be projected
   RooArgSet projectedVars ;
   RooArgSet sliceSet ;
   if (o.projSet) {
     makeProjectionSet(frame->getPlotVar(),o.projSet,projectedVars,false) ;
 
-    // Print std::list of non-projected variables
+    // Print list of non-projected variables
     if (frame->getNormVars()) {
       RooArgSet sliceSetTmp;
       getObservables(frame->getNormVars(), sliceSetTmp) ;
@@ -2620,7 +2620,7 @@ double RooAbsReal::getPropagatedError(const RooFitResult &fr, const RooArgSet &n
 
   // Re-evaluate this RooAbsReal with the central parameters just to be
   // extra-safe that a call to `getPropagatedError()` doesn't change any state.
-  // It should not be necessarry because thanks to the dirty flag propagation
+  // It should not be necessary because thanks to the dirty flag propagation
   // the RooAbsReal is re-evaluated anyway the next time getVal() is called.
   // Still there are imaginable corner cases where it would not be triggered,
   // for example if the user changes the RooFit operation more after the error
@@ -2689,7 +2689,7 @@ RooPlot* RooAbsReal::plotOnWithErrorBand(RooPlot* frame,const RooFitResult& fr, 
   RooLinkedList plotArgListTmp(argList) ;
   RooCmdConfig::stripCmdList(plotArgListTmp,"VisualizeError,MoveToBack") ;
 
-  // Strip any 'internal normalization' arguments from std::list
+  // Strip any 'internal normalization' arguments from list
   RooLinkedList plotArgList ;
   for (auto * cmd : static_range_cast<RooCmdArg*>(plotArgListTmp)) {
     if (std::string("Normalization")==cmd->GetName()) {
@@ -2801,7 +2801,7 @@ RooPlot* RooAbsReal::plotOnWithErrorBand(RooPlot* frame,const RooFitResult& fr, 
     }
 
 
-    // Make std::list of parameter instances of cloneFunc in order of error matrix
+    // Make list of parameter instances of cloneFunc in order of error matrix
     RooArgList paramList ;
     const RooArgList& fpf = fr.floatParsFinal() ;
     std::vector<int> fpf_idx ;
@@ -2980,7 +2980,7 @@ bool RooAbsReal::plotSanityChecks(RooPlot* frame) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Utility function for plotOn() that constructs the set of
 /// observables to project when plotting ourselves as function of
-/// 'plotVar'. 'allVars' is the std::list of variables that must be
+/// 'plotVar'. 'allVars' is the list of variables that must be
 /// projected, but may contain variables that we do not depend on. If
 /// 'silent' is cleared, warnings about inconsistent input parameters
 /// will be printed.
@@ -2994,7 +2994,7 @@ void RooAbsReal::makeProjectionSet(const RooAbsArg* plotVar, const RooArgSet* al
   projectedVars.removeAll() ;
   if (!allVars) return ;
 
-  // Start out with suggested std::list of variables
+  // Start out with suggested list of variables
   projectedVars.add(*allVars) ;
 
   // Take out plot variable
@@ -3485,7 +3485,7 @@ double RooAbsReal::maxVal(Int_t /*code*/) const
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Interface to insert remote error logging messages received by RooRealMPFE into current error loggin stream
+/// Interface to insert remote error logging messages received by RooRealMPFE into current error logging stream.
 
 void RooAbsReal::logEvalError(const RooAbsReal* originator, const char* origName, const char* message, const char* serverValueString)
 {
@@ -3533,10 +3533,10 @@ void RooAbsReal::logEvalError(const RooAbsReal* originator, const char* origName
 /// protocol than generic RooFit warning message (which go straight through RooMsgService)
 /// because evaluation errors can occur in very large numbers in the use of likelihood
 /// evaluations. In logEvalError mode, controlled by global method enableEvalErrorLogging()
-/// messages reported through this function are not printed but all stored in a std::list,
+/// messages reported through this function are not printed but all stored in a list,
 /// along with server values at the time of reporting. Error messages logged in this
 /// way can be printed in a structured way, eliminating duplicates and with the ability
-/// to truncate the std::list by printEvalErrors. This is the standard mode of error logging
+/// to truncate the list by printEvalErrors. This is the standard mode of error logging
 /// during MINUIT operations. If enableEvalErrorLogging() is false, all errors
 /// reported through this method are passed for immediate printing through RooMsgService.
 /// A string with server names and values is constructed automatically for error logging
@@ -3593,8 +3593,8 @@ void RooAbsReal::logEvalError(const char* message, const char* serverValueString
           << " server values: " << ee._srvval << std::endl ;
   } else if (_evalErrorMode==CollectErrors) {
     if (_evalErrorList[this].second.size() >= 2048) {
-       // avoid overflowing the error std::list, so if there are very many, print
-       // the oldest one first, and pop it off the std::list
+       // avoid overflowing the error list, so if there are very many, print
+       // the oldest one first, and pop it off the list
        const EvalError& oee = _evalErrorList[this].second.front();
        // print to debug stream, since these would normally be suppressed, and
        // we do not want to increase the error count in the message service...
@@ -3654,7 +3654,7 @@ std::list<double>* RooAbsReal::plotSamplingHint(RooAbsRealLValue& /*obs*/, doubl
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Print all outstanding logged evaluation error on the given ostream. If maxPerNode
-/// is zero, only the number of errors for each source (object with unique name) is std::listed.
+/// is zero, only the number of errors for each source (object with unique name) is listed.
 /// If maxPerNode is greater than zero, up to maxPerNode detailed error messages are shown
 /// per source of errors. A truncation message is shown if there were more errors logged
 /// than shown.
@@ -3764,7 +3764,7 @@ void RooAbsReal::fixAddCoefRange(const char* rangeName, bool force)
 /// Interface method for function objects to indicate their preferred order of observables
 /// for scanning their values into a (multi-dimensional) histogram or RooDataSet. The observables
 /// to be ordered are offered in argument 'obs' and should be copied in their preferred
-/// order into argument 'orderdObs', This default implementation indicates no preference
+/// order into argument 'orderedObs', This default implementation indicates no preference
 /// and copies the original order of 'obs' into 'orderedObs'
 
 void RooAbsReal::preferredObservableScanOrder(const RooArgSet& obs, RooArgSet& orderedObs) const
@@ -3787,7 +3787,7 @@ RooFit::OwningPtr<RooAbsReal> RooAbsReal::createRunningIntegral(const RooArgSet&
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Create an object that represents the running integral of the function over one or more observables std::listed in iset, i.e.
+/// Create an object that represents the running integral of the function over one or more observables listed in iset, i.e.
 /// \f[
 ///   \int_{x_\mathrm{lo}}^x f(x') \, \mathrm{d}x'
 /// \f]
@@ -3902,7 +3902,7 @@ RooFit::OwningPtr<RooAbsReal> RooAbsReal::createScanRI(const RooArgSet& iset, co
 
 RooFit::OwningPtr<RooAbsReal> RooAbsReal::createIntRI(const RooArgSet& iset, const RooArgSet& nset)
 {
-  // Make std::list of input arguments keeping only RooRealVars
+  // Make list of input arguments keeping only RooRealVars
   RooArgList ilist ;
   for(RooAbsArg * arg : iset) {
     if (dynamic_cast<RooRealVar*>(arg)) {
@@ -3916,7 +3916,7 @@ RooFit::OwningPtr<RooAbsReal> RooAbsReal::createIntRI(const RooArgSet& iset, con
   RooArgList loList ;
   RooArgSet clonedBranchNodes ;
 
-  // Setup customizer that stores all cloned branches in our non-owning std::list
+  // Setup customizer that stores all cloned branches in our non-owning list
   RooCustomizer cust(*this,"cdf") ;
   cust.setCloneBranchSet(clonedBranchNodes) ;
   cust.setOwning(false) ;
@@ -4195,7 +4195,7 @@ RooFit::OwningPtr<RooFitResult> RooAbsReal::chi2FitTo(RooDataHist& data, const R
   // Select the pdf-specific commands
   RooCmdConfig pc("RooAbsPdf::chi2FitTo(" + std::string(GetName()) + ")");
 
-  // Pull arguments to be passed to chi2 construction from std::list
+  // Pull arguments to be passed to chi2 construction from list
   RooLinkedList fitCmdList(cmdList) ;
   RooLinkedList chi2CmdList = pc.filterCmdList(fitCmdList, createChi2DataHistCmdArgs().c_str());
 
@@ -4211,7 +4211,7 @@ RooFit::OwningPtr<RooFitResult> RooAbsReal::chi2FitTo(RooDataHist& data, const R
 ///
 /// \param arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8 ordered arguments
 ///
-/// The std::list of supported command arguments is given in the documentation for
+/// The list of supported command arguments is given in the documentation for
 ///     RooChi2Var::RooChi2Var(const char *name, const char* title, RooAbsReal& func, RooDataHist& hdata, const RooCmdArg&,const RooCmdArg&,const RooCmdArg&, const RooCmdArg&,const RooCmdArg&,const RooCmdArg&, const RooCmdArg&,const RooCmdArg&,const RooCmdArg&).
 ///
 /// \param data Histogram with data
@@ -4310,7 +4310,7 @@ RooFit::OwningPtr<RooFitResult> RooAbsReal::chi2FitTo(RooDataSet& xydata, const 
   // Select the pdf-specific commands
   RooCmdConfig pc("RooAbsPdf::chi2FitTo(" + std::string(GetName()) + ")");
 
-  // Pull arguments to be passed to chi2 construction from std::list
+  // Pull arguments to be passed to chi2 construction from list
   RooLinkedList fitCmdList(cmdList) ;
   RooLinkedList chi2CmdList = pc.filterCmdList(fitCmdList,"YVar,Integrate") ;
 
@@ -4530,7 +4530,7 @@ void RooAbsReal::setParameterizeIntegral(const RooArgSet& paramVars)
   for (auto const* arg : paramVars) {
     if (!dependsOnValue(*arg)) {
       coutW(InputArguments) << "RooAbsReal::setParameterizeIntegral(" << GetName()
-             << ") function does not depend on std::listed parameter " << arg->GetName() << ", ignoring" << std::endl ;
+             << ") function does not depend on listed parameter " << arg->GetName() << ", ignoring" << std::endl ;
       continue ;
     }
     if (!plist.empty()) plist += ":" ;
@@ -4621,7 +4621,7 @@ void RooAbsReal::computeBatch(double* output, size_t nEvents, RooFit::Detail::Da
 ///
 /// \param[in] code The code that decides the integrands.
 /// \param[in] rangeName Name of the normalization range.
-/// \param[in] ctx An object to manage auxilary information for code-squashing.
+/// \param[in] ctx An object to manage auxiliary information for code-squashing.
 ///
 /// \returns The representative code string of the integral for the given object.
 std::string RooAbsReal::buildCallToAnalyticIntegral(Int_t /* code */, const char * /* rangeName */,

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -4399,7 +4399,7 @@ RooFit::OwningPtr<RooFitResult> RooAbsReal::chi2FitDriver(RooAbsReal& fcn, RooLi
   pc.defineInt("initHesse","InitialHesse",0,0) ;
   pc.defineInt("hesse","Hesse",0,1) ;
   pc.defineInt("minos","Minos",0,0) ;
-  pc.defineInt("ext","Extended",0,2) ;
+  pc.defineInt("ext","Extended",0,RooAbsPdf::extendedFitDefault) ;
   pc.defineInt("numee","PrintEvalErrors",0,10) ;
   pc.defineInt("doWarn","Warnings",0,1) ;
   pc.defineString("mintype","Minimizer",0,"") ;

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -4153,7 +4153,7 @@ double RooAbsReal::findRoot(RooRealVar& x, double xmin, double xmax, double yval
 /// <tr><td> `Hesse(bool flag)`             <td> Flag controls if HESSE is run after MIGRAD, on by default
 /// <tr><td> `Minos(bool flag)`             <td> Flag controls if MINOS is run after HESSE, on by default
 /// <tr><td> `Minos(const RooArgSet& set)`    <td> Only run MINOS on given subset of arguments
-/// <tr><td> `Save(bool flag)`              <td> Flac controls if RooFitResult object is produced and returned, off by default
+/// <tr><td> `Save(bool flag)`              <td> Flag controls if RooFitResult object is produced and returned, off by default
 /// <tr><td> `Strategy(Int_t flag)`           <td> Set Minuit strategy (0 through 2, default is 1)
 ///
 /// <tr><th> <th> Options to control informational output
@@ -4184,7 +4184,11 @@ RooFit::OwningPtr<RooFitResult> RooAbsReal::chi2FitTo(RooDataHist& data, const R
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// \copydoc RooAbsReal::chi2FitTo(RooDataHist&,const RooCmdArg&,const RooCmdArg&,const RooCmdArg&,const RooCmdArg&,const RooCmdArg&,const RooCmdArg&,const RooCmdArg&,const RooCmdArg&)
+/// Calls RooAbsReal::createChi2(RooDataSet& data, const RooLinkedList& cmdList) and returns fit result.
+///
+/// For the list of possible commands in the `cmdList`, see
+/// RooAbsReal::chi2FitTo(RooDataHist&,const RooCmdArg&,const RooCmdArg&,const RooCmdArg&,const RooCmdArg&,const RooCmdArg&,const RooCmdArg&,const RooCmdArg&,const RooCmdArg&) and
+/// RooAbsPdf::chi2FitTo(RooDataHist&,const RooCmdArg&,const RooCmdArg&,const RooCmdArg&,const RooCmdArg&,const RooCmdArg&,const RooCmdArg&,const RooCmdArg&,const RooCmdArg&).
 
 RooFit::OwningPtr<RooFitResult> RooAbsReal::chi2FitTo(RooDataHist& data, const RooLinkedList& cmdList)
 {
@@ -4193,7 +4197,7 @@ RooFit::OwningPtr<RooFitResult> RooAbsReal::chi2FitTo(RooDataHist& data, const R
 
   // Pull arguments to be passed to chi2 construction from std::list
   RooLinkedList fitCmdList(cmdList) ;
-  RooLinkedList chi2CmdList = pc.filterCmdList(fitCmdList,"Range,RangeWithName,NumCPU,Optimize,IntegrateBins") ;
+  RooLinkedList chi2CmdList = pc.filterCmdList(fitCmdList, createChi2DataHistCmdArgs().c_str());
 
   std::unique_ptr<RooAbsReal> chi2{createChi2(data,chi2CmdList)};
   return chi2FitDriver(*chi2,fitCmdList) ;
@@ -4269,7 +4273,7 @@ RooFit::OwningPtr<RooAbsReal> RooAbsReal::createChi2(RooDataHist& data, const Ro
 /// <tr><td> `Hesse(bool flag)`             <td>  Flag controls if HESSE is run after MIGRAD, on by default
 /// <tr><td> `Minos(bool flag)`             <td>  Flag controls if MINOS is run after HESSE, on by default
 /// <tr><td> `Minos(const RooArgSet& set)`    <td>  Only run MINOS on given subset of arguments
-/// <tr><td> `Save(bool flag)`              <td>  Flac controls if RooFitResult object is produced and returned, off by default
+/// <tr><td> `Save(bool flag)`              <td>  Flag controls if RooFitResult object is produced and returned, off by default
 /// <tr><td> `Strategy(Int_t flag)`           <td>  Set Minuit strategy (0 through 2, default is 1)
 ///
 /// <tr><th><th> Options to control informational output

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -4141,6 +4141,16 @@ double RooAbsReal::findRoot(RooRealVar& x, double xmin, double xmax, double yval
 ///
 /// <table>
 /// <tr><th> <th> Options to control construction of chi2
+/// <tr><td> `Extended(bool flag)` <td> **Only applicable when fitting a RooAbsPdf**. Scale the normalized pdf by the number of events predicted by the model instead of scaling by the total data weight.
+///                                     This imposes a constraint on the predicted number of events analogous to the extended term in a likelihood fit.
+///                                     - If you don't pass this command, an extended fit will be done by default if the pdf makes a prediction on the number of events
+///                                       (in RooFit jargon, "if the pdf can be extended").
+///                                     - Passing `Extended(true)` when the the pdf makes no prediction on the expected number of events will result in error messages,
+///                                       and the chi2 will fall back to the total data weight to scale the normalized pdf.
+///                                     - There are cases where the fit **must** be done in extended mode. This happens for example when you have a RooAddPdf
+///                                       where the coefficients represent component yields. If the fit is not extended, these coefficients will not be
+///                                       well-defined, as the RooAddPdf always normalizes itself. If you pass `Extended(false)` in such a case, an error will be
+///                                       printed and you'll most likely get garbage results.
 /// <tr><td> `Range(const char* name)`         <td> Fit only data inside range with given name
 /// <tr><td> `Range(double lo, double hi)` <td> Fit only data inside given range. A range named "fit" is created on the fly on all observables.
 ///                                               Multiple comma separated range names can be specified.

--- a/roofit/roofitcore/src/RooAbsRealLValue.cxx
+++ b/roofit/roofitcore/src/RooAbsRealLValue.cxx
@@ -102,7 +102,7 @@ RooAbsRealLValue::~RooAbsRealLValue()
 /// but this should be only done if there is no other solution.
 bool RooAbsRealLValue::inRange(double value, const char* rangeName, double* clippedValPtr) const
 {
-  // double range = getMax() - getMin() ; // ok for +/-INIFINITY
+  // double range = getMax() - getMin() ; // ok for +/-INFINITY
   double clippedValue(value);
   bool isInRange(true) ;
 

--- a/roofit/roofitcore/src/RooChi2Var.cxx
+++ b/roofit/roofitcore/src/RooChi2Var.cxx
@@ -144,15 +144,15 @@ RooChi2Var::RooChi2Var(const char *name, const char* title, RooAbsReal& func, Ro
 {
   RooCmdConfig pc("RooChi2Var::RooChi2Var") ;
   pc.defineInt("etype","DataError",0,(Int_t)RooDataHist::Auto) ;
-  pc.defineInt("extended","Extended",0,false) ;
+  pc.defineInt("extended","Extended",0,RooAbsPdf::extendedFitDefault);
   pc.allowUndefined() ;
 
   pc.process(arg1) ;  pc.process(arg2) ;  pc.process(arg3) ;
   pc.process(arg4) ;  pc.process(arg5) ;  pc.process(arg6) ;
   pc.process(arg7) ;  pc.process(arg8) ;  pc.process(arg9) ;
 
-  if (func.IsA()->InheritsFrom(RooAbsPdf::Class())) {
-    _funcMode = pc.getInt("extended") ? ExtendedPdf : Pdf ;
+  if (auto pdf = dynamic_cast<RooAbsPdf*>(&func)) {
+    _funcMode = pdf->interpretExtendedCmdArg(pc.getInt("extended")) ? ExtendedPdf : Pdf ;
   } else {
     _funcMode = Function ;
   }
@@ -204,7 +204,7 @@ RooChi2Var::RooChi2Var(const char *name, const char* title, RooAbsPdf& pdf, RooD
                          makeRooAbsTestStatisticCfgForPdf(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9))
 {
   RooCmdConfig pc("RooChi2Var::RooChi2Var") ;
-  pc.defineInt("extended","Extended",0,false) ;
+  pc.defineInt("extended","Extended",0,RooAbsPdf::extendedFitDefault) ;
   pc.defineInt("etype","DataError",0,(Int_t)RooDataHist::Auto) ;
   pc.allowUndefined() ;
 
@@ -212,7 +212,7 @@ RooChi2Var::RooChi2Var(const char *name, const char* title, RooAbsPdf& pdf, RooD
   pc.process(arg4) ;  pc.process(arg5) ;  pc.process(arg6) ;
   pc.process(arg7) ;  pc.process(arg8) ;  pc.process(arg9) ;
 
-  _funcMode = pc.getInt("extended") ? ExtendedPdf : Pdf ;
+  _funcMode = pdf.interpretExtendedCmdArg(pc.getInt("extended")) ? ExtendedPdf : Pdf ;
   _etype = (RooDataHist::ErrorType) pc.getInt("etype") ;
   if (_etype==RooAbsData::Auto) {
     _etype = hdata.isNonPoissonWeighted()? RooAbsData::SumW2 : RooAbsData::Expected ;

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -444,7 +444,7 @@ bool hasConsistentLayoutAndBinning(RooDataHist const& h1, RooDataHist const& h2)
   auto const& vars1 = *h1.get();
   auto const& vars2 = *h2.get();
 
-  // Check if numer of variables and names is consistent
+  // Check if number of variables and names is consistent
   if(!vars1.hasSameLayout(vars2)) {
     return false;
   }
@@ -658,7 +658,7 @@ void RooDataHist::_adjustBinning(RooRealVar &theirVar, const TAxis &axis,
    const std::string ourVarName(ourVar->GetName() ? ourVar->GetName() : ""), ownName(GetName() ? GetName() : "");
    // RooRealVar is derived from RooAbsRealLValue which is itself
    // derived from RooAbsReal and a virtual class RooAbsLValue
-   // supplying setter fuctions, check if ourVar is indeed derived
+   // supplying setter functions, check if ourVar is indeed derived
    // as real
    if (!dynamic_cast<RooAbsReal *>(ourVar)) {
       coutE(InputArguments) << "RooDataHist::adjustBinning(" << ownName << ") ERROR: dimension " << ourVarName
@@ -1143,7 +1143,7 @@ RooPlot *RooDataHist::plotOn(RooPlot *frame, PlotOpt o) const
 /// \param[in] xVals An array of event coordinates for which the weights should be
 ///                  calculated.
 /// \param[in] correctForBinSize Enable the inverse bin volume correction factor.
-/// \param[in] cdfBoundaries Enable the special boundary coundition for a cdf:
+/// \param[in] cdfBoundaries Enable the special boundary condition for a cdf:
 ///                          Underflow bins are assumed to have weight zero and
 ///                          overflow bins have weight one. Otherwise, the
 ///                          histogram is mirrored at the boundaries for the
@@ -1250,7 +1250,7 @@ void RooDataHist::interpolateQuadratic(double* output, std::span<const double> x
 /// \param[in] xVals An array of event coordinates for which the weights should be
 ///                  calculated.
 /// \param[in] correctForBinSize Enable the inverse bin volume correction factor.
-/// \param[in] cdfBoundaries Enable the special boundary coundition for a cdf:
+/// \param[in] cdfBoundaries Enable the special boundary condition for a cdf:
 ///                          Underflow bins are assumed to have weight zero and
 ///                          overflow bins have weight one. Otherwise, the
 ///                          histogram is mirrored at the boundaries for the
@@ -1338,7 +1338,7 @@ void RooDataHist::interpolateLinear(double* output, std::span<const double> xVal
 ///                  calculated.
 /// \param[in] intOrder Interpolation order; 0th and 1st order are supported.
 /// \param[in] correctForBinSize Enable the inverse bin volume correction factor.
-/// \param[in] cdfBoundaries Enable the special boundary coundition for a cdf:
+/// \param[in] cdfBoundaries Enable the special boundary condition for a cdf:
 ///                          Underflow bins are assumed to have weight zero and
 ///                          overflow bins have weight one. Otherwise, the
 ///                          histogram is mirrored at the boundaries for the
@@ -1386,7 +1386,7 @@ void RooDataHist::weights(double* output, std::span<double const> xVals, int int
 ///                     used for the interpolation. If zero, the bare weight for
 ///                     the bin enclosing the coordinatesis returned.
 /// \param[in] correctForBinSize Enable the inverse bin volume correction factor.
-/// \param[in] cdfBoundaries Enable the special boundary coundition for a cdf:
+/// \param[in] cdfBoundaries Enable the special boundary condition for a cdf:
 ///                          underflow bins are assumed to have weight zero and
 ///                          overflow bins have weight one. Otherwise, the
 ///                          histogram is mirrored at the boundaries for the
@@ -1420,7 +1420,7 @@ double RooDataHist::weightFast(const RooArgSet& bin, Int_t intOrder, bool correc
 ///                     used for the interpolation. If zero, the bare weight for
 ///                     the bin enclosing the coordinatesis returned.
 /// \param[in] correctForBinSize Enable the inverse bin volume correction factor.
-/// \param[in] cdfBoundaries Enable the special boundary coundition for a cdf:
+/// \param[in] cdfBoundaries Enable the special boundary condition for a cdf:
 ///                          underflow bins are assumed to have weight zero and
 ///                          overflow bins have weight one. Otherwise, the
 ///                          histogram is mirrored at the boundaries for the
@@ -1457,7 +1457,7 @@ double RooDataHist::weight(const RooArgSet& bin, Int_t intOrder, bool correctFor
 /// \param[in] intOrder Interpolation order, i.e. how many neighbouring bins are
 ///                     used for the interpolation.
 /// \param[in] correctForBinSize Enable the inverse bin volume correction factor.
-/// \param[in] cdfBoundaries Enable the special boundary coundition for a cdf:
+/// \param[in] cdfBoundaries Enable the special boundary condition for a cdf:
 ///                          underflow bins are assumed to have weight zero and
 ///                          overflow bins have weight one. Otherwise, the
 ///                          histogram is mirrored at the boundaries for the
@@ -1625,7 +1625,7 @@ void RooDataHist::weightError(double& lo, double& hi, ErrorType etype) const
 /// \param[in] intOrder Interpolation order, i.e. how many neighbouring bins are
 ///                     used for the interpolation.
 /// \param[in] correctForBinSize Enable the inverse bin volume correction factor.
-/// \param[in] cdfBoundaries Enable the special boundary coundition for a cdf:
+/// \param[in] cdfBoundaries Enable the special boundary condition for a cdf:
 ///                          underflow bins are assumed to have weight zero and
 ///                          overflow bins have weight one. Otherwise, the
 ///                          histogram is mirrored at the boundaries for the
@@ -1900,7 +1900,7 @@ double RooDataHist::sum(const RooArgSet& sumSet, const RooArgSet& sliceSet, bool
      pbinv = &calculatePartialBinVolume(sumSet);
   }
 
-  // Calculate mask and refence plot bins for non-iterating variables
+  // Calculate mask and reference plot bins for non-iterating variables
   std::vector<bool> mask(_vars.size());
   std::vector<int> refBin(_vars.size());
 
@@ -2013,7 +2013,7 @@ double RooDataHist::sum(const RooArgSet& sumSet, const RooArgSet& sliceSet,
     if (skip) continue;
 
     // Work out bin volume
-    // It's not necessary to figure out the bin volume for the slice-only set explicitely here.
+    // It's not necessary to figure out the bin volume for the slice-only set explicitly here.
     // We need to loop over the sumSet anyway to get the partial bin containment correction,
     // so we can get the slice-only set volume later by dividing _binv[ibin] / binVolumeSumSetFull.
     double binVolumeSumSetFull = 1.;

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -207,18 +207,18 @@ FinalizeVarsOutput finalizeVars(RooArgSet const &vars,
 
    // Gather all imported weighted datasets to infer the weight variable name
    // and whether we need weight errors
-   std::vector<RooAbsData*> weightedImpDatas;
-   if(impData && impData->isWeighted()) weightedImpDatas.push_back(impData);
+   std::vector<RooAbsData*> weightedImpDatasets;
+   if(impData && impData->isWeighted()) weightedImpDatasets.push_back(impData);
    for(auto * data : static_range_cast<RooAbsData*>(impSliceData)) {
       if(data->isWeighted()) {
-         weightedImpDatas.push_back(data);
+         weightedImpDatasets.push_back(data);
       }
    }
 
    bool needsWeightErrors = false;
 
    // Figure out if the weight needs to store errors
-   for(RooAbsData * data : weightedImpDatas) {
+   for(RooAbsData * data : weightedImpDatasets) {
       if(dynamic_cast<RooDataHist const*>(data)) {
          needsWeightErrors = true;
       }
@@ -233,7 +233,7 @@ FinalizeVarsOutput finalizeVars(RooArgSet const &vars,
    if(out.weightVarName.empty()) {
       // Even if no weight variable is specified, we want to have one if we are
       // importing weighted datasets
-      for(RooAbsData * data : weightedImpDatas) {
+      for(RooAbsData * data : weightedImpDatasets) {
          if(auto ds = dynamic_cast<RooDataSet const*>(data)) {
             // If the imported data is a RooDataSet, we take over its weight variable name
             out.weightVarName = ds->weightVar()->GetName();
@@ -296,7 +296,7 @@ std::unique_ptr<RooDataSet> makeDataSetFromDataHist(RooDataHist const &hist)
 ///
 /// <table>
 /// <tr><th> %RooCmdArg <th> Effect
-/// <tr><td> Import(TTree*)              <td> Import contents of given TTree. Only braches of the TTree that have names
+/// <tr><td> Import(TTree*)              <td> Import contents of given TTree. Only branches of the TTree that have names
 ///                                corresponding to those of the RooAbsArgs that define the RooDataSet are
 ///                                imported.
 /// <tr><td> ImportFromFile(const char* fileName, const char* treeName) <td> Import tree with given name from file with given name.
@@ -1728,7 +1728,7 @@ bool RooDataSet::write(ostream & ofs) const {
   }
 
   if (ofs.fail()) {
-    coutW(DataHandling) << "RooDataSet::write(" << GetName() << "): WARNING error(s) have occured in writing" << endl ;
+    coutW(DataHandling) << "RooDataSet::write(" << GetName() << "): WARNING error(s) have occurred in writing" << endl ;
   }
 
   return ofs.fail() ;

--- a/roofit/roofitcore/src/RooErrorVar.cxx
+++ b/roofit/roofitcore/src/RooErrorVar.cxx
@@ -20,7 +20,7 @@
 \ingroup Roofitcore
 
 RooErrorVar is an auxilary class that represents the error
-of a RooRealVar as a seperate object. The main reason of
+of a RooRealVar as a separate object. The main reason of
 existence of this class is to facilitate the reuse of existing
 techniques to perform calculations that involve a RooRealVars
 error, such as calculating the pull value.

--- a/roofit/roofitcore/src/RooFactoryWSTool.cxx
+++ b/roofit/roofitcore/src/RooFactoryWSTool.cxx
@@ -794,7 +794,7 @@ RooProduct* RooFactoryWSTool::prodfunc(const char *objName, const char* pdfList)
 /// creates the sum of a Gaussian and a Chebychev and all its variables.
 ///
 ///
-/// A seperate series of operator meta-type exists to simplify the construction of composite expressions
+/// A separate series of operator meta-type exists to simplify the construction of composite expressions
 /// meta-types in all capitals (SUM) create pdfs, meta types in lower case (sum) create
 /// functions.
 ///

--- a/roofit/roofitcore/src/RooFit/Evaluator.cxx
+++ b/roofit/roofitcore/src/RooFit/Evaluator.cxx
@@ -149,7 +149,7 @@ struct NodeInfo {
 ///
 /// \param[in] absReal The RooAbsReal object that sits on top of the
 ///            computation graph that we want to evaluate.
-/// \param[in] useGPU Whether the evaluation should be preferrably done on the GPU.
+/// \param[in] useGPU Whether the evaluation should be preferably done on the GPU.
 Evaluator::Evaluator(const RooAbsReal &absReal, bool useGPU)
    : _bufferManager{std::make_unique<Detail::BufferManager>()},
      _topNode{const_cast<RooAbsReal &>(absReal)},

--- a/roofit/roofitcore/src/RooNLLVarNew.cxx
+++ b/roofit/roofitcore/src/RooNLLVarNew.cxx
@@ -182,7 +182,7 @@ double RooNLLVarNew::computeBatchBinnedL(std::span<const double> preds, std::spa
    return finalizeResult(result, sumWeightKahanSum.Sum());
 }
 
-/** Compute multiple negative logs of propabilities
+/** Compute multiple negative logs of probabilities.
 
 \param output An array of doubles where the computation results will be stored
 \param nOut not used

--- a/roofit/roofitcore/src/RooPlot.cxx
+++ b/roofit/roofitcore/src/RooPlot.cxx
@@ -1079,7 +1079,7 @@ void RooPlot::SetMinimum(double minimum)
 ///
 /// \note The \f$ \chi^2 \f$ is calculated between a *plot of the original distribution* and the data.
 /// It therefore has more rounding errors than directly calculating the \f$ \chi^2 \f$ from a PDF or
-/// function. To do this, use RooChi2Var.
+/// function. To do this, use RooAbsReal::createChi2(RooDataHist&, const RooCmdArg&,  const RooCmdArg&, const RooCmdArg&,  const RooCmdArg&, const RooCmdArg&, const RooCmdArg&,  const RooCmdArg&, const RooCmdArg&).
 double RooPlot::chiSquare(const char* curvename, const char* histname, int nFitParam) const
 {
 

--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -578,7 +578,7 @@ bool RooWorkspace::import(const RooAbsArg& inArg,
                 << origName << " to " << wsnode->GetName() << endl ;
         }
       } else {
-        coutW(ObjectHandling) << "RooWorkspce::import(" << GetName() << ") Internal error: expected to find existing node "
+        coutW(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") Internal error: expected to find existing node "
             << origName << " to be renamed, but didn't find it..." << endl ;
       }
 
@@ -760,7 +760,7 @@ bool RooWorkspace::import(RooAbsData const& inData,
   if (!silence)
     coutI(ObjectHandling) << "RooWorkspace::import(" << GetName() << ") importing dataset " << inData.GetName() << endl ;
 
-  // Transform emtpy string into null pointer
+  // Transform empty string into null pointer
   if (dsetName && strlen(dsetName)==0) {
     dsetName=nullptr ;
   }
@@ -1098,7 +1098,7 @@ bool RooWorkspace::importClassCode(TClass* theClass, bool doReplace)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Inport code of all classes in the workspace that have a class name
+/// Import code of all classes in the workspace that have a class name
 /// that matches pattern 'pat' and which are not found to be part of
 /// the standard ROOT distribution. If doReplace is true any existing
 /// class code saved in the workspace is replaced
@@ -1157,7 +1157,7 @@ bool RooWorkspace::saveSnapshot(RooStringView name, const RooArgSet& params, boo
   }
 
   if (std::unique_ptr<RooArgSet> oldSnap{static_cast<RooArgSet*>(_snapshots.FindObject(name.c_str()))}) {
-    coutI(ObjectHandling) << "RooWorkspace::saveSnaphot(" << GetName() << ") replacing previous snapshot with name " << name << endl ;
+    coutI(ObjectHandling) << "RooWorkspace::saveSnapshot(" << GetName() << ") replacing previous snapshot with name " << name << endl ;
     _snapshots.Remove(oldSnap.get()) ;
   }
 
@@ -1501,7 +1501,7 @@ bool RooWorkspace::CodeRepo::autoImportClass(TClass* tc, bool doReplace)
     return true ;
   }
 
-  // Check if class is listed in a ROOTMAP file - if so we can skip it because it is in the root distribtion
+  // Check if class is listed in a ROOTMAP file - if so we can skip it because it is in the root distribution
   const char* mapEntry = gInterpreter->GetClassSharedLibs(tc->GetName()) ;
   if (mapEntry && strlen(mapEntry)>0) {
     oocxcoutD(_wspace,ObjectHandling) << "RooWorkspace::CodeRepo(" << _wspace->GetName() << ") code of class " << tc->GetName() << " is in ROOT distribution, skipping " << endl ;
@@ -1652,7 +1652,7 @@ bool RooWorkspace::CodeRepo::autoImportClass(TClass* tc, bool doReplace)
 
   list<string> extraHeaders ;
 
-  // If file has not beed stored yet, enter stl strings with implementation and declaration in file map
+  // If file has not been stored yet, enter stl strings with implementation and declaration in file map
   if (_fmap.find(declfilebase) == _fmap.end()) {
 
     // Open declaration file
@@ -1723,7 +1723,7 @@ bool RooWorkspace::CodeRepo::autoImportClass(TClass* tc, bool doReplace)
     }
 
 
-    // Import entire implentation file into stl string
+    // Import entire implementation file into stl string
     string impl ;
     while(fimpl.getline(buf,1023)) {
       // Process #include statements here
@@ -2720,12 +2720,12 @@ bool RooWorkspace::CodeRepo::compileClasses()
     if (!writeExtraHeaders) {
       writeExtraHeaders = true ;
 
-      map<TString,ExtraHeader>::iterator eiter = _ehmap.begin() ;
-      while(eiter!=_ehmap.end()) {
+      map<TString,ExtraHeader>::iterator extraIter = _ehmap.begin() ;
+      while(extraIter!=_ehmap.end()) {
 
    // Check if identical declaration file (header) is already written
    bool needEHWrite=true ;
-   string fdname = Form("%s/%s",dirName.c_str(),eiter->second._hname.Data()) ;
+   string fdname = Form("%s/%s",dirName.c_str(),extraIter->second._hname.Data()) ;
    ifstream ifdecl(fdname.c_str()) ;
    if (ifdecl) {
      TString contents ;
@@ -2735,7 +2735,7 @@ bool RooWorkspace::CodeRepo::compileClasses()
         contents += "\n";
      }
      UInt_t crcFile = crc32(contents.Data());
-     UInt_t crcWS = crc32(eiter->second._hfile.Data());
+     UInt_t crcWS = crc32(extraIter->second._hfile.Data());
      needEHWrite = (crcFile != crcWS);
    }
 
@@ -2753,10 +2753,10 @@ bool RooWorkspace::CodeRepo::compileClasses()
                                           << " for writing" << endl;
          return false;
       }
-      fdecl << eiter->second._hfile.Data();
+      fdecl << extraIter->second._hfile.Data();
       fdecl.close();
    }
-   ++eiter;
+   ++extraIter;
       }
     }
 

--- a/roofit/roofitcore/src/TestStatistics/buildLikelihood.cxx
+++ b/roofit/roofitcore/src/TestStatistics/buildLikelihood.cxx
@@ -152,7 +152,7 @@ std::unique_ptr<RooSubsidiaryL> buildSubsidiaryL(RooAbsPdf *pdf, RooAbsData *dat
    // Include constraints, if any, in likelihood
    if (!allConstraints.empty()) {
 
-      oocoutI(nullptr, Minimization) << " Including the following contraint terms in minimization: " << allConstraints
+      oocoutI(nullptr, Minimization) << " Including the following constraint terms in minimization: " << allConstraints
                                      << std::endl;
       if (!global_observables.empty()) {
          oocoutI(nullptr, Minimization) << "The following global observables have been defined: " << global_observables


### PR DESCRIPTION
It is confusing to the users that the chi2 fit is by default not extended, even if the pdf is extended. Because this is what happens in normal likelihood fits.

This commit makes that behavior consistent and explains it in the release notes.

Also, a new error message is added for the case you forcing a non extended fit on a pdf that must be extended, because this is guaranteed to give wrong results.

This change addresses the confusion on the forum:
https://root-forum.cern.ch/t/failing-chi2-fit/56309
