### PR TITLE
Fix 13691

### DIFF
--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -96,7 +96,9 @@ TDirectory::TDirectory(const char *name, const char *title, Option_t * /*classna
 
 TDirectory::~TDirectory()
 {
-   if (!gROOT) {
+   // Use gROOTLocal to avoid triggering undesired initialization of gROOT.
+   // For example in compiled C++ programs that don't use it directly.
+   if (!ROOT::Internal::gROOTLocal) {
       delete fList;
       return; //when called by TROOT destructor
    }

--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -1202,7 +1202,8 @@ void TDirectory::pwd() const
 
 void TDirectory::RecursiveRemove(TObject *obj)
 {
-   fList->RecursiveRemove(obj);
+   if (fList)
+      fList->RecursiveRemove(obj);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/test/CMakeLists.txt
+++ b/hist/hist/test/CMakeLists.txt
@@ -26,3 +26,12 @@ if(clad)
   ROOT_ADD_GTEST(TFormulaGradientTests TFormulaGradientTests.cxx LIBRARIES Core MathCore Hist)
   ROOT_ADD_GTEST(TFormulaHessianTests TFormulaHessianTests.cxx LIBRARIES Core MathCore Hist)
 endif()
+
+# Regression test for https://github.com/root-project/root/issues/13691
+# The test needs the following to be actually useful:
+# - It must be compiled and run as a standalone executable, as it depends on
+#   gROOT not being initialized yet.
+# - It must link to any library that is not in `core`. See the linked issue
+#   for details.
+ROOT_EXECUTABLE(tdirectoryfile_destructor_segfault tdirectoryfile_destructor_segfault.cxx LIBRARIES RIO Hist)
+ROOT_ADD_TEST(test-tdirectoryfile_destructor_segfault COMMAND tdirectoryfile_destructor_segfault)

--- a/hist/hist/test/tdirectoryfile_destructor_segfault.cxx
+++ b/hist/hist/test/tdirectoryfile_destructor_segfault.cxx
@@ -1,0 +1,18 @@
+#include "TDirectoryFile.h"
+
+int main()
+{
+   // Test against https://github.com/root-project/root/issues/13691
+   // At destruction time TDirectoryFile called the destructor of
+   // TDirectory, thus:
+   // - inadvertently triggered initialization of gROOT
+   // - called TDirectory::RecursiveRemove which didn't check for the validity
+   //   of the `fList` data member, which had already been deleted in the
+   //   TDirectoryFile destructor
+   //
+   // NOTE: In order for the segfault to actually be triggered, this test needs
+   // to link against some library that is not in the list of globally ignored
+   // PCMs (gIgnoredPCMNames in TCling.cxx). The loading of a PCM is what
+   // actually triggers the call to TDirectory::RecursiveRemove in the end.
+   TDirectoryFile f{"f", "f"};
+}


### PR DESCRIPTION
This PR fixes #13691 , although we might want to revisit the logic of [`TDirectoryFile::~TDirectoryFile`](https://github.com/root-project/root/blob/e8bdfaf5add048e5301bc8f96927ed6c7d3a8db2/io/io/src/TDirectoryFile.cxx#L178) since it's weird that it was triggered this way, IMHO.

If deemed appropriate, I can use the small reproducer of the linked issue as a unittest of this fix.