### PR TITLE
[Backport][TMVA] Fix unused variable warnings

### DIFF
--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu/CpuTensor.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu/CpuTensor.h
@@ -196,7 +196,7 @@ public:
    //this will be an unsafe view. Method exists for backwards compatibility only
    TCpuMatrix<AFloat> GetMatrix() const
    {
-      size_t ndims = 0;
+      [[maybe_unused]] size_t ndims = 0;
       auto& shape = this->GetShape();
       //check if squeezable but do not actually squeeze
       for (auto& shape_i : shape){


### PR DESCRIPTION
BP of https://github.com/root-project/root/pull/13835 . The usage of the annotation is possible since for 6.30 cpp17 is enforced.
