### PR TITLE
Make sure the legend endcaps fill style matches the graph one

### DIFF
--- a/graf2d/graf/src/TLegend.cxx
+++ b/graf2d/graf/src/TLegend.cxx
@@ -628,6 +628,7 @@ void TLegend::PaintPrimitives()
    Double_t y2 = fY2NDC;
    Double_t margin = fMargin*( x2-x1 )/fNColumns;
    Double_t boxw = margin*0.35;
+   Double_t barw = boxw*0.1*gStyle->GetEndErrorSize();
    Double_t yspace = (y2-y1)/nRows;
    Double_t yspace2 = yspace/2.;
    Double_t textsize = GetTextSize();
@@ -815,7 +816,8 @@ void TLegend::PaintPrimitives()
             if (eobjopt.Contains("|>")) endcaps = 3; // filled arrow.
          }
       }
-
+      float arrow_shift = 0.3;
+      if (endcaps == 3) arrow_shift = 0.2;
       // Draw fill pattern (in a box)
 
       if ( opt.Contains("f")) {
@@ -855,116 +857,8 @@ void TLegend::PaintPrimitives()
          if (entrymarker.GetMarkerStyle() >= 5 ) symbolsize = entrymarker.GetMarkerSize();
       }
 
-      // Draw line
-
-      if ( opt.Contains("l") || opt.Contains("f")) {
-
-         if (eobj && eobj->InheritsFrom(TAttLine::Class())) {
-            dynamic_cast<TAttLine*>(eobj)->Copy(*entry);
-         }
-         // line total length (in x) is margin*0.8
-         TLine entryline( xsym - boxw, ysym, xsym + boxw, ysym );
-         entryline.SetBit(TLine::kLineNDC);
-         entry->TAttLine::Copy(entryline);
-         // if the entry is filled, then surround the box with the line instead
-         if ( opt.Contains("f") && !opt.Contains("l")) {
-            entryline.PaintLineNDC( xsym - boxw, ysym + yspace*0.35,
-                                    xsym + boxw, ysym + yspace*0.35);
-            entryline.PaintLineNDC( xsym - boxw, ysym - yspace*0.35,
-                                    xsym + boxw, ysym - yspace*0.35);
-            entryline.PaintLineNDC( xsym + boxw, ysym - yspace*0.35,
-                                    xsym + boxw, ysym + yspace*0.35);
-            entryline.PaintLineNDC( xsym - boxw, ysym - yspace*0.35,
-                                    xsym - boxw, ysym + yspace*0.35);
-         } else {
-            entryline.Paint();
-            if (opt.Contains("e")) {
-               if ( !opt.Contains("p")) {
-                  entryline.PaintLineNDC( xsym, ysym - yspace*0.30,
-                                          xsym, ysym + yspace*0.30);
-               } else {
-                  Double_t sy  = (fY2NDC-fY1NDC)*((0.5*(gPad->PixeltoY(0) - gPad->PixeltoY(Int_t(symbolsize*8.))))/(fY2-fY1));
-                  TLine entryline1(xsym, ysym + sy, xsym, ysym + yspace*0.30);
-                  entryline1.SetBit(TLine::kLineNDC);
-                  entry->TAttLine::Copy(entryline1);
-                  entryline1.Paint();
-                  TLine entryline2(xsym, ysym - sy, xsym, ysym - yspace*0.30);
-                  entryline2.SetBit(TLine::kLineNDC);
-                  entry->TAttLine::Copy(entryline2);
-                  entryline2.Paint();
-               }
-               Double_t barw = boxw*0.1*gStyle->GetEndErrorSize();
-               if (endcaps == 1) {
-                  TLine entrytop1(xsym-barw, ysym + yspace*0.30, xsym+barw, ysym + yspace*0.30);
-                  entrytop1.SetBit(TLine::kLineNDC);
-                  entry->TAttLine::Copy(entrytop1);
-                  entrytop1.Paint();
-                  TLine entrytop2(xsym-barw, ysym - yspace*0.30, xsym+barw, ysym - yspace*0.30);
-                  entrytop2.SetBit(TLine::kLineNDC);
-                  entry->TAttLine::Copy(entrytop2);
-                  entrytop2.Paint();
-               } else if (endcaps == 2) {
-                  Double_t xe1[3] = {xsym-barw, xsym ,xsym+barw};
-                  Double_t ye1[3] = {ysym+yspace*0.20, ysym + yspace*0.30 ,ysym+yspace*0.20};
-                  TPolyLine ple1(3,xe1,ye1);
-                  ple1.SetBit(TLine::kLineNDC);
-                  entry->TAttLine::Copy(ple1);
-                  ple1.Paint();
-                  Double_t xe2[3] = {xsym-barw, xsym ,xsym+barw};
-                  Double_t ye2[3] = {ysym-yspace*0.20, ysym - yspace*0.30 ,ysym-yspace*0.20};
-                  TPolyLine ple2(3,xe2,ye2);
-                  ple2.SetBit(TLine::kLineNDC);
-                  entry->TAttLine::Copy(ple2);
-               } else if (endcaps == 3) {
-                  Double_t xe1[3] = {xsym-barw, xsym ,xsym+barw};
-                  Double_t ye1[3] = {ysym+yspace*0.20, ysym + yspace*0.30 ,ysym+yspace*0.20};
-                  Double_t xe2[3] = {xsym-barw, xsym ,xsym+barw};
-                  Double_t ye2[3] = {ysym-yspace*0.20, ysym - yspace*0.30 ,ysym-yspace*0.20};
-                  for (Int_t i=0;i<3;i++) {
-                     xe1[i] = gPad->GetX1() + xe1[i]*(gPad->GetX2()-gPad->GetX1());
-                     ye1[i] = gPad->GetY1() + ye1[i]*(gPad->GetY2()-gPad->GetY1());
-                     xe2[i] = gPad->GetX1() + xe2[i]*(gPad->GetX2()-gPad->GetX1());
-                     ye2[i] = gPad->GetY1() + ye2[i]*(gPad->GetY2()-gPad->GetY1());
-                  }
-                  TPolyLine ple1(3,xe1,ye1);
-                  ple1.SetFillColor(entry->GetLineColor());
-                  ple1.SetFillStyle(1001);
-                  ple1.Paint("f");
-                  TPolyLine ple2(3,xe2,ye2);
-                  ple2.SetFillColor(entry->GetLineColor());
-                  ple2.SetFillStyle(1001);
-                  ple2.Paint("f");
-               }
-            }
-         }
-      }
-
-      // Draw error only
-
-      if (opt.Contains("e") && !(opt.Contains("l") || opt.Contains("f"))) {
-         if (eobj && eobj->InheritsFrom(TAttLine::Class())) {
-            dynamic_cast<TAttLine*>(eobj)->Copy(*entry);
-         }
-         if ( !opt.Contains("p")) {
-            float arrow_shift = 0.3;
-            if (endcaps == 3) arrow_shift = 0.2;
-            TLine entryline(xsym, ysym - yspace*arrow_shift,
-                            xsym, ysym + yspace*arrow_shift);
-            entryline.SetBit(TLine::kLineNDC);
-            entry->TAttLine::Copy(entryline);
-            entryline.Paint();
-         } else {
-            Double_t sy  = (fY2NDC-fY1NDC)*((0.5*(gPad->PixeltoY(0) - gPad->PixeltoY(Int_t(symbolsize*8.))))/(fY2-fY1));
-            TLine entryline1(xsym, ysym + sy, xsym, ysym + yspace*0.30);
-            entryline1.SetBit(TLine::kLineNDC);
-            entry->TAttLine::Copy(entryline1);
-            entryline1.Paint();
-            TLine entryline2(xsym, ysym - sy, xsym, ysym - yspace*0.30);
-            entryline2.SetBit(TLine::kLineNDC);
-            entry->TAttLine::Copy(entryline2);
-            entryline2.Paint();
-         }
-         Double_t barw = boxw*0.1*gStyle->GetEndErrorSize();
+      // Lambda function to draw end caps 3
+      auto DrawEndCaps = [&]() {
          if (endcaps == 1) {
             TLine entrytop1(xsym-barw, ysym + yspace*0.30, xsym+barw, ysym + yspace*0.30);
             entrytop1.SetBit(TLine::kLineNDC);
@@ -988,25 +882,109 @@ void TLegend::PaintPrimitives()
             entry->TAttLine::Copy(ple2);
             ple2.Paint();
          } else if (endcaps == 3) {
+            if (eobj && eobj->InheritsFrom(TAttFill::Class())) {
+               dynamic_cast<TAttFill*>(eobj)->Copy(*entry);
+            }
             Double_t xe1[3] = {xsym-barw, xsym ,xsym+barw};
             Double_t ye1[3] = {ysym+yspace*0.20, ysym + yspace*0.30 ,ysym+yspace*0.20};
             Double_t xe2[3] = {xsym-barw, xsym ,xsym+barw};
             Double_t ye2[3] = {ysym-yspace*0.20, ysym - yspace*0.30 ,ysym-yspace*0.20};
             for (Int_t i=0;i<3;i++) {
-               xe1[i] = gPad->GetX1() + xe1[i]*(gPad->GetX2()-gPad->GetX1());
-               ye1[i] = gPad->GetY1() + ye1[i]*(gPad->GetY2()-gPad->GetY1());
-               xe2[i] = gPad->GetX1() + xe2[i]*(gPad->GetX2()-gPad->GetX1());
-               ye2[i] = gPad->GetY1() + ye2[i]*(gPad->GetY2()-gPad->GetY1());
+            xe1[i] = gPad->GetX1() + xe1[i]*(gPad->GetX2()-gPad->GetX1());
+            ye1[i] = gPad->GetY1() + ye1[i]*(gPad->GetY2()-gPad->GetY1());
+            xe2[i] = gPad->GetX1() + xe2[i]*(gPad->GetX2()-gPad->GetX1());
+            ye2[i] = gPad->GetY1() + ye2[i]*(gPad->GetY2()-gPad->GetY1());
             }
+            int lc = entry->GetLineColor();
+            int lw = entry->GetLineWidth();
+            int fc = entry->GetFillColor();
+            int fs = entry->GetFillStyle();
+            if (fs==1) fs=1001;
+
             TPolyLine ple1(3,xe1,ye1);
-            ple1.SetFillColor(entry->GetLineColor());
-            ple1.SetFillStyle(entry->GetFillStyle());
+            ple1.SetLineColor(lc);
+            ple1.SetLineWidth(lw);
+            ple1.SetFillColor(fc);
+            ple1.SetFillStyle(fs);
             ple1.Paint("f");
+            ple1.Paint();
+
             TPolyLine ple2(3,xe2,ye2);
-            ple2.SetFillColor(entry->GetLineColor());
-            ple2.SetFillStyle(entry->GetFillStyle());
+            ple2.SetLineColor(lc);
+            ple2.SetLineWidth(lw);
+            ple2.SetFillColor(fc);
+            ple2.SetFillStyle(fs);
             ple2.Paint("f");
+            ple2.Paint();
          }
+      };
+
+      // Draw line
+
+      if ( opt.Contains("l") || opt.Contains("f")) {
+         if (eobj && eobj->InheritsFrom(TAttLine::Class())) {
+            dynamic_cast<TAttLine*>(eobj)->Copy(*entry);
+         }
+         // line total length (in x) is margin*0.8
+         TLine entryline( xsym - boxw, ysym, xsym + boxw, ysym );
+         entryline.SetBit(TLine::kLineNDC);
+         entry->TAttLine::Copy(entryline);
+         // if the entry is filled, then surround the box with the line instead
+         if ( opt.Contains("f") && !opt.Contains("l")) {
+            entryline.PaintLineNDC( xsym - boxw, ysym + yspace*0.35,
+                                    xsym + boxw, ysym + yspace*0.35);
+            entryline.PaintLineNDC( xsym - boxw, ysym - yspace*0.35,
+                                    xsym + boxw, ysym - yspace*0.35);
+            entryline.PaintLineNDC( xsym + boxw, ysym - yspace*0.35,
+                                    xsym + boxw, ysym + yspace*0.35);
+            entryline.PaintLineNDC( xsym - boxw, ysym - yspace*0.35,
+                                    xsym - boxw, ysym + yspace*0.35);
+         } else {
+            entryline.Paint();
+            if (opt.Contains("e")) {
+               if ( !opt.Contains("p")) {
+                  entryline.PaintLineNDC( xsym, ysym - yspace*arrow_shift,
+                                          xsym, ysym + yspace*arrow_shift);
+               } else {
+                  Double_t sy  = (fY2NDC-fY1NDC)*((0.5*(gPad->PixeltoY(0) - gPad->PixeltoY(Int_t(symbolsize*8.))))/(fY2-fY1));
+                  TLine entryline1(xsym, ysym + sy, xsym, ysym + yspace*arrow_shift);
+                  entryline1.SetBit(TLine::kLineNDC);
+                  entry->TAttLine::Copy(entryline1);
+                  entryline1.Paint();
+                  TLine entryline2(xsym, ysym - sy, xsym, ysym - yspace*arrow_shift);
+                  entryline2.SetBit(TLine::kLineNDC);
+                  entry->TAttLine::Copy(entryline2);
+                  entryline2.Paint();
+               }
+               DrawEndCaps();
+            }
+         }
+      }
+
+      // Draw error only
+
+      if (opt.Contains("e") && !(opt.Contains("l") || opt.Contains("f"))) {
+         if (eobj && eobj->InheritsFrom(TAttLine::Class())) {
+            dynamic_cast<TAttLine*>(eobj)->Copy(*entry);
+         }
+         if ( !opt.Contains("p")) {
+            TLine entryline(xsym, ysym - yspace*arrow_shift,
+                            xsym, ysym + yspace*arrow_shift);
+            entryline.SetBit(TLine::kLineNDC);
+            entry->TAttLine::Copy(entryline);
+            entryline.Paint();
+         } else {
+            Double_t sy  = (fY2NDC-fY1NDC)*((0.5*(gPad->PixeltoY(0) - gPad->PixeltoY(Int_t(symbolsize*8.))))/(fY2-fY1));
+            TLine entryline1(xsym, ysym + sy, xsym, ysym + yspace*arrow_shift);
+            entryline1.SetBit(TLine::kLineNDC);
+            entry->TAttLine::Copy(entryline1);
+            entryline1.Paint();
+            TLine entryline2(xsym, ysym - sy, xsym, ysym - yspace*arrow_shift);
+            entryline2.SetBit(TLine::kLineNDC);
+            entry->TAttLine::Copy(entryline2);
+            entryline2.Paint();
+         }
+         DrawEndCaps();
       }
 
       // Draw Polymarker

--- a/graf2d/graf/src/TLegend.cxx
+++ b/graf2d/graf/src/TLegend.cxx
@@ -946,8 +946,10 @@ void TLegend::PaintPrimitives()
             dynamic_cast<TAttLine*>(eobj)->Copy(*entry);
          }
          if ( !opt.Contains("p")) {
-            TLine entryline(xsym, ysym - yspace*0.30,
-                            xsym, ysym + yspace*0.30);
+            float arrow_shift = 0.3;
+            if (endcaps == 3) arrow_shift = 0.2;
+            TLine entryline(xsym, ysym - yspace*arrow_shift,
+                            xsym, ysym + yspace*arrow_shift);
             entryline.SetBit(TLine::kLineNDC);
             entry->TAttLine::Copy(entryline);
             entryline.Paint();
@@ -998,11 +1000,11 @@ void TLegend::PaintPrimitives()
             }
             TPolyLine ple1(3,xe1,ye1);
             ple1.SetFillColor(entry->GetLineColor());
-            ple1.SetFillStyle(1001);
+            ple1.SetFillStyle(entry->GetFillStyle());
             ple1.Paint("f");
             TPolyLine ple2(3,xe2,ye2);
             ple2.SetFillColor(entry->GetLineColor());
-            ple2.SetFillStyle(1001);
+            ple2.SetFillStyle(entry->GetFillStyle());
             ple2.Paint("f");
          }
       }

--- a/hist/histpainter/src/TGraphPainter.cxx
+++ b/hist/histpainter/src/TGraphPainter.cxx
@@ -3527,6 +3527,7 @@ void TGraphPainter::PaintGraphErrors(TGraph *theGraph, Option_t *option)
 
    TArrow arrow;
    arrow.SetLineWidth(theGraph->GetLineWidth());
+   arrow.SetLineStyle(theGraph->GetLineStyle());
    arrow.SetLineColor(theGraph->GetLineColor());
    arrow.SetFillColor(theGraph->GetFillColor());
 


### PR DESCRIPTION
Reproducer:
```
void gerrors() {
   TCanvas *c1 = new TCanvas("c1","A Simple Graph with error bars",200,10,700,500);


   const Int_t n = 10;
   Float_t x[n]  = {-0.22, 0.05, 0.25, 0.35, 0.5, 0.61,0.7,0.85,0.89,0.95};
   Float_t y[n]  = {1,2.9,5.6,7.4,9,9.6,8.7,6.3,4.5,1};
   Float_t ex[n] = {.05,.1,.07,.07,.04,.05,.06,.07,.08,.05};
   Float_t ey[n] = {.8,.7,.6,.5,.4,.4,.5,.6,.7,.8};
   TGraphErrors *gr = new TGraphErrors(n,x,y,ex,ey);
   gr->SetTitle("TGraphErrors Example");
   gr->SetMarkerColor(4);
   gr->SetMarkerStyle(21);
   gr->Draw("AP|>");

   c1->Update();
   auto l = new TLegend(0.45,0.65,0.8,0.8,"","NDC");
   l->SetBorderSize(0.);
   l->SetTextFont(42);
   l->AddEntry(gr, "TGraphErrors new title", "e");
   l->Draw();
}

```
