### PR TITLE
[RF] Again skip overflow bins correctly in HistFactory in 2D and 3D case

### DIFF
--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -75,8 +75,13 @@ std::vector<double> histToVector(TH1 const &hist)
    // Must get the full size of the TH1 (No direct method to do this...)
    int numBins = hist.GetNbinsX() * hist.GetNbinsY() * hist.GetNbinsZ();
    std::vector<double> out(numBins);
+   int histIndex = 0;
    for (int i = 0; i < numBins; ++i) {
-      out[i] = hist.GetBinContent(i + 1);
+      while (hist.IsBinUnderflow(histIndex) || hist.IsBinOverflow(histIndex)) {
+         ++histIndex;
+      }
+      out[i] = hist.GetBinContent(histIndex);
+      ++histIndex;
    }
    return out;
 }


### PR DESCRIPTION
In the 6.30 dev cycle, I made a mistake when refactoring the HistFactory code in 3c68044c257:

https://github.com/root-project/root/commit/3c68044c257e9ee7207e23e7cceb69d7eda596e9#diff-42ea09980f1ed2bacde4381f212c35d78be6ddedccf746953dc99d6455525d8aL1801-L1804

The robust way to skip overflow bins in 2D and 3D was replaced with something that only worked in 1D.

Thanks to Veronica for reporting this on the ROOT forum!

https://root-forum.cern.ch/t/discrepancy-in-2d-histfactory-fit-results-between-root-versions-6-28-06-vs-nightlies-with-beeston-barlow-method-activated

I validated now that the fit results with the reproducer on the forum are the same with 6.28 and 6.30.

To be backported to the 6.30 branch.