### PR TITLE
[webcanvas] several fixes for axis and palette drawing [skip-ci]

### DIFF
--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -1586,7 +1586,7 @@ TH1F *TPad::DrawFrame(Double_t xmin, Double_t ymin, Double_t xmax, Double_t ymax
 
    if (this != gPad) {
       Warning("DrawFrame", "Must be called for the current pad only");
-      return gPad->DrawFrame(xmin,ymin,xmax,ymax,title);
+      if (gPad) return gPad->DrawFrame(xmin,ymin,xmax,ymax,title);
    }
 
    cd();

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -1445,6 +1445,8 @@ Bool_t TWebCanvas::ProcessData(unsigned connid, const std::string &arg)
    if (indx >= fWebConn.size())
       return kTRUE;
 
+   Bool_t is_main_connection = indx == 1; // first connection allow to make changes
+
    struct FlagGuard {
       Bool_t &flag;
       FlagGuard(Bool_t &_flag) : flag(_flag) { flag = true; }
@@ -1475,7 +1477,7 @@ Bool_t TWebCanvas::ProcessData(unsigned connid, const std::string &arg)
          fWebConn[indx].fDrawVersion = std::stoll(cdata);
       } else {
          fWebConn[indx].fDrawVersion = std::stoll(std::string(cdata, separ - cdata));
-         if ((indx == 0) && !IsReadOnly())
+         if (is_main_connection && !IsReadOnly())
             if (DecodePadOptions(separ+1, false))
                CheckCanvasModified();
       }
@@ -1516,18 +1518,18 @@ Bool_t TWebCanvas::ProcessData(unsigned connid, const std::string &arg)
 
    } else if (arg.compare(0, 9, "OPTIONS6:") == 0) {
 
-      if ((indx == 0) && !IsReadOnly())
+      if (is_main_connection && !IsReadOnly())
          if (DecodePadOptions(arg.substr(9), true))
             CheckCanvasModified();
 
    } else if (arg.compare(0, 11, "STATUSBITS:") == 0) {
 
-      if (indx == 0) {
+      if (is_main_connection) {
          AssignStatusBits(std::stoul(arg.substr(11)));
          if (fUpdatedSignal) fUpdatedSignal(); // invoke signal
       }
    } else if (arg.compare(0, 10, "HIGHLIGHT:") == 0) {
-      if (indx == 0) {
+      if (is_main_connection) {
          auto arr = TBufferJSON::FromJSON<std::vector<std::string>>(arg.substr(10));
          if (!arr || (arr->size() != 4)) {
             Error("ProcessData", "Wrong arguments count %d in highlight message", (int)(arr ? arr->size() : -1));

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -655,11 +655,13 @@ void TWebCanvas::CreatePadSnapshot(TPadWebSnapshot &paddata, TPad *pad, Long64_t
                stats = dynamic_cast<TPaveStats *> (fobj);
          }
 
+         TString gropt = iter.GetOption();
+
          // ensure histogram exists on server to draw it properly on clients side
-         if (!IsReadOnly() && first_obj)
+         if (!IsReadOnly() && (first_obj || gropt.Index("A", 0, TString::kIgnoreCase) != kNPOS ||
+               (gropt.Index("X+", 0, TString::kIgnoreCase) != kNPOS) || (gropt.Index("X+", 0, TString::kIgnoreCase) != kNPOS)))
             gr->GetHistogram();
 
-         TString gropt = iter.GetOption();
          if (title && first_obj) gropt.Append(";;use_pad_title");
          if (stats) gropt.Append(";;use_pad_stats");
 

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -447,7 +447,8 @@ void TWebCanvas::CreatePadSnapshot(TPadWebSnapshot &paddata, TPad *pad, Long64_t
             has_histo = true;
          }
       } else if (obj->InheritsFrom(TFrame::Class())) {
-         frame = static_cast<TFrame *>(obj);
+         if (!frame)
+            frame = static_cast<TFrame *>(obj);
       } else if (obj->InheritsFrom(TH1::Class())) {
          need_frame = true;
          has_histo = true;
@@ -745,6 +746,12 @@ void TWebCanvas::CreatePadSnapshot(TPadWebSnapshot &paddata, TPad *pad, Long64_t
             paddata.NewPrimitive(func, "__ignore_drawing__").SetSnapshot(TWebSnapshot::kObject, func);
 
          paddata.NewPrimitive(obj, iter.GetOption()).SetSnapshot(TWebSnapshot::kObject, obj);
+      } else if (obj->InheritsFrom(TFrame::Class())) {
+         flush_master();
+         if (frame && (obj == frame)) {
+            paddata.NewPrimitive(obj, iter.GetOption()).SetSnapshot(TWebSnapshot::kObject, obj);
+            frame = nullptr; // add frame only once
+         }
       } else if (IsJSSupportedClass(obj, usemaster)) {
          flush_master();
          paddata.NewPrimitive(obj, iter.GetOption()).SetSnapshot(TWebSnapshot::kObject, obj);

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -451,7 +451,7 @@ void TWebCanvas::CreatePadSnapshot(TPadWebSnapshot &paddata, TPad *pad, Long64_t
       } else if (obj->InheritsFrom(TH1::Class())) {
          need_frame = true;
          has_histo = true;
-         if (!obj->TestBit(TH1::kNoTitle) && !opt.Contains("SAME") && (strlen(obj->GetTitle()) > 0))
+         if (!obj->TestBit(TH1::kNoTitle) && !opt.Contains("SAME") && !opt.Contains("AXIS") && !opt.Contains("AXIG") && (strlen(obj->GetTitle()) > 0))
             need_title = obj->GetTitle();
          if (obj->InheritsFrom(TH2::Class()) && (opt.Contains("COLZ") || opt.Contains("LEGO2Z") || opt.Contains("LEGO4Z") || opt.Contains("SURF2Z")))
             need_palette = true;

--- a/js/build/jsroot.js
+++ b/js/build/jsroot.js
@@ -66110,7 +66110,9 @@ class TPadPainter extends ObjectPainter {
       if (!svg_rect)
          svg_rect = this.iscan ? this.getCanvSvg().selectChild('.canvas_fillrect') : this.svg_this_pad().selectChild('.root_pad_border');
 
-      let lineatt = this.is_active_pad ? new TAttLineHandler({ style: 1, width: 1, color: 'red' }) : this.lineatt;
+      const cp = this.getCanvPainter();
+
+      let lineatt = this.is_active_pad && (cp?.highlight_gpad !== false) ? new TAttLineHandler({ style: 1, width: 1, color: 'red' }) : this.lineatt;
 
       if (!lineatt) lineatt = new TAttLineHandler({ color: 'none' });
 

--- a/js/build/jsroot.js
+++ b/js/build/jsroot.js
@@ -11,7 +11,7 @@ const version_id = '7.5.pre',
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-version_date = '26/09/2023',
+version_date = '27/09/2023',
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}
@@ -273,7 +273,9 @@ settings = {
    /** @summary Prefer to use saved points in TF1/TF2, avoids eval() and Function() when possible */
    PreferSavedPoints: false,
    /** @summary Angle in degree for axis labels tilt when available space is not enough */
-   AxisTiltAngle: 25
+   AxisTiltAngle: 25,
+   /** @summary Strip axis labels trailing 0 or replace 10^0 by 1 */
+   StripAxisLabels: true
 },
 
 /** @namespace
@@ -58854,7 +58856,7 @@ class JSRootMenu {
             arg => { faxis.InvertBit(EAxisBits.kLabelsVert); painter.interactiveRedraw('pad', `exec:SetBit(TAxis::kLabelsVert,${arg})`, kind); });
       this.addColorMenu('Color', faxis.fLabelColor,
             arg => { faxis.fLabelColor = arg; painter.interactiveRedraw('pad', getColorExec(arg, 'SetLabelColor'), kind); });
-      this.addSizeMenu('Offset', 0, 0.1, 0.01, faxis.fLabelOffset,
+      this.addSizeMenu('Offset', -0.02, 0.1, 0.01, faxis.fLabelOffset,
             arg => { faxis.fLabelOffset = arg; painter.interactiveRedraw('pad', `exec:SetLabelOffset(${arg})`, kind); });
       let a = faxis.fLabelSize >= 1;
       this.addSizeMenu('Size', a ? 2 : 0.02, a ? 30 : 0.11, a ? 2 : 0.01, faxis.fLabelSize,
@@ -59807,8 +59809,12 @@ const AxisPainterMethods = {
       const base = this.logbase;
       if (base !== 10) vlog = vlog / Math.log10(base);
       if (this.moreloglabels || (Math.abs(vlog - Math.round(vlog)) < 0.001)) {
-         if (!this.noexp && (asticks !== 2))
-            return this.formatExp(base, Math.floor(vlog+0.01), val);
+         if (!this.noexp && (asticks !== 2)) {
+            const pow = Math.floor(vlog+0.01);
+            if ((pow === 0) && settings.StripAxisLabels)
+               return '1';
+            return this.formatExp(base, pow, val);
+         }
          if (Math.abs(base - Math.E) < 0.001)
             return floatToString(val, fmt || gStyle.fStatFormat);
          return (vlog < 0) ? val.toFixed(Math.round(-vlog+0.5)) : val.toFixed(0);
@@ -59825,8 +59831,17 @@ const AxisPainterMethods = {
       if (gStyle.fStripDecimals && (val === Math.round(val)))
          return Math.abs(val) < 1e9 ? val.toFixed(0) : val.toExponential(4);
 
-      if (asticks)
-         return this.ndig > 10 ? val.toExponential(this.ndig-11) : val.toFixed(this.ndig);
+      if (asticks) {
+         if (this.ndig > 10)
+            return val.toExponential(this.ndig - 11);
+         let res = val.toFixed(this.ndig);
+         const p = res.indexOf('.');
+         if ((p > 0) && settings.StripAxisLabels) {
+            while ((res.length >= p) && ((res[res.length-1] === '0') || (res[res.length-1] === '.')))
+               res = res.slice(0, res.length - 1);
+         }
+         return res;
+      }
 
       return floatToString(val, fmt || gStyle.fStatFormat);
    },
@@ -60759,7 +60774,7 @@ class TAxisPainter extends ObjectPainter {
             pp = this.getPadPainter(),
             pad_w = pp?.getPadWidth() || scalingSize || w/0.8, // use factor 0.8 as ratio between frame and pad size
             pad_h = pp?.getPadHeight() || scalingSize || h/0.8;
-      let tickSize = 0, tickScalingSize = 0, titleColor;
+      let tickSize = 0, tickScalingSize = 0, titleColor, offset;
 
       this.scalingSize = scalingSize || Math.max(Math.min(pad_w, pad_h), 10);
 
@@ -60775,6 +60790,9 @@ class TAxisPainter extends ObjectPainter {
          tickScalingSize = scalingSize || (this.vertical ? 1.7*h : 0.6*w);
          tickSize = optionSize ? axis.fTickSize : 0.03;
          titleColor = this.getColor(axis.fTextColor);
+         offset = axis.fLabelOffset;
+         if ((this.vertical && axis.fY1 > axis.fY2 && !this.optionMinus) || (!this.vertical && axis.fX1 > axis.fX2))
+            offset = -offset;
       } else {
          this.optionUnlab = false;
          this.optionMinus = this.vertical ^ this.invert_side;
@@ -60786,7 +60804,10 @@ class TAxisPainter extends ObjectPainter {
          tickScalingSize = scalingSize || (this.vertical ? pad_w : pad_h);
          tickSize = axis.fTickLength;
          titleColor = this.getColor(axis.fTitleColor);
+         offset = axis.fLabelOffset;
       }
+
+      offset += (this.vertical ? 0.002 : 0.005);
 
       if (this.kind === 'labels')
          this.optionText = true;
@@ -60805,7 +60826,7 @@ class TAxisPainter extends ObjectPainter {
 
       const k = this.optionText ? 0.66666 : 1; // set TGaxis.cxx, line 1504
       this.labelSize = Math.round((axis.fLabelSize < 1) ? k * axis.fLabelSize * this.scalingSize : k * axis.fLabelSize);
-      this.labelsOffset = Math.round(Math.abs(axis.fLabelOffset) * this.scalingSize);
+      this.labelsOffset = Math.round(offset * this.scalingSize);
       this.labelsFont = new FontHandler(axis.fLabelFont, this.labelSize, scalingSize);
       if ((this.labelSize <= 0) || (Math.abs(axis.fLabelOffset) > 1.1)) this.optionUnlab = true; // disable labels when size not specified
       this.labelsFont.setColor(this.getColor(axis.fLabelColor));
@@ -61669,9 +61690,14 @@ const TooltipHandler = {
                                 only_resize: true, minwidth: 20, minheight: 20, redraw: () => this.sizeChanged() });
       }
 
-      const main_svg = this.draw_g.selectChild('.main_layer');
+      const top_rect = this.draw_g.selectChild('path'),
+            main_svg = this.draw_g.selectChild('.main_layer');
+
+      top_rect.style('pointer-events', 'visibleFill')  // let process mouse events inside frame
+              .style('cursor', 'default');             // show normal cursor
 
       main_svg.style('pointer-events', 'visibleFill')
+              .style('cursor', 'default')
               .property('handlers_set', 0);
 
       const pp = this.getPadPainter(),
@@ -63473,14 +63499,6 @@ class TFramePainter extends ObjectPainter {
               .attr('height', h)
               .attr('viewBox', `0 0 ${w} ${h}`);
 
-      if (!this.isBatchMode()) {
-         top_rect.style('pointer-events', 'visibleFill')  // let process mouse events inside frame
-                 .style('cursor', 'default');             // show normal cursor
-         main_svg.style('cursor', 'default');             // show normal cursor
-         FrameInteractive.assign(this);
-         this.addBasicInteractivity();
-      }
-
       return this;
    }
 
@@ -63532,7 +63550,7 @@ class TFramePainter extends ObjectPainter {
       if ((kind === 'x') || (kind === 'y') || (kind === 'z') || (kind === 'x2') || (kind === 'y2')) {
          const faxis = obj || this[kind+'axis'],
                handle = this[`${kind}_handle`];
-        if (typeof faxis?.TestBit !== 'function')
+        if (!isFunc(faxis?.TestBit))
            return false;
 
          menu.add(`header: ${kind.toUpperCase()} axis`);
@@ -63934,6 +63952,9 @@ class TFramePainter extends ObjectPainter {
          return false;
 
       FrameInteractive.assign(this);
+      if (!for_second_axes)
+         this.addBasicInteractivity();
+
       return this.addFrameInteractivity(for_second_axes);
    }
 
@@ -66262,10 +66283,8 @@ class TPadPainter extends ObjectPainter {
 
       if (this._fixed_size)
          svg.attr('width', rect.width).attr('height', rect.height);
-      else {
-         svg.style('width', '100%').style('height', '100%')
-            .style('left', 0).style('top', 0).style('right', 0).style('bottom', 0);
-      }
+      else
+         svg.style('width', '100%').style('height', '100%').style('inset', '0px');
 
       svg.style('filter', settings.DarkMode || this.pad?.$dark ? 'invert(100%)' : null);
 
@@ -66596,7 +66615,7 @@ class TPadPainter extends ObjectPainter {
    checkSpecialsInPrimitives(can) {
       const lst = can?.fPrimitives;
       if (!lst) return;
-      for (let i = 0; i < lst.arr.length; ++i) {
+      for (let i = 0; i < lst.arr?.length; ++i) {
          if (this.checkSpecial(lst.arr[i])) {
             lst.arr.splice(i, 1);
             lst.opt.splice(i, 1);
@@ -66713,8 +66732,13 @@ class TPadPainter extends ObjectPainter {
          return;
       }
 
+      const obj = this.pad.fPrimitives.arr[indx];
+
+      if (!obj || ((indx > 0) && (obj._typename === 'TFrame') && this.getFramePainter()))
+         return this.drawPrimitives(indx+1);
+
       // use of Promise should avoid large call-stack depth when many primitives are drawn
-      return this.drawObject(this.getDom(), this.pad.fPrimitives.arr[indx], this.pad.fPrimitives.opt[indx]).then(op => {
+      return this.drawObject(this.getDom(), obj, this.pad.fPrimitives.opt[indx]).then(op => {
          if (isObject(op))
             op._primitive = true; // mark painter as belonging to primitives
 
@@ -67054,7 +67078,7 @@ class TPadPainter extends ObjectPainter {
       if (!obj.fPrimitives) return false;
 
       let isany = false, p = 0;
-      for (let n = 0; n < obj.fPrimitives.arr.length; ++n) {
+      for (let n = 0; n < obj.fPrimitives.arr?.length; ++n) {
          while (p < this.painters.length) {
             const pp = this.painters[p++];
             if (!pp._primitive) continue;
@@ -69714,12 +69738,25 @@ class TPavePainter extends ObjectPainter {
             framep = this.getFramePainter(),
             contour = main.fContour,
             levels = contour?.getLevels(),
-            draw_palette = main._color_palette;
+            draw_palette = main._color_palette,
+            zaxis = main?.getObject()?.fZaxis;
+
       let zmin = 0, zmax = 100, gzmin, gzmax, axis_transform = '';
 
       this._palette_vertical = (palette.fX2NDC - palette.fX1NDC) < (palette.fY2NDC - palette.fY1NDC);
 
       axis.fTickSize = 0.6 * s_width / width; // adjust axis ticks size
+      if (typeof zaxis?.fLabelOffset !== 'undefined') {
+         axis.fTitle = zaxis.fTitle;
+         axis.fTitleSize = zaxis.fTitleSize;
+         axis.fTitleOffset =  zaxis.fTitleOffset;
+         axis.fTitleColor = zaxis.fTitleColor;
+         axis.fLineColor = zaxis.fAxisColor;
+         axis.fTextSize = zaxis.fLabelSize;
+         axis.fTextColor = zaxis.fLabelColor;
+         axis.fTextFont = zaxis.fLabelFont;
+         axis.fLabelOffset = zaxis.fLabelOffset;
+      }
 
       if (contour && framep) {
          if ((framep.zmin !== undefined) && (framep.zmax !== undefined) && (framep.zmin !== framep.zmax)) {
@@ -72273,10 +72310,13 @@ class THistPainter extends ObjectPainter {
 
          const zaxis = this.getHisto().fZaxis;
 
-         Object.assign(pal.fAxis, { fTitle: zaxis.fTitle, fTitleSize: zaxis.fTitleSize, fChopt: '+',
+         Object.assign(pal.fAxis, { fTitle: zaxis.fTitle, fTitleSize: zaxis.fTitleSize,
+                                    fTitleOffset: zaxis.fTitleOffset, fTitleColor: zaxis.fTitleColor,
+                                    fChopt: '+',
                                     fLineColor: zaxis.fAxisColor, fLineSyle: 1, fLineWidth: 1,
                                     fTextAngle: 0, fTextSize: zaxis.fLabelSize, fTextAlign: 11,
-                                    fTextColor: zaxis.fLabelColor, fTextFont: zaxis.fLabelFont });
+                                    fTextColor: zaxis.fLabelColor, fTextFont: zaxis.fLabelFont,
+                                    fLabelOffset: zaxis.fLabelOffset });
 
          // place colz in the beginning, that stat box is always drawn on the top
          this.addFunction(pal, true);
@@ -72284,7 +72324,6 @@ class THistPainter extends ObjectPainter {
          can_move = true;
       } else if (pp?._palette_vertical !== undefined)
          this.options.Zvert = pp._palette_vertical;
-
 
       const fp = this.getFramePainter();
 
@@ -73735,7 +73774,8 @@ let TH2Painter$2 = class TH2Painter extends THistPainter {
             palette = this.getHistPalette(),
             entries = [],
             show_empty = this._show_empty_bins,
-            can_merge = (handle.ybar2 === 1) && (handle.ybar1 === 0);
+            can_merge_x = (handle.xbar2 === 1) && (handle.xbar1 === 0),
+            can_merge_y = (handle.ybar2 === 1) && (handle.ybar1 === 0);
 
       let dx, dy, x1, y2, binz, is_zero, colindx, last_entry = null,
           skip_zero = !this.options.Zero;
@@ -73751,9 +73791,13 @@ let TH2Painter$2 = class TH2Painter extends THistPainter {
 
       // now start build
       for (let i = handle.i1; i < handle.i2; ++i) {
-         dx = handle.grx[i+1] - handle.grx[i];
-         x1 = Math.round(handle.grx[i] + dx*handle.xbar1);
-         dx = Math.round(dx*(handle.xbar2 - handle.xbar1)) || 1;
+         dx = (handle.grx[i+1] - handle.grx[i]) || 1;
+         if (can_merge_x)
+            x1 = handle.grx[i];
+         else {
+            x1 = Math.round(handle.grx[i] + dx*handle.xbar1);
+            dx = Math.round(dx*(handle.xbar2 - handle.xbar1)) || 1;
+         }
 
          for (let j = handle.j2 - 1; j >= handle.j1; --j) {
             binz = histo.getBinContent(i + 1, j + 1);
@@ -73775,10 +73819,10 @@ let TH2Painter$2 = class TH2Painter extends THistPainter {
             }
 
             dy = (handle.gry[j] - handle.gry[j+1]) || 1;
-            if (can_merge)
+            if (can_merge_y)
                y2 = handle.gry[j+1];
-             else {
-               y2 = Math.round(handle.gry[j+1] + dy*handle.ybar2);
+            else {
+               y2 = Math.round(handle.gry[j] - dy*handle.ybar2);
                dy = Math.round(dy*(handle.ybar2 - handle.ybar1)) || 1;
             }
 
@@ -73786,7 +73830,7 @@ let TH2Painter$2 = class TH2Painter extends THistPainter {
             let entry = entries[colindx];
             if (!entry)
                entry = entries[colindx] = { path: cmd1 };
-             else if (can_merge && (entry === last_entry)) {
+             else if (can_merge_y && (entry === last_entry)) {
                entry.y1 = y2 + dy;
                continue;
             } else {
@@ -73801,7 +73845,7 @@ let TH2Painter$2 = class TH2Painter extends THistPainter {
             entry.x1 = x1;
             entry.y2 = y2;
 
-            if (can_merge) {
+            if (can_merge_y) {
                entry.y1 = y2 + dy;
                last_entry = entry;
             } else
@@ -73811,12 +73855,12 @@ let TH2Painter$2 = class TH2Painter extends THistPainter {
       }
 
       entries.forEach((entry, colindx) => {
-        if (entry) {
-           this.draw_g
-               .append('svg:path')
-               .attr('fill', palette.getColor(colindx))
-               .attr('d', entry.path);
-        }
+         if (entry) {
+            this.draw_g
+                .append('svg:path')
+                .attr('fill', palette.getColor(colindx))
+                .attr('d', entry.path);
+         }
       });
 
       return handle;
@@ -106582,7 +106626,7 @@ let TGraphPainter$1 = class TGraphPainter extends ObjectPainter {
          return this;
 
       const func = graph.fFunctions.arr[indx],
-          opt = graph.fFunctions.opt[indx];
+            opt = graph.fFunctions.opt[indx];
 
       //  required for stats filling
       // TODO: use weak reference (via pad list of painters and any kind of string)
@@ -112456,7 +112500,7 @@ class TASImagePainter extends ObjectPainter {
          if (!res?.url)
             return this;
 
-         const img = this.createG(fp)
+         const img = this.createG(!!fp)
              .append('image')
              .attr('href', res.url)
              .attr('width', rect.width)
@@ -114753,16 +114797,7 @@ class RFramePainter extends RObjectPainter {
          pr = this.drawAxes().then(() => this.addInteractivity());
       }
 
-      return pr.then(() => {
-         if (!this.isBatchMode()) {
-            top_rect.style('pointer-events', 'visibleFill');  // let process mouse events inside frame
-
-            FrameInteractive.assign(this);
-            this.addBasicInteractivity();
-         }
-
-         return this;
-      });
+      return pr.then(() => { return this; });
    }
 
    /** @summary Returns frame X position */
@@ -115167,7 +115202,10 @@ class RFramePainter extends RObjectPainter {
    addInteractivity(for_second_axes) {
       if (this.isBatchMode() || (!settings.Zooming && !settings.ContextMenu))
          return true;
+
       FrameInteractive.assign(this);
+      if (!for_second_axes)
+         this.addBasicInteractivity();
       return this.addFrameInteractivity(for_second_axes);
    }
 

--- a/js/build/jsroot.js
+++ b/js/build/jsroot.js
@@ -11,7 +11,7 @@ const version_id = '7.5.pre',
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-version_date = '22/09/2023',
+version_date = '26/09/2023',
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}
@@ -60770,6 +60770,7 @@ class TAxisPainter extends ObjectPainter {
          this.optionPlus = (axis.fChopt.indexOf('+') >= 0) || axis.TestBit(EAxisBits.kTickPlus);
          this.optionNoopt = (axis.fChopt.indexOf('N') >= 0);  // no ticks position optimization
          this.optionInt = (axis.fChopt.indexOf('I') >= 0);  // integer labels
+         this.optionText = (axis.fChopt.indexOf('T') >= 0);  // text scaling?
          this.createAttLine({ attr: axis });
          tickScalingSize = scalingSize || (this.vertical ? 1.7*h : 0.6*w);
          tickSize = optionSize ? axis.fTickSize : 0.03;
@@ -60780,11 +60781,15 @@ class TAxisPainter extends ObjectPainter {
          this.optionPlus = !this.optionMinus;
          this.optionNoopt = false;  // no ticks position optimization
          this.optionInt = false;  // integer labels
+         this.optionText = false;
          this.createAttLine({ color: axis.fAxisColor, width: 1, style: 1 });
          tickScalingSize = scalingSize || (this.vertical ? pad_w : pad_h);
          tickSize = axis.fTickLength;
          titleColor = this.getColor(axis.fTitleColor);
       }
+
+      if (this.kind === 'labels')
+         this.optionText = true;
 
       this.optionNoexp = axis.TestBit(EAxisBits.kNoExponent);
 
@@ -60798,7 +60803,8 @@ class TAxisPainter extends ObjectPainter {
       this.ticksColor = this.lineatt.color;
       this.ticksWidth = this.lineatt.width;
 
-      this.labelSize = Math.round((axis.fLabelSize < 1) ? axis.fLabelSize * this.scalingSize : axis.fLabelSize);
+      const k = this.optionText ? 0.66666 : 1; // set TGaxis.cxx, line 1504
+      this.labelSize = Math.round((axis.fLabelSize < 1) ? k * axis.fLabelSize * this.scalingSize : k * axis.fLabelSize);
       this.labelsOffset = Math.round(Math.abs(axis.fLabelOffset) * this.scalingSize);
       this.labelsFont = new FontHandler(axis.fLabelFont, this.labelSize, scalingSize);
       if ((this.labelSize <= 0) || (Math.abs(axis.fLabelOffset) > 1.1)) this.optionUnlab = true; // disable labels when size not specified
@@ -69108,9 +69114,10 @@ class TPavePainter extends ObjectPainter {
          }
 
          const pad_rect = pp.getPadRect(),
-             brd = pt.fBorderSize,
-             dx = (opt.indexOf('L') >= 0) ? -1 : ((opt.indexOf('R') >= 0) ? 1 : 0),
-             dy = (opt.indexOf('T') >= 0) ? -1 : ((opt.indexOf('B') >= 0) ? 1 : 0);
+               brd = pt.fBorderSize,
+               noborder = opt.indexOf('NB') >= 0,
+               dx = (opt.indexOf('L') >= 0) ? -1 : ((opt.indexOf('R') >= 0) ? 1 : 0),
+               dy = (opt.indexOf('T') >= 0) ? -1 : ((opt.indexOf('B') >= 0) ? 1 : 0);
 
          // container used to recalculate coordinates
          this.createG();
@@ -69130,7 +69137,7 @@ class TPavePainter extends ObjectPainter {
             const h2 = Math.round(height/2), w2 = Math.round(width/2),
                   dpath = `l${w2},${-h2}l${w2},${h2}l${-w2},${h2}z`;
 
-            if ((brd > 1) && (pt.fShadowColor > 0) && (dx || dy) && !this.fillatt.empty()) {
+            if ((brd > 1) && (pt.fShadowColor > 0) && (dx || dy) && !this.fillatt.empty() && !noborder) {
                 this.draw_g.append('svg:path')
                     .attr('d', 'M0,'+(h2+brd) + dpath)
                     .style('fill', this.getColor(pt.fShadowColor))
@@ -69149,7 +69156,7 @@ class TPavePainter extends ObjectPainter {
             return this.drawPaveText(w2, h2, arg, text_g);
          } else {
             // add shadow decoration before main rect
-            if ((brd > 1) && (pt.fShadowColor > 0) && !pt.fNpaves && (dx || dy)) {
+            if ((brd > 1) && (pt.fShadowColor > 0) && !pt.fNpaves && (dx || dy) && !noborder) {
                const scol = this.getColor(pt.fShadowColor);
                let spath = '';
                if (this.fillatt.empty()) {
@@ -69177,11 +69184,12 @@ class TPavePainter extends ObjectPainter {
                }
             }
 
-            if (!this.isBatchMode() || !this.fillatt.empty() || !this.lineatt.empty()) {
+            if (!this.isBatchMode() || !this.fillatt.empty() || (!this.lineatt.empty() && !noborder)) {
                interactive_element = this.draw_g.append('svg:path')
                                                 .attr('d', `M0,0H${width}V${height}H0Z`)
-                                                .call(this.fillatt.func)
-                                                .call(this.lineatt.func);
+                                                .call(this.fillatt.func);
+               if (!noborder)
+                  interactive_element.call(this.lineatt.func);
             }
 
             return isFunc(this.paveDrawFunc) ? this.paveDrawFunc(width, height, arg) : true;
@@ -69388,6 +69396,7 @@ class TPavePainter extends ObjectPainter {
                   // individual positioning
                   const x = entry.fX ? entry.fX*width : margin_x,
                         y = entry.fY ? (1 - entry.fY)*height : texty;
+
                   let color = entry.fTextColor ? this.getColor(entry.fTextColor) : '';
                   if (!color) color = this.textatt.color;
 
@@ -69405,19 +69414,19 @@ class TPavePainter extends ObjectPainter {
                      this.startTextDrawing(this.textatt.font, height/(nlines * 1.2), text_g, max_font_size);
 
                   const arg = { x: 0, y: 0, width, height, align: entry.fTextAlign || this.textatt.align,
-                              draw_g: text_g, latex: entry._typename === clTText ? 0 : 1,
-                              text: entry.fTitle, fast },
-                   halign = Math.floor(arg.align / 10);
+                                draw_g: text_g, latex: (entry._typename === clTText) ? 0 : 1,
+                                text: entry.fTitle, fast },
+                  halign = Math.floor(arg.align / 10);
                   // when horizontal align applied, just shift text, not change width to keep scaling
                   arg.x = (halign === 1) ? margin_x : (halign === 3 ? -margin_x : 0);
 
                   if (nlines > 1) {
                      arg.y = texty;
                      arg.height = stepy;
-                     if (entry.fTextColor) arg.color = this.getColor(entry.fTextColor);
-                     if (entry.fTextSize) arg.font_size = this.textatt.getAltSize(entry.fTextSize, pad_height);
                   }
+                  if (entry.fTextColor) arg.color = this.getColor(entry.fTextColor);
                   if (!arg.color) arg.color = this.textatt.color;
+                  if (entry.fTextSize) arg.font_size = this.textatt.getAltSize(entry.fTextSize, pad_height);
                   this.drawText(arg);
                }
                break;
@@ -70433,7 +70442,7 @@ class THistDrawOptions {
       if (d.check('PERSPECTIVE') || d.check('PERSP')) this.Ortho = false;
       if (d.check('ORTHO')) this.Ortho = true;
 
-      let lx = 0, ly = 0, check3dbox = '', check3d = (hdim === 3);
+      let lx = 0, ly = 0, check3dbox = '';
       if (d.check('LOG2XY')) lx = ly = 2;
       if (d.check('LOGXY')) lx = ly = 1;
       if (d.check('LOG2X')) lx = 2;
@@ -70576,7 +70585,6 @@ class THistDrawOptions {
       if (d.check('CHAR')) this.Char = 1;
       if (d.check('ALLFUNC')) this.AllFunc = true;
       if (d.check('FUNC')) { this.Func = true; this.Hist = false; }
-      if (d.check('AXIS3D')) { this.Axis = 1; this.Lego = 1; check3d = true; }
       if (d.check('AXIS')) this.Axis = 1;
       if (d.check('AXIG')) this.Axis = 2;
 
@@ -70625,8 +70633,8 @@ class THistDrawOptions {
          if (check3dbox.indexOf('BB') >= 0) this.BackBox = false;
       }
 
-      if (check3d && d.check('FB')) this.FrontBox = false;
-      if (check3d && d.check('BB')) this.BackBox = false;
+      if ((hdim === 3) && d.check('FB')) this.FrontBox = false;
+      if ((hdim === 3) && d.check('BB')) this.BackBox = false;
 
       this._pfc = d.check('PFC');
       this._plc = d.check('PLC') || this.AutoColor;
@@ -71441,7 +71449,9 @@ class THistPainter extends ObjectPainter {
       if (this.options.Same)
          return false;
 
-      return fp.drawAxes(false, this.options.Axis < 0, this.options.Axis < 0,
+      const disable_axis_draw = (this.options.Axis < 0) || (this.options.Axis === 2);
+
+      return fp.drawAxes(false, disable_axis_draw, disable_axis_draw,
                          this.options.AxisPos, this.options.Zscale && this.options.Zvert, this.options.Zscale && !this.options.Zvert);
    }
 
@@ -71467,7 +71477,6 @@ class THistPainter extends ObjectPainter {
       return res;
    }
 
-
    /** @summary Toggle histogram title drawing */
    toggleTitle(arg) {
       const histo = this.getHisto();
@@ -71483,7 +71492,7 @@ class THistPainter extends ObjectPainter {
      * @return {Promise} with painter */
    async drawHistTitle() {
       // case when histogram drawn over other histogram (same option)
-      if (!this.isMainPainter() || this.options.Same)
+      if (!this.isMainPainter() || this.options.Same || this.options.Axis > 0)
          return this;
 
       const histo = this.getHisto(), st = gStyle,
@@ -75704,7 +75713,6 @@ let TH2Painter$2 = class TH2Painter extends THistPainter {
             pr = this.drawBinsChord();
           else
             pr = this.drawAxes().then(() => this.draw2DBins());
-
 
          return pr.then(() => this.completePalette(pp));
       }).then(() => this.drawHistTitle())
@@ -105238,7 +105246,7 @@ let TGraphPainter$1 = class TGraphPainter extends ObjectPainter {
       res._plc = d.check('PLC');
       res._pmc = d.check('PMC');
 
-      if (d.check('A')) res.Axis = d.check('I') ? 'A' : 'AXIS'; // I means invisible axis
+      if (d.check('A')) res.Axis = d.check('I') ? 'A' : 'AXIS;'; // I means invisible axis
       if (d.check('X+')) { res.Axis += 'X+'; res.second_x = has_main; }
       if (d.check('Y+')) { res.Axis += 'Y+'; res.second_y = has_main; }
       if (d.check('RX')) res.Axis += 'RX';
@@ -105288,10 +105296,9 @@ let TGraphPainter$1 = class TGraphPainter extends ObjectPainter {
          // either graph drawn directly or
          // graph is first object in list of primitives
          const pad = this.getPadPainter()?.getRootPad(true);
-         if (!pad || (pad?.fPrimitives?.arr[0] === this.getObject())) res.Axis = 'AXIS';
+         if (!pad || (pad?.fPrimitives?.arr[0] === this.getObject())) res.Axis = 'AXIS;';
       } else if (res.Axis.indexOf('A') < 0)
-         res.Axis = 'AXIS,' + res.Axis;
-
+         res.Axis = 'AXIS;' + res.Axis;
 
       res.Axis += hopt;
 
@@ -106582,11 +106589,20 @@ let TGraphPainter$1 = class TGraphPainter extends ObjectPainter {
       return this.getPadPainter().drawObject(this.getDom(), func, opt).then(() => this.drawNextFunction(indx+1));
    }
 
+   /** @summary Return draw option for axis histogram
+     * @private */
+   getHistoOpt() {
+      let hopt = this.options.Axis;
+      if (hopt.indexOf('AXIS;') === 0)
+         hopt = hopt.slice(5);
+      return hopt;
+   }
+
    /** @summary Draw axis histogram
      * @private */
    async drawAxisHisto() {
       const histo = this.createHistogram();
-      return TH1Painter$2.draw(this.getDom(), histo, this.options.Axis);
+      return TH1Painter$2.draw(this.getDom(), histo, this.getHistoOpt());
    }
 
    /** @summary Draw TGraph
@@ -107659,7 +107675,7 @@ class THStackPainter extends ObjectPainter {
              stack.fHistogram = painter.createHistogram(stack);
 
          const mm = painter.getMinMax(painter.options.errors || painter.options.draw_errors),
-               hopt = painter.options.hopt + ';axis;' + mm.hopt;
+               hopt = painter.options.hopt + ';' + mm.hopt;
 
          return painter.hdraw_func(dom, stack.fHistogram, hopt).then(subp => {
             painter.addToPadPrimitives();
@@ -107924,7 +107940,7 @@ class TGraphTimePainter extends ObjectPainter {
 
       painter.selfid = 'grtime_' + internals.id_counter++; // use to identify primitives which should be clean
 
-      return TH1Painter$2.draw(dom, gr.fFrame, 'AXIS').then(() => {
+      return TH1Painter$2.draw(dom, gr.fFrame, '').then(() => {
          painter.addToPadPrimitives();
          return painter.startDrawing();
       });
@@ -109158,6 +109174,12 @@ class TGraph2DPainter extends ObjectPainter {
       }
 
       return Promise.all(promises).then(() => {
+         if (this.options.Zscale && this.ownhisto) {
+            const pal = this.getMainPainter()?.findFunction(clTPaletteAxis),
+                  pal_painter = this.getPadPainter()?.findPainterFor(pal);
+            return pal_painter?.drawPave();
+         }
+      }).then(() => {
          fp.render3D(100);
          return this;
       });
@@ -109174,7 +109196,7 @@ class TGraph2DPainter extends ObjectPainter {
          if (!gr.fHistogram)
             gr.fHistogram = painter.createHistogram();
 
-         promise = TH2Painter.draw(dom, gr.fHistogram, painter.options.Zscale ? 'lego2z;axis' : 'lego2;axis');
+         promise = TH2Painter.draw(dom, gr.fHistogram, painter.options.Zscale ? 'lego2z' : 'lego2');
          painter.ownhisto = true;
       }
 
@@ -110359,7 +110381,7 @@ class TScatterPainter extends TGraphPainter$1 {
     * @private */
    async drawAxisHisto() {
       const histo = this.createHistogram();
-      return TH2Painter$2.draw(this.getDom(), histo, this.options.Axis);
+      return TH2Painter$2.draw(this.getDom(), histo, this.getHistoOpt());
    }
 
   /** @summary Provide palette, create if necessary
@@ -110882,11 +110904,10 @@ let TMultiGraphPainter$2 = class TMultiGraphPainter extends ObjectPainter {
       if (!histo) {
          let xaxis, yaxis;
          if (this._3d) {
-            histo = create$1(clTH2I);
+            histo = createHistogram(clTH2I, graphs.arr.length, 10);
             xaxis = histo.fXaxis;
             xaxis.fXmin = 0;
             xaxis.fXmax = graphs.arr.length;
-            xaxis.fNbins = graphs.arr.length;
             xaxis.fLabels = create$1(clTHashList);
             for (let i = 0; i < graphs.arr.length; i++) {
                const lbl = create$1(clTObjString);
@@ -110897,7 +110918,7 @@ let TMultiGraphPainter$2 = class TMultiGraphPainter extends ObjectPainter {
             xaxis = histo.fYaxis;
             yaxis = histo.fZaxis;
          } else {
-            histo = create$1(clTH1I);
+            histo = createHistogram(clTH1I, 10);
             xaxis = histo.fXaxis;
             yaxis = histo.fYaxis;
          }
@@ -110928,7 +110949,7 @@ let TMultiGraphPainter$2 = class TMultiGraphPainter extends ObjectPainter {
    /** @summary draw speical histogram for axis
      * @return {Promise} when ready */
    async drawAxisHist(histo, hopt) {
-      return TH1Painter$2.draw(this.getDom(), histo, 'AXIS' + hopt);
+      return TH1Painter$2.draw(this.getDom(), histo, hopt);
    }
 
    /** @summary method draws next function from the functions list  */
@@ -110992,12 +111013,13 @@ let TMultiGraphPainter$2 = class TMultiGraphPainter extends ObjectPainter {
       painter._pmc = d.check('PMC');
 
       let hopt = '';
+      if (d.check('FB') && painter._3d) hopt += 'FB'; // will be directly combined with LEGO
       PadDrawOptions.forEach(name => { if (d.check(name)) hopt += ';' + name; });
 
       let promise = Promise.resolve(true);
       if (d.check('A') || !painter.getMainPainter()) {
           const mgraph = painter.getObject(),
-              histo = painter.scanGraphsRange(mgraph.fGraphs, mgraph.fHistogram, painter.getPadPainter()?.getRootPad(true));
+                histo = painter.scanGraphsRange(mgraph.fGraphs, mgraph.fHistogram, painter.getPadPainter()?.getRootPad(true));
 
          promise = painter.drawAxisHist(histo, hopt).then(ap => {
             painter.firstpainter = ap;
@@ -111025,8 +111047,8 @@ class TMultiGraphPainter extends TMultiGraphPainter$2 {
      * @return {Promise} when ready */
    async drawAxisHist(histo, hopt) {
       return this._3d
-              ? TH2Painter.draw(this.getDom(), histo, 'AXIS3D' + hopt)
-              : TH1Painter$2.draw(this.getDom(), histo, 'AXIS' + hopt);
+              ? TH2Painter.draw(this.getDom(), histo, 'LEGO' + hopt)
+              : TH1Painter$2.draw(this.getDom(), histo, hopt);
    }
 
    /** @summary draw multigraph in 3D */
@@ -111618,7 +111640,7 @@ class TSplinePainter extends ObjectPainter {
          if (ymin < 0) ymin *= (1 + gStyle.fHistTopMargin);
       }
 
-      const histo = create$1(clTH1I);
+      const histo = createHistogram(clTH1I, 10);
 
       histo.fName = spline.fName + '_hist';
       histo.fTitle = spline.fTitle;
@@ -111803,7 +111825,7 @@ class TSplinePainter extends ObjectPainter {
          Line: d.check('L'),
          Curve: d.check('C'),
          Mark: d.check('P'),
-         Hopt: 'AXIS',
+         Hopt: '',
          second_x: false,
          second_y: false
       });

--- a/js/changes.md
+++ b/js/changes.md
@@ -1,36 +1,37 @@
 # JSROOT changelog
 
 ## Changes in 7.5
-1. Correctly implement TH2 projections like MERCATOR or PARABOLIC
-2. Use https://github.com/georgealways/lil-gui/ instead of dat.GUI
-3. Let configure material and scene properties in geom control gui
-4. Upgrade three.js r151 -> r155
-5. Let toggle vertical/horizontal flag for color palette via context menu
-6. Provide "Bring to front" menu command for different objects like pave, box, marker, ...
-7. Handle "dark mode" in geom painter - automatically adjust background
+1. Correctly implement `TH2` projections like MERCATOR or PARABOLIC, add MOLLWEIDE
+2. Support "pol", "cyl", "sph" and "psr" coordinates systems for lego and surf plots
+3. Support orthographic camera for lego and surface plots
+4. Implement "tri1", "tri2", "triw" draw options for `TGraph2D` with Delaunay algorithm
+5. Add support of `TProfile3D` and `TPaveClass` classes
+6. Use "col" as default draw option for `TH2`, "box2" for `TH3`
+7. Draw axes grids in front of objects - making it equivalent to original ROOT
 8. Change `TF1` and `TF2` drawing - always convert into histogram, support TWebCanvas, handle log scales
-9. Add "Superimpose" menu command in hierarchy - let select draw option when append item to pad
-10. Support "pol", "cyl", "sph" and "psr" coordinates systems with lego and surf plots
-11. Use "col" as default draw option for TH2, "box2" for TH3
-12. Support "mollweide" projection for TH2
+9. Provide "Bring to front" menu command for different objects like pave, box, marker, ...
+10. Provide "Build legend" context menu command for the pad
+11. Let toggle vertical/horizontal flag for color palette via context menu
+12. Support canvas grayscale, let toggle via context menu
 13. Basic latex support when drawing axes labels and titles in 3D
-14. Support orthographic camera for lego and surface plots
-15. Implement "tri1", "tri2", "triw" draw options for `TGraph2D` with Delaunay algorithm
-16. Draw axes grids in front of objects - making it equivalent to original ROOT
-17. Put `gl` in "devDependencies" of package.json. One can skip it installation with `npm i --production`.
-18. Add support of `TPaveClass`
+14. Handle "dark mode" in geom painter - automatically adjust background
+15. Let configure material and scene properties in geom control gui
+16. Reset pad enlarge state when pressing "Escape" key #265
+17. Scale special fill patterns like 3244 to pad size
+18. Add "Superimpose" menu command in hierarchy - let select draw option when append item to pad
 19. Support `inspectN` draw option, allows automatically expand object content to specified level
 20. Implement `allfunc` draw option for histograms, force drawing disregard of TF1::kNotDraw bit
 21. Use `eslint` for static code checking, add testing of interactive features
-22. Provide `Build legend` context menu command for the pad
-23. Reset pad enlarge state when pressing Escape key #265
-24. Support canvas grayscale, let toggle via context menu
-25. Support `TProfile3D` class
-26. Scale special fill patterns like 3244 to pad size
-27. Fix - correct scaling of axis labels when tilt them by 25 degree, make this angle configurable
-28. Fix - legend multi-columns drawing and labels scaling
-29. Fix - graph "B" bar widths as in native ROOT
-30. Fix - use pad and not frame size for TText/TLatex scaling
+22. Upgrade three.js r151 -> r155
+23. Use https://github.com/georgealways/lil-gui/ instead of dat.GUI in geom painter
+24. Put `gl` in "devDependencies" of package.json. One can skip it installation with `npm i --production`.
+25. Fix - correct scaling of axis labels when tilt them by 25 degree, make this angle configurable
+26. Fix - legend multi-columns drawing and labels scaling
+27. Fix - graph "B" bar widths as in native ROOT
+28. Fix - use pad and not frame size for `TText` / `TLatex` scaling
+29. Fix - properly handle "NB" (no border) draw option for `TPave` classes
+30. Fix - do not draw histogram title with AXIS draw option
+31. Fix - correct scaling of custom axis labels
 
 
 ## Changes in 7.4.3

--- a/js/changes.md
+++ b/js/changes.md
@@ -32,6 +32,8 @@
 29. Fix - properly handle "NB" (no border) draw option for `TPave` classes
 30. Fix - do not draw histogram title with AXIS draw option
 31. Fix - correct scaling of custom axis labels
+32. Fix - shrink axis labels like 0.20 -> 0.2 or 10^0 -> 1
+33. Fix - copy axis attributes from histogram z scale to palette
 
 
 ## Changes in 7.4.3

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -4,7 +4,7 @@ const version_id = '7.5.pre',
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-version_date = '22/09/2023',
+version_date = '26/09/2023',
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -4,7 +4,7 @@ const version_id = '7.5.pre',
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-version_date = '26/09/2023',
+version_date = '27/09/2023',
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}
@@ -267,7 +267,9 @@ settings = {
    /** @summary Prefer to use saved points in TF1/TF2, avoids eval() and Function() when possible */
    PreferSavedPoints: false,
    /** @summary Angle in degree for axis labels tilt when available space is not enough */
-   AxisTiltAngle: 25
+   AxisTiltAngle: 25,
+   /** @summary Strip axis labels trailing 0 or replace 10^0 by 1 */
+   StripAxisLabels: true
 },
 
 /** @namespace

--- a/js/modules/draw/TASImagePainter.mjs
+++ b/js/modules/draw/TASImagePainter.mjs
@@ -278,7 +278,7 @@ class TASImagePainter extends ObjectPainter {
          if (!res?.url)
             return this;
 
-         const img = this.createG(fp)
+         const img = this.createG(!!fp)
              .append('image')
              .attr('href', res.url)
              .attr('width', rect.width)

--- a/js/modules/draw/TSplinePainter.mjs
+++ b/js/modules/draw/TSplinePainter.mjs
@@ -1,4 +1,4 @@
-import { gStyle, create, clTH1I, kNoStats } from '../core.mjs';
+import { gStyle, clTH1I, kNoStats, createHistogram } from '../core.mjs';
 import { DrawOptions, floatToString, buildSvgCurve } from '../base/BasePainter.mjs';
 import { ObjectPainter } from '../base/ObjectPainter.mjs';
 import { TH1Painter } from '../hist/TH1Painter.mjs';
@@ -89,7 +89,7 @@ class TSplinePainter extends ObjectPainter {
          if (ymin < 0) ymin *= (1 + gStyle.fHistTopMargin);
       }
 
-      const histo = create(clTH1I);
+      const histo = createHistogram(clTH1I, 10);
 
       histo.fName = spline.fName + '_hist';
       histo.fTitle = spline.fTitle;
@@ -274,7 +274,7 @@ class TSplinePainter extends ObjectPainter {
          Line: d.check('L'),
          Curve: d.check('C'),
          Mark: d.check('P'),
-         Hopt: 'AXIS',
+         Hopt: '',
          second_x: false,
          second_y: false
       });

--- a/js/modules/gpad/RFramePainter.mjs
+++ b/js/modules/gpad/RFramePainter.mjs
@@ -727,16 +727,7 @@ class RFramePainter extends RObjectPainter {
          pr = this.drawAxes().then(() => this.addInteractivity());
       }
 
-      return pr.then(() => {
-         if (!this.isBatchMode()) {
-            top_rect.style('pointer-events', 'visibleFill');  // let process mouse events inside frame
-
-            FrameInteractive.assign(this);
-            this.addBasicInteractivity();
-         }
-
-         return this;
-      });
+      return pr.then(() => { return this; });
    }
 
    /** @summary Returns frame X position */
@@ -1141,7 +1132,10 @@ class RFramePainter extends RObjectPainter {
    addInteractivity(for_second_axes) {
       if (this.isBatchMode() || (!settings.Zooming && !settings.ContextMenu))
          return true;
+
       FrameInteractive.assign(this);
+      if (!for_second_axes)
+         this.addBasicInteractivity();
       return this.addFrameInteractivity(for_second_axes);
    }
 

--- a/js/modules/gpad/TAxisPainter.mjs
+++ b/js/modules/gpad/TAxisPainter.mjs
@@ -1102,6 +1102,7 @@ class TAxisPainter extends ObjectPainter {
          this.optionPlus = (axis.fChopt.indexOf('+') >= 0) || axis.TestBit(EAxisBits.kTickPlus);
          this.optionNoopt = (axis.fChopt.indexOf('N') >= 0);  // no ticks position optimization
          this.optionInt = (axis.fChopt.indexOf('I') >= 0);  // integer labels
+         this.optionText = (axis.fChopt.indexOf('T') >= 0);  // text scaling?
          this.createAttLine({ attr: axis });
          tickScalingSize = scalingSize || (this.vertical ? 1.7*h : 0.6*w);
          tickSize = optionSize ? axis.fTickSize : 0.03;
@@ -1112,11 +1113,15 @@ class TAxisPainter extends ObjectPainter {
          this.optionPlus = !this.optionMinus;
          this.optionNoopt = false;  // no ticks position optimization
          this.optionInt = false;  // integer labels
+         this.optionText = false;
          this.createAttLine({ color: axis.fAxisColor, width: 1, style: 1 });
          tickScalingSize = scalingSize || (this.vertical ? pad_w : pad_h);
          tickSize = axis.fTickLength;
          titleColor = this.getColor(axis.fTitleColor);
       }
+
+      if (this.kind === 'labels')
+         this.optionText = true;
 
       this.optionNoexp = axis.TestBit(EAxisBits.kNoExponent);
 
@@ -1130,7 +1135,8 @@ class TAxisPainter extends ObjectPainter {
       this.ticksColor = this.lineatt.color;
       this.ticksWidth = this.lineatt.width;
 
-      this.labelSize = Math.round((axis.fLabelSize < 1) ? axis.fLabelSize * this.scalingSize : axis.fLabelSize);
+      const k = this.optionText ? 0.66666 : 1; // set TGaxis.cxx, line 1504
+      this.labelSize = Math.round((axis.fLabelSize < 1) ? k * axis.fLabelSize * this.scalingSize : k * axis.fLabelSize);
       this.labelsOffset = Math.round(Math.abs(axis.fLabelOffset) * this.scalingSize);
       this.labelsFont = new FontHandler(axis.fLabelFont, this.labelSize, scalingSize);
       if ((this.labelSize <= 0) || (Math.abs(axis.fLabelOffset) > 1.1)) this.optionUnlab = true; // disable labels when size not specified

--- a/js/modules/gpad/TFramePainter.mjs
+++ b/js/modules/gpad/TFramePainter.mjs
@@ -689,9 +689,14 @@ const TooltipHandler = {
                                 only_resize: true, minwidth: 20, minheight: 20, redraw: () => this.sizeChanged() });
       }
 
-      const main_svg = this.draw_g.selectChild('.main_layer');
+      const top_rect = this.draw_g.selectChild('path'),
+            main_svg = this.draw_g.selectChild('.main_layer');
+
+      top_rect.style('pointer-events', 'visibleFill')  // let process mouse events inside frame
+              .style('cursor', 'default');             // show normal cursor
 
       main_svg.style('pointer-events', 'visibleFill')
+              .style('cursor', 'default')
               .property('handlers_set', 0);
 
       const pp = this.getPadPainter(),
@@ -2493,14 +2498,6 @@ class TFramePainter extends ObjectPainter {
               .attr('height', h)
               .attr('viewBox', `0 0 ${w} ${h}`);
 
-      if (!this.isBatchMode()) {
-         top_rect.style('pointer-events', 'visibleFill')  // let process mouse events inside frame
-                 .style('cursor', 'default');             // show normal cursor
-         main_svg.style('cursor', 'default');             // show normal cursor
-         FrameInteractive.assign(this);
-         this.addBasicInteractivity();
-      }
-
       return this;
    }
 
@@ -2552,7 +2549,7 @@ class TFramePainter extends ObjectPainter {
       if ((kind === 'x') || (kind === 'y') || (kind === 'z') || (kind === 'x2') || (kind === 'y2')) {
          const faxis = obj || this[kind+'axis'],
                handle = this[`${kind}_handle`];
-        if (typeof faxis?.TestBit !== 'function')
+        if (!isFunc(faxis?.TestBit))
            return false;
 
          menu.add(`header: ${kind.toUpperCase()} axis`);
@@ -2954,6 +2951,9 @@ class TFramePainter extends ObjectPainter {
          return false;
 
       FrameInteractive.assign(this);
+      if (!for_second_axes)
+         this.addBasicInteractivity();
+
       return this.addFrameInteractivity(for_second_axes);
    }
 

--- a/js/modules/gpad/TPadPainter.mjs
+++ b/js/modules/gpad/TPadPainter.mjs
@@ -419,7 +419,9 @@ class TPadPainter extends ObjectPainter {
       if (!svg_rect)
          svg_rect = this.iscan ? this.getCanvSvg().selectChild('.canvas_fillrect') : this.svg_this_pad().selectChild('.root_pad_border');
 
-      let lineatt = this.is_active_pad ? new TAttLineHandler({ style: 1, width: 1, color: 'red' }) : this.lineatt;
+      const cp = this.getCanvPainter();
+
+      let lineatt = this.is_active_pad && (cp?.highlight_gpad !== false) ? new TAttLineHandler({ style: 1, width: 1, color: 'red' }) : this.lineatt;
 
       if (!lineatt) lineatt = new TAttLineHandler({ color: 'none' });
 

--- a/js/modules/gpad/TPadPainter.mjs
+++ b/js/modules/gpad/TPadPainter.mjs
@@ -571,10 +571,8 @@ class TPadPainter extends ObjectPainter {
 
       if (this._fixed_size)
          svg.attr('width', rect.width).attr('height', rect.height);
-      else {
-         svg.style('width', '100%').style('height', '100%')
-            .style('left', 0).style('top', 0).style('right', 0).style('bottom', 0);
-      }
+      else
+         svg.style('width', '100%').style('height', '100%').style('inset', '0px');
 
       svg.style('filter', settings.DarkMode || this.pad?.$dark ? 'invert(100%)' : null);
 
@@ -905,7 +903,7 @@ class TPadPainter extends ObjectPainter {
    checkSpecialsInPrimitives(can) {
       const lst = can?.fPrimitives;
       if (!lst) return;
-      for (let i = 0; i < lst.arr.length; ++i) {
+      for (let i = 0; i < lst.arr?.length; ++i) {
          if (this.checkSpecial(lst.arr[i])) {
             lst.arr.splice(i, 1);
             lst.opt.splice(i, 1);
@@ -1022,8 +1020,13 @@ class TPadPainter extends ObjectPainter {
          return;
       }
 
+      const obj = this.pad.fPrimitives.arr[indx];
+
+      if (!obj || ((indx > 0) && (obj._typename === 'TFrame') && this.getFramePainter()))
+         return this.drawPrimitives(indx+1);
+
       // use of Promise should avoid large call-stack depth when many primitives are drawn
-      return this.drawObject(this.getDom(), this.pad.fPrimitives.arr[indx], this.pad.fPrimitives.opt[indx]).then(op => {
+      return this.drawObject(this.getDom(), obj, this.pad.fPrimitives.opt[indx]).then(op => {
          if (isObject(op))
             op._primitive = true; // mark painter as belonging to primitives
 
@@ -1363,7 +1366,7 @@ class TPadPainter extends ObjectPainter {
       if (!obj.fPrimitives) return false;
 
       let isany = false, p = 0;
-      for (let n = 0; n < obj.fPrimitives.arr.length; ++n) {
+      for (let n = 0; n < obj.fPrimitives.arr?.length; ++n) {
          while (p < this.painters.length) {
             const pp = this.painters[p++];
             if (!pp._primitive) continue;

--- a/js/modules/gui/menu.mjs
+++ b/js/modules/gui/menu.mjs
@@ -601,7 +601,7 @@ class JSRootMenu {
             arg => { faxis.InvertBit(EAxisBits.kLabelsVert); painter.interactiveRedraw('pad', `exec:SetBit(TAxis::kLabelsVert,${arg})`, kind); });
       this.addColorMenu('Color', faxis.fLabelColor,
             arg => { faxis.fLabelColor = arg; painter.interactiveRedraw('pad', getColorExec(arg, 'SetLabelColor'), kind); });
-      this.addSizeMenu('Offset', 0, 0.1, 0.01, faxis.fLabelOffset,
+      this.addSizeMenu('Offset', -0.02, 0.1, 0.01, faxis.fLabelOffset,
             arg => { faxis.fLabelOffset = arg; painter.interactiveRedraw('pad', `exec:SetLabelOffset(${arg})`, kind); });
       let a = faxis.fLabelSize >= 1;
       this.addSizeMenu('Size', a ? 2 : 0.02, a ? 30 : 0.11, a ? 2 : 0.01, faxis.fLabelSize,

--- a/js/modules/hist/TGraph2DPainter.mjs
+++ b/js/modules/hist/TGraph2DPainter.mjs
@@ -1,4 +1,5 @@
-import { settings, createHistogram, setHistogramTitle, kNoZoom, clTH2I, clTGraph2DErrors, clTGraph2DAsymmErrors, kNoStats } from '../core.mjs';
+import { settings, createHistogram, setHistogramTitle, kNoZoom,
+         clTH2I, clTGraph2DErrors, clTGraph2DAsymmErrors, clTPaletteAxis, kNoStats } from '../core.mjs';
 import { Color, DoubleSide, LineBasicMaterial, MeshBasicMaterial, Mesh } from '../three.mjs';
 import { DrawOptions } from '../base/BasePainter.mjs';
 import { ObjectPainter } from '../base/ObjectPainter.mjs';
@@ -1229,6 +1230,12 @@ class TGraph2DPainter extends ObjectPainter {
       }
 
       return Promise.all(promises).then(() => {
+         if (this.options.Zscale && this.ownhisto) {
+            const pal = this.getMainPainter()?.findFunction(clTPaletteAxis),
+                  pal_painter = this.getPadPainter()?.findPainterFor(pal);
+            return pal_painter?.drawPave();
+         }
+      }).then(() => {
          fp.render3D(100);
          return this;
       });
@@ -1245,7 +1252,7 @@ class TGraph2DPainter extends ObjectPainter {
          if (!gr.fHistogram)
             gr.fHistogram = painter.createHistogram();
 
-         promise = TH2Painter.draw(dom, gr.fHistogram, painter.options.Zscale ? 'lego2z;axis' : 'lego2;axis');
+         promise = TH2Painter.draw(dom, gr.fHistogram, painter.options.Zscale ? 'lego2z' : 'lego2');
          painter.ownhisto = true;
       }
 

--- a/js/modules/hist/TGraphTimePainter.mjs
+++ b/js/modules/hist/TGraphTimePainter.mjs
@@ -145,7 +145,7 @@ class TGraphTimePainter extends ObjectPainter {
 
       painter.selfid = 'grtime_' + internals.id_counter++; // use to identify primitives which should be clean
 
-      return TH1Painter.draw(dom, gr.fFrame, 'AXIS').then(() => {
+      return TH1Painter.draw(dom, gr.fFrame, '').then(() => {
          painter.addToPadPrimitives();
          return painter.startDrawing();
       });

--- a/js/modules/hist/THStackPainter.mjs
+++ b/js/modules/hist/THStackPainter.mjs
@@ -421,7 +421,7 @@ class THStackPainter extends ObjectPainter {
              stack.fHistogram = painter.createHistogram(stack);
 
          const mm = painter.getMinMax(painter.options.errors || painter.options.draw_errors),
-               hopt = painter.options.hopt + ';axis;' + mm.hopt;
+               hopt = painter.options.hopt + ';' + mm.hopt;
 
          return painter.hdraw_func(dom, stack.fHistogram, hopt).then(subp => {
             painter.addToPadPrimitives();

--- a/js/modules/hist/TMultiGraphPainter.mjs
+++ b/js/modules/hist/TMultiGraphPainter.mjs
@@ -10,8 +10,8 @@ class TMultiGraphPainter extends TMultiGraphPainter2D {
      * @return {Promise} when ready */
    async drawAxisHist(histo, hopt) {
       return this._3d
-              ? TH2Painter.draw(this.getDom(), histo, 'AXIS3D' + hopt)
-              : TH1Painter.draw(this.getDom(), histo, 'AXIS' + hopt);
+              ? TH2Painter.draw(this.getDom(), histo, 'LEGO' + hopt)
+              : TH1Painter.draw(this.getDom(), histo, hopt);
    }
 
    /** @summary draw multigraph in 3D */

--- a/js/modules/hist/TPavePainter.mjs
+++ b/js/modules/hist/TPavePainter.mjs
@@ -802,12 +802,25 @@ class TPavePainter extends ObjectPainter {
             framep = this.getFramePainter(),
             contour = main.fContour,
             levels = contour?.getLevels(),
-            draw_palette = main._color_palette;
+            draw_palette = main._color_palette,
+            zaxis = main?.getObject()?.fZaxis;
+
       let zmin = 0, zmax = 100, gzmin, gzmax, axis_transform = '';
 
       this._palette_vertical = (palette.fX2NDC - palette.fX1NDC) < (palette.fY2NDC - palette.fY1NDC);
 
       axis.fTickSize = 0.6 * s_width / width; // adjust axis ticks size
+      if (typeof zaxis?.fLabelOffset !== 'undefined') {
+         axis.fTitle = zaxis.fTitle;
+         axis.fTitleSize = zaxis.fTitleSize;
+         axis.fTitleOffset =  zaxis.fTitleOffset;
+         axis.fTitleColor = zaxis.fTitleColor;
+         axis.fLineColor = zaxis.fAxisColor;
+         axis.fTextSize = zaxis.fLabelSize;
+         axis.fTextColor = zaxis.fLabelColor;
+         axis.fTextFont = zaxis.fLabelFont;
+         axis.fLabelOffset = zaxis.fLabelOffset;
+      }
 
       if (contour && framep) {
          if ((framep.zmin !== undefined) && (framep.zmax !== undefined) && (framep.zmin !== framep.zmax)) {

--- a/js/modules/hist2d/TGraphPainter.mjs
+++ b/js/modules/hist2d/TGraphPainter.mjs
@@ -156,7 +156,7 @@ class TGraphPainter extends ObjectPainter {
       res._plc = d.check('PLC');
       res._pmc = d.check('PMC');
 
-      if (d.check('A')) res.Axis = d.check('I') ? 'A' : 'AXIS'; // I means invisible axis
+      if (d.check('A')) res.Axis = d.check('I') ? 'A' : 'AXIS;'; // I means invisible axis
       if (d.check('X+')) { res.Axis += 'X+'; res.second_x = has_main; }
       if (d.check('Y+')) { res.Axis += 'Y+'; res.second_y = has_main; }
       if (d.check('RX')) res.Axis += 'RX';
@@ -206,10 +206,9 @@ class TGraphPainter extends ObjectPainter {
          // either graph drawn directly or
          // graph is first object in list of primitives
          const pad = this.getPadPainter()?.getRootPad(true);
-         if (!pad || (pad?.fPrimitives?.arr[0] === this.getObject())) res.Axis = 'AXIS';
+         if (!pad || (pad?.fPrimitives?.arr[0] === this.getObject())) res.Axis = 'AXIS;';
       } else if (res.Axis.indexOf('A') < 0)
-         res.Axis = 'AXIS,' + res.Axis;
-
+         res.Axis = 'AXIS;' + res.Axis;
 
       res.Axis += hopt;
 
@@ -1500,11 +1499,20 @@ class TGraphPainter extends ObjectPainter {
       return this.getPadPainter().drawObject(this.getDom(), func, opt).then(() => this.drawNextFunction(indx+1));
    }
 
+   /** @summary Return draw option for axis histogram
+     * @private */
+   getHistoOpt() {
+      let hopt = this.options.Axis;
+      if (hopt.indexOf('AXIS;') === 0)
+         hopt = hopt.slice(5);
+      return hopt;
+   }
+
    /** @summary Draw axis histogram
      * @private */
    async drawAxisHisto() {
       const histo = this.createHistogram();
-      return TH1Painter.draw(this.getDom(), histo, this.options.Axis);
+      return TH1Painter.draw(this.getDom(), histo, this.getHistoOpt());
    }
 
    /** @summary Draw TGraph

--- a/js/modules/hist2d/TGraphPainter.mjs
+++ b/js/modules/hist2d/TGraphPainter.mjs
@@ -1490,7 +1490,7 @@ class TGraphPainter extends ObjectPainter {
          return this;
 
       const func = graph.fFunctions.arr[indx],
-          opt = graph.fFunctions.opt[indx];
+            opt = graph.fFunctions.opt[indx];
 
       //  required for stats filling
       // TODO: use weak reference (via pad list of painters and any kind of string)

--- a/js/modules/hist2d/TH2Painter.mjs
+++ b/js/modules/hist2d/TH2Painter.mjs
@@ -3102,7 +3102,6 @@ class TH2Painter extends THistPainter {
           else
             pr = this.drawAxes().then(() => this.draw2DBins())
 
-
          return pr.then(() => this.completePalette(pp));
       }).then(() => this.drawHistTitle())
         .then(() => this.drawNextFunction(0, true))

--- a/js/modules/hist2d/THistPainter.mjs
+++ b/js/modules/hist2d/THistPainter.mjs
@@ -165,7 +165,7 @@ class THistDrawOptions {
       if (d.check('PERSPECTIVE') || d.check('PERSP')) this.Ortho = false;
       if (d.check('ORTHO')) this.Ortho = true;
 
-      let lx = 0, ly = 0, check3dbox = '', check3d = (hdim === 3);
+      let lx = 0, ly = 0, check3dbox = '';
       if (d.check('LOG2XY')) lx = ly = 2;
       if (d.check('LOGXY')) lx = ly = 1;
       if (d.check('LOG2X')) lx = 2;
@@ -308,7 +308,6 @@ class THistDrawOptions {
       if (d.check('CHAR')) this.Char = 1;
       if (d.check('ALLFUNC')) this.AllFunc = true;
       if (d.check('FUNC')) { this.Func = true; this.Hist = false; }
-      if (d.check('AXIS3D')) { this.Axis = 1; this.Lego = 1; check3d = true; }
       if (d.check('AXIS')) this.Axis = 1;
       if (d.check('AXIG')) this.Axis = 2;
 
@@ -357,8 +356,8 @@ class THistDrawOptions {
          if (check3dbox.indexOf('BB') >= 0) this.BackBox = false;
       }
 
-      if (check3d && d.check('FB')) this.FrontBox = false;
-      if (check3d && d.check('BB')) this.BackBox = false;
+      if ((hdim === 3) && d.check('FB')) this.FrontBox = false;
+      if ((hdim === 3) && d.check('BB')) this.BackBox = false;
 
       this._pfc = d.check('PFC');
       this._plc = d.check('PLC') || this.AutoColor;
@@ -1173,7 +1172,9 @@ class THistPainter extends ObjectPainter {
       if (this.options.Same)
          return false;
 
-      return fp.drawAxes(false, this.options.Axis < 0, this.options.Axis < 0,
+      const disable_axis_draw = (this.options.Axis < 0) || (this.options.Axis === 2);
+
+      return fp.drawAxes(false, disable_axis_draw, disable_axis_draw,
                          this.options.AxisPos, this.options.Zscale && this.options.Zvert, this.options.Zscale && !this.options.Zvert);
    }
 
@@ -1199,7 +1200,6 @@ class THistPainter extends ObjectPainter {
       return res;
    }
 
-
    /** @summary Toggle histogram title drawing */
    toggleTitle(arg) {
       const histo = this.getHisto();
@@ -1215,7 +1215,7 @@ class THistPainter extends ObjectPainter {
      * @return {Promise} with painter */
    async drawHistTitle() {
       // case when histogram drawn over other histogram (same option)
-      if (!this.isMainPainter() || this.options.Same)
+      if (!this.isMainPainter() || this.options.Same || this.options.Axis > 0)
          return this;
 
       const histo = this.getHisto(), st = gStyle,

--- a/js/modules/hist2d/THistPainter.mjs
+++ b/js/modules/hist2d/THistPainter.mjs
@@ -1994,10 +1994,13 @@ class THistPainter extends ObjectPainter {
 
          const zaxis = this.getHisto().fZaxis;
 
-         Object.assign(pal.fAxis, { fTitle: zaxis.fTitle, fTitleSize: zaxis.fTitleSize, fChopt: '+',
+         Object.assign(pal.fAxis, { fTitle: zaxis.fTitle, fTitleSize: zaxis.fTitleSize,
+                                    fTitleOffset: zaxis.fTitleOffset, fTitleColor: zaxis.fTitleColor,
+                                    fChopt: '+',
                                     fLineColor: zaxis.fAxisColor, fLineSyle: 1, fLineWidth: 1,
                                     fTextAngle: 0, fTextSize: zaxis.fLabelSize, fTextAlign: 11,
-                                    fTextColor: zaxis.fLabelColor, fTextFont: zaxis.fLabelFont });
+                                    fTextColor: zaxis.fLabelColor, fTextFont: zaxis.fLabelFont,
+                                    fLabelOffset: zaxis.fLabelOffset });
 
          // place colz in the beginning, that stat box is always drawn on the top
          this.addFunction(pal, true);
@@ -2005,7 +2008,6 @@ class THistPainter extends ObjectPainter {
          can_move = true;
       } else if (pp?._palette_vertical !== undefined)
          this.options.Zvert = pp._palette_vertical;
-
 
       const fp = this.getFramePainter();
 

--- a/js/modules/hist2d/TMultiGraphPainter.mjs
+++ b/js/modules/hist2d/TMultiGraphPainter.mjs
@@ -1,4 +1,4 @@
-import { create, isFunc, clTH1I, clTH2I, clTObjString, clTHashList, kNoZoom, kNoStats } from '../core.mjs';
+import { create, createHistogram, isFunc, clTH1I, clTH2I, clTObjString, clTHashList, kNoZoom, kNoStats } from '../core.mjs';
 import { DrawOptions } from '../base/BasePainter.mjs';
 import { ObjectPainter } from '../base/ObjectPainter.mjs';
 import { TH1Painter, PadDrawOptions } from './TH1Painter.mjs';
@@ -162,11 +162,10 @@ class TMultiGraphPainter extends ObjectPainter {
       if (!histo) {
          let xaxis, yaxis;
          if (this._3d) {
-            histo = create(clTH2I);
+            histo = createHistogram(clTH2I, graphs.arr.length, 10);
             xaxis = histo.fXaxis;
             xaxis.fXmin = 0;
             xaxis.fXmax = graphs.arr.length;
-            xaxis.fNbins = graphs.arr.length;
             xaxis.fLabels = create(clTHashList);
             for (let i = 0; i < graphs.arr.length; i++) {
                const lbl = create(clTObjString);
@@ -177,7 +176,7 @@ class TMultiGraphPainter extends ObjectPainter {
             xaxis = histo.fYaxis;
             yaxis = histo.fZaxis;
          } else {
-            histo = create(clTH1I);
+            histo = createHistogram(clTH1I, 10);
             xaxis = histo.fXaxis;
             yaxis = histo.fYaxis;
          }
@@ -208,7 +207,7 @@ class TMultiGraphPainter extends ObjectPainter {
    /** @summary draw speical histogram for axis
      * @return {Promise} when ready */
    async drawAxisHist(histo, hopt) {
-      return TH1Painter.draw(this.getDom(), histo, 'AXIS' + hopt);
+      return TH1Painter.draw(this.getDom(), histo, hopt);
    }
 
    /** @summary method draws next function from the functions list  */
@@ -272,12 +271,13 @@ class TMultiGraphPainter extends ObjectPainter {
       painter._pmc = d.check('PMC');
 
       let hopt = '';
+      if (d.check('FB') && painter._3d) hopt += 'FB'; // will be directly combined with LEGO
       PadDrawOptions.forEach(name => { if (d.check(name)) hopt += ';' + name; });
 
       let promise = Promise.resolve(true);
       if (d.check('A') || !painter.getMainPainter()) {
           const mgraph = painter.getObject(),
-              histo = painter.scanGraphsRange(mgraph.fGraphs, mgraph.fHistogram, painter.getPadPainter()?.getRootPad(true));
+                histo = painter.scanGraphsRange(mgraph.fGraphs, mgraph.fHistogram, painter.getPadPainter()?.getRootPad(true));
 
          promise = painter.drawAxisHist(histo, hopt).then(ap => {
             painter.firstpainter = ap;

--- a/js/modules/hist2d/TScatterPainter.mjs
+++ b/js/modules/hist2d/TScatterPainter.mjs
@@ -24,7 +24,7 @@ class TScatterPainter extends TGraphPainter {
     * @private */
    async drawAxisHisto() {
       const histo = this.createHistogram();
-      return TH2Painter.draw(this.getDom(), histo, this.options.Axis);
+      return TH2Painter.draw(this.getDom(), histo, this.getHistoOpt());
    }
 
   /** @summary Provide palette, create if necessary

--- a/ui5/canv/controller/Canvas.controller.js
+++ b/ui5/canv/controller/Canvas.controller.js
@@ -46,6 +46,7 @@ sap.ui.define([
                                      ToolbarIcon: chk_icon(false),
                                      TooltipIcon: chk_icon(true),
                                      AutoResizeIcon: chk_icon(true),
+                                     HighlightPadIcon: chk_icon(false),
                                      StatusLbl1: '', StatusLbl2: '', StatusLbl3: '', StatusLbl4: '',
                                      Standalone: true, isRoot6: true, canResize: true, FixedSize: false });
          this.getView().setModel(model);
@@ -85,6 +86,7 @@ sap.ui.define([
             if (cp.v7canvas) model.setProperty('/isRoot6', false);
 
             cp.enforceCanvasSize = !cp.embed_canvas && cp.online_canvas;
+            cp.highlight_gpad = false;
 
             model.setProperty('/canResize', !cp.embed_canvas && cp.online_canvas);
 
@@ -696,6 +698,13 @@ sap.ui.define([
                 cp._online_fixed_size = is_fixed;
                 cp.sendResized(true);
              }
+         } else if (item.getText() == 'Highlight gPad') {
+            cp = this.getCanvasPainter();
+            if (cp) {
+               cp.highlight_gpad = !cp.highlight_gpad;
+               this.getView().getModel().setProperty('/HighlightPadIcon', chk_icon(cp.highlight_gpad));
+               cp.redraw();
+            }
          }
       },
 

--- a/ui5/canv/view/Canvas.view.xml
+++ b/ui5/canv/view/Canvas.view.xml
@@ -83,6 +83,7 @@
                   <Menu itemSelected="onOptionsMenuAction">
                      <items>
                         <MenuItem text="Auto resize" icon="{/AutoResizeIcon}" tooltip="Canvas automatically resized with web browser"/>
+                        <MenuItem text="Highlight gPad" icon="{/HighlightPadIcon}" enabled="{/isRoot6}" tooltip="Highlight active pad in the canvas"/>
                      </items>
                   </Menu>
                </menu>


### PR DESCRIPTION
1. Do not draw hist title when "AXIS" option is used; do not create title in TWebCanvas
2. Use factor 0.66666 when draw custom axis labels.
3. Correctly position axis labels - extra offset as in ROOT
4. If there are many frames on the pad - only one with axes drawing will be interactive
5. Copy Z axis attributes to color palette - labels offset, colors and so on 

Fixes #13719 
Fixes #13707