### PR TITLE
Minuit2: Fix VERSION_FILE path for standalone mode

### DIFF
--- a/math/minuit2/StandAlone.cmake
+++ b/math/minuit2/StandAlone.cmake
@@ -40,8 +40,8 @@ endfunction()
 include(copy_standalone.cmake)
 
 # Copy these files in if needed
-copy_standalone(SOURCE ../.. DESTINATION . OUTPUT VERSION_FILE
-                FILES core/foundation/inc/ROOT/RVersion.hxx)
+copy_standalone(SOURCE ../../core/foundation/inc/ROOT DESTINATION . OUTPUT VERSION_FILE
+                FILES RVersion.hxx)
 
 copy_standalone(SOURCE ../.. DESTINATION .
                 FILES LGPL2_1.txt)


### PR DESCRIPTION
Fixes #14157. When building minuit2 standalone with root 6.30/02 (-Dminuit2_standalone=ON), cmake errors out when looking for the version file 'RVersion.hxx' in 'core/foundation/inc/ROOT/RVersion.hxx' whereas it is copied to the top-level dir (i.e. 'math/minuit2/'). This is because the variable VERSION_FILE is incorrectly set to the file path matching the full path of the file. Fixed by setting the parent dir path of 'RVersion.hxx' as the `SOURCE` in `copy_standalone()` so that `VERSION_FILE` is set to just the base file name.

# This Pull request:

## Changes or fixes: commit 27082fb


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #14157 

