### PR TITLE
[TMVA] Do not run CNN tutorial if imt not specified

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -261,7 +261,7 @@ if(NOT TBB_FOUND AND NOT builtin_tbb)
 endif()
 
 if(NOT ROOT_imt_FOUND)
-  set(imt_veto multicore/imt*.C multicore/mt*.C)
+  set(imt_veto multicore/imt*.C multicore/mt*.C tmva/TMVA_CNN_Classification.C)
 endif()
 if(MSVC)
   #---Multiproc is not supported on Windows


### PR DESCRIPTION
if imt is not specified, this tutorial should not be run as a test.

# This Pull request:
Avoids running the `TMVA_CNN_Classification.C` when ROOT is not built with imt, since it is a requirement and trying to proceed nevertheless causes errors.

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

