### PR TITLE
[cmake] Remove " linux" in package names:

### DIFF
--- a/cmake/modules/RootCPack.cmake
+++ b/cmake/modules/RootCPack.cmake
@@ -117,6 +117,8 @@ else()
     execute_process(COMMAND lsb_release -rs OUTPUT_VARIABLE osvers OUTPUT_STRIP_TRAILING_WHITESPACE)
   endif()
   string(TOLOWER "${osid}" osid)
+  # "fedora linux" => "fedora"
+  string(REGEX REPLACE " linux$" "" osid "${osid}")
   if(osid MATCHES ubuntu)
     string(REGEX REPLACE "([0-9]+[.][0-9]+)[.].*" "\\1" osvers "${osvers}")
   endif()


### PR DESCRIPTION
E.g. "root_v6.30.02.Linux-fedora linux39-x86_64-gcc13.2.tar.gz" should really be "root_v6.30.02.Linux-fedora39-x86_64-gcc13.2.tar.gz".
