### PR TITLE
[ntuple] Homogenize `RNTupleInspector` method names

### DIFF
--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -126,7 +126,7 @@ private:
    RFieldTreeInfo CollectFieldTreeInfo(DescriptorId_t fieldId);
 
    /// Get the IDs of the columns that make up the given field, including its sub-fields.
-   std::vector<DescriptorId_t> GetColumnsForFieldTree(DescriptorId_t fieldId) const;
+   std::vector<DescriptorId_t> GetColumnsByFieldId(DescriptorId_t fieldId) const;
 
 public:
    RNTupleInspector(const RNTupleInspector &other) = delete;
@@ -164,7 +164,7 @@ public:
    const RColumnInfo &GetColumnInfo(DescriptorId_t physicalColumnId) const;
 
    /// Get the number of columns of a given type present in the RNTuple.
-   size_t GetColumnTypeCount(EColumnType colType) const;
+   size_t GetColumnCountByType(EColumnType colType) const;
 
    /// Get the IDs of all columns with the given type.
    const std::vector<DescriptorId_t> GetColumnsByType(EColumnType);
@@ -174,10 +174,10 @@ public:
 
    /// Get the number of fields of a given type or class present in the RNTuple. The type name may contain regular
    /// expression patterns in order to be able to group multiple kinds of types or classes.
-   size_t GetFieldTypeCount(const std::regex &typeNamePattern, bool searchInSubFields = true) const;
-   size_t GetFieldTypeCount(std::string_view typeNamePattern, bool searchInSubFields = true) const
+   size_t GetFieldCountByType(const std::regex &typeNamePattern, bool searchInSubFields = true) const;
+   size_t GetFieldCountByType(std::string_view typeNamePattern, bool searchInSubFields = true) const
    {
-      return GetFieldTypeCount(std::regex{std::string(typeNamePattern)}, searchInSubFields);
+      return GetFieldCountByType(std::regex{std::string(typeNamePattern)}, searchInSubFields);
    }
 
    /// Get the IDs of (sub-)fields whose name matches the given string. Because field names are unique by design,

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -110,7 +110,7 @@ ROOT::Experimental::RNTupleInspector::CollectFieldTreeInfo(DescriptorId_t fieldI
 }
 
 std::vector<ROOT::Experimental::DescriptorId_t>
-ROOT::Experimental::RNTupleInspector::GetColumnsForFieldTree(DescriptorId_t fieldId) const
+ROOT::Experimental::RNTupleInspector::GetColumnsByFieldId(DescriptorId_t fieldId) const
 {
    std::vector<DescriptorId_t> colIds;
    std::deque<DescriptorId_t> fieldIdQueue{fieldId};
@@ -193,7 +193,7 @@ ROOT::Experimental::RNTupleInspector::GetColumnInfo(DescriptorId_t physicalColum
    return fColumnInfo.at(physicalColumnId);
 }
 
-size_t ROOT::Experimental::RNTupleInspector::GetColumnTypeCount(ROOT::Experimental::EColumnType colType) const
+size_t ROOT::Experimental::RNTupleInspector::GetColumnCountByType(ROOT::Experimental::EColumnType colType) const
 {
    size_t typeCount = 0;
 
@@ -243,8 +243,8 @@ ROOT::Experimental::RNTupleInspector::GetFieldTreeInfo(std::string_view fieldNam
    return GetFieldTreeInfo(fieldId);
 }
 
-size_t
-ROOT::Experimental::RNTupleInspector::GetFieldTypeCount(const std::regex &typeNamePattern, bool includeSubFields) const
+size_t ROOT::Experimental::RNTupleInspector::GetFieldCountByType(const std::regex &typeNamePattern,
+                                                                 bool includeSubFields) const
 {
    size_t typeCount = 0;
 

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -113,7 +113,7 @@ TEST(RNTupleInspector, SizeUncompressedComplex)
 
    auto inspector = RNTupleInspector::Create("ntuple", fileGuard.GetPath());
 
-   int nIndexCols = inspector->GetColumnTypeCount(ROOT::Experimental::EColumnType::kIndex64);
+   int nIndexCols = inspector->GetColumnCountByType(ROOT::Experimental::EColumnType::kIndex64);
    int nEntries = inspector->GetDescriptor()->GetNEntries();
 
    EXPECT_EQ(2, nIndexCols);
@@ -279,9 +279,9 @@ TEST(RNTupleInspector, ColumnTypeCount)
 
    auto inspector = RNTupleInspector::Create("ntuple", fileGuard.GetPath());
 
-   EXPECT_EQ(2, inspector->GetColumnTypeCount(ROOT::Experimental::EColumnType::kSplitIndex64));
-   EXPECT_EQ(4, inspector->GetColumnTypeCount(ROOT::Experimental::EColumnType::kSplitReal32));
-   EXPECT_EQ(3, inspector->GetColumnTypeCount(ROOT::Experimental::EColumnType::kSplitInt32));
+   EXPECT_EQ(2, inspector->GetColumnCountByType(ROOT::Experimental::EColumnType::kSplitIndex64));
+   EXPECT_EQ(4, inspector->GetColumnCountByType(ROOT::Experimental::EColumnType::kSplitReal32));
+   EXPECT_EQ(3, inspector->GetColumnCountByType(ROOT::Experimental::EColumnType::kSplitInt32));
 }
 
 TEST(RNTupleInspector, ColumnsByType)
@@ -424,23 +424,23 @@ TEST(RNTupleInspector, FieldTypeCount)
 
    auto inspector = RNTupleInspector::Create("ntuple", fileGuard.GetPath());
 
-   EXPECT_EQ(1, inspector->GetFieldTypeCount("ComplexStructUtil"));
-   EXPECT_EQ(1, inspector->GetFieldTypeCount("ComplexStructUtil", false));
+   EXPECT_EQ(1, inspector->GetFieldCountByType("ComplexStructUtil"));
+   EXPECT_EQ(1, inspector->GetFieldCountByType("ComplexStructUtil", false));
 
-   EXPECT_EQ(1, inspector->GetFieldTypeCount("std::vector<HitUtil>"));
-   EXPECT_EQ(0, inspector->GetFieldTypeCount("std::vector<HitUtil>", false));
+   EXPECT_EQ(1, inspector->GetFieldCountByType("std::vector<HitUtil>"));
+   EXPECT_EQ(0, inspector->GetFieldCountByType("std::vector<HitUtil>", false));
 
-   EXPECT_EQ(2, inspector->GetFieldTypeCount("std::vector<.*>"));
-   EXPECT_EQ(0, inspector->GetFieldTypeCount("std::vector<.*>", false));
+   EXPECT_EQ(2, inspector->GetFieldCountByType("std::vector<.*>"));
+   EXPECT_EQ(0, inspector->GetFieldCountByType("std::vector<.*>", false));
 
-   EXPECT_EQ(3, inspector->GetFieldTypeCount("BaseUtil"));
-   EXPECT_EQ(0, inspector->GetFieldTypeCount("BaseUtil", false));
+   EXPECT_EQ(3, inspector->GetFieldCountByType("BaseUtil"));
+   EXPECT_EQ(0, inspector->GetFieldCountByType("BaseUtil", false));
 
-   EXPECT_EQ(6, inspector->GetFieldTypeCount("std::int32_t"));
-   EXPECT_EQ(3, inspector->GetFieldTypeCount("std::int32_t", false));
+   EXPECT_EQ(6, inspector->GetFieldCountByType("std::int32_t"));
+   EXPECT_EQ(3, inspector->GetFieldCountByType("std::int32_t", false));
 
-   EXPECT_EQ(4, inspector->GetFieldTypeCount("float"));
-   EXPECT_EQ(0, inspector->GetFieldTypeCount("float", false));
+   EXPECT_EQ(4, inspector->GetFieldCountByType("float"));
+   EXPECT_EQ(0, inspector->GetFieldCountByType("float", false));
 }
 
 TEST(RNTupleInspector, FieldsByName)


### PR DESCRIPTION
As mentioned in #13367, this PR homogenizes the naming used in the `RNTupleInspector` by consistently using the `ByType` or `ByName` suffix for methods that return aggregated information.

