### PR TITLE
[ntuple] Add `GetCompressionSettingsAsString()` to inspector

### DIFF
--- a/core/zip/inc/Compression.h
+++ b/core/zip/inc/Compression.h
@@ -14,6 +14,8 @@
 
 #include "RtypesCore.h"
 
+#include <string>
+
 namespace ROOT {
 
 /// The global settings depend on a global variable named R__ZipMode which can be
@@ -100,6 +102,8 @@ struct RCompressionSetting {
          kUndefined
       };
    };
+
+   static std::string AlgorithmToString(EAlgorithm::EValues algorithm);
 };
 
 enum ECompressionAlgorithm {

--- a/core/zip/src/Compression.cxx
+++ b/core/zip/src/Compression.cxx
@@ -34,4 +34,16 @@ namespace ROOT {
     if (algorithm >= ROOT::ECompressionAlgorithm::kUndefinedCompressionAlgorithm) algo = 0;
     return algo * 100 + compressionLevel;
   }
+
+  std::string RCompressionSetting::AlgorithmToString(RCompressionSetting::EAlgorithm::EValues algorithm)
+  {
+     switch (algorithm) {
+     case EAlgorithm::EValues::kZLIB: return "zlib"; break;
+     case EAlgorithm::EValues::kLZMA: return "LZMA"; break;
+     case EAlgorithm::EValues::kOldCompressionAlgo: return "Old compression algorithm"; break;
+     case EAlgorithm::EValues::kLZ4: return "lz4"; break;
+     case EAlgorithm::EValues::kZSTD: return "zstd"; break;
+     default: return "Undefined compression algorithm";
+     }
+  }
 }

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -147,10 +147,15 @@ public:
    /// Get the descriptor for the RNTuple being inspected.
    RNTupleDescriptor *GetDescriptor() const { return fDescriptor.get(); }
 
-   /// Get the compression settings of the RNTuple being inspected. Here, we assume that the compression settings are
-   /// consistent across all clusters and columns. If this is not the case, an exception will be thrown upon
-   /// `RNTupleInspector::Create`.
+   /// Get the compression settings of the RNTuple being inspected according to the format described in Compression.h.
+   /// Here, we assume that the compression settings are consistent across all clusters and columns. If this is not the
+   /// case, an exception will be thrown upon `RNTupleInspector::Create`.
    int GetCompressionSettings() const { return fCompressionSettings; }
+
+   /// Get a description of compression settings of the RNTuple being inspected. Here, we assume that the compression
+   /// settings are consistent across all clusters and columns. If this is not the case, an exception will be thrown
+   /// upon `RNTupleInspector::Create`.
+   std::string GetCompressionSettingsAsString() const;
 
    /// Get the compressed, on-disk size of the RNTuple being inspected, in bytes.
    /// Does **not** include the size of the header and footer.

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -182,6 +182,15 @@ ROOT::Experimental::RNTupleInspector::Create(std::string_view ntupleName, std::s
    return inspector;
 }
 
+std::string ROOT::Experimental::RNTupleInspector::GetCompressionSettingsAsString() const
+{
+   int algorithm = fCompressionSettings / 100;
+   int level = fCompressionSettings - (algorithm * 100);
+
+   return RCompressionSetting::AlgorithmToString(static_cast<RCompressionSetting::EAlgorithm::EValues>(algorithm)) +
+          " (level " + std::to_string(level) + ")";
+}
+
 //------------------------------------------------------------------------------
 
 const ROOT::Experimental::RNTupleInspector::RColumnInfo &

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -57,7 +57,7 @@ TEST(RNTupleInspector, CompressionSettings)
       auto nFldInt = model->MakeField<std::int32_t>("int");
 
       auto writeOptions = RNTupleWriteOptions();
-      writeOptions.SetCompression(505);
+      writeOptions.SetCompression(207);
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
 
       *nFldInt = 42;
@@ -66,7 +66,8 @@ TEST(RNTupleInspector, CompressionSettings)
 
    auto inspector = RNTupleInspector::Create("ntuple", fileGuard.GetPath());
 
-   EXPECT_EQ(505, inspector->GetCompressionSettings());
+   EXPECT_EQ(207, inspector->GetCompressionSettings());
+   EXPECT_EQ("LZMA (level 7)", inspector->GetCompressionSettingsAsString());
 }
 
 TEST(RNTupleInspector, SizeUncompressedSimple)


### PR DESCRIPTION
This PR adds a new `RNTupleInspector` method that returns the compression settings as a string next to the internal integer representation.

The format of the string is "`A` (level `L`)", where `A` is the name of the compression algorithm and `L` the compression level.