### PR TITLE
[RF] Enable external roottest build

### DIFF
--- a/roofit/histfactory/test/testParamHistFunc.cxx
+++ b/roofit/histfactory/test/testParamHistFunc.cxx
@@ -10,7 +10,7 @@
 #include <RooFit/Detail/NormalizationHelpers.h>
 #include <RooFit/Evaluator.h>
 
-#include "../src/RooFit/BatchModeDataHelpers.h"
+#include "RooFit/Detail/BatchModeDataHelpers.h"
 
 #include <gtest/gtest.h>
 #include <array>
@@ -73,8 +73,9 @@ TEST(ParamHistFunc, ValidateND)
    std::unique_ptr<RooAbsReal> clone = RooFit::Detail::compileForNormSet<RooAbsReal>(paramHistFunc, *data.get());
    RooFit::Evaluator evaluator(*clone);
    std::stack<std::vector<double>> vectorBuffers;
-   auto dataSpans = RooFit::BatchModeDataHelpers::getDataSpans(data, "", nullptr, /*skipZeroWeights=*/true,
-                                                               /*takeGlobalObservablesFromData=*/false, vectorBuffers);
+   auto dataSpans =
+      RooFit::Detail::BatchModeDataHelpers::getDataSpans(data, "", nullptr, /*skipZeroWeights=*/true,
+                                                         /*takeGlobalObservablesFromData=*/false, vectorBuffers);
    for (auto const &item : dataSpans) {
       evaluator.setInput(item.first->GetName(), item.second, false);
    }

--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -130,6 +130,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     RooFit.h
     RooFit/Config.h
     RooFit/Detail/AnalyticalIntegrals.h
+    RooFit/Detail/BatchModeDataHelpers.h
     RooFit/Detail/CodeSquashContext.h
     RooFit/Detail/DataMap.h
     RooFit/Detail/EvaluateFuncs.h

--- a/roofit/roofitcore/inc/RooFit/Detail/BatchModeDataHelpers.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/BatchModeDataHelpers.h
@@ -33,6 +33,7 @@ class RooSimultaneous;
 class TNamed;
 
 namespace RooFit {
+namespace Detail {
 namespace BatchModeDataHelpers {
 
 std::map<RooFit::Detail::DataKey, std::span<const double>>
@@ -44,6 +45,7 @@ determineOutputSizes(RooAbsArg const &topNode,
                      std::function<std::size_t(RooFit::Detail::DataKey)> const &inputSizeFunc);
 
 } // namespace BatchModeDataHelpers
+} // namespace Detail
 } // namespace RooFit
 
 #endif

--- a/roofit/roofitcore/src/BatchModeDataHelpers.cxx
+++ b/roofit/roofitcore/src/BatchModeDataHelpers.cxx
@@ -12,7 +12,7 @@
  * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
  */
 
-#include "RooFit/BatchModeDataHelpers.h"
+#include "RooFit/Detail/BatchModeDataHelpers.h"
 
 #include <RooAbsData.h>
 #include <RooRealVar.h>
@@ -210,9 +210,10 @@ getSingleDataSpans(RooAbsData const &data, std::string_view rangeName, std::stri
 ///            object can't be used directly (e.g. because you used the range
 ///            selection or the splitting by categories).
 std::map<RooFit::Detail::DataKey, std::span<const double>>
-RooFit::BatchModeDataHelpers::getDataSpans(RooAbsData const &data, std::string const &rangeName,
-                                           RooSimultaneous const *simPdf, bool skipZeroWeights,
-                                           bool takeGlobalObservablesFromData, std::stack<std::vector<double>> &buffers)
+RooFit::Detail::BatchModeDataHelpers::getDataSpans(RooAbsData const &data, std::string const &rangeName,
+                                                   RooSimultaneous const *simPdf, bool skipZeroWeights,
+                                                   bool takeGlobalObservablesFromData,
+                                                   std::stack<std::vector<double>> &buffers)
 {
    std::vector<std::pair<std::string, RooAbsData const *>> datasets;
    std::vector<bool> isBinnedL;
@@ -272,7 +273,7 @@ RooFit::BatchModeDataHelpers::getDataSpans(RooAbsData const &data, std::string c
 /// \return A `std::map` with output sizes for each node in the computation graph.
 /// \param[in] topNode The top node of the computation graph.
 /// \param[in] inputSizeFunc A function to get the input sizes.
-std::map<RooFit::Detail::DataKey, std::size_t> RooFit::BatchModeDataHelpers::determineOutputSizes(
+std::map<RooFit::Detail::DataKey, std::size_t> RooFit::Detail::BatchModeDataHelpers::determineOutputSizes(
    RooAbsArg const &topNode, std::function<std::size_t(RooFit::Detail::DataKey)> const &inputSizeFunc)
 {
    std::map<RooFit::Detail::DataKey, std::size_t> output;

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -51,7 +51,7 @@
 #include "RooDataSet.h"
 #include "RooDerivative.h"
 #include "RooFirstMoment.h"
-#include "RooFit/BatchModeDataHelpers.h"
+#include "RooFit/Detail/BatchModeDataHelpers.h"
 #include "RooFit/Evaluator.h"
 #include "RooFitResult.h"
 #include "RooFormulaVar.h"
@@ -121,9 +121,9 @@ public:
       _arg->recursiveRedirectServers(RooArgList{var});
       _evaluator = std::make_unique<RooFit::Evaluator>(*_arg);
       std::stack<std::vector<double>>{}.swap(_vectorBuffers);
-      auto dataSpans = RooFit::BatchModeDataHelpers::getDataSpans(data, "", nullptr, /*skipZeroWeights=*/false,
-                                                                   /*takeGlobalObservablesFromData=*/true,
-                                                                   _vectorBuffers);
+      auto dataSpans =
+         RooFit::Detail::BatchModeDataHelpers::getDataSpans(data, "", nullptr, /*skipZeroWeights=*/false,
+                                                            /*takeGlobalObservablesFromData=*/true, _vectorBuffers);
       for (auto const& item : dataSpans) {
          _evaluator->setInput(item.first->GetName(), item.second, false);
       }

--- a/roofit/roofitcore/src/RooEvaluatorWrapper.cxx
+++ b/roofit/roofitcore/src/RooEvaluatorWrapper.cxx
@@ -28,7 +28,7 @@ Wraps a RooFit::Evaluator that evaluates a RooAbsReal back into a RooAbsReal.
 #include <RooRealVar.h>
 #include <RooHelpers.h>
 #include <RooMsgService.h>
-#include "RooFit/BatchModeDataHelpers.h"
+#include "RooFit/Detail/BatchModeDataHelpers.h"
 #include <RooSimultaneous.h>
 
 #include <TList.h>
@@ -77,8 +77,8 @@ bool RooEvaluatorWrapper::setData(RooAbsData &data, bool /*cloneData*/)
 {
    _data = &data;
    std::stack<std::vector<double>>{}.swap(_vectorBuffers);
-   auto dataSpans = RooFit::BatchModeDataHelpers::getDataSpans(*_data, _rangeName, _simPdf, /*skipZeroWeights=*/true,
-                                                               _takeGlobalObservablesFromData, _vectorBuffers);
+   auto dataSpans = RooFit::Detail::BatchModeDataHelpers::getDataSpans(
+      *_data, _rangeName, _simPdf, /*skipZeroWeights=*/true, _takeGlobalObservablesFromData, _vectorBuffers);
    for (auto const &item : dataSpans) {
       _evaluator->setInput(item.first->GetName(), item.second, false);
    }

--- a/roofit/roofitcore/src/RooFit/Evaluator.cxx
+++ b/roofit/roofitcore/src/RooFit/Evaluator.cxx
@@ -37,7 +37,7 @@ RooAbsPdf::fitTo() is called and gets destroyed when the fitting ends.
 #include <RooNameReg.h>
 #include <RooSimultaneous.h>
 
-#include "BatchModeDataHelpers.h"
+#include "RooFit/Detail/BatchModeDataHelpers.h"
 #include "BatchModeHelpers.h"
 #include "Detail/Buffers.h"
 #include "RooFitImplHelpers.h"
@@ -313,10 +313,11 @@ void Evaluator::updateOutputSizes()
       }
    }
 
-   auto outputSizeMap = RooFit::BatchModeDataHelpers::determineOutputSizes(_topNode, [&](RooFit::Detail::DataKey key) {
-      auto found = sizeMap.find(key);
-      return found != sizeMap.end() ? found->second : 0;
-   });
+   auto outputSizeMap =
+      RooFit::Detail::BatchModeDataHelpers::determineOutputSizes(_topNode, [&](RooFit::Detail::DataKey key) {
+         auto found = sizeMap.find(key);
+         return found != sizeMap.end() ? found->second : 0;
+      });
 
    for (auto &info : _nodes) {
       info.outputSize = outputSizeMap.at(info.absArg);

--- a/roofit/roofitcore/src/RooFuncWrapper.cxx
+++ b/roofit/roofitcore/src/RooFuncWrapper.cxx
@@ -18,7 +18,7 @@
 #include <RooRealVar.h>
 #include <RooHelpers.h>
 #include <RooFit/Detail/CodeSquashContext.h>
-#include "RooFit/BatchModeDataHelpers.h"
+#include "RooFit/Detail/BatchModeDataHelpers.h"
 
 #include <TROOT.h>
 #include <TSystem.h>
@@ -70,7 +70,7 @@ void RooFuncWrapper::loadParamsAndData(RooAbsArg const *head, RooArgSet const &p
    std::map<RooFit::Detail::DataKey, std::span<const double>> spans;
 
    if (data) {
-      spans = RooFit::BatchModeDataHelpers::getDataSpans(*data, "", simPdf, true, false, vectorBuffers);
+      spans = RooFit::Detail::BatchModeDataHelpers::getDataSpans(*data, "", simPdf, true, false, vectorBuffers);
    }
 
    std::size_t idx = 0;
@@ -101,7 +101,7 @@ void RooFuncWrapper::loadParamsAndData(RooAbsArg const *head, RooArgSet const &p
 
    if (head) {
       _nodeOutputSizes =
-         RooFit::BatchModeDataHelpers::determineOutputSizes(*head, [&spans](RooFit::Detail::DataKey key) {
+         RooFit::Detail::BatchModeDataHelpers::determineOutputSizes(*head, [&spans](RooFit::Detail::DataKey key) {
             auto found = spans.find(key);
             return found != spans.end() ? found->second.size() : 0;
          });

--- a/roofit/roofitcore/src/TestStatistics/RooUnbinnedL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooUnbinnedL.cxx
@@ -33,7 +33,7 @@ In extended mode, a
 #include <RooNaNPacker.h>
 #include <RooFit/Evaluator.h>
 
-#include "../RooFit/BatchModeDataHelpers.h"
+#include "RooFit/Detail/BatchModeDataHelpers.h"
 
 namespace RooFit {
 namespace TestStatistics {
@@ -63,8 +63,8 @@ RooUnbinnedL::RooUnbinnedL(RooAbsPdf *pdf, RooAbsData *data, RooAbsL::Extended e
       evaluator_ = std::make_unique<RooFit::Evaluator>(*pdf_, evalBackend.value() == RooFit::EvalBackend::Value::Cuda);
       std::stack<std::vector<double>>{}.swap(_vectorBuffers);
       auto dataSpans =
-         RooFit::BatchModeDataHelpers::getDataSpans(*data, "", nullptr, /*skipZeroWeights=*/true,
-                                                    /*takeGlobalObservablesFromData=*/false, _vectorBuffers);
+         RooFit::Detail::BatchModeDataHelpers::getDataSpans(*data, "", nullptr, /*skipZeroWeights=*/true,
+                                                            /*takeGlobalObservablesFromData=*/false, _vectorBuffers);
       for (auto const &item : dataSpans) {
          evaluator_->setInput(item.first->GetName(), item.second, false);
       }


### PR DESCRIPTION
By moving the header currently hidden in `src/RooFit` to `inc/RooFit` we can allow a roottest build to work when built with an external installation of ROOT. To preserve the intent of the header, the functions declared are moved to the `RooFit::Internal` namespace, as they are not meant for public use.

## Context

This is required for the conda nightlies builds, which build roottest after having built ROOT.