### PR TITLE
Add redundant 'virtual' destructor declarations

### DIFF
--- a/math/mathcore/inc/Math/GaussIntegrator.h
+++ b/math/mathcore/inc/Math/GaussIntegrator.h
@@ -43,7 +43,7 @@ class GaussIntegrator: public VirtualIntegratorOneDim {
 public:
 
    /** Destructor */
-   ~GaussIntegrator() override;
+   virtual ~GaussIntegrator() override;
 
    /** Default Constructor.
        If the tolerance are not given, use default values specified in  ROOT::Math::IntegratorOneDimOptions

--- a/math/mathcore/inc/Math/VirtualIntegrator.h
+++ b/math/mathcore/inc/Math/VirtualIntegrator.h
@@ -103,7 +103,7 @@ class VirtualIntegratorOneDim : public VirtualIntegrator {
 public:
 
    /// destructor: no operation
-   ~VirtualIntegratorOneDim() override {}
+   virtual ~VirtualIntegratorOneDim() override {}
 
    /// evaluate integral
    virtual double Integral(double a, double b) = 0;
@@ -162,7 +162,7 @@ class VirtualIntegratorMultiDim : public VirtualIntegrator {
 public:
 
    /// destructor: no operation
-   ~VirtualIntegratorMultiDim() override {}
+   virtual ~VirtualIntegratorMultiDim() override {}
 
    /// evaluate multi-dim integral
    virtual double Integral(const double*, const double*)  = 0;


### PR DESCRIPTION
This PR adds back 'virtual' destructor declarations for classes derived from ROOT::Math::VirtualIntegrator which themselves contain virtual functions. These were present until recently, and their absence causes undefined behavior, typically a memory leak.

Fast merging would be appreciated if possible. The current code causes a severe memory leak when running the Nieves charged-current quasielastic model in the GENIE neutrino event generator (https://github.com/GENIE-MC/Generator).