### PR TITLE
[RF] Make `RooFFTConfPdf` also work if ROOT was built with `fftw3=OFF`

### DIFF
--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -493,6 +493,10 @@ if(cuda)
   target_compile_definitions(RooFitCore PUBLIC ROOFIT_CUDA)
 endif()
 
+if(fftw3)
+  target_compile_definitions(RooFitCore PUBLIC ROOFIT_MATH_FFTW3)
+endif()
+
 target_include_directories(RooFitCore INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/res>)
 
 # For recent clang, this can facilitate auto-vectorisation.


### PR DESCRIPTION
Since ROOT 6.30, we are not building ROOT with the `math/fftw`
subpackage anymore (`fftw3=OFF`). It is the interface between ROOT and
fftw3, but is incompatible with fftws GPL license.

That means that for default ROOT builds, the `RooFFTConvPdf` class for
FFT convolutions is not working anymore, because it uses `math/fftw`.

This commit implements a solution to make the `RooFFTConvPdf` work
again in this situation: the routine that uses fftw is declared
on-the-fly to the interpreter. This will work if the user has an
external install of `fftw3`, which is usually available in all Linux
distributions.

Closes #14162.

Note: the error that you get if `fftw3.h` can't be found looks like this:
```txt
input_line_21:1:10: fatal error: 'fftw3.h' file not found
#include "fftw3.h"
         ^~~~~~~~~
[#0] ERROR:Eval -- RooFFTConvPdf evaluation Failed! The interpreter could not find the fftw3.h header.
You have three options to fix this problem:
    1) Install fftw3 on your system so that the interpreter can find it
    2) In case fftw3.h is installed somewhere else,
       tell ROOT with gInterpreter->AddIncludePath() where to find it
    3) Compile ROOT with the -Dfftw3=ON in the CMake configuration,
       such that ROOT comes with built-in fftw3 convolution routines

terminate called after throwing an instance of 'std::runtime_error'
  what():  RooFFTConvPdf evaluation Failed! The interpreter could not find the fftw3.h header
```