### PR TITLE
Made public TH1::CheckConsistency (2)

### DIFF
--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -83,6 +83,17 @@ public:
          kNeutral = 2,  ///< Adapt to the global flag
    };
 
+   /// Enumeration specifying inconsistencies between two histograms,
+   /// in increasing severity.
+   enum  EInconsistencyBits {
+         kFullyConsistent = 0,
+         kDifferentLabels = BIT(0),
+         kDifferentBinLimits = BIT(1),
+         kDifferentAxisLimits = BIT(2),
+         kDifferentNumberOfBins = BIT(3),
+         kDifferentDimensions = BIT(4)
+   };
+
    friend class TH1Merger;
 
 protected:

--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -156,7 +156,6 @@ protected:
    static bool CheckBinLabels(const TAxis* a1, const TAxis* a2);
    static bool CheckEqualAxes(const TAxis* a1, const TAxis* a2);
    static bool CheckConsistentSubAxes(const TAxis *a1, Int_t firstBin1, Int_t lastBin1, const TAxis *a2, Int_t firstBin2=0, Int_t lastBin2=0);
-   static int CheckConsistency(const TH1* h1, const TH1* h2);
    int LoggedInconsistency(const char* name, const TH1* h1, const TH1* h2, bool useMerge=false) const;
 
 public:
@@ -199,6 +198,7 @@ public:
    virtual Double_t Chi2Test(const TH1* h2, Option_t *option = "UU", Double_t *res = nullptr) const;
    virtual Double_t Chi2TestX(const TH1* h2, Double_t &chi2, Int_t &ndf, Int_t &igood,Option_t *option = "UU",  Double_t *res = nullptr) const;
    virtual Double_t Chisquare(TF1 * f1, Option_t *option = "") const;
+   static  Int_t    CheckConsistency(const TH1* h1, const TH1* h2);
    virtual void     ClearUnderflowAndOverflow();
    virtual Double_t ComputeIntegral(Bool_t onlyPositive = false);
            TObject* Clone(const char *newname = "") const override;

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -594,21 +594,6 @@ extern void H1LeastSquareFit(Int_t n, Int_t m, Double_t *a);
 extern void H1LeastSquareLinearFit(Int_t ndata, Double_t &a0, Double_t &a1, Int_t &ifail);
 extern void H1LeastSquareSeqnd(Int_t n, Double_t *a, Int_t idim, Int_t &ifail, Int_t k, Double_t *b);
 
-namespace {
-
-/// Enumeration specifying inconsistencies between two histograms,
-/// in increasing severity.
-enum EInconsistencyBits {
-   kFullyConsistent = 0,
-   kDifferentLabels = BIT(0),
-   kDifferentBinLimits = BIT(1),
-   kDifferentAxisLimits = BIT(2),
-   kDifferentNumberOfBins = BIT(3),
-   kDifferentDimensions = BIT(4)
-};
-
-} // namespace
-
 ClassImp(TH1);
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1675,6 +1660,8 @@ bool TH1::CheckConsistentSubAxes(const TAxis *a1, Int_t firstBin1, Int_t lastBin
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Check histogram compatibility.
+/// The returned integer is part of EInconsistencyBits
+/// The value 0 means that the histograms are compatible
 
 Int_t TH1::CheckConsistency(const TH1* h1, const TH1* h2)
 {

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -1676,7 +1676,7 @@ bool TH1::CheckConsistentSubAxes(const TAxis *a1, Int_t firstBin1, Int_t lastBin
 ////////////////////////////////////////////////////////////////////////////////
 /// Check histogram compatibility.
 
-int TH1::CheckConsistency(const TH1* h1, const TH1* h2)
+Int_t TH1::CheckConsistency(const TH1* h1, const TH1* h2)
 {
    if (h1 == h2) return kFullyConsistent;
 


### PR DESCRIPTION
# This Pull request:
This is a follow up of https://github.com/root-project/root/pull/13748, which was modified by 
@guitargeek to fix the unnecessary use of exceptions.

Associated roottest PR:
  * https://github.com/root-project/roottest/pull/1040

## Changes or fixes:
Made the static function `TH1::CheckConsistency` public, and changed its return type to `Int_t`.
Since the meaning of the returned integer is actually part of `EInconsistencyBits`, I made the `enum` public as well (but left the return value type to `Int_t`). This is done in a separate commit in case it is decided to keep the `enum` itself as an implementation detail.

## Motivation
At the moment `TH1::CheckConsistency` is called internally by `TH1::Add`, and error messages are print in case of failure, but continues the execution. Making it public allows user code to manually check the consistency to catch errors and stop the program. This is especially useful for programs that make hundreds of `Add`s, out of which only a few fail, and the error messages may be lost in logs and go unnoticed.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)