### PR TITLE
[math] Don't `#include "Math/Error.h"` and `"Math/Util.h"` in Minuit2 headers

### DIFF
--- a/math/mathcore/CMakeLists.txt
+++ b/math/mathcore/CMakeLists.txt
@@ -155,10 +155,12 @@ ROOT_STANDARD_LIBRARY_PACKAGE(MathCore
     src/GaussLegendreIntegrator.cxx
     src/GenAlgoOptions.cxx
     src/GoFTest.cxx
+    src/IOptions.cxx
     src/Integrator.cxx
     src/IntegratorOptions.cxx
     src/MersenneTwisterEngine.cxx
     src/MinimTransformFunction.cxx
+    src/Minimizer.cxx
     src/MinimizerOptions.cxx
     src/MinimizerVariableTransformation.cxx
     src/MixMaxEngineImpl17.cxx

--- a/math/mathcore/inc/Fit/ParameterSettings.h
+++ b/math/mathcore/inc/Fit/ParameterSettings.h
@@ -15,9 +15,6 @@
 
 #include <string>
 
-#include "Math/Error.h"
-
-
 namespace ROOT {
 
    namespace Fit {
@@ -140,29 +137,7 @@ public:
    void SetValue(double val) {fValue = val;}
    /// set the step size
    void SetStepSize(double err) {fStepSize = err;}
-   /// set a double side limit,
-   /// if low == up the parameter is fixed  if low > up the limits are removed
-   /// The current parameter value should be within the given limits [low,up].
-   /// If the value is outside the limits, then a new parameter value is set to = (up+low)/2
-   void SetLimits(double low, double up) {
-
-      if ( low > up ) {
-         RemoveLimits();
-         return;
-      }
-      if (low == up && low == fValue) {
-         Fix();
-         return;
-      }
-      if (low > fValue || up < fValue) {
-         MATH_INFO_MSG("ParameterSettings","lower/upper bounds outside current parameter value. The value will be set to (low+up)/2 ");
-         fValue = 0.5 * (up+low);
-      }
-      fLowerLimit = low;
-      fUpperLimit = up;
-      fHasLowerLimit = true;
-      fHasUpperLimit = true;
-   }
+   void SetLimits(double low, double up);
    /// set a single upper limit
    void SetUpperLimit(double up) {
     fLowerLimit = 0.;

--- a/math/mathcore/inc/Math/IOptions.h
+++ b/math/mathcore/inc/Math/IOptions.h
@@ -11,9 +11,6 @@
 #ifndef ROOT_Math_IOptions
 #define ROOT_Math_IOptions
 
-
-#include "Math/Error.h"
-
 #include <iostream>
 #include <string>
 
@@ -47,26 +44,9 @@ public:
    void SetValue(const char * name, const char * val) { SetNamedValue(name,val);}
 
 
-   double  RValue(const char * name) const {
-      double val = 0;
-      bool ret = GetRealValue(name,val);
-      if (!ret )  MATH_ERROR_MSGVAL("IOptions::RValue"," return 0 - real option not found",name);
-      return val;
-   }
-
-   int   IValue(const char * name) const {
-      int val = 0;
-      bool ret = GetIntValue(name,val);
-      if (!ret )   MATH_ERROR_MSGVAL("IOptions::IValue"," return 0 - integer option not found",name);
-      return val;
-   }
-
-   std::string  NamedValue(const char * name) const {
-      std::string val;
-      bool ret = GetNamedValue(name,val);
-      if (!ret )  MATH_ERROR_MSGVAL("IOptions::NamedValue"," return empty string - named option not found",name);
-      return val;
-   }
+   double  RValue(const char * name) const;
+   int   IValue(const char * name) const;
+   std::string  NamedValue(const char * name) const;
 
 
    // generic method to retrieve  a type
@@ -80,24 +60,15 @@ public:
 
    // methods to be re-implemented in the derived classes
 
-
    virtual bool GetRealValue(const char *, double &) const { return false; }
-
    virtual bool GetIntValue(const char *, int &) const { return false; }
-
    virtual bool GetNamedValue(const char *, std::string &) const { return false; }
 
-   /// method wich need to be re-implemented by the derived classes
-   virtual void SetRealValue(const char * , double )  {MATH_ERROR_MSG("IOptions::SetRealValue","Invalid setter method called"); }
+   virtual void SetRealValue(const char * , double );
+   virtual void SetIntValue(const char * , int );
+   virtual void SetNamedValue(const char * , const char * );
 
-   virtual void SetIntValue(const char * , int ) {MATH_ERROR_MSG("IOptions::SetIntValue","Invalid setter method called"); }
-
-   virtual void SetNamedValue(const char * , const char * ) {MATH_ERROR_MSG("IOptions::SetNamedValue","Invalid setter method called"); }
-
-
-   /// print options
-   virtual void Print(std::ostream & = std::cout ) const {MATH_INFO_MSG("IOptions::Print","it is not implemented");}
-
+   virtual void Print(std::ostream & = std::cout ) const;
 
 private:
 

--- a/math/mathcore/inc/Math/Minimizer.h
+++ b/math/mathcore/inc/Math/Minimizer.h
@@ -14,13 +14,7 @@
 #define ROOT_Math_Minimizer
 
 #include "Math/IFunction.h"
-
 #include "Math/MinimizerOptions.h"
-
-#include "Math/Util.h"
-
-#include "Math/Error.h"
-
 
 #include <string>
 #include <limits>
@@ -200,25 +194,10 @@ public:
    virtual bool SetUpperLimitedVariable(unsigned int ivar , const std::string & name , double val , double step , double upper ) {
       return SetLimitedVariable(ivar, name, val, step, - std::numeric_limits<double>::infinity(), upper );
    }
-   /// set a new upper/lower limited variable (override if minimizer supports them ) otherwise as default set an unlimited variable
    virtual bool SetLimitedVariable(unsigned int ivar  , const std::string & name  , double val  , double  step ,
-                                   double lower , double  upper ) {
-      MATH_WARN_MSG("Minimizer::SetLimitedVariable","Setting of limited variable not implemented - set as unlimited");
-      MATH_UNUSED(lower); MATH_UNUSED(upper);
-      return SetVariable(ivar, name, val, step);
-   }
-   /// set a new fixed variable (override if minimizer supports them )
-   virtual bool SetFixedVariable(unsigned int  ivar  , const std::string &  name , double val  ) {
-      MATH_ERROR_MSG("Minimizer::SetFixedVariable","Setting of fixed variable not implemented");
-      MATH_UNUSED(ivar); MATH_UNUSED(name); MATH_UNUSED(val);
-      return false;
-   }
-   /// set the value of an already existing variable
-   virtual bool SetVariableValue(unsigned int ivar , double value) {
-      MATH_ERROR_MSG("Minimizer::SetVariableValue","Set of a variable value not implemented");
-      MATH_UNUSED(ivar); MATH_UNUSED(value);
-      return false;
-   }
+                                   double lower , double  upper );
+   virtual bool SetFixedVariable(unsigned int  ivar  , const std::string &  name , double val  );
+   virtual bool SetVariableValue(unsigned int ivar , double value);
    /// set the values of all existing variables (array must be dimensioned to the size of the existing parameters)
    virtual bool SetVariableValues(const double * x) {
       bool ret = true;
@@ -228,54 +207,17 @@ public:
       }
       return ret;
    }
-   /// set the step size of an already existing variable
-   virtual bool SetVariableStepSize(unsigned int ivar, double value ) {
-      MATH_ERROR_MSG("Minimizer::SetVariableStepSize","Setting an existing variable step size not implemented");
-      MATH_UNUSED(ivar); MATH_UNUSED(value);
-      return false;
-   }
-   /// set the lower-limit of an already existing variable
-   virtual bool SetVariableLowerLimit(unsigned int ivar, double lower) {
-      MATH_ERROR_MSG("Minimizer::SetVariableLowerLimit","Setting an existing variable limit not implemented");
-      MATH_UNUSED(ivar); MATH_UNUSED(lower);
-      return false;
-   }
-   /// set the upper-limit of an already existing variable
-   virtual bool SetVariableUpperLimit(unsigned int ivar, double upper) {
-      MATH_ERROR_MSG("Minimizer::SetVariableUpperLimit","Setting an existing variable limit not implemented");
-      MATH_UNUSED(ivar); MATH_UNUSED(upper);
-      return false;
-   }
+   virtual bool SetVariableStepSize(unsigned int ivar, double value );
+   virtual bool SetVariableLowerLimit(unsigned int ivar, double lower);
+   virtual bool SetVariableUpperLimit(unsigned int ivar, double upper);
    /// set the limits of an already existing variable
    virtual bool SetVariableLimits(unsigned int ivar, double lower, double upper) {
       return SetVariableLowerLimit(ivar,lower) && SetVariableUpperLimit(ivar,upper);
    }
-   /// fix an existing variable
-   virtual bool FixVariable(unsigned int ivar) {
-      MATH_ERROR_MSG("Minimizer::FixVariable","Fixing an existing variable not implemented");
-      MATH_UNUSED(ivar);
-      return false;
-   }
-   /// release an existing variable
-   virtual bool ReleaseVariable(unsigned int ivar) {
-      MATH_ERROR_MSG("Minimizer::ReleaseVariable","Releasing an existing variable not implemented");
-      MATH_UNUSED(ivar);
-      return false;
-   }
-   /// query if an existing variable is fixed (i.e. considered constant in the minimization)
-   /// note that by default all variables are not fixed
-   virtual bool IsFixedVariable(unsigned int ivar) const {
-      MATH_ERROR_MSG("Minimizer::IsFixedVariable","Querying an existing variable not implemented");
-      MATH_UNUSED(ivar);
-      return false;
-   }
-   /// get variable settings in a variable object (like ROOT::Fit::ParamsSettings)
-   virtual bool GetVariableSettings(unsigned int ivar, ROOT::Fit::ParameterSettings & pars) const {
-      MATH_ERROR_MSG("Minimizer::GetVariableSettings","Querying an existing variable not implemented");
-      MATH_UNUSED(ivar); MATH_UNUSED(pars);
-      return false;
-   }
-
+   virtual bool FixVariable(unsigned int ivar);
+   virtual bool ReleaseVariable(unsigned int ivar);
+   virtual bool IsFixedVariable(unsigned int ivar) const;
+   virtual bool GetVariableSettings(unsigned int ivar, ROOT::Fit::ParameterSettings & pars) const;
 
    /// set the initial range of an existing variable
    virtual bool SetVariableInitialRange(unsigned int /* ivar */, double /* mininitial */, double /* maxinitial */) {
@@ -318,39 +260,9 @@ public:
    /// return errors at the minimum
    virtual const double * Errors() const { return nullptr; }
 
-   /** return covariance matrices element for variables ivar,jvar
-       if the variable is fixed the return value is zero
-       The ordering of the variables is the same as in the parameter and errors vectors
-   */
-   virtual double CovMatrix(unsigned int  ivar , unsigned int jvar ) const {
-      MATH_UNUSED(ivar); MATH_UNUSED(jvar);
-      return 0;
-   }
-
-   /**
-       Fill the passed array with the  covariance matrix elements
-       if the variable is fixed or const the value is zero.
-       The array will be filled as cov[i *ndim + j]
-       The ordering of the variables is the same as in errors and parameter value.
-       This is different from the direct interface of Minuit2 or TMinuit where the
-       values were obtained only to variable parameters
-   */
-   virtual bool GetCovMatrix(double * covMat) const {
-      MATH_UNUSED(covMat);
-      return false;
-   }
-
-   /**
-       Fill the passed array with the Hessian matrix elements
-       The Hessian matrix is the matrix of the second derivatives
-       and is the inverse of the covariance matrix
-       If the variable is fixed or const the values for that variables are zero.
-       The array will be filled as h[i *ndim + j]
-   */
-   virtual bool GetHessianMatrix(double * hMat) const {
-      MATH_UNUSED(hMat);
-      return false;
-   }
+   virtual double CovMatrix(unsigned int  ivar , unsigned int jvar ) const;
+   virtual bool GetCovMatrix(double * covMat) const;
+   virtual bool GetHessianMatrix(double * hMat) const;
 
 
    ///return status of covariance matrix
@@ -369,60 +281,14 @@ public:
       return ( tmp < 0) ? 0 : CovMatrix(i,j) / std::sqrt( tmp );
    }
 
-   /**
-      return global correlation coefficient for variable i
-      This is a number between zero and one which gives
-      the correlation between the i-th parameter  and that linear combination of all
-      other parameters which is most strongly correlated with i.
-      Minimizer must overload method if implemented
-    */
-   virtual double GlobalCC(unsigned int ivar) const {
-      MATH_UNUSED(ivar);
-      return -1;
-   }
+   virtual double GlobalCC(unsigned int ivar) const;
 
-   /**
-      minos error for variable i, return false if Minos failed or not supported
-      and the lower and upper errors are returned in errLow and errUp
-      An extra flag  specifies if only the lower (option=-1) or the upper (option=+1) error calculation is run
-   */
-   virtual bool GetMinosError(unsigned int ivar , double & errLow, double & errUp, int option = 0) {
-      MATH_ERROR_MSG("Minimizer::GetMinosError","Minos Error not implemented");
-      MATH_UNUSED(ivar); MATH_UNUSED(errLow); MATH_UNUSED(errUp); MATH_UNUSED(option);
-      return false;
-   }
-
-   /**
-      perform a full calculation of the Hessian matrix for error calculation
-    */
-   virtual bool Hesse() {
-      MATH_ERROR_MSG("Minimizer::Hesse","Hesse not implemented");
-      return false;
-   }
-
-   /**
-      scan function minimum for variable i. Variable and function must be set before using Scan
-      Return false if an error or if minimizer does not support this functionality
-    */
+   virtual bool GetMinosError(unsigned int ivar , double & errLow, double & errUp, int option = 0);
+   virtual bool Hesse();
    virtual bool Scan(unsigned int ivar , unsigned int & nstep , double * x , double * y ,
-                     double xmin = 0, double xmax = 0) {
-      MATH_ERROR_MSG("Minimizer::Scan","Scan not implemented");
-      MATH_UNUSED(ivar); MATH_UNUSED(nstep); MATH_UNUSED(x); MATH_UNUSED(y);
-      MATH_UNUSED(xmin); MATH_UNUSED(xmax);
-      return false;
-   }
-
-   /**
-      find the contour points (xi, xj) of the function for parameter ivar and jvar around the minimum
-      The contour will be find for value of the function = Min + ErrorUp();
-    */
+                     double xmin = 0, double xmax = 0);
    virtual bool Contour(unsigned int ivar , unsigned int jvar, unsigned int & npoints,
-                        double *  xi , double * xj ) {
-      MATH_ERROR_MSG("Minimizer::Contour","Contour not implemented");
-      MATH_UNUSED(ivar); MATH_UNUSED(jvar); MATH_UNUSED(npoints);
-      MATH_UNUSED(xi); MATH_UNUSED(xj);
-      return false;
-   }
+                        double *  xi , double * xj );
 
    /// return reference to the objective function
    ///virtual const ROOT::Math::IGenFunction & Function() const = 0;
@@ -430,20 +296,9 @@ public:
    /// print the result according to set level (implemented for TMinuit for maintaining Minuit-style printing)
    virtual void PrintResults() {}
 
-   /// get name of variables (override if minimizer support storing of variable names)
-   /// return an empty string if variable is not found
-   virtual std::string VariableName(unsigned int ivar) const {
-      MATH_UNUSED(ivar);
-      return std::string(); // return empty string
-   }
+   virtual std::string VariableName(unsigned int ivar) const;
 
-   /// get index of variable given a variable given a name
-   /// return -1 if variable is not found
-   virtual int VariableIndex(const std::string & name) const {
-      MATH_ERROR_MSG("Minimizer::VariableIndex","Getting variable index from name not implemented");
-      MATH_UNUSED(name);
-      return -1;
-   }
+   virtual int VariableIndex(const std::string & name) const;
 
    /** minimizer configuration parameters **/
 

--- a/math/mathcore/src/IOptions.cxx
+++ b/math/mathcore/src/IOptions.cxx
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023, CERN
+ */
+
+#include <Math/IOptions.h>
+
+#include <Math/Error.h>
+
+namespace ROOT {
+namespace Math {
+
+double IOptions::RValue(const char *name) const
+{
+   double val = 0;
+   bool ret = GetRealValue(name, val);
+   if (!ret)
+      MATH_ERROR_MSGVAL("IOptions::RValue", " return 0 - real option not found", name);
+   return val;
+}
+
+int IOptions::IValue(const char *name) const
+{
+   int val = 0;
+   bool ret = GetIntValue(name, val);
+   if (!ret)
+      MATH_ERROR_MSGVAL("IOptions::IValue", " return 0 - integer option not found", name);
+   return val;
+}
+
+std::string IOptions::NamedValue(const char *name) const
+{
+   std::string val;
+   bool ret = GetNamedValue(name, val);
+   if (!ret)
+      MATH_ERROR_MSGVAL("IOptions::NamedValue", " return empty string - named option not found", name);
+   return val;
+}
+
+/// method wich need to be re-implemented by the derived classes
+void IOptions::SetRealValue(const char *, double)
+{
+   MATH_ERROR_MSG("IOptions::SetRealValue", "Invalid setter method called");
+}
+
+void IOptions::SetIntValue(const char *, int)
+{
+   MATH_ERROR_MSG("IOptions::SetIntValue", "Invalid setter method called");
+}
+
+void IOptions::SetNamedValue(const char *, const char *)
+{
+   MATH_ERROR_MSG("IOptions::SetNamedValue", "Invalid setter method called");
+}
+
+/// print options
+void IOptions::Print(std::ostream &) const
+{
+   MATH_INFO_MSG("IOptions::Print", "it is not implemented");
+}
+
+} // namespace Math
+} // namespace ROOT

--- a/math/mathcore/src/Minimizer.cxx
+++ b/math/mathcore/src/Minimizer.cxx
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2023, CERN
+ */
+
+#include <Math/Minimizer.h>
+
+#include <Math/Error.h>
+#include <Math/Util.h>
+
+namespace ROOT {
+namespace Math {
+
+/// set a new upper/lower limited variable (override if minimizer supports them ) otherwise as default set an unlimited
+/// variable
+bool Minimizer::SetLimitedVariable(unsigned int ivar, const std::string &name, double val, double step, double lower,
+                                   double upper)
+{
+   MATH_WARN_MSG("Minimizer::SetLimitedVariable", "Setting of limited variable not implemented - set as unlimited");
+   MATH_UNUSED(lower);
+   MATH_UNUSED(upper);
+   return SetVariable(ivar, name, val, step);
+}
+
+/// set a new fixed variable (override if minimizer supports them )
+bool Minimizer::SetFixedVariable(unsigned int ivar, const std::string &name, double val)
+{
+   MATH_ERROR_MSG("Minimizer::SetFixedVariable", "Setting of fixed variable not implemented");
+   MATH_UNUSED(ivar);
+   MATH_UNUSED(name);
+   MATH_UNUSED(val);
+   return false;
+}
+/// set the value of an already existing variable
+bool Minimizer::SetVariableValue(unsigned int ivar, double value)
+{
+   MATH_ERROR_MSG("Minimizer::SetVariableValue", "Set of a variable value not implemented");
+   MATH_UNUSED(ivar);
+   MATH_UNUSED(value);
+   return false;
+}
+
+/// set the step size of an already existing variable
+bool Minimizer::SetVariableStepSize(unsigned int ivar, double value)
+{
+   MATH_ERROR_MSG("Minimizer::SetVariableStepSize", "Setting an existing variable step size not implemented");
+   MATH_UNUSED(ivar);
+   MATH_UNUSED(value);
+   return false;
+}
+/// set the lower-limit of an already existing variable
+bool Minimizer::SetVariableLowerLimit(unsigned int ivar, double lower)
+{
+   MATH_ERROR_MSG("Minimizer::SetVariableLowerLimit", "Setting an existing variable limit not implemented");
+   MATH_UNUSED(ivar);
+   MATH_UNUSED(lower);
+   return false;
+}
+/// set the upper-limit of an already existing variable
+bool Minimizer::SetVariableUpperLimit(unsigned int ivar, double upper)
+{
+   MATH_ERROR_MSG("Minimizer::SetVariableUpperLimit", "Setting an existing variable limit not implemented");
+   MATH_UNUSED(ivar);
+   MATH_UNUSED(upper);
+   return false;
+}
+
+/// fix an existing variable
+bool Minimizer::FixVariable(unsigned int ivar)
+{
+   MATH_ERROR_MSG("Minimizer::FixVariable", "Fixing an existing variable not implemented");
+   MATH_UNUSED(ivar);
+   return false;
+}
+/// release an existing variable
+bool Minimizer::ReleaseVariable(unsigned int ivar)
+{
+   MATH_ERROR_MSG("Minimizer::ReleaseVariable", "Releasing an existing variable not implemented");
+   MATH_UNUSED(ivar);
+   return false;
+}
+/// query if an existing variable is fixed (i.e. considered constant in the minimization)
+/// note that by default all variables are not fixed
+bool Minimizer::IsFixedVariable(unsigned int ivar) const
+{
+   MATH_ERROR_MSG("Minimizer::IsFixedVariable", "Querying an existing variable not implemented");
+   MATH_UNUSED(ivar);
+   return false;
+}
+/// get variable settings in a variable object (like ROOT::Fit::ParamsSettings)
+bool Minimizer::GetVariableSettings(unsigned int ivar, ROOT::Fit::ParameterSettings &pars) const
+{
+   MATH_ERROR_MSG("Minimizer::GetVariableSettings", "Querying an existing variable not implemented");
+   MATH_UNUSED(ivar);
+   MATH_UNUSED(pars);
+   return false;
+}
+/** return covariance matrices element for variables ivar,jvar
+    if the variable is fixed the return value is zero
+    The ordering of the variables is the same as in the parameter and errors vectors
+*/
+double Minimizer::CovMatrix(unsigned int ivar, unsigned int jvar) const
+{
+   MATH_UNUSED(ivar);
+   MATH_UNUSED(jvar);
+   return 0;
+}
+
+/**
+    Fill the passed array with the  covariance matrix elements
+    if the variable is fixed or const the value is zero.
+    The array will be filled as cov[i *ndim + j]
+    The ordering of the variables is the same as in errors and parameter value.
+    This is different from the direct interface of Minuit2 or TMinuit where the
+    values were obtained only to variable parameters
+*/
+bool Minimizer::GetCovMatrix(double *covMat) const
+{
+   MATH_UNUSED(covMat);
+   return false;
+}
+
+/**
+    Fill the passed array with the Hessian matrix elements
+    The Hessian matrix is the matrix of the second derivatives
+    and is the inverse of the covariance matrix
+    If the variable is fixed or const the values for that variables are zero.
+    The array will be filled as h[i *ndim + j]
+*/
+bool Minimizer::GetHessianMatrix(double *hMat) const
+{
+   MATH_UNUSED(hMat);
+   return false;
+}
+
+/**
+   return global correlation coefficient for variable i
+   This is a number between zero and one which gives
+   the correlation between the i-th parameter  and that linear combination of all
+   other parameters which is most strongly correlated with i.
+   Minimizer must overload method if implemented
+ */
+double Minimizer::GlobalCC(unsigned int ivar) const
+{
+   MATH_UNUSED(ivar);
+   return -1;
+}
+
+/**
+   minos error for variable i, return false if Minos failed or not supported
+   and the lower and upper errors are returned in errLow and errUp
+   An extra flag  specifies if only the lower (option=-1) or the upper (option=+1) error calculation is run
+*/
+bool Minimizer::GetMinosError(unsigned int ivar, double &errLow, double &errUp, int option)
+{
+   MATH_ERROR_MSG("Minimizer::GetMinosError", "Minos Error not implemented");
+   MATH_UNUSED(ivar);
+   MATH_UNUSED(errLow);
+   MATH_UNUSED(errUp);
+   MATH_UNUSED(option);
+   return false;
+}
+
+/**
+   perform a full calculation of the Hessian matrix for error calculation
+ */
+bool Minimizer::Hesse()
+{
+   MATH_ERROR_MSG("Minimizer::Hesse", "Hesse not implemented");
+   return false;
+}
+
+/**
+   scan function minimum for variable i. Variable and function must be set before using Scan
+   Return false if an error or if minimizer does not support this functionality
+ */
+bool Minimizer::Scan(unsigned int ivar, unsigned int &nstep, double *x, double *y, double xmin, double xmax)
+{
+   MATH_ERROR_MSG("Minimizer::Scan", "Scan not implemented");
+   MATH_UNUSED(ivar);
+   MATH_UNUSED(nstep);
+   MATH_UNUSED(x);
+   MATH_UNUSED(y);
+   MATH_UNUSED(xmin);
+   MATH_UNUSED(xmax);
+   return false;
+}
+
+/**
+   find the contour points (xi, xj) of the function for parameter ivar and jvar around the minimum
+   The contour will be find for value of the function = Min + ErrorUp();
+ */
+bool Minimizer::Contour(unsigned int ivar, unsigned int jvar, unsigned int &npoints, double *xi, double *xj)
+{
+   MATH_ERROR_MSG("Minimizer::Contour", "Contour not implemented");
+   MATH_UNUSED(ivar);
+   MATH_UNUSED(jvar);
+   MATH_UNUSED(npoints);
+   MATH_UNUSED(xi);
+   MATH_UNUSED(xj);
+   return false;
+}
+
+/// get name of variables (override if minimizer support storing of variable names)
+/// return an empty string if variable is not found
+std::string Minimizer::VariableName(unsigned int ivar) const
+{
+   MATH_UNUSED(ivar);
+   return std::string(); // return empty string
+}
+
+/// get index of variable given a variable given a name
+/// return -1 if variable is not found
+int Minimizer::VariableIndex(const std::string &name) const
+{
+   MATH_ERROR_MSG("Minimizer::VariableIndex", "Getting variable index from name not implemented");
+   MATH_UNUSED(name);
+   return -1;
+}
+
+} // namespace Math
+} // namespace ROOT

--- a/math/mathcore/src/ParameterSettings.cxx
+++ b/math/mathcore/src/ParameterSettings.cxx
@@ -10,20 +10,40 @@
 
 // Implementation file for class ParameterSettings
 
-#include "Fit/ParameterSettings.h"
+#include <Fit/ParameterSettings.h>
 
+#include <Math/Error.h>
 
 namespace ROOT {
 
-   namespace Fit {
+namespace Fit {
 
+/// set a double side limit,
+/// if low == up the parameter is fixed  if low > up the limits are removed
+/// The current parameter value should be within the given limits [low,up].
+/// If the value is outside the limits, then a new parameter value is set to = (up+low)/2
+void ParameterSettings::SetLimits(double low, double up)
+{
 
-// ParameterSettings::ParameterSettings()
-// {
-//    // Default constructor implementation.
-// }
+   if (low > up) {
+      RemoveLimits();
+      return;
+   }
+   if (low == up && low == fValue) {
+      Fix();
+      return;
+   }
+   if (low > fValue || up < fValue) {
+      MATH_INFO_MSG("ParameterSettings",
+                    "lower/upper bounds outside current parameter value. The value will be set to (low+up)/2 ");
+      fValue = 0.5 * (up + low);
+   }
+   fLowerLimit = low;
+   fUpperLimit = up;
+   fHasLowerLimit = true;
+   fHasUpperLimit = true;
+}
 
-   } // end namespace Fit
+} // end namespace Fit
 
 } // end namespace ROOT
-

--- a/math/minuit2/src/Minuit2Minimizer.cxx
+++ b/math/minuit2/src/Minuit2Minimizer.cxx
@@ -44,6 +44,7 @@
 #include <functional>
 
 #ifdef USE_ROOT_ERROR
+#include "TError.h"
 #include "TROOT.h"
 #include "TMinuit2TraceObject.h"
 #endif

--- a/math/minuit2/src/math/CMakeLists.txt
+++ b/math/minuit2/src/math/CMakeLists.txt
@@ -26,7 +26,10 @@ set(MATH_HEADERS
 
 set(MATH_SOURCES
     GenAlgoOptions.cxx
+    IOptions.cxx
+    Minimizer.cxx
     MinimizerOptions.cxx
+    ParameterSettings.cxx
     )
 
 copy_standalone(SOURCE ../../../mathcore/inc/Fit DESTINATION ../../inc/Fit

--- a/roofit/roofitcore/inc/RooFit/TestStatistics/LikelihoodWrapper.h
+++ b/roofit/roofitcore/inc/RooFit/TestStatistics/LikelihoodWrapper.h
@@ -17,7 +17,8 @@
 #include "RooAbsArg.h" // enum ConstOpCode
 
 #include <Fit/ParameterSettings.h>
-#include "Math/MinimizerOptions.h"
+#include <Math/MinimizerOptions.h>
+#include <Math/Util.h>
 
 #include <memory> // shared_ptr
 #include <string>


### PR DESCRIPTION
The "Math/Error.h" header is not shipped with standalone Minuit2.

It is not a perfect solution to just ship it with Minuit2, because the Error.h header behaves differently depending on the `MATHCORE_STANDALONE` macro being defined or not. The code would only work correctly if the user defines the `MATHCORE_STANDALONE` herself in the user code that uses standalone Minuit2, which would be annoying.

Instead, this commit proposes another solution to the problem: for all headers also used in Minuit2 standalone, MathCore
moves the definitions of all functions that use `Math/Error.h` out of the header files in the cxx files. Like this, the `Math/Error.h` is only a build dependency of standalone Minuit2, and the user doesn't need to define the `MATHCORE_STANDALONE` macro for it to work.

Including the "Math/Util.h" header needs to be avoided for similar reasons (it's about another preprocessor macro related to `veccore`).