### PR TITLE
Handle the case of arrays in the data model

### DIFF
--- a/tutorials/v7/ntuple/ntpl003_lhcbOpenData.C
+++ b/tutorials/v7/ntuple/ntpl003_lhcbOpenData.C
@@ -66,7 +66,15 @@ void Convert() {
       TLeaf *l = static_cast<TLeaf*>(b->GetListOfLeaves()->First());
 
       // Create an ntuple field with the same name and type than the tree branch
-      auto field = RFieldBase::Create(l->GetName(), l->GetTypeName()).Unwrap();
+      std::unique_ptr<RFieldBase> field{nullptr};
+      if (l->GetLen() == 1) {
+        field = Detail::RFieldBase::Create(l->GetName(), l->GetTypeName()).Unwrap();
+      } else if (l->GetLen() > 1) {
+        field = Detail::RFieldBase::Create(l->GetName(), std::string(l->GetTypeName()) + "[" + std::to_string(l->GetLen()) + "]").Unwrap();
+      } else {
+        // This is the VLA case. Not sure how to handle it yet.
+        field = Detail::RFieldBase::Create(l->GetName(), std::string(l->GetTypeName())).Unwrap();
+      }
       std::cout << "Convert leaf " << l->GetName() << " [" << l->GetTypeName() << "]"
                 << " --> " << "field " << field->GetName() << " [" << field->GetType() << "]" << std::endl;
 


### PR DESCRIPTION
# This Pull request:

Makes sure the converter code works also in the case arrays are in the data model of the TTree, so that when someone uses it to convert a TTree they do not get a segmentation fault when the branch contains a fixed size array per entry.

This PR fixes #13996, in the sense that with that, my O2 AOD converter does not crash anymore.
