### PR TITLE
[PyROOT] Avoid SyntaxWarning about invalid escape sequence

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_numbadeclare.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_numbadeclare.py
@@ -295,7 +295,7 @@ def pywrapper({SIGNATURE}):
         input_types_ref = []
         func_ptr_input_types = []
         for t in input_types:
-            m = re.match('\s*(const\s+)?(RVec\w+|RVec<[\w\s]+>)', t)
+            m = re.match(r'\s*(const\s+)?(RVec\w+|RVec<[\w\s]+>)', t)
             if m:
                 const_mod = '' if m.group(1) is None else 'const '
                 rvect = m.group(2)


### PR DESCRIPTION
As suggested by https://docs.python.org/3/whatsnew/3.12.html#other-language-changes
