### PR TITLE
[ntuple] Add support for `std::unordered_map` fields

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -751,9 +751,9 @@ This means that they have the same on-disk representation as `std::vector<T>`, u
   - Child field of type `T`, which must by a type with RNTuple I/O support.
     The name of the child field is `_0`.
 
-#### std::map\<K, V\>
+#### std::map\<K, V\> and std::unordered_map\<K, V\>
 
-A map is stored using a collection mother field, whose principal column is of type `(Split)Index[64|32]` and a child field of type `std::pair<K, V>` named `_0`.
+An (unordered) map is stored using a collection mother field, whose principal column is of type `(Split)Index[64|32]` and a child field of type `std::pair<K, V>` named `_0`.
 
 ### std::atomic\<T\>
 

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <string>
 #include <variant>
 #include <vector>

--- a/tree/ntuple/v7/test/ProxiedSTLContainer.hxx
+++ b/tree/ntuple/v7/test/ProxiedSTLContainer.hxx
@@ -6,6 +6,7 @@
 #include <map>
 #include <set>
 #include <unordered_set>
+#include <unordered_map>
 #include <utility>
 
 #endif // ROOT7_RNTuple_Test_ProxiedSTLContainer

--- a/tree/ntuple/v7/test/ProxiedSTLContainerLinkDef.h
+++ b/tree/ntuple/v7/test/ProxiedSTLContainerLinkDef.h
@@ -25,6 +25,12 @@
 #pragma link C++ class std::map<char, std::map<int, CustomStruct>>+;
 #pragma link C++ class std::map<float, std::map<char, std::int32_t>>+;
 
+#pragma link C++ class std::unordered_map<char, long>+;
+#pragma link C++ class std::unordered_map<char, std::int64_t>+;
+#pragma link C++ class std::unordered_map<char, std::string>+;
+#pragma link C++ class std::unordered_map<int, CustomStruct>+;
+#pragma link C++ class std::unordered_map<float, std::vector<bool>>+;
+
 #pragma link C++ class std::pair<char, long>+;
 #pragma link C++ class std::pair<char, std::int64_t>+;
 #pragma link C++ class std::pair<char, std::string>+;
@@ -32,5 +38,6 @@
 #pragma link C++ class std::pair<int, std::vector<CustomStruct>>+;
 #pragma link C++ class std::pair<float, std::map<char, std::int32_t>>+;
 #pragma link C++ class std::pair<char, std::int32_t>+;
+#pragma link C++ class std::pair<float, std::vector<bool>>+;
 
 #endif


### PR DESCRIPTION
This PR extends the support for `std::map` fields with `std::unordered_map` fields.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)
