### PR TITLE
[Backport][CMake] Remove N-1 identical link statements

### DIFF
--- a/builtins/lz4/CMakeLists.txt
+++ b/builtins/lz4/CMakeLists.txt
@@ -43,8 +43,10 @@ set(LZ4_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR} CACHE INTERNAL "" FORCE)
 
 add_library(lz4 STATIC ${LZ4_PUBLIC_HEADERS} ${LZ4_PRIVATE_HEADERS} ${LZ4_SOURCES})
 set_target_properties(lz4 PROPERTIES C_VISIBILITY_PRESET hidden POSITION_INDEPENDENT_CODE ON)
-target_include_directories(lz4 INTERFACE $<BUILD_INTERFACE:${LZ4_INCLUDE_DIR}>)
-target_link_libraries(lz4 PRIVATE xxHash::xxHash)
+target_include_directories(lz4
+  PRIVATE ${xxHash_INCLUDE_DIR} ${LZ4_INCLUDE_DIR}
+  INTERFACE $<BUILD_INTERFACE:${LZ4_INCLUDE_DIR}>
+)
 
 add_library(LZ4::LZ4 ALIAS lz4)
 

--- a/builtins/zstd/CMakeLists.txt
+++ b/builtins/zstd/CMakeLists.txt
@@ -88,8 +88,11 @@ set(ZSTD_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR} CACHE INTERNAL "" FORCE)
 add_library(zstd STATIC ${ZSTDHEADERS} ${ZSTD_SOURCES})
 target_compile_definitions(zstd PRIVATE "XXH_NAMESPACE=ZSTD_")
 set_target_properties(zstd PROPERTIES COMPILE_DEFINITIONS "ZSTD_HEAPMODE=0;_CRT_SECURE_NO_WARNINGS" C_VISIBILITY_PRESET hidden)
-target_include_directories(zstd PRIVATE ${ZSTD_INCLUDE_DIR} INTERFACE $<BUILD_INTERFACE:${ZSTD_INCLUDE_DIR}>)
-target_link_libraries(zstd PRIVATE xxHash::xxHash)
+target_include_directories(zstd
+  PRIVATE ${xxHash_INCLUDE_DIR} ${ZSTD_INCLUDE_DIR}
+  INTERFACE $<BUILD_INTERFACE:${ZSTD_INCLUDE_DIR}>
+)
+
 if(NOT MSVC)
   target_compile_options(zstd PRIVATE -fPIC -w -O3)
 endif()


### PR DESCRIPTION
of the libxxhash.a library when building libCore.so

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

