### PR TITLE
IO: Fix StreamerInfo record write during file update.

### DIFF
--- a/core/thread/inc/ROOT/RConcurrentHashColl.hxx
+++ b/core/thread/inc/ROOT/RConcurrentHashColl.hxx
@@ -54,10 +54,12 @@ public:
    RConcurrentHashColl();
    ~RConcurrentHashColl();
 
-   /// Return true if the hash is already in already there
+   /// Return the collection of UID corresponding to the hash if the hash has
+   /// already been seen or nullptr otherwise.
    const RUidColl *Find(const HashValue &hash) const;
 
-   /// If the hash is there, return false. Otherwise, insert the hash and return true;
+   /// If the hash is there, return false. Otherwise, insert the hash and UID
+   /// collection and return true.
    bool Insert(const HashValue &hash, RUidColl &&coll) const;
 
    /// Return the hash object corresponding to the buffer.

--- a/core/thread/src/RConcurrentHashColl.cxx
+++ b/core/thread/src/RConcurrentHashColl.cxx
@@ -43,7 +43,6 @@ RConcurrentHashColl::RConcurrentHashColl()
 
 RConcurrentHashColl::~RConcurrentHashColl() = default;
 
-/// Return true if the hash is already in already there
 const RUidColl* RConcurrentHashColl::Find(const HashValue &hash) const
 {
    ROOT::TRWSpinLockReadGuard rg(*fRWLock);
@@ -54,13 +53,11 @@ const RUidColl* RConcurrentHashColl::Find(const HashValue &hash) const
       return nullptr;
 }
 
-/// If the buffer is there, return false. Otherwise, insert the hash and return true
 RConcurrentHashColl::HashValue RConcurrentHashColl::Hash(char *buffer, int len)
 {
    return HashValue(buffer, len);
 }
 
-/// If the buffer is there, return false. Otherwise, insert the hash and return true
 bool RConcurrentHashColl::Insert(const HashValue &hash, RUidColl &&values) const
 {
    ROOT::TRWSpinLockWriteGuard wg(*fRWLock);

--- a/io/io/inc/TFile.h
+++ b/io/io/inc/TFile.h
@@ -39,7 +39,6 @@
 #include <mutex>
 #endif
 
-
 class TMap;
 class TFree;
 class TArrayC;
@@ -117,8 +116,8 @@ protected:
 
 #ifdef R__USE_IMT
    std::mutex                                 fWriteMutex;  ///<!Lock for writing baskets / keys into the file.
-   static ROOT::Internal::RConcurrentHashColl fgTsSIHashes; ///<!TS Set of hashes built from read streamer infos
 #endif
+   static ROOT::Internal::RConcurrentHashColl fgTsSIHashes; ///<!TS Set of hashes built from read streamer infos
 
    static TList    *fgAsyncOpenRequests; //List of handles for pending open requests
 

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -1382,8 +1382,12 @@ TFile::InfoListRet TFile::GetStreamerInfoListImpl(bool lookupSICache)
          // key data must be excluded from the hash, otherwise the timestamp will
          // always lead to unique hashes for each file
          hash = fgTsSIHashes.Hash(buf + key->GetKeylen(), fNbytesInfo - key->GetKeylen());
-         if (fgTsSIHashes.Find(hash)) {
-            if (gDebug > 0) Info("GetStreamerInfo", "The streamer info record for file %s has already been treated, skipping it.", GetName());
+         auto si_uids = fgTsSIHashes.Find(hash);
+         if (si_uids) {
+            if (gDebug > 0)
+               Info("GetStreamerInfo", "The streamer info record for file %s has already been treated, skipping it.", GetName());
+            for(auto uid : *si_uids)
+               fClassIndex->fArray[uid] = 1;
             return {nullptr, 0, hash};
          }
       }
@@ -3630,6 +3634,7 @@ void TFile::ReadStreamerInfo()
       }
    }
 
+   std::vector<Int_t> si_uids;
    // loop on all TStreamerInfo classes
    for (int mode=0;mode<2; ++mode) {
       // In order for the collection proxy to be initialized properly, we need
@@ -3680,7 +3685,10 @@ void TFile::ReadStreamerInfo()
             Int_t uid = info->GetNumber();
             Int_t asize = fClassIndex->GetSize();
             if (uid >= asize && uid <100000) fClassIndex->Set(2*asize);
-            if (uid >= 0 && uid < fClassIndex->GetSize()) fClassIndex->fArray[uid] = 1;
+            if (uid >= 0 && uid < fClassIndex->GetSize()) {
+               si_uids.push_back(uid);
+               fClassIndex->fArray[uid] = 1;
+            }
             else if (!isstl && !info->GetClass()->IsSyntheticPair()) {
                printf("ReadStreamerInfo, class:%s, illegal uid=%d\n",info->GetName(),uid);
             }
@@ -3696,7 +3704,7 @@ void TFile::ReadStreamerInfo()
 #ifdef R__USE_IMT
    // We are done processing the record, let future calls and other threads that it
    // has been done.
-   fgTsSIHashes.Insert(listRetcode.fHash);
+   fgTsSIHashes.Insert(listRetcode.fHash, std::move(si_uids));
 #endif
 }
 

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -161,9 +161,7 @@ Bool_t   TFile::fgCacheFileForce = kFALSE;
 Bool_t   TFile::fgCacheFileDisconnected = kTRUE;
 UInt_t   TFile::fgOpenTimeout = TFile::kEternalTimeout;
 Bool_t   TFile::fgOnlyStaged = kFALSE;
-#ifdef R__USE_IMT
 ROOT::Internal::RConcurrentHashColl TFile::fgTsSIHashes;
-#endif
 
 #ifdef R__MACOSX
 /* On macOS getxattr takes two extra arguments that should be set to 0 */
@@ -1377,7 +1375,6 @@ TFile::InfoListRet TFile::GetStreamerInfoListImpl(bool lookupSICache)
          return {nullptr, 1, hash};
       }
 
-#ifdef R__USE_IMT
       if (lookupSICache) {
          // key data must be excluded from the hash, otherwise the timestamp will
          // always lead to unique hashes for each file
@@ -1391,9 +1388,6 @@ TFile::InfoListRet TFile::GetStreamerInfoListImpl(bool lookupSICache)
             return {nullptr, 0, hash};
          }
       }
-#else
-      (void) lookupSICache;
-#endif
       key->ReadKeyBuffer(buf);
       list = dynamic_cast<TList*>(key->ReadObjWithBuffer(buffer.data()));
       if (list) list->SetOwner();
@@ -3701,11 +3695,9 @@ void TFile::ReadStreamerInfo()
    list->Clear();  //this will delete all TStreamerInfo objects with kCanDelete bit set
    delete list;
 
-#ifdef R__USE_IMT
    // We are done processing the record, let future calls and other threads that it
    // has been done.
    fgTsSIHashes.Insert(listRetcode.fHash, std::move(si_uids));
-#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fix #12783

Since "66dfb08bd7 - [IO] Do not process the streamerinfo record of a file if we read the si already read"
which was extended in scope by "7cf9d5dc8c - fix hashing of streamer info,"

if a file is opened in update mode and the reading of its `StreamerInfo` record is skip (but
an identical record was already read) *and* some data is stored in the file, the new
`StreamerInfo` record written was missing all the classes in the original record that
were not used during the update.

To resolve this we record not only the fact that the record has been read and process
but also its content (via a collectin of uid of the `TStreamerInfo` objects).
Upon skipping the `StreamerInfo` record, we now mark of its `TStreamerInfo` objects has
been used by the file (and thus upon writing the record is complete).

This behavior was seen #12783 due an awkward 'create, fill, close, update immediately' cycle
for a couple of files.# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

Fix #12783

Since "66dfb08bd7 - [IO] Do not process the streamerinfo record of a file if we read the si already read"
which was extended in scope by "7cf9d5dc8c - fix hashing of streamer info,"

if a file is opened in update mode and the reading of its `StreamerInfo` record is skip (but
an identical record was already read) *and* some data is stored in the file, the new
`StreamerInfo` record written was missing all the classes in the original record that
were not used during the update.

To resolve this we record not only the fact that the record has been read and process
but also its content (via a collectin of uid of the `TStreamerInfo` objects).
Upon skipping the `StreamerInfo` record, we now mark of its `TStreamerInfo` objects has
been used by the file (and thus upon writing the record is complete).

This behavior was seen #12783 due an awkward 'create, fill, close, update immediately' cycle
for a couple of files.