### PR TITLE
Do not complain about the internal of unique_ptr.  Do not complain about transient std::tuple.

### DIFF
--- a/core/base/src/TMemberInspector.cxx
+++ b/core/base/src/TMemberInspector.cxx
@@ -121,7 +121,7 @@ void TMemberInspector::GenericShowMembers(const char *topClassName, const void *
       }
    }
 
-   TClass *top = TClass::GetClass(topClassName);
+   TClass *top = TClass::GetClass(topClassName, true, isTransient);
    if (top) {
       top->CallShowMembers(obj, *this, isTransient);
    } else {

--- a/core/clingutils/res/TClingUtils.h
+++ b/core/clingutils/res/TClingUtils.h
@@ -677,6 +677,16 @@ const clang::TypedefNameDecl* GetAnnotatedRedeclarable(const clang::TypedefNameD
 const clang::TagDecl* GetAnnotatedRedeclarable(const clang::TagDecl* TND);
 
 //______________________________________________________________________________
+// Return true if the DeclContext is representing an entity reacheable from the
+// global namespace
+bool IsCtxtReacheable(const clang::DeclContext &ctxt);
+
+//______________________________________________________________________________
+// Return true if the decl is representing an entity reacheable from the
+// global namespace
+bool IsDeclReacheable(const clang::Decl &decl);
+
+//______________________________________________________________________________
 // Return true if the decl is part of the std namespace.
 bool IsStdClass(const clang::RecordDecl &cl);
 

--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -4396,6 +4396,7 @@ bool ROOT::TMetaUtils::IsDeclReacheable(const clang::Decl &decl)
          return !ctxt || IsCtxtReacheable(*ctxt);
       default:
          // IMPOSSIBLE
+         assert(false && "Unexpected value for the access property value in Clang");
          return false;
    }
 }

--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -4364,6 +4364,43 @@ const clang::Type *ROOT::TMetaUtils::GetUnderlyingType(clang::QualType type)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Return true if the DeclContext is representing an entity reacheable from the
+/// global namespace
+
+bool ROOT::TMetaUtils::IsCtxtReacheable(const clang::DeclContext &ctxt)
+{
+   if (ctxt.isNamespace() || ctxt.isTranslationUnit())
+      return true;
+   else if(const auto parentdecl = llvm::dyn_cast<clang::CXXRecordDecl>(&ctxt))
+      return ROOT::TMetaUtils::IsDeclReacheable(*parentdecl);
+   else
+      // For example "extern C" context.
+      return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Return true if the decl is representing an entity reacheable from the
+/// global namespace
+
+bool ROOT::TMetaUtils::IsDeclReacheable(const clang::Decl &decl)
+{
+   const clang::DeclContext *ctxt = decl.getDeclContext();
+   switch (decl.getAccess()) {
+      case clang::AS_public:
+         return !ctxt || IsCtxtReacheable(*ctxt);
+      case clang::AS_protected:
+         return false;
+      case clang::AS_private:
+         return false;
+      case clang::AS_none:
+         return !ctxt || IsCtxtReacheable(*ctxt);
+      default:
+         // IMPOSSIBLE
+         return false;
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Return true, if the decl is part of the std namespace.
 
 bool ROOT::TMetaUtils::IsStdClass(const clang::RecordDecl &cl)

--- a/core/meta/inc/TDictionary.h
+++ b/core/meta/inc/TDictionary.h
@@ -84,7 +84,7 @@ enum EProperty {
    kIsCCompiled     = 0x00040000,
    kIsCPPCompiled   = kIsCCompiled,
    kIsCompiled      = kIsCCompiled,
-   // 0x00080000 is available
+   kIsNotReacheable = 0x00080000,   // Indicate that the entity can not be used from the Global Namespace
    kIsConstant      = 0x00100000,
    kIsVirtualBase   = 0x00200000,
    kIsConstPointer  = 0x00400000,

--- a/core/meta/inc/TInterpreter.h
+++ b/core/meta/inc/TInterpreter.h
@@ -208,7 +208,7 @@ public:
    virtual void     UpdateListOfGlobals() = 0;
    virtual void     UpdateListOfGlobalFunctions() = 0;
    virtual void     UpdateListOfTypes() = 0;
-   virtual void     SetClassInfo(TClass *cl, Bool_t reload = kFALSE) = 0;
+   virtual void     SetClassInfo(TClass *cl, Bool_t reload = kFALSE, Bool_t silent = kFALSE) = 0;
 
    enum ECheckClassInfo {
       kUnknown = 0, // backward compatible with false

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -1514,7 +1514,7 @@ void TClass::Init(const char *name, Version_t cversion,
             proto->FillTClass(this);
       }
       if (!fHasRootPcmInfo && gInterpreter->CheckClassInfo(fName, /* autoload = */ kTRUE)) {
-         gInterpreter->SetClassInfo(this);   // sets fClassInfo pointer
+         gInterpreter->SetClassInfo(this, kFALSE, silent);   // sets fClassInfo pointer
          if (fClassInfo) {
             // This should be moved out of GetCheckSum itself however the last time
             // we tried this cause problem, in particular in the end-of-process operation.

--- a/core/meta/src/TDataMember.cxx
+++ b/core/meta/src/TDataMember.cxx
@@ -595,7 +595,14 @@ Long_t TDataMember::Property() const
    if (!fInfo || !gCling->DataMemberInfo_IsValid(fInfo)) return 0;
    int prop  = gCling->DataMemberInfo_Property(fInfo);
    int propt = gCling->DataMemberInfo_TypeProperty(fInfo);
-   t->fProperty = prop|propt;
+   t->fProperty = (prop | propt) & ~(kIsPublic | kIsProtected | kIsPrivate);
+   // Set to the strictest access of the member and the type
+   if ((prop | propt) & kIsPrivate)
+      t->fProperty |= kIsPrivate;
+   else if ((prop | propt) & kIsProtected)
+      t->fProperty |= kIsProtected;
+   else
+      t->fProperty |= kIsPublic;
 
    t->fFullTypeName = TClassEdit::GetLong64_Name(gCling->DataMemberInfo_TypeName(fInfo));
    t->fTrueTypeName = TClassEdit::GetLong64_Name(gCling->DataMemberInfo_TypeTrueName(fInfo));

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -3972,7 +3972,7 @@ static std::string AlternateTuple(const char *classname, const cling::LookupHelp
    switch(IsTupleAscending()) {
       case ETupleOrdering::kAscending: {
          unsigned int nMember = 0;
-         auto iter = tupleContent.fElements.begin() + 1; // Skip the template name (tuple)
+         auto iter = tupleContent.fElements.begin() + 1; // Skip the template name (tuple).
          auto theEnd = tupleContent.fElements.end() - 1; // skip the 'stars'.
          while (iter != theEnd) {
             alternateTuple << "   " << *iter << " _" << nMember << ";\n";
@@ -3983,8 +3983,8 @@ static std::string AlternateTuple(const char *classname, const cling::LookupHelp
       }
       case ETupleOrdering::kDescending: {
          unsigned int nMember = tupleContent.fElements.size() - 3;
-         auto iter = tupleContent.fElements.rbegin() + 1; // Skip the template name (tuple)
-         auto theEnd = tupleContent.fElements.rend() - 1; // skip the 'stars'.
+         auto iter = tupleContent.fElements.rbegin() + 1; // skip the 'stars'.
+         auto theEnd = tupleContent.fElements.rend() - 1; // Skip the template name (tuple).
          while (iter != theEnd) {
             alternateTuple << "   " << *iter << " _" << nMember << ";\n";
             ++iter;

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -2716,6 +2716,14 @@ void TCling::InspectMembers(TMemberInspector& insp, const void* obj,
       return;
    }
 
+   if (TClassEdit::IsUniquePtr(cl->GetName())) {
+      // Ignore error caused by the inside of std::unique_ptr
+      // This is needed solely because of rootclingIO's IsUnsupportedUniquePointer
+      // which check the numbers of data members.
+      // If this usage is remove, this can be replace with a return statement.
+      isTransient = true;
+   }
+
    const char* cobj = (const char*) obj; // for ptr arithmetics
 
    // Treat the case of std::complex in a special manner. We want to enforce

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -3965,9 +3965,9 @@ static std::string AlternateTuple(const char *classname, const cling::LookupHelp
       std::unique_ptr<TypeInfo_t, decltype(deleter)> type{ gInterpreter->TypeInfo_Factory(), deleter };
       while (iter != theEnd) {
          gInterpreter->TypeInfo_Init(type.get(), iter->c_str());
-         if (gInterpreter->TypeInfo_Property(type.get()) & (kIsProtected | kIsPrivate)) {
+         if (gInterpreter->TypeInfo_Property(type.get()) & kIsNotReacheable) {
             if (!silent)
-               Error("Load","Could not declare alternate type for %s since %s is private or protected",
+               Error("Load","Could not declare alternate type for %s since %s (or one of its context) is private or protected",
                      classname, iter->c_str());
             return "";
          }

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -4034,7 +4034,7 @@ static std::string AlternateTuple(const char *classname, const cling::LookupHelp
 /// If 'reload' is true, (attempt to) generate a new ClassInfo even if we
 /// already have one.
 
-void TCling::SetClassInfo(TClass* cl, Bool_t reload)
+void TCling::SetClassInfo(TClass* cl, Bool_t reload, Bool_t silent)
 {
    // We are shutting down, there is no point in reloading, it only triggers
    // redundant deserializations.

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -2719,8 +2719,9 @@ void TCling::InspectMembers(TMemberInspector& insp, const void* obj,
    if (TClassEdit::IsUniquePtr(cl->GetName())) {
       // Ignore error caused by the inside of std::unique_ptr
       // This is needed solely because of rootclingIO's IsUnsupportedUniquePointer
-      // which check the numbers of data members.
-      // If this usage is remove, this can be replace with a return statement.
+      // which checks the number of elements in the GetListOfRealData.
+      // If this usage is removed, this can be replaced with a return statement.
+      // See https://github.com/root-project/root/issues/13574
       isTransient = true;
    }
 

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -8899,6 +8899,7 @@ Long_t TCling::FuncTempInfo_Property(FuncTempInfo_t *ft_info) const
          break;
       default:
          // IMPOSSIBLE
+         assert(false && "Unexpected value for the access property value in Clang");
          break;
    }
 

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -270,7 +270,7 @@ public: // Public Interface
    void    UpdateListOfGlobals() final;
    void    UpdateListOfGlobalFunctions() final;
    void    UpdateListOfTypes() final;
-   void    SetClassInfo(TClass* cl, Bool_t reload = kFALSE) final;
+   void    SetClassInfo(TClass* cl, Bool_t reload = kFALSE, Bool_t silent = kFALSE) final;
 
    ECheckClassInfo CheckClassInfo(const char *name, Bool_t autoload, Bool_t isClassOrNamespaceOnly = kFALSE) final;
 

--- a/core/metacling/src/TClingBaseClassInfo.cxx
+++ b/core/metacling/src/TClingBaseClassInfo.cxx
@@ -541,6 +541,10 @@ long TClingBaseClassInfo::Property() const
          break;
       case clang::AS_none:
          // IMPOSSIBLE
+         assert(false && "Unexpected value for the access property value in Clang");
+         break;
+      default:
+         assert(false && "Unexpected value for the access property value in Clang");
          break;
    }
    return property;

--- a/core/metacling/src/TClingDataMemberInfo.cxx
+++ b/core/metacling/src/TClingDataMemberInfo.cxx
@@ -471,6 +471,7 @@ long TClingDataMemberInfo::Property() const
          break;
       default:
          // IMPOSSIBLE
+         assert(false && "Unexpected value for the access property value in Clang");
          break;
    }
    if (llvm::isa<clang::UsingShadowDecl>(thisDecl))

--- a/core/metacling/src/TClingDataMemberInfo.cxx
+++ b/core/metacling/src/TClingDataMemberInfo.cxx
@@ -453,16 +453,18 @@ long TClingDataMemberInfo::Property() const
    };
 
    getParentAccessAndNonTransparentDC();
-
+   // TODO: Now that we have the kIsNotReacheable we could return the property
+   // to be reflecting the local information.  However it is unclear if the
+   // information is used as-is (it appears to not be used in ROOT proper)
    switch (strictestAccess) {
       case clang::AS_public:
          property |= kIsPublic;
          break;
       case clang::AS_protected:
-         property |= kIsProtected;
+         property |= kIsProtected | kIsNotReacheable;
          break;
       case clang::AS_private:
-         property |= kIsPrivate;
+         property |= kIsPrivate | kIsNotReacheable;
          break;
       case clang::AS_none: //?
          property |= kIsPublic;

--- a/core/metacling/src/TClingMethodInfo.cxx
+++ b/core/metacling/src/TClingMethodInfo.cxx
@@ -493,6 +493,7 @@ long TClingMethodInfo::Property() const
          break;
       default:
          // IMPOSSIBLE
+         assert(false && "Unexpected value for the access property value in Clang");
          break;
    }
 

--- a/core/metacling/src/TClingMethodInfo.cxx
+++ b/core/metacling/src/TClingMethodInfo.cxx
@@ -482,10 +482,10 @@ long TClingMethodInfo::Property() const
          property |= kIsPublic;
          break;
       case clang::AS_protected:
-         property |= kIsProtected;
+         property |= kIsProtected | kIsNotReacheable;
          break;
       case clang::AS_private:
-         property |= kIsPrivate;
+         property |= kIsPrivate | kIsNotReacheable;
          break;
       case clang::AS_none:
          if (declAccess->getDeclContext()->isNamespace())
@@ -494,6 +494,11 @@ long TClingMethodInfo::Property() const
       default:
          // IMPOSSIBLE
          break;
+   }
+
+   if (!(property & kIsNotReacheable)) {
+      if (! ROOT::TMetaUtils::IsDeclReacheable(*fd))
+         property |= kIsNotReacheable;
    }
 
    if (fd->isConstexpr())

--- a/core/metacling/src/TClingTypeInfo.cxx
+++ b/core/metacling/src/TClingTypeInfo.cxx
@@ -148,6 +148,7 @@ long TClingTypeInfo::Property() const
             break;
          default:
             // IMPOSSIBLE
+            assert(false && "Unexpected value for the access property value in Clang");
             break;
       }
       if (!(property & kIsNotReacheable)) {

--- a/core/metacling/src/TClingTypeInfo.cxx
+++ b/core/metacling/src/TClingTypeInfo.cxx
@@ -132,6 +132,24 @@ long TClingTypeInfo::Property() const
       const clang::TagDecl *TD = llvm::dyn_cast<clang::TagDecl>(tagQT->getDecl());
       if (!TD)
          return property;
+      switch (TD->getAccess()) {
+         case clang::AS_public:
+            property |= kIsPublic;
+            break;
+         case clang::AS_protected:
+            property |= kIsProtected;
+            break;
+         case clang::AS_private:
+            property |= kIsPrivate;
+            break;
+         case clang::AS_none:
+            if (TD->getDeclContext()->isNamespace())
+               property |= kIsPublic;
+            break;
+         default:
+            // IMPOSSIBLE
+            break;
+      }
       if (TD->isEnum()) {
          property |= kIsEnum;
       } else {

--- a/core/metacling/src/TClingTypeInfo.cxx
+++ b/core/metacling/src/TClingTypeInfo.cxx
@@ -137,10 +137,10 @@ long TClingTypeInfo::Property() const
             property |= kIsPublic;
             break;
          case clang::AS_protected:
-            property |= kIsProtected;
+            property |= kIsProtected | kIsNotReacheable;
             break;
          case clang::AS_private:
-            property |= kIsPrivate;
+            property |= kIsPrivate | kIsNotReacheable;
             break;
          case clang::AS_none:
             if (TD->getDeclContext()->isNamespace())
@@ -149,6 +149,10 @@ long TClingTypeInfo::Property() const
          default:
             // IMPOSSIBLE
             break;
+      }
+      if (!(property & kIsNotReacheable)) {
+         if (! ROOT::TMetaUtils::IsDeclReacheable(*TD))
+            property |= kIsNotReacheable;
       }
       if (TD->isEnum()) {
          property |= kIsEnum;

--- a/core/metacling/test/TClingDataMemberInfoTests.cxx
+++ b/core/metacling/test/TClingDataMemberInfoTests.cxx
@@ -214,11 +214,11 @@ protected:
 
    ASSERT_TRUE(TClass::GetClass("DMLookup::Outer")->GetListOfDataMembers()->FindObject("InnerPrivate"));
    auto *dmInnerPrivate = (TDataMember*)TClass::GetClass("DMLookup::Outer")->GetListOfDataMembers()->FindObject("InnerPrivate");
-   EXPECT_EQ(dmInnerPrivate->Property(), kIsPrivate | kIsClass);
+   EXPECT_EQ(dmInnerPrivate->Property(), kIsPrivate | kIsClass | kIsNotReacheable);
 
    ASSERT_TRUE(TClass::GetClass("DMLookup::Outer")->GetListOfDataMembers()->FindObject("InnerProtected"));
    auto *dmInnerProtected = (TDataMember*)TClass::GetClass("DMLookup::Outer")->GetListOfDataMembers()->FindObject("InnerProtected");
-   EXPECT_EQ(dmInnerProtected->Property(), kIsProtected | kIsClass);
+   EXPECT_EQ(dmInnerProtected->Property(), kIsProtected | kIsClass | kIsNotReacheable);
 }
 
 TEST(TClingDataMemberInfo, Offset)

--- a/io/rootpcm/src/rootclingIO.cxx
+++ b/io/rootpcm/src/rootclingIO.cxx
@@ -82,7 +82,9 @@ static bool IsUnsupportedUniquePointer(const char *normName, TDataMember *dm)
          return true;
       }
 
-      clm->BuildRealData();
+      // TODO: Is it not clear what situation we are checking for by checking if
+      // the unique_ptr class has any data members.
+      clm->BuildRealData(nullptr, /* istransient = */ true);
       auto upDms = clm->GetListOfRealData();
       if (!upDms) {
          Error("CloseStreamerInfoROOTFile", "Cannot determine unique pointer %s data members.", dmTypeName);


### PR DESCRIPTION
This fixes #13574

This prevents complains about the internals of `unique_ptr` when we are just investigating its suitability for streaming.  

Also do not complains about a transient `std::tuple` even if we can not stream it (for example if one of component is a private entity).

Test at https://github.com/root-project/roottest/pull/1030