### PR TITLE
[skip-ci] make sure the legacy box is readable in dark mode.

### DIFF
--- a/documentation/doxygen/ROOT.css
+++ b/documentation/doxygen/ROOT.css
@@ -27,5 +27,6 @@ div.contents {
 .legacybox {
   border: 3px solid #879ecb;
   background-color: #fdf06b;
+  color: #000000;
   padding: 15px;
 }


### PR DESCRIPTION
The "legacy code" boxes were not readable in dark mode (tanks @eguiraud to have seen it).

