### PR TITLE
[CMake] Update Vc version to 1.4.4

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1387,9 +1387,9 @@ if(builtin_vc)
   set(vc ON CACHE BOOL "Enabled because builtin_vc requested (${vc_description})" FORCE)
 elseif(vc)
   if(fail-on-missing)
-    find_package(Vc 1.3.0 CONFIG QUIET REQUIRED)
+    find_package(Vc 1.4.4 CONFIG QUIET REQUIRED)
   else()
-    find_package(Vc 1.3.0 CONFIG QUIET)
+    find_package(Vc 1.4.4 CONFIG QUIET)
     if(NOT Vc_FOUND)
       message(STATUS "Vc library not found, support for it disabled.")
       message(STATUS "Please enable the option 'builtin_vc' to build Vc internally.")
@@ -1411,7 +1411,7 @@ if(vc AND NOT Vc_FOUND AND NO_CONNECTION)
 endif()
 
 if(vc AND NOT Vc_FOUND)
-  set(Vc_VERSION "1.4.3")
+  set(Vc_VERSION "1.4.4")
   set(Vc_PROJECT "Vc-${Vc_VERSION}")
   set(Vc_SRC_URI "${lcgpackages}/${Vc_PROJECT}.tar.gz")
   set(Vc_DESTDIR "${CMAKE_BINARY_DIR}/externals")
@@ -1421,7 +1421,7 @@ if(vc AND NOT Vc_FOUND)
 
   ExternalProject_Add(VC
     URL     ${Vc_SRC_URI}
-    URL_HASH SHA256=988ea0053f3fbf17544ca776a2749c097b3139089408b0286fa4e9e8513e037f
+    URL_HASH SHA256=5933108196be44c41613884cd56305df320263981fe6a49e648aebb3354d57f3
     BUILD_IN_SOURCE 0
     BUILD_BYPRODUCTS ${Vc_LIBRARY}
     LOG_DOWNLOAD 1 LOG_CONFIGURE 1 LOG_BUILD 1 LOG_INSTALL 1


### PR DESCRIPTION
# This Pull request:
bumps the version of built-in Vc to 1.4.4 which does not use any more the deprecated std::iterator in favour of traits.

## Changes or fixes:


## Checklist:

- [v] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes warnings on Fedora

