### PR TITLE
[graf2d] Apply `clang-tidy` suggestions

### DIFF
--- a/graf2d/fitsio/src/TFITS.cxx
+++ b/graf2d/fitsio/src/TFITS.cxx
@@ -221,12 +221,12 @@ void TFITSHDU::_release_resources()
 
 void TFITSHDU::_initialize_me()
 {
-   fRecords = 0;
-   fPixels = 0;
-   fSizes = 0;
-   fColumnsInfo = 0;
+   fRecords = nullptr;
+   fPixels = nullptr;
+   fSizes = nullptr;
+   fColumnsInfo = nullptr;
    fNColumns = fNRows = 0;
-   fCells = 0;
+   fCells = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -236,7 +236,7 @@ void TFITSHDU::_initialize_me()
 
 Bool_t TFITSHDU::LoadHDU(TString& filepath_filter)
 {
-   fitsfile *fp=0;
+   fitsfile *fp=nullptr;
    int status = 0;
    char errdescr[FLEN_STATUS+1];
 
@@ -449,8 +449,8 @@ Bool_t TFITSHDU::LoadHDU(TString& filepath_filter)
 
                fColumnsInfo[colnum].fDim = (Int_t) repeat;
 
-               double *array = 0;
-               char *arrayl = 0;
+               double *array = nullptr;
+               char *arrayl = nullptr;
 
                if (repeat > 0) {
 
@@ -629,7 +629,7 @@ struct TFITSHDU::HDURecord* TFITSHDU::GetRecord(const char *keyword)
          return &fRecords[i];
       }
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -664,7 +664,7 @@ void TFITSHDU::PrintHDUMetadata(const Option_t *) const
 
 void TFITSHDU::PrintFileMetadata(const Option_t *opt) const
 {
-   fitsfile *fp=0;
+   fitsfile *fp=nullptr;
    int status = 0;
    char errdescr[FLEN_STATUS+1];
    int hducount, extnum;
@@ -881,12 +881,12 @@ TImage *TFITSHDU::ReadAsImage(Int_t layer, TImagePalette *pal)
 {
    if (fType != kImageHDU) {
       Warning("ReadAsImage", "this is not an image HDU.");
-      return 0;
+      return nullptr;
    }
 
    if (((fSizes->GetSize() != 2) && (fSizes->GetSize() != 3) && (fSizes->GetSize() != 4)) || ((fSizes->GetSize() == 4) && (fSizes->GetAt(3) > 1))) {
       Warning("ReadAsImage", "could not convert image HDU to image because it has %d dimensions.", fSizes->GetSize());
-      return 0;
+      return nullptr;
    }
 
    Int_t width, height;
@@ -901,7 +901,7 @@ TImage *TFITSHDU::ReadAsImage(Int_t layer, TImagePalette *pal)
       || (((fSizes->GetSize() == 3) || (fSizes->GetSize() == 4)) && (layer >= fSizes->GetAt(2)))) {
 
       Warning("ReadAsImage", "layer out of bounds.");
-      return 0;
+      return nullptr;
    }
 
    // Get the maximum and minimum pixel values in the layer to auto-stretch pixels
@@ -925,7 +925,7 @@ TImage *TFITSHDU::ReadAsImage(Int_t layer, TImagePalette *pal)
    //Build the image stretching pixels into a range from 0.0 to 255.0
    //TImage *im = new TImage(width, height);
    TImage *im = TImage::Create();
-   if (!im) return 0;
+   if (!im) return nullptr;
    TArrayD *layer_pixels = new TArrayD(pixels_per_layer);
 
 
@@ -942,7 +942,7 @@ TImage *TFITSHDU::ReadAsImage(Int_t layer, TImagePalette *pal)
       }
    }
 
-   if (pal == 0) {
+   if (pal == nullptr) {
       // Default palette: grayscale palette
       pal = new TImagePalette(256);
       for (i = 0; i < 256; i++) {
@@ -977,7 +977,7 @@ void TFITSHDU::Draw(Option_t *)
       return;
    }
 
-   TImage *im = ReadAsImage(0, 0);
+   TImage *im = ReadAsImage(0, nullptr);
    if (im) {
       Int_t width = Int_t(fSizes->GetAt(0));
       Int_t height = Int_t(fSizes->GetAt(1));
@@ -1001,26 +1001,26 @@ TMatrixD* TFITSHDU::ReadAsMatrix(Int_t layer, Option_t *opt)
 {
    if (fType != kImageHDU) {
       Warning("ReadAsMatrix", "this is not an image HDU.");
-      return 0;
+      return nullptr;
    }
 
    if (((fSizes->GetSize() != 2) && (fSizes->GetSize() != 3) && (fSizes->GetSize() != 4)) || ((fSizes->GetSize() == 4) && (fSizes->GetAt(3) > 1))) {
       Warning("ReadAsMatrix", "could not convert image HDU to image because it has %d dimensions.", fSizes->GetSize());
-      return 0;
+      return nullptr;
    }
 
 
    if (   ((fSizes->GetSize() == 2) && (layer > 0))
        || (((fSizes->GetSize() == 3) || (fSizes->GetSize() == 4)) && (layer >= fSizes->GetAt(2)))) {
       Warning("ReadAsMatrix", "layer out of bounds.");
-      return 0;
+      return nullptr;
    }
 
    Int_t width, height;
    UInt_t pixels_per_layer;
    Int_t offset;
    UInt_t i;
-   TMatrixD *mat=0;
+   TMatrixD *mat=nullptr;
 
    width  = Int_t(fSizes->GetAt(0));
    height = Int_t(fSizes->GetAt(1));
@@ -1094,14 +1094,14 @@ TH1 *TFITSHDU::ReadAsHistogram()
 {
    if (fType != kImageHDU) {
       Warning("ReadAsHistogram", "this is not an image HDU.");
-      return 0;
+      return nullptr;
    }
 
-   TH1 *result=0;
+   TH1 *result=nullptr;
 
    if ((fSizes->GetSize() != 1) && (fSizes->GetSize() != 2) && (fSizes->GetSize() != 3)) {
       Warning("ReadAsHistogram", "could not convert image HDU to histogram because it has %d dimensions.", fSizes->GetSize());
-      return 0;
+      return nullptr;
    }
 
    if (fSizes->GetSize() == 1) {
@@ -1173,12 +1173,12 @@ TVectorD* TFITSHDU::GetArrayRow(UInt_t row)
 {
    if (fType != kImageHDU) {
       Warning("GetArrayRow", "this is not an image HDU.");
-      return 0;
+      return nullptr;
    }
 
    if (fSizes->GetSize() != 2) {
       Warning("GetArrayRow", "could not get row from HDU because it has %d dimensions.", fSizes->GetSize());
-      return 0;
+      return nullptr;
    }
 
    UInt_t i, offset, W,H;
@@ -1189,7 +1189,7 @@ TVectorD* TFITSHDU::GetArrayRow(UInt_t row)
 
    if (row >= H) {
       Warning("GetArrayRow", "index out of bounds.");
-      return 0;
+      return nullptr;
    }
 
    offset = W * row;
@@ -1213,12 +1213,12 @@ TVectorD* TFITSHDU::GetArrayColumn(UInt_t col)
 {
    if (fType != kImageHDU) {
       Warning("GetArrayColumn", "this is not an image HDU.");
-      return 0;
+      return nullptr;
    }
 
    if (fSizes->GetSize() != 2) {
       Warning("GetArrayColumn", "could not get row from HDU because it has %d dimensions.", fSizes->GetSize());
-      return 0;
+      return nullptr;
    }
 
    UInt_t i, W,H;
@@ -1229,7 +1229,7 @@ TVectorD* TFITSHDU::GetArrayColumn(UInt_t col)
 
    if (col >= W) {
       Warning("GetArrayColumn", "index out of bounds.");
-      return 0;
+      return nullptr;
    }
 
    double *v = new double[H];
@@ -1267,17 +1267,17 @@ TObjArray* TFITSHDU::GetTabStringColumn(Int_t colnum)
 {
    if (fType != kTableHDU) {
       Warning("GetTabStringColumn", "this is not a table HDU.");
-      return 0;
+      return nullptr;
    }
 
    if ((colnum < 0) || (colnum >= fNColumns)) {
       Warning("GetTabStringColumn", "column index out of bounds.");
-      return 0;
+      return nullptr;
    }
 
    if (fColumnsInfo[colnum].fType != kString) {
       Warning("GetTabStringColumn", "attempting to read a column that is not of type 'kString'.");
-      return 0;
+      return nullptr;
    }
 
    Int_t offset = colnum * fNRows;
@@ -1297,7 +1297,7 @@ TObjArray* TFITSHDU::GetTabStringColumn(const char *colname)
 {
    if (fType != kTableHDU) {
       Warning("GetTabStringColumn", "this is not a table HDU.");
-      return 0;
+      return nullptr;
    }
 
 
@@ -1305,12 +1305,12 @@ TObjArray* TFITSHDU::GetTabStringColumn(const char *colname)
 
    if (colnum == -1) {
       Warning("GetTabStringColumn", "column not found.");
-      return 0;
+      return nullptr;
    }
 
    if (fColumnsInfo[colnum].fType != kString) {
       Warning("GetTabStringColumn", "attempting to read a column that is not of type 'kString'.");
-      return 0;
+      return nullptr;
    }
 
    Int_t offset = colnum * fNRows;
@@ -1330,22 +1330,22 @@ TVectorD* TFITSHDU::GetTabRealVectorColumn(Int_t colnum)
 {
    if (fType != kTableHDU) {
       Warning("GetTabRealVectorColumn", "this is not a table HDU.");
-      return 0;
+      return nullptr;
    }
 
    if ((colnum < 0) || (colnum >= fNColumns)) {
       Warning("GetTabRealVectorColumn", "column index out of bounds.");
-      return 0;
+      return nullptr;
    }
 
    if (fColumnsInfo[colnum].fType == kRealArray) {
       Warning("GetTabRealVectorColumn", "attempting to read a column whose cells have embedded fixed-length arrays");
       Info("GetTabRealVectorColumn", "Use GetTabRealVectorCells() or GetTabRealVectorCell() instead.");
-      return 0;
+      return nullptr;
    } else if (fColumnsInfo[colnum].fType == kRealVector) {
       Warning("GetTabRealVectorColumn", "attempting to read a column whose cells have embedded variable-length arrays");
       Info("GetTabRealVectorColumn", "Use GetTabVarLengthCell() instead.");
-      return 0;
+      return nullptr;
    }
 
    Int_t offset = colnum * fNRows;
@@ -1369,24 +1369,24 @@ TVectorD* TFITSHDU::GetTabRealVectorColumn(const char *colname)
 {
    if (fType != kTableHDU) {
       Warning("GetTabRealVectorColumn", "this is not a table HDU.");
-      return 0;
+      return nullptr;
    }
 
    Int_t colnum = GetColumnNumber(colname);
 
    if (colnum == -1) {
       Warning("GetTabRealVectorColumn", "column not found.");
-      return 0;
+      return nullptr;
    }
 
    if (fColumnsInfo[colnum].fType == kRealArray) {
       Warning("GetTabRealVectorColumn", "attempting to read a column whose cells have embedded fixed-length arrays");
       Info("GetTabRealVectorColumn", "Use GetTabRealVectorCells() or GetTabRealVectorCell() instead.");
-      return 0;
+      return nullptr;
    } else if (fColumnsInfo[colnum].fType == kRealVector) {
       Warning("GetTabRealVectorColumn", "attempting to read a column whose cells have embedded variable-length arrays");
       Info("GetTabRealVectorColumn", "Use GetTabVarLengthCell() instead.");
-      return 0;
+      return nullptr;
    }
 
    Int_t offset = colnum * fNRows;
@@ -1455,18 +1455,18 @@ TObjArray *TFITSHDU::GetTabRealVectorCells(Int_t colnum)
 {
    if (fType != kTableHDU) {
       Warning("GetTabRealVectorCells", "this is not a table HDU.");
-      return 0;
+      return nullptr;
    }
 
    if ((colnum < 0) || (colnum >= fNColumns)) {
       Warning("GetTabRealVectorCells", "column index out of bounds.");
-      return 0;
+      return nullptr;
    }
 
    if (fColumnsInfo[colnum].fType == kRealVector) {
       Warning("GetTabRealVectorCells", "attempting to read a column whose cells have embedded variable-length arrays");
       Info("GetTabRealVectorCells", "Use GetTabVarLengthCell() instead.");
-      return 0;
+      return nullptr;
    }
 
    Int_t offset = colnum * fNRows;
@@ -1494,14 +1494,14 @@ TObjArray *TFITSHDU::GetTabRealVectorCells(const char *colname)
 {
    if (fType != kTableHDU) {
       Warning("GetTabRealVectorCells", "this is not a table HDU.");
-      return 0;
+      return nullptr;
    }
 
    Int_t colnum = GetColumnNumber(colname);
 
    if (colnum == -1) {
       Warning("GetTabRealVectorCells", "column not found.");
-      return 0;
+      return nullptr;
    }
 
    return GetTabRealVectorCells(colnum);
@@ -1514,23 +1514,23 @@ TVectorD *TFITSHDU::GetTabRealVectorCell(Int_t rownum, Int_t colnum)
 {
    if (fType != kTableHDU) {
       Warning("GetTabRealVectorCell", "this is not a table HDU.");
-      return 0;
+      return nullptr;
    }
 
    if ((colnum < 0) || (colnum >= fNColumns)) {
       Warning("GetTabRealVectorCell", "column index out of bounds.");
-      return 0;
+      return nullptr;
    }
 
    if ((rownum < 0) || (rownum >= fNRows)) {
       Warning("GetTabRealVectorCell", "row index out of bounds.");
-      return 0;
+      return nullptr;
    }
    
    if (fColumnsInfo[colnum].fType == kRealVector) {
       Warning("GetTabRealVectorCells", "attempting to read a column whose cells have embedded variable-length arrays");
       Info("GetTabRealVectorCells", "Use GetTabVarLengthCell() instead.");
-      return 0;
+      return nullptr;
    }
 
    TVectorD *v = new TVectorD();
@@ -1545,14 +1545,14 @@ TVectorD *TFITSHDU::GetTabRealVectorCell(Int_t rownum, const char *colname)
 {
    if (fType != kTableHDU) {
       Warning("GetTabRealVectorCell", "this is not a table HDU.");
-      return 0;
+      return nullptr;
    }
 
    Int_t colnum = GetColumnNumber(colname);
 
    if (colnum == -1) {
       Warning("GetTabRealVectorCell", "column not found.");
-      return 0;
+      return nullptr;
    }
 
    return GetTabRealVectorCell(rownum, colnum);
@@ -1584,17 +1584,17 @@ TArrayD *TFITSHDU::GetTabVarLengthVectorCell(Int_t rownum, Int_t colnum) {
 
    if (fType != kTableHDU) {
       Warning("GetTabVarLengthVectorCell", "this is not a table HDU.");
-      return 0;
+      return nullptr;
    }
 
    if ((colnum < 0) || (colnum >= fNColumns)) {
       Warning("GetTabVarLengthVectorCell", "column index out of bounds.");
-      return 0;
+      return nullptr;
    }
 
    if ((rownum < 0) || (rownum >= fNRows)) {
       Warning("GetTabVarLengthVectorCell", "row index out of bounds.");
-      return 0;
+      return nullptr;
    } 
    
    return fCells[(colnum * fNRows) + rownum].fRealVector;
@@ -1607,14 +1607,14 @@ TArrayD *TFITSHDU::GetTabVarLengthVectorCell(Int_t rownum, const char *colname)
 {
    if (fType != kTableHDU) {
       Warning("GetTabVarLengthVectorCell", "this is not a table HDU.");
-      return 0;
+      return nullptr;
    }
 
    Int_t colnum = GetColumnNumber(colname);
 
    if (colnum == -1) {
       Warning("GetTabVarLengthVectorCell", "column not found.");
-      return 0;
+      return nullptr;
    }
 
    return GetTabVarLengthVectorCell(rownum, colnum);

--- a/graf2d/gpad/inc/TPad.h
+++ b/graf2d/gpad/inc/TPad.h
@@ -274,7 +274,7 @@ public:
    Bool_t            IsVertical() const override { return !TestBit(kHori); }
    Bool_t            IsWeb() const override;
    void              ls(Option_t *option="") const override;
-   void              Modified(Bool_t flag=1) override;  // *SIGNAL*
+   void              Modified(Bool_t flag=true) override;  // *SIGNAL*
    Bool_t            OpaqueMoving() const override;
    Bool_t            OpaqueResizing() const override;
    Double_t          PadtoX(Double_t x) const override;

--- a/graf2d/gpad/src/TCanvas.cxx
+++ b/graf2d/gpad/src/TCanvas.cxx
@@ -292,10 +292,10 @@ void TCanvas::Constructor(const char *name, const char *title, Int_t form)
    }
 
    Init();
-   SetBit(kMenuBar,1);
+   SetBit(kMenuBar,true);
    if (form < 0) {
       form     = -form;
-      SetBit(kMenuBar,0);
+      SetBit(kMenuBar,false);
    }
 
    fCanvas = this;
@@ -392,10 +392,10 @@ void TCanvas::Constructor(const char *name, const char *title, Int_t ww, Int_t w
    }
 
    Init();
-   SetBit(kMenuBar,1);
+   SetBit(kMenuBar,true);
    if (ww < 0) {
       ww       = -ww;
-      SetBit(kMenuBar,0);
+      SetBit(kMenuBar,false);
    }
    if (wh <= 0) {
       Error("Constructor", "Invalid canvas height: %d",wh);
@@ -483,10 +483,10 @@ void TCanvas::Constructor(const char *name, const char *title, Int_t wtopx,
    }
 
    Init();
-   SetBit(kMenuBar,1);
+   SetBit(kMenuBar,true);
    if (wtopx < 0) {
       wtopx    = -wtopx;
-      SetBit(kMenuBar,0);
+      SetBit(kMenuBar,false);
    }
    fCw       = ww;
    fCh       = wh;
@@ -993,14 +993,14 @@ void TCanvas::DrawEventStatus(Int_t event, Int_t px, Int_t py, TObject *selected
    fCanvasImp->SetStatusText(atext,2);
 
    // Show date/time if TimeDisplay is selected
-   TAxis *xaxis = NULL;
+   TAxis *xaxis = nullptr;
    if ( selected->InheritsFrom("TH1") )
       xaxis = ((TH1*)selected)->GetXaxis();
    else if ( selected->InheritsFrom("TGraph") )
       xaxis = ((TGraph*)selected)->GetXaxis();
    else if ( selected->InheritsFrom("TAxis") )
       xaxis = (TAxis*)selected;
-   if ( xaxis != NULL && xaxis->GetTimeDisplay()) {
+   if ( xaxis != nullptr && xaxis->GetTimeDisplay()) {
       TString objinfo = selected->GetObjectInfo(px,py);
       // check if user has overwritten GetObjectInfo and altered
       // the default text from TObject::GetObjectInfo "x=.. y=.."
@@ -2649,13 +2649,13 @@ void TCanvas::DeleteCanvasPainter()
 
 Bool_t TCanvas::SaveAll(const std::vector<TPad *> &pads, const char *filename, Option_t *option)
 {
-   if (pads.size() == 0) {
+   if (pads.empty()) {
       std::vector<TPad *> canvases;
       TIter iter(gROOT->GetListOfCanvases());
       while (auto c = dynamic_cast<TCanvas *>(iter()))
          canvases.emplace_back(c);
 
-      if (canvases.size() == 0) {
+      if (canvases.empty()) {
          ::Warning("TCanvas::SaveAll", "No pads are provided");
          return kFALSE;
       }

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -190,8 +190,8 @@ TPad::TPad()
    fLogx  = 0;
    fLogy  = 0;
    fLogz  = 0;
-   fGridx = 0;
-   fGridy = 0;
+   fGridx = false;
+   fGridy = false;
    fTickx = 0;
    fTicky = 0;
    fFrame = nullptr;
@@ -2228,7 +2228,7 @@ void TPad::ExecuteEvent(Int_t event, Int_t px, Int_t py)
 
       ExecuteEvent(kButton1Down, px, py);
 
-      while (1) {
+      while (true) {
          px = py = 0;
          event = gVirtualX->RequestLocator(1, 1, px, py);
 

--- a/graf2d/gpadv7/inc/ROOT/RCanvas.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RCanvas.hxx
@@ -31,7 +31,7 @@ class RChangeAttrRequest : public RDrawableRequest {
    RChangeAttrRequest& operator=(const RChangeAttrRequest &) = delete;
 public:
    RChangeAttrRequest() = default; // for I/O
-   virtual ~RChangeAttrRequest() = default;
+   ~RChangeAttrRequest() override = default;
    std::unique_ptr<RDrawableReply> Process() override;
    bool NeedCanvasUpdate() const override { return fNeedUpdate; }
 };
@@ -87,7 +87,7 @@ public:
    /// Create a temporary RCanvas; for long-lived ones please use Create().
    RCanvas() : RPadBase("canvas") {}
 
-   ~RCanvas() = default;
+   ~RCanvas() override = default;
 
    const RCanvas *GetCanvas() const override { return this; }
 

--- a/graf2d/gpadv7/inc/ROOT/RMenuItems.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RMenuItems.hxx
@@ -83,7 +83,7 @@ public:
    }
 
    /** virtual destructor need for vtable, used when vector of RMenuItem* is stored */
-   virtual ~RCheckedMenuItem() {}
+   ~RCheckedMenuItem() override {}
 
    /** Set checked state for the item, default is none */
    void SetChecked(bool on = true) { fChecked = on; }
@@ -137,7 +137,7 @@ public:
    RArgsMenuItem(const std::string &name, const std::string &title) : RMenuItem(name, title) {}
 
    /** virtual destructor need for vtable, used when vector of RMenuItem* is stored */
-   virtual ~RArgsMenuItem() {}
+   ~RArgsMenuItem() override {}
 
    void AddArg(const RMenuArgument &arg) { fArgs.emplace_back(arg); }
 };
@@ -168,7 +168,7 @@ public:
       fSpecifier = _specifier;
    }
 
-   virtual ~RMenuItems();
+   ~RMenuItems() override;
 
    const std::string &GetFullId() const { return fId; }
    const std::string &GetSpecifier() const { return fSpecifier; }

--- a/graf2d/gpadv7/inc/ROOT/ROnFrameDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/ROnFrameDrawable.hxx
@@ -32,7 +32,7 @@ protected:
    explicit ROnFrameDrawable(const char *type) : RDrawable(type) {}
 
 public:
-   virtual ~ROnFrameDrawable() = default;
+   ~ROnFrameDrawable() override = default;
 
    RAttrValue<bool> onFrame{this, "onFrame", false};  ///<! is drawn on the frame or not
    RAttrValue<bool> clipping{this, "clipping", false}; ///<! is clipping on when drawn on the frame

--- a/graf2d/gpadv7/inc/ROOT/RPad.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPad.hxx
@@ -58,7 +58,7 @@ public:
    RPad(TRootIOCtor*) : RPad() {}
 
    /// Destructor to have a vtable.
-   virtual ~RPad();
+   ~RPad() override;
 
    /// Access to the parent pad (const version).
    const RPadBase *GetParent() const { return fParent; }

--- a/graf2d/gpadv7/inc/ROOT/RPadBase.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPadBase.hxx
@@ -70,7 +70,7 @@ public:
 
    using Primitives_t = std::vector<std::shared_ptr<RDrawable>>;
 
-   virtual ~RPadBase();
+   ~RPadBase() override;
 
    void UseStyle(const std::shared_ptr<RStyle> &style) override;
 

--- a/graf2d/gpadv7/inc/ROOT/RPadDisplayItem.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPadDisplayItem.hxx
@@ -36,7 +36,7 @@ protected:
    std::vector<std::shared_ptr<RStyle>> fStyles; ///<! locked styles of the objects and pad until streaming is performed
 public:
    RPadBaseDisplayItem() = default;
-   virtual ~RPadBaseDisplayItem() = default;
+   ~RPadBaseDisplayItem() override = default;
    void SetAttributes(const RAttrMap *f) { fAttr = f; }
    /// Add display item and style which should be used for it
    void Add(std::unique_ptr<RDisplayItem> &&item, std::shared_ptr<RStyle> &&style)
@@ -72,7 +72,7 @@ protected:
    const RPadExtent *fSize{nullptr};    ///< pad size
 public:
    RPadDisplayItem() = default;
-   virtual ~RPadDisplayItem() {}
+   ~RPadDisplayItem() override {}
    void SetPadPosSize(const RPadPos *pos, const RPadExtent *size) { fPos = pos; fSize = size; }
 
    void BuildFullId(const std::string &prefix) override
@@ -100,7 +100,7 @@ protected:
    std::array<int, 2> fWinSize;         ///< canvas window size
 public:
    RCanvasDisplayItem() = default;
-   virtual ~RCanvasDisplayItem() = default;
+   ~RCanvasDisplayItem() override = default;
    void SetTitle(const std::string &title) { fTitle = title; }
    void SetWindowSize(int width, int height) { fWinSize[0] = width; fWinSize[1] = height; }
 

--- a/graf2d/gpadv7/inc/ROOT/RPadLength.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPadLength.hxx
@@ -132,13 +132,13 @@ public:
    /// Constructor from string representation
    RPadLength(const std::string &csscode) : RPadLength() { if (!csscode.empty()) ParseString(csscode); }
 
-   bool HasNormal() const { return fArr.size() > 0; }
+   bool HasNormal() const { return !fArr.empty(); }
    bool HasPixel() const { return fArr.size() > 1; }
    bool HasUser() const { return fArr.size() > 2; }
 
    RPadLength &SetNormal(double v)
    {
-      if (fArr.size() < 1)
+      if (fArr.empty())
          fArr.resize(1);
       fArr[0] = v;
       return *this;
@@ -160,7 +160,7 @@ public:
       return *this;
    }
 
-   double GetNormal() const { return fArr.size() > 0 ? fArr[0] : 0.; }
+   double GetNormal() const { return !fArr.empty() ? fArr[0] : 0.; }
    double GetPixel() const { return fArr.size() > 1 ? fArr[1] : 0.; }
    double GetUser() const { return fArr.size() > 2 ? fArr[2] : 0.; }
 

--- a/graf2d/gpadv7/inc/ROOT/TObjectDisplayItem.hxx
+++ b/graf2d/gpadv7/inc/ROOT/TObjectDisplayItem.hxx
@@ -58,7 +58,7 @@ public:
       fOwner = true;
    }
 
-   virtual ~TObjectDisplayItem()
+   ~TObjectDisplayItem() override
    {
       if (fOwner) delete fObject;
    }

--- a/graf2d/gpadv7/inc/ROOT/TObjectDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/TObjectDrawable.hxx
@@ -86,7 +86,7 @@ public:
    TObjectDrawable(const std::shared_ptr<TObject> &obj);
    TObjectDrawable(const std::shared_ptr<TObject> &obj, const std::string &opt);
    TObjectDrawable(EKind kind, bool persistent = false);
-   virtual ~TObjectDrawable();
+   ~TObjectDrawable() override;
 
    void Reset();
 

--- a/graf2d/gpadv7/src/RCanvas.cxx
+++ b/graf2d/gpadv7/src/RCanvas.cxx
@@ -15,8 +15,8 @@
 #include <mutex>
 #include <thread>
 #include <chrono>
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 #include "TList.h"
 #include "TROOT.h"
@@ -24,13 +24,13 @@
 
 namespace {
 
-static std::mutex &GetHeldCanvasesMutex()
+std::mutex &GetHeldCanvasesMutex()
 {
    static std::mutex sMutex;
    return sMutex;
 }
 
-static std::vector<std::shared_ptr<ROOT::Experimental::RCanvas>> &GetHeldCanvases()
+std::vector<std::shared_ptr<ROOT::Experimental::RCanvas>> &GetHeldCanvases()
 {
    static std::vector<std::shared_ptr<ROOT::Experimental::RCanvas>> sCanvases;
    return sCanvases;
@@ -159,7 +159,7 @@ std::string ROOT::Experimental::RCanvas::GetWindowAddr() const
 void ROOT::Experimental::RCanvas::Hide()
 {
    if (fPainter)
-      delete fPainter.release();
+      fPainter = nullptr;
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/graf2d/gpadv7/src/RColor.cxx
+++ b/graf2d/gpadv7/src/RColor.cxx
@@ -206,7 +206,7 @@ std::vector<uint8_t> RColor::AsRGBA() const
    else if (IsRGBA())
       rgba.resize(4);
 
-   if (rgba.size() > 0) {
+   if (!rgba.empty()) {
       try {
         rgba[0] = std::stoi(fColor.substr(1,2), nullptr, 16);
         rgba[1] = std::stoi(fColor.substr(3,2), nullptr, 16);

--- a/graf2d/gpadv7/src/RPadBase.cxx
+++ b/graf2d/gpadv7/src/RPadBase.cxx
@@ -63,7 +63,7 @@ std::shared_ptr<RDrawable> RPadBase::FindPrimitive(const std::string &id) const
 
 std::shared_ptr<RDrawable> RPadBase::FindPrimitiveByDisplayId(const std::string &id) const
 {
-   auto p = id.find("_");
+   auto p = id.find('_');
    if (p == std::string::npos)
       return nullptr;
 
@@ -86,7 +86,7 @@ std::shared_ptr<RDrawable> RPadBase::FindPrimitiveByDisplayId(const std::string 
 
 const RPadBase *RPadBase::FindPadForPrimitiveWithDisplayId(const std::string &id) const
 {
-   auto p = id.find("_");
+   auto p = id.find('_');
    if (p == std::string::npos)
       return nullptr;
 

--- a/graf2d/gpadv7/src/RPalette.cxx
+++ b/graf2d/gpadv7/src/RPalette.cxx
@@ -38,7 +38,7 @@ RPalette::RPalette(bool interpolate, bool knownNormalized, const std::vector<RPa
 }
 
 namespace {
-static std::vector<RPalette::OrdinalAndColor> AddOrdinals(const std::vector<RColor> &points)
+std::vector<RPalette::OrdinalAndColor> AddOrdinals(const std::vector<RColor> &points)
 {
    std::vector<RPalette::OrdinalAndColor> ret(points.size());
    auto addOneOrdinal = [&](const RColor &col) -> RPalette::OrdinalAndColor {
@@ -55,7 +55,7 @@ RPalette::RPalette(bool interpolate, const std::vector<RColor> &points)
 
 RColor RPalette::GetColor(double ordinal)
 {
-   if (fColors.size() == 0)
+   if (fColors.empty())
       return RColor();
 
    if (fColors.size() == 1)
@@ -114,7 +114,7 @@ RColor RPalette::GetColor(double ordinal)
 
 namespace {
 using GlobalPalettes_t = std::unordered_map<std::string, RPalette>;
-static GlobalPalettes_t CreateDefaultPalettes()
+GlobalPalettes_t CreateDefaultPalettes()
 {
    GlobalPalettes_t ret;
    ret["default"] = RPalette({RColor::kRed, RColor::kBlue});
@@ -128,7 +128,7 @@ static GlobalPalettes_t CreateDefaultPalettes()
    return ret;
 }
 
-static GlobalPalettes_t &GetGlobalPalettes()
+GlobalPalettes_t &GetGlobalPalettes()
 {
    static GlobalPalettes_t globalPalettes = CreateDefaultPalettes();
    return globalPalettes;

--- a/graf2d/gpadv7/src/RVirtualCanvasPainter.cxx
+++ b/graf2d/gpadv7/src/RVirtualCanvasPainter.cxx
@@ -15,13 +15,13 @@
 #include <exception>
 
 namespace {
-static int LoadCanvasPainterLibraryOnce() {
+int LoadCanvasPainterLibraryOnce() {
   static int loadResult = gSystem->Load("libROOTCanvasPainter");
   if (loadResult != 0)
      R__LOG_ERROR(ROOT::Experimental::GPadLog()) << "Loading of libROOTCanvasPainter failed!";
   return loadResult;
 }
-static void LoadCanvasPainterLibrary() {
+void LoadCanvasPainterLibrary() {
   static int loadResult = LoadCanvasPainterLibraryOnce();
   (void) loadResult;
 }

--- a/graf2d/graf/src/TBox.cxx
+++ b/graf2d/graf/src/TBox.cxx
@@ -9,7 +9,7 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include <stdlib.h>
+#include <cstdlib>
 
 #include <iostream>
 #include "TROOT.h"
@@ -620,7 +620,7 @@ void TBox::ExecuteEvent(Int_t event, Int_t px, Int_t py)
 
       ExecuteEvent(kButton1Down, px, py);
 
-      while (1) {
+      while (true) {
          px = py = 0;
          event = gVirtualX->RequestLocator(1, 1, px, py);
 

--- a/graf2d/graf/src/TCandle.cxx
+++ b/graf2d/graf/src/TCandle.cxx
@@ -118,7 +118,7 @@ TCandle::TCandle(const Double_t candlePos, const Double_t candleWidth, Long64_t 
    fWhiskerUp     = 0;
    fWhiskerDown   = 0;
    fNDatapoints   = n;
-   fIsCalculated  = 0;
+   fIsCalculated  = false;
    fIsRaw         = true;
    fPosCandleAxis = candlePos;
    fCandleWidth   = candleWidth;

--- a/graf2d/graf/src/TDiamond.cxx
+++ b/graf2d/graf/src/TDiamond.cxx
@@ -9,7 +9,7 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include <stdlib.h>
+#include <cstdlib>
 
 #include <iostream>
 #include "TBufferFile.h"
@@ -360,7 +360,7 @@ void TDiamond::ExecuteEvent(Int_t event, Int_t px, Int_t py)
 
       ExecuteEvent(kButton1Down, px, py);
 
-      while (1) {
+      while (true) {
          px = py = 0;
          event = gVirtualX->RequestLocator(1, 1, px, py);
 

--- a/graf2d/graf/src/TEllipse.cxx
+++ b/graf2d/graf/src/TEllipse.cxx
@@ -9,7 +9,7 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include <stdlib.h>
+#include <cstdlib>
 
 #include <iostream>
 #include "TROOT.h"

--- a/graf2d/graf/src/TGaxis.cxx
+++ b/graf2d/graf/src/TGaxis.cxx
@@ -1063,7 +1063,7 @@ void TGaxis::PaintAxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t yma
    Int_t ndyn;
    Int_t nhilab = 0;
    Int_t idn;
-   Bool_t flexe = 0;
+   Bool_t flexe = false;
    Bool_t flexpo,flexne;
    char *label;
    char *chtemp;
@@ -1876,7 +1876,7 @@ void TGaxis::PaintAxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t yma
 
                if (flexpo) {
                   flexe = kTRUE;
-                  while (1) {
+                  while (true) {
                      nexe++;
                      ww      /= 10;
                      wlabel  /= 10;
@@ -1888,7 +1888,7 @@ void TGaxis::PaintAxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t yma
                if (flexne) {
                   flexe = kTRUE;
                   rne   = 1/TMath::Power(10,maxDigits-2);
-                  while (1) {
+                  while (true) {
                      nexe--;
                      ww      *= 10;
                      wlabel  *= 10;

--- a/graf2d/graf/src/TLegend.cxx
+++ b/graf2d/graf/src/TLegend.cxx
@@ -587,7 +587,7 @@ Int_t TLegend::GetNRows() const
    if ( nEntries == 0 ) return 0;
 
    Int_t nRows;
-   if(GetHeader() != NULL) nRows = 1 + (Int_t) TMath::Ceil((Double_t) (nEntries-1)/fNColumns);
+   if(GetHeader() != nullptr) nRows = 1 + (Int_t) TMath::Ceil((Double_t) (nEntries-1)/fNColumns);
    else  nRows = (Int_t) TMath::Ceil((Double_t) nEntries/fNColumns);
 
    return nRows;

--- a/graf2d/graf/src/TLine.cxx
+++ b/graf2d/graf/src/TLine.cxx
@@ -9,7 +9,7 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include <stdlib.h>
+#include <cstdlib>
 
 #include <iostream>
 #include "TROOT.h"
@@ -360,7 +360,7 @@ void TLine::ExecuteEvent(Int_t event, Int_t px, Int_t py)
    case kButton1Locate:
 
       ExecuteEvent(kButton1Down, px, py);
-      while (1) {
+      while (true) {
          px = py = 0;
          event = gVirtualX->RequestLocator(1,1,px,py);
 

--- a/graf2d/graf/src/TPaveText.cxx
+++ b/graf2d/graf/src/TPaveText.cxx
@@ -628,7 +628,7 @@ void TPaveText::ReadFile(const char *filename, Option_t *option, Int_t nlines, I
    char *ss, *sclose, *s = nullptr;
 
    Int_t kline = 0;
-   while (1) {
+   while (true) {
       file.getline(currentline,linesize);
       if (file.eof())break;
       if (kline >= fromline && kline < fromline+nlines) {

--- a/graf2d/graf/src/TPie.cxx
+++ b/graf2d/graf/src/TPie.cxx
@@ -612,7 +612,7 @@ void TPie::ExecuteEvent(Int_t event, Int_t px, Int_t py)
 
          ExecuteEvent(kButton1Down, px, py);
 
-         while (1) {
+         while (true) {
             px = py = 0;
             event = gVirtualX->RequestLocator(1, 1, px, py);
 

--- a/graf2d/mathtext/inc/fontembed.h
+++ b/graf2d/mathtext/inc/fontembed.h
@@ -27,9 +27,9 @@ typedef unsigned __int16 uint16_t;
 typedef unsigned __int32 uint32_t;
 typedef unsigned __int64 uint64_t;
 #else
-#include <stdint.h>
+#include <cstdint>
 #endif
-#include <stdio.h>
+#include <cstdio>
 #include <vector>
 #include <string>
 #include <map>

--- a/graf2d/mathtext/inc/mathrender.h
+++ b/graf2d/mathtext/inc/mathrender.h
@@ -30,9 +30,9 @@ typedef unsigned __int16 uint16_t;
 typedef unsigned __int32 uint32_t;
 typedef unsigned __int64 uint64_t;
 #else
-#include <stdint.h>
+#include <cstdint>
 #endif
-#include <math.h>
+#include <cmath>
 #include <string>
 #include <iostream>
 #include <algorithm>

--- a/graf2d/mathtext/src/fontembed.cxx
+++ b/graf2d/mathtext/src/fontembed.cxx
@@ -18,8 +18,8 @@
 
 #include "../inc/fontembed.h"
 #include <algorithm>
-#include <string.h>
-#include <stdio.h>
+#include <cstring>
+#include <cstdio>
 #ifdef WIN32
 #define snprintf _snprintf
 #endif
@@ -318,7 +318,7 @@ namespace mathtext {
                                      {
                                         std::vector<uint8_t> font_data;
 
-                                        if (fp == NULL) {
+                                        if (fp == nullptr) {
                                            return font_data;
                                         }
                                         if (fseek(fp, 0L, SEEK_SET) == -1) {
@@ -359,7 +359,7 @@ namespace mathtext {
                                         FILE *fp = fopen(filename.c_str(), "r");
                                         std::vector<uint8_t> font_data;
 
-                                        if (fp == NULL) {
+                                        if (fp == nullptr) {
                                            perror("fopen");
                                            return font_data;
                                         }

--- a/graf2d/mathtext/src/fontembedps.cxx
+++ b/graf2d/mathtext/src/fontembedps.cxx
@@ -17,8 +17,8 @@
 // 02110-1301 USA
 
 #include "../inc/fontembed.h"
-#include <string.h>
-#include <stdio.h>
+#include <cstring>
+#include <cstdio>
 #include <algorithm>
 #ifdef WIN32
 #define snprintf _snprintf
@@ -410,7 +410,7 @@ namespace mathtext {
          unsigned int glyph_index = cid_map[code_point];
 
          if (char_strings[glyph_index] != ".notdef" &&
-             char_strings[glyph_index] != "") {
+             !char_strings[glyph_index].empty()) {
             snprintf(linebuf, BUFSIZ, "dup %u /%s put\n",
                      code_point,
                      char_strings[glyph_index].c_str());

--- a/graf2d/mathtext/src/mathrender.cxx
+++ b/graf2d/mathtext/src/mathrender.cxx
@@ -24,7 +24,7 @@
 #pragma warning( disable : 4066)
 #endif
 
-#include <math.h>
+#include <cmath>
 #include <algorithm>
 #include <sstream>
 #include "../inc/mathrender.h"

--- a/graf2d/mathtext/src/mathrenderstyle.cxx
+++ b/graf2d/mathtext/src/mathrenderstyle.cxx
@@ -16,7 +16,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 // 02110-1301 USA
 
-#include <math.h>
+#include <cmath>
 #include "../inc/mathrender.h"
 
 /////////////////////////////////////////////////////////////////////

--- a/graf2d/mathtext/src/mathtextparse.cxx
+++ b/graf2d/mathtext/src/mathtextparse.cxx
@@ -351,7 +351,7 @@ namespace mathtext {
 
       std::vector<std::string> ret;
 
-      if(code.size() <= 0) {
+      if(code.empty()) {
          return ret;
       }
 

--- a/graf2d/mathtext/src/mathtextview.cxx
+++ b/graf2d/mathtext/src/mathtextview.cxx
@@ -30,7 +30,7 @@ namespace mathtext {
    tree_view_prefix(const std::vector<bool> &branch,
                     const bool final) const
    {
-      if(branch.size() > 0) {
+      if(!branch.empty()) {
          std::cerr << ' ';
          for (std::vector<bool>::const_iterator iterator = branch.begin(); iterator != branch.end(); ++iterator) {
             if(*iterator) {

--- a/graf2d/postscript/src/TPDF.cxx
+++ b/graf2d/postscript/src/TPDF.cxx
@@ -208,7 +208,7 @@ void TPDF::Close(Option_t *)
    Int_t streamLength = fNByte-fStartStream-10;
    EndObject();
    NewObject(4*(fNbPage-1)+kObjFirstPage+2);
-   WriteInteger(streamLength, 0);
+   WriteInteger(streamLength, false);
    PrintStr("@");
    EndObject();
    NewObject(4*(fNbPage-1)+kObjFirstPage+3);
@@ -305,7 +305,7 @@ void TPDF::Close(Option_t *)
    }
    PrintStr(">>@");
    EndObject();
-   if (fAlphas.size()) fAlphas.clear();
+   if (!fAlphas.empty()) fAlphas.clear();
 
    // Cross-Reference Table
    Int_t refInd = fNByte;
@@ -335,7 +335,7 @@ void TPDF::Close(Option_t *)
    PrintStr(" 0 R@");
    PrintStr(">>@");
    PrintStr("startxref@");
-   WriteInteger(refInd, 0);
+   WriteInteger(refInd, false);
    PrintStr("@");
    PrintStr("%%EOF@");
 
@@ -1399,7 +1399,7 @@ void TPDF::FontEncode()
       PrintStr("/Type /Font@");
       PrintStr("/Subtype /Type1@");
       PrintStr("/Name /F");
-      WriteInteger(i+1,0);
+      WriteInteger(i+1,false);
       PrintStr("@");
       PrintStr("/BaseFont ");
       PrintStr(sdtfonts[i]);
@@ -1454,7 +1454,7 @@ void TPDF::NewObject(Int_t n)
    }
    fObjPos[n-1] = fNByte;
    fNbObj       = TMath::Max(fNbObj,n);
-   WriteInteger(n, 0);
+   WriteInteger(n, false);
    PrintStr(" 0 obj");
    PrintStr("@");
 }
@@ -1484,7 +1484,7 @@ void TPDF::NewPage()
       Int_t streamLength = fNByte-fStartStream-10;
       EndObject();
       NewObject(4*(fNbPage-2)+kObjFirstPage+2);
-      WriteInteger(streamLength, 0);
+      WriteInteger(streamLength, false);
       PrintStr("@");
       EndObject();
       NewObject(4*(fNbPage-2)+kObjFirstPage+3);
@@ -1799,7 +1799,7 @@ void TPDF::Open(const char *fname, Int_t wtype)
    PrintStr("<<@");
    for (i=0; i<kNumberOfFonts; i++) {
       PrintStr(" /F");
-      WriteInteger(i+1,0);
+      WriteInteger(i+1,false);
       WriteInteger(kObjFont+i);
       PrintStr(" 0 R");
    }
@@ -1809,7 +1809,7 @@ void TPDF::Open(const char *fname, Int_t wtype)
    PrintStr("/ExtGState");
    WriteInteger(kObjTransList);
    PrintStr(" 0 R @");
-   if (fAlphas.size()) fAlphas.clear();
+   if (!fAlphas.empty()) fAlphas.clear();
 
    PrintStr("/ColorSpace << /Cs8");
    WriteInteger(kObjColorSpace);
@@ -2415,9 +2415,9 @@ void TPDF::WriteCompressedBuffer()
    stream.avail_in  = (uInt)fLenBuffer;
    stream.next_out  = (Bytef*)out;
    stream.avail_out = (uInt)2*fLenBuffer;
-   stream.zalloc    = (alloc_func)0;
-   stream.zfree     = (free_func)0;
-   stream.opaque    = (voidpf)0;
+   stream.zalloc    = (alloc_func)nullptr;
+   stream.zfree     = (free_func)nullptr;
+   stream.opaque    = (voidpf)nullptr;
 
    err = deflateInit(&stream, Z_DEFAULT_COMPRESSION);
    if (err != Z_OK) {

--- a/graf2d/win32gdk/inc/TGWin32VirtualXProxy.h
+++ b/graf2d/win32gdk/inc/TGWin32VirtualXProxy.h
@@ -39,7 +39,7 @@ public:
    TGWin32VirtualXProxy(const char *name, const char *title) {}
      ~TGWin32VirtualXProxy() override {}
 
-   Bool_t    Init(void *display=0) override;
+   Bool_t    Init(void *display=nullptr) override;
    void      ClearWindow() override;
    void      ClosePixmap() override;
    void      CloseWindow() override;
@@ -56,7 +56,7 @@ public:
    EDrawMode GetDrawMode();
    Int_t     GetDoubleBuffer(Int_t wid) override;
    void      GetGeometry(Int_t wid, Int_t &x, Int_t &y, UInt_t &w, UInt_t &h) override;
-   const char *DisplayName(const char * = 0) override;
+   const char *DisplayName(const char * = nullptr) override;
    Handle_t  GetNativeEvent() const override;
    ULong_t   GetPixel(Color_t cindex) override;
    void      GetPlanes(Int_t &nplanes) override;
@@ -149,7 +149,7 @@ public:
    Window_t  CreateWindow(Window_t parent, Int_t x, Int_t y,
                           UInt_t w, UInt_t h, UInt_t border, Int_t depth, UInt_t clss,
                           void *visual, SetWindowAttributes_t *attr, UInt_t wtype) override;
-   Int_t        OpenDisplay(const char *dpyName=0) override;
+   Int_t        OpenDisplay(const char *dpyName=nullptr) override;
    void         CloseDisplay() override;
    Display_t    GetDisplay() const override;
    Visual_t     GetVisual() const override;

--- a/graf2d/x11/src/GX11Gui.cxx
+++ b/graf2d/x11/src/GX11Gui.cxx
@@ -13,11 +13,11 @@
 // TGX11 class. Most of the methods are used by the machine independent
 // GUI classes (libGUI.so).
 
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <ctype.h>
-#include <limits.h>
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
+#include <cctype>
+#include <climits>
 #include <unistd.h>
 
 #include <X11/Xlib.h>
@@ -1764,7 +1764,7 @@ Bool_t TGX11::CheckEvent(Window_t id, EGEventType type, Event_t &ev)
    tev.fCount = 0;
    tev.fFormat = 0;
    tev.fHandle = 0;
-   tev.fSendEvent = 0;
+   tev.fSendEvent = false;
    tev.fTime = 0;
    tev.fX = tev.fY = 0;
    tev.fXRoot = tev.fYRoot = 0;

--- a/graf2d/x11/src/Rotated.cxx
+++ b/graf2d/x11/src/Rotated.cxx
@@ -27,9 +27,9 @@
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <X11/Xatom.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
 
 #include "TMath.h"
 
@@ -634,7 +634,7 @@ static int XRotDrawHorizontalString(Display *dpy, XFontStruct *font, Drawable dr
       /* move to next line */
       yp+=height;
 
-      str3=my_strtok((char *)0, str2);
+      str3=my_strtok((char *)nullptr, str2);
    }
    while(str3);
 

--- a/graf2d/x11/src/TGX11.cxx
+++ b/graf2d/x11/src/TGX11.cxx
@@ -1613,7 +1613,7 @@ Int_t TGX11::RequestLocator(int mode, int ctyp, int &x, int &y)
 
          case LeaveNotify :
             if (mode == 0) {
-               while (1) {
+               while (true) {
                   XNextEvent((Display*)fDisplay, &event);
                   if (event.type == EnterNotify) break;
                }


### PR DESCRIPTION
This is applying most of the suggestions from the CMSSW clang-tidy configuration:
https://github.com/cms-sw/cmssw/blob/master/.clang-tidy

Two checks are excluded though, because they can make wrong suggestions about replacing copies with const references:

  * `performance-for-range-copy`

  * `performance-unnecessary-copy-initialization`