### PR TITLE
Fix potential crash of the rreader test on Windows

### DIFF
--- a/tmva/tmva/test/rreader.cxx
+++ b/tmva/tmva/test/rreader.cxx
@@ -35,7 +35,7 @@ void TrainClassificationModel()
 
    // Open trees with signal and background events
    const std::string filename = "http://root.cern.ch/files/tmva_class_example.root";
-   auto data = TFile::Open(filename.c_str());
+   std::unique_ptr<TFile> data{TFile::Open(filename.c_str())};
    auto signal = (TTree *)data->Get("TreeS");
    auto background = (TTree *)data->Get("TreeB");
 
@@ -53,7 +53,6 @@ void TrainClassificationModel()
    factory->BookMethod(dataloader, TMVA::Types::kBDT, "BDT", "!V:!H:NTrees=100:MaxDepth=2");
    factory->TrainAllMethods();
    output->Close();
-   delete data;
 }
 
 // Regression
@@ -78,7 +77,7 @@ void TrainRegressionModel()
 
    // Open trees with signal and background events
    const std::string filename = "http://root.cern.ch/files/tmva_reg_example.root";
-   auto data = TFile::Open(filename.c_str());
+   std::unique_ptr<TFile> data{TFile::Open(filename.c_str())};
    auto tree = (TTree *)data->Get("TreeR");
 
    // Add variables and register the trees with the dataloader
@@ -93,7 +92,6 @@ void TrainRegressionModel()
    factory->BookMethod(dataloader, TMVA::Types::kBDT, "BDTG", "!V:!H:NTrees=100:MaxDepth=2");
    factory->TrainAllMethods();
    output->Close();
-   delete data;
 }
 
 // Multiclass
@@ -118,7 +116,7 @@ void TrainMulticlassModel()
 
    // Open trees with signal and background events
    const std::string filename = "http://root.cern.ch/files/tmva_multiclass_example.root";
-   auto data = TFile::Open(filename.c_str());
+   std::unique_ptr<TFile> data{TFile::Open(filename.c_str())};
    auto signal = (TTree *)data->Get("TreeS");
    auto background0 = (TTree *)data->Get("TreeB0");
    auto background1 = (TTree *)data->Get("TreeB1");
@@ -140,7 +138,6 @@ void TrainMulticlassModel()
    factory->BookMethod(dataloader, TMVA::Types::kBDT, "BDT", "!V:!H:NTrees=100:MaxDepth=2:BoostType=Grad");
    factory->TrainAllMethods();
    output->Close();
-   delete data;
 }
 
 TEST(RReader, ClassificationGetVariables)

--- a/tmva/tmva/test/rreader.cxx
+++ b/tmva/tmva/test/rreader.cxx
@@ -53,6 +53,7 @@ void TrainClassificationModel()
    factory->BookMethod(dataloader, TMVA::Types::kBDT, "BDT", "!V:!H:NTrees=100:MaxDepth=2");
    factory->TrainAllMethods();
    output->Close();
+   delete data;
 }
 
 // Regression
@@ -92,6 +93,7 @@ void TrainRegressionModel()
    factory->BookMethod(dataloader, TMVA::Types::kBDT, "BDTG", "!V:!H:NTrees=100:MaxDepth=2");
    factory->TrainAllMethods();
    output->Close();
+   delete data;
 }
 
 // Multiclass
@@ -138,6 +140,7 @@ void TrainMulticlassModel()
    factory->BookMethod(dataloader, TMVA::Types::kBDT, "BDT", "!V:!H:NTrees=100:MaxDepth=2:BoostType=Grad");
    factory->TrainAllMethods();
    output->Close();
+   delete data;
 }
 
 TEST(RReader, ClassificationGetVariables)


### PR DESCRIPTION
Delete the `TFile` pointers, preventing a potential crash in `TROOT::CloseFiles()` when trying to call the `Close()` method on `TWebSocket`/`TWebFile` via the interpreter `CallFunc_Exec` on Windows (visible with LLVM 16)
