### PR TITLE
[cling] Provide fallback for LLVM_INCLUDE_DIRS

### DIFF
--- a/interpreter/cling/CMakeLists.txt
+++ b/interpreter/cling/CMakeLists.txt
@@ -190,6 +190,9 @@ else()
     set (CLANG_INCLUDE_DIRS "${CLANG_INCLUDE_DIRS}"
       "${LLVM_BINARY_DIR}/tools/clang/include")
   endif()
+  if (NOT LLVM_INCLUDE_DIRS)
+    set (LLVM_INCLUDE_DIRS "${LLVM_MAIN_SRC_DIR}/include" "${LLVM_BINARY_DIR}/include")
+  endif()
 endif()
 
 if( NOT "NVPTX" IN_LIST LLVM_TARGETS_TO_BUILD)


### PR DESCRIPTION
In standalone builds, it could otherwise happen that the variable is not set during the first CMake invocation and tests fail because they are unable to locate the LLVM headers.