### PR TITLE
[tmva][sofie] Fix parsing of single MatMul and fix Pool padding

### DIFF
--- a/tmva/sofie/inc/TMVA/ROperator_Gemm.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Gemm.hxx
@@ -213,7 +213,7 @@ namespace SOFIE{
             //in this case fAttrBeta needs to be equal to zero otherwise second time we run we will use
             // the previous result
             if (fAttrBeta != 0) {
-               throw std::runtime_error("TMVA SOFIE Gemm Op : Bias tensor is not present but beta value in Gemm is not zero");
+               throw std::runtime_error("TMVA SOFIE Gemm Op " + OpName + " Bias tensor is not present but beta value in Gemm is not zero");
             }
          }
          if (fType == "float"){

--- a/tmva/sofie/inc/TMVA/ROperator_Pool.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Pool.hxx
@@ -131,8 +131,9 @@ public:
                           k3 + (fAttrDilations[2] - 1) * (k3 - 1)};
 
       if (fAttrAutopad == "NOTSET") {
+         // in auto_pad is NOTSET then fAttrPads should have been set or default zero is used
          if (fAttrPads.empty()) {
-            fAttrPads = {1, 1, 1, 1, 1, 1};
+            fAttrPads = {0, 0, 0, 0, 0, 0};
          }
       } else if (fAttrAutopad == "SAME_UPPER" || fAttrAutopad == "SAME_LOWER") {
          if (fDim == 1)

--- a/tmva/sofie_parsers/src/ParseMatMul.cxx
+++ b/tmva/sofie_parsers/src/ParseMatMul.cxx
@@ -20,8 +20,9 @@ ParserFuncSignature ParseMatMul = [](RModelParser_ONNX &parser, const onnx::Node
 
    std::unique_ptr<ROperator> op;
 
+   // for MatMul there is no alpha and beta : use alpha=1 and beta=0
    float attr_alpha = 1.0;
-   float attr_beta = 1.0;
+   float attr_beta = 0.0;
    int_t attr_transA = 0;
    int_t attr_transB = 0;
 

--- a/tmva/sofie_parsers/src/RModelParser_ONNX.cxx
+++ b/tmva/sofie_parsers/src/RModelParser_ONNX.cxx
@@ -176,37 +176,40 @@ ETensorType RModelParser_ONNX::GetTensorType(const std::string &name)
 std::unique_ptr<ROperator>
 RModelParser_ONNX::ParseOperator(const size_t i, const onnx::GraphProto &graphproto, const std::vector<size_t> &nodes)
 {
-   int idx = (nodes.size() > i) ? nodes[i] : (int)i;
+   if (i >= nodes.size())
+      throw std::runtime_error("TMVA::SOFIE - Error in parsing ordered operators " + std::to_string(i) + " is >=  " + std::to_string(nodes.size()));
+   int idx = nodes[i];
    const auto &nodeproto = graphproto.node(idx);
    const std::string op_type = nodeproto.op_type();
    if (fVerbose)
       std::cout << "Parsing an operator " << op_type << std::endl;
 
-
-   if (op_type == "MatMul") {
-      // Fuse MatMul and Add
-      int idx2 = (nodes.size() > i + 1) ? nodes[i + 1] : (int)i + 1;
-      if (idx2 < graphproto.node_size() && graphproto.node(idx2).op_type() == "Add") {
-         return ParseFuseMatMulAdd(*this, graphproto.node(idx), graphproto.node(idx2));
-      }
-      else if(graphproto.node(idx2).op_type() != "Add"){
-         return ParseMatMul(*this, graphproto.node(idx));
-      }
-   } else if (nodeproto.op_type() == "Conv" || nodeproto.op_type() == "ConvTranspose") {
+   // try to fuse with following operator in case it is not last one
+   if (i < nodes.size() - 1) {
+      int idx2 = nodes[i+1];
+      if (op_type == "MatMul") {
+        // Fuse MatMul and Add
+         if (idx2 < graphproto.node_size() && graphproto.node(idx2).op_type() == "Add") {
+            return ParseFuseMatMulAdd(*this, graphproto.node(idx), graphproto.node(idx2));
+         }
+         else {
+            return ParseMatMul(*this, graphproto.node(idx));
+         }
+      } else if (nodeproto.op_type() == "Conv" || nodeproto.op_type() == "ConvTranspose") {
       // Fuse Conv or ConvTranspose without bias and Add
-      int j = (nodes.size() > i + 1) ? nodes[i + 1] : (int)i + 1;
-      if (j < graphproto.node_size() && graphproto.node(j).op_type() == "Add") {
-         if (nodeproto.op_type() == "Conv") {
-            return ParseFuseConvAdd(*this, graphproto.node(idx), graphproto.node(j));
-         } else {
-            return ParseFuseConvTransposeAdd(*this, graphproto.node(idx), graphproto.node(j));
+         if (idx2 < graphproto.node_size() && graphproto.node(idx2).op_type() == "Add") {
+            if (nodeproto.op_type() == "Conv") {
+               return ParseFuseConvAdd(*this, graphproto.node(idx), graphproto.node(idx2));
+            } else {
+               return ParseFuseConvTransposeAdd(*this, graphproto.node(idx), graphproto.node(idx2));
+            }
          }
       }
    }
 
-   // skip then the following Add
+   // skip then the following Add if it was fused before
    if (idx > 0 && op_type == "Add") {
-      int idx0 = (nodes.size() > i) ? nodes[i - 1] : (int)i - 1;
+      int idx0 = nodes[i - 1];
       if (graphproto.node(idx0).op_type() == "MatMul")
          return nullptr;
       else if (graphproto.node(idx0).op_type() == "ConvTranspose")


### PR DESCRIPTION
Fix the parsing of the single MatMul operator:

 - the beta attribute used for Gemm when generating code must be set to zero and not 1
 - When MatMul is the last operator a bug was present looking for the next operator that was not existing. This is now fixed

- Fix also the default padding in the MaxPool operator. When auto_pad is at default ("notset") and padding is not specified a zero value should be used instead of 1


