### PR TITLE
[ntuple] Add support for `std::unordered_set` fields

### DIFF
--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -186,6 +186,8 @@ std::string GetNormalizedTypeName(const std::string &typeName)
       normalizedType = "std::" + normalizedType;
    if (normalizedType.substr(0, 4) == "set<")
       normalizedType = "std::" + normalizedType;
+   if (normalizedType.substr(0, 14) == "unordered_set<")
+      normalizedType = "std::" + normalizedType;
    if (normalizedType.substr(0, 7) == "atomic<")
       normalizedType = "std::" + normalizedType;
    if (normalizedType == "byte")
@@ -456,6 +458,12 @@ ROOT::Experimental::Detail::RFieldBase::Create(const std::string &fieldName, con
       auto normalizedInnerTypeName = itemField->GetType();
       result =
          std::make_unique<RSetField>(fieldName, "std::set<" + normalizedInnerTypeName + ">", std::move(itemField));
+   } else if (canonicalType.substr(0, 19) == "std::unordered_set<") {
+      std::string itemTypeName = canonicalType.substr(19, canonicalType.length() - 20);
+      auto itemField = Create("_0", itemTypeName).Unwrap();
+      auto normalizedInnerTypeName = itemField->GetType();
+      result = std::make_unique<RSetField>(fieldName, "std::unordered_set<" + normalizedInnerTypeName + ">",
+                                           std::move(itemField));
    } else if (canonicalType.substr(0, 12) == "std::atomic<") {
       std::string itemTypeName = canonicalType.substr(12, canonicalType.length() - 13);
       auto itemField = Create("_0", itemTypeName).Unwrap();

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <set>
 #include <string>
+#include <unordered_set>
 #include <variant>
 #include <vector>
 
@@ -36,6 +37,11 @@ struct CustomStruct {
    bool operator<(const CustomStruct &c) const { return a < c.a && v1 < c.v1 && v2 < c.v2 && s < c.s; }
 
    bool operator==(const CustomStruct &c) const { return a == c.a && v1 == c.v1 && v2 == c.v2 && s == c.s; }
+};
+
+template <>
+struct std::hash<CustomStruct> {
+   std::size_t operator()(const CustomStruct &c) const noexcept { return std::hash<float>{}(c.a); }
 };
 
 struct DerivedA : public CustomStruct {

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -58,6 +58,12 @@
 #pragma link C++ class std::set<std::set<char>> +;
 #pragma link C++ class std::set<std::pair<int, CustomStruct>> +;
 
+#pragma link C++ class std::unordered_set<std::int64_t> +;
+#pragma link C++ class std::unordered_set<std::string> +;
+#pragma link C++ class std::unordered_set<float> +;
+#pragma link C++ class std::unordered_set<CustomStruct> +;
+#pragma link C++ class std::unordered_set<std::vector<bool>> +;
+
 #pragma link C++ options = version(3) class StructWithIORulesBase + ;
 #pragma link C++ options = version(3) class StructWithTransientString + ;
 #pragma link C++ options = version(3) class StructWithIORules + ;


### PR DESCRIPTION
This PR extends the support for `std::set` fields with `std::unordered_set` fields.

N.B. We might want to consider moving the dictionary entries for the tests of these types (along with the ones for `std::map` fields) to a dedicated LinkDef file, since technically they don't have anything to do with the `CustomStruct` test type. This can be addressed in a separate PR.