### PR TITLE
[RF] Fix skipping of zero weights in tests statistic caching

### DIFF
--- a/roofit/roofitcore/inc/RooAbsOptTestStatistic.h
+++ b/roofit/roofitcore/inc/RooAbsOptTestStatistic.h
@@ -73,6 +73,7 @@ protected:
   virtual RooArgSet requiredExtraObservables() const { return RooArgSet() ; }
   void optimizeCaching() ;
   void optimizeConstantTerms(bool,bool=true) ;
+  void runRecalculateCache(std::size_t firstEvent, std::size_t lastEvent, std::size_t stepSize) const override;
 
   RooArgSet*  _normSet = nullptr;           ///< Pointer to set with observables used for normalization
   RooArgSet*  _funcCloneSet = nullptr;      ///< Set owning all components of internal clone of input function
@@ -84,6 +85,7 @@ protected:
   TString     _sealNotice ;  ///< User-defined notice shown when reading a sealed likelihood
   RooArgSet*  _funcObsSet = nullptr;  ///< List of observables in the pdf expression
   RooArgSet   _cachedNodes ; ///<! List of nodes that are cached as constant expressions
+  bool _skipZeroWeights = false; ///<! Whether to skip entries with weight zero in the evaluation
 
   RooAbsReal* _origFunc = nullptr;  ///< Original function
   RooAbsData* _origData = nullptr;  ///< Original data

--- a/roofit/roofitcore/inc/RooAbsTestStatistic.h
+++ b/roofit/roofitcore/inc/RooAbsTestStatistic.h
@@ -92,6 +92,9 @@ protected:
   virtual double evaluatePartition(std::size_t firstEvent, std::size_t lastEvent, std::size_t stepSize) const = 0 ;
   virtual double getCarry() const;
 
+  // Overridden in cache-optimized test statistic
+  virtual void runRecalculateCache(std::size_t /*firstEvent*/, std::size_t /*lastEvent*/, std::size_t /*stepSize*/) const {}
+
   void setMPSet(Int_t setNum, Int_t numSets) ;
   void setSimCount(Int_t simCount) {
     // Store total number of components p.d.f. of a RooSimultaneous in this component test statistic

--- a/roofit/roofitcore/src/RooAbsTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsTestStatistic.cxx
@@ -256,6 +256,7 @@ double RooAbsTestStatistic::evaluate() const
       break ;
     }
 
+    runRecalculateCache(nFirst, nLast, nStep);
     double ret = evaluatePartition(nFirst,nLast,nStep);
 
     if (numSets()==1) {

--- a/roofit/roofitcore/src/RooChi2Var.cxx
+++ b/roofit/roofitcore/src/RooChi2Var.cxx
@@ -240,11 +240,7 @@ RooChi2Var::RooChi2Var(const RooChi2Var& other, const char* name) :
 
 double RooChi2Var::evaluatePartition(std::size_t firstEvent, std::size_t lastEvent, std::size_t stepSize) const
 {
-
   double result(0), carry(0);
-
-  _dataClone->store()->recalculateCache( _projDeps, firstEvent, lastEvent, stepSize, false) ;
-
 
   // Determine normalization factor depending on type of input function
   double normFactor(1) ;

--- a/roofit/roofitcore/src/RooDataWeightedAverage.cxx
+++ b/roofit/roofitcore/src/RooDataWeightedAverage.cxx
@@ -111,8 +111,6 @@ double RooDataWeightedAverage::evaluatePartition(std::size_t firstEvent, std::si
 {
   double result(0) ;
 
-  _dataClone->store()->recalculateCache( _projDeps, firstEvent, lastEvent, stepSize,false) ;
-
   if (setNum()==0 && _showProgress) {
     ccoutP(Plotting) << "." ;
     cout.flush() ;
@@ -130,6 +128,3 @@ double RooDataWeightedAverage::evaluatePartition(std::size_t firstEvent, std::si
 
   return result  ;
 }
-
-
-

--- a/roofit/roofitcore/src/RooNLLVar.cxx
+++ b/roofit/roofitcore/src/RooNLLVar.cxx
@@ -108,6 +108,7 @@ RooNLLVar::RooNLLVar(const char *name, const char* title, RooAbsPdf& pdf, RooAbs
   pc.process(arg7) ;  pc.process(arg8) ;  pc.process(arg9) ;
 
   _extended = pc.getInt("extended") ;
+  _skipZeroWeights = true;
 }
 
 
@@ -157,6 +158,10 @@ RooNLLVar::RooNLLVar(const char *name, const char *title, RooAbsPdf& pdf, RooAbs
         ++biter ;
       }
     }
+
+    _skipZeroWeights = false;
+  } else {
+    _skipZeroWeights = true;
   }
 }
 
@@ -230,11 +235,6 @@ double RooNLLVar::evaluatePartition(std::size_t firstEvent, std::size_t lastEven
   double sumWeight{0.0};
 
   auto * pdfClone = static_cast<RooAbsPdf*>(_funcClone);
-
-  // cout << "RooNLLVar::evaluatePartition(" << GetName() << ") projDeps = " << (_projDeps?*_projDeps:RooArgSet()) << endl ;
-
-  _dataClone->store()->recalculateCache( _projDeps, firstEvent, lastEvent, stepSize, (_binnedPdf?false:true) ) ;
-
 
 
   // If pdf is marked as binned - do a binned likelihood calculation here (sum of log-Poisson for each bin)

--- a/roofit/roofitcore/src/RooXYChi2Var.cxx
+++ b/roofit/roofitcore/src/RooXYChi2Var.cxx
@@ -373,8 +373,6 @@ double RooXYChi2Var::evaluatePartition(std::size_t firstEvent, std::size_t lastE
   // Loop over bins of dataset
   RooDataSet* xydata = (RooDataSet*) _dataClone ;
 
-  _dataClone->store()->recalculateCache( _projDeps, firstEvent, lastEvent, stepSize,false ) ;
-
   for (auto i=firstEvent ; i<lastEvent ; i+=stepSize) {
 
     // get the data values for this event


### PR DESCRIPTION
There was an evil hack in `RooAbsOptTestStatistic`:

```c++
_dataClone->cacheArgs(this,_cachedNodes,_normSet,!_funcClone->getAttribute("BinnedLikelihood")) ;
```

The final parameter determins if zero weights should be skipped when recalculating the caches. Indeed, for the NLL case, this corresponds to the BinnedLikelihood attrribute being present or not, but it broke the other test statistics for which zero weights should not be skipped at all.

This commit suggests a safer way to manage this with a new `RooAbOptTestStatistic::_skipZeroWeights` flag.

In particular, this change fixed a bug that got uncovered during a forum discussion:

https://root-forum.cern.ch/t/failing-chi2-fit/56309/3