### PR TITLE
[ntuple] Fix the way `RPairField` determines member offsets

### DIFF
--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -2948,8 +2948,16 @@ ROOT::Experimental::RPairField::RPairField(std::string_view fieldName,
    if (!fClass)
       throw RException(R__FAIL("cannot get type information for " + GetType()));
    fSize = fClass->Size();
-   fOffsets[0] = fClass->GetDataMember("first")->GetOffset();
-   fOffsets[1] = fClass->GetDataMember("second")->GetOffset();
+
+   auto firstElem = fClass->GetRealData("first");
+   if (!firstElem)
+      throw RException(R__FAIL("first: no such member"));
+   fOffsets[0] = firstElem->GetThisOffset();
+
+   auto secondElem = fClass->GetRealData("second");
+   if (!secondElem)
+      throw RException(R__FAIL("second: no such member"));
+   fOffsets[1] = secondElem->GetThisOffset();
 }
 
 std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>

--- a/tree/ntuple/v7/test/ProxiedSTLContainerLinkDef.h
+++ b/tree/ntuple/v7/test/ProxiedSTLContainerLinkDef.h
@@ -31,13 +31,4 @@
 #pragma link C++ class std::unordered_map<int, CustomStruct>+;
 #pragma link C++ class std::unordered_map<float, std::vector<bool>>+;
 
-#pragma link C++ class std::pair<char, long>+;
-#pragma link C++ class std::pair<char, std::int64_t>+;
-#pragma link C++ class std::pair<char, std::string>+;
-#pragma link C++ class std::pair<int, CustomStruct>+;
-#pragma link C++ class std::pair<int, std::vector<CustomStruct>>+;
-#pragma link C++ class std::pair<float, std::map<char, std::int32_t>>+;
-#pragma link C++ class std::pair<char, std::int32_t>+;
-#pragma link C++ class std::pair<float, std::vector<bool>>+;
-
 #endif

--- a/tree/ntuple/v7/test/ProxiedSTLContainerLinkDef.h
+++ b/tree/ntuple/v7/test/ProxiedSTLContainerLinkDef.h
@@ -9,7 +9,7 @@
 #pragma link C++ class std::set<float>+;
 #pragma link C++ class std::set<std::set<CustomStruct>>+;
 #pragma link C++ class std::set<std::set<char>>+;
-#pragma link C++ class std::set<std::pair<int, CustomStruct>>+;
+#pragma link C++ class std::set<std::tuple<int, char, CustomStruct>>+;
 
 #pragma link C++ class std::unordered_set<std::int64_t>+;
 #pragma link C++ class std::unordered_set<std::string>+;

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -322,7 +322,7 @@ TEST(RNTuple, StdSet)
    {
       auto model = RNTupleModel::Create();
       auto set_field = model->MakeField<std::set<float>>({"mySet", "float set"});
-      auto set_field2 = model->MakeField<std::set<std::pair<int, CustomStruct>>>({"mySet2"});
+      auto set_field2 = model->MakeField<std::set<std::tuple<int, char, CustomStruct>>>({"mySet2"});
 
       auto mySet3 = RFieldBase::Create("mySet3", "std::set<std::string>").Unwrap();
       auto mySet4 = RFieldBase::Create("mySet4", "std::set<std::set<char>>").Unwrap();
@@ -335,8 +335,9 @@ TEST(RNTuple, StdSet)
       auto set_field4 = ntuple->GetModel()->GetDefaultEntry()->Get<std::set<std::set<char>>>("mySet4");
       for (int i = 0; i < 2; i++) {
          *set_field = {static_cast<float>(i), 3.14, 0.42};
-         *set_field2 = {std::make_pair(i, CustomStruct{6.f, {7.f, 8.f}, {{9.f}, {10.f}}, "foo"}),
-                        std::make_pair(i + 1, CustomStruct{2.f, {3.f, 4.f}, {{5.f}, {6.f}}, "bar"})};
+         *set_field2 = {
+            std::make_tuple(i, static_cast<char>(i + 65), CustomStruct{6.f, {7.f, 8.f}, {{9.f}, {10.f}}, "foo"}),
+            std::make_tuple(i + 1, static_cast<char>(i + 97), CustomStruct{2.f, {3.f, 4.f}, {{5.f}, {6.f}}, "bar"})};
          *set_field3 = {"Hello", "world!", std::to_string(i)};
          *set_field4 = {{static_cast<char>(i), 'a'}, {'r', 'o', 'o', 't'}, {'h', 'i'}};
          ntuple->Fill();
@@ -347,27 +348,27 @@ TEST(RNTuple, StdSet)
    EXPECT_EQ(2, ntuple->GetNEntries());
 
    auto viewSet = ntuple->GetView<std::set<float>>("mySet");
-   auto viewSet2 = ntuple->GetView<std::set<std::pair<int, CustomStruct>>>("mySet2");
+   auto viewSet2 = ntuple->GetView<std::set<std::tuple<int, char, CustomStruct>>>("mySet2");
    auto viewSet3 = ntuple->GetView<std::set<std::string>>("mySet3");
    auto viewSet4 = ntuple->GetView<std::set<std::set<char>>>("mySet4");
    for (auto i : ntuple->GetEntryRange()) {
       EXPECT_EQ(std::set<float>({static_cast<float>(i), 3.14, 0.42}), viewSet(i));
 
-      auto pairSet = std::set<std::pair<int, CustomStruct>>(
-         {std::make_pair(i, CustomStruct{6.f, {7.f, 8.f}, {{9.f}, {10.f}}, "foo"}),
-          std::make_pair(i + 1, CustomStruct{2.f, {3.f, 4.f}, {{5.f}, {6.f}}, "bar"})});
-      EXPECT_EQ(pairSet, viewSet2(i));
+      auto tupleSet = std::set<std::tuple<int, char, CustomStruct>>(
+         {std::make_tuple(i, static_cast<char>(i + 65), CustomStruct{6.f, {7.f, 8.f}, {{9.f}, {10.f}}, "foo"}),
+          std::make_tuple(i + 1, static_cast<char>(i + 97), CustomStruct{2.f, {3.f, 4.f}, {{5.f}, {6.f}}, "bar"})});
+      EXPECT_EQ(tupleSet, viewSet2(i));
 
       EXPECT_EQ(std::set<std::string>({"Hello", "world!", std::to_string(i)}), viewSet3(i));
       EXPECT_EQ(std::set<std::set<char>>({{static_cast<char>(i), 'a'}, {'r', 'o', 'o', 't'}, {'h', 'i'}}), viewSet4(i));
    }
 
    ntuple->LoadEntry(0);
-   auto mySet2 = ntuple->GetModel()->GetDefaultEntry()->Get<std::set<std::pair<int, CustomStruct>>>("mySet2");
-   auto pairSet =
-      std::set<std::pair<int, CustomStruct>>({std::make_pair(0, CustomStruct{6.f, {7.f, 8.f}, {{9.f}, {10.f}}, "foo"}),
-                                              std::make_pair(1, CustomStruct{2.f, {3.f, 4.f}, {{5.f}, {6.f}}, "bar"})});
-   EXPECT_EQ(pairSet, *mySet2);
+   auto mySet2 = ntuple->GetModel()->GetDefaultEntry()->Get<std::set<std::tuple<int, char, CustomStruct>>>("mySet2");
+   auto tupleSet = std::set<std::tuple<int, char, CustomStruct>>(
+      {std::make_tuple(0, 'A', CustomStruct{6.f, {7.f, 8.f}, {{9.f}, {10.f}}, "foo"}),
+       std::make_tuple(1, 'a', CustomStruct{2.f, {3.f, 4.f}, {{5.f}, {6.f}}, "bar"})});
+   EXPECT_EQ(tupleSet, *mySet2);
 }
 
 TEST(RNTuple, StdUnorderedSet)


### PR DESCRIPTION
This PR fixes the way data member offsets are determined for `std::pair` fields. The previous implementation used an auto-generated TClass for `std::pair` without its information loaded in the interpreter (as explained in #14084), which for ROOT builds *with* runtime C++ modules enabled is no problem, but without would need the addition of some dictionaries, most notably for `std::map` fields.

In #14084, a fix is proposed which works. However, I also discovered that the way that is currently used to get the data member offsets for `std::tuple` fields through `TRealData` also works, so I opted to implement that one instead for consistency's sake (if there are reasons this implementation is problematic, we should also change it for `RTupleField`).

