### PR TITLE
[RF] modify flexibleInterp code 4 for numerical stability

### DIFF
--- a/roofit/roofitcore/inc/RooFit/Detail/EvaluateFuncs.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/EvaluateFuncs.h
@@ -156,7 +156,7 @@ inline double flexibleInterp(unsigned int code, double low, double high, double 
          return total * std::pow(low / nominal, -paramVal);
       }
 
-      return total * std::exp(interpolate6thDegree(x, std::log(low), std::log(high), std::log(nominal), boundary));
+      return total * (1 + interpolate6thDegree(x, low, high, nominal, boundary));
    }
 
    return total;


### PR DESCRIPTION
The previous equation interpolated between low and high values in logarithmic space and transformed the result back with an exp. This introduced an issue with low or high values that were zero. Taking their logarithm would introduce -inf values which led to nan values from the interpolation call. Instead, we now do the interpolation without the back and forth logaritmic transformations. This gives slightly deviating values from the previous implementation. However, that implementation already was a recent change from the earlier implementation with similarly deviating values, so in the end this additional change is not very significant. See commit 466f3f689c578cb53d75ddeeb04472ec4d82e3ed for that previous reimplementation. This change can be considered a fix for that commit.

Fixes #13749.