### PR TITLE
[ntuple] Move includes in test helpers to correct header file

### DIFF
--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -6,10 +6,7 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <map>
-#include <set>
 #include <string>
-#include <unordered_set>
 #include <variant>
 #include <vector>
 

--- a/tree/ntuple/v7/test/ProxiedSTLContainer.hxx
+++ b/tree/ntuple/v7/test/ProxiedSTLContainer.hxx
@@ -3,7 +3,9 @@
 
 #include "CustomStruct.hxx"
 
+#include <map>
 #include <set>
 #include <unordered_set>
+#include <utility>
 
 #endif // ROOT7_RNTuple_Test_ProxiedSTLContainer


### PR DESCRIPTION
This PR is a minor follow-up from #14072, moving some leftover `#include`s from `CustomStruct.hxx` to `ProxiedSTLContainer.hxx`.