### PR TITLE
[CMake] Use `find_package(XRootD)` and not `XROOTD` (case sensitivity)

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -988,7 +988,7 @@ endforeach()
 
 if(xrootd AND NOT builtin_xrootd)
   message(STATUS "Looking for XROOTD")
-  find_package(XROOTD)
+  find_package(XRootD) # Case sensitivity is important here to match the XRootDConfig.cmake file
   if(NOT XROOTD_FOUND)
     if(fail-on-missing)
       message(FATAL_ERROR "XROOTD not found. Set environment variable XRDSYS to point to your XROOTD installation, "


### PR DESCRIPTION
With this change, the reproducer provided in #12631 works for me, while it indeed fails to find `xrootd` in the configuration step without this commit.

See:
https://github.com/xrootd/xrootd/blob/master/cmake/XRootDConfig.cmake.in

Closes #12631.