### PR TITLE
[io] Don't use `R__ALWAYS_INLINE` In TBufferJSON

### DIFF
--- a/io/io/inc/TBufferJSON.h
+++ b/io/io/inc/TBufferJSON.h
@@ -299,19 +299,19 @@ protected:
    void JsonPushValue();
 
    template <typename T>
-   R__ALWAYS_INLINE void JsonWriteArrayCompress(const T *vname, Int_t arrsize, const char *typname);
+   void JsonWriteArrayCompress(const T *vname, Int_t arrsize, const char *typname);
 
    template <typename T>
-   R__ALWAYS_INLINE void JsonReadBasic(T &value);
+   void JsonReadBasic(T &value);
 
    template <typename T>
-   R__ALWAYS_INLINE Int_t JsonReadArray(T *value);
+   Int_t JsonReadArray(T *value);
 
    template <typename T>
-   R__ALWAYS_INLINE void JsonReadFastArray(T *arr, Int_t arrsize, bool asstring = false);
+   void JsonReadFastArray(T *arr, Int_t arrsize, bool asstring = false);
 
    template <typename T>
-   R__ALWAYS_INLINE void JsonWriteFastArray(const T *arr, Int_t arrsize, const char *typname,
+   void JsonWriteFastArray(const T *arr, Int_t arrsize, const char *typname,
                                             void (TBufferJSON::*method)(const T *, Int_t, const char *));
 
    TString fOutBuffer;                 ///<!  main output buffer for json code

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -2635,7 +2635,7 @@ Int_t TBufferJSON::ReadArray(Double_t *&d)
 /// Read static array from JSON - not used
 
 template <typename T>
-R__ALWAYS_INLINE Int_t TBufferJSON::JsonReadArray(T *value)
+Int_t TBufferJSON::JsonReadArray(T *value)
 {
    Info("ReadArray", "Not implemented");
    return value ? 1 : 0;
@@ -2749,7 +2749,7 @@ Int_t TBufferJSON::ReadStaticArray(Double_t *d)
 /// Template method to read array from the JSON
 
 template <typename T>
-R__ALWAYS_INLINE void TBufferJSON::JsonReadFastArray(T *arr, Int_t arrsize, bool asstring)
+void TBufferJSON::JsonReadFastArray(T *arr, Int_t arrsize, bool asstring)
 {
    if (!arr || (arrsize <= 0))
       return;
@@ -3031,7 +3031,7 @@ void TBufferJSON::ReadFastArray(void **start, const TClass *cl, Int_t n, Bool_t 
 }
 
 template <typename T>
-R__ALWAYS_INLINE void TBufferJSON::JsonWriteArrayCompress(const T *vname, Int_t arrsize, const char *typname)
+void TBufferJSON::JsonWriteArrayCompress(const T *vname, Int_t arrsize, const char *typname)
 {
    bool is_base64 = Stack()->fBase64 || (fArrayCompact == kBase64);
 
@@ -3254,7 +3254,7 @@ void TBufferJSON::WriteArray(const Double_t *d, Int_t n)
 /// either JsonWriteArrayCompress<T>() or JsonWriteConstChar()
 
 template <typename T>
-R__ALWAYS_INLINE void TBufferJSON::JsonWriteFastArray(const T *arr, Int_t arrsize, const char *typname,
+void TBufferJSON::JsonWriteFastArray(const T *arr, Int_t arrsize, const char *typname,
                                                       void (TBufferJSON::*method)(const T *, Int_t, const char *))
 {
    JsonPushValue();
@@ -3545,7 +3545,7 @@ void TBufferJSON::StreamObject(void *obj, const TClass *cl, const TClass * /* on
 /// Template function to read basic value from JSON
 
 template <typename T>
-R__ALWAYS_INLINE void TBufferJSON::JsonReadBasic(T &value)
+void TBufferJSON::JsonReadBasic(T &value)
 {
    value = Stack()->GetStlNode()->get<T>();
 }


### PR DESCRIPTION
The `R__ALWAYS_INLINE` macro was introduced by commit b7c9be5 in TBufferJSON. However, it breaks the build with GCC and the `-Og` flag, for debug-compatible optimizations:

```txt
In member function ‘void TBufferJSON::JsonWriteFastArray(const T*, Int_t, const char*, void (TBufferJSON::*)(const T*, Int_t, const char*)) [with T = bool]’,
    inlined from ‘virtual void TBufferJSON::WriteFastArray(const Bool_t*, Int_t)’ at /home/rembserj/spaces/master-debug/root/src/root/io/io/src/TBufferJSON.cxx:3296:22:
/home/rembserj/spaces/master-debug/root/src/root/io/io/src/TBufferJSON.cxx:3034:23: error: inlining failed in call to ‘always_inline’ ‘void TBufferJSON::JsonWriteArrayCompress(const T*, Int_t, const char*) [with T = bool]’: function not considered for inlining
 3034 | R__ALWAYS_INLINE void TBufferJSON::JsonWriteArrayCompress(const T *vname, Int_t arrsize, const char *typname)
```

Libraries other than ROOT have also encountered similar problems: https://github.com/Cyan4973/xxHash/pull/804

The `R__ALWAYS_INLINE` macro is probably not necessary for these templated functions, because the compiler figures out itself whether it's worth to inline the templated functions or not.