### PR TITLE
[LLVM] Backport commit

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/Sema/SemaExpr.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Sema/SemaExpr.cpp
@@ -18763,7 +18763,7 @@ void Sema::MarkDeclRefReferenced(DeclRefExpr *E, const Expr *Base) {
 
   if (auto *FD = dyn_cast<FunctionDecl>(E->getDecl()))
     if (!isConstantEvaluated() && FD->isConsteval() &&
-        !RebuildingImmediateInvocation)
+        !RebuildingImmediateInvocation && !FD->isDependentContext())
       ExprEvalContexts.back().ReferenceToConsteval.insert(E);
   MarkExprReferenced(*this, E->getLocation(), E->getDecl(), E, OdrUse,
                      RefsMinusAssignments);


### PR DESCRIPTION
This is an adaptation of commit 6627da727b88ef70b74b7d87f274e0a21a9cea45 Fixes https://github.com/root-project/root/issues/13698, a problem with the new C++ headers from the new macOS SDK.

# This Pull request:
Unfortunately the directory structure of our llvm changed, and it was not possible to cherry-pick.

## Changes or fixes:


## Checklist:

- [v] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #13698

