### PR TITLE
Addition of Unique Ptr type Open interface with implementation

### DIFF
--- a/io/io/inc/TFile.h
+++ b/io/io/inc/TFile.h
@@ -299,6 +299,11 @@ public:
    static TFile       *Open(const char *name, Option_t *option = "",
                             const char *ftitle = "", Int_t compress = ROOT::RCompressionSetting::EDefaults::kUseCompiledDefault,
                             Int_t netopt = 0);
+
+   static std::unique_ptr<TFile> OpenU(const char *name, Option_t *option = "",
+                            const char *ftitle = "", Int_t compress = ROOT::RCompressionSetting::EDefaults::kUseCompiledDefault,
+                            Int_t netopt = 0);
+
    static TFile       *Open(TFileOpenHandle *handle);
 
    static EFileType    GetType(const char *name, Option_t *option = "", TString *prefix = nullptr);

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -4068,6 +4068,13 @@ TFile *TFile::OpenFromCache(const char *name, Option_t *, const char *ftitle,
 /// In RECREATE mode, a nullptr is returned if the file can not be created.
 /// In UPDATE mode, a nullptr is returned if the file cannot be created or opened.
 
+std::unique_ptr<TFile> OpenU(const char *url, Option_t *options, const char *ftitle,
+                   Int_t compress, Int_t netopt)
+{
+   std::unique_ptr<TFile> uniquePtr = std::make_unique<TFile>(&url, &options, &ftitle, compress, netopt);
+   return(uniquePtr);
+}
+
 TFile *TFile::Open(const char *url, Option_t *options, const char *ftitle,
                    Int_t compress, Int_t netopt)
 {


### PR DESCRIPTION
# This Pull request:
Addition of Unique Pointer for TFile::Open -> Creation of Interface and implementation for the same

## Changes or fixes:
Enables utilization of Unique Pointer for TFile::Open

## Checklist:

- [ ] tested changes locally

