### PR TITLE
[ntuple] use cluster boundaries in RDF iteration

### DIFF
--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -319,7 +319,7 @@ std::vector<std::pair<ULong64_t, ULong64_t>> RNTupleDS::GetEntryRanges()
    // Distribute slots equidistantly over the entry range, aligned on cluster boundaries
    const unsigned int nRangesByCluster = rangesByCluster.size();
    const auto chunkSize = nRangesByCluster / fNSlots;
-   const auto remainder = (1U == fNSlots) ? 0 : nRangesByCluster % fNSlots;
+   const auto remainder = nRangesByCluster % fNSlots;
    std::size_t iRange = 0;
    const unsigned int N = std::min(fNSlots, nRangesByCluster);
    for (unsigned int i = 0; i < N; ++i) {

--- a/tree/ntuple/v7/src/RClusterPool.cxx
+++ b/tree/ntuple/v7/src/RClusterPool.cxx
@@ -267,6 +267,10 @@ ROOT::Experimental::Detail::RClusterPool::GetCluster(DescriptorId_t clusterId,
 
          auto cid = next;
          next = descriptorGuard->FindNextClusterId(cid);
+         if (next != kInvalidClusterIndex) {
+            if (!fPageSource.GetEntryRange().IntersectsWith(descriptorGuard->GetClusterDescriptor(next)))
+               next = kInvalidClusterIndex;
+         }
          if (next == kInvalidDescriptorId)
             provideInfo.fFlags |= RProvides::kFlagLast;
 

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -77,6 +77,22 @@ ROOT::Experimental::Detail::RPageSource::RActivePhysicalColumns::ToColumnSet() c
    return result;
 }
 
+bool ROOT::Experimental::Detail::RPageSource::REntryRange::IntersectsWith(const RClusterDescriptor &clusterDesc) const
+{
+   if (fFirstEntry == kInvalidNTupleIndex) {
+      /// Entry range unset, we assume that the entry range covers the complete source
+      return true;
+   }
+
+   if (clusterDesc.GetNEntries() == 0)
+      return true;
+   if ((clusterDesc.GetFirstEntryIndex() + clusterDesc.GetNEntries()) <= fFirstEntry)
+      return false;
+   if (clusterDesc.GetFirstEntryIndex() >= (fFirstEntry + fNEntries))
+      return false;
+   return true;
+}
+
 ROOT::Experimental::Detail::RPageSource::RPageSource(std::string_view name, const RNTupleReadOptions &options)
    : RPageStorage(name), fMetrics(""), fOptions(options)
 {
@@ -118,6 +134,14 @@ ROOT::Experimental::Detail::RPageSource::AddColumn(DescriptorId_t fieldId, const
 void ROOT::Experimental::Detail::RPageSource::DropColumn(ColumnHandle_t columnHandle)
 {
    fActivePhysicalColumns.Erase(columnHandle.fPhysicalId);
+}
+
+void ROOT::Experimental::Detail::RPageSource::SetEntryRange(const REntryRange &range)
+{
+   if ((range.fFirstEntry + range.fNEntries) > GetNEntries()) {
+      throw RException(R__FAIL("invalid entry range"));
+   }
+   fEntryRange = range;
 }
 
 ROOT::Experimental::NTupleSize_t ROOT::Experimental::Detail::RPageSource::GetNEntries()

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -20,7 +20,7 @@ TEST(RNTuple, ReconstructModel)
    RPageSourceFile source("myNTuple", fileGuard.GetPath(), RNTupleReadOptions());
    source.Attach();
    try {
-      source.SetEntryRange({0, 2});
+      source.SetEntryRange({0, source.GetNEntries() + 1});
       FAIL() << "invalid entry range should throw";
    } catch (const RException &err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("invalid entry range"));

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -19,6 +19,14 @@ TEST(RNTuple, ReconstructModel)
 
    RPageSourceFile source("myNTuple", fileGuard.GetPath(), RNTupleReadOptions());
    source.Attach();
+   try {
+      source.SetEntryRange({0, 2});
+      FAIL() << "invalid entry range should throw";
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("invalid entry range"));
+   }
+   // Should not throw
+   source.SetEntryRange({0, source.GetNEntries()});
 
    auto modelReconstructed = source.GetSharedDescriptorGuard()->GenerateModel();
    try {

--- a/tree/ntuple/v7/test/ntuple_cluster.cxx
+++ b/tree/ntuple/v7/test/ntuple_cluster.cxx
@@ -262,6 +262,43 @@ TEST(ClusterPool, GetClusterBasics)
    EXPECT_EQ(5U, p4.fReqsClusterIds[3]);
 }
 
+TEST(ClusterPool, SetEntryRange)
+{
+   RPageSourceMock p1;
+   p1.SetEntryRange({0, 6});
+   RClusterPool c1(p1, 1);
+   c1.GetCluster(3, {0});
+   c1.WaitForInFlightClusters();
+   ASSERT_EQ(2U, p1.fReqsClusterIds.size());
+   EXPECT_EQ(3U, p1.fReqsClusterIds[0]);
+   EXPECT_EQ(4U, p1.fReqsClusterIds[1]);
+
+   RPageSourceMock p2;
+   p2.SetEntryRange({3, 1});
+   RClusterPool c2(p2, 1);
+   c2.GetCluster(3, {0});
+   c2.WaitForInFlightClusters();
+   ASSERT_EQ(1U, p2.fReqsClusterIds.size());
+   EXPECT_EQ(3U, p2.fReqsClusterIds[0]);
+
+   RPageSourceMock p3;
+   p3.SetEntryRange({0, 1});
+   RClusterPool c3(p3, 1);
+   c3.GetCluster(3, {0});
+   c3.WaitForInFlightClusters();
+   ASSERT_EQ(1U, p3.fReqsClusterIds.size());
+   EXPECT_EQ(3U, p3.fReqsClusterIds[0]);
+
+   RPageSourceMock p4;
+   p4.SetEntryRange({0, 3});
+   RClusterPool c4(p4, 2);
+   c4.GetCluster(0, {0});
+   c4.WaitForInFlightClusters();
+   ASSERT_EQ(3U, p4.fReqsClusterIds.size());
+   EXPECT_EQ(0U, p4.fReqsClusterIds[0]);
+   EXPECT_EQ(1U, p4.fReqsClusterIds[1]);
+   EXPECT_EQ(2U, p4.fReqsClusterIds[2]);
+}
 
 TEST(ClusterPool, GetClusterIncrementally)
 {


### PR DESCRIPTION
# This Pull request:

- Respect cluster boundaries when assigning entry ranges to slots
- Add RPageSource::SetEntryRange to avoid cluster read-ahead into other slots entry range

## Changes or fixes:

Fixes RDF-IMT with RNTuple

## Checklist:

- [X] tested changes locally

