### PR TITLE
[Backport] [PyROOT] Speedup inclusion of ROOT module

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_facade.py
@@ -364,7 +364,7 @@ class ROOTFacade(types.ModuleType):
         #this line is needed to import the pythonizations in _tmva directory
         from ._pythonization import _tmva
         ns = self._fallback_getattr('TMVA')
-        hasRDF = gSystem.GetFromPipe("root-config --has-dataframe") == "yes"
+        hasRDF = "dataframe" in gROOT.GetConfigFeatures()
         if hasRDF:
             try:
                 from libROOTPythonizations import AsRTensor

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tmva/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tmva/__init__.py
@@ -12,7 +12,7 @@
 
 import sys
 import cppyy
-from cppyy.gbl import gSystem
+from cppyy.gbl import gSystem, gROOT
 
 from .. import pythonization
 
@@ -22,7 +22,7 @@ from ._crossvalidation import CrossValidation
 
 from ._rbdt import Compute, pythonize_rbdt
 
-hasRDF = gSystem.GetFromPipe("root-config --has-dataframe") == "yes"
+hasRDF = "dataframe" in gROOT.GetConfigFeatures()
 if hasRDF:
     from ._rtensor import get_array_interface, add_array_interface_property, RTensorGetitem, pythonize_rtensor
 


### PR DESCRIPTION
by removing invocations to the root-config executable. This executable was invoked twice to check if RDataFrame was available. Such a behaviour causes a severe slowdown, especially on cvmfs. This has been replaced by a simple string comparison.

Backport of 4c863d

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

