### PR TITLE
[tmva] Fix cross entropy calculation for large input values

### DIFF
--- a/tmva/tmva/src/DNN/Architectures/Cpu/LossFunctions.hxx
+++ b/tmva/tmva/src/DNN/Architectures/Cpu/LossFunctions.hxx
@@ -87,13 +87,20 @@ AFloat TCpu<AFloat>::CrossEntropy(const TCpuMatrix<AFloat> &Y, const TCpuMatrix<
 
    auto f = [&dataY, &dataOutput, &dataWeights, &temp, m](UInt_t workerID) {
       AFloat y   = dataY[workerID];
-      AFloat sig = 1.0 / (1.0 + exp(- dataOutput[workerID]));
-      if (y == 0)
-         temp[workerID] = - log(1.0 - sig);
-      else if ( y == 1.)
-         temp[workerID] = - log(sig);
+      // AFloat sig = 1.0 / (1.0 + exp(- dataOutput[workerID]));
+      // Use more robust formula to compute log(sig) and log(1-sig) where sig= 1./(1+exp(-x))
+      // when sig is close to zero or to 1
+      AFloat x = dataOutput[workerID];
+      AFloat lr = 0;
+      if (x < -75.)
+         lr = -x ;
+      else if (x > 75)
+         lr = exp(-x);
       else
-         temp[workerID] = - (y * log(sig) + (1.0 - y) * log(1.0 - sig));
+         lr = std::log(1. + exp(-x));
+
+      //temp[workerID] = - (y * log(sig) + (1.0 - y) * log(1.0 - sig));
+      temp[workerID] =  y * lr + (1.0 - y) * (x +lr);
 
       temp[workerID] *= dataWeights[workerID % m];
       return 0;

--- a/tmva/tmva/src/DNN/Architectures/Cuda/Kernels.cuh
+++ b/tmva/tmva/src/DNN/Architectures/Cuda/Kernels.cuh
@@ -811,16 +811,14 @@ __global__ void CrossEntropy(AFloat * result,
    __shared__ AFloat sdata[TDevice::BlockSize];
 
    if ((i < m) && (j < n)) {
-       AFloat norm = 1 / ((AFloat) (m * n));
-       AFloat sig  = 1.0 / (1.0 + exp(-output[index]));
-       if (Y[index] == 0)
-          sdata[tid] = -weights[i] * norm * log(1.0 - sig);
-       else if (Y[index] == 1.0)
-          sdata[tid] = -weights[i] * norm * log(sig);
-       else {
-          AFloat ce  = Y[index] * log(sig) + (1.0 - Y[index]) * log(1.0 - sig);
-          sdata[tid] = -weights[i] * norm * ce;
-       }
+      AFloat norm = 1 / ((AFloat) (m * n));
+      AFloat x = output[index]);
+      AFloat lr = std::log(1. + exp(-x));
+      if (x < -75.) lr = -x;
+      else if (x > 75.) lr = exp(-x);
+
+      AFloat ce  = Y[index] * lr + (1.0 - Y[index]) * (x + lr);
+      sdata[tid] = weights[i] * norm * ce;
    } else {
        sdata[tid] = 0.0;
    }


### PR DESCRIPTION
Improve the calculation for the binary cross entropy loss when the inputs are very large (and also very large negative). Use correct log approximation to avoid loss of precisions and returning infinity values.

Fix both the CPU and GPU calculations

This has been initiated by this post https://root-forum.cern.ch/t/when-tmva-comput-loss-some-eopchs-loss-is-inf/57018/ where `inf` loss values were obtained during training