### PR TITLE
[v628] Backports to fix warnings about enum comparisons in the nightlies

### DIFF
--- a/geom/geombuilder/src/TGeoBBoxEditor.cxx
+++ b/geom/geombuilder/src/TGeoBBoxEditor.cxx
@@ -67,7 +67,7 @@ TGeoBBoxEditor::TGeoBBoxEditor(const TGWindow *p, Int_t width,
    TGCompositeFrame *compxyz = new TGCompositeFrame(this, 118, 30, kVerticalFrame | kRaisedFrame | kDoubleBorder);
    // Number entry for dx
    TGCompositeFrame *f1 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kFixedWidth | kOwnBackground);
+                                 kFitWidth | kFixedWidth | kOwnBackground);
    f1->AddFrame(new TGLabel(f1, "DX"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fBoxDx = new TGNumberEntry(f1, 0., 5, kBOX_X);
    fBoxDx->SetNumAttr(TGNumberFormat::kNEAPositive);
@@ -79,7 +79,7 @@ TGeoBBoxEditor::TGeoBBoxEditor(const TGWindow *p, Int_t width,
 
    // Number entry for dy
    TGCompositeFrame *f2 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kFixedWidth | kOwnBackground);
+                                 kFitWidth | kFixedWidth | kOwnBackground);
    f2->AddFrame(new TGLabel(f2, "DY"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fBoxDy = new TGNumberEntry(f2, 0., 5, kBOX_Y);
    fBoxDy->SetNumAttr(TGNumberFormat::kNEAPositive);
@@ -91,7 +91,7 @@ TGeoBBoxEditor::TGeoBBoxEditor(const TGWindow *p, Int_t width,
 
    // Number entry for dx
    TGCompositeFrame *f3 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kFixedWidth | kOwnBackground);
+                                 kFitWidth | kFixedWidth | kOwnBackground);
    f3->AddFrame(new TGLabel(f3, "DZ"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fBoxDz = new TGNumberEntry(f3, 0., 5, kBOX_Z);
    fBoxDz->SetNumAttr(TGNumberFormat::kNEAPositive);
@@ -108,7 +108,7 @@ TGeoBBoxEditor::TGeoBBoxEditor(const TGWindow *p, Int_t width,
    compxyz = new TGCompositeFrame(this, 118, 30, kVerticalFrame | kRaisedFrame | kDoubleBorder);
    // Number entry for dx
    f1 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                             kLHintsExpandX | kFixedWidth | kOwnBackground);
+                             kFitWidth | kFixedWidth | kOwnBackground);
    f1->AddFrame(new TGLabel(f1, "OX"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fBoxOx = new TGNumberEntry(f1, 0., 5, kBOX_OX);
    nef = (TGTextEntry*)fBoxOx->GetNumberEntry();
@@ -119,7 +119,7 @@ TGeoBBoxEditor::TGeoBBoxEditor(const TGWindow *p, Int_t width,
 
    // Number entry for dy
    f2 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                             kLHintsExpandX | kFixedWidth | kOwnBackground);
+                             kFitWidth | kFixedWidth | kOwnBackground);
    f2->AddFrame(new TGLabel(f2, "OY"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fBoxOy = new TGNumberEntry(f2, 0., 5, kBOX_OY);
    nef = (TGTextEntry*)fBoxOy->GetNumberEntry();
@@ -130,7 +130,7 @@ TGeoBBoxEditor::TGeoBBoxEditor(const TGWindow *p, Int_t width,
 
    // Number entry for dx
    f3 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                             kLHintsExpandX | kFixedWidth | kOwnBackground);
+                             kFitWidth | kFixedWidth | kOwnBackground);
    f3->AddFrame(new TGLabel(f3, "OZ"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fBoxOz = new TGNumberEntry(f3, 0., 5, kBOX_OZ);
    nef = (TGTextEntry*)fBoxOz->GetNumberEntry();

--- a/geom/geombuilder/src/TGeoManagerEditor.cxx
+++ b/geom/geombuilder/src/TGeoManagerEditor.cxx
@@ -515,7 +515,7 @@ TGeoManagerEditor::TGeoManagerEditor(const TGWindow *p, Int_t width,
 
    // List of media
    f5 = new TGCompositeFrame(container, 155, 10, kVerticalFrame | kFixedWidth);
-   f1 = new TGCompositeFrame(f5, 145, 10, kHorizontalFrame | kLHintsExpandX | kFixedWidth | kOwnBackground);
+   f1 = new TGCompositeFrame(f5, 145, 10, kHorizontalFrame | kFitWidth | kFixedWidth | kOwnBackground);
    f1->AddFrame(label = new TGLabel(f1, "Existing media"), new TGLayoutHints(kLHintsLeft, 1, 1, 0, 0));
    f1->AddFrame(new TGHorizontal3DLine(f1), new TGLayoutHints(kLHintsExpandX, 5, 5, 7, 7));
    gClient->GetColorByName("#ff0000", color);

--- a/geom/geombuilder/src/TGeoMaterialEditor.cxx
+++ b/geom/geombuilder/src/TGeoMaterialEditor.cxx
@@ -91,7 +91,7 @@ TGeoMaterialEditor::TGeoMaterialEditor(const TGWindow *p, Int_t width,
    TGCompositeFrame *compxyz = new TGCompositeFrame(this, 118, 30, kVerticalFrame | kRaisedFrame | kDoubleBorder);
    // Combo box for material state
    f1 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                             kLHintsExpandX | kFixedWidth | kOwnBackground);
+                             kFitWidth | kFixedWidth | kOwnBackground);
    f1->AddFrame(new TGLabel(f1, "State"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fMatState = new TGComboBox(f1, kMATERIAL_STATE);
    fMatState->AddEntry("Undefined", TGeoMaterial::kMatStateUndefined);
@@ -104,7 +104,7 @@ TGeoMaterialEditor::TGeoMaterialEditor(const TGWindow *p, Int_t width,
 
    // Number entry for density
    f1 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                             kLHintsExpandX | kFixedWidth | kOwnBackground);
+                             kFitWidth | kFixedWidth | kOwnBackground);
    f1->AddFrame(new TGLabel(f1, "Density"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fMatDensity = new TGNumberEntry(f1, 0., 5, kMATERIAL_RHO, TGNumberFormat::kNESRealThree);
    fMatDensity->Resize(90, fMaterialName->GetDefaultHeight());
@@ -116,7 +116,7 @@ TGeoMaterialEditor::TGeoMaterialEditor(const TGWindow *p, Int_t width,
 
    // Number entry for temperature
    f1 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                             kLHintsExpandX | kFixedWidth | kOwnBackground);
+                             kFitWidth | kFixedWidth | kOwnBackground);
    f1->AddFrame(new TGLabel(f1, "Temperature"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fMatTemperature = new TGNumberEntry(f1, 0., 5, kMATERIAL_TEMP, TGNumberFormat::kNESRealTwo);
    fMatTemperature->Resize(90, fMaterialName->GetDefaultHeight());
@@ -128,7 +128,7 @@ TGeoMaterialEditor::TGeoMaterialEditor(const TGWindow *p, Int_t width,
 
    // Number entry for pressure
    f1 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                             kLHintsExpandX | kFixedWidth | kOwnBackground);
+                             kFitWidth | kFixedWidth | kOwnBackground);
    f1->AddFrame(new TGLabel(f1, "Pressure"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fMatPressure = new TGNumberEntry(f1, 0., 5, kMATERIAL_PRES, TGNumberFormat::kNESRealThree);
    fMatPressure->Resize(90, fMaterialName->GetDefaultHeight());
@@ -140,7 +140,7 @@ TGeoMaterialEditor::TGeoMaterialEditor(const TGWindow *p, Int_t width,
 
    // Number entry for radiation length
    f1 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                             kLHintsExpandX | kFixedWidth | kOwnBackground);
+                             kFitWidth | kFixedWidth | kOwnBackground);
    f1->AddFrame(new TGLabel(f1, "RadLen"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fMatRadLen = new TGNumberEntry(f1, 0., 5, kMATERIAL_RAD);
    fMatRadLen->Resize(90, fMaterialName->GetDefaultHeight());
@@ -152,7 +152,7 @@ TGeoMaterialEditor::TGeoMaterialEditor(const TGWindow *p, Int_t width,
 
    // Number entry for absorption length
    f1 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                             kLHintsExpandX | kFixedWidth | kOwnBackground);
+                             kFitWidth | kFixedWidth | kOwnBackground);
    f1->AddFrame(new TGLabel(f1, "AbsLen"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fMatAbsLen = new TGNumberEntry(f1, 0., 5, kMATERIAL_ABS);
    fMatAbsLen->Resize(90, fMaterialName->GetDefaultHeight());
@@ -407,7 +407,7 @@ TGeoMixtureEditor::TGeoMixtureEditor(const TGWindow *p, Int_t width,
    compxyz = new TGCompositeFrame(this, 118, 30, kVerticalFrame | kRaisedFrame | kDoubleBorder);
    // Combo box for selecting elements
    f1 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                             kLHintsExpandX | kFixedWidth | kOwnBackground);
+                             kFitWidth | kFixedWidth | kOwnBackground);
    fMixElem = new TGComboBox(f1, kMIX_ELEM);
    TGeoElementTable *table = gGeoManager->GetElementTable();
    if (table) {
@@ -430,7 +430,7 @@ TGeoMixtureEditor::TGeoMixtureEditor(const TGWindow *p, Int_t width,
 
    // Fraction by weight
    f1 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                             kLHintsExpandX | kFixedWidth | kOwnBackground);
+                             kFitWidth | kFixedWidth | kOwnBackground);
    fChkFraction = new TGCheckButton(f1, "% weight");
    fChkFraction->SetDown(kTRUE);
    f1->AddFrame(fChkFraction, new TGLayoutHints(kLHintsLeft , 2, 2, 6, 1));
@@ -446,7 +446,7 @@ TGeoMixtureEditor::TGeoMixtureEditor(const TGWindow *p, Int_t width,
 
    // Fraction by number of atoms
    f1 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                             kLHintsExpandX | kFixedWidth | kOwnBackground);
+                             kFitWidth | kFixedWidth | kOwnBackground);
    fChkNatoms = new TGCheckButton(f1, "N. atoms");
    fChkNatoms->SetDown(kFALSE);
    f1->AddFrame(fChkNatoms, new TGLayoutHints(kLHintsLeft, 2, 2, 6, 1));

--- a/geom/geombuilder/src/TGeoMatrixEditor.cxx
+++ b/geom/geombuilder/src/TGeoMatrixEditor.cxx
@@ -60,7 +60,7 @@ TGeoTranslationEditor::TGeoTranslationEditor(const TGWindow *p, Int_t width,
    TGCompositeFrame *compxyz = new TGCompositeFrame(this, 118, 30, kVerticalFrame | kRaisedFrame | kDoubleBorder);
    // Number entry for dx
    TGCompositeFrame *f1 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kFixedWidth | kOwnBackground);
+                                 kFitWidth | kFixedWidth | kOwnBackground);
    f1->AddFrame(new TGLabel(f1, "DX"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fTransDx = new TGNumberEntry(f1, 0., 5, kMATRIX_DX);
    nef = (TGTextEntry*)fTransDx->GetNumberEntry();
@@ -71,7 +71,7 @@ TGeoTranslationEditor::TGeoTranslationEditor(const TGWindow *p, Int_t width,
 
    // Number entry for dy
    TGCompositeFrame *f2 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kFixedWidth | kOwnBackground);
+                                 kFitWidth | kFixedWidth | kOwnBackground);
    f2->AddFrame(new TGLabel(f2, "DY"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fTransDy = new TGNumberEntry(f2, 0., 5, kMATRIX_DY);
    nef = (TGTextEntry*)fTransDy->GetNumberEntry();
@@ -82,7 +82,7 @@ TGeoTranslationEditor::TGeoTranslationEditor(const TGWindow *p, Int_t width,
 
    // Number entry for dx
    TGCompositeFrame *f3 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kFixedWidth | kOwnBackground);
+                                 kFitWidth | kFixedWidth | kOwnBackground);
    f3->AddFrame(new TGLabel(f3, "DZ"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fTransDz = new TGNumberEntry(f3, 0., 5, kMATRIX_DZ);
    nef = (TGTextEntry*)fTransDz->GetNumberEntry();
@@ -314,7 +314,7 @@ TGeoRotationEditor::TGeoRotationEditor(const TGWindow *p, Int_t width,
    TGCompositeFrame *compxyz = new TGCompositeFrame(this, 140, 30, kVerticalFrame | kRaisedFrame | kDoubleBorder);
    // Number entry for phi angle
    TGCompositeFrame *f1 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kFixedWidth | kOwnBackground);
+                                 kFitWidth | kFixedWidth | kOwnBackground);
    f1->AddFrame(new TGLabel(f1, " PHI "), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fRotPhi = new TGNumberEntry(f1, 0., 5, kMATRIX_PHI);
    nef = (TGTextEntry*)fRotPhi->GetNumberEntry();
@@ -326,7 +326,7 @@ TGeoRotationEditor::TGeoRotationEditor(const TGWindow *p, Int_t width,
 
    // Number entry for theta angle
    TGCompositeFrame *f2 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kFixedWidth | kOwnBackground);
+                                 kFitWidth | kFixedWidth | kOwnBackground);
    f2->AddFrame(new TGLabel(f2, "THETA"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fRotTheta = new TGNumberEntry(f2, 0., 5, kMATRIX_THETA);
    nef = (TGTextEntry*)fRotTheta->GetNumberEntry();
@@ -338,7 +338,7 @@ TGeoRotationEditor::TGeoRotationEditor(const TGWindow *p, Int_t width,
 
    // Number entry for psi angle
    TGCompositeFrame *f3 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kFixedWidth | kOwnBackground);
+                                 kFitWidth | kFixedWidth | kOwnBackground);
    f3->AddFrame(new TGLabel(f3, " PSI "), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fRotPsi = new TGNumberEntry(f3, 0., 5, kMATRIX_PSI);
    nef = (TGTextEntry*)fRotPsi->GetNumberEntry();
@@ -355,7 +355,7 @@ TGeoRotationEditor::TGeoRotationEditor(const TGWindow *p, Int_t width,
    compxyz = new TGCompositeFrame(this, 140, 30, kVerticalFrame | kRaisedFrame | kDoubleBorder);
    // Number entry for rotation angle about one axis
    f1 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kFixedWidth | kOwnBackground);
+                                 kFitWidth | kFixedWidth | kOwnBackground);
    f1->AddFrame(new TGLabel(f1, "ANGLE"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fRotAxis = new TGNumberEntry(f1, 0., 5, kMATRIX_DX);
    nef = (TGTextEntry*)fRotAxis->GetNumberEntry();
@@ -622,7 +622,7 @@ TGeoCombiTransEditor::TGeoCombiTransEditor(const TGWindow *p, Int_t width,
    TGCompositeFrame *compxyz = new TGCompositeFrame(this, 118, 30, kVerticalFrame | kRaisedFrame | kDoubleBorder);
    // Number entry for dx
    TGCompositeFrame *f1 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kFixedWidth | kOwnBackground);
+                                 kFitWidth | kFixedWidth | kOwnBackground);
    f1->AddFrame(new TGLabel(f1, "DX"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fTransDx = new TGNumberEntry(f1, 0., 5, kMATRIX_DX);
    nef = (TGTextEntry*)fTransDx->GetNumberEntry();
@@ -633,7 +633,7 @@ TGeoCombiTransEditor::TGeoCombiTransEditor(const TGWindow *p, Int_t width,
 
    // Number entry for dy
    TGCompositeFrame *f2 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kFixedWidth | kOwnBackground);
+                                 kFitWidth | kFixedWidth | kOwnBackground);
    f2->AddFrame(new TGLabel(f2, "DY"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fTransDy = new TGNumberEntry(f2, 0., 5, kMATRIX_DY);
    nef = (TGTextEntry*)fTransDy->GetNumberEntry();
@@ -644,7 +644,7 @@ TGeoCombiTransEditor::TGeoCombiTransEditor(const TGWindow *p, Int_t width,
 
    // Number entry for dx
    TGCompositeFrame *f3 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kFixedWidth | kOwnBackground);
+                                 kFitWidth | kFixedWidth | kOwnBackground);
    f3->AddFrame(new TGLabel(f3, "DZ"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fTransDz = new TGNumberEntry(f3, 0., 5, kMATRIX_DZ);
    nef = (TGTextEntry*)fTransDz->GetNumberEntry();
@@ -661,7 +661,7 @@ TGeoCombiTransEditor::TGeoCombiTransEditor(const TGWindow *p, Int_t width,
    compxyz = new TGCompositeFrame(this, 140, 30, kVerticalFrame | kRaisedFrame | kDoubleBorder);
    // Number entry for phi angle
    f1 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kFixedWidth | kOwnBackground);
+                                 kFitWidth | kFixedWidth | kOwnBackground);
    f1->AddFrame(new TGLabel(f1, " PHI "), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fRotPhi = new TGNumberEntry(f1, 0., 5, kMATRIX_PHI);
    nef = (TGTextEntry*)fRotPhi->GetNumberEntry();
@@ -673,7 +673,7 @@ TGeoCombiTransEditor::TGeoCombiTransEditor(const TGWindow *p, Int_t width,
 
    // Number entry for theta angle
    f2 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kFixedWidth | kOwnBackground);
+                                 kFitWidth | kFixedWidth | kOwnBackground);
    f2->AddFrame(new TGLabel(f2, "THETA"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fRotTheta = new TGNumberEntry(f2, 0., 5, kMATRIX_THETA);
    nef = (TGTextEntry*)fRotTheta->GetNumberEntry();
@@ -685,7 +685,7 @@ TGeoCombiTransEditor::TGeoCombiTransEditor(const TGWindow *p, Int_t width,
 
    // Number entry for psi angle
    f3 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kFixedWidth | kOwnBackground);
+                                 kFitWidth | kFixedWidth | kOwnBackground);
    f3->AddFrame(new TGLabel(f3, " PSI "), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fRotPsi = new TGNumberEntry(f3, 0., 5, kMATRIX_PSI);
    nef = (TGTextEntry*)fRotPsi->GetNumberEntry();
@@ -702,7 +702,7 @@ TGeoCombiTransEditor::TGeoCombiTransEditor(const TGWindow *p, Int_t width,
    compxyz = new TGCompositeFrame(this, 140, 30, kVerticalFrame | kRaisedFrame | kDoubleBorder);
    // Number entry for rotation angle about one axis
    f1 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kFixedWidth | kOwnBackground);
+                                 kFitWidth | kFixedWidth | kOwnBackground);
    f1->AddFrame(new TGLabel(f1, "ANGLE"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fRotAxis = new TGNumberEntry(f1, 0., 5, kMATRIX_DX);
    nef = (TGTextEntry*)fRotAxis->GetNumberEntry();

--- a/geom/geombuilder/src/TGeoMediumEditor.cxx
+++ b/geom/geombuilder/src/TGeoMediumEditor.cxx
@@ -100,7 +100,7 @@ TGeoMediumEditor::TGeoMediumEditor(const TGWindow *p, Int_t width,
    AddFrame(f1, new TGLayoutHints(kLHintsLeft | kLHintsExpandX, 2, 2, 0, 0));
 
 // Combo box for magnetic field option
-   f1 = new TGCompositeFrame(this, 145, 10, kHorizontalFrame | kLHintsExpandX | kFixedWidth | kOwnBackground);
+   f1 = new TGCompositeFrame(this, 145, 10, kHorizontalFrame | kFitWidth | kFixedWidth | kOwnBackground);
    f1->AddFrame(label = new TGLabel(f1, "Mag. field option"), new TGLayoutHints(kLHintsLeft, 1, 1, 0, 0));
    f1->AddFrame(new TGHorizontal3DLine(f1), new TGLayoutHints(kLHintsExpandX, 5, 5, 7, 7));
    gClient->GetColorByName("#ff0000", color);
@@ -122,7 +122,7 @@ TGeoMediumEditor::TGeoMediumEditor(const TGWindow *p, Int_t width,
 
    // Number entry for fieldm
    f1 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kFixedWidth | kOwnBackground);
+                                 kFitWidth | kFixedWidth | kOwnBackground);
    f1->AddFrame(new TGLabel(f1, "FIELDM"), new TGLayoutHints(kLHintsLeft, 1, 1, 4, 0));
    fMedFieldm = new TGNumberEntry(f1, 0., 5, kMED_FIELDM);
    nef = (TGTextEntry*)fMedFieldm->GetNumberEntry();
@@ -134,7 +134,7 @@ TGeoMediumEditor::TGeoMediumEditor(const TGWindow *p, Int_t width,
 
    // Number entry for tmaxfd
    TGCompositeFrame *f2 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kFixedWidth | kOwnBackground);
+                                 kFitWidth | kFixedWidth | kOwnBackground);
    f2->AddFrame(new TGLabel(f2, "TMAXFD"), new TGLayoutHints(kLHintsLeft, 1, 1, 4, 0));
    fMedTmaxfd = new TGNumberEntry(f2, 0., 5, kMED_TMAX);
    nef = (TGTextEntry*)fMedTmaxfd->GetNumberEntry();
@@ -146,7 +146,7 @@ TGeoMediumEditor::TGeoMediumEditor(const TGWindow *p, Int_t width,
 
    // Number entry for stemax
    TGCompositeFrame *f3 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kFixedWidth | kOwnBackground);
+                                 kFitWidth | kFixedWidth | kOwnBackground);
    f3->AddFrame(new TGLabel(f3, "STEMAX"), new TGLayoutHints(kLHintsLeft, 1, 1, 4, 0));
    fMedStemax = new TGNumberEntry(f3, 0., 5, kMED_STEMAX);
    nef = (TGTextEntry*)fMedStemax->GetNumberEntry();
@@ -158,7 +158,7 @@ TGeoMediumEditor::TGeoMediumEditor(const TGWindow *p, Int_t width,
 
    // Number entry for deemax
    TGCompositeFrame *f4 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kFixedWidth | kOwnBackground);
+                                 kFitWidth | kFixedWidth | kOwnBackground);
    f4->AddFrame(new TGLabel(f4, "DEEMAX"), new TGLayoutHints(kLHintsLeft, 1, 1, 4, 0));
    fMedDeemax = new TGNumberEntry(f4, 0., 5, kMED_DEEMAX);
    nef = (TGTextEntry*)fMedDeemax->GetNumberEntry();
@@ -170,7 +170,7 @@ TGeoMediumEditor::TGeoMediumEditor(const TGWindow *p, Int_t width,
 
    // Number entry for epsil
    TGCompositeFrame *f5 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kFixedWidth | kOwnBackground);
+                                 kFitWidth | kFixedWidth | kOwnBackground);
    f5->AddFrame(new TGLabel(f5, "EPSIL"), new TGLayoutHints(kLHintsLeft, 1, 1, 4, 0));
    fMedEpsil = new TGNumberEntry(f5, 0., 5, kMED_EPSIL);
    nef = (TGTextEntry*)fMedEpsil->GetNumberEntry();
@@ -182,7 +182,7 @@ TGeoMediumEditor::TGeoMediumEditor(const TGWindow *p, Int_t width,
 
    // Number entry for stmin
    TGCompositeFrame *f6 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kFixedWidth | kOwnBackground);
+                                 kFitWidth | kFixedWidth | kOwnBackground);
    f6->AddFrame(new TGLabel(f6, "STMIN"), new TGLayoutHints(kLHintsLeft, 1, 1, 4, 0));
    fMedStmin = new TGNumberEntry(f6, 0., 5, kMED_STMIN);
    nef = (TGTextEntry*)fMedStmin->GetNumberEntry();

--- a/geom/geombuilder/src/TGeoSphereEditor.cxx
+++ b/geom/geombuilder/src/TGeoSphereEditor.cxx
@@ -68,7 +68,7 @@ TGeoSphereEditor::TGeoSphereEditor(const TGWindow *p, Int_t width,
    TGCompositeFrame *compxyz = new TGCompositeFrame(this, 118, 30, kVerticalFrame | kRaisedFrame);
    // Number entry for rmin
    TGCompositeFrame *f1 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kOwnBackground);
+                                 kFitWidth | kOwnBackground);
    f1->AddFrame(new TGLabel(f1, "Rmin"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fERmin = new TGNumberEntry(f1, 0., 5, kSPHERE_RMIN);
    fERmin->SetNumAttr(TGNumberFormat::kNEANonNegative);
@@ -81,7 +81,7 @@ TGeoSphereEditor::TGeoSphereEditor(const TGWindow *p, Int_t width,
 
    // Number entry for Rmax
    f1 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kOwnBackground);
+                                 kFitWidth | kOwnBackground);
    f1->AddFrame(new TGLabel(f1, "Rmax"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fERmax = new TGNumberEntry(f1, 0., 5, kSPHERE_RMAX);
    fERmax->SetNumAttr(TGNumberFormat::kNEANonNegative);

--- a/geom/geombuilder/src/TGeoTabManager.cxx
+++ b/geom/geombuilder/src/TGeoTabManager.cxx
@@ -298,7 +298,7 @@ TGeoTreeDialog::TGeoTreeDialog(TGFrame *caller, const TGWindow *main, UInt_t w, 
    fLT->Associate(this);
    fCanvas->SetContainer(fLT);
    AddFrame(fCanvas, new TGLayoutHints(kLHintsLeft | kLHintsExpandX | kLHintsExpandY, 2,2,2,2));
-   f1 = new TGCompositeFrame(this, 100, 10, kHorizontalFrame | kLHintsExpandX);
+   f1 = new TGCompositeFrame(this, 100, 10, kHorizontalFrame | kFitWidth);
    fObjLabel = new TGLabel(f1, "Selected: -none-");
    Pixel_t color;
    gClient->GetColorByName("#0000ff", color);

--- a/geom/geombuilder/src/TGeoTrd1Editor.cxx
+++ b/geom/geombuilder/src/TGeoTrd1Editor.cxx
@@ -66,7 +66,7 @@ TGeoTrd1Editor::TGeoTrd1Editor(const TGWindow *p, Int_t width,
 
    // Number entry for dx1
    TGCompositeFrame *f1 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kFixedWidth | kOwnBackground);
+                                 kFitWidth | kFixedWidth | kOwnBackground);
    f1->AddFrame(new TGLabel(f1, "DX1"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fEDx1 = new TGNumberEntry(f1, 0., 5, kTRD1_X1);
    fEDx1->SetNumAttr(TGNumberFormat::kNEAPositive);
@@ -78,7 +78,7 @@ TGeoTrd1Editor::TGeoTrd1Editor(const TGWindow *p, Int_t width,
 
    // Number entry for dx2
    f1 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kFixedWidth | kOwnBackground);
+                                 kFitWidth | kFixedWidth | kOwnBackground);
    f1->AddFrame(new TGLabel(f1, "DX2"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fEDx2 = new TGNumberEntry(f1, 0., 5, kTRD1_X2);
    fEDx2->SetNumAttr(TGNumberFormat::kNEAPositive);
@@ -90,7 +90,7 @@ TGeoTrd1Editor::TGeoTrd1Editor(const TGWindow *p, Int_t width,
 
    // Number entry for dy
    TGCompositeFrame *f2 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kFixedWidth | kOwnBackground);
+                                 kFitWidth | kFixedWidth | kOwnBackground);
    f2->AddFrame(new TGLabel(f2, "DY"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fEDy = new TGNumberEntry(f2, 0., 5, kTRD1_Y);
    fEDy->SetNumAttr(TGNumberFormat::kNEAPositive);
@@ -102,7 +102,7 @@ TGeoTrd1Editor::TGeoTrd1Editor(const TGWindow *p, Int_t width,
 
    // Number entry for dz
    TGCompositeFrame *f3 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kFixedWidth | kOwnBackground);
+                                 kFitWidth | kFixedWidth | kOwnBackground);
    f3->AddFrame(new TGLabel(f3, "DZ"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fEDz = new TGNumberEntry(f3, 0., 5, kTRD1_Z);
    fEDz->SetNumAttr(TGNumberFormat::kNEAPositive);

--- a/geom/geombuilder/src/TGeoTrd2Editor.cxx
+++ b/geom/geombuilder/src/TGeoTrd2Editor.cxx
@@ -66,7 +66,7 @@ TGeoTrd2Editor::TGeoTrd2Editor(const TGWindow *p, Int_t width,
 
    // Number entry for dx1
    TGCompositeFrame *f1 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kFixedWidth | kOwnBackground);
+                                 kFitWidth | kFixedWidth | kOwnBackground);
    f1->AddFrame(new TGLabel(f1, "DX1"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fEDx1 = new TGNumberEntry(f1, 0., 5, kTRD2_X1);
    fEDx1->SetNumAttr(TGNumberFormat::kNEAPositive);
@@ -78,7 +78,7 @@ TGeoTrd2Editor::TGeoTrd2Editor(const TGWindow *p, Int_t width,
 
    // Number entry for dx2
    f1 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kFixedWidth | kOwnBackground);
+                                 kFitWidth | kFixedWidth | kOwnBackground);
    f1->AddFrame(new TGLabel(f1, "DX2"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fEDx2 = new TGNumberEntry(f1, 0., 5, kTRD2_X2);
    fEDx2->SetNumAttr(TGNumberFormat::kNEAPositive);
@@ -90,7 +90,7 @@ TGeoTrd2Editor::TGeoTrd2Editor(const TGWindow *p, Int_t width,
 
    // Number entry for dy1
    TGCompositeFrame *f2 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kFixedWidth | kOwnBackground);
+                                 kFitWidth | kFixedWidth | kOwnBackground);
    f2->AddFrame(new TGLabel(f2, "DY1"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fEDy1 = new TGNumberEntry(f2, 0., 5, kTRD2_Y1);
    fEDy1->SetNumAttr(TGNumberFormat::kNEAPositive);
@@ -102,7 +102,7 @@ TGeoTrd2Editor::TGeoTrd2Editor(const TGWindow *p, Int_t width,
 
    // Number entry for dy2
    f2 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kFixedWidth | kOwnBackground);
+                                 kFitWidth | kFixedWidth | kOwnBackground);
    f2->AddFrame(new TGLabel(f2, "DY2"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fEDy2 = new TGNumberEntry(f2, 0., 5, kTRD2_Y2);
    fEDy2->SetNumAttr(TGNumberFormat::kNEAPositive);
@@ -114,7 +114,7 @@ TGeoTrd2Editor::TGeoTrd2Editor(const TGWindow *p, Int_t width,
 
    // Number entry for dz
    TGCompositeFrame *f3 = new TGCompositeFrame(compxyz, 118, 10, kHorizontalFrame |
-                                 kLHintsExpandX | kFixedWidth | kOwnBackground);
+                                 kFitWidth | kFixedWidth | kOwnBackground);
    f3->AddFrame(new TGLabel(f3, "DZ"), new TGLayoutHints(kLHintsLeft, 1, 1, 6, 0));
    fEDz = new TGNumberEntry(f3, 0., 5, kTRD2_Z);
    fEDz->SetNumAttr(TGNumberFormat::kNEAPositive);

--- a/graf3d/eve/src/TEveProjectionAxesEditor.cxx
+++ b/graf3d/eve/src/TEveProjectionAxesEditor.cxx
@@ -89,7 +89,7 @@ TEveProjectionAxesEditor::TEveProjectionAxesEditor(const TGWindow *p, Int_t widt
 
    TGCompositeFrame *title1 = new TGCompositeFrame(fCenterFrame, 180, 10,
                                                    kHorizontalFrame |
-                                                   kLHintsExpandX   |
+                                                   kFitWidth        |
                                                    kFixedWidth      |
                                                    kOwnBackground);
    title1->AddFrame(new TGLabel(title1, "Distortion Center"),

--- a/graf3d/eve/src/TEveTrackEditor.cxx
+++ b/graf3d/eve/src/TEveTrackEditor.cxx
@@ -141,7 +141,7 @@ void TEveTrackListEditor::CreateRefsTab()
 
    TGCompositeFrame *title1 = new TGCompositeFrame(fRefs, 145, 10,
                                                    kHorizontalFrame |
-                                                   kLHintsExpandX   |
+                                                   kFitWidth        |
                                                    kFixedWidth      |
                                                    kOwnBackground);
    title1->AddFrame(new TGLabel(title1, "PathMarks"),

--- a/graf3d/eve/src/TEveTrackPropagatorEditor.cxx
+++ b/graf3d/eve/src/TEveTrackPropagatorEditor.cxx
@@ -167,7 +167,7 @@ void TEveTrackPropagatorSubEditor::CreateRefsContainer(TGVerticalFrame* p)
    // First vertex.
    {
       TGCompositeFrame *vf = new TGCompositeFrame
-         (fRefsCont, 145, 10, kHorizontalFrame | kLHintsExpandX | kFixedWidth | kOwnBackground);
+         (fRefsCont, 145, 10, kHorizontalFrame | kFitWidth | kFixedWidth | kOwnBackground);
       vf->AddFrame(new TGLabel(vf, "FirstVertex"),
                    new TGLayoutHints(kLHintsLeft, 1, 1, 0, 0));
       vf->AddFrame(new TGHorizontal3DLine(vf),
@@ -188,7 +188,7 @@ void TEveTrackPropagatorSubEditor::CreateRefsContainer(TGVerticalFrame* p)
    // Break-points of projected tracks
    {
       TGCompositeFrame *vf = new TGCompositeFrame
-         (fRefsCont, 145, 10, kHorizontalFrame | kLHintsExpandX | kFixedWidth | kOwnBackground);
+         (fRefsCont, 145, 10, kHorizontalFrame | kFitWidth | kFixedWidth | kOwnBackground);
       vf->AddFrame(new TGLabel(vf, "BreakPoints"),
                    new TGLayoutHints(kLHintsLeft, 1, 1, 0, 0));
       vf->AddFrame(new TGHorizontal3DLine(vf),
@@ -440,7 +440,7 @@ TEveTrackPropagatorEditor::TEveTrackPropagatorEditor(const TGWindow *p,
    TGVerticalFrame* refsFrame = CreateEditorTabSubFrame("Refs");
    {
       TGCompositeFrame *cf = new TGCompositeFrame
-         (refsFrame, 145, 10, kHorizontalFrame | kLHintsExpandX | kFixedWidth | kOwnBackground);
+         (refsFrame, 145, 10, kHorizontalFrame | kFitWidth | kFixedWidth | kOwnBackground);
       cf->AddFrame(new TGLabel(cf, "PathMarks"),
                    new TGLayoutHints(kLHintsLeft, 1, 1, 0, 0));
       cf->AddFrame(new TGHorizontal3DLine(cf),

--- a/gui/ged/src/TH1Editor.cxx
+++ b/gui/ged/src/TH1Editor.cxx
@@ -166,7 +166,7 @@ TH1Editor::TH1Editor(const TGWindow *p,  Int_t width,
    // Histogram draw options
    TGCompositeFrame *fHistLbl = new TGCompositeFrame(this, 145, 10,
                                                            kHorizontalFrame |
-                                                           kLHintsExpandX   |
+                                                           kFitWidth        |
                                                            kFixedWidth      |
                                                            kOwnBackground);
    fHistLbl->AddFrame(new TGLabel(fHistLbl,"Histogram"),
@@ -277,7 +277,7 @@ TH1Editor::TH1Editor(const TGWindow *p,  Int_t width,
 
    // Bar Menu => appears when the BAR checkbox is set
    f10 = new TGCompositeFrame(this, 145, 10, kHorizontalFrame |
-                                             kLHintsExpandX   |
+                                             kFitWidth        |
                                              kFixedWidth      |
                                              kOwnBackground);
    f10->AddFrame(new TGLabel(f10,"Bar"),
@@ -343,7 +343,7 @@ void TH1Editor::CreateBinTab()
 
    TGCompositeFrame *title1 = new TGCompositeFrame(fBin, 145, 10,
                                                          kHorizontalFrame |
-                                                         kLHintsExpandX   |
+                                                         kFitWidth        |
                                                          kFixedWidth      |
                                                          kOwnBackground);
    title1->AddFrame(new TGLabel(title1, "Rebin"),
@@ -450,7 +450,7 @@ void TH1Editor::CreateBinTab()
                                                     kVerticalFrame);
    TGCompositeFrame *title2 = new TGCompositeFrame(sldCont, 145, 10,
                                                             kHorizontalFrame |
-                                                            kLHintsExpandX   |
+                                                            kFitWidth        |
                                                             kFixedWidth      |
                                                             kOwnBackground);
    title2->AddFrame(new TGLabel(title2, "Axis Range"),

--- a/gui/ged/src/TH2Editor.cxx
+++ b/gui/ged/src/TH2Editor.cxx
@@ -288,7 +288,7 @@ TH2Editor::TH2Editor(const TGWindow *p, Int_t width,
 
    // Bin bar settings
    f12 = new TGCompositeFrame(this, 145, 10, kHorizontalFrame |
-                                             kLHintsExpandX   |
+                                             kFitWidth        |
                                              kFixedWidth      |
                                              kOwnBackground);
    f12->AddFrame(new TGLabel(f12,"Bar"),
@@ -323,7 +323,7 @@ TH2Editor::TH2Editor(const TGWindow *p, Int_t width,
    // Set the color and pattern of the Frame (only for Cartesian 3D plot).
    f38 = new TGCompositeFrame(this, 80, 20, kVerticalFrame);
    TGCompositeFrame *f39 = new TGCompositeFrame(f38, 145, 10, kHorizontalFrame |
-                                                              kLHintsExpandX   |
+                                                              kFitWidth        |
                                                               kFixedWidth      |
                                                               kOwnBackground);
    f39->AddFrame(new TGLabel(f39,"Frame Fill"),
@@ -361,7 +361,7 @@ void TH2Editor::CreateBinTab()
    fBinXCont = new TGCompositeFrame(fBin, 80, 20, kVerticalFrame);
    TGCompositeFrame *title1 = new TGCompositeFrame(fBinXCont, 145, 10,
                                                               kHorizontalFrame |
-                                                              kLHintsExpandX   |
+                                                              kFitWidth        |
                                                               kFixedWidth      |
                                                               kOwnBackground);
    title1->AddFrame(new TGLabel(title1, "Rebin"),
@@ -430,7 +430,7 @@ void TH2Editor::CreateBinTab()
    fBinXCont1 = new TGCompositeFrame(fBin, 80, 20, kVerticalFrame);
    TGCompositeFrame *title2 = new TGCompositeFrame(fBinXCont1, 145, 10,
                                                                kHorizontalFrame |
-                                                               kLHintsExpandX   |
+                                                               kFitWidth        |
                                                                kFixedWidth      |
                                                                kOwnBackground);
    title2->AddFrame(new TGLabel(title2, "X-Axis"),
@@ -504,7 +504,7 @@ void TH2Editor::CreateBinTab()
    fBinYCont1 = new TGCompositeFrame(fBin, 80, 20, kVerticalFrame);
    TGCompositeFrame *title3 = new TGCompositeFrame(fBinYCont1, 145, 10,
                                                                kHorizontalFrame |
-                                                               kLHintsExpandX   |
+                                                               kFitWidth        |
                                                                kFixedWidth      |
                                                                kOwnBackground);
    title3->AddFrame(new TGLabel(title3, "Y-Axis"),
@@ -576,7 +576,7 @@ void TH2Editor::CreateBinTab()
    // Axis ranges
    TGCompositeFrame *title4 = new TGCompositeFrame(fBin, 145, 10,
                                                          kHorizontalFrame |
-                                                         kLHintsExpandX   |
+                                                         kFitWidth        |
                                                          kFixedWidth      |
                                                          kOwnBackground);
    title4->AddFrame(new TGLabel(title4, "Axis Range"),

--- a/math/mathcore/inc/Math/Types.h
+++ b/math/mathcore/inc/Math/Types.h
@@ -12,6 +12,9 @@
 #pragma GCC diagnostic ignored "-Warray-bounds"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#if (__cplusplus >= 202002L) // only for C++20
+#pragma GCC diagnostic ignored "-Wdeprecated-enum-enum-conversion"
+#endif
 
 #ifdef __clang__
 #pragma clang diagnostic ignored "-Wconditional-uninitialized"


### PR DESCRIPTION
Backport two PRs to fix warnings about enum comparisons in the nightlies:

* https://github.com/root-project/root/pull/13360
* https://github.com/root-project/root/pull/13082

The warnings can be seen here:
https://lcgapp-services.cern.ch/root-jenkins/view/ROOT%20Nightly/job/root-nightly-v6-28-00-patches/LABEL=ROOT-ubuntu2204,SPEC=cxx20,V=6-28/lastBuild/parsed_console/