### PR TITLE
[RF] Deprecate old test statistics headers

### DIFF
--- a/README/ReleaseNotes/v632/index.md
+++ b/README/ReleaseNotes/v632/index.md
@@ -164,6 +164,18 @@ They should be replaced with the suitable STL-compatible interfaces, or you can 
 
 - `RooWorkspace::componentIterator()`: use `RooWorkspace::components()` with range-based loop
 
+### Deprecation of legacy test statistics classes in public interface
+
+Instantiating the following classes and even including their header files is deprecated, and the headers will be removed in ROOT 6.34:
+
+* RooAbsTestStatistic
+* RooAbsOptTestStatistic
+* RooNLLVar
+* RooChi2Var
+* RooXYChi2Var
+
+Please use the higher-level functions `RooAbsPdf::createNLL()` and `RooAbsPdf::createChi2()` if you want to create objects that represent test statistics.
+
 ## 2D Graphics Libraries
 
 

--- a/build/unix/makepchinput.py
+++ b/build/unix/makepchinput.py
@@ -457,6 +457,11 @@ def makePCHInput():
    allHeadersContent = getSTLIncludes()
    allHeadersContent += getExtraIncludes(clingetpchList)
 
+   # Make sure we don't get warnings from the old RooFit test statistics
+   # headers that are deprecated. This line can be removed once the deprecaded
+   # headers are gone (ROOT 6.32.00):
+   allHeadersContent += "#define ROOFIT_BUILDS_ITSELF\n"
+
    allLinkdefsContent = ""
 
    # Loop over the dictionaries, ROOT modules

--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -498,6 +498,10 @@ if(fftw3)
   target_compile_definitions(RooFitCore PUBLIC ROOFIT_MATH_FFTW3)
 endif()
 
+# To avoid deprecation warnings when including old test statistics headers.
+# RooFit has to include them to build the documentation.
+target_compile_definitions(RooFitCore PUBLIC ROOFIT_BUILDS_ITSELF)
+
 target_include_directories(RooFitCore INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/res>)
 
 # For recent clang, this can facilitate auto-vectorisation.

--- a/roofit/roofitcore/inc/RooAbsOptTestStatistic.h
+++ b/roofit/roofitcore/inc/RooAbsOptTestStatistic.h
@@ -16,6 +16,31 @@
 #ifndef ROO_ABS_OPT_TEST_STATISTIC
 #define ROO_ABS_OPT_TEST_STATISTIC
 
+// We can't print deprecation warnings when including headers in cling, because
+// this will be done automatically anyway.
+#ifdef __CLING__
+#ifndef ROOFIT_BUILDS_ITSELF
+// These warnings should only be suppressed when building ROOT itself!
+#warning "Including RooAbsOptTestStatistic.h is deprecated, and this header will be removed in ROOT v6.34: it is an implementation detail that should not be part of the public user interface"
+#else
+// If we are builting RooFit itself, this will serve as a reminder to actually
+// remove this deprecate public header. Here is now this needs to be done:
+//    1. Move this header file from inc/ to src/
+//    2. Remove the LinkDef entry, ClassDefOverride, and ClassImpl macros for
+//       this class
+//    3. If there are are tests using this class in the test/ directory, change
+//       the include to use a relative path the moved header file in the src/
+//       directory, e.g. #include <RemovedInterface.h> becomes #include
+//       "../src/RemovedInterface.h"
+//    4. Remove this ifndef-else-endif block from the header
+//    5. Remove the deprecation warning at the end of the class declaration
+#include <RVersion.h>
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 34, 00)
+#error "Please remove this deprecated public interface."
+#endif
+#endif
+#endif
+
 #include "RooAbsTestStatistic.h"
 #include "RooSetProxy.h"
 #include "RooCategoryProxy.h"
@@ -93,6 +118,10 @@ protected:
   double      _integrateBinsPrecision{-1.}; // Precision for finer sampling of bins.
 
   ClassDefOverride(RooAbsOptTestStatistic,0) // Abstract base class for optimized test statistics
+#ifndef ROOFIT_BUILDS_ITSELF
+} R__DEPRECATED(6,34, "RooAbsOptTestStatistic is a RooFit implementation detail that should not be instantiated in user code.");
+#else
 };
+#endif
 
 #endif

--- a/roofit/roofitcore/inc/RooAbsTestStatistic.h
+++ b/roofit/roofitcore/inc/RooAbsTestStatistic.h
@@ -16,6 +16,31 @@
 #ifndef ROO_ABS_TEST_STATISTIC
 #define ROO_ABS_TEST_STATISTIC
 
+// We can't print deprecation warnings when including headers in cling, because
+// this will be done automatically anyway.
+#ifdef __CLING__
+#ifndef ROOFIT_BUILDS_ITSELF
+// These warnings should only be suppressed when building ROOT itself!
+#warning "Including RooAbsTestStatistic.h is deprecated, and this header will be removed in ROOT v6.34: it is an implementation detail that should not be part of the public user interface"
+#else
+// If we are builting RooFit itself, this will serve as a reminder to actually
+// remove this deprecate public header. Here is now this needs to be done:
+//    1. Move this header file from inc/ to src/
+//    2. Remove the LinkDef entry, ClassDefOverride, and ClassImpl macros for
+//       this class
+//    3. If there are are tests using this class in the test/ directory, change
+//       the include to use a relative path the moved header file in the src/
+//       directory, e.g. #include <RemovedInterface.h> becomes #include
+//       "../src/RemovedInterface.h"
+//    4. Remove this ifndef-else-endif block from the header
+//    5. Remove the deprecation warning at the end of the class declaration
+#include <RVersion.h>
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 34, 00)
+#error "Please remove this deprecated public interface."
+#endif
+#endif
+#endif
+
 #include "RooAbsReal.h"
 #include "RooSetProxy.h"
 #include "RooRealProxy.h"
@@ -162,6 +187,10 @@ protected:
 
   ClassDefOverride(RooAbsTestStatistic,0) // Abstract base class for real-valued test statistics
 
+#ifndef ROOFIT_BUILDS_ITSELF
+} R__DEPRECATED(6,34, "RooAbsTestStatistic is a RooFit implementation detail that should not be instantiated in user code.");
+#else
 };
+#endif
 
 #endif

--- a/roofit/roofitcore/inc/RooChi2Var.h
+++ b/roofit/roofitcore/inc/RooChi2Var.h
@@ -17,6 +17,31 @@
 #ifndef ROO_CHI2_VAR
 #define ROO_CHI2_VAR
 
+// We can't print deprecation warnings when including headers in cling, because
+// this will be done automatically anyway.
+#ifdef __CLING__
+#ifndef ROOFIT_BUILDS_ITSELF
+// These warnings should only be suppressed when building ROOT itself!
+#warning "Including RooChi2Var.h is deprecated, and this header will be removed in ROOT v6.34: Please use RooAbsReal::createChi2() to create chi-square test statistics objects"
+#else
+// If we are builting RooFit itself, this will serve as a reminder to actually
+// remove this deprecate public header. Here is now this needs to be done:
+//    1. Move this header file from inc/ to src/
+//    2. Remove the LinkDef entry, ClassDefOverride, and ClassImpl macros for
+//       this class
+//    3. If there are are tests using this class in the test/ directory, change
+//       the include to use a relative path the moved header file in the src/
+//       directory, e.g. #include <RemovedInterface.h> becomes #include
+//       "../src/RemovedInterface.h"
+//    4. Remove this ifndef-else-endif block from the header
+//    5. Remove the deprecation warning at the end of the class declaration
+#include <RVersion.h>
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 34, 00)
+#error "Please remove this deprecated public interface."
+#endif
+#endif
+#endif
+
 #include "RooAbsOptTestStatistic.h"
 #include "RooCmdArg.h"
 #include "RooDataHist.h"
@@ -65,7 +90,12 @@ protected:
   FuncMode _funcMode ;                ///< Function, P.d.f. or extended p.d.f?
 
   ClassDefOverride(RooChi2Var,0) // Chi^2 function of p.d.f w.r.t a binned dataset
+
+#ifndef ROOFIT_BUILDS_ITSELF
+} R__DEPRECATED(6,34, "Please use RooAbsReal::createChi2() to create chi-square test statistics objects.");
+#else
 };
+#endif
 
 
 #endif

--- a/roofit/roofitcore/inc/RooNLLVar.h
+++ b/roofit/roofitcore/inc/RooNLLVar.h
@@ -16,6 +16,31 @@
 #ifndef ROO_NLL_VAR
 #define ROO_NLL_VAR
 
+// We can't print deprecation warnings when including headers in cling, because
+// this will be done automatically anyway.
+#ifdef __CLING__
+#ifndef ROOFIT_BUILDS_ITSELF
+// These warnings should only be suppressed when building ROOT itself!
+#warning "Including RooNLLVar.h is deprecated, and this header will be removed in ROOT v6.34: please use RooAbsPdf::createNLL() to create likelihood objects"
+#else
+// If we are builting RooFit itself, this will serve as a reminder to actually
+// remove this deprecate public header. Here is now this needs to be done:
+//    1. Move this header file from inc/ to src/
+//    2. Remove the LinkDef entry, ClassDefOverride, and ClassImpl macros for
+//       this class
+//    3. If there are are tests using this class in the test/ directory, change
+//       the include to use a relative path the moved header file in the src/
+//       directory, e.g. #include <RemovedInterface.h> becomes #include
+//       "../src/RemovedInterface.h"
+//    4. Remove this ifndef-else-endif block from the header
+//    5. Remove the deprecation warning at the end of the class declaration
+#include <RVersion.h>
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 34, 00)
+#error "Please remove this deprecated public interface."
+#endif
+#endif
+#endif
+
 #include "RooAbsOptTestStatistic.h"
 #include "RooCmdArg.h"
 #include "RooAbsPdf.h"
@@ -82,7 +107,12 @@ private:
   std::unique_ptr<RooAbsPdf> _offsetPdf; ///<! An optional per-bin likelihood offset
 
   ClassDefOverride(RooNLLVar,0) // Function representing (extended) -log(L) of p.d.f and dataset
+
+#ifndef ROOFIT_BUILDS_ITSELF
+} R__DEPRECATED(6,34, "Please use RooAbsPdf::createNLL() to create likelihood objects");
+#else
 };
+#endif
 
 #endif
 

--- a/roofit/roofitcore/inc/RooXYChi2Var.h
+++ b/roofit/roofitcore/inc/RooXYChi2Var.h
@@ -17,6 +17,31 @@
 #ifndef ROO_XY_CHI2_VAR
 #define ROO_XY_CHI2_VAR
 
+// We can't print deprecation warnings when including headers in cling, because
+// this will be done automatically anyway.
+#ifdef __CLING__
+#ifndef ROOFIT_BUILDS_ITSELF
+// These warnings should only be suppressed when building ROOT itself!
+#warning "Including RooXYChi2Var.h is deprecated, and this header will be removed in ROOT v6.34: please use RooAbsReal::createChi2(RooAbsData &, ...) to create chi-square test statistics objects on X-Y data"
+#else
+// If we are builting RooFit itself, this will serve as a reminder to actually
+// remove this deprecate public header. Here is now this needs to be done:
+//    1. Move this header file from inc/ to src/
+//    2. Remove the LinkDef entry, ClassDefOverride, and ClassImpl macros for
+//       this class
+//    3. If there are are tests using this class in the test/ directory, change
+//       the include to use a relative path the moved header file in the src/
+//       directory, e.g. #include <RemovedInterface.h> becomes #include
+//       "../src/RemovedInterface.h"
+//    4. Remove this ifndef-else-endif block from the header
+//    5. Remove the deprecation warning at the end of the class declaration
+#include <RVersion.h>
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 34, 00)
+#error "Please remove this deprecated public interface."
+#endif
+#endif
+#endif
+
 #include "RooAbsOptTestStatistic.h"
 #include "RooCmdArg.h"
 #include "RooDataSet.h"
@@ -86,7 +111,12 @@ protected:
   std::list<RooAbsBinning*> _binList ; ///<! Bin ranges
 
   ClassDefOverride(RooXYChi2Var,0) // Chi^2 function of p.d.f w.r.t a unbinned dataset with X and Y values
+
+#ifndef ROOFIT_BUILDS_ITSELF
+} R__DEPRECATED(6,34, "Please use RooAbsReal::createChi2(RooAbsData &, ...) to create chi-square test statistics objects on X-Y data");
+#else
 };
+#endif
 
 
 #endif


### PR DESCRIPTION
The old test statistic headers and classes should not be used anymore,
since the test statistics should be created with the higher-level
functions `createNLL()` and `createChi2()`. This allows us more
flexibility in the implementation, and to phase out the old test
statistics classes eventually.

