### PR TITLE
[RF] Move internal enums of RooResolutionModels out of public interface

### DIFF
--- a/roofit/roofit/inc/RooGExpModel.h
+++ b/roofit/roofit/inc/RooGExpModel.h
@@ -25,22 +25,10 @@
 class RooGExpModel : public RooResolutionModel {
 public:
 
-  enum RooGExpBasis { noBasis=0, expBasisMinus= 1, expBasisSum= 2, expBasisPlus= 3,
-                       sinBasisMinus=11, sinBasisSum=12, sinBasisPlus=13,
-                                 cosBasisMinus=21, cosBasisSum=22, cosBasisPlus=23,
-             sinhBasisMinus=31,sinhBasisSum=32,sinhBasisPlus=33,
-             coshBasisMinus=41,coshBasisSum=42,coshBasisPlus=43} ;
-
-
-
-  enum BasisType { none=0, expBasis=1, sinBasis=2, cosBasis=3, sinhBasis=4, coshBasis=5 } ;
-  enum BasisSign { Both=0, Plus=+1, Minus=-1 } ;
   enum Type { Normal, Flipped };
 
   // Constructors, assignment etc
-  inline RooGExpModel() {
-    // coverity[UNINIT_CTOR]
-  }
+  RooGExpModel() = default;
 
   RooGExpModel(const char *name, const char *title, RooAbsRealLValue& x,
           RooAbsReal& mean, RooAbsReal& sigma, RooAbsReal& rlife,
@@ -109,8 +97,8 @@ private:
 
   bool _flip ;
   bool _nlo ;
-  bool _flatSFInt ;
-  bool _asympInt ;  // added FMV,07/24/03
+  bool _flatSFInt = false;
+  bool _asympInt = false;  // added FMV,07/24/03
 
   ClassDefOverride(RooGExpModel,2) // Gauss (x) Exponential resolution model
 };

--- a/roofit/roofit/inc/RooGaussModel.h
+++ b/roofit/roofit/inc/RooGaussModel.h
@@ -24,20 +24,8 @@
 
 class RooGaussModel : public RooResolutionModel {
 public:
-
-  enum RooGaussBasis { noBasis=0, expBasisMinus= 1, expBasisSum= 2, expBasisPlus= 3,
-                                  sinBasisMinus=11, sinBasisSum=12, sinBasisPlus=13,
-                                  cosBasisMinus=21, cosBasisSum=22, cosBasisPlus=23,
-                                                                    linBasisPlus=33,
-                                                                   quadBasisPlus=43,
-              coshBasisMinus=51,coshBasisSum=52,coshBasisPlus=53,
-                 sinhBasisMinus=61,sinhBasisSum=62,sinhBasisPlus=63};
-  enum BasisType { none=0, expBasis=1, sinBasis=2, cosBasis=3,
-         linBasis=4, quadBasis=5, coshBasis=6, sinhBasis=7 } ;
-  enum BasisSign { Both=0, Plus=+1, Minus=-1 } ;
-
   // Constructors, assignment etc
-  inline RooGaussModel() : _flatSFInt(false), _asympInt(false) { }
+  RooGaussModel() = default;
   RooGaussModel(const char *name, const char *title, RooAbsRealLValue& x,
       RooAbsReal& mean, RooAbsReal& sigma) ;
   RooGaussModel(const char *name, const char *title, RooAbsRealLValue& x,
@@ -60,7 +48,7 @@ public:
 
   void computeBatch(double* output, size_t size, RooFit::Detail::DataMap const&) const override;
 
-  bool canComputeBatchWithCuda() const override { return getBasisType(_basisCode) == expBasis; }
+  bool canComputeBatchWithCuda() const override;
 
 protected:
 
@@ -71,15 +59,9 @@ protected:
   std::complex<double> evalCerfInt(double sign, double wt, double tau, double umin, double umax, double c) const;
 
 private:
+  bool _flatSFInt = false;
 
-  static BasisType getBasisType(int basisCode)
-  {
-    return static_cast<BasisType>(basisCode == 0 ? 0 : (basisCode / 10) + 1);
-  }
-
-  bool _flatSFInt ;
-
-  bool _asympInt ;  // added FMV,07/24/03
+  bool _asympInt = false;  // added FMV,07/24/03
 
   RooRealProxy mean ;
   RooRealProxy sigma ;

--- a/roofit/roofitcore/inc/RooTruthModel.h
+++ b/roofit/roofitcore/inc/RooTruthModel.h
@@ -20,24 +20,10 @@
 
 class RooTruthModel : public RooResolutionModel {
 public:
-
-  enum RooTruthBasis { noBasis=0, expBasisMinus= 1, expBasisSum= 2, expBasisPlus= 3,
-                                  sinBasisMinus=11, sinBasisSum=12, sinBasisPlus=13,
-                                  cosBasisMinus=21, cosBasisSum=22, cosBasisPlus=23,
-                                                          linBasisPlus=33,
-                                                         quadBasisPlus=43,
-              coshBasisMinus=51,coshBasisSum=52,coshBasisPlus=53,
-                 sinhBasisMinus=61,sinhBasisSum=62,sinhBasisPlus=63,
-                       genericBasis=100 } ;
-
-  enum BasisType { none=0, expBasis=1, sinBasis=2, cosBasis=3,
-                   linBasis=4, quadBasis=5, coshBasis=6, sinhBasis=7 } ;
-  enum BasisSign { Both=0, Plus=+1, Minus=-1 } ;
-
   // Constructors, assignment etc
-  inline RooTruthModel() { }
+  RooTruthModel() = default;
   RooTruthModel(const char *name, const char *title, RooAbsRealLValue& x) ;
-  RooTruthModel(const RooTruthModel& other, const char* name=nullptr);
+  RooTruthModel(const RooTruthModel& other, const char* name=nullptr) : RooResolutionModel{other, name} {}
   TObject* clone(const char* newname) const override { return new RooTruthModel(*this,newname) ; }
 
   Int_t basisCode(const char* name) const override ;


### PR DESCRIPTION
This gives us more freedom when refactoring things to also support code
generation with AD.

Also apply other code modernizations, like less use of `TString` or
delegating constructors.