### PR TITLE
[ntuple] Add support for `std::map` fields

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -751,6 +751,10 @@ This means that they have the same on-disk representation as `std::vector<T>`, u
   - Child field of type `T`, which must by a type with RNTuple I/O support.
     The name of the child field is `_0`.
 
+#### std::map\<K, V\>
+
+A map is stored using a collection mother field, whose principal column is of type `(Split)Index[64|32]` and a child field of type `std::pair<K, V>` named `_0`.
+
 ### std::atomic\<T\>
 
 Atomic types are stored as a leaf field with a single subfield named `_0`.

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -2491,6 +2491,14 @@ private:
       return {std::make_unique<RField<Ty1>>("_0"), std::make_unique<RField<Ty2>>("_1")};
    }
 
+   static std::array<std::size_t, 2> BuildItemOffsets()
+   {
+      auto pair = ContainerT();
+      auto offsetFirst = reinterpret_cast<std::uintptr_t>(&(pair.first)) - reinterpret_cast<std::uintptr_t>(&pair);
+      auto offsetSecond = reinterpret_cast<std::uintptr_t>(&(pair.second)) - reinterpret_cast<std::uintptr_t>(&pair);
+      return {offsetFirst, offsetSecond};
+   }
+
 protected:
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final
    {
@@ -2511,7 +2519,7 @@ public:
       return "std::pair<" + RField<T1>::TypeName() + "," + RField<T2>::TypeName() + ">";
    }
    explicit RField(std::string_view name, std::array<std::unique_ptr<Detail::RFieldBase>, 2> &&itemFields)
-      : RPairField(name, std::move(itemFields), {offsetof(ContainerT, first), offsetof(ContainerT, second)})
+      : RPairField(name, std::move(itemFields), BuildItemOffsets())
    {
       fMaxAlignment = std::max(alignof(T1), alignof(T2));
       fSize = sizeof(ContainerT);

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -2682,6 +2682,9 @@ ROOT::Experimental::RMapField::RMapField(std::string_view fieldName, std::string
                                          std::unique_ptr<Detail::RFieldBase> itemField)
    : RProxiedCollectionField(fieldName, typeName, TClass::GetClass(std::string(typeName).c_str()))
 {
+   if (!dynamic_cast<RPairField *>(itemField.get()))
+      throw RException(R__FAIL("RMapField inner field type must be of RPairField"));
+
    fItemClass = fProxy->GetValueClass();
    fItemSize = fItemClass->GetClassSize();
 

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <map>
 #include <set>
 #include <string>
 #include <unordered_set>

--- a/tree/ntuple/v7/test/ProxiedSTLContainerLinkDef.h
+++ b/tree/ntuple/v7/test/ProxiedSTLContainerLinkDef.h
@@ -17,4 +17,12 @@
 #pragma link C++ class std::unordered_set<CustomStruct>+;
 #pragma link C++ class std::unordered_set<std::vector<bool>>+;
 
+#pragma link C++ class std::map<char, long>+;
+#pragma link C++ class std::map<char, std::int64_t>+;
+#pragma link C++ class std::map<char, std::string>+;
+#pragma link C++ class std::map<int, std::vector<CustomStruct>>+;
+#pragma link C++ class std::map<std::string, float>+;
+#pragma link C++ class std::map<char, std::map<int, CustomStruct>>+;
+#pragma link C++ class std::map<float, std::map<char, std::int32_t>>+;
+
 #endif

--- a/tree/ntuple/v7/test/ProxiedSTLContainerLinkDef.h
+++ b/tree/ntuple/v7/test/ProxiedSTLContainerLinkDef.h
@@ -25,4 +25,12 @@
 #pragma link C++ class std::map<char, std::map<int, CustomStruct>>+;
 #pragma link C++ class std::map<float, std::map<char, std::int32_t>>+;
 
+#pragma link C++ class std::pair<char, long>+;
+#pragma link C++ class std::pair<char, std::int64_t>+;
+#pragma link C++ class std::pair<char, std::string>+;
+#pragma link C++ class std::pair<int, CustomStruct>+;
+#pragma link C++ class std::pair<int, std::vector<CustomStruct>>+;
+#pragma link C++ class std::pair<float, std::map<char, std::int32_t>>+;
+#pragma link C++ class std::pair<char, std::int32_t>+;
+
 #endif

--- a/tree/ntuple/v7/test/ntuple_show.cxx
+++ b/tree/ntuple/v7/test/ntuple_show.cxx
@@ -538,6 +538,32 @@ TEST(RNTupleShow, CollectionProxy)
    }
 }
 
+TEST(RNTupleShow, Map)
+{
+   FileRaii fileGuard("test_ntuple_show_map.ntuple");
+   {
+      auto model = RNTupleModel::Create();
+      auto mapF = model->MakeField<std::map<std::string, float>>("mapF");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "f", fileGuard.GetPath());
+
+      *mapF = {{"foo", 3.14}, {"bar", 2.72}};
+      ntuple->Fill();
+   }
+
+   auto ntuple = RNTupleReader::Open("f", fileGuard.GetPath());
+   EXPECT_EQ(1U, ntuple->GetNEntries());
+
+   std::ostringstream os;
+   ntuple->Show(0, os);
+   // clang-format off
+   std::string expected{std::string("")
+      + "{\n"
+      + "  \"mapF\": [{\"_0\": \"bar\", \"_1\": 2.72}, {\"_0\": \"foo\", \"_1\": 3.14}]\n"
+      + "}\n"};
+   // clang-format on
+   EXPECT_EQ(os.str(), expected);
+}
+
 TEST(RNTupleShow, Enum)
 {
 

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -455,6 +455,11 @@ TEST(RNTuple, StdMap)
    EXPECT_THROW(RFieldBase::Create("myInvalidMap", "std::map<char>").Unwrap(), RException);
    EXPECT_THROW(RFieldBase::Create("myInvalidMap", "std::map<char, std::string, int>").Unwrap(), RException);
 
+   auto invalidInnerField = RFieldBase::Create("someIntField", "int").Unwrap();
+   EXPECT_THROW(std::make_unique<ROOT::Experimental::RMapField>("myInvalidMap", "std::map<char, int>",
+                                                                std::move(invalidInnerField)),
+                RException);
+
    FileRaii fileGuard("test_ntuple_rfield_stdmap.root");
    {
       auto model = RNTupleModel::Create();


### PR DESCRIPTION
This PR adds support for `std::map` fields through collection proxies (similar to `std::set`).

In theory, other (custom) associative collections (provided they implement a collection proxy) should now also be able to be added as fields. Because the use case for this is not yet obvious, this is still disabled.
