### PR TITLE
[RF] Introduce `RooAbsCollection::addTyped()` method

### DIFF
--- a/roofit/histfactory/inc/RooStats/HistFactory/ParamHistFunc.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/ParamHistFunc.h
@@ -98,7 +98,6 @@ protected:
   mutable RooDataHist _dataSet;
 
   Int_t getCurrentBin() const;
-  Int_t addVarSet( const RooArgList& vars );
   Int_t addParamSet( const RooArgList& params );
   static Int_t GetNumBins( const RooArgSet& vars );
   double evaluate() const override;

--- a/roofit/histfactory/src/ParamHistFunc.cxx
+++ b/roofit/histfactory/src/ParamHistFunc.cxx
@@ -103,7 +103,7 @@ ParamHistFunc::ParamHistFunc(const char* name, const char* title,
   _numBins = GetNumBins( vars );
 
   // Add the parameters (with checking)
-  addVarSet( vars );
+  _dataVars.addTyped<RooRealVar>(vars);
   addParamSet( paramSet );
 }
 
@@ -138,7 +138,7 @@ ParamHistFunc::ParamHistFunc(const char* name, const char* title,
   _numBins = GetNumBins( vars );
 
   // Add the parameters (with checking)
-  addVarSet( vars );
+  _dataVars.addTyped<RooRealVar>(vars);
   addParamSet( paramSet );
 }
 
@@ -516,27 +516,6 @@ Int_t ParamHistFunc::getCurrentBin() const {
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// return 0 for success
-/// return 1 for failure
-/// Check that the elements
-/// are actually RooRealVar's
-/// If so, add them to the
-/// list of vars
-Int_t ParamHistFunc::addVarSet( const RooArgList& vars ) {
-  for(auto const& comp : vars) {
-    if (!dynamic_cast<RooRealVar*>(comp)) {
-      auto errorMsg = std::string("ParamHistFunc::(") + GetName() + ") ERROR: component "
-                      + comp->GetName() + " in variables list is not of type RooRealVar";
-      coutE(InputArguments) <<  errorMsg << std::endl;
-      throw std::runtime_error(errorMsg);
-    }
-    _dataVars.add( *comp );
-  }
-  return 0;
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
 
 Int_t ParamHistFunc::addParamSet( const RooArgList& params ) {
   // return 0 for success
@@ -563,16 +542,7 @@ Int_t ParamHistFunc::addParamSet( const RooArgList& params ) {
   // If so, add them to the
   // list of params
 
-  for (const auto comp : params) {
-    if (!dynamic_cast<const RooAbsReal*>(comp)) {
-      auto errorMsg = std::string("ParamHistFunc::(") + GetName() + ") ERROR: component "
-                      + comp->GetName() + " in parameter list is not of type RooAbsReal.";
-      coutE(InputArguments) <<  errorMsg << std::endl;
-      throw std::runtime_error(errorMsg);
-    }
-
-    _paramSet.add( *comp );
-  }
+  _paramSet.addTyped<RooAbsReal>(params);
 
   return 0;
 }

--- a/roofit/roofit/inc/RooMomentMorphFuncND.h
+++ b/roofit/roofit/inc/RooMomentMorphFuncND.h
@@ -135,8 +135,6 @@ public:
 
 protected:
    void initialize();
-   void initializeParameters(const RooArgList &parList);
-   void initializeObservables(const RooArgList &obsList);
 
    RooAbsReal *sumFunc(const RooArgSet *nset);
    CacheElem *getCache(const RooArgSet *nset) const;

--- a/roofit/roofit/inc/RooNDKeysPdf.h
+++ b/roofit/roofit/inc/RooNDKeysPdf.h
@@ -158,7 +158,6 @@ protected:
 
   std::vector<itVec> _sortTVIdcs; //!
 
-  std::vector<std::string> _varName;
   mutable std::vector<double> _rho;
   RooArgSet _dataVars;
   mutable std::vector<double> _x; // Cache for x values
@@ -200,7 +199,7 @@ protected:
 
   RooChangeTracker *_tracker{nullptr}; //
 
-  ClassDefOverride(RooNDKeysPdf, 2) // General N-dimensional non-parametric kernel estimation p.d.f
+  ClassDefOverride(RooNDKeysPdf, 3) // General N-dimensional non-parametric kernel estimation p.d.f
 };
 
 #endif

--- a/roofit/roofit/src/RooBernstein.cxx
+++ b/roofit/roofit/src/RooBernstein.cxx
@@ -53,14 +53,7 @@ RooBernstein::RooBernstein(const char* name, const char* title,
   _x("x", "Dependent", this, x),
   _coefList("coefficients","List of coefficients",this)
 {
-  for (auto *coef : coefList) {
-    if (!dynamic_cast<RooAbsReal*>(coef)) {
-      cout << "RooBernstein::ctor(" << GetName() << ") ERROR: coefficient " << coef->GetName()
-      << " is not of type RooAbsReal" << endl ;
-      R__ASSERT(0) ;
-    }
-    _coefList.add(*coef) ;
-  }
+  _coefList.addTyped<RooAbsReal>(coefList);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooChebychev.cxx
+++ b/roofit/roofit/src/RooChebychev.cxx
@@ -49,15 +49,7 @@ RooChebychev::RooChebychev(const char* name, const char* title,
   _x("x", "Dependent", this, x),
   _coefList("coefficients","List of coefficients",this)
 {
-  for (const auto coef : coefList) {
-    if (!dynamic_cast<RooAbsReal*>(coef)) {
-      coutE(InputArguments) << "RooChebychev::ctor(" << GetName() <<
-       ") ERROR: coefficient " << coef->GetName() <<
-       " is not of type RooAbsReal" << std::endl ;
-      throw std::invalid_argument("Wrong input arguments for RooChebychev");
-    }
-    _coefList.add(*coef) ;
-  }
+  _coefList.addTyped<RooAbsReal>(coefList);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooExpPoly.cxx
+++ b/roofit/roofit/src/RooExpPoly.cxx
@@ -75,14 +75,7 @@ RooExpPoly::RooExpPoly(const char *name, const char *title, RooAbsReal &x, const
       _lowestOrder = 0;
    }
 
-   for (auto coef : coefList) {
-      if (!dynamic_cast<RooAbsReal *>(coef)) {
-         coutE(InputArguments) << "RooExpPoly::ctor(" << GetName() << ") ERROR: coefficient " << coef->GetName()
-                               << " is not of type RooAbsReal" << std::endl;
-         R__ASSERT(0);
-      }
-      _coefList.add(*coef);
-   }
+   _coefList.addTyped<RooAbsReal>(coefList);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooJeffreysPrior.cxx
+++ b/roofit/roofit/src/RooJeffreysPrior.cxx
@@ -47,23 +47,8 @@ RooJeffreysPrior::RooJeffreysPrior(const char* name, const char* title,
   _paramSet("!paramSet","Parameters",this),
   _cacheMgr(this, 1, true, false)
 {
-  for (const auto comp : obsSet) {
-    if (!dynamic_cast<RooAbsReal*>(comp)) {
-      coutE(InputArguments) << "RooJeffreysPrior::ctor(" << GetName() << ") ERROR: component " << comp->GetName()
-             << " in observable list is not of type RooAbsReal" << endl ;
-      RooErrorHandler::softAbort() ;
-    }
-    _obsSet.add(*comp) ;
-  }
-
-  for (const auto comp : paramSet) {
-    if (!dynamic_cast<RooAbsReal*>(comp)) {
-      coutE(InputArguments) << "RooJeffreysPrior::ctor(" << GetName() << ") ERROR: component " << comp->GetName()
-             << " in parameter list is not of type RooAbsReal" << endl ;
-      RooErrorHandler::softAbort() ;
-    }
-    _paramSet.add(*comp) ;
-  }
+  _obsSet.addTyped<RooAbsReal>(obsSet);
+  _paramSet.addTyped<RooAbsReal>(paramSet);
 
   // use a different integrator by default.
   if(paramSet.size()==1)

--- a/roofit/roofit/src/RooMomentMorph.cxx
+++ b/roofit/roofit/src/RooMomentMorph.cxx
@@ -55,23 +55,10 @@ RooMomentMorph::RooMomentMorph(const char *name, const char *title, RooAbsReal &
      _useHorizMorph(true)
 {
   // observables
-  for (auto *var : varList) {
-    if (!dynamic_cast<RooAbsReal*>(var)) {
-      coutE(InputArguments) << "RooMomentMorph::ctor(" << GetName() << ") ERROR: variable " << var->GetName() << " is not of type RooAbsReal" << std::endl ;
-      throw std::string("RooPolyMorh::ctor() ERROR variable is not of type RooAbsReal") ;
-    }
-    _varList.add(*var) ;
-  }
+  _varList.addTyped<RooAbsReal>(varList);
 
   // reference p.d.f.s
-
-  for (auto const *pdf : pdfList) {
-    if (!dynamic_cast<RooAbsPdf const*>(pdf)) {
-      coutE(InputArguments) << "RooMomentMorph::ctor(" << GetName() << ") ERROR: pdf " << pdf->GetName() << " is not of type RooAbsPdf" << std::endl ;
-      throw std::string("RooPolyMorh::ctor() ERROR pdf is not of type RooAbsPdf") ;
-    }
-    _pdfList.add(*pdf) ;
-  }
+  _pdfList.addTyped<RooAbsPdf>(pdfList);
 
   // initialization
   initialize();
@@ -92,22 +79,10 @@ RooMomentMorph::RooMomentMorph(const char *name, const char *title, RooAbsReal &
      _useHorizMorph(true)
 {
   // observables
-  for (auto *var : varList) {
-    if (!dynamic_cast<RooAbsReal*>(var)) {
-      coutE(InputArguments) << "RooMomentMorph::ctor(" << GetName() << ") ERROR: variable " << var->GetName() << " is not of type RooAbsReal" << std::endl ;
-      throw std::string("RooPolyMorh::ctor() ERROR variable is not of type RooAbsReal") ;
-    }
-    _varList.add(*var) ;
-  }
+  _varList.addTyped<RooAbsReal>(varList);
 
   // reference p.d.f.s
-  for (auto const *pdf : pdfList) {
-    if (!dynamic_cast<RooAbsPdf const*>(pdf)) {
-      coutE(InputArguments) << "RooMomentMorph::ctor(" << GetName() << ") ERROR: pdf " << pdf->GetName() << " is not of type RooAbsPdf" << std::endl ;
-      throw std::string("RooPolyMorh::ctor() ERROR pdf is not of type RooAbsPdf") ;
-    }
-    _pdfList.add(*pdf) ;
-  }
+  _pdfList.addTyped<RooAbsPdf>(pdfList);
 
   // reference points in m
 

--- a/roofit/roofit/src/RooMomentMorphFunc.cxx
+++ b/roofit/roofit/src/RooMomentMorphFunc.cxx
@@ -52,27 +52,11 @@ RooMomentMorphFunc::RooMomentMorphFunc(const char *name, const char *title, RooA
      _setting(setting),
      _useHorizMorph(true)
 {
-   // CTOR
-
    // observables
-   for (auto *var : varList) {
-      if (!dynamic_cast<RooAbsReal *>(var)) {
-         coutE(InputArguments) << "RooMomentMorphFunc::ctor(" << GetName() << ") ERROR: variable " << var->GetName()
-                               << " is not of type RooAbsReal" << endl;
-         throw string("RooPolyMorh::ctor() ERROR variable is not of type RooAbsReal");
-      }
-      _varList.add(*var);
-   }
+  _varList.addTyped<RooAbsReal>(varList);
 
    // reference p.d.f.s
-   for (auto const *pdf : pdfList) {
-      if (!dynamic_cast<RooAbsReal const*>(pdf)) {
-         coutE(InputArguments) << "RooMomentMorphFunc::ctor(" << GetName() << ") ERROR: func " << pdf->GetName()
-                               << " is not of type RooAbsReal" << endl;
-         throw string("RooMomentMorhFunc::ctor() ERROR func is not of type RooAbsReal");
-      }
-      _pdfList.add(*pdf);
-   }
+  _pdfList.addTyped<RooAbsPdf>(pdfList);
 
    // initialization
    initialize();
@@ -90,27 +74,11 @@ RooMomentMorphFunc::RooMomentMorphFunc(const char *name, const char *title, RooA
      _setting(setting),
      _useHorizMorph(true)
 {
-   // CTOR
-
    // observables
-   for (auto *var : varList) {
-      if (!dynamic_cast<RooAbsReal *>(var)) {
-         coutE(InputArguments) << "RooMomentMorphFunc::ctor(" << GetName() << ") ERROR: variable " << var->GetName()
-                               << " is not of type RooAbsReal" << endl;
-         throw string("RooMomentMorh::ctor() ERROR variable is not of type RooAbsReal");
-      }
-      _varList.add(*var);
-   }
+  _varList.addTyped<RooAbsReal>(varList);
 
    // reference p.d.f.s
-   for (auto const *pdf : pdfList){
-      if (!dynamic_cast<RooAbsPdf const*>(pdf)) {
-         coutE(InputArguments) << "RooMomentMorphFunc::ctor(" << GetName() << ") ERROR: function " << pdf->GetName()
-                               << " is not of type RooAbsReal" << endl;
-         throw string("RooMomentMorh::ctor() ERROR function is not of type RooAbsReal");
-      }
-      _pdfList.add(*pdf);
-   }
+  _pdfList.addTyped<RooAbsPdf>(pdfList);
 
    // reference points in m
 

--- a/roofit/roofit/src/RooMomentMorphFuncND.cxx
+++ b/roofit/roofit/src/RooMomentMorphFuncND.cxx
@@ -64,10 +64,10 @@ RooMomentMorphFuncND::RooMomentMorphFuncND(const char *name, const char *title, 
      _useHorizMorph(true)
 {
    // morph parameters
-   initializeParameters(parList);
+   _parList.addTyped<RooAbsReal>(parList);
 
    // observables
-   initializeObservables(obsList);
+   _obsList.addTyped<RooAbsReal>(obsList);
 
    _pdfList.add(_referenceGrid._pdfList);
 
@@ -106,10 +106,10 @@ RooMomentMorphFuncND::RooMomentMorphFuncND(const char *name, const char *title, 
    // morph parameters
    RooArgList parList;
    parList.add(_m);
-   initializeParameters(parList);
+   _parList.addTyped<RooAbsReal>(parList);
 
    // observables
-   initializeObservables(varList);
+   _obsList.addTyped<RooAbsReal>(varList);
 
    // general initialization
    initialize();
@@ -161,10 +161,10 @@ RooMomentMorphFuncND::RooMomentMorphFuncND(const char *name, const char *title, 
    // morph parameters
    RooArgList parList;
    parList.add(_m);
-   initializeParameters(parList);
+   _parList.addTyped<RooAbsReal>(parList);
 
    // observables
-   initializeObservables(varList);
+   _obsList.addTyped<RooAbsReal>(varList);
 
    // general initialization
    initialize();
@@ -193,32 +193,6 @@ RooMomentMorphFuncND::RooMomentMorphFuncND(const RooMomentMorphFuncND &other, co
 RooMomentMorphFuncND::~RooMomentMorphFuncND()
 {
    TRACE_DESTROY;
-}
-
-//_____________________________________________________________________________
-void RooMomentMorphFuncND::initializeParameters(const RooArgList &parList)
-{
-   for (auto *par : parList) {
-      if (!dynamic_cast<RooAbsReal *>(par)) {
-         coutE(InputArguments) << "RooMomentMorphFuncND::ctor(" << GetName() << ") ERROR: parameter " << par->GetName()
-                               << " is not of type RooAbsReal" << endl;
-         throw string("RooMomentMorphFuncND::initializeParameters() ERROR parameter is not of type RooAbsReal");
-      }
-      _parList.add(*par);
-   }
-}
-
-//_____________________________________________________________________________
-void RooMomentMorphFuncND::initializeObservables(const RooArgList &obsList)
-{
-   for (auto *var : obsList) {
-      if (!dynamic_cast<RooAbsReal *>(var)) {
-         coutE(InputArguments) << "RooMomentMorphFuncND::ctor(" << GetName() << ") ERROR: variable " << var->GetName()
-                               << " is not of type RooAbsReal" << endl;
-         throw string("RooMomentMorphFuncND::initializeObservables() ERROR variable is not of type RooAbsReal");
-      }
-      _obsList.add(*var);
-   }
 }
 
 //_____________________________________________________________________________

--- a/roofit/roofit/src/RooNDKeysPdf.cxx
+++ b/roofit/roofit/src/RooNDKeysPdf.cxx
@@ -73,17 +73,7 @@ RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, const RooArgList
      _rhoList("rhoList", "List of rho parameters", this), _options(options), _widthFactor(rho),
      _nSigma(nSigma), _rotate(rotate), _sortInput(sortInput), _nAdpt(1)
 {
-  // Constructor
-
-  for (const auto var : varList) {
-    if (!dynamic_cast<const RooAbsReal*>(var)) {
-      coutE(InputArguments) << "RooNDKeysPdf::ctor(" << GetName() << ") ERROR: variable " << var->GetName()
-             << " is not of type RooAbsReal" << endl ;
-      R__ASSERT(0) ;
-    }
-    _varList.add(*var) ;
-    _varName.push_back(var->GetName());
-  }
+  _varList.addTyped<RooAbsReal>(varList);
 
   createPdf(true, data);
 }
@@ -98,15 +88,7 @@ RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, const RooArgList
      _options(options), _widthFactor(rho), _nSigma(nSigma), _rotate(rotate),
      _sortInput(sortInput), _nAdpt(1)
 {
-   for (const auto var : varList) {
-      if (!dynamic_cast<const RooAbsReal *>(var)) {
-         coutE(InputArguments) << "RooNDKeysPdf::ctor(" << GetName() << ") ERROR: variable " << var->GetName()
-                               << " is not of type RooAbsReal" << endl;
-         assert(0);
-      }
-      _varList.add(*var);
-      _varName.push_back(var->GetName());
-   }
+   _varList.addTyped<RooAbsReal>(varList);
 
    createPdf(true, *std::unique_ptr<RooDataSet>{createDatasetFromHist(varList, hist)});
 }
@@ -120,15 +102,7 @@ RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, const RooArgList
      _rhoList("rhoList", "List of rho parameters", this), _options(options), _widthFactor(-1.0),
      _nSigma(nSigma), _rotate(rotate), _sortInput(sortInput), _nAdpt(1)
 {
-  for (const auto var : varList) {
-    if (!dynamic_cast<const RooAbsReal*>(var)) {
-       coutE(InputArguments) << "RooNDKeysPdf::ctor(" << GetName() << ") ERROR: variable " << var->GetName()
-                             << " is not of type RooAbsReal" << endl;
-       R__ASSERT(0);
-    }
-    _varList.add(*var) ;
-    _varName.push_back(var->GetName());
-  }
+  _varList.addTyped<RooAbsReal>(varList);
 
   // copy rho widths
   if(int( _varList.size()) != rho.GetNrows() ) {
@@ -159,15 +133,7 @@ RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, const RooArgList
      _rhoList("rhoList", "List of rho parameters", this), _options(options), _widthFactor(-1.0),
      _nSigma(nSigma), _rotate(rotate), _sortInput(sortInput), _nAdpt(1)
 {
-   for (const auto var : varList) {
-      if (!dynamic_cast<RooAbsReal *>(var)) {
-         coutE(InputArguments) << "RooNDKeysPdf::ctor(" << GetName() << ") ERROR: variable " << var->GetName()
-                               << " is not of type RooAbsReal" << endl;
-         assert(0);
-      }
-      _varList.add(*var);
-      _varName.push_back(var->GetName());
-   }
+   _varList.addTyped<RooAbsReal>(varList);
 
    _rho.resize(rhoList.size(), 1.0);
 
@@ -206,15 +172,7 @@ RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, const RooArgList
      _options(options), _widthFactor(-1), _nSigma(nSigma), _rotate(rotate), _sortInput(sortInput),
      _nAdpt(1)
 {
-   for (const auto var : varList) {
-      if (!dynamic_cast<RooAbsReal *>(var)) {
-         coutE(InputArguments) << "RooNDKeysPdf::ctor(" << GetName() << ") ERROR: variable " << var->GetName()
-                               << " is not of type RooAbsReal" << endl;
-         assert(0);
-      }
-      _varList.add(*var);
-      _varName.push_back(var->GetName());
-   }
+   _varList.addTyped<RooAbsReal>(varList);
 
    // copy rho widths
    _rho.resize(rhoList.size(), 1.0);
@@ -253,7 +211,6 @@ RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, RooAbsReal &x, c
      _nSigma(nSigma), _rotate(rotate), _sortInput(sortInput), _nAdpt(1)
 {
    _varList.add(x);
-   _varName.push_back(x.GetName());
 
    if (mirror != NoMirror) {
       if (mirror != MirrorBoth) {
@@ -277,8 +234,6 @@ RooNDKeysPdf::RooNDKeysPdf(const char *name, const char *title, RooAbsReal &x, R
      _nSigma(nSigma), _rotate(rotate), _sortInput(sortInput), _nAdpt(1)
 {
    _varList.add(RooArgSet(x, y));
-   _varName.push_back(x.GetName());
-   _varName.push_back(y.GetName());
 
    createPdf(true, data);
 }
@@ -309,7 +264,6 @@ RooNDKeysPdf::RooNDKeysPdf(const RooNDKeysPdf &other, const char *name)
      _weights1(other._weights1),
      _weights(_options.Contains("a") ? &_weights1 : &_weights0),
      _sortTVIdcs(other._sortTVIdcs),
-     _varName(other._varName),
      _rho(other._rho),
      _x(other._x),
      _x0(other._x0),
@@ -539,7 +493,7 @@ void RooNDKeysPdf::loadDataSet(bool firstCall, RooDataSet const& data)
   const RooArgSet* values= data.get();
   vector<RooRealVar*> dVars(_nDim);
   for  (Int_t j=0; j<_nDim; j++) {
-    dVars[j] = static_cast<RooRealVar*>(values->find(_varName[j].c_str()));
+    dVars[j] = static_cast<RooRealVar*>(values->find(_varList[j].GetName()));
     _x0[j]=_x1[j]=_x2[j]=0.;
   }
 

--- a/roofit/roofit/src/RooParametricStepFunction.cxx
+++ b/roofit/roofit/src/RooParametricStepFunction.cxx
@@ -103,16 +103,7 @@ RooParametricStepFunction::RooParametricStepFunction(const char* name, const cha
     _nBins=0 ;
   }
 
-  for (auto *coef : coefList) {
-    if (!dynamic_cast<RooAbsReal*>(coef)) {
-      std::stringstream errorMsg;
-      errorMsg << "RooParametricStepFunction::ctor(" << GetName() << ") ERROR: coefficient " << coef->GetName()
-                << " is not of type RooAbsReal";
-      coutE(InputArguments) << errorMsg.str() << std::endl;
-      throw std::invalid_argument(errorMsg.str().c_str());
-    }
-    _coefList.add(*coef) ;
-  }
+  _coefList.addTyped<RooAbsReal>(coefList);
 
   // Bin limits
   limits.Copy(_limits);

--- a/roofit/roofit/src/RooPolynomial.cxx
+++ b/roofit/roofit/src/RooPolynomial.cxx
@@ -76,14 +76,7 @@ RooPolynomial::RooPolynomial(const char *name, const char *title, RooAbsReal &x,
       _lowestOrder = 0;
    }
 
-   for (auto *coef : coefList) {
-      if (!dynamic_cast<RooAbsReal *>(coef)) {
-         coutE(InputArguments) << "RooPolynomial::ctor(" << GetName() << ") ERROR: coefficient " << coef->GetName()
-                               << " is not of type RooAbsReal" << std::endl;
-         R__ASSERT(0);
-      }
-      _coefList.add(*coef);
-   }
+   _coefList.addTyped<RooAbsReal>(coefList);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooPower.cxx
+++ b/roofit/roofit/src/RooPower.cxx
@@ -64,22 +64,8 @@ RooPower::RooPower(const char *name, const char *title, RooAbsReal &x, const Roo
                             << ") ERROR: coefficient list and exponent list must be of same length" << std::endl;
       return;
    }
-   for (auto coef : coefList) {
-      if (!dynamic_cast<RooAbsReal *>(coef)) {
-         coutE(InputArguments) << "RooPower::ctor(" << GetName() << ") ERROR: coefficient " << coef->GetName()
-                               << " is not of type RooAbsReal" << std::endl;
-         R__ASSERT(0);
-      }
-      _coefList.add(*coef);
-   }
-   for (auto exp : expList) {
-      if (!dynamic_cast<RooAbsReal *>(exp)) {
-         coutE(InputArguments) << "RooPower::ctor(" << GetName() << ") ERROR: coefficient " << exp->GetName()
-                               << " is not of type RooAbsReal" << std::endl;
-         R__ASSERT(0);
-      }
-      _expList.add(*exp);
-   }
+   _coefList.addTyped<RooAbsReal>(coefList);
+   _expList.addTyped<RooAbsReal>(expList);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooStepFunction.cxx
+++ b/roofit/roofit/src/RooStepFunction.cxx
@@ -49,23 +49,8 @@ RooStepFunction::RooStepFunction(const char* name, const char* title,
   _boundaryList("boundaryList","List of boundaries",this),
   _interpolate(interpolate)
 {
-  for (auto *coef : coefList) {
-    if (!dynamic_cast<RooAbsReal*>(coef)) {
-      std::cout << "RooStepFunction::ctor(" << GetName() << ") ERROR: coefficient " << coef->GetName()
-      << " is not of type RooAbsReal" << std::endl ;
-      assert(0) ;
-    }
-    _coefList.add(*coef) ;
-  }
-
-  for (auto *boundary : boundaryList) {
-    if (!dynamic_cast<RooAbsReal*>(boundary)) {
-      std::cout << "RooStepFunction::ctor(" << GetName() << ") ERROR: boundary " << boundary->GetName()
-      << " is not of type RooAbsReal" << std::endl;
-      assert(0) ;
-    }
-    _boundaryList.add(*boundary) ;
-  }
+  _coefList.addTyped<RooAbsReal>(coefList);
+  _boundaryList.addTyped<RooAbsReal>(boundaryList);
 
   if (_boundaryList.size()!=_coefList.size()+1) {
     coutE(InputArguments) << "RooStepFunction::ctor(" << GetName() << ") ERROR: Number of boundaries must be number of coefficients plus 1" << std::endl ;

--- a/roofit/roofitcore/src/RooAbsCollection.cxx
+++ b/roofit/roofitcore/src/RooAbsCollection.cxx
@@ -1578,3 +1578,13 @@ bool RooAbsCollection::hasSameLayout(const RooAbsCollection& other) const {
 
   return true;
 }
+
+void RooAbsCollection::throwAddTypedException(TClass *klass, RooAbsArg *arg)
+{
+   std::string typeName = klass->GetName();
+   std::stringstream msg;
+   msg << "RooAbsCollection::addTyped<" << typeName << ">() ERROR: component " << arg->GetName() << " is not of type "
+       << typeName;
+   oocoutE(nullptr, InputArguments) << msg.str() << std::endl;
+   throw std::invalid_argument(msg.str());
+}

--- a/roofit/roofitcore/src/RooAddition.cxx
+++ b/roofit/roofitcore/src/RooAddition.cxx
@@ -64,18 +64,12 @@ RooAddition::RooAddition(const char* name, const char* title, const RooArgList& 
   , _set("!set","set of components",this)
   , _cacheMgr(this,10)
 {
-  for (RooAbsArg *comp : sumSet) {
-    if (!dynamic_cast<RooAbsReal*>(comp)) {
-      coutE(InputArguments) << "RooAddition::ctor(" << GetName() << ") ERROR: component " << comp->GetName()
-             << " is not of type RooAbsReal" << std::endl;
-      RooErrorHandler::softAbort() ;
-    }
-    _set.add(*comp) ;
+  _set.addTyped<RooAbsReal>(sumSet);
 #ifndef ROOFIT_MEMORY_SAFE_INTERFACES
+  for (RooAbsArg *comp : sumSet) {
     if (takeOwnership) _ownedList.addOwned(std::unique_ptr<RooAbsArg>{comp});
-#endif
   }
-
+#endif
 }
 
 

--- a/roofit/roofitcore/src/RooConstraintSum.cxx
+++ b/roofit/roofitcore/src/RooConstraintSum.cxx
@@ -48,15 +48,7 @@ RooConstraintSum::RooConstraintSum(const char* name, const char* title, const Ro
   _set1("set1","First set of components",this),
   _takeGlobalObservablesFromData{takeGlobalObservablesFromData}
 {
-  for (const auto comp : constraintSet) {
-    if (!dynamic_cast<RooAbsPdf*>(comp)) {
-      coutE(InputArguments) << "RooConstraintSum::ctor(" << GetName() << ") ERROR: component " << comp->GetName()
-                            << " is not of type RooAbsPdf" << std::endl ;
-      RooErrorHandler::softAbort() ;
-    }
-    _set1.add(*comp) ;
-  }
-
+  _set1.addTyped<RooAbsPdf>(constraintSet);
   _paramSet.add(normSet) ;
 }
 

--- a/roofit/roofitcore/src/RooPolyFunc.cxx
+++ b/roofit/roofitcore/src/RooPolyFunc.cxx
@@ -138,17 +138,7 @@ RooPolyFunc::RooPolyFunc() {}
 RooPolyFunc::RooPolyFunc(const char *name, const char *title, const RooAbsCollection &vars)
    : RooAbsReal(name, title), _vars("x", "list of dependent variables", this)
 {
-   for (const auto &var : vars) {
-      if (!dynamic_cast<RooAbsReal *>(var)) {
-         std::stringstream ss;
-         ss << "RooPolyFunc::ctor(" << GetName() << ") ERROR: coefficient " << var->GetName()
-            << " is not of type RooAbsReal";
-         const std::string errorMsg = ss.str();
-         coutE(InputArguments) << errorMsg << std::endl;
-         throw std::runtime_error(errorMsg);
-      }
-      _vars.add(*var);
-   }
+   _vars.addTyped<RooAbsReal>(vars);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooPolyVar.cxx
+++ b/roofit/roofitcore/src/RooPolyVar.cxx
@@ -59,14 +59,7 @@ RooPolyVar::RooPolyVar(const char *name, const char *title, RooAbsReal &x, const
       _lowestOrder = 0;
    }
 
-   for (RooAbsArg *coef : coefList) {
-      if (!dynamic_cast<RooAbsReal *>(coef)) {
-         coutE(InputArguments) << "RooPolyVar::ctor(" << GetName() << ") ERROR: coefficient " << coef->GetName()
-                               << " is not of type RooAbsReal" << std::endl;
-         R__ASSERT(0);
-      }
-      _coefList.add(*coef);
-   }
+   _coefList.addTyped<RooAbsReal>(coefList);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/TestStatistics/RooSubsidiaryL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooSubsidiaryL.cxx
@@ -44,14 +44,7 @@ RooSubsidiaryL::RooSubsidiaryL(const std::string &parent_pdf_name, const RooArgS
                                const RooArgSet &parameter_set)
    : RooAbsL(nullptr, nullptr, 0, 0, RooAbsL::Extended::No), parent_pdf_name_(parent_pdf_name)
 {
-   for (const auto comp : pdfs) {
-      if (!dynamic_cast<RooAbsPdf *>(comp)) {
-         oocoutE(nullptr, InputArguments) << "RooSubsidiaryL::ctor(" << GetName() << ") ERROR: component "
-                                               << comp->GetName() << " is not of type RooAbsPdf" << std::endl;
-         RooErrorHandler::softAbort();
-      }
-      subsidiary_pdfs_.add(*comp);
-   }
+   subsidiary_pdfs_.addTyped<RooAbsPdf>(pdfs);
    parameter_set_.add(parameter_set);
 }
 

--- a/roofit/roofitmore/src/RooAdaptiveGaussKronrodIntegrator1D.h
+++ b/roofit/roofitmore/src/RooAdaptiveGaussKronrodIntegrator1D.h
@@ -36,7 +36,7 @@ public:
    bool setLimits(double *xmin, double *xmax) override;
    bool setUseIntegrandLimits(bool flag) override
    {
-      // If flag is true, intergration limits are taken from definition in input function binding
+      // If flag is true, integration limits are taken from definition in input function binding
       _useIntegrandLimits = flag;
       return true;
    }


### PR DESCRIPTION
It's a very common pattern in the RooFit implementation and user code to check the type when adding to a `RooAbsCollection`, and erroring out if the type is not correct.

This commit suggests a function in `RooAbsCollection` to do exactly this, drastically reducing the code duplication in RooFit and experiment frameworks like CMS combine.