### PR TITLE
[ntuple] Add `PrintColumnTypeInfo` to `RNTupleInspector`

### DIFF
--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -24,11 +24,13 @@
 
 #include <cstdlib>
 #include <memory>
-#include <vector>
 #include <regex>
+#include <vector>
 
 namespace ROOT {
 namespace Experimental {
+
+enum class ENTupleInspectorPrintFormat { kTable, kCSV };
 
 // clang-format off
 /**
@@ -168,6 +170,11 @@ public:
 
    /// Get the IDs of all columns with the given type.
    const std::vector<DescriptorId_t> GetColumnsByType(EColumnType);
+
+   /// Print the per-column type information in CSV format. This includes the column type, its count, the total number
+   /// of elements, the on-disk size and the in-memory size.
+   void PrintColumnTypeInfo(ENTupleInspectorPrintFormat format = ENTupleInspectorPrintFormat::kTable,
+                            std::ostream &output = std::cout);
 
    const RFieldTreeInfo &GetFieldTreeInfo(DescriptorId_t fieldId) const;
    const RFieldTreeInfo &GetFieldTreeInfo(std::string_view fieldName) const;

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -171,8 +171,43 @@ public:
    /// Get the IDs of all columns with the given type.
    const std::vector<DescriptorId_t> GetColumnsByType(EColumnType);
 
-   /// Print the per-column type information in CSV format. This includes the column type, its count, the total number
-   /// of elements, the on-disk size and the in-memory size.
+   /// Print the per-column type information, either as a table or in CSV format. The output includes the column type,
+   /// its count, the total number of elements, the on-disk size and the in-memory size.
+   ///
+   /// **Example: printing the column type information of an RNTuple as a table**
+   /// ~~~ {.cpp}
+   /// #include <ROOT/RNTupleInspector.hxx>
+   /// using ROOT::Experimental::RNTupleInspector;
+   /// using ROOT::Experimental::ENTupleInspectorPrintFormat;
+   ///
+   /// auto inspector = RNTupleInspector::Create("myNTuple", "some/file.root");
+   /// inspector->PrintColumnTypeInfo();
+   /// ~~~
+   /// Ouput:
+   /// ~~~
+   ///        column type |   count |        # elements |     bytes on disk |     bytes in memory
+   /// ------------------------------------------------------------------------------------------
+   ///       SplitIndex64 |       2 |               150 |                72 |              1200
+   ///        SplitReal32 |       4 |               300 |               189 |              1200
+   ///        SplitUInt32 |       3 |               225 |               123 |               900
+   /// ~~~
+   ///
+   /// **Example: printing the column type information of an RNTuple in CSV format**
+   /// ~~~ {.cpp}
+   /// #include <ROOT/RNTupleInspector.hxx>
+   /// using ROOT::Experimental::RNTupleInspector;
+   /// using ROOT::Experimental::ENTupleInspectorPrintFormat;
+   ///
+   /// auto inspector = RNTupleInspector::Create("myNTuple", "some/file.root");
+   /// inspector->PrintColumnTypeInfo();
+   /// ~~~
+   /// Ouput:
+   /// ~~~
+   /// columnType,count,nElements,onDiskSize,inMemSize
+   /// SplitIndex64,2,150,72,1200
+   /// SplitReal32,4,300,189,1200
+   /// SplitUInt32,3,225,123,900
+   /// ~~~
    void PrintColumnTypeInfo(ENTupleInspectorPrintFormat format = ENTupleInspectorPrintFormat::kTable,
                             std::ostream &output = std::cout);
 

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -185,11 +185,11 @@ public:
    /// ~~~
    /// Ouput:
    /// ~~~
-   ///        column type |   count |        # elements |     bytes on disk |     bytes in memory
-   /// ------------------------------------------------------------------------------------------
-   ///       SplitIndex64 |       2 |               150 |                72 |              1200
-   ///        SplitReal32 |       4 |               300 |               189 |              1200
-   ///        SplitUInt32 |       3 |               225 |               123 |               900
+   ///  column type    | count   | # elements      | bytes on disk   | bytes in memory
+   /// ----------------|---------|-----------------|-----------------|-----------------
+   ///    SplitIndex64 |       2 |             150 |              72 |            1200
+   ///     SplitReal32 |       4 |             300 |             189 |            1200
+   ///     SplitUInt32 |       3 |             225 |             123 |             900
    /// ~~~
    ///
    /// **Example: printing the column type information of an RNTuple in CSV format**

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -226,7 +226,7 @@ void ROOT::Experimental::RNTupleInspector::PrintColumnTypeInfo(ENTupleInspectorP
       std::uint32_t count;
       std::uint64_t nElems, onDiskSize, inMemSize;
 
-      void operator()(const RColumnInfo &colInfo)
+      void operator+=(const RColumnInfo &colInfo)
       {
          this->count++;
          this->nElems += colInfo.GetNElements();
@@ -238,7 +238,7 @@ void ROOT::Experimental::RNTupleInspector::PrintColumnTypeInfo(ENTupleInspectorP
    std::map<EColumnType, ColumnTypeInfo> colTypeInfo;
 
    for (const auto &[colId, colInfo] : fColumnInfo) {
-      colTypeInfo[colInfo.GetType()](colInfo);
+      colTypeInfo[colInfo.GetType()] += colInfo;
    }
 
    int colWidth = 20;

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -241,19 +241,14 @@ void ROOT::Experimental::RNTupleInspector::PrintColumnTypeInfo(ENTupleInspectorP
       colTypeInfo[colInfo.GetType()] += colInfo;
    }
 
-   int colWidth = 20;
    switch (format) {
    case ENTupleInspectorPrintFormat::kTable:
-      output << std::setw(colWidth) << "column type |" << std::setw(colWidth / 2) << "count |" << std::setw(colWidth)
-             << "# elements |" << std::setw(colWidth) << "bytes on disk |" << std::setw(colWidth) << "bytes in memory"
-             << std::endl;
-      output << std::setw(colWidth * 4 + (colWidth / 2)) << std::setfill('-') << "-" << std::setfill(' ') << std::endl;
-      colWidth -= 2;
+      output << " column type    | count   | # elements      | bytes on disk   | bytes in memory" << std::endl;
+      output << "----------------|---------|-----------------|-----------------|-----------------" << std::endl;
       for (const auto &[colType, typeInfo] : colTypeInfo) {
-         output << std::setw(colWidth) << Detail::RColumnElementBase::GetTypeName(colType) << " |"
-                << std::setw(colWidth / 2 - 1) << typeInfo.count << " |" << std::setw(colWidth) << typeInfo.nElems
-                << " |" << std::setw(colWidth) << typeInfo.onDiskSize << " |" << std::setw(colWidth)
-                << typeInfo.inMemSize << std::endl;
+         output << std::setw(15) << Detail::RColumnElementBase::GetTypeName(colType) << " |" << std::setw(8)
+                << typeInfo.count << " |" << std::setw(16) << typeInfo.nElems << " |" << std::setw(16)
+                << typeInfo.onDiskSize << " |" << std::setw(16) << typeInfo.inMemSize << " " << std::endl;
       }
       break;
    case ENTupleInspectorPrintFormat::kCSV:

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -367,14 +367,13 @@ TEST(RNTupleInspector, PrintColumnTypeInfo)
    std::stringstream tableOutput;
    inspector->PrintColumnTypeInfo(ROOT::Experimental::ENTupleInspectorPrintFormat::kTable, tableOutput);
 
-   std::string expectedTableHeader{
-      "       column type |   count |        # elements |     bytes on disk |     bytes in memory"};
    std::getline(tableOutput, line);
-   EXPECT_EQ(expectedTableHeader, line);
+   EXPECT_EQ(" column type    | count   | # elements      | bytes on disk   | bytes in memory", line);
+
+   std::getline(tableOutput, line);
+   EXPECT_EQ("----------------|---------|-----------------|-----------------|-----------------", line);
 
    nLines = 0;
-   // The table output contains a separator line
-   std::getline(tableOutput, line);
    while (std::getline(tableOutput, line)) {
       ++nLines;
       colTypeStr = line.substr(0, line.find("|"));


### PR DESCRIPTION
This PR adds the functionality to print per-column type information for a given RNTuple. Output can be formatted in both a text-based table as well as CSV (and may be extended with more formats where desired).

## Example

For an RNTuple with 75 rows each containing one [ComplexStructUtil](https://github.com/root-project/root/blob/3acc0e601bd74ffd876c755069e8e989d922521c/tree/ntupleutil/v7/test/CustomStructUtil.hxx#L36) field, the default (table-formatted) output is as follows:

```
root [1] inspector->PrintColumnTypeInfo()
 column type    | count   | # elements      | bytes on disk   | bytes in memory
----------------|---------|-----------------|-----------------|-----------------
   SplitIndex64 |       2 |             150 |              72 |            1200 
    SplitReal32 |       4 |             300 |             189 |            1200 
    SplitUInt32 |       3 |             225 |             123 |             900 
```

And the CSV-formatted output:

```
root [2] inspector->PrintColumnTypeInfo(ROOT::Experimental::ENTupleInspectorPrintFormat::kCSV)
columnType,count,nElements,onDiskSize,inMemSize
SplitIndex64,2,150,72,1200
SplitReal32,4,300,189,1200
SplitUInt32,3,225,123,900
```

Additionally, it is possible to define where the output should be written to (default is stdout).