### PR TITLE
[DF] Improve progress bar finalization

### DIFF
--- a/tree/dataframe/inc/ROOT/RDFHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDFHelpers.hxx
@@ -298,6 +298,8 @@ private:
    double EvtPerSec() const;
    std::pair<std::size_t, std::chrono::seconds> RecordEvtCountAndTime();
    void PrintStats(std::ostream &stream, std::size_t currentEventCount, std::chrono::seconds totalElapsedSeconds) const;
+   void
+   PrintStatsFinal(std::ostream &stream, std::chrono::seconds totalElapsedSeconds) const;
    void PrintProgressbar(std::ostream &stream, std::size_t currentEventCount) const;
 
    std::chrono::time_point<std::chrono::system_clock> fBeginTime = std::chrono::system_clock::now();
@@ -378,21 +380,9 @@ public:
       // ***************************************************
       fProcessedEvents += fIncrement;
 
-      unsigned int currentFileIdx = ComputeCurrentFileIdx();
-      unsigned int GetNEventsOfCurrentFile = ComputeNEventsSoFar();
-
       // We only print every n seconds.
       if (duration_cast<seconds>(system_clock::now() - fLastPrintTime) < fPrintInterval) {
-
-         // Unless we are at the end of file processing, then we want to print the progress bar again (the final status)
-         // Otherwise, if the last processed files are too small and they are processed in less than the time interval,
-         // the final progress bar status would be incomplete. We want to prevent this from happening.
-
-         if (fTotalFiles != currentFileIdx) {
-            if (currentFileIdx <= GetNEventsOfCurrentFile - fIncrement) {
-               return;
-            }
-         }
+         return;
       }
 
       // ***************************************************

--- a/tree/dataframe/inc/ROOT/RDFHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDFHelpers.hxx
@@ -272,6 +272,8 @@ SnapshotPtr_t VariationsFor(SnapshotPtr_t resPtr);
 void AddProgressbar(ROOT::RDF::RNode df);
 void AddProgressbar(ROOT::RDataFrame df);
 
+class ProgressBarAction;
+
 /// RDF progress helper.
 /// This class provides callback functions to the RDataFrame. The event statistics
 /// (including elapsed time, currently processed file, currently processed events, the rate of event processing
@@ -333,6 +335,8 @@ public:
                   unsigned int printInterval = 1, bool useColors = true);
 
    ~ProgressHelper() = default;
+
+   friend class ProgressBarAction;
 
    /// Register a new sample for completion statistics.
    /// \see ROOT::RDF::RInterface::DefinePerSample().

--- a/tree/dataframe/inc/ROOT/RDFHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDFHelpers.hxx
@@ -298,8 +298,7 @@ private:
    double EvtPerSec() const;
    std::pair<std::size_t, std::chrono::seconds> RecordEvtCountAndTime();
    void PrintStats(std::ostream &stream, std::size_t currentEventCount, std::chrono::seconds totalElapsedSeconds) const;
-   void
-   PrintStatsFinal(std::ostream &stream, std::chrono::seconds totalElapsedSeconds) const;
+   void PrintStatsFinal(std::ostream &stream, std::chrono::seconds totalElapsedSeconds) const;
    void PrintProgressbar(std::ostream &stream, std::size_t currentEventCount) const;
 
    std::chrono::time_point<std::chrono::system_clock> fBeginTime = std::chrono::system_clock::now();

--- a/tree/dataframe/inc/ROOT/RDFHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDFHelpers.hxx
@@ -272,8 +272,6 @@ SnapshotPtr_t VariationsFor(SnapshotPtr_t resPtr);
 void AddProgressbar(ROOT::RDF::RNode df);
 void AddProgressbar(ROOT::RDataFrame df);
 
-} // namespace Experimental
-
 /// RDF progress helper.
 /// This class provides callback functions to the RDataFrame. The event statistics
 /// (including elapsed time, currently processed file, currently processed events, the rate of event processing
@@ -431,7 +429,7 @@ public:
       return fSampleNameToEventEntries.size();
    }
 };
-
+} // namespace Experimental
 } // namespace RDF
 } // namespace ROOT
 #endif

--- a/tree/dataframe/src/RDFHelpers.cxx
+++ b/tree/dataframe/src/RDFHelpers.cxx
@@ -143,6 +143,8 @@ ROOT::RDF::Experimental::SnapshotPtr_t ROOT::RDF::Experimental::VariationsFor(RO
 namespace ROOT {
 namespace RDF {
 
+namespace Experimental {
+
 ProgressHelper::ProgressHelper(std::size_t increment, unsigned int totalFiles, unsigned int progressBarWidth,
                                unsigned int printInterval, bool useColors)
    : fPrintInterval(printInterval),
@@ -288,7 +290,6 @@ void ProgressHelper::PrintProgressbar(std::ostream &stream, std::size_t currentE
       stream << "\033[0m";
 }
 //*/
-namespace Experimental {
 
 class ProgressBarAction final : public ROOT::Detail::RDF::RActionImpl<ProgressBarAction> {
 public:

--- a/tree/dataframe/src/RDFHelpers.cxx
+++ b/tree/dataframe/src/RDFHelpers.cxx
@@ -22,7 +22,9 @@
 #endif // R__USE_IMT
 
 #include <algorithm>
+#include <iostream>
 #include <set>
+#include <stdio.h>
 
 // TODO, this function should be part of core libraries
 #include <numeric>
@@ -30,17 +32,14 @@
 #include <unistd.h>
 #endif
 
-#include <stdio.h>
-#include <iostream>
-
 #if defined(_WIN32) || defined(_WIN64)
 #define WIN32_LEAN_AND_MEAN
 #define VC_EXTRALEAN
 #include <io.h>
 #include <Windows.h>
-#elif defined(__linux__)
+#else
 #include <sys/ioctl.h>
-#endif // Windows/Linux
+#endif
 
 // Get terminal size for progress bar
 int get_tty_size()
@@ -53,15 +52,13 @@ int get_tty_size()
    if (GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi))
       width = (int)(csbi.srWindow.Right - csbi.srWindow.Left + 1);
    return width;
-#elif defined(__linux__)
+#else
    int width = 0;
    struct winsize w;
    ioctl(fileno(stdout), TIOCGWINSZ, &w);
    width = (int)(w.ws_col);
    return width;
-#else
-   return 0;
-#endif // Windows/Linux
+#endif
 }
 
 using ROOT::RDF::RResultHandle;
@@ -268,6 +265,35 @@ void ProgressHelper::PrintStats(std::ostream &stream, std::size_t currentEventCo
    stream << "]   ";
 }
 
+void ProgressHelper::PrintStatsFinal(std::ostream &stream,
+                                     std::chrono::seconds elapsedSeconds) const
+{
+   auto totalEvents = ComputeNEventsSoFar();
+   auto totalFiles = fTotalFiles;
+
+   if (fUseShellColours)
+      stream << "\033[35m";
+   stream << "["
+          << "Total elapsed time: " << elapsedSeconds << "  ";
+   if (fUseShellColours)
+      stream << "\033[0m";
+   stream << "processed files: " << totalFiles << " / " << totalFiles << "  ";
+
+   // Event counts:
+   if (fUseShellColours)
+      stream << "\033[32m";
+
+   stream << "processed evts: " << totalEvents;
+   if (totalEvents != 0) {
+      stream << " / " << std::scientific << std::setprecision(2) << totalEvents;
+   }
+
+   if (fUseShellColours)
+      stream << "\033[0m";
+
+   stream << "]   ";
+}
+
 /// Print a progress bar of width `ProgressHelper::fBarWidth` if `fGetNEventsOfCurrentFile` is known.
 void ProgressHelper::PrintProgressbar(std::ostream &stream, std::size_t currentEventCount) const
 {
@@ -309,7 +335,22 @@ public:
 
    void Exec(unsigned int) {}
 
-   void Finalize() { std::cout << '\n'; }
+   void Finalize()
+   {
+      std::mutex fPrintMutex;
+      if (!fPrintMutex.try_lock())
+         return;
+      std::lock_guard<std::mutex> lockGuard(fPrintMutex, std::adopt_lock);
+      const auto &[eventCount, elapsedSeconds] = fHelper->RecordEvtCountAndTime();
+
+      // The next line resets the current line output in the terminal.
+      // Brings the cursor at the beginning ('\r'), prints whitespace with the
+      // same length as the terminal size, then resets the cursor again so we
+      // can print the final stats on a clean line.
+      std::cout << '\r' << std::string(get_tty_size(), ' ') << '\r';
+      fHelper->PrintStatsFinal(std::cout, elapsedSeconds);
+      std::cout << '\n';
+   }
 
    std::string GetActionName() { return "ProgressBar"; }
    // dummy implementation of PartialUpdate

--- a/tree/dataframe/src/RDFHelpers.cxx
+++ b/tree/dataframe/src/RDFHelpers.cxx
@@ -257,7 +257,7 @@ void ProgressHelper::PrintStats(std::ostream &stream, std::size_t currentEventCo
       std::chrono::seconds remainingSeconds(
          static_cast<long long>((ComputeNEventsSoFar() - currentEventCount) / evtpersec));
       stream << " " << remainingSeconds << " "
-             << " remaining time (per file)";
+             << " remaining time (per file being processed)";
       if (fUseShellColours)
          stream << "\033[0m";
    }
@@ -265,8 +265,7 @@ void ProgressHelper::PrintStats(std::ostream &stream, std::size_t currentEventCo
    stream << "]   ";
 }
 
-void ProgressHelper::PrintStatsFinal(std::ostream &stream,
-                                     std::chrono::seconds elapsedSeconds) const
+void ProgressHelper::PrintStatsFinal(std::ostream &stream, std::chrono::seconds elapsedSeconds) const
 {
    auto totalEvents = ComputeNEventsSoFar();
    auto totalFiles = fTotalFiles;


### PR DESCRIPTION
After a quick discussion at one of the recent PPP round tables, we decided that the ProgressBar feature is missing a nice finalization, which prints the final status with all processed events. This PR introduces this feature. It now looks as on the attached screen-shot (both for MT and non MT modes, checked with df106_HiggsToFourLeptons and df102_NanoAODDimuonAnalysis tutorials). 
![Screenshot 2023-10-13 at 15 03 30](https://github.com/root-project/root/assets/80402204/b0afc4b3-e136-43ec-846b-a7909bb5cbe7)



