### PR TITLE
🚨  Revert "[pyroot] make Mac and Linux events handling similar"

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_application.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_application.py
@@ -78,7 +78,7 @@ class PyROOTApplication(object):
         if self._is_ipython and 'IPython' in sys.modules and sys.modules['IPython'].version_info[0] >= 5:
             # ipython and notebooks, register our event processing with their hooks
             self._ipython_config()
-        elif sys.flags.interactive == 1 or not hasattr(__main__, '__file__'):
+        elif sys.flags.interactive == 1 or not hasattr(__main__, '__file__') or gSystem.InheritsFrom('TMacOSXSystem'):
             # Python in interactive mode, use the PyOS_InputHook to call our event processing
             # - sys.flags.interactive checks for the -i flags passed to python
             # - __main__ does not have the attribute __file__ if the Python prompt is started directly


### PR DESCRIPTION
This revert is in place because python scripts now hang whenever the ROOT module is imported on macos 12, 13 and 14.

This reverts commit 06b86c3a3408fec00eaa615790a9298bb9b7eb41.

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

