### PR TITLE
[webgui] Improve firefox support 

### DIFF
--- a/bindings/pyroot/cppyy/cppyy-backend/cling/create_src_directory.py
+++ b/bindings/pyroot/cppyy/cppyy-backend/cling/create_src_directory.py
@@ -43,7 +43,7 @@ ROOT_BUILTINS_KEEP = ['openssl', 'pcre', 'xxhash', 'zlib']
 ROOT_IO_KEEP = ['CMakeLists.txt', 'io', 'rootpcm']
 ROOT_MATH_KEEP = ['CMakeLists.txt', 'mathcore']
 ROOT_ETC_KEEP = ['Makefile.arch', 'class.rules', 'cmake', 'dictpch',
-                 'gdb-backtrace.sh', 'gitinfo.txt', 'helgrind-root.supp',
+                 'gdb-backtrace.sh', 'runfirefox.sh', 'gitinfo.txt', 'helgrind-root.supp',
                  'hostcert.conf', 'plugins', 'system.plugins-ios',
                  'valgrind-root-python.supp', 'valgrind-root.supp']
 ROOT_PLUGINS_KEEP = ['TVirtualStreamerInfo']

--- a/etc/runfirefox.sh
+++ b/etc/runfirefox.sh
@@ -8,7 +8,7 @@ firefox=$1
 shift
 
 if [ "$profile" != "<dummy>" ]; then
-   trap "rm -rf $profile; echo remove $profile at exit" EXIT   
+   trap "rm -rf $profile; echo remove $profile at exit" 0 1 2 3 6
 fi
 
 args=

--- a/etc/runfirefox.sh
+++ b/etc/runfirefox.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# Helper script to run firefox and delete temporary profile at exit
+profile=$1
+shift
+
+firefox=$1
+shift
+
+if [ "$profile" != "<dummy>" ]; then
+   trap "rm -rf $profile; echo remove $profile at exit" EXIT   
+fi
+
+args=
+
+while [ "$1" != "" ]; do
+   args="$args $1"
+   shift
+done
+
+echo "Running $firefox $args"
+
+$firefox $args

--- a/gui/webdisplay/inc/ROOT/RWebDisplayHandle.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebDisplayHandle.hxx
@@ -65,7 +65,7 @@ protected:
       ChromeCreator(bool is_edge = false);
       ~ChromeCreator() override = default;
       bool IsActive() const override { return !fProg.empty(); }
-      void ProcessGeometry(std::string &, const RWebDisplayArgs &args) override;
+      void ProcessGeometry(std::string &, const RWebDisplayArgs &) override;
       std::string MakeProfile(std::string &exec, bool) override;
    };
 
@@ -74,6 +74,7 @@ protected:
       FirefoxCreator();
       ~FirefoxCreator() override = default;
       bool IsActive() const override { return !fProg.empty(); }
+      void ProcessGeometry(std::string &, const RWebDisplayArgs &) override;
       std::string MakeProfile(std::string &exec, bool batch) override;
    };
 

--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -454,14 +454,16 @@ std::string RWebDisplayHandle::ChromeCreator::MakeProfile(std::string &exec, boo
       profile_arg = chrome_profile;
    } else {
       gRandom->SetSeed(0);
-      std::string rnd_profile = "root_chrome_profile_"s + std::to_string(gRandom->Integer(0x100000));
       profile_arg = gSystem->TempDirectory();
-
 #ifdef _MSC_VER
-      profile_arg += "\\"s + rnd_profile;
+      char slash = '\\';
 #else
-      profile_arg += "/"s + rnd_profile;
+      char slash = '/';
 #endif
+      if (!profile_arg.empty() && (profile_arg[profile_arg.length()-1] != slash)) 
+         profile_arg += slash;
+      profile_arg += "root_chrome_profile_"s + std::to_string(gRandom->Integer(0x100000));
+
       rmdir = profile_arg;
    }
 
@@ -534,14 +536,16 @@ std::string RWebDisplayHandle::FirefoxCreator::MakeProfile(std::string &exec, bo
    } else if (ff_randomprofile > 0) {
 
       gRandom->SetSeed(0);
-      std::string rnd_profile = "root_ff_profile_"s + std::to_string(gRandom->Integer(0x100000));
       std::string profile_dir = gSystem->TempDirectory();
 
 #ifdef _MSC_VER
-      profile_dir += "\\"s + rnd_profile;
+      char slash = '\\';
 #else
-      profile_dir += "/"s + rnd_profile;
+      char slash = '/';
 #endif
+      if (!profile_dir.empty() && (profile_dir[profile_dir.length()-1] != slash)) 
+         profile_dir += slash;
+      profile_dir += "root_ff_profile_"s + std::to_string(gRandom->Integer(0x100000));
 
       profile_arg = "-profile "s + profile_dir;
 
@@ -584,7 +588,7 @@ std::string RWebDisplayHandle::FirefoxCreator::MakeProfile(std::string &exec, bo
 
    exec = std::regex_replace(exec, std::regex("\\$profile"), profile_arg);
 
-   if (exec.find("$profile") == std::string::npos) {
+   if (exec.find("$cleanup_profile") != std::string::npos) {
       if (rmdir.empty()) rmdir = "<dummy>";
       exec = std::regex_replace(exec, std::regex("\\$cleanup_profile"), rmdir);
       rmdir.clear(); // no need to delete directory - it will be removed by script

--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -548,25 +548,26 @@ std::string RWebDisplayHandle::FirefoxCreator::MakeProfile(std::string &exec, bo
       if (gSystem->mkdir(profile_dir.c_str()) == 0) {
          rmdir = profile_dir;
 
-         if (batch_mode) {
-            std::ofstream user_js(profile_dir + "/user.js", std::ios::trunc);
-            user_js << "user_pref(\"browser.dom.window.dump.enabled\", true);" << std::endl;
-            // workaround for current Firefox, without such settings it fail to close window and terminate it from batch
-            user_js << "user_pref(\"datareporting.policy.dataSubmissionPolicyAcceptedVersion\", 2);" << std::endl;
-            user_js << "user_pref(\"datareporting.policy.dataSubmissionPolicyNotifiedTime\", \"1635760572813\");" << std::endl;
-         } else {
-            std::ofstream times_json(profile_dir + "/times.json", std::ios::trunc);
-            times_json << "{" << std::endl;
-            times_json << "   \"created\": 1699968480952," << std::endl;
-            times_json << "   \"firstUse\": null" << std::endl;
-            times_json << "}" << std::endl;
-            std::ofstream user_js(profile_dir + "/user.js", std::ios::trunc);
+         std::ofstream user_js(profile_dir + "/user.js", std::ios::trunc);
+         user_js << "user_pref(\"browser.dom.window.dump.enabled\", true);" << std::endl;
+         // workaround for current Firefox, without such settings it fail to close window and terminate it from batch
+         // also disable question about upload of data
+         user_js << "user_pref(\"datareporting.policy.dataSubmissionPolicyAcceptedVersion\", 2);" << std::endl;
+         user_js << "user_pref(\"datareporting.policy.dataSubmissionPolicyNotifiedTime\", \"1635760572813\");" << std::endl;
+
+         if (!batch_mode) {
             // to suppress annoying privacy tab
             user_js << "user_pref(\"datareporting.policy.firstRunURL\", \"\");" << std::endl;
             // to use custom userChrome.css files
             user_js << "user_pref(\"toolkit.legacyUserProfileCustomizations.stylesheets\", true);" << std::endl;
             // do not put tabs in title
             user_js << "user_pref(\"browser.tabs.inTitlebar\", 0);" << std::endl;
+
+            std::ofstream times_json(profile_dir + "/times.json", std::ios::trunc);
+            times_json << "{" << std::endl;
+            times_json << "   \"created\": 1699968480952," << std::endl;
+            times_json << "   \"firstUse\": null" << std::endl;
+            times_json << "}" << std::endl;
             if (gSystem->mkdir((profile_dir + "/chrome").c_str()) == 0) {
                std::ofstream style(profile_dir + "/chrome/userChrome.css", std::ios::trunc);
                // do not show tabs 

--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -553,13 +553,20 @@ std::string RWebDisplayHandle::FirefoxCreator::MakeProfile(std::string &exec, bo
          rmdir = profile_dir;
 
          std::ofstream user_js(profile_dir + "/user.js", std::ios::trunc);
-         user_js << "user_pref(\"browser.dom.window.dump.enabled\", true);" << std::endl;
          // workaround for current Firefox, without such settings it fail to close window and terminate it from batch
          // also disable question about upload of data
          user_js << "user_pref(\"datareporting.policy.dataSubmissionPolicyAcceptedVersion\", 2);" << std::endl;
          user_js << "user_pref(\"datareporting.policy.dataSubmissionPolicyNotifiedTime\", \"1635760572813\");" << std::endl;
 
-         if (!batch_mode) {
+         // try to ensure that window closes with last tab
+         user_js << "user_pref(\"browser.tabs.closeWindowWithLastTab\", true);" << std::endl;
+         user_js << "user_pref(\"dom.allow_scripts_to_close_windows\", true);" << std::endl;
+         user_js << "user_pref(\"browser.sessionstore.resume_from_crash\", false);" << std::endl;
+
+         if (batch_mode) {
+            // allow to dump messages to std output
+            user_js << "user_pref(\"browser.dom.window.dump.enabled\", true);" << std::endl;
+         } else {
             // to suppress annoying privacy tab
             user_js << "user_pref(\"datareporting.policy.firstRunURL\", \"\");" << std::endl;
             // to use custom userChrome.css files


### PR DESCRIPTION
1. Create custom firefox profile for interactive session. In this profile set several parameters to hide URL and tabs widget
2. Custom profile allows to configure initial -width and -height URL parameters for window geometry
3. Introduce `runfirefox.sh` shell script to use 'trap' functionality to cleanup temporary profile after firefox is exiting. Trying to cleanup from ROOT does not work - while ROOT exit faster than firefox.

With these changes Firefox behaves much better than before - one gets normal window without extra decorations.

The only missing part for Firefox - support of PDF output in headless mode.