### PR TITLE
[RF] Implement Offset("bin") also for `RooDataSet` fits

### DIFF
--- a/roofit/batchcompute/inc/RooBatchCompute.h
+++ b/roofit/batchcompute/inc/RooBatchCompute.h
@@ -151,9 +151,8 @@ public:
    }
 
    virtual double reduceSum(Config const &cfg, InputArr input, size_t n) = 0;
-   virtual ReduceNLLOutput reduceNLL(Config const &cfg, std::span<const double> probas,
-                                     std::span<const double> weightSpan, std::span<const double> weights,
-                                     double weightSum, std::span<const double> binVolumes) = 0;
+   virtual ReduceNLLOutput reduceNLL(Config const &cfg, std::span<const double> probas, std::span<const double> weights,
+                                     std::span<const double> offsetProbas) = 0;
 
    virtual Architecture architecture() const = 0;
    virtual std::string architectureName() const = 0;
@@ -207,12 +206,12 @@ inline double reduceSum(Config cfg, InputArr input, size_t n)
    return dispatch->reduceSum(cfg, input, n);
 }
 
-inline ReduceNLLOutput reduceNLL(Config cfg, std::span<const double> probas, std::span<const double> weightSpan,
-                                 std::span<const double> weights, double weightSum, std::span<const double> binVolumes)
+inline ReduceNLLOutput reduceNLL(Config cfg, std::span<const double> probas, std::span<const double> weights,
+                                 std::span<const double> offsetProbas)
 {
    init();
    auto dispatch = cfg.useCuda() ? dispatchCUDA : dispatchCPU;
-   return dispatch->reduceNLL(cfg, probas, weightSpan, weights, weightSum, binVolumes);
+   return dispatch->reduceNLL(cfg, probas, weights, offsetProbas);
 }
 
 } // End namespace RooBatchCompute

--- a/roofit/roofitcore/inc/RooNLLVar.h
+++ b/roofit/roofitcore/inc/RooNLLVar.h
@@ -22,8 +22,6 @@
 #include <vector>
 #include <utility>
 
-class RooRealSumPdf ;
-
 class RooNLLVar : public RooAbsOptTestStatistic {
 public:
 
@@ -53,15 +51,15 @@ public:
 
   double defaultErrorLevel() const override { return 0.5 ; }
 
-  void enableBinOffsetting(bool on = true) {
-    _doBinOffset = on;
-  }
+  void enableBinOffsetting(bool on = true);
 
   using ComputeResult = std::pair<ROOT::Math::KahanSum<double>, double>;
 
   static RooNLLVar::ComputeResult computeScalarFunc(const RooAbsPdf *pdfClone, RooAbsData *dataClone, RooArgSet *normSet,
                                                 bool weightSq, std::size_t stepSize, std::size_t firstEvent,
-                                                std::size_t lastEvent, bool doBinOffset=false);
+                                                std::size_t lastEvent, RooAbsPdf const* offsetPdf = nullptr);
+
+  bool setData(RooAbsData& data, bool cloneData=true) override;
 
 protected:
 
@@ -80,7 +78,8 @@ private:
   ROOT::Math::KahanSum<double> _offsetSaveW2{0.0}; ///<!
 
   mutable std::vector<double> _binw ; ///<!
-  mutable RooRealSumPdf* _binnedPdf{nullptr}; ///<!
+  mutable RooAbsPdf* _binnedPdf{nullptr}; ///<!
+  std::unique_ptr<RooAbsPdf> _offsetPdf; ///<! An optional per-bin likelihood offset
 
   ClassDefOverride(RooNLLVar,0) // Function representing (extended) -log(L) of p.d.f and dataset
 };

--- a/roofit/roofitcore/src/BatchModeDataHelpers.cxx
+++ b/roofit/roofitcore/src/BatchModeDataHelpers.cxx
@@ -12,7 +12,6 @@
 
 #include "RooFit/BatchModeDataHelpers.h"
 #include <RooAbsData.h>
-#include <RooDataHist.h>
 #include <RooHelpers.h>
 #include "RooNLLVarNew.h"
 #include <RooRealVar.h>
@@ -96,24 +95,8 @@ getSingleDataSpans(RooAbsData const &data, std::string_view rangeName, std::stri
          assignSpan(weight, {buffer.data(), nNonZeroWeight});
          assignSpan(weightSumW2, {bufferSumW2.data(), nNonZeroWeight});
       }
-      using namespace ROOT::Experimental;
       insert(RooNLLVarNew::weightVarName, weight);
       insert(RooNLLVarNew::weightVarNameSumW2, weightSumW2);
-   }
-
-   // Add also bin volume information if we are dealing with a RooDataHist
-   if (auto dataHist = dynamic_cast<RooDataHist const *>(&data)) {
-      buffers.emplace();
-      auto &buffer = buffers.top();
-      buffer.reserve(nNonZeroWeight);
-
-      for (std::size_t i = 0; i < nEvents; ++i) {
-         if (!hasZeroWeight[i]) {
-            buffer.push_back(dataHist->binVolume(i));
-         }
-      }
-
-      insert("_bin_volume", {buffer.data(), buffer.size()});
    }
 
    // Get the real-valued batches and cast the also to double branches to put in
@@ -203,9 +186,7 @@ getSingleDataSpans(RooAbsData const &data, std::string_view rangeName, std::stri
 /// Spans with the weights and squared weights will be also stored in the map,
 /// keyed with the names `_weight` and the `_weight_sumW2`. If the dataset is
 /// unweighted, these weight spans will only contain the single value `1.0`.
-/// Entries with zero weight will be skipped. If the input dataset is a
-/// RooDataHist, the output map will also contain an item for the key
-/// `_bin_volume` with the bin volumes.
+/// Entries with zero weight will be skipped.
 ///
 /// \return A `std::map` with spans keyed to name pointers.
 /// \param[in] data The input dataset.

--- a/roofit/roofitcore/src/BatchModeHelpers.cxx
+++ b/roofit/roofitcore/src/BatchModeHelpers.cxx
@@ -25,8 +25,6 @@
 
 #include <string>
 
-using ROOT::Experimental::RooNLLVarNew;
-
 namespace {
 
 std::unique_ptr<RooAbsArg> createSimultaneousNLL(RooSimultaneous const &simPdf, bool isExtended,

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1076,12 +1076,6 @@ RooFit::OwningPtr<RooAbsReal> RooAbsPdf::createNLL(RooAbsData& data, const RooLi
   Int_t cloneData = pc.getInt("cloneData") ;
   auto offset = static_cast<RooFit::OffsetMode>(pc.getInt("doOffset"));
 
-  if(offset == RooFit::OffsetMode::Bin && dynamic_cast<RooDataSet*>(&data)) {
-    coutE(Minimization) << "The Offset(\"bin\") option doesn't support fits to RooDataSet yet, only to RooDataHist."
-                           " Falling back to no offsetting."  << endl;
-    offset = RooFit::OffsetMode::None;
-  }
-
   // If no explicit cloneData command is specified, cloneData is set to true if optimization is activated
   if (cloneData==2) {
     cloneData = optConst ;

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1654,7 +1654,7 @@ RooFit::OwningPtr<RooFitResult> RooAbsPdf::fitTo(RooAbsData& data, const RooLink
       "CloneData,GlobalObservables,GlobalObservablesSource,GlobalObservablesTag,"
       "BatchMode,IntegrateBins,ModularL";
 
-  if (((RooCmdArg*)cmdList.FindObject("ModularL")) && !((RooCmdArg*)cmdList.FindObject("ModularL"))->getInt(0))
+  if (!cmdList.FindObject("ModularL") || static_cast<RooCmdArg*>(cmdList.FindObject("ModularL"))->getInt(0) == 0)
     nllCmdListString += ",OffsetLikelihood";
 
   RooLinkedList nllCmdList = pc.filterCmdList(fitCmdList, nllCmdListString.c_str());

--- a/roofit/roofitcore/src/RooAddition.cxx
+++ b/roofit/roofitcore/src/RooAddition.cxx
@@ -240,7 +240,7 @@ double RooAddition::defaultErrorLevel() const
 
   std::unique_ptr<RooArgSet> comps{getComponents()};
   for(RooAbsArg * arg : *comps) {
-    if (dynamic_cast<RooNLLVar*>(arg) || dynamic_cast<ROOT::Experimental::RooNLLVarNew*>(arg)) {
+    if (dynamic_cast<RooNLLVar*>(arg) || dynamic_cast<RooNLLVarNew*>(arg)) {
       nllArg = (RooAbsReal*)arg ;
     }
     if (dynamic_cast<RooChi2Var*>(arg)) {

--- a/roofit/roofitcore/src/RooNLLVarNew.h
+++ b/roofit/roofitcore/src/RooNLLVarNew.h
@@ -21,9 +21,6 @@
 
 #include <Math/Util.h>
 
-namespace ROOT {
-namespace Experimental {
-
 class RooNLLVarNew : public RooAbsReal {
 
 public:
@@ -31,7 +28,6 @@ public:
    static constexpr const char *weightVarName = "_weight";
    static constexpr const char *weightVarNameSumW2 = "_weight_sumW2";
 
-   RooNLLVarNew() {}
    RooNLLVarNew(const char *name, const char *title, RooAbsPdf &pdf, RooArgSet const &observables, bool isExtended,
                 RooFit::OffsetMode offsetMode);
    RooNLLVarNew(const RooNLLVarNew &other, const char *name = nullptr);
@@ -68,8 +64,8 @@ private:
    RooTemplateProxy<RooAbsPdf> _pdf;
    RooTemplateProxy<RooAbsReal> _weightVar;
    RooTemplateProxy<RooAbsReal> _weightSquaredVar;
-   RooTemplateProxy<RooAbsReal> _binVolumeVar;
    std::unique_ptr<RooTemplateProxy<RooAbsReal>> _expectedEvents;
+   std::unique_ptr<RooTemplateProxy<RooAbsPdf>> _offsetPdf;
    mutable double _sumWeight = 0.0;  //!
    mutable double _sumWeight2 = 0.0; //!
    bool _weightSquared = false;
@@ -82,8 +78,5 @@ private:
    mutable ROOT::Math::KahanSum<double> _offset{0.}; ///<! Offset as KahanSum to avoid loss of precision
 
 }; // end class RooNLLVar
-
-} // end namespace Experimental
-} // end namespace ROOT
 
 #endif

--- a/tutorials/roofit/rf103_interprfuncs.py
+++ b/tutorials/roofit/rf103_interprfuncs.py
@@ -22,7 +22,7 @@ x = ROOT.RooRealVar("x", "x", -20, 20)
 # ------------------------------------------------------
 
 # ROOT.To construct a proper pdf, the formula expression is explicitly normalized internally by dividing
-# it by a numeric integral of the expresssion over x in the range [-20,20]
+# it by a numeric integral of the expression over x in the range [-20,20]
 #
 alpha = ROOT.RooRealVar("alpha", "alpha", 5, 0.1, 10)
 genpdf = ROOT.RooGenericPdf("genpdf", "genpdf", "(1+0.1*abs(x)+sin(sqrt(abs(x*alpha+0.1))))", [x, alpha])

--- a/tutorials/roofit/rf204b_extendedLikelihood_rangedFit.C
+++ b/tutorials/roofit/rf204b_extendedLikelihood_rangedFit.C
@@ -34,7 +34,7 @@
 /// fit of these regions with different interpretations of the same model parameter results
 /// in a number that is not easily interpreted.
 ///
-/// If both regions correct their interpretatin such that N_expected refers to the full range,
+/// If both regions correct their interpretations such that N_expected refers to the full range,
 /// it is interpreted easily, and consistent in both regions.
 ///
 /// This requires that the likelihood model is extended using RooAddPdf in the

--- a/tutorials/roofit/rf204b_extendedLikelihood_rangedFit.py
+++ b/tutorials/roofit/rf204b_extendedLikelihood_rangedFit.py
@@ -34,7 +34,7 @@
 ##  fit of these regions with different interpretations of the same model parameter results
 ##  in a number that is not easily interpreted.
 ##
-##  If both regions correct their interpretatin such that N_expected refers to the full range,
+##  If both regions correct their interpretation such that N_expected refers to the full range,
 ##  it is interpreted easily, and consistent in both regions.
 ##
 ##  This requires that the likelihood model is extended using RooAddPdf in the

--- a/tutorials/roofit/rf210_angularconv.py
+++ b/tutorials/roofit/rf210_angularconv.py
@@ -2,7 +2,7 @@
 ## \ingroup tutorial_roofit
 ## \notebook
 ## Convolution in cyclical angular observables theta, and
-## construction of p.d.f in terms of trasnformed angular
+## construction of p.d.f in terms of transformed angular
 ## coordinates, e.g. cos(theta), the convolution
 ## is performed in theta rather than cos(theta)
 ##

--- a/tutorials/roofit/rf308_normintegration2d.py
+++ b/tutorials/roofit/rf308_normintegration2d.py
@@ -56,7 +56,7 @@ print("gx_Norm[x] = ", gxy.getVal(nset_x))
 nset_y = {y}
 print("gx_Norm[y] = ", gxy.getVal(nset_y))
 
-# Integarte normalizes pdf over subrange
+# Integrate normalized pdf over subrange
 # ----------------------------------------------------------------------------
 
 # Define a range named "signal" in x from -5,5

--- a/tutorials/roofit/rf316_llratioplot.py
+++ b/tutorials/roofit/rf316_llratioplot.py
@@ -1,7 +1,7 @@
 ## \file
 ## \ingroup tutorial_roofit
 ## \notebook
-## Multidimensional models: using the likelihood ratio techique to construct a signal
+## Multidimensional models: using the likelihood ratio technique to construct a signal
 ## enhanced one-dimensional projection of a multi-dimensional pdf
 ##
 ## \macro_image

--- a/tutorials/roofit/rf402_datahandling.C
+++ b/tutorials/roofit/rf402_datahandling.C
@@ -98,7 +98,7 @@ void rf402_datahandling()
    d1->merge(d2);
    d1->Print("v");
 
-   // The append() function addes two datasets row-wise
+   // The append() function adds two datasets row-wise
    cout << endl << ">> append data points of d3 to d1" << endl;
    d1->append(*d3);
    d1->Print("v");

--- a/tutorials/roofit/rf402_datahandling.py
+++ b/tutorials/roofit/rf402_datahandling.py
@@ -95,7 +95,7 @@ print("\n >> merge d2(y) with d1(x,c) to form d1(x,c,y)")
 d1.merge(d2)
 d1.Print("v")
 
-# The append() function addes two datasets row-wise
+# The append() function adds two datasets row-wise
 print("\n >> append data points of d3 to d1")
 d1.append(d3)
 d1.Print("v")

--- a/tutorials/roofit/rf406_cattocatfuncs.C
+++ b/tutorials/roofit/rf406_cattocatfuncs.C
@@ -58,7 +58,7 @@ void rf406_cattocatfuncs()
    tcatType.map("Lepton", "Cut based");
    tcatType.map("Kaon", "Cut based");
 
-   // Enter a wilcard expression mapping
+   // Enter a wildcard expression mapping
    tcatType.map("NetTagger*", "Neural Network");
 
    // Make a table of the mapped category state multiplicity in data

--- a/tutorials/roofit/rf406_cattocatfuncs.py
+++ b/tutorials/roofit/rf406_cattocatfuncs.py
@@ -44,7 +44,7 @@ tcatType = ROOT.RooMappedCategory("tcatType", "tagCat type", tagCat, "Cut based"
 tcatType.map("Lepton", "Cut based")
 tcatType.map("Kaon", "Cut based")
 
-# Enter a wilcard expression mapping
+# Enter a wildcard expression mapping
 tcatType.map("NetTagger*", "Neural Network")
 
 # Make a table of the mapped category state multiplicit in data

--- a/tutorials/roofit/rf409_NumPyPandasToRooFit.py
+++ b/tutorials/roofit/rf409_NumPyPandasToRooFit.py
@@ -3,7 +3,7 @@
 ## \notebook
 ## Convert between NumPy arrays or Pandas DataFrames and RooDataSets.
 ##
-## This totorial first how to export a RooDataSet to NumPy arrays or a Pandas
+## This tutorials first how to export a RooDataSet to NumPy arrays or a Pandas
 ## DataFrame, and then it shows you how to create a RooDataSet from a Pandas
 ## DataFrame.
 ##
@@ -107,14 +107,14 @@ datahist = data.binnedClone()
 # You can also export a RooDataHist to numpy arrays with
 # RooDataHist.to_numpy(). As output, you will get a multidimensional array with
 # the histogram counts and a list of arrays with bin edges. This is comparable
-# to the ouput of numpy.histogram (or numpy.histogramdd for the
+# to the output of numpy.histogram (or numpy.histogramdd for the
 # multidimensional case).
 counts, bin_edges = datahist.to_numpy()
 
 print("Counts and bin edges from RooDataHist.to_numpy:")
 print_histogram_output((counts, bin_edges))
 
-# Let's compare the ouput to the counts and bin edges we get with
+# Let's compare the output to the counts and bin edges we get with
 # numpy.histogramdd when we pass it the original samples:
 print("Counts and bin edges from np.histogram:")
 print_histogram_output(np.histogramdd([x_arr], bins=[x.bins()]))

--- a/tutorials/roofit/rf509_wsinteractive.py
+++ b/tutorials/roofit/rf509_wsinteractive.py
@@ -88,7 +88,7 @@ r = model.fitTo(d, PrintLevel=-1)
 frame = x.frame()
 d.plotOn(frame)
 
-# OLD syntax to ommit x.
+# OLD syntax to omit x.
 # NB: The 'w.' prefix can be omitted if namespace w is imported in local namespace
 # in the usual C++ way
 #

--- a/tutorials/roofit/rf511_wsfactory_basic.py
+++ b/tutorials/roofit/rf511_wsfactory_basic.py
@@ -52,7 +52,7 @@ else:
 #
 # Double_t -. converted to ROOT.RooConst(...)
 # {a,b,c} -. converted to ROOT.RooArgSet() or ROOT.RooArgList() depending on required ctor arg
-# dataset name -. convered to ROOT.RooAbsData reference for any dataset residing in the workspace
+# dataset name -. converted to ROOT.RooAbsData reference for any dataset residing in the workspace
 # enum -. Any enum label that belongs to an enum defined in the (base)
 # class
 

--- a/tutorials/roofit/rf514_RooCustomizer.C
+++ b/tutorials/roofit/rf514_RooCustomizer.C
@@ -69,7 +69,7 @@ void rf514_RooCustomizer() {
 
   // 2. Each sample should have its own signal yield, but there is an extra complication:
   // We need the yields 1 and 2 to be a function of the variable "mass".
-  // For this, we pre-define nodes with exacly the names that the customiser would have created automatically,
+  // For this, we pre-define nodes with exactly the names that the customiser would have created automatically,
   // that is, "<nodeName>_<categoryName>", and we register them in the set of customiser nodes.
   // The customiser will pick them up instead of creating new ones.
   // If we don't provide one (e.g. for "yieldSig_Sample3"), it will be created automatically by cloning `yieldSig`.

--- a/tutorials/roofit/rf514_RooCustomizer.py
+++ b/tutorials/roofit/rf514_RooCustomizer.py
@@ -51,7 +51,7 @@ cust.splitArg(meanG, sample)
 
 # 2. Each sample should have its own signal yield, but there is an extra complication:
 # We need the yields 1 and 2 to be a function of the variable "mass".
-# For this, we pre-define nodes with exacly the names that the customiser would have created automatically,
+# For this, we pre-define nodes with exactly the names that the customiser would have created automatically,
 # that is, "<nodeName>_<categoryName>", and we register them in the set of customiser nodes.
 # The customiser will pick them up instead of creating new ones.
 # If we don't provide one (e.g. for "yieldSig_Sample3"), it will be created automatically by cloning `yieldSig`.

--- a/tutorials/roofit/rf606_nllerrorhandling.py
+++ b/tutorials/roofit/rf606_nllerrorhandling.py
@@ -55,7 +55,7 @@ argus.plotOn(frame1)
 
 argus.fitTo(data, PrintEvalErrors=10)
 
-# Peform another fit. In self configuration only the number of errors per
+# Perform another fit. In self configuration only the number of errors per
 # likelihood evaluation is shown, it is greater than zero. The
 # EvalErrorWall(kFALSE) arguments disables the default error handling strategy
 # and will cause the actual (problematic) value of the likelihood to be passed

--- a/tutorials/roofit/rf610_visualerror.py
+++ b/tutorials/roofit/rf610_visualerror.py
@@ -68,7 +68,7 @@ model.plotOn(frame, VisualizeError=(r, 1), FillColor="kOrange")
 # In self method a number of curves is calculated with variations of the parameter values, sampled
 # from a multi-variate Gaussian pdf that is constructed from the fit results covariance matrix.
 # The error(x) is determined by calculating a central interval that capture N% of the variations
-# for each valye of x, N% is controlled by Z (i.e. Z=1 gives N=68%). The number of sampling curves
+# for each value of x, N% is controlled by Z (i.e. Z=1 gives N=68%). The number of sampling curves
 # is chosen to be such that at least 100 curves are expected to be outside the N% interval, is minimally
 # 100 (e.g. Z=1.Ncurve=356, Z=2.Ncurve=2156)) Intervals from the sampling method can be asymmetric,
 # and may perform better in the presence of strong correlations, may take

--- a/tutorials/roofit/rf613_global_observables.C
+++ b/tutorials/roofit/rf613_global_observables.C
@@ -46,7 +46,7 @@
 ///
 /// \f[ L'(data | mu, count) = L(data | mu, count) * \text{Poisson}(count_obs | count) \f]
 ///
-/// Unlike a Guassian, a Poissonian is not symmetric under exchange of the
+/// Unlike a Gaussian, a Poissonian is not symmetric under exchange of the
 /// observable and the parameter, so here you need to be more careful to follow
 /// the global observable prescription correctly.
 ///
@@ -169,7 +169,7 @@ void rf613_global_observables()
 
    // If you want to explicitly ignore the global observables in the dataset,
    // you can do that by specifying GlobalObservablesSource("model"). Keep in
-   // mind that now it's also again your responsability to define the set of
+   // mind that now it's also again your responsibility to define the set of
    // global observables.
    std::cout << "3. model.fitTo(*data, GlobalObservables(mu_obs), GlobalObservablesSource(\"model\"))\n";
    std::cout << "------------------------------------------------\n";

--- a/tutorials/roofit/rf613_global_observables.py
+++ b/tutorials/roofit/rf613_global_observables.py
@@ -46,7 +46,7 @@
 ##
 ## \f[ L'(data | mu, count) = L(data | mu, count) * \text{Poisson}(count_obs | count) \f]
 ##
-## Unlike a Guassian, a Poissonian is not symmetric under exchange of the
+## Unlike a Gaussian, a Poissonian is not symmetric under exchange of the
 ## observable and the parameter, so here you need to be more careful to follow
 ## the global observable prescription correctly.
 ##
@@ -153,7 +153,7 @@ modelParameters.assign(origParameters)
 
 # If you want to explicitly ignore the global observables in the dataset,
 # you can do that by specifying GlobalObservablesSource("model"). Keep in
-# mind that now it's also again your responsability to define the set of
+# mind that now it's also again your responsibility to define the set of
 # global observables.
 print('3. model.fitTo(*data, GlobalObservables(mu_obs), GlobalObservablesSource("model"))')
 print("------------------------------------------------")

--- a/tutorials/roofit/rf614_binned_fit_problems.C
+++ b/tutorials/roofit/rf614_binned_fit_problems.C
@@ -26,7 +26,7 @@
 // One should in principle be able to use
 // pdf.generateBinned(x, nEvents, RooFit::ExpectedData()).
 // Unfortunately it has a problem: it also has the bin bias that this tutorial
-// demostrates, to if we would use it, the biases would cancel out.
+// demonstrates, to if we would use it, the biases would cancel out.
 std::unique_ptr<RooDataHist> generateBinnedAsimov(RooAbsPdf const &pdf, RooRealVar &x, int nEvents)
 {
    auto dataH = std::make_unique<RooDataHist>("dataH", "dataH", RooArgSet{x});
@@ -182,7 +182,7 @@ void rf614_binned_fit_problems()
    // each bin a constant counterterm \f[n\log(n/N)\f], we get terms for each
    // bin that are closer to each other in order of magnitude as long as the
    // initial model is not extremely off. Proving this mathematically is left
-   // as an excercise to the reader.
+   // as an exercise to the reader.
 
    // This counterterms can be enabled by passing the Offset("bin") option to
    // RooAbsPdf::fitTo() or RooAbsPdf::createNLL().

--- a/tutorials/roofit/rf614_binned_fit_problems.C
+++ b/tutorials/roofit/rf614_binned_fit_problems.C
@@ -184,8 +184,7 @@ void rf614_binned_fit_problems()
    // initial model is not extremely off. Proving this mathematically is left
    // as an excercise to the reader.
 
-   // This counterterms can be enabled in RooFit if you use a binned
-   // RooDataHist to do your fit and pass the Offset("bin") option to
+   // This counterterms can be enabled by passing the Offset("bin") option to
    // RooAbsPdf::fitTo() or RooAbsPdf::createNLL().
 
    std::unique_ptr<RooFitResult> fit7{

--- a/tutorials/roofit/rf614_binned_fit_problems.py
+++ b/tutorials/roofit/rf614_binned_fit_problems.py
@@ -31,7 +31,7 @@ def generateBinnedAsimov(pdf, x, n_events):
     One should in principle be able to use
     pdf.generateBinned(x, n_events, RooFit::ExpectedData()).
     Unfortunately it has a problem: it also has the bin bias that this tutorial
-    demostrates, to if we would use it, the biases would cancel out.
+    demonstrates, to if we would use it, the biases would cancel out.
     """
     data_h = ROOT.RooDataHist("dataH", "dataH", {x})
     x_binning = x.getBinning()
@@ -186,7 +186,7 @@ fit6.Print()
 # each bin a constant counterterm \f[n\log(n/N)\f], we get terms for each
 # bin that are closer to each other in order of magnitude as long as the
 # initial model is not extremely off. Proving this mathematically is left
-# as an excercise to the reader.
+# as an exercise to the reader.
 
 # This counterterms can be enabled by passing the Offset("bin") option to
 # RooAbsPdf::fitTo() or RooAbsPdf::createNLL().

--- a/tutorials/roofit/rf614_binned_fit_problems.py
+++ b/tutorials/roofit/rf614_binned_fit_problems.py
@@ -188,8 +188,7 @@ fit6.Print()
 # initial model is not extremely off. Proving this mathematically is left
 # as an excercise to the reader.
 
-# This counterterms can be enabled in RooFit if you use a binned
-# RooDataHist to do your fit and pass the Offset("bin") option to
+# This counterterms can be enabled by passing the Offset("bin") option to
 # RooAbsPdf::fitTo() or RooAbsPdf::createNLL().
 
 fit7 = model.fitTo(model_data, Offset="bin", Save=True, PrintLevel=-1, SumW2Error=False)

--- a/tutorials/roofit/rf709_BarlowBeeston.C
+++ b/tutorials/roofit/rf709_BarlowBeeston.C
@@ -113,7 +113,7 @@ void rf709_BarlowBeeston()
   // can be re-used.
   // The first ParamHistFunc will create one parameter per bin, such as `p_ph_sig2_gamma_bin_0`.
   // This allows bin 0 to fluctuate up and down.
-  // Then, the SAME parameters are connected to the background histogram, so the bins flucutate
+  // Then, the SAME parameters are connected to the background histogram, so the bins fluctuate
   // synchronously. This reduces the number of parameters.
   RooParamHistFunc p_ph_sig2("p_ph_sig2", "p_ph_sig2", *dh_sig);
   RooParamHistFunc p_ph_bkg2("p_ph_bkg2", "p_ph_bkg2", *dh_bkg, p_ph_sig2, true);

--- a/tutorials/roofit/rf709_BarlowBeeston.py
+++ b/tutorials/roofit/rf709_BarlowBeeston.py
@@ -85,7 +85,7 @@ model1 = ROOT.RooProdPdf("model1", "model1", {hc_sig, hc_bkg}, Conditional=(mode
 # can be re-used.
 # The first ParamHistFunc will create one parameter per bin, such as `p_ph_sig2_gamma_bin_0`.
 # This allows bin 0 to fluctuate up and down.
-# Then, the SAME parameters are connected to the background histogram, so the bins flucutate
+# Then, the SAME parameters are connected to the background histogram, so the bins fluctuate
 # synchronously. This reduces the number of parameters.
 p_ph_sig2 = ROOT.RooParamHistFunc("p_ph_sig2", "p_ph_sig2", dh_sig)
 p_ph_bkg2 = ROOT.RooParamHistFunc("p_ph_bkg2", "p_ph_bkg2", dh_bkg, p_ph_sig2, True)

--- a/tutorials/roofit/rf712_lagrangianmorphfit.py
+++ b/tutorials/roofit/rf712_lagrangianmorphfit.py
@@ -21,7 +21,7 @@ ROOT.gROOT.SetBatch(True)
 observablename = "pTV"
 obsvar = ROOT.RooRealVar(observablename, "observable of pTV", 10, 600)
 
-# Setup three EFT coefficent and constant SM modifier
+# Setup three EFT coefficient and constant SM modifier
 kSM = ROOT.RooRealVar("kSM", "sm modifier", 1.0)
 cHq3 = ROOT.RooRealVar("cHq3", "EFT modifier", -10.0, 10.0)
 cHq3.setAttribute("NewPhysics", True)

--- a/tutorials/roofit/rf901_numintconfig.py
+++ b/tutorials/roofit/rf901_numintconfig.py
@@ -85,7 +85,7 @@ print(" [3] int_dx landau(x) = ", val3)
 if not integratorGKNotExisting:
     ROOT.RooAbsReal.defaultIntegratorConfig().method1D().setLabel("RooAdaptiveGaussKronrodIntegrator1D")
 
-    # Adjusting parameters of a speficic technique
+    # Adjusting parameters of a specific technique
     # ---------------------------------------------------------------------------------------
 
     # Adjust maximum number of steps of ROOT.RooIntegrator1D in the global


### PR DESCRIPTION
Fully implement the `Offset("bin")` feature also for RooDataSet, both
with CPU/CUDA BatchMode and the legacy tests statistics.

This is done now by introducing a new element in the computation graph:
an "offset pdf" that is created as a RooHistPdf from the observed data,
and it is used to get the counterterm in each bin.

It was validated with the `rf614` tutorial that this binwise offsetting
is inteed fixing the convergense problems that the simple offsetting by
the initial NLL value can't fix.

Closes https://github.com/root-project/root/issues/11965.