### PR TITLE
[ntuple] Add support for std::byte

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -805,14 +805,6 @@ If $i == 0$, i.e. it falls on the start of a cluster, the $(i-1)$-th value in th
 The `SizeT` template parameter defines the in-memory integer type of the collection size.
 The valid types are `std::uint32_t` and `std::uint64_t`.
 
-### ROOT::Experimental::RNTupleBLOB
-
-A field that stores uninterpreted byte arrays.
-Similar to a string field, the `RNTupleBLOB` field has two columns.
-It represents the data as a collection of bytes.
-The first (principal) column is of type [Split]Index[64,32].
-The second column is of type `Byte`.
-
 ## Limits
 
 TODO(jblomer)

--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -810,7 +810,7 @@ The valid types are `std::uint32_t` and `std::uint64_t`.
 A field that stores uninterpreted byte arrays.
 Similar to a string field, the `RNTupleBLOB` field has two columns.
 It represents the data as a collection of bytes.
-The first (principle) column is of type [Split]Index[64,32].
+The first (principal) column is of type [Split]Index[64,32].
 The second column is of type `Byte`.
 
 ## Limits

--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -805,6 +805,14 @@ If $i == 0$, i.e. it falls on the start of a cluster, the $(i-1)$-th value in th
 The `SizeT` template parameter defines the in-memory integer type of the collection size.
 The valid types are `std::uint32_t` and `std::uint64_t`.
 
+### ROOT::Experimental::RNTupleBLOB
+
+A field that stores uninterpreted byte arrays.
+Similar to a string field, the `RNTupleBLOB` field has two columns.
+It represents the data as a collection of bytes.
+The first (principle) column is of type [Split]Index[64,32].
+The second column is of type `Byte`.
+
 ## Limits
 
 TODO(jblomer)

--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -25,6 +25,7 @@
 #include <TError.h>
 
 #include <cstring> // for memcpy
+#include <cstddef> // for std::byte
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -435,6 +436,13 @@ public:
 };
 
 template <>
+class RColumnElement<std::byte, EColumnType::kUnknown> : public RColumnElementBase {
+public:
+   static constexpr std::size_t kSize = sizeof(std::byte);
+   RColumnElement() : RColumnElementBase(kSize) {}
+};
+
+template <>
 class RColumnElement<char, EColumnType::kUnknown> : public RColumnElementBase {
 public:
    static constexpr std::size_t kSize = sizeof(char);
@@ -614,6 +622,8 @@ public:
       static constexpr bool kIsMappable = true;                           \
       __RCOLUMNELEMENT_SPEC_BODY(CppT, RColumnElementBase, BitsOnStorage) \
    }
+
+DECLARE_RCOLUMNELEMENT_SPEC_SIMPLE(std::byte, EColumnType::kByte, 8);
 
 DECLARE_RCOLUMNELEMENT_SPEC_SIMPLE(char, EColumnType::kByte, 8);
 DECLARE_RCOLUMNELEMENT_SPEC_SIMPLE(char, EColumnType::kChar, 8);

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -2545,63 +2545,6 @@ public:
    using Detail::RFieldBase::GenerateValue;
 };
 
-class RNTupleBLOB {
-private:
-   std::shared_ptr<void> fData;
-   std::size_t fSize = 0;
-
-public:
-   RNTupleBLOB() = default;
-   RNTupleBLOB(std::shared_ptr<void> data, std::size_t size) : fData(data), fSize(size) {}
-
-   void Set(std::shared_ptr<void> data, std::size_t size)
-   {
-      fData = data;
-      fSize = size;
-   }
-
-   std::shared_ptr<void> GetData() const { return fData; }
-   std::size_t GetSize() const { return fSize; }
-};
-
-template <>
-class RField<RNTupleBLOB> : public Detail::RFieldBase {
-private:
-   ClusterSize_t fIndex;
-
-   std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final
-   {
-      return std::make_unique<RField>(newName);
-   }
-
-   const RColumnRepresentations &GetColumnRepresentations() const final;
-   void GenerateColumnsImpl() final;
-   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
-
-   void GenerateValue(void *where) const final { new (where) RNTupleBLOB(); }
-   void DestroyValue(void *objPtr, bool dtorOnly = false) const override;
-
-   std::size_t AppendImpl(const void *from) final;
-   void ReadGlobalImpl(ROOT::Experimental::NTupleSize_t globalIndex, void *to) final;
-
-   void CommitClusterImpl() final { fIndex = 0; }
-
-public:
-   static std::string TypeName() { return "ROOT::Experimental::RNTupleBLOB"; }
-   explicit RField(std::string_view name)
-      : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, false /* isSimple */), fIndex(0)
-   {
-   }
-   RField(RField &&other) = default;
-   RField &operator=(RField &&other) = default;
-   ~RField() override = default;
-
-   using Detail::RFieldBase::GenerateValue;
-   size_t GetValueSize() const final { return sizeof(RNTupleBLOB); }
-   size_t GetAlignment() const final { return std::alignment_of<RNTupleBLOB>(); }
-   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
-};
-
 template <typename ItemT>
 class RField<std::atomic<ItemT>> : public RAtomicField {
 public:

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -1727,6 +1727,47 @@ public:
 };
 
 template <>
+class RField<std::byte> : public Detail::RFieldBase {
+protected:
+   std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final
+   {
+      return std::make_unique<RField>(newName);
+   }
+
+   const RColumnRepresentations &GetColumnRepresentations() const final;
+   void GenerateColumnsImpl() final;
+   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+   void GenerateValue(void *where) const final { new (where) std::byte{0}; }
+
+public:
+   static std::string TypeName() { return "std::byte"; }
+   explicit RField(std::string_view name)
+      : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
+   {
+      fTraits |= kTraitTrivialType;
+   }
+   RField(RField &&other) = default;
+   RField &operator=(RField &&other) = default;
+   ~RField() override = default;
+
+   std::byte *Map(NTupleSize_t globalIndex) { return fPrincipalColumn->Map<std::byte>(globalIndex); }
+   std::byte *Map(const RClusterIndex &clusterIndex) { return fPrincipalColumn->Map<std::byte>(clusterIndex); }
+   std::byte *MapV(NTupleSize_t globalIndex, NTupleSize_t &nItems)
+   {
+      return fPrincipalColumn->MapV<std::byte>(globalIndex, nItems);
+   }
+   std::byte *MapV(const RClusterIndex &clusterIndex, NTupleSize_t &nItems)
+   {
+      return fPrincipalColumn->MapV<std::byte>(clusterIndex, nItems);
+   }
+
+   using Detail::RFieldBase::GenerateValue;
+   size_t GetValueSize() const final { return sizeof(std::byte); }
+   size_t GetAlignment() const final { return alignof(std::byte); }
+   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+};
+
+template <>
 class RField<char> : public Detail::RFieldBase {
 protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final {

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -2504,6 +2504,63 @@ public:
    using Detail::RFieldBase::GenerateValue;
 };
 
+class RNTupleBLOB {
+private:
+   std::shared_ptr<void> fData;
+   std::size_t fSize = 0;
+
+public:
+   RNTupleBLOB() = default;
+   RNTupleBLOB(std::shared_ptr<void> data, std::size_t size) : fData(data), fSize(size) {}
+
+   void Set(std::shared_ptr<void> data, std::size_t size)
+   {
+      fData = data;
+      fSize = size;
+   }
+
+   std::shared_ptr<void> GetData() const { return fData; }
+   std::size_t GetSize() const { return fSize; }
+};
+
+template <>
+class RField<RNTupleBLOB> : public Detail::RFieldBase {
+private:
+   ClusterSize_t fIndex;
+
+   std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final
+   {
+      return std::make_unique<RField>(newName);
+   }
+
+   const RColumnRepresentations &GetColumnRepresentations() const final;
+   void GenerateColumnsImpl() final;
+   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+
+   void GenerateValue(void *where) const final { new (where) RNTupleBLOB(); }
+   void DestroyValue(void *objPtr, bool dtorOnly = false) const override;
+
+   std::size_t AppendImpl(const void *from) final;
+   void ReadGlobalImpl(ROOT::Experimental::NTupleSize_t globalIndex, void *to) final;
+
+   void CommitClusterImpl() final { fIndex = 0; }
+
+public:
+   static std::string TypeName() { return "ROOT::Experimental::RNTupleBLOB"; }
+   explicit RField(std::string_view name)
+      : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, false /* isSimple */), fIndex(0)
+   {
+   }
+   RField(RField &&other) = default;
+   RField &operator=(RField &&other) = default;
+   ~RField() override = default;
+
+   using Detail::RFieldBase::GenerateValue;
+   size_t GetValueSize() const final { return sizeof(RNTupleBLOB); }
+   size_t GetAlignment() const final { return std::alignment_of<RNTupleBLOB>(); }
+   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+};
+
 template <typename ItemT>
 class RField<std::atomic<ItemT>> : public RAtomicField {
 public:

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -56,6 +56,7 @@ public:
    virtual void VisitDoubleField(const RField<double> &field) { VisitField(field); }
    virtual void VisitEnumField(const REnumField &field) { VisitField(field); }
    virtual void VisitFloatField(const RField<float> &field) { VisitField(field); }
+   virtual void VisitByteField(const RField<std::byte> &field) { VisitField(field); }
    virtual void VisitCharField(const RField<char> &field) { VisitField(field); }
    virtual void VisitInt8Field(const RField<std::int8_t> &field) { VisitField(field); }
    virtual void VisitInt16Field(const RField<std::int16_t> &field) { VisitField(field); }
@@ -201,6 +202,7 @@ public:
    void VisitBoolField(const RField<bool> &field) final;
    void VisitDoubleField(const RField<double> &field) final;
    void VisitFloatField(const RField<float> &field) final;
+   void VisitByteField(const RField<std::byte> &field) final;
    void VisitCharField(const RField<char> &field) final;
    void VisitInt8Field(const RField<std::int8_t> &field) final;
    void VisitInt16Field(const RField<std::int16_t> &field) final;

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -70,6 +70,7 @@ public:
    virtual void VisitVectorField(const RVectorField &field) { VisitField(field); }
    virtual void VisitVectorBoolField(const RField<std::vector<bool>> &field) { VisitField(field); }
    virtual void VisitRVecField(const RRVecField &field) { VisitField(field); }
+   virtual void VisitBLOBField(const RField<ROOT::Experimental::RNTupleBLOB> &field) { VisitField(field); }
 }; // class RFieldVisitor
 
 } // namespace Detail
@@ -223,6 +224,7 @@ public:
    void VisitNullableField(const RNullableField &field) final;
    void VisitEnumField(const REnumField &field) final;
    void VisitAtomicField(const RAtomicField &field) final;
+   void VisitBLOBField(const RField<ROOT::Experimental::RNTupleBLOB> &field) final;
 };
 
 

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -71,7 +71,6 @@ public:
    virtual void VisitVectorField(const RVectorField &field) { VisitField(field); }
    virtual void VisitVectorBoolField(const RField<std::vector<bool>> &field) { VisitField(field); }
    virtual void VisitRVecField(const RRVecField &field) { VisitField(field); }
-   virtual void VisitBLOBField(const RField<ROOT::Experimental::RNTupleBLOB> &field) { VisitField(field); }
 }; // class RFieldVisitor
 
 } // namespace Detail
@@ -226,7 +225,6 @@ public:
    void VisitNullableField(const RNullableField &field) final;
    void VisitEnumField(const REnumField &field) final;
    void VisitAtomicField(const RAtomicField &field) final;
-   void VisitBLOBField(const RField<ROOT::Experimental::RNTupleBLOB> &field) final;
 };
 
 

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -31,7 +31,7 @@ ROOT::Experimental::Detail::RColumnElementBase::Generate<void>(EColumnType type)
    case EColumnType::kIndex64: return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kIndex64>>();
    case EColumnType::kIndex32: return std::make_unique<RColumnElement<ClusterSize_t, EColumnType::kIndex32>>();
    case EColumnType::kSwitch: return std::make_unique<RColumnElement<RColumnSwitch, EColumnType::kSwitch>>();
-   case EColumnType::kByte: return std::make_unique<RColumnElement<std::uint8_t, EColumnType::kByte>>();
+   case EColumnType::kByte: return std::make_unique<RColumnElement<std::byte, EColumnType::kByte>>();
    case EColumnType::kChar: return std::make_unique<RColumnElement<char, EColumnType::kChar>>();
    case EColumnType::kBit: return std::make_unique<RColumnElement<bool, EColumnType::kBit>>();
    case EColumnType::kReal64: return std::make_unique<RColumnElement<double, EColumnType::kReal64>>();

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -187,6 +187,8 @@ std::string GetNormalizedTypeName(const std::string &typeName)
       normalizedType = "std::" + normalizedType;
    if (normalizedType.substr(0, 7) == "atomic<")
       normalizedType = "std::" + normalizedType;
+   if (normalizedType == "byte")
+      normalizedType = "std::byte";
 
    return normalizedType;
 }
@@ -372,6 +374,8 @@ ROOT::Experimental::Detail::RFieldBase::Create(const std::string &fieldName, con
       result = std::make_unique<RField<bool>>(fieldName);
    } else if (canonicalType == "char") {
       result = std::make_unique<RField<char>>(fieldName);
+   } else if (canonicalType == "std::byte") {
+      result = std::make_unique<RField<std::byte>>(fieldName);
    } else if (canonicalType == "std::int8_t") {
       result = std::make_unique<RField<std::int8_t>>(fieldName);
    } else if (canonicalType == "std::uint8_t") {
@@ -894,6 +898,31 @@ void ROOT::Experimental::RField<char>::GenerateColumnsImpl(const RNTupleDescript
 void ROOT::Experimental::RField<char>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitCharField(*this);
+}
+
+//------------------------------------------------------------------------------
+
+const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
+ROOT::Experimental::RField<std::byte>::GetColumnRepresentations() const
+{
+   static RColumnRepresentations representations({{EColumnType::kByte}}, {{}});
+   return representations;
+}
+
+void ROOT::Experimental::RField<std::byte>::GenerateColumnsImpl()
+{
+   fColumns.emplace_back(Detail::RColumn::Create<char>(RColumnModel(GetColumnRepresentative()[0]), 0));
+}
+
+void ROOT::Experimental::RField<std::byte>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
+{
+   auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
+   fColumns.emplace_back(Detail::RColumn::Create<char>(RColumnModel(onDiskTypes[0]), 0));
+}
+
+void ROOT::Experimental::RField<std::byte>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
+{
+   visitor.VisitByteField(*this);
 }
 
 //------------------------------------------------------------------------------

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -464,8 +464,6 @@ ROOT::Experimental::Detail::RFieldBase::Create(const std::string &fieldName, con
    } else if (canonicalType == ":Collection:") {
       // TODO: create an RCollectionField?
       result = std::make_unique<RField<ClusterSize_t>>(fieldName);
-   } else if (canonicalType == "ROOT::Experimental::RNTupleBLOB") {
-      result = std::make_unique<RField<ROOT::Experimental::RNTupleBLOB>>(fieldName);
    } else if (canonicalType.substr(0, 39) == "ROOT::Experimental::RNTupleCardinality<") {
       auto innerTypes = TokenizeTypeList(canonicalType.substr(39, canonicalType.length() - 40));
       if (innerTypes.size() != 1)
@@ -2985,69 +2983,6 @@ ROOT::Experimental::RCollectionField::CloneImpl(std::string_view newName) const
 void ROOT::Experimental::RCollectionField::CommitClusterImpl()
 {
    *fCollectionNTuple->GetOffsetPtr() = 0;
-}
-
-//------------------------------------------------------------------------------
-
-const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
-ROOT::Experimental::RField<ROOT::Experimental::RNTupleBLOB>::GetColumnRepresentations() const
-{
-   static RColumnRepresentations representations({{EColumnType::kSplitIndex64, EColumnType::kByte},
-                                                  {EColumnType::kIndex64, EColumnType::kByte},
-                                                  {EColumnType::kSplitIndex32, EColumnType::kByte},
-                                                  {EColumnType::kIndex32, EColumnType::kByte}},
-                                                 {});
-   return representations;
-}
-
-void ROOT::Experimental::RField<ROOT::Experimental::RNTupleBLOB>::GenerateColumnsImpl()
-{
-   fColumns.emplace_back(Detail::RColumn::Create<ClusterSize_t>(RColumnModel(GetColumnRepresentative()[0]), 0));
-   fColumns.emplace_back(Detail::RColumn::Create<unsigned char>(RColumnModel(GetColumnRepresentative()[1]), 1));
-}
-
-void ROOT::Experimental::RField<ROOT::Experimental::RNTupleBLOB>::GenerateColumnsImpl(const RNTupleDescriptor &desc)
-{
-   auto onDiskTypes = EnsureCompatibleColumnTypes(desc);
-   fColumns.emplace_back(Detail::RColumn::Create<ClusterSize_t>(RColumnModel(onDiskTypes[0]), 0));
-   fColumns.emplace_back(Detail::RColumn::Create<unsigned char>(RColumnModel(onDiskTypes[1]), 1));
-}
-
-void ROOT::Experimental::RField<ROOT::Experimental::RNTupleBLOB>::DestroyValue(void *objPtr, bool dtorOnly) const
-{
-   std::destroy_at(static_cast<ROOT::Experimental::RNTupleBLOB *>(objPtr));
-   Detail::RFieldBase::DestroyValue(objPtr, dtorOnly);
-}
-
-std::size_t ROOT::Experimental::RField<ROOT::Experimental::RNTupleBLOB>::AppendImpl(const void *from)
-{
-   auto typedValue = static_cast<const ROOT::Experimental::RNTupleBLOB *>(from);
-   auto size = typedValue->GetSize();
-   fColumns[1]->AppendV(typedValue->GetData().get(), size);
-   fIndex += size;
-   fColumns[0]->Append(&fIndex);
-   return size + fColumns[0]->GetElement()->GetPackedSize();
-}
-
-void ROOT::Experimental::RField<ROOT::Experimental::RNTupleBLOB>::ReadGlobalImpl(
-   ROOT::Experimental::NTupleSize_t globalIndex, void *to)
-{
-   auto typedValue = static_cast<ROOT::Experimental::RNTupleBLOB *>(to);
-   RClusterIndex collectionStart;
-   ClusterSize_t size;
-   fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &size);
-   if (size == 0) {
-      typedValue->Set(nullptr, 0);
-   } else {
-      auto data = std::shared_ptr<unsigned char[]>(new unsigned char[size]);
-      fColumns[1]->ReadV(collectionStart, size, data.get());
-      typedValue->Set(data, size);
-   }
-}
-
-void ROOT::Experimental::RField<ROOT::Experimental::RNTupleBLOB>::AcceptVisitor(Detail::RFieldVisitor &visitor) const
-{
-   visitor.VisitBLOBField(*this);
 }
 
 //------------------------------------------------------------------------------

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -234,13 +234,6 @@ void ROOT::Experimental::RPrintValueVisitor::VisitStringField(const RField<std::
    fOutput << "\"" << *fValue.Get<std::string>() << "\"";
 }
 
-void ROOT::Experimental::RPrintValueVisitor::VisitBLOBField(const RField<RNTupleBLOB> &field)
-{
-   PrintIndent();
-   PrintName(field);
-   fOutput << "\"BLOB\"";
-}
-
 void ROOT::Experimental::RPrintValueVisitor::VisitUInt8Field(const RField<std::uint8_t> &field)
 {
    PrintIndent();

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -223,6 +223,12 @@ void ROOT::Experimental::RPrintValueVisitor::VisitStringField(const RField<std::
    fOutput << "\"" << *fValue.Get<std::string>() << "\"";
 }
 
+void ROOT::Experimental::RPrintValueVisitor::VisitBLOBField(const RField<RNTupleBLOB> &field)
+{
+   PrintIndent();
+   PrintName(field);
+   fOutput << "\"BLOB\"";
+}
 
 void ROOT::Experimental::RPrintValueVisitor::VisitUInt8Field(const RField<std::uint8_t> &field)
 {

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -20,6 +20,7 @@
 #include <ROOT/RNTupleView.hxx>
 
 #include <cassert>
+#include <iomanip>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -178,6 +179,16 @@ void ROOT::Experimental::RPrintValueVisitor::VisitFloatField(const RField<float>
    PrintIndent();
    PrintName(field);
    fOutput << *fValue.Get<float>();
+}
+
+void ROOT::Experimental::RPrintValueVisitor::VisitByteField(const RField<std::byte> &field)
+{
+   PrintIndent();
+   PrintName(field);
+   char prev = std::cout.fill();
+   fOutput << "0x" << std::setw(2) << std::setfill('0') << std::hex << (*fValue.Get<unsigned char>() & 0xff);
+   fOutput << std::resetiosflags(std::ios_base::basefield);
+   std::cout.fill(prev);
 }
 
 void ROOT::Experimental::RPrintValueVisitor::VisitCharField(const RField<char> &field)

--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -43,6 +43,7 @@ endif()
 ROOT_ADD_GTEST(ntuple_view ntuple_view.cxx LIBRARIES ROOTNTuple CustomStruct)
 ROOT_ADD_GTEST(ntuple_zip ntuple_zip.cxx LIBRARIES ROOTNTuple CustomStruct)
 
+ROOT_ADD_GTEST(rfield_blob rfield_blob.cxx LIBRARIES ROOTNTuple)
 ROOT_ADD_GTEST(rfield_class rfield_class.cxx LIBRARIES ROOTNTuple CustomStruct)
 ROOT_ADD_GTEST(rfield_string rfield_string.cxx LIBRARIES ROOTNTuple CustomStruct)
 ROOT_ADD_GTEST(rfield_variant rfield_variant.cxx LIBRARIES ROOTNTuple CustomStruct)

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -4,6 +4,7 @@
 #include <RtypesCore.h> // for Double32_t
 #include <TRootIOCtor.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <set>
 #include <string>
@@ -30,6 +31,7 @@ struct CustomStruct {
    std::vector<float> v1;
    std::vector<std::vector<float>> v2;
    std::string s;
+   std::byte b{0};
 
    bool operator<(const CustomStruct &c) const { return a < c.a && v1 < c.v1 && v2 < c.v2 && s < c.s; }
 

--- a/tree/ntuple/v7/test/ntuple_show.cxx
+++ b/tree/ntuple/v7/test/ntuple_show.cxx
@@ -35,6 +35,7 @@ TEST(RNTupleShow, BasicTypes)
       auto model = RNTupleModel::Create();
       auto fieldPt = model->MakeField<float>("pt");
       auto fielddb = model->MakeField<double>("db");
+      auto fieldbyte = model->MakeField<std::byte>("byte");
       auto fieldint = model->MakeField<int>("int");
       auto fielduint = model->MakeField<unsigned>("uint");
       auto field64uint = model->MakeField<std::uint64_t>("uint64");
@@ -48,6 +49,7 @@ TEST(RNTupleShow, BasicTypes)
 
       *fieldPt = 5.0f;
       *fielddb = 9.99;
+      *fieldbyte = std::byte{137};
       *fieldint = -4;
       *fielduint = 3;
       *field64uint = 44444444444ull;
@@ -61,6 +63,7 @@ TEST(RNTupleShow, BasicTypes)
 
       *fieldPt = 8.5f;
       *fielddb = 9.998;
+      *fieldbyte = std::byte{42};
       *fieldint = -94;
       *fielduint = -30;
       *field64uint = 2299994967294ull;
@@ -82,6 +85,7 @@ TEST(RNTupleShow, BasicTypes)
       + "{\n"
       + "  \"pt\": 5,\n"
       + "  \"db\": 9.99,\n"
+      + "  \"byte\": 0x89,\n"
       + "  \"int\": -4,\n"
       + "  \"uint\": 3,\n"
       + "  \"uint64\": 44444444444,\n"
@@ -102,6 +106,7 @@ TEST(RNTupleShow, BasicTypes)
       + "{\n"
       + "  \"pt\": 8.5,\n"
       + "  \"db\": 9.998,\n"
+      + "  \"byte\": 0x2a,\n"
       + "  \"int\": -94,\n"
       + "  \"uint\": 4294967266,\n"
       + "  \"uint64\": 2299994967294,\n"
@@ -295,22 +300,24 @@ TEST(RNTupleShow, Objects)
       + "    \"a\": 4.1,\n"
       + "    \"v1\": [0.1, 0.2, 0.3],\n"
       + "    \"v2\": [[1.1, 1.2, 1.3], [2.1, 2.2, 2.3]],\n"
-      + "    \"s\": \"Example1String\"\n"
+      + "    \"s\": \"Example1String\",\n"
+      + "    \"b\": 0x00\n"
       + "  },\n"
       + "  \"CustomStructVec\": [{\"a\": 4.2, \"v1\": [0.1, 0.2, 0.3], \"v2\": [[1.1, 1.3], [2.1, 2.2, 2.3]], "
-      +      "\"s\": \"Example2String\"}, {\"a\": 4.3, \"v1\": [0.1, 0.2, 0.3], "
-      +      "\"v2\": [[1.1, 1.2, 1.3], [2.1, 2.3]], \"s\": \"Example3String\"}, "
+      +      "\"s\": \"Example2String\", \"b\": 0x00}, {\"a\": 4.3, \"v1\": [0.1, 0.2, 0.3], "
+      +      "\"v2\": [[1.1, 1.2, 1.3], [2.1, 2.3]], \"s\": \"Example3String\", \"b\": 0x00}, "
       +      "{\"a\": 4.4, \"v1\": [0.1, 0.3], \"v2\": [[1.1, 1.2, 1.3], [2.1, 2.2, 2.3]], "
-      +      "\"s\": \"Example4String\"}],\n"
+      +      "\"s\": \"Example4String\", \"b\": 0x00}],\n"
       + "  \"CustomStructArray\": [{\"a\": 4.5, \"v1\": [0.1, 0.2, 0.3], \"v2\": [[1.1, 1.3], [2.1, 2.2, 2.3]], "
-      +      "\"s\": \"AnotherString1\"}, {\"a\": 4.6, \"v1\": [0.1, 0.2, 0.3], "
-      +      "\"v2\": [[1.1, 1.2, 1.3], [2.1, 2.3]], \"s\": \"AnotherString2\"}],\n"
+      +      "\"s\": \"AnotherString1\", \"b\": 0x00}, {\"a\": 4.6, \"v1\": [0.1, 0.2, 0.3], "
+      +      "\"v2\": [[1.1, 1.2, 1.3], [2.1, 2.3]], \"s\": \"AnotherString2\", \"b\": 0x00}],\n"
       + "  \"DerivedA\": {\n"
       + "    \":_0\": {\n"
       + "      \"a\": 0,\n"
       + "      \"v1\": [],\n"
       + "      \"v2\": [],\n"
-      + "      \"s\": \"\"\n"
+      + "      \"s\": \"\",\n"
+      + "      \"b\": 0x00\n"
       + "    },\n"
       + "    \"a_v\": [],\n"
       + "    \"a_s\": \"\"\n"
@@ -404,8 +411,8 @@ TEST(RNTupleShow, RVec)
       + "{\n"
       + "  \"intVec\": [1, 2, 3],\n"
       + "  \"floatVecVec\": [[0.1, 0.2], [1.1, 1.2]],\n"
-      + "  \"customStructVec\": [{\"a\": 0, \"v1\": [], \"v2\": [], \"s\": \"\"},"
-      + " {\"a\": 1, \"v1\": [2, 3], \"v2\": [[4], [5]], \"s\": \"foo\"}]\n"
+      + "  \"customStructVec\": [{\"a\": 0, \"v1\": [], \"v2\": [], \"s\": \"\", \"b\": 0x00},"
+      + " {\"a\": 1, \"v1\": [2, 3], \"v2\": [[4], [5]], \"s\": \"foo\", \"b\": 0x00}]\n"
       + "}\n"};
    // clang-format on
    EXPECT_EQ(os.str(), expected1);
@@ -417,9 +424,9 @@ TEST(RNTupleShow, RVec)
       + "{\n"
       + "  \"intVec\": [1, 2, 3, 4],\n"
       + "  \"floatVecVec\": [[0.1, 0.2], [1.1, 1.2], [2.1, 2.2]],\n"
-      + "  \"customStructVec\": [{\"a\": 0, \"v1\": [], \"v2\": [], \"s\": \"\"},"
-      + " {\"a\": 1, \"v1\": [2, 3], \"v2\": [[4], [5]], \"s\": \"foo\"},"
-      + " {\"a\": 6, \"v1\": [7, 8], \"v2\": [[9], [10]], \"s\": \"bar\"}]\n"
+      + "  \"customStructVec\": [{\"a\": 0, \"v1\": [], \"v2\": [], \"s\": \"\", \"b\": 0x00},"
+      + " {\"a\": 1, \"v1\": [2, 3], \"v2\": [[4], [5]], \"s\": \"foo\", \"b\": 0x00},"
+      + " {\"a\": 6, \"v1\": [7, 8], \"v2\": [[9], [10]], \"s\": \"bar\", \"b\": 0x00}]\n"
       + "}\n"};
    // clang-format on
    EXPECT_EQ(os2.str(), expected2);
@@ -471,8 +478,8 @@ TEST(RNTupleShow, RVecTypeErased)
       + "{\n"
       + "  \"intVec\": [1, 2, 3],\n"
       + "  \"floatVecVec\": [[0.1, 0.2], [1.1, 1.2]],\n"
-      + "  \"customStructVec\": [{\"a\": 0, \"v1\": [], \"v2\": [], \"s\": \"\"},"
-      + " {\"a\": 1, \"v1\": [2, 3], \"v2\": [[4], [5]], \"s\": \"foo\"}]\n"
+      + "  \"customStructVec\": [{\"a\": 0, \"v1\": [], \"v2\": [], \"s\": \"\", \"b\": 0x00},"
+      + " {\"a\": 1, \"v1\": [2, 3], \"v2\": [[4], [5]], \"s\": \"foo\", \"b\": 0x00}]\n"
       + "}\n"};
    // clang-format on
    EXPECT_EQ(fString, os.str());
@@ -484,9 +491,9 @@ TEST(RNTupleShow, RVecTypeErased)
       + "{\n"
       + "  \"intVec\": [1, 2, 3, 4],\n"
       + "  \"floatVecVec\": [[0.1, 0.2], [1.1, 1.2], [2.1, 2.2]],\n"
-      + "  \"customStructVec\": [{\"a\": 0, \"v1\": [], \"v2\": [], \"s\": \"\"},"
-      + " {\"a\": 1, \"v1\": [2, 3], \"v2\": [[4], [5]], \"s\": \"foo\"},"
-      + " {\"a\": 6, \"v1\": [7, 8], \"v2\": [[9], [10]], \"s\": \"bar\"}]\n"
+      + "  \"customStructVec\": [{\"a\": 0, \"v1\": [], \"v2\": [], \"s\": \"\", \"b\": 0x00},"
+      + " {\"a\": 1, \"v1\": [2, 3], \"v2\": [[4], [5]], \"s\": \"foo\", \"b\": 0x00},"
+      + " {\"a\": 6, \"v1\": [7, 8], \"v2\": [[9], [10]], \"s\": \"bar\", \"b\": 0x00}]\n"
       + "}\n"};
    // clang-format off
    EXPECT_EQ(fString1, os1.str());

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -550,6 +550,27 @@ TEST(RNTuple, Char)
    ASSERT_EQ("char", charTField.GetType());
 }
 
+TEST(RNTuple, Byte)
+{
+   FileRaii fileGuard("ntuple_test_byte.root");
+
+   auto byteField = RField<std::byte>("myByte");
+   auto otherField = RFieldBase::Create("test", "std::byte").Unwrap();
+   ASSERT_EQ("std::byte", otherField->GetType());
+
+   {
+      auto model = RNTupleModel::Create();
+      auto f = model->MakeField<std::byte>("b", std::byte{137});
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
+      writer->Fill();
+   }
+
+   auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
+   EXPECT_EQ(1u, reader->GetNEntries());
+   reader->LoadEntry(0);
+   EXPECT_EQ(std::byte{137}, *reader->GetModel()->GetDefaultEntry()->Get<std::byte>("b"));
+}
+
 TEST(RNTuple, Int8_t)
 {
    auto field = RField<std::int8_t>("myInt8");

--- a/tree/ntuple/v7/test/rfield_blob.cxx
+++ b/tree/ntuple/v7/test/rfield_blob.cxx
@@ -1,0 +1,33 @@
+#include "ntuple_test.hxx"
+
+#include <TMemFile.h>
+
+TEST(RField, Blob)
+{
+   FileRaii fileGuard("test_ntuple_rfield_blob.root");
+
+   {
+      auto model = RNTupleModel::Create();
+      auto ptrBlob = model->MakeField<ROOT::Experimental::RNTupleBLOB>("blob");
+      auto writer = RNTupleWriter::Recreate(std::move(model), "f", fileGuard.GetPath());
+
+      TMemFile f("buffer", "CREATE");
+      std::string str = "x";
+      f.WriteObject(&str, "string");
+      f.Close();
+      auto data = std::shared_ptr<unsigned char[]>(new unsigned char[f.GetSize()]);
+      f.CopyTo(data.get(), f.GetSize());
+      ptrBlob->Set(data, f.GetSize());
+
+      writer->Fill();
+   }
+
+   auto reader = RNTupleReader::Open("f", fileGuard.GetPath());
+   ASSERT_EQ(1U, reader->GetNEntries());
+   reader->LoadEntry(0);
+   auto ptrBlob = reader->GetModel()->GetDefaultEntry()->Get<ROOT::Experimental::RNTupleBLOB>("blob");
+   TMemFile f("buffer",
+              TMemFile::ZeroCopyView_t(reinterpret_cast<char *>(ptrBlob->GetData().get()), ptrBlob->GetSize()));
+   auto str = f.Get<std::string>("string");
+   EXPECT_EQ("x", *str);
+}


### PR DESCRIPTION
# This Pull request:

Adds support for the `std::byte` type. Vectors of bytes can be used to represent BLOBs in RNTuple. The unit test shows an example where a `TMemFile` is stored in such a vector. A follow-up PR should provide a convenient interface to store BLOBs.

## Checklist:

- [X] tested changes locally
- [X] updated the docs (if necessary)

