### PR TITLE
[core] Add `FloatHalf_t` typedef

### DIFF
--- a/core/foundation/inc/RtypesCore.h
+++ b/core/foundation/inc/RtypesCore.h
@@ -34,6 +34,7 @@ class TRootIOCtor;
 
 //---- types -------------------------------------------------------------------
 
+// clang-format off
 typedef char           Char_t;      //Signed Character 1 byte (char)
 typedef unsigned char  UChar_t;     //Unsigned Character 1 byte (unsigned char)
 typedef short          Short_t;     //Signed Short integer 2 bytes (short)
@@ -55,7 +56,8 @@ typedef long           Long_t;      //Signed long integer 4 bytes (long)
 typedef unsigned long  ULong_t;     //Unsigned long integer 4 bytes (unsigned long)
 #endif
 typedef float          Float_t;     //Float 4 bytes (float)
-typedef float          Float16_t;   //Float 4 bytes written with a truncated mantissa
+typedef float          Float16_t;   //Float 4 bytes in memory, written as a 2 bytes float with a truncated mantissa
+typedef float          FloatHalf_t; //Float 4 bytes in memory, written as a 2 bytes float with IEEE half-precision
 typedef double         Double_t;    //Double 8 bytes
 typedef double         Double32_t;  //Double 8 bytes in memory, written as a 4 bytes float
 typedef long double    LongDouble_t;//Long Double
@@ -94,6 +96,7 @@ typedef short          SCoord_t;    //Screen coordinates (short)
 typedef double         Coord_t;     //Pad world coordinates (double)
 typedef float          Angle_t;     //Graphics angle (float)
 typedef float          Size_t;      //Attribute size (float)
+// clang-format on
 
 //---- constants ---------------------------------------------------------------
 


### PR DESCRIPTION
This PR adds a typedef to represent half-precision IEEE floats, so that they can be supported by RNTuple. Until official support in C++23, they are represented as 4-byte single-precision floats in memory while written as 2-byte half-precision floats. This is consistent with the existing `Float16_t` type that only truncates the mantissa. See also #13917.