### PR TITLE
[io] adjust RRawFile/XRootD unit test to new target

### DIFF
--- a/net/netxng/test/RRawFileNetXNG.cxx
+++ b/net/netxng/test/RRawFileNetXNG.cxx
@@ -2,6 +2,7 @@
 #include "ROOT/RRawFileNetXNG.hxx"
 
 #include <string>
+#include <utility>
 
 #include "gtest/gtest.h"
 
@@ -12,19 +13,19 @@ TEST(RRawFileNetXNG, Idle)
 {
    // Test construction and destruction if the URL is never opened
    RRawFile::ROptions options;
-   RRawFileNetXNG("root://eospublic.cern.ch//eos/root-eos/xrootd.test", options);
+   RRawFileNetXNG("root://eospublic.cern.ch//eos/root-eos/testfiles/xrootd.test", options);
 }
 
 TEST(RRawFileNetXNG, Basics)
 {
    std::string line;
    RRawFile::ROptions options;
-   std::unique_ptr<RRawFileNetXNG> f(new RRawFileNetXNG("root://eospublic.cern.ch//eos/root-eos/xrootd.test", options));
+   auto f = std::make_unique<RRawFileNetXNG>("root://eospublic.cern.ch//eos/root-eos/testfiles/xrootd.test", options);
    f->Readln(line);
-   EXPECT_STREQ("Hello, World", line.c_str());
-   EXPECT_EQ(13u, f->GetSize());
+   EXPECT_STREQ("This file is used in the RRawFile unit tests", line.c_str());
+   EXPECT_EQ(45u, f->GetSize());
 
-   std::unique_ptr<RRawFileNetXNG> f2(new RRawFileNetXNG("root://eospublic.cern.ch//eos/root-eos/xrootd.test.ENOENT", options));
+   auto f2 = std::make_unique<RRawFileNetXNG>("root://eospublic.cern.ch//eos/root-eos/testfiles/xrootd.NOENT", options);
    EXPECT_THROW(f2->Readln(line), std::runtime_error);
 }
 
@@ -34,10 +35,10 @@ TEST(RRawFileNetXNG, Eof)
    char tail[4];
    tail[3] = '\0';
    RRawFile::ROptions options;
-   std::unique_ptr<RRawFileNetXNG> f(new RRawFileNetXNG("root://eospublic.cern.ch//eos/root-eos/xrootd.test", options));
+   auto f = std::make_unique<RRawFileNetXNG>("root://eospublic.cern.ch//eos/root-eos/testfiles/xrootd.test", options);
    auto nbytes = f->ReadAt(tail, 10, f->GetSize() - 3);
    EXPECT_EQ(3u, nbytes);
-   EXPECT_STREQ("ld\n", tail);
+   EXPECT_STREQ("ts\n", tail);
 }
 
 
@@ -45,7 +46,7 @@ TEST(RRawFileNetXNG, ReadV)
 {
    RRawFile::ROptions options;
    options.fBlockSize = 0;
-   std::unique_ptr<RRawFileNetXNG> f(new RRawFileNetXNG("root://eospublic.cern.ch//eos/root-eos/xrootd.test", options));
+   auto f = std::make_unique<RRawFileNetXNG>("root://eospublic.cern.ch//eos/root-eos/testfiles/xrootd.test", options);
 
    char buffer[2];
    buffer[0] = buffer[1] = 0;
@@ -54,12 +55,12 @@ TEST(RRawFileNetXNG, ReadV)
    iovec[0].fOffset = 0;
    iovec[0].fSize = 1;
    iovec[1].fBuffer = &buffer[1];
-   iovec[1].fOffset = 11;
+   iovec[1].fOffset = 43;
    iovec[1].fSize = 1;
    f->ReadV(iovec, 2);
 
    EXPECT_EQ(1U, iovec[0].fOutBytes);
    EXPECT_EQ(1U, iovec[1].fOutBytes);
-   EXPECT_EQ('H', buffer[0]);
-   EXPECT_EQ('d', buffer[1]);
+   EXPECT_EQ('T', buffer[0]);
+   EXPECT_EQ('s', buffer[1]);
 }


### PR DESCRIPTION
# This Pull request:

Adjusts the XRootD RRawFile unit test to a new testfile location.


