### PR TITLE
[webgui] use loopback by default

### DIFF
--- a/config/rootrc.in
+++ b/config/rootrc.in
@@ -247,8 +247,8 @@ WebGui.HttpPortMin:         8800
 WebGui.HttpPortMax:         9800
 # Exact IP iddress to bind bind http server (default - empty)
 WebGui.HttpBind:
-# Use only loopback address to bind http server (default - no)
-WebGui.HttpLoopback:        no
+# Use only loopback address to bind http server (default - yes)
+WebGui.HttpLoopback:        yes
 # Use https protocol for the http server (default - no)
 WebGui.UseHttps:            no
 WebGui.ServerCert:          rootserver.pem


### PR DESCRIPTION
Default value is `ON` in C++ code,
but was remained off in system.rootrc and over-rulling C++

Reported in forum: 
https://root-forum.cern.ch/t/root-web-is-insecure/57164