### PR TITLE
[RF][HS3] Fix JSON import of older HistFactory models

### DIFF
--- a/roofit/histfactory/test/testHistFactory.cxx
+++ b/roofit/histfactory/test/testHistFactory.cxx
@@ -38,7 +38,7 @@
 namespace {
 
 // If the JSON files should be written out for debugging purpose.
-const bool writeJsonFiles = true;
+const bool writeJsonFiles = false;
 
 std::vector<double> getValues(RooAbsReal const &real, RooRealVar &obs, bool normalize, bool useBatchMode)
 {

--- a/roofit/histfactory/test/testHistFactory.cxx
+++ b/roofit/histfactory/test/testHistFactory.cxx
@@ -154,7 +154,7 @@ std::string getName(HFTestParam const &param)
 {
    const MakeModelMode mode = std::get<0>(param);
    const bool customBins = std::get<1>(param);
-   auto const& evalBackend = std::get<2>(param);
+   auto const &evalBackend = std::get<2>(param);
 
    std::stringstream ss;
 
@@ -677,15 +677,15 @@ TEST_P(HFFixtureFit, Fit)
       }
 
       using namespace RooFit;
-      std::unique_ptr<RooFitResult> fitResult{
-         simPdf->fitTo(*data, evalBackend, Optimize(constTermOptimization),
-                       GlobalObservables(*mc->GetGlobalObservables()), Save(), PrintLevel(verbose ? 1 : -1))};
+      std::unique_ptr<RooFitResult> fitResult{simPdf->fitTo(*data, evalBackend, Optimize(constTermOptimization),
+                                                            GlobalObservables(*mc->GetGlobalObservables()), Save(),
+                                                            PrintLevel(verbose ? 1 : -1))};
       ASSERT_NE(fitResult, nullptr);
       if (verbose)
          fitResult->Print("v");
       EXPECT_EQ(fitResult->status(), 0);
 
-      auto checkParam = [&](const std::string &param, double target, double absPrecision=1.e-2) {
+      auto checkParam = [&](const std::string &param, double target, double absPrecision = 1.e-2) {
          auto par = dynamic_cast<RooRealVar *>(fitResult->floatParsFinal().find(param.c_str()));
          if (!par) {
             // Parameter was constant in this fit
@@ -720,7 +720,7 @@ TEST_P(HFFixtureFit, Fit)
          checkParam("alpha_SignalShape", -0.9, 5.E-2); // Pull slightly lower than 1 because of constraint term
       } else if (makeModelMode == MakeModelMode::StatSyst) {
          // Model is set up with a -1 sigma pull on the signal shape parameter.
-         checkParam("SigXsecOverSM", 2., 1.1E-1);               // Higher tolerance: Expect a pull due to shape syst.
+         checkParam("SigXsecOverSM", 2., 1.1E-1);       // Higher tolerance: Expect a pull due to shape syst.
          checkParam("gamma_stat_channel1_bin_0", 1.09); // This should be pulled
          checkParam("gamma_stat_channel1_bin_1", 1.);
       } else if (makeModelMode == MakeModelMode::ShapeSyst) {

--- a/roofit/hs3/src/JSONFactories_HistFactory.cxx
+++ b/roofit/hs3/src/JSONFactories_HistFactory.cxx
@@ -668,7 +668,15 @@ bool tryExportHistFactory(RooJSONFactoryWSTool *tool, const std::string &pdfname
       };
 
       for (RooAbsArg *e : elems) {
-         if (auto constVar = dynamic_cast<RooConstVar *>(e)) {
+         if (TString(e->GetName()).Contains("binWidth")) {
+            // The bin width modifiers are handled separately. We can't just
+            // check for the RooBinWidthFunction type here, because prior to
+            // ROOT 6.26, the multiplication with the inverse bin width was
+            // done in a different way (like a normfactor with a RooRealVar,
+            // but it was stored in the dataset).
+            // Fortunately, the name was similar, so we can match the modifier
+            // name.
+         } else if (auto constVar = dynamic_cast<RooConstVar *>(e)) {
             if (constVar->getVal() != 1.) {
                sample.normfactors.emplace_back(*e);
             }
@@ -681,9 +689,7 @@ bool tryExportHistFactory(RooJSONFactoryWSTool *tool, const std::string &pdfname
          } else if (!fip && (fip = dynamic_cast<RooStats::HistFactory::FlexibleInterpVar *>(e))) {
          } else if (!pip && (pip = dynamic_cast<PiecewiseInterpolation *>(e))) {
          } else if (auto real = dynamic_cast<RooAbsReal *>(e)) {
-            if (!dynamic_cast<RooBinWidthFunction *>(real)) {
-               sample.otherElements.push_back(real);
-            }
+            sample.otherElements.push_back(real);
          }
       }
 

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -1754,9 +1754,9 @@ void RooJSONFactoryWSTool::exportAllObjects(JSONNode &n)
       this->exportObject(*p, exportedObjectNames);
    }
 
-   // export attributes of exported objects
-   for (std::string const &name : exportedObjectNames) {
-      exportAttributes(_workspace.arg(name), n);
+   // export attributes of all objects
+   for (RooAbsArg *arg : _workspace.components()) {
+      exportAttributes(arg, n);
    }
 
    // export all datasets


### PR DESCRIPTION
The HistFactory JSON IO had some problems with models that were produced prior to ROOT 6.26, e.g., prior to this PR:
https://github.com/root-project/root/pull/8167

In particular, the problem was that the JSON export assumed that the multiplication with the inverse bin width as always done with the RooBinWidthFunction.

Also, the first commits in this PR makes sure that the `BinnedLikelihood` attribute is correctly preserved by the JSON IO.

More details in the commit descriptions.