### PR TITLE
[tree] Apply suggestions from clang-tidy

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -571,7 +571,7 @@ void JitVariationHelper(F &&f, const char **colsPtr, std::size_t colsSize, const
    // use unique_ptr<RDefineBase> instead of make_unique<NewCol_t> to reduce jit/compile-times
    std::unique_ptr<RVariationBase> newVariation{new RVariation<std::decay_t<F>, IsSingleColumn>(
       std::move(variedColNames), variationName, std::forward<F>(f), std::move(tags), jittedVariation->GetTypeName(),
-      *colRegister, *lm, std::move(inputColNames))};
+      *colRegister, *lm, inputColNames)};
    jittedVariation->SetVariation(std::move(newVariation));
 
    doDeletes();

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -2925,8 +2925,8 @@ private:
                                             const std::vector<std::string> &variationTags,
                                             std::string_view variationName, bool isSingleColumn)
    {
-      R__ASSERT(variationTags.size() > 0 && "Must have at least one variation.");
-      R__ASSERT(colNames.size() > 0 && "Must have at least one varied column.");
+      R__ASSERT(!variationTags.empty() && "Must have at least one variation.");
+      R__ASSERT(!colNames.empty() && "Must have at least one varied column.");
       R__ASSERT(!variationName.empty() && "Must provide a variation name.");
 
       for (auto &colName : colNames) {

--- a/tree/dataframe/inc/ROOT/RDF/RInterfaceBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterfaceBase.hxx
@@ -71,8 +71,8 @@ protected:
    void SanityChecksForVary(const std::vector<std::string> &colNames, const std::vector<std::string> &variationTags,
                             std::string_view variationName)
    {
-      R__ASSERT(variationTags.size() > 0 && "Must have at least one variation.");
-      R__ASSERT(colNames.size() > 0 && "Must have at least one varied column.");
+      R__ASSERT(!variationTags.empty() && "Must have at least one variation.");
+      R__ASSERT(!colNames.empty() && "Must have at least one varied column.");
       R__ASSERT(!variationName.empty() && "Must provide a variation name.");
 
       for (auto &colName : colNames) {

--- a/tree/dataframe/inc/ROOT/RDataFrame.hxx
+++ b/tree/dataframe/inc/ROOT/RDataFrame.hxx
@@ -46,7 +46,7 @@ public:
               const ColumnNames_t &defaultColumns = {});
    RDataFrame(std::string_view treename, std::initializer_list<std::string> filenames,
               const ColumnNames_t &defaultColumns = {}):
-              RDataFrame(treename, std::vector<std::string>(std::move(filenames)), defaultColumns) {}
+              RDataFrame(treename, std::vector<std::string>(filenames), defaultColumns) {}
    RDataFrame(std::string_view treeName, ::TDirectory *dirPtr, const ColumnNames_t &defaultColumns = {});
    RDataFrame(TTree &tree, const ColumnNames_t &defaultColumns = {});
    RDataFrame(ULong64_t numEntries);

--- a/tree/dataframe/src/RArrowDS.cxx
+++ b/tree/dataframe/src/RArrowDS.cxx
@@ -115,58 +115,58 @@ public:
    void SetEntry(ULong64_t entry) { fCurrentEntry = entry; }
 
    /// Check if we are asking the same entry as before.
-   virtual arrow::Status Visit(arrow::Int32Array const &array) final
+   arrow::Status Visit(arrow::Int32Array const &array) final
    {
       *fResult = (void *)(array.raw_values() + fCurrentEntry);
       return arrow::Status::OK();
    }
 
-   virtual arrow::Status Visit(arrow::Int64Array const &array) final
+   arrow::Status Visit(arrow::Int64Array const &array) final
    {
       *fResult = (void *)(array.raw_values() + fCurrentEntry);
       return arrow::Status::OK();
    }
 
    /// Check if we are asking the same entry as before.
-   virtual arrow::Status Visit(arrow::UInt32Array const &array) final
+   arrow::Status Visit(arrow::UInt32Array const &array) final
    {
       *fResult = (void *)(array.raw_values() + fCurrentEntry);
       return arrow::Status::OK();
    }
 
-   virtual arrow::Status Visit(arrow::UInt64Array const &array) final
+   arrow::Status Visit(arrow::UInt64Array const &array) final
    {
       *fResult = (void *)(array.raw_values() + fCurrentEntry);
       return arrow::Status::OK();
    }
 
-   virtual arrow::Status Visit(arrow::FloatArray const &array) final
+   arrow::Status Visit(arrow::FloatArray const &array) final
    {
       *fResult = (void *)(array.raw_values() + fCurrentEntry);
       return arrow::Status::OK();
    }
 
-   virtual arrow::Status Visit(arrow::DoubleArray const &array) final
+   arrow::Status Visit(arrow::DoubleArray const &array) final
    {
       *fResult = (void *)(array.raw_values() + fCurrentEntry);
       return arrow::Status::OK();
    }
 
-   virtual arrow::Status Visit(arrow::BooleanArray const &array) final
+   arrow::Status Visit(arrow::BooleanArray const &array) final
    {
       fCachedBool = array.Value(fCurrentEntry);
       *fResult = reinterpret_cast<void *>(&fCachedBool);
       return arrow::Status::OK();
    }
 
-   virtual arrow::Status Visit(arrow::StringArray const &array) final
+   arrow::Status Visit(arrow::StringArray const &array) final
    {
       fCachedString = array.GetString(fCurrentEntry);
       *fResult = reinterpret_cast<void *>(&fCachedString);
       return arrow::Status::OK();
    }
 
-   virtual arrow::Status Visit(arrow::ListArray const &array) final
+   arrow::Status Visit(arrow::ListArray const &array) final
    {
       switch (array.value_type()->id()) {
       case arrow::Type::FLOAT: {
@@ -367,15 +367,15 @@ public:
 class VerifyValidColumnType : public ::arrow::TypeVisitor {
 private:
 public:
-   virtual arrow::Status Visit(const arrow::Int64Type &) override { return arrow::Status::OK(); }
-   virtual arrow::Status Visit(const arrow::UInt64Type &) override { return arrow::Status::OK(); }
-   virtual arrow::Status Visit(const arrow::Int32Type &) override { return arrow::Status::OK(); }
-   virtual arrow::Status Visit(const arrow::UInt32Type &) override { return arrow::Status::OK(); }
-   virtual arrow::Status Visit(const arrow::FloatType &) override { return arrow::Status::OK(); }
-   virtual arrow::Status Visit(const arrow::DoubleType &) override { return arrow::Status::OK(); }
-   virtual arrow::Status Visit(const arrow::StringType &) override { return arrow::Status::OK(); }
-   virtual arrow::Status Visit(const arrow::BooleanType &) override { return arrow::Status::OK(); }
-   virtual arrow::Status Visit(const arrow::ListType &) override { return arrow::Status::OK(); }
+   arrow::Status Visit(const arrow::Int64Type &) override { return arrow::Status::OK(); }
+   arrow::Status Visit(const arrow::UInt64Type &) override { return arrow::Status::OK(); }
+   arrow::Status Visit(const arrow::Int32Type &) override { return arrow::Status::OK(); }
+   arrow::Status Visit(const arrow::UInt32Type &) override { return arrow::Status::OK(); }
+   arrow::Status Visit(const arrow::FloatType &) override { return arrow::Status::OK(); }
+   arrow::Status Visit(const arrow::DoubleType &) override { return arrow::Status::OK(); }
+   arrow::Status Visit(const arrow::StringType &) override { return arrow::Status::OK(); }
+   arrow::Status Visit(const arrow::BooleanType &) override { return arrow::Status::OK(); }
+   arrow::Status Visit(const arrow::ListType &) override { return arrow::Status::OK(); }
 
    using ::arrow::TypeVisitor::Visit;
 };

--- a/tree/dataframe/src/RDFHelpers.cxx
+++ b/tree/dataframe/src/RDFHelpers.cxx
@@ -24,7 +24,7 @@
 #include <algorithm>
 #include <iostream>
 #include <set>
-#include <stdio.h>
+#include <cstdio>
 
 // TODO, this function should be part of core libraries
 #include <numeric>
@@ -355,7 +355,7 @@ public:
    // dummy implementation of PartialUpdate
    int &PartialUpdate(unsigned int) { return *fDummyResult; }
 
-   ROOT::RDF::SampleCallback_t GetSampleCallback()
+   ROOT::RDF::SampleCallback_t GetSampleCallback() final
    {
       return [this](unsigned int slot, const ROOT::RDF::RSampleInfo &id) {
          this->fHelper->registerNewSample(slot, id);

--- a/tree/dataframe/src/RDFHistoModels.cxx
+++ b/tree/dataframe/src/RDFHistoModels.cxx
@@ -12,7 +12,7 @@
 #include <ROOT/TSeq.hxx>
 #include <TProfile.h>
 #include <TProfile2D.h>
-#include <stddef.h>
+#include <cstddef>
 #include <vector>
 
 #include "TAxis.h"
@@ -268,7 +268,7 @@ std::shared_ptr<::THnD> THnDModel::GetHistogram() const
 {
    bool varbinning = false;
    for (const auto &bins : fBinEdges) {
-      if (bins.size()) {
+      if (!bins.empty()) {
          varbinning = true;
          break;
       }

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -92,7 +92,7 @@ struct ParsedExpression {
 };
 
 /// Look at expression `expr` and return a pair of (column names used, aliases used)
-static std::pair<ColumnNames_t, ColumnNames_t>
+std::pair<ColumnNames_t, ColumnNames_t>
 FindUsedColsAndAliases(const std::string &expr, const ColumnNames_t &treeBranchNames,
                        const ROOT::Internal::RDF::RColumnRegister &colRegister, const ColumnNames_t &dataSourceColNames)
 {
@@ -155,7 +155,7 @@ FindUsedColsAndAliases(const std::string &expr, const ColumnNames_t &treeBranchN
 }
 
 /// Substitute each '.' in a string with '\.'
-static std::string EscapeDots(const std::string &s)
+std::string EscapeDots(const std::string &s)
 {
    TString out(s);
    TPRegexp dot("\\.");
@@ -163,7 +163,7 @@ static std::string EscapeDots(const std::string &s)
    return std::string(std::move(out));
 }
 
-static TString ResolveAliases(const TString &expr, const ColumnNames_t &usedAliases,
+TString ResolveAliases(const TString &expr, const ColumnNames_t &usedAliases,
                               const ROOT::Internal::RDF::RColumnRegister &colRegister)
 {
    TString out(expr);
@@ -177,7 +177,7 @@ static TString ResolveAliases(const TString &expr, const ColumnNames_t &usedAlia
    return out;
 }
 
-static ParsedExpression ParseRDFExpression(std::string_view expr, const ColumnNames_t &treeBranchNames,
+ParsedExpression ParseRDFExpression(std::string_view expr, const ColumnNames_t &treeBranchNames,
                                            const ROOT::Internal::RDF::RColumnRegister &colRegister,
                                            const ColumnNames_t &dataSourceColNames)
 {
@@ -226,12 +226,12 @@ static ParsedExpression ParseRDFExpression(std::string_view expr, const ColumnNa
 /// jitted variable that corresponds to that expression. For example, for:
 ///     auto f1(){ return 42; }
 /// key would be "(){ return 42; }" and value would be "f1".
-static std::unordered_map<std::string, std::string> &GetJittedExprs() {
+std::unordered_map<std::string, std::string> &GetJittedExprs() {
    static std::unordered_map<std::string, std::string> jittedExpressions;
    return jittedExpressions;
 }
 
-static std::string
+std::string
 BuildFunctionString(const std::string &expr, const ColumnNames_t &vars, const ColumnNames_t &varTypes)
 {
    assert(vars.size() == varTypes.size());
@@ -301,7 +301,7 @@ BuildFunctionString(const std::string &expr, const ColumnNames_t &vars, const Co
 
 /// Declare a function to the interpreter in namespace R_rdf, return the name of the jitted function.
 /// If the function is already in GetJittedExprs, return the name for the function that has already been jitted.
-static std::string DeclareFunction(const std::string &expr, const ColumnNames_t &vars, const ColumnNames_t &varTypes)
+std::string DeclareFunction(const std::string &expr, const ColumnNames_t &vars, const ColumnNames_t &varTypes)
 {
    R__LOCKGUARD(gROOTMutex);
 
@@ -321,7 +321,7 @@ static std::string DeclareFunction(const std::string &expr, const ColumnNames_t 
    const auto toDeclare = "namespace R_rdf {\nauto " + funcBaseName + funcCode + "\nusing " + funcBaseName +
                           "_ret_t = typename ROOT::TypeTraits::CallableTraits<decltype(" + funcBaseName +
                           ")>::ret_type;\n}";
-   ROOT::Internal::RDF::InterpreterDeclare(toDeclare.c_str());
+   ROOT::Internal::RDF::InterpreterDeclare(toDeclare);
 
    // InterpreterDeclare could throw. If it doesn't, mark the function as already jitted
    exprMap.insert({funcCode, funcFullName});
@@ -331,7 +331,7 @@ static std::string DeclareFunction(const std::string &expr, const ColumnNames_t 
 
 /// Each jitted function comes with a func_ret_t type alias for its return type.
 /// Resolve that alias and return the true type as string.
-static std::string RetTypeOfFunc(const std::string &funcName)
+std::string RetTypeOfFunc(const std::string &funcName)
 {
    const auto dt = gROOT->GetType((funcName + "_ret_t").c_str());
    R__ASSERT(dt != nullptr);
@@ -913,7 +913,7 @@ ColumnNames_t GetValidatedColumnNames(RLoopManager &lm, const unsigned int nColu
       for (auto &unknownColumn : unknownColumns)
          errMsg += '"' + unknownColumn + "\", ";
       errMsg.resize(errMsg.size() - 2); // remove last ", "
-      throw std::runtime_error(std::move(errMsg));
+      throw std::runtime_error(errMsg);
    }
 
    return selectedColumns;

--- a/tree/dataframe/src/RDFUtils.cxx
+++ b/tree/dataframe/src/RDFUtils.cxx
@@ -53,7 +53,7 @@ const std::type_info &TypeName2TypeID(const std::string &name)
    if (auto c = TClass::GetClass(name.c_str())) {
       if (!c->GetTypeInfo()) {
          std::string msg("Cannot extract type_info of type ");
-         msg += name.c_str();
+         msg += name;
          msg += ".";
          throw std::runtime_error(msg);
       }
@@ -86,7 +86,7 @@ const std::type_info &TypeName2TypeID(const std::string &name)
       return typeid(bool);
    else {
       std::string msg("Cannot extract type_info of type ");
-      msg += name.c_str();
+      msg += name;
       msg += ".";
       throw std::runtime_error(msg);
    }

--- a/tree/dataframe/src/RDataFrame.cxx
+++ b/tree/dataframe/src/RDataFrame.cxx
@@ -1693,7 +1693,7 @@ namespace Experimental {
 ROOT::RDataFrame FromSpec(const std::string &jsonFile)
 {
    const nlohmann::ordered_json fullData = nlohmann::ordered_json::parse(std::ifstream(jsonFile));
-   if (!fullData.contains("samples") || fullData["samples"].size() == 0) {
+   if (!fullData.contains("samples") || fullData["samples"].empty()) {
       throw std::runtime_error(
          R"(The input specification does not contain any samples. Please provide the samples in the specification like:
 {

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -59,13 +59,13 @@ namespace {
 /// We want RLoopManagers to be able to add their code to a global "code to execute via cling",
 /// so that, lazily, we can jit everything that's needed by all RDFs in one go, which is potentially
 /// much faster than jitting each RLoopManager's code separately.
-static std::string &GetCodeToJit()
+std::string &GetCodeToJit()
 {
    static std::string code;
    return code;
 }
 
-static bool ContainsLeaf(const std::set<TLeaf *> &leaves, TLeaf *leaf)
+bool ContainsLeaf(const std::set<TLeaf *> &leaves, TLeaf *leaf)
 {
    return (leaves.find(leaf) != leaves.end());
 }
@@ -73,7 +73,7 @@ static bool ContainsLeaf(const std::set<TLeaf *> &leaves, TLeaf *leaf)
 ///////////////////////////////////////////////////////////////////////////////
 /// This overload does not check whether the leaf/branch is already in bNamesReg. In case this is a friend leaf/branch,
 /// `allowDuplicates` controls whether we add both `friendname.bname` and `bname` or just the shorter version.
-static void InsertBranchName(std::set<std::string> &bNamesReg, ColumnNames_t &bNames, const std::string &branchName,
+void InsertBranchName(std::set<std::string> &bNamesReg, ColumnNames_t &bNames, const std::string &branchName,
                              const std::string &friendName, bool allowDuplicates)
 {
    if (!friendName.empty()) {
@@ -91,7 +91,7 @@ static void InsertBranchName(std::set<std::string> &bNamesReg, ColumnNames_t &bN
 
 ///////////////////////////////////////////////////////////////////////////////
 /// This overload makes sure that the TLeaf has not been already inserted.
-static void InsertBranchName(std::set<std::string> &bNamesReg, ColumnNames_t &bNames, const std::string &branchName,
+void InsertBranchName(std::set<std::string> &bNamesReg, ColumnNames_t &bNames, const std::string &branchName,
                              const std::string &friendName, std::set<TLeaf *> &foundLeaves, TLeaf *leaf,
                              bool allowDuplicates)
 {
@@ -105,7 +105,7 @@ static void InsertBranchName(std::set<std::string> &bNamesReg, ColumnNames_t &bN
    foundLeaves.insert(leaf);
 }
 
-static void ExploreBranch(TTree &t, std::set<std::string> &bNamesReg, ColumnNames_t &bNames, TBranch *b,
+void ExploreBranch(TTree &t, std::set<std::string> &bNamesReg, ColumnNames_t &bNames, TBranch *b,
                           std::string prefix, std::string &friendName, bool allowDuplicates)
 {
    for (auto sb : *b->GetListOfBranches()) {
@@ -131,7 +131,7 @@ static void ExploreBranch(TTree &t, std::set<std::string> &bNamesReg, ColumnName
    }
 }
 
-static void GetBranchNamesImpl(TTree &t, std::set<std::string> &bNamesReg, ColumnNames_t &bNames,
+void GetBranchNamesImpl(TTree &t, std::set<std::string> &bNamesReg, ColumnNames_t &bNames,
                                std::set<TTree *> &analysedTrees, std::string &friendName, bool allowDuplicates)
 {
    std::set<TLeaf *> foundLeaves;
@@ -214,7 +214,7 @@ static void GetBranchNamesImpl(TTree &t, std::set<std::string> &bNamesReg, Colum
    }
 }
 
-static void ThrowIfNSlotsChanged(unsigned int nSlots)
+void ThrowIfNSlotsChanged(unsigned int nSlots)
 {
    const auto currentSlots = RDFInternal::GetNSlots();
    if (currentSlots != nSlots) {
@@ -299,7 +299,7 @@ DatasetLogInfo TreeDatasetLogInfo(const TTreeReader &r, unsigned int slot)
    return {std::move(what), static_cast<ULong64_t>(entryRange.first), end, slot};
 }
 
-static auto MakeDatasetColReadersKey(const std::string &colName, const std::type_info &ti)
+auto MakeDatasetColReadersKey(const std::string &colName, const std::type_info &ti)
 {
    // We use a combination of column name and column type name as the key because in some cases we might end up
    // with concrete readers that use different types for the same column, e.g. std::vector and RVec here:

--- a/tree/dataframe/src/RSqliteDS.cxx
+++ b/tree/dataframe/src/RSqliteDS.cxx
@@ -153,7 +153,7 @@ int VfsRdOnlyDeviceCharacteristics(sqlite3_file * /*pFile*/)
 ////////////////////////////////////////////////////////////////////////////
 /// Set the function pointers of the custom VFS I/O operations in a
 /// forward-compatible way
-static sqlite3_io_methods GetSqlite3IoMethods()
+sqlite3_io_methods GetSqlite3IoMethods()
 {
    // The C style initialization is compatible with version 1 and later versions of the struct.
    // Version 1 was introduced with sqlite 3.6, version 2 with sqlite 3.7.8, version 3 with sqlite 3.7.17
@@ -286,7 +286,7 @@ int VfsRdOnlyCurrentTime(sqlite3_vfs *vfs, double *prNow)
 ////////////////////////////////////////////////////////////////////////////
 /// Set the function pointers of the VFS implementation in a
 /// forward-compatible way
-static sqlite3_vfs GetSqlite3Vfs()
+sqlite3_vfs GetSqlite3Vfs()
 {
    // The C style initialization is compatible with version 1 and later versions of the struct.
    // Version 1 was introduced with sqlite 3.5, version 2 with sqlite 3.7, version 3 with sqlite 3.7.6
@@ -309,9 +309,9 @@ static sqlite3_vfs GetSqlite3Vfs()
 
 ////////////////////////////////////////////////////////////////////////////
 /// A global struct of function pointers and details on the VfsRootFile class that together constitue a VFS module
-static struct sqlite3_vfs kSqlite3Vfs = GetSqlite3Vfs();
+struct sqlite3_vfs kSqlite3Vfs = GetSqlite3Vfs();
 
-static bool RegisterSqliteVfs()
+bool RegisterSqliteVfs()
 {
    int retval;
    retval = sqlite3_vfs_register(&kSqlite3Vfs, false);

--- a/tree/dataframe/src/RVariationsDescription.cxx
+++ b/tree/dataframe/src/RVariationsDescription.cxx
@@ -14,7 +14,7 @@
 #include <iostream>
 
 namespace {
-static std::string GetStringRepr(const std::vector<const ROOT::Internal::RDF::RVariationBase *> &variations)
+std::string GetStringRepr(const std::vector<const ROOT::Internal::RDF::RVariationBase *> &variations)
 {
    std::string s;
 

--- a/tree/dataframe/test/dataframe_datasetspec.cxx
+++ b/tree/dataframe/test/dataframe_datasetspec.cxx
@@ -93,7 +93,7 @@ protected:
          ROOT::EnableImplicitMT(NSLOTS);
    }
 
-   ~RDatasetSpecTest()
+   ~RDatasetSpecTest() override
    {
       if (GetParam())
          ROOT::DisableImplicitMT();

--- a/tree/dataframe/test/dataframe_simple.cxx
+++ b/tree/dataframe/test/dataframe_simple.cxx
@@ -41,7 +41,7 @@ protected:
       if (GetParam())
          ROOT::EnableImplicitMT(NSLOTS);
    }
-   ~RDFSimpleTests()
+   ~RDFSimpleTests() override
    {
       if (GetParam())
          ROOT::DisableImplicitMT();
@@ -637,6 +637,7 @@ public:
    void GenerateNumbers(int n)
    {
       std::vector<double> numbers;
+      numbers.reserve(n);
       for (int i = 0; i < n; ++i)
          numbers.push_back(fDistribution(fGenerator));
       samples = numbers;

--- a/tree/dataframe/test/dataframe_snapshot.cxx
+++ b/tree/dataframe/test/dataframe_snapshot.cxx
@@ -1049,7 +1049,7 @@ TEST(RDFSnapshotMore, ManyTasksPerThread)
 
    // test multi-thread Snapshotting from many tasks per worker thread
    const auto outputFile = "snapshot_manytasks_out.root";
-   ROOT::RDataFrame tdf("t", (inputFilePrefix + "*.root").c_str());
+   ROOT::RDataFrame tdf("t", inputFilePrefix + "*.root");
    tdf.Snapshot<int>("t", outputFile, {"x"});
 
    // check output contents

--- a/tree/dataframe/test/dataframe_vary.cxx
+++ b/tree/dataframe/test/dataframe_vary.cxx
@@ -26,7 +26,7 @@ protected:
       if (GetParam())
          ROOT::EnableImplicitMT(NSLOTS);
    }
-   ~RDFVary()
+   ~RDFVary() override
    {
       if (GetParam())
          ROOT::DisableImplicitMT();
@@ -1629,7 +1629,7 @@ struct HelperWithCallback : ROOT::Detail::RDF::RActionImpl<HelperWithCallback> {
    void Initialize() {}
    void Finalize() { *fResult = fCallbackCallCount; }
    std::shared_ptr<Result_t> GetResultPtr() const { return fResult; }
-   ROOT::RDF::SampleCallback_t GetSampleCallback() // increments fCallbackCallCount
+   ROOT::RDF::SampleCallback_t GetSampleCallback() override // increments fCallbackCallCount
    {
       auto callback = [](unsigned int, const ROOT::RDF::RSampleInfo &) { ++fCallbackCallCount; };
       return callback;

--- a/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumnElement.hxx
@@ -70,7 +70,7 @@ namespace {
 /// Used on big-endian architectures for packing/unpacking elements whose column type requires
 /// a little-endian on-disk representation.
 template <std::size_t N>
-static void CopyBswap(void *destination, const void *source, std::size_t count)
+void CopyBswap(void *destination, const void *source, std::size_t count)
 {
    auto dst = reinterpret_cast<typename RByteSwap<N>::value_type *>(destination);
    auto src = reinterpret_cast<const typename RByteSwap<N>::value_type *>(source);

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -1469,7 +1469,7 @@ protected:
 public:
    RCardinalityField(RCardinalityField &&other) = default;
    RCardinalityField &operator=(RCardinalityField &&other) = default;
-   ~RCardinalityField() = default;
+   ~RCardinalityField() override = default;
 
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 
@@ -1545,7 +1545,7 @@ public:
    explicit RField(std::string_view name) : RCardinalityField(name, TypeName()) {}
    RField(RField &&other) = default;
    RField &operator=(RField &&other) = default;
-   ~RField() = default;
+   ~RField() override = default;
 
    using Detail::RFieldBase::GenerateValue;
    size_t GetValueSize() const final { return sizeof(RNTupleCardinality<SizeT>); }

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -26,6 +26,7 @@
 #include <ROOT/RNTupleView.hxx>
 #include <ROOT/RPageStorage.hxx>
 #include <ROOT/RSpan.hxx>
+#include <memory>
 #include <string_view>
 
 #include <TClassRef.h>
@@ -452,7 +453,7 @@ public:
    /// ~~~
    std::unique_ptr<RNTupleModel::RUpdater> CreateModelUpdater()
    {
-      return std::unique_ptr<RNTupleModel::RUpdater>(new RNTupleModel::RUpdater(*this));
+      return std::make_unique<RNTupleModel::RUpdater>(*this);
    }
 };
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleZip.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleZip.hxx
@@ -52,7 +52,7 @@ public:
    }
    static constexpr size_t kMaxSingleBlock = kMAXZIPBUF;
 
-   RNTupleCompressor() : fZipBuffer(std::unique_ptr<Buffer_t>(new Buffer_t())) {}
+   RNTupleCompressor() : fZipBuffer(std::make_unique<Buffer_t>()) {}
    RNTupleCompressor(const RNTupleCompressor &other) = delete;
    RNTupleCompressor &operator =(const RNTupleCompressor &other) = delete;
    RNTupleCompressor(RNTupleCompressor &&other) = default;
@@ -179,7 +179,7 @@ private:
    std::unique_ptr<Buffer_t> fUnzipBuffer;
 
 public:
-   RNTupleDecompressor() : fUnzipBuffer(std::unique_ptr<Buffer_t>(new Buffer_t())) {}
+   RNTupleDecompressor() : fUnzipBuffer(std::make_unique<Buffer_t>()) {}
    RNTupleDecompressor(const RNTupleDecompressor &other) = delete;
    RNTupleDecompressor &operator =(const RNTupleDecompressor &other) = delete;
    RNTupleDecompressor(RNTupleDecompressor &&other) = default;

--- a/tree/ntuple/v7/src/RClusterPool.cxx
+++ b/tree/ntuple/v7/src/RClusterPool.cxx
@@ -369,7 +369,7 @@ ROOT::Experimental::Detail::RClusterPool::GetCluster(DescriptorId_t clusterId,
 
             fReadQueue.emplace_back(std::move(readItem));
          }
-         if (fReadQueue.size() > 0)
+         if (!fReadQueue.empty())
             fCvHasReadWork.notify_one();
       }
    } // work queue lock guard

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -934,9 +934,9 @@ struct RBareFileHeader {
 #pragma pack(pop)
 
 /// The artifical class name shown for opaque RNTuple keys (see TBasket)
-static constexpr char const *kBlobClassName = "RBlob";
+constexpr char const *kBlobClassName = "RBlob";
 /// The class name of the RNTuple anchor
-static constexpr char const *kNTupleClassName = "ROOT::Experimental::RNTuple";
+constexpr char const *kNTupleClassName = "ROOT::Experimental::RNTuple";
 
 /// The RKeyBlob writes an invisible key into a TFile.  That is, a key that is not indexed in the list of keys,
 /// like a TBasket.

--- a/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
@@ -62,7 +62,7 @@ struct ColumnInfo {
    }
 };
 
-static std::string GetFieldName(ROOT::Experimental::DescriptorId_t fieldId,
+std::string GetFieldName(ROOT::Experimental::DescriptorId_t fieldId,
    const ROOT::Experimental::RNTupleDescriptor &ntupleDesc)
 {
    const auto &fieldDesc = ntupleDesc.GetFieldDescriptor(fieldId);
@@ -71,7 +71,7 @@ static std::string GetFieldName(ROOT::Experimental::DescriptorId_t fieldId,
    return GetFieldName(fieldDesc.GetParentId(), ntupleDesc) + "." + fieldDesc.GetFieldName();
 }
 
-static std::string GetFieldDescription(ROOT::Experimental::DescriptorId_t fFieldId,
+std::string GetFieldDescription(ROOT::Experimental::DescriptorId_t fFieldId,
    const ROOT::Experimental::RNTupleDescriptor &ntupleDesc)
 {
    const auto &fieldDesc = ntupleDesc.GetFieldDescriptor(fFieldId);

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -21,6 +21,7 @@
 #include <ROOT/RPageSinkBuf.hxx>
 
 #include <algorithm>
+#include <memory>
 
 void ROOT::Experimental::Detail::RPageSinkBuf::RColumnBuf::DropBufferedPages()
 {
@@ -38,7 +39,7 @@ ROOT::Experimental::Detail::RPageSinkBuf::RPageSinkBuf(std::unique_ptr<RPageSink
    , fMetrics("RPageSinkBuf")
    , fInnerSink(std::move(inner))
 {
-   fCounters = std::unique_ptr<RCounters>(new RCounters{
+   fCounters = std::make_unique<RCounters>(RCounters{
       *fMetrics.MakeCounter<RNTuplePlainCounter*>("ParallelZip", "",
          "compressing pages in parallel")
    });

--- a/tree/ntuple/v7/src/RPageSourceFriends.cxx
+++ b/tree/ntuple/v7/src/RPageSourceFriends.cxx
@@ -119,6 +119,7 @@ std::unique_ptr<ROOT::Experimental::Detail::RPageSource>
 ROOT::Experimental::Detail::RPageSourceFriends::Clone() const
 {
    std::vector<std::unique_ptr<RPageSource>> cloneSources;
+   cloneSources.reserve(fSources.size());
    for (const auto &f : fSources)
       cloneSources.emplace_back(f->Clone());
    return std::make_unique<RPageSourceFriends>(fNTupleName, cloneSources);

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -23,6 +23,7 @@
 #include <ROOT/RPagePool.hxx>
 #include <ROOT/RPageSinkBuf.hxx>
 #include <ROOT/RPageStorageFile.hxx>
+#include <memory>
 #include <string_view>
 #ifdef R__ENABLE_DAOS
 # include <ROOT/RPageStorageDaos.hxx>
@@ -202,7 +203,7 @@ void ROOT::Experimental::Detail::RPageSource::PrepareLoadCluster(
 void ROOT::Experimental::Detail::RPageSource::EnableDefaultMetrics(const std::string &prefix)
 {
    fMetrics = RNTupleMetrics(prefix);
-   fCounters = std::unique_ptr<RCounters>(new RCounters{
+   fCounters = std::make_unique<RCounters>(RCounters{
       *fMetrics.MakeCounter<RNTupleAtomicCounter*>("nReadV", "", "number of vector read requests"),
       *fMetrics.MakeCounter<RNTupleAtomicCounter*>("nRead", "", "number of byte ranges read"),
       *fMetrics.MakeCounter<RNTupleAtomicCounter*>("szReadPayload", "B", "volume read from storage (required)"),
@@ -572,7 +573,7 @@ ROOT::Experimental::Detail::RPageSink::SealPage(
 void ROOT::Experimental::Detail::RPageSink::EnableDefaultMetrics(const std::string &prefix)
 {
    fMetrics = RNTupleMetrics(prefix);
-   fCounters = std::unique_ptr<RCounters>(new RCounters{
+   fCounters = std::make_unique<RCounters>(RCounters{
       *fMetrics.MakeCounter<RNTupleAtomicCounter*>("nPageCommitted", "", "number of pages committed to storage"),
       *fMetrics.MakeCounter<RNTupleAtomicCounter*>("szWritePayload", "B", "volume written for committed pages"),
       *fMetrics.MakeCounter<RNTupleAtomicCounter*>("szZip", "B", "volume before zipping"),

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -654,7 +654,7 @@ struct RFieldCallbackInjector {
 };
 } // namespace ROOT::Experimental::Internal
 namespace {
-static unsigned gNCallReadCallback = 0;
+unsigned gNCallReadCallback = 0;
 }
 
 TEST(RNTuple, ReadCallback)

--- a/tree/ntuple/v7/test/ntuple_modelext.cxx
+++ b/tree/ntuple/v7/test/ntuple_modelext.cxx
@@ -28,7 +28,7 @@ struct RFieldBaseTest : public ROOT::Experimental::Detail::RFieldBase {
    }
 };
 
-static std::size_t GetFirstEntry(const RFieldBase *f)
+std::size_t GetFirstEntry(const RFieldBase *f)
 {
    return static_cast<const RFieldBaseTest *>(f)->GetFirstEntry();
 }

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -190,7 +190,7 @@ private:
    /// Transform a NULL terminated C string branch into an std::string field
    struct RCStringTransformation : public RImportTransformation {
       RCStringTransformation(std::size_t b, std::size_t f) : RImportTransformation(b, f) {}
-      virtual ~RCStringTransformation() = default;
+      ~RCStringTransformation() override = default;
       RResult<void> Transform(const RImportBranch &branch, RImportField &field) final;
       void ResetEntry() final {}
    };
@@ -201,7 +201,7 @@ private:
    struct RLeafArrayTransformation : public RImportTransformation {
       std::int64_t fNum = 0;
       RLeafArrayTransformation(std::size_t b, std::size_t f) : RImportTransformation(b, f) {}
-      virtual ~RLeafArrayTransformation() = default;
+      ~RLeafArrayTransformation() override = default;
       RResult<void> Transform(const RImportBranch &branch, RImportField &field) final;
       void ResetEntry() final { fNum = 0; }
    };

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -46,7 +46,7 @@ private:
    std::uint64_t fNbytesNext = gUpdateFrequencyBytes;
 
 public:
-   virtual ~RDefaultProgressCallback() {}
+   ~RDefaultProgressCallback() override {}
    void Call(std::uint64_t nbytesWritten, std::uint64_t neventsWritten) final
    {
       // Report if more than 50MB (compressed) where written since the last status update

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -275,7 +275,7 @@ std::unique_ptr<TH1D>
 ROOT::Experimental::RNTupleInspector::GetColumnTypeInfoAsHist(ROOT::Experimental::ENTupleInspectorHist histKind,
                                                               std::string_view histName, std::string_view histTitle)
 {
-   if (histName == "") {
+   if (histName.empty()) {
       switch (histKind) {
       case ENTupleInspectorHist::kCount: histName = "colTypeCountHist"; break;
       case ENTupleInspectorHist::kNElems: histName = "colTypeElemCountHist"; break;
@@ -285,7 +285,7 @@ ROOT::Experimental::RNTupleInspector::GetColumnTypeInfoAsHist(ROOT::Experimental
       }
    }
 
-   if (histTitle == "") {
+   if (histTitle.empty()) {
       switch (histKind) {
       case ENTupleInspectorHist::kCount: histTitle = "Column count by type"; break;
       case ENTupleInspectorHist::kNElems: histTitle = "Number of elements by column type"; break;

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -357,7 +357,7 @@ TEST(RNTupleInspector, PrintColumnTypeInfo)
    std::string colTypeStr;
    while (std::getline(csvOutput, line)) {
       ++nLines;
-      colTypeStr = line.substr(0, line.find(","));
+      colTypeStr = line.substr(0, line.find(','));
 
       if (colTypeStr != "SplitIndex64" && colTypeStr != "SplitInt64" && colTypeStr != "SplitReal32")
          FAIL() << "Unexpected column type: " << colTypeStr;
@@ -376,7 +376,7 @@ TEST(RNTupleInspector, PrintColumnTypeInfo)
    nLines = 0;
    while (std::getline(tableOutput, line)) {
       ++nLines;
-      colTypeStr = line.substr(0, line.find("|"));
+      colTypeStr = line.substr(0, line.find('|'));
       colTypeStr.erase(remove_if(colTypeStr.begin(), colTypeStr.end(), isspace), colTypeStr.end());
 
       if (colTypeStr != "SplitIndex64" && colTypeStr != "SplitInt64" && colTypeStr != "SplitReal32")


### PR DESCRIPTION
Applies the clang-tidy suggestions from the following checks, which are the same as in the CMSSW `.clang-tidy`, only that the checks that replace copies with `const` references are removed:

```
  ,boost-use-to-string,
  ,misc-definitions-in-headers,
  ,misc-string-compare,
  ,misc-uniqueptr-reset-release,
  ,modernize-deprecated-headers,
  ,modernize-make-shared,
  ,modernize-make-unique,
  ,modernize-use-bool-literals,
  ,modernize-use-equals-delete,
  ,modernize-use-nullptr,
  ,modernize-use-override,
  ,performance-inefficient-algorithm,
  ,performance-inefficient-vector-operation,
  ,performance-faster-string-find,
  ,performance-move-const-arg,
  ,readability-container-size-empty,
  ,readability-redundant-string-cstr,
  ,readability-static-definition-in-anonymous-namespace,
  ,readability-uniqueptr-delete-release
```
