### PR TITLE
[webgui] improve handling of embed widgets [6.30]

### DIFF
--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -270,13 +270,12 @@ std::shared_ptr<RWebWindow::WebConn> RWebWindow::FindOrCreateConnection(unsigned
             keyvalue = url.GetValueFromOptions("key");
       }
 
-      if (!keyvalue.empty())
-         for (size_t n = 0; n < fPendingConn.size(); ++n)
-            if (fPendingConn[n]->fKey == keyvalue) {
-               key = std::move(fPendingConn[n]);
-               fPendingConn.erase(fPendingConn.begin() + n);
-               break;
-            }
+      for (size_t n = 0; n < fPendingConn.size(); ++n)
+         if (fPendingConn[n]->fKey == keyvalue) {
+            key = std::move(fPendingConn[n]);
+            fPendingConn.erase(fPendingConn.begin() + n);
+            break;
+         }
 
       if (key) {
          key->fWSId = wsid;

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -591,8 +591,12 @@ unsigned RWebWindowsManager::ShowWindow(RWebWindow &win, const RWebDisplayArgs &
 
    // catch window showing, used by the RBrowser to embed some of ROOT widgets
    if (fShowCallback)
-      if (fShowCallback(win, user_args))
+      if (fShowCallback(win, user_args)) {
+         // add dummy handle to pending connections, widget (like TWebCanvas) may wait until connection established
+         auto handle = std::make_unique<RWebDisplayHandle>("");
+         win.AddDisplayHandle(false, "", handle);
          return 0;
+      }
 
    // place here while involves conn mutex
    auto token = win.GetConnToken();


### PR DESCRIPTION
In RBrowser different widgets are embed.
Add dummy pending connection handle to get possibility for widget wait for such connection been established

