### PR TITLE
[DF][NFC] Add missing column name in Aggregate code example

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -2543,7 +2543,7 @@ public:
    /// double initValue = 1.;
    ///
    /// // Multiplies all elements of the column "x"
-   /// auto result = d.Aggregate(aggregator, merger, columnName, initValue);
+   /// auto result = d.Aggregate(aggregator, merger, "x", initValue);
    /// ~~~
    // clang-format on
    template <typename AccFun, typename MergeFun, typename R = typename TTraits::CallableTraits<AccFun>::ret_type,


### PR DESCRIPTION
The comment in the code snippet mentions a column "x", but this is not reflected in the call to `Aggregate`.

