### PR TITLE
[tmva] Remove the links to the old TMVA Web site on sourceforge

### DIFF
--- a/documentation/tmva/UsersGuide/Introduction.tex
+++ b/documentation/tmva/UsersGuide/Introduction.tex
@@ -143,7 +143,7 @@ with or without modification, are permitted according to the terms listed in the
 BSD license\index{License}.\footnote
 {
   For the BSD l
-icense, see \urlsm{http://tmva.sourceforge.net/LICENSE}. 
+icense, see \urlsm{see tmva/doc/LICENSE}. 
 }
 Several similar combined multivariate analysis (``machine learning'') packages exist 
 with rising importance in most fields of science and industry. In the HEP

--- a/documentation/tmva/UsersGuide/UsingTMVAQuickStart.tex
+++ b/documentation/tmva/UsersGuide/UsingTMVAQuickStart.tex
@@ -1,12 +1,12 @@
 \section{TMVA Quick Start}
 \label{sec:quickstart}
 
-To run TMVA it is not necessary to know much about its concepts or to understand 
-the detailed functionality of the multivariate methods. Better, just begin 
+To run TMVA it is not necessary to know much about its concepts or to understand
+the detailed functionality of the multivariate methods. Better, just begin
 with the quick start tutorial given below.
 
-Classification and regression analyses in TMVA have similar training, testing and 
-evaluation phases, and will be treated in parallel in the following. 
+Classification and regression analyses in TMVA have similar training, testing and
+evaluation phases, and will be treated in parallel in the following.
 
 \subsection{How to download and build TMVA}
 \label{sec:download}
@@ -19,13 +19,13 @@ The latest version of ROOT can be found at \urlsm{https://root.cern/downloading-
 \label{sec:intro:compat}
 
 TMVA can be run with any ROOT version equal or above v5.08\index{ROOT!compatibility}.
-The few occurring conflicts due to ROOT source code evolution after v5.08 are 
+The few occurring conflicts due to ROOT source code evolution after v5.08 are
 intercepted in TMVA via C++ preprocessor conditions.
 
 \subsection{The TMVA namespace}
 \label{sec:quickstart:namespace}
 
-All TMVA classes are embedded in the namespace \code{TMVA}. For interactive access, or 
+All TMVA classes are embedded in the namespace \code{TMVA}. For interactive access, or
 use in macros, the classes must thus be preceded by \code{TMVA::}.
 
 One may also use the command \code{using} \code{namespace} \code{TMVA;} instead. However, this approach is not preferred since it can lead to ambiguities.
@@ -33,13 +33,13 @@ One may also use the command \code{using} \code{namespace} \code{TMVA;} instead.
 \subsection{Example jobs\index{Examples}}
 \label{sec:examplejob}
 
-TMVA comes with example jobs for the training phase (this phase actually 
-includes training, testing and evaluation) using the TMVA {\em Factory}\index{Factory}, 
+TMVA comes with example jobs for the training phase (this phase actually
+includes training, testing and evaluation) using the TMVA {\em Factory}\index{Factory},
 as well as the application of the training results in a classification or regression analysis
 using the TMVA {\em Reader}\index{Reader}. The training examples are
 \code{TMVAClassification.C}\index{TMVAClassification},
 \code{TMVAMulticlass.C}\index{TMVAMulticlass} and
-\code{TMVARegression.C}\index{TMVARegression}, and the application examples are 
+\code{TMVARegression.C}\index{TMVARegression}, and the application examples are
 \code{TMVAClassificationApplication.C}\index{TMVAClassificationApplication},
 \code{TMVAMulticlassApplication.C}\index{TMVAMulticlassApplication} and
 \code{TMVARegressionApplication.C}\index{TMVARegressionApplication}.
@@ -51,7 +51,7 @@ The above macros (extension \code{.C}) are located in the directory \TmvaTutoria
 Some examples are also provided in form of C++ executables
 (replace \code{.C} by \code{.cxx}). To build the executables, go to
 \TmvaTutorialDir, type \code{make} and then simply execute them by typing
-\code{./TMVAClassification}, \code{./TMVAMulticlass} or \code{./TMVARegression} (and similarly for the 
+\code{./TMVAClassification}, \code{./TMVAMulticlass} or \code{./TMVARegression} (and similarly for the
 applications).
 
 % This is not true anymore. This file does not exist.
@@ -60,24 +60,24 @@ applications).
 \subsection{Running the example}
 \label{sec:qs:example}
 
-The most straightforward way to get started with TMVA is to simply run the \code{TMVAClassification.C} 
-or \code{TMVARegression.C} example macros. Both use academic toy datasets for training 
-and testing, which, for classification, consists of four linearly correlated, Gaussian 
-distributed discriminating input variables, with different sample means for signal and 
-background, and, for regression, has two input variables with fuzzy parabolic dependence 
-on the target (\code{fvalue}), and no correlations among themselves. All 
+The most straightforward way to get started with TMVA is to simply run the \code{TMVAClassification.C}
+or \code{TMVARegression.C} example macros. Both use academic toy datasets for training
+and testing, which, for classification, consists of four linearly correlated, Gaussian
+distributed discriminating input variables, with different sample means for signal and
+background, and, for regression, has two input variables with fuzzy parabolic dependence
+on the target (\code{fvalue}), and no correlations among themselves. All
 classifiers are trained, tested and evaluated using the toy datasets in the
 same way the user is expected to proceed for his or her own data. It
-is a valuable exercise to look at the example file in more detail. Most 
-of the command lines therein should be self explaining, and one will easily 
+is a valuable exercise to look at the example file in more detail. Most
+of the command lines therein should be self explaining, and one will easily
 find how they need to be customized to apply TMVA to a real use case.
 A detailed description is given in Sec.~\ref{sec:usingtmva}.
 
-The macros automatically fetch the data file from 
+The macros automatically fetch the data file from
 the web using the corresponding \code{TFile} constructor, \eg,
-\code{TFile::Open("http://root.cern/files/tmva_class_example.root")} (\code{tmva_reg_example.root} for regression). The example %ToDo: insert this code into our example execs and macros. 
+\code{TFile::Open("http://root.cern/files/tmva_class_example.root")} (\code{tmva_reg_example.root} for regression). The example %ToDo: insert this code into our example execs and macros.
 ROOT macros can be run directly in the \TmvaTutorialDir directory,
-or from anywhere after adding the macro directory 
+or from anywhere after adding the macro directory
 to ROOT's macro search path:
 \begin{codeexample}
 \begin{tmvacode}
@@ -88,22 +88,22 @@ to ROOT's macro search path:
 \caption[.]{\codeexampleCaptionSize Running the example \code{TMVAClassification.C}.}
 \end{codeexample}
 
-It is also possible to explicitly select the MVA methods to be processed: 
+It is also possible to explicitly select the MVA methods to be processed:
 \begin{codeexample}
 \begin{tmvacode}
 > root -l '$ROOTSYS/tutorials/tmva/TMVAClassification.C("Fisher","BDT")'
 \end{tmvacode}
 \caption[.]{\codeexampleCaptionSize Running the example \code{TMVAClassification.C} and processing only the Fisher and BDTclassifier. Multiple classifiers are separated by commas. The others macros can be called accordingly.}
 \end{codeexample}
-where the names of the MVA methods are predefined in the macro. 
+where the names of the MVA methods are predefined in the macro.
 
 The training job provides formatted output logging containing analysis information
-such as: linear correlation matrices for the input variables, correlation ratios 
+such as: linear correlation matrices for the input variables, correlation ratios
 and mutual information (see below) between input variables and regression targets,
 variable ranking, summaries of the MVA configurations, goodness-of-fit evaluation
-for PDFs (if requested), signal and background (or regression target) correlations 
+for PDFs (if requested), signal and background (or regression target) correlations
 between the various MVA methods, decision overlaps, signal efficiencies
-at benchmark background rejection rates (classification) or deviations from target 
+at benchmark background rejection rates (classification) or deviations from target
 (regression), as well as other performance estimators. Comparison between the results
 for training and independent test samples provides overtraining validation.
 \begin{figure}[p]
@@ -112,43 +112,43 @@ for training and independent test samples provides overtraining validation.
      \includegraphics[width=0.47\textwidth]{plots/TMVARegGui}
   \end{center}
   \vspace{-0.1cm}
-  \caption[.]{Graphical user interfaces (GUI) to execute  
-              macros displaying training, test and evaluation results 
-              (\cf\  Tables~\ref{pgr:scripttable1} and \ref{pgr:scripttable2} on page 
-              \pageref{pgr:scripttable1}) for classification (left) and regression 
+  \caption[.]{Graphical user interfaces (GUI) to execute
+              macros displaying training, test and evaluation results
+              (\cf\  Tables~\ref{pgr:scripttable1} and \ref{pgr:scripttable2} on page
+              \pageref{pgr:scripttable1}) for classification (left) and regression
               problems (right). The multiclass classification GUI is similar to the classification GUI,
               where some functionality is not available.
               The classification GUI can be launched manually by executing the script
-              {\tt \$}\code{ROOTSYS/tmva/test/TMVAGui.C} in a ROOT 
+              {\tt \$}\code{ROOTSYS/tmva/test/TMVAGui.C} in a ROOT
               session. To launch the multiclass or regression GUIs use the macros \code{TMVARegGui.C}
               or \code{TMVAMultiClassGui.C}, respectively. \\[0.2cm]
               {\footnotesize
               \underline{Classification (left)}. The buttons behave as follows:
-              (1a) plots the signal and background 
-              distributions of input variables (training sample), (1b--d) the 
-              same after applying the corresponding preprocessing transformation of the input 
-              variables, (2a--f) scatter plots with superimposed profiles for all 
+              (1a) plots the signal and background
+              distributions of input variables (training sample), (1b--d) the
+              same after applying the corresponding preprocessing transformation of the input
+              variables, (2a--f) scatter plots with superimposed profiles for all
               pairs of input variables for signal and background and the applied transformations
-              (training sample), (3) correlation coefficients 
-              between the input variables for signal and background (training sample), 
-              (4a/b) signal and background distributions for the trained classifiers (test 
-              sample/test and training samples superimposed to probe overtraining), 
+              (training sample), (3) correlation coefficients
+              between the input variables for signal and background (training sample),
+              (4a/b) signal and background distributions for the trained classifiers (test
+              sample/test and training samples superimposed to probe overtraining),
               (4c,d) the corresponding probability and Rarity distributions of the classifiers
-              (where requested, \cf\  see Sec.~\ref{sec:otherRepresentations}), 
+              (where requested, \cf\  see Sec.~\ref{sec:otherRepresentations}),
               (5a) signal and background efficiencies and purities versus the cut on the classifier
-              output for the expected numbers of signal and background events (before applying the cut) 
+              output for the expected numbers of signal and background events (before applying the cut)
               given by the user (an input dialog box pops up, where the numbers are inserted),
-              (5b) background rejection versus signal efficiency obtained when cutting 
+              (5b) background rejection versus signal efficiency obtained when cutting
               on the classifier outputs (ROC curve, from the test sample), (6) plot of so-called
-              Parallel Coordinates visualising the correlations among the input variables, and 
-              among the classifier and the input variables,  (7--13) show classifier 
-              specific diagnostic plots, and (14) quits the GUI. Titles greyed out indicate 
-              actions that are not available because the corresponding classifier has not 
+              Parallel Coordinates visualising the correlations among the input variables, and
+              among the classifier and the input variables,  (7--13) show classifier
+              specific diagnostic plots, and (14) quits the GUI. Titles greyed out indicate
+              actions that are not available because the corresponding classifier has not
               been trained or because the transformation was not requested.\\
               \underline{Regression (right)}. The buttons behave as follows:
-              (1--3) same as for classification GUI, (4a--d) show the linear deviations between 
-              regression targets and estimates versus the targets or input variables for the 
-              test and training samples, respectively, (5) compares the average deviations 
+              (1--3) same as for classification GUI, (4a--d) show the linear deviations between
+              regression targets and estimates versus the targets or input variables for the
+              test and training samples, respectively, (5) compares the average deviations
               between target and MVA output for the trained methods, and (6--8) are as for the classification GUI.}
 }
 \label{fig:tmvagui}
@@ -185,16 +185,16 @@ for training and independent test samples provides overtraining validation.
   \vspace{-0.5cm}
 \caption[.]{Example plots for input variable distributions. The histogram
             limits are chosen to zoom into the bulk of the distributions, which
-            may lead to truncated tails. The vertical text on the 
+            may lead to truncated tails. The vertical text on the
             right-hand side of the plots indicates the under- and overflows.
-            The limits in terms of multiples of the distribution's RMS can 
+            The limits in terms of multiples of the distribution's RMS can
             be adjusted in the user script by modifying the variable
-            \code{(TMVA::gConfig().GetVariablePlotting()).fTimesRMS} (\cf\  
+            \code{(TMVA::gConfig().GetVariablePlotting()).fTimesRMS} (\cf\
             Code Example~\ref{ce:gconfig}). }
 \label{fig:usingtmva:variables}
 \end{figure}
 
-After a successful training, TMVA provides so called ``weight''-files that contain all information necessary to recreate the method without retraining. For further information, see the \code{TMVA::Reader} in Section~\ref{sec:usingtmva:reader}. TMVA also provides a variety of control and performance plots that can be displayed via a dedicated GUI (see Fig.~\ref{fig:tmvagui}). The GUI can be launched with 
+After a successful training, TMVA provides so called ``weight''-files that contain all information necessary to recreate the method without retraining. For further information, see the \code{TMVA::Reader} in Section~\ref{sec:usingtmva:reader}. TMVA also provides a variety of control and performance plots that can be displayed via a dedicated GUI (see Fig.~\ref{fig:tmvagui}). The GUI can be launched with
 \begin{codeexample}\begin{tmvacode}
 > root -l -e 'TMVA::TMVAGui("path/to/tmva/output/file.root")'
 > root -l -e 'TMVA::TMVAMultiClassGui("path/to/tmva/output/file.root")'
@@ -202,7 +202,7 @@ After a successful training, TMVA provides so called ``weight''-files that conta
 \end{tmvacode}
 \caption[.]{\codeexampleCaptionSize Running the TMVA GUI's from the command line.}
 \end{codeexample}
-or through the adding line 
+or through the adding line
 \begin{codeexample}\begin{tmvacode}
 if (not gROOT->IsBatch()) {
    TMVA::TMVAGui("path/to/tmva/output/file.root");
@@ -214,34 +214,34 @@ to your training file. See the last lines of \code{TMVAClassification.C} for an 
 
 % This is not true anymore
 % TMVA also provides a variety of control and performance plots that can be displayed via a set of ROOT macros available in {\tt \$}\code{ROOTSYS/tmva/test/}. The macros are summarized in Tables~\ref{pgr:scripttable1} and \ref{pgr:scripttable2} on  page~\pageref{pgr:scripttable1}.  At the end of the example jobs a graphical  user interface (GUI)\index{Graphical user interface (GUI)} is displayed, which conveniently allows to run these macros (see Fig.~\ref{fig:tmvagui}).
- 
-Examples for plots produced by these macros are given in 
-Figs.~\ref{fig:usingtmva:correlations}--\ref{fig:usingtmva:rejBvsS} for a 
+
+Examples for plots produced by these macros are given in
+Figs.~\ref{fig:usingtmva:correlations}--\ref{fig:usingtmva:rejBvsS} for a
 classification problem.
-The distributions of the input variables for signal and background 
-according to our example job are shown in Fig.~\ref{fig:usingtmva:variables}. 
+The distributions of the input variables for signal and background
+according to our example job are shown in Fig.~\ref{fig:usingtmva:variables}.
 It is useful to quantify the correlations between the input variables.
 These are drawn in form of a scatter plot with the superimposed profile for
-two of the input variables in Fig.~\ref{fig:usingtmva:correlations} (upper left).  
-As will be discussed in Sec.~\ref{sec:dataPreprocessing}, TMVA allows to perform 
+two of the input variables in Fig.~\ref{fig:usingtmva:correlations} (upper left).
+As will be discussed in Sec.~\ref{sec:dataPreprocessing}, TMVA allows to perform
 a linear decorrelation transformation of the input variables prior to the MVA
-training (for classification only). The result of such decorrelation is shown 
-at the upper right hand plot of Fig.~\ref{fig:usingtmva:correlations}. The lower 
-plots display the linear correlation coefficients between all input variables, 
+training (for classification only). The result of such decorrelation is shown
+at the upper right hand plot of Fig.~\ref{fig:usingtmva:correlations}. The lower
+plots display the linear correlation coefficients between all input variables,
 for the signal and background training samples of the classification example.
 
-Figure~\ref{fig:usingtmva:mvas} shows several classifier output 
-distributions for signal and background events based on the test sample. 
-By TMVA convention, signal (background) events accumulate at large 
+Figure~\ref{fig:usingtmva:mvas} shows several classifier output
+distributions for signal and background events based on the test sample.
+By TMVA convention, signal (background) events accumulate at large
 (small) classifier output values. Hence, cutting on the output and retaining
 the events with \yMVA larger than the cut requirement selects signal samples
-with efficiencies and purities that respectively decrease and increase with 
-the cut value. The resulting relations between background rejection versus 
-signal efficiency are shown in Fig.~\ref{fig:usingtmva:rejBvsS} for all 
-classifiers that were used in the example macro. This plot belongs to the 
-class of {\em Receiver Operating Characteristic} (ROC)\index{Receiver 
+with efficiencies and purities that respectively decrease and increase with
+the cut value. The resulting relations between background rejection versus
+signal efficiency are shown in Fig.~\ref{fig:usingtmva:rejBvsS} for all
+classifiers that were used in the example macro. This plot belongs to the
+class of {\em Receiver Operating Characteristic} (ROC)\index{Receiver
 Operating Characteristic (ROC)} diagrams,
-which in its standard form shows the true positive rate versus the false 
+which in its standard form shows the true positive rate versus the false
 positive rate for the different possible cutpoints of a hypothesis test.
 
 For multiclass classification the corresponding GUI is show in Figure~\ref{fig:tmva:multiclass:gui} (left). Some differences to the binary classification GUI exists.
@@ -252,14 +252,14 @@ In 1 vs. 1, $C(C-1)$ plots are generated where each pair of classes are consider
 Example output for one classes in 1 vs. Rest is shown in Figure~\ref{fig:tmva:multiclass:gui} (right).
 
 As an example for multivariate regression, Fig.~\ref{fig:usingtmva:deviation} displays
-the deviation between the regression output and target values for linear and 
-nonlinear regression algorithms. 
+the deviation between the regression output and target values for linear and
+nonlinear regression algorithms.
 
-More macros are available to validate training and response of specific 
-MVA methods. For example, the macro \code{likelihoodrefs.C} compares the 
-probability density functions used by the likelihood classifier to the normalised 
-variable distributions of the training sample. It is also possible to visualize 
-the MLP neural network architecture and to draw decision trees (see 
+More macros are available to validate training and response of specific
+MVA methods. For example, the macro \code{likelihoodrefs.C} compares the
+probability density functions used by the likelihood classifier to the normalised
+variable distributions of the training sample. It is also possible to visualize
+the MLP neural network architecture and to draw decision trees (see
 Table~\ref{pgr:scripttable2}).
 \begin{figure}[t]
 \begin{center}
@@ -275,10 +275,10 @@ Table~\ref{pgr:scripttable2}).
 \end{center}
 \vspace{-0.7cm}
 \caption[.]{Correlation between input variables. Upper left: correlations
-         between var3 and var4 for the signal training sample. 
-         Upper right: the same after applying a linear decorrelation transformation 
-         (see Sec.~\ref{sec:decorrelation}). Lower plots: 
-         linear correlation coefficients for the signal and background 
+         between var3 and var4 for the signal training sample.
+         Upper right: the same after applying a linear decorrelation transformation
+         (see Sec.~\ref{sec:decorrelation}). Lower plots:
+         linear correlation coefficients for the signal and background
          training samples.
 }
 \label{fig:usingtmva:correlations}
@@ -296,7 +296,7 @@ Table~\ref{pgr:scripttable2}).
   \includegraphics[width=0.50\textwidth]{plots/MVA-BDT}
 \end{center}
 \vspace{-0.5cm}
-\caption[.]{Example plots for classifier output distributions for signal and 
+\caption[.]{Example plots for classifier output distributions for signal and
             background events from the academic test sample. Shown are
             likelihood (upper left), PDE range search
             (upper right), Multilayer perceptron (MLP -- lower left) and boosted decision trees.}
@@ -321,8 +321,8 @@ Table~\ref{pgr:scripttable2}).
 \end{center}
 \vspace{-1.2cm}
 \caption[.]{Example plots for the deviation between regression output and target values
-            for a Linear Discriminant (LD -- left) and MLP (right). The dependence of the 
-            input variables on the target being strongly nonlinear, LD cannot appropriately 
+            for a Linear Discriminant (LD -- left) and MLP (right). The dependence of the
+            input variables on the target being strongly nonlinear, LD cannot appropriately
             solve the regression problem. }
 \label{fig:usingtmva:deviation}
 \end{figure}
@@ -331,11 +331,13 @@ Table~\ref{pgr:scripttable2}).
 
 \subsection{Getting help}
 
-Several help sources exist for TMVA (all web address given below are also linked from the 
-TMVA home page \urlsm{http://tmva.sourceforge.net}).
+Several help sources exist for TMVA
+%(all web address given below are also linked from the
+%TMVA home page \urlsm{http://tmva.sourceforge.net}).
+
 \begin{itemize}
 
-%\item Information on how to download and install TMVA, and the TMVA {\em Quick-start} commands 
+%\item Information on how to download and install TMVA, and the TMVA {\em Quick-start} commands
 %      are also available on the web at: \urlsm{http://tmva.sourceforge.net/howto.shtml}.
 
 \item TMVA tutorial: \urlsm{https://twiki.cern.ch/twiki/bin/view/TMVA}.
@@ -343,9 +345,9 @@ TMVA home page \urlsm{http://tmva.sourceforge.net}).
 %\item An up-to-date reference of all configuration options for the TMVA Factory, the fitters,
 %      and all the MVA methods: \urlsm{http://tmva.sourceforge.net/optionRef.html}.
 
-\item On request, the TMVA methods provide a help message with a brief description of the 
-      method, and hints for improving the performance by tuning the available configuration 
-      options. The message is printed when the option "\code{H}" is added to the configuration 
+\item On request, the TMVA methods provide a help message with a brief description of the
+      method, and hints for improving the performance by tuning the available configuration
+      options. The message is printed when the option "\code{H}" is added to the configuration
       string while booking the method (switch off by setting "\code{!H}").
 
 \item The web address of this Users Guide:
@@ -361,7 +363,7 @@ TMVA home page \urlsm{http://tmva.sourceforge.net}).
 
 \end{itemize}
 
-%%% Local Variables: 
+%%% Local Variables:
 %%% mode: latex
 %%% TeX-master: "TMVAUsersGuide"
-%%% End: 
+%%% End:

--- a/documentation/users-guide/MathLibraries.md
+++ b/documentation/users-guide/MathLibraries.md
@@ -3169,4 +3169,4 @@ details the chapter "Neural Networks").
 determinant estimator (MCD).
 
 **`TMVA`** is a package for multivariate data analysis (see
-<http://tmva.sourceforge.net/docu/TMVAUsersGuide.pdf> the User's Guide).
+<https://github.com/root-project/root/blob/master/documentation/tmva/UsersGuide/TMVAUsersGuide.pdf> the User's Guide).

--- a/tmva/doc/README
+++ b/tmva/doc/README
@@ -3,11 +3,9 @@
 ========================================================================================
 
 
-TMVA Users Guide    : http://tmva.sourceforge.net/docu/TMVAUsersGuide.pdf
-TMVA home page      : http://tmva.sourceforge.net/
-TMVA download page  : http://sourceforge.net/projects/tmva
-TMVA mailing list   : http://sourceforge.net/mailarchive/forum.php?forum_name=tmva-users
-TMVA license (BSD)  : http://tmva.sourceforge.net/LICENSE
+TMVA Users Guide    : https://github.com/root-project/root/blob/master/documentation/tmva/UsersGuide/TMVAUsersGuide.pdf
+TMVA home page      : https://root.cern/manual/tmva/
+TMVA license (BSD)  : see tmva/doc/LICENSE
 
 ========================================================================================
 
@@ -18,25 +16,25 @@ copying of 'evaluation macros' necessary anymore !
 
 All the evaluation macros are now part of the TMVA library libTMVA.so
 
-Example scripts of how to run TMVA are availabe in $ROOTSYS/tutorials/tmva/
+Example scripts of how to run TMVA are available in $ROOTSYS/tutorials/tmva/
 !!!!!
- 
+
+After 2013 TMVA was completely integrated into ROOT and is now released as part of it.
+The old Web site can still be found at https://tmva.sourceforge.net/old_site
+
 
 System requirements:
 --------------------
 
   TMVA has been tested to run on Linux, MAC/OSX and Windows platforms.
 
-  Running TMVA requires the availability of ROOT shared libraries with ROOT_VERSION >= 5.14
-  (type "root-config --version" to see the version installed)
-
 ========================================================================================
-Getting Started: 
+Getting Started:
 ----------------
   Example scripts of how to run TMVA are availabe in $ROOTSYS/tutorials/tmva/
-  
-  please simply copy one of those scripts to you 'work' directory  
-  
+
+  please simply copy one of those scripts to you 'work' directory
+
   --- For classification:
   ~/myTMVAwork> root -l TMVAClassification.C                       # run all standard classifiers (takes a while)
   ~/myTMVAWork> root -l TMVAClassification.C\(\"LD,Likelihood\"\)  # run LD and Likelihood classifiers
@@ -50,26 +48,26 @@ Getting Started:
       corresponding classifiers/regression algorithms have been trained/tested before
       (unless they are greyed out)
 
-  How to run the code as an executable: 
+  How to run the code as an executable:
   -------------------------------------
   Get an example code/makefile from $ROOTSYS/tuturial/tmva
   ~/myTMVAwork> make TMVAClassification
-  ~/myTMVAwork> ./TMVAClassification                              # run all standard classifiers 
-  ~/myTMVAwork> ./TMVAClassification LD Likelihood                # run LD and Likelihood classifiers 
+  ~/myTMVAwork> ./TMVAClassification                              # run all standard classifiers
+  ~/myTMVAwork> ./TMVAClassification LD Likelihood                # run LD and Likelihood classifiers
 
   ... and similarly for regression
 
-  ~/myTMVAwork> root -l 
-  ~/myTMVAwork> TMVA::Tools::Instance()  #setup TMVA (loads the library)           
-  ~/myTMVAwork> TMVA::TMVAGui()   #starts the Gui on the 'default tmva ouput file' TMVA.root   
+  ~/myTMVAwork> root -l
+  ~/myTMVAwork> TMVA::Tools::Instance()  #setup TMVA (loads the library)
+  ~/myTMVAwork> TMVA::TMVAGui()   #starts the Gui on the 'default tmva ouput file' TMVA.root
   ~/myTMVAwork> TMVA::TMVAGui("TheFileCreatedByYourTraining.root"   # start the GUI
 
   How to apply the TMVA methods:
   -------------------------------------
 
   --- For classification:
-  ~/myTMVAwork> root -l TMVAClassificationApplication.C                
-  ~/myTMVAwork> root -l TMVAClassificationApplication.C\(\"LD,Likelihood\"\) 
+  ~/myTMVAwork> root -l TMVAClassificationApplication.C
+  ~/myTMVAwork> root -l TMVAClassificationApplication.C\(\"LD,Likelihood\"\)
 
   ... and similar for regression.
   ... and similar for executables.
@@ -79,10 +77,10 @@ Getting Started:
 Executive summary:
 ------------------
 
-The Toolkit for Multivariate Analysis (TMVA) provides a machine learning environment 
+The Toolkit for Multivariate Analysis (TMVA) provides a machine learning environment
 for the processing and parallel evaluation of multivariate classification and regression
-algorithms. TMVA is integrated into the data analysis framework ROOT. It is specifically 
-designed to the needs of high-energy physics (HEP) applications, but should not be 
+algorithms. TMVA is integrated into the data analysis framework ROOT. It is specifically
+designed to the needs of high-energy physics (HEP) applications, but should not be
 restricted to these. The package includes:
 
     * Rectangular cut optimisation
@@ -93,73 +91,75 @@ restricted to these. The package includes:
     * Artificial neural networks (three different Multilayer Perceptron implementations)
     * Support Vector Machine (SVM)
     * Boosted/Bagged decision trees
-    * Predictive learning via rule ensembles (RuleFit) 
+    * Predictive learning via rule ensembles (RuleFit)
 
-TMVA consists of object-oriented implementations in C++ for each of these discrimination 
-techniques and provides training, testing and performance evaluation algorithms and 
-visualization scripts. The classifier/regression training and testing is performed with 
-the use of user-supplied data sets in form of ROOT trees or text files, where each event 
-can have an individual weight. The true event classification/target value in these data 
-sets must be known. Preselection requirements and transformations can be applied on this 
+TMVA consists of object-oriented implementations in C++ for each of these discrimination
+techniques and provides training, testing and performance evaluation algorithms and
+visualization scripts. The classifier/regression training and testing is performed with
+the use of user-supplied data sets in form of ROOT trees or text files, where each event
+can have an individual weight. The true event classification/target value in these data
+sets must be known. Preselection requirements and transformations can be applied on this
 data. TMVA supports the use of variable combinations and formulas.
 
-TMVA works in transparent factory mode to guarantee an unbiased performance comparison 
-between the algorithms: all algorithms see the same training and test data, and are 
-evaluated following the same prescriptions within the same execution job. A Factory 
-class organises the interaction between the user and the TMVA analysis steps. It performs 
-preanalysis and preprocessing of the training data to assess basic properties of the 
-discriminating variables used as input to the algorithms. The linear correlation 
-coefficients of the input variables are calculated and displayed, and a preliminary 
-ranking is derived (which is later superseded by method-specific variable rankings). 
-The variables can be linearly transformed (individually for each algorithm) into a 
-non-correlated variable space or projected upon their principle components. To compare 
-the signal-efficiency and background-rejection performance of the algorithms, the 
-analysis job prints tabulated results for some benchmark values, besides other criteria 
-such as a measure of the separation and the maximum signal significance. Smooth 
-efficiency versus background rejection curves are stored in a ROOT output file, 
-together with other graphical evaluation information. These results can be displayed 
-using ROOT macros, which are conveniently executed via a graphical user interface that 
+TMVA works in transparent factory mode to guarantee an unbiased performance comparison
+between the algorithms: all algorithms see the same training and test data, and are
+evaluated following the same prescriptions within the same execution job. A Factory
+class organises the interaction between the user and the TMVA analysis steps. It performs
+preanalysis and preprocessing of the training data to assess basic properties of the
+discriminating variables used as input to the algorithms. The linear correlation
+coefficients of the input variables are calculated and displayed, and a preliminary
+ranking is derived (which is later superseded by method-specific variable rankings).
+The variables can be linearly transformed (individually for each algorithm) into a
+non-correlated variable space or projected upon their principle components. To compare
+the signal-efficiency and background-rejection performance of the algorithms, the
+analysis job prints tabulated results for some benchmark values, besides other criteria
+such as a measure of the separation and the maximum signal significance. Smooth
+efficiency versus background rejection curves are stored in a ROOT output file,
+together with other graphical evaluation information. These results can be displayed
+using ROOT macros, which are conveniently executed via a graphical user interface that
 comes with the TMVA distribution.
 
-The TMVA training job runs alternatively as a ROOT script, as a standalone executable, 
-where libTMVA.so is linked as a shared library, or as a python script via the PyROOT 
-interface. Each MVA method trained in one of these applications writes its configuration 
-and training results in result (``weight'') files, which consists of one text and one 
+The TMVA training job runs alternatively as a ROOT script, as a standalone executable,
+where libTMVA.so is linked as a shared library, or as a python script via the PyROOT
+interface. Each MVA method trained in one of these applications writes its configuration
+and training results in result (``weight'') files, which consists of one text and one
 ROOT file.
 
-A light-weight Reader class is provided, which reads and interprets the weight files 
-(interfaced by the corresponding MVA method), and which can be included in any C++ 
+A light-weight Reader class is provided, which reads and interprets the weight files
+(interfaced by the corresponding MVA method), and which can be included in any C++
 executable, ROOT macro or python analysis job.
 
-For standalone use of the trained MVA methods, TMVA also generates lightweight C++ 
-response classes (not available for all MVA methods), which contain the encoded 
-information from the weight files so that these are not required anymore. These classes 
+For standalone use of the trained MVA methods, TMVA also generates lightweight C++
+response classes (not available for all MVA methods), which contain the encoded
+information from the weight files so that these are not required anymore. These classes
 do not depend on TMVA or ROOT, neither on any other external library.
 
-We have put emphasis on the clarity and functionality of the Factory and Reader 
-interfaces to the user applications. All MVA methods run with reasonable default 
-configurations, so that for standard applications that do not require particular 
-tuning, the user script for a full TMVA analysis will hardly exceed a few lines 
-of code. For individual optimisation the user can (and should) customize the 
+We have put emphasis on the clarity and functionality of the Factory and Reader
+interfaces to the user applications. All MVA methods run with reasonable default
+configurations, so that for standard applications that do not require particular
+tuning, the user script for a full TMVA analysis will hardly exceed a few lines
+of code. For individual optimisation the user can (and should) customize the
 classifiers via configuration strings.
 
 Please report any problems and/or suggestions for improvements to the authors.
 
 ========================================================================================
 
-Copyright © (2005-2010):  
+Copyright © (2005-2010):
 ------------------------
 
    Andreas Hoecker, Peter Speckmayer, Jörg Stelzer (CERN, Switzerland),
-   Jan Therhaag, Eckhard von Toerne (U. Bonn, Germany), 
-   Helge Voss (MPI-KP Heidelberg, Germany), 
+   Jan Therhaag, Eckhard von Toerne (U. Bonn, Germany),
+   Helge Voss (MPI-KP Heidelberg, Germany),
 
-Contributed to TMVA have, please see: http://tmva.sourceforge.net/#authors
+Contributed to TMVA (up to 2013) please see: http://tmva.sourceforge.net/old_site/#authors
 
-Redistribution and use of TMVA in source and binary forms, with or without 
+For contributors after 2013 (when TMVA was fully integrated in ROOT), see $ROOTSYS/README/CREDITS
+
+Redistribution and use of TMVA in source and binary forms, with or without
 modification, are permitted according to the terms listed in the BSD license:
-http://tmva.sourceforge.net/LICENSE
+see tmva/doc/LICENSE
 
 -----------------------------------------------------------------------------
-@(#)root/tmva $Id: README,v 1.14 2008-03-12 18:10:35 andreas.hoecker Exp $   
+@(#)root/tmva $Id: README,v 1.14 2008-03-12 18:10:35 andreas.hoecker Exp $
 

--- a/tmva/doc/index.md
+++ b/tmva/doc/index.md
@@ -5,7 +5,11 @@ The TMVA Multi-Variate-Analysis classes.
 
  See:
 
-  - [The full description of the Multi Variate Analysis package.](http://tmva.sourceforge.net)
-  - [The TMVA Users Guide.](http://tmva.sourceforge.net/docu/TMVAUsersGuide.pdf)
-  - [The TMVA Options Reference.](http://tmva.sourceforge.net/optionRef.html)
+  - [The TMVA Web manual in ROOT Web site](https://root.cern/manual/tmva/)
+  - [The TMVA Users Guide.](https://github.com/root-project/root/blob/master/documentation/tmva/UsersGuide/TMVAUsersGuide.pdf)
+
+Old links, referring to old TMVA versions, but they can still be useful for some of the TMVA methods:
+
+  - [Description of the traditional TMVA Methods](http://tmva.sourceforge.net/old_site)
+  - [The TMVA Options Reference.](http://tmva.sourceforge.net/old_site/optionRef.html)
 

--- a/tmva/pymva/inc/TMVA/MethodPyKeras.h
+++ b/tmva/pymva/inc/TMVA/MethodPyKeras.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodPyKeras                                                         *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Interface for Keras python package which is a wrapper for the Theano and  *
@@ -20,7 +20,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_MethodPyKeras

--- a/tmva/pymva/inc/TMVA/MethodPyTorch.h
+++ b/tmva/pymva/inc/TMVA/MethodPyTorch.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodPyTorch                                                         *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Interface for PyTorch python based scientific package supporting          *
@@ -20,7 +20,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_MethodPyTorch

--- a/tmva/pymva/inc/TMVA/RModelParser_Keras.h
+++ b/tmva/pymva/inc/TMVA/RModelParser_Keras.h
@@ -4,7 +4,7 @@
 /**********************************************************************************
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Functionality for parsing a saved Keras .H5 model into RModel object      *
@@ -18,7 +18,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 

--- a/tmva/pymva/inc/TMVA/RModelParser_PyTorch.h
+++ b/tmva/pymva/inc/TMVA/RModelParser_PyTorch.h
@@ -4,7 +4,7 @@
 /**********************************************************************************
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Functionality for parsing a saved PyTorch .PT model into RModel object    *
@@ -18,7 +18,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 

--- a/tmva/pymva/src/MethodPyAdaBoost.cxx
+++ b/tmva/pymva/src/MethodPyAdaBoost.cxx
@@ -13,7 +13,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  *                                                                                *
  **********************************************************************************/
 

--- a/tmva/pymva/src/MethodPyGTB.cxx
+++ b/tmva/pymva/src/MethodPyGTB.cxx
@@ -13,7 +13,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  *                                                                                *
  **********************************************************************************/
 

--- a/tmva/pymva/src/MethodPyRandomForest.cxx
+++ b/tmva/pymva/src/MethodPyRandomForest.cxx
@@ -13,7 +13,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  *                                                                                *
  **********************************************************************************/
 #include <Python.h>    // Needs to be included first to avoid redefinition of _POSIX_C_SOURCE

--- a/tmva/rmva/src/MethodC50.cxx
+++ b/tmva/rmva/src/MethodC50.cxx
@@ -13,7 +13,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  *                                                                                *
  **********************************************************************************/
 

--- a/tmva/rmva/src/MethodRSNNS.cxx
+++ b/tmva/rmva/src/MethodRSNNS.cxx
@@ -14,7 +14,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  *                                                                                *
  **********************************************************************************/
 

--- a/tmva/rmva/src/MethodRSVM.cxx
+++ b/tmva/rmva/src/MethodRSVM.cxx
@@ -13,7 +13,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  *                                                                                *
  **********************************************************************************/
 

--- a/tmva/rmva/src/MethodRXGB.cxx
+++ b/tmva/rmva/src/MethodRXGB.cxx
@@ -13,7 +13,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  *                                                                                *
  **********************************************************************************/
 

--- a/tmva/tmva/inc/TMVA/BDTEventWrapper.h
+++ b/tmva/tmva/inc/TMVA/BDTEventWrapper.h
@@ -3,7 +3,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : BDTEventWrapper                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *                                                                                *
@@ -16,7 +16,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_BDTEventWrapper

--- a/tmva/tmva/inc/TMVA/BinarySearchTree.h
+++ b/tmva/tmva/inc/TMVA/BinarySearchTree.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : BinarySearchTree                                                      *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      BinarySearchTree incl. volume Search method                               *
@@ -24,7 +24,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_BinarySearchTree

--- a/tmva/tmva/inc/TMVA/BinarySearchTreeNode.h
+++ b/tmva/tmva/inc/TMVA/BinarySearchTreeNode.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: Node, NodeID                                                          *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Node for the BinarySearch                                                 *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_BinarySearchTreeNode

--- a/tmva/tmva/inc/TMVA/BinaryTree.h
+++ b/tmva/tmva/inc/TMVA/BinaryTree.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : BinaryTree                                                            *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      BinaryTree: A base class for BinarySearch- or Decision-Trees              *
@@ -24,7 +24,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_BinaryTree

--- a/tmva/tmva/inc/TMVA/CCPruner.h
+++ b/tmva/tmva/inc/TMVA/CCPruner.h
@@ -4,7 +4,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : CCPruner                                                              *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description: Cost Complexity Pruning                                           *
  *
@@ -18,7 +18,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/inc/TMVA/CCTreeWrapper.h
+++ b/tmva/tmva/inc/TMVA/CCTreeWrapper.h
@@ -3,7 +3,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : CCTreeWrapper                                                         *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description: a light wrapper of a decision tree, used to perform cost          *
  *              complexity pruning "in-place" Cost Complexity Pruning             *
@@ -18,7 +18,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_CCTreeWrapper

--- a/tmva/tmva/inc/TMVA/ClassInfo.h
+++ b/tmva/tmva/inc/TMVA/ClassInfo.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : ClassInfo                                                             *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Contains all the data information                                         *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_ClassInfo

--- a/tmva/tmva/inc/TMVA/ClassifierFactory.h
+++ b/tmva/tmva/inc/TMVA/ClassifierFactory.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Factory                                                               *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  * This template creates ClassifierFactory stores creator functors                *
@@ -20,7 +20,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_ClassifierFactory

--- a/tmva/tmva/inc/TMVA/Config.h
+++ b/tmva/tmva/inc/TMVA/Config.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Config                                                                *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      GLobal configuration settings (singleton)                                 *

--- a/tmva/tmva/inc/TMVA/Configurable.h
+++ b/tmva/tmva/inc/TMVA/Configurable.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Configurable                                                          *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Base class for all classes with option parsing                            *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_Configurable

--- a/tmva/tmva/inc/TMVA/ConvergenceTest.h
+++ b/tmva/tmva/inc/TMVA/ConvergenceTest.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : ConvergenceTest                                                             *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Contains all the data information                                         *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_ConvergenceTest

--- a/tmva/tmva/inc/TMVA/CostComplexityPruneTool.h
+++ b/tmva/tmva/inc/TMVA/CostComplexityPruneTool.h
@@ -2,7 +2,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::DecisionTree                                                    *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation of a Decision Tree                                         *

--- a/tmva/tmva/inc/TMVA/CrossEntropy.h
+++ b/tmva/tmva/inc/TMVA/CrossEntropy.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : CrossEntropy                                                          *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description: Implementation of the CrossEntropy as separation criterion        *
  *                                                                                *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_CrossEntropy

--- a/tmva/tmva/inc/TMVA/DNN/Adadelta.h
+++ b/tmva/tmva/inc/TMVA/DNN/Adadelta.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TAdadelta                                                                 *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Adadelta Optimizer Class                                                      *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef TMVA_DNN_ADADELTA

--- a/tmva/tmva/inc/TMVA/DNN/Adagrad.h
+++ b/tmva/tmva/inc/TMVA/DNN/Adagrad.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TAdagrad                                                                 *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Adagrad Optimizer Class                                                      *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef TMVA_DNN_ADAGRAD

--- a/tmva/tmva/inc/TMVA/DNN/Adam.h
+++ b/tmva/tmva/inc/TMVA/DNN/Adam.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TAdam                                                                 *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Adam Optimizer Class                                                      *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef TMVA_DNN_ADAM

--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Reference/TensorDataLoader.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Reference/TensorDataLoader.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TTensorDataLoader                                                     *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Specialization of the Tensor Data Loader Class                            *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 //////////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/inc/TMVA/DNN/BatchNormLayer.h
+++ b/tmva/tmva/inc/TMVA/DNN/BatchNormLayer.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TBatchNormLayer                                                           *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Dense Layer Class                                                         *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef TMVA_DNN_BatchNormLayer

--- a/tmva/tmva/inc/TMVA/DNN/CNN/ConvLayer.h
+++ b/tmva/tmva/inc/TMVA/DNN/CNN/ConvLayer.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TConvLayer                                                            *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Convolutional Deep Neural Network Layer                                   *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef TMVA_CNN_CONVLAYER

--- a/tmva/tmva/inc/TMVA/DNN/CNN/MaxPoolLayer.h
+++ b/tmva/tmva/inc/TMVA/DNN/CNN/MaxPoolLayer.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMaxPoolLayer                                                         *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Max Pool Deep Neural Network Layer                                        *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef MAXPOOLLAYER_H_

--- a/tmva/tmva/inc/TMVA/DNN/DLMinimizers.h
+++ b/tmva/tmva/inc/TMVA/DNN/DLMinimizers.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TDLGradientDescent                                                    *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Deel Learning Minimizers                                                  *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef TMVA_DNN_DLMINIMIZERS

--- a/tmva/tmva/inc/TMVA/DNN/DeepNet.h
+++ b/tmva/tmva/inc/TMVA/DNN/DeepNet.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TDeepNet                                                              *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Deep Neural Network                                                       *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef TMVA_DNN_DEEPNET

--- a/tmva/tmva/inc/TMVA/DNN/DenseLayer.h
+++ b/tmva/tmva/inc/TMVA/DNN/DenseLayer.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TDenseLayer                                                           *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Dense Layer Class                                                         *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef TMVA_DNN_DENSELAYER

--- a/tmva/tmva/inc/TMVA/DNN/GeneralLayer.h
+++ b/tmva/tmva/inc/TMVA/DNN/GeneralLayer.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TGeneralLayer                                                         *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      General Deep Neural Network Layer                                         *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef TMVA_DNN_GENERALLAYER

--- a/tmva/tmva/inc/TMVA/DNN/Optimizer.h
+++ b/tmva/tmva/inc/TMVA/DNN/Optimizer.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : VOptimizer                                                            *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      General Optimizer Class                                                   *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef TMVA_DNN_OPTIMIZER

--- a/tmva/tmva/inc/TMVA/DNN/RMSProp.h
+++ b/tmva/tmva/inc/TMVA/DNN/RMSProp.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TRMSProp                                                              *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      RMSProp Optimizer Class                                                   *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef TMVA_DNN_RMSPROP

--- a/tmva/tmva/inc/TMVA/DNN/ReshapeLayer.h
+++ b/tmva/tmva/inc/TMVA/DNN/ReshapeLayer.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TReshapeLayer                                                         *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Reshape Deep Neural Network Layer                                         *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef TMVA_DNN_RESHAPELAYER

--- a/tmva/tmva/inc/TMVA/DNN/SGD.h
+++ b/tmva/tmva/inc/TMVA/DNN/SGD.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TSGD                                                                  *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Stochastic Batch Gradient Descent Optimizer Class                         *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef TMVA_DNN_SGD

--- a/tmva/tmva/inc/TMVA/DNN/TensorDataLoader.h
+++ b/tmva/tmva/inc/TMVA/DNN/TensorDataLoader.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TTensorDataLoader                                                     *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Tensor Data Loader Class                                                  *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef TMVA_DNN_TENSORDATALOADER

--- a/tmva/tmva/inc/TMVA/DataInputHandler.h
+++ b/tmva/tmva/inc/TMVA/DataInputHandler.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : DataInputHandler                                                      *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Contains all the data information                                         *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_DataInputHandler

--- a/tmva/tmva/inc/TMVA/DataLoader.h
+++ b/tmva/tmva/inc/TMVA/DataLoader.h
@@ -6,7 +6,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : DataLoader                                                            *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      This is a class to load datasets into every booked method                 *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_DataLoader

--- a/tmva/tmva/inc/TMVA/DataSet.h
+++ b/tmva/tmva/inc/TMVA/DataSet.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : DataSet                                                               *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Contains all the data information                                         *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_DataSet

--- a/tmva/tmva/inc/TMVA/DataSetFactory.h
+++ b/tmva/tmva/inc/TMVA/DataSetFactory.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : DataSetFactory                                                        *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Contains all the data information                                         *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_DataSetFactory

--- a/tmva/tmva/inc/TMVA/DataSetInfo.h
+++ b/tmva/tmva/inc/TMVA/DataSetInfo.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : DataSetInfo                                                           *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Contains all the data information                                         *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_DataSetInfo

--- a/tmva/tmva/inc/TMVA/DataSetManager.h
+++ b/tmva/tmva/inc/TMVA/DataSetManager.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : DataSetManager                                                        *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Singleton class for dataset management                                    *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_DataSetManager

--- a/tmva/tmva/inc/TMVA/DecisionTree.h
+++ b/tmva/tmva/inc/TMVA/DecisionTree.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : DecisionTree                                                          *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation of a Decision Tree                                         *

--- a/tmva/tmva/inc/TMVA/DecisionTreeNode.h
+++ b/tmva/tmva/inc/TMVA/DecisionTreeNode.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : DecisionTreeNode                                                      *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Node for the Decision Tree                                                *
@@ -24,7 +24,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_DecisionTreeNode

--- a/tmva/tmva/inc/TMVA/Event.h
+++ b/tmva/tmva/inc/TMVA/Event.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Event                                                                 *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Event container                                                           *

--- a/tmva/tmva/inc/TMVA/ExpectedErrorPruneTool.h
+++ b/tmva/tmva/inc/TMVA/ExpectedErrorPruneTool.h
@@ -2,7 +2,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::DecisionTree                                                    *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation of a Decision Tree                                         *

--- a/tmva/tmva/inc/TMVA/Factory.h
+++ b/tmva/tmva/inc/TMVA/Factory.h
@@ -6,7 +6,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Factory                                                               *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      This is the main MVA steering class: it creates (books) all MVA methods,  *
@@ -34,7 +34,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_Factory

--- a/tmva/tmva/inc/TMVA/FitterBase.h
+++ b/tmva/tmva/inc/TMVA/FitterBase.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : FitterBase                                                            *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Base class for TMVA fitters                                               *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_FitterBase

--- a/tmva/tmva/inc/TMVA/GeneticAlgorithm.h
+++ b/tmva/tmva/inc/TMVA/GeneticAlgorithm.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : GeneticAlgorithm                                                      *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Base definition for genetic algorithm                                     *
@@ -19,7 +19,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_GeneticAlgorithm

--- a/tmva/tmva/inc/TMVA/GeneticFitter.h
+++ b/tmva/tmva/inc/TMVA/GeneticFitter.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : GeneticFitter                                                         *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *       Fitter using a Genetic Algorithm                                         *
@@ -19,7 +19,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_GeneticFitter

--- a/tmva/tmva/inc/TMVA/GeneticGenes.h
+++ b/tmva/tmva/inc/TMVA/GeneticGenes.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : GeneticGenes                                                          *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Genes definition for genetic algorithm                                    *
@@ -19,7 +19,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_GeneticGenes

--- a/tmva/tmva/inc/TMVA/GeneticPopulation.h
+++ b/tmva/tmva/inc/TMVA/GeneticPopulation.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : GeneticPopulation                                                     *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *    Population definition for genetic algorithm                                 *
@@ -19,7 +19,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_GeneticPopulation

--- a/tmva/tmva/inc/TMVA/GeneticRange.h
+++ b/tmva/tmva/inc/TMVA/GeneticRange.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : GeneticRange                                                          *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *    Range definition for genetic algorithm                                      *
@@ -19,7 +19,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_GeneticRange

--- a/tmva/tmva/inc/TMVA/GiniIndex.h
+++ b/tmva/tmva/inc/TMVA/GiniIndex.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : GiniIndex                                                             *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description: Implementation of the GiniIndex as separation criterion           *
  *              Large Gini Indices (maximum 0.5) mean , that the sample is well   *

--- a/tmva/tmva/inc/TMVA/GiniIndexWithLaplace.h
+++ b/tmva/tmva/inc/TMVA/GiniIndexWithLaplace.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : GiniIndexWithLaplace                                                  *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description: Implementation of the GiniIndex With Laplace correction           *
  *              as separation criterion                                           *

--- a/tmva/tmva/inc/TMVA/IFitterTarget.h
+++ b/tmva/tmva/inc/TMVA/IFitterTarget.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : IFitterTarget                                                         *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Interface for generic fitter                                              *
@@ -20,7 +20,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_IFitterTarget

--- a/tmva/tmva/inc/TMVA/IMethod.h
+++ b/tmva/tmva/inc/TMVA/IMethod.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : IMethod                                                               *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Interface for all concrete MVA method implementations                     *
@@ -24,7 +24,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_IMethod

--- a/tmva/tmva/inc/TMVA/IPruneTool.h
+++ b/tmva/tmva/inc/TMVA/IPruneTool.h
@@ -2,7 +2,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::DecisionTree                                                    *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      IPruneTool - a helper interface class to prune a decision tree            *

--- a/tmva/tmva/inc/TMVA/Interval.h
+++ b/tmva/tmva/inc/TMVA/Interval.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Interval                                                              *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *    Generic range definition (used, eg, in genetic algorithm)                   *
@@ -19,7 +19,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_Interval

--- a/tmva/tmva/inc/TMVA/KDEKernel.h
+++ b/tmva/tmva/inc/TMVA/KDEKernel.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : KDEKernel                                                             *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      The Probability Density Functions (PDFs) used for the Likelihood analysis *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_KDEKernel

--- a/tmva/tmva/inc/TMVA/LDA.h
+++ b/tmva/tmva/inc/TMVA/LDA.h
@@ -3,7 +3,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : LDA                                                                   *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Local LDA method used by MethodKNN to compute MVA value.                  *
@@ -20,7 +20,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_LDA

--- a/tmva/tmva/inc/TMVA/LogInterval.h
+++ b/tmva/tmva/inc/TMVA/LogInterval.h
@@ -2,7 +2,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Interval                                                              *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *          Extension of the Interval to "logarithmic" intervals                  *
@@ -18,7 +18,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_LogInterval

--- a/tmva/tmva/inc/TMVA/LossFunction.h
+++ b/tmva/tmva/inc/TMVA/LossFunction.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Event                                                                 *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      LossFunction and associated classes                                       *

--- a/tmva/tmva/inc/TMVA/MCFitter.h
+++ b/tmva/tmva/inc/TMVA/MCFitter.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MCFitter                                                              *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Fitter using Monte Carlo sampling of parameters                           *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_MCFitter

--- a/tmva/tmva/inc/TMVA/MethodANNBase.h
+++ b/tmva/tmva/inc/TMVA/MethodANNBase.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodANNBase                                                         *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Artificial neural network base class for the discrimination of signal     *
@@ -28,7 +28,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_MethodANNBase

--- a/tmva/tmva/inc/TMVA/MethodBDT.h
+++ b/tmva/tmva/inc/TMVA/MethodBDT.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodBDT  (Boosted Decision Trees)                                   *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Analysis of Boosted Decision Trees                                        *
@@ -25,7 +25,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_MethodBDT

--- a/tmva/tmva/inc/TMVA/MethodBase.h
+++ b/tmva/tmva/inc/TMVA/MethodBase.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodBase                                                            *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Virtual base class for all MVA method                                     *
@@ -27,7 +27,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_MethodBase

--- a/tmva/tmva/inc/TMVA/MethodBayesClassifier.h
+++ b/tmva/tmva/inc/TMVA/MethodBayesClassifier.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodBayesClassifier                                                 *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Bayesian Classifier                                                       *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_MethodBayesClassifier

--- a/tmva/tmva/inc/TMVA/MethodBoost.h
+++ b/tmva/tmva/inc/TMVA/MethodBoost.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodCompositeBase                                                   *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Virtual base class for all MVA method                                     *
@@ -26,7 +26,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_MethodBoost

--- a/tmva/tmva/inc/TMVA/MethodCFMlpANN.h
+++ b/tmva/tmva/inc/TMVA/MethodCFMlpANN.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodCFMlpANN                                                        *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Interface for Clermond-Ferrand artificial neural network.                 *
@@ -68,7 +68,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  *                                                                                *
  **********************************************************************************/
 

--- a/tmva/tmva/inc/TMVA/MethodCFMlpANN_Utils.h
+++ b/tmva/tmva/inc/TMVA/MethodCFMlpANN_Utils.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodCFMlpANN_utils                                                  *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Reference for the original FORTRAN version "mlpl3.F":                          *
  *      Authors  : J. Proriol and contributions from ALEPH-Clermont-Fd            *
@@ -29,7 +29,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_MethodCFMlpANN_Utils

--- a/tmva/tmva/inc/TMVA/MethodCFMlpANN_def.h
+++ b/tmva/tmva/inc/TMVA/MethodCFMlpANN_def.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Header : MethodCFMlpANN_def                                                    *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Common definition for CFMlpANN method                                     *
@@ -24,7 +24,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 // ------------- common definitions used in several modules --------------

--- a/tmva/tmva/inc/TMVA/MethodCategory.h
+++ b/tmva/tmva/inc/TMVA/MethodCategory.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodCompositeBase                                                   *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Virtual base class for all MVA method                                     *
@@ -25,7 +25,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_MethodCategory

--- a/tmva/tmva/inc/TMVA/MethodCompositeBase.h
+++ b/tmva/tmva/inc/TMVA/MethodCompositeBase.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodCompositeBase                                                   *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Virtual base class for all MVA method                                     *
@@ -25,7 +25,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_MethodCompositeBase

--- a/tmva/tmva/inc/TMVA/MethodCuts.h
+++ b/tmva/tmva/inc/TMVA/MethodCuts.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodCuts                                                            *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Multivariate optimisation of signal efficiency for given background       *
@@ -27,7 +27,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_MethodCuts

--- a/tmva/tmva/inc/TMVA/MethodDL.h
+++ b/tmva/tmva/inc/TMVA/MethodDL.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodDL                                                              *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Deep Neural Network Method                                                *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_MethodDL

--- a/tmva/tmva/inc/TMVA/MethodDNN.h
+++ b/tmva/tmva/inc/TMVA/MethodDNN.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodDNN                                                              *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      NeuralNetwork                                                             *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 //#pragma once

--- a/tmva/tmva/inc/TMVA/MethodDT.h
+++ b/tmva/tmva/inc/TMVA/MethodDT.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodDT  (Boosted Decision Trees)                                   *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Analysis of Boosted Decision Trees                                        *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_MethodDT

--- a/tmva/tmva/inc/TMVA/MethodFDA.h
+++ b/tmva/tmva/inc/TMVA/MethodFDA.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodFDA                                                             *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Function discriminant analysis (FDA). This simple classifier              *
@@ -25,7 +25,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_MethodFDA

--- a/tmva/tmva/inc/TMVA/MethodFisher.h
+++ b/tmva/tmva/inc/TMVA/MethodFisher.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodFisher                                                          *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Analysis of Fisher discriminant (Fisher or Mahalanobis approach)          *
@@ -28,7 +28,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_MethodFisher

--- a/tmva/tmva/inc/TMVA/MethodHMatrix.h
+++ b/tmva/tmva/inc/TMVA/MethodHMatrix.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodHMatrix                                                         *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      H-Matrix method, which is implemented as a simple comparison of           *
@@ -27,7 +27,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_MethodHMatrix

--- a/tmva/tmva/inc/TMVA/MethodKNN.h
+++ b/tmva/tmva/inc/TMVA/MethodKNN.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodKNN                                                             *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Analysis of k-nearest neighbor                                            *
@@ -20,7 +20,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_MethodKNN

--- a/tmva/tmva/inc/TMVA/MethodLD.h
+++ b/tmva/tmva/inc/TMVA/MethodLD.h
@@ -4,7 +4,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodLD                                                              *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Linear Discriminant (Simple Linear Regression)                            *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  *                                                                                *
  **********************************************************************************/
 

--- a/tmva/tmva/inc/TMVA/MethodLikelihood.h
+++ b/tmva/tmva/inc/TMVA/MethodLikelihood.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodLikelihood                                                      *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Likelihood analysis ("non-parametric approach")                           *
@@ -32,7 +32,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_MethodLikelihood

--- a/tmva/tmva/inc/TMVA/MethodMLP.h
+++ b/tmva/tmva/inc/TMVA/MethodMLP.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodMLP                                                             *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      ANN Multilayer Perceptron  class for the discrimination of signal         *
@@ -32,7 +32,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_MethodMLP

--- a/tmva/tmva/inc/TMVA/MethodPDEFoam.h
+++ b/tmva/tmva/inc/TMVA/MethodPDEFoam.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate Data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodPDEFoam                                                         *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      The PDEFoam method is an extension of the PDERS method, which divides     *
@@ -29,7 +29,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_MethodPDEFoam

--- a/tmva/tmva/inc/TMVA/MethodPDERS.h
+++ b/tmva/tmva/inc/TMVA/MethodPDERS.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodPDERS                                                           *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Multidimensional Likelihood using the "Probability density estimator      *
@@ -32,7 +32,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_MethodPDERS

--- a/tmva/tmva/inc/TMVA/MethodRuleFit.h
+++ b/tmva/tmva/inc/TMVA/MethodRuleFit.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodRuleFit                                                         *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Friedman's RuleFit method                                                 *

--- a/tmva/tmva/inc/TMVA/MethodSVM.h
+++ b/tmva/tmva/inc/TMVA/MethodSVM.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodSVM                                                             *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Support Vector Machine                                                    *
@@ -27,7 +27,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_MethodSVM

--- a/tmva/tmva/inc/TMVA/MethodTMlpANN.h
+++ b/tmva/tmva/inc/TMVA/MethodTMlpANN.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodTMlpANN                                                         *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation of interface for Root-integrated artificial neural         *
@@ -25,7 +25,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_MethodTMlpANN

--- a/tmva/tmva/inc/TMVA/MinuitFitter.h
+++ b/tmva/tmva/inc/TMVA/MinuitFitter.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MinuitFitter                                                          *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *       Fitter using MINUIT                                                      *
@@ -19,7 +19,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_MinuitFitter

--- a/tmva/tmva/inc/TMVA/MinuitWrapper.h
+++ b/tmva/tmva/inc/TMVA/MinuitWrapper.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MinuitWrapper                                                         *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *       Wrapper around MINUIT                                                    *
@@ -19,7 +19,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_MinuitWrapper

--- a/tmva/tmva/inc/TMVA/MisClassificationError.h
+++ b/tmva/tmva/inc/TMVA/MisClassificationError.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MisClassificationError                                                *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation of the MisClassificationError as separation                *
@@ -24,7 +24,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_MisClassificationError

--- a/tmva/tmva/inc/TMVA/ModulekNN.h
+++ b/tmva/tmva/inc/TMVA/ModulekNN.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : ModulekNN                                                             *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Module for k-nearest neighbor algorithm                                   *
@@ -20,7 +20,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_ModulekNN

--- a/tmva/tmva/inc/TMVA/MsgLogger.h
+++ b/tmva/tmva/inc/TMVA/MsgLogger.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MsgLogger                                                             *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      TMVA output logger class producing nicely formatted log messages          *
@@ -24,7 +24,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_MsgLogger

--- a/tmva/tmva/inc/TMVA/Node.h
+++ b/tmva/tmva/inc/TMVA/Node.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: Node                                                                  *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Node for the BinarySearch or Decision Trees                               *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_Node

--- a/tmva/tmva/inc/TMVA/NodekNN.h
+++ b/tmva/tmva/inc/TMVA/NodekNN.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Node                                                                  *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      kd-tree (binary tree) template                                            *
@@ -20,7 +20,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_NodekNN

--- a/tmva/tmva/inc/TMVA/OptimizeConfigParameters.h
+++ b/tmva/tmva/inc/TMVA/OptimizeConfigParameters.h
@@ -2,7 +2,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : OptimizeConfigParameters                                              *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description: The OptimizeConfigParameters takes care of "scanning/fitting"     *
  *              different tuning parameters in order to find the best set of      *

--- a/tmva/tmva/inc/TMVA/Option.h
+++ b/tmva/tmva/inc/TMVA/Option.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Option                                                                *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Option container                                                          *

--- a/tmva/tmva/inc/TMVA/PDEFoam.h
+++ b/tmva/tmva/inc/TMVA/PDEFoam.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoam                                                               *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Class for PDEFoam object                                                  *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_PDEFoam

--- a/tmva/tmva/inc/TMVA/PDEFoamCell.h
+++ b/tmva/tmva/inc/TMVA/PDEFoamCell.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoamCell                                                           *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Objects of this class are hyperrectangular cells organized in             *
@@ -25,7 +25,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_PDEFoamCell

--- a/tmva/tmva/inc/TMVA/PDEFoamDecisionTree.h
+++ b/tmva/tmva/inc/TMVA/PDEFoamDecisionTree.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoamDecisionTree                                                   *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Class for decision tree like PDEFoam.  It overrides                       *
@@ -24,7 +24,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_PDEFoamDecisionTree

--- a/tmva/tmva/inc/TMVA/PDEFoamDecisionTreeDensity.h
+++ b/tmva/tmva/inc/TMVA/PDEFoamDecisionTreeDensity.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoamDecisionTreeDensity                                            *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Class PDEFoamDecisionTreeDensity is a class representing                  *
@@ -26,7 +26,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_PDEFoamDecisionTreeDensity

--- a/tmva/tmva/inc/TMVA/PDEFoamDensityBase.h
+++ b/tmva/tmva/inc/TMVA/PDEFoamDensityBase.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoamDensityBase                                                    *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Class PDEFoamDensityBase is an Abstract class representing                *
@@ -26,7 +26,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_PDEFoamDensityBase

--- a/tmva/tmva/inc/TMVA/PDEFoamDiscriminant.h
+++ b/tmva/tmva/inc/TMVA/PDEFoamDiscriminant.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoamDiscriminant                                                   *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *    Concrete PDEFoam sub-class.  This foam stores the discriminant D            *
@@ -24,7 +24,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_PDEFoamDiscriminant

--- a/tmva/tmva/inc/TMVA/PDEFoamDiscriminantDensity.h
+++ b/tmva/tmva/inc/TMVA/PDEFoamDiscriminantDensity.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoamDiscriminantDensity                                            *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Class PDEFoamDiscriminantDensity is a class representing                  *
@@ -26,7 +26,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_PDEFoamDiscriminantDensity

--- a/tmva/tmva/inc/TMVA/PDEFoamEvent.h
+++ b/tmva/tmva/inc/TMVA/PDEFoamEvent.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoamEvent                                                          *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Concrete PDEFoam sub-class.  This foam stores the number of               *
@@ -24,7 +24,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_PDEFoamEvent

--- a/tmva/tmva/inc/TMVA/PDEFoamEventDensity.h
+++ b/tmva/tmva/inc/TMVA/PDEFoamEventDensity.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoamEventDensity                                                   *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Class PDEFoamEventDensity is a class representing                         *
@@ -26,7 +26,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_PDEFoamEventDensity

--- a/tmva/tmva/inc/TMVA/PDEFoamKernelBase.h
+++ b/tmva/tmva/inc/TMVA/PDEFoamKernelBase.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoamKernelBase                                                     *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      PDEFoam kernel interface                                                  *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_PDEFoamKernelBase

--- a/tmva/tmva/inc/TMVA/PDEFoamKernelGauss.h
+++ b/tmva/tmva/inc/TMVA/PDEFoamKernelGauss.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoamKernelGauss                                                    *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      PDEFoam kernel, which weights all cell values by a gauss function.        *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_PDEFoamKernelGauss

--- a/tmva/tmva/inc/TMVA/PDEFoamKernelLinN.h
+++ b/tmva/tmva/inc/TMVA/PDEFoamKernelLinN.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoamKernelLinN                                                     *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      PDEFoam kernel, which linear weights with the neighbor cells.             *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_PDEFoamKernelLinN

--- a/tmva/tmva/inc/TMVA/PDEFoamKernelTrivial.h
+++ b/tmva/tmva/inc/TMVA/PDEFoamKernelTrivial.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoamKernelTrivial                                                  *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Trivial PDEFoam kernel                                                    *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_PDEFoamKernelTrivial

--- a/tmva/tmva/inc/TMVA/PDEFoamMultiTarget.h
+++ b/tmva/tmva/inc/TMVA/PDEFoamMultiTarget.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoamMultiTarget                                                    *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Concrete PDEFoamEvent sub-class.  This foam stores the number             *
@@ -26,7 +26,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_PDEFoamMultiTarget

--- a/tmva/tmva/inc/TMVA/PDEFoamTarget.h
+++ b/tmva/tmva/inc/TMVA/PDEFoamTarget.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoamTarget                                                         *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Concrete PDEFoam sub-class.  This foam stores the first target            *
@@ -24,7 +24,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_PDEFoamTarget

--- a/tmva/tmva/inc/TMVA/PDEFoamTargetDensity.h
+++ b/tmva/tmva/inc/TMVA/PDEFoamTargetDensity.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoamTargetDensity                                                  *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Class PDEFoamTargetDensity is a class representing                        *
@@ -26,7 +26,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_PDEFoamTargetDensity

--- a/tmva/tmva/inc/TMVA/PDEFoamVect.h
+++ b/tmva/tmva/inc/TMVA/PDEFoamVect.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoamVect                                                           *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Auxiliary class PDEFoamVect of n-dimensional vector, with dynamic         *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_PDEFoamVect

--- a/tmva/tmva/inc/TMVA/PDF.h
+++ b/tmva/tmva/inc/TMVA/PDF.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : PDF                                                                   *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      PDF wrapper for histograms; uses user-defined spline interpolation        *
@@ -27,7 +27,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_PDF

--- a/tmva/tmva/inc/TMVA/RBDT.hxx
+++ b/tmva/tmva/inc/TMVA/RBDT.hxx
@@ -1,7 +1,7 @@
 /**********************************************************************************
  * Project: ROOT - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *                                                                                *
@@ -13,7 +13,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef TMVA_RBDT

--- a/tmva/tmva/inc/TMVA/Ranking.h
+++ b/tmva/tmva/inc/TMVA/Ranking.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Ranking                                                               *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Virtual ranking class                                                     *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  *                                                                                *
  **********************************************************************************/
 

--- a/tmva/tmva/inc/TMVA/Reader.h
+++ b/tmva/tmva/inc/TMVA/Reader.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Reader                                                                *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Reader class to be used in the user application to interpret the trained  *
@@ -28,7 +28,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_Reader

--- a/tmva/tmva/inc/TMVA/RegressionVariance.h
+++ b/tmva/tmva/inc/TMVA/RegressionVariance.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : RegressionVariance                                                    *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description: Calculate the separation criteria used in regression              *
  *                                                                                *
@@ -31,7 +31,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_RegressionVariance

--- a/tmva/tmva/inc/TMVA/Results.h
+++ b/tmva/tmva/inc/TMVA/Results.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Results                                                               *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Base-class for result-vectors                                             *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_Results

--- a/tmva/tmva/inc/TMVA/ResultsClassification.h
+++ b/tmva/tmva/inc/TMVA/ResultsClassification.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : ResultsClassification                                                 *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Base-class for result-vectors                                             *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_ResultsClassification

--- a/tmva/tmva/inc/TMVA/ResultsMulticlass.h
+++ b/tmva/tmva/inc/TMVA/ResultsMulticlass.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : ResultsMulticlass                                                     *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Base-class for result-vectors                                             *
@@ -25,7 +25,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_ResultsMulticlass

--- a/tmva/tmva/inc/TMVA/ResultsRegression.h
+++ b/tmva/tmva/inc/TMVA/ResultsRegression.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : ResultsRegression                                                     *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Base-class for result-vectors                                             *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_ResultsRegression

--- a/tmva/tmva/inc/TMVA/RootFinder.h
+++ b/tmva/tmva/inc/TMVA/RootFinder.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : RootFinder                                                            *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Root finding using Brents algorithm                                       *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_RootFinder

--- a/tmva/tmva/inc/TMVA/Rule.h
+++ b/tmva/tmva/inc/TMVA/Rule.h
@@ -25,7 +25,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_Rule

--- a/tmva/tmva/inc/TMVA/RuleCut.h
+++ b/tmva/tmva/inc/TMVA/RuleCut.h
@@ -19,7 +19,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 #ifndef ROOT_TMVA_RuleCut
 #define ROOT_TMVA_RuleCut

--- a/tmva/tmva/inc/TMVA/RuleEnsemble.h
+++ b/tmva/tmva/inc/TMVA/RuleEnsemble.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : RuleEnsemble                                                          *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      A class generating an ensemble of rules                                   *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_RuleEnsemble

--- a/tmva/tmva/inc/TMVA/RuleFit.h
+++ b/tmva/tmva/inc/TMVA/RuleFit.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : RuleFit                                                               *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      A class implementing various fits of rule ensembles                       *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_RuleFit

--- a/tmva/tmva/inc/TMVA/RuleFitAPI.h
+++ b/tmva/tmva/inc/TMVA/RuleFitAPI.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : RuleFitAPI                                                            *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Interface to Friedman's RuleFit method                                    *

--- a/tmva/tmva/inc/TMVA/RuleFitParams.h
+++ b/tmva/tmva/inc/TMVA/RuleFitParams.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : RuleFitParams                                                         *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      A class doing the actual fitting of a linear model using rules as         *
@@ -27,7 +27,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_RuleFitParams

--- a/tmva/tmva/inc/TMVA/SVEvent.h
+++ b/tmva/tmva/inc/TMVA/SVEvent.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : SVEvent                                                               *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Event class for Support Vector Machine                                    *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_SVEvent

--- a/tmva/tmva/inc/TMVA/SVKernelFunction.h
+++ b/tmva/tmva/inc/TMVA/SVKernelFunction.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : SVKernelFunction                                                      *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Kernel for Support Vector Machine                                         *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_SVKernelFunction

--- a/tmva/tmva/inc/TMVA/SVKernelMatrix.h
+++ b/tmva/tmva/inc/TMVA/SVKernelMatrix.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : SVKernelMatrix                                                        *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Kernel matrix for Support Vector Machine                                  *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_SVKernelMatrix

--- a/tmva/tmva/inc/TMVA/SVWorkingSet.h
+++ b/tmva/tmva/inc/TMVA/SVWorkingSet.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : SVWorkingSet                                                          *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Working class for Support Vector Machine                                  *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_SVWorkingSet

--- a/tmva/tmva/inc/TMVA/SdivSqrtSplusB.h
+++ b/tmva/tmva/inc/TMVA/SdivSqrtSplusB.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : SdivSqrtSplusB                                                        *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description: Implementation of the SdivSqrtSplusB as separation criterion      *
  *              S/sqrt(S + B)                                                     *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_SdivSqrtSplusB

--- a/tmva/tmva/inc/TMVA/SeparationBase.h
+++ b/tmva/tmva/inc/TMVA/SeparationBase.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : SeparationBase                                                        *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description: An interface to different separation criteria used in various     *
  *              training algorithms, as there are:                                *
@@ -39,7 +39,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_SeparationBase

--- a/tmva/tmva/inc/TMVA/SimulatedAnnealing.h
+++ b/tmva/tmva/inc/TMVA/SimulatedAnnealing.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : SimulatedAnnealing                                                    *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation of simulated annealing fitting procedure                   *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_SimulatedAnnealing

--- a/tmva/tmva/inc/TMVA/SimulatedAnnealingFitter.h
+++ b/tmva/tmva/inc/TMVA/SimulatedAnnealingFitter.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : SimulatedAnnealingFitter                                              *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *       Fitter using Simulated Annealing algorithm                               *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_SimulatedAnnealingFitter

--- a/tmva/tmva/inc/TMVA/TActivation.h
+++ b/tmva/tmva/inc/TMVA/TActivation.h
@@ -17,7 +17,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 

--- a/tmva/tmva/inc/TMVA/TActivationChooser.h
+++ b/tmva/tmva/inc/TMVA/TActivationChooser.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::TActivationChooser                                              *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Class for easily choosing activation functions.                           *
@@ -18,7 +18,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 

--- a/tmva/tmva/inc/TMVA/TActivationIdentity.h
+++ b/tmva/tmva/inc/TMVA/TActivationIdentity.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::TActivationIdentity                                             *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Identity activation function for TNeuron                                  *
@@ -18,7 +18,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_TActivationIdentity

--- a/tmva/tmva/inc/TMVA/TActivationRadial.h
+++ b/tmva/tmva/inc/TMVA/TActivationRadial.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::TActivationRadial                                               *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Radial basis activation function for TNeuron                              *
@@ -18,7 +18,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_TActivationRadial

--- a/tmva/tmva/inc/TMVA/TActivationReLU.h
+++ b/tmva/tmva/inc/TMVA/TActivationReLU.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::TActivationReLU                                                 *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Tanh activation function for TNeuron                                      *
@@ -18,7 +18,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_TActivationReLU

--- a/tmva/tmva/inc/TMVA/TActivationSigmoid.h
+++ b/tmva/tmva/inc/TMVA/TActivationSigmoid.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::TActivationSigmoid                                              *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Sigmoid activation function for TNeuron                                   *
@@ -18,7 +18,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_TActivationSigmoid

--- a/tmva/tmva/inc/TMVA/TActivationTanh.h
+++ b/tmva/tmva/inc/TMVA/TActivationTanh.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::TActivationTanh                                                 *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Tanh activation function for TNeuron                                      *
@@ -18,7 +18,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_TActivationTanh

--- a/tmva/tmva/inc/TMVA/TNeuron.h
+++ b/tmva/tmva/inc/TMVA/TNeuron.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::TNeuron                                                         *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Neuron class to be used in MethodANNBase and its derivatives.             *
@@ -18,7 +18,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_TNeuron

--- a/tmva/tmva/inc/TMVA/TNeuronInput.h
+++ b/tmva/tmva/inc/TMVA/TNeuronInput.h
@@ -17,7 +17,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 

--- a/tmva/tmva/inc/TMVA/TNeuronInputAbs.h
+++ b/tmva/tmva/inc/TMVA/TNeuronInputAbs.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::TNeuronInputAbs                                                 *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      TNeuron input calculator -- calculates the sum of the absolute values     *
@@ -19,7 +19,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 

--- a/tmva/tmva/inc/TMVA/TNeuronInputChooser.h
+++ b/tmva/tmva/inc/TMVA/TNeuronInputChooser.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::TNeuronInputChooser                                             *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Class for easily choosing neuron input functions.                         *
@@ -18,7 +18,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 

--- a/tmva/tmva/inc/TMVA/TNeuronInputSqSum.h
+++ b/tmva/tmva/inc/TMVA/TNeuronInputSqSum.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::TNeuronInputSqSum                                               *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *       TNeuron input calculator -- calculates the square                        *
@@ -19,7 +19,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 

--- a/tmva/tmva/inc/TMVA/TNeuronInputSum.h
+++ b/tmva/tmva/inc/TMVA/TNeuronInputSum.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::TNeuronInputSum                                                 *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      TNeuron input calculator -- calculates the weighted sum of inputs.        *
@@ -18,7 +18,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 

--- a/tmva/tmva/inc/TMVA/TSpline1.h
+++ b/tmva/tmva/inc/TMVA/TSpline1.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TSpline1                                                              *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Linear interpolation class; derivative of TSpline                         *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_TSpline1

--- a/tmva/tmva/inc/TMVA/TSpline2.h
+++ b/tmva/tmva/inc/TMVA/TSpline2.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TSpline2                                                              *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Quadratic spline class; uses quadrax function for interpolation           *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_TSpline2

--- a/tmva/tmva/inc/TMVA/TSynapse.h
+++ b/tmva/tmva/inc/TMVA/TSynapse.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::TSynapse                                                        *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Synapse class for use in derivatives of MethodANNBase                     *
@@ -18,7 +18,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_TSynapse

--- a/tmva/tmva/inc/TMVA/Timer.h
+++ b/tmva/tmva/inc/TMVA/Timer.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Timer                                                                 *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Timing information for methods training                                   *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_Timer

--- a/tmva/tmva/inc/TMVA/Tools.h
+++ b/tmva/tmva/inc/TMVA/Tools.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Tools                                                                 *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Global auxiliary applications and data treatment routines                 *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_Tools

--- a/tmva/tmva/inc/TMVA/TrainingHistory.h
+++ b/tmva/tmva/inc/TMVA/TrainingHistory.h
@@ -2,7 +2,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MsgLogger                                                             *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -15,7 +15,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 

--- a/tmva/tmva/inc/TMVA/TransformationHandler.h
+++ b/tmva/tmva/inc/TMVA/TransformationHandler.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TransformationHandler                                                 *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Contains all the data information                                         *
@@ -25,7 +25,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_TransformationHandler

--- a/tmva/tmva/inc/TMVA/TreeInference/BranchlessTree.hxx
+++ b/tmva/tmva/inc/TMVA/TreeInference/BranchlessTree.hxx
@@ -1,7 +1,7 @@
 /**********************************************************************************
  * Project: ROOT - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *                                                                                *
@@ -14,7 +14,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef TMVA_TREEINFERENCE_BRANCHLESSTREE

--- a/tmva/tmva/inc/TMVA/TreeInference/Forest.hxx
+++ b/tmva/tmva/inc/TMVA/TreeInference/Forest.hxx
@@ -1,7 +1,7 @@
 /**********************************************************************************
  * Project: ROOT - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *                                                                                *
@@ -14,7 +14,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef TMVA_TREEINFERENCE_FOREST

--- a/tmva/tmva/inc/TMVA/TreeInference/Objectives.hxx
+++ b/tmva/tmva/inc/TMVA/TreeInference/Objectives.hxx
@@ -1,7 +1,7 @@
 /**********************************************************************************
  * Project: ROOT - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *                                                                                *
@@ -14,7 +14,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef TMVA_TREEINFERENCE_OBJECTIVES

--- a/tmva/tmva/inc/TMVA/TreeInference/PythonHelpers.hxx
+++ b/tmva/tmva/inc/TMVA/TreeInference/PythonHelpers.hxx
@@ -1,7 +1,7 @@
 /**********************************************************************************
  * Project: ROOT - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *                                                                                *
@@ -13,7 +13,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef TMVA_TREEINFERENCE_PYTHONHELPERS

--- a/tmva/tmva/inc/TMVA/Types.h
+++ b/tmva/tmva/inc/TMVA/Types.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Types                                                                 *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      GLobal types (singleton class)                                            *

--- a/tmva/tmva/inc/TMVA/VarTransformHandler.h
+++ b/tmva/tmva/inc/TMVA/VarTransformHandler.h
@@ -2,7 +2,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : VarTransformHandler                                                   *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation of unsupervised variable transformation methods            *
@@ -15,7 +15,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_VarTransformHandler

--- a/tmva/tmva/inc/TMVA/VariableDecorrTransform.h
+++ b/tmva/tmva/inc/TMVA/VariableDecorrTransform.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : VariableDecorrTransform                                               *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Decorrelation of input variables                                          *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_VariableDecorrTransform

--- a/tmva/tmva/inc/TMVA/VariableGaussTransform.h
+++ b/tmva/tmva/inc/TMVA/VariableGaussTransform.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : VariableGaussTransform                                                *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Decorrelation of input variables                                          *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_VariableGaussTransform

--- a/tmva/tmva/inc/TMVA/VariableIdentityTransform.h
+++ b/tmva/tmva/inc/TMVA/VariableIdentityTransform.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : VariableIdentityTransform                                             *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Identity transform                                                        *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_VariableIdentityTransform

--- a/tmva/tmva/inc/TMVA/VariableInfo.h
+++ b/tmva/tmva/inc/TMVA/VariableInfo.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Option                                                                *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Variable type info                                                        *

--- a/tmva/tmva/inc/TMVA/VariableNormalizeTransform.h
+++ b/tmva/tmva/inc/TMVA/VariableNormalizeTransform.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : VariableNormalizeTransform                                            *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Decorrelation of input variables                                          *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_VariableNormalizeTransform

--- a/tmva/tmva/inc/TMVA/VariablePCATransform.h
+++ b/tmva/tmva/inc/TMVA/VariablePCATransform.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : VariablePCATransform                                                  *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Principal value composition of input variables                            *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_VariablePCATransform

--- a/tmva/tmva/inc/TMVA/VariableRearrangeTransform.h
+++ b/tmva/tmva/inc/TMVA/VariableRearrangeTransform.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : VariableRearrangeTransform                                            *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      rearrangement of input variables                                          *
@@ -20,7 +20,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_VariableRearrangeTransform

--- a/tmva/tmva/inc/TMVA/VariableTransform.h
+++ b/tmva/tmva/inc/TMVA/VariableTransform.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : VariableTransformBase                                                 *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Pre-transformation of input variables (base class)                        *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_VariableTransform

--- a/tmva/tmva/inc/TMVA/VariableTransformBase.h
+++ b/tmva/tmva/inc/TMVA/VariableTransformBase.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : VariableTransformBase                                                 *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Pre-transformation of input variables (base class)                        *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_VariableTransformBase

--- a/tmva/tmva/inc/TMVA/Version.h
+++ b/tmva/tmva/inc/TMVA/Version.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Version                                                               *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Current TMVA Version - filled automatically during cvs tagging            *
@@ -27,7 +27,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_Version

--- a/tmva/tmva/inc/TMVA/Volume.h
+++ b/tmva/tmva/inc/TMVA/Volume.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Volume                                                                *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Volume for BinarySearchTree                                               *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef ROOT_TMVA_Volume

--- a/tmva/tmva/src/BDTEventWrapper.cxx
+++ b/tmva/tmva/src/BDTEventWrapper.cxx
@@ -2,7 +2,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : BDTEventWrapper                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *                                                                                *
@@ -17,7 +17,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #include "TMVA/BDTEventWrapper.h"

--- a/tmva/tmva/src/BinarySearchTree.cxx
+++ b/tmva/tmva/src/BinarySearchTree.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : BinarySearchTree                                                      *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header file for description)                          *
@@ -24,7 +24,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  *                                                                                *
  **********************************************************************************/
 

--- a/tmva/tmva/src/BinarySearchTreeNode.cxx
+++ b/tmva/tmva/src/BinarySearchTreeNode.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate Data analysis       *
  * Package: TMVA                                                                  *
  * Classes: Node                                                                  *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header file for description)                          *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::BinarySearchTreeNode

--- a/tmva/tmva/src/BinaryTree.cxx
+++ b/tmva/tmva/src/BinaryTree.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::BinaryTree                                                      *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header file for description)                          *
@@ -25,7 +25,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::BinaryTree

--- a/tmva/tmva/src/CCPruner.cxx
+++ b/tmva/tmva/src/CCPruner.cxx
@@ -2,7 +2,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : CCPruner                                                              *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description: Cost Complexity Pruning                                           *
  *
@@ -16,7 +16,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #include "TMVA/CCPruner.h"

--- a/tmva/tmva/src/CCTreeWrapper.cxx
+++ b/tmva/tmva/src/CCTreeWrapper.cxx
@@ -2,7 +2,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : CCTreeWrapper                                                         *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description: a light wrapper of a decision tree, used to perform cost          *
  *              complexity pruning "in-place" Cost Complexity Pruning             *
@@ -17,7 +17,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::CCTreeWrapper

--- a/tmva/tmva/src/ClassInfo.cxx
+++ b/tmva/tmva/src/ClassInfo.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : ClassInfo                                                             *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::ClassInfo

--- a/tmva/tmva/src/ClassifierFactory.cxx
+++ b/tmva/tmva/src/ClassifierFactory.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Factory                                                               *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -18,7 +18,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::ClassifierFactory

--- a/tmva/tmva/src/Config.cxx
+++ b/tmva/tmva/src/Config.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Config                                                                *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation                                                            *

--- a/tmva/tmva/src/Configurable.cxx
+++ b/tmva/tmva/src/Configurable.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Configurable                                                          *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  *                                                                                *
  **********************************************************************************/
 

--- a/tmva/tmva/src/ConvergenceTest.cxx
+++ b/tmva/tmva/src/ConvergenceTest.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : ConvergenceTest                                                             *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::ConvergenceTest

--- a/tmva/tmva/src/CostComplexityPruneTool.cxx
+++ b/tmva/tmva/src/CostComplexityPruneTool.cxx
@@ -2,7 +2,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::DecisionTree                                                    *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation of a Decision Tree                                         *

--- a/tmva/tmva/src/CrossEntropy.cxx
+++ b/tmva/tmva/src/CrossEntropy.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::CrossEntropy                                                    *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description: Implementation of the CrossEntropy as separation criterion        *
  *              -p log (p) - (1-p)log(1-p);     p=purity                          *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::CrossEntropy

--- a/tmva/tmva/src/DNN/Architectures/Reference/TensorDataLoader.cxx
+++ b/tmva/tmva/src/DNN/Architectures/Reference/TensorDataLoader.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TTensorDataLoader                                                     *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Specialization of the Tensor Data Loader Class                            *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ///////////////////////////////////////////////////////////////////

--- a/tmva/tmva/src/DataInputHandler.cxx
+++ b/tmva/tmva/src/DataInputHandler.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : DataInputHandler                                                      *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::DataInputHandler

--- a/tmva/tmva/src/DataLoader.cxx
+++ b/tmva/tmva/src/DataLoader.cxx
@@ -7,7 +7,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : DataLoader                                                            *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      This is a class to load datasets into every booked method                 *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 

--- a/tmva/tmva/src/DataSet.cxx
+++ b/tmva/tmva/src/DataSet.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : DataSet                                                               *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::DataSet

--- a/tmva/tmva/src/DataSetFactory.cxx
+++ b/tmva/tmva/src/DataSetFactory.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis  *
  * Package: TMVA                                                             *
  * Class  : DataSetFactory                                                   *
- * Web    : http://tmva.sourceforge.net                                      *
+ *                                        *
  *                                                                           *
  * Description:                                                              *
  *      Implementation (see header for description)                          *
@@ -23,7 +23,7 @@
  *      U. of Bonn, Germany                                                  *
  * Redistribution and use in source and binary forms, with or without        *
  * modification, are permitted according to the terms listed in LICENSE      *
- * (http://tmva.sourceforge.net/LICENSE)                                     *
+ * (see tmva/doc/LICENSE)                                     *
  *****************************************************************************/
 
 /*! \class TMVA::DataSetFactory

--- a/tmva/tmva/src/DataSetInfo.cxx
+++ b/tmva/tmva/src/DataSetInfo.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : DataSetInfo                                                           *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::DataSetInfo

--- a/tmva/tmva/src/DataSetManager.cxx
+++ b/tmva/tmva/src/DataSetManager.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : DataSetManager                                                        *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::DataSetManager

--- a/tmva/tmva/src/DecisionTree.cxx
+++ b/tmva/tmva/src/DecisionTree.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::DecisionTree                                                    *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation of a Decision Tree                                         *

--- a/tmva/tmva/src/DecisionTreeNode.cxx
+++ b/tmva/tmva/src/DecisionTreeNode.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::DecisionTreeNode                                                *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation of a Decision Tree Node                                    *
@@ -24,7 +24,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::

--- a/tmva/tmva/src/Event.cxx
+++ b/tmva/tmva/src/Event.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Event                                                                 *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *

--- a/tmva/tmva/src/ExpectedErrorPruneTool.cxx
+++ b/tmva/tmva/src/ExpectedErrorPruneTool.cxx
@@ -2,7 +2,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::DecisionTree                                                    *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation of a Decision Tree                                         *

--- a/tmva/tmva/src/Factory.cxx
+++ b/tmva/tmva/src/Factory.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Factory                                                               *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -33,7 +33,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::Factory

--- a/tmva/tmva/src/FitterBase.cxx
+++ b/tmva/tmva/src/FitterBase.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : FitterBase                                                            *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation                                                            *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::FitterBase

--- a/tmva/tmva/src/GeneticAlgorithm.cxx
+++ b/tmva/tmva/src/GeneticAlgorithm.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::GeneticAlgorithm                                                *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -19,7 +19,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::GeneticAlgorithm

--- a/tmva/tmva/src/GeneticFitter.cxx
+++ b/tmva/tmva/src/GeneticFitter.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : GeneticFitter                                                         *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation                                                            *
@@ -19,7 +19,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::GeneticFitter

--- a/tmva/tmva/src/GeneticGenes.cxx
+++ b/tmva/tmva/src/GeneticGenes.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::GeneticGenes                                                    *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -19,7 +19,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #include "TMVA/GeneticGenes.h"

--- a/tmva/tmva/src/GeneticPopulation.cxx
+++ b/tmva/tmva/src/GeneticPopulation.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::GeneticPopulation                                               *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -19,7 +19,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::GeneticPopulation

--- a/tmva/tmva/src/GeneticRange.cxx
+++ b/tmva/tmva/src/GeneticRange.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::GeneticRange                                                    *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -19,7 +19,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  *                                                                                *
  * File and Version Information:                                                  *
  **********************************************************************************/

--- a/tmva/tmva/src/GiniIndex.cxx
+++ b/tmva/tmva/src/GiniIndex.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::GiniIndex                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description: Implementation of the GiniIndex as separation criterion           *
  *              Large Gini Indices (maximum 0.5) mean , that the sample is well   *
@@ -31,7 +31,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::GiniIndex

--- a/tmva/tmva/src/GiniIndexWithLaplace.cxx
+++ b/tmva/tmva/src/GiniIndexWithLaplace.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::GiniIndex                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description: Implementation of the GiniIndex With Laplace correction           *
  *              as separation criterion                                           *
@@ -29,7 +29,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::GiniIndexWithLaplace

--- a/tmva/tmva/src/IFitterTarget.cxx
+++ b/tmva/tmva/src/IFitterTarget.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : IFitterTarget                                                         *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation                                                            *
@@ -20,7 +20,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::IFitterTarget

--- a/tmva/tmva/src/Interval.cxx
+++ b/tmva/tmva/src/Interval.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::Interval                                                        *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -19,7 +19,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  *                                                                                *
  * File and Version Information:                                                  *
  **********************************************************************************/

--- a/tmva/tmva/src/KDEKernel.cxx
+++ b/tmva/tmva/src/KDEKernel.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate Data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::KDEKernel                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -20,7 +20,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::KDEKernel

--- a/tmva/tmva/src/LDA.cxx
+++ b/tmva/tmva/src/LDA.cxx
@@ -3,7 +3,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : LDA                                                                   *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Local LDA method used by MethodKNN to compute MVA value.                  *
@@ -20,7 +20,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::LDA

--- a/tmva/tmva/src/LogInterval.cxx
+++ b/tmva/tmva/src/LogInterval.cxx
@@ -2,7 +2,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Interval                                                              *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *          Extension of the Interval to "logarithmic" intervals                  *
@@ -18,7 +18,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::LogInterval

--- a/tmva/tmva/src/LossFunction.cxx
+++ b/tmva/tmva/src/LossFunction.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : LossFunction                                                          *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *

--- a/tmva/tmva/src/MCFitter.cxx
+++ b/tmva/tmva/src/MCFitter.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::MCFitter                                                        *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation                                                            *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::MCFitter

--- a/tmva/tmva/src/MethodANNBase.cxx
+++ b/tmva/tmva/src/MethodANNBase.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodANNBase                                                         *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Artificial neural network base class for the discrimination of signal     *
@@ -28,7 +28,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::MethodANNBase

--- a/tmva/tmva/src/MethodBDT.cxx
+++ b/tmva/tmva/src/MethodBDT.cxx
@@ -4,7 +4,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodBDT (BDT = Boosted Decision Trees)                              *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Analysis of Boosted Decision Trees                                        *
@@ -25,7 +25,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::MethodBDT

--- a/tmva/tmva/src/MethodBase.cxx
+++ b/tmva/tmva/src/MethodBase.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodBase                                                            *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -27,7 +27,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  *                                                                                *
  **********************************************************************************/
 

--- a/tmva/tmva/src/MethodBayesClassifier.cxx
+++ b/tmva/tmva/src/MethodBayesClassifier.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodBayesClassifier                                                 *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header file for description)                          *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::MethodBayesClassifier

--- a/tmva/tmva/src/MethodBoost.cxx
+++ b/tmva/tmva/src/MethodBoost.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodCompositeBase                                                   *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Virtual base class for all MVA method                                     *
@@ -26,7 +26,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::MethodBoost

--- a/tmva/tmva/src/MethodCFMlpANN.cxx
+++ b/tmva/tmva/src/MethodCFMlpANN.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate Data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::MethodCFMlpANN                                                  *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -24,7 +24,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::MethodCFMlpANN

--- a/tmva/tmva/src/MethodCFMlpANN_Utils.cxx
+++ b/tmva/tmva/src/MethodCFMlpANN_Utils.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::MethodCFMlpANN_utils                                            *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Reference for the original FORTRAN version "mlpl3.F":                          *
  *      Authors  : J. Proriol and contributions from ALEPH-Clermont-Ferrand       *
@@ -42,7 +42,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  *                                                                                *
  **********************************************************************************/
 

--- a/tmva/tmva/src/MethodCategory.cxx
+++ b/tmva/tmva/src/MethodCategory.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodCompositeBase                                                   *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Virtual base class for all MVA method                                     *
@@ -27,7 +27,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::MethodCategory

--- a/tmva/tmva/src/MethodCompositeBase.cxx
+++ b/tmva/tmva/src/MethodCompositeBase.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis  *
  * Package: TMVA                                                             *
  * Class  : MethodCompositeBase                                              *
- * Web    : http://tmva.sourceforge.net                                      *
+ *                                        *
  *                                                                           *
  * Description:                                                              *
  *      Virtual base class for all MVA method                                *
@@ -25,7 +25,7 @@
  *                                                                           *
  * Redistribution and use in source and binary forms, with or without        *
  * modification, are permitted according to the terms listed in LICENSE      *
- * (http://tmva.sourceforge.net/LICENSE)                                     *
+ * (see tmva/doc/LICENSE)                                     *
  *****************************************************************************/
 
 /*! \class TMVA::MethodCompositeBase

--- a/tmva/tmva/src/MethodCuts.cxx
+++ b/tmva/tmva/src/MethodCuts.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate Data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::MethodCuts                                                      *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -25,7 +25,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::MethodCuts

--- a/tmva/tmva/src/MethodDL.cxx
+++ b/tmva/tmva/src/MethodDL.cxx
@@ -4,7 +4,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodDL                                                              *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Deep Neural Network Method                                                *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #include "TFormula.h"

--- a/tmva/tmva/src/MethodDNN.cxx
+++ b/tmva/tmva/src/MethodDNN.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodDNN                                                             *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      A neural network implementation                                           *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::MethodDNN

--- a/tmva/tmva/src/MethodDT.cxx
+++ b/tmva/tmva/src/MethodDT.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodDT (DT = Decision Trees)                                         *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Analysis of Boosted Decision Trees                                        *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::MethodDT

--- a/tmva/tmva/src/MethodFDA.cxx
+++ b/tmva/tmva/src/MethodFDA.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodFDA                                                             *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation                                                            *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::MethodFDA
@@ -736,10 +736,10 @@ void TMVA::MethodFDA::GetHelpMessage() const
    Log() << "Please consult the Users Guide for the format of the formula string" << Endl;
    Log() << "and the allowed parameter ranges:" << Endl;
    if (gConfig().WriteOptionsReference()) {
-      Log() << "<a href=\"http://tmva.sourceforge.net/docu/TMVAUsersGuide.pdf\">"
-            << "http://tmva.sourceforge.net/docu/TMVAUsersGuide.pdf</a>" << Endl;
+      Log() << "<a href=\"https://github.com/root-project/root/blob/master/documentation/tmva/UsersGuide/TMVAUsersGuide.pdf\">"
+            << "TMVAUsersGuide.pdf</a>" << Endl;
    }
-   else Log() << "http://tmva.sourceforge.net/docu/TMVAUsersGuide.pdf" << Endl;
+   else Log() << "documentation/tmva/UsersGuide/TMVAUsersGuide.pdf" << Endl;
    Log() << Endl;
    Log() << gTools().Color("bold") << "--- Performance optimisation:" << gTools().Color("reset") << Endl;
    Log() << Endl;

--- a/tmva/tmva/src/MethodFisher.cxx
+++ b/tmva/tmva/src/MethodFisher.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate Data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodFisher                                                          *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -28,7 +28,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::MethodFisher

--- a/tmva/tmva/src/MethodHMatrix.cxx
+++ b/tmva/tmva/src/MethodHMatrix.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate Data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::MethodHMatrix                                                   *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header file for description)                          *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #include "TMVA/MethodHMatrix.h"

--- a/tmva/tmva/src/MethodKNN.cxx
+++ b/tmva/tmva/src/MethodKNN.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodKNN                                                             *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation                                                            *
@@ -20,7 +20,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::MethodKNN

--- a/tmva/tmva/src/MethodLD.cxx
+++ b/tmva/tmva/src/MethodLD.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodLD                                                              *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Linear Discriminant - Simple Linear Regression and Classification         *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  *                                                                                *
  **********************************************************************************/
 

--- a/tmva/tmva/src/MethodLikelihood.cxx
+++ b/tmva/tmva/src/MethodLikelihood.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate Data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::MethodLikelihood                                                *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -25,7 +25,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::MethodLikelihood

--- a/tmva/tmva/src/MethodMLP.cxx
+++ b/tmva/tmva/src/MethodMLP.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodMLP                                                             *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      ANN Multilayer Perceptron class for the discrimination of signal          *
@@ -32,7 +32,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::MethodMLP

--- a/tmva/tmva/src/MethodPDEFoam.cxx
+++ b/tmva/tmva/src/MethodPDEFoam.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate Data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodPDEFoam                                                         *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -25,7 +25,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::MethodPDEFoam

--- a/tmva/tmva/src/MethodPDERS.cxx
+++ b/tmva/tmva/src/MethodPDERS.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis        *
  * Package: TMVA                                                                   *
  * Class  : MethodPDERS                                                            *
- * Web    : http://tmva.sourceforge.net                                            *
+ *                                              *
  *                                                                                 *
  * Description:                                                                    *
  *      Implementation                                                             *
@@ -26,7 +26,7 @@
  *                                                                                 *
  * Redistribution and use in source and binary forms, with or without              *
  * modification, are permitted according to the terms listed in LICENSE            *
- * (http://tmva.sourceforge.net/LICENSE)                                           *
+ * (see tmva/doc/LICENSE)                                           *
  ***********************************************************************************/
 
 /*! \class TMVA::MethodPDERS

--- a/tmva/tmva/src/MethodPlugins.cxx
+++ b/tmva/tmva/src/MethodPlugins.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate Data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::MethodPlugins                                                *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -27,7 +27,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::CreateMethodPlugins

--- a/tmva/tmva/src/MethodRuleFit.cxx
+++ b/tmva/tmva/src/MethodRuleFit.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodRuleFit                                                         *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header file for description)                          *
@@ -20,7 +20,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::MethodRuleFit

--- a/tmva/tmva/src/MethodSVM.cxx
+++ b/tmva/tmva/src/MethodSVM.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodSVM                                                             *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation                                                            *
@@ -34,7 +34,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::MethodSVM

--- a/tmva/tmva/src/MethodTMlpANN.cxx
+++ b/tmva/tmva/src/MethodTMlpANN.cxx
@@ -4,7 +4,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MethodTMlpANN                                                         *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::MethodTMlpANN

--- a/tmva/tmva/src/MinuitFitter.cxx
+++ b/tmva/tmva/src/MinuitFitter.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MinuitFitter                                                          *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation                                                            *
@@ -19,7 +19,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::MinuitFitter

--- a/tmva/tmva/src/MinuitWrapper.cxx
+++ b/tmva/tmva/src/MinuitWrapper.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MinuitWrapper                                                         *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation                                                            *
@@ -19,7 +19,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::MinuitWrapper

--- a/tmva/tmva/src/MisClassificationError.cxx
+++ b/tmva/tmva/src/MisClassificationError.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MisClassificationError                                                *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description: Implementation of the MisClassificationError as separation        *
  *              criterion:   1-max(p, 1-p) as
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::MisClassificationError

--- a/tmva/tmva/src/ModulekNN.cxx
+++ b/tmva/tmva/src/ModulekNN.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : ModulekNN                                                             *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation                                                            *
@@ -20,7 +20,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::kNN

--- a/tmva/tmva/src/MsgLogger.cxx
+++ b/tmva/tmva/src/MsgLogger.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : MsgLogger                                                             *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -24,7 +24,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::MsgLogger

--- a/tmva/tmva/src/Node.cxx
+++ b/tmva/tmva/src/Node.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate Data analysis       *
  * Package: TMVA                                                                  *
  * Classes: Node                                                                  *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header file for description)                          *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::Node

--- a/tmva/tmva/src/OptimizeConfigParameters.cxx
+++ b/tmva/tmva/src/OptimizeConfigParameters.cxx
@@ -2,7 +2,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : OptimizeConfigParameters                                              *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description: The OptimizeConfigParameters takes care of "scanning/fitting"     *
  *              different tuning parameters in order to find the best set of      *

--- a/tmva/tmva/src/Option.cxx
+++ b/tmva/tmva/src/Option.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Option                                                                *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation                                                            *

--- a/tmva/tmva/src/PDEFoam.cxx
+++ b/tmva/tmva/src/PDEFoam.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoam                                                               *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementations                                                           *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::PDEFoam

--- a/tmva/tmva/src/PDEFoamCell.cxx
+++ b/tmva/tmva/src/PDEFoamCell.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoamCell                                                           *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Objects of this class are hyperrectangular cells organized in             *
@@ -25,7 +25,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::PDEFoamCell

--- a/tmva/tmva/src/PDEFoamDecisionTree.cxx
+++ b/tmva/tmva/src/PDEFoamDecisionTree.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoamDecisionTree                                                   *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation of decision tree like PDEFoam                              *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::PDEFoamDecisionTree

--- a/tmva/tmva/src/PDEFoamDecisionTreeDensity.cxx
+++ b/tmva/tmva/src/PDEFoamDecisionTreeDensity.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoamDecisionTreeDensity                                            *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      This class provides an interface between the Binary search tree           *
@@ -28,7 +28,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::PDEFoamDecisionTreeDensity

--- a/tmva/tmva/src/PDEFoamDensityBase.cxx
+++ b/tmva/tmva/src/PDEFoamDensityBase.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoamDensityBase                                                    *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      This class provides an interface between the Binary search tree           *
@@ -28,7 +28,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::PDEFoamDensityBase

--- a/tmva/tmva/src/PDEFoamDiscriminant.cxx
+++ b/tmva/tmva/src/PDEFoamDiscriminant.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoamDiscriminant                                                   *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation.                                                           *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::PDEFoamDiscriminant

--- a/tmva/tmva/src/PDEFoamDiscriminantDensity.cxx
+++ b/tmva/tmva/src/PDEFoamDiscriminantDensity.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoamDiscriminantDensity                                            *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      The TFDSITR class provides an interface between the Binary search tree    *
@@ -28,7 +28,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::PDEFoamDiscriminantDensity

--- a/tmva/tmva/src/PDEFoamEvent.cxx
+++ b/tmva/tmva/src/PDEFoamEvent.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoamEvent                                                          *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation.                                                           *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::PDEFoamEvent

--- a/tmva/tmva/src/PDEFoamEventDensity.cxx
+++ b/tmva/tmva/src/PDEFoamEventDensity.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoamEventDensity                                                   *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      The TFDSITR class provides an interface between the Binary search tree    *
@@ -29,7 +29,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::PDEFoamEventDensity

--- a/tmva/tmva/src/PDEFoamKernelBase.cxx
+++ b/tmva/tmva/src/PDEFoamKernelBase.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoamKernelBase                                                     *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation of PDEFoam kernel interface                                *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::PDEFoamKernelBase

--- a/tmva/tmva/src/PDEFoamKernelGauss.cxx
+++ b/tmva/tmva/src/PDEFoamKernelGauss.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoamKernelGauss                                                    *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation of gauss PDEFoam kernel                                    *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::PDEFoamKernelGauss

--- a/tmva/tmva/src/PDEFoamKernelLinN.cxx
+++ b/tmva/tmva/src/PDEFoamKernelLinN.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoamKernelLinN                                                     *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation of linear neighbors PDEFoam kernel                         *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::PDEFoamKernelLinN

--- a/tmva/tmva/src/PDEFoamKernelTrivial.cxx
+++ b/tmva/tmva/src/PDEFoamKernelTrivial.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoamKernelTrivial                                                  *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation of trivial PDEFoam kernel                                  *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::PDEFoamKernelTrivial

--- a/tmva/tmva/src/PDEFoamMultiTarget.cxx
+++ b/tmva/tmva/src/PDEFoamMultiTarget.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoamMultiTarget                                                    *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation.                                                           *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::PDEFoamMultiTarget

--- a/tmva/tmva/src/PDEFoamTarget.cxx
+++ b/tmva/tmva/src/PDEFoamTarget.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoamTarget                                                         *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation.                                                           *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::PDEFoamTarget

--- a/tmva/tmva/src/PDEFoamTargetDensity.cxx
+++ b/tmva/tmva/src/PDEFoamTargetDensity.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoamTargetDensity                                                  *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      The TFDSITR class provides an interface between the Binary search tree    *
@@ -28,7 +28,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::PDEFoamTargetDensity

--- a/tmva/tmva/src/PDEFoamVect.cxx
+++ b/tmva/tmva/src/PDEFoamVect.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Classes: PDEFoamVect                                                           *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Auxiliary class PDEFoamVect of n-dimensional vector, with dynamic         *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::PDEFoamVect

--- a/tmva/tmva/src/PDF.cxx
+++ b/tmva/tmva/src/PDF.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : PDF                                                                   *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -27,7 +27,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::PDF

--- a/tmva/tmva/src/Ranking.cxx
+++ b/tmva/tmva/src/Ranking.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate Data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Ranking                                                               *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::Ranking

--- a/tmva/tmva/src/Reader.cxx
+++ b/tmva/tmva/src/Reader.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Reader                                                                *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Reader class to be used in the user application to interpret the trained  *
@@ -28,7 +28,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::Reader

--- a/tmva/tmva/src/RegressionVariance.cxx
+++ b/tmva/tmva/src/RegressionVariance.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : RegressionVariance                                                    *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description: Calculate the separation criteria used in regression              *
  *                                                                                *
@@ -31,7 +31,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 #include "TMath.h"
 #include "TMVA/RegressionVariance.h"

--- a/tmva/tmva/src/Results.cxx
+++ b/tmva/tmva/src/Results.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Results                                                             *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::Results

--- a/tmva/tmva/src/ResultsClassification.cxx
+++ b/tmva/tmva/src/ResultsClassification.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : ResultsClassification                                                 *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::ResultsClassification

--- a/tmva/tmva/src/ResultsMulticlass.cxx
+++ b/tmva/tmva/src/ResultsMulticlass.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : ResultsMulticlass                                                     *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -24,7 +24,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::ResultsMulticlass

--- a/tmva/tmva/src/ResultsRegression.cxx
+++ b/tmva/tmva/src/ResultsRegression.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : ResultsRegression                                                     *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::ResultsRegression

--- a/tmva/tmva/src/RootFinder.cxx
+++ b/tmva/tmva/src/RootFinder.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : RootFinder                                                            *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header file for description)                          *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::RootFinder

--- a/tmva/tmva/src/Rule.cxx
+++ b/tmva/tmva/src/Rule.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Rule                                                                  *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      A class describing a 'rule'                                               *
@@ -24,7 +24,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::Rule

--- a/tmva/tmva/src/RuleCut.cxx
+++ b/tmva/tmva/src/RuleCut.cxx
@@ -19,7 +19,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::RuleCut

--- a/tmva/tmva/src/RuleEnsemble.cxx
+++ b/tmva/tmva/src/RuleEnsemble.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : RuleEnsemble                                                          *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      A class generating an ensemble of rules                                   *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::RuleEnsemble

--- a/tmva/tmva/src/RuleFit.cxx
+++ b/tmva/tmva/src/RuleFit.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Rule                                                                  *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      A class describing a 'rule'                                               *
@@ -25,7 +25,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::RuleFit

--- a/tmva/tmva/src/RuleFitAPI.cxx
+++ b/tmva/tmva/src/RuleFitAPI.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : RuleFitAPI                                                            *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header file for description)                          *
@@ -20,7 +20,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::RuleFitAPI

--- a/tmva/tmva/src/RuleFitParams.cxx
+++ b/tmva/tmva/src/RuleFitParams.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : RuleFitParams                                                         *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation                                                            *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::RuleFitParams

--- a/tmva/tmva/src/SVEvent.cxx
+++ b/tmva/tmva/src/SVEvent.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : SVEvent                                                               *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation                                                            *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::SVEvent

--- a/tmva/tmva/src/SVKernelFunction.cxx
+++ b/tmva/tmva/src/SVKernelFunction.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : SVKernelFunction                                                      *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation                                                            *
@@ -28,7 +28,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::SVKernelFunction

--- a/tmva/tmva/src/SVKernelMatrix.cxx
+++ b/tmva/tmva/src/SVKernelMatrix.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : SVKernelMatrix                                                        *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation                                                            *
@@ -28,7 +28,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::SVKernelMatrix

--- a/tmva/tmva/src/SVWorkingSet.cxx
+++ b/tmva/tmva/src/SVWorkingSet.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : SVWorkingSet                                                          *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation                                                            *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::SVWorkingSet

--- a/tmva/tmva/src/SdivSqrtSplusB.cxx
+++ b/tmva/tmva/src/SdivSqrtSplusB.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : SdivSqrtSplusB                                                        *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description: Implementation of the SdivSqrtSplusB as separation criterion      *
  *              s / sqrt( s+b )                                                   *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::SdivSqrtSplusB

--- a/tmva/tmva/src/SeparationBase.cxx
+++ b/tmva/tmva/src/SeparationBase.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : SeparationBase                                                        *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description: An interface to different separation criteria used in various     *
  *              training algorithms, as there are:                                *
@@ -37,7 +37,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::SeparationBase

--- a/tmva/tmva/src/SimulatedAnnealing.cxx
+++ b/tmva/tmva/src/SimulatedAnnealing.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : SimulatedAnnealing                                                    *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::SimulatedAnnealing

--- a/tmva/tmva/src/SimulatedAnnealingFitter.cxx
+++ b/tmva/tmva/src/SimulatedAnnealingFitter.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : SimulatedAnnealingFitter                                              *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation                                                            *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::SimulatedAnnealingFitter

--- a/tmva/tmva/src/TActivation.cxx
+++ b/tmva/tmva/src/TActivation.cxx
@@ -17,7 +17,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::TActivation

--- a/tmva/tmva/src/TActivationChooser.cxx
+++ b/tmva/tmva/src/TActivationChooser.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::TActivationChooser                                              *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Class for easily choosing activation functions.                           *
@@ -18,7 +18,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::TActivationChooser

--- a/tmva/tmva/src/TActivationIdentity.cxx
+++ b/tmva/tmva/src/TActivationIdentity.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TActivationIdentity                                                   *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Identity activation function for TNeuron                                  *
@@ -18,7 +18,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::TActivationIdentity

--- a/tmva/tmva/src/TActivationRadial.cxx
+++ b/tmva/tmva/src/TActivationRadial.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TActivationRadial                                                     *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Radial basis activation function for TNeuron                              *
@@ -18,7 +18,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::TActivationRadial

--- a/tmva/tmva/src/TActivationReLU.cxx
+++ b/tmva/tmva/src/TActivationReLU.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TActivationReLU                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Rectified linear unit function  for an ANN.                               *
@@ -18,7 +18,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::TActivationReLU

--- a/tmva/tmva/src/TActivationSigmoid.cxx
+++ b/tmva/tmva/src/TActivationSigmoid.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TActivationSigmoid                                                    *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Sigmoid activation function for TNeuron                                   *
@@ -18,7 +18,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::TActivationSigmoid

--- a/tmva/tmva/src/TActivationTanh.cxx
+++ b/tmva/tmva/src/TActivationTanh.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TActivationTanh                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Tanh activation function (sigmoid normalized in [-1,1] for an ANN.        *
@@ -18,7 +18,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::TActivationTanh

--- a/tmva/tmva/src/TNeuron.cxx
+++ b/tmva/tmva/src/TNeuron.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TNeuron                                                               *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -18,7 +18,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::TNeuron

--- a/tmva/tmva/src/TNeuronInput.cxx
+++ b/tmva/tmva/src/TNeuronInput.cxx
@@ -17,7 +17,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::TNeuronInput

--- a/tmva/tmva/src/TNeuronInputAbs.cxx
+++ b/tmva/tmva/src/TNeuronInputAbs.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::TNeuronInputAbs                                                 *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      TNeuron input calculator -- calculates the sum of the absolute values     *
@@ -19,7 +19,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::TNeuronInputAbs

--- a/tmva/tmva/src/TNeuronInputChooser.cxx
+++ b/tmva/tmva/src/TNeuronInputChooser.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::TNeuronInputChooser                                             *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Class for easily choosing neuron input functions.                         *
@@ -18,7 +18,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::TNeuronInputChooser

--- a/tmva/tmva/src/TNeuronInputSqSum.cxx
+++ b/tmva/tmva/src/TNeuronInputSqSum.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::TNeuronInputSqSum                                               *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *       TNeuron input calculator -- calculates the square                        *
@@ -19,7 +19,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::TNeuronInputSqSum

--- a/tmva/tmva/src/TNeuronInputSum.cxx
+++ b/tmva/tmva/src/TNeuronInputSum.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TMVA::TNeuronInputSum                                                 *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      TNeuron input calculator -- calculates the weighted sum of inputs.        *
@@ -18,7 +18,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::TNeuronInputSum

--- a/tmva/tmva/src/TSpline1.cxx
+++ b/tmva/tmva/src/TSpline1.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TSpline1                                                              *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::TSpline1

--- a/tmva/tmva/src/TSpline2.cxx
+++ b/tmva/tmva/src/TSpline2.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TSpline2                                                              *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::TSpline2

--- a/tmva/tmva/src/TSynapse.cxx
+++ b/tmva/tmva/src/TSynapse.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TSynapse                                                              *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -18,7 +18,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::TSynapse

--- a/tmva/tmva/src/Timer.cxx
+++ b/tmva/tmva/src/Timer.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Timer                                                                 *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header file for description)                          *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::Timer

--- a/tmva/tmva/src/Tools.cxx
+++ b/tmva/tmva/src/Tools.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Tools                                                                 *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -25,7 +25,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::Tools
@@ -1348,8 +1348,7 @@ void TMVA::Tools::TMVAWelcomeMessage( MsgLogger& logger, EWelcomeMessage msgType
    case kStandardWelcomeMsg:
       logger << Color("white") << "TMVA -- Toolkit for Multivariate Analysis" << Color("reset") << Endl;
       logger << "Copyright (C) 2005-2006 CERN, LAPP & MPI-K Heidelberg and Victoria U." << Endl;
-      logger << "Home page http://tmva.sourceforge.net" << Endl;
-      logger << "All rights reserved, please read http://tmva.sf.net/license.txt" << Endl << Endl;
+      logger << "Home page https://root.cern/manual/tmva/" << Endl;
       break;
 
    case kIsometricWelcomeMsg:

--- a/tmva/tmva/src/TrainingHistory.cxx
+++ b/tmva/tmva/src/TrainingHistory.cxx
@@ -2,7 +2,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TrainingHistory                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -15,7 +15,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::TrainingHistory

--- a/tmva/tmva/src/TransformationHandler.cxx
+++ b/tmva/tmva/src/TransformationHandler.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : TransformationHandler                                                 *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -25,7 +25,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::TransformationHandler

--- a/tmva/tmva/src/Types.cxx
+++ b/tmva/tmva/src/Types.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Types                                                                 *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation                                                            *

--- a/tmva/tmva/src/VarTransformHandler.cxx
+++ b/tmva/tmva/src/VarTransformHandler.cxx
@@ -2,7 +2,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : VarTransformHandler                                                   *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *       Implementation of unsupervised variable transformation methods           *
@@ -15,7 +15,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #include "TMVA/VarTransformHandler.h"

--- a/tmva/tmva/src/VariableDecorrTransform.cxx
+++ b/tmva/tmva/src/VariableDecorrTransform.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : VariableDecorrTransform                                               *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -23,7 +23,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::VariableDecorrTransform

--- a/tmva/tmva/src/VariableGaussTransform.cxx
+++ b/tmva/tmva/src/VariableGaussTransform.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : VariableGaussTransform                                                *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -24,7 +24,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::VariableGaussTransform

--- a/tmva/tmva/src/VariableIdentityTransform.cxx
+++ b/tmva/tmva/src/VariableIdentityTransform.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : VariableIdentityTransform                                             *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::VariableIdentityTransform

--- a/tmva/tmva/src/VariableInfo.cxx
+++ b/tmva/tmva/src/VariableInfo.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : VariableInfo                                                          *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *

--- a/tmva/tmva/src/VariableNormalizeTransform.cxx
+++ b/tmva/tmva/src/VariableNormalizeTransform.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : VariableNormalizeTransform                                            *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -24,7 +24,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::VariableNormalizeTransform

--- a/tmva/tmva/src/VariablePCATransform.cxx
+++ b/tmva/tmva/src/VariablePCATransform.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : VariablePCATransform                                                  *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -24,7 +24,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::VariablePCATransform

--- a/tmva/tmva/src/VariableRearrangeTransform.cxx
+++ b/tmva/tmva/src/VariableRearrangeTransform.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : VariableRearrangeTransform                                            *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -19,7 +19,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::VariableRearrangeTransform

--- a/tmva/tmva/src/VariableTransform.cxx
+++ b/tmva/tmva/src/VariableTransform.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : VariableTransformBase                                                 *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #include "TMVA/VariableTransformBase.h"

--- a/tmva/tmva/src/VariableTransformBase.cxx
+++ b/tmva/tmva/src/VariableTransformBase.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : VariableTransformBase                                                 *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::VariableTransformBase

--- a/tmva/tmva/src/Volume.cxx
+++ b/tmva/tmva/src/Volume.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  : Volume                                                                *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header file for description)                          *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 /*! \class TMVA::Volume

--- a/tmva/tmva/test/DNN/CNN/TestConvBackpropagation.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestConvBackpropagation.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing Conv Net Backpropagation                                          *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/test/DNN/CNN/TestConvBackpropagationCuda.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestConvBackpropagationCuda.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing Conv Net Backpropagation                                          *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/test/DNN/CNN/TestConvBackpropagationCudnn.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestConvBackpropagationCudnn.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing Conv Net Backpropagation                                          *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/test/DNN/CNN/TestConvLayer.h
+++ b/tmva/tmva/test/DNN/CNN/TestConvLayer.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing Downsample method on a CPU architecture                           *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/test/DNN/CNN/TestConvLayerCpu.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestConvLayerCpu.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing Downsample method on a CPU architecture                           *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/test/DNN/CNN/TestConvLayerCuda.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestConvLayerCuda.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing Downsample method on a CPU architecture                           *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/test/DNN/CNN/TestConvLayerCudnn.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestConvLayerCudnn.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing Downsample method on a CPU architecture                           *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/test/DNN/CNN/TestConvNet.h
+++ b/tmva/tmva/test/DNN/CNN/TestConvNet.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing Conv Net Features                                                 *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef TMVA_TEST_DNN_TEST_CNN_TEST_CONV_NET_H

--- a/tmva/tmva/test/DNN/CNN/TestConvNetLoss.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestConvNetLoss.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing Conv Net Loss                                                     *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/test/DNN/CNN/TestConvNetLossCpu.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestConvNetLossCpu.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing Conv Net Loss for CPU                                             *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/test/DNN/CNN/TestConvNetPrediction.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestConvNetPrediction.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing Conv Net Prediction                                               *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/test/DNN/CNN/TestConvNetPredictionCpu.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestConvNetPredictionCpu.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing Conv Net Prediction for CPU                                       *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/test/DNN/CNN/TestForwardPass.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestForwardPass.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing Conv Net Forward Pass                                             *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/test/DNN/CNN/TestForwardPassCpu.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestForwardPassCpu.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing Conv Net Forward Pass for the CPU                                 *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/test/DNN/CNN/TestForwardPassCuda.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestForwardPassCuda.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing Conv Net Forward Pass for the CPU                                 *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/test/DNN/CNN/TestForwardPassCudnn.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestForwardPassCudnn.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing Conv Net Forward Pass for the CPU                                 *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/test/DNN/CNN/TestIm2Col.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestIm2Col.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing Im2Col method                                                     *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/test/DNN/CNN/TestIm2Col.h
+++ b/tmva/tmva/test/DNN/CNN/TestIm2Col.h
@@ -9,7 +9,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing Im2Col method                                                     *
@@ -26,7 +26,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/test/DNN/CNN/TestIm2ColCpu.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestIm2ColCpu.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing Im2Col method on a CPU architecture                               *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/test/DNN/CNN/TestIm2ColCuda.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestIm2ColCuda.cxx
@@ -2,7 +2,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing Im2Col method on the GPU                                          *
@@ -18,7 +18,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/test/DNN/CNN/TestMethodDLCNN.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestMethodDLCNN.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing Method DL for Conv Net for the Reference backend                  *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #include "TestMethodDLCNN.h"

--- a/tmva/tmva/test/DNN/CNN/TestMethodDLCNN.h
+++ b/tmva/tmva/test/DNN/CNN/TestMethodDLCNN.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing Method DL for Conv Net                                            *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef TMVA_TEST_DNN_TEST_CNN_TEST_METHOD_DL_CNN_H

--- a/tmva/tmva/test/DNN/CNN/TestMinimization.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestMinimization.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing Deep Learning Minimizer for the Reference backend                 *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #include "TestMinimization.h"

--- a/tmva/tmva/test/DNN/CNN/TestMinimization.h
+++ b/tmva/tmva/test/DNN/CNN/TestMinimization.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing Deep Learning Minimizer                                           *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef TMVA_TEST_DNN_TEST_CNN_TEST_DL_MINIMIZER_H

--- a/tmva/tmva/test/DNN/CNN/TestMinimizationCpu.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestMinimizationCpu.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing Deep Learning Minimizer for the CPU backend                       *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #include "TestMinimization.h"

--- a/tmva/tmva/test/DNN/CNN/TestMixedArchitectures.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestMixedArchitectures.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing Conv Net Forward Pass for the CPU                                 *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/test/DNN/CNN/TestPoolingLayer.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestPoolingLayer.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing the Pooling Layer on a CPU architecture                           *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/test/DNN/CNN/TestPoolingLayer.h
+++ b/tmva/tmva/test/DNN/CNN/TestPoolingLayer.h
@@ -8,7 +8,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing the Pooling layer in an architecture agnostic manner.             *
@@ -24,7 +24,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/test/DNN/CNN/TestPoolingLayerCpu.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestPoolingLayerCpu.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing the Pooling Layer on a CPU architecture                           *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/test/DNN/CNN/TestPoolingLayerCuda.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestPoolingLayerCuda.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing the Pooling Layer on a CPU architecture                           *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/test/DNN/CNN/TestPoolingLayerCudnn.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestPoolingLayerCudnn.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing the Pooling Layer on a CPU architecture                           *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/test/DNN/CNN/TestReshape.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestReshape.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing Flatten function for Reference backend                            *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/test/DNN/CNN/TestReshape.h
+++ b/tmva/tmva/test/DNN/CNN/TestReshape.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing Flatten function for every architecture using templates           *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 

--- a/tmva/tmva/test/DNN/CNN/TestReshapeCpu.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestReshapeCpu.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing Flatten function for Reference backend                            *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/test/DNN/CNN/TestReshapeCuda.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestReshapeCuda.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing Flatten function for Reference backend                            *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/test/DNN/CNN/TestRotateWeights.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestRotateWeights.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing RotateWeights method                                              *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/test/DNN/CNN/TestRotateWeights.h
+++ b/tmva/tmva/test/DNN/CNN/TestRotateWeights.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing RotateWeights method on a CPU architecture                        *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/test/DNN/CNN/TestRotateWeightsCpu.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestRotateWeightsCpu.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing RotateWeights method on a CPU architecture                        *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 ////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/test/DNN/CNN/TestRotateWeightsCuda.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestRotateWeightsCuda.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing RotateWeights method on a CPU architecture                        *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #include <iostream>

--- a/tmva/tmva/test/DNN/TestMethodDLAdadeltaOptimizationCpu.cxx
+++ b/tmva/tmva/test/DNN/TestMethodDLAdadeltaOptimizationCpu.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing MethodDL with DNN for Adadelta optimizer ( CPU backend )          *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #include "TestMethodDLOptimization.h"

--- a/tmva/tmva/test/DNN/TestMethodDLAdagradOptimizationCpu.cxx
+++ b/tmva/tmva/test/DNN/TestMethodDLAdagradOptimizationCpu.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing MethodDL with DNN for Adagrad optimizer ( CPU backend )           *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #include "TestMethodDLOptimization.h"

--- a/tmva/tmva/test/DNN/TestMethodDLAdamOptimizationCpu.cxx
+++ b/tmva/tmva/test/DNN/TestMethodDLAdamOptimizationCpu.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing MethodDL with DNN for Adam optimizer ( CPU backend )              *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #include "TestMethodDLOptimization.h"

--- a/tmva/tmva/test/DNN/TestMethodDLOptimization.h
+++ b/tmva/tmva/test/DNN/TestMethodDLOptimization.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing MethodDL with DNN for various optimizers                          *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef TMVA_TEST_DNN_TEST_METHOD_DL_OPTIMIZATION_H

--- a/tmva/tmva/test/DNN/TestMethodDLRMSPropOptimizationCpu.cxx
+++ b/tmva/tmva/test/DNN/TestMethodDLRMSPropOptimizationCpu.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing MethodDL with DNN for RMSProp optimizer ( CPU backend )           *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #include "TestMethodDLOptimization.h"

--- a/tmva/tmva/test/DNN/TestMethodDLSGDOptimizationCpu.cxx
+++ b/tmva/tmva/test/DNN/TestMethodDLSGDOptimizationCpu.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing MethodDL with DNN for SGD optimizer ( CPU backend )               *
@@ -22,7 +22,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #include "TestMethodDLOptimization.h"

--- a/tmva/tmva/test/DNN/TestOptimization.h
+++ b/tmva/tmva/test/DNN/TestOptimization.h
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing Various Optimizers for training DeepNet                           *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef TMVA_TEST_DNN_TEST_OPTIMIZATION_H

--- a/tmva/tmva/test/DNN/TestOptimizationCpu.cxx
+++ b/tmva/tmva/test/DNN/TestOptimizationCpu.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing various optimizers for Cpu Backend                                *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #include "TestOptimization.h"

--- a/tmva/tmva/test/DNN/TestOptimizationCuda.cxx
+++ b/tmva/tmva/test/DNN/TestOptimizationCuda.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing various optimizers for Cpu Backend                                *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #include "TestOptimization.h"

--- a/tmva/tmva/test/DNN/TestOptimizationCudnn.cxx
+++ b/tmva/tmva/test/DNN/TestOptimizationCudnn.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing various optimizers for Cpu Backend                                *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #include "TestOptimization.h"

--- a/tmva/tmva/test/DNN/TestRegressionMethodDL.cxx
+++ b/tmva/tmva/test/DNN/TestRegressionMethodDL.cxx
@@ -5,7 +5,7 @@
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVA                                                                  *
  * Class  :                                                                       *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Testing Method DL for Regression                                          *
@@ -21,7 +21,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #ifndef TMVA_TEST_DNN_TEST_REGRESSION_TEST_METHOD_DL_H

--- a/tmva/tmvagui/src/efficienciesMulticlass.cxx
+++ b/tmva/tmvagui/src/efficienciesMulticlass.cxx
@@ -3,7 +3,7 @@
 /**********************************************************************************
  * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
  * Package: TMVAGUI                                                               *
- * Web    : http://tmva.sourceforge.net                                           *
+ *                                             *
  *                                                                                *
  * Description:                                                                   *
  *      Implementation (see header for description)                               *
@@ -17,7 +17,7 @@
  *                                                                                *
  * Redistribution and use in source and binary forms, with or without             *
  * modification, are permitted according to the terms listed in LICENSE           *
- * (http://tmva.sourceforge.net/LICENSE)                                          *
+ * (see tmva/doc/LICENSE)                                          *
  **********************************************************************************/
 
 #include "TMVA/efficienciesMulticlass.h"

--- a/tutorials/tmva/TMVAClassification.C
+++ b/tutorials/tmva/TMVAClassification.C
@@ -306,7 +306,7 @@ int TMVAClassification( TString myMethodList = "" )
    // ### Book MVA methods
    //
    // Please lookup the various method configuration options in the corresponding cxx files, eg:
-   // src/MethoCuts.cxx, etc, or here: http://tmva.sourceforge.net/optionRef.html
+   // src/MethoCuts.cxx, etc, or here: http://tmva.sourceforge.net/old_site/optionRef.html
    // it is possible to preset ranges in the option string in which the cut optimisation should be done:
    // "...:CutRangeMin[2]=-1:CutRangeMax[2]=1"...", where [2] is the third input variable
 

--- a/tutorials/tmva/TMVARegression.C
+++ b/tutorials/tmva/TMVARegression.C
@@ -222,7 +222,7 @@ void TMVARegression( TString myMethodList = "" )
    // Book MVA methods
    //
    // Please lookup the various method configuration options in the corresponding cxx files, eg:
-   // src/MethoCuts.cxx, etc, or here: http://tmva.sourceforge.net/optionRef.html
+   // src/MethoCuts.cxx, etc, or here: http://tmva.sourceforge.net/old_site/optionRef.html
    // it is possible to preset ranges in the option string in which the cut optimisation should be done:
    // "...:CutRangeMin[2]=-1:CutRangeMax[2]=1"...", where [2] is the third input variable
 


### PR DESCRIPTION
Fix also links to the correct Users Guide and keep when needed link to old web site using the correct link : https://tmva.sourceforge.net/old_site/

This PR fixes #7627 