### PR TITLE
Change default TColor resolution

### DIFF
--- a/core/base/src/TColor.cxx
+++ b/core/base/src/TColor.cxx
@@ -1956,10 +1956,10 @@ Int_t TColor::GetColor(Int_t r, Int_t g, Int_t b, Float_t a)
    if (gColorThreshold >= 0) {
       thres = gColorThreshold;
    } else {
-      Int_t nplanes = 16;
-      thres = 1.0f/31.0f;   // 5 bits per color : 0 - 0x1F !
+      Int_t nplanes = 24;
+      thres = 1.0f/255.0f;       // 8 bits per color : 0 - 0xFF !
       if (gVirtualX) gVirtualX->GetPlanes(nplanes);
-      if (nplanes >= 24) thres = 1.0f/255.0f;       // 8 bits per color : 0 - 0xFF !
+      if ((nplanes > 0) && (nplanes <= 16)) thres = 1.0f/31.0f; // 5 bits per color : 0 - 0x1F !
    }
 
    // Loop over all defined colors


### PR DESCRIPTION
TColor::GetColor(r,g,b) uses 5bit threshold by
 default to create new colors. This differs
 from normal X11 with 8bit colors. As  a result,
 images produced in batch and in interactive
 session may differ - see greyscale.C macro.

 Make default 8bit resolution for colors, and
 reduce it only if detecting such display.
