### PR TITLE
Minuit2: Install libs to CMAKE_INSTALL_LIBDIR.

### DIFF
--- a/math/minuit2/src/CMakeLists.txt
+++ b/math/minuit2/src/CMakeLists.txt
@@ -216,8 +216,8 @@ target_link_libraries(Minuit2 PUBLIC Minuit2Math Minuit2Common)
 
 install(TARGETS Minuit2
         EXPORT Minuit2Targets
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         )
 
 install(FILES ${MINUIT2_HEADERS} DESTINATION include/Minuit2/Minuit2)

--- a/math/minuit2/src/math/CMakeLists.txt
+++ b/math/minuit2/src/math/CMakeLists.txt
@@ -89,8 +89,8 @@ set_target_properties(Minuit2Math PROPERTIES CXX_EXTENSIONS OFF)
 
 install(TARGETS Minuit2Math
         EXPORT Minuit2Targets
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         )
 
 install(FILES ${FIT_HEADERS} DESTINATION include/Minuit2/Fit)


### PR DESCRIPTION
Instead of hard-coding 'lib' as the path to which minuit2 is installed as a standalone library, use the user configurable CMAKE_INSTALL_LIBDIR. As a particularly common example, this allows a user to specify the library installation path to '${_prefix}/lib64' for 64-bit machines from the cmake command line.

This is part of upstreaming patches that I use to build packages for root on openSUSE [1].

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

[1] https://build.opensuse.org/package/show/science/root6