### PR TITLE
[RF] Deprecate RooFit legacy iterators

### DIFF
--- a/README/ReleaseNotes/v632/index.md
+++ b/README/ReleaseNotes/v632/index.md
@@ -38,7 +38,7 @@ The following people have contributed to this new version:
  Wouter Verkerke, NIKHEF/Atlas,
 
 ## Deprecation and Removal
-
+- The RooFit legacy iterators are deprecated and will be removed in ROOT 6.34 (see section "RooFit libraries")
 
 ## Core Libraries
 
@@ -57,6 +57,24 @@ The following people have contributed to this new version:
 
 ## RooFit Libraries
 
+### Deprecation of legacy iterators
+
+The following methods related to the RooFit legacy iterators are deprecated and will be removed in ROOT 6.34.
+They should be replaced with the suitable STL-compatible interfaces, or you can just use range-based loops:
+
+- `RooAbsArg::clientIterator()`: use `clients()` and `begin()`, `end()` or range-based loops instead
+- `RooAbsArg::valueClientIterator()`: use `valueClients()`
+- `RooAbsArg::shapeClientIterator()`: use `shapeClients()`
+- `RooAbsArg::serverIterator()`: use `servers()`
+- `RooAbsArg::valueClientMIterator()`: use `valueClients()`
+- `RooAbsArg::shapeClientMIterator()`: use `shapeClients()`
+- `RooAbsArg::serverMIterator()`: use `servers()`
+
+- `RooAbsCollection::createIterator()`: use `begin()`, `end()` and range-based for loops
+- `RooAbsCollection::iterator()`: same
+- `RooAbsCollection::fwdIterator()`: same
+
+- `RooWorkspace::componentIterator()`: use `RooWorkspace::components()` with range-based loop
 
 ## 2D Graphics Libraries
 

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -135,36 +135,36 @@ public:
 
   /// Retrieve a client iterator.
   inline TIterator* clientIterator() const
-  R__SUGGEST_ALTERNATIVE("Use clients() and begin(), end() or range-based loops.") {
+  R__DEPRECATED(6,34, "Use clients() and begin(), end() or range-based loops.") {
     // Return iterator over all client RooAbsArgs
     return makeLegacyIterator(_clientList);
   }
   inline TIterator* valueClientIterator() const
-  R__SUGGEST_ALTERNATIVE("Use valueClients() and begin(), end() or range-based loops.") {
+  R__DEPRECATED(6,34, "Use valueClients() and begin(), end() or range-based loops.") {
     // Return iterator over all shape client RooAbsArgs
     return makeLegacyIterator(_clientListValue);
   }
   inline TIterator* shapeClientIterator() const
-  R__SUGGEST_ALTERNATIVE("Use shapeClients() and begin(), end() or range-based loops.") {
+  R__DEPRECATED(6,34, "Use shapeClients() and begin(), end() or range-based loops.") {
     // Return iterator over all shape client RooAbsArgs
     return makeLegacyIterator(_clientListShape);
   }
   inline TIterator* serverIterator() const
-  R__SUGGEST_ALTERNATIVE("Use servers() and begin(), end() or range-based loops.") {
+  R__DEPRECATED(6,34, "Use servers() and begin(), end() or range-based loops.") {
     // Return iterator over all server RooAbsArgs
     return makeLegacyIterator(_serverList);
   }
 
   inline RooFIter valueClientMIterator() const
-  R__SUGGEST_ALTERNATIVE("Use valueClients() and begin(), end() or range-based loops.") {
+  R__DEPRECATED(6,34, "Use valueClients() and begin(), end() or range-based loops.") {
     return RooFIter(std::unique_ptr<RefCountListLegacyIterator_t>(makeLegacyIterator(_clientListValue)));
   }
   inline RooFIter shapeClientMIterator() const
-  R__SUGGEST_ALTERNATIVE("Use shapeClients() and begin(), end() or range-based loops.") {
+  R__DEPRECATED(6,34, "Use shapeClients() and begin(), end() or range-based loops.") {
     return RooFIter(std::unique_ptr<RefCountListLegacyIterator_t>(makeLegacyIterator(_clientListShape)));
   }
   inline RooFIter serverMIterator() const
-  R__SUGGEST_ALTERNATIVE("Use servers() and begin(), end() or range-based loops.") {
+  R__DEPRECATED(6,34, "Use servers() and begin(), end() or range-based loops.") {
     return RooFIter(std::unique_ptr<RefCountListLegacyIterator_t>(makeLegacyIterator(_serverList)));
   }
 

--- a/roofit/roofitcore/inc/RooAbsCollection.h
+++ b/roofit/roofitcore/inc/RooAbsCollection.h
@@ -225,7 +225,7 @@ public:
   /// \note These iterators are slow. Use begin() and end() or
   /// range-based for loop instead.
   inline TIterator* createIterator(bool dir = kIterForward) const
-  R__SUGGEST_ALTERNATIVE("begin(), end() and range-based for loops.") {
+  R__DEPRECATED(6,34, "begin(), end() and range-based for loops.") {
     // Create and return an iterator over the elements in this collection
     return new RooLinkedListIter(makeLegacyIterator(dir));
   }
@@ -233,14 +233,14 @@ public:
   /// TIterator-style iteration over contained elements.
   /// \note This iterator is slow. Use begin() and end() or range-based for loop instead.
   RooLinkedListIter iterator(bool dir = kIterForward) const
-  R__SUGGEST_ALTERNATIVE("begin(), end() and range-based for loops.") {
+  R__DEPRECATED(6,34, "begin(), end() and range-based for loops.") {
     return RooLinkedListIter(makeLegacyIterator(dir));
   }
 
   /// One-time forward iterator.
   /// \note Use begin() and end() or range-based for loop instead.
   RooFIter fwdIterator() const
-  R__SUGGEST_ALTERNATIVE("begin(), end() and range-based for loops.") {
+  R__DEPRECATED(6,34, "begin(), end() and range-based for loops.") {
     return RooFIter(makeLegacyIterator());
   }
 
@@ -401,7 +401,15 @@ protected:
   }
 
 private:
+
+#if ROOT_VERSION_CODE < ROOT_VERSION(6, 34, 00)
+  // TODO: Remove this friend declaration and function in 6.34, where it's not
+  // needed anymore because the deprecated legacy iterators will be removed.
+  friend class RooWorkspace;
   std::unique_ptr<LegacyIterator_t> makeLegacyIterator (bool forward = true) const;
+#else
+#error "Please remove this unneeded code."
+#endif
 
   using HashAssistedFind = RooFit::Detail::HashAssistedFind;
   mutable std::unique_ptr<HashAssistedFind> _hashAssistedFind; ///<!

--- a/roofit/roofitcore/inc/RooWorkspace.h
+++ b/roofit/roofitcore/inc/RooWorkspace.h
@@ -113,8 +113,7 @@ public:
   RooAbsArg* fundArg(RooStringView name) const ;
   RooArgSet argSet(RooStringView nameList) const ;
   TIterator* componentIterator() const
-  R__SUGGEST_ALTERNATIVE("Better iterate over RooWorkspace::components() with range-based loop instead of using RooWorkspace::componentIterator().")
-  { return _allOwnedNodes.createIterator() ; }
+  R__DEPRECATED(6,34, "Better iterate over RooWorkspace::components() with range-based loop instead of using RooWorkspace::componentIterator().");
   const RooArgSet& components() const { return _allOwnedNodes ; }
   TObject* genobj(RooStringView name) const ;
   TObject* obj(RooStringView name) const ;

--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -45,27 +45,30 @@ ulimit -s
 and try reading again.
 **/
 
-#include "RooWorkspace.h"
-#include "RooWorkspaceHandle.h"
-#include "RooAbsPdf.h"
-#include "RooRealVar.h"
-#include "RooCategory.h"
-#include "RooAbsData.h"
-#include "RooCmdConfig.h"
-#include "RooMsgService.h"
-#include "RooConstVar.h"
-#include "RooResolutionModel.h"
-#include "RooPlot.h"
-#include "RooRandom.h"
+#include <RooWorkspace.h>
+
+#include <RooAbsData.h>
+#include <RooAbsPdf.h>
+#include <RooAbsStudy.h>
+#include <RooCategory.h>
+#include <RooCmdConfig.h>
+#include <RooConstVar.h>
+#include <RooFactoryWSTool.h>
+#include <RooLinkedListIter.h>
+#include <RooMsgService.h>
+#include <RooPlot.h>
+#include <RooRandom.h>
+#include <RooRealVar.h>
+#include <RooResolutionModel.h>
+#include <RooTObjWrap.h>
+#include <RooWorkspaceHandle.h>
+
 #include "TBuffer.h"
 #include "TInterpreter.h"
 #include "TClassTable.h"
 #include "TBaseClass.h"
 #include "TSystem.h"
 #include "TRegexp.h"
-#include "RooFactoryWSTool.h"
-#include "RooAbsStudy.h"
-#include "RooTObjWrap.h"
 #include "TROOT.h"
 #include "TFile.h"
 #include "TH1.h"
@@ -2937,4 +2940,9 @@ void RooWorkspace::RecursiveRemove(TObject *removedObj)
    }
 
    _eocache.RecursiveRemove(removedObj); // RooExpensiveObjectCache
+}
+
+TIterator *RooWorkspace::componentIterator() const
+{
+   return new RooLinkedListIter(_allOwnedNodes.makeLegacyIterator());
 }


### PR DESCRIPTION
The STL-compatible alternatives are now around long enough (since ROOT 6.18, 4 years ago) so after this grace period it is time to deprecate and eventually remove the old iterators.