### PR TITLE
[CMake] Fix warning about xxhash linked more than once when building libCore.

### DIFF
--- a/builtins/lz4/CMakeLists.txt
+++ b/builtins/lz4/CMakeLists.txt
@@ -43,8 +43,10 @@ set(LZ4_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR} CACHE INTERNAL "" FORCE)
 
 add_library(lz4 STATIC ${LZ4_PUBLIC_HEADERS} ${LZ4_PRIVATE_HEADERS} ${LZ4_SOURCES})
 set_target_properties(lz4 PROPERTIES C_VISIBILITY_PRESET hidden POSITION_INDEPENDENT_CODE ON)
-target_include_directories(lz4 INTERFACE $<BUILD_INTERFACE:${LZ4_INCLUDE_DIR}>)
-target_link_libraries(lz4 PRIVATE xxHash::xxHash)
+target_include_directories(lz4
+  PRIVATE ${xxHash_INCLUDE_DIR} ${LZ4_INCLUDE_DIR}
+  INTERFACE $<BUILD_INTERFACE:${LZ4_INCLUDE_DIR}>
+)
 
 add_library(LZ4::LZ4 ALIAS lz4)
 

--- a/builtins/zstd/CMakeLists.txt
+++ b/builtins/zstd/CMakeLists.txt
@@ -88,8 +88,11 @@ set(ZSTD_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR} CACHE INTERNAL "" FORCE)
 add_library(zstd STATIC ${ZSTDHEADERS} ${ZSTD_SOURCES})
 target_compile_definitions(zstd PRIVATE "XXH_NAMESPACE=ZSTD_")
 set_target_properties(zstd PROPERTIES COMPILE_DEFINITIONS "ZSTD_HEAPMODE=0;_CRT_SECURE_NO_WARNINGS" C_VISIBILITY_PRESET hidden)
-target_include_directories(zstd PRIVATE ${ZSTD_INCLUDE_DIR} INTERFACE $<BUILD_INTERFACE:${ZSTD_INCLUDE_DIR}>)
-target_link_libraries(zstd PRIVATE xxHash::xxHash)
+target_include_directories(zstd
+  PRIVATE ${xxHash_INCLUDE_DIR} ${ZSTD_INCLUDE_DIR}
+  INTERFACE $<BUILD_INTERFACE:${ZSTD_INCLUDE_DIR}>
+)
+
 if(NOT MSVC)
   target_compile_options(zstd PRIVATE -fPIC -w -O3)
 endif()


### PR DESCRIPTION
# This Pull request:
This PR is a WIP and has been posted to collect feedback.

It proposes a fix for warnings on MacOS which are prompted when linking the libCore shared library due to two links to libxxHash, which are there only if xxhash and lz4 are builtins.

This seems to be a non trivial CMake problem, which is fixed with some perhaps non-hortodox CMake code.


## Changes or fixes:


## Checklist:

- [v] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

