### PR TITLE
[RF] Don't check Minos output code in RooStats LikelihoodInterval

### DIFF
--- a/roofit/roostats/src/LikelihoodInterval.cxx
+++ b/roofit/roostats/src/LikelihoodInterval.cxx
@@ -338,10 +338,6 @@ bool LikelihoodInterval::FindLimits(const RooRealVar & param, double &lower, dou
    double elow = 0;
    double eup = 0;
    ret = fMinimizer->GetMinosError(ivarX, elow, eup );
-   if (!ret)  {
-      ccoutE(Minimization) << "Error  running Minos for parameter " << param.GetName() << std::endl;
-      return false;
-   }
 
    // WHEN error is zero normally is at limit
    if (elow == 0) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -278,6 +278,7 @@ if(ROOT_roofit_FOUND)
   endif()
   if (ROOT_minuit2_FOUND)
     ROOT_ADD_TEST(test-stressroostats-minuit2 COMMAND stressRooStats -minim Minuit2 -b legacy  FAILREGEX "FAILED|Error in" LABELS longtest)
+    ROOT_ADD_TEST(test-stressroostats-batchmode-cpu-minuit2 COMMAND stressRooStats -minim Minuit2 -b cpu FAILREGEX "FAILED|Error in" LABELS longtest)
   endif()
 
 endif()


### PR DESCRIPTION
Don't check the Minos output code, because if the Minos errors are
at the limit, Minuit2 will return nonzero, unlike Minuit 1.
This case where the errors are at limit should not cause a failure
though. The `stressRooStats` test suite actively provokes it, by fitting
a dataset with a single observed value that corresponds to a best-fit
parameter value at the limit.

With these changes, the `stressRooStats` suite will also pass with
Minuit2 and BatchMode, which is now added as a unit test.