### PR TITLE
Add RDefinePerSample to CMakeLists.txt

### DIFF
--- a/tree/dataframe/CMakeLists.txt
+++ b/tree/dataframe/CMakeLists.txt
@@ -62,6 +62,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTDataFrame
     ROOT/RDF/RSampleInfo.hxx
     ROOT/RDF/RDefineBase.hxx
     ROOT/RDF/RDefine.hxx
+    ROOT/RDF/RDefinePerSample.hxx
     ROOT/RDF/RDefineReader.hxx
     ROOT/RDF/RDSColumnReader.hxx
     ROOT/RDF/RColumnReaderBase.hxx


### PR DESCRIPTION
This is just a quickfix PR to add the header to the library generation (before it worked due to transitive inclusion in `RInterface.hxx`). In a followup PR I will propose a way to automatise this and avoid further cases