### PR TITLE
[skip-ci] Remove extra semicolon

### DIFF
--- a/hist/hist/inc/TFormula.h
+++ b/hist/hist/inc/TFormula.h
@@ -325,6 +325,6 @@ Double_t TFormula::Eval(Args... args) const
    }
    double xxx[] = {static_cast<Double_t>(args)...};
    return EvalPar(xxx, nullptr);
-};
+}
 
 #endif


### PR DESCRIPTION
Fix the following  compilation error with the `-Wpedantic` compiler flag
```
[81%] Building... ... ... ... error: extra ';' [-Wpedantic]
```
