### PR TITLE
[RF][HF] Clearly mark interpolation code 3 as unknown

### DIFF
--- a/roofit/histfactory/inc/RooStats/HistFactory/FlexibleInterpVar.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/FlexibleInterpVar.h
@@ -71,6 +71,10 @@ namespace HistFactory{
 
     double evaluate() const override;
 
+  private:
+
+    void setInterpCodeForParam(int iParam, int code);
+
     ClassDefOverride(RooStats::HistFactory::FlexibleInterpVar,2); // flexible interpolation
   };
 }

--- a/roofit/histfactory/inc/RooStats/HistFactory/PiecewiseInterpolation.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/PiecewiseInterpolation.h
@@ -61,7 +61,7 @@ public:
   void setPositiveDefinite(bool flag=true){_positiveDefinite=flag;}
   bool positiveDefinite() const {return _positiveDefinite;}
 
-  void setInterpCode(RooAbsReal& param, int code, bool silent=false);
+  void setInterpCode(RooAbsReal& param, int code, bool silent=true);
   void setAllInterpCodes(int code);
   void printAllInterpCodes();
 
@@ -101,6 +101,10 @@ protected:
 
   double evaluate() const override;
   void doEval(RooFit::EvalContext &) const override;
+
+private:
+
+  void setInterpCodeForParam(int iParam, int code);
 
   ClassDefOverride(PiecewiseInterpolation,4) // Sum of RooAbsReal objects
 };

--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -603,7 +603,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
        assert(lowVec.size() == params.size());
 
        FlexibleInterpVar interp( (interpName).c_str(), "", params, 1., lowVec, highVec);
-       interp.setAllInterpCodes(4); // LM: change to 4 (piece-wise linear to 6th order polynomial interpolation + linear extrapolation )
+       interp.setAllInterpCodes(4); // LM: change to 4 (piece-wise exponential to 6th order polynomial interpolation + exponential extrapolation )
        //interp.setAllInterpCodes(0); // simple linear interpolation
        proto.import(interp); // params have already been imported in first loop of this function
     } else{

--- a/roofit/roofitcore/inc/RooFit/Detail/MathFuncs.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/MathFuncs.h
@@ -239,18 +239,10 @@ inline double flexibleInterpSingle(unsigned int code, double low, double high, d
       } else {
          return a * std::pow(paramVal, 2) + b * paramVal + c;
       }
-   } else if (code == 3) {
-      // parabolic version of log-normal
-      double a = 0.5 * (high + low) - nominal;
-      double b = 0.5 * (high - low);
-      double c = 0;
-      if (paramVal > 1) {
-         return (2 * a + b) * (paramVal - 1) + high - nominal;
-      } else if (paramVal < -1) {
-         return -1 * (2 * a - b) * (paramVal + 1) + low - nominal;
-      } else {
-         return a * std::pow(paramVal, 2) + b * paramVal + c;
-      }
+   // According to an old comment in the source code, code 3 was apparently
+   // meant to be a "parabolic version of log-normal", but it never got
+   // implemented. If someone would need it, it could be implemented as doing
+   // code 2 in log space.
    } else if (code == 4) {
       double x = paramVal;
       if (x >= boundary) {


### PR DESCRIPTION
As noted in GitHub issue #7103, the interpolation code 3 is the same as code 2 in the `FlexibleInterpVar` and the `PiecewiseInterpolation` classes.

According to some comments in the source code, interpolation code 3 was meant to be "a parabolic version of log-normal".

There were two options to fix this:

1) Actually implement this parabolic interpolation with linear
   extrapolation, analogous to code 2 but in log space.

2) Clearly mark interpolation code 3 as non-existing.

This commit implements solution 2, because the interpolation code 3 is not mentioned anywhere outside the ROOT source code. Especially not is the HistFactory paper:
https://cds.cern.ch/record/1456844/files/CERN-OPEN-2012-016.pdf

Implementing a new interpolation scheme that apparently was not needed in the last 10 years anyway would increase the burden on the user to understand all these different settings unnecessarily.

Closes #7103.

