### PR TITLE
[tmva] Improve CNN and RNN tutorials

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -264,7 +264,7 @@ if(NOT TBB_FOUND AND NOT builtin_tbb)
 endif()
 
 if(NOT ROOT_imt_FOUND)
-  set(imt_veto multicore/imt*.C multicore/mt*.C tmva/TMVA_CNN_Classification.C)
+  set(imt_veto multicore/imt*.C multicore/mt*.C)
 endif()
 if(MSVC)
   #---Multiproc is not supported on Windows

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -828,6 +828,9 @@ if(ROOT_pyroot_FOUND)
   # Avoid a race condition: make sure Python tutorial is ran after C++ tutorial
   set(roofit-rf104_classfactory-depends tutorial-roofit-rf104_classfactory)
   set(roofit-rf512_wsfactory_oper-depends tutorial-roofit-rf512_wsfactory_oper)
+  set (tmva-Higgs_CNN_Classification-depends tutorial-tmva-TMVA_Higgs_Classification)
+  set (tmva-TMVA_CNN_Classification-depends tutorial-tmva-TMVA_CNN_Classification)
+  set (tmva-TMVA_RNN_Classification-depends tutorial-tmva-TMVA_RNN_Classification)
 
   #----------------------------------------------------------------------
   # List requirements for python tutorials.

--- a/tutorials/tmva/TMVA_CNN_Classification.C
+++ b/tutorials/tmva/TMVA_CNN_Classification.C
@@ -134,16 +134,18 @@ void TMVA_CNN_Classification(int nevts = 1000, std::vector<bool> opt = {1, 1, 1,
 
    bool writeOutputFile = true;
 
+#ifdef R__USE_IMT
    int num_threads = 4;  // use by default 4 threads if value is not set before
    // switch off MT in OpenBLAS to avoid conflict with tbb
    gSystem->Setenv("OMP_NUM_THREADS", "1");
-
-   TMVA::Tools::Instance();
 
    // do enable MT running
    if (num_threads >= 0) {
       ROOT::EnableImplicitMT(num_threads);
    }
+#endif
+
+   TMVA::Tools::Instance();
 
 
    std::cout << "Running with nthreads  = " << ROOT::GetThreadPoolSize() << std::endl;
@@ -320,7 +322,7 @@ void TMVA_CNN_Classification(int nevts = 1000, std::vector<bool> opt = {1, 1, 1,
       // parameters) The training string must be concatenates with the `|` delimiter
       TString trainingString1("LearningRate=1e-3,Momentum=0.9,Repetitions=1,"
                               "ConvergenceSteps=5,BatchSize=100,TestRepetitions=1,"
-                              "MaxEpochs=20,WeightDecay=1e-4,Regularization=None,"
+                              "MaxEpochs=10,WeightDecay=1e-4,Regularization=None,"
                               "Optimizer=ADAM,DropConfig=0.0+0.0+0.0+0.");
 
       TString trainingStrategyString("TrainingStrategy=");
@@ -388,7 +390,7 @@ void TMVA_CNN_Classification(int nevts = 1000, std::vector<bool> opt = {1, 1, 1,
       // Training strategies.
       TString trainingString1("LearningRate=1e-3,Momentum=0.9,Repetitions=1,"
                               "ConvergenceSteps=5,BatchSize=100,TestRepetitions=1,"
-                              "MaxEpochs=20,WeightDecay=1e-4,Regularization=None,"
+                              "MaxEpochs=10,WeightDecay=1e-4,Regularization=None,"
                               "Optimizer=ADAM,DropConfig=0.0+0.0+0.0+0.0");
 
       TString trainingStrategyString("TrainingStrategy=");
@@ -467,7 +469,7 @@ void TMVA_CNN_Classification(int nevts = 1000, std::vector<bool> opt = {1, 1, 1,
          factory.BookMethod(
             loader, TMVA::Types::kPyKeras, "PyKeras",
             "H:!V:VarTransform=None:FilenameModel=model_cnn.h5:tf.keras:"
-            "FilenameTrainedModel=trained_model_cnn.h5:NumEpochs=20:BatchSize=100:"
+            "FilenameTrainedModel=trained_model_cnn.h5:NumEpochs=10:BatchSize=100:"
             "GpuOptions=allow_growth=True"); // needed for RTX NVidia card and to avoid TF allocates all GPU memory
       }
    }
@@ -485,7 +487,7 @@ void TMVA_CNN_Classification(int nevts = 1000, std::vector<bool> opt = {1, 1, 1,
          // book PyTorch method only if PyTorch model could be created
          Info("TMVA_CNN_Classification", "Booking PyTorch CNN model");
          TString methodOpt = "H:!V:VarTransform=None:FilenameModel=PyTorchModelCNN.pt:"
-                             "FilenameTrainedModel=PyTorchTrainedModelCNN.pt:NumEpochs=20:BatchSize=100";
+                             "FilenameTrainedModel=PyTorchTrainedModelCNN.pt:NumEpochs=10:BatchSize=100";
          methodOpt += TString(":UserCode=") + pyTorchFileName;
          factory.BookMethod(loader, TMVA::Types::kPyTorch, "PyTorch", methodOpt);
       }

--- a/tutorials/tmva/TMVA_CNN_Classification.py
+++ b/tutorials/tmva/TMVA_CNN_Classification.py
@@ -26,7 +26,6 @@
 import ROOT
 
 #switch off MT in OpenMP (BLAS)
-ROOT.gSystem.Setenv("OMP_NUM_THREADS", "1")
 
 TMVA = ROOT.TMVA
 TFile = ROOT.TFile
@@ -105,8 +104,8 @@ def MakeImagesTree(n, nh, nw):
     bkg.Print()
     f.Close()
 
-hasGPU = ROOT.gSystem.GetFromPipe("root-config --has-tmva-gpu") == "yes"
-hasCPU = ROOT.gSystem.GetFromPipe("root-config --has-tmva-cpu") == "yes"
+hasGPU = "tmva-gpu" in ROOT.gROOT.GetConfigFeatures()
+hasCPU = "tmva-cpu" in ROOT.gROOT.GetConfigFeatures()
 
 nevt = 1000    # use a larger value to get better results
 opt = [1, 1, 1, 1, 1]
@@ -121,7 +120,7 @@ if (not hasCPU and not hasGPU) :
     useTMVACNN = False
     useTMVADNN = False
 
-if ROOT.gSystem.GetFromPipe("root-config --has-tmva-pymva") != "yes":
+if not "tmva-pymva" in ROOT.gROOT.GetConfigFeatures():
     useKerasCNN = False
     usePyTorchCNN = False
 else:
@@ -150,10 +149,13 @@ max_epochs = 10  # maximum number of epochs used for training
 
 
 # do enable MT running
-if num_threads >= 0:
+if "imt" in ROOT.gROOT.GetConfigFeatures():
     ROOT.EnableImplicitMT(num_threads)
+    ROOT.gSystem.Setenv("OMP_NUM_THREADS", "1")  # switch OFF MT in OpenBLAS
+    print("Running with nthreads  = {}".format(ROOT.GetThreadPoolSize()))
+else:
+    print("Running in serial mode since ROOT does not support MT")
 
-print("Running with nthreads  = ", ROOT.GetThreadPoolSize())
 
 
 

--- a/tutorials/tmva/TMVA_RNN_Classification.C
+++ b/tutorials/tmva/TMVA_RNN_Classification.C
@@ -191,12 +191,14 @@ void TMVA_RNN_Classification(int nevts = 2000, int use_type = 1)
    useKeras = false;
 #endif
 
+#ifdef R__USE_IMT
    int num_threads = 4;   // use by default all threads
    gSystem->Setenv("OMP_NUM_THREADS", "1"); // switch off MT in OpenBLAS
    // do enable MT running
    if (num_threads >= 0) {
       ROOT::EnableImplicitMT(num_threads);
    }
+#endif
 
    TMVA::Config::Instance();
 

--- a/tutorials/tmva/TMVA_RNN_Classification.py
+++ b/tutorials/tmva/TMVA_RNN_Classification.py
@@ -24,12 +24,12 @@ import ROOT
 
 num_threads = 4  # use max 4 threads
 # do enable MT running
-if ROOT.gSystem.GetFromPipe("root-config --has-imt") == "yes":
+if "imt" in ROOT.gROOT.GetConfigFeatures():
     ROOT.EnableImplicitMT(num_threads)
     ROOT.gSystem.Setenv("OMP_NUM_THREADS", "1")  # switch OFF MT in OpenBLAS
     print("Running with nthreads  = {}".format(ROOT.GetThreadPoolSize()))
 else:
-    print("Running in serail mode since ROOT does not support MT")
+    print("Running in serial mode since ROOT does not support MT")
 
 
 TMVA = ROOT.TMVA
@@ -174,8 +174,8 @@ if 0 <= use_type < 3:
 
 useGPU = True  # use GPU for TMVA if available
 
-useGPU = ROOT.gSystem.GetFromPipe("root-config --has-tmva-gpu") == "yes"
-useTMVA_RNN = ROOT.gSystem.GetFromPipe("root-config --has-tmva-cpu") == "yes" or useGPU
+useGPU = "tmva-gpu" in ROOT.gROOT.GetConfigFeatures()
+useTMVA_RNN = ("tmva-cpu" in ROOT.gROOT.GetConfigFeatures()) or useGPU
 
 if useTMVA_RNN:
     ROOT.Warning(
@@ -189,7 +189,7 @@ writeOutputFile = True
 
 rnn_type = "RNN"
 
-if ROOT.gSystem.GetFromPipe("root-config --has-tmva-pymva") == "yes":
+if "tmva-pymva" in ROOT.gROOT.GetConfigFeatures():
     TMVA.PyMethodBase.PyInitialize()
 else:
     useKeras = False


### PR DESCRIPTION
Speed-up CNN and RNN tutorials in TMVA (use less epochs) and add some fixes for IMT and to not use root-config in the python versions. 
Add also a dependency in the Python tutorials on the C++ to avoid conflicts with the same file name.

Remove not needed veto for the no-imt case for the TMVA_CNN_Classification.C tutorial introduced in #13712

