### PR TITLE
small improvements in sqlite3_prepare

### DIFF
--- a/sql/sqlite/src/TSQLiteServer.cxx
+++ b/sql/sqlite/src/TSQLiteServer.cxx
@@ -149,7 +149,7 @@ TSQLResult *TSQLiteServer::Query(const char *sql)
    }
 
    sqlite3_stmt *preparedStmt = nullptr;
-   const char *tail;
+   const char *tail = nullptr;
 
    // -1 as we read until we encounter a \0.
 #if SQLITE_VERSION_NUMBER >= 3005000
@@ -383,7 +383,7 @@ TSQLStatement* TSQLiteServer::Statement(const char *sql, Int_t)
    }
 
    sqlite3_stmt *preparedStmt = nullptr;
-   const char *tail;
+   const char *tail = nullptr;
 
    // -1 as we read until we encounter a \0.
 #if SQLITE_VERSION_NUMBER >= 3005000

--- a/sql/sqlite/src/TSQLiteServer.cxx
+++ b/sql/sqlite/src/TSQLiteServer.cxx
@@ -149,18 +149,20 @@ TSQLResult *TSQLiteServer::Query(const char *sql)
    }
 
    sqlite3_stmt *preparedStmt = nullptr;
+   const char *tail;
 
    // -1 as we read until we encounter a \0.
-   // NULL because we do not check which char was read last.
 #if SQLITE_VERSION_NUMBER >= 3005000
-   int retVal = sqlite3_prepare_v2(fSQLite, sql, -1, &preparedStmt, nullptr);
+   int retVal = sqlite3_prepare_v2(fSQLite, sql, -1, &preparedStmt, &tail);
 #else
-   int retVal = sqlite3_prepare(fSQLite, sql, -1, &preparedStmt, nullptr);
+   int retVal = sqlite3_prepare(fSQLite, sql, -1, &preparedStmt, &tail);
 #endif
    if (retVal != SQLITE_OK) {
       Error("Query", "SQL Error: %d %s", retVal, sqlite3_errmsg(fSQLite));
       return nullptr;
    }
+   if (tail && tail[0] != '\0')
+      Warning("Query", "Don't use multiple queries, '%s' query was ignored", tail);
 
    return new TSQLiteResult(preparedStmt);
 }
@@ -381,18 +383,20 @@ TSQLStatement* TSQLiteServer::Statement(const char *sql, Int_t)
    }
 
    sqlite3_stmt *preparedStmt = nullptr;
+   const char *tail;
 
    // -1 as we read until we encounter a \0.
-   // NULL because we do not check which char was read last.
 #if SQLITE_VERSION_NUMBER >= 3005000
-   int retVal = sqlite3_prepare_v2(fSQLite, sql, -1, &preparedStmt, NULL);
+   int retVal = sqlite3_prepare_v2(fSQLite, sql, -1, &preparedStmt, &tail);
 #else
-   int retVal = sqlite3_prepare(fSQLite, sql, -1, &preparedStmt, NULL);
+   int retVal = sqlite3_prepare(fSQLite, sql, -1, &preparedStmt, &tail);
 #endif
    if (retVal != SQLITE_OK) {
       Error("Statement", "SQL Error: %d %s", retVal, sqlite3_errmsg(fSQLite));
       return nullptr;
    }
+   if (tail && tail[0] != '\0')
+      Warning("Statement", "Don't use multiple statements, '%s' statement was ignored", tail);
 
    SQLite3_Stmt_t *stmt = new SQLite3_Stmt_t;
    stmt->fConn = fSQLite;


### PR DESCRIPTION
Function `sqlite3_prepare` in `sql/sqlite/src/TSQLiteServer.cxx` with info about [tail](https://sqlite.org/c3ref/prepare.html). `sqlite3_prepare` only compile the first statement in "sql", so "tail" is left pointing to what remains uncompiled.

```
void test()
{
   TSQLServer *db = TSQLServer::Connect("sqlite://test.sqlite", "", "");
   TSQLResult *res = db->Query("CREATE TABLE test(name TEXT)");
   if (res) { res->Next(); delete res; }
   res = db->Query("INSERT INTO test VALUES('1st');"
                   "INSERT INTO test VALUES('2nd');");
   if (res) { res->Next(); delete res; }
}
```
```
$ root test.C
root [0]
Processing test.C...
Warning in <TSQLiteServer::Query>: Don't use multiple queries, 'INSERT INTO test VALUES('2nd');' query was ignored
root [1]
```
