### PR TITLE
[DF] Avoid unused parameter warning in RDF ActionHelpers

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1770,6 +1770,7 @@ public:
                          fBranchAddresses[slot][S] = GetData(values), 0 : 0, 0)...,
                         0};
       (void)expander; // avoid unused parameter warnings (gcc 12.1)
+      (void)slot; // Also "slot" might be unused, in case "values" is empty
    }
 
    template <std::size_t... S>


### PR DESCRIPTION
This avoids the following warning when building `rootbench` (gcc 13.2.1):

```txt
In file included from /home/rembserj/spaces/master/root/src/build/include/ROOT/RDF/RInterface.hxx:15,
                 from /home/rembserj/spaces/master/root/src/build/include/ROOT/RDataFrame.hxx:21,
                 from /home/rembserj/spaces/master/root/src/root/rootbench/root/tree/dataframe/RDataFrameBenchmarks.cxx:1:
/home/rembserj/spaces/master/root/src/build/include/ROOT/RDF/ActionHelpers.hxx: In instantiation of ‘void ROOT::Internal::RDF::SnapshotHelperMT<ColTypes>::UpdateCArraysPtrs(unsigned int, ColTypes& ..., std::index_sequence<S ...>) [with long unsigned int ...S = {}; ColTypes = {}; std::index_sequence<S ...> = std::integer_sequence<long unsigned int>]’:
/home/rembserj/spaces/master/root/src/build/include/ROOT/RDF/ActionHelpers.hxx:1747:27:   required from ‘void ROOT::Internal::RDF::SnapshotHelperMT<ColTypes>::Exec(unsigned int, ColTypes& ...) [with ColTypes = {}]’
/home/rembserj/spaces/master/root/src/build/include/ROOT/RDF/RAction.hxx:104:19:   required from ‘void ROOT::Internal::RDF::RAction<Helper, PrevNode, ColumnTypes_t>::CallExec(unsigned int, Long64_t, ROOT::TypeTraits::TypeList<ColTypes ...>, std::index_sequence<_Ind ...>) [with ColTypes = {}; long unsigned int ...S = {}; Helper = ROOT::Internal::RDF::SnapshotHelperMT<>; PrevNode = ROOT::Detail::RDF::RLoopManager; ColumnTypes_t = ROOT::TypeTraits::TypeList<>; Long64_t = long long int; std::index_sequence<_Ind ...> = std::integer_sequence<long unsigned int>]’
/home/rembserj/spaces/master/root/src/build/include/ROOT/RDF/RAction.hxx:112:18:   required from ‘void ROOT::Internal::RDF::RAction<Helper, PrevNode, ColumnTypes_t>::Run(unsigned int, Long64_t) [with Helper = ROOT::Internal::RDF::SnapshotHelperMT<>; PrevNode = ROOT::Detail::RDF::RLoopManager; ColumnTypes_t = ROOT::TypeTraits::TypeList<>; Long64_t = long long int]’
/home/rembserj/spaces/master/root/src/build/include/ROOT/RDF/RAction.hxx:108:9:   required from here
/home/rembserj/spaces/master/root/src/build/include/ROOT/RDF/ActionHelpers.hxx:1760:40: error: parameter ‘slot’ set but not used [-Werror=unused-but-set-parameter]
 1760 |    void UpdateCArraysPtrs(unsigned int slot, ColTypes &... values, std::index_sequence<S...> /*dummy*/)
 ```

 I'm sure similar warnings also pop up in other places, but I just
 happened to notice them in `rootbench`.