### PR TITLE
[HS3][RF] Hotfixes

### DIFF
--- a/roofit/histfactory/CMakeLists.txt
+++ b/roofit/histfactory/CMakeLists.txt
@@ -52,8 +52,9 @@ ROOT_STANDARD_LIBRARY_PACKAGE(HistFactory
     src/HistFactoryImpl.cxx
     src/HistFactoryModelUtils.cxx
     src/HistFactoryNavigation.cxx
-    src/HistoToWorkspaceFactoryFast.cxx
     src/HistRef.cxx
+    src/HistoToWorkspaceFactoryFast.cxx
+    src/JSONTool.cxx
     src/LinInterpVar.cxx
     src/MakeModelAndMeasurementsFast.cxx
     src/Measurement.cxx
@@ -80,6 +81,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(HistFactory
     Graf
     Gpad
     RooStats
+    RooFitJSONInterface
   ${EXTRA_DICT_OPTS}
 )
 

--- a/roofit/histfactory/src/JSONTool.h
+++ b/roofit/histfactory/src/JSONTool.h
@@ -1,17 +1,19 @@
+/// \cond ROOFIT_INTERNAL
+
 /*
  * Project: RooFit
  * Authors:
  *   Carsten D. Burgard, DESY/ATLAS, Dec 2021
  *
- * Copyright (c) 2022, CERN
+ * Copyright (c) 2023, CERN
  *
  * Redistribution and use in source and binary forms,
  * with or without modification, are permitted according to the terms
  * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
  */
 
-#ifndef RooFitHS3_HistFactoryJSONTool_h
-#define RooFitHS3_HistFactoryJSONTool_h
+#ifndef RooStats_HistFactory_JSONTool_h
+#define RooStats_HistFactory_JSONTool_h
 
 #include <iostream>
 #include <string>
@@ -46,3 +48,5 @@ private:
 } // namespace RooStats
 
 #endif
+
+/// \endcond

--- a/roofit/histfactory/test/testHistFactory.cxx
+++ b/roofit/histfactory/test/testHistFactory.cxx
@@ -9,7 +9,6 @@
 
 #include <RooFitHS3/JSONIO.h>
 #include <RooFitHS3/RooJSONFactoryWSTool.h>
-#include <RooFitHS3/HistFactoryJSONTool.h>
 
 #include <RooFit/Detail/NormalizationHelpers.h>
 #include <RooDataHist.h>
@@ -27,6 +26,8 @@
 #include <TFile.h>
 #include <TCanvas.h>
 #include <gtest/gtest.h>
+
+#include "../src/JSONTool.h"
 
 // Backward compatibility for gtest version < 1.10.0
 #ifndef INSTANTIATE_TEST_SUITE_P

--- a/roofit/hs3/CMakeLists.txt
+++ b/roofit/hs3/CMakeLists.txt
@@ -13,12 +13,10 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitHS3
   HEADERS
     RooFitHS3/JSONIO.h
     RooFitHS3/RooJSONFactoryWSTool.h
-    RooFitHS3/HistFactoryJSONTool.h
   SOURCES
     src/Domains.cxx
     src/JSONIO.cxx
     src/RooJSONFactoryWSTool.cxx
-    src/HistFactoryJSONTool.cxx
     src/JSONFactories_RooFitCore.cxx
     src/JSONFactories_HistFactory.cxx
     src/JSONIOUtils.cxx

--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -177,7 +177,7 @@ public:
 
    static void exportArray(std::size_t n, double const *contents, RooFit::Detail::JSONNode &output);
 
-   static void exportCategory(RooAbsCategory const &cat, RooFit::Detail::JSONNode &node);
+   void exportCategory(RooAbsCategory const &cat, RooFit::Detail::JSONNode &node);
 
    void queueExport(RooAbsArg const &arg) { _serversToExport.push_back(&arg); }
 

--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -53,7 +53,7 @@ public:
    static RooFit::Detail::JSONNode &appendNamedChild(RooFit::Detail::JSONNode &node, std::string const &name);
    static RooFit::Detail::JSONNode const *findNamedChild(RooFit::Detail::JSONNode const &node, std::string const &name);
 
-   static void fillSeq(RooFit::Detail::JSONNode &node, RooAbsCollection const &coll);
+   static void fillSeq(RooFit::Detail::JSONNode &node, RooAbsCollection const &coll, size_t nMax = -1);
 
    template <class T>
    T *request(const std::string &objname, const std::string &requestAuthor)

--- a/roofit/hs3/src/JSONFactories_HistFactory.cxx
+++ b/roofit/hs3/src/JSONFactories_HistFactory.cxx
@@ -10,7 +10,6 @@
  * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
  */
 
-#include <RooFitHS3/HistFactoryJSONTool.h>
 #include <RooFitHS3/RooJSONFactoryWSTool.h>
 #include <RooFitHS3/JSONIO.h>
 #include <RooFit/Detail/JSONInterface.h>

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -51,18 +51,18 @@ exporting to and importing from JSON and YML.
 
 In order to import a workspace from a JSON file, you can do
 
-~~ {.py}
+~~~ {.py}
 ws = ROOT.RooWorkspace("ws")
 tool = ROOT.RooJSONFactoryWSTool(ws)
 tool.importJSON("myjson.json")
-~~
+~~~
 
 Similarly, in order to export a workspace to a JSON file, you can do
 
-~~ {.py}
+~~~ {.py}
 tool = ROOT.RooJSONFactoryWSTool(ws)
 tool.exportJSON("myjson.json")
-~~
+~~~
 
 For more details, consult the tutorial <a
 href="https://root.cern/doc/v626/rf515__hfJSON_8py.html">rf515_hfJSON</a>.
@@ -70,8 +70,7 @@ href="https://root.cern/doc/v626/rf515__hfJSON_8py.html">rf515_hfJSON</a>.
 In order to import and export YML files, `ROOT` needs to be compiled
 with the external dependency <a
 href="https://github.com/biojppm/rapidyaml">RapidYAML</a>, which needs
-to be installed on your system and enabled via the CMake option
-`roofit_hs3_ryml`.
+to be installed on your system when building `ROOT`.
 
 The RooJSONFactoryWSTool only knows about a limited set of classes for
 import and export. If import or export of a class you're interested in
@@ -81,18 +80,18 @@ href="https://github.com/root-project/root/blob/master/roofit/hs3/README.md">REA
 to learn how to do that.
 
 You can always get a list of all the available importers and exporters by calling the following functions:
-~~ {.py}
+~~~ {.py}
 ROOT.RooFit.JSONIO.printImporters()
 ROOT.RooFit.JSONIO.printExporters()
 ROOT.RooFit.JSONIO.printFactoryExpressions()
 ROOT.RooFit.JSONIO.printExportKeys()
-~~
+~~~
 
 Alternatively, you can generate a LaTeX version of the available importers and exporters by calling
-~~ {.py}
+~~~ {.py}
 tool = ROOT.RooJSONFactoryWSTool(ws)
 tool.writedoc("hs3.tex")
-~~
+~~~
 
 */
 

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -1121,11 +1121,12 @@ void RooJSONFactoryWSTool::exportObject(RooAbsArg const &func, std::set<std::str
       if (auto l = dynamic_cast<RooListProxy *>(p)) {
          fillSeq(elem[k->second], *l);
       }
-      if (auto r = dynamic_cast<RooRealProxy *>(p)) {
-         if (isLiteralConstVar(r->arg()))
-            elem[k->second] << r->arg().getVal();
+      if (auto r = dynamic_cast<RooArgProxy *>(p)) {
+         std::cout << "writing single proxy " << r->GetName() << std::endl;
+         if (isLiteralConstVar(*r->absArg()))
+            elem[k->second] << static_cast<RooConstVar *>(r->absArg())->getVal();
          else
-            elem[k->second] << r->arg().GetName();
+            elem[k->second] << r->absArg()->GetName();
       }
    }
 

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -776,15 +776,22 @@ RooJSONFactoryWSTool::RooJSONFactoryWSTool(RooWorkspace &ws) : _workspace{ws} {}
 
 RooJSONFactoryWSTool::~RooJSONFactoryWSTool() {}
 
-void RooJSONFactoryWSTool::fillSeq(JSONNode &node, RooAbsCollection const &coll)
+void RooJSONFactoryWSTool::fillSeq(JSONNode &node, RooAbsCollection const &coll, size_t nMax)
 {
-   node.set_seq();
-   for (RooAbsArg const *arg : coll) {
-      if (isLiteralConstVar(*arg))
-         node.append_child() << static_cast<RooConstVar const *>(arg)->getVal();
-      else
-         node.append_child() << arg->GetName();
-   }
+  const size_t old_children = node.num_children();
+  node.set_seq();
+  size_t n = 0;
+  for (RooAbsArg const *arg : coll) {
+    if(n>=nMax) break;
+    if (isLiteralConstVar(*arg))
+      node.append_child() << static_cast<RooConstVar const *>(arg)->getVal();
+    else
+      node.append_child() << arg->GetName();
+    ++n;
+  }
+  if(node.num_children() != old_children + coll.size()){
+    error("unable to stream collection " + std::string(coll.GetName()) + " to " + node.key());
+  }
 }
 
 JSONNode &RooJSONFactoryWSTool::appendNamedChild(JSONNode &node, std::string const &name)

--- a/roofit/hs3/test/testRooFitHS3.cxx
+++ b/roofit/hs3/test/testRooFitHS3.cxx
@@ -211,6 +211,12 @@ TEST(RooFitHS3, RooGaussian)
    EXPECT_EQ(status, 0);
 }
 
+TEST(RooFitHS3, RooBernstein)
+{
+   int status = validate({"RooBernstein::bernstein(x[0, 10], { a[1], 3, b[5, 0, 20] })"});
+   EXPECT_EQ(status, 0);
+}
+
 TEST(RooFitHS3, RooGenericPdf)
 {
    // To silence the numeric integration

--- a/roofit/jsoninterface/inc/RooFit/Detail/JSONInterface.h
+++ b/roofit/jsoninterface/inc/RooFit/Detail/JSONInterface.h
@@ -131,6 +131,19 @@ public:
       }
    }
 
+   template <typename Collection>
+   void fill_seq(Collection const &coll, size_t nmax)
+   {
+      set_seq();
+      size_t n = 0;
+      for (auto const &item : coll) {
+         if (n >= nmax)
+            break;
+         append_child() << item;
+         ++n;
+      }
+   }
+
    template <typename Collection, typename TransformationFunc>
    void fill_seq(Collection const &coll, TransformationFunc func)
    {

--- a/roofit/roofit/src/RooParamHistFunc.cxx
+++ b/roofit/roofit/src/RooParamHistFunc.cxx
@@ -23,7 +23,7 @@
 #include "RooParamHistFunc.h"
 #include "RooAbsCategory.h"
 #include "RooRealVar.h"
-#include "RooHelpers.h"
+#include "RooFitImplHelpers.h"
 #include <cmath>
 #include "TMath.h"
 

--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -32,23 +32,15 @@ endif()
 
 ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
   HEADERS
-    RooFit/Config.h
-    RooFit/Detail/AnalyticalIntegrals.h
-    RooFit/Detail/EvaluateFuncs.h
-    RooFit/Detail/CodeSquashContext.h
-    RooFit/Detail/DataMap.h
-    RooFit/Detail/NormalizationHelpers.h
-    RooFit/Evaluator.h
-    RooFit/Floats.h
-    RooFit/ModelConfig.h
     Roo1DTable.h
+    RooAICRegistry.h
     RooAbsAnaConvPdf.h
     RooAbsArg.h
     RooAbsBinning.h
+    RooAbsCache.h
+    RooAbsCacheElement.h
     RooAbsCachedPdf.h
     RooAbsCachedReal.h
-    RooAbsCacheElement.h
-    RooAbsCache.h
     RooAbsCategory.h
     RooAbsCategoryLValue.h
     RooAbsCollection.h
@@ -72,21 +64,22 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     RooAbsTestStatistic.h
     RooAdaptiveIntegratorND.h
     RooAddGenContext.h
-    RooAddition.h
     RooAddModel.h
     RooAddPdf.h
-    RooAICRegistry.h
+    RooAddition.h
     RooArgList.h
     RooArgProxy.h
     RooArgSet.h
     RooBinIntegrator.h
+    RooBinSamplingPdf.h
+    RooBinWidthFunction.h
     RooBinnedGenContext.h
-    RooBinningCategory.h
     RooBinning.h
+    RooBinningCategory.h
     RooBrentRootFinder.h
+    RooCacheManager.h
     RooCachedPdf.h
     RooCachedReal.h
-    RooCacheManager.h
     RooCategory.h
     RooCategoryProxy.h
     RooChangeTracker.h
@@ -96,82 +89,102 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     RooCmdConfig.h
     RooCollectionProxy.h
     RooCompositeDataStore.h
-    RooConstraintSum.h
     RooConstVar.h
+    RooConstraintSum.h
     RooConvCoefVar.h
     RooConvGenContext.h
     RooCurve.h
     RooCustomizer.h
+    RooDLLSignificanceMCSModule.h
     RooDataHist.h
     RooDataHistSliceIter.h
     RooDataProjBinding.h
     RooDataSet.h
     RooDerivative.h
     RooDirItem.h
-    RooDLLSignificanceMCSModule.h
     RooDouble.h
     RooEffGenContext.h
-    RooEfficiency.h
     RooEffProd.h
+    RooEfficiency.h
     RooEllipse.h
     RooErrorHandler.h
     RooErrorVar.h
     RooExpensiveObjectCache.h
+    RooExtendPdf.h
     RooExtendedBinding.h
     RooExtendedTerm.h
-    RooExtendPdf.h
-    RooFactoryWSTool.h
     RooFFTConvPdf.h
+    RooFactoryWSTool.h
     RooFirstMoment.h
     RooFit.h
+    RooFit/Config.h
+    RooFit/Detail/AnalyticalIntegrals.h
+    RooFit/Detail/CodeSquashContext.h
+    RooFit/Detail/DataMap.h
+    RooFit/Detail/EvaluateFuncs.h
+    RooFit/Detail/NormalizationHelpers.h
+    RooFit/Evaluator.h
+    RooFit/Floats.h
+    RooFit/ModelConfig.h
+    RooFit/TestStatistics/LikelihoodGradientWrapper.h
+    RooFit/TestStatistics/LikelihoodWrapper.h
+    RooFit/TestStatistics/RooAbsL.h
+    RooFit/TestStatistics/RooBinnedL.h
+    RooFit/TestStatistics/RooRealL.h
+    RooFit/TestStatistics/RooSubsidiaryL.h
+    RooFit/TestStatistics/RooSumL.h
+    RooFit/TestStatistics/RooUnbinnedL.h
+    RooFit/TestStatistics/buildLikelihood.h
+    RooFitLegacy/RooCatTypeLegacy.h
+    RooFitLegacy/RooCategorySharedProperties.h
+    RooFitLegacy/RooTreeData.h
     RooFitResult.h
     RooFormulaVar.h
     RooFracRemainder.h
-    RooFunctor.h
     RooFuncWrapper.h
+    RooFunctor.h
     RooGenContext.h
-    RooGenericPdf.h
     RooGenFitStudy.h
+    RooGenericPdf.h
     RooGlobalFunc.h
     RooGrid.h
+    RooHist.h
     RooHistError.h
     RooHistFunc.h
-    RooHist.h
     RooHistPdf.h
     RooImproperIntegrator1D.h
-    RooRombergIntegrator.h
     RooInvTransform.h
+    RooLinTransBinning.h
     RooLinearCombination.h
     RooLinearVar.h
-    RooLinkedListElem.h
     RooLinkedList.h
+    RooLinkedListElem.h
     RooLinkedListIter.h
-    RooLinTransBinning.h
     RooListProxy.h
-    RooMath.h
-    RooMappedCategory.h
     RooMCIntegrator.h
     RooMCStudy.h
+    RooMappedCategory.h
+    RooMath.h
     RooMinimizer.h
     RooMoment.h
     RooMsgService.h
     RooMultiCategory.h
     RooMultiVarGaussian.h
-    RooNameReg.h
     RooNLLVar.h
+    RooNameReg.h
     RooNormSetCache.h
-    RooNumber.h
     RooNumCdf.h
-    RooNumConvolution.h
     RooNumConvPdf.h
+    RooNumConvolution.h
     RooNumGenConfig.h
     RooNumIntConfig.h
     RooNumIntFactory.h
     RooNumRunningInt.h
+    RooNumber.h
     RooObjCacheManager.h
     RooParamBinning.h
-    RooPlotable.h
     RooPlot.h
+    RooPlotable.h
     RooPolyFunc.h
     RooPolyVar.h
     RooPrintable.h
@@ -183,16 +196,15 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     RooProofDriverSelector.h
     RooPullVar.h
     RooQuasiRandomGenerator.h
-    RooRatio.h
     RooRandom.h
     RooRandomizeParamMCSModule.h
     RooRangeBinning.h
     RooRangeBoolean.h
+    RooRatio.h
     RooRealBinding.h
     RooRealConstant.h
     RooRealIntegral.h
     RooRealMPFE.h
-    RooTemplateProxy.h
     RooRealProxy.h
     RooRealSumFunc.h
     RooRealSumPdf.h
@@ -200,24 +212,26 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     RooRealVarSharedProperties.h
     RooRecursiveFraction.h
     RooRefCountList.h
-    RooSTLRefCountList.h
     RooResolutionModel.h
+    RooRombergIntegrator.h
+    RooSTLRefCountList.h
     RooSecondMoment.h
     RooSetProxy.h
     RooSharedProperties.h
     RooSimGenContext.h
     RooSimSplitGenContext.h
-    RooSimultaneous.h
     RooSimWSTool.h
+    RooSimultaneous.h
     RooStreamParser.h
     RooStringVar.h
     RooStringView.h
     RooStudyManager.h
     RooStudyPackage.h
     RooSuperCategory.h
-    RooTable.h
-    RooThresholdCategory.h
     RooTObjWrap.h
+    RooTable.h
+    RooTemplateProxy.h
+    RooThresholdCategory.h
     RooTrace.h
     RooTreeDataStore.h
     RooTruthModel.h
@@ -226,41 +240,28 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     RooVectorDataStore.h
     RooWorkspace.h
     RooWorkspaceHandle.h
-    RooXYChi2Var.h
-    RooHelpers.h
     RooWrapperPdf.h
-    RooBinSamplingPdf.h
-    RooBinWidthFunction.h
-    RooFitLegacy/RooCatTypeLegacy.h
-    RooFitLegacy/RooCategorySharedProperties.h
-    RooFitLegacy/RooTreeData.h
-    RooFit/TestStatistics/LikelihoodGradientWrapper.h
-    RooFit/TestStatistics/LikelihoodWrapper.h
-    RooFit/TestStatistics/RooAbsL.h
-    RooFit/TestStatistics/RooBinnedL.h
-    RooFit/TestStatistics/RooSubsidiaryL.h
-    RooFit/TestStatistics/RooSumL.h
-    RooFit/TestStatistics/RooRealL.h
-    RooFit/TestStatistics/RooUnbinnedL.h
-    RooFit/TestStatistics/buildLikelihood.h
+    RooXYChi2Var.h
   SOURCES
-    src/ConstraintHelpers.cxx
-    src/BatchModeHelpers.cxx
     src/BatchModeDataHelpers.cxx
-    src/Buffers.cxx
+    src/BatchModeHelpers.cxx
     src/BidirMMapPipe.cxx
     src/BidirMMapPipe.h
+    src/Buffers.cxx
+    src/ConstraintHelpers.cxx
     src/FitHelpers.cxx
+    src/Initialisation.cxx
     src/ModelConfig.cxx
     src/NormalizationHelpers.cxx
     src/Roo1DTable.cxx
+    src/RooAICRegistry.cxx
     src/RooAbsAnaConvPdf.cxx
     src/RooAbsArg.cxx
     src/RooAbsBinning.cxx
     src/RooAbsCache.cxx
+    src/RooAbsCacheElement.cxx
     src/RooAbsCachedPdf.cxx
     src/RooAbsCachedReal.cxx
-    src/RooAbsCacheElement.cxx
     src/RooAbsCategory.cxx
     src/RooAbsCategoryLValue.cxx
     src/RooAbsCollection.cxx
@@ -286,22 +287,22 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     src/RooAdaptiveIntegratorND.cxx
     src/RooAddGenContext.cxx
     src/RooAddHelpers.cxx
-    src/RooAddition.cxx
     src/RooAddModel.cxx
     src/RooAddPdf.cxx
-    src/RooAICRegistry.cxx
+    src/RooAddition.cxx
     src/RooArgList.cxx
     src/RooArgProxy.cxx
     src/RooArgSet.cxx
-    src/Initialisation.cxx
     src/RooBinIntegrator.cxx
+    src/RooBinSamplingPdf.cxx
+    src/RooBinWidthFunction.cxx
     src/RooBinnedGenContext.cxx
-    src/RooBinningCategory.cxx
     src/RooBinning.cxx
+    src/RooBinningCategory.cxx
     src/RooBrentRootFinder.cxx
+    src/RooCacheManager.cxx
     src/RooCachedPdf.cxx
     src/RooCachedReal.cxx
-    src/RooCacheManager.cxx
     src/RooCategory.cxx
     src/RooChangeTracker.cxx
     src/RooChi2Var.cxx
@@ -309,88 +310,92 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     src/RooCmdArg.cxx
     src/RooCmdConfig.cxx
     src/RooCompositeDataStore.cxx
-    src/RooConstraintSum.cxx
     src/RooConstVar.cxx
+    src/RooConstraintSum.cxx
     src/RooConvCoefVar.cxx
     src/RooConvGenContext.cxx
     src/RooConvIntegrandBinding.cxx
     src/RooCurve.cxx
     src/RooCustomizer.cxx
+    src/RooDLLSignificanceMCSModule.cxx
     src/RooDataHist.cxx
     src/RooDataHistSliceIter.cxx
     src/RooDataProjBinding.cxx
     src/RooDataSet.cxx
     src/RooDerivative.cxx
     src/RooDirItem.cxx
-    src/RooDLLSignificanceMCSModule.cxx
     src/RooDouble.cxx
     src/RooEffGenContext.cxx
-    src/RooEfficiency.cxx
     src/RooEffProd.cxx
+    src/RooEfficiency.cxx
     src/RooEllipse.cxx
     src/RooErrorVar.cxx
+    src/RooEvaluatorWrapper.cxx
     src/RooExpensiveObjectCache.cxx
+    src/RooExtendPdf.cxx
     src/RooExtendedBinding.cxx
     src/RooExtendedTerm.cxx
-    src/RooExtendPdf.cxx
-    src/RooFactoryWSTool.cxx
     src/RooFFTConvPdf.cxx
+    src/RooFactoryWSTool.cxx
     src/RooFirstMoment.cxx
+    src/RooFit/Detail/CodeSquashContext.cxx
+    src/RooFit/Detail/DataMap.cxx
+    src/RooFit/Evaluator.cxx
+    src/RooFitImplHelpers.cxx
+    src/RooFitLegacy/RooCatTypeLegacy.cxx
     src/RooFitResult.cxx
     src/RooFoamGenerator.cxx
     src/RooFormula.cxx
     src/RooFormulaVar.cxx
     src/RooFracRemainder.cxx
-    src/RooFunctor.cxx
     src/RooFuncWrapper.cxx
+    src/RooFunctor.cxx
     src/RooGenContext.cxx
-    src/RooGenericPdf.cxx
     src/RooGenFitStudy.cxx
     src/RooGenProdProj.cxx
+    src/RooGenericPdf.cxx
     src/RooGlobalFunc.cxx
     src/RooGrid.cxx
+    src/RooHelpers.cxx
     src/RooHist.cxx
     src/RooHistError.cxx
     src/RooHistFunc.cxx
     src/RooHistPdf.cxx
     src/RooImproperIntegrator1D.cxx
-    src/RooRombergIntegrator.cxx
     src/RooInvTransform.cxx
+    src/RooLinTransBinning.cxx
     src/RooLinearCombination.cxx
     src/RooLinearVar.cxx
     src/RooLinkedList.cxx
     src/RooLinkedListElem.cxx
-    src/RooLinTransBinning.cxx
-    src/RooMath.cxx
-    src/RooMappedCategory.cxx
     src/RooMCIntegrator.cxx
     src/RooMCStudy.cxx
+    src/RooMappedCategory.cxx
+    src/RooMath.cxx
     src/RooMinimizer.cxx
     src/RooMinimizerFcn.cxx
     src/RooMoment.cxx
     src/RooMsgService.cxx
     src/RooMultiCategory.cxx
     src/RooMultiVarGaussian.cxx
-    src/RooNameReg.cxx
-    src/RooFit/Evaluator.cxx
-    src/RooEvaluatorWrapper.cxx
     src/RooNLLVar.cxx
     src/RooNLLVarNew.cxx
+    src/RooNameReg.cxx
     src/RooNormSetCache.cxx
     src/RooNormalizedPdf.cxx
-    src/RooNumber.cxx
     src/RooNumCdf.cxx
-    src/RooNumConvolution.cxx
     src/RooNumConvPdf.cxx
+    src/RooNumConvolution.cxx
     src/RooNumGenConfig.cxx
     src/RooNumGenFactory.cxx
     src/RooNumIntConfig.cxx
     src/RooNumIntFactory.cxx
     src/RooNumRunningInt.cxx
+    src/RooNumber.cxx
     src/RooObjCacheManager.cxx
     src/RooParamBinning.cxx
-    src/RooPlotable.cxx
     src/RooPlot.cxx
+    src/RooPlotable.cxx
     src/RooPolyFunc.cxx
     src/RooPolyVar.cxx
     src/RooPrintable.cxx
@@ -402,11 +407,11 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     src/RooProofDriverSelector.cxx
     src/RooPullVar.cxx
     src/RooQuasiRandomGenerator.cxx
-    src/RooRatio.cxx
     src/RooRandom.cxx
     src/RooRandomizeParamMCSModule.cxx
     src/RooRangeBinning.cxx
     src/RooRangeBoolean.cxx
+    src/RooRatio.cxx
     src/RooRealBinding.cxx
     src/RooRealConstant.cxx
     src/RooRealIntegral.cxx
@@ -415,24 +420,25 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     src/RooRealSumPdf.cxx
     src/RooRealVar.cxx
     src/RooRecursiveFraction.cxx
-    src/RooSTLRefCountList.cxx
     src/RooResolutionModel.cxx
+    src/RooRombergIntegrator.cxx
+    src/RooSTLRefCountList.cxx
     src/RooSecondMoment.cxx
     src/RooSentinel.cxx
     src/RooSharedProperties.cxx
     src/RooSimGenContext.cxx
     src/RooSimSplitGenContext.cxx
-    src/RooSimultaneous.cxx
     src/RooSimWSTool.cxx
+    src/RooSimultaneous.cxx
     src/RooStreamParser.cxx
     src/RooStringVar.cxx
     src/RooStudyManager.cxx
     src/RooStudyPackage.cxx
     src/RooSuperCategory.cxx
-    src/RooTable.cxx
     src/RooTFoamBinding.cxx
-    src/RooThresholdCategory.cxx
     src/RooTObjWrap.cxx
+    src/RooTable.cxx
+    src/RooThresholdCategory.cxx
     src/RooTrace.cxx
     src/RooTreeDataStore.cxx
     src/RooTruthModel.cxx
@@ -440,24 +446,18 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     src/RooUnitTest.cxx
     src/RooVectorDataStore.cxx
     src/RooWorkspace.cxx
-    src/RooXYChi2Var.cxx
-    src/RooHelpers.cxx
     src/RooWrapperPdf.cxx
-    src/RooBinSamplingPdf.cxx
-    src/RooBinWidthFunction.cxx
-    src/RooFitLegacy/RooCatTypeLegacy.cxx
-    src/RooFit/Detail/CodeSquashContext.cxx
-    src/RooFit/Detail/DataMap.cxx
+    src/RooXYChi2Var.cxx
     src/TestStatistics/ConstantTermsOptimizer.cxx
     src/TestStatistics/LikelihoodGradientWrapper.cxx
-    src/TestStatistics/LikelihoodWrapper.cxx
     src/TestStatistics/LikelihoodSerial.cxx
+    src/TestStatistics/LikelihoodWrapper.cxx
     src/TestStatistics/MinuitFcnGrad.cxx
     src/TestStatistics/RooAbsL.cxx
     src/TestStatistics/RooBinnedL.cxx
+    src/TestStatistics/RooRealL.cxx
     src/TestStatistics/RooSubsidiaryL.cxx
     src/TestStatistics/RooSumL.cxx
-    src/TestStatistics/RooRealL.cxx
     src/TestStatistics/RooUnbinnedL.cxx
     src/TestStatistics/buildLikelihood.cxx
     ${RooFitMPTestStatisticsSources}
@@ -482,6 +482,8 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     inc/LinkDef.h
   ${EXTRA_DICT_OPTS}
 )
+
+target_include_directories(RooFitCore INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/res>)
 
 # For recent clang, this can facilitate auto-vectorisation.
 # In RooFit, the errno side effect is not needed, anyway:

--- a/roofit/roofitcore/inc/RooCacheManager.h
+++ b/roofit/roofitcore/inc/RooCacheManager.h
@@ -16,8 +16,6 @@
 #ifndef ROO_CACHE_MANAGER
 #define ROO_CACHE_MANAGER
 
-#include "Rtypes.h"
-
 #include "RooMsgService.h"
 #include "RooNormSetCache.h"
 #include "RooAbsReal.h"
@@ -26,7 +24,10 @@
 #include "RooAbsCache.h"
 #include "RooAbsCacheElement.h"
 #include "RooNameReg.h"
-#include "RooHelpers.h"
+
+#include <ROOT/StringUtils.hxx>
+#include "Rtypes.h"
+
 #include <vector>
 
 
@@ -317,21 +318,31 @@ T* RooCacheManager<T>::getObjByIndex(Int_t index) const
 
 
 /// Create RooArgSet containing the objects that are both in the cached set 1
-//with a given index and an input argSet.
-template<class T>
-RooArgSet RooCacheManager<T>::selectFromSet1(RooArgSet const& argSet, int index) const
+/// with a given index and an input argSet.
+template <class T>
+RooArgSet RooCacheManager<T>::selectFromSet1(RooArgSet const &argSet, int index) const
 {
-  return RooHelpers::selectFromArgSet(argSet, _nsetCache.at(index).nameSet1());
+   RooArgSet output;
+   for (auto const &name : ROOT::Split(_nsetCache.at(index).nameSet1(), ":")) {
+      if (RooAbsArg *arg = argSet.find(name.c_str())) {
+         output.add(*arg);
+      }
+   }
+   return output;
 }
-
 
 /// Create RooArgSet containing the objects that are both in the cached set 2
-//with a given index and an input argSet.
-template<class T>
-RooArgSet RooCacheManager<T>::selectFromSet2(RooArgSet const& argSet, int index) const
+/// with a given index and an input argSet.
+template <class T>
+RooArgSet RooCacheManager<T>::selectFromSet2(RooArgSet const &argSet, int index) const
 {
-  return RooHelpers::selectFromArgSet(argSet, _nsetCache.at(index).nameSet2());
+   RooArgSet output;
+   for (auto const &name : ROOT::Split(_nsetCache.at(index).nameSet2(), ":")) {
+      if (RooAbsArg *arg = argSet.find(name.c_str())) {
+         output.add(*arg);
+      }
+   }
+   return output;
 }
-
 
 #endif

--- a/roofit/roofitcore/inc/RooFit/Detail/CodeSquashContext.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/CodeSquashContext.h
@@ -28,8 +28,6 @@
 template <class T>
 class RooTemplateProxy;
 
-class TString;
-
 namespace RooFit {
 
 namespace Detail {
@@ -104,7 +102,7 @@ public:
    std::unique_ptr<LoopScope> beginLoop(RooAbsArg const *in);
 
    std::string getTmpVarName();
-   std::string makeValidVarName(TString in) const;
+   std::string makeValidVarName(std::string const &in) const;
 
    std::string buildArg(RooAbsCollection const &x);
    std::string buildArg(std::span<const double> arr);

--- a/roofit/roofitcore/inc/RooFit/Detail/CodeSquashContext.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/CodeSquashContext.h
@@ -102,7 +102,6 @@ public:
    std::unique_ptr<LoopScope> beginLoop(RooAbsArg const *in);
 
    std::string getTmpVarName();
-   std::string makeValidVarName(std::string const &in) const;
 
    std::string buildArg(RooAbsCollection const &x);
    std::string buildArg(std::span<const double> arr);

--- a/roofit/roofitcore/inc/RooFit/Evaluator.h
+++ b/roofit/roofitcore/inc/RooFit/Evaluator.h
@@ -4,7 +4,7 @@
  *   Jonas Rembser, CERN 2021
  *   Emmanouil Michalainas, CERN 2021
  *
- * Copyright (c) 2021, CERN
+ * Copyright (c) 2023, CERN
  *
  * Redistribution and use in source and binary forms,
  * with or without modification, are permitted according to the terms
@@ -14,14 +14,15 @@
 #ifndef RooFit_Evaluator_h
 #define RooFit_Evaluator_h
 
+#include <RooAbsReal.h>
 #include <RooFit/Detail/DataMap.h>
-#include <RooHelpers.h>
 
 #include <RConfig.h>
 
 #include <memory>
 #include <stack>
 
+class ChangeOperModeRAII;
 class RooAbsArg;
 
 namespace RooFit {
@@ -38,7 +39,7 @@ class BufferManager;
 
 class Evaluator {
 public:
-   Evaluator(const RooAbsReal &absReal, bool useGPU=false);
+   Evaluator(const RooAbsReal &absReal, bool useGPU = false);
    ~Evaluator();
 
    std::span<const double> run();
@@ -68,8 +69,8 @@ private:
 #ifdef R__HAS_CUDA
    RooFit::Detail::DataMap _dataMapCUDA;
 #endif
-   std::vector<NodeInfo> _nodes;                                    // the ordered computation graph
-   std::stack<RooHelpers::ChangeOperModeRAII> _changeOperModeRAIIs; // for resetting state of computation graph
+   std::vector<NodeInfo> _nodes; // the ordered computation graph
+   std::stack<std::unique_ptr<ChangeOperModeRAII>> _changeOperModeRAIIs;
 };
 
 } // end namespace RooFit

--- a/roofit/roofitcore/inc/RooHelpers.h
+++ b/roofit/roofitcore/inc/RooHelpers.h
@@ -1,21 +1,17 @@
-// Author: Stephan Hageboeck, CERN  01/2019
+/*
+ * Project: RooFit
+ * Author:
+ *   Stephan Hageboeck, CERN 2019
+ *
+ * Copyright (c) 2023, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
 
-/*****************************************************************************
- * RooFit
- * Authors:                                                                  *
- *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
- *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
- *                                                                           *
- * Copyright (c) 2000-2019, Regents of the University of California          *
- *                          and Stanford University. All rights reserved.    *
- *                                                                           *
- * Redistribution and use in source and binary forms,                        *
- * with or without modification, are permitted according to the terms        *
- * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
- *****************************************************************************/
-
-#ifndef ROOFIT_ROOFITCORE_INC_ROOHELPERS_H_
-#define ROOFIT_ROOFITCORE_INC_ROOHELPERS_H_
+#ifndef RooFit_RooHelpers_h
+#define RooFit_RooHelpers_h
 
 #include <RooMsgService.h>
 #include <RooAbsArg.h>
@@ -29,7 +25,6 @@
 class RooAbsPdf;
 class RooAbsData;
 
-
 namespace RooHelpers {
 
 /// Switches the message service to a different level while the instance is alive.
@@ -40,127 +35,60 @@ namespace RooHelpers {
 /// [ statements that normally generate a lot of output ]
 /// ~~~
 class LocalChangeMsgLevel {
-  public:
-    /// Change message level (and topics) while this object is alive, reset when it goes out of scope.
-    /// \param[in] lvl The desired message level. Defaults to verbose.
-    /// \param[in] extraTopics Extra topics to be switched on. These will only switched on in the last stream to prevent all streams are printing.
-    /// \param[in] removeTopics Message topics to be switched off
-    /// \param[in] overrideExternalLevel Override the user message level.
-    LocalChangeMsgLevel(RooFit::MsgLevel lvl = RooFit::DEBUG,
-        unsigned int extraTopics = 0u,
-        unsigned int removeTopics = 0u,
-        bool overrideExternalLevel = true);
+public:
+   /// Change message level (and topics) while this object is alive, reset when it goes out of scope.
+   /// \param[in] lvl The desired message level. Defaults to verbose.
+   /// \param[in] extraTopics Extra topics to be switched on. These will only switched on in the last stream to prevent
+   /// all streams are printing. \param[in] removeTopics Message topics to be switched off \param[in]
+   /// overrideExternalLevel Override the user message level.
+   LocalChangeMsgLevel(RooFit::MsgLevel lvl = RooFit::DEBUG, unsigned int extraTopics = 0u,
+                       unsigned int removeTopics = 0u, bool overrideExternalLevel = true);
 
-    ~LocalChangeMsgLevel();
+   ~LocalChangeMsgLevel();
 
-  private:
-    RooFit::MsgLevel fOldKillBelow;
-    std::vector<RooMsgService::StreamConfig> fOldConf;
-    int fExtraStream{-1};
+private:
+   RooFit::MsgLevel fOldKillBelow;
+   std::vector<RooMsgService::StreamConfig> fOldConf;
+   int fExtraStream{-1};
 };
-
 
 /// Wrap an object into a TObject. Sometimes needed to avoid reinterpret_cast or enable RTTI.
-template<typename T>
+template <typename T>
 struct WrapIntoTObject : public TObject {
-  WrapIntoTObject(T& obj) : _payload(&obj) { }
-  T* _payload;
+   WrapIntoTObject(T &obj) : _payload(&obj) {}
+   T *_payload;
 };
-
 
 /// Hijacks all messages with given level and topic (and optionally object name) while alive.
 /// Use this like an ostringstream afterwards. The messages can e.g. be retrieved using `str()`.
 /// Useful for unit tests / debugging.
-class HijackMessageStream{
-  public:
-    HijackMessageStream(RooFit::MsgLevel level, RooFit::MsgTopic topics, const char* objectName = nullptr);
-    template<typename T>
-    const HijackMessageStream& operator<<(const T& v) const {
+class HijackMessageStream {
+public:
+   HijackMessageStream(RooFit::MsgLevel level, RooFit::MsgTopic topics, const char *objectName = nullptr);
+   template <typename T>
+   const HijackMessageStream &operator<<(const T &v) const
+   {
       _str << v;
       return *this;
-    }
-    std::string str() { return _str.str(); }
-    std::ostringstream& stream() { return _str; };
-    ~HijackMessageStream();
-
-  private:
-    std::ostringstream _str;
-    RooFit::MsgLevel _oldKillBelow;
-    std::vector<RooMsgService::StreamConfig> _oldConf;
-    Int_t _thisStream;
-};
-
-
-/// Check if the parameters have a range, and warn if the range extends below / above the set limits.
-void checkRangeOfParameters(const RooAbsReal* callingClass, std::initializer_list<const RooAbsReal*> pars,
-    double min = -std::numeric_limits<double>::max(), double max = std::numeric_limits<double>::max(),
-    bool limitsInAllowedRange = false, std::string const& extraMessage = "");
-
-
-/// Disable all caches for sub-branches in an expression tree.
-/// This is helpful when an expression with cached sub-branches needs to be integrated numerically.
-struct DisableCachingRAII {
-  /// Inhibit all dirty-state propagation, and assume every node as dirty.
-  /// \param[in] oldState Restore this state when going out of scope.
-  DisableCachingRAII(bool oldState):
-  _oldState(oldState) {
-    RooAbsArg::setDirtyInhibit(true);
-  }
-
-  ~DisableCachingRAII() {
-    RooAbsArg::setDirtyInhibit(_oldState);
-  }
-  bool _oldState;
-};
-
-
-/// Struct to temporarily change the operation mode of a RooAbsArg until it
-/// goes out of scope.
-class ChangeOperModeRAII {
-public:
-   ChangeOperModeRAII(RooAbsArg *arg, RooAbsArg::OperMode opMode) : _arg{arg}, _oldOpMode(arg->operMode())
-   {
-      arg->setOperMode(opMode, /*recurse=*/false);
    }
-   ~ChangeOperModeRAII() { _arg->setOperMode(_oldOpMode, /*recurse=*/false); }
+   std::string str() { return _str.str(); }
+   std::ostringstream &stream() { return _str; };
+   ~HijackMessageStream();
 
 private:
-   RooAbsArg *_arg = nullptr;
-   RooAbsArg::OperMode _oldOpMode;
+   std::ostringstream _str;
+   RooFit::MsgLevel _oldKillBelow;
+   std::vector<RooMsgService::StreamConfig> _oldConf;
+   Int_t _thisStream;
 };
 
+/// Check if the parameters have a range, and warn if the range extends below / above the set limits.
+void checkRangeOfParameters(const RooAbsReal *callingClass, std::initializer_list<const RooAbsReal *> pars,
+                            double min = -std::numeric_limits<double>::max(),
+                            double max = std::numeric_limits<double>::max(), bool limitsInAllowedRange = false,
+                            std::string const &extraMessage = "");
 
-std::pair<double, double> getRangeOrBinningInterval(RooAbsArg const* arg, const char* rangeName);
 
-bool checkIfRangesOverlap(RooArgSet const& observables, std::vector<std::string> const& rangeNames);
+} // namespace RooHelpers
 
-std::string getColonSeparatedNameString(RooArgSet const& argSet, char delim=':');
-RooArgSet selectFromArgSet(RooArgSet const&, std::string const& names);
-
-namespace Detail {
-
-bool snapshotImpl(RooAbsCollection const& input, RooAbsCollection& output, bool deepCopy, RooArgSet const *observables);
-RooAbsArg *cloneTreeWithSameParametersImpl(RooAbsArg const &arg, RooArgSet const *observables);
-
-} // namespace Detail
-
-/// Clone RooAbsArg object and reattach to original parameters.
-template<class T>
-std::unique_ptr<T> cloneTreeWithSameParameters(T const& arg, RooArgSet const* observables=nullptr) {
-  return std::unique_ptr<T>{static_cast<T *>(Detail::cloneTreeWithSameParametersImpl(arg, observables))};
-}
-
-std::string getRangeNameForSimComponent(std::string const& rangeName, bool splitRange, std::string const& catName);
-
-struct BinnedLOutput {
-    RooAbsPdf * binnedPdf = nullptr;
-    bool isBinnedL = false;
-};
-
-BinnedLOutput getBinnedL(RooAbsPdf const &pdf);
-
-void getSortedComputationGraph(RooAbsArg const &func, RooArgSet &out);
-
-}
-
-#endif /* ROOFIT_ROOFITCORE_INC_ROOHELPERS_H_ */
+#endif

--- a/roofit/roofitcore/res/RooFitImplHelpers.h
+++ b/roofit/roofitcore/res/RooFitImplHelpers.h
@@ -1,0 +1,98 @@
+/*
+ * Project: RooFit
+ *
+ * Copyright (c) 2023, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#ifndef RooFit_RooFitImplHelpers_h
+#define RooFit_RooFitImplHelpers_h
+
+#include <RooMsgService.h>
+#include <RooAbsArg.h>
+#include <RooAbsReal.h>
+
+#include <sstream>
+#include <vector>
+#include <string>
+#include <utility>
+
+class RooAbsPdf;
+class RooAbsData;
+
+/// Disable all caches for sub-branches in an expression tree.
+/// This is helpful when an expression with cached sub-branches needs to be integrated numerically.
+class DisableCachingRAII {
+public:
+   /// Inhibit all dirty-state propagation, and assume every node as dirty.
+   /// \param[in] oldState Restore this state when going out of scope.
+   DisableCachingRAII(bool oldState) : _oldState(oldState) { RooAbsArg::setDirtyInhibit(true); }
+
+   DisableCachingRAII(DisableCachingRAII const &other) = delete;
+   DisableCachingRAII &operator=(DisableCachingRAII const &other) = delete;
+
+   ~DisableCachingRAII() { RooAbsArg::setDirtyInhibit(_oldState); }
+
+private:
+   bool _oldState;
+};
+
+/// Struct to temporarily change the operation mode of a RooAbsArg until it
+/// goes out of scope.
+class ChangeOperModeRAII {
+public:
+   ChangeOperModeRAII(RooAbsArg *arg, RooAbsArg::OperMode opMode) : _arg{arg}, _oldOpMode(arg->operMode())
+   {
+      arg->setOperMode(opMode, /*recurse=*/false);
+   }
+
+   ChangeOperModeRAII(ChangeOperModeRAII const &other) = delete;
+   ChangeOperModeRAII &operator=(ChangeOperModeRAII const &other) = delete;
+
+   ~ChangeOperModeRAII() { _arg->setOperMode(_oldOpMode, /*recurse=*/false); }
+
+private:
+   RooAbsArg *_arg = nullptr;
+   RooAbsArg::OperMode _oldOpMode;
+};
+
+namespace RooHelpers {
+
+std::pair<double, double> getRangeOrBinningInterval(RooAbsArg const *arg, const char *rangeName);
+
+bool checkIfRangesOverlap(RooArgSet const &observables, std::vector<std::string> const &rangeNames);
+
+std::string getColonSeparatedNameString(RooArgSet const &argSet, char delim = ':');
+RooArgSet selectFromArgSet(RooArgSet const &, std::string const &names);
+
+namespace Detail {
+
+bool snapshotImpl(RooAbsCollection const &input, RooAbsCollection &output, bool deepCopy, RooArgSet const *observables);
+RooAbsArg *cloneTreeWithSameParametersImpl(RooAbsArg const &arg, RooArgSet const *observables);
+
+} // namespace Detail
+
+/// Clone RooAbsArg object and reattach to original parameters.
+template <class T>
+std::unique_ptr<T> cloneTreeWithSameParameters(T const &arg, RooArgSet const *observables = nullptr)
+{
+   return std::unique_ptr<T>{static_cast<T *>(Detail::cloneTreeWithSameParametersImpl(arg, observables))};
+}
+
+std::string getRangeNameForSimComponent(std::string const &rangeName, bool splitRange, std::string const &catName);
+
+struct BinnedLOutput {
+   RooAbsPdf *binnedPdf = nullptr;
+   bool isBinnedL = false;
+};
+
+BinnedLOutput getBinnedL(RooAbsPdf const &pdf);
+
+void getSortedComputationGraph(RooAbsArg const &func, RooArgSet &out);
+
+} // namespace RooHelpers
+
+#endif

--- a/roofit/roofitcore/res/RooFitImplHelpers.h
+++ b/roofit/roofitcore/res/RooFitImplHelpers.h
@@ -95,4 +95,12 @@ void getSortedComputationGraph(RooAbsArg const &func, RooArgSet &out);
 
 } // namespace RooHelpers
 
+namespace RooFit {
+namespace Detail {
+
+std::string makeValidVarName(std::string const &in);
+
+} // namespace Detail
+} // namespace RooFit
+
 #endif

--- a/roofit/roofitcore/src/BatchModeDataHelpers.cxx
+++ b/roofit/roofitcore/src/BatchModeDataHelpers.cxx
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*
  * Project: RooFit
  * Authors:
@@ -11,11 +13,13 @@
  */
 
 #include "RooFit/BatchModeDataHelpers.h"
+
 #include <RooAbsData.h>
-#include <RooHelpers.h>
-#include "RooNLLVarNew.h"
 #include <RooRealVar.h>
 #include <RooSimultaneous.h>
+
+#include "RooFitImplHelpers.h"
+#include "RooNLLVarNew.h"
 
 #include <ROOT/StringUtils.hxx>
 
@@ -300,3 +304,5 @@ std::map<RooFit::Detail::DataKey, std::size_t> RooFit::BatchModeDataHelpers::det
 
    return output;
 }
+
+/// \endcond

--- a/roofit/roofitcore/src/BatchModeHelpers.cxx
+++ b/roofit/roofitcore/src/BatchModeHelpers.cxx
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*
  * Project: RooFit
  * Authors:
@@ -125,3 +127,5 @@ RooFit::BatchModeHelpers::createNLL(RooAbsPdf &pdf, RooAbsData &data, std::uniqu
 
    return nll;
 }
+
+/// \endcond

--- a/roofit/roofitcore/src/ConstraintHelpers.cxx
+++ b/roofit/roofitcore/src/ConstraintHelpers.cxx
@@ -17,6 +17,8 @@
 #include <RooConstraintSum.h>
 #include <RooMsgService.h>
 
+#include "RooFitImplHelpers.h"
+
 namespace {
 
 std::unique_ptr<RooArgSet>

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -76,6 +76,7 @@ for single nodes.
 #include <RooConstVar.h>
 #include <RooExpensiveObjectCache.h>
 #include <RooHelpers.h>
+#include "RooFitImplHelpers.h"
 #include <RooListProxy.h>
 #include <RooMsgService.h>
 #include <RooRealIntegral.h>

--- a/roofit/roofitcore/src/RooAbsCollection.cxx
+++ b/roofit/roofitcore/src/RooAbsCollection.cxx
@@ -41,7 +41,7 @@ implemented using the container denoted by RooAbsCollection::Storage_t.
 #include "RooRealVar.h"
 #include "RooGlobalFunc.h"
 #include "RooMsgService.h"
-#include <RooHelpers.h>
+#include "RooFitImplHelpers.h"
 
 #include <strlcpy.h>
 #include <algorithm>

--- a/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
@@ -35,31 +35,32 @@ Support for calculation in partitions is needed to allow multi-core
 parallelized calculation of test statistics.
 **/
 
+#include "RooAbsOptTestStatistic.h"
+
 #include "Riostream.h"
 #include "TClass.h"
 #include <cstring>
 
-
-#include "RooAbsOptTestStatistic.h"
-#include "RooMsgService.h"
-#include "RooAbsPdf.h"
 #include "RooAbsData.h"
-#include "RooDataHist.h"
-#include "RooArgSet.h"
-#include "RooRealVar.h"
-#include "RooErrorHandler.h"
-#include "RooGlobalFunc.h"
-#include "RooBinning.h"
 #include "RooAbsDataStore.h"
-#include "RooCategory.h"
-#include "RooDataSet.h"
-#include "RooProdPdf.h"
+#include "RooAbsPdf.h"
 #include "RooAddPdf.h"
+#include "RooArgSet.h"
+#include "RooBinSamplingPdf.h"
+#include "RooBinning.h"
+#include "RooCategory.h"
+#include "RooDataHist.h"
+#include "RooDataSet.h"
+#include "RooErrorHandler.h"
+#include "RooFitImplHelpers.h"
+#include "RooGlobalFunc.h"
+#include "RooMsgService.h"
+#include "RooProdPdf.h"
 #include "RooProduct.h"
 #include "RooRealSumPdf.h"
+#include "RooRealVar.h"
 #include "RooTrace.h"
 #include "RooVectorDataStore.h"
-#include "RooBinSamplingPdf.h"
 
 #include "ROOT/StringUtils.hxx"
 

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -164,6 +164,7 @@ called for each data event.
 #include "RooRealIntegral.h"
 #include "RooWorkspace.h"
 #include "RooNaNPacker.h"
+#include "RooFitImplHelpers.h"
 #include "RooHelpers.h"
 #include "RooFormulaVar.h"
 #include "RooDerivative.h"

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -58,7 +58,7 @@
 #include "RooFormulaVar.h"
 #include "RooFunctor.h"
 #include "RooGlobalFunc.h"
-#include "RooHelpers.h"
+#include "RooFitImplHelpers.h"
 #include "RooHist.h"
 #include "RooMoment.h"
 #include "RooMsgService.h"

--- a/roofit/roofitcore/src/RooAbsTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsTestStatistic.cxx
@@ -45,7 +45,7 @@ combined in the main thread.
 #include "RooErrorHandler.h"
 #include "RooMsgService.h"
 #include "RooAbsCategoryLValue.h"
-#include "RooHelpers.h"
+#include "RooFitImplHelpers.h"
 #include "RooAbsOptTestStatistic.h"
 #include "RooCategory.h"
 

--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -71,7 +71,6 @@ An (enforced) condition for this assumption is that each \f$ \mathrm{PDF}_i \f$ 
 #include <RooDataSet.h>
 #include <RooGenericPdf.h>
 #include <RooGlobalFunc.h>
-#include <RooHelpers.h>
 #include <RooProduct.h>
 #include <RooRatio.h>
 #include <RooRealConstant.h>
@@ -82,6 +81,7 @@ An (enforced) condition for this assumption is that each \f$ \mathrm{PDF}_i \f$ 
 #include <RooRecursiveFraction.h>
 
 #include "RooAddHelpers.h"
+#include "RooFitImplHelpers.h"
 
 #include <ROOT/StringUtils.hxx>
 

--- a/roofit/roofitcore/src/RooBinSamplingPdf.cxx
+++ b/roofit/roofitcore/src/RooBinSamplingPdf.cxx
@@ -91,7 +91,7 @@
 
 #include "RooBinSamplingPdf.h"
 
-#include "RooHelpers.h"
+#include "RooFitImplHelpers.h"
 #include "RooRealBinding.h"
 #include "RooRealVar.h"
 #include "RooGlobalFunc.h"
@@ -146,7 +146,7 @@ double RooBinSamplingPdf::evaluate() const {
   double result;
   {
     // Important: When the integrator samples x, caching of sub-tree values needs to be off.
-    RooHelpers::DisableCachingRAII disableCaching(inhibitDirty());
+    DisableCachingRAII disableCaching(inhibitDirty());
     result = integrate(_normSet, low, high) / (high-low);
   }
 
@@ -167,7 +167,7 @@ void RooBinSamplingPdf::computeBatch(double* output, size_t /*size*/, RooFit::De
   auto xValues = dataMap.at(_observable);
 
   // Important: When the integrator samples x, caching of sub-tree values needs to be off.
-  RooHelpers::DisableCachingRAII disableCaching(inhibitDirty());
+  DisableCachingRAII disableCaching(inhibitDirty());
 
   // Now integrate PDF in each bin:
   for (unsigned int i=0; i < xValues.size(); ++i) {

--- a/roofit/roofitcore/src/RooCacheManager.cxx
+++ b/roofit/roofitcore/src/RooCacheManager.cxx
@@ -35,10 +35,11 @@ configurations can be cached.
 **/
 //
 
-#include <vector>
 #include "RooCacheManager.h"
 
-using namespace std ;
+#include "RooHelpers.h"
+
+#include <vector>
 
 #ifndef ROOFIT_R__NO_CLASS_TEMPLATE_SPECIALIZATION
 #define ROOFIT_R__NO_CLASS_TEMPLATE_SPECIALIZATION

--- a/roofit/roofitcore/src/RooClassFactory.cxx
+++ b/roofit/roofitcore/src/RooClassFactory.cxx
@@ -43,6 +43,7 @@ instantiate objects.
 #include <ROOT/StringUtils.hxx>
 
 #include <strlcpy.h>
+#include <cctype>
 #include <fstream>
 #include <mutex>
 
@@ -408,19 +409,9 @@ void replaceAll(std::string &inOut, std::string_view what, std::string_view with
    }
 }
 
-bool isSpecial(char c)
+inline bool isSpecial(char c)
 {
-   static const int nSpecialChars = 27;
-   static const char *specialChars[nSpecialChars] = {"+", "-", "*", "/", "&", "%", "|", "^",  ">",
-                                                     "<", "=", "~", ".", "(", ")", "[", "]",  "!",
-                                                     ",", "$", " ", ":", "'", "#", "@", "\\", "\""};
-
-   for (int i = 0; i < nSpecialChars; ++i) {
-      if (c == specialChars[i][0]) {
-         return true;
-      }
-   }
-   return false;
+   return c != '_' && !std::isalnum(c);
 }
 
 bool isComplex(std::string const &expression)

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -64,6 +64,8 @@ See RooAbsData::plotOn().
 #include "RooFormula.h"
 #include "RooUniformBinning.h"
 
+#include "RooFitImplHelpers.h"
+
 #include <ROOT/RSpan.hxx>
 #include <ROOT/StringUtils.hxx>
 
@@ -979,7 +981,7 @@ Int_t RooDataHist::getIndex(const RooAbsCollection& coord, bool fast) const {
 std::string RooDataHist::declWeightArrayForCodeSquash(RooAbsArg const *klass, RooFit::Detail::CodeSquashContext &ctx,
                                                       bool correctForBinSize) const
 {
-   std::string weightName = ctx.makeValidVarName(klass->GetName()) + "_HistWeights";
+   std::string weightName = RooFit::Detail::makeValidVarName(klass->GetName()) + "_HistWeights";
 
    std::string arrayDecl = "double " + weightName + "[" + std::to_string(_arrSize) + "] = {";
    for (Int_t i = 0; i < _arrSize; i++) {

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -101,7 +101,7 @@ the new `RooAbsData::uniqueId()`.
 #include "RooCompositeDataStore.h"
 #include "RooSentinel.h"
 #include "RooTrace.h"
-#include "RooHelpers.h"
+#include "RooFitImplHelpers.h"
 
 #include "ROOT/StringUtils.hxx"
 

--- a/roofit/roofitcore/src/RooFit/BatchModeDataHelpers.h
+++ b/roofit/roofitcore/src/RooFit/BatchModeDataHelpers.h
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*
  * Project: RooFit
  * Authors:
@@ -45,3 +47,5 @@ determineOutputSizes(RooAbsArg const &topNode,
 } // namespace RooFit
 
 #endif
+
+/// \endcond

--- a/roofit/roofitcore/src/RooFit/BatchModeHelpers.h
+++ b/roofit/roofitcore/src/RooFit/BatchModeHelpers.h
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*
  * Project: RooFit
  * Authors:
@@ -34,3 +36,5 @@ std::unique_ptr<RooAbsReal> createNLL(RooAbsPdf &pdf, RooAbsData &data, std::uni
 } // namespace RooFit
 
 #endif
+
+/// \endcond

--- a/roofit/roofitcore/src/RooFit/Detail/CodeSquashContext.cxx
+++ b/roofit/roofitcore/src/RooFit/Detail/CodeSquashContext.cxx
@@ -13,29 +13,26 @@
 
 #include <RooFit/Detail/CodeSquashContext.h>
 
-#include <TString.h>
+#include <algorithm>
+#include <cctype>
 
 namespace RooFit {
 
 namespace Detail {
 
-/// Transform a string into a valid C++ variable name by replacing forbidden.
-/// \note The implementation was copy-pasted from `TSystem.cxx`.
+/// Transform a string into a valid C++ variable name by replacing forbidden
 /// characters with underscores.
 /// @param in The input string.
 /// @return A new string valid variable name.
-std::string CodeSquashContext::makeValidVarName(TString in) const
+std::string CodeSquashContext::makeValidVarName(std::string const &in) const
 {
-
-   static const int nForbidden = 27;
-   static const char *forbiddenChars[nForbidden] = {"+", "-", "*", "/", "&", "%", "|", "^",  ">",
-                                                    "<", "=", "~", ".", "(", ")", "[", "]",  "!",
-                                                    ",", "$", " ", ":", "'", "#", "@", "\\", "\""};
-   for (int ic = 0; ic < nForbidden; ic++) {
-      in.ReplaceAll(forbiddenChars[ic], "_");
+   std::string out;
+   if (std::isdigit(in[0])) {
+      out += '_';
    }
-
-   return in.Data();
+   out += in;
+   std::transform(out.begin(), out.end(), out.begin(), [](char c) { return std::isalnum(c) ? c : '_'; });
+   return out;
 }
 
 /// @brief Adds (or overwrites) the string representing the result of a node.

--- a/roofit/roofitcore/src/RooFit/Detail/CodeSquashContext.cxx
+++ b/roofit/roofitcore/src/RooFit/Detail/CodeSquashContext.cxx
@@ -13,27 +13,14 @@
 
 #include <RooFit/Detail/CodeSquashContext.h>
 
+#include "RooFitImplHelpers.h"
+
 #include <algorithm>
 #include <cctype>
 
 namespace RooFit {
 
 namespace Detail {
-
-/// Transform a string into a valid C++ variable name by replacing forbidden
-/// characters with underscores.
-/// @param in The input string.
-/// @return A new string valid variable name.
-std::string CodeSquashContext::makeValidVarName(std::string const &in) const
-{
-   std::string out;
-   if (std::isdigit(in[0])) {
-      out += '_';
-   }
-   out += in;
-   std::transform(out.begin(), out.end(), out.begin(), [](char c) { return std::isalnum(c) ? c : '_'; });
-   return out;
-}
 
 /// @brief Adds (or overwrites) the string representing the result of a node.
 /// @param key The name of the node to add the result for.
@@ -202,7 +189,7 @@ std::string CodeSquashContext::getTmpVarName()
 /// @param valueToSave The actual string value to save as a temporary.
 void CodeSquashContext::addResult(RooAbsArg const *in, std::string const &valueToSave)
 {
-   std::string savedName = makeValidVarName(in->GetName());
+   std::string savedName = RooFit::Detail::makeValidVarName(in->GetName());
 
    // Only save values if they contain operations.
    bool hasOperations = valueToSave.find_first_of(":-+/*") != std::string::npos;

--- a/roofit/roofitcore/src/RooFit/Evaluator.cxx
+++ b/roofit/roofitcore/src/RooFit/Evaluator.cxx
@@ -33,7 +33,6 @@ RooAbsPdf::fitTo() is called and gets destroyed when the fitting ends.
 #include <RooAbsReal.h>
 #include <RooRealVar.h>
 #include <RooBatchCompute.h>
-#include <RooHelpers.h>
 #include <RooMsgService.h>
 #include <RooNameReg.h>
 #include <RooSimultaneous.h>
@@ -41,6 +40,7 @@ RooAbsPdf::fitTo() is called and gets destroyed when the fitting ends.
 #include "BatchModeDataHelpers.h"
 #include "BatchModeHelpers.h"
 #include "Detail/Buffers.h"
+#include "RooFitImplHelpers.h"
 
 #include <chrono>
 #include <iomanip>
@@ -164,7 +164,7 @@ Evaluator::Evaluator(const RooAbsReal &absReal, bool useGPU)
    logArchitectureInfo(_useGPU);
 
    RooArgSet serverSet;
-   RooHelpers::getSortedComputationGraph(_topNode, serverSet);
+   ::RooHelpers::getSortedComputationGraph(_topNode, serverSet);
 
    _dataMapCPU.resize(serverSet.size());
 #ifdef R__HAS_CUDA
@@ -589,7 +589,7 @@ void Evaluator::markGPUNodes()
 void Evaluator::setOperMode(RooAbsArg *arg, RooAbsArg::OperMode opMode)
 {
    if (opMode != arg->operMode()) {
-      _changeOperModeRAIIs.emplace(arg, opMode);
+      _changeOperModeRAIIs.emplace(std::make_unique<ChangeOperModeRAII>(arg, opMode));
    }
 }
 

--- a/roofit/roofitcore/src/RooFitImplHelpers.cxx
+++ b/roofit/roofitcore/src/RooFitImplHelpers.cxx
@@ -1,0 +1,292 @@
+/// \cond ROOFIT_INTERNAL
+
+/*
+ * Project: RooFit
+ * Author:
+ *   Jonas Rembser, CERN 2023
+ *
+ * Copyright (c) 2023, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+
+#include <RooFitImplHelpers.h>
+
+#include <RooAbsCategory.h>
+#include <RooAbsData.h>
+#include <RooAbsPdf.h>
+#include <RooAbsRealLValue.h>
+#include <RooArgList.h>
+#include <RooDataHist.h>
+#include <RooDataSet.h>
+#include <RooProdPdf.h>
+#include <RooRealSumPdf.h>
+#include <RooSimultaneous.h>
+
+#include <ROOT/StringUtils.hxx>
+#include <TClass.h>
+
+#include <unordered_map>
+
+namespace RooHelpers {
+
+namespace {
+std::pair<double, double> getBinningInterval(RooAbsBinning const &binning)
+{
+   if (!binning.isParameterized()) {
+      return {binning.lowBound(), binning.highBound()};
+   } else {
+      return {binning.lowBoundFunc()->getVal(), binning.highBoundFunc()->getVal()};
+   }
+}
+} // namespace
+
+/// Get the lower and upper bound of parameter range if arg can be casted to RooAbsRealLValue.
+/// If no range with rangeName is defined for the argument, this will check if a binning of the
+/// same name exists and return the interval covered by the binning.
+/// Returns `{-infinity, infinity}` if argument can't be casted to RooAbsRealLValue* or if no
+/// range or binning with the requested name exists.
+/// \param[in] arg RooAbsArg for which to get the range.
+/// \param[in] rangeName The name of the range.
+std::pair<double, double> getRangeOrBinningInterval(RooAbsArg const *arg, const char *rangeName)
+{
+   auto rlv = dynamic_cast<RooAbsRealLValue const *>(arg);
+   if (rlv) {
+      if (rangeName && rlv->hasRange(rangeName)) {
+         return {rlv->getMin(rangeName), rlv->getMax(rangeName)};
+      } else if (auto binning = rlv->getBinningPtr(rangeName)) {
+         return getBinningInterval(*binning);
+      }
+   }
+   return {-std::numeric_limits<double>::infinity(), +std::numeric_limits<double>::infinity()};
+}
+
+/// Check if there is any overlap when a list of ranges is applied to a set of observables.
+/// \param[in] observables The observables to check for overlap
+/// \param[in] rangeNames The names of the ranges.
+bool checkIfRangesOverlap(RooArgSet const &observables, std::vector<std::string> const &rangeNames)
+{
+   // cache the range limits in a flat vector
+   std::vector<std::pair<double, double>> limits;
+   limits.reserve(rangeNames.size() * observables.size());
+
+   for (auto const &range : rangeNames) {
+      for (auto const &obs : observables) {
+         if (dynamic_cast<RooAbsCategory const *>(obs)) {
+            // Nothing to be done for category observables
+         } else if (auto *rlv = dynamic_cast<RooAbsRealLValue const *>(obs)) {
+            limits.emplace_back(rlv->getMin(range.c_str()), rlv->getMax(range.c_str()));
+         } else {
+            throw std::logic_error(
+               "Classes that represent observables are expected to inherit from RooAbsRealLValue or RooAbsCategory!");
+         }
+      }
+   }
+
+   auto nRanges = rangeNames.size();
+   auto nObs = limits.size() / nRanges; // number of observables that are not categories
+
+   // loop over pairs of ranges
+   for (size_t ir1 = 0; ir1 < nRanges; ++ir1) {
+      for (size_t ir2 = ir1 + 1; ir2 < nRanges; ++ir2) {
+
+         // Loop over observables. If all observables have overlapping limits for
+         // these ranges, the hypercubes defining the range are overlapping and we
+         // can return `true`.
+         size_t overlaps = 0;
+         for (size_t io1 = 0; io1 < nObs; ++io1) {
+            auto r1 = limits[ir1 * nObs + io1];
+            auto r2 = limits[ir2 * nObs + io1];
+            overlaps +=
+               (r1.second > r2.first && r1.first < r2.second) || (r2.second > r1.first && r2.first < r1.second);
+         }
+         if (overlaps == nObs)
+            return true;
+      }
+   }
+
+   return false;
+}
+
+/// Create a string with all sorted names of RooArgSet elements separated by delimiters.
+/// \param[in] argSet The input RooArgSet.
+std::string getColonSeparatedNameString(RooArgSet const &argSet, char delim)
+{
+
+   RooArgList tmp(argSet);
+   tmp.sort();
+
+   std::string content;
+   for (auto const &arg : tmp) {
+      content += arg->GetName();
+      content += delim;
+   }
+   if (!content.empty()) {
+      content.pop_back();
+   }
+   return content;
+}
+
+/// Construct a RooArgSet of objects in a RooArgSet whose names match to those
+/// in the names string.
+/// \param[in] argSet The input RooArgSet.
+/// \param[in] names The names of the objects to select in a colon-separated string.
+RooArgSet selectFromArgSet(RooArgSet const &argSet, std::string const &names)
+{
+   RooArgSet output;
+   for (auto const &name : ROOT::Split(names, ":")) {
+      if (auto arg = argSet.find(name.c_str()))
+         output.add(*arg);
+   }
+   return output;
+}
+
+std::string getRangeNameForSimComponent(std::string const &rangeName, bool splitRange, std::string const &catName)
+{
+   if (splitRange && !rangeName.empty()) {
+      std::string out;
+      auto tokens = ROOT::Split(rangeName, ",");
+      for (std::string const &token : tokens) {
+         out += token + "_" + catName + ",";
+      }
+      out.pop_back(); // to remove the last comma
+      return out;
+   }
+
+   return rangeName;
+}
+
+BinnedLOutput getBinnedL(RooAbsPdf const &pdf)
+{
+   if (pdf.getAttribute("BinnedLikelihood") && pdf.IsA()->InheritsFrom(RooRealSumPdf::Class())) {
+      // Simplest case: top-level of component is a RooRealSumPdf
+      return {const_cast<RooAbsPdf *>(&pdf), true};
+   } else if (pdf.IsA()->InheritsFrom(RooProdPdf::Class())) {
+      // Default case: top-level pdf is a product of RooRealSumPdf and other pdfs
+      for (RooAbsArg *component : static_cast<RooProdPdf const &>(pdf).pdfList()) {
+         if (component->getAttribute("BinnedLikelihood") && component->IsA()->InheritsFrom(RooRealSumPdf::Class())) {
+            return {static_cast<RooAbsPdf *>(component), true};
+         }
+         if (component->getAttribute("MAIN_MEASUREMENT")) {
+            // not really a binned pdf, but this prevents a (potentially) long list of subsidiary measurements to be
+            // passed to the slave calculator
+            return {static_cast<RooAbsPdf *>(component), false};
+         }
+      }
+   }
+   return {nullptr, false};
+}
+
+/// Get the topologically-sorted list of all nodes in the computation graph.
+void getSortedComputationGraph(RooAbsArg const &func, RooArgSet &out)
+{
+   // Get the set of nodes in the computation graph. Do the detour via
+   // RooArgList to avoid deduplication done after adding each element.
+   RooArgList serverList;
+   func.treeNodeServerList(&serverList, nullptr, true, true, false, true);
+   // If we fill the servers in reverse order, they are approximately in
+   // topological order so we save a bit of work in sortTopologically().
+   out.add(serverList.rbegin(), serverList.rend(), /*silent=*/true);
+   // Sort nodes topologically: the servers of any node will be before that
+   // node in the collection.
+   out.sortTopologically();
+}
+
+namespace Detail {
+
+namespace {
+
+using ToCloneList = std::vector<RooAbsArg const *>;
+using ToCloneMap = std::unordered_map<TNamed const *, RooAbsArg const *>;
+
+// Add clones of servers of given argument to end of list
+void addServerClonesToList(const RooAbsArg &var, ToCloneList &outlist, ToCloneMap &outmap, bool deepCopy,
+                           RooArgSet const *observables)
+{
+   if (outmap.find(var.namePtr()) != outmap.end()) {
+      return;
+   }
+
+   if (observables && var.isFundamental() && !observables->find(var)) {
+      return;
+   }
+
+   outmap[var.namePtr()] = &var;
+   outlist.push_back(&var);
+
+   if (deepCopy) {
+      for (const auto server : var.servers()) {
+         addServerClonesToList(*server, outlist, outmap, deepCopy, observables);
+      }
+   }
+}
+
+} // namespace
+
+/// Implementation of RooAbsCollection::snapshot() with some extra parameters.
+/// to be used in other RooHelpers functions.
+/// param[in] input The input collection.
+/// param[in] output The output collection.
+/// param[in] deepCopy If the whole computation graph should be cloned recursively.
+/// param[in] observables If this is not a nullptr, only the fundamental
+///                       variables that are in observables are deep cloned.
+bool snapshotImpl(RooAbsCollection const &input, RooAbsCollection &output, bool deepCopy, RooArgSet const *observables)
+{
+   // Figure out what needs to be cloned
+   ToCloneList toCloneList;
+   ToCloneMap toCloneMap;
+   for (RooAbsArg *orig : input) {
+      addServerClonesToList(*orig, toCloneList, toCloneMap, deepCopy, observables);
+   }
+
+   // Actually do the cloning
+   output.reserve(toCloneList.size());
+   for (RooAbsArg const *arg : toCloneList) {
+      std::unique_ptr<RooAbsArg> serverClone{static_cast<RooAbsArg *>(arg->Clone())};
+      serverClone->setAttribute("SnapShot_ExtRefClone");
+      output.addOwned(std::move(serverClone));
+   }
+
+   // Redirect all server connections to internal list members
+   for (RooAbsArg *var : output) {
+      var->redirectServers(output, deepCopy && !observables);
+   }
+
+   return false;
+}
+
+RooAbsArg *cloneTreeWithSameParametersImpl(RooAbsArg const &arg, RooArgSet const *observables)
+{
+   // Clone tree using snapshot
+   RooArgSet clonedNodes;
+   snapshotImpl(RooArgSet(arg), clonedNodes, true, observables);
+
+   // Find the head node in the cloneSet
+   RooAbsArg *head = clonedNodes.find(arg);
+   assert(head);
+
+   // We better to release the ownership before removing the "head". Otherwise,
+   // "head" might also be deleted as the clonedNodes collection owns it.
+   // (Actually this does not happen because even an owning collection doesn't
+   // delete the element when removed by pointer lookup, but it's better not to
+   // rely on this unexpected fact).
+   clonedNodes.releaseOwnership();
+
+   // Remove the head node from the cloneSet
+   // To release it from the set ownership
+   clonedNodes.remove(*head);
+
+   // Add the set as owned component of the head
+   head->addOwnedComponents(std::move(clonedNodes));
+
+   return head;
+}
+
+} // namespace Detail
+
+} // namespace RooHelpers
+
+/// \endcond

--- a/roofit/roofitcore/src/RooFitImplHelpers.cxx
+++ b/roofit/roofitcore/src/RooFitImplHelpers.cxx
@@ -12,7 +12,6 @@
  * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
  */
 
-
 #include <RooFitImplHelpers.h>
 
 #include <RooAbsCategory.h>
@@ -288,5 +287,26 @@ RooAbsArg *cloneTreeWithSameParametersImpl(RooAbsArg const &arg, RooArgSet const
 } // namespace Detail
 
 } // namespace RooHelpers
+
+namespace RooFit {
+namespace Detail {
+
+/// Transform a string into a valid C++ variable name by replacing forbidden
+/// characters with underscores.
+/// @param in The input string.
+/// @return A new string valid variable name.
+std::string makeValidVarName(std::string const &in)
+{
+   std::string out;
+   if (std::isdigit(in[0])) {
+      out += '_';
+   }
+   out += in;
+   std::transform(out.begin(), out.end(), out.begin(), [](char c) { return std::isalnum(c) ? c : '_'; });
+   return out;
+}
+
+} // namespace Detail
+} // namespace RooFit
 
 /// \endcond

--- a/roofit/roofitcore/src/RooHelpers.cxx
+++ b/roofit/roofitcore/src/RooHelpers.cxx
@@ -1,18 +1,14 @@
-// Author: Stephan Hageboeck, CERN  01/2019
-
-/*****************************************************************************
- * RooFit
- * Authors:                                                                  *
- *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
- *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
- *                                                                           *
- * Copyright (c) 2000-2019, Regents of the University of California          *
- *                          and Stanford University. All rights reserved.    *
- *                                                                           *
- * Redistribution and use in source and binary forms,                        *
- * with or without modification, are permitted according to the terms        *
- * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
- *****************************************************************************/
+/*
+ * Project: RooFit
+ * Author:
+ *   Stephan Hageboeck, CERN 2019
+ *
+ * Copyright (c) 2023, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
 
 #include <RooHelpers.h>
 
@@ -23,9 +19,9 @@
 #include <RooArgList.h>
 #include <RooDataHist.h>
 #include <RooDataSet.h>
-#include <RooSimultaneous.h>
 #include <RooProdPdf.h>
 #include <RooRealSumPdf.h>
+#include <RooSimultaneous.h>
 
 #include <ROOT/StringUtils.hxx>
 #include <TClass.h>
@@ -34,87 +30,84 @@
 
 namespace RooHelpers {
 
-LocalChangeMsgLevel::LocalChangeMsgLevel(RooFit::MsgLevel lvl,
-    unsigned int extraTopics, unsigned int removeTopics, bool overrideExternalLevel) {
-  auto& msg = RooMsgService::instance();
-  fOldKillBelow = msg.globalKillBelow();
-  if (overrideExternalLevel) msg.setGlobalKillBelow(lvl);
+LocalChangeMsgLevel::LocalChangeMsgLevel(RooFit::MsgLevel lvl, unsigned int extraTopics, unsigned int removeTopics,
+                                         bool overrideExternalLevel)
+{
+   auto &msg = RooMsgService::instance();
+   fOldKillBelow = msg.globalKillBelow();
+   if (overrideExternalLevel)
+      msg.setGlobalKillBelow(lvl);
 
-  for (int i = 0; i < msg.numStreams(); ++i) {
-    fOldConf.push_back(msg.getStream(i));
-    if (overrideExternalLevel) msg.getStream(i).minLevel = lvl;
-    msg.getStream(i).removeTopic(static_cast<RooFit::MsgTopic>(removeTopics));
-    msg.setStreamStatus(i, true);
-  }
+   for (int i = 0; i < msg.numStreams(); ++i) {
+      fOldConf.push_back(msg.getStream(i));
+      if (overrideExternalLevel)
+         msg.getStream(i).minLevel = lvl;
+      msg.getStream(i).removeTopic(static_cast<RooFit::MsgTopic>(removeTopics));
+      msg.setStreamStatus(i, true);
+   }
 
-  if (extraTopics != 0) {
-    fExtraStream = msg.addStream(lvl);
-    msg.getStream(fExtraStream).addTopic(static_cast<RooFit::MsgTopic>(extraTopics));
-  }
+   if (extraTopics != 0) {
+      fExtraStream = msg.addStream(lvl);
+      msg.getStream(fExtraStream).addTopic(static_cast<RooFit::MsgTopic>(extraTopics));
+   }
 }
 
-LocalChangeMsgLevel::~LocalChangeMsgLevel() {
-  auto& msg = RooMsgService::instance();
-  msg.setGlobalKillBelow(fOldKillBelow);
-  for (int i=0; i < msg.numStreams(); ++i) {
-    if (i < static_cast<int>(fOldConf.size()))
-      msg.getStream(i) = fOldConf[i];
-  }
+LocalChangeMsgLevel::~LocalChangeMsgLevel()
+{
+   auto &msg = RooMsgService::instance();
+   msg.setGlobalKillBelow(fOldKillBelow);
+   for (int i = 0; i < msg.numStreams(); ++i) {
+      if (i < static_cast<int>(fOldConf.size()))
+         msg.getStream(i) = fOldConf[i];
+   }
 
-  if (fExtraStream > 0)
-    msg.deleteStream(fExtraStream);
+   if (fExtraStream > 0)
+      msg.deleteStream(fExtraStream);
 }
-
 
 /// Hijack all messages with given level and topics while this object is alive.
 /// \param[in] level Minimum level to hijack. Higher levels also get captured.
-/// \param[in] topics Topics to hijack. Use `|` to combine different topics, and cast to `RooFit::MsgTopic` if necessary.
-/// \param[in] objectName Only hijack messages from an object with the given name. Defaults to any object.
-HijackMessageStream::HijackMessageStream(RooFit::MsgLevel level, RooFit::MsgTopic topics, const char* objectName)
+/// \param[in] topics Topics to hijack. Use `|` to combine different topics, and cast to `RooFit::MsgTopic` if
+/// necessary. \param[in] objectName Only hijack messages from an object with the given name. Defaults to any object.
+HijackMessageStream::HijackMessageStream(RooFit::MsgLevel level, RooFit::MsgTopic topics, const char *objectName)
 {
-  auto& msg = RooMsgService::instance();
-  _oldKillBelow = msg.globalKillBelow();
-  if (_oldKillBelow > level)
-    msg.setGlobalKillBelow(level);
+   auto &msg = RooMsgService::instance();
+   _oldKillBelow = msg.globalKillBelow();
+   if (_oldKillBelow > level)
+      msg.setGlobalKillBelow(level);
 
-  std::vector<RooMsgService::StreamConfig> tmpStreams;
-  for (int i = 0; i < msg.numStreams(); ++i) {
-    _oldConf.push_back(msg.getStream(i));
-    if (msg.getStream(i).match(level, topics, static_cast<RooAbsArg*>(nullptr))) {
-      tmpStreams.push_back(msg.getStream(i));
-      msg.setStreamStatus(i, false);
-    }
-  }
+   std::vector<RooMsgService::StreamConfig> tmpStreams;
+   for (int i = 0; i < msg.numStreams(); ++i) {
+      _oldConf.push_back(msg.getStream(i));
+      if (msg.getStream(i).match(level, topics, static_cast<RooAbsArg *>(nullptr))) {
+         tmpStreams.push_back(msg.getStream(i));
+         msg.setStreamStatus(i, false);
+      }
+   }
 
-  _thisStream = msg.addStream(level,
-      RooFit::Topic(topics),
-      RooFit::OutputStream(_str),
-      objectName ? RooFit::ObjectName(objectName) : RooCmdArg());
+   _thisStream = msg.addStream(level, RooFit::Topic(topics), RooFit::OutputStream(_str),
+                               objectName ? RooFit::ObjectName(objectName) : RooCmdArg());
 
-  for (RooMsgService::StreamConfig& st : tmpStreams) {
-    msg.addStream(st.minLevel,
-        RooFit::Topic(st.topic),
-        RooFit::OutputStream(*st.os),
-        RooFit::ObjectName(st.objectName.c_str()),
-        RooFit::ClassName(st.className.c_str()),
-        RooFit::BaseClassName(st.baseClassName.c_str()),
-        RooFit::TagName(st.tagName.c_str()));
-  }
+   for (RooMsgService::StreamConfig &st : tmpStreams) {
+      msg.addStream(st.minLevel, RooFit::Topic(st.topic), RooFit::OutputStream(*st.os),
+                    RooFit::ObjectName(st.objectName.c_str()), RooFit::ClassName(st.className.c_str()),
+                    RooFit::BaseClassName(st.baseClassName.c_str()), RooFit::TagName(st.tagName.c_str()));
+   }
 }
 
 /// Deregister the hijacked stream and restore the stream state of all previous streams.
-HijackMessageStream::~HijackMessageStream() {
-  auto& msg = RooMsgService::instance();
-  msg.setGlobalKillBelow(_oldKillBelow);
-  for (unsigned int i = 0; i < _oldConf.size(); ++i) {
-    msg.getStream(i) = _oldConf[i];
-  }
+HijackMessageStream::~HijackMessageStream()
+{
+   auto &msg = RooMsgService::instance();
+   msg.setGlobalKillBelow(_oldKillBelow);
+   for (unsigned int i = 0; i < _oldConf.size(); ++i) {
+      msg.getStream(i) = _oldConf[i];
+   }
 
-  while (_thisStream < msg.numStreams()) {
-    msg.deleteStream(_thisStream);
-  }
+   while (_thisStream < msg.numStreams()) {
+      msg.deleteStream(_thisStream);
+   }
 }
-
 
 /// \param[in] callingClass Class that's calling. Needed to include name and type name of the class in error message.
 /// \param[in] pars List of all parameters to be checked.
@@ -122,287 +115,35 @@ HijackMessageStream::~HijackMessageStream() {
 /// \param[in] max Maximum of allowed range. `max` itself counts as disallowed.
 /// \param[in] limitsInAllowedRange If true, the limits passed as parameters are part of the allowed range.
 /// \param[in] extraMessage Message that should be appended to the warning.
-void checkRangeOfParameters(const RooAbsReal* callingClass, std::initializer_list<const RooAbsReal*> pars,
-    double min, double max, bool limitsInAllowedRange, std::string const& extraMessage) {
-  const char openBr = limitsInAllowedRange ? '[' : '(';
-  const char closeBr = limitsInAllowedRange ? ']' : ')';
-
-  for (auto parameter : pars) {
-    auto par = dynamic_cast<const RooAbsRealLValue*>(parameter);
-    if (par && (
-        (par->getMin() < min || par->getMax() > max)
-        || (!limitsInAllowedRange && (par->getMin() == min || par->getMax() == max)) )) {
-      std::stringstream rangeMsg;
-      rangeMsg << openBr;
-      if (min > -std::numeric_limits<double>::max())
-        rangeMsg << min << ", ";
-      else
-        rangeMsg << "-inf, ";
-
-      if (max < std::numeric_limits<double>::max())
-        rangeMsg << max << closeBr;
-      else
-        rangeMsg << "inf" << closeBr;
-
-      oocoutW(callingClass, InputArguments) << "The parameter '" << par->GetName() << "' with range [" << par->getMin("") << ", "
-          << par->getMax() << "] of the " << callingClass->ClassName() << " '" << callingClass->GetName()
-          << "' exceeds the safe range of " << rangeMsg.str() << ". Advise to limit its range."
-          << (!extraMessage.empty() ? "\n" : "") << extraMessage << std::endl;
-    }
-  }
-}
-
-
-namespace {
-  std::pair<double, double> getBinningInterval(RooAbsBinning const& binning) {
-    if (!binning.isParameterized()) {
-      return {binning.lowBound(), binning.highBound()};
-    } else {
-      return {binning.lowBoundFunc()->getVal(), binning.highBoundFunc()->getVal()};
-    }
-  }
-} // namespace
-
-
-/// Get the lower and upper bound of parameter range if arg can be casted to RooAbsRealLValue.
-/// If no range with rangeName is defined for the argument, this will check if a binning of the
-/// same name exists and return the interval covered by the binning.
-/// Returns `{-infinity, infinity}` if argument can't be casted to RooAbsRealLValue* or if no
-/// range or binning with the requested name exists.
-/// \param[in] arg RooAbsArg for which to get the range.
-/// \param[in] rangeName The name of the range.
-std::pair<double, double> getRangeOrBinningInterval(RooAbsArg const* arg, const char* rangeName) {
-  auto rlv = dynamic_cast<RooAbsRealLValue const*>(arg);
-  if (rlv) {
-    if (rangeName && rlv->hasRange(rangeName)) {
-      return {rlv->getMin(rangeName), rlv->getMax(rangeName)};
-    } else if (auto binning = rlv->getBinningPtr(rangeName)) {
-      return getBinningInterval(*binning);
-    }
-  }
-  return {-std::numeric_limits<double>::infinity(), +std::numeric_limits<double>::infinity()};
-}
-
-
-/// Check if there is any overlap when a list of ranges is applied to a set of observables.
-/// \param[in] observables The observables to check for overlap
-/// \param[in] rangeNames The names of the ranges.
-bool checkIfRangesOverlap(RooArgSet const& observables, std::vector<std::string> const& rangeNames)
+void checkRangeOfParameters(const RooAbsReal *callingClass, std::initializer_list<const RooAbsReal *> pars, double min,
+                            double max, bool limitsInAllowedRange, std::string const &extraMessage)
 {
-  // cache the range limits in a flat vector
-  std::vector<std::pair<double,double>> limits;
-  limits.reserve(rangeNames.size() * observables.size());
+   const char openBr = limitsInAllowedRange ? '[' : '(';
+   const char closeBr = limitsInAllowedRange ? ']' : ')';
 
-  for (auto const& range : rangeNames) {
-    for (auto const& obs : observables) {
-      if(dynamic_cast<RooAbsCategory const*>(obs)) {
-        // Nothing to be done for category observables
-      } else if(auto * rlv = dynamic_cast<RooAbsRealLValue const*>(obs)) {
-        limits.emplace_back(rlv->getMin(range.c_str()), rlv->getMax(range.c_str()));
-      } else {
-        throw std::logic_error("Classes that represent observables are expected to inherit from RooAbsRealLValue or RooAbsCategory!");
-      }
-    }
-  }
+   for (auto parameter : pars) {
+      auto par = dynamic_cast<const RooAbsRealLValue *>(parameter);
+      if (par && ((par->getMin() < min || par->getMax() > max) ||
+                  (!limitsInAllowedRange && (par->getMin() == min || par->getMax() == max)))) {
+         std::stringstream rangeMsg;
+         rangeMsg << openBr;
+         if (min > -std::numeric_limits<double>::max())
+            rangeMsg << min << ", ";
+         else
+            rangeMsg << "-inf, ";
 
-  auto nRanges = rangeNames.size();
-  auto nObs = limits.size() / nRanges; // number of observables that are not categories
+         if (max < std::numeric_limits<double>::max())
+            rangeMsg << max << closeBr;
+         else
+            rangeMsg << "inf" << closeBr;
 
-  // loop over pairs of ranges
-  for(size_t ir1 = 0; ir1 < nRanges; ++ir1) {
-    for(size_t ir2 = ir1 + 1; ir2 < nRanges; ++ir2) {
-
-      // Loop over observables. If all observables have overlapping limits for
-      // these ranges, the hypercubes defining the range are overlapping and we
-      // can return `true`.
-      size_t overlaps = 0;
-      for(size_t io1 = 0; io1 < nObs; ++io1) {
-        auto r1 = limits[ir1 * nObs + io1];
-        auto r2 = limits[ir2 * nObs + io1];
-        overlaps += (r1.second > r2.first && r1.first < r2.second)
-                 || (r2.second > r1.first && r2.first < r1.second);
-      }
-      if(overlaps == nObs) return true;
-    }
-  }
-
-  return false;
-}
-
-
-/// Create a string with all sorted names of RooArgSet elements separated by delimiters.
-/// \param[in] argSet The input RooArgSet.
-std::string getColonSeparatedNameString(RooArgSet const& argSet, char delim) {
-
-  RooArgList tmp(argSet);
-  tmp.sort();
-
-  std::string content;
-  for(auto const& arg : tmp) {
-    content += arg->GetName();
-    content += delim;
-  }
-  if(!content.empty()) {
-    content.pop_back();
-  }
-  return content;
-}
-
-
-/// Construct a RooArgSet of objects in a RooArgSet whose names match to those
-/// in the names string.
-/// \param[in] argSet The input RooArgSet.
-/// \param[in] names The names of the objects to select in a colon-separated string.
-RooArgSet selectFromArgSet(RooArgSet const& argSet, std::string const& names) {
-  RooArgSet output;
-  for(auto const& name : ROOT::Split(names, ":")) {
-    if(auto arg = argSet.find(name.c_str())) output.add(*arg);
-  }
-  return output;
-}
-
-
-std::string getRangeNameForSimComponent(std::string const& rangeName, bool splitRange, std::string const& catName)
-{
-   if (splitRange && !rangeName.empty()) {
-      std::string out;
-      auto tokens = ROOT::Split(rangeName, ",");
-      for(std::string const& token : tokens) {
-         out += token + "_" + catName + ",";
-      }
-      out.pop_back(); // to remove the last comma
-      return out;
-   }
-
-   return rangeName;
-}
-
-BinnedLOutput getBinnedL(RooAbsPdf const &pdf)
-{
-   if (pdf.getAttribute("BinnedLikelihood") && pdf.IsA()->InheritsFrom(RooRealSumPdf::Class())) {
-      // Simplest case: top-level of component is a RooRealSumPdf
-      return {const_cast<RooAbsPdf *>(&pdf), true};
-   } else if (pdf.IsA()->InheritsFrom(RooProdPdf::Class())) {
-      // Default case: top-level pdf is a product of RooRealSumPdf and other pdfs
-      for (RooAbsArg *component : static_cast<RooProdPdf const &>(pdf).pdfList()) {
-         if (component->getAttribute("BinnedLikelihood") && component->IsA()->InheritsFrom(RooRealSumPdf::Class())) {
-            return {static_cast<RooAbsPdf *>(component), true};
-         }
-         if (component->getAttribute("MAIN_MEASUREMENT")) {
-            // not really a binned pdf, but this prevents a (potentially) long list of subsidiary measurements to be
-            // passed to the slave calculator
-            return {static_cast<RooAbsPdf *>(component), false};
-         }
-      }
-   }
-   return {nullptr, false};
-}
-
-/// Get the topologically-sorted list of all nodes in the computation graph.
-void getSortedComputationGraph(RooAbsArg const &func, RooArgSet &out)
-{
-   // Get the set of nodes in the computation graph. Do the detour via
-   // RooArgList to avoid deduplication done after adding each element.
-   RooArgList serverList;
-   func.treeNodeServerList(&serverList, nullptr, true, true, false, true);
-   // If we fill the servers in reverse order, they are approximately in
-   // topological order so we save a bit of work in sortTopologically().
-   out.add(serverList.rbegin(), serverList.rend(), /*silent=*/true);
-   // Sort nodes topologically: the servers of any node will be before that
-   // node in the collection.
-   out.sortTopologically();
-}
-
-namespace Detail {
-
-namespace {
-
-using ToCloneList = std::vector<RooAbsArg const *>;
-using ToCloneMap = std::unordered_map<TNamed const *, RooAbsArg const *>;
-
-// Add clones of servers of given argument to end of list
-void addServerClonesToList(const RooAbsArg &var, ToCloneList &outlist, ToCloneMap &outmap, bool deepCopy,
-                           RooArgSet const *observables)
-{
-   if (outmap.find(var.namePtr()) != outmap.end()) {
-      return;
-   }
-
-   if (observables && var.isFundamental() && !observables->find(var)) {
-      return;
-   }
-
-   outmap[var.namePtr()] = &var;
-   outlist.push_back(&var);
-
-   if (deepCopy) {
-      for (const auto server : var.servers()) {
-         addServerClonesToList(*server, outlist, outmap, deepCopy, observables);
+         oocoutW(callingClass, InputArguments)
+            << "The parameter '" << par->GetName() << "' with range [" << par->getMin("") << ", " << par->getMax()
+            << "] of the " << callingClass->ClassName() << " '" << callingClass->GetName()
+            << "' exceeds the safe range of " << rangeMsg.str() << ". Advise to limit its range."
+            << (!extraMessage.empty() ? "\n" : "") << extraMessage << std::endl;
       }
    }
 }
 
-} // namespace
-
-/// Implementation of RooAbsCollection::snapshot() with some extra parameters.
-/// to be used in other RooHelpers functions.
-/// param[in] input The input collection.
-/// param[in] output The output collection.
-/// param[in] deepCopy If the whole computation graph should be cloned recursively.
-/// param[in] observables If this is not a nullptr, only the fundamental
-///                       variables that are in observables are deep cloned.
-bool snapshotImpl(RooAbsCollection const &input, RooAbsCollection &output, bool deepCopy, RooArgSet const *observables)
-{
-   // Figure out what needs to be cloned
-   ToCloneList toCloneList;
-   ToCloneMap toCloneMap;
-   for (RooAbsArg *orig : input) {
-      addServerClonesToList(*orig, toCloneList, toCloneMap, deepCopy, observables);
-   }
-
-   // Actually do the cloning
-   output.reserve(toCloneList.size());
-   for (RooAbsArg const *arg : toCloneList) {
-      std::unique_ptr<RooAbsArg> serverClone{static_cast<RooAbsArg *>(arg->Clone())};
-      serverClone->setAttribute("SnapShot_ExtRefClone");
-      output.addOwned(std::move(serverClone));
-   }
-
-   // Redirect all server connections to internal list members
-   for (RooAbsArg *var : output) {
-      var->redirectServers(output, deepCopy && !observables);
-   }
-
-   return false;
-}
-
-RooAbsArg *cloneTreeWithSameParametersImpl(RooAbsArg const &arg, RooArgSet const *observables)
-{
-   // Clone tree using snapshot
-   RooArgSet clonedNodes;
-   snapshotImpl(RooArgSet(arg), clonedNodes, true, observables);
-
-   // Find the head node in the cloneSet
-   RooAbsArg *head = clonedNodes.find(arg);
-   assert(head);
-
-   // We better to release the ownership before removing the "head". Otherwise,
-   // "head" might also be deleted as the clonedNodes collection owns it.
-   // (Actually this does not happen because even an owning collection doesn't
-   // delete the element when removed by pointer lookup, but it's better not to
-   // rely on this unexpected fact).
-   clonedNodes.releaseOwnership();
-
-   // Remove the head node from the cloneSet
-   // To release it from the set ownership
-   clonedNodes.remove(*head);
-
-   // Add the set as owned component of the head
-   head->addOwnedComponents(std::move(clonedNodes));
-
-   return head;
-}
-
-} // namespace Detail
-
-}
+} // namespace RooHelpers

--- a/roofit/roofitcore/src/RooHistFunc.cxx
+++ b/roofit/roofitcore/src/RooHistFunc.cxx
@@ -31,7 +31,7 @@ discrete dimensions and may have negative values.
 #include "RooCategory.h"
 #include "RooWorkspace.h"
 #include "RooHistPdf.h"
-#include "RooHelpers.h"
+#include "RooFitImplHelpers.h"
 
 #include "TError.h"
 #include "TBuffer.h"

--- a/roofit/roofitcore/src/RooHistPdf.cxx
+++ b/roofit/roofitcore/src/RooHistPdf.cxx
@@ -27,16 +27,16 @@ discrete dimensions.
 
 #include "Riostream.h"
 
-#include "RooHistPdf.h"
+#include "RooCategory.h"
 #include "RooCurve.h"
 #include "RooDataHist.h"
+#include "RooFitImplHelpers.h"
+#include "RooGlobalFunc.h"
+#include "RooHistPdf.h"
 #include "RooMsgService.h"
 #include "RooRealVar.h"
-#include "RooCategory.h"
-#include "RooWorkspace.h"
-#include "RooGlobalFunc.h"
-#include "RooHelpers.h"
 #include "RooUniformBinning.h"
+#include "RooWorkspace.h"
 
 #include "TError.h"
 #include "TBuffer.h"

--- a/roofit/roofitcore/src/RooNLLVarNew.cxx
+++ b/roofit/roofitcore/src/RooNLLVarNew.cxx
@@ -32,6 +32,8 @@ computation times.
 #include <RooSetProxy.h>
 #include "RooFit/Detail/Buffers.h"
 
+#include "RooFitImplHelpers.h"
+
 #include <ROOT/StringUtils.hxx>
 
 #include <TClass.h>
@@ -357,8 +359,8 @@ double RooNLLVarNew::finalizeResult(ROOT::Math::KahanSum<double> result, double 
 
 void RooNLLVarNew::translate(RooFit::Detail::CodeSquashContext &ctx) const
 {
-   std::string weightSumName = ctx.makeValidVarName(GetName()) + "WeightSum";
-   std::string resName = ctx.makeValidVarName(GetName()) + "Result";
+   std::string weightSumName = RooFit::Detail::makeValidVarName(GetName()) + "WeightSum";
+   std::string resName = RooFit::Detail::makeValidVarName(GetName()) + "Result";
    ctx.addResult(this, resName);
    ctx.addToGlobalScope("double " + weightSumName + " = 0.0;\n");
    ctx.addToGlobalScope("double " + resName + " = 0.0;\n");

--- a/roofit/roofitcore/src/RooNormSetCache.cxx
+++ b/roofit/roofitcore/src/RooNormSetCache.cxx
@@ -33,7 +33,8 @@ during their lifetime.
 **/
 
 #include <RooNormSetCache.h>
-#include <RooHelpers.h>
+
+#include "RooFitImplHelpers.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Clear contents
@@ -85,11 +86,6 @@ bool RooNormSetCache::autoCache(const RooAbsArg* self, const RooArgSet* set1,
 
   // B - Check if dependents(set1/set2) are compatible with current cache
 
-//   cout << "RooNormSetCache::autoCache set1 = " << (set1?*set1:RooArgSet()) << " set2 = " << (set2?*set2:RooArgSet()) << endl;
-//   if (set1) set1->Print("v");
-//   if (set2) set2->Print("v");
-  //if (self) self->Print("v");
-
   RooArgSet set1d;
   RooArgSet set2d;
   if (self) {
@@ -99,8 +95,6 @@ bool RooNormSetCache::autoCache(const RooAbsArg* self, const RooArgSet* set1,
     if(set1) set1->snapshot(set1d);
     if(set2) set2->snapshot(set2d);
   }
-
-//   cout << "RooNormSetCache::autoCache set1d = " << *set1d << " set2 = " << *set2d << endl;
 
   using RooHelpers::getColonSeparatedNameString;
 
@@ -119,8 +113,6 @@ bool RooNormSetCache::autoCache(const RooAbsArg* self, const RooArgSet* set1,
     add(set1,set2);
     _name1 = getColonSeparatedNameString(set1d);
     _name2 = getColonSeparatedNameString(set2d);
-//     cout << "RooNormSetCache::autoCache() _name1 refilled from " << *set1d << " to " ; _name1.printValue(cout) ; cout << endl;
-//     cout << "RooNormSetCache::autoCache() _name2 refilled from " << *set2d << " to " ; _name2.printValue(cout) ; cout << endl;
     _set2RangeName = (TNamed*) set2RangeName;
   }
 

--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -59,7 +59,7 @@ have to appear in any specific place in the list.
 #include "RooCustomizer.h"
 #include "RooRealIntegral.h"
 #include "RooTrace.h"
-#include "RooHelpers.h"
+#include "RooFitImplHelpers.h"
 #include "RooBatchCompute.h"
 #include "strtok.h"
 

--- a/roofit/roofitcore/src/RooRealIntegral.cxx
+++ b/roofit/roofitcore/src/RooRealIntegral.cxx
@@ -47,6 +47,8 @@ integration is performed in the various implementations of the RooAbsIntegrator 
 #include <RooSuperCategory.h>
 #include <RooTrace.h>
 
+#include "RooFitImplHelpers.h"
+
 #include <TClass.h>
 
 #include <iostream>
@@ -1113,7 +1115,7 @@ void RooRealIntegral::translate(RooFit::Detail::CodeSquashContext &ctx) const
 
    std::stringstream ss;
 
-   std::string resName = ctx.makeValidVarName(GetName()) + "Result";
+   std::string resName = RooFit::Detail::makeValidVarName(GetName()) + "Result";
    ctx.addResult(this, resName);
    ctx.addToGlobalScope("double " + resName + " = 0.0;\n");
 

--- a/roofit/roofitcore/src/RooSimultaneous.cxx
+++ b/roofit/roofitcore/src/RooSimultaneous.cxx
@@ -47,27 +47,30 @@ in each category.
 **/
 
 #include "RooSimultaneous.h"
-#include "RooAbsCategoryLValue.h"
-#include "RooPlot.h"
-#include "RooRealVar.h"
-#include "RooAddPdf.h"
-#include "RooAbsData.h"
+
 #include "Roo1DTable.h"
-#include "RooSimGenContext.h"
-#include "RooSimSplitGenContext.h"
-#include "RooDataSet.h"
-#include "RooCmdConfig.h"
-#include "RooNameReg.h"
-#include "RooGlobalFunc.h"
-#include "RooMsgService.h"
-#include "RooCategory.h"
-#include "RooSuperCategory.h"
-#include "RooDataHist.h"
-#include "RooRandom.h"
+#include "RooAbsCategoryLValue.h"
+#include "RooAbsData.h"
+#include "RooAddPdf.h"
 #include "RooArgSet.h"
 #include "RooBinSamplingPdf.h"
+#include "RooCategory.h"
+#include "RooCmdConfig.h"
+#include "RooDataHist.h"
+#include "RooDataSet.h"
+#include "RooGlobalFunc.h"
+#include "RooMsgService.h"
+#include "RooNameReg.h"
+#include "RooPlot.h"
+#include "RooRandom.h"
+#include "RooRealVar.h"
+#include "RooSimGenContext.h"
+#include "RooSimSplitGenContext.h"
+#include "RooSuperCategory.h"
 
-#include "ROOT/StringUtils.hxx"
+#include "RooFitImplHelpers.h"
+
+#include <ROOT/StringUtils.hxx>
 
 #include <iostream>
 

--- a/roofit/roofitcore/src/RooVectorDataStore.cxx
+++ b/roofit/roofitcore/src/RooVectorDataStore.cxx
@@ -40,7 +40,7 @@ which returns spans pointing directly to the data.
 #include "RooCategory.h"
 #include "RooHistError.h"
 #include "RooTrace.h"
-#include "RooHelpers.h"
+#include "RooFitImplHelpers.h"
 
 #include "Math/Util.h"
 #include "ROOT/StringUtils.hxx"

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodJob.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodJob.cxx
@@ -12,17 +12,18 @@
 
 #include "RooFit/TestStatistics/LikelihoodWrapper.h"
 
-#include "RooRandom.h"
-#include "RooWorkspace.h"
-#include "RooMinimizer.h"
-#include "RooFitResult.h"
-#include "RooDataHist.h" // complete type in Binned test
-#include "RooCategory.h" // complete type in MultiBinnedConstraint test
-#include "RooFit/TestStatistics/RooUnbinnedL.h"
-#include "RooFit/TestStatistics/RooBinnedL.h"
-#include "RooFit/TestStatistics/buildLikelihood.h"
-#include "RooFit/TestStatistics/RooRealL.h"
-#include "RooFit/MultiProcess/Config.h"
+#include <RooRandom.h>
+#include <RooWorkspace.h>
+#include <RooMinimizer.h>
+#include <RooFitResult.h>
+#include <RooDataHist.h> // complete type in Binned test
+#include <RooCategory.h> // complete type in MultiBinnedConstraint test
+#include <RooFit/TestStatistics/RooUnbinnedL.h>
+#include <RooFit/TestStatistics/RooBinnedL.h>
+#include <RooFit/TestStatistics/buildLikelihood.h>
+#include <RooFit/TestStatistics/RooRealL.h>
+#include <RooFit/MultiProcess/Config.h>
+#include <RooHelpers.h>
 
 #include "Math/Util.h" // KahanSum
 

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodSerial.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodSerial.cxx
@@ -24,6 +24,7 @@
 #include <RooFit/TestStatistics/RooSumL.h>
 #include <RooFit/TestStatistics/buildLikelihood.h>
 #include <RooFit/TestStatistics/RooRealL.h>
+#include <RooHelpers.h>
 
 #include "Math/Util.h" // KahanSum
 

--- a/roofit/roofitcore/test/TestStatistics/testPlot.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testPlot.cxx
@@ -10,16 +10,17 @@
  * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
  */
 
-#include <RooWorkspace.h>
-#include <RooPlot.h>
-#include <RooDataSet.h>
-#include <RooFit/TestStatistics/buildLikelihood.h>
 #include <RooAbsPdf.h>
-#include <RooRealVar.h>
-#include <RooFit/TestStatistics/RooRealL.h>
+#include <RooDataSet.h>
 #include <RooFit/MultiProcess/Config.h>
+#include <RooFit/TestStatistics/RooRealL.h>
+#include <RooFit/TestStatistics/buildLikelihood.h>
+#include <RooHelpers.h>
 #include <RooMinimizer.h>
+#include <RooPlot.h>
+#include <RooRealVar.h>
 #include <RooUnitTest.h>
+#include <RooWorkspace.h>
 
 #include <TFile.h>
 

--- a/roofit/roofitcore/test/TestStatistics/testRooAbsL.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testRooAbsL.cxx
@@ -24,6 +24,7 @@
 #include <RooFit/TestStatistics/RooSumL.h>
 #include <RooFit/TestStatistics/buildLikelihood.h>
 #include <RooFit/TestStatistics/RooRealL.h>
+#include <RooHelpers.h>
 
 #include "Math/Util.h" // KahanSum
 


### PR DESCRIPTION
# This Pull request:

This PR contains a few hotfixes to the HS3 implementation.

## Changes or fixes:

- attempting to export a forbidden variable name now triggers an error message
- export-keys-based exporters now use RooAbsProxy instead of RooRealProxy to allow also non-function-type and non-list-type proxies to be exported successfully.
- added a unit test for import and export of RooBernstein to cover the import/export issues for export-keys-based exporters.
- invalid category names will now be fixed upon export such that they don't lead to invalid data names
- FlexibleInterpVars with unequal numbers of variables and high/low variations will now be cut-off on minimum length upon export.
- HistFactory ShapeSys and staterror will now export and import the parameter names instead of auto-generating them.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

