### PR TITLE
Extend `TColor::DefinedColors()` functionality

### DIFF
--- a/core/base/inc/TColor.h
+++ b/core/base/inc/TColor.h
@@ -100,7 +100,7 @@ public:
    static const char *PixelAsHexString(ULong_t pixel);
    static Bool_t  SaveColor(std::ostream &out, Int_t ci);
    static void    SetColorThreshold(Float_t t);
-   static Bool_t  DefinedColors();
+   static Bool_t  DefinedColors(Int_t set_always_on = 0);
    static void    InvertPalette();
    static Bool_t  IsGrayscale();
    static void    SetGrayscale(Bool_t set = kTRUE);

--- a/core/base/inc/TColorGradient.h
+++ b/core/base/inc/TColorGradient.h
@@ -67,6 +67,7 @@ private:
    ECoordinateMode fCoordinateMode = kObjectBoundingMode;
 
 public:
+   TColorGradient() {}
    TColorGradient(Color_t newColor, UInt_t nPoints, const Double_t *points,
                   const Color_t *colorIndices, ECoordinateMode mode = kObjectBoundingMode);
    TColorGradient(Color_t newColor, UInt_t nPoints, const Double_t *points,
@@ -98,6 +99,8 @@ public:
    //With C++11 we'll use inherited constructors!!!
    using TColorGradient::TColorGradient;
 
+   TLinearGradient() {}
+
    //points are always in NDC (and also affected by fCoordinateMode).
    void SetStartEnd(const Point &p1, const Point &p2);
    const Point &GetStart() const;
@@ -127,6 +130,8 @@ public:
 
    //With C++11 we'll use inherited constructors!!!
    using TColorGradient::TColorGradient;
+
+   TRadialGradient() {}
 
    EGradientType GetGradientType()const;
 

--- a/core/base/src/TColor.cxx
+++ b/core/base/src/TColor.cxx
@@ -1474,12 +1474,23 @@ Int_t TColor::GetNumberOfColors()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Static function returning kTRUE if some new colors have been defined after
+/// Static method returning kTRUE if some new colors have been defined after
 /// initialisation or since the last call to this method. This allows to avoid
 /// the colors and palette streaming in TCanvas::Streamer if not needed.
+/// If method called once with set_always_on = 1, all next canvases will be
+//  saved with color palette - disregard if new colors created or not.
+/// To reset such mode, just call methoid once with set_always_on = -1
 
-Bool_t TColor::DefinedColors()
+Bool_t TColor::DefinedColors(Int_t set_always_on)
 {
+   if (set_always_on > 0)
+      gLastDefinedColors = -1;
+   else if (set_always_on < 0)
+      gLastDefinedColors = gDefinedColors;
+
+   if (gLastDefinedColors < 0)
+      return kTRUE;
+
    // After initialization gDefinedColors == 649. If it is bigger it means some new
    // colors have been defined
    Bool_t hasChanged = (gDefinedColors - gLastDefinedColors) > 50;

--- a/graf2d/gpad/src/TCanvas.cxx
+++ b/graf2d/gpad/src/TCanvas.cxx
@@ -2241,6 +2241,8 @@ void TCanvas::Streamer(TBuffer &b)
       //restore the colors
       auto colors = dynamic_cast<TObjArray *>(fPrimitives->FindObject("ListOfColors"));
       if (colors) {
+         auto root_colors = dynamic_cast<TObjArray *>(gROOT->GetListOfColors());
+
          TIter next(colors);
          while (auto colold = static_cast<TColor *>(next())) {
             Int_t cn = colold->GetNumber();
@@ -2251,11 +2253,11 @@ void TCanvas::Streamer(TBuffer &b)
                colcur->SetAlpha(colold->GetAlpha());
             } else {
                if (colcur) {
-                  gROOT->GetListOfColors()->Remove(colcur);
+                  if (root_colors) root_colors->Remove(colcur);
                   delete colcur;
                }
-               gROOT->GetListOfColors()->Add(colold);
                colors->Remove(colold);
+               if (root_colors) root_colors->AddAtAndExpand(colold, cn);
             }
          }
          //restore the palette if needed

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -7026,26 +7026,22 @@ TVirtualViewer3D *TPad::GetViewer3D(Option_t *type)
 {
    Bool_t validType = kFALSE;
 
-   if ( (!type || !type[0] || (strstr(type, "gl") && !strstr(type, "ogl"))) && !fCanvas->UseGL())
+   if ((!type || !*type || (strstr(type, "gl") && !strstr(type, "ogl"))) && (!fCanvas || !fCanvas->UseGL()))
       type = "pad";
 
-   if (type && type[0]) {
-
+   if (type && *type) {
       if (gPluginMgr->FindHandler("TVirtualViewer3D", type))
          validType = kTRUE;
-
    }
 
    // Invalid/null type requested?
    if (!validType) {
       // Return current viewer if there is one
-      if (fViewer3D) {
+      if (fViewer3D)
          return fViewer3D;
-      }
       // otherwise default to the pad
-      else {
+      else
          type = "pad";
-      }
    }
 
    // Ensure we can create the new viewer before removing any existing one
@@ -7055,22 +7051,25 @@ TVirtualViewer3D *TPad::GetViewer3D(Option_t *type)
 
    // External viewers need to be created via plugin manager via interface...
    if (!strstr(type,"pad")) {
-      newViewer = TVirtualViewer3D::Viewer3D(this,type);
+      newViewer = TVirtualViewer3D::Viewer3D(this, type);
 
       if (!newViewer) {
-         Warning("TPad::CreateViewer3D", "Cannot create 3D viewer of type: %s", type);
-
+         Warning("GetViewer3D", "Cannot create 3D viewer of type: %s", type);
          // Return the existing viewer
          return fViewer3D;
       }
 
-      if (strstr(type, "gl") && !strstr(type, "ogl"))
-         fEmbeddedGL = kTRUE, fCopyGLDevice = kTRUE, Modified();
-      else
+      if (strstr(type, "gl") && !strstr(type, "ogl")) {
+         fEmbeddedGL = kTRUE;
+         fCopyGLDevice = kTRUE;
+         Modified();
+      } else {
          createdExternal = kTRUE;
+      }
 
-   } else
+   } else {
       newViewer = new TViewer3DPad(*this);
+   }
 
    // If we had a previous viewer destroy it now
    // In this case we do take responsibility for destroying viewer

--- a/graf3d/gviz3d/src/TStructViewerGUI.cxx
+++ b/graf3d/gviz3d/src/TStructViewerGUI.cxx
@@ -47,7 +47,7 @@ ClassImp(TStructViewerGUI);
 //
 //////////////////////////////////////////////////////////////////////////
 
-TGeoMedium* TStructViewerGUI::fgMedium = NULL;
+TGeoMedium* TStructViewerGUI::fgMedium = nullptr;
 UInt_t      TStructViewerGUI::fgCounter = 0;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -813,18 +813,24 @@ void TStructViewerGUI::UnCheckMaxObjects()
 
 void TStructViewerGUI::Update(Bool_t resetCamera)
 {
-   if (!fNodePtr) {
+   if (!fNodePtr)
       return;
-   }
 
-   fCanvas->GetListOfPrimitives()->Clear();
-   fTopVolume->ClearNodes();
+   if (fCanvas && fCanvas->GetListOfPrimitives())
+      fCanvas->GetListOfPrimitives()->Clear();
+
+   if (fTopVolume)
+      fTopVolume->ClearNodes();
+
    Draw();
-   fCanvas->GetListOfPrimitives()->Add(fTopVolume);
-   fGLViewer->UpdateScene();
 
-   if(resetCamera) {
-      fGLViewer->ResetCurrentCamera();
+   if (fCanvas && fCanvas->GetListOfPrimitives())
+      fCanvas->GetListOfPrimitives()->Add(fTopVolume);
+
+   if (fGLViewer) {
+      fGLViewer->UpdateScene();
+      if(resetCamera)
+         fGLViewer->ResetCurrentCamera();
    }
 }
 

--- a/tutorials/gl/gviz3d.C
+++ b/tutorials/gl/gviz3d.C
@@ -6,60 +6,61 @@
 ///
 /// \author  Timur Pocheptsov
 
-#include <TRandom.h>
-#include <TList.h>
-#include <TROOT.h>
+#include "TRandom.h"
+#include "TList.h"
+#include "TROOT.h"
+#include "TStructViewer.h"
+
+const Int_t ncl =12;
+const char *clnames[ncl] = {"TH1F","TGraph","TGraphErrors","TF1","TPaveText",
+                            "TAxis","TF2","TH2D","TLatex","TText","TCutG","THnSparseF"};
 
 // Function creating elements of lists
-void MakeCrazy(TList *list, Int_t maxDepth, Int_t maxObjects, Float_t pList) {
-   const Int_t ncl =12;
-   const char *clnames[ncl] = {"TH1F","TGraph","TGraphErrors","TF1","TPaveText",
-      "TAxis","TF2","TH2D","TLatex","TText","TCutG","THnSparseF"};
-      Int_t nobj = gRandom->Uniform(0,maxObjects);
-      for (Int_t i=0;i<nobj;i++) {
-         if (maxDepth && gRandom->Rndm() < pList) {
-            TList *slist = new TList();
-            slist->SetName(Form("list_%d_%d",maxDepth,i));
-            list->Add(slist);
-            MakeCrazy(slist,maxDepth-1,maxObjects,pList);
-         } else {
-            Int_t icl = (Int_t)gRandom->Uniform(0,ncl);
-            TNamed *named = (TNamed*)gROOT->ProcessLine(Form("new %s;",clnames[icl]));
-            named->SetName(Form("%s_%d_%d",clnames[icl],maxDepth,i));
-            list->Add(named);
-         }
+void MakeCrazy(TList *list, Int_t maxDepth, Int_t maxObjects, Float_t pList)
+{
+   Int_t nobj = gRandom->Uniform(0,maxObjects);
+   for (Int_t i = 0; i < nobj; i++) {
+      if (maxDepth && gRandom->Rndm() < pList) {
+         TList *slist = new TList();
+         slist->SetName(Form("list_%d_%d",maxDepth,i));
+         list->Add(slist);
+         MakeCrazy(slist,maxDepth-1,maxObjects,pList);
+      } else {
+         Int_t icl = (Int_t)gRandom->Uniform(0,ncl);
+         TNamed *named = (TNamed*)gROOT->ProcessLine(Form("new %s;",clnames[icl]));
+         named->SetName(Form("%s_%d_%d",clnames[icl],maxDepth,i));
+         list->Add(named);
       }
+   }
 }
 
-// function creating a hierachy of objects to test the TStructViewer
-TList *crazy(Int_t maxDepth=5, Int_t maxObjects=20, Float_t pList=0.2) {
+// function creating a hierarchy of objects to test the TStructViewer
+TList *crazy(Int_t maxDepth=5, Int_t maxObjects=20, Float_t pList=0.2)
+{
    TList *list = new TList();
    list->SetName("SuperList");
    MakeCrazy(list,maxDepth,maxObjects,pList);
    gROOT->GetListOfTasks()->Add(list);
    return list;
 }
+
 // function adding colors to viewer
 void FillColorsMap(TStructViewer* sv)
 {
-   // Fills list fColors with TStructNodeProperty
-  const Int_t ncl =12;
-  const char *clnames[ncl] = {"TH1F","TGraph","TGraphErrors","TF1","TPaveText",
-    "TAxis","TF2","TH2D","TLatex","TText","TCutG","THnSparseF"};
-
-  for (int i = 0; i < ncl ; i++) {
-    sv->SetColor(clnames[i], (Int_t)gRandom->Integer(8)+2);
-  }
+  for (int i = 0; i < ncl ; i++)
+     sv->SetColor(clnames[i], (Int_t)gRandom->Integer(8)+2);
 }
-
 
 void gviz3d()
 {
    // Creating a pointer to list
    TList* pointer = crazy(2,10);
+
    // Creating a viewer
    TStructViewer* sv = new TStructViewer(pointer);
+
    // adding colors
    FillColorsMap(sv);
+
    sv->Draw();
 }


### PR DESCRIPTION
1. If called once with argument TColor::DefinedColors(1), all saved canvas will include color and palette. One can reset flag with TColor::DefinedColors(-1)

2. When reading canvas with stored colors - correctly restore all colors attributes and support gradients

3. Provide default constructors for color gradient classes. Let correctly read canvases with gradients

4. Fix TPad::GetViewer3D(), prevent crash in gviz3d.C tutorial
 