### PR TITLE
[RF] Use `TAxis::FindBin()` to determine bin offsets for TH1 import

### DIFF
--- a/roofit/roofitcore/inc/RooBinning.h
+++ b/roofit/roofitcore/inc/RooBinning.h
@@ -39,7 +39,6 @@ public:
     return _nbins+1;
   }
   void binNumbers(double const * x, int * bins, std::size_t n, int coef) const override;
-  Int_t rawBinNumber(double x) const;
   virtual double nearestBoundary(double x) const;
 
   void setRange(double xlo, double xhi) override;

--- a/roofit/roofitcore/src/RooBinning.cxx
+++ b/roofit/roofitcore/src/RooBinning.cxx
@@ -193,17 +193,6 @@ void RooBinning::binNumbers(double const * x, int * bins, std::size_t n, int coe
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return sequential bin number that contains value x where bin
-/// zero is the first bin that is defined, regardless if that bin
-/// is outside the current defined range
-
-Int_t RooBinning::rawBinNumber(double x) const
-{
-  return rawBinNumberImpl(x, _boundaries);
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
 /// Return the value of the nearest boundary to x
 
 double RooBinning::nearestBoundary(double x) const


### PR DESCRIPTION
When importing a `TH1` into a RooDataHist, the RooFit variable ranges are automatically adjusted to the nearest `TH1` bin boundaries. Then, the number of the corresponding `TH1` bin is stored in a "offset" variable to be used later when filling the RooDataHist.

For this range adjustment, there are two code branches. One for the uniform case, and one for non-uniform binning.

The uniform binning code branch was a bit weird, because it also created a non-uniform `RooBinning` object, only used to determine the original `TH1` bin of the lower adjusted boundary via
`RooBinning::rawBinNumber()`. But this can just be done with `TAxis::FindBin()`. Hence, we don't even need this confusing `rawBinNumber()` function as an implementation detail of RooFit and can get rid of it.

With this change, we don't need a non-uniform `RooBinning` object in the uniform binning code branch anymore, and also circumvent an crash in the nightlies:

https://lcgapp-services.cern.ch/root-jenkins/job/root-incremental-master/LABEL=ROOT-debian10-i386,SPEC=noimt/12007/testReport/projectroot/test/test_stressroofit/