### PR TITLE
[ntuple] Throw exception when trying to load out-of-bounds entries

### DIFF
--- a/tree/ntuple/v7/src/RColumn.cxx
+++ b/tree/ntuple/v7/src/RColumn.cxx
@@ -92,6 +92,9 @@ void ROOT::Experimental::Detail::RColumn::Flush()
 void ROOT::Experimental::Detail::RColumn::MapPage(const NTupleSize_t index)
 {
    fPageSource->ReleasePage(fReadPage);
+   // Set fReadPage to an empty page before populating it to prevent double destruction of the previously page in case
+   // the page population fails.
+   fReadPage = RPage();
    fReadPage = fPageSource->PopulatePage(fHandleSource, index);
    R__ASSERT(fReadPage.Contains(index));
 }
@@ -99,6 +102,9 @@ void ROOT::Experimental::Detail::RColumn::MapPage(const NTupleSize_t index)
 void ROOT::Experimental::Detail::RColumn::MapPage(const RClusterIndex &clusterIndex)
 {
    fPageSource->ReleasePage(fReadPage);
+   // Set fReadPage to an empty page before populating it to prevent double destruction of the previously page in case
+   // the page population fails.
+   fReadPage = RPage();
    fReadPage = fPageSource->PopulatePage(fHandleSource, clusterIndex);
    R__ASSERT(fReadPage.Contains(clusterIndex));
 }

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -633,7 +633,9 @@ ROOT::Experimental::Detail::RPageSourceDaos::PopulatePage(ColumnHandle_t columnH
    {
       auto descriptorGuard = GetSharedDescriptorGuard();
       clusterInfo.fClusterId = descriptorGuard->FindClusterId(columnId, globalIndex);
-      R__ASSERT(clusterInfo.fClusterId != kInvalidDescriptorId);
+
+      if (clusterInfo.fClusterId == kInvalidDescriptorId)
+         throw RException(R__FAIL("entry with index " + std::to_string(globalIndex) + " out of bounds"));
 
       const auto &clusterDescriptor = descriptorGuard->GetClusterDescriptor(clusterInfo.fClusterId);
       clusterInfo.fColumnOffset = clusterDescriptor.GetColumnRange(columnId).fFirstElementIndex;
@@ -655,7 +657,9 @@ ROOT::Experimental::Detail::RPageSourceDaos::PopulatePage(ColumnHandle_t columnH
    if (!cachedPage.IsNull())
       return cachedPage;
 
-   R__ASSERT(clusterId != kInvalidDescriptorId);
+   if (clusterId == kInvalidDescriptorId)
+      throw RException(R__FAIL("entry out of bounds"));
+
    RClusterInfo clusterInfo;
    {
       auto descriptorGuard = GetSharedDescriptorGuard();

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -372,7 +372,9 @@ ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageSourceFile::P
    {
       auto descriptorGuard = GetSharedDescriptorGuard();
       clusterInfo.fClusterId = descriptorGuard->FindClusterId(columnId, globalIndex);
-      R__ASSERT(clusterInfo.fClusterId != kInvalidDescriptorId);
+
+      if (clusterInfo.fClusterId == kInvalidDescriptorId)
+         throw RException(R__FAIL("entry with index " + std::to_string(globalIndex) + " out of bounds"));
 
       const auto &clusterDescriptor = descriptorGuard->GetClusterDescriptor(clusterInfo.fClusterId);
       clusterInfo.fColumnOffset = clusterDescriptor.GetColumnRange(columnId).fFirstElementIndex;
@@ -395,7 +397,9 @@ ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageSourceFile::P
    if (!cachedPage.IsNull())
       return cachedPage;
 
-   R__ASSERT(clusterId != kInvalidDescriptorId);
+   if (clusterId == kInvalidDescriptorId)
+      throw RException(R__FAIL("entry out of bounds"));
+
    RClusterInfo clusterInfo;
    {
       auto descriptorGuard = GetSharedDescriptorGuard();

--- a/tree/ntuple/v7/test/ntuple_friends.cxx
+++ b/tree/ntuple/v7/test/ntuple_friends.cxx
@@ -84,9 +84,23 @@ TEST(RPageStorageFriends, Basic)
    EXPECT_DOUBLE_EQ(2.0, viewPt(1));
    EXPECT_DOUBLE_EQ(3.0, viewPt(2));
 
+   try {
+      viewPt(3);
+      FAIL() << "loading a non-existing entry should throw";
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("entry with index 3 out of bounds"));
+   }
+
    EXPECT_DOUBLE_EQ(4.0, viewEta(0));
    EXPECT_DOUBLE_EQ(5.0, viewEta(1));
    EXPECT_DOUBLE_EQ(6.0, viewEta(2));
+
+   try {
+      viewEta(3);
+      FAIL() << "loading a non-existing entry should throw";
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("entry with index 3 out of bounds"));
+   }
 }
 
 

--- a/tree/ntuple/v7/test/ntuple_show.cxx
+++ b/tree/ntuple/v7/test/ntuple_show.cxx
@@ -120,8 +120,12 @@ TEST(RNTupleShow, BasicTypes)
    // clang-format on
    EXPECT_EQ(fString1, os1.str());
 
-   // TODO(jblomer): this should fail to an exception instead
-   EXPECT_DEATH(ntuple2->Show(2), ".*");
+   try {
+      ntuple2->LoadEntry(2);
+      FAIL() << "loading a non-existing entry should throw";
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("entry with index 2 out of bounds"));
+   }
 }
 
 TEST(RNTupleShow, Vectors)

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -79,6 +79,13 @@ TEST(RNTuple, Basics)
    EXPECT_EQ(24.0, *rdPt);
    ntuple->LoadEntry(2);
    EXPECT_EQ(12.0, *rdPt);
+
+   try {
+      ntuple->LoadEntry(3);
+      FAIL() << "loading a non-existing entry should throw";
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("entry with index 3 out of bounds"));
+   }
 }
 
 TEST(RNTuple, Extended)

--- a/tree/ntuple/v7/test/ntuple_storage_daos.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage_daos.cxx
@@ -74,6 +74,13 @@ TEST_F(RPageStorageDaos, Basics)
    EXPECT_EQ(24.0, *rdPt);
    ntuple->LoadEntry(2);
    EXPECT_EQ(12.0, *rdPt);
+
+   try {
+      ntuple->LoadEntry(3);
+      FAIL() << "loading a non-existing entry should throw";
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("entry with index 3 out of bounds"));
+   }
 }
 
 TEST_F(RPageStorageDaos, Extended)


### PR DESCRIPTION
With this PR, a proper exception is thrown when a user tries to load an out-of-bounds RNTuple entry (instead of aborting due to a failed assert statement).
To prevent the `RColumn` destructor from attempting to again clean up the page for the entry that was (potentially) loaded prior to attempting to read the out-bounds entry, `fReadPage` in `RColumn` is reset to a null page before attempting to populate it.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

