### PR TITLE
[ntuple] Rename `R*Info` classes to `R*Inspector`

### DIFF
--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -94,21 +94,21 @@ public:
    };
 
    /////////////////////////////////////////////////////////////////////////////
-   /// \brief Holds field-level storage information.
+   /// \brief Provides field-level storage information.
    ///
-   /// The RFieldTreeInfo class provides storage information for a field **and** its subfields. This information is
-   /// either collected during the construction of the RNTupleInpector object, or can be accessed using
+   /// The RFieldTreeInspector class provides storage information for a field **and** its subfields. This information is
+   /// partly collected during the construction of the RNTupleInspector object, and can partly be accessed using
    /// the RFieldDescriptor that belongs to this field.
-   class RFieldTreeInfo {
+   class RFieldTreeInspector {
    private:
       const RFieldDescriptor &fRootFieldDescriptor;
       std::uint64_t fCompressedSize = 0;
       std::uint64_t fUncompressedSize = 0;
 
    public:
-      RFieldTreeInfo(const RFieldDescriptor &fieldDesc, std::uint64_t onDiskSize, std::uint64_t inMemSize)
+      RFieldTreeInspector(const RFieldDescriptor &fieldDesc, std::uint64_t onDiskSize, std::uint64_t inMemSize)
          : fRootFieldDescriptor(fieldDesc), fCompressedSize(onDiskSize), fUncompressedSize(inMemSize){};
-      ~RFieldTreeInfo() = default;
+      ~RFieldTreeInspector() = default;
 
       const RFieldDescriptor &GetDescriptor() const { return fRootFieldDescriptor; }
       std::uint64_t GetCompressedSize() const { return fCompressedSize; }
@@ -124,7 +124,7 @@ private:
    std::uint64_t fUncompressedSize = 0;
 
    std::map<int, RColumnInspector> fColumnInfo;
-   std::map<int, RFieldTreeInfo> fFieldTreeInfo;
+   std::map<int, RFieldTreeInspector> fFieldTreeInfo;
 
    RNTupleInspector(std::unique_ptr<Detail::RPageSource> pageSource);
 
@@ -142,10 +142,10 @@ private:
    /// \param[in] fieldId The ID of the field from which to start the recursive traversal. Typically this is the "zero
    /// ID", i.e. the logical parent of all top-level fields.
    ///
-   /// \return The RFieldTreeInfo for the provided field ID.
+   /// \return The RFieldTreeInspector for the provided field ID.
    ///
-   // / This method iscalled when the RNTupleInpector is initially created.
-   RFieldTreeInfo CollectFieldTreeInfo(DescriptorId_t fieldId);
+   /// This method is called when the RNTupleInspector is initially created.
+   RFieldTreeInspector CollectFieldTreeInfo(DescriptorId_t fieldId);
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Get the columns that make up the given field, including its subfields.
@@ -323,20 +323,20 @@ public:
                                                  std::string_view histTitle = "");
 
    /////////////////////////////////////////////////////////////////////////////
-   /// \brief Get storage information for a given (sub)field by ID.
+   /// \brief Get a storage information inspector for a given (sub)field by ID, including its subfields.
    ///
    /// \param[in] fieldId The ID of the (sub)field for which to get the information.
    ///
-   /// \return The storage information for the provided (sub)field.
-   const RFieldTreeInfo &GetFieldTreeInfo(DescriptorId_t fieldId) const;
+   /// \return The storage information inspector for the provided (sub)field tree.
+   const RFieldTreeInspector &GetFieldTreeInspector(DescriptorId_t fieldId) const;
 
    /////////////////////////////////////////////////////////////////////////////
-   /// \brief Get storage information for a given (sub)field by name.
+   /// \brief Get a storage information inspector for a given (sub)field by name, including its subfields.
    ///
    /// \param[in] fieldName The name of the (sub)field for which to get the information.
    ///
-   /// \return The storage information for the provided (sub)field.
-   const RFieldTreeInfo &GetFieldTreeInfo(std::string_view fieldName) const;
+   /// \return The storage information inspector for the provided (sub)field tree.
+   const RFieldTreeInspector &GetFieldTreeInspector(std::string_view fieldName) const;
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Get the number of fields of a given type or class present in the RNTuple.

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -67,12 +67,12 @@ std::cout << "The compression factor is " << inspector->GetCompressionFactor()
 class RNTupleInspector {
 public:
    /////////////////////////////////////////////////////////////////////////////
-   /// \brief Holds column-level storage information.
+   /// \brief Provides column-level storage information.
    ///
-   /// The RColumnInfo class provides storage information for an individual column. This information is either
-   /// collected during the construction of the RNTupleInpector object, or can be accessed using
-   /// the RColumnDescriptor that belongs to this column.
-   class RColumnInfo {
+   /// The RColumnInspector class provides storage information for an individual column. This information is partly
+   /// collected during the construction of the RNTupleInspector object, and can partly be accessed using the
+   /// RColumnInspector that belongs to this field.
+   class RColumnInspector {
    private:
       const RColumnDescriptor &fColumnDescriptor;
       std::uint64_t fCompressedSize = 0;
@@ -80,10 +80,10 @@ public:
       std::uint64_t fNElements = 0;
 
    public:
-      RColumnInfo(const RColumnDescriptor &colDesc, std::uint64_t onDiskSize, std::uint32_t elemSize,
-                  std::uint64_t nElems)
+      RColumnInspector(const RColumnDescriptor &colDesc, std::uint64_t onDiskSize, std::uint32_t elemSize,
+                       std::uint64_t nElems)
          : fColumnDescriptor(colDesc), fCompressedSize(onDiskSize), fElementSize(elemSize), fNElements(nElems){};
-      ~RColumnInfo() = default;
+      ~RColumnInspector() = default;
 
       const RColumnDescriptor &GetDescriptor() const { return fColumnDescriptor; }
       std::uint64_t GetCompressedSize() const { return fCompressedSize; }
@@ -123,7 +123,7 @@ private:
    std::uint64_t fCompressedSize = 0;
    std::uint64_t fUncompressedSize = 0;
 
-   std::map<int, RColumnInfo> fColumnInfo;
+   std::map<int, RColumnInspector> fColumnInfo;
    std::map<int, RFieldTreeInfo> fFieldTreeInfo;
 
    RNTupleInspector(std::unique_ptr<Detail::RPageSource> pageSource);
@@ -244,7 +244,7 @@ public:
    /// \param[in] physicalColumnId The physical ID of the column for which to get the information.
    ///
    /// \return The storage information for the provided column.
-   const RColumnInfo &GetColumnInfo(DescriptorId_t physicalColumnId) const;
+   const RColumnInspector &GetColumnInspector(DescriptorId_t physicalColumnId) const;
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Get the number of columns of a given type present in the RNTuple.
@@ -280,7 +280,7 @@ public:
    /// auto inspector = RNTupleInspector::Create("myNTuple", "some/file.root");
    /// inspector->PrintColumnTypeInfo();
    /// ~~~
-   /// Ouput:
+   /// Output:
    /// ~~~
    ///  column type    | count   | # elements      | compressed bytes  | uncompressed bytes
    /// ----------------|---------|-----------------|-------------------|--------------------
@@ -298,7 +298,7 @@ public:
    /// auto inspector = RNTupleInspector::Create("myNTuple", "some/file.root");
    /// inspector->PrintColumnTypeInfo();
    /// ~~~
-   /// Ouput:
+   /// Output:
    /// ~~~
    /// columnType,count,nElements,compressedSize,uncompressedSize
    /// SplitIndex64,2,150,72,1200

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -84,7 +84,7 @@ void ROOT::Experimental::RNTupleInspector::CollectColumnInfo()
    }
 }
 
-ROOT::Experimental::RNTupleInspector::RFieldTreeInfo
+ROOT::Experimental::RNTupleInspector::RFieldTreeInspector
 ROOT::Experimental::RNTupleInspector::CollectFieldTreeInfo(DescriptorId_t fieldId)
 {
    std::uint64_t compressedSize = 0;
@@ -105,7 +105,7 @@ ROOT::Experimental::RNTupleInspector::CollectFieldTreeInfo(DescriptorId_t fieldI
       uncompressedSize += subFieldInfo.GetUncompressedSize();
    }
 
-   auto fieldInfo = RFieldTreeInfo(fDescriptor->GetFieldDescriptor(fieldId), compressedSize, uncompressedSize);
+   auto fieldInfo = RFieldTreeInspector(fDescriptor->GetFieldDescriptor(fieldId), compressedSize, uncompressedSize);
    fFieldTreeInfo.emplace(fieldId, fieldInfo);
    return fieldInfo;
 }
@@ -316,8 +316,8 @@ ROOT::Experimental::RNTupleInspector::GetColumnTypeInfoAsHist(ROOT::Experimental
 
 //------------------------------------------------------------------------------
 
-const ROOT::Experimental::RNTupleInspector::RFieldTreeInfo &
-ROOT::Experimental::RNTupleInspector::GetFieldTreeInfo(DescriptorId_t fieldId) const
+const ROOT::Experimental::RNTupleInspector::RFieldTreeInspector &
+ROOT::Experimental::RNTupleInspector::GetFieldTreeInspector(DescriptorId_t fieldId) const
 {
    if (fieldId >= fDescriptor->GetNFields()) {
       throw RException(R__FAIL("No field with ID " + std::to_string(fieldId) + " present"));
@@ -326,8 +326,8 @@ ROOT::Experimental::RNTupleInspector::GetFieldTreeInfo(DescriptorId_t fieldId) c
    return fFieldTreeInfo.at(fieldId);
 }
 
-const ROOT::Experimental::RNTupleInspector::RFieldTreeInfo &
-ROOT::Experimental::RNTupleInspector::GetFieldTreeInfo(std::string_view fieldName) const
+const ROOT::Experimental::RNTupleInspector::RFieldTreeInspector &
+ROOT::Experimental::RNTupleInspector::GetFieldTreeInspector(std::string_view fieldName) const
 {
    DescriptorId_t fieldId = fDescriptor->FindFieldId(fieldName);
 
@@ -335,7 +335,7 @@ ROOT::Experimental::RNTupleInspector::GetFieldTreeInfo(std::string_view fieldNam
       throw RException(R__FAIL("Could not find field `" + std::string(fieldName) + "`"));
    }
 
-   return GetFieldTreeInfo(fieldId);
+   return GetFieldTreeInspector(fieldId);
 }
 
 size_t ROOT::Experimental::RNTupleInspector::GetFieldCountByType(const std::regex &typeNamePattern,

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -64,7 +64,7 @@ void ROOT::Experimental::RNTupleInspector::CollectColumnInfo()
             fCompressionSettings = columnRange.fCompressionSettings;
          } else if (fCompressionSettings != columnRange.fCompressionSettings) {
             // Note that currently all clusters and columns are compressed with the same settings and it is not yet
-            // possible to do otherwise. This measn that currently, this exception should never be thrown, but this
+            // possible to do otherwise. This means that currently, this exception should never be thrown, but this
             // could change in the future.
             throw RException(R__FAIL("compression setting mismatch between column ranges (" +
                                      std::to_string(fCompressionSettings) + " vs " +
@@ -80,7 +80,7 @@ void ROOT::Experimental::RNTupleInspector::CollectColumnInfo()
          }
       }
 
-      fColumnInfo.emplace(colId, RColumnInfo(colDesc, compressedSize, elemSize, nElems));
+      fColumnInfo.emplace(colId, RColumnInspector(colDesc, compressedSize, elemSize, nElems));
    }
 }
 
@@ -91,7 +91,7 @@ ROOT::Experimental::RNTupleInspector::CollectFieldTreeInfo(DescriptorId_t fieldI
    std::uint64_t uncompressedSize = 0;
 
    for (const auto &colDescriptor : fDescriptor->GetColumnIterable(fieldId)) {
-      auto colInfo = GetColumnInfo(colDescriptor.GetPhysicalId());
+      auto colInfo = GetColumnInspector(colDescriptor.GetPhysicalId());
       compressedSize += colInfo.GetCompressedSize();
       uncompressedSize += colInfo.GetUncompressedSize();
    }
@@ -193,8 +193,8 @@ std::string ROOT::Experimental::RNTupleInspector::GetCompressionSettingsAsString
 
 //------------------------------------------------------------------------------
 
-const ROOT::Experimental::RNTupleInspector::RColumnInfo &
-ROOT::Experimental::RNTupleInspector::GetColumnInfo(DescriptorId_t physicalColumnId) const
+const ROOT::Experimental::RNTupleInspector::RColumnInspector &
+ROOT::Experimental::RNTupleInspector::GetColumnInspector(DescriptorId_t physicalColumnId) const
 {
    if (physicalColumnId > fDescriptor->GetNPhysicalColumns()) {
       throw RException(R__FAIL("No column with physical ID " + std::to_string(physicalColumnId) + " present"));
@@ -235,7 +235,7 @@ void ROOT::Experimental::RNTupleInspector::PrintColumnTypeInfo(ENTupleInspectorP
       std::uint32_t count;
       std::uint64_t nElems, compressedSize, uncompressedSize;
 
-      void operator+=(const RColumnInfo &colInfo)
+      void operator+=(const RColumnInspector &colInfo)
       {
          this->count++;
          this->nElems += colInfo.GetNElements();

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -464,7 +464,7 @@ TEST(RNTupleInspector, FieldInfoCompressed)
 
    auto inspector = RNTupleInspector::Create("ntuple", fileGuard.GetPath());
 
-   auto topFieldInfo = inspector->GetFieldTreeInfo("object");
+   auto topFieldInfo = inspector->GetFieldTreeInspector("object");
 
    EXPECT_GT(topFieldInfo.GetCompressedSize(), 0);
    EXPECT_EQ(topFieldInfo.GetUncompressedSize(), inspector->GetUncompressedSize());
@@ -474,7 +474,7 @@ TEST(RNTupleInspector, FieldInfoCompressed)
    std::uint64_t subFieldInMemorySize = 0;
 
    for (const auto &subField : inspector->GetDescriptor()->GetFieldIterable(topFieldInfo.GetDescriptor().GetId())) {
-      auto subFieldInfo = inspector->GetFieldTreeInfo(subField.GetId());
+      auto subFieldInfo = inspector->GetFieldTreeInspector(subField.GetId());
       subFieldOnDiskSize += subFieldInfo.GetCompressedSize();
       subFieldInMemorySize += subFieldInfo.GetUncompressedSize();
    }
@@ -482,8 +482,9 @@ TEST(RNTupleInspector, FieldInfoCompressed)
    EXPECT_EQ(topFieldInfo.GetCompressedSize(), subFieldOnDiskSize);
    EXPECT_EQ(topFieldInfo.GetUncompressedSize(), subFieldInMemorySize);
 
-   EXPECT_THROW(inspector->GetFieldTreeInfo("invalid_field"), ROOT::Experimental::RException);
-   EXPECT_THROW(inspector->GetFieldTreeInfo(inspector->GetDescriptor()->GetNFields()), ROOT::Experimental::RException);
+   EXPECT_THROW(inspector->GetFieldTreeInspector("invalid_field"), ROOT::Experimental::RException);
+   EXPECT_THROW(inspector->GetFieldTreeInspector(inspector->GetDescriptor()->GetNFields()),
+                ROOT::Experimental::RException);
 }
 
 TEST(RNTupleInspector, FieldInfoUncompressed)
@@ -509,7 +510,7 @@ TEST(RNTupleInspector, FieldInfoUncompressed)
 
    auto inspector = RNTupleInspector::Create("ntuple", fileGuard.GetPath());
 
-   auto topFieldInfo = inspector->GetFieldTreeInfo("object");
+   auto topFieldInfo = inspector->GetFieldTreeInspector("object");
 
    EXPECT_EQ(topFieldInfo.GetCompressedSize(), topFieldInfo.GetUncompressedSize());
 
@@ -517,7 +518,7 @@ TEST(RNTupleInspector, FieldInfoUncompressed)
    std::uint64_t subFieldInMemorySize = 0;
 
    for (const auto &subField : inspector->GetDescriptor()->GetFieldIterable(topFieldInfo.GetDescriptor().GetId())) {
-      auto subFieldInfo = inspector->GetFieldTreeInfo(subField.GetId());
+      auto subFieldInfo = inspector->GetFieldTreeInspector(subField.GetId());
       subFieldOnDiskSize += subFieldInfo.GetCompressedSize();
       subFieldInMemorySize += subFieldInfo.GetUncompressedSize();
    }
@@ -586,6 +587,6 @@ TEST(RNTupleInspector, FieldsByName)
 
    EXPECT_EQ(3, intFieldIds.size());
    for (const auto fieldId : intFieldIds) {
-      EXPECT_EQ("std::int32_t", inspector->GetFieldTreeInfo(fieldId).GetDescriptor().GetTypeName());
+      EXPECT_EQ("std::int32_t", inspector->GetFieldTreeInspector(fieldId).GetDescriptor().GetTypeName());
    }
 }

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -216,7 +216,7 @@ TEST(RNTupleInspector, ColumnInfoCompressed)
    std::uint64_t totalOnDiskSize = 0;
 
    for (std::size_t i = 0; i < inspector->GetDescriptor()->GetNLogicalColumns(); ++i) {
-      auto colInfo = inspector->GetColumnInfo(i);
+      auto colInfo = inspector->GetColumnInspector(i);
       totalOnDiskSize += colInfo.GetCompressedSize();
 
       EXPECT_GT(colInfo.GetCompressedSize(), 0);
@@ -226,7 +226,7 @@ TEST(RNTupleInspector, ColumnInfoCompressed)
 
    EXPECT_EQ(totalOnDiskSize, inspector->GetCompressedSize());
 
-   EXPECT_THROW(inspector->GetColumnInfo(42), ROOT::Experimental::RException);
+   EXPECT_THROW(inspector->GetColumnInspector(42), ROOT::Experimental::RException);
 }
 
 TEST(RNTupleInspector, ColumnInfoUncompressed)
@@ -260,7 +260,7 @@ TEST(RNTupleInspector, ColumnInfoUncompressed)
    std::uint64_t colTypeSizes[] = {sizeof(std::int32_t), sizeof(double)};
 
    for (std::size_t i = 0; i < inspector->GetDescriptor()->GetNLogicalColumns(); ++i) {
-      auto colInfo = inspector->GetColumnInfo(i);
+      auto colInfo = inspector->GetColumnInspector(i);
       EXPECT_EQ(colInfo.GetCompressedSize(), colInfo.GetUncompressedSize());
       EXPECT_EQ(colInfo.GetCompressedSize(), colTypeSizes[i] * 5);
    }
@@ -304,18 +304,18 @@ TEST(RNTupleInspector, ColumnsByType)
 
    EXPECT_EQ(2U, inspector->GetColumnsByType(ROOT::Experimental::EColumnType::kSplitInt64).size());
    for (const auto colId : inspector->GetColumnsByType(ROOT::Experimental::EColumnType::kSplitInt64)) {
-      EXPECT_EQ(ROOT::Experimental::EColumnType::kSplitInt64, inspector->GetColumnInfo(colId).GetType());
+      EXPECT_EQ(ROOT::Experimental::EColumnType::kSplitInt64, inspector->GetColumnInspector(colId).GetType());
    }
 
    EXPECT_EQ(2U, inspector->GetColumnsByType(ROOT::Experimental::EColumnType::kSplitReal32).size());
    for (const auto colId : inspector->GetColumnsByType(ROOT::Experimental::EColumnType::kSplitReal32)) {
-      EXPECT_EQ(ROOT::Experimental::EColumnType::kSplitReal32, inspector->GetColumnInfo(colId).GetType());
+      EXPECT_EQ(ROOT::Experimental::EColumnType::kSplitReal32, inspector->GetColumnInspector(colId).GetType());
    }
 
    EXPECT_EQ(1U, inspector->GetColumnsByType(ROOT::Experimental::EColumnType::kSplitIndex64).size());
    EXPECT_EQ(1U, inspector->GetColumnsByType(ROOT::Experimental::EColumnType::kSplitIndex64).size());
    for (const auto colId : inspector->GetColumnsByType(ROOT::Experimental::EColumnType::kSplitIndex64)) {
-      EXPECT_EQ(ROOT::Experimental::EColumnType::kSplitIndex64, inspector->GetColumnInfo(colId).GetType());
+      EXPECT_EQ(ROOT::Experimental::EColumnType::kSplitIndex64, inspector->GetColumnInspector(colId).GetType());
    }
 
    EXPECT_EQ(0U, inspector->GetColumnsByType(ROOT::Experimental::EColumnType::kSplitReal64).size());


### PR DESCRIPTION
With this PR, `RNTupleInspector::RColumnInfo` and `RNTupleInspector::RFieldTreeInfo` are renamed to `RNTupleInspector::RColumnInspector` and `RNTupleInspector::RFieldTreeInspector`, along with their getters. The rationale behind this change is to make the class names more symmetric with the general `RNTupleInspector` name and remove any potential ambiguity.

- [x] tested changes locally
- [x] updated the docs (if necessary)
