### PR TITLE
[geom] Don't use `-fabi-version=6` when compiling geom/vecgeom with GCC 

### DIFF
--- a/geom/vecgeom/CMakeLists.txt
+++ b/geom/vecgeom/CMakeLists.txt
@@ -12,10 +12,6 @@
 include_directories(AFTER SYSTEM ${VECGEOM_INCLUDE_DIRS})
 if ( Vc_FOUND )
    include_directories( AFTER SYSTEM ${Vc_INCLUDE_DIRS})
-   if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"
-       AND NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fabi-version=6")
-   endif()
 endif()
 
 ROOT_STANDARD_LIBRARY_PACKAGE(ConverterVG


### PR DESCRIPTION
The `-fabi-version=6` flag was added to the compilation of
`geom/vecgeom` in https://github.com/guitargeek/root/commit/ded69d0daad299f528fb172a0e922215ac18615b without any explanation.

But recently, it caused some compilation problems with `std::unique-ptr`
in newer GCC versions.

Simple reproducer:
```c++
  #include <memory>

 int main() { std::unique_ptr<int>(nullptr); }
```
Compile with `g++ -fabi-version=6 -o test test.cpp`, using GCC 13.2.

So the implementation of `std::unique_ptr` in the standard library
version that comes with gcc 13.2.1 is incompatible with that (super old)
gcc abi version.

Since it's not clear why this flag is there to begin with, I suggest to
remove it so it doesn't cause further problems.

The ABI version 6 is very old anyway (it came with GCC 4.7 in 2012).

Closes https://github.com/root-project/root/pull/12315.
