### PR TITLE
[hist] Avoid `try-catch` in TH1

### DIFF
--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -155,7 +155,8 @@ protected:
    static bool CheckBinLabels(const TAxis* a1, const TAxis* a2);
    static bool CheckEqualAxes(const TAxis* a1, const TAxis* a2);
    static bool CheckConsistentSubAxes(const TAxis *a1, Int_t firstBin1, Int_t lastBin1, const TAxis *a2, Int_t firstBin2=0, Int_t lastBin2=0);
-   static bool CheckConsistency(const TH1* h1, const TH1* h2);
+   static int CheckConsistency(const TH1* h1, const TH1* h2);
+   int LoggedInconsistency(const char* name, const TH1* h1, const TH1* h2, bool useMerge=false) const;
 
 public:
    /// TH1 status bits


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
Made the static function `TH1::CheckConsistency` public and changed the return type to `Bool_t`.
The exceptions types it throws were also made public, so that user code could catch them

## Checklist:

- [X] tested changes locally

## Motivation
At the moment `TH1::CheckConsistency` is called internally by `TH1::Add`, and prints error messages in case of failure, but continues the execution.
Making it public allows user code to manually check the consistency to catch errors and stop the program.
This is especially useful for programs that make hundreds of `Add`s, out of which only a few fail, and the error messages may be lost in logs and go unnoticed.