### PR TITLE
[ntuple] Add support for half-precision floats

### DIFF
--- a/core/base/CMakeLists.txt
+++ b/core/base/CMakeLists.txt
@@ -199,6 +199,7 @@ set(BASE_SOURCES
 if(root7)
   set(BASE_HEADER_DIRS inc/ v7/inc/)
   list(APPEND BASE_HEADERS
+      ROOT/RFloat16.hxx
       ROOT/RDirectoryEntry.hxx
       ROOT/RIndexIter.hxx)
   target_sources(Core PRIVATE v7/src/RDirectory.cxx)

--- a/core/base/v7/inc/ROOT/RFloat16.hxx
+++ b/core/base/v7/inc/ROOT/RFloat16.hxx
@@ -1,0 +1,154 @@
+// @(#)root/base
+
+/*************************************************************************
+ * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include <cstdint>
+#include <cstring>
+
+#ifndef ROOT_RFloat16
+#define ROOT_RFloat16
+
+/**
+ * Conversion functions between full- and half-precision floats. The code used here is taken (with some modifications)
+ * from the `half` C++ library (https://half.sourceforge.net/index.html), distributed under the MIT license.
+ *
+ * Original license:
+ *
+ * The MIT License
+ *
+ * Copyright (c) 2012-2021 Christian Rau
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef HALF_ENABLE_F16C_INTRINSICS
+/// Enable F16C intruction set intrinsics.
+/// Defining this to 1 enables the use of [F16C compiler intrinsics](https://en.wikipedia.org/wiki/F16C) for converting
+/// between half-precision and single-precision values which may result in improved performance. This will not perform
+/// additional checks for support of the F16C instruction set, so an appropriate target platform is required when
+/// enabling this feature.
+///
+/// Unless predefined it will be enabled automatically when the `__F16C__` symbol is defined, which some compilers do on
+/// supporting platforms.
+#define HALF_ENABLE_F16C_INTRINSICS __F16C__
+#endif
+#if HALF_ENABLE_F16C_INTRINSICS
+#include <immintrin.h>
+#endif
+
+namespace ROOT {
+namespace Experimental {
+namespace Internal {
+////////////////////////////////////////////////////////////////////////////////
+/// \brief Get the half-precision overflow.
+///
+/// \param[in] value Half-precision value with sign bit only
+///
+/// \return Rounded overflowing half-precision value
+constexpr std::uint16_t GetOverflowedValue(std::uint16_t value = 0)
+{
+   return (value | 0x7C00);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// \brief Round the given half-precision number to the nearest representable value.
+///
+/// \param[in] value The finite half-precision number to round
+/// \param[in] guardBit The most significant discarded bit
+/// \param[in] stickyBit Logical OR of all but the most significant discarded bits
+///
+/// \return The nearest-rounded half-precision value
+constexpr std::uint16_t GetRoundedValue(std::uint16_t value, int guardBit, int stickyBit)
+{
+   return (value + (guardBit & (stickyBit | value)));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// \brief Convert an IEEE single-precision float to half-precision.
+///
+/// Credit for this goes to [Jeroen van der Zijp](http://fox-toolkit.org/ftp/fasthalffloatconversion.pdf).
+///
+/// \param[in] value The single-precision value to convert
+///
+/// \return The converted half-precision value
+inline std::uint16_t FloatToHalf(float value)
+{
+#if HALF_ENABLE_F16C_INTRINSICS
+   return _mm_cvtsi128_si32(_mm_cvtps_ph(_mm_set_ss(value), _MM_FROUND_TO_NEAREST_INT));
+#else
+   std::uint32_t fbits;
+   std::memcpy(&fbits, &value, sizeof(float));
+
+   std::uint16_t sign = (fbits >> 16) & 0x8000;
+   fbits &= 0x7FFFFFFF;
+   if (fbits >= 0x7F800000)
+      return sign | 0x7C00 | ((fbits > 0x7F800000) ? (0x200 | ((fbits >> 13) & 0x3FF)) : 0);
+   if (fbits >= 0x47800000)
+      return GetOverflowedValue(sign);
+   if (fbits >= 0x38800000)
+      return GetRoundedValue(sign | (((fbits >> 23) - 112) << 10) | ((fbits >> 13) & 0x3FF), (fbits >> 12) & 1,
+                             (fbits & 0xFFF) != 0);
+   if (fbits >= 0x33000000) {
+      int i = 125 - (fbits >> 23);
+      fbits = (fbits & 0x7FFFFF) | 0x800000;
+      return GetRoundedValue(sign | (fbits >> (i + 1)), (fbits >> i) & 1,
+                             (fbits & ((static_cast<std::uint32_t>(1) << i) - 1)) != 0);
+   }
+
+   return sign;
+#endif
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// \brief Convert an IEEE half-precision float to single-precision.
+///
+/// Credit for this goes to [Jeroen van der Zijp](http://fox-toolkit.org/ftp/fasthalffloatconversion.pdf).
+///
+/// \param[in] value The half-precision value to convert
+///
+/// \return The converted single-precision value
+inline float HalfToFloat(std::uint16_t value)
+{
+#if HALF_ENABLE_F16C_INTRINSICS
+   return _mm_cvtss_f32(_mm_cvtph_ps(_mm_cvtsi32_si128(value)));
+#else
+   std::uint32_t fbits = static_cast<std::uint32_t>(value & 0x8000) << 16;
+   int abs = value & 0x7FFF;
+   if (abs) {
+      fbits |= 0x38000000 << static_cast<unsigned>(abs >= 0x7C00);
+      for (; abs < 0x400; abs <<= 1, fbits -= 0x800000)
+         ;
+      fbits += static_cast<std::uint32_t>(abs) << 13;
+   }
+   float out;
+   std::memcpy(&out, &fbits, sizeof(float));
+   return out;
+#endif
+}
+} // namespace Internal
+} // namespace Experimental
+} // namespace ROOT
+
+#endif // ROOT_RFloat16

--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -19,6 +19,7 @@
 #include <ROOT/RColumnModel.hxx>
 #include <ROOT/RConfig.hxx>
 #include <ROOT/RError.hxx>
+#include <ROOT/RFloat16.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 
 #include <Byteswap.h>
@@ -583,6 +584,39 @@ public:
    void Unpack(void *dst, void *src, std::size_t count) const final;
 };
 
+template <>
+class RColumnElement<float, EColumnType::kReal16> : public RColumnElementBase {
+public:
+   static constexpr bool kIsMappable = false;
+   static constexpr std::size_t kSize = sizeof(float);
+   static constexpr std::size_t kBitsOnStorage = 16;
+   RColumnElement() : RColumnElementBase(kSize) {}
+   bool IsMappable() const final { return kIsMappable; }
+   std::size_t GetBitsOnStorage() const final { return kBitsOnStorage; }
+
+   void Pack(void *dst, void *src, std::size_t count) const final
+   {
+      float *floatArray = reinterpret_cast<float *>(src);
+      std::uint16_t *uint16Array = reinterpret_cast<std::uint16_t *>(dst);
+
+      for (std::size_t i = 0; i < count; ++i) {
+         uint16Array[i] = Internal::FloatToHalf(floatArray[i]);
+         ByteSwapIfNecessary(uint16Array[i]);
+      }
+   }
+
+   void Unpack(void *dst, void *src, std::size_t count) const final
+   {
+      float *floatArray = reinterpret_cast<float *>(dst);
+      std::uint16_t *uint16Array = reinterpret_cast<std::uint16_t *>(src);
+
+      for (std::size_t i = 0; i < count; ++i) {
+         ByteSwapIfNecessary(floatArray[i]);
+         floatArray[i] = Internal::HalfToFloat(uint16Array[i]);
+      }
+   }
+};
+
 #define __RCOLUMNELEMENT_SPEC_BODY(CppT, BaseT, BitsOnStorage)  \
    static constexpr std::size_t kSize = sizeof(CppT);           \
    static constexpr std::size_t kBitsOnStorage = BitsOnStorage; \
@@ -703,6 +737,7 @@ std::unique_ptr<RColumnElementBase> RColumnElementBase::Generate(EColumnType typ
    case EColumnType::kBit: return std::make_unique<RColumnElement<CppT, EColumnType::kBit>>();
    case EColumnType::kReal64: return std::make_unique<RColumnElement<CppT, EColumnType::kReal64>>();
    case EColumnType::kReal32: return std::make_unique<RColumnElement<CppT, EColumnType::kReal32>>();
+   case EColumnType::kReal16: return std::make_unique<RColumnElement<CppT, EColumnType::kReal16>>();
    case EColumnType::kInt64: return std::make_unique<RColumnElement<CppT, EColumnType::kInt64>>();
    case EColumnType::kUInt64: return std::make_unique<RColumnElement<CppT, EColumnType::kUInt64>>();
    case EColumnType::kInt32: return std::make_unique<RColumnElement<CppT, EColumnType::kInt32>>();

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -1643,8 +1643,9 @@ public:
    size_t GetValueSize() const final { return sizeof(float); }
    size_t GetAlignment() const final { return alignof(float); }
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
-};
 
+   void SetHalfPrecision();
+};
 
 template <>
 class RField<double> : public Detail::RFieldBase {

--- a/tree/ntuple/v7/src/RColumnElement.cxx
+++ b/tree/ntuple/v7/src/RColumnElement.cxx
@@ -36,6 +36,8 @@ ROOT::Experimental::Detail::RColumnElementBase::Generate<void>(EColumnType type)
    case EColumnType::kBit: return std::make_unique<RColumnElement<bool, EColumnType::kBit>>();
    case EColumnType::kReal64: return std::make_unique<RColumnElement<double, EColumnType::kReal64>>();
    case EColumnType::kReal32: return std::make_unique<RColumnElement<float, EColumnType::kReal32>>();
+   // TODO: Change to std::float16_t in-memory type once available (from C++23).
+   case EColumnType::kReal16: return std::make_unique<RColumnElement<float, EColumnType::kReal16>>();
    case EColumnType::kInt64: return std::make_unique<RColumnElement<std::int64_t, EColumnType::kInt64>>();
    case EColumnType::kUInt64: return std::make_unique<RColumnElement<std::uint64_t, EColumnType::kUInt64>>();
    case EColumnType::kInt32: return std::make_unique<RColumnElement<std::int32_t, EColumnType::kInt32>>();
@@ -72,6 +74,7 @@ std::size_t ROOT::Experimental::Detail::RColumnElementBase::GetBitsOnStorage(ECo
    case EColumnType::kBit: return 1;
    case EColumnType::kReal64: return 64;
    case EColumnType::kReal32: return 32;
+   case EColumnType::kReal16: return 16;
    case EColumnType::kInt64: return 64;
    case EColumnType::kUInt64: return 64;
    case EColumnType::kInt32: return 32;
@@ -106,6 +109,7 @@ std::string ROOT::Experimental::Detail::RColumnElementBase::GetTypeName(EColumnT
    case EColumnType::kBit: return "Bit";
    case EColumnType::kReal64: return "Real64";
    case EColumnType::kReal32: return "Real32";
+   case EColumnType::kReal16: return "Real16";
    case EColumnType::kInt64: return "Int64";
    case EColumnType::kUInt64: return "UInt64";
    case EColumnType::kInt32: return "Int32";

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -966,7 +966,8 @@ void ROOT::Experimental::RField<bool>::AcceptVisitor(Detail::RFieldVisitor &visi
 const ROOT::Experimental::Detail::RFieldBase::RColumnRepresentations &
 ROOT::Experimental::RField<float>::GetColumnRepresentations() const
 {
-   static RColumnRepresentations representations({{EColumnType::kSplitReal32}, {EColumnType::kReal32}}, {});
+   static RColumnRepresentations representations(
+      {{EColumnType::kSplitReal32}, {EColumnType::kReal32}, {EColumnType::kReal16}}, {});
    return representations;
 }
 
@@ -986,6 +987,10 @@ void ROOT::Experimental::RField<float>::AcceptVisitor(Detail::RFieldVisitor &vis
    visitor.VisitFloatField(*this);
 }
 
+void ROOT::Experimental::RField<float>::SetHalfPrecision()
+{
+   SetColumnRepresentative({EColumnType::kReal16});
+}
 
 //------------------------------------------------------------------------------
 

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -886,6 +886,58 @@ TEST(RNTuple, Casting)
    EXPECT_EQ(137, *fieldCast2);
 }
 
+TEST(RNTuple, HalfPrecisionFloat)
+{
+   FileRaii fileGuard("test_ntuple_half_precision_float.root");
+
+   // TODO: Add std::float16 tests once available (from C++23)
+   auto f1Fld = RFieldBase::Create("f1", "float").Unwrap();
+   dynamic_cast<RField<float> *>(f1Fld.get())->SetHalfPrecision();
+   EXPECT_EQ(EColumnType::kReal16, f1Fld->GetColumnRepresentative()[0]);
+   EXPECT_EQ("float", f1Fld->GetType());
+
+   auto fVecFld = RFieldBase::Create("fVec", "std::vector<float>").Unwrap();
+   dynamic_cast<RField<float> *>(fVecFld->GetSubFields()[0])->SetHalfPrecision();
+   EXPECT_EQ(EColumnType::kReal16, fVecFld->GetSubFields()[0]->GetColumnRepresentative()[0]);
+
+   auto model = RNTupleModel::Create();
+   model->AddField(std::move(f1Fld));
+   model->AddField(std::move(fVecFld));
+
+   {
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
+      auto f1 = writer->GetModel()->GetDefaultEntry()->Get<float>("f1");
+      auto fVec = writer->GetModel()->GetDefaultEntry()->Get<std::vector<float>>("fVec");
+      *f1 = 0.1f;
+      *fVec = {0.1f, 0.2f};
+      writer->Fill();
+      *f1 = 4245.5f;
+      *fVec = {std::numeric_limits<float>::max(), std::numeric_limits<float>::min(),
+               std::numeric_limits<float>::lowest(), std::numeric_limits<float>::denorm_min()};
+      writer->Fill();
+   }
+
+   auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
+
+   EXPECT_EQ(4, ROOT::Experimental::Detail::RColumnElementBase::Generate(EColumnType::kReal16)->GetSize());
+
+   const auto *desc = reader->GetDescriptor();
+   EXPECT_EQ(EColumnType::kReal16, (*desc->GetColumnIterable(desc->FindFieldId("f1")).begin()).GetModel().GetType());
+
+   auto f1 = reader->GetModel()->GetDefaultEntry()->Get<float>("f1");
+   auto fVec = reader->GetModel()->GetDefaultEntry()->Get<std::vector<float>>("fVec");
+   reader->LoadEntry(0);
+   EXPECT_FLOAT_EQ(0.0999755859375f, *f1);
+   EXPECT_FLOAT_EQ(0.0999755859375f, (*fVec)[0]);
+   EXPECT_FLOAT_EQ(0.199951171875f, (*fVec)[1]);
+   reader->LoadEntry(1);
+   EXPECT_FLOAT_EQ(4244.f, *f1);
+   EXPECT_FLOAT_EQ(INFINITY, (*fVec)[0]);
+   EXPECT_FLOAT_EQ(0.0f, (*fVec)[1]);
+   EXPECT_FLOAT_EQ(-INFINITY, (*fVec)[2]);
+   EXPECT_FLOAT_EQ(0.0f, (*fVec)[3]);
+}
+
 TEST(RNTuple, Double32)
 {
    FileRaii fileGuard("test_ntuple_double32.root");


### PR DESCRIPTION
This PR adds support to 16-bit (IEEE 754-2008) floating point numbers to RNTuple. In similar vein to 32-bit doubles, this is enabled by changing the column representation of ordinary `float` fields (i.e., regular `float` fields are used, but the values are saved to disk using half precision).

Because half-precision floats are only part of the C++ standard from C++23 onwards, for now we use parts of the [`half`](https://half.sourceforge.net/) library (MIT-licensed) for converting between half- and single-precision floats. For x86 processors, the [F16C](https://en.wikipedia.org/wiki/F16C) ISA extension can be enabled to do this conversion on the hardware directly. However, this appears to mess with `TFormulaTests`.