### PR TITLE
Fix [TF1,TF2,TF3] Save methods

### DIFF
--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -2345,15 +2345,15 @@ Double_t TF1::GetSave(const Double_t *xx)
 {
    if (fSave.empty()) return 0;
    //if (fSave == 0) return 0;
-   int fNsave = fSave.size();
+   int nsave = fSave.size();
    Double_t x    = Double_t(xx[0]);
    Double_t y, dx, xmin, xmax, xlow, xup, ylow, yup;
    if (fParent && fParent->InheritsFrom(TH1::Class())) {
       //if parent is a histogram the function had been saved at the center of the bins
       //we make a linear interpolation between the saved values
-      xmin = fSave[fNsave - 3];
-      xmax = fSave[fNsave - 2];
-      if (fSave[fNsave - 1] == xmax) {
+      xmin = fSave[nsave - 3];
+      xmax = fSave[nsave - 2];
+      if (fSave[nsave - 1] == xmax) {
          TH1 *h = (TH1 *)fParent;
          TAxis *xaxis = h->GetXaxis();
          Int_t bin1  = xaxis->FindBin(xmin);
@@ -2375,9 +2375,9 @@ Double_t TF1::GetSave(const Double_t *xx)
          return y;
       }
    }
-   Int_t np = fNsave - 3;
-   xmin = Double_t(fSave[np + 1]);
-   xmax = Double_t(fSave[np + 2]);
+   Int_t np = nsave - 3;
+   xmin = fSave[np + 1];
+   xmax = fSave[np + 2];
    dx   = (xmax - xmin) / np;
    if (x < xmin || x > xmax) return 0;
    // return a Nan in case of x=nan, otherwise will crash later

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -2384,7 +2384,7 @@ Double_t TF1::GetSave(const Double_t *xx)
    if (TMath::IsNaN(x)) return x;
    if (dx <= 0) return 0;
 
-   Int_t bin     = Int_t((x - xmin) / dx);
+   Int_t bin = TMath::Min(np - 1, Int_t((x - xmin) / dx));
    xlow = xmin + bin * dx;
    xup  = xlow + dx;
    ylow = fSave[bin];

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -3160,6 +3160,9 @@ void TF1::ReleaseParameter(Int_t ipar)
 
 void TF1::Save(Double_t xmin, Double_t xmax, Double_t, Double_t, Double_t, Double_t)
 {
+   if (!fSave.empty())
+      fSave.clear();
+
    Double_t *parameters = GetParameters();
    //if (fSave != 0) {delete [] fSave; fSave = 0;}
    if (fParent && fParent->InheritsFrom(TH1::Class())) {
@@ -3168,9 +3171,8 @@ void TF1::Save(Double_t xmin, Double_t xmax, Double_t, Double_t, Double_t, Doubl
          TH1 *h = (TH1 *)fParent;
          Int_t bin1 = h->GetXaxis()->FindBin(xmin);
          Int_t bin2 = h->GetXaxis()->FindBin(xmax);
-         int fNsave = bin2 - bin1 + 4;
-         //fSave  = new Double_t[fNsave];
-         fSave.resize(fNsave);
+         int nsave = bin2 - bin1 + 4;
+         fSave.resize(nsave);
          Double_t xv[1];
 
          InitArgs(xv, parameters);
@@ -3178,33 +3180,35 @@ void TF1::Save(Double_t xmin, Double_t xmax, Double_t, Double_t, Double_t, Doubl
             xv[0]    = h->GetXaxis()->GetBinCenter(i);
             fSave[i - bin1] = EvalPar(xv, parameters);
          }
-         fSave[fNsave - 3] = xmin;
-         fSave[fNsave - 2] = xmax;
-         fSave[fNsave - 1] = xmax;
+         fSave[nsave - 3] = xmin;
+         fSave[nsave - 2] = xmax;
+         fSave[nsave - 1] = xmax;
          return;
       }
    }
-   int fNsave = fNpx + 3;
-   if (fNsave <= 3) {
+
+   Int_t npx = fNpx;
+   if (npx <= 0)
       return;
-   }
-   //fSave  = new Double_t[fNsave];
-   fSave.resize(fNsave);
+
    Double_t dx = (xmax - xmin) / fNpx;
    if (dx <= 0) {
       dx = (fXmax - fXmin) / fNpx;
-      fNsave--;
+      npx--;
       xmin = fXmin + 0.5 * dx;
       xmax = fXmax - 0.5 * dx;
    }
+   if (npx <= 0)
+      return;
+   fSave.resize(npx + 3);
    Double_t xv[1];
    InitArgs(xv, parameters);
-   for (Int_t i = 0; i <= fNpx; i++) {
+   for (Int_t i = 0; i <= npx; i++) {
       xv[0]    = xmin + dx * i;
       fSave[i] = EvalPar(xv, parameters);
    }
-   fSave[fNpx + 1] = xmin;
-   fSave[fNpx + 2] = xmax;
+   fSave[npx + 1] = xmin;
+   fSave[npx + 2] = xmax;
 }
 
 

--- a/hist/hist/src/TF2.cxx
+++ b/hist/hist/src/TF2.cxx
@@ -622,16 +622,14 @@ void TF2::GetRange(Double_t &xmin, Double_t &ymin, Double_t &zmin, Double_t &xma
 
 Double_t TF2::GetSave(const Double_t *xx)
 {
-   //if (fNsave <= 0) return 0;
-   if (fSave.empty()) return 0;
-   Int_t fNsave = fSave.size();
-   Int_t np = fNsave - 6;
-   Double_t xmin = Double_t(fSave[np+0]);
-   Double_t xmax = Double_t(fSave[np+1]);
-   Double_t ymin = Double_t(fSave[np+2]);
-   Double_t ymax = Double_t(fSave[np+3]);
-   Int_t npx     = Int_t(fSave[np+4]);
-   Int_t npy     = Int_t(fSave[np+5]);
+   if (fSave.size() < 6) return 0;
+   Int_t nsave = fSave.size() - 6;
+   Double_t xmin = fSave[nsave+0];
+   Double_t xmax = fSave[nsave+1];
+   Double_t ymin = fSave[nsave+2];
+   Double_t ymax = fSave[nsave+3];
+   Int_t npx     = Int_t(fSave[nsave+4]);
+   Int_t npy     = Int_t(fSave[nsave+5]);
    Double_t x    = Double_t(xx[0]);
    Double_t dx   = (xmax-xmin)/npx;
    if (x < xmin || x > xmax) return 0;
@@ -797,43 +795,47 @@ void TF2::Paint(Option_t *option)
 
 void TF2::Save(Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Double_t, Double_t)
 {
-   if (!fSave.empty()) fSave.clear();
-   //if (fSave != 0) {delete [] fSave; fSave = 0;}
-   Int_t nsave = (fNpx+1)*(fNpy+1);
-   Int_t fNsave = nsave+6;
-   if (fNsave <= 6) {fNsave=0; return;}
-   //fSave  = new Double_t[fNsave];
-   fSave.resize(fNsave);
-   Int_t i,j,k=0;
+   if (!fSave.empty())
+      fSave.clear();
+   Int_t npx = fNpx, npy = fNpy;
+   if ((npx <= 0) || (npy <= 0))
+      return;
    Double_t dx = (xmax-xmin)/fNpx;
    Double_t dy = (ymax-ymin)/fNpy;
    if (dx <= 0) {
       dx = (fXmax-fXmin)/fNpx;
-      xmin = fXmin +0.5*dx;
-      xmax = fXmax -0.5*dx;
+      npx--;
+      xmin = fXmin + 0.5*dx;
+      xmax = fXmax - 0.5*dx;
    }
    if (dy <= 0) {
       dy = (fYmax-fYmin)/fNpy;
-      ymin = fYmin +0.5*dy;
-      ymax = fYmax -0.5*dy;
+      npy--;
+      ymin = fYmin + 0.5*dy;
+      ymax = fYmax - 0.5*dy;
    }
+
+   if ((npx <= 0) || (npy <= 0))
+      return;
+
+   Int_t nsave = (npx + 1) * (npy + 1);
+   fSave.resize(nsave + 6);
    Double_t xv[2];
    Double_t *parameters = GetParameters();
-   InitArgs(xv,parameters);
-   for (j=0;j<=fNpy;j++) {
+   InitArgs(xv, parameters);
+   for (Int_t j = 0, k = 0; j <= npy; j++) {
       xv[1]    = ymin + dy*j;
-      for (i=0;i<=fNpx;i++) {
+      for (Int_t i = 0; i <= npx; i++) {
          xv[0]    = xmin + dx*i;
-         fSave[k] = EvalPar(xv,parameters);
-         k++;
+         fSave[k++] = EvalPar(xv, parameters);
       }
    }
    fSave[nsave+0] = xmin;
    fSave[nsave+1] = xmax;
    fSave[nsave+2] = ymin;
    fSave[nsave+3] = ymax;
-   fSave[nsave+4] = fNpx;
-   fSave[nsave+5] = fNpy;
+   fSave[nsave+4] = npx;
+   fSave[nsave+5] = npy;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/TF2.cxx
+++ b/hist/hist/src/TF2.cxx
@@ -640,8 +640,8 @@ Double_t TF2::GetSave(const Double_t *xx)
    if (dy <= 0) return 0;
 
    //we make a bilinear interpolation using the 4 points surrounding x,y
-   Int_t ibin    = Int_t((x-xmin)/dx);
-   Int_t jbin    = Int_t((y-ymin)/dy);
+   Int_t ibin    = TMath::Min(npx-1, Int_t((x-xmin)/dx));
+   Int_t jbin    = TMath::Min(npy-1, Int_t((y-ymin)/dy));
    Double_t xlow = xmin + ibin*dx;
    Double_t ylow = ymin + jbin*dy;
    Double_t t    = (x-xlow)/dx;
@@ -798,7 +798,7 @@ void TF2::Save(Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Doubl
    if (!fSave.empty())
       fSave.clear();
    Int_t npx = fNpx, npy = fNpy;
-   if ((npx <= 0) || (npy <= 0))
+   if ((npx < 2) || (npy < 2))
       return;
    Double_t dx = (xmax-xmin)/fNpx;
    Double_t dy = (ymax-ymin)/fNpy;
@@ -814,9 +814,6 @@ void TF2::Save(Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Doubl
       ymin = fYmin + 0.5*dy;
       ymax = fYmax - 0.5*dy;
    }
-
-   if ((npx <= 0) || (npy <= 0))
-      return;
 
    Int_t nsave = (npx + 1) * (npy + 1);
    fSave.resize(nsave + 6);

--- a/hist/hist/src/TF3.cxx
+++ b/hist/hist/src/TF3.cxx
@@ -439,9 +439,9 @@ Double_t TF3::GetSave(const Double_t *xx)
    if (dz <= 0) return 0;
 
    //we make a trilinear interpolation using the 8 points surrounding x,y,z
-   Int_t ibin    = Int_t((x-xmin)/dx);
-   Int_t jbin    = Int_t((y-ymin)/dy);
-   Int_t kbin    = Int_t((z-zmin)/dz);
+   Int_t ibin    = TMath::Min(npx-1, Int_t((x-xmin)/dx));
+   Int_t jbin    = TMath::Min(npy-1, Int_t((y-ymin)/dy));
+   Int_t kbin    = TMath::Min(npz-1, Int_t((z-zmin)/dz));
    Double_t xlow = xmin + ibin*dx;
    Double_t ylow = ymin + jbin*dy;
    Double_t zlow = zmin + kbin*dz;
@@ -552,7 +552,7 @@ void TF3::Save(Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Doubl
 {
    if (!fSave.empty()) fSave.clear();
    Int_t npx = fNpx, npy = fNpy, npz = fNpz;
-   if ((npx <= 0) || (npy <= 0))
+   if ((npx < 2) || (npy < 2) || (npz < 2))
       return;
 
    Double_t dx = (xmax-xmin)/fNpx;

--- a/hist/hist/src/TF3.cxx
+++ b/hist/hist/src/TF3.cxx
@@ -414,27 +414,26 @@ void TF3::GetRange(Double_t &xmin, Double_t &ymin, Double_t &zmin, Double_t &xma
 
 Double_t TF3::GetSave(const Double_t *xx)
 {
-   //if (fNsave <= 0) return 0;
-   if (fSave.empty()) return 0;
-   Int_t np = fSave.size() - 9;
-   Double_t xmin = Double_t(fSave[np+0]);
-   Double_t xmax = Double_t(fSave[np+1]);
-   Double_t ymin = Double_t(fSave[np+2]);
-   Double_t ymax = Double_t(fSave[np+3]);
-   Double_t zmin = Double_t(fSave[np+4]);
-   Double_t zmax = Double_t(fSave[np+5]);
-   Int_t npx     = Int_t(fSave[np+6]);
-   Int_t npy     = Int_t(fSave[np+7]);
-   Int_t npz     = Int_t(fSave[np+8]);
-   Double_t x    = Double_t(xx[0]);
+   if (fSave.size() < 9) return 0;
+   Int_t nsave = fSave.size() - 9;
+   Double_t xmin = fSave[nsave+0];
+   Double_t xmax = fSave[nsave+1];
+   Double_t ymin = fSave[nsave+2];
+   Double_t ymax = fSave[nsave+3];
+   Double_t zmin = fSave[nsave+4];
+   Double_t zmax = fSave[nsave+5];
+   Int_t npx     = Int_t(fSave[nsave+6]);
+   Int_t npy     = Int_t(fSave[nsave+7]);
+   Int_t npz     = Int_t(fSave[nsave+8]);
+   Double_t x    = xx[0];
    Double_t dx   = (xmax-xmin)/npx;
    if (x < xmin || x > xmax) return 0;
    if (dx <= 0) return 0;
-   Double_t y    = Double_t(xx[1]);
+   Double_t y    = xx[1];
    Double_t dy   = (ymax-ymin)/npy;
    if (y < ymin || y > ymax) return 0;
    if (dy <= 0) return 0;
-   Double_t z    = Double_t(xx[2]);
+   Double_t z    = xx[2];
    Double_t dz   = (zmax-zmin)/npz;
    if (z < zmin || z > zmax) return 0;
    if (dz <= 0) return 0;
@@ -552,41 +551,43 @@ void TF3::SetClippingBoxOff()
 void TF3::Save(Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Double_t zmin, Double_t zmax)
 {
    if (!fSave.empty()) fSave.clear();
-   Int_t nsave = (fNpx+1)*(fNpy+1)*(fNpz+1);
-   Int_t fNsave = nsave+9;
-   assert(fNsave > 9);
-   //fSave  = new Double_t[fNsave];
-   fSave.resize(fNsave);
-   Int_t i,j,k,l=0;
+   Int_t npx = fNpx, npy = fNpy, npz = fNpz;
+   if ((npx <= 0) || (npy <= 0))
+      return;
+
    Double_t dx = (xmax-xmin)/fNpx;
    Double_t dy = (ymax-ymin)/fNpy;
    Double_t dz = (zmax-zmin)/fNpz;
    if (dx <= 0) {
       dx = (fXmax-fXmin)/fNpx;
-      xmin = fXmin +0.5*dx;
-      xmax = fXmax -0.5*dx;
+      npx--;
+      xmin = fXmin + 0.5*dx;
+      xmax = fXmax - 0.5*dx;
    }
    if (dy <= 0) {
       dy = (fYmax-fYmin)/fNpy;
-      ymin = fYmin +0.5*dy;
-      ymax = fYmax -0.5*dy;
+      npy--;
+      ymin = fYmin + 0.5*dy;
+      ymax = fYmax - 0.5*dy;
    }
    if (dz <= 0) {
       dz = (fZmax-fZmin)/fNpz;
-      zmin = fZmin +0.5*dz;
-      zmax = fZmax -0.5*dz;
+      npz--;
+      zmin = fZmin + 0.5*dz;
+      zmax = fZmax - 0.5*dz;
    }
+   Int_t nsave = (npx + 1)*(npy + 1)*(npz + 1);
+   fSave.resize(nsave + 9);
    Double_t xv[3];
    Double_t *pp = GetParameters();
    InitArgs(xv,pp);
-   for (k=0;k<=fNpz;k++) {
+   for (Int_t k = 0, l = 0; k <= npz; k++) {
       xv[2]    = zmin + dz*k;
-      for (j=0;j<=fNpy;j++) {
+      for (Int_t j = 0; j <= npy; j++) {
          xv[1]    = ymin + dy*j;
-         for (i=0;i<=fNpx;i++) {
+         for (Int_t i = 0; i <= npx; i++) {
             xv[0]    = xmin + dx*i;
-            fSave[l] = EvalPar(xv,pp);
-            l++;
+            fSave[l++] = EvalPar(xv, pp);
          }
       }
    }
@@ -596,9 +597,9 @@ void TF3::Save(Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Doubl
    fSave[nsave+3] = ymax;
    fSave[nsave+4] = zmin;
    fSave[nsave+5] = zmax;
-   fSave[nsave+6] = fNpx;
-   fSave[nsave+7] = fNpy;
-   fSave[nsave+8] = fNpz;
+   fSave[nsave+6] = npx;
+   fSave[nsave+7] = npy;
+   fSave[nsave+8] = npz;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/test/CMakeLists.txt
+++ b/hist/hist/test/CMakeLists.txt
@@ -23,6 +23,8 @@ if(fftw3)
   ROOT_ADD_GTEST(testTF1 test_tf1.cxx LIBRARIES Hist)
 endif()
 
+ROOT_ADD_GTEST(testTF2 test_tf2.cxx LIBRARIES Hist)
+
 if(clad)
   ROOT_ADD_GTEST(TFormulaGradientTests TFormulaGradientTests.cxx LIBRARIES Core MathCore Hist)
   ROOT_ADD_GTEST(TFormulaHessianTests TFormulaHessianTests.cxx LIBRARIES Core MathCore Hist)

--- a/hist/hist/test/CMakeLists.txt
+++ b/hist/hist/test/CMakeLists.txt
@@ -24,6 +24,7 @@ if(fftw3)
 endif()
 
 ROOT_ADD_GTEST(testTF2 test_tf2.cxx LIBRARIES Hist)
+ROOT_ADD_GTEST(testTF3 test_tf3.cxx LIBRARIES Hist)
 
 if(clad)
   ROOT_ADD_GTEST(TFormulaGradientTests TFormulaGradientTests.cxx LIBRARIES Core MathCore Hist)

--- a/hist/hist/test/test_tf1.cxx
+++ b/hist/hist/test/test_tf1.cxx
@@ -223,3 +223,56 @@ TEST(TF1, Constructors)
    for (auto tf1 : vtf1)
       EXPECT_EQ(tf1(&x, &p), 2);
 }
+
+TEST(TF1, Save)
+{
+   TF1 linear("linear", "x", -10., 10.);
+   linear.SetNpx(20);
+
+   Double_t args[1];
+
+   // save with explicit range
+   linear.Save(-10, 10, 0, 0, 0, 0);
+
+   // test at position of saved bins
+   for (Double_t x = -10.; x <= 10.; x += 1.) {
+      args[0] = x;
+      EXPECT_NEAR(x, linear.GetSave(args), 1e-10);
+   }
+
+   // test linear approximation
+   for (Double_t x = -10.; x <= 10.; x += 0.77) {
+      args[0] = x;
+      EXPECT_NEAR(x, linear.GetSave(args), 1e-10);
+   }
+
+   // test outside range
+   args[0] = -11;
+   EXPECT_EQ(0., linear.GetSave(args));
+
+   args[0] = 11;
+   EXPECT_EQ(0., linear.GetSave(args));
+
+
+   // now test saved at middle of bins
+   linear.Save(0, 0, 0, 0, 0, 0);
+
+   // test at position of saved bins
+   for (Double_t x = -9.5; x <= 9.5; x += 1.) {
+      args[0] = x;
+      EXPECT_NEAR(x, linear.GetSave(args), 1e-10);
+   }
+
+   // test linear approximation
+   for (Double_t x = -9.5; x <= 9.5; x += 0.77) {
+      args[0] = x;
+      EXPECT_NEAR(x, linear.GetSave(args), 1e-10);
+   }
+
+   // test outside range
+   args[0] = -11;
+   EXPECT_EQ(0., linear.GetSave(args));
+
+   args[0] = 11;
+   EXPECT_EQ(0., linear.GetSave(args));
+}

--- a/hist/hist/test/test_tf2.cxx
+++ b/hist/hist/test/test_tf2.cxx
@@ -1,0 +1,74 @@
+#include "TF2.h"
+
+#include "gtest/gtest.h"
+
+TEST(TF2, Save)
+{
+   TF2 linear("linear", "x+y", -10, 10, -10, 10);
+   linear.SetNpx(20);
+   linear.SetNpy(20);
+
+   Double_t args[2];
+
+   // store at exactly defined range
+   linear.Save(-10, 10, -10, 10, 0, 0);
+
+   // test exact position
+   for (Double_t x = -10.; x <= 10.; x += 1.) {
+      for (Double_t y = -10.; y <= 10.; y += 1.) {
+         args[0] = x;
+         args[1] = y;
+         EXPECT_NEAR(x + y, linear.GetSave(args), 1e-10);
+      }
+   }
+
+   // test approximation
+   for (Double_t x = -10.; x <= 10.; x += 0.33) {
+      for (Double_t y = -10.; y <= 10.; y += 0.44) {
+         args[0] = x;
+         args[1] = y;
+         EXPECT_NEAR(x + y, linear.GetSave(args), 1e-10);
+      }
+   }
+
+   // test boundaries
+   for (Double_t x = -11.; x <= 11.; x += 22) {
+      for (Double_t y = -11.; y <= 11.; y += 22) {
+         args[0] = x;
+         args[1] = y;
+         EXPECT_EQ(0, linear.GetSave(args));
+      }
+   }
+
+
+   // store at middle of bins
+   linear.Save(0, 0, 0, 0, 0, 0);
+
+   // test exact position
+   for (Double_t x = -9.5; x <= 9.5; x += 1.) {
+      for (Double_t y = -9.5; y <= 9.5; y += 1.) {
+         args[0] = x;
+         args[1] = y;
+         EXPECT_NEAR(x + y, linear.GetSave(args), 1e-10);
+      }
+   }
+
+   // test approximation
+   for (Double_t x = -9.5; x <= 9.5; x += 0.33) {
+      for (Double_t y = -9.5; y <= 9.5; y += 0.44) {
+         args[0] = x;
+         args[1] = y;
+         EXPECT_NEAR(x + y, linear.GetSave(args), 1e-10);
+      }
+   }
+
+   // test boundaries
+   for (Double_t x = -11.; x <= 11.; x += 22) {
+      for (Double_t y = -11.; y <= 11.; y += 22) {
+         args[0] = x;
+         args[1] = y;
+         EXPECT_EQ(0, linear.GetSave(args));
+      }
+   }
+
+}

--- a/hist/hist/test/test_tf3.cxx
+++ b/hist/hist/test/test_tf3.cxx
@@ -1,0 +1,92 @@
+#include "TF3.h"
+
+#include "gtest/gtest.h"
+
+TEST(TF3, Save)
+{
+   TF3 linear("linear", "x+y+z", -10, 10, -10, 10, -10, 10);
+   linear.SetNpx(20);
+   linear.SetNpy(20);
+   linear.SetNpz(20);
+
+   Double_t args[3];
+
+   // store at exactly defined range
+   linear.Save(-10, 10, -10, 10, -10, 10);
+
+   // test exact position
+   for (Double_t x = -10.; x <= 10.; x += 1.) {
+      for (Double_t y = -10.; y <= 10.; y += 1.) {
+         for (Double_t z = -10.; z <= 10.; z += 1.) {
+            args[0] = x;
+            args[1] = y;
+            args[2] = z;
+            EXPECT_NEAR(x + y + z, linear.GetSave(args), 1e-10);
+         }
+      }
+   }
+
+   // test approximation
+   for (Double_t x = -10.; x <= 10.; x += 0.33) {
+      for (Double_t y = -10.; y <= 10.; y += 0.44) {
+         for (Double_t z = -10.; z <= 10.; z += 0.55) {
+            args[0] = x;
+            args[1] = y;
+            args[2] = z;
+            EXPECT_NEAR(x + y + z, linear.GetSave(args), 1e-10);
+         }
+      }
+   }
+
+   // test boundaries
+   for (Double_t x = -11.; x <= 11.; x += 22) {
+      for (Double_t y = -11.; y <= 11.; y += 22) {
+         for (Double_t z = -11; z <= 11; z += 22) {
+            args[0] = x;
+            args[1] = y;
+            args[2] = z;
+            EXPECT_EQ(0., linear.GetSave(args));
+         }
+      }
+   }
+
+
+   // store at middle of bins
+   linear.Save(0, 0, 0, 0, 0, 0);
+
+   // test exact position
+   for (Double_t x = -9.5; x <= 9.5; x += 1.) {
+      for (Double_t y = -9.5; y <= 9.5; y += 1.) {
+         for (Double_t z = -9.5; z <= 9.5; z += 1.) {
+            args[0] = x;
+            args[1] = y;
+            args[2] = z;
+            EXPECT_NEAR(x + y + z, linear.GetSave(args), 1e-10);
+         }
+      }
+   }
+
+   // test approximation
+   for (Double_t x = -9.5; x <= 9.5; x += 0.33) {
+      for (Double_t y = -9.5; y <= 9.5; y += 0.44) {
+         for (Double_t z = -9.5; z <= 9.5; z += 0.55) {
+            args[0] = x;
+            args[1] = y;
+            args[2] = z;
+            EXPECT_NEAR(x + y + z, linear.GetSave(args), 1e-10);
+         }
+      }
+   }
+
+   // test boundaries
+   for (Double_t x = -11.; x <= 11.; x += 22) {
+      for (Double_t y = -11.; y <= 11.; y += 22) {
+         for (Double_t z = -11; z <= 11; z += 22) {
+            args[0] = x;
+            args[1] = y;
+            args[2] = z;
+            EXPECT_EQ(0., linear.GetSave(args));
+         }
+      }
+   }
+}


### PR DESCRIPTION
Since the beginning when 0 ranges were specified by Save method, 
half a bin was add to coordinate. But wrong number of bins was stored and 
therefore produced buffer was not able to use. Error was from very beginning  - 
already by initial import from rcs to svn 23 years ago.

Now proper number of bins are stored. It still stores middle of bins when `f1->Save(0,0,0,0,0,0)` is called.

There was also failure to use such saved buffer when trying to get approximation at upper boundaries. Now it is fixed.

Adding tests for all TF1/TF2/TF3.

Fixes #13927
