### PR TITLE
[RF] Promote `ROOFIT_MEMORY_SAFE_INTERFACES` to users in release notes

### DIFF
--- a/README/ReleaseNotes/v632/index.md
+++ b/README/ReleaseNotes/v632/index.md
@@ -39,6 +39,7 @@ The following people have contributed to this new version:
 
 ## Deprecation and Removal
 - The RooFit legacy iterators are deprecated and will be removed in ROOT 6.34 (see section "RooFit libraries")
+- Some memory-unsafe RooFit interfaces were removed
 
 ## Core Libraries
 
@@ -56,6 +57,81 @@ The following people have contributed to this new version:
 
 
 ## RooFit Libraries
+
+### Compile your code with memory safe interfaces
+
+If you define the `ROOFIT_MEMORY_SAFE_INTERFACES` preprocessor macro, the
+RooFit interface changes in a way such that memory leaks are avoided.
+
+The most prominent effect of this change is that many functions that used to
+return an owning pointer (e.g., a pointer to an object that you need to
+manually `delete`) are then returning a `std::unique_pt` for automatic memory
+management.
+
+For example this code would not compile anymore, because there is the rist that
+the caller forgets to `delete params`:
+```c++
+RooArgSet * params = pdf.getParameters(nullptr);
+```
+If you wrap such return values in a `std::unique_ptr`, then your code will
+compile both with and without memory safe interfaces:
+```c++
+std::unique_ptr<RooArgSet> params{pdf.getParameters(nullptr)};
+```
+
+Also some `virtual` RooFit functions like [RooAbsReal::createIntegral()](https://root.cern.ch/doc/master/classRooAbsReal.html#aff4be07dd6a131721daeeccf6359aea9)
+are returning a different type conditional on `ROOFIT_MEMORY_SAFE_INTERFACES`.
+If you are overriding such a function, you need to use the `RooFit::OwningPtr`
+return type, which is an alias for `std::unique_ptr` in memory-safe mode or an
+alias for a raw pointer otherwise.
+```c++
+RooFit::OwningPtr<RooAbsReal> RooAbsReal::createIntegral(...) const override
+{
+   std::unique_ptr<RooAbsReal> integral;
+   // Prepare a std::unique_ptr as the return value
+   ...
+   // Use the RooFit::makeOwningPtr<T>() helper to translate the
+   // std::unique_ptr to the actual return type (either std::unique_ptr<T> or T*).
+   return RooFit::makeOwningPtr<RooAbsReal>(std::move(integral));
+}
+```
+
+The biggest application of the memory-safe interfaces is to spot memory leaks
+in RooFit-based frameworks. If you make sure that your framework compiles both
+with and without `ROOFIT_MEMORY_SAFE_INTERFACES`, you can get rid of all memory
+leaks related to RooFit user error! After making the necessary changes, you can
+remove the marco definition again to keep backwards compatibility.
+
+Note that the memory-safe interfaces might become the default at some point, so
+doing this **backwards-compatible migration early** is strongly encouraged and
+appreciated.
+
+### Removal of some memory-unsafe interfaces
+
+* The final `bool takeOwnership` parameter of the **RooAddition** and
+  **RooStats::HistFactory::PiecewiseInterpolation** constructors was removed.
+  This is to avoid situations where ownership is not clear to the compiler.
+  Now, ownership of the input RooAbsArgs is never passed in the constructor. If
+  you want the pass input ownership to the created object, please use
+  `addOwnedComponents`. If you want to be extra safe, make sure the inputs are
+  in an owning collection and then `std::move` the collection, so that the
+  ownership is always clear.
+
+  Example:
+  ```c++
+  RooArgList sumSet;
+  sumSet.add(*(new RooRealVar("var1", "var1", 1.0)));
+  sumSet.add(*(new RooRealVar("var2", "var2", 3.0)));
+  RooAddition addition{"addition", "addition", sumSet, /*takeOwnership=*/true};
+  ```
+  should become:
+  ```c++
+  RooArgList sumSet;
+  sumSet.addOwned(std::make_unique<RooRealVar>("var1", "var1", 1.0));
+  sumSet.addOwned(std::make_unique<RooRealVar>("var2", "var2", 3.0));
+  RooAddition addition{"addition", "addition", sumSet};
+  addition.addOwnedComponents(std::move(sumSet));
+  ```
 
 ### Deprecation of legacy iterators
 

--- a/roofit/histfactory/inc/RooStats/HistFactory/PiecewiseInterpolation.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/PiecewiseInterpolation.h
@@ -31,11 +31,8 @@ class PiecewiseInterpolation : public RooAbsReal {
 public:
 
   PiecewiseInterpolation() ;
-  PiecewiseInterpolation(const char *name, const char *title, const RooAbsReal& nominal, const RooArgList& lowSet, const RooArgList& highSet, const RooArgList& paramSet
-#ifndef ROOFIT_MEMORY_SAFE_INTERFACES
-              , bool takeOwnership=false
-#endif
-  );
+  PiecewiseInterpolation(const char *name, const char *title, const RooAbsReal &nominal, const RooArgList &lowSet,
+                         const RooArgList &highSet, const RooArgList &paramSet);
   ~PiecewiseInterpolation() override ;
 
   PiecewiseInterpolation(const PiecewiseInterpolation& other, const char *name = nullptr);

--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -234,7 +234,7 @@ namespace HistFactory{
     // properties of the measurement
     HistoToWorkspaceFactoryFast::ConfigureWorkspaceForMeasurement( "model_"+ch_name, ws_single.get(), measurement );
 
-    return RooFit::Detail::owningPtr(std::move(ws_single));
+    return RooFit::makeOwningPtr(std::move(ws_single));
 
   }
 
@@ -284,7 +284,7 @@ namespace HistFactory{
     HistoToWorkspaceFactoryFast::ConfigureWorkspaceForMeasurement("simPdf", ws.get(), measurement);
 
     // Done.  Return the pointer
-    return RooFit::Detail::owningPtr(std::move(ws));
+    return RooFit::makeOwningPtr(std::move(ws));
 
   }
 
@@ -1599,7 +1599,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
       throw hf_exc();
     }
 
-    return RooFit::Detail::owningPtr(std::move(combined));
+    return RooFit::makeOwningPtr(std::move(combined));
   }
 
 

--- a/roofit/histfactory/src/MakeModelAndMeasurementsFast.cxx
+++ b/roofit/histfactory/src/MakeModelAndMeasurementsFast.cxx
@@ -263,7 +263,7 @@ RooStats::HistFactory::MakeModelAndMeasurementFast(RooStats::HistFactory::Measur
 
   msgSvc.getStream(1).addTopic(RooFit::ObjectHandling);
 
-  return RooFit::Detail::owningPtr(std::move(ws));
+  return RooFit::makeOwningPtr(std::move(ws));
 }
 
 

--- a/roofit/histfactory/src/PiecewiseInterpolation.cxx
+++ b/roofit/histfactory/src/PiecewiseInterpolation.cxx
@@ -63,21 +63,16 @@ PiecewiseInterpolation::PiecewiseInterpolation() : _normIntMgr(this)
 /// \param highSet Set of up variations.
 /// \param paramSet Parameters that control the interpolation.
 /// \param takeOwnership If true, the PiecewiseInterpolation object will take ownership of the arguments in the low, high and parameter sets.
-PiecewiseInterpolation::PiecewiseInterpolation(const char* name, const char* title, const RooAbsReal& nominal,
-                      const RooArgList& lowSet,
-                      const RooArgList& highSet,
-                      const RooArgList& paramSet
-#ifndef ROOFIT_MEMORY_SAFE_INTERFACES
-                     , bool takeOwnership
-#endif
-  ) :
-  RooAbsReal(name, title),
-  _normIntMgr(this),
-  _nominal("!nominal","nominal value", this, (RooAbsReal&)nominal),
-  _lowSet("!lowSet","low-side variation",this),
-  _highSet("!highSet","high-side variation",this),
-  _paramSet("!paramSet","high-side variation",this),
-  _positiveDefinite(false)
+PiecewiseInterpolation::PiecewiseInterpolation(const char *name, const char *title, const RooAbsReal &nominal,
+                                               const RooArgList &lowSet, const RooArgList &highSet,
+                                               const RooArgList &paramSet)
+   : RooAbsReal(name, title),
+     _normIntMgr(this),
+     _nominal("!nominal", "nominal value", this, (RooAbsReal &)nominal),
+     _lowSet("!lowSet", "low-side variation", this),
+     _highSet("!highSet", "high-side variation", this),
+     _paramSet("!paramSet", "high-side variation", this),
+     _positiveDefinite(false)
 
 {
   // KC: check both sizes
@@ -93,11 +88,6 @@ PiecewiseInterpolation::PiecewiseInterpolation(const char* name, const char* tit
       RooErrorHandler::softAbort() ;
     }
     _lowSet.add(*comp) ;
-#ifndef ROOFIT_MEMORY_SAFE_INTERFACES
-    if (takeOwnership) {
-      _ownedList.addOwned(std::unique_ptr<RooAbsArg>{comp});
-    }
-#endif
   }
 
 
@@ -108,11 +98,6 @@ PiecewiseInterpolation::PiecewiseInterpolation(const char* name, const char* tit
       RooErrorHandler::softAbort() ;
     }
     _highSet.add(*comp) ;
-#ifndef ROOFIT_MEMORY_SAFE_INTERFACES
-    if (takeOwnership) {
-      _ownedList.addOwned(std::unique_ptr<RooAbsArg>{comp});
-    }
-#endif
   }
 
 
@@ -123,11 +108,6 @@ PiecewiseInterpolation::PiecewiseInterpolation(const char* name, const char* tit
       RooErrorHandler::softAbort() ;
     }
     _paramSet.add(*comp) ;
-#ifndef ROOFIT_MEMORY_SAFE_INTERFACES
-    if (takeOwnership) {
-      _ownedList.addOwned(std::unique_ptr<RooAbsArg>{comp});
-    }
-#endif
     _interpCode.push_back(0); // default code: linear interpolation
   }
 

--- a/roofit/roofit/src/RooIntegralMorph.cxx
+++ b/roofit/roofit/src/RooIntegralMorph.cxx
@@ -155,7 +155,7 @@ RooFit::OwningPtr<RooArgSet> RooIntegralMorph::actualParameters(const RooArgSet&
   if (!_cacheAlpha) {
     par1->add(alpha.arg()) ;
   }
-  return RooFit::Detail::owningPtr(std::move(par1));
+  return RooFit::makeOwningPtr(std::move(par1));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -156,13 +156,13 @@ public:
   template <typename... CmdArgs_t>
   RooFit::OwningPtr<RooFitResult> fitTo(RooAbsData& data, CmdArgs_t const&... cmdArgs)
   {
-    return RooFit::Detail::owningPtr(fitToImpl(data, *RooFit::Detail::createCmdList(&cmdArgs...)));
+    return RooFit::makeOwningPtr(fitToImpl(data, *RooFit::Detail::createCmdList(&cmdArgs...)));
   }
 
   template <typename... CmdArgs_t>
   RooFit::OwningPtr<RooAbsReal> createNLL(RooAbsData& data, CmdArgs_t const&... cmdArgs)
   {
-    return RooFit::Detail::owningPtr(createNLLImpl(data, *RooFit::Detail::createCmdList(&cmdArgs...)));
+    return RooFit::makeOwningPtr(createNLLImpl(data, *RooFit::Detail::createCmdList(&cmdArgs...)));
   }
 
   // Constraint management

--- a/roofit/roofitcore/inc/RooAddition.h
+++ b/roofit/roofitcore/inc/RooAddition.h
@@ -28,16 +28,8 @@ class RooAddition : public RooAbsReal {
 public:
 
   RooAddition() : _cacheMgr(this,10) {}
-  RooAddition(const char *name, const char *title, const RooArgList& sumSet
-#ifndef ROOFIT_MEMORY_SAFE_INTERFACES
-              , bool takeOwnership=false
-#endif
-  );
-  RooAddition(const char *name, const char *title, const RooArgList& sumSet1, const RooArgList& sumSet2
-#ifndef ROOFIT_MEMORY_SAFE_INTERFACES
-              , bool takeOwnership=false
-#endif
-  );
+  RooAddition(const char *name, const char *title, const RooArgList& sumSet);
+  RooAddition(const char *name, const char *title, const RooArgList& sumSet1, const RooArgList& sumSet2);
 
   RooAddition(const RooAddition& other, const char* name = nullptr);
   TObject* clone(const char* newname) const override { return new RooAddition(*this, newname); }

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -59,7 +59,7 @@ public:
 
   /// Return empty clone of this RooDataHist.
   RooFit::OwningPtr<RooAbsData> emptyClone(const char* newName=nullptr, const char* newTitle=nullptr, const RooArgSet*vars=nullptr, const char* /*wgtVarName*/=nullptr) const override {
-    return RooFit::Detail::owningPtr(std::make_unique<RooDataHist>(newName?newName:GetName(),newTitle?newTitle:GetTitle(),vars?*vars:*get()));
+    return RooFit::makeOwningPtr(std::make_unique<RooDataHist>(newName?newName:GetName(),newTitle?newTitle:GetTitle(),vars?*vars:*get()));
   }
 
   /// Add `wgt` to the bin content enclosed by the coordinates passed in `row`.

--- a/roofit/roofitcore/inc/RooFit/Config.h
+++ b/roofit/roofitcore/inc/RooFit/Config.h
@@ -17,14 +17,6 @@
 // memory safe.
 // #define ROOFIT_MEMORY_SAFE_INTERFACES
 
-// The memory safe interfaces mode implies that all RooFit::OwningPtr<T> are
-// std::unique_ptr<T>.
-#ifdef ROOFIT_MEMORY_SAFE_INTERFACES
-#ifndef ROOFIT_OWNING_PTR_IS_UNIQUE_PTR
-#define ROOFIT_OWNING_PTR_IS_UNIQUE_PTR
-#endif
-#endif
-
 #include <memory>
 
 namespace RooFit {
@@ -37,19 +29,17 @@ namespace RooFit {
 /// wraps the result of functions returning a RooFit::OwningPtr<T> in a
 /// std::unique_ptr<T>.
 template <typename T>
-#ifdef ROOFIT_OWNING_PTR_IS_UNIQUE_PTR
+#ifdef ROOFIT_MEMORY_SAFE_INTERFACES
 using OwningPtr = std::unique_ptr<T>;
 #else
 using OwningPtr = T *;
 #endif
 
-namespace Detail {
-
 /// Internal helper to turn a std::unique_ptr<T> into an OwningPtr.
 template <typename T>
-OwningPtr<T> owningPtr(std::unique_ptr<T> &&ptr)
+OwningPtr<T> makeOwningPtr(std::unique_ptr<T> &&ptr)
 {
-#ifdef ROOFIT_OWNING_PTR_IS_UNIQUE_PTR
+#ifdef ROOFIT_MEMORY_SAFE_INTERFACES
    return std::move(ptr);
 #else
    return ptr.release();
@@ -58,16 +48,14 @@ OwningPtr<T> owningPtr(std::unique_ptr<T> &&ptr)
 
 /// internal helper to turn a std::unique_ptr<t> into an owningptr.
 template <typename T, typename U>
-OwningPtr<T> owningPtr(std::unique_ptr<U> &&ptr)
+OwningPtr<T> makeOwningPtr(std::unique_ptr<U> &&ptr)
 {
-#ifdef ROOFIT_OWNING_PTR_IS_UNIQUE_PTR
+#ifdef ROOFIT_MEMORY_SAFE_INTERFACES
    return std::unique_ptr<T>{static_cast<T *>(ptr.release())};
 #else
    return static_cast<T *>(ptr.release());
 #endif
 }
-
-} // namespace Detail
 
 } // namespace RooFit
 

--- a/roofit/roofitcore/inc/RooStringVar.h
+++ b/roofit/roofitcore/inc/RooStringVar.h
@@ -53,9 +53,11 @@ public:
   void printValue(std::ostream& os) const override { os << _string; }
 
 
-  RooFit::OwningPtr<RooAbsArg> createFundamental(const char* newname=nullptr) const override {
-    return RooFit::Detail::owningPtr(std::make_unique<RooStringVar>(newname ? newname : GetName(), GetTitle(), "", 1));
-  }
+   RooFit::OwningPtr<RooAbsArg> createFundamental(const char *newname = nullptr) const override
+   {
+      return RooFit::makeOwningPtr<RooAbsArg>(
+         std::make_unique<RooStringVar>(newname ? newname : GetName(), GetTitle(), "", 1));
+   }
 
 protected:
   // Internal consistency checking (needed by RooDataSet)

--- a/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
@@ -630,7 +630,7 @@ RooFit::OwningPtr<RooArgSet> RooAbsAnaConvPdf::coefVars(Int_t /*coefIdx*/) const
 
   cVars->remove(tmp.begin(), tmp.end(), true, true);
 
-  return RooFit::Detail::owningPtr(std::move(cVars));
+  return RooFit::makeOwningPtr(std::move(cVars));
 }
 
 

--- a/roofit/roofitcore/src/RooAbsCategory.cxx
+++ b/roofit/roofitcore/src/RooAbsCategory.cxx
@@ -643,7 +643,7 @@ RooFit::OwningPtr<RooAbsArg> RooAbsCategory::createFundamental(const char* newna
     fund->defineStateUnchecked(type.first, type.second);
   }
 
-  return RooFit::Detail::owningPtr<RooAbsArg>(std::move(fund));
+  return RooFit::makeOwningPtr<RooAbsArg>(std::move(fund));
 }
 
 

--- a/roofit/roofitcore/src/RooAbsData.cxx
+++ b/roofit/roofitcore/src/RooAbsData.cxx
@@ -460,7 +460,7 @@ RooFit::OwningPtr<RooAbsData> RooAbsData::reduce(const RooCmdArg& arg1,const Roo
   if (title) ret->SetTitle(title) ;
 
   ret->copyGlobalObservables(*this);
-  return RooFit::Detail::owningPtr(std::move(ret));
+  return RooFit::makeOwningPtr(std::move(ret));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -474,7 +474,7 @@ RooFit::OwningPtr<RooAbsData> RooAbsData::reduce(const char* cut)
   RooFormulaVar cutVar(cut,cut,*get()) ;
   auto ret = reduceEng(*get(),&cutVar,nullptr,0,std::numeric_limits<std::size_t>::max()) ;
   ret->copyGlobalObservables(*this);
-  return RooFit::Detail::owningPtr(std::move(ret));
+  return RooFit::makeOwningPtr(std::move(ret));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -486,7 +486,7 @@ RooFit::OwningPtr<RooAbsData> RooAbsData::reduce(const RooFormulaVar& cutVar)
 {
   auto ret = reduceEng(*get(),&cutVar,nullptr,0,std::numeric_limits<std::size_t>::max()) ;
   ret->copyGlobalObservables(*this);
-  return RooFit::Detail::owningPtr(std::move(ret));
+  return RooFit::makeOwningPtr(std::move(ret));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -517,7 +517,7 @@ RooFit::OwningPtr<RooAbsData> RooAbsData::reduce(const RooArgSet& varSubset, con
     ret = reduceEng(varSubset2,nullptr,nullptr,0,std::numeric_limits<std::size_t>::max());
   }
   ret->copyGlobalObservables(*this);
-  return RooFit::Detail::owningPtr(std::move(ret));
+  return RooFit::makeOwningPtr(std::move(ret));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -541,7 +541,7 @@ RooFit::OwningPtr<RooAbsData> RooAbsData::reduce(const RooArgSet& varSubset, con
 
   auto ret = reduceEng(varSubset2,&cutVar,nullptr,0,std::numeric_limits<std::size_t>::max()) ;
   ret->copyGlobalObservables(*this);
-  return RooFit::Detail::owningPtr(std::move(ret));
+  return RooFit::makeOwningPtr(std::move(ret));
 }
 
 
@@ -1050,7 +1050,7 @@ RooFit::OwningPtr<TMatrixDSym> RooAbsData::corrcovMatrix(const RooArgList& vars,
     }
   }
 
-  return RooFit::Detail::owningPtr(std::move(C));
+  return RooFit::makeOwningPtr(std::move(C));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1523,7 +1523,7 @@ RooFit::OwningPtr<TList> splitImpl(RooAbsData const &data, const RooAbsCategory 
       }
    }
 
-   return RooFit::Detail::owningPtr(std::move(dsetList));
+   return RooFit::makeOwningPtr(std::move(dsetList));
 }
 
 } // namespace

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1707,7 +1707,7 @@ RooFit::OwningPtr<RooDataSet> RooAbsPdf::generate(const RooArgSet& whatVars, con
     data->SetName(dsetName) ;
   }
 
-  return RooFit::Detail::owningPtr(std::move(data));
+  return RooFit::makeOwningPtr(std::move(data));
 }
 
 
@@ -1782,7 +1782,7 @@ RooFit::OwningPtr<RooDataSet> RooAbsPdf::generate(RooAbsPdf::GenSpec& spec) cons
   std::unique_ptr<RooDataSet> ret{generate(*spec._genContext,spec._whatVars,spec._protoData, nEvt,false,spec._randProto,spec._resampleProto,
               spec._init,spec._extended)};
   spec._init = true ;
-  return RooFit::Detail::owningPtr(std::move(ret));
+  return RooFit::makeOwningPtr(std::move(ret));
 }
 
 
@@ -1811,7 +1811,7 @@ RooFit::OwningPtr<RooDataSet> RooAbsPdf::generate(RooAbsPdf::GenSpec& spec) cons
 RooFit::OwningPtr<RooDataSet> RooAbsPdf::generate(const RooArgSet &whatVars, double nEvents, bool verbose, bool autoBinned, const char* binnedTag, bool expectedData, bool extended) const
 {
   if (nEvents==0 && extendMode()==CanNotBeExtended) {
-    return RooFit::Detail::owningPtr(std::make_unique<RooDataSet>("emptyData","emptyData",whatVars));
+    return RooFit::makeOwningPtr(std::make_unique<RooDataSet>("emptyData","emptyData",whatVars));
   }
 
   // Request for binned generation
@@ -1827,7 +1827,7 @@ RooFit::OwningPtr<RooDataSet> RooAbsPdf::generate(const RooArgSet &whatVars, dou
   else {
     coutE(Generation)  << "RooAbsPdf::generate(" << GetName() << ") cannot create a valid context" << endl;
   }
-  return RooFit::Detail::owningPtr(std::move(generated));
+  return RooFit::makeOwningPtr(std::move(generated));
 }
 
 
@@ -1897,7 +1897,7 @@ RooFit::OwningPtr<RooDataSet> RooAbsPdf::generate(const RooArgSet &whatVars, con
 {
   std::unique_ptr<RooAbsGenContext> context{genContext(whatVars,&prototype,nullptr,verbose)};
   if (context) {
-    return RooFit::Detail::owningPtr(generate(*context,whatVars,&prototype,nEvents,verbose,randProtoOrder,resampleProto));
+    return RooFit::makeOwningPtr(generate(*context,whatVars,&prototype,nEvents,verbose,randProtoOrder,resampleProto));
   }
   coutE(Generation) << "RooAbsPdf::generate(" << GetName() << ") ERROR creating generator context" << endl ;
   return nullptr;
@@ -2214,7 +2214,7 @@ RooFit::OwningPtr<RooDataHist> RooAbsPdf::generateBinned(const RooArgSet &whatVa
 
   }
 
-  return RooFit::Detail::owningPtr(std::move(hist));
+  return RooFit::makeOwningPtr(std::move(hist));
 }
 
 
@@ -2990,7 +2990,7 @@ RooFit::OwningPtr<RooAbsReal> RooAbsPdf::createScanCdf(const RooArgSet& iset, co
   ivar->setBins(numScanBins,"numcdf") ;
   auto ret = std::make_unique<RooNumCdf>(name.c_str(),name.c_str(),*this,*ivar,"numcdf");
   ret->setInterpolationOrder(intOrder) ;
-  return RooFit::Detail::owningPtr(std::move(ret));
+  return RooFit::makeOwningPtr<RooAbsReal>(std::move(ret));
 }
 
 

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -490,7 +490,7 @@ RooFit::OwningPtr<RooAbsReal> RooAbsReal::createProfile(const RooArgSet& paramsO
 
   // Create and return profile object
   auto out = std::make_unique<RooProfileLL>(name.c_str(),(std::string("Profile of ") + GetTitle()).c_str(),*this,paramsOfInterest);
-  return RooFit::Detail::owningPtr(std::move(out));
+  return RooFit::makeOwningPtr<RooAbsReal>(std::move(out));
 }
 
 
@@ -585,7 +585,7 @@ RooFit::OwningPtr<RooAbsReal> RooAbsReal::createIntegral(const RooArgSet& iset, 
 
   auto out = std::make_unique<RooAddition>(fullName.c_str(), title.c_str(), components);
   out->addOwnedComponents(std::move(components));
-  return RooFit::Detail::owningPtr<RooAbsReal>(std::move(out));
+  return RooFit::makeOwningPtr<RooAbsReal>(std::move(out));
 }
 
 
@@ -612,7 +612,7 @@ RooFit::OwningPtr<RooAbsReal> RooAbsReal::createIntObj(const RooArgSet& iset2, c
     const std::string name = std::string(GetName()) + integralNameSuffix(iset,nset,rangeName).Data();
 
     auto out = std::make_unique<RooRealIntegral>(name.c_str(), title.c_str(), *this, iset, nset, cfg, rangeName);
-    return RooFit::Detail::owningPtr<RooAbsReal>(std::move(out));
+    return RooFit::makeOwningPtr<RooAbsReal>(std::move(out));
   }
 
   // Process integration over remaining integration variables
@@ -686,11 +686,11 @@ RooFit::OwningPtr<RooAbsReal> RooAbsReal::createIntObj(const RooArgSet& iset2, c
    cachedIntegral->setOperMode(ADirty) ;
       }
       //cachedIntegral->disableCache(true) ;
-      return RooFit::Detail::owningPtr<RooAbsReal>(std::move(cachedIntegral));
+      return RooFit::makeOwningPtr<RooAbsReal>(std::move(cachedIntegral));
     }
   }
 
-  return RooFit::Detail::owningPtr(std::move(integral));
+  return RooFit::makeOwningPtr(std::move(integral));
 }
 
 
@@ -3076,7 +3076,7 @@ RooFit::OwningPtr<RooAbsFunc> RooAbsReal::bindVars(const RooArgSet &vars, const 
     coutE(InputArguments) << ClassName() << "::" << GetName() << ":bindVars: cannot bind to " << vars << std::endl ;
     return nullptr;
   }
-  return RooFit::Detail::owningPtr(std::unique_ptr<RooAbsFunc>{std::move(binding)});
+  return RooFit::makeOwningPtr(std::unique_ptr<RooAbsFunc>{std::move(binding)});
 }
 
 
@@ -3222,7 +3222,7 @@ RooFit::OwningPtr<RooAbsArg> RooAbsReal::createFundamental(const char* newname) 
   fund->removeRange();
   fund->setPlotLabel(getPlotLabel());
   fund->setAttribute("fundamentalCopy");
-  return RooFit::Detail::owningPtr<RooAbsArg>(std::move(fund));
+  return RooFit::makeOwningPtr<RooAbsArg>(std::move(fund));
 }
 
 
@@ -3897,7 +3897,7 @@ RooFit::OwningPtr<RooAbsReal> RooAbsReal::createScanRI(const RooArgSet& iset, co
   ivar->setBins(numScanBins,"numcdf") ;
   auto ret = std::make_unique<RooNumRunningInt>(name.c_str(),name.c_str(),*this,*ivar,"numrunint") ;
   ret->setInterpolationOrder(intOrder) ;
-  return RooFit::Detail::owningPtr(std::move(ret));
+  return RooFit::makeOwningPtr<RooAbsReal>(std::move(ret));
 }
 
 
@@ -3959,7 +3959,7 @@ RooFit::OwningPtr<RooAbsReal> RooAbsReal::createIntRI(const RooArgSet& iset, con
   cdf->addOwnedComponents(cloneList) ;
   cdf->addOwnedComponents(loList) ;
 
-  return RooFit::Detail::owningPtr(std::move(cdf));
+  return RooFit::makeOwningPtr(std::move(cdf));
 }
 
 
@@ -4228,7 +4228,7 @@ RooFit::OwningPtr<RooFitResult> RooAbsReal::chi2FitTo(RooDataHist &data, const R
    }
 
    std::unique_ptr<RooAbsReal> chi2{createChi2(data, chi2CmdList)};
-   return RooFit::Detail::owningPtr(RooFit::FitHelpers::minimize(*this, *chi2, data, pc));
+   return RooFit::makeOwningPtr(RooFit::FitHelpers::minimize(*this, *chi2, data, pc));
 }
 
 
@@ -4262,7 +4262,7 @@ RooFit::OwningPtr<RooAbsReal> RooAbsReal::createChi2(RooDataHist &data, const Ro
                                             arg5, arg6, arg7, arg8);
    RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::PrintErrors);
 
-   return RooFit::Detail::owningPtr(std::move(chi2));
+   return RooFit::makeOwningPtr<RooAbsReal>(std::move(chi2));
 #else
    throw std::runtime_error("createChi2() is not supported without the legacy evaluation backend");
    return nullptr;
@@ -4365,7 +4365,7 @@ RooFit::OwningPtr<RooFitResult> RooAbsReal::chi2FitTo(RooDataSet &xydata, const 
    }
 
    std::unique_ptr<RooAbsReal> xychi2{createChi2(xydata, chi2CmdList)};
-   return RooFit::Detail::owningPtr(RooFit::FitHelpers::minimize(*this, *xychi2, xydata, pc));
+   return RooFit::makeOwningPtr(RooFit::FitHelpers::minimize(*this, *xychi2, xydata, pc));
 }
 
 
@@ -4445,7 +4445,7 @@ RooFit::OwningPtr<RooAbsReal> RooAbsReal::createChi2(RooDataSet &data, const Roo
 
    std::string name = "chi2_" + std::string(GetName()) + "_" + data.GetName();
 
-   return RooFit::Detail::owningPtr(
+   return RooFit::makeOwningPtr<RooAbsReal>(
       std::make_unique<RooXYChi2Var>(name.c_str(), name.c_str(), *this, data, yvar, integrate, cfg));
 #else
    throw std::runtime_error("createChi2() is not supported without the legacy evaluation backend");

--- a/roofit/roofitcore/src/RooAddition.cxx
+++ b/roofit/roofitcore/src/RooAddition.cxx
@@ -55,21 +55,10 @@ ClassImp(RooAddition);
 /// \param[in] sumSet The value of the function will be the sum of the values in this set
 /// \param[in] takeOwnership If true, the RooAddition object will take ownership of the arguments in `sumSet`
 
-RooAddition::RooAddition(const char* name, const char* title, const RooArgList& sumSet
-#ifndef ROOFIT_MEMORY_SAFE_INTERFACES
-                         , bool takeOwnership
-#endif
-  )
-  : RooAbsReal(name, title)
-  , _set("!set","set of components",this)
-  , _cacheMgr(this,10)
+RooAddition::RooAddition(const char *name, const char *title, const RooArgList &sumSet)
+   : RooAbsReal(name, title), _set("!set", "set of components", this), _cacheMgr(this, 10)
 {
   _set.addTyped<RooAbsReal>(sumSet);
-#ifndef ROOFIT_MEMORY_SAFE_INTERFACES
-  for (RooAbsArg *comp : sumSet) {
-    if (takeOwnership) _ownedList.addOwned(std::unique_ptr<RooAbsArg>{comp});
-  }
-#endif
 }
 
 
@@ -88,14 +77,8 @@ RooAddition::RooAddition(const char* name, const char* title, const RooArgList& 
 /// \param[in] sumSet2 Right-hand element of the pair-wise products
 /// \param[in] takeOwnership If true, the RooAddition object will take ownership of the arguments in the `sumSets`
 ///
-RooAddition::RooAddition(const char* name, const char* title, const RooArgList& sumSet1, const RooArgList& sumSet2
-#ifndef ROOFIT_MEMORY_SAFE_INTERFACES
-                         , bool takeOwnership
-#endif
-  )
-    : RooAbsReal(name, title)
-    , _set("!set","set of components",this)
-    , _cacheMgr(this,10)
+RooAddition::RooAddition(const char *name, const char *title, const RooArgList &sumSet1, const RooArgList &sumSet2)
+   : RooAbsReal(name, title), _set("!set", "set of components", this), _cacheMgr(this, 10)
 {
   if (sumSet1.size() != sumSet2.size()) {
     coutE(InputArguments) << "RooAddition::ctor(" << GetName() << ") ERROR: input lists should be of equal length" << std::endl;
@@ -126,12 +109,6 @@ RooAddition::RooAddition(const char* name, const char* title, const RooArgList& 
     auto prod = std::make_unique<RooProduct>( _name, _name , RooArgSet(*comp1, *comp2));
     _set.add(*prod);
     _ownedList.addOwned(std::move(prod));
-#ifndef ROOFIT_MEMORY_SAFE_INTERFACES
-    if (takeOwnership) {
-        _ownedList.addOwned(std::unique_ptr<RooAbsArg>{comp1});
-        _ownedList.addOwned(std::unique_ptr<RooAbsArg>{comp2});
-    }
-#endif
   }
 }
 

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -779,7 +779,8 @@ RooFit::OwningPtr<RooAbsData> RooDataSet::emptyClone(const char* newName, const 
    }
 
    using namespace RooFit;
-   return RooFit::Detail::owningPtr(std::make_unique<RooDataSet>(newName, newTitle, vars2, WeightVar(wgtVarName), StoreError(errorSet), StoreAsymError(asymErrorSet)));
+   return RooFit::makeOwningPtr<RooAbsData>(std::make_unique<RooDataSet>(
+      newName, newTitle, vars2, WeightVar(wgtVarName), StoreError(errorSet), StoreAsymError(asymErrorSet)));
 }
 
 
@@ -882,7 +883,7 @@ RooFit::OwningPtr<RooDataHist> RooDataSet::binnedClone(const char* newName, cons
     title = std::string(GetTitle()) + "_binned" ;
   }
 
-  return RooFit::Detail::owningPtr(std::make_unique<RooDataHist>(name,title,*get(),*this));
+  return RooFit::makeOwningPtr(std::make_unique<RooDataHist>(name,title,*get(),*this));
 }
 
 

--- a/roofit/roofitcore/src/RooFFTConvPdf.cxx
+++ b/roofit/roofitcore/src/RooFFTConvPdf.cxx
@@ -750,7 +750,7 @@ RooFit::OwningPtr<RooArgSet> RooFFTConvPdf::actualParameters(const RooArgSet& ns
   std::unique_ptr<RooArgSet> vars{getVariables()};
   vars->remove(*std::unique_ptr<RooArgSet>{actualObservables(nset)});
 
-  return RooFit::Detail::owningPtr(std::move(vars));
+  return RooFit::makeOwningPtr(std::move(vars));
 }
 
 

--- a/roofit/roofitcore/src/RooMCStudy.cxx
+++ b/roofit/roofitcore/src/RooMCStudy.cxx
@@ -640,7 +640,7 @@ RooFit::OwningPtr<RooFitResult> RooMCStudy::refit(RooAbsData* genSample)
     fr = std::unique_ptr<RooFitResult>{doFit(genSample)};
   }
 
-  return RooFit::Detail::owningPtr(std::move(fr));
+  return RooFit::makeOwningPtr(std::move(fr));
 }
 
 

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -641,7 +641,7 @@ RooFit::OwningPtr<RooFitResult> RooMinimizer::save(const char *userName, const c
 
    fitRes->setStatusHistory(_statusHistory);
 
-   return RooFit::Detail::owningPtr(std::move(fitRes));
+   return RooFit::makeOwningPtr(std::move(fitRes));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -911,7 +911,7 @@ RooFit::OwningPtr<RooFitResult> RooMinimizer::lastMinuitFit(const RooArgList &va
    }
    res->fillCorrMatrix(globalCC, corrs, covs);
 
-   return RooFit::Detail::owningPtr(std::move(res));
+   return RooFit::makeOwningPtr(std::move(res));
 }
 
 /// Try to recover from invalid function values. When invalid function values

--- a/roofit/roofitcore/src/RooSimultaneous.cxx
+++ b/roofit/roofitcore/src/RooSimultaneous.cxx
@@ -1065,7 +1065,7 @@ RooFit::OwningPtr<RooDataSet> RooSimultaneous::generateSimGlobal(const RooArgSet
     data->add(globClone) ;
   }
 
-  return RooFit::Detail::owningPtr(std::move(data));
+  return RooFit::makeOwningPtr(std::move(data));
 }
 
 

--- a/roofit/roostats/src/MarkovChain.cxx
+++ b/roofit/roostats/src/MarkovChain.cxx
@@ -138,7 +138,7 @@ RooFit::OwningPtr<RooDataSet> MarkovChain::GetAsDataSet(RooArgSet* whichVars) co
       args.add(*whichVars);
    }
 
-   return RooFit::Detail::owningPtr<RooDataSet>(std::unique_ptr<RooAbsData>{fChain->reduce(args)});
+   return RooFit::makeOwningPtr<RooDataSet>(std::unique_ptr<RooAbsData>{fChain->reduce(args)});
 }
 
 RooFit::OwningPtr<RooDataSet> MarkovChain::GetAsDataSet(const RooCmdArg &arg1, const RooCmdArg &arg2,
@@ -146,7 +146,7 @@ RooFit::OwningPtr<RooDataSet> MarkovChain::GetAsDataSet(const RooCmdArg &arg1, c
                                                         const RooCmdArg &arg5, const RooCmdArg &arg6,
                                                         const RooCmdArg &arg7, const RooCmdArg &arg8) const
 {
-   return RooFit::Detail::owningPtr<RooDataSet>(
+   return RooFit::makeOwningPtr<RooDataSet>(
       std::unique_ptr<RooAbsData>{fChain->reduce(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)});
 }
 
@@ -162,7 +162,7 @@ RooFit::OwningPtr<RooDataHist> MarkovChain::GetAsDataHist(RooArgSet* whichVars) 
    }
 
    std::unique_ptr<RooAbsData> data{fChain->reduce(args)};
-   return RooFit::Detail::owningPtr(std::unique_ptr<RooDataHist>{static_cast<RooDataSet&>(*data).binnedClone()});
+   return RooFit::makeOwningPtr(std::unique_ptr<RooDataHist>{static_cast<RooDataSet&>(*data).binnedClone()});
 }
 
 RooFit::OwningPtr<RooDataHist> MarkovChain::GetAsDataHist(const RooCmdArg &arg1, const RooCmdArg &arg2,
@@ -171,7 +171,7 @@ RooFit::OwningPtr<RooDataHist> MarkovChain::GetAsDataHist(const RooCmdArg &arg1,
                                                           const RooCmdArg &arg7, const RooCmdArg &arg8) const
 {
    std::unique_ptr<RooAbsData> data{fChain->reduce(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)};
-   return RooFit::Detail::owningPtr(std::unique_ptr<RooDataHist>{static_cast<RooDataSet &>(*data).binnedClone()});
+   return RooFit::makeOwningPtr(std::unique_ptr<RooDataHist>{static_cast<RooDataSet &>(*data).binnedClone()});
 }
 
 THnSparse* MarkovChain::GetAsSparseHist(RooAbsCollection* whichVars) const

--- a/roofit/roostats/src/ProfileLikelihoodCalculator.cxx
+++ b/roofit/roostats/src/ProfileLikelihoodCalculator.cxx
@@ -135,7 +135,7 @@ RooFit::OwningPtr<RooAbsReal>  ProfileLikelihoodCalculator::DoGlobalFit() const 
 
    // check if global fit has been already done
    if (fFitResult && fGlobalFitDone) {
-      return RooFit::Detail::owningPtr(std::move(nll));
+      return RooFit::makeOwningPtr(std::move(nll));
    }
 
       // calculate MLE
@@ -154,7 +154,7 @@ RooFit::OwningPtr<RooAbsReal>  ProfileLikelihoodCalculator::DoGlobalFit() const 
       }
    }
 
-   return RooFit::Detail::owningPtr(std::move(nll));
+   return RooFit::makeOwningPtr(std::move(nll));
 }
 
 RooFit::OwningPtr<RooFitResult> ProfileLikelihoodCalculator::DoMinimizeNLL(RooAbsReal * nll)  {


### PR DESCRIPTION
  * The `ROOFIT_MEMORY_SAFE_INTERFACES` macro is explained in the release notes, so that users and framework developers can use it to detect memory leaks

  * Since people are now encouraged to use it, the `RooFit::Detail::owningPtr` helper function was renamed to `RooFit::makeOwningPtr`, because this is now not an implementation detail anymore but part of the user interface

  * Remove `takeOwnership` constructor arguments from `PiecewiseInterpolation` and `RooAddition`, because there are not memory-safe and it's not easily possible to only exclude selected parameters behind the `ROOFIT_MEMORY_SAFE_INTERFACES` macro without also changing the sources. Like this, we ensure that the memory-safe interfaces can be used without re-building ROOT.