### PR TITLE
[tree] Add globbing for subdirectories in TChain::Add

### DIFF
--- a/tree/tree/src/InternalTreeUtils.cxx
+++ b/tree/tree/src/InternalTreeUtils.cxx
@@ -424,7 +424,7 @@ std::vector<std::unique_ptr<TChain>> MakeFriends(const ROOT::TreeUtils::RFriendI
 /// TSystem::OpenDirectory. If the directory can be opened, then current
 /// glob is used as regex expression (via TRegexp) to find subdirectories or
 /// store those files in the directory that match the regex.
-void RecursiveGlob(TList &l, const std::string &glob)
+void RecursiveGlob(TList &out, const std::string &glob)
 {
    std::string dirname;
    std::string basename; // current glob to expand, could be a directory or file.
@@ -479,11 +479,11 @@ void RecursiveGlob(TList &l, const std::string &glob)
          // but for GCC < 9.1 this requires an extra linking flag https://en.cppreference.com/w/cpp/filesystem
          bool isDirectory = TSystemFile().IsDirectory((dirname + '/' + dirEntry).c_str());
          if (!remainder.empty() && isDirectory) {
-            RecursiveGlob(l, dirname + '/' + dirEntry + '/' + remainder);
+            RecursiveGlob(out, dirname + '/' + dirEntry + '/' + remainder);
          } else if (remainder.empty() && !isDirectory) {
             // Using '/' as separator here as it was done in TChain::Add
             // In principle this should be using the appropriate platform separator
-            l.Add(new TObjString((dirname + '/' + dirEntry).c_str()));
+            out.Add(new TObjString((dirname + '/' + dirEntry).c_str()));
          }
       }
 

--- a/tree/tree/src/InternalTreeUtils.cxx
+++ b/tree/tree/src/InternalTreeUtils.cxx
@@ -17,6 +17,7 @@
 #include "TRegexp.h"
 #include "TString.h"
 #include "TSystem.h"
+#include "TSystemFile.h"
 #include "TTree.h"
 #include "TVirtualIndex.h"
 
@@ -409,35 +410,53 @@ std::vector<std::unique_ptr<TChain>> MakeFriends(const ROOT::TreeUtils::RFriendI
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// \brief Expands input glob into a collection of full paths to files.
+/// \brief Recursively expand the glob to take care of potential wildcard
+/// specials for subdirectories in the glob.
+/// \param[in] l The list of full paths to files.
 /// \param[in] glob The glob to expand.
-/// \throws std::runtime_error If the directory part of the glob refers to a
+/// \throws std::runtime_error If the directory parts of the glob refer to a
 ///         path that cannot be opened.
-/// \return A vector of strings, the fully expanded paths to the files referred
-///         to by the glob.
 ///
-/// The two parts of the glob (directory, fileglob) are separated. The directory
-/// is first expanded via TSystem::ExpandPathName then opened via
-/// TSystem::OpenDirectory. If the directory can be opened, then the remaining
-/// fileglob is used as regex expression (via TRegexp) and the function stores
-/// those files in the directory that match the regex.
-std::vector<std::string> ExpandGlob(const std::string &glob)
+/// If the glob contains a wildcard special for subdirectories, the three parts
+/// of the glob (directory, subdirectoryglob, remainder) are separated.
+/// Otherwise the glob is expanded to (directory, fileglob).
+/// The directory is first expanded via TSystem::ExpandPathName then opened via
+/// TSystem::OpenDirectory. If the directory can be opened, then current
+/// glob is used as regex expression (via TRegexp) to find subdirectories or
+/// store those files in the directory that match the regex.
+void RecursiveGlob(TList &l, const std::string &glob)
 {
-   // TODO: Also implement this pattern in some other free function
-   // This is practically Python's os.path.split
    std::string dirname;
-   std::string basename;
+   std::string basename; // current glob to expand, could be a directory or file.
+   std::string remainder;
 
-   const auto slashpos = glob.rfind('/');
+   // This list of characters is currently only defined inside TString::MaybeWildcard() at
+   // https://github.com/root-project/root/blob/5df0ef8bfa3c127e554e845cd6582bc0b4d7f96a/core/base/src/TString.cxx#L960.
+   const char *wildcardSpecials = "[]*?";
 
-   if (slashpos != std::string::npos) {
-      // Separate the glob into its two components
-      dirname = glob.substr(0, slashpos);
-      basename = glob.substr(slashpos + 1);
+   const auto wildcardPos = glob.find_first_of(wildcardSpecials);
+   // Get the closest slash, to the left of the first wildcard
+   auto slashLPos = glob.rfind("/", wildcardPos);
+   // Get the closest slash, to the right of the first wildcard
+   const auto slashRPos = glob.find("/", wildcardPos);
+
+   if (slashLPos != std::string::npos) {
+      // Separate the base directory in the glob.
+      dirname = glob.substr(0, slashLPos);
    } else {
       // There is no directory component in the glob, use the CWD
       dirname = gSystem->UnixPathName(gSystem->WorkingDirectory());
-      basename = glob;
+
+      // Set to -1 to extract the basename from the beginning of the glob string when doing +1 below.
+      slashLPos = -1;
+   }
+
+   // Seperate the subdirectory and/or file component.
+   if (slashRPos != std::string::npos) {
+      basename = glob.substr(slashLPos + 1, slashRPos - (slashLPos + 1));
+      remainder = glob.substr(slashRPos + 1);
+   } else {
+      basename = glob.substr(slashLPos + 1);
    }
 
    // Attempt opening of directory contained in the glob
@@ -446,36 +465,61 @@ std::vector<std::string> ExpandGlob(const std::string &glob)
    delete[] epath;
 
    if (dir) {
-      // Create a TList to store the file names (not yet sorted)
-      TList l;
-      l.SetOwner(); // Make sure the TList will delete its objects
       TRegexp re(basename.c_str(), true);
-      const char *file;
-      TString fname;
-      while ((file = gSystem->GetDirEntry(dir))) {
-         if (!strcmp(file, ".") || !strcmp(file, ".."))
-            continue;
-         fname = file;
-         if ((basename != file) && fname.Index(re) == kNPOS)
-            continue;
-         // Using '/' as separator here as it was done in TChain::Add
-         // In principle this should be using the appropriate platform separator
-         l.Add(new TObjString((dirname + '/' + file).c_str()));
-      }
-      gSystem->FreeDirectory(dir);
-      // Sort the files in alphanumeric order
-      l.Sort();
+      TString entryName;
 
-      // Convert TList<TObjString> to std::vector<std::string>
-      std::vector<std::string> ret;
-      ret.reserve(l.GetEntries());
-      for (const auto *tobjstr : ROOT::RangeStaticCast<const TObjString *>(l)) {
-         ret.push_back(tobjstr->GetName());
+      while (const char *dirEntry = gSystem->GetDirEntry(dir)) {
+         if (!strcmp(dirEntry, ".") || !strcmp(dirEntry, ".."))
+            continue;
+         entryName = dirEntry;
+         if ((basename != dirEntry) && entryName.Index(re) == kNPOS)
+            continue;
+
+         // TODO: It might be better to use std::file_system::is_directory(),
+         // but for GCC < 9.1 this requires an extra linking flag https://en.cppreference.com/w/cpp/filesystem
+         bool isDirectory = TSystemFile().IsDirectory((dirname + "/" + dirEntry).c_str());
+         if (!remainder.empty() && isDirectory) {
+            RecursiveGlob(l, dirname + '/' + dirEntry + "/" + remainder);
+         } else if (remainder.empty() && !isDirectory) {
+            // Using '/' as separator here as it was done in TChain::Add
+            // In principle this should be using the appropriate platform separator
+            l.Add(new TObjString((dirname + '/' + dirEntry).c_str()));
+         }
       }
-      return ret;
+
+      gSystem->FreeDirectory(dir);
    } else {
       throw std::runtime_error("ExpandGlob: could not open directory '" + dirname + "'.");
    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// \brief Expands input glob into a collection of full paths to files.
+/// \param[in] glob The glob to expand.
+/// \throws std::runtime_error If the directory parts of the glob refer to a
+///         path that cannot be opened.
+/// \return A vector of strings, the fully expanded paths to the files referred
+///         to by the glob.
+///
+/// The glob is expanded recursively, but subdirectories are only expanded when
+/// it is explicitly included in the pattern. For example, "dir/*" will only
+/// list the files in the subdirectories of "dir", but "dir/*/*" will list the
+/// files in the subsubdirectories of "dir".
+std::vector<std::string> ExpandGlob(const std::string &glob)
+{
+   TList l;
+   RecursiveGlob(l, glob);
+
+   // Sort the files in alphanumeric order
+   l.Sort();
+
+   std::vector<std::string> ret;
+   ret.reserve(l.GetEntries());
+   for (const auto *tobjstr : ROOT::RangeStaticCast<const TObjString *>(l)) {
+      ret.push_back(tobjstr->GetName());
+   }
+
+   return ret;
 }
 
 } // namespace TreeUtils

--- a/tree/tree/src/InternalTreeUtils.cxx
+++ b/tree/tree/src/InternalTreeUtils.cxx
@@ -327,7 +327,7 @@ std::vector<std::string> GetTreeFullPaths(const TTree &tree)
       }
       std::string fullPath = treeDir->GetPath();            // e.g. "file.root:/dir"
       fullPath = fullPath.substr(fullPath.rfind(":/") + 1); // e.g. "/dir"
-      fullPath += "/";
+      fullPath += '/';
       fullPath += tree.GetName(); // e.g. "/dir/tree"
       return {fullPath};
    }
@@ -436,9 +436,9 @@ void RecursiveGlob(TList &l, const std::string &glob)
 
    const auto wildcardPos = glob.find_first_of(wildcardSpecials);
    // Get the closest slash, to the left of the first wildcard
-   auto slashLPos = glob.rfind("/", wildcardPos);
+   auto slashLPos = glob.rfind('/', wildcardPos);
    // Get the closest slash, to the right of the first wildcard
-   const auto slashRPos = glob.find("/", wildcardPos);
+   const auto slashRPos = glob.find('/', wildcardPos);
 
    if (slashLPos != std::string::npos) {
       // Separate the base directory in the glob.
@@ -477,9 +477,9 @@ void RecursiveGlob(TList &l, const std::string &glob)
 
          // TODO: It might be better to use std::file_system::is_directory(),
          // but for GCC < 9.1 this requires an extra linking flag https://en.cppreference.com/w/cpp/filesystem
-         bool isDirectory = TSystemFile().IsDirectory((dirname + "/" + dirEntry).c_str());
+         bool isDirectory = TSystemFile().IsDirectory((dirname + '/' + dirEntry).c_str());
          if (!remainder.empty() && isDirectory) {
-            RecursiveGlob(l, dirname + '/' + dirEntry + "/" + remainder);
+            RecursiveGlob(l, dirname + '/' + dirEntry + '/' + remainder);
          } else if (remainder.empty() && !isDirectory) {
             // Using '/' as separator here as it was done in TChain::Add
             // In principle this should be using the appropriate platform separator

--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -296,8 +296,10 @@ Int_t TChain::Add(TChain* chain)
 ///   c.Add("myfile.root?#treename");
 ///   ~~~
 /// - Wildcard treatment is triggered by any of the special characters:
-///   <b>[]*?</b> which may be used in the file name, eg. specifying "xxx*.root"
-///   adds all files starting with xxx in the current file system directory.
+///   <b>[]*?</b> which may be used in the file name or subdirectory name,
+///   eg. specifying "xxx*.root" adds all files starting with xxx in the
+///   current file system directory and "*/*.root" adds all the files in the
+///   current subdirectories (but not in the subsubdirectories).
 ///
 /// The second format accepted for \p name may have the form of a URL, e.g.:
 ///

--- a/tree/tree/test/TChainParsing.cxx
+++ b/tree/tree/test/TChainParsing.cxx
@@ -197,21 +197,29 @@ std::vector<std::string> GetFileNamesVec(const TObjArray *chainFiles)
    return chainFileNames;
 }
 
+void MakeDirIfNotExist(const char *dir)
+{
+   // Note that AccessPathName returns FALSE if the dir DOES exist
+   if (gSystem->AccessPathName(dir, kFileExists)) {
+      ASSERT_EQ(gSystem->mkdir(dir), 0);
+   }
+}
+
 TEST(TChainParsing, RecursiveGlob)
 {
    // Need to change working directory to ensure "*" only adds files we create here.
-   auto testDir = "testdir";
-   ASSERT_EQ(gSystem->mkdir(testDir), 0);
+   const auto *testDir = "testdir";
+   MakeDirIfNotExist(testDir);
    gSystem->ChangeDirectory(testDir);
 
    const auto *cwd = gSystem->WorkingDirectory();
 
-   ASSERT_EQ(gSystem->mkdir("testglob"), 0);
-   ASSERT_EQ(gSystem->mkdir("testglob/subdir1"), 0);
-   ASSERT_EQ(gSystem->mkdir("testglob/subdir1/subdir11"), 0);
-   ASSERT_EQ(gSystem->mkdir("testglob/subdir2"), 0);
-   ASSERT_EQ(gSystem->mkdir("testglob/subdir2/subdir21"), 0);
-   ASSERT_EQ(gSystem->mkdir("testglob/subdir3"), 0);
+   MakeDirIfNotExist("testglob");
+   MakeDirIfNotExist("testglob/subdir1");
+   MakeDirIfNotExist("testglob/subdir1/subdir11");
+   MakeDirIfNotExist("testglob/subdir2");
+   MakeDirIfNotExist("testglob/subdir2/subdir21");
+   MakeDirIfNotExist("testglob/subdir3");
 
    // Unsorted to also test sorting the final list of globbed files.
    std::vector<std::string> fileNames{"0a.root",
@@ -264,13 +272,6 @@ TEST(TChainParsing, RecursiveGlob)
    for (std::size_t i = 0; i < expectedFileNamesGlobDir.size(); i++) {
       EXPECT_EQ(globDirChainFileNames[i], expectedFileNamesGlobDir[i]);
    }
-
-   gSystem->ChangeDirectory("../");
-#if defined(_WIN32) || defined(_WIN64)
-   gSystem->Exec(Form("rmdir /s /q %s", testDir));
-#else
-   gSystem->Exec(Form("rm -rf %s", testDir));
-#endif
 }
 
 #if !defined(_MSC_VER) || defined(R__ENABLE_BROKEN_WIN_TESTS)


### PR DESCRIPTION
# This Pull request:

`ROOT::Internal::TreeUtils::ExpandGlob` now expands  the globbing string recursively to support patterns with wildcards for subdirectories e.g.,  `path/to/tree/files/*/*/*.root`.  Subdirectories are only expanded when it is explicitly included in the pattern. For example, `dir/*` will only add the files in the subdirectories of `dir`, but `dir/*/*` will add the files in the subsubdirectories of `dir`. This behavior resembles Python's glob.glob.

Some other options for expanding a directory wildcard e.g., `dir/*` is to also add files in the subdirectories of `dir` (behavior of `ls`)  or also all the files in all the subdirectories, subsubdirectories, subsubsubdirectories etc. (behavior of `find`).  I believe this would be unwanted since it breaks backwards compatibility.

This currently uses TSystemFile.IsDirectory() to check whether a path is a directory. A better solution might be to use C++17 `std::filesystem::is_directory` but this requires an additional compiler/linker option for some builds (see https://en.cppreference.com/w/cpp/filesystem under Notes)
 
## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes #13623  

