### PR TITLE
Fix invalid memory access in TRandom3

### DIFF
--- a/math/mathcore/inc/TRandom3.h
+++ b/math/mathcore/inc/TRandom3.h
@@ -35,7 +35,7 @@ public:
    ~TRandom3() override;
    /// return current element of the state used for generate the random number
    /// Note that it is not the seed of the generator that was used in the SetSeed function
-    UInt_t    GetSeed() const override { return fMt[fCount624];}
+    UInt_t    GetSeed() const override { return fMt[fCount624 % 624];}
    using TRandom::Rndm;
     Double_t  Rndm( ) override;
     void      RndmArray(Int_t n, Float_t *array) override;


### PR DESCRIPTION
The TRandom3 generator was observed to fail
a very simple test on the SetSeed/GetSeed interface:

```
gRandom->SetSeed(11);
auto a = gRandom->GetSeed();
gRandom->SetSeed(12);
auto b = gRandom->GetSeed();
assert(a != b);
```

Indeed a `GetSeed()` following any `SetSeed(seed)` call always returns the magic number 624. This is because in the current implementation

`GetSeed() { return fMT[fCount624]; }`

we access memory location `fMT[624]` which does not exist in fMT ... and so the value of fCount624 is returned, which happens to be `624`.

This commit fixes this bug by imposing an index range between 0 and 623.
