### PR TITLE
[v6-24] Compiling on Debian 12 (bookworm)

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPConstructor.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPConstructor.cxx
@@ -122,7 +122,7 @@ PyObject* CPyCppyy::CPPConstructor::Call(
             if (pyclass) {
                 self->SetSmart((PyObject*)Py_TYPE(self));
                 Py_DECREF((PyObject*)Py_TYPE(self));
-                Py_TYPE(self) = (PyTypeObject*)pyclass;
+                (((PyObject*)(self))->ob_type) = (PyTypeObject*)pyclass;
             }
         }
 

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPOverload.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPOverload.cxx
@@ -1,9 +1,12 @@
 // Bindings
 #include "CPyCppyy.h"
 #include "structmember.h"    // from Python
-#if PY_VERSION_HEX >= 0x02050000
+#if PY_VERSION_HEX >= 0x030B0000
+// from version 3.11 code.h is (only) in cpython subdir and is not needed to include
+;
+#elif PY_VERSION_HEX >= 0x02050000
 #include "code.h"            // from Python
-#else
+#else   // PY_VERSION_HEX < 0x02050000
 #include "compile.h"         // from Python
 #endif
 #ifndef CO_NOFREE


### PR DESCRIPTION
    Patches for compile on Debian 12 with Python 3.11 libraries

# This Pull request:

## Changes or fixes:
Permit to compile with Python's libraries 3.11, too
I've tested locally on Debian 12 (bookworm)


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

