### PR TITLE
[math] Apply the CMSSW clang-tidy suggestions to ROOT Math

### DIFF
--- a/math/fumili/inc/TFumiliMinimizer.h
+++ b/math/fumili/inc/TFumiliMinimizer.h
@@ -136,7 +136,7 @@ public:
      return covariance matrix status
    */
    int CovMatrixStatus() const override {
-      if (fCovar.size() == 0) return 0;
+      if (fCovar.empty()) return 0;
       return (fStatus ==0) ? 3 : 1;
    }
 

--- a/math/genvector/test/stress2D.cxx
+++ b/math/genvector/test/stress2D.cxx
@@ -35,7 +35,7 @@
 #include <iostream>
 #include <algorithm>
 
-#include <assert.h>
+#include <cassert>
 #include <map>
 
 #include "TStopwatch.h"

--- a/math/mathcore/inc/Fit/BinData.h
+++ b/math/mathcore/inc/Fit/BinData.h
@@ -543,7 +543,7 @@ public :
       query if the data store the bin edges instead of the center
    */
    bool HasBinEdges() const {
-      return fBinEdge.size() == fDim && fBinEdge[0].size() > 0;
+      return fBinEdge.size() == fDim && !fBinEdge[0].empty();
    }
 
    /**

--- a/math/mathcore/inc/Fit/DataRange.h
+++ b/math/mathcore/inc/Fit/DataRange.h
@@ -79,7 +79,7 @@ public:
     */
    bool IsSet() const {
       for (unsigned int icoord = 0; icoord < fRanges.size(); ++icoord)
-         if (fRanges[icoord].size() > 0) return true;
+         if (!fRanges[icoord].empty()) return true;
       return false;
    }
 

--- a/math/mathcore/inc/Fit/FitResult.h
+++ b/math/mathcore/inc/Fit/FitResult.h
@@ -105,7 +105,7 @@ public:
    bool IsValid() const { return fValid; }
 
    /// True if a fit result does not exist (even invalid) with parameter values
-   bool IsEmpty() const { return (fParams.size() == 0);  }
+   bool IsEmpty() const { return (fParams.empty());  }
 
    /// Return value of the objective function (chi2 or likelihood) used in the fit
    double MinFcnValue() const { return fVal; }
@@ -212,7 +212,7 @@ public:
    /// retrieve covariance matrix element
    double CovMatrix (unsigned int i, unsigned int j) const {
       if ( i >= fErrors.size() || j >= fErrors.size() ) return 0;
-      if (fCovMatrix.size() == 0) return 0; // no matrix is available in case of non-valid fits
+      if (fCovMatrix.empty()) return 0; // no matrix is available in case of non-valid fits
       if ( j < i )
          return fCovMatrix[j + i* (i+1) / 2];
       else
@@ -222,7 +222,7 @@ public:
    /// retrieve correlation elements
    double Correlation(unsigned int i, unsigned int j ) const {
       if ( i >= fErrors.size() || j >= fErrors.size() ) return 0;
-      if (fCovMatrix.size() == 0) return 0; // no matrix is available in case of non-valid fits
+      if (fCovMatrix.empty()) return 0; // no matrix is available in case of non-valid fits
       double tmp = CovMatrix(i,i)*CovMatrix(j,j);
       return ( tmp > 0) ? CovMatrix(i,j)/ std::sqrt(tmp) : 0;
    }

--- a/math/mathcore/inc/Fit/FitUtil.h
+++ b/math/mathcore/inc/Fit/FitUtil.h
@@ -250,8 +250,8 @@ namespace FitUtil {
 #endif
 
      // objects of this class are not meant to be copied / assigned
-     IntegralEvaluator(const IntegralEvaluator &rhs);
-     IntegralEvaluator &operator=(const IntegralEvaluator &rhs);
+     IntegralEvaluator(const IntegralEvaluator &rhs) = delete;
+     IntegralEvaluator &operator=(const IntegralEvaluator &rhs) = delete;
 
      unsigned int fDim;
      const double *fParams;

--- a/math/mathcore/inc/Math/ParamFunctor.h
+++ b/math/mathcore/inc/Math/ParamFunctor.h
@@ -245,8 +245,8 @@ private:
    // };
 
 private :
-   ParamMemFunHandler(const ParamMemFunHandler&); // Not implemented
-   ParamMemFunHandler& operator=(const ParamMemFunHandler&); // Not implemented
+   ParamMemFunHandler(const ParamMemFunHandler&) = delete; // Not implemented
+   ParamMemFunHandler& operator=(const ParamMemFunHandler&) = delete; // Not implemented
 
    PointerToObj fObj;
    PointerToMemFn fMemFn;

--- a/math/mathcore/inc/Math/WrappedParamFunction.h
+++ b/math/mathcore/inc/Math/WrappedParamFunction.h
@@ -180,8 +180,8 @@ public:
 
 private:
    // copy ctor
-   WrappedParamFunctionGen(const  WrappedParamFunctionGen &);   // not implemented
-   WrappedParamFunctionGen & operator=(const  WrappedParamFunctionGen &); // not implemented
+   WrappedParamFunctionGen(const  WrappedParamFunctionGen &) = delete;   // not implemented
+   WrappedParamFunctionGen & operator=(const  WrappedParamFunctionGen &) = delete; // not implemented
 
 public:
 

--- a/math/mathcore/inc/TMath.h
+++ b/math/mathcore/inc/TMath.h
@@ -573,8 +573,8 @@ struct Limits {
 ////////////////////////////////////////////////////////////////////////////////
 // Trig and other functions
 
-#include <float.h>
-#include <math.h>
+#include <cfloat>
+#include <cmath>
 
 #if defined(R__WIN32) && !defined(__CINT__)
 #   ifndef finite

--- a/math/mathcore/src/BasicMinimizer.cxx
+++ b/math/mathcore/src/BasicMinimizer.cxx
@@ -264,7 +264,7 @@ bool BasicMinimizer::CheckObjFunction() const {
 
 MinimTransformFunction * BasicMinimizer::CreateTransformation(std::vector<double> & startValues, const ROOT::Math::IMultiGradFunction * func) {
 
-   bool doTransform = (fBounds.size() > 0);
+   bool doTransform = (!fBounds.empty());
    unsigned int ivar = 0;
    while (!doTransform && ivar < fVarTypes.size() ) {
       doTransform = (fVarTypes[ivar++] != kDefault );

--- a/math/mathcore/src/DataRange.cxx
+++ b/math/mathcore/src/DataRange.cxx
@@ -106,7 +106,7 @@ void DataRange::AddRange(unsigned  int  icoord , double xmin, double xmax  ) {
    }
    RangeSet & rs = fRanges[icoord];
    // case the vector  of the ranges is empty in the given coordinate
-   if ( rs.size() == 0) {
+   if ( rs.empty()) {
       rs.push_back(std::make_pair(xmin,xmax) );
       return;
    }

--- a/math/mathcore/src/Delaunay2D.cxx
+++ b/math/mathcore/src/Delaunay2D.cxx
@@ -22,7 +22,7 @@
 #endif
 
 #include <algorithm>
-#include <stdlib.h>
+#include <cstdlib>
 
 #include <iostream>
 #include <limits>

--- a/math/mathcore/src/FitConfig.cxx
+++ b/math/mathcore/src/FitConfig.cxx
@@ -105,7 +105,7 @@ void FitConfig::SetFromFitResult(const FitResult &result) {
 
          // query if parameter needs to run Minos
          if (result.HasMinosError(i) ) {
-            if (fMinosParams.size() == 0) {
+            if (fMinosParams.empty()) {
                fMinosErrors = true;
                fMinosParams.reserve(npar-i);
             }
@@ -243,7 +243,7 @@ std::string FitConfig::MinimizerName() const
 
    // append algorithm name for minimizer that support it
    if ((name.find("Fumili") == std::string::npos) && (name.find("GSLMultiFit") == std::string::npos)) {
-      if (MinimizerAlgoType() != "")
+      if (!MinimizerAlgoType().empty())
          name += " / " + MinimizerAlgoType();
    }
    return name;

--- a/math/mathcore/src/FitResult.cxx
+++ b/math/mathcore/src/FitResult.cxx
@@ -75,7 +75,7 @@ FitResult::FitResult(const FitConfig & fconfig) :
    if ( (fMinimType.find("Fumili") == std::string::npos) &&
         (fMinimType.find("GSLMultiFit") == std::string::npos)
       ) {
-      if (fconfig.MinimizerAlgoType() != "") fMinimType += " / " + fconfig.MinimizerAlgoType();
+      if (!fconfig.MinimizerAlgoType().empty()) fMinimType += " / " + fconfig.MinimizerAlgoType();
    }
 
    // get parameter values and errors (step sizes)
@@ -427,7 +427,7 @@ void FitResult::Print(std::ostream & os, bool doCovMatrix) const {
       if (IsParameterFixed(i) )
          os << std::setw(9) << " "  << std::setw(nn) << " " << " \t (fixed)";
       else {
-         if (fErrors.size() != 0)
+         if (!fErrors.empty())
             os << "   +/-   " << std::left << std::setw(nn) << fErrors[i] << std::right;
          if (HasMinosError(i))
             os << "  " << std::left  << std::setw(nn) << LowerError(i) << " +" << std::setw(nn) << UpperError(i)
@@ -447,7 +447,7 @@ void FitResult::Print(std::ostream & os, bool doCovMatrix) const {
 void FitResult::PrintCovMatrix(std::ostream &os) const {
    // print the covariance and correlation matrix
    if (!fValid) return;
-   if (fCovMatrix.size() == 0) return;
+   if (fCovMatrix.empty()) return;
 //   os << "****************************************\n";
    os << "\nCovariance Matrix:\n\n";
    unsigned int npar = fParams.size();

--- a/math/mathcore/src/Fitter.cxx
+++ b/math/mathcore/src/Fitter.cxx
@@ -626,7 +626,7 @@ bool Fitter::CalculateMinosErrors() {
 
 
    const std::vector<unsigned int> & ipars = fConfig.MinosParams();
-   unsigned int n = (ipars.size() > 0) ? ipars.size() : fResult->Parameters().size();
+   unsigned int n = (!ipars.empty()) ? ipars.size() : fResult->Parameters().size();
    bool ok = false;
 
    int iparNewMin = 0;
@@ -639,7 +639,7 @@ bool Fitter::CalculateMinosErrors() {
       iparNewMin = 0;
       for (int i = 0; i < iparMax; ++i) {
          double elow, eup;
-         unsigned int index = (ipars.size() > 0) ? ipars[i] : i;
+         unsigned int index = (!ipars.empty()) ? ipars[i] : i;
          bool ret = fMinimizer->GetMinosError(index, elow, eup);
          // flags case when a new minimum has been found
          if ((fMinimizer->MinosStatus() & 8) != 0) {

--- a/math/mathcore/src/GaussLegendreIntegrator.cxx
+++ b/math/mathcore/src/GaussLegendreIntegrator.cxx
@@ -14,7 +14,7 @@
 #include "Math/IFunctionfwd.h"
 #include "Math/IntegratorOptions.h"
 #include <cmath>
-#include <string.h>
+#include <cstring>
 #include <algorithm>
 
 namespace ROOT {

--- a/math/mathcore/src/GenAlgoOptions.cxx
+++ b/math/mathcore/src/GenAlgoOptions.cxx
@@ -16,7 +16,7 @@
 // for toupper
 #include <algorithm>
 #include <functional>
-#include <ctype.h>   // need to use c version of tolower defined here
+#include <cctype>   // need to use c version of tolower defined here
 #include <string>
 
 namespace ROOT {

--- a/math/mathcore/src/GoFTest.cxx
+++ b/math/mathcore/src/GoFTest.cxx
@@ -13,8 +13,9 @@
 #include <functional>
 #include <iostream>
 #include <map>
+#include <memory>
 #include <numeric>
-#include <string.h>
+#include <cstring>
 #include <cassert>
 
 #include "Math/Error.h"
@@ -270,9 +271,9 @@ namespace Math {
       fDist = kUserDefined;
       // function will be cloned inside the wrapper PDFIntegral of CDFWrapper classes
       if (isPDF)
-         fCDF.reset(new PDFIntegral(f, xmin, xmax) );
+         fCDF = std::make_unique<PDFIntegral>(f, xmin, xmax );
       else
-         fCDF.reset(new CDFWrapper(f, xmin, xmax) );
+         fCDF = std::make_unique<CDFWrapper>(f, xmin, xmax );
    }
 
    void GoFTest::Instantiate(const Double_t* sample, size_t sampleSize) {

--- a/math/mathcore/src/Integrator.cxx
+++ b/math/mathcore/src/Integrator.cxx
@@ -27,7 +27,7 @@
 
 #include <algorithm>
 #include <functional>
-#include <ctype.h>   // need to use c version of tolower defined here
+#include <cctype>   // need to use c version of tolower defined here
 
 
 #include <cassert>

--- a/math/mathcore/src/IntegratorOptions.cxx
+++ b/math/mathcore/src/IntegratorOptions.cxx
@@ -17,7 +17,7 @@
 
 #include <algorithm>
 #include <functional>
-#include <ctype.h>   // need to use c version of tolower defined here
+#include <cctype>   // need to use c version of tolower defined here
 
 #include <map>
 

--- a/math/mathcore/src/MinimizerOptions.cxx
+++ b/math/mathcore/src/MinimizerOptions.cxx
@@ -46,7 +46,7 @@ void MinimizerOptions::SetDefaultMinimizer(const char * type, const char * algo)
    // set the default minimizer type and algorithm
    if (type) Minim::gDefaultMinimizer = std::string(type);
    if (algo) Minim::gDefaultMinimAlgo = std::string(algo);
-   if (Minim::gDefaultMinimAlgo == "" && ( Minim::gDefaultMinimizer == "Minuit" ||
+   if (Minim::gDefaultMinimAlgo.empty() && ( Minim::gDefaultMinimizer == "Minuit" ||
        Minim::gDefaultMinimizer == "Minuit2") )
       Minim::gDefaultMinimAlgo = "Migrad";
 }
@@ -122,14 +122,14 @@ const std::string & MinimizerOptions::DefaultMinimizerType()
 #else
    R__READ_LOCKGUARD(ROOT::gCoreMutex);
 
-   if (Minim::gDefaultMinimizer.size() != 0)
+   if (!Minim::gDefaultMinimizer.empty())
       return Minim::gDefaultMinimizer;
 
    R__WRITE_LOCKGUARD(ROOT::gCoreMutex);
 
    // Another thread also waiting for the write lock might have
    // done the assignment
-   if (Minim::gDefaultMinimizer.size() != 0)
+   if (!Minim::gDefaultMinimizer.empty())
       return Minim::gDefaultMinimizer;
 
    // use value defined in etc/system.rootrc  (if not found Minuit is used)

--- a/math/mathcore/src/ProbFuncMathCore.cxx
+++ b/math/mathcore/src/ProbFuncMathCore.cxx
@@ -7,7 +7,7 @@
 #include "Math/Error.h"
 #include "Math/ProbFuncMathCore.h"
 #include "Math/SpecFuncMathCore.h"
-#include <stdio.h>
+#include <cstdio>
 #include <limits>
 using namespace std;
 namespace ROOT {

--- a/math/mathcore/src/RandomFunctions.cxx
+++ b/math/mathcore/src/RandomFunctions.cxx
@@ -153,7 +153,7 @@ double RandomFunctionsImpl<TRandomEngine>::GausACR(Double_t mean, Double_t sigma
          }
       }
 
-      while (1) {
+      while (true) {
          x = Rndm();
          y = kYm * Rndm();
          z = kX0 - kS*x - y;
@@ -170,7 +170,7 @@ double RandomFunctionsImpl<TRandomEngine>::GausACR(Double_t mean, Double_t sigma
             if (rn*rn<4*(kB-log(x))) {
                result = rn; break; }
       }
-   } while(0);
+   } while(false);
 
    return mean + sigma * result;
 }
@@ -218,7 +218,7 @@ Int_t RandomFunctionsImpl<TRandomEngine>::Poisson(Double_t mean)
       Double_t expmean = TMath::Exp(-mean);
       Double_t pir = 1;
       n = -1;
-      while(1) {
+      while(true) {
          n++;
          pir *= Rndm();
          if (pir <= expmean) break;
@@ -270,7 +270,7 @@ Double_t RandomFunctionsImpl<TRandomEngine>::PoissonD(Double_t mean)
       Double_t expmean = TMath::Exp(-mean);
       Double_t pir = 1;
       n = -1;
-      while(1) {
+      while(true) {
          n++;
          pir *= Rndm();
          if (pir <= expmean) break;

--- a/math/mathcore/src/TKDTree.cxx
+++ b/math/mathcore/src/TKDTree.cxx
@@ -13,7 +13,7 @@
 #include "TRandom.h"
 
 #include "TString.h"
-#include <string.h>
+#include <cstring>
 #include <limits>
 
 templateClassImp(TKDTree);
@@ -525,7 +525,7 @@ void TKDTree<Index, Value>::Build()
       posStack[currentIndex]    = cpos+nleft;
       nodeStack[currentIndex]   = (cnode*2)+2;
       //
-      if (0){
+      if (false){
          // consistency check
          Info("Build()", "%s", Form("points %d left %d right %d", npoints, nleft, nright));
          if (nleft<nright) Warning("Build", "Problem Left-Right");

--- a/math/mathcore/src/TKDTreeBinning.cxx
+++ b/math/mathcore/src/TKDTreeBinning.cxx
@@ -640,7 +640,7 @@ UInt_t TKDTreeBinning::FindBin(const Double_t * point) const {
 std::vector<std::vector<Double_t> > TKDTreeBinning::GetPointsInBin(UInt_t bin) const {
    std::vector<Double_t> point(fDim);
    std::vector< std::vector<Double_t> > thePoints;
-   if (fData.size() == 0) {
+   if (fData.empty()) {
       Error("GetPointsInBin","Internal data set is not valid");
       return thePoints;
    }

--- a/math/mathcore/src/TMath.cxx
+++ b/math/mathcore/src/TMath.cxx
@@ -2773,7 +2773,7 @@ Double_t TMath::Vavilov(Double_t x, Double_t kappa, Double_t beta2)
 
    Int_t itype;
    Int_t npt;
-   TMath::VavilovSet(kappa, beta2, 0, nullptr, ac, hc, itype, npt);
+   TMath::VavilovSet(kappa, beta2, false, nullptr, ac, hc, itype, npt);
    Double_t v =  TMath::VavilovDenEval(x, ac, hc, itype);
    delete [] ac;
    delete [] hc;
@@ -2808,7 +2808,7 @@ Double_t TMath::VavilovI(Double_t x, Double_t kappa, Double_t beta2)
    Int_t npt;
    Int_t k;
    Double_t xx, v;
-   TMath::VavilovSet(kappa, beta2, 1, wcm, ac, hc, itype, npt);
+   TMath::VavilovSet(kappa, beta2, true, wcm, ac, hc, itype, npt);
    if (x < ac[0]) v = 0;
    else if (x >=ac[8]) v = 1;
    else {

--- a/math/mathcore/src/TRandom.cxx
+++ b/math/mathcore/src/TRandom.cxx
@@ -331,7 +331,7 @@ Double_t TRandom::Gaus(Double_t mean, Double_t sigma)
          }
       }
 
-      while (1) {
+      while (true) {
          x = Rndm();
          y = kYm * Rndm();
          z = kX0 - kS*x - y;
@@ -348,7 +348,7 @@ Double_t TRandom::Gaus(Double_t mean, Double_t sigma)
             if (rn*rn<4*(kB-log(x))) {
                result = rn; break; }
       }
-   } while(0);
+   } while(false);
 
    return mean + sigma * result;
 }
@@ -407,7 +407,7 @@ Int_t TRandom::Poisson(Double_t mean)
       Double_t expmean = TMath::Exp(-mean);
       Double_t pir = 1;
       n = -1;
-      while(1) {
+      while(true) {
          n++;
          pir *= Rndm();
          if (pir <= expmean) break;
@@ -459,7 +459,7 @@ Double_t TRandom::PoissonD(Double_t mean)
       Double_t expmean = TMath::Exp(-mean);
       Double_t pir = 1;
       n = -1;
-      while(1) {
+      while(true) {
          n++;
          pir *= Rndm();
          if (pir <= expmean) break;

--- a/math/mathcore/src/TRandom1.cxx
+++ b/math/mathcore/src/TRandom1.cxx
@@ -22,7 +22,7 @@ Comp. Phys. Comm. 60 (1990) 329-344".
 #include "TRandom1.h"
 #include "TRandom3.h"
 #include "TMath.h"
-#include <stdlib.h>
+#include <cstdlib>
 
 // Number of instances with automatic seed selection
 int TRandom1::fgNumEngines = 0;

--- a/math/mathcore/test/fit/testLogLExecPolicy.cxx
+++ b/math/mathcore/test/fit/testLogLExecPolicy.cxx
@@ -177,7 +177,7 @@ public:
       fitter.SetFunction(*wfSeq, false);
       fitter.Config().ParamsSettings() = paramSettings; 
       start = std::chrono::system_clock::now();
-      bool ret = fitter.Fit(*dataSB, 0, ROOT::EExecutionPolicy::kMultiThread);
+      bool ret = fitter.Fit(*dataSB, false, ROOT::EExecutionPolicy::kMultiThread);
       end =  std::chrono::system_clock::now();
       duration = end - start;
       std::cout << "Time for the parallel test: " << duration.count() << std::endl;
@@ -191,7 +191,7 @@ public:
       fitter.SetFunction(*wfSeq, false);
       fitter.Config().ParamsSettings() = paramSettings; 
       start = std::chrono::system_clock::now();
-      bool ret = fitter.Fit(*dataSB, 0, ROOT::EExecutionPolicy::kMultiProcess);
+      bool ret = fitter.Fit(*dataSB, false, ROOT::EExecutionPolicy::kMultiProcess);
       end =  std::chrono::system_clock::now();
       duration = end - start;
       std::cout << "Time for the multiprocess test:" << duration.count() << std::endl;

--- a/math/mathcore/test/newKDTreeTest.cxx
+++ b/math/mathcore/test/newKDTreeTest.cxx
@@ -3,12 +3,12 @@
 
 // program to test new KDTree class
 
-#include <time.h>
+#include <ctime>
 // STL include(s)
 #include <iostream>
-#include <stdlib.h>
+#include <cstdlib>
 #include <vector>
-#include "assert.h"
+#include <cassert>
 
 // custom include(s)
 #include "Math/KDTree.h"

--- a/math/mathcore/test/stress/VectorTest.h
+++ b/math/mathcore/test/stress/VectorTest.h
@@ -199,7 +199,7 @@ public:
       V *v1 = new V();
 
       // need to add namespace to full type name
-      if (typeName == "") {
+      if (typeName.empty()) {
          typeName = "ROOT::Math::" + VecType<V>::name();
       }
 

--- a/math/mathcore/test/testIntegrationMultiDim.cxx
+++ b/math/mathcore/test/testIntegrationMultiDim.cxx
@@ -178,7 +178,7 @@ void performance()
       num_performance->SetBarWidth(0.45);
       num_performance->SetBarOffset(0.05);
       num_performance->SetFillColor(49);
-      num_performance->SetStats(0);
+      num_performance->SetStats(false);
       //num_performance->GetXaxis()->SetLimits(1.5, Nmax+0.5);
       num_performance->GetXaxis()->SetTitle("number of dimensions");
       num_performance->GetYaxis()->SetTitle("time [s]");

--- a/math/mathmore/inc/Math/GSLNLSMinimizer.h
+++ b/math/mathmore/inc/Math/GSLNLSMinimizer.h
@@ -114,7 +114,7 @@ public:
    bool ProvidesError() const override { return true; }
 
    /// return errors at the minimum
-   const double * Errors() const override { return (fErrors.size() > 0) ? &fErrors.front() : nullptr; }
+   const double * Errors() const override { return (!fErrors.empty()) ? &fErrors.front() : nullptr; }
 //  {
 //       static std::vector<double> err;
 //       err.resize(fDim);

--- a/math/mathmore/inc/Math/MCParameters.h
+++ b/math/mathmore/inc/Math/MCParameters.h
@@ -26,7 +26,7 @@
 #ifndef ROOT_Math_MCParameters
 #define ROOT_Math_MCParameters
 
-#include <stddef.h>   // for size_t
+#include <cstddef>   // for size_t
 
 namespace ROOT {
 namespace Math {

--- a/math/mathmore/src/GSL1DMinimizerWrapper.h
+++ b/math/mathmore/src/GSL1DMinimizerWrapper.h
@@ -54,8 +54,8 @@ public:
 
 private:
 // usually copying is non trivial, so we make this unaccessible
-   GSL1DMinimizerWrapper(const GSL1DMinimizerWrapper &);
-   GSL1DMinimizerWrapper & operator = (const GSL1DMinimizerWrapper &);
+   GSL1DMinimizerWrapper(const GSL1DMinimizerWrapper &) = delete;
+   GSL1DMinimizerWrapper & operator = (const GSL1DMinimizerWrapper &) = delete;
 
 public:
 

--- a/math/mathmore/src/GSLChebSeries.h
+++ b/math/mathmore/src/GSLChebSeries.h
@@ -55,8 +55,8 @@ public:
 
 private:
 // usually copying is non trivial, so we make this unaccessible
-  GSLChebSeries(const GSLChebSeries &);
-  GSLChebSeries & operator = (const GSLChebSeries &);
+  GSLChebSeries(const GSLChebSeries &) = delete;
+  GSLChebSeries & operator = (const GSLChebSeries &) = delete;
 
 public:
 

--- a/math/mathmore/src/GSLIntegrator.cxx
+++ b/math/mathmore/src/GSLIntegrator.cxx
@@ -40,7 +40,7 @@
 // for toupper
 #include <algorithm>
 #include <functional>
-#include <ctype.h>   // need to use c version of tolower defined here
+#include <cctype>   // need to use c version of tolower defined here
 
 
 #include <iostream>

--- a/math/mathmore/src/GSLMCIntegrator.cxx
+++ b/math/mathmore/src/GSLMCIntegrator.cxx
@@ -39,7 +39,7 @@
 
 #include <algorithm>
 #include <functional>
-#include <ctype.h>   // need to use c version of tolower defined here
+#include <cctype>   // need to use c version of tolower defined here
 
 
 #include "gsl/gsl_monte_vegas.h"

--- a/math/mathmore/src/GSLMinimizer.cxx
+++ b/math/mathmore/src/GSLMinimizer.cxx
@@ -40,7 +40,7 @@
 #include <cmath>
 #include <algorithm>
 #include <functional>
-#include <ctype.h>   // need to use c version of tolower defined here
+#include <cctype>   // need to use c version of tolower defined here
 #include <limits>
 
 namespace ROOT {

--- a/math/mathmore/src/GSLMinimizer1D.cxx
+++ b/math/mathmore/src/GSLMinimizer1D.cxx
@@ -28,7 +28,7 @@
 // Last update: Wed Dec  1 15:04:51 2004
 //
 
-#include <assert.h>
+#include <cassert>
 
 #include "Math/GSLMinimizer1D.h"
 #include "Math/Error.h"

--- a/math/mathmore/src/GSLMultiRootFinder.cxx
+++ b/math/mathmore/src/GSLMultiRootFinder.cxx
@@ -41,7 +41,7 @@
 
 #include <algorithm>
 #include <functional>
-#include <ctype.h>   // need to use c version of tolower defined here
+#include <cctype>   // need to use c version of tolower defined here
 
 
 namespace ROOT {
@@ -240,7 +240,7 @@ bool GSLMultiRootFinder::Solve (const double * x, int maxIter, double absTol, do
    if (fSolver) delete fSolver;
    fSolver = nullptr;
 
-   if (fFunctions.size() == 0) {
+   if (fFunctions.empty()) {
       MATH_ERROR_MSG("GSLMultiRootFinder::Solve","Function list is empty");
       fStatus = -1;
       return false;

--- a/math/mathmore/src/GSLNLSMinimizer.cxx
+++ b/math/mathmore/src/GSLNLSMinimizer.cxx
@@ -99,8 +99,8 @@ public:
 private:
 
    // objects of this class are not meant for copying or assignment
-   FitTransformFunction(const FitTransformFunction& rhs);
-   FitTransformFunction& operator=(const FitTransformFunction& rhs);
+   FitTransformFunction(const FitTransformFunction& rhs) = delete;
+   FitTransformFunction& operator=(const FitTransformFunction& rhs) = delete;
 
    virtual double DoEval(const double * x) const  {
       return fFunc( fTransform->Transformation(x) );
@@ -456,7 +456,7 @@ const double * GSLNLSMinimizer::MinGradient() const {
 double GSLNLSMinimizer::CovMatrix(unsigned int i , unsigned int j ) const {
    // return covariance matrix element
    unsigned int ndim = NDim();
-   if ( fCovMatrix.size() == 0) return 0;
+   if ( fCovMatrix.empty()) return 0;
    if (i > ndim || j > ndim) return 0;
    return fCovMatrix[i*ndim + j];
 }
@@ -464,7 +464,7 @@ double GSLNLSMinimizer::CovMatrix(unsigned int i , unsigned int j ) const {
 int GSLNLSMinimizer::CovMatrixStatus( ) const {
    // return covariance  matrix status = 0 not computed,
    // 1 computed but is approximate because minimum is not valid, 3 is fine
-   if ( fCovMatrix.size() == 0) return 0;
+   if ( fCovMatrix.empty()) return 0;
    // case minimization did not finished correctly
    if (fStatus != GSL_SUCCESS) return 1;
    return 3;

--- a/math/mathmore/src/GSLQRngWrapper.h
+++ b/math/mathmore/src/GSLQRngWrapper.h
@@ -32,7 +32,7 @@ public:
       Default constructor
    */
    GSLQRngWrapper () :
-      fOwn(0),
+      fOwn(false),
       fRng(nullptr),
       fRngType(nullptr)
     {
@@ -42,7 +42,7 @@ public:
       Constructor with type
    */
    GSLQRngWrapper(const gsl_qrng_type * type) :
-      fOwn(1),
+      fOwn(true),
       fRng(nullptr),
       fRngType(type)
     {
@@ -53,7 +53,7 @@ public:
        it is managed externally - so will not be deleted at the end
    */
    GSLQRngWrapper(const gsl_qrng * r ) :
-      fOwn(0),
+      fOwn(false),
       fRngType(nullptr)
     {
        fRng = const_cast<gsl_qrng *>(r);
@@ -63,7 +63,7 @@ public:
       Copy constructor - clone the GSL object and manage it
    */
    GSLQRngWrapper(GSLQRngWrapper & r) :
-      fOwn(1),
+      fOwn(true),
       fRngType(r.fRngType)
    {
       fRng = gsl_qrng_clone(r.fRng);

--- a/math/mathmore/src/complex_quartic.h
+++ b/math/mathmore/src/complex_quartic.h
@@ -27,7 +27,7 @@
  *  x^4 + a x^3 + b x^2 + c x + d = 0
  */
 
-#include <math.h>
+#include <cmath>
 #include <gsl/gsl_math.h>
 #include <gsl/gsl_complex.h>
 #include <gsl/gsl_complex_math.h>

--- a/math/mathmore/src/zsolve_cubic.cxx
+++ b/math/mathmore/src/zsolve_cubic.cxx
@@ -20,7 +20,7 @@
 /* zsolve_cubic.c - finds the complex roots of x^3 + a x^2 + b x + c = 0 */
 
 //#include <config.h>
-#include <math.h>
+#include <cmath>
 #include <gsl/gsl_math.h>
 #include <gsl/gsl_complex.h>
 #include <gsl/gsl_poly.h>

--- a/math/mathmore/test/pirndm.C
+++ b/math/mathmore/test/pirndm.C
@@ -143,7 +143,7 @@ void pirndm(Long64_t n1=1, unsigned int seed = 0) {
    frame->GetYaxis()->SetTitle("Difference with #pi");
    frame->GetYaxis()->SetTitleOffset(1.3);
    frame->GetYaxis()->SetDecimals();
-   frame->SetStats(0);
+   frame->SetStats(false);
    frame->Draw();
    legend = new TLegend(0.6,0.7,0.88,0.88);
    legend->Draw();

--- a/math/mathmore/test/testMCIntegration.cxx
+++ b/math/mathmore/test/testMCIntegration.cxx
@@ -301,7 +301,7 @@ bool performance()
       num_performance->SetBarWidth(0.23);
       num_performance->SetBarOffset(0.04);
       num_performance->SetFillColor(kRed+3);
-      num_performance->SetStats(0);
+      num_performance->SetStats(false);
       //num_performance->GetXaxis()->SetLimits(1.5, Nmax+0.5);
       num_performance->GetXaxis()->SetTitle("number of dimensions");
       num_performance->GetYaxis()->SetTitle("time [s]");

--- a/math/mathmore/test/testMultiRootFinder.cxx
+++ b/math/mathmore/test/testMultiRootFinder.cxx
@@ -14,7 +14,7 @@ struct TStopwatch {
 #endif
 
 #include <iostream>
-#include <stdlib.h>
+#include <cstdlib>
 
 // solve Roots of rosenbrock function
 // f1(x,y) = a(1-x)

--- a/math/matrix/src/TDecompSVD.cxx
+++ b/math/matrix/src/TDecompSVD.cxx
@@ -507,7 +507,7 @@ void TDecompSVD::SortSingular(TMatrixD &v,TMatrixD &u,TVectorD &sDiag)
 
    Int_t i,j;
    if (nCol_v > 1) {
-      while (1) {
+      while (true) {
          Bool_t found = kFALSE;
          i = 1;
          while (!found && i < nCol_v) {

--- a/math/minuit/inc/TLinearMinimizer.h
+++ b/math/minuit/inc/TLinearMinimizer.h
@@ -113,7 +113,7 @@ public:
 
    /// return covariance matrix status
    int CovMatrixStatus() const override {
-      if (fCovar.size() == 0) return 0;
+      if (fCovar.empty()) return 0;
       return (fStatus ==0) ? 3 : 1;
    }
 

--- a/math/minuit/src/TFitter.cxx
+++ b/math/minuit/src/TFitter.cxx
@@ -130,11 +130,11 @@ void TFitter::GetConfidenceIntervals(Int_t n, Int_t ndim, const Double_t *x, Dou
       memset(fixed,0,npar_real*sizeof(Bool_t));
 
       for (Int_t ipar=0; ipar<npar_real; ipar++){
-         fixed[ipar]=0;
+         fixed[ipar]=false;
          f->GetParLimits(ipar,al,bl);
          if (al*bl != 0 && al >= bl) {
             //this parameter is fixed
-            fixed[ipar]=1;
+            fixed[ipar]=true;
          }
       }
    }

--- a/math/minuit/src/TLinearFitter.cxx
+++ b/math/minuit/src/TLinearFitter.cxx
@@ -547,7 +547,7 @@ void TLinearFitter::Add(TLinearFitter *tlf)
 
    fChisquare=0;
    fH=0;
-   fRobust=0;
+   fRobust=false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -768,7 +768,7 @@ void TLinearFitter::Clear(Option_t * /*option*/)
    fNdim=0;
    if (fFormula) delete [] fFormula;
    fFormula=nullptr;
-   fIsSet=0;
+   fIsSet=false;
    if (fFixedParams) delete [] fFixedParams;
    fFixedParams=nullptr;
 
@@ -799,7 +799,7 @@ void TLinearFitter::ClearPoints()
    fParSign.Zero();
 
    for (Int_t i=0; i<fNfunctions; i++)
-      fFixedParams[i]=0;
+      fFixedParams[i]=false;
    fChisquare=0;
    fNpoints=0;
 
@@ -1028,7 +1028,7 @@ void TLinearFitter::FixParameter(Int_t ipar)
    }
    if (!fFixedParams)
       fFixedParams = new Bool_t[fNfunctions];
-   fFixedParams[ipar] = 1;
+   fFixedParams[ipar] = true;
    fNfixed++;
 }
 
@@ -1047,7 +1047,7 @@ void TLinearFitter::FixParameter(Int_t ipar, Double_t parvalue)
    }
    if(!fFixedParams)
       fFixedParams = new Bool_t[fNfunctions];
-   fFixedParams[ipar] = 1;
+   fFixedParams[ipar] = true;
    if (fParams.GetNoElements()<fNfunctions)
       fParams.ResizeTo(fNfunctions);
    fParams(ipar) = parvalue;
@@ -1067,7 +1067,7 @@ void TLinearFitter::ReleaseParameter(Int_t ipar)
       Warning("ReleaseParameter","This parameter is not fixed\n");
       return;
    } else {
-      fFixedParams[ipar] = 0;
+      fFixedParams[ipar] = false;
       fNfixed--;
    }
 }
@@ -1501,7 +1501,7 @@ void TLinearFitter::SetBasisFunctions(TObjArray * functions)
    fY2Temp=0;
    fY2=0;
    for (int i=0; i<size; i++)
-      fFixedParams[i]=0;
+      fFixedParams[i]=false;
    fIsSet=kFALSE;
    fChisquare=0;
 
@@ -1644,7 +1644,7 @@ void TLinearFitter::SetFormula(const char *formula)
    fY2Temp=0;
    fY2=0;
    for (i=0; i<size; i++)
-      fFixedParams[i]=0;
+      fFixedParams[i]=false;
    fIsSet=kFALSE;
    fChisquare=0;
 
@@ -1699,7 +1699,7 @@ void TLinearFitter::SetFormula(TFormula *function)
    fY2Temp=0;
    fY2=0;
    for (Int_t i=0; i<size; i++)
-      fFixedParams[i]=0;
+      fFixedParams[i]=false;
    //check if any parameters are fixed (not for pure TFormula)
 
    if (function->InheritsFrom(TF1::Class())){
@@ -1726,9 +1726,9 @@ Bool_t TLinearFitter::UpdateMatrix()
       for (Int_t i=0; i<fNpoints; i++) {
          AddToDesign(TMatrixDRow(fX, i).GetPtr(), fY(i), fE(i));
       }
-      return 1;
+      return true;
    } else
-      return 0;
+      return false;
 
 }
 

--- a/math/minuit/src/TMinuit.cxx
+++ b/math/minuit/src/TMinuit.cxx
@@ -320,8 +320,8 @@ into account the non-linearities much more precisely.
 
 */
 
-#include <stdlib.h>
-#include <stdio.h>
+#include <cstdlib>
+#include <cstdio>
 
 #include "TROOT.h"
 #include "TList.h"

--- a/math/minuit2/src/Minuit2Minimizer.cxx
+++ b/math/minuit2/src/Minuit2Minimizer.cxx
@@ -191,11 +191,11 @@ bool Minuit2Minimizer::SetVariable(unsigned int ivar, const std::string &name, d
 
    if (step <= 0) {
       print.Info("Parameter", name, "has zero or invalid step size - consider it as constant");
-      fState.Add(name.c_str(), val);
+      fState.Add(name, val);
    } else
-      fState.Add(name.c_str(), val, step);
+      fState.Add(name, val, step);
 
-   unsigned int minuit2Index = fState.Index(name.c_str());
+   unsigned int minuit2Index = fState.Index(name);
    if (minuit2Index != ivar) {
       print.Warn("Wrong index", minuit2Index, "used for the variable", name);
       ivar = minuit2Index;
@@ -243,7 +243,7 @@ bool Minuit2Minimizer::SetFixedVariable(unsigned int ivar, const std::string &na
    // use 10%
    double step = (val != 0) ? 0.1 * std::abs(val) : 0.1;
    if (!SetVariable(ivar, name, val, step)) {
-      ivar = fState.Index(name.c_str());
+      ivar = fState.Index(name);
    }
    fState.Fix(ivar);
    return true;
@@ -655,8 +655,8 @@ bool Minuit2Minimizer::ExamineMinimum(const ROOT::Minuit2::FunctionMinimum &min)
 
    // set the minimum values in the fValues vector
    const std::vector<MinuitParameter> &paramsObj = fState.MinuitParameters();
-   if (paramsObj.size() == 0)
-      return 0;
+   if (paramsObj.empty())
+      return false;
    assert(fDim == paramsObj.size());
    // re-size vector if it has changed after a new minimization
    if (fValues.size() != fDim)
@@ -705,7 +705,7 @@ const double *Minuit2Minimizer::Errors() const
 {
    // return error at minimum (set to zero for fixed and constant params)
    const std::vector<MinuitParameter> &paramsObj = fState.MinuitParameters();
-   if (paramsObj.size() == 0)
+   if (paramsObj.empty())
       return nullptr;
    assert(fDim == paramsObj.size());
    // be careful for multiple calls of this function. I will redo an allocation here

--- a/math/minuit2/test/MnSim/PaulTest.cxx
+++ b/math/minuit2/test/MnSim/PaulTest.cxx
@@ -54,7 +54,7 @@ int main()
          nmeas += int(ni);
       }
       std::cout << "size= " << var.size() << std::endl;
-      assert(var.size() > 0);
+      assert(!var.empty());
       std::cout << "nmeas: " << nmeas << std::endl;
    }
 

--- a/math/minuit2/test/MnSim/PaulTest2.cxx
+++ b/math/minuit2/test/MnSim/PaulTest2.cxx
@@ -55,7 +55,7 @@ int main()
          nmeas += y;
       }
       std::cout << "size= " << var.size() << std::endl;
-      assert(var.size() > 0);
+      assert(!var.empty());
       std::cout << "nmeas: " << nmeas << std::endl;
    }
 

--- a/math/mlp/src/TMLPAnalyzer.cxx
+++ b/math/mlp/src/TMLPAnalyzer.cxx
@@ -370,8 +370,8 @@ void TMLPAnalyzer::DrawNetwork(Int_t neuron, const char* signal, const char* bg)
    sigh->SetLineColor(kRed);
    sigh->SetFillStyle(3003);
    sigh->SetFillColor(kRed);
-   bgh->SetStats(0);
-   sigh->SetStats(0);
+   bgh->SetStats(false);
+   sigh->SetStats(false);
    stack->Add(bgh);
    stack->Add(sigh);
    TLegend *legend = new TLegend(.75, .80, .95, .95);

--- a/math/physics/src/TGenPhaseSpace.cxx
+++ b/math/physics/src/TGenPhaseSpace.cxx
@@ -129,7 +129,7 @@ Double_t TGenPhaseSpace::Generate()
 
    Int_t i=1;
    Int_t j;
-   while (1) {
+   while (true) {
       fDecPro[i].SetPxPyPzE(0, -pd[i-1], 0 , TMath::Sqrt(pd[i-1]*pd[i-1]+fMass[i]*fMass[i]) );
 
       Double_t cZ   = 2*gRandom->Rndm() - 1;

--- a/math/physics/src/TRobustEstimator.cxx
+++ b/math/physics/src/TRobustEstimator.cxx
@@ -1038,7 +1038,6 @@ Int_t TRobustEstimator::Exact(Double_t *ndist)
    Int_t i, j;
 
    TMatrixDSymEigen eigen(fCovariance);
-   TVectorD eigenValues=eigen.GetEigenValues();
    TMatrixD eigenMatrix=eigen.GetEigenVectors();
 
    for (j=0; j<fNvar; j++) {

--- a/math/physics/src/TRolke.cxx
+++ b/math/physics/src/TRolke.cxx
@@ -452,7 +452,7 @@ bool TRolke::GetSensitivity(Double_t& low, Double_t& high, Double_t pPrecision)
 
    int loop_x = 0;
 
-   while (1) {
+   while (true) {
       ComputeInterval(loop_x, f_y, f_z, f_bm, f_em, f_e, f_mid, f_sde, f_sdb, f_tau, f_b, f_m);
       weight = TMath::PoissonI(loop_x, background);
       low += fLowerLimit * weight;
@@ -485,7 +485,7 @@ bool TRolke::GetLimitsQuantile(Double_t& low, Double_t& high, Int_t& out_x, Doub
    Double_t weightSum = 0;
    Int_t loop_x = 0;
 
-   while (1) {
+   while (true) {
       weight = TMath::PoissonI(loop_x, background);
       weightSum += weight;
       if (weightSum >= integral) {

--- a/math/smatrix/inc/Math/HelperOps.h
+++ b/math/smatrix/inc/Math/HelperOps.h
@@ -19,7 +19,7 @@
  */
 #include "Math/StaticCheck.h"
 #include <algorithm>  // required by std::copy
-#include <assert.h>
+#include <cassert>
 
 namespace ROOT {
 

--- a/math/smatrix/test/matrixOperations.C
+++ b/math/smatrix/test/matrixOperations.C
@@ -106,8 +106,8 @@ TGraphErrors * hd = h1;
     // ned to do after drawing
     mg->GetXaxis()->SetLimits(1.8,32);
     mg->GetXaxis()->SetTitle("Matrix size ");
-    mg->GetXaxis()->SetMoreLogLabels(1);
-    mg->GetXaxis()->SetNoExponent(1);
+    mg->GetXaxis()->SetMoreLogLabels(true);
+    mg->GetXaxis()->SetNoExponent(true);
     mg->GetYaxis()->SetTitle("CPU Time ");
     mg->GetYaxis()->SetTitleOffset(1.25);
 
@@ -140,7 +140,7 @@ TGraphErrors * hd = h1;
 
 void GetData(std::string s,double * x, double * y, double * ey) {
    std::string fileName;
-   if (systemName != "")
+   if (!systemName.empty())
       fileName="testOperations_" + systemName + ".root";
    else
       fileName="testOperations.root";

--- a/math/unuran/inc/TUnuranDiscrDist.h
+++ b/math/unuran/inc/TUnuranDiscrDist.h
@@ -74,9 +74,9 @@ public:
       fXmax(-1),
       fMode(0),
       fSum(0),
-      fHasDomain(0),
-      fHasMode(0),
-      fHasSum(0),
+      fHasDomain(false),
+      fHasMode(false),
+      fHasSum(false),
       fOwnFunc(false)
    {}
 

--- a/math/unuran/inc/TUnuranEmpDist.h
+++ b/math/unuran/inc/TUnuranEmpDist.h
@@ -67,7 +67,7 @@ public:
       fData(std::vector<double>(begin,end) ),
       fDim(dim),
       fMin(0), fMax(0),
-      fBinned(0)  {}
+      fBinned(false)  {}
 
    /**
       Constructor from a set of 1D data

--- a/math/unuran/inc/TUnuranMultiContDist.h
+++ b/math/unuran/inc/TUnuranMultiContDist.h
@@ -117,14 +117,14 @@ public:
       get the distribution lower domain values. Return a null pointer if domain is not defined
    */
    const double * GetLowerDomain() const {
-      if (fXmin.size() == 0 || (  fXmin.size() != fXmax.size() )  ) return nullptr;
+      if (fXmin.empty() || (  fXmin.size() != fXmax.size() )  ) return nullptr;
       return &fXmin[0];
    }
    /**
       get the distribution upper domain values. Return a null pointer if domain is not defined
    */
    const double * GetUpperDomain() const {
-      if (fXmax.size() == 0 || (  fXmin.size() != fXmax.size() )  ) return nullptr;
+      if (fXmax.empty() || (  fXmin.size() != fXmax.size() )  ) return nullptr;
       return &fXmax[0];
    }
 
@@ -134,7 +134,7 @@ public:
       If a mode has not defined return a NULL pointer
    */
    const double * GetMode() const {
-      if (fMode.size() == 0) return nullptr;
+      if (fMode.empty()) return nullptr;
       return &fMode.front();
    }
 

--- a/math/unuran/src/TUnuran.cxx
+++ b/math/unuran/src/TUnuran.cxx
@@ -305,7 +305,7 @@ bool  TUnuran::SetDiscreteDistribution(const TUnuranDiscrDist & dist)
    if (fUdistr == nullptr) return false;
    unsigned int ret = 0;
    // if a probability mesh function is provided
-   if (dist.ProbVec().size() == 0) {
+   if (dist.ProbVec().empty()) {
       ret = unur_distr_set_extobj(fUdistr, &dist );
       ret |= unur_distr_discr_set_pmf(fUdistr, &DiscrDist::Pmf);
       if (dist.HasCdf() ) ret |= unur_distr_discr_set_cdf(fUdistr, &DiscrDist::Cdf);

--- a/math/unuran/src/TUnuranContDist.cxx
+++ b/math/unuran/src/TUnuranContDist.cxx
@@ -24,8 +24,8 @@ ClassImp(TUnuranContDist);
 
 TUnuranContDist::TUnuranContDist(const ROOT::Math::IGenFunction *pdf, const ROOT::Math::IGenFunction *dpdf,
                                  const ROOT::Math::IGenFunction *cdf, bool isLogPdf, bool copyFunc)
-   : fPdf(pdf), fDPdf(dpdf), fCdf(cdf), fXmin(1.), fXmax(-1.), fMode(0), fArea(0), fIsLogPdf(isLogPdf), fHasDomain(0),
-     fHasMode(0), fHasArea(0), fOwnFunc(copyFunc)
+   : fPdf(pdf), fDPdf(dpdf), fCdf(cdf), fXmin(1.), fXmax(-1.), fMode(0), fArea(0), fIsLogPdf(isLogPdf), fHasDomain(false),
+     fHasMode(false), fHasArea(false), fOwnFunc(copyFunc)
 {
    // Constructor from generic function interfaces
    // manage the functions and clone them if flag copyFunc is true
@@ -52,9 +52,9 @@ TUnuranContDist::TUnuranContDist (TF1 * pdf, TF1 * deriv, TF1 * cdf, bool isLogP
    fMode(0),
    fArea(0),
    fIsLogPdf(isLogPdf),
-   fHasDomain(0),
-   fHasMode(0),
-   fHasArea(0),
+   fHasDomain(false),
+   fHasMode(false),
+   fHasArea(false),
    fOwnFunc(true)
 {
    // Constructor from a TF1 objects

--- a/math/unuran/src/TUnuranDiscrDist.cxx
+++ b/math/unuran/src/TUnuranDiscrDist.cxx
@@ -27,9 +27,9 @@ TUnuranDiscrDist::TUnuranDiscrDist (const ROOT::Math::IGenFunction & func, bool 
    fXmax(-1),
    fMode(0),
    fSum(0),
-   fHasDomain(0),
-   fHasMode(0),
-   fHasSum(0),
+   fHasDomain(false),
+   fHasMode(false),
+   fHasSum(false),
    fOwnFunc(copyFunc)
 {
    //Constructor from a generic function object
@@ -47,9 +47,9 @@ TUnuranDiscrDist::TUnuranDiscrDist (TF1 * func) :
    fXmax(-1),
    fMode(0),
    fSum(0),
-   fHasDomain(0),
-   fHasMode(0),
-   fHasSum(0),
+   fHasDomain(false),
+   fHasMode(false),
+   fHasSum(false),
    fOwnFunc(true)
 {
    //Constructor from a TF1 objects

--- a/math/unuran/src/TUnuranEmpDist.cxx
+++ b/math/unuran/src/TUnuranEmpDist.cxx
@@ -64,7 +64,7 @@ TUnuranEmpDist::TUnuranEmpDist (unsigned int n, double * x) :
    fData(std::vector<double>(x,x+n) ),
    fDim(1),
    fMin(0), fMax(0),
-   fBinned(0)
+   fBinned(false)
 {
    // constructor for 1D unbinned data
 }
@@ -73,7 +73,7 @@ TUnuranEmpDist::TUnuranEmpDist (unsigned int n, double * x, double * y) :
    fData(std::vector<double>(2*n) ),
    fDim(2),
    fMin(0), fMax(0),
-   fBinned(0)
+   fBinned(false)
 {
    // constructor for 2D unbinned data
    for (unsigned int i = 0; i < n; ++i) {
@@ -86,7 +86,7 @@ TUnuranEmpDist::TUnuranEmpDist (unsigned int n, double * x, double * y, double *
    fData(std::vector<double>(3*n) ),
    fDim(3),
    fMin(0), fMax(0),
-   fBinned(0)
+   fBinned(false)
 {
    // constructor for 3D unbinned data
    for (unsigned int i = 0; i < n; ++i) {

--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -1256,7 +1256,7 @@ public:
       if (n != this->size()) {
          std::string msg = "Cannot index RVecN of size " + std::to_string(this->size()) +
                            " with condition vector of different size (" + std::to_string(n) + ").";
-         throw std::runtime_error(std::move(msg));
+         throw std::runtime_error(msg);
       }
 
       size_type n_true = 0ull;
@@ -1287,7 +1287,7 @@ public:
       if (pos >= size_type(this->fSize)) {
          std::string msg = "RVecN::at: size is " + std::to_string(this->fSize) + " but out-of-bounds index " +
                            std::to_string(pos) + " was requested.";
-         throw std::out_of_range(std::move(msg));
+         throw std::out_of_range(msg);
       }
       return this->operator[](pos);
    }
@@ -1297,7 +1297,7 @@ public:
       if (pos >= size_type(this->fSize)) {
          std::string msg = "RVecN::at: size is " + std::to_string(this->fSize) + " but out-of-bounds index " +
                            std::to_string(pos) + " was requested.";
-         throw std::out_of_range(std::move(msg));
+         throw std::out_of_range(msg);
       }
       return this->operator[](pos);
    }


### PR DESCRIPTION
Like for RooFit previously, this commit applies the `clang-tidy` suggestions from the battle-tested CMSSW config file: https://github.com/cms-sw/cmssw/blob/master/.clang-tidy

I scrolled over the changes, and they look unintrusive. It's mostly replacing `0` and `1` literals with `false` and `true`, replaces the included headers, and uses more `empty()`.