### PR TITLE
[eve7] Silence "unused par" warning on Mac release builds:

### DIFF
--- a/graf3d/eve7/glu/render.c
+++ b/graf3d/eve7/glu/render.c
@@ -299,6 +299,7 @@ static void RenderFan( GLUtesselator *tess, GLUhalfEdge *e, long size )
   }
 
   assert( size == 0 );
+  (void)size;
   CALL_END_OR_END_DATA();
 }
 
@@ -327,6 +328,7 @@ static void RenderStrip( GLUtesselator *tess, GLUhalfEdge *e, long size )
   }
 
   assert( size == 0 );
+  (void)size;
   CALL_END_OR_END_DATA();
 }
 


### PR DESCRIPTION
parameter 'size' set but not used [-Wunused-but-set-parameter]

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

