### PR TITLE
[v630][RF] Yet another fix to bin-by-bin offsetting

### DIFF
--- a/roofit/roofitcore/src/RooNLLVar.cxx
+++ b/roofit/roofitcore/src/RooNLLVar.cxx
@@ -288,7 +288,8 @@ double RooNLLVar::evaluatePartition(std::size_t firstEvent, std::size_t lastEven
 
   // If part of simultaneous PDF normalize probability over
   // number of simultaneous PDFs: -sum(log(p/n)) = -sum(log(p)) + N*log(n)
-  if (_simCount>1) {
+  // If we do bin-by bin offsetting, we don't do this because it cancels out
+  if (!_doBinOffset && _simCount>1) {
     result += sumWeight * std::log(static_cast<double>(_simCount));
   }
 


### PR DESCRIPTION
In simultaneous fits with more than one channel, the NLL variable adds by default a normalization term so that the probability is normalized over the full measurement including all channels.

In case of bin-by-bin offsetting, this should not be done because the same term appears in the likelihood in the denominator and cancels out.

Also, fixes a problem where the name of the `_offsetPdf` was not correctly reset (previously, only the name of the proxy was changed, not the name of the pdf).

Backport of https://github.com/root-project/root/pull/13986.