### PR TITLE
[math] Use `EXPECT_DOUBLE_EQ` in test_tprofile2poly.cxx

### DIFF
--- a/hist/hist/test/test_tprofile2poly.cxx
+++ b/hist/hist/test/test_tprofile2poly.cxx
@@ -9,11 +9,6 @@
 #include <algorithm>
 #include <iostream>
 
-using namespace std;
-
-Float_t delta=0.00000000001;
-
-
 void FillForTest(TProfile2D* tp2d, TProfile2Poly* tpp, TRandom& ran) {
    Double_t value, weight;
    Double_t px, py;
@@ -31,9 +26,9 @@ void FillForTest(TProfile2D* tp2d, TProfile2Poly* tpp, TRandom& ran) {
 
 void globalStatsCompare(TProfile2D* tp2d, TProfile2Poly* tpp) {
    for(Int_t c=1; c<=3; ++c) {
-      ASSERT_NEAR(tp2d->GetMean(c), tpp->GetMean(c), delta);
-      ASSERT_NEAR(tp2d->GetMeanError(c), tpp->GetMeanError(c), delta);
-      ASSERT_NEAR(tp2d->GetStdDev(c), tpp->GetStdDev(c), delta);
+      ASSERT_DOUBLE_EQ(tp2d->GetMean(c), tpp->GetMean(c));
+      ASSERT_DOUBLE_EQ(tp2d->GetMeanError(c), tpp->GetMeanError(c));
+      ASSERT_DOUBLE_EQ(tp2d->GetStdDev(c), tpp->GetStdDev(c));
    }
 }
 
@@ -43,13 +38,13 @@ void binContentCompare(TProfile2D* tp2d, TProfile2Poly* tpp) {
       for(Double_t x=0.5; x<10; x+=2.0) {
          cont1 = tp2d->GetBinContent(tp2d->FindBin(x,y));
          cont2 = tpp->GetBinContent(tpp->FindBin(x,y));
-         ASSERT_NEAR(cont1, cont2, delta);
+         ASSERT_DOUBLE_EQ(cont1, cont2);
       }
    }
    // test overflow
    cont1 = tp2d->GetBinContent(tp2d->FindBin(11,11));
    cont2 = tpp->GetBinContent(tpp->FindBin(11,11));
-   ASSERT_NEAR(cont1, cont2, delta);
+   ASSERT_DOUBLE_EQ(cont1, cont2);
 }
 
 void binEntriesCompare(TProfile2D* tp2d, TProfile2Poly* tpp) {
@@ -58,14 +53,14 @@ void binEntriesCompare(TProfile2D* tp2d, TProfile2Poly* tpp) {
       for(Double_t x=0.5; x<10; x+=2.0) {
          cont1 = tp2d->GetBinEffectiveEntries(tp2d->FindBin(x,y));
          cont2 = tpp->GetBinEffectiveEntries(tpp->FindBin(x,y));
-         ASSERT_NEAR(cont1, cont2, delta);
+         ASSERT_DOUBLE_EQ(cont1, cont2);
       }
 
    }
    // test overflow
    cont1 = tp2d->GetBinEffectiveEntries(tp2d->FindBin(11,11));
    cont2 = tpp->GetBinEffectiveEntries(tpp->FindBin(11,11));
-   ASSERT_NEAR(cont1, cont2, delta);
+   ASSERT_DOUBLE_EQ(cont1, cont2);
 
 }
 
@@ -77,18 +72,17 @@ void binErrorCompare(TProfile2D* tp2d, TProfile2Poly* tpp) {
          cont2 = tpp->GetBinError(tpp->FindBin(x,y));
          // std::cout << x << "  " << y << "  " <<  tpp->FindBin(x,y) << "  " <<  tpp->GetBinContent(tpp->FindBin(x,y))
          //           << "   " << tpp->GetBinEffectiveEntries(tpp->FindBin(x,y)) << std::endl;
-         ASSERT_NEAR(cont1, cont2, delta);
+         ASSERT_DOUBLE_EQ(cont1, cont2);
       }
    }
    // test overflow
    cont1 = tp2d->GetBinError(tp2d->FindBin(11,11));
    cont2 = tpp->GetBinError(tpp->FindBin(11,11));
-   ASSERT_NEAR(cont1, cont2, delta);
+   ASSERT_DOUBLE_EQ(cont1, cont2);
 }
 
 void SetupPlots(TProfile2Poly* TP2P_2, TProfile2Poly* TP2P, TProfile2D* TP2D_2, TProfile2D* TP2D, TString opt = "")
 {
-     
    TP2D->SetErrorOption(opt);
    TP2D_2->SetErrorOption(opt);
    if (opt == "S") {
@@ -98,7 +92,7 @@ void SetupPlots(TProfile2Poly* TP2P_2, TProfile2Poly* TP2P, TProfile2D* TP2D_2, 
       TP2P->SetErrorOption(kERRORMEAN);
       TP2P_2->SetErrorOption(kERRORMEAN);
    }
-       
+
    double minx = -10; double maxx = 10;
    double miny = -10; double maxy = 10;
    double binsz = 2;
@@ -115,7 +109,7 @@ void SetupPlots(TProfile2Poly* TP2P_2, TProfile2Poly* TP2P, TProfile2D* TP2D_2, 
 void test_globalStats() {
 
    TH1::StatOverflows(true);
-   
+
    auto TP2D = new TProfile2D("1", "1", 10, -10, 10, 10, -10, 10, 0, 0);
    auto TP2D_2 = new TProfile2D("2", "2", 10, -10, 10, 10, -10, 10, 0, 0);
 


### PR DESCRIPTION
As seen in #9601, using `EXCEPT_NEAR` with an absolute error is not so good, because if the numbers are large the hardcoded absolute error can be smaller than the double precision. In these cases, `EXPECT_DOUBLE_EQ` is recommended instead.

@ellert, I'm suggesting this as an alternative to what you suggested in #9601, but without magic numbers of two. Can you maybe check if this approach with `EXPECT_DOUBLE_EQ` also works? Thanks!