### PR TITLE
[ci] Remove `--shm-size=1g -m 16`:

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -354,7 +354,7 @@ jobs:
 
     container:
       image: registry.cern.ch/root-ci/${{ matrix.image }}:buildready # ALSO UPDATE BELOW!
-      options: '--shm-size=1g -m 16g --security-opt label=disable --rm' # ALSO UPDATE BELOW!
+      options: '--security-opt label=disable --rm' # ALSO UPDATE BELOW!
       env:
         OS_APPLICATION_CREDENTIAL_ID: '7f5b64a265244623a3a933308569bdba'
         OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
@@ -423,7 +423,7 @@ jobs:
                     --buildtype      RelWithDebInfo
                     --platform       ${{ matrix.image }}
                     --image          registry.cern.ch/root-ci/${{ matrix.image }}:buildready
-                    --dockeropts     '--shm-size=1g -m 16g --security-opt label=disable --rm'
+                    --dockeropts     '--security-opt label=disable --rm'
                     --incremental    $INCREMENTAL
                     --base_ref       ${{ github.base_ref }}
                     --head_ref       refs/pull/${{ github.event.pull_request.number }}/head:${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
I suspect that this is the cause of the error:
```
Resource limits are not supported and ignored on cgroups V1 rootless systems
  aaa674cabd09a8ff746c97b6c9b065865428b74ddcbcbe54a9892fc3c47d7407
  /bin/docker start aaa674cabd09a8ff746c97b6c9b065865428b74ddcbcbe54a9892fc3c47d7407
  Error: OCI runtime error: unable to start container "aaa674cabd09a8ff746c97b6c9b065865428b74ddcbcbe54a9892fc3c47d7407": runc: runc create failed: unable to start container process: error during container init: error setting cgroup config for procHooks process: cannot set memory limit: container could not join or create cgroup
  Error: Docker start fail with exit code 125
```
