### PR TITLE
[math][mathmore] Fix setting optional parameters for GSLMCIntegrator

### DIFF
--- a/math/mathmore/inc/Math/GSLMCIntegrator.h
+++ b/math/mathmore/inc/Math/GSLMCIntegrator.h
@@ -254,7 +254,7 @@ public:
       /**
        set parameters for PLAIN method
       */
-      //void SetPParameters(const PlainParameters &p);
+      //void SetParameters(const PlainParameters &p);
 
       /**
        returns the error sigma from the last iteration of the Vegas algorithm
@@ -284,9 +284,15 @@ public:
 
       /**
          get the specific options (for Vegas or Miser)
-         in term of string-  name
+         in term of string-  name. This is for querying existing options and
+         return object is managed by the user
       */
-      ROOT::Math::IOptions * ExtraOptions() const;
+      std::unique_ptr<ROOT::Math::IOptions> ExtraOptions() const;
+
+      /**
+       * set the extra options for Vegas and Miser
+      */
+      void SetExtraOptions(const ROOT::Math::IOptions & opt);
 
 
    protected:

--- a/math/mathmore/inc/Math/GSLMCIntegrator.h
+++ b/math/mathmore/inc/Math/GSLMCIntegrator.h
@@ -290,7 +290,7 @@ public:
       std::unique_ptr<ROOT::Math::IOptions> ExtraOptions() const;
 
       /**
-       * set the extra options for Vegas and Miser
+       * Set the extra options for Vegas and Miser.
       */
       void SetExtraOptions(const ROOT::Math::IOptions & opt);
 

--- a/math/mathmore/inc/Math/MCParameters.h
+++ b/math/mathmore/inc/Math/MCParameters.h
@@ -27,12 +27,13 @@
 #define ROOT_Math_MCParameters
 
 #include <cstddef>   // for size_t
+#include <memory>  // for unique_ptr
+
+#include "Math/IOptions.h"
 
 namespace ROOT {
 namespace Math {
 
-
-class IOptions;
 
 /**
    structures collecting parameters
@@ -61,7 +62,7 @@ struct VegasParameters{
    VegasParameters & operator=(const ROOT::Math::IOptions & opt);
 
    /// convert to options (return object is managed by the user)
-   ROOT::Math::IOptions * operator() () const;
+   std::unique_ptr<ROOT::Math::IOptions>  operator() () const;
 };
 
 
@@ -93,7 +94,7 @@ struct MiserParameters{
    MiserParameters & operator=(const ROOT::Math::IOptions & opt);
 
    /// convert to options (return object is managed by the user)
-   ROOT::Math::IOptions * operator() () const;
+   std::unique_ptr<ROOT::Math::IOptions> operator() () const;
 
 };
 

--- a/math/mathmore/inc/Math/MCParameters.h
+++ b/math/mathmore/inc/Math/MCParameters.h
@@ -36,9 +36,9 @@ namespace Math {
 
 
 /**
-   structures collecting parameters
+   Structures collecting parameters
    for VEGAS multidimensional integration
-   FOr implementation of default parameters see file
+   For implementation of default parameters see file
    mathmore/src/GSLMCIntegrationWorkspace.h
 
    @ingroup MCIntegration
@@ -61,15 +61,15 @@ struct VegasParameters{
 
    VegasParameters & operator=(const ROOT::Math::IOptions & opt);
 
-   /// convert to options (return object is managed by the user)
-   std::unique_ptr<ROOT::Math::IOptions>  operator() () const;
+   /// Convert to options
+   std::unique_ptr<ROOT::Math::IOptions>  MakeIOptions() const;
 };
 
 
 
 
 /**
-   structures collecting parameters
+   Structure collecting parameters
    for MISER multidimensional integration
 
    @ingroup MCIntegration
@@ -94,7 +94,7 @@ struct MiserParameters{
    MiserParameters & operator=(const ROOT::Math::IOptions & opt);
 
    /// convert to options (return object is managed by the user)
-   std::unique_ptr<ROOT::Math::IOptions> operator() () const;
+   std::unique_ptr<ROOT::Math::IOptions> MakeIOptions() const;
 
 };
 

--- a/math/mathmore/src/GSLMCIntegrationWorkspace.h
+++ b/math/mathmore/src/GSLMCIntegrationWorkspace.h
@@ -69,7 +69,10 @@ namespace Math {
 
       /// retrieve option pointer corresponding to parameters
       /// create a new object to be managed by the user
-      virtual ROOT::Math::IOptions * Options() const = 0;
+      virtual std::unique_ptr<ROOT::Math::IOptions>  Options() const = 0;
+
+      /// set options
+      virtual void SetOptions(const ROOT::Math::IOptions &)  = 0;
 
    private:
 
@@ -128,10 +131,13 @@ namespace Math {
       const VegasParameters & Parameters() const { return fParams; }
       VegasParameters & Parameters()  { return fParams; }
 
-      ROOT::Math::IOptions * Options() const override {
+      std::unique_ptr<IOptions> Options() const override {
          return fParams();
       }
-
+      /// set options
+      virtual void SetOptions(const ROOT::Math::IOptions & opt) override {
+         SetParameters(VegasParameters(opt));
+      }
 
    private:
 
@@ -202,8 +208,11 @@ namespace Math {
       const MiserParameters & Parameters() const { return fParams; }
       MiserParameters & Parameters()  { return fParams; }
 
-      ROOT::Math::IOptions * Options() const override {
+      std::unique_ptr<ROOT::Math::IOptions> Options() const override {
          return fParams();
+      }
+      virtual void SetOptions(const ROOT::Math::IOptions & opt) override {
+         SetParameters(MiserParameters(opt));
       }
 
    private:
@@ -260,9 +269,11 @@ namespace Math {
 
       size_t NDim() const override { return (fWs) ? fWs->dim : 0; }
 
-      ROOT::Math::IOptions * Options() const override {
-         return nullptr;
+      std::unique_ptr<ROOT::Math::IOptions>  Options() const override {
+         return std::unique_ptr<ROOT::Math::IOptions>();
       }
+
+      virtual void SetOptions(const ROOT::Math::IOptions &) override {}
 
 
    private:

--- a/math/mathmore/src/GSLMCIntegrationWorkspace.h
+++ b/math/mathmore/src/GSLMCIntegrationWorkspace.h
@@ -132,7 +132,7 @@ namespace Math {
       VegasParameters & Parameters()  { return fParams; }
 
       std::unique_ptr<IOptions> Options() const override {
-         return fParams();
+         return fParams.MakeIOptions();
       }
       /// set options
       virtual void SetOptions(const ROOT::Math::IOptions & opt) override {
@@ -209,7 +209,7 @@ namespace Math {
       MiserParameters & Parameters()  { return fParams; }
 
       std::unique_ptr<ROOT::Math::IOptions> Options() const override {
-         return fParams();
+         return fParams.MakeIOptions();
       }
       virtual void SetOptions(const ROOT::Math::IOptions & opt) override {
          SetParameters(MiserParameters(opt));

--- a/math/mathmore/src/GSLMCIntegrator.cxx
+++ b/math/mathmore/src/GSLMCIntegrator.cxx
@@ -471,8 +471,7 @@ const char * GSLMCIntegrator::GetTypeName() const {
 }
 
 ROOT::Math::IntegratorMultiDimOptions  GSLMCIntegrator::Options() const {
-   auto extraOpts = ExtraOptions();
-   ROOT::Math::IntegratorMultiDimOptions opt(extraOpts.release());
+   ROOT::Math::IntegratorMultiDimOptions opt(ExtraOptions().release());
    opt.SetAbsTolerance(fAbsTol);
    opt.SetRelTolerance(fRelTol);
    opt.SetNCalls(fCalls);

--- a/math/mathmore/src/MCParameters.cxx
+++ b/math/mathmore/src/MCParameters.cxx
@@ -26,7 +26,6 @@
 // Author: Lorenzo Moneta , Nov 2010
 //
 //
-
 #include "Math/MCParameters.h"
 #include "Math/GenAlgoOptions.h"
 
@@ -70,7 +69,7 @@ namespace Math {
       return *this;
    }
 
-   IOptions * VegasParameters::operator() () const {
+   std::unique_ptr<ROOT::Math::IOptions> VegasParameters::operator() () const {
       // convert to options (return object is managed by the user)
       GenAlgoOptions * opt = new GenAlgoOptions();
       opt->SetRealValue("alpha",alpha);
@@ -78,7 +77,7 @@ namespace Math {
       opt->SetIntValue("stage",stage);
       opt->SetIntValue("mode",mode);
       opt->SetIntValue("verbose",verbose);
-      return opt;
+      return std::unique_ptr<ROOT::Math::IOptions>(opt);
    }
 
 
@@ -120,7 +119,7 @@ namespace Math {
       return *this;
    }
 
-   IOptions * MiserParameters::operator() () const {
+   std::unique_ptr<ROOT::Math::IOptions>  MiserParameters::operator() () const {
       // convert to options (return object is managed by the user)
       GenAlgoOptions * opt = new GenAlgoOptions();
       opt->SetRealValue("alpha",alpha);
@@ -128,7 +127,7 @@ namespace Math {
       opt->SetRealValue("estimate_frac",estimate_frac);
       opt->SetIntValue("min_calls",min_calls);
       opt->SetIntValue("min_calls_per_bisection",min_calls_per_bisection);
-      return opt;
+      return std::unique_ptr<ROOT::Math::IOptions>(opt);
    }
 
 

--- a/math/mathmore/src/MCParameters.cxx
+++ b/math/mathmore/src/MCParameters.cxx
@@ -69,15 +69,15 @@ namespace Math {
       return *this;
    }
 
-   std::unique_ptr<ROOT::Math::IOptions> VegasParameters::operator() () const {
+   std::unique_ptr<ROOT::Math::IOptions> VegasParameters::MakeIOptions() const {
       // convert to options (return object is managed by the user)
-      GenAlgoOptions * opt = new GenAlgoOptions();
+      auto opt = std::make_unique<GenAlgoOptions>();
       opt->SetRealValue("alpha",alpha);
       opt->SetIntValue("iterations",iterations);
       opt->SetIntValue("stage",stage);
       opt->SetIntValue("mode",mode);
       opt->SetIntValue("verbose",verbose);
-      return std::unique_ptr<ROOT::Math::IOptions>(opt);
+      return opt;
    }
 
 
@@ -119,15 +119,15 @@ namespace Math {
       return *this;
    }
 
-   std::unique_ptr<ROOT::Math::IOptions>  MiserParameters::operator() () const {
+   std::unique_ptr<ROOT::Math::IOptions>  MiserParameters::MakeIOptions() const {
       // convert to options (return object is managed by the user)
-      GenAlgoOptions * opt = new GenAlgoOptions();
+      auto opt = std::make_unique<GenAlgoOptions>();
       opt->SetRealValue("alpha",alpha);
       opt->SetRealValue("dither",dither);
       opt->SetRealValue("estimate_frac",estimate_frac);
       opt->SetIntValue("min_calls",min_calls);
       opt->SetIntValue("min_calls_per_bisection",min_calls_per_bisection);
-      return std::unique_ptr<ROOT::Math::IOptions>(opt);
+      return opt;
    }
 
 


### PR DESCRIPTION
Calling `GSLMCIntegrator::SetMode` crashed because the internal workspace was not yet created. 
This PR fixes this and also the way the extra option parameters are retrieved and set in the GSLMCIntegrator. 

A small change in the interface is done by returning now a unique_ptr instead of a row pointer in 
`GSLMCIntegrator::ExtraOptions()`

