### PR TITLE
[PyROOT] Better way to make C++ namespaces appear as Python modules

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/__init__.py
@@ -11,13 +11,13 @@
 from os import environ
 
 # Prevent cppyy's check for the PCH
-environ['CLING_STANDARD_PCH'] = 'none'
+environ["CLING_STANDARD_PCH"] = "none"
 
 # Prevent cppyy's check for extra header directory
-environ['CPPYY_API_PATH'] = 'none'
+environ["CPPYY_API_PATH"] = "none"
 
 # Prevent cppyy from filtering ROOT libraries
-environ['CPPYY_NO_ROOT_FILTER'] = '1'
+environ["CPPYY_NO_ROOT_FILTER"] = "1"
 
 # Do setup specific to AddressSanitizer environments
 from . import _asan
@@ -29,58 +29,65 @@ import sys, importlib
 import warnings
 
 major, minor = sys.version_info[0:2]
-librootpyz_mod_name = 'libROOTPythonizations{}_{}'.format(major, minor)
+librootpyz_mod_name = "libROOTPythonizations{}_{}".format(major, minor)
 importlib.import_module(librootpyz_mod_name)
 
 # ensure 'import libROOTPythonizations' will find the versioned module
-sys.modules['libROOTPythonizations'] = sys.modules[librootpyz_mod_name]
+sys.modules["libROOTPythonizations"] = sys.modules[librootpyz_mod_name]
 
 # Trigger the addition of the pythonizations
 from ._pythonization import _register_pythonizations
+
 _register_pythonizations()
 
 # Check if we are in the IPython shell
 if major == 3:
     import builtins
 else:
-    import __builtin__ as builtins  
+    import __builtin__ as builtins
 
-_is_ipython = hasattr(builtins, '__IPYTHON__')
+_is_ipython = hasattr(builtins, "__IPYTHON__")
 
 # Configure ROOT facade module
 import sys
 from ._facade import ROOTFacade
+
 sys.modules[__name__] = ROOTFacade(sys.modules[__name__], _is_ipython)
 
 # Configuration for usage from Jupyter notebooks
 if _is_ipython:
     from IPython import get_ipython
+
     ip = get_ipython()
-    if hasattr(ip,"kernel"):
+    if hasattr(ip, "kernel"):
         import JupyROOT
         import JsMVA
 
 # Register cleanup
 import atexit
+
+
 def cleanup():
     # If spawned, stop thread which processes ROOT events
     facade = sys.modules[__name__]
-    if 'app' in facade.__dict__ and hasattr(facade.__dict__['app'], 'process_root_events'):
-        facade.__dict__['app'].keep_polling = False
-        facade.__dict__['app'].process_root_events.join()
+    if "app" in facade.__dict__ and hasattr(facade.__dict__["app"], "process_root_events"):
+        facade.__dict__["app"].keep_polling = False
+        facade.__dict__["app"].process_root_events.join()
 
-    if 'libROOTPythonizations' in sys.modules:
-        backend = sys.modules['libROOTPythonizations']
+    if "libROOTPythonizations" in sys.modules:
+        backend = sys.modules["libROOTPythonizations"]
 
         # Make sure all the objects regulated by PyROOT are deleted and their
         # Python proxies are properly nonified.
         backend.ClearProxiedObjects()
 
         from ROOT import PyConfig
+
         if PyConfig.ShutDown:
             # Hard teardown: run part of the gROOT shutdown sequence.
             # Running it here ensures that it is done before any ROOT libraries
             # are off-loaded, with unspecified order of static object destruction.
             backend.gROOT.EndOfProcessCleanups()
+
 
 atexit.register(cleanup)

--- a/bindings/pyroot/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_facade.py
@@ -28,18 +28,18 @@ class PyROOTConfiguration(object):
 
 class _gROOTWrapper(object):
     """Internal class to manage lookups of gROOT in the facade.
-       This wrapper calls _finalSetup on the facade when it
-       receives a lookup, unless the lookup is for SetBatch.
-       This allows to evaluate the command line parameters
-       before checking if batch mode is on in _finalSetup
+    This wrapper calls _finalSetup on the facade when it
+    receives a lookup, unless the lookup is for SetBatch.
+    This allows to evaluate the command line parameters
+    before checking if batch mode is on in _finalSetup
     """
 
     def __init__(self, facade):
-        self.__dict__['_facade'] = facade
-        self.__dict__['_gROOT'] = gROOT
+        self.__dict__["_facade"] = facade
+        self.__dict__["_gROOT"] = gROOT
 
-    def __getattr__( self, name ):
-        if name != 'SetBatch' and self._facade.__dict__['gROOT'] != self._gROOT:
+    def __getattr__(self, name):
+        if name != "SetBatch" and self._facade.__dict__["gROOT"] != self._gROOT:
             self._facade._finalSetup()
         return getattr(self._gROOT, name)
 
@@ -60,6 +60,7 @@ def _create_rdf_experimental_distributed_module(parent):
         types.ModuleType: The ROOT.RDF.Experimental.Distributed submodule.
     """
     import DistRDF
+
     return DistRDF.create_distributed_module(parent)
 
 
@@ -83,7 +84,7 @@ class ROOTFacade(types.ModuleType):
         # Importing all will be customised later
         self.module.__all__ = []
 
-        self.__doc__  = module.__doc__
+        self.__doc__ = module.__doc__
         self.__name__ = module.__name__
         self.__file__ = module.__file__
 
@@ -91,9 +92,16 @@ class ROOTFacade(types.ModuleType):
         self.gROOT = _gROOTWrapper(self)
 
         # Expose some functionality from CPyCppyy extension module
-        self._cppyy_exports = [ 'nullptr', 'bind_object', 'as_cobject', 'addressof',
-                                'SetMemoryPolicy', 'kMemoryHeuristics', 'kMemoryStrict',
-                                'SetOwnership' ]
+        self._cppyy_exports = [
+            "nullptr",
+            "bind_object",
+            "as_cobject",
+            "addressof",
+            "SetMemoryPolicy",
+            "kMemoryHeuristics",
+            "kMemoryStrict",
+            "SetOwnership",
+        ]
         for name in self._cppyy_exports:
             setattr(self, name, getattr(cppyy_backend, name))
         # For backwards compatibility
@@ -126,7 +134,7 @@ class ROOTFacade(types.ModuleType):
         # address of the object
 
         # addr is the address of the address of the object
-        addr = self.addressof(instance = obj, byref = True)
+        addr = self.addressof(instance=obj, byref=True)
 
         # Create a buffer (LowLevelView) from address
         return CreateBufferFromAddress(addr)
@@ -142,13 +150,15 @@ class ROOTFacade(types.ModuleType):
         except ImportError:
             import builtins as __builtin__  # name change in p3
         _orig_ihook = __builtin__.__import__
+
         def _importhook(name, *args, **kwds):
-            if name[0:5] == 'ROOT.':
+            if name[0:5] == "ROOT.":
                 try:
                     sys.modules[name] = getattr(self, name[5:])
                 except Exception:
                     pass
             return _orig_ihook(name, *args, **kwds)
+
         __builtin__.__import__ = _importhook
 
     def _handle_import_all(self):
@@ -158,10 +168,10 @@ class ROOTFacade(types.ModuleType):
 
         # Get caller module (jump over the facade frames)
         num_frame = 2
-        frame = sys._getframe(num_frame).f_globals['__name__']
-        while frame == 'ROOT._facade':
+        frame = sys._getframe(num_frame).f_globals["__name__"]
+        while frame == "ROOT._facade":
             num_frame += 1
-            frame = sys._getframe(num_frame).f_globals['__name__']
+            frame = sys._getframe(num_frame).f_globals["__name__"]
         caller = sys.modules[frame]
 
         # Install the hook
@@ -176,7 +186,7 @@ class ROOTFacade(types.ModuleType):
         # The first two attempts allow to lookup
         # e.g. ROOT.ROOT.Math as ROOT.Math
 
-        if name == '__all__':
+        if name == "__all__":
             self._handle_import_all()
             # Make the attributes of the facade be injected in the
             # caller module
@@ -194,10 +204,10 @@ class ROOTFacade(types.ModuleType):
 
     def _finalSetup(self):
         # Prevent this method from being re-entered through the gROOT wrapper
-        self.__dict__['gROOT'] = gROOT
+        self.__dict__["gROOT"] = gROOT
 
         # Setup interactive usage from Python
-        self.__dict__['app'] = PyROOTApplication(self.PyConfig, self._is_ipython)
+        self.__dict__["app"] = PyROOTApplication(self.PyConfig, self._is_ipython)
         if not self.gROOT.IsBatch() and self.PyConfig.StartGUIThread:
             self.app.init_graphics()
 
@@ -215,7 +225,7 @@ class ROOTFacade(types.ModuleType):
 
     def _getattr(self, name):
         # Special case, to allow "from ROOT import gROOT" w/o starting the graphics
-        if name == '__path__':
+        if name == "__path__":
             raise AttributeError(name)
 
         self._finalSetup()
@@ -230,9 +240,10 @@ class ROOTFacade(types.ModuleType):
     def _execute_rootlogon_module(self, file_path):
         """Execute the 'rootlogon.py' module found at the given 'file_path'"""
         # Could also have used execfile, but import is likely to give fewer surprises
-        module_name = 'rootlogon'
+        module_name = "rootlogon"
 
         import importlib.util
+
         spec = importlib.util.spec_from_file_location(module_name, file_path)
         module = importlib.util.module_from_spec(spec)
         sys.modules[module_name] = module
@@ -240,11 +251,11 @@ class ROOTFacade(types.ModuleType):
 
     def _run_rootlogon(self):
         # Run custom logon file (must be after creation of ROOT globals)
-        hasargv = hasattr(sys, 'argv')
+        hasargv = hasattr(sys, "argv")
         # -n disables the reading of the logon file, just like with root
-        if hasargv and not '-n' in sys.argv and not self.PyConfig.DisableRootLogon:
-            file_path_home = os.path.expanduser('~/.rootlogon.py')
-            file_path_local = os.path.join(os.getcwd(), '.rootlogon.py')
+        if hasargv and not "-n" in sys.argv and not self.PyConfig.DisableRootLogon:
+            file_path_home = os.path.expanduser("~/.rootlogon.py")
+            file_path_local = os.path.join(os.getcwd(), ".rootlogon.py")
             if os.path.exists(file_path_home):
                 self._execute_rootlogon_module(file_path_home)
             elif os.path.exists(file_path_local):
@@ -253,10 +264,10 @@ class ROOTFacade(types.ModuleType):
                 # If the .py version of rootlogon exists, the .C is ignored (the user can
                 # load the .C from the .py, if so desired).
                 # System logon, user logon, and local logon (skip Rint.Logon)
-                name = '.rootlogon.C'
+                name = ".rootlogon.C"
                 logons = [
-                    os.path.join(str(self.TROOT.GetEtcDir()), 'system' + name),
-                    os.path.expanduser(os.path.join('~', name))
+                    os.path.join(str(self.TROOT.GetEtcDir()), "system" + name),
+                    os.path.expanduser(os.path.join("~", name)),
                 ]
                 if logons[-1] != os.path.join(os.getcwd(), name):
                     logons.append(name)
@@ -304,31 +315,33 @@ class ROOTFacade(types.ModuleType):
     # namespace lazily.
     @property
     def VecOps(self):
-        ns = self._fallback_getattr('VecOps')
+        ns = self._fallback_getattr("VecOps")
         try:
             from libROOTPythonizations import AsRVec
+
             ns.AsRVec = AsRVec
         except:
-            raise Exception('Failed to pythonize the namespace VecOps')
+            raise Exception("Failed to pythonize the namespace VecOps")
         del type(self).VecOps
         return ns
 
     # Overload RDF namespace
     @property
     def RDF(self):
-        ns = self._fallback_getattr('RDF')
+        ns = self._fallback_getattr("RDF")
         try:
             # Inject FromNumpy function
             from libROOTPythonizations import MakeNumpyDataFrame
 
             # Make a copy of the arrays that have strides to make sure we read the correct values
-            # TODO a cleaner fix 
-            def MakeNumpyDataFrameCopy(np_dict):  
-                import numpy  
+            # TODO a cleaner fix
+            def MakeNumpyDataFrameCopy(np_dict):
+                import numpy
+
                 for key in np_dict.keys():
-                    if (np_dict[key].__array_interface__['strides']) is not None:
+                    if (np_dict[key].__array_interface__["strides"]) is not None:
                         np_dict[key] = numpy.copy(np_dict[key])
-                return MakeNumpyDataFrame(np_dict) 
+                return MakeNumpyDataFrame(np_dict)
 
             ns.FromNumpy = MakeNumpyDataFrameCopy
             try:
@@ -337,7 +350,7 @@ class ROOTFacade(types.ModuleType):
             except ImportError:
                 pass
         except:
-            raise Exception('Failed to pythonize the namespace RDF')
+            raise Exception("Failed to pythonize the namespace RDF")
         del type(self).RDF
         return ns
 
@@ -345,37 +358,41 @@ class ROOTFacade(types.ModuleType):
     @property
     def RooFit(self):
         from ._pythonization._roofit import pythonize_roofit_namespace
-        ns = self._fallback_getattr('RooFit')
+
+        ns = self._fallback_getattr("RooFit")
         try:
             pythonize_roofit_namespace(ns)
         except:
-            raise Exception('Failed to pythonize the namespace RooFit')
+            raise Exception("Failed to pythonize the namespace RooFit")
         del type(self).RooFit
         return ns
 
     # Overload TMVA namespace
     @property
     def TMVA(self):
-        #this line is needed to import the pythonizations in _tmva directory
+        # this line is needed to import the pythonizations in _tmva directory
         from ._pythonization import _tmva
-        ns = self._fallback_getattr('TMVA')
+
+        ns = self._fallback_getattr("TMVA")
         hasRDF = "dataframe" in gROOT.GetConfigFeatures()
         if hasRDF:
             try:
                 from ._pythonization._tmva import inject_rbatchgenerator
+
                 inject_rbatchgenerator(ns)
                 from libROOTPythonizations import AsRTensor
+
                 ns.Experimental.AsRTensor = AsRTensor
             except:
-                raise Exception('Failed to pythonize the namespace TMVA')
+                raise Exception("Failed to pythonize the namespace TMVA")
         del type(self).TMVA
         return ns
 
     # Create and overload Numba namespace
     @property
     def Numba(self):
-        cppdef('namespace Numba {}')
-        ns = self._fallback_getattr('Numba')
+        cppdef("namespace Numba {}")
+        ns = self._fallback_getattr("Numba")
         ns.Declare = staticmethod(_NumbaDeclareDecorator)
         del type(self).Numba
         return ns
@@ -383,7 +400,8 @@ class ROOTFacade(types.ModuleType):
     @property
     def NumbaExt(self):
         import numba
-        if not hasattr(numba, 'version_info') or numba.version_info < (0, 54):
+
+        if not hasattr(numba, "version_info") or numba.version_info < (0, 54):
             raise Exception("NumbaExt requires Numba version 0.54 or higher")
 
         import cppyy.numba_ext
@@ -394,7 +412,7 @@ class ROOTFacade(types.ModuleType):
     # Get TPyDispatcher for programming GUI callbacks
     @property
     def TPyDispatcher(self):
-        include('ROOT/TPyDispatcher.h')
+        include("ROOT/TPyDispatcher.h")
         tpd = gbl_namespace.TPyDispatcher
         type(self).TPyDispatcher = tpd
         return tpd

--- a/bindings/pyroot/pythonizations/test/root_module.py
+++ b/bindings/pyroot/pythonizations/test/root_module.py
@@ -1,5 +1,32 @@
 import unittest
 
+# Helper functions for the tests
+
+
+def hasattr_recursive(obj, keys):
+    """
+    Check that a Python object has a nested attribute that can be retrieved by
+    recursively using a given list of keys.
+    """
+    has_first = hasattr(obj, keys[0])
+    if not has_first:
+        return False
+    if len(keys) == 1:
+        return has_first
+    return hasattr_recursive(getattr(obj, keys[0]), keys[1:])
+
+
+def root_module_has(path):
+    """
+    Check if the ROOT module has a certain attribute, that can also be nested.
+    For example:
+
+        root_module_has("RooFit.Experimental")
+    """
+    import ROOT
+
+    return hasattr_recursive(ROOT, path.split("."))
+
 
 class ROOTModule(unittest.TestCase):
     """
@@ -11,48 +38,71 @@ class ROOTModule(unittest.TestCase):
         Test import
         """
         import ROOT
-        self.assertEqual(ROOT.__name__, "ROOT")
 
+        self.assertEqual(ROOT.__name__, "ROOT")
 
     def test_relative_import(self):
         """
         Test relative import
         """
         from ROOT import TH1F
+
         self.assertEqual(TH1F.__name__, "TH1F")
         from ROOT import TH1F as Foo
+
         self.assertEqual(Foo.__name__, "TH1F")
         self.assertEqual(TH1F, Foo)
-
 
     def test_version(self):
         """
         Test __version__ property
         """
         import ROOT
+
         v = ROOT.__version__
         self.assertTrue(type(v) == str)
         self.assertIn("/", v)
         self.assertIn(".", v)
         self.assertEqual(v, ROOT.gROOT.GetVersion())
 
-
     def test_ignore_cmdline_options(self):
         """
         Test module flag to ignore command line options
         """
         import ROOT
+
         self.assertEqual(ROOT.PyConfig.IgnoreCommandLineOptions, True)
         ROOT.PyConfig.IgnoreCommandLineOptions = False
 
     def test_implicit_root_namespace(self):
         """
-        Test importing implicitely from the ROOT namespace
+        Test importing implicitly from the ROOT namespace
         """
         import ROOT
+
         ROOT.RVec
         ROOT.ROOT.RVec
         ROOT.VecOps.RVec
         ROOT.ROOT.VecOps.RVec
         ROOT.EnableImplicitMT()
         ROOT.ROOT.EnableImplicitMT()
+
+    def test_import_nested_submodules(self):
+        """
+        Test that we can correctly import C++ namespaces and other things that
+        should behave like Python modules, including nested cases.
+        """
+        #
+
+        if root_module_has("RDF.Experimental.Distributed"):
+            import ROOT.RDF.Experimental.Distributed
+
+        if root_module_has("Experimental.RNTuple"):
+            from ROOT.Experimental import RNTuple
+
+        if root_module_has("RooFit.Evaluator"):
+            from ROOT.RooFit import Evaluator
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This reimplements the mechanism to provide C++ namespace as Python
modules without replacing the built-in `__import__` function.

Credits to @chrisburr!