### PR TITLE
Append to the `xml_veto` list instead of (re-)creating it

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -169,7 +169,7 @@ if(NOT ROOT_xml_FOUND)
 endif()
 
 if(NOT ROOT_unfold_FOUND)
-  set(xml_veto  unfold/*.C)
+  list(APPEND xml_veto unfold/*.C)
 endif()
 
 if(NOT ROOT_mpi_FOUND)


### PR DESCRIPTION
Prevent running xml tests when xml is disabled, suppressing the following test failures:
```
TEST FAILURES:
971:tutorial-xml-DOMParsePerson
972:tutorial-xml-DOMRecursive
973:tutorial-xml-SAXHandler
```
