### PR TITLE
[PyROOT] Fix distributed RDataFrame tests due to error serialization

### DIFF
--- a/bindings/pyroot/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/CMakeLists.txt
@@ -92,6 +92,7 @@ set(py2_py3_sources
   ROOT/_pythonization/__init__.py
   ROOT/_pythonization/_pyz_utils.py
   ROOT/_pythonization/_rvec.py
+  ROOT/_pythonization/_runtime_error.py
   ROOT/_pythonization/_stl_vector.py
   ROOT/_pythonization/_tarray.py
   ROOT/_pythonization/_tclass.py

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_runtime_error.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_runtime_error.py
@@ -1,0 +1,37 @@
+# Author: Vincenzo Eduardo Padulano CERN  10/2023
+
+################################################################################
+# Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+from . import pythonization
+
+# TODO: vpadulan
+# This module enables pickling/unpickling of the std::runtime_error Python proxy
+# defined in cppyy (via CPPExcInstance). The same logic should be implemented
+# in the CPython extension to be more generic.
+
+def _create_error(what):
+    """
+    Creates a new cppyy std::runtime_error proxy with the original message.
+    """
+    import cppyy
+    return cppyy.gbl.std.runtime_error(what)
+
+def _reduce_error(self):
+    """
+    Establish the strategy to recreate a std::runtime_error when unpickling.
+
+    Creates a new error from the original message. Need to use a separate free
+    function instead of an inline lambda to help pickle.
+    """
+    return _create_error, (self.what(), )
+
+@pythonization("runtime_error", ns="std")
+def pythonize_runtime_error(klass):
+    """Add serialization capabilities to std::runtime_error."""
+    klass.__reduce__ = _reduce_error


### PR DESCRIPTION
This commit enables serialization of the Python proxy defined within cppyy to the C++ std::runtime_error class. By doing so, we avoid errors that happen in certain configurations of Dask tasks where a std::runtime_error may be thrown within the event loop itself. Recent CI failures report the following:

```
  RDataFrame::Run: event loop was interrupted
  Warning in <TBufferFile::WriteObjectAny>: since runtime_error has no public constructor
	which can be called without argument, objects of this class
	can not be read with the current library. You will need to
	add a default constructor before attempting to read it.
  Warning in <TStreamerInfo::Build>: runtime_error: base class exception has no streamer or dictionary it will not be saved
  Warning in <TStreamerInfo::Build>: runtime_error: __cow_string has no streamer or dictionary, data member "_M_msg" will not be saved
  Error in <TClass::New>: cannot create object of class runtime_error
  Error in <TBufferFile::ReadObject>: could not create object of class runtime_error
   *** Break *** segmentation violation
```

This is due to the fact that for some reason the std::runtime_error object is serialized at the end of the function scope within the Dask task. It is important to note that this has only appeared very recently (after October 20th 2023), somehow concurrently on multiple platforms/configurations:

* Alma9 (GCC 11, C++17, Python 3.9, Dask 2023.10) - also tested with Dask 2022.8.1 - 2023.9.3
* Ubuntu22 (GCC11, C++17, Python 3.10, Dask 2023.10)
* Ubuntu23.10 (GCC13, C++20, Python 3.11, Dask 2023.10)

~~The reason why have appeared on these platforms and not on others (notably they do not appear in any Jenkins CI run) is unclear.~~Found culprit, see comment below
