### PR TITLE
[pyroot] adjust GUI events processing

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_application.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_application.py
@@ -86,6 +86,10 @@ class PyROOTApplication(object):
             self._inputhook_config()
         else:
             # Python in script mode, start a separate thread for the event processing
+
+            # indicate that ProcessEvents called in different thread, let ignore thread id checks in RWebWindow
+            gEnv.SetValue("WebGui.ExternalProcessEvents", "yes")
+
             def _process_root_events(self):
                 while self.keep_polling:
                     gSystem.ProcessEvents()
@@ -99,5 +103,3 @@ class PyROOTApplication(object):
 
         self._set_display_hook()
 
-        # indicate that ProcessEvents called in different thread, let ignore thread id checks in RWebWindow
-        gEnv.SetValue("WebGui.ExternalProcessEvents", "yes")

--- a/bindings/pyroot/pythonizations/python/ROOT/_application.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_application.py
@@ -78,7 +78,7 @@ class PyROOTApplication(object):
         if self._is_ipython and 'IPython' in sys.modules and sys.modules['IPython'].version_info[0] >= 5:
             # ipython and notebooks, register our event processing with their hooks
             self._ipython_config()
-        elif sys.flags.interactive == 1 or not hasattr(__main__, '__file__') or gSystem.InheritsFrom('TMacOSXSystem'):
+        elif sys.flags.interactive == 1 or not hasattr(__main__, '__file__'):
             # Python in interactive mode, use the PyOS_InputHook to call our event processing
             # - sys.flags.interactive checks for the -i flags passed to python
             # - __main__ does not have the attribute __file__ if the Python prompt is started directly

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -443,7 +443,10 @@ void RWebWindow::ProvideQueueEntry(unsigned connid, EQueueEntryKind kind, std::s
       fInputQueue.emplace(connid, kind, std::move(arg));
    }
 
-   InvokeCallbacks();
+   // if special python mode is used, process events called from special thread
+   // there is no other way to get regular calls in main python thread,
+   // therefore invoke widgets callbacks directly - which potentially can be dangerous
+   InvokeCallbacks(fUseProcessEvents);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -704,8 +704,8 @@ Int_t THttpServer::ProcessRequests()
    auto id = TThread::SelfId();
 
    if (fMainThrdId != id) {
-      if (fMainThrdId)
-         Error("ProcessRequests", "Changing main thread to %ld", (long)id);
+      if (gDebug > 0 && fMainThrdId)
+         Warning("ProcessRequests", "Changing main thread to %ld", (long)id);
       fMainThrdId = id;
    }
 


### PR DESCRIPTION
First of all, make handling for Mac and Linux similar.
In non-interactive mode run special thread where `gSystem->ProcessEvents()` are called.
In interactive mode try to use input hook.
 
In webgui in python non-interactive mode allow to use calling thread for callbacks invocation. 
It is the only chance to get processing of http requests from clients.

Probably fixes #13744 