### PR TITLE
[tree] Apply `modernize-use-nullptr` suggestions from clang-tidy

### DIFF
--- a/tree/dataframe/src/lexertk.hpp
+++ b/tree/dataframe/src/lexertk.hpp
@@ -353,13 +353,13 @@ public:
    typedef std::deque<token_t> token_list_t;
    typedef std::deque<token_t>::iterator token_list_itr_t;
 
-   generator() : base_itr_(0), s_itr_(0), s_end_(0) { clear(); }
+   generator() : base_itr_(nullptr), s_itr_(nullptr), s_end_(nullptr) { clear(); }
 
    inline void clear()
    {
-      base_itr_ = 0;
-      s_itr_ = 0;
-      s_end_ = 0;
+      base_itr_ = nullptr;
+      s_itr_ = nullptr;
+      s_end_ = nullptr;
       token_list_.clear();
       token_itr_ = token_list_.end();
       store_token_itr_ = token_list_.end();

--- a/tree/tree/src/TBasket.cxx
+++ b/tree/tree/src/TBasket.cxx
@@ -89,7 +89,7 @@ TBasket::TBasket(const char *name, const char *title, TBranch *branch)
    fKeylen      = fBufferRef->Length();
    fObjlen      = fBufferSize - fKeylen;
    fLast        = fKeylen;
-   fBuffer      = 0;
+   fBuffer      = nullptr;
    fHeaderOnly  = kFALSE;
    if (fNevBufSize) {
       fEntryOffset = new Int_t[fNevBufSize];
@@ -106,13 +106,13 @@ TBasket::~TBasket()
    if (fDisplacement) delete [] fDisplacement;
    ResetEntryOffset();
    if (fBufferRef) delete fBufferRef;
-   fBufferRef = 0;
-   fBuffer = 0;
-   fDisplacement= 0;
+   fBufferRef = nullptr;
+   fBuffer = nullptr;
+   fDisplacement= nullptr;
    // Note we only delete the compressed buffer if we own it
    if (fCompressedBufferRef && fOwnsCompressedBuffer) {
       delete fCompressedBufferRef;
-      fCompressedBufferRef = 0;
+      fCompressedBufferRef = nullptr;
    }
    // TKey::~TKey will use fMotherDir to attempt to remove they key
    // from the directory's list of key.  A basket is never in that list
@@ -178,11 +178,11 @@ Int_t TBasket::DropBuffers()
    ResetEntryOffset();
    if (fBufferRef)    delete fBufferRef;
    if (fCompressedBufferRef && fOwnsCompressedBuffer) delete fCompressedBufferRef;
-   fBufferRef   = 0;
-   fCompressedBufferRef = 0;
-   fBuffer      = 0;
-   fDisplacement= 0;
-   fEntryOffset = 0;
+   fBufferRef   = nullptr;
+   fCompressedBufferRef = nullptr;
+   fBuffer      = nullptr;
+   fDisplacement= nullptr;
+   fEntryOffset = nullptr;
    fBranch->GetTree()->IncrementTotalBuffers(-fBufferSize);
    return fBufferSize;
 }
@@ -288,7 +288,7 @@ Int_t TBasket::LoadBasketBuffers(Long64_t pos, Int_t len, TFile *file, TTree *tr
       file->SetOffset(pos + len);
    } else {
       TVirtualPerfStats* temp = gPerfStats;
-      if (tree->GetPerfStats() != 0) gPerfStats = tree->GetPerfStats();
+      if (tree->GetPerfStats() != nullptr) gPerfStats = tree->GetPerfStats();
       if (file->ReadBuffer(buffer,len)) {
          gPerfStats = temp;
          return 1; //error while reading
@@ -368,7 +368,7 @@ Int_t TBasket::ReadBasketBuffersUncompressedCase()
    // Usage of this mode assume the existence of only ONE
    // entry in this basket.
    ResetEntryOffset();
-   delete [] fDisplacement; fDisplacement = 0;
+   delete [] fDisplacement; fDisplacement = nullptr;
 
    fBranch->GetTree()->IncrementTotalBuffers(fBufferSize);
    return 0;
@@ -431,7 +431,7 @@ static inline TBuffer* R__InitializeReadBasketBuffer(TBuffer* bufferRef, Int_t l
 
 void inline TBasket::InitializeCompressedBuffer(Int_t len, TFile* file)
 {
-   Bool_t compressedBufferExists = fCompressedBufferRef != NULL;
+   Bool_t compressedBufferExists = fCompressedBufferRef != nullptr;
    fCompressedBufferRef = R__InitializeReadBasketBuffer(fCompressedBufferRef, len, file);
    if (R__unlikely(!compressedBufferExists)) {
       fOwnsCompressedBuffer = kTRUE;
@@ -515,7 +515,7 @@ Int_t TBasket::ReadBasketBuffers(Long64_t pos, Int_t len, TFile *file)
 
    if (pf) {
       TVirtualPerfStats* temp = gPerfStats;
-      if (fBranch->GetTree()->GetPerfStats() != 0) gPerfStats = fBranch->GetTree()->GetPerfStats();
+      if (fBranch->GetTree()->GetPerfStats() != nullptr) gPerfStats = fBranch->GetTree()->GetPerfStats();
       Int_t st = 0;
       {
          R__LOCKGUARD_IMT(gROOTMutex); // Lock for parallel TTree I/O
@@ -542,7 +542,7 @@ Int_t TBasket::ReadBasketBuffers(Long64_t pos, Int_t len, TFile *file)
    } else {
       // Read from the file and unstream the header information.
       TVirtualPerfStats* temp = gPerfStats;
-      if (fBranch->GetTree()->GetPerfStats() != 0) gPerfStats = fBranch->GetTree()->GetPerfStats();
+      if (fBranch->GetTree()->GetPerfStats() != nullptr) gPerfStats = fBranch->GetTree()->GetPerfStats();
       R__LOCKGUARD_IMT(gROOTMutex);  // Lock for parallel TTree I/O
       if (file->ReadBuffer(readBufferRef->Buffer(),pos,len)) {
          gPerfStats = temp;
@@ -635,7 +635,7 @@ Int_t TBasket::ReadBasketBuffers(Long64_t pos, Int_t len, TFile *file)
       }
       len = fObjlen+fKeylen;
       TVirtualPerfStats* temp = gPerfStats;
-      if (fBranch->GetTree()->GetPerfStats() != 0) gPerfStats = fBranch->GetTree()->GetPerfStats();
+      if (fBranch->GetTree()->GetPerfStats() != nullptr) gPerfStats = fBranch->GetTree()->GetPerfStats();
       if (R__unlikely(gPerfStats)) {
          gPerfStats->UnzipEvent(fBranch->GetTree(),pos,start,nintot,fObjlen);
       }
@@ -677,7 +677,7 @@ AfterBuffer:
    fReadEntryOffset = kTRUE;
    // Read the array of displacement if any.
    delete [] fDisplacement;
-   fDisplacement = 0;
+   fDisplacement = nullptr;
    if (fBufferRef->Length() != len) {
       // There is more data in the buffer!  It is the displacement
       // array.  If len is less than TBuffer::kMinimalSize the actual
@@ -712,7 +712,7 @@ Int_t TBasket::ReadBasketBytes(Long64_t pos, TFile *file)
 /// This TBasket is now useless and invalid until it is told to adopt a buffer.
 void TBasket::DisownBuffer()
 {
-   fBufferRef = NULL;
+   fBufferRef = nullptr;
 }
 
 
@@ -894,10 +894,10 @@ void TBasket::WriteReset()
 
    fNevBuf      = 0;
    Int_t *storeEntryOffset = fEntryOffset;
-   fEntryOffset = 0;
+   fEntryOffset = nullptr;
    Int_t *storeDisplacement = fDisplacement;
-   fDisplacement= 0;
-   fBuffer      = 0;
+   fDisplacement= nullptr;
+   fBuffer      = nullptr;
 
    fBufferRef->Reset();
    fBufferRef->SetWriteMode();
@@ -910,7 +910,7 @@ void TBasket::WriteReset()
    fKeylen      = fBufferRef->Length();
    fObjlen      = fBufferSize - fKeylen;
    fLast        = fKeylen;
-   fBuffer      = 0;
+   fBuffer      = nullptr;
    fHeaderOnly  = kFALSE;
    fDisplacement= storeDisplacement;
    fEntryOffset = storeEntryOffset;
@@ -1200,7 +1200,7 @@ Int_t TBasket::WriteBuffer()
       if (fDisplacement) {
          fBufferRef->WriteArray(fDisplacement, fNevBuf + 1);
          delete[] fDisplacement;
-         fDisplacement = 0;
+         fDisplacement = nullptr;
       }
    }
 

--- a/tree/tree/src/TBasketSQL.cxx
+++ b/tree/tree/src/TBasketSQL.cxx
@@ -31,7 +31,7 @@ Implement TBasket for a SQL backend.
 ////////////////////////////////////////////////////////////////////////////////
 /// Default constructor.
 
-TBasketSQL::TBasketSQL() : TBasket(), fResultPtr(0), fRowPtr(0), fInsertQuery(0)
+TBasketSQL::TBasketSQL() : TBasket(), fResultPtr(nullptr), fRowPtr(nullptr), fInsertQuery(nullptr)
 {
 }
 
@@ -49,20 +49,20 @@ TBasketSQL::TBasketSQL(const char *name, const char *title, TBranch *branch,
    fBufferSize  = branch->GetBasketSize();
    fNevBufSize  = branch->GetEntryOffsetLen();
    fNevBuf      = 0;
-   fEntryOffset = 0;  //Must be set to 0 before calling Sizeof
-   fDisplacement= 0;  //Must be set to 0 before calling Sizeof
-   fBuffer      = 0;  //Must be set to 0 before calling Sizeof
+   fEntryOffset = nullptr;  //Must be set to 0 before calling Sizeof
+   fDisplacement= nullptr;  //Must be set to 0 before calling Sizeof
+   fBuffer      = nullptr;  //Must be set to 0 before calling Sizeof
    fInsertQuery = insert_query;
 
-   if (vc==0) {
-      fBufferRef = 0;
+   if (vc==nullptr) {
+      fBufferRef = nullptr;
    } else {
       fBufferRef = new TBufferSQL(TBuffer::kWrite, fBufferSize, vc, fInsertQuery, fRowPtr);
    }
    fHeaderOnly  = kTRUE;
    fLast        = 0; // Must initialize before calling Streamer()
    //Streamer(*fBufferRef);
-   fBuffer      = 0;
+   fBuffer      = nullptr;
    fBranch      = branch;
    fHeaderOnly  = kFALSE;
    branch->GetTree()->IncrementTotalBuffers(fBufferSize);
@@ -90,12 +90,12 @@ void TBasketSQL::CreateBuffer(const char *name, TString title,
    fBufferSize  = branch->GetBasketSize();
    fNevBufSize  = branch->GetEntryOffsetLen();
    fNevBuf      = 0;
-   fEntryOffset = 0;  //Must be set to 0 before calling Sizeof
-   fDisplacement= 0;  //Must be set to 0 before calling Sizeof
-   fBuffer      = 0;  //Must be set to 0 before calling Sizeof
+   fEntryOffset = nullptr;  //Must be set to 0 before calling Sizeof
+   fDisplacement= nullptr;  //Must be set to 0 before calling Sizeof
+   fBuffer      = nullptr;  //Must be set to 0 before calling Sizeof
 
-   if(vc==0) {
-      fBufferRef = 0;
+   if(vc==nullptr) {
+      fBufferRef = nullptr;
       Error("CreateBuffer","Need a vector of columns\n");
    } else {
       fBufferRef   = new TBufferSQL(TBuffer::kWrite, fBufferSize, vc, fInsertQuery, fRowPtr);
@@ -103,7 +103,7 @@ void TBasketSQL::CreateBuffer(const char *name, TString title,
    fHeaderOnly  = kTRUE;
    fLast        = 0;
    //Streamer(*fBufferRef);
-   fBuffer      = 0;
+   fBuffer      = nullptr;
    fBranch      = branch;
    fHeaderOnly  = kFALSE;
    branch->GetTree()->IncrementTotalBuffers(fBufferSize);

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -102,7 +102,7 @@ TBranch::TBranch()
 , fReadEntry(-1)
 , fFirstBasketEntry(-1)
 , fNextBasketEntry(-1)
-, fCurrentBasket(0)
+, fCurrentBasket(nullptr)
 , fEntries(0)
 , fFirstEntry(0)
 , fTotBytes(0)
@@ -110,18 +110,18 @@ TBranch::TBranch()
 , fBranches()
 , fLeaves()
 , fBaskets(fMaxBaskets)
-, fBasketBytes(0)
-, fBasketEntry(0)
-, fBasketSeek(0)
-, fTree(0)
-, fMother(0)
-, fParent(0)
-, fAddress(0)
-, fDirectory(0)
+, fBasketBytes(nullptr)
+, fBasketEntry(nullptr)
+, fBasketSeek(nullptr)
+, fTree(nullptr)
+, fMother(nullptr)
+, fParent(nullptr)
+, fAddress(nullptr)
+, fDirectory(nullptr)
 , fFileName("")
-, fEntryBuffer(0)
-, fTransientBuffer(0)
-, fBrowsables(0)
+, fEntryBuffer(nullptr)
+, fTransientBuffer(nullptr)
+, fBrowsables(nullptr)
 , fBulk(*this)
 , fSkipZip(kFALSE)
 , fReadLeaves(&TBranch::ReadLeavesImpl)
@@ -215,7 +215,7 @@ TBranch::TBranch(TTree *tree, const char *name, void *address, const char *leafl
 , fReadEntry(-1)
 , fFirstBasketEntry(-1)
 , fNextBasketEntry(-1)
-, fCurrentBasket(0)
+, fCurrentBasket(nullptr)
 , fEntries(0)
 , fFirstEntry(0)
 , fTotBytes(0)
@@ -223,18 +223,18 @@ TBranch::TBranch(TTree *tree, const char *name, void *address, const char *leafl
 , fBranches()
 , fLeaves()
 , fBaskets(fMaxBaskets)
-, fBasketBytes(0)
-, fBasketEntry(0)
-, fBasketSeek(0)
+, fBasketBytes(nullptr)
+, fBasketEntry(nullptr)
+, fBasketSeek(nullptr)
 , fTree(tree)
-, fMother(0)
-, fParent(0)
+, fMother(nullptr)
+, fParent(nullptr)
 , fAddress((char *)address)
 , fDirectory(fTree->GetDirectory())
 , fFileName("")
-, fEntryBuffer(0)
-, fTransientBuffer(0)
-, fBrowsables(0)
+, fEntryBuffer(nullptr)
+, fTransientBuffer(nullptr)
+, fBrowsables(nullptr)
 , fBulk(*this)
 , fSkipZip(kFALSE)
 , fReadLeaves(&TBranch::ReadLeavesImpl)
@@ -269,7 +269,7 @@ TBranch::TBranch(TBranch *parent, const char *name, void *address, const char *l
 , fReadEntry(-1)
 , fFirstBasketEntry(-1)
 , fNextBasketEntry(-1)
-, fCurrentBasket(0)
+, fCurrentBasket(nullptr)
 , fEntries(0)
 , fFirstEntry(0)
 , fTotBytes(0)
@@ -277,18 +277,18 @@ TBranch::TBranch(TBranch *parent, const char *name, void *address, const char *l
 , fBranches()
 , fLeaves()
 , fBaskets(fMaxBaskets)
-, fBasketBytes(0)
-, fBasketEntry(0)
-, fBasketSeek(0)
-, fTree(parent ? parent->GetTree() : 0)
-, fMother(parent ? parent->GetMother() : 0)
+, fBasketBytes(nullptr)
+, fBasketEntry(nullptr)
+, fBasketSeek(nullptr)
+, fTree(parent ? parent->GetTree() : nullptr)
+, fMother(parent ? parent->GetMother() : nullptr)
 , fParent(parent)
 , fAddress((char *)address)
-, fDirectory(fTree ? fTree->GetDirectory() : 0)
+, fDirectory(fTree ? fTree->GetDirectory() : nullptr)
 , fFileName("")
-, fEntryBuffer(0)
-, fTransientBuffer(0)
-, fBrowsables(0)
+, fEntryBuffer(nullptr)
+, fTransientBuffer(nullptr)
+, fBrowsables(nullptr)
 , fBulk(*this)
 , fSkipZip(kFALSE)
 , fReadLeaves(&TBranch::ReadLeavesImpl)
@@ -338,7 +338,7 @@ void TBranch::Init(const char* name, const char* leaflist, Int_t compress)
       if ((*pos == ':') || (*pos == 0)) {
          // -- Reached end of a leaf spec, create a leaf.
          Int_t lenName = pos - nameBegin;
-         char* ctype = 0;
+         char* ctype = nullptr;
          if (lenName) {
             strncpy(leafname, nameBegin, lenName);
             leafname[lenName] = 0;
@@ -352,7 +352,7 @@ void TBranch::Init(const char* name, const char* leaflist, Int_t compress)
             Warning("TBranch","No name was given to the leaf number '%d' in the leaflist of the branch '%s'.",fNleaves,name);
             snprintf(leafname,640,"__noname%d",fNleaves);
          }
-         TLeaf* leaf = 0;
+         TLeaf* leaf = nullptr;
          if (leaftype[1] == '[' && !strchr(leaftype, ',')) {
             Warning("TBranch", "Array size for branch '%s' must be specified after leaf name, not after the type name!", name);
             // and continue for backward compatibility?
@@ -407,7 +407,7 @@ void TBranch::Init(const char* name, const char* leaflist, Int_t compress)
          }
          if (leaf->IsZombie()) {
             delete leaf;
-            leaf = 0;
+            leaf = nullptr;
             auto msg = "Illegal leaf: %s/%s. If this is a variable size C array it's possible that the branch holding the size is not available.";
             Error("TBranch", msg, name, leaflist);
             delete [] leafname;
@@ -438,9 +438,9 @@ void TBranch::Init(const char* name, const char* leaflist, Int_t compress)
       }
    }
    delete[] leafname;
-   leafname = 0;
+   leafname = nullptr;
    delete[] leaftype;
-   leaftype = 0;
+   leaftype = nullptr;
 
 }
 
@@ -450,25 +450,25 @@ void TBranch::Init(const char* name, const char* leaflist, Int_t compress)
 TBranch::~TBranch()
 {
    delete fBrowsables;
-   fBrowsables = 0;
+   fBrowsables = nullptr;
 
    // Note: We do *not* have ownership of the buffer.
-   fEntryBuffer = 0;
+   fEntryBuffer = nullptr;
 
    delete [] fBasketSeek;
-   fBasketSeek  = 0;
+   fBasketSeek  = nullptr;
 
    delete [] fBasketEntry;
-   fBasketEntry = 0;
+   fBasketEntry = nullptr;
 
    delete [] fBasketBytes;
-   fBasketBytes = 0;
+   fBasketBytes = nullptr;
 
    if (fExtraBasket && !fBaskets.Remove(fExtraBasket))
       delete fExtraBasket;
    fBaskets.Delete();
    fNBaskets = 0;
-   fCurrentBasket = 0;
+   fCurrentBasket = nullptr;
    fFirstBasketEntry = -1;
    fNextBasketEntry = -1;
 
@@ -504,16 +504,16 @@ TBranch::~TBranch()
       if (file){
          file->Close();
          delete file;
-         file = 0;
+         file = nullptr;
       }
    }
 
-   fTree = 0;
-   fDirectory = 0;
+   fTree = nullptr;
+   fDirectory = nullptr;
 
    if (fTransientBuffer) {
       delete fTransientBuffer;
-      fTransientBuffer = 0;
+      fTransientBuffer = nullptr;
    }
 }
 
@@ -593,7 +593,7 @@ void TBranch::AddBasket(TBasket& b, Bool_t ondisk, Long64_t startEntry)
    if (ondisk) {
       fBasketBytes[where] = basket->GetNbytes();  // not for in mem
       fBasketSeek[where] = basket->GetSeekKey();  // not for in mem
-      fBaskets.AddAtAndExpand(0, fWriteBasket);
+      fBaskets.AddAtAndExpand(nullptr, fWriteBasket);
       ++fWriteBasket;
    } else {
       ++fNBaskets;
@@ -632,7 +632,7 @@ void TBranch::AddLastBasket(Long64_t startEntry)
    // it, this likely to be from merging 'empty' branches (base class node and the likes)
    if (where) {
       fBasketEntry[where] = startEntry;
-      fBaskets.AddAtAndExpand(0,fWriteBasket);
+      fBaskets.AddAtAndExpand(nullptr,fWriteBasket);
    }
 }
 
@@ -779,7 +779,7 @@ void TBranch::DropBaskets(Option_t* options)
          --fNBaskets;
          fBaskets.RemoveAt(i);
          if (basket == fCurrentBasket) {
-            fCurrentBasket    = 0;
+            fCurrentBasket    = nullptr;
             fFirstBasketEntry = -1;
             fNextBasketEntry  = -1;
          }
@@ -804,12 +804,12 @@ void TBranch::DropBaskets(Option_t* options)
          if (basket && fBasketBytes[i]!=0) {
             basket->DropBuffers();
             if (basket == fCurrentBasket) {
-               fCurrentBasket    = 0;
+               fCurrentBasket    = nullptr;
                fFirstBasketEntry = -1;
                fNextBasketEntry  = -1;
             }
             delete basket;
-            fBaskets.AddAt(0,i);
+            fBaskets.AddAt(nullptr,i);
             fBaskets.SetLast(-1);
             fNBaskets = 0;
          }
@@ -1051,7 +1051,7 @@ TBranch* TBranch::FindBranch(const char* name)
    UInt_t namelen = strlen(name);
 
    Int_t nbranches = fBranches.GetEntries();
-   TBranch* branch = 0;
+   TBranch* branch = nullptr;
    for(Int_t i = 0; i < nbranches; ++i) {
       branch = (TBranch*) fBranches.UncheckedAt(i);
 
@@ -1072,7 +1072,7 @@ TBranch* TBranch::FindBranch(const char* name)
          return branch;
       }
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1087,7 +1087,7 @@ TLeaf* TBranch::FindLeaf(const char* searchname)
 
    // We allow the user to pass only the last dotted component of the name.
    TIter next(GetListOfLeaves());
-   TLeaf* leaf = 0;
+   TLeaf* leaf = nullptr;
    while ((leaf = (TLeaf*) next())) {
       leafname = leaf->GetName();
       Ssiz_t dim = leafname.First('[');
@@ -1126,7 +1126,7 @@ TLeaf* TBranch::FindLeaf(const char* searchname)
          if (strstr(searchname, ".") && !strcmp(searchname, branch->GetName())) return leaf;
       }
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1203,13 +1203,13 @@ Int_t TBranch::FlushOneBasket(UInt_t ibasket)
             } else {
                basket->DropBuffers();
                if (basket == fCurrentBasket) {
-                  fCurrentBasket    = 0;
+                  fCurrentBasket    = nullptr;
                   fFirstBasketEntry = -1;
                   fNextBasketEntry  = -1;
                }
                delete basket;
                --fNBaskets;
-               fBaskets[ibasket] = 0;
+               fBaskets[ibasket] = nullptr;
             }
          }
       }
@@ -1232,15 +1232,15 @@ TBasket* TBranch::GetBasketImpl(Int_t basketnumber, TBuffer *user_buffer)
    static std::atomic<Int_t> nerrors(0);
 
       // reference to an existing basket in memory ?
-   if (basketnumber <0 || basketnumber > fWriteBasket) return 0;
+   if (basketnumber <0 || basketnumber > fWriteBasket) return nullptr;
    TBasket *basket = (TBasket*)fBaskets.UncheckedAt(basketnumber);
    if (basket) return basket;
-   if (basketnumber == fWriteBasket) return 0;
+   if (basketnumber == fWriteBasket) return nullptr;
 
    // create/decode basket parameters from buffer
    TFile *file = GetFile(0);
-   if (file == 0) {
-      return 0;
+   if (file == nullptr) {
+      return nullptr;
    }
    // if cluster pre-fetching or retaining is on, do not re-use existing baskets
    // unless a new cluster is used.
@@ -1268,21 +1268,21 @@ TBasket* TBranch::GetBasketImpl(Int_t basketnumber, TBuffer *user_buffer)
    Int_t badread = basket->ReadBasketBuffers(fBasketSeek[basketnumber],fBasketBytes[basketnumber],file);
    if (R__unlikely(badread || basket->GetSeekKey() != fBasketSeek[basketnumber] || basket->IsZombie())) {
       nerrors++;
-      if (nerrors > 10) return 0;
+      if (nerrors > 10) return nullptr;
       if (nerrors == 10) {
          printf(" file probably overwritten: stopping reporting error messages\n");
          if (fBasketSeek[basketnumber] > 2000000000) {
             printf("===>File is more than 2 Gigabytes\n");
-            return 0;
+            return nullptr;
          }
          if (fBasketSeek[basketnumber] > 1000000000) {
             printf("===>Your file is may be bigger than the maximum file size allowed on your system\n");
             printf("    Check your AFS maximum file size limit for example\n");
-            return 0;
+            return nullptr;
          }
       }
       Error("GetBasket","File: %s at byte:%lld, branch:%s, entry:%lld, badread=%d, nerrors=%d, basketnumber=%d",file->GetName(),basket->GetSeekKey(),GetName(),fReadEntry,badread,nerrors.load(),basketnumber);
-      return 0;
+      return nullptr;
    }
 
    ++fNBaskets;
@@ -1389,7 +1389,7 @@ Int_t TBranch::GetBasketAndFirst(TBasket *&basket, Long64_t &first,
       if (!basket) {
          basket = GetBasketImpl(fReadBasket, user_buffer);
          if (!basket) {
-            fCurrentBasket = 0;
+            fCurrentBasket = nullptr;
             fFirstBasketEntry = -1;
             fNextBasketEntry = -1;
             return -2;
@@ -1833,7 +1833,7 @@ Int_t TBranch::GetEntryExport(Long64_t entry, Int_t /*getall*/, TClonesArray* li
 
 Int_t TBranch::GetExpectedType(TClass *&expectedClass,EDataType &expectedType)
 {
-   expectedClass = 0;
+   expectedClass = nullptr;
    expectedType = kOther_t;
    TLeaf* l = (TLeaf*) GetListOfLeaves()->At(0);
    if (l) {
@@ -1855,7 +1855,7 @@ TFile* TBranch::GetFile(Int_t mode)
    if (fDirectory) return fDirectory->GetFile();
 
    // check if a file with this name is in the list of Root files
-   TFile *file = 0;
+   TFile *file = nullptr;
    {
       R__LOCKGUARD(gROOTMutex);
       file = (TFile*)gROOT->GetListOfFiles()->FindObject(fFileName.Data());
@@ -1865,7 +1865,7 @@ TFile* TBranch::GetFile(Int_t mode)
       }
    }
 
-   if (fFileName.Length() == 0) return 0;
+   if (fFileName.Length() == 0) return nullptr;
 
    TString bFileName( GetRealFileName() );
 
@@ -1875,8 +1875,8 @@ TFile* TBranch::GetFile(Int_t mode)
       if (mode) file = TFile::Open(bFileName, "recreate");
       else      file = TFile::Open(bFileName);
    }
-   if (!file) return 0;
-   if (file->IsZombie()) {delete file; return 0;}
+   if (!file) return nullptr;
+   if (file->IsZombie()) {delete file; return nullptr;}
    fDirectory = (TDirectory*)file;
    return file;
 }
@@ -1893,7 +1893,7 @@ TFile* TBranch::GetFile(Int_t mode)
 
 TBasket* TBranch::GetFreshBasket(Int_t basketnumber, TBuffer* user_buffer)
 {
-   TBasket *basket = 0;
+   TBasket *basket = nullptr;
    if (user_buffer && fExtraBasket) {
       basket = fExtraBasket;
       fExtraBasket = nullptr;
@@ -1913,11 +1913,11 @@ TBasket* TBranch::GetFreshBasket(Int_t basketnumber, TBuffer* user_buffer)
             }
             if (basket && fBasketBytes[oldindex]!=0) {
                if (basket == fCurrentBasket) {
-                  fCurrentBasket    = 0;
+                  fCurrentBasket    = nullptr;
                   fFirstBasketEntry = -1;
                   fNextBasketEntry  = -1;
                }
-               fBaskets.AddAt(0,oldindex);
+               fBaskets.AddAt(nullptr,oldindex);
                fBaskets.SetLast(-1);
                fNBaskets = 0;
                basket->ReadResetBuffer(basketnumber);
@@ -1952,7 +1952,7 @@ TBasket* TBranch::GetFreshBasket(Int_t basketnumber, TBuffer* user_buffer)
 
 TBasket *TBranch::GetFreshCluster(TBuffer* user_buffer)
 {
-   TBasket *basket = 0;
+   TBasket *basket = nullptr;
 
    auto CreateOrReuseBasket = [this, user_buffer]() -> TBasket* {
       TBasket *newbasket = nullptr;
@@ -1999,7 +1999,7 @@ TBasket *TBranch::GetFreshCluster(TBuffer* user_buffer)
    // exist, create a new one
    basket = (TBasket *)fBaskets.UncheckedAt(basketToUnload);
    if (basket) {
-      fBaskets.AddAt(0, basketToUnload);
+      fBaskets.AddAt(nullptr, basketToUnload);
       --fNBaskets;
    } else {
       basket = CreateOrReuseBasket();
@@ -2016,7 +2016,7 @@ TBasket *TBranch::GetFreshCluster(TBuffer* user_buffer)
       if (oldbasket) {
          oldbasket->DropBuffers();
          delete oldbasket;
-         fBaskets.AddAt(0, basketToUnload);
+         fBaskets.AddAt(nullptr, basketToUnload);
          --fNBaskets;
       }
       ++basketToUnload;
@@ -2059,7 +2059,7 @@ TLeaf* TBranch::GetLeaf(const char* name) const
       TLeaf *leaf = (TLeaf*)fLeaves.UncheckedAt(i);
       if (!strcmp(leaf->GetName(),name)) return leaf;
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2154,7 +2154,7 @@ TBranch* TBranch::GetMother() const
          return branch;
       }
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2192,7 +2192,7 @@ TBranch* TBranch::GetSubBranch(const TBranch* child) const
       }
    }
    // We failed to find the parent.
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2507,7 +2507,7 @@ void TBranch::FillLeavesImpl(TBuffer& b)
 
 void TBranch::Refresh(TBranch* b)
 {
-   if (b==0) return;
+   if (b==nullptr) return;
 
    fEntryOffsetLen = b->fEntryOffsetLen;
    fWriteBasket    = b->fWriteBasket;
@@ -2520,7 +2520,7 @@ void TBranch::Refresh(TBranch* b)
    fReadEntry      = -1;
    fFirstBasketEntry = -1;
    fNextBasketEntry  = -1;
-   fCurrentBasket    =  0;
+   fCurrentBasket    =  nullptr;
    delete [] fBasketBytes;
    delete [] fBasketEntry;
    delete [] fBasketSeek;
@@ -2560,7 +2560,7 @@ void TBranch::Reset(Option_t*)
    fReadEntry = -1;
    fFirstBasketEntry = -1;
    fNextBasketEntry = -1;
-   fCurrentBasket   = 0;
+   fCurrentBasket   = nullptr;
    fWriteBasket = 0;
    fEntries = 0;
    fTotBytes = 0;
@@ -2601,7 +2601,7 @@ void TBranch::ResetAfterMerge(TFileMergeInfo *)
    fReadEntry        = -1;
    fFirstBasketEntry = -1;
    fNextBasketEntry  = -1;
-   fCurrentBasket    = 0;
+   fCurrentBasket    = nullptr;
    fWriteBasket      = 0;
    fEntries          = 0;
    fTotBytes         = 0;
@@ -2628,11 +2628,11 @@ void TBranch::ResetAfterMerge(TFileMergeInfo *)
 
    TBasket *reusebasket = (TBasket*)fBaskets[fWriteBasket];
    if (reusebasket) {
-      fBaskets[fWriteBasket] = 0;
+      fBaskets[fWriteBasket] = nullptr;
    } else {
       reusebasket = (TBasket*)fBaskets[fReadBasket];
       if (reusebasket) {
-         fBaskets[fReadBasket] = 0;
+         fBaskets[fReadBasket] = nullptr;
       }
    }
    fBaskets.Delete();
@@ -2650,14 +2650,14 @@ void TBranch::ResetAfterMerge(TFileMergeInfo *)
 
 void TBranch::ResetAddress()
 {
-   fAddress = 0;
+   fAddress = nullptr;
 
    //  Reset last read entry number, we have will had new user object now.
    fReadEntry = -1;
 
    for (Int_t i = 0; i < fNleaves; ++i) {
       TLeaf* leaf = (TLeaf*) fLeaves.UncheckedAt(i);
-      leaf->SetAddress(0);
+      leaf->SetAddress(nullptr);
    }
 
    Int_t nbranches = fBranches.GetEntriesFast();
@@ -2695,7 +2695,7 @@ void TBranch::SetAddress(void* addr)
          offset = 0;
       }
       if (fAddress) leaf->SetAddress(fAddress + offset);
-      else leaf->SetAddress(0);
+      else leaf->SetAddress(nullptr);
    }
 }
 
@@ -2862,7 +2862,7 @@ void TBranch::SetEntries(Long64_t entries)
 
 void TBranch::SetFile(TFile* file)
 {
-   if (file == 0) file = fTree->GetCurrentFile();
+   if (file == nullptr) file = fTree->GetCurrentFile();
    fDirectory = (TDirectory*)file;
    if (file == fTree->GetCurrentFile()) fFileName = "";
    else                                 fFileName = file->GetName();
@@ -2908,7 +2908,7 @@ void TBranch::SetFile(TFile* file)
 void TBranch::SetFile(const char* fname)
 {
    fFileName  = fname;
-   fDirectory = 0;
+   fDirectory = nullptr;
 
    //apply to sub-branches as well
    TIter next(GetListOfBranches());
@@ -2957,13 +2957,13 @@ void TBranch::Streamer(TBuffer& b)
 {
    if (b.IsReading()) {
       UInt_t R__s, R__c;
-      fTree = 0; // Will be set by TTree::Streamer
-      fAddress = 0;
+      fTree = nullptr; // Will be set by TTree::Streamer
+      fAddress = nullptr;
       gROOT->SetReadingObject(kTRUE);
 
       // Reset transients.
       SetBit(TBranch::kDoNotUseBufferMap);
-      fCurrentBasket    = 0;
+      fCurrentBasket    = nullptr;
       fFirstBasketEntry = -1;
       fNextBasketEntry  = -1;
 
@@ -2974,7 +2974,7 @@ void TBranch::Streamer(TBuffer& b)
          if (fWriteBasket>=fBaskets.GetSize()) {
             fBaskets.Expand(fWriteBasket+1);
          }
-         fDirectory = 0;
+         fDirectory = nullptr;
          fNleaves = fLeaves.GetEntriesFast();
          for (Int_t i=0;i<fNleaves;i++) {
             TLeaf *leaf = (TLeaf*)fLeaves.UncheckedAt(i);
@@ -3054,7 +3054,7 @@ void TBranch::Streamer(TBuffer& b)
          }
          fFileName.Streamer(b);
          b.CheckByteCount(R__s, R__c, TBranch::IsA());
-         fDirectory = 0;
+         fDirectory = nullptr;
          fNleaves = fLeaves.GetEntriesFast();
          for (i=0;i<fNleaves;i++) {
             TLeaf *leaf = (TLeaf*)fLeaves.UncheckedAt(i);
@@ -3149,7 +3149,7 @@ void TBranch::Streamer(TBuffer& b)
       if (v > 2) {
          fFileName.Streamer(b);
       }
-      fDirectory = 0;
+      fDirectory = nullptr;
       if (v < 4) SetAutoDelete(kTRUE);
       if (!fSplitLevel && fBranches.GetEntriesFast()) fSplitLevel = 1;
       gROOT->SetReadingObject(kFALSE);
@@ -3220,10 +3220,10 @@ Int_t TBranch::WriteBasketImpl(TBasket* basket, Int_t where, ROOT::Internal::TBr
       fBasketBytes[where]  = basket->GetNbytes();
       fBasketSeek[where]   = basket->GetSeekKey();
       Int_t addbytes = basket->GetObjlen() + basket->GetKeylen();
-      TBasket *reusebasket = 0;
+      TBasket *reusebasket = nullptr;
       if (nout>0) {
          // The Basket was written so we can now safely reuse it.
-         fBaskets[where] = 0;
+         fBaskets[where] = nullptr;
 
          reusebasket = basket;
          reusebasket->WriteReset();
@@ -3246,7 +3246,7 @@ Int_t TBranch::WriteBasketImpl(TBasket* basket, Int_t where, ROOT::Internal::TBr
          if (reusebasket && reusebasket == fCurrentBasket) {
             // The 'current' basket has Reset, so if we need it we will need
             // to reload it.
-            fCurrentBasket    = 0;
+            fCurrentBasket    = nullptr;
             fFirstBasketEntry = -1;
             fNextBasketEntry  = -1;
          }
@@ -3254,10 +3254,10 @@ Int_t TBranch::WriteBasketImpl(TBasket* basket, Int_t where, ROOT::Internal::TBr
          fBasketEntry[fWriteBasket] = fEntryNumber;
       } else {
          --fNBaskets;
-         fBaskets[where] = 0;
+         fBaskets[where] = nullptr;
          basket->DropBuffers();
          if (basket == fCurrentBasket) {
-            fCurrentBasket    = 0;
+            fCurrentBasket    = nullptr;
             fFirstBasketEntry = -1;
             fNextBasketEntry  = -1;
          }

--- a/tree/tree/src/TBranchBrowsable.cxx
+++ b/tree/tree/src/TBranchBrowsable.cxx
@@ -117,7 +117,7 @@ void TVirtualBranchBrowsable::Browse(TBrowser *b)
       name.ReplaceAll(".@","@.");
       name.ReplaceAll("->@","@->");
 
-      TTree* tree=0;
+      TTree* tree=nullptr;
       if (!fBranch) {
          Error("Browse", "branch not set - might access wrong tree!");
          return;
@@ -161,8 +161,8 @@ TClass* TVirtualBranchBrowsable::GetCollectionContainedType(const TBranch* branc
                                                             const TVirtualBranchBrowsable* parent,
                                                             TClass* &contained)
 {
-   contained=0;
-   TClass* type=0;
+   contained=nullptr;
+   TClass* type=nullptr;
    if (parent)
       type=parent->GetClassType();
    else if (branch) {
@@ -177,7 +177,7 @@ TClass* TVirtualBranchBrowsable::GetCollectionContainedType(const TBranch* branc
 
          // check if we're in a sub-branch of this class
          // we can only find out asking the streamer given our ID
-         TStreamerElement *element=0;
+         TStreamerElement *element=nullptr;
          if (be->GetID()>=0 && be->GetInfo()
             && (be->GetID() < be->GetInfo()->GetNelement())
             && be->GetInfo()->IsCompiled()
@@ -200,16 +200,16 @@ TClass* TVirtualBranchBrowsable::GetCollectionContainedType(const TBranch* branc
          // could be an unsplit TClonesArray
          TBranchObject* bo=(TBranchObject*)branch;
          const char* clonesname=bo->GetClassName();
-         contained=0;
-         if (!clonesname || !clonesname[0]) return 0;
+         contained=nullptr;
+         if (!clonesname || !clonesname[0]) return nullptr;
          type=TClass::GetClass(clonesname);
       }
    } else {
       ::Warning("TVirtualBranchBrowsable::GetCollectionContainedType", "Neither branch nor parent given!");
-      return 0;
+      return nullptr;
    }
 
-   if (!type) return 0;
+   if (!type) return nullptr;
 
    TBranch* branchNonCost=const_cast<TBranch*>(branch);
    if (type->InheritsFrom(TClonesArray::Class())
@@ -260,9 +260,9 @@ TClass* TVirtualBranchBrowsable::GetCollectionContainedType(const TBranch* branc
       return type;
    } else if (type->InheritsFrom(TRef::Class()))
       // we don't do TRefs, so return contained and container as 0
-      return 0;
+      return nullptr;
    else contained=type;
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -408,7 +408,7 @@ ClassImp(TMethodBrowsable);
 
 TMethodBrowsable::TMethodBrowsable(const TBranch* branch, TMethod* m,
                                    const TVirtualBranchBrowsable* parent /* =0 */):
-   TVirtualBranchBrowsable(branch, 0, kFALSE, parent), fMethod(m)
+   TVirtualBranchBrowsable(branch, nullptr, kFALSE, parent), fMethod(m)
 {
    TString name(m->GetName());
    name+="()";
@@ -475,7 +475,7 @@ void TMethodBrowsable::GetBrowsableMethodsForClass(TClass* cl, TList& li)
    while ((cl=(TClass*)iC())) {
       TList* methods=cl->GetListOfMethods();
       if (!methods) continue;
-      TMethod* method=0;
+      TMethod* method=nullptr;
       TIter iM(methods);
       while ((method=(TMethod*)iM()))
          if (method && !allMethods.FindObject(method->GetName()))
@@ -483,7 +483,7 @@ void TMethodBrowsable::GetBrowsableMethodsForClass(TClass* cl, TList& li)
    }
 
    TIter iM(&allMethods);
-   TMethod* m=0;
+   TMethod* m=nullptr;
    while ((m=(TMethod*)iM())) {
       if (TMethodBrowsable::IsMethodBrowsable(m)) {
          li.Add(m);
@@ -509,7 +509,7 @@ Int_t TMethodBrowsable::GetBrowsables(TList& li, const TBranch* branch,
 
    TList listMethods;
    GetBrowsableMethodsForClass(cl, listMethods);
-   TMethod* method=0;
+   TMethod* method=nullptr;
    TIter iMethods(&listMethods);
    while ((method=(TMethod*)iMethods())) {
       li.Add(new TMethodBrowsable(branch, method, parent));
@@ -568,7 +568,7 @@ Bool_t TMethodBrowsable::IsMethodBrowsable(const TMethod* m)
          baseName+=3;
       if (!baseName[0]) return kTRUE;
 
-      TObject* mem=0;
+      TObject* mem=nullptr;
       const char* arrMemberNames[3]={"f%s","_%s","m%s"};
       for (Int_t i=0; !mem && i<3; i++)
          mem=members->FindObject(TString::Format(arrMemberNames[i],baseName));
@@ -636,8 +636,8 @@ Int_t TNonSplitBrowsable::GetBrowsables(TList& li, const TBranch* branch,
                                         const TVirtualBranchBrowsable* parent /* =0 */)
 {
    // branch has to be unsplit, i.e. without sub-branches
-   if (parent==0
-       && (branch==0 ||
+   if (parent==nullptr
+       && (branch==nullptr ||
            (const_cast<TBranch*>(branch)->GetListOfBranches()
             && const_cast<TBranch*>(branch)->GetListOfBranches()->GetEntries()!=0)
            )
@@ -647,9 +647,9 @@ Int_t TNonSplitBrowsable::GetBrowsables(TList& li, const TBranch* branch,
    // we only expand our own parents
    //if (parent && parent->IsA()!=TNonSplitBrowsable::Class()) return 0;
 
-   TClass* clContained=0;
+   TClass* clContained=nullptr;
    GetCollectionContainedType(branch, parent, clContained);
-   TVirtualStreamerInfo* streamerInfo= clContained?clContained->GetStreamerInfo():0;
+   TVirtualStreamerInfo* streamerInfo= clContained?clContained->GetStreamerInfo():nullptr;
    if (!streamerInfo
       || !streamerInfo->GetElements()
       || !streamerInfo->GetElements()->GetSize())  return 0;
@@ -661,7 +661,7 @@ Int_t TNonSplitBrowsable::GetBrowsables(TList& li, const TBranch* branch,
    myStreamerElementsToCheck.AddAll(streamerInfo->GetElements());
 
    Int_t numAdded=0;
-   TStreamerElement* streamerElement=0;
+   TStreamerElement* streamerElement=nullptr;
    for (TObjLink *link = myStreamerElementsToCheck.FirstLink();
         link;
         link = link->Next() ) {
@@ -678,7 +678,7 @@ Int_t TNonSplitBrowsable::GetBrowsables(TList& li, const TBranch* branch,
          TObjArray* baseElements=base->GetStreamerInfo()->GetElements();
          if (!baseElements) continue;
          TIter iBaseSE(baseElements);
-         TStreamerElement* baseSE=0;
+         TStreamerElement* baseSE=nullptr;
          while ((baseSE=(TStreamerElement*)iBaseSE()))
             // we should probably check whether we're replacing something here...
             myStreamerElementsToCheck.Add(baseSE);
@@ -687,15 +687,15 @@ Int_t TNonSplitBrowsable::GetBrowsables(TList& li, const TBranch* branch,
          // this is a collection of the real elements.
          // So get the class ptr for these elements...
          TClass* clElements=streamerElement->GetClassPointer();
-         TVirtualCollectionProxy* collProxy=clElements?clElements->GetCollectionProxy():0;
-         clElements=collProxy?collProxy->GetValueClass():0;
+         TVirtualCollectionProxy* collProxy=clElements?clElements->GetCollectionProxy():nullptr;
+         clElements=collProxy?collProxy->GetValueClass():nullptr;
          if (!clElements) continue;
 
          // now loop over the class's streamer elements
          streamerInfo = clElements->GetStreamerInfo();
          if (streamerInfo) {
             TIter iElem(streamerInfo->GetElements());
-            TStreamerElement* elem=0;
+            TStreamerElement* elem=nullptr;
             while ((elem=(TStreamerElement*)iElem())) {
                TNonSplitBrowsable* nsb=new TNonSplitBrowsable(elem, branch, parent);
                li.Add(nsb);
@@ -777,7 +777,7 @@ void TCollectionPropertyBrowsable::Browse(TBrowser *b)
 Int_t TCollectionPropertyBrowsable::GetBrowsables(TList& li, const TBranch* branch,
                                                   const TVirtualBranchBrowsable* parent /* =0 */)
 {
-   TClass* clContained=0;
+   TClass* clContained=nullptr;
    TClass* clCollection=GetCollectionContainedType(branch, parent, clContained);
    if (!clCollection || !clContained) return 0;
 
@@ -835,9 +835,9 @@ Int_t TCollectionPropertyBrowsable::GetBrowsables(TList& li, const TBranch* bran
 
       TCollectionPropertyBrowsable* cpb;
       if ( clCollection->GetCollectionProxy() &&
-           ( (clCollection->GetCollectionProxy()->GetValueClass()==0)
-           ||(clCollection->GetCollectionProxy()->GetValueClass()->GetCollectionProxy()!=0
-              && clCollection->GetCollectionProxy()->GetValueClass()->GetCollectionProxy()->GetValueClass()==0)
+           ( (clCollection->GetCollectionProxy()->GetValueClass()==nullptr)
+           ||(clCollection->GetCollectionProxy()->GetValueClass()->GetCollectionProxy()!=nullptr
+              && clCollection->GetCollectionProxy()->GetValueClass()->GetCollectionProxy()->GetValueClass()==nullptr)
             )) {
          // If the contained type is not a class, we need an explicit handle to get to the data.
          cpb = new TCollectionPropertyBrowsable("values", "values in the container",
@@ -925,14 +925,14 @@ TMethodBrowsable(branch, m, parent)
 Int_t TCollectionMethodBrowsable::GetBrowsables(TList& li, const TBranch* branch,
                                                 const TVirtualBranchBrowsable* parent /*=0*/)
 {
-   TClass* clContained=0;
+   TClass* clContained=nullptr;
    // we don't care about the contained class, but only about the collections,
    TClass* clContainer=GetCollectionContainedType(branch, parent, clContained);
    if (!clContainer || !clContained) return 0;
 
    TList listMethods;
    GetBrowsableMethodsForClass(clContainer, listMethods);
-   TMethod* method=0;
+   TMethod* method=nullptr;
    TIter iMethods(&listMethods);
    while ((method=(TMethod*)iMethods()))
       li.Add(new TCollectionMethodBrowsable(branch, method, parent));

--- a/tree/tree/src/TBranchClones.cxx
+++ b/tree/tree/src/TBranchClones.cxx
@@ -39,11 +39,11 @@ See TTree.
 
 TBranchClones::TBranchClones()
 : TBranch()
-, fList(0)
+, fList(nullptr)
 , fRead(0)
 , fN(0)
 , fNdataMax(0)
-, fBranchCount(0)
+, fBranchCount(nullptr)
 {
 }
 
@@ -52,13 +52,13 @@ TBranchClones::TBranchClones()
 
 TBranchClones::TBranchClones(TTree *tree, const char* name, void* pointer, Int_t basketsize, Int_t compress, Int_t splitlevel)
 : TBranch()
-, fList(0)
+, fList(nullptr)
 , fRead(0)
 , fN(0)
 , fNdataMax(0)
-, fBranchCount(0)
+, fBranchCount(nullptr)
 {
-   Init(tree,0,name,pointer,basketsize,compress,splitlevel);
+   Init(tree,nullptr,name,pointer,basketsize,compress,splitlevel);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -66,13 +66,13 @@ TBranchClones::TBranchClones(TTree *tree, const char* name, void* pointer, Int_t
 
 TBranchClones::TBranchClones(TBranch *parent, const char* name, void* pointer, Int_t basketsize, Int_t compress, Int_t splitlevel)
 : TBranch()
-, fList(0)
+, fList(nullptr)
 , fRead(0)
 , fN(0)
 , fNdataMax(0)
-, fBranchCount(0)
+, fBranchCount(nullptr)
 {
-   Init(0,parent,name,pointer,basketsize,compress,splitlevel);
+   Init(nullptr,parent,name,pointer,basketsize,compress,splitlevel);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -80,7 +80,7 @@ TBranchClones::TBranchClones(TBranch *parent, const char* name, void* pointer, I
 
 void TBranchClones::Init(TTree *tree, TBranch *parent, const char* name, void* pointer, Int_t basketsize, Int_t compress, Int_t splitlevel)
 {
-   if (tree==0 && parent!=0) tree = parent->GetTree();
+   if (tree==nullptr && parent!=nullptr) tree = parent->GetTree();
    fTree   = tree;
    fMother = parent ? parent->GetMother() : this;
    fParent = parent;
@@ -90,7 +90,7 @@ void TBranchClones::Init(TTree *tree, TBranch *parent, const char* name, void* p
    TString branchcount;
    SetName(name);
    if ((compress == -1) && tree->GetDirectory()) {
-      TFile* bfile = 0;
+      TFile* bfile = nullptr;
       if (tree->GetDirectory()) {
          bfile = tree->GetDirectory()->GetFile();
       }
@@ -123,8 +123,8 @@ void TBranchClones::Init(TTree *tree, TBranch *parent, const char* name, void* p
    fFileName = "";
 
    // Loop on all public data members of the class and its base classes.
-   const char* itype = 0;
-   TRealData* rd = 0;
+   const char* itype = nullptr;
+   TRealData* rd = nullptr;
    TIter next(cl->GetListOfRealData());
    while ((rd = (TRealData *) next())) {
       if (rd->TestBit(TRealData::kTransient)) continue;
@@ -205,10 +205,10 @@ void TBranchClones::Init(TTree *tree, TBranch *parent, const char* name, void* p
 TBranchClones::~TBranchClones()
 {
    delete fBranchCount;
-   fBranchCount = 0;
+   fBranchCount = nullptr;
    fBranches.Delete();
    // FIXME: We might own this, possible memory leak.
-   fList = 0;
+   fList = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -275,7 +275,7 @@ Int_t TBranchClones::GetEntry(Long64_t entry, Int_t getall)
       }
       return 0;
    }
-   TBranch* branch = 0;
+   TBranch* branch = nullptr;
    Int_t nbranches = fBranches.GetEntriesFast();
    // If fList exists, create clones array objects.
    if (fList) {
@@ -356,11 +356,11 @@ void TBranchClones::SetAddress(void* addr)
    fReadEntry = -1;
    fAddress = (char*) addr;
    char** pp= (char**) fAddress;
-   if (pp && (*pp == 0)) {
+   if (pp && (*pp == nullptr)) {
       // We've been asked to allocate an object for the user.
       *pp= (char*) new TClonesArray(fClassName);
    }
-   fList = 0;
+   fList = nullptr;
    if (pp) {
       fList = (TClonesArray*) *pp;
    }
@@ -403,9 +403,9 @@ void TBranchClones::Streamer(TBuffer& b)
       b >> fBranchCount;
       fClassName.Streamer(b);
       fBranches.Streamer(b);
-      fTree = 0;
-      TBranch* branch = 0;
-      TLeaf* leaf = 0;
+      fTree = nullptr;
+      TBranch* branch = nullptr;
+      TLeaf* leaf = nullptr;
       Int_t nbranches = fBranches.GetEntriesFast();
       for (Int_t i = 0; i < nbranches; i++) {
          branch = (TBranch*) fBranches[i];
@@ -424,7 +424,7 @@ void TBranchClones::Streamer(TBuffer& b)
          cl->BuildRealData();
       }
       TString branchname;
-      TRealData* rd = 0;
+      TRealData* rd = nullptr;
       TIter next(cl->GetListOfRealData());
       while ((rd = (TRealData*) next())) {
          if (rd->TestBit(TRealData::kTransient)) continue;

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -90,7 +90,7 @@ void TBranchElement::SwitchContainer(TObjArray* branches) {
          case 31: br->SetType(41); break;
          case 41: {
             br->SetType(31);
-            br->fCollProxy = 0;
+            br->fCollProxy = nullptr;
             break;
          }
       }
@@ -135,7 +135,7 @@ TBranchElement::TBranchElement()
 , fClassName()
 , fParentName()
 , fClonesName()
-, fCollProxy(0)
+, fCollProxy(nullptr)
 , fCheckSum(0)
 , fClassVersion(0)
 , fID(0)
@@ -144,11 +144,11 @@ TBranchElement::TBranchElement()
 , fMaximum(0)
 , fSTLtype(ROOT::kNotSTL)
 , fNdata(1)
-, fBranchCount(0)
-, fBranchCount2(0)
-, fInfo(0)
-, fObject(0)
-, fOnfileObject(0)
+, fBranchCount(nullptr)
+, fBranchCount2(nullptr)
+, fInfo(nullptr)
+, fObject(nullptr)
+, fOnfileObject(nullptr)
 , fInit(kFALSE)
 , fInInitInfo(kFALSE)
 , fInitOffsets(kFALSE)
@@ -157,13 +157,13 @@ TBranchElement::TBranchElement()
 , fParentClass()
 , fBranchClass()
 , fClonesClass()
-, fBranchOffset(0)
+, fBranchOffset(nullptr)
 , fBranchID(-1)
-, fReadActionSequence(0)
-, fFillActionSequence(0)
-, fIterators(0)
-, fWriteIterators(0)
-, fPtrIterators(0)
+, fReadActionSequence(nullptr)
+, fFillActionSequence(nullptr)
+, fIterators(nullptr)
+, fWriteIterators(nullptr)
+, fPtrIterators(nullptr)
 {
    fNleaves = 0;
    fReadLeaves = (ReadLeaves_t)&TBranchElement::ReadLeavesImpl;
@@ -180,7 +180,7 @@ TBranchElement::TBranchElement(TTree *tree, const char* bname, TStreamerInfo* si
 , fClassName(sinfo->GetName())
 , fParentName()
 , fClonesName()
-, fCollProxy(0)
+, fCollProxy(nullptr)
 , fCheckSum(sinfo->GetCheckSum())
 , fClassVersion(sinfo->GetClass()->GetClassVersion())
 , fID(id)
@@ -189,11 +189,11 @@ TBranchElement::TBranchElement(TTree *tree, const char* bname, TStreamerInfo* si
 , fMaximum(0)
 , fSTLtype(ROOT::kNotSTL)
 , fNdata(1)
-, fBranchCount(0)
-, fBranchCount2(0)
+, fBranchCount(nullptr)
+, fBranchCount2(nullptr)
 , fInfo(sinfo)
-, fObject(0)
-, fOnfileObject(0)
+, fObject(nullptr)
+, fOnfileObject(nullptr)
 , fInit(kTRUE)
 , fInInitInfo(kFALSE)
 , fInitOffsets(kFALSE)
@@ -202,19 +202,19 @@ TBranchElement::TBranchElement(TTree *tree, const char* bname, TStreamerInfo* si
 , fParentClass()
 , fBranchClass(sinfo->GetClass())
 , fClonesClass()
-, fBranchOffset(0)
+, fBranchOffset(nullptr)
 , fBranchID(-1)
-, fReadActionSequence(0)
-, fFillActionSequence(0)
-, fIterators(0)
-, fWriteIterators(0)
-, fPtrIterators(0)
+, fReadActionSequence(nullptr)
+, fFillActionSequence(nullptr)
+, fIterators(nullptr)
+, fWriteIterators(nullptr)
+, fPtrIterators(nullptr)
 {
    if (tree) {
       ROOT::TIOFeatures features = tree->GetIOFeatures();
       SetIOFeatures(features);
    }
-   Init(tree, 0, bname,sinfo,id,pointer,basketsize,splitlevel,btype);
+   Init(tree, nullptr, bname,sinfo,id,pointer,basketsize,splitlevel,btype);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -227,7 +227,7 @@ TBranchElement::TBranchElement(TBranch *parent, const char* bname, TStreamerInfo
 , fClassName(sinfo->GetName())
 , fParentName()
 , fClonesName()
-, fCollProxy(0)
+, fCollProxy(nullptr)
 , fCheckSum(sinfo->GetCheckSum())
 , fClassVersion(sinfo->GetClass()->GetClassVersion())
 , fID(id)
@@ -236,11 +236,11 @@ TBranchElement::TBranchElement(TBranch *parent, const char* bname, TStreamerInfo
 , fMaximum(0)
 , fSTLtype(ROOT::kNotSTL)
 , fNdata(1)
-, fBranchCount(0)
-, fBranchCount2(0)
+, fBranchCount(nullptr)
+, fBranchCount2(nullptr)
 , fInfo(sinfo)
-, fObject(0)
-, fOnfileObject(0)
+, fObject(nullptr)
+, fOnfileObject(nullptr)
 , fInit(kTRUE)
 , fInInitInfo(kFALSE)
 , fInitOffsets(kFALSE)
@@ -249,17 +249,17 @@ TBranchElement::TBranchElement(TBranch *parent, const char* bname, TStreamerInfo
 , fParentClass()
 , fBranchClass(sinfo->GetClass())
 , fClonesClass()
-, fBranchOffset(0)
+, fBranchOffset(nullptr)
 , fBranchID(-1)
-, fReadActionSequence(0)
-, fFillActionSequence(0)
-, fIterators(0)
-, fWriteIterators(0)
-, fPtrIterators(0)
+, fReadActionSequence(nullptr)
+, fFillActionSequence(nullptr)
+, fIterators(nullptr)
+, fWriteIterators(nullptr)
+, fPtrIterators(nullptr)
 {
    ROOT::TIOFeatures features = parent->GetIOFeatures();
    SetIOFeatures(features);
-   Init(parent ? parent->GetTree() : 0, parent, bname,sinfo,id,pointer,basketsize,splitlevel,btype);
+   Init(parent ? parent->GetTree() : nullptr, parent, bname,sinfo,id,pointer,basketsize,splitlevel,btype);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -278,7 +278,7 @@ void TBranchElement::Init(TTree *tree, TBranch *parent,const char* bname, TStrea
    // Set our TBranch attributes.
    fSplitLevel = splitlevel;
    fTree   = tree;
-   if (fTree == 0) return;
+   if (fTree == nullptr) return;
    fMother = parent ? parent->GetMother() : this;
    fParent = parent;
    fDirectory = fTree->GetDirectory();
@@ -356,7 +356,7 @@ void TBranchElement::Init(TTree *tree, TBranch *parent,const char* bname, TStrea
    // We need to keep track of the counter branch if we have
    // one, since we cannot set it until we have created our
    // leaf, which we do last.
-   TBranchElement* brOfCounter = 0;
+   TBranchElement* brOfCounter = nullptr;
 
    if (id < 0) {
       // -- We are a top-level branch.  Don't split a top-level branch, TTree::Bronch will do that work.
@@ -368,7 +368,7 @@ void TBranchElement::Init(TTree *tree, TBranch *parent,const char* bname, TStrea
             hasCustomStreamer = (!fBranchClass.GetClass()->GetCollectionProxy() && fBranchClass.GetClass()->TestBit(TClass::kHasCustomStreamerMember));
          } else {
             if (canSelfReference) SetBit(kBranchAny);
-            hasCustomStreamer = !fBranchClass.GetClass()->GetCollectionProxy() && (fBranchClass.GetClass()->GetStreamer() != 0 || fBranchClass.GetClass()->TestBit(TClass::kHasCustomStreamerMember));
+            hasCustomStreamer = !fBranchClass.GetClass()->GetCollectionProxy() && (fBranchClass.GetClass()->GetStreamer() != nullptr || fBranchClass.GetClass()->TestBit(TClass::kHasCustomStreamerMember));
          }
          if (hasCustomStreamer) {
             fType = -1;
@@ -672,13 +672,13 @@ TBranchElement::TBranchElement(TTree *tree, const char* bname, TClonesArray* clo
 , fParentClass()
 , fBranchClass(TClonesArray::Class())
 , fBranchID(-1)
-, fReadActionSequence(0)
-, fFillActionSequence(0)
-, fIterators(0)
-, fWriteIterators(0)
-, fPtrIterators(0)
+, fReadActionSequence(nullptr)
+, fFillActionSequence(nullptr)
+, fIterators(nullptr)
+, fWriteIterators(nullptr)
+, fPtrIterators(nullptr)
 {
-   Init(tree, 0, bname, clones, basketsize, splitlevel, compress);
+   Init(tree, nullptr, bname, clones, basketsize, splitlevel, compress);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -699,13 +699,13 @@ TBranchElement::TBranchElement(TBranch *parent, const char* bname, TClonesArray*
 , fParentClass()
 , fBranchClass(TClonesArray::Class())
 , fBranchID(-1)
-, fReadActionSequence(0)
-, fFillActionSequence(0)
-, fIterators(0)
-, fWriteIterators(0)
-, fPtrIterators(0)
+, fReadActionSequence(nullptr)
+, fFillActionSequence(nullptr)
+, fIterators(nullptr)
+, fWriteIterators(nullptr)
+, fPtrIterators(nullptr)
 {
-   Init(parent ? parent->GetTree() : 0, parent, bname, clones, basketsize, splitlevel, compress);
+   Init(parent ? parent->GetTree() : nullptr, parent, bname, clones, basketsize, splitlevel, compress);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -715,7 +715,7 @@ TBranchElement::TBranchElement(TBranch *parent, const char* bname, TClonesArray*
 
 void TBranchElement::Init(TTree *tree, TBranch *parent, const char* bname, TClonesArray* clones, Int_t basketsize, Int_t splitlevel, Int_t compress)
 {
-   fCollProxy = 0;
+   fCollProxy = nullptr;
    fSplitLevel    = splitlevel;
    fID            = 0;
    fInit          = kTRUE;
@@ -723,12 +723,12 @@ void TBranchElement::Init(TTree *tree, TBranch *parent, const char* bname, TClon
    fType          = 0;
    fClassVersion  = TClonesArray::Class()->GetClassVersion();
    fCheckSum      = fInfo->GetCheckSum();
-   fBranchCount   = 0;
-   fBranchCount2  = 0;
-   fObject        = 0;
-   fOnfileObject  = 0;
+   fBranchCount   = nullptr;
+   fBranchCount2  = nullptr;
+   fObject        = nullptr;
+   fOnfileObject  = nullptr;
    fMaximum       = 0;
-   fBranchOffset  = 0;
+   fBranchOffset  = nullptr;
    fSTLtype       = ROOT::kNotSTL;
    fInitOffsets   = kFALSE;
 
@@ -789,7 +789,7 @@ void TBranchElement::Init(TTree *tree, TBranch *parent, const char* bname, TClon
       SetTitle(branchname);
       leaf->SetName(branchname);
       leaf->SetTitle(branchname);
-      Unroll(name, clonesClass, clonesClass, 0, basketsize, splitlevel, 31);
+      Unroll(name, clonesClass, clonesClass, nullptr, basketsize, splitlevel, 31);
       BuildTitle(name);
       SetReadLeavesPtr();
       SetFillLeavesPtr();
@@ -826,13 +826,13 @@ TBranchElement::TBranchElement(TTree *tree, const char* bname, TVirtualCollectio
 , fParentClass()
 , fBranchClass(cont->GetCollectionClass())
 , fBranchID(-1)
-, fReadActionSequence(0)
-, fFillActionSequence(0)
-, fIterators(0)
-, fWriteIterators(0)
-, fPtrIterators(0)
+, fReadActionSequence(nullptr)
+, fFillActionSequence(nullptr)
+, fIterators(nullptr)
+, fWriteIterators(nullptr)
+, fPtrIterators(nullptr)
 {
-   Init(tree, 0, bname, cont, basketsize, splitlevel, compress);
+   Init(tree, nullptr, bname, cont, basketsize, splitlevel, compress);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -852,13 +852,13 @@ TBranchElement::TBranchElement(TBranch *parent, const char* bname, TVirtualColle
 , fParentClass()
 , fBranchClass(cont->GetCollectionClass())
 , fBranchID(-1)
-, fReadActionSequence(0)
-, fFillActionSequence(0)
-, fIterators(0)
-, fWriteIterators(0)
-, fPtrIterators(0)
+, fReadActionSequence(nullptr)
+, fFillActionSequence(nullptr)
+, fIterators(nullptr)
+, fWriteIterators(nullptr)
+, fPtrIterators(nullptr)
 {
-   Init(parent ? parent->GetTree() : 0, parent, bname, cont, basketsize, splitlevel, compress);
+   Init(parent ? parent->GetTree() : nullptr, parent, bname, cont, basketsize, splitlevel, compress);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -875,19 +875,19 @@ void TBranchElement::Init(TTree *tree, TBranch *parent, const char* bname, TVirt
    }
    fInitOffsets   = kFALSE;
    fSplitLevel    = splitlevel;
-   fInfo          = 0;
+   fInfo          = nullptr;
    fID            = -1;
    fInit          = kTRUE;
    fStreamerType  = -1; // TVirtualStreamerInfo::kSTLp;
    fType          = 0;
    fClassVersion  = cont->GetCollectionClass()->GetClassVersion();
    fCheckSum      = cont->GetCollectionClass()->GetCheckSum();
-   fBranchCount   = 0;
-   fBranchCount2  = 0;
-   fObject        = 0;
-   fOnfileObject  = 0;
+   fBranchCount   = nullptr;
+   fBranchCount2  = nullptr;
+   fObject        = nullptr;
+   fOnfileObject  = nullptr;
    fMaximum       = 0;
-   fBranchOffset  = 0;
+   fBranchOffset  = nullptr;
 
    //Must be set here so that write actions will be properly matched to the ReadLeavesPtr
    fSTLtype = cont->GetCollectionType();
@@ -953,7 +953,7 @@ void TBranchElement::Init(TTree *tree, TBranch *parent, const char* bname, TVirt
       SetTitle(branchname);
       leaf->SetName(branchname);
       leaf->SetTitle(branchname);
-      Unroll(name, valueClass, valueClass, 0, basketsize, splitlevel, 41);
+      Unroll(name, valueClass, valueClass, nullptr, basketsize, splitlevel, 41);
       BuildTitle(name);
       SetReadLeavesPtr();
       SetFillLeavesPtr();
@@ -977,23 +977,23 @@ TBranchElement::~TBranchElement()
    // Release any allocated I/O buffers.
    if (fOnfileObject && TestBit(kOwnOnfileObj)) {
       delete fOnfileObject;
-      fOnfileObject = 0;
+      fOnfileObject = nullptr;
    }
    ResetAddress();
 
    delete[] fBranchOffset;
-   fBranchOffset = 0;
+   fBranchOffset = nullptr;
 
-   fInfo = 0;
-   fBranchCount2 = 0;
-   fBranchCount = 0;
+   fInfo = nullptr;
+   fBranchCount2 = nullptr;
+   fBranchCount = nullptr;
 
    if (fType == 4 || fType == 0) {
       // Only the top level TBranchElement containing an STL container,
       // owns the collectionproxy.
       delete fCollProxy;
    }
-   fCollProxy = 0;
+   fCollProxy = nullptr;
 
    delete fReadActionSequence;
    delete fFillActionSequence;
@@ -1034,13 +1034,13 @@ void TBranchElement::Browse(TBrowser* b)
    Int_t nbranches = fBranches.GetEntriesFast();
    if (nbranches > 0) {
       TList persistentBranches;
-      TBranch* branch=0;
+      TBranch* branch=nullptr;
       TIter iB(&fBranches);
       while((branch=(TBranch*)iB())) {
          if (branch->IsFolder()) persistentBranches.Add(branch);
          else {
             // only show branches corresponding to persistent members
-            TClass* cl=0;
+            TClass* cl=nullptr;
             if (strlen(GetClonesName()))
                // this works both for top level branches and for sub-branches,
                // as GetClonesName() is properly updated for sub-branches
@@ -1050,8 +1050,8 @@ void TBranchElement::Browse(TBrowser* b)
 
                // check if we're in a sub-branch of this class
                // we can only find out asking the streamer given our ID
-               TStreamerElement *element=0;
-               TClass* clsub=0;
+               TStreamerElement *element=nullptr;
+               TClass* clsub=nullptr;
                if (fID>=0 && GetInfoImp()
                    && GetInfoImp()->IsCompiled()
                    && ((element=GetInfoImp()->GetElement(fID)))
@@ -1167,7 +1167,7 @@ void TBranchElement::BuildTitle(const char* name)
       bre->fCollProxy = GetCollectionProxy();
       bre->BuildTitle(name);
       const char* fin = strrchr(bre->GetTitle(), '.');
-      if (fin == 0) {
+      if (fin == nullptr) {
          continue;
       }
       // The branch counter for a sub-branch of a container is the container master branch.
@@ -1488,7 +1488,7 @@ void TBranchElement::FillLeavesCollectionSplitVectorPtrMember(TBuffer& b)
    }
 
    TVirtualCollectionIterators *iter = fBranchCount->fIterators;
-   R__ASSERT(0!=iter);
+   R__ASSERT(nullptr!=iter);
    b.ApplySequenceVecPtr(*fFillActionSequence,iter->fBegin,iter->fEnd);
 }
 
@@ -1549,7 +1549,7 @@ void TBranchElement::FillLeavesCollectionMember(TBuffer& b)
    }
 
    TVirtualCollectionIterators *iter = fBranchCount->fIterators;
-   R__ASSERT(0!=iter);
+   R__ASSERT(nullptr!=iter);
    b.ApplySequence(*fFillActionSequence,iter->fBegin,iter->fEnd);
 
 }
@@ -1580,7 +1580,7 @@ void TBranchElement::FillLeavesAssociativeCollectionMember(TBuffer& b)
    }
 
    TVirtualCollectionIterators *iter = fBranchCount->fWriteIterators;
-   R__ASSERT(0!=iter);
+   R__ASSERT(nullptr!=iter);
    b.ApplySequence(*fFillActionSequence,iter->fBegin,iter->fEnd);
 
 }
@@ -1634,7 +1634,7 @@ void TBranchElement::FillLeavesClonesMember(TBuffer& b)
       return;
    }
 
-   char **arr = (char **)clones->GetObjectRef(0);
+   char **arr = (char **)clones->GetObjectRef(nullptr);
    char **end = arr + n;
    b.ApplySequenceVecPtr(*fFillActionSequence,arr,end);
 }
@@ -1811,7 +1811,7 @@ TBranch* TBranchElement::FindBranch(const char *name)
 
          UInt_t namelen = strlen(name);
 
-         TBranch* branch = 0;
+         TBranch* branch = nullptr;
          Int_t nbranches = fBranches.GetEntries();
          for(Int_t i = 0; i < nbranches; ++i) {
             branch = (TBranch*) fBranches.UncheckedAt(i);
@@ -1873,22 +1873,22 @@ TLeaf* TBranchElement::FindLeaf(const char *name)
 {
    TLeaf *leaf = TBranch::FindLeaf(name);
 
-   if (leaf==0 && GetListOfLeaves()->GetEntries()==1) {
+   if (leaf==nullptr && GetListOfLeaves()->GetEntries()==1) {
       TBranch *br = GetMother()->GetSubBranch( this );
       if( br->IsA() != TBranchElement::Class() )
-         return 0;
+         return nullptr;
 
       TBranchElement *parent = (TBranchElement*)br;
-      if (parent==this || parent->GetID()<0 ) return 0;
+      if (parent==this || parent->GetID()<0 ) return nullptr;
 
       TVirtualStreamerInfo* si = parent->GetInfoImp();
       TStreamerElement* se = si->GetElement(parent->GetID());
 
-      if (! se->IsBase() ) return 0;
+      if (! se->IsBase() ) return nullptr;
 
       br = GetMother()->GetSubBranch( parent );
       if( br->IsA() != TBranchElement::Class() )
-         return 0;
+         return nullptr;
 
       TBranchElement *grand_parent = (TBranchElement*)br;
 
@@ -2125,7 +2125,7 @@ void TBranchElement::SetupInfo()
    // Check if we're dealing with the name change
    //////////////////////////////////////////////////////////////////////////
 
-   TClass* targetClass = 0;
+   TClass* targetClass = nullptr;
    if( fTargetClass.GetClassName()[0] ) {
       targetClass = fTargetClass;
       if (!targetClass && GetCollectionProxy()) {
@@ -2461,7 +2461,7 @@ void TBranchElement::InitInfo()
                // fID = -3;
                // SetBit(kDoNotProcess);
             }
-            if (fOnfileObject==0 && (fType==31 || fType==41 || (0 <= fType && fType <=2) ) && fInfo->GetNelement()
+            if (fOnfileObject==nullptr && (fType==31 || fType==41 || (0 <= fType && fType <=2) ) && fInfo->GetNelement()
                 && fInfo->GetElement(0)->GetType() == TStreamerInfo::kCacheNew)
             {
                SetOnfileObject(fInfo);
@@ -2532,7 +2532,7 @@ TVirtualCollectionProxy* TBranchElement::GetCollectionProxy()
    TBranchElement* thiscast = const_cast<TBranchElement*>(this);
    if (fType == 4) {
       // STL container top-level branch.
-      const char* className = 0;
+      const char* className = nullptr;
       TClass* cl = nullptr;
       if (fID < 0) {
          // We are a top-level branch.
@@ -2622,7 +2622,7 @@ TClass* TBranchElement::GetCurrentClass()
       return cl;
    }
    if (GetID() < 0 || GetID()>=brInfo->GetNelement()) {
-      return 0;
+      return nullptr;
    }
    TStreamerElement* currentStreamerElement = brInfo->GetElement(GetID());
    TDataMember* dm = (TDataMember*) motherCl->GetListOfDataMembers()->FindObject(currentStreamerElement->GetName());
@@ -2805,7 +2805,7 @@ Int_t TBranchElement::GetEntry(Long64_t entry, Int_t getall)
 
 Int_t TBranchElement::GetExpectedType(TClass *&expectedClass,EDataType &expectedType)
 {
-   expectedClass = 0;
+   expectedClass = nullptr;
    expectedType = kOther_t;
 
    Int_t type = GetStreamerType();
@@ -2915,7 +2915,7 @@ const char* TBranchElement::GetTypeName() const
             return fBranchClass.GetClass()->GetName();
          }
       } else {
-         return 0;
+         return nullptr;
       }
    }
    const char *types[20] = {
@@ -3013,7 +3013,7 @@ T TBranchElement::GetTypedValue(Int_t j, Int_t len, Bool_t subarr) const
       }
    }
 
-   if (object == 0)
+   if (object == nullptr)
    {
       // We have nowhere to read the data from (probably because the data member was
       // 'dropped' from the current schema).
@@ -3074,46 +3074,46 @@ void* TBranchElement::GetValuePointer() const
    }
    if (TestBit(kDecomposedObj)) {
       if (!fAddress) {
-         return 0;
+         return nullptr;
       }
       if (fType == 3) {    //top level branch of a TClonesArray
                            //return &fNdata;
-         return 0;
+         return nullptr;
       } else if (fType == 4) {    //top level branch of a TClonesArray
                                   //return &fNdata;
-         return 0;
+         return nullptr;
       } else if (fType == 31) {    // sub branch of a TClonesArray
                                    //Int_t atype = fStreamerType;
                                    //if (atype < 20) atype += 20;
                                    //return GetInfoImp()->GetValue(fAddress, atype, j, 1);
-         return 0;
+         return nullptr;
       } else if (fType == 41) {    // sub branch of a TClonesArray
                                    //Int_t atype = fStreamerType;
                                    //if (atype < 20) atype += 20;
                                    //return GetInfoImp()->GetValue(fAddress, atype, j, 1);
-         return 0;
+         return nullptr;
       } else if (fType <= 2) {     // branch in split mode
                                    // FIXME: This should probably be < 60 instead!
          if (fStreamerType > 40 && fStreamerType < 55) {
             //Int_t atype = fStreamerType - 20;
             //return GetInfoImp()->GetValue(fAddress, atype, j, 1);
-            return 0;
+            return nullptr;
          } else {
             //return GetInfoImp()->GetValue(object, fID, j, -1);
-            return 0;
+            return nullptr;
          }
       }
    }
 
    if (fType == 31) {
-      return 0;
+      return nullptr;
    } else if (fType == 41) {
-      return 0;
+      return nullptr;
    } else if (prID < 0) {
       return object;
    } else {
       //return GetInfoImp()->GetValue(object,fID,j,-1);
-      if (!GetInfoImp() || !object) return 0;
+      if (!GetInfoImp() || !object) return nullptr;
       char **val = (char**)(object+GetInfoImp()->TStreamerInfo::GetElementOffset(prID));
       return *val;
    }
@@ -3165,7 +3165,7 @@ void TBranchElement::InitializeOffsets()
    if (nbranches) {
       // Allocate space for the new sub-branch offsets.
       delete[] fBranchOffset;
-      fBranchOffset = 0;
+      fBranchOffset = nullptr;
       fBranchOffset = new Int_t[nbranches];
       // Make sure we can instantiate our class meta info.
       if (!fBranchClass.GetClass()) {
@@ -3185,7 +3185,7 @@ void TBranchElement::InitializeOffsets()
       // inside of our containing subobject (our local offset).
       // Note: branchElem stays zero if we are a top-level branch,
       //       we have to be careful about this later.
-      TStreamerElement* branchElem = 0;
+      TStreamerElement* branchElem = nullptr;
       Int_t localOffset = 0;
       TClass* branchClass = fBranchClass.GetClass();
       Bool_t renamed = kFALSE;
@@ -3219,7 +3219,7 @@ void TBranchElement::InitializeOffsets()
          localOffset = branchElem->GetOffset();
          branchClass = branchElem->GetClassPointer();
          if (localOffset == TStreamerInfo::kMissing) {
-            fObject = 0;
+            fObject = nullptr;
          } else {
             renamed = branchClass && branchElem->GetNewClass() && (branchClass != branchElem->GetNewClass());
          }
@@ -3255,7 +3255,7 @@ void TBranchElement::InitializeOffsets()
 
          fBranchOffset[subBranchIdx] = 0;
          TBranchElement* subBranch = dynamic_cast<TBranchElement*> (fBranches[subBranchIdx]);
-         if (subBranch == 0) {
+         if (subBranch == nullptr) {
             // -- Skip sub-branches that are not TBranchElements.
             continue;
          }
@@ -3313,7 +3313,7 @@ void TBranchElement::InitializeOffsets()
 
          localOffset = subBranchElement->GetOffset();
          if (localOffset == TStreamerInfo::kMissing) {
-            subBranch->fObject = 0;
+            subBranch->fObject = nullptr;
          }
          {
             Int_t streamerType = subBranchElement->GetType();
@@ -3538,7 +3538,7 @@ void TBranchElement::InitializeOffsets()
          if (dataName.Length()) {
             // -- We have our data member name, do a lookup in the dictionary meta info of our parent class.
             // Get our parent class.
-            TClass* pClass = 0;
+            TClass* pClass = nullptr;
             // First check whether this sub-branch is part of the 'cache' (because the data member it
             // represents is no longer in the current class layout.
             TStreamerInfo *subInfo = subBranch->GetInfoImp();
@@ -3684,7 +3684,7 @@ void TBranchElement::InitializeOffsets()
             // the beginning of the data member described by the current branch.
             //
             // Compensate for the i/o routines adding our local offset later.
-            if (subBranch->fObject == 0 && localOffset == TStreamerInfo::kMissing) {
+            if (subBranch->fObject == nullptr && localOffset == TStreamerInfo::kMissing) {
                subBranch->SetMissing();
                // We stil need to set fBranchOffset in the case of a missing
                // element so that SetAddress is (as expected) not called
@@ -3704,7 +3704,7 @@ void TBranchElement::InitializeOffsets()
          } else {
             // -- Set fBranchOffset for sub-branch.
             Int_t isSplit = 0 != subBranch->GetListOfBranches()->GetEntriesFast();
-            if (subBranch->fObject == 0 && localOffset == TStreamerInfo::kMissing) {
+            if (subBranch->fObject == nullptr && localOffset == TStreamerInfo::kMissing) {
                // The branch is missing
                fBranchOffset[subBranchIdx] = TStreamerInfo::kMissing;
 
@@ -3738,7 +3738,7 @@ void TBranchElement::InitializeOffsets()
          // Branch is *not* a top-level branch.
          // Let's check if the target member is still present in memory
          if (GetOffset() == TStreamerInfo::kMissing) {
-            fObject = 0;
+            fObject = nullptr;
          }
       }
    }
@@ -4081,7 +4081,7 @@ void TBranchElement::ReadLeavesMakeClass(TBuffer& b)
          for( k=0; k<n; k++) {
             char **where = &(((char**)fAddress)[k]);
             delete [] *where;
-            *where = 0;
+            *where = nullptr;
             switch(len_atype) {
                case  1:  {length = ((Char_t*)   len_where)[k]; break;}
                case  2:  {length = ((Short_t*)  len_where)[k]; break;}
@@ -4169,7 +4169,7 @@ void TBranchElement::ReadLeavesMakeClass(TBuffer& b)
       if (fStreamerType > 40 && fStreamerType < 55) {
          Int_t atype = fStreamerType - 40;
          Int_t n;
-         if (fBranchCount==0) {
+         if (fBranchCount==nullptr) {
             // Missing fBranchCount.  let's attempts to recover.
 
             TString countname( GetName() );
@@ -4269,7 +4269,7 @@ void TBranchElement::ReadLeavesMakeClass(TBuffer& b)
 void TBranchElement::ReadLeavesCollection(TBuffer& b)
 {
    ValidateAddress();
-   if (fObject == 0)
+   if (fObject == nullptr)
    {
       // We have nowhere to copy the data (probably because the data member was
       // 'dropped' from the current schema) so let's no copy it in a random place.
@@ -4346,7 +4346,7 @@ void TBranchElement::ReadLeavesCollection(TBuffer& b)
 
       Int_t i = 0;
       // coverity[returned_null] the fNdata is check enough to prevent the use of null value of At(0)
-      if( !fNdata || *(void**)proxy->At( 0 ) != 0 )
+      if( !fNdata || *(void**)proxy->At( 0 ) != nullptr )
          i = fNdata;
 
       for( ; i < fNdata; ++i )
@@ -4367,7 +4367,7 @@ void TBranchElement::ReadLeavesCollection(TBuffer& b)
 void TBranchElement::ReadLeavesCollectionSplitPtrMember(TBuffer& b)
 {
    ValidateAddress();
-   if (fObject == 0)
+   if (fObject == nullptr)
    {
       // We have nowhere to copy the data (probably because the data member was
       // 'dropped' from the current schema) so let's no copy it in a random place.
@@ -4383,7 +4383,7 @@ void TBranchElement::ReadLeavesCollectionSplitPtrMember(TBuffer& b)
    R__PushCache onfileObject(((TBufferFile&)b),fOnfileObject,fNdata);
 
    TStreamerInfo *info = GetInfoImp();
-   if (info == 0) return;
+   if (info == nullptr) return;
 
    TVirtualCollectionProxy *proxy = GetCollectionProxy();
    TVirtualCollectionProxy::TPushPop helper(proxy, fObject);
@@ -4400,7 +4400,7 @@ void TBranchElement::ReadLeavesCollectionSplitPtrMember(TBuffer& b)
 void TBranchElement::ReadLeavesCollectionSplitVectorPtrMember(TBuffer& b)
 {
    ValidateAddress();
-   if (fObject == 0)
+   if (fObject == nullptr)
    {
       // We have nowhere to copy the data (probably because the data member was
       // 'dropped' from the current schema) so let's no copy it in a random place.
@@ -4415,7 +4415,7 @@ void TBranchElement::ReadLeavesCollectionSplitVectorPtrMember(TBuffer& b)
    R__PushCache onfileObject(((TBufferFile&)b),fOnfileObject,fNdata);
 
    TStreamerInfo *info = GetInfoImp();
-   if (info == 0) return;
+   if (info == nullptr) return;
 
    TVirtualCollectionProxy *proxy = GetCollectionProxy();
    TVirtualCollectionProxy::TPushPop helper(proxy, fObject);
@@ -4431,7 +4431,7 @@ void TBranchElement::ReadLeavesCollectionSplitVectorPtrMember(TBuffer& b)
 void TBranchElement::ReadLeavesCollectionMember(TBuffer& b)
 {
    ValidateAddress();
-   if (fObject == 0)
+   if (fObject == nullptr)
    {
       // We have nowhere to copy the data (probably because the data member was
       // 'dropped' from the current schema) so let's no copy it in a random place.
@@ -4446,7 +4446,7 @@ void TBranchElement::ReadLeavesCollectionMember(TBuffer& b)
    R__PushCache onfileObject(((TBufferFile&)b),fOnfileObject,fNdata);
 
    TStreamerInfo *info = GetInfoImp();
-   if (info == 0) return;
+   if (info == nullptr) return;
    // Since info is not null, fReadActionSequence is not null either.
 
    // Still calling PushPop for the legacy entries.
@@ -4464,7 +4464,7 @@ void TBranchElement::ReadLeavesCollectionMember(TBuffer& b)
 void TBranchElement::ReadLeavesClones(TBuffer& b)
 {
    ValidateAddress();
-   if (fObject == 0)
+   if (fObject == nullptr)
    {
       // We have nowhere to copy the data (probably because the data member was
       // 'dropped' from the current schema) so let's no copy it in a random place.
@@ -4504,7 +4504,7 @@ void TBranchElement::ReadLeavesClonesMember(TBuffer& b)
    // fID is positive
    //   ValidateAddress();
 
-   if (fObject == 0)
+   if (fObject == nullptr)
    {
       // We have nowhere to copy the data (probably because the data member was
       // 'dropped' from the current schema) so let's no copy it in a random place.
@@ -4518,7 +4518,7 @@ void TBranchElement::ReadLeavesClonesMember(TBuffer& b)
       return;
    }
    TStreamerInfo *info = GetInfoImp();
-   if (info==0) return;
+   if (info==nullptr) return;
    // Since info is not null, fReadActionSequence is not null either.
 
    // Note, we could (possibly) save some more, by configuring the action
@@ -4537,11 +4537,11 @@ void TBranchElement::ReadLeavesClonesMember(TBuffer& b)
 
 void TBranchElement::ReadLeavesMember(TBuffer& b)
 {
-   R__ASSERT(fBranchCount==0);
+   R__ASSERT(fBranchCount==nullptr);
    R__ASSERT(fStreamerType != TVirtualStreamerInfo::kCounter);
 
    ValidateAddress();
-   if (fObject == 0)
+   if (fObject == nullptr)
    {
       // We have nowhere to copy the data (probably because the data member was
       // 'dropped' from the current schema) so let's no copy it in a random place.
@@ -4578,7 +4578,7 @@ void TBranchElement::ReadLeavesMemberBranchCount(TBuffer& b)
    R__ASSERT(fStreamerType != TVirtualStreamerInfo::kCounter);
 
    ValidateAddress();
-   if (fObject == 0)
+   if (fObject == nullptr)
    {
       // We have nowhere to copy the data (probably because the data member was
       // 'dropped' from the current schema) so let's no copy it in a random place.
@@ -4613,7 +4613,7 @@ void TBranchElement::ReadLeavesMemberBranchCount(TBuffer& b)
 void TBranchElement::ReadLeavesMemberCounter(TBuffer& b)
 {
    ValidateAddress();
-   if (fObject == 0)
+   if (fObject == nullptr)
    {
       // We have nowhere to copy the data (probably because the data member was
       // 'dropped' from the current schema) so let's no copy it in a random place.
@@ -4649,7 +4649,7 @@ void TBranchElement::ReadLeavesMemberCounter(TBuffer& b)
 void TBranchElement::ReadLeavesCustomStreamer(TBuffer& b)
 {
    ValidateAddress();
-   if (fObject == 0)
+   if (fObject == nullptr)
    {
       // We have nowhere to copy the data (probably because the data member was
       // 'dropped' from the current schema) so let's no copy it in a random place.
@@ -4675,18 +4675,18 @@ void TBranchElement::ReleaseObject()
 {
    if (fObject && TestBit(kDeleteObject)) {
       if (IsAutoDelete() && fAddress != (char*)&fObject) {
-         *((char**) fAddress) = 0;
+         *((char**) fAddress) = nullptr;
       }
       ResetBit(kDeleteObject);
       if (fType == 3) {
          // -- We are a TClonesArray master branch.
          TClonesArray::Class()->Destructor(fObject);
-         fObject = 0;
+         fObject = nullptr;
          if ((fStreamerType == TVirtualStreamerInfo::kObjectp) ||
              (fStreamerType == TVirtualStreamerInfo::kObjectP)) {
             // -- We are a pointer to a TClonesArray.
             // We must zero the pointer in the object.
-            *((char**) fAddress) = 0;
+            *((char**) fAddress) = nullptr;
          }
       } else if (fType == 4) {
          // -- We are an STL container master branch.
@@ -4694,7 +4694,7 @@ void TBranchElement::ReleaseObject()
 
          if (!proxy) {
             Warning("ReleaseObject", "Cannot delete allocated STL container because I do not have a proxy!  branch: %s", GetName());
-            fObject = 0;
+            fObject = nullptr;
          } else {
             Bool_t needDelete = proxy->GetProperties()&TVirtualCollectionProxy::kNeedDelete;
             if (needDelete && fID >= 0) {
@@ -4707,19 +4707,19 @@ void TBranchElement::ReleaseObject()
                proxy->Clear("force");
             }
             proxy->Destructor(fObject);
-            fObject = 0;
+            fObject = nullptr;
          }
          if (fStreamerType == TVirtualStreamerInfo::kSTLp) {
             // -- We are a pointer to an STL container.
             // We must zero the pointer in the object.
-            *((char**) fAddress) = 0;
+            *((char**) fAddress) = nullptr;
          }
       } else {
          // We are *not* a TClonesArray master branch and we are *not* an STL container master branch.
          TClass* cl = fBranchClass.GetClass();
          if (!cl) {
             Warning("ReleaseObject", "Cannot delete allocated object because I cannot instantiate a TClass object for its class!  branch: '%s' class: '%s'", GetName(), fBranchClass.GetClassName());
-            fObject = 0;
+            fObject = nullptr;
          } else {
             TVirtualCollectionProxy* proxy = cl->GetCollectionProxy();
 
@@ -4738,7 +4738,7 @@ void TBranchElement::ReleaseObject()
 
             }
             cl->Destructor(fObject);
-            fObject = 0;
+            fObject = nullptr;
          }
       }
    }
@@ -4784,7 +4784,7 @@ void TBranchElement::ResetAddress()
    for (Int_t i = 0; i < fNleaves; ++i) {
       TLeaf* leaf = (TLeaf*) fLeaves.UncheckedAt(i);
       //if (leaf) leaf->SetAddress(0);
-      leaf->SetAddress(0);
+      leaf->SetAddress(nullptr);
    }
 
    // Note: We *must* do the sub-branches first, otherwise
@@ -4803,8 +4803,8 @@ void TBranchElement::ResetAddress()
    ReleaseObject();
 
    ResetBit(kAddressSet);
-   fAddress = 0;
-   fObject = 0;
+   fAddress = nullptr;
+   fObject = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -5037,7 +5037,7 @@ void TBranchElement::SetAddressImpl(void* addr, bool implied)
 
    fAddress = (char*) addr;
    if (fAddress != (char*)(&fObject)) {
-      fObject = 0;
+      fObject = nullptr;
    }
    ResetBit(kDeleteObject);
    SetBit(kAddressSet);
@@ -5114,7 +5114,7 @@ void TBranchElement::SetAddressImpl(void* addr, bool implied)
             }
          } else {
             // FIXME: Must maintain fObject here as well.
-            fAddress = 0;
+            fAddress = nullptr;
             ResetBit(kAddressSet);
          }
       }
@@ -5132,7 +5132,7 @@ void TBranchElement::SetAddressImpl(void* addr, bool implied)
             fSTLtype = fCollProxy->GetCollectionType();
             for (Int_t i = 0; i < nbranches; ++i) {
                TBranchElement* br = (TBranchElement*) GetListOfBranches()->UncheckedAt(i);
-               br->fCollProxy = 0;
+               br->fCollProxy = nullptr;
                if (br->fReadActionSequence) {
                   br->SetReadActionSequence();
                }
@@ -5155,7 +5155,7 @@ void TBranchElement::SetAddressImpl(void* addr, bool implied)
                fIterators = new TVirtualCollectionIterators(fCollProxy);
             }
          }
-         else if (newProxy && (oldProxy->HasPointers() == newProxy->HasPointers()) && (oldProxy->GetValueClass()!=0) && (newProxy->GetValueClass()!=0)) {
+         else if (newProxy && (oldProxy->HasPointers() == newProxy->HasPointers()) && (oldProxy->GetValueClass()!=nullptr) && (newProxy->GetValueClass()!=nullptr)) {
             // Let see if there is a rule to convert the content of the collection into each other.
             if (newType->GetSchemaRules()->HasRuleWithSourceClass( oldProxy->GetCollectionClass()->GetName())) {
                TClass *oldValueClass = oldProxy->GetValueClass();
@@ -5165,7 +5165,7 @@ void TBranchElement::SetAddressImpl(void* addr, bool implied)
                fSTLtype = fCollProxy->GetCollectionType();
                for (Int_t i = 0; i < nbranches; ++i) {
                   TBranchElement* br = (TBranchElement*) GetListOfBranches()->UncheckedAt(i);
-                  br->fCollProxy = 0;
+                  br->fCollProxy = nullptr;
                   if (br->fBranchClass == oldValueClass) {
                      br->SetTargetClass(fCollProxy->GetValueClass()->GetName());
                   }
@@ -5193,8 +5193,8 @@ void TBranchElement::SetAddressImpl(void* addr, bool implied)
             } else {
                Error("SetAddress","For %s, we can not convert %s into %s\n",
                      GetName(),oldProxy->GetCollectionClass()->GetName(),newType->GetName());
-               fAddress = 0;
-               fObject = 0;
+               fAddress = nullptr;
+               fObject = nullptr;
                ResetBit(kAddressSet);
                return;
             }
@@ -5230,7 +5230,7 @@ void TBranchElement::SetAddressImpl(void* addr, bool implied)
             fClonesClass = oldProxy->GetValueClass();
             fClonesName = fClonesClass->GetName();
             delete fCollProxy;
-            fCollProxy = 0;
+            fCollProxy = nullptr;
             TClass* clm = fClonesClass;
             if (clm) {
                clm->BuildRealData(); //just in case clm derives from an abstract class
@@ -5240,13 +5240,13 @@ void TBranchElement::SetAddressImpl(void* addr, bool implied)
             SetReadLeavesPtr();
             SetFillLeavesPtr();
             delete fIterators;
-            fIterators = 0;
+            fIterators = nullptr;
             delete fPtrIterators;
-            fPtrIterators =0;
+            fPtrIterators =nullptr;
          } else {
             // FIXME: We must maintain fObject here as well.
             Error("SetAddress","For %s can not convert %s into %s\n",GetName(),GetCurrentClass()->GetName(),newType->GetName());
-            fAddress = 0;
+            fAddress = nullptr;
             ResetBit(kAddressSet);
             return;
          }
@@ -5379,7 +5379,7 @@ void TBranchElement::SetAddressImpl(void* addr, bool implied)
                      // FIXME: Should we do this?  Lots of other code wants
                      //        fAddress to be zero if no fObject, but is
                      //        that a good thing?
-                     fAddress = 0;
+                     fAddress = nullptr;
                      ResetBit(kAddressSet);
                   }
                }
@@ -5397,7 +5397,7 @@ void TBranchElement::SetAddressImpl(void* addr, bool implied)
                      // FIXME: Should we do this?  Lots of other code wants
                      //        fAddress to be zero if no fObject, but is
                      //        that a good thing?
-                     fAddress = 0;
+                     fAddress = nullptr;
                      ResetBit(kAddressSet);
                   }
                }
@@ -5432,7 +5432,7 @@ void TBranchElement::SetAddressImpl(void* addr, bool implied)
                   // FIXME: Should we do this?  Lots of other code wants
                   //        fAddress to be zero if no fObject, but is
                   //        that a good thing?
-                  fAddress = 0;
+                  fAddress = nullptr;
                   ResetBit(kAddressSet);
                }
             } else {
@@ -5469,8 +5469,8 @@ void TBranchElement::SetAddressImpl(void* addr, bool implied)
          } else {
             Error("SetAddress", "I have no TClass for branch %s, so I cannot allocate an I/O buffer!", GetName());
             if (pp) {
-               fObject = 0;
-               *pp = 0;
+               fObject = nullptr;
+               *pp = nullptr;
             }
          }
       }
@@ -5531,7 +5531,7 @@ void TBranchElement::SetBasketSize(Int_t buffsize)
 void TBranchElement::SetBranchCount(TBranchElement* brOfCounter)
 {
    fBranchCount = brOfCounter;
-   if (fBranchCount==0) return;
+   if (fBranchCount==nullptr) return;
 
    TLeafElement* leafOfCounter  = (TLeafElement*) brOfCounter->GetListOfLeaves()->At(0);
    TLeafElement* leaf = (TLeafElement*) GetListOfLeaves()->At(0);
@@ -5664,7 +5664,7 @@ void TBranchElement::SetActionSequence(TClass *originalClass, TStreamerInfo *loc
 /// Set the sequence of actions needed to read the data out of the buffer.
 void TBranchElement::SetReadActionSequence()
 {
-   if (fInfo == 0) {
+   if (fInfo == nullptr) {
       // We are called too soon.  We will be called again by InitInfo
       return;
    }
@@ -5734,7 +5734,7 @@ void TBranchElement::SetReadLeavesPtr()
       fReadLeaves = (ReadLeaves_t)&TBranchElement::ReadLeavesCustomStreamer;
    } else if (fType == 0 && fID == -1) {
       // top-level branch.
-      Bool_t hasCustomStreamer = fBranchClass.GetClass() && !fBranchClass.GetClass()->GetCollectionProxy() && (fBranchClass.GetClass()->GetStreamer() != 0 || fBranchClass.GetClass()->TestBit(TClass::kHasCustomStreamerMember));
+      Bool_t hasCustomStreamer = fBranchClass.GetClass() && !fBranchClass.GetClass()->GetCollectionProxy() && (fBranchClass.GetClass()->GetStreamer() != nullptr || fBranchClass.GetClass()->TestBit(TClass::kHasCustomStreamerMember));
       if (hasCustomStreamer) {
          // We are in the case where the object did *not* have a custom
          // Streamer when the TTree was written but now *does* have a custom
@@ -5764,7 +5764,7 @@ void TBranchElement::SetReadLeavesPtr()
 
 void TBranchElement::SetFillActionSequence()
 {
-   if (fInfo == 0) {
+   if (fInfo == nullptr) {
       // We are called too soon.  We will be called again by InitInfo
       return;
    }
@@ -5856,7 +5856,7 @@ void TBranchElement::SetFillLeavesPtr()
 
 void TBranchElement::SetTargetClass(const char *name)
 {
-   if (name == 0) return;
+   if (name == nullptr) return;
 
    if (strcmp(fTargetClass.GetClassName(),name) != 0 )
    {
@@ -5929,7 +5929,7 @@ void TBranchElement::SetupAddressesImpl()
       GetInfoImp();
 
       if( !parent->GetAddress() )
-         parent->SetAddress( 0 );
+         parent->SetAddress( nullptr );
       return;
    }
 
@@ -5955,7 +5955,7 @@ void TBranchElement::SetupAddressesImpl()
       Bool_t motherStatus = mother->TestBit(kDoNotProcess);
       mother->ResetBit(kDoNotProcess);
       // Note: This will allocate an object.
-      mother->SetAddress(0);
+      mother->SetAddress(nullptr);
       mother->SetBit(kDoNotProcess, motherStatus);
    }
 }
@@ -5988,7 +5988,7 @@ void TBranchElement::Streamer(TBuffer& R__b)
    }
    else {
       TDirectory* dirsav = fDirectory;
-      fDirectory = 0;  // to avoid recursive calls
+      fDirectory = nullptr;  // to avoid recursive calls
       {
          // Save class version.
          Int_t classVersion = fClassVersion;
@@ -6096,7 +6096,7 @@ void TBranchElement::Unroll(const char *name, TClass *cl, TStreamerInfo *sinfo, 
    // Loop on all public data members of the class and its base classes and create branches for each one.
    TObjArray* blist = this->GetListOfBranches();
    TIter next(sinfo->GetElements());
-   TStreamerElement* element = 0;
+   TStreamerElement* element = nullptr;
    TString bname;
    for (Int_t id = 0; (element = (TStreamerElement*) next()); ++id) {
       if (element->IsA() == TStreamerArtificial::Class()) {
@@ -6291,7 +6291,7 @@ Int_t TBranchElement::Unroll(const char* name, TClass* clParent, TClass* cl, cha
                } else {
                   branchname.Form("%s", elem->GetFullName());
                }
-               TBranchElement* branch = new TBranchElement(this, branchname, sinfo, elemID, 0, basketsize, 0, btype);
+               TBranchElement* branch = new TBranchElement(this, branchname, sinfo, elemID, nullptr, basketsize, 0, btype);
                branch->SetParentClass(clParent);
                fBranches.Add(branch);
             }
@@ -6402,7 +6402,7 @@ Int_t TBranchElement::Unroll(const char* name, TClass* clParent, TClass* cl, cha
             fBranches.Add(branch);
          } else {
             // -- We are not going to split this element any farther.
-            TBranchElement* branch = new TBranchElement(this, branchname, sinfo, elemID, 0, basketsize, splitSTLP, btype);
+            TBranchElement* branch = new TBranchElement(this, branchname, sinfo, elemID, nullptr, basketsize, splitSTLP, btype);
             branch->SetType(btype);
             branch->SetParentClass(clParent);
             fBranches.Add(branch);

--- a/tree/tree/src/TBranchObject.cxx
+++ b/tree/tree/src/TBranchObject.cxx
@@ -41,7 +41,7 @@ TBranchObject::TBranchObject()
 : TBranch()
 {
    fNleaves = 1;
-   fOldObject = 0;
+   fOldObject = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -50,7 +50,7 @@ TBranchObject::TBranchObject()
 TBranchObject::TBranchObject(TTree *tree, const char* name, const char* classname, void* addobj, Int_t basketsize, Int_t splitlevel, Int_t compress, Bool_t isptrptr /* = kTRUE */)
 : TBranch()
 {
-   Init(tree,0,name,classname,addobj,basketsize,splitlevel,compress,isptrptr);
+   Init(tree,nullptr,name,classname,addobj,basketsize,splitlevel,compress,isptrptr);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -59,7 +59,7 @@ TBranchObject::TBranchObject(TTree *tree, const char* name, const char* classnam
 TBranchObject::TBranchObject(TBranch *parent, const char* name, const char* classname, void* addobj, Int_t basketsize, Int_t splitlevel, Int_t compress, Bool_t isptrptr /* = kTRUE */)
 : TBranch()
 {
-   Init(0,parent,name,classname,addobj,basketsize,splitlevel,compress,isptrptr);
+   Init(nullptr,parent,name,classname,addobj,basketsize,splitlevel,compress,isptrptr);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -67,7 +67,7 @@ TBranchObject::TBranchObject(TBranch *parent, const char* name, const char* clas
 
 void TBranchObject::Init(TTree *tree, TBranch *parent, const char* name, const char* classname, void* addobj, Int_t basketsize, Int_t /*splitlevel*/, Int_t compress, Bool_t isptrptr)
 {
-   if (tree==0 && parent!=0) tree = parent->GetTree();
+   if (tree==nullptr && parent!=nullptr) tree = parent->GetTree();
    fTree   = tree;
    fMother = parent ? parent->GetMother() : this;
    fParent = parent;
@@ -83,7 +83,7 @@ void TBranchObject::Init(TTree *tree, TBranch *parent, const char* name, const c
       fOldObject = (TObject*)addobj;
       addobj = &fOldObject;
    } else {
-      fOldObject = 0;
+      fOldObject = nullptr;
    }
 
    char** apointer = (char**) addobj;
@@ -212,7 +212,7 @@ Int_t TBranchObject::GetEntry(Long64_t entry, Int_t getall)
    Int_t nbranches = fBranches.GetEntriesFast();
 
    if (nbranches) {
-      if (fAddress == 0) {
+      if (fAddress == nullptr) {
          SetupAddresses();
       }
       nbytes = 0;
@@ -241,7 +241,7 @@ Int_t TBranchObject::GetEntry(Long64_t entry, Int_t getall)
 
 Int_t TBranchObject::GetExpectedType(TClass *&expectedClass,EDataType &expectedType)
 {
-   expectedClass = 0;
+   expectedClass = nullptr;
    expectedType = kOther_t;
    TLeafObject* lobj = (TLeafObject*) GetListOfLeaves()->At(0);
    if (!lobj) {
@@ -345,7 +345,7 @@ void TBranchObject::SetAddress(void* add)
    fAddress = (char*) add;
    char** ppointer = (char**) add;
 
-   char* obj = 0;
+   char* obj = nullptr;
    if (ppointer) {
       obj = *ppointer;
    }
@@ -399,8 +399,8 @@ void TBranchObject::SetAddress(void* add)
       isDot = 1;
    }
 
-   char* pointer = 0;
-   TRealData* rd = 0;
+   char* pointer = nullptr;
+   TRealData* rd = nullptr;
    TIter next(cl->GetListOfRealData());
    while ((rd = (TRealData*) next())) {
       if (rd->TestBit(TRealData::kTransient)) continue;
@@ -419,9 +419,9 @@ void TBranchObject::SetAddress(void* add)
       if (ppointer) {
          pointer = obj + offset;
       }
-      TBranch* branch = 0;
+      TBranch* branch = nullptr;
       if (dm->IsaPointer()) {
-         TClass* clobj = 0;
+         TClass* clobj = nullptr;
          if (!dm->IsBasic()) {
             clobj = TClass::GetClass(dm->GetTypeName());
          }
@@ -551,7 +551,7 @@ void TBranchObject::Streamer(TBuffer& R__b)
       ResetBit(kOldWarn);
    } else {
       TDirectory* dirsav = fDirectory;
-      fDirectory = 0;  // to avoid recursive calls
+      fDirectory = nullptr;  // to avoid recursive calls
 
       R__b.WriteClassBuffer(TBranchObject::Class(), this);
 
@@ -593,7 +593,7 @@ void TBranchObject::Streamer(TBuffer& R__b)
 
 void TBranchObject::SetupAddresses()
 {
-   if (fAddress == 0) {
+   if (fAddress == nullptr) {
       // try to create object
       if (!TestBit(kWarn)) {
          TClass* cl = TClass::GetClass(fClassName);

--- a/tree/tree/src/TBranchRef.cxx
+++ b/tree/tree/src/TBranchRef.cxx
@@ -43,7 +43,7 @@ ClassImp(TBranchRef);
 ////////////////////////////////////////////////////////////////////////////////
 /// Default constructor.
 
-TBranchRef::TBranchRef(): TBranch(), fRequestedEntry(-1), fRefTable(0)
+TBranchRef::TBranchRef(): TBranch(), fRequestedEntry(-1), fRefTable(nullptr)
 {
    fReadLeaves = (ReadLeaves_t)&TBranchRef::ReadLeavesImpl;
    fFillLeaves = (FillLeaves_t)&TBranchRef::FillLeavesImpl;
@@ -53,7 +53,7 @@ TBranchRef::TBranchRef(): TBranch(), fRequestedEntry(-1), fRefTable(0)
 /// Main constructor called by TTree::BranchRef.
 
 TBranchRef::TBranchRef(TTree *tree)
-    : TBranch(), fRequestedEntry(-1), fRefTable(0)
+    : TBranch(), fRequestedEntry(-1), fRefTable(nullptr)
 {
    if (!tree) return;
    SetName("TRefTable");
@@ -62,7 +62,7 @@ TBranchRef::TBranchRef(TTree *tree)
 
    fCompress       = 1;
    fBasketSize     = 32000;
-   fAddress        = 0;
+   fAddress        = nullptr;
    fBasketBytes    = new Int_t[fMaxBaskets];
    fBasketEntry    = new Long64_t[fMaxBaskets];
    fBasketSeek     = new Long64_t[fMaxBaskets];

--- a/tree/tree/src/TBranchSTL.cxx
+++ b/tree/tree/src/TBranchSTL.cxx
@@ -26,13 +26,13 @@ ClassImp(TBranchSTL);
 /// Default constructor.
 
 TBranchSTL::TBranchSTL():
-   fCollProxy( 0 ),
-   fParent( 0 ),
-   fIndArrayCl( 0 ),
+   fCollProxy( nullptr ),
+   fParent( nullptr ),
+   fIndArrayCl( nullptr ),
    fClassVersion( 0 ),
    fClCheckSum( 0 ),
-   fInfo( 0 ),
-   fObject( 0 ),
+   fInfo( nullptr ),
+   fObject( nullptr ),
    fID( -2 )
 {
    fIndArrayCl = TClass::GetClass( "TIndArray" );
@@ -57,9 +57,9 @@ TBranchSTL::TBranchSTL( TTree *tree, const char *name,
    fClCheckSum   = 0;
    fClassVersion = 1;
    fID           = -2;
-   fInfo         = 0;
+   fInfo         = nullptr;
    fMother = this;
-   fParent = 0;
+   fParent = nullptr;
    fDirectory = fTree->GetDirectory();
    fFileName = "";
    SetName( name );
@@ -149,7 +149,7 @@ void TBranchSTL::Browse( TBrowser *b )
    Int_t nbranches = fBranches.GetEntriesFast();
    if (nbranches > 0) {
       TList persistentBranches;
-      TBranch* branch=0;
+      TBranch* branch=nullptr;
       TIter iB(&fBranches);
       while( (branch = (TBranch*)iB()) )
          persistentBranches.Add(branch);
@@ -176,7 +176,7 @@ Int_t TBranchSTL::FillImpl(ROOT::Internal::TBranchIMTHelper *imtHelper)
       //------------------------------------------------------------------------
       // We have received a zero pointer - treat it as an empty collection
       //------------------------------------------------------------------------
-      if( fObject == 0 ) {
+      if( fObject == nullptr ) {
          Int_t bytes      = 0;
          Int_t totalBytes = 0;
 
@@ -226,11 +226,11 @@ Int_t TBranchSTL::FillImpl(ROOT::Internal::TBranchIMTHelper *imtHelper)
    // Loop over the elements and create branches as needed
    //---------------------------------------------------------------------------
    TClass*               cl         = fCollProxy->GetValueClass();
-   TClass*               actClass   = 0;
-   TClass*               vectClass  = 0;
-   char*                 element    = 0;
-   std::vector<void*>*   elPointers = 0;
-   TBranchElement*       elBranch   = 0;
+   TClass*               actClass   = nullptr;
+   TClass*               vectClass  = nullptr;
+   char*                 element    = nullptr;
+   std::vector<void*>*   elPointers = nullptr;
+   TBranchElement*       elBranch   = nullptr;
    UInt_t                elOffset   = 0;
    UChar_t               maxID      = fBranches.GetEntriesFast()+1;
    UChar_t               elID;
@@ -397,7 +397,7 @@ Int_t TBranchSTL::GetEntry( Long64_t entry, Int_t getall )
    //---------------------------------------------------------------------------
    UInt_t nBranches = fBranches.GetEntriesFast();
    TClass*               elClass   = fCollProxy->GetValueClass();
-   TClass*               tmpClass  = 0;
+   TClass*               tmpClass  = nullptr;
 
    if( fBranchVector.size() < nBranches )
       fBranchVector.resize( nBranches );
@@ -416,9 +416,9 @@ Int_t TBranchSTL::GetEntry( Long64_t entry, Int_t getall )
    // Process entries
    //---------------------------------------------------------------------------
    UChar_t             index      = 0;
-   void**              element    = 0;
-   std::vector<void*>* elemVect   = 0;
-   TBranchElement*     elemBranch = 0;
+   void**              element    = nullptr;
+   std::vector<void*>* elemVect   = nullptr;
+   TBranchElement*     elemBranch = nullptr;
 
    for( Int_t i = 0; i < size; ++i ) {
       element = (void**)fCollProxy->At(i);
@@ -428,7 +428,7 @@ Int_t TBranchSTL::GetEntry( Long64_t entry, Int_t getall )
       // The case of zero pointers
       //------------------------------------------------------------------------
       if( index == 0 ) {
-         *element = 0;
+         *element = nullptr;
          continue;
       }
 
@@ -438,7 +438,7 @@ Int_t TBranchSTL::GetEntry( Long64_t entry, Int_t getall )
       if( index > nBranches ) {
          Error( "GetEntry", "Index %d out of range, unable to find the branch, setting pointer to 0",
                 index );
-         *element = 0;
+         *element = nullptr;
          continue;
       }
 
@@ -455,14 +455,14 @@ Int_t TBranchSTL::GetEntry( Long64_t entry, Int_t getall )
 
          if( bytes == 0 ) {
             Error( "GetEntry", "No entry for index %d, setting pointer to 0", index );
-            *element = 0;
+            *element = nullptr;
             fBranchVector[index].fPosition++;
             continue;
          }
 
          if( bytes <= 0 ) {
             Error( "GetEntry", "I/O error while getting entry for index %d, setting pointer to 0", index );
-            *element = 0;
+            *element = nullptr;
             fBranchVector[index].fPosition++;
             continue;
          }
@@ -504,7 +504,7 @@ Int_t TBranchSTL::GetEntry( Long64_t entry, Int_t getall )
    //---------------------------------------------------------------------------
    for( UInt_t i = 0; i < fBranchVector.size(); ++i ) {
       delete fBranchVector[i].fPointers;
-      fBranchVector[i].fPointers = 0;
+      fBranchVector[i].fPointers = nullptr;
    }
 
    return totalBytes;
@@ -518,7 +518,7 @@ Int_t TBranchSTL::GetEntry( Long64_t entry, Int_t getall )
 
 Int_t TBranchSTL::GetExpectedType(TClass *&expectedClass,EDataType &expectedType)
 {
-   expectedClass = 0;
+   expectedClass = nullptr;
    expectedType = kOther_t;
 
    if (fID < 0) {
@@ -609,7 +609,7 @@ void TBranchSTL::Print(const char *option) const
       TBranchElement *parent = dynamic_cast<TBranchElement*>(GetMother()->GetSubBranch(this));
       Int_t ind = parent ? parent->GetListOfBranches()->IndexOf(this) : -1;
       TVirtualStreamerInfo *info = GetInfo();
-      Int_t *branchOffset = parent ? parent->GetBranchOffset() : 0;
+      Int_t *branchOffset = parent ? parent->GetBranchOffset() : nullptr;
 
       Printf("%-16s %2d SplitCollPtr %-16s %-16s %8x %-16s n/a\n",
              info ? info->GetName() : "StreamerInfo unavailable", fID,

--- a/tree/tree/src/TBufferSQL.cxx
+++ b/tree/tree/src/TBufferSQL.cxx
@@ -64,7 +64,7 @@ TBufferSQL::TBufferSQL(TBuffer::EMode mode, Int_t bufsiz, std::vector<Int_t> *vc
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor.
 
-TBufferSQL::TBufferSQL() : TBufferFile(), fColumnVec(0),fInsertQuery(0),fRowPtr(0)
+TBufferSQL::TBufferSQL() : TBufferFile(), fColumnVec(nullptr),fInsertQuery(nullptr),fRowPtr(nullptr)
 {
 }
 

--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -70,8 +70,8 @@ ClassImp(TChain);
 /// Default constructor.
 
 TChain::TChain(Mode mode)
-   : TTree(), fTreeOffsetLen(100), fNtrees(0), fTreeNumber(-1), fTreeOffset(0), fCanDeleteRefs(kFALSE), fTree(0),
-     fFile(0), fFiles(0), fStatus(0), fProofChain(0), fGlobalRegistration(mode == kWithGlobalRegistration)
+   : TTree(), fTreeOffsetLen(100), fNtrees(0), fTreeNumber(-1), fTreeOffset(nullptr), fCanDeleteRefs(kFALSE), fTree(nullptr),
+     fFile(nullptr), fFiles(nullptr), fStatus(nullptr), fProofChain(nullptr), fGlobalRegistration(mode == kWithGlobalRegistration)
 {
    fTreeOffset = new Long64_t[fTreeOffsetLen];
    fFiles = new TObjArray(fTreeOffsetLen);
@@ -80,8 +80,8 @@ TChain::TChain(Mode mode)
    if (fGlobalRegistration) {
       gROOT->GetListOfSpecials()->Add(this);
    }
-   fFile = 0;
-   fDirectory = 0;
+   fFile = nullptr;
+   fDirectory = nullptr;
 
    // Reset PROOF-related bits
    ResetBit(kProofUptodate);
@@ -138,8 +138,8 @@ TChain::TChain(Mode mode)
 /// ~~~
 
 TChain::TChain(const char *name, const char *title, Mode mode)
-   : TTree(name, title, /*splitlevel*/ 99, nullptr), fTreeOffsetLen(100), fNtrees(0), fTreeNumber(-1), fTreeOffset(0),
-     fCanDeleteRefs(kFALSE), fTree(0), fFile(0), fFiles(0), fStatus(0), fProofChain(0),
+   : TTree(name, title, /*splitlevel*/ 99, nullptr), fTreeOffsetLen(100), fNtrees(0), fTreeNumber(-1), fTreeOffset(nullptr),
+     fCanDeleteRefs(kFALSE), fTree(nullptr), fFile(nullptr), fFiles(nullptr), fStatus(nullptr), fProofChain(nullptr),
      fGlobalRegistration(mode == kWithGlobalRegistration)
 {
    //
@@ -149,7 +149,7 @@ TChain::TChain(const char *name, const char *title, Mode mode)
    fFiles = new TObjArray(fTreeOffsetLen);
    fStatus = new TList();
    fTreeOffset[0]  = 0;
-   fFile = 0;
+   fFile = nullptr;
 
    // Reset PROOF-related bits
    ResetBit(kProofUptodate);
@@ -182,24 +182,24 @@ TChain::~TChain()
    SafeDelete(fProofChain);
    fStatus->Delete();
    delete fStatus;
-   fStatus = 0;
+   fStatus = nullptr;
    fFiles->Delete();
    delete fFiles;
-   fFiles = 0;
+   fFiles = nullptr;
 
    //first delete cache if exists
    auto tc = fFile && fTree ? fTree->GetReadCache(fFile) : nullptr;
    if (tc) {
       delete tc;
-      fFile->SetCacheRead(0, fTree);
+      fFile->SetCacheRead(nullptr, fTree);
    }
 
    delete fFile;
-   fFile = 0;
+   fFile = nullptr;
    // Note: We do *not* own the tree.
-   fTree = 0;
+   fTree = nullptr;
    delete[] fTreeOffset;
-   fTreeOffset = 0;
+   fTreeOffset = nullptr;
 
    // Remove from the global lists
    if (rootAlive && fGlobalRegistration) {
@@ -209,7 +209,7 @@ TChain::~TChain()
    }
 
    // This is the same as fFile, don't delete it a second time.
-   fDirectory = 0;
+   fDirectory = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -233,7 +233,7 @@ Int_t TChain::Add(TChain* chain)
    chain->GetEntries(); //to force the computation of nentries
    TIter next(chain->GetListOfFiles());
    Int_t nf = 0;
-   TChainElement* element = 0;
+   TChainElement* element = nullptr;
    while ((element = (TChainElement*) next())) {
       Long64_t nentries = element->GetEntries();
       if (fTreeOffset[fNtrees] == TTree::kMaxEntries) {
@@ -465,7 +465,7 @@ Int_t TChain::Add(const char *name, Long64_t nentries /* = TTree::kMaxEntries */
 
 Int_t TChain::AddFile(const char* name, Long64_t nentries /* = TTree::kMaxEntries */, const char* tname /* = "" */)
 {
-   if(name==0 || name[0]=='\0') {
+   if(name==nullptr || name[0]=='\0') {
       Error("AddFile", "No file name; no files connected");
       return 0;
    }
@@ -505,9 +505,9 @@ Int_t TChain::AddFile(const char* name, Long64_t nentries /* = TTree::kMaxEntrie
       }
       if (!file || file->IsZombie()) {
          delete file;
-         file = 0;
+         file = nullptr;
          delete[] filename;
-         filename = 0;
+         filename = nullptr;
          return 0;
       }
 
@@ -517,9 +517,9 @@ Int_t TChain::AddFile(const char* name, Long64_t nentries /* = TTree::kMaxEntrie
       if (!obj || !obj->InheritsFrom(TTree::Class())) {
          Error("AddFile", "cannot find tree with name %s in file %s", treename, filename);
          delete file;
-         file = 0;
+         file = nullptr;
          delete[] filename;
-         filename = 0;
+         filename = nullptr;
          return 0;
       }
       TTree* tree = (TTree*) obj;
@@ -527,7 +527,7 @@ Int_t TChain::AddFile(const char* name, Long64_t nentries /* = TTree::kMaxEntrie
       pksize = tree->GetPacketSize();
       // Note: This deletes the tree we fetched.
       delete file;
-      file = 0;
+      file = nullptr;
    }
 
    if (nentries > 0) {
@@ -567,15 +567,15 @@ Int_t TChain::AddFileInfoList(TCollection* filelist, Long64_t nfiles /* = TTree:
       return 0;
    TIter next(filelist);
 
-   TObject *o = 0;
+   TObject *o = nullptr;
    Long64_t cnt=0;
    while ((o = next())) {
       // Get the url
       TString cn = o->ClassName();
-      const char *url = 0;
+      const char *url = nullptr;
       if (cn == "TFileInfo") {
          TFileInfo *fi = (TFileInfo *)o;
-         url = (fi->GetCurrentUrl()) ? fi->GetCurrentUrl()->GetUrl() : 0;
+         url = (fi->GetCurrentUrl()) ? fi->GetCurrentUrl()->GetUrl() : nullptr;
          if (!url) {
             Warning("AddFileInfoList", "found TFileInfo with empty Url - ignoring");
             continue;
@@ -763,7 +763,7 @@ void TChain::CanDeleteRefs(Bool_t flag /* = kTRUE */)
 void TChain::CreatePackets()
 {
    TIter next(fFiles);
-   TChainElement* element = 0;
+   TChainElement* element = nullptr;
    while ((element = (TChainElement*) next())) {
       element->CreatePackets();
    }
@@ -842,7 +842,7 @@ TBranch* TChain::FindBranch(const char* branchname)
    if (fTree) {
       return fTree->FindBranch(branchname);
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -863,7 +863,7 @@ TLeaf* TChain::FindLeaf(const char* searchname)
    if (fTree) {
       return fTree->FindLeaf(searchname);
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -882,7 +882,7 @@ const char* TChain::GetAlias(const char* aliasName) const
    if (fTree) {
       return fTree->GetAlias(aliasName);
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -903,7 +903,7 @@ TBranch* TChain::GetBranch(const char* name)
    if (fTree) {
       return fTree->GetBranch(name);
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1062,7 +1062,7 @@ TLeaf* TChain::GetLeaf(const char* branchname, const char *leafname)
    if (fTree) {
       return fTree->GetLeaf(branchname, leafname);
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1083,7 +1083,7 @@ TLeaf* TChain::GetLeaf(const char* name)
    if (fTree) {
       return fTree->GetLeaf(name);
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1109,7 +1109,7 @@ TObjArray* TChain::GetListOfBranches()
    if (fTree) {
       return fTree->GetListOfBranches();
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1132,7 +1132,7 @@ TObjArray* TChain::GetListOfLeaves()
    if (fTree) {
       return fTree->GetListOfLeaves();
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1256,7 +1256,7 @@ void TChain::InvalidateCurrentTree()
       }
    }
    fTreeNumber = -1;
-   fTree = 0;
+   fTree = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1343,7 +1343,7 @@ Long64_t TChain::LoadTree(Long64_t entry)
          //
          TIter next(fFriends);
          TFriendLock lock(this, kLoadTree);
-         TFriendElement* fe = 0;
+         TFriendElement* fe = nullptr;
          while ((fe = (TFriendElement*) next())) {
             TTree* at = fe->GetTree();
             // If the tree is a
@@ -1422,7 +1422,7 @@ Long64_t TChain::LoadTree(Long64_t entry)
    }
 
    // Delete the current tree and open the new tree.
-   TTreeCache* tpf = 0;
+   TTreeCache* tpf = nullptr;
    // Delete file unless the file owns this chain!
    // FIXME: The "unless" case here causes us to leak memory.
    if (fFile) {
@@ -1440,7 +1440,7 @@ Long64_t TChain::LoadTree(Long64_t entry)
                tpf->ResetCache();
             }
 
-            fFile->SetCacheRead(0, fTree);
+            fFile->SetCacheRead(nullptr, fTree);
             // If the tree has clones, copy them into the chain
             // clone list so we can change their branch addresses
             // when necessary.
@@ -1459,7 +1459,7 @@ Long64_t TChain::LoadTree(Long64_t entry)
             fFile->Close("R");
          }
          delete fFile;
-         fFile = 0;
+         fFile = nullptr;
       } else {
          // If the tree has clones, copy them into the chain
          // clone list so we can change their branch addresses
@@ -1500,10 +1500,10 @@ Long64_t TChain::LoadTree(Long64_t entry)
    if (!fFile || fFile->IsZombie()) {
       if (fFile) {
          delete fFile;
-         fFile = 0;
+         fFile = nullptr;
       }
       // Note: We do *not* own fTree.
-      fTree = 0;
+      fTree = nullptr;
       returnCode = -3;
    } else {
       if (fPerfStats)
@@ -1515,7 +1515,7 @@ Long64_t TChain::LoadTree(Long64_t entry)
          // Now that we do not check during the addition, we need to check here!
          Error("LoadTree", "Cannot find tree with name %s in file %s", element->GetName(), element->GetTitle());
          delete fFile;
-         fFile = 0;
+         fFile = nullptr;
          // We do not return yet so that 'fEntries' can be updated with the
          // sum of the entries of all the other trees.
          returnCode = -4;
@@ -1541,7 +1541,7 @@ Long64_t TChain::LoadTree(Long64_t entry)
          // we have no place to hold the pointer to the
          // TTreeCache.
          delete tpf;
-         tpf = 0;
+         tpf = nullptr;
       }
    } else {
       if (fCacheUserSet) {
@@ -1629,12 +1629,12 @@ Long64_t TChain::LoadTree(Long64_t entry)
       // calling LoadTree (and to overload a few more).
       TIter next(fFriends);
       TFriendLock lock(this, kLoadTree);
-      TFriendElement* fe = 0;
+      TFriendElement* fe = nullptr;
       while ((fe = (TFriendElement*) next())) {
          TTree* t = fe->GetTree();
          if (!t) continue;
          if (t->GetTreeIndex()) {
-            t->GetTreeIndex()->UpdateFormulaLeaves(0);
+            t->GetTreeIndex()->UpdateFormulaLeaves(nullptr);
          }
          if (t->GetTree() && t->GetTree()->GetTreeIndex()) {
             t->GetTree()->GetTreeIndex()->UpdateFormulaLeaves(GetTree());
@@ -1727,12 +1727,12 @@ Long64_t TChain::LoadTree(Long64_t entry)
 void TChain::Lookup(Bool_t force)
 {
    TIter next(fFiles);
-   TChainElement* element = 0;
+   TChainElement* element = nullptr;
    Int_t nelements = fFiles->GetEntries();
    printf("\n");
    printf("TChain::Lookup - Looking up %d files .... \n", nelements);
    Int_t nlook = 0;
-   TFileStager *stg = 0;
+   TFileStager *stg = nullptr;
    while ((element = (TChainElement*) next())) {
       // Do not do it more than needed
       if (element->HasBeenLookedUp() && !force) continue;
@@ -1842,7 +1842,7 @@ void TChain::ls(Option_t* option) const
 {
    TObject::ls(option);
    TIter next(fFiles);
-   TChainElement* file = 0;
+   TChainElement* file = nullptr;
    TROOT::IncreaseDirLevel();
    while ((file = (TChainElement*)next())) {
       file->ls(option);
@@ -2056,7 +2056,7 @@ Long64_t TChain::Merge(TFile* file, Int_t basketsize, Option_t* option)
 
    // Reset the compression level of the branches.
    if (opt.Contains("c")) {
-      TBranch* branch = 0;
+      TBranch* branch = nullptr;
       TIter nextb(newTree->GetListOfBranches());
       while ((branch = (TBranch*) nextb())) {
          branch->SetCompressionSettings(file->GetCompressionSettings());
@@ -2065,7 +2065,7 @@ Long64_t TChain::Merge(TFile* file, Int_t basketsize, Option_t* option)
 
    // Reset the basket size of the branches.
    if (basketsize > 1000) {
-      TBranch* branch = 0;
+      TBranch* branch = nullptr;
       TIter nextb(newTree->GetListOfBranches());
       while ((branch = (TBranch*) nextb())) {
          branch->SetBasketSize(basketsize);
@@ -2272,16 +2272,16 @@ Long64_t TChain::Process(TSelector* selector, Option_t* option, Long64_t nentrie
 void TChain::RecursiveRemove(TObject *obj)
 {
    if (fFile == obj) {
-      fFile = 0;
-      fDirectory = 0;
-      fTree = 0;
+      fFile = nullptr;
+      fDirectory = nullptr;
+      fTree = nullptr;
    }
    if (fDirectory == obj) {
-      fDirectory = 0;
-      fTree = 0;
+      fDirectory = nullptr;
+      fTree = nullptr;
    }
    if (fTree == obj) {
-      fTree = 0;
+      fTree = nullptr;
    }
 }
 
@@ -2314,17 +2314,17 @@ void TChain::RemoveFriend(TTree* oldFriend)
 void TChain::Reset(Option_t*)
 {
    delete fFile;
-   fFile = 0;
+   fFile = nullptr;
    fNtrees         = 0;
    fTreeNumber     = -1;
-   fTree           = 0;
-   fFile           = 0;
+   fTree           = nullptr;
+   fFile           = nullptr;
    fFiles->Delete();
    fStatus->Delete();
    fTreeOffset[0]  = 0;
    TChainElement* element = new TChainElement("*", "");
    fStatus->Add(element);
-   fDirectory = 0;
+   fDirectory = nullptr;
 
    TTree::Reset();
 }
@@ -2337,8 +2337,8 @@ void TChain::ResetAfterMerge(TFileMergeInfo *info)
 {
    fNtrees         = 0;
    fTreeNumber     = -1;
-   fTree           = 0;
-   fFile           = 0;
+   fTree           = nullptr;
+   fFile           = nullptr;
    fFiles->Delete();
    fTreeOffset[0]  = 0;
 
@@ -2460,7 +2460,7 @@ void TChain::ResetBranchAddress(TBranch *branch)
 {
    TChainElement* element = (TChainElement*) fStatus->FindObject(branch->GetName());
    if (element) {
-      element->SetBaddress(0);
+      element->SetBaddress(nullptr);
    }
    if (fTree) {
       fTree->ResetBranchAddress(branch);
@@ -2473,9 +2473,9 @@ void TChain::ResetBranchAddress(TBranch *branch)
 void TChain::ResetBranchAddresses()
 {
    TIter next(fStatus);
-   TChainElement* element = 0;
+   TChainElement* element = nullptr;
    while ((element = (TChainElement*) next())) {
-      element->SetBaddress(0);
+      element->SetBaddress(nullptr);
    }
    if (fTree) {
       fTree->ResetBranchAddresses();
@@ -2548,7 +2548,7 @@ Int_t TChain::SetBranchAddress(const char *bname, void* add, TBranch** ptr)
       }
    } else {
       if (ptr) {
-         *ptr = 0;
+         *ptr = nullptr;
       }
    }
    return res;
@@ -2563,7 +2563,7 @@ Int_t TChain::SetBranchAddress(const char *bname, void* add, TBranch** ptr)
 
 Int_t TChain::SetBranchAddress(const char* bname, void* add, TClass* realClass, EDataType datatype, Bool_t isptr)
 {
-   return SetBranchAddress(bname, add, 0, realClass, datatype, isptr);
+   return SetBranchAddress(bname, add, nullptr, realClass, datatype, isptr);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2639,7 +2639,7 @@ void TChain::SetDirectory(TDirectory* dir)
       fDirectory->Append(this);
       fFile = fDirectory->GetFile();
    } else {
-      fFile = 0;
+      fFile = nullptr;
    }
 }
 
@@ -2675,20 +2675,20 @@ void TChain::SetEntryList(TEntryList *elist, Option_t *opt)
       //TEventList in SetEventList() function)
       if (fEntryList->TestBit(kCanDelete)) {
          TEntryList *tmp = fEntryList;
-         fEntryList = 0; // Avoid problem with RecursiveRemove.
+         fEntryList = nullptr; // Avoid problem with RecursiveRemove.
          delete tmp;
       } else {
-         fEntryList = 0;
+         fEntryList = nullptr;
       }
    }
    if (!elist){
-      fEntryList = 0;
-      fEventList = 0;
+      fEntryList = nullptr;
+      fEventList = nullptr;
       return;
    }
    if (!elist->TestBit(kCanDelete)){
       //this is a direct call to SetEntryList, not via SetEventList
-      fEventList = 0;
+      fEventList = nullptr;
    }
    if (elist->GetN() == 0){
       fEntryList = elist;
@@ -2697,7 +2697,7 @@ void TChain::SetEntryList(TEntryList *elist, Option_t *opt)
    if (fProofChain){
       //for processing on proof, event list and entry list can't be
       //set at the same time.
-      fEventList = 0;
+      fEventList = nullptr;
       fEntryList = elist;
       return;
    }
@@ -2706,7 +2706,7 @@ void TChain::SetEntryList(TEntryList *elist, Option_t *opt)
    Int_t listfound=0;
    TString treename, filename;
 
-   TEntryList *templist = 0;
+   TEntryList *templist = nullptr;
 
    const auto *subentrylists = elist->GetLists();
    if(strcmp(opt, "sync") == 0){
@@ -2770,7 +2770,7 @@ void TChain::SetEntryList(TEntryList *elist, Option_t *opt)
 
    if (listfound == 0){
       Error("SetEntryList", "No list found for the trees in this chain");
-      fEntryList = 0;
+      fEntryList = nullptr;
       return;
    }
    fEntryList = elist;
@@ -2821,14 +2821,14 @@ void TChain::SetEntryListFile(const char *filename, Option_t * /*opt*/)
       //TEventList in SetEventList() function)
       if (fEntryList->TestBit(kCanDelete)) {
          TEntryList *tmp = fEntryList;
-         fEntryList = 0; // Avoid problem with RecursiveRemove.
+         fEntryList = nullptr; // Avoid problem with RecursiveRemove.
          delete tmp;
       } else {
-         fEntryList = 0;
+         fEntryList = nullptr;
       }
    }
 
-   fEventList = 0;
+   fEventList = nullptr;
 
    TString basename(filename);
 
@@ -2842,7 +2842,7 @@ void TChain::SetEntryListFile(const char *filename, Option_t * /*opt*/)
    }
    fEntryList = new TEntryListFromFile(basename.Data(), behind_dot_root.Data(), fNtrees);
    fEntryList->SetBit(kCanDelete, kTRUE);
-   fEntryList->SetDirectory(0);
+   fEntryList->SetDirectory(nullptr);
    ((TEntryListFromFile*)fEntryList)->SetFileNames(fFiles);
 }
 
@@ -2864,16 +2864,16 @@ void TChain::SetEventList(TEventList *evlist)
    if (fEntryList) {
       if (fEntryList->TestBit(kCanDelete)) {
          TEntryList *tmp = fEntryList;
-         fEntryList = 0; // Avoid problem with RecursiveRemove.
+         fEntryList = nullptr; // Avoid problem with RecursiveRemove.
          delete tmp;
       } else {
-         fEntryList = 0;
+         fEntryList = nullptr;
       }
    }
 
    if (!evlist) {
-      fEntryList = 0;
-      fEventList = 0;
+      fEntryList = nullptr;
+      fEventList = nullptr;
       return;
    }
 
@@ -2885,10 +2885,10 @@ void TChain::SetEventList(TEventList *evlist)
          //TEventList in SetEventList() function)
          if (fEntryList->TestBit(kCanDelete)){
             TEntryList *tmp = fEntryList;
-            fEntryList = 0; // Avoid problem with RecursiveRemove.
+            fEntryList = nullptr; // Avoid problem with RecursiveRemove.
             delete tmp;
          } else {
-            fEntryList = 0;
+            fEntryList = nullptr;
          }
       }
       return;
@@ -2897,7 +2897,7 @@ void TChain::SetEventList(TEventList *evlist)
    char enlistname[100];
    snprintf(enlistname,100, "%s_%s", evlist->GetName(), "entrylist");
    TEntryList *enlist = new TEntryList(enlistname, evlist->GetTitle());
-   enlist->SetDirectory(0);
+   enlist->SetDirectory(nullptr);
 
    Int_t nsel = evlist->GetN();
    Long64_t globalentry, localentry;

--- a/tree/tree/src/TChainElement.cxx
+++ b/tree/tree/src/TChainElement.cxx
@@ -25,11 +25,11 @@ ClassImp(TChainElement);
 ////////////////////////////////////////////////////////////////////////////////
 /// Default constructor for a chain element.
 
-TChainElement::TChainElement() : TNamed(),fBaddress(0),fBaddressType(0),
-   fBaddressIsPtr(kFALSE), fDecomposedObj(kFALSE), fCheckedType(kFALSE), fBranchPtr(0), fLoadResult(0)
+TChainElement::TChainElement() : TNamed(),fBaddress(nullptr),fBaddressType(0),
+   fBaddressIsPtr(kFALSE), fDecomposedObj(kFALSE), fCheckedType(kFALSE), fBranchPtr(nullptr), fLoadResult(0)
 {
    fNPackets   = 0;
-   fPackets    = 0;
+   fPackets    = nullptr;
    fEntries    = 0;
    fPacketSize = 100;
    fStatus     = -1;
@@ -40,11 +40,11 @@ TChainElement::TChainElement() : TNamed(),fBaddress(0),fBaddressType(0),
 /// Create a chain element.
 
 TChainElement::TChainElement(const char *name, const char *title)
-   :TNamed(name,title),fBaddress(0),fBaddressType(0),
-    fBaddressIsPtr(kFALSE), fDecomposedObj(kFALSE), fCheckedType(kFALSE), fBranchPtr(0), fLoadResult(0)
+   :TNamed(name,title),fBaddress(nullptr),fBaddressType(0),
+    fBaddressIsPtr(kFALSE), fDecomposedObj(kFALSE), fCheckedType(kFALSE), fBranchPtr(nullptr), fLoadResult(0)
 {
    fNPackets   = 0;
-   fPackets    = 0;
+   fPackets    = nullptr;
    fEntries    = 0;
    fPacketSize = 100;
    fStatus     = -1;

--- a/tree/tree/src/TEntryList.cxx
+++ b/tree/tree/src/TEntryList.cxx
@@ -162,16 +162,16 @@ ClassImp(TEntryList);
 
 TEntryList::TEntryList() : fEntriesToProcess(0)
 {
-   fLists = 0;
-   fCurrent = 0;
-   fBlocks = 0;
+   fLists = nullptr;
+   fCurrent = nullptr;
+   fBlocks = nullptr;
    fN = 0;
    fNBlocks = 0;
    fTreeName = "";
    fFileName = "";
    fStringHash = 0;
    fTreeNumber = -1;
-   fDirectory = 0;
+   fDirectory = nullptr;
    fReapply = kFALSE;
    fLastIndexQueried = -1;
    fLastIndexReturned = 0;
@@ -185,9 +185,9 @@ TEntryList::TEntryList(const char *name, const char *title) :
    TNamed(name, title),
    fEntriesToProcess(0)
 {
-   fLists = 0;
-   fCurrent = 0;
-   fBlocks = 0;
+   fLists = nullptr;
+   fCurrent = nullptr;
+   fBlocks = nullptr;
    fN = 0;
    fNBlocks = 0;
    fTreeName = "";
@@ -209,9 +209,9 @@ TEntryList::TEntryList(const char *name, const char *title) :
 
 TEntryList::TEntryList(const char *name, const char *title, const TTree *tree):TNamed(name, title)
 {
-   fLists = 0;
-   fCurrent = 0;
-   fBlocks = 0;
+   fLists = nullptr;
+   fCurrent = nullptr;
+   fBlocks = nullptr;
    fN = 0;
    fNBlocks = 0;
    fTreeNumber = -1;
@@ -231,9 +231,9 @@ TEntryList::TEntryList(const char *name, const char *title, const TTree *tree):T
 
 TEntryList::TEntryList(const char *name, const char *title, const char *treename, const char *filename) : TNamed(name, title),fEntriesToProcess(0)
 {
-   fLists = 0;
-   fCurrent = 0;
-   fBlocks = 0;
+   fLists = nullptr;
+   fCurrent = nullptr;
+   fBlocks = nullptr;
    fNBlocks = 0;
    fN = 0;
    SetTree(treename, filename);
@@ -253,9 +253,9 @@ TEntryList::TEntryList(const char *name, const char *title, const char *treename
 
 TEntryList::TEntryList(const TTree *tree) : fEntriesToProcess(0)
 {
-   fLists = 0;
-   fCurrent = 0;
-   fBlocks = 0;
+   fLists = nullptr;
+   fCurrent = nullptr;
+   fBlocks = nullptr;
    fNBlocks = 0;
    fN = 0;
 
@@ -285,15 +285,15 @@ TEntryList::TEntryList(const TEntryList &elist) : TNamed(elist)
    fLastIndexReturned = 0;
    fN = elist.fN;
    fShift = elist.fShift;
-   fLists = 0;
-   fBlocks = 0;
+   fLists = nullptr;
+   fBlocks = nullptr;
    fReapply = elist.fReapply;
-   fCurrent = 0;
+   fCurrent = nullptr;
    fEntriesToProcess = elist.fEntriesToProcess;
    if (elist.fLists){
       fLists = new TList();
-      TEntryList *el1 = 0;
-      TEntryList *el2 = 0;
+      TEntryList *el1 = nullptr;
+      TEntryList *el2 = nullptr;
       TIter next(elist.fLists);
       while((el1 = (TEntryList*)next())){
          el2 = new TEntryList(*el1);
@@ -303,8 +303,8 @@ TEntryList::TEntryList(const TEntryList &elist) : TNamed(elist)
       }
    } else {
       if (elist.fBlocks){
-         TEntryListBlock *block1 = 0;
-         TEntryListBlock *block2 = 0;
+         TEntryListBlock *block1 = nullptr;
+         TEntryListBlock *block2 = nullptr;
          //or just copy it as a TObjArray??
          fBlocks = new TObjArray();
          for (Int_t i=0; i<fNBlocks; i++){
@@ -315,7 +315,7 @@ TEntryList::TEntryList(const TEntryList &elist) : TNamed(elist)
       }
       fCurrent = this;
    }
-   fDirectory  = 0;
+   fDirectory  = nullptr;
 
 }
 
@@ -328,16 +328,16 @@ TEntryList::~TEntryList()
       fBlocks->Delete();
       delete fBlocks;
    }
-   fBlocks = 0;
+   fBlocks = nullptr;
    if (fLists){
       fLists->Delete();
       delete fLists;
    }
 
-   fLists = 0;
+   fLists = nullptr;
 
    if (fDirectory) fDirectory->Remove(this);
-   fDirectory  = 0;
+   fDirectory  = nullptr;
 
 }
 
@@ -373,8 +373,8 @@ void TEntryList::Add(const TEntryList *elist)
          fN = elist->fN;
          if (elist->fLists){
             fLists = new TList();
-            TEntryList *el1 = 0;
-            TEntryList *el2 = 0;
+            TEntryList *el1 = nullptr;
+            TEntryList *el2 = nullptr;
             TIter next(elist->fLists);
             while((el1 = (TEntryList*)next())){
                el2 = new TEntryList(*el1);
@@ -384,8 +384,8 @@ void TEntryList::Add(const TEntryList *elist)
             }
          } else {
             if (elist->fBlocks){
-               TEntryListBlock *block1 = 0;
-               TEntryListBlock *block2 = 0;
+               TEntryListBlock *block1 = nullptr;
+               TEntryListBlock *block2 = nullptr;
                fBlocks = new TObjArray();
                for (Int_t i=0; i<fNBlocks; i++){
                   block1 = (TEntryListBlock*)elist->fBlocks->UncheckedAt(i);
@@ -393,7 +393,7 @@ void TEntryList::Add(const TEntryList *elist)
                   fBlocks->Add(block2);
                }
             }
-            fCurrent = 0;
+            fCurrent = nullptr;
          }
          return;
       }
@@ -408,8 +408,8 @@ void TEntryList::Add(const TEntryList *elist)
                return;
             if (!fBlocks){
                //this entry list is empty
-               TEntryListBlock *block1 = 0;
-               TEntryListBlock *block2 = 0;
+               TEntryListBlock *block1 = nullptr;
+               TEntryListBlock *block2 = nullptr;
                fNBlocks = elist->fNBlocks;
                fN = elist->fN;
                fBlocks = new TObjArray();
@@ -421,8 +421,8 @@ void TEntryList::Add(const TEntryList *elist)
                return;
             }
             //both not empty, merge block by block
-            TEntryListBlock *block1=0;
-            TEntryListBlock *block2=0;
+            TEntryListBlock *block1=nullptr;
+            TEntryListBlock *block2=nullptr;
             Int_t i;
             Int_t nmin = TMath::Min(fNBlocks, elist->fNBlocks);
             Long64_t nnew, nold;
@@ -455,7 +455,7 @@ void TEntryList::Add(const TEntryList *elist)
             el->fTreeName = fTreeName;
             el->fFileName = fFileName;
             el->fBlocks = fBlocks;
-            fBlocks = 0;
+            fBlocks = nullptr;
             el->fNBlocks = fNBlocks;
             el->fN = fN;
             el->fLastIndexQueried = -1;
@@ -466,23 +466,23 @@ void TEntryList::Add(const TEntryList *elist)
             el->fLastIndexReturned = 0;
             fLists->Add(el);
             fN+=el->GetN();
-            fCurrent = 0;
+            fCurrent = nullptr;
          }
       } else {
          //second list already has sublists. add one by one
-         TEntryList *el = 0;
+         TEntryList *el = nullptr;
          TIter next(elist->fLists);
          while ((el = (TEntryList*)next())){
             Add(el);
          }
-         fCurrent = 0;
+         fCurrent = nullptr;
       }
    } else {
       //there are already some sublists in this list, just add another one
       if (!elist->fLists){
          //the other list doesn't have sublists
          TIter next(fLists);
-         TEntryList *el = 0;
+         TEntryList *el = nullptr;
          Bool_t found = kFALSE;
          while ((el = (TEntryList*)next())){
             if (!strcmp(el->fTreeName.Data(), elist->fTreeName.Data()) &&
@@ -505,12 +505,12 @@ void TEntryList::Add(const TEntryList *elist)
          }
       } else {
          //add all sublists from the other list
-         TEntryList *el = 0;
+         TEntryList *el = nullptr;
          TIter next(elist->fLists);
          while ((el = (TEntryList*)next())){
             Add(el);
          }
-         fCurrent = 0;
+         fCurrent = nullptr;
       }
       if (fCurrent){
          if (fCurrent->fBlocks){
@@ -521,7 +521,7 @@ void TEntryList::Add(const TEntryList *elist)
             fCurrent->fLastIndexQueried = -1;
          }
       }
-      fCurrent = 0;
+      fCurrent = nullptr;
    }
 
 }
@@ -588,7 +588,7 @@ Int_t TEntryList::Contains(Long64_t entry, TTree *tree)
    if (!tree){
       if (fBlocks) {
          //this entry list doesn't contain any sub-lists
-         TEntryListBlock *block = 0;
+         TEntryListBlock *block = nullptr;
          Int_t nblock = entry/kBlockSize;
          if (nblock >= fNBlocks) return 0;
          block = (TEntryListBlock*)fBlocks->UncheckedAt(nblock);
@@ -629,7 +629,7 @@ Bool_t TEntryList::Enter(Long64_t entry, TTree *tree)
    if (!tree){
       if (!fLists) {
          if (!fBlocks) fBlocks = new TObjArray();
-         TEntryListBlock *block = 0;
+         TEntryListBlock *block = nullptr;
          Long64_t nblock = entry/kBlockSize;
          if (nblock >= fNBlocks) {
             if (fNBlocks>0){
@@ -717,7 +717,7 @@ Bool_t TEntryList::Remove(Long64_t entry, TTree *tree)
    if (!tree) {
       if (!fLists) {
          if (!fBlocks) return 0;
-         TEntryListBlock *block = 0;
+         TEntryListBlock *block = nullptr;
          Long64_t nblock = entry/kBlockSize;
          block = (TEntryListBlock*)fBlocks->UncheckedAt(nblock);
          if (!block) return 0;
@@ -763,7 +763,7 @@ Long64_t TEntryList::GetEntry(Long64_t index)
       return Next();
    } else {
       if (fBlocks) {
-         TEntryListBlock *block = 0;
+         TEntryListBlock *block = nullptr;
          Long64_t total_passed = 0;
          Int_t i=0;
          while (total_passed<=index && i<fNBlocks){
@@ -888,7 +888,7 @@ TEntryList *TEntryList::GetEntryList(const char *treename, const char *filename,
       Info("GetEntryList","tree: %s, file: %s",
                           (treename ? treename : "-"), (filename ? filename : "-"));
 
-   if (!treename || !filename) return 0;
+   if (!treename || !filename) return nullptr;
    TString option = opt;
    option.ToUpper();
    Bool_t nexp = option.Contains("NE");
@@ -915,7 +915,7 @@ TEntryList *TEntryList::GetEntryList(const char *treename, const char *filename,
             if (!strcmp(treename, fTreeName.Data()) && !(strcmp(fn.Data(), fFileName.Data())))
                return this;
          }
-         return 0;
+         return nullptr;
       }
    }
 
@@ -966,7 +966,7 @@ TEntryList *TEntryList::GetEntryList(const char *treename, const char *filename,
          }
       }
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -976,7 +976,7 @@ Int_t TEntryList::Merge(TCollection *list)
 {
    if (!list) return -1;
    TIter next(list);
-   TEntryList *elist = 0;
+   TEntryList *elist = nullptr;
    while ((elist = (TEntryList*)next())) {
       if (!elist->InheritsFrom(TEntryList::Class())) {
          Error("Add","Attempt to add object of class: %s to a %s",elist->ClassName(),this->ClassName());
@@ -1081,7 +1081,7 @@ Long64_t TEntryList::Next()
 void TEntryList::OptimizeStorage()
 {
    if (fBlocks){
-      TEntryListBlock *block = 0;
+      TEntryListBlock *block = nullptr;
       for (Int_t i=0; i<fNBlocks; i++){
          block = (TEntryListBlock*)fBlocks->UncheckedAt(i);
          block->OptimizeStorage();
@@ -1101,7 +1101,7 @@ void TEntryList::Print(const Option_t* option) const
    if (fBlocks) {
       Printf("%s %s %lld", fTreeName.Data(), fFileName.Data(), fN);
       if (opt.Contains("A")){
-         TEntryListBlock* block = 0;
+         TEntryListBlock* block = nullptr;
          for (Int_t i=0; i<fNBlocks; i++){
             block = (TEntryListBlock*)fBlocks->UncheckedAt(i);
             Int_t shift = i*kBlockSize;
@@ -1110,7 +1110,7 @@ void TEntryList::Print(const Option_t* option) const
       }
    }
    else {
-      TEntryList *elist = 0;
+      TEntryList *elist = nullptr;
       if (fN>0){
          TIter next(fLists);
          while((elist = (TEntryList*)next())){
@@ -1138,17 +1138,17 @@ void TEntryList::Reset()
    if (fBlocks){
       fBlocks->Delete();
       delete fBlocks;
-      fBlocks = 0;
+      fBlocks = nullptr;
    }
    if (fLists){
       if (!((TEntryList*)fLists->First())->GetDirectory()){
          fLists->Delete();
       }
       delete fLists;
-      fLists = 0;
+      fLists = nullptr;
    }
-   fCurrent = 0;
-   fBlocks = 0;
+   fCurrent = nullptr;
+   fBlocks = nullptr;
    fNBlocks = 0;
    fN = 0;
    fTreeName = "";
@@ -1179,7 +1179,7 @@ void TEntryList::SetDirectory(TDirectory *dir)
 
 void TEntryList::SetTree(const char *treename, const char *filename)
 {
-   TEntryList *elist = 0;
+   TEntryList *elist = nullptr;
 
    TString fn;
    GetFileName(filename, fn);
@@ -1226,7 +1226,7 @@ void TEntryList::SetTree(const char *treename, const char *filename)
       if (elist->GetDirectory()) {
          //sub lists are not added to the current directory
          elist->GetDirectory()->Remove(elist);
-         elist->SetDirectory(0);
+         elist->SetDirectory(nullptr);
       }
       fLists->Add(elist);
       fCurrent = elist;
@@ -1256,14 +1256,14 @@ void TEntryList::SetTree(const char *treename, const char *filename)
             elist->fN = fN;
             elist->fTreeNumber = fTreeNumber;
             elist->fBlocks = fBlocks;
-            fBlocks = 0;
+            fBlocks = nullptr;
             elist->fNBlocks = fNBlocks;
             fLists->Add(elist);
             elist = new TEntryList("", "", treename, fn.Data());
             if (elist->GetDirectory()) {
                //sub lists are not added to the current directory
                elist->GetDirectory()->Remove(elist);
-               elist->SetDirectory(0);
+               elist->SetDirectory(nullptr);
             }
             fLists->Add(elist);
             fCurrent = elist;
@@ -1327,7 +1327,7 @@ void TEntryList::SetTree(const TTree *tree)
 
 void TEntryList::Subtract(const TEntryList *elist)
 {
-   TEntryList *templist = 0;
+   TEntryList *templist = nullptr;
    if (!fLists){
       if (!fBlocks) return;
       //check if lists are for the same tree
@@ -1349,7 +1349,7 @@ void TEntryList::Subtract(const TEntryList *elist)
       } else {
          //second list has sublists, try to find one for the same tree as this list
          TIter next1(elist->GetLists());
-         templist = 0;
+         templist = nullptr;
          Bool_t found = kFALSE;
          while ((templist = (TEntryList*)next1())){
             if (!strcmp(templist->fTreeName.Data(),fTreeName.Data()) &&
@@ -1365,7 +1365,7 @@ void TEntryList::Subtract(const TEntryList *elist)
    } else {
       //this list has sublists
       TIter next2(fLists);
-      templist = 0;
+      templist = nullptr;
       Long64_t oldn=0;
       while ((templist = (TEntryList*)next2())){
          oldn = templist->GetN();
@@ -1415,7 +1415,7 @@ Int_t TEntryList::RelocatePaths(const char *newroot, const char *oldroot)
    // Apply to all underlying lists, if any
    if (fLists) {
       TIter nxl(fLists);
-      TEntryList *enl = 0;
+      TEntryList *enl = nullptr;
       while ((enl = (TEntryList *) nxl())) {
          if ((xnrl = enl->RelocatePaths(newroot, oldroot)) < 0) {
             Warning("RelocatePaths", "problems relocating '%s'", enl->GetName());
@@ -1474,7 +1474,7 @@ Int_t TEntryList::Relocate(const char *fn,
    if (nm.IsNull()) nm = "*";
    TRegexp nmrg(nm, kTRUE);
    TIter nxk(fl->GetListOfKeys());
-   TKey *key = 0;
+   TKey *key = nullptr;
    while ((key = (TKey *) nxk())) {
       if (!strcmp(key->GetClassName(), "TEntryList")) {
          TString knm(key->GetName());
@@ -1552,7 +1552,7 @@ Int_t TEntryList::ScanPaths(TList *roots, Bool_t notify)
    // Apply to all underlying lists, if any
    if (fLists) {
       TIter nxl(fLists);
-      TEntryList *enl = 0;
+      TEntryList *enl = nullptr;
       while ((enl = (TEntryList *) nxl()))
          nrl += enl->ScanPaths(xrl, kFALSE);
    }
@@ -1613,7 +1613,7 @@ Int_t TEntryList::Scan(const char *fn, TList *roots)
    Int_t nrs = 0;
    // Read the lists
    TIter nxk(fl->GetListOfKeys());
-   TKey *key = 0;
+   TKey *key = nullptr;
    while ((key = (TKey *) nxk())) {
       if (!strcmp(key->GetClassName(), "TEntryList")) {
          TEntryList *enl = dynamic_cast<TEntryList *>(fl->Get(key->GetName()));

--- a/tree/tree/src/TEntryListArray.cxx
+++ b/tree/tree/src/TEntryListArray.cxx
@@ -81,51 +81,51 @@ ClassImp(TEntryListArray);
 
 void TEntryListArray::Init()
 {
-   fSubLists = 0;
+   fSubLists = nullptr;
    fEntry = -1;
-   fLastSubListQueried = 0;
-   fSubListIter = 0;
+   fLastSubListQueried = nullptr;
+   fSubListIter = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Default c-tor
 
-TEntryListArray::TEntryListArray() : TEntryList(), fSubLists(0), fEntry(-1), fLastSubListQueried(0), fSubListIter(0)
+TEntryListArray::TEntryListArray() : TEntryList(), fSubLists(nullptr), fEntry(-1), fLastSubListQueried(nullptr), fSubListIter(nullptr)
 {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// c-tor with name and title
 
-TEntryListArray::TEntryListArray(const char *name, const char *title): TEntryList(name, title), fSubLists(0), fEntry(-1), fLastSubListQueried(0), fSubListIter(0)
+TEntryListArray::TEntryListArray(const char *name, const char *title): TEntryList(name, title), fSubLists(nullptr), fEntry(-1), fLastSubListQueried(nullptr), fSubListIter(nullptr)
 {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 ///constructor with name and title, which also sets the tree
 
-TEntryListArray::TEntryListArray(const char *name, const char *title, const TTree *tree): TEntryList(name, title, tree), fSubLists(0), fEntry(-1), fLastSubListQueried(0), fSubListIter(0)
+TEntryListArray::TEntryListArray(const char *name, const char *title, const TTree *tree): TEntryList(name, title, tree), fSubLists(nullptr), fEntry(-1), fLastSubListQueried(nullptr), fSubListIter(nullptr)
 {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// c-tor with name and title, which also sets the treename and the filename
 
-TEntryListArray::TEntryListArray(const char *name, const char *title, const char *treename, const char *filename): TEntryList(name, title, treename, filename), fSubLists(0), fEntry(-1), fLastSubListQueried(0), fSubListIter(0)
+TEntryListArray::TEntryListArray(const char *name, const char *title, const char *treename, const char *filename): TEntryList(name, title, treename, filename), fSubLists(nullptr), fEntry(-1), fLastSubListQueried(nullptr), fSubListIter(nullptr)
 {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// c-tor, which sets the tree
 
-TEntryListArray::TEntryListArray(const TTree *tree) : TEntryList(tree), fSubLists(0), fEntry(-1), fLastSubListQueried(0), fSubListIter(0)
+TEntryListArray::TEntryListArray(const TTree *tree) : TEntryList(tree), fSubLists(nullptr), fEntry(-1), fLastSubListQueried(nullptr), fSubListIter(nullptr)
 {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy c-tor
 
-TEntryListArray::TEntryListArray(const TEntryListArray &elist) : TEntryList(), fSubLists(0), fEntry(-1), fLastSubListQueried(0), fSubListIter(0)
+TEntryListArray::TEntryListArray(const TEntryListArray &elist) : TEntryList(), fSubLists(nullptr), fEntry(-1), fLastSubListQueried(nullptr), fSubListIter(nullptr)
 {
    fEntry = elist.fEntry;
    Add(&elist);
@@ -134,7 +134,7 @@ TEntryListArray::TEntryListArray(const TEntryListArray &elist) : TEntryList(), f
 ////////////////////////////////////////////////////////////////////////////////
 /// c-tor, from TEntryList
 
-TEntryListArray::TEntryListArray(const TEntryList& elist) : TEntryList(elist), fSubLists(0), fEntry(-1), fLastSubListQueried(0), fSubListIter(0)
+TEntryListArray::TEntryListArray(const TEntryList& elist) : TEntryList(elist), fSubLists(nullptr), fEntry(-1), fLastSubListQueried(nullptr), fSubListIter(nullptr)
 {
 }
 
@@ -147,9 +147,9 @@ TEntryListArray::~TEntryListArray()
       fSubLists->Delete();
       delete fSubLists;
    }
-   fSubLists = 0;
+   fSubLists = nullptr;
    delete fSubListIter;
-   fSubListIter = 0;
+   fSubListIter = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -168,7 +168,7 @@ void TEntryListArray::Add(const TEntryList *elist)
    // This would happen in any case when calling TEntryList::Add
    if (elist->GetLists()) { // the other list has lists to hold multiple trees, add one by one
       TIter next(elist->GetLists());
-      const TEntryList *e = 0;
+      const TEntryList *e = nullptr;
       while ((e = (const TEntryList*)next())) {
          SetTree(e->GetTreeName(), e->GetFileName());
       }
@@ -194,7 +194,7 @@ void TEntryListArray::AddEntriesAndSubLists(const TEntryList *elist)
    if (!elist) return;
 
    if (fLists) { // This list is split
-      TEntryListArray* e = 0;
+      TEntryListArray* e = nullptr;
       TIter next(fLists);
       fN = 0; // reset fN to set it to the sum of fN in each list
       // Only need to do it here and the next condition will be called only from here
@@ -204,7 +204,7 @@ void TEntryListArray::AddEntriesAndSubLists(const TEntryList *elist)
       }
    } else if (elist->GetLists()) { // The other list is split --> will be called only from the previous if
       TIter next(elist->GetLists());
-      TEntryList *e = 0;
+      TEntryList *e = nullptr;
       while ((e = (TEntryList*) next())) {
          AddEntriesAndSubLists(e);
       }
@@ -225,7 +225,7 @@ void TEntryListArray::AddEntriesAndSubLists(const TEntryList *elist)
       }
       TEntryListArray *el1;
       const TEntryListArray *el2;
-      TCollection *other_sublists = 0;
+      TCollection *other_sublists = nullptr;
       if (elist_array) {
          other_sublists = elist_array->GetSubLists();
       }
@@ -275,7 +275,7 @@ Int_t TEntryListArray::Contains(Long64_t entry, TTree *tree, Long64_t subentry)
       SetTree(tree->GetTree());
       TEntryListArray *currentArray = dynamic_cast<TEntryListArray*>(fCurrent);
       if (currentArray) {
-         return currentArray->Contains(localentry, 0, subentry);
+         return currentArray->Contains(localentry, nullptr, subentry);
       }
       return 0;
    }
@@ -317,7 +317,7 @@ void TEntryListArray::ConvertToTEntryListArray(TEntryList *e)
    // and must keep the current sublists
    if (fSubLists) {
       earray->fSubLists = fSubLists;
-      fSubLists = 0;
+      fSubLists = nullptr;
    }
    if (e == fLists->First()) {
       fLists->AddFirst(earray);
@@ -326,7 +326,7 @@ void TEntryListArray::ConvertToTEntryListArray(TEntryList *e)
    }
    fLists->Remove(e);
    delete e;
-   e = 0;
+   e = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -350,7 +350,7 @@ Bool_t TEntryListArray::Enter(Long64_t entry, TTree *tree, Long64_t subentry)
       SetTree(tree->GetTree());
       TEntryListArray *currentArray = dynamic_cast<TEntryListArray*>(fCurrent);
       if (currentArray) {
-         if ((result = currentArray->Enter(localentry, 0, subentry)))
+         if ((result = currentArray->Enter(localentry, nullptr, subentry)))
             if (fLists) ++fN;
       }
       return result;
@@ -358,7 +358,7 @@ Bool_t TEntryListArray::Enter(Long64_t entry, TTree *tree, Long64_t subentry)
    if (fLists) {
       if (!fCurrent) fCurrent = (TEntryList*)fLists->First();
       TEntryListArray *currentArray = dynamic_cast<TEntryListArray*>(fCurrent);
-      if (currentArray && (result = currentArray->Enter(entry, 0, subentry))) {
+      if (currentArray && (result = currentArray->Enter(entry, nullptr, subentry))) {
          ++fN;
       }
       return result;
@@ -388,7 +388,7 @@ Bool_t TEntryListArray::Enter(Long64_t localentry, const char *treename, const c
    SetTree(treename, filename);
    TEntryListArray *currentArray = dynamic_cast<TEntryListArray *>(fCurrent);
    if (currentArray) {
-      if ((result = currentArray->Enter(localentry, 0, subentry)))
+      if ((result = currentArray->Enter(localentry, nullptr, subentry)))
          if (fLists)
             ++fN;
    }
@@ -409,12 +409,12 @@ TEntryListArray* TEntryListArray::GetSubListForEntry(Long64_t entry, TTree *tree
             return currentArray->GetSubListForEntry(localentry);
          }
       }
-      return 0;
+      return nullptr;
    }
    // tree = 0
 
    if (!fSubLists || !fSubLists->GetEntries()) {
-      return 0;
+      return nullptr;
    }
 
    if (!fSubListIter) {
@@ -441,7 +441,7 @@ TEntryListArray* TEntryListArray::GetSubListForEntry(Long64_t entry, TTree *tree
          break;
       }
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -463,7 +463,7 @@ void TEntryListArray::Print(const Option_t* option) const
 
    if (fLists) {
       TIter next(fLists);
-      TEntryListArray *e = 0;
+      TEntryListArray *e = nullptr;
       while ((e = (TEntryListArray*)next())) {
          std::cout << e->fTreeName << ":" << std::endl;
          e->Print(option);
@@ -508,7 +508,7 @@ Bool_t TEntryListArray::Remove(Long64_t entry, TTree *tree, Long64_t subentry)
       Long64_t localentry = tree->LoadTree(entry);
       SetTree(tree->GetTree());
       TEntryListArray *currentArray = dynamic_cast<TEntryListArray*>(fCurrent);
-      if (currentArray && (result = currentArray->Remove(localentry, 0, subentry))) {
+      if (currentArray && (result = currentArray->Remove(localentry, nullptr, subentry))) {
          if (fLists) {
             --fN;
          }
@@ -518,7 +518,7 @@ Bool_t TEntryListArray::Remove(Long64_t entry, TTree *tree, Long64_t subentry)
    if (fLists) {
       if (!fCurrent) fCurrent = (TEntryList*)fLists->First();
       TEntryListArray *currentArray = dynamic_cast<TEntryListArray*>(fCurrent);
-      if (currentArray && (result = currentArray->Remove(entry, 0, subentry)) && fLists) {
+      if (currentArray && (result = currentArray->Remove(entry, nullptr, subentry)) && fLists) {
          --fN;
       }
       return result;
@@ -604,7 +604,7 @@ void TEntryListArray::Reset()
 
 TEntryListArray* TEntryListArray::SetEntry(Long64_t entry, TTree *tree)
 {
-   if (entry < 0) return 0;
+   if (entry < 0) return nullptr;
 
    // If tree is given, switch to the list that contains tree
    if (tree) {
@@ -614,7 +614,7 @@ TEntryListArray* TEntryListArray::SetEntry(Long64_t entry, TTree *tree)
       if (currentArray) {
          return currentArray->SetEntry(localentry);
       }
-      return 0;
+      return nullptr;
    }
    // tree = 0
    if (!fSubLists) {
@@ -643,7 +643,7 @@ void TEntryListArray::Subtract(const TEntryList *elist)
    if (!elist) return;
 
    if (fLists) { // This list is split
-      TEntryListArray* e = 0;
+      TEntryListArray* e = nullptr;
       TIter next(fLists);
       fN = 0; // reset fN to set it to the sum of fN in each list
       while ((e = (TEntryListArray*) next())) {
@@ -652,7 +652,7 @@ void TEntryListArray::Subtract(const TEntryList *elist)
       }
    } else if (elist->GetLists()) { // The other list is split
       TIter next(elist->GetLists());
-      TEntryList *e = 0;
+      TEntryList *e = nullptr;
       while ((e = (TEntryList*) next())) {
          Subtract(e);
       }
@@ -663,7 +663,7 @@ void TEntryListArray::Subtract(const TEntryList *elist)
       if (!fSubLists || !elist_array || !elist_array->GetSubLists()) {  // there are no sublists in one of the lists
          TEntryList::Subtract(elist);
          if (fSubLists) {
-            TEntryListArray *e = 0;
+            TEntryListArray *e = nullptr;
             TIter next(fSubLists);
             while ((e = (TEntryListArray*) next())) {
                if (!Contains(e->fEntry))

--- a/tree/tree/src/TEntryListBlock.cxx
+++ b/tree/tree/src/TEntryListBlock.cxx
@@ -53,7 +53,7 @@ ClassImp(TEntryListBlock);
 
 TEntryListBlock::TEntryListBlock()
 {
-   fIndices = 0;
+   fIndices = nullptr;
    fN = kBlockSize;
    fNPassed = 0;
    fType = -1;
@@ -74,7 +74,7 @@ TEntryListBlock::TEntryListBlock(const TEntryListBlock &eblock) : TObject(eblock
       for (Int_t i=0; i<fN; i++)
          fIndices[i] = eblock.fIndices[i];
    } else {
-      fIndices = 0;
+      fIndices = nullptr;
    }
    fNPassed = eblock.fNPassed;
    fType = eblock.fType;
@@ -91,7 +91,7 @@ TEntryListBlock::~TEntryListBlock()
 {
    if (fIndices)
       delete [] fIndices;
-   fIndices = 0;
+   fIndices = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -108,7 +108,7 @@ TEntryListBlock &TEntryListBlock::operator=(const TEntryListBlock &eblock)
          for (Int_t i=0; i<fN; i++)
             fIndices[i] = eblock.fIndices[i];
       } else {
-         fIndices = 0;
+         fIndices = nullptr;
       }
       fNPassed = eblock.fNPassed;
       fType = eblock.fType;

--- a/tree/tree/src/TEntryListFromFile.cxx
+++ b/tree/tree/src/TEntryListFromFile.cxx
@@ -41,7 +41,7 @@ list.
 ClassImp(TEntryListFromFile);
 
 TEntryListFromFile::TEntryListFromFile(): TEntryList(),
-   fListFileName(""), fListName(""), fNFiles(0), fListOffset(0), fFile(0), fFileNames(0)
+   fListFileName(""), fListName(""), fNFiles(0), fListOffset(nullptr), fFile(nullptr), fFileNames(nullptr)
 {
    // default constructor.
 
@@ -62,7 +62,7 @@ TEntryListFromFile::TEntryListFromFile(): TEntryList(),
 /// nfiles is the total number of files to process
 
 TEntryListFromFile::TEntryListFromFile(const char *filename, const char *listname, Int_t nfiles) : TEntryList(),
-   fListFileName(filename), fListName(listname), fNFiles(nfiles), fListOffset(0), fFile(0), fFileNames(0)
+   fListFileName(filename), fListName(listname), fNFiles(nfiles), fListOffset(nullptr), fFile(nullptr), fFileNames(nullptr)
 {
    fListOffset = new Long64_t[fNFiles+1];
    fListOffset[0]=0;
@@ -78,9 +78,9 @@ TEntryListFromFile::TEntryListFromFile(const char *filename, const char *listnam
 TEntryListFromFile::~TEntryListFromFile()
 {
    delete [] fListOffset;
-   fListOffset = 0;
+   fListOffset = nullptr;
    delete fFile;
-   fFile = 0;
+   fFile = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -234,8 +234,8 @@ Int_t TEntryListFromFile::LoadList(Int_t listnumber)
    if (fCurrent){
       if (fFile) {
          delete fFile;
-         fFile = 0;
-         fCurrent = 0;
+         fFile = nullptr;
+         fCurrent = nullptr;
       }
    }
 
@@ -263,9 +263,9 @@ Int_t TEntryListFromFile::LoadList(Int_t listnumber)
    if (!fFile || fFile->IsZombie()){
       if (fFile) {
          delete fFile;
-         fFile = 0;
+         fFile = nullptr;
       }
-      fCurrent = 0;
+      fCurrent = nullptr;
       fListOffset[listnumber+1] = fListOffset[listnumber];
       return -1;
    }
@@ -285,7 +285,7 @@ Int_t TEntryListFromFile::LoadList(Int_t listnumber)
 
    if (!fCurrent){
       Error("LoadList", "List %s not found in the file\n", fListName.Data());
-      fCurrent = 0;
+      fCurrent = nullptr;
       fListOffset[listnumber+1]=fListOffset[listnumber];
       return -1;
    }
@@ -306,8 +306,8 @@ void TEntryListFromFile::Print(const Option_t* option) const
 {
    printf("total number of files: %d\n", fNFiles);
    TFile *f;
-   TEntryList *el=0;
-   if (fFileNames==0) {
+   TEntryList *el=nullptr;
+   if (fFileNames==nullptr) {
       Error("Print","fFileNames was not set properly.");
    } else {
       for (Int_t listnumber=0; listnumber<fNFiles; listnumber++){

--- a/tree/tree/src/TEventList.cxx
+++ b/tree/tree/src/TEventList.cxx
@@ -63,8 +63,8 @@ TEventList::TEventList(): TNamed()
    fN          = 0;
    fSize       = 100;
    fDelta      = 100;
-   fList       = 0;
-   fDirectory  = 0;
+   fList       = nullptr;
+   fDirectory  = nullptr;
    fReapply    = kFALSE;
 }
 
@@ -81,7 +81,7 @@ TEventList::TEventList(const char *name, const char *title, Int_t initsize, Int_
    else                fSize  = 100;
    if (delta > 100)    fDelta = delta;
    else                fDelta = 100;
-   fList       = 0;
+   fList       = nullptr;
    fDirectory  = gDirectory;
    if (fDirectory) fDirectory->Append(this);
 }
@@ -98,7 +98,7 @@ TEventList::TEventList(const TEventList &list) : TNamed(list)
    for (Int_t i=0; i<fN; i++)
       fList[i] = list.fList[i];
    fReapply = list.fReapply;
-   fDirectory = 0;
+   fDirectory = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -106,9 +106,9 @@ TEventList::TEventList(const TEventList &list) : TNamed(list)
 
 TEventList::~TEventList()
 {
-   delete [] fList;  fList = 0;
+   delete [] fList;  fList = nullptr;
    if (fDirectory) fDirectory->Remove(this);
-   fDirectory  = 0;
+   fDirectory  = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -400,7 +400,7 @@ void TEventList::Streamer(TBuffer &b)
    if (b.IsReading()) {
       UInt_t R__s, R__c;
       Version_t R__v = b.ReadVersion(&R__s, &R__c);
-      fDirectory = 0;
+      fDirectory = nullptr;
       if (R__v > 1) {
          b.ReadClassBuffer(TEventList::Class(), this, R__v, R__s, R__c);
          ResetBit(kMustCleanup);

--- a/tree/tree/src/TFriendElement.cxx
+++ b/tree/tree/src/TFriendElement.cxx
@@ -37,10 +37,10 @@ ClassImp(TFriendElement);
 
 TFriendElement::TFriendElement() : TNamed()
 {
-   fFile       = 0;
-   fTree       = 0;
+   fFile       = nullptr;
+   fTree       = nullptr;
    fOwnFile    = kFALSE;
-   fParentTree = 0;
+   fParentTree = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -52,8 +52,8 @@ TFriendElement::TFriendElement() : TNamed()
 TFriendElement::TFriendElement(TTree *tree, const char *treename, const char *filename)
     :TNamed(treename,filename)
 {
-   fFile       = 0;
-   fTree       = 0;
+   fFile       = nullptr;
+   fTree       = nullptr;
    fOwnFile    = kTRUE;
    fParentTree = tree;
    fTreeName   = treename;
@@ -81,7 +81,7 @@ TFriendElement::TFriendElement(TTree *tree, const char *treename, TFile *file)
     :TNamed(treename,file?file->GetName():"")
 {
    fFile       = file;
-   fTree       = 0;
+   fTree       = nullptr;
    fOwnFile    = kFALSE;
    fParentTree = tree;
    fTreeName   = treename;
@@ -119,7 +119,7 @@ TFriendElement::TFriendElement(TTree *tree, TTree* friendtree, const char *alias
 {
    fTree       = friendtree;
    fTreeName   = "";
-   fFile       = 0;
+   fFile       = nullptr;
    fOwnFile    = kFALSE;
    fParentTree = tree;
    if (fTree) {
@@ -174,9 +174,9 @@ TTree *TFriendElement::DisConnect()
    if (fTree)
       fTree->RemoveExternalFriend(this);
    if (fOwnFile) delete fFile;
-   fFile = 0;
-   fTree = 0;
-   return 0;
+   fFile = nullptr;
+   fTree = nullptr;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -200,7 +200,7 @@ TFile *TFriendElement::GetFile()
    if (fFile && fFile->IsZombie()) {
       MakeZombie();
       delete fFile;
-      fFile = 0;
+      fFile = nullptr;
    }
    return fFile;
 }

--- a/tree/tree/src/TLeaf.cxx
+++ b/tree/tree/src/TLeaf.cxx
@@ -60,9 +60,9 @@ TLeaf::TLeaf()
    , fOffset(0)
    , fIsRange(kFALSE)
    , fIsUnsigned(kFALSE)
-   , fLeafCount(0)
-   , fBranch(0)
-   , fLeafCountValues(0)
+   , fLeafCount(nullptr)
+   , fBranch(nullptr)
+   , fLeafCountValues(nullptr)
 {
 }
 
@@ -79,9 +79,9 @@ TLeaf::TLeaf(TBranch *parent, const char* name, const char *)
    , fOffset(0)
    , fIsRange(kFALSE)
    , fIsUnsigned(kFALSE)
-   , fLeafCount(0)
+   , fLeafCount(nullptr)
    , fBranch(parent)
-   , fLeafCountValues(0)
+   , fLeafCountValues(nullptr)
 {
    fLeafCount = GetLeafCounter(fLen);
 
@@ -141,13 +141,13 @@ TLeaf::~TLeaf()
 {
    if (fBranch) {
       TTree* tree = fBranch->GetTree();
-      fBranch = 0;
+      fBranch = nullptr;
       if (tree) {
          TObjArray *lst = tree->GetListOfLeaves();
          if (lst->GetLast()!=-1) lst->Remove(this);
       }
    }
-   fLeafCount = 0;
+   fLeafCount = nullptr;
    delete fLeafCountValues;
 }
 
@@ -252,7 +252,7 @@ TLeaf* TLeaf::GetLeafCounter(Int_t& countval) const
    const char* name = GetTitle();
    char* bleft = (char*) strchr(name, '[');
    if (!bleft) {
-      return 0;
+      return nullptr;
    }
    bleft++;
    Int_t nch = strlen(bleft);
@@ -261,29 +261,29 @@ TLeaf* TLeaf::GetLeafCounter(Int_t& countval) const
    char* bright = (char*) strchr(countname, ']');
    if (!bright) {
       delete[] countname;
-      countname = 0;
+      countname = nullptr;
       countval = -1;
-      return 0;
+      return nullptr;
    }
    char *bleft2 = (char*) strchr(countname, '[');
    *bright = 0;
    nch = strlen(countname);
 
    // Now search a branch name with a leaf name = countname
-   if (fBranch == 0) {
+   if (fBranch == nullptr) {
       Error("GetLeafCounter","TLeaf %s is not setup properly, fBranch is null.",GetName());
       delete[] countname;
-      return 0;
+      return nullptr;
    }
-   if (fBranch->GetTree() == 0) {
+   if (fBranch->GetTree() == nullptr) {
       Error("GetLeafCounter","For Leaf %s, the TBranch %s is not setup properly, fTree is null.",GetName(),fBranch->GetName());
       delete[] countname;
-      return 0;
+      return nullptr;
    }
    TTree* pTree = fBranch->GetTree();
 
    TLeaf* leaf = (TLeaf*) GetBranch()->GetListOfLeaves()->FindObject(countname);
-   if (leaf == 0) {
+   if (leaf == nullptr) {
       // Try outside the branch:
       leaf = (TLeaf*) pTree->GetListOfLeaves()->FindObject(countname);
    }
@@ -295,7 +295,7 @@ TLeaf* TLeaf::GetLeafCounter(Int_t& countval) const
       strcpy(lastdot, countname);
       leaf = (TLeaf*) pTree->GetListOfLeaves()->FindObject(withdot);
       delete[] withdot;
-      withdot = 0;
+      withdot = nullptr;
    }
    if (!leaf && strchr(countname,'.')) {
       // Not yet found and the countname has a dot in it, let's try
@@ -322,16 +322,16 @@ TLeaf* TLeaf::GetLeafCounter(Int_t& countval) const
          bleft2 = bleft;
       }
       delete[] countname;
-      countname = 0;
+      countname = nullptr;
       return leaf;
    }
    // not found in a branch/leaf. Is it a numerical value?
    for (i = 0; i < nch; i++) {
       if (!isdigit(countname[i])) {
          delete[] countname;
-         countname = 0;
+         countname = nullptr;
          countval = -1;
-         return 0;
+         return nullptr;
       }
    }
    sscanf(countname, "%d", &countval);
@@ -352,8 +352,8 @@ TLeaf* TLeaf::GetLeafCounter(Int_t& countval) const
    }
 
    delete[] countname;
-   countname = 0;
-   return 0;
+   countname = nullptr;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/tree/src/TLeafB.cxx
+++ b/tree/tree/src/TLeafB.cxx
@@ -30,8 +30,8 @@ TLeafB::TLeafB()
 : TLeaf()
 , fMinimum(0)
 , fMaximum(0)
-, fValue(0)
-, fPointer(0)
+, fValue(nullptr)
+, fPointer(nullptr)
 {
    fLenType = 1;
 }
@@ -43,8 +43,8 @@ TLeafB::TLeafB(TBranch *parent, const char* name, const char* type)
    : TLeaf(parent, name, type)
    , fMinimum(0)
    , fMaximum(0)
-   , fValue(0)
-   , fPointer(0)
+   , fValue(nullptr)
+   , fPointer(nullptr)
 {
    fLenType = 1;
 }
@@ -54,12 +54,12 @@ TLeafB::TLeafB(TBranch *parent, const char* name, const char* type)
 
 TLeafB::~TLeafB()
 {
-   if (ResetAddress(0, kTRUE)) {
+   if (ResetAddress(nullptr, kTRUE)) {
       delete[] fValue;
-      fValue = 0;
+      fValue = nullptr;
    }
    // Note: We do not own this, the user's object does.
-   fPointer = 0;
+   fPointer = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -217,7 +217,7 @@ void TLeafB::SetAddress(void *addr)
    if (ResetAddress(addr)) {
       // -- We owned the old value buffer, delete it.
       delete[] fValue;
-      fValue = 0;
+      fValue = nullptr;
    }
    if (addr) {
       // -- We have been provided a new value buffer.
@@ -233,7 +233,7 @@ void TLeafB::SetAddress(void *addr)
          // Reallocate the value buffer if needed.
          if ((fLeafCount && (Int_t(fLeafCount->GetValue()) < ncountmax)) ||
              (fNdata < ncountmax) ||
-             (*fPointer == 0)) {
+             (*fPointer == nullptr)) {
             // -- Reallocate.
             // Note:
             //      1) For a varying length array we do this based on
@@ -259,7 +259,7 @@ void TLeafB::SetAddress(void *addr)
                fNdata = ncountmax;
             }
             delete[] *fPointer;
-            *fPointer = 0;
+            *fPointer = nullptr;
             *fPointer = new Char_t[fNdata];
          }
          fValue = *fPointer;

--- a/tree/tree/src/TLeafC.cxx
+++ b/tree/tree/src/TLeafC.cxx
@@ -35,8 +35,8 @@ TLeafC::TLeafC(): TLeaf()
    fLenType = 1;
    fMinimum = 0;
    fMaximum = 0;
-   fValue   = 0;
-   fPointer = 0;
+   fValue   = nullptr;
+   fPointer = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -48,8 +48,8 @@ TLeafC::TLeafC(TBranch *parent, const char *name, const char *type)
    fLenType = 1;
    fMinimum = 0;
    fMaximum = 0;
-   fValue   = 0;
-   fPointer = 0;
+   fValue   = nullptr;
+   fPointer = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -57,7 +57,7 @@ TLeafC::TLeafC(TBranch *parent, const char *name, const char *type)
 
 TLeafC::~TLeafC()
 {
-   if (ResetAddress(0,kTRUE)) delete [] fValue;
+   if (ResetAddress(nullptr,kTRUE)) delete [] fValue;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -228,7 +228,7 @@ void TLeafC::SetAddress(void *add)
          Int_t ncountmax = fLen;
          if (fLeafCount) ncountmax = fLen*(fLeafCount->GetMaximum() + 1);
          if ((fLeafCount && ncountmax > Int_t(fLeafCount->GetValue())) ||
-             ncountmax > fNdata || *fPointer == 0) {
+             ncountmax > fNdata || *fPointer == nullptr) {
             if (*fPointer) delete [] *fPointer;
             if (ncountmax > fNdata) fNdata = ncountmax;
             *fPointer = new char[fNdata];

--- a/tree/tree/src/TLeafD.cxx
+++ b/tree/tree/src/TLeafD.cxx
@@ -31,8 +31,8 @@ TLeafD::TLeafD(): TLeaf()
    fLenType = 8;
    fMinimum = 0;
    fMaximum = 0;
-   fValue   = 0;
-   fPointer = 0;
+   fValue   = nullptr;
+   fPointer = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -44,8 +44,8 @@ TLeafD::TLeafD(TBranch *parent, const char *name, const char *type)
    fLenType = 8;
    fMinimum = 0;
    fMaximum = 0;
-   fValue   = 0;
-   fPointer = 0;
+   fValue   = nullptr;
+   fPointer = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -53,7 +53,7 @@ TLeafD::TLeafD(TBranch *parent, const char *name, const char *type)
 
 TLeafD::~TLeafD()
 {
-   if (ResetAddress(0,kTRUE)) delete [] fValue;
+   if (ResetAddress(nullptr,kTRUE)) delete [] fValue;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -173,7 +173,7 @@ void TLeafD::SetAddress(void *add)
          Int_t ncountmax = fLen;
          if (fLeafCount) ncountmax = fLen*(fLeafCount->GetMaximum() + 1);
          if ((fLeafCount && ncountmax > Int_t(fLeafCount->GetValue())) ||
-             ncountmax > fNdata || *fPointer == 0) {
+             ncountmax > fNdata || *fPointer == nullptr) {
             if (*fPointer) delete [] *fPointer;
             if (ncountmax > fNdata) fNdata = ncountmax;
             *fPointer = new Double_t[fNdata];

--- a/tree/tree/src/TLeafElement.cxx
+++ b/tree/tree/src/TLeafElement.cxx
@@ -29,7 +29,7 @@ ClassImp(TLeafElement);
 
 TLeafElement::TLeafElement(): TLeaf()
 {
-   fAbsAddress = 0;
+   fAbsAddress = nullptr;
    fID   = -1;
    fType = -1;
 }
@@ -41,7 +41,7 @@ TLeafElement::TLeafElement(TBranch *parent, const char *name, Int_t id, Int_t ty
    : TLeaf(parent, name,name)
 {
    fLenType    = 0;
-   fAbsAddress = 0;
+   fAbsAddress = nullptr;
    fID         = id;
    fType       = type;
    if (type < TVirtualStreamerInfo::kObject) {
@@ -156,7 +156,7 @@ Bool_t TLeafElement::ReadBasketFast(TBuffer &input_buf, Long64_t N)
 
 TMethodCall *TLeafElement::GetMethodCall(const char * /*name*/)
 {
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/tree/src/TLeafF.cxx
+++ b/tree/tree/src/TLeafF.cxx
@@ -31,8 +31,8 @@ TLeafF::TLeafF(): TLeaf()
    fLenType = 4;
    fMinimum = 0;
    fMaximum = 0;
-   fValue   = 0;
-   fPointer = 0;
+   fValue   = nullptr;
+   fPointer = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -44,8 +44,8 @@ TLeafF::TLeafF(TBranch *parent, const char *name, const char *type)
    fLenType = 4;
    fMinimum = 0;
    fMaximum = 0;
-   fValue   = 0;
-   fPointer = 0;
+   fValue   = nullptr;
+   fPointer = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -53,7 +53,7 @@ TLeafF::TLeafF(TBranch *parent, const char *name, const char *type)
 
 TLeafF::~TLeafF()
 {
-   if (ResetAddress(0,kTRUE)) delete [] fValue;
+   if (ResetAddress(nullptr,kTRUE)) delete [] fValue;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -186,7 +186,7 @@ void TLeafF::SetAddress(void *add)
          Int_t ncountmax = fLen;
          if (fLeafCount) ncountmax = fLen*(fLeafCount->GetMaximum() + 1);
          if ((fLeafCount && ncountmax > Int_t(fLeafCount->GetValue())) ||
-             ncountmax > fNdata || *fPointer == 0) {
+             ncountmax > fNdata || *fPointer == nullptr) {
             if (*fPointer) delete [] *fPointer;
             if (ncountmax > fNdata) fNdata = ncountmax;
             *fPointer = new Float_t[fNdata];

--- a/tree/tree/src/TLeafG.cxx
+++ b/tree/tree/src/TLeafG.cxx
@@ -31,8 +31,8 @@ TLeafG::TLeafG(): TLeaf()
    fLenType = sizeof(Long_t);
    fMinimum = 0;
    fMaximum = 0;
-   fValue   = 0;
-   fPointer = 0;
+   fValue   = nullptr;
+   fPointer = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -44,8 +44,8 @@ TLeafG::TLeafG(TBranch *parent, const char *name, const char *type)
    fLenType = sizeof(Long_t);
    fMinimum = 0;
    fMaximum = 0;
-   fValue   = 0;
-   fPointer = 0;
+   fValue   = nullptr;
+   fPointer = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -53,7 +53,7 @@ TLeafG::TLeafG(TBranch *parent, const char *name, const char *type)
 
 TLeafG::~TLeafG()
 {
-   if (ResetAddress(0,kTRUE)) delete [] fValue;
+   if (ResetAddress(nullptr,kTRUE)) delete [] fValue;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -255,7 +255,7 @@ void TLeafG::SetAddress(void *add)
          Int_t ncountmax = fLen;
          if (fLeafCount) ncountmax = fLen*(fLeafCount->GetMaximum() + 1);
          if ((fLeafCount && ncountmax > Int_t(fLeafCount->GetValue())) ||
-             ncountmax > fNdata || *fPointer == 0) {
+             ncountmax > fNdata || *fPointer == nullptr) {
             if (*fPointer) delete [] *fPointer;
             if (ncountmax > fNdata) fNdata = ncountmax;
             *fPointer = new Long_t[fNdata];

--- a/tree/tree/src/TLeafI.cxx
+++ b/tree/tree/src/TLeafI.cxx
@@ -31,8 +31,8 @@ TLeafI::TLeafI(): TLeaf()
    fLenType = 4;
    fMinimum = 0;
    fMaximum = 0;
-   fValue   = 0;
-   fPointer = 0;
+   fValue   = nullptr;
+   fPointer = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -44,8 +44,8 @@ TLeafI::TLeafI(TBranch *parent, const char *name, const char *type)
    fLenType = 4;
    fMinimum = 0;
    fMaximum = 0;
-   fValue   = 0;
-   fPointer = 0;
+   fValue   = nullptr;
+   fPointer = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -53,7 +53,7 @@ TLeafI::TLeafI(TBranch *parent, const char *name, const char *type)
 
 TLeafI::~TLeafI()
 {
-   if (ResetAddress(0,kTRUE)) delete [] fValue;
+   if (ResetAddress(nullptr,kTRUE)) delete [] fValue;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -240,7 +240,7 @@ void TLeafI::SetAddress(void *add)
          Int_t ncountmax = fLen;
          if (fLeafCount) ncountmax = fLen*(fLeafCount->GetMaximum() + 1);
          if ((fLeafCount && ncountmax > Int_t(fLeafCount->GetValue())) ||
-             ncountmax > fNdata || *fPointer == 0) {
+             ncountmax > fNdata || *fPointer == nullptr) {
             if (*fPointer) delete [] *fPointer;
             if (ncountmax > fNdata) fNdata = ncountmax;
             *fPointer = new Int_t[fNdata];

--- a/tree/tree/src/TLeafL.cxx
+++ b/tree/tree/src/TLeafL.cxx
@@ -31,8 +31,8 @@ TLeafL::TLeafL(): TLeaf()
    fLenType = sizeof(Long64_t);
    fMinimum = 0;
    fMaximum = 0;
-   fValue   = 0;
-   fPointer = 0;
+   fValue   = nullptr;
+   fPointer = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -44,8 +44,8 @@ TLeafL::TLeafL(TBranch *parent, const char *name, const char *type)
    fLenType = sizeof(Long64_t);
    fMinimum = 0;
    fMaximum = 0;
-   fValue   = 0;
-   fPointer = 0;
+   fValue   = nullptr;
+   fPointer = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -53,7 +53,7 @@ TLeafL::TLeafL(TBranch *parent, const char *name, const char *type)
 
 TLeafL::~TLeafL()
 {
-   if (ResetAddress(0,kTRUE)) delete [] fValue;
+   if (ResetAddress(nullptr,kTRUE)) delete [] fValue;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -255,7 +255,7 @@ void TLeafL::SetAddress(void *add)
          Int_t ncountmax = fLen;
          if (fLeafCount) ncountmax = fLen*(fLeafCount->GetMaximum() + 1);
          if ((fLeafCount && ncountmax > Int_t(fLeafCount->GetValue())) ||
-             ncountmax > fNdata || *fPointer == 0) {
+             ncountmax > fNdata || *fPointer == nullptr) {
             if (*fPointer) delete [] *fPointer;
             if (ncountmax > fNdata) fNdata = ncountmax;
             *fPointer = new Long64_t[fNdata];

--- a/tree/tree/src/TLeafO.cxx
+++ b/tree/tree/src/TLeafO.cxx
@@ -28,8 +28,8 @@ ClassImp(TLeafO);
 
 TLeafO::TLeafO(): TLeaf()
 {
-   fValue   = 0;
-   fPointer = 0;
+   fValue   = nullptr;
+   fPointer = nullptr;
    fMinimum = 0;
    fMaximum = 0;
    fLenType = sizeof(Bool_t);
@@ -44,8 +44,8 @@ TLeafO::TLeafO(TBranch *parent, const char *name, const char *type)
    fLenType = sizeof(Bool_t);
    fMinimum = 0;
    fMaximum = 0;
-   fValue   = 0;
-   fPointer = 0;
+   fValue   = nullptr;
+   fPointer = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -53,7 +53,7 @@ TLeafO::TLeafO(TBranch *parent, const char *name, const char *type)
 
 TLeafO::~TLeafO()
 {
-   if (ResetAddress(0,kTRUE)) delete [] fValue;
+   if (ResetAddress(nullptr,kTRUE)) delete [] fValue;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -190,7 +190,7 @@ void TLeafO::SetAddress(void *add)
          Int_t ncountmax = fLen;
          if (fLeafCount) ncountmax = fLen*(fLeafCount->GetMaximum() + 1);
          if ((fLeafCount && ncountmax > Int_t(fLeafCount->GetValue())) ||
-             ncountmax > fNdata || *fPointer == 0) {
+             ncountmax > fNdata || *fPointer == nullptr) {
             if (*fPointer) delete [] *fPointer;
             if (ncountmax > fNdata) fNdata = ncountmax;
             *fPointer = new Bool_t[fNdata];

--- a/tree/tree/src/TLeafObject.cxx
+++ b/tree/tree/src/TLeafObject.cxx
@@ -29,8 +29,8 @@ ClassImp(TLeafObject);
 
 TLeafObject::TLeafObject(): TLeaf()
 {
-   fClass      = 0;
-   fObjAddress = 0;
+   fClass      = nullptr;
+   fObjAddress = nullptr;
    fVirtual    = kTRUE;
 }
 
@@ -42,7 +42,7 @@ TLeafObject::TLeafObject(TBranch *parent, const char *name, const char *type)
 {
    SetTitle(type);
    fClass      = TClass::GetClass(type);
-   fObjAddress = 0;
+   fObjAddress = nullptr;
    fVirtual    = kTRUE;
 }
 
@@ -102,7 +102,7 @@ TMethodCall *TLeafObject::GetMethodCall(const char *name)
    if (m->GetMethod()) return m;
    Error("GetMethodCall","Unknown method:%s",name);
    delete m;
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -171,11 +171,11 @@ void TLeafObject::ReadBasket(TBuffer &b)
       if (object->TestBit(kInvalidObject)) {
          if (object->GetUniqueID() == 123456789) {
             fClass->Destructor(object);
-            object = 0;
+            object = nullptr;
          }
       }
       *fObjAddress = object;
-   } else GetBranch()->SetAddress(0);
+   } else GetBranch()->SetAddress(nullptr);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -197,7 +197,7 @@ void TLeafObject::Streamer(TBuffer &b)
       if (R__v > 3 || R__v == 2) {
          b.ReadClassBuffer(TLeafObject::Class(), this, R__v, R__s, R__c);
          if (R__v == 2) fVirtual = kTRUE;
-         fObjAddress = 0;
+         fObjAddress = nullptr;
          fClass  = TClass::GetClass(fTitle.Data());
          if (!fClass) Warning("Streamer","Cannot find class:%s",fTitle.Data());
 
@@ -209,7 +209,7 @@ void TLeafObject::Streamer(TBuffer &b)
       }
       //====process old versions before automatic schema evolution
       TLeaf::Streamer(b);
-      fObjAddress = 0;
+      fObjAddress = nullptr;
       fClass  = TClass::GetClass(fTitle.Data());
       if (!fClass) Warning("Streamer","Cannot find class:%s",fTitle.Data());
       if (R__v  < 1) fVirtual = kFALSE;

--- a/tree/tree/src/TLeafS.cxx
+++ b/tree/tree/src/TLeafS.cxx
@@ -28,8 +28,8 @@ ClassImp(TLeafS);
 
 TLeafS::TLeafS(): TLeaf()
 {
-   fValue = 0;
-   fPointer = 0;
+   fValue = nullptr;
+   fPointer = nullptr;
    fMinimum = 0;
    fMaximum = 0;
    fLenType = 2;
@@ -44,8 +44,8 @@ TLeafS::TLeafS(TBranch *parent, const char *name, const char *type)
    fLenType = 2;
    fMinimum = 0;
    fMaximum = 0;
-   fValue   = 0;
-   fPointer = 0;
+   fValue   = nullptr;
+   fPointer = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -53,7 +53,7 @@ TLeafS::TLeafS(TBranch *parent, const char *name, const char *type)
 
 TLeafS::~TLeafS()
 {
-   if (ResetAddress(0,kTRUE)) delete [] fValue;
+   if (ResetAddress(nullptr,kTRUE)) delete [] fValue;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -233,7 +233,7 @@ void TLeafS::SetAddress(void *add)
          Int_t ncountmax = fLen;
          if (fLeafCount) ncountmax = fLen*(fLeafCount->GetMaximum() + 1);
          if ((fLeafCount && ncountmax > Int_t(fLeafCount->GetValue())) ||
-             ncountmax > fNdata || *fPointer == 0) {
+             ncountmax > fNdata || *fPointer == nullptr) {
             if (*fPointer) delete [] *fPointer;
             if (ncountmax > fNdata) fNdata = ncountmax;
             *fPointer = new Short_t[fNdata];

--- a/tree/tree/src/TNtuple.cxx
+++ b/tree/tree/src/TNtuple.cxx
@@ -46,7 +46,7 @@ It is filled via:
 TNtuple::TNtuple(): TTree()
 {
    fNvar = 0;
-   fArgs = 0;
+   fArgs = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -68,7 +68,7 @@ TNtuple::TNtuple(const char *name, const char *title, const char *varlist, Int_t
 {
    Int_t i;
    fNvar = 0;
-   fArgs = 0;
+   fArgs = nullptr;
 
 //   Count number of variables (separated by :)
    Int_t nch = strlen(varlist);
@@ -103,7 +103,7 @@ TNtuple::TNtuple(const char *name, const char *title, const char *varlist, Int_t
 TNtuple::~TNtuple()
 {
    delete [] fArgs;
-   fArgs = 0;
+   fArgs = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/tree/src/TNtupleD.cxx
+++ b/tree/tree/src/TNtupleD.cxx
@@ -45,7 +45,7 @@ It is filled via:
 TNtupleD::TNtupleD(): TTree()
 {
    fNvar = 0;
-   fArgs = 0;
+   fArgs = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -67,7 +67,7 @@ TNtupleD::TNtupleD(const char *name, const char *title, const char *varlist, Int
 {
    Int_t i;
    fNvar = 0;
-   fArgs = 0;
+   fArgs = nullptr;
 
 //   Count number of variables (separated by :)
    Int_t nch = strlen(varlist);
@@ -104,7 +104,7 @@ TNtupleD::TNtupleD(const char *name, const char *title, const char *varlist, Int
 TNtupleD::~TNtupleD()
 {
    delete [] fArgs;
-   fArgs = 0;
+   fArgs = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/tree/src/TQueryResult.cxx
+++ b/tree/tree/src/TQueryResult.cxx
@@ -38,7 +38,7 @@ TQueryResult::TQueryResult(Int_t seqnum, const char *opt, TList *inlist,
                            Long64_t entries, Long64_t first, const char *selec)
              : fSeqNum(seqnum), fStatus(kSubmitted), fUsedCPU(0.), fOptions(opt),
                fEntries(entries), fFirst(first),
-               fBytes(0), fParList("-"), fOutputList(0),
+               fBytes(0), fParList("-"), fOutputList(nullptr),
                fFinalized(kFALSE), fArchived(kFALSE), fResultFile("-"),
                fPrepTime(0.), fInitTime(0.), fProcTime(0.), fMergeTime(0.),
                fRecvTime(-1), fTermTime(-1), fNumWrks(-1), fNumMergers(-1)
@@ -53,7 +53,7 @@ TQueryResult::TQueryResult(Int_t seqnum, const char *opt, TList *inlist,
    fEnd.Set(fStart.Convert()-1);
 
    // Save input list
-   fInputList = 0;
+   fInputList = nullptr;
    if (inlist) {
       fInputList = (TList *) (inlist->Clone());
       fInputList->SetOwner();
@@ -70,7 +70,7 @@ TQueryResult::TQueryResult(Int_t seqnum, const char *opt, TList *inlist,
       TString varsel;
       if (fInputList) {
          TIter nxo(fInputList);
-         TObject *o = 0;
+         TObject *o = nullptr;
          while ((o = nxo())) {
             if (!strcmp(o->GetName(),"varexp")) {
                varsel = o->GetTitle();
@@ -90,7 +90,7 @@ TQueryResult::TQueryResult(Int_t seqnum, const char *opt, TList *inlist,
       }
       // Standard draw action: save only the name
       fSelecImp = new TMacro(selec, varsel);
-      fSelecHdr = 0;
+      fSelecHdr = nullptr;
    } else {
       // Save selector file
       fSelecHdr = new TMacro;
@@ -124,8 +124,8 @@ TQueryResult::~TQueryResult()
 TQueryResult *TQueryResult::CloneInfo()
 {
    // Create instance
-   TQueryResult *qr = new TQueryResult(fSeqNum, fOptions, 0, fEntries,
-                                       fFirst, 0);
+   TQueryResult *qr = new TQueryResult(fSeqNum, fOptions, nullptr, fEntries,
+                                       fFirst, nullptr);
 
    // Correct fields
    qr->fStatus = fStatus;
@@ -147,13 +147,13 @@ TQueryResult *TQueryResult::CloneInfo()
    qr->fNumWrks = fNumWrks;
    qr->fNumMergers = fNumMergers;
 
-   qr->fSelecHdr = 0;
+   qr->fSelecHdr = nullptr;
    if (GetSelecHdr()) {
       qr->fSelecHdr = new TMacro();
       qr->fSelecHdr->SetName(GetSelecHdr()->GetName());
       qr->fSelecHdr->SetTitle(GetSelecHdr()->GetTitle());
    }
-   qr->fSelecImp = 0;
+   qr->fSelecImp = nullptr;
    if (GetSelecImp()) {
       qr->fSelecImp = new TMacro();
       qr->fSelecImp->SetName(GetSelecImp()->GetName());
@@ -439,7 +439,7 @@ void TQueryResult::SetInputList(TList *in, Bool_t adopt)
       } else {
          fInputList = new TList;
          TIter nxi(in);
-         TObject *o = 0;
+         TObject *o = nullptr;
          while ((o = nxi()))
             fInputList->Add(o);
          in->SetOwner(kFALSE);
@@ -462,7 +462,7 @@ void TQueryResult::SetOutputList(TList *out, Bool_t adopt)
    }
 
    if (out && out != fOutputList) {
-      TObject *o = 0;
+      TObject *o = nullptr;
       if (fOutputList) {
          TIter nxoo(fOutputList);
          while ((o = nxoo())) {
@@ -475,7 +475,7 @@ void TQueryResult::SetOutputList(TList *out, Bool_t adopt)
       } else {
          fOutputList = new TList;
          TIter nxo(out);
-         o = 0;
+         o = nullptr;
          while ((o = nxo()))
             fOutputList->Add(o);
          out->SetOwner(kFALSE);
@@ -515,7 +515,7 @@ Bool_t TQueryResult::Matches(const char *ref)
 
 TObject *TQueryResult::GetInputObject(const char *classname) const
 {
-   TObject *o = 0;
+   TObject *o = nullptr;
    if (classname && fInputList) {
       TIter nxi(fInputList);
       while ((o = nxi()))

--- a/tree/tree/src/TSelector.cxx
+++ b/tree/tree/src/TSelector.cxx
@@ -90,8 +90,8 @@ TSelector::TSelector() : TObject()
 {
    fStatus = 0;
    fAbort  = kContinue;
-   fObject = 0;
-   fInput  = 0;
+   fObject = nullptr;
+   fInput  = nullptr;
    fOutput = new TSelectorList;
    fOutput->SetOwner();
 }
@@ -144,7 +144,7 @@ TSelector *TSelector::GetSelector(const char *filename)
    // If the filename does not contain "." assume class is compiled in
    TString localname;
    Bool_t fromFile = kFALSE;
-   if (strchr(filename, '.') != 0) {
+   if (strchr(filename, '.') != nullptr) {
       //Interpret/compile filename via CINT
       localname  = ".L ";
       localname += filename;
@@ -157,7 +157,7 @@ TSelector *TSelector::GetSelector(const char *filename)
    const char *basename = gSystem->BaseName(filename);
    if (!basename) {
       ::Error("TSelector::GetSelector","unable to determine the classname for file %s", filename);
-      return 0;
+      return nullptr;
    }
    TString aclicmode,args,io;
    localname = gSystem->SplitAclicMode(basename,aclicmode,args,io);
@@ -186,7 +186,7 @@ TSelector *TSelector::GetSelector(const char *filename)
          else
             ::Error("TSelector::GetSelector",
                     "class %s does not exist or does not derive from TSelector", filename);
-         return 0;
+         return nullptr;
       }
       char *result = (char*)selCl->New();
       // By adding offset, we support the case where TSelector is not the
@@ -220,7 +220,7 @@ TSelector *TSelector::GetSelector(const char *filename)
                        "class %s does not exist or does not derive from TSelector", filename);
          }
          gCling->ClassInfo_Delete(cl);
-         return 0;
+         return nullptr;
       }
 
       // we can now create an instance of the class

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -758,8 +758,8 @@ TTree::TTree()
 , fAutoSave( -300000000)
 , fAutoFlush(-30000000)
 , fEstimate(1000000)
-, fClusterRangeEnd(0)
-, fClusterSize(0)
+, fClusterRangeEnd(nullptr)
+, fClusterSize(nullptr)
 , fCacheSize(0)
 , fChainOffset(0)
 , fReadEntry(-1)
@@ -771,25 +771,25 @@ TTree::TTree()
 , fDebugMax(9999999)
 , fMakeClass(0)
 , fFileNumber(0)
-, fNotify(0)
-, fDirectory(0)
+, fNotify(nullptr)
+, fDirectory(nullptr)
 , fBranches()
 , fLeaves()
-, fAliases(0)
-, fEventList(0)
-, fEntryList(0)
+, fAliases(nullptr)
+, fEventList(nullptr)
+, fEntryList(nullptr)
 , fIndexValues()
 , fIndex()
-, fTreeIndex(0)
-, fFriends(0)
-, fExternalFriends(0)
-, fPerfStats(0)
-, fUserInfo(0)
-, fPlayer(0)
-, fClones(0)
-, fBranchRef(0)
+, fTreeIndex(nullptr)
+, fFriends(nullptr)
+, fExternalFriends(nullptr)
+, fPerfStats(nullptr)
+, fUserInfo(nullptr)
+, fPlayer(nullptr)
+, fClones(nullptr)
+, fBranchRef(nullptr)
 , fFriendLockStatus(0)
-, fTransientBuffer(0)
+, fTransientBuffer(nullptr)
 , fCacheDoAutoInit(kTRUE)
 , fCacheDoClusterPrefetch(kFALSE)
 , fCacheUserSet(kFALSE)
@@ -839,8 +839,8 @@ TTree::TTree(const char* name, const char* title, Int_t splitlevel /* = 99 */,
 , fAutoSave( -300000000)
 , fAutoFlush(-30000000)
 , fEstimate(1000000)
-, fClusterRangeEnd(0)
-, fClusterSize(0)
+, fClusterRangeEnd(nullptr)
+, fClusterSize(nullptr)
 , fCacheSize(0)
 , fChainOffset(0)
 , fReadEntry(-1)
@@ -852,25 +852,25 @@ TTree::TTree(const char* name, const char* title, Int_t splitlevel /* = 99 */,
 , fDebugMax(9999999)
 , fMakeClass(0)
 , fFileNumber(0)
-, fNotify(0)
+, fNotify(nullptr)
 , fDirectory(dir)
 , fBranches()
 , fLeaves()
-, fAliases(0)
-, fEventList(0)
-, fEntryList(0)
+, fAliases(nullptr)
+, fEventList(nullptr)
+, fEntryList(nullptr)
 , fIndexValues()
 , fIndex()
-, fTreeIndex(0)
-, fFriends(0)
-, fExternalFriends(0)
-, fPerfStats(0)
-, fUserInfo(0)
-, fPlayer(0)
-, fClones(0)
-, fBranchRef(0)
+, fTreeIndex(nullptr)
+, fFriends(nullptr)
+, fExternalFriends(nullptr)
+, fPerfStats(nullptr)
+, fUserInfo(nullptr)
+, fPlayer(nullptr)
+, fClones(nullptr)
+, fBranchRef(nullptr)
 , fFriendLockStatus(0)
-, fTransientBuffer(0)
+, fTransientBuffer(nullptr)
 , fCacheDoAutoInit(kTRUE)
 , fCacheDoClusterPrefetch(kFALSE)
 , fCacheUserSet(kFALSE)
@@ -938,7 +938,7 @@ TTree::~TTree()
       }
       //delete the file cache if it points to this Tree
       TFile *file = fDirectory->GetFile();
-      MoveReadCache(file,0);
+      MoveReadCache(file,nullptr);
    }
 
    // Remove the TTree from any list (linked to to the list of Cleanups) to avoid the unnecessary call to
@@ -975,7 +975,7 @@ TTree::~TTree()
 
    // FIXME: We must consider what to do with the reset of these if we are a clone.
    delete fPlayer;
-   fPlayer = 0;
+   fPlayer = nullptr;
    if (fExternalFriends) {
       using namespace ROOT::Detail;
       for(auto fetree : TRangeStaticCast<TFriendElement>(*fExternalFriends))
@@ -986,17 +986,17 @@ TTree::~TTree()
    if (fFriends) {
       fFriends->Delete();
       delete fFriends;
-      fFriends = 0;
+      fFriends = nullptr;
    }
    if (fAliases) {
       fAliases->Delete();
       delete fAliases;
-      fAliases = 0;
+      fAliases = nullptr;
    }
    if (fUserInfo) {
       fUserInfo->Delete();
       delete fUserInfo;
-      fUserInfo = 0;
+      fUserInfo = nullptr;
    }
    if (fClones) {
       // Clone trees should no longer be removed from fClones when they are deleted.
@@ -1006,29 +1006,29 @@ TTree::~TTree()
      }
       // Note: fClones does not own its content.
       delete fClones;
-      fClones = 0;
+      fClones = nullptr;
    }
    if (fEntryList) {
-      if (fEntryList->TestBit(kCanDelete) && fEntryList->GetDirectory()==0) {
+      if (fEntryList->TestBit(kCanDelete) && fEntryList->GetDirectory()==nullptr) {
          // Delete the entry list if it is marked to be deleted and it is not also
          // owned by a directory.  (Otherwise we would need to make sure that a
          // TDirectoryFile that has a TTree in it does a 'slow' TList::Delete.
          delete fEntryList;
-         fEntryList=0;
+         fEntryList=nullptr;
       }
    }
    delete fTreeIndex;
-   fTreeIndex = 0;
+   fTreeIndex = nullptr;
    delete fBranchRef;
-   fBranchRef = 0;
+   fBranchRef = nullptr;
    delete [] fClusterRangeEnd;
-   fClusterRangeEnd = 0;
+   fClusterRangeEnd = nullptr;
    delete [] fClusterSize;
-   fClusterSize = 0;
+   fClusterSize = nullptr;
 
    if (fTransientBuffer) {
       delete fTransientBuffer;
-      fTransientBuffer = 0;
+      fTransientBuffer = nullptr;
    }
 }
 
@@ -1398,7 +1398,7 @@ TFriendElement *TTree::AddFriend(const char *treename, TFile *file)
 TFriendElement *TTree::AddFriend(TTree *tree, const char *alias, Bool_t warn)
 {
    if (!tree) {
-      return 0;
+      return nullptr;
    }
    if (!fFriends) {
       fFriends = new TList();
@@ -1559,11 +1559,11 @@ TBranch* TTree::BranchImp(const char* branchname, const char* classname, TClass*
       if (claim && claim->GetCollectionProxy() && dynamic_cast<TEmulatedCollectionProxy*>(claim->GetCollectionProxy())) {
          Error("Branch", writeStlWithoutProxyMsg,
                claim->GetName(), branchname, claim->GetName());
-         return 0;
+         return nullptr;
       }
       return Branch(branchname, classname, (void*) addobj, bufsize, splitlevel);
    }
-   TClass* actualClass = 0;
+   TClass* actualClass = nullptr;
    void** addr = (void**) addobj;
    if (addr) {
       actualClass = ptrClass->GetActualClass(*addr);
@@ -1591,7 +1591,7 @@ TBranch* TTree::BranchImp(const char* branchname, const char* classname, TClass*
    if (claim && claim->GetCollectionProxy() && dynamic_cast<TEmulatedCollectionProxy*>(claim->GetCollectionProxy())) {
       Error("Branch", writeStlWithoutProxyMsg,
             claim->GetName(), branchname, claim->GetName());
-      return 0;
+      return nullptr;
    }
    return Branch(branchname, classname, (void*) addobj, bufsize, splitlevel);
 }
@@ -1604,9 +1604,9 @@ TBranch* TTree::BranchImp(const char* branchname, TClass* ptrClass, void* addobj
 {
    if (!ptrClass) {
       Error("Branch", "The pointer specified for %s is not of a class known to ROOT", branchname);
-      return 0;
+      return nullptr;
    }
-   TClass* actualClass = 0;
+   TClass* actualClass = nullptr;
    void** addr = (void**) addobj;
    if (addr && *addr) {
       actualClass = ptrClass->GetActualClass(*addr);
@@ -1616,7 +1616,7 @@ TBranch* TTree::BranchImp(const char* branchname, TClass* ptrClass, void* addobj
          actualClass = ptrClass;
       } else if ((ptrClass != actualClass) && !actualClass->InheritsFrom(ptrClass)) {
          Error("Branch", "The actual class (%s) of the object provided for the definition of the branch \"%s\" does not inherit from %s", actualClass->GetName(), branchname, ptrClass->GetName());
-         return 0;
+         return nullptr;
       }
    } else {
       actualClass = ptrClass;
@@ -1624,7 +1624,7 @@ TBranch* TTree::BranchImp(const char* branchname, TClass* ptrClass, void* addobj
    if (actualClass && actualClass->GetCollectionProxy() && dynamic_cast<TEmulatedCollectionProxy*>(actualClass->GetCollectionProxy())) {
       Error("Branch", writeStlWithoutProxyMsg,
             actualClass->GetName(), branchname, actualClass->GetName());
-      return 0;
+      return nullptr;
    }
    return Branch(branchname, actualClass->GetName(), (void*) addobj, bufsize, splitlevel);
 }
@@ -1640,17 +1640,17 @@ TBranch* TTree::BranchImpRef(const char* branchname, const char *classname, TCla
       if (claim && claim->GetCollectionProxy() && dynamic_cast<TEmulatedCollectionProxy*>(claim->GetCollectionProxy())) {
          Error("Branch", writeStlWithoutProxyMsg,
                claim->GetName(), branchname, claim->GetName());
-         return 0;
-      } else if (claim == 0) {
+         return nullptr;
+      } else if (claim == nullptr) {
          Error("Branch", "The pointer specified for %s is not of a class known to ROOT and %s is not a known class", branchname, classname);
-         return 0;
+         return nullptr;
       }
       ptrClass = claim;
    }
-   TClass* actualClass = 0;
+   TClass* actualClass = nullptr;
    if (!addobj) {
       Error("Branch", "Reference interface requires a valid object (for branch: %s)!", branchname);
-      return 0;
+      return nullptr;
    }
    actualClass = ptrClass->GetActualClass(addobj);
    if (ptrClass && claim) {
@@ -1679,12 +1679,12 @@ TBranch* TTree::BranchImpRef(const char* branchname, const char *classname, TCla
       actualClass = ptrClass;
    } else if ((ptrClass != actualClass) && !actualClass->InheritsFrom(ptrClass)) {
       Error("Branch", "The actual class (%s) of the object provided for the definition of the branch \"%s\" does not inherit from %s", actualClass->GetName(), branchname, ptrClass->GetName());
-      return 0;
+      return nullptr;
    }
    if (actualClass && actualClass->GetCollectionProxy() && dynamic_cast<TEmulatedCollectionProxy*>(actualClass->GetCollectionProxy())) {
       Error("Branch", writeStlWithoutProxyMsg,
             actualClass->GetName(), branchname, actualClass->GetName());
-      return 0;
+      return nullptr;
    }
    return BronchExec(branchname, actualClass->GetName(), (void*) addobj, kFALSE, bufsize, splitlevel);
 }
@@ -1702,12 +1702,12 @@ TBranch* TTree::BranchImpRef(const char* branchname, TClass* ptrClass, EDataType
          TString varname; varname.Form("%s/%c",branchname,DataTypeToChar(datatype));
          return Branch(branchname,addobj,varname.Data(),bufsize);
       }
-      return 0;
+      return nullptr;
    }
-   TClass* actualClass = 0;
+   TClass* actualClass = nullptr;
    if (!addobj) {
       Error("Branch", "Reference interface requires a valid object (for branch: %s)!", branchname);
-      return 0;
+      return nullptr;
    }
    actualClass = ptrClass->GetActualClass(addobj);
    if (!actualClass) {
@@ -1716,12 +1716,12 @@ TBranch* TTree::BranchImpRef(const char* branchname, TClass* ptrClass, EDataType
       actualClass = ptrClass;
    } else if ((ptrClass != actualClass) && !actualClass->InheritsFrom(ptrClass)) {
       Error("Branch", "The actual class (%s) of the object provided for the definition of the branch \"%s\" does not inherit from %s", actualClass->GetName(), branchname, ptrClass->GetName());
-      return 0;
+      return nullptr;
    }
    if (actualClass && actualClass->GetCollectionProxy() && dynamic_cast<TEmulatedCollectionProxy*>(actualClass->GetCollectionProxy())) {
       Error("Branch", writeStlWithoutProxyMsg,
             actualClass->GetName(), branchname, actualClass->GetName());
-      return 0;
+      return nullptr;
    }
    return BronchExec(branchname, actualClass->GetName(), (void*) addobj, kFALSE, bufsize, splitlevel);
 }
@@ -1837,7 +1837,7 @@ Int_t TTree::Branch(TCollection* li, Int_t bufsize /* = 32000 */, Int_t splitlev
    if (!li) {
       return 0;
    }
-   TObject* obj = 0;
+   TObject* obj = nullptr;
    Int_t nbranches = GetListOfBranches()->GetEntries();
    if (li->InheritsFrom(TClonesArray::Class())) {
       Error("Branch", "Cannot call this constructor for a TClonesArray");
@@ -1890,7 +1890,7 @@ Int_t TTree::Branch(const char* foldername, Int_t bufsize /* = 32000 */, Int_t s
    Int_t nbranches = GetListOfBranches()->GetEntries();
    TFolder* folder = (TFolder*) ob;
    TIter next(folder->GetListOfFolders());
-   TObject* obj = 0;
+   TObject* obj = nullptr;
    char* curname = new char[1000];
    char occur[20];
    while ((obj = next())) {
@@ -1989,8 +1989,8 @@ TBranch* TTree::Branch(const char* name, void* address, const char* leaflist, In
    TBranch* branch = new TBranch(this, name, address, leaflist, bufsize);
    if (branch->IsZombie()) {
       delete branch;
-      branch = 0;
-      return 0;
+      branch = nullptr;
+      return nullptr;
    }
    fBranches.Add(branch);
    return branch;
@@ -2077,7 +2077,7 @@ TBranch* TTree::BranchOld(const char* name, const char* classname, void* addobj,
    TClass* cl = TClass::GetClass(classname);
    if (!cl) {
       Error("BranchOld", "Cannot find class: '%s'", classname);
-      return 0;
+      return nullptr;
    }
    if (!cl->IsTObject()) {
       if (fgBranchStyle == 0) {
@@ -2088,7 +2088,7 @@ TBranch* TTree::BranchOld(const char* name, const char* classname, void* addobj,
         Fatal("BranchOld", "The requested class ('%s') does not inherit from TObject.\n"
               "\tYou can not use BranchOld to store objects of this type.",classname);
       }
-      return 0;
+      return nullptr;
    }
    TBranch* branch = new TBranchObject(this, name, classname, addobj, bufsize, splitlevel);
    fBranches.Add(branch);
@@ -2097,8 +2097,8 @@ TBranch* TTree::BranchOld(const char* name, const char* classname, void* addobj,
    }
    // We are going to fully split the class now.
    TObjArray* blist = branch->GetListOfBranches();
-   const char* rdname = 0;
-   const char* dname = 0;
+   const char* rdname = nullptr;
+   const char* dname = nullptr;
    TString branchname;
    char** apointer = (char**) addobj;
    TObject* obj = (TObject*) *apointer;
@@ -2115,9 +2115,9 @@ TBranch* TTree::BranchOld(const char* name, const char* classname, void* addobj,
    if (name[lenName-1] == '.') {
       isDot = 1;
    }
-   TBranch* branch1 = 0;
-   TRealData* rd = 0;
-   TRealData* rdi = 0;
+   TBranch* branch1 = nullptr;
+   TRealData* rd = nullptr;
+   TRealData* rdi = nullptr;
    TIter nexti(cl->GetListOfRealData());
    TIter next(cl->GetListOfRealData());
    // Note: This loop results in a full split because the
@@ -2179,7 +2179,7 @@ TBranch* TTree::BranchOld(const char* name, const char* classname, void* addobj,
       char* pointer = ((char*) obj) + offset;
       if (dm->IsaPointer()) {
          // We have a pointer to an object or a pointer to an array of basic types.
-         TClass* clobj = 0;
+         TClass* clobj = nullptr;
          if (!dm->IsBasic()) {
             clobj = TClass::GetClass(dm->GetTypeName());
          }
@@ -2310,7 +2310,7 @@ TBranch* TTree::BranchOld(const char* name, const char* classname, void* addobj,
    }
    if (delobj) {
       delete obj;
-      obj = 0;
+      obj = nullptr;
    }
    return branch;
 }
@@ -2415,7 +2415,7 @@ TBranch* TTree::BronchExec(const char* name, const char* classname, void* addr, 
    TClass* cl = TClass::GetClass(classname);
    if (!cl) {
       Error("Bronch", "Cannot find class:%s", classname);
-      return 0;
+      return nullptr;
    }
 
    //if splitlevel <= 0 and class has a custom Streamer, we must create
@@ -2423,7 +2423,7 @@ TBranch* TTree::BronchExec(const char* name, const char* classname, void* addr, 
    //with the custom Streamer. The penalty is that one cannot process
    //this Tree without the class library containing the class.
 
-   char* objptr = 0;
+   char* objptr = nullptr;
    if (!isptrptr) {
       objptr = (char*)addr;
    } else if (addr) {
@@ -2434,15 +2434,15 @@ TBranch* TTree::BronchExec(const char* name, const char* classname, void* addr, 
       TClonesArray* clones = (TClonesArray*) objptr;
       if (!clones) {
          Error("Bronch", "Pointer to TClonesArray is null");
-         return 0;
+         return nullptr;
       }
       if (!clones->GetClass()) {
          Error("Bronch", "TClonesArray with no class defined in branch: %s", name);
-         return 0;
+         return nullptr;
       }
       if (!clones->GetClass()->HasDataMemberInfo()) {
          Error("Bronch", "TClonesArray with no dictionary defined in branch: %s", name);
-         return 0;
+         return nullptr;
       }
       bool hasCustomStreamer = clones->GetClass()->TestBit(TClass::kHasCustomStreamerMember);
       if (splitlevel > 0) {
@@ -2464,14 +2464,14 @@ TBranch* TTree::BronchExec(const char* name, const char* classname, void* addr, 
       TClass* inklass = collProxy->GetValueClass();
       if (!inklass && (collProxy->GetType() == 0)) {
          Error("Bronch", "%s with no class defined in branch: %s", classname, name);
-         return 0;
+         return nullptr;
       }
-      if ((splitlevel > 0) && inklass && (inklass->GetCollectionProxy() == 0)) {
+      if ((splitlevel > 0) && inklass && (inklass->GetCollectionProxy() == nullptr)) {
          ROOT::ESTLType stl = cl->GetCollectionType();
          if ((stl != ROOT::kSTLmap) && (stl != ROOT::kSTLmultimap)) {
             if (!inklass->HasDataMemberInfo()) {
                Error("Bronch", "Container with no dictionary defined in branch: %s", name);
-               return 0;
+               return nullptr;
             }
             if (inklass->TestBit(TClass::kHasCustomStreamerMember)) {
                Warning("Bronch", "Using split mode on a class: %s with a custom Streamer", inklass->GetName());
@@ -2500,7 +2500,7 @@ TBranch* TTree::BronchExec(const char* name, const char* classname, void* addr, 
    Bool_t hasCustomStreamer = kFALSE;
    if (!cl->HasDataMemberInfo() && !cl->GetCollectionProxy()) {
       Error("Bronch", "Cannot find dictionary for class: %s", classname);
-      return 0;
+      return nullptr;
    }
 
    if (!cl->GetCollectionProxy() && cl->TestBit(TClass::kHasCustomStreamerMember)) {
@@ -2564,7 +2564,7 @@ TBranch* TTree::BronchExec(const char* name, const char* classname, void* addr, 
    TStreamerInfo* sinfo = BuildStreamerInfo(cl, objptr, splitlevel==0);
    if (!sinfo) {
       Error("Bronch", "Cannot build the StreamerInfo for class: %s", cl->GetName());
-      return 0;
+      return nullptr;
    }
 
    //
@@ -2598,7 +2598,7 @@ TBranch* TTree::BronchExec(const char* name, const char* classname, void* addr, 
 
    if (delobj) {
       cl->Destructor(objptr);
-      objptr = 0;
+      objptr = nullptr;
    }
 
    return branch;
@@ -2640,7 +2640,7 @@ Int_t TTree::BuildIndex(const char* majorname, const char* minorname /* = "0" */
    fTreeIndex = GetPlayer()->BuildIndex(this, majorname, minorname);
    if (fTreeIndex->IsZombie()) {
       delete fTreeIndex;
-      fTreeIndex = 0;
+      fTreeIndex = nullptr;
       return 0;
    }
    return fTreeIndex->GetN();
@@ -2653,13 +2653,13 @@ Int_t TTree::BuildIndex(const char* majorname, const char* minorname /* = "0" */
 TStreamerInfo* TTree::BuildStreamerInfo(TClass* cl, void* pointer /* = 0 */, Bool_t canOptimize /* = kTRUE */ )
 {
    if (!cl) {
-      return 0;
+      return nullptr;
    }
    cl->BuildRealData(pointer);
    TStreamerInfo* sinfo = (TStreamerInfo*)cl->GetStreamerInfo(cl->GetClassVersion());
 
    // Create StreamerInfo for all base classes.
-   TBaseClass* base = 0;
+   TBaseClass* base = nullptr;
    TIter nextb(cl->GetListOfBases());
    while((base = (TBaseClass*) nextb())) {
       if (base->IsSTLContainer()) {
@@ -2798,15 +2798,15 @@ TFile* TTree::ChangeFile(TFile* file)
    }
    Int_t compress = file->GetCompressionSettings();
    TFile* newfile = TFile::Open(fname, "recreate", "chain files", compress);
-   if (newfile == 0) {
+   if (newfile == nullptr) {
       Error("Fill","Failed to open new file %s, continuing as a memory tree.",fname);
    } else {
       Printf("Fill: Switching to new file: %s", fname);
    }
    // The current directory may contain histograms and trees.
    // These objects must be moved to the new file.
-   TBranch* branch = 0;
-   TObject* obj = 0;
+   TBranch* branch = nullptr;
+   TObject* obj = nullptr;
    while ((obj = file->GetList()->First())) {
       file->Remove(obj);
       // Histogram: just change the directory.
@@ -2837,9 +2837,9 @@ TFile* TTree::ChangeFile(TFile* file)
       file->Remove(obj);
    }
    file->TObject::Delete();
-   file = 0;
+   file = nullptr;
    delete[] fname;
-   fname = 0;
+   fname = nullptr;
    return newfile;
 }
 
@@ -2873,14 +2873,14 @@ Int_t TTree::CheckBranchAddressType(TBranch* branch, TClass* ptrClass, EDataType
    }
 
    // Let's determine what we need!
-   TClass* expectedClass = 0;
+   TClass* expectedClass = nullptr;
    EDataType expectedType = kOther_t;
    if (0 != branch->GetExpectedType(expectedClass,expectedType) ) {
       // Something went wrong, the warning message has already been issued.
       return kInternalError;
    }
    bool isBranchElement = branch->InheritsFrom( TBranchElement::Class() );
-   if (expectedClass && datatype == kOther_t && ptrClass == 0) {
+   if (expectedClass && datatype == kOther_t && ptrClass == nullptr) {
       if (isBranchElement) {
          TBranchElement* bEl = (TBranchElement*)branch;
          bEl->SetTargetClass( expectedClass->GetName() );
@@ -3148,7 +3148,7 @@ TTree* TTree::CloneTree(Long64_t nentries /* = -1 */, Option_t* option /* = "" *
    // If we are a chain, switch to the first tree.
    if ((fEntries > 0) && (LoadTree(0) < 0)) {
          // FIXME: We need an error message here.
-         return 0;
+         return nullptr;
    }
 
    // Note: For a tree we get the this pointer, for
@@ -3163,7 +3163,7 @@ TTree* TTree::CloneTree(Long64_t nentries /* = -1 */, Option_t* option /* = "" *
    //       a clone of the chain's first tree.
    TTree* newtree = (TTree*) thistree->Clone();
    if (!newtree) {
-      return 0;
+      return nullptr;
    }
 
    // The clone should not delete any objects allocated by SetAddress().
@@ -3188,7 +3188,7 @@ TTree* TTree::CloneTree(Long64_t nentries /* = -1 */, Option_t* option /* = "" *
    newtree->Reset();
 
    TDirectory* ndir = newtree->GetDirectory();
-   TFile* nfile = 0;
+   TFile* nfile = nullptr;
    if (ndir) {
       nfile = ndir->GetFile();
    }
@@ -3224,7 +3224,7 @@ TTree* TTree::CloneTree(Long64_t nentries /* = -1 */, Option_t* option /* = "" *
          if (br == branch) {
             branches->RemoveAt(i);
             delete br;
-            br = 0;
+            br = nullptr;
             branches->Compress();
             break;
          }
@@ -3238,7 +3238,7 @@ TTree* TTree::CloneTree(Long64_t nentries /* = -1 */, Option_t* option /* = "" *
             if (b1 == branch) {
                lb->RemoveAt(j);
                delete b1;
-               b1 = 0;
+               b1 = nullptr;
                lb->Compress();
                break;
             }
@@ -3252,7 +3252,7 @@ TTree* TTree::CloneTree(Long64_t nentries /* = -1 */, Option_t* option /* = "" *
                if (b2 == branch) {
                   lb1->RemoveAt(k);
                   delete b2;
-                  b2 = 0;
+                  b2 = nullptr;
                   lb1->Compress();
                   break;
                }
@@ -3278,8 +3278,8 @@ TTree* TTree::CloneTree(Long64_t nentries /* = -1 */, Option_t* option /* = "" *
             // There was a problem!
             Error("CloneTTree", "TTree has not been cloned\n");
             delete newtree;
-            newtree = 0;
-            return 0;
+            newtree = nullptr;
+            return nullptr;
          }
       } else {
          newtree->CopyEntries( this, nentries, option, kFALSE );
@@ -3322,7 +3322,7 @@ void TTree::CopyAddresses(TTree* tree, Bool_t undo)
                }
             }
             // Note: This may cause an object to be allocated.
-            branch->SetAddress(0);
+            branch->SetAddress(nullptr);
             addr = branch->GetAddress();
          }
          TBranch* br = tree->GetBranch(branch->GetFullName());
@@ -3435,11 +3435,11 @@ namespace {
       Bool_t withIndex = kTRUE;
 
       if ( newtree->GetTreeIndex() ) {
-         if ( oldtree->GetTree()->GetTreeIndex() == 0 ) {
+         if ( oldtree->GetTree()->GetTreeIndex() == nullptr ) {
             switch (onIndexError) {
                case kDrop:
                   delete newtree->GetTreeIndex();
-                  newtree->SetTreeIndex(0);
+                  newtree->SetTreeIndex(nullptr);
                   withIndex = kFALSE;
                   break;
                case kKeep:
@@ -3451,14 +3451,14 @@ namespace {
                      newtree->GetTreeIndex()->Append(oldtree->GetTree()->GetTreeIndex(), kTRUE);
                      // Clean up
                      delete oldtree->GetTree()->GetTreeIndex();
-                     oldtree->GetTree()->SetTreeIndex(0);
+                     oldtree->GetTree()->SetTreeIndex(nullptr);
                   }
                   break;
             }
          } else {
             newtree->GetTreeIndex()->Append(oldtree->GetTree()->GetTreeIndex(), kTRUE);
          }
-      } else if ( oldtree->GetTree()->GetTreeIndex() != 0 ) {
+      } else if ( oldtree->GetTree()->GetTreeIndex() != nullptr ) {
          // We discover the first index in the middle of the chain.
          switch (onIndexError) {
             case kDrop:
@@ -3639,7 +3639,7 @@ Long64_t TTree::CopyEntries(TTree* tree, Long64_t nentries /* = -1 */, Option_t*
 
       }
       if (this->GetTreeIndex()) {
-         this->GetTreeIndex()->Append(0,kFALSE); // Force the sorting
+         this->GetTreeIndex()->Append(nullptr,kFALSE); // Force the sorting
       }
       nbytes = GetTotBytes() - totbytes;
    } else {
@@ -3673,7 +3673,7 @@ Long64_t TTree::CopyEntries(TTree* tree, Long64_t nentries /* = -1 */, Option_t*
       if (needCopyAddresses)
          tree->ResetBranchAddresses();
       if (this->GetTreeIndex()) {
-         this->GetTreeIndex()->Append(0,kFALSE); // Force the sorting
+         this->GetTreeIndex()->Append(nullptr,kFALSE); // Force the sorting
       }
    }
    return nbytes;
@@ -3720,7 +3720,7 @@ TTree* TTree::CopyTree(const char* selection, Option_t* option /* = 0 */, Long64
    if (fPlayer) {
       return fPlayer->CopyTree(selection, option, nentries, firstentry);
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -3729,7 +3729,7 @@ TTree* TTree::CopyTree(const char* selection, Option_t* option /* = 0 */, Long64
 TBasket* TTree::CreateBasket(TBranch* branch)
 {
    if (!branch) {
-      return 0;
+      return nullptr;
    }
    return new TBasket(branch->GetName(), GetName(), branch);
 }
@@ -3798,7 +3798,7 @@ void TTree::Delete(Option_t* option /* = "" */)
    if (fDirectory) {
       fDirectory->Remove(this);
       //delete the file cache if it points to this Tree
-      MoveReadCache(file,0);
+      MoveReadCache(file,nullptr);
       fDirectory = nullptr;
       ResetBit(kMustCleanup);
    }
@@ -3824,7 +3824,7 @@ void TTree::DirectoryAutoAdd(TDirectory* dir)
       MoveReadCache(file,dir);
    }
    fDirectory = dir;
-   TBranch* b = 0;
+   TBranch* b = nullptr;
    TIter next(GetListOfBranches());
    while((b = (TBranch*) next())) {
       b->UpdateFile();
@@ -4515,7 +4515,7 @@ Long64_t TTree::Draw(const char* varexp, const char* selection, Option_t* option
 
 void TTree::DropBaskets()
 {
-   TBranch* branch = 0;
+   TBranch* branch = nullptr;
    Int_t nb = fBranches.GetEntriesFast();
    for (Int_t i = 0; i < nb; ++i) {
       branch = (TBranch*) fBranches.UncheckedAt(i);
@@ -4789,7 +4789,7 @@ Int_t TTree::Fill()
 /// with the branch possibly expressed as a 'full' path name (with dots).
 
 static TBranch *R__FindBranchHelper(TObjArray *list, const char *branchname) {
-   if (list==0 || branchname == 0 || branchname[0] == '\0') return 0;
+   if (list==nullptr || branchname == nullptr || branchname[0] == '\0') return nullptr;
 
    Int_t nbranches = list->GetEntries();
 
@@ -4809,7 +4809,7 @@ static TBranch *R__FindBranchHelper(TObjArray *list, const char *branchname) {
       if (brlen == len && strncmp(branchname,name,len)==0) {
          return where;
       }
-      TBranch *next = 0;
+      TBranch *next = nullptr;
       if ((brlen >= len) && (branchname[len] == '.')
           && strncmp(name, branchname, len) == 0) {
          // The prefix subbranch name match the branch name.
@@ -4828,7 +4828,7 @@ static TBranch *R__FindBranchHelper(TObjArray *list, const char *branchname) {
          }
       }
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -5477,7 +5477,7 @@ TTree::TClusterIterator TTree::GetClusterIterator(Long64_t firstentry)
 TFile* TTree::GetCurrentFile() const
 {
    if (!fDirectory || fDirectory==gROOT) {
-      return 0;
+      return nullptr;
    }
    return fDirectory->GetFile();
 }
@@ -5514,7 +5514,7 @@ Long64_t TTree::GetEntriesFriend() const
    TFriendElement *fr = (TFriendElement*)fFriends->At(0);
    if (!fr) return 0;
    TTree *t = fr->GetTree();
-   if (t==0) return 0;
+   if (t==nullptr) return 0;
    return t->GetEntriesFriend();
 }
 
@@ -5953,7 +5953,7 @@ Int_t TTree::GetEntryWithIndex(Int_t major, Int_t minor)
    if (!fFriends) return nbytes;
    TFriendLock lock(this,kGetEntryWithIndex);
    TIter nextf(fFriends);
-   TFriendElement* fe = 0;
+   TFriendElement* fe = nullptr;
    while ((fe = (TFriendElement*) nextf())) {
       TTree *t = fe->GetTree();
       if (t) {
@@ -5976,14 +5976,14 @@ TTree* TTree::GetFriend(const char *friendname) const
    // We already have been visited while recursively
    // looking through the friends tree, let's return.
    if (kGetFriend & fFriendLockStatus) {
-      return 0;
+      return nullptr;
    }
    if (!fFriends) {
-      return 0;
+      return nullptr;
    }
    TFriendLock lock(const_cast<TTree*>(this), kGetFriend);
    TIter nextf(fFriends);
-   TFriendElement* fe = 0;
+   TFriendElement* fe = nullptr;
    while ((fe = (TFriendElement*) nextf())) {
       if (strcmp(friendname,fe->GetName())==0
           || strcmp(friendname,fe->GetTreeName())==0) {
@@ -5993,14 +5993,14 @@ TTree* TTree::GetFriend(const char *friendname) const
    // After looking at the first level,
    // let's see if it is a friend of friends.
    nextf.Reset();
-   fe = 0;
+   fe = nullptr;
    while ((fe = (TFriendElement*) nextf())) {
       TTree *res = fe->GetTree()->GetFriend(friendname);
       if (res) {
          return res;
       }
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -6030,20 +6030,20 @@ TTree* TTree::GetFriend(const char *friendname) const
 const char* TTree::GetFriendAlias(TTree* tree) const
 {
    if ((tree == this) || (tree == GetTree())) {
-      return 0;
+      return nullptr;
    }
 
    // We already have been visited while recursively
    // looking through the friends tree, let's return.
    if (kGetFriendAlias & fFriendLockStatus) {
-      return 0;
+      return nullptr;
    }
    if (!fFriends) {
-      return 0;
+      return nullptr;
    }
    TFriendLock lock(const_cast<TTree*>(this), kGetFriendAlias);
    TIter nextf(fFriends);
-   TFriendElement* fe = 0;
+   TFriendElement* fe = nullptr;
    while ((fe = (TFriendElement*) nextf())) {
       TTree* t = fe->GetTree();
       if (t == tree) {
@@ -6057,14 +6057,14 @@ const char* TTree::GetFriendAlias(TTree* tree) const
    // After looking at the first level,
    // let's see if it is a friend of friends.
    nextf.Reset();
-   fe = 0;
+   fe = nullptr;
    while ((fe = (TFriendElement*) nextf())) {
       const char* res = fe->GetTree()->GetFriendAlias(tree);
       if (res) {
          return res;
       }
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -6192,12 +6192,12 @@ TLeaf* TTree::GetLeafImpl(const char* branchname, const char *leafname)
 
 TLeaf* TTree::GetLeaf(const char* branchname, const char *leafname)
 {
-   if (leafname == 0) return 0;
+   if (leafname == nullptr) return nullptr;
 
    // We already have been visited while recursively looking
    // through the friends tree, let return
    if (kGetLeaf & fFriendLockStatus) {
-      return 0;
+      return nullptr;
    }
 
    return GetLeafImpl(branchname,leafname);
@@ -6333,7 +6333,7 @@ TTreeCache *TTree::GetReadCache(TFile *file, Bool_t create)
       if (fCacheDoAutoInit)
          SetCacheSizeAux(kTRUE, -1);
       pe = dynamic_cast<TTreeCache*>(file->GetCacheRead(GetTree()));
-      if (pe && pe->GetTree() != GetTree()) pe = 0;
+      if (pe && pe->GetTree() != GetTree()) pe = nullptr;
    }
    return pe;
 }
@@ -6500,7 +6500,7 @@ Long64_t TTree::LoadTree(Long64_t entry)
          // This scope is need to insure the lock is released at the right time
          TIter nextf(fFriends);
          TFriendLock lock(this, kLoadTree);
-         TFriendElement* fe = 0;
+         TFriendElement* fe = nullptr;
          while ((fe = (TFriendElement*) nextf())) {
             if (fe->TestBit(TFriendElement::kFromChain)) {
                // This friend element was added by the chain that owns this
@@ -6848,9 +6848,9 @@ Bool_t TTree::MemoryFull(Int_t nbytes)
 
 TTree* TTree::MergeTrees(TList* li, Option_t* options)
 {
-   if (!li) return 0;
+   if (!li) return nullptr;
    TIter next(li);
-   TTree *newtree = 0;
+   TTree *newtree = nullptr;
    TObject *obj;
 
    while ((obj=next())) {
@@ -6875,7 +6875,7 @@ TTree* TTree::MergeTrees(TList* li, Option_t* options)
       newtree->CopyEntries(tree, -1, options, kTRUE);
    }
    if (newtree && newtree->GetTreeIndex()) {
-      newtree->GetTreeIndex()->Append(0,kFALSE); // Force the sorting
+      newtree->GetTreeIndex()->Append(nullptr,kFALSE); // Force the sorting
    }
    return newtree;
 }
@@ -6981,18 +6981,18 @@ Long64_t TTree::Merge(TCollection* li, TFileMergeInfo *info)
 void TTree::MoveReadCache(TFile *src, TDirectory *dir)
 {
    if (!src) return;
-   TFile *dst = (dir && dir != gROOT) ? dir->GetFile() : 0;
+   TFile *dst = (dir && dir != gROOT) ? dir->GetFile() : nullptr;
    if (src == dst) return;
 
    TTreeCache *pf = GetReadCache(src);
    if (dst) {
-      src->SetCacheRead(0,this);
+      src->SetCacheRead(nullptr,this);
       dst->SetCacheRead(pf, this);
    } else {
       if (pf) {
          pf->WaitFinishPrefetch();
       }
-      src->SetCacheRead(0,this);
+      src->SetCacheRead(nullptr,this);
       delete pf;
    }
 }
@@ -7031,7 +7031,7 @@ Bool_t TTree::InPlaceClone(TDirectory *newdirectory, const char *options)
 Bool_t TTree::Notify()
 {
    TIter next(GetListOfLeaves());
-   TLeaf* leaf = 0;
+   TLeaf* leaf = nullptr;
    while ((leaf = (TLeaf*) next())) {
       leaf->Notify();
       leaf->GetBranch()->Notify();
@@ -7201,7 +7201,7 @@ TPrincipal* TTree::Principal(const char* varexp, const char* selection, Option_t
    if (fPlayer) {
       return fPlayer->Principal(varexp, selection, option, nentries, firstentry);
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -7514,7 +7514,7 @@ TSQLResult* TTree::Query(const char* varexp, const char* selection, Option_t* op
    if (fPlayer) {
       return fPlayer->Query(varexp, selection, option, nentries, firstentry);
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -7631,7 +7631,7 @@ Long64_t TTree::ReadStream(std::istream& inputStream, const char *branchDescript
    std::istream& in = *inTemp;
    Long64_t nlines = 0;
 
-   TBranch *branch = 0;
+   TBranch *branch = nullptr;
    Int_t nbranches = fBranches.GetEntries();
    if (nbranches == 0) {
       char *bdname = new char[4000];
@@ -7670,7 +7670,7 @@ Long64_t TTree::ReadStream(std::istream& inputStream, const char *branchDescript
       char bdelim = ':';
       if(delimiter != ' ') {
          bdelim = delimiter;
-         if (strchr(bdcur,bdelim)==0 && strchr(bdcur,':') != 0) {
+         if (strchr(bdcur,bdelim)==nullptr && strchr(bdcur,':') != nullptr) {
             // revert to the default
             bdelim = ':';
          }
@@ -7697,7 +7697,7 @@ Long64_t TTree::ReadStream(std::istream& inputStream, const char *branchDescript
             Warning("ReadStream","Illegal branch definition: %s",bdcur);
          } else {
             fBranches.Add(branch);
-            branch->SetAddress(0);
+            branch->SetAddress(nullptr);
          }
          if (!colon)break;
          bdcur = colon+1;
@@ -7764,7 +7764,7 @@ Long64_t TTree::ReadStream(std::istream& inputStream, const char *branchDescript
       }
 
       // Loop on branches and read the branch values into their buffer
-      branch = 0;
+      branch = nullptr;
       TString tok; // one column's data
       TString leafData; // leaf data, possibly multiple tokens for e.g. /I[2]
       std::stringstream sToken; // string stream feeding leafData into leaves
@@ -7944,7 +7944,7 @@ void TTree::Refresh()
    fDirectory->Remove(tree);
    fDirectory->Append(this);
    delete tree;
-   tree = 0;
+   tree = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -7984,13 +7984,13 @@ void TTree::RemoveFriend(TTree* oldFriend)
    }
    TFriendLock lock(this, kRemoveFriend);
    TIter nextf(fFriends);
-   TFriendElement* fe = 0;
+   TFriendElement* fe = nullptr;
    while ((fe = (TFriendElement*) nextf())) {
       TTree* friend_t = fe->GetTree();
       if (friend_t == oldFriend) {
          fFriends->Remove(fe);
          delete fe;
-         fe = 0;
+         fe = nullptr;
       }
    }
 }
@@ -8000,7 +8000,7 @@ void TTree::RemoveFriend(TTree* oldFriend)
 
 void TTree::Reset(Option_t* option)
 {
-   fNotify        = 0;
+   fNotify        = nullptr;
    fEntries       = 0;
    fNClusterRange = 0;
    fTotBytes      = 0;
@@ -8012,7 +8012,7 @@ void TTree::Reset(Option_t* option)
    fReadEntry     = -1;
 
    delete fTreeIndex;
-   fTreeIndex = 0;
+   fTreeIndex = nullptr;
 
    Int_t nb = fBranches.GetEntriesFast();
    for (Int_t i = 0; i < nb; ++i)  {
@@ -8042,7 +8042,7 @@ void TTree::ResetAfterMerge(TFileMergeInfo *info)
    fReadEntry     = -1;
 
    delete fTreeIndex;
-   fTreeIndex     = 0;
+   fTreeIndex     = nullptr;
 
    Int_t nb = fBranches.GetEntriesFast();
    for (Int_t i = 0; i < nb; ++i)  {
@@ -8379,7 +8379,7 @@ Int_t TTree::SetBranchAddress(const char* bname, void* addr, TBranch** ptr)
 {
    TBranch* branch = GetBranch(bname);
    if (!branch) {
-      if (ptr) *ptr = 0;
+      if (ptr) *ptr = nullptr;
       Error("SetBranchAddress", "unknown branch -> %s", bname);
       return kMissingBranch;
    }
@@ -8395,7 +8395,7 @@ Int_t TTree::SetBranchAddress(const char* bname, void* addr, TBranch** ptr)
 
 Int_t TTree::SetBranchAddress(const char* bname, void* addr, TClass* ptrClass, EDataType datatype, Bool_t isptr)
 {
-   return SetBranchAddress(bname, addr, 0, ptrClass, datatype, isptr);
+   return SetBranchAddress(bname, addr, nullptr, ptrClass, datatype, isptr);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -8409,7 +8409,7 @@ Int_t TTree::SetBranchAddress(const char* bname, void* addr, TBranch** ptr, TCla
 {
    TBranch* branch = GetBranch(bname);
    if (!branch) {
-      if (ptr) *ptr = 0;
+      if (ptr) *ptr = nullptr;
       Error("SetBranchAddress", "unknown branch -> %s", bname);
       return kMissingBranch;
    }
@@ -8423,7 +8423,7 @@ Int_t TTree::SetBranchAddress(const char* bname, void* addr, TBranch** ptr, TCla
          branch->SetMakeClass(kTRUE);
       SetBranchAddressImp(branch,addr,ptr);
    } else {
-      if (ptr) *ptr = 0;
+      if (ptr) *ptr = nullptr;
    }
    return res;
 }
@@ -8443,7 +8443,7 @@ Int_t TTree::SetBranchAddressImp(TBranch *branch, void* addr, TBranch** ptr)
    if (fClones) {
       void* oldAddr = branch->GetAddress();
       TIter next(fClones);
-      TTree* clone = 0;
+      TTree* clone = nullptr;
       const char *bname = branch->GetName();
       while ((clone = (TTree*) next())) {
          TBranch* cloneBr = clone->GetBranch(bname);
@@ -8607,12 +8607,12 @@ void TTree::SetBranchStatus(const char* bname, Bool_t status, UInt_t* found)
    if (!nb && !foundInFriend) {
       if (!found) {
          if (status) {
-            if (strchr(bname,'*') != 0)
+            if (strchr(bname,'*') != nullptr)
                Error("SetBranchStatus", "No branch name is matching wildcard -> %s", bname);
             else
                Error("SetBranchStatus", "unknown branch -> %s", bname);
          } else {
-            if (strchr(bname,'*') != 0)
+            if (strchr(bname,'*') != nullptr)
                Warning("SetBranchStatus", "No branch name is matching wildcard -> %s", bname);
             else
                Warning("SetBranchStatus", "unknown branch -> %s", bname);
@@ -8766,9 +8766,9 @@ Int_t TTree::SetCacheSizeAux(Bool_t autocache /* = kTRUE */, Long64_t cacheSize 
       if (cacheSize == 0) {
          // delete existing cache
          pf->WaitFinishPrefetch();
-         file->SetCacheRead(0,this);
+         file->SetCacheRead(nullptr,this);
          delete pf;
-         pf = 0;
+         pf = nullptr;
       } else {
          // resize
          Int_t res = pf->SetBufferSize(cacheSize);
@@ -8967,14 +8967,14 @@ void TTree::SetDirectory(TDirectory* dir)
    if (fDirectory) {
       fDirectory->Append(this);
    }
-   TFile* file = 0;
+   TFile* file = nullptr;
    if (fDirectory) {
       file = fDirectory->GetFile();
    }
    if (fBranchRef) {
       fBranchRef->SetFile(file);
    }
-   TBranch* b = 0;
+   TBranch* b = nullptr;
    TIter next(GetListOfBranches());
    while((b = (TBranch*) next())) {
       b->SetFile(file);
@@ -9039,9 +9039,9 @@ void TTree::SetEntryList(TEntryList *enlist, Option_t * /*opt*/)
          delete fEntryList;
       }
    }
-   fEventList = 0;
+   fEventList = nullptr;
    if (!enlist) {
-      fEntryList = 0;
+      fEntryList = nullptr;
       return;
    }
    fEntryList = enlist;
@@ -9060,16 +9060,16 @@ void TTree::SetEventList(TEventList *evlist)
    if (fEntryList){
       if (fEntryList->TestBit(kCanDelete)) {
          TEntryList *tmp = fEntryList;
-         fEntryList = 0; // Avoid problem with RecursiveRemove.
+         fEntryList = nullptr; // Avoid problem with RecursiveRemove.
          delete tmp;
       } else {
-         fEntryList = 0;
+         fEntryList = nullptr;
       }
    }
 
    if (!evlist) {
-      fEntryList = 0;
-      fEventList = 0;
+      fEntryList = nullptr;
+      fEventList = nullptr;
       return;
    }
 
@@ -9077,7 +9077,7 @@ void TTree::SetEventList(TEventList *evlist)
    char enlistname[100];
    snprintf(enlistname,100, "%s_%s", evlist->GetName(), "entrylist");
    fEntryList = new TEntryList(enlistname, evlist->GetTitle());
-   fEntryList->SetDirectory(0); // We own this.
+   fEntryList->SetDirectory(nullptr); // We own this.
    Int_t nsel = evlist->GetN();
    fEntryList->SetTree(this);
    Long64_t entry;
@@ -9197,13 +9197,13 @@ void TTree::SetName(const char* name)
    }
    // Trees are named objects in a THashList.
    // We must update hashlists if we change the name.
-   TFile *file = 0;
-   TTreeCache *pf = 0;
+   TFile *file = nullptr;
+   TTreeCache *pf = nullptr;
    if (fDirectory) {
       fDirectory->Remove(this);
       if ((file = GetCurrentFile())) {
          pf = GetReadCache(file);
-         file->SetCacheRead(0,this,TFile::kDoNotDisconnect);
+         file->SetCacheRead(nullptr,this,TFile::kDoNotDisconnect);
       }
    }
    // This changes our hash value.
@@ -9253,13 +9253,13 @@ void TTree::SetObject(const char* name, const char* title)
 
    //  Trees are named objects in a THashList.
    //  We must update hashlists if we change the name
-   TFile *file = 0;
-   TTreeCache *pf = 0;
+   TFile *file = nullptr;
+   TTreeCache *pf = nullptr;
    if (fDirectory) {
       fDirectory->Remove(this);
       if ((file = GetCurrentFile())) {
          pf = GetReadCache(file);
-         file->SetCacheRead(0,this,TFile::kDoNotDisconnect);
+         file->SetCacheRead(nullptr,this,TFile::kDoNotDisconnect);
       }
    }
    // This changes our hash value.
@@ -9279,7 +9279,7 @@ void TTree::SetObject(const char* name, const char* title)
 void TTree::SetParallelUnzip(Bool_t opt, Float_t RelSize)
 {
 #ifdef R__USE_IMT
-   if (GetTree() == 0) {
+   if (GetTree() == nullptr) {
       LoadTree(GetReadEntry());
       if (!GetTree())
          return;
@@ -9334,7 +9334,7 @@ void TTree::SetPerfStats(TVirtualPerfStats *perf)
 void TTree::SetTreeIndex(TVirtualIndex* index)
 {
    if (fTreeIndex) {
-      fTreeIndex->SetTree(0);
+      fTreeIndex->SetTree(nullptr);
    }
    fTreeIndex = index;
 }
@@ -9538,9 +9538,9 @@ void TTree::Streamer(TBuffer& b)
          fDirectory->Remove(this);
          //delete the file cache if it points to this Tree
          TFile *file = fDirectory->GetFile();
-         MoveReadCache(file,0);
+         MoveReadCache(file,nullptr);
       }
-      fDirectory = 0;
+      fDirectory = nullptr;
       fCacheDoAutoInit = kTRUE;
       fCacheUserSet = kFALSE;
       Version_t R__v = b.ReadVersion(&R__s, &R__c);
@@ -9618,7 +9618,7 @@ void TTree::Streamer(TBuffer& b)
          fBranchRef->Clear();
       }
       TRefTable *table  = TRefTable::GetRefTable();
-      if (table) TRefTable::SetRefTable(0);
+      if (table) TRefTable::SetRefTable(nullptr);
 
       b.WriteClassBuffer(TTree::Class(), this);
 
@@ -9756,8 +9756,8 @@ ClassImp(TTreeFriendLeafIter);
 
 TTreeFriendLeafIter::TTreeFriendLeafIter(const TTree* tree, Bool_t dir)
 : fTree(const_cast<TTree*>(tree))
-, fLeafIter(0)
-, fTreeIter(0)
+, fLeafIter(nullptr)
+, fTreeIter(nullptr)
 , fDirection(dir)
 {
 }
@@ -9768,8 +9768,8 @@ TTreeFriendLeafIter::TTreeFriendLeafIter(const TTree* tree, Bool_t dir)
 TTreeFriendLeafIter::TTreeFriendLeafIter(const TTreeFriendLeafIter& iter)
 : TIterator(iter)
 , fTree(iter.fTree)
-, fLeafIter(0)
-, fTreeIter(0)
+, fLeafIter(nullptr)
+, fTreeIter(nullptr)
 , fDirection(iter.fDirection)
 {
 }
@@ -9802,16 +9802,16 @@ TTreeFriendLeafIter& TTreeFriendLeafIter::operator=(const TTreeFriendLeafIter& r
 
 TObject* TTreeFriendLeafIter::Next()
 {
-   if (!fTree) return 0;
+   if (!fTree) return nullptr;
 
    TObject * next;
    TTree * nextTree;
 
    if (!fLeafIter) {
       TObjArray *list = fTree->GetListOfLeaves();
-      if (!list) return 0; // Can happen with an empty chain.
+      if (!list) return nullptr; // Can happen with an empty chain.
       fLeafIter =  list->MakeIterator(fDirection);
-      if (!fLeafIter) return 0;
+      if (!fLeafIter) return nullptr;
    }
 
    next = fLeafIter->Next();
@@ -9820,7 +9820,7 @@ TObject* TTreeFriendLeafIter::Next()
          TCollection * list = fTree->GetListOfFriends();
          if (!list) return next;
          fTreeIter = list->MakeIterator(fDirection);
-         if (!fTreeIter) return 0;
+         if (!fTreeIter) return nullptr;
       }
       TFriendElement * nextFriend = (TFriendElement*) fTreeIter->Next();
       ///nextTree = (TTree*)fTreeIter->Next();
@@ -9829,7 +9829,7 @@ TObject* TTreeFriendLeafIter::Next()
          if (!nextTree) return Next();
          SafeDelete(fLeafIter);
          fLeafIter = nextTree->GetListOfLeaves()->MakeIterator(fDirection);
-         if (!fLeafIter) return 0;
+         if (!fLeafIter) return nullptr;
          next = fLeafIter->Next();
       }
    }

--- a/tree/tree/src/TTreeCache.cxx
+++ b/tree/tree/src/TTreeCache.cxx
@@ -331,10 +331,10 @@ TTreeCache::~TTreeCache()
 {
    // Informe the TFile that we have been deleted (in case
    // we are deleted explicitly by legacy user code).
-   if (fFile) fFile->SetCacheRead(0, fTree);
+   if (fFile) fFile->SetCacheRead(nullptr, fTree);
 
    delete fBranches;
-   if (fBrNames) {fBrNames->Delete(); delete fBrNames; fBrNames=0;}
+   if (fBrNames) {fBrNames->Delete(); delete fBrNames; fBrNames=nullptr;}
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -479,7 +479,7 @@ Int_t TTreeCache::AddBranch(const char *bname, Bool_t subbranches /*= kFALSE*/)
          }
       }
    }
-   if (nb==0 && strchr(bname,'*')==0) {
+   if (nb==0 && strchr(bname,'*')==nullptr) {
       branch = fTree->GetBranch(bname);
       if (branch) {
          if (AddBranch(branch, subbranches)<0) {
@@ -497,14 +497,14 @@ Int_t TTreeCache::AddBranch(const char *bname, Bool_t subbranches /*= kFALSE*/)
       TString name;
       while ((fe = (TFriendElement*)nextf())) {
          TTree *t = fe->GetTree();
-         if (t==0) continue;
+         if (t==nullptr) continue;
 
          // If the alias is present replace it with the real name.
          char *subbranch = (char*)strstr(bname,fe->GetName());
-         if (subbranch!=bname) subbranch = 0;
+         if (subbranch!=bname) subbranch = nullptr;
          if (subbranch) {
             subbranch += strlen(fe->GetName());
-            if ( *subbranch != '.' ) subbranch = 0;
+            if ( *subbranch != '.' ) subbranch = nullptr;
             else subbranch ++;
          }
          if (subbranch) {
@@ -619,7 +619,7 @@ Int_t TTreeCache::DropBranch(const char *bname, Bool_t subbranches /*= kFALSE*/)
          }
       }
    }
-   if (nb==0 && strchr(bname,'*')==0) {
+   if (nb==0 && strchr(bname,'*')==nullptr) {
       branch = fTree->GetBranch(bname);
       if (branch) {
          if (DropBranch(branch, subbranches)<0) {
@@ -637,14 +637,14 @@ Int_t TTreeCache::DropBranch(const char *bname, Bool_t subbranches /*= kFALSE*/)
       TString name;
       while ((fe = (TFriendElement*)nextf())) {
          TTree *t = fe->GetTree();
-         if (t==0) continue;
+         if (t==nullptr) continue;
 
          // If the alias is present replace it with the real name.
          char *subbranch = (char*)strstr(bname,fe->GetName());
-         if (subbranch!=bname) subbranch = 0;
+         if (subbranch!=bname) subbranch = nullptr;
          if (subbranch) {
             subbranch += strlen(fe->GetName());
-            if ( *subbranch != '.' ) subbranch = 0;
+            if ( *subbranch != '.' ) subbranch = nullptr;
             else subbranch ++;
          }
          if (subbranch) {
@@ -713,7 +713,7 @@ void TTreeCache::ResetMissCache()
 /// - On failure, IOPos.length will be set to 0.
 TTreeCache::IOPos TTreeCache::FindBranchBasketPos(TBranch &b, Long64_t entry)
 {
-   if (R__unlikely(b.GetDirectory() == 0)) {
+   if (R__unlikely(b.GetDirectory() == nullptr)) {
       // printf("Branch at %p has no valid directory.\n", &b);
       return IOPos{0, 0};
    }
@@ -1385,7 +1385,7 @@ Bool_t TTreeCache::FillBuffer()
          Bool_t filled = kFALSE;
          for (Int_t i = 0; i < fNbranches; ++i) {
             TBranch *b = (TBranch*)fBranches->UncheckedAt(i);
-            if (b->GetDirectory()==0 || b->TestBit(TBranch::kDoNotProcess))
+            if (b->GetDirectory()==nullptr || b->TestBit(TBranch::kDoNotProcess))
                continue;
             if (b->GetDirectory()->GetFile() != fFile)
                continue;
@@ -2039,7 +2039,7 @@ void TTreeCache::ResetCache()
 {
    for (Int_t i = 0; i < fNbranches; ++i) {
       TBranch *b = (TBranch*)fBranches->UncheckedAt(i);
-      if (b->GetDirectory()==0 || b->TestBit(TBranch::kDoNotProcess))
+      if (b->GetDirectory()==nullptr || b->TestBit(TBranch::kDoNotProcess))
          continue;
       if (b->GetDirectory()->GetFile() != fFile)
          continue;
@@ -2129,8 +2129,8 @@ void TTreeCache::SetFile(TFile *file, TFile::ECacheAction action)
    // calling SetFile (and also by setting fFile to zero before the calling).
    if (fFile) {
       TFile *prevFile = fFile;
-      fFile = 0;
-      prevFile->SetCacheRead(0, fTree, action);
+      fFile = nullptr;
+      prevFile->SetCacheRead(nullptr, fTree, action);
    }
    TFileCacheRead::SetFile(file, action);
 }

--- a/tree/tree/src/TTreeCacheUnzip.cxx
+++ b/tree/tree/src/TTreeCacheUnzip.cxx
@@ -311,7 +311,7 @@ Bool_t TTreeCacheUnzip::FillBuffer()
    //store baskets
    for (Int_t i = 0; i < fNbranches; i++) {
       TBranch *b = (TBranch*)fBranches->UncheckedAt(i);
-      if (b->GetDirectory() == 0) continue;
+      if (b->GetDirectory() == nullptr) continue;
       if (b->GetDirectory()->GetFile() != fFile) continue;
       Int_t nb = b->GetMaxBaskets();
       Int_t *lbaskets   = b->GetBasketBytes();
@@ -550,7 +550,7 @@ Int_t TTreeCacheUnzip::UnzipCache(Int_t index)
    }
 
    // Prepare a memory buffer of adequate size
-   char* locbuff = 0;
+   char* locbuff = nullptr;
    if (rdlen > 16384) {
       locbuff = new char[rdlen];
    } else if (rdlen * 3 < 16384) {
@@ -929,7 +929,7 @@ Int_t TTreeCacheUnzip::UnzipBuffer(char **dest, char *src)
                nbytes,keylen,objlen, noutot,nout,nin,nbuf);
          uzlen = -1;
          if(alloc) delete [] *dest;
-         *dest = 0;
+         *dest = nullptr;
          return uzlen;
       }
       uzlen += objlen;

--- a/tree/tree/src/TTreeCloner.cxx
+++ b/tree/tree/src/TTreeCloner.cxx
@@ -387,7 +387,7 @@ UInt_t TTreeCloner::CollectBranches(TObjArray *from, TObjArray *to)
          }
          if (fi==firstfi) {
             // We tried all the branches and there is not match.
-            fb = 0;
+            fb = nullptr;
             break;
          }
          fb = (TBranch*) from->UncheckedAt(fi);
@@ -480,7 +480,7 @@ void TTreeCloner::CopyStreamerInfos()
       if (oldInfo->IsA() != TStreamerInfo::Class()) {
          continue;
       }
-      TStreamerInfo *curInfo = 0;
+      TStreamerInfo *curInfo = nullptr;
       TClass *cl = TClass::GetClass(oldInfo->GetName());
 
       if (!cl->IsLoaded() || cl->GetNew()) {
@@ -515,12 +515,12 @@ void TTreeCloner::CopyMemoryBaskets()
    if (IsInPlace())
       return;
 
-   TBasket *basket = 0;
+   TBasket *basket = nullptr;
    for(Int_t i=0; i<fToBranches.GetEntriesFast(); ++i) {
       TBranch *from = (TBranch*)fFromBranches.UncheckedAt( i );
       TBranch *to   = (TBranch*)fToBranches.UncheckedAt( i );
 
-      basket = (!from->GetListOfBaskets()->IsEmpty()) ? from->GetBasket(from->GetWriteBasket()) : 0;
+      basket = (!from->GetListOfBaskets()->IsEmpty()) ? from->GetBasket(from->GetWriteBasket()) : nullptr;
       if (basket && basket->GetNevBuf()) {
          basket = (TBasket*)basket->Clone();
          basket->SetBranch(to);
@@ -530,7 +530,7 @@ void TTreeCloner::CopyMemoryBaskets()
       }
       // In older files, if the branch is a TBranchElement non-terminal 'object' branch, it's basket will contain 0
       // events, in newer file in the same case, the write basket will be missing.
-      if (from->GetEntries()!=0 && from->GetWriteBasket()==0 && (basket==0 || basket->GetNevBuf()==0)) {
+      if (from->GetEntries()!=0 && from->GetWriteBasket()==0 && (basket==nullptr || basket->GetNevBuf()==0)) {
          to->SetEntries(to->GetEntries()+from->GetEntries());
       }
    }
@@ -554,7 +554,7 @@ void TTreeCloner::CopyProcessIds()
    TDirectory::TContext cur(fromfile);
    while ((key = (TKey*)next())) {
       if (!strcmp(key->GetClassName(),"TProcessID")) {
-         TProcessID *pid = (TProcessID*)key->ReadObjectAny(0);
+         TProcessID *pid = (TProcessID*)key->ReadObjectAny(nullptr);
          if (!pid) continue;
 
          //UShort_t out = TProcessID::WriteProcessID(id,tofile);

--- a/tree/tree/src/TTreeResult.cxx
+++ b/tree/tree/src/TTreeResult.cxx
@@ -33,8 +33,8 @@ TTreeResult::TTreeResult()
 {
    fColumnCount = 0;
    fRowCount    = 0;
-   fFields      = 0;
-   fResult      = 0;
+   fFields      = nullptr;
+   fResult      = nullptr;
    fNextRow     = 0;
 }
 
@@ -71,7 +71,7 @@ void TTreeResult::Close(Option_t *)
 
    fResult->Delete();
    delete fResult;
-   fResult   = 0;
+   fResult   = nullptr;
    fRowCount = 0;
 }
 
@@ -109,7 +109,7 @@ Int_t TTreeResult::GetFieldCount()
 const char *TTreeResult::GetFieldName(Int_t field)
 {
    if (!IsValid(field))
-      return 0;
+      return nullptr;
 
    return fFields[field].Data();
 }
@@ -123,11 +123,11 @@ TSQLRow *TTreeResult::Next()
 {
    if (!fResult) {
       Error("Next", "result set closed");
-      return 0;
+      return nullptr;
    }
 
    if (fNextRow >= fRowCount)
-      return 0;
+      return nullptr;
    else {
       TTreeRow *row = new TTreeRow((TTreeRow*)fResult->At(fNextRow));
       fNextRow++;

--- a/tree/tree/src/TTreeRow.cxx
+++ b/tree/tree/src/TTreeRow.cxx
@@ -29,9 +29,9 @@ ClassImp(TTreeRow);
 TTreeRow::TTreeRow()
 {
    fColumnCount = 0;
-   fFields      = 0;
-   fOriginal    = 0;
-   fRow         = 0;
+   fFields      = nullptr;
+   fOriginal    = nullptr;
+   fRow         = nullptr;
 
 }
 
@@ -41,9 +41,9 @@ TTreeRow::TTreeRow()
 TTreeRow::TTreeRow(Int_t nfields)
 {
    fColumnCount = nfields;
-   fFields      = 0;
-   fOriginal    = 0;
-   fRow         = 0;
+   fFields      = nullptr;
+   fOriginal    = nullptr;
+   fRow         = nullptr;
 
 }
 
@@ -53,9 +53,9 @@ TTreeRow::TTreeRow(Int_t nfields)
 TTreeRow::TTreeRow(Int_t nfields, const Int_t *fields, const char *row)
 {
    fColumnCount = nfields;
-   fFields      = 0;
-   fOriginal    = 0;
-   fRow         = 0;
+   fFields      = nullptr;
+   fOriginal    = nullptr;
+   fRow         = nullptr;
    SetRow(fields,row);
 }
 
@@ -65,10 +65,10 @@ TTreeRow::TTreeRow(Int_t nfields, const Int_t *fields, const char *row)
 
 TTreeRow::TTreeRow(TSQLRow *original)
 {
-   fFields      = 0;
-   fOriginal    = 0;
+   fFields      = nullptr;
+   fOriginal    = nullptr;
    fColumnCount = 0;
-   fRow         = 0;
+   fRow         = nullptr;
 
    if (!original) {
       Error("TTreeRow", "original may not be 0");
@@ -100,7 +100,7 @@ void TTreeRow::Close(Option_t *)
    if (fRow)    delete [] fRow;
    if (fFields) delete [] fFields;
    fColumnCount = 0;
-   fOriginal = 0;
+   fOriginal = nullptr;
    fRow = nullptr;
    fFields = nullptr;
 }
@@ -142,7 +142,7 @@ ULong_t TTreeRow::GetFieldLength(Int_t field)
 const char *TTreeRow::GetField(Int_t field)
 {
    if (!IsValid(field))
-      return 0;
+      return nullptr;
 
    if (fOriginal)
       return fOriginal->GetField(field);
@@ -160,7 +160,7 @@ void TTreeRow::SetRow(const Int_t *fields, const char *row)
    if (fFields) delete [] fFields;
    Int_t nch    = fields[fColumnCount-1];
    fFields      = new Int_t[fColumnCount];
-   fOriginal    = 0;
+   fOriginal    = nullptr;
    if (fRow) delete [] fRow;
    fRow         = new char[nch];
    for (Int_t i=0;i<fColumnCount;i++) fFields[i] = fields[i];

--- a/tree/tree/src/TTreeSQL.cxx
+++ b/tree/tree/src/TTreeSQL.cxx
@@ -52,16 +52,16 @@ ClassImp(TTreeSQL);
 TTreeSQL::TTreeSQL(TSQLServer *server, TString DB, const TString& table) :
    TTree(table.Data(), "Database read from table: " + table, 0), fDB(DB),
    fTable(table.Data()),
-   fResult(0), fRow(0),
+   fResult(nullptr), fRow(nullptr),
    fServer(server),
    fBranchChecked(kFALSE),
-   fTableInfo(0)
+   fTableInfo(nullptr)
 {
    fCurrentEntry = -1;
    fQuery = TString("Select * from " + fTable);
    fEntries = 0;
 
-   if (fServer==0) {
+   if (fServer==nullptr) {
       Error("TTreeSQL","No TSQLServer specified");
       return;
    }
@@ -78,7 +78,7 @@ TBranch* TTreeSQL::BranchImp(const char *, const char *,
                              Int_t )
 {
    Fatal("BranchImp","Not implemented yet");
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -88,7 +88,7 @@ TBranch* TTreeSQL::BranchImp(const char *, TClass *,
                              void *, Int_t , Int_t )
 {
    Fatal("BranchImp","Not implemented yet");
-   return 0;
+   return nullptr;
 }
 ////////////////////////////////////////////////////////////////////////////////
 /// Not implemented yet
@@ -126,7 +126,7 @@ TBranch* TTreeSQL::Bronch(const char *, const char *, void *,
                           Int_t, Int_t)
 {
    Fatal("Bronch","Not implemented yet");
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -136,7 +136,7 @@ TBranch* TTreeSQL::BranchOld(const char *, const char *,
                              void *, Int_t, Int_t)
 {
    Fatal("BranchOld","Not implemented yet");
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -146,7 +146,7 @@ TBranch *TTreeSQL::Branch(const char *, const char *, void *,
                           Int_t, Int_t)
 {
    Fatal("Branch","Not implemented yet");
-   return 0;
+   return nullptr;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -188,15 +188,15 @@ void TTreeSQL::CheckBasket(TBranch *branch)
 {
    TBasketSQL* basket = (TBasketSQL *)branch->GetBasket(0);
 
-   if (basket==0) {
+   if (basket==nullptr) {
       basket = (TBasketSQL*)CreateBasket(branch);
-      if (basket==0) return;
+      if (basket==nullptr) return;
       //++(branch->fNBaskets);
       branch->GetListOfBaskets()->AddAtAndExpand(basket,0);
    }
    TBuffer * buffer = basket->GetBufferRef();
 
-   if(buffer == 0){
+   if(buffer == nullptr){
       std::vector<Int_t> *columns = GetColumnIndice(branch);
       if (columns) basket->CreateBuffer(branch->GetName(),"A", columns, branch, &fResult);
    }
@@ -214,7 +214,7 @@ void TTreeSQL::CheckBasket(TBranch *branch)
 
 Bool_t TTreeSQL::CheckBranch(TBranch * tb)
 {
-   if (fServer==0) {
+   if (fServer==nullptr) {
       return kFALSE;
    }
    TString leafName;
@@ -262,10 +262,10 @@ Bool_t TTreeSQL::CheckBranch(TBranch * tb)
 
 Bool_t TTreeSQL::CheckTable(const TString &table) const
 {
-   if (fServer==0) return kFALSE;
+   if (fServer==nullptr) return kFALSE;
    TSQLResult * tables = fServer->GetTables(fDB.Data(),table);
    if (!tables) return kFALSE;
-   TSQLRow * row = 0;
+   TSQLRow * row = nullptr;
    while( (row = tables->Next()) ) {
       if(table.CompareTo(row->GetField(0),TString::kIgnoreCase)==0){
          return kTRUE;
@@ -350,16 +350,16 @@ TString TTreeSQL::ConvertTypeName(const TString& typeName )
 
 TBasket * TTreeSQL::CreateBasket(TBranch * tb)
 {
-   if (fServer==0) {
+   if (fServer==nullptr) {
       Error("CreateBasket","No TSQLServer specified");
-      return 0;
+      return nullptr;
    }
    std::vector<Int_t> *columnVec = GetColumnIndice(tb);
    if (columnVec) {
       return new TBasketSQL(tb->GetName(), tb->GetName(), tb,
                             &fResult, &fInsertQuery, columnVec, &fRow);
    } else {
-      return 0;
+      return nullptr;
    }
 }
 
@@ -368,7 +368,7 @@ TBasket * TTreeSQL::CreateBasket(TBranch * tb)
 
 void TTreeSQL::CreateBranch(const TString &branchName, const TString &typeName)
 {
-   if (fServer==0) {
+   if (fServer==nullptr) {
       Error("CreateBranch","No TSQLServer specified");
       return;
    }
@@ -398,7 +398,7 @@ void TTreeSQL::CreateBranches()
    TString branchName;
    TString type;
    TString leafName;
-   TBranch * br = 0;
+   TBranch * br = nullptr;
    TSQLColumnInfo * info;
    while ( (info = ((TSQLColumnInfo*) next()) ))
    {
@@ -420,7 +420,7 @@ void TTreeSQL::CreateBranches()
       double d;
       float f;
 
-      br = 0;
+      br = nullptr;
 
       if(type.CompareTo("varchar",TString::kIgnoreCase)==0 ||
          type.CompareTo("varchar2",TString::kIgnoreCase)==0 ||
@@ -465,7 +465,7 @@ void TTreeSQL::CreateBranches()
          br = TTree::Branch(leafName,&d);
       }
 
-      if (br == 0)
+      if (br == nullptr)
       {
          Error("CreateBranches", "Skipped %s", branchName.Data());
          continue;
@@ -487,7 +487,7 @@ void TTreeSQL::CreateBranches()
 
 Bool_t TTreeSQL::CreateTable(const TString &table)
 {
-   if (fServer==0) {
+   if (fServer==nullptr) {
       Error("CreateTable","No TSQLServer specified");
       return false;
    }
@@ -541,7 +541,7 @@ Bool_t TTreeSQL::CreateTable(const TString &table)
    // retrieve table to initialize fResult
    delete fResult;
    fResult = fServer->Query(fQuery.Data());
-   return (fResult!=0);
+   return (fResult!=nullptr);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -573,7 +573,7 @@ Int_t TTreeSQL::Fill()
    TString typeName;
    TBranch *branch;
 
-   if (fServer==0) return 0;
+   if (fServer==nullptr) return 0;
 
    if(!CheckTable(fTable.Data())) {
       if (!CreateTable(fTable.Data())) {
@@ -604,7 +604,7 @@ Int_t TTreeSQL::Fill()
    if (fInsertQuery[fInsertQuery.Length()-1]!='(') {
       fInsertQuery.Remove(fInsertQuery.Length()-1);
       fInsertQuery += ")";
-      TSQLResult *res = fServer?fServer->Query(fInsertQuery):0;
+      TSQLResult *res = fServer?fServer->Query(fInsertQuery):nullptr;
 
       if (res) {
          return res->GetRowCount();
@@ -621,7 +621,7 @@ Int_t TTreeSQL::Fill()
 
 std::vector<Int_t> *TTreeSQL::GetColumnIndice(TBranch *branch)
 {
-   if (!CheckTable(fTable)) return 0;
+   if (!CheckTable(fTable)) return nullptr;
 
    std::vector<Int_t> *columns = new std::vector<Int_t>;
 
@@ -630,9 +630,9 @@ std::vector<Int_t> *TTreeSQL::GetColumnIndice(TBranch *branch)
    std::vector<TString> names;
 
    TList *col_list = fTableInfo->GetColumns();
-   if (col_list==0) {
+   if (col_list==nullptr) {
       delete columns;
-      return 0;
+      return nullptr;
    }
 
    std::pair<TString,Int_t> value;
@@ -677,7 +677,7 @@ std::vector<Int_t> *TTreeSQL::GetColumnIndice(TBranch *branch)
    }
    if (columns->empty()) {
       delete columns;
-      return 0;
+      return nullptr;
    } else
       return columns;
 }
@@ -687,7 +687,7 @@ std::vector<Int_t> *TTreeSQL::GetColumnIndice(TBranch *branch)
 
 Long64_t  TTreeSQL::GetEntries() const
 {
-   if (fServer==0) return GetEntriesFast();
+   if (fServer==nullptr) return GetEntriesFast();
    if (!CheckTable(fTable.Data())) return 0;
 
    TTreeSQL* thisvar = const_cast<TTreeSQL*>(this);
@@ -698,7 +698,7 @@ Long64_t  TTreeSQL::GetEntries() const
    TString counting = "select count(*) from " + fTable;
    TSQLResult *count = fServer->Query(counting);
 
-   if (count==0) {
+   if (count==nullptr) {
       thisvar->fEntries = 0;
    } else {
       TSQLRow * row = count->Next();
@@ -746,12 +746,12 @@ Long64_t TTreeSQL::LoadTree(Long64_t entry)
 
 Long64_t TTreeSQL::PrepEntry(Long64_t entry)
 {
-   if (entry < 0 || entry >= fEntries || fServer==0) return 0;
+   if (entry < 0 || entry >= fEntries || fServer==nullptr) return 0;
    fReadEntry = entry;
 
    if(entry == fCurrentEntry) return entry;
 
-   if(entry < fCurrentEntry || fResult==0){
+   if(entry < fCurrentEntry || fResult==nullptr){
       delete fResult;
       fResult = fServer->Query(fQuery.Data());
       fCurrentEntry = -1;
@@ -762,14 +762,14 @@ Long64_t TTreeSQL::PrepEntry(Long64_t entry)
       ++fCurrentEntry;
       delete fRow;
       fRow = fResult->Next();
-      if (fRow==0 && !reset) {
+      if (fRow==nullptr && !reset) {
          delete fResult;
          fResult = fServer->Query(fQuery.Data());
          fCurrentEntry = -1;
          reset = true;
       }
    }
-   if (fRow==0) return -1;
+   if (fRow==nullptr) return -1;
    return entry;
 }
 
@@ -798,8 +798,8 @@ void TTreeSQL::Refresh()
    // Note : something to be done?
    GetEntries(); // Re-load the number of entries
    fCurrentEntry = -1;
-   delete fResult; fResult = 0;
-   delete fRow; fRow = 0;
+   delete fResult; fResult = nullptr;
+   delete fRow; fRow = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/tree/src/TVirtualTreePlayer.cxx
+++ b/tree/tree/src/TVirtualTreePlayer.cxx
@@ -22,8 +22,8 @@ See the individual documentations in TTree.
 #include "TPluginManager.h"
 #include "TClass.h"
 
-TClass              *TVirtualTreePlayer::fgPlayer  = 0;
-TVirtualTreePlayer  *TVirtualTreePlayer::fgCurrent = 0;
+TClass              *TVirtualTreePlayer::fgPlayer  = nullptr;
+TVirtualTreePlayer  *TVirtualTreePlayer::fgCurrent = nullptr;
 
 ClassImp(TVirtualTreePlayer);
 
@@ -39,10 +39,10 @@ TVirtualTreePlayer *TVirtualTreePlayer::TreePlayer(TTree *obj)
       TPluginHandler *h;
       if ((h = gROOT->GetPluginManager()->FindHandler("TVirtualTreePlayer"))) {
          if (h->LoadPlugin() == -1)
-            return 0;
+            return nullptr;
          TVirtualTreePlayer::SetPlayer(h->GetClass());
       }
-      if (!fgPlayer) return 0;
+      if (!fgPlayer) return nullptr;
    }
 
    //create an instance of the Tree player
@@ -59,7 +59,7 @@ TVirtualTreePlayer::~TVirtualTreePlayer()
 {
    if (fgCurrent==this) {
       // Make sure fgCurrent does not point to a deleted player.
-      fgCurrent=0;
+      fgCurrent=nullptr;
    }
 }
 

--- a/tree/tree/src/TreeUtils.cxx
+++ b/tree/tree/src/TreeUtils.cxx
@@ -98,7 +98,7 @@ Long64_t FillNtupleFromStream(std::istream &inputStream, Tuple &tuple, char deli
    }
 
    DataType *args = tuple.GetArgs();
-   assert(args != 0 && "FillNtupleFromStream, args buffer is a null");
+   assert(args != nullptr && "FillNtupleFromStream, args buffer is a null");
 
    Long64_t nLines = 0;
 

--- a/tree/treeplayer/inc/ROOT/TTreeReaderFast.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeReaderFast.hxx
@@ -128,7 +128,7 @@ public:
    {}
 
    TTreeReaderFast(TTree* tree);
-   TTreeReaderFast(const char* keyname, TDirectory* dir = NULL );
+   TTreeReaderFast(const char* keyname, TDirectory* dir = nullptr );
 
    ~TTreeReaderFast() override;
 

--- a/tree/treeplayer/inc/TMPWorkerTree.h
+++ b/tree/treeplayer/inc/TMPWorkerTree.h
@@ -191,7 +191,7 @@ void TMPWorkerTreeFunc<F>::Process(UInt_t code, MPCodeBufPair &msg)
 
    Long64_t start = 0;
    Long64_t finish = 0;
-   TEntryList *enl = 0;
+   TEntryList *enl = nullptr;
    std::string reply, errmsg, sn = "[S" + std::to_string(GetNWorker()) + "]: ";
    if (LoadTree(code, msg, start, finish, &enl, errmsg) != 0) {
       reply = sn + errmsg;

--- a/tree/treeplayer/src/TBranchProxy.cxx
+++ b/tree/treeplayer/src/TBranchProxy.cxx
@@ -29,12 +29,12 @@ using namespace ROOT::Internal;
 /// Constructor.
 
 ROOT::Detail::TBranchProxy::TBranchProxy() :
-   fDirector(0), fInitialized(false), fIsMember(false), fIsClone(false), fIsaPointer(false),
-   fHasLeafCount(false), fBranchName(""), fParent(0), fDataMember(""),
-   fClassName(""), fClass(0), fElement(0), fMemberOffset(0), fOffset(0), fArrayLength(1),
-   fBranch(0), fBranchCount(0),
+   fDirector(nullptr), fInitialized(false), fIsMember(false), fIsClone(false), fIsaPointer(false),
+   fHasLeafCount(false), fBranchName(""), fParent(nullptr), fDataMember(""),
+   fClassName(""), fClass(nullptr), fElement(nullptr), fMemberOffset(0), fOffset(0), fArrayLength(1),
+   fBranch(nullptr), fBranchCount(nullptr),
    fNotify(this),
-   fRead(-1), fWhere(0),fCollection(0)
+   fRead(-1), fWhere(nullptr),fCollection(nullptr)
 {
 };
 
@@ -44,11 +44,11 @@ ROOT::Detail::TBranchProxy::TBranchProxy() :
 ROOT::Detail::TBranchProxy::TBranchProxy(TBranchProxyDirector* boss, const char* top,
                                  const char* name) :
    fDirector(boss), fInitialized(false), fIsMember(false), fIsClone(false), fIsaPointer(false),
-   fHasLeafCount(false), fBranchName(top), fParent(0), fDataMember(""),
-   fClassName(""), fClass(0), fElement(0), fMemberOffset(0), fOffset(0), fArrayLength(1),
-   fBranch(0), fBranchCount(0),
+   fHasLeafCount(false), fBranchName(top), fParent(nullptr), fDataMember(""),
+   fClassName(""), fClass(nullptr), fElement(nullptr), fMemberOffset(0), fOffset(0), fArrayLength(1),
+   fBranch(nullptr), fBranchCount(nullptr),
    fNotify(this),
-   fRead(-1),  fWhere(0),fCollection(0)
+   fRead(-1),  fWhere(nullptr),fCollection(nullptr)
 {
    if (fBranchName.Length() && fBranchName[fBranchName.Length()-1]!='.' && name) {
       ((TString&)fBranchName).Append(".");
@@ -62,11 +62,11 @@ ROOT::Detail::TBranchProxy::TBranchProxy(TBranchProxyDirector* boss, const char*
 
 ROOT::Detail::TBranchProxy::TBranchProxy(TBranchProxyDirector* boss, const char *top, const char *name, const char *membername) :
    fDirector(boss), fInitialized(false), fIsMember(true), fIsClone(false), fIsaPointer(false),
-   fHasLeafCount(false), fBranchName(top), fParent(0), fDataMember(membername),
-   fClassName(""), fClass(0), fElement(0), fMemberOffset(0), fOffset(0), fArrayLength(1),
-   fBranch(0), fBranchCount(0),
+   fHasLeafCount(false), fBranchName(top), fParent(nullptr), fDataMember(membername),
+   fClassName(""), fClass(nullptr), fElement(nullptr), fMemberOffset(0), fOffset(0), fArrayLength(1),
+   fBranch(nullptr), fBranchCount(nullptr),
    fNotify(this),
-   fRead(-1), fWhere(0),fCollection(0)
+   fRead(-1), fWhere(nullptr),fCollection(nullptr)
 {
    if (name && strlen(name)) {
       if (fBranchName.Length() && fBranchName[fBranchName.Length()-1]!='.') {
@@ -84,10 +84,10 @@ ROOT::Detail::TBranchProxy::TBranchProxy(TBranchProxyDirector* boss, Detail::TBr
                                  const char* name) :
    fDirector(boss), fInitialized(false), fIsMember(true), fIsClone(false), fIsaPointer(false),
    fHasLeafCount(false), fBranchName(top), fParent(parent), fDataMember(membername),
-   fClassName(""), fClass(0), fElement(0), fMemberOffset(0), fOffset(0), fArrayLength(1),
-   fBranch(0), fBranchCount(0),
+   fClassName(""), fClass(nullptr), fElement(nullptr), fMemberOffset(0), fOffset(0), fArrayLength(1),
+   fBranch(nullptr), fBranchCount(nullptr),
    fNotify(this),
-   fRead(-1), fWhere(0),fCollection(0)
+   fRead(-1), fWhere(nullptr),fCollection(nullptr)
 {
    if (name && strlen(name)) {
       if (fBranchName.Length() && fBranchName[fBranchName.Length()-1]!='.') {
@@ -102,12 +102,12 @@ ROOT::Detail::TBranchProxy::TBranchProxy(TBranchProxyDirector* boss, Detail::TBr
 /// Constructor.
 
 ROOT::Detail::TBranchProxy::TBranchProxy(TBranchProxyDirector* boss, TBranch* branch, const char* membername) :
-   fDirector(boss), fInitialized(false), fIsMember(membername != 0 && membername[0]), fIsClone(false), fIsaPointer(false),
-   fHasLeafCount(false), fBranchName(branch->GetName()), fParent(0), fDataMember(membername),
-   fClassName(""), fClass(0), fElement(0), fMemberOffset(0), fOffset(0), fArrayLength(1),
-   fBranch(0), fBranchCount(0),
+   fDirector(boss), fInitialized(false), fIsMember(membername != nullptr && membername[0]), fIsClone(false), fIsaPointer(false),
+   fHasLeafCount(false), fBranchName(branch->GetName()), fParent(nullptr), fDataMember(membername),
+   fClassName(""), fClass(nullptr), fElement(nullptr), fMemberOffset(0), fOffset(0), fArrayLength(1),
+   fBranch(nullptr), fBranchCount(nullptr),
    fNotify(this),
-   fRead(-1), fWhere(0),fCollection(0)
+   fRead(-1), fWhere(nullptr),fCollection(nullptr)
 {
    boss->Attach(this);
 }
@@ -139,12 +139,12 @@ static std::string GetFriendBranchName(TTree* directorTree, TBranch* branch, con
 /// Used by TTreeReaderValue in place of TFriendProxy.
 
 ROOT::Detail::TBranchProxy::TBranchProxy(TBranchProxyDirector* boss, const char* branchname, TBranch* branch, const char* membername) :
-   fDirector(boss), fInitialized(false), fIsMember(membername != 0 && membername[0]), fIsClone(false), fIsaPointer(false),
-   fHasLeafCount(false), fBranchName(GetFriendBranchName(boss->GetTree(), branch, branchname)), fParent(0), fDataMember(membername),
-   fClassName(""), fClass(0), fElement(0), fMemberOffset(0), fOffset(0), fArrayLength(1),
-   fBranch(0), fBranchCount(0),
+   fDirector(boss), fInitialized(false), fIsMember(membername != nullptr && membername[0]), fIsClone(false), fIsaPointer(false),
+   fHasLeafCount(false), fBranchName(GetFriendBranchName(boss->GetTree(), branch, branchname)), fParent(nullptr), fDataMember(membername),
+   fClassName(""), fClass(nullptr), fElement(nullptr), fMemberOffset(0), fOffset(0), fArrayLength(1),
+   fBranch(nullptr), fBranchCount(nullptr),
    fNotify(this),
-   fRead(-1), fWhere(0),fCollection(0)
+   fRead(-1), fWhere(nullptr),fCollection(nullptr)
 {
    // Constructor.
 
@@ -165,12 +165,12 @@ ROOT::Detail::TBranchProxy::~TBranchProxy()
 
 void ROOT::Detail::TBranchProxy::Reset()
 {
-   fWhere = 0;
-   fBranch = 0;
-   fBranchCount = 0;
+   fWhere = nullptr;
+   fBranch = nullptr;
+   fBranchCount = nullptr;
    fRead = -1;
-   fClass = 0;
-   fElement = 0;
+   fClass = nullptr;
+   fElement = nullptr;
    fMemberOffset = 0;
    fOffset = 0;
    fArrayLength = 1;
@@ -178,7 +178,7 @@ void ROOT::Detail::TBranchProxy::Reset()
    fInitialized = false;
    fHasLeafCount = false;
    delete fCollection;
-   fCollection = 0;
+   fCollection = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -237,7 +237,7 @@ Bool_t ROOT::Detail::TBranchProxy::Setup()
          if (fCollection) delete fCollection;
          fCollection = pcl->GetCollectionProxy()->Generate();
          pcl = fCollection->GetValueClass();
-         if (pcl == 0) {
+         if (pcl == nullptr) {
             // coverity[dereference] fparent is checked jus a bit earlier and can not be null here
             Error("Setup","Not finding TClass for collection for the data member %s seems no longer be in class %s",fDataMember.Data(),fParent->GetClass()->GetName());
             return false;
@@ -292,7 +292,7 @@ Bool_t ROOT::Detail::TBranchProxy::Setup()
 
          TBranchElement* be = ((TBranchElement*)fBranch);
 
-         be->GetMother()->SetAddress(0);
+         be->GetMother()->SetAddress(nullptr);
          fWhere =  (double*)fBranch->GetAddress();
 
       }
@@ -508,7 +508,7 @@ Bool_t ROOT::Detail::TBranchProxy::Setup()
       }
    }
    if (fClass==TClonesArray::Class()) fIsClone = true;
-   if (fWhere!=0) {
+   if (fWhere!=nullptr) {
       fInitialized = true;
       return true;
    } else {

--- a/tree/treeplayer/src/TBranchProxyClassDescriptor.cxx
+++ b/tree/treeplayer/src/TBranchProxyClassDescriptor.cxx
@@ -91,7 +91,7 @@ namespace Internal {
       fSplitLevel(0),
       fBranchName(branchname),
       fSubBranchPrefix(branchname),
-      fInfo(0),
+      fInfo(nullptr),
       fMaxDatamemberType(3)
    {
       NameToSymbol();

--- a/tree/treeplayer/src/TBranchProxyDirector.cxx
+++ b/tree/treeplayer/src/TBranchProxyDirector.cxx
@@ -99,7 +99,7 @@ namespace Internal {
       if (gPad && optSame) {
          TListIter np(gPad->GetListOfPrimitives());
          TObject *op;
-         TH1 *oldhtemp = 0;
+         TH1 *oldhtemp = nullptr;
          while ((op = np()) && !oldhtemp) {
             if (op->InheritsFrom(TH1::Class())) oldhtemp = (TH1 *)op;
          }
@@ -128,7 +128,7 @@ namespace Internal {
       if (canExtend) hist->SetCanExtend(TH1::kAllAxes);
       hist->GetXaxis()->SetTitle("var");
       hist->SetBit(kCanDelete);
-      hist->SetDirectory(0);
+      hist->SetDirectory(nullptr);
 
       if (opt.Length() && opt.Contains("e")) hist->Sumw2();
       return hist;

--- a/tree/treeplayer/src/TChainIndex.cxx
+++ b/tree/treeplayer/src/TChainIndex.cxx
@@ -46,8 +46,8 @@ ClassImp(TChainIndex);
 
 TChainIndex::TChainIndex(): TVirtualIndex()
 {
-   fTree = 0;
-   fMajorFormulaParent = fMinorFormulaParent = 0;
+   fTree = nullptr;
+   fMajorFormulaParent = fMinorFormulaParent = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -63,8 +63,8 @@ TChainIndex::TChainIndex(): TVirtualIndex()
 TChainIndex::TChainIndex(const TTree *T, const char *majorname, const char *minorname)
            : TVirtualIndex()
 {
-   fTree = 0;
-   fMajorFormulaParent = fMinorFormulaParent = 0;
+   fTree = nullptr;
+   fMajorFormulaParent = fMinorFormulaParent = nullptr;
 
    TChain *chain = dynamic_cast<TChain*>(const_cast<TTree*>(T));
    if (!chain) {
@@ -85,7 +85,7 @@ TChainIndex::TChainIndex(const TTree *T, const char *majorname, const char *mino
       TVirtualIndex *index = chain->GetTree()->GetTreeIndex();
 
       TChainIndexEntry entry;
-      entry.fTreeIndex = 0;
+      entry.fTreeIndex = nullptr;
 
       //if an index already exists, we must check if major/minorname correspond
       //to the major/minor names in this function call
@@ -99,7 +99,7 @@ TChainIndex::TChainIndex(const TTree *T, const char *majorname, const char *mino
       if (!index) {
          chain->GetTree()->BuildIndex(majorname, minorname);
          index = chain->GetTree()->GetTreeIndex();
-         chain->GetTree()->SetTreeIndex(0);
+         chain->GetTree()->SetTreeIndex(nullptr);
          entry.fTreeIndex = index;
       }
       if (!index || index->IsZombie() || index->GetN() == 0) {
@@ -110,7 +110,7 @@ TChainIndex::TChainIndex(const TTree *T, const char *majorname, const char *mino
       }
 
       TTreeIndex *ti_index = dynamic_cast<TTreeIndex*>(index);
-      if (ti_index == 0) {
+      if (ti_index == nullptr) {
          Error("TChainIndex", "The underlying TTree must have a TTreeIndex but has a %s.",
                index->IsA()->GetName());
          return;
@@ -138,13 +138,13 @@ void TChainIndex::Append(const TVirtualIndex *index, Bool_t delaySort )
 {
    if (index) {
       const TTreeIndex *ti_index = dynamic_cast<const TTreeIndex*>(index);
-      if (ti_index == 0) {
+      if (ti_index == nullptr) {
          Error("Append", "The given index is not a TTreeIndex but a %s",
                index->IsA()->GetName());
       }
 
       TChainIndexEntry entry;
-      entry.fTreeIndex = 0;
+      entry.fTreeIndex = nullptr;
       entry.SetMinMaxFrom(ti_index);
       fEntries.push_back(entry);
    }
@@ -169,7 +169,7 @@ void TChainIndex::DeleteIndices()
    for (unsigned int i = 0; i < fEntries.size(); i++) {
       if (fEntries[i].fTreeIndex) {
          if (fTree->GetTree() && fTree->GetTree()->GetTreeIndex() == fEntries[i].fTreeIndex) {
-            fTree->GetTree()->SetTreeIndex(0);
+            fTree->GetTree()->SetTreeIndex(nullptr);
             SafeDelete(fEntries[i].fTreeIndex);
          }
          SafeDelete(fEntries[i].fTreeIndex);
@@ -200,14 +200,14 @@ std::pair<TVirtualIndex*, Int_t> TChainIndex::GetSubTreeIndex(Long64_t major, Lo
    using namespace std;
    if (fEntries.size() == 0) {
       Warning("GetSubTreeIndex", "No subindices in the chain. The chain is probably empty");
-      return make_pair(static_cast<TVirtualIndex*>(0), 0);
+      return make_pair(static_cast<TVirtualIndex*>(nullptr), 0);
    }
 
    const TChainIndexEntry::IndexValPair_t     indexValue(major, minor);
 
    if( indexValue < fEntries[0].GetMinIndexValPair() ) {
       Warning("GetSubTreeIndex", "The index value is less than the smallest index values in subtrees");
-      return make_pair(static_cast<TVirtualIndex*>(0), 0);
+      return make_pair(static_cast<TVirtualIndex*>(nullptr), 0);
    }
 
    Int_t treeNo = fEntries.size() - 1;
@@ -219,7 +219,7 @@ std::pair<TVirtualIndex*, Int_t> TChainIndex::GetSubTreeIndex(Long64_t major, Lo
    }
    // Double check we found the right range.
    if( indexValue > fEntries[treeNo].GetMaxIndexValPair() ) {
-      return make_pair(static_cast<TVirtualIndex*>(0), 0);
+      return make_pair(static_cast<TVirtualIndex*>(nullptr), 0);
    }
    TChain* chain = dynamic_cast<TChain*> (fTree);
    R__ASSERT(chain);
@@ -232,7 +232,7 @@ std::pair<TVirtualIndex*, Int_t> TChainIndex::GetSubTreeIndex(Long64_t major, Lo
       if (!index) {
          Warning("GetSubTreeIndex", "The tree has no index and the chain index"
                   " doesn't store an index for that tree");
-         return make_pair(static_cast<TVirtualIndex*>(0), 0);
+         return make_pair(static_cast<TVirtualIndex*>(nullptr), 0);
       }
       else {
          fTree->GetTree()->SetTreeIndex(index);
@@ -250,7 +250,7 @@ void TChainIndex::ReleaseSubTreeIndex(TVirtualIndex* index, int treeNo) const
 {
    if (fEntries[treeNo].fTreeIndex == index) {
       R__ASSERT(fTree->GetTree()->GetTreeIndex() == index);
-      fTree->GetTree()->SetTreeIndex(0);
+      fTree->GetTree()->SetTreeIndex(nullptr);
    }
 }
 
@@ -403,7 +403,7 @@ void TChainIndex::UpdateFormulaLeaves(const TTree *parent)
 
 void TChainIndex::SetTree(TTree *T)
 {
-   R__ASSERT(fTree == 0 || fTree == T || T==0);
+   R__ASSERT(fTree == nullptr || fTree == T || T==nullptr);
    fTree = T;
 }
 

--- a/tree/treeplayer/src/TFileDrawMap.cxx
+++ b/tree/treeplayer/src/TFileDrawMap.cxx
@@ -80,8 +80,8 @@ ClassImp(TFileDrawMap);
 
 TFileDrawMap::TFileDrawMap() :TNamed()
 {
-   fFile   = 0;
-   fFrame  = 0;
+   fFile   = nullptr;
+   fFrame  = nullptr;
    fXsize  = 1000;
    fYsize  = 1000;
 }
@@ -107,7 +107,7 @@ TFileDrawMap::TFileDrawMap(const TFile *file, const char *keys, Option_t *option
       fXsize = 1000;
    }
    fFrame = new TH1D("hmapframe","",1000,0,fXsize);
-   fFrame->SetDirectory(0);
+   fFrame->SetDirectory(nullptr);
    fFrame->SetBit(TH1::kNoStats);
    fFrame->SetBit(kCanDelete);
    fFrame->SetMinimum(0);
@@ -348,7 +348,7 @@ void TFileDrawMap::ExecuteEvent(Int_t event, Int_t px, Int_t py)
 
 TObject *TFileDrawMap::GetObject()
 {
-   if (strstr(GetName(),"entry=")) return 0;
+   if (strstr(GetName(),"entry=")) return nullptr;
    char *info = new char[fName.Length()+1];
    strlcpy(info,fName.Data(),fName.Length()+1);
    char *colon = strstr(info,"::");

--- a/tree/treeplayer/src/TFormLeafInfo.cxx
+++ b/tree/treeplayer/src/TFormLeafInfo.cxx
@@ -74,7 +74,7 @@ The following method are available from the TFormLeafInfo interface:
 TFormLeafInfo::TFormLeafInfo(TClass* classptr, Longptr_t offset,
                              TStreamerElement* element) :
      fClass(classptr),fOffset(offset),fElement(element),
-     fCounter(0), fNext(0),fMultiplicity(0)
+     fCounter(nullptr), fNext(nullptr),fMultiplicity(0)
 {
    if (fClass) fClassName = fClass->GetName();
    if (fElement) {
@@ -85,7 +85,7 @@ TFormLeafInfo::TFormLeafInfo(TClass* classptr, Longptr_t offset,
 ////////////////////////////////////////////////////////////////////////////////
 ///Constructor.
 
-TFormLeafInfo::TFormLeafInfo(const TFormLeafInfo& orig) : TObject(orig),fClass(orig.fClass),fOffset(orig.fOffset),fElement(orig.fElement),fCounter(0),fNext(0),fClassName(orig.fClassName),fElementName(orig.fElementName),fMultiplicity(orig.fMultiplicity)
+TFormLeafInfo::TFormLeafInfo(const TFormLeafInfo& orig) : TObject(orig),fClass(orig.fClass),fOffset(orig.fOffset),fElement(orig.fElement),fCounter(nullptr),fNext(nullptr),fClassName(orig.fClassName),fElementName(orig.fElementName),fMultiplicity(orig.fMultiplicity)
 {
    // Deep copy the pointers.
    if (orig.fCounter) fCounter = orig.fCounter->DeepCopy();
@@ -200,7 +200,7 @@ char* TFormLeafInfo::GetObjectAddress(TLeafElement* leaf, Int_t& instance)
       // Branch is *not* a top-level branch.
       offset = info->TStreamerInfo::GetElementOffset(id);
    }
-   char* address = 0;
+   char* address = nullptr;
    // Branch is *not* a top-level branch.
    if (branch->GetTree()->GetMakeClass()) {
       // Branch belongs to a MakeClass tree.
@@ -208,7 +208,7 @@ char* TFormLeafInfo::GetObjectAddress(TLeafElement* leaf, Int_t& instance)
    } else {
       address = (char*) branch->GetObject();
    }
-   char* thisobj = 0;
+   char* thisobj = nullptr;
    if (!address) {
       // FIXME: This makes no sense, if the branch address is not set, then object will not be set either.
       thisobj = branch->GetObject();
@@ -342,7 +342,7 @@ Bool_t TFormLeafInfo::HasCounter() const
 {
    Bool_t result = kFALSE;
    if (fNext) result = fNext->HasCounter();
-   return fCounter!=0 || result;
+   return fCounter!=nullptr || result;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -602,13 +602,13 @@ Int_t TFormLeafInfo::ReadCounterValue(char* where)
 
 void* TFormLeafInfo::GetLocalValuePointer(TLeaf *leaf, Int_t instance)
 {
-   char *thisobj = 0;
+   char *thisobj = nullptr;
    if (leaf->InheritsFrom(TLeafObject::Class()) ) {
       thisobj = (char*)((TLeafObject*)leaf)->GetObject();
    } else {
       thisobj = GetObjectAddress((TLeafElement*)leaf, instance); // instance might be modified
    }
-   if (!thisobj) return 0;
+   if (!thisobj) return nullptr;
    return GetLocalValuePointer(thisobj, instance);
 }
 
@@ -640,7 +640,7 @@ void* TFormLeafInfo::GetValuePointer(char *thisobj, Int_t instance)
 
 void* TFormLeafInfo::GetLocalValuePointer(char *thisobj, Int_t instance)
 {
-   if (fElement==0 || thisobj==0) return thisobj;
+   if (fElement==nullptr || thisobj==nullptr) return thisobj;
 
    switch (fElement->GetNewType()) {
       // basic types
@@ -779,7 +779,7 @@ void* TFormLeafInfo::GetLocalValuePointer(char *thisobj, Int_t instance)
          {TObject *obj = (TObject*)(thisobj+fOffset);   return obj; }
 
       case kOther_t:
-      default:        return 0;
+      default:        return nullptr;
    }
 }
 
@@ -790,13 +790,13 @@ void* TFormLeafInfo::GetLocalValuePointer(char *thisobj, Int_t instance)
 template <typename T>
 T TFormLeafInfo::GetValueImpl(TLeaf *leaf, Int_t instance)
 {
-   char *thisobj = 0;
+   char *thisobj = nullptr;
    if (leaf->InheritsFrom(TLeafObject::Class()) ) {
       thisobj = (char*)((TLeafObject*)leaf)->GetObject();
    } else {
       thisobj = GetObjectAddress((TLeafElement*)leaf, instance); // instance might be modified
    }
-   if (thisobj==0) return 0;
+   if (thisobj==nullptr) return 0;
    return ReadTypedValue<T>(thisobj,instance);
 }
 
@@ -1002,7 +1002,7 @@ void* TFormLeafInfoDirect::GetLocalValuePointer(char *thisobj, Int_t instance)
 /// Constructor.
 
 TFormLeafInfoNumerical::TFormLeafInfoNumerical(EDataType kind) :
-   TFormLeafInfo(0,0,0),
+   TFormLeafInfo(nullptr,0,nullptr),
    fKind(kind), fIsBool(kFALSE)
 {
    fElement = new TStreamerElement("data","in collection", 0, fKind, "");
@@ -1012,7 +1012,7 @@ TFormLeafInfoNumerical::TFormLeafInfoNumerical(EDataType kind) :
 /// Construct a TFormLeafInfo for the numerical type contained in the collection.
 
 TFormLeafInfoNumerical::TFormLeafInfoNumerical(TVirtualCollectionProxy *collection) :
-   TFormLeafInfo(0,0,0),
+   TFormLeafInfo(nullptr,0,nullptr),
    fKind(kNoType_t), fIsBool(kFALSE)
 {
    if (collection) {
@@ -1200,7 +1200,7 @@ Int_t TFormLeafInfoClones::ReadCounterValue(char* where)
 template <typename T>
 T TFormLeafInfoClones::ReadValueImpl(char *where, Int_t instance)
 {
-   if (fNext==0) return 0;
+   if (fNext==nullptr) return 0;
    Int_t len,index,sub_instance;
    len = fNext->GetArrayLength();
    if (len) {
@@ -1254,9 +1254,9 @@ void* TFormLeafInfoClones::GetLocalValuePointer(char *where, Int_t instance)
 template <typename T>
 T TFormLeafInfoClones::GetValueImpl(TLeaf *leaf, Int_t instance)
 {
-   if (fNext==0) return 0;
+   if (fNext==nullptr) return 0;
    Int_t len,index,sub_instance;
-   len = (fNext->fElement==0)? 0 : fNext->GetArrayLength();
+   len = (fNext->fElement==nullptr)? 0 : fNext->GetArrayLength();
    Int_t primary = fNext->GetPrimaryIndex();
    if (len) {
       index = instance / len;
@@ -1269,7 +1269,7 @@ T TFormLeafInfoClones::GetValueImpl(TLeaf *leaf, Int_t instance)
       sub_instance = 0;
    }
    TClonesArray *clones = (TClonesArray*)GetLocalValuePointer(leaf);
-   if (clones==0) return 0;
+   if (clones==nullptr) return 0;
 
    // Note we take advantage of having only one physically variable
    // dimension:
@@ -1286,7 +1286,7 @@ void * TFormLeafInfoClones::GetValuePointer(TLeaf *leaf, Int_t instance)
    if (fNext && clones) {
       // Same as in TFormLeafInfoClones::GetValue
       Int_t len,index,sub_instance;
-      len = (fNext->fElement==0)? 0 : fNext->GetArrayLength();
+      len = (fNext->fElement==nullptr)? 0 : fNext->GetArrayLength();
       if (len) {
          index = instance / len;
          sub_instance = instance % len;
@@ -1309,7 +1309,7 @@ void * TFormLeafInfoClones::GetValuePointer(char *where, Int_t instance)
    if (fNext) {
       // Same as in TFormLeafInfoClones::GetValue
       Int_t len,index,sub_instance;
-      len = (fNext->fElement==0)? 0 : fNext->GetArrayLength();
+      len = (fNext->fElement==nullptr)? 0 : fNext->GetArrayLength();
       if (len) {
          index = instance / len;
          sub_instance = instance % len;
@@ -1416,7 +1416,7 @@ T TFormLeafInfoCollectionObject::GetValueImpl(TLeaf *leaf, Int_t instance)
 {
    char * obj = (char*)GetLocalValuePointer(leaf);
 
-   if (fNext==0) return 0;
+   if (fNext==nullptr) return 0;
    return fNext->ReadTypedValue<T>(obj,instance);
 }
 
@@ -1459,9 +1459,9 @@ TFormLeafInfoCollection::TFormLeafInfoCollection(TClass* classptr,
                                                  Bool_t top) :
    TFormLeafInfo(classptr,offset,element),
    fTop(top),
-   fCollClass( 0),
-   fCollProxy( 0),
-   fLocalElement( 0)
+   fCollClass( nullptr),
+   fCollProxy( nullptr),
+   fLocalElement( nullptr)
 {
    if (element) {
       fCollClass = element->GetClass();
@@ -1495,8 +1495,8 @@ TFormLeafInfoCollection::TFormLeafInfoCollection(TClass* motherclassptr,
                                           : "Unknown")
                                       ) ),
    fTop(top),
-   fCollClass( 0),
-   fCollProxy( 0) ,
+   fCollClass( nullptr),
+   fCollProxy( nullptr) ,
    fLocalElement( fElement )
 {
    if (elementclassptr) {
@@ -1519,9 +1519,9 @@ TFormLeafInfoCollection::TFormLeafInfoCollection(TClass* motherclassptr,
 TFormLeafInfoCollection::TFormLeafInfoCollection() :
    TFormLeafInfo(),
    fTop(kFALSE),
-   fCollClass( 0),
-   fCollProxy( 0),
-   fLocalElement( 0)
+   fCollClass( nullptr),
+   fCollProxy( nullptr),
+   fLocalElement( nullptr)
 {
 }
 
@@ -1533,8 +1533,8 @@ TFormLeafInfoCollection::TFormLeafInfoCollection(const TFormLeafInfoCollection& 
    fTop( orig.fTop),
    fCollClass( orig.fCollClass ),
    fCollClassName( orig.fCollClassName ),
-   fCollProxy( orig.fCollProxy ? orig.fCollProxy->Generate() : 0 ),
-   fLocalElement( 0 ) // humm why not initialize it?
+   fCollProxy( orig.fCollProxy ? orig.fCollProxy->Generate() : nullptr ),
+   fLocalElement( nullptr ) // humm why not initialize it?
 {
 }
 
@@ -1588,7 +1588,7 @@ Bool_t TFormLeafInfoCollection::Update()
    Bool_t changed = kFALSE;
    TClass * new_class = TClass::GetClass(fCollClassName);
    if (new_class!=fCollClass) {
-      delete fCollProxy; fCollProxy = 0;
+      delete fCollProxy; fCollProxy = nullptr;
       fCollClass = new_class;
       if (fCollClass && fCollClass->GetCollectionProxy()) {
          fCollProxy = fCollClass->GetCollectionProxy()->Generate();
@@ -1603,7 +1603,7 @@ Bool_t TFormLeafInfoCollection::Update()
 
 Bool_t TFormLeafInfoCollection::HasCounter() const
 {
-   return fCounter!=0 || fCollProxy!=0;
+   return fCounter!=nullptr || fCollProxy!=nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1616,7 +1616,7 @@ Int_t TFormLeafInfoCollection::GetCounterValue(TLeaf* leaf)
    if (fCounter) { return (Int_t)fCounter->ReadValue((char*)ptr); }
 
    R__ASSERT(fCollProxy);
-   if (ptr==0) return 0;
+   if (ptr==nullptr) return 0;
    TVirtualCollectionProxy::TPushPop helper(fCollProxy, ptr);
    return (Int_t)fCollProxy->Size();
 }
@@ -1628,7 +1628,7 @@ Int_t TFormLeafInfoCollection::ReadCounterValue(char* where)
 {
    if (fCounter) { return (Int_t)fCounter->ReadValue(where); }
    R__ASSERT(fCollProxy);
-   if (where==0) return 0;
+   if (where==nullptr) return 0;
    void *ptr = GetLocalValuePointer(where,0);
    TVirtualCollectionProxy::TPushPop helper(fCollProxy, ptr);
    return (Int_t)fCollProxy->Size();
@@ -1644,7 +1644,7 @@ Int_t TFormLeafInfoCollection::GetCounterValue(TLeaf* leaf, Int_t instance)
       return (Int_t)fCounter->ReadValue((char*)ptr);
    }
    R__ASSERT(fCollProxy);
-   if (ptr==0) return 0;
+   if (ptr==nullptr) return 0;
    TVirtualCollectionProxy::TPushPop helper(fCollProxy, ptr);
    return (Int_t)fCollProxy->Size();
 }
@@ -1656,9 +1656,9 @@ Int_t TFormLeafInfoCollection::GetCounterValue(TLeaf* leaf, Int_t instance)
 template <typename T>
 T TFormLeafInfoCollection::ReadValueImpl(char *where, Int_t instance)
 {
-   if (fNext==0) return 0;
+   if (fNext==nullptr) return 0;
    UInt_t len,index,sub_instance;
-   len = (fNext->fElement==0)? 0 : fNext->GetArrayLength();
+   len = (fNext->fElement==nullptr)? 0 : fNext->GetArrayLength();
    Int_t primary = fNext->GetPrimaryIndex();
    if (len) {
       index = instance / len;
@@ -1719,9 +1719,9 @@ void* TFormLeafInfoCollection::GetLocalValuePointer(char *where, Int_t instance)
 template <typename T>
 T TFormLeafInfoCollection::GetValueImpl(TLeaf *leaf, Int_t instance)
 {
-   if (fNext==0) return 0;
+   if (fNext==nullptr) return 0;
    Int_t len,index,sub_instance;
-   len = (fNext->fElement==0)? 0 : fNext->GetArrayLength();
+   len = (fNext->fElement==nullptr)? 0 : fNext->GetArrayLength();
    Int_t primary = fNext->GetPrimaryIndex();
    if (len) {
       index = instance / len;
@@ -1741,9 +1741,9 @@ T TFormLeafInfoCollection::GetValueImpl(TLeaf *leaf, Int_t instance)
    // Note we take advantage of having only one physically variable
    // dimension:
    char * obj = (char*)fCollProxy->At(index);
-   if (obj==0) return 0;
+   if (obj==nullptr) return 0;
    if (fCollProxy->HasPointers()) obj = *(char**)obj;
-   if (obj==0) return 0;
+   if (obj==nullptr) return 0;
    return fNext->ReadTypedValue<T>(obj,sub_instance);
 }
 
@@ -1792,7 +1792,7 @@ void * TFormLeafInfoCollection::GetValuePointer(char *where, Int_t instance)
    if (fNext) {
       // Same as in TFormLeafInfoClones::GetValue
       Int_t len,index,sub_instance;
-      len = (fNext->fElement==0)? 0 : fNext->GetArrayLength();
+      len = (fNext->fElement==nullptr)? 0 : fNext->GetArrayLength();
       if (len) {
          index = instance / len;
          sub_instance = instance % len;
@@ -1816,7 +1816,7 @@ void * TFormLeafInfoCollection::GetValuePointer(char *where, Int_t instance)
 /// Constructor.
 
 TFormLeafInfoCollectionSize::TFormLeafInfoCollectionSize(TClass* classptr) :
-   TFormLeafInfo(), fCollClass(classptr), fCollProxy(0)
+   TFormLeafInfo(), fCollClass(classptr), fCollProxy(nullptr)
 {
    if (fCollClass
        && fCollClass!=TClonesArray::Class()
@@ -1832,7 +1832,7 @@ TFormLeafInfoCollectionSize::TFormLeafInfoCollectionSize(TClass* classptr) :
 
 TFormLeafInfoCollectionSize::TFormLeafInfoCollectionSize(
    TClass* classptr,Longptr_t offset,TStreamerElement* element) :
-   TFormLeafInfo(classptr,offset,element), fCollClass(element->GetClassPointer()), fCollProxy(0)
+   TFormLeafInfo(classptr,offset,element), fCollClass(element->GetClassPointer()), fCollProxy(nullptr)
 {
    if (fCollClass
        && fCollClass!=TClonesArray::Class()
@@ -1847,7 +1847,7 @@ TFormLeafInfoCollectionSize::TFormLeafInfoCollectionSize(
 /// Constructor.
 
 TFormLeafInfoCollectionSize::TFormLeafInfoCollectionSize() :
-   TFormLeafInfo(), fCollClass(0), fCollProxy(0)
+   TFormLeafInfo(), fCollClass(nullptr), fCollProxy(nullptr)
 {
 }
 
@@ -1858,7 +1858,7 @@ TFormLeafInfoCollectionSize::TFormLeafInfoCollectionSize(
    const TFormLeafInfoCollectionSize& orig) :  TFormLeafInfo(),
       fCollClass(orig.fCollClass),
       fCollClassName(orig.fCollClassName),
-      fCollProxy(orig.fCollProxy?orig.fCollProxy->Generate():0)
+      fCollProxy(orig.fCollProxy?orig.fCollProxy->Generate():nullptr)
 {
 }
 
@@ -1909,7 +1909,7 @@ Bool_t TFormLeafInfoCollectionSize::Update()
    Bool_t changed = kFALSE;
    TClass *new_class = TClass::GetClass(fCollClassName);
    if (new_class!=fCollClass) {
-      delete fCollProxy; fCollProxy = 0;
+      delete fCollProxy; fCollProxy = nullptr;
       fCollClass = new_class;
       if (fCollClass && fCollClass->GetCollectionProxy()) {
          fCollProxy = fCollClass->GetCollectionProxy()->Generate();
@@ -1925,7 +1925,7 @@ Bool_t TFormLeafInfoCollectionSize::Update()
 void *TFormLeafInfoCollectionSize::GetValuePointer(TLeaf * /* leaf */, Int_t  /* instance */)
 {
    Error("GetValuePointer","This should never be called");
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1934,7 +1934,7 @@ void *TFormLeafInfoCollectionSize::GetValuePointer(TLeaf * /* leaf */, Int_t  /*
 void *TFormLeafInfoCollectionSize::GetValuePointer(char  * /* from */, Int_t  /* instance */)
 {
    Error("GetValuePointer","This should never be called");
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1943,7 +1943,7 @@ void *TFormLeafInfoCollectionSize::GetValuePointer(char  * /* from */, Int_t  /*
 void *TFormLeafInfoCollectionSize::GetLocalValuePointer(TLeaf * /* leaf */, Int_t  /* instance */)
 {
    Error("GetLocalValuePointer","This should never be called");
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1952,7 +1952,7 @@ void *TFormLeafInfoCollectionSize::GetLocalValuePointer(TLeaf * /* leaf */, Int_
 void *TFormLeafInfoCollectionSize::GetLocalValuePointer( char * /* from */, Int_t  /* instance */)
 {
    Error("GetLocalValuePointer","This should never be called");
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1961,7 +1961,7 @@ void *TFormLeafInfoCollectionSize::GetLocalValuePointer( char * /* from */, Int_
 Double_t  TFormLeafInfoCollectionSize::ReadValue(char *where, Int_t /* instance */)
 {
    R__ASSERT(fCollProxy);
-   if (where==0) return 0;
+   if (where==nullptr) return 0;
    void *ptr = fElement ? TFormLeafInfo::GetLocalValuePointer(where) : where;
    TVirtualCollectionProxy::TPushPop helper(fCollProxy, ptr);
    return (Int_t)fCollProxy->Size();
@@ -2066,7 +2066,7 @@ T  TFormLeafInfoPointer::GetValueImpl(TLeaf *leaf, Int_t instance)
 {
    if (!fNext) return 0;
    char * where = (char*)GetLocalValuePointer(leaf,instance);
-   if (where==0) return 0;
+   if (where==nullptr) return 0;
    return fNext->ReadTypedValue<T>(where,instance);
 }
 
@@ -2083,8 +2083,8 @@ INSTANTIATE_READVAL(TFormLeafInfoPointer);
 
 TFormLeafInfoMethod::TFormLeafInfoMethod( TClass* classptr,
                                           TMethodCall *method) :
-   TFormLeafInfo(classptr,0,0),fMethod(method),
-   fResult(0), fCopyFormat(),fDeleteFormat(),fValuePointer(0),fIsByValue(kFALSE)
+   TFormLeafInfo(classptr,0,nullptr),fMethod(method),
+   fResult(0), fCopyFormat(),fDeleteFormat(),fValuePointer(nullptr),fIsByValue(kFALSE)
 {
    if (method) {
       fMethodName = method->GetMethodName();
@@ -2125,11 +2125,11 @@ TFormLeafInfoMethod::TFormLeafInfoMethod(const TFormLeafInfoMethod& orig)
       fMethod = new TMethodCall();
       fMethod->Init(orig.fMethod->GetMethod());
    } else {
-      fMethod = 0;
+      fMethod = nullptr;
    }
    fCopyFormat = orig.fCopyFormat;
    fDeleteFormat = orig.fDeleteFormat;
-   fValuePointer = 0;
+   fValuePointer = nullptr;
    fIsByValue = orig.fIsByValue;
 }
 
@@ -2220,7 +2220,7 @@ TClass* TFormLeafInfoMethod::GetClass() const
 {
    if (fNext) return fNext->GetClass();
    TMethodCall::EReturnType r = fMethod->ReturnType();
-   if (r!=TMethodCall::kOther) return 0;
+   if (r!=TMethodCall::kOther) return nullptr;
 
    return ReturnTClass(fMethod);
 }
@@ -2277,7 +2277,7 @@ void *TFormLeafInfoMethod::GetLocalValuePointer(char *from,
                                                 Int_t /*instance*/)
 {
    void *thisobj = from;
-   if (!thisobj) return 0;
+   if (!thisobj) return nullptr;
 
    TMethodCall::EReturnType r = fMethod->ReturnType();
    fResult = 0;
@@ -2299,17 +2299,17 @@ void *TFormLeafInfoMethod::GetLocalValuePointer(char *from,
       return &fResult;
 
    } else if (r == TMethodCall::kString) {
-      char *returntext = 0;
+      char *returntext = nullptr;
       fMethod->Execute(thisobj,&returntext);
       gInterpreter->ClearStack();
       return returntext;
 
    } else if (r == TMethodCall::kOther) {
-      char * char_result = 0;
+      char * char_result = nullptr;
       if (fIsByValue) {
          if (fValuePointer) {
             gROOT->ProcessLine(Form(fDeleteFormat.Data(),fValuePointer));
-            fValuePointer = 0;
+            fValuePointer = nullptr;
          }
       }
       fMethod->Execute(thisobj, &char_result);
@@ -2321,7 +2321,7 @@ void *TFormLeafInfoMethod::GetLocalValuePointer(char *from,
       return char_result;
 
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2347,12 +2347,12 @@ T TFormLeafInfoMethod::ReadValueImpl(char *where, Int_t instance)
       result = (T) d;
 
    } else if (r == TMethodCall::kString) {
-      char *returntext = 0;
+      char *returntext = nullptr;
       fMethod->Execute(thisobj,&returntext);
       result = T((Longptr_t) returntext);
 
    } else if (fNext) {
-      char * char_result = 0;
+      char * char_result = nullptr;
       fMethod->Execute(thisobj, &char_result);
       result = fNext->ReadTypedValue<T>(char_result,instance);
 
@@ -2379,7 +2379,7 @@ TFormLeafInfoMultiVarDim::TFormLeafInfoMultiVarDim( TClass* classptr,
                                                     Longptr_t offset,
                                                     TStreamerElement* element,
                                                     TFormLeafInfo* parent) :
-   TFormLeafInfo(classptr,offset,element),fNsize(0),fCounter2(0),fSumOfSizes(0),
+   TFormLeafInfo(classptr,offset,element),fNsize(0),fCounter2(nullptr),fSumOfSizes(0),
    fDim(0),fVirtDim(-1),fPrimaryIndex(-1),fSecondaryIndex(-1)
 {
    if (element && element->InheritsFrom(TStreamerBasicPointer::Class())) {
@@ -2390,7 +2390,7 @@ TFormLeafInfoMultiVarDim::TFormLeafInfoMultiVarDim( TClass* classptr,
       if (!parent) return;
       fCounter2 = parent->DeepCopy();
       TFormLeafInfo ** next = &(fCounter2->fNext);
-      while(*next != 0) next = &( (*next)->fNext);
+      while(*next != nullptr) next = &( (*next)->fNext);
       *next = new TFormLeafInfo(classptr,counterOffset,counter);
 
    } else Error("Constructor","Called without a proper TStreamerElement");
@@ -2400,7 +2400,7 @@ TFormLeafInfoMultiVarDim::TFormLeafInfoMultiVarDim( TClass* classptr,
 /// Constructor.
 
 TFormLeafInfoMultiVarDim::TFormLeafInfoMultiVarDim() :
-   TFormLeafInfo(0,0,0),fNsize(0),fCounter2(0),fSumOfSizes(0),
+   TFormLeafInfo(nullptr,0,nullptr),fNsize(0),fCounter2(nullptr),fSumOfSizes(0),
    fDim(0),fVirtDim(-1),fPrimaryIndex(-1),fSecondaryIndex(-1)
 {
 }
@@ -2412,7 +2412,7 @@ TFormLeafInfoMultiVarDim::TFormLeafInfoMultiVarDim(const TFormLeafInfoMultiVarDi
 {
    fNsize = orig.fNsize;
    orig.fSizes.Copy(fSizes);
-   fCounter2 = orig.fCounter2?orig.fCounter2->DeepCopy():0;
+   fCounter2 = orig.fCounter2?orig.fCounter2->DeepCopy():nullptr;
    fSumOfSizes = orig.fSumOfSizes;
    fDim = orig.fDim;
    fVirtDim = orig.fVirtDim;
@@ -2670,7 +2670,7 @@ TFormLeafInfoMultiVarDimCollection::TFormLeafInfoMultiVarDimCollection(
    fCounter = parent->DeepCopy();
    fCounter2 = parent->DeepCopy();
    TFormLeafInfo ** next = &(fCounter2->fNext);
-   while(*next != 0) next = &( (*next)->fNext);
+   while(*next != nullptr) next = &( (*next)->fNext);
    *next = new TFormLeafInfoCollectionSize(elementclassptr);
 }
 
@@ -2688,7 +2688,7 @@ TFormLeafInfoMultiVarDimCollection::TFormLeafInfoMultiVarDimCollection(
    fCounter = parent->DeepCopy();
    fCounter2 = parent->DeepCopy();
    TFormLeafInfo ** next = &(fCounter2->fNext);
-   while(*next != 0) next = &( (*next)->fNext);
+   while(*next != nullptr) next = &( (*next)->fNext);
    *next = new TFormLeafInfoCollectionSize(motherclassptr,offset,element);
 }
 
@@ -2780,7 +2780,7 @@ TFormLeafInfoMultiVarDimClones::TFormLeafInfoMultiVarDimClones(
    fCounter = parent->DeepCopy();
    fCounter2 = parent->DeepCopy();
    TFormLeafInfo ** next = &(fCounter2->fNext);
-   while(*next != 0) next = &( (*next)->fNext);
+   while(*next != nullptr) next = &( (*next)->fNext);
    *next = new TFormLeafInfoClones(elementclassptr);
 }
 
@@ -2798,7 +2798,7 @@ TFormLeafInfoMultiVarDimClones::TFormLeafInfoMultiVarDimClones(
    fCounter = parent->DeepCopy();
    fCounter2 = parent->DeepCopy();
    TFormLeafInfo ** next = &(fCounter2->fNext);
-   while(*next != 0) next = &( (*next)->fNext);
+   while(*next != nullptr) next = &( (*next)->fNext);
    *next = new TFormLeafInfoClones(motherclassptr,offset,element);
 }
 
@@ -2988,9 +2988,9 @@ Bool_t TFormLeafInfoCast::Update()
 /// Constructor.
 
 TFormLeafInfoTTree::TFormLeafInfoTTree(TTree *tree, const char *alias, TTree *current) :
-TFormLeafInfo( TTree::Class(), 0, 0 ), fTree(tree),fCurrent(current),fAlias(alias)
+TFormLeafInfo( TTree::Class(), 0, nullptr ), fTree(tree),fCurrent(current),fAlias(alias)
 {
-   if (fCurrent==0) fCurrent = fTree->GetFriend(alias);
+   if (fCurrent==nullptr) fCurrent = fTree->GetFriend(alias);
 }
 
 TFormLeafInfoTTree::TFormLeafInfoTTree(const TFormLeafInfoTTree& orig) :

--- a/tree/treeplayer/src/TFormLeafInfoReference.cxx
+++ b/tree/treeplayer/src/TFormLeafInfoReference.cxx
@@ -24,7 +24,7 @@ of reference objects stored in a TTree
 /// Constructor.
 
 TFormLeafInfoReference::TFormLeafInfoReference(TClass* cl, TStreamerElement* e, int off)
-: TFormLeafInfo(cl,off,e), fProxy(0), fBranch(0)
+: TFormLeafInfo(cl,off,e), fProxy(nullptr), fBranch(nullptr)
 {
    TVirtualRefProxy* p = cl->GetReferenceProxy();
    if ( !p )  {
@@ -38,7 +38,7 @@ TFormLeafInfoReference::TFormLeafInfoReference(TClass* cl, TStreamerElement* e, 
 /// Copy constructor.
 
 TFormLeafInfoReference::TFormLeafInfoReference(const TFormLeafInfoReference& org)
-: TFormLeafInfo(org), fProxy(0), fBranch(org.fBranch)
+: TFormLeafInfo(org), fProxy(nullptr), fBranch(org.fBranch)
 {
    TVirtualRefProxy* p = org.fProxy;
    if ( !p )  {
@@ -89,7 +89,7 @@ TFormLeafInfo* TFormLeafInfoReference::DeepCopy() const
 
 TClass* TFormLeafInfoReference::GetClass() const
 {
-   return fNext ? fNext->GetClass() : 0;
+   return fNext ? fNext->GetClass() : nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -99,7 +99,7 @@ Bool_t TFormLeafInfoReference::HasCounter() const
 {
    Bool_t result = fProxy ? fProxy->HasCounter() : false;
    if (fNext) result |= fNext->HasCounter();
-   return fCounter!=0 || result;
+   return fCounter!=nullptr || result;
 }
 ////////////////////////////////////////////////////////////////////////////////
 /// Return the size of the underlying array for the current entry in the TTree.
@@ -123,7 +123,7 @@ Int_t TFormLeafInfoReference::ReadCounterValue(char *where)
 
 Int_t TFormLeafInfoReference::GetCounterValue(TLeaf* leaf)  {
    if ( HasCounter() )  {
-      char *thisobj = 0;
+      char *thisobj = nullptr;
       Int_t instance = 0;
       if (leaf->InheritsFrom(TLeafObject::Class()) ) {
          thisobj = (char*)((TLeafObject*)leaf)->GetObject();
@@ -148,7 +148,7 @@ TClass* TFormLeafInfoReference::GetValueClass(TLeaf* leaf)
 
 TClass* TFormLeafInfoReference::GetValueClass(void* obj)
 {
-   return fProxy ? fProxy->GetValueClass(obj) : 0;
+   return fProxy ? fProxy->GetValueClass(obj) : nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -199,7 +199,7 @@ void *TFormLeafInfoReference::GetLocalValuePointer(char *where, Int_t instance)
       }
    }
    gInterpreter->ClearStack();
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/treeplayer/src/TFriendProxy.cxx
+++ b/tree/treeplayer/src/TFriendProxy.cxx
@@ -25,7 +25,7 @@ namespace Internal {
 
 /////////////////////////////////////////////////////////////////////////////
 
-TFriendProxy::TFriendProxy() : fDirector(0,-1), fIndex(-1)
+TFriendProxy::TFriendProxy() : fDirector(nullptr,-1), fIndex(-1)
 {
 }
 
@@ -33,7 +33,7 @@ TFriendProxy::TFriendProxy() : fDirector(0,-1), fIndex(-1)
    /// Constructor.
 
    TFriendProxy::TFriendProxy(TBranchProxyDirector *director, TTree *main, Int_t index) :
-      fDirector(0,-1), fIndex(index)
+      fDirector(nullptr,-1), fIndex(index)
    {
       // The list of friends needs to be accessed via GetTree()->GetListOfFriends()
       // (and not directly GetListOfFriends()), otherwise when `main` is a TChain we
@@ -74,9 +74,9 @@ TFriendProxy::TFriendProxy() : fDirector(0,-1), fIndex(-1)
          TObject *obj = newmain->GetTree()->GetListOfFriends()->At(fIndex);
          TFriendElement *element = dynamic_cast<TFriendElement*>( obj );
          if (element) fDirector.SetTree(element->GetTree());
-         else fDirector.SetTree(0);
+         else fDirector.SetTree(nullptr);
       } else {
-         fDirector.SetTree(0);
+         fDirector.SetTree(nullptr);
       }
    }
 

--- a/tree/treeplayer/src/TMPWorkerTree.cxx
+++ b/tree/treeplayer/src/TMPWorkerTree.cxx
@@ -45,7 +45,7 @@
 
 TMPWorkerTree::TMPWorkerTree()
    : TMPWorker(), fFileNames(), fTreeName(), fTree(nullptr), fFile(nullptr), fEntryList(nullptr), fFirstEntry(0),
-     fTreeCache(0), fTreeCacheIsLearning(kFALSE), fUseTreeCache(kTRUE), fCacheSize(-1)
+     fTreeCache(nullptr), fTreeCacheIsLearning(kFALSE), fUseTreeCache(kTRUE), fCacheSize(-1)
 {
    Setup();
 }
@@ -53,7 +53,7 @@ TMPWorkerTree::TMPWorkerTree()
 TMPWorkerTree::TMPWorkerTree(const std::vector<std::string> &fileNames, TEntryList *entries,
                              const std::string &treeName, UInt_t nWorkers, ULong64_t maxEntries, ULong64_t firstEntry)
    : TMPWorker(nWorkers, maxEntries), fFileNames(fileNames), fTreeName(treeName), fTree(nullptr), fFile(nullptr),
-     fEntryList(entries), fFirstEntry(firstEntry), fTreeCache(0), fTreeCacheIsLearning(kFALSE), fUseTreeCache(kTRUE),
+     fEntryList(entries), fFirstEntry(firstEntry), fTreeCache(nullptr), fTreeCacheIsLearning(kFALSE), fUseTreeCache(kTRUE),
      fCacheSize(-1)
 {
    Setup();
@@ -62,7 +62,7 @@ TMPWorkerTree::TMPWorkerTree(const std::vector<std::string> &fileNames, TEntryLi
 TMPWorkerTree::TMPWorkerTree(TTree *tree, TEntryList *entries, UInt_t nWorkers, ULong64_t maxEntries,
                              ULong64_t firstEntry)
    : TMPWorker(nWorkers, maxEntries), fTree(tree), fFile(nullptr), fEntryList(entries), fFirstEntry(firstEntry),
-     fTreeCache(0), fTreeCacheIsLearning(kFALSE), fUseTreeCache(kTRUE), fCacheSize(-1)
+     fTreeCache(nullptr), fTreeCacheIsLearning(kFALSE), fUseTreeCache(kTRUE), fCacheSize(-1)
 {
    Setup();
 }
@@ -89,9 +89,9 @@ void TMPWorkerTree::CloseFile()
 {
    // Avoid destroying the cache; must be placed before deleting the trees
    if (fFile) {
-      if (fTree) fFile->SetCacheRead(0, fTree);
+      if (fTree) fFile->SetCacheRead(nullptr, fTree);
       delete fFile ;
-      fFile = 0;
+      fFile = nullptr;
    }
 }
 
@@ -243,7 +243,7 @@ void TMPWorkerTreeSel::Process(UInt_t code, MPCodeBufPair &msg)
 
    Long64_t start = 0;
    Long64_t finish = 0;
-   TEntryList *enl = 0;
+   TEntryList *enl = nullptr;
    std::string errmsg;
    if (LoadTree(code, msg, start, finish, &enl, errmsg) != 0) {
       SendError(errmsg);
@@ -289,7 +289,7 @@ Int_t TMPWorkerTree::LoadTree(UInt_t code, MPCodeBufPair &msg, Long64_t &start, 
 
    std::string mgroot = "[S" + std::to_string(GetNWorker()) + "]: ";
 
-   TTree *tree = 0;
+   TTree *tree = nullptr;
    if (code ==  MPCode::kProcTree) {
 
       mgroot += "MPCode::kProcTree: ";

--- a/tree/treeplayer/src/TRefProxy.cxx
+++ b/tree/treeplayer/src/TRefProxy.cxx
@@ -39,7 +39,7 @@ Bool_t TRefProxy::Update()
 TClass* TRefProxy::GetValueClass(void* data) const
 {
    TObject* obj = (TObject*)data;
-   return ( obj ) ? obj->IsA() : 0;
+   return ( obj ) ? obj->IsA() : nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -63,21 +63,21 @@ void* TRefProxy::GetObject(TFormLeafInfoReference* info, void* data, int)
             table->SetUID(uid, ref->GetPID());
             ((TBranch*)table->GetOwner())->GetEntry(ent);
             TBranch *b = (TBranch*)table->GetParent(uid, ref->GetPID());
-            if ( 0 == b ) {
+            if ( nullptr == b ) {
                ((TBranch*)table->GetOwner())->GetEntry(ent);
                b = (TBranch*)table->GetParent(uid, ref->GetPID());
             }
-            if ( 0 != b )  {
+            if ( nullptr != b )  {
                TBranch* br = b->GetMother();
                if ( br ) br->GetEntry(ent);
             }
             obj = ref->GetObject();
             if ( obj )   {
-               (*ref) = 0;
+               (*ref) = nullptr;
                return obj;
             }
          }
       }
    }
-   return 0;
+   return nullptr;
 }

--- a/tree/treeplayer/src/TSelectorDraw.cxx
+++ b/tree/treeplayer/src/TSelectorDraw.cxx
@@ -46,8 +46,8 @@ const Int_t kCustomHistogram = BIT(17);
 
 TSelectorDraw::TSelectorDraw()
 {
-   fTree           = 0;
-   fW              = 0;
+   fTree           = nullptr;
+   fW              = nullptr;
    fValSize        = 4;
    fVal            = new Double_t*[fValSize];
    fVmin           = new Double_t[fValSize];
@@ -56,20 +56,20 @@ TSelectorDraw::TSelectorDraw()
    fVarMultiple    = new Bool_t[fValSize];
    fVar            = new TTreeFormula*[fValSize];
    for (Int_t i = 0; i < fValSize; ++i) {
-      fVal[i] = 0;
-      fVar[i] = 0;
+      fVal[i] = nullptr;
+      fVar[i] = nullptr;
    }
-   fManager        = 0;
+   fManager        = nullptr;
    fMultiplicity   = 0;
-   fSelect         = 0;
+   fSelect         = nullptr;
    fSelectedRows   = 0;
    fDraw           = 0;
-   fObject         = 0;
-   fOldHistogram   = 0;
+   fObject         = nullptr;
+   fOldHistogram   = nullptr;
    fObjEval        = kFALSE;
    fSelectMultiple = kFALSE;
    fCleanElist     = kFALSE;
-   fTreeElist      = 0;
+   fTreeElist      = nullptr;
    fAction         = 0;
    fNfill          = 0;
    fDimension      = 0;
@@ -77,7 +77,7 @@ TSelectorDraw::TSelectorDraw()
    fForceRead      = 0;
    fWeight         = 1;
    fCurrentSubEntry = -1;
-   fTreeElistArray  = 0;
+   fTreeElistArray  = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -124,9 +124,9 @@ void TSelectorDraw::Begin(TTree *tree)
    Int_t i, j, hkeep;
    opt = option;
    opt.ToLower();
-   fOldHistogram = 0;
-   TEntryList *enlist = 0;
-   TEventList *evlist = 0;
+   fOldHistogram = nullptr;
+   TEntryList *enlist = nullptr;
+   TEventList *evlist = nullptr;
    TString htitle;
    Bool_t profile = kFALSE;
    Bool_t optSame = kFALSE;
@@ -175,7 +175,7 @@ void TSelectorDraw::Begin(TTree *tree)
    fCleanElist = kFALSE;
    fTreeElist = inElist;
 
-   fTreeElistArray = inElist ? dynamic_cast<TEntryListArray*>(fTreeElist) : 0;
+   fTreeElistArray = inElist ? dynamic_cast<TEntryListArray*>(fTreeElist) : nullptr;
 
 
    if (inElist && inElist->GetReapplyCut()) {
@@ -198,7 +198,7 @@ void TSelectorDraw::Begin(TTree *tree)
    Int_t nbinsx = 0, nbinsy = 0, nbinsz = 0;
    Double_t xmin = 0, xmax = 0, ymin = 0, ymax = 0, zmin = 0, zmax = 0;
 
-   fObject  = 0;
+   fObject  = nullptr;
    char *hname = nullptr;
    TString hnamealloc;
    i = 0;
@@ -255,7 +255,7 @@ void TSelectorDraw::Begin(TTree *tree)
 
          pstart = strchr(hname, '(');
          pend =  strchr(hname, ')');
-         if (pstart != 0) {   // found the bracket
+         if (pstart != nullptr) {   // found the bracket
 
             mustdelete = 1;
 
@@ -266,7 +266,7 @@ void TSelectorDraw::Begin(TTree *tree)
                ncomma = 0;
                cdummy = pstart;
                cdummy = strchr(&cdummy[1], ',');
-               while (cdummy != 0) {
+               while (cdummy != nullptr) {
                   cdummy = strchr(&cdummy[1], ',');
                   ncomma++;
                }
@@ -371,7 +371,7 @@ void TSelectorDraw::Begin(TTree *tree)
          }
 
          TObject *oldObject = gDirectory->Get(hname);  // if hname contains '(...)' the return values is NULL, which is what we want
-         fOldHistogram = oldObject ? dynamic_cast<TH1*>(oldObject) : 0;
+         fOldHistogram = oldObject ? dynamic_cast<TH1*>(oldObject) : nullptr;
 
          if (!fOldHistogram && oldObject && !oldObject->InheritsFrom(TH1::Class())) {
             abrt.Form("An object of type '%s' has the same name as the requested histo (%s)", oldObject->IsA()->GetName(), hname);
@@ -385,7 +385,7 @@ void TSelectorDraw::Begin(TTree *tree)
             if (gDebug) {
                Warning("Begin", "Deleting old histogram, since (possibly new) limits and binnings have been given");
             }
-            delete fOldHistogram; fOldHistogram=0;
+            delete fOldHistogram; fOldHistogram=nullptr;
          }
 
       } else {
@@ -393,7 +393,7 @@ void TSelectorDraw::Begin(TTree *tree)
          TObject *oldObject = gDirectory->Get(hname);
          if (optEnlist) {
             //write into a TEntryList
-            enlist = oldObject ? dynamic_cast<TEntryList*>(oldObject) : 0;
+            enlist = oldObject ? dynamic_cast<TEntryList*>(oldObject) : nullptr;
 
             if (!enlist && oldObject) {
                abrt.Form("An object of type '%s' has the same name as the requested event list (%s)",
@@ -432,7 +432,7 @@ void TSelectorDraw::Begin(TTree *tree)
             }
          } else {
             //write into a TEventList
-            evlist = oldObject ? dynamic_cast<TEventList*>(oldObject) : 0;
+            evlist = oldObject ? dynamic_cast<TEventList*>(oldObject) : nullptr;
 
             if (!evlist && oldObject) {
                abrt.Form("An object of type '%s' has the same name as the requested event list (%s)",
@@ -472,7 +472,7 @@ void TSelectorDraw::Begin(TTree *tree)
       strlcpy(varexp, varexp0, varexpLen);
       if (gDirectory) {
          fOldHistogram = (TH1*)gDirectory->Get(hname);
-         if (fOldHistogram) { fOldHistogram->Delete(); fOldHistogram = 0;}
+         if (fOldHistogram) { fOldHistogram->Delete(); fOldHistogram = nullptr;}
       }
    }
 
@@ -523,7 +523,7 @@ void TSelectorDraw::Begin(TTree *tree)
       if (mustdelete) {
          Warning("Begin", "Deleting old histogram with different dimensions");
          delete fOldHistogram;
-         fOldHistogram = 0;
+         fOldHistogram = nullptr;
       }
    }
 
@@ -547,7 +547,7 @@ void TSelectorDraw::Begin(TTree *tree)
          if (gPad && optSame) {
             TListIter np(gPad->GetListOfPrimitives());
             TObject *op;
-            TH1 *oldhtemp = 0;
+            TH1 *oldhtemp = nullptr;
             while ((op = np()) && !oldhtemp) {
                if (op->InheritsFrom(TH1::Class())) oldhtemp = (TH1 *)op;
             }
@@ -588,7 +588,7 @@ void TSelectorDraw::Begin(TTree *tree)
          if (!hkeep) {
             hist->GetXaxis()->SetTitle(fVar[0]->GetTitle());
             hist->SetBit(kCanDelete);
-            if (!opt.Contains("goff")) hist->SetDirectory(0);
+            if (!opt.Contains("goff")) hist->SetDirectory(nullptr);
          }
          if (opt.Length() && opt.Contains("e")) hist->Sumw2();
       }
@@ -661,7 +661,7 @@ void TSelectorDraw::Begin(TTree *tree)
             }
             if (!hkeep) {
                hp->SetBit(kCanDelete);
-               if (!opt.Contains("goff")) hp->SetDirectory(0);
+               if (!opt.Contains("goff")) hp->SetDirectory(nullptr);
             }
             hp->SetLineColor(fTree->GetLineColor());
             hp->SetLineWidth(fTree->GetLineWidth());
@@ -701,7 +701,7 @@ void TSelectorDraw::Begin(TTree *tree)
                h2->GetYaxis()->SetTitle(fVar[0]->GetTitle());
                h2->SetBit(TH1::kNoStats);
                h2->SetBit(kCanDelete);
-               if (!opt.Contains("goff")) h2->SetDirectory(0);
+               if (!opt.Contains("goff")) h2->SetDirectory(nullptr);
             }
          }
          fVar[0]->SetAxis(h2->GetYaxis());
@@ -803,7 +803,7 @@ void TSelectorDraw::Begin(TTree *tree)
             }
             if (!hkeep) {
                hp->SetBit(kCanDelete);
-               if (!opt.Contains("goff")) hp->SetDirectory(0);
+               if (!opt.Contains("goff")) hp->SetDirectory(nullptr);
             }
             hp->SetLineColor(fTree->GetLineColor());
             hp->SetLineWidth(fTree->GetLineWidth());
@@ -839,7 +839,7 @@ void TSelectorDraw::Begin(TTree *tree)
                h2->GetZaxis()->SetTitle(fVar[2]->GetTitle());
                h2->SetBit(TH1::kNoStats);
                h2->SetBit(kCanDelete);
-               if (!opt.Contains("goff")) h2->SetDirectory(0);
+               if (!opt.Contains("goff")) h2->SetDirectory(nullptr);
             }
          }
          fVar[0]->SetAxis(h2->GetYaxis());
@@ -877,7 +877,7 @@ void TSelectorDraw::Begin(TTree *tree)
                h3->GetZaxis()->SetTitle(fVar[0]->GetTitle());
                h3->SetBit(kCanDelete);
                h3->SetBit(TH1::kNoStats);
-               if (!opt.Contains("goff")) h3->SetDirectory(0);
+               if (!opt.Contains("goff")) h3->SetDirectory(nullptr);
             }
          }
          fVar[0]->SetAxis(h3->GetZaxis());
@@ -943,10 +943,10 @@ void TSelectorDraw::ClearFormula()
    ResetBit(kWarn);
    for (Int_t i = 0; i < fValSize; ++i) {
       delete fVar[i];
-      fVar[i] = 0;
+      fVar[i] = nullptr;
    }
-   delete fSelect; fSelect = 0;
-   fManager = 0;
+   delete fSelect; fSelect = nullptr;
+   fManager = nullptr;
    fMultiplicity = 0;
 }
 
@@ -988,7 +988,7 @@ Bool_t TSelectorDraw::CompileVariables(const char *varexp, const char *selection
       fSelect->SetQuickLoad(kTRUE);
       if (!fSelect->GetNdim()) {
          delete fSelect;
-         fSelect = 0;
+         fSelect = nullptr;
          return kFALSE;
       }
    }
@@ -1069,7 +1069,7 @@ Bool_t TSelectorDraw::CompileVariables(const char *varexp, const char *selection
 Double_t* TSelectorDraw::GetVal(Int_t i) const
 {
    if (i < 0 || i >= fDimension)
-      return 0;
+      return nullptr;
    else
       return fVal[i];
 }
@@ -1081,7 +1081,7 @@ Double_t* TSelectorDraw::GetVal(Int_t i) const
 TTreeFormula* TSelectorDraw::GetVar(Int_t i) const
 {
    if (i < 0 || i >= fDimension)
-      return 0;
+      return nullptr;
    else
       return fVar[i];
 }
@@ -1112,8 +1112,8 @@ void TSelectorDraw::InitArrays(Int_t newsize)
       fVal = new Double_t*[fValSize];
       fVar = new TTreeFormula*[fValSize];
       for (Int_t i = 0; i < fValSize; ++i) {
-         fVal[i] = 0;
-         fVar[i] = 0;
+         fVal[i] = nullptr;
+         fVar[i] = nullptr;
       }
    }
 }
@@ -1215,7 +1215,7 @@ void TSelectorDraw::ProcessFillMultiple(Long64_t entry)
    if (!ndata) return;
 
    // If the entry list is a TEntryListArray, get the selected subentries for this entry
-   TEntryList *subList = 0;
+   TEntryList *subList = nullptr;
    if (fTreeElistArray) {
       subList = fTreeElistArray->GetSubListForEntry(entry, fTree->GetTree());
    }
@@ -1353,10 +1353,10 @@ void TSelectorDraw::SetEstimate(Long64_t)
    if (fVal) {
       for (Int_t i = 0; i < fValSize; ++i) {
          delete [] fVal[i];
-         fVal[i] = 0;
+         fVal[i] = nullptr;
       }
    }
-   delete [] fW;   fW  = 0;
+   delete [] fW;   fW  = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1379,7 +1379,7 @@ void TSelectorDraw::TakeAction()
       if (fObject->InheritsFrom(TEntryListArray::Class())) {
          TEntryListArray *enlistarray = (TEntryListArray*)fObject;
          Long64_t enumb = fTree->GetTree()->GetReadEntry();
-         enlistarray->Enter(enumb, 0, fCurrentSubEntry);
+         enlistarray->Enter(enumb, nullptr, fCurrentSubEntry);
       } else if (fObject->InheritsFrom(TEntryList::Class())) {
          TEntryList *enlist = (TEntryList*)fObject;
          Long64_t enumb = fTree->GetTree()->GetReadEntry();
@@ -1667,7 +1667,7 @@ void TSelectorDraw::TakeEstimate()
                   if (h2->TestBit(kCanDelete)) {
                      // h2 will be deleted, the axis setting is delegated to only
                      // the TGraph.
-                     h2 = 0;
+                     h2 = nullptr;
                      fObject = pm->GetHistogram();
                   }
                }

--- a/tree/treeplayer/src/TSelectorEntries.cxx
+++ b/tree/treeplayer/src/TSelectorEntries.cxx
@@ -44,7 +44,7 @@ To use this file, try the following session on your Tree T:
 /// Default, constructor.
 
 TSelectorEntries::TSelectorEntries(TTree *tree, const char *selection) :
-   fOwnInput(kFALSE), fChain(tree), fSelect(0), fSelectedRows(0), fSelectMultiple(kFALSE)
+   fOwnInput(kFALSE), fChain(tree), fSelect(nullptr), fSelectedRows(0), fSelectMultiple(kFALSE)
 {
    if (selection && selection[0]) {
       TSelectorEntries::SetSelection(selection);
@@ -55,7 +55,7 @@ TSelectorEntries::TSelectorEntries(TTree *tree, const char *selection) :
 /// Constructor.
 
 TSelectorEntries::TSelectorEntries(const char *selection) :
-   fOwnInput(kFALSE), fChain(0), fSelect(0), fSelectedRows(0), fSelectMultiple(kFALSE)
+   fOwnInput(kFALSE), fChain(nullptr), fSelect(nullptr), fSelectedRows(0), fSelectMultiple(kFALSE)
 {
    TSelectorEntries::SetSelection(selection);
 }
@@ -102,7 +102,7 @@ void TSelectorEntries::SlaveBegin(TTree *tree)
    if (strlen(selection)) {
       fSelect = new TTreeFormula("Selection",selection,fChain);
       fSelect->SetQuickLoad(kTRUE);
-      if (!fSelect->GetNdim()) {delete fSelect; fSelect = 0; return; }
+      if (!fSelect->GetNdim()) {delete fSelect; fSelect = nullptr; return; }
    }
    if (fSelect && fSelect->GetMultiplicity()) fSelectMultiple = kTRUE;
 

--- a/tree/treeplayer/src/TTreeDrawArgsParser.cxx
+++ b/tree/treeplayer/src/TTreeDrawArgsParser.cxx
@@ -68,7 +68,7 @@ void TTreeDrawArgsParser::ClearPrevious()
       fParameters[i] = 0;
    }
    fShouldDraw = kTRUE;
-   fOriginal = 0;
+   fOriginal = nullptr;
    fDrawProfile = kFALSE;
    fOptionSame = kFALSE;
    fEntryList = kFALSE;
@@ -253,7 +253,7 @@ Bool_t TTreeDrawArgsParser::Parse(const char *varexp, const char *selection, Opt
       fOriginal = gDirectory->Get(fName);
    }
    else
-      fOriginal = 0;
+      fOriginal = nullptr;
 
    DefineType();
 

--- a/tree/treeplayer/src/TTreeFormula.cxx
+++ b/tree/treeplayer/src/TTreeFormula.cxx
@@ -122,20 +122,20 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 TTreeFormula::TTreeFormula(): ROOT::v5::TFormula(), fQuickLoad(kFALSE), fNeedLoading(kTRUE),
-   fDidBooleanOptimization(kFALSE), fDimensionSetup(0)
+   fDidBooleanOptimization(kFALSE), fDimensionSetup(nullptr)
 
 {
    // Tree Formula default constructor
 
-   fTree         = 0;
-   fLookupType   = 0;
+   fTree         = nullptr;
+   fLookupType   = nullptr;
    fNindex       = 0;
    fNcodes       = 0;
-   fAxis         = 0;
+   fAxis         = nullptr;
    fHasCast      = 0;
-   fManager      = 0;
+   fManager      = nullptr;
    fMultiplicity = 0;
-   fConstLD      = 0;
+   fConstLD      = nullptr;
 
    Int_t j,k;
    for (j=0; j<kMAXCODES; j++) {
@@ -146,7 +146,7 @@ TTreeFormula::TTreeFormula(): ROOT::v5::TFormula(), fQuickLoad(kFALSE), fNeedLoa
       for (k = 0; k<kMAXFORMDIM; k++) {
          fIndexes[j][k] = -1;
          fCumulSizes[j][k] = 1;
-         fVarIndexes[j][k] = 0;
+         fVarIndexes[j][k] = nullptr;
       }
    }
 }
@@ -156,7 +156,7 @@ TTreeFormula::TTreeFormula(): ROOT::v5::TFormula(), fQuickLoad(kFALSE), fNeedLoa
 
 TTreeFormula::TTreeFormula(const char *name,const char *expression, TTree *tree)
    :ROOT::v5::TFormula(), fTree(tree), fQuickLoad(kFALSE), fNeedLoading(kTRUE),
-    fDidBooleanOptimization(kFALSE), fDimensionSetup(0)
+    fDidBooleanOptimization(kFALSE), fDimensionSetup(nullptr)
 {
    Init(name,expression);
 }
@@ -167,7 +167,7 @@ TTreeFormula::TTreeFormula(const char *name,const char *expression, TTree *tree)
 TTreeFormula::TTreeFormula(const char *name,const char *expression, TTree *tree,
                            const std::vector<std::string>& aliases)
    :ROOT::v5::TFormula(), fTree(tree), fQuickLoad(kFALSE), fNeedLoading(kTRUE),
-    fDidBooleanOptimization(kFALSE), fDimensionSetup(0), fAliasesUsed(aliases)
+    fDidBooleanOptimization(kFALSE), fDimensionSetup(nullptr), fAliasesUsed(aliases)
 {
    Init(name,expression);
 }
@@ -183,9 +183,9 @@ void TTreeFormula::Init(const char*name, const char* expression)
    fLookupType   = new Int_t[fNindex];
    fNcodes       = 0;
    fMultiplicity = 0;
-   fAxis         = 0;
+   fAxis         = nullptr;
    fHasCast      = 0;
-   fConstLD      = 0;
+   fConstLD      = nullptr;
    Int_t i,j,k;
    fManager      = new TTreeFormulaManager;
    fManager->Add(this);
@@ -199,14 +199,14 @@ void TTreeFormula::Init(const char*name, const char* expression)
       for (k = 0; k<kMAXFORMDIM; k++) {
          fIndexes[j][k] = -1;
          fCumulSizes[j][k] = 1;
-         fVarIndexes[j][k] = 0;
+         fVarIndexes[j][k] = nullptr;
       }
    }
 
    fDimensionSetup = new TList;
 
    if (Compile(expression)) {
-      fTree = 0; fNdim = 0;
+      fTree = nullptr; fNdim = 0;
       if(savedir) savedir->cd();
       return;
    }
@@ -273,7 +273,7 @@ void TTreeFormula::Init(const char*name, const char* expression)
             Error("TTreeFormula",
                   "Index %d for dimension #%d in %s is too high (max is %d)",
                   fIndexes[k0][k1],k1+1, expression,fFixedSizes[k0][k1]-1);
-            fTree = 0; fNdim = 0;
+            fTree = nullptr; fNdim = 0;
             if(savedir) savedir->cd();
             return;
          }
@@ -282,11 +282,11 @@ void TTreeFormula::Init(const char*name, const char* expression)
 
    // Create a list of uniques branches to load.
    for(k=0; k<fNcodes ; k++) {
-      TLeaf *leaf = k <= fLeaves.GetLast() ? (TLeaf*)fLeaves.UncheckedAt(k) : 0;
-      TBranch *branch = 0;
+      TLeaf *leaf = k <= fLeaves.GetLast() ? (TLeaf*)fLeaves.UncheckedAt(k) : nullptr;
+      TBranch *branch = nullptr;
       if (leaf) {
          branch = leaf->GetBranch();
-         if (fBranches.FindObject(branch)) branch = 0;
+         if (fBranches.FindObject(branch)) branch = nullptr;
       }
       fBranches.AddAtAndExpand(branch,k);
    }
@@ -327,7 +327,7 @@ TTreeFormula::~TTreeFormula()
       fManager->Remove(this);
       if (fManager->fFormulas.GetLast()<0) {
          delete fManager;
-         fManager = 0;
+         fManager = nullptr;
       }
    }
    // Objects in fExternalCuts are not owned and should not be deleted
@@ -340,7 +340,7 @@ TTreeFormula::~TTreeFormula()
    for (int j=0; j<fNcodes; j++) {
       for (int k = 0; k<fNdimensions[j]; k++) {
          if (fVarIndexes[j][k]) delete fVarIndexes[j][k];
-         fVarIndexes[j][k] = 0;
+         fVarIndexes[j][k] = nullptr;
       }
    }
    if (fDimensionSetup) {
@@ -454,7 +454,7 @@ Int_t TTreeFormula::RegisterDimensions(Int_t code, TFormLeafInfo *leafinfo,
    vardim = 0;
 
    const TStreamerElement * elem = leafinfo->fElement;
-   TClass* c = elem ? elem->GetClassPointer() : 0;
+   TClass* c = elem ? elem->GetClassPointer() : nullptr;
 
    TFormLeafInfoMultiVarDim * multi = dynamic_cast<TFormLeafInfoMultiVarDim * >(leafinfo);
    if (multi) {
@@ -774,7 +774,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
    const char *right = subExpression;
    TString name = fullExpression;
 
-   TBranch *branch = leaf ? leaf->GetBranch() : 0;
+   TBranch *branch = leaf ? leaf->GetBranch() : nullptr;
    Long64_t readentry = fTree->GetTree()->GetReadEntry();
    if (readentry < 0) readentry=0;
 
@@ -783,12 +783,12 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
 
    // Make a check to prevent problem with some corrupted files (missing TStreamerInfo).
    if (leaf && leaf->IsA()==TLeafElement::Class()) {
-      TBranchElement *br = 0;
+      TBranchElement *br = nullptr;
       if( branch->IsA() ==  TBranchElement::Class() )
       {
          br = ((TBranchElement*)branch);
 
-         if ( br->GetInfo() == 0 ) {
+         if ( br->GetInfo() == nullptr ) {
             Error("DefinedVariable","Missing StreamerInfo for %s.  We will be unable to read!",
                   name.Data());
             return -2;
@@ -800,7 +800,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
       {
          TBranchElement *mom = (TBranchElement*)br->GetMother();
          if (mom!=br) {
-            if (mom->GetInfo()==0) {
+            if (mom->GetInfo()==nullptr) {
                Error("DefinedVariable","Missing StreamerInfo for %s."
                      "  We will be unable to read!",
                      mom->GetName());
@@ -820,7 +820,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
 
    // Let's reconstruct the name of the leaf, including the possible friend alias
    TTree *realtree = fTree->GetTree();
-   const char* alias = 0;
+   const char* alias = nullptr;
    if (leaf) {
       if (realtree) alias = realtree->GetFriendAlias(leaf->GetBranch()->GetTree());
       if (!alias && realtree!=fTree) {
@@ -862,17 +862,17 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
    // Analyze the content of 'right'
 
    // Try to find out the class (if any) of the object in the leaf.
-   TClass * cl = 0;
-   TFormLeafInfo *maininfo = 0;
-   TFormLeafInfo *previnfo = 0;
+   TClass * cl = nullptr;
+   TFormLeafInfo *maininfo = nullptr;
+   TFormLeafInfo *previnfo = nullptr;
    Bool_t unwindCollection = kFALSE;
    const static TClassRef stdStringClass = TClass::GetClass("string");
 
-   if (leaf==0) {
+   if (leaf==nullptr) {
       TNamed *names = (TNamed*)fLeafNames.UncheckedAt(code);
-      fLeafNames.AddAt(0,code);
+      fLeafNames.AddAt(nullptr,code);
       TTree *what = (TTree*)fLeaves.UncheckedAt(code);
-      fLeaves.AddAt(0,code);
+      fLeaves.AddAt(nullptr,code);
 
       cl = what ? what->IsA() : TTree::Class();
       maininfo = new TFormLeafInfoTTree(fTree,names->GetName(),what);
@@ -886,7 +886,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
       TBranchElement *branchEl = (TBranchElement *)leaf->GetBranch();
       branchEl->SetupAddresses();
       TStreamerInfo *info = branchEl->GetInfo();
-      TStreamerElement *element = 0;
+      TStreamerElement *element = nullptr;
       Int_t type = branchEl->GetStreamerType();
       switch(type) {
          case TStreamerInfo::kBase:
@@ -1061,8 +1061,8 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
             maininfo = collectioninfo;
             previnfo = collectioninfo;
 
-            if (cl->GetCollectionProxy()->GetValueClass()!=0 &&
-                cl->GetCollectionProxy()->GetValueClass()->GetCollectionProxy()!=0) {
+            if (cl->GetCollectionProxy()->GetValueClass()!=nullptr &&
+                cl->GetCollectionProxy()->GetValueClass()->GetCollectionProxy()!=nullptr) {
 
                TFormLeafInfo *multi = new TFormLeafInfoMultiVarDimCollection(cl,0,
                      cl->GetCollectionProxy()->GetValueClass(),collectioninfo);
@@ -1075,7 +1075,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                previnfo = multi->fNext;
 
             }
-            if (cl->GetCollectionProxy()->GetValueClass()==0 &&
+            if (cl->GetCollectionProxy()->GetValueClass()==nullptr &&
                 cl->GetCollectionProxy()->GetType()>0) {
 
                previnfo->fNext =
@@ -1115,7 +1115,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
             multi->fNext =  new TFormLeafInfoCollection(cl, 0, cl, false);
             previnfo = multi->fNext;
 
-            if (cl->GetCollectionProxy()->GetValueClass()==0 &&
+            if (cl->GetCollectionProxy()->GetValueClass()==nullptr &&
                 cl->GetCollectionProxy()->GetType()>0) {
 
                previnfo->fNext =
@@ -1125,7 +1125,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
 
          } else if (!useLeafCollectionObject
                && elemCl && elemCl->GetCollectionProxy()
-               && elemCl->GetCollectionProxy()->GetValueClass()==0
+               && elemCl->GetCollectionProxy()->GetValueClass()==nullptr
                && elemCl->GetCollectionProxy()->GetType()>0) {
 
             // At this point we have an element which is inside a class (which is not
@@ -1211,7 +1211,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
             multi->fNext =  new TFormLeafInfoCollection(cl, 0, cl, false);
             previnfo = multi->fNext;
 
-            if (cl->GetCollectionProxy()->GetValueClass()==0 &&
+            if (cl->GetCollectionProxy()->GetValueClass()==nullptr &&
                 cl->GetCollectionProxy()->GetType()>0) {
 
                previnfo->fNext =
@@ -1237,8 +1237,8 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
          right = "Data()";
       }
       Int_t nchname = strlen(right);
-      TFormLeafInfo *leafinfo = 0;
-      TStreamerElement* element = 0;
+      TFormLeafInfo *leafinfo = nullptr;
+      TStreamerElement* element = nullptr;
 
       // Let see if the leaf was attempted to be casted.
       // Since there would have been something like
@@ -1257,19 +1257,19 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
             }
             leafinfo = new TFormLeafInfoCast(cl,casted);
             fHasCast = kTRUE;
-            if (maininfo==0) {
+            if (maininfo==nullptr) {
                maininfo = leafinfo;
             }
-            if (previnfo==0) {
+            if (previnfo==nullptr) {
                previnfo = leafinfo;
             } else {
                previnfo->fNext = leafinfo;
                previnfo = leafinfo;
             }
-            leafinfo = 0;
+            leafinfo = nullptr;
 
             cl = casted;
-            castqueue.AddAt(0,paran_level);
+            castqueue.AddAt(nullptr,paran_level);
          }
       }
       Int_t i;
@@ -1290,7 +1290,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
             if (params) {
                *params = 0; params++;
             } else params = (char *) ")";
-            if (cl==0) {
+            if (cl==nullptr) {
                Error("DefinedVariable","Can not call '%s' with a class",work);
                return -1;
             }
@@ -1337,7 +1337,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                // in its contents.
                // We need to retrieve the class of its content.
 
-               if (previnfo==0) {
+               if (previnfo==nullptr) {
 
                   Bool_t top = (branch==((TBranchElement*)branch)->GetMother()
                                  || !leaf->IsOnTerminalBranch());
@@ -1368,8 +1368,8 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                   return -2;
                }
             }
-            TMethodCall *method  = 0;
-            if (cl==0) {
+            TMethodCall *method  = nullptr;
+            if (cl==nullptr) {
                Error("DefinedVariable",
                      "Could not discover the TClass corresponding to (%s)!",
                      right);
@@ -1377,8 +1377,8 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
             } else if (cl==TClonesArray::Class() && strcmp(work,"size")==0) {
                method = new TMethodCall(cl, "GetEntriesFast", "");
             } else if (cl->GetCollectionProxy() && strcmp(work,"size")==0) {
-               if (maininfo==0) {
-                  TFormLeafInfo* collectioninfo=0;
+               if (maininfo==nullptr) {
+                  TFormLeafInfo* collectioninfo=nullptr;
                   if (useLeafCollectionObject) {
 
                      Bool_t top = (branch==((TBranchElement*)branch)->GetMother()
@@ -1388,7 +1388,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                   maininfo=previnfo=collectioninfo;
                }
                leafinfo = new TFormLeafInfoCollectionSize(cl);
-               cl = 0;
+               cl = nullptr;
             } else {
                if (!cl->HasDataMemberInfo()) {
                   Error("DefinedVariable",
@@ -1406,17 +1406,17 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                switch(method->ReturnType()) {
                   case TMethodCall::kLong:
                      leafinfo = new TFormLeafInfoMethod(cl,method);
-                     cl = 0;
+                     cl = nullptr;
                      break;
                   case TMethodCall::kDouble:
                      leafinfo = new TFormLeafInfoMethod(cl,method);
-                     cl = 0;
+                     cl = nullptr;
                      break;
                   case TMethodCall::kString:
                      leafinfo = new TFormLeafInfoMethod(cl,method);
                      // 1 will be replaced by -1 when we know how to use strlen
                      numberOfVarDim += RegisterDimensions(code,1); //NOTE: changed from 0
-                     cl = 0;
+                     cl = nullptr;
                      break;
                   case TMethodCall::kOther:
                      {
@@ -1430,16 +1430,16 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                      return -2;
                }
             }
-            if (maininfo==0) {
+            if (maininfo==nullptr) {
                maininfo = leafinfo;
             }
-            if (previnfo==0) {
+            if (previnfo==nullptr) {
                previnfo = leafinfo;
             } else {
                previnfo->fNext = leafinfo;
                previnfo = leafinfo;
             }
-            leafinfo = 0;
+            leafinfo = nullptr;
             current = &(work[0]);
             *current = 0;
             prevUseCollectionObject = kFALSE;
@@ -1450,7 +1450,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                if (numberOfVarDim>1) {
                   Warning("DefinedVariable","TTreeFormula support only 2 level of variables size collections.  Assuming '@' notation for the collection %s.",
                      cl->GetName());
-                  leafinfo = new TFormLeafInfo(cl,0,0);
+                  leafinfo = new TFormLeafInfo(cl,0,nullptr);
                   useCollectionObject = kTRUE;
                } else if (numberOfVarDim==0) {
                   R__ASSERT(maininfo);
@@ -1460,7 +1460,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                   R__ASSERT(maininfo);
                   leafinfo =
                      new TFormLeafInfoMultiVarDimCollection(cl,0,
-                     (TStreamerElement*)0,maininfo);
+                     (TStreamerElement*)nullptr,maininfo);
                   previnfo->fNext = leafinfo;
                   previnfo = leafinfo;
                   leafinfo = new TFormLeafInfoCollection(cl,0,cl);
@@ -1470,27 +1470,27 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                }
                previnfo->fNext = leafinfo;
                previnfo = leafinfo;
-               leafinfo = 0;
+               leafinfo = nullptr;
             }
             continue;
          } else if (right[i] == ')') {
             // We should have the end of a cast operator.  Let's introduce a TFormLeafCast
             // in the chain.
-            TClass * casted = (TClass*) ((int(--paran_level)>=0) ? castqueue.At(paran_level) : 0);
+            TClass * casted = (TClass*) ((int(--paran_level)>=0) ? castqueue.At(paran_level) : nullptr);
             if (casted) {
                leafinfo = new TFormLeafInfoCast(cl,casted);
                fHasCast = kTRUE;
 
-               if (maininfo==0) {
+               if (maininfo==nullptr) {
                   maininfo = leafinfo;
                }
-               if (previnfo==0) {
+               if (previnfo==nullptr) {
                   previnfo = leafinfo;
                } else {
                   previnfo->fNext = leafinfo;
                   previnfo = leafinfo;
                }
-               leafinfo = 0;
+               leafinfo = nullptr;
                current = &(work[0]);
                *current = 0;
 
@@ -1538,7 +1538,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                   previnfo = previnfo->fNext;
                }
                TVirtualRefProxy *refproxy = cl->GetReferenceProxy();
-               cl = 0;
+               cl = nullptr;
                for(Long64_t entry=0; entry<leaf->GetBranch()->GetEntries()-readentry; ++entry)  {
                   R__LoadBranch(leaf->GetBranch(), readentry+i, fQuickLoad);
                   void *refobj = maininfo->GetValuePointer(leaf,0);
@@ -1591,7 +1591,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                      clones = (TClonesArray*)clonesinfo->GetLocalValuePointer(leaf,0);
                }
                // NOTE clones can be zero!
-               if (clones==0) {
+               if (clones==nullptr) {
                   Warning("DefinedVariable",
                           "TClonesArray object was not retrievable for %s!",
                           name.Data());
@@ -1619,7 +1619,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                TBranch *clbranch = leaf->GetBranch();
                R__LoadBranch(clbranch,readentry,fQuickLoad);
 
-               if (maininfo==0) {
+               if (maininfo==nullptr) {
 
                   // we have a unsplit Collection leaf
                   // or we did not yet match any of the sub-branches!
@@ -1683,7 +1683,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                      if (previnfo) {
                         previnfo->fNext = clonesinfo;
                         clones = (TClonesArray*)maininfo->GetValuePointer(leaf,0);
-                        previnfo->fNext = 0;
+                        previnfo->fNext = nullptr;
                      } else {
                         clones = (TClonesArray*)clonesinfo->GetLocalValuePointer(leaf,0);
                      }
@@ -1695,13 +1695,13 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                      if (element) {
                         leafinfo = new TFormLeafInfoClones(cl,clones_offset,curelem);
                         numberOfVarDim += RegisterDimensions(code,leafinfo,maininfo,kFALSE);
-                        if (maininfo==0) maininfo = leafinfo;
-                        if (previnfo==0) previnfo = leafinfo;
+                        if (maininfo==nullptr) maininfo = leafinfo;
+                        if (previnfo==nullptr) previnfo = leafinfo;
                         else {
                            previnfo->fNext = leafinfo;
                            previnfo = leafinfo;
                         }
-                        leafinfo = 0;
+                        leafinfo = nullptr;
                         cl = sub_cl;
                         break;
                      }
@@ -1733,8 +1733,8 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                            leafinfo = new TFormLeafInfoCollection(cl,coll_offset,curelem);
                            numberOfVarDim += RegisterDimensions(code,leafinfo,maininfo,kFALSE);
                         }
-                        if (maininfo==0) maininfo = leafinfo;
-                        if (previnfo==0) previnfo = leafinfo;
+                        if (maininfo==nullptr) maininfo = leafinfo;
+                        if (previnfo==nullptr) previnfo = leafinfo;
                         else {
                            previnfo->fNext = leafinfo;
                            previnfo = leafinfo;
@@ -1742,7 +1742,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                         if (leafinfo->fNext) {
                            previnfo = leafinfo->fNext;
                         }
-                        leafinfo = 0;
+                        leafinfo = nullptr;
                         cl = sub_cl;
                         break;
                      }
@@ -1856,7 +1856,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                            //   previnfo = leafinfo;
                            //}
                            leafinfo->fNext =  new TFormLeafInfoCollection(cl, offset, element);
-                           if (element->GetClassPointer()->GetCollectionProxy()->GetValueClass()==0) {
+                           if (element->GetClassPointer()->GetCollectionProxy()->GetValueClass()==nullptr) {
                               TFormLeafInfo *info = new TFormLeafInfoNumerical(
                                  element->GetClassPointer()->GetCollectionProxy());
                               if (leafinfo->fNext) leafinfo->fNext->fNext = info;
@@ -1869,10 +1869,10 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                            TClass *valueCl = elemCl->GetCollectionProxy()->GetValueClass();
                            if (!maininfo) maininfo = leafinfo;
 
-                           if (valueCl!=0 && valueCl->GetCollectionProxy()!=0) {
+                           if (valueCl!=nullptr && valueCl->GetCollectionProxy()!=nullptr) {
 
                               numberOfVarDim += RegisterDimensions(code,leafinfo,maininfo,kFALSE);
-                              if (previnfo==0) previnfo = leafinfo;
+                              if (previnfo==nullptr) previnfo = leafinfo;
                               else {
                                  previnfo->fNext = leafinfo;
                                  previnfo = leafinfo;
@@ -1887,7 +1887,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                               elemCl = valueCl;
                            }
                            if (elemCl->GetCollectionProxy() &&
-                               elemCl->GetCollectionProxy()->GetValueClass()==0) {
+                               elemCl->GetCollectionProxy()->GetValueClass()==nullptr) {
                               TFormLeafInfo *info = new TFormLeafInfoNumerical(elemCl->GetCollectionProxy());
                               if (leafinfo->fNext) leafinfo->fNext->fNext = info;
                               else leafinfo->fNext = info;
@@ -1927,10 +1927,10 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
             }
 
             numberOfVarDim += RegisterDimensions(code,leafinfo,maininfo,useCollectionObject); // Note or useCollectionObject||prevUseColectionObject
-            if (maininfo==0) {
+            if (maininfo==nullptr) {
                maininfo = leafinfo;
             }
-            if (previnfo==0) {
+            if (previnfo==nullptr) {
                previnfo = leafinfo;
             } else if (previnfo!=leafinfo) {
                previnfo->fNext = leafinfo;
@@ -1942,7 +1942,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                if ( !needClass && mustderef )   {
                   maininfo->SetBranch(leaf->GetBranch());
                   char *ptr = (char*)maininfo->GetValuePointer(leaf,0);
-                  TFormLeafInfoReference* refInfo = 0;
+                  TFormLeafInfoReference* refInfo = nullptr;
                   if ( !maininfo->IsReference() )  {
                      for( TFormLeafInfo* inf = maininfo->fNext; inf; inf = inf->fNext )  {
                         if ( inf->IsReference() )  {
@@ -1970,7 +1970,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                   cl = element->GetClassPointer();
                }
             }
-            if (mustderef) leafinfo = 0;
+            if (mustderef) leafinfo = nullptr;
             current = &(work[0]);
             *current = 0;
             R__ASSERT(right[i] != '[');  // We are supposed to have removed all dimensions already!
@@ -2000,7 +2000,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
 
    TClass *objClass = EvalClass(code);
    if (objClass && !useLeafCollectionObject && objClass->GetCollectionProxy() && objClass->GetCollectionProxy()->GetValueClass()) {
-      TFormLeafInfo *last = 0;
+      TFormLeafInfo *last = nullptr;
       if ( SwitchToFormLeafInfo(code) ) {
 
          last = (TFormLeafInfo*)fDataMembers.At(code);
@@ -2028,7 +2028,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
    }
    if (IsLeafString(code) || objClass == TString::Class() || objClass == stdStringClass) {
 
-      TFormLeafInfo *last = 0;
+      TFormLeafInfo *last = nullptr;
       if ( SwitchToFormLeafInfo(code) ) {
 
          last = (TFormLeafInfo*)fDataMembers.At(code);
@@ -2037,7 +2037,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
          while (last->fNext) { last = last->fNext; }
 
       }
-      const char *funcname = 0;
+      const char *funcname = nullptr;
       if (objClass == TString::Class()) {
          funcname = "Data";
          //tobetested: numberOfVarDim += RegisterDimensions(code,1,0); // Register the dim of the implied char*
@@ -2063,7 +2063,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
       if (method->IsValid()
           && (method->ReturnType() == TMethodCall::kLong || method->ReturnType() == TMethodCall::kDouble)) {
 
-         TFormLeafInfo *last = 0;
+         TFormLeafInfo *last = nullptr;
          if (SwitchToFormLeafInfo(code)) {
             last = (TFormLeafInfo*)fDataMembers.At(code);
             // Improbable case
@@ -2088,7 +2088,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
       if (method->IsValid()
           && method->ReturnType() == TMethodCall::kString) {
 
-         TFormLeafInfo *last = 0;
+         TFormLeafInfo *last = nullptr;
          if (SwitchToFormLeafInfo(code)) {
             last = (TFormLeafInfo*)fDataMembers.At(code);
             // Improbable case
@@ -2115,7 +2115,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
          TClass *rcl = TFormLeafInfoMethod::ReturnTClass(method);
          if ((rcl == TString::Class() || rcl == stdStringClass) ) {
 
-            TFormLeafInfo *last = 0;
+            TFormLeafInfo *last = nullptr;
             if (SwitchToFormLeafInfo(code)) {
                last = (TFormLeafInfo*)fDataMembers.At(code);
                // Improbable case
@@ -2137,7 +2137,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
 
             objClass = rcl;
 
-            const char *funcname = 0;
+            const char *funcname = nullptr;
             if (objClass == TString::Class()) {
                funcname = "Data";
             } else if (objClass == stdStringClass) {
@@ -2175,9 +2175,9 @@ Int_t TTreeFormula::FindLeafForExpression(const char* expression, TLeaf*& leaf, 
 {
    // Later on we will need to read one entry, let's make sure
    // it is a real entry.
-   if (fTree->GetTree()==0) {
+   if (fTree->GetTree()==nullptr) {
       fTree->LoadTree(0);
-      if (fTree->GetTree()==0) return -1;
+      if (fTree->GetTree()==nullptr) return -1;
    }
    Long64_t readentry = fTree->GetTree()->GetReadEntry();
    if (readentry < 0) readentry=0;
@@ -2192,8 +2192,8 @@ Int_t TTreeFormula::FindLeafForExpression(const char* expression, TLeaf*& leaf, 
    std::string currentname;
    Int_t previousdot = 0;
    char *current;
-   TLeaf *tmp_leaf=0;
-   TBranch *branch=0, *tmp_branch=0;
+   TLeaf *tmp_leaf=nullptr;
+   TBranch *branch=nullptr, *tmp_branch=nullptr;
    Int_t nchname = strlen(cname);
    Int_t i;
    Bool_t foundAtSign = kFALSE;
@@ -2261,7 +2261,7 @@ Int_t TTreeFormula::FindLeafForExpression(const char* expression, TLeaf*& leaf, 
             if (branch && !leaf) {
                // We have a branch but not a leaf.  We are likely to have found
                // the top of split branch.
-               if (BranchHasMethod(0, branch, work, params, readentry)) {
+               if (BranchHasMethod(nullptr, branch, work, params, readentry)) {
                   //fprintf(stderr, "Does have a method %s for %s.\n", work, branch->GetName());
                }
             }
@@ -2269,7 +2269,7 @@ Int_t TTreeFormula::FindLeafForExpression(const char* expression, TLeaf*& leaf, 
             // What we have so far might be a member function of one of the
             // leaves that are not split (for example "GetNtrack" for the Event class).
             TIter next(fTree->GetIteratorOnAllLeaves());
-            TLeaf* leafcur = 0;
+            TLeaf* leafcur = nullptr;
             while (!leaf && (leafcur = (TLeaf*) next())) {
                TBranch* br = leafcur->GetBranch();
                Bool_t yes = BranchHasMethod(leafcur, br, work, params, readentry);
@@ -2402,14 +2402,14 @@ Int_t TTreeFormula::FindLeafForExpression(const char* expression, TLeaf*& leaf, 
             if (cname[i]) first[strlen(first)-1]='\0';
             if (!branch) branch = fTree->FindBranch(first);
             if (!leaf) leaf = fTree->FindLeaf(first);
-            TClass* cl = 0;
+            TClass* cl = nullptr;
             if ( branch && branch->InheritsFrom(TBranchElement::Class()) ) {
                int offset=0;
                TBranchElement* bElt = (TBranchElement*)branch;
                TStreamerInfo* info  = bElt->GetInfo();
-               TStreamerElement* element = info ? info->GetStreamerElement(first,offset) : 0;
+               TStreamerElement* element = info ? info->GetStreamerElement(first,offset) : nullptr;
                if (element) cl = element->GetClassPointer();
-               if ( cl && !cl->GetReferenceProxy() ) cl = 0;
+               if ( cl && !cl->GetReferenceProxy() ) cl = nullptr;
             }
             if ( cl )  {  // We have a reference class here....
                final = kTRUE;
@@ -2423,7 +2423,7 @@ Int_t TTreeFormula::FindLeafForExpression(const char* expression, TLeaf*& leaf, 
                // we do NOT look at the 'IsOnTerminalBranch' status of the leaf
                // we found ... yet!
 
-               if (leaf==0) {
+               if (leaf==nullptr) {
                   // Note we do not know (yet?) what (if anything) to do
                   // for a TBranchObject branch.
                   if (branch->InheritsFrom(TBranchElement::Class()) ) {
@@ -2610,7 +2610,7 @@ Int_t TTreeFormula::FindLeafForExpression(const char* expression, TLeaf*& leaf, 
       if (strlen(right)==0) strlcpy(right,work,2*kMaxLen);
    }
 
-   if (leaf==0 && left[0]!=0) {
+   if (leaf==nullptr && left[0]!=0) {
       if (left[strlen(left)-1]=='.') left[strlen(left)-1]=0;
 
       // Check for an alias.
@@ -2829,7 +2829,7 @@ Int_t TTreeFormula::DefinedVariable(TString &name, Int_t &action)
 
    Bool_t useLeafCollectionObject = kFALSE;
    TString leftover;
-   TLeaf *leaf = 0;
+   TLeaf *leaf = nullptr;
    {
       std::vector<std::string> aliasSofar = fAliasesUsed;
       res = FindLeafForExpression(cname, leaf, leftover, final, paran_level, castqueue, aliasSofar, useLeafCollectionObject, name);
@@ -3059,18 +3059,18 @@ Int_t TTreeFormula::DefinedVariable(TString &name, Int_t &action)
 
 TLeaf* TTreeFormula::GetLeafWithDatamember(const char* topchoice, const char* nextchoice, Long64_t readentry) const
 {
-   TClass * cl = 0;
+   TClass * cl = nullptr;
    TIter nextleaf (fTree->GetIteratorOnAllLeaves());
-   TFormLeafInfo* clonesinfo = 0;
+   TFormLeafInfo* clonesinfo = nullptr;
    TLeaf *leafcur;
    while ((leafcur = (TLeaf*)nextleaf())) {
       // The following code is used somewhere else, we need to factor it out.
 
       // Here since we are interested in data member, we want to consider only
       // 'terminal' branch and leaf.
-      cl = 0;
+      cl = nullptr;
       if (leafcur->InheritsFrom(TLeafObject::Class()) &&
-          leafcur->GetBranch()->GetListOfBranches()->Last()==0) {
+          leafcur->GetBranch()->GetListOfBranches()->Last()==nullptr) {
          TLeafObject *lobj = (TLeafObject*)leafcur;
          cl = lobj->GetClass();
       } else if (leafcur->InheritsFrom(TLeafElement::Class()) && leafcur->IsOnTerminalBranch()) {
@@ -3079,19 +3079,19 @@ TLeaf* TTreeFormula::GetLeafWithDatamember(const char* topchoice, const char* ne
             TBranchElement *branchEl = (TBranchElement *)leafcur->GetBranch();
             Int_t type = branchEl->GetStreamerType();
             if (type==-1) {
-               cl = branchEl->GetInfo() ? branchEl->GetInfo()->GetClass() : 0;
+               cl = branchEl->GetInfo() ? branchEl->GetInfo()->GetClass() : nullptr;
             } else if (type>60 || type==0) {
                // Case of an object data member.  Here we allow for the
                // variable name to be omitted.  Eg, for Event.root with split
                // level 1 or above  Draw("GetXaxis") is the same as Draw("fH.GetXaxis()")
                TStreamerElement* element = branchEl->GetInfo()->GetElement(branchEl->GetID());
                if (element) cl = element->GetClassPointer();
-               else cl = 0;
+               else cl = nullptr;
             }
          }
 
       }
-      if (clonesinfo) { delete clonesinfo; clonesinfo = 0; }
+      if (clonesinfo) { delete clonesinfo; clonesinfo = nullptr; }
       if (cl ==  TClonesArray::Class()) {
          // We have a unsplit TClonesArray leaves
          // In this case we assume that cl is the class in which the TClonesArray
@@ -3143,7 +3143,7 @@ TLeaf* TTreeFormula::GetLeafWithDatamember(const char* topchoice, const char* ne
          // or if the nextchoice is a datamember of one of its datamember.
          Int_t offset;
          TStreamerInfo* info =  (TStreamerInfo*)cl->GetStreamerInfo();
-         TStreamerElement* element = info?info->GetStreamerElement(topchoice,offset):0;
+         TStreamerElement* element = info?info->GetStreamerElement(topchoice,offset):nullptr;
          if (!element) {
             TIter nextel( cl->GetStreamerInfo()->GetElements() );
             TStreamerElement * curelem;
@@ -3155,7 +3155,7 @@ TLeaf* TTreeFormula::GetLeafWithDatamember(const char* topchoice, const char* ne
                   // We need to do that because we are never interested in the TClonesArray
                   // itself but only in the object inside.
                   TBranch *branch = leafcur->GetBranch();
-                  TFormLeafInfo *leafinfo = 0;
+                  TFormLeafInfo *leafinfo = nullptr;
                   if (clonesinfo) {
                      leafinfo = clonesinfo;
                   } else if (branch->IsA()==TBranchElement::Class()
@@ -3181,7 +3181,7 @@ TLeaf* TTreeFormula::GetLeafWithDatamember(const char* topchoice, const char* ne
 
                   TClonesArray * clones = (TClonesArray*)leafinfo->GetValuePointer(leafcur,0);
 
-                  delete leafinfo; clonesinfo = 0;
+                  delete leafinfo; clonesinfo = nullptr;
                   // If TClonesArray object does not exist we have no information, so let go
                   // on.  This is a weakish test since the TClonesArray object might exist in
                   // the next entry ... In other word, we ONLY rely on the information available
@@ -3208,14 +3208,14 @@ TLeaf* TTreeFormula::GetLeafWithDatamember(const char* topchoice, const char* ne
             } // loop on elements
          }
          if (element) break;
-         else cl = 0;
+         else cl = nullptr;
       }
    }
    delete clonesinfo;
    if (cl) {
       return leafcur;
    } else {
-      return 0;
+      return nullptr;
    }
 }
 
@@ -3225,8 +3225,8 @@ TLeaf* TTreeFormula::GetLeafWithDatamember(const char* topchoice, const char* ne
 
 Bool_t TTreeFormula::BranchHasMethod(TLeaf* leafcur, TBranch* branch, const char* method, const char* params, Long64_t readentry) const
 {
-   TClass *cl = 0;
-   TLeafObject* lobj = 0;
+   TClass *cl = nullptr;
+   TLeafObject* lobj = nullptr;
 
    // Since the user does not want this branch to be loaded anyway, we just
    // skip it.  This prevents us from warning the user that the method might
@@ -3246,7 +3246,7 @@ Bool_t TTreeFormula::BranchHasMethod(TLeaf* leafcur, TBranch* branch, const char
       TBranchElement* branchEl = (TBranchElement*) branch;
       Int_t type = branchEl->GetStreamerType();
       if (type == -1) {
-         cl = branchEl->GetInfo() ? branchEl->GetInfo()->GetClass() : 0;
+         cl = branchEl->GetInfo() ? branchEl->GetInfo()->GetClass() : nullptr;
       } else if (type > 60) {
          // Case of an object data member.  Here we allow for the
          // variable name to be omitted.  Eg, for Event.root with split
@@ -3255,13 +3255,13 @@ Bool_t TTreeFormula::BranchHasMethod(TLeaf* leafcur, TBranch* branch, const char
          if (element) {
             cl = element->GetClassPointer();
          } else {
-            cl = 0;
+            cl = nullptr;
          }
          if ((cl == TClonesArray::Class()) && (branchEl->GetType() == 31)) {
             // we have a TClonesArray inside a split TClonesArray,
             // Let's not dig any further.  If the user really wants a data member
             // inside the nested TClonesArray, it has to specify it explicitly.
-            cl = 0;
+            cl = nullptr;
          }
          // NOTE do we need code for Collection here?
       }
@@ -3272,7 +3272,7 @@ Bool_t TTreeFormula::BranchHasMethod(TLeaf* leafcur, TBranch* branch, const char
       // TClonesArray.
       // Since the leaf was not terminal, we might have a split or
       // unsplit and/or top leaf/branch.
-      TClonesArray* clones = 0;
+      TClonesArray* clones = nullptr;
       R__LoadBranch(branch, readentry, fQuickLoad);
       if (branch->InheritsFrom(TBranchObject::Class())) {
          clones = (TClonesArray*) lobj->GetObject();
@@ -3309,7 +3309,7 @@ Bool_t TTreeFormula::BranchHasMethod(TLeaf* leafcur, TBranch* branch, const char
          Error("BranchHasMethod","A TClonesArray was stored in a branch type no yet support (i.e. neither TBranchObject nor TBranchElement): %s",branch->IsA()->GetName());
          return kFALSE;
       }
-      cl = clones ? clones->GetClass() : 0;
+      cl = clones ? clones->GetClass() : nullptr;
    } else if (cl && cl->GetCollectionProxy()) {
       cl = cl->GetCollectionProxy()->GetValueClass();
    }
@@ -3352,7 +3352,7 @@ Int_t TTreeFormula::GetRealInstance(Int_t instance, Int_t codeindex) {
          check = kTRUE;
       }
 
-      TFormLeafInfo * info = 0;
+      TFormLeafInfo * info = nullptr;
       Int_t max_dim = fNdimensions[codeindex];
       if ( max_dim ) {
          virt_dim = 0;
@@ -3579,7 +3579,7 @@ Int_t TTreeFormula::GetRealInstance(Int_t instance, Int_t codeindex) {
 
 TClass* TTreeFormula::EvalClass() const
 {
-   if (fNoper != 1 || fNcodes <=0 ) return 0;
+   if (fNoper != 1 || fNcodes <=0 ) return nullptr;
 
    return EvalClass(0);
 }
@@ -3602,31 +3602,31 @@ TClass* TTreeFormula::EvalClass(Int_t oper) const
             TStreamerInfo * info = branch->GetInfo();
             Int_t id = branch->GetID();
             if (id>=0) {
-               if (info==0 || !info->IsCompiled()) {
+               if (info==nullptr || !info->IsCompiled()) {
                   // we probably do not have a way to know the class of the object.
-                  return 0;
+                  return nullptr;
                }
                TStreamerElement* elem = (TStreamerElement*)info->GetElement(id);
-               if (elem==0) {
+               if (elem==nullptr) {
                   // we probably do not have a way to know the class of the object.
-                  return 0;
+                  return nullptr;
                } else {
                   return elem->GetClass();
                }
             } else return TClass::GetClass( branch->GetClassName() );
          } else {
-            return 0;
+            return nullptr;
          }
       }
-      case kMethod: return 0; // kMethod is deprecated so let's no waste time implementing this.
+      case kMethod: return nullptr; // kMethod is deprecated so let's no waste time implementing this.
       case kTreeMember:
       case kDataMember: {
          TObject *obj = fDataMembers.UncheckedAt(oper);
-         if (!obj) return 0;
+         if (!obj) return nullptr;
          return ((TFormLeafInfo*)obj)->GetClass();
       }
 
-      default: return 0;
+      default: return nullptr;
    }
 
 
@@ -3641,7 +3641,7 @@ TClass* TTreeFormula::EvalClass(Int_t oper) const
 
 void* TTreeFormula::EvalObject(int instance)
 {
-   if (fNoper != 1 || fNcodes <=0 ) return 0;
+   if (fNoper != 1 || fNcodes <=0 ) return nullptr;
 
 
    switch (fLookupType[0]) {
@@ -3653,7 +3653,7 @@ void* TTreeFormula::EvalObject(int instance)
       case kLengthFunc:
       case kIteration:
       case kEntryList:
-         return 0;
+         return nullptr;
    }
 
    TLeaf *leaf = (TLeaf*)fLeaves.UncheckedAt(0);
@@ -3666,9 +3666,9 @@ void* TTreeFormula::EvalObject(int instance)
                     leaf->GetBranch()->GetTree()->GetReadEntry(),
                     fQuickLoad);
    }
-   else if (real_instance>=fNdata[0]) return 0;
+   else if (real_instance>=fNdata[0]) return nullptr;
    if (fAxis) {
-      return 0;
+      return nullptr;
    }
    switch(fLookupType[0]) {
       case kDirect: {
@@ -3680,7 +3680,7 @@ void* TTreeFormula::EvalObject(int instance)
       case kMethod: return GetValuePointerFromMethod(0,leaf);
       case kTreeMember:
       case kDataMember: return ((TFormLeafInfo*)fDataMembers.UncheckedAt(0))->GetValuePointer(leaf,real_instance);
-      default: return 0;
+      default: return nullptr;
    }
 
 
@@ -3705,7 +3705,7 @@ const char* TTreeFormula::EvalStringInstance(Int_t instance)
          TBranch *branch = leaf->GetBranch();
          R__LoadBranch(branch,branch->GetTree()->GetReadEntry(),fQuickLoad);
       } else if (real_instance>=fNdata[0]) {
-         return 0;
+         return nullptr;
       }
 
       if (fLookupType[0]==kDirect) {
@@ -3963,7 +3963,7 @@ T TTreeFormula::EvalInstance(Int_t instance, const char *stringStackArg[])
          }
          case kTreeMember: {
             TREE_EVAL_INIT;
-            return ((TFormLeafInfo*)fDataMembers.UncheckedAt(0))->GetTypedValue<T>((TLeaf*)0x0,real_instance);
+            return ((TFormLeafInfo*)fDataMembers.UncheckedAt(0))->GetTypedValue<T>((TLeaf*)nullptr,real_instance);
          }
          case kIndexOfEntry: return (T)fTree->GetReadEntry();
          case kIndexOfLocalEntry: return (T)fTree->GetTree()->GetReadEntry();
@@ -4242,7 +4242,7 @@ T TTreeFormula::EvalInstance(Int_t instance, const char *stringStackArg[])
                case kDataMember: { TT_EVAL_INIT_LOOP; tab[pos++] = ((TFormLeafInfo*)fDataMembers.UncheckedAt(code))->
                                           GetTypedValue<T>(leaf,real_instance); continue; }
                case kTreeMember: { TREE_EVAL_INIT_LOOP; tab[pos++] = ((TFormLeafInfo*)fDataMembers.UncheckedAt(code))->
-                                          GetTypedValue<T>((TLeaf*)0x0,real_instance); continue; }
+                                          GetTypedValue<T>((TLeaf*)nullptr,real_instance); continue; }
                case kEntryList: { TEntryList *elist = (TEntryList*)fExternalCuts.At(code);
                   tab[pos++] = elist->Contains(fTree->GetReadEntry());
                   continue;}
@@ -4463,7 +4463,7 @@ Double_t TTreeFormula::GetValueFromMethod(Int_t i, TLeaf* leaf) const
       return 0.0;
    }
 
-   void* thisobj = 0;
+   void* thisobj = nullptr;
    if (leaf->InheritsFrom(TLeafObject::Class())) {
       thisobj = ((TLeafObject*) leaf)->GetObject();
    } else {
@@ -4521,7 +4521,7 @@ void* TTreeFormula::GetValuePointerFromMethod(Int_t i, TLeaf* leaf) const
    TMethodCall* m = GetMethodCall(i);
 
    if (!m) {
-      return 0;
+      return nullptr;
    }
 
    void* thisobj;
@@ -4559,24 +4559,24 @@ void* TTreeFormula::GetValuePointerFromMethod(Int_t i, TLeaf* leaf) const
    if (r == TMethodCall::kLong) {
       Longptr_t l = 0;
       m->Execute(thisobj, l);
-      return 0;
+      return nullptr;
    }
 
    if (r == TMethodCall::kDouble) {
       Double_t d = 0.0;
       m->Execute(thisobj, d);
-      return 0;
+      return nullptr;
    }
 
    if (r == TMethodCall::kOther) {
-      char* c = 0;
+      char* c = nullptr;
       m->Execute(thisobj, &c);
       return c;
    }
 
    m->Execute(thisobj);
 
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -4742,7 +4742,7 @@ Bool_t  TTreeFormula::IsLeafString(Int_t code) const
             TBranchElement * br = (TBranchElement*)leaf->GetBranch();
             Int_t bid = br->GetID();
             if (bid < 0) return kFALSE;
-            if (br->GetInfo()==0 || !br->GetInfo()->IsCompiled()) {
+            if (br->GetInfo()==nullptr || !br->GetInfo()->IsCompiled()) {
                // Case where the file is corrupted is some ways.
                // We can not get to the actual type of the data
                // let's assume it is NOT a string.
@@ -4816,13 +4816,13 @@ char *TTreeFormula::PrintValue(Int_t mode, Int_t instance, const char *decform) 
    } else if (mode == 0) {
       if ( (fNstring && fNval==0 && fNoper==1) || IsString() )
       {
-         const char * val = 0;
+         const char * val = nullptr;
          if (GetAction(0)==kStringConst) {
             val = fExpr[0].Data();
          } else if (instance<fNdata[0]) {
             if (fNoper == 1) {
                if (fLookupType[0]==kTreeMember) {
-                  val = (char*)GetLeafInfo(0)->GetValuePointer((TLeaf*)0x0,instance);
+                  val = (char*)GetLeafInfo(0)->GetValuePointer((TLeaf*)nullptr,instance);
                } else {
                   TLeaf *leaf = (TLeaf*)fLeaves.UncheckedAt(0);
                   TBranch *branch = leaf->GetBranch();
@@ -4851,7 +4851,7 @@ char *TTreeFormula::PrintValue(Int_t mode, Int_t instance, const char *decform) 
          if (real_instance<fNdata[0]) {
             Ssiz_t len = strlen(decform);
             Char_t outputSizeLevel = 1;
-            char *expo = 0;
+            char *expo = nullptr;
             if (len>2) {
                switch (decform[len-2]) {
                   case 'l':
@@ -4983,7 +4983,7 @@ void TTreeFormula::ResetLoading()
 
 void TTreeFormula::SetAxis(TAxis *axis)
 {
-   if (!axis) {fAxis = 0; return;}
+   if (!axis) {fAxis = nullptr; return;}
    if (IsString()) {
       fAxis = axis;
       if (fNoper==1 && GetAction(0)==kAliasString){
@@ -5088,7 +5088,7 @@ void TTreeFormula::UpdateFormulaLeaves()
          // we reset the entry of all branches in the TTree.
          ((TBranch*)fBranches[i])->ResetReadEntry();
       }
-      if (leaf==0) SetBit( kMissingLeaf );
+      if (leaf==nullptr) SetBit( kMissingLeaf );
    }
    for (Int_t j=0; j<kMAXCODES; j++) {
       for (Int_t k = 0; k<kMAXFORMDIM; k++) {
@@ -5262,7 +5262,7 @@ void TTreeFormula::ResetDimensions() {
          continue;
       }
 
-      TLeaf *leaf = i <= fLeaves.GetLast() ? (TLeaf*)fLeaves.UncheckedAt(i) : 0;
+      TLeaf *leaf = i <= fLeaves.GetLast() ? (TLeaf*)fLeaves.UncheckedAt(i) : nullptr;
       if (!leaf) continue;
 
       // Reminder of the meaning of fMultiplicity:
@@ -5290,7 +5290,7 @@ void TTreeFormula::ResetDimensions() {
          // If the leaf belongs to a friend tree which has an index, we might
          // be in the case where some entry do not exist.
 
-         TTree *realtree = fTree ? fTree->GetTree() : 0;
+         TTree *realtree = fTree ? fTree->GetTree() : nullptr;
          TTree *tleaf = leaf->GetBranch()->GetTree();
          if (tleaf && tleaf != realtree && tleaf->GetTreeIndex()) {
             // Reset the multiplicity if we have a friend tree with an index.
@@ -5336,7 +5336,7 @@ void TTreeFormula::LoadBranches()
    Int_t i;
    for (i=0; i<fNoper ; ++i) {
       TLeaf *leaf = (TLeaf*)fLeaves.UncheckedAt(i);
-      if (leaf==0) continue;
+      if (leaf==nullptr) continue;
 
       TBranch *br = leaf->GetBranch();
       Long64_t treeEntry = br->GetTree()->GetReadEntry();
@@ -5401,7 +5401,7 @@ Bool_t TTreeFormula::LoadCurrentDim() {
       if (leaf->GetLeafCount()) {
          TLeaf* leafcount = leaf->GetLeafCount();
          TBranch *branchcount = leafcount->GetBranch();
-         TFormLeafInfo * info = 0;
+         TFormLeafInfo * info = nullptr;
          if (leaf->IsA() == TLeafElement::Class()) {
             //if branchcount address not yet set, GetEntry will set the address
             // read branchcount value
@@ -5423,7 +5423,7 @@ Bool_t TTreeFormula::LoadCurrentDim() {
             // member to be signed integral type.
 
             TBranchElement* branch = (TBranchElement*) leaf->GetBranch();
-            if (branch->GetAddress() == 0) {
+            if (branch->GetAddress() == nullptr) {
                // Humm there is no space reserve to write the data,
                // the data member is likely 'removed' from the class
                // layout, so rather than crashing by accessing
@@ -5571,7 +5571,7 @@ Bool_t TTreeFormula::LoadCurrentDim() {
       }
       // However we allow several dimensions that virtually vary via the size of their
       // index variables.  So we have code to recalculate fCumulUsedSizes.
-      TFormLeafInfo * info = 0;
+      TFormLeafInfo * info = nullptr;
       if (fLookupType[i]!=kDirect) {
          info = (TFormLeafInfo *)fDataMembers.At(i);
       }
@@ -5678,7 +5678,7 @@ void TTreeFormula::Convert(UInt_t oldversion)
 
 Bool_t TTreeFormula::SwitchToFormLeafInfo(Int_t code)
 {
-   TFormLeafInfo *last = 0;
+   TFormLeafInfo *last = nullptr;
    TLeaf *leaf = (TLeaf*)fLeaves.At(code);
    if (!leaf) return kFALSE;
 

--- a/tree/treeplayer/src/TTreeFormulaManager.cxx
+++ b/tree/treeplayer/src/TTreeFormulaManager.cxx
@@ -35,12 +35,12 @@ TTreeFormulaManager::TTreeFormulaManager() : TObject()
    fNdata = 1;
 
    for (Int_t i = 0; i < kMAXFORMDIM + 1; i++) {
-      fVarDims[i] = 0;
+      fVarDims[i] = nullptr;
       fCumulUsedSizes[i] = 1;
       fUsedSizes[i] = 1;
       fVirtUsedSizes[i] = 1;
    }
-   fCumulUsedVarDims = 0;
+   fCumulUsedVarDims = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -50,7 +50,7 @@ TTreeFormulaManager::~TTreeFormulaManager()
 {
    for (int l = 0; l < kMAXFORMDIM; l++) {
       if (fVarDims[l]) delete fVarDims[l];
-      fVarDims[l] = 0;
+      fVarDims[l] = nullptr;
    }
    if (fCumulUsedVarDims) delete fCumulUsedVarDims;
 }
@@ -146,7 +146,7 @@ Int_t TTreeFormulaManager::GetNdata(Bool_t forceLoadDim)
       }
    }
 
-   TTreeFormula *current = 0;
+   TTreeFormula *current = nullptr;
 
    Int_t size = fFormulas.GetLast() + 1;
 
@@ -220,7 +220,7 @@ Bool_t TTreeFormulaManager::Sync()
 {
    if (!fNeedSync) return true;
 
-   TTreeFormula *current = 0;
+   TTreeFormula *current = nullptr;
    Bool_t hasCast = kFALSE;
 
    fMultiplicity = 0;

--- a/tree/treeplayer/src/TTreeGeneratorBase.cxx
+++ b/tree/treeplayer/src/TTreeGeneratorBase.cxx
@@ -42,7 +42,7 @@ namespace Internal {
 
    void TTreeGeneratorBase::AddHeader(TClass *cl)
    {
-      if (cl==0) return;
+      if (cl==nullptr) return;
 
       // Check if already included
       TObject *obj = fListOfHeaders.FindObject(cl->GetName());
@@ -175,7 +175,7 @@ namespace Internal {
          // TClass *clm = TClass::GetClass(GetClassName());
          Int_t lOffset = 0; // offset in the local streamerInfo.
          if (clparent) {
-            const char *ename = 0;
+            const char *ename = nullptr;
             if (element) {
                ename = element->GetName();
                lOffset = clparent->GetStreamerInfo()->GetOffset(ename);
@@ -210,7 +210,7 @@ namespace Internal {
          TVirtualStreamerInfo *info = base->GetBaseStreamerInfo();
          if (info) return info;
       }
-      return 0;
+      return nullptr;
    }
 
    ////////////////////////////////////////////////////////////////////////////////
@@ -220,8 +220,8 @@ namespace Internal {
 
    TVirtualStreamerInfo *TTreeGeneratorBase::GetStreamerInfo(TBranch *branch, TIter current, TClass *cl)
    {
-      TVirtualStreamerInfo *objInfo = 0;
-      TBranchElement *b = 0;
+      TVirtualStreamerInfo *objInfo = nullptr;
+      TBranchElement *b = nullptr;
       TString cname = cl->GetName();
 
       while( ( b = (TBranchElement*)current() ) ) {
@@ -230,7 +230,7 @@ namespace Internal {
             break;
          }
       }
-      if (objInfo == 0 && branch->GetTree()->GetDirectory()->GetFile()) {
+      if (objInfo == nullptr && branch->GetTree()->GetDirectory()->GetFile()) {
          const TList *infolist = branch->GetTree()->GetDirectory()->GetFile()->GetStreamerInfoCache();
          if (infolist) {
             TVirtualStreamerInfo *i = (TVirtualStreamerInfo *)infolist->FindObject(cname);
@@ -240,7 +240,7 @@ namespace Internal {
             }
          }
       }
-      if (objInfo == 0) {
+      if (objInfo == nullptr) {
          // We still haven't found it ... this is likely to be an STL collection .. anyway, use the current StreamerInfo.
          objInfo = cl->GetStreamerInfo();
       }

--- a/tree/treeplayer/src/TTreeIndex.cxx
+++ b/tree/treeplayer/src/TTreeIndex.cxx
@@ -48,15 +48,15 @@ struct IndexSortComparator {
 
 TTreeIndex::TTreeIndex(): TVirtualIndex()
 {
-   fTree               = 0;
+   fTree               = nullptr;
    fN                  = 0;
-   fIndexValues        = 0;
-   fIndexValuesMinor   = 0;
-   fIndex              = 0;
-   fMajorFormula       = 0;
-   fMinorFormula       = 0;
-   fMajorFormulaParent = 0;
-   fMinorFormulaParent = 0;
+   fIndexValues        = nullptr;
+   fIndexValuesMinor   = nullptr;
+   fIndex              = nullptr;
+   fMajorFormula       = nullptr;
+   fMinorFormula       = nullptr;
+   fMajorFormulaParent = nullptr;
+   fMinorFormulaParent = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -128,13 +128,13 @@ TTreeIndex::TTreeIndex(const TTree *T, const char *majorname, const char *minorn
 {
    fTree               = (TTree*)T;
    fN                  = 0;
-   fIndexValues        = 0;
-   fIndexValuesMinor   = 0;
-   fIndex              = 0;
-   fMajorFormula       = 0;
-   fMinorFormula       = 0;
-   fMajorFormulaParent = 0;
-   fMinorFormulaParent = 0;
+   fIndexValues        = nullptr;
+   fIndexValuesMinor   = nullptr;
+   fIndex              = nullptr;
+   fMajorFormula       = nullptr;
+   fMinorFormula       = nullptr;
+   fMajorFormulaParent = nullptr;
+   fMinorFormulaParent = nullptr;
    fMajorName          = majorname;
    fMinorName          = minorname;
    if (!T) return;
@@ -220,14 +220,14 @@ TTreeIndex::TTreeIndex(const TTree *T, const char *majorname, const char *minorn
 
 TTreeIndex::~TTreeIndex()
 {
-   if (fTree && fTree->GetTreeIndex() == this) fTree->SetTreeIndex(0);
-   delete [] fIndexValues;      fIndexValues = 0;
-   delete [] fIndexValuesMinor;      fIndexValuesMinor = 0;
-   delete [] fIndex;            fIndex = 0;
-   delete fMajorFormula;        fMajorFormula  = 0;
-   delete fMinorFormula;        fMinorFormula  = 0;
-   delete fMajorFormulaParent;  fMajorFormulaParent = 0;
-   delete fMinorFormulaParent;  fMinorFormulaParent = 0;
+   if (fTree && fTree->GetTreeIndex() == this) fTree->SetTreeIndex(nullptr);
+   delete [] fIndexValues;      fIndexValues = nullptr;
+   delete [] fIndexValuesMinor;      fIndexValuesMinor = nullptr;
+   delete [] fIndex;            fIndex = nullptr;
+   delete fMajorFormula;        fMajorFormula  = nullptr;
+   delete fMinorFormula;        fMinorFormula  = nullptr;
+   delete fMajorFormulaParent;  fMajorFormulaParent = nullptr;
+   delete fMinorFormulaParent;  fMinorFormulaParent = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -242,7 +242,7 @@ void TTreeIndex::Append(const TVirtualIndex *add, Bool_t delaySort )
       // Create new buffer (if needed)
 
       const TTreeIndex *ti_add = dynamic_cast<const TTreeIndex*>(add);
-      if (ti_add == 0) {
+      if (ti_add == nullptr) {
          Error("Append","Can only Append a TTreeIndex to a TTreeIndex but got a %s",
                add->IsA()->GetName());
       }

--- a/tree/treeplayer/src/TTreePerfStats.cxx
+++ b/tree/treeplayer/src/TTreePerfStats.cxx
@@ -108,13 +108,13 @@ TTreePerfStats::TTreePerfStats() : TVirtualPerfStats()
 {
    fName      = "";
    fHostInfo  = "";
-   fTree      = 0;
+   fTree      = nullptr;
    fNleaves   = 0;
-   fFile      = 0;
-   fGraphIO   = 0;
-   fGraphTime = 0;
-   fWatch     = 0;
-   fPave      = 0;
+   fFile      = nullptr;
+   fGraphIO   = nullptr;
+   fGraphTime = nullptr;
+   fWatch     = nullptr;
+   fPave      = nullptr;
    fTreeCacheSize = 0;
    fReadCalls     = 0;
    fReadaheadSize = 0;
@@ -128,8 +128,8 @@ TTreePerfStats::TTreePerfStats() : TVirtualPerfStats()
    fUnzipInputSize= 0;
    fUnzipObjSize  = 0;
    fCompress      = 0;
-   fRealTimeAxis  = 0;
-   fHostInfoText  = 0;
+   fRealTimeAxis  = nullptr;
+   fHostInfoText  = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -152,7 +152,7 @@ TTreePerfStats::TTreePerfStats(const char *name, TTree *T) : TVirtualPerfStats()
    fGraphTime->SetTitle("Real time vs entries");
    fWatch  = new TStopwatch();
    fWatch->Start();
-   fPave  = 0;
+   fPave  = nullptr;
    fTreeCacheSize = 0;
    fReadCalls     = 0;
    fReadaheadSize = 0;
@@ -165,7 +165,7 @@ TTreePerfStats::TTreePerfStats(const char *name, TTree *T) : TVirtualPerfStats()
    fUnzipTime     = 0;
    fUnzipInputSize= 0;
    fUnzipObjSize  = 0;
-   fRealTimeAxis  = 0;
+   fRealTimeAxis  = nullptr;
    fCompress      = (T->GetTotBytes()+0.00001)/T->GetZipBytes();
 
    Bool_t isUNIX = strcmp(gSystem->GetName(), "Unix") == 0;
@@ -177,7 +177,7 @@ TTreePerfStats::TTreePerfStats(const char *name, TTree *T) : TVirtualPerfStats()
    fHostInfo += TString::Format("ROOT %s, Git: %s", gROOT->GetVersion(), gROOT->GetGitCommit());
    TDatime dt;
    fHostInfo += TString::Format(" %s",dt.AsString());
-   fHostInfoText   = 0;
+   fHostInfoText   = nullptr;
 
    gPerfStats = this;
 }
@@ -187,8 +187,8 @@ TTreePerfStats::TTreePerfStats(const char *name, TTree *T) : TVirtualPerfStats()
 
 TTreePerfStats::~TTreePerfStats()
 {
-   fTree = 0;
-   fFile = 0;
+   fTree = nullptr;
+   fFile = nullptr;
    delete fGraphIO;
    delete fGraphTime;
    delete fPave;
@@ -197,7 +197,7 @@ TTreePerfStats::~TTreePerfStats()
    delete fHostInfoText;
 
    if (gPerfStats == this) {
-      gPerfStats = 0;
+      gPerfStats = nullptr;
    }
 }
 

--- a/tree/treeplayer/src/TTreePlayer.cxx
+++ b/tree/treeplayer/src/TTreePlayer.cxx
@@ -98,18 +98,18 @@ ClassImp(TTreePlayer);
 
 TTreePlayer::TTreePlayer()
 {
-   fTree           = 0;
-   fScanFileName   = 0;
+   fTree           = nullptr;
+   fScanFileName   = nullptr;
    fScanRedirect   = kFALSE;
    fSelectedRows   = 0;
    fDimension      = 0;
-   fHistogram      = 0;
+   fHistogram      = nullptr;
    fFormulaList    = new TList();
    fFormulaList->SetOwner(kTRUE);
    fSelector         = new TSelectorDraw();
-   fSelectorFromFile = 0;
-   fSelectorClass    = 0;
-   fSelectorUpdate   = 0;
+   fSelectorFromFile = nullptr;
+   fSelectorClass    = nullptr;
+   fSelectorUpdate   = nullptr;
    fInput            = new TList();
    fInput->Add(new TNamed("varexp",""));
    fInput->Add(new TNamed("selection",""));
@@ -190,7 +190,7 @@ TTree *TTreePlayer::CopyTree(const char *selection, Option_t *, Long64_t nentrie
 
    // we make a copy of the tree header
    TTree *tree = fTree->CloneTree(0);
-   if (tree == 0) return 0;
+   if (tree == nullptr) return nullptr;
 
    // The clone should not delete any shared i/o buffers.
    TObjArray* branches = tree->GetListOfBranches();
@@ -206,7 +206,7 @@ TTree *TTreePlayer::CopyTree(const char *selection, Option_t *, Long64_t nentrie
    nentries = GetEntriesToProcess(firstentry, nentries);
 
    // Compile selection expression if there is one
-   TTreeFormula *select = 0; // no need to interfere with fSelect since we
+   TTreeFormula *select = nullptr; // no need to interfere with fSelect since we
                              // handle the loop explicitly below and can call
                              // UpdateFormulaLeaves ourselves.
    if (strlen(selection)) {
@@ -214,7 +214,7 @@ TTree *TTreePlayer::CopyTree(const char *selection, Option_t *, Long64_t nentrie
       if (!select || !select->GetNdim()) {
          delete select;
          delete tree;
-         return 0;
+         return nullptr;
       }
       fFormulaList->Add(select);
    }
@@ -256,8 +256,8 @@ void TTreePlayer::DeleteSelectorFromFile()
          delete fSelectorFromFile;
       }
    }
-   fSelectorFromFile = 0;
-   fSelectorClass = 0;
+   fSelectorFromFile = nullptr;
+   fSelectorClass = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -321,7 +321,7 @@ Long64_t TTreePlayer::DrawScript(const char* wrapperPrefix,
 
    Info("DrawScript","%s",Form("Will process tree/chain using %s",selname.Data()));
    Long64_t result = fTree->Process(selname,option,nentries,firstentry);
-   fTree->SetNotify(0);
+   fTree->SetNotify(nullptr);
 
    // could delete the file selname+".h"
    // However this would remove the optimization of avoiding a useless
@@ -592,7 +592,7 @@ Long64_t TTreePlayer::GetEntries(const char *selection)
 {
    TSelectorEntries s(selection);
    fTree->Process(&s);
-   fTree->SetNotify(0);
+   fTree->SetNotify(nullptr);
    return s.GetSelectedRows();
 }
 
@@ -801,7 +801,7 @@ Int_t TTreePlayer::MakeClass(const char *classname, const char *option)
             } else if (strncmp(declfile,"/usr/include/",13) == 0) {
                fprintf(fp,"#include <%s>\n",declfile+strlen("/include/c++/"));
                listOfHeaders.Add(new TNamed(cl->GetName(),declfile+strlen("/include/c++/")));
-            } else if (strstr(declfile,"/include/c++/") != 0) {
+            } else if (strstr(declfile,"/include/c++/") != nullptr) {
                fprintf(fp,"#include <%s>\n",declfile+strlen("/include/c++/"));
                listOfHeaders.Add(new TNamed(cl->GetName(),declfile+strlen("/include/c++/")));
             } else if (strncmp(declfile,rootinclude,rootinclude_len) == 0) {
@@ -888,7 +888,7 @@ Int_t TTreePlayer::MakeClass(const char *classname, const char *option)
    fprintf(fp,"\n   // Declaration of leaf types\n");
    TLeaf *leafcount;
    TLeafObject *leafobj;
-   TBranchElement *bre=0;
+   TBranchElement *bre=nullptr;
    const char *headOK  = "   ";
    const char *headcom = " //";
    const char *head;
@@ -1916,7 +1916,7 @@ Int_t TTreePlayer::MakeProxy(const char *proxyClassname,
                              const char *macrofilename, const char *cutfilename,
                              const char *option, Int_t maxUnrolling)
 {
-   if (macrofilename==0 || strlen(macrofilename)==0 ) {
+   if (macrofilename==nullptr || strlen(macrofilename)==0 ) {
       // We currently require a file name for the script
       Error("MakeProxy","A file name for the user script is required");
       return 0;
@@ -2008,7 +2008,7 @@ TPrincipal *TTreePlayer::Principal(const char *varexp, const char *selection, Op
    std::vector<TString> cnames;
    TString opt = option;
    opt.ToLower();
-   TPrincipal *principal = 0;
+   TPrincipal *principal = nullptr;
    Long64_t entry,entryNumber;
    Int_t i,nch;
    Int_t ncols = 8;   // by default first 8 columns are printed only
@@ -2020,7 +2020,7 @@ TPrincipal *TTreePlayer::Principal(const char *varexp, const char *selection, Op
    nentries = GetEntriesToProcess(firstentry, nentries);
 
 //*-*- Compile selection expression if there is one
-   TTreeFormula *select = 0;
+   TTreeFormula *select = nullptr;
    if (strlen(selection)) {
       select = new TTreeFormula("Selection",selection,fTree);
       if (!select) return principal;
@@ -2048,7 +2048,7 @@ TPrincipal *TTreePlayer::Principal(const char *varexp, const char *selection, Op
    }
 
 //*-*- Create a TreeFormulaManager to coordinate the formulas
-   TTreeFormulaManager *manager=0;
+   TTreeFormulaManager *manager=nullptr;
    if (fFormulaList->LastIndex()>=0) {
       manager = new TTreeFormulaManager;
       for(i=0;i<=fFormulaList->LastIndex();i++) {
@@ -2251,7 +2251,7 @@ Long64_t TTreePlayer::Process(TSelector *selector,Option_t *option, Long64_t nen
       readbytesatstart = TFile::GetFileBytesRead();
 
       //set the file cache
-      TTreeCache *tpf = 0;
+      TTreeCache *tpf = nullptr;
       TFile *curfile = fTree->GetCurrentFile();
       if (curfile) {
          tpf = (TTreeCache*)curfile->GetCacheRead(fTree);
@@ -2267,7 +2267,7 @@ Long64_t TTreePlayer::Process(TSelector *selector,Option_t *option, Long64_t nen
       }
 
       //Create a timer to get control in the entry loop(s)
-      TProcessEventTimer *timer = 0;
+      TProcessEventTimer *timer = nullptr;
       Int_t interval = fTree->GetTimerInterval();
       if (!gROOT->IsBatch() && interval)
          timer = new TProcessEventTimer(interval);
@@ -2329,8 +2329,8 @@ Long64_t TTreePlayer::Process(TSelector *selector,Option_t *option, Long64_t nen
       selector->Terminate();        //<==call user termination function
       res = selector->GetStatus();
    }
-   fTree->SetNotify(0); // Detach the selector from the tree.
-   fSelectorUpdate = 0;
+   fTree->SetNotify(nullptr); // Detach the selector from the tree.
+   fSelectorUpdate = nullptr;
    if (gMonitoringWriter)
       gMonitoringWriter->SendProcessingStatus("DONE");
 
@@ -2342,7 +2342,7 @@ Long64_t TTreePlayer::Process(TSelector *selector,Option_t *option, Long64_t nen
 
 void TTreePlayer::RecursiveRemove(TObject *obj)
 {
-   if (fHistogram == obj) fHistogram = 0;
+   if (fHistogram == obj) fHistogram = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2553,7 +2553,7 @@ Long64_t TTreePlayer::Scan(const char *varexp, const char *selection,
       }
    }
    TObjArray *leaves = fTree->GetListOfLeaves();
-   if (leaves==0) return 0;
+   if (leaves==nullptr) return 0;
    UInt_t nleaves = leaves->GetEntriesFast();
    if (nleaves < ncols) ncols = nleaves;
    nch = varexp ? strlen(varexp) : 0;
@@ -2561,7 +2561,7 @@ Long64_t TTreePlayer::Scan(const char *varexp, const char *selection,
    nentries = GetEntriesToProcess(firstentry, nentries);
 
 //*-*- Compile selection expression if there is one
-   TTreeFormula        *select  = 0;
+   TTreeFormula        *select  = nullptr;
    if (selection && strlen(selection)) {
       select = new TTreeFormula("Selection",selection,fTree);
       if (!select) return -1;
@@ -2624,7 +2624,7 @@ Long64_t TTreePlayer::Scan(const char *varexp, const char *selection,
    }
 
 //*-*- Create a TreeFormulaManager to coordinate the formulas
-   TTreeFormulaManager *manager=0;
+   TTreeFormulaManager *manager=nullptr;
    Bool_t hasArray = kFALSE;
    Bool_t forceDim = kFALSE;
    if (fFormulaList->LastIndex()>=0) {
@@ -2822,11 +2822,11 @@ TSQLResult *TTreePlayer::Query(const char *varexp, const char *selection,
    nentries = GetEntriesToProcess(firstentry, nentries);
 
    // compile selection expression if there is one
-   TTreeFormula *select = 0;
+   TTreeFormula *select = nullptr;
    if (strlen(selection)) {
       select = new TTreeFormula("Selection",selection,fTree);
-      if (!select) return 0;
-      if (!select->GetNdim()) { delete select; return 0; }
+      if (!select) return nullptr;
+      if (!select->GetNdim()) { delete select; return nullptr; }
       fFormulaList->Add(select);
    }
 
@@ -2856,7 +2856,7 @@ TSQLResult *TTreePlayer::Query(const char *varexp, const char *selection,
    }
 
    //*-*- Create a TreeFormulaManager to coordinate the formulas
-   TTreeFormulaManager *manager=0;
+   TTreeFormulaManager *manager=nullptr;
    if (fFormulaList->LastIndex()>=0) {
       manager = new TTreeFormulaManager;
       for(i=0;i<=fFormulaList->LastIndex();i++) {
@@ -3163,7 +3163,7 @@ void TTreePlayer::UpdateFormulaLeaves()
       }
       if (fSelectorFromFile==fSelectorUpdate) {
          TIter next(fSelectorFromFile->GetOutputList());
-         TEntryList *elist=0;
+         TEntryList *elist=nullptr;
          while ((elist=(TEntryList*)next())){
             if (elist->InheritsFrom(TEntryList::Class())){
                elist->SetTree(fTree->GetTree());

--- a/tree/treeplayer/src/TTreeProcessorMP.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMP.cxx
@@ -327,7 +327,7 @@ void TTreeProcessorMP::FixLists(std::vector<TObject*> &lists) {
    TList *firstlist = new TList;
    TList *oldlist = (TList *) lists[0];
    TIter nxo(oldlist);
-   TObject *o = 0;
+   TObject *o = nullptr;
    while ((o = nxo())) { firstlist->Add(o); }
    oldlist->SetOwner(kFALSE);
    lists.erase(lists.begin());

--- a/tree/treeplayer/src/TTreeProxyGenerator.cxx
+++ b/tree/treeplayer/src/TTreeProxyGenerator.cxx
@@ -258,7 +258,7 @@ namespace Internal {
 
    Bool_t TTreeProxyGenerator::NeedToEmulate(TClass *cl, UInt_t /* level */)
    {
-      return cl!=0 && cl->TestBit(TClass::kIsEmulation);
+      return cl!=nullptr && cl->TestBit(TClass::kIsEmulation);
    }
 
    ////////////////////////////////////////////////////////////////////////////////
@@ -267,7 +267,7 @@ namespace Internal {
    TBranchProxyClassDescriptor*
    TTreeProxyGenerator::AddClass( TBranchProxyClassDescriptor* desc )
    {
-      if (desc==0) return 0;
+      if (desc==nullptr) return nullptr;
 
       TBranchProxyClassDescriptor *existing =
          (TBranchProxyClassDescriptor*)fListOfClasses(desc->GetName());
@@ -297,7 +297,7 @@ namespace Internal {
 
    void TTreeProxyGenerator::AddFriend( TFriendProxyDescriptor* desc )
    {
-      if (desc==0) return;
+      if (desc==nullptr) return;
 
       TFriendProxyDescriptor *existing =
          (TFriendProxyDescriptor*)fListOfFriends(desc->GetName());
@@ -349,7 +349,7 @@ namespace Internal {
       TObject *obj = fListOfForwards.FindObject(classname);
       if (obj) return;
 
-      if (strstr(classname,"<")!=0) {
+      if (strstr(classname,"<")!=nullptr) {
          // this is a template instantiation.
          // let's ignore it for now
 
@@ -412,7 +412,7 @@ namespace Internal {
 
    void TTreeProxyGenerator::AddMissingClassAsEnum(const char *clname, Bool_t isscope)
    {
-      if (!TClassEdit::IsStdClass(clname) && !TClass::GetClass(clname) && gROOT->GetType(clname) == 0) {
+      if (!TClassEdit::IsStdClass(clname) && !TClass::GetClass(clname) && gROOT->GetType(clname) == nullptr) {
 
          TObject *obj = fListOfForwards.FindObject(clname);
          if (obj) return;
@@ -483,7 +483,7 @@ namespace Internal {
    UInt_t TTreeProxyGenerator::AnalyzeBranches(UInt_t level,TBranchProxyClassDescriptor *topdesc,
                                                TBranchElement *branch, TVirtualStreamerInfo *info)
    {
-      if (info==0) info = branch->GetInfo();
+      if (info==nullptr) info = branch->GetInfo();
 
       TIter branches( branch->GetListOfBranches() );
 
@@ -581,7 +581,7 @@ namespace Internal {
          TIter peek = branches;
          TBranchElement *branch = (TBranchElement*)peek();
 
-         if (branch==0) {
+         if (branch==nullptr) {
             if (topdesc) {
                Error("AnalyzeBranches","Ran out of branches when looking in branch %s, class %s",
                      topdesc->GetBranchName(), info->GetName());
@@ -724,7 +724,7 @@ namespace Internal {
                }
 
                TBranch *parent = branch->GetMother()->GetSubBranch(branch);
-               TVirtualStreamerInfo *objInfo = 0;
+               TVirtualStreamerInfo *objInfo = nullptr;
                if (branch->GetListOfBranches()->GetEntries()) {
                   objInfo = ((TBranchElement*)branch->GetListOfBranches()->At(0))->GetInfo();
                } else {
@@ -739,7 +739,7 @@ namespace Internal {
                      continue;
                   }
 
-                  TBranchProxyClassDescriptor *cldesc = 0;
+                  TBranchProxyClassDescriptor *cldesc = nullptr;
 
                   if (branchEndname == element->GetName()) {
                      // We have a proper node for the base class, recurse
@@ -748,7 +748,7 @@ namespace Internal {
                         // The branch contains a non-split base class that we are unfolding!
 
                         // See AnalyzeTree for similar code!
-                        TBranchProxyClassDescriptor *local_cldesc = 0;
+                        TBranchProxyClassDescriptor *local_cldesc = nullptr;
 
                         TVirtualStreamerInfo *binfo = branch->GetInfo();
                         if (strcmp(cl->GetName(),binfo->GetName())!=0) {
@@ -759,7 +759,7 @@ namespace Internal {
                                                                        isclones, 0 /* unsplit object */,
                                                                        containerName);
 
-                        TStreamerElement *elem = 0;
+                        TStreamerElement *elem = nullptr;
 
                         TIter next(binfo->GetElements());
                         while( (elem = (TStreamerElement*)next()) ) {
@@ -794,7 +794,7 @@ namespace Internal {
                      }
                      TString local_prefix = topdesc ? topdesc->GetSubBranchPrefix() : parent->GetName();
                      objInfo = GetBaseClass( element );
-                     if (objInfo == 0) {
+                     if (objInfo == nullptr) {
                         // There is no data in this base class
                         continue;
                      }
@@ -812,7 +812,7 @@ namespace Internal {
                   if (added) proxyTypeName = added->GetName();
 
                } else {
-                  TBranchProxyClassDescriptor *cldesc = 0;
+                  TBranchProxyClassDescriptor *cldesc = nullptr;
 
                   if (branchEndname == element->GetName()) {
 
@@ -821,7 +821,7 @@ namespace Internal {
                         // The branch contains a non-split object that we are unfolding!
 
                         // See AnalyzeTree for similar code!
-                        TBranchProxyClassDescriptor *local_cldesc = 0;
+                        TBranchProxyClassDescriptor *local_cldesc = nullptr;
 
                         TVirtualStreamerInfo *binfo = branch->GetInfo();
                         if (strcmp(cl->GetName(),binfo->GetName())!=0) {
@@ -832,7 +832,7 @@ namespace Internal {
                                                                        isclones, 0 /* unsplit object */,
                                                                        containerName);
 
-                        TStreamerElement *elem = 0;
+                        TStreamerElement *elem = nullptr;
 
                         TIter next(binfo->GetElements());
                         while( (elem = (TStreamerElement*)next()) ) {
@@ -1110,7 +1110,7 @@ namespace Internal {
       TIter next( tree->GetListOfBranches() );
       TBranch *branch;
       while ( (branch = (TBranch*)next()) ) {
-         TVirtualStreamerInfo *info = 0;
+         TVirtualStreamerInfo *info = nullptr;
          const char *branchname = branch->GetName();
          const char *classname = branch->GetClassName();
          if (classname && strlen(classname)) {
@@ -1118,7 +1118,7 @@ namespace Internal {
             AddHeader( classname );
          }
 
-         TBranchProxyClassDescriptor *desc = 0;
+         TBranchProxyClassDescriptor *desc = nullptr;
          TClass *cl = TClass::GetClass(classname);
          TString type = "unknown";
          if (cl) {
@@ -1139,14 +1139,14 @@ namespace Internal {
                   }
                } else {
                   TClonesArray **ptr = (TClonesArray**)branch->GetAddress();
-                  TClonesArray *clones = 0;
-                  if (ptr==0) {
+                  TClonesArray *clones = nullptr;
+                  if (ptr==nullptr) {
                      clones = new TClonesArray;
                      branch->SetAddress(&clones);
                      ptr = &clones;
                   }
                   branch->GetEntry(0);
-                  TClass *ncl = *ptr ? (*ptr)->GetClass() : 0;
+                  TClass *ncl = *ptr ? (*ptr)->GetClass() : nullptr;
                   if (ncl) {
                      cl = ncl;
                   } else {
@@ -1189,7 +1189,7 @@ namespace Internal {
 
                if (desc) {
                   TVirtualStreamerInfo *cinfo = cl->GetStreamerInfo();
-                  TStreamerElement *elem = 0;
+                  TStreamerElement *elem = nullptr;
 
                   TIter cnext(cinfo->GetElements());
                   while( (elem = (TStreamerElement*)cnext()) ) {
@@ -1214,7 +1214,7 @@ namespace Internal {
             } else {
 
                // We have a top level raw type.
-               AnalyzeOldBranch(branch, 0, 0);
+               AnalyzeOldBranch(branch, 0, nullptr);
             }
 
          } else {
@@ -1234,7 +1234,7 @@ namespace Internal {
             if ( branchname[strlen(branchname)-1] != '.' ) {
                // If there is no dot also include the data member directly
 
-               AnalyzeBranches(1,0,dynamic_cast<TBranchElement*>(branch),info);
+               AnalyzeBranches(1,nullptr,dynamic_cast<TBranchElement*>(branch),info);
 
                subnext.Reset();
             }
@@ -1324,7 +1324,7 @@ namespace Internal {
                //                                          containerName);
 
                TVirtualStreamerInfo *info = cl->GetStreamerInfo();
-               TStreamerElement *elem = 0;
+               TStreamerElement *elem = nullptr;
 
                TString subpath = path;
                if (subpath.Length()>0) subpath += ".";
@@ -1513,7 +1513,7 @@ namespace Internal {
                                                      containerName);
 
             TVirtualStreamerInfo *info = cl->GetStreamerInfo();
-            TStreamerElement *elem = 0;
+            TStreamerElement *elem = nullptr;
 
             TString subpath = path;
             if (subpath.Length()>0) subpath += ".";
@@ -1644,7 +1644,7 @@ namespace Internal {
       // if and only if it is different.
 
       Bool_t updating = kFALSE;
-      if (gSystem->GetPathInfo( fHeaderFileName, 0, (Long_t*)0, 0, 0 ) == 0) {
+      if (gSystem->GetPathInfo( fHeaderFileName, nullptr, (Long_t*)nullptr, nullptr, nullptr ) == 0) {
          // file already exist
          updating = kTRUE;
       }
@@ -1713,7 +1713,7 @@ namespace Internal {
       } else {
          hf = fopen(fHeaderFileName, "w");
       }
-      if (hf == 0) {
+      if (hf == nullptr) {
          Error("WriteProxy","Unable to open the file %s for writing.",
                updating ? tmpfilename.Data() : fHeaderFileName.Data());
          delete [] filename;
@@ -1761,7 +1761,7 @@ namespace Internal {
       TIter next( &fListOfForwards );
       TObject *current;
       while ( (current=next()) ) {
-         if (strstr(current->GetTitle(),"::")==0) {
+         if (strstr(current->GetTitle(),"::")==nullptr) {
             // We can not forward declared nested classes (well we might be able to do so for
             // the one nested in a namespace but it is not clear yet if we can really reliably
             // find this information)

--- a/tree/treeplayer/src/TTreeReaderArray.cxx
+++ b/tree/treeplayer/src/TTreeReaderArray.cxx
@@ -46,7 +46,7 @@ namespace {
          if (!proxy->Read()){
             fReadStatus = TTreeReaderValueBase::kReadError;
             Error("TClonesReader::GetCA()", "Read error in TBranchProxy.");
-            return 0;
+            return nullptr;
          }
          fReadStatus = TTreeReaderValueBase::kReadSuccess;
          return (TClonesArray*) proxy->GetWhere();
@@ -63,7 +63,7 @@ namespace {
          if (myClonesArray){
             return myClonesArray->UncheckedAt(idx);
          }
-         else return 0;
+         else return nullptr;
       }
    };
 
@@ -75,11 +75,11 @@ namespace {
          if (!proxy->Read()) {
             fReadStatus = TTreeReaderValueBase::kReadError;
             Error("TSTLReader::GetCP()", "Read error in TBranchProxy.");
-            return 0;
+            return nullptr;
          }
          if (!proxy->GetWhere()) {
             Error("TSTLReader::GetCP()", "Logic error, proxy object not set in TBranchProxy.");
-            return 0;
+            return nullptr;
          }
          fReadStatus = TTreeReaderValueBase::kReadSuccess;
          return (TVirtualCollectionProxy*) proxy->GetCollection();
@@ -93,7 +93,7 @@ namespace {
 
       void* At(ROOT::Detail::TBranchProxy* proxy, size_t idx) override {
          TVirtualCollectionProxy *myCollectionProxy = GetCP(proxy);
-         if (!myCollectionProxy) return 0;
+         if (!myCollectionProxy) return nullptr;
          if (myCollectionProxy->HasPointers()){
             return *(void**)myCollectionProxy->At(idx);
          }
@@ -113,11 +113,11 @@ namespace {
          if (!proxy->Read()) {
             fReadStatus = TTreeReaderValueBase::kReadError;
             Error("TCollectionLessSTLReader::GetCP()", "Read error in TBranchProxy.");
-            return 0;
+            return nullptr;
          }
          if (!proxy->GetWhere()) {
             Error("TCollectionLessSTLReader::GetCP()", "Logic error, proxy object not set in TBranchProxy.");
-            return 0;
+            return nullptr;
          }
          fReadStatus = TTreeReaderValueBase::kReadSuccess;
          return fLocalCollection;
@@ -135,7 +135,7 @@ namespace {
 
       void* At(ROOT::Detail::TBranchProxy* proxy, size_t idx) override {
          TVirtualCollectionProxy *myCollectionProxy = GetCP(proxy);
-         if (!myCollectionProxy) return 0;
+         if (!myCollectionProxy) return nullptr;
          // Here we do not use a RAII but we empty the proxy to then fill it.
          // This is done because we are returning a pointer and we need to keep
          // alive the memory it points to.
@@ -162,7 +162,7 @@ namespace {
          if (!proxy->Read()){
             fReadStatus = TTreeReaderValueBase::kReadError;
             Error("TObjectArrayReader::GetCP()", "Read error in TBranchProxy.");
-            return 0;
+            return nullptr;
          }
          fReadStatus = TTreeReaderValueBase::kReadSuccess;
          return (TVirtualCollectionProxy*) proxy->GetCollection();
@@ -173,7 +173,7 @@ namespace {
          return myCollectionProxy->Size();
       }
       void* At(ROOT::Detail::TBranchProxy* proxy, size_t idx) override {
-         if (!proxy->Read()) return 0;
+         if (!proxy->Read()) return nullptr;
 
          Int_t objectSize;
          void *array = (void*)proxy->GetStart();
@@ -182,7 +182,7 @@ namespace {
             TClass *myClass = proxy->GetClass();
             if (!myClass){
                Error("TObjectArrayReader::At()", "Cannot get class info from branch proxy.");
-               return 0;
+               return nullptr;
             }
             objectSize = myClass->GetClassSize();
          }
@@ -314,7 +314,7 @@ namespace {
          if (!proxy->Read()){
             fReadStatus = TTreeReaderValueBase::kReadError;
             Error("TBasicTypeArrayReader::GetCP()", "Read error in TBranchProxy.");
-            return 0;
+            return nullptr;
          }
          fReadStatus = TTreeReaderValueBase::kReadSuccess;
          return (TVirtualCollectionProxy*) proxy->GetCollection();
@@ -328,7 +328,7 @@ namespace {
 
       void* At(ROOT::Detail::TBranchProxy* proxy, size_t idx) override{
          TVirtualCollectionProxy *myCollectionProxy = GetCP(proxy);
-         if (!myCollectionProxy) return 0;
+         if (!myCollectionProxy) return nullptr;
          return (Byte_t*)myCollectionProxy->At(idx) + proxy->GetOffset();
       }
    };
@@ -341,7 +341,7 @@ namespace {
 
       void* At(ROOT::Detail::TBranchProxy* proxy, size_t idx) override{
          TClonesArray *myClonesArray = GetCA(proxy);
-         if (!myClonesArray) return 0;
+         if (!myClonesArray) return nullptr;
          return (Byte_t*)myClonesArray->At(idx) + fOffset;
       }
    };
@@ -363,7 +363,7 @@ namespace {
          void *address = fValueReader->GetAddress();
          if (fElementSize == -1){
             TLeaf *myLeaf = fValueReader->GetLeaf();
-            if (!myLeaf) return 0; // Error will be printed by GetLeaf
+            if (!myLeaf) return nullptr; // Error will be printed by GetLeaf
             fElementSize = myLeaf->GetLenType();
          }
          return (Byte_t*)address + (fElementSize * idx);
@@ -413,7 +413,7 @@ void ROOT::Internal::TTreeReaderArrayBase::CreateProxy()
       TBranch* br = fTreeReader->GetTree()->GetBranch(fBranchName);
       const char* brDataType = "{UNDETERMINED}";
       if (br) {
-         TDictionary* dictUnused = 0;
+         TDictionary* dictUnused = nullptr;
          brDataType = GetBranchDataType(br, dictUnused, fDict);
       }
       Error("TTreeReaderArrayBase::CreateProxy()", "The template argument type T of %s accessing branch %s (which contains data of type %s) is not known to ROOT. You will need to create a dictionary for it.",
@@ -427,7 +427,7 @@ void ROOT::Internal::TTreeReaderArrayBase::CreateProxy()
    // Search for the branchname, determine what it contains, and wire the
    // TBranchProxy representing it to us so we can access its data.
 
-   TDictionary* branchActualType = 0;
+   TDictionary* branchActualType = nullptr;
    TBranch* branch = nullptr;
    TLeaf *myLeaf = nullptr;
    if (!GetBranchAndLeaf(branch, myLeaf, branchActualType))
@@ -516,7 +516,7 @@ void ROOT::Internal::TTreeReaderArrayBase::CreateProxy()
                fBranchName.Data(), nonCollTypeName, nonCollTypeName);
          if (fSetupStatus == kSetupInternalError)
             fSetupStatus = kSetupNotACollection;
-         fProxy = 0;
+         fProxy = nullptr;
          return;
       }
       if (!branchActualType) {
@@ -529,7 +529,7 @@ void ROOT::Internal::TTreeReaderArrayBase::CreateProxy()
             if (fSetupStatus == kSetupInternalError)
                fSetupStatus = kSetupMissingDictionary;
          }
-         fProxy = 0;
+         fProxy = nullptr;
          return;
       }
 
@@ -591,7 +591,7 @@ bool ROOT::Internal::TTreeReaderArrayBase::GetBranchAndLeaf(TBranch* &branch, TL
    if (!fBranchName.Contains(".")) {
       Error("TTreeReaderArrayBase::GetBranchAndLeaf()", "The tree does not have a branch called %s. You could check with TTree::Print() for available branches.", fBranchName.Data());
       fSetupStatus = kSetupMissingBranch;
-      fProxy = 0;
+      fProxy = nullptr;
       return false;
    }
 
@@ -602,7 +602,7 @@ bool ROOT::Internal::TTreeReaderArrayBase::GetBranchAndLeaf(TBranch* &branch, TL
    if (!branch){
       Error("TTreeReaderArrayBase::GetBranchAndLeaf()", "The tree does not have a branch called %s. You could check with TTree::Print() for available branches.", fBranchName.Data());
       fSetupStatus = kSetupMissingBranch;
-      fProxy = 0;
+      fProxy = nullptr;
       return false;
    }
 
@@ -610,7 +610,7 @@ bool ROOT::Internal::TTreeReaderArrayBase::GetBranchAndLeaf(TBranch* &branch, TL
    if (!myLeaf){
       Error("TTreeReaderArrayBase::GetBranchAndLeaf()", "The tree does not have a branch, nor a sub-branch called %s. You could check with TTree::Print() for available branches.", fBranchName.Data());
       fSetupStatus = kSetupMissingBranch;
-      fProxy = 0;
+      fProxy = nullptr;
       return false;
    }
 
@@ -618,7 +618,7 @@ bool ROOT::Internal::TTreeReaderArrayBase::GetBranchAndLeaf(TBranch* &branch, TL
    if (!tempDict){
       Error("TTreeReaderArrayBase::GetBranchAndLeaf()", "Failed to get the dictionary for %s.", myLeaf->GetTypeName());
       fSetupStatus = kSetupMissingDictionary;
-      fProxy = 0;
+      fProxy = nullptr;
       return false;
    }
 
@@ -633,7 +633,7 @@ bool ROOT::Internal::TTreeReaderArrayBase::GetBranchAndLeaf(TBranch* &branch, TL
    }
    else {
       Error("TTreeReaderArrayBase::GetBranchAndLeaf()", "Leaf of type %s cannot be read by TTreeReaderValue<%s>.", myLeaf->GetTypeName(), fDict->GetName());
-      fProxy = 0;
+      fProxy = nullptr;
       fSetupStatus = kSetupMismatch;
       return false;
    }
@@ -805,7 +805,7 @@ const char* ROOT::Internal::TTreeReaderArrayBase::GetBranchContentDataType(TBran
             TClass *myClass = collProxy->GetValueClass();
             if (!myClass){
                Error("TTreeReaderArrayBase::GetBranchContentDataType()", "Could not get value class.");
-               return 0;
+               return nullptr;
             }
             dict = TDictionary::GetDictionary(myClass->GetName());
             if (!dict) dict = TDataType::GetDataType(collProxy->GetType());
@@ -816,7 +816,7 @@ const char* ROOT::Internal::TTreeReaderArrayBase::GetBranchContentDataType(TBran
             if (brElement->GetType() == 3) {
                contentTypeName = brElement->GetClonesName();
                dict = TDictionary::GetDictionary(brElement->GetClonesName());
-               return 0;
+               return nullptr;
             }
             // STL:
             TClassEdit::TSplitType splitType(brElement->GetClassName());
@@ -833,13 +833,13 @@ const char* ROOT::Internal::TTreeReaderArrayBase::GetBranchContentDataType(TBran
                contentTypeName += splitType.fElements[2];
                contentTypeName += " >";
             }
-            return 0;
+            return nullptr;
          }
-         return 0;
+         return nullptr;
       } else if (brElement->GetType() == 31
                  || brElement->GetType() == 41) {
          // it's a member, extract from GetClass()'s streamer info
-         TClass* clData = 0;
+         TClass* clData = nullptr;
          EDataType dtData = kOther_t;
          int ExpectedTypeRet = brElement->GetExpectedType(clData, dtData);
          if (ExpectedTypeRet == 0) {
@@ -857,9 +857,9 @@ const char* ROOT::Internal::TTreeReaderArrayBase::GetBranchContentDataType(TBran
                Error("TTreeReaderArrayBase::GetBranchContentDataType()", "The branch %s contains a data type %d for which the dictionary cannot be retrieved.",
                      branch->GetName(), (int)dtData);
                contentTypeName = TDataType::GetTypeName(dtData);
-               return 0;
+               return nullptr;
             }
-            return 0;
+            return nullptr;
          } else if (ExpectedTypeRet == 1) {
             int brID = brElement->GetID();
             if (brID == -1) {
@@ -867,14 +867,14 @@ const char* ROOT::Internal::TTreeReaderArrayBase::GetBranchContentDataType(TBran
                Error("TTreeReaderArrayBase::GetBranchContentDataType()", "The branch %s contains data of type %s for which the dictionary does not exist. It's needed.",
                      branch->GetName(), brElement->GetClassName());
                contentTypeName = brElement->GetClassName();
-               return 0;
+               return nullptr;
             }
             // Either the data type name doesn't have an EDataType entry
             // or the streamer info doesn't have a TClass* attached.
             TStreamerElement* element =
                (TStreamerElement*) brElement->GetInfo()->GetElement(brID);
             contentTypeName = element->GetTypeName();
-            return 0;
+            return nullptr;
          }
          /* else (ExpectedTypeRet == 2)*/
          // The streamer info entry cannot be found.
@@ -892,12 +892,12 @@ const char* ROOT::Internal::TTreeReaderArrayBase::GetBranchContentDataType(TBran
                TClass *myClass = brElement->GetCurrentClass();
                if (!myClass){
                   Error("TTreeReaderArrayBase::GetBranchDataType()", "Could not get class from branch element.");
-                  return 0;
+                  return nullptr;
                }
                TVirtualCollectionProxy *myCollectionProxy = myClass->GetCollectionProxy();
                if (!myCollectionProxy){
                   Error("TTreeReaderArrayBase::GetBranchDataType()", "Could not get collection proxy from STL class");
-                  return 0;
+                  return nullptr;
                }
                // Try getting the contained class
                dict = myCollectionProxy->GetValueClass();
@@ -905,22 +905,22 @@ const char* ROOT::Internal::TTreeReaderArrayBase::GetBranchContentDataType(TBran
                if (!dict) dict = TDataType::GetDataType(myCollectionProxy->GetType());
                if (!dict){
                   Error("TTreeReaderArrayBase::GetBranchDataType()", "Could not get valueClass from collectionProxy.");
-                  return 0;
+                  return nullptr;
                }
                contentTypeName = dict->GetName();
-               return 0;
+               return nullptr;
             }
             else if (element->IsA() == TStreamerObject::Class() && !strcmp(element->GetTypeName(), "TClonesArray")){
                if (!fProxy->Setup() || !fProxy->Read()){
                   Error("TTreeReaderArrayBase::GetBranchContentDataType()", "Failed to get type from proxy, unable to check type");
                   contentTypeName = "UNKNOWN";
-                  dict = 0;
+                  dict = nullptr;
                   return contentTypeName;
                }
                TClonesArray *myArray = (TClonesArray*)fProxy->GetWhere();
                dict = myArray->GetClass();
                contentTypeName = dict->GetName();
-               return 0;
+               return nullptr;
             }
             else {
                dict = brElement->GetCurrentClass();
@@ -929,7 +929,7 @@ const char* ROOT::Internal::TTreeReaderArrayBase::GetBranchContentDataType(TBran
                   dict = TDataType::GetDataType((EDataType)((TDataType*)myDataType)->GetType());
                }
                contentTypeName = brElement->GetTypeName();
-               return 0;
+               return nullptr;
             }
          }
          if (brElement->GetCurrentClass() == TClonesArray::Class()){
@@ -944,17 +944,17 @@ const char* ROOT::Internal::TTreeReaderArrayBase::GetBranchContentDataType(TBran
             // If it fails, try to get the contained type as a primitive type
             if (!dict) dict = TDataType::GetDataType(brElement->GetClass()->GetCollectionProxy()->GetType());
             if (dict) contentTypeName = dict->GetName();
-            return 0;
+            return nullptr;
          }
          else if (!dict){
             dict = brElement->GetClass();
             contentTypeName = dict->GetName();
-            return 0;
+            return nullptr;
          }
 
-         return 0;
+         return nullptr;
       }
-      return 0;
+      return nullptr;
    } else if (branch->IsA() == TBranch::Class()
               || branch->IsA() == TBranchObject::Class()
               || branch->IsA() == TBranchSTL::Class()) {
@@ -972,25 +972,25 @@ const char* ROOT::Internal::TTreeReaderArrayBase::GetBranchContentDataType(TBran
                else if (typeEnumConstant == kFloat16_t) typeEnumConstant = kFloat_t;
                dict = TDataType::GetDataType(typeEnumConstant);
                contentTypeName = myLeaf->GetTypeName();
-               return 0;
+               return nullptr;
             }
          }
 
          // leaflist. Can't represent.
          Error("TTreeReaderArrayBase::GetBranchContentDataType()", "The branch %s was created using a leaf list and cannot be represented as a C++ type. Please access one of its siblings using a TTreeReaderArray:", branch->GetName());
          TIter iLeaves(branch->GetListOfLeaves());
-         TLeaf* leaf = 0;
+         TLeaf* leaf = nullptr;
          while ((leaf = (TLeaf*) iLeaves())) {
             Error("TTreeReaderArrayBase::GetBranchContentDataType()", "   %s.%s", branch->GetName(), leaf->GetName());
          }
-         return 0;
+         return nullptr;
       }
       if (dataTypeName) dict = TDictionary::GetDictionary(dataTypeName);
       if (branch->IsA() == TBranchSTL::Class()){
          Warning("TTreeReaderArrayBase::GetBranchContentDataType()", "Not able to check type correctness, ignoring check");
          dict = fDict;
          fSetupStatus = kSetupNoCheck;
-         return 0;
+         return nullptr;
       }
       return dataTypeName;
    } else if (branch->IsA() == TBranchClones::Class()) {
@@ -999,11 +999,11 @@ const char* ROOT::Internal::TTreeReaderArrayBase::GetBranchContentDataType(TBran
    } else if (branch->IsA() == TBranchRef::Class()) {
       // Can't represent.
       Error("TTreeReaderArrayBase::GetBranchContentDataType()", "The branch %s is a TBranchRef and cannot be represented as a C++ type.", branch->GetName());
-      return 0;
+      return nullptr;
    } else {
       Error("TTreeReaderArrayBase::GetBranchContentDataType()", "The branch %s is of type %s - something that is not handled yet.", branch->GetName(), branch->IsA()->GetName());
-      return 0;
+      return nullptr;
    }
 
-   return 0;
+   return nullptr;
 }

--- a/tree/treeplayer/src/TTreeReaderGenerator.cxx
+++ b/tree/treeplayer/src/TTreeReaderGenerator.cxx
@@ -84,7 +84,7 @@ namespace Internal {
 
    UInt_t TTreeReaderGenerator::AnalyzeBranches(TBranchDescriptor *desc, TBranchElement *branch, TVirtualStreamerInfo *info)
    {
-      if (info==0) info = branch->GetInfo();
+      if (info==nullptr) info = branch->GetInfo();
 
       TIter branches(branch->GetListOfBranches());
 
@@ -162,7 +162,7 @@ namespace Internal {
          // try the next ones
          TBranchElement *branch = (TBranchElement*)peek();
          // There is a problem if there are more elements than branches
-         if (branch==0) {
+         if (branch==nullptr) {
             if (desc) {
                Error("AnalyzeBranches","Ran out of branches when looking in branch %s, class %s",
                      desc->fBranchName.Data(), info->GetName());
@@ -332,7 +332,7 @@ namespace Internal {
                //     - Split: recurse with sub-sub-branches
                //   - Element and branch does not match: recurse with same branches
                TBranch *parent = branch->GetMother()->GetSubBranch(branch);
-               TVirtualStreamerInfo *objInfo = 0;
+               TVirtualStreamerInfo *objInfo = nullptr;
                if (branch->GetListOfBranches()->GetEntries()) {
                   objInfo = ((TBranchElement*)branch->GetListOfBranches()->At(0))->GetInfo();
                } else {
@@ -345,7 +345,7 @@ namespace Internal {
                      continue; // Ignore TObject
                   }
 
-                  TBranchDescriptor *bdesc = 0;
+                  TBranchDescriptor *bdesc = nullptr;
 
                   if (branchEndName == element->GetName()) { // The element and the branch matches
                      if (branch->GetListOfBranches()->GetEntries() == 0) { // The branch contains a non-split base class
@@ -371,7 +371,7 @@ namespace Internal {
                      }
                      TString local_prefix = desc ? desc->fSubBranchPrefix : TString(parent->GetName());
                      objInfo = GetBaseClass(element);
-                     if (objInfo == 0) {
+                     if (objInfo == nullptr) {
                         continue; // There is no data in this base class
                      }
                      cl = objInfo->GetClass();
@@ -383,7 +383,7 @@ namespace Internal {
                   }
                   delete bdesc;
                } else { // Not base class
-                  TBranchDescriptor *bdesc = 0;
+                  TBranchDescriptor *bdesc = nullptr;
                   if (branchEndName == element->GetName()) { // The element and the branch matches
                      if (branch->GetListOfBranches()->GetEntries() == 0) { // The branch contains a non-split class
                         // FIXME: nothing to do in such cases, because readers cannot access
@@ -576,7 +576,7 @@ namespace Internal {
          branchName.Form("%s.%s", leaf->GetBranch()->GetName(), leaf->GetName());
       }
 
-      AddReader(type, dataType, leaf->GetName(), branchName, 0, kTRUE);
+      AddReader(type, dataType, leaf->GetName(), branchName, nullptr, kTRUE);
 
       return 0;
    }
@@ -649,7 +649,7 @@ namespace Internal {
 
       // Loop through branches
       while ( (branch = (TBranch*)next()) ) {
-         TVirtualStreamerInfo *info = 0;
+         TVirtualStreamerInfo *info = nullptr;
          // Get the name and the class of the branch
          const char *branchName = branch->GetName();
          const char *branchClassName = branch->GetClassName();
@@ -663,7 +663,7 @@ namespace Internal {
          TString type = "unknown";   // Type of branch
          ELocation isclones = kOut;  // Type of container
          TString containerName = ""; // Name of container
-         TBranchDescriptor *desc = 0;
+         TBranchDescriptor *desc = nullptr;
          // Check whether the branch is a container
          if (cl) {
             // Check if it is a TClonesArray
@@ -683,14 +683,14 @@ namespace Internal {
                   }
                } else {
                   TClonesArray **ptr = (TClonesArray**)branch->GetAddress();
-                  TClonesArray *clones = 0;
-                  if (ptr==0) {
+                  TClonesArray *clones = nullptr;
+                  if (ptr==nullptr) {
                      clones = new TClonesArray;
                      branch->SetAddress(&clones);
                      ptr = &clones;
                   }
                   branch->GetEntry(0);
-                  TClass *ncl = *ptr ? (*ptr)->GetClass() : 0;
+                  TClass *ncl = *ptr ? (*ptr)->GetClass() : nullptr;
                   if (ncl) {
                      cl = ncl;
                   } else {
@@ -713,11 +713,11 @@ namespace Internal {
                   if (containerName.EqualTo("vector<bool>")) {
                      AddReader(TTreeReaderDescriptor::ReaderType::kValue,
                             containerName,
-                            branch->GetName(), branch->GetName(), 0, kTRUE);
+                            branch->GetName(), branch->GetName(), nullptr, kTRUE);
                   } else { // Otherwise we can generate a TTreeReaderArray with the inner type
                      AddReader(TTreeReaderDescriptor::ReaderType::kArray,
                             TDataType::GetDataType(cl->GetCollectionProxy()->GetType())->GetName(),
-                            branch->GetName(), branch->GetName(), 0, kTRUE);
+                            branch->GetName(), branch->GetName(), nullptr, kTRUE);
                   }
                   continue; // Nothing else to with this branch in these cases
                }
@@ -737,7 +737,7 @@ namespace Internal {
                   AddReader(isclones == kOut ?
                               TTreeReaderDescriptor::ReaderType::kValue
                             : TTreeReaderDescriptor::ReaderType::kArray,
-                            cl->GetName(), branchName, branchName, 0, kTRUE);
+                            cl->GetName(), branchName, branchName, nullptr, kTRUE);
                   // TODO: can't we just put a continue here?
                }
             }
@@ -751,7 +751,7 @@ namespace Internal {
                   AddReader(isclones == kOut ?
                               TTreeReaderDescriptor::ReaderType::kValue
                             : TTreeReaderDescriptor::ReaderType::kArray,
-                            desc->GetName(), desc->fBranchName, desc->fBranchName, 0, kTRUE);
+                            desc->GetName(), desc->fBranchName, desc->fBranchName, nullptr, kTRUE);
                }
             } else { // Top-level RAW type
                AnalyzeOldBranch(branch); // Analyze branch and extract readers
@@ -770,7 +770,7 @@ namespace Internal {
                AddReader(isclones == kOut ?
                               TTreeReaderDescriptor::ReaderType::kValue
                             : TTreeReaderDescriptor::ReaderType::kArray,
-                            desc->GetName(), desc->fBranchName, desc->fBranchName, 0, kFALSE);
+                            desc->GetName(), desc->fBranchName, desc->fBranchName, nullptr, kFALSE);
             }
          }
          delete desc;

--- a/tree/treeplayer/src/TTreeReaderValue.cxx
+++ b/tree/treeplayer/src/TTreeReaderValue.cxx
@@ -251,7 +251,7 @@ void ROOT::Internal::TTreeReaderValueBase::NotifyNewTree(TTree* newTree) {
 /// Returns the memory address of the object being read.
 
 void* ROOT::Internal::TTreeReaderValueBase::GetAddress() {
-   if (ProxyRead() != kReadSuccess) return 0;
+   if (ProxyRead() != kReadSuccess) return nullptr;
 
    if (fHaveLeaf){
       if (GetLeaf()){
@@ -260,7 +260,7 @@ void* ROOT::Internal::TTreeReaderValueBase::GetAddress() {
       else {
          fReadStatus = kReadError;
          Error("TTreeReaderValueBase::GetAddress()", "Unable to get the leaf");
-         return 0;
+         return nullptr;
       }
    }
    if (fHaveStaticClassOffsets){ // Follow all the pointers
@@ -323,11 +323,11 @@ TBranch *ROOT::Internal::TTreeReaderValueBase::SearchBranchWithCompositeName(TLe
 
          bool found = true;
 
-         TDataType *finalDataType = 0;
+         TDataType *finalDataType = nullptr;
 
          std::vector<Long64_t> offsets;
          Long64_t offset = 0;
-         TClass *elementClass = 0;
+         TClass *elementClass = nullptr;
 
          TObjArray *myObjArray = myBranchElement->GetInfo()->GetElements();
          TVirtualStreamerInfo *myInfo = myBranchElement->GetInfo();
@@ -382,7 +382,7 @@ TBranch *ROOT::Internal::TTreeReaderValueBase::SearchBranchWithCompositeName(TLe
                errMsg = "Wrong data type ";
                errMsg += finalDataType ? finalDataType->GetName() : elementClass ? elementClass->GetName() : "UNKNOWN";
                fSetupStatus = kSetupMismatch;
-               fProxy = 0;
+               fProxy = nullptr;
                return nullptr;
             }
          }
@@ -394,7 +394,7 @@ TBranch *ROOT::Internal::TTreeReaderValueBase::SearchBranchWithCompositeName(TLe
          errMsg += fBranchName;
          errMsg += ". You could check with TTree::Print() for available branches.";
          fSetupStatus = kSetupMissingBranch;
-         fProxy = 0;
+         fProxy = nullptr;
          return nullptr;
       }
    }
@@ -405,7 +405,7 @@ TBranch *ROOT::Internal::TTreeReaderValueBase::SearchBranchWithCompositeName(TLe
          errMsg += fBranchName;
          errMsg += ". You could check with TTree::Print() for available branches.";
          fSetupStatus = kSetupMissingBranch;
-         fProxy = 0;
+         fProxy = nullptr;
          return nullptr;
       }
       else {
@@ -460,7 +460,7 @@ void ROOT::Internal::TTreeReaderValueBase::CreateProxy() {
    if (!fDict) {
       const char* brDataType = "{UNDETERMINED}";
       if (branchFromFullName) {
-         TDictionary* brDictUnused = 0;
+         TDictionary* brDictUnused = nullptr;
          brDataType = GetBranchDataType(branchFromFullName, brDictUnused, fDict);
       }
       Error(errPrefix, "The template argument type T of %s accessing branch %s (which contains data of type %s) is not known to ROOT. You will need to create a dictionary for it.",
@@ -545,7 +545,7 @@ void ROOT::Internal::TTreeReaderValueBase::CreateProxy() {
       if (!branchActualType) {
          Error(errPrefix, "The branch %s contains data of type %s, which does not have a dictionary.",
                fBranchName.Data(), branchActualTypeName ? branchActualTypeName : "{UNDETERMINED TYPE}");
-         fProxy = 0;
+         fProxy = nullptr;
          return;
       }
 
@@ -676,7 +676,7 @@ const char* ROOT::Internal::TTreeReaderValueBase::GetBranchDataType(TBranch* bra
                                            TDictionary* &dict,
                                            TDictionary const *curDict)
 {
-   dict = 0;
+   dict = nullptr;
    if (branch->IsA() == TBranchElement::Class()) {
       TBranchElement* brElement = (TBranchElement*)branch;
 
@@ -708,7 +708,7 @@ const char* ROOT::Internal::TTreeReaderValueBase::GetBranchDataType(TBranch* bra
             if (element->IsA() == TStreamerSTL::Class()){
                TStreamerSTL *myStl = (TStreamerSTL*)element;
                dict = myStl->GetClass();
-               return 0;
+               return nullptr;
             }
          }
 
@@ -740,7 +740,7 @@ const char* ROOT::Internal::TTreeReaderValueBase::GetBranchDataType(TBranch* bra
       } else {
          Error("TTreeReaderValueBase::GetBranchDataType()", "Unknown type and class combination: %i, %s", brElement->GetType(), brElement->GetClassName());
       }
-      return 0;
+      return nullptr;
    } else if (branch->IsA() == TBranch::Class()
               || branch->IsA() == TBranchObject::Class()
               || branch->IsA() == TBranchSTL::Class()) {
@@ -763,7 +763,7 @@ const char* ROOT::Internal::TTreeReaderValueBase::GetBranchDataType(TBranch* bra
             if (myDataType && myDataType->IsA() == TDataType::Class()){
                if (myLeaf->GetLeafCount() != nullptr || myLeaf->GetLenStatic() > 1) {
                   Error("TTreeReaderValueBase::GetBranchDataType()", "Must use TTreeReaderArray to read branch %s: it contains an array or a collection.", branch->GetName());
-                  return 0;
+                  return nullptr;
                }
                dict = TDataType::GetDataType((EDataType)((TDataType*)myDataType)->GetType());
                return myLeaf->GetTypeName();
@@ -773,11 +773,11 @@ const char* ROOT::Internal::TTreeReaderValueBase::GetBranchDataType(TBranch* bra
          // leaflist. Can't represent.
          Error("TTreeReaderValueBase::GetBranchDataType()", "The branch %s was created using a leaf list and cannot be represented as a C++ type. Please access one of its siblings using a TTreeReaderArray:", branch->GetName());
          TIter iLeaves(branch->GetListOfLeaves());
-         TLeaf* leaf = 0;
+         TLeaf* leaf = nullptr;
          while ((leaf = (TLeaf*) iLeaves())) {
             Error("TTreeReaderValueBase::GetBranchDataType()", "   %s.%s", branch->GetName(), leaf->GetName());
          }
-         return 0;
+         return nullptr;
       }
       if (dataTypeName) dict = TDictionary::GetDictionary(dataTypeName);
       return dataTypeName;
@@ -787,11 +787,11 @@ const char* ROOT::Internal::TTreeReaderValueBase::GetBranchDataType(TBranch* bra
    } else if (branch->IsA() == TBranchRef::Class()) {
       // Can't represent.
       Error("TTreeReaderValueBase::GetBranchDataType()", "The branch %s is a TBranchRef and cannot be represented as a C++ type.", branch->GetName());
-      return 0;
+      return nullptr;
    } else {
       Error("TTreeReaderValueBase::GetBranchDataType()", "The branch %s is of type %s - something that is not handled yet.", branch->GetName(), branch->IsA()->GetName());
-      return 0;
+      return nullptr;
    }
 
-   return 0;
+   return nullptr;
 }

--- a/tree/treeplayer/src/TTreeTableInterface.cxx
+++ b/tree/treeplayer/src/TTreeTableInterface.cxx
@@ -43,11 +43,11 @@ of the changes.
 TTreeTableInterface::TTreeTableInterface (TTree *tree, const char *varexp,
    const char *selection, Option_t *option, Long64_t nentries,
    Long64_t firstentry)
-   : TVirtualTableInterface(), fTree(tree), fFormulas(0), fEntry(0),
-     fNEntries(nentries), fFirstEntry(firstentry), fManager(0), fSelect(0), fSelector(0), fInput(0),
-     fForceDim(kFALSE), fEntries(0), fNRows(0), fNColumns(0)
+   : TVirtualTableInterface(), fTree(tree), fFormulas(nullptr), fEntry(0),
+     fNEntries(nentries), fFirstEntry(firstentry), fManager(nullptr), fSelect(nullptr), fSelector(nullptr), fInput(nullptr),
+     fForceDim(kFALSE), fEntries(nullptr), fNRows(0), fNColumns(0)
 {
-   if (fTree == 0) {
+   if (fTree == nullptr) {
       Error("TTreeTableInterface", "No tree supplied");
       return;
    }
@@ -90,7 +90,7 @@ TTreeTableInterface::~TTreeTableInterface()
    delete fInput;
    delete fSelector;
 
-   if (fTree) fTree->SetEntryList(0);
+   if (fTree) fTree->SetEntryList(nullptr);
    delete fEntries;
 }
 
@@ -143,7 +143,7 @@ void TTreeTableInterface::SetSelection(const char *selection)
    if (fSelect) {
       fFormulas->Remove(fSelect);
       delete fSelect;
-      fSelect = 0;
+      fSelect = nullptr;
    }
    if (selection && strlen(selection)) {
       fSelect = new TTreeFormula("Selection", selection, fTree);
@@ -312,7 +312,7 @@ const char *TTreeTableInterface::GetValueAsString(UInt_t row, UInt_t column)
       fTree->LoadTree(entry);
    } else {
       Error("TTreeTableInterface", "Row requested does not exist");
-      return 0;
+      return nullptr;
    }
    if (column < fNColumns) {
       TTreeFormula *formula = (TTreeFormula *)fFormulas->At(column);
@@ -323,7 +323,7 @@ const char *TTreeTableInterface::GetValueAsString(UInt_t row, UInt_t column)
       }
    } else {
       Error("TTreeTableInterface", "Column requested does not exist");
-      return 0;
+      return nullptr;
    }
 }
 

--- a/tree/treeviewer/src/TGTreeTable.cxx
+++ b/tree/treeviewer/src/TGTreeTable.cxx
@@ -31,7 +31,7 @@ GetInterface() method.
 TGTreeTable::TGTreeTable(TGWindow *p, Int_t id, TTree *tree,
                          const char *expression, const char *selection,
                          const char *option, UInt_t nrows, UInt_t ncolumns)
-   : TGTable(p, id, 0, nrows, ncolumns)
+   : TGTable(p, id, nullptr, nrows, ncolumns)
 {
    TTreeTableInterface *iface = new TTreeTableInterface(tree, expression,
                                                         selection, option);

--- a/tree/treeviewer/src/TParallelCoord.cxx
+++ b/tree/treeviewer/src/TParallelCoord.cxx
@@ -180,7 +180,7 @@ TParallelCoord::TParallelCoord(TTree* tree, Long64_t nentries)
 
 TParallelCoord::~TParallelCoord()
 {
-   if (fInitEntries != fCurrentEntries && fCurrentEntries != 0) delete fCurrentEntries;
+   if (fInitEntries != fCurrentEntries && fCurrentEntries != nullptr) delete fCurrentEntries;
    if (fVarList) {
       fVarList->Delete();
       delete fVarList;
@@ -254,7 +254,7 @@ void  TParallelCoord::ApplySelectionToTree()
    if(!fTree) return;
    if(fSelectList) {
       if(fSelectList->GetSize() == 0) return;
-      if(fCurrentSelection == 0) fCurrentSelection = (TParallelCoordSelect*)fSelectList->First();
+      if(fCurrentSelection == nullptr) fCurrentSelection = (TParallelCoordSelect*)fSelectList->First();
    }
    fCurrentEntries = GetEntryList();
    fNentries = fCurrentEntries->GetN();
@@ -276,7 +276,7 @@ void  TParallelCoord::ApplySelectionToTree()
    }
    if (fSelectList) {           // FIXME It would be better to update the selections by deleting
       fSelectList->Delete();    // the meaningless ranges (selecting everything or nothing for example)
-      fCurrentSelection = 0;    // after applying a new entrylist to the tree.
+      fCurrentSelection = nullptr;    // after applying a new entrylist to the tree.
    }
    gPad->Modified();
    gPad->Update();
@@ -326,7 +326,7 @@ void TParallelCoord::DeleteSelection(TParallelCoordSelect * sel)
 {
    fSelectList->Remove(sel);
    delete sel;
-   if(fSelectList->GetSize() == 0) fCurrentSelection = 0;
+   if(fSelectList->GetSize() == 0) fCurrentSelection = nullptr;
    else fCurrentSelection = (TParallelCoordSelect*)fSelectList->At(0);
 }
 
@@ -379,7 +379,7 @@ void TParallelCoord::Draw(Option_t* option)
    TView *view = gPad->GetView();
    if(view){
       delete view;
-      gPad->SetView(0);
+      gPad->SetView(nullptr);
    }
    gPad->Clear();
    if (!optcandle) {
@@ -437,7 +437,7 @@ void TParallelCoord::ExecuteEvent(Int_t /*entry*/, Int_t /*px*/, Int_t /*py*/)
 
 TParallelCoordSelect* TParallelCoord::GetCurrentSelection()
 {
-   if (!fSelectList) return 0;
+   if (!fSelectList) return nullptr;
    if (!fCurrentSelection) {
       fCurrentSelection = (TParallelCoordSelect*)fSelectList->First();
    }
@@ -524,20 +524,20 @@ TTree* TParallelCoord::GetTree()
    if (fTree) return fTree;
    if (fTreeFileName=="" || fTreeName=="") {
       Error("GetTree","Cannot load the tree: no tree defined!");
-      return 0;
+      return nullptr;
    }
    TFile *f = TFile::Open(fTreeFileName.Data());
    if (!f) {
       Error("GetTree","Tree file name : \"%s\" does not exist (Are you in the correct directory?).",fTreeFileName.Data());
-      return 0;
+      return nullptr;
    } else if (f->IsZombie()) {
       Error("GetTree","while opening \"%s\".",fTreeFileName.Data());
-      return 0;
+      return nullptr;
    } else {
       fTree = (TTree*)f->Get(fTreeName.Data());
       if (!fTree) {
          Error("GetTree","\"%s\" not found in \"%s\".", fTreeName.Data(), fTreeFileName.Data());
-         return 0;
+         return nullptr;
       } else {
          fTree->SetEntryList(fCurrentEntries);
          TString varexp = "";
@@ -564,9 +564,9 @@ TTree* TParallelCoord::GetTree()
 Double_t* TParallelCoord::GetVariable(const char* vartitle)
 {
    TIter next(fVarList);
-   TParallelCoordVar* var = 0;
-   while(((var = (TParallelCoordVar*)next()) != 0) && (var->GetTitle() != vartitle)) { }
-   if(!var) return 0;
+   TParallelCoordVar* var = nullptr;
+   while(((var = (TParallelCoordVar*)next()) != nullptr) && (var->GetTitle() != vartitle)) { }
+   if(!var) return nullptr;
    else     return var->GetValues();
 }
 
@@ -575,7 +575,7 @@ Double_t* TParallelCoord::GetVariable(const char* vartitle)
 
 Double_t* TParallelCoord::GetVariable(Int_t i)
 {
-   if(i<0 || (UInt_t)i>fNvar) return 0;
+   if(i<0 || (UInt_t)i>fNvar) return nullptr;
    else return ((TParallelCoordVar*)fVarList->At(i))->GetValues();
 }
 
@@ -585,8 +585,8 @@ Double_t* TParallelCoord::GetVariable(Int_t i)
 void TParallelCoord::Init()
 {
    fNentries = 0;
-   fVarList = 0;
-   fSelectList = 0;
+   fVarList = nullptr;
+   fSelectList = nullptr;
    SetBit(kVertDisplay,kTRUE);
    SetBit(kCurveDisplay,kFALSE);
    SetBit(kPaintEntries,kTRUE);
@@ -594,15 +594,15 @@ void TParallelCoord::Init()
    SetBit(kGlobalScale,kFALSE);
    SetBit(kCandleChart,kFALSE);
    SetBit(kGlobalLogScale,kFALSE);
-   fTree = 0;
-   fCurrentEntries = 0;
-   fInitEntries = 0;
-   fCurrentSelection = 0;
+   fTree = nullptr;
+   fCurrentEntries = nullptr;
+   fInitEntries = nullptr;
+   fCurrentSelection = nullptr;
    fNvar = 0;
    fDotsSpacing = 0;
    fCurrentFirst = 0;
    fCurrentN = 0;
-   fCandleAxis = 0;
+   fCandleAxis = nullptr;
    fWeightCut = 0;
    fLineWidth = 1;
    fLineColor = kGreen-8;
@@ -621,7 +621,7 @@ void TParallelCoord::Paint(Option_t* /*option*/)
    frame->SetLineColor(gPad->GetFillColor());
    SetAxesPosition();
    if(TestBit(kPaintEntries)){
-      PaintEntries(0);
+      PaintEntries(nullptr);
       TIter next(fSelectList);
       TParallelCoordSelect* sel;
       while((sel = (TParallelCoordSelect*)next())) {
@@ -633,7 +633,7 @@ void TParallelCoord::Paint(Option_t* /*option*/)
    gPad->RangeAxis(0,0,1,1);
 
    TIter nextVar(fVarList);
-   TParallelCoordVar* var=0;
+   TParallelCoordVar* var=nullptr;
    while((var = (TParallelCoordVar*)nextVar())) {
       var->Paint();
    }
@@ -651,9 +651,9 @@ void TParallelCoord::PaintEntries(TParallelCoordSelect* sel)
    Double_t *x = new Double_t[fNvar];
    Double_t *y = new Double_t[fNvar];
 
-   TGraph    *gr     = 0;
-   TPolyLine *pl     = 0;
-   TAttLine  *evline = 0;
+   TGraph    *gr     = nullptr;
+   TPolyLine *pl     = nullptr;
+   TAttLine  *evline = nullptr;
 
    if (TestBit (kCurveDisplay)) {gr = new TGraph(fNvar); evline = (TAttLine*)gr;}
    else                       {pl = new TPolyLine(fNvar); evline = (TAttLine*)pl;}
@@ -739,7 +739,7 @@ void TParallelCoord::RemoveVariable(TParallelCoordVar *var)
 Bool_t TParallelCoord::RemoveVariable(const char* vartitle)
 {
    TIter next(fVarList);
-   TParallelCoordVar* var=0;
+   TParallelCoordVar* var=nullptr;
    while((var = (TParallelCoordVar*)next())) {
       if (!strcmp(var->GetTitle(),vartitle)) break;
    }
@@ -779,7 +779,7 @@ void TParallelCoord::ResetTree()
    }
    if (fSelectList) {           // FIXME It would be better to update the selections by deleting
       fSelectList->Delete();    // the meaningless ranges (selecting everything or nothing for example)
-      fCurrentSelection = 0;    // after applying a new entrylist to the tree.
+      fCurrentSelection = nullptr;    // after applying a new entrylist to the tree.
    }
    gPad->Modified();
    gPad->Update();
@@ -986,7 +986,7 @@ void TParallelCoord::SetGlobalScale(Bool_t gl)
    SetBit(kGlobalScale,gl);
    if (fCandleAxis) {
       delete fCandleAxis;
-      fCandleAxis = 0;
+      fCandleAxis = nullptr;
    }
    if (gl) {
       Double_t min,max;
@@ -1035,7 +1035,7 @@ void TParallelCoord::SetCandleChart(Bool_t can)
       var->SetHistogramLineWidth(0);
    }
    if (fCandleAxis) delete fCandleAxis;
-   fCandleAxis = 0;
+   fCandleAxis = nullptr;
    SetBit(kPaintEntries,!can);
    if (can) {
       if (TestBit(kVertDisplay)) fCandleAxis = new TGaxis(0.05,0.1,0.05,0.9,GetGlobalMin(),GetGlobalMax());
@@ -1044,7 +1044,7 @@ void TParallelCoord::SetCandleChart(Bool_t can)
    } else {
       if (fCandleAxis) {
          delete fCandleAxis;
-         fCandleAxis = 0;
+         fCandleAxis = nullptr;
       }
    }
    gPad->Modified();

--- a/tree/treeviewer/src/TParallelCoordEditor.cxx
+++ b/tree/treeviewer/src/TParallelCoordEditor.cxx
@@ -721,7 +721,7 @@ void TParallelCoordEditor::DoHistColorSelect(Pixel_t p)
 
    Color_t col = TColor::GetColor(p);
    TIter next(fParallel->GetVarList());
-   TParallelCoordVar *var = NULL;
+   TParallelCoordVar *var = nullptr;
    while ((var = (TParallelCoordVar*)next())) var->SetFillColor(col);
    Update();
 }
@@ -747,7 +747,7 @@ void TParallelCoordEditor::DoHistPatternSelect(Style_t sty)
    if (fAvoidSignal) return;
 
    TIter next(fParallel->GetVarList());
-   TParallelCoordVar *var = NULL;
+   TParallelCoordVar *var = nullptr;
    while ((var = (TParallelCoordVar*)next())) var->SetFillStyle(sty);
    Update();
 }

--- a/tree/treeviewer/src/TParallelCoordRange.cxx
+++ b/tree/treeviewer/src/TParallelCoordRange.cxx
@@ -38,8 +38,8 @@ TParallelCoordRange::TParallelCoordRange()
 {
    fMin = 0;
    fMax = 0;
-   fVar = NULL;
-   fSelect = NULL;
+   fVar = nullptr;
+   fSelect = nullptr;
    SetBit(kShowOnPad,kTRUE);
    SetBit(kLiveUpdate,kFALSE);
 }
@@ -65,7 +65,7 @@ TParallelCoordRange::TParallelCoordRange(TParallelCoordVar *var, Double_t min, D
    fMax = max;
 
    fVar = var;
-   fSelect = NULL;
+   fSelect = nullptr;
 
    if (!sel) {
       TParallelCoordSelect* s = var->GetParallel()->GetCurrentSelection();
@@ -168,7 +168,7 @@ void TParallelCoordRange::ExecuteEvent(Int_t entry, Int_t px, Int_t py)
    gPad->SetCursor(kPointer);
    gVirtualX->SetLineColor(-1);
    gVirtualX->SetLineWidth(1);
-   TPoint *p = NULL;
+   TPoint *p = nullptr;
    switch (entry) {
       case kButton1Down:
          fVar->GetParallel()->SetCurrentSelection(fSelect);

--- a/tree/treeviewer/src/TParallelCoordVar.cxx
+++ b/tree/treeviewer/src/TParallelCoordVar.cxx
@@ -355,9 +355,9 @@ Int_t TParallelCoordVar::GetEntryWeight(Long64_t evtidx)
 TH1F* TParallelCoordVar::GetHistogram()
 {
    if (fHistogram) delete fHistogram;
-   fHistogram = NULL;
+   fHistogram = nullptr;
    fHistogram = new TH1F("hpa", "hpa", fNbins, fMinCurrent, fMaxCurrent+0.0001*(fMaxCurrent-fMinCurrent));
-   fHistogram->SetDirectory(0);
+   fHistogram->SetDirectory(nullptr);
    Long64_t first = fParallel->GetCurrentFirst();
    Long64_t nentries = fParallel->GetCurrentN();
    for(Long64_t li=first; li<first+nentries;++li) {
@@ -522,7 +522,7 @@ void TParallelCoordVar::Init()
    fY1         = 0;
    fY2         = 0;
    fId         = 0;
-   fVal        = NULL;
+   fVal        = nullptr;
    fMean       = 0;
    fMinInit    = 0;
    fMinCurrent = 0;
@@ -532,12 +532,12 @@ void TParallelCoordVar::Init()
    fQua1       = 0;
    fQua3       = 0;
    fNentries   = 0;
-   fParallel   = NULL;
-   fHistogram  = NULL;
+   fParallel   = nullptr;
+   fHistogram  = nullptr;
    fNbins      = 100;
    fHistoLW    = 2;
    fHistoHeight     = 0.5;
-   fRanges     = NULL;
+   fRanges     = nullptr;
    SetBit(kLogScale,kFALSE);
    SetBit(kShowBox,kFALSE);
    SetBit(kShowBarHisto,kTRUE);
@@ -646,7 +646,7 @@ void TParallelCoordVar::PaintBoxPlot()
       Double_t mean;
       if (TestBit(kLogScale)) mean = TMath::Log10(fMean);
       else mean = fMean;
-      TMarker *mark = NULL;
+      TMarker *mark = nullptr;
       if(fX1==fX2) mark = new TMarker(fX1,fY1 + ((mean-a)/b)*(fY2-fY1),24);
       else         mark = new TMarker(fX1 + ((mean-a)/b)*(fX2-fX1),fY1,24);
       mark->Paint();
@@ -930,7 +930,7 @@ void TParallelCoordVar::SetCurrentLimits(Double_t min, Double_t max)
    fMaxCurrent = max;
 
    delete fHistogram;
-   fHistogram = NULL;
+   fHistogram = nullptr;
    GetHistogram();
 
    if (fParallel->TestBit(TParallelCoord::kGlobalScale)) {

--- a/tree/treeviewer/src/TSpider.cxx
+++ b/tree/treeviewer/src/TSpider.cxx
@@ -77,32 +77,32 @@ TSpider::TSpider()
 {
    fDisplayAverage=kFALSE;
    fForceDim=kFALSE;
-   fPolargram=NULL;
-   fInput=NULL;
-   fManager=NULL;
+   fPolargram=nullptr;
+   fInput=nullptr;
+   fManager=nullptr;
    fNcols=0;
    fNx=3;
    fNy=4;
-   fPolyList=NULL;
-   fSelect=NULL;
-   fSelector=NULL;
-   fTree=NULL;
-   fMax=NULL;
-   fMin=NULL;
-   fAve=NULL;
-   fCanvas=NULL;
-   fAveragePoly=NULL;
+   fPolyList=nullptr;
+   fSelect=nullptr;
+   fSelector=nullptr;
+   fTree=nullptr;
+   fMax=nullptr;
+   fMin=nullptr;
+   fAve=nullptr;
+   fCanvas=nullptr;
+   fAveragePoly=nullptr;
    fEntry=0;
-   fSuperposed=NULL;
+   fSuperposed=nullptr;
    fShowRange=kFALSE;
    fAngularLabels=kFALSE;
-   fAverageSlices=NULL;
+   fAverageSlices=nullptr;
    fSegmentDisplay=kFALSE;
    fNentries=0;
    fFirstEntry=0;
    fArraySize=0;
-   fCurrentEntries = NULL;
-   fFormulas = NULL;
+   fCurrentEntries = nullptr;
+   fFormulas = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -129,16 +129,16 @@ TSpider::TSpider(TTree* tree ,const char *varexp, const char *selection,
    fNx=2;
    fNy=2;
    fDisplayAverage=kFALSE;
-   fSelect=NULL;
-   fManager=NULL;
-   fCanvas=NULL;
-   fAveragePoly=NULL;
+   fSelect=nullptr;
+   fManager=nullptr;
+   fCanvas=nullptr;
+   fAveragePoly=nullptr;
    fEntry=fFirstEntry;
-   fSuperposed=NULL;
+   fSuperposed=nullptr;
    fShowRange=kFALSE;
    fAngularLabels=kTRUE;
    fForceDim=kFALSE;
-   fAverageSlices=NULL;
+   fAverageSlices=nullptr;
    fSegmentDisplay=kFALSE;
    if (firstentry < 0 || firstentry > tree->GetEstimate()) firstentry = 0;
    fFirstEntry = firstentry;
@@ -147,8 +147,8 @@ TSpider::TSpider(TTree* tree ,const char *varexp, const char *selection,
 
    fEntry = fFirstEntry;
 
-   fPolargram=NULL;
-   fPolyList=NULL;
+   fPolargram=nullptr;
+   fPolyList=nullptr;
 
    fTree->SetScanField(fNx*fNy);
    fCurrentEntries = new Long64_t[fNx*fNy];
@@ -310,7 +310,7 @@ void TSpider::AddVariable(const char* varexp)
    }
 
    delete fPolargram;
-   fPolargram = NULL;
+   fPolargram = nullptr;
 
    if(fSegmentDisplay){
       for(ui=0;ui<fNx*fNy;++ui) ((TList*)fPolyList->At(ui))->Delete();
@@ -318,11 +318,11 @@ void TSpider::AddVariable(const char* varexp)
    }
    fPolyList->Delete();
    delete fPolyList;
-   fPolyList = NULL;
+   fPolyList = nullptr;
    delete [] fAverageSlices;
-   fAverageSlices = NULL;
+   fAverageSlices = nullptr;
    delete fAveragePoly;
-   fAveragePoly = NULL;
+   fAveragePoly = nullptr;
 
    if (fCanvas) {
       fCanvas->Clear();
@@ -395,7 +395,7 @@ void TSpider::DeleteVariable(const char* varexp)
    }
 
    delete fPolargram;
-   fPolargram = NULL;
+   fPolargram = nullptr;
 
    if(fSegmentDisplay){
       for(ui=0;ui<fNx*fNy;++ui) ((TList*)fPolyList->At(ui))->Delete();
@@ -403,11 +403,11 @@ void TSpider::DeleteVariable(const char* varexp)
    }
    fPolyList->Delete();
    delete fPolyList;
-   fPolyList = NULL;
+   fPolyList = nullptr;
    delete [] fAverageSlices;
-   fAverageSlices = NULL;
+   fAverageSlices = nullptr;
    delete fAveragePoly;
-   fAveragePoly = NULL;
+   fAveragePoly = nullptr;
 
    if (fCanvas) {
       fCanvas->Clear();
@@ -1030,12 +1030,12 @@ void TSpider::SetDisplayAverage(Bool_t disp)
 
    fDisplayAverage = disp;
    delete fAveragePoly;
-   fAveragePoly = NULL;
+   fAveragePoly = nullptr;
    if(fAverageSlices){
       for(ui = 0;ui<fNcols;++ui) delete fAverageSlices[ui];
    }
    delete [] fAverageSlices;
-   fAverageSlices = NULL;
+   fAverageSlices = nullptr;
 
    for(ui=0;ui<fNx*fNy;++ui){
       if (fCanvas) fCanvas->cd(ui+1);
@@ -1253,9 +1253,9 @@ void TSpider::SetNx(UInt_t nx)
    }
    fPolyList->Delete();
    delete fPolyList;
-   fPolyList = NULL;
+   fPolyList = nullptr;
    delete [] fCurrentEntries;
-   fCurrentEntries = NULL;
+   fCurrentEntries = nullptr;
 
    fNx = nx;
 
@@ -1330,9 +1330,9 @@ void TSpider::SetNy(UInt_t ny)
    }
    fPolyList->Delete();
    delete fPolyList;
-   fPolyList = NULL;
+   fPolyList = nullptr;
    delete [] fCurrentEntries;
-   fCurrentEntries = NULL;
+   fCurrentEntries = nullptr;
 
    fNy = ny;
 
@@ -1412,14 +1412,14 @@ void TSpider::SetSegmentDisplay(Bool_t seg)
    }
 
    delete fPolyList;
-   fPolyList = NULL;
+   fPolyList = nullptr;
    if(fAverageSlices){
       for(ui=0;ui<fNcols;++ui) delete fAverageSlices[ui];
    }
    delete [] fAverageSlices;
-   fAverageSlices = NULL;
+   fAverageSlices = nullptr;
    delete fAveragePoly;
-   fAveragePoly = NULL;
+   fAveragePoly = nullptr;
 
    for(ui=0;ui<fNx*fNy;++ui){
       if (fCanvas) fCanvas->cd(ui+1);

--- a/tree/treeviewer/src/TTVLVContainer.cxx
+++ b/tree/treeviewer/src/TTVLVContainer.cxx
@@ -32,7 +32,7 @@ Empty object used as context menu support for TGLVTreeEntries.
 
 TGItemContext::TGItemContext()
 {
-   fItem = 0;
+   fItem = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -103,7 +103,7 @@ TTVLVEntry::TTVLVEntry(const TGWindow *p,
    // both alias and true name are initialized to name
    fContainer = (TTVLVContainer *) p;
 
-   fTip = 0;
+   fTip = nullptr;
    fIsCut = kFALSE;
    fTrueName = name->GetString();
    fContext = new TGItemContext();
@@ -276,7 +276,7 @@ void TTVLVEntry::SetToolTipText(const char *text, Long_t delayms)
 {
    if (fTip) {
       delete fTip;
-      fTip = 0;
+      fTip = nullptr;
    }
 
    if (text && strlen(text))
@@ -291,7 +291,7 @@ void TTVLVEntry::SetSmallPic(const TGPicture *spic)
    fSmallPic = spic;
    fCurrent = fSmallPic;
    if (fSelPic) delete fSelPic;
-   fSelPic = 0;
+   fSelPic = nullptr;
    if (fActive) {
       fSelPic = new TGSelectedPicture(fClient, fCurrent);
    }
@@ -312,8 +312,8 @@ It is a TGLVContainer with item dragging capabilities for the TTVLVEntry objects
 TTVLVContainer::TTVLVContainer(const TGWindow *p, UInt_t w, UInt_t h, UInt_t options)
           :TGLVContainer(p, w, h,options | kSunkenFrame)
 {
-   fListView = 0;
-   fViewer = 0;
+   fListView = nullptr;
+   fViewer = nullptr;
    fExpressionList = new TList;
    fCursor = gVirtualX->CreateCursor(kMove);
    fDefaultCursor = gVirtualX->CreateCursor(kPointer);
@@ -337,9 +337,9 @@ const char* TTVLVContainer::Cut()
    if (el) {
       TTVLVEntry *f = (TTVLVEntry *) el->fFrame;
       if (f) return f->ConvertAliases();
-      return 0;
+      return nullptr;
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -352,7 +352,7 @@ TTVLVEntry * TTVLVContainer::ExpressionItem(Int_t index)
       TTVLVEntry *item = (TTVLVEntry *) el->fFrame;
       return item;
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -383,9 +383,9 @@ const char* TTVLVContainer::Ex()
    if (el) {
       TTVLVEntry *f = (TTVLVEntry *) el->fFrame;
       if (f) return f->ConvertAliases();
-      return 0;
+      return nullptr;
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -397,9 +397,9 @@ const char* TTVLVContainer::Ey()
    if (el) {
       TTVLVEntry *f = (TTVLVEntry *) el->fFrame;
       if (f) return f->ConvertAliases();
-      return 0;
+      return nullptr;
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -411,9 +411,9 @@ const char* TTVLVContainer::Ez()
    if (el) {
       TTVLVEntry *f = (TTVLVEntry *) el->fFrame;
       if (f) return f->ConvertAliases();
-      return 0;
+      return nullptr;
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -425,9 +425,9 @@ const char* TTVLVContainer::ScanList()
    if (el) {
       TTVLVEntry *f = (TTVLVEntry *) el->fFrame;
       if (f) return f->GetTrueName();
-      return 0;
+      return nullptr;
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -442,7 +442,7 @@ Bool_t TTVLVContainer::HandleButton(Event_t *event)
       fYp = event->fY;
       if (fLastActive) {
          fLastActive->Activate(kFALSE);
-         fLastActive = 0;
+         fLastActive = nullptr;
       }
       total = selected = 0;
 
@@ -617,7 +617,7 @@ void TTVLVContainer::RemoveNonStatic()
          RemoveItem(f);
       }
    }
-   fLastActive = 0;
+   fLastActive = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -627,7 +627,7 @@ void TTVLVContainer::SelectItem(const char* name)
 {
    if (fLastActive) {
       fLastActive->Activate(kFALSE);
-      fLastActive = 0;
+      fLastActive = nullptr;
    }
    TGFrameElement *el;
    fSelected = 0;
@@ -656,7 +656,7 @@ enum ETransientFrameCommands {
    kTFCancel
 };
 
-TGSelectBox* TGSelectBox::fgInstance = 0;
+TGSelectBox* TGSelectBox::fgInstance = nullptr;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// TGSelectBox constructor
@@ -669,7 +669,7 @@ TGSelectBox::TGSelectBox(const TGWindow *p, const TGWindow *main,
       fgInstance = this;
       fViewer = (TTreeViewer *)fMain;
       if (!fViewer) Error("TGSelectBox", "Must be started from viewer");
-      fEntry = 0;
+      fEntry = nullptr;
       fLayout = new TGLayoutHints(kLHintsTop | kLHintsCenterY | kLHintsExpandX, 0, 0, 0, 2);
       fBLayout = new TGLayoutHints(kLHintsTop | kLHintsLeft, 0, 2, 2, 2);
       fBLayout1= new TGLayoutHints(kLHintsTop | kLHintsRight, 2, 0, 2, 2);
@@ -719,7 +719,7 @@ TGSelectBox::TGSelectBox(const TGWindow *p, const TGWindow *main,
 
 TGSelectBox::~TGSelectBox()
 {
-   fgInstance = 0;
+   fgInstance = nullptr;
    delete fLabel;
    delete fTe;
    delete fLabelAlias;

--- a/tree/treeviewer/src/TTVSession.cxx
+++ b/tree/treeviewer/src/TTVSession.cxx
@@ -187,7 +187,7 @@ TTVRecord *TTVSession::AddRecord(Bool_t fromFile)
 
 TTVRecord *TTVSession::GetRecord(Int_t i)
 {
-   if (!fRecords) return 0;
+   if (!fRecords) return nullptr;
    fCurrent = i;
    if (i < 0)           fCurrent = 0;
    if (i > fRecords-1)  fCurrent = fRecords - 1;

--- a/tree/treeviewer/src/TTreeViewer.cxx
+++ b/tree/treeviewer/src/TTreeViewer.cxx
@@ -247,10 +247,10 @@ static const char* gOpt2D[14] =
 };
 
 static const char* gOpenTypes[] = {"Root files",   "*.root",
-                                   0,              0       };
+                                   nullptr,              nullptr       };
 
 static const char* gMacroTypes[] = {"C++ macros",   "*.C",
-                                   0,              0       };
+                                   nullptr,              nullptr       };
 
 // Menu command id's
 enum ERootTreeViewerCommands {
@@ -315,12 +315,12 @@ ClassImp(TTreeViewer);
 /// TTreeViewer default constructor
 
 TTreeViewer::TTreeViewer(const char* treeName) :
-   TGMainFrame(0,10,10,kVerticalFrame),
+   TGMainFrame(nullptr,10,10,kVerticalFrame),
    fDimension(0), fVarDraw(0), fScanMode(0),
    fTreeIndex(0), fDefaultCursor(0), fWatchCursor(0),
    fCounting(0), fStopMapping(0), fEnableCut(0),fNexpressions(0)
 {
-   fTree = 0;
+   fTree = nullptr;
    if (!gClient) return;
    char command[128];
    gROOT->ProcessLine("#ifndef GTV_DEFINED\n\
@@ -343,7 +343,7 @@ TTreeViewer::TTreeViewer(const char* treeName) :
 ////////////////////////////////////////////////////////////////////////////////
 
 TTreeViewer::TTreeViewer(const TTree *tree) :
-   TGMainFrame(0, 10, 10, kVerticalFrame),
+   TGMainFrame(nullptr, 10, 10, kVerticalFrame),
    fDimension(0), fVarDraw(0), fScanMode(0),
    fTreeIndex(0), fDefaultCursor(0), fWatchCursor(0),
    fCounting(0), fStopMapping(0), fEnableCut(0),fNexpressions(0)
@@ -351,7 +351,7 @@ TTreeViewer::TTreeViewer(const TTree *tree) :
 {
    // TTreeViewer constructor with a pointer to a Tree
 
-   fTree = 0;
+   fTree = nullptr;
    char command[128];
    gROOT->ProcessLine("#ifndef GTV_DEFINED\n\
                        TTreeViewer *gTV = 0;\n\
@@ -404,7 +404,7 @@ void TTreeViewer::AppendTree(TTree *tree)
             // map it on the right panel
             MapTree(fTree);
             fListView->Layout();
-            TGListTreeItem *base = 0;
+            TGListTreeItem *base = nullptr;
             TGListTreeItem *parent = fLt->FindChildByName(base, "TreeList");
             TGListTreeItem *item = fLt->FindChildByName(parent, fTree->GetName());
             fLt->ClearHighlighted();
@@ -427,7 +427,7 @@ void TTreeViewer::AppendTree(TTree *tree)
    if (fTreeList) fTreeList->Add(fTree);
    ExecuteCommand("tv__tree_list->Add(tv__tree);");
    //--- map this tree
-   TGListTreeItem *base = 0;
+   TGListTreeItem *base = nullptr;
    TGListTreeItem *parent = fLt->FindChildByName(base, "TreeList");
    if (!parent) parent = fLt->AddItem(base, "TreeList", new ULong_t(kLTNoType));
    ULong_t *itemType = new ULong_t((fTreeIndex << 8) | kLTTreeType);
@@ -491,7 +491,7 @@ void TTreeViewer::SetTree(TTree *tree)
    if (fTreeList) fTreeList->Add(fTree);
    ExecuteCommand("tv__tree_list->Add(tv__tree);");
    //--- map this tree
-   TGListTreeItem *base = 0;
+   TGListTreeItem *base = nullptr;
    TGListTreeItem *parent = fLt->FindChildByName(base, "TreeList");
    if (!parent) parent = fLt->AddItem(base, "TreeList", new ULong_t(kLTNoType));
    ULong_t *itemType = new ULong_t((fTreeIndex << 8) | kLTTreeType);
@@ -533,7 +533,7 @@ void TTreeViewer::SetTreeName(const char* treeName)
             // map it on the right panel
             MapTree(fTree);
             fListView->Layout();
-            TGListTreeItem *base = 0;
+            TGListTreeItem *base = nullptr;
             TGListTreeItem *parent = fLt->FindChildByName(base, "TreeList");
             TGListTreeItem *item = fLt->FindChildByName(parent, fTree->GetName());
             fLt->ClearHighlighted();
@@ -556,7 +556,7 @@ void TTreeViewer::SetTreeName(const char* treeName)
    if (fTreeList) fTreeList->Add(fTree);
    ExecuteCommand("tv__tree_list->Add(tv__tree);");
    //--- map this tree
-   TGListTreeItem *base = 0;
+   TGListTreeItem *base = nullptr;
    TGListTreeItem *parent = fLt->FindChildByName(base, "TreeList");
    if (!parent) parent = fLt->AddItem(base, "TreeList", new ULong_t(kLTNoType));
    ULong_t *itemType = new ULong_t((fTreeIndex << 8) | kLTTreeType);
@@ -626,9 +626,9 @@ void TTreeViewer::BuildInterface()
 
    //--- general context menu
    fContextMenu = new TContextMenu("TreeViewer context menu","");
-   fMappedTree = 0;
-   fMappedBranch = 0;
-   fDialogBox = 0;
+   fMappedTree = nullptr;
+   fMappedBranch = nullptr;
+   fDialogBox = nullptr;
    fDimension = 0;
    fVarDraw = kFALSE;
    fStopMapping = kFALSE;
@@ -1076,7 +1076,7 @@ void TTreeViewer::BuildInterface()
    fLVContainer->RemoveAll();
    TTVLVEntry* entry;
    Char_t symbol;
-   entry = new TTVLVEntry(fLVContainer,fPicX,fPicX,new TGString(),0,kLVSmallIcons);
+   entry = new TTVLVEntry(fLVContainer,fPicX,fPicX,new TGString(),nullptr,kLVSmallIcons);
    symbol = 'X';
    entry->SetUserData(new ULong_t((symbol << 8) | kLTExpressionType | kLTTreeType));
    entry->SetToolTipText("X expression. Drag and drop expressions here");
@@ -1085,7 +1085,7 @@ void TTreeViewer::BuildInterface()
    entry->Empty();
    entry->MapWindow();
 
-   entry = new TTVLVEntry(fLVContainer,fPicY,fPicY,new TGString(),0,kLVSmallIcons);
+   entry = new TTVLVEntry(fLVContainer,fPicY,fPicY,new TGString(),nullptr,kLVSmallIcons);
    symbol = 'Y';
    entry->SetUserData(new ULong_t((symbol << 8) | kLTExpressionType | kLTTreeType));
    entry->SetToolTipText("Y expression. Drag and drop expressions here");
@@ -1094,7 +1094,7 @@ void TTreeViewer::BuildInterface()
    entry->Empty();
    entry->MapWindow();
 
-   entry = new TTVLVEntry(fLVContainer,fPicZ,fPicZ,new TGString(),0,kLVSmallIcons);
+   entry = new TTVLVEntry(fLVContainer,fPicZ,fPicZ,new TGString(),nullptr,kLVSmallIcons);
    symbol = 'Z';
    entry->SetUserData(new ULong_t((symbol << 8) | kLTExpressionType | kLTTreeType));
    entry->SetToolTipText("Z expression. Drag and drop expressions here");
@@ -1105,7 +1105,7 @@ void TTreeViewer::BuildInterface()
 
    pic = gClient->GetPicture("cut_t.xpm");
    spic = gClient->GetPicture("cut_t.xpm");
-   entry = new TTVLVEntry(fLVContainer,pic,spic,new TGString(),0,kLVSmallIcons);
+   entry = new TTVLVEntry(fLVContainer,pic,spic,new TGString(),nullptr,kLVSmallIcons);
    entry->SetUserData(new ULong_t(kLTExpressionType | kLTCutType));
    entry->SetToolTipText("Active cut. Double-click to enable/disable");
    //--- Cut item (scissors icon)
@@ -1115,7 +1115,7 @@ void TTreeViewer::BuildInterface()
 
    pic = gClient->GetPicture("pack_t.xpm");
    spic = gClient->GetPicture("pack-empty_t.xpm");
-   entry = new TTVLVEntry(fLVContainer,pic,spic,new TGString("Scan box"),0,kLVSmallIcons);
+   entry = new TTVLVEntry(fLVContainer,pic,spic,new TGString("Scan box"),nullptr,kLVSmallIcons);
    entry->SetUserData(new ULong_t(kLTExpressionType | kLTPackType));
    entry->SetToolTipText("Drag and drop expressions/leaves here. Double-click to scan. Check <Scan> to redirect on file.");
    //--- Scan Box
@@ -1128,7 +1128,7 @@ void TTreeViewer::BuildInterface()
    for (Int_t i=0; i<fNexpressions; i++) {
       pic = gClient->GetPicture("expression_t.xpm");
       spic = gClient->GetPicture("expression_t.xpm");
-      entry = new TTVLVEntry(fLVContainer,pic,spic,new TGString(),0,kLVSmallIcons);
+      entry = new TTVLVEntry(fLVContainer,pic,spic,new TGString(),nullptr,kLVSmallIcons);
       entry->SetUserData(new ULong_t(kLTExpressionType | kLTDragType));
       entry->SetToolTipText("User defined expression/cut. Double-click to edit");
       fLVContainer->AddThisItem(entry);
@@ -1329,9 +1329,9 @@ void TTreeViewer::EmptyAll()
 
 void TTreeViewer::Empty()
 {
-   void *p = 0;
-   TTVLVEntry *item = 0;
-   if ((item = (TTVLVEntry *) fLVContainer->GetNextSelected(&p)) == 0) {
+   void *p = nullptr;
+   TTVLVEntry *item = nullptr;
+   if ((item = (TTVLVEntry *) fLVContainer->GetNextSelected(&p)) == nullptr) {
       Warning("Empty", "No item selected.");
       return;
    }
@@ -1389,7 +1389,7 @@ void TTreeViewer::ExecuteDraw()
    Int_t i;
    // fill in expressions
    if (fVarDraw) {
-      void *p = 0;
+      void *p = nullptr;
       dimension = 1;
       if (!(item = (TTVLVEntry *) fLVContainer->GetNextSelected(&p))) return;
       alias[0] = item->GetAlias();
@@ -1425,8 +1425,8 @@ void TTreeViewer::ExecuteDraw()
       return;
    }
    // find ListIn
-   fTree->SetEventList(0);
-   TEventList *elist = 0;
+   fTree->SetEventList(nullptr);
+   TEventList *elist = nullptr;
    if (strlen(fBarListIn->GetText())) {
       elist = (TEventList *) gROOT->FindObject(fBarListIn->GetText());
       if (elist) fTree->SetEventList(elist);
@@ -1597,8 +1597,8 @@ void TTreeViewer::ExecuteSpider()
       return;
    }
    // find ListIn
-   fTree->SetEventList(0);
-   TEventList *elist = 0;
+   fTree->SetEventList(nullptr);
+   TEventList *elist = nullptr;
    if (strlen(fBarListIn->GetText())) {
       elist = (TEventList *) gROOT->FindObject(fBarListIn->GetText());
       if (elist) fTree->SetEventList(elist);
@@ -1668,10 +1668,10 @@ const char* TTreeViewer::En(Int_t n)
 
 void TTreeViewer::EditExpression()
 {
-   void *p = 0;
+   void *p = nullptr;
    // get the selected item
-   TTVLVEntry *item = 0;
-   if ((item = (TTVLVEntry *) fLVContainer->GetNextSelected(&p)) == 0) {
+   TTVLVEntry *item = nullptr;
+   if ((item = (TTVLVEntry *) fLVContainer->GetNextSelected(&p)) == nullptr) {
       Warning("EditExpression", "No item selected.");
       return;
    }
@@ -1744,10 +1744,10 @@ Bool_t TTreeViewer::IsScanRedirected()
 
 void TTreeViewer::RemoveItem()
 {
-   void *p = 0;
-   TTVLVEntry *item = 0;
+   void *p = nullptr;
+   TTVLVEntry *item = nullptr;
    // get the selected item
-   if ((item = (TTVLVEntry *) fLVContainer->GetNextSelected(&p)) == 0) {
+   if ((item = (TTVLVEntry *) fLVContainer->GetNextSelected(&p)) == nullptr) {
       Warning("RemoveItem", "No item selected.");
       return;
    }
@@ -1828,9 +1828,9 @@ Bool_t TTreeViewer::ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t par
                // coverity[mixed_enums]
                if (((EMouseButton)parm1==kButton1) ||
                    ((EMouseButton)parm1==kButton3)) {
-                  TGListTreeItem *ltItem = 0;
+                  TGListTreeItem *ltItem = nullptr;
                   // get item that sent this
-                  if ((ltItem = fLt->GetSelected()) != 0) {
+                  if ((ltItem = fLt->GetSelected()) != nullptr) {
                   // get item type
                      ULong_t *itemType = (ULong_t *)ltItem->GetUserData();
                      if (!itemType)
@@ -2149,9 +2149,9 @@ Bool_t TTreeViewer::ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t par
                   case kButton1:
                      if (fLVContainer->NumSelected()) {
                      // get item that sent this
-                        void *p = 0;
+                        void *p = nullptr;
                         TTVLVEntry *item;
-                        if ((item = (TTVLVEntry *) fLVContainer->GetNextSelected(&p)) != 0) {
+                        if ((item = (TTVLVEntry *) fLVContainer->GetNextSelected(&p)) != nullptr) {
                            const char* vname = item->GetTrueName();
                            TString trueName(vname);
                            if (trueName.Contains("[]")) {
@@ -2218,11 +2218,11 @@ Bool_t TTreeViewer::ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t par
                   case kButton3:
                   // activate general context menu
                      if (fLVContainer->NumSelected()) {
-                        void *p = 0;
+                        void *p = nullptr;
                         Int_t x = (Int_t)(parm2 &0xffff);
                         Int_t y = (Int_t)((parm2 >> 16) & 0xffff);
-                        TTVLVEntry *item = 0;
-                        if ((item = (TTVLVEntry *) fLVContainer->GetNextSelected(&p)) != 0) {
+                        TTVLVEntry *item = nullptr;
+                        if ((item = (TTVLVEntry *) fLVContainer->GetNextSelected(&p)) != nullptr) {
                            fContextMenu->Popup(x, y, item->GetContext());
                         }
                      } else {        // empty click
@@ -2240,9 +2240,9 @@ Bool_t TTreeViewer::ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t par
                   case kButton1:
                      if (fLVContainer->NumSelected()) {
                      // get item that sent this
-                        void *p = 0;
+                        void *p = nullptr;
                         TTVLVEntry *item;
-                        if ((item = (TTVLVEntry *) fLVContainer->GetNextSelected(&p)) != 0) {
+                        if ((item = (TTVLVEntry *) fLVContainer->GetNextSelected(&p)) != nullptr) {
                         // get item type
                            ULong_t *itemType = (ULong_t *) item->GetUserData();
                            if (!(*itemType & kLTCutType) && !(*itemType & kLTBranchType)
@@ -2449,7 +2449,7 @@ void TTreeViewer::MapTree(TTree *tree, TGListTreeItem *parent, Bool_t listIt)
    // tell who was last mapped
    if (listIt) {
       fMappedTree    = tree;
-      fMappedBranch  = 0;
+      fMappedBranch  = nullptr;
    }
 }
 
@@ -2467,7 +2467,7 @@ void TTreeViewer::MapBranch(TBranch *branch, const char *prefix, TGListTreeItem 
    }
    else name = branch->GetName();
    Int_t ind;
-   TGListTreeItem *branchItem = 0;
+   TGListTreeItem *branchItem = nullptr;
    ULong_t *itemType;
    // map this branch
    if (name.Contains("fBits") || name.Contains("fUniqueID")) return;
@@ -2498,7 +2498,7 @@ void TTreeViewer::MapBranch(TBranch *branch, const char *prefix, TGListTreeItem 
                spic = gClient->GetPicture("branch_t.xpm");
                branchItem = fLt->AddItem(parent, EmptyBrackets(name), itemType,pic, spic);
                TObjArray *leaves = branch->GetListOfLeaves();
-               TLeaf *leaf = 0;
+               TLeaf *leaf = nullptr;
                TString leafName;
                for (Int_t lf=0; lf<leaves->GetEntries(); lf++) {
                   leaf = (TLeaf *)leaves->At(lf);
@@ -2521,13 +2521,13 @@ void TTreeViewer::MapBranch(TBranch *branch, const char *prefix, TGListTreeItem 
    }
    // list branch in list view if necessary
    if (listIt) {
-      TGString *textEntry = 0;
+      TGString *textEntry = nullptr;
       const TGPicture *pic, *spic;
       TTVLVEntry *entry;
       // make list view items in the right frame
       if (!fStopMapping) {
          fMappedBranch = branch;
-         fMappedTree = 0;
+         fMappedTree = nullptr;
          fStopMapping = kTRUE;
       }
       if ((branch->GetListOfBranches()->GetEntries()) ||
@@ -2546,7 +2546,7 @@ void TTreeViewer::MapBranch(TBranch *branch, const char *prefix, TGListTreeItem 
                   spic = gClient->GetPicture("branch_t.xpm");
                }
             }
-            entry = new TTVLVEntry(fLVContainer,pic,spic,textEntry,0,kLVSmallIcons);
+            entry = new TTVLVEntry(fLVContainer,pic,spic,textEntry,nullptr,kLVSmallIcons);
             entry->SetUserData(new UInt_t(kLTBranchType));
             entry->SetToolTipText("Branch with sub-branches. Can not be dragged");
             fLVContainer->AddThisItem(entry);
@@ -2558,7 +2558,7 @@ void TTreeViewer::MapBranch(TBranch *branch, const char *prefix, TGListTreeItem 
                textEntry = new TGString(EmptyBrackets(name.Data()));
                pic = gClient->GetPicture("branch_t.xpm");
                spic = gClient->GetPicture("branch_t.xpm");
-               entry = new TTVLVEntry(fLVContainer, pic, spic, textEntry,0,kLVSmallIcons);
+               entry = new TTVLVEntry(fLVContainer, pic, spic, textEntry,nullptr,kLVSmallIcons);
                entry->SetUserData(new UInt_t(kLTBranchType));
                entry->SetToolTipText("Branch with more than one leaf. Can not be dragged");
                fLVContainer->AddThisItem(entry);
@@ -2566,7 +2566,7 @@ void TTreeViewer::MapBranch(TBranch *branch, const char *prefix, TGListTreeItem 
                entry->SetAlias(textEntry->GetString());
 
                TObjArray *leaves = branch->GetListOfLeaves();
-               TLeaf *leaf = 0;
+               TLeaf *leaf = nullptr;
                TString leafName;
                for (Int_t lf=0; lf<leaves->GetEntries(); lf++) {
                   leaf = (TLeaf *)leaves->At(lf);
@@ -2576,7 +2576,7 @@ void TTreeViewer::MapBranch(TBranch *branch, const char *prefix, TGListTreeItem 
                   textEntry = new TGString(leafName.Data());
                   pic = gClient->GetPicture("leaf_t.xpm");
                   spic = gClient->GetPicture("leaf_t.xpm");
-                  entry = new TTVLVEntry(fLVContainer, pic, spic, textEntry,0,kLVSmallIcons);
+                  entry = new TTVLVEntry(fLVContainer, pic, spic, textEntry,nullptr,kLVSmallIcons);
                   entry->SetUserData(new UInt_t(kLTDragType | kLTLeafType));
                   entry->SetToolTipText("Double-click to draw. Drag to X, Y, Z or scan box.");
                   fLVContainer->AddThisItem(entry);
@@ -2588,7 +2588,7 @@ void TTreeViewer::MapBranch(TBranch *branch, const char *prefix, TGListTreeItem 
                if (!pic) pic = gClient->GetPicture("leaf_t.xpm");
                spic = gClient->GetMimeTypeList()->GetIcon("TLeaf",kTRUE);
                if (!spic) spic = gClient->GetPicture("leaf_t.xpm");
-               entry = new TTVLVEntry(fLVContainer,pic,spic,textEntry,0,kLVSmallIcons);
+               entry = new TTVLVEntry(fLVContainer,pic,spic,textEntry,nullptr,kLVSmallIcons);
                entry->SetUserData(new UInt_t(kLTDragType | kLTLeafType));
                entry->SetToolTipText("Double-click to draw. Drag to X, Y, Z or scan box.");
                fLVContainer->AddThisItem(entry);
@@ -2600,7 +2600,7 @@ void TTreeViewer::MapBranch(TBranch *branch, const char *prefix, TGListTreeItem 
    }
 
    TObjArray *branches = branch->GetListOfBranches();
-   TBranch   *branchDaughter = 0;
+   TBranch   *branchDaughter = nullptr;
 
    // loop all sub-branches
    for (ind=0; ind<branches->GetEntries(); ind++) {
@@ -2620,7 +2620,7 @@ void TTreeViewer::NewExpression()
    const TGPicture *spic = gClient->GetPicture("expression_t.xpm");
 
    TTVLVEntry *entry = new TTVLVEntry(fLVContainer,pic,spic,
-                                            new TGString(),0,kLVSmallIcons);
+                                            new TGString(),nullptr,kLVSmallIcons);
    entry->SetUserData(new ULong_t(kLTExpressionType | kLTDragType));
    fLVContainer->AddThisItem(entry);
    entry->MapWindow();
@@ -2639,7 +2639,7 @@ void TTreeViewer::SetParentTree(TGListTreeItem *item)
    if (!item) return;
    ULong_t *itemType = (ULong_t *)item->GetUserData();
    if (!itemType) return;
-   TGListTreeItem *parent = 0;
+   TGListTreeItem *parent = nullptr;
    Int_t index;
    if (!(*itemType & kLTTreeType)) {
       parent = item->GetParent();


### PR DESCRIPTION
Automatic suggestions by `clang-tidy`. Only the trivial `nullptr` changes, such that the remaining suggestions get easier to review in isolation.

