### PR TITLE
[Dict][13543] Correct dicts with rootcling+selection xml

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -2657,6 +2657,7 @@ int GenerateFullDict(std::ostream &dictStream,
                      const ROOT::TMetaUtils::RConstructorTypes &ctorTypes,
                      bool isSplit,
                      bool isGenreflex,
+                     bool isSelXML,
                      bool writeEmptyRootPCM)
 {
    ROOT::TMetaUtils::TNormalizedCtxt normCtxt(interp.getLookupHelper());
@@ -2703,7 +2704,7 @@ int GenerateFullDict(std::ostream &dictStream,
 
       if (clang::CXXRecordDecl *CXXRD =
                llvm::dyn_cast<clang::CXXRecordDecl>(const_cast<clang::RecordDecl *>(selClass.GetRecordDecl()))) {
-         AnnotateDecl(*CXXRD, scan.GetDeclsSelRulesMap() , interp, isGenreflex);
+         AnnotateDecl(*CXXRD, scan.GetDeclsSelRulesMap() , interp, isSelXML);
       }
 
       const clang::CXXRecordDecl *CRD = llvm::dyn_cast<clang::CXXRecordDecl>(selClass.GetRecordDecl());
@@ -2775,6 +2776,12 @@ int GenerateFullDict(std::ostream &dictStream,
    // Loop to write all the ClassCode
    if (!gOptIgnoreExistingDict) {
       for (auto const &selClass : scan.fSelectedClasses) {
+         // The "isGenreflex" parameter allows the distinction between
+         // genreflex and rootcling only for the treatment of collections which
+         // are data members. To preserve the behaviour of the original
+         // genreflex and rootcling tools, if the selection is performed with
+         // genreflex, data members with collection type do not trigger the
+         // selection of the collection type
           ROOT::TMetaUtils::WriteClassCode(&CallWriteStreamer,
                                            selClass,
                                            interp,
@@ -4947,6 +4954,7 @@ int RootClingMain(int argc,
                                  constructorTypes,
                                  gOptSplit,
                                  isGenreflex,
+                                 isSelXML,
                                  gOptWriteEmptyRootPCM);
    }
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
These changes allow the user to generate a dictionary with rootcling and selecting classes with a selection XML file, the selection file format of genreflex, instead of a traditional LinkDef file.

This PR is coupled with ROOT Test PR https://github.com/root-project/roottest/pull/1014 .

## Checklist:

- [v] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 
https://github.com/dpiparo/root/pull/new/issue_13543

