### PR TITLE
[jsroot] dev 21/09/2023 with fixes [skip-ci]

### DIFF
--- a/js/changes.md
+++ b/js/changes.md
@@ -26,6 +26,9 @@
 23. Reset pad enlarge state when pressing Escape key #265
 24. Support canvas grayscale, let toggle via context menu
 25. Fix - correct scaling of axis labels when tilt them by 25 degree, make this angle configurable
+26. Fix - legend multi-columns drawing and labels scaling
+27. Fix - graph "B" bar widths as in native ROOT
+28. Fix - use pad and not frame size for TText/TLatex scaling 
 
 
 ## Changes in 7.4.3

--- a/js/modules/base/ObjectPainter.mjs
+++ b/js/modules/base/ObjectPainter.mjs
@@ -1095,6 +1095,7 @@ class ObjectPainter extends BasePainter {
      * @param {number} [arg.y = 0] - y position
      * @param {number} [arg.width] - when specified, adjust font size in the specified box
      * @param {number} [arg.height] - when specified, adjust font size in the specified box
+     * @param {boolean} [arg.scale = true] - scale into draw box when width and height parameters are specified
      * @param {number} [arg.latex] - 0 - plain text, 1 - normal TLatex, 2 - math
      * @param {string} [arg.color=black] - text color
      * @param {number} [arg.rotate] - rotaion angle
@@ -1141,7 +1142,8 @@ class ObjectPainter extends BasePainter {
       arg.align = align;
       arg.x = arg.x || 0;
       arg.y = arg.y || 0;
-      arg.scale = arg.width && arg.height && !arg.font_size;
+      if (arg.scale !== false)
+         arg.scale = arg.width && arg.height && !arg.font_size;
       arg.width = arg.width || 0;
       arg.height = arg.height || 0;
 

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -4,7 +4,7 @@ const version_id = '7.5.pre',
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-version_date = '19/09/2023',
+version_date = '21/09/2023',
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}
@@ -388,7 +388,8 @@ gStyle = {
    fYAxisExpXOffset: 0,
    fYAxisExpYOffset: 0,
    fAxisMaxDigits: 5,
-   fStripDecimals: true
+   fStripDecimals: true,
+   fBarWidth: 1
 };
 
 /** @summary Method returns current document in use

--- a/js/modules/draw/more.mjs
+++ b/js/modules/draw/more.mjs
@@ -10,18 +10,17 @@ import { assignContextMenu, kToFront } from '../gui/menu.mjs';
 async function drawText() {
    const text = this.getObject(),
          pp = this.getPadPainter(),
-         main = this.getFramePainter();
-   let w = pp.getPadWidth(),
-       h = pp.getPadHeight(),
-       pos_x = text.fX, pos_y = text.fY,
-       use_frame = false,
+         w = pp.getPadWidth(),
+         h = pp.getPadHeight(),
+         fp = this.getFramePainter();
+   let pos_x = text.fX, pos_y = text.fY,
        fact = 1,
        annot = this.matchObjectType(clTAnnotation);
 
    this.createAttText({ attr: text });
 
-   if (annot && main?.mode3d && isFunc(main?.convert3DtoPadNDC)) {
-      const pos = main.convert3DtoPadNDC(text.fX, text.fY, text.fZ);
+   if (annot && fp?.mode3d && isFunc(fp?.convert3DtoPadNDC)) {
+      const pos = fp.convert3DtoPadNDC(text.fX, text.fY, text.fZ);
       pos_x = pos.x;
       pos_y = pos.y;
       this.isndc = true;
@@ -29,11 +28,6 @@ async function drawText() {
    } else if (text.TestBit(BIT(14))) {
       // NDC coordinates
       this.isndc = true;
-   } else if (main && !main.mode3d) {
-      // frame coordiantes
-      w = main.getFrameWidth();
-      h = main.getFrameHeight();
-      use_frame = 'upper_layer';
    } else if (pp.getRootPad(true)) {
       // force pad coordiantes
    } else {
@@ -43,7 +37,7 @@ async function drawText() {
       text.fTextAlign = 22;
    }
 
-   this.createG(use_frame);
+   this.createG();
 
    this.draw_g.attr('transform', null); // remove transofrm from interactive changes
 
@@ -90,9 +84,9 @@ async function drawText() {
       if (annot !== '3d')
          addMoveHandler(this);
       else {
-         main.processRender3D = true;
+         fp.processRender3D = true;
          this.handleRender3D = () => {
-            const pos = main.convert3DtoPadNDC(text.fX, text.fY, text.fZ),
+            const pos = fp.convert3DtoPadNDC(text.fX, text.fY, text.fZ),
                   new_x = this.axisToSvg('x', pos.x, true),
                   new_y = this.axisToSvg('y', pos.y, true);
             makeTranslate(this.draw_g, new_x - this.pos_x, new_y - this.pos_y);

--- a/js/modules/gpad/TAxisPainter.mjs
+++ b/js/modules/gpad/TAxisPainter.mjs
@@ -476,8 +476,12 @@ class TAxisPainter extends ObjectPainter {
       let ndiv = 508;
       if (this.is_gaxis)
          ndiv = axis.fNdiv;
-       else if (axis)
-          ndiv = Math.max(axis.fNdivisions, 4);
+      else if (axis) {
+          if (!axis.fNdivisions)
+             ndiv = 0;
+          else
+             ndiv = Math.max(axis.fNdivisions, 4);
+      }
 
       this.nticks = ndiv % 100;
       this.nticks2 = (ndiv % 10000 - this.nticks) / 100;

--- a/js/modules/gpad/TPadPainter.mjs
+++ b/js/modules/gpad/TPadPainter.mjs
@@ -2027,6 +2027,14 @@ class TPadPainter extends ObjectPainter {
       if (elem.empty())
          return '';
 
+      if (use_frame || !full_canvas) {
+         const defs = this.getCanvSvg().selectChild('.canvas_defs');
+         if (!defs.empty()) {
+            items.push({ prnt: this.getCanvSvg(), defs });
+            elem.node().insertBefore(defs.node(), elem.node().firstChild);
+         }
+      }
+
       let active_pp = null;
       painter.forEachPainterInPad(pp => {
          if (pp.is_active_pad && !active_pp) {
@@ -2052,12 +2060,11 @@ class TPadPainter extends ObjectPainter {
          if (!isFunc(main?.render3D) || !isFunc(main?.access3dKind)) return;
 
          const can3d = main.access3dKind();
-
          if ((can3d !== constants.Embed3D.Overlay) && (can3d !== constants.Embed3D.Embed)) return;
 
          const sz2 = main.getSizeFor3d(constants.Embed3D.Embed), // get size and position of DOM element as it will be embed
 
-          canvas = main.renderer.domElement;
+         canvas = main.renderer.domElement;
          main.render3D(0); // WebGL clears buffers, therefore we should render scene and convert immediately
          const dataUrl = canvas.toDataURL('image/png');
 
@@ -2113,6 +2120,9 @@ class TPadPainter extends ObjectPainter {
 
             if (item.btns_node) // reinsert buttons
                item.btns_prnt.insertBefore(item.btns_node, item.btns_next);
+
+            if (item.defs) // reinsert defs
+               item.prnt.node().insertBefore(item.defs.node(), item.prnt.node().firstChild);
          }
          return res;
       });
@@ -2257,6 +2267,7 @@ class TPadPainter extends ObjectPainter {
       if (d.check('NOPALETTE') || d.check('NOPAL')) this.options.IgnorePalette = true;
       if (d.check('ROTATE')) this.options.RotateFrame = true;
       if (d.check('FIXFRAME')) this.options.FixFrame = true;
+      if (d.check('FIXSIZE') && this.iscan) this._fixed_size = true;
 
       if (d.check('CP', true)) this.options.CreatePalette = d.partAsInt(0, 0);
 

--- a/js/modules/hist2d/TGraphPainter.mjs
+++ b/js/modules/hist2d/TGraphPainter.mjs
@@ -647,17 +647,22 @@ class TGraphPainter extends ObjectPainter {
 
       if (options.Bar) {
          // calculate bar width
-         for (let i = 1; i < drawbins.length-1; ++i)
-            drawbins[i].width = Math.max(2, (drawbins[i+1].grx1 - drawbins[i-1].grx1) / 2 - 2);
 
-         // first and last bins
-         switch (drawbins.length) {
-            case 0: break;
-            case 1: drawbins[0].width = w/4; break; // pathologic case of single bin
-            case 2: drawbins[0].width = drawbins[1].width = (drawbins[1].grx1-drawbins[0].grx1)/2; break;
-            default:
-               drawbins[0].width = drawbins[1].width;
-               drawbins[drawbins.length-1].width = drawbins[drawbins.length-2].width;
+         let xmin = 0, xmax = 0;
+         for (let i = 0; i < drawbins.length; ++i) {
+            if (i === 0)
+               xmin = xmax = drawbins[i].grx1;
+            else {
+               xmin = Math.min(xmin, drawbins[i].grx1);
+               xmax = Math.max(xmax, drawbins[i].grx1);
+            }
+         }
+
+         if (drawbins.length === 1)
+            drawbins[0].width = w/4; // pathologic case of single bin
+         else {
+            for (let i = 0; i < drawbins.length; ++i)
+               drawbins[i].width = (xmax - xmin) / drawbins.length * gStyle.fBarWidth;
          }
 
          const yy0 = Math.round(funcs.gry(0));
@@ -674,9 +679,9 @@ class TGraphPainter extends ObjectPainter {
               .attr('d', d => {
                  d.bar = true; // element drawn as bar
                  const dx = Math.round(-d.width/2),
-                     dw = Math.round(d.width),
-                     dy = (options.Bar !== 1) ? 0 : ((d.gry1 > yy0) ? yy0-d.gry1 : 0),
-                     dh = (options.Bar !== 1) ? (h > d.gry1 ? h - d.gry1 : 0) : Math.abs(yy0 - d.gry1);
+                       dw = Math.round(d.width),
+                       dy = (options.Bar !== 1) ? 0 : ((d.gry1 > yy0) ? yy0-d.gry1 : 0),
+                       dh = (options.Bar !== 1) ? (h > d.gry1 ? h - d.gry1 : 0) : Math.abs(yy0 - d.gry1);
                  return `M${dx},${dy}h${dw}v${dh}h${-dw}z`;
               })
             .call(usefill.func);


### PR DESCRIPTION
1. TText/TLatex scaling to pad size
2. Handle TAxis with ndiv = 0
3. TGraph B draw option - proper bar width
4. Correctly use fixed label font size in TLegend, not always autoscale
5. Adjust columns width in TLegend to content
6. Correctly store/restore defs with fill patterns when producing screenshot 

This PR fixes #13693
