### PR TITLE
[RF] Remove unused `JSONTool` entry in the LinkDef file

### DIFF
--- a/roofit/hs3/LinkDef.h
+++ b/roofit/hs3/LinkDef.h
@@ -3,7 +3,6 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
-#pragma link C++ class RooStats::HistFactory::JSONTool + ;
 #pragma link C++ class RooJSONFactoryWSTool + ;
 #pragma link C++ class RooFit::JSONIO::Importer + ;
 #pragma link C++ class RooFit::JSONIO::Exporter + ;


### PR DESCRIPTION
This is to fix build warnings.

Seen for example here:
https://lcgapp-services.cern.ch/root-jenkins/view/ROOT%20Nightly/job/root-nightly-master/LABEL=ROOT-centos9,SPEC=noimt,V=master/lastBuild/parsed_console/

```
Warning: Unused class rule: RooStats::HistFactory::JSONTool
```