### PR TITLE
[RF] Improve the signature of vectorized evaluation function

### DIFF
--- a/roofit/batchcompute/src/Batches.h
+++ b/roofit/batchcompute/src/Batches.h
@@ -46,7 +46,7 @@ public:
    std::size_t nEvents = 0;
    std::size_t nBatches = 0;
    std::size_t nExtra = 0;
-   RestrictArr output = nullptr;
+   double *__restrict output = nullptr;
 };
 
 } // end namespace RooBatchCompute

--- a/roofit/histfactory/inc/RooStats/HistFactory/FlexibleInterpVar.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/FlexibleInterpVar.h
@@ -56,7 +56,7 @@ namespace HistFactory{
     const std::vector<double>& low() const { return _low; }
     const std::vector<double>& high() const { return _high; }
 
-    void computeBatch(double* output, size_t size, RooFit::Detail::DataMap const&) const override;
+    void doEval(RooFit::EvalContext &) const override;
 
     void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
 

--- a/roofit/histfactory/inc/RooStats/HistFactory/ParamHistFunc.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/ParamHistFunc.h
@@ -101,7 +101,7 @@ protected:
   Int_t addParamSet( const RooArgList& params );
   static Int_t GetNumBins( const RooArgSet& vars );
   double evaluate() const override;
-  void computeBatch(double* output, size_t size, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
 
   void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
 

--- a/roofit/histfactory/inc/RooStats/HistFactory/PiecewiseInterpolation.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/PiecewiseInterpolation.h
@@ -100,7 +100,7 @@ protected:
   std::vector<int> _interpCode;
 
   double evaluate() const override;
-  void computeBatch(double* output, size_t size, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
 
   ClassDefOverride(PiecewiseInterpolation,4) // Sum of RooAbsReal objects
 };

--- a/roofit/histfactory/src/FlexibleInterpVar.cxx
+++ b/roofit/histfactory/src/FlexibleInterpVar.cxx
@@ -245,7 +245,7 @@ void FlexibleInterpVar::translate(RooFit::Detail::CodeSquashContext &ctx) const
    ctx.addResult(this, resName);
 }
 
-void FlexibleInterpVar::computeBatch(double *output, size_t /*nEvents*/, RooFit::Detail::DataMap const &dataMap) const
+void FlexibleInterpVar::doEval(RooFit::EvalContext &ctx) const
 {
    double total(_nominal);
 
@@ -260,14 +260,14 @@ void FlexibleInterpVar::computeBatch(double *output, size_t /*nEvents*/, RooFit:
          code = 5;
       }
       total += RooFit::Detail::EvaluateFuncs::flexibleInterp(code, _low[i], _high[i], _interpBoundary, _nominal,
-                                                             dataMap.at(&_paramList[i])[0], total);
+                                                             ctx.at(&_paramList[i])[0], total);
    }
 
    if (total <= 0) {
       total = TMath::Limits<double>::Min();
    }
 
-   output[0] = total;
+   ctx.output()[0] = total;
 }
 
 void FlexibleInterpVar::printMultiline(std::ostream& os, Int_t contents,

--- a/roofit/histfactory/src/PiecewiseInterpolation.cxx
+++ b/roofit/histfactory/src/PiecewiseInterpolation.cxx
@@ -216,22 +216,25 @@ void PiecewiseInterpolation::translate(RooFit::Detail::CodeSquashContext &ctx) c
 /// Interpolate between input distributions for all values of the observable in `evalData`.
 /// \param[in,out] evalData Struct holding spans pointing to input data. The results of this function will be stored here.
 /// \param[in] normSet Arguments to normalise over.
-void PiecewiseInterpolation::computeBatch(double* sum, size_t /*size*/, RooFit::Detail::DataMap const& dataMap) const {
-  auto nominal = dataMap.at(_nominal);
+void PiecewiseInterpolation::doEval(RooFit::EvalContext & ctx) const
+{
+  std::span<double> sum = ctx.output();
+
+  auto nominal = ctx.at(_nominal);
   for(unsigned int j=0; j < nominal.size(); ++j) {
     sum[j] = nominal[j];
   }
 
   for (unsigned int i=0; i < _paramSet.size(); ++i) {
     const double param = static_cast<RooAbsReal*>(_paramSet.at(i))->getVal();
-    auto low   = dataMap.at(_lowSet.at(i));
-    auto high  = dataMap.at(_highSet.at(i));
+    auto low   = ctx.at(_lowSet.at(i));
+    auto high  = ctx.at(_highSet.at(i));
     const int icode = _interpCode[i];
 
     if (icode < 0 || icode > 5) {
-      coutE(InputArguments) << "PiecewiseInterpolation::computeBatch(): " << _paramSet[i].GetName()
+      coutE(InputArguments) << "PiecewiseInterpolation::doEval(): " << _paramSet[i].GetName()
                        << " with unknown interpolation code" << icode << std::endl;
-      throw std::invalid_argument("PiecewiseInterpolation::computeBatch() got invalid interpolation code " + std::to_string(icode));
+      throw std::invalid_argument("PiecewiseInterpolation::doEval() got invalid interpolation code " + std::to_string(icode));
     }
 
     for (unsigned int j=0; j < nominal.size(); ++j) {

--- a/roofit/histfactory/test/testHistFactory.cxx
+++ b/roofit/histfactory/test/testHistFactory.cxx
@@ -649,7 +649,7 @@ TEST_P(HFFixtureFit, Fit)
    auto mc = dynamic_cast<RooStats::ModelConfig *>(ws->obj("ModelConfig"));
    ASSERT_NE(mc, nullptr);
 
-   // This tests both correct pre-caching of constant terms and (if false) that all computeBatch() are correct.
+   // This tests both correct pre-caching of constant terms and (if false) that all doEval() are correct.
    for (bool constTermOptimization : {true, false}) {
 
       // constTermOptimization makes only sense in the legacy backend

--- a/roofit/roofit/inc/RooArgusBG.h
+++ b/roofit/roofit/inc/RooArgusBG.h
@@ -45,7 +45,7 @@ protected:
   RooRealProxy p ;
 
   double evaluate() const override ;
-  void computeBatch(double* output, size_t size, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
   inline bool canComputeBatchWithCuda() const override { return true; }
 
 

--- a/roofit/roofit/inc/RooBMixDecay.h
+++ b/roofit/roofit/inc/RooBMixDecay.h
@@ -45,7 +45,7 @@ public:
   void initGenerator(Int_t code) override ;
   void generateEvent(Int_t code) override;
 
-  void computeBatch(double* output, size_t size, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
   inline bool canComputeBatchWithCuda() const override { return true; }
 
 protected:

--- a/roofit/roofit/inc/RooBernstein.h
+++ b/roofit/roofit/inc/RooBernstein.h
@@ -45,7 +45,7 @@ private:
   std::string _refRangeName ;
 
   double evaluate() const override;
-  void computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
   inline bool canComputeBatchWithCuda() const override { return true; }
 
   ClassDefOverride(RooBernstein,2) // Bernstein polynomial PDF

--- a/roofit/roofit/inc/RooBifurGauss.h
+++ b/roofit/roofit/inc/RooBifurGauss.h
@@ -42,7 +42,7 @@ protected:
    RooRealProxy sigmaR;
 
    double evaluate() const override;
-   void computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &) const override;
+   void doEval(RooFit::EvalContext &) const override;
    inline bool canComputeBatchWithCuda() const override { return true; }
 
 private:

--- a/roofit/roofit/inc/RooBreitWigner.h
+++ b/roofit/roofit/inc/RooBreitWigner.h
@@ -40,7 +40,7 @@ protected:
   RooRealProxy width ;
 
   double evaluate() const override ;
-  void computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
   inline bool canComputeBatchWithCuda() const override { return true; }
 
 //   void initGenerator();

--- a/roofit/roofit/inc/RooBukinPdf.h
+++ b/roofit/roofit/inc/RooBukinPdf.h
@@ -47,7 +47,7 @@ protected:
   RooRealProxy rho1;
   RooRealProxy rho2;
   double evaluate() const override;
-  void computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
   inline bool canComputeBatchWithCuda() const override { return true; }
 
 private:

--- a/roofit/roofit/inc/RooCBShape.h
+++ b/roofit/roofit/inc/RooCBShape.h
@@ -49,7 +49,7 @@ protected:
   RooRealProxy n;
 
   double evaluate() const override;
-  void computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
   inline bool canComputeBatchWithCuda() const override { return true; }
 
 

--- a/roofit/roofit/inc/RooChebychev.h
+++ b/roofit/roofit/inc/RooChebychev.h
@@ -47,7 +47,7 @@ public:
   mutable TNamed* _refRangeName = nullptr;
 
   double evaluate() const override;
-  void computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
   inline bool canComputeBatchWithCuda() const override { return true; }
 
   double evalAnaInt(const double a, const double b) const;

--- a/roofit/roofit/inc/RooChiSquarePdf.h
+++ b/roofit/roofit/inc/RooChiSquarePdf.h
@@ -38,7 +38,7 @@ private:
   RooRealProxy _ndof;
 
   double evaluate() const override;
-  void computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
   inline bool canComputeBatchWithCuda() const override { return true; }
 
   ClassDefOverride(RooChiSquarePdf,1) // Chi Square distribution (eg. the PDF )

--- a/roofit/roofit/inc/RooDstD0BG.h
+++ b/roofit/roofit/inc/RooDstD0BG.h
@@ -41,7 +41,7 @@ protected:
    RooRealProxy C, A, B;
 
    double evaluate() const override;
-   void computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &) const override;
+   void doEval(RooFit::EvalContext &) const override;
    inline bool canComputeBatchWithCuda() const override { return true; }
 
 private:

--- a/roofit/roofit/inc/RooExpPoly.h
+++ b/roofit/roofit/inc/RooExpPoly.h
@@ -47,7 +47,7 @@ protected:
    int _lowestOrder;
 
    // CUDA support
-   void computeBatch(double *output, size_t size, RooFit::Detail::DataMap const &) const override;
+   void doEval(RooFit::EvalContext &) const override;
    inline bool canComputeBatchWithCuda() const override { return true; }
 
    /// Evaluation

--- a/roofit/roofit/inc/RooExponential.h
+++ b/roofit/roofit/inc/RooExponential.h
@@ -48,7 +48,7 @@ protected:
    bool _negateCoefficient = false;
 
    double evaluate() const override;
-   void computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &) const override;
+   void doEval(RooFit::EvalContext &) const override;
    inline bool canComputeBatchWithCuda() const override { return true; }
 
 private:

--- a/roofit/roofit/inc/RooGamma.h
+++ b/roofit/roofit/inc/RooGamma.h
@@ -43,7 +43,7 @@ protected:
   RooRealProxy mu ;
 
   double evaluate() const override ;
-  void computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
   inline bool canComputeBatchWithCuda() const override { return true; }
 
 private:

--- a/roofit/roofit/inc/RooGaussModel.h
+++ b/roofit/roofit/inc/RooGaussModel.h
@@ -46,7 +46,7 @@ public:
 
   void advertiseAymptoticIntegral(bool flag) { _asympInt = flag ; }  // added FMV,07/24/03
 
-  void computeBatch(double* output, size_t size, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
 
   bool canComputeBatchWithCuda() const override;
 

--- a/roofit/roofit/inc/RooGaussian.h
+++ b/roofit/roofit/inc/RooGaussian.h
@@ -61,7 +61,7 @@ protected:
   RooRealProxy sigma ;
 
   double evaluate() const override;
-  void computeBatch(double* output, size_t size, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
   inline bool canComputeBatchWithCuda() const override { return true; }
 
 private:

--- a/roofit/roofit/inc/RooJohnson.h
+++ b/roofit/roofit/inc/RooJohnson.h
@@ -55,7 +55,7 @@ private:
   double _massThreshold{-1.E300};
 
   double evaluate() const override;
-  void computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
   inline bool canComputeBatchWithCuda() const override { return true; }
 
   ClassDefOverride(RooJohnson,1)

--- a/roofit/roofit/inc/RooLandau.h
+++ b/roofit/roofit/inc/RooLandau.h
@@ -48,7 +48,7 @@ protected:
   RooRealProxy sigma ;
 
   double evaluate() const override ;
-  void computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
   inline bool canComputeBatchWithCuda() const override { return true; }
 
 private:

--- a/roofit/roofit/inc/RooLognormal.h
+++ b/roofit/roofit/inc/RooLognormal.h
@@ -50,7 +50,7 @@ protected:
    bool _useStandardParametrization = false;
 
    double evaluate() const override;
-   void computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &) const override;
+   void doEval(RooFit::EvalContext &) const override;
    inline bool canComputeBatchWithCuda() const override { return true; }
 
 private:

--- a/roofit/roofit/inc/RooNovosibirsk.h
+++ b/roofit/roofit/inc/RooNovosibirsk.h
@@ -42,7 +42,7 @@ public:
 
 protected:
   double evaluate() const override;
-  void computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
   inline bool canComputeBatchWithCuda() const override { return true; }
 
 private:

--- a/roofit/roofit/inc/RooPoisson.h
+++ b/roofit/roofit/inc/RooPoisson.h
@@ -57,7 +57,7 @@ protected:
   bool  _protectNegative{true};
 
   double evaluate() const override;
-  void computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
   inline bool canComputeBatchWithCuda() const override { return true; }
 
   ClassDefOverride(RooPoisson,3) // A Poisson PDF

--- a/roofit/roofit/inc/RooPolynomial.h
+++ b/roofit/roofit/inc/RooPolynomial.h
@@ -61,7 +61,7 @@ protected:
 
    /// Evaluation
    double evaluate() const override;
-   void computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &) const override;
+   void doEval(RooFit::EvalContext &) const override;
 
    // It doesn't make sense to use the GPU if the polynomial has no terms.
    inline bool canComputeBatchWithCuda() const override { return !_coefList.empty(); }

--- a/roofit/roofit/inc/RooPower.h
+++ b/roofit/roofit/inc/RooPower.h
@@ -47,7 +47,7 @@ protected:
    mutable std::vector<double> _wksp; //! do not persist
 
    // CUDA support
-   void computeBatch(double *output, size_t size, RooFit::Detail::DataMap const &) const override;
+   void doEval(RooFit::EvalContext &) const override;
    inline bool canComputeBatchWithCuda() const override { return true; }
 
    /// Evaluation

--- a/roofit/roofit/inc/RooVoigtian.h
+++ b/roofit/roofit/inc/RooVoigtian.h
@@ -45,7 +45,7 @@ protected:
   RooRealProxy sigma ;
 
   double evaluate() const override ;
-  void computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
   inline bool canComputeBatchWithCuda() const override { return true; }
 
 private:

--- a/roofit/roofit/src/RooArgusBG.cxx
+++ b/roofit/roofit/src/RooArgusBG.cxx
@@ -74,10 +74,10 @@ double RooArgusBG::evaluate() const {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void RooArgusBG::computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const& dataMap) const
+void RooArgusBG::doEval(RooFit::EvalContext & ctx) const
 {
-  RooBatchCompute::compute(dataMap.config(this), RooBatchCompute::ArgusBG, output, nEvents,
-          {dataMap.at(m), dataMap.at(m0), dataMap.at(c), dataMap.at(p)});
+  RooBatchCompute::compute(ctx.config(this), RooBatchCompute::ArgusBG, ctx.output(),
+          {ctx.at(m), ctx.at(m0), ctx.at(c), ctx.at(p)});
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooBMixDecay.cxx
+++ b/roofit/roofit/src/RooBMixDecay.cxx
@@ -119,11 +119,11 @@ double RooBMixDecay::coefficient(Int_t basisIndex) const
   return 0 ;
 }
 
-void RooBMixDecay::computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &dataMap) const
+void RooBMixDecay::doEval(RooFit::EvalContext &ctx) const
 {
-   RooBatchCompute::compute(dataMap.config(this), RooBatchCompute::BMixDecay, output, nEvents,
-                            {dataMap.at(&_convSet[0]), dataMap.at(&_convSet[1]), dataMap.at(_tagFlav),
-                             dataMap.at(_delMistag), dataMap.at(_mixState), dataMap.at(_mistag)});
+   RooBatchCompute::compute(ctx.config(this), RooBatchCompute::BMixDecay, ctx.output(),
+                            {ctx.at(&_convSet[0]), ctx.at(&_convSet[1]), ctx.at(_tagFlav),
+                             ctx.at(_delMistag), ctx.at(_mixState), ctx.at(_mistag)});
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooBernstein.cxx
+++ b/roofit/roofit/src/RooBernstein.cxx
@@ -125,7 +125,7 @@ double RooBernstein::evaluate() const
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute multiple values of Bernstein distribution.
-void RooBernstein::computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const& dataMap) const
+void RooBernstein::doEval(RooFit::EvalContext & ctx) const
 {
   const int nCoef = _coefList.size();
   std::vector<double> extraArgs(nCoef+2);
@@ -134,7 +134,7 @@ void RooBernstein::computeBatch(double* output, size_t nEvents, RooFit::Detail::
   extraArgs[nCoef] = _x.min();
   extraArgs[nCoef+1] = _x.max();
 
-  RooBatchCompute::compute(dataMap.config(this), RooBatchCompute::Bernstein, output, nEvents, {dataMap.at(_x)}, extraArgs);
+  RooBatchCompute::compute(ctx.config(this), RooBatchCompute::Bernstein, ctx.output(), {ctx.at(_x)}, extraArgs);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooBifurGauss.cxx
+++ b/roofit/roofit/src/RooBifurGauss.cxx
@@ -70,10 +70,10 @@ void RooBifurGauss::translate(RooFit::Detail::CodeSquashContext &ctx) const
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute multiple values of BifurGauss distribution.
-void RooBifurGauss::computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &dataMap) const
+void RooBifurGauss::doEval(RooFit::EvalContext & ctx) const
 {
-   RooBatchCompute::compute(dataMap.config(this), RooBatchCompute::BifurGauss, output, nEvents,
-                            {dataMap.at(x), dataMap.at(mean), dataMap.at(sigmaL), dataMap.at(sigmaR)});
+   RooBatchCompute::compute(ctx.config(this), RooBatchCompute::BifurGauss, ctx.output(),
+          {ctx.at(x),ctx.at(mean),ctx.at(sigmaL),ctx.at(sigmaR)});
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooBreitWigner.cxx
+++ b/roofit/roofit/src/RooBreitWigner.cxx
@@ -61,9 +61,9 @@ double RooBreitWigner::evaluate() const
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute multiple values of BreitWigner distribution.
-void RooBreitWigner::computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const& dataMap) const
+void RooBreitWigner::doEval(RooFit::EvalContext & ctx) const
 {
-  RooBatchCompute::compute(dataMap.config(this), RooBatchCompute::BreitWigner, output, nEvents, {dataMap.at(x), dataMap.at(mean), dataMap.at(width)});
+  RooBatchCompute::compute(ctx.config(this), RooBatchCompute::BreitWigner, ctx.output(), {ctx.at(x), ctx.at(mean), ctx.at(width)});
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooBukinPdf.cxx
+++ b/roofit/roofit/src/RooBukinPdf.cxx
@@ -146,8 +146,8 @@ double RooBukinPdf::evaluate() const
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute multiple values of Bukin distribution.
-void RooBukinPdf::computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const& dataMap) const
+void RooBukinPdf::doEval(RooFit::EvalContext & ctx) const
 {
-  RooBatchCompute::compute(dataMap.config(this), RooBatchCompute::Bukin, output, nEvents,
-          {dataMap.at(x), dataMap.at(Xp), dataMap.at(sigp), dataMap.at(xi), dataMap.at(rho1), dataMap.at(rho2)});
+  RooBatchCompute::compute(ctx.config(this), RooBatchCompute::Bukin, ctx.output(),
+          {ctx.at(x), ctx.at(Xp), ctx.at(sigp), ctx.at(xi), ctx.at(rho1), ctx.at(rho2)});
 }

--- a/roofit/roofit/src/RooCBShape.cxx
+++ b/roofit/roofit/src/RooCBShape.cxx
@@ -89,10 +89,10 @@ double RooCBShape::evaluate() const {
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute multiple values of Crystal ball Shape distribution.
-void RooCBShape::computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &dataMap) const
+void RooCBShape::doEval(RooFit::EvalContext &ctx) const
 {
-   RooBatchCompute::compute(dataMap.config(this), RooBatchCompute::CBShape, output, nEvents,
-                            {dataMap.at(m), dataMap.at(m0), dataMap.at(sigma), dataMap.at(alpha), dataMap.at(n)});
+   RooBatchCompute::compute(ctx.config(this), RooBatchCompute::CBShape, ctx.output(),
+                            {ctx.at(m), ctx.at(m0), ctx.at(sigma), ctx.at(alpha), ctx.at(n)});
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooChebychev.cxx
+++ b/roofit/roofit/src/RooChebychev.cxx
@@ -104,7 +104,7 @@ void RooChebychev::translate(RooFit::Detail::CodeSquashContext &ctx) const
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute multiple values of Chebychev.
-void RooChebychev::computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &dataMap) const
+void RooChebychev::doEval(RooFit::EvalContext &ctx) const
 {
    std::vector<double> extraArgs;
    extraArgs.reserve(_coefList.size() + 2);
@@ -113,8 +113,7 @@ void RooChebychev::computeBatch(double *output, size_t nEvents, RooFit::Detail::
    }
    extraArgs.push_back(_x.min(_refRangeName ? _refRangeName->GetName() : nullptr));
    extraArgs.push_back(_x.max(_refRangeName ? _refRangeName->GetName() : nullptr));
-   RooBatchCompute::compute(dataMap.config(this), RooBatchCompute::Chebychev, output, nEvents, {dataMap.at(_x)},
-                            extraArgs);
+   RooBatchCompute::compute(ctx.config(this), RooBatchCompute::Chebychev, ctx.output(), {ctx.at(_x)}, extraArgs);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooChiSquarePdf.cxx
+++ b/roofit/roofit/src/RooChiSquarePdf.cxx
@@ -63,11 +63,10 @@ double RooChiSquarePdf::evaluate() const
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute multiple values of ChiSquare distribution.
-void RooChiSquarePdf::computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &dataMap) const
+void RooChiSquarePdf::doEval(RooFit::EvalContext &ctx) const
 {
    std::array<double, 1> extraArgs{_ndof};
-   RooBatchCompute::compute(dataMap.config(this), RooBatchCompute::ChiSquare, output, nEvents, {dataMap.at(_x)},
-                            extraArgs);
+   RooBatchCompute::compute(ctx.config(this), RooBatchCompute::ChiSquare, ctx.output(), {ctx.at(_x)}, extraArgs);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooDstD0BG.cxx
+++ b/roofit/roofit/src/RooDstD0BG.cxx
@@ -80,10 +80,10 @@ double RooDstD0BG::evaluate() const
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute multiple values of D*-D0 mass difference distribution.
-void RooDstD0BG::computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &dataMap) const
+void RooDstD0BG::doEval(RooFit::EvalContext & ctx) const
 {
-   RooBatchCompute::compute(dataMap.config(this), RooBatchCompute::DstD0BG, output, nEvents,
-                            {dataMap.at(dm), dataMap.at(dm0), dataMap.at(C), dataMap.at(A), dataMap.at(B)});
+   RooBatchCompute::compute(ctx.config(this), RooBatchCompute::DstD0BG, ctx.output(),
+          {ctx.at(dm), ctx.at(dm0), ctx.at(C), ctx.at(A), ctx.at(B)});
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooExpPoly.cxx
+++ b/roofit/roofit/src/RooExpPoly.cxx
@@ -127,20 +127,20 @@ double RooExpPoly::evaluateLog() const
 ////////////////////////////////////////////////////////////////////////////////
 
 /// Compute multiple values of ExpPoly distribution.
-void RooExpPoly::computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &dataMap) const
+void RooExpPoly::doEval(RooFit::EvalContext &ctx) const
 {
    std::vector<std::span<const double>> vars;
    vars.reserve(_coefList.size() + 1);
-   vars.push_back(dataMap.at(_x));
+   vars.push_back(ctx.at(_x));
 
    std::vector<double> coefVals;
    for (RooAbsArg *coef : _coefList) {
-      vars.push_back(dataMap.at(coef));
+      vars.push_back(ctx.at(coef));
    }
 
    std::array<double, 2> args{static_cast<double>(_lowestOrder), static_cast<double>(_coefList.size())};
 
-   RooBatchCompute::compute(dataMap.config(this), RooBatchCompute::ExpPoly, output, nEvents, vars, args);
+   RooBatchCompute::compute(ctx.config(this), RooBatchCompute::ExpPoly, ctx.output(), vars, args);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooExponential.cxx
+++ b/roofit/roofit/src/RooExponential.cxx
@@ -68,10 +68,10 @@ double RooExponential::evaluate() const
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute multiple values of Exponential distribution.
-void RooExponential::computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &dataMap) const
+void RooExponential::doEval(RooFit::EvalContext &ctx) const
 {
    auto computer = _negateCoefficient ? RooBatchCompute::ExponentialNeg : RooBatchCompute::Exponential;
-   RooBatchCompute::compute(dataMap.config(this), computer, output, nEvents, {dataMap.at(x), dataMap.at(c)});
+   RooBatchCompute::compute(ctx.config(this), computer, ctx.output(), {ctx.at(x), ctx.at(c)});
 }
 
 Int_t RooExponential::getAnalyticalIntegral(RooArgSet &allVars, RooArgSet &analVars, const char * /*rangeName*/) const

--- a/roofit/roofit/src/RooGamma.cxx
+++ b/roofit/roofit/src/RooGamma.cxx
@@ -94,10 +94,10 @@ void RooGamma::translate(RooFit::Detail::CodeSquashContext &ctx) const
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute multiple values of Gamma PDF.
-void RooGamma::computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &dataMap) const
+void RooGamma::doEval(RooFit::EvalContext &ctx) const
 {
-   RooBatchCompute::compute(dataMap.config(this), RooBatchCompute::Gamma, output, nEvents,
-                            {dataMap.at(x), dataMap.at(gamma), dataMap.at(beta), dataMap.at(mu)});
+   RooBatchCompute::compute(ctx.config(this), RooBatchCompute::Gamma, ctx.output(),
+                            {ctx.at(x), ctx.at(gamma), ctx.at(beta), ctx.at(mu)});
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooGaussModel.cxx
+++ b/roofit/roofit/src/RooGaussModel.cxx
@@ -169,20 +169,22 @@ double RooGaussModel::evaluate() const
    return evaluate(x, mean * msf, sigma * ssf, param1, param2, _basisCode);
 }
 
-void RooGaussModel::computeBatch(double *output, size_t size,
-                                 RooFit::Detail::DataMap const &dataMap) const
+void RooGaussModel::doEval(RooFit::EvalContext &ctx) const
 {
-   auto xVals = dataMap.at(x);
-   auto meanVals = dataMap.at(mean);
-   auto meanSfVals = dataMap.at(msf);
-   auto sigmaVals = dataMap.at(sigma);
-   auto sigmaSfVals = dataMap.at(ssf);
+   std::span<double> output = ctx.output();
+   std::size_t size = output.size();
+
+   auto xVals = ctx.at(x);
+   auto meanVals = ctx.at(mean);
+   auto meanSfVals = ctx.at(msf);
+   auto sigmaVals = ctx.at(sigma);
+   auto sigmaSfVals = ctx.at(ssf);
 
    auto param1 = static_cast<RooAbsReal *>(basis().getParameter(1));
    auto param2 = static_cast<RooAbsReal *>(basis().getParameter(2));
    const double zeroVal = 0.0;
-   auto param1Vals = param1 ? dataMap.at(param1) : std::span<const double>{&zeroVal, 1};
-   auto param2Vals = param2 ? dataMap.at(param2) : std::span<const double>{&zeroVal, 1};
+   auto param1Vals = param1 ? ctx.at(param1) : std::span<const double>{&zeroVal, 1};
+   auto param2Vals = param2 ? ctx.at(param2) : std::span<const double>{&zeroVal, 1};
 
    BasisType basisType = getBasisType(_basisCode);
    double basisSign = _basisCode - 10 * (basisType - 1) - 2;
@@ -193,7 +195,7 @@ void RooGaussModel::computeBatch(double *output, size_t size,
    // adapt RooGaussModel::canComputeBatchWithCuda().
    if (basisType == expBasis) {
       std::array<double, 1> extraArgs{basisSign};
-      RooBatchCompute::compute(dataMap.config(this), RooBatchCompute::GaussModelExpBasis, output, size,
+      RooBatchCompute::compute(ctx.config(this), RooBatchCompute::GaussModelExpBasis, output,
                         {xVals, meanVals, meanSfVals, sigmaVals, sigmaSfVals, param1Vals}, extraArgs);
       return;
    }
@@ -201,7 +203,7 @@ void RooGaussModel::computeBatch(double *output, size_t size,
    // For now, if the arrays don't have the expected input shape, fall back to the scalar mode
    if (xVals.size() != size || meanVals.size() != 1 || meanSfVals.size() != 1 || sigmaVals.size() != 1 ||
        sigmaSfVals.size() != 1 || param1Vals.size() != 1 || param2Vals.size() != 1) {
-      return RooAbsPdf::computeBatch(output, size, dataMap);
+      return RooAbsPdf::doEval(ctx);
    }
 
    for (unsigned int i = 0; i < size; ++i) {

--- a/roofit/roofit/src/RooGaussian.cxx
+++ b/roofit/roofit/src/RooGaussian.cxx
@@ -63,10 +63,10 @@ double RooGaussian::evaluate() const
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute multiple values of Gaussian distribution.
-void RooGaussian::computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const& dataMap) const
+void RooGaussian::doEval(RooFit::EvalContext & ctx) const
 {
-  RooBatchCompute::compute(dataMap.config(this), RooBatchCompute::Gaussian, output, nEvents,
-          {dataMap.at(x), dataMap.at(mean), dataMap.at(sigma)});
+  RooBatchCompute::compute(ctx.config(this), RooBatchCompute::Gaussian, ctx.output(),
+          {ctx.at(x), ctx.at(mean), ctx.at(sigma)});
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooJohnson.cxx
+++ b/roofit/roofit/src/RooJohnson.cxx
@@ -114,12 +114,11 @@ double RooJohnson::evaluate() const
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute multiple values of the Johnson distribution.
-void RooJohnson::computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const& dataMap) const
+void RooJohnson::doEval(RooFit::EvalContext &ctx) const
 {
-  std::array<double, 1> extraArgs{_massThreshold};
-  RooBatchCompute::compute(dataMap.config(this), RooBatchCompute::Johnson, output, nEvents,
-          {dataMap.at(_mass), dataMap.at(_mu), dataMap.at(_lambda), dataMap.at(_gamma), dataMap.at(_delta)},
-          extraArgs);
+   std::array<double, 1> extraArgs{_massThreshold};
+   RooBatchCompute::compute(ctx.config(this), RooBatchCompute::Johnson, ctx.output(),
+                            {ctx.at(_mass), ctx.at(_mu), ctx.at(_lambda), ctx.at(_gamma), ctx.at(_delta)}, extraArgs);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooLandau.cxx
+++ b/roofit/roofit/src/RooLandau.cxx
@@ -68,10 +68,10 @@ void RooLandau::translate(RooFit::Detail::CodeSquashContext &ctx) const
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute multiple values of Landau distribution.
-void RooLandau::computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &dataMap) const
+void RooLandau::doEval(RooFit::EvalContext &ctx) const
 {
-   RooBatchCompute::compute(dataMap.config(this), RooBatchCompute::Landau, output, nEvents,
-                            {dataMap.at(x), dataMap.at(mean), dataMap.at(sigma)});
+   RooBatchCompute::compute(ctx.config(this), RooBatchCompute::Landau, ctx.output(),
+                            {ctx.at(x), ctx.at(mean), ctx.at(sigma)});
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooLognormal.cxx
+++ b/roofit/roofit/src/RooLognormal.cxx
@@ -90,11 +90,11 @@ void RooLognormal::translate(RooFit::Detail::CodeSquashContext &ctx) const
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute multiple values of Lognormal distribution.
-void RooLognormal::computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &dataMap) const
+void RooLognormal::doEval(RooFit::EvalContext &ctx) const
 {
    auto computer = _useStandardParametrization ? RooBatchCompute::LognormalStandard : RooBatchCompute::Lognormal;
-   RooBatchCompute::compute(dataMap.config(this), computer, output, nEvents,
-                            {dataMap.at(x), dataMap.at(m0), dataMap.at(k)});
+   RooBatchCompute::compute(ctx.config(this), computer, ctx.output(),
+                            {ctx.at(x), ctx.at(m0), ctx.at(k)});
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooNovosibirsk.cxx
+++ b/roofit/roofit/src/RooNovosibirsk.cxx
@@ -88,10 +88,10 @@ double RooNovosibirsk::evaluate() const
 }
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute multiple values of Novosibirsk distribution.
-void RooNovosibirsk::computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const& dataMap) const
+void RooNovosibirsk::doEval(RooFit::EvalContext & ctx) const
 {
-  RooBatchCompute::compute(dataMap.config(this), RooBatchCompute::Novosibirsk, output, nEvents,
-          {dataMap.at(x), dataMap.at(peak), dataMap.at(width), dataMap.at(tail)});
+  RooBatchCompute::compute(ctx.config(this), RooBatchCompute::Novosibirsk, ctx.output(),
+          {ctx.at(x), ctx.at(peak), ctx.at(width), ctx.at(tail)});
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooPoisson.cxx
+++ b/roofit/roofit/src/RooPoisson.cxx
@@ -77,12 +77,11 @@ void RooPoisson::translate(RooFit::Detail::CodeSquashContext &ctx) const
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute multiple values of the Poisson distribution.
-void RooPoisson::computeBatch(double *output, size_t nEvents,
-                              RooFit::Detail::DataMap const &dataMap) const
+void RooPoisson::doEval(RooFit::EvalContext &ctx) const
 {
    std::array<double, 2> extraArgs{static_cast<double>(_protectNegative), static_cast<double>(_noRounding)};
-   RooBatchCompute::compute(dataMap.config(this), RooBatchCompute::Poisson, output, nEvents,
-                            {dataMap.at(x), dataMap.at(mean)}, extraArgs);
+   RooBatchCompute::compute(ctx.config(this), RooBatchCompute::Poisson, ctx.output(), {ctx.at(x), ctx.at(mean)},
+                            extraArgs);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooPolynomial.cxx
+++ b/roofit/roofit/src/RooPolynomial.cxx
@@ -125,19 +125,16 @@ void RooPolynomial::translate(RooFit::Detail::CodeSquashContext &ctx) const
 }
 
 /// Compute multiple values of Polynomial.
-void RooPolynomial::computeBatch(double *output, size_t nEvents,
-                                 RooFit::Detail::DataMap const &dataMap) const
+void RooPolynomial::doEval(RooFit::EvalContext &ctx) const
 {
-   return RooPolyVar::computeBatchImpl(this, output, nEvents, dataMap, _x.arg(), _coefList, _lowestOrder);
+   return RooPolyVar::doEvalImpl(this, ctx, _x.arg(), _coefList, _lowestOrder);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Advertise to RooFit that this function can be analytically integrated.
 Int_t RooPolynomial::getAnalyticalIntegral(RooArgSet &allVars, RooArgSet &analVars, const char * /*rangeName*/) const
 {
-   if (matchArgs(allVars, analVars, _x))
-      return 1;
-   return 0;
+   return matchArgs(allVars, analVars, _x);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooPower.cxx
+++ b/roofit/roofit/src/RooPower.cxx
@@ -83,22 +83,22 @@ RooPower::RooPower(const RooPower &other, const char *name)
 ////////////////////////////////////////////////////////////////////////////////
 
 /// Compute multiple values of Power distribution.
-void RooPower::computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &dataMap) const
+void RooPower::doEval(RooFit::EvalContext &ctx) const
 {
     std::vector<std::span<const double>> vars;
     vars.reserve(2 *  _coefList.size() + 1);
-    vars.push_back(dataMap.at(_x));
+    vars.push_back(ctx.at(_x));
 
     assert(_coefList.size() == _expList.size());
 
    for (std::size_t i = 0; i < _coefList.size(); ++i) {
-     vars.push_back(dataMap.at(&_coefList[i]));
-     vars.push_back(dataMap.at(&_expList[i]));
+     vars.push_back(ctx.at(&_coefList[i]));
+     vars.push_back(ctx.at(&_expList[i]));
    }
 
    std::array<double, 1> args{static_cast<double>(_coefList.size())};
 
-   RooBatchCompute::compute(dataMap.config(this), RooBatchCompute::Power, output, nEvents, vars, args);
+   RooBatchCompute::compute(ctx.config(this), RooBatchCompute::Power, ctx.output(), vars, args);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooVoigtian.cxx
+++ b/roofit/roofit/src/RooVoigtian.cxx
@@ -112,8 +112,8 @@ double RooVoigtian::evaluate() const
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute multiple values of Voigtian distribution.
-void RooVoigtian::computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &dataMap) const
+void RooVoigtian::doEval(RooFit::EvalContext &ctx) const
 {
-   RooBatchCompute::compute(dataMap.config(this), RooBatchCompute::Voigtian, output, nEvents,
-                            {dataMap.at(x), dataMap.at(mean), dataMap.at(width), dataMap.at(sigma)});
+   RooBatchCompute::compute(ctx.config(this), RooBatchCompute::Voigtian, ctx.output(),
+                            {ctx.at(x), ctx.at(mean), ctx.at(width), ctx.at(sigma)});
 }

--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -132,9 +132,9 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     RooFit/Detail/AnalyticalIntegrals.h
     RooFit/Detail/BatchModeDataHelpers.h
     RooFit/Detail/CodeSquashContext.h
-    RooFit/Detail/DataMap.h
     RooFit/Detail/EvaluateFuncs.h
     RooFit/Detail/NormalizationHelpers.h
+    RooFit/EvalContext.h
     RooFit/Evaluator.h
     RooFit/Floats.h
     RooFit/ModelConfig.h
@@ -339,7 +339,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     src/RooFactoryWSTool.cxx
     src/RooFirstMoment.cxx
     src/RooFit/Detail/CodeSquashContext.cxx
-    src/RooFit/Detail/DataMap.cxx
+    src/RooFit/EvalContext.cxx
     src/RooFit/Evaluator.cxx
     src/RooFitImplHelpers.cxx
     src/RooFitLegacy/RooCatTypeLegacy.cxx

--- a/roofit/roofitcore/inc/RooAbsCachedPdf.h
+++ b/roofit/roofitcore/inc/RooAbsCachedPdf.h
@@ -87,7 +87,7 @@ public:
 
   protected:
 
-  void computeBatch(double* output, size_t size, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
 
   PdfCacheElem* getCache(const RooArgSet* nset, bool recalculate=true) const ;
 

--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -22,7 +22,7 @@
 #include "RooArgList.h"
 #include "RooNameReg.h"
 #include "RooFit/UniqueId.h"
-#include "RooFit/Detail/DataMap.h"
+#include "RooFit/EvalContext.h"
 
 #include <ROOT/RSpan.hxx>
 

--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -17,13 +17,13 @@
 #define ROO_ABS_REAL
 
 #include "RooAbsArg.h"
+#include "RooArgList.h"
+#include "RooArgSet.h"
 #include "RooCmdArg.h"
 #include "RooCurve.h"
-#include "RooArgSet.h"
-#include "RooArgList.h"
-#include "RooGlobalFunc.h"
-#include "RooFit/Detail/DataMap.h"
 #include "RooFit/Detail/CodeSquashContext.h"
+#include "RooFit/EvalContext.h"
+#include "RooGlobalFunc.h"
 
 #include <ROOT/RSpan.hxx>
 
@@ -389,7 +389,7 @@ public:
   const RooAbsReal* createPlotProjection(const RooArgSet& depVars, const RooArgSet& projVars, RooArgSet*& cloneSet) const ;
   const RooAbsReal *createPlotProjection(const RooArgSet &dependentVars, const RooArgSet *projectedVars,
                      RooArgSet *&cloneSet, const char* rangeName=nullptr, const RooArgSet* condObs=nullptr) const;
-  virtual void computeBatch(double* output, size_t size, RooFit::Detail::DataMap const&) const;
+  virtual void doEval(RooFit::EvalContext &) const;
 
   virtual bool hasGradient() const { return false; }
   virtual void gradient(double *) const {
@@ -412,7 +412,7 @@ protected:
   friend class RooAddPdf;
   friend class RooAddModel;
   friend class AddCacheElem;
-  friend class RooFit::Detail::DataMap;
+  friend class RooFit::EvalContext;
 
   // Hook for objects with normalization-dependent parameters interpretation
   virtual void selectNormalization(const RooArgSet* depSet=nullptr, bool force=false) ;

--- a/roofit/roofitcore/inc/RooAddModel.h
+++ b/roofit/roofitcore/inc/RooAddModel.h
@@ -36,7 +36,7 @@ public:
   double evaluate() const override ;
   bool checkObservables(const RooArgSet* nset) const override ;
 
-  void computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
   inline bool canComputeBatchWithCuda() const override { return true; }
 
   Int_t basisCode(const char* name) const override ;

--- a/roofit/roofitcore/inc/RooAddPdf.h
+++ b/roofit/roofitcore/inc/RooAddPdf.h
@@ -122,7 +122,7 @@ public:
       return getValV(nullptr);
   }
   double getValV(const RooArgSet* set=nullptr) const override ;
-  void computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
   inline bool canComputeBatchWithCuda() const override { return true; }
 
 

--- a/roofit/roofitcore/inc/RooAddition.h
+++ b/roofit/roofitcore/inc/RooAddition.h
@@ -54,7 +54,7 @@ public:
   std::list<double>* plotSamplingHint(RooAbsRealLValue& /*obs*/, double /*xlo*/, double /*xhi*/) const override ;
   bool isBinnedDistribution(const RooArgSet& obs) const override  ;
 
-  void computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
 
   void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
 

--- a/roofit/roofitcore/inc/RooBinSamplingPdf.h
+++ b/roofit/roofitcore/inc/RooBinSamplingPdf.h
@@ -106,7 +106,7 @@ public:
   const RooAbsPdf& pdf() const { return _pdf.arg(); }
   const RooAbsReal& observable() const { return _observable.arg(); }
 
-  void computeBatch(double* output, size_t size, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
 
 protected:
   double evaluate() const override;

--- a/roofit/roofitcore/inc/RooBinWidthFunction.h
+++ b/roofit/roofitcore/inc/RooBinWidthFunction.h
@@ -67,7 +67,7 @@ public:
   bool divideByBinWidth() const { return _divideByBinWidth; }
   const RooHistFunc& histFunc() const { return (*_histFunc); }
   double evaluate() const override;
-  void computeBatch(double* output, size_t size, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
 
 private:
   RooTemplateProxy<const RooHistFunc> _histFunc;

--- a/roofit/roofitcore/inc/RooConstraintSum.h
+++ b/roofit/roofitcore/inc/RooConstraintSum.h
@@ -41,7 +41,7 @@ public:
     return setData(static_cast<RooAbsData const&>(data), cloneData);
   }
 
-  void computeBatch(double* output, size_t size, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
 
   std::unique_ptr<RooAbsArg> compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileContext & ctx) const override;
 

--- a/roofit/roofitcore/inc/RooFit/Detail/BatchModeDataHelpers.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/BatchModeDataHelpers.h
@@ -15,7 +15,7 @@
 #ifndef RooFit_BatchModeDataHelpers_h
 #define RooFit_BatchModeDataHelpers_h
 
-#include <RooFit/Detail/DataMap.h>
+#include <RooFit/EvalContext.h>
 
 #include <ROOT/RSpan.hxx>
 #include <string_view>

--- a/roofit/roofitcore/inc/RooFit/Detail/CodeSquashContext.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/CodeSquashContext.h
@@ -15,7 +15,7 @@
 #define RooFit_Detail_CodeSquashContext_h
 
 #include <RooAbsCollection.h>
-#include <RooFit/Detail/DataMap.h>
+#include <RooFit/EvalContext.h>
 #include <RooNumber.h>
 
 #include <ROOT/RSpan.hxx>

--- a/roofit/roofitcore/inc/RooFit/Evaluator.h
+++ b/roofit/roofitcore/inc/RooFit/Evaluator.h
@@ -15,7 +15,7 @@
 #define RooFit_Evaluator_h
 
 #include <RooAbsReal.h>
-#include <RooFit/Detail/DataMap.h>
+#include <RooFit/EvalContext.h>
 
 #include <RConfig.h>
 
@@ -45,7 +45,7 @@ public:
    std::span<const double> run();
    void setInput(std::string const &name, std::span<const double> inputArray, bool isOnDevice);
    RooArgSet getParameters() const;
-   void print(std::ostream &os) const;
+   void print(std::ostream &os);
 
 private:
    void processVariable(NodeInfo &nodeInfo);
@@ -63,8 +63,8 @@ private:
    const bool _useGPU = false;
    int _nEvaluations = 0;
    bool _needToUpdateOutputSizes = false;
-   RooFit::Detail::DataMap _dataMapCPU;
-   RooFit::Detail::DataMap _dataMapCUDA;
+   RooFit::EvalContext _evalContextCPU;
+   RooFit::EvalContext _evalContextCUDA;
    std::vector<NodeInfo> _nodes; // the ordered computation graph
    std::stack<std::unique_ptr<ChangeOperModeRAII>> _changeOperModeRAIIs;
 };

--- a/roofit/roofitcore/inc/RooFormulaVar.h
+++ b/roofit/roofitcore/inc/RooFormulaVar.h
@@ -73,8 +73,8 @@ public:
 
   // Function evaluation
   double evaluate() const override ;
+  void doEval(RooFit::EvalContext &ctx) const override;
   void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
-  void computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const& dataMap) const override;
 
   protected:
   // Post-processing of server redirection

--- a/roofit/roofitcore/inc/RooGenericPdf.h
+++ b/roofit/roofitcore/inc/RooGenericPdf.h
@@ -66,8 +66,8 @@ protected:
   // Function evaluation
   RooListProxy _actualVars ;
   double evaluate() const override ;
+  void doEval(RooFit::EvalContext &) const override;
   void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
-  void computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const&) const override;
 
   // Post-processing of server redirection
   bool redirectServersHook(const RooAbsCollection& newServerList, bool mustReplaceAll, bool nameChange, bool isRecursive) override ;

--- a/roofit/roofitcore/inc/RooHistFunc.h
+++ b/roofit/roofitcore/inc/RooHistFunc.h
@@ -97,7 +97,7 @@ public:
 
 
   Int_t getBin() const;
-  std::vector<Int_t> getBins(RooFit::Detail::DataMap const& dataMap) const;
+  std::vector<Int_t> getBins(RooFit::EvalContext & ctx) const;
 
   void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
   std::string
@@ -108,7 +108,7 @@ protected:
   bool areIdentical(const RooDataHist& dh1, const RooDataHist& dh2) ;
 
   double evaluate() const override;
-  void computeBatch(double* output, size_t size, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
   friend class RooAbsCachedReal ;
 
   void ioStreamerPass2() override ;

--- a/roofit/roofitcore/inc/RooHistPdf.h
+++ b/roofit/roofitcore/inc/RooHistPdf.h
@@ -93,7 +93,7 @@ public:
   std::list<double>* binBoundaries(RooAbsRealLValue& /*obs*/, double /*xlo*/, double /*xhi*/) const override ;
   bool isBinnedDistribution(const RooArgSet&) const override { return _intOrder==0 ; }
 
-  void computeBatch(double* output, size_t size, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
 
   void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
   std::string

--- a/roofit/roofitcore/inc/RooPolyVar.h
+++ b/roofit/roofitcore/inc/RooPolyVar.h
@@ -46,7 +46,7 @@ protected:
    mutable std::vector<double> _wksp; ///<! do not persist
 
    double evaluate() const override;
-   void computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &) const override;
+   void doEval(RooFit::EvalContext &) const override;
 
    // It doesn't make sense to use the GPU if the polynomial has no terms.
    inline bool canComputeBatchWithCuda() const override { return !_coefList.empty(); }
@@ -54,8 +54,8 @@ protected:
 private:
    friend class RooPolynomial;
 
-   static void computeBatchImpl(RooAbsArg const* caller, double *output, size_t nEvents, RooFit::Detail::DataMap const &,
-                                RooAbsReal const &x, RooArgList const &coefs, int lowestOrder);
+   static void doEvalImpl(RooAbsArg const* caller, RooFit::EvalContext &,
+                          RooAbsReal const &x, RooArgList const &coefs, int lowestOrder);
 
    static void fillCoeffValues(std::vector<double> &wksp, RooListProxy const &coefList);
 

--- a/roofit/roofitcore/inc/RooProdPdf.h
+++ b/roofit/roofitcore/inc/RooProdPdf.h
@@ -160,7 +160,7 @@ private:
   std::unique_ptr<RooAbsReal> specializeIntegral(RooAbsReal& orig, const char* targetRangeName) const ;
   std::unique_ptr<RooAbsReal> specializeRatio(RooFormulaVar& input, const char* targetRangeName) const ;
   double calculate(const RooProdPdf::CacheElem& cache, bool verbose=false) const ;
-  void calculateBatch(RooAbsArg const* caller, const RooProdPdf::CacheElem &cache, double* output, size_t nEvents, RooFit::Detail::DataMap const&) const;
+  void doEvalImpl(RooAbsArg const* caller, const RooProdPdf::CacheElem &cache, RooFit::EvalContext &) const;
 
 
   friend class RooProdGenContext ;

--- a/roofit/roofitcore/inc/RooProduct.h
+++ b/roofit/roofitcore/inc/RooProduct.h
@@ -84,7 +84,7 @@ protected:
 
   double calculate(const RooArgList& partIntList) const;
   double evaluate() const override;
-  void computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
 
   const char* makeFPName(const char *pfx,const RooArgSet& terms) const ;
   ProdMap* groupProductTerms(const RooArgSet&) const;

--- a/roofit/roofitcore/inc/RooRatio.h
+++ b/roofit/roofitcore/inc/RooRatio.h
@@ -33,7 +33,7 @@ public:
 
 protected:
    double evaluate() const override;
-   void computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &) const override;
+   void doEval(RooFit::EvalContext &) const override;
    inline bool canComputeBatchWithCuda() const override { return true; }
 
    void translate(RooFit::Detail::CodeSquashContext &ctx) const override;

--- a/roofit/roofitcore/inc/RooRealSumPdf.h
+++ b/roofit/roofitcore/inc/RooRealSumPdf.h
@@ -35,7 +35,7 @@ public:
   double evaluate() const override ;
   bool checkObservables(const RooArgSet* nset) const override ;
 
-  void computeBatch(double* output, size_t size, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
 
   bool forceAnalyticalInt(const RooAbsArg& arg) const override { return arg.isFundamental() ; }
   Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& numVars, const RooArgSet* normSet, const char* rangeName=nullptr) const override ;

--- a/roofit/roofitcore/inc/RooTruthModel.h
+++ b/roofit/roofitcore/inc/RooTruthModel.h
@@ -38,7 +38,7 @@ public:
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
   double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
 
-  void computeBatch(double* output, size_t size, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
   inline bool canComputeBatchWithCuda() const override { return true; }
 
 protected:

--- a/roofit/roofitcore/src/RooAbsCachedPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsCachedPdf.cxx
@@ -400,10 +400,9 @@ double RooAbsCachedPdf::analyticalIntegralWN(int code, const RooArgSet* normSet,
 }
 
 
-void RooAbsCachedPdf::computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const& dataMap) const
+void RooAbsCachedPdf::doEval(RooFit::EvalContext &ctx) const
 {
-  auto * cachePdf = getCachePdf(_normSet);
-  cachePdf->computeBatch(output, nEvents, dataMap);
+   getCachePdf(_normSet)->doEval(ctx);
 }
 
 

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -127,11 +127,11 @@ the proxy holds a function, and will trigger an assert.
 ### Batched function evaluations (Advanced usage)
 
 To speed up computations with large numbers of data events in unbinned fits,
-it is beneficial to override `computeBatch()`. Like this, large spans of
+it is beneficial to override `doEval()`. Like this, large spans of
 computations can be done, without having to call `evaluate()` for each single data event.
-`computeBatch()` should execute the same computation as `evaluate()`, but it
+`doEval()` should execute the same computation as `evaluate()`, but it
 may choose an implementation that is capable of SIMD computations.
-If computeBatch is not implemented, the classic and slower `evaluate()` will be
+If doEval is not implemented, the classic and slower `evaluate()` will be
 called for each data event.
 */
 

--- a/roofit/roofitcore/src/RooAddModel.cxx
+++ b/roofit/roofitcore/src/RooAddModel.cxx
@@ -375,14 +375,14 @@ double RooAddModel::evaluate() const
   return value ;
 }
 
-void RooAddModel::computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &dataMap) const
+void RooAddModel::doEval(RooFit::EvalContext &ctx) const
 {
    // Like many other functions in this class, the implementation was copy-pasted from the RooAddPdf
-   RooBatchCompute::Config config = dataMap.config(this);
+   RooBatchCompute::Config config = ctx.config(this);
 
    _coefCache.resize(_pdfList.size());
    for (std::size_t i = 0; i < _coefList.size(); ++i) {
-      auto coefVals = dataMap.at(&_coefList[i]);
+      auto coefVals = ctx.at(&_coefList[i]);
       // We don't support per-event coefficients in this function. If the CPU
       // mode is used, we can just fall back to the RooAbsReal implementation.
       // With CUDA, we can't do that because the inputs might be on the device.
@@ -391,7 +391,7 @@ void RooAddModel::computeBatch(double *output, size_t nEvents, RooFit::Detail::D
          if (config.useCuda()) {
             throw std::runtime_error("The RooAddPdf doesn't support per-event coefficients in CUDA mode yet!");
          }
-         RooAbsReal::computeBatch(output, nEvents, dataMap);
+         RooAbsReal::doEval(ctx);
          return;
       }
       _coefCache[i] = coefVals[0];
@@ -405,11 +405,11 @@ void RooAddModel::computeBatch(double *output, size_t nEvents, RooFit::Detail::D
    for (unsigned int pdfNo = 0; pdfNo < _pdfList.size(); ++pdfNo) {
       auto pdf = static_cast<RooAbsPdf *>(&_pdfList[pdfNo]);
       if (pdf->isSelectedComp()) {
-         pdfs.push_back(dataMap.at(pdf));
+         pdfs.push_back(ctx.at(pdf));
          coefs.push_back(_coefCache[pdfNo] / cache->suppNormVal(pdfNo));
       }
    }
-   RooBatchCompute::compute(config, RooBatchCompute::AddPdf, output, nEvents, pdfs, coefs);
+   RooBatchCompute::compute(config, RooBatchCompute::AddPdf, ctx.output(), pdfs, coefs);
 }
 
 

--- a/roofit/roofitcore/src/RooAddition.cxx
+++ b/roofit/roofitcore/src/RooAddition.cxx
@@ -143,17 +143,17 @@ double RooAddition::evaluate() const
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute addition of PDFs in batches.
-void RooAddition::computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &dataMap) const
+void RooAddition::doEval(RooFit::EvalContext &ctx) const
 {
    std::vector<std::span<const double>> pdfs;
    std::vector<double> coefs;
    pdfs.reserve(_set.size());
    coefs.reserve(_set.size());
    for (const auto arg : _set) {
-      pdfs.push_back(dataMap.at(arg));
+      pdfs.push_back(ctx.at(arg));
       coefs.push_back(1.0);
    }
-   RooBatchCompute::compute(dataMap.config(this), RooBatchCompute::AddPdf, output, nEvents, pdfs, coefs);
+   RooBatchCompute::compute(ctx.config(this), RooBatchCompute::AddPdf, ctx.output(), pdfs, coefs);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooBinSamplingPdf.cxx
+++ b/roofit/roofitcore/src/RooBinSamplingPdf.cxx
@@ -160,24 +160,26 @@ double RooBinSamplingPdf::evaluate() const {
 /// Integrate the PDF over all its bins, and return a batch with those values.
 /// \param[in,out] evalData Struct with evaluation data.
 /// \param[in] normSet Normalisation set that's used to evaluate the PDF.
-void RooBinSamplingPdf::computeBatch(double* output, size_t /*size*/, RooFit::Detail::DataMap const& dataMap) const
+void RooBinSamplingPdf::doEval(RooFit::EvalContext &ctx) const
 {
-  // Retrieve binning, which we need to compute the probabilities
-  auto boundaries = binBoundaries();
-  auto xValues = dataMap.at(_observable);
+   std::span<double> output = ctx.output();
 
-  // Important: When the integrator samples x, caching of sub-tree values needs to be off.
-  DisableCachingRAII disableCaching(inhibitDirty());
+   // Retrieve binning, which we need to compute the probabilities
+   auto boundaries = binBoundaries();
+   auto xValues = ctx.at(_observable);
 
-  // Now integrate PDF in each bin:
-  for (unsigned int i=0; i < xValues.size(); ++i) {
-    const double x = xValues[i];
-    const auto upperIt = std::upper_bound(boundaries.begin(), boundaries.end(), x);
-    const unsigned int bin = std::distance(boundaries.begin(), upperIt) - 1;
-    assert(bin < boundaries.size());
+   // Important: When the integrator samples x, caching of sub-tree values needs to be off.
+   DisableCachingRAII disableCaching(inhibitDirty());
 
-    output[i] = integrate(nullptr, boundaries[bin], boundaries[bin+1]) / (boundaries[bin+1]-boundaries[bin]);
-  }
+   // Now integrate PDF in each bin:
+   for (unsigned int i = 0; i < xValues.size(); ++i) {
+      const double x = xValues[i];
+      const auto upperIt = std::upper_bound(boundaries.begin(), boundaries.end(), x);
+      const unsigned int bin = std::distance(boundaries.begin(), upperIt) - 1;
+      assert(bin < boundaries.size());
+
+      output[i] = integrate(nullptr, boundaries[bin], boundaries[bin + 1]) / (boundaries[bin + 1] - boundaries[bin]);
+   }
 }
 
 

--- a/roofit/roofitcore/src/RooBinWidthFunction.cxx
+++ b/roofit/roofitcore/src/RooBinWidthFunction.cxx
@@ -97,26 +97,28 @@ double RooBinWidthFunction::evaluate() const {
 /// Compute bin index for all values of the observable(s) in `evalData`, and return their volumes or inverse volumes, depending
 /// on the configuration chosen in the constructor.
 /// If a bin is not valid, return a volume of 1.
-void RooBinWidthFunction::computeBatch(double* output, size_t, RooFit::Detail::DataMap const& dataMap) const {
-  const RooDataHist& dataHist = _histFunc->dataHist();
-  std::vector<Int_t> bins = _histFunc->getBins(dataMap);
-  auto volumes = dataHist.binVolumes(0, dataHist.numEntries());
+void RooBinWidthFunction::doEval(RooFit::EvalContext &ctx) const
+{
+   std::span<double> output = ctx.output();
+   const RooDataHist &dataHist = _histFunc->dataHist();
+   std::vector<Int_t> bins = _histFunc->getBins(ctx);
+   auto volumes = dataHist.binVolumes(0, dataHist.numEntries());
 
-  if(!_enabled){
-    for (std::size_t i=0; i < bins.size(); ++i) {
-      output[i] = 1.;
-    }
-  } else {
-    if (_divideByBinWidth) {
-      for (std::size_t i=0; i < bins.size(); ++i) {
-        output[i] = bins[i] >= 0 ? 1./volumes[bins[i]] : 1.;
+   if (!_enabled) {
+      for (std::size_t i = 0; i < bins.size(); ++i) {
+         output[i] = 1.;
       }
-    } else {
-      for (std::size_t i=0; i < bins.size(); ++i) {
-        output[i] = bins[i] >= 0 ? volumes[bins[i]] : 1.;
+   } else {
+      if (_divideByBinWidth) {
+         for (std::size_t i = 0; i < bins.size(); ++i) {
+            output[i] = bins[i] >= 0 ? 1. / volumes[bins[i]] : 1.;
+         }
+      } else {
+         for (std::size_t i = 0; i < bins.size(); ++i) {
+            output[i] = bins[i] >= 0 ? volumes[bins[i]] : 1.;
+         }
       }
-    }
-  }
+   }
 }
 
 

--- a/roofit/roofitcore/src/RooClassFactory.cxx
+++ b/roofit/roofitcore/src/RooClassFactory.cxx
@@ -383,7 +383,7 @@ std::string declareVarSpans(std::vector<std::string> const &alist)
    std::stringstream ss;
    for (std::size_t i = 0; i < alist.size(); ++i) {
       ss << "   "
-         << "std::span<const double> " << alist[i] << "Span = dataMap.at(" << alist[i] << ");\n";
+         << "std::span<const double> " << alist[i] << "Span = ctx.at(" << alist[i] << ");\n";
    }
    return ss.str();
 }
@@ -554,7 +554,7 @@ public:
 
   hf << R"(
   double evaluate() const override;
-  void computeBatch(double* output, std::size_t size, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
   void translate(RooFit::Detail::CodeSquashContext &ctx) const override;
 
 private:
@@ -664,12 +664,13 @@ CLASS_NAME::CLASS_NAME(const char *name, const char *title,
      << "   return CLASS_NAME_evaluate(" << listVars(alist) << "); " << endl
      << "}\n"
      << "\n"
-     << "void CLASS_NAME::computeBatch(double *output, std::size_t size, RooFit::Detail::DataMap const &dataMap) const " << endl
+     << "void CLASS_NAME::doEval(RooFit::EvalContext &ctx) const " << endl
      << "{ \n"
      << declareVarSpans(alist)
      << "\n"
-     << "   for (std::size_t i = 0; i < size; ++i) {\n"
-     << "      output[i] = CLASS_NAME_evaluate(" << getFromVarSpans(alist) << ");\n"
+     << "   std::size_t n = ctx.output().size();\n"
+     << "   for (std::size_t i = 0; i < n; ++i) {\n"
+     << "      ctx.output()[i] = CLASS_NAME_evaluate(" << getFromVarSpans(alist) << ");\n"
      << "   }\n"
      << "} \n";
 

--- a/roofit/roofitcore/src/RooConstraintSum.cxx
+++ b/roofit/roofitcore/src/RooConstraintSum.cxx
@@ -84,16 +84,15 @@ void RooConstraintSum::translate(RooFit::Detail::CodeSquashContext &ctx) const
    ctx.addResult(this, ctx.buildCall("RooFit::Detail::EvaluateFuncs::constraintSumEvaluate", _set1, _set1.size()));
 }
 
-void RooConstraintSum::computeBatch(double *output, size_t /*size*/,
-                                    RooFit::Detail::DataMap const &dataMap) const
+void RooConstraintSum::doEval(RooFit::EvalContext &ctx) const
 {
    double sum(0);
 
    for (const auto comp : _set1) {
-      sum -= std::log(dataMap.at(comp)[0]);
+      sum -= std::log(ctx.at(comp)[0]);
    }
 
-   output[0] = sum;
+   ctx.output()[0] = sum;
 }
 
 std::unique_ptr<RooAbsArg> RooConstraintSum::compileForNormSet(RooArgSet const & /*normSet*/, RooFit::Detail::CompileContext & ctx) const

--- a/roofit/roofitcore/src/RooEvaluatorWrapper.h
+++ b/roofit/roofitcore/src/RooEvaluatorWrapper.h
@@ -16,7 +16,7 @@
 #define RooFit_RooEvaluatorWrapper_h
 
 #include <RooAbsData.h>
-#include "RooFit/Detail/DataMap.h"
+#include <RooFit/EvalContext.h>
 #include <RooGlobalFunc.h>
 #include <RooHelpers.h>
 #include <RooRealProxy.h>

--- a/roofit/roofitcore/src/RooFit/EvalContext.cxx
+++ b/roofit/roofitcore/src/RooFit/EvalContext.cxx
@@ -11,7 +11,7 @@
  * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
  */
 
-#include <RooFit/Detail/DataMap.h>
+#include <RooFit/EvalContext.h>
 
 #include <RooBatchCompute.h>
 #include <RooRealVar.h>
@@ -30,9 +30,8 @@ void assignSpan(std::span<T> &to, std::span<T> const &from)
 } // namespace
 
 namespace RooFit {
-namespace Detail {
 
-std::span<const double> DataMap::at(RooAbsArg const *arg, RooAbsArg const * /*caller*/)
+std::span<const double> EvalContext::at(RooAbsArg const *arg, RooAbsArg const * /*caller*/)
 {
    std::span<const double> out;
 
@@ -41,7 +40,7 @@ std::span<const double> DataMap::at(RooAbsArg const *arg, RooAbsArg const * /*ca
       assignSpan(out, {&var->_value, 1});
    } else {
       std::size_t idx = arg->dataToken();
-      out = _dataMap[idx];
+      out = _ctx[idx];
    }
 
    if (!_enableVectorBuffers || out.size() != 1) {
@@ -62,7 +61,7 @@ std::span<const double> DataMap::at(RooAbsArg const *arg, RooAbsArg const * /*ca
    return out;
 }
 
-void DataMap::setConfig(RooAbsArg const *arg, RooBatchCompute::Config const &config)
+void EvalContext::setConfig(RooAbsArg const *arg, RooBatchCompute::Config const &config)
 {
    if (!arg->hasDataToken())
       return;
@@ -70,7 +69,7 @@ void DataMap::setConfig(RooAbsArg const *arg, RooBatchCompute::Config const &con
    _cfgs[idx] = config;
 }
 
-RooBatchCompute::Config DataMap::config(RooAbsArg const *arg) const
+RooBatchCompute::Config EvalContext::config(RooAbsArg const *arg) const
 {
    if (!arg->hasDataToken()) {
       return {};
@@ -79,11 +78,10 @@ RooBatchCompute::Config DataMap::config(RooAbsArg const *arg) const
    return _cfgs[idx];
 }
 
-void DataMap::resize(std::size_t n)
+void EvalContext::resize(std::size_t n)
 {
    _cfgs.resize(n);
-   _dataMap.resize(n);
+   _ctx.resize(n);
 }
 
-} // namespace Detail
 } // namespace RooFit

--- a/roofit/roofitcore/src/RooFormula.h
+++ b/roofit/roofitcore/src/RooFormula.h
@@ -14,7 +14,7 @@
 #include "RooPrintable.h"
 #include "RooArgList.h"
 #include "RooArgSet.h"
-#include "RooFit/Detail/DataMap.h"
+#include "RooFit/EvalContext.h"
 
 #include "TFormula.h"
 
@@ -50,7 +50,7 @@ public:
    bool ok() const { return _tFormula != nullptr; }
    /// Evaluate all parameters/observables, and then evaluate formula.
    double eval(const RooArgSet *nset = nullptr) const;
-   void computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &) const;
+   void doEval(RooFit::EvalContext &) const;
 
    /// DEBUG: Dump state information
    void dump() const;

--- a/roofit/roofitcore/src/RooFormulaVar.cxx
+++ b/roofit/roofitcore/src/RooFormulaVar.cxx
@@ -161,9 +161,9 @@ double RooFormulaVar::evaluate() const
 }
 
 
-void RooFormulaVar::computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const& dataMap) const
+void RooFormulaVar::doEval(RooFit::EvalContext &ctx) const
 {
-  getFormula().computeBatch(output, nEvents, dataMap);
+   getFormula().doEval(ctx);
 }
 
 

--- a/roofit/roofitcore/src/RooGenericPdf.cxx
+++ b/roofit/roofitcore/src/RooGenericPdf.cxx
@@ -135,9 +135,9 @@ double RooGenericPdf::evaluate() const
 
 
 ////////////////////////////////////////////////////////////////////////////////
-void RooGenericPdf::computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const& dataMap) const
+void RooGenericPdf::doEval(RooFit::EvalContext & ctx) const
 {
-  formula().computeBatch(output, nEvents, dataMap);
+  formula().doEval(ctx);
 }
 
 

--- a/roofit/roofitcore/src/RooHistFunc.cxx
+++ b/roofit/roofitcore/src/RooHistFunc.cxx
@@ -195,10 +195,14 @@ void RooHistFunc::translate(RooFit::Detail::CodeSquashContext &ctx) const
    RooHistPdf::rooHistTranslateImpl(this, ctx, _intOrder, _dataHist, _depList, false);
 }
 
-void RooHistFunc::computeBatch(double* output, size_t size, RooFit::Detail::DataMap const& dataMap) const {
+void RooHistFunc::doEval(RooFit::EvalContext & ctx) const
+{
+  std::span<double> output = ctx.output();
+  std::size_t nEvents = output.size();
+
   if (_depList.size() == 1) {
-    auto xVals = dataMap.at(_depList[0]);
-    _dataHist->weights(output, xVals, _intOrder, false, _cdfBoundaries);
+    auto xVals = ctx.at(_depList[0]);
+    _dataHist->weights(output.data(), xVals, _intOrder, false, _cdfBoundaries);
     return;
   }
 
@@ -206,13 +210,13 @@ void RooHistFunc::computeBatch(double* output, size_t size, RooFit::Detail::Data
   for (const auto& obs : _depList) {
     auto realObs = dynamic_cast<const RooAbsReal*>(obs);
     if (realObs) {
-      inputValues.push_back(dataMap.at(realObs));
+      inputValues.push_back(ctx.at(realObs));
     } else {
       inputValues.emplace_back();
     }
   }
 
-  for (std::size_t i = 0; i < size; ++i) {
+  for (std::size_t i = 0; i < nEvents; ++i) {
     bool skip = false;
 
     for (auto j = 0u; j < _histObsList.size(); ++j) {
@@ -563,12 +567,12 @@ Int_t RooHistFunc::getBin() const {
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute bin numbers corresponding to all coordinates in `evalData`.
 /// \return Vector of bin numbers. If a bin is not in the current range of the observables, return -1.
-std::vector<Int_t> RooHistFunc::getBins(RooFit::Detail::DataMap const& dataMap) const {
+std::vector<Int_t> RooHistFunc::getBins(RooFit::EvalContext & ctx) const {
   std::vector<std::span<const double>> depData;
   for (const auto dep : _depList) {
     auto real = dynamic_cast<const RooAbsReal*>(dep);
     if (real) {
-      depData.push_back(dataMap.at(real));
+      depData.push_back(ctx.at(real));
     } else {
       depData.emplace_back();
     }

--- a/roofit/roofitcore/src/RooHistPdf.cxx
+++ b/roofit/roofitcore/src/RooHistPdf.cxx
@@ -181,16 +181,18 @@ RooDataHist* RooHistPdf::cloneAndOwnDataHist(const char* newname) {
    return _dataHist;
 }
 
-void RooHistPdf::computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const& dataMap) const {
+void RooHistPdf::doEval(RooFit::EvalContext &ctx) const
+{
+   std::span<double> output = ctx.output();
 
-  // For interpolation and histograms of higher dimension, use base function
-  if(_pdfObsList.size() > 1) {
-      RooAbsReal::computeBatch(output, nEvents, dataMap);
+   // For interpolation and histograms of higher dimension, use base function
+   if (_pdfObsList.size() > 1) {
+      RooAbsReal::doEval(ctx);
       return;
-  }
+   }
 
-  auto xVals = dataMap.at(_pdfObsList[0]);
-  _dataHist->weights(output, xVals, _intOrder, true, _cdfBoundaries);
+   auto xVals = ctx.at(_pdfObsList[0]);
+   _dataHist->weights(output.data(), xVals, _intOrder, true, _cdfBoundaries);
 }
 
 

--- a/roofit/roofitcore/src/RooNLLVarNew.h
+++ b/roofit/roofitcore/src/RooNLLVarNew.h
@@ -40,7 +40,7 @@ public:
    /// Return default level for MINUIT error analysis.
    double defaultErrorLevel() const override { return 0.5; }
 
-   void computeBatch(double *output, size_t nOut, RooFit::Detail::DataMap const &) const override;
+   void doEval(RooFit::EvalContext &) const override;
    bool canComputeBatchWithCuda() const override { return !_binnedL; }
    bool isReducerNode() const override { return true; }
 
@@ -61,7 +61,7 @@ private:
    void resetWeightVarNames();
    double finalizeResult(ROOT::Math::KahanSum<double> result, double weightSum) const;
    void fillBinWidthsFromPdfBoundaries(RooAbsReal const &pdf, RooArgSet const &observables);
-   double computeBatchBinnedL(std::span<const double> preds, std::span<const double> weights) const;
+   double doEvalBinnedL(std::span<const double> preds, std::span<const double> weights) const;
 
    RooTemplateProxy<RooAbsPdf> _pdf;
    RooTemplateProxy<RooAbsReal> _weightVar;

--- a/roofit/roofitcore/src/RooNormalizedPdf.cxx
+++ b/roofit/roofitcore/src/RooNormalizedPdf.cxx
@@ -22,15 +22,15 @@
  * normalization set into a new self-normalized pdf.
  */
 
-void RooNormalizedPdf::computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &dataMap) const
+void RooNormalizedPdf::doEval(RooFit::EvalContext &ctx) const
 {
-   auto nums = dataMap.at(_pdf);
-   auto integralSpan = dataMap.at(_normIntegral);
+   auto nums = ctx.at(_pdf);
+   auto integralSpan = ctx.at(_normIntegral);
 
    // We use the extraArgs as output parameter to count evaluation errors.
    std::array<double, 3> extraArgs{0.0, 0.0, 0.0};
 
-   RooBatchCompute::compute(dataMap.config(this), RooBatchCompute::NormalizedPdf, output, nEvents, {nums, integralSpan},
+   RooBatchCompute::compute(ctx.config(this), RooBatchCompute::NormalizedPdf, ctx.output(), {nums, integralSpan},
                             extraArgs);
 
    std::size_t nEvalErrorsType0 = extraArgs[0];

--- a/roofit/roofitcore/src/RooNormalizedPdf.h
+++ b/roofit/roofitcore/src/RooNormalizedPdf.h
@@ -70,7 +70,7 @@ public:
    bool canComputeBatchWithCuda() const override { return true; }
 
 protected:
-   void computeBatch(double *output, size_t size, RooFit::Detail::DataMap const &) const override;
+   void doEval(RooFit::EvalContext &) const override;
    double evaluate() const override
    {
       // Evaluate() should not be called in the BatchMode, but we still need it

--- a/roofit/roofitcore/src/RooProduct.cxx
+++ b/roofit/roofitcore/src/RooProduct.cxx
@@ -371,15 +371,18 @@ double RooProduct::evaluate() const
 }
 
 
-void RooProduct::computeBatch(double* output, size_t nEvents, RooFit::Detail::DataMap const& dataMap) const
+void RooProduct::doEval(RooFit::EvalContext & ctx) const
 {
+  std::span<double> output = ctx.output();
+  std::size_t nEvents = output.size();
+
   for (unsigned int i = 0; i < nEvents; ++i) {
     output[i] = 1.;
   }
 
   for (const auto item : _compRSet) {
     auto rcomp = static_cast<const RooAbsReal*>(item);
-    auto componentValues = dataMap.at(rcomp);
+    auto componentValues = ctx.at(rcomp);
 
     for (unsigned int i = 0; i < nEvents; ++i) {
       output[i] *= componentValues.size() == 1 ? componentValues[0] : componentValues[i];

--- a/roofit/roofitcore/src/RooRatio.cxx
+++ b/roofit/roofitcore/src/RooRatio.cxx
@@ -118,10 +118,10 @@ double RooRatio::evaluate() const
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Evaluate in batch mode.
-void RooRatio::computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &dataMap) const
+void RooRatio::doEval(RooFit::EvalContext &ctx) const
 {
-   RooBatchCompute::compute(dataMap.config(this), RooBatchCompute::Ratio, output, nEvents,
-                            {dataMap.at(_numerator), dataMap.at(_denominator)});
+   RooBatchCompute::compute(ctx.config(this), RooBatchCompute::Ratio, ctx.output(),
+                            {ctx.at(_numerator), ctx.at(_denominator)});
 }
 
 void RooRatio::translate(RooFit::Detail::CodeSquashContext &ctx) const

--- a/roofit/roofitcore/src/RooTruthModel.cxx
+++ b/roofit/roofitcore/src/RooTruthModel.cxx
@@ -236,20 +236,20 @@ double RooTruthModel::evaluate() const
 }
 
 
-void RooTruthModel::computeBatch(double *output, size_t nEvents, RooFit::Detail::DataMap const &dataMap) const
+void RooTruthModel::doEval(RooFit::EvalContext &ctx) const
 {
-   auto config = dataMap.config(this);
-   auto xVals = dataMap.at(x);
+   auto config = ctx.config(this);
+   auto xVals = ctx.at(x);
 
    // No basis: delta function
    if (_basisCode == noBasis) {
-      RooBatchCompute::compute(config, RooBatchCompute::DeltaFunction, output, nEvents, {xVals});
+      RooBatchCompute::compute(config, RooBatchCompute::DeltaFunction, ctx.output(), {xVals});
       return;
    }
 
    // Generic basis: evaluate basis function object
    if (_basisCode == genericBasis) {
-      RooBatchCompute::compute(config, RooBatchCompute::Identity, output, nEvents, {dataMap.at(&basis())});
+      RooBatchCompute::compute(config, RooBatchCompute::Identity, ctx.output(), {ctx.at(&basis())});
       return;
    }
 
@@ -262,44 +262,44 @@ void RooTruthModel::computeBatch(double *output, size_t nEvents, RooFit::Detail:
 
    auto param1 = static_cast<RooAbsReal const *>(basis().getParameter(1));
    auto param2 = static_cast<RooAbsReal const *>(basis().getParameter(2));
-   auto param1Vals = param1 ? dataMap.at(param1) : std::span<const double>{};
-   auto param2Vals = param2 ? dataMap.at(param2) : std::span<const double>{};
+   auto param1Vals = param1 ? ctx.at(param1) : std::span<const double>{};
+   auto param2Vals = param2 ? ctx.at(param2) : std::span<const double>{};
 
    // Return desired basis function
    std::array<double, 1> extraArgs{basisSign};
    switch (basisType) {
    case expBasis: {
-      RooBatchCompute::compute(config, RooBatchCompute::TruthModelExpBasis, output, nEvents, {xVals, param1Vals},
+      RooBatchCompute::compute(config, RooBatchCompute::TruthModelExpBasis, ctx.output(), {xVals, param1Vals},
                                extraArgs);
       break;
    }
    case sinBasis: {
-      RooBatchCompute::compute(config, RooBatchCompute::TruthModelSinBasis, output, nEvents,
+      RooBatchCompute::compute(config, RooBatchCompute::TruthModelSinBasis, ctx.output(),
                                {xVals, param1Vals, param2Vals}, extraArgs);
       break;
    }
    case cosBasis: {
-      RooBatchCompute::compute(config, RooBatchCompute::TruthModelCosBasis, output, nEvents,
+      RooBatchCompute::compute(config, RooBatchCompute::TruthModelCosBasis, ctx.output(),
                                {xVals, param1Vals, param2Vals}, extraArgs);
       break;
    }
    case linBasis: {
-      RooBatchCompute::compute(config, RooBatchCompute::TruthModelLinBasis, output, nEvents, {xVals, param1Vals},
+      RooBatchCompute::compute(config, RooBatchCompute::TruthModelLinBasis, ctx.output(), {xVals, param1Vals},
                                extraArgs);
       break;
    }
    case quadBasis: {
-      RooBatchCompute::compute(config, RooBatchCompute::TruthModelQuadBasis, output, nEvents, {xVals, param1Vals},
+      RooBatchCompute::compute(config, RooBatchCompute::TruthModelQuadBasis, ctx.output(), {xVals, param1Vals},
                                extraArgs);
       break;
    }
    case sinhBasis: {
-      RooBatchCompute::compute(config, RooBatchCompute::TruthModelSinhBasis, output, nEvents,
+      RooBatchCompute::compute(config, RooBatchCompute::TruthModelSinhBasis, ctx.output(),
                                {xVals, param1Vals, param2Vals}, extraArgs);
       break;
    }
    case coshBasis: {
-      RooBatchCompute::compute(config, RooBatchCompute::TruthModelCoshBasis, output, nEvents,
+      RooBatchCompute::compute(config, RooBatchCompute::TruthModelCoshBasis, ctx.output(),
                                {xVals, param1Vals, param2Vals}, extraArgs);
       break;
    }

--- a/roofit/roofitmore/inc/RooHypatia2.h
+++ b/roofit/roofitmore/inc/RooHypatia2.h
@@ -52,7 +52,7 @@ private:
   RooRealProxy _n2;
 
   double evaluate() const override;
-  void computeBatch(double* output, size_t size, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
 
   /// \cond CLASS_DEF_DOXY
   ClassDefOverride(RooHypatia2, 1);

--- a/roofit/roofitmore/inc/RooLegendre.h
+++ b/roofit/roofitmore/inc/RooLegendre.h
@@ -41,7 +41,7 @@ protected: // allow RooSpHarmonic access...
   int _l2,_m2;
 
   double evaluate() const override;
-  void computeBatch(double* output, size_t size, RooFit::Detail::DataMap const&) const override;
+  void doEval(RooFit::EvalContext &) const override;
 
   ClassDefOverride(RooLegendre,1) // Legendre polynomial
 };

--- a/roofit/roofitmore/src/RooHypatia2.cxx
+++ b/roofit/roofitmore/src/RooHypatia2.cxx
@@ -471,36 +471,35 @@ void compute(std::span<double> output, std::span<const double> x,
 
 }
 
-void RooHypatia2::computeBatch(double* output, size_t size, RooFit::Detail::DataMap const& dataMap) const
+void RooHypatia2::doEval(RooFit::EvalContext & ctx) const
 {
   using namespace RooBatchCompute;
 
-  auto x = dataMap.at(_x);
-  auto lambda = dataMap.at(_lambda);
-  auto zeta = dataMap.at(_zeta);
-  auto beta = dataMap.at(_beta);
-  auto sig = dataMap.at(_sigma);
-  auto mu = dataMap.at(_mu);
-  auto a = dataMap.at(_a);
-  auto n = dataMap.at(_n);
-  auto a2 = dataMap.at(_a2);
-  auto n2 = dataMap.at(_n2);
+  auto x = ctx.at(_x);
+  auto lambda = ctx.at(_lambda);
+  auto zeta = ctx.at(_zeta);
+  auto beta = ctx.at(_beta);
+  auto sig = ctx.at(_sigma);
+  auto mu = ctx.at(_mu);
+  auto a = ctx.at(_a);
+  auto n = ctx.at(_n);
+  auto a2 = ctx.at(_a2);
+  auto n2 = ctx.at(_n2);
 
   size_t paramSizeSum=0;
   for (const auto& i:{lambda, zeta, beta, sig, mu, a, n, a2, n2}) {
     paramSizeSum += i.size();
   }
-  std::span<double> outputSpan{output, size};
 
   // Run high performance compute if only x has multiple values
   if (x.size()>1 && paramSizeSum==9) {
-    compute(outputSpan, x,
+    compute(ctx.output(), x,
         BracketAdapter<double>(_lambda), BracketAdapter<double>(_zeta),
         BracketAdapter<double>(_beta), BracketAdapter<double>(_sigma), BracketAdapter<double>(_mu),
         BracketAdapter<double>(_a), BracketAdapter<double>(_n),
         BracketAdapter<double>(_a2), BracketAdapter<double>(_n2));
   } else {
-    compute(outputSpan, BracketAdapterWithMask(_x, x),
+    compute(ctx.output(), BracketAdapterWithMask(_x, x),
         BracketAdapterWithMask(_lambda, lambda), BracketAdapterWithMask(_zeta, zeta),
         BracketAdapterWithMask(_beta, beta), BracketAdapterWithMask(_sigma, sig),
         BracketAdapterWithMask(_mu, mu),

--- a/roofit/roofitmore/src/RooLegendre.cxx
+++ b/roofit/roofitmore/src/RooLegendre.cxx
@@ -143,9 +143,9 @@ void compute(  size_t batchSize, const int l1, const int m1, const int l2, const
 }
 };
 
-void RooLegendre::computeBatch(double* output, size_t size, RooFit::Detail::DataMap const& dataMap) const
+void RooLegendre::doEval(RooFit::EvalContext &ctx) const
 {
-  compute(size, _l1, _m1, _l2, _m2, output, dataMap.at(_ctheta).data());
+   compute(ctx.output().size(), _l1, _m1, _l2, _m2, ctx.output().data(), ctx.at(_ctheta).data());
 }
 
 


### PR DESCRIPTION
So far, the signature for the function that is called for the vectorized evaluation was this one:

```c++
void RooAbsReal::computeBatch(double* output, size_t nEvents,
                              RooFit::Detail::DataMap const& dataMap) const
```

This commit is suggesting a new signature:

```c++
void doEval(RooFit::EvalContext & ctx) const;
```

The idea is to make the signature as short as possible, so it doesn't have to be changed anymore if more information needs to be passed. That's why the only parameter is now an `EvalContext` object, reminicint of the old `RunContext` object that fulfilled this task in the very first implementation of the BatchMode by Stephan.

The name is now simply `doEval`, because the overloaded term "Batch" should be dropped. It needed to be something with "evaluate", because there is also `RooAbsReal::evaluate()` and we are talking about "evaluation backends".

The motivation to change this interface now is because I want to write a documentation for developers (like CMS combine mainteiners) on how to use these new interfaces. And if they start to use it, the interfaces should not change anymore.

Than's why I'm doing this change now, which I had in mind already for some time.