### PR TITLE
2D/3D version of TH1::AddBinContent, as with TH2::SetBinContent/TH3::SetBinContent

### DIFF
--- a/hist/hist/inc/TH2.h
+++ b/hist/hist/inc/TH2.h
@@ -70,8 +70,8 @@ private:
 
 public:
    ~TH2() override;
-   virtual void     AddBinContent(Int_t bin) override;
-   virtual void     AddBinContent(Int_t bin, Double_t w) override;
+           void     AddBinContent(Int_t bin) override;
+           void     AddBinContent(Int_t bin, Double_t w) override;
    virtual void     AddBinContent(Int_t binx, Int_t biny);
    virtual void     AddBinContent(Int_t binx, Int_t biny, Double_t w);
            Int_t    BufferEmpty(Int_t action=0) override;

--- a/hist/hist/inc/TH2.h
+++ b/hist/hist/inc/TH2.h
@@ -70,6 +70,10 @@ private:
 
 public:
    ~TH2() override;
+   virtual void     AddBinContent(Int_t bin) override;
+   virtual void     AddBinContent(Int_t bin, Double_t w) override;
+   virtual void     AddBinContent(Int_t binx, Int_t biny);
+   virtual void     AddBinContent(Int_t binx, Int_t biny, Double_t w);
            Int_t    BufferEmpty(Int_t action=0) override;
            void     Copy(TObject &hnew) const override;
            Int_t    Fill(Double_t x, Double_t y) override;
@@ -151,6 +155,8 @@ public:
 
            void     AddBinContent(Int_t bin) override;
            void     AddBinContent(Int_t bin, Double_t w) override;
+           void     AddBinContent(Int_t binx, Int_t biny) override { AddBinContent(GetBin(binx, biny)); }
+           void     AddBinContent(Int_t binx, Int_t biny, Double_t w) override { AddBinContent(GetBin(binx, biny), w); }
            void     Copy(TObject &hnew) const override;
            void     Reset(Option_t *option="") override;
            void     SetBinsLength(Int_t n=-1) override;
@@ -192,6 +198,8 @@ public:
 
            void     AddBinContent(Int_t bin) override;
            void     AddBinContent(Int_t bin, Double_t w) override;
+           void     AddBinContent(Int_t binx, Int_t biny) override { AddBinContent(GetBin(binx, biny)); }
+           void     AddBinContent(Int_t binx, Int_t biny, Double_t w) override { AddBinContent(GetBin(binx, biny), w); }
            void     Copy(TObject &hnew) const override;
            void     Reset(Option_t *option="") override;
            void     SetBinsLength(Int_t n=-1) override;
@@ -233,6 +241,8 @@ public:
 
            void     AddBinContent(Int_t bin) override;
            void     AddBinContent(Int_t bin, Double_t w) override;
+           void     AddBinContent(Int_t binx, Int_t biny) override { AddBinContent(GetBin(binx, biny)); }
+           void     AddBinContent(Int_t binx, Int_t biny, Double_t w) override { AddBinContent(GetBin(binx, biny), w); }
            void     Copy(TObject &hnew) const override;
            void     Reset(Option_t *option="") override;
            void     SetBinsLength(Int_t n=-1) override;
@@ -272,6 +282,8 @@ public:
    ~TH2L() override;
    void     AddBinContent(Int_t bin) override;
    void     AddBinContent(Int_t bin, Double_t w) override;
+   void     AddBinContent(Int_t binx, Int_t biny) override { AddBinContent(GetBin(binx, biny)); }
+   void     AddBinContent(Int_t binx, Int_t biny, Double_t w) override { AddBinContent(GetBin(binx, biny), w); }
    void     Copy(TObject &hnew) const override;
    void     Reset(Option_t *option="") override;
    void     SetBinsLength(Int_t n=-1) override;
@@ -313,6 +325,8 @@ public:
            void     AddBinContent(Int_t bin) override {++fArray[bin];}
            void     AddBinContent(Int_t bin, Double_t w) override
                                  {fArray[bin] += Float_t (w);}
+           void     AddBinContent(Int_t binx, Int_t biny) override { AddBinContent(GetBin(binx, biny)); }
+           void     AddBinContent(Int_t binx, Int_t biny, Double_t w) override { AddBinContent(GetBin(binx, biny), w); }
            void     Copy(TObject &hnew) const override;
            void     Reset(Option_t *option="") override;
            void     SetBinsLength(Int_t n=-1) override;
@@ -356,6 +370,8 @@ public:
            void     AddBinContent(Int_t bin) override {++fArray[bin];}
            void     AddBinContent(Int_t bin, Double_t w) override
                                  {fArray[bin] += Double_t (w);}
+           void     AddBinContent(Int_t binx, Int_t biny) override { AddBinContent(GetBin(binx, biny)); }
+           void     AddBinContent(Int_t binx, Int_t biny, Double_t w) override { AddBinContent(GetBin(binx, biny), w); }
            void     Copy(TObject &hnew) const override;
            void     Reset(Option_t *option="") override;
            void     SetBinsLength(Int_t n=-1) override;

--- a/hist/hist/inc/TH3.h
+++ b/hist/hist/inc/TH3.h
@@ -75,6 +75,10 @@ private:
 
 public:
    ~TH3() override;
+   virtual void     AddBinContent(Int_t bin) override;
+   virtual void     AddBinContent(Int_t bin, Double_t w) override;
+   virtual void     AddBinContent(Int_t binx, Int_t biny, Int_t binz);
+   virtual void     AddBinContent(Int_t binx, Int_t biny, Int_t binz, Double_t w);
            Int_t    BufferEmpty(Int_t action = 0) override;
            void     Copy(TObject &hnew) const override;
    virtual Int_t    Fill(Double_t x, Double_t y, Double_t z);
@@ -167,6 +171,8 @@ public:
 
            void      AddBinContent(Int_t bin) override;
            void      AddBinContent(Int_t bin, Double_t w) override;
+           void      AddBinContent(Int_t binx, Int_t biny, Int_t binz) override { AddBinContent(GetBin(binx, biny, binz)); }
+           void      AddBinContent(Int_t binx, Int_t biny, Int_t binz, Double_t w) override { AddBinContent(GetBin(binx, biny, binz), w); }
            void      Copy(TObject &hnew) const override;
            void      Reset(Option_t *option="") override;
            void      SetBinsLength(Int_t n=-1) override;
@@ -205,6 +211,8 @@ public:
 
            void      AddBinContent(Int_t bin) override;
            void      AddBinContent(Int_t bin, Double_t w) override;
+           void      AddBinContent(Int_t binx, Int_t biny, Int_t binz) override { AddBinContent(GetBin(binx, biny, binz)); }
+           void      AddBinContent(Int_t binx, Int_t biny, Int_t binz, Double_t w) override { AddBinContent(GetBin(binx, biny, binz), w); }
            void      Copy(TObject &hnew) const override;
            void      Reset(Option_t *option="") override;
            void      SetBinsLength(Int_t n=-1) override;
@@ -243,6 +251,8 @@ public:
 
            void      AddBinContent(Int_t bin) override;
            void      AddBinContent(Int_t bin, Double_t w) override;
+           void      AddBinContent(Int_t binx, Int_t biny, Int_t binz) override { AddBinContent(GetBin(binx, biny, binz)); }
+           void      AddBinContent(Int_t binx, Int_t biny, Int_t binz, Double_t w) override { AddBinContent(GetBin(binx, biny, binz), w); }
            void      Copy(TObject &hnew) const override;
            void      Reset(Option_t *option="") override;
            void      SetBinsLength(Int_t n=-1) override;
@@ -281,6 +291,8 @@ public:
    ~TH3L() override;
    void      AddBinContent(Int_t bin) override;
    void      AddBinContent(Int_t bin, Double_t w) override;
+   void      AddBinContent(Int_t binx, Int_t biny, Int_t binz) override { AddBinContent(GetBin(binx, biny, binz)); }
+   void      AddBinContent(Int_t binx, Int_t biny, Int_t binz, Double_t w) override { AddBinContent(GetBin(binx, biny, binz), w); }
    void      Copy(TObject &hnew) const override;
    void      Reset(Option_t *option="") override;
    void      SetBinsLength(Int_t n=-1) override;
@@ -320,6 +332,8 @@ public:
            void      AddBinContent(Int_t bin) override {++fArray[bin];}
            void      AddBinContent(Int_t bin, Double_t w) override
                                  {fArray[bin] += Float_t (w);}
+           void      AddBinContent(Int_t binx, Int_t biny, Int_t binz) override { AddBinContent(GetBin(binx, biny, binz)); }
+           void      AddBinContent(Int_t binx, Int_t biny, Int_t binz, Double_t w) override { AddBinContent(GetBin(binx, biny, binz), w); }
            void      Copy(TObject &hnew) const override;
            void      Reset(Option_t *option="") override;
            void      SetBinsLength(Int_t n=-1) override;
@@ -359,6 +373,8 @@ public:
            void      AddBinContent(Int_t bin) override {++fArray[bin];}
            void      AddBinContent(Int_t bin, Double_t w) override
                                  {fArray[bin] += Double_t (w);}
+           void      AddBinContent(Int_t binx, Int_t biny, Int_t binz) override { AddBinContent(GetBin(binx, biny, binz)); }
+           void      AddBinContent(Int_t binx, Int_t biny, Int_t binz, Double_t w) override { AddBinContent(GetBin(binx, biny, binz), w); }
            void      Copy(TObject &hnew) const override;
            void      Reset(Option_t *option="") override;
            void      SetBinsLength(Int_t n=-1) override;

--- a/hist/hist/inc/TH3.h
+++ b/hist/hist/inc/TH3.h
@@ -75,8 +75,8 @@ private:
 
 public:
    ~TH3() override;
-   virtual void     AddBinContent(Int_t bin) override;
-   virtual void     AddBinContent(Int_t bin, Double_t w) override;
+           void     AddBinContent(Int_t bin) override;
+           void     AddBinContent(Int_t bin, Double_t w) override;
    virtual void     AddBinContent(Int_t binx, Int_t biny, Int_t binz);
    virtual void     AddBinContent(Int_t binx, Int_t biny, Int_t binz, Double_t w);
            Int_t    BufferEmpty(Int_t action = 0) override;

--- a/hist/hist/src/TH2.cxx
+++ b/hist/hist/src/TH2.cxx
@@ -3701,6 +3701,7 @@ TH2L::TH2L(const TH2L &h2l) : TH2(), TArrayL64()
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Increment bin content by 1.
+/// Passing an out-of-range bin leads to undefined behavior
 
 void TH2L::AddBinContent(Int_t bin)
 {
@@ -3710,6 +3711,7 @@ void TH2L::AddBinContent(Int_t bin)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Increment bin content by w.
+/// Passing an out-of-range bin leads to undefined behavior
 
 void TH2L::AddBinContent(Int_t bin, Double_t w)
 {

--- a/hist/hist/src/TH2.cxx
+++ b/hist/hist/src/TH2.cxx
@@ -223,6 +223,41 @@ TH2::~TH2()
 {
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// Increment bin content by 1.
+/// Passing an out-of-range bin leads to undefined behavior
+
+void TH2::AddBinContent(Int_t)
+{
+   AbstractMethod("AddBinContent");
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Increment bin content by a weight w.
+/// Passing an out-of-range bin leads to undefined behavior
+
+void TH2::AddBinContent(Int_t, Double_t)
+{
+   AbstractMethod("AddBinContent");
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Increment 2D bin content by 1.
+/// Passing an out-of-range bin leads to undefined behavior
+
+void TH2::AddBinContent(Int_t, Int_t)
+{
+   AbstractMethod("AddBinContent");
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Increment 2D bin content by a weight w.
+/// Passing an out-of-range bin leads to undefined behavior
+
+void TH2::AddBinContent(Int_t, Int_t, Double_t)
+{
+   AbstractMethod("AddBinContent");
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill histogram with all entries in the buffer.

--- a/hist/hist/src/TH3.cxx
+++ b/hist/hist/src/TH3.cxx
@@ -213,6 +213,41 @@ void TH3::Copy(TObject &obj) const
    ((TH3&)obj).fTsumwyz     = fTsumwyz;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// Increment bin content by 1.
+/// Passing an out-of-range bin leads to undefined behavior
+
+void TH3::AddBinContent(Int_t)
+{
+   AbstractMethod("AddBinContent");
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Increment bin content by a weight w.
+/// Passing an out-of-range bin leads to undefined behavior
+
+void TH3::AddBinContent(Int_t, Double_t)
+{
+   AbstractMethod("AddBinContent");
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Increment 3D bin content by 1.
+/// Passing an out-of-range bin leads to undefined behavior
+
+void TH3::AddBinContent(Int_t, Int_t, Int_t)
+{
+   AbstractMethod("AddBinContent");
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Increment 3D bin content by a weight w.
+/// Passing an out-of-range bin leads to undefined behavior
+
+void TH3::AddBinContent(Int_t, Int_t, Int_t, Double_t)
+{
+   AbstractMethod("AddBinContent");
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill histogram with all entries in the buffer.


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

You can call `TH1::SetBinContent(1, 5)` and `TH2::SetBinContent(1, 1, 5)`
You can call `TH1::AddBinContent(1,5)` but you cannot call `TH2::AddBinContent(1, 1, 5)`

This PR makes the latter option available, for symmetry.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

