### PR TITLE
[webgui] change loopback via API, do not expose server dirs [6.30]

### DIFF
--- a/gui/browserv7/src/RBrowser.cxx
+++ b/gui/browserv7/src/RBrowser.cxx
@@ -291,8 +291,8 @@ RBrowser::RBrowser(bool use_rcanvas)
    fWebWindow->SetDefaultPage("file:rootui5sys/browser/browser.html");
 
    // this is call-back, invoked when message received via websocket
-   fWebWindow->SetCallBacks([this](unsigned connid) { fConnId = connid; SendInitMsg(connid); },
-                            [this](unsigned connid, const std::string &arg) { ProcessMsg(connid, arg); });
+   fWebWindow->SetCallBacks([this](unsigned connid) { if (!fConnId) { fConnId = connid; SendInitMsg(connid); } else fConnId = 0xffffff; },
+                            [this](unsigned connid, const std::string &arg) { if ((connid == fConnId) && (fConnId != 0xffffff)) ProcessMsg(connid, arg); });
    fWebWindow->SetGeometry(1200, 700); // configure predefined window geometry
    fWebWindow->SetConnLimit(1); // the only connection is allowed
    fWebWindow->SetMaxQueueLength(30); // number of allowed entries in the window queue

--- a/gui/gui/src/TRootBrowser.cxx
+++ b/gui/gui/src/TRootBrowser.cxx
@@ -576,7 +576,7 @@ Longptr_t TRootBrowser::ExecPlugin(const char *name, const char *fname,
    Bool_t new_canvas = command.Contains("new TCanvas");
    Bool_t is_web_canvas = strcmp(gEnv->GetValue("Canvas.Name", ""), "TWebCanvas") == 0;
 
-   if (IsWebGUI() && new_canvas && is_web_canvas)
+   if (IsWebGUI() && gROOT->IsWebDisplay() && new_canvas && is_web_canvas)
       return gROOT->ProcessLine(command.Data());
 
    if (new_canvas && is_web_canvas)

--- a/gui/webdisplay/inc/ROOT/RWebWindowsManager.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindowsManager.hxx
@@ -93,6 +93,8 @@ public:
 
    static bool IsMainThrd();
    static void AssignMainThrd();
+
+   static void SetLoopbackMode(bool on = true);
 };
 
 } // namespace ROOT

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -435,12 +435,12 @@ bool RWebWindowsManager::CreateServer(bool with_http)
          if (http_maxage >= 0)
             engine.Append(TString::Format("&max_age=%d", http_maxage));
 
-         if (use_secure) {
+         if (use_secure && !strchr(ssl_cert,'&')) {
             engine.Append("&ssl_cert=");
             engine.Append(ssl_cert);
          }
 
-         if (extra_args && strlen(extra_args) > 0) {
+         if (!use_unix_socket && !assign_loopback && extra_args && strlen(extra_args) > 0) {
             engine.Append("&");
             engine.Append(extra_args);
          }

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -90,6 +90,7 @@ std::shared_ptr<RWebWindowsManager> &RWebWindowsManager::Instance()
 
 static std::thread::id gWebWinMainThrd = std::this_thread::get_id();
 static bool gWebWinMainThrdSet = true;
+static bool gWebWinLoopbackMode = true;
 
 //////////////////////////////////////////////////////////////////////////////////////////
 /// Returns true when called from main process
@@ -115,6 +116,23 @@ void RWebWindowsManager::AssignMainThrd()
    gWebWinMainThrdSet = true;
    gWebWinMainThrd = std::this_thread::get_id();
 }
+
+
+//////////////////////////////////////////////////////////////////////////////////////////
+/// Set loopback mode for THttpServer used for web widgets
+/// By default is on. Only local communication via localhost address is possible
+/// Disable it only if really necessary - it may open unauthorized access to your application from external nodes!!
+
+void RWebWindowsManager::SetLoopbackMode(bool on)
+{
+   gWebWinLoopbackMode = on;
+   if (!on) {
+      printf("\nWARNING!\n");
+      printf("Disabling loopback mode may leads to security problem.\n");
+      printf("See https://root.cern/about/security/ for more information.\n\n");
+   }
+}
+
 
 //////////////////////////////////////////////////////////////////////////////////////////
 /// window manager constructor
@@ -331,8 +349,7 @@ bool RWebWindowsManager::CreateServer(bool with_http)
    int fcgi_thrds = gEnv->GetValue("WebGui.FastCgiThreads", 10);
    const char *fcgi_serv = gEnv->GetValue("WebGui.FastCgiServer", "");
    fLaunchTmout = gEnv->GetValue("WebGui.LaunchTmout", 30.);
-   // always use loopback
-   bool assign_loopback = true; // RWebWindowWSHandler::GetBoolEnv("WebGui.HttpLoopback", 1) == 1;
+   bool assign_loopback = gWebWinLoopbackMode;
    const char *http_bind = gEnv->GetValue("WebGui.HttpBind", "");
    bool use_secure = RWebWindowWSHandler::GetBoolEnv("WebGui.UseHttps", 0) == 1;
    const char *ssl_cert = gEnv->GetValue("WebGui.ServerCert", "rootserver.pem");

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -181,15 +181,20 @@ THttpServer::THttpServer(const char *engine) : TNamed("http", "ROOT http server"
       }
    }
 
-   AddLocation("currentdir/", ".");
+   Bool_t basic_sniffer = strstr(engine, "basic_sniffer") != nullptr;
+
    AddLocation("jsrootsys/", fJSROOTSYS.Data());
-   AddLocation("rootsys/", TROOT::GetRootSys());
+
+   if (!basic_sniffer) {
+      AddLocation("currentdir/", ".");
+      AddLocation("rootsys/", TROOT::GetRootSys());
+   }
 
    fDefaultPage = fJSROOTSYS + "/files/online.htm";
    fDrawPage = fJSROOTSYS + "/files/draw.htm";
 
    TRootSniffer *sniff = nullptr;
-   if (strstr(engine, "basic_sniffer")) {
+   if (basic_sniffer) {
       sniff = new TRootSniffer("sniff");
       sniff->SetScanGlobalDir(kFALSE);
       sniff->CreateOwnTopFolder(); // use dedicated folder

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -926,7 +926,8 @@ void THttpServer::ProcessRequest(std::shared_ptr<THttpCallArg> arg)
       }
 
       if (arg->fContent.empty() && arg->fFileName.IsNull() && arg->fPathName.IsNull() && IsWSOnly()) {
-         arg->fContent = BuildWSEntryPage();
+         arg->SetContent("refused"); //  BuildWSEntryPage();
+         arg->Set404();
       }
 
       if (arg->fContent.empty() && !IsWSOnly()) {


### PR DESCRIPTION
Introduce `RWebWindowsManager::SetLoopbackMode()` to let change binding to loopback device 

Do not expose current directory via webgui http server

Do not provide list of window on default webpage

Do not allow to reconnect to RBrowser

