### PR TITLE
[tree] Apply suggestions from clang-tidy

### DIFF
--- a/tree/tree/inc/TBranch.h
+++ b/tree/tree/inc/TBranch.h
@@ -283,7 +283,7 @@ public:
            void      SetIOFeatures(TIOFeatures &features) {fIOFeatures = features;}
    virtual Bool_t    SetMakeClass(Bool_t decomposeObj = kTRUE);
    virtual void      SetOffset(Int_t offset=0) {fOffset=offset;}
-   virtual void      SetStatus(Bool_t status=1);
+   virtual void      SetStatus(Bool_t status=true);
    virtual void      SetTree(TTree *tree) { fTree = tree; }
    virtual void      SetupAddresses();
            Bool_t    SupportsBulkRead() const;

--- a/tree/tree/inc/TBranchElement.h
+++ b/tree/tree/inc/TBranchElement.h
@@ -211,7 +211,7 @@ public:
            Bool_t           IsBranchFolder() const { return TestBit(kBranchFolder); }
            Bool_t           IsFolder() const override;
    virtual Bool_t           IsObjectOwner() const { return TestBit(kDeleteObject); }
-           Bool_t           Notify() override { if (fAddress) { ResetAddress(); } return 1; }
+           Bool_t           Notify() override { if (fAddress) { ResetAddress(); } return true; }
            void             Print(Option_t* option = "") const override;
            void             PrintValue(Int_t i) const;
            void             Reset(Option_t* option = "") override;

--- a/tree/tree/inc/TChain.h
+++ b/tree/tree/inc/TChain.h
@@ -157,7 +157,7 @@ public:
    }
 #endif
 
-   void      SetBranchStatus(const char *bname, Bool_t status = 1, UInt_t *found = nullptr) override;
+   void      SetBranchStatus(const char *bname, Bool_t status = true, UInt_t *found = nullptr) override;
    Int_t     SetCacheSize(Long64_t cacheSize = -1) override;
    void      SetDirectory(TDirectory *dir) override;
    void      SetEntryList(TEntryList *elist, Option_t *opt="") override;

--- a/tree/tree/inc/TQueryResult.h
+++ b/tree/tree/inc/TQueryResult.h
@@ -106,7 +106,7 @@ protected:
    void            SetNumMergers(Int_t nmergers) { fNumMergers = nmergers; }
 
 public:
-   TQueryResult() : fSeqNum(-1), fDraw(0), fStatus(kSubmitted), fUsedCPU(0.),
+   TQueryResult() : fSeqNum(-1), fDraw(false), fStatus(kSubmitted), fUsedCPU(0.),
                     fInputList(nullptr), fEntries(-1), fFirst(-1), fBytes(0),
                     fLogFile(nullptr), fSelecHdr(nullptr), fSelecImp(nullptr),
                     fLibList("-"), fOutputList(nullptr),

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -601,7 +601,7 @@ public:
       return SetBranchAddress(bname,add,ptr,cl,type,false);
    }
 #endif
-   virtual void            SetBranchStatus(const char* bname, Bool_t status = 1, UInt_t* found = nullptr);
+   virtual void            SetBranchStatus(const char* bname, Bool_t status = true, UInt_t* found = nullptr);
    static  void            SetBranchStyle(Int_t style = 1);  //style=0 for old branch, =1 for new branch style
    virtual Int_t           SetCacheSize(Long64_t cachesize = -1);
    virtual Int_t           SetCacheEntryRange(Long64_t first, Long64_t last);

--- a/tree/tree/src/TBasket.cxx
+++ b/tree/tree/src/TBasket.cxx
@@ -606,7 +606,7 @@ Int_t TBasket::ReadBasketBuffers(Long64_t pos, Int_t len, TFile *file)
       Int_t nout = 0, noutot = 0, nintot = 0;
 
       // Unzip all the compressed objects in the compressed object buffer.
-      while (1) {
+      while (true) {
          // Check the header for errors.
          if (R__unlikely(R__unzip_header(&nin, rawCompressedObjectBuffer, &nbuf) != 0)) {
             Error("ReadBasketBuffers", "Inconsistency found in header (nin=%d, nbuf=%d)", nin, nbuf);

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -1039,7 +1039,7 @@ TBranch* TBranch::FindBranch(const char* name)
    longnm.reserve(fName.Length()+strlen(name)+3);
    longnm = fName.Data();
    if (longnm[longnm.length()-1]==']') {
-      std::size_t dim = longnm.find_first_of("[");
+      std::size_t dim = longnm.find_first_of('[');
       if (dim != std::string::npos) {
          longnm.erase(dim);
       }
@@ -2716,9 +2716,9 @@ void TBranch::SetAddress(void* addr)
 void TBranch::SetAutoDelete(Bool_t autodel)
 {
    if (autodel) {
-      SetBit(kAutoDelete, 1);
+      SetBit(kAutoDelete, true);
    } else {
-      SetBit(kAutoDelete, 0);
+      SetBit(kAutoDelete, false);
    }
 }
 

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -1771,7 +1771,7 @@ void TBranchElement::FillLeavesMember(TBuffer& b)
 static void R__CleanName(std::string &name)
 {
    if (name[name.length()-1]==']') {
-      std::size_t dim = name.find_first_of("[");
+      std::size_t dim = name.find_first_of('[');
       if (dim != std::string::npos) {
          name.erase(dim);
       }
@@ -1984,7 +1984,7 @@ TStreamerInfo *TBranchElement::FindOnfileInfo(TClass *valueClass, const TObjArra
 }
 
 namespace {
-static void GatherArtificialElements(const TObjArray &branches, TStreamerInfoActions::TIDs &ids, TString prefix, TStreamerInfo *info, Int_t offset) {
+void GatherArtificialElements(const TObjArray &branches, TStreamerInfoActions::TIDs &ids, TString prefix, TStreamerInfo *info, Int_t offset) {
    size_t ndata = info->GetNelement();
    for (size_t i =0; i < ndata; ++i) {
       TStreamerElement *nextel = info->GetElement(i);

--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -2425,9 +2425,9 @@ Long64_t TChain::Scan(const char* varexp, const char* selection, Option_t* optio
 void TChain::SetAutoDelete(Bool_t autodelete)
 {
    if (autodelete) {
-      SetBit(kAutoDelete, 1);
+      SetBit(kAutoDelete, true);
    } else {
-      SetBit(kAutoDelete, 0);
+      SetBit(kAutoDelete, false);
    }
 }
 

--- a/tree/tree/src/TEntryList.cxx
+++ b/tree/tree/src/TEntryList.cxx
@@ -634,7 +634,7 @@ Bool_t TEntryList::Enter(Long64_t entry, TTree *tree)
          if (nblock >= fNBlocks) {
             if (fNBlocks>0){
                block = (TEntryListBlock*)fBlocks->UncheckedAt(fNBlocks-1);
-               if (!block) return 0;
+               if (!block) return false;
                block->OptimizeStorage();
             }
             for (Int_t i=fNBlocks; i<=nblock; i++){
@@ -646,7 +646,7 @@ Bool_t TEntryList::Enter(Long64_t entry, TTree *tree)
          block = (TEntryListBlock*)fBlocks->UncheckedAt(nblock);
          if (block->Enter(entry-nblock*kBlockSize)) {
             fN++;
-            return 1;
+            return true;
          }
       } else {
          //the entry in the current entry list
@@ -654,7 +654,7 @@ Bool_t TEntryList::Enter(Long64_t entry, TTree *tree)
          if (fCurrent->Enter(entry)) {
             if (fLists)
                fN++;
-            return 1;
+            return true;
          }
       }
    } else {
@@ -664,11 +664,11 @@ Bool_t TEntryList::Enter(Long64_t entry, TTree *tree)
          if (fCurrent->Enter(localentry)) {
             if (fLists)
                fN++;
-            return 1;
+            return true;
          }
       }
    }
-   return 0;
+   return false;
 
 }
 
@@ -679,10 +679,10 @@ Bool_t TEntryList::Enter(Long64_t localentry, const char *treename, const char *
       if (fCurrent->Enter(localentry)) {
          if (fLists)
             fN++;
-         return 1;
+         return true;
       }
    }
-   return 0;
+   return false;
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -716,22 +716,22 @@ Bool_t TEntryList::Remove(Long64_t entry, TTree *tree)
      return kFALSE;
    if (!tree) {
       if (!fLists) {
-         if (!fBlocks) return 0;
+         if (!fBlocks) return false;
          TEntryListBlock *block = nullptr;
          Long64_t nblock = entry/kBlockSize;
          block = (TEntryListBlock*)fBlocks->UncheckedAt(nblock);
-         if (!block) return 0;
+         if (!block) return false;
          Long64_t blockindex = entry - nblock*kBlockSize;
          if (block->Remove(blockindex)){
             fN--;
-            return 1;
+            return true;
          }
       } else {
          if (!fCurrent) fCurrent = (TEntryList*)fLists->First();
          if (fCurrent->Remove(entry)){
             if (fLists)
                fN--;
-            return 1;
+            return true;
          }
       }
    } else {
@@ -741,11 +741,11 @@ Bool_t TEntryList::Remove(Long64_t entry, TTree *tree)
          if (fCurrent->Remove(localentry)) {
             if (fLists)
                fN--;
-            return 1;
+            return true;
          }
       }
    }
-   return 0;
+   return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/tree/src/TEntryListArray.cxx
+++ b/tree/tree/src/TEntryListArray.cxx
@@ -343,7 +343,7 @@ Bool_t TEntryListArray::Enter(Long64_t entry, TTree *tree, Long64_t subentry)
    //add only the given subentry, creating a TEntryListArray to hold the subentries for the given entry
    //Return true only if the entry is new (not the subentry)
 
-   Bool_t result = 0;
+   Bool_t result = false;
 
    if (tree) {
       Long64_t localentry = tree->LoadTree(entry);
@@ -384,7 +384,7 @@ Bool_t TEntryListArray::Enter(Long64_t entry, TTree *tree, Long64_t subentry)
 
 Bool_t TEntryListArray::Enter(Long64_t localentry, const char *treename, const char *filename, Long64_t subentry)
 {
-   Bool_t result = 0;
+   Bool_t result = false;
    SetTree(treename, filename);
    TEntryListArray *currentArray = dynamic_cast<TEntryListArray *>(fCurrent);
    if (currentArray) {

--- a/tree/tree/src/TEntryListBlock.cxx
+++ b/tree/tree/src/TEntryListBlock.cxx
@@ -57,7 +57,7 @@ TEntryListBlock::TEntryListBlock()
    fN = kBlockSize;
    fNPassed = 0;
    fType = -1;
-   fPassing = 1;
+   fPassing = true;
    fCurrent = 0;
    fLastIndexReturned = -1;
    fLastIndexQueried = -1;
@@ -129,7 +129,7 @@ Bool_t TEntryListBlock::Enter(Int_t entry)
 {
    if (entry > kBlockSize*16) {
       Error("Enter", "illegal entry value!");
-      return 0;
+      return false;
    }
    if (!fIndices){
       fIndices = new UShort_t[kBlockSize] ;
@@ -144,17 +144,17 @@ Bool_t TEntryListBlock::Enter(Int_t entry)
       if ((fIndices[i] & (1<<j))==0){
          fIndices[i] |= 1<<j;
          fNPassed++;
-         return 1;
+         return true;
       } else {
-         return 0;
+         return false;
       }
    }
    //list
    //change to bits
    UShort_t *bits = new UShort_t[kBlockSize];
-   Transform(1, bits);
+   Transform(true, bits);
    Enter(entry);
-   return 0;
+   return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -167,7 +167,7 @@ Bool_t TEntryListBlock::Remove(Int_t entry)
 {
    if (entry > kBlockSize*16) {
       Error("Remove", "Illegal entry value!\n");
-      return 0;
+      return false;
    }
    if (fType==0){
       Int_t i = entry>>4;
@@ -175,15 +175,15 @@ Bool_t TEntryListBlock::Remove(Int_t entry)
       if ((fIndices[i] & (1<<j))!=0){
          fIndices[i] &= (0xFFFF^(1<<j));
          fNPassed--;
-         return 1;
+         return true;
       } else {
-         return 0;
+         return false;
       }
    }
    //list
    //change to bits
    UShort_t *bits = new UShort_t[kBlockSize];
-   Transform(1, bits);
+   Transform(true, bits);
    return Remove(entry);
    //return 0;
 }
@@ -294,7 +294,7 @@ Int_t TEntryListBlock::Merge(TEntryListBlock *block)
       if (GetNPassed() + block->GetNPassed() > kBlockSize){
          //change to bits
          UShort_t *bits = new UShort_t[kBlockSize];
-         Transform(1, bits);
+         Transform(true, bits);
          Merge(block);
       } else {
          //this is only possible if fPassing=1 in both blocks
@@ -548,11 +548,11 @@ void TEntryListBlock::OptimizeStorage()
 {
    if (fType!=0) return;
    if (fNPassed > kBlockSize*15)
-      fPassing = 0;
+      fPassing = false;
    if (fNPassed<kBlockSize || !fPassing){
       //less than 4000 entries passing, makes sense to change from bits to list
       UShort_t *indexnew = new UShort_t[fNPassed];
-      Transform(0, indexnew);
+      Transform(false, indexnew);
    }
 }
 
@@ -615,6 +615,6 @@ void TEntryListBlock::Transform(Bool_t dir, UShort_t *indexnew)
    fIndices = indexnew;
    fType = 0;
    fN = kBlockSize;
-   fPassing = 1;
+   fPassing = true;
    return;
 }

--- a/tree/tree/src/TLeafO.cxx
+++ b/tree/tree/src/TLeafO.cxx
@@ -30,8 +30,8 @@ TLeafO::TLeafO(): TLeaf()
 {
    fValue   = nullptr;
    fPointer = nullptr;
-   fMinimum = 0;
-   fMaximum = 0;
+   fMinimum = false;
+   fMaximum = false;
    fLenType = sizeof(Bool_t);
 }
 
@@ -42,8 +42,8 @@ TLeafO::TLeafO(TBranch *parent, const char *name, const char *type)
    : TLeaf(parent,name,type)
 {
    fLenType = sizeof(Bool_t);
-   fMinimum = 0;
-   fMaximum = 0;
+   fMinimum = false;
+   fMaximum = false;
    fValue   = nullptr;
    fPointer = nullptr;
 }
@@ -201,6 +201,6 @@ void TLeafO::SetAddress(void *add)
       }
    } else {
       fValue = new Bool_t[fNdata];
-      fValue[0] = 0;
+      fValue[0] = false;
    }
 }

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -511,7 +511,7 @@ TTree::TFriendLock::TFriendLock(TTree* tree, UInt_t methodbit)
       fPrevious = fTree->fFriendLockStatus & fMethodBit;
       fTree->fFriendLockStatus |= fMethodBit;
    } else {
-      fPrevious = 0;
+      fPrevious = false;
    }
 }
 
@@ -3428,7 +3428,7 @@ namespace {
 
    enum EOnIndexError { kDrop, kKeep, kBuild };
 
-   static Bool_t R__HandleIndex(EOnIndexError onIndexError, TTree *newtree, TTree *oldtree)
+   Bool_t R__HandleIndex(EOnIndexError onIndexError, TTree *newtree, TTree *oldtree)
    {
       // Return true if we should continue to handle indices, false otherwise.
 
@@ -5381,7 +5381,7 @@ Bool_t TTree::GetBranchStatus(const char* branchname) const
    if (br) {
       return br->TestBit(kDoNotProcess) == 0;
    }
-   return 0;
+   return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -6218,7 +6218,7 @@ TLeaf* TTree::GetLeaf(const char *name)
       return nullptr;
 
    std::string path(name);
-   const auto sep = path.find_last_of("/");
+   const auto sep = path.find_last_of('/');
    if (sep != std::string::npos)
       return GetLeafImpl(path.substr(0, sep).c_str(), name+sep+1);
 
@@ -7587,7 +7587,7 @@ char TTree::GetNewlineValue(std::istream &inputStream)
 {
    Long_t inPos = inputStream.tellg();
    char newline = '\n';
-   while(1) {
+   while(true) {
       char c = 0;
       inputStream.get(c);
       if(!inputStream.good()) {

--- a/tree/tree/src/TTreeCache.cxx
+++ b/tree/tree/src/TTreeCache.cxx
@@ -299,7 +299,9 @@ myTreeOrChain.GetTree()->PrintCacheStats();
 #include "TMath.h"
 #include "TBranchCacheInfo.h"
 #include "TVirtualPerfStats.h"
-#include <limits.h>
+#include <climits>
+
+#include <memory>
 
 Int_t TTreeCache::fgLearnEntries = 100;
 
@@ -699,7 +701,7 @@ void TTreeCache::ResetMissCache()
    fFirstMiss = -1;
 
    if (!fMissCache) {
-      fMissCache.reset(new MissCache());
+      fMissCache = std::make_unique<MissCache>();
    }
    fMissCache->clear();
 }
@@ -816,7 +818,7 @@ TBranch *TTreeCache::CalculateMissEntries(Long64_t pos, Int_t len, Bool_t all)
          // Note that we continue to iterate; fills up the rest of the entries in the cache.
       }
       // At this point, we are ready to push back a new offset
-      fMissCache->fEntries.emplace_back(std::move(iopos));
+      fMissCache->fEntries.emplace_back(iopos);
 
       if (R__unlikely(perfStats)) {
          Int_t blistsize = b->GetWriteBasket();
@@ -1995,7 +1997,7 @@ Int_t TTreeCache::ReadBufferPrefetch(char *buf, Long64_t pos, Int_t len)
    // try to prefetch a couple of times and if request is still not satisfied then
    // fall back to normal reading without prefetching for the current request
    Int_t counter = 0;
-   while (1) {
+   while (true) {
       if(TFileCacheRead::ReadBuffer(buf, pos, len)) {
          break;
       }

--- a/tree/tree/src/TTreeCacheUnzip.cxx
+++ b/tree/tree/src/TTreeCacheUnzip.cxx
@@ -648,7 +648,7 @@ Int_t TTreeCacheUnzip::CreateTasks()
       pool.Foreach(unzipFunction, basketIndices);
    };
 
-   fUnzipTaskGroup.reset(new ROOT::Experimental::TTaskGroup());
+   fUnzipTaskGroup = std::make_unique<ROOT::Experimental::TTaskGroup>();
    fUnzipTaskGroup->Run(mapFunction);
 
    return 0;
@@ -895,7 +895,7 @@ Int_t TTreeCacheUnzip::UnzipBuffer(char **dest, char *src)
       Int_t nout = 0;
       Int_t noutot = 0;
 
-      while (1) {
+      while (true) {
          Int_t hc = R__unzip_header(&nin, bufcur, &nbuf);
          if (hc != 0) break;
          if (gDebug > 2)

--- a/tree/tree/test/BulkApi.cxx
+++ b/tree/tree/test/BulkApi.cxx
@@ -1,4 +1,4 @@
-#include <stdio.h>
+#include <cstdio>
 
 #include "Bytes.h"
 #include "TBranch.h"

--- a/tree/tree/test/BulkApiMultiple.cxx
+++ b/tree/tree/test/BulkApiMultiple.cxx
@@ -1,4 +1,4 @@
-#include <stdio.h>
+#include <cstdio>
 
 #include "TBranch.h"
 #include "TBufferFile.h"

--- a/tree/tree/test/BulkApiSillyStruct.cxx
+++ b/tree/tree/test/BulkApiSillyStruct.cxx
@@ -1,4 +1,4 @@
-#include <stdio.h>
+#include <cstdio>
 
 #include "Bytes.h"
 #include "Rtypes.h"

--- a/tree/tree/test/BulkApiVarLength.cxx
+++ b/tree/tree/test/BulkApiVarLength.cxx
@@ -1,4 +1,4 @@
-#include <stdio.h>
+#include <cstdio>
 
 #include "Bytes.h"
 #include "TBranch.h"

--- a/tree/tree/test/TOffsetGeneration.cxx
+++ b/tree/tree/test/TOffsetGeneration.cxx
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "TFile.h"
 #include "TTree.h"
 #include "TBranch.h"
@@ -177,7 +179,7 @@ TEST_F(TOffsetGeneration, primitiveTest)
    auto br = tree->GetBranch("sample");
    ASSERT_TRUE(br->GetTotalSize() < fEventCount * 14);
 
-   file.reset(new TFile("TOffsetGeneration2.root"));
+   file = std::make_unique<TFile>("TOffsetGeneration2.root");
    tree = static_cast<TTree *>(file->Get("tree"));
    br = tree->GetBranch("sample");
    ASSERT_TRUE(br->GetTotalSize() > fEventCount * 14);
@@ -190,7 +192,7 @@ TEST_F(TOffsetGeneration, elementsTest)
    auto br = tree->GetBranch("d");
    ASSERT_TRUE(br->GetTotalSize() > fEventCount * 10);
 
-   file.reset(new TFile("TOffsetGeneration4.root"));
+   file = std::make_unique<TFile>("TOffsetGeneration4.root");
    tree = static_cast<TTree *>(file->Get("tree2"));
    br = tree->GetBranch("d");
    TClass *expectedClass = nullptr;

--- a/tree/tree/test/entrylist_addsublist.cxx
+++ b/tree/tree/test/entrylist_addsublist.cxx
@@ -1,4 +1,4 @@
-#include <string.h>
+#include <cstring>
 
 #include "TEntryList.h"
 #include "TFile.h"

--- a/tree/tree/test/entrylist_enterrange.cxx
+++ b/tree/tree/test/entrylist_enterrange.cxx
@@ -1,5 +1,5 @@
 #include <memory>
-#include <string.h>
+#include <cstring>
 
 #include "TEntryList.h"
 #include "TFile.h"

--- a/tree/tree/test/friendinfo.cxx
+++ b/tree/tree/test/friendinfo.cxx
@@ -50,17 +50,17 @@ void FillTree(const std::string &fileName, const std::string &treeName, int nEnt
    f.Close();
 }
 
-constexpr static std::size_t nEntriesInMainTree{20};
-constexpr static std::size_t nEntriesInFriendTree{5};
-const static std::string mainTreeName{"rfriendinfo_test_main"};
-const static std::string mainFileName{"rfriendinfo_test_main.root"};
-const static std::vector<std::string> friendTreeNames{
+constexpr std::size_t nEntriesInMainTree{20};
+constexpr std::size_t nEntriesInFriendTree{5};
+const std::string mainTreeName{"rfriendinfo_test_main"};
+const std::string mainFileName{"rfriendinfo_test_main.root"};
+const std::vector<std::string> friendTreeNames{
    "rfriendinfo_test_friend_0",
    "rfriendinfo_test_friend_1",
    "rfriendinfo_test_friend_2",
    "rfriendinfo_test_friend_3",
 };
-const static std::vector<std::string> friendFileNames{
+const std::vector<std::string> friendFileNames{
    "rfriendinfo_test_friend_0.root",
    "rfriendinfo_test_friend_1.root",
    "rfriendinfo_test_friend_2.root",
@@ -256,6 +256,7 @@ TEST_P(RFriendInfoTest, MakeFriendsFromAddFriendOverload3)
    ROOT::TreeUtils::RFriendInfo friendInfo;
    auto retrieveEntries = GetParam();
    std::vector<std::pair<std::string, std::string>> treeAndFileNames;
+   treeAndFileNames.reserve(friendTreeNames.size());
    for (std::size_t i = 0ul; i < friendTreeNames.size(); i++) {
       treeAndFileNames.emplace_back(friendTreeNames[i], friendFileNames[i]);
    }

--- a/tree/treeplayer/src/TBranchProxyDescriptor.cxx
+++ b/tree/treeplayer/src/TBranchProxyDescriptor.cxx
@@ -24,7 +24,7 @@
 
 #include "TTreeFormula.h"
 #include "TFormLeafInfo.h"
-#include <ctype.h>
+#include <cctype>
 
 ClassImp(ROOT::Internal::TBranchProxyDescriptor);
 

--- a/tree/treeplayer/src/TChainIndex.cxx
+++ b/tree/treeplayer/src/TChainIndex.cxx
@@ -198,7 +198,7 @@ TChainIndex::~TChainIndex()
 std::pair<TVirtualIndex*, Int_t> TChainIndex::GetSubTreeIndex(Long64_t major, Long64_t minor) const
 {
    using namespace std;
-   if (fEntries.size() == 0) {
+   if (fEntries.empty()) {
       Warning("GetSubTreeIndex", "No subindices in the chain. The chain is probably empty");
       return make_pair(static_cast<TVirtualIndex*>(nullptr), 0);
    }

--- a/tree/treeplayer/src/TMPWorkerTree.cxx
+++ b/tree/treeplayer/src/TMPWorkerTree.cxx
@@ -121,7 +121,7 @@ TTree *TMPWorkerTree::RetrieveTree(TFile *fp)
    //retrieve the TTree with the specified name from file
    //we are not the owner of the TTree object, the file is!
    TTree *tree = nullptr;
-   if(fTreeName == "") {
+   if(fTreeName.empty()) {
       // retrieve the first TTree
       // (re-adapted from TEventIter.cxx)
       if (fp->GetListOfKeys()) {

--- a/tree/treeplayer/src/TSelectorDraw.cxx
+++ b/tree/treeplayer/src/TSelectorDraw.cxx
@@ -1318,7 +1318,7 @@ void TSelectorDraw::ProcessFillObject(Long64_t /*entry*/)
                Int_t nbits = bits->GetNbits();
 
                Int_t nextbit = -1;
-               while (1) {
+               while (true) {
                   nextbit = bits->FirstSetBit(nextbit + 1);
                   if (nextbit >= nbits) break;
                   fVal[0][fNfill] = nextbit;

--- a/tree/treeplayer/src/TSimpleAnalysis.cxx
+++ b/tree/treeplayer/src/TSimpleAnalysis.cxx
@@ -99,7 +99,7 @@ std::string TSimpleAnalysis::HandleExpressionConfig(const std::string& line)
 {
    static const std::string kCutIntr = " if ";
 
-   std::size_t equal = line.find("=");
+   std::size_t equal = line.find('=');
    if (equal == std::string::npos)
       return "Error: missing '='";
 
@@ -383,7 +383,7 @@ bool TSimpleAnalysis::Run()
 
 bool TSimpleAnalysis::HandleInputFileNameConfig(const std::string& line)
 {
-   if (line.find("=") == std::string::npos) {
+   if (line.find('=') == std::string::npos) {
       fInputFiles.push_back(line);
       return true;
    }

--- a/tree/treeplayer/src/TTreeFormula.cxx
+++ b/tree/treeplayer/src/TTreeFormula.cxx
@@ -132,7 +132,7 @@ TTreeFormula::TTreeFormula(): ROOT::v5::TFormula(), fQuickLoad(kFALSE), fNeedLoa
    fNindex       = 0;
    fNcodes       = 0;
    fAxis         = nullptr;
-   fHasCast      = 0;
+   fHasCast      = false;
    fManager      = nullptr;
    fMultiplicity = 0;
    fConstLD      = nullptr;
@@ -184,7 +184,7 @@ void TTreeFormula::Init(const char*name, const char* expression)
    fNcodes       = 0;
    fMultiplicity = 0;
    fAxis         = nullptr;
-   fHasCast      = 0;
+   fHasCast      = false;
    fConstLD      = nullptr;
    Int_t i,j,k;
    fManager      = new TTreeFormulaManager;
@@ -2359,7 +2359,7 @@ Int_t TTreeFormula::FindLeafForExpression(const char* expression, TLeaf*& leaf, 
             strlcpy(first,work,kMaxLen);
 
             std::string treename(first);
-            if (treename.size() && treename[treename.size()-1]=='.') {
+            if (!treename.empty() && treename[treename.size()-1]=='.') {
                treename.erase(treename.size()-1);
             }
             if (treename== "This" /* || treename == fTree->GetName() */ ) {

--- a/tree/treeplayer/src/TTreePerfStats.cxx
+++ b/tree/treeplayer/src/TTreePerfStats.cxx
@@ -598,7 +598,7 @@ void TTreePerfStats::PrintBasketInfo(Option_t *option) const
       const char *branchname = branches->At(i)->GetName();
 
       printf("  br=%zu %s read not cached: ", i, branchname);
-      if (fBasketsInfo[i].size() == 0) {
+      if (fBasketsInfo[i].empty()) {
          printf("none");
       } else
          for (size_t j = 0; j < fBasketsInfo[i].size(); ++j) {

--- a/tree/treeplayer/src/TTreeProxyGenerator.cxx
+++ b/tree/treeplayer/src/TTreeProxyGenerator.cxx
@@ -1032,7 +1032,7 @@ namespace Internal {
                                                              type,
                                                              branchName.Data(),
                                                              true, false, true ),
-                                 0 );
+                                 false );
       } else {
          AddDescriptor( new TBranchProxyDescriptor( dataMemberName.Data(),
                                                     type,
@@ -1082,7 +1082,7 @@ namespace Internal {
             topdesc->AddDescriptor(  new TBranchProxyDescriptor( dataMemberName.Data(),
                                                                  type,
                                                                  branchName.Data() ),
-                                    0 );
+                                    false );
          } else {
             // leafname.Prepend(prefix);
             AddDescriptor( new TBranchProxyDescriptor( dataMemberName.Data(),

--- a/tree/treeplayer/src/TTreeReaderGenerator.cxx
+++ b/tree/treeplayer/src/TTreeReaderGenerator.cxx
@@ -11,7 +11,7 @@
 
 #include "TTreeReaderGenerator.h"
 #include <algorithm>
-#include <stdio.h>
+#include <cstdio>
 #include <fstream>
 
 #include "TBranchElement.h"

--- a/tree/treeplayer/src/TTreeReaderValue.cxx
+++ b/tree/treeplayer/src/TTreeReaderValue.cxx
@@ -332,7 +332,7 @@ TBranch *ROOT::Internal::TTreeReaderValueBase::SearchBranchWithCompositeName(TLe
          TObjArray *myObjArray = myBranchElement->GetInfo()->GetElements();
          TVirtualStreamerInfo *myInfo = myBranchElement->GetInfo();
 
-         while (nameStack.size() && found){
+         while (!nameStack.empty() && found){
             found = false;
 
             for (int i = 0; i < myObjArray->GetEntries(); ++i){

--- a/tree/treeplayer/src/TTreeReaderValueFast.cxx
+++ b/tree/treeplayer/src/TTreeReaderValueFast.cxx
@@ -46,7 +46,7 @@ ROOT::Experimental::Internal::TTreeReaderValueFastBase::~TTreeReaderValueFastBas
 void ROOT::Experimental::Internal::TTreeReaderValueFastBase::CreateProxy() {
    fReadStatus = ROOT::Internal::TTreeReaderValueBase::kReadError;
    fSetupStatus = ROOT::Internal::TTreeReaderValueBase::kSetupMissingBranch;
-   if (fLeafName.size() > 0){
+   if (!fLeafName.empty()){
 
       Long64_t newChainOffset = fTreeReader->GetTree()->GetChainOffset();
 

--- a/tree/treeplayer/test/basic.cxx
+++ b/tree/treeplayer/test/basic.cxx
@@ -12,7 +12,7 @@
 
 #include "gtest/gtest.h"
 #include "ROOT/TestSupport.hxx"
-#include <stdlib.h>
+#include <cstdlib>
 #include <memory>
 
 #include "RErrorIgnoreRAII.hxx"

--- a/tree/treeplayer/test/treeprocmt/treeprocessormt.cxx
+++ b/tree/treeplayer/test/treeprocmt/treeprocessormt.cxx
@@ -73,6 +73,7 @@ TEST(TreeProcessorMT, ManyFiles)
    const auto nFiles = 100u;
    const std::string treename = "t";
    std::vector<std::string> filenames;
+   filenames.reserve(nFiles);
    for (auto i = 0u; i < nFiles; ++i)
       filenames.emplace_back("treeprocmt_manyfiles" + std::to_string(i) + ".root");
 
@@ -94,6 +95,7 @@ TEST(TreeProcessorMT, ManyFiles)
 
    // TTreeProcMT requires a vector<string_view>
    std::vector<std::string_view> fnames;
+   fnames.reserve(filenames.size());
    for (const auto &f : filenames)
       fnames.emplace_back(f);
 
@@ -163,6 +165,7 @@ TEST(TreeProcessorMT, TreesWithDifferentNamesVecCtor)
 
    // TTreeProcMT requires a vector<string_view>
    std::vector<std::string_view> fnames;
+   fnames.reserve(filenames.size());
    for (const auto &f : filenames)
       fnames.emplace_back(f);
 

--- a/tree/treeviewer/inc/TParallelCoord.h
+++ b/tree/treeviewer/inc/TParallelCoord.h
@@ -111,7 +111,7 @@ public:
    void           SetAxisHistogramHeight(Double_t h=0.5); // *MENU*
    void           SetAxisHistogramLineWidth(Int_t lw=2); // *MENU*
    void           SetCandleChart(Bool_t can); // *TOGGLE* *GETTER=GetCandleChart
-   virtual void   SetCurveDisplay(Bool_t curve=1) {SetBit(kCurveDisplay,curve);} // *TOGGLE* *GETTER=GetCurveDisplay
+   virtual void   SetCurveDisplay(Bool_t curve=true) {SetBit(kCurveDisplay,curve);} // *TOGGLE* *GETTER=GetCurveDisplay
    void           SetCurrentEntries(TEntryList* entries) {fCurrentEntries = entries;}
    void           SetCurrentFirst(Long64_t);
    void           SetCurrentN(Long64_t);

--- a/tree/treeviewer/src/TSpider.cxx
+++ b/tree/treeviewer/src/TSpider.cxx
@@ -28,7 +28,7 @@
 #include "TMath.h"
 #include "TCanvas.h"
 #include "TArc.h"
-#include "float.h"
+#include <cfloat>
 #include "TEnv.h"
 
 ClassImp(TSpider);

--- a/tree/treeviewer/src/TTreeViewer.cxx
+++ b/tree/treeviewer/src/TTreeViewer.cxx
@@ -316,9 +316,9 @@ ClassImp(TTreeViewer);
 
 TTreeViewer::TTreeViewer(const char* treeName) :
    TGMainFrame(nullptr,10,10,kVerticalFrame),
-   fDimension(0), fVarDraw(0), fScanMode(0),
+   fDimension(0), fVarDraw(false), fScanMode(false),
    fTreeIndex(0), fDefaultCursor(0), fWatchCursor(0),
-   fCounting(0), fStopMapping(0), fEnableCut(0),fNexpressions(0)
+   fCounting(false), fStopMapping(false), fEnableCut(false),fNexpressions(0)
 {
    fTree = nullptr;
    if (!gClient) return;
@@ -344,9 +344,9 @@ TTreeViewer::TTreeViewer(const char* treeName) :
 
 TTreeViewer::TTreeViewer(const TTree *tree) :
    TGMainFrame(nullptr, 10, 10, kVerticalFrame),
-   fDimension(0), fVarDraw(0), fScanMode(0),
+   fDimension(0), fVarDraw(false), fScanMode(false),
    fTreeIndex(0), fDefaultCursor(0), fWatchCursor(0),
-   fCounting(0), fStopMapping(0), fEnableCut(0),fNexpressions(0)
+   fCounting(false), fStopMapping(false), fEnableCut(false),fNexpressions(0)
 
 {
    // TTreeViewer constructor with a pointer to a Tree
@@ -1989,7 +1989,7 @@ Bool_t TTreeViewer::ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t par
                      gROOT->MakeDefCanvas();
                      break;
                   case kFileBrowse:
-                     if (1) {
+                     if (true) {
                         static TString dir(".");
                         TGFileInfo info;
                         info.fFileTypes = gOpenTypes;
@@ -2007,7 +2007,7 @@ Bool_t TTreeViewer::ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t par
                      break;
                   case kFileLoadLibrary:
                      fBarCommand->SetText("gSystem->Load(\"\");");
-                     if (1) {
+                     if (true) {
                         Event_t event;
                         event.fType = kButtonPress;
                         event.fCode = kButton1;
@@ -2017,7 +2017,7 @@ Bool_t TTreeViewer::ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t par
                      fBarCommand->SetCursorPosition(15);
                      break;
                   case kFileOpenSession:
-                     if (1) {
+                     if (true) {
                         static TString dir(".");
                         TGFileInfo info;
                         info.fFileTypes = gMacroTypes;

--- a/tree/webviewer/src/RTreeViewer.cxx
+++ b/tree/webviewer/src/RTreeViewer.cxx
@@ -417,7 +417,7 @@ void RTreeViewer::InvokeTreeDraw()
    std::string canv_name;
 
    if (gPad) {
-      if ((expr.find("\\") != std::string::npos) || (expr.find("#") != std::string::npos)) {
+      if ((expr.find('\\') != std::string::npos) || (expr.find('#') != std::string::npos)) {
          auto FixTitle = [](TNamed *obj) {
             if (!obj) return;
             TString title = obj->GetTitle();


### PR DESCRIPTION
Applies the clang-tidy suggestions from the following checks, which are the same as in the CMSSW `.clang-tidy`, only that the checks that replace copies with `const` references are removed:

```
  ,boost-use-to-string,
  ,misc-definitions-in-headers,
  ,misc-string-compare,
  ,misc-uniqueptr-reset-release,
  ,modernize-deprecated-headers,
  ,modernize-make-shared,
  ,modernize-make-unique,
  ,modernize-use-bool-literals,
  ,modernize-use-equals-delete,
  ,modernize-use-nullptr,
  ,modernize-use-override,
  ,performance-inefficient-algorithm,
  ,performance-inefficient-vector-operation,
  ,performance-faster-string-find,
  ,performance-move-const-arg,
  ,readability-container-size-empty,
  ,readability-redundant-string-cstr,
  ,readability-static-definition-in-anonymous-namespace,
  ,readability-uniqueptr-delete-release
```