### PR TITLE
A few fixes for compiling with nvc++

### DIFF
--- a/builtins/davix/CMakeLists.txt
+++ b/builtins/davix/CMakeLists.txt
@@ -20,6 +20,10 @@ list(APPEND DAVIX_LIBRARIES ${DAVIX_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}da
 list(APPEND DAVIX_LIBRARIES ${DAVIX_PREFIX}/src/DAVIX-build/deps/curl-install/usr/lib/${CMAKE_STATIC_LIBRARY_PREFIX}curl${CMAKE_STATIC_LIBRARY_SUFFIX})
 
 string(REPLACE "-Werror " "" DAVIX_CXX_FLAGS "${CMAKE_CXX_FLAGS} ")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC")
+    # DAVIX uses the flag -fstack-protector-all, which nvc++ does not understand
+    set(DAVIX_CXX_FLAGS "${DAVIX_CXX_FLAGS} -noswitcherror")
+endif()
 
 ExternalProject_Add(DAVIX
   URL ${DAVIX_URL}/davix-${DAVIX_VERSION}.tar.gz

--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -555,9 +555,13 @@ if(PYTHON_VERSION_STRING_Development_Other)
 endif()
 
 #---RConfigure.h---------------------------------------------------------------------------------------------
-try_compile(has__cplusplus "${CMAKE_BINARY_DIR}" SOURCES "${CMAKE_SOURCE_DIR}/config/__cplusplus.cxx"
+if (CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC")
+   execute_process(COMMAND ${CMAKE_CXX_COMPILER} -dM -E /dev/null OUTPUT_VARIABLE __cplusplus_PPout)
+else()
+   try_compile(has__cplusplus "${CMAKE_BINARY_DIR}" SOURCES "${CMAKE_SOURCE_DIR}/config/__cplusplus.cxx"
             OUTPUT_VARIABLE __cplusplus_PPout)
-string(REGEX MATCH "__cplusplus=([0-9]+)" __cplusplus "${__cplusplus_PPout}")
+endif()
+string(REGEX MATCH "__cplusplus[=| ]([0-9]+)" __cplusplus "${__cplusplus_PPout}")
 set(__cplusplus ${CMAKE_MATCH_1}L)
 
 configure_file(${PROJECT_SOURCE_DIR}/config/RConfigure.in ginclude/RConfigure.h NEWLINE_STYLE UNIX)

--- a/config/__cplusplus.cxx
+++ b/config/__cplusplus.cxx
@@ -1,7 +1,7 @@
 #define _STRINGIFY(x) #x
 #define STRINGIFY(x) _STRINGIFY(x)
 
-// `#pragma message` is supported in well-known compilers including gcc, clang, icc, and MSVC
+// `#pragma message` is supported in well-known compilers including gcc, clang, icc, and MSVC. But not nvc++.
 #pragma message("__cplusplus=" STRINGIFY(__cplusplus))
 
 int main(void)

--- a/interpreter/llvm-project/llvm/include/llvm/ADT/PointerUnion.h
+++ b/interpreter/llvm-project/llvm/include/llvm/ADT/PointerUnion.h
@@ -261,8 +261,9 @@ struct PointerLikeTypeTraits<PointerUnion<PTs...>> {
 
   // The number of bits available are the min of the pointer types minus the
   // bits needed for the discriminator.
-  static constexpr int NumLowBitsAvailable = PointerLikeTypeTraits<decltype(
-      PointerUnion<PTs...>::Val)>::NumLowBitsAvailable;
+  using nvhpcWorkAround = decltype(PointerUnion<PTs...>::Val);
+  static constexpr int NumLowBitsAvailable =
+      PointerLikeTypeTraits<nvhpcWorkAround>::NumLowBitsAvailable;
 };
 
 // Teach DenseMap how to use PointerUnions as keys.

--- a/interpreter/llvm-project/llvm/lib/Support/CommandLine.cpp
+++ b/interpreter/llvm-project/llvm/lib/Support/CommandLine.cpp
@@ -729,6 +729,9 @@ static Option *getOptionPred(StringRef Name, size_t &Length,
   // string.
   while (OMI == OptionsMap.end() && Name.size() > 1) {
     Name = Name.substr(0, Name.size() - 1); // Chop off the last character.
+#ifdef __NVCOMPILER
+    nulls() << "asdf" << Name; // nvc++ workaround to prevent optimizer bug
+#endif
     OMI = OptionsMap.find(Name);
     if (OMI != OptionsMap.end() && !Pred(OMI->getValue()))
       OMI = OptionsMap.end();

--- a/interpreter/llvm-project/llvm/utils/TableGen/AsmMatcherEmitter.cpp
+++ b/interpreter/llvm-project/llvm/utils/TableGen/AsmMatcherEmitter.cpp
@@ -586,6 +586,9 @@ struct MatchableInfo {
   /// suboperand index.
   int findAsmOperand(StringRef N, int SubOpIdx) const {
     auto I = find_if(AsmOperands, [&](const AsmOperand &Op) {
+#ifdef __NVCOMPILER
+      nulls() << Op.SrcOpName << " " << N << "\n"; // nvc++ workaround to prevent optimizer bug
+#endif
       return Op.SrcOpName == N && Op.SubOpIdx == SubOpIdx;
     });
     return (I != AsmOperands.end()) ? I - AsmOperands.begin() : -1;
@@ -595,14 +598,24 @@ struct MatchableInfo {
   /// This does not check the suboperand index.
   int findAsmOperandNamed(StringRef N, int LastIdx = -1) const {
     auto I = std::find_if(AsmOperands.begin() + LastIdx + 1, AsmOperands.end(),
-                     [&](const AsmOperand &Op) { return Op.SrcOpName == N; });
+                     [&](const AsmOperand &Op) {
+#ifdef __NVCOMPILER
+                            nulls() << Op.SrcOpName << " " << N << "\n"; // nvc++ workaround to prevent optimizer bug
+#endif
+                            return Op.SrcOpName == N;
+                          });
     return (I != AsmOperands.end()) ? I - AsmOperands.begin() : -1;
   }
 
   int findAsmOperandOriginallyNamed(StringRef N) const {
     auto I =
         find_if(AsmOperands,
-                [&](const AsmOperand &Op) { return Op.OrigSrcOpName == N; });
+                [&](const AsmOperand &Op) {
+#ifdef __NVCOMPILER
+                  nulls()  << Op.OrigSrcOpName << " " << N << "\n"; // nvc++ workaround to prevent optimizer bug
+#endif
+                  return Op.OrigSrcOpName == N;
+                });
     return (I != AsmOperands.end()) ? I - AsmOperands.begin() : -1;
   }
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Fixes several issues when compiling ROOT with nvc++, but not all of them. The build still fails ultimately, because `clang-tblgen` crashes. See also #9036.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)
