### PR TITLE
Add the `TWebFile::Close(Option_t *option)` method

### DIFF
--- a/net/net/inc/TWebFile.h
+++ b/net/net/inc/TWebFile.h
@@ -77,6 +77,7 @@ public:
    TWebFile(TUrl url, Option_t *opt="");
    virtual ~TWebFile();
 
+   void        Close(Option_t *option="") override;
    Long64_t    GetSize() const override;
    Bool_t      IsOpen() const override;
    Int_t       ReOpen(Option_t *mode) override;

--- a/net/net/src/TWebFile.cxx
+++ b/net/net/src/TWebFile.cxx
@@ -406,6 +406,23 @@ Int_t TWebFile::ReOpen(Option_t *mode)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Close a Web file. Close the socket connection and delete the cache
+/// See also the TFile::Close() function
+
+void TWebFile::Close(Option_t *option)
+{
+   if (fSocket)
+      delete fSocket;
+   fSocket = nullptr;
+   if (fFullCache) {
+      free(fFullCache);
+      fFullCache = 0;
+      fFullCacheSize = 0;
+   }
+   return TFile::Close(option);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Read specified byte range from remote file via HTTP daemon. This
 /// routine connects to the remote host, sends the request and returns
 /// the buffer. Returns kTRUE in case of error.


### PR DESCRIPTION
This is needed to properly close and delete the socket when closing the file in `TROOT::CloseFiles()`, preventing a potential issue when trying to close the socket afterwards
