### PR TITLE
[cmake] Only add a move_header_XYZ target if there are headers:

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -1233,9 +1233,6 @@ function(ROOT_INSTALL_HEADERS)
     set (options ${options} REGEX "${f}" EXCLUDE)
   endforeach()
   set (filter "(${filter})")
-  string(REPLACE ${CMAKE_SOURCE_DIR} "" tgt ${CMAKE_CURRENT_SOURCE_DIR})
-  string(MAKE_C_IDENTIFIER move_header${tgt} tgt)
-  set_property(GLOBAL APPEND PROPERTY ROOT_HEADER_TARGETS ${tgt})
   foreach(d ${dirs})
     install(DIRECTORY ${d} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
                            COMPONENT headers
@@ -1257,7 +1254,12 @@ function(ROOT_INSTALL_HEADERS)
       list(APPEND dst_list ${dst})
     endforeach()
   endforeach()
-  add_custom_target(${tgt} DEPENDS ${dst_list})
+  if (dst_list)
+    string(REPLACE ${CMAKE_SOURCE_DIR} "" tgt ${CMAKE_CURRENT_SOURCE_DIR})
+    string(MAKE_C_IDENTIFIER move_header${tgt} tgt)
+    set_property(GLOBAL APPEND PROPERTY ROOT_HEADER_TARGETS ${tgt})
+    add_custom_target(${tgt} DEPENDS ${dst_list})
+  endif()
 endfunction()
 
 #---------------------------------------------------------------------------------------------------


### PR DESCRIPTION
ninja rightfully said:
```
ninja explain: output core/newdelete/move_header_core_newdelete of phony edge with no inputs doesn't exist
ninja explain: core/newdelete/move_header_core_newdelete is dirty
ninja explain: move_headers is dirty
```

which likely triggered MSBUILD to re-run the move-headers target (during roottest). This might fix it, and in general gets rid of useless "rebuilds" of move_headers.

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

