### PR TITLE
[cmake] Adapt to ZeroMQ 4.3.5 being now released

### DIFF
--- a/cmake/modules/FindZeroMQ.cmake
+++ b/cmake/modules/FindZeroMQ.cmake
@@ -37,22 +37,10 @@ find_library(ZeroMQ_LIBRARY
 set ( ZeroMQ_LIBRARIES ${ZeroMQ_LIBRARY} )
 set ( ZeroMQ_INCLUDE_DIRS ${ZeroMQ_INCLUDE_DIR} )
 
-# check for zmq_ppoll
-if(ZeroMQ_LIBRARIES)
-    include(CheckCXXSymbolExists)
-    set(CMAKE_REQUIRED_LIBRARIES ${ZeroMQ_LIBRARIES})
-    set(CMAKE_REQUIRED_INCLUDES ${ZeroMQ_INCLUDE_DIRS})
-    set(CMAKE_REQUIRED_DEFINITIONS "-DZMQ_BUILD_DRAFT_API")
-    check_cxx_symbol_exists(zmq_ppoll zmq.h ZeroMQ_HAS_PPOLL)
-    unset(CMAKE_REQUIRED_LIBRARIES)
-    unset(CMAKE_REQUIRED_INCLUDES)
-    unset(CMAKE_REQUIRED_DEFINITIONS)
-endif()
-
 include ( FindPackageHandleStandardArgs )
 # handle the QUIETLY and REQUIRED arguments and set ZeroMQ_FOUND to TRUE
 # if all listed variables are TRUE
-find_package_handle_standard_args ( ZeroMQ DEFAULT_MSG ZeroMQ_LIBRARIES ZeroMQ_INCLUDE_DIRS ZeroMQ_HAS_PPOLL )
+find_package_handle_standard_args ( ZeroMQ DEFAULT_MSG ZeroMQ_LIBRARIES ZeroMQ_INCLUDE_DIRS )
 
 if(ZeroMQ_FOUND)
     if(NOT TARGET libzmq)

--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -160,7 +160,7 @@ ROOT_BUILD_OPTION(qt5web OFF "Enable support for Qt5 web-based display (requires
 ROOT_BUILD_OPTION(qt6web OFF "Enable support for Qt6 web-based display (requires Qt6::WebEngineCore and Qt6::WebEngineWidgets)")
 ROOT_BUILD_OPTION(r OFF "Enable support for R bindings (requires R, Rcpp, and RInside)")
 ROOT_BUILD_OPTION(roofit ON "Build the advanced fitting package RooFit, and RooStats for statistical tests. If xml is available, also build HistFactory.")
-ROOT_BUILD_OPTION(roofit_multiprocess OFF "Build RooFit::MultiProcess and multi-process RooFit::TestStatistics classes (requires ZeroMQ with zmq_ppoll and cppzmq).")
+ROOT_BUILD_OPTION(roofit_multiprocess OFF "Build RooFit::MultiProcess and multi-process RooFit::TestStatistics classes (requires ZeroMQ >= 3.4.5 built with -DENABLE_DRAFTS and cppzmq).")
 ROOT_BUILD_OPTION(webgui ON "Build Web-based UI components of ROOT (requires C++17 standard or higher)")
 ROOT_BUILD_OPTION(root7 ON "Build ROOT 7 components of ROOT (requires C++17 standard or higher)")
 ROOT_BUILD_OPTION(rpath ON "Link libraries with built-in RPATH (run-time search path)")

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1831,9 +1831,9 @@ if (roofit_multiprocess)
     set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
 
     if(fail-on-missing)
-      find_package(ZeroMQ REQUIRED)
+      find_package(ZeroMQ 4.3.5 REQUIRED)
     else()
-      find_package(ZeroMQ)
+      find_package(ZeroMQ 4.3.5)
       if(NOT ZeroMQ_FOUND)
         message(STATUS "ZeroMQ not found. Switching on builtin_zeromq option")
         set(builtin_zeromq ON CACHE BOOL "Enabled because ZeroMQ not found (${builtin_zeromq_description})" FORCE)
@@ -1877,12 +1877,6 @@ if (roofit_multiprocess)
     list(APPEND ROOT_BUILTINS cppzmq)
     add_subdirectory(builtins/zeromq/cppzmq)
   endif()
-
-  # zmq_ppoll is still in the draft API, so enable that transitively
-  target_compile_definitions(libzmq INTERFACE ZMQ_BUILD_DRAFT_API)
-  target_compile_definitions(libzmq INTERFACE ZMQ_NO_EXPORT)
-  target_compile_definitions(cppzmq INTERFACE ZMQ_BUILD_DRAFT_API)
-  target_compile_definitions(cppzmq INTERFACE ZMQ_NO_EXPORT)
 endif (roofit_multiprocess)
 
 #---Check for googletest---------------------------------------------------------------

--- a/roofit/roofitZMQ/CMakeLists.txt
+++ b/roofit/roofitZMQ/CMakeLists.txt
@@ -16,4 +16,9 @@ target_include_directories(RooFitZMQ
         PRIVATE ${RooFitZMQ_INCLUDE_DIR}
         INTERFACE $<BUILD_INTERFACE:${RooFitZMQ_INCLUDE_DIR}>)
 
+# zmq_ppoll is still in the draft API, and RooFitZMQ relies on it
+target_compile_definitions(RooFitZMQ PUBLIC ZMQ_BUILD_DRAFT_API)
+# to avoid leaking symbols
+target_compile_definitions(RooFitZMQ PUBLIC ZMQ_NO_EXPORT)
+
 ROOT_ADD_TEST_SUBDIRECTORY(test)


### PR DESCRIPTION
So far, ROOT, in particular the `roofit_multiprocess` feature was depending on a feature developed by @egpbos that was not part of the ZeroMQ 4.3.4 release yet. Therefore, it was a bit awkward to check if ZeroMQ had that feature. Now that it's released, we can just do a proper cmake version check.

The only caveat is that ZeroMQ needs to be built with `-DENABLE_DRAFTS`
to work for `roofit_multiprocess`, which is explained in the build
options documentation.

Also, move some compilation flags to specifically RooFitZMQ, where they
are needed.

This PR superseeds two other PRs:
  * https://github.com/root-project/root/pull/13995
  * https://github.com/root-project/root/pull/9473