### PR TITLE
[math] Avoid out-of-bounds array access with `vc` in FitUtil.h

### DIFF
--- a/math/mathcore/inc/Fit/FitUtil.h
+++ b/math/mathcore/inc/Fit/FitUtil.h
@@ -229,20 +229,23 @@ namespace FitUtil {
 #ifdef R__HAS_VECCORE
      inline double ExecFunc(const IModelFunctionTempl<ROOT::Double_v> *f, const double *x, const double *p) const
      {
-        if (fDim == 1) {
-           ROOT::Double_v xx;
-           vecCore::Load<ROOT::Double_v>(xx, x);
-           const double *p0 = p;
-           auto res = (*f)(&xx, (const double *)p0);
-           return vecCore::Get<ROOT::Double_v>(res, 0);
-        } else {
-           std::vector<ROOT::Double_v> xx(fDim);
-           for (unsigned int i = 0; i < fDim; ++i) {
-              vecCore::Load<ROOT::Double_v>(xx[i], x + i);
+        // Figure out the size of the SIMD vectors.
+        constexpr static int vecSize = sizeof(ROOT::Double_v) / sizeof(double);
+        double xBuffer[vecSize];
+        ROOT::Double_v xx[fDim];
+        for (unsigned int i = 0; i < fDim; ++i) {
+           // The Load() function reads multiple values from tbe pointed-to
+           // memory into xx. This is why we hav to copy the input values from
+           // the x array into a zero-padded buffer to read from. Otherwise,
+           // Load() would access the x array out of bounds.
+           *xBuffer = x[i];
+           for(int j = 1; j < vecSize; ++j) {
+              xBuffer[j] = 0.0;
            }
-           auto res = (*f)(xx.data(), p);
-           return vecCore::Get<ROOT::Double_v>(res, 0);
+           vecCore::Load<ROOT::Double_v>(xx[i], xBuffer);
         }
+        auto res = (*f)(xx, p);
+        return vecCore::Get<ROOT::Double_v>(res, 0);
      }
 #endif
 

--- a/math/mathcore/inc/Math/Types.h
+++ b/math/mathcore/inc/Math/Types.h
@@ -9,7 +9,6 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wall"
-#pragma GCC diagnostic ignored "-Warray-bounds"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #if (__cplusplus >= 202002L) // only for C++20

--- a/roofit/batchcompute/inc/RooBatchCompute.h
+++ b/roofit/batchcompute/inc/RooBatchCompute.h
@@ -23,8 +23,6 @@
 
 #include <DllImport.h> //for R__EXTERN, needed for windows
 
-#include <Math/Util.h>
-
 #include <cassert>
 #include <functional>
 #include <string>
@@ -114,7 +112,8 @@ enum Computer {
 };
 
 struct ReduceNLLOutput {
-   ROOT::Math::KahanSum<double> nllSum;
+   double nllSum = 0.0;
+   double nllSumCarry = 0.0;
    std::size_t nLargeValues = 0;
    std::size_t nNonPositiveValues = 0;
    std::size_t nNaNValues = 0;

--- a/roofit/batchcompute/src/RooBatchCompute.cu
+++ b/roofit/batchcompute/src/RooBatchCompute.cu
@@ -291,7 +291,8 @@ ReduceNLLOutput RooBatchComputeClass::reduceNLL(RooBatchCompute::Config const &c
       tmpCarry *= weights[0];
    }
 
-   out.nllSum = ROOT::Math::KahanSum<double>{tmpSum, tmpCarry};
+   out.nllSum = tmpSum;
+   out.nllSumCarry = tmpCarry;
    return out;
 }
 

--- a/roofit/roofitcore/src/RooNLLVarNew.cxx
+++ b/roofit/roofitcore/src/RooNLLVarNew.cxx
@@ -289,7 +289,7 @@ void RooNLLVarNew::computeBatch(double *output, size_t /*nOut*/, RooFit::Detail:
       nllOut.nllSum += _pdf->extendedTerm(_sumWeight, expected[0], _weightSquared ? _sumWeight2 : 0.0, _doBinOffset);
    }
 
-   output[0] = finalizeResult(nllOut.nllSum, _sumWeight);
+   output[0] = finalizeResult({nllOut.nllSum, nllOut.nllSumCarry}, _sumWeight);
 }
 
 void RooNLLVarNew::getParametersHook(const RooArgSet * /*nset*/, RooArgSet *params, bool /*stripDisconnected*/) const


### PR DESCRIPTION
There was a problem in the `IntegralEvaluator` class in the FitUtils.h
in case veccore and vc is used. To evaluate the integral, some input
doubles `x` need to be transferred each of them into a different
`ROOT::Double_v` to call the underlying function.

However, the `ROOT::Double_v` can't load just a single double. Calling
the `Load()` function should be done with a pointer to a `double *`
arrary that is large enough to hold as many doubles as the
`ROOT::Double_v` for SIMD instructions.

If you use pointers to single doubles anyway, then you get rightly and
out-of-bounds warning.

This commits suggests to get gid of this problem by first transferring
the doubles to the beginning of temporary buffers of the right size, and
then passing these buffers to `vecCore::Load()`.

Furthermore, I suggest to merge the two code paths of 1D and ND
functions into one. The difference was that the ND path allocated the
`Double_v`s on the heap in a STD vector, and the 1D path used just an
single `Double_v` on the stack, probably for performance reasons.

This commit suggests to use the stack also for the ND code path using
stack arrays, so the 1D path would not be a special case anymore.

Also, the `<Math/Util.h>` header can not be compiled with CUDA if `vc` is enabled, so there is a second commit in this PR to avoid that.
