### PR TITLE
[hist] Fix license for TGraphSmooth (NFC): [skip-ci]

### DIFF
--- a/hist/hist/inc/TGraphSmooth.h
+++ b/hist/hist/inc/TGraphSmooth.h
@@ -1,22 +1,20 @@
 // @(#)root/hist:$Id$
 // Author: Christian Stratowa 30/09/2001
 
+/*************************************************************************
+ * Copyright (C) 2006, Rene Brun and Fons Rademakers.                    *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
 /******************************************************************************
-* Copyright(c) 2001-    , Dr. Christian Stratowa, Vienna, Austria.            *
+* Copyright(c) 2001-2006, Dr. Christian Stratowa, Vienna, Austria.            *
 * Author: Christian Stratowa with help from Rene Brun.                        *
 *                                                                             *
 * Algorithms for smooth regression adapted from:                              *
 * R: A Computer Language for Statistical Data Analysis                        *
-* Copyright (C) 1996 Robert Gentleman and Ross Ihaka                          *
-* Copyright (C) 1999-2001 Robert Gentleman, Ross Ihaka and the                *
-* R Development Core Team                                                     *
-* R is free software, for licensing see the GNU General Public License        *
-* http://www.ci.tuwien.ac.at/R-project/welcome.html                           *
-*                                                                             *
-* Based on: "The ROOT System", All rights reserved.                           *
-* Authors: Rene Brun and Fons Rademakers.                                     *
-* For the licensing terms of "The ROOT System" see $ROOTSYS/AA_LICENSE.       *
-* For the list of contributors to "The ROOT System" see $ROOTSYS/AA_CREDITS.  *
 ******************************************************************************/
 
 #ifndef ROOT_TGraphSmooth

--- a/hist/hist/src/TGraphSmooth.cxx
+++ b/hist/hist/src/TGraphSmooth.cxx
@@ -10,16 +10,11 @@
  *************************************************************************/
 
 /******************************************************************************
-* Copyright(c) 2001-    , Dr. Christian Stratowa, Vienna, Austria.            *
+* Copyright(c) 2001-2006, Dr. Christian Stratowa, Vienna, Austria.            *
 * Author: Christian Stratowa with help from Rene Brun.                        *
 *                                                                             *
 * Algorithms for smooth regression adapted from:                              *
 * R: A Computer Language for Statistical Data Analysis                        *
-* Copyright (C) 1996 Robert Gentleman and Ross Ihaka                          *
-* Copyright (C) 1999-2001 Robert Gentleman, Ross Ihaka and the                *
-* R Development Core Team                                                     *
-* R is free software, for licensing see the GNU General Public License        *
-* http://www.ci.tuwien.ac.at/R-project/welcome.html                           *
 *                                                                             *
 ******************************************************************************/
 


### PR DESCRIPTION
After consultation with Christian Stratowa, the intent was to use the same license as that of ROOT. Given the commit 041f9ed55290e7edcfd78a15dfcd3c0eb7b8c9fc which sets the (c) to Fons+Rene, the copyright for Christian must end around that time that Christian has donated the code to Fons&Rene. Use consistent header for .h and .cxx.
