### PR TITLE
fix: Use TKey::ReadObject<T> instead of ReadObj

### DIFF
--- a/net/http/src/TRootSniffer.cxx
+++ b/net/http/src/TRootSniffer.cxx
@@ -741,7 +741,7 @@ void TRootSniffer::ScanKeyProperties(TRootSnifferScanRec &rec, TKey *key, TObjec
 {
    if (strcmp(key->GetClassName(), "TDirectoryFile") == 0) {
       if (rec.fLevel == 0) {
-         TDirectory *dir = dynamic_cast<TDirectory *>(key->ReadObj());
+         auto dir = key->ReadObject<TDirectory>();
          if (dir) {
             obj = dir;
             obj_class = dir->IsA();

--- a/proof/proofplayer/src/TEventIter.cxx
+++ b/proof/proofplayer/src/TEventIter.cxx
@@ -985,7 +985,7 @@ TTree* TEventIterTree::Load(TDSetElement *e, Bool_t &localfile, const char *objn
 
    PDB(kLoop,2) Info("Load", "Reading: %s", tn);
 
-   TTree *tree = dynamic_cast<TTree*> (key->ReadObj());
+   auto tree = key->ReadObject<TTree>();
    dd->cd();
 
    if (tree == 0) {

--- a/roofit/histfactory/src/Channel.cxx
+++ b/roofit/histfactory/src/Channel.cxx
@@ -473,7 +473,7 @@ TH1* RooStats::HistFactory::Channel::GetHistogram(std::string InputFile, std::st
     throw hf_exc();
   }
 
-  auto hist = dynamic_cast<TH1*>(key->ReadObj());
+  auto hist = key->ReadObject<TH1>();
   if( !hist ) {
     cxcoutEHF << "Histogram '" << HistoName
         << "' wasn't found in file '" << InputFile


### PR DESCRIPTION

# This Pull request:

## Changes or fixes:

`ReadObj` returns an owning pointer.
Using `dynamic_cast` and ignoring the "not castable" case can leak memory.

See: https://root-forum.cern.ch/t/possible-leak-with-dynamic-cast-and-tkey-readobj/56799


## Checklist:

- [X] tested changes locally
- [ ] updated the docs (if necessary)