### PR TITLE
[DF] Fix AddProgressbar to AddProgressBar and related typos

### DIFF
--- a/tree/dataframe/inc/ROOT/RDFHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDFHelpers.hxx
@@ -269,8 +269,8 @@ RResultMap<T> VariationsFor(RResultPtr<T> resPtr)
 using SnapshotPtr_t = ROOT::RDF::RResultPtr<ROOT::RDF::RInterface<ROOT::Detail::RDF::RLoopManager, void>>;
 SnapshotPtr_t VariationsFor(SnapshotPtr_t resPtr);
 
-void AddProgressbar(ROOT::RDF::RNode df);
-void AddProgressbar(ROOT::RDataFrame df);
+void AddProgressBar(ROOT::RDF::RNode df);
+void AddProgressBar(ROOT::RDataFrame df);
 
 class ProgressBarAction;
 
@@ -283,15 +283,15 @@ class ProgressBarAction;
 /// ProgressBar should be added after creating the dataframe object (df):
 /// ~~~{.cpp}
 /// ROOT::RDataFrame df("tree", "file.root");
-/// ROOT::RDF::Experimental::AddProgressbar(df);
+/// ROOT::RDF::Experimental::AddProgressBar(df);
 /// ~~~
 /// alternatively RDataFrame can be cast to an RNode first giving it more flexibility.
 /// For example, it can be called at any computational node, such as Filter or Define, not only the head node,
-/// with no change to the Progressbar function itself:
+/// with no change to the ProgressBar function itself:
 /// ~~~{.cpp}
 /// ROOT::RDataFrame df("tree", "file.root");
 /// auto df_1 = ROOT::RDF::RNode(df.Filter("x>1"));
-/// ROOT::RDF::Experimental::AddProgressbar(df_1);
+/// ROOT::RDF::Experimental::AddProgressBar(df_1);
 /// ~~~
 class ProgressHelper {
 private:
@@ -299,7 +299,7 @@ private:
    std::pair<std::size_t, std::chrono::seconds> RecordEvtCountAndTime();
    void PrintStats(std::ostream &stream, std::size_t currentEventCount, std::chrono::seconds totalElapsedSeconds) const;
    void PrintStatsFinal(std::ostream &stream, std::chrono::seconds totalElapsedSeconds) const;
-   void PrintProgressbar(std::ostream &stream, std::size_t currentEventCount) const;
+   void PrintProgressBar(std::ostream &stream, std::size_t currentEventCount) const;
 
    std::chrono::time_point<std::chrono::system_clock> fBeginTime = std::chrono::system_clock::now();
    std::chrono::time_point<std::chrono::system_clock> fLastPrintTime = fBeginTime;
@@ -398,7 +398,7 @@ public:
       if (fIsTTY)
          std::cout << "\r";
 
-      PrintProgressbar(std::cout, eventCount);
+      PrintProgressBar(std::cout, eventCount);
       PrintStats(std::cout, eventCount, elapsedSeconds);
 
       if (fIsTTY)

--- a/tree/dataframe/src/RDFHelpers.cxx
+++ b/tree/dataframe/src/RDFHelpers.cxx
@@ -294,7 +294,7 @@ void ProgressHelper::PrintStatsFinal(std::ostream &stream, std::chrono::seconds 
 }
 
 /// Print a progress bar of width `ProgressHelper::fBarWidth` if `fGetNEventsOfCurrentFile` is known.
-void ProgressHelper::PrintProgressbar(std::ostream &stream, std::size_t currentEventCount) const
+void ProgressHelper::PrintProgressBar(std::ostream &stream, std::size_t currentEventCount) const
 {
    auto GetNEventsOfCurrentFile = ComputeNEventsSoFar();
    if (GetNEventsOfCurrentFile == 0)
@@ -364,7 +364,7 @@ public:
    }
 };
 
-void AddProgressbar(ROOT::RDF::RNode node)
+void AddProgressBar(ROOT::RDF::RNode node)
 {
    auto total_files = node.GetNFiles();
    auto progress = std::make_shared<ProgressHelper>(1000, total_files);
@@ -373,10 +373,10 @@ void AddProgressbar(ROOT::RDF::RNode node)
    r.OnPartialResultSlot(1000, [progress](unsigned int slot, auto &&arg) { (*progress)(slot, arg); });
 }
 
-void AddProgressbar(ROOT::RDataFrame dataframe)
+void AddProgressBar(ROOT::RDataFrame dataframe)
 {
    auto node = ROOT::RDF::AsRNode(dataframe);
-   ROOT::RDF::Experimental::AddProgressbar(node);
+   ROOT::RDF::Experimental::AddProgressBar(node);
 }
 } // namespace Experimental
 } // namespace RDF

--- a/tree/dataframe/src/RDataFrame.cxx
+++ b/tree/dataframe/src/RDataFrame.cxx
@@ -1504,16 +1504,16 @@ n seconds (by default m = 1000 and n = 1). The ProgressBar can be also added whe
 ProgressBar is added after creating the dataframe object (df):
 ~~~{.cpp}
 ROOT::RDataFrame df("tree", "file.root");
-ROOT::RDF::Experimental::AddProgressbar(df);
+ROOT::RDF::Experimental::AddProgressBar(df);
 ~~~
 
 Alternatively, RDataFrame can be cast to an RNode first, giving the user more flexibility 
 For example, it can be called at any computational node, such as Filter or Define, not only the head node,
-with no change to the Progressbar function itself: 
+with no change to the ProgressBar function itself: 
 ~~~{.cpp}
 ROOT::RDataFrame df("tree", "file.root");
 auto df_1 = ROOT::RDF::RNode(df.Filter("x>1"));
-ROOT::RDF::Experimental::AddProgressbar(df_1);
+ROOT::RDF::Experimental::AddProgressBar(df_1);
 ~~~
 Examples of implemented progress bars can be seen by running [Higgs to Four Lepton tutorial](https://root.cern/doc/master/df106__HiggsToFourLeptons_8py_source.html) and [Dimuon tutorial](https://root.cern/doc/master/df102__NanoAODDimuonAnalysis_8C.html). 
 

--- a/tree/dataframe/test/dataframe_helpers.cxx
+++ b/tree/dataframe/test/dataframe_helpers.cxx
@@ -701,7 +701,7 @@ TEST(RDFHelpers, ProgressHelper_Existence_ST)
    auto d_write_1 = ROOT::RDataFrame(10000).Define("x", ret42).Snapshot<int>("tree", "fh1.root", {"x"});
    auto d_write_2 = ROOT::RDataFrame(10000).Define("y", ret1).Snapshot<int>("tree", "fh2.root", {"y"});
    ROOT::RDF::RNode d = ROOT::RDataFrame("tree", {"fh1.root", "fh2.root"});
-   ROOT::RDF::Experimental::AddProgressbar(d);
+   ROOT::RDF::Experimental::AddProgressBar(d);
    d.Count().GetValue();
    // Restore old cout.
    std::cout.rdbuf(oldCoutStreamBuf);
@@ -767,7 +767,7 @@ TEST(RDFHelpers, ProgressHelper_Existence_MT)
    auto d_write_1 = ROOT::RDataFrame(10000).Define("x", ret42).Snapshot<int>("tree", "fh1.root", {"x"});
    auto d_write_2 = ROOT::RDataFrame(10000).Define("y", ret1).Snapshot<int>("tree", "fh2.root", {"y"});
    ROOT::RDF::RNode d = ROOT::RDataFrame("tree", {"fh1.root", "fh2.root"});
-   ROOT::RDF::Experimental::AddProgressbar(d);
+   ROOT::RDF::Experimental::AddProgressBar(d);
    d.Count().GetValue();
    // Restore old cout.
    std::cout.rdbuf(oldCoutStreamBuf);
@@ -784,7 +784,7 @@ TEST(RDFHelpers, ProgressHelper_existence_singleTTreeInput)
    std::cout.rdbuf(strCout.rdbuf());
    auto d_write_1 = ROOT::RDataFrame(10000).Define("x", ret42).Snapshot<int>("tree", "fh1.root", {"x"});
    ROOT::RDF::RNode d = ROOT::RDataFrame("tree", {"fh1.root"});
-   ROOT::RDF::Experimental::AddProgressbar(d);
+   ROOT::RDF::Experimental::AddProgressBar(d);
    d.Count().GetValue();
    // Restore old cout.
    std::cout.rdbuf(oldCoutStreamBuf);

--- a/tutorials/dataframe/df102_NanoAODDimuonAnalysis.C
+++ b/tutorials/dataframe/df102_NanoAODDimuonAnalysis.C
@@ -41,7 +41,7 @@ void df102_NanoAODDimuonAnalysis()
                                  "Run2012BC_DoubleMuParked_Muons.root");
 
    // Add ProgressBar
-   ROOT::RDF::Experimental::AddProgressbar(df);
+   ROOT::RDF::Experimental::AddProgressBar(df);
 
    // For simplicity, select only events with exactly two muons and require opposite charge
    auto df_2mu = df.Filter("nMuon == 2", "Events with exactly two muons");

--- a/tutorials/dataframe/df106_HiggsToFourLeptons.C
+++ b/tutorials/dataframe/df106_HiggsToFourLeptons.C
@@ -86,7 +86,7 @@ void df106_HiggsToFourLeptons()
    ROOT::RDataFrame df = ROOT::RDF::Experimental::FromSpec(dataset_spec);
 
    // Add the ProgressBar feature
-   ROOT::RDF::Experimental::AddProgressbar(df);
+   ROOT::RDF::Experimental::AddProgressBar(df);
 
    // Perform the analysis
    // Access metadata information that is stored in the JSON config file of the RDataFrame

--- a/tutorials/dataframe/df106_HiggsToFourLeptons.py
+++ b/tutorials/dataframe/df106_HiggsToFourLeptons.py
@@ -34,7 +34,7 @@ dataset_spec = os.path.join(ROOT.gROOT.GetTutorialsDir(), "dataframe", "df106_Hi
 df = ROOT.RDF.Experimental.FromSpec(dataset_spec)  # Creates a single dataframe for all the samples
 
 # Add the ProgressBar feature
-ROOT.RDF.Experimental.AddProgressbar(df)
+ROOT.RDF.Experimental.AddProgressBar(df)
 
 # Access metadata information that is stored in the JSON config file of the RDataFrame.
 # The metadata contained in the JSON file is accessible within a `DefinePerSample` call, through the `RDFSampleInfo` class.


### PR DESCRIPTION
For consistency since progress bar is two words we should use it as ProgressBar in all functions - AddProgressBar and PrintProgressBar

