### PR TITLE
[cmake] Don't check `minuit2` option before `ROOT_APPLY_OPTIONS()`

### DIFF
--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -355,12 +355,6 @@ if(roofit_multiprocess AND WIN32)
     message(FATAL_ERROR ">>> Option 'roofit_multiprocess' is not supported on Windows.")
 endif()
 
-# RooFit multiprocess only works with Minuit2. In fact, it depends on it at build time.
-if(roofit_multiprocess AND NOT minuit2)
-    message(WARNING "Option 'roofit_multiprocess' requires option `minuit2`. We're setting `minuit2=ON` for you. Consider setting `minuit=ON` yourself to silence this warning.")
-    set(minuit2 ON CACHE BOOL "" FORCE)
-endif()
-
 #---Options depending of CMake Generator-------------------------------------------------------
 if( CMAKE_GENERATOR STREQUAL Ninja)
    set(fortran_defvalue OFF)
@@ -387,6 +381,12 @@ endif()
 
 #---Define at moment the options with the selected default values------------------------------
 ROOT_APPLY_OPTIONS()
+
+# RooFit multiprocess only works with Minuit2. In fact, it depends on it at build time.
+if(roofit_multiprocess AND NOT minuit2)
+    message(WARNING "Option 'roofit_multiprocess' requires option `minuit2`. We're setting `minuit2=ON` for you. Consider setting `minuit2=ON` yourself to silence this warning.")
+    set(minuit2 ON CACHE BOOL "" FORCE)
+endif()
 
 #---roottest option implies testing
 if(roottest OR rootbench)


### PR DESCRIPTION
The `if(roofit_multiprocess AND NOT minuit2)` check should be done after `ROOT_APPLY_OPTIONS()`, because otherwise the variables will not be defined as the defaults if the user didn't define them explicitly.

This avoids warnings when not defining the `minuit2` option when setting `roofit_multiprocess=ON`.

Follows up directly on 3acc0e601bd.

To be backported to the 6.30 branch.