### PR TITLE
TFormula/TTreeFormula: Use TMath::Pi() instead of TMath::ACos(-1)

### DIFF
--- a/graf2d/graf/src/TText.cxx
+++ b/graf2d/graf/src/TText.cxx
@@ -315,7 +315,7 @@ void TText::ExecuteEvent(Int_t event, Int_t px, Int_t py)
             theta = TMath::ACos((px-px1)/norm);
             dtheta= TMath::ASin((py1-py)/norm);
             if (dtheta<0) theta = -theta;
-            theta = theta/TMath::ACos(-1)*180;
+            theta = theta/TMath::Pi()*180;
             if (theta<0) theta += 360;
             if (right) {theta = theta+180; if (theta>=360) theta -= 360;}
          }

--- a/hist/hist/src/TFormula_v5.cxx
+++ b/hist/hist/src/TFormula_v5.cxx
@@ -2778,7 +2778,7 @@ Double_t TFormula::EvalParOld(const Double_t *x, const Double_t *uparams)
                       else {tab[pos-1] = 0;} //{indetermination }
                       continue;
 
-         case kpi   : pos++; tab[pos-1] = TMath::ACos(-1); continue;
+         case kpi   : pos++; tab[pos-1] = TMath::Pi(); continue;
 
          case kabs  : tab[pos-1] = TMath::Abs(tab[pos-1]); continue;
          case ksign : if (tab[pos-1] < 0) tab[pos-1] = -1; else tab[pos-1] = 1; continue;
@@ -4275,7 +4275,7 @@ Double_t TFormula::EvalParFast(const Double_t *x, const Double_t *uparams)
             if (strstr(stringStack[strpos],stringStack[strpos+1])) tab[pos-1]=1;
             else tab[pos-1]=0;
             continue;
-         case kpi   : pos++; tab[pos-1] = TMath::ACos(-1); continue;
+         case kpi   : pos++; tab[pos-1] = TMath::Pi(); continue;
 
 
          case kSignInv: tab[pos-1] = -1 * tab[pos-1]; continue;

--- a/tree/treeplayer/src/TTreeFormula.cxx
+++ b/tree/treeplayer/src/TTreeFormula.cxx
@@ -4092,7 +4092,7 @@ T TTreeFormula::EvalInstance(Int_t instance, const char *stringStackArg[])
                          else {tab[pos-1] = 0;} //{indetermination }
                          continue;
 
-            case kpi   : pos++; tab[pos-1] = TMath::ACos(-1); continue;
+            case kpi   : pos++; tab[pos-1] = TMath::Pi(); continue;
 
             case kabs  : tab[pos-1] = TMath::Abs(tab[pos-1]); continue;
             case ksign : if (tab[pos-1] < 0) tab[pos-1] = -1; else tab[pos-1] = 1;


### PR DESCRIPTION
It's a minor change that might or might not give better performace, but at least it means we can close this JIRA ticket:

https://sft.its.cern.ch/jira/browse/ROOT-6954