### PR TITLE
[clang] Fix crash with constexpr destructor [v6.28]

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/AST/ExprConstant.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/AST/ExprConstant.cpp
@@ -14932,10 +14932,13 @@ bool Expr::EvaluateAsInitializer(APValue &Value, const ASTContext &Ctx,
     LValue LVal;
     LVal.set(VD);
 
-    if (!EvaluateInPlace(Value, Info, LVal, this,
-                         /*AllowNonLiteralTypes=*/true) ||
-        EStatus.HasSideEffects)
-      return false;
+    {
+      FullExpressionRAII Scope(Info);
+      if (!EvaluateInPlace(Value, Info, LVal, this,
+                           /*AllowNonLiteralTypes=*/true) ||
+          EStatus.HasSideEffects)
+        return false;
+    }
 
     // At this point, any lifetime-extended temporaries are completely
     // initialized.


### PR DESCRIPTION
Fixes https://github.com/root-project/root/issues/13851
See also https://github.com/llvm/llvm-project/issues/68702

(cherry picked from commit 0919a5359eefda0fc9e56a3198da21596114d62f)