### PR TITLE
[ntuple] Add support for n-dim C arrays in EDMs

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -704,7 +704,7 @@ Fixed-sized arrays are stored as two fields:
   - A repetitive field of type `std::array<T, N>` with no attached columns. The array size `N` is stored in the field meta-data.
   - Child field of type `T` named `_0`, which must be a type with RNTuple I/O support.
 
-Multi-dimensional arrays of the form `T[N][M]...` are currently not supported.
+Note that T can itself be an array type, which includes support for multidimensional C-style arrays.
 
 #### std::variant<T1, T2, ..., Tn>
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -365,12 +365,12 @@ ROOT::Experimental::Detail::RFieldBase::Create(const std::string &fieldName, con
    if (canonicalType.empty())
       return R__FAIL("no type name specified for Field " + fieldName);
 
-   if (auto [arrayBaseType, arraySize] = ParseArrayType(canonicalType); !arraySize.empty()) {
-      // TODO(jalopezg): support multi-dimensional row-major (C order) arrays in RArrayField
-      if (arraySize.size() > 1)
-         return R__FAIL("multi-dimensional array type not supported " + canonicalType);
-      auto itemField = Create("_0", arrayBaseType).Unwrap();
-      return {std::make_unique<RArrayField>(fieldName, std::move(itemField), arraySize[0])};
+   if (auto [arrayBaseType, arraySizes] = ParseArrayType(canonicalType); !arraySizes.empty()) {
+      std::unique_ptr<RFieldBase> arrayField = Create("_0", arrayBaseType).Unwrap();
+      for (int i = arraySizes.size() - 1; i >= 0; --i) {
+         arrayField = std::make_unique<RArrayField>((i == 0) ? fieldName : "_0", std::move(arrayField), arraySizes[i]);
+      }
+      return arrayField;
    }
 
    std::unique_ptr<ROOT::Experimental::Detail::RFieldBase> result;

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -66,6 +66,7 @@ struct DerivedC : public DerivedA, public DerivedA2 {
 struct StructWithArrays {
    unsigned char c[4];
    float f[2];
+   int i[2][1];
 };
 
 struct EmptyStruct {};

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -164,7 +164,7 @@ TEST(RNTuple, ArrayField)
       auto array1_field = ntuple->GetModel()->GetDefaultEntry()->Get<float[2]>("array1");
       auto array2_field = ntuple->GetModel()->GetDefaultEntry()->Get<unsigned char[4]>("array2");
       for (int i = 0; i < 2; i++) {
-         new (struct_field.get()) StructWithArrays({{'n', 't', 'p', 'l'}, {1.0, 42.0}});
+         new (struct_field.get()) StructWithArrays({{'n', 't', 'p', 'l'}, {1.0, 42.0}, {{2*i}, {2*i + 1}}});
          new (array1_field) float[2]{0.0f, static_cast<float>(i)};
          memcpy(array2_field, charArray, sizeof(charArray));
          ntuple->Fill();
@@ -180,6 +180,8 @@ TEST(RNTuple, ArrayField)
       EXPECT_EQ(0, memcmp(viewStruct(i).c, "ntpl", 4));
       EXPECT_EQ(1.0f, viewStruct(i).f[0]);
       EXPECT_EQ(42.0f, viewStruct(i).f[1]);
+      EXPECT_EQ(2*i, viewStruct(i).i[0][0]);
+      EXPECT_EQ(2*i + 1, viewStruct(i).i[1][0]);
 
       float fs[] = {0.0f, static_cast<float>(i)};
       EXPECT_EQ(0, memcmp(viewArray1(i), fs, sizeof(fs)));


### PR DESCRIPTION
# This Pull request:

Adds type support for multidimensional C style arrays. For the time being, the support is limited to the construction of fields from type strings through `RFieldBase::Create`. Support for construction through template parameters `MakeField` is subject to a follow-up PR.

## Changes or fixes:

Enables RNTuple support for classes with multidimensional C array members .

## Checklist:

- [X] tested changes locally
- [X] updated the docs (if necessary)

