### PR TITLE
[ntuple] add support for std::atomic<T>

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -751,6 +751,12 @@ This means that they have the same on-disk representation as `std::vector<T>`, u
   - Child field of type `T`, which must by a type with RNTuple I/O support.
     The name of the child field is `_0`.
 
+### std::atomic\<T\>
+
+Atomic types are stored as a leaf field with a single subfield named `_0`.
+The mother field has no attached columns.
+The subfield corresponds to the the inner type `T`.
+
 ### User-defined enums
 
 User-defined enums are stored as a leaf field with a single subfield named `_0`.

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -45,6 +45,7 @@ public:
    virtual void VisitField(const Detail::RFieldBase &field) = 0;
    virtual void VisitFieldZero(const RFieldZero &field) { VisitField(field); }
    virtual void VisitArrayField(const RArrayField &field) { VisitField(field); }
+   virtual void VisitAtomicField(const RAtomicField &field) { VisitField(field); }
    virtual void VisitBitsetField(const RBitsetField &field) { VisitField(field); }
    virtual void VisitBoolField(const RField<bool> &field) { VisitField(field); }
    virtual void VisitClassField(const RClassField &field) { VisitField(field); }
@@ -221,6 +222,7 @@ public:
    void VisitBitsetField(const RBitsetField &field) final;
    void VisitNullableField(const RNullableField &field) final;
    void VisitEnumField(const REnumField &field) final;
+   void VisitAtomicField(const RAtomicField &field) final;
 };
 
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -185,7 +185,7 @@ std::string GetNormalizedTypeName(const std::string &typeName)
       normalizedType = "std::" + normalizedType;
    if (normalizedType.substr(0, 4) == "set<")
       normalizedType = "std::" + normalizedType;
-   if (normalizedType.substr(0, 4) == "atomic<")
+   if (normalizedType.substr(0, 7) == "atomic<")
       normalizedType = "std::" + normalizedType;
 
    return normalizedType;

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -380,6 +380,18 @@ void ROOT::Experimental::RPrintValueVisitor::VisitEnumField(const REnumField &fi
    intValue.GetField()->AcceptVisitor(visitor);
 }
 
+void ROOT::Experimental::RPrintValueVisitor::VisitAtomicField(const RAtomicField &field)
+{
+   PrintIndent();
+   PrintName(field);
+   auto itemValue = field.SplitValue(fValue)[0].GetNonOwningCopy();
+   RPrintOptions options;
+   options.fPrintSingleLine = true;
+   options.fPrintName = false;
+   RPrintValueVisitor visitor(itemValue.GetNonOwningCopy(), fOutput, fLevel, options);
+   itemValue.GetField()->AcceptVisitor(visitor);
+}
+
 void ROOT::Experimental::RPrintValueVisitor::VisitProxiedCollectionField(const RProxiedCollectionField &field)
 {
    PrintCollection(field);

--- a/tree/ntuple/v7/test/ntuple_show.cxx
+++ b/tree/ntuple/v7/test/ntuple_show.cxx
@@ -43,6 +43,7 @@ TEST(RNTupleShow, BasicTypes)
       auto fieldchar = model->MakeField<uint8_t>("uint8");
       auto fieldbitset = model->MakeField<std::bitset<65>>("bitset");
       auto fielduniqueptr = model->MakeField<std::unique_ptr<std::string>>("pstring");
+      auto fieldatomic = model->MakeField<std::atomic<bool>>("atomic");
       auto ntuple = RNTupleWriter::Recreate(std::move(model), ntupleName, rootFileName);
 
       *fieldPt = 5.0f;
@@ -55,6 +56,7 @@ TEST(RNTupleShow, BasicTypes)
       *fieldchar = 97;
       *fieldbitset = std::bitset<65>("10000000000000000000000000000010000000000000000000000000000010010");
       *fielduniqueptr = std::make_unique<std::string>("abc");
+      *fieldatomic = false;
       ntuple->Fill();
 
       *fieldPt = 8.5f;
@@ -67,6 +69,7 @@ TEST(RNTupleShow, BasicTypes)
       *fieldchar = 98;
       fieldbitset->flip();
       fielduniqueptr->reset();
+      *fieldatomic = true;
       ntuple->Fill();
    }
 
@@ -86,7 +89,8 @@ TEST(RNTupleShow, BasicTypes)
       + "  \"boolean\": true,\n"
       + "  \"uint8\": 97,\n"
       + "  \"bitset\": \"10000000000000000000000000000010000000000000000000000000000010010\",\n"
-      + "  \"pstring\": \"abc\"\n"
+      + "  \"pstring\": \"abc\",\n"
+      + "  \"atomic\": false\n"
       + "}\n" };
    // clang-format on
    EXPECT_EQ(fString, os.str());
@@ -105,7 +109,8 @@ TEST(RNTupleShow, BasicTypes)
       + "  \"boolean\": false,\n"
       + "  \"uint8\": 98,\n"
       + "  \"bitset\": \"01111111111111111111111111111101111111111111111111111111111101101\",\n"
-      + "  \"pstring\": null\n"
+      + "  \"pstring\": null,\n"
+      + "  \"atomic\": true\n"
       + "}\n" };
    // clang-format on
    EXPECT_EQ(fString1, os1.str());


### PR DESCRIPTION
# This Pull request:

Adds RNTuple support for `std::atomic<T>`. The inner type `T` has to be an I/O supported type. On-disk representation is identical between atomic `T` and plain `T` except for an extra marker field for the atomic wrapper. CMS MiniAOD use atomic types.

## Checklist:

- [X] tested changes locally
- [X] updated the docs (if necessary)

