### PR TITLE
[cling] Handle length modifiers in IsClassOrFunction

### DIFF
--- a/interpreter/cling/lib/Utils/SourceNormalization.cpp
+++ b/interpreter/cling/lib/Utils/SourceNormalization.cpp
@@ -266,7 +266,8 @@ public:
     } else {
       bool SeenModifier = false;
       auto AnalyzeModifier = [&SeenModifier](llvm::StringRef Modifier) {
-        if (Modifier.equals("signed") || Modifier.equals("unsigned")) {
+        if (Modifier.equals("signed") || Modifier.equals("unsigned") ||
+            Modifier.equals("short") || Modifier.equals("long")) {
           SeenModifier = true;
         }
       };

--- a/interpreter/cling/test/Prompt/DontWrap.C
+++ b/interpreter/cling/test/Prompt/DontWrap.C
@@ -98,6 +98,50 @@ suiFun(11, 12)
 // CHECK: suiFun(11, 12)
 // CHECK: (unsigned int) 13
 
+long lFun(int a) {
+  printf("lFun(%d)\n", a);
+  return 15;
+}
+
+long int liFun(int a, int b) {
+  printf("liFun(%d, %d)\n", a, b);
+  return 17;
+}
+
+lFun(13)
+// CHECK: lFun(13)
+// CHECK: (long) 15
+
+liFun(14, 15)
+// CHECK: liFun(14, 15)
+// CHECK: (long) 17
+
+
+static long slFun(int a) {
+  printf("slFun(%d)\n", a);
+  return 19;
+}
+
+static long int sliFun(int a, int b) {
+  printf("sliFun(%d, %d)\n", a, b);
+  return 21;
+}
+
+slFun(16)
+// CHECK: slFun(16)
+// CHECK: (long) 19
+
+sliFun(17, 18)
+// CHECK: sliFun(17, 18)
+// CHECK: (long) 21
+
+long double ldFun(long double x) {
+  return x * x;
+}
+
+ldFun(2.0)
+// CHECK: (long double) 4.0
+
   
 class Test {
 public:


### PR DESCRIPTION
This expands the handling introduced in commit 31e46a65f6 to include the length modifiers `short` and `long` as mentioned back then. It still doesn't handle the cases of multiple modifiers such as `unsigned long long int` and `long int unsigned long` (being the same type).

Fixes https://github.com/root-project/root/issues/13288