### PR TITLE
Remove duplicated key from .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -46,19 +46,6 @@ DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
-IncludeCategories:
-  - Regex:           '^("|<)T'
-    Priority:        4
-  - Regex:           '^("|<)ROOT/'
-    Priority:        5
-  - Regex:           '^<.*\.h>'
-    Priority:        1
-  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
-    Priority:        2
-  - Regex:           '^(<|"(gtest|isl|json)/)'
-    Priority:        3
-  - Regex:           '.*'
-    Priority:        6
 IndentCaseLabels: false
 IndentWidth:     3
 IndentWrappedFunctionNames: false
@@ -99,6 +86,8 @@ UseTab:          Never
 IncludeCategories:
   - Regex:           '^"[^/]+\"'
     Priority:        10
+  - Regex:           '^("|<)T'
+    Priority:        12
   - Regex:           '^"ROOT/'
     Priority:        15
   - Regex:           '^"cling/'


### PR DESCRIPTION
# This Pull request:

The key IncludeCategories appeared twice in the file which caused tools other than clang-format (.e.g CLion) to fail to parse the file and format correctly. clang-format took the settings from the second occurrence (as indicated by running `clang-format --dump-config`), so the first occurrence of IncludeCategories was deleted.

## Changes or fixes:

Fixes CLion's parser for the `.clang-format` file.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

