### PR TITLE
[ntuple] Move STL dictionary entries to separate file

### DIFF
--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -39,6 +39,11 @@ ROOT_ADD_GTEST(ntuple_modelext ntuple_modelext.cxx LIBRARIES ROOTNTuple MathCore
 ROOT_ADD_GTEST(ntuple_serialize ntuple_serialize.cxx LIBRARIES ROOTNTuple CustomStruct)
 if(NOT MSVC OR llvm13_broken_tests)
   ROOT_ADD_GTEST(ntuple_types ntuple_types.cxx LIBRARIES ROOTNTuple CustomStruct)
+  ROOT_GENERATE_DICTIONARY(ProxiedSTLContainerDict ${CMAKE_CURRENT_SOURCE_DIR}/ProxiedSTLContainer.hxx
+                         MODULE ntuple_types
+                         LINKDEF ProxiedSTLContainerLinkDef.h
+                         OPTIONS -inlineInputHeader
+                         DEPENDENCIES CustomStruct)
 endif()
 ROOT_ADD_GTEST(ntuple_view ntuple_view.cxx LIBRARIES ROOTNTuple CustomStruct)
 ROOT_ADD_GTEST(ntuple_zip ntuple_zip.cxx LIBRARIES ROOTNTuple CustomStruct)

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -51,19 +51,6 @@
 #pragma link C++ class ConstructorTraits + ;
 #pragma link C++ class DestructorTraits + ;
 
-#pragma link C++ class std::set<std::int64_t> +;
-#pragma link C++ class std::set<std::string> +;
-#pragma link C++ class std::set<float> +;
-#pragma link C++ class std::set<std::set<CustomStruct>> +;
-#pragma link C++ class std::set<std::set<char>> +;
-#pragma link C++ class std::set<std::pair<int, CustomStruct>> +;
-
-#pragma link C++ class std::unordered_set<std::int64_t> +;
-#pragma link C++ class std::unordered_set<std::string> +;
-#pragma link C++ class std::unordered_set<float> +;
-#pragma link C++ class std::unordered_set<CustomStruct> +;
-#pragma link C++ class std::unordered_set<std::vector<bool>> +;
-
 #pragma link C++ options = version(3) class StructWithIORulesBase + ;
 #pragma link C++ options = version(3) class StructWithTransientString + ;
 #pragma link C++ options = version(3) class StructWithIORules + ;

--- a/tree/ntuple/v7/test/ProxiedSTLContainer.hxx
+++ b/tree/ntuple/v7/test/ProxiedSTLContainer.hxx
@@ -1,0 +1,9 @@
+#ifndef ROOT7_RNTuple_Test_ProxiedSTLContainer
+#define ROOT7_RNTuple_Test_ProxiedSTLContainer
+
+#include "CustomStruct.hxx"
+
+#include <set>
+#include <unordered_set>
+
+#endif // ROOT7_RNTuple_Test_ProxiedSTLContainer

--- a/tree/ntuple/v7/test/ProxiedSTLContainerLinkDef.h
+++ b/tree/ntuple/v7/test/ProxiedSTLContainerLinkDef.h
@@ -1,0 +1,20 @@
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class std::set<std::int64_t>+;
+#pragma link C++ class std::set<std::string>+;
+#pragma link C++ class std::set<float>+;
+#pragma link C++ class std::set<std::set<CustomStruct>>+;
+#pragma link C++ class std::set<std::set<char>>+;
+#pragma link C++ class std::set<std::pair<int, CustomStruct>>+;
+
+#pragma link C++ class std::unordered_set<std::int64_t>+;
+#pragma link C++ class std::unordered_set<std::string>+;
+#pragma link C++ class std::unordered_set<float>+;
+#pragma link C++ class std::unordered_set<CustomStruct>+;
+#pragma link C++ class std::unordered_set<std::vector<bool>>+;
+
+#endif


### PR DESCRIPTION
This PR moves the dictionaries for STL containers required for testing to a separate LinkDef. The rationale behind this is that these dictionaries are not directly related to the `CustomStruct` and once #13904 and #14069 are merged even more (unrelated) dictionary entries would be added, so it would be good to avoid clutter and separate these.

