### PR TITLE
[PyROOT] Speedup inclusion of ROOT module

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_facade.py
@@ -368,7 +368,7 @@ class ROOTFacade(types.ModuleType):
         #this line is needed to import the pythonizations in _tmva directory
         from ._pythonization import _tmva
         ns = self._fallback_getattr('TMVA')
-        hasRDF = gSystem.GetFromPipe("root-config --has-dataframe") == "yes"
+        hasRDF = "dataframe" in gROOT.GetConfigFeatures()
         if hasRDF:
             try:
                 if sys.version_info >= (3, 8):

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tmva/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tmva/__init__.py
@@ -16,6 +16,8 @@ from cppyy.gbl import gSystem
 
 from .. import pythonization
 
+from libROOTPythonizations import gROOT
+
 from ._factory import Factory
 from ._dataloader import DataLoader
 from ._crossvalidation import CrossValidation
@@ -44,7 +46,7 @@ if sys.version_info >= (3, 8):
 
     from ._gnn import RModel_GNN, RModel_GraphIndependent
 
-hasRDF = gSystem.GetFromPipe("root-config --has-dataframe") == "yes"
+hasRDF = "dataframe" in gROOT.GetConfigFeatures()
 if hasRDF:
     from ._rtensor import get_array_interface, add_array_interface_property, RTensorGetitem, pythonize_rtensor
 


### PR DESCRIPTION
# This Pull request:
Removes invocations to the root-config executable at *ROOT module import time*. The executable `root-config` was invoked twice to check if RDataFrame was available. Such a behaviour causes a severe slowdown, especially on cvmfs. This has been replaced by a simple string comparison, which is fast and which has no impact in terms of memory (as a query to the type system would have caused with modules),

More in general, this simple PR could be considered as the first of a series to reduce the time needed to `import ROOT` as much as possible.

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

