### PR TITLE
[cmake] Replace FindOracle.cmake:

### DIFF
--- a/cmake/modules/FindOracle.cmake
+++ b/cmake/modules/FindOracle.cmake
@@ -1,175 +1,90 @@
-# TOra: Configure Oracle libraries
+###############################################################################
 #
-# ORACLE_FOUND - system has Oracle OCI
-# ORACLE_INCLUDE_DIR - where to find oci.h
-# ORACLE_LIBRARIES - the libraries to link against to use Oracle OCI
+# CMake module to search for Oracle client library (OCI)
 #
-# copyright (c) 2007 Petr Vanek <petr@scribus.info>
-# Redistribution and use is allowed according to the terms of the GPLv2 license.
-# Mofified by Pere Mato
+# On success, the macro sets the following variables:
+# ORACLE_FOUND       = if the library found
+# ORACLE_LIBRARY     = full path to the library
+# ORACLE_LIBRARIES   = full path to the library
+# ORACLE_INCLUDE_DIR = where to find the library headers also defined,
+#                       but not for general use are
+# ORACLE_VERSION     = version of library which was found, e.g. "1.2.5"
+#
+# Copyright (c) 2009-2013 Mateusz Loskot <mateusz@loskot.net>
+#
+# Developed with inspiration from Petr Vanek <petr@scribus.info>
+# who wrote similar macro for TOra - http://torasql.com/
+#
+# Module source: http://github.com/mloskot/workshop/tree/master/cmake/
+#
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+#
+###############################################################################
 
-set(ORACLE_FOUND 0)
-if(ORACLE_INCLUDE_DIR AND ORACLE_LIBRARY_OCCI)
-  set(ORACLE_FIND_QUIETLY 1)
+# First check for CMAKE  variable
+if(NOT ORACLE_HOME)
+  # If ORACLE_HOME is not defined check for env var and if exists set from env var
+  if(EXISTS $ENV{ORACLE_HOME})
+    set(ORACLE_HOME $ENV{ORACLE_HOME})
+  endif()
 endif()
-set(ORACLE_HOME $ENV{ORACLE_HOME})
 
-IF (ORACLE_PATH_INCLUDES)
-    SET (ORACLE_INCLUDES_LOCATION ${ORACLE_PATH_INCLUDES})
-ELSE (ORACLE_PATH_INCLUDES)
-    SET (ORACLE_INCLUDES_LOCATION
-            ${ORACLE_HOME}/rdbms/public
-            ${ORACLE_HOME}/include
-            # sdk
-            ${ORACLE_HOME}/sdk/include
-            # xe on windows
-            ${ORACLE_HOME}/OCI/include
-       )
-ENDIF (ORACLE_PATH_INCLUDES)
+message(STATUS "ORACLE_HOME=${ORACLE_HOME}")
 
-IF (ORACLE_PATH_LIB)
-    SET (ORACLE_LIB_LOCATION ${ORACLE_PATH_LIB})
-ELSE (ORACLE_PATH_LIB)
-    SET (ORACLE_LIB_LOCATION
-            ${ORACLE_HOME}/lib
-            # xe on windows
-            ${ORACLE_HOME}/OCI/lib/MSVC
-        )
-ENDIF (ORACLE_PATH_LIB)
+find_path(ORACLE_INCLUDE_DIR
+  NAMES oci.h
+  PATHS
+  ${ORACLE_HOME}/rdbms/public
+  ${ORACLE_HOME}/include
+  ${ORACLE_HOME}/sdk/include  # Oracle SDK
+  ${ORACLE_HOME}/OCI/include # Oracle XE on Windows
+  # instant client from rpm
+  /usr/include/oracle/*/client${LIB_SUFFIX})
 
-FIND_PATH(
-    ORACLE_INCLUDE_DIR
-    oci.h
-    ${ORACLE_INCLUDES_LOCATION}
-)
+set(ORACLE_VERSIONS 21 20 19 18 12 11 10)
+set(ORACLE_OCI_NAMES clntsh libclntsh oci) # Dirty trick might help on OSX, see issues/89
+set(ORACLE_OCCI_NAMES libocci occi)
+set(ORACLE_NNZ_NAMES ociw32)
+foreach(loop_var IN LISTS ORACLE_VERSIONS)
+  set(ORACLE_OCCI_NAMES ${ORACLE_OCCI_NAMES} oraocci${loop_var})
+  set(ORACLE_NNZ_NAMES ${ORACLE_NNZ_NAMES} nnz${loop_var} libnnz${loop_var})
+endforeach(loop_var)
 
-FIND_LIBRARY(
-    ORACLE_LIBRARY_OCCI
-    NAMES libocci occi oraocci10
-    PATHS ${ORACLE_LIB_LOCATION}
-)
-FIND_LIBRARY(
-    ORACLE_LIBRARY_CLNTSH
-    NAMES libclntsh clntsh oci
-    PATHS ${ORACLE_LIB_LOCATION}
-)
-FIND_LIBRARY(
-    ORACLE_LIBRARY_LNNZ
-    NAMES libnnz10 nnz10 libnnz11 nnz11 libnnz12 nnz12 nnz18 nnz19 nnz21 ociw32
-    PATHS ${ORACLE_LIB_LOCATION}
-)
+set(ORACLE_LIB_DIR
+  ${ORACLE_HOME}
+  ${ORACLE_HOME}/lib
+  ${ORACLE_HOME}/sdk/lib       # Oracle SDK
+  ${ORACLE_HOME}/sdk/lib/msvc
+  ${ORACLE_HOME}/OCI/lib/msvc # Oracle XE on Windows
+  # Instant client from rpm
+  /usr/lib/oracle/*/client${LIB_SUFFIX}/lib)
 
-SET (ORACLE_LIBRARY ${ORACLE_LIBRARY_OCCI} ${ORACLE_LIBRARY_CLNTSH} ${ORACLE_LIBRARY_LNNZ})
+find_library(ORACLE_OCI_LIBRARY
+  NAMES ${ORACLE_OCI_NAMES} PATHS ${ORACLE_LIB_DIR})
+find_library(ORACLE_OCCI_LIBRARY
+  NAMES ${ORACLE_OCCI_NAMES} PATHS ${ORACLE_LIB_DIR})
+find_library(ORACLE_NNZ_LIBRARY
+  NAMES ${ORACLE_NNZ_NAMES} PATHS ${ORACLE_LIB_DIR})
 
-IF (ORACLE_LIBRARY)
-    SET(ORACLE_LIBRARIES ${ORACLE_LIBRARY})
-    SET(ORACLE_FOUND 1)
-ENDIF (ORACLE_LIBRARY)
+set(ORACLE_LIBRARY
+  ${ORACLE_OCI_LIBRARY}
+  ${ORACLE_OCCI_LIBRARY}
+  ${ORACLE_NNZ_LIBRARY})
 
+if(NOT WIN32)
+  set(ORACLE_LIBRARY ${ORACLE_LIBRARY} ${ORACLE_CLNTSH_LIBRARY})
+endif(NOT WIN32)
 
-# guess OCI version
-IF (NOT DEFINED ORACLE_OCI_VERSION)
-    FIND_PROGRAM(SQLPLUS_EXECUTABLE sqlplus
-      /usr/bin/
-      /usr/local/bin
-      ${ORACLE_HOME}/bin
-    )
-    IF(SQLPLUS_EXECUTABLE)
-      get_filename_component(_bindir ${SQLPLUS_EXECUTABLE} PATH) # sqlplus executable needs its shared libraries
-      set(ENV{LD_LIBRARY_PATH} ${_bindir}/../lib:$ENV{LD_LIBRARY_PATH})
-      EXECUTE_PROCESS(COMMAND ${SQLPLUS_EXECUTABLE} -version OUTPUT_VARIABLE sqlplus_out)
-      STRING(REGEX MATCH "([0-9.]+)" sqlplus_version ${sqlplus_out})
-      MESSAGE(STATUS "Found sqlplus version: ${sqlplus_version}")
+set(ORACLE_LIBRARIES ${ORACLE_LIBRARY})
 
-      # WARNING!
-      # MATCHES operator is using Cmake regular expression.
-      # so the e.g. 9.* does not expand like shell file mask
-      # but as "9 and then any sequence of characters"
-      IF (${sqlplus_version} MATCHES "8.*")
-         SET(ORACLE_OCI_VERSION "8I")
-      ELSEIF (${sqlplus_version} MATCHES "9.*")
-         SET(ORACLE_OCI_VERSION "9")
-# do not change the order of the ora10 checking!
-      ELSEIF (${sqlplus_version} MATCHES "10.2.*")
-         SET(ORACLE_OCI_VERSION "10G_R2")
-      ELSEIF (${sqlplus_version} MATCHES "10.*")
-         SET(ORACLE_OCI_VERSION "10G")
-      ELSEIF (${sqlplus_version} MATCHES "11.*")
-         SET(ORACLE_OCI_VERSION "11G")
-      ELSE (${sqlplus_version} MATCHES "8.*")
-         SET(ORACLE_OCI_VERSION "10G_R2")
-      ENDIF (${sqlplus_version} MATCHES "8.*")
+# Handle the QUIETLY and REQUIRED arguments and set ORACLE_FOUND to TRUE
+# if all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Oracle DEFAULT_MSG ORACLE_LIBRARY ORACLE_INCLUDE_DIR)
 
-      MESSAGE(STATUS "Guessed ORACLE_OCI_VERSION value: ${ORACLE_OCI_VERSION}")
-   ENDIF()
-ENDIF (NOT DEFINED ORACLE_OCI_VERSION)
+if(NOT ORACLE_FOUND)
+	message(STATUS "None of the supported Oracle versions (${ORACLE_VERSIONS}) could be found, consider updating ORACLE_VERSIONS if the version you use is not among them.")
+endif()
 
-
-IF (ORACLE_FOUND)
-    IF (NOT ORACLE_FIND_QUIETLY)
-         MESSAGE(STATUS "Found Oracle: ${ORACLE_LIBRARIES}")
-    ENDIF (NOT ORACLE_FIND_QUIETLY)
-    # there *must* be OCI version defined for internal libraries
-    IF (ORACLE_OCI_VERSION)
-        SET(ORACLE_DEFINITIONS -DOTL_ORA${ORACLE_OCI_VERSION})
-    ELSE (ORACLE_OCI_VERSION)
-        MESSAGE(FATAL_ERROR "Set -DORACLE_OCI_VERSION for your oci. [8, 8I, 9I, 10G, 10G_R2]")
-    ENDIF (ORACLE_OCI_VERSION)
-
-ELSE (ORACLE_FOUND)
-    MESSAGE(STATUS "Oracle not found.")
-    MESSAGE(STATUS "Oracle: You can specify includes: -DORACLE_PATH_INCLUDES=/usr/include/oracle/10.2.0.3/client")
-    MESSAGE(STATUS "   currently found includes: ${ORACLE_INCLUDES}")
-    MESSAGE(STATUS "Oracle: You can specify libs: -DORACLE_PATH_LIB=/usr/lib/oracle/10.2.0.3/client/lib")
-    MESSAGE(STATUS "   currently found libs: ${ORACLE_LIBRARY}")
-    IF (ORACLE_FIND_REQUIRED)
-        MESSAGE(FATAL_ERROR "Could not find Oracle library")
-    ELSE (ORACLE_FIND_REQUIRED)
-        # setup the variables for silent continue
-        SET (ORACLE_INCLUDES "")
-    ENDIF (ORACLE_FIND_REQUIRED)
-ENDIF (ORACLE_FOUND)
-
-mark_as_advanced(
-  ORACLE_INCLUDE_DIR
-  ORACLE_LIBRARY_OCCI
-  ORACLE_LIBRARY_LNNZ
-  ORACLE_LIBRARY_CLNTSH
-  SQLPLUS_EXECUTABLE
-)
-
-
-MACRO (PREPROCESS_ORACLE_FILES INFILES INCLUDE_DIRS_IN)
-
-  set(SYS_INCLUDE "'sys_include=(${ORACLE_HOME}/precomp/public,/usr/include/,/usr/local/gcc3.2.3/lib/gcc-lib/i686-pc-linux-gnu/3.2.3/include,/usr/local/gcc3.2.3/lib/gcc-lib/i686-pc-linux-gnu,/usr/include/g++-3,/usr/include/c++/3.2/backward,/usr/include/c++/3.2)'")
-
-#  set(INCLUDE_DIRS "
-#      include=${ORACLE_HOME}/precomp/public
-#      include=${ORACLE_HOME}/rdbms/public
-#      include=${ORACLE_HOME}/rdbms/demo
-#      include=${ORACLE_HOME}/plsql/public
-#      include=${ORACLE_HOME}/network/public
-#  ")
-
-  set(INCLUDE_DIRS)
-
-  foreach (_current_FILE ${INCLUDE_DIRS_IN})
-    set(INCLUDE_DIRS ${INCLUDE_DIRS} include=${_current_FILE})
-  endforeach (_current_FILE ${INCLUDE_DIRS_IN})
-
-  SET(PROCFLAGS oraca=yes code=cpp parse=partial sqlcheck=semantics ireclen=130 oreclen=130 ${INCLUDE_DIRS})
-# ${SYS_INCLUDE} ${INCLUDE_DIRS})
-
-
-#  MESSAGE("PROCFLAGS: ${PROCFLAGS}")
-#  MESSAGE("INCLUDE_DIRS: ${INCLUDE_DIRS}")
-
-
-  foreach (_current_FILE ${INFILES})
-    GET_FILENAME_COMPONENT(OUTFILE_NAME ${_current_FILE} NAME_WE)
-    set(OUTFILE "${OUTFILE_NAME}.cxx")
-    ADD_CUSTOM_COMMAND(OUTPUT ${OUTFILE}
-     COMMAND $ENV{ORACLE_HOME}/bin/proc ARGS iname=${CMAKE_CURRENT_SOURCE_DIR}/${_current_FILE} oname=${CMAKE_CURRENT_BINARY_DIR}/${OUTFILE} ${PROCFLAGS} DEPENDS ${_current_FILE})
-  endforeach (_current_FILE ${INFILES})
-
-ENDMACRO (PREPROCESS_ORACLE_FILES)
+mark_as_advanced(ORACLE_INCLUDE_DIR ORACLE_LIBRARY)


### PR DESCRIPTION
Nicer to distribute a BSD licensed version.
The file `COPYING-CMAKE-SCRIPTS` is missing virtually worldwide, not even CMake includes it: https://gitlab.kitware.com/search?search=COPYING-CMAKE-SCRIPTS&nav_source=navbar&project_id=541&group_id=415&search_code=true&repository_ref=master
