### PR TITLE
[DF] Fix RDataFrame FromNumpy wrong reading of values from sliced arrays

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_facade.py
@@ -327,8 +327,18 @@ class ROOTFacade(types.ModuleType):
         try:
             # Inject FromNumpy function
             from libROOTPythonizations import MakeNumpyDataFrame
-            ns.FromNumpy = MakeNumpyDataFrame
 
+            # Make a copy of the arrays that have strides to make sure we read the correct values
+            # TODO a cleaner fix 
+            def MakeNumpyDataFrameCopy(np_dict):  
+                import numpy  
+                for key in np_dict.keys():
+                    if (np_dict[key].__array_interface__['strides']) is not None:
+                        np_dict[key] = numpy.copy(np_dict[key])
+                return MakeNumpyDataFrame(np_dict) 
+
+            ns.FromNumpy = MakeNumpyDataFrameCopy
+            
             if sys.version_info >= (3, 8):
                 try:
                     # Inject Experimental.Distributed package into namespace RDF if available

--- a/bindings/pyroot/pythonizations/test/rdataframe_makenumpy.py
+++ b/bindings/pyroot/pythonizations/test/rdataframe_makenumpy.py
@@ -142,7 +142,19 @@ class DataFrameFromNumpy(unittest.TestCase):
         gc.collect()
         ref4 = sys.getrefcount(x)
         self.assertEqual(ref1, ref4)
-
+    
+    def test_sliced_array(self):
+        """
+        Test correct reading of a sliced numpy array (#13690)
+        """
+        table = np.array([[1,2], [3,4]])
+        columns = {'x': table[:,0], 'y': table[:,1]}
+        df = ROOT.RDF.FromNumpy(columns)
+        x_col = df.Take['Long64_t']("x")
+        y_col = df.Take['Long64_t']("y")
+        self.assertEqual(list(x_col.GetValue()), [1,3]) 
+        self.assertEqual(list(y_col.GetValue()), [2,4])
+        
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
# This Pull request:
The RDF FromNumpy was silently reading wrong values if sliced arrays (arrays with strides) were given as an input. This PR fixes the issue by producing copies of the sliced arrays that are then read correctly. 

TODO for the future: a neater solution, without making copies. 

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #13690 

