### PR TITLE
Cppyy fix derived overload visibility

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/ProxyWrappers.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/ProxyWrappers.cxx
@@ -117,6 +117,18 @@ void AddScopeToParent(PyObject* parent, const std::string& name, PyObject* newsc
     Py_DECREF(pyname);
 }
 
+static inline
+PyObject* GetAttrDirect(PyObject* pyclass, PyObject* pyname) {
+// get an attribute without causing getattr lookups
+    PyObject* dct = PyObject_GetAttr(pyclass, PyStrings::gDict);
+    if (dct) {
+        PyObject* attr = PyObject_GetItem(dct, pyname);
+        Py_DECREF(dct);
+        return attr;
+    }
+    return nullptr;
+}
+
 } // namespace CPyCppyy
 
 
@@ -245,9 +257,13 @@ static int BuildScopeProxyDict(Cppyy::TCppScope_t scope, PyObject* pyclass)
 
         // for operator[]/() that returns by ref, also add __setitem__
             if (setupSetItem) {
-                TemplateProxy* pysi = (TemplateProxy*)PyObject_GetAttrString(pyclass, const_cast<char*>("__setitem__"));
-                if (!pysi) {
+                TemplateProxy* pysi = (TemplateProxy*)GetAttrDirect(pyclass, PyStrings::gSetItem);
+                if (!TemplateProxy_Check(pysi)) {
+                     CPPOverload* precursor = (CPPOverload_Check(pysi)) ? (CPPOverload*)pysi : nullptr;
+                     if (pysi && !precursor) Py_DECREF(pysi);        // something unknown, just drop it
                      pysi = TemplateProxy_New(mtCppName, "__setitem__", pyclass);
+                     if (precursor) pysi->MergeOverload(precursor);
+                     Py_XDECREF(precursor);
                      PyObject_SetAttrString(pyclass, const_cast<char*>("__setitem__"), (PyObject*)pysi);
                 }
                 if (isTemplate) pysi->AdoptTemplate(new CPPSetItem(scope, method));

--- a/bindings/pyroot/cppyy/CPyCppyy/src/PyStrings.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/PyStrings.cxx
@@ -18,6 +18,7 @@ PyObject* CPyCppyy::PyStrings::gEq               = nullptr;
 PyObject* CPyCppyy::PyStrings::gFollow           = nullptr;
 PyObject* CPyCppyy::PyStrings::gGetItem          = nullptr;
 PyObject* CPyCppyy::PyStrings::gGetNoCheck       = nullptr;
+PyObject* CPyCppyy::PyStrings::gSetItem          = nullptr;
 PyObject* CPyCppyy::PyStrings::gInit             = nullptr;
 PyObject* CPyCppyy::PyStrings::gIter             = nullptr;
 PyObject* CPyCppyy::PyStrings::gLen              = nullptr;
@@ -83,6 +84,7 @@ bool CPyCppyy::CreatePyStrings() {
     CPPYY_INITIALIZE_STRING(gFollow,         __follow__);
     CPPYY_INITIALIZE_STRING(gGetItem,        __getitem__);
     CPPYY_INITIALIZE_STRING(gGetNoCheck,     _getitem__unchecked);
+    CPPYY_INITIALIZE_STRING(gSetItem,        __setitem__);
     CPPYY_INITIALIZE_STRING(gInit,           __init__);
     CPPYY_INITIALIZE_STRING(gIter,           __iter__);
     CPPYY_INITIALIZE_STRING(gLen,            __len__);
@@ -143,6 +145,7 @@ PyObject* CPyCppyy::DestroyPyStrings() {
     Py_DECREF(PyStrings::gFollow);      PyStrings::gFollow      = nullptr;
     Py_DECREF(PyStrings::gGetItem);     PyStrings::gGetItem     = nullptr;
     Py_DECREF(PyStrings::gGetNoCheck);  PyStrings::gGetNoCheck  = nullptr;
+    Py_DECREF(PyStrings::gSetItem);     PyStrings::gSetItem     = nullptr;
     Py_DECREF(PyStrings::gInit);        PyStrings::gInit        = nullptr;
     Py_DECREF(PyStrings::gIter);        PyStrings::gIter        = nullptr;
     Py_DECREF(PyStrings::gLen);         PyStrings::gLen         = nullptr;

--- a/bindings/pyroot/cppyy/CPyCppyy/src/PyStrings.h
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/PyStrings.h
@@ -21,6 +21,7 @@ namespace PyStrings {
     extern PyObject* gFollow;
     extern PyObject* gGetItem;
     extern PyObject* gGetNoCheck;
+    extern PyObject* gSetItem;
     extern PyObject* gInit;
     extern PyObject* gIter;
     extern PyObject* gLen;


### PR DESCRIPTION
The changes in the commits are taken from upstream. Each commit references the upstream commit(s) that were needed to implement those changes. This should fix #13410 and hopefully not provoke other test failures