### PR TITLE
Add dependency of Core on etc/gitinfo.txt

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -41,7 +41,7 @@ generateHeader(Core
   ${CMAKE_BINARY_DIR}/ginclude/TApplicationCommandLineOptionsHelp.h
 )
 
-add_dependencies(Core CLING rconfigure)
+add_dependencies(Core CLING rconfigure gitinfotxt)
 
 target_link_libraries(Core
   PRIVATE


### PR DESCRIPTION
Make sure `etc/gitinfo.txt` is copied before building `Core`. This should fix the following errors when generating the dictionaries when building from scratch:
```
  Generating G__Gui.cxx, ../../bin/libGui_rdict.pcm, ../../bin/libGui.rootmap
  Error in <UnknownClass::ReadGitInfo()>: Cannot determine git info: etc/gitinfo.txt not found!
```
