### PR TITLE
[RF] RooFit documentation improvements

### DIFF
--- a/roofit/.clang-tidy
+++ b/roofit/.clang-tidy
@@ -19,11 +19,14 @@ Checks: -*,
   ,performance-move-const-arg,
   ,performance-trivially-destructible,
   ,readability-container-size-empty,
+  ,readability-duplicate-include,
+  ,readability-isolate-declaration,
   ,readability-redundant-member-init,
   ,readability-redundant-smartptr-get,
   ,readability-redundant-string-cstr,
   ,readability-redundant-string-init,
   ,readability-static-definition-in-anonymous-namespace,
+  ,readability-string-compare,
   ,readability-uniqueptr-delete-release
 WarningsAsErrors: '*'
 HeaderFilterRegex: ''

--- a/roofit/batchcompute/src/ComputeFunctions.cxx
+++ b/roofit/batchcompute/src/ComputeFunctions.cxx
@@ -55,7 +55,10 @@ __rooglobal__ void computeAddPdf(BatchesHandle batches)
 
 __rooglobal__ void computeArgusBG(BatchesHandle batches)
 {
-   Batch m = batches[0], m0 = batches[1], c = batches[2], p = batches[3];
+   Batch m = batches[0];
+   Batch m0 = batches[1];
+   Batch c = batches[2];
+   Batch p = batches[3];
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
       const double t = m[i] / m0[i];
       const double u = 1 - t * t;
@@ -100,7 +103,10 @@ __rooglobal__ void computeBernstein(BatchesHandle batches)
    }
 
    if (STEP == 1) {
-      double X[bufferSize], _1_X[bufferSize], powX[bufferSize], pow_1_X[bufferSize];
+      double X[bufferSize];
+      double _1_X[bufferSize];
+      double powX[bufferSize];
+      double pow_1_X[bufferSize];
       for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
          powX[i] = pow_1_X[i] = 1.0;
          X[i] = (xData[i] - xmin) / (xmax - xmin);
@@ -133,7 +139,8 @@ __rooglobal__ void computeBernstein(BatchesHandle batches)
       for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
          batches._output[i] = 0.0;
          const double X = (xData[i] - xmin) / (xmax - xmin);
-         double powX = 1.0, pow_1_X = 1.0;
+         double powX = 1.0;
+         double pow_1_X = 1.0;
          for (int k = 1; k <= degree; k++)
             pow_1_X *= 1 - X;
          const double _1_X = 1 / (1 - X);
@@ -154,7 +161,10 @@ __rooglobal__ void computeBernstein(BatchesHandle batches)
 
 __rooglobal__ void computeBifurGauss(BatchesHandle batches)
 {
-   Batch X = batches[0], M = batches[1], SL = batches[2], SR = batches[3];
+   Batch X = batches[0];
+   Batch M = batches[1];
+   Batch SL = batches[2];
+   Batch SR = batches[3];
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
       double arg = X[i] - M[i];
       if (arg < 0)
@@ -167,7 +177,9 @@ __rooglobal__ void computeBifurGauss(BatchesHandle batches)
 
 __rooglobal__ void computeBreitWigner(BatchesHandle batches)
 {
-   Batch X = batches[0], M = batches[1], W = batches[2];
+   Batch X = batches[0];
+   Batch M = batches[1];
+   Batch W = batches[2];
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
       const double arg = X[i] - M[i];
       batches._output[i] = 1 / (arg * arg + 0.25 * W[i] * W[i]);
@@ -176,7 +188,12 @@ __rooglobal__ void computeBreitWigner(BatchesHandle batches)
 
 __rooglobal__ void computeBukin(BatchesHandle batches)
 {
-   Batch X = batches[0], XP = batches[1], SP = batches[2], XI = batches[3], R1 = batches[4], R2 = batches[5];
+   Batch X = batches[0];
+   Batch XP = batches[1];
+   Batch SP = batches[2];
+   Batch XI = batches[3];
+   Batch R1 = batches[4];
+   Batch R2 = batches[5];
    const double r3 = log(2.0);
    const double r6 = exp(-6.0);
    const double r7 = 2 * sqrt(2 * log(2.0));
@@ -192,7 +209,11 @@ __rooglobal__ void computeBukin(BatchesHandle batches)
       if (XI[i] > r6 || XI[i] < -r6)
          r5 = XI[i] / fast_log(r4 + XI[i]);
 
-      double factor = 1, y = X[i] - x1, Yp = XP[i] - x1, yi = r4 - XI[i], rho = R1[i];
+      double factor = 1;
+      double y = X[i] - x1;
+      double Yp = XP[i] - x1;
+      double yi = r4 - XI[i];
+      double rho = R1[i];
       if (X[i] >= x2) {
          factor = -1;
          y = X[i] - x2;
@@ -216,7 +237,11 @@ __rooglobal__ void computeBukin(BatchesHandle batches)
 
 __rooglobal__ void computeCBShape(BatchesHandle batches)
 {
-   Batch M = batches[0], M0 = batches[1], S = batches[2], A = batches[3], N = batches[4];
+   Batch M = batches[0];
+   Batch M0 = batches[1];
+   Batch S = batches[2];
+   Batch A = batches[3];
+   Batch N = batches[4];
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
       const double t = (M[i] - M0[i]) / S[i];
       if ((A[i] > 0 && t >= -A[i]) || (A[i] < 0 && -t >= A[i]))
@@ -240,7 +265,8 @@ __rooglobal__ void computeChebychev(BatchesHandle batches)
    const double xmax = batches.extraArg(nCoef + 1);
 
    if (STEP == 1) {
-      double prev[bufferSize][2], X[bufferSize];
+      double prev[bufferSize][2];
+      double X[bufferSize];
 
       for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
          // set a0-->prev[i][0] and a1-->prev[i][1]
@@ -259,7 +285,9 @@ __rooglobal__ void computeChebychev(BatchesHandle batches)
          }
    } else
       for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
-         double prev0 = 1.0, prev1 = 2 * (xData[i] - 0.5 * (xmax + xmin)) / (xmax - xmin), X = prev1;
+         double prev0 = 1.0;
+         double prev1 = 2 * (xData[i] - 0.5 * (xmax + xmin)) / (xmax - xmin);
+         double X = prev1;
          batches._output[i] = 1.0;
          for (int k = 0; k < nCoef; k++) {
             batches._output[i] += prev1 * batches.extraArg(k);
@@ -296,7 +324,11 @@ __rooglobal__ void computeDeltaFunction(BatchesHandle batches)
 
 __rooglobal__ void computeDstD0BG(BatchesHandle batches)
 {
-   Batch DM = batches[0], DM0 = batches[1], C = batches[2], A = batches[3], B = batches[4];
+   Batch DM = batches[0];
+   Batch DM0 = batches[1];
+   Batch C = batches[2];
+   Batch A = batches[3];
+   Batch B = batches[4];
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
       const double ratio = DM[i] / DM0[i];
       const double arg1 = (DM0[i] - DM[i]) / C[i];
@@ -346,7 +378,10 @@ __rooglobal__ void computeExponentialNeg(BatchesHandle batches)
 
 __rooglobal__ void computeGamma(BatchesHandle batches)
 {
-   Batch X = batches[0], G = batches[1], B = batches[2], M = batches[3];
+   Batch X = batches[0];
+   Batch G = batches[1];
+   Batch B = batches[2];
+   Batch M = batches[3];
    double gamma = -std::lgamma(G[0]);
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
       if (X[i] == M[i])
@@ -437,7 +472,11 @@ __rooglobal__ void computeNegativeLogarithms(BatchesHandle batches)
 
 __rooglobal__ void computeJohnson(BatchesHandle batches)
 {
-   Batch mass = batches[0], mu = batches[1], lambda = batches[2], gamma = batches[3], delta = batches[4];
+   Batch mass = batches[0];
+   Batch mu = batches[1];
+   Batch lambda = batches[2];
+   Batch gamma = batches[3];
+   Batch delta = batches[4];
    const double sqrtTwoPi = std::sqrt(TMath::TwoPi());
    const double massThreshold = batches.extraArg(0);
 
@@ -514,7 +553,9 @@ __rooglobal__ void computeLandau(BatchesHandle batches)
       return u * u * (1 + (a2[0] + a2[1] * u) * u);
    };
 
-   Batch X = batches[0], M = batches[1], S = batches[2];
+   Batch X = batches[0];
+   Batch M = batches[1];
+   Batch S = batches[2];
 
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
       batches._output[i] = (X[i] - M[i]) / S[i];
@@ -542,7 +583,9 @@ __rooglobal__ void computeLandau(BatchesHandle batches)
 
 __rooglobal__ void computeLognormal(BatchesHandle batches)
 {
-   Batch X = batches[0], M0 = batches[1], K = batches[2];
+   Batch X = batches[0];
+   Batch M0 = batches[1];
+   Batch K = batches[2];
    constexpr double rootOf2pi = 2.506628274631000502415765284811;
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
       double lnxOverM0 = fast_log(X[i] / M0[i]);
@@ -557,7 +600,9 @@ __rooglobal__ void computeLognormal(BatchesHandle batches)
 
 __rooglobal__ void computeLognormalStandard(BatchesHandle batches)
 {
-   Batch X = batches[0], M0 = batches[1], K = batches[2];
+   Batch X = batches[0];
+   Batch M0 = batches[1];
+   Batch K = batches[2];
    constexpr double rootOf2pi = 2.506628274631000502415765284811;
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
       double lnxOverM0 = fast_log(X[i]) - M0[i];
@@ -618,7 +663,10 @@ __rooglobal__ void computeNormalizedPdf(BatchesHandle batches)
  */
 __rooglobal__ void computeNovosibirsk(BatchesHandle batches)
 {
-   Batch X = batches[0], P = batches[1], W = batches[2], T = batches[3];
+   Batch X = batches[0];
+   Batch P = batches[1];
+   Batch W = batches[2];
+   Batch T = batches[3];
    constexpr double xi = 2.3548200450309494; // 2 Sqrt( Ln(4) )
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
       double argasinh = 0.5 * xi * T[i];
@@ -639,7 +687,8 @@ __rooglobal__ void computeNovosibirsk(BatchesHandle batches)
 
 __rooglobal__ void computePoisson(BatchesHandle batches)
 {
-   Batch x = batches[0], mean = batches[1];
+   Batch x = batches[0];
+   Batch mean = batches[1];
    bool protectNegative = batches.extraArg(0);
    bool noRounding = batches.extraArg(1);
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
@@ -813,7 +862,10 @@ __rooglobal__ void computeTruthModelCoshBasis(BatchesHandle batches)
 
 __rooglobal__ void computeVoigtian(BatchesHandle batches)
 {
-   Batch X = batches[0], M = batches[1], W = batches[2], S = batches[3];
+   Batch X = batches[0];
+   Batch M = batches[1];
+   Batch W = batches[2];
+   Batch S = batches[3];
    const double invSqrt2 = 0.707106781186547524400844362105;
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
       const double arg = (X[i] - M[i]) * (X[i] - M[i]);

--- a/roofit/doc/developers/roofit_hs3.md
+++ b/roofit/doc/developers/roofit_hs3.md
@@ -29,8 +29,7 @@ can be selected at compile time with the `cmake` flag
 ### Usage
 
 The main class providing import from and export to JSON and YML is the
-`RooJSONFactoryWSTool`. For basic usage, please refer to the
-[class documentation](https://root.cern.ch/doc/master/RooJSONFactoryWSTool_8h.html).
+RooJSONFactoryWSTool.
 
 ### Open-world philosophy
 

--- a/roofit/histfactory/src/ConfigParser.cxx
+++ b/roofit/histfactory/src/ConfigParser.cxx
@@ -37,7 +37,8 @@ namespace {
 
     void AddSubStrings( vector<std::string> & vs, std::string s){
       const std::string delims("\\ ");
-      std::string::size_type begIdx, endIdx;
+      std::string::size_type begIdx;
+      std::string::size_type endIdx;
       begIdx=s.find_first_not_of(delims);
       while(begIdx!=string::npos){
    endIdx=s.find_first_of(delims, begIdx);
@@ -54,7 +55,8 @@ namespace {
       std::vector<std::string> child_vec;
 
       const std::string delims("\\ ");
-      std::string::size_type begIdx, endIdx;
+      std::string::size_type begIdx;
+      std::string::size_type endIdx;
       begIdx=str.find_first_not_of(delims);
       while(begIdx!=string::npos){
    endIdx=str.find_first_of(delims, begIdx);
@@ -360,8 +362,8 @@ HistFactory::Measurement ConfigParser::CreateMeasurementFromDriverNode(TXMLNode 
    TXMLAttr *curAttr = nullptr;
    while ((/**/ curAttr = dynamic_cast<TXMLAttr *>(attribIt()) /**/) != nullptr) {
       // curAttr is guaranteed non-null above
-      const std::string curAttrName(curAttr->GetName() ? curAttr->GetName() : ""),
-         curAttrValue(curAttr->GetValue() ? curAttr->GetValue() : "");
+      const std::string curAttrName(curAttr->GetName() ? curAttr->GetName() : "");
+      const std::string curAttrValue(curAttr->GetValue() ? curAttr->GetValue() : "");
       if (curAttrName.empty()) {
          cxcoutEHF << "Found XML attribute in Measurement with no name.\n";
          // ADD Output Here
@@ -389,9 +391,9 @@ HistFactory::Measurement ConfigParser::CreateMeasurementFromDriverNode(TXMLNode 
    // Then, get the properties of the children nodes
    TXMLNode *child = node->GetChildren();
    while (child != nullptr) {
-      const std::string childName(child->GetName() ? child->GetName() : ""),
-         childNodeName(child->GetNodeName() ? child->GetNodeName() : ""),
-         childText(child->GetText() ? child->GetText() : "");
+      const std::string childName(child->GetName() ? child->GetName() : "");
+      const std::string childNodeName(child->GetNodeName() ? child->GetNodeName() : "");
+      const std::string childText(child->GetText() ? child->GetText() : "");
       if (childNodeName.empty()) {
          cxcoutEHF << "Found XML child node of Measurement with no name\n";
          throw hf_exc();
@@ -445,8 +447,8 @@ HistFactory::Measurement ConfigParser::CreateMeasurementFromDriverNode(TXMLNode 
          attribIt = child->GetAttributes();
          curAttr = nullptr;
          while ((/**/ curAttr = dynamic_cast<TXMLAttr *>(attribIt()) /**/) != nullptr) {
-            const std::string curAttrName(curAttr->GetName() ? curAttr->GetName() : ""),
-               curAttrValue(curAttr->GetValue() ? curAttr->GetValue() : "");
+            const std::string curAttrName(curAttr->GetName() ? curAttr->GetName() : "");
+            const std::string curAttrValue(curAttr->GetValue() ? curAttr->GetValue() : "");
             if (curAttrName.empty()) {
                cxcoutEHF << "Error: Found tag attribute with no name in ConstraintTerm\n";
                throw hf_exc();
@@ -485,8 +487,8 @@ HistFactory::Measurement ConfigParser::CreateMeasurementFromDriverNode(TXMLNode 
          attribIt = child->GetAttributes();
          curAttr = nullptr;
          while ((/**/ curAttr = dynamic_cast<TXMLAttr *>(attribIt()) /**/) != nullptr) {
-            const std::string curAttrName(curAttr->GetName() ? curAttr->GetName() : ""),
-               curAttrValue(curAttr->GetValue() ? curAttr->GetValue() : "");
+            const std::string curAttrName(curAttr->GetName() ? curAttr->GetName() : "");
+            const std::string curAttrValue(curAttr->GetValue() ? curAttr->GetValue() : "");
             if (curAttrName.empty()) {
                cxcoutEHF << "Error: Found tag attribute with no name in ConstraintTerm\n";
                throw hf_exc();

--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -433,8 +433,8 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
     std::vector<string> prodNames;
 
     vector<NormFactor> normList = sample.GetNormFactorList();
-    vector<string> normFactorNames, rangeNames;
-
+    vector<string> normFactorNames;
+    vector<string> rangeNames;
 
     string overallNorm_times_sigmaEpsilon = sample.GetName() + "_" + channel + "_scaleFactors";
     auto sigEps = proto.arg(sigmaEpsilon);
@@ -499,7 +499,8 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
     totSystTermNames.push_back(prefix);
 
     RooArgSet params(prefix.c_str());
-    vector<double> lowVec, highVec;
+    vector<double> lowVec;
+    vector<double> highVec;
 
     std::map<std::string, double>::iterator itconstr;
     for(unsigned int i = 0; i < systList.size(); ++i) {
@@ -793,8 +794,11 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
       proto.Print();
     }
 
-    RooArgSet likelihoodTerms("likelihoodTerms"), constraintTerms("constraintTerms");
-    vector<string> likelihoodTermNames, constraintTermNames, totSystTermNames;
+    RooArgSet likelihoodTerms("likelihoodTerms");
+    RooArgSet constraintTerms("constraintTerms");
+    vector<string> likelihoodTermNames;
+    vector<string> constraintTermNames;
+    vector<string> totSystTermNames;
     // All histogram functions to be multiplied in each sample
     std::vector<std::vector<RooAbsArg*>> allSampleHistFuncs;
     std::vector<RooProduct*> sampleScaleFactors;
@@ -803,7 +807,8 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
     std::vector< pair<const TH1*, std::unique_ptr<TH1>> > statHistPairs; // <nominal, error>
     const std::string statFuncName = "mc_stat_" + channel_name;
 
-    string prefix, range;
+    string prefix;
+    string range;
 
     /////////////////////////////
     // shared parameters

--- a/roofit/histfactory/src/PiecewiseInterpolation.cxx
+++ b/roofit/histfactory/src/PiecewiseInterpolation.cxx
@@ -438,7 +438,8 @@ double PiecewiseInterpolation::analyticalIntegralWN(Int_t code, const RooArgSet*
 
   // old integral, only works for linear and not positive definite
 
-  RooAbsReal *low, *high;
+  RooAbsReal *low;
+  RooAbsReal *high;
   double value(0);
   double nominal(0);
 

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -43,8 +43,8 @@
 /** \class RooJSONFactoryWSTool
 \ingroup roofit
 
-When using `RooFit`, statistical models can be conveniently handled and
-stored as a `RooWorkspace`. However, for the sake of interoperability
+When using \ref Roofitmain, statistical models can be conveniently handled and
+stored as a RooWorkspace. However, for the sake of interoperability
 with other statistical frameworks, and also ease of manipulation, it
 may be useful to store statistical models in text form.
 
@@ -66,8 +66,7 @@ tool = ROOT.RooJSONFactoryWSTool(ws)
 tool.exportJSON("myjson.json")
 ~~~
 
-For more details, consult the tutorial <a
-href="https://root.cern/doc/v626/rf515__hfJSON_8py.html">rf515_hfJSON</a>.
+For more details, consult the tutorial <a href="rf515__hfJSON_8py.html">rf515_hfJSON</a>.
 
 In order to import and export YML files, `ROOT` needs to be compiled
 with the external dependency <a
@@ -77,9 +76,7 @@ to be installed on your system when building `ROOT`.
 The RooJSONFactoryWSTool only knows about a limited set of classes for
 import and export. If import or export of a class you're interested in
 fails, you might need to add your own importer or exporter. Please
-consult the <a
-href="https://github.com/root-project/root/blob/master/roofit/hs3/README.md">README</a>
-to learn how to do that.
+consult the relevant section in the \ref roofit_dev_docs to learn how to do that (\ref roofit_dev_docs_hs3).
 
 You can always get a list of all the available importers and exporters by calling the following functions:
 ~~~ {.py}
@@ -94,7 +91,6 @@ Alternatively, you can generate a LaTeX version of the available importers and e
 tool = ROOT.RooJSONFactoryWSTool(ws)
 tool.writedoc("hs3.tex")
 ~~~
-
 */
 
 constexpr auto hs3VersionTag = "0.1.90";

--- a/roofit/multiprocess/src/Messenger.cxx
+++ b/roofit/multiprocess/src/Messenger.cxx
@@ -291,7 +291,8 @@ void Messenger::test_receive(X2X expected_ping_value, test_rcv_pipes rcv_pipe, s
 {
    X2X handshake = X2X::initial_value;
 
-   std::size_t max_tries = 3, tries = 0;
+   std::size_t max_tries = 3;
+   std::size_t tries = 0;
    bool carry_on = true;
    while (carry_on && (tries++ < max_tries)) {
       try {

--- a/roofit/multiprocess/src/ProcessTimer.cxx
+++ b/roofit/multiprocess/src/ProcessTimer.cxx
@@ -162,7 +162,8 @@ void ProcessTimer::write_file()
 void ProcessTimer::add_metadata(json data)
 {
    if (write_interval) {
-      json j, meta;
+      json j;
+      json meta;
       meta.push_back(std::move(data));
       j["metadata"] = meta;
       std::ofstream file("p_" + to_string((long)ProcessTimer::get_process()) + ".json", ios::app);
@@ -176,7 +177,8 @@ void ProcessTimer::set_write_interval(int write_int)
 {
    write_interval = write_int;
    if (write_interval) {
-      json j, meta;
+      json j;
+      json meta;
       meta["write_interval"] = true;
       j["metadata"] = meta;
       std::ofstream file("p_" + to_string((long)ProcessTimer::get_process()) + ".json", ios::app);

--- a/roofit/roofit/inc/RooJeffreysPrior.h
+++ b/roofit/roofit/inc/RooJeffreysPrior.h
@@ -37,7 +37,6 @@ protected:
 private:
   struct CacheElem : public RooAbsCacheElement {
   public:
-      ~CacheElem() override = default;
       // Payload
       std::unique_ptr<RooAbsPdf> _pdf;
       std::unique_ptr<RooArgSet> _pdfVariables;

--- a/roofit/roofit/inc/RooJohnson.h
+++ b/roofit/roofit/inc/RooJohnson.h
@@ -32,8 +32,6 @@ public:
 
   RooJohnson(const RooJohnson& other, const char* newName = nullptr);
 
-  ~RooJohnson() override = default;
-
   TObject* clone(const char* newname) const override {
     return new RooJohnson(*this,newname);
   }

--- a/roofit/roofit/src/Roo2DKeysPdf.cxx
+++ b/roofit/roofit/src/Roo2DKeysPdf.cxx
@@ -361,7 +361,10 @@ double Roo2DKeysPdf::evaluateFull(double thisX, double thisY) const
 
   double f=0.0;
 
-  double rx2, ry2, zx, zy;
+  double rx2;
+  double ry2;
+  double zx;
+  double zy;
   if( _MirrorAtBoundary )
   {
     for (Int_t j = 0; j < _nEvents; ++j)
@@ -567,7 +570,9 @@ void Roo2DKeysPdf::writeNTupleToFile(char * outputFile, const char * name) const
   RooAbsReal & xArg = (RooAbsReal&)x.arg();
   RooAbsReal & yArg = (RooAbsReal&)y.arg();
 
-  double theX, theY, hx/*, hy*/;
+  double theX;
+  double theY;
+  double hx;
   TString label = name;
   label += " the source data for 2D Keys PDF";
   TTree * _theTree =  new TTree(name, label);

--- a/roofit/roofit/src/RooArgusBG.cxx
+++ b/roofit/roofit/src/RooArgusBG.cxx
@@ -104,7 +104,8 @@ double RooArgusBG::analyticalIntegral(Int_t code, const char* rangeName) const
   double max = (m.max(rangeName) < m0) ? m.max(rangeName) : m0;
   double f1 = (1.-TMath::Power(min/m0,2));
   double f2 = (1.-TMath::Power(max/m0,2));
-  double aLow, aHigh ;
+  double aLow;
+  double aHigh;
   if ( c < 0. ) {
     aLow  = -0.5*m0*m0*(exp(c*f1)*sqrt(f1)/c + 0.5/TMath::Power(-c,1.5)*sqrt(pi)*RooMath::erf(sqrt(-c*f1)));
     aHigh = -0.5*m0*m0*(exp(c*f2)*sqrt(f2)/c + 0.5/TMath::Power(-c,1.5)*sqrt(pi)*RooMath::erf(sqrt(-c*f2)));

--- a/roofit/roofit/src/RooBernstein.cxx
+++ b/roofit/roofit/src/RooBernstein.cxx
@@ -88,7 +88,8 @@ void RooBernstein::selectNormalizationRange(const char* rangeName, bool force)
 
 double RooBernstein::evaluate() const
 {
-  double xmax,xmin;
+  double xmax;
+  double xmin;
   std::tie(xmin, xmax) = _x->getRange(_refRangeName.empty() ? nullptr : _refRangeName.c_str());
   double x = (_x - xmin) / (xmax - xmin); // rescale to [0,1]
   Int_t degree = _coefList.size() - 1; // n+1 polys of degree n
@@ -159,7 +160,8 @@ double RooBernstein::analyticalIntegral(Int_t code, const char* rangeName) const
 {
   R__ASSERT(code==1) ;
 
-  double xmax,xmin;
+  double xmax;
+  double xmin;
   std::tie(xmin, xmax) = _x->getRange(_refRangeName.empty() ? nullptr : _refRangeName.c_str());
 
   const double xlo = (_x.min(rangeName) - xmin) / (xmax - xmin);

--- a/roofit/roofit/src/RooBukinPdf.cxx
+++ b/roofit/roofit/src/RooBukinPdf.cxx
@@ -87,8 +87,14 @@ RooBukinPdf::RooBukinPdf(const RooBukinPdf& other, const char *name):
 double RooBukinPdf::evaluate() const
 {
   const double consts = 2*sqrt(2*log(2.0));
-  double r1=0,r2=0,r3=0,r4=0,r5=0,hp=0;
-  double x1 = 0,x2 = 0;
+  double r1 = 0;
+  double r2 = 0;
+  double r3 = 0;
+  double r4 = 0;
+  double r5 = 0;
+  double hp = 0;
+  double x1 = 0;
+  double x2 = 0;
   double fit_result = 0;
 
   hp=sigp*consts;

--- a/roofit/roofit/src/RooExpPoly.cxx
+++ b/roofit/roofit/src/RooExpPoly.cxx
@@ -255,7 +255,8 @@ double deltaerfi(double x1, double x2)
 
 double RooExpPoly::analyticalIntegral(int /*code*/, const char *rangeName) const
 {
-   const double xmin = _x.min(rangeName), xmax = _x.max(rangeName);
+   const double xmin = _x.min(rangeName);
+   const double xmax = _x.max(rangeName);
    const unsigned sz = _coefList.size();
    if (!sz)
       return xmax - xmin;

--- a/roofit/roofit/src/RooGExpModel.cxx
+++ b/roofit/roofit/src/RooGExpModel.cxx
@@ -203,7 +203,9 @@ namespace {
 /// Approximation of the log of the complex error function
 double logErfC(double xx)
 {
-  double t,z,ans;
+  double t;
+  double z;
+  double ans;
   z=std::abs(xx);
   t=1.0/(1.0+0.5*z);
 
@@ -498,7 +500,8 @@ double RooGExpModel::calcDecayConv(double sign, double tau, double sig, double r
     double expArg1 = sig*sig/(2*tau*tau)-sign*xp/tau ;
     double expArg2 = sig*sig/(2*rtau*rtau)+xp/rtau ;
 
-    double term1, term2 ;
+    double term1;
+    double term2;
     if (expArg1<300) {
       term1 = exp(expArg1) *RooMath::erfc(sig/(root2*tau)-sign*xp/(root2*sig)) ;
     } else {

--- a/roofit/roofit/src/RooIntegralMorph.cxx
+++ b/roofit/roofit/src/RooIntegralMorph.cxx
@@ -285,7 +285,8 @@ double RooIntegralMorph::MorphCacheElem::calcX(double y, bool& ok)
   if (y<0 || y>1) {
     oocoutW(_self,Eval) << "RooIntegralMorph::MorphCacheElem::calcX() WARNING: requested root finding for unphysical CDF value " << y << endl ;
   }
-  double x1,x2 ;
+  double x1;
+  double x2;
 
   double xmax = _x->getMax("cache") ;
   double xmin = _x->getMin("cache") ;
@@ -561,10 +562,13 @@ void RooIntegralMorph::MorphCacheElem::findRange()
   double xmax = _x->getMax("cache") ;
   Int_t nbins = _x->numBins("cache") ;
 
-  double x1,x2 ;
+  double x1;
+  double x2;
   bool ok = true ;
-  double ymin=0.1,yminSave(-1) ;
-  double Xsave(-1),Xlast=xmax ;
+  double ymin = 0.1;
+  double yminSave(-1);
+  double Xsave(-1);
+  double Xlast = xmax;
 
   // Find lowest Y value that can be measured
   // Start at 0.1 and iteratively lower limit by sqrt(10)
@@ -602,7 +606,8 @@ void RooIntegralMorph::MorphCacheElem::findRange()
   // Find highest Y value that can be measured
   // Start at 1 - 0.1 and iteratively lower delta by sqrt(10)
   ok = true ;
-  double deltaymax=0.1, deltaymaxSave(-1) ;
+  double deltaymax = 0.1;
+  double deltaymaxSave(-1);
   Xlast=xmin ;
   while(true) {
     ok &= _rf1->findRoot(x1,xmin,xmax,1-deltaymax) ;

--- a/roofit/roofit/src/RooJohnson.cxx
+++ b/roofit/roofit/src/RooJohnson.cxx
@@ -147,7 +147,8 @@ double RooJohnson::analyticalIntegral(Int_t code, const char* rangeName) const
   double min = -1.E300;
   double max = 1.E300;
   if (kMass <= code && code <= kLambda) {
-    double argMin, argMax;
+    double argMin;
+    double argMax;
 
     if (code == kMass) {
       argMin = (_mass.min(rangeName)-_mu)/_lambda;

--- a/roofit/roofit/src/RooKeysPdf.cxx
+++ b/roofit/roofit/src/RooKeysPdf.cxx
@@ -154,7 +154,9 @@ void RooKeysPdf::LoadDataSet( RooDataSet& data) {
 
   std::vector<Data> tmp;
   tmp.reserve((1 + _mirrorLeft + _mirrorRight) * data.numEntries());
-  double x0 = 0., x1 = 0., x2 = 0.;
+  double x0 = 0.;
+  double x1 = 0.;
+  double x2 = 0.;
   _sumWgt = 0.;
   // read the data set into tmp and accumulate some statistics
   RooRealVar& real = static_cast<RooRealVar&>(data.get()->operator[](_varName));

--- a/roofit/roofit/src/RooLagrangianMorphFunc.cxx
+++ b/roofit/roofit/src/RooLagrangianMorphFunc.cxx
@@ -1380,7 +1380,8 @@ public:
       Matrix inverse(diagMatrix(size(matrix)));
 
       double condition = (double)(invertMatrix(matrix, inverse));
-      double unityDeviation, largestWeight;
+      double unityDeviation;
+      double largestWeight;
       inverseSanity(matrix, inverse, unityDeviation, largestWeight);
       bool weightwarning(largestWeight > morphLargestWeight ? true : false);
       bool unitywarning(unityDeviation > morphUnityDeviation ? true : false);
@@ -2030,7 +2031,8 @@ int RooLagrangianMorphFunc::countSamples(int nprod, int ndec, int nboth)
 
 int RooLagrangianMorphFunc::countSamples(std::vector<RooArgList *> &vertices)
 {
-   RooArgList operators, couplings;
+   RooArgList operators;
+   RooArgList couplings;
    for (auto vertex : vertices) {
       extractOperators(*vertex, operators);
       extractCouplings(*vertex, couplings);
@@ -3013,7 +3015,8 @@ double RooLagrangianMorphFunc::getCondition() const
 std::unique_ptr<RooRatio>
 RooLagrangianMorphFunc::makeRatio(const char *name, const char *title, RooArgList &nr, RooArgList &dr)
 {
-   RooArgList num, denom;
+   RooArgList num;
+   RooArgList denom;
    for (auto it : nr) {
       num.add(*it);
    }

--- a/roofit/roofit/src/RooMomentMorphFuncND.cxx
+++ b/roofit/roofit/src/RooMomentMorphFuncND.cxx
@@ -698,7 +698,8 @@ void RooMomentMorphFuncND::CacheElem::calculateFractions(const RooMomentMorphFun
          } while (RooFit::Detail::nextCombination(xtmp.begin(), xtmp.begin() + iperm, xtmp.end()));
       }
 
-      double origFrac1(0.), origFrac2(0.);
+      double origFrac1(0.);
+      double origFrac2(0.);
       for (int i = 0; i < depth; ++i) {
          double ffrac = 0.;
          for (int j = 0; j < depth; ++j) {

--- a/roofit/roofit/src/RooPolynomial.cxx
+++ b/roofit/roofit/src/RooPolynomial.cxx
@@ -153,7 +153,8 @@ double RooPolynomial::analyticalIntegral(Int_t code, const char *rangeName) cons
 {
    R__ASSERT(code == 1);
 
-   const double xmin = _x.min(rangeName), xmax = _x.max(rangeName);
+   const double xmin = _x.min(rangeName);
+   const double xmax = _x.max(rangeName);
    const unsigned sz = _coefList.size();
    if (!sz)
       return _lowestOrder ? xmax - xmin : 0.0;
@@ -166,7 +167,8 @@ double RooPolynomial::analyticalIntegral(Int_t code, const char *rangeName) cons
 std::string RooPolynomial::buildCallToAnalyticIntegral(Int_t /* code */, const char *rangeName,
                                                        RooFit::Detail::CodeSquashContext &ctx) const
 {
-   const double xmin = _x.min(rangeName), xmax = _x.max(rangeName);
+   const double xmin = _x.min(rangeName);
+   const double xmax = _x.max(rangeName);
    const unsigned sz = _coefList.size();
    if (!sz)
       return std::to_string(_lowestOrder ? xmax - xmin : 0.0);

--- a/roofit/roofitZMQ/res/RooFit_ZMQ/ZeroMQSvc.h
+++ b/roofit/roofitZMQ/res/RooFit_ZMQ/ZeroMQSvc.h
@@ -34,16 +34,10 @@ namespace ZMQ {
 
 struct TimeOutException : std::exception {
    TimeOutException() = default;
-   TimeOutException(const TimeOutException &) = default;
-   ~TimeOutException() = default;
-   TimeOutException &operator=(const TimeOutException &) = default;
 };
 
 struct MoreException : std::exception {
    MoreException() = default;
-   MoreException(const MoreException &) = default;
-   ~MoreException() = default;
-   MoreException &operator=(const MoreException &) = default;
 };
 
 } // namespace ZMQ

--- a/roofit/roofitcore/inc/RooAbsCategoryLValue.h
+++ b/roofit/roofitcore/inc/RooAbsCategoryLValue.h
@@ -31,7 +31,6 @@ public:
   }
   RooAbsCategoryLValue(const char *name, const char *title);
   RooAbsCategoryLValue(const RooAbsCategoryLValue& other, const char* name=nullptr) ;
-  ~RooAbsCategoryLValue() override = default;
 
   // Value modifiers
   ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/inc/RooAddPdf.h
+++ b/roofit/roofitcore/inc/RooAddPdf.h
@@ -147,6 +147,8 @@ private:
 
   void finalizeConstruction();
   void materializeRefCoefNormFromAttribute() const;
+  inline void setRecursiveFraction(bool recursiveFraction) { _recursive = recursiveFraction; }
+  inline void setAllExtendable(bool allExtendable) { _allExtendable = allExtendable; }
 
   ClassDefOverride(RooAddPdf,5) // PDF representing a sum of PDFs
 };

--- a/roofit/roofitcore/inc/RooBinningCategory.h
+++ b/roofit/roofitcore/inc/RooBinningCategory.h
@@ -23,12 +23,10 @@
 class RooBinningCategory : public RooAbsCategory {
 
 public:
-  // Constructors etc.
-  inline RooBinningCategory() { }
+  RooBinningCategory() = default;
   RooBinningCategory(const char *name, const char *title, RooAbsRealLValue& inputVar, const char* binningName=nullptr, const char* catTypeName=nullptr);
   RooBinningCategory(const RooBinningCategory& other, const char *name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooBinningCategory(*this, newname); }
-  ~RooBinningCategory() override;
 
   /// Printing interface (human readable)
   void printMultiline(std::ostream& os, Int_t content, bool verbose=false, TString indent="") const override ;

--- a/roofit/roofitcore/inc/RooCollectionProxy.h
+++ b/roofit/roofitcore/inc/RooCollectionProxy.h
@@ -17,7 +17,7 @@
 /**
 \class RooCollectionProxy
 \ingroup Roofitcore
-RooCollectionProxy is the concrete proxy for RooArgSet or RooArgList objects.
+Concrete proxy for RooArgSet or RooArgList objects.
 A RooCollectionProxy is the general mechanism to store a RooArgSet or RooArgList
 with RooAbsArgs in a RooAbsArg.
 Creating a RooCollectionProxy adds all members of the proxied RooArgSet to the proxy owners

--- a/roofit/roofitcore/inc/RooConstVar.h
+++ b/roofit/roofitcore/inc/RooConstVar.h
@@ -27,7 +27,6 @@ public:
   RooConstVar(const char *name, const char *title, double value);
   RooConstVar(const RooConstVar& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooConstVar(*this,newname); }
-  ~RooConstVar() override = default;
 
   /// Return (constant) value.
   double getValV(const RooArgSet*) const override {

--- a/roofit/roofitcore/inc/RooCustomizer.h
+++ b/roofit/roofitcore/inc/RooCustomizer.h
@@ -39,7 +39,6 @@ public:
   // Constructors, assignment etc
   RooCustomizer(const RooAbsArg& pdf, const RooAbsCategoryLValue& masterCat, RooArgSet& splitLeafListOwned, RooArgSet* splitLeafListAll=nullptr) ;
   RooCustomizer(const RooAbsArg& pdf, const char* name) ;
-  ~RooCustomizer() = default;
 
   /// If flag is true, make customizer own all created components
   void setOwning(bool flag) {

--- a/roofit/roofitcore/inc/RooEffGenContext.h
+++ b/roofit/roofitcore/inc/RooEffGenContext.h
@@ -33,6 +33,11 @@ protected:
    void generateEvent(RooArgSet &theEvent, Int_t remaining) override;
 
 private:
+   inline void initializeEff(RooAbsReal const &eff)
+   {
+      _eff = dynamic_cast<RooAbsReal *>(_cloneSet.find(eff.GetName()));
+   }
+
    RooArgSet _cloneSet;          ///< Internal clone of p.d.f.
    RooAbsReal *_eff;             ///< Pointer to efficiency function
    std::unique_ptr<RooAbsGenContext> _generator; ///< Generator context for p.d.f

--- a/roofit/roofitcore/inc/RooFunctor.h
+++ b/roofit/roofitcore/inc/RooFunctor.h
@@ -48,7 +48,8 @@ public:
   double eval(const double* /*x*/) const ;
   double eval(double  /*x*/) const ;
 
-  RooAbsFunc& binding() { return *_binding ; }
+  inline RooAbsFunc& binding() { return _ownedBinding ? *_ownedBinding : *_binding; }
+  inline RooAbsFunc const& binding() const { return _ownedBinding ? *_ownedBinding : *_binding; }
 
 protected:
 
@@ -63,4 +64,3 @@ protected:
 };
 
 #endif
-

--- a/roofit/roofitcore/inc/RooGenFitStudy.h
+++ b/roofit/roofitcore/inc/RooGenFitStudy.h
@@ -37,7 +37,6 @@ public:
 
   RooGenFitStudy(const char* name=nullptr, const char* title=nullptr) ;
   RooGenFitStudy(const RooGenFitStudy& other) ;
-  ~RooGenFitStudy() override ;
   RooAbsStudy* clone(const char* newname="") const override { return new RooGenFitStudy(newname?newname:GetName(),GetTitle()) ; }
 
   void setGenConfig(const char* pdfName, const char* obsName, const RooCmdArg& arg1={},const RooCmdArg& arg2={},const RooCmdArg& arg3={}) ;
@@ -60,16 +59,16 @@ public:
   RooLinkedList _genOpts ;
   RooLinkedList _fitOpts ;
 
-  RooAbsPdf* _genPdf ; ///<!
+  RooAbsPdf* _genPdf = nullptr; ///<!
   RooArgSet _genObs ; ///<!
-  RooAbsPdf* _fitPdf ; ///<!
+  RooAbsPdf* _fitPdf = nullptr; ///<!
   RooArgSet _fitObs ; ///<!
 
-  RooAbsPdf::GenSpec* _genSpec ; ///<!
-  RooRealVar* _nllVar ; ///<!
-  RooRealVar* _ngenVar ; ///<!
+  RooAbsPdf::GenSpec* _genSpec = nullptr; ///<!
+  RooRealVar* _nllVar = nullptr; ///<!
+  RooRealVar* _ngenVar = nullptr; ///<!
   std::unique_ptr<RooArgSet> _params; ///<!
-  RooArgSet* _initParams; ///<!
+  RooArgSet* _initParams= nullptr; ///<!
 
   ClassDefOverride(RooGenFitStudy,2) // Generate-and-Fit study module
 } ;

--- a/roofit/roofitcore/inc/RooGrid.h
+++ b/roofit/roofitcore/inc/RooGrid.h
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -79,4 +81,4 @@ protected:
 
 #endif
 
-
+/// \endcond

--- a/roofit/roofitcore/inc/RooHistFunc.h
+++ b/roofit/roofitcore/inc/RooHistFunc.h
@@ -123,6 +123,12 @@ protected:
   mutable double _totVolume = 0.0;             ///<! Total volume of space (product of ranges of observables)
   bool _unitNorm = false;                      ///<! Assume contents is unit normalized (for use as pdf cache)
 
+private:
+  inline void initializeOwnedDataHist(std::unique_ptr<RooDataHist> &&dataHist)
+  {
+     _ownedDataHist = std::move(dataHist);
+  }
+
   ClassDefOverride(RooHistFunc,2) // Histogram based function
 };
 

--- a/roofit/roofitcore/inc/RooHistPdf.h
+++ b/roofit/roofitcore/inc/RooHistPdf.h
@@ -153,6 +153,12 @@ private:
   static std::string rooHistIntegralTranslateImpl(int code, RooAbsArg const *klass, RooDataHist const *dataHist,
                                                   const RooArgSet &obs, bool histFuncMode);
 
+private:
+  inline void initializeOwnedDataHist(std::unique_ptr<RooDataHist> &&dataHist)
+  {
+     _ownedDataHist = std::move(dataHist);
+  }
+
   ClassDefOverride(RooHistPdf,4) // Histogram based PDF
 };
 

--- a/roofit/roofitcore/inc/RooMappedCategory.h
+++ b/roofit/roofitcore/inc/RooMappedCategory.h
@@ -85,6 +85,9 @@ protected:
 
   friend class RooMappedCategoryCache;
 
+private:
+  inline void setDefCat(value_type defCat) { _defCat = defCat; }
+
   ClassDefOverride(RooMappedCategory, 2) // Index variable, derived from another index using pattern-matching based mapping
 };
 

--- a/roofit/roofitcore/inc/RooNameReg.h
+++ b/roofit/roofitcore/inc/RooNameReg.h
@@ -26,7 +26,6 @@ class RooNameReg : public TNamed {
 public:
 
   static RooNameReg& instance() ;
-  ~RooNameReg() override;
   const TNamed* constPtr(const char* stringPtr) ;
   /// Return C++ string corresponding to given TNamed pointer.
   inline static const char* constStr(const TNamed* ptr) {

--- a/roofit/roofitcore/inc/RooObjCacheManager.h
+++ b/roofit/roofitcore/inc/RooObjCacheManager.h
@@ -55,7 +55,7 @@ protected:
   bool _allowOptimize ;
   bool _optCacheModeSeen  ;              ///<!
 
-  RooArgSet* _optCacheObservables ;        ///<! current optCacheObservables
+  RooArgSet* _optCacheObservables = nullptr; ///<! current optCacheObservables
 
   static bool _clearObsList ; ///< Clear obslist on sterilize?
 

--- a/roofit/roofitcore/inc/RooProdPdf.h
+++ b/roofit/roofitcore/inc/RooProdPdf.h
@@ -136,7 +136,6 @@ private:
   class CacheElem final : public RooAbsCacheElement {
   public:
     CacheElem() : _isRearranged(false) { }
-    ~CacheElem() override = default;
     // Payload
     RooArgList _partList ;
     RooArgList _numList ;

--- a/roofit/roofitcore/inc/RooPullVar.h
+++ b/roofit/roofitcore/inc/RooPullVar.h
@@ -24,9 +24,8 @@
 class RooPullVar : public RooAbsReal {
 public:
 
-  RooPullVar() ;
+  RooPullVar() = default;
   RooPullVar(const char *name, const char *title, RooRealVar& measurement, RooAbsReal& truth) ;
-  ~RooPullVar() override ;
 
   RooPullVar(const RooPullVar& other, const char *name = nullptr);
   TObject* clone(const char* newname) const override { return new RooPullVar(*this, newname); }

--- a/roofit/roofitcore/inc/RooRealSumPdf.h
+++ b/roofit/roofitcore/inc/RooRealSumPdf.h
@@ -133,6 +133,8 @@ private:
 
   static void setCacheAndTrackHints(RooArgList const& funcList, RooArgSet& trackNodes);
 
+  inline void setExtended(bool extended) { _extended = extended; }
+
   ClassDefOverride(RooRealSumPdf, 5) // PDF constructed from a sum of (non-pdf) functions
 };
 

--- a/roofit/roofitcore/inc/RooRealVarSharedProperties.h
+++ b/roofit/roofitcore/inc/RooRealVarSharedProperties.h
@@ -19,7 +19,7 @@
 \class RooRealVarSharedProperties
 \ingroup Roofitcore
 
-Class RooRealVarSharedProperties is an implementation of RooSharedProperties
+Implementation of RooSharedProperties
 that stores the properties of a RooRealVar that are shared among clones.
 For RooRealVars these are the definitions of the named ranges.
 **/

--- a/roofit/roofitcore/inc/RooStringVar.h
+++ b/roofit/roofitcore/inc/RooStringVar.h
@@ -27,7 +27,6 @@ public:
   RooStringVar(const char *name, const char *title, const char* value, Int_t size=1024) ;
   RooStringVar(const RooStringVar& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooStringVar(*this,newname); }
-  ~RooStringVar() override = default;
 
   // Parameter value and error accessors
   virtual operator TString() {return TString(_string.c_str()); }

--- a/roofit/roofitcore/src/BidirMMapPipe.cxx
+++ b/roofit/roofitcore/src/BidirMMapPipe.cxx
@@ -1070,7 +1070,8 @@ unsigned BidirMMapPipe::recvpages()
 {
     unsigned char pg;
     unsigned retVal = 0;
-    Page *plisthead = nullptr, *plisttail = nullptr;
+    Page *plisthead = nullptr;
+    Page *plisttail = nullptr;
     if (1 == xferraw(m_inpipe, &pg, 1, ::read)) {
         plisthead = plisttail = m_pages[pg];
         // ok, have number of pages
@@ -1140,7 +1141,8 @@ void BidirMMapPipe::feedPageLists(Page* plist)
     // ok, might have to send free pages to other end, and (if we do have to
     // send something to the other end) while we're at it, send any dirty
     // pages which are completely full, too
-    Page *sendlisthead = nullptr, *sendlisttail = nullptr;
+    Page *sendlisthead = nullptr;
+    Page *sendlisttail = nullptr;
     // loop over plist
     while (plist) {
         Page* p = plist;
@@ -1274,7 +1276,8 @@ void BidirMMapPipe::doFlush(bool forcePartialPages)
 {
     assert(!(m_flags & failbit));
     // build a list of pages to flush
-    Page *flushlisthead = nullptr, *flushlisttail = nullptr;
+    Page *flushlisthead = nullptr;
+    Page *flushlisttail = nullptr;
     while (m_dirtylist) {
         Page* p = m_dirtylist;
         if (!forcePartialPages && !p->full()) break;

--- a/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
@@ -476,7 +476,10 @@ double RooAbsAnaConvPdf::analyticalIntegralWN(Int_t code, const RooArgSet *normS
       return getVal(normSet);
 
    // Unpack master code
-   RooArgSet *intCoefSet, *intConvSet, *normCoefSet, *normConvSet;
+   RooArgSet *intCoefSet;
+   RooArgSet *intConvSet;
+   RooArgSet *normCoefSet;
+   RooArgSet *normConvSet;
    _codeReg.retrieve(code - 1, intCoefSet, intConvSet, normCoefSet, normConvSet);
 
    Int_t index(0);

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -144,7 +144,8 @@ RooAbsArg::RooAbsArg(const RooAbsArg &other, const char *name)
 {
 
   // Copy server list by hand
-  bool valueProp, shapeProp ;
+  bool valueProp;
+  bool shapeProp;
   for (const auto server : other._serverList) {
     valueProp = server->_clientListValue.containsByNamePtr(&other);
     shapeProp = server->_clientListShape.containsByNamePtr(&other);
@@ -2468,14 +2469,17 @@ RooAbsArg::makeLegacyIterator(const RooAbsArg::RefCountList_t& list) const {
 
 void RooRefArray::Streamer(TBuffer &R__b)
 {
-   UInt_t R__s, R__c;
+   UInt_t R__s;
+   UInt_t R__c;
    if (R__b.IsReading()) {
 
-      Version_t R__v = R__b.ReadVersion(&R__s, &R__c); if (R__v) { }
+      Version_t R__v = R__b.ReadVersion(&R__s, &R__c);
+      if (R__v) {
+      }
 
       // Make temporary refArray and read that from the streamer
       auto refArray = std::make_unique<TRefArray>();
-      refArray->Streamer(R__b) ;
+      refArray->Streamer(R__b);
       R__b.CheckByteCount(R__s, R__c, refArray->IsA());
 
       // Schedule deferred processing of TRefArray into proxy list
@@ -2483,17 +2487,16 @@ void RooRefArray::Streamer(TBuffer &R__b)
 
    } else {
 
-     R__c = R__b.WriteVersion(RooRefArray::IsA(), true);
+      R__c = R__b.WriteVersion(RooRefArray::IsA(), true);
 
-     // Make a temporary refArray and write that to the streamer
-     TRefArray refArray;
-     for(TObject * tmpObj : *this) {
-       refArray.Add(tmpObj) ;
-     }
+      // Make a temporary refArray and write that to the streamer
+      TRefArray refArray;
+      for (TObject *tmpObj : *this) {
+         refArray.Add(tmpObj);
+      }
 
-     refArray.Streamer(R__b) ;
-     R__b.SetByteCount(R__c, true) ;
-
+      refArray.Streamer(R__b);
+      R__b.SetByteCount(R__c, true);
    }
 }
 

--- a/roofit/roofitcore/src/RooAbsBinning.cxx
+++ b/roofit/roofitcore/src/RooAbsBinning.cxx
@@ -115,13 +115,16 @@ void RooAbsBinning::printValue(ostream &os) const
 
 void RooAbsBinning::Streamer(TBuffer &R__b)
 {
-   UInt_t R__s, R__c;
+   UInt_t R__s;
+   UInt_t R__c;
    if (R__b.IsReading()) {
-      Version_t R__v = R__b.ReadVersion(&R__s, &R__c); if (R__v) { }
-      if (R__v==1) {
-   TObject::Streamer(R__b);
+      Version_t R__v = R__b.ReadVersion(&R__s, &R__c);
+      if (R__v) {
+      }
+      if (R__v == 1) {
+         TObject::Streamer(R__b);
       } else {
-   TNamed::Streamer(R__b);
+         TNamed::Streamer(R__b);
       }
       RooPrintable::Streamer(R__b);
       R__b.CheckByteCount(R__s, R__c, RooAbsBinning::IsA());
@@ -132,4 +135,3 @@ void RooAbsBinning::Streamer(TBuffer &R__b)
       R__b.SetByteCount(R__c, true);
    }
 }
-

--- a/roofit/roofitcore/src/RooAbsCachedPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsCachedPdf.cxx
@@ -379,7 +379,10 @@ double RooAbsCachedPdf::analyticalIntegralWN(int code, const RooArgSet* normSet,
     return getVal(normSet) ;
   }
 
-  RooArgSet *allVars(nullptr),*anaVars(nullptr),*normSet2(nullptr),*dummy(nullptr) ;
+  RooArgSet *allVars(nullptr);
+  RooArgSet *anaVars(nullptr);
+  RooArgSet *normSet2(nullptr);
+  RooArgSet *dummy(nullptr);
   const std::vector<int> codeList = _anaReg.retrieve(code-1,allVars,anaVars,normSet2,dummy) ;
 
   PdfCacheElem* cache = getCache(normSet2?normSet2:anaVars,false) ;

--- a/roofit/roofitcore/src/RooAbsCollection.cxx
+++ b/roofit/roofitcore/src/RooAbsCollection.cxx
@@ -1329,7 +1329,9 @@ void RooAbsCollection::printLatex(std::ostream& ofs, Int_t ncol, const char* opt
 {
   // Count number of rows to print
   Int_t nrow = (Int_t) (size() / ncol + 0.99) ;
-  Int_t i,j,k ;
+  Int_t i;
+  Int_t j;
+  Int_t k;
 
   // Sibling list do not need to print their name as it is supposed to be the same
   TString sibOption ;

--- a/roofit/roofitcore/src/RooAbsData.cxx
+++ b/roofit/roofitcore/src/RooAbsData.cxx
@@ -707,7 +707,8 @@ TH1 *RooAbsData::createHistogram(const char *name, const RooAbsRealLValue& xvar,
   RooLinkedList ownedCmds ;
   RooCmdArg* autoRD = static_cast<RooCmdArg*>(argList.find("AutoRangeData")) ;
   if (autoRD) {
-    double xmin,xmax ;
+    double xmin;
+    double xmax;
     if (!getRange(static_cast<RooRealVar const&>(xvar),xmin,xmax,autoRD->getDouble(0),autoRD->getInt(0))) {
        RooCmdArg* bincmd = static_cast<RooCmdArg*>(RooFit::Binning(autoRD->getInt(1),xmin,xmax).Clone()) ;
        ownedCmds.Add(bincmd) ;
@@ -718,11 +719,12 @@ TH1 *RooAbsData::createHistogram(const char *name, const RooAbsRealLValue& xvar,
   if (yvar) {
     RooCmdArg* autoRDY = static_cast<RooCmdArg*>((static_cast<RooCmdArg*>(argList.find("YVar")))->subArgs().find("AutoRangeData")) ;
     if (autoRDY) {
-      double ymin,ymax ;
-      if (!getRange(static_cast<RooRealVar&>(*yvar),ymin,ymax,autoRDY->getDouble(0),autoRDY->getInt(0))) {
-         RooCmdArg* bincmd = static_cast<RooCmdArg*>(RooFit::Binning(autoRDY->getInt(1),ymin,ymax).Clone()) ;
-         //ownedCmds.Add(bincmd) ;
-         (static_cast<RooCmdArg*>(argList.find("YVar")))->subArgs().Replace(autoRDY,bincmd) ;
+       double ymin;
+       double ymax;
+       if (!getRange(static_cast<RooRealVar &>(*yvar), ymin, ymax, autoRDY->getDouble(0), autoRDY->getInt(0))) {
+        RooCmdArg *bincmd = static_cast<RooCmdArg *>(RooFit::Binning(autoRDY->getInt(1), ymin, ymax).Clone());
+        // ownedCmds.Add(bincmd) ;
+        (static_cast<RooCmdArg *>(argList.find("YVar")))->subArgs().Replace(autoRDY, bincmd);
       }
       delete autoRDY ;
     }
@@ -731,7 +733,8 @@ TH1 *RooAbsData::createHistogram(const char *name, const RooAbsRealLValue& xvar,
   if (zvar) {
     RooCmdArg* autoRDZ = static_cast<RooCmdArg*>((static_cast<RooCmdArg*>(argList.find("ZVar")))->subArgs().find("AutoRangeData")) ;
     if (autoRDZ) {
-      double zmin,zmax ;
+      double zmin;
+      double zmax;
       if (!getRange(static_cast<RooRealVar&>(*zvar),zmin,zmax,autoRDZ->getDouble(0),autoRDZ->getInt(0))) {
          RooCmdArg* bincmd = static_cast<RooCmdArg*>(RooFit::Binning(autoRDZ->getInt(1),zmin,zmax).Clone()) ;
          //ownedCmds.Add(bincmd) ;
@@ -938,7 +941,11 @@ double RooAbsData::corrcov(const RooRealVar &x, const RooRealVar &y, const char*
   if (cutSpec) select = std::make_unique<RooFormula>("select",cutSpec,*get());
 
   // Calculate requested moment
-  double xysum(0),xsum(0),ysum(0),x2sum(0),y2sum(0);
+  double xysum(0);
+  double xsum(0);
+  double ysum(0);
+  double x2sum(0);
+  double y2sum(0);
   const RooArgSet* vars ;
   for(int index= 0; index < numEntries(); index++) {
     vars = get(index) ;
@@ -1092,7 +1099,8 @@ RooRealVar* RooAbsData::rmsVar(const RooRealVar &var, const char* cutSpec, const
   // RMS/(2*Sqrt(N)) which is only valid if the variable has a Gaussian distribution.
 
   // Create RMS value holder
-  std::string name(var.GetName()),title("RMS of ") ;
+  std::string name(var.GetName());
+  std::string title("RMS         of ");
   name += "RMS";
   title += var.GetTitle();
   auto *rms= new RooRealVar(name.c_str(), title.c_str(), 0) ;
@@ -1213,7 +1221,8 @@ RooPlot* RooAbsData::statOn(RooPlot* frame, const char* what, const char *label,
   if (showM) nPar++ ;
 
   // calculate the box's size
-  double dy(0.06), ymin(ymax-nPar*dy);
+  double dy(0.06);
+  double ymin(ymax - nPar * dy);
   if(showLabel) ymin-= dy;
 
   // create the box and set its options
@@ -1233,7 +1242,9 @@ RooPlot* RooAbsData::statOn(RooPlot* frame, const char* what, const char *label,
   meanv->setPlotLabel("Mean") ;
   std::unique_ptr<RooRealVar> rms{rmsVar(*static_cast<RooRealVar*>(frame->getPlotVar()),cutSpec,cutRange)};
   rms->setPlotLabel("RMS") ;
-  std::unique_ptr<TString> rmsText, meanText, NText;
+  std::unique_ptr<TString> rmsText;
+  std::unique_ptr<TString> meanText;
+  std::unique_ptr<TString> NText;
   if (options) {
     rmsText.reset(rms->format(sigDigits,options));
     meanText.reset(meanv->format(sigDigits,options));
@@ -1278,7 +1289,8 @@ TH1 *RooAbsData::fillHistogram(TH1 *hist, const RooArgList &plotVars, const char
   // Check that the plot variables are all actually RooAbsReal's and print a warning if we do not
   // explicitly depend on one of them. Clone any variables that we do not contain directly and
   // redirect them to use our event data.
-  RooArgSet plotClones,localVars;
+  RooArgSet plotClones;
+  RooArgSet localVars;
   for(std::size_t index= 0; index < plotVars.size(); index++) {
     const RooAbsArg *var= plotVars.at(index);
     const RooAbsReal *realVar= dynamic_cast<const RooAbsReal*>(var);
@@ -1964,9 +1976,11 @@ RooPlot* RooAbsData::plotAsymOn(RooPlot* frame, const RooAbsCategoryLValue& asym
   }
 
   // create and fill temporary histograms of this variable for each state
-  std::string hist1Name(GetName()),hist2Name(GetName());
+  std::string hist1Name(GetName());
+  std::string hist2Name(GetName());
   hist1Name += "_plot1";
-  std::unique_ptr<TH1> hist1, hist2;
+  std::unique_ptr<TH1> hist1;
+  std::unique_ptr<TH1> hist2;
   hist2Name += "_plot2";
 
   if (o.bins) {
@@ -1983,7 +1997,8 @@ RooPlot* RooAbsData::plotAsymOn(RooPlot* frame, const RooAbsCategoryLValue& asym
 
   assert(hist1 && hist2);
 
-  std::string cuts1,cuts2 ;
+  std::string cuts1;
+  std::string cuts2;
   if (o.cuts && strlen(o.cuts)) {
     cuts1 = Form("(%s)&&(%s>0)",o.cuts,asymCat.GetName());
     cuts2 = Form("(%s)&&(%s<0)",o.cuts,asymCat.GetName());
@@ -2054,9 +2069,11 @@ RooPlot* RooAbsData::plotEffOn(RooPlot* frame, const RooAbsCategoryLValue& effCa
   }
 
   // create and fill temporary histograms of this variable for each state
-  std::string hist1Name(GetName()),hist2Name(GetName());
+  std::string hist1Name(GetName());
+  std::string hist2Name(GetName());
   hist1Name += "_plot1";
-  std::unique_ptr<TH1> hist1, hist2;
+  std::unique_ptr<TH1> hist1;
+  std::unique_ptr<TH1> hist2;
   hist2Name += "_plot2";
 
   if (o.bins) {
@@ -2073,7 +2090,8 @@ RooPlot* RooAbsData::plotEffOn(RooPlot* frame, const RooAbsCategoryLValue& effCa
 
   assert(hist1 && hist2);
 
-  std::string cuts1,cuts2 ;
+  std::string cuts1;
+  std::string cuts2;
   if (o.cuts && strlen(o.cuts)) {
     cuts1 = Form("(%s)&&(%s==1)",o.cuts,effCat.GetName());
     cuts2 = Form("(%s)&&(%s==0)",o.cuts,effCat.GetName());
@@ -2302,7 +2320,8 @@ void RooAbsData::optimizeReadingWithCaching(RooAbsArg& arg, const RooArgSet& cac
 
 bool RooAbsData::allClientsCached(RooAbsArg* var, const RooArgSet& cacheList)
 {
-  bool ret(true), anyClient(false) ;
+  bool ret(true);
+  bool anyClient(false);
 
   for (const auto client : var->valueClients()) {
     anyClient = true ;

--- a/roofit/roofitcore/src/RooAbsGenContext.cxx
+++ b/roofit/roofitcore/src/RooAbsGenContext.cxx
@@ -185,7 +185,8 @@ RooDataSet *RooAbsGenContext::generate(double nEvents, bool skipInit, bool exten
   if (_verbose) Print("v") ;
 
   // create a new dataset
-  TString name(GetName()),title(GetTitle());
+  TString name(GetName());
+  TString title(GetTitle());
   name.Append("Data");
   title.Prepend("Generated From ");
 

--- a/roofit/roofitcore/src/RooAbsMCStudyModule.cxx
+++ b/roofit/roofitcore/src/RooAbsMCStudyModule.cxx
@@ -19,7 +19,7 @@
 \class RooAbsMCStudyModule
 \ingroup Roofitcore
 
-RooAbsMCStudyModule is a base class for add-on modules to RooMCStudy that
+Base class for add-on modules to RooMCStudy that
 can perform additional calculations on each generate+fit cycle managed
 by RooMCStudy.
 

--- a/roofit/roofitcore/src/RooAbsNumGenerator.cxx
+++ b/roofit/roofitcore/src/RooAbsNumGenerator.cxx
@@ -19,7 +19,7 @@
 \class RooAbsNumGenerator
 \ingroup Roofitcore
 
-Class RooAbsNumGenerator is the abstract base class for MC event generator
+Abstract base class for MC event generator
 implementations like RooAcceptReject and RooFoam
 **/
 

--- a/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
@@ -367,7 +367,8 @@ RooAbsOptTestStatistic::~RooAbsOptTestStatistic()
 double RooAbsOptTestStatistic::combinedValue(RooAbsReal** array, Int_t n) const
 {
   // Default implementation returns sum of components
-  double sum(0), carry(0);
+  double sum(0);
+  double carry(0);
   for (Int_t i = 0; i < n; ++i) {
     double y = array[i]->getValV();
     carry += reinterpret_cast<RooAbsOptTestStatistic*>(array[i])->getCarry();

--- a/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
@@ -19,7 +19,7 @@
 \class RooAbsOptTestStatistic
 \ingroup Roofitcore
 
-RooAbsOptTestStatistic is the abstract base class for test
+Abstract base class for test
 statistics objects that evaluate a function or PDF at each point of a given
 dataset.  This class provides generic optimizations, such as
 caching and precalculation of constant terms that can be made for

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -2458,7 +2458,8 @@ RooPlot* RooAbsPdf::plotOn(RooPlot* frame, RooLinkedList& cmdList) const
 
     if (frame->getFitRangeNEvt() && stype==Relative) {
 
-      bool hasCustomRange(false), adjustNorm(false) ;
+      bool hasCustomRange(false);
+      bool adjustNorm(false);
 
       std::vector<pair<double,double> > rangeLim;
 
@@ -2771,7 +2772,8 @@ RooPlot* RooAbsPdf::paramOn(RooPlot* frame, const RooArgSet& params, bool showCo
 
   // calculate the box's size, adjusting for constant parameters
 
-  double ymin(ymax), dy(0.06);
+  double ymin(ymax);
+  double dy(0.06);
   for (const auto param : params) {
     auto var = static_cast<RooRealVar*>(param);
     if(showConstants || !var->isConstant()) ymin-= dy;

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -506,7 +506,7 @@ RooFit::OwningPtr<RooAbsReal> RooAbsReal::createProfile(const RooArgSet& paramsO
 ///
 /// \note The integral over a PDF is usually not normalised (*i.e.*, it is usually not
 /// 1 when integrating the PDF over the full range). In fact, this integral is used *to compute*
-/// the normalisation of each PDF. See the rf110 tutorial at https://root.cern.ch/doc/master/group__tutorial__roofit.html
+/// the normalisation of each PDF. See the [rf110 tutorial](group__tutorial__roofit.html)
 /// for details on PDF normalisation.
 ///
 /// The following named arguments are accepted
@@ -520,8 +520,6 @@ RooFit::OwningPtr<RooAbsReal> RooAbsReal::createIntegral(const RooArgSet& iset, 
                    const RooCmdArg& arg3, const RooCmdArg& arg4, const RooCmdArg& arg5,
                    const RooCmdArg& arg6, const RooCmdArg& arg7, const RooCmdArg& arg8) const
 {
-
-
   // Define configuration for this method
   RooCmdConfig pc("RooAbsReal::createIntegral(" + std::string(GetName()) + ")");
   pc.defineString("rangeName","RangeWithName",0,"",true) ;

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -1037,7 +1037,9 @@ TH1 *RooAbsReal::fillHistogram(TH1 *hist, const RooArgList &plotVars,
   cxcoutD(Plotting) << "RooAbsReal::fillHistogram(" << GetName() << ") plot projection object is " << projected->GetName() << std::endl ;
 
   // Prepare to loop over the histogram bins
-  Int_t xbins(0),ybins(1),zbins(1);
+  Int_t xbins(0);
+  Int_t ybins(1);
+  Int_t zbins(1);
   RooRealVar *xvar = nullptr;
   RooRealVar *yvar = nullptr;
   RooRealVar *zvar = nullptr;
@@ -1081,7 +1083,9 @@ TH1 *RooAbsReal::fillHistogram(TH1 *hist, const RooArgList &plotVars,
   // Loop over the input histogram's bins and fill each one with our projection's
   // value, calculated at the center.
   RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CollectErrors) ;
-  Int_t xbin(0),ybin(0),zbin(0);
+  Int_t xbin(0);
+  Int_t ybin(0);
+  Int_t zbin(0);
   Int_t bins= xbins*ybins*zbins;
   for(Int_t bin= 0; bin < bins; bin++) {
     switch(hdim) {
@@ -2399,7 +2403,8 @@ RooPlot* RooAbsReal::plotAsymOn(RooPlot *frame, const RooAbsCategoryLValue& asym
   std::unique_ptr<RooAbsReal> funcNeg{static_cast<RooAbsReal*>(custNeg.build())};
 
   // Create projection integral
-  RooArgSet *posProjCompList, *negProjCompList ;
+  RooArgSet *posProjCompList;
+  RooArgSet *negProjCompList;
 
   // Add projDataVars to normalized dependents of projection
   // This is needed only for asymmetries (why?)
@@ -2814,7 +2819,8 @@ RooPlot* RooAbsReal::plotOnWithErrorBand(RooPlot* frame,const RooFitResult& fr, 
       }
     }
 
-    std::vector<RooCurve*> plusVar, minusVar ;
+    std::vector<RooCurve *> plusVar;
+    std::vector<RooCurve *> minusVar;
 
     // Create std::vector of plus,minus variations for each parameter
 

--- a/roofit/roofitcore/src/RooAbsRealLValue.cxx
+++ b/roofit/roofitcore/src/RooAbsRealLValue.cxx
@@ -251,7 +251,8 @@ RooPlot* RooAbsRealLValue::frame(const RooLinkedList& cmdList) const
   }
 
   // Extract values from named arguments
-  double xmin(getMin()),xmax(getMax()) ;
+  double xmin(getMin());
+  double xmax(getMax());
   if (pc.hasProcessed("Range")) {
     xmin = pc.getDouble("min") ;
     xmax = pc.getDouble("max") ;

--- a/roofit/roofitcore/src/RooAbsTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsTestStatistic.cxx
@@ -176,7 +176,8 @@ double RooAbsTestStatistic::evaluate() const
     if (_mpinterl == RooFit::BulkPartition || _mpinterl == RooFit::Interleave ) {
       ret = combinedValue(reinterpret_cast<RooAbsReal**>(const_cast<std::unique_ptr<RooAbsTestStatistic>*>(_gofArray.data())),_gofArray.size());
     } else {
-      double sum = 0., carry = 0.;
+      double sum = 0.;
+      double carry = 0.;
       int i = 0;
       for (auto& gof : _gofArray) {
         if (i % _numSets == _setNum || (_mpinterl==RooFit::Hybrid && gof->_mpinterl != RooFit::SimComponents )) {
@@ -207,8 +208,8 @@ double RooAbsTestStatistic::evaluate() const
     // Start calculations in parallel
     for (Int_t i = 0; i < _nCPU; ++i) _mpfeArray[i]->calculate();
 
-
-    double sum(0), carry = 0.;
+    double sum(0);
+    double carry = 0.;
     for (Int_t i = 0; i < _nCPU; ++i) {
       double y = _mpfeArray[i]->getValV();
       carry += _mpfeArray[i]->getCarry();
@@ -230,7 +231,9 @@ double RooAbsTestStatistic::evaluate() const
   } else {
 
     // Evaluate as straight FUNC
-    Int_t nFirst(0), nLast(_nEvents), nStep(1) ;
+    Int_t nFirst(0);
+    Int_t nLast(_nEvents);
+    Int_t nStep(1);
 
     switch (_mpinterl) {
     case RooFit::BulkPartition:

--- a/roofit/roofitcore/src/RooAcceptReject.cxx
+++ b/roofit/roofitcore/src/RooAcceptReject.cxx
@@ -19,7 +19,7 @@
 \class RooAcceptReject
 \ingroup Roofitcore
 
-Class RooAcceptReject is a generic toy monte carlo generator implement
+Generic Monte Carlo toy generator implement
 the accept/reject sampling technique on any positively valued function.
 The RooAcceptReject generator is used by the various generator context
 classes to take care of generation of observables for which p.d.fs

--- a/roofit/roofitcore/src/RooAddModel.cxx
+++ b/roofit/roofitcore/src/RooAddModel.cxx
@@ -280,7 +280,8 @@ RooResolutionModel* RooAddModel::convolution(RooFormulaVar* inBasis, RooAbsArg* 
 
 Int_t RooAddModel::basisCode(const char* name) const
 {
-  bool first(true), code(false) ;
+  bool first(true);
+  bool code(false);
   for (auto obj : _pdfList) {
     auto model = static_cast<RooResolutionModel*>(obj);
     Int_t subCode = model->basisCode(name) ;

--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -160,7 +160,7 @@ RooAddPdf::RooAddPdf(const char *name, const char *title, const RooArgList &inPd
                      bool recursiveFractions)
    : RooAddPdf(name, title)
 {
-  _recursive = recursiveFractions;
+  setRecursiveFraction(recursiveFractions);
 
   if (inPdfList.size()>inCoefList.size()+1 || inPdfList.size()<inCoefList.size()) {
     std::stringstream errorMsg;
@@ -257,7 +257,7 @@ RooAddPdf::RooAddPdf(const char *name, const char *title, const RooArgList &inPd
 RooAddPdf::RooAddPdf(const char *name, const char *title, const RooArgList &inPdfList)
    : RooAddPdf(name, title)
 {
-  _allExtendable = true;
+  setAllExtendable(true);
 
   // Constructor with N PDFs
   for (const auto pdfArg : inPdfList) {

--- a/roofit/roofitcore/src/RooBinning.cxx
+++ b/roofit/roofitcore/src/RooBinning.cxx
@@ -190,7 +190,8 @@ void RooBinning::binNumbers(double const * x, int * bins, std::size_t n, int coe
 
 double RooBinning::nearestBoundary(double x) const
 {
-  double xl, xh;
+  double xl;
+  double xh;
   if (binEdges(binNumber(x), xl, xh)) return 0;
   return (std::abs(xl - x) < std::abs(xh - x)) ? xl : xh;
 }
@@ -265,7 +266,8 @@ bool RooBinning::binEdges(Int_t bin, double& xlo, double& xhi) const
 
 double RooBinning::binCenter(Int_t bin) const
 {
-  double xlo, xhi;
+  double xlo;
+  double xhi;
   if (binEdges(bin, xlo, xhi)) return 0;
   return 0.5 * (xlo + xhi);
 }
@@ -275,7 +277,8 @@ double RooBinning::binCenter(Int_t bin) const
 
 double RooBinning::binWidth(Int_t bin) const
 {
-  double xlo, xhi;
+  double xlo;
+  double xhi;
   if (binEdges(bin, xlo, xhi)) return 0;
   return (xhi - xlo);
 }
@@ -285,7 +288,8 @@ double RooBinning::binWidth(Int_t bin) const
 
 double RooBinning::binLow(Int_t bin) const
 {
-  double xlo, xhi;
+  double xlo;
+  double xhi;
   if (binEdges(bin, xlo, xhi)) return 0;
   return xlo;
 }
@@ -295,7 +299,8 @@ double RooBinning::binLow(Int_t bin) const
 
 double RooBinning::binHigh(Int_t bin) const
 {
-  double xlo, xhi;
+  double xlo;
+  double xhi;
   if (binEdges(bin, xlo, xhi)) return  0;
   return xhi;
 }
@@ -307,8 +312,10 @@ void RooBinning::Streamer(TBuffer &R__b)
 {
    if (R__b.IsReading()) {
 
-     UInt_t R__s, R__c;
-     Version_t R__v = R__b.ReadVersion(&R__s, &R__c); if (R__v) { }
+    UInt_t R__s;
+    UInt_t R__c;
+    Version_t R__v = R__b.ReadVersion(&R__s, &R__c);
+    if (R__v) { }
      switch (R__v) {
        case 3:
     // current version - fallthrough intended

--- a/roofit/roofitcore/src/RooBinning.cxx
+++ b/roofit/roofitcore/src/RooBinning.cxx
@@ -19,7 +19,7 @@
 \class RooBinning
 \ingroup Roofitcore
 
-Class RooBinning is an implements RooAbsBinning in terms
+Implements a RooAbsBinning in terms
 of an array of boundary values, posing no constraints on the choice
 of binning, thus allowing variable bin sizes. Various methods allow
 the user to add single bin boundaries, mirrored pairs, or sets of
@@ -42,7 +42,6 @@ uniformly spaced boundaries.
 using namespace std;
 
 ClassImp(RooBinning);
-;
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooBinningCategory.cxx
+++ b/roofit/roofitcore/src/RooBinningCategory.cxx
@@ -19,7 +19,7 @@
 \class RooBinningCategory
 \ingroup Roofitcore
 
-Class RooBinningCategory provides a real-to-category mapping defined
+Provides a real-to-category mapping defined
 by a series of thresholds. It evaluates the value of `inputVar` passed in the
 constructor, and converts this into a bin number using a binning defined for
 the inputVar. The name of this binning is passed in the constructor.
@@ -31,11 +31,7 @@ the inputVar. The name of this binning is passed in the constructor.
 #include "Riostream.h"
 #include "RooStreamParser.h"
 
-using namespace std;
-
 ClassImp(RooBinningCategory);
-
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor with input function to be mapped and name and index of default
@@ -46,7 +42,6 @@ RooBinningCategory::RooBinningCategory(const char *name, const char *title, RooA
   RooAbsCategory(name, title), _inputVar("inputVar","Input category",this,inputVar), _bname(binningName)
 {
   initialize(catTypeName) ;
-
 }
 
 
@@ -59,18 +54,6 @@ RooBinningCategory::RooBinningCategory(const RooBinningCategory& other, const ch
 {
 }
 
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Destructor
-
-RooBinningCategory::~RooBinningCategory()
-{
-}
-
-
-
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Iterator over all bins in input variable and define corresponding state labels
 
@@ -78,7 +61,7 @@ void RooBinningCategory::initialize(const char* catTypeName)
 {
   const int nbins = _inputVar->getBinning(_bname.Length() > 0 ? _bname.Data() : nullptr).numBins();
   for (Int_t i=0 ; i<nbins ; i++) {
-    string name = catTypeName!=nullptr ? Form("%s%d",catTypeName,i)
+    std::string name = catTypeName!=nullptr ? Form("%s%d",catTypeName,i)
             : (_bname.Length()>0 ? Form("%s_%s_bin%d",_inputVar.arg().GetName(),_bname.Data(),i)
             : Form("%s_bin%d",_inputVar.arg().GetName(),i)) ;
     defineState(name,i);
@@ -96,7 +79,7 @@ RooAbsCategory::value_type RooBinningCategory::evaluate() const
   Int_t ibin = _inputVar->getBin(_bname.Length() > 0 ? _bname.Data() : nullptr);
 
   if (!hasIndex(ibin)) {
-    string name = (_bname.Length()>0) ? Form("%s_%s_bin%d",_inputVar.arg().GetName(),_bname.Data(),ibin)
+    std::string name = (_bname.Length()>0) ? Form("%s_%s_bin%d",_inputVar.arg().GetName(),_bname.Data(),ibin)
                                  : Form("%s_bin%d",_inputVar.arg().GetName(),ibin) ;
     const_cast<RooBinningCategory*>(this)->defineState(name,ibin);
   }
@@ -115,15 +98,13 @@ RooAbsCategory::value_type RooBinningCategory::evaluate() const
 ///     Shape : default value
 ///   Verbose : list of thresholds
 
-void RooBinningCategory::printMultiline(ostream& os, Int_t content, bool verbose, TString indent) const
+void RooBinningCategory::printMultiline(std::ostream& os, Int_t content, bool verbose, TString indent) const
 {
    RooAbsCategory::printMultiline(os,content,verbose,indent);
 
    if (verbose) {
-     os << indent << "--- RooBinningCategory ---" << endl
+     os << indent << "--- RooBinningCategory ---" << std::endl
    << indent << "  Maps from " ;
      _inputVar.arg().printStream(os,kName|kValue,kSingleLine);
    }
 }
-
-

--- a/roofit/roofitcore/src/RooBrentRootFinder.cxx
+++ b/roofit/roofitcore/src/RooBrentRootFinder.cxx
@@ -61,7 +61,8 @@ bool RooBrentRootFinder::findRoot(double &result, double xlo, double xhi, double
 {
   _function->saveXVec() ;
 
-  double a(xlo),b(xhi);
+  double a(xlo);
+  double b(xhi);
   double fa= (*_function)(&a) - value;
   double fb= (*_function)(&b) - value;
   if(fb*fa > 0) {
@@ -72,7 +73,9 @@ bool RooBrentRootFinder::findRoot(double &result, double xlo, double xhi, double
 
   bool ac_equal(false);
   double fc= fb;
-  double c(0),d(0),e(0);
+  double c(0);
+  double d(0);
+  double e(0);
   for(Int_t iter= 0; iter <= MaxIterations; iter++) {
 
     if ((fb < 0 && fc < 0) || (fb > 0 && fc > 0)) {
@@ -112,7 +115,9 @@ bool RooBrentRootFinder::findRoot(double &result, double xlo, double xhi, double
     }
     else {
       // Attempt inverse cubic interpolation
-      double p, q, r;
+      double p;
+      double q;
+      double r;
       double s = fb / fa;
 
       if (ac_equal) {

--- a/roofit/roofitcore/src/RooCacheManager.cxx
+++ b/roofit/roofitcore/src/RooCacheManager.cxx
@@ -19,7 +19,7 @@
 \class RooCacheManager
 \ingroup Roofitcore
 
-Template class RooCacheManager manages the storage of any type of data indexed on
+Manages the storage of any type of data indexed on
 the choice of normalization and optionally the set of integrated observables.
 The purpose of this class is to facilitate storage of intermediate results
 in operator p.d.f.s whose value and inner working are often highly dependent
@@ -33,7 +33,6 @@ recognized and will all point to the same normalization list. Lists
 for up to 'maxSize' different normalization/ projection
 configurations can be cached.
 **/
-//
 
 #include "RooCacheManager.h"
 

--- a/roofit/roofitcore/src/RooCachedPdf.cxx
+++ b/roofit/roofitcore/src/RooCachedPdf.cxx
@@ -14,7 +14,7 @@
 \class RooCachedPdf
 \ingroup Roofitcore
 
-RooCachedPdf is an implementation of RooAbsCachedPdf that can cache
+Implementation of RooAbsCachedPdf that can cache
 any external RooAbsPdf input function provided in the constructor.
 **/
 

--- a/roofit/roofitcore/src/RooCachedReal.cxx
+++ b/roofit/roofitcore/src/RooCachedReal.cxx
@@ -14,7 +14,7 @@
 \class RooCachedReal
 \ingroup Roofitcore
 
-RooCachedReal is an implementation of RooAbsCachedReal that can cache
+Implementation of RooAbsCachedReal that can cache
 any external RooAbsReal input function provided in the constructor.
 **/
 

--- a/roofit/roofitcore/src/RooCategory.cxx
+++ b/roofit/roofitcore/src/RooCategory.cxx
@@ -431,7 +431,8 @@ bool RooCategory::isStateInRange(const char* rangeName, const char* stateName) c
 
 void RooCategory::Streamer(TBuffer &R__b)
 {
-  UInt_t R__s, R__c;
+  UInt_t R__s;
+  UInt_t R__c;
   if (R__b.IsReading()) {
 
     Version_t R__v = R__b.ReadVersion(&R__s, &R__c);

--- a/roofit/roofitcore/src/RooChi2Var.cxx
+++ b/roofit/roofitcore/src/RooChi2Var.cxx
@@ -180,7 +180,8 @@ RooChi2Var::RooChi2Var(const RooChi2Var& other, const char* name) :
 
 double RooChi2Var::evaluatePartition(std::size_t firstEvent, std::size_t lastEvent, std::size_t stepSize) const
 {
-  double result(0), carry(0);
+  double result(0);
+  double carry(0);
 
   // Determine normalization factor depending on type of input function
   double normFactor(1) ;
@@ -206,9 +207,10 @@ double RooChi2Var::evaluatePartition(std::size_t firstEvent, std::size_t lastEve
 
     double eInt ;
     if (_etype != RooAbsData::Expected) {
-      double eIntLo,eIntHi ;
-      hdata->weightError(eIntLo,eIntHi,_etype) ;
-      eInt = (eExt>0) ? eIntHi : eIntLo ;
+       double eIntLo;
+       double eIntHi;
+       hdata->weightError(eIntLo, eIntHi, _etype);
+       eInt = (eExt > 0) ? eIntHi : eIntLo;
     } else {
       eInt = sqrt(nPdf) ;
     }

--- a/roofit/roofitcore/src/RooChi2Var.cxx
+++ b/roofit/roofitcore/src/RooChi2Var.cxx
@@ -17,7 +17,7 @@
 //////////////////////////////////////////////////////////////////////////////
 /** \class RooChi2Var
     \ingroup Roofitcore
-    \brief RooChi2Var implements a simple \f$ \chi^2 \f$ calculation from a binned dataset and a PDF.
+    \brief Simple \f$ \chi^2 \f$ calculation from a binned dataset and a PDF.
  *
  * It calculates:
  *

--- a/roofit/roofitcore/src/RooClassFactory.cxx
+++ b/roofit/roofitcore/src/RooClassFactory.cxx
@@ -126,7 +126,8 @@ bool makeAndCompileClass(std::string const &baseClassName, std::string const &na
 
    infosVec.emplace_back(info);
 
-   std::string realArgNames, catArgNames;
+   std::string realArgNames;
+   std::string catArgNames;
    for (RooAbsArg *arg : vars) {
       if (dynamic_cast<RooAbsReal *>(arg)) {
          if (!realArgNames.empty())

--- a/roofit/roofitcore/src/RooCmdConfig.cxx
+++ b/roofit/roofitcore/src/RooCmdConfig.cxx
@@ -20,12 +20,12 @@
 \class RooCmdConfig
 \ingroup Roofitcore
 
-Class RooCmdConfig is a configurable parser for RooCmdArg named
+Configurable parser for RooCmdArg named
 arguments. It maps the contents of named arguments named to integers,
 doubles, strings and TObjects that can be retrieved after processing
 a set of RooCmdArgs. The parser also has options to enforce syntax
 rules such as (conditionally) required arguments, mutually exclusive
-arguments and dependencies between arguments
+arguments and dependencies between arguments.
 **/
 
 #include <RooCmdConfig.h>

--- a/roofit/roofitcore/src/RooCompositeDataStore.cxx
+++ b/roofit/roofitcore/src/RooCompositeDataStore.cxx
@@ -19,7 +19,7 @@
 \class RooCompositeDataStore
 \ingroup Roofitcore
 
-RooCompositeDataStore combines several disjunct datasets into one. This is useful for simultaneous PDFs
+Combines several disjunct datasets into one. This is useful for simultaneous PDFs
 that do not depend on the same observable such as a PDF depending on `x` combined with another one depending
 on `y`.
 The composite storage will store two different datasets, `{x}` and `{y}`, but they can be passed as a single

--- a/roofit/roofitcore/src/RooConstVar.cxx
+++ b/roofit/roofitcore/src/RooConstVar.cxx
@@ -19,16 +19,13 @@
 \class RooConstVar
 \ingroup Roofitcore
 
-RooConstVar represent a constant real-valued object
+Represents a constant real-valued object.
 **/
 
 #include "RooConstVar.h"
 #include "RooNumber.h"
 
-using namespace std;
-
 ClassImp(RooConstVar);
-
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -54,7 +51,7 @@ RooConstVar::RooConstVar(const RooConstVar& other, const char* name) :
 ////////////////////////////////////////////////////////////////////////////////
 /// Write object contents to stream
 
-void RooConstVar::writeToStream(ostream& os, bool /*compact*/) const
+void RooConstVar::writeToStream(std::ostream& os, bool /*compact*/) const
 {
   os << _value ;
 }

--- a/roofit/roofitcore/src/RooConvCoefVar.cxx
+++ b/roofit/roofitcore/src/RooConvCoefVar.cxx
@@ -19,7 +19,7 @@
 \class RooConvCoefVar
 \ingroup Roofitcore
 
-RooConvCoefVar is an auxiliary class that represents the coefficient
+Auxiliary class that represents the coefficient
 of a RooAbsAnaConvPdf implementation as a separate RooAbsReal object
 to be able to interface these coefficient terms with the generic
 RooRealIntegral integration mechanism.

--- a/roofit/roofitcore/src/RooCurve.cxx
+++ b/roofit/roofitcore/src/RooCurve.cxx
@@ -19,7 +19,7 @@
 \class RooCurve
 \ingroup Roofitcore
 
-A RooCurve is a one-dimensional graphical representation of a real-valued function.
+One-dimensional graphical representation of a real-valued function.
 A curve is approximated by straight line segments with end points chosen to give
 a "good" approximation to the true curve. The goodness of the approximation is
 controlled by a precision and a resolution parameter.

--- a/roofit/roofitcore/src/RooCurve.cxx
+++ b/roofit/roofitcore/src/RooCurve.cxx
@@ -184,17 +184,20 @@ RooCurve::RooCurve(const char* name, const char* title, const RooCurve& c1, cons
 
   // Make deque of points in X
   deque<double> pointList ;
-  double x,y ;
+  double x;
+  double y;
 
   // Add X points of C1
-  Int_t i1,n1 = c1.GetN() ;
+  Int_t i1;
+  Int_t n1 = c1.GetN();
   for (i1=0 ; i1<n1 ; i1++) {
     c1.GetPoint(i1,x,y) ;
     pointList.push_back(x) ;
   }
 
   // Add X points of C2
-  Int_t i2,n2 = c2.GetN() ;
+  Int_t i2;
+  Int_t n2 = c2.GetN();
   for (i2=0 ; i2<n2 ; i2++) {
     c2.GetPoint(i2,x,y) ;
     pointList.push_back(x) ;
@@ -337,7 +340,8 @@ void RooCurve::addPoints(const RooAbsFunc &func, double xlo, double xhi,
 
   // store points of the coarse scan and calculate any refinements necessary
   double minDx= resolution*(xhi-xlo);
-  double x1,x2= xlo;
+  double x1;
+  double x2 = xlo;
 
   if (wmode==Extended) {
     // Add two points to make curve jump from 0 to yval at the left end of the plotting range.
@@ -523,11 +527,18 @@ void RooCurve::printMultiline(ostream& os, Int_t /*contents*/, bool /*verbose*/,
 
 double RooCurve::chiSquare(const RooHist& hist, Int_t nFitParam) const
 {
-  Int_t i,np = hist.GetN() ;
-  double x,y,eyl,eyh,exl,exh ;
+  Int_t i;
+  Int_t np = hist.GetN();
+  double x;
+  double y;
+  double eyl;
+  double eyh;
+  double exl;
+  double exh;
 
   // Find starting and ending bin of histogram based on range of RooCurve
-  double xstart,xstop ;
+  double xstart;
+  double xstop;
 
   GetPoint(0,xstart,y) ;
   GetPoint(GetN()-1,xstop,y) ;
@@ -584,7 +595,10 @@ double RooCurve::average(double xFirst, double xLast) const
   // Find first and last mid points
   Int_t ifirst = findPoint(xFirst,1e10) ;
   Int_t ilast  = findPoint(xLast,1e10) ;
-  double xFirstPt,yFirstPt,xLastPt,yLastPt ;
+  double xFirstPt;
+  double yFirstPt;
+  double xLastPt;
+  double yLastPt;
   GetPoint(ifirst,xFirstPt,yFirstPt) ;
   GetPoint(ilast,xLastPt,yLastPt) ;
 
@@ -609,7 +623,11 @@ double RooCurve::average(double xFirst, double xLast) const
     const_cast<RooCurve&>(*this).GetPoint(ilast,xLastPt,yLastPt) ;
   }
 
-  double sum(0),x1,y1,x2,y2 ;
+  double sum(0);
+  double x1;
+  double y1;
+  double x2;
+  double y2;
 
   // Trapezoid integration from lower edge to first midpoint
   sum += (xFirstPt-xFirst)*(yFirst+yFirstPt)/2 ;
@@ -635,8 +653,11 @@ double RooCurve::average(double xFirst, double xLast) const
 
 Int_t RooCurve::findPoint(double xvalue, double tolerance) const
 {
-  double delta(std::numeric_limits<double>::max()),x,y ;
-  Int_t i,n = GetN() ;
+  double delta(std::numeric_limits<double>::max());
+  double x;
+  double y;
+  Int_t i;
+  Int_t n = GetN();
   Int_t ibest(-1) ;
   for (i=0 ; i<n ; i++) {
     GetPoint(i,x,y);
@@ -662,7 +683,8 @@ double RooCurve::interpolate(double xvalue, double tolerance) const
   int ibest = findPoint(xvalue,1e10) ;
 
   // Get position of best point
-  double xbest, ybest ;
+  double xbest;
+  double ybest;
   const_cast<RooCurve*>(this)->GetPoint(ibest,xbest,ybest) ;
 
   // Handle trivial case of being dead on
@@ -671,7 +693,9 @@ double RooCurve::interpolate(double xvalue, double tolerance) const
   }
 
   // Get nearest point on other side w.r.t. xvalue
-  double xother,yother, retVal(0) ;
+  double xother;
+  double yother;
+  double retVal(0);
   if (xbest<xvalue) {
     if (ibest==n-1) {
       // Value beyond end requested -- return value of last point
@@ -783,7 +807,8 @@ RooCurve* RooCurve::makeErrorBand(const vector<RooCurve*>& plusVar, const vector
 
 void RooCurve::calcBandInterval(const vector<RooCurve*>& plusVar, const vector<RooCurve*>& minusVar,Int_t i, const TMatrixD& C, double /*Z*/, double& lo, double& hi) const
 {
-  vector<double> y_plus(plusVar.size()), y_minus(minusVar.size()) ;
+  vector<double> y_plus(plusVar.size());
+  vector<double> y_minus(minusVar.size());
   Int_t j(0) ;
   for (vector<RooCurve*>::const_iterator iter=plusVar.begin() ; iter!=plusVar.end() ; ++iter) {
     y_plus[j++] = (*iter)->interpolate(GetX()[i]) ;
@@ -829,7 +854,8 @@ void RooCurve::calcBandInterval(const vector<RooCurve*>& variations,Int_t i,doub
     hi = y[y.size()-delta] ;
   } else {
     // Estimate R.M.S of variations at each point and use that as Gaussian sigma
-    double sum_y(0), sum_ysq(0) ;
+    double sum_y(0);
+    double sum_ysq(0);
     for (unsigned int k=0 ; k<y.size() ; k++) {
       sum_y   += y[k] ;
       sum_ysq += y[k]*y[k] ;
@@ -854,7 +880,10 @@ bool RooCurve::isIdentical(const RooCurve& other, double tol, bool verbose) cons
 {
   // Determine X range and Y range
   Int_t n= min(GetN(),other.GetN());
-  double xmin(1e30), xmax(-1e30), ymin(1e30), ymax(-1e30) ;
+  double xmin(1e30);
+  double xmax(-1e30);
+  double ymin(1e30);
+  double ymax(-1e30);
   for(Int_t i= 0; i < n; i++) {
     if (fX[i]<xmin) xmin=fX[i] ;
     if (fX[i]>xmax) xmax=fX[i] ;

--- a/roofit/roofitcore/src/RooCustomizer.cxx
+++ b/roofit/roofitcore/src/RooCustomizer.cxx
@@ -613,7 +613,8 @@ void RooCustomizer::printMultiline(ostream& os, Int_t /*content*/, bool /*verbos
 {
   os << indent << "RooCustomizer for " << _masterPdf->GetName() << (_sterile?" (sterile)":"") << endl ;
 
-  Int_t i, nsplit = _splitArgList.GetSize() ;
+  Int_t i;
+  Int_t nsplit = _splitArgList.GetSize();
   if (nsplit>0) {
     os << indent << "  Splitting rules:" << endl ;
     for (i=0 ; i<nsplit ; i++) {

--- a/roofit/roofitcore/src/RooDLLSignificanceMCSModule.cxx
+++ b/roofit/roofitcore/src/RooDLLSignificanceMCSModule.cxx
@@ -19,7 +19,7 @@
 \class RooDLLSignificanceMCSModule
 \ingroup Roofitcore
 
-RooDLLSignificanceMCSModule is an add-on modules to RooMCStudy that
+Add-on module to RooMCStudy that
 calculates the significance of a signal by comparing the likelihood of
 a fit fit with a given parameter floating with a fit with that given
 parameter fixed to a nominal value (usually zero). The difference in

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -387,7 +387,9 @@ void RooDataHist::importTH1(const RooArgList& vars, const TH1& histo, double wgt
   RooRealVar* zvar = static_cast<RooRealVar*>(vars.at(2) ? _vars.find(vars.at(2)->GetName()) : nullptr ) ;
 
   // Transfer contents
-  Int_t xmin(0),ymin(0),zmin(0) ;
+  Int_t xmin(0);
+  Int_t ymin(0);
+  Int_t zmin(0);
   RooArgSet vset(*xvar) ;
   xmin = offset[0] ;
   if (yvar) {
@@ -399,7 +401,9 @@ void RooDataHist::importTH1(const RooArgList& vars, const TH1& histo, double wgt
     zmin = offset[2] ;
   }
 
-  Int_t ix(0),iy(0),iz(0) ;
+  Int_t ix(0);
+  Int_t iy(0);
+  Int_t iz(0);
   for (ix=0 ; ix < xvar->getBins() ; ix++) {
     xvar->setBin(ix) ;
     if (yvar) {
@@ -541,7 +545,9 @@ void RooDataHist::importTH1Set(const RooArgList& vars, RooCategory& indexCat, st
   RooRealVar* zvar = static_cast<RooRealVar*>(vars.at(2) ? _vars.find(vars.at(2)->GetName()) : nullptr ) ;
 
   // Transfer contents
-  Int_t xmin(0),ymin(0),zmin(0) ;
+  Int_t xmin(0);
+  Int_t ymin(0);
+  Int_t zmin(0);
   RooArgSet vset(*xvar) ;
   double volume = xvar->getMax()-xvar->getMin() ;
   xmin = offset[0] ;
@@ -557,7 +563,10 @@ void RooDataHist::importTH1Set(const RooArgList& vars, RooCategory& indexCat, st
   }
   double avgBV = volume / numEntries() ;
 
-  Int_t ic(0),ix(0),iy(0),iz(0) ;
+  Int_t ic(0);
+  Int_t ix(0);
+  Int_t iy(0);
+  Int_t iz(0);
   for (ic=0 ; ic < icat->numBins(nullptr) ; ic++) {
     icat->setBin(ic) ;
     histo = hmap[icat->getCurrentLabel()] ;
@@ -593,62 +602,63 @@ void RooDataHist::importTH1Set(const RooArgList& vars, RooCategory& indexCat, st
 /// in the constructed RooDataHist. The stl map provides the mapping between the indexCat state labels
 /// and the import source
 
-void RooDataHist::importDHistSet(const RooArgList& /*vars*/, RooCategory& indexCat, std::map<std::string,RooDataHist*> dmap, double initWgt)
+void RooDataHist::importDHistSet(const RooArgList & /*vars*/, RooCategory &indexCat,
+                                 std::map<std::string, RooDataHist *> dmap, double initWgt)
 {
-  auto* icat = static_cast<RooCategory*>(_vars.find(indexCat.GetName()));
+   auto *icat = static_cast<RooCategory *>(_vars.find(indexCat.GetName()));
 
-  RooDataHist* dhistForBinning = nullptr;
+   RooDataHist *dhistForBinning = nullptr;
 
-  for (const auto& diter : dmap) {
+   for (const auto &diter : dmap) {
 
-    std::string const& label = diter.first;
-    RooDataHist* dhist = diter.second ;
+      std::string const &label = diter.first;
+      RooDataHist *dhist = diter.second;
 
-    if(!dhistForBinning) {
-      dhistForBinning = dhist;
-    }
-    else {
-      if(!hasConsistentLayoutAndBinning(*dhistForBinning, *dhist)) {
-        coutE(InputArguments) << "Layout or binning of histogram " << dhist->GetName() << " is not consistent with first processed "
-            << "histogram " << dhistForBinning->GetName() << std::endl;
-        throw std::invalid_argument("Layout or binning of inputs for RooDataHist is inconsistent");
+      if (!dhistForBinning) {
+         dhistForBinning = dhist;
+      } else {
+         if (!hasConsistentLayoutAndBinning(*dhistForBinning, *dhist)) {
+            coutE(InputArguments) << "Layout or binning of histogram " << dhist->GetName()
+                                  << " is not consistent with first processed "
+                                  << "histogram " << dhistForBinning->GetName() << std::endl;
+            throw std::invalid_argument("Layout or binning of inputs for RooDataHist is inconsistent");
+         }
       }
-    }
 
-    // Define state labels in index category (both in provided indexCat and in internal copy in dataset)
-    if (!indexCat.hasLabel(label)) {
-      indexCat.defineType(label) ;
-      coutI(InputArguments) << "RooDataHist::importDHistSet(" << GetName() << ") defining state \"" << label << "\" in index category " << indexCat.GetName() << endl ;
-    }
-    if (!icat->hasLabel(label)) {
-      icat->defineType(label) ;
-    }
-  }
+      // Define state labels in index category (both in provided indexCat and in internal copy in dataset)
+      if (!indexCat.hasLabel(label)) {
+         indexCat.defineType(label);
+         coutI(InputArguments) << "RooDataHist::importDHistSet(" << GetName() << ") defining state \"" << label
+                               << "\" in index category " << indexCat.GetName() << endl;
+      }
+      if (!icat->hasLabel(label)) {
+         icat->defineType(label);
+      }
+   }
 
-  // adjust the binning of the created histogram
-  for(auto * theirVar : dynamic_range_cast<RooRealVar*>(dhistForBinning->_vars)) {
-    auto * ourVar = dynamic_cast<RooRealVar*>(_vars.find(theirVar->GetName()));
-    if(!theirVar || !ourVar) continue;
-    ourVar->setBinning(theirVar->getBinning());
-  }
+   // adjust the binning of the created histogram
+   for (auto *theirVar : dynamic_range_cast<RooRealVar *>(dhistForBinning->_vars)) {
+      auto *ourVar = dynamic_cast<RooRealVar *>(_vars.find(theirVar->GetName()));
+      if (!theirVar || !ourVar)
+         continue;
+      ourVar->setBinning(theirVar->getBinning());
+   }
 
-  initialize() ;
-  appendToDir(this,true) ;
+   initialize();
+   appendToDir(this, true);
 
+   for (const auto &diter : dmap) {
+      std::string const &label = diter.first;
+      RooDataHist *dhist = diter.second;
 
-  for (const auto& diter : dmap) {
-    std::string const& label = diter.first;
-    RooDataHist* dhist = diter.second ;
+      icat->setLabel(label.c_str());
 
-    icat->setLabel(label.c_str()) ;
-
-    // Transfer contents
-    for (Int_t i=0 ; i<dhist->numEntries() ; i++) {
-      _vars.assign(*dhist->get(i)) ;
-      add(_vars,dhist->weight()*initWgt, pow(dhist->weightError(SumW2),2) ) ;
-    }
-
-  }
+      // Transfer contents
+      for (Int_t i = 0; i < dhist->numEntries(); i++) {
+         _vars.assign(*dhist->get(i));
+         add(_vars, dhist->weight() * initWgt, pow(dhist->weightError(SumW2), 2));
+      }
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -657,16 +667,17 @@ void RooDataHist::importDHistSet(const RooArgList& /*vars*/, RooCategory& indexC
 void RooDataHist::_adjustBinning(RooRealVar &theirVar, const TAxis &axis,
     RooRealVar *ourVar, Int_t *offset)
 {
-   const std::string ourVarName(ourVar->GetName() ? ourVar->GetName() : ""), ownName(GetName() ? GetName() : "");
-   // RooRealVar is derived from RooAbsRealLValue which is itself
-   // derived from RooAbsReal and a virtual class RooAbsLValue
-   // supplying setter functions, check if ourVar is indeed derived
-   // as real
-   if (!dynamic_cast<RooAbsReal *>(ourVar)) {
-      coutE(InputArguments) << "RooDataHist::adjustBinning(" << ownName << ") ERROR: dimension " << ourVarName
-                            << " must be real\n";
-      throw std::logic_error("Incorrect type object (" + ourVarName +
-                             ") passed as argument to RooDataHist::_adjustBinning. Please report this issue.");
+  const std::string ourVarName(ourVar->GetName() ? ourVar->GetName() : "");
+  const std::string ownName(GetName() ? GetName() : "");
+  // RooRealVar is derived from RooAbsRealLValue which is itself
+  // derived from RooAbsReal and a virtual class RooAbsLValue
+  // supplying setter functions, check if ourVar is indeed derived
+  // as real
+  if (!dynamic_cast<RooAbsReal *>(ourVar)) {
+    coutE(InputArguments) << "RooDataHist::adjustBinning(" << ownName << ") ERROR: dimension " << ourVarName
+                          << " must be real\n";
+    throw std::logic_error("Incorrect type object (" + ourVarName +
+                           ") passed as argument to RooDataHist::_adjustBinning. Please report this issue.");
    }
 
   const double xlo = theirVar.getMin();
@@ -832,7 +843,9 @@ void RooDataHist::initialize(const char* binningName, bool fillTree)
   // Calculate plot bins of components from master index
 
   for (Int_t ibin=0 ; ibin < _arrSize ; ibin++) {
-    Int_t j(0), idx(0), tmp(ibin) ;
+    Int_t j(0);
+    Int_t idx(0);
+    Int_t tmp(ibin);
     double theBinVolume(1) ;
     for (auto arg2 : _lvvars) {
       idx  = tmp / _idxMult[j] ;
@@ -921,7 +934,8 @@ std::unique_ptr<RooAbsData> RooDataHist::reduceEng(const RooArgSet& varSubset, c
     cloneVar->attachDataSet(*this) ;
   }
 
-  double lo,hi ;
+  double lo;
+  double hi;
   const std::size_t nevt = nStop < static_cast<std::size_t>(numEntries()) ? nStop : static_cast<std::size_t>(numEntries());
   for (auto i=nStart; i<nevt ; i++) {
     const RooArgSet* row = get(i) ;
@@ -1581,7 +1595,8 @@ void RooDataHist::weightError(double& lo, double& hi, ErrorType etype) const
     initializeAsymErrArrays();
 
     // Calculate poisson errors
-    double ym,yp ;
+    double ym;
+    double yp;
     RooHistError::instance().getPoissonInterval(Int_t(weight()+0.5),ym,yp,1) ;
     _errLo[_curIndex] = weight()-ym;
     _errHi[_curIndex] = yp-weight();
@@ -2076,7 +2091,8 @@ const std::vector<double>& RooDataHist::calculatePartialBinVolume(const RooArgSe
 
   // Recalculate partial bin volume cache
   for (Int_t ibin=0; ibin < _arrSize ;ibin++) {
-    Int_t idx(0), tmp(ibin) ;
+    Int_t idx(0);
+    Int_t tmp(ibin);
     double theBinVolume(1) ;
     for (unsigned int j=0; j < _lvvars.size(); ++j) {
       const RooAbsLValue* arg = _lvvars[j];
@@ -2318,7 +2334,8 @@ void RooDataHist::printDataHistogram(ostream& os, RooRealVar* obs) const
 void RooDataHist::Streamer(TBuffer &R__b) {
   if (R__b.IsReading()) {
 
-    UInt_t R__s, R__c;
+    UInt_t R__s;
+    UInt_t R__c;
     Version_t R__v = R__b.ReadVersion(&R__s, &R__c);
 
     if (R__v > 2) {
@@ -2333,7 +2350,8 @@ void RooDataHist::Streamer(TBuffer &R__b) {
       // new-style RooAbsData base class
 
       // --- This is the contents of the streamer code of RooTreeData version 2 ---
-      UInt_t R__s1, R__c1;
+      UInt_t R__s1;
+      UInt_t R__c1;
       Version_t R__v1 = R__b.ReadVersion(&R__s1, &R__c1); if (R__v1) { }
 
       RooAbsData::Streamer(R__b);

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -19,7 +19,7 @@
 \class RooDataHist
 \ingroup Roofitcore
 
-The RooDataHist is a container class to hold N-dimensional binned data. Each bin's central
+Container class to hold N-dimensional binned data. Each bin's central
 coordinates in N-dimensional space are represented by a RooArgSet containing RooRealVar, RooCategory
 or RooStringVar objects, thus data can be binned in real and/or discrete dimensions.
 

--- a/roofit/roofitcore/src/RooDataHistSliceIter.cxx
+++ b/roofit/roofitcore/src/RooDataHistSliceIter.cxx
@@ -19,9 +19,8 @@
 \class RooDataHistSliceIter
 \ingroup Roofitcore
 
-RooDataHistSliceIter iterates over all bins in a RooDataHist that
-occur in a slice defined by the bin coordinates of the input
-sliceSet.
+Iterates over all bins in a RooDataHist that occur in a slice defined by the
+bin coordinates of the input sliceSet.
 **/
 
 #include "RooDataHist.h"
@@ -29,12 +28,7 @@ sliceSet.
 #include "RooAbsLValue.h"
 #include "RooDataHistSliceIter.h"
 
-using namespace std;
-
 ClassImp(RooDataHistSliceIter);
-;
-
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Construct an iterator over all bins of RooDataHist 'hist' in the slice defined

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -1413,7 +1413,9 @@ RooPlot* RooDataSet::plotOnXY(RooPlot* frame, const RooCmdArg& arg1, const RooCm
     double x = xvar->getVal() ;
     double exlo = xvar->getErrorLo() ;
     double exhi = xvar->getErrorHi() ;
-    double y,eylo,eyhi ;
+    double y;
+    double eylo;
+    double eyhi;
     if (!dataY) {
       y = weight() ;
       weightError(eylo,eyhi) ;
@@ -1802,48 +1804,53 @@ void RooDataSet::Streamer(TBuffer &R__b)
 {
    if (R__b.IsReading()) {
 
-     UInt_t R__s, R__c;
-     Version_t R__v = R__b.ReadVersion(&R__s, &R__c);
+      UInt_t R__s;
+      UInt_t R__c;
+      Version_t R__v = R__b.ReadVersion(&R__s, &R__c);
 
-     if (R__v>1) {
+      if (R__v > 1) {
 
-       // Use new-style streaming for version >1
-       R__b.ReadClassBuffer(RooDataSet::Class(),this,R__v,R__s,R__c);
+         // Use new-style streaming for version >1
+         R__b.ReadClassBuffer(RooDataSet::Class(), this, R__v, R__s, R__c);
 
-     } else {
+      } else {
 
-       // Legacy dataset conversion happens here. Legacy RooDataSet inherits from RooTreeData
-       // which in turn inherits from RooAbsData. Manually stream RooTreeData contents on
-       // file here and convert it into a RooTreeDataStore which is installed in the
-       // new-style RooAbsData base class
+         // Legacy dataset conversion happens here. Legacy RooDataSet inherits from RooTreeData
+         // which in turn inherits from RooAbsData. Manually stream RooTreeData contents on
+         // file here and convert it into a RooTreeDataStore which is installed in the
+         // new-style RooAbsData base class
 
-       // --- This is the contents of the streamer code of RooTreeData version 1 ---
-       UInt_t R__s1, R__c1;
-       Version_t R__v1 = R__b.ReadVersion(&R__s1, &R__c1); if (R__v1) { }
+         // --- This is the contents of the streamer code of RooTreeData version 1 ---
+         UInt_t R__s1;
+         UInt_t R__c1;
+         Version_t R__v1 = R__b.ReadVersion(&R__s1, &R__c1);
+         if (R__v1) {
+         }
 
-       RooAbsData::Streamer(R__b);
-       TTree* X_tree(nullptr) ; R__b >> X_tree;
-       RooArgSet X_truth ; X_truth.Streamer(R__b);
-       TString X_blindString ; X_blindString.Streamer(R__b);
-       R__b.CheckByteCount(R__s1, R__c1, TClass::GetClass("RooTreeData"));
-       // --- End of RooTreeData-v1 streamer
+         RooAbsData::Streamer(R__b);
+         TTree *X_tree(nullptr);
+         R__b >> X_tree;
+         RooArgSet X_truth;
+         X_truth.Streamer(R__b);
+         TString X_blindString;
+         X_blindString.Streamer(R__b);
+         R__b.CheckByteCount(R__s1, R__c1, TClass::GetClass("RooTreeData"));
+         // --- End of RooTreeData-v1 streamer
 
-       // Construct RooTreeDataStore from X_tree and complete initialization of new-style RooAbsData
-       _dstore = std::make_unique<RooTreeDataStore>(X_tree,_vars) ;
-       _dstore->SetName(GetName()) ;
-       _dstore->SetTitle(GetTitle()) ;
-       _dstore->checkInit() ;
+         // Construct RooTreeDataStore from X_tree and complete initialization of new-style RooAbsData
+         _dstore = std::make_unique<RooTreeDataStore>(X_tree, _vars);
+         _dstore->SetName(GetName());
+         _dstore->SetTitle(GetTitle());
+         _dstore->checkInit();
 
-       // This is the contents of the streamer code of RooDataSet version 1
-       RooDirItem::Streamer(R__b);
-       _varsNoWgt.Streamer(R__b);
-       R__b >> _wgtVar;
-       R__b.CheckByteCount(R__s, R__c, RooDataSet::IsA());
-
-
-     }
+         // This is the contents of the streamer code of RooDataSet version 1
+         RooDirItem::Streamer(R__b);
+         _varsNoWgt.Streamer(R__b);
+         R__b >> _wgtVar;
+         R__b.CheckByteCount(R__s, R__c, RooDataSet::IsA());
+      }
    } else {
-      R__b.WriteClassBuffer(RooDataSet::Class(),this);
+      R__b.WriteClassBuffer(RooDataSet::Class(), this);
    }
 }
 

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -19,7 +19,7 @@
 \class RooDataSet
 \ingroup Roofitcore
 
-RooDataSet is a container class to hold unbinned data. The binned equivalent is
+Container class to hold unbinned data. The binned equivalent is
 RooDataHist. In RooDataSet, each data point in N-dimensional space is represented
 by a RooArgSet of RooRealVar, RooCategory or RooStringVar objects, which can be
 retrieved using get().

--- a/roofit/roofitcore/src/RooDerivative.cxx
+++ b/roofit/roofitcore/src/RooDerivative.cxx
@@ -19,7 +19,7 @@
 \class RooDerivative
 \ingroup Roofitcore
 
-RooDerivative represents the first, second, or third order derivative
+Represents the first, second, or third order derivative
 of any RooAbsReal as calculated (numerically) by the MathCore Richardson
 derivator class.
 **/

--- a/roofit/roofitcore/src/RooDirItem.cxx
+++ b/roofit/roofitcore/src/RooDirItem.cxx
@@ -19,16 +19,14 @@
 \class RooDirItem
 \ingroup Roofitcore
 
-RooDirItem is a utility base class for RooFit objects that are to be attached
+Utility base class for \ref Roofitmain objects that are to be attached
 to ROOT directories. Concrete classes inherit the appendToDir and removeToDir
-methods that can be used to safely attach and detach one self from a TDirectory
+methods that can be used to safely attach and detach one self from a TDirectory.
 **/
 
 #include <iostream>
 #include "TDirectoryFile.h"
 #include "RooDirItem.h"
-
-using namespace std;
 
 ClassImp(RooDirItem);
 

--- a/roofit/roofitcore/src/RooDouble.cxx
+++ b/roofit/roofitcore/src/RooDouble.cxx
@@ -19,14 +19,11 @@
 \class RooDouble
 \ingroup Roofitcore
 
-RooDouble is a minimal implementation of a TObject holding a double
-value.
+Minimal implementation of a TObject holding a double value.
 **/
 
 #include "RooDouble.h"
 #include <string>
-
-using namespace std;
 
 ClassImp(RooDouble);
 

--- a/roofit/roofitcore/src/RooEffGenContext.cxx
+++ b/roofit/roofitcore/src/RooEffGenContext.cxx
@@ -30,8 +30,6 @@ and applying an extra rejection step based on the efficiency function.
 #include "RooAbsPdf.h"
 #include "RooRandom.h"
 
-using namespace std;
-
 ClassImp(RooEffGenContext);
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -44,7 +42,7 @@ RooEffGenContext::RooEffGenContext(const RooAbsPdf &model, const RooAbsPdf &pdf,
 {
    RooArgSet x(eff, eff.GetName());
    x.snapshot(_cloneSet, true);
-   _eff = dynamic_cast<RooAbsReal *>(_cloneSet.find(eff.GetName()));
+   initializeEff(eff);
    _generator = std::unique_ptr<RooAbsGenContext>{pdf.genContext(vars, prototype, auxProto, verbose)};
    vars.snapshot(_vars, true);
 }
@@ -90,13 +88,13 @@ void RooEffGenContext::generateEvent(RooArgSet &theEvent, Int_t remaining)
 ////////////////////////////////////////////////////////////////////////////////
 /// Detailed printing interface
 
-void RooEffGenContext::printMultiline(ostream &os, Int_t content, bool verbose, TString indent) const
+void RooEffGenContext::printMultiline(std::ostream &os, Int_t content, bool verbose, TString indent) const
 {
    RooAbsGenContext::printMultiline(os, content, verbose, indent);
-   os << indent << "--- RooEffGenContext ---" << endl;
+   os << indent << "--- RooEffGenContext ---" << std::endl;
    os << indent << "Using EFF ";
    _eff->printStream(os, kName | kArgs | kClassName, kSingleLine, indent);
-   os << indent << "PDF generator" << endl;
+   os << indent << "PDF generator" << std::endl;
 
    TString indent2(indent);
    indent2.Append("    ");

--- a/roofit/roofitcore/src/RooEllipse.cxx
+++ b/roofit/roofitcore/src/RooEllipse.cxx
@@ -71,7 +71,14 @@ RooEllipse::RooEllipse(const char *name, double x1, double x2, double s1, double
     setYAxisLimits(x2-s2,x2+s2);
   }
   else {
-    double r,psi,phi,u1,u2,xx1,xx2,dphi(2*TMath::Pi()/points);
+    double r;
+    double psi;
+    double phi;
+    double u1;
+    double u2;
+    double xx1;
+    double xx2;
+    double dphi(2 * TMath::Pi() / points);
     for(Int_t index= 0; index < points; index++) {
       phi= index*dphi;
       // adjust the angular spacing of the points for the aspect ratio

--- a/roofit/roofitcore/src/RooEllipse.cxx
+++ b/roofit/roofitcore/src/RooEllipse.cxx
@@ -19,8 +19,7 @@
 \class RooEllipse
 \ingroup Roofitcore
 
-A RooEllipse is a two-dimensional ellipse that can be used to represent
-an error contour.
+Two-dimensional ellipse that can be used to represent an error contour.
 **/
 
 #include "RooEllipse.h"

--- a/roofit/roofitcore/src/RooErrorVar.cxx
+++ b/roofit/roofitcore/src/RooErrorVar.cxx
@@ -290,7 +290,8 @@ void RooErrorVar::setRange( const char* name, double min, double max)
 
 bool RooErrorVar::readFromStream(istream& is, bool /*compact*/, bool verbose)
 {
-  TString token,errorPrefix("RooErrorVar::readFromStream(") ;
+  TString token;
+  TString errorPrefix("RooErrorVar::readFromStream(");
   errorPrefix.Append(GetName()) ;
   errorPrefix.Append(")") ;
   RooStreamParser parser(is,errorPrefix) ;

--- a/roofit/roofitcore/src/RooExpensiveObjectCache.cxx
+++ b/roofit/roofitcore/src/RooExpensiveObjectCache.cxx
@@ -19,7 +19,7 @@
 \class RooExpensiveObjectCache
 \ingroup Roofitcore
 
-RooExpensiveObjectCache is a singleton class that serves as repository
+Singleton class that serves as repository
 for objects that are expensive to calculate. Owners of such objects
 can registers these here with associated parameter values for which
 the object is valid, so that other instances can, at a later moment
@@ -44,8 +44,8 @@ ClassImp(RooExpensiveObjectCache::ExpensiveObject);
 
 RooExpensiveObjectCache::~RooExpensiveObjectCache()
 {
-  for (std::map<TString,ExpensiveObject*>::iterator iter = _map.begin() ; iter!=_map.end() ; ++iter) {
-    delete iter->second ;
+  for (auto& item : _map) {
+    delete item.second;
   }
 }
 

--- a/roofit/roofitcore/src/RooExtendedTerm.cxx
+++ b/roofit/roofitcore/src/RooExtendedTerm.cxx
@@ -19,7 +19,7 @@
 \class RooExtendedTerm
 \ingroup Roofitcore
 
-RooExtendedTerm is a p.d.f with no observables that only introduces
+A p.d.f with no observables that only introduces
 an extended ML term for a given number of expected events term when an extended ML
 is constructed.
 **/

--- a/roofit/roofitcore/src/RooFFTConvPdf.cxx
+++ b/roofit/roofitcore/src/RooFFTConvPdf.cxx
@@ -499,7 +499,10 @@ void RooFFTConvPdf::fillCacheSlice(FFTCacheElem& aux, const RooArgSet& slicePos)
   //
   //
 
-  Int_t N,N2,binShift1,binShift2 ;
+  Int_t N;
+  Int_t N2;
+  Int_t binShift1;
+  Int_t binShift2;
 
   RooRealVar* histX = static_cast<RooRealVar*>(cacheHist.get()->find(_x.arg().GetName())) ;
   if (_bufStrat==Extend) histX->setBinning(*aux.scanBinning) ;
@@ -533,7 +536,10 @@ void RooFFTConvPdf::fillCacheSlice(FFTCacheElem& aux, const RooArgSet& slicePos)
   // Loop over first half +1 of complex output results, multiply
   // and set as input of reverse transform
   for (Int_t i=0 ; i<N2/2+1 ; i++) {
-    double re1,re2,im1,im2 ;
+    double re1;
+    double re2;
+    double im1;
+    double im2;
     aux.fftr2c1->GetPointComplex(i,re1,im1) ;
     aux.fftr2c2->GetPointComplex(i,re2,im2) ;
     double re = re1*re2 - im1*im2 ;

--- a/roofit/roofitcore/src/RooFactoryWSTool.cxx
+++ b/roofit/roofitcore/src/RooFactoryWSTool.cxx
@@ -19,11 +19,7 @@
 \class RooFactoryWSTool
 \ingroup Roofitcore
 
-RooFactoryWSTool is a class similar to TTree::MakeClass() that generates
-skeleton code for RooAbsPdf and RooAbsReal functions given
-a list of input parameter names. The factory can also compile
-the generated code on the fly, and on request also
-instantiate the objects.
+Implementation detail of the RooWorkspace.
 
 It interprets all expressions for RooWorkspace::factory(const char*).
 **/

--- a/roofit/roofitcore/src/RooFactoryWSTool.cxx
+++ b/roofit/roofitcore/src/RooFactoryWSTool.cxx
@@ -298,7 +298,9 @@ RooAbsArg* RooFactoryWSTool::createArg(const char* className, const char* objNam
 
   _args.clear();
   string tmp(varList);
-  size_t blevel = 0, end_tok, start_tok = 0;
+  size_t blevel = 0;
+  size_t end_tok;
+  size_t start_tok = 0;
   bool litmode = false;
   for (end_tok = 0; end_tok < tmp.length(); end_tok++) {
     // Keep track of opening and closing brackets
@@ -985,7 +987,8 @@ std::string RooFactoryWSTool::processSingleExpression(const char* arg)
   strlcpy(buf.data(),arg,bufSize) ;
   char* bufptr = buf.data();
 
-  string func,prefix ;
+  string func;
+  string prefix;
   vector<string> args ;
 
   // Process token into arguments
@@ -1478,7 +1481,9 @@ vector<string> RooFactoryWSTool::splitFunctionArgs(const char* funcExpr)
 bool RooFactoryWSTool::checkSyntax(const char* arg)
 {
   // Count parentheses
-  Int_t nParentheses(0), nBracket(0), nAccolade(0) ;
+  Int_t nParentheses(0);
+  Int_t nBracket(0);
+  Int_t nAccolade(0);
   const char* ptr = arg ;
   while(*ptr) {
     if (*ptr=='(') nParentheses++ ;
@@ -2007,7 +2012,9 @@ std::string RooFactoryWSTool::SpecialsIFace::create(RooFactoryWSTool& ft, const 
 
     // taylorexpand::name[func,{var,var,..},val,order]
     int order(1);
-    double eps1(1e-6), eps2(1e-3), observablesValue(0.0);
+    double eps1(1e-6);
+    double eps2(1e-3);
+    double observablesValue(0.0);
 
     if (pargv.size() < 2)
       throw string(Form("taylorexpand::%s, requires atleast 2 arguments (function, observables) atleast, has %d arguments", instName, (Int_t)pargv.size()));

--- a/roofit/roofitcore/src/RooFitResult.cxx
+++ b/roofit/roofitcore/src/RooFitResult.cxx
@@ -713,8 +713,14 @@ void RooFitResult::fillCorrMatrix()
 
   // WVE: This code directly manipulates minuit internal workspace,
   //      if TMinuit code changes this may need updating
-  Int_t ndex, i, j, m, n, it /* nparm,id,ix */ ;
-  Int_t ndi, ndj /*, iso, isw2, isw5*/;
+  Int_t ndex;
+  Int_t i;
+  Int_t j;
+  Int_t m;
+  Int_t n;
+  Int_t it /* nparm,id,ix */;
+  Int_t ndi;
+  Int_t ndj /*, iso, isw2, isw5*/;
   for (i = 1; i <= gMinuit->fNpar; ++i) {
     ndi = i*(i + 1) / 2;
     for (j = 1; j <= gMinuit->fNpar; ++j) {
@@ -976,8 +982,12 @@ RooFitResult* RooFitResult::lastMinuitFit(const RooArgList& varList)
     }
   }
 
-  Int_t icode,npari,nparx ;
-  double fmin,edm,errdef ;
+  Int_t icode;
+  Int_t npari;
+  Int_t nparx;
+  double fmin;
+  double edm;
+  double errdef;
   gMinuit->mnstat(fmin,edm,errdef,npari,nparx,icode) ;
 
   r->setConstParList(constPars) ;
@@ -1194,7 +1204,8 @@ TMatrixDSym RooFitResult::conditionalCovarianceMatrix(const RooArgList& params) 
   }
 
   // Find (subset) of parameters that are stored in the covariance matrix
-  vector<int> map1, map2 ;
+  vector<int> map1;
+  vector<int> map2;
   for (std::size_t i=0 ; i<_finalPars->size() ; i++) {
     if (params3.find(_finalPars->at(i)->GetName())) {
       map1.push_back(i) ;
@@ -1205,8 +1216,10 @@ TMatrixDSym RooFitResult::conditionalCovarianceMatrix(const RooArgList& params) 
 
   // Rearrange matrix in block form with 'params' first and 'others' last
   // (preserving relative order)
-  TMatrixDSym S11, S22 ;
-  TMatrixD S12, S21 ;
+  TMatrixDSym S11;
+  TMatrixDSym S22;
+  TMatrixD S12;
+  TMatrixD S21;
   RooMultiVarGaussian::blockDecompose(V,map1,map2,S11,S12,S21,S22) ;
 
   // Constructed conditional matrix form         -1
@@ -1298,7 +1311,8 @@ RooAbsPdf* RooFitResult::createHessePdf(const RooArgSet& params) const
   // Handle case of conditional p.d.f. MVG(p1|p2) here
 
   // Find (subset) of parameters that are stored in the covariance matrix
-  vector<int> map1, map2 ;
+  vector<int> map1;
+  vector<int> map2;
   for (std::size_t i=0 ; i<_finalPars->size() ; i++) {
     if (params3.find(_finalPars->at(i)->GetName())) {
       map1.push_back(i) ;
@@ -1309,8 +1323,10 @@ RooAbsPdf* RooFitResult::createHessePdf(const RooArgSet& params) const
 
   // Rearrange matrix in block form with 'params' first and 'others' last
   // (preserving relative order)
-  TMatrixDSym S11, S22 ;
-  TMatrixD S12, S21 ;
+  TMatrixDSym S11;
+  TMatrixDSym S22;
+  TMatrixD S12;
+  TMatrixD S21;
   RooMultiVarGaussian::blockDecompose(V,map1,map2,S11,S12,S21,S22) ;
 
   // Calculate offset vectors mu1 and mu2
@@ -1442,7 +1458,8 @@ RooPrintable::StyleOption RooFitResult::defaultPrintStyle(Option_t* opt) const
 void RooFitResult::Streamer(TBuffer &R__b)
 {
   if (R__b.IsReading()) {
-    UInt_t R__s, R__c;
+    UInt_t R__s;
+    UInt_t R__c;
     Version_t R__v = R__b.ReadVersion(&R__s, &R__c);
     if (R__v>3) {
       R__b.ReadClassBuffer(RooFitResult::Class(),this,R__v,R__s,R__c);

--- a/roofit/roofitcore/src/RooFoamGenerator.cxx
+++ b/roofit/roofitcore/src/RooFoamGenerator.cxx
@@ -19,7 +19,7 @@
 \class RooFoamGenerator
 \ingroup Roofitcore
 
-Class RooFoamGenerator is a generic toy monte carlo generator that implement
+Generic Monte Carlo toy generator that implement
 the TFOAM sampling technique on any positively valued function.
 The RooFoamGenerator generator is used by the various generator context
 classes to take care of generation of observables for which p.d.fs

--- a/roofit/roofitcore/src/RooFormula.cxx
+++ b/roofit/roofitcore/src/RooFormula.cxx
@@ -19,8 +19,7 @@
 \class RooFormula
 \ingroup Roofitcore
 
-RooFormula internally uses ROOT's TFormula to compute user-defined expressions
-of RooAbsArgs.
+Internally uses ROOT's TFormula to compute user-defined expressions of RooAbsArgs.
 
 The string expression can be any valid TFormula expression referring to the
 listed servers either by name or by their ordinal list position. These three are

--- a/roofit/roofitcore/src/RooGenContext.cxx
+++ b/roofit/roofitcore/src/RooGenContext.cxx
@@ -19,7 +19,7 @@
 \class RooGenContext
 \ingroup Roofitcore
 
-Class RooGenContext implement a universal generator context for all
+Implements a universal generator context for all
 RooAbsPdf classes that do not have or need a specialized generator
 context. This generator context queries the input p.d.f which observables
 it can generate internally and delegates generation of those observables

--- a/roofit/roofitcore/src/RooGenFitStudy.cxx
+++ b/roofit/roofitcore/src/RooGenFitStudy.cxx
@@ -19,8 +19,7 @@
 \class RooGenFitStudy
 \ingroup Roofitcore
 
-RooGenFitStudy is an abstract base class for RooStudyManager modules
-
+Abstract base class for RooStudyManager modules
 **/
 
 #include "Riostream.h"
@@ -35,23 +34,13 @@ RooGenFitStudy is an abstract base class for RooStudyManager modules
 #include "RooFitResult.h"
 
 
-using namespace std ;
-
 ClassImp(RooGenFitStudy);
-  ;
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor
 
 RooGenFitStudy::RooGenFitStudy(const char* name, const char* title) :
-  RooAbsStudy(name?name:"RooGenFitStudy",title?title:"RooGenFitStudy"),
-  _genPdf(nullptr),
-  _fitPdf(nullptr),
-  _genSpec(nullptr),
-  _nllVar(nullptr),
-  _ngenVar(nullptr),
-  _initParams(nullptr)
+  RooAbsStudy(name?name:"RooGenFitStudy",title?title:"RooGenFitStudy")
 {
 }
 
@@ -65,27 +54,11 @@ RooGenFitStudy::RooGenFitStudy(const RooGenFitStudy& other) :
   _genPdfName(other._genPdfName),
   _genObsName(other._genObsName),
   _fitPdfName(other._fitPdfName),
-  _fitObsName(other._fitObsName),
-  _genPdf(nullptr),
-  _fitPdf(nullptr),
-  _genSpec(nullptr),
-  _nllVar(nullptr),
-  _ngenVar(nullptr),
-  _initParams(nullptr)
+  _fitObsName(other._fitObsName)
 {
   for(TObject * o : other._genOpts) _genOpts.Add(o->Clone());
   for(TObject * o : other._fitOpts) _fitOpts.Add(o->Clone());
 }
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-
-RooGenFitStudy::~RooGenFitStudy()
-{
-}
-
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Function called after insertion into workspace
@@ -98,13 +71,13 @@ bool RooGenFitStudy::attach(RooWorkspace& w)
   if (pdf) {
     _genPdf = pdf ;
   } else {
-    coutE(InputArguments) << "RooGenFitStudy(" << GetName() << ") ERROR: generator p.d.f named " << _genPdfName << " not found in workspace " << w.GetName() << endl ;
+    coutE(InputArguments) << "RooGenFitStudy(" << GetName() << ") ERROR: generator p.d.f named " << _genPdfName << " not found in workspace " << w.GetName() << std::endl ;
     ret = true ;
   }
 
   _genObs.add(w.argSet(_genObsName)) ;
   if (_genObs.empty()) {
-    coutE(InputArguments) << "RooGenFitStudy(" << GetName() << ") ERROR: no generator observables defined" << endl ;
+    coutE(InputArguments) << "RooGenFitStudy(" << GetName() << ") ERROR: no generator observables defined" << std::endl ;
     ret = true ;
   }
 
@@ -112,13 +85,13 @@ bool RooGenFitStudy::attach(RooWorkspace& w)
   if (pdf) {
     _fitPdf = pdf ;
   } else {
-    coutE(InputArguments) << "RooGenFitStudy(" << GetName() << ") ERROR: fitting p.d.f named " << _fitPdfName << " not found in workspace " << w.GetName() << endl ;
+    coutE(InputArguments) << "RooGenFitStudy(" << GetName() << ") ERROR: fitting p.d.f named " << _fitPdfName << " not found in workspace " << w.GetName() << std::endl ;
     ret = true ;
   }
 
   _fitObs.add(w.argSet(_fitObsName)) ;
   if (_fitObs.empty()) {
-    coutE(InputArguments) << "RooGenFitStudy(" << GetName() << ") ERROR: no fitting observables defined" << endl ;
+    coutE(InputArguments) << "RooGenFitStudy(" << GetName() << ") ERROR: no fitting observables defined" << std::endl ;
     ret = true ;
   }
 

--- a/roofit/roofitcore/src/RooGenProdProj.cxx
+++ b/roofit/roofitcore/src/RooGenProdProj.cxx
@@ -131,7 +131,8 @@ RooGenProdProj::RooGenProdProj(const RooGenProdProj &other, const char *name)
 RooAbsReal* RooGenProdProj::makeIntegral(const char* name, const RooArgSet& compSet, const RooArgSet& intSet,
                 RooArgSet& saveSet, const char* isetRangeName, bool doFactorize)
 {
-  RooArgSet anaIntSet, numIntSet ;
+  RooArgSet anaIntSet;
+  RooArgSet numIntSet;
 
   // First determine subset of observables in intSet that are factorizable
   for (const auto arg : intSet) {

--- a/roofit/roofitcore/src/RooGenericPdf.cxx
+++ b/roofit/roofitcore/src/RooGenericPdf.cxx
@@ -19,8 +19,8 @@
 \class RooGenericPdf
 \ingroup Roofitcore
 
-RooGenericPdf is a concrete implementation of a probability density function,
-which takes a RooArgList of servers and a C++ expression string defining how
+Implementation of a probability density function
+that takes a RooArgList of servers and a C++ expression string defining how
 its value should be calculated from the given list of servers.
 A fully numerical integration is automatically performed to normalize the given
 expression. RooGenericPdf uses a RooFormula object to perform the expression evaluation.

--- a/roofit/roofitcore/src/RooGrid.cxx
+++ b/roofit/roofitcore/src/RooGrid.cxx
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*****************************************************************************
  * Project: RooFit                                                           *
  * Package: RooFitCore                                                       *
@@ -19,7 +21,7 @@
 \class RooGrid
 \ingroup Roofitcore
 
-RooGrid is a utility class for RooMCIntegrator which
+Utility class for RooMCIntegrator which
 implements an adaptive multi-dimensional Monte Carlo numerical
 integration, following the VEGAS algorithm.
 **/
@@ -332,3 +334,5 @@ void RooGrid::refine(double alpha)
     coord(_bins, j) = 1;
   }
 }
+
+/// \endcond

--- a/roofit/roofitcore/src/RooGrid.cxx
+++ b/roofit/roofitcore/src/RooGrid.cxx
@@ -117,7 +117,9 @@ void RooGrid::resize(UInt_t bins)
 
   // loop over grid dimensions
   for (UInt_t j = 0; j < _dim; j++) {
-    double xold,xnew(0),dw(0);
+    double xold;
+    double xnew(0);
+    double dw(0);
     Int_t i = 1;
     // loop over bins in this dimension and load _xin[] with new bin edges
 
@@ -186,7 +188,8 @@ void RooGrid::generatePoint(const UInt_t box[], double x[], UInt_t bin[], double
     // in normalized bin coordinates.
     Int_t k= static_cast<Int_t>(z);
     bin[j] = k;
-    double y, bin_width;
+    double y;
+    double bin_width;
     if(k == 0) {
       bin_width= coord(1,j);
       y= z * bin_width;

--- a/roofit/roofitcore/src/RooHist.cxx
+++ b/roofit/roofitcore/src/RooHist.cxx
@@ -220,9 +220,14 @@ RooHist::RooHist(const RooHist &hist1, const RooHist &hist2, double wgt1, double
     }
 
     // Add histograms, calculate Poisson confidence interval on sum value
-    Int_t i,n=hist1.GetN() ;
+    Int_t i;
+    Int_t n = hist1.GetN();
     for(i=0 ; i<n ; i++) {
-      double x1,y1,x2,y2,dx1 ;
+      double x1;
+      double y1;
+      double x2;
+      double y2;
+      double dx1;
       hist1.GetPoint(i,x1,y1) ;
       dx1 = hist1.GetErrorX(i) ;
       hist2.GetPoint(i,x2,y2) ;
@@ -233,9 +238,16 @@ RooHist::RooHist(const RooHist &hist1, const RooHist &hist2, double wgt1, double
     // Add histograms with SumW2 errors
 
     // Add histograms, calculate combined sum-of-weights error
-    Int_t i,n=hist1.GetN() ;
+    Int_t i;
+    Int_t n = hist1.GetN();
     for(i=0 ; i<n ; i++) {
-      double x1,y1,x2,y2,dx1,dy1,dy2 ;
+      double x1;
+      double y1;
+      double x2;
+      double y2;
+      double dx1;
+      double dy1;
+      double dy2;
       hist1.GetPoint(i,x1,y1) ;
       dx1 = hist1.GetErrorX(i) ;
       dy1 = hist1.GetErrorY(i) ;
@@ -336,7 +348,8 @@ double RooHist::getFitRangeNEvt(double xlo, double xhi) const
 {
   double sum(0) ;
   for (int i=0 ; i<GetN() ; i++) {
-    double x,y ;
+    double x;
+    double y;
 
     GetPoint(i,x,y) ;
 
@@ -423,11 +436,16 @@ void RooHist::addBin(Axis_t binCenter, double n, double binWidth, double xErrorF
   _entries+= n;
 
   // calculate Poisson errors for this bin
-  double ym,yp,dx(0.5*binWidth);
+  double ym;
+  double yp;
+  double dx(0.5 * binWidth);
 
   if (std::abs((double)((n-Int_t(n))>1e-5))) {
     // need interpolation
-    double ym1(0),yp1(0),ym2(0),yp2(0) ;
+    double ym1(0);
+    double yp1(0);
+    double ym2(0);
+    double yp2(0);
     Int_t n1 = Int_t(n) ;
     Int_t n2 = n1+1 ;
     if(!RooHistError::instance().getPoissonInterval(n1,ym1,yp1,_nSigma) ||
@@ -496,7 +514,9 @@ void RooHist::addBinWithXYError(Axis_t binCenter, double n, double exlow, double
 void RooHist::addAsymmetryBin(Axis_t binCenter, Int_t n1, Int_t n2, double binWidth, double xErrorFrac, double scaleFactor)
 {
   // calculate Binomial errors for this bin
-  double ym,yp,dx(0.5*binWidth);
+  double ym;
+  double yp;
+  double dx(0.5 * binWidth);
   if(!RooHistError::instance().getBinomialIntervalAsym(n1,n2,ym,yp,_nSigma)) {
     coutE(Plotting) << "RooHist::addAsymmetryBin: unable to calculate binomial error for bin with " << n1 << "," << n2 << " events" << std::endl;
     return;
@@ -515,7 +535,9 @@ void RooHist::addAsymmetryBin(Axis_t binCenter, Int_t n1, Int_t n2, double binWi
 void RooHist::addAsymmetryBinWithError(Axis_t binCenter, double n1, double n2, double en1, double en2, double binWidth, double xErrorFrac, double scaleFactor)
 {
   // calculate Binomial errors for this bin
-  double ym,yp,dx(0.5*binWidth);
+  double ym;
+  double yp;
+  double dx(0.5 * binWidth);
   double a= (double)(n1-n2)/(n1+n2);
 
   double error = 2*sqrt( pow(en1,2)*pow(n2,2) + pow(en2,2)*pow(n1,2) ) / pow(n1+n2,2) ;
@@ -536,7 +558,9 @@ void RooHist::addEfficiencyBin(Axis_t binCenter, Int_t n1, Int_t n2, double binW
   double a= (double)(n1)/(n1+n2);
 
   // calculate Binomial errors for this bin
-  double ym,yp,dx(0.5*binWidth);
+  double ym;
+  double yp;
+  double dx(0.5 * binWidth);
   if(!RooHistError::instance().getBinomialIntervalEff(n1,n2,ym,yp,_nSigma)) {
     coutE(Plotting) << "RooHist::addEfficiencyBin: unable to calculate binomial error for bin with " << n1 << "," << n2 << " events" << std::endl;
     return;
@@ -558,7 +582,9 @@ void RooHist::addEfficiencyBinWithError(Axis_t binCenter, double n1, double n2, 
   double error = sqrt( pow(en1,2)*pow(n2,2) + pow(en2,2)*pow(n1,2) ) / pow(n1+n2,2) ;
 
   // calculate Binomial errors for this bin
-  double ym,yp,dx(0.5*binWidth);
+  double ym;
+  double yp;
+  double dx(0.5 * binWidth);
   ym=a-error ;
   yp=a+error ;
 
@@ -580,7 +606,10 @@ bool RooHist::hasIdenticalBinning(const RooHist& other) const
   // Next require that all bin centers are the same
   Int_t i ;
   for (i=0 ; i<GetN() ; i++) {
-    double x1,x2,y1,y2 ;
+    double x1;
+    double x2;
+    double y1;
+    double y2;
 
     GetPoint(i,x1,y1) ;
     other.GetPoint(i,x2,y2) ;
@@ -698,13 +727,16 @@ std::unique_ptr<RooHist> RooHist::createEmptyResidHist(const RooCurve& curve, bo
 void RooHist::fillResidHist(RooHist & residHist, const RooCurve& curve,bool normalize, bool useAverage) const
 {
   // Determine range of curve
-  double xstart,xstop,y ;
+  double xstart;
+  double xstop;
+  double y;
   curve.GetPoint(0,xstart,y) ;
   curve.GetPoint(curve.GetN()-1,xstop,y) ;
 
   // Add histograms, calculate Poisson confidence interval on sum value
   for(Int_t i=0 ; i<GetN() ; i++) {
-    double x,point;
+    double x;
+    double point;
     GetPoint(i,x,point) ;
 
     // Only calculate pull for bins inside curve range

--- a/roofit/roofitcore/src/RooHist.cxx
+++ b/roofit/roofitcore/src/RooHist.cxx
@@ -19,7 +19,7 @@
 \class RooHist
 \ingroup Roofitcore
 
-A RooHist is a graphical representation of binned data based on the
+Graphical representation of binned data based on the
 TGraphAsymmErrors class. Error bars are calculated using either Poisson
 or Binomial statistics. A RooHist is used to represent histograms in
 a RooPlot.

--- a/roofit/roofitcore/src/RooHistError.cxx
+++ b/roofit/roofitcore/src/RooHistError.cxx
@@ -266,7 +266,8 @@ bool RooHistError::getInterval(const RooAbsFunc *Qu, const RooAbsFunc *Ql, doubl
 
   // Does the central interval contain the point estimate?
   bool ok(true);
-  double loProb(1),hiProb(0);
+  double loProb(1);
+  double hiProb(0);
   if(nullptr != Ql) loProb= (*Ql)(&pointEstimate);
   if(nullptr != Qu) hiProb= (*Qu)(&pointEstimate);
 
@@ -290,7 +291,8 @@ bool RooHistError::getInterval(const RooAbsFunc *Qu, const RooAbsFunc *Ql, doubl
     // use a central interval
     lo= seek(*Ql,pointEstimate,-stepSize,alpha+beta);
     hi= seek(*Qu,pointEstimate,+stepSize,alpha);
-    RooBrentRootFinder lFinder(*Ql),uFinder(*Qu);
+    RooBrentRootFinder lFinder(*Ql);
+    RooBrentRootFinder uFinder(*Qu);
     ok= lFinder.findRoot(lo,lo,lo+stepSize,alpha+beta);
     ok|= uFinder.findRoot(hi,hi-stepSize,hi,alpha);
   }
@@ -307,8 +309,10 @@ bool RooHistError::getInterval(const RooAbsFunc *Qu, const RooAbsFunc *Ql, doubl
 double RooHistError::seek(const RooAbsFunc &f, double startAt, double step, double value) const
 {
   Int_t steps(1000);
-  double min(f.getMinLimit(1)),max(f.getMaxLimit(1));
-  double x(startAt), f0= f(&startAt) - value;
+  double min(f.getMinLimit(1));
+  double max(f.getMaxLimit(1));
+  double x(startAt);
+  double f0 = f(&startAt) - value;
   do {
     x+= step;
   }

--- a/roofit/roofitcore/src/RooHistError.cxx
+++ b/roofit/roofitcore/src/RooHistError.cxx
@@ -19,7 +19,7 @@
 \class RooHistError
 \ingroup Roofitcore
 
-RooHistError is a singleton class used to calculate the error bars
+Singleton class used to calculate the error bars
 for each bin of a RooHist object. Errors are calculated by integrating
 a specified area of a Poisson or Binomail error distribution.
 **/

--- a/roofit/roofitcore/src/RooHistFunc.cxx
+++ b/roofit/roofitcore/src/RooHistFunc.cxx
@@ -122,14 +122,14 @@ RooHistFunc::RooHistFunc(const char *name, const char *title, const RooArgSet &v
                          int intOrder)
    : RooHistFunc{name, title, vars, *dhist, intOrder}
 {
-   _ownedDataHist = std::move(dhist);
+   initializeOwnedDataHist(std::move(dhist));
 }
 
 RooHistFunc::RooHistFunc(const char *name, const char *title, const RooArgList &pdfObs, const RooArgList &histObs,
                          std::unique_ptr<RooDataHist> dhist, int intOrder)
    : RooHistFunc{name, title, pdfObs, histObs, *dhist, intOrder}
 {
-   _ownedDataHist = std::move(dhist);
+   initializeOwnedDataHist(std::move(dhist));
 }
 
 

--- a/roofit/roofitcore/src/RooHistFunc.cxx
+++ b/roofit/roofitcore/src/RooHistFunc.cxx
@@ -19,7 +19,7 @@
 \class RooHistFunc
 \ingroup Roofitcore
 
-RooHistFunc implements a real-valued function sampled from a
+A real-valued function sampled from a
 multidimensional histogram. The histogram can have an arbitrary number of real or
 discrete dimensions and may have negative values.
 **/

--- a/roofit/roofitcore/src/RooHistPdf.cxx
+++ b/roofit/roofitcore/src/RooHistPdf.cxx
@@ -148,13 +148,13 @@ RooHistPdf::RooHistPdf(const char *name, const char *title, const RooArgSet &var
                        int intOrder)
    : RooHistPdf{name, title, vars, *dhist, intOrder}
 {
-   _ownedDataHist = std::move(dhist);
+   initializeOwnedDataHist(std::move(dhist));
 }
 RooHistPdf::RooHistPdf(const char *name, const char *title, const RooArgList &pdfObs, const RooArgList &histObs,
                        std::unique_ptr<RooDataHist> dhist, int intOrder)
    : RooHistPdf{name, title, pdfObs, histObs, *dhist, intOrder}
 {
-  _ownedDataHist = std::move(dhist);
+   initializeOwnedDataHist(std::move(dhist));
 }
 
 

--- a/roofit/roofitcore/src/RooHistPdf.cxx
+++ b/roofit/roofitcore/src/RooHistPdf.cxx
@@ -19,7 +19,7 @@
 \class RooHistPdf
 \ingroup Roofitcore
 
-RooHistPdf implements a propability density function sampled from a
+A propability density function sampled from a
 multidimensional histogram. The histogram distribution is explicitly
 normalized by RooHistPdf and can have an arbitrary number of real or
 discrete dimensions.

--- a/roofit/roofitcore/src/RooLinTransBinning.cxx
+++ b/roofit/roofitcore/src/RooLinTransBinning.cxx
@@ -19,7 +19,7 @@
 \class RooLinTransBinning
 \ingroup Roofitcore
 
-RooLinTransBinning is a special binning implementation for RooLinearVar
+Special binning implementation for RooLinearVar
 that transforms the binning of the RooLinearVar input variable in the same
 way that RooLinearVar does
 **/
@@ -27,8 +27,6 @@ way that RooLinearVar does
 #include "RooLinTransBinning.h"
 
 #include <stdexcept>
-
-using namespace std;
 
 ClassImp(RooLinTransBinning);
 

--- a/roofit/roofitcore/src/RooLinkedList.cxx
+++ b/roofit/roofitcore/src/RooLinkedList.cxx
@@ -19,7 +19,7 @@
 \class RooLinkedList
 \ingroup Roofitcore
 
-RooLinkedList is an collection class for internal use, storing
+Collection class for internal use, storing
 a collection of RooAbsArg pointers in a doubly linked list.
 It can optionally add a hash table to speed up random access
 in large collections

--- a/roofit/roofitcore/src/RooLinkedListElem.cxx
+++ b/roofit/roofitcore/src/RooLinkedListElem.cxx
@@ -19,17 +19,10 @@
 \class RooLinkedListElem
 \ingroup Roofitcore
 
-RooLinkedListElem is an link element for the RooLinkedList class
+Link element for the RooLinkedList class
 **/
 
 #include "TBuffer.h"
 #include "RooLinkedListElem.h"
 
-
-using namespace std;
-
 ClassImp(RooLinkedListElem);
-;
-
-
-

--- a/roofit/roofitcore/src/RooMCIntegrator.cxx
+++ b/roofit/roofitcore/src/RooMCIntegrator.cxx
@@ -236,11 +236,15 @@ double RooMCIntegrator::vegas(Stage stage, UInt_t calls, UInt_t iterations, doub
 
 
   // loop over iterations for this step
-  double cum_int(0),cum_sig(0);
+  double cum_int(0);
+  double cum_sig(0);
   _it_start = _it_num;
   _chisq = 0.0;
   for (UInt_t it = 0; it < iterations; it++) {
-    double intgrl(0),intgrl_sq(0),sig(0),jacbin(_jac);
+    double intgrl(0);
+    double intgrl_sq(0);
+    double sig(0);
+    double jacbin(_jac);
 
     _it_num = _it_start + it;
 
@@ -250,7 +254,8 @@ double RooMCIntegrator::vegas(Stage stage, UInt_t calls, UInt_t iterations, doub
     // loop over grid boxes
     _grid.firstBox(box.data());
     do {
-      double m(0),q(0);
+      double m(0);
+      double q(0);
       // loop over integrand evaluations within this grid box
       for(UInt_t k = 0; k < _calls_per_box; k++) {
         // generate a random point in this box

--- a/roofit/roofitcore/src/RooMCIntegrator.cxx
+++ b/roofit/roofitcore/src/RooMCIntegrator.cxx
@@ -19,7 +19,7 @@
 \class RooMCIntegrator
 \ingroup Roofitcore
 
-RooMCIntegrator implements an adaptive multi-dimensional Monte Carlo
+Implements an adaptive multi-dimensional Monte Carlo
 numerical integration, following the VEGAS algorithm originally described
 in G. P. Lepage, J. Comp. Phys. 27, 192(1978). This implementation is
 based on a C version from the 0.9 beta release of the GNU scientific library.
@@ -37,7 +37,6 @@ based on a C version from the 0.9 beta release of the GNU scientific library.
 #include "RooMsgService.h"
 
 #include <cmath>
-
 
 
 using namespace std;

--- a/roofit/roofitcore/src/RooMCStudy.cxx
+++ b/roofit/roofitcore/src/RooMCStudy.cxx
@@ -741,7 +741,8 @@ void RooMCStudy::calcPulls()
     const auto par = static_cast<RooRealVar*>(*it);
     _fitParData->addColumn(*std::unique_ptr<RooErrorVar>{par->errorVar()});
 
-    TString name(par->GetName()), title(par->GetTitle()) ;
+    TString name(par->GetName());
+    TString title(par->GetTitle());
     name.Append("pull") ;
     title.Append(" Pull") ;
 
@@ -1106,7 +1107,8 @@ RooPlot* RooMCStudy::plotPull(const RooRealVar& param, const RooCmdArg& arg1, co
   cmdList.Add(const_cast<RooCmdArg*>(&arg5)) ;  cmdList.Add(const_cast<RooCmdArg*>(&arg6)) ;
   cmdList.Add(const_cast<RooCmdArg*>(&arg7)) ;  cmdList.Add(const_cast<RooCmdArg*>(&arg8)) ;
 
-  TString name(param.GetName()), title(param.GetTitle()) ;
+  TString name(param.GetName());
+  TString title(param.GetTitle());
   name.Append("pull") ; title.Append(" Pull") ;
   RooRealVar pvar(name,title,-100,100) ;
   pvar.setBins(100) ;
@@ -1255,8 +1257,8 @@ RooPlot* RooMCStudy::plotPull(const RooRealVar& param, double lo, double hi, Int
     _canAddFitResults=false ;
   }
 
-
-  TString name(param.GetName()), title(param.GetTitle()) ;
+  TString name(param.GetName());
+  TString title(param.GetTitle());
   name.Append("pull") ; title.Append(" Pull") ;
   RooRealVar pvar(name,title,lo,hi) ;
   pvar.setBins(nbins) ;

--- a/roofit/roofitcore/src/RooMCStudy.cxx
+++ b/roofit/roofitcore/src/RooMCStudy.cxx
@@ -19,7 +19,7 @@
 \class RooMCStudy
 \ingroup Roofitcore
 
-RooMCStudy is a helper class to facilitate Monte Carlo studies
+Helper class to facilitate Monte Carlo studies
 such as 'goodness-of-fit' studies, that involve fitting a PDF
 to multiple toy Monte Carlo sets. These may be generated from either same PDF
 or from a different PDF with similar parameters.

--- a/roofit/roofitcore/src/RooMappedCategory.cxx
+++ b/roofit/roofitcore/src/RooMappedCategory.cxx
@@ -98,7 +98,7 @@ RooMappedCategory::RooMappedCategory(const RooMappedCategory &other, const char 
      _inputCat("input", this, other._inputCat),
      _mapArray(other._mapArray)
 {
-   _defCat = lookupIndex(other.lookupName(other._defCat));
+   setDefCat(lookupIndex(other.lookupName(other._defCat)));
 }
 
 RooMappedCategory::~RooMappedCategory() = default;

--- a/roofit/roofitcore/src/RooMappedCategory.cxx
+++ b/roofit/roofitcore/src/RooMappedCategory.cxx
@@ -204,13 +204,15 @@ bool RooMappedCategory::readFromStream(std::istream& is, bool compact, bool /*ve
      clearTypes() ;
      _defCat = defineState(defCatName.Data()).second;
 
-     TString token,errorPrefix("RooMappedCategory::readFromStream(") ;
+     TString token;
+     TString errorPrefix("RooMappedCategory::readFromStream(");
      errorPrefix.Append(GetName()) ;
      errorPrefix.Append(")") ;
      RooStreamParser parser(is,errorPrefix) ;
      parser.setPunctuation(":,") ;
 
-     TString destKey,srcKey ;
+     TString destKey;
+     TString srcKey;
      bool readToken(true) ;
 
     // Loop over definition sequences

--- a/roofit/roofitcore/src/RooMath.cxx
+++ b/roofit/roofitcore/src/RooMath.cxx
@@ -82,9 +82,16 @@ double RooMath::interpolate(double ya[], Int_t n, double x)
    // Int to Double conversion is faster via array lookup than type conversion!
    static double itod[20] = {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,  9.0,
                              10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0};
-   int i, m, ns = 1;
-   double den, dif, dift /*,ho,hp,w*/, y, dy;
-   double c[20], d[20];
+   int i;
+   int m;
+   int ns = 1;
+   double den;
+   double dif;
+   double dift /*,ho,hp,w*/;
+   double y;
+   double dy;
+   double c[20];
+   double d[20];
 
    dif = std::abs(x);
    for (i = 1; i <= n; i++) {
@@ -116,9 +123,19 @@ double RooMath::interpolate(double xa[], double ya[], Int_t n, double x)
    // Int to Double conversion is faster via array lookup than type conversion!
    //   static double itod[20] = { 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0,
    //                10.0,11.0,12.0,13.0,14.0,15.0,16.0,17.0,18.0,19.0} ;
-   int i, m, ns = 1;
-   double den, dif, dift, ho, hp, w, y, dy;
-   double c[20], d[20];
+   int i;
+   int m;
+   int ns = 1;
+   double den;
+   double dif;
+   double dift;
+   double ho;
+   double hp;
+   double w;
+   double y;
+   double dy;
+   double c[20];
+   double d[20];
 
    dif = std::abs(x - xa[0]);
    for (i = 1; i <= n; i++) {

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -591,7 +591,8 @@ RooFit::OwningPtr<RooFitResult> RooMinimizer::save(const char *userName, const c
       return nullptr;
    }
 
-   TString name, title;
+   TString name;
+   TString title;
    name = userName ? userName : Form("%s", _fcn->getFunctionName().c_str());
    title = userTitle ? userTitle : Form("%s", _fcn->getFunctionTitle().c_str());
    auto fitRes = std::make_unique<RooFitResult>(name, title);

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -18,7 +18,7 @@
 \class RooMinimizer
 \ingroup Roofitcore
 
-RooMinimizer is a wrapper class around ROOT::Fit:Fitter that
+Wrapper class around ROOT::Fit:Fitter that
 provides a seamless interface between the minimizer functionality
 and the native RooFit interface.
 By default the Minimizer is MINUIT for classic mode and MINUIT2

--- a/roofit/roofitcore/src/RooMsgService.cxx
+++ b/roofit/roofitcore/src/RooMsgService.cxx
@@ -20,7 +20,7 @@
 \ingroup Roofitcore
 
 
-The class RooMsgService is a singleton that organizes messages generated in RooFit.
+Singleton class that organizes messages generated in RooFit.
 Each message has a message level RooFit::MsgLevel (DEBUG,INFO,PROGRESS,WARNING,ERROR or FATAL),
 an source object, and a RooFit::MsgTopic.
 RooMsgService allows to filter and redirect messages into streams

--- a/roofit/roofitcore/src/RooMultiCategory.cxx
+++ b/roofit/roofitcore/src/RooMultiCategory.cxx
@@ -19,7 +19,7 @@
 \class RooMultiCategory
 \ingroup Roofitcore
 
-RooMultiCategory connects several RooAbsCategory objects into
+Connects several RooAbsCategory objects into
 a single category. The states of the multi-category consist of all the permutations
 of the input categories.
 RooMultiCategory states are automatically defined and updated whenever an input

--- a/roofit/roofitcore/src/RooMultiVarGaussian.cxx
+++ b/roofit/roofitcore/src/RooMultiVarGaussian.cxx
@@ -324,14 +324,17 @@ RooMultiVarGaussian::AnaIntData& RooMultiVarGaussian::anaIntData(Int_t code) con
   // Calculate cache contents
 
   // Decode integration code
-  vector<int> map1,map2 ;
+  vector<int> map1;
+  vector<int> map2;
   decodeCode(code,map1,map2) ;
 
   // Rearrage observables so that all non-integrated observables
   // go first (preserving relative order) and all integrated observables
   // go last (preserving relative order)
-  TMatrixDSym S11, S22 ;
-  TMatrixD S12, S21 ;
+  TMatrixDSym S11;
+  TMatrixDSym S22;
+  TMatrixD S12;
+  TMatrixD S21;
   blockDecompose(_covI,map1,map2,S11,S12,S21,S22) ;
 
   // Begin calculation of partial integrals
@@ -528,12 +531,15 @@ RooMultiVarGaussian::GenData& RooMultiVarGaussian::genData(Int_t code) const
   } else {
 
     // Construct observables: map1 = generated, map2 = given
-    vector<int> map1, map2 ;
+    vector<int> map1;
+    vector<int> map2;
     decodeCode(code,map2,map1) ;
 
     // Do block decomposition of covariance matrix
-    TMatrixDSym S11, S22 ;
-    TMatrixD S12, S21 ;
+    TMatrixDSym S11;
+    TMatrixDSym S22;
+    TMatrixD S12;
+    TMatrixD S21;
     blockDecompose(_cov,map1,map2,S11,S12,S21,S22) ;
 
     // Constructed conditional matrix form
@@ -553,7 +559,8 @@ RooMultiVarGaussian::GenData& RooMultiVarGaussian::genData(Int_t code) const
     TMatrixD TU(TMatrixD::kTransposed,U) ;
 
     // Split mu vector into mu1 and mu2
-    TVectorD mu1(map1.size()),mu2(map2.size()) ;
+    TVectorD mu1(map1.size());
+    TVectorD mu2(map2.size());
     syncMuVec() ;
     for (UInt_t i=0 ; i<map1.size() ; i++) {
       mu1(i) = _muVec(map1[i]) ;

--- a/roofit/roofitcore/src/RooNLLVar.cxx
+++ b/roofit/roofitcore/src/RooNLLVar.cxx
@@ -19,7 +19,7 @@
 \class RooNLLVar
 \ingroup Roofitcore
 
-Class RooNLLVar implements a -log(likelihood) calculation from a dataset
+Implements a -log(likelihood) calculation from a dataset
 and a PDF. The NLL is calculated as
 \f[
  \sum_\mathrm{data} -\log( \mathrm{pdf}(x_\mathrm{data}))

--- a/roofit/roofitcore/src/RooNLLVarNew.cxx
+++ b/roofit/roofitcore/src/RooNLLVarNew.cxx
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*
  * Project: RooFit
  * Authors:
@@ -409,3 +411,5 @@ void RooNLLVarNew::translate(RooFit::Detail::CodeSquashContext &ctx) const
       ctx.addToCodeBody(resName + " += " + expected + " - " + weightSumName + " * std::log(" + expected + ");\n");
    }
 }
+
+/// \endcond

--- a/roofit/roofitcore/src/RooNLLVarNew.h
+++ b/roofit/roofitcore/src/RooNLLVarNew.h
@@ -1,3 +1,5 @@
+/// \cond ROOFIT_INTERNAL
+
 /*
  * Project: RooFit
  * Authors:
@@ -80,3 +82,5 @@ private:
 }; // end class RooNLLVar
 
 #endif
+
+/// \endcond

--- a/roofit/roofitcore/src/RooNameReg.cxx
+++ b/roofit/roofitcore/src/RooNameReg.cxx
@@ -19,7 +19,7 @@
 \class RooNameReg
 \ingroup Roofitcore
 
-RooNameReg is a registry for `const char*` names. For each unique
+Registry for `const char*` names. For each unique
 name (which is not necessarily a unique pointer in the C++ standard),
 a unique pointer to a TNamed object is returned that can be used for
 fast searches and comparisons.
@@ -35,14 +35,6 @@ using namespace std ;
 RooNameReg::RooNameReg() :
     TNamed("RooNameReg","RooFit Name Registry")
 {}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Destructor
-
-RooNameReg::~RooNameReg()
-{
-}
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return reference to singleton instance

--- a/roofit/roofitcore/src/RooNumCdf.cxx
+++ b/roofit/roofitcore/src/RooNumCdf.cxx
@@ -14,8 +14,8 @@
 \class RooNumCdf
 \ingroup Roofitcore
 
-Class RooNumCdf is an implementation of RooNumRunningInt specialized
-to calculate cumulative distribution functions from p.d.f.s. The main
+Implementation of RooNumRunningInt
+that calculates cumulative distribution functions from p.d.f.s. The main
 difference between RooNumCdf and RooNumRunningInt is that this class
 imposes special end-point conditions on the interpolated histogram
 that represents the output so that the value at the lower bound is

--- a/roofit/roofitcore/src/RooNumGenConfig.cxx
+++ b/roofit/roofitcore/src/RooNumGenConfig.cxx
@@ -19,7 +19,7 @@
 \class RooNumGenConfig
 \ingroup Roofitcore
 
-RooNumGenConfig holds the configuration parameters of the various
+Holds the configuration parameters of the various
 numeric integrators used by RooRealIntegral. RooRealIntegral and RooAbsPdf
 use this class in the (normalization) integral configuration interface
 **/

--- a/roofit/roofitcore/src/RooNumGenFactory.cxx
+++ b/roofit/roofitcore/src/RooNumGenFactory.cxx
@@ -19,7 +19,7 @@
 \class RooNumGenFactory
 \ingroup Roofitcore
 
-RooNumGenFactory is a factory to instantiate numeric integrators
+%Factory to instantiate numeric integrators
 from a given function binding and a given configuration. The factory
 searches for a numeric integrator registered with the factory that
 has the ability to perform the numeric integration. The choice of
@@ -42,8 +42,6 @@ the preference of the caller as encoded in the configuration object.
 
 
 #include "RooMsgService.h"
-
-using namespace std ;
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -188,7 +186,7 @@ RooAbsNumGenerator* RooNumGenFactory::createSampler(RooAbsReal& func, const RooA
   // Check that a method was defined for this case
   if (!method.CompareTo("N/A")) {
     oocoutE(nullptr,Integration) << "RooNumGenFactory::createSampler: No sampler method has been defined for "
-                 << (cond?"a conditional ":"a ") << ndim << "-dimensional p.d.f" << endl ;
+                 << (cond?"a conditional ":"a ") << ndim << "-dimensional p.d.f" << std::endl;
     return nullptr ;
   }
 

--- a/roofit/roofitcore/src/RooNumIntFactory.cxx
+++ b/roofit/roofitcore/src/RooNumIntFactory.cxx
@@ -19,7 +19,7 @@
 \class RooNumIntFactory
 \ingroup Roofitcore
 
-Factory to instantiate numeric integrators
+%Factory to instantiate numeric integrators
 from a given function binding and a given configuration. The factory
 searches for a numeric integrator registered with the factory that
 has the ability to perform the numeric integration. The choice of

--- a/roofit/roofitcore/src/RooNumRunningInt.cxx
+++ b/roofit/roofitcore/src/RooNumRunningInt.cxx
@@ -14,7 +14,7 @@
 \class RooNumRunningInt
 \ingroup Roofitcore
 
-Class RooNumRunningInt is an implementation of RooAbsCachedReal that represents a running integral
+Implementation of RooAbsCachedReal that represents a running integral
 \f[ RI(f(x)) = \int_{xlow}^{x} f(x') dx'                 \f]
 that is calculated internally with a numeric technique: The input function
 is first sampled into a histogram, which is then numerically integrated.

--- a/roofit/roofitcore/src/RooNumber.cxx
+++ b/roofit/roofitcore/src/RooNumber.cxx
@@ -19,7 +19,7 @@
 \class RooNumber
 \ingroup Roofitcore
 
-Class RooNumber implements numeric constants used by RooFit
+Provides numeric constants used in \ref Roofitmain.
 **/
 
 #include <RooNumber.h>

--- a/roofit/roofitcore/src/RooObjCacheManager.cxx
+++ b/roofit/roofitcore/src/RooObjCacheManager.cxx
@@ -19,8 +19,8 @@
 \class RooObjCacheManager
 \ingroup Roofitcore
 
-Class RooObjCacheManager is an implementation of class RooCacheManager<RooAbsCacheElement>
-and specializes in the storage of cache elements that contain RooAbsArg objects.
+Implementation of a RooCacheManager<RooAbsCacheElement>
+that specializes in the storage of cache elements that contain RooAbsArg objects.
 Caches with RooAbsArg derived payload require special care as server redirects
 cache operation mode changes and constant term optimization calls may need to be
 forwarded to such cache payload. This cache manager takes care of all these operations
@@ -33,11 +33,7 @@ have a sensible default implementation.
 #include "RooObjCacheManager.h"
 #include "RooMsgService.h"
 
-using namespace std ;
-
 ClassImp(RooObjCacheManager);
-   ;
-
 
 bool RooObjCacheManager::_clearObsList(false) ;
 
@@ -52,8 +48,7 @@ RooObjCacheManager::RooObjCacheManager(RooAbsArg* owner, Int_t maxSize, bool cle
   RooCacheManager<RooAbsCacheElement>(owner,maxSize),
   _clearOnRedirect(clearCacheOnServerRedirect),
   _allowOptimize(allowOptimize),
-  _optCacheModeSeen(false),
-  _optCacheObservables(nullptr)
+  _optCacheModeSeen(false)
 {
 }
 
@@ -65,8 +60,7 @@ RooObjCacheManager::RooObjCacheManager(const RooObjCacheManager& other, RooAbsAr
   RooCacheManager<RooAbsCacheElement>(other,owner),
   _clearOnRedirect(other._clearOnRedirect),
   _allowOptimize(other._allowOptimize),
-  _optCacheModeSeen(false), // cache mode properties are not transferred in copy ctor
-  _optCacheObservables(nullptr)
+  _optCacheModeSeen(false) // cache mode properties are not transferred in copy ctor
 {
 }
 
@@ -134,7 +128,7 @@ void RooObjCacheManager::operModeHook()
 
 void RooObjCacheManager::optimizeCacheMode(const RooArgSet& obs, RooArgSet& optNodes, RooLinkedList& processedNodes)
 {
-  oocxcoutD(_owner,Caching) << "RooObjCacheManager::optimizeCacheMode(owner=" << _owner->GetName() << ") obs = " << obs << endl ;
+  oocxcoutD(_owner,Caching) << "RooObjCacheManager::optimizeCacheMode(owner=" << _owner->GetName() << ") obs = " << obs << std::endl;
 
   _optCacheModeSeen = true ;
 

--- a/roofit/roofitcore/src/RooPlot.cxx
+++ b/roofit/roofitcore/src/RooPlot.cxx
@@ -455,7 +455,8 @@ namespace {
       std::map<int,double> minValues;
       std::map<int,double> maxValues;
       int n = graph->GetN();
-      double x, y;
+      double x;
+      double y;
       // for each bin, find the min and max points to form an envelope
       for(int i=0; i<n; ++i){
         graph->GetPoint(i,x,y);
@@ -499,7 +500,8 @@ namespace {
     int n = graph->GetN();
     double xmin = hist->GetXaxis()->GetXmin();
     double xmax = hist->GetXaxis()->GetXmax();
-    double x, y;
+    double x;
+    double y;
     // as this graph is histogram-like, we expect there to be one point per bin
     // we just move these points to the respective bin centers
     for(int i=0; i<n; ++i){
@@ -1378,7 +1380,8 @@ void RooPlot::Streamer(TBuffer &R__b)
     if (_dir)
       _dir->Remove(this);
 
-    UInt_t R__s, R__c;
+    UInt_t R__s;
+    UInt_t R__c;
     Version_t R__v = R__b.ReadVersion(&R__s, &R__c);
     if (R__v > 1) {
       R__b.ReadClassBuffer(RooPlot::Class(),this,R__v,R__s,R__c);

--- a/roofit/roofitcore/src/RooPlot.cxx
+++ b/roofit/roofitcore/src/RooPlot.cxx
@@ -19,7 +19,7 @@
 \class RooPlot
 \ingroup Roofitcore
 
-A RooPlot is a plot frame and a container for graphics objects
+Plot frame and a container for graphics objects
 within that frame. As a frame, it provides the TH1-style public interface
 for setting plot ranges, configuring axes, etc. As a container, it
 holds an arbitrary set of objects that might be histograms of data,

--- a/roofit/roofitcore/src/RooPolyVar.cxx
+++ b/roofit/roofitcore/src/RooPolyVar.cxx
@@ -19,7 +19,7 @@
 \class RooPolyVar
 \ingroup Roofitcore
 
-Class RooPolyVar is a RooAbsReal implementing a polynomial in terms
+A RooAbsReal implementing a polynomial in terms
 of a list of RooAbsReal coefficients
 \f[f(x) = \sum_{i} a_{i} \cdot x^i \f]
 Class RooPolyvar implements analytical integrals of all polynomials

--- a/roofit/roofitcore/src/RooPolyVar.cxx
+++ b/roofit/roofitcore/src/RooPolyVar.cxx
@@ -183,7 +183,8 @@ double RooPolyVar::analyticalIntegral(Int_t code, const char *rangeName) const
 {
    R__ASSERT(code == 1);
 
-   const double xmin = _x.min(rangeName), xmax = _x.max(rangeName);
+   const double xmin = _x.min(rangeName);
+   const double xmax = _x.max(rangeName);
    const unsigned sz = _coefList.size();
    if (!sz)
       return _lowestOrder ? xmax - xmin : 0.0;
@@ -196,7 +197,8 @@ double RooPolyVar::analyticalIntegral(Int_t code, const char *rangeName) const
 std::string RooPolyVar::buildCallToAnalyticIntegral(Int_t /* code */, const char *rangeName,
                                                     RooFit::Detail::CodeSquashContext &ctx) const
 {
-   const double xmin = _x.min(rangeName), xmax = _x.max(rangeName);
+   const double xmin = _x.min(rangeName);
+   const double xmax = _x.max(rangeName);
    const unsigned sz = _coefList.size();
    if (!sz)
       return std::to_string(_lowestOrder ? xmax - xmin : 0.0);

--- a/roofit/roofitcore/src/RooPrintable.cxx
+++ b/roofit/roofitcore/src/RooPrintable.cxx
@@ -19,7 +19,7 @@
 \class RooPrintable
 \ingroup Roofitcore
 
-RooPlotable is a 'mix-in' base class that define the standard RooFit plotting and
+A 'mix-in' base class that define the standard RooFit plotting and
 printing methods. Each RooPlotable implementation must define methods that
 print the objects name, class name, title, value, arguments and extras
 to a provided stream. The definition of value is class dependent. The definition
@@ -42,7 +42,6 @@ given a Print() option string.
 using namespace std;
 
 ClassImp(RooPrintable);
-;
 
 Int_t  RooPrintable::_nameLength(0) ;
 

--- a/roofit/roofitcore/src/RooProdGenContext.cxx
+++ b/roofit/roofitcore/src/RooProdGenContext.cxx
@@ -63,7 +63,11 @@ RooProdGenContext::RooProdGenContext(const RooProdPdf &model, const RooArgSet &v
   }
 
   // Factorize product in irreducible terms
-  RooLinkedList termList,depsList,impDepList,crossDepList,intList ;
+  RooLinkedList termList;
+  RooLinkedList depsList;
+  RooLinkedList impDepList;
+  RooLinkedList crossDepList;
+  RooLinkedList intList;
   model.factorizeProduct(deps,RooArgSet(),termList,depsList,impDepList,crossDepList,intList) ;
 
   if (dologD(Generation)) {

--- a/roofit/roofitcore/src/RooProfileLL.cxx
+++ b/roofit/roofitcore/src/RooProfileLL.cxx
@@ -14,7 +14,7 @@
 \class RooProfileLL
 \ingroup Roofitcore
 
-Class RooProfileLL implements the profile likelihood estimator for
+Implements the profile likelihood estimator for
 a given likelihood and set of parameters of interest. The value return by
 RooProfileLL is the input likelihood nll minimized w.r.t all nuisance parameters
 (which are all parameters except for those listed in the constructor) minus
@@ -41,7 +41,6 @@ ClassImp(RooProfileLL);
 
 RooProfileLL::RooProfileLL()
    : RooAbsReal("RooProfileLL", "RooProfileLL"),
-
      _obs("paramOfInterest", "Parameters of interest", this),
      _par("nuisanceParam", "Nuisance parameters", this, false, false)
 {
@@ -273,5 +272,3 @@ bool RooProfileLL::redirectServersHook(const RooAbsCollection& newServerList, bo
   _minimizer.reset();
   return RooAbsReal::redirectServersHook(newServerList, mustReplaceAll, nameChange, isRecursive);
 }
-
-

--- a/roofit/roofitcore/src/RooProjectedPdf.cxx
+++ b/roofit/roofitcore/src/RooProjectedPdf.cxx
@@ -14,7 +14,7 @@
 \class RooProjectedPdf
 \ingroup Roofitcore
 
-Class RooProjectedPdf is a RooAbsPdf implementation that represent a projection
+A RooAbsPdf implementation that represent a projection
 of a given input p.d.f and the object returned by RooAbsPdf::createProjection.
 The actual projection integral for it value and normalization are
 calculated on the fly in getVal() once the normalization observables are known.

--- a/roofit/roofitcore/src/RooPullVar.cxx
+++ b/roofit/roofitcore/src/RooPullVar.cxx
@@ -19,7 +19,7 @@
 \class RooPullVar
 \ingroup Roofitcore
 
-RooPullVar represents the pull of a measurement w.r.t. the true value
+Represents the pull of a measurement w.r.t. the true value
 using the measurement and its error. Both the true value and
 the measured value (with error) are taken from two user-supplied
 RooRealVars. If the measured parameter has an asymmetric error, the proper
@@ -34,20 +34,7 @@ side of that error will be used:
 #include "RooAbsReal.h"
 #include "RooRealVar.h"
 
-using namespace std;
-
 ClassImp(RooPullVar);
-;
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Default constructor
-
-RooPullVar::RooPullVar()
-{
-}
-
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Construct the pull of the RooRealVar 'meas'.
@@ -77,17 +64,6 @@ RooPullVar::RooPullVar(const RooPullVar& other, const char* name) :
 {
 }
 
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Destructor
-
-RooPullVar::~RooPullVar()
-{
-}
-
-
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Calculate pull. Use asymmetric error if defined in measurement,
 /// otherwise use symmetric error. If measurement has no error
@@ -109,5 +85,3 @@ double RooPullVar::evaluate() const
     return 0 ;
   }
 }
-
-

--- a/roofit/roofitcore/src/RooQuasiRandomGenerator.cxx
+++ b/roofit/roofitcore/src/RooQuasiRandomGenerator.cxx
@@ -92,7 +92,8 @@ bool RooQuasiRandomGenerator::generate(UInt_t dimension, double vector[])
    * This is the bit that changes in the Gray-code representation as
    * the count is advanced.
    */
-  Int_t r(0),c(_sequenceCount);
+  Int_t r(0);
+  Int_t c(_sequenceCount);
   while(true) {
     if((c % 2) == 1) {
       ++r;
@@ -128,7 +129,8 @@ void RooQuasiRandomGenerator::calculateCoefs(UInt_t dimension)
   for(i_dim=0; i_dim<dimension; i_dim++) {
 
     const int poly_index = i_dim + 1;
-    int j, k;
+    int j;
+    int k;
 
     /* Niederreiter (page 56, after equation (7), defines two
      * variables Q and U.  We do not need Q explicitly, but we
@@ -210,7 +212,9 @@ void RooQuasiRandomGenerator::calculateV(const int px[], int px_degree,
   /* int ph_degree = *pb_degree; */
   int bigm = *pb_degree;      /* m from section 3.3 */
   int m;                      /* m from section 2.3 */
-  int r, k, kj;
+  int r;
+  int k;
+  int kj;
 
   for(k=0; k<=MaxDegree; k++) {
     ph[k] = pb[k];
@@ -291,7 +295,8 @@ void RooQuasiRandomGenerator::calculateV(const int px[], int px_degree,
 void RooQuasiRandomGenerator::polyMultiply(const int pa[], int pa_degree, const int pb[],
                   int pb_degree, int pc[], int  * pc_degree)
 {
-  int j, k;
+  int j;
+  int k;
   int pt[MaxDegree+1];
   int pt_degree = pa_degree + pb_degree;
 

--- a/roofit/roofitcore/src/RooRealIntegral.cxx
+++ b/roofit/roofitcore/src/RooRealIntegral.cxx
@@ -345,7 +345,8 @@ RooRealIntegral::RooRealIntegral(const char *name, const char *title,
 
   // Initial fill of list of LValue branches
   RooArgSet exclLVBranches("exclLVBranches") ;
-  RooArgSet branchList,branchListVD ;
+  RooArgSet branchList;
+  RooArgSet branchListVD;
   function.branchNodeServerList(&branchList) ;
 
   for (auto branch: branchList) {

--- a/roofit/roofitcore/src/RooRealMPFE.cxx
+++ b/roofit/roofitcore/src/RooRealMPFE.cxx
@@ -249,7 +249,9 @@ void RooRealMPFE::serverLoop()
 #ifndef _WIN32
   int msg ;
 
-  Int_t idx, index, numErrors ;
+  Int_t idx;
+  Int_t index;
+  Int_t numErrors;
   double value ;
   bool isConst ;
 
@@ -444,13 +446,15 @@ void RooRealMPFE::calculate() const
     Int_t i(0) ;
 
     //for (i=0 ; i<_vars.size() ; i++) {
-    RooAbsArg *var, *saveVar ;
+    RooAbsArg *var;
+    RooAbsArg *saveVar;
     for (std::size_t j=0 ; j<_vars.size() ; j++) {
       var = _vars.at(j);
       saveVar = _saveVars.at(j);
 
       //bool valChanged = !(*var==*saveVar) ;
-      bool valChanged,constChanged  ;
+      bool valChanged;
+      bool constChanged;
       if (!_updateMaster) {
    valChanged = !var->isIdentical(*saveVar,true) ;
    constChanged = (var->isConstant() != saveVar->isConstant()) ;
@@ -601,7 +605,9 @@ double RooRealMPFE::evaluate() const
               << ") IPC fromServer> NumErrors " << numError << endl ;
     if (numError) {
       // Retrieve remote errors and feed into local error queue
-      char *msgbuf1 = nullptr, *msgbuf2 = nullptr, *msgbuf3 = nullptr;
+      char *msgbuf1 = nullptr;
+      char *msgbuf2 = nullptr;
+      char *msgbuf3 = nullptr;
       RooAbsArg *ptr = nullptr;
       while (true) {
    *_pipe >> ptr;

--- a/roofit/roofitcore/src/RooRealSumPdf.cxx
+++ b/roofit/roofitcore/src/RooRealSumPdf.cxx
@@ -130,7 +130,7 @@ RooRealSumPdf::RooRealSumPdf(const char *name, const char *title, const RooArgLi
                              const RooArgList &inCoefList, bool extended)
    : RooRealSumPdf(name, title)
 {
-  _extended = extended;
+  setExtended(extended);
 
   RooRealSumPdf::initializeFuncsAndCoefs(*this, inFuncList, inCoefList, _funcList, _coefList);
 }

--- a/roofit/roofitcore/src/RooRealVar.cxx
+++ b/roofit/roofitcore/src/RooRealVar.cxx
@@ -277,7 +277,8 @@ void RooRealVar::setVal(double value, const char* rangeName)
 
 RooErrorVar* RooRealVar::errorVar() const
 {
-  TString name(GetName()), title(GetTitle()) ;
+  TString name(GetName());
+  TString title(GetTitle());
   name.Append("err") ;
   title.Append(" Error") ;
 
@@ -554,7 +555,8 @@ void RooRealVar::setRange(const char* name, RooAbsReal& min, RooAbsReal& max)
 
 bool RooRealVar::readFromStream(istream& is, bool compact, bool verbose)
 {
-  TString token,errorPrefix("RooRealVar::readFromStream(") ;
+  TString token;
+  TString errorPrefix("RooRealVar::readFromStream(");
   errorPrefix.Append(GetName()) ;
   errorPrefix.Append(")") ;
   RooStreamParser parser(is,errorPrefix) ;
@@ -605,7 +607,8 @@ bool RooRealVar::readFromStream(istream& is, bool compact, bool verbose)
 
    } else {
      // Have error
-     double asymErrLo=0., asymErrHi=0.;
+     double asymErrLo = 0.;
+     double asymErrHi = 0.;
      if (parser.readDouble(asymErrLo,true) ||
          parser.expectToken(",",true) ||
          parser.readDouble(asymErrHi,true) ||
@@ -622,8 +625,9 @@ bool RooRealVar::readFromStream(istream& is, bool compact, bool verbose)
       } else if (!token.CompareTo("P")) {
 
    // Next tokens are plot limits
-   double plotMin(0), plotMax(0) ;
-        Int_t plotBins(0) ;
+   double plotMin(0);
+   double plotMax(0);
+   Int_t plotBins(0);
    if (parser.expectToken("(",true) ||
        parser.readDouble(plotMin,true) ||
        parser.expectToken("-",true) ||
@@ -638,7 +642,8 @@ bool RooRealVar::readFromStream(istream& is, bool compact, bool verbose)
       } else if (!token.CompareTo("F")) {
 
    // Next tokens are fit limits
-   double fitMin, fitMax ;
+   double fitMin;
+   double fitMax;
    Int_t fitBins ;
    if (parser.expectToken("(",true) ||
        parser.readDouble(fitMin,true) ||
@@ -656,8 +661,9 @@ bool RooRealVar::readFromStream(istream& is, bool compact, bool verbose)
       } else if (!token.CompareTo("L")) {
 
    // Next tokens are fit limits
-   double fitMin = 0.0, fitMax = 0.0;
-// Int_t fitBins ;
+   double fitMin = 0.0;
+   double fitMax = 0.0;
+   // Int_t fitBins ;
    if (parser.expectToken("(",true) ||
        parser.readDouble(fitMin,true) ||
        parser.expectToken("-",true) ||
@@ -700,7 +706,8 @@ void RooRealVar::writeToStream(ostream& os, bool compact) const
 
     // Write value with error (if not zero)
     if (_printScientific) {
-      char fmtVal[16], fmtErr[16] ;
+      char fmtVal[16];
+      char fmtErr[16];
       snprintf(fmtVal,16,"%%.%de",_printSigDigits) ;
       snprintf(fmtErr,16,"%%.%de",(_printSigDigits+1)/2) ;
       if (_value>=0) os << " " ;
@@ -947,7 +954,8 @@ TString *RooRealVar::format(Int_t sigDigits, const char *options) const
   Int_t leadingDigitErr= (Int_t)floor(log10(std::abs(_error+1e-10)));
   Int_t whereVal= leadingDigitVal - sigDigits + 1;
   Int_t whereErr= leadingDigitErr - sigDigits + 1;
-  char fmtVal[16], fmtErr[16];
+  char fmtVal[16];
+  char fmtErr[16];
 
   if (_value<0) whereVal -= 1 ;
   snprintf(fmtVal,16,"%%.%df", whereVal < 0 ? -whereVal : 0);
@@ -1210,14 +1218,16 @@ void RooRealVar::copyCache(const RooAbsArg* source, bool valueOnly, bool setValD
 
 void RooRealVar::Streamer(TBuffer &R__b)
 {
-  UInt_t R__s, R__c;
+  UInt_t R__s;
+  UInt_t R__c;
   if (R__b.IsReading()) {
 
     Version_t R__v = R__b.ReadVersion(&R__s, &R__c); if (R__v) { }
     RooAbsRealLValue::Streamer(R__b);
     if (R__v==1) {
       coutI(Eval) << "RooRealVar::Streamer(" << GetName() << ") converting version 1 data format" << endl ;
-      double fitMin, fitMax ;
+      double fitMin;
+      double fitMax;
       Int_t fitBins ;
       R__b >> fitMin;
       R__b >> fitMax;

--- a/roofit/roofitcore/src/RooRecursiveFraction.cxx
+++ b/roofit/roofitcore/src/RooRecursiveFraction.cxx
@@ -19,7 +19,7 @@
 \class RooRecursiveFraction
 \ingroup Roofitcore
 
-Class RooRecursiveFraction is a RooAbsReal implementation that
+A RooAbsReal implementation that
 calculates the plain fraction of sum of RooAddPdf components
 from a set of recursive fractions: for a given set of input fractions
 \f$ {a_i} \f$, it returns \f$ a_n * \prod_{i=0}^{n-1} (1 - a_i) \f$.

--- a/roofit/roofitcore/src/RooSimGenContext.cxx
+++ b/roofit/roofitcore/src/RooSimGenContext.cxx
@@ -227,7 +227,8 @@ void RooSimGenContext::generateEvent(RooArgSet &theEvent, Int_t remaining)
   if (_haveIdxProto) {
 
     // Lookup pdf from selected prototype index state
-    Int_t gidx(0), cidx =_idxCat->getCurrentIndex() ;
+    Int_t gidx(0);
+    Int_t cidx = _idxCat->getCurrentIndex();
     for (Int_t i=0 ; i<(Int_t)_gcIndex.size() ; i++) {
       if (_gcIndex[i]==cidx) { gidx = i ; break ; }
     }

--- a/roofit/roofitcore/src/RooStreamParser.cxx
+++ b/roofit/roofitcore/src/RooStreamParser.cxx
@@ -116,8 +116,13 @@ bool RooStreamParser::isPunctChar(char c) const
 TString RooStreamParser::readToken()
 {
   // Smart tokenizer. Absorb white space and token must be either punctuation or alphanum
-  bool first(true), quotedString(false), lineCont(false) ;
-  char buffer[64000], c(0), cnext = '\0', cprev = ' ';
+  bool first(true);
+  bool quotedString(false);
+  bool lineCont(false);
+  char buffer[64000];
+  char c(0);
+  char cnext = '\0';
+  char cprev = ' ';
   bool haveINF(false) ;
   Int_t bufptr(0) ;
 
@@ -170,12 +175,13 @@ TString RooStreamParser::readToken()
 
 
       if (cnext=='I' || cnext=='i') {
-        char tmp1,tmp2 ;
-        _is->get(tmp1) ;
-        _is->get(tmp2) ;
-        _is->putback(tmp2) ;
-        _is->putback(tmp1) ;
-        haveINF = ((cnext=='I' && tmp1 == 'N' && tmp2 == 'F') || (cnext=='i' && tmp1 == 'n' && tmp2 == 'f')) ;
+          char tmp1;
+          char tmp2;
+          _is->get(tmp1);
+          _is->get(tmp2);
+          _is->putback(tmp2);
+          _is->putback(tmp1);
+          haveINF = ((cnext == 'I' && tmp1 == 'N' && tmp2 == 'F') || (cnext == 'i' && tmp1 == 'n' && tmp2 == 'f'));
       } else {
         haveINF = false ;
       }
@@ -295,7 +301,8 @@ TString RooStreamParser::readToken()
 
 TString RooStreamParser::readLine()
 {
-   char c, buffer[64000];
+   char c;
+   char buffer[64000];
    Int_t nfree(63999);
 
    if (_is->peek() == '\n')
@@ -315,27 +322,30 @@ TString RooStreamParser::readLine()
       if (nextpcontseq)
          nfree -= (nextpcontseq - pcontseq);
       pcontseq = nextpcontseq;
-  }
+   }
 
-  // Chop eventual comments
-  char *pcomment = strstr(buffer,"//") ;
-  if (pcomment) *pcomment=0 ;
+   // Chop eventual comments
+   char *pcomment = strstr(buffer, "//");
+   if (pcomment)
+      *pcomment = 0;
 
-  // Chop leading and trailing space
-  char *pstart=buffer ;
-  while (isspace(*pstart)) {
-    pstart++ ;
-  }
-  char *pend=buffer+strlen(buffer)-1 ;
-  if (pend>pstart)
-    while (isspace(*pend)) { *pend--=0 ; }
+   // Chop leading and trailing space
+   char *pstart = buffer;
+   while (isspace(*pstart)) {
+      pstart++;
+   }
+   char *pend = buffer + strlen(buffer) - 1;
+   if (pend > pstart)
+      while (isspace(*pend)) {
+         *pend-- = 0;
+      }
 
-  if (_is->eof() || _is->fail()) {
-    _atEOF = true ;
-  }
+   if (_is->eof() || _is->fail()) {
+      _atEOF = true;
+   }
 
-  // Convert to TString
-  return TString(pstart) ;
+   // Convert to TString
+   return TString(pstart);
 }
 
 
@@ -413,25 +423,25 @@ bool RooStreamParser::readDouble(double& value, bool /*zapOnError*/)
 ////////////////////////////////////////////////////////////////////////////////
 /// Convert given string to a double. Return true if the conversion fails.
 
-bool RooStreamParser::convertToDouble(const TString& token, double& value)
+bool RooStreamParser::convertToDouble(const TString &token, double &value)
 {
-  char* endptr = nullptr;
-  const char* data=token.Data() ;
+   char *endptr = nullptr;
+   const char *data = token.Data();
 
-  // Handle +/- infinity cases, (token is guaranteed to be >1 char long)
-  if (!strcasecmp(data,"inf") || !strcasecmp(data+1,"inf")) {
-    value = (data[0]=='-') ? -RooNumber::infinity() : RooNumber::infinity() ;
-    return false ;
-  }
+   // Handle +/- infinity cases, (token is guaranteed to be >1 char long)
+   if (!strcasecmp(data, "inf") || !strcasecmp(data + 1, "inf")) {
+      value = (data[0] == '-') ? -RooNumber::infinity() : RooNumber::infinity();
+      return false;
+   }
 
-  value = strtod(data,&endptr) ;
-  bool error = (endptr-data!=token.Length()) ;
+   value = strtod(data, &endptr);
+   bool error = (endptr - data != token.Length());
 
-  if (error && !_prefix.IsNull()) {
-    oocoutE(nullptr,InputArguments) << _prefix << ": parse error, cannot convert '"
-               << token << "'" << " to double precision" <<  endl ;
-  }
-  return error ;
+   if (error && !_prefix.IsNull()) {
+      oocoutE(nullptr, InputArguments) << _prefix << ": parse error, cannot convert '" << token << "'"
+                                       << " to double precision" << endl;
+   }
+   return error;
 }
 
 
@@ -489,12 +499,13 @@ bool RooStreamParser::readString(TString& value, bool /*zapOnError*/)
 bool RooStreamParser::convertToString(const TString& token, TString& string)
 {
    // Transport to buffer
-   char buffer[64000], *ptr;
-   strncpy(buffer, token.Data(), 63999);
-   if (token.Length() >= 63999) {
-      oocoutW(nullptr, InputArguments) << "RooStreamParser::convertToString: token length exceeds 63999, truncated"
-                                            << endl;
-      buffer[63999] = 0;
+  char buffer[64000];
+  char *ptr;
+  strncpy(buffer, token.Data(), 63999);
+  if (token.Length() >= 63999) {
+    oocoutW(nullptr, InputArguments) << "RooStreamParser::convertToString: token length exceeds 63999, truncated"
+                                     << endl;
+    buffer[63999] = 0;
   }
   int len = strlen(buffer) ;
 

--- a/roofit/roofitcore/src/RooStringVar.cxx
+++ b/roofit/roofitcore/src/RooStringVar.cxx
@@ -58,7 +58,8 @@ RooStringVar::RooStringVar(const RooStringVar& other, const char* name) :
 /// Read object contents from given stream
 bool RooStringVar::readFromStream(std::istream& is, bool compact, bool)
 {
-  TString token,errorPrefix("RooStringVar::readFromStream(") ;
+  TString token;
+  TString errorPrefix("RooStringVar::readFromStream(");
   errorPrefix.Append(GetName()) ;
   errorPrefix.Append(")") ;
   RooStreamParser parser(is,errorPrefix) ;

--- a/roofit/roofitcore/src/RooTrace.cxx
+++ b/roofit/roofitcore/src/RooTrace.cxx
@@ -302,8 +302,8 @@ void RooTrace::dump3(ostream& os, bool sinceMarked)
 {
   os << "List of RooFit objects allocated while trace active:" << endl ;
 
-
-  Int_t i, nMarked(0) ;
+  Int_t i;
+  Int_t nMarked(0);
   for(i=0 ; i<_list.GetSize() ; i++) {
     if (!sinceMarked || _markList.IndexOf(_list.At(i)) == -1) {
       os << hex << setw(10) << _list.At(i) << dec << " : " << setw(20) << _list.At(i)->ClassName() << setw(0) << " - " << _list.At(i)->GetName() << endl ;

--- a/roofit/roofitcore/src/RooTreeDataStore.cxx
+++ b/roofit/roofitcore/src/RooTreeDataStore.cxx
@@ -619,7 +619,8 @@ double RooTreeDataStore::weightError(RooAbsData::ErrorType etype) const
     // We have a weight array, use that info
 
     // Return symmetric error on current bin calculated either from Poisson statistics or from SumOfWeights
-    double lo = 0, hi =0;
+    double lo = 0;
+    double hi = 0;
     weightError(lo,hi,etype) ;
     return (lo+hi)/2 ;
 
@@ -668,7 +669,8 @@ void RooTreeDataStore::weightError(double& lo, double& hi, RooAbsData::ErrorType
       }
 
       // Otherwise Calculate poisson errors
-      double ym,yp ;
+      double ym;
+      double yp;
       RooHistError::instance().getPoissonInterval(Int_t(weight()+0.5),ym,yp,1) ;
       lo = weight()-ym ;
       hi = yp-weight() ;
@@ -887,7 +889,8 @@ double RooTreeDataStore::sumEntries() const
 {
   if (_wgtVar) {
 
-    double sum(0), carry(0);
+    double sum(0);
+    double carry(0);
     Int_t nevt = numEntries() ;
     for (int i=0 ; i<nevt ; i++) {
       get(i) ;
@@ -901,7 +904,8 @@ double RooTreeDataStore::sumEntries() const
 
   } else if (_extWgtArray) {
 
-    double sum(0) , carry(0);
+    double sum(0);
+    double carry(0);
     Int_t nevt = numEntries() ;
     for (int i=0 ; i<nevt ; i++) {
       // Kahan's algorithm for summing to avoid loss of precision
@@ -1142,7 +1146,8 @@ void RooTreeDataStore::Draw(Option_t* option)
 void RooTreeDataStore::Streamer(TBuffer &R__b)
 {
   if (R__b.IsReading()) {
-    UInt_t R__s, R__c;
+    UInt_t R__s;
+    UInt_t R__c;
     const Version_t R__v = R__b.ReadVersion(&R__s, &R__c);
 
     R__b.ReadClassBuffer(RooTreeDataStore::Class(), this, R__v, R__s, R__c);

--- a/roofit/roofitcore/src/RooVectorDataStore.cxx
+++ b/roofit/roofitcore/src/RooVectorDataStore.cxx
@@ -394,7 +394,8 @@ double RooVectorDataStore::weightError(RooAbsData::ErrorType etype) const
     // We have a weight array, use that info
 
     // Return symmetric error on current bin calculated either from Poisson statistics or from SumOfWeights
-    double lo = 0, hi = 0 ;
+    double lo = 0;
+    double hi = 0;
     weightError(lo,hi,etype) ;
     return (lo+hi)/2 ;
 
@@ -447,7 +448,8 @@ void RooVectorDataStore::weightError(double& lo, double& hi, RooAbsData::ErrorTy
 
       // Otherwise Calculate poisson errors
       wgt = weight();
-      double ym,yp ;
+      double ym;
+      double yp;
       RooHistError::instance().getPoissonInterval(Int_t(wgt+0.5),ym,yp,1);
       lo = wgt-ym;
       hi = yp-wgt;

--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -2351,97 +2351,97 @@ void RooWorkspace::Print(Option_t* opts) const
 
 void RooWorkspace::CodeRepo::Streamer(TBuffer &R__b)
 {
-  typedef ::RooWorkspace::CodeRepo thisClass;
+   typedef ::RooWorkspace::CodeRepo thisClass;
 
    // Stream an object of class RooWorkspace::CodeRepo.
    if (R__b.IsReading()) {
 
-     UInt_t R__s, R__c;
-     Version_t R__v =  R__b.ReadVersion(&R__s, &R__c);
+      UInt_t R__s;
+      UInt_t R__c;
+      Version_t R__v = R__b.ReadVersion(&R__s, &R__c);
 
-     // Stream contents of ClassFiles map
-     Int_t count(0) ;
-     R__b >> count ;
-     while(count--) {
-       TString name ;
-       name.Streamer(R__b) ;
-       _fmap[name]._hext.Streamer(R__b) ;
-       _fmap[name]._hfile.Streamer(R__b) ;
-       _fmap[name]._cxxfile.Streamer(R__b) ;
-     }
+      // Stream contents of ClassFiles map
+      Int_t count(0);
+      R__b >> count;
+      while (count--) {
+         TString name;
+         name.Streamer(R__b);
+         _fmap[name]._hext.Streamer(R__b);
+         _fmap[name]._hfile.Streamer(R__b);
+         _fmap[name]._cxxfile.Streamer(R__b);
+      }
 
-     // Stream contents of ClassRelInfo map
-     count=0 ;
-     R__b >> count ;
-     while(count--) {
-       TString name ;
-       name.Streamer(R__b) ;
-       _c2fmap[name]._baseName.Streamer(R__b) ;
-       _c2fmap[name]._fileBase.Streamer(R__b) ;
-     }
+      // Stream contents of ClassRelInfo map
+      count = 0;
+      R__b >> count;
+      while (count--) {
+         TString name;
+         name.Streamer(R__b);
+         _c2fmap[name]._baseName.Streamer(R__b);
+         _c2fmap[name]._fileBase.Streamer(R__b);
+      }
 
-     if (R__v==2) {
+      if (R__v == 2) {
 
-       count=0 ;
-       R__b >> count ;
-       while(count--) {
-    TString name ;
-    name.Streamer(R__b) ;
-    _ehmap[name]._hname.Streamer(R__b) ;
-    _ehmap[name]._hfile.Streamer(R__b) ;
-       }
-     }
+         count = 0;
+         R__b >> count;
+         while (count--) {
+            TString name;
+            name.Streamer(R__b);
+            _ehmap[name]._hname.Streamer(R__b);
+            _ehmap[name]._hfile.Streamer(R__b);
+         }
+      }
 
-     R__b.CheckByteCount(R__s, R__c, thisClass::IsA());
+      R__b.CheckByteCount(R__s, R__c, thisClass::IsA());
 
-     // Instantiate any classes that are not defined in current session
-     _compiledOK = !compileClasses() ;
+      // Instantiate any classes that are not defined in current session
+      _compiledOK = !compileClasses();
 
    } else {
 
-     UInt_t R__c;
-     R__c = R__b.WriteVersion(thisClass::IsA(), true);
+      UInt_t R__c;
+      R__c = R__b.WriteVersion(thisClass::IsA(), true);
 
-     // Stream contents of ClassFiles map
-     UInt_t count = _fmap.size() ;
-     R__b << count ;
-     map<TString,ClassFiles>::iterator iter = _fmap.begin() ;
-     while(iter!=_fmap.end()) {
-       TString key_copy(iter->first) ;
-       key_copy.Streamer(R__b) ;
-       iter->second._hext.Streamer(R__b) ;
-       iter->second._hfile.Streamer(R__b);
-       iter->second._cxxfile.Streamer(R__b);
+      // Stream contents of ClassFiles map
+      UInt_t count = _fmap.size();
+      R__b << count;
+      map<TString, ClassFiles>::iterator iter = _fmap.begin();
+      while (iter != _fmap.end()) {
+         TString key_copy(iter->first);
+         key_copy.Streamer(R__b);
+         iter->second._hext.Streamer(R__b);
+         iter->second._hfile.Streamer(R__b);
+         iter->second._cxxfile.Streamer(R__b);
 
-       ++iter ;
-     }
+         ++iter;
+      }
 
-     // Stream contents of ClassRelInfo map
-     count = _c2fmap.size() ;
-     R__b << count ;
-     map<TString,ClassRelInfo>::iterator iter2 = _c2fmap.begin() ;
-     while(iter2!=_c2fmap.end()) {
-       TString key_copy(iter2->first) ;
-       key_copy.Streamer(R__b) ;
-       iter2->second._baseName.Streamer(R__b) ;
-       iter2->second._fileBase.Streamer(R__b);
-       ++iter2 ;
-     }
+      // Stream contents of ClassRelInfo map
+      count = _c2fmap.size();
+      R__b << count;
+      map<TString, ClassRelInfo>::iterator iter2 = _c2fmap.begin();
+      while (iter2 != _c2fmap.end()) {
+         TString key_copy(iter2->first);
+         key_copy.Streamer(R__b);
+         iter2->second._baseName.Streamer(R__b);
+         iter2->second._fileBase.Streamer(R__b);
+         ++iter2;
+      }
 
-     // Stream contents of ExtraHeader map
-     count = _ehmap.size() ;
-     R__b << count ;
-     map<TString,ExtraHeader>::iterator iter3 = _ehmap.begin() ;
-     while(iter3!=_ehmap.end()) {
-       TString key_copy(iter3->first) ;
-       key_copy.Streamer(R__b) ;
-       iter3->second._hname.Streamer(R__b) ;
-       iter3->second._hfile.Streamer(R__b);
-       ++iter3 ;
-     }
+      // Stream contents of ExtraHeader map
+      count = _ehmap.size();
+      R__b << count;
+      map<TString, ExtraHeader>::iterator iter3 = _ehmap.begin();
+      while (iter3 != _ehmap.end()) {
+         TString key_copy(iter3->first);
+         key_copy.Streamer(R__b);
+         iter3->second._hname.Streamer(R__b);
+         iter3->second._hfile.Streamer(R__b);
+         ++iter3;
+      }
 
-     R__b.SetByteCount(R__c, true);
-
+      R__b.SetByteCount(R__c, true);
    }
 }
 
@@ -2458,106 +2458,107 @@ void RooWorkspace::Streamer(TBuffer &R__b)
 {
    if (R__b.IsReading()) {
 
-      R__b.ReadClassBuffer(RooWorkspace::Class(),this);
+      R__b.ReadClassBuffer(RooWorkspace::Class(), this);
 
       // Perform any pass-2 schema evolution here
-      for(RooAbsArg* node : _allOwnedNodes) {
-   node->ioStreamerPass2() ;
+      for (RooAbsArg *node : _allOwnedNodes) {
+         node->ioStreamerPass2();
       }
-      RooAbsArg::ioStreamerPass2Finalize() ;
+      RooAbsArg::ioStreamerPass2Finalize();
 
       // Make expensive object cache of all objects point to intermal copy.
       // Somehow this doesn't work OK automatically
-      for(RooAbsArg* node : _allOwnedNodes) {
-   node->setExpensiveObjectCache(_eocache) ;
-   node->setWorkspace(*this);
+      for (RooAbsArg *node : _allOwnedNodes) {
+         node->setExpensiveObjectCache(_eocache);
+         node->setWorkspace(*this);
 #ifdef ROOFIT_LEGACY_EVAL_BACKEND
-   if (node->IsA()->InheritsFrom(RooAbsOptTestStatistic::Class())) {
-      RooAbsOptTestStatistic *tmp = static_cast<RooAbsOptTestStatistic *>(node);
-      if (tmp->isSealed() && tmp->sealNotice() && strlen(tmp->sealNotice()) > 0) {
-         cout << "RooWorkspace::Streamer(" << GetName() << ") " << node->ClassName() << "::" << node->GetName()
-              << " : " << tmp->sealNotice() << endl;
-      }
-   }
+         if (node->IsA()->InheritsFrom(RooAbsOptTestStatistic::Class())) {
+            RooAbsOptTestStatistic *tmp = static_cast<RooAbsOptTestStatistic *>(node);
+            if (tmp->isSealed() && tmp->sealNotice() && strlen(tmp->sealNotice()) > 0) {
+               cout << "RooWorkspace::Streamer(" << GetName() << ") " << node->ClassName() << "::" << node->GetName()
+                    << " : " << tmp->sealNotice() << endl;
+            }
+         }
 #endif
       }
 
    } else {
 
-     // Make lists of external clients of WS objects, and remove those links temporarily
+      // Make lists of external clients of WS objects, and remove those links temporarily
 
-     map<RooAbsArg*,vector<RooAbsArg *> > extClients, extValueClients, extShapeClients ;
+      map<RooAbsArg *, vector<RooAbsArg *>> extClients;
+      map<RooAbsArg *, vector<RooAbsArg *>> extValueClients;
+      map<RooAbsArg *, vector<RooAbsArg *>> extShapeClients;
 
-     for(RooAbsArg* tmparg : _allOwnedNodes) {
+      for (RooAbsArg *tmparg : _allOwnedNodes) {
 
-       // Loop over client list of this arg
-       std::vector<RooAbsArg *> clientsTmp{tmparg->_clientList.begin(), tmparg->_clientList.end()};
-       for (auto client : clientsTmp) {
-         if (!_allOwnedNodes.containsInstance(*client)) {
+         // Loop over client list of this arg
+         std::vector<RooAbsArg *> clientsTmp{tmparg->_clientList.begin(), tmparg->_clientList.end()};
+         for (auto client : clientsTmp) {
+            if (!_allOwnedNodes.containsInstance(*client)) {
 
-           const auto refCount = tmparg->_clientList.refCount(client);
-           auto& bufferVec = extClients[tmparg];
+               const auto refCount = tmparg->_clientList.refCount(client);
+               auto &bufferVec = extClients[tmparg];
 
-           bufferVec.insert(bufferVec.end(), refCount, client);
-           tmparg->_clientList.Remove(client, true);
+               bufferVec.insert(bufferVec.end(), refCount, client);
+               tmparg->_clientList.Remove(client, true);
+            }
          }
-       }
 
-       // Loop over value client list of this arg
-       clientsTmp.assign(tmparg->_clientListValue.begin(), tmparg->_clientListValue.end());
-       for (auto vclient : clientsTmp) {
-         if (!_allOwnedNodes.containsInstance(*vclient)) {
-           cxcoutD(ObjectHandling) << "RooWorkspace::Streamer(" << GetName() << ") element " << tmparg->GetName()
-                   << " has external value client link to " << vclient << " (" << vclient->GetName() << ") with ref count " << tmparg->_clientListValue.refCount(vclient) << endl ;
+         // Loop over value client list of this arg
+         clientsTmp.assign(tmparg->_clientListValue.begin(), tmparg->_clientListValue.end());
+         for (auto vclient : clientsTmp) {
+            if (!_allOwnedNodes.containsInstance(*vclient)) {
+               cxcoutD(ObjectHandling) << "RooWorkspace::Streamer(" << GetName() << ") element " << tmparg->GetName()
+                                       << " has external value client link to " << vclient << " (" << vclient->GetName()
+                                       << ") with ref count " << tmparg->_clientListValue.refCount(vclient) << endl;
 
-           const auto refCount = tmparg->_clientListValue.refCount(vclient);
-           auto& bufferVec = extValueClients[tmparg];
+               const auto refCount = tmparg->_clientListValue.refCount(vclient);
+               auto &bufferVec = extValueClients[tmparg];
 
-           bufferVec.insert(bufferVec.end(), refCount, vclient);
-           tmparg->_clientListValue.Remove(vclient, true);
+               bufferVec.insert(bufferVec.end(), refCount, vclient);
+               tmparg->_clientListValue.Remove(vclient, true);
+            }
          }
-       }
 
-       // Loop over shape client list of this arg
-       clientsTmp.assign(tmparg->_clientListShape.begin(), tmparg->_clientListShape.end());
-       for (auto sclient : clientsTmp) {
-         if (!_allOwnedNodes.containsInstance(*sclient)) {
-           cxcoutD(ObjectHandling) << "RooWorkspace::Streamer(" << GetName() << ") element " << tmparg->GetName()
-                     << " has external shape client link to " << sclient << " (" << sclient->GetName() << ") with ref count " << tmparg->_clientListShape.refCount(sclient) << endl ;
+         // Loop over shape client list of this arg
+         clientsTmp.assign(tmparg->_clientListShape.begin(), tmparg->_clientListShape.end());
+         for (auto sclient : clientsTmp) {
+            if (!_allOwnedNodes.containsInstance(*sclient)) {
+               cxcoutD(ObjectHandling) << "RooWorkspace::Streamer(" << GetName() << ") element " << tmparg->GetName()
+                                       << " has external shape client link to " << sclient << " (" << sclient->GetName()
+                                       << ") with ref count " << tmparg->_clientListShape.refCount(sclient) << endl;
 
-           const auto refCount = tmparg->_clientListShape.refCount(sclient);
-           auto& bufferVec = extShapeClients[tmparg];
+               const auto refCount = tmparg->_clientListShape.refCount(sclient);
+               auto &bufferVec = extShapeClients[tmparg];
 
-           bufferVec.insert(bufferVec.end(), refCount, sclient);
-           tmparg->_clientListShape.Remove(sclient, true);
+               bufferVec.insert(bufferVec.end(), refCount, sclient);
+               tmparg->_clientListShape.Remove(sclient, true);
+            }
          }
-       }
+      }
 
-     }
+      R__b.WriteClassBuffer(RooWorkspace::Class(), this);
 
-     R__b.WriteClassBuffer(RooWorkspace::Class(),this);
+      // Reinstate clients here
 
-     // Reinstate clients here
+      for (auto &iterx : extClients) {
+         for (auto client : iterx.second) {
+            iterx.first->_clientList.Add(client);
+         }
+      }
 
+      for (auto &iterx : extValueClients) {
+         for (auto client : iterx.second) {
+            iterx.first->_clientListValue.Add(client);
+         }
+      }
 
-     for (auto &iterx : extClients) {
-       for (auto client : iterx.second) {
-         iterx.first->_clientList.Add(client);
-       }
-     }
-
-     for (auto &iterx : extValueClients) {
-       for (auto client : iterx.second) {
-         iterx.first->_clientListValue.Add(client);
-       }
-     }
-
-     for (auto &iterx : extShapeClients) {
-       for (auto client : iterx.second) {
-         iterx.first->_clientListShape.Add(client);
-       }
-     }
-
+      for (auto &iterx : extShapeClients) {
+         for (auto client : iterx.second) {
+            iterx.first->_clientListShape.Add(client);
+         }
+      }
    }
 }
 

--- a/roofit/roofitcore/src/RooXYChi2Var.cxx
+++ b/roofit/roofitcore/src/RooXYChi2Var.cxx
@@ -321,7 +321,8 @@ double RooXYChi2Var::fy() const
 
 double RooXYChi2Var::evaluatePartition(std::size_t firstEvent, std::size_t lastEvent, std::size_t stepSize) const
 {
-  double result(0), carry(0);
+  double result(0);
+  double carry(0);
 
   // Loop over bins of dataset
   RooDataSet* xydata = static_cast<RooDataSet*>(_dataClone) ;
@@ -336,7 +337,8 @@ double RooXYChi2Var::evaluatePartition(std::size_t firstEvent, std::size_t lastE
 
     // Get data value and error
     double ydata ;
-    double eylo,eyhi ;
+    double eylo;
+    double eyhi;
     if (_yvar) {
       ydata = _yvar->getVal() ;
       eylo = -1*_yvar->getErrorLo() ;

--- a/roofit/roofitcore/src/TestStatistics/RooBinnedL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooBinnedL.cxx
@@ -15,7 +15,7 @@
 \class RooBinnedL
 \ingroup Roofitcore
 
-Class RooBinnedL implements a -log(likelihood) calculation from a dataset
+Implements a -log(likelihood) calculation from a dataset
 (assumed to be binned) and a PDF. The NLL is calculated as
 \f[
  \sum_\mathrm{data} -\log( \mathrm{pdf}(x_\mathrm{data}))

--- a/roofit/roofitcore/src/TestStatistics/RooSubsidiaryL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooSubsidiaryL.cxx
@@ -15,7 +15,7 @@
 \class RooSubsidiaryL
 \ingroup Roofitcore
 
-\brief RooSubsidiaryL calculates the sum of the -(log) likelihoods of a set of RooAbsPdf objects that represent
+\brief Calculates the sum of the -(log) likelihoods of a set of RooAbsPdf objects that represent
 subsidiary or constraint functions.
 
 This class is used to gather all subsidiary PDF terms from the component PDFs of RooSumL likelihoods and calculate the

--- a/roofit/roofitcore/src/TestStatistics/RooUnbinnedL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooUnbinnedL.cxx
@@ -15,7 +15,7 @@
 \class RooUnbinnedL
 \ingroup Roofitcore
 
-Class RooUnbinnedL implements a -log(likelihood) calculation from a dataset
+A -log(likelihood) calculation from a dataset
 (assumed to be unbinned) and a PDF. The NLL is calculated as
 \f[
  \sum_\mathrm{data} -\log( \mathrm{pdf}(x_\mathrm{data}))

--- a/roofit/roofitmore/src/RooAdaptiveGaussKronrodIntegrator1D.cxx
+++ b/roofit/roofitmore/src/RooAdaptiveGaussKronrodIntegrator1D.cxx
@@ -328,7 +328,8 @@ double RooAdaptiveGaussKronrodIntegrator1D::integral(const double *yvec)
   F.params = this ;
 
   // Return values
-  double result, error;
+  double result;
+  double error;
 
   // Call GSL implementation of integeator
   switch(_domainType) {
@@ -535,7 +536,9 @@ void qpsrt (gsl_integration_workspace * workspace)
 
   double errmax ;
   double errmin ;
-  int i, k, top;
+  int i;
+  int k;
+  int top;
 
   size_t i_nrmax = workspace->nrmax;
   size_t i_maxerr = order[i_nrmax] ;
@@ -804,11 +807,17 @@ qag (const gsl_function * f,
      double *result, double *abserr,
      gsl_integration_rule * q)
 {
-  double area, errsum;
-  double result0, abserr0, resabs0, resasc0;
+  double area;
+  double errsum;
+  double result0;
+  double abserr0;
+  double resabs0;
+  double resasc0;
   double tolerance;
   size_t iteration = 0;
-  int roundoff_type1 = 0, roundoff_type2 = 0, error_type = 0;
+  int roundoff_type1 = 0;
+  int roundoff_type2 = 0;
+  int error_type = 0;
 
   double round_off;
 
@@ -874,12 +883,24 @@ qag (const gsl_function * f,
 
   do
     {
-      double a1, b1, a2, b2;
-      double a_i, b_i, r_i, e_i;
-      double area1 = 0, area2 = 0, area12 = 0;
-      double error1 = 0, error2 = 0, error12 = 0;
-      double resasc1, resasc2;
-      double resabs1, resabs2;
+      double a1;
+      double b1;
+      double a2;
+      double b2;
+      double a_i;
+      double b_i;
+      double r_i;
+      double e_i;
+      double area1 = 0;
+      double area2 = 0;
+      double area12 = 0;
+      double error1 = 0;
+      double error2 = 0;
+      double error12 = 0;
+      double resasc1;
+      double resasc2;
+      double resabs1;
+      double resabs2;
 
       /* Bisect the subinterval with the largest error estimate */
 
@@ -1020,7 +1041,8 @@ gsl_integration_qk (const int n,
 
   double result_abs = std::abs(result_kronrod);
   double result_asc = 0;
-  double mean = 0, err = 0;
+  double mean = 0;
+  double err = 0;
 
   int j;
 
@@ -1123,7 +1145,8 @@ gsl_integration_qk15 (const gsl_function * f, double a, double b,
       double *result, double *abserr,
       double *resabs, double *resasc)
 {
-  double fv1[8], fv2[8];
+  double fv1[8];
+  double fv2[8];
   // coverity[UNINIT_CTOR]
   gsl_integration_qk (8, xgkA, wgA, wgkA, fv1, fv2, f, a, b, result, abserr, resabs, resasc);
 }
@@ -1180,7 +1203,8 @@ gsl_integration_qk21 (const gsl_function * f, double a, double b,
                       double *result, double *abserr,
                       double *resabs, double *resasc)
 {
-  double fv1[11], fv2[11];
+  double fv1[11];
+  double fv2[11];
   // coverity[UNINIT_CTOR]
   gsl_integration_qk (11, xgkB, wgB, wgkB, fv1, fv2, f, a, b, result, abserr, resabs, resasc);
 }
@@ -1249,7 +1273,8 @@ gsl_integration_qk31 (const gsl_function * f, double a, double b,
       double *result, double *abserr,
       double *resabs, double *resasc)
 {
-  double fv1[16], fv2[16];
+  double fv1[16];
+  double fv2[16];
   // coverity[UNINIT_CTOR]
   gsl_integration_qk (16, xgkC, wgC, wgkC, fv1, fv2, f, a, b, result, abserr, resabs, resasc);
 }
@@ -1330,7 +1355,8 @@ gsl_integration_qk41 (const gsl_function * f, double a, double b,
                       double *result, double *abserr,
                       double *resabs, double *resasc)
 {
-  double fv1[21], fv2[21];
+  double fv1[21];
+  double fv2[21];
   // coverity[UNINIT]
   gsl_integration_qk (21, xgkD, wgD, wgkD, fv1, fv2, f, a, b, result, abserr, resabs, resasc);
 }
@@ -1426,7 +1452,8 @@ gsl_integration_qk51 (const gsl_function * f, double a, double b,
                       double *result, double *abserr,
                       double *resabs, double *resasc)
 {
-  double fv1[26], fv2[26];
+  double fv1[26];
+  double fv2[26];
   //coverity[UNINIT]
   gsl_integration_qk (26, xgkE, wgE, wgkE, fv1, fv2, f, a, b, result, abserr, resabs, resasc);
 }
@@ -1532,7 +1559,8 @@ gsl_integration_qk61 (const gsl_function * f, double a, double b,
                       double *result, double *abserr,
                       double *resabs, double *resasc)
 {
-  double fv1[31], fv2[31];
+  double fv1[31];
+  double fv2[31];
   //coverity[UNINIT]
   gsl_integration_qk (31, xgkF, wgF, wgkF, fv1, fv2, f, a, b, result, abserr, resabs, resasc);
 }
@@ -1823,7 +1851,11 @@ qelg (struct extrapolation_table *table, double *result, double *abserr)
       double err3 = std::abs(delta3);
       double tol3 = GSL_MAX_DBL (e1abs, std::abs(e0)) * GSL_DBL_EPSILON;
 
-      double e3, delta1, err1, tol1, ss;
+      double e3;
+      double delta1;
+      double err1;
+      double tol1;
+      double ss;
 
       if (err2 <= tol2 && err3 <= tol3)
         {
@@ -2130,17 +2162,27 @@ qags (const gsl_function * f,
       double *result, double *abserr,
       gsl_integration_rule * q)
 {
-  double area, errsum;
-  double res_ext, err_ext;
-  double result0, abserr0, resabs0, resasc0;
+  double area;
+  double errsum;
+  double res_ext;
+  double err_ext;
+  double result0;
+  double abserr0;
+  double resabs0;
+  double resasc0;
   double tolerance;
 
   double ertest = 0;
   double error_over_large_intervals = 0;
-  double reseps = 0, abseps = 0, correc = 0;
+  double reseps = 0;
+  double abseps = 0;
+  double correc = 0;
   size_t ktmin = 0;
-  int roundoff_type1 = 0, roundoff_type2 = 0, roundoff_type3 = 0;
-  int error_type = 0, error_type2 = 0;
+  int roundoff_type1 = 0;
+  int roundoff_type2 = 0;
+  int roundoff_type3 = 0;
+  int error_type = 0;
+  int error_type2 = 0;
 
   size_t iteration = 0;
 
@@ -2219,12 +2261,24 @@ qags (const gsl_function * f,
   do
     {
       size_t current_level;
-      double a1, b1, a2, b2;
-      double a_i, b_i, r_i, e_i;
-      double area1 = 0, area2 = 0, area12 = 0;
-      double error1 = 0, error2 = 0, error12 = 0;
-      double resasc1, resasc2;
-      double resabs1, resabs2;
+      double a1;
+      double b1;
+      double a2;
+      double b2;
+      double a_i;
+      double b_i;
+      double r_i;
+      double e_i;
+      double area1 = 0;
+      double area2 = 0;
+      double area12 = 0;
+      double error1 = 0;
+      double error2 = 0;
+      double error12 = 0;
+      double resasc1;
+      double resasc2;
+      double resabs1;
+      double resabs2;
       double last_e_i;
 
       /* Bisect the subinterval with the largest error estimate */

--- a/roofit/roofitmore/src/RooAdaptiveGaussKronrodIntegrator1D.cxx
+++ b/roofit/roofitmore/src/RooAdaptiveGaussKronrodIntegrator1D.cxx
@@ -19,7 +19,7 @@
 \class RooAdaptiveGaussKronrodIntegrator1D
 \ingroup Roofitcore
 
-RooAdaptiveGaussKronrodIntegrator1D implements the Gauss-Kronrod integration algorithm.
+Implements the Gauss-Kronrod integration algorithm.
 
 An adaptive Gaussian quadrature method for numerical integration in
 which error is estimated based on evaluation at special points
@@ -59,7 +59,6 @@ using namespace std ;
 
 
 ClassImp(RooAdaptiveGaussKronrodIntegrator1D);
-;
 
 // --- From GSL_MATH.h -------------------------------------------
 struct gsl_function_struct

--- a/roofit/roofitmore/src/RooGaussKronrodIntegrator1D.cxx
+++ b/roofit/roofitmore/src/RooGaussKronrodIntegrator1D.cxx
@@ -210,7 +210,8 @@ double RooGaussKronrodIntegrator1D::integral(const double *yvec)
   F.params = this ;
 
   // Return values
-  double result, error;
+  double result;
+  double error;
   size_t neval = 0 ;
 
   // Call GSL implementation of integeator

--- a/roofit/roofitmore/src/RooGaussKronrodIntegrator1D.cxx
+++ b/roofit/roofitmore/src/RooGaussKronrodIntegrator1D.cxx
@@ -19,7 +19,7 @@
 \class RooGaussKronrodIntegrator1D
 \ingroup Roofitcore
 
-RooGaussKronrodIntegrator1D implements the Gauss-Kronrod integration algorithm.
+Implements the Gauss-Kronrod integration algorithm.
 
 An Gaussian quadrature method for numerical integration in which
 error is estimation based on evaluation at special points known as

--- a/roofit/roofitmore/src/RooLegendre.cxx
+++ b/roofit/roofitmore/src/RooLegendre.cxx
@@ -116,7 +116,8 @@ void compute(  size_t batchSize, const int l1, const int m1, const int l2, const
               double * __restrict output,
               double const * __restrict TH)
 {
-  double legendre1=1.0, legendreMinus1=1.0;
+  double legendre1 = 1.0;
+  double legendreMinus1 = 1.0;
   if (l1+m1 > 0) {
     legendre1      = ROOT::Math::internal::legendre(l1,m1,1.0);
     legendreMinus1 = ROOT::Math::internal::legendre(l1,m1,-1.0);

--- a/roofit/roostats/src/AsymptoticCalculator.cxx
+++ b/roofit/roostats/src/AsymptoticCalculator.cxx
@@ -709,7 +709,8 @@ HypoTestResult* AsymptoticCalculator::GetHypoTest() const {
    //          t(mu), t_tilde(mu) for the 2-sided
    //          q(mu) and q_tilde(mu) for the one -sided test statistics
 
-   double pnull = -1, palt = -1;
+   double pnull = -1;
+   double palt = -1;
 
    // asymptotic formula for pnull (for only one POI)
    // From fact that qmu is a chi2 with ndf=1

--- a/roofit/roostats/src/BernsteinCorrection.cxx
+++ b/roofit/roostats/src/BernsteinCorrection.cxx
@@ -281,37 +281,34 @@ void BernsteinCorrection::CreateQSamplingDist(RooWorkspace* wks,
 
 
   //  TH1F* samplingDist = new TH1F("samplingDist","",20,0,10);
-  double q = 0, qExtra = 0;
-  // do toys
-  for(int i=0; i<nToys; ++i){
-    cout << "on toy " << i << endl;
+    double q = 0;
+    double qExtra = 0;
+    // do toys
+    for (int i = 0; i < nToys; ++i) {
+       cout << "on toy " << i << endl;
 
-    std::unique_ptr<RooDataSet> tmpData{toyGen.generate(*x,data->numEntries())};
-    // check to see how well this correction fits
-    std::unique_ptr<RooFitResult> result{
-        corrected->fitTo(*tmpData,Save(),Minos(false),
-          Hesse(false),PrintLevel(printLevel))};
+       std::unique_ptr<RooDataSet> tmpData{toyGen.generate(*x, data->numEntries())};
+       // check to see how well this correction fits
+       std::unique_ptr<RooFitResult> result{
+          corrected->fitTo(*tmpData, Save(), Minos(false), Hesse(false), PrintLevel(printLevel))};
 
-    std::unique_ptr<RooFitResult> resultNull{
-        correctedNull->fitTo(*tmpData,Save(),Minos(false),
-          Hesse(false),PrintLevel(printLevel))};
+       std::unique_ptr<RooFitResult> resultNull{
+          correctedNull->fitTo(*tmpData, Save(), Minos(false), Hesse(false), PrintLevel(printLevel))};
 
+       std::unique_ptr<RooFitResult> resultExtra{
+          correctedExtra->fitTo(*tmpData, Save(), Minos(false), Hesse(false), PrintLevel(printLevel))};
 
-    std::unique_ptr<RooFitResult> resultExtra{
-        correctedExtra->fitTo(*tmpData,Save(),Minos(false),
-          Hesse(false),PrintLevel(printLevel))};
+       // Hypothesis test between previous correction (null)
+       // and this one (alternate).  Use -2 log LR for test statistic
+       q = 2 * (resultNull->minNll() - result->minNll());
 
+       qExtra = 2 * (result->minNll() - resultExtra->minNll());
 
-    // Hypothesis test between previous correction (null)
-    // and this one (alternate).  Use -2 log LR for test statistic
-    q = 2*(resultNull->minNll() - result->minNll());
-
-    qExtra = 2*(result->minNll() - resultExtra->minNll());
-
-    samplingDist->Fill(q);
-    samplingDistExtra->Fill(qExtra);
-    if (printLevel > 0)
-       cout << "NLL Results: null " <<  resultNull->minNll() << " ref = " << result->minNll() << " extra" << resultExtra->minNll() << endl;
+       samplingDist->Fill(q);
+       samplingDistExtra->Fill(qExtra);
+       if (printLevel > 0)
+      cout << "NLL Results: null " << resultNull->minNll() << " ref = " << result->minNll() << " extra"
+           << resultExtra->minNll() << endl;
   }
 
   RooMsgService::instance().setGlobalKillBelow(msglevel);

--- a/roofit/roostats/src/HybridPlot.cxx
+++ b/roofit/roostats/src/HybridPlot.cxx
@@ -324,8 +324,10 @@ double* HybridPlot::GetHistoPvals (TH1* histo, double percentage){
 
    // Now select the couple of extremes which have the lower bin content diff
    std::map<int,int>::iterator it;
-   int a,b;
-   double left_bin_center(0.),right_bin_center(0.);
+   int a;
+   int b;
+   double left_bin_center(0.);
+   double right_bin_center(0.);
    double diff=10e40;
    double current_diff;
    for (it = extremes_map.begin();it != extremes_map.end();++it){

--- a/roofit/roostats/src/HybridResult.cxx
+++ b/roofit/roostats/src/HybridResult.cxx
@@ -24,9 +24,8 @@ New contributions to this class have been written by Matthias Wolf (error estima
 The objects of this class store and access with lightweight methods the
 information calculated by LimitResults through a Lent calculation using
 MC toy experiments.
-In some ways can be considered an extended and extensible implementation of the
-TConfidenceLevel class (http://root.cern.ch/root/html/TConfidenceLevel.html).
-
+In some ways can be considered an extended and extensible implementation of
+TConfidenceLevel..
 */
 
 

--- a/roofit/roostats/src/HypoTestInverter.cxx
+++ b/roofit/roostats/src/HypoTestInverter.cxx
@@ -502,7 +502,8 @@ HypoTestInverterResult* HypoTestInverter::GetInterval() const {
    }
    else {
       oocoutI(nullptr,Eval) << "HypoTestInverter::GetInterval - run an automatic scan" << std::endl;
-      double limit(0),err(0);
+      double limit(0);
+      double err(0);
       bool ret = RunLimit(limit,err);
       if (!ret)
          oocoutE(nullptr,Eval) << "HypoTestInverter::GetInterval - error running an auto scan " << std::endl;
@@ -786,8 +787,11 @@ bool HypoTestInverter::RunLimit(double &limit, double &limitErr, double absAccur
 
   typedef std::pair<double,double> CLs_t;
   double clsTarget = fSize;
-  CLs_t clsMin(1,0), clsMax(0,0), clsMid(0,0);
-  double rMin = r->getMin(), rMax = r->getMax();
+  CLs_t clsMin(1, 0);
+  CLs_t clsMax(0, 0);
+  CLs_t clsMid(0, 0);
+  double rMin = r->getMin();
+  double rMax = r->getMax();
   limit    = 0.5*(rMax + rMin);
   limitErr = 0.5*(rMax - rMin);
   bool done = false;
@@ -866,7 +870,9 @@ bool HypoTestInverter::RunLimit(double &limit, double &limitErr, double absAccur
      // determine point by bisection or interpolation
      limit = 0.5*(rMin+rMax); limitErr = 0.5*(rMax-rMin);
      if (fgAlgo == "logSecant" && clsMax.first != 0) {
-        double logMin = log(clsMin.first), logMax = log(clsMax.first), logTarget = log(clsTarget);
+        double logMin = log(clsMin.first);
+        double logMax = log(clsMax.first);
+        double logTarget = log(clsTarget);
         limit = rMin + (rMax-rMin) * (logTarget - logMin)/(logMax - logMin);
         if (clsMax.second != 0 && clsMin.second != 0) {
            limitErr = hypot((logTarget-logMax) * (clsMin.second/clsMin.first), (logTarget-logMin) * (clsMax.second/clsMax.first));
@@ -904,7 +910,8 @@ bool HypoTestInverter::RunLimit(double &limit, double &limitErr, double absAccur
        }
      } else {
        if (fVerbose > 0) std::cout << "Trying to move the interval edges closer" << std::endl;
-       double rMinBound = rMin, rMaxBound = rMax;
+       double rMinBound = rMin;
+       double rMaxBound = rMax;
        // try to reduce the size of the interval
        while (clsMin.second == 0 || std::abs(rMin-limit) > std::max(absAccuracy, relAccuracy * limit)) {
          rMin = 0.5*(rMin+limit);
@@ -940,7 +947,9 @@ bool HypoTestInverter::RunLimit(double &limit, double &limitErr, double absAccur
       expoFit.FixParameter(0,clsTarget);
       expoFit.SetParameter(1,log(clsMax.first/clsMin.first)/(rMax-rMin));
       expoFit.SetParameter(2,limit);
-      double rMinBound, rMaxBound; expoFit.GetRange(rMinBound, rMaxBound);
+      double rMinBound;
+      double rMaxBound;
+      expoFit.GetRange(rMinBound, rMaxBound);
       limitErr = std::max(std::abs(rMinBound-limit), std::abs(rMaxBound-limit));
       int npoints = 0;
 
@@ -978,7 +987,8 @@ bool HypoTestInverter::RunLimit(double &limit, double &limitErr, double absAccur
        //new TCanvas("c1","c1");
       fLimitPlot->Sort();
       fLimitPlot->SetLineWidth(2);
-      double xmin = r->getMin(), xmax = r->getMax();
+      double xmin = r->getMin();
+      double xmax = r->getMax();
       for (int j = 0; j < fLimitPlot->GetN(); ++j) {
         if (fLimitPlot->GetY()[j] > 1.4*clsTarget || fLimitPlot->GetY()[j] < 0.6*clsTarget) continue;
         xmin = std::min(fLimitPlot->GetX()[j], xmin);

--- a/roofit/roostats/src/HypoTestInverterPlot.cxx
+++ b/roofit/roostats/src/HypoTestInverterPlot.cxx
@@ -101,7 +101,8 @@ TGraphErrors* HypoTestInverterPlot::MakePlot(Option_t * opt)
    std::vector<double> yErrArray;
 
    for (int i=0; i<nEntries; i++) {
-      double CLVal = 0., CLErr = 0.;
+      double CLVal = 0.;
+      double CLErr = 0.;
       if (type == Default) {
          CLVal = fResults->GetYValue(index[i]);
          CLErr = fResults->GetYError(index[i]);

--- a/roofit/roostats/src/HypoTestInverterResult.cxx
+++ b/roofit/roostats/src/HypoTestInverterResult.cxx
@@ -1001,7 +1001,8 @@ double HypoTestInverterResult::CalculateEstimatedError(double target, bool lower
   TMath::SortItr(fXValues.begin(), fXValues.end(), indx.begin(), false);
   // make a graph with the sorted point
   TGraphErrors graph;
-  int ip = 0, np = 0;
+  int ip = 0;
+  int np = 0;
   for (int i = 0; i < ArraySize(); ++i) {
      if ( (xmin < xmax) && ( GetXValue(indx[i]) >= xmin && GetXValue(indx[i]) <= xmax) ) {
         np++;

--- a/roofit/roostats/src/HypoTestPlot.cxx
+++ b/roofit/roostats/src/HypoTestPlot.cxx
@@ -61,7 +61,9 @@ void HypoTestPlot::ApplyResult(HypoTestResult& result, Option_t* opt) {
    }
 
    if(result.HasTestStatisticData()) {
-      double theMin(0.), theMax(0.), theYMax(0.);
+      double theMin(0.);
+      double theMax(0.);
+      double theYMax(0.);
       GetAbsoluteInterval(theMin, theMax, theYMax);
 
       AddLine(result.GetTestStatisticData(), 0, result.GetTestStatisticData(), theYMax*0.66, "test statistic data");

--- a/roofit/roostats/src/MetropolisHastings.cxx
+++ b/roofit/roostats/src/MetropolisHastings.cxx
@@ -103,7 +103,9 @@ MarkovChain* MetropolisHastings::ConstructChain()
    chain->SetParameters(fChainParams);
 
    Int_t weight = 0;
-   double xL = 0.0, xPrimeL = 0.0, a = 0.0;
+   double xL = 0.0;
+   double xPrimeL = 0.0;
+   double a = 0.0;
 
    // ibucur: i think the user should have the possibility to display all the message
    //    levels should they want to; maybe a setPrintLevel would be appropriate

--- a/roofit/roostats/src/NeymanConstruction.cxx
+++ b/roofit/roostats/src/NeymanConstruction.cxx
@@ -154,8 +154,12 @@ PointSetInterval* NeymanConstruction::GetInterval() const {
 
     SamplingDistribution* samplingDist=nullptr;
     double sigma;
-    double upperEdgeOfAcceptance, upperEdgeMinusSigma, upperEdgePlusSigma;
-    double lowerEdgeOfAcceptance, lowerEdgeMinusSigma, lowerEdgePlusSigma;
+    double upperEdgeOfAcceptance;
+    double upperEdgeMinusSigma;
+    double upperEdgePlusSigma;
+    double lowerEdgeOfAcceptance;
+    double lowerEdgeMinusSigma;
+    double lowerEdgePlusSigma;
     Int_t additionalMC=0;
 
     // the adaptive sampling algorithm wants at least one toy event to be outside

--- a/roofit/roostats/src/PointSetInterval.cxx
+++ b/roofit/roostats/src/PointSetInterval.cxx
@@ -135,7 +135,8 @@ bool PointSetInterval::CheckParameters(const RooArgSet &parameterPoint) const
 double PointSetInterval::UpperLimit(RooRealVar& param )
 {
   RooDataSet*  tree = dynamic_cast<RooDataSet*>( fParameterPointsInInterval );
-  double low = 0, high = 0;
+  double low = 0;
+  double high = 0;
   if( tree ){
     tree->getRange(param, low, high);
     return high;
@@ -148,7 +149,8 @@ double PointSetInterval::UpperLimit(RooRealVar& param )
 double PointSetInterval::LowerLimit(RooRealVar& param )
 {
   RooDataSet*  tree = dynamic_cast<RooDataSet*>( fParameterPointsInInterval );
-  double low = 0, high = 0;
+  double low = 0;
+  double high = 0;
   if( tree ){
     tree->getRange(param, low, high);
     return low;

--- a/roofit/roostats/src/RooStatsUtils.cxx
+++ b/roofit/roostats/src/RooStatsUtils.cxx
@@ -134,7 +134,8 @@ namespace RooStats {
 
    RooAbsPdf * MakeNuisancePdf(RooAbsPdf &pdf, const RooArgSet &observables, const char *name) {
       // make a nuisance pdf by factorizing out all constraint terms in a common pdf
-      RooArgList obsTerms, constraints;
+      RooArgList obsTerms;
+      RooArgList constraints;
       FactorizePdf(observables, pdf, obsTerms, constraints);
       if(constraints.empty()) {
          oocoutW(nullptr, Eval) << "RooStatsUtils::MakeNuisancePdf - no constraints found on nuisance parameters in the input model" << endl;

--- a/roofit/roostats/src/SamplingDistPlot.cxx
+++ b/roofit/roostats/src/SamplingDistPlot.cxx
@@ -77,7 +77,8 @@ double SamplingDistPlot::AddSamplingDistribution(const SamplingDistribution *sam
    TString options(drawOptions);
    options.ToUpper();
 
-   double xmin(TMath::Infinity()), xmax(-TMath::Infinity());
+   double xmin(TMath::Infinity());
+   double xmax(-TMath::Infinity());
    // remove cases where xmin and xmax are +/- inf
    for( unsigned int i=0; i < fSamplingDistr.size(); i++ ) {
       if( fSamplingDistr[i] < xmin  &&  fSamplingDistr[i] != -TMath::Infinity() ) {
@@ -262,7 +263,10 @@ void SamplingDistPlot::addOtherObject(TObject *obj, Option_t *drawOptions)
 void SamplingDistPlot::Draw(Option_t * /*options */) {
    ApplyDefaultStyle();
 
-   double theMin(0.), theMax(0.), theYMin(std::numeric_limits<float>::quiet_NaN()), theYMax(0.);
+   double theMin(0.);
+   double theMax(0.);
+   double theYMin(std::numeric_limits<float>::quiet_NaN());
+   double theYMax(0.);
    GetAbsoluteInterval(theMin, theMax, theYMax);
    if( !TMath::IsNaN(fXMin) ) theMin = fXMin;
    if( !TMath::IsNaN(fXMax) ) theMax = fXMax;

--- a/roofit/roostats/src/SequentialProposal.cxx
+++ b/roofit/roostats/src/SequentialProposal.cxx
@@ -43,12 +43,17 @@ void SequentialProposal::Propose(RooArgSet& xPrime, RooArgSet& x )
    int i = 0;
    for (auto *var : static_range_cast<RooRealVar *>(xPrime)) {
       if (i == j) {
-        double val = var->getVal(), max = var->getMax(), min = var->getMin(), len = max - min;
-        val += RooRandom::gaussian() * len * fDivisor;
-        while (val > max) val -= len;
-        while (val < min) val += len;
-        var->setVal(val);
-        //std::cout << "Proposing a step along " << var->GetName() << std::endl;
+         double val = var->getVal();
+         double max = var->getMax();
+         double min = var->getMin();
+         double len = max - min;
+         val += RooRandom::gaussian() * len * fDivisor;
+         while (val > max)
+            val -= len;
+         while (val < min)
+            val += len;
+         var->setVal(val);
+         // std::cout << "Proposing a step along " << var->GetName() << std::endl;
       }
       ++i;
    }

--- a/roofit/roostats/src/ToyMCSampler.cxx
+++ b/roofit/roostats/src/ToyMCSampler.cxx
@@ -360,7 +360,8 @@ RooDataSet* ToyMCSampler::GetSamplingDistributionsSingleWorker(RooArgSet& paramP
       // TODO: change this treatment to keep track of all values so that the threshold
       // for adaptive sampling is counted for all distributions and not just the
       // first one.
-      double valueFirst = -999.0, weight = 1.0;
+      double valueFirst = -999.0;
+      double weight = 1.0;
 
       // set variables to requested parameter point
       allVars->assign(*saveAll); // important for example for SimpleLikelihoodRatioTestStat

--- a/roofit/xroofit/src/xRooFit.cxx
+++ b/roofit/xroofit/src/xRooFit.cxx
@@ -1357,7 +1357,8 @@ int xRooFit::minos(RooAbsReal &nll, const RooFitResult &ufit, const char *parNam
       double val_pre =
          val_guess -
          10 * precision * sigma_guess; // this is just to set value st. guarantees will do at least one iteration
-      bool lastOverflow = false, lastUnderflow = false;
+      bool lastOverflow = false;
+      bool lastUnderflow = false;
       while (std::abs(val_pre - val_guess) > precision * sigma_guess) {
          val_pre = val_guess;
          if (val_guess > 0 && par->getMax() < val_guess)
@@ -1623,7 +1624,8 @@ xRooFit::hypoTest(RooWorkspace &w, int nToysNull, int /*nToysAlt*/, const xRooFi
       std::vector<int> expSig = {-2, -1, 0, 1, 2};
       if (std::isnan(altVal))
          expSig.clear();
-      std::map<int, TGraphErrors> exp_pcls, exp_cls;
+      std::map<int, TGraphErrors> exp_pcls;
+      std::map<int, TGraphErrors> exp_cls;
       for (auto &s : expSig) {
          exp_pcls[s].SetNameTitle(TString::Format("exp%d_p%s", s, sCL),
                                   TString::Format("Expected (%d#sigma) p_{%s};%s", s, sCL, mu->GetTitle()));

--- a/roofit/xroofit/src/xRooNode.cxx
+++ b/roofit/xroofit/src/xRooNode.cxx
@@ -6127,7 +6127,8 @@ xRooNode xRooNode::fitResult(const char *opt) const
          if (pConstr) {
             // there will be 3 deps, one will be this par, the other two are the mean and error (or error^2 in case of
             // poisson use the one that's a ConstVar as the error to break a tie ...
-            double prefitVal = 0, prefitError = 0;
+            double prefitVal = 0;
+            double prefitError = 0;
             for (auto &_d : pConstr->vars()) {
                if (strcmp(p->GetName(), _d->get()->GetName()) == 0)
                   continue;
@@ -7964,8 +7965,10 @@ TPaveText *getPave(const char *name = "labels", bool create = true, bool doPaint
 TLegend *getLegend(bool create = true, bool doPaint = false)
 {
    if (auto p = dynamic_cast<TLegend *>(gPad->GetPrimitive("legend")); p) {
-      double x, y;
-      double w = p->GetX2NDC() - p->GetX1NDC(), h = p->GetY2NDC() - p->GetY1NDC();
+      double x;
+      double y;
+      double w = p->GetX2NDC() - p->GetX1NDC();
+      double h = p->GetY2NDC() - p->GetY1NDC();
       if (doPaint)
          gPad->PaintModified(); //-- slows down x11 so trying to avoid
       if (TopRightPlaceBox(dynamic_cast<TPad *>(gPad), p, w, h, x, y)) {
@@ -8178,7 +8181,8 @@ void xRooNode::Draw(Option_t *opt)
       if (auto _idx2 = varPart.Index("("); _idx2 > 0) {
          varName = varPart(0, _idx2);
          TStringToken pattern(TString(varPart(_idx2 + 1, varPart.Length() - _idx2 - 2)), ",");
-         double min(0), max(0);
+         double min(0);
+         double max(0);
          int nBins = 0;
          int ii = 0;
          while (pattern.NextToken()) {

--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -76,7 +76,7 @@ The `$ROOTSYS/tutorials` directory includes several sub-directories:
 
 \defgroup tutorial_roofit RooFit Tutorials
 \ingroup Tutorials
-\brief These tutorials illustrate the main features of \ref Roofitmain: the name of the examples and their short description help in figuring out their objective.
+\brief These tutorials illustrate the main features of [RooFit](group__Roofitmain.html): the name of the examples and their short description help in figuring out their objective.
 
 \defgroup tutorial_graphs Graphs tutorials
 \ingroup Tutorials


### PR DESCRIPTION
  * Fix the link from the RooFit tutorials to the main RooFit page

  * Fix broken link in `RooJSONFactoryWSTool`

  * Remove redundant links in `roofit_hs3.md` (doxygen generates the links automatically)

  * Use relative paths to reference guide

  * Avoid class names in the brief description because the duplicated name looks not nice in the generated docs: https://root.cern/doc/v628/group__Roofitcore.html

  * Remove a few unneeded destructor declarations