### PR TITLE
[TMVA] Remove workaround from the CINT era

### DIFF
--- a/tmva/tmva/inc/TMVA/Reader.h
+++ b/tmva/tmva/inc/TMVA/Reader.h
@@ -82,10 +82,6 @@ namespace TMVA {
       IMethod* BookMVA( const TString& methodTag, const TString& weightfile );
       IMethod* BookMVA( TMVA::Types::EMVA methodType, const char* xmlstr );
       IMethod* FindMVA( const TString& methodTag );
-      // special function for Cuts to avoid dynamic_casts in ROOT macros,
-      // which are not properly handled by CINT
-      MethodCuts* FindCutsMVA( const TString& methodTag );
-
 
       // returns the MVA response for given event
       Double_t EvaluateMVA( const std::vector<Float_t> &, const TString& methodTag, Double_t aux = 0 );

--- a/tmva/tmva/src/Reader.cxx
+++ b/tmva/tmva/src/Reader.cxx
@@ -701,15 +701,6 @@ TMVA::IMethod* TMVA::Reader::FindMVA( const TString& methodTag )
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// special function for Cuts to avoid dynamic_casts in ROOT macros,
-/// which are not properly handled by CINT
-
-TMVA::MethodCuts* TMVA::Reader::FindCutsMVA( const TString& methodTag )
-{
-   return dynamic_cast<MethodCuts*>(FindMVA(methodTag));
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// evaluates probability of MVA for given set of input variables
 
 Double_t TMVA::Reader::GetProba( const TString& methodTag,  Double_t ap_sig, Double_t mvaVal )

--- a/tutorials/tmva/TMVAClassificationApplication.C
+++ b/tutorials/tmva/TMVAClassificationApplication.C
@@ -382,8 +382,7 @@ void TMVAClassificationApplication( TString myMethodList = "" )
    if (Use["CutsGA"]) {
 
       // test: retrieve cuts for particular signal efficiency
-      // CINT ignores dynamic_casts so we have to use a cuts-specific Reader function to access the pointer
-      TMVA::MethodCuts* mcuts = reader->FindCutsMVA( "CutsGA method" ) ;
+      TMVA::MethodCuts* mcuts = dynamic_cast<TMVA::MethodCuts*>(reader->FindMVA( "CutsGA method" ));
 
       if (mcuts) {
          std::vector<Double_t> cutsMin;

--- a/tutorials/tmva/TMVAClassificationCategoryApplication.C
+++ b/tutorials/tmva/TMVAClassificationCategoryApplication.C
@@ -26,11 +26,9 @@
 #include "TH1F.h"
 #include "TStopwatch.h"
 
-#if not defined(__CINT__) || defined(__MAKECINT__)
 #include "TMVA/Tools.h"
 #include "TMVA/Reader.h"
 #include "TMVA/MethodCuts.h"
-#endif
 
 // two types of category methods are implemented
 Bool_t UseOffsetMethod = kTRUE;


### PR DESCRIPTION
Since cling can deal with `dynamic_cast` correctly, the `TMVA::Reader::FindCutsMVA()` workaround is not needed anymore.

That's one of the changes necessary to address #10058.