### PR TITLE
[tmva][sofie] Fix the issue with GNN receivers/senders different every by event

### DIFF
--- a/bindings/pyroot/pythonizations/test/sofie_gnn.py
+++ b/bindings/pyroot/pythonizations/test/sofie_gnn.py
@@ -147,6 +147,8 @@ class SOFIE_GNN(unittest.TestCase):
         input_data.node_data = ROOT.TMVA.Experimental.AsRTensor(GraphData['nodes'])
         input_data.edge_data = ROOT.TMVA.Experimental.AsRTensor(GraphData['edges'])
         input_data.global_data = ROOT.TMVA.Experimental.AsRTensor(GraphData['globals'])
+        input_data.receivers = GraphData['receivers']
+        input_data.senders = GraphData['senders']
 
         session = ROOT.TMVA_SOFIE_gnn_network.Session()
         session.infer(input_data)
@@ -182,7 +184,7 @@ class SOFIE_GNN(unittest.TestCase):
         model = ROOT.TMVA.Experimental.SOFIE.RModel_GraphIndependent.ParseFromMemory(GraphModule, GraphData)
         model.Generate()
         model.OutputGenerated()
-        
+
         ret = ROOT.gInterpreter.Declare('#include "graph_independent_network.hxx"')
 
         input_data = ROOT.TMVA.Experimental.SOFIE.GNN_Data()
@@ -190,6 +192,8 @@ class SOFIE_GNN(unittest.TestCase):
         input_data.node_data = ROOT.TMVA.Experimental.AsRTensor(GraphData['nodes'])
         input_data.edge_data = ROOT.TMVA.Experimental.AsRTensor(GraphData['edges'])
         input_data.global_data = ROOT.TMVA.Experimental.AsRTensor(GraphData['globals'])
+        input_data.receivers = GraphData['receivers']
+        input_data.senders = GraphData['senders']
 
         session = ROOT.TMVA_SOFIE_graph_independent_network.Session()
         session.infer(input_data)
@@ -269,6 +273,11 @@ class SOFIE_GNN(unittest.TestCase):
         input_data.node_data = ROOT.TMVA.Experimental.AsRTensor(InputGraphData['nodes'])
         input_data.edge_data = ROOT.TMVA.Experimental.AsRTensor(InputGraphData['edges'])
         input_data.global_data = ROOT.TMVA.Experimental.AsRTensor(InputGraphData['globals'])
+        input_data.receivers = InputGraphData['receivers']
+        input_data.senders = InputGraphData['senders']
+
+        print ("input receivers",input_data.receivers)
+        print ("input senders",input_data.senders)
 
         output_gn = ep_model(input_graphs, 2)
 
@@ -306,9 +315,9 @@ class SOFIE_GNN(unittest.TestCase):
           os.remove(fname + '.hxx')
           os.remove(fname + '.dat')
 
-    
+
 
 
 if __name__ == '__main__':
     unittest.main()
-  
+

--- a/tmva/sofie/inc/TMVA/RFunction.hxx
+++ b/tmva/sofie/inc/TMVA/RFunction.hxx
@@ -76,6 +76,7 @@ public:
         return fReducer;
     }
     std::string Generate(std::size_t num_features, const std::vector<std::string>& inputTensors);
+    std::string Generate(std::size_t num_features, const std::string & inputTensors);
 
 };
 

--- a/tmva/sofie/inc/TMVA/SOFIE_common.hxx
+++ b/tmva/sofie/inc/TMVA/SOFIE_common.hxx
@@ -428,7 +428,12 @@ struct GNN_Data {
       RTensor<float> edge_data;
       RTensor<float> global_data;
 
-      GNN_Data(): node_data(RTensor<float>({})), edge_data(RTensor<float>({})), global_data(RTensor<float>({})){}
+      std::vector<int> receivers;
+      std::vector<int> senders;
+
+      // need to have default constructor since RTensor has not one
+      GNN_Data(): node_data(RTensor<float>({})), edge_data(RTensor<float>({})), global_data(RTensor<float>({})) {}
+
 };
 
 template<typename T>
@@ -470,6 +475,11 @@ inline GNN_Data Concatenate(GNN_Data & data1, GNN_Data & data2, int axis = 0) {
    out.node_data = Concatenate(data1.node_data,data2.node_data, axis);
    out.edge_data = Concatenate(data1.edge_data,data2.edge_data, axis);
    out.global_data = Concatenate<float>(data1.global_data,data2.global_data, axis-1);
+   // assume sender/receivers of data1 and data2 are the same
+   if (data1.receivers != data2.receivers || data1.senders != data2.senders)
+       throw std::runtime_error("GNN_Data Concatenate: data1 and data2 have different net structures");
+   out.receivers = data1.receivers;
+   out.senders = data1.senders;
    return out;
 }
 
@@ -481,6 +491,8 @@ inline GNN_Data Copy(const GNN_Data & data) {
    std::copy(data.node_data.GetData(), data.node_data.GetData()+ data.node_data.GetSize(), out.node_data.GetData());
    std::copy(data.edge_data.GetData(), data.edge_data.GetData()+ data.edge_data.GetSize(), out.edge_data.GetData());
    std::copy(data.global_data.GetData(), data.global_data.GetData()+ data.global_data.GetSize(), out.global_data.GetData());
+   out.receivers = data.receivers;
+   out.senders = data.senders;
    return out;
 }
 

--- a/tmva/sofie/src/RFunction.cxx
+++ b/tmva/sofie/src/RFunction.cxx
@@ -73,7 +73,7 @@ std::string RFunction_Update::Generate(const std::vector<std::string>& inputPtrs
     return inferFunc;
 }
 
-
+// passing as input a vector of strings for each input tensor
 std::string RFunction_Aggregate::Generate(std::size_t num_features, const std::vector<std::string>& inputTensors) {
     std::string inferFunc = fFuncName+"("+std::to_string(num_features)+",{";
     for(auto&it : inputTensors) {
@@ -82,6 +82,12 @@ std::string RFunction_Aggregate::Generate(std::size_t num_features, const std::v
     }
     inferFunc.pop_back();
     inferFunc+="});";
+    return inferFunc;
+}
+
+// here passing directly the name of the vector containing the input tensor
+std::string RFunction_Aggregate::Generate(std::size_t num_features, const std::string & inputTensors) {
+    std::string inferFunc = fFuncName + "(" +std::to_string(num_features) + "," + inputTensors + ")";
     return inferFunc;
 }
 

--- a/tmva/sofie/src/RModel_GNN.cxx
+++ b/tmva/sofie/src/RModel_GNN.cxx
@@ -151,52 +151,43 @@ void RModel_GNN::Generate() {
     fGC += "Node_Update::Session node_update;\n";
     fGC += "Global_Update::Session global_update;\n\n";
 
-    fGC += "std::vector<int> fSenders = { ";
-    for(int k=0; k<num_edges; ++k) {
-        fGC += std::to_string(senders[k]);
-        if (k < num_edges-1) fGC += ", ";
-        if (k > 0 && k%32 == 0) fGC += "\n";
-    }
-    fGC += " };\n";
-    fGC += "std::vector<int> fReceivers = { ";
-    for(int k=0; k<num_edges; ++k) {
-        fGC += std::to_string(receivers[k]);
-        if (k < num_edges-1) fGC += ", ";
-        if (k > 0 && k%32 == 0) fGC += "\n";
-    }
-    fGC += " };\n";
+    std::string e_num = std::to_string(num_edges);
+    std::string n_num = std::to_string(num_nodes);
+    std::string e_size_input =  std::to_string(num_edge_features_input);
+    std::string n_size_input =  std::to_string(num_node_features_input);
+    std::string g_size_input =  std::to_string(num_global_features_input);
+    std::string e_size =  std::to_string(num_edge_features);
+    std::string n_size =  std::to_string(num_node_features);
+    std::string g_size =  std::to_string(num_global_features);
 
     // create temp vector for edge and node updates
-    fGC += "std::vector<float> fEdgeUpdates = std::vector<float>(" + std::to_string(num_edges) + "*" + std::to_string(num_edge_features) + ");\n";
-    fGC += "\n\nstd::vector<float> fNodeUpdates = std::vector<float>(" + std::to_string(num_nodes) + "*" + std::to_string(num_node_features) + ");\n";
+    fGC += "std::vector<float> fEdgeUpdates = std::vector<float>(" + e_num + "*" + e_size + ");\n";
+    fGC += "\n\nstd::vector<float> fNodeUpdates = std::vector<float>(" + n_num + "*" + n_size + ");\n";
 
     fGC += "\n// input vectors for edge update\n";
-    fGC += "std::vector<float> fEdgeInputs = std::vector<float>(" + std::to_string(num_edges) + "*" + std::to_string(num_edge_features_input) + ");\n";
-    fGC += "std::vector<float> fRecNodeInputs = std::vector<float>(" + std::to_string(num_edges) + "*" + std::to_string(num_node_features_input) + ");\n";
-    fGC += "std::vector<float> fSndNodeInputs = std::vector<float>(" + std::to_string(num_edges) + "*" + std::to_string(num_node_features_input) + ");\n";
-    fGC += "std::vector<float> fGlobInputs = std::vector<float>(" + std::to_string(num_edges) + "*" + std::to_string(num_global_features_input) + ");\n\n";
+    fGC += "std::vector<float> fEdgeInputs = std::vector<float>(" + e_num + "*" + e_size_input + ");\n";
+    fGC += "std::vector<float> fRecNodeInputs = std::vector<float>(" + e_num + "*" + n_size_input + ");\n";
+    fGC += "std::vector<float> fSndNodeInputs = std::vector<float>(" + e_num + "*" + n_size_input + ");\n";
+    fGC += "std::vector<float> fGlobInputs = std::vector<float>(" + e_num + "*" + g_size_input + ");\n\n";
 
     fGC += "\n// input vectors for node update\n";
-    fGC += "std::vector<float> fNodeInputs = std::vector<float>(" + std::to_string(num_nodes) + "*" + std::to_string(num_node_features_input) + ");\n";
-    fGC += "std::vector<float> fNodeEdgeAggregate = std::vector<float>(" + std::to_string(num_nodes) + "*" + std::to_string(num_node_features_input) + ", 0);\n";
+    fGC += "std::vector<float> fNodeInputs = std::vector<float>(" + n_num + "*" + n_size_input + ");\n";
+    fGC += "std::vector<float> fNodeEdgeAggregate = std::vector<float>(" + n_num + "*" + n_size_input + ", 0);\n";
     fGC += "std::vector<float> fNodeAggregateTemp;\n";
 
     fGC += "\nvoid infer(TMVA::Experimental::SOFIE::GNN_Data& input_graph){\n";
 
     // computing updated edge attributes
     fGC += "\n// --- Edge Update ---\n";
-    std::string e_size_input =  std::to_string(num_edge_features_input);
-    std::string n_size_input =  std::to_string(num_node_features_input);
-    std::string g_size_input =  std::to_string(num_global_features_input);
-    fGC += "for (int k = 0; k < " + std::to_string(num_edges) + "; k++) { \n";
+    fGC += "for (int k = 0; k < " + e_num + "; k++) { \n";
     fGC += "   std::copy(input_graph.edge_data.GetData() + k * " + e_size_input +
            ", input_graph.edge_data.GetData() + (k + 1) * " + e_size_input +
            ", fEdgeInputs.begin() + k * " + e_size_input + ");\n";
-    fGC += "   std::copy(input_graph.node_data.GetData() + fReceivers[k] * " + n_size_input +
-           ", input_graph.node_data.GetData() + (fReceivers[k] + 1) * " + n_size_input +
+    fGC += "   std::copy(input_graph.node_data.GetData() + input_graph.receivers[k] * " + n_size_input +
+           ", input_graph.node_data.GetData() + (input_graph.receivers[k] + 1) * " + n_size_input +
            ", fRecNodeInputs.begin() + k * " + n_size_input + ");\n";
-    fGC += "   std::copy(input_graph.node_data.GetData() + fSenders[k] * " + n_size_input +
-           ", input_graph.node_data.GetData() + (fSenders[k] + 1) * " + n_size_input +
+    fGC += "   std::copy(input_graph.node_data.GetData() + input_graph.senders[k] * " + n_size_input +
+           ", input_graph.node_data.GetData() + (input_graph.senders[k] + 1) * " + n_size_input +
            ", fSndNodeInputs.begin() + k * " + n_size_input + ");\n";
     fGC += "   std::copy(input_graph.global_data.GetData()";
     fGC += ", input_graph.global_data.GetData() + " + g_size_input +
@@ -207,19 +198,19 @@ void RModel_GNN::Generate() {
 
     if(num_edge_features != num_edge_features_input) {
         fGC += "\n//  resize edge graph data since output feature size is not equal to input size\n";
-        fGC+="input_graph.edge_data = input_graph.edge_data.Resize({"+std::to_string(num_edges)+", "+std::to_string(num_edge_features)+"});\n";
+        fGC+="input_graph.edge_data = input_graph.edge_data.Resize({"+e_num+", "+e_size+"});\n";
     }
     // copy output
-    fGC += "\nfor (int k = 0; k < " + std::to_string(num_edges) + "; k++) { \n";
-    fGC += "   std::copy(fEdgeUpdates.begin()+ k * " + std::to_string(num_edge_features) + ", fEdgeUpdates.begin()+ (k+1) * " + std::to_string(num_edge_features) +
-           ",input_graph.edge_data.GetData() + k * " + std::to_string(num_edge_features)+ ");\n";
+    fGC += "\nfor (int k = 0; k < " + e_num + "; k++) { \n";
+    fGC += "   std::copy(fEdgeUpdates.begin()+ k * " + e_size + ", fEdgeUpdates.begin()+ (k+1) * " + e_size +
+           ",input_graph.edge_data.GetData() + k * " + e_size+ ");\n";
     fGC += "}\n";
     fGC += "\n";
 
     fGC += "\n\n// --- Node Update ---\n";
 
     // computing updated edge attributes
-    fGC += "for (int k = 0; k < " + std::to_string(num_nodes) + "; k++) { \n";
+    fGC += "for (int k = 0; k < " + n_num + "; k++) { \n";
     fGC += "   std::copy(input_graph.node_data.GetData() + k * " + n_size_input +
            ", input_graph.node_data.GetData() + (k + 1) * " + n_size_input +
            ", fNodeInputs.begin() + k * " + n_size_input + ");\n";
@@ -231,28 +222,26 @@ void RModel_GNN::Generate() {
     if (num_nodes > num_edges) {
         fGC += "\n// resize global vector feature to number of nodes\n";
         fGC += "fGlobInputs.resize( " + std::to_string(num_nodes * num_global_features_input) + ");";
-        fGC += "for (size_t k = " + std::to_string(num_edges) + "; k < " + std::to_string(num_nodes) + "; k++)";
-            fGC += "   std::copy(fGlobInputs.begin(), fGlobInputs.begin() + " + std::to_string(num_global_features_input) +
-                   " , fGlobInputs.begin() + k * " + std::to_string(num_global_features_input) + ");\n";
+        fGC += "for (size_t k = " + e_num + "; k < " + n_num + "; k++)";
+            fGC += "   std::copy(fGlobInputs.begin(), fGlobInputs.begin() + " + g_size_input +
+                   " , fGlobInputs.begin() + k * " + g_size_input + ");\n";
     }
 
     // aggregating edge if it's a receiver node and then updating corresponding node
-    for(int i=0; i<num_nodes; ++i) {
-        std::vector<std::string> Node_Edge_Aggregate_String;
-        for(int k=0; k<num_edges; ++k) {
-            if(receivers[k] == i) {
-                Node_Edge_Aggregate_String.emplace_back("input_graph.edge_data.GetData()+"+std::to_string(k*num_edge_features));
-            }
-        }
+    // loop on nodes
+    fGC += "\nfor (int j = 0; j < " + n_num + "; j++) {\n";
+    int naprec = int(num_edges/num_nodes) +1;  // approximate number of receivers/node
+    fGC += "   std::vector<float *> edgesData; edgesData.reserve(" + std::to_string(naprec) + ");\n";
+    // loop on edges
+    fGC += "   for (int k = 0; k < " + e_num + "; k++) {\n";
+    fGC += "      if (input_graph.receivers[k] == j) \n";
+    fGC += "         edgesData.emplace_back(input_graph.edge_data.GetData() + k * " + e_size + ");\n";
+    fGC += "   }\n";
+    fGC += "   fNodeAggregateTemp = " + edge_node_agg_block->Generate(num_edge_features, "edgesData") + ";\n";
+    fGC += "   std::copy(fNodeAggregateTemp.begin(), fNodeAggregateTemp.end(), fNodeEdgeAggregate.begin() + " +
+                   e_size + " * j);\n";
+    fGC += "}\n";   // end node loop
 
-        // when node is not a receiver, fill the aggregated vector with 0 values
-        if(Node_Edge_Aggregate_String.size()!=0) {
-            fGC+="\nfNodeAggregateTemp = ";
-            fGC+=edge_node_agg_block->Generate(num_edge_features, {Node_Edge_Aggregate_String});                     // aggregating edge attributes per node
-            fGC += "\nstd::copy(fNodeAggregateTemp.begin(), fNodeAggregateTemp.end(), fNodeEdgeAggregate.begin() + " +
-                   std::to_string(num_edge_features * i) + ");";
-        }
-    }
 
     fGC+="\n";
     fGC+="fNodeUpdates = ";
@@ -261,12 +250,12 @@ void RModel_GNN::Generate() {
 
     if(num_node_features != num_node_features_input) {
         fGC += "\n//  resize node graph data since output feature size is not equal to input size\n";
-        fGC+="input_graph.node_data = input_graph.node_data.Resize({"+std::to_string(num_nodes)+", "+std::to_string(num_node_features)+"});\n";
+        fGC+="input_graph.node_data = input_graph.node_data.Resize({"+n_num+", "+n_size+"});\n";
     }
     // copy output
-    fGC += "\nfor (int k = 0; k < " + std::to_string(num_nodes) + "; k++) { \n";
-    fGC += "   std::copy(fNodeUpdates.begin()+ k * " + std::to_string(num_node_features) + ", fNodeUpdates.begin() + (k+1) * " + std::to_string(num_node_features) +
-           ",input_graph.node_data.GetData() + k * " + std::to_string(num_node_features)+ ");\n";
+    fGC += "\nfor (int k = 0; k < " + n_num + "; k++) { \n";
+    fGC += "   std::copy(fNodeUpdates.begin()+ k * " + n_size + ", fNodeUpdates.begin() + (k+1) * " + n_size +
+           ",input_graph.node_data.GetData() + k * " + n_size+ ");\n";
     fGC += "}\n";
     fGC += "\n";
 
@@ -295,7 +284,7 @@ void RModel_GNN::Generate() {
     fGC += globals_update_block->Generate({"Edge_Global_Aggregate.data()","Node_Global_Aggregate.data()", "input_graph.global_data.GetData()"});
     if(num_global_features != num_global_features_input) {
         fGC += "\n//  resize global graph data since output feature size is not equal to input size\n";
-        fGC+="input_graph.global_data = input_graph.global_data.Resize({"+std::to_string(num_global_features)+"});\n";
+        fGC+="input_graph.global_data = input_graph.global_data.Resize({"+g_size+"});\n";
     }
     fGC += "\nstd::copy(Global_Data.begin(), Global_Data.end(), input_graph.global_data.GetData());";
     fGC+="\n}\n";


### PR DESCRIPTION


The SOFIE GNN must support having different senders and receivers (adjacent matrix) for every event as it is the case in the GraphNet library

This is now achieved by including the list(vector)  of sender/receivers in the GNN data structure which is passed to the generated infer function. Before the list was used as a static data member of the generated GNN secton class

