### PR TITLE
[geom] Apply `clang-tidy` suggestions

### DIFF
--- a/geom/gdml/src/TGDMLParse.cxx
+++ b/geom/gdml/src/TGDMLParse.cxx
@@ -127,13 +127,13 @@ ClassImp(TGDMLParse);
 TGDMLParse::TGDMLParse()
 {
    fWorldName = "";
-   fWorld = 0;
+   fWorld = nullptr;
    fVolID = 0;
    fFILENO = 0;
    for (Int_t i = 0; i < 20; i++)
-      fFileEngine[i] = 0;
-   fStartFile = 0;
-   fCurrentFile = 0;
+      fFileEngine[i] = nullptr;
+   fStartFile = nullptr;
+   fCurrentFile = nullptr;
    auto def_units = gGeoManager->GetDefaultUnits();
    switch (def_units) {
    case TGeoManager::kG4Units:
@@ -163,9 +163,9 @@ TGeoVolume *TGDMLParse::GDMLReadFile(const char *filename)
 
    // Now try to parse xml file
    XMLDocPointer_t gdmldoc = gdml->ParseFile(filename);
-   if (gdmldoc == 0) {
+   if (gdmldoc == nullptr) {
       delete gdml;
-      return 0;
+      return nullptr;
    } else {
 
       // take access to main node
@@ -205,7 +205,7 @@ const char *TGDMLParse::ParseGDML(TXMLEngine *gdml, XMLNodePointer_t node)
    const char *name = gdml->GetNodeName(node);
    XMLNodePointer_t parentn = gdml->GetParent(node);
    const char *parent = gdml->GetNodeName(parentn);
-   XMLNodePointer_t childtmp = 0;
+   XMLNodePointer_t childtmp = nullptr;
 
    const char *posistr = "position";
    const char *setustr = "setup";
@@ -396,7 +396,7 @@ const char *TGDMLParse::ParseGDML(TXMLEngine *gdml, XMLNodePointer_t node)
    // Check for Child node - if present call this funct. recursively until no more
 
    XMLNodePointer_t child = gdml->GetChild(node);
-   while (child != 0) {
+   while (child != nullptr) {
       ParseGDML(gdml, child);
       child = gdml->GetNext(child);
    }
@@ -465,7 +465,7 @@ XMLNodePointer_t TGDMLParse::ConProcess(TXMLEngine *gdml, XMLNodePointer_t node,
    TString value = "";
    TString tempattr;
 
-   while (attr != 0) {
+   while (attr != nullptr) {
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
 
@@ -539,7 +539,7 @@ XMLNodePointer_t TGDMLParse::QuantityProcess(TXMLEngine *gdml, XMLNodePointer_t 
    TString unit = "1.0";
    TString tempattr;
 
-   while (attr != 0) {
+   while (attr != nullptr) {
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
 
@@ -570,7 +570,7 @@ XMLNodePointer_t TGDMLParse::MatrixProcess(TXMLEngine *gdml, XMLNodePointer_t no
    std::string values;
    TString tempattr;
 
-   while (attr != 0) {
+   while (attr != nullptr) {
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
 
@@ -626,7 +626,7 @@ XMLNodePointer_t TGDMLParse::OpticalSurfaceProcess(TXMLEngine *gdml, XMLNodePoin
    Double_t value = 0;
    TString tempattr;
 
-   while (attr != 0) {
+   while (attr != nullptr) {
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
 
@@ -651,10 +651,10 @@ XMLNodePointer_t TGDMLParse::OpticalSurfaceProcess(TXMLEngine *gdml, XMLNodePoin
    TGeoOpticalSurface *surf = new TGeoOpticalSurface(name, model, finish, type, value);
 
    XMLNodePointer_t child = gdml->GetChild(node);
-   while (child != 0) {
+   while (child != nullptr) {
       attr = gdml->GetFirstAttr(child);
       if ((strcmp(gdml->GetNodeName(child), "property")) == 0) {
-         while (attr != 0) {
+         while (attr != nullptr) {
             tempattr = gdml->GetAttrName(attr);
             tempattr.ToLower();
             if (tempattr == "name") {
@@ -862,7 +862,7 @@ XMLNodePointer_t TGDMLParse::PosProcess(TXMLEngine *gdml, XMLNodePointer_t node,
    TString name = "0";
    TString tempattr;
 
-   while (attr != 0) {
+   while (attr != nullptr) {
 
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
@@ -918,7 +918,7 @@ XMLNodePointer_t TGDMLParse::RotProcess(TXMLEngine *gdml, XMLNodePointer_t node,
    TString name = "";
    TString tempattr;
 
-   while (attr != 0) {
+   while (attr != nullptr) {
 
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
@@ -976,7 +976,7 @@ XMLNodePointer_t TGDMLParse::SclProcess(TXMLEngine *gdml, XMLNodePointer_t node,
    TString name = "";
    TString tempattr;
 
-   while (attr != 0) {
+   while (attr != nullptr) {
 
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
@@ -1024,7 +1024,7 @@ XMLNodePointer_t TGDMLParse::IsoProcess(TXMLEngine *gdml, XMLNodePointer_t node,
 
    XMLAttrPointer_t attr = gdml->GetFirstAttr(parentn);
 
-   while (attr != 0) {
+   while (attr != nullptr) {
 
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
@@ -1044,7 +1044,7 @@ XMLNodePointer_t TGDMLParse::IsoProcess(TXMLEngine *gdml, XMLNodePointer_t node,
 
    attr = gdml->GetFirstAttr(node);
 
-   while (attr != 0) {
+   while (attr != nullptr) {
 
       tempattr = gdml->GetAttrName(attr);
 
@@ -1098,7 +1098,7 @@ XMLNodePointer_t TGDMLParse::EleProcess(TXMLEngine *gdml, XMLNodePointer_t node,
    typedef FracMap::iterator fractions;
    FracMap fracmap;
 
-   XMLNodePointer_t child = 0;
+   XMLNodePointer_t child = nullptr;
 
    // obtain attributes for the element
 
@@ -1107,7 +1107,7 @@ XMLNodePointer_t TGDMLParse::EleProcess(TXMLEngine *gdml, XMLNodePointer_t node,
    if (hasIsotopes) {
 
       // Get the name of the element
-      while (attr != 0) {
+      while (attr != nullptr) {
          tempattr = gdml->GetAttrName(attr);
          if (tempattr == "name") {
             name = gdml->GetAttrValue(attr);
@@ -1121,7 +1121,7 @@ XMLNodePointer_t TGDMLParse::EleProcess(TXMLEngine *gdml, XMLNodePointer_t node,
       }
       // Get component isotopes. Loop all children.
       child = gdml->GetChild(node);
-      while (child != 0) {
+      while (child != nullptr) {
 
          // Check for fraction node name
          if ((strcmp(gdml->GetNodeName(child), "fraction")) == 0) {
@@ -1129,7 +1129,7 @@ XMLNodePointer_t TGDMLParse::EleProcess(TXMLEngine *gdml, XMLNodePointer_t node,
             TString ref = "";
             ncompo = ncompo + 1;
             attr = gdml->GetFirstAttr(child);
-            while (attr != 0) {
+            while (attr != nullptr) {
                tempattr = gdml->GetAttrName(attr);
                tempattr.ToLower();
                if (tempattr == "n") {
@@ -1166,7 +1166,7 @@ XMLNodePointer_t TGDMLParse::EleProcess(TXMLEngine *gdml, XMLNodePointer_t node,
 
    if (hasIsotopesExtended) {
 
-      while (attr != 0) {
+      while (attr != nullptr) {
          tempattr = gdml->GetAttrName(attr);
 
          if (tempattr == "name") {
@@ -1181,7 +1181,7 @@ XMLNodePointer_t TGDMLParse::EleProcess(TXMLEngine *gdml, XMLNodePointer_t node,
       }
       // Get component isotopes. Loop all children.
       child = gdml->GetChild(node);
-      while (child != 0) {
+      while (child != nullptr) {
 
          // Check for fraction node name
          if ((strcmp(gdml->GetNodeName(child), "fraction")) == 0) {
@@ -1189,7 +1189,7 @@ XMLNodePointer_t TGDMLParse::EleProcess(TXMLEngine *gdml, XMLNodePointer_t node,
             TString ref = "";
             ncompo = ncompo + 1;
             attr = gdml->GetFirstAttr(child);
-            while (attr != 0) {
+            while (attr != nullptr) {
                tempattr = gdml->GetAttrName(attr);
                tempattr.ToLower();
                if (tempattr == "n") {
@@ -1225,7 +1225,7 @@ XMLNodePointer_t TGDMLParse::EleProcess(TXMLEngine *gdml, XMLNodePointer_t node,
    //***************************
 
    attr = gdml->GetFirstAttr(parentn);
-   while (attr != 0) {
+   while (attr != nullptr) {
 
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
@@ -1246,7 +1246,7 @@ XMLNodePointer_t TGDMLParse::EleProcess(TXMLEngine *gdml, XMLNodePointer_t node,
 
    attr = gdml->GetFirstAttr(node);
 
-   while (attr != 0) {
+   while (attr != nullptr) {
 
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
@@ -1308,8 +1308,8 @@ XMLNodePointer_t TGDMLParse::MatProcess(TXMLEngine *gdml, XMLNodePointer_t node,
    Int_t ncompo = 0, mixflag = 2;
    Double_t density = 0;
    TString name, local_name;
-   TGeoMixture *mix = 0;
-   TGeoMaterial *mat = 0;
+   TGeoMixture *mix = nullptr;
+   TGeoMaterial *mat = nullptr;
    TString tempconst = "";
    TString matname;
    Bool_t composite = kFALSE;
@@ -1324,12 +1324,12 @@ XMLNodePointer_t TGDMLParse::MatProcess(TXMLEngine *gdml, XMLNodePointer_t node,
          local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
       }
 
-      while (child != 0) {
+      while (child != nullptr) {
          attr = gdml->GetFirstAttr(child);
 
          if ((strcmp(gdml->GetNodeName(child), "property")) == 0) {
             TNamed *property = new TNamed();
-            while (attr != 0) {
+            while (attr != nullptr) {
                tempattr = gdml->GetAttrName(attr);
                tempattr.ToLower();
 
@@ -1341,7 +1341,7 @@ XMLNodePointer_t TGDMLParse::MatProcess(TXMLEngine *gdml, XMLNodePointer_t node,
                   if (matrix)
                      properties.Add(property);
                   else {
-                     Bool_t error = 0;
+                     Bool_t error = false;
                      gGeoManager->GetProperty(property->GetTitle(), &error);
                      if (error)
                         Error("MatProcess", "Reference %s for material %s not found", property->GetTitle(),
@@ -1355,7 +1355,7 @@ XMLNodePointer_t TGDMLParse::MatProcess(TXMLEngine *gdml, XMLNodePointer_t node,
          }
 
          if ((strcmp(gdml->GetNodeName(child), "atom")) == 0) {
-            while (attr != 0) {
+            while (attr != nullptr) {
                tempattr = gdml->GetAttrName(attr);
                tempattr.ToLower();
 
@@ -1367,7 +1367,7 @@ XMLNodePointer_t TGDMLParse::MatProcess(TXMLEngine *gdml, XMLNodePointer_t node,
          }
 
          if ((strcmp(gdml->GetNodeName(child), "D")) == 0) {
-            while (attr != 0) {
+            while (attr != nullptr) {
                tempattr = gdml->GetAttrName(attr);
                tempattr.ToLower();
 
@@ -1426,12 +1426,12 @@ XMLNodePointer_t TGDMLParse::MatProcess(TXMLEngine *gdml, XMLNodePointer_t node,
    }
 
    else if (z == 0) {
-      while (child != 0) {
+      while (child != nullptr) {
          attr = gdml->GetFirstAttr(child);
 
          if ((strcmp(gdml->GetNodeName(child), "property")) == 0) {
             TNamed *property = new TNamed();
-            while (attr != 0) {
+            while (attr != nullptr) {
                tempattr = gdml->GetAttrName(attr);
                tempattr.ToLower();
 
@@ -1443,7 +1443,7 @@ XMLNodePointer_t TGDMLParse::MatProcess(TXMLEngine *gdml, XMLNodePointer_t node,
                   if (matrix)
                      properties.Add(property);
                   else {
-                     Bool_t error = 0;
+                     Bool_t error = false;
                      gGeoManager->GetProperty(property->GetTitle(), &error);
                      if (error)
                         Error("MatProcess", "Reference %s for material %s not found", property->GetTitle(),
@@ -1460,7 +1460,7 @@ XMLNodePointer_t TGDMLParse::MatProcess(TXMLEngine *gdml, XMLNodePointer_t node,
             TString ref = "";
             ncompo = ncompo + 1;
 
-            while (attr != 0) {
+            while (attr != nullptr) {
                tempattr = gdml->GetAttrName(attr);
                tempattr.ToLower();
 
@@ -1483,7 +1483,7 @@ XMLNodePointer_t TGDMLParse::MatProcess(TXMLEngine *gdml, XMLNodePointer_t node,
             TString ref = "";
             ncompo = ncompo + 1;
 
-            while (attr != 0) {
+            while (attr != nullptr) {
                tempattr = gdml->GetAttrName(attr);
                tempattr.ToLower();
                if (tempattr == "n") {
@@ -1498,7 +1498,7 @@ XMLNodePointer_t TGDMLParse::MatProcess(TXMLEngine *gdml, XMLNodePointer_t node,
             }
             fracmap[ref.Data()] = n;
          } else if ((strcmp(gdml->GetNodeName(child), "D")) == 0) {
-            while (attr != 0) {
+            while (attr != nullptr) {
                tempattr = gdml->GetAttrName(attr);
                tempattr.ToLower();
 
@@ -1599,7 +1599,7 @@ XMLNodePointer_t TGDMLParse::SkinSurfaceProcess(TXMLEngine *gdml, XMLNodePointer
    TString name, surfname, volname;
    TString tempattr;
 
-   while (attr != 0) {
+   while (attr != nullptr) {
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
 
@@ -1613,10 +1613,10 @@ XMLNodePointer_t TGDMLParse::SkinSurfaceProcess(TXMLEngine *gdml, XMLNodePointer
    }
 
    XMLNodePointer_t child = gdml->GetChild(node);
-   while (child != 0) {
+   while (child != nullptr) {
       attr = gdml->GetFirstAttr(child);
       if ((strcmp(gdml->GetNodeName(child), "volumeref")) == 0) {
-         while (attr != 0) {
+         while (attr != nullptr) {
             tempattr = gdml->GetAttrName(attr);
             tempattr.ToLower();
             if (tempattr == "ref") {
@@ -1645,7 +1645,7 @@ XMLNodePointer_t TGDMLParse::BorderSurfaceProcess(TXMLEngine *gdml, XMLNodePoint
    TString name, surfname, nodename[2];
    TString tempattr;
 
-   while (attr != 0) {
+   while (attr != nullptr) {
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
 
@@ -1660,10 +1660,10 @@ XMLNodePointer_t TGDMLParse::BorderSurfaceProcess(TXMLEngine *gdml, XMLNodePoint
 
    XMLNodePointer_t child = gdml->GetChild(node);
    Int_t inode = 0;
-   while (child != 0) {
+   while (child != nullptr) {
       attr = gdml->GetFirstAttr(child);
       if ((strcmp(gdml->GetNodeName(child), "physvolref")) == 0) {
-         while (attr != 0) {
+         while (attr != nullptr) {
             tempattr = gdml->GetAttrName(attr);
             tempattr.ToLower();
             if (tempattr == "ref") {
@@ -1811,17 +1811,17 @@ XMLNodePointer_t TGDMLParse::VolProcess(TXMLEngine *gdml, XMLNodePointer_t node)
    TString name;
    TString solidname = "";
    TString tempattr = "";
-   TGeoShape *solid = 0;
-   TGeoMedium *medium = 0;
-   TGeoVolume *vol = 0;
-   TGeoVolume *lv = 0;
-   TGeoShape *reflex = 0;
-   const Double_t *parentrot = 0;
+   TGeoShape *solid = nullptr;
+   TGeoMedium *medium = nullptr;
+   TGeoVolume *vol = nullptr;
+   TGeoVolume *lv = nullptr;
+   TGeoShape *reflex = nullptr;
+   const Double_t *parentrot = nullptr;
    int yesrefl = 0;
    TString reftemp = "";
-   TMap *auxmap = 0;
+   TMap *auxmap = nullptr;
 
-   while (child != 0) {
+   while (child != nullptr) {
       if ((strcmp(gdml->GetNodeName(child), "solidref")) == 0) {
 
          reftemp = gdml->GetAttr(child, "ref");
@@ -1859,7 +1859,7 @@ XMLNodePointer_t TGDMLParse::VolProcess(TXMLEngine *gdml, XMLNodePointer_t node)
       local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
    }
 
-   if (reflex == 0) {
+   if (reflex == nullptr) {
       vol = new TGeoVolume(NameShort(name), solid, medium);
    } else {
       vol = new TGeoVolume(NameShort(name), reflex, medium);
@@ -1875,21 +1875,21 @@ XMLNodePointer_t TGDMLParse::VolProcess(TXMLEngine *gdml, XMLNodePointer_t node)
 
    child = gdml->GetChild(node);
 
-   while (child != 0) {
+   while (child != nullptr) {
       if ((strcmp(gdml->GetNodeName(child), "physvol")) == 0) {
 
          TString volref = "";
 
-         TGeoTranslation *pos = 0;
-         TGeoRotation *rot = 0;
-         TGeoScale *scl = 0;
+         TGeoTranslation *pos = nullptr;
+         TGeoRotation *rot = nullptr;
+         TGeoScale *scl = nullptr;
          TString pnodename = gdml->GetAttr(child, "name");
          TString scopynum = gdml->GetAttr(child, "copynumber");
          Int_t copynum = (scopynum.IsNull()) ? 0 : (Int_t)Value(scopynum);
 
          subchild = gdml->GetChild(child);
 
-         while (subchild != 0) {
+         while (subchild != nullptr) {
             tempattr = gdml->GetNodeName(subchild);
             tempattr.ToLower();
 
@@ -1907,7 +1907,7 @@ XMLNodePointer_t TGDMLParse::VolProcess(TXMLEngine *gdml, XMLNodePointer_t node)
                TXMLEngine *gdml2 = new TXMLEngine;
                gdml2->SetSkipComments(kTRUE);
                XMLDocPointer_t filedoc1 = gdml2->ParseFile(fCurrentFile);
-               if (filedoc1 == 0) {
+               if (filedoc1 == nullptr) {
                   Fatal("VolProcess", "Bad filename given %s", fCurrentFile);
                }
                // take access to main node
@@ -1975,12 +1975,12 @@ XMLNodePointer_t TGDMLParse::VolProcess(TXMLEngine *gdml, XMLNodePointer_t node)
 
          TGeoHMatrix *transform = new TGeoHMatrix();
 
-         if (pos != 0)
+         if (pos != nullptr)
             transform->SetTranslation(pos->GetTranslation());
-         if (rot != 0)
+         if (rot != nullptr)
             transform->SetRotation(rot->GetRotationMatrix());
 
-         if (scl != 0) { // Scaling must be added to the rotation matrix!
+         if (scl != nullptr) { // Scaling must be added to the rotation matrix!
 
             Double_t scale3x3[9];
             memset(scale3x3, 0, 9 * sizeof(Double_t));
@@ -2031,7 +2031,7 @@ XMLNodePointer_t TGDMLParse::VolProcess(TXMLEngine *gdml, XMLNodePointer_t node)
 
          attr = gdml->GetFirstAttr(child);
 
-         while (attr != 0) {
+         while (attr != nullptr) {
 
             tempattr = gdml->GetAttrName(attr);
             tempattr.ToLower();
@@ -2054,7 +2054,7 @@ XMLNodePointer_t TGDMLParse::VolProcess(TXMLEngine *gdml, XMLNodePointer_t node)
 
          subchild = gdml->GetChild(child);
 
-         while (subchild != 0) {
+         while (subchild != nullptr) {
             tempattr = gdml->GetNodeName(subchild);
             tempattr.ToLower();
 
@@ -2119,7 +2119,7 @@ XMLNodePointer_t TGDMLParse::VolProcess(TXMLEngine *gdml, XMLNodePointer_t node)
 
          attr = gdml->GetFirstAttr(child);
 
-         while (attr != 0) {
+         while (attr != nullptr) {
 
             tempattr = gdml->GetAttrName(attr);
             tempattr.ToLower();
@@ -2132,7 +2132,7 @@ XMLNodePointer_t TGDMLParse::VolProcess(TXMLEngine *gdml, XMLNodePointer_t node)
 
          subchild = gdml->GetChild(child);
 
-         while (subchild != 0) {
+         while (subchild != nullptr) {
             tempattr = gdml->GetNodeName(subchild);
             tempattr.ToLower();
 
@@ -2148,10 +2148,10 @@ XMLNodePointer_t TGDMLParse::VolProcess(TXMLEngine *gdml, XMLNodePointer_t node)
             if (tempattr == "replicate_along_axis") {
                subsubchild = gdml->GetChild(subchild);
 
-               while (subsubchild != 0) {
+               while (subsubchild != nullptr) {
                   if ((strcmp(gdml->GetNodeName(subsubchild), "width")) == 0) {
                      attr = gdml->GetFirstAttr(subsubchild);
-                     while (attr != 0) {
+                     while (attr != nullptr) {
                         tempattr = gdml->GetAttrName(attr);
                         tempattr.ToLower();
                         if (tempattr == "value") {
@@ -2165,7 +2165,7 @@ XMLNodePointer_t TGDMLParse::VolProcess(TXMLEngine *gdml, XMLNodePointer_t node)
                      }
                   } else if ((strcmp(gdml->GetNodeName(subsubchild), "offset")) == 0) {
                      attr = gdml->GetFirstAttr(subsubchild);
-                     while (attr != 0) {
+                     while (attr != nullptr) {
                         tempattr = gdml->GetAttrName(attr);
                         tempattr.ToLower();
                         if (tempattr == "value") {
@@ -2178,7 +2178,7 @@ XMLNodePointer_t TGDMLParse::VolProcess(TXMLEngine *gdml, XMLNodePointer_t node)
                      }
                   } else if ((strcmp(gdml->GetNodeName(subsubchild), "direction")) == 0) {
                      attr = gdml->GetFirstAttr(subsubchild);
-                     while (attr != 0) {
+                     while (attr != nullptr) {
                         tempattr = gdml->GetAttrName(attr);
                         tempattr.ToLower();
                         if (tempattr == "x") {
@@ -2284,8 +2284,8 @@ XMLNodePointer_t TGDMLParse::BooSolid(TXMLEngine *gdml, XMLNodePointer_t node, X
    TString tempattr = "";
    XMLNodePointer_t child = gdml->GetChild(node);
 
-   TGeoShape *first = 0;
-   TGeoShape *second = 0;
+   TGeoShape *first = nullptr;
+   TGeoShape *second = nullptr;
 
    TGeoTranslation *firstPos = new TGeoTranslation(0, 0, 0);
    TGeoTranslation *secondPos = new TGeoTranslation(0, 0, 0);
@@ -2307,7 +2307,7 @@ XMLNodePointer_t TGDMLParse::BooSolid(TXMLEngine *gdml, XMLNodePointer_t node, X
    if ((strcmp(fCurrentFile, fStartFile)) != 0)
       local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
 
-   while (child != 0) {
+   while (child != nullptr) {
       tempattr = gdml->GetNodeName(child);
       tempattr.ToLower();
 
@@ -2368,7 +2368,7 @@ XMLNodePointer_t TGDMLParse::BooSolid(TXMLEngine *gdml, XMLNodePointer_t node, X
    TGeoMatrix *firstMatrix = new TGeoCombiTrans(*firstPos, firstRot->Inverse());
    TGeoMatrix *secondMatrix = new TGeoCombiTrans(*secondPos, secondRot->Inverse());
 
-   TGeoCompositeShape *boolean = 0;
+   TGeoCompositeShape *boolean = nullptr;
    switch (num) {
    case 1:
       boolean = new TGeoCompositeShape(NameShort(name), new TGeoSubtraction(first, second, firstMatrix, secondMatrix));
@@ -2456,9 +2456,9 @@ XMLNodePointer_t TGDMLParse::AssProcess(TXMLEngine *gdml, XMLNodePointer_t node)
    XMLNodePointer_t subchild;
    XMLNodePointer_t child = gdml->GetChild(node);
    TString tempattr = "";
-   TGeoVolume *lv = 0;
-   TGeoTranslation *pos = 0;
-   TGeoRotation *rot = 0;
+   TGeoVolume *lv = nullptr;
+   TGeoTranslation *pos = nullptr;
+   TGeoRotation *rot = nullptr;
    TGeoCombiTrans *matr;
 
    TGeoVolumeAssembly *assem = new TGeoVolumeAssembly(NameShort(name));
@@ -2467,7 +2467,7 @@ XMLNodePointer_t TGDMLParse::AssProcess(TXMLEngine *gdml, XMLNodePointer_t node)
 
    //   child = gdml->GetChild(node);
 
-   while (child != 0) {
+   while (child != nullptr) {
       if ((strcmp(gdml->GetNodeName(child), "physvol")) == 0) {
          TString pnodename = gdml->GetAttr(child, "name");
          TString scopynum = gdml->GetAttr(child, "copynumber");
@@ -2477,7 +2477,7 @@ XMLNodePointer_t TGDMLParse::AssProcess(TXMLEngine *gdml, XMLNodePointer_t node)
          pos = new TGeoTranslation(0, 0, 0);
          rot = new TGeoRotation();
 
-         while (subchild != 0) {
+         while (subchild != nullptr) {
             tempattr = gdml->GetNodeName(subchild);
             tempattr.ToLower();
 
@@ -2537,7 +2537,7 @@ XMLNodePointer_t TGDMLParse::TopProcess(TXMLEngine *gdml, XMLNodePointer_t node)
    XMLNodePointer_t child = gdml->GetChild(node);
    TString reftemp = "";
 
-   while (child != 0) {
+   while (child != nullptr) {
 
       if ((strcmp(gdml->GetNodeName(child), "world") == 0)) {
          // const char* reftemp;
@@ -2568,7 +2568,7 @@ XMLNodePointer_t TGDMLParse::Box(TXMLEngine *gdml, XMLNodePointer_t node, XMLAtt
    TString name = "";
    TString tempattr;
 
-   while (attr != 0) {
+   while (attr != nullptr) {
 
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
@@ -2629,7 +2629,7 @@ XMLNodePointer_t TGDMLParse::Ellipsoid(TXMLEngine *gdml, XMLNodePointer_t node, 
    TString name = "";
    TString tempattr;
 
-   while (attr != 0) {
+   while (attr != nullptr) {
 
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
@@ -2688,7 +2688,7 @@ XMLNodePointer_t TGDMLParse::Ellipsoid(TXMLEngine *gdml, XMLNodePointer_t node, 
    origin[2] = 0.5 * (z1 + z2);
    Double_t dz = 0.5 * (z2 - z1);
    TGeoBBox *pCutBox = new TGeoBBox("cutBox", dx, dy, dz, origin);
-   TGeoBoolNode *pBoolNode = new TGeoIntersection(shape, pCutBox, 0, 0);
+   TGeoBoolNode *pBoolNode = new TGeoIntersection(shape, pCutBox, nullptr, nullptr);
    TGeoCompositeShape *cs = new TGeoCompositeShape(NameShort(name), pBoolNode);
    fsolmap[local_name.Data()] = cs;
 
@@ -2715,7 +2715,7 @@ XMLNodePointer_t TGDMLParse::ElCone(TXMLEngine *gdml, XMLNodePointer_t node, XML
    TString name = "";
    TString tempattr;
 
-   while (attr != 0) {
+   while (attr != nullptr) {
 
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
@@ -2793,7 +2793,7 @@ XMLNodePointer_t TGDMLParse::Paraboloid(TXMLEngine *gdml, XMLNodePointer_t node,
    TString name = "";
    TString tempattr;
 
-   while (attr != 0) {
+   while (attr != nullptr) {
 
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
@@ -2863,7 +2863,7 @@ XMLNodePointer_t TGDMLParse::Arb8(TXMLEngine *gdml, XMLNodePointer_t node, XMLAt
    TString name = "";
    TString tempattr;
 
-   while (attr != 0) {
+   while (attr != nullptr) {
 
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
@@ -2974,7 +2974,7 @@ XMLNodePointer_t TGDMLParse::Tube(TXMLEngine *gdml, XMLNodePointer_t node, XMLAt
    TString name = "";
    TString tempattr;
 
-   while (attr != 0) {
+   while (attr != nullptr) {
 
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
@@ -3017,7 +3017,7 @@ XMLNodePointer_t TGDMLParse::Tube(TXMLEngine *gdml, XMLNodePointer_t node, XMLAt
    Double_t deltaphideg = Value(deltaphi) * retaunit;
    Double_t endphideg = startphideg + deltaphideg;
 
-   TGeoShape *tube = 0;
+   TGeoShape *tube = nullptr;
    if (deltaphideg < 360.)
       tube = new TGeoTubeSeg(NameShort(name), rminline, rmaxline, zline / 2, startphideg, endphideg);
    else
@@ -3054,7 +3054,7 @@ XMLNodePointer_t TGDMLParse::CutTube(TXMLEngine *gdml, XMLNodePointer_t node, XM
    TString name = "";
    TString tempattr;
 
-   while (attr != 0) {
+   while (attr != nullptr) {
 
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
@@ -3145,7 +3145,7 @@ XMLNodePointer_t TGDMLParse::Cone(TXMLEngine *gdml, XMLNodePointer_t node, XMLAt
    TString name = "";
    TString tempattr;
 
-   while (attr != 0) {
+   while (attr != nullptr) {
 
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
@@ -3194,7 +3194,7 @@ XMLNodePointer_t TGDMLParse::Cone(TXMLEngine *gdml, XMLNodePointer_t node, XMLAt
    Double_t dphi = Value(deltaphi) * retaunit;
    Double_t ephi = sphi + dphi;
 
-   TGeoShape *cone = 0;
+   TGeoShape *cone = nullptr;
    if (dphi < 360.)
       cone = new TGeoConeSeg(NameShort(name), zline / 2, rmin1line, rmax1line, rmin2line, rmax2line, sphi, ephi);
    else
@@ -3232,7 +3232,7 @@ XMLNodePointer_t TGDMLParse::Trap(TXMLEngine *gdml, XMLNodePointer_t node, XMLAt
    TString name = "";
    TString tempattr;
 
-   while (attr != 0) {
+   while (attr != nullptr) {
 
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
@@ -3319,7 +3319,7 @@ XMLNodePointer_t TGDMLParse::Trd(TXMLEngine *gdml, XMLNodePointer_t node, XMLAtt
    TString name = "";
    TString tempattr;
 
-   while (attr != 0) {
+   while (attr != nullptr) {
 
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
@@ -3386,7 +3386,7 @@ XMLNodePointer_t TGDMLParse::Polycone(TXMLEngine *gdml, XMLNodePointer_t node, X
    TString name = "";
    TString tempattr;
 
-   while (attr != 0) {
+   while (attr != nullptr) {
 
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
@@ -3420,7 +3420,7 @@ XMLNodePointer_t TGDMLParse::Polycone(TXMLEngine *gdml, XMLNodePointer_t node, X
    XMLNodePointer_t child = gdml->GetChild(node);
    int numplanes = 0;
 
-   while (child != 0) {
+   while (child != nullptr) {
       numplanes = numplanes + 1;
       child = gdml->GetNext(child);
    }
@@ -3440,7 +3440,7 @@ XMLNodePointer_t TGDMLParse::Polycone(TXMLEngine *gdml, XMLNodePointer_t node, X
    child = gdml->GetChild(node);
    int planeno = 0;
 
-   while (child != 0) {
+   while (child != nullptr) {
       if (strcmp(gdml->GetNodeName(child), "zplane") == 0) {
          // removed original dec
          Double_t rminline = 0;
@@ -3449,7 +3449,7 @@ XMLNodePointer_t TGDMLParse::Polycone(TXMLEngine *gdml, XMLNodePointer_t node, X
 
          attr = gdml->GetFirstAttr(child);
 
-         while (attr != 0) {
+         while (attr != nullptr) {
             tempattr = gdml->GetAttrName(attr);
             tempattr.ToLower();
 
@@ -3516,7 +3516,7 @@ XMLNodePointer_t TGDMLParse::Polyhedra(TXMLEngine *gdml, XMLNodePointer_t node, 
    TString name = "";
    TString tempattr;
 
-   while (attr != 0) {
+   while (attr != nullptr) {
 
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
@@ -3553,7 +3553,7 @@ XMLNodePointer_t TGDMLParse::Polyhedra(TXMLEngine *gdml, XMLNodePointer_t node, 
    XMLNodePointer_t child = gdml->GetChild(node);
    int numplanes = 0;
 
-   while (child != 0) {
+   while (child != nullptr) {
       numplanes = numplanes + 1;
       child = gdml->GetNext(child);
    }
@@ -3573,7 +3573,7 @@ XMLNodePointer_t TGDMLParse::Polyhedra(TXMLEngine *gdml, XMLNodePointer_t node, 
    child = gdml->GetChild(node);
    int planeno = 0;
 
-   while (child != 0) {
+   while (child != nullptr) {
       if (strcmp(gdml->GetNodeName(child), "zplane") == 0) {
 
          Double_t rminline = 0;
@@ -3581,7 +3581,7 @@ XMLNodePointer_t TGDMLParse::Polyhedra(TXMLEngine *gdml, XMLNodePointer_t node, 
          Double_t zline = 0;
          attr = gdml->GetFirstAttr(child);
 
-         while (attr != 0) {
+         while (attr != nullptr) {
             tempattr = gdml->GetAttrName(attr);
             tempattr.ToLower();
 
@@ -3649,7 +3649,7 @@ XMLNodePointer_t TGDMLParse::Sphere(TXMLEngine *gdml, XMLNodePointer_t node, XML
    TString name = "";
    TString tempattr;
 
-   while (attr != 0) {
+   while (attr != nullptr) {
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
 
@@ -3722,7 +3722,7 @@ XMLNodePointer_t TGDMLParse::Torus(TXMLEngine *gdml, XMLNodePointer_t node, XMLA
    TString name = "";
    TString tempattr;
 
-   while (attr != 0) {
+   while (attr != nullptr) {
 
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
@@ -3792,7 +3792,7 @@ XMLNodePointer_t TGDMLParse::Hype(TXMLEngine *gdml, XMLNodePointer_t node, XMLAt
    TString name = "";
    TString tempattr;
 
-   while (attr != 0) {
+   while (attr != nullptr) {
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
 
@@ -3862,7 +3862,7 @@ XMLNodePointer_t TGDMLParse::Para(TXMLEngine *gdml, XMLNodePointer_t node, XMLAt
    TString name = "";
    TString tempattr;
 
-   while (attr != 0) {
+   while (attr != nullptr) {
 
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
@@ -3942,7 +3942,7 @@ XMLNodePointer_t TGDMLParse::TwistTrap(TXMLEngine *gdml, XMLNodePointer_t node, 
    TString name = "";
    TString tempattr;
 
-   while (attr != 0) {
+   while (attr != nullptr) {
 
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
@@ -4031,7 +4031,7 @@ XMLNodePointer_t TGDMLParse::ElTube(TXMLEngine *gdml, XMLNodePointer_t node, XML
    TString name = "";
    TString tempattr;
 
-   while (attr != 0) {
+   while (attr != nullptr) {
 
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
@@ -4084,7 +4084,7 @@ XMLNodePointer_t TGDMLParse::Orb(TXMLEngine *gdml, XMLNodePointer_t node, XMLAtt
    TString name = "";
    TString tempattr;
 
-   while (attr != 0) {
+   while (attr != nullptr) {
 
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
@@ -4141,7 +4141,7 @@ XMLNodePointer_t TGDMLParse::Xtru(TXMLEngine *gdml, XMLNodePointer_t node, XMLAt
    TString name = "";
    TString tempattr;
 
-   while (attr != 0) {
+   while (attr != nullptr) {
 
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();
@@ -4169,7 +4169,7 @@ XMLNodePointer_t TGDMLParse::Xtru(TXMLEngine *gdml, XMLNodePointer_t node, XMLAt
    int nosects = 0;
    int noverts = 0;
 
-   while (child != 0) {
+   while (child != nullptr) {
       tempattr = gdml->GetNodeName(child);
 
       if (tempattr == "twoDimVertex") {
@@ -4201,14 +4201,14 @@ XMLNodePointer_t TGDMLParse::Xtru(TXMLEngine *gdml, XMLNodePointer_t node, XMLAt
    int sect = 0;
    int vert = 0;
 
-   while (child != 0) {
+   while (child != nullptr) {
       if (strcmp(gdml->GetNodeName(child), "twoDimVertex") == 0) {
          Double_t xline = 0;
          Double_t yline = 0;
 
          attr = gdml->GetFirstAttr(child);
 
-         while (attr != 0) {
+         while (attr != nullptr) {
             tempattr = gdml->GetAttrName(attr);
 
             if (tempattr == "x") {
@@ -4235,7 +4235,7 @@ XMLNodePointer_t TGDMLParse::Xtru(TXMLEngine *gdml, XMLNodePointer_t node, XMLAt
 
          attr = gdml->GetFirstAttr(child);
 
-         while (attr != 0) {
+         while (attr != nullptr) {
             tempattr = gdml->GetAttrName(attr);
 
             if (tempattr == "zOrder") {
@@ -4471,7 +4471,7 @@ XMLNodePointer_t TGDMLParse::ScaledSolid(TXMLEngine *gdml, XMLNodePointer_t node
       local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
    }
 
-   while (child != 0) {
+   while (child != nullptr) {
       tempattr = gdml->GetNodeName(child);
       tempattr.ToLower();
       if (tempattr == "solidref") {
@@ -4532,7 +4532,7 @@ XMLNodePointer_t TGDMLParse::Reflection(TXMLEngine *gdml, XMLNodePointer_t node,
    TString solid = "0";
    TString tempattr;
 
-   while (attr != 0) {
+   while (attr != nullptr) {
 
       tempattr = gdml->GetAttrName(attr);
       tempattr.ToLower();

--- a/geom/gdml/src/TGDMLWrite.cxx
+++ b/geom/gdml/src/TGDMLWrite.cxx
@@ -204,20 +204,20 @@ struct MaterialExtractor {
 
 TGDMLWrite::TGDMLWrite()
    : TObject(),
-     fIsotopeList(0),
-     fElementList(0),
-     fAccPatt(0),
-     fRejShape(0),
-     fNameList(0),
+     fIsotopeList(nullptr),
+     fElementList(nullptr),
+     fAccPatt(nullptr),
+     fRejShape(nullptr),
+     fNameList(nullptr),
      fgNamingSpeed(0),
-     fgG4Compatibility(0),
-     fGdmlFile(0),
+     fgG4Compatibility(false),
+     fGdmlFile(nullptr),
      fTopVolumeName(0),
-     fGdmlE(0),
-     fDefineNode(0),
-     fMaterialsNode(0),
-     fSolidsNode(0),
-     fStructureNode(0),
+     fGdmlE(nullptr),
+     fDefineNode(nullptr),
+     fMaterialsNode(nullptr),
+     fSolidsNode(nullptr),
+     fStructureNode(nullptr),
      fVolCnt(0),
      fPhysVolCnt(0),
      fActNameErr(0),
@@ -240,7 +240,7 @@ TGDMLWrite::~TGDMLWrite()
    delete fRejShape;
    delete fNameList;
 
-   fgGDMLWrite = 0;
+   fgGDMLWrite = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -607,7 +607,7 @@ void TGDMLWrite::ExtractVolumes(TGeoNode *node)
    XMLNodePointer_t volumeN, childN;
    TGeoVolume *volume = node->GetVolume();
    TString volname, matname, solname, pattClsName, nodeVolNameBak;
-   TGeoPatternFinder *pattFinder = 0;
+   TGeoPatternFinder *pattFinder = nullptr;
    Bool_t isPattern = kFALSE;
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
 
@@ -2142,7 +2142,7 @@ XMLNodePointer_t TGDMLWrite::CreatePhysVolN(const char *name, Int_t copyno, cons
 XMLNodePointer_t TGDMLWrite::CreateDivisionN(Double_t offset, Double_t width, Int_t number, const char *axis,
                                              const char *unit, const char *volref)
 {
-   XMLNodePointer_t childN = 0;
+   XMLNodePointer_t childN = nullptr;
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "divisionvol", nullptr);
    fGdmlE->NewAttr(mainN, nullptr, "axis", axis);
    fGdmlE->NewAttr(mainN, nullptr, "number", TString::Format("%i", number));

--- a/geom/geom/src/TGeoArb8.cxx
+++ b/geom/geom/src/TGeoArb8.cxx
@@ -1400,7 +1400,7 @@ TGeoTrap::TGeoTrap()
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor providing just a range in Z, theta and phi.
 
-TGeoTrap::TGeoTrap(Double_t dz, Double_t theta, Double_t phi) : TGeoArb8("", 0, 0)
+TGeoTrap::TGeoTrap(Double_t dz, Double_t theta, Double_t phi) : TGeoArb8("", 0, nullptr)
 {
    fDz = dz;
    fTheta = theta;
@@ -1413,7 +1413,7 @@ TGeoTrap::TGeoTrap(Double_t dz, Double_t theta, Double_t phi) : TGeoArb8("", 0, 
 
 TGeoTrap::TGeoTrap(Double_t dz, Double_t theta, Double_t phi, Double_t h1, Double_t bl1, Double_t tl1, Double_t alpha1,
                    Double_t h2, Double_t bl2, Double_t tl2, Double_t alpha2)
-   : TGeoArb8("", 0, 0)
+   : TGeoArb8("", 0, nullptr)
 {
    fDz = dz;
    fTheta = theta;
@@ -1458,7 +1458,7 @@ TGeoTrap::TGeoTrap(Double_t dz, Double_t theta, Double_t phi, Double_t h1, Doubl
 
 TGeoTrap::TGeoTrap(const char *name, Double_t dz, Double_t theta, Double_t phi, Double_t h1, Double_t bl1, Double_t tl1,
                    Double_t alpha1, Double_t h2, Double_t bl2, Double_t tl2, Double_t alpha2)
-   : TGeoArb8(name, 0, 0)
+   : TGeoArb8(name, 0, nullptr)
 {
    SetName(name);
    fDz = dz;
@@ -1713,7 +1713,7 @@ TGeoTrap::Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndi
    TString opt = "";          //--- option to be attached
    if (iaxis != 3) {
       Error("Divide", "cannot divide trapezoids on other axis than Z");
-      return 0;
+      return nullptr;
    }
    Double_t end = start + ndiv * step;
    Double_t points_lo[8];
@@ -1754,10 +1754,10 @@ TGeoTrap::Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndi
 TGeoShape *TGeoTrap::GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix * /*mat*/) const
 {
    if (!TestShapeBit(kGeoRunTimeShape))
-      return 0;
+      return nullptr;
    if (mother->IsRunTimeShape()) {
       Error("GetMakeRuntimeShape", "invalid mother");
-      return 0;
+      return nullptr;
    }
    Double_t dz, h1, bl1, tl1, h2, bl2, tl2;
    if (fDz < 0)
@@ -2117,10 +2117,10 @@ TGeoGtra::DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact
 TGeoShape *TGeoGtra::GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix * /*mat*/) const
 {
    if (!TestShapeBit(kGeoRunTimeShape))
-      return 0;
+      return nullptr;
    if (mother->IsRunTimeShape()) {
       Error("GetMakeRuntimeShape", "invalid mother");
-      return 0;
+      return nullptr;
    }
    Double_t dz, h1, bl1, tl1, h2, bl2, tl2;
    if (fDz < 0)

--- a/geom/geom/src/TGeoBBox.cxx
+++ b/geom/geom/src/TGeoBBox.cxx
@@ -343,7 +343,7 @@ TGeoBBox::Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndi
       finder = new TGeoPatternZ(voldiv, ndiv, start, end);
       opt = "Z";
       break;
-   default: Error("Divide", "Wrong axis type for division"); return 0;
+   default: Error("Divide", "Wrong axis type for division"); return nullptr;
    }
    vol = new TGeoVolume(divname, shape, voldiv->GetMedium());
    vmulti = gGeoManager->MakeVolumeMulti(divname, voldiv->GetMedium());
@@ -829,12 +829,12 @@ Int_t TGeoBBox::GetFittingBox(const TGeoBBox *parambox, TGeoMatrix *mat, Double_
 TGeoShape *TGeoBBox::GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix *mat) const
 {
    if (!TestShapeBit(kGeoRunTimeShape))
-      return 0;
+      return nullptr;
    Double_t dx, dy, dz;
    Int_t ierr = mother->GetFittingBox(this, mat, dx, dy, dz);
    if (ierr) {
       Error("GetMakeRuntimeShape", "cannot fit this to mother");
-      return 0;
+      return nullptr;
    }
    return (new TGeoBBox(dx, dy, dz));
 }

--- a/geom/geom/src/TGeoBoolNode.cxx
+++ b/geom/geom/src/TGeoBoolNode.cxx
@@ -103,7 +103,7 @@ void TGeoBoolNode::CreateThreadData(Int_t nthreads)
    fThreadData.resize(nthreads);
    fThreadSize = nthreads;
    for (Int_t tid = 0; tid < nthreads; tid++) {
-      if (fThreadData[tid] == 0) {
+      if (fThreadData[tid] == nullptr) {
          fThreadData[tid] = new ThreadData_t;
       }
    }
@@ -1091,7 +1091,7 @@ Double_t TGeoSubtraction::DistFromOutside(const Double_t *point, const Double_t 
    // check if inside '-'
    Bool_t inside = fRight->Contains(&local[0]);
    Double_t epsil = 0.;
-   while (1) {
+   while (true) {
       if (inside) {
          // propagate to outside of '-'
          node->SetSelected(2);
@@ -1541,7 +1541,7 @@ Double_t TGeoIntersection::DistFromOutside(const Double_t *point, const Double_t
          return snext;
    }
 
-   while (1) {
+   while (true) {
       d1 = d2 = 0;
       if (!inleft) {
          d1 = fLeft->DistFromOutside(lpt, ldir, 3);

--- a/geom/geom/src/TGeoBranchArray.cxx
+++ b/geom/geom/src/TGeoBranchArray.cxx
@@ -50,11 +50,11 @@ TGeoBranchArray::TGeoBranchArray(Int_t maxlevel) : fLevel(-1), fMaxLevel(maxleve
 
 TGeoBranchArray *TGeoBranchArray::MakeInstance(size_t maxlevel)
 {
-   TGeoBranchArray *ba = 0;
+   TGeoBranchArray *ba = nullptr;
    size_t needed = SizeOf(maxlevel);
    char *ptr = new char[needed];
    if (!ptr)
-      return 0;
+      return nullptr;
    new (ptr) TGeoBranchArray(maxlevel);
    ba = reinterpret_cast<TGeoBranchArray *>(ptr);
    ba->SetBit(kBASelfAlloc, kTRUE);
@@ -68,7 +68,7 @@ TGeoBranchArray *TGeoBranchArray::MakeInstance(size_t maxlevel)
 
 TGeoBranchArray *TGeoBranchArray::MakeInstanceAt(size_t maxlevel, void *addr)
 {
-   TGeoBranchArray *ba = 0;
+   TGeoBranchArray *ba = nullptr;
    new (addr) TGeoBranchArray(maxlevel);
    ba = reinterpret_cast<TGeoBranchArray *>(addr);
    ba->SetBit(kBASelfAlloc, kFALSE);
@@ -80,11 +80,11 @@ TGeoBranchArray *TGeoBranchArray::MakeInstanceAt(size_t maxlevel, void *addr)
 
 TGeoBranchArray *TGeoBranchArray::MakeCopy(const TGeoBranchArray &other)
 {
-   TGeoBranchArray *copy = 0;
+   TGeoBranchArray *copy = nullptr;
    size_t needed = SizeOf(other.fMaxLevel);
    char *ptr = new char[needed];
    if (!ptr)
-      return 0;
+      return nullptr;
    new (ptr) TGeoBranchArray(other.fMaxLevel);
    copy = reinterpret_cast<TGeoBranchArray *>(ptr);
    copy->SetBit(kBASelfAlloc, kTRUE);
@@ -100,7 +100,7 @@ TGeoBranchArray *TGeoBranchArray::MakeCopy(const TGeoBranchArray &other)
 
 TGeoBranchArray *TGeoBranchArray::MakeCopyAt(const TGeoBranchArray &other, void *addr)
 {
-   TGeoBranchArray *copy = 0;
+   TGeoBranchArray *copy = nullptr;
    new (addr) TGeoBranchArray(other.fMaxLevel);
    copy = reinterpret_cast<TGeoBranchArray *>(addr);
    copy->SetBit(kBASelfAlloc, kFALSE);
@@ -154,7 +154,7 @@ void TGeoBranchArray::UpdateArray(size_t nobj)
 /// Copy constructor. Not callable anymore. Use TGeoBranchArray::MakeCopy instead
 
 TGeoBranchArray::TGeoBranchArray(const TGeoBranchArray &other)
-   : TObject(other), fLevel(other.fLevel), fMaxLevel(other.fMaxLevel), fMatrix(other.fMatrix), fArray(NULL)
+   : TObject(other), fLevel(other.fLevel), fMaxLevel(other.fMaxLevel), fMatrix(other.fMatrix), fArray(nullptr)
 {
    if (fMaxLevel) {
       fArray = new TGeoNode *[fMaxLevel];

--- a/geom/geom/src/TGeoBuilder.cxx
+++ b/geom/geom/src/TGeoBuilder.cxx
@@ -49,7 +49,7 @@ geometries.
 
 ClassImp(TGeoBuilder);
 
-TGeoBuilder *TGeoBuilder::fgInstance = NULL;
+TGeoBuilder *TGeoBuilder::fgInstance = nullptr;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Default constructor.
@@ -74,7 +74,7 @@ TGeoBuilder *TGeoBuilder::Instance(TGeoManager *geom)
 {
    if (!geom) {
       printf("ERROR: Cannot create geometry builder with NULL geometry\n");
-      return NULL;
+      return nullptr;
    }
    if (!fgInstance)
       fgInstance = new TGeoBuilder();
@@ -155,7 +155,7 @@ TGeoVolume *TGeoBuilder::MakeArb8(const char *name, TGeoMedium *medium, Double_t
 TGeoVolume *TGeoBuilder::MakeBox(const char *name, TGeoMedium *medium, Double_t dx, Double_t dy, Double_t dz)
 {
    TGeoBBox *box = new TGeoBBox(name, dx, dy, dz);
-   TGeoVolume *vol = 0;
+   TGeoVolume *vol = nullptr;
    if (box->IsRunTimeShape()) {
       vol = fGeometry->MakeVolumeMulti(name, medium);
       vol->SetShape(box);
@@ -175,9 +175,9 @@ TGeoVolume *TGeoBuilder::MakePara(const char *name, TGeoMedium *medium, Double_t
       Warning("MakePara", "parallelepiped %s having alpha=0, theta=0 -> making box instead", name);
       return MakeBox(name, medium, dx, dy, dz);
    }
-   TGeoPara *para = 0;
+   TGeoPara *para = nullptr;
    para = new TGeoPara(name, dx, dy, dz, alpha, theta, phi);
-   TGeoVolume *vol = 0;
+   TGeoVolume *vol = nullptr;
    if (para->IsRunTimeShape()) {
       vol = fGeometry->MakeVolumeMulti(name, medium);
       vol->SetShape(para);
@@ -218,7 +218,7 @@ TGeoVolume *TGeoBuilder::MakeTube(const char *name, TGeoMedium *medium, Double_t
       Error("MakeTube", "tube %s, Rmin=%g greater than Rmax=%g", name, rmin, rmax);
    }
    TGeoTube *tube = new TGeoTube(name, rmin, rmax, dz);
-   TGeoVolume *vol = 0;
+   TGeoVolume *vol = nullptr;
    if (tube->IsRunTimeShape()) {
       vol = fGeometry->MakeVolumeMulti(name, medium);
       vol->SetShape(tube);
@@ -235,7 +235,7 @@ TGeoVolume *TGeoBuilder::MakeTubs(const char *name, TGeoMedium *medium, Double_t
                                   Double_t phi1, Double_t phi2)
 {
    TGeoTubeSeg *tubs = new TGeoTubeSeg(name, rmin, rmax, dz, phi1, phi2);
-   TGeoVolume *vol = 0;
+   TGeoVolume *vol = nullptr;
    if (tubs->IsRunTimeShape()) {
       vol = fGeometry->MakeVolumeMulti(name, medium);
       vol->SetShape(tubs);
@@ -251,7 +251,7 @@ TGeoVolume *TGeoBuilder::MakeTubs(const char *name, TGeoMedium *medium, Double_t
 TGeoVolume *TGeoBuilder::MakeEltu(const char *name, TGeoMedium *medium, Double_t a, Double_t b, Double_t dz)
 {
    TGeoEltu *eltu = new TGeoEltu(name, a, b, dz);
-   TGeoVolume *vol = 0;
+   TGeoVolume *vol = nullptr;
    if (eltu->IsRunTimeShape()) {
       vol = fGeometry->MakeVolumeMulti(name, medium);
       vol->SetShape(eltu);
@@ -268,7 +268,7 @@ TGeoVolume *TGeoBuilder::MakeHype(const char *name, TGeoMedium *medium, Double_t
                                   Double_t stout, Double_t dz)
 {
    TGeoHype *hype = new TGeoHype(name, rin, stin, rout, stout, dz);
-   TGeoVolume *vol = 0;
+   TGeoVolume *vol = nullptr;
    if (hype->IsRunTimeShape()) {
       vol = fGeometry->MakeVolumeMulti(name, medium);
       vol->SetShape(hype);
@@ -284,7 +284,7 @@ TGeoVolume *TGeoBuilder::MakeHype(const char *name, TGeoMedium *medium, Double_t
 TGeoVolume *TGeoBuilder::MakeParaboloid(const char *name, TGeoMedium *medium, Double_t rlo, Double_t rhi, Double_t dz)
 {
    TGeoParaboloid *parab = new TGeoParaboloid(name, rlo, rhi, dz);
-   TGeoVolume *vol = 0;
+   TGeoVolume *vol = nullptr;
    if (parab->IsRunTimeShape()) {
       vol = fGeometry->MakeVolumeMulti(name, medium);
       vol->SetShape(parab);
@@ -313,7 +313,7 @@ TGeoVolume *TGeoBuilder::MakeCone(const char *name, TGeoMedium *medium, Double_t
                                   Double_t rmin2, Double_t rmax2)
 {
    TGeoCone *cone = new TGeoCone(name, dz, rmin1, rmax1, rmin2, rmax2);
-   TGeoVolume *vol = 0;
+   TGeoVolume *vol = nullptr;
    if (cone->IsRunTimeShape()) {
       vol = fGeometry->MakeVolumeMulti(name, medium);
       vol->SetShape(cone);
@@ -330,7 +330,7 @@ TGeoVolume *TGeoBuilder::MakeCons(const char *name, TGeoMedium *medium, Double_t
                                   Double_t rmin2, Double_t rmax2, Double_t phi1, Double_t phi2)
 {
    TGeoConeSeg *cons = new TGeoConeSeg(name, dz, rmin1, rmax1, rmin2, rmax2, phi1, phi2);
-   TGeoVolume *vol = 0;
+   TGeoVolume *vol = nullptr;
    if (cons->IsRunTimeShape()) {
       vol = fGeometry->MakeVolumeMulti(name, medium);
       vol->SetShape(cons);
@@ -368,7 +368,7 @@ TGeoVolume *
 TGeoBuilder::MakeTrd1(const char *name, TGeoMedium *medium, Double_t dx1, Double_t dx2, Double_t dy, Double_t dz)
 {
    TGeoTrd1 *trd1 = new TGeoTrd1(name, dx1, dx2, dy, dz);
-   TGeoVolume *vol = 0;
+   TGeoVolume *vol = nullptr;
    if (trd1->IsRunTimeShape()) {
       vol = fGeometry->MakeVolumeMulti(name, medium);
       vol->SetShape(trd1);
@@ -385,7 +385,7 @@ TGeoVolume *TGeoBuilder::MakeTrd2(const char *name, TGeoMedium *medium, Double_t
                                   Double_t dy2, Double_t dz)
 {
    TGeoTrd2 *trd2 = new TGeoTrd2(name, dx1, dx2, dy1, dy2, dz);
-   TGeoVolume *vol = 0;
+   TGeoVolume *vol = nullptr;
    if (trd2->IsRunTimeShape()) {
       vol = fGeometry->MakeVolumeMulti(name, medium);
       vol->SetShape(trd2);
@@ -479,7 +479,7 @@ TGeoVolume *TGeoBuilder::Division(const char *name, const char *mother, Int_t ia
 
    Error("Division", "VOLUME: \"%s\" not defined", mname);
 
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -589,8 +589,8 @@ TGeoMedium *TGeoBuilder::Medium(const char *name, Int_t numed, Int_t nmat, Int_t
 void TGeoBuilder::Node(const char *name, Int_t nr, const char *mother, Double_t x, Double_t y, Double_t z, Int_t irot,
                        Bool_t isOnly, Float_t *upar, Int_t npar)
 {
-   TGeoVolume *amother = 0;
-   TGeoVolume *volume = 0;
+   TGeoVolume *amother = nullptr;
+   TGeoVolume *volume = nullptr;
 
    // look into special volume list first
    amother = fGeometry->FindVolumeFast(mother, kTRUE);
@@ -690,7 +690,7 @@ void TGeoBuilder::Node(const char *name, Int_t nr, const char *mother, Double_t 
       vmulti->AddVolume(volume);
    }
    if (irot) {
-      TGeoRotation *matrix = 0;
+      TGeoRotation *matrix = nullptr;
       TGeoMatrix *mat;
       TIter next(fGeometry->GetListOfMatrices());
       while ((mat = (TGeoMatrix *)next())) {
@@ -741,8 +741,8 @@ void TGeoBuilder::Node(const char *name, Int_t nr, const char *mother, Double_t 
 void TGeoBuilder::Node(const char *name, Int_t nr, const char *mother, Double_t x, Double_t y, Double_t z, Int_t irot,
                        Bool_t isOnly, Double_t *upar, Int_t npar)
 {
-   TGeoVolume *amother = 0;
-   TGeoVolume *volume = 0;
+   TGeoVolume *amother = nullptr;
+   TGeoVolume *volume = nullptr;
 
    // look into special volume list first
    amother = fGeometry->FindVolumeFast(mother, kTRUE);
@@ -842,7 +842,7 @@ void TGeoBuilder::Node(const char *name, Int_t nr, const char *mother, Double_t 
       vmulti->AddVolume(volume);
    }
    if (irot) {
-      TGeoRotation *matrix = 0;
+      TGeoRotation *matrix = nullptr;
       TGeoMatrix *mat;
       TIter next(fGeometry->GetListOfMatrices());
       while ((mat = (TGeoMatrix *)next())) {
@@ -886,11 +886,11 @@ void TGeoBuilder::Node(const char *name, Int_t nr, const char *mother, Double_t 
 TGeoVolume *TGeoBuilder::Volume(const char *name, const char *shape, Int_t nmed, Float_t *upar, Int_t npar)
 {
    Int_t i;
-   TGeoVolume *volume = 0;
+   TGeoVolume *volume = nullptr;
    TGeoMedium *medium = fGeometry->GetMedium(nmed);
    if (!medium) {
       Error("Volume", "cannot create volume: %s, medium: %d is unknown", name, nmed);
-      return 0;
+      return nullptr;
    }
    TString sh = shape;
    TString sname = name;
@@ -903,7 +903,7 @@ TGeoVolume *TGeoBuilder::Volume(const char *name, const char *shape, Int_t nmed,
       TGeoVolumeMulti *vmulti = (TGeoVolumeMulti *)fGeometry->GetListOfGVolumes()->FindObject(vname);
       if (!vmulti) {
          Error("Volume", "volume multi: %s not created", vname);
-         return 0;
+         return nullptr;
       }
       return vmulti;
    }
@@ -956,7 +956,7 @@ TGeoVolume *TGeoBuilder::Volume(const char *name, const char *shape, Int_t nmed,
 
    if (!volume) {
       Error("Volume", "volume: %s not created", vname);
-      return 0;
+      return nullptr;
    }
    return volume;
 }
@@ -972,11 +972,11 @@ TGeoVolume *TGeoBuilder::Volume(const char *name, const char *shape, Int_t nmed,
 TGeoVolume *TGeoBuilder::Volume(const char *name, const char *shape, Int_t nmed, Double_t *upar, Int_t npar)
 {
    Int_t i;
-   TGeoVolume *volume = 0;
+   TGeoVolume *volume = nullptr;
    TGeoMedium *medium = fGeometry->GetMedium(nmed);
    if (!medium) {
       Error("Volume", "cannot create volume: %s, medium: %d is unknown", name, nmed);
-      return 0;
+      return nullptr;
    }
    TString sh = shape;
    TString sname = name;
@@ -989,7 +989,7 @@ TGeoVolume *TGeoBuilder::Volume(const char *name, const char *shape, Int_t nmed,
       TGeoVolumeMulti *vmulti = (TGeoVolumeMulti *)fGeometry->GetListOfGVolumes()->FindObject(vname);
       if (!vmulti) {
          Error("Volume", "volume multi: %s not created", vname);
-         return 0;
+         return nullptr;
       }
       return vmulti;
    }
@@ -1042,7 +1042,7 @@ TGeoVolume *TGeoBuilder::Volume(const char *name, const char *shape, Int_t nmed,
 
    if (!volume) {
       Error("Volume", "volume: %s not created", vname);
-      return 0;
+      return nullptr;
    }
    return volume;
 }

--- a/geom/geom/src/TGeoCache.cxx
+++ b/geom/geom/src/TGeoCache.cxx
@@ -42,16 +42,16 @@ TGeoNodeCache::TGeoNodeCache()
    fCurrentID = 0;
    fIndex = 0;
    fPath = "";
-   fTop = 0;
-   fNode = 0;
-   fMatrix = 0;
-   fStack = 0;
-   fMatrixBranch = 0;
-   fMPB = 0;
-   fNodeBranch = 0;
-   fInfoBranch = 0;
-   fPWInfo = 0;
-   fNodeIdArray = 0;
+   fTop = nullptr;
+   fNode = nullptr;
+   fMatrix = nullptr;
+   fStack = nullptr;
+   fMatrixBranch = nullptr;
+   fMPB = nullptr;
+   fNodeBranch = nullptr;
+   fInfoBranch = nullptr;
+   fPWInfo = nullptr;
+   fNodeIdArray = nullptr;
    for (Int_t i = 0; i < 100; i++)
       fIdBranch[i] = 0;
 }
@@ -81,16 +81,16 @@ TGeoNodeCache::TGeoNodeCache(TGeoNode *top, Bool_t nodeid, Int_t capacity)
    fInfoBranch = new TGeoStateInfo *[fGeoInfoStackSize];
    for (Int_t i = 0; i < fGeoCacheMaxLevels; i++) {
       fMPB[i] = new TGeoHMatrix(TString::Format("global_%d", i));
-      fMatrixBranch[i] = 0;
-      fNodeBranch[i] = 0;
+      fMatrixBranch[i] = nullptr;
+      fNodeBranch[i] = nullptr;
    }
    for (Int_t i = 0; i < fGeoInfoStackSize; i++) {
-      fInfoBranch[i] = 0;
+      fInfoBranch[i] = nullptr;
    }
-   fPWInfo = 0;
+   fPWInfo = nullptr;
    fMatrix = fMatrixBranch[0] = fMPB[0];
    fNodeBranch[0] = top;
-   fNodeIdArray = 0;
+   fNodeIdArray = nullptr;
    for (Int_t i = 0; i < 100; i++)
       fIdBranch[i] = 0;
    if (nodeid)
@@ -393,7 +393,7 @@ Int_t TGeoNodeCache::PushState(Bool_t ovlp, Int_t startlevel, Int_t nmany, Doubl
 Bool_t TGeoNodeCache::PopState(Int_t &nmany, Double_t *point)
 {
    if (!fStackLevel)
-      return 0;
+      return false;
    Bool_t ovlp = ((TGeoCacheState *)fStack->At(--fStackLevel))->GetState(fLevel, nmany, point);
    Refresh();
    //   return (fStackLevel+1);
@@ -406,7 +406,7 @@ Bool_t TGeoNodeCache::PopState(Int_t &nmany, Double_t *point)
 Bool_t TGeoNodeCache::PopState(Int_t &nmany, Int_t level, Double_t *point)
 {
    if (level <= 0)
-      return 0;
+      return false;
    Bool_t ovlp = ((TGeoCacheState *)fStack->At(level - 1))->GetState(fLevel, nmany, point);
    Refresh();
    return ovlp;
@@ -491,9 +491,9 @@ TGeoCacheState::TGeoCacheState()
    memset(fIdBranch, 0, 30 * sizeof(Int_t));
    memset(fPoint, 0, 3 * sizeof(Int_t));
    fOverlapping = kFALSE;
-   fNodeBranch = 0;
-   fMatrixBranch = 0;
-   fMatPtr = 0;
+   fNodeBranch = nullptr;
+   fMatrixBranch = nullptr;
+   fMatPtr = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -513,7 +513,7 @@ TGeoCacheState::TGeoCacheState(Int_t capacity)
    fMatPtr = new TGeoHMatrix *[capacity];
    for (Int_t i = 0; i < capacity; i++) {
       fMatrixBranch[i] = new TGeoHMatrix("global");
-      fNodeBranch[i] = 0;
+      fNodeBranch[i] = nullptr;
    }
 }
 
@@ -603,7 +603,7 @@ void TGeoCacheState::SetState(Int_t level, Int_t startlevel, Int_t nmany, Bool_t
    Int_t nelem = level + 1 - fStart;
    memcpy(fNodeBranch, node_branch + fStart, nelem * sizeof(TGeoNode *));
    memcpy(fMatPtr, mat_branch + fStart, nelem * sizeof(TGeoHMatrix *));
-   TGeoHMatrix *last = 0;
+   TGeoHMatrix *last = nullptr;
    TGeoHMatrix *current;
    for (Int_t i = 0; i < nelem; i++) {
       current = mat_branch[i + fStart];
@@ -632,7 +632,7 @@ Bool_t TGeoCacheState::GetState(Int_t &level, Int_t &nmany, Double_t *point) con
    Int_t nelem = level + 1 - fStart;
    memcpy(node_branch + fStart, fNodeBranch, nelem * sizeof(TGeoNode *));
    memcpy(mat_branch + fStart, fMatPtr, (level + 1 - fStart) * sizeof(TGeoHMatrix *));
-   TGeoHMatrix *last = 0;
+   TGeoHMatrix *last = nullptr;
    TGeoHMatrix *current;
    for (Int_t i = 0; i < nelem; i++) {
       current = mat_branch[i + fStart];

--- a/geom/geom/src/TGeoCompositeShape.cxx
+++ b/geom/geom/src/TGeoCompositeShape.cxx
@@ -218,7 +218,7 @@ void TGeoCompositeShape::CreateThreadData(Int_t nthreads)
 TGeoCompositeShape::TGeoCompositeShape() : TGeoBBox(0, 0, 0)
 {
    SetShapeBit(TGeoShape::kGeoComb);
-   fNode = 0;
+   fNode = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -228,7 +228,7 @@ TGeoCompositeShape::TGeoCompositeShape(const char *name, const char *expression)
 {
    SetShapeBit(TGeoShape::kGeoComb);
    SetName(name);
-   fNode = 0;
+   fNode = nullptr;
    MakeNode(expression);
    if (!fNode) {
       Error("ctor", "Composite %s: cannot parse expression: %s", name, expression);
@@ -243,7 +243,7 @@ TGeoCompositeShape::TGeoCompositeShape(const char *name, const char *expression)
 TGeoCompositeShape::TGeoCompositeShape(const char *expression) : TGeoBBox(0, 0, 0)
 {
    SetShapeBit(TGeoShape::kGeoComb);
-   fNode = 0;
+   fNode = nullptr;
    MakeNode(expression);
    if (!fNode) {
       TString message = TString::Format("Composite (no name) could not parse expression %s", expression);
@@ -369,7 +369,7 @@ TGeoVolume *TGeoCompositeShape::Divide(TGeoVolume * /*voldiv*/, const char * /*d
                                        Int_t /*ndiv*/, Double_t /*start*/, Double_t /*step*/)
 {
    Error("Divide", "Composite shapes cannot be divided");
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -401,7 +401,7 @@ void TGeoCompositeShape::MakeNode(const char *expression)
 {
    if (fNode)
       delete fNode;
-   fNode = 0;
+   fNode = nullptr;
    SetTitle(expression);
    TString sleft, sright, smat;
    Int_t boolop;

--- a/geom/geom/src/TGeoCone.cxx
+++ b/geom/geom/src/TGeoCone.cxx
@@ -628,7 +628,7 @@ TGeoCone::Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndi
    switch (iaxis) {
    case 1: //---              R division
       Error("Divide", "division of a cone on R not implemented");
-      return 0;
+      return nullptr;
    case 2: // ---             Phi division
       finder = new TGeoPatternCylPhi(voldiv, ndiv, start, end);
       voldiv->SetFinder(finder);
@@ -663,7 +663,7 @@ TGeoCone::Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndi
          ((TGeoNodeOffset *)voldiv->GetNodes()->At(voldiv->GetNdaughters() - 1))->SetFinder(finder);
       }
       return vmulti;
-   default: Error("Divide", "Wrong axis type for division"); return 0;
+   default: Error("Divide", "Wrong axis type for division"); return nullptr;
    }
 }
 
@@ -723,10 +723,10 @@ void TGeoCone::GetBoundingCylinder(Double_t *param) const
 TGeoShape *TGeoCone::GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix * /*mat*/) const
 {
    if (!TestShapeBit(kGeoRunTimeShape))
-      return 0;
+      return nullptr;
    if (!mother->TestShapeBit(kGeoCone)) {
       Error("GetMakeRuntimeShape", "invalid mother");
-      return 0;
+      return nullptr;
    }
    Double_t rmin1, rmax1, rmin2, rmax2, dz;
    rmin1 = fRmin1;
@@ -2090,7 +2090,7 @@ TGeoConeSeg::Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t 
    switch (iaxis) {
    case 1: //---               R division
       Error("Divide", "division of a cone segment on R not implemented");
-      return 0;
+      return nullptr;
    case 2: //---               Phi division
       dphi = fPhi2 - fPhi1;
       if (dphi < 0)
@@ -2128,7 +2128,7 @@ TGeoConeSeg::Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t 
          ((TGeoNodeOffset *)voldiv->GetNodes()->At(voldiv->GetNdaughters() - 1))->SetFinder(finder);
       }
       return vmulti;
-   default: Error("Divide", "Wrong axis type for division"); return 0;
+   default: Error("Divide", "Wrong axis type for division"); return nullptr;
    }
 }
 
@@ -2178,10 +2178,10 @@ void TGeoConeSeg::GetBoundingCylinder(Double_t *param) const
 TGeoShape *TGeoConeSeg::GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix * /*mat*/) const
 {
    if (!TestShapeBit(kGeoRunTimeShape))
-      return 0;
+      return nullptr;
    if (!mother->TestShapeBit(kGeoConeSeg)) {
       Error("GetMakeRuntimeShape", "invalid mother");
-      return 0;
+      return nullptr;
    }
    Double_t rmin1, rmax1, rmin2, rmax2, dz;
    rmin1 = fRmin1;

--- a/geom/geom/src/TGeoElement.cxx
+++ b/geom/geom/src/TGeoElement.cxx
@@ -354,7 +354,7 @@ TGeoIsotope *TGeoIsotope::FindIsotope(const char *name)
 {
    TGeoElementTable *elTable = TGeoElement::GetElementTable();
    if (!elTable)
-      return 0;
+      return nullptr;
    return elTable->FindIsotope(name);
 }
 
@@ -385,8 +385,8 @@ TGeoElementRN::TGeoElementRN()
    fTH_S = 0;
    fTG_S = 0;
    fStatus = 0;
-   fRatio = 0;
-   fDecays = 0;
+   fRatio = nullptr;
+   fDecays = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -412,8 +412,8 @@ TGeoElementRN::TGeoElementRN(Int_t aa, Int_t zz, Int_t iso, Double_t level, Doub
    fTH_S = th_s;
    fTG_S = tg_s;
    fStatus = status;
-   fDecays = 0;
-   fRatio = 0;
+   fDecays = nullptr;
+   fRatio = nullptr;
    MakeName(aa, zz, iso);
    if ((TMath::Abs(fHalfLife) < 1.e-30) || fHalfLife < -1)
       Warning("ctor", "Element %s has T1/2=%g [s]", fName.Data(), fHalfLife);
@@ -696,7 +696,7 @@ void TGeoElementRN::ResetRatio()
 {
    if (fRatio) {
       delete fRatio;
-      fRatio = 0;
+      fRatio = nullptr;
    }
 }
 
@@ -829,7 +829,7 @@ ClassImp(TGeoElemIter);
 /// Default constructor.
 
 TGeoElemIter::TGeoElemIter(TGeoElementRN *top, Double_t limit)
-   : fTop(top), fElem(top), fBranch(0), fLevel(0), fLimitRatio(limit), fRatio(1.)
+   : fTop(top), fElem(top), fBranch(nullptr), fLevel(0), fLimitRatio(limit), fRatio(1.)
 {
    fBranch = new TObjArray(10);
 }
@@ -840,7 +840,7 @@ TGeoElemIter::TGeoElemIter(TGeoElementRN *top, Double_t limit)
 TGeoElemIter::TGeoElemIter(const TGeoElemIter &iter)
    : fTop(iter.fTop),
      fElem(iter.fElem),
-     fBranch(0),
+     fBranch(nullptr),
      fLevel(iter.fLevel),
      fLimitRatio(iter.fLimitRatio),
      fRatio(iter.fRatio)
@@ -982,9 +982,9 @@ TGeoElementTable::TGeoElementTable()
    fNelements = 0;
    fNelementsRN = 0;
    fNisotopes = 0;
-   fList = 0;
-   fListRN = 0;
-   fIsotopes = 0;
+   fList = nullptr;
+   fListRN = nullptr;
+   fIsotopes = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -996,8 +996,8 @@ TGeoElementTable::TGeoElementTable(Int_t /*nelements*/)
    fNelementsRN = 0;
    fNisotopes = 0;
    fList = new TObjArray(128);
-   fListRN = 0;
-   fIsotopes = 0;
+   fListRN = nullptr;
+   fIsotopes = nullptr;
    BuildDefaultElements();
    //   BuildElementsRN();
 }
@@ -1012,7 +1012,7 @@ TGeoElementTable::TGeoElementTable(const TGeoElementTable &get)
      fNisotopes(get.fNisotopes),
      fList(get.fList),
      fListRN(get.fListRN),
-     fIsotopes(0)
+     fIsotopes(nullptr)
 {
 }
 
@@ -1028,7 +1028,7 @@ TGeoElementTable &TGeoElementTable::operator=(const TGeoElementTable &get)
       fNisotopes = get.fNisotopes;
       fList = get.fList;
       fListRN = get.fListRN;
-      fIsotopes = 0;
+      fIsotopes = nullptr;
    }
    return *this;
 }
@@ -1349,7 +1349,7 @@ TGeoElement *TGeoElementTable::FindElement(const char *name) const
       if (s == elem->GetTitle())
          return elem;
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1371,12 +1371,12 @@ TGeoElementRN *TGeoElementTable::GetElementRN(Int_t ENDFcode) const
       TGeoElementTable *table = (TGeoElementTable *)this;
       table->ImportElementsRN();
       if (!fListRN)
-         return 0;
+         return nullptr;
    }
    ElementRNMap_t::const_iterator it = fElementsRN.find(ENDFcode);
    if (it != fElementsRN.end())
       return it->second;
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1540,7 +1540,7 @@ TGeoBatemanSol &TGeoBatemanSol::operator=(const TGeoBatemanSol &other)
    fElemTop = other.fElemTop;
    if (fCoeff)
       delete[] fCoeff;
-   fCoeff = 0;
+   fCoeff = nullptr;
    fCsize = other.fCsize;
    fNcoeff = other.fNcoeff;
    fFactor = other.fFactor;

--- a/geom/geom/src/TGeoEltu.cxx
+++ b/geom/geom/src/TGeoEltu.cxx
@@ -336,7 +336,7 @@ TGeoVolume *TGeoEltu::Divide(TGeoVolume * /*voldiv*/, const char * /*divname*/, 
                              Double_t /*start*/, Double_t /*step*/)
 {
    Error("Divide", "Elliptical tubes divisions not implemented");
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -359,10 +359,10 @@ void TGeoEltu::GetBoundingCylinder(Double_t *param) const
 TGeoShape *TGeoEltu::GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix * /*mat*/) const
 {
    if (!TestShapeBit(kGeoRunTimeShape))
-      return 0;
+      return nullptr;
    if (!mother->TestShapeBit(kGeoEltu)) {
       Error("GetMakeRuntimeShape", "invalid mother");
-      return 0;
+      return nullptr;
    }
    Double_t a, b, dz;
    a = fRmin;

--- a/geom/geom/src/TGeoHalfSpace.cxx
+++ b/geom/geom/src/TGeoHalfSpace.cxx
@@ -172,7 +172,7 @@ TGeoVolume *TGeoHalfSpace::Divide(TGeoVolume * /*voldiv*/, const char * /*divnam
                                   Double_t /*start*/, Double_t /*step*/)
 {
    Error("Divide", "Half-spaces cannot be divided");
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/geom/geom/src/TGeoHelix.cxx
+++ b/geom/geom/src/TGeoHelix.cxx
@@ -70,7 +70,7 @@ TGeoHelix::TGeoHelix()
    fDir[0] = fDir[1] = fDir[2] = 0.;
    fB[0] = fB[1] = fB[2] = 0.;
    fQ = 0;
-   fMatrix = 0;
+   fMatrix = nullptr;
    TObject::SetBit(kHelixNeedUpdate, kTRUE);
    TObject::SetBit(kHelixStraight, kFALSE);
    TObject::SetBit(kHelixCircle, kFALSE);

--- a/geom/geom/src/TGeoHype.cxx
+++ b/geom/geom/src/TGeoHype.cxx
@@ -422,7 +422,7 @@ TGeoVolume *TGeoHype::Divide(TGeoVolume * /*voldiv*/, const char *divname, Int_t
                              Double_t /*start*/, Double_t /*step*/)
 {
    Error("Divide", "Hyperboloids cannot be divided. Division volume %s not created", divname);
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/geom/geom/src/TGeoManager.cxx
+++ b/geom/geom/src/TGeoManager.cxx
@@ -300,7 +300,7 @@ Int_t TGeoManager::fgMaxXtruVert = 1;
 Int_t TGeoManager::fgNumThreads = 0;
 UInt_t TGeoManager::fgExportPrecision = 17;
 TGeoManager::EDefaultUnits TGeoManager::fgDefaultUnits = TGeoManager::kRootUnits;
-TGeoManager::ThreadsMap_t *TGeoManager::fgThreadId = 0;
+TGeoManager::ThreadsMap_t *TGeoManager::fgThreadId = nullptr;
 static Bool_t gGeometryLocked = kFALSE;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -323,39 +323,39 @@ TGeoManager::TGeoManager()
       fIsGeomCleaning = kFALSE;
       fClosed = kFALSE;
       fLoopVolumes = kFALSE;
-      fBits = 0;
-      fCurrentNavigator = 0;
-      fMaterials = 0;
-      fHashPNE = 0;
-      fArrayPNE = 0;
-      fMatrices = 0;
-      fNodes = 0;
-      fOverlaps = 0;
-      fRegions = 0;
+      fBits = nullptr;
+      fCurrentNavigator = nullptr;
+      fMaterials = nullptr;
+      fHashPNE = nullptr;
+      fArrayPNE = nullptr;
+      fMatrices = nullptr;
+      fNodes = nullptr;
+      fOverlaps = nullptr;
+      fRegions = nullptr;
       fNNodes = 0;
       fMaxVisNodes = 10000;
-      fVolumes = 0;
-      fPhysicalNodes = 0;
-      fShapes = 0;
-      fGVolumes = 0;
-      fGShapes = 0;
-      fTracks = 0;
-      fMedia = 0;
+      fVolumes = nullptr;
+      fPhysicalNodes = nullptr;
+      fShapes = nullptr;
+      fGVolumes = nullptr;
+      fGShapes = nullptr;
+      fTracks = nullptr;
+      fMedia = nullptr;
       fNtracks = 0;
       fNpdg = 0;
-      fPdgNames = 0;
-      fGDMLMatrices = 0;
-      fOpticalSurfaces = 0;
-      fSkinSurfaces = 0;
-      fBorderSurfaces = 0;
+      fPdgNames = nullptr;
+      fGDMLMatrices = nullptr;
+      fOpticalSurfaces = nullptr;
+      fSkinSurfaces = nullptr;
+      fBorderSurfaces = nullptr;
       memset(fPdgId, 0, 1024 * sizeof(Int_t));
       //   TObjArray            *fNavigators;       //! list of navigators
-      fCurrentTrack = 0;
-      fCurrentVolume = 0;
-      fTopVolume = 0;
-      fTopNode = 0;
-      fMasterVolume = 0;
-      fPainter = 0;
+      fCurrentTrack = nullptr;
+      fCurrentVolume = nullptr;
+      fTopVolume = nullptr;
+      fTopNode = nullptr;
+      fMasterVolume = nullptr;
+      fPainter = nullptr;
       fActivity = kFALSE;
       fIsNodeSelectable = kFALSE;
       fVisDensity = 0.;
@@ -364,25 +364,25 @@ TGeoManager::TGeoManager()
       fExplodedView = 0;
       fNsegments = 20;
       fNLevel = 0;
-      fUniqueVolumes = 0;
-      fClippingShape = 0;
+      fUniqueVolumes = nullptr;
+      fClippingShape = nullptr;
       fMatrixTransform = kFALSE;
       fMatrixReflection = kFALSE;
-      fGLMatrix = 0;
-      fPaintVolume = 0;
-      fUserPaintVolume = 0;
-      fElementTable = 0;
-      fHashVolumes = 0;
-      fHashGVolumes = 0;
+      fGLMatrix = nullptr;
+      fPaintVolume = nullptr;
+      fUserPaintVolume = nullptr;
+      fElementTable = nullptr;
+      fHashVolumes = nullptr;
+      fHashGVolumes = nullptr;
       fSizePNEId = 0;
       fNPNEId = 0;
-      fKeyPNEId = 0;
-      fValuePNEId = 0;
+      fKeyPNEId = nullptr;
+      fValuePNEId = nullptr;
       fMultiThread = kFALSE;
       fRaytraceMode = 0;
       fMaxThreads = 0;
       fUsePWNav = kFALSE;
-      fParallelWorld = 0;
+      fParallelWorld = nullptr;
       ClearThreadsMap();
    } else {
       Init();
@@ -436,9 +436,9 @@ void TGeoManager::Init()
    fClosed = kFALSE;
    fLoopVolumes = kFALSE;
    fBits = new UChar_t[50000]; // max 25000 nodes per volume
-   fCurrentNavigator = 0;
+   fCurrentNavigator = nullptr;
    fHashPNE = new THashList(256, 3);
-   fArrayPNE = 0;
+   fArrayPNE = nullptr;
    fMaterials = new THashList(200, 3);
    fMatrices = new TObjArray(256);
    fNodes = new TObjArray(30);
@@ -455,18 +455,18 @@ void TGeoManager::Init()
    fMedia = new THashList(200, 3);
    fNtracks = 0;
    fNpdg = 0;
-   fPdgNames = 0;
+   fPdgNames = nullptr;
    fGDMLMatrices = new TObjArray();
    fOpticalSurfaces = new TObjArray();
    fSkinSurfaces = new TObjArray();
    fBorderSurfaces = new TObjArray();
    memset(fPdgId, 0, 1024 * sizeof(Int_t));
-   fCurrentTrack = 0;
-   fCurrentVolume = 0;
-   fTopVolume = 0;
-   fTopNode = 0;
-   fMasterVolume = 0;
-   fPainter = 0;
+   fCurrentTrack = nullptr;
+   fCurrentVolume = nullptr;
+   fTopVolume = nullptr;
+   fTopNode = nullptr;
+   fMasterVolume = nullptr;
+   fPainter = nullptr;
    fActivity = kFALSE;
    fIsNodeSelectable = kFALSE;
    fVisDensity = 0.;
@@ -476,24 +476,24 @@ void TGeoManager::Init()
    fNsegments = 20;
    fNLevel = 0;
    fUniqueVolumes = new TObjArray(256);
-   fClippingShape = 0;
+   fClippingShape = nullptr;
    fMatrixTransform = kFALSE;
    fMatrixReflection = kFALSE;
    fGLMatrix = new TGeoHMatrix();
-   fPaintVolume = 0;
-   fUserPaintVolume = 0;
-   fElementTable = 0;
-   fHashVolumes = 0;
-   fHashGVolumes = 0;
+   fPaintVolume = nullptr;
+   fUserPaintVolume = nullptr;
+   fElementTable = nullptr;
+   fHashVolumes = nullptr;
+   fHashGVolumes = nullptr;
    fSizePNEId = 0;
    fNPNEId = 0;
-   fKeyPNEId = 0;
-   fValuePNEId = 0;
+   fKeyPNEId = nullptr;
+   fValuePNEId = nullptr;
    fMultiThread = kFALSE;
    fRaytraceMode = 0;
    fMaxThreads = 0;
    fUsePWNav = kFALSE;
-   fParallelWorld = 0;
+   fParallelWorld = nullptr;
    ClearThreadsMap();
 }
 
@@ -604,8 +604,8 @@ TGeoManager::~TGeoManager()
    }
    delete fParallelWorld;
    fIsGeomCleaning = kFALSE;
-   gGeoIdentity = 0;
-   gGeoManager = 0;
+   gGeoIdentity = nullptr;
+   gGeoManager = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -792,7 +792,7 @@ TGeoNavigator *TGeoManager::AddNavigator()
    }
    std::thread::id threadId = std::this_thread::get_id();
    NavigatorsMap_t::const_iterator it = fNavigators.find(threadId);
-   TGeoNavigatorArray *array = 0;
+   TGeoNavigatorArray *array = nullptr;
    if (it != fNavigators.end())
       array = it->second;
    else {
@@ -812,7 +812,7 @@ TGeoNavigator *TGeoManager::AddNavigator()
 
 TGeoNavigator *TGeoManager::GetCurrentNavigator() const
 {
-   TTHREAD_TLS(TGeoNavigator *) tnav = 0;
+   TTHREAD_TLS(TGeoNavigator *) tnav = nullptr;
    if (!fMultiThread)
       return fCurrentNavigator;
    TGeoNavigator *nav = tnav; // TTHREAD_TLS_GET(TGeoNavigator*,tnav);
@@ -821,7 +821,7 @@ TGeoNavigator *TGeoManager::GetCurrentNavigator() const
    std::thread::id threadId = std::this_thread::get_id();
    NavigatorsMap_t::const_iterator it = fNavigators.find(threadId);
    if (it == fNavigators.end())
-      return 0;
+      return nullptr;
    TGeoNavigatorArray *array = it->second;
    nav = array->GetCurrentNavigator();
    tnav = nav; // TTHREAD_TLS_SET(TGeoNavigator*,tnav,nav);
@@ -836,7 +836,7 @@ TGeoNavigatorArray *TGeoManager::GetListOfNavigators() const
    std::thread::id threadId = std::this_thread::get_id();
    NavigatorsMap_t::const_iterator it = fNavigators.find(threadId);
    if (it == fNavigators.end())
-      return 0;
+      return nullptr;
    TGeoNavigatorArray *array = it->second;
    return array;
 }
@@ -880,7 +880,7 @@ void TGeoManager::ClearNavigators()
 {
    if (fMultiThread)
       fgMutex.lock();
-   TGeoNavigatorArray *arr = 0;
+   TGeoNavigatorArray *arr = nullptr;
    for (NavigatorsMap_t::iterator it = fNavigators.begin(); it != fNavigators.end(); ++it) {
       arr = (*it).second;
       if (arr)
@@ -1454,7 +1454,7 @@ void TGeoManager::ClearAttributes()
 {
    if (gPad)
       delete gPad;
-   gPad = 0;
+   gPad = nullptr;
    SetVisOption(0);
    SetVisLevel(3);
    SetExplodedView(0);
@@ -1462,7 +1462,7 @@ void TGeoManager::ClearAttributes()
    if (!gStyle)
       return;
    TIter next(fVolumes);
-   TGeoVolume *vol = 0;
+   TGeoVolume *vol = nullptr;
    while ((vol = (TGeoVolume *)next())) {
       if (!vol->IsVisTouched())
          continue;
@@ -1498,7 +1498,7 @@ void TGeoManager::CloseGeometry(Option_t *option)
    //   Bool_t dummy = opt.Contains("d");
    Bool_t nodeid = opt.Contains("i");
    // Create a geometry navigator if not present
-   TGeoNavigator *nav = 0;
+   TGeoNavigator *nav = nullptr;
    Int_t nnavigators = 0;
    // Check if the geometry is streamed from file
    if (fIsGeomReading) {
@@ -1629,20 +1629,20 @@ void TGeoManager::CleanGarbage()
    Int_t i, nentries;
    if (fGVolumes) {
       nentries = fGVolumes->GetEntries();
-      TGeoVolume *vol = 0;
+      TGeoVolume *vol = nullptr;
       for (i = 0; i < nentries; i++) {
          vol = (TGeoVolume *)fGVolumes->At(i);
          if (vol)
-            vol->SetFinder(0);
+            vol->SetFinder(nullptr);
       }
       fGVolumes->Delete();
       delete fGVolumes;
-      fGVolumes = 0;
+      fGVolumes = nullptr;
    }
    if (fGShapes) {
       fGShapes->Delete();
       delete fGShapes;
-      fGShapes = 0;
+      fGShapes = nullptr;
    }
 }
 
@@ -2137,7 +2137,7 @@ Int_t TGeoManager::GetNumThreads()
 TGeoHMatrix *TGeoManager::GetHMatrix()
 {
    if (!GetCurrentNavigator())
-      return NULL;
+      return nullptr;
    return GetCurrentNavigator()->GetHMatrix();
 }
 
@@ -2177,7 +2177,7 @@ Int_t TGeoManager::GetVirtualLevel()
 
 TVirtualGeoTrack *TGeoManager::FindTrackWithId(Int_t id) const
 {
-   TVirtualGeoTrack *trk = 0;
+   TVirtualGeoTrack *trk = nullptr;
    trk = GetTrackOfId(id);
    if (trk)
       return trk;
@@ -2189,7 +2189,7 @@ TVirtualGeoTrack *TGeoManager::FindTrackWithId(Int_t id) const
       if (trk)
          return trk;
    }
-   return NULL;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2204,7 +2204,7 @@ TVirtualGeoTrack *TGeoManager::GetTrackOfId(Int_t id) const
             return track;
       }
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2217,7 +2217,7 @@ TVirtualGeoTrack *TGeoManager::GetParentTrackOfId(Int_t id) const
       if (track->GetId() == id)
          return track;
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2505,7 +2505,7 @@ void TGeoManager::OptimizeVoxels(const char *filename)
    out << "//===== <run this macro JUST BEFORE closing the geometry>" << std::endl;
    out << "   TGeoVolume *vol = 0;" << std::endl;
    out << "   // parse all voxelized volumes" << std::endl;
-   TGeoVolume *vol = 0;
+   TGeoVolume *vol = nullptr;
    Bool_t cyltype;
    TIter next(fVolumes);
    while ((vol = (TGeoVolume *)next())) {
@@ -2694,7 +2694,7 @@ void TGeoManager::SaveAttributes(const char *filename)
        << std::endl;
    out << "   // iterate volumes container and set new attributes" << std::endl;
    //   out << "   TIter next(gGeoManager->GetListOfVolumes());"<<std::endl;
-   TGeoVolume *vol = 0;
+   TGeoVolume *vol = nullptr;
    fTopNode->SaveAttributes(out);
 
    TIter next(fVolumes);
@@ -2991,7 +2991,7 @@ TGeoMaterial *TGeoManager::FindDuplicateMaterial(const TGeoMaterial *mat) const
 {
    Int_t index = fMaterials->IndexOf(mat);
    if (index <= 0)
-      return 0;
+      return nullptr;
    TGeoMaterial *other;
    for (Int_t i = 0; i < index; i++) {
       other = (TGeoMaterial *)fMaterials->At(i);
@@ -3000,7 +3000,7 @@ TGeoMaterial *TGeoManager::FindDuplicateMaterial(const TGeoMaterial *mat) const
       if (other->IsEq(mat))
          return other;
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -3036,7 +3036,7 @@ TGeoMedium *TGeoManager::GetMedium(Int_t numed) const
       if (med->GetId() == numed)
          return med;
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -3045,7 +3045,7 @@ TGeoMedium *TGeoManager::GetMedium(Int_t numed) const
 TGeoMaterial *TGeoManager::GetMaterial(Int_t id) const
 {
    if (id < 0 || id >= fMaterials->GetSize())
-      return 0;
+      return nullptr;
    TGeoMaterial *mat = (TGeoMaterial *)fMaterials->At(id);
    return mat;
 }
@@ -3097,7 +3097,7 @@ void TGeoManager::ResetUserData()
    TIter next(fVolumes);
    TGeoVolume *vol;
    while ((vol = (TGeoVolume *)next()))
-      vol->SetField(0);
+      vol->SetField(nullptr);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -3340,7 +3340,7 @@ TGeoVolume *TGeoManager::MakeXtru(const char *name, TGeoMedium *medium, Int_t nz
 TGeoPNEntry *TGeoManager::SetAlignableEntry(const char *unique_name, const char *path, Int_t uid)
 {
    if (!CheckPath(path))
-      return NULL;
+      return nullptr;
    if (!fHashPNE)
       fHashPNE = new THashList(256, 3);
    if (!fArrayPNE)
@@ -3348,7 +3348,7 @@ TGeoPNEntry *TGeoManager::SetAlignableEntry(const char *unique_name, const char 
    TGeoPNEntry *entry = GetAlignableEntry(unique_name);
    if (entry) {
       Error("SetAlignableEntry", "An alignable object with name %s already existing. NOT ADDED !", unique_name);
-      return 0;
+      return nullptr;
    }
    entry = new TGeoPNEntry(unique_name, path);
    Int_t ientry = fHashPNE->GetSize();
@@ -3368,7 +3368,7 @@ TGeoPNEntry *TGeoManager::SetAlignableEntry(const char *unique_name, const char 
 TGeoPNEntry *TGeoManager::GetAlignableEntry(const char *name) const
 {
    if (!fHashPNE)
-      return 0;
+      return nullptr;
    return (TGeoPNEntry *)fHashPNE->FindObject(name);
 }
 
@@ -3378,7 +3378,7 @@ TGeoPNEntry *TGeoManager::GetAlignableEntry(const char *name) const
 TGeoPNEntry *TGeoManager::GetAlignableEntry(Int_t index) const
 {
    if (!fArrayPNE && !InitArrayPNE())
-      return 0;
+      return nullptr;
    return (TGeoPNEntry *)fArrayPNE->At(index);
 }
 
@@ -3388,10 +3388,10 @@ TGeoPNEntry *TGeoManager::GetAlignableEntry(Int_t index) const
 TGeoPNEntry *TGeoManager::GetAlignableEntryByUID(Int_t uid) const
 {
    if (!fNPNEId || (!fArrayPNE && !InitArrayPNE()))
-      return NULL;
+      return nullptr;
    Int_t index = TMath::BinarySearch(fNPNEId, fKeyPNEId, uid);
    if (index < 0 || fKeyPNEId[index] != uid)
-      return NULL;
+      return nullptr;
    return (TGeoPNEntry *)fArrayPNE->At(fValuePNEId[index]);
 }
 
@@ -3473,7 +3473,7 @@ TGeoPhysicalNode *TGeoManager::MakeAlignablePN(const char *name)
    TGeoPNEntry *entry = GetAlignableEntry(name);
    if (!entry) {
       Error("MakeAlignablePN", "No alignable object named %s found !", name);
-      return 0;
+      return nullptr;
    }
    return MakeAlignablePN(entry);
 }
@@ -3485,12 +3485,12 @@ TGeoPhysicalNode *TGeoManager::MakeAlignablePN(TGeoPNEntry *entry)
 {
    if (!entry) {
       Error("MakeAlignablePN", "No alignable object specified !");
-      return 0;
+      return nullptr;
    }
    const char *path = entry->GetTitle();
    if (!cd(path)) {
       Error("MakeAlignablePN", "Alignable object %s poins to invalid path: %s", entry->GetName(), path);
-      return 0;
+      return nullptr;
    }
    TGeoPhysicalNode *node = MakePhysicalNode(path);
    entry->SetPhysicalNode(node);
@@ -3507,7 +3507,7 @@ TGeoPhysicalNode *TGeoManager::MakePhysicalNode(const char *path)
    if (path) {
       if (!CheckPath(path)) {
          Error("MakePhysicalNode", "path: %s not valid", path);
-         return NULL;
+         return nullptr;
       }
       node = new TGeoPhysicalNode(path);
    } else {
@@ -3657,7 +3657,7 @@ void TGeoManager::SetTopVolume(TGeoVolume *vol)
 
    TSeqCollection *brlist = gROOT->GetListOfBrowsers();
    TIter next(brlist);
-   TBrowser *browser = 0;
+   TBrowser *browser = nullptr;
 
    if (fTopVolume)
       fTopVolume->SetTitle("");
@@ -3665,7 +3665,7 @@ void TGeoManager::SetTopVolume(TGeoVolume *vol)
    vol->SetTitle("Top volume");
    if (fTopNode) {
       TGeoNode *topn = fTopNode;
-      fTopNode = 0;
+      fTopNode = nullptr;
       while ((browser = (TBrowser *)next()))
          browser->RecursiveRemove(topn);
       delete topn;
@@ -4098,7 +4098,7 @@ TGeoManager *TGeoManager::Import(const char *filename, const char *name, Option_
       return nullptr;
    }
    if (!filename)
-      return 0;
+      return nullptr;
    if (fgVerboseLevel > 0)
       ::Info("TGeoManager::Import", "Reading geometry from file: %s", filename);
 
@@ -4150,7 +4150,7 @@ TGeoManager *TGeoManager::Import(const char *filename, const char *name, Option_
       delete f;
    }
    if (!gGeoManager)
-      return 0;
+      return nullptr;
    if (!gROOT->GetListOfGeometries()->FindObject(gGeoManager))
       gROOT->GetListOfGeometries()->Add(gGeoManager);
    if (!gROOT->GetListOfBrowsables()->FindObject(gGeoManager))

--- a/geom/geom/src/TGeoMaterial.cxx
+++ b/geom/geom/src/TGeoMaterial.cxx
@@ -69,11 +69,11 @@ TGeoMaterial::TGeoMaterial()
      fTemperature(0.),
      fPressure(0.),
      fState(kMatStateUndefined),
-     fShader(NULL),
-     fCerenkov(NULL),
-     fElement(NULL),
-     fUserExtension(0),
-     fFWExtension(0)
+     fShader(nullptr),
+     fCerenkov(nullptr),
+     fElement(nullptr),
+     fUserExtension(nullptr),
+     fFWExtension(nullptr)
 {
    TGeoManager::SetDefaultUnits(TGeoManager::GetDefaultUnits()); // Ensure nobody changes the units afterwards
    SetUsed(kFALSE);
@@ -100,11 +100,11 @@ TGeoMaterial::TGeoMaterial(const char *name)
      fTemperature(0.),
      fPressure(0.),
      fState(kMatStateUndefined),
-     fShader(NULL),
-     fCerenkov(NULL),
-     fElement(NULL),
-     fUserExtension(0),
-     fFWExtension(0)
+     fShader(nullptr),
+     fCerenkov(nullptr),
+     fElement(nullptr),
+     fUserExtension(nullptr),
+     fFWExtension(nullptr)
 {
    TGeoManager::SetDefaultUnits(TGeoManager::GetDefaultUnits()); // Ensure nobody changes the units afterwards
    fName = fName.Strip();
@@ -142,11 +142,11 @@ TGeoMaterial::TGeoMaterial(const char *name, Double_t a, Double_t z, Double_t rh
      fTemperature(0.),
      fPressure(0.),
      fState(kMatStateUndefined),
-     fShader(NULL),
-     fCerenkov(NULL),
-     fElement(NULL),
-     fUserExtension(0),
-     fFWExtension(0)
+     fShader(nullptr),
+     fCerenkov(nullptr),
+     fElement(nullptr),
+     fUserExtension(nullptr),
+     fFWExtension(nullptr)
 {
    TGeoManager::SetDefaultUnits(TGeoManager::GetDefaultUnits()); // Ensure nobody changes the units afterwards
    fName = fName.Strip();
@@ -193,11 +193,11 @@ TGeoMaterial::TGeoMaterial(const char *name, Double_t a, Double_t z, Double_t rh
      fTemperature(temperature),
      fPressure(pressure),
      fState(state),
-     fShader(NULL),
-     fCerenkov(NULL),
-     fElement(NULL),
-     fUserExtension(0),
-     fFWExtension(0)
+     fShader(nullptr),
+     fCerenkov(nullptr),
+     fElement(nullptr),
+     fUserExtension(nullptr),
+     fFWExtension(nullptr)
 {
    TGeoManager::SetDefaultUnits(TGeoManager::GetDefaultUnits()); // Ensure nobody changes the units afterwards
    fName = fName.Strip();
@@ -233,11 +233,11 @@ TGeoMaterial::TGeoMaterial(const char *name, TGeoElement *elem, Double_t rho)
      fTemperature(0.),
      fPressure(0.),
      fState(kMatStateUndefined),
-     fShader(NULL),
-     fCerenkov(NULL),
+     fShader(nullptr),
+     fCerenkov(nullptr),
      fElement(elem),
-     fUserExtension(0),
-     fFWExtension(0)
+     fUserExtension(nullptr),
+     fFWExtension(nullptr)
 {
    TGeoManager::SetDefaultUnits(TGeoManager::GetDefaultUnits()); // Ensure nobody changes the units afterwards
    fName = fName.Strip();
@@ -327,11 +327,11 @@ TGeoMaterial::~TGeoMaterial()
 {
    if (fUserExtension) {
       fUserExtension->Release();
-      fUserExtension = 0;
+      fUserExtension = nullptr;
    }
    if (fFWExtension) {
       fFWExtension->Release();
-      fFWExtension = 0;
+      fFWExtension = nullptr;
    }
 }
 
@@ -347,7 +347,7 @@ void TGeoMaterial::SetUserExtension(TGeoExtension *ext)
 {
    if (fUserExtension)
       fUserExtension->Release();
-   fUserExtension = 0;
+   fUserExtension = nullptr;
    if (ext)
       fUserExtension = ext->Grab();
 }
@@ -450,7 +450,7 @@ void TGeoMaterial::SetFWExtension(TGeoExtension *ext)
 {
    if (fFWExtension)
       fFWExtension->Release();
-   fFWExtension = 0;
+   fFWExtension = nullptr;
    if (ext)
       fFWExtension = ext->Grab();
 }
@@ -464,7 +464,7 @@ TGeoExtension *TGeoMaterial::GrabUserExtension() const
 {
    if (fUserExtension)
       return fUserExtension->Grab();
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -476,7 +476,7 @@ TGeoExtension *TGeoMaterial::GrabFWExtension() const
 {
    if (fFWExtension)
       return fFWExtension->Grab();
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -687,7 +687,7 @@ TGeoMaterial *TGeoMaterial::DecayMaterial(Double_t time, Double_t precision)
       amed += weight[i];
    }
    Double_t rho = fDensity * amed / fA;
-   TGeoMixture *mix = 0;
+   TGeoMixture *mix = nullptr;
    Int_t ncomp1 = ncomp;
    for (i = 0; i < ncomp; i++) {
       if ((weight[i] / amed) < precision) {
@@ -701,7 +701,7 @@ TGeoMaterial *TGeoMaterial::DecayMaterial(Double_t time, Double_t precision)
       delete pop;
       if (ncomp1 == 1)
          return new TGeoMaterial(TString::Format("%s-evol", GetName()), el, rho);
-      return NULL;
+      return nullptr;
    }
    mix = new TGeoMixture(TString::Format("%s-evol", GetName()), ncomp, rho);
    for (i = 0; i < ncomp; i++) {
@@ -779,12 +779,12 @@ ClassImp(TGeoMixture);
 TGeoMixture::TGeoMixture()
 {
    fNelements = 0;
-   fZmixture = 0;
-   fAmixture = 0;
-   fWeights = 0;
-   fNatoms = 0;
-   fVecNbOfAtomsPerVolume = 0;
-   fElements = 0;
+   fZmixture = nullptr;
+   fAmixture = nullptr;
+   fWeights = nullptr;
+   fNatoms = nullptr;
+   fVecNbOfAtomsPerVolume = nullptr;
+   fElements = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -792,14 +792,14 @@ TGeoMixture::TGeoMixture()
 
 TGeoMixture::TGeoMixture(const char *name, Int_t /*nel*/, Double_t rho) : TGeoMaterial(name)
 {
-   fZmixture = 0;
-   fAmixture = 0;
-   fWeights = 0;
+   fZmixture = nullptr;
+   fAmixture = nullptr;
+   fWeights = nullptr;
    fNelements = 0;
-   fNatoms = 0;
-   fVecNbOfAtomsPerVolume = 0;
+   fNatoms = nullptr;
+   fVecNbOfAtomsPerVolume = nullptr;
    fDensity = rho;
-   fElements = 0;
+   fElements = nullptr;
    if (fDensity < 0)
       fDensity = 0.001;
 }
@@ -1123,9 +1123,9 @@ TGeoElement *TGeoMixture::GetElement(Int_t i) const
 {
    if (i < 0 || i >= fNelements) {
       Error("GetElement", "Mixture %s has only %d elements", GetName(), fNelements);
-      return 0;
+      return nullptr;
    }
-   TGeoElement *elem = 0;
+   TGeoElement *elem = nullptr;
    if (fElements)
       elem = (TGeoElement *)fElements->At(i);
    if (elem)
@@ -1257,7 +1257,7 @@ TGeoMaterial *TGeoMixture::DecayMaterial(Double_t time, Double_t precision)
       amed += weight[i];
    }
    Double_t rho = fDensity * fWeights[0] * amed / fAmixture[0];
-   TGeoMixture *mix = 0;
+   TGeoMixture *mix = nullptr;
    Int_t ncomp1 = ncomp;
    for (i = 0; i < ncomp; i++) {
       if ((weight[i] / amed) < precision) {
@@ -1271,7 +1271,7 @@ TGeoMaterial *TGeoMixture::DecayMaterial(Double_t time, Double_t precision)
       delete pop;
       if (ncomp1 == 1)
          return new TGeoMaterial(TString::Format("%s-evol", GetName()), el, rho);
-      return NULL;
+      return nullptr;
    }
    mix = new TGeoMixture(TString::Format("%s-evol", GetName()), ncomp, rho);
    for (i = 0; i < ncomp; i++) {

--- a/geom/geom/src/TGeoMatrix.cxx
+++ b/geom/geom/src/TGeoMatrix.cxx
@@ -1683,7 +1683,7 @@ TGeoCombiTrans::TGeoCombiTrans()
 {
    for (Int_t i = 0; i < 3; i++)
       fTranslation[i] = 0.0;
-   fRotation = 0;
+   fRotation = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1704,7 +1704,7 @@ TGeoCombiTrans::TGeoCombiTrans(const TGeoMatrix &other) : TGeoMatrix(other)
       SetBit(kGeoMatrixOwned);
       fRotation = new TGeoRotation(other);
    } else
-      fRotation = 0;
+      fRotation = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1726,7 +1726,7 @@ TGeoCombiTrans::TGeoCombiTrans(const TGeoTranslation &tr, const TGeoRotation &ro
       fRotation = new TGeoRotation(rot);
       SetBit(kGeoReflection, rot.TestBit(kGeoReflection));
    } else
-      fRotation = 0;
+      fRotation = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1736,7 +1736,7 @@ TGeoCombiTrans::TGeoCombiTrans(const char *name) : TGeoMatrix(name)
 {
    for (Int_t i = 0; i < 3; i++)
       fTranslation[i] = 0.0;
-   fRotation = 0;
+   fRotation = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1746,7 +1746,7 @@ TGeoCombiTrans::TGeoCombiTrans(const char *name) : TGeoMatrix(name)
 TGeoCombiTrans::TGeoCombiTrans(Double_t dx, Double_t dy, Double_t dz, TGeoRotation *rot) : TGeoMatrix("")
 {
    SetTranslation(dx, dy, dz);
-   fRotation = 0;
+   fRotation = nullptr;
    SetRotation(rot);
 }
 
@@ -1757,7 +1757,7 @@ TGeoCombiTrans::TGeoCombiTrans(const char *name, Double_t dx, Double_t dy, Doubl
    : TGeoMatrix(name)
 {
    SetTranslation(dx, dy, dz);
-   fRotation = 0;
+   fRotation = nullptr;
    SetRotation(rot);
 }
 
@@ -1792,7 +1792,7 @@ TGeoCombiTrans &TGeoCombiTrans::operator=(const TGeoMatrix &matrix)
       if (fRotation && TestBit(kGeoMatrixOwned))
          delete fRotation;
       ResetBit(kGeoMatrixOwned);
-      fRotation = 0;
+      fRotation = nullptr;
    }
    SetBit(kGeoRegistered, registered);
    ResetBit(kGeoScale);
@@ -1858,7 +1858,7 @@ void TGeoCombiTrans::Clear(Option_t *)
    if (fRotation) {
       if (TestBit(kGeoMatrixOwned))
          delete fRotation;
-      fRotation = 0;
+      fRotation = nullptr;
    }
    ResetBit(kGeoRotation);
    ResetBit(kGeoTranslation);
@@ -2126,7 +2126,7 @@ void TGeoCombiTrans::SetRotation(const TGeoRotation *rot)
 {
    if (fRotation && TestBit(kGeoMatrixOwned))
       delete fRotation;
-   fRotation = 0;
+   fRotation = nullptr;
    ResetBit(TGeoMatrix::kGeoMatrixOwned);
    ResetBit(kGeoRotation);
    ResetBit(kGeoReflection);
@@ -2148,7 +2148,7 @@ void TGeoCombiTrans::SetRotation(const TGeoRotation &rot)
 {
    if (fRotation && TestBit(kGeoMatrixOwned))
       delete fRotation;
-   fRotation = 0;
+   fRotation = nullptr;
    if (!rot.IsRotation()) {
       ResetBit(kGeoRotation);
       ResetBit(kGeoReflection);
@@ -2234,7 +2234,7 @@ TGeoGenTrans::TGeoGenTrans()
       fTranslation[i] = 0.0;
    for (Int_t j = 0; j < 3; j++)
       fScale[j] = 1.0;
-   fRotation = 0;
+   fRotation = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2247,7 +2247,7 @@ TGeoGenTrans::TGeoGenTrans(const char *name) : TGeoCombiTrans(name)
       fTranslation[i] = 0.0;
    for (Int_t j = 0; j < 3; j++)
       fScale[j] = 1.0;
-   fRotation = 0;
+   fRotation = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/geom/geom/src/TGeoMedium.cxx
+++ b/geom/geom/src/TGeoMedium.cxx
@@ -37,7 +37,7 @@ TGeoMedium::TGeoMedium()
    fId = 0;
    for (Int_t i = 0; i < 20; i++)
       fParams[i] = 0.;
-   fMaterial = 0;
+   fMaterial = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -77,7 +77,7 @@ TGeoMedium::TGeoMedium(const char *name, Int_t numed, Int_t imat, Int_t isvol, I
          break;
    }
    if (!mat || (mat->GetUniqueID() != (UInt_t)imat)) {
-      fMaterial = 0;
+      fMaterial = nullptr;
       Error("TGeoMedium", "%s, material number %d does not exist", name, imat);
       return;
    }

--- a/geom/geom/src/TGeoNavigator.cxx
+++ b/geom/geom/src/TGeoNavigator.cxx
@@ -62,7 +62,7 @@ TGeoNavigator::TGeoNavigator()
      fNextDaughterIndex(0),
      fOverlapSize(0),
      fOverlapMark(0),
-     fOverlapClusters(0),
+     fOverlapClusters(nullptr),
      fSearchOverlaps(kFALSE),
      fCurrentOverlapping(kFALSE),
      fStartSafe(kFALSE),
@@ -74,18 +74,18 @@ TGeoNavigator::TGeoNavigator()
      fIsOnBoundary(kFALSE),
      fIsSameLocation(kFALSE),
      fIsNullStep(kFALSE),
-     fGeometry(0),
-     fCache(0),
-     fCurrentVolume(0),
-     fCurrentNode(0),
-     fTopNode(0),
-     fLastNode(0),
-     fNextNode(0),
-     fForcedNode(0),
-     fBackupState(0),
-     fCurrentMatrix(0),
-     fGlobalMatrix(0),
-     fDivMatrix(0),
+     fGeometry(nullptr),
+     fCache(nullptr),
+     fCurrentVolume(nullptr),
+     fCurrentNode(nullptr),
+     fTopNode(nullptr),
+     fLastNode(nullptr),
+     fNextNode(nullptr),
+     fForcedNode(nullptr),
+     fBackupState(nullptr),
+     fCurrentMatrix(nullptr),
+     fGlobalMatrix(nullptr),
+     fDivMatrix(nullptr),
      fPath()
 
 {
@@ -113,7 +113,7 @@ TGeoNavigator::TGeoNavigator(TGeoManager *geom)
      fNextDaughterIndex(-2),
      fOverlapSize(1000),
      fOverlapMark(0),
-     fOverlapClusters(0),
+     fOverlapClusters(nullptr),
      fSearchOverlaps(kFALSE),
      fCurrentOverlapping(kFALSE),
      fStartSafe(kTRUE),
@@ -126,17 +126,17 @@ TGeoNavigator::TGeoNavigator(TGeoManager *geom)
      fIsSameLocation(kTRUE),
      fIsNullStep(kFALSE),
      fGeometry(geom),
-     fCache(0),
-     fCurrentVolume(0),
-     fCurrentNode(0),
-     fTopNode(0),
-     fLastNode(0),
-     fNextNode(0),
-     fForcedNode(0),
-     fBackupState(0),
-     fCurrentMatrix(0),
-     fGlobalMatrix(0),
-     fDivMatrix(0),
+     fCache(nullptr),
+     fCurrentVolume(nullptr),
+     fCurrentNode(nullptr),
+     fTopNode(nullptr),
+     fLastNode(nullptr),
+     fNextNode(nullptr),
+     fForcedNode(nullptr),
+     fBackupState(nullptr),
+     fCurrentMatrix(nullptr),
+     fGlobalMatrix(nullptr),
+     fDivMatrix(nullptr),
      fPath()
 
 {
@@ -366,7 +366,7 @@ void TGeoNavigator::CdUp()
    } else {
       Int_t up = 1;
       Bool_t offset = kTRUE;
-      TGeoNode *mother = 0;
+      TGeoNode *mother = nullptr;
       while (offset) {
          mother = GetMother(up++);
          offset = mother->IsOffset();
@@ -459,7 +459,7 @@ TGeoNode *TGeoNavigator::CrossDivisionCell()
    TGeoPatternFinder *finder = fCurrentNode->GetFinder();
    if (!finder) {
       Fatal("CrossDivisionCell", "Volume has no pattern finder");
-      return 0;
+      return nullptr;
    }
    // Mark current node and go up to the level of the divided volume
    TGeoNode *skip = fCurrentNode;
@@ -540,12 +540,12 @@ TGeoNode *TGeoNavigator::CrossBoundaryAndLocate(Bool_t downwards, TGeoNode *skip
    fPoint[1] += extra * fDirection[1];
    fPoint[2] += extra * fDirection[2];
    TGeoNode *current = SearchNode(downwards, skipnode);
-   fForcedNode = 0;
+   fForcedNode = nullptr;
    fPoint[0] -= extra * fDirection[0];
    fPoint[1] -= extra * fDirection[1];
    fPoint[2] -= extra * fDirection[2];
    if (!current)
-      return 0;
+      return nullptr;
    if (downwards) {
       Int_t nextindex = current->GetVolume()->GetNextNodeIndex();
       while (nextindex >= 0) {
@@ -626,7 +626,7 @@ TGeoNode *TGeoNavigator::FindNextBoundary(Double_t stepmax, const char *path, Bo
    fStep = TGeoShape::Big();
    fIsStepEntering = kFALSE;
    fIsStepExiting = kFALSE;
-   fForcedNode = 0;
+   fForcedNode = nullptr;
    Bool_t computeGlobal = kFALSE;
    fIsOnBoundary = frombdr;
    fSafety = 0.;
@@ -677,7 +677,7 @@ TGeoNode *TGeoNavigator::FindNextBoundary(Double_t stepmax, const char *path, Bo
       PushPath();
       if (!cd(path)) {
          PopPath();
-         return 0;
+         return nullptr;
       }
       if (computeGlobal)
          fCurrentMatrix->CopyFrom(fGlobalMatrix);
@@ -745,7 +745,7 @@ TGeoNode *TGeoNavigator::FindNextBoundary(Double_t stepmax, const char *path, Bo
          }
          return fNextNode;
       }
-      return 0;
+      return nullptr;
    }
    fGlobalMatrix->MasterToLocal(fPoint, &point[0]);
    fGlobalMatrix->MasterToLocalVect(fDirection, &dir[0]);
@@ -768,15 +768,15 @@ TGeoNode *TGeoNavigator::FindNextBoundary(Double_t stepmax, const char *path, Bo
       if (fStep < 1E-6)
          return fCurrentNode;
    }
-   fNextNode = (fStep < 1E20) ? fCurrentNode : 0;
+   fNextNode = (fStep < 1E20) ? fCurrentNode : nullptr;
    // Find next daughter boundary for the current volume
    Int_t idaughter = -1;
    FindNextDaughterBoundary(point, dir, idaughter, computeGlobal);
    if (idaughter >= 0)
       fNextDaughterIndex = idaughter;
-   TGeoNode *current = 0;
-   TGeoNode *dnode = 0;
-   TGeoVolume *mother = 0;
+   TGeoNode *current = nullptr;
+   TGeoNode *dnode = nullptr;
+   TGeoVolume *mother = nullptr;
    // if we are in an overlapping node, check also the mother(s)
    if (fNmany) {
       Double_t mothpt[3];
@@ -900,7 +900,7 @@ TGeoNode *TGeoNavigator::FindNextBoundary(Double_t stepmax, const char *path, Bo
             mothernode = GetMother(up);
             if (!mothernode) {
                Fatal("FindNextBoundary", "Cannot find mother node");
-               return 0;
+               return nullptr;
             }
             mup = mothernode;
             imother = up + 1;
@@ -923,7 +923,7 @@ TGeoNode *TGeoNavigator::FindNextBoundary(Double_t stepmax, const char *path, Bo
                matrix = GetMotherMatrix(up);
                if (!matrix) {
                   Fatal("FindNextBoundary", "Cannot find mother matrix");
-                  return 0;
+                  return nullptr;
                }
                matrix->MasterToLocal(fPoint, dpt);
                matrix->MasterToLocalVect(fDirection, dvec);
@@ -986,17 +986,17 @@ TGeoNode *TGeoNavigator::FindNextDaughterBoundary(Double_t *point, Double_t *dir
    Double_t snext = TGeoShape::Big();
    Int_t idebug = TGeoManager::GetVerboseLevel();
    idaughter = -1; // nothing crossed
-   TGeoNode *nodefound = 0;
+   TGeoNode *nodefound = nullptr;
    // Get number of daughters. If no daughters we are done.
 
    TGeoVolume *vol = fCurrentNode->GetVolume();
    Int_t nd = vol->GetNdaughters();
    if (!nd)
-      return 0; // No daughter
+      return nullptr; // No daughter
    if (fGeometry->IsActivityEnabled() && !vol->IsActiveDaughters())
-      return 0;
+      return nullptr;
    Double_t lpoint[3], ldir[3];
-   TGeoNode *current = 0;
+   TGeoNode *current = nullptr;
    Int_t i = 0;
    // if current volume is divided, we are in the non-divided region. We
    // check first if we are inside a cell in which case compute distance to next cell
@@ -1113,7 +1113,7 @@ TGeoNode *TGeoNavigator::FindNextDaughterBoundary(Double_t *point, Double_t *dir
    // if current volume is voxelized, first get current voxel
    Int_t ncheck = 0;
    Int_t sumchecked = 0;
-   Int_t *vlist = 0;
+   Int_t *vlist = nullptr;
    TGeoStateInfo &info = *fCache->GetInfo();
    voxels->SortCrossedVoxels(point, dir, info);
    while ((sumchecked < nd) && (vlist = voxels->GetNextVoxel(point, dir, ncheck, info))) {
@@ -1177,7 +1177,7 @@ TGeoNode *TGeoNavigator::FindNextBoundaryAndStep(Double_t stepmax, Bool_t compsa
    Int_t idebug = TGeoManager::GetVerboseLevel();
    Int_t nextindex;
    Bool_t is_assembly;
-   fForcedNode = 0;
+   fForcedNode = nullptr;
    fIsStepExiting = kFALSE;
    TGeoNode *skip;
    fIsStepEntering = kFALSE;
@@ -1259,9 +1259,9 @@ TGeoNode *TGeoNavigator::FindNextBoundaryAndStep(Double_t stepmax, Bool_t compsa
          return fNextNode;
       }
       // top node not reachable from current point/direction
-      fNextNode = 0;
+      fNextNode = nullptr;
       fIsOnBoundary = kFALSE;
-      return 0;
+      return nullptr;
    }
    Double_t point[3], dir[3];
    Int_t icrossed = -2;
@@ -1293,14 +1293,14 @@ TGeoNode *TGeoNavigator::FindNextBoundaryAndStep(Double_t stepmax, Bool_t compsa
       is_assembly = fCurrentNode->GetVolume()->IsAssembly();
       if (!fLevel && !is_assembly) {
          fIsOutside = kTRUE;
-         return 0;
+         return nullptr;
       }
       if (fCurrentNode->IsOffset())
          return CrossDivisionCell();
       if (fLevel)
          CdUp();
       else
-         skip = 0;
+         skip = nullptr;
       return CrossBoundaryAndLocate(kFALSE, skip);
    }
 
@@ -1319,9 +1319,9 @@ TGeoNode *TGeoNavigator::FindNextBoundaryAndStep(Double_t stepmax, Bool_t compsa
       icrossed = idaughter;
       fIsStepEntering = kTRUE;
    }
-   TGeoNode *current = 0;
-   TGeoNode *dnode = 0;
-   TGeoVolume *mother = 0;
+   TGeoNode *current = nullptr;
+   TGeoNode *dnode = nullptr;
+   TGeoVolume *mother = nullptr;
    // if we are in an overlapping node, check also the mother(s)
    if (fNmany) {
       Double_t mothpt[3];
@@ -1472,7 +1472,7 @@ TGeoNode *TGeoNavigator::FindNextBoundaryAndStep(Double_t stepmax, Bool_t compsa
    }
    // Compute now the distance in case we have a parallel world
    Double_t parstep = TGeoShape::Big();
-   TGeoPhysicalNode *pnode = 0;
+   TGeoPhysicalNode *pnode = nullptr;
    if (fGeometry->IsParallelWorldNav()) {
       pnode = fGeometry->GetParallelWorld()->FindNextBoundary(fPoint, fDirection, parstep, fStep);
       if (pnode) {
@@ -1511,14 +1511,14 @@ TGeoNode *TGeoNavigator::FindNextBoundaryAndStep(Double_t stepmax, Bool_t compsa
       is_assembly = fCurrentNode->GetVolume()->IsAssembly();
       if (!fLevel && !is_assembly) {
          fIsOutside = kTRUE;
-         return 0;
+         return nullptr;
       }
       if (fCurrentNode->IsOffset())
          return CrossDivisionCell();
       if (fLevel)
          CdUp();
       else
-         skip = 0;
+         skip = nullptr;
       return CrossBoundaryAndLocate(kFALSE, skip);
    }
 
@@ -1589,7 +1589,7 @@ TGeoNode *TGeoNavigator::FindNode(Double_t x, Double_t y, Double_t z)
 Double_t *TGeoNavigator::FindNormalFast()
 {
    if (!fNextNode)
-      return 0;
+      return nullptr;
    Double_t local[3];
    Double_t ldir[3];
    Double_t lnorm[3];
@@ -1895,7 +1895,7 @@ TGeoNode *TGeoNavigator::SearchNode(Bool_t downwards, const TGeoNode *skipnode)
    }
    Double_t point[3];
    fNextDaughterIndex = -2;
-   TGeoVolume *vol = 0;
+   TGeoVolume *vol = nullptr;
    Int_t idebug = TGeoManager::GetVerboseLevel();
    Bool_t inside_current = (fCurrentNode == skipnode) ? kTRUE : kFALSE;
    if (!downwards) {
@@ -1926,7 +1926,7 @@ TGeoNode *TGeoNavigator::SearchNode(Bool_t downwards, const TGeoNode *skipnode)
          // check if we can go up
          if (!fLevel) {
             fIsOutside = kTRUE;
-            return 0;
+            return nullptr;
          }
          CdUp();
          return SearchNode(kFALSE, skip);
@@ -1942,7 +1942,7 @@ TGeoNode *TGeoNavigator::SearchNode(Bool_t downwards, const TGeoNode *skipnode)
          inside_current = vol->Contains(point);
       if (!inside_current) {
          fIsSameLocation = kFALSE;
-         return 0;
+         return nullptr;
       } else {
          if (fIsOutside) {
             fIsOutside = kFALSE;
@@ -1997,7 +1997,7 @@ TGeoNode *TGeoNavigator::SearchNode(Bool_t downwards, const TGeoNode *skipnode)
          // go inside the division cell and search downwards
          fIsSameLocation = kFALSE;
          CdDown(node->GetIndex());
-         fForcedNode = 0;
+         fForcedNode = nullptr;
          return SearchNode(kTRUE, node);
       }
       // point is not inside the division, but might be in other nodes
@@ -2008,7 +2008,7 @@ TGeoNode *TGeoNavigator::SearchNode(Bool_t downwards, const TGeoNode *skipnode)
    }
    // second, look if current volume is voxelized
    TGeoVoxelFinder *voxels = vol->GetVoxels();
-   Int_t *check_list = 0;
+   Int_t *check_list = nullptr;
    Int_t id;
    if (voxels) {
       // get the list of nodes passing thorough the current voxel
@@ -2024,7 +2024,7 @@ TGeoNode *TGeoNavigator::SearchNode(Bool_t downwards, const TGeoNode *skipnode)
          if (!fLevel) {
             fIsOutside = kTRUE;
             fCache->ReleaseInfo();
-            return 0;
+            return nullptr;
          }
          CdUp();
          fCache->ReleaseInfo();
@@ -2055,7 +2055,7 @@ TGeoNode *TGeoNavigator::SearchNode(Bool_t downwards, const TGeoNode *skipnode)
             }
          }
          CdDown(check_list[id]);
-         fForcedNode = 0;
+         fForcedNode = nullptr;
          node = SearchNode(kTRUE);
          if (node) {
             fIsSameLocation = kFALSE;
@@ -2072,7 +2072,7 @@ TGeoNode *TGeoNavigator::SearchNode(Bool_t downwards, const TGeoNode *skipnode)
       if (!fLevel) {
          fIsOutside = kTRUE;
          fCache->ReleaseInfo();
-         return 0;
+         return nullptr;
       }
       CdUp();
       fCache->ReleaseInfo();
@@ -2086,7 +2086,7 @@ TGeoNode *TGeoNavigator::SearchNode(Bool_t downwards, const TGeoNode *skipnode)
       if (fGeometry->IsActivityEnabled() && !node->GetVolume()->IsActive())
          continue;
       CdDown(id);
-      fForcedNode = 0;
+      fForcedNode = nullptr;
       node = SearchNode(kTRUE);
       if (node) {
          fIsSameLocation = kFALSE;
@@ -2099,7 +2099,7 @@ TGeoNode *TGeoNavigator::SearchNode(Bool_t downwards, const TGeoNode *skipnode)
       node = fCurrentNode;
       if (!fLevel) {
          fIsOutside = kTRUE;
-         return 0;
+         return nullptr;
       }
       CdUp();
       return SearchNode(kFALSE, node);
@@ -2113,11 +2113,11 @@ TGeoNode *TGeoNavigator::SearchNode(Bool_t downwards, const TGeoNode *skipnode)
 
 TGeoNode *TGeoNavigator::FindInCluster(Int_t *cluster, Int_t nc)
 {
-   TGeoNode *clnode = 0;
+   TGeoNode *clnode = nullptr;
    TGeoNode *priority = fLastNode;
    // save current node
    TGeoNode *current = fCurrentNode;
-   TGeoNode *found = 0;
+   TGeoNode *found = nullptr;
    // save path
    Int_t ipop = PushPath();
    // mark this search
@@ -2257,7 +2257,7 @@ TGeoNode *TGeoNavigator::Step(Bool_t is_geom, Bool_t cross)
    TGeoNode *old = fCurrentNode;
    Int_t idold = GetNodeId();
    if (fIsOutside)
-      old = 0;
+      old = nullptr;
    fStep += epsil;
    for (Int_t i = 0; i < 3; i++)
       fPoint[i] += fStep * fDirection[i];
@@ -2291,7 +2291,7 @@ Int_t TGeoNavigator::GetVirtualLevel()
    Int_t new_media = 0;
    TGeoMedium *medium = fCurrentNode->GetMedium();
    Int_t virtual_level = 1;
-   TGeoNode *mother = 0;
+   TGeoNode *mother = nullptr;
 
    while ((mother = GetMother(virtual_level))) {
       if (!mother->IsOverlapping() && !mother->IsOffset()) {
@@ -2498,7 +2498,7 @@ Bool_t TGeoNavigator::IsSameLocation(Double_t x, Double_t y, Double_t z, Bool_t 
    }
    // if we are not allowed to do changes, save the current path
    TGeoVoxelFinder *voxels = vol->GetVoxels();
-   Int_t *check_list = 0;
+   Int_t *check_list = nullptr;
    Int_t ncheck = 0;
    Double_t local1[3];
    if (voxels) {
@@ -2678,8 +2678,8 @@ void TGeoNavigator::ResetAll()
    fIsNullStep = kFALSE;
    fCurrentVolume = fGeometry->GetTopVolume();
    fCurrentNode = fGeometry->GetTopNode();
-   fLastNode = 0;
-   fNextNode = 0;
+   fLastNode = nullptr;
+   fNextNode = nullptr;
    fPath = "";
    if (fCache) {
       Bool_t dummy = fCache->IsDummy();

--- a/geom/geom/src/TGeoNode.cxx
+++ b/geom/geom/src/TGeoNode.cxx
@@ -94,13 +94,13 @@ ClassImp(TGeoNode);
 
 TGeoNode::TGeoNode()
 {
-   fVolume = 0;
-   fMother = 0;
+   fVolume = nullptr;
+   fMother = nullptr;
    fNumber = 0;
    fNovlp = 0;
-   fOverlaps = 0;
-   fUserExtension = 0;
-   fFWExtension = 0;
+   fOverlaps = nullptr;
+   fUserExtension = nullptr;
+   fFWExtension = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -116,12 +116,12 @@ TGeoNode::TGeoNode(const TGeoVolume *vol)
    if (fVolume->IsAdded())
       fVolume->SetReplicated();
    fVolume->SetAdded();
-   fMother = 0;
+   fMother = nullptr;
    fNumber = 0;
    fNovlp = 0;
-   fOverlaps = 0;
-   fUserExtension = 0;
-   fFWExtension = 0;
+   fOverlaps = nullptr;
+   fUserExtension = nullptr;
+   fFWExtension = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -133,11 +133,11 @@ TGeoNode::~TGeoNode()
       delete[] fOverlaps;
    if (fUserExtension) {
       fUserExtension->Release();
-      fUserExtension = 0;
+      fUserExtension = nullptr;
    }
    if (fFWExtension) {
       fFWExtension->Release();
-      fFWExtension = 0;
+      fFWExtension = nullptr;
    }
 }
 
@@ -281,10 +281,10 @@ void TGeoNode::ExecuteEvent(Int_t event, Int_t px, Int_t py)
 char *TGeoNode::GetObjectInfo(Int_t px, Int_t py) const
 {
    if (!fVolume)
-      return 0;
+      return nullptr;
    TVirtualGeoPainter *painter = fVolume->GetGeoManager()->GetPainter();
    if (!painter)
-      return 0;
+      return nullptr;
    return (char *)painter->GetVolumeInfo(fVolume, px, py);
 }
 
@@ -501,7 +501,7 @@ void TGeoNode::SetUserExtension(TGeoExtension *ext)
 {
    if (fUserExtension)
       fUserExtension->Release();
-   fUserExtension = 0;
+   fUserExtension = nullptr;
    if (ext)
       fUserExtension = ext->Grab();
 }
@@ -518,7 +518,7 @@ void TGeoNode::SetFWExtension(TGeoExtension *ext)
 {
    if (fFWExtension)
       fFWExtension->Release();
-   fFWExtension = 0;
+   fFWExtension = nullptr;
    if (ext)
       fFWExtension = ext->Grab();
 }
@@ -532,7 +532,7 @@ TGeoExtension *TGeoNode::GrabUserExtension() const
 {
    if (fUserExtension)
       return fUserExtension->Grab();
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -544,7 +544,7 @@ TGeoExtension *TGeoNode::GrabFWExtension() const
 {
    if (fFWExtension)
       return fFWExtension->Grab();
-   return 0;
+   return nullptr;
 }
 ////////////////////////////////////////////////////////////////////////////////
 /// Check the overlab between the bounding box of the node overlaps with the one
@@ -746,7 +746,7 @@ ClassImp(TGeoNodeMatrix);
 
 TGeoNodeMatrix::TGeoNodeMatrix()
 {
-   fMatrix = 0;
+   fMatrix = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -846,7 +846,7 @@ TGeoNodeOffset::TGeoNodeOffset()
    TObject::SetBit(kGeoNodeOffset);
    fOffset = 0;
    fIndex = 0;
-   fFinder = 0;
+   fFinder = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -857,7 +857,7 @@ TGeoNodeOffset::TGeoNodeOffset(const TGeoVolume *vol, Int_t index, Double_t offs
    TObject::SetBit(kGeoNodeOffset);
    fOffset = offset;
    fIndex = index;
-   fFinder = 0;
+   fFinder = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -996,7 +996,7 @@ TGeoIterator::TGeoIterator(TGeoVolume *top)
    fArray = new Int_t[30];
    fMatrix = new TGeoHMatrix();
    fTopName = fTop->GetName();
-   fPlugin = 0;
+   fPlugin = nullptr;
    fPluginAutoexec = kFALSE;
 }
 
@@ -1063,14 +1063,14 @@ TGeoIterator &TGeoIterator::operator=(const TGeoIterator &iter)
 TGeoNode *TGeoIterator::Next()
 {
    if (fMustStop)
-      return 0;
-   TGeoNode *mother = 0;
-   TGeoNode *next = 0;
+      return nullptr;
+   TGeoNode *mother = nullptr;
+   TGeoNode *next = nullptr;
    Int_t i;
    Int_t nd = fTop->GetNdaughters();
    if (!nd) {
       fMustStop = kTRUE;
-      return 0;
+      return nullptr;
    }
    if (!fLevel) {
       fArray[++fLevel] = 0;
@@ -1117,7 +1117,7 @@ TGeoNode *TGeoIterator::Next()
                return fTop->GetNode(fArray[fLevel]);
             }
             fMustStop = kTRUE;
-            return 0;
+            return nullptr;
          } else {
             nd = next->GetNdaughters();
             if (fArray[fLevel] < nd - 1) {
@@ -1144,7 +1144,7 @@ TGeoNode *TGeoIterator::Next()
       }
    }
    fMustStop = kTRUE;
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1178,7 +1178,7 @@ const TGeoMatrix *TGeoIterator::GetCurrentMatrix() const
 TGeoNode *TGeoIterator::GetNode(Int_t level) const
 {
    if (!level || level > fLevel)
-      return 0;
+      return nullptr;
    TGeoNode *node = fTop->GetNode(fArray[1]);
    for (Int_t i = 2; i < level + 1; i++)
       node = node->GetDaughter(fArray[i]);
@@ -1250,7 +1250,7 @@ void TGeoIterator::Skip()
       // cd up and pick next
       while (next) {
          next = GetNode(fLevel - 1);
-         nd = (next == 0) ? fTop->GetNdaughters() : next->GetNdaughters();
+         nd = (next == nullptr) ? fTop->GetNdaughters() : next->GetNdaughters();
          if (fArray[fLevel] < nd - 1) {
             ++fArray[fLevel];
             return;
@@ -1264,7 +1264,7 @@ void TGeoIterator::Skip()
       break;
    case 1: // one level search
       next = GetNode(fLevel - 1);
-      nd = (next == 0) ? fTop->GetNdaughters() : next->GetNdaughters();
+      nd = (next == nullptr) ? fTop->GetNdaughters() : next->GetNdaughters();
       if (fArray[fLevel] < nd - 1) {
          ++fArray[fLevel];
          return;

--- a/geom/geom/src/TGeoPara.cxx
+++ b/geom/geom/src/TGeoPara.cxx
@@ -415,7 +415,7 @@ TGeoPara::Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndi
       finder = new TGeoPatternParaZ(voldiv, ndiv, start, end);
       opt = "Z";
       break;
-   default: Error("Divide", "Wrong axis type for division"); return 0;
+   default: Error("Divide", "Wrong axis type for division"); return nullptr;
    }
    vol = new TGeoVolume(divname, shape, voldiv->GetMedium());
    vmulti = gGeoManager->MakeVolumeMulti(divname, voldiv->GetMedium());
@@ -547,10 +547,10 @@ Int_t TGeoPara::GetFittingBox(const TGeoBBox *parambox, TGeoMatrix *mat, Double_
 TGeoShape *TGeoPara::GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix * /*mat*/) const
 {
    if (!TestShapeBit(kGeoRunTimeShape))
-      return 0;
+      return nullptr;
    if (!mother->TestShapeBit(kGeoPara)) {
       Error("GetMakeRuntimeShape", "invalid mother");
-      return 0;
+      return nullptr;
    }
    Double_t dx, dy, dz;
    if (fX < 0)

--- a/geom/geom/src/TGeoParaboloid.cxx
+++ b/geom/geom/src/TGeoParaboloid.cxx
@@ -319,7 +319,7 @@ TGeoVolume *TGeoParaboloid::Divide(TGeoVolume * /*voldiv*/, const char * /*divna
                                    Double_t /*start*/, Double_t /*step*/)
 {
    Error("Divide", "Paraboloid divisions not implemented");
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -341,7 +341,7 @@ void TGeoParaboloid::GetBoundingCylinder(Double_t *param) const
 
 TGeoShape *TGeoParaboloid::GetMakeRuntimeShape(TGeoShape *, TGeoMatrix *) const
 {
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/geom/geom/src/TGeoParallelWorld.cxx
+++ b/geom/geom/src/TGeoParallelWorld.cxx
@@ -43,8 +43,8 @@ TGeoParallelWorld::TGeoParallelWorld(const char *name, TGeoManager *mgr)
      fPaths(new TObjArray(256)),
      fUseOverlaps(kFALSE),
      fIsClosed(kFALSE),
-     fVolume(0),
-     fLastState(0),
+     fVolume(nullptr),
+     fLastState(nullptr),
      fPhysical(new TObjArray(256))
 {
 }
@@ -216,7 +216,7 @@ TGeoPhysicalNode *TGeoParallelWorld::FindNode(Double_t point[3])
    Int_t *check_list = voxels->GetCheckList(point, ncheck, info);
    //   cache->ReleaseInfo(); // no hierarchical use
    if (!check_list)
-      return 0;
+      return nullptr;
    // loop all nodes in voxel
    TGeoNode *node;
    Double_t local[3];
@@ -229,7 +229,7 @@ TGeoPhysicalNode *TGeoParallelWorld::FindNode(Double_t point[3])
          return fLastState;
       }
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -241,16 +241,16 @@ TGeoParallelWorld::FindNextBoundary(Double_t point[3], Double_t dir[3], Double_t
 {
    if (!fIsClosed)
       Fatal("FindNextBoundary", "Parallel geometry must be closed first");
-   TGeoPhysicalNode *pnode = 0;
+   TGeoPhysicalNode *pnode = nullptr;
    TGeoNavigator *nav = fGeoManager->GetCurrentNavigator();
    // Fast return if not in an overlapping candidate
    if (fUseOverlaps && !nav->GetCurrentVolume()->IsOverlappingCandidate())
-      return 0;
+      return nullptr;
    //   TIter next(fPhysical);
    // Ignore the request if the current state in the main geometry matches the
    // last touched physical node in the parallel geometry
    if (fLastState && fLastState->IsMatchingState(nav))
-      return 0;
+      return nullptr;
    //   while ((pnode = (TGeoPhysicalNode*)next())) {
    //      if (pnode->IsMatchingState(nav)) return 0;
    //   }
@@ -282,12 +282,12 @@ TGeoParallelWorld::FindNextBoundary(Double_t point[3], Double_t dir[3], Double_t
          return pnode;
       }
       step = TGeoShape::Big();
-      return 0;
+      return nullptr;
    }
    // Get current voxel
    Int_t ncheck = 0;
    Int_t sumchecked = 0;
-   Int_t *vlist = 0;
+   Int_t *vlist = nullptr;
    TGeoNodeCache *cache = nav->GetCache();
    TGeoStateInfo &info = *cache->GetMakePWInfo(nd);
    //   TGeoStateInfo &info = *cache->GetInfo();
@@ -298,7 +298,7 @@ TGeoParallelWorld::FindNextBoundary(Double_t point[3], Double_t dir[3], Double_t
          pnode = (TGeoPhysicalNode *)fPhysical->At(vlist[i]);
          if (pnode->IsMatchingState(nav)) {
             step = TGeoShape::Big();
-            return 0;
+            return nullptr;
          }
          current = fVolume->GetNode(vlist[i]);
          current->MasterToLocal(point, lpoint);
@@ -320,7 +320,7 @@ TGeoParallelWorld::FindNextBoundary(Double_t point[3], Double_t dir[3], Double_t
       }
    }
    step = TGeoShape::Big();
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -338,7 +338,7 @@ Double_t TGeoParallelWorld::Safety(Double_t point[3], Double_t safmax)
    Double_t local[3];
    Double_t safe = safmax;
    Double_t safnext;
-   TGeoPhysicalNode *pnode = 0;
+   TGeoPhysicalNode *pnode = nullptr;
    const Double_t tolerance = TGeoShape::Tolerance();
    Int_t nd = fVolume->GetNdaughters();
    TGeoNode *current;

--- a/geom/geom/src/TGeoPatternFinder.cxx
+++ b/geom/geom/src/TGeoPatternFinder.cxx
@@ -54,7 +54,7 @@ ClassImp(TGeoPatternHoneycomb);
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor.
 
-TGeoPatternFinder::ThreadData_t::ThreadData_t() : fMatrix(0), fCurrent(-1), fNextIndex(-1) {}
+TGeoPatternFinder::ThreadData_t::ThreadData_t() : fMatrix(nullptr), fCurrent(-1), fNextIndex(-1) {}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Destructor.
@@ -95,7 +95,7 @@ void TGeoPatternFinder::CreateThreadData(Int_t nthreads)
    fThreadData.resize(nthreads);
    fThreadSize = nthreads;
    for (Int_t tid = 0; tid < nthreads; tid++) {
-      if (fThreadData[tid] == 0) {
+      if (fThreadData[tid] == nullptr) {
          fThreadData[tid] = new ThreadData_t;
          fThreadData[tid]->fMatrix = CreateMatrix();
       }
@@ -112,7 +112,7 @@ TGeoPatternFinder::TGeoPatternFinder()
    fStep = 0;
    fStart = 0;
    fEnd = 0;
-   fVolume = 0;
+   fVolume = nullptr;
    fThreadSize = 0;
 }
 
@@ -208,7 +208,7 @@ TGeoNode *TGeoPatternFinder::CdNext()
 {
    ThreadData_t &td = GetThreadData();
    if (td.fNextIndex < 0)
-      return NULL;
+      return nullptr;
    cd(td.fNextIndex);
    return GetNodeOffset(td.fCurrent);
 }
@@ -354,7 +354,7 @@ Bool_t TGeoPatternX::IsOnBoundary(const Double_t *point) const
 TGeoNode *TGeoPatternX::FindNode(Double_t *point, const Double_t *dir)
 {
    ThreadData_t &td = GetThreadData();
-   TGeoNode *node = 0;
+   TGeoNode *node = nullptr;
    Int_t ind = (Int_t)(1. + (point[0] - fStart) / fStep) - 1;
    if (dir) {
       td.fNextIndex = ind;
@@ -548,7 +548,7 @@ Bool_t TGeoPatternY::IsOnBoundary(const Double_t *point) const
 TGeoNode *TGeoPatternY::FindNode(Double_t *point, const Double_t *dir)
 {
    ThreadData_t &td = GetThreadData();
-   TGeoNode *node = 0;
+   TGeoNode *node = nullptr;
    Int_t ind = (Int_t)(1. + (point[1] - fStart) / fStep) - 1;
    if (dir) {
       td.fNextIndex = ind;
@@ -738,7 +738,7 @@ Bool_t TGeoPatternZ::IsOnBoundary(const Double_t *point) const
 TGeoNode *TGeoPatternZ::FindNode(Double_t *point, const Double_t *dir)
 {
    ThreadData_t &td = GetThreadData();
-   TGeoNode *node = 0;
+   TGeoNode *node = nullptr;
    Int_t ind = (Int_t)(1. + (point[2] - fStart) / fStep) - 1;
    if (dir) {
       td.fNextIndex = ind;
@@ -906,7 +906,7 @@ Bool_t TGeoPatternParaX::IsOnBoundary(const Double_t *point) const
 TGeoNode *TGeoPatternParaX::FindNode(Double_t *point, const Double_t *dir)
 {
    ThreadData_t &td = GetThreadData();
-   TGeoNode *node = 0;
+   TGeoNode *node = nullptr;
    Double_t txy = ((TGeoPara *)fVolume->GetShape())->GetTxy();
    Double_t txz = ((TGeoPara *)fVolume->GetShape())->GetTxz();
    Double_t tyz = ((TGeoPara *)fVolume->GetShape())->GetTyz();
@@ -1088,7 +1088,7 @@ Bool_t TGeoPatternParaY::IsOnBoundary(const Double_t *point) const
 TGeoNode *TGeoPatternParaY::FindNode(Double_t *point, const Double_t *dir)
 {
    ThreadData_t &td = GetThreadData();
-   TGeoNode *node = 0;
+   TGeoNode *node = nullptr;
    Double_t tyz = ((TGeoPara *)fVolume->GetShape())->GetTyz();
    Double_t yt = point[1] - tyz * point[2];
    Int_t ind = (Int_t)(1. + (yt - fStart) / fStep) - 1;
@@ -1274,7 +1274,7 @@ Bool_t TGeoPatternParaZ::IsOnBoundary(const Double_t *point) const
 TGeoNode *TGeoPatternParaZ::FindNode(Double_t *point, const Double_t *dir)
 {
    ThreadData_t &td = GetThreadData();
-   TGeoNode *node = 0;
+   TGeoNode *node = nullptr;
    Double_t zt = point[2];
    Int_t ind = (Int_t)(1. + (zt - fStart) / fStep) - 1;
    if (dir) {
@@ -1463,7 +1463,7 @@ Bool_t TGeoPatternTrapZ::IsOnBoundary(const Double_t *point) const
 TGeoNode *TGeoPatternTrapZ::FindNode(Double_t *point, const Double_t *dir)
 {
    ThreadData_t &td = GetThreadData();
-   TGeoNode *node = 0;
+   TGeoNode *node = nullptr;
    Double_t zt = point[2];
    Int_t ind = (Int_t)(1. + (zt - fStart) / fStep) - 1;
    if (dir) {
@@ -1628,7 +1628,7 @@ TGeoNode *TGeoPatternCylR::FindNode(Double_t *point, const Double_t *dir)
    ThreadData_t &td = GetThreadData();
    if (!td.fMatrix)
       td.fMatrix = gGeoIdentity;
-   TGeoNode *node = 0;
+   TGeoNode *node = nullptr;
    Double_t r = TMath::Sqrt(point[0] * point[0] + point[1] * point[1]);
    Int_t ind = (Int_t)(1. + (r - fStart) / fStep) - 1;
    if (dir) {
@@ -1695,7 +1695,7 @@ void TGeoPatternCylR::UpdateMatrix(Int_t, TGeoHMatrix &matrix) const
 
 TGeoPatternCylPhi::TGeoPatternCylPhi()
 {
-   fSinCos = 0;
+   fSinCos = nullptr;
    CreateThreadData(1);
 }
 ////////////////////////////////////////////////////////////////////////////////
@@ -1796,7 +1796,7 @@ Bool_t TGeoPatternCylPhi::IsOnBoundary(const Double_t *point) const
 TGeoNode *TGeoPatternCylPhi::FindNode(Double_t *point, const Double_t *dir)
 {
    ThreadData_t &td = GetThreadData();
-   TGeoNode *node = 0;
+   TGeoNode *node = nullptr;
    Double_t phi = TMath::ATan2(point[1], point[0]) * TMath::RadToDeg();
    if (phi < 0)
       phi += 360;
@@ -1966,7 +1966,7 @@ void TGeoPatternSphR::cd(Int_t idiv)
 
 TGeoNode *TGeoPatternSphR::FindNode(Double_t * /*point*/, const Double_t * /*dir*/)
 {
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2079,7 +2079,7 @@ void TGeoPatternSphTheta::cd(Int_t idiv)
 
 TGeoNode *TGeoPatternSphTheta::FindNode(Double_t * /*point*/, const Double_t * /*dir*/)
 {
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2126,7 +2126,7 @@ void TGeoPatternSphTheta::UpdateMatrix(Int_t, TGeoHMatrix &matrix) const
 
 TGeoPatternSphPhi::TGeoPatternSphPhi()
 {
-   fSinCos = 0;
+   fSinCos = nullptr;
    CreateThreadData(1);
 }
 ////////////////////////////////////////////////////////////////////////////////
@@ -2231,7 +2231,7 @@ Bool_t TGeoPatternSphPhi::IsOnBoundary(const Double_t *point) const
 TGeoNode *TGeoPatternSphPhi::FindNode(Double_t *point, const Double_t *dir)
 {
    ThreadData_t &td = GetThreadData();
-   TGeoNode *node = 0;
+   TGeoNode *node = nullptr;
    Double_t phi = TMath::ATan2(point[1], point[0]) * TMath::RadToDeg();
    if (phi < 0)
       phi += 360;
@@ -2316,8 +2316,8 @@ TGeoPatternHoneycomb::TGeoPatternHoneycomb()
 {
    fNrows = 0;
    fAxisOnRows = 0;
-   fNdivisions = 0;
-   fStart = 0;
+   fNdivisions = nullptr;
+   fStart = nullptr;
    CreateThreadData(1);
 }
 ////////////////////////////////////////////////////////////////////////////////
@@ -2327,8 +2327,8 @@ TGeoPatternHoneycomb::TGeoPatternHoneycomb(TGeoVolume *vol, Int_t nrows) : TGeoP
 {
    fNrows = nrows;
    fAxisOnRows = 0;
-   fNdivisions = 0;
-   fStart = 0;
+   fNdivisions = nullptr;
+   fStart = nullptr;
    CreateThreadData(1);
    // compute everything else
 }
@@ -2377,7 +2377,7 @@ void TGeoPatternHoneycomb::cd(Int_t idiv)
 
 TGeoNode *TGeoPatternHoneycomb::FindNode(Double_t * /*point*/, const Double_t * /*dir*/)
 {
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/geom/geom/src/TGeoPcon.cxx
+++ b/geom/geom/src/TGeoPcon.cxx
@@ -745,7 +745,7 @@ TGeoPcon::Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndi
    switch (iaxis) {
    case 1: //---               R division
       Error("Divide", "Shape %s: cannot divide a pcon on radius", GetName());
-      return 0;
+      return nullptr;
    case 2: //---               Phi division
       finder = new TGeoPatternCylPhi(voldiv, ndiv, start, start + ndiv * step);
       vmulti = gGeoManager->MakeVolumeMulti(divname, voldiv->GetMedium());
@@ -778,7 +778,7 @@ TGeoPcon::Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndi
       }
       if (isect < 0) {
          Error("Divide", "Shape %s: cannot divide pcon on Z if divided region is not between 2 planes", GetName());
-         return 0;
+         return nullptr;
       }
       finder = new TGeoPatternZ(voldiv, ndiv, start, start + ndiv * step);
       vmulti = gGeoManager->MakeVolumeMulti(divname, voldiv->GetMedium());
@@ -814,7 +814,7 @@ TGeoPcon::Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndi
          ((TGeoNodeOffset *)voldiv->GetNodes()->At(voldiv->GetNdaughters() - 1))->SetFinder(finder);
       }
       return vmulti;
-   default: Error("Divide", "Shape %s: Wrong axis %d for division", GetName(), iaxis); return 0;
+   default: Error("Divide", "Shape %s: Wrong axis %d for division", GetName(), iaxis); return nullptr;
    }
 }
 

--- a/geom/geom/src/TGeoPgon.cxx
+++ b/geom/geom/src/TGeoPgon.cxx
@@ -71,7 +71,7 @@ ClassImp(TGeoPgon);
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor.
 
-TGeoPgon::ThreadData_t::ThreadData_t() : fIntBuffer(0), fDblBuffer(0) {}
+TGeoPgon::ThreadData_t::ThreadData_t() : fIntBuffer(nullptr), fDblBuffer(nullptr) {}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Destructor.
@@ -115,7 +115,7 @@ void TGeoPgon::CreateThreadData(Int_t nthreads)
    fThreadData.resize(nthreads);
    fThreadSize = nthreads;
    for (Int_t tid = 0; tid < nthreads; tid++) {
-      if (fThreadData[tid] == 0) {
+      if (fThreadData[tid] == nullptr) {
          fThreadData[tid] = new ThreadData_t;
          fThreadData[tid]->fIntBuffer = new Int_t[fNedges + 10];
          fThreadData[tid]->fDblBuffer = new Double_t[fNedges + 10];
@@ -1443,11 +1443,11 @@ TGeoPgon::Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndi
    switch (iaxis) {
    case 1: //---                R division
       Error("Divide", "makes no sense dividing a pgon on radius");
-      return 0;
+      return nullptr;
    case 2: //---                Phi division
       if (fNedges % ndiv) {
          Error("Divide", "ndiv should divide number of pgon edges");
-         return 0;
+         return nullptr;
       }
       nedges = fNedges / ndiv;
       finder = new TGeoPatternCylPhi(voldiv, ndiv, start, start + ndiv * step);
@@ -1481,7 +1481,7 @@ TGeoPgon::Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndi
       }
       if (isect < 0) {
          Error("Divide", "cannot divide pcon on Z if divided region is not between 2 consecutive planes");
-         return 0;
+         return nullptr;
       }
       finder = new TGeoPatternZ(voldiv, ndiv, start, start + ndiv * step);
       vmulti = gGeoManager->MakeVolumeMulti(divname, voldiv->GetMedium());
@@ -1504,7 +1504,7 @@ TGeoPgon::Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndi
          ((TGeoNodeOffset *)voldiv->GetNodes()->At(voldiv->GetNdaughters() - 1))->SetFinder(finder);
       }
       return vmulti;
-   default: Error("Divide", "Wrong axis type for division"); return 0;
+   default: Error("Divide", "Wrong axis type for division"); return nullptr;
    }
 }
 

--- a/geom/geom/src/TGeoPhysicalNode.cxx
+++ b/geom/geom/src/TGeoPhysicalNode.cxx
@@ -77,9 +77,9 @@ ClassImp(TGeoPhysicalNode);
 TGeoPhysicalNode::TGeoPhysicalNode() : TNamed()
 {
    fLevel = 0;
-   fMatrices = 0;
-   fNodes = 0;
-   fMatrixOrig = 0;
+   fMatrices = nullptr;
+   fNodes = nullptr;
+   fMatrixOrig = nullptr;
    SetVisibility(kTRUE);
    SetVisibleFull(kFALSE);
    SetIsVolAtt(kTRUE);
@@ -98,7 +98,7 @@ TGeoPhysicalNode::TGeoPhysicalNode(const char *path) : TNamed(path, "")
    fLevel = 0;
    fMatrices = new TObjArray(30);
    fNodes = new TObjArray(30);
-   fMatrixOrig = 0;
+   fMatrixOrig = nullptr;
    SetPath(path);
    SetVisibility(kTRUE);
    SetVisibleFull(kFALSE);
@@ -281,7 +281,7 @@ Bool_t TGeoPhysicalNode::Align(TGeoMatrix *newmat, TGeoShape *newshape, Bool_t c
                ncs->GetBoolNode()->ReplaceMatrix(oldmat, newmat1);
                vd->SetShape(ncs);
                // The right-side matrix pointer is preserved, so no need to update nodes.
-               aligned = 0; // to prevent updating its matrix
+               aligned = nullptr; // to prevent updating its matrix
             }
          }
       }
@@ -348,11 +348,11 @@ Bool_t TGeoPhysicalNode::Align(TGeoMatrix *newmat, TGeoShape *newshape, Bool_t c
                  "The check for overlaps for assembly node: \n%s\n cannot be performed since the parent %s is declared "
                  "possibly overlapping",
                  GetName(), node->GetName());
-            node = 0;
+            node = nullptr;
          }
          if (node)
             node->CheckOverlaps(ovlp);
-         gGeoManager->SetCheckedNode(0);
+         gGeoManager->SetCheckedNode(nullptr);
       }
    }
    // Clean current matrices from cache
@@ -382,7 +382,7 @@ TGeoNode *TGeoPhysicalNode::GetMother(Int_t levup) const
 {
    Int_t ind = fLevel - levup;
    if (ind < 0)
-      return 0;
+      return nullptr;
    return (TGeoNode *)fNodes->UncheckedAt(ind);
 }
 
@@ -394,7 +394,7 @@ TGeoHMatrix *TGeoPhysicalNode::GetMatrix(Int_t level) const
    if (level < 0)
       return (TGeoHMatrix *)fMatrices->UncheckedAt(fLevel);
    if (level > fLevel)
-      return 0;
+      return nullptr;
    return (TGeoHMatrix *)fMatrices->UncheckedAt(level);
 }
 
@@ -406,7 +406,7 @@ TGeoNode *TGeoPhysicalNode::GetNode(Int_t level) const
    if (level < 0)
       return (TGeoNode *)fNodes->UncheckedAt(fLevel);
    if (level > fLevel)
-      return 0;
+      return nullptr;
    return (TGeoNode *)fNodes->UncheckedAt(level);
 }
 
@@ -418,7 +418,7 @@ TGeoVolume *TGeoPhysicalNode::GetVolume(Int_t level) const
    TGeoNode *node = GetNode(level);
    if (node)
       return node->GetVolume();
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -429,7 +429,7 @@ TGeoShape *TGeoPhysicalNode::GetShape(Int_t level) const
    TGeoVolume *vol = GetVolume(level);
    if (vol)
       return vol->GetShape();
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -571,9 +571,9 @@ ClassImp(TGeoPNEntry);
 
 TGeoPNEntry::TGeoPNEntry()
 {
-   fNode = 0;
-   fMatrix = 0;
-   fGlobalOrig = 0;
+   fNode = nullptr;
+   fMatrix = nullptr;
+   fGlobalOrig = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -592,8 +592,8 @@ TGeoPNEntry::TGeoPNEntry(const char *name, const char *path) : TNamed(name, path
    fGlobalOrig = new TGeoHMatrix();
    *fGlobalOrig = gGeoManager->GetCurrentMatrix();
    gGeoManager->PopPath();
-   fNode = 0;
-   fMatrix = 0;
+   fNode = nullptr;
+   fMatrix = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/geom/geom/src/TGeoPolygon.cxx
+++ b/geom/geom/src/TGeoPolygon.cxx
@@ -202,7 +202,7 @@ void TGeoPolygon::FinishPolygon()
    // ... algorithm here
    if (!fDaughters)
       fDaughters = new TObjArray();
-   TGeoPolygon *poly = 0;
+   TGeoPolygon *poly = nullptr;
    Int_t indconv = 0;
    Int_t indnext, indback;
    Int_t nskip;

--- a/geom/geom/src/TGeoScaledShape.cxx
+++ b/geom/geom/src/TGeoScaledShape.cxx
@@ -34,8 +34,8 @@ ClassImp(TGeoScaledShape);
 
 TGeoScaledShape::TGeoScaledShape()
 {
-   fShape = 0;
-   fScale = 0;
+   fShape = nullptr;
+   fScale = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -187,7 +187,7 @@ TGeoVolume *TGeoScaledShape::Divide(TGeoVolume * /*voldiv*/, const char *divname
                                     Double_t /*start*/, Double_t /*step*/)
 {
    Error("Divide", "Scaled shapes cannot be divided. Division volume %s not created", divname);
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -221,7 +221,7 @@ const TBuffer3D &TGeoScaledShape::GetBuffer3D(Int_t reqSections, Bool_t localFra
 TGeoShape *TGeoScaledShape::GetMakeRuntimeShape(TGeoShape * /*mother*/, TGeoMatrix * /*mat*/) const
 {
    Error("GetMakeRuntimeShape", "Scaled shapes cannot be parametrized.");
-   return NULL;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/geom/geom/src/TGeoShape.cxx
+++ b/geom/geom/src/TGeoShape.cxx
@@ -158,7 +158,7 @@ are interpreted and which is their result inside specific shape classes.
 
 ClassImp(TGeoShape);
 
-TGeoMatrix *TGeoShape::fgTransform = NULL;
+TGeoMatrix *TGeoShape::fgTransform = nullptr;
 Double_t TGeoShape::fgEpsMch = 2.220446049250313e-16;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -686,7 +686,7 @@ void TGeoShape::FillBuffer3D(TBuffer3D &buffer, Int_t reqSections, Bool_t localF
 
       // Set up local -> master translation matrix
       if (localFrame) {
-         TGeoMatrix *localMasterMat = 0;
+         TGeoMatrix *localMasterMat = nullptr;
          if (TGeoShape::GetTransform()) {
             localMasterMat = TGeoShape::GetTransform();
          } else {

--- a/geom/geom/src/TGeoShapeAssembly.cxx
+++ b/geom/geom/src/TGeoShapeAssembly.cxx
@@ -33,7 +33,7 @@ ClassImp(TGeoShapeAssembly);
 
 TGeoShapeAssembly::TGeoShapeAssembly()
 {
-   fVolume = 0;
+   fVolume = nullptr;
    fBBoxOK = kFALSE;
 }
 
@@ -197,7 +197,7 @@ Bool_t TGeoShapeAssembly::Contains(const Double_t *point) const
    TGeoVoxelFinder *voxels = fVolume->GetVoxels();
    TGeoNode *node;
    TGeoShape *shape;
-   Int_t *check_list = 0;
+   Int_t *check_list = nullptr;
    Int_t ncheck, id;
    Double_t local[3];
    if (voxels) {
@@ -378,7 +378,7 @@ Double_t TGeoShapeAssembly::DistFromOutside(const Double_t *point, const Double_
    }
    // current volume is voxelized, first get current voxel
    Int_t ncheck = 0;
-   Int_t *vlist = 0;
+   Int_t *vlist = nullptr;
    TGeoNavigator *nav = gGeoManager->GetCurrentNavigator();
    TGeoStateInfo &td = *nav->GetCache()->GetInfo();
 
@@ -435,7 +435,7 @@ TGeoVolume *TGeoShapeAssembly::Divide(TGeoVolume * /*voldiv*/, const char *divna
                                       Double_t /*start*/, Double_t /*step*/)
 {
    Error("Divide", "Assemblies cannot be divided. Division volume %s not created", divname);
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -445,7 +445,7 @@ TGeoVolume *TGeoShapeAssembly::Divide(TGeoVolume * /*voldiv*/, const char *divna
 TGeoShape *TGeoShapeAssembly::GetMakeRuntimeShape(TGeoShape * /*mother*/, TGeoMatrix * /*mat*/) const
 {
    Error("GetMakeRuntimeShape", "Assemblies cannot be parametrized.");
-   return NULL;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -500,7 +500,7 @@ Double_t TGeoShapeAssembly::Safety(const Double_t *point, Bool_t in) const
    Double_t safe;
    TGeoVoxelFinder *voxels = fVolume->GetVoxels();
    Int_t nd = fVolume->GetNdaughters();
-   Double_t *boxes = 0;
+   Double_t *boxes = nullptr;
    if (voxels)
       boxes = voxels->GetBoxes();
    TGeoNode *node;

--- a/geom/geom/src/TGeoSphere.cxx
+++ b/geom/geom/src/TGeoSphere.cxx
@@ -1116,7 +1116,7 @@ TGeoSphere::Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t n
          ((TGeoNodeOffset *)voldiv->GetNodes()->At(voldiv->GetNdaughters() - 1))->SetFinder(finder);
       }
       return vmulti;
-   default: Error("Divide", "In shape %s wrong axis type for division", GetName()); return 0;
+   default: Error("Divide", "In shape %s wrong axis type for division", GetName()); return nullptr;
    }
 }
 

--- a/geom/geom/src/TGeoStateInfo.cxx
+++ b/geom/geom/src/TGeoStateInfo.cxx
@@ -27,7 +27,7 @@ ClassImp(TGeoStateInfo);
 /// Constructor
 
 TGeoStateInfo::TGeoStateInfo(Int_t maxdaughters)
-   : fNode(0),
+   : fNode(nullptr),
      fAsmCurrent(0),
      fAsmNext(0),
      fDivCurrent(0),
@@ -37,14 +37,14 @@ TGeoStateInfo::TGeoStateInfo(Int_t maxdaughters)
      fDivCombi(),
      fVoxNcandidates(0),
      fVoxCurrent(0),
-     fVoxCheckList(0),
-     fVoxBits1(0),
+     fVoxCheckList(nullptr),
+     fVoxBits1(nullptr),
      fBoolSelected(0),
      fXtruSeg(0),
      fXtruIz(0),
-     fXtruXc(0),
-     fXtruYc(0),
-     fXtruPoly(0)
+     fXtruXc(nullptr),
+     fXtruYc(nullptr),
+     fXtruPoly(nullptr)
 {
    Int_t maxDaughters = (maxdaughters > 0) ? maxdaughters : TGeoManager::GetMaxDaughters();
    Int_t maxXtruVert = TGeoManager::GetMaxXtruVert();

--- a/geom/geom/src/TGeoTessellated.cxx
+++ b/geom/geom/src/TGeoTessellated.cxx
@@ -250,7 +250,7 @@ bool TGeoTessellated::AddFacet(int i0, int i1, int i2)
       Error("AddFacet", "Shape %s already fully defined. Not adding", GetName());
       return false;
    }
-   if (fVertices.size() == 0) {
+   if (fVertices.empty()) {
       Error("AddFacet", "Shape %s Cannot add facets by indices without vertices. Not adding", GetName());
       return false;
    }
@@ -301,7 +301,7 @@ bool TGeoTessellated::AddFacet(int i0, int i1, int i2, int i3)
       Error("AddFacet", "Shape %s already fully defined. Not adding", GetName());
       return false;
    }
-   if (fVertices.size() == 0) {
+   if (fVertices.empty()) {
       Error("AddFacet", "Shape %s Cannot add facets by indices without vertices. Not adding", GetName());
       return false;
    }
@@ -330,7 +330,7 @@ void TGeoTessellated::CloseShape(bool check, bool fixFlipped, bool verbose)
    invExtent[1] = 0.5 / (fDY + tolerance);
    invExtent[2] = 0.5 / (fDZ + tolerance);
 
-   if (fVertices.size() > 0) {
+   if (!fVertices.empty()) {
       fDefined = true;
       if (!check)
          return;
@@ -722,14 +722,14 @@ TGeoTessellated *TGeoTessellated::ImportFromObjFormat(const char *objfile, bool 
       string tag;
 
       // We ignore everything which is not a vertex or a face
-      if (line.rfind("v", 0) == 0 && line.rfind("vt", 0) != 0 && line.rfind("vn", 0) != 0 && line.rfind("vn", 0) != 0) {
+      if (line.rfind('v', 0) == 0 && line.rfind("vt", 0) != 0 && line.rfind("vn", 0) != 0 && line.rfind("vn", 0) != 0) {
          // Decode the vertex
          double pos[4] = {0, 0, 0, 1};
          ss >> tag >> pos[0] >> pos[1] >> pos[2] >> pos[3];
          vertices.emplace_back(pos[0] * pos[3], pos[1] * pos[3], pos[2] * pos[3]);
       }
 
-      else if (line.rfind("f", 0) == 0) {
+      else if (line.rfind('f', 0) == 0) {
          // Decode the face
          ss >> tag;
          string word;

--- a/geom/geom/src/TGeoTorus.cxx
+++ b/geom/geom/src/TGeoTorus.cxx
@@ -510,7 +510,7 @@ TGeoTorus::DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iac
 TGeoVolume *TGeoTorus::Divide(TGeoVolume * /*voldiv*/, const char * /*divname*/, Int_t /*iaxis*/, Int_t /*ndiv*/,
                               Double_t /*start*/, Double_t /*step*/)
 {
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -568,9 +568,9 @@ void TGeoTorus::GetBoundingCylinder(Double_t *param) const
 TGeoShape *TGeoTorus::GetMakeRuntimeShape(TGeoShape * /*mother*/, TGeoMatrix * /*mat*/) const
 {
    if (!TestShapeBit(kGeoRunTimeShape))
-      return 0;
+      return nullptr;
    Error("GetMakeRuntimeShape", "parametrized toruses not supported");
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/geom/geom/src/TGeoTrd1.cxx
+++ b/geom/geom/src/TGeoTrd1.cxx
@@ -469,7 +469,7 @@ TGeoTrd1::Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndi
    Int_t id;
    Double_t end = start + ndiv * step;
    switch (iaxis) {
-   case 1: Warning("Divide", "dividing a Trd1 on X not implemented"); return 0;
+   case 1: Warning("Divide", "dividing a Trd1 on X not implemented"); return nullptr;
    case 2:
       finder = new TGeoPatternY(voldiv, ndiv, start, end);
       voldiv->SetFinder(finder);
@@ -502,7 +502,7 @@ TGeoTrd1::Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndi
          ((TGeoNodeOffset *)voldiv->GetNodes()->At(voldiv->GetNdaughters() - 1))->SetFinder(finder);
       }
       return vmulti;
-   default: Error("Divide", "Wrong axis type for division"); return 0;
+   default: Error("Divide", "Wrong axis type for division"); return nullptr;
    }
 }
 
@@ -606,10 +606,10 @@ Int_t TGeoTrd1::GetFittingBox(const TGeoBBox *parambox, TGeoMatrix *mat, Double_
 TGeoShape *TGeoTrd1::GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix * /*mat*/) const
 {
    if (!TestShapeBit(kGeoRunTimeShape))
-      return 0;
+      return nullptr;
    if (!mother->TestShapeBit(kGeoTrd1)) {
       Error("GetMakeRuntimeShape", "invalid mother");
-      return 0;
+      return nullptr;
    }
    Double_t dx1, dx2, dy, dz;
    if (fDx1 < 0)

--- a/geom/geom/src/TGeoTrd2.cxx
+++ b/geom/geom/src/TGeoTrd2.cxx
@@ -525,8 +525,8 @@ TGeoTrd2::Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndi
    Int_t id;
    Double_t end = start + ndiv * step;
    switch (iaxis) {
-   case 1: Warning("Divide", "dividing a Trd2 on X not implemented"); return 0;
-   case 2: Warning("Divide", "dividing a Trd2 on Y not implemented"); return 0;
+   case 1: Warning("Divide", "dividing a Trd2 on X not implemented"); return nullptr;
+   case 2: Warning("Divide", "dividing a Trd2 on Y not implemented"); return nullptr;
    case 3:
       finder = new TGeoPatternZ(voldiv, ndiv, start, end);
       vmulti = gGeoManager->MakeVolumeMulti(divname, voldiv->GetMedium());
@@ -547,7 +547,7 @@ TGeoTrd2::Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndi
          ((TGeoNodeOffset *)voldiv->GetNodes()->At(voldiv->GetNdaughters() - 1))->SetFinder(finder);
       }
       return vmulti;
-   default: Error("Divide", "Wrong axis type for division"); return 0;
+   default: Error("Divide", "Wrong axis type for division"); return nullptr;
    }
 }
 
@@ -624,10 +624,10 @@ Int_t TGeoTrd2::GetFittingBox(const TGeoBBox *parambox, TGeoMatrix *mat, Double_
 TGeoShape *TGeoTrd2::GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix * /*mat*/) const
 {
    if (!TestShapeBit(kGeoRunTimeShape))
-      return 0;
+      return nullptr;
    if (!mother->TestShapeBit(kGeoTrd2)) {
       Error("GetMakeRuntimeShape", "invalid mother");
-      return 0;
+      return nullptr;
    }
    Double_t dx1, dx2, dy1, dy2, dz;
    if (fDx1 < 0)

--- a/geom/geom/src/TGeoTube.cxx
+++ b/geom/geom/src/TGeoTube.cxx
@@ -576,7 +576,7 @@ TGeoTube::Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t ndi
          ((TGeoNodeOffset *)voldiv->GetNodes()->At(voldiv->GetNdaughters() - 1))->SetFinder(finder);
       }
       return vmulti;
-   default: Error("Divide", "In shape %s wrong axis type for division", GetName()); return 0;
+   default: Error("Divide", "In shape %s wrong axis type for division", GetName()); return nullptr;
    }
 }
 
@@ -642,7 +642,7 @@ void TGeoTube::GetBoundingCylinder(Double_t *param) const
 TGeoShape *TGeoTube::GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix * /*mat*/) const
 {
    if (!TestShapeBit(kGeoRunTimeShape))
-      return 0;
+      return nullptr;
    Double_t rmin, rmax, dz;
    Double_t xmin, xmax;
    rmin = fRmin;
@@ -651,18 +651,18 @@ TGeoShape *TGeoTube::GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix * /*mat*/
    if (fDz < 0) {
       mother->GetAxisRange(3, xmin, xmax);
       if (xmax < 0)
-         return 0;
+         return nullptr;
       dz = xmax;
    }
    mother->GetAxisRange(1, xmin, xmax);
    if (fRmin < 0) {
       if (xmin < 0)
-         return 0;
+         return nullptr;
       rmin = xmin;
    }
    if (fRmax < 0) {
       if (xmax <= 0)
-         return 0;
+         return nullptr;
       rmax = xmax;
    }
 
@@ -1976,7 +1976,7 @@ TGeoTubeSeg::Divide(TGeoVolume *voldiv, const char *divname, Int_t iaxis, Int_t 
          ((TGeoNodeOffset *)voldiv->GetNodes()->At(voldiv->GetNdaughters() - 1))->SetFinder(finder);
       }
       return vmulti;
-   default: Error("Divide", "In shape %s wrong axis type for division", GetName()); return 0;
+   default: Error("Divide", "In shape %s wrong axis type for division", GetName()); return nullptr;
    }
 }
 
@@ -2029,10 +2029,10 @@ void TGeoTubeSeg::GetBoundingCylinder(Double_t *param) const
 TGeoShape *TGeoTubeSeg::GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix * /*mat*/) const
 {
    if (!TestShapeBit(kGeoRunTimeShape))
-      return 0;
+      return nullptr;
    if (!mother->TestShapeBit(kGeoTube)) {
       Error("GetMakeRuntimeShape", "Invalid mother for shape %s", GetName());
-      return 0;
+      return nullptr;
    }
    Double_t rmin, rmax, dz;
    rmin = fRmin;
@@ -3123,7 +3123,7 @@ TGeoVolume *TGeoCtub::Divide(TGeoVolume * /*voldiv*/, const char * /*divname*/, 
                              Double_t /*start*/, Double_t /*step*/)
 {
    Warning("Divide", "In shape %s division of a cut tube not implemented", GetName());
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -3133,10 +3133,10 @@ TGeoVolume *TGeoCtub::Divide(TGeoVolume * /*voldiv*/, const char * /*divname*/, 
 TGeoShape *TGeoCtub::GetMakeRuntimeShape(TGeoShape *mother, TGeoMatrix * /*mat*/) const
 {
    if (!TestShapeBit(kGeoRunTimeShape))
-      return 0;
+      return nullptr;
    if (!mother->TestShapeBit(kGeoTube)) {
       Error("GetMakeRuntimeShape", "Invalid mother for shape %s", GetName());
-      return 0;
+      return nullptr;
    }
    Double_t rmin, rmax, dz;
    rmin = fRmin;

--- a/geom/geom/src/TGeoVolume.cxx
+++ b/geom/geom/src/TGeoVolume.cxx
@@ -404,7 +404,7 @@ volumes (or volume assemblies) as content.
 
 ClassImp(TGeoVolume);
 
-TGeoMedium *TGeoVolume::fgDummyMedium = 0;
+TGeoMedium *TGeoVolume::fgDummyMedium = nullptr;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Create a dummy medium
@@ -452,19 +452,19 @@ TGeoMedium *TGeoVolume::DummyMedium()
 
 TGeoVolume::TGeoVolume()
 {
-   fNodes = 0;
-   fShape = 0;
-   fMedium = 0;
-   fFinder = 0;
-   fVoxels = 0;
+   fNodes = nullptr;
+   fShape = nullptr;
+   fMedium = nullptr;
+   fFinder = nullptr;
+   fVoxels = nullptr;
    fGeoManager = gGeoManager;
-   fField = 0;
+   fField = nullptr;
    fOption = "";
    fNumber = 0;
    fNtotal = 0;
    fRefCount = 0;
-   fUserExtension = 0;
-   fFWExtension = 0;
+   fUserExtension = nullptr;
+   fFWExtension = nullptr;
    fTransparency = -1;
    TObject::ResetBit(kVolumeImportNodes);
 }
@@ -475,7 +475,7 @@ TGeoVolume::TGeoVolume()
 TGeoVolume::TGeoVolume(const char *name, const TGeoShape *shape, const TGeoMedium *med) : TNamed(name, "")
 {
    fName = fName.Strip();
-   fNodes = 0;
+   fNodes = nullptr;
    fShape = (TGeoShape *)shape;
    if (fShape) {
       if (fShape->TestShapeBit(TGeoShape::kGeoBad)) {
@@ -488,16 +488,16 @@ TGeoVolume::TGeoVolume(const char *name, const TGeoShape *shape, const TGeoMediu
    fMedium = (TGeoMedium *)med;
    if (fMedium && fMedium->GetMaterial())
       fMedium->GetMaterial()->SetUsed();
-   fFinder = 0;
-   fVoxels = 0;
+   fFinder = nullptr;
+   fVoxels = nullptr;
    fGeoManager = gGeoManager;
-   fField = 0;
+   fField = nullptr;
    fOption = "";
    fNumber = 0;
    fNtotal = 0;
    fRefCount = 0;
-   fUserExtension = 0;
-   fFWExtension = 0;
+   fUserExtension = nullptr;
+   fFWExtension = nullptr;
    fTransparency = -1;
    if (fGeoManager)
       fNumber = fGeoManager->AddVolume(this);
@@ -521,11 +521,11 @@ TGeoVolume::~TGeoVolume()
       delete fVoxels;
    if (fUserExtension) {
       fUserExtension->Release();
-      fUserExtension = 0;
+      fUserExtension = nullptr;
    }
    if (fFWExtension) {
       fFWExtension->Release();
-      fFWExtension = 0;
+      fFWExtension = nullptr;
    }
 }
 
@@ -591,7 +591,7 @@ void TGeoVolume::CheckGeometry(Int_t nrays, Double_t startx, Double_t starty, Do
    if (old_vol != this)
       fGeoManager->SetTopVolume((TGeoVolume *)this);
    else
-      old_vol = 0;
+      old_vol = nullptr;
    fGeoManager->GetTopVolume()->Draw();
    TVirtualGeoPainter *painter = fGeoManager->GetGeomPainter();
    painter->CheckGeometry(nrays, startx, starty, startz);
@@ -683,9 +683,9 @@ void TGeoVolume::CheckShapes()
    if (!fNodes)
       return;
    Int_t nd = fNodes->GetEntriesFast();
-   TGeoNode *node = 0;
+   TGeoNode *node = nullptr;
    TGeoNode *new_node;
-   const TGeoShape *shape = 0;
+   const TGeoShape *shape = nullptr;
    TGeoVolume *old_vol;
    for (Int_t i = 0; i < nd; i++) {
       node = (TGeoNode *)fNodes->At(i);
@@ -805,7 +805,7 @@ void TGeoVolume::InvisibleAll(Bool_t flag)
       list->Add(vol);
    }
    TIter next(gROOT->GetListOfBrowsers());
-   TBrowser *browser = 0;
+   TBrowser *browser = nullptr;
    while ((browser = (TBrowser *)next())) {
       for (Int_t i = 0; i < nd + 1; i++) {
          vol = (TGeoVolume *)list->At(i);
@@ -875,8 +875,8 @@ TGeoVolume *TGeoVolume::Import(const char *filename, const char *name, Option_t 
    if (!gGeoManager)
       gGeoManager = new TGeoManager("geometry", "");
    if (!filename)
-      return 0;
-   TGeoVolume *volume = 0;
+      return nullptr;
+   TGeoVolume *volume = nullptr;
    if (strstr(filename, ".gdml")) {
       // import from a gdml file
    } else {
@@ -885,7 +885,7 @@ TGeoVolume *TGeoVolume::Import(const char *filename, const char *name, Option_t 
       TFile *f = TFile::Open(filename);
       if (!f || f->IsZombie()) {
          printf("Error: TGeoVolume::Import : Cannot open file %s\n", filename);
-         return 0;
+         return nullptr;
       }
       if (name && name[0]) {
          volume = (TGeoVolume *)f->Get(name);
@@ -902,7 +902,7 @@ TGeoVolume *TGeoVolume::Import(const char *filename, const char *name, Option_t 
       delete f;
    }
    if (!volume)
-      return NULL;
+      return nullptr;
    volume->RegisterYourself();
    return volume;
 }
@@ -975,18 +975,18 @@ void TGeoVolume::cd(Int_t inode) const
 TGeoNode *TGeoVolume::AddNode(TGeoVolume *vol, Int_t copy_no, TGeoMatrix *mat, Option_t * /*option*/)
 {
    TGeoMatrix *matrix = mat;
-   if (matrix == 0)
+   if (matrix == nullptr)
       matrix = gGeoIdentity;
    else
       matrix->RegisterYourself();
    if (!vol) {
       Error("AddNode", "Volume is NULL");
-      return 0;
+      return nullptr;
    }
    if (!vol->IsValid()) {
       Error("AddNode", "Won't add node with invalid shape");
       printf("### invalid volume was : %s\n", vol->GetName());
-      return 0;
+      return nullptr;
    }
    if (!fNodes)
       fNodes = new TObjArray();
@@ -994,10 +994,10 @@ TGeoNode *TGeoVolume::AddNode(TGeoVolume *vol, Int_t copy_no, TGeoMatrix *mat, O
    if (fFinder) {
       // volume already divided.
       Error("AddNode", "Cannot add node %s_%i into divided volume %s", vol->GetName(), copy_no, GetName());
-      return 0;
+      return nullptr;
    }
 
-   TGeoNodeMatrix *node = 0;
+   TGeoNodeMatrix *node = nullptr;
    node = new TGeoNodeMatrix(vol, matrix);
    node->SetMotherVolume(this);
    fNodes->Add(node);
@@ -1060,7 +1060,7 @@ void TGeoVolume::AddNodeOverlap(TGeoVolume *vol, Int_t copy_no, TGeoMatrix *mat,
       return;
    }
    TGeoMatrix *matrix = mat;
-   if (matrix == 0)
+   if (matrix == nullptr)
       matrix = gGeoIdentity;
    else
       matrix->RegisterYourself();
@@ -1106,7 +1106,7 @@ TGeoVolume *TGeoVolume::Divide(const char *divname, Int_t iaxis, Int_t ndiv, Dou
    if (fFinder) {
       // volume already divided.
       Fatal("Divide", "volume %s already divided", GetName());
-      return 0;
+      return nullptr;
    }
    TString opt(option);
    opt.ToLower();
@@ -1127,18 +1127,18 @@ TGeoVolume *TGeoVolume::Divide(const char *divname, Int_t iaxis, Int_t ndiv, Dou
    if (range <= 0) {
       InspectShape();
       Fatal("Divide", "cannot divide volume %s (%s) on %s axis", GetName(), stype.Data(), fShape->GetAxisName(iaxis));
-      return 0;
+      return nullptr;
    }
    if (ndiv <= 0 || opt.Contains("s")) {
       if (step <= 0) {
          Fatal("Divide", "invalid division type for volume %s : ndiv=%i, step=%g", GetName(), ndiv, step);
-         return 0;
+         return nullptr;
       }
       if (opt.Contains("x")) {
          if ((xlo - start) > 1E-3 || (xhi - start) < -1E-3) {
             Fatal("Divide", "invalid START=%g for division on axis %s of volume %s. Range is (%g, %g)", start,
                   fShape->GetAxisName(iaxis), GetName(), xlo, xhi);
-            return 0;
+            return nullptr;
          }
          xlo = start;
          range = xhi - xlo;
@@ -1156,7 +1156,7 @@ TGeoVolume *TGeoVolume::Divide(const char *divname, Int_t iaxis, Int_t ndiv, Dou
          if ((xlo - start) > 1E-3 || (xhi - start) < -1E-3) {
             Fatal("Divide", "invalid START=%g for division on axis %s of volume %s. Range is (%g, %g)", start,
                   fShape->GetAxisName(iaxis), GetName(), xlo, xhi);
-            return 0;
+            return nullptr;
          }
          xlo = start;
          range = xhi - xlo;
@@ -1169,7 +1169,7 @@ TGeoVolume *TGeoVolume::Divide(const char *divname, Int_t iaxis, Int_t ndiv, Dou
    if (((start - xlo) < -1E-3) || ((end - xhi) > 1E-3)) {
       Fatal("Divide", "division of volume %s on axis %s exceed range (%g, %g)", GetName(), fShape->GetAxisName(iaxis),
             xlo, xhi);
-      return 0;
+      return nullptr;
    }
    TGeoVolume *voldiv = fShape->Divide(this, divname, iaxis, ndiv, start, step);
    if (numed) {
@@ -1337,7 +1337,7 @@ TH2F *TGeoVolume::LegoPlot(Int_t ntheta, Double_t themin, Double_t themax, Int_t
    if (old_vol != this)
       fGeoManager->SetTopVolume(this);
    else
-      old_vol = 0;
+      old_vol = nullptr;
    TH2F *hist = p->LegoPlot(ntheta, themin, themax, nphi, phimin, phimax, rmin, rmax, option);
    hist->Draw("lego1sph");
    return hist;
@@ -1397,7 +1397,7 @@ void TGeoVolume::RandomPoints(Int_t npoints, Option_t *option)
    if (old_vol != this)
       fGeoManager->SetTopVolume(this);
    else
-      old_vol = 0;
+      old_vol = nullptr;
    fGeoManager->RandomPoints(this, npoints, option);
    if (old_vol)
       fGeoManager->SetTopVolume(old_vol);
@@ -1415,7 +1415,7 @@ void TGeoVolume::RandomRays(Int_t nrays, Double_t startx, Double_t starty, Doubl
    if (old_vol != this)
       fGeoManager->SetTopVolume(this);
    else
-      old_vol = 0;
+      old_vol = nullptr;
    fGeoManager->RandomRays(nrays, startx, starty, startz, target_vol, check_norm);
    if (old_vol)
       fGeoManager->SetTopVolume(old_vol);
@@ -1481,7 +1481,7 @@ void TGeoVolume::SetUserExtension(TGeoExtension *ext)
 {
    if (fUserExtension)
       fUserExtension->Release();
-   fUserExtension = 0;
+   fUserExtension = nullptr;
    if (ext)
       fUserExtension = ext->Grab();
 }
@@ -1498,7 +1498,7 @@ void TGeoVolume::SetFWExtension(TGeoExtension *ext)
 {
    if (fFWExtension)
       fFWExtension->Release();
-   fFWExtension = 0;
+   fFWExtension = nullptr;
    if (ext)
       fFWExtension = ext->Grab();
 }
@@ -1512,7 +1512,7 @@ TGeoExtension *TGeoVolume::GrabUserExtension() const
 {
    if (fUserExtension)
       return fUserExtension->Grab();
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1524,7 +1524,7 @@ TGeoExtension *TGeoVolume::GrabFWExtension() const
 {
    if (fFWExtension)
       return fFWExtension->Grab();
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1726,7 +1726,7 @@ TGeoNode *TGeoVolume::FindNode(const char *name) const
 
 Int_t TGeoVolume::GetNodeIndex(const TGeoNode *node, Int_t *check_list, Int_t ncheck) const
 {
-   TGeoNode *current = 0;
+   TGeoNode *current = nullptr;
    for (Int_t i = 0; i < ncheck; i++) {
       current = (TGeoNode *)fNodes->At(check_list[i]);
       if (current == node)
@@ -1740,7 +1740,7 @@ Int_t TGeoVolume::GetNodeIndex(const TGeoNode *node, Int_t *check_list, Int_t nc
 
 Int_t TGeoVolume::GetIndex(const TGeoNode *node) const
 {
-   TGeoNode *current = 0;
+   TGeoNode *current = nullptr;
    Int_t nd = GetNdaughters();
    if (!nd)
       return -1;
@@ -1760,7 +1760,7 @@ char *TGeoVolume::GetObjectInfo(Int_t px, Int_t py) const
    TGeoVolume *vol = (TGeoVolume *)this;
    TVirtualGeoPainter *painter = fGeoManager->GetPainter();
    if (!painter)
-      return 0;
+      return nullptr;
    return (char *)painter->GetVolumeInfo(vol, px, py);
 }
 
@@ -1801,7 +1801,7 @@ TGeoVoxelFinder *TGeoVolume::GetVoxels() const
 {
    if (fVoxels && !fVoxels->IsInvalid())
       return fVoxels;
-   return NULL;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1856,7 +1856,7 @@ TGeoVolume *TGeoVolume::CloneVolume() const
    // if volume is divided, copy finder
    vol->SetFinder(fFinder);
    // copy voxels
-   TGeoVoxelFinder *voxels = 0;
+   TGeoVoxelFinder *voxels = nullptr;
    if (fVoxels) {
       voxels = new TGeoVoxelFinder(vol);
       vol->SetVoxelFinder(voxels);
@@ -1958,7 +1958,7 @@ TGeoVolume *TGeoVolume::MakeReflectedVolume(const char *newname) const
    static TMap map(100);
    if (!fGeoManager->IsClosed()) {
       Error("MakeReflectedVolume", "Geometry must be closed.");
-      return NULL;
+      return nullptr;
    }
    TGeoVolume *vol = (TGeoVolume *)map.GetValue(this);
    if (vol) {
@@ -1970,13 +1970,13 @@ TGeoVolume *TGeoVolume::MakeReflectedVolume(const char *newname) const
    vol = CloneVolume();
    if (!vol) {
       Fatal("MakeReflectedVolume", "Cannot clone volume %s\n", GetName());
-      return 0;
+      return nullptr;
    }
    map.Add((TObject *)this, vol);
    if (newname && newname[0])
       vol->SetName(newname);
    delete vol->GetNodes();
-   vol->SetNodes(NULL);
+   vol->SetNodes(nullptr);
    vol->SetBit(kVolumeImportNodes, kFALSE);
    CloneNodesAndConnect(vol);
    // The volume is now properly cloned, but with the same shape.
@@ -2028,12 +2028,12 @@ TGeoVolume *TGeoVolume::MakeReflectedVolume(const char *newname) const
    TGeoPatternFinder *new_finder = fFinder->MakeCopy(kTRUE);
    if (!new_finder) {
       Fatal("MakeReflectedVolume", "Could not copy finder for volume %s", GetName());
-      return 0;
+      return nullptr;
    }
    new_finder->SetVolume(vol);
    vol->SetFinder(new_finder);
    TGeoNodeOffset *nodeoff;
-   new_vol = 0;
+   new_vol = nullptr;
    for (Int_t i = 0; i < nd; i++) {
       nodeoff = (TGeoNodeOffset *)vol->GetNode(i);
       nodeoff->SetFinder(new_finder);
@@ -2089,7 +2089,7 @@ void TGeoVolume::SortNodes()
       return;
    //   printf("Nodes for %s\n", GetName());
    Int_t id = 0;
-   TGeoNode *node = 0;
+   TGeoNode *node = nullptr;
    TObjArray *nodes = new TObjArray(nd);
    Int_t inode = 0;
    // first put ONLY's
@@ -2143,7 +2143,7 @@ void TGeoVolume::Streamer(TBuffer &R__b)
       } else {
          if (!fGeoManager->IsStreamingVoxels()) {
             TGeoVoxelFinder *voxels = fVoxels;
-            fVoxels = 0;
+            fVoxels = nullptr;
             R__b.WriteClassBuffer(TGeoVolume::Class(), this);
             fVoxels = voxels;
          } else {
@@ -2191,7 +2191,7 @@ void TGeoVolume::SetLineWidth(Style_t lwidth)
 TGeoNode *TGeoVolume::GetNode(const char *name) const
 {
    if (!fNodes)
-      return 0;
+      return nullptr;
    TGeoNode *node = (TGeoNode *)fNodes->FindObject(name);
    return node;
 }
@@ -2233,7 +2233,7 @@ void TGeoVolume::FindOverlaps() const
    Int_t nd = GetNdaughters();
    if (!nd)
       return;
-   TGeoNode *node = 0;
+   TGeoNode *node = nullptr;
    Int_t inode = 0;
    for (inode = 0; inode < nd; inode++) {
       node = GetNode(inode);
@@ -2268,11 +2268,11 @@ TGeoNode *TGeoVolume::ReplaceNode(TGeoNode *nodeorig, TGeoShape *newshape, TGeoM
 {
    Int_t ind = GetIndex(nodeorig);
    if (ind < 0)
-      return NULL;
+      return nullptr;
    TGeoVolume *oldvol = nodeorig->GetVolume();
    if (oldvol->IsAssembly()) {
       Error("ReplaceNode", "Cannot replace node %s since it is an assembly", nodeorig->GetName());
-      return NULL;
+      return nullptr;
    }
    TGeoShape *shape = oldvol->GetShape();
    if (newshape && !nodeorig->IsOffset())
@@ -2295,7 +2295,7 @@ TGeoNode *TGeoVolume::ReplaceNode(TGeoNode *nodeorig, TGeoShape *newshape, TGeoM
    TGeoNode *newnode = nodeorig->MakeCopyNode();
    if (!newnode) {
       Fatal("ReplaceNode", "Cannot make copy node for %s", nodeorig->GetName());
-      return 0;
+      return nullptr;
    }
    // Change the volume for the new node
    newnode->SetVolume(vol);
@@ -2350,7 +2350,7 @@ void TGeoVolume::SetVisibility(Bool_t vis)
    fGeoManager->SetVisOption(4);
    TSeqCollection *brlist = gROOT->GetListOfBrowsers();
    TIter next(brlist);
-   TBrowser *browser = 0;
+   TBrowser *browser = nullptr;
    while ((browser = (TBrowser *)next())) {
       browser->CheckObjectItem(this, vis);
       browser->Refresh();
@@ -2479,7 +2479,7 @@ void TGeoVolume::Voxelize(Option_t *option)
    if (fVoxels) {
       if (!TObject::TestBit(kVolumeClone))
          delete fVoxels;
-      fVoxels = 0;
+      fVoxels = nullptr;
    }
    // Create the voxels structure
    fVoxels = new TGeoVoxelFinder(this);
@@ -2487,7 +2487,7 @@ void TGeoVolume::Voxelize(Option_t *option)
    if (fVoxels) {
       if (fVoxels->IsInvalid()) {
          delete fVoxels;
-         fVoxels = 0;
+         fVoxels = nullptr;
       }
    }
 }
@@ -2502,7 +2502,7 @@ Double_t TGeoVolume::Weight(Double_t precision, Option_t *option)
    if (top != this)
       fGeoManager->SetTopVolume(this);
    else
-      top = 0;
+      top = nullptr;
    Double_t weight = fGeoManager->Weight(precision, option);
    if (top)
       fGeoManager->SetTopVolume(top);
@@ -2542,8 +2542,8 @@ ClassImp(TGeoVolumeMulti);
 
 TGeoVolumeMulti::TGeoVolumeMulti()
 {
-   fVolumes = 0;
-   fDivision = 0;
+   fVolumes = nullptr;
+   fDivision = nullptr;
    fNumed = 0;
    fNdiv = 0;
    fAxis = 0;
@@ -2559,7 +2559,7 @@ TGeoVolumeMulti::TGeoVolumeMulti()
 TGeoVolumeMulti::TGeoVolumeMulti(const char *name, TGeoMedium *med)
 {
    fVolumes = new TObjArray();
-   fDivision = 0;
+   fDivision = nullptr;
    fNumed = 0;
    fNdiv = 0;
    fAxis = 0;
@@ -2626,7 +2626,7 @@ TGeoNode *TGeoVolumeMulti::AddNode(TGeoVolume *vol, Int_t copy_no, TGeoMatrix *m
 {
    TGeoNode *n = TGeoVolume::AddNode(vol, copy_no, mat, option);
    Int_t nvolumes = fVolumes->GetEntriesFast();
-   TGeoVolume *volume = 0;
+   TGeoVolume *volume = nullptr;
    for (Int_t ivo = 0; ivo < nvolumes; ivo++) {
       volume = GetVolume(ivo);
       volume->SetLineColor(GetLineColor());
@@ -2647,7 +2647,7 @@ void TGeoVolumeMulti::AddNodeOverlap(TGeoVolume *vol, Int_t copy_no, TGeoMatrix 
 {
    TGeoVolume::AddNodeOverlap(vol, copy_no, mat, option);
    Int_t nvolumes = fVolumes->GetEntriesFast();
-   TGeoVolume *volume = 0;
+   TGeoVolume *volume = nullptr;
    for (Int_t ivo = 0; ivo < nvolumes; ivo++) {
       volume = GetVolume(ivo);
       volume->SetLineColor(GetLineColor());
@@ -2666,7 +2666,7 @@ TGeoShape *TGeoVolumeMulti::GetLastShape() const
 {
    TGeoVolume *vol = GetVolume(fVolumes->GetEntriesFast() - 1);
    if (!vol)
-      return 0;
+      return nullptr;
    return vol->GetShape();
 }
 
@@ -2678,7 +2678,7 @@ TGeoVolume *TGeoVolumeMulti::Divide(const char *divname, Int_t iaxis, Int_t ndiv
 {
    if (fDivision) {
       Error("Divide", "volume %s already divided", GetName());
-      return 0;
+      return nullptr;
    }
    Int_t nvolumes = fVolumes->GetEntriesFast();
    TGeoMedium *medium = fMedium;
@@ -2701,7 +2701,7 @@ TGeoVolume *TGeoVolumeMulti::Divide(const char *divname, Int_t iaxis, Int_t ndiv
       // nothing else to do at this stage
       return fDivision;
    }
-   TGeoVolume *vol = 0;
+   TGeoVolume *vol = nullptr;
    fDivision = new TGeoVolumeMulti(divname, medium);
    if (medium)
       fNumed = medium->GetId();
@@ -2755,7 +2755,7 @@ TGeoVolume *TGeoVolumeMulti::MakeCopyVolume(TGeoShape *newshape)
          (TGeoVolumeMulti *)vol->Divide(fDivision->GetName(), fAxis, fNdiv, fStart, fStep, fNumed, fOption.Data());
       if (!div) {
          Fatal("MakeCopyVolume", "Cannot divide volume %s", vol->GetName());
-         return 0;
+         return nullptr;
       }
       for (i = 0; i < div->GetNvolumes(); i++) {
          cell = div->GetVolume(i);
@@ -2779,7 +2779,7 @@ TGeoVolume *TGeoVolumeMulti::MakeCopyVolume(TGeoShape *newshape)
       node = GetNode(i)->MakeCopyNode();
       if (!node) {
          Fatal("MakeCopyNode", "cannot make copy node for daughter %d of %s", i, GetName());
-         return 0;
+         return nullptr;
       }
       node->SetMotherVolume(vol);
       list->Add(node);
@@ -2794,7 +2794,7 @@ void TGeoVolumeMulti::SetLineColor(Color_t lcolor)
 {
    TGeoVolume::SetLineColor(lcolor);
    Int_t nvolumes = fVolumes->GetEntriesFast();
-   TGeoVolume *vol = 0;
+   TGeoVolume *vol = nullptr;
    for (Int_t ivo = 0; ivo < nvolumes; ivo++) {
       vol = GetVolume(ivo);
       vol->SetLineColor(lcolor);
@@ -2808,7 +2808,7 @@ void TGeoVolumeMulti::SetLineStyle(Style_t lstyle)
 {
    TGeoVolume::SetLineStyle(lstyle);
    Int_t nvolumes = fVolumes->GetEntriesFast();
-   TGeoVolume *vol = 0;
+   TGeoVolume *vol = nullptr;
    for (Int_t ivo = 0; ivo < nvolumes; ivo++) {
       vol = GetVolume(ivo);
       vol->SetLineStyle(lstyle);
@@ -2822,7 +2822,7 @@ void TGeoVolumeMulti::SetLineWidth(Width_t lwidth)
 {
    TGeoVolume::SetLineWidth(lwidth);
    Int_t nvolumes = fVolumes->GetEntriesFast();
-   TGeoVolume *vol = 0;
+   TGeoVolume *vol = nullptr;
    for (Int_t ivo = 0; ivo < nvolumes; ivo++) {
       vol = GetVolume(ivo);
       vol->SetLineWidth(lwidth);
@@ -2836,7 +2836,7 @@ void TGeoVolumeMulti::SetMedium(TGeoMedium *med)
 {
    TGeoVolume::SetMedium(med);
    Int_t nvolumes = fVolumes->GetEntriesFast();
-   TGeoVolume *vol = 0;
+   TGeoVolume *vol = nullptr;
    for (Int_t ivo = 0; ivo < nvolumes; ivo++) {
       vol = GetVolume(ivo);
       vol->SetMedium(med);
@@ -2850,7 +2850,7 @@ void TGeoVolumeMulti::SetVisibility(Bool_t vis)
 {
    TGeoVolume::SetVisibility(vis);
    Int_t nvolumes = fVolumes->GetEntriesFast();
-   TGeoVolume *vol = 0;
+   TGeoVolume *vol = nullptr;
    for (Int_t ivo = 0; ivo < nvolumes; ivo++) {
       vol = GetVolume(ivo);
       vol->SetVisibility(vis);
@@ -2901,7 +2901,7 @@ void TGeoVolumeAssembly::CreateThreadData(Int_t nthreads)
    fThreadData.resize(nthreads);
    fThreadSize = nthreads;
    for (Int_t tid = 0; tid < nthreads; tid++) {
-      if (fThreadData[tid] == 0) {
+      if (fThreadData[tid] == nullptr) {
          fThreadData[tid] = new ThreadData_t;
       }
    }
@@ -3018,7 +3018,7 @@ TGeoVolume *TGeoVolumeAssembly::CloneVolume() const
    //   CloneNodesAndConnect(vol);
    ((TGeoShapeAssembly *)vol->GetShape())->NeedsBBoxRecompute();
    // copy voxels
-   TGeoVoxelFinder *voxels = 0;
+   TGeoVoxelFinder *voxels = nullptr;
    if (fVoxels) {
       voxels = new TGeoVoxelFinder(vol);
       vol->SetVoxelFinder(voxels);
@@ -3037,7 +3037,7 @@ TGeoVolume *TGeoVolumeAssembly::CloneVolume() const
 TGeoVolume *TGeoVolumeAssembly::Divide(const char *, Int_t, Int_t, Double_t, Double_t, Int_t, Option_t *)
 {
    Error("Divide", "Assemblies cannot be divided");
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -3049,16 +3049,16 @@ TGeoVolume *TGeoVolumeAssembly::Divide(TGeoVolume *cell, TGeoPatternFinder *patt
 {
    if (fNodes) {
       Error("Divide", "Cannot divide assembly %s since it has nodes", GetName());
-      return NULL;
+      return nullptr;
    }
    if (fFinder) {
       Error("Divide", "Assembly %s already divided", GetName());
-      return NULL;
+      return nullptr;
    }
    Int_t ncells = pattern->GetNdiv();
    if (!ncells || pattern->GetStep() <= 0) {
       Error("Divide", "Pattern finder for dividing assembly %s not initialized. Use SetRange() method.", GetName());
-      return NULL;
+      return nullptr;
    }
    fFinder = pattern;
    TString opt(option);
@@ -3083,10 +3083,10 @@ TGeoVolume *TGeoVolumeAssembly::Divide(TGeoVolume *cell, TGeoPatternFinder *patt
 TGeoVolumeAssembly *TGeoVolumeAssembly::MakeAssemblyFromVolume(TGeoVolume *volorig)
 {
    if (volorig->IsAssembly() || volorig->IsVolumeMulti())
-      return 0;
+      return nullptr;
    Int_t nd = volorig->GetNdaughters();
    if (!nd)
-      return 0;
+      return nullptr;
    TGeoVolumeAssembly *vol = new TGeoVolumeAssembly(volorig->GetName());
    Int_t i;
    // copy other attributes
@@ -3107,7 +3107,7 @@ TGeoVolumeAssembly *TGeoVolumeAssembly::MakeAssemblyFromVolume(TGeoVolume *volor
    //   volorig->CloneNodesAndConnect(vol);
    vol->GetShape()->ComputeBBox();
    // copy voxels
-   TGeoVoxelFinder *voxels = 0;
+   TGeoVoxelFinder *voxels = nullptr;
    if (volorig->GetVoxels()) {
       voxels = new TGeoVoxelFinder(vol);
       vol->SetVoxelFinder(voxels);

--- a/geom/geom/src/TGeoVoxelFinder.cxx
+++ b/geom/geom/src/TGeoVoxelFinder.cxx
@@ -38,7 +38,7 @@ ClassImp(TGeoVoxelFinder);
 
 TGeoVoxelFinder::TGeoVoxelFinder()
 {
-   fVolume = 0;
+   fVolume = nullptr;
    fNboxes = 0;
    fIbx = 0;
    fIby = 0;
@@ -52,25 +52,25 @@ TGeoVoxelFinder::TGeoVoxelFinder()
    fNx = 0;
    fNy = 0;
    fNz = 0;
-   fBoxes = 0;
-   fXb = 0;
-   fYb = 0;
-   fZb = 0;
-   fOBx = 0;
-   fOBy = 0;
-   fOBz = 0;
-   fOEx = 0;
-   fOEy = 0;
-   fOEz = 0;
-   fIndcX = 0;
-   fIndcY = 0;
-   fIndcZ = 0;
-   fExtraX = 0;
-   fExtraY = 0;
-   fExtraZ = 0;
-   fNsliceX = 0;
-   fNsliceY = 0;
-   fNsliceZ = 0;
+   fBoxes = nullptr;
+   fXb = nullptr;
+   fYb = nullptr;
+   fZb = nullptr;
+   fOBx = nullptr;
+   fOBy = nullptr;
+   fOBz = nullptr;
+   fOEx = nullptr;
+   fOEy = nullptr;
+   fOEz = nullptr;
+   fIndcX = nullptr;
+   fIndcY = nullptr;
+   fIndcZ = nullptr;
+   fExtraX = nullptr;
+   fExtraY = nullptr;
+   fExtraZ = nullptr;
+   fNsliceX = nullptr;
+   fNsliceY = nullptr;
+   fNsliceZ = nullptr;
    memset(fPriority, 0, 3 * sizeof(Int_t));
    SetInvalid(kFALSE);
 }
@@ -98,25 +98,25 @@ TGeoVoxelFinder::TGeoVoxelFinder(TGeoVolume *vol)
    fNx = 0;
    fNy = 0;
    fNz = 0;
-   fBoxes = 0;
-   fXb = 0;
-   fYb = 0;
-   fZb = 0;
-   fOBx = 0;
-   fOBy = 0;
-   fOBz = 0;
-   fOEx = 0;
-   fOEy = 0;
-   fOEz = 0;
-   fIndcX = 0;
-   fIndcY = 0;
-   fIndcZ = 0;
-   fExtraX = 0;
-   fExtraY = 0;
-   fExtraZ = 0;
-   fNsliceX = 0;
-   fNsliceY = 0;
-   fNsliceZ = 0;
+   fBoxes = nullptr;
+   fXb = nullptr;
+   fYb = nullptr;
+   fZb = nullptr;
+   fOBx = nullptr;
+   fOBy = nullptr;
+   fOBz = nullptr;
+   fOEx = nullptr;
+   fOEy = nullptr;
+   fOEz = nullptr;
+   fIndcX = nullptr;
+   fIndcY = nullptr;
+   fIndcZ = nullptr;
+   fExtraX = nullptr;
+   fExtraY = nullptr;
+   fExtraZ = nullptr;
+   fNsliceX = nullptr;
+   fNsliceY = nullptr;
+   fNsliceZ = nullptr;
    memset(fPriority, 0, 3 * sizeof(Int_t));
    SetNeedRebuild();
 }
@@ -203,7 +203,7 @@ void TGeoVoxelFinder::BuildVoxelLimits()
    Double_t pt[3] = {0};
    Double_t xyz[6] = {0};
    //   printf("boundaries for %s :\n", GetName());
-   TGeoBBox *box = 0;
+   TGeoBBox *box = nullptr;
    for (id = 0; id < nd; id++) {
       node = fVolume->GetNode(id);
       //      if (!strcmp(node->ClassName(), "TGeoNodeOffset") continue;
@@ -334,7 +334,7 @@ void TGeoVoxelFinder::FindOverlaps(Int_t inode) const
    Double_t xmin1, xmax1, ymin1, ymax1, zmin1, zmax1;
    Double_t ddx1, ddx2;
    Int_t nd = fVolume->GetNdaughters();
-   Int_t *ovlps = 0;
+   Int_t *ovlps = nullptr;
    Int_t *otmp = new Int_t[nd - 1];
    Int_t novlp = 0;
    TGeoNode *node = fVolume->GetNode(inode);
@@ -434,7 +434,7 @@ Bool_t TGeoVoxelFinder::GetIndices(const Double_t *point, TGeoStateInfo &td)
 
 Int_t *TGeoVoxelFinder::GetExtraX(Int_t islice, Bool_t left, Int_t &nextra) const
 {
-   Int_t *list = 0;
+   Int_t *list = nullptr;
    nextra = 0;
    if (fPriority[0] != 2)
       return list;
@@ -454,7 +454,7 @@ Int_t *TGeoVoxelFinder::GetExtraX(Int_t islice, Bool_t left, Int_t &nextra) cons
 
 Int_t *TGeoVoxelFinder::GetExtraY(Int_t islice, Bool_t left, Int_t &nextra) const
 {
-   Int_t *list = 0;
+   Int_t *list = nullptr;
    nextra = 0;
    if (fPriority[1] != 2)
       return list;
@@ -474,7 +474,7 @@ Int_t *TGeoVoxelFinder::GetExtraY(Int_t islice, Bool_t left, Int_t &nextra) cons
 
 Int_t *TGeoVoxelFinder::GetExtraZ(Int_t islice, Bool_t left, Int_t &nextra) const
 {
-   Int_t *list = 0;
+   Int_t *list = nullptr;
    nextra = 0;
    if (fPriority[2] != 2)
       return list;
@@ -564,11 +564,11 @@ Int_t *TGeoVoxelFinder::GetNextCandidates(const Double_t *point, Int_t &ncheck, 
    }
    ncheck = 0;
    if (td.fVoxLimits[0] < 0)
-      return 0;
+      return nullptr;
    if (td.fVoxLimits[1] < 0)
-      return 0;
+      return nullptr;
    if (td.fVoxLimits[2] < 0)
-      return 0;
+      return nullptr;
    Int_t dind[3]; // new slices
    //---> start from old slices
    memcpy(&dind[0], &td.fVoxSlices[0], 3 * sizeof(Int_t));
@@ -589,11 +589,11 @@ Int_t *TGeoVoxelFinder::GetNextCandidates(const Double_t *point, Int_t &ncheck, 
       dind[0] += td.fVoxInc[0];
       if (td.fVoxInc[0] == 1) {
          if (dind[0] < 0 || dind[0] > fIbx - 1)
-            return 0; // outside range
+            return nullptr; // outside range
          dmin[0] = (fXb[dind[0]] - point[0]) * td.fVoxInvdir[0];
       } else {
          if (td.fVoxSlices[0] < 0 || td.fVoxSlices[0] > fIbx - 1)
-            return 0; // outside range
+            return nullptr; // outside range
          dmin[0] = (fXb[td.fVoxSlices[0]] - point[0]) * td.fVoxInvdir[0];
       }
       isXlimit = (dmin[0] > maxstep) ? kTRUE : kFALSE;
@@ -607,7 +607,7 @@ Int_t *TGeoVoxelFinder::GetNextCandidates(const Double_t *point, Int_t &ncheck, 
          iforced++;
          //         printf("   FORCED 1\n");
          if (isXlimit)
-            return 0;
+            return nullptr;
       } else {
          if (fPriority[0] == 2) {
             // if no candidates in current slice, force next slice
@@ -617,7 +617,7 @@ Int_t *TGeoVoxelFinder::GetNextCandidates(const Double_t *point, Int_t &ncheck, 
                iforced++;
                //               printf("   FORCED 2\n");
                if (isXlimit)
-                  return 0;
+                  return nullptr;
             }
          }
       }
@@ -633,11 +633,11 @@ Int_t *TGeoVoxelFinder::GetNextCandidates(const Double_t *point, Int_t &ncheck, 
       dind[1] += td.fVoxInc[1];
       if (td.fVoxInc[1] == 1) {
          if (dind[1] < 0 || dind[1] > fIby - 1)
-            return 0; // outside range
+            return nullptr; // outside range
          dmin[1] = (fYb[dind[1]] - point[1]) * td.fVoxInvdir[1];
       } else {
          if (td.fVoxSlices[1] < 0 || td.fVoxSlices[1] > fIby - 1)
-            return 0; // outside range
+            return nullptr; // outside range
          dmin[1] = (fYb[td.fVoxSlices[1]] - point[1]) * td.fVoxInvdir[1];
       }
       isYlimit = (dmin[1] > maxstep) ? kTRUE : kFALSE;
@@ -652,7 +652,7 @@ Int_t *TGeoVoxelFinder::GetNextCandidates(const Double_t *point, Int_t &ncheck, 
          iforced++;
          //         printf("   FORCED 1\n");
          if (isYlimit)
-            return 0;
+            return nullptr;
       } else {
          if (fPriority[1] == 2) {
             // if no candidates in current slice, force next slice
@@ -662,7 +662,7 @@ Int_t *TGeoVoxelFinder::GetNextCandidates(const Double_t *point, Int_t &ncheck, 
                iforced++;
                //               printf("   FORCED 2\n");
                if (isYlimit)
-                  return 0;
+                  return nullptr;
             }
          }
       }
@@ -678,11 +678,11 @@ Int_t *TGeoVoxelFinder::GetNextCandidates(const Double_t *point, Int_t &ncheck, 
       dind[2] += td.fVoxInc[2];
       if (td.fVoxInc[2] == 1) {
          if (dind[2] < 0 || dind[2] > fIbz - 1)
-            return 0; // outside range
+            return nullptr; // outside range
          dmin[2] = (fZb[dind[2]] - point[2]) * td.fVoxInvdir[2];
       } else {
          if (td.fVoxSlices[2] < 0 || td.fVoxSlices[2] > fIbz - 1)
-            return 0; // outside range
+            return nullptr; // outside range
          dmin[2] = (fZb[td.fVoxSlices[2]] - point[2]) * td.fVoxInvdir[2];
       }
       isZlimit = (dmin[2] > maxstep) ? kTRUE : kFALSE;
@@ -697,7 +697,7 @@ Int_t *TGeoVoxelFinder::GetNextCandidates(const Double_t *point, Int_t &ncheck, 
          iforced++;
          //         printf("   FORCED 1\n");
          if (isZlimit)
-            return 0;
+            return nullptr;
       } else {
          if (fPriority[2] == 2) {
             // if no candidates in current slice, force next slice
@@ -707,7 +707,7 @@ Int_t *TGeoVoxelFinder::GetNextCandidates(const Double_t *point, Int_t &ncheck, 
                iforced++;
                //               printf("   FORCED 2\n");
                if (isZlimit)
-                  return 0;
+                  return nullptr;
             }
          }
       }
@@ -775,33 +775,33 @@ Int_t *TGeoVoxelFinder::GetNextCandidates(const Double_t *point, Int_t &ncheck, 
       dslice = dmin[islice];
       if (dslice >= maxstep) {
          //         printf("DSLICE > MAXSTEP -> EXIT\n");
-         return 0;
+         return nullptr;
       }
    }
    //   printf("5- islicenext=%i  DSLICE=%g\n", islice, dslice);
    Double_t xptnew;
    Int_t *new_list; // list of new candidates
-   UChar_t *slice1 = 0;
-   UChar_t *slice2 = 0;
+   UChar_t *slice1 = nullptr;
+   UChar_t *slice2 = nullptr;
    Int_t ndd[2] = {0, 0};
    Int_t islices = 0;
    Bool_t left;
    switch (islice) {
    case 0:
       if (isXlimit)
-         return 0;
+         return nullptr;
       // increment/decrement X slice
       td.fVoxSlices[0] = dind[0];
       if (iforced) {
          // we have to recompute Y and Z slices
          if (dslice > td.fVoxLimits[1])
-            return 0;
+            return nullptr;
          if (dslice > td.fVoxLimits[2])
-            return 0;
+            return nullptr;
          if ((dslice > dmin[1]) && td.fVoxInc[1]) {
             xptnew = point[1] + dslice / td.fVoxInvdir[1];
             //               printf("   recomputing Y slice, pos=%g\n", xptnew);
-            while (1) {
+            while (true) {
                td.fVoxSlices[1] += td.fVoxInc[1];
                if (td.fVoxInc[1] == 1) {
                   if (td.fVoxSlices[1] < -1 || td.fVoxSlices[1] > fIby - 2)
@@ -820,7 +820,7 @@ Int_t *TGeoVoxelFinder::GetNextCandidates(const Double_t *point, Int_t &ncheck, 
          if ((dslice > dmin[2]) && td.fVoxInc[2]) {
             xptnew = point[2] + dslice / td.fVoxInvdir[2];
             //               printf("   recomputing Z slice, pos=%g\n", xptnew);
-            while (1) {
+            while (true) {
                td.fVoxSlices[2] += td.fVoxInc[2];
                if (td.fVoxInc[2] == 1) {
                   if (td.fVoxSlices[2] < -1 || td.fVoxSlices[2] > fIbz - 2)
@@ -918,19 +918,19 @@ Int_t *TGeoVoxelFinder::GetNextCandidates(const Double_t *point, Int_t &ncheck, 
       }
    case 1:
       if (isYlimit)
-         return 0;
+         return nullptr;
       // increment/decrement Y slice
       td.fVoxSlices[1] = dind[1];
       if (iforced) {
          // we have to recompute X and Z slices
          if (dslice > td.fVoxLimits[0])
-            return 0;
+            return nullptr;
          if (dslice > td.fVoxLimits[2])
-            return 0;
+            return nullptr;
          if ((dslice > dmin[0]) && td.fVoxInc[0]) {
             xptnew = point[0] + dslice / td.fVoxInvdir[0];
             //               printf("   recomputing X slice, pos=%g\n", xptnew);
-            while (1) {
+            while (true) {
                td.fVoxSlices[0] += td.fVoxInc[0];
                if (td.fVoxInc[0] == 1) {
                   if (td.fVoxSlices[0] < -1 || td.fVoxSlices[0] > fIbx - 2)
@@ -949,7 +949,7 @@ Int_t *TGeoVoxelFinder::GetNextCandidates(const Double_t *point, Int_t &ncheck, 
          if ((dslice > dmin[2]) && td.fVoxInc[2]) {
             xptnew = point[2] + dslice / td.fVoxInvdir[2];
             //               printf("   recomputing Z slice, pos=%g\n", xptnew);
-            while (1) {
+            while (true) {
                td.fVoxSlices[2] += td.fVoxInc[2];
                if (td.fVoxInc[2] == 1) {
                   if (td.fVoxSlices[2] < -1 || td.fVoxSlices[2] > fIbz - 2)
@@ -1047,19 +1047,19 @@ Int_t *TGeoVoxelFinder::GetNextCandidates(const Double_t *point, Int_t &ncheck, 
       }
    case 2:
       if (isZlimit)
-         return 0;
+         return nullptr;
       // increment/decrement Z slice
       td.fVoxSlices[2] = dind[2];
       if (iforced) {
          // we have to recompute Y and X slices
          if (dslice > td.fVoxLimits[1])
-            return 0;
+            return nullptr;
          if (dslice > td.fVoxLimits[0])
-            return 0;
+            return nullptr;
          if ((dslice > dmin[1]) && td.fVoxInc[1]) {
             xptnew = point[1] + dslice / td.fVoxInvdir[1];
             //               printf("   recomputing Y slice, pos=%g\n", xptnew);
-            while (1) {
+            while (true) {
                td.fVoxSlices[1] += td.fVoxInc[1];
                if (td.fVoxInc[1] == 1) {
                   if (td.fVoxSlices[1] < -1 || td.fVoxSlices[1] > fIby - 2)
@@ -1078,7 +1078,7 @@ Int_t *TGeoVoxelFinder::GetNextCandidates(const Double_t *point, Int_t &ncheck, 
          if ((dslice > dmin[0]) && td.fVoxInc[0]) {
             xptnew = point[0] + dslice / td.fVoxInvdir[0];
             //               printf("   recomputing X slice, pos=%g\n", xptnew);
-            while (1) {
+            while (true) {
                td.fVoxSlices[0] += td.fVoxInc[0];
                if (td.fVoxInc[0] == 1) {
                   if (td.fVoxSlices[0] < -1 || td.fVoxSlices[0] > fIbx - 2)
@@ -1176,7 +1176,7 @@ Int_t *TGeoVoxelFinder::GetNextCandidates(const Double_t *point, Int_t &ncheck, 
       }
    default: Error("GetNextCandidates", "Invalid islice=%i inside %s", islice, fVolume->GetName());
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1259,13 +1259,13 @@ void TGeoVoxelFinder::SortCrossedVoxels(const Double_t *point, const Double_t *d
    Int_t nd[3];
    Int_t islices = 0;
    memset(&nd[0], 0, 3 * sizeof(Int_t));
-   UChar_t *slicex = 0;
+   UChar_t *slicex = nullptr;
    if (fPriority[0] == 2) {
       nd[0] = fNsliceX[td.fVoxSlices[0]];
       slicex = &fIndcX[fOBx[td.fVoxSlices[0]]];
       islices++;
    }
-   UChar_t *slicey = 0;
+   UChar_t *slicey = nullptr;
    if (fPriority[1] == 2) {
       nd[1] = fNsliceY[td.fVoxSlices[1]];
       islices++;
@@ -1276,7 +1276,7 @@ void TGeoVoxelFinder::SortCrossedVoxels(const Double_t *point, const Double_t *d
          nd[0] = nd[1];
       }
    }
-   UChar_t *slicez = 0;
+   UChar_t *slicez = nullptr;
    if (fPriority[2] == 2) {
       nd[2] = fNsliceZ[td.fVoxSlices[2]];
       islices++;
@@ -1322,35 +1322,35 @@ Int_t *TGeoVoxelFinder::GetCheckList(const Double_t *point, Int_t &nelem, TGeoSt
    if (fVolume->GetNdaughters() == 1) {
       if (fXb) {
          if (point[0] < fXb[0] || point[0] > fXb[1])
-            return 0;
+            return nullptr;
       }
       if (fYb) {
          if (point[1] < fYb[0] || point[1] > fYb[1])
-            return 0;
+            return nullptr;
       }
 
       if (fZb) {
          if (point[2] < fZb[0] || point[2] > fZb[1])
-            return 0;
+            return nullptr;
       }
       td.fVoxCheckList[0] = 0;
       nelem = 1;
       return td.fVoxCheckList;
    }
    Int_t nslices = 0;
-   UChar_t *slice1 = 0;
-   UChar_t *slice2 = 0;
-   UChar_t *slice3 = 0;
+   UChar_t *slice1 = nullptr;
+   UChar_t *slice2 = nullptr;
+   UChar_t *slice3 = nullptr;
    Int_t nd[3] = {0, 0, 0};
    Int_t im;
    if (fPriority[0]) {
       im = TMath::BinarySearch(fIbx, fXb, point[0]);
       if ((im == -1) || (im == fIbx - 1))
-         return 0;
+         return nullptr;
       if (fPriority[0] == 2) {
          nd[0] = fNsliceX[im];
          if (!nd[0])
-            return 0;
+            return nullptr;
          nslices++;
          slice1 = &fIndcX[fOBx[im]];
       }
@@ -1359,11 +1359,11 @@ Int_t *TGeoVoxelFinder::GetCheckList(const Double_t *point, Int_t &nelem, TGeoSt
    if (fPriority[1]) {
       im = TMath::BinarySearch(fIby, fYb, point[1]);
       if ((im == -1) || (im == fIby - 1))
-         return 0;
+         return nullptr;
       if (fPriority[1] == 2) {
          nd[1] = fNsliceY[im];
          if (!nd[1])
-            return 0;
+            return nullptr;
          nslices++;
          if (slice1) {
             slice2 = &fIndcY[fOBy[im]];
@@ -1377,11 +1377,11 @@ Int_t *TGeoVoxelFinder::GetCheckList(const Double_t *point, Int_t &nelem, TGeoSt
    if (fPriority[2]) {
       im = TMath::BinarySearch(fIbz, fZb, point[2]);
       if ((im == -1) || (im == fIbz - 1))
-         return 0;
+         return nullptr;
       if (fPriority[2] == 2) {
          nd[2] = fNsliceZ[im];
          if (!nd[2])
-            return 0;
+            return nullptr;
          nslices++;
          if (slice1 && slice2) {
             slice3 = &fIndcZ[fOBz[im]];
@@ -1400,14 +1400,14 @@ Int_t *TGeoVoxelFinder::GetCheckList(const Double_t *point, Int_t &nelem, TGeoSt
    //   Int_t i = 0;
    Bool_t intersect = kFALSE;
    switch (nslices) {
-   case 0: Error("GetCheckList", "No slices for %s", fVolume->GetName()); return 0;
+   case 0: Error("GetCheckList", "No slices for %s", fVolume->GetName()); return nullptr;
    case 1: intersect = Intersect(nd[0], slice1, nelem, td.fVoxCheckList); break;
    case 2: intersect = Intersect(nd[0], slice1, nd[1], slice2, nelem, td.fVoxCheckList); break;
    default: intersect = Intersect(nd[0], slice1, nd[1], slice2, nd[2], slice3, nelem, td.fVoxCheckList);
    }
    if (intersect)
       return td.fVoxCheckList;
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1415,15 +1415,15 @@ Int_t *TGeoVoxelFinder::GetCheckList(const Double_t *point, Int_t &nelem, TGeoSt
 
 Int_t *TGeoVoxelFinder::GetVoxelCandidates(Int_t i, Int_t j, Int_t k, Int_t &ncheck, TGeoStateInfo &td)
 {
-   UChar_t *slice1 = 0;
-   UChar_t *slice2 = 0;
-   UChar_t *slice3 = 0;
+   UChar_t *slice1 = nullptr;
+   UChar_t *slice2 = nullptr;
+   UChar_t *slice3 = nullptr;
    Int_t nd[3] = {0, 0, 0};
    Int_t nslices = 0;
    if (fPriority[0] == 2) {
       nd[0] = fNsliceX[i];
       if (!nd[0])
-         return 0;
+         return nullptr;
       nslices++;
       slice1 = &fIndcX[fOBx[i]];
    }
@@ -1431,7 +1431,7 @@ Int_t *TGeoVoxelFinder::GetVoxelCandidates(Int_t i, Int_t j, Int_t k, Int_t &nch
    if (fPriority[1] == 2) {
       nd[1] = fNsliceY[j];
       if (!nd[1])
-         return 0;
+         return nullptr;
       nslices++;
       if (slice1) {
          slice2 = &fIndcY[fOBy[j]];
@@ -1444,7 +1444,7 @@ Int_t *TGeoVoxelFinder::GetVoxelCandidates(Int_t i, Int_t j, Int_t k, Int_t &nch
    if (fPriority[2] == 2) {
       nd[2] = fNsliceZ[k];
       if (!nd[2])
-         return 0;
+         return nullptr;
       nslices++;
       if (slice1 && slice2) {
          slice3 = &fIndcZ[fOBz[k]];
@@ -1460,14 +1460,14 @@ Int_t *TGeoVoxelFinder::GetVoxelCandidates(Int_t i, Int_t j, Int_t k, Int_t &nch
    }
    Bool_t intersect = kFALSE;
    switch (nslices) {
-   case 0: Error("GetCheckList", "No slices for %s", fVolume->GetName()); return 0;
+   case 0: Error("GetCheckList", "No slices for %s", fVolume->GetName()); return nullptr;
    case 1: intersect = Intersect(nd[0], slice1, ncheck, td.fVoxCheckList); break;
    case 2: intersect = Intersect(nd[0], slice1, nd[1], slice2, ncheck, td.fVoxCheckList); break;
    default: intersect = Intersect(nd[0], slice1, nd[1], slice2, nd[2], slice3, ncheck, td.fVoxCheckList);
    }
    if (intersect)
       return td.fVoxCheckList;
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1872,15 +1872,15 @@ void TGeoVoxelFinder::SortAll(Option_t *)
          fPriority[0] = 0; // always skip this axis
          if (fIndcX)
             delete[] fIndcX;
-         fIndcX = 0;
+         fIndcX = nullptr;
          fNx = 0;
          if (fXb)
             delete[] fXb;
-         fXb = 0;
+         fXb = nullptr;
          fIbx = 0;
          if (fOBx)
             delete[] fOBx;
-         fOBx = 0;
+         fOBx = nullptr;
          fNox = 0;
       } else {
          fPriority[0] = 1; // all in one slice
@@ -2008,15 +2008,15 @@ void TGeoVoxelFinder::SortAll(Option_t *)
          fPriority[1] = 0; // always skip this axis
          if (fIndcY)
             delete[] fIndcY;
-         fIndcY = 0;
+         fIndcY = nullptr;
          fNy = 0;
          if (fYb)
             delete[] fYb;
-         fYb = 0;
+         fYb = nullptr;
          fIby = 0;
          if (fOBy)
             delete[] fOBy;
-         fOBy = 0;
+         fOBy = nullptr;
          fNoy = 0;
       } else {
          fPriority[1] = 1; // all in one slice
@@ -2145,15 +2145,15 @@ void TGeoVoxelFinder::SortAll(Option_t *)
          fPriority[2] = 0;
          if (fIndcZ)
             delete[] fIndcZ;
-         fIndcZ = 0;
+         fIndcZ = nullptr;
          fNz = 0;
          if (fZb)
             delete[] fZb;
-         fZb = 0;
+         fZb = nullptr;
          fIbz = 0;
          if (fOBz)
             delete[] fOBz;
-         fOBz = 0;
+         fOBz = nullptr;
          fNoz = 0;
       } else {
          fPriority[2] = 1; // all in one slice

--- a/geom/geom/src/TGeoXtru.cxx
+++ b/geom/geom/src/TGeoXtru.cxx
@@ -105,7 +105,7 @@ ClassImp(TGeoXtru);
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor.
 
-TGeoXtru::ThreadData_t::ThreadData_t() : fSeg(0), fIz(0), fXc(0), fYc(0), fPoly(0) {}
+TGeoXtru::ThreadData_t::ThreadData_t() : fSeg(0), fIz(0), fXc(nullptr), fYc(nullptr), fPoly(nullptr) {}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Destructor.
@@ -150,7 +150,7 @@ void TGeoXtru::CreateThreadData(Int_t nthreads)
    fThreadData.resize(nthreads);
    fThreadSize = nthreads;
    for (Int_t tid = 0; tid < nthreads; tid++) {
-      if (fThreadData[tid] == 0) {
+      if (fThreadData[tid] == nullptr) {
          fThreadData[tid] = new ThreadData_t;
          ThreadData_t &td = *fThreadData[tid];
          td.fXc = new Double_t[fNvert];
@@ -190,12 +190,12 @@ TGeoXtru::TGeoXtru()
      fNvert(0),
      fNz(0),
      fZcurrent(0.),
-     fX(0),
-     fY(0),
-     fZ(0),
-     fScale(0),
-     fX0(0),
-     fY0(0),
+     fX(nullptr),
+     fY(nullptr),
+     fZ(nullptr),
+     fScale(nullptr),
+     fX0(nullptr),
+     fY0(nullptr),
      fThreadData(0),
      fThreadSize(0)
 {
@@ -210,8 +210,8 @@ TGeoXtru::TGeoXtru(Int_t nz)
      fNvert(0),
      fNz(nz),
      fZcurrent(0.),
-     fX(0),
-     fY(0),
+     fX(nullptr),
+     fY(nullptr),
      fZ(new Double_t[nz]),
      fScale(new Double_t[nz]),
      fX0(new Double_t[nz]),
@@ -246,12 +246,12 @@ TGeoXtru::TGeoXtru(Double_t *param)
      fNvert(0),
      fNz(0),
      fZcurrent(0.),
-     fX(0),
-     fY(0),
-     fZ(0),
-     fScale(0),
-     fX0(0),
-     fY0(0),
+     fX(nullptr),
+     fY(nullptr),
+     fZ(nullptr),
+     fScale(nullptr),
+     fX0(nullptr),
+     fY0(nullptr),
      fThreadData(0),
      fThreadSize(0)
 {
@@ -266,27 +266,27 @@ TGeoXtru::~TGeoXtru()
 {
    if (fX) {
       delete[] fX;
-      fX = 0;
+      fX = nullptr;
    }
    if (fY) {
       delete[] fY;
-      fY = 0;
+      fY = nullptr;
    }
    if (fZ) {
       delete[] fZ;
-      fZ = 0;
+      fZ = nullptr;
    }
    if (fScale) {
       delete[] fScale;
-      fScale = 0;
+      fScale = nullptr;
    }
    if (fX0) {
       delete[] fX0;
-      fX0 = 0;
+      fX0 = nullptr;
    }
    if (fY0) {
       delete[] fY0;
-      fY0 = 0;
+      fY0 = nullptr;
    }
    ClearThreadData();
 }

--- a/geom/geom/src/TVirtualGeoConverter.cxx
+++ b/geom/geom/src/TVirtualGeoConverter.cxx
@@ -22,7 +22,7 @@ Abstract class for geometry converters
 #include "TPluginManager.h"
 #include "TGeoManager.h"
 
-TVirtualGeoConverter *TVirtualGeoConverter::fgGeoConverter = 0;
+TVirtualGeoConverter *TVirtualGeoConverter::fgGeoConverter = nullptr;
 
 ClassImp(TVirtualGeoConverter);
 
@@ -36,7 +36,7 @@ TVirtualGeoConverter::TVirtualGeoConverter(TGeoManager *geom) : TObject(), fGeom
 
 TVirtualGeoConverter::~TVirtualGeoConverter()
 {
-   fgGeoConverter = 0;
+   fgGeoConverter = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -60,7 +60,7 @@ TVirtualGeoConverter *TVirtualGeoConverter::Instance(TGeoManager *geom)
                     "To enable it, configure ROOT with:\n"
                     "   -Dvecgeom -DCMAKE_PREFIX_PATH=<vecgeom_prefix_path>/lib/CMake/VecGeom"
                     "\n+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n");
-            return 0;
+            return nullptr;
          }
          fgGeoConverter = (TVirtualGeoConverter *)h->ExecPlugin(1, mgr);
       }

--- a/geom/geom/src/TVirtualGeoPainter.cxx
+++ b/geom/geom/src/TVirtualGeoPainter.cxx
@@ -20,7 +20,7 @@ Abstract class for geometry painters
 #include "TPluginManager.h"
 #include "TGeoManager.h"
 
-TVirtualGeoPainter *TVirtualGeoPainter::fgGeoPainter = 0;
+TVirtualGeoPainter *TVirtualGeoPainter::fgGeoPainter = nullptr;
 
 ClassImp(TVirtualGeoPainter);
 
@@ -34,7 +34,7 @@ TVirtualGeoPainter::TVirtualGeoPainter(TGeoManager *) {}
 
 TVirtualGeoPainter::~TVirtualGeoPainter()
 {
-   fgGeoPainter = 0;
+   fgGeoPainter = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -49,7 +49,7 @@ TVirtualGeoPainter *TVirtualGeoPainter::GeoPainter()
       TPluginHandler *h;
       if ((h = gROOT->GetPluginManager()->FindHandler("TVirtualGeoPainter"))) {
          if (h->LoadPlugin() == -1)
-            return 0;
+            return nullptr;
          fgGeoPainter = (TVirtualGeoPainter *)h->ExecPlugin(1, gGeoManager);
       }
    }

--- a/geom/geom/src/TVirtualGeoTrack.cxx
+++ b/geom/geom/src/TVirtualGeoTrack.cxx
@@ -34,9 +34,9 @@ TVirtualGeoTrack::TVirtualGeoTrack()
 {
    fPDG = 0;
    fId = -1;
-   fParent = 0;
-   fParticle = 0;
-   fTracks = 0;
+   fParent = nullptr;
+   fParticle = nullptr;
+   fTracks = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -49,7 +49,7 @@ TVirtualGeoTrack::TVirtualGeoTrack(Int_t id, Int_t pdgcode, TVirtualGeoTrack *pa
    fId = id;
    fParent = parent;
    fParticle = particle;
-   fTracks = 0;
+   fTracks = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -82,21 +82,21 @@ Int_t TVirtualGeoTrack::GetDaughterId(Int_t index) const
 
 TVirtualGeoTrack *TVirtualGeoTrack::FindTrackWithId(Int_t id) const
 {
-   TVirtualGeoTrack *trk = 0;
+   TVirtualGeoTrack *trk = nullptr;
    if (GetId() == id) {
       trk = (TVirtualGeoTrack *)this;
       return trk;
    }
-   TVirtualGeoTrack *kid = 0;
+   TVirtualGeoTrack *kid = nullptr;
    Int_t nd = GetNdaughters();
    for (Int_t i = 0; i < nd; i++)
       if (GetDaughterId(i) == id)
          return GetDaughter(i);
    for (Int_t i = 0; i < nd; i++) {
       kid = GetDaughter(i);
-      if (kid != 0) {
+      if (kid != nullptr) {
          trk = kid->FindTrackWithId(id);
-         if (trk != 0)
+         if (trk != nullptr)
             break;
       }
    }

--- a/geom/geombuilder/src/TGeoBBoxEditor.cxx
+++ b/geom/geombuilder/src/TGeoBBoxEditor.cxx
@@ -42,7 +42,7 @@ enum ETGeoBBoxWid { kBOX_NAME, kBOX_X, kBOX_Y, kBOX_Z, kBOX_OX, kBOX_OY, kBOX_OZ
 TGeoBBoxEditor::TGeoBBoxEditor(const TGWindow *p, Int_t width, Int_t height, UInt_t options, Pixel_t back)
    : TGeoGedFrame(p, width, height, options | kVerticalFrame, back)
 {
-   fShape = 0;
+   fShape = nullptr;
    fDxi = fDyi = fDzi = 0.0;
    memset(fOrigi, 0, 3 * sizeof(Double_t));
    fNamei = "";
@@ -194,7 +194,7 @@ void TGeoBBoxEditor::ConnectSignals2Slots()
 
 void TGeoBBoxEditor::SetModel(TObject *obj)
 {
-   if (obj == 0 || (obj->IsA() != TGeoBBox::Class())) {
+   if (obj == nullptr || (obj->IsA() != TGeoBBox::Class())) {
       SetActive(kFALSE);
       return;
    }

--- a/geom/geombuilder/src/TGeoConeEditor.cxx
+++ b/geom/geombuilder/src/TGeoConeEditor.cxx
@@ -43,7 +43,7 @@ enum ETGeoConeWid { kCONE_NAME, kCONE_RMIN1, kCONE_RMIN2, kCONE_RMAX1, kCONE_RMA
 TGeoConeEditor::TGeoConeEditor(const TGWindow *p, Int_t width, Int_t height, UInt_t options, Pixel_t back)
    : TGeoGedFrame(p, width, height, options | kVerticalFrame, back)
 {
-   fShape = 0;
+   fShape = nullptr;
    fRmini1 = fRmaxi1 = fRmini2 = fRmaxi2 = fDzi = 0.0;
    fNamei = "";
    fIsModified = kFALSE;
@@ -182,7 +182,7 @@ void TGeoConeEditor::ConnectSignals2Slots()
 
 void TGeoConeEditor::SetModel(TObject *obj)
 {
-   if (obj == 0 || (obj->IsA() != TGeoCone::Class())) {
+   if (obj == nullptr || (obj->IsA() != TGeoCone::Class())) {
       SetActive(kFALSE);
       return;
    }
@@ -460,7 +460,7 @@ void TGeoConeSegEditor::ConnectSignals2Slots()
 
 void TGeoConeSegEditor::SetModel(TObject *obj)
 {
-   if (obj == 0 || (obj->IsA() != TGeoConeSeg::Class())) {
+   if (obj == nullptr || (obj->IsA() != TGeoConeSeg::Class())) {
       SetActive(kFALSE);
       return;
    }

--- a/geom/geombuilder/src/TGeoEltuEditor.cxx
+++ b/geom/geombuilder/src/TGeoEltuEditor.cxx
@@ -42,7 +42,7 @@ enum ETGeoEltuWid { kELTU_NAME, kELTU_A, kELTU_B, kELTU_DZ, kELTU_APPLY, kELTU_U
 TGeoEltuEditor::TGeoEltuEditor(const TGWindow *p, Int_t width, Int_t height, UInt_t options, Pixel_t back)
    : TGeoGedFrame(p, width, height, options | kVerticalFrame, back)
 {
-   fShape = 0;
+   fShape = nullptr;
    fAi = fBi = fDzi = 0.0;
    fNamei = "";
    fIsModified = kFALSE;
@@ -148,7 +148,7 @@ void TGeoEltuEditor::ConnectSignals2Slots()
 
 void TGeoEltuEditor::SetModel(TObject *obj)
 {
-   if (obj == 0 || (obj->IsA() != TGeoEltu::Class())) {
+   if (obj == nullptr || (obj->IsA() != TGeoEltu::Class())) {
       SetActive(kFALSE);
       return;
    }

--- a/geom/geombuilder/src/TGeoGedFrame.cxx
+++ b/geom/geombuilder/src/TGeoGedFrame.cxx
@@ -20,7 +20,7 @@ ClassImp(TGeoGedFrame);
 /// Constructor.
 
 TGeoGedFrame::TGeoGedFrame(const TGWindow *p, Int_t width, Int_t height, UInt_t options, Pixel_t back)
-   : TGedFrame(p, width, height, options, back), fTab(0), fTabMgr(0), fPad(0)
+   : TGedFrame(p, width, height, options, back), fTab(nullptr), fTabMgr(nullptr), fPad(nullptr)
 {
    fTab = fGedEditor->GetTab();
    fPad = fGedEditor->GetPad();

--- a/geom/geombuilder/src/TGeoHypeEditor.cxx
+++ b/geom/geombuilder/src/TGeoHypeEditor.cxx
@@ -43,7 +43,7 @@ enum ETGeoHypeWid { kHYPE_NAME, kHYPE_RIN, kHYPE_ROUT, kHYPE_DZ, kHYPE_STIN, kHY
 TGeoHypeEditor::TGeoHypeEditor(const TGWindow *p, Int_t width, Int_t height, UInt_t options, Pixel_t back)
    : TGeoGedFrame(p, width, height, options | kVerticalFrame, back)
 {
-   fShape = 0;
+   fShape = nullptr;
    fRini = fRouti = fStIni = fStOuti = 0.0;
    fNamei = "";
    fIsModified = kFALSE;
@@ -176,7 +176,7 @@ void TGeoHypeEditor::ConnectSignals2Slots()
 
 void TGeoHypeEditor::SetModel(TObject *obj)
 {
-   if (obj == 0 || (obj->IsA() != TGeoHype::Class())) {
+   if (obj == nullptr || (obj->IsA() != TGeoHype::Class())) {
       SetActive(kFALSE);
       return;
    }

--- a/geom/geombuilder/src/TGeoManagerEditor.cxx
+++ b/geom/geombuilder/src/TGeoManagerEditor.cxx
@@ -158,9 +158,9 @@ TGeoManagerEditor::TGeoManagerEditor(const TGWindow *p, Int_t width, Int_t heigh
    : TGedFrame(p, width, height, options | kVerticalFrame, back)
 {
    fGeometry = gGeoManager;
-   fTabMgr = 0;
-   fTab = 0;
-   fConnectedCanvas = 0;
+   fTabMgr = nullptr;
+   fTab = nullptr;
+   fConnectedCanvas = nullptr;
 
    fIsModified = kFALSE;
    TGCompositeFrame *f1;
@@ -317,7 +317,7 @@ TGeoManagerEditor::TGeoManagerEditor(const TGWindow *p, Int_t width, Int_t heigh
    label->SetTextColor(color);
    f2->AddFrame(f1, new TGLayoutHints(kLHintsTop, 0, 0, 0, 0));
    f1 = new TGCompositeFrame(f2, 155, 30, kHorizontalFrame | kFixedWidth);
-   fSelectedShape = 0;
+   fSelectedShape = nullptr;
    fLSelShape = new TGLabel(f1, "Select shape");
    gClient->GetColorByName("#0000ff", color);
    fLSelShape->SetTextColor(color);
@@ -357,7 +357,7 @@ TGeoManagerEditor::TGeoManagerEditor(const TGWindow *p, Int_t width, Int_t heigh
 
    // ComboBox for shape component
    f1 = new TGCompositeFrame(container, 155, 30, kHorizontalFrame | kFixedWidth);
-   fSelectedShape2 = 0;
+   fSelectedShape2 = nullptr;
    fLSelShape2 = new TGLabel(f1, "Select shape");
    gClient->GetColorByName("#0000ff", color);
    fLSelShape2->SetTextColor(color);
@@ -371,7 +371,7 @@ TGeoManagerEditor::TGeoManagerEditor(const TGWindow *p, Int_t width, Int_t heigh
 
    // ComboBox for medium component
    f1 = new TGCompositeFrame(container, 155, 30, kHorizontalFrame | kFixedWidth);
-   fSelectedMedium2 = 0;
+   fSelectedMedium2 = nullptr;
    fLSelMedium2 = new TGLabel(f1, "Select medium");
    gClient->GetColorByName("#0000ff", color);
    fLSelMedium2->SetTextColor(color);
@@ -401,7 +401,7 @@ TGeoManagerEditor::TGeoManagerEditor(const TGWindow *p, Int_t width, Int_t heigh
    label->SetTextColor(color);
    f3->AddFrame(f1, new TGLayoutHints(kLHintsTop, 0, 0, 0, 0));
    f1 = new TGCompositeFrame(f3, 155, 30, kHorizontalFrame | kFixedWidth);
-   fSelectedVolume = 0;
+   fSelectedVolume = nullptr;
    fLSelVolume = new TGLabel(f1, "Select volume");
    gClient->GetColorByName("#0000ff", color);
    fLSelVolume->SetTextColor(color);
@@ -495,7 +495,7 @@ TGeoManagerEditor::TGeoManagerEditor(const TGWindow *p, Int_t width, Int_t heigh
    label->SetTextColor(color);
    f4->AddFrame(f1, new TGLayoutHints(kLHintsTop, 0, 0, 0, 0));
    f1 = new TGCompositeFrame(f4, 155, 30, kHorizontalFrame | kFixedWidth);
-   fSelectedMaterial = 0;
+   fSelectedMaterial = nullptr;
    fLSelMaterial = new TGLabel(f1, "Select material");
    gClient->GetColorByName("#0000ff", color);
    fLSelMaterial->SetTextColor(color);
@@ -545,7 +545,7 @@ TGeoManagerEditor::TGeoManagerEditor(const TGWindow *p, Int_t width, Int_t heigh
    container->AddFrame(f1, new TGLayoutHints(kLHintsLeft, 2, 2, 4, 0));
    // ComboBox for materials
    f1 = new TGCompositeFrame(container, 155, 30, kHorizontalFrame | kFixedWidth);
-   fSelectedMaterial2 = 0;
+   fSelectedMaterial2 = nullptr;
    fLSelMaterial2 = new TGLabel(f1, "Select material");
    gClient->GetColorByName("#0000ff", color);
    fLSelMaterial2->SetTextColor(color);
@@ -573,7 +573,7 @@ TGeoManagerEditor::TGeoManagerEditor(const TGWindow *p, Int_t width, Int_t heigh
    label->SetTextColor(color);
    f5->AddFrame(f1, new TGLayoutHints(kLHintsTop, 0, 0, 0, 0));
    f1 = new TGCompositeFrame(f5, 155, 30, kHorizontalFrame | kFixedWidth);
-   fSelectedMedium = 0;
+   fSelectedMedium = nullptr;
    fLSelMedium = new TGLabel(f1, "Select medium");
    gClient->GetColorByName("#0000ff", color);
    fLSelMedium->SetTextColor(color);
@@ -631,7 +631,7 @@ TGeoManagerEditor::TGeoManagerEditor(const TGWindow *p, Int_t width, Int_t heigh
    label->SetTextColor(color);
    f6->AddFrame(f1, new TGLayoutHints(kLHintsTop, 0, 0, 2, 0));
    f1 = new TGCompositeFrame(f6, 155, 30, kHorizontalFrame | kFixedWidth);
-   fSelectedMatrix = 0;
+   fSelectedMatrix = nullptr;
    fLSelMatrix = new TGLabel(f1, "Select matrix");
    gClient->GetColorByName("#0000ff", color);
    fLSelMatrix->SetTextColor(color);
@@ -846,7 +846,7 @@ void TGeoManagerEditor::SetModel(TObject *obj)
 
    fTab->SetTab(0);
    fCategories->Layout();
-   if (fTabMgr == 0) {
+   if (fTabMgr == nullptr) {
       fTabMgr = TGeoTabManager::GetMakeTabManager(fGedEditor);
       fTabMgr->fVolumeTab = fVolumeTab;
    }

--- a/geom/geombuilder/src/TGeoMaterialEditor.cxx
+++ b/geom/geombuilder/src/TGeoMaterialEditor.cxx
@@ -57,7 +57,7 @@ enum ETGeoMixtureWid { kMIX_ELEM, kMIX_CHK1, kMIX_FRAC, kMIX_CHK2, kMIX_NATOMS, 
 TGeoMaterialEditor::TGeoMaterialEditor(const TGWindow *p, Int_t width, Int_t height, UInt_t options, Pixel_t back)
    : TGeoGedFrame(p, width, height, options | kVerticalFrame, back)
 {
-   fMaterial = 0;
+   fMaterial = nullptr;
    fAi = fZi = 0;
    fDensityi = 0.0;
    fNamei = "";
@@ -211,7 +211,7 @@ void TGeoMaterialEditor::ConnectSignals2Slots()
 
 void TGeoMaterialEditor::SetModel(TObject *obj)
 {
-   if (obj == 0 || !(obj->InheritsFrom(TGeoMaterial::Class()))) {
+   if (obj == nullptr || !(obj->InheritsFrom(TGeoMaterial::Class()))) {
       SetActive(kFALSE);
       return;
    }
@@ -395,8 +395,8 @@ ClassImp(TGeoMixtureEditor);
 TGeoMixtureEditor::TGeoMixtureEditor(const TGWindow *p, Int_t width, Int_t height, UInt_t options, Pixel_t back)
    : TGeoMaterialEditor(p, width, height, options | kVerticalFrame, back)
 {
-   fMixture = 0;
-   TGCompositeFrame *compxyz = 0, *f1 = 0;
+   fMixture = nullptr;
+   TGCompositeFrame *compxyz = nullptr, *f1 = nullptr;
    TGTextEntry *nef;
    MakeTitle("Mixture settings");
    fNelem = new TGLabel(this, "Number of elements: 0");
@@ -500,7 +500,7 @@ void TGeoMixtureEditor::ConnectSignals2Slots()
 
 void TGeoMixtureEditor::SetModel(TObject *obj)
 {
-   if (obj == 0 || !(obj->InheritsFrom(TGeoMixture::Class()))) {
+   if (obj == nullptr || !(obj->InheritsFrom(TGeoMixture::Class()))) {
       SetActive(kFALSE);
       return;
    }

--- a/geom/geombuilder/src/TGeoMatrixEditor.cxx
+++ b/geom/geombuilder/src/TGeoMatrixEditor.cxx
@@ -47,7 +47,7 @@ enum ETGeoMatrixWid {
 TGeoTranslationEditor::TGeoTranslationEditor(const TGWindow *p, Int_t width, Int_t height, UInt_t options, Pixel_t back)
    : TGeoGedFrame(p, width, height, options | kVerticalFrame, back)
 {
-   fTranslation = 0;
+   fTranslation = nullptr;
    fDxi = fDyi = fDzi = 0.0;
    fNamei = "";
    fIsModified = kFALSE;
@@ -153,7 +153,7 @@ void TGeoTranslationEditor::ConnectSignals2Slots()
 
 void TGeoTranslationEditor::SetModel(TObject *obj)
 {
-   if (obj == 0 || (obj->IsA() != TGeoTranslation::Class())) {
+   if (obj == nullptr || (obj->IsA() != TGeoTranslation::Class())) {
       SetActive(kFALSE);
       return;
    }
@@ -305,7 +305,7 @@ ClassImp(TGeoRotationEditor);
 TGeoRotationEditor::TGeoRotationEditor(const TGWindow *p, Int_t width, Int_t height, UInt_t options, Pixel_t back)
    : TGeoGedFrame(p, width, height, options | kVerticalFrame, back)
 {
-   fRotation = 0;
+   fRotation = nullptr;
    fPhii = fThetai = fPsii = 0.0;
    fAngleX = fAngleY = fAngleZ = 0.0;
    fNamei = "";
@@ -438,7 +438,7 @@ void TGeoRotationEditor::ConnectSignals2Slots()
 
 void TGeoRotationEditor::SetModel(TObject *obj)
 {
-   if (obj == 0 || (obj->IsA() != TGeoRotation::Class())) {
+   if (obj == nullptr || (obj->IsA() != TGeoRotation::Class())) {
       SetActive(kFALSE);
       return;
    }
@@ -634,7 +634,7 @@ ClassImp(TGeoCombiTransEditor);
 TGeoCombiTransEditor::TGeoCombiTransEditor(const TGWindow *p, Int_t width, Int_t height, UInt_t options, Pixel_t back)
    : TGeoGedFrame(p, width, height, options | kVerticalFrame, back)
 {
-   fCombi = 0;
+   fCombi = nullptr;
    fPhii = fThetai = fPsii = 0.0;
    fDxi = fDyi = fDzi = 0.0;
    fAngleX = fAngleY = fAngleZ = 0.0;
@@ -809,7 +809,7 @@ void TGeoCombiTransEditor::ConnectSignals2Slots()
 
 void TGeoCombiTransEditor::SetModel(TObject *obj)
 {
-   if (obj == 0 || (obj->IsA() != TGeoCombiTrans::Class())) {
+   if (obj == nullptr || (obj->IsA() != TGeoCombiTrans::Class())) {
       SetActive(kFALSE);
       return;
    }

--- a/geom/geombuilder/src/TGeoMediumEditor.cxx
+++ b/geom/geombuilder/src/TGeoMediumEditor.cxx
@@ -55,7 +55,7 @@ enum ETGeoMediumWid {
 TGeoMediumEditor::TGeoMediumEditor(const TGWindow *p, Int_t width, Int_t height, UInt_t options, Pixel_t back)
    : TGeoGedFrame(p, width, height, options | kVerticalFrame, back)
 {
-   fMedium = 0;
+   fMedium = nullptr;
    fIsEditable = kFALSE;
    fIsModified = kFALSE;
    Pixel_t color;
@@ -92,7 +92,7 @@ TGeoMediumEditor::TGeoMediumEditor(const TGWindow *p, Int_t width, Int_t height,
    label->SetTextColor(color);
    AddFrame(f1, new TGLayoutHints(kLHintsTop, 0, 0, 2, 0));
    f1 = new TGCompositeFrame(this, 155, 30, kHorizontalFrame);
-   fSelectedMaterial = 0;
+   fSelectedMaterial = nullptr;
    fLSelMaterial = new TGLabel(f1, "Select material");
    gClient->GetColorByName("#0000ff", color);
    fLSelMaterial->SetTextColor(color);
@@ -254,7 +254,7 @@ void TGeoMediumEditor::ConnectSignals2Slots()
 
 void TGeoMediumEditor::SetModel(TObject *obj)
 {
-   if (obj == 0 || !(obj->IsA() == TGeoMedium::Class())) {
+   if (obj == nullptr || !(obj->IsA() == TGeoMedium::Class())) {
       SetActive(kFALSE);
       return;
    }

--- a/geom/geombuilder/src/TGeoNodeEditor.cxx
+++ b/geom/geombuilder/src/TGeoNodeEditor.cxx
@@ -46,7 +46,7 @@ enum ETGeoNodeWid {
 TGeoNodeEditor::TGeoNodeEditor(const TGWindow *p, Int_t width, Int_t height, UInt_t options, Pixel_t back)
    : TGeoGedFrame(p, width, height, options | kVerticalFrame, back)
 {
-   fNode = 0;
+   fNode = nullptr;
    fIsEditable = kTRUE;
    Pixel_t color;
 
@@ -70,7 +70,7 @@ TGeoNodeEditor::TGeoNodeEditor(const TGWindow *p, Int_t width, Int_t height, UIn
    // Mother volume selection
    MakeTitle("Mother volume");
    f1 = new TGCompositeFrame(this, 155, 30, kHorizontalFrame | kFixedWidth);
-   fSelectedMother = 0;
+   fSelectedMother = nullptr;
    fLSelMother = new TGLabel(f1, "Select mother");
    gClient->GetColorByName("#0000ff", color);
    fLSelMother->SetTextColor(color);
@@ -88,7 +88,7 @@ TGeoNodeEditor::TGeoNodeEditor(const TGWindow *p, Int_t width, Int_t height, UIn
    // Volume selection
    MakeTitle("Volume");
    f1 = new TGCompositeFrame(this, 155, 30, kHorizontalFrame | kFixedWidth);
-   fSelectedVolume = 0;
+   fSelectedVolume = nullptr;
    fLSelVolume = new TGLabel(f1, "Select volume");
    gClient->GetColorByName("#0000ff", color);
    fLSelVolume->SetTextColor(color);
@@ -106,7 +106,7 @@ TGeoNodeEditor::TGeoNodeEditor(const TGWindow *p, Int_t width, Int_t height, UIn
    // Matrix selection
    MakeTitle("Matrix");
    f1 = new TGCompositeFrame(this, 155, 30, kHorizontalFrame | kFixedWidth);
-   fSelectedMatrix = 0;
+   fSelectedMatrix = nullptr;
    fLSelMatrix = new TGLabel(f1, "Select matrix");
    gClient->GetColorByName("#0000ff", color);
    fLSelMatrix->SetTextColor(color);
@@ -169,7 +169,7 @@ void TGeoNodeEditor::ConnectSignals2Slots()
 
 void TGeoNodeEditor::SetModel(TObject *obj)
 {
-   if (obj == 0 || !obj->InheritsFrom(TGeoNode::Class())) {
+   if (obj == nullptr || !obj->InheritsFrom(TGeoNode::Class())) {
       SetActive(kFALSE);
       return;
    }

--- a/geom/geombuilder/src/TGeoParaEditor.cxx
+++ b/geom/geombuilder/src/TGeoParaEditor.cxx
@@ -52,7 +52,7 @@ enum ETGeoParaWid {
 TGeoParaEditor::TGeoParaEditor(const TGWindow *p, Int_t width, Int_t height, UInt_t options, Pixel_t back)
    : TGeoGedFrame(p, width, height, options | kVerticalFrame, back)
 {
-   fShape = 0;
+   fShape = nullptr;
    fXi = fYi = fZi = fAlphai = fThetai = fPhii = 0.0;
    fNamei = "";
    fIsModified = kFALSE;
@@ -199,7 +199,7 @@ void TGeoParaEditor::ConnectSignals2Slots()
 
 void TGeoParaEditor::SetModel(TObject *obj)
 {
-   if (obj == 0 || (obj->IsA() != TGeoPara::Class())) {
+   if (obj == nullptr || (obj->IsA() != TGeoPara::Class())) {
       SetActive(kFALSE);
       return;
    }

--- a/geom/geombuilder/src/TGeoPconEditor.cxx
+++ b/geom/geombuilder/src/TGeoPconEditor.cxx
@@ -43,15 +43,15 @@ enum ETGeoPconWid { kPCON_NAME, kPCON_NZ, kPCON_PHI1, kPCON_DPHI, kPCON_APPLY, k
 TGeoPconEditor::TGeoPconEditor(const TGWindow *p, Int_t width, Int_t height, UInt_t options, Pixel_t back)
    : TGeoGedFrame(p, width, height, options | kVerticalFrame, back)
 {
-   fShape = 0;
+   fShape = nullptr;
    fNsections = 0;
-   fSections = 0;
+   fSections = nullptr;
    fNsecti = 0;
    fPhi1i = 0;
    fDPhii = 0;
-   fZi = 0;
-   fRmini = 0;
-   fRmaxi = 0;
+   fZi = nullptr;
+   fRmini = nullptr;
+   fRmaxi = nullptr;
    fIsModified = kFALSE;
    fIsShapeEditable = kFALSE;
 
@@ -178,7 +178,7 @@ void TGeoPconEditor::ConnectSignals2Slots()
 
 void TGeoPconEditor::SetModel(TObject *obj)
 {
-   if (obj == 0 || (obj->IsA() != TGeoPcon::Class())) {
+   if (obj == nullptr || (obj->IsA() != TGeoPcon::Class())) {
       SetActive(kFALSE);
       return;
    }
@@ -401,7 +401,7 @@ void TGeoPconEditor::DoApply()
 
 void TGeoPconEditor::DoSectionChange(Int_t isect)
 {
-   TGeoPconSection *sect, *sectlo = 0, *secthi = 0;
+   TGeoPconSection *sect, *sectlo = nullptr, *secthi = nullptr;
    sect = (TGeoPconSection *)fSections->At(isect);
    if (isect)
       sectlo = (TGeoPconSection *)fSections->At(isect - 1);

--- a/geom/geombuilder/src/TGeoPgonEditor.cxx
+++ b/geom/geombuilder/src/TGeoPgonEditor.cxx
@@ -68,7 +68,7 @@ TGeoPgonEditor::~TGeoPgonEditor()
 
 void TGeoPgonEditor::SetModel(TObject *obj)
 {
-   if (obj == 0 || (obj->IsA() != TGeoPgon::Class())) {
+   if (obj == nullptr || (obj->IsA() != TGeoPgon::Class())) {
       SetActive(kFALSE);
       return;
    }

--- a/geom/geombuilder/src/TGeoSphereEditor.cxx
+++ b/geom/geombuilder/src/TGeoSphereEditor.cxx
@@ -55,7 +55,7 @@ enum ETGeoSphereWid {
 TGeoSphereEditor::TGeoSphereEditor(const TGWindow *p, Int_t width, Int_t height, UInt_t options, Pixel_t back)
    : TGeoGedFrame(p, width, height, options | kVerticalFrame, back)
 {
-   fShape = 0;
+   fShape = nullptr;
    fRmini = fRmaxi = fTheta1i = fTheta2i = fPhi1i = fPhi2i = 0.0;
    fNamei = "";
    fIsModified = kFALSE;
@@ -215,7 +215,7 @@ void TGeoSphereEditor::ConnectSignals2Slots()
 
 void TGeoSphereEditor::SetModel(TObject *obj)
 {
-   if (obj == 0 || (obj->IsA() != TGeoSphere::Class())) {
+   if (obj == nullptr || (obj->IsA() != TGeoSphere::Class())) {
       SetActive(kFALSE);
       return;
    }

--- a/geom/geombuilder/src/TGeoTabManager.cxx
+++ b/geom/geombuilder/src/TGeoTabManager.cxx
@@ -60,12 +60,12 @@ TGeoTabManager::TGeoTabManager(TGedEditor *ged)
    fGedEditor = ged;
    fPad = ged->GetPad();
    fTab = ged->GetTab();
-   fVolume = 0;
-   fShapePanel = 0;
-   fMediumPanel = 0;
-   fMaterialPanel = 0;
-   fMatrixPanel = 0;
-   fVolumeTab = 0;
+   fVolume = nullptr;
+   fShapePanel = nullptr;
+   fMediumPanel = nullptr;
+   fMaterialPanel = nullptr;
+   fMatrixPanel = nullptr;
+   fVolumeTab = nullptr;
    fgEditorToMgrMap.Add(ged, this);
 }
 
@@ -202,7 +202,7 @@ void TGeoTabManager::GetEditors(TClass *cl)
       TGedEditor::SetFrameCreator(fGedEditor);
       TGedFrame *gfr = reinterpret_cast<TGedFrame *>(class2->New());
       gfr->SetModelClass(cl);
-      TGedEditor::SetFrameCreator(0);
+      TGedEditor::SetFrameCreator(nullptr);
       client->SetRoot(exroot);
       fVolumeTab->AddFrame(gfr, new TGLayoutHints(kLHintsTop | kLHintsExpandX, 0, 0, 2, 2));
       gfr->MapSubwindows();
@@ -216,7 +216,7 @@ void TGeoTabManager::GetEditors(TClass *cl)
 TGeoTabManager *TGeoTabManager::GetMakeTabManager(TGedEditor *ged)
 {
    if (!ged)
-      return NULL;
+      return nullptr;
    TPair *pair = (TPair *)fgEditorToMgrMap.FindObject(ged);
    if (pair) {
       return (TGeoTabManager *)pair->Value();
@@ -250,7 +250,7 @@ void TGeoTabManager::MoveFrame(TGCompositeFrame *fr, TGCompositeFrame *p)
 {
    TList *list = p->GetList();
    TIter next(list);
-   TGFrameElement *el = 0;
+   TGFrameElement *el = nullptr;
    while ((el = (TGFrameElement *)next())) {
       if (el->fFrame == fr)
          break;
@@ -295,7 +295,7 @@ void TGeoTabManager::SetTab()
 
 ClassImp(TGeoTreeDialog);
 
-TObject *TGeoTreeDialog::fgSelectedObj = 0;
+TObject *TGeoTreeDialog::fgSelectedObj = nullptr;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// static; return selected object
@@ -311,7 +311,7 @@ TObject *TGeoTreeDialog::GetSelected()
 TGeoTreeDialog::TGeoTreeDialog(TGFrame *caller, const TGWindow *main, UInt_t w, UInt_t h)
    : TGTransientFrame(main, main, w, h)
 {
-   fgSelectedObj = 0;
+   fgSelectedObj = nullptr;
    fCanvas = new TGCanvas(this, 100, 200, kSunkenFrame | kDoubleBorder);
    fLT = new TGListTree(fCanvas->GetViewPort(), 100, 200);
    fLT->Associate(this);
@@ -356,7 +356,7 @@ void TGeoTreeDialog::DoSelect(TGListTreeItem *item)
 {
    static TString name;
    if (!item || !item->GetUserData()) {
-      fgSelectedObj = 0;
+      fgSelectedObj = nullptr;
       name = "Selected: -none-";
       fObjLabel->SetText(name);
       return;
@@ -394,7 +394,7 @@ void TGeoVolumeDialog::BuildListTree()
    const TGPicture *pic_fldo = gClient->GetPicture("ofolder_t.xpm");
    const TGPicture *pic_file = gClient->GetPicture("mdi_default.xpm");
    const TGPicture *pic_fileo = gClient->GetPicture("fileopen.xpm");
-   TGListTreeItem *parent_item = 0;
+   TGListTreeItem *parent_item = nullptr;
    TGeoVolume *parent_vol = gGeoManager->GetMasterVolume();
    TGeoVolume *vol;
    // Existing volume hierarchy
@@ -412,7 +412,7 @@ void TGeoVolumeDialog::BuildListTree()
          fLT->SetSelected(parent_item);
       }
    }
-   parent_item = fLT->AddItem(NULL, "Other volumes", pic_fldo, pic_fld);
+   parent_item = fLT->AddItem(nullptr, "Other volumes", pic_fldo, pic_fld);
    parent_item->SetTipText("Select a volume from the list of unconnected volumes");
    TIter next1(gGeoManager->GetListOfVolumes());
    Bool_t found = kFALSE;
@@ -517,7 +517,7 @@ void TGeoShapeDialog::BuildListTree()
    const TGPicture *pic_fld = gClient->GetPicture("folder_t.xpm");
    const TGPicture *pic_fldo = gClient->GetPicture("ofolder_t.xpm");
    const TGPicture *pic_shape;
-   TGListTreeItem *parent_item = 0;
+   TGListTreeItem *parent_item = nullptr;
    TGeoShape *shape;
    const char *shapename;
    TString fld_name;
@@ -534,9 +534,9 @@ void TGeoShapeDialog::BuildListTree()
       fld_name = shapename;  // e.g. "TGeoBBox"
       fld_name.Remove(0, 4); // remove "TGeo" part -> "BBox"
       fld_name += " Shapes";
-      parent_item = fLT->FindChildByName(NULL, fld_name.Data());
+      parent_item = fLT->FindChildByName(nullptr, fld_name.Data());
       if (!parent_item) {
-         parent_item = fLT->AddItem(NULL, fld_name.Data(), pic_fldo, pic_fld);
+         parent_item = fLT->AddItem(nullptr, fld_name.Data(), pic_fldo, pic_fld);
          parent_item->SetTipText(TString::Format("List of %s shapes", fld_name.Data()));
       }
       fLT->AddItem(parent_item, shape->GetName(), shape, pic_shape, pic_shape);
@@ -604,7 +604,7 @@ void TGeoMediumDialog::BuildListTree()
    // Existing media
    for (Int_t i = 0; i < nmed; i++) {
       med = (TGeoMedium *)gGeoManager->GetListOfMedia()->At(i);
-      fLT->AddItem(NULL, med->GetName(), med, pic_med, pic_med);
+      fLT->AddItem(nullptr, med->GetName(), med, pic_med, pic_med);
    }
 }
 
@@ -670,7 +670,7 @@ void TGeoMaterialDialog::BuildListTree()
    // Existing materials
    for (Int_t i = 0; i < nmat; i++) {
       mat = (TGeoMaterial *)gGeoManager->GetListOfMaterials()->At(i);
-      fLT->AddItem(NULL, mat->GetName(), mat, pic_mat, pic_mat);
+      fLT->AddItem(nullptr, mat->GetName(), mat, pic_mat, pic_mat);
    }
 }
 
@@ -731,7 +731,7 @@ void TGeoMatrixDialog::BuildListTree()
    const TGPicture *pic_rot = gClient->GetPicture("georotation_t.xpm");
    const TGPicture *pic_combi = gClient->GetPicture("geocombi_t.xpm");
    const TGPicture *pic;
-   TGListTreeItem *parent_item = 0;
+   TGListTreeItem *parent_item = nullptr;
    TGeoMatrix *matrix;
    Int_t nmat = gGeoManager->GetListOfMatrices()->GetEntriesFast();
    if (!nmat)
@@ -743,24 +743,24 @@ void TGeoMatrixDialog::BuildListTree()
          continue;
       if (!strcmp(matrix->IsA()->GetName(), "TGeoTranslation")) {
          pic = pic_tr;
-         parent_item = fLT->FindChildByName(NULL, "Translations");
+         parent_item = fLT->FindChildByName(nullptr, "Translations");
          if (!parent_item) {
-            parent_item = fLT->AddItem(NULL, "Translations", pic, pic);
+            parent_item = fLT->AddItem(nullptr, "Translations", pic, pic);
             parent_item->SetTipText("List of translations");
          }
       } else if (!strcmp(matrix->IsA()->GetName(), "TGeoRotation")) {
          pic = pic_rot;
-         parent_item = fLT->FindChildByName(NULL, "Rotations");
+         parent_item = fLT->FindChildByName(nullptr, "Rotations");
          if (!parent_item) {
-            parent_item = fLT->AddItem(NULL, "Rotations", pic, pic);
+            parent_item = fLT->AddItem(nullptr, "Rotations", pic, pic);
             parent_item->SetTipText("List of rotations");
          }
       } else if (!strcmp(matrix->IsA()->GetName(), "TGeoCombiTrans") ||
                  !strcmp(matrix->IsA()->GetName(), "TGeoHMatrix")) {
          pic = pic_combi;
-         parent_item = fLT->FindChildByName(NULL, "Combined");
+         parent_item = fLT->FindChildByName(nullptr, "Combined");
          if (!parent_item) {
-            parent_item = fLT->AddItem(NULL, "Combined", pic, pic);
+            parent_item = fLT->AddItem(nullptr, "Combined", pic, pic);
             parent_item->SetTipText("List of combined transformations");
          }
       } else
@@ -872,7 +872,7 @@ void TGeoTransientPanel::GetEditors(TClass *cl)
       TGedEditor::SetFrameCreator(fGedEditor);
       TGedFrame *gfr = reinterpret_cast<TGedFrame *>(class2->New());
       gfr->SetModelClass(cl);
-      TGedEditor::SetFrameCreator(0);
+      TGedEditor::SetFrameCreator(nullptr);
       client->SetRoot(exroot);
       fStyle->AddFrame(gfr, new TGLayoutHints(kLHintsTop | kLHintsExpandX, 0, 0, 2, 2));
       gfr->MapSubwindows();

--- a/geom/geombuilder/src/TGeoTorusEditor.cxx
+++ b/geom/geombuilder/src/TGeoTorusEditor.cxx
@@ -51,7 +51,7 @@ enum ETGeoTorusWid {
 TGeoTorusEditor::TGeoTorusEditor(const TGWindow *p, Int_t width, Int_t height, UInt_t options, Pixel_t back)
    : TGeoGedFrame(p, width, height, options | kVerticalFrame, back)
 {
-   fShape = 0;
+   fShape = nullptr;
    fRi = fRmini = fRmaxi = fPhi1i = fDphii = 0.0;
    fNamei = "";
    fIsModified = kFALSE;
@@ -185,7 +185,7 @@ void TGeoTorusEditor::ConnectSignals2Slots()
 
 void TGeoTorusEditor::SetModel(TObject *obj)
 {
-   if (obj == 0 || (obj->IsA() != TGeoTorus::Class())) {
+   if (obj == nullptr || (obj->IsA() != TGeoTorus::Class())) {
       SetActive(kFALSE);
       return;
    }

--- a/geom/geombuilder/src/TGeoTrapEditor.cxx
+++ b/geom/geombuilder/src/TGeoTrapEditor.cxx
@@ -55,7 +55,7 @@ enum ETGeoTrapWid {
 TGeoTrapEditor::TGeoTrapEditor(const TGWindow *p, Int_t width, Int_t height, UInt_t options, Pixel_t back)
    : TGeoGedFrame(p, width, height, options | kVerticalFrame, back)
 {
-   fShape = 0;
+   fShape = nullptr;
    fH1i = fBl1i = fTl1i = fDzi = fAlpha1i = fThetai = fPhii = fSci = 0.0;
    fNamei = "";
    fIsModified = kFALSE;
@@ -244,7 +244,7 @@ void TGeoTrapEditor::ConnectSignals2Slots()
 
 void TGeoTrapEditor::SetModel(TObject *obj)
 {
-   if (obj == 0 || (obj->IsA() != TGeoTrap::Class())) {
+   if (obj == nullptr || (obj->IsA() != TGeoTrap::Class())) {
       SetActive(kFALSE);
       return;
    }
@@ -575,7 +575,7 @@ TGeoGtraEditor::~TGeoGtraEditor()
 
 void TGeoGtraEditor::SetModel(TObject *obj)
 {
-   if (obj == 0 || (obj->IsA() != TGeoGtra::Class())) {
+   if (obj == nullptr || (obj->IsA() != TGeoGtra::Class())) {
       SetActive(kFALSE);
       return;
    }

--- a/geom/geombuilder/src/TGeoTrd1Editor.cxx
+++ b/geom/geombuilder/src/TGeoTrd1Editor.cxx
@@ -42,7 +42,7 @@ enum ETGeoTrd1Wid { kTRD1_NAME, kTRD1_X1, kTRD1_X2, kTRD1_Y, kTRD1_Z, kTRD1_APPL
 TGeoTrd1Editor::TGeoTrd1Editor(const TGWindow *p, Int_t width, Int_t height, UInt_t options, Pixel_t back)
    : TGeoGedFrame(p, width, height, options | kVerticalFrame, back)
 {
-   fShape = 0;
+   fShape = nullptr;
    fDxi1 = fDxi2 = fDyi = fDzi = 0.0;
    fNamei = "";
    fIsModified = kFALSE;
@@ -166,7 +166,7 @@ void TGeoTrd1Editor::ConnectSignals2Slots()
 
 void TGeoTrd1Editor::SetModel(TObject *obj)
 {
-   if (obj == 0 || (obj->IsA() != TGeoTrd1::Class())) {
+   if (obj == nullptr || (obj->IsA() != TGeoTrd1::Class())) {
       SetActive(kFALSE);
       return;
    }

--- a/geom/geombuilder/src/TGeoTrd2Editor.cxx
+++ b/geom/geombuilder/src/TGeoTrd2Editor.cxx
@@ -42,7 +42,7 @@ enum ETGeoTrd2Wid { kTRD2_NAME, kTRD2_X1, kTRD2_X2, kTRD2_Y1, kTRD2_Y2, kTRD2_Z,
 TGeoTrd2Editor::TGeoTrd2Editor(const TGWindow *p, Int_t width, Int_t height, UInt_t options, Pixel_t back)
    : TGeoGedFrame(p, width, height, options | kVerticalFrame, back)
 {
-   fShape = 0;
+   fShape = nullptr;
    fDxi1 = fDxi2 = fDyi1 = fDyi2 = fDzi = 0.0;
    fNamei = "";
    fIsModified = kFALSE;
@@ -179,7 +179,7 @@ void TGeoTrd2Editor::ConnectSignals2Slots()
 
 void TGeoTrd2Editor::SetModel(TObject *obj)
 {
-   if (obj == 0 || (obj->IsA() != TGeoTrd2::Class())) {
+   if (obj == nullptr || (obj->IsA() != TGeoTrd2::Class())) {
       SetActive(kFALSE);
       return;
    }

--- a/geom/geombuilder/src/TGeoTubeEditor.cxx
+++ b/geom/geombuilder/src/TGeoTubeEditor.cxx
@@ -44,7 +44,7 @@ enum ETGeoTubeWid { kTUBE_NAME, kTUBE_RMIN, kTUBE_RMAX, kTUBE_Z, kTUBE_APPLY, kT
 TGeoTubeEditor::TGeoTubeEditor(const TGWindow *p, Int_t width, Int_t height, UInt_t options, Pixel_t back)
    : TGeoGedFrame(p, width, height, options | kVerticalFrame, back)
 {
-   fShape = 0;
+   fShape = nullptr;
    fRmini = fRmaxi = fDzi = 0.0;
    fNamei = "";
    fIsModified = kFALSE;
@@ -154,7 +154,7 @@ void TGeoTubeEditor::ConnectSignals2Slots()
 
 void TGeoTubeEditor::SetModel(TObject *obj)
 {
-   if (obj == 0 || (obj->IsA() != TGeoTube::Class())) {
+   if (obj == nullptr || (obj->IsA() != TGeoTube::Class())) {
       SetActive(kFALSE);
       return;
    }
@@ -380,7 +380,7 @@ void TGeoTubeSegEditor::ConnectSignals2Slots()
 
 void TGeoTubeSegEditor::SetModel(TObject *obj)
 {
-   if (obj == 0 || (obj->IsA() != TGeoTubeSeg::Class())) {
+   if (obj == nullptr || (obj->IsA() != TGeoTubeSeg::Class())) {
       SetActive(kFALSE);
       return;
    }
@@ -630,7 +630,7 @@ TGeoCtubEditor::~TGeoCtubEditor()
 
 void TGeoCtubEditor::SetModel(TObject *obj)
 {
-   if (obj == 0 || (obj->IsA() != TGeoCtub::Class())) {
+   if (obj == nullptr || (obj->IsA() != TGeoCtub::Class())) {
       SetActive(kFALSE);
       return;
    }

--- a/geom/geombuilder/src/TGeoVolumeEditor.cxx
+++ b/geom/geombuilder/src/TGeoVolumeEditor.cxx
@@ -89,8 +89,8 @@ enum ETGeoVolumeWid {
 TGeoVolumeEditor::TGeoVolumeEditor(const TGWindow *p, Int_t width, Int_t height, UInt_t options, Pixel_t back)
    : TGeoGedFrame(p, width, height, options | kVerticalFrame, back)
 {
-   fGeometry = 0;
-   fVolume = 0;
+   fGeometry = nullptr;
+   fVolume = nullptr;
 
    fIsModified = kFALSE;
    fIsAssembly = kFALSE;
@@ -128,7 +128,7 @@ TGeoVolumeEditor::TGeoVolumeEditor(const TGWindow *p, Int_t width, Int_t height,
    label->SetTextColor(color);
    container->AddFrame(f1, new TGLayoutHints(kLHintsTop, 0, 0, 10, 0));
    f1 = new TGCompositeFrame(container, 155, 30, kHorizontalFrame);
-   fSelectedShape = 0;
+   fSelectedShape = nullptr;
    fLSelShape = new TGLabel(f1, "Select shape");
    gClient->GetColorByName("#0000ff", color);
    fLSelShape->SetTextColor(color);
@@ -146,7 +146,7 @@ TGeoVolumeEditor::TGeoVolumeEditor(const TGWindow *p, Int_t width, Int_t height,
 
    // Current medium
    f1 = new TGCompositeFrame(container, 155, 30, kHorizontalFrame);
-   fSelectedMedium = 0;
+   fSelectedMedium = nullptr;
    fLSelMedium = new TGLabel(f1, "Select medium");
    gClient->GetColorByName("#0000ff", color);
    fLSelMedium->SetTextColor(color);
@@ -204,7 +204,7 @@ TGeoVolumeEditor::TGeoVolumeEditor(const TGWindow *p, Int_t width, Int_t height,
 
    // Select from existing volumes
    f1 = new TGCompositeFrame(container, 155, 30, kHorizontalFrame | kFixedWidth);
-   fSelectedVolume = 0;
+   fSelectedVolume = nullptr;
    fLSelVolume = new TGLabel(f1, "Select volume");
    gClient->GetColorByName("#0000ff", color);
    fLSelVolume->SetTextColor(color);
@@ -218,7 +218,7 @@ TGeoVolumeEditor::TGeoVolumeEditor(const TGWindow *p, Int_t width, Int_t height,
 
    // Matrix selection for nodes
    f1 = new TGCompositeFrame(container, 155, 30, kHorizontalFrame | kFixedWidth);
-   fSelectedMatrix = 0;
+   fSelectedMatrix = nullptr;
    fLSelMatrix = new TGLabel(f1, "Select matrix");
    gClient->GetColorByName("#0000ff", color);
    fLSelMatrix->SetTextColor(color);
@@ -451,7 +451,7 @@ void TGeoVolumeEditor::ConnectSignals2Slots()
 
 void TGeoVolumeEditor::SetModel(TObject *obj)
 {
-   if (obj == 0 || !obj->InheritsFrom(TGeoVolume::Class())) {
+   if (obj == nullptr || !obj->InheritsFrom(TGeoVolume::Class())) {
       SetActive(kFALSE);
       return;
    }
@@ -1012,7 +1012,7 @@ void TGeoVolumeEditor::DoApplyDiv()
       nodes->Delete();
       nodes->Clear();
       delete finder;
-      fVolume->SetFinder(0);
+      fVolume->SetFinder(nullptr);
    }
    fVolume->Divide(fDivName->GetText(), iaxis, ndiv, xlo, step);
    fApplyDiv->SetEnabled(kFALSE);

--- a/geom/geompainter/src/TGeoChecker.cxx
+++ b/geom/geompainter/src/TGeoChecker.cxx
@@ -95,16 +95,16 @@ ClassImp(TGeoChecker);
 
 TGeoChecker::TGeoChecker()
    : TObject(),
-     fGeoManager(NULL),
-     fVsafe(NULL),
-     fBuff1(NULL),
-     fBuff2(NULL),
+     fGeoManager(nullptr),
+     fVsafe(nullptr),
+     fBuff1(nullptr),
+     fBuff2(nullptr),
      fFullCheck(kFALSE),
-     fVal1(NULL),
-     fVal2(NULL),
-     fFlags(NULL),
-     fTimer(NULL),
-     fSelectedNode(NULL),
+     fVal1(nullptr),
+     fVal2(nullptr),
+     fFlags(nullptr),
+     fTimer(nullptr),
+     fSelectedNode(nullptr),
      fNchecks(0),
      fNmeshPoints(1000)
 {
@@ -116,15 +116,15 @@ TGeoChecker::TGeoChecker()
 TGeoChecker::TGeoChecker(TGeoManager *geom)
    : TObject(),
      fGeoManager(geom),
-     fVsafe(NULL),
-     fBuff1(NULL),
-     fBuff2(NULL),
+     fVsafe(nullptr),
+     fBuff1(nullptr),
+     fBuff2(nullptr),
      fFullCheck(kFALSE),
-     fVal1(NULL),
-     fVal2(NULL),
-     fFlags(NULL),
-     fTimer(NULL),
-     fSelectedNode(NULL),
+     fVal1(nullptr),
+     fVal2(nullptr),
+     fFlags(nullptr),
+     fTimer(nullptr),
+     fSelectedNode(nullptr),
      fNchecks(0),
      fNmeshPoints(1000)
 {
@@ -157,7 +157,7 @@ void TGeoChecker::OpProgress(const char *opname, Long64_t current, Long64_t size
    static Long64_t ocurrent = 0;
    static Long64_t osize = 0;
    static Int_t oseconds = 0;
-   static TStopwatch *owatch = 0;
+   static TStopwatch *owatch = nullptr;
    static Bool_t oneoftwo = kFALSE;
    static Int_t nrefresh = 0;
    const char symbol[4] = {'=', '\\', '|', '/'};
@@ -239,7 +239,7 @@ void TGeoChecker::OpProgress(const char *opname, Long64_t current, Long64_t size
       owatch->Continue();
    if (last) {
       icount = 0;
-      owatch = 0;
+      owatch = nullptr;
       ocurrent = 0;
       osize = 0;
       oseconds = 0;
@@ -293,7 +293,7 @@ void TGeoChecker::CheckBoundaryErrors(Int_t ntracks, Double_t radius)
    TH2F *hplotS = new TH2F("hplotS", "Problematic points", 100, -dl[0], dl[0], 100, -dl[1], dl[1]);
    gStyle->SetOptStat(111111);
 
-   TGeoNode *node = 0;
+   TGeoNode *node = nullptr;
    Long_t igen = 0;
    Long_t itry = 0;
    Long_t n100 = ntracks / 100;
@@ -379,7 +379,7 @@ void TGeoChecker::CheckBoundaryErrors(Int_t ntracks, Double_t radius)
              1000000. * fTimer->RealTime() / itry);
    bug->Write();
    delete bug;
-   bug = 0;
+   bug = nullptr;
    delete f;
 
    CheckBoundaryReference();
@@ -528,7 +528,7 @@ void TGeoChecker::CheckGeometryFull(Bool_t checkoverlaps, Bool_t checkcrossings,
 
    if (!checkcrossings) {
       delete[] fFlags;
-      fFlags = 0;
+      fFlags = nullptr;
       delete c;
       return;
    }
@@ -617,7 +617,7 @@ void TGeoChecker::CheckGeometryFull(Bool_t checkoverlaps, Bool_t checkcrossings,
    c1->SetTopMargin(0.15);
    TFile *f = new TFile("statistics.root", "RECREATE");
    TH1F *h = new TH1F("h", "number of boundary crossings per volume", 3, 0, 3);
-   h->SetStats(0);
+   h->SetStats(false);
    h->SetFillColor(38);
    h->SetCanExtend(TH1::kAllAxes);
 
@@ -638,10 +638,10 @@ void TGeoChecker::CheckGeometryFull(Bool_t checkoverlaps, Bool_t checkcrossings,
    c2->SetGrid();
    c2->SetTopMargin(0.15);
    TH2F *h2 = new TH2F("h2", "time per FNB call vs. ndaughters", 100, 0, 100, 100, 0, 15);
-   h2->SetStats(0);
+   h2->SetStats(false);
    h2->SetMarkerStyle(2);
    TH1F *h1 = new TH1F("h1", "percent of time spent per volume", 3, 0, 3);
-   h1->SetStats(0);
+   h1->SetStats(false);
    h1->SetFillColor(38);
    h1->SetCanExtend(TH1::kAllAxes);
    for (i = 0; i < nuid; i++) {
@@ -661,13 +661,13 @@ void TGeoChecker::CheckGeometryFull(Bool_t checkoverlaps, Bool_t checkcrossings,
    h2->Draw();
    f->Write();
    delete[] fFlags;
-   fFlags = 0;
+   fFlags = nullptr;
    delete[] fVal1;
-   fVal1 = 0;
+   fVal1 = nullptr;
    delete[] fVal2;
-   fVal2 = 0;
+   fVal2 = nullptr;
    delete fTimer;
-   fTimer = 0;
+   fTimer = nullptr;
    delete c;
 }
 
@@ -678,7 +678,7 @@ void TGeoChecker::CheckGeometryFull(Bool_t checkoverlaps, Bool_t checkcrossings,
 Int_t TGeoChecker::PropagateInGeom(Double_t *start, Double_t *dir)
 {
    fGeoManager->InitTrack(start, dir);
-   TGeoNode *current = 0;
+   TGeoNode *current = nullptr;
    Int_t nzero = 0;
    Int_t nhits = 0;
    while (!fGeoManager->IsOutside()) {
@@ -1035,7 +1035,7 @@ TGeoOverlap *TGeoChecker::MakeCheckOverlap(const char *name, TGeoVolume *vol1, T
    Double_t tolerance = TGeoShape::Tolerance();
    TGeoShape *shape1 = vol1->GetShape();
    TGeoShape *shape2 = vol2->GetShape();
-   OpProgress("refresh", 0, 0, NULL, kFALSE, kTRUE);
+   OpProgress("refresh", 0, 0, nullptr, kFALSE, kTRUE);
    shape1->GetMeshNumbers(numPoints1, numSegs1, numPols1);
    if (fBuff1->fID != (TObject *)shape1) {
       // Fill first buffer.
@@ -1416,7 +1416,7 @@ Int_t TGeoChecker::NChecksPerVolume(TGeoVolume *vol)
             }
          }
       }
-      node01->SetOverlaps(0, 0);
+      node01->SetOverlaps(nullptr, 0);
    }
    return nchecks;
 }
@@ -1668,7 +1668,7 @@ void TGeoChecker::CheckOverlaps(const TGeoVolume *vol, Double_t ovlp, Option_t *
             }
          }
       }
-      node01->SetOverlaps(0, 0);
+      node01->SetOverlaps(nullptr, 0);
    }
 }
 
@@ -1783,8 +1783,8 @@ void TGeoChecker::ShapeDistances(TGeoShape *shape, Int_t nsamples, Option_t *)
    Double_t point[3], pnew[3];
    Double_t dir[3], dnew[3];
    Double_t theta, phi, delta;
-   TPolyMarker3D *pmfrominside = 0;
-   TPolyMarker3D *pmfromoutside = 0;
+   TPolyMarker3D *pmfrominside = nullptr;
+   TPolyMarker3D *pmfromoutside = nullptr;
    TH1D *hist = new TH1D("hTest1", "Residual distance from inside/outside", 200, -20, 0);
    hist->GetXaxis()->SetTitle("delta[cm] - first bin=overflow");
    hist->GetYaxis()->SetTitle("count");
@@ -1950,8 +1950,8 @@ void TGeoChecker::ShapeSafety(TGeoShape *shape, Int_t nsamples, Option_t *)
    Double_t point[3];
    Double_t dir[3];
    Double_t theta, phi;
-   TPolyMarker3D *pm1 = 0;
-   TPolyMarker3D *pm2 = 0;
+   TPolyMarker3D *pm1 = nullptr;
+   TPolyMarker3D *pm2 = nullptr;
    if (!fTimer)
       fTimer = new TStopwatch();
    fTimer->Reset();
@@ -2044,9 +2044,9 @@ void TGeoChecker::ShapeNormal(TGeoShape *shape, Int_t nsamples, Option_t *)
    Double_t point[3], newpoint[3], oldpoint[3];
    Double_t dir[3], olddir[3];
    Double_t norm[3], newnorm[3], oldnorm[3];
-   TCanvas *errcanvas = 0;
-   TPolyMarker3D *pm1 = 0;
-   TPolyMarker3D *pm2 = 0;
+   TCanvas *errcanvas = nullptr;
+   TPolyMarker3D *pm1 = nullptr;
+   TPolyMarker3D *pm2 = nullptr;
    pm2 = new TPolyMarker3D();
    //   pm2->SetMarkerStyle(24);
    pm2->SetMarkerSize(0.2);
@@ -2146,7 +2146,7 @@ void TGeoChecker::ShapeNormal(TGeoShape *shape, Int_t nsamples, Option_t *)
          shape->ComputeNormal(point, dir, norm);
          memcpy(oldnorm, norm, 3 * sizeof(Double_t));
          memcpy(olddir, dir, 3 * sizeof(Double_t));
-         while (1) {
+         while (true) {
             phi = 2 * TMath::Pi() * gRandom->Rndm();
             theta = TMath::ACos(1. - 2. * gRandom->Rndm());
             dir[0] = TMath::Sin(theta) * TMath::Cos(phi);
@@ -2209,7 +2209,7 @@ TH2F *TGeoChecker::LegoPlot(Int_t ntheta, Double_t themin, Double_t themax, Int_
          fGeoManager->InitTrack(&start[0], &dir[0]);
          startnode = fGeoManager->GetCurrentNode();
          if (fGeoManager->IsOutside())
-            startnode = 0;
+            startnode = nullptr;
          if (startnode) {
             matprop = startnode->GetVolume()->GetMaterial()->GetRadLen();
          } else {
@@ -2234,7 +2234,7 @@ TH2F *TGeoChecker::LegoPlot(Int_t ntheta, Double_t themin, Double_t themax, Int_
             if (matprop > 0) {
                x += step / matprop;
             }
-            if (endnode == 0 && step > 1E10)
+            if (endnode == nullptr && step > 1E10)
                break;
             // generate an extra step to cross boundary
             startnode = endnode;
@@ -2266,7 +2266,7 @@ void TGeoChecker::RandomPoints(TGeoVolume *vol, Int_t npoints, Option_t *option)
    TString opt = option;
    opt.ToLower();
    TObjArray *pm = new TObjArray(128);
-   TPolyMarker3D *marker = 0;
+   TPolyMarker3D *marker = nullptr;
    const TGeoShape *shape = vol->GetShape();
    TGeoBBox *box = (TGeoBBox *)shape;
    Double_t dx = box->GetDX();
@@ -2277,7 +2277,7 @@ void TGeoChecker::RandomPoints(TGeoVolume *vol, Int_t npoints, Option_t *option)
    Double_t oz = (box->GetOrigin())[2];
    Double_t *xyz = new Double_t[3];
    printf("Random box : %f, %f, %f\n", dx, dy, dz);
-   TGeoNode *node = 0;
+   TGeoNode *node = nullptr;
    printf("Start... %i points\n", npoints);
    Int_t i = 0;
    Int_t igen = 0;
@@ -2343,8 +2343,8 @@ void TGeoChecker::RandomRays(Int_t nrays, Double_t startx, Double_t starty, Doub
 {
    TObjArray *pm = new TObjArray(128);
    TString starget = target_vol;
-   TPolyLine3D *line = 0;
-   TPolyLine3D *normline = 0;
+   TPolyLine3D *line = nullptr;
+   TPolyLine3D *normline = nullptr;
    TGeoVolume *vol = fGeoManager->GetTopVolume();
    //   vol->VisibleDaughters(kTRUE);
 
@@ -2397,9 +2397,9 @@ void TGeoChecker::RandomRays(Int_t nrays, Double_t startx, Double_t starty, Doub
       dir[1] = TMath::Sin(theta) * TMath::Sin(phi);
       dir[2] = TMath::Cos(theta);
       startnode = fGeoManager->InitTrack(start[0], start[1], start[2], dir[0], dir[1], dir[2]);
-      line = 0;
+      line = nullptr;
       if (fGeoManager->IsOutside())
-         startnode = 0;
+         startnode = nullptr;
       vis1 = kFALSE;
       if (target_vol) {
          if (startnode && starget == startnode->GetVolume()->GetName())
@@ -2423,7 +2423,7 @@ void TGeoChecker::RandomRays(Int_t nrays, Double_t startx, Double_t starty, Doub
             inull = 0;
          if (inull > 5)
             break;
-         const Double_t *normal = 0;
+         const Double_t *normal = nullptr;
          if (check_norm) {
             normal = fGeoManager->FindNormalFast();
             if (!normal)
@@ -2448,7 +2448,7 @@ void TGeoChecker::RandomRays(Int_t nrays, Double_t startx, Double_t starty, Doub
                pm->Add(normline);
             }
             ipoint = 0;
-            line = 0;
+            line = nullptr;
          }
          if (vis2) {
             // create new segment
@@ -2492,12 +2492,12 @@ void TGeoChecker::RandomRays(Int_t nrays, Double_t startx, Double_t starty, Doub
 TGeoNode *TGeoChecker::SamplePoints(Int_t npoints, Double_t &dist, Double_t epsil, const char *g3path)
 {
    TGeoNode *node = fGeoManager->FindNode();
-   TGeoNode *nodegeo = 0;
-   TGeoNode *nodeg3 = 0;
-   TGeoNode *solg3 = 0;
+   TGeoNode *nodegeo = nullptr;
+   TGeoNode *nodeg3 = nullptr;
+   TGeoNode *solg3 = nullptr;
    if (!node) {
       dist = -1;
-      return 0;
+      return nullptr;
    }
    Bool_t hasg3 = kFALSE;
    if (strlen(g3path))
@@ -2508,8 +2508,8 @@ TGeoNode *TGeoChecker::SamplePoints(Int_t npoints, Double_t &dist, Double_t epsi
    // cd to common path
    Double_t point[3];
    Double_t closest[3];
-   TGeoNode *node1 = 0;
-   TGeoNode *node_close = 0;
+   TGeoNode *node1 = nullptr;
+   TGeoNode *node_close = nullptr;
    dist = 1E10;
    Double_t dist1 = 0;
    // initialize size of random box to epsil
@@ -2546,9 +2546,9 @@ TGeoNode *TGeoChecker::SamplePoints(Int_t npoints, Double_t &dist, Double_t epsi
             fGeoManager->CdUp();
          }
          if (!nodegeo)
-            return 0;
+            return nullptr;
          if (!nodeg3)
-            return 0;
+            return nullptr;
          fGeoManager->cd(common.Data());
          fGeoManager->MasterToLocal(fGeoManager->GetCurrentPoint(), &point[0]);
          Double_t xyz[3], local[3];
@@ -2660,7 +2660,7 @@ Double_t *TGeoChecker::ShootRay(Double_t *start, Double_t dirx, Double_t diry, D
          //         printf("%i (%f, %f, %f) step=%f\n", nelem, point[0], point[1], point[2], step);
          nelem++;
       } else {
-         if (endnode == 0 && step > 1E10) {
+         if (endnode == nullptr && step > 1E10) {
             //            printf("exit : NULL endnode. nelem=%i\n", nelem);
             return array;
          }
@@ -2777,7 +2777,7 @@ void TGeoChecker::TestOverlaps(const char *path)
    Double_t zmin = big;
    Double_t zmax = -big;
    TObjArray *pm = new TObjArray(128);
-   TPolyMarker3D *marker = 0;
+   TPolyMarker3D *marker = nullptr;
    TPolyMarker3D *markthis = new TPolyMarker3D();
    markthis->SetMarkerColor(5);
    TNtuple *ntpl = new TNtuple("ntpl", "random points", "x:y:z");

--- a/geom/geompainter/src/TGeoOverlap.cxx
+++ b/geom/geompainter/src/TGeoOverlap.cxx
@@ -39,11 +39,11 @@ each other nor extrude the shape of their mother volume.
 TGeoOverlap::TGeoOverlap()
 {
    fOverlap = 0;
-   fVolume1 = 0;
-   fVolume2 = 0;
-   fMatrix1 = 0;
-   fMatrix2 = 0;
-   fMarker = 0;
+   fVolume1 = nullptr;
+   fVolume2 = nullptr;
+   fMatrix1 = nullptr;
+   fMatrix2 = nullptr;
+   fMarker = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -98,7 +98,7 @@ void TGeoOverlap::Browse(TBrowser *b)
 
 Int_t TGeoOverlap::Compare(const TObject *obj) const
 {
-   TGeoOverlap *other = 0;
+   TGeoOverlap *other = nullptr;
    other = (TGeoOverlap *)obj;
    if (!other) {
       Error("Compare", "other object is not TGeoOverlap");
@@ -186,7 +186,7 @@ void TGeoOverlap::SampleOverlap(Int_t npoints)
 {
    Draw();
    // Select bounding box of the second volume (may extrude first)
-   TPolyMarker3D *marker = 0;
+   TPolyMarker3D *marker = nullptr;
    TGeoBBox *box = (TGeoBBox *)fVolume2->GetShape();
    Double_t dx = box->GetDX();
    Double_t dy = box->GetDY();

--- a/geom/geompainter/src/TGeoPainter.cxx
+++ b/geom/geompainter/src/TGeoPainter.cxx
@@ -129,7 +129,7 @@ void TGeoPainter::AddSize3D(Int_t numpoints, Int_t numsegs, Int_t numpolys)
 
 TVirtualGeoTrack *TGeoPainter::AddTrack(Int_t id, Int_t pdgcode, TObject *particle)
 {
-   return (TVirtualGeoTrack *)(new TGeoTrack(id, pdgcode, 0, particle));
+   return (TVirtualGeoTrack *)(new TGeoTrack(id, pdgcode, nullptr, particle));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -788,9 +788,9 @@ void TGeoPainter::DrawPolygon(const TGeoPolygon *poly)
    g1->SetMarkerSize(0.8);
    delete[] x;
    delete[] y;
-   Double_t *xc = 0;
-   Double_t *yc = 0;
-   TGraph *g2 = 0;
+   Double_t *xc = nullptr;
+   Double_t *yc = nullptr;
+   TGraph *g2 = nullptr;
    if (nconv && !poly->IsConvex()) {
       xc = new Double_t[nconv + 1];
       yc = new Double_t[nconv + 1];
@@ -834,7 +834,7 @@ void TGeoPainter::DrawVolume(TGeoVolume *vol, Option_t *option)
       ClearVisibleVolumes();
       fVisLock = kFALSE;
    }
-   Bool_t has_pad = (gPad == 0) ? kFALSE : kTRUE;
+   Bool_t has_pad = (gPad == nullptr) ? kFALSE : kTRUE;
    // Clear pad if option "same" not given
    if (!gPad) {
       gROOT->MakeDefCanvas();
@@ -847,7 +847,7 @@ void TGeoPainter::DrawVolume(TGeoVolume *vol, Option_t *option)
    // Create a 3-D view
    TView *view = gPad->GetView();
    if (!view) {
-      view = TView::CreateView(11, 0, 0);
+      view = TView::CreateView(11, nullptr, nullptr);
       // Set the view to perform a first autorange (frame) draw.
       // TViewer3DPad will revert view to normal painting after this
       view->SetAutoRange(kTRUE);
@@ -880,7 +880,7 @@ void TGeoPainter::DrawShape(TGeoShape *shape, Option_t *option)
    fOverlap = nullptr;
    fIsPaintingShape = kTRUE;
 
-   Bool_t has_pad = (gPad == 0) ? kFALSE : kTRUE;
+   Bool_t has_pad = (gPad == nullptr) ? kFALSE : kTRUE;
    // Clear pad if option "same" not given
    if (!gPad) {
       gROOT->MakeDefCanvas();
@@ -893,7 +893,7 @@ void TGeoPainter::DrawShape(TGeoShape *shape, Option_t *option)
    // Create a 3-D view
    TView *view = gPad->GetView();
    if (!view) {
-      view = TView::CreateView(11, 0, 0);
+      view = TView::CreateView(11, nullptr, nullptr);
       // Set the view to perform a first autorange (frame) draw.
       // TViewer3DPad will revert view to normal painting after this
       view->SetAutoRange(kTRUE);
@@ -925,7 +925,7 @@ void TGeoPainter::DrawOverlap(void *ovlp, Option_t *option)
       ClearVisibleVolumes();
       fVisLock = kFALSE;
    }
-   Bool_t has_pad = (gPad == 0) ? kFALSE : kTRUE;
+   Bool_t has_pad = (gPad == nullptr) ? kFALSE : kTRUE;
    // Clear pad if option "same" not given
    if (!gPad) {
       gROOT->MakeDefCanvas();
@@ -940,7 +940,7 @@ void TGeoPainter::DrawOverlap(void *ovlp, Option_t *option)
    gPad->GetViewer3D(option);
    TView *view = gPad->GetView();
    if (!view) {
-      view = TView::CreateView(11, 0, 0);
+      view = TView::CreateView(11, nullptr, nullptr);
       // Set the view to perform a first autorange (frame) draw.
       // TViewer3DPad will revert view to normal painting after this
       view->SetAutoRange(kTRUE);
@@ -969,7 +969,7 @@ void TGeoPainter::DrawOnly(Option_t *option)
    }
    fPaintingOverlaps = kFALSE;
    fIsPaintingShape = kFALSE;
-   Bool_t has_pad = (gPad == 0) ? kFALSE : kTRUE;
+   Bool_t has_pad = (gPad == nullptr) ? kFALSE : kTRUE;
    // Clear pad if option "same" not given
    if (!gPad) {
       gROOT->MakeDefCanvas();
@@ -983,7 +983,7 @@ void TGeoPainter::DrawOnly(Option_t *option)
    // Create a 3-D view
    TView *view = gPad->GetView();
    if (!view) {
-      view = TView::CreateView(11, 0, 0);
+      view = TView::CreateView(11, nullptr, nullptr);
       // Set the view to perform a first autorange (frame) draw.
       // TViewer3DPad will revert view to normal painting after this
       view->SetAutoRange(kTRUE);
@@ -1044,7 +1044,7 @@ void TGeoPainter::EstimateCameraMove(Double_t tmin, Double_t tmax, Double_t *sta
    TVirtualGeoTrack *track;
    TObject *obj;
    Int_t ntracks = 0;
-   Double_t *point = 0;
+   Double_t *point = nullptr;
    AddTrackPoint(point, start, kTRUE);
    while ((obj = next())) {
       if (strcmp(obj->ClassName(), "TGeoTrack"))
@@ -1539,7 +1539,7 @@ void TGeoPainter::PaintVolume(TGeoVolume *top, Option_t *option, TGeoMatrix *glo
       }
    }
    if (fPlugin)
-      fPlugin->SetIterator(0);
+      fPlugin->SetIterator(nullptr);
    fGeoManager->SetMatrixReflection(kFALSE);
    fVisLock = kTRUE;
 }
@@ -1599,7 +1599,7 @@ void TGeoPainter::PaintShape(TGeoShape *shape, Option_t *option)
 {
    TGeoShape::SetTransform(fGlobal);
    fGlobal->Clear();
-   fGeoManager->SetPaintVolume(0);
+   fGeoManager->SetPaintVolume(nullptr);
    PaintShape(*shape, option);
 }
 
@@ -1820,7 +1820,7 @@ void TGeoPainter::Raytrace(Option_t *)
          //         fGeoManager->InitTrack(cop,dir);
          // current ray pointing to pixel (px,py)
          done = kFALSE;
-         norm = 0;
+         norm = nullptr;
          // propagate to the clipping shape if any
          if (fClippingShape) {
             if (inclip) {
@@ -1967,7 +1967,7 @@ void TGeoPainter::SetExplodedView(Int_t ibomb)
    }
    if ((Int_t)ibomb == fExplodedView)
       return;
-   Bool_t change = (gPad == 0) ? kFALSE : kTRUE;
+   Bool_t change = (gPad == nullptr) ? kFALSE : kTRUE;
 
    if (ibomb == kGeoNoBomb) {
       change &= ((fExplodedView == kGeoNoBomb) ? kFALSE : kTRUE);

--- a/geom/geompainter/src/TGeoTrack.cxx
+++ b/geom/geompainter/src/TGeoTrack.cxx
@@ -41,7 +41,7 @@ TGeoTrack::TGeoTrack()
 {
    fPointsSize = 0;
    fNpoints = 0;
-   fPoints = 0;
+   fPoints = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -52,8 +52,8 @@ TGeoTrack::TGeoTrack(Int_t id, Int_t pdgcode, TVirtualGeoTrack *parent, TObject 
 {
    fPointsSize = 0;
    fNpoints = 0;
-   fPoints = 0;
-   if (fParent == 0) {
+   fPoints = nullptr;
+   if (fParent == nullptr) {
       SetMarkerColor(2);
       SetMarkerStyle(8);
       SetMarkerSize(0.6);
@@ -389,7 +389,7 @@ Int_t TGeoTrack::GetPoint(Int_t i, Double_t &x, Double_t &y, Double_t &z, Double
 const Double_t *TGeoTrack::GetPoint(Int_t i) const
 {
    if (!fNpoints)
-      return 0;
+      return nullptr;
    return (&fPoints[i << 2]);
 }
 
@@ -736,8 +736,8 @@ void TGeoTrack::ResetTrack()
       fTracks->Delete();
       delete fTracks;
    }
-   fTracks = 0;
+   fTracks = nullptr;
    if (fPoints)
       delete[] fPoints;
-   fPoints = 0;
+   fPoints = nullptr;
 }

--- a/geom/webviewer/src/RGeomHierarchy.cxx
+++ b/geom/webviewer/src/RGeomHierarchy.cxx
@@ -160,7 +160,7 @@ void RGeomHierarchy::ProcessSignal(const std::string &kind)
    if (kind == "HighlightItem") {
       auto stack = fDesc.GetHighlightedItem();
       auto path = fDesc.MakePathByStack(stack);
-      if (stack.size() == 0)
+      if (stack.empty())
          path = {"__OFF__"}; // just clear highlight
       if (fWebWindow)
          fWebWindow->Send(0, "HIGHL:"s + TBufferJSON::ToJSON(&path).Data());

--- a/geom/webviewer/src/RGeomViewer.cxx
+++ b/geom/webviewer/src/RGeomViewer.cxx
@@ -392,7 +392,7 @@ void RGeomViewer::SaveAsMacro(const std::string &fname)
       return;
    std::string prefix = "   ";
 
-   auto p = fname.find(".");
+   auto p = fname.find('.');
    if (p > 0) {
       fs << "void " << fname.substr(0, p) << "() { " << std::endl;
    } else {


### PR DESCRIPTION
This is applying most of the suggestions from the CMSSW clang-tidy configuration:
https://github.com/cms-sw/cmssw/blob/master/.clang-tidy

Two checks are excluded though, because they can make wrong suggestions about replacing copies with const references:

  * `performance-for-range-copy`

  * `performance-unnecessary-copy-initialization`