### PR TITLE
[ntuple] add RFieldBase::RValue::Release()

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -170,6 +170,11 @@ public:
       ~RValue() { DestroyIfOwning(); }
 
       RValue GetNonOwningCopy() { return RValue(fField, fObjPtr, false); }
+      void *Release()
+      {
+         fIsOwning = false;
+         return fObjPtr;
+      }
 
       std::size_t Append() { return fField->Append(fObjPtr); }
       void Read(NTupleSize_t globalIndex) { fField->Read(globalIndex, fObjPtr); }

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -175,7 +175,9 @@ public:
       void *Release()
       {
          fIsOwning = false;
-         return static_cast<T *>(fObjPtr);
+         void *result = nullptr;
+         std::swap(result, fObjPtr);
+         return static_cast<T *>(result);
       }
 
       std::size_t Append() { return fField->Append(fObjPtr); }

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -170,10 +170,12 @@ public:
       ~RValue() { DestroyIfOwning(); }
 
       RValue GetNonOwningCopy() { return RValue(fField, fObjPtr, false); }
+
+      template <typename T>
       void *Release()
       {
          fIsOwning = false;
-         return fObjPtr;
+         return static_cast<T *>(fObjPtr);
       }
 
       std::size_t Append() { return fField->Append(fObjPtr); }


### PR DESCRIPTION
Adds a method to drop ownership of the object pointer in RValue. That is useful for framework code that uses RNTuple to construct an object and would then want to decouple that object from the RValue class.