### PR TITLE
[v628] Backports to fix TMVA nightly errors

### DIFF
--- a/tmva/pymva/src/RModelParser_Keras.cxx
+++ b/tmva/pymva/src/RModelParser_Keras.cxx
@@ -809,6 +809,7 @@ RModel Parse(std::string filename){
    // For each layer: type,name,activation,dtype,input tensor's name,
    // output tensor's name, kernel's name, bias's name
    // None object is returned for if property doesn't belong to layer
+   PyRunString("import tensorflow",fGlobalNS,fLocalNS);
    PyRunString("import tensorflow.keras as keras",fGlobalNS,fLocalNS);
    PyRunString("from tensorflow.keras.models import load_model",fGlobalNS,fLocalNS);
    PyRunString("print('TF/Keras Version: '+ tensorflow.__version__)",fGlobalNS,fLocalNS);

--- a/tmva/pymva/src/RModelParser_Keras.cxx
+++ b/tmva/pymva/src/RModelParser_Keras.cxx
@@ -811,7 +811,7 @@ RModel Parse(std::string filename){
    // None object is returned for if property doesn't belong to layer
    PyRunString("import tensorflow.keras as keras",fGlobalNS,fLocalNS);
    PyRunString("from tensorflow.keras.models import load_model",fGlobalNS,fLocalNS);
-   PyRunString("print('Keras Version: '+ keras.__version__)",fGlobalNS,fLocalNS);
+   PyRunString("print('TF/Keras Version: '+ tensorflow.__version__)",fGlobalNS,fLocalNS);
    PyRunString(TString::Format("model=load_model('%s')",filename.c_str()),fGlobalNS,fLocalNS);
    PyRunString(TString::Format("model.load_weights('%s')",filename.c_str()),fGlobalNS,fLocalNS);
    PyRunString("globals().update(locals())",fGlobalNS,fLocalNS);

--- a/tmva/pymva/src/RModelParser_PyTorch.cxx
+++ b/tmva/pymva/src/RModelParser_PyTorch.cxx
@@ -422,12 +422,18 @@ RModel Parse(std::string filename, std::vector<std::vector<size_t>> inputShapes,
 
     //Extracting the model information in list modelData
     PyRunString("modelData=[]",fGlobalNS,fLocalNS);
+    // The '_node_get' helper function is used to avoid dependency on onnx submodule
+    // (for the subscript operator of torch._C.Node), as done in https://github.com/pytorch/pytorch/pull/82628
+    PyRunString("def _node_get(node, key):\n"
+                "    sel = node.kindOf(key)\n"
+                "    return getattr(node, sel)(key)\n",
+                fGlobalNS, fLocalNS);
     PyRunString("for i in graph[0].nodes():\n"
                 "    globals().update(locals())\n"
                 "    nodeData={}\n"
                 "    nodeData['nodeType']=i.kind()\n"
                 "    nodeAttributeNames=[x for x in i.attributeNames()]\n"
-                "    nodeAttributes={j:i[j] for j in nodeAttributeNames}\n"
+                "    nodeAttributes={j: _node_get(i, j) for j in nodeAttributeNames}\n"
                 "    nodeData['nodeAttributes']=nodeAttributes\n"
                 "    nodeInputs=[x for x in i.inputs()]\n"
                 "    nodeInputNames=[x.debugName() for x in nodeInputs]\n"
@@ -437,7 +443,8 @@ RModel Parse(std::string filename, std::vector<std::vector<size_t>> inputShapes,
                 "    nodeData['nodeOutputs']=nodeOutputNames\n"
                 "    nodeDType=[x.type().scalarType() for x in nodeOutputs]\n"
                 "    nodeData['nodeDType']=nodeDType\n"
-                "    modelData.append(nodeData)",fGlobalNS,fLocalNS);
+                "    modelData.append(nodeData)",
+                fGlobalNS, fLocalNS);
 
     PyObject* fPModel = PyDict_GetItemString(fLocalNS,"modelData");
     Py_ssize_t fPModelSize = PyList_Size(fPModel);

--- a/tmva/pymva/test/CMakeLists.txt
+++ b/tmva/pymva/test/CMakeLists.txt
@@ -145,9 +145,12 @@ if((PY_KERAS_FOUND AND PY_THEANO_FOUND) OR (PY_KERAS_FOUND AND PY_TENSORFLOW_FOU
    ROOT_ADD_TEST(PyMVA-Keras-Classification COMMAND testPyKerasClassification DEPENDS ${PyMVA-Keras-Classification-depends})
 
    # Test PyKeras: Regression
-   ROOT_EXECUTABLE(testPyKerasRegression testPyKerasRegression.C
-      LIBRARIES ${Libraries})
-   ROOT_ADD_TEST(PyMVA-Keras-Regression COMMAND testPyKerasRegression DEPENDS ${PyMVA-Keras-Regression-depends})
+   if (NOT ROOT_ARCHITECTURE MATCHES macosx)
+      #veto also keras tutorial on macos due to issue in disabling eager execution on macos
+      ROOT_EXECUTABLE(testPyKerasRegression testPyKerasRegression.C
+         LIBRARIES ${Libraries})
+      ROOT_ADD_TEST(PyMVA-Keras-Regression COMMAND testPyKerasRegression DEPENDS ${PyMVA-Keras-Regression-depends})
+   endif()
 
 
    # Test PyKeras: Multi-class classification

--- a/tmva/tmva/CMakeLists.txt
+++ b/tmva/tmva/CMakeLists.txt
@@ -31,18 +31,12 @@ endif()
 # Enable parts dependent RDataFrame
 if(dataframe)
     set(TMVA_EXTRA_HEADERS
-        TMVA/RTensor.hxx
         TMVA/RTensorUtils.hxx
-        TMVA/RStandardScaler.hxx
-        TMVA/RReader.hxx
-        TMVA/RInferenceUtils.hxx
-        TMVA/RBDT.hxx
-        TMVA/RSofieReader.hxx
     )
     set(TMVA_EXTRA_SOURCES
-        RBDT.cxx
     )
-    list(APPEND TMVA_EXTRA_DEPENDENCIES ROOTDataFrame ROOTVecOps)
+#    list(APPEND TMVA_EXTRA_DEPENDENCIES ROOTDataFrame ROOTVecOps)
+#    list(APPEND TMVA_EXTRA_DEPENDENCIES )
 endif()
 
 if (imt)
@@ -215,6 +209,12 @@ ROOT_STANDARD_LIBRARY_PACKAGE(TMVA
     TMVA/VarTransformHandler.h
     TMVA/Version.h
     TMVA/Volume.h
+    TMVA/RStandardScaler.hxx
+    TMVA/RReader.hxx
+    TMVA/RInferenceUtils.hxx
+    TMVA/RBDT.hxx
+    TMVA/RSofieReader.hxx
+    TMVA/RTensor.hxx
     TMVA/TreeInference/PythonHelpers.hxx
     TMVA/TreeInference/BranchlessTree.hxx
     TMVA/TreeInference/Forest.hxx
@@ -349,6 +349,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(TMVA
     src/PDEFoamVect.cxx
     src/PDF.cxx
     src/QuickMVAProbEstimator.cxx
+    src/RBDT.cxx
     src/Ranking.cxx
     src/Reader.cxx
     src/RegressionVariance.cxx

--- a/tmva/tmva/CMakeLists.txt
+++ b/tmva/tmva/CMakeLists.txt
@@ -28,16 +28,6 @@ else()
   set(installoptions ${installoptions} FILTER "Cuda")
 endif()
 
-# Enable parts dependent RDataFrame
-if(dataframe)
-    set(TMVA_EXTRA_HEADERS
-        TMVA/RTensorUtils.hxx
-    )
-    set(TMVA_EXTRA_SOURCES
-    )
-#    list(APPEND TMVA_EXTRA_DEPENDENCIES ROOTDataFrame ROOTVecOps)
-#    list(APPEND TMVA_EXTRA_DEPENDENCIES )
-endif()
 
 if (imt)
   list(APPEND TMVA_EXTRA_DEPENDENCIES Imt)
@@ -209,16 +199,6 @@ ROOT_STANDARD_LIBRARY_PACKAGE(TMVA
     TMVA/VarTransformHandler.h
     TMVA/Version.h
     TMVA/Volume.h
-    TMVA/RStandardScaler.hxx
-    TMVA/RReader.hxx
-    TMVA/RInferenceUtils.hxx
-    TMVA/RBDT.hxx
-    TMVA/RSofieReader.hxx
-    TMVA/RTensor.hxx
-    TMVA/TreeInference/PythonHelpers.hxx
-    TMVA/TreeInference/BranchlessTree.hxx
-    TMVA/TreeInference/Forest.hxx
-    TMVA/TreeInference/Objectives.hxx
     #  TMVA/DNN/Adadelta.h
     #  TMVA/DNN/Adagrad.h
     #  TMVA/DNN/Adam.h
@@ -481,6 +461,37 @@ if(tmva-gpu)
                    src/DNN/Architectures/Cuda/CudaMatrix.cu
                    src/DNN/Architectures/Cuda/CudaTensor.cu )
    endif()
+endif()
+
+if(dataframe)
+ROOT_STANDARD_LIBRARY_PACKAGE(TMVAUtils
+  NO_INSTALL_HEADERS
+  HEADERS
+  TMVA/RTensorUtils.hxx
+  TMVA/RStandardScaler.hxx
+  TMVA/RReader.hxx
+  TMVA/RInferenceUtils.hxx
+  TMVA/RBDT.hxx
+  TMVA/RSofieReader.hxx
+  TMVA/TreeInference/PythonHelpers.hxx
+  TMVA/TreeInference/BranchlessTree.hxx
+  TMVA/TreeInference/Forest.hxx
+  TMVA/TreeInference/Objectives.hxx
+
+  SOURCES
+
+  src/RBDT.cxx
+
+  DEPENDENCIES
+    TMVA ROOTDataFrame ROOTVecOps
+    ${TMVA_EXTRA_DEPENDENCIES}
+
+  LINKDEF  LinkDefUtils.h
+  DICTIONARY_OPTIONS
+    -writeEmptyRootPCM
+
+  ${EXTRA_DICT_OPTS}
+)
 endif()
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/tmva/tmva/inc/LinkDef1.h
+++ b/tmva/tmva/inc/LinkDef1.h
@@ -71,9 +71,4 @@
 #pragma link C++ class TMVA::MethodCrossValidation+;
 #pragma link C++ class TMVA::MethodDL+;
 
-#ifdef R__HAS_DATAFRAME
-// BDT inference
-#pragma link C++ class TMVA::Experimental::RBDT<TMVA::Experimental::BranchlessForest<float>>;
-#pragma link C++ class TMVA::Experimental::RBDT<TMVA::Experimental::BranchlessJittedForest<float>>;
-#endif
 #endif

--- a/tmva/tmva/inc/LinkDefUtils.h
+++ b/tmva/tmva/inc/LinkDefUtils.h
@@ -1,0 +1,18 @@
+#ifdef __CINT__
+
+#include "RConfigure.h"
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+#pragma link off all namespaces;
+
+#pragma link C++ nestedclass;
+
+#ifdef R__HAS_DATAFRAME
+// BDT inference
+#pragma link C++ class TMVA::Experimental::RBDT<TMVA::Experimental::BranchlessForest<float>>;
+#pragma link C++ class TMVA::Experimental::RBDT<TMVA::Experimental::BranchlessJittedForest<float>>;
+#endif
+
+#endif

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -252,11 +252,10 @@ endif()
 
 if(NOT ROOT_imt_FOUND)
   set(imt_veto multicore/imt*.C multicore/mt*.C)
-else()
-  if(MSVC)
-    #---Multiproc is not supported on Windows
-    set(imt_veto ${imt_veto} multicore/mp*.C multicore/mtbb201_parallelHistoFill.C)
-  endif()
+endif()
+if(MSVC)
+  #---Multiproc is not supported on Windows
+  set(imt_veto ${imt_veto} multicore/mp*.C multicore/mtbb201_parallelHistoFill.C)
 endif()
 
 if(ROOT_CLASSIC_BUILD)

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -754,6 +754,12 @@ if(ROOT_pyroot_FOUND)
   if(NOT PY_KERAS_FOUND)
     file(GLOB tmva_veto_py RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} tmva/keras/*.py)
     list(APPEND pyveto ${tmva_veto_py})
+  else()
+    if (ROOT_ARCHITECTURE MATCHES macosx)   #veto also keras tutorial on macos due to issue in disabling eager execution on macos
+       list(APPEND pyveto tmva/keras/RegressionKeras.py)
+       list(APPEND pyveto tmva/keras/ApplicationRegressionKeras.py)
+       list(APPEND pyveto tmva/keras/MultiClassKeras.py)
+    endif()
   endif()
 
   find_python_module(torch QUIET)

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -754,12 +754,11 @@ if(ROOT_pyroot_FOUND)
   if(NOT PY_KERAS_FOUND)
     file(GLOB tmva_veto_py RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} tmva/keras/*.py)
     list(APPEND pyveto ${tmva_veto_py})
-  else()
-    if (ROOT_ARCHITECTURE MATCHES macosx)   #veto also keras tutorial on macos due to issue in disabling eager execution on macos
-       list(APPEND pyveto tmva/keras/RegressionKeras.py)
-       list(APPEND pyveto tmva/keras/ApplicationRegressionKeras.py)
-       list(APPEND pyveto tmva/keras/MultiClassKeras.py)
-    endif()
+  elseif(ROOT_ARCHITECTURE MATCHES macosx)
+    #veto also keras tutorial on macos due to issue in disabling eager execution on macos
+    list(APPEND pyveto tmva/keras/RegressionKeras.py)
+    list(APPEND pyveto tmva/keras/ApplicationRegressionKeras.py)
+    list(APPEND pyveto tmva/keras/MultiClassKeras.py)
   endif()
 
   find_python_module(torch QUIET)

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -251,7 +251,7 @@ if(NOT TBB_FOUND AND NOT builtin_tbb)
 endif()
 
 if(NOT ROOT_imt_FOUND)
-  set(imt_veto multicore/imt*.C multicore/mt*.C)
+  set(imt_veto multicore/imt*.C multicore/mt*.C tmva/TMVA_CNN_Classification.C)
 endif()
 if(MSVC)
   #---Multiproc is not supported on Windows


### PR DESCRIPTION
Backporting some PRs to avoid test failures in the nightlies:
* https://github.com/root-project/root/pull/12693
* https://github.com/root-project/root/pull/13712
* https://github.com/root-project/root/pull/13718
* https://github.com/root-project/root/pull/13765
* https://github.com/root-project/root/pull/13524
* https://github.com/root-project/root/pull/13525
* https://github.com/root-project/root/pull/13613

After these trivial backports, the only PR that needs to be backported to fix the remaining failures is this one:
* https://github.com/root-project/root/pull/13533

However, this would not be a simple conflict-less backport because the changes interact with new feature development for ROOT 6.30. It's maybe better if @lmoneta takes care of this.
