### PR TITLE
[ntuple] Add importer CLI

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -42,6 +42,11 @@ ROOT_EXECUTABLE(rootnb.exe nbmain.cxx LIBRARIES Core)
 #---ReadSpeed-------------------------------------------------------------------------------------
 ROOT_EXECUTABLE(rootreadspeed src/readspeed.cxx LIBRARIES RIO Tree TreePlayer ReadSpeed)
 
+#---ttree2rntuple----------------------------------------------------------------------------------
+if (root7)
+  ROOT_EXECUTABLE(ttree2rntuple src/ttree2rntuple.cxx LIBRARIES RIO Tree ROOTNTuple ROOTNTupleUtil)
+endif()
+
 #---CreateHaddCommandLineOptions------------------------------------------------------------------
 generateHeader(hadd
   ${CMAKE_SOURCE_DIR}/main/src/hadd-argparse.py

--- a/main/src/ttree2rntuple.cxx
+++ b/main/src/ttree2rntuple.cxx
@@ -1,0 +1,30 @@
+/// \file ttree2rntuple.cxx
+/// \ingroup NTuple ROOT7
+/// \author Florine de Geus <florine.de.geus@cern.ch>
+/// \date 2023-10-25
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOT/RNTupleImporterCLI.hxx"
+
+using namespace ROOT::Experimental::RNTupleImporterCLI;
+
+int main(int argc, char **argv)
+{
+   auto config = ParseArgs(argc, argv);
+
+   if (!config.fShouldRun)
+      return 1; // ParseArgs has printed the --help or has encountered an issue and logged about it
+
+   RunImporter(config);
+
+   return 0;
+}

--- a/tree/ntupleutil/CMakeLists.txt
+++ b/tree/ntupleutil/CMakeLists.txt
@@ -16,9 +16,11 @@ endif()
 ROOT_STANDARD_LIBRARY_PACKAGE(ROOTNTupleUtil
 HEADERS
   ROOT/RNTupleImporter.hxx
+  ROOT/RNTupleImporterCLI.hxx
   ROOT/RNTupleInspector.hxx
 SOURCES
   v7/src/RNTupleImporter.cxx
+  v7/src/RNTupleImporterCLI.cxx
   v7/src/RNTupleInspector.cxx
 LINKDEF
   LinkDef.h

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporterCLI.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporterCLI.hxx
@@ -19,8 +19,9 @@
 #ifndef ROOT7_RNTupleImporterCLI
 #define ROOT7_RNTupleImporterCLI
 
-#include "ROOT/RNTupleImporter.hxx"
 #include "ROOT/RNTupleOptions.hxx"
+
+#include <vector>
 
 namespace ROOT {
 namespace Experimental {

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporterCLI.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporterCLI.hxx
@@ -1,0 +1,58 @@
+/// \file ROOT/RNTupleImporterCLI.hxx
+/// \ingroup NTuple ROOT7
+/// \author Florine de Geus <florine.de.geus@cern.ch>
+/// \date 2023-10-25
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+/* This header contains helper functions for the ttree2rntuple program
+   for CLI related actions, such as argument parsing and output printing. */
+
+#ifndef ROOT7_RNTupleImporterCLI
+#define ROOT7_RNTupleImporterCLI
+
+#include "ROOT/RNTupleImporter.hxx"
+#include "ROOT/RNTupleOptions.hxx"
+
+namespace ROOT {
+namespace Experimental {
+namespace RNTupleImporterCLI {
+
+struct ImporterConfig {
+   /// By default, compress RNTuple with zstd, level 5
+   static constexpr int kDefaultCompressionSettings = 505;
+   /// The name of the TTree to convert from.
+   std::string fTreeName;
+   /// The path to the ROOT file containing the TTree to convert from.
+   std::string fTreePath;
+   /// The name of the RNTuple to convert to.
+   std::string fNTupleName;
+   /// The path to the ROOT file that will contain the newly converted RNTuple.
+   std::string fNTuplePath;
+   /// The RNTuple write options to use when converting.
+   RNTupleWriteOptions fNTupleOpts;
+   /// Whether dots present in branch names should be converted to underscores.
+   bool fConvertDots = false;
+   /// Whether per-branch progress should be printed.
+   bool fVerbose = false;
+   /// Whether the importing should actually happen (or, for example, only a help text should be printed).
+   bool fShouldRun = false;
+};
+
+ImporterConfig ParseArgs(const std::vector<std::string> &args);
+ImporterConfig ParseArgs(int argc, char **argv);
+
+void RunImporter(const ImporterConfig &config);
+} // namespace RNTupleImporterCLI
+} // namespace Experimental
+} // namespace ROOT
+
+#endif // ROOT7_RNTupleImporterCLI

--- a/tree/ntupleutil/v7/src/RNTupleImporterCLI.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporterCLI.cxx
@@ -111,7 +111,20 @@ ImporterConfig ROOT::Experimental::RNTupleImporterCLI::ParseArgs(const std::vect
    for (size_t i = 1; i < args.size(); ++i) {
       const auto &arg = args[i];
 
-      if (arg == "--ttree" || arg == "-t") {
+      if (argState != EArgState::kNone) {
+         switch (argState) {
+         case EArgState::kTreeName: config.fTreeName = arg; break;
+         case EArgState::kTreePath: config.fTreePath = arg; break;
+         case EArgState::kNTuplePath: config.fNTuplePath = arg; break;
+         case EArgState::kNTupleName: config.fNTupleName = arg; break;
+         case EArgState::kCompression: config.fNTupleOpts.SetCompression(std::stoi(arg)); break;
+         case EArgState::kUnzippedPageSize: config.fNTupleOpts.SetApproxUnzippedPageSize(std::stol(arg)); break;
+         case EArgState::kZippedClusterSize: config.fNTupleOpts.SetApproxZippedClusterSize(std::stol(arg)); break;
+         case EArgState::kUnzippedClusterSize: config.fNTupleOpts.SetMaxUnzippedClusterSize(std::stol(arg)); break;
+         default: std::cerr << "Unrecognized option '" << arg << "'\n"; return {};
+         }
+         argState = EArgState::kNone;
+      } else if (arg == "--ttree" || arg == "-t") {
          argState = EArgState::kTreeName;
       } else if (arg == "--infile" || arg == "-i") {
          argState = EArgState::kTreePath;
@@ -129,23 +142,13 @@ ImporterConfig ROOT::Experimental::RNTupleImporterCLI::ParseArgs(const std::vect
          argState = EArgState::kUnzippedClusterSize;
       } else if (arg == "--convert-dots") {
          config.fConvertDots = true;
+         argState = EArgState::kNone;
       } else if (arg == "--verbose" || arg == "-v") {
          config.fVerbose = true;
-      } else if (arg[0] == '-') {
-         std::cerr << "Unrecognized option '" << arg << "'\n";
-         return {};
+         argState = EArgState::kNone;
       } else {
-         switch (argState) {
-         case EArgState::kTreeName: config.fTreeName = arg; break;
-         case EArgState::kTreePath: config.fTreePath = arg; break;
-         case EArgState::kNTuplePath: config.fNTuplePath = arg; break;
-         case EArgState::kNTupleName: config.fNTupleName = arg; break;
-         case EArgState::kCompression: config.fNTupleOpts.SetCompression(std::stoi(arg)); break;
-         case EArgState::kUnzippedPageSize: config.fNTupleOpts.SetApproxUnzippedPageSize(std::stol(arg)); break;
-         case EArgState::kZippedClusterSize: config.fNTupleOpts.SetApproxZippedClusterSize(std::stol(arg)); break;
-         case EArgState::kUnzippedClusterSize: config.fNTupleOpts.SetMaxUnzippedClusterSize(std::stol(arg)); break;
-         default: std::cerr << "Unrecognized option '" << arg << "'\n"; return {};
-         }
+         std::cerr << "Unrecognized argument '" << arg << "'\n";
+         return {};
       }
    }
 

--- a/tree/ntupleutil/v7/src/RNTupleImporterCLI.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporterCLI.cxx
@@ -1,0 +1,197 @@
+/// \file RNTupleImporterCLI.cxx
+/// \ingroup NTuple ROOT7
+/// \author Florine de Geus <florine.de.geus@cern.ch>
+/// \date 2023-10-25
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOT/RNTupleImporterCLI.hxx"
+
+#include "TROOT.h"
+
+using namespace ROOT::Experimental::RNTupleImporterCLI;
+
+const auto usageText = "Usage:\n"
+                       " ttree2rntuple (--ttree|-t) name\n"
+                       "               (--infile|-i) path\n"
+                       "               (--outfile|-o) path\n"
+                       "               [(--rntuple|-r) name]\n"
+                       "               [(--compression|-c) compression]\n"
+                       "               [--unzipped-page-size size]\n"
+                       "               [--zipped-cluster-size size]\n"
+                       "               [--max-unzipped-cluster-size size]\n"
+                       "               [--convert-dots]\n"
+                       "               [(--verbose|-v)]\n"
+                       " ttree2rntuple [--help|-h]\n\n";
+
+const auto argUsageText =
+   "ttree2rntuple: a utility CLI for converting ROOT TTrees to ROOT RNTuples.\n"
+   "\n"
+   "Required arguments:\n"
+   "  --ttree, -t name\n"
+   "    The name of the source TTree to convert to RNTuple.\n"
+   "  --infile, -i path\n"
+   "    The path to the ROOT file that contains the source TTree.\n"
+   "  --outfile, -o path\n"
+   "    The path to the ROOT file to write the target RNTuple to. This file does not have to exist yet.\n"
+   "    This may be the same file as the input file. Note that in this case the name of the target RNTuple should\n"
+   "    be set to something different from the source TTree name using `--rntuple`, to avoid naming conflicts.\n"
+   "\n"
+   "Optional arguments:\n"
+   "  --rntuple, -r name\n"
+   "    The name of the target RNTuple.\n"
+   "    This argument is optional. When not provided, the name of the source TTree will be used.\n"
+   "  --compression, -c compression\n"
+   "    The compression settings of the target RNTuple, provided as an integer.\n"
+   "    This argument should be provided following ROOT's compression setting scheme (algorithm * 100 + level),\n"
+   "    where `algorithm` uses the following mapping: {1: ZLIB, 2: LZMA, 4: LZMA, 5: ZSTD} \n"
+   "    and `level` is a number from 0 to 9 (inclusive, 0 indicating no compression).\n"
+   "    If not specified, the default zstd (505) compression is used.\n"
+   "  --unzipped-page-size size\n"
+   "    The desired approximate unzipped (in-memory) page size in bytes, provided as an integer.\n"
+   "    If not specified, the default size of 64 * 1024 bytes is used.\n"
+   "  --zipped-cluster-size size\n"
+   "    The desired approximate zipped cluster size in bytes, provided as an integer.\n"
+   "    If not specified, the default size of 50 * 1000 * 1000 bytes is used.\n"
+   "  --max-unzipped-cluster-size size\n"
+   "    The desired maximum unzipped (in-memory) cluster size in bytes, provided as an integer.\n"
+   "    If not specified, the default size of 512 * 1024 * 1024 bytes is used.\n"
+   "  --convert-dots\n"
+   "    Whether to convert dots in branch names (if present) to underscores in field names.\n"
+   "    RNTuple does not allow for dots in field names, so this option will convert them to underscores.\n"
+   "    If not specified, no conversion happens and an error is thrown when branch names with dots are encountered.\n"
+   "  --verbose, -v\n"
+   "    Whether to print schema information and progress.\n"
+   "    If not specified, nothing will be printed except for a brief report about the source TTree and target "
+   "RNTuple.\n";
+
+ImporterConfig ROOT::Experimental::RNTupleImporterCLI::ParseArgs(const std::vector<std::string> &args)
+{
+   // Print help message and exit if "--help"
+   const auto argsProvided = args.size() >= 2;
+   const auto helpUsed = argsProvided && (args[1] == "--help" || args[1] == "-h");
+
+   if (!argsProvided || helpUsed) {
+      std::cout << usageText;
+      if (!argsProvided)
+         std::cout << " Use --help or -h for usage help.";
+      if (helpUsed)
+         std::cout << argUsageText;
+      std::cout << std::endl;
+
+      return {};
+   }
+
+   enum class EArgState {
+      kNone,
+      kTreeName,
+      kTreePath,
+      kNTuplePath,
+      kNTupleName,
+      kCompression,
+      kUnzippedPageSize,
+      kUnzippedClusterSize,
+      kZippedClusterSize
+   } argState = EArgState::kNone;
+   ImporterConfig config;
+   // The config will overwrite the write options set by `RNTupleImporter`, so we need to set the default zstd
+   // compression here as well.
+   config.fNTupleOpts.SetCompression(config.kDefaultCompressionSettings);
+
+   for (size_t i = 1; i < args.size(); ++i) {
+      const auto &arg = args[i];
+
+      if (arg == "--ttree" || arg == "-t") {
+         argState = EArgState::kTreeName;
+      } else if (arg == "--infile" || arg == "-i") {
+         argState = EArgState::kTreePath;
+      } else if (arg == "--outfile" || arg == "-o") {
+         argState = EArgState::kNTuplePath;
+      } else if (arg == "--rntuple" || arg == "-r") {
+         argState = EArgState::kNTupleName;
+      } else if (arg == "--compression" || arg == "-c") {
+         argState = EArgState::kCompression;
+      } else if (arg == "--unzipped-page-size") {
+         argState = EArgState::kUnzippedPageSize;
+      } else if (arg == "--zipped-cluster-size") {
+         argState = EArgState::kZippedClusterSize;
+      } else if (arg == "--max-unzipped-cluster-size") {
+         argState = EArgState::kUnzippedClusterSize;
+      } else if (arg == "--convert-dots") {
+         config.fConvertDots = true;
+      } else if (arg == "--verbose" || arg == "-v") {
+         config.fVerbose = true;
+      } else if (arg[0] == '-') {
+         std::cerr << "Unrecognized option '" << arg << "'\n";
+         return {};
+      } else {
+         switch (argState) {
+         case EArgState::kTreeName: config.fTreeName = arg; break;
+         case EArgState::kTreePath: config.fTreePath = arg; break;
+         case EArgState::kNTuplePath: config.fNTuplePath = arg; break;
+         case EArgState::kNTupleName: config.fNTupleName = arg; break;
+         case EArgState::kCompression: config.fNTupleOpts.SetCompression(std::stoi(arg)); break;
+         case EArgState::kUnzippedPageSize: config.fNTupleOpts.SetApproxUnzippedPageSize(std::stol(arg)); break;
+         case EArgState::kZippedClusterSize: config.fNTupleOpts.SetApproxZippedClusterSize(std::stol(arg)); break;
+         case EArgState::kUnzippedClusterSize: config.fNTupleOpts.SetMaxUnzippedClusterSize(std::stol(arg)); break;
+         default: std::cerr << "Unrecognized option '" << arg << "'\n"; return {};
+         }
+      }
+   }
+
+   if (config.fTreeName == "") {
+      std::cerr << "Please provide the name of the TTree to convert.\n\n" << usageText << "\n";
+      return {};
+   } else if (config.fTreePath == "") {
+      std::cerr << "Please provide the name of the ROOT file containing the TTree to convert.\n\n" << usageText << "\n";
+      return {};
+   } else if (config.fNTuplePath == "") {
+      std::cerr << "Please provide the name of the ROOT file to write the converted RNTuple to.\n\n"
+                << usageText << "\n";
+      return {};
+   }
+
+   config.fShouldRun = true;
+   return config;
+}
+
+ImporterConfig ROOT::Experimental::RNTupleImporterCLI::ParseArgs(int argc, char **argv)
+{
+   std::vector<std::string> args;
+   args.reserve(argc);
+
+   for (int i = 0; i < argc; ++i) {
+      args.emplace_back(argv[i]);
+   }
+
+   return ParseArgs(args);
+}
+
+void ROOT::Experimental::RNTupleImporterCLI::RunImporter(const ImporterConfig &config)
+{
+#ifdef R__USE_IMT
+   ROOT::EnableImplicitMT();
+#endif
+
+   auto importer = RNTupleImporter::Create(config.fTreePath, config.fTreeName, config.fNTuplePath);
+
+   importer->SetWriteOptions(config.fNTupleOpts);
+   importer->SetIsQuiet(!config.fVerbose);
+   importer->SetConvertDotsInBranchNames(config.fConvertDots);
+
+   if (!config.fNTupleName.empty())
+      importer->SetNTupleName(config.fNTupleName);
+
+   std::cout << "Converting TTree '" << config.fTreeName << "' in '" << config.fTreePath << "' to RNTuple '"
+             << config.fTreeName << "' in '" << config.fNTuplePath << "'..." << std::endl;
+
+   importer->Import();
+}

--- a/tree/ntupleutil/v7/src/RNTupleImporterCLI.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporterCLI.cxx
@@ -19,6 +19,7 @@
 
 using namespace ROOT::Experimental::RNTupleImporterCLI;
 
+namespace {
 const auto usageText = "Usage:\n"
                        " ttree2rntuple (--ttree|-t) name\n"
                        "               (--infile|-i) path\n"
@@ -72,6 +73,7 @@ const auto argUsageText =
    "    Whether to print schema information and progress.\n"
    "    If not specified, nothing will be printed except for a brief report about the source TTree and target "
    "RNTuple.\n";
+} // namespace
 
 ImporterConfig ROOT::Experimental::RNTupleImporterCLI::ParseArgs(const std::vector<std::string> &args)
 {

--- a/tree/ntupleutil/v7/src/RNTupleImporterCLI.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporterCLI.cxx
@@ -14,8 +14,11 @@
  *************************************************************************/
 
 #include "ROOT/RNTupleImporterCLI.hxx"
+#include "ROOT/RNTupleImporter.hxx"
 
 #include "TROOT.h"
+
+#include <iostream>
 
 using namespace ROOT::Experimental::RNTupleImporterCLI;
 

--- a/tree/ntupleutil/v7/test/CMakeLists.txt
+++ b/tree/ntupleutil/v7/test/CMakeLists.txt
@@ -20,4 +20,5 @@ if(MSVC)
 endif()
 
 ROOT_ADD_GTEST(ntuple_importer ntuple_importer.cxx LIBRARIES ROOTNTupleUtil CustomStructUtil)
+ROOT_ADD_GTEST(ntuple_importer_cli ntuple_importer_cli.cxx LIBRARIES ROOTNTupleUtil)
 ROOT_ADD_GTEST(ntuple_inspector ntuple_inspector.cxx LIBRARIES ROOTNTupleUtil)

--- a/tree/ntupleutil/v7/test/ntuple_importer_cli.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer_cli.cxx
@@ -1,0 +1,203 @@
+#include "gtest/gtest.h"
+
+#include "ROOT/RNTupleImporterCLI.hxx"
+#include "ROOT/RNTupleInspector.hxx"
+
+#include "ROOT/TestSupport.hxx"
+#include "ntupleutil_test.hxx"
+
+#include "TFile.h"
+#include "TSystem.h"
+#include "TTree.h"
+
+using namespace ROOT::Experimental::RNTupleImporterCLI;
+using ROOT::Experimental::RNTupleInspector;
+using ROOT::Experimental::RNTupleReader;
+
+TEST(RNTupleImporterCLI, Basic)
+{
+   FileRaii inputFileGuard("test_ntuple_importer_cli_basic_in.root");
+   {
+      std::unique_ptr<TFile> file(TFile::Open(inputFileGuard.GetPath().c_str(), "RECREATE"));
+      auto tree = std::make_unique<TTree>("tree", "");
+      tree->Write();
+   }
+   FileRaii outputFileGuard("test_ntuple_importer_cli_basic_out.root");
+
+   const std::vector<std::string> args{"ttree2rntuple",          "-t", "tree", "-i", inputFileGuard.GetPath(), "-o",
+                                       outputFileGuard.GetPath()};
+
+   const auto importerCfg = ParseArgs(args);
+
+   EXPECT_TRUE(importerCfg.fShouldRun) << "Arguments are valid and should have been correctly parsed.";
+
+   RunImporter(importerCfg);
+
+   EXPECT_NO_THROW(RNTupleReader::Open("tree", outputFileGuard.GetPath()))
+      << "RNTuple should exist in the provided output file";
+}
+
+TEST(RNTupleImporterCLI, LongArgs)
+{
+   const std::vector<std::string> args{"ttree2rntuple", "--ttree",          "tree", "--infile", "my_tree_file.root",
+                                       "--outfile",     "my_tree_file.root"};
+
+   const auto importerCfg = ParseArgs(args);
+
+   EXPECT_EQ(importerCfg.fTreeName, "tree") << "Provided TTree name does not match expected name.";
+   EXPECT_EQ(importerCfg.fTreePath, "my_tree_file.root") << "Provided input filename does not match expected name.";
+   EXPECT_EQ(importerCfg.fNTuplePath, "my_tree_file.root") << "Provided output filename does not match expected name.";
+}
+
+TEST(RNTupleImporterCLI, NoArgs)
+{
+   const std::vector<std::string> args{"ttree2rntuple"};
+
+   const auto importerCfg = ParseArgs(args);
+
+   EXPECT_TRUE(!importerCfg.fShouldRun) << "Program running when not provided any argument.";
+}
+
+TEST(RNTupleImporterCLI, HelpArg)
+{
+   const std::vector<std::string> args{"ttree2rntuple", "--help"};
+
+   const auto importerCfg = ParseArgs(args);
+
+   EXPECT_TRUE(!importerCfg.fShouldRun) << "Program running when provided --help argument.";
+}
+
+TEST(RNTupleImporterCLI, MissingTreeName)
+{
+   const std::vector<std::string> args{"ttree2rntuple", "--infile", "my_tree_file.root", "--outfile",
+                                       "my_tree_file.root"};
+
+   const auto importerCfg = ParseArgs(args);
+
+   EXPECT_TRUE(!importerCfg.fShouldRun) << "Program running when missing --ttree argument.";
+}
+
+TEST(RNTupleImporterCLI, MissingTreePath)
+{
+   const std::vector<std::string> args{"ttree2rntuple", "--ttree", "tree", "--outfile", "my_tree_file.root"};
+
+   const auto importerCfg = ParseArgs(args);
+
+   EXPECT_TRUE(!importerCfg.fShouldRun) << "Program running when missing --infile argument.";
+}
+
+TEST(RNTupleImporterCLI, MissingNTuplePath)
+{
+   const std::vector<std::string> args{"ttree2rntuple", "--ttree", "tree", "--infile", "my_tree_file.root"};
+
+   const auto importerCfg = ParseArgs(args);
+
+   EXPECT_TRUE(!importerCfg.fShouldRun) << "Program running when missing --outfile argument.";
+}
+
+TEST(RNTupleImporterCLI, InvalidArgs)
+{
+   const std::vector<std::string> args{"ttree2rntuple", "--wrong"};
+
+   const auto importerCfg = ParseArgs(args);
+
+   EXPECT_TRUE(!importerCfg.fShouldRun) << "Program running when not using any arguments.";
+}
+
+TEST(RNTupleImporterCLI, Name)
+{
+   FileRaii inputFileGuard("test_ntuple_importer_cli_name_in.root");
+   {
+      std::unique_ptr<TFile> file(TFile::Open(inputFileGuard.GetPath().c_str(), "RECREATE"));
+      auto tree = std::make_unique<TTree>("tree", "");
+      tree->Write();
+   }
+   FileRaii outputFileGuard("test_ntuple_importer_cli_name_out.root");
+
+   const std::vector<std::string> args{
+      "ttree2rntuple", "-t", "tree", "-i", inputFileGuard.GetPath(), "-r", "ntuple", "-o", outputFileGuard.GetPath()};
+
+   const auto importerCfg = ParseArgs(args);
+
+   EXPECT_EQ("ntuple", importerCfg.fNTupleName) << "RNTuple name should be correctly set";
+   EXPECT_TRUE(importerCfg.fShouldRun) << "Arguments are valid and should have been correctly parsed.";
+
+   RunImporter(importerCfg);
+
+   EXPECT_NO_THROW(RNTupleReader::Open("ntuple", outputFileGuard.GetPath()))
+      << "RNTuple should exist in the provided output file";
+}
+
+TEST(RNTupleImporterCLI, WriteOptions)
+{
+   FileRaii inputFileGuard("test_ntuple_importer_cli_writeopts_in.root");
+   {
+      std::unique_ptr<TFile> file(TFile::Open(inputFileGuard.GetPath().c_str(), "RECREATE"));
+      auto tree = std::make_unique<TTree>("tree", "");
+      Int_t a = 42;
+      tree->Branch("a", &a);
+      tree->Fill();
+      tree->Write();
+   }
+   FileRaii outputFileGuard("test_ntuple_importer_cli_writeopts_out.root");
+
+   const std::vector<std::string> args{"ttree2rntuple",
+                                       "-t",
+                                       "tree",
+                                       "-i",
+                                       inputFileGuard.GetPath(),
+                                       "-o",
+                                       outputFileGuard.GetPath(),
+                                       "-c",
+                                       "207",
+                                       "--unzipped-page-size",
+                                       std::to_string(32 * 1024),
+                                       "--zipped-cluster-size",
+                                       std::to_string(25 * 1000 * 1000),
+                                       "--max-unzipped-cluster-size",
+                                       std::to_string(256 * 1024 * 1024)};
+
+   const auto importerCfg = ParseArgs(args);
+
+   EXPECT_EQ(207, importerCfg.fNTupleOpts.GetCompression()) << "Compression should be correctly set";
+   EXPECT_EQ(32 * 1024, importerCfg.fNTupleOpts.GetApproxUnzippedPageSize()) << "Page size should be correctly set";
+   EXPECT_EQ(25 * 1000 * 1000, importerCfg.fNTupleOpts.GetApproxZippedClusterSize())
+      << "Cluster size should be correctly set";
+   EXPECT_EQ(256 * 1024 * 1024, importerCfg.fNTupleOpts.GetMaxUnzippedClusterSize())
+      << "Max cluster size should be correctly set";
+   EXPECT_TRUE(importerCfg.fShouldRun) << "Arguments are valid and should have been correctly parsed.";
+
+   RunImporter(importerCfg);
+
+   auto inspector = RNTupleInspector::Create("tree", outputFileGuard.GetPath());
+
+   EXPECT_EQ(207, inspector->GetCompressionSettings()) << "Compression should be correctly set";
+}
+
+TEST(RNTupleImporterCLI, ConvertDots)
+{
+   FileRaii inputFileGuard("test_ntuple_importer_cli_dots_in.root");
+   {
+      std::unique_ptr<TFile> file(TFile::Open(inputFileGuard.GetPath().c_str(), "RECREATE"));
+      auto tree = std::make_unique<TTree>("tree", "");
+      Int_t pt = 42;
+      tree->Branch("a.pt", &pt);
+      tree->Fill();
+      tree->Write();
+   }
+   FileRaii outputFileGuard("test_ntuple_importer_cli_dots_out.root");
+
+   const std::vector<std::string> args{
+      "ttree2rntuple", "-t", "tree", "-i", inputFileGuard.GetPath(), "-o", outputFileGuard.GetPath(), "--convert-dots"};
+
+   const auto importerCfg = ParseArgs(args);
+
+   EXPECT_TRUE(importerCfg.fShouldRun) << "Arguments are valid and should have been correctly parsed.";
+
+   RunImporter(importerCfg);
+
+   auto ntuple = RNTupleReader::Open("tree", outputFileGuard.GetPath());
+
+   auto pt = ntuple->GetView<Int_t>("a_pt");
+   EXPECT_EQ(42, pt(0)) << "RNTuple entry value should match that of TTree";
+}

--- a/tree/ntupleutil/v7/test/ntuple_importer_cli.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer_cli.cxx
@@ -95,13 +95,32 @@ TEST(RNTupleImporterCLI, MissingNTuplePath)
    EXPECT_TRUE(!importerCfg.fShouldRun) << "Program running when missing --outfile argument.";
 }
 
-TEST(RNTupleImporterCLI, InvalidArgs)
+TEST(RNTupleImporterCLI, InvalidArgs1)
 {
    const std::vector<std::string> args{"ttree2rntuple", "--wrong"};
 
    const auto importerCfg = ParseArgs(args);
 
-   EXPECT_TRUE(!importerCfg.fShouldRun) << "Program running when not using any arguments.";
+   EXPECT_TRUE(!importerCfg.fShouldRun) << "Program running when using invalid arguments.";
+}
+
+TEST(RNTupleImporterCLI, InvalidArgs2)
+{
+   const std::vector<std::string> args{"ttree2rntuple", "wrong"};
+
+   const auto importerCfg = ParseArgs(args);
+
+   EXPECT_TRUE(!importerCfg.fShouldRun) << "Program running when using invalid arguments.";
+}
+
+TEST(RNTupleImporterCLI, OptionAsName)
+{
+   const std::vector<std::string> args{"ttree2rntuple", "-t", "-v", "-i", "in.root", "-o", "out.root"};
+
+   const auto importerCfg = ParseArgs(args);
+
+   EXPECT_EQ(importerCfg.fTreeName, "-v") << "Provided TTree name does not match expected name.";
+   EXPECT_FALSE(importerCfg.fVerbose) << "Verbosity should not be enabled.";
 }
 
 TEST(RNTupleImporterCLI, Name)


### PR DESCRIPTION
This PR adds a CLI to the `RNTupleImporter` utility. The executable is called `ttree2rntuple` (can be changed if there are suggestions for better names), usage is as follows (copied from `ttree2rntuple --help`):

```
Usage:
 ttree2rntuple (--ttree|-t) name
               (--infile|-i) path
               (--outfile|-o) path
               [(--rntuple|-r) name]
               [(--compression|-c) compression]
               [--unzipped-page-size size]
               [--zipped-cluster-size size]
               [--max-unzipped-cluster-size size]
               [--convert-dots]
               [(--verbose|-v)]
 ttree2rntuple [--help|-h]

ttree2rntuple: a utility CLI for converting ROOT TTrees to ROOT RNTuples.

Required arguments:
  --ttree, -t name
    The name of the source TTree to convert to RNTuple.
  --infile, -i path
    The path to the ROOT file that contains the source TTree.
  --outfile, -o path
    The path to the ROOT file to write the target RNTuple to. This file does not have to exist yet.
    This may be the same file as the input file. Note that in this case the name of the target RNTuple should
    be set to something different from the source TTree name using `--rntuple`, to avoid naming conflicts.

Optional arguments:
  --rntuple, -r name
    The name of the target RNTuple.
    This argument is optional. When not provided, the name of the source TTree will be used.
  --compression, -c compression
    The compression settings of the target RNTuple, provided as an integer.
    This argument should be provided following ROOT's compression setting scheme (algorithm * 100 + level),
    where `algorithm` uses the following mapping: {1: ZLIB, 2: LZMA, 4: LZMA, 5: ZSTD} 
    and `level` is a number from 0 to 9 (inclusive, 0 indicating no compression).
    If not specified, the default zstd (505) compression is used.
  --unzipped-page-size size
    The desired approximate unzipped (in-memory) page size in bytes, provided as an integer.
    If not specified, the default size of 64 * 1024 bytes is used.
  --zipped-cluster-size size
    The desired approximate zipped cluster size in bytes, provided as an integer.
    If not specified, the default size of 50 * 1000 * 1000 bytes is used.
  --max-unzipped-cluster-size size
    The desired maximum unzipped (in-memory) cluster size in bytes, provided as an integer.
    If not specified, the default size of 512 * 1024 * 1024 bytes is used.
  --convert-dots
    Whether to convert dots in branch names (if present) to underscores in field names.
    RNTuple does not allow for dots in field names, so this option will convert them to underscores.
    If not specified, no conversion happens and an error is thrown when branch names with dots are encountered.
  --verbose, -v
    Whether to print schema information and progress.
    If not specified, nothing will be printed except for a brief report about the source TTree and target RNTuple.
```

