### PR TITLE
Backport in 6.28 fixes in pymva to avoid timeout in keras tests

### DIFF
--- a/tmva/pymva/src/PyMethodBase.cxx
+++ b/tmva/pymva/src/PyMethodBase.cxx
@@ -120,6 +120,8 @@ PyMethodBase::PyMethodBase(Types::EMVA methodType,
 PyMethodBase::~PyMethodBase()
 {
    // should we delete here fLocalNS ?
+   //PyFinalize();
+   if (fLocalNS) Py_DECREF(fLocalNS);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -321,6 +323,7 @@ Int_t PyMethodBase::UnSerialize(TString path, PyObject **obj)
 /// Py_single_input, Py_file_input)
 
 void PyMethodBase::PyRunString(TString code, TString errorMessage, int start) {
+   //std::cout << "Run: >> " << code << std::endl;
    fPyReturn = PyRun_String(code, start, fGlobalNS, fLocalNS);
    if (!fPyReturn) {
       Log() << kWARNING << "Failed to run python code: " << code << Endl;
@@ -397,7 +400,7 @@ std::vector<size_t> PyMethodBase::GetDataFromList(PyObject* listObject){
 }
 
 //////////////////////////////////////////////////////////////////////////////////
-/// \brief Utility function which checks if a given key is present in a Python 
+/// \brief Utility function which checks if a given key is present in a Python
 ///        dictionary object and returns the associated value or throws runtime
 ///        error. This is to replace PyDict_GetItemWithError in Python 2.
 ///

--- a/tmva/tmva/src/DataSetInfo.cxx
+++ b/tmva/tmva/src/DataSetInfo.cxx
@@ -85,10 +85,10 @@ TMVA::DataSetInfo::~DataSetInfo()
    ClearDataSet();
 
    for(UInt_t i=0, iEnd = fClasses.size(); i<iEnd; ++i) {
-      delete fClasses[i];
+      if (fClasses[i]) delete fClasses[i];
    }
 
-   delete fTargetsForMulticlass;
+   if (fTargetsForMulticlass) delete fTargetsForMulticlass;
 
    delete fLogger;
 }
@@ -97,7 +97,7 @@ TMVA::DataSetInfo::~DataSetInfo()
 
 void TMVA::DataSetInfo::ClearDataSet() const
 {
-   if(fDataSet!=0) { delete fDataSet; fDataSet=0; }
+   if(fDataSet) { delete fDataSet; fDataSet=nullptr; }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/src/MethodBase.cxx
+++ b/tmva/tmva/src/MethodBase.cxx
@@ -364,7 +364,7 @@ TMVA::MethodBase::MethodBase( Types::EMVA methodType,
 TMVA::MethodBase::~MethodBase( void )
 {
    // destructor
-   if (!fSetupCompleted) Log() << kFATAL <<Form("Dataset[%s] : ",DataInfo().GetName())<< "Calling destructor of method which got never setup" << Endl;
+   if (!fSetupCompleted) Log() << kWARNING <<Form("Dataset[%s] : ",DataInfo().GetName())<< "Calling destructor of method which got never setup" << Endl;
 
    // destructor
    if (fInputVars != 0)  { fInputVars->clear(); delete fInputVars; }
@@ -385,14 +385,14 @@ TMVA::MethodBase::~MethodBase( void )
    if (fSplTrainRefB)    { delete fSplTrainRefB; fSplTrainRefB = 0; }
    if (fSplTrainEffBvsS) { delete fSplTrainEffBvsS; fSplTrainEffBvsS = 0; }
 
-   for (Int_t i = 0; i < 2; i++ ) {
+   for (size_t i = 0; i < fEventCollections.size(); i++ ) {
       if (fEventCollections.at(i)) {
          for (std::vector<Event*>::const_iterator it = fEventCollections.at(i)->begin();
               it != fEventCollections.at(i)->end(); ++it) {
             delete (*it);
          }
          delete fEventCollections.at(i);
-         fEventCollections.at(i) = 0;
+         fEventCollections.at(i) = nullptr;
       }
    }
 


### PR DESCRIPTION

This PR fixes backports the fix to keep eager execution on macOS to avoid multi-processing issue that gives timeout of tests

