### PR TITLE
[PyROOT] Fix typo in recent PyROOT commit

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.cxx
@@ -224,8 +224,8 @@ static PyObject* im_descr_get(PyObject* meth, PyObject* obj, PyObject* pyclass)
 // of a class that's not a base class of pyclass
     if (CustomInstanceMethod_GET_SELF(meth)
 #if PY_VERSION_HEX < 0x03000000
-         || (CustomInstanceMetho_GET_CLASS(meth) &&
-             !PyObject_IsSubclass(pyclass, CustomInstanceMetho_GET_CLASS(meth)))
+         || (CustomInstanceMethod_GET_CLASS(meth) &&
+             !PyObject_IsSubclass(pyclass, CustomInstanceMethod_GET_CLASS(meth)))
 #endif
             ) {
         Py_INCREF(meth);

--- a/bindings/pyroot/cppyy/patches/avoiding-python312-assert.patch
+++ b/bindings/pyroot/cppyy/patches/avoiding-python312-assert.patch
@@ -88,8 +88,8 @@ index ed41b1637c6..88f50d91616 100644
  #if PY_VERSION_HEX < 0x03000000
 -         || (PyMethod_GET_CLASS(meth) &&
 -             !PyObject_IsSubclass(pyclass, PyMethod_GET_CLASS(meth)))
-+         || (CustomInstanceMetho_GET_CLASS(meth) &&
-+             !PyObject_IsSubclass(pyclass, CustomInstanceMetho_GET_CLASS(meth)))
++         || (CustomInstanceMethod_GET_CLASS(meth) &&
++             !PyObject_IsSubclass(pyclass, CustomInstanceMethod_GET_CLASS(meth)))
  #endif
              ) {
          Py_INCREF(meth);


### PR DESCRIPTION
`Metho_` -> `Method_`

Backport of https://github.com/root-project/root/pull/13968.
