### PR TITLE
[tmva] Fix dependency of libTMVA from 

### DIFF
--- a/tmva/tmva/CMakeLists.txt
+++ b/tmva/tmva/CMakeLists.txt
@@ -28,19 +28,6 @@ else()
   set(installoptions ${installoptions} FILTER "Cuda")
 endif()
 
-# Enable parts dependent RDataFrame
-if(dataframe)
-    set(TMVA_EXTRA_HEADERS
-        TMVA/RTensorUtils.hxx
-        TMVA/RBatchGenerator.hxx
-        TMVA/RBatchLoader.hxx
-        TMVA/RChunkLoader.hxx
-    )
-    set(TMVA_EXTRA_SOURCES
-    )
-#    list(APPEND TMVA_EXTRA_DEPENDENCIES ROOTDataFrame ROOTVecOps)
-#    list(APPEND TMVA_EXTRA_DEPENDENCIES )
-endif()
 
 if (imt)
   list(APPEND TMVA_EXTRA_DEPENDENCIES Imt)
@@ -217,16 +204,6 @@ ROOT_STANDARD_LIBRARY_PACKAGE(TMVA
     TMVA/VarTransformHandler.h
     TMVA/Version.h
     TMVA/Volume.h
-    TMVA/RStandardScaler.hxx
-    TMVA/RReader.hxx
-    TMVA/RInferenceUtils.hxx
-    TMVA/RBDT.hxx
-    TMVA/RSofieReader.hxx
-    TMVA/RTensor.hxx
-    TMVA/TreeInference/PythonHelpers.hxx
-    TMVA/TreeInference/BranchlessTree.hxx
-    TMVA/TreeInference/Forest.hxx
-    TMVA/TreeInference/Objectives.hxx
     #  TMVA/DNN/Adadelta.h
     #  TMVA/DNN/Adagrad.h
     #  TMVA/DNN/Adam.h
@@ -490,6 +467,40 @@ if(tmva-gpu)
                    src/DNN/Architectures/Cuda/CudaMatrix.cu
                    src/DNN/Architectures/Cuda/CudaTensor.cu )
    endif()
+endif()
+
+if(dataframe)
+ROOT_STANDARD_LIBRARY_PACKAGE(TMVAUtils
+  NO_INSTALL_HEADERS
+  HEADERS
+  TMVA/RTensorUtils.hxx
+  TMVA/RStandardScaler.hxx
+  TMVA/RReader.hxx
+  TMVA/RInferenceUtils.hxx
+  TMVA/RBDT.hxx
+  TMVA/RSofieReader.hxx
+  TMVA/RBatchGenerator.hxx
+  TMVA/RBatchLoader.hxx
+  TMVA/RChunkLoader.hxx
+  TMVA/TreeInference/PythonHelpers.hxx
+  TMVA/TreeInference/BranchlessTree.hxx
+  TMVA/TreeInference/Forest.hxx
+  TMVA/TreeInference/Objectives.hxx
+
+  SOURCES
+
+  src/RBDT.cxx
+
+  DEPENDENCIES
+    TMVA ROOTDataFrame ROOTVecOps
+    ${TMVA_EXTRA_DEPENDENCIES}
+
+  LINKDEF  LinkDefUtils.h
+  DICTIONARY_OPTIONS
+    -writeEmptyRootPCM
+
+  ${EXTRA_DICT_OPTS}
+)
 endif()
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/tmva/tmva/CMakeLists.txt
+++ b/tmva/tmva/CMakeLists.txt
@@ -31,21 +31,15 @@ endif()
 # Enable parts dependent RDataFrame
 if(dataframe)
     set(TMVA_EXTRA_HEADERS
-        TMVA/RTensor.hxx
         TMVA/RTensorUtils.hxx
-        TMVA/RStandardScaler.hxx
-        TMVA/RReader.hxx
-        TMVA/RInferenceUtils.hxx
-        TMVA/RBDT.hxx
-        TMVA/RSofieReader.hxx
         TMVA/RBatchGenerator.hxx
         TMVA/RBatchLoader.hxx
         TMVA/RChunkLoader.hxx
     )
     set(TMVA_EXTRA_SOURCES
-        RBDT.cxx
     )
-    list(APPEND TMVA_EXTRA_DEPENDENCIES ROOTDataFrame ROOTVecOps)
+#    list(APPEND TMVA_EXTRA_DEPENDENCIES ROOTDataFrame ROOTVecOps)
+#    list(APPEND TMVA_EXTRA_DEPENDENCIES )
 endif()
 
 if (imt)
@@ -223,6 +217,12 @@ ROOT_STANDARD_LIBRARY_PACKAGE(TMVA
     TMVA/VarTransformHandler.h
     TMVA/Version.h
     TMVA/Volume.h
+    TMVA/RStandardScaler.hxx
+    TMVA/RReader.hxx
+    TMVA/RInferenceUtils.hxx
+    TMVA/RBDT.hxx
+    TMVA/RSofieReader.hxx
+    TMVA/RTensor.hxx
     TMVA/TreeInference/PythonHelpers.hxx
     TMVA/TreeInference/BranchlessTree.hxx
     TMVA/TreeInference/Forest.hxx
@@ -357,6 +357,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(TMVA
     src/PDEFoamVect.cxx
     src/PDF.cxx
     src/QuickMVAProbEstimator.cxx
+    src/RBDT.cxx
     src/Ranking.cxx
     src/Reader.cxx
     src/RegressionVariance.cxx

--- a/tmva/tmva/inc/LinkDef1.h
+++ b/tmva/tmva/inc/LinkDef1.h
@@ -71,9 +71,4 @@
 #pragma link C++ class TMVA::MethodCrossValidation+;
 #pragma link C++ class TMVA::MethodDL+;
 
-#ifdef R__HAS_DATAFRAME
-// BDT inference
-#pragma link C++ class TMVA::Experimental::RBDT<TMVA::Experimental::BranchlessForest<float>>;
-#pragma link C++ class TMVA::Experimental::RBDT<TMVA::Experimental::BranchlessJittedForest<float>>;
-#endif
 #endif

--- a/tmva/tmva/inc/LinkDefUtils.h
+++ b/tmva/tmva/inc/LinkDefUtils.h
@@ -1,0 +1,18 @@
+#ifdef __CINT__
+
+#include "RConfigure.h"
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+#pragma link off all namespaces;
+
+#pragma link C++ nestedclass;
+
+#ifdef R__HAS_DATAFRAME
+// BDT inference
+#pragma link C++ class TMVA::Experimental::RBDT<TMVA::Experimental::BranchlessForest<float>>;
+#pragma link C++ class TMVA::Experimental::RBDT<TMVA::Experimental::BranchlessJittedForest<float>>;
+#endif
+
+#endif

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -784,6 +784,12 @@ if(ROOT_pyroot_FOUND)
   if(NOT PY_KERAS_FOUND)
     file(GLOB tmva_veto_py RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} tmva/keras/*.py)
     list(APPEND pyveto ${tmva_veto_py})
+  else()
+    if (ROOT_ARCHITECTURE MATCHES macosx)   #veto also keras tutorial on macos due to issue in disabling eager execution on macos
+       list(APPEND pyveto tmva/keras/RegressionKeras.py)
+       list(APPEND pyveto tmva/keras/ApplicationRegressionKeras.py)
+       list(APPEND pyveto tmva/keras/MultiClassKeras.py)
+    endif()
   endif()
 
   find_python_module(torch QUIET)


### PR DESCRIPTION
This PR removes the dependency of libTMVA from libROOTDataFrame. 

The dependency is needed only for the test programs. 
This should fix the conflict seen when loading PyTorch models on some architectures. See https://github.com/root-project/root/pull/13674#issuecomment-1733208800 

In addition the PR veto some Keras tutorials which time-out on macOS due to need to keep eager execution on MacOS
(see https://github.com/root-project/root/pull/13634/commits/e1d2ed4a937e546d197a1c1c026c17f671a16bcc )