### PR TITLE
Adjust test for failures on aarch64, ppc64le and s390x

### DIFF
--- a/roofit/roofitcore/test/testRooTruthModel.cxx
+++ b/roofit/roofitcore/test/testRooTruthModel.cxx
@@ -35,5 +35,5 @@ TEST(RooTruthModel, IntegrateSubrange)
    dt.setRange("integral", 2, 2);
 
    std::unique_ptr<RooAbsReal> integ{bcpg.createIntegral({dt}, "integral")};
-   EXPECT_FLOAT_EQ(integ->getVal(), 0.0);
+   EXPECT_NEAR(integ->getVal(), 0.0, 1e-16);
 }


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
```
[ RUN      ] RooTruthModel.IntegrateSubrange
[#1] INFO:Eval -- RooRealVar::setRange(dt) new range named 'integral' created with bounds [2,2]
/builddir/build/BUILD/root-6.30.02/roofit/roofitcore/test/testRooTruthModel.cxx:38: Failure
Expected equality of these values:
  integ->getVal()
    Which is: -2.8822093e-17
  0.0
    Which is: 0
[  FAILED  ] RooTruthModel.IntegrateSubrange (194 ms)
```

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

