### PR TITLE
src/RBDT.cxx is a source file of both  libTMVA and libTMVAUtils 

### DIFF
--- a/tmva/tmva/CMakeLists.txt
+++ b/tmva/tmva/CMakeLists.txt
@@ -334,7 +334,6 @@ ROOT_STANDARD_LIBRARY_PACKAGE(TMVA
     src/PDEFoamVect.cxx
     src/PDF.cxx
     src/QuickMVAProbEstimator.cxx
-    src/RBDT.cxx
     src/Ranking.cxx
     src/Reader.cxx
     src/RegressionVariance.cxx

--- a/tmva/tmva/test/CMakeLists.txt
+++ b/tmva/tmva/test/CMakeLists.txt
@@ -29,7 +29,7 @@ if(dataframe)
     # Tree inference system and user interface
     if(NOT MSVC OR llvm13_broken_tests)
         ROOT_ADD_GTEST(branchlessForest branchlessForest.cxx LIBRARIES TMVA)
-        ROOT_ADD_GTEST(rbdt rbdt.cxx LIBRARIES ROOTVecOps TMVA)
+        ROOT_ADD_GTEST(rbdt rbdt.cxx LIBRARIES ROOTVecOps TMVAUtils)
     endif()
 endif()
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

src/RBDT.cxx is a source file of libTMVAUtils and should not also be asource file of libTMVA. Remove it.
Adjust test using symbols defined in this source file to link to libTMVAUtils instead of libTMVA.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This change should alse be ported to 6.28.