### PR TITLE
[ntuple] Implement RPageSinkFile::CommitSealedPageVImpl

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -41,6 +41,11 @@ Envelopes can reference other envelopes and pages by means of a **locator** or a
 for a file embedding, the locator consists of an offset and a size.
 The RNTuple format does _not_ establish a specific order of pages and envelopes.
 
+For the ROOT file embedding, pages and envelopes are stored in "invisible", non-indexed **RBlob** keys.
+The RNTuple format does _not_ establish a semantic mapping from objects to keys or vice versa.
+For example, one key may hold a single page or a number of pages of the same cluster.
+The only relevant means of finding objects is the locator information, consisting of an offset and a size.
+
 Every embedding must define an **anchor** that contains the format version supported by the writer,
 and envelope links (location, compressed and uncompressed size) of the header and footer envelopes.
 For the ROOT file embedding, the **ROOT::Experimental::RNTuple** object acts as an anchor.

--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -180,6 +180,11 @@ public:
    std::uint64_t WriteNTupleFooter(const void *data, size_t nbytes, size_t lenFooter);
    /// Writes a new record as an RBlob key into the file
    std::uint64_t WriteBlob(const void *data, size_t nbytes, size_t len);
+   /// Reserves a new record as an RBlob key in the file.
+   std::uint64_t ReserveBlob(size_t nbytes, size_t len);
+   /// Write into a reserved record; the caller is responsible for making sure that the written byte range is in the
+   /// previously reserved key.
+   void WriteIntoReservedBlob(const void *buffer, size_t nbytes, std::int64_t offset);
    /// Writes the RNTuple key to the file so that the header and footer keys can be found
    void Commit();
 };

--- a/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RMiniFile.hxx
@@ -102,6 +102,8 @@ private:
       FILE *fFile = nullptr;
       /// Keeps track of the seek offset
       std::uint64_t fFilePos = 0;
+      /// Keeps track of the next key offset
+      std::uint64_t fKeyOffset = 0;
       /// Keeps track of TFile control structures, which need to be updated on committing the data set
       std::unique_ptr<ROOT::Experimental::Internal::RTFileControlBlock> fControlBlock;
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -73,6 +73,7 @@ protected:
    RNTupleLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) final;
    RNTupleLocator
    CommitSealedPageImpl(DescriptorId_t physicalColumnId, const RPageStorage::RSealedPage &sealedPage) final;
+   std::vector<RNTupleLocator> CommitSealedPageVImpl(std::span<RPageStorage::RSealedPageGroup> ranges) final;
    std::uint64_t CommitClusterImpl(NTupleSize_t nEntries) final;
    RNTupleLocator CommitClusterGroupImpl(unsigned char *serializedPageList, std::uint32_t length) final;
    void CommitDatasetImpl(unsigned char *serializedFooter, std::uint32_t length) final;

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -1249,7 +1249,8 @@ std::uint64_t ROOT::Experimental::Internal::RNTupleFileWriter::RFileProper::Writ
    Write(&strTitle, strTitle.GetSize(), offset);
    offset += strTitle.GetSize();
    auto offsetData = offset;
-   Write(buffer, nbytes, offset);
+   if (buffer)
+      Write(buffer, nbytes, offset);
 
    return offsetData;
 }

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -203,8 +203,10 @@ struct RTFKey {
    RTFKey() : fInfoShort() {}
    RTFKey(std::uint64_t seekKey, std::uint64_t seekPdir,
           const RTFString &clName, const RTFString &objName, const RTFString &titleName,
-          std::uint32_t szObjInMem, std::uint32_t szObjOnDisk = 0)
+          std::size_t szObjInMem, std::size_t szObjOnDisk = 0)
    {
+      R__ASSERT(szObjInMem < std::numeric_limits<std::int32_t>::max());
+      R__ASSERT(szObjOnDisk < std::numeric_limits<std::int32_t>::max());
       fObjLen = szObjInMem;
       if ((seekKey > static_cast<unsigned int>(std::numeric_limits<std::int32_t>::max())) ||
           (seekPdir > static_cast<unsigned int>(std::numeric_limits<std::int32_t>::max())))

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -234,6 +234,7 @@ struct RTFKey {
       fInfoLong.fSeekKey = seekKey;
       fInfoLong.fSeekPdir = seekPdir;
       fKeyHeaderSize = fKeyHeaderSize + sizeof(fInfoLong) - sizeof(fInfoShort);
+      fKeyLen = fKeyLen + sizeof(fInfoLong) - sizeof(fInfoShort);
       fNbytes = fNbytes + sizeof(fInfoLong) - sizeof(fInfoShort);
       fVersion = fVersion + 1000;
    }

--- a/tree/ntuple/v7/src/RMiniFile.cxx
+++ b/tree/ntuple/v7/src/RMiniFile.cxx
@@ -1378,6 +1378,31 @@ std::uint64_t ROOT::Experimental::Internal::RNTupleFileWriter::WriteBlob(const v
    return offset;
 }
 
+std::uint64_t ROOT::Experimental::Internal::RNTupleFileWriter::ReserveBlob(size_t nbytes, size_t len)
+{
+   std::uint64_t offset;
+   if (fFileSimple) {
+      if (fIsBare) {
+         offset = fFileSimple.fKeyOffset;
+         fFileSimple.fKeyOffset += nbytes;
+      } else {
+         offset = fFileSimple.WriteKey(/*buffer=*/nullptr, nbytes, len, -1, 100, kBlobClassName);
+      }
+   } else {
+      offset = fFileProper.WriteKey(/*buffer=*/nullptr, nbytes, len);
+   }
+   return offset;
+}
+
+void ROOT::Experimental::Internal::RNTupleFileWriter::WriteIntoReservedBlob(const void *buffer, size_t nbytes,
+                                                                            std::int64_t offset)
+{
+   if (fFileSimple) {
+      fFileSimple.Write(buffer, nbytes, offset);
+   } else {
+      fFileProper.Write(buffer, nbytes, offset);
+   }
+}
 
 std::uint64_t ROOT::Experimental::Internal::RNTupleFileWriter::WriteNTupleHeader(
    const void *data, size_t nbytes, size_t lenHeader)

--- a/tree/ntuple/v7/test/ntuple_minifile.cxx
+++ b/tree/ntuple/v7/test/ntuple_minifile.cxx
@@ -123,6 +123,30 @@ TEST(MiniFile, SimpleKeys)
 
    char blob1 = '1';
    auto offBlob1 = writer->WriteBlob(&blob1, 1, 1);
+
+   // Reserve a blob and fully write it.
+   char blob2 = '2';
+   auto offBlob2 = writer->ReserveBlob(1, 1);
+   writer->WriteIntoReservedBlob(&blob2, 1, offBlob2);
+
+   // Reserve a blob, but only write at the beginning.
+   char blob3 = '3';
+   auto offBlob3 = writer->ReserveBlob(2, 2);
+   writer->WriteIntoReservedBlob(&blob3, 1, offBlob3);
+
+   // Reserve a blob, but only write somewhere in the middle.
+   char blob4 = '4';
+   auto offBlob4 = writer->ReserveBlob(3, 3);
+   auto offBlob4Write = offBlob4 + 1;
+   writer->WriteIntoReservedBlob(&blob4, 1, offBlob4Write);
+
+   // Reserve a blob, but don't write it at all.
+   auto offBlob5 = writer->ReserveBlob(2, 2);
+
+   // For good measure, write a final blob to make sure all indices match up.
+   char blob6 = '6';
+   auto offBlob6 = writer->WriteBlob(&blob6, 1, 1);
+
    writer->Commit();
 
    // Manually check the written keys.
@@ -155,6 +179,30 @@ TEST(MiniFile, SimpleKeys)
    EXPECT_STREQ(key->GetClassName(), "RBlob");
    EXPECT_EQ(key->GetSeekKey() + key->GetKeylen(), offBlob1);
    EXPECT_EQ(buffer[offBlob1], blob1);
+
+   ASSERT_TRUE(readNextKey());
+   EXPECT_STREQ(key->GetClassName(), "RBlob");
+   EXPECT_EQ(key->GetSeekKey() + key->GetKeylen(), offBlob2);
+   EXPECT_EQ(buffer[offBlob2], blob2);
+
+   ASSERT_TRUE(readNextKey());
+   EXPECT_STREQ(key->GetClassName(), "RBlob");
+   EXPECT_EQ(key->GetSeekKey() + key->GetKeylen(), offBlob3);
+   EXPECT_EQ(buffer[offBlob3], blob3);
+
+   ASSERT_TRUE(readNextKey());
+   EXPECT_STREQ(key->GetClassName(), "RBlob");
+   EXPECT_EQ(key->GetSeekKey() + key->GetKeylen(), offBlob4);
+   EXPECT_EQ(buffer[offBlob4Write], blob4);
+
+   ASSERT_TRUE(readNextKey());
+   EXPECT_STREQ(key->GetClassName(), "RBlob");
+   EXPECT_EQ(key->GetSeekKey() + key->GetKeylen(), offBlob5);
+
+   ASSERT_TRUE(readNextKey());
+   EXPECT_STREQ(key->GetClassName(), "RBlob");
+   EXPECT_EQ(key->GetSeekKey() + key->GetKeylen(), offBlob6);
+   EXPECT_EQ(buffer[offBlob6], blob6);
 
    ASSERT_TRUE(readNextKey());
    EXPECT_STREQ(key->GetClassName(), "ROOT::Experimental::RNTuple");
@@ -180,6 +228,30 @@ TEST(MiniFile, ProperKeys)
 
    char blob1 = '1';
    auto offBlob1 = writer->WriteBlob(&blob1, 1, 1);
+
+   // Reserve a blob and fully write it.
+   char blob2 = '2';
+   auto offBlob2 = writer->ReserveBlob(1, 1);
+   writer->WriteIntoReservedBlob(&blob2, 1, offBlob2);
+
+   // Reserve a blob, but only write at the beginning.
+   char blob3 = '3';
+   auto offBlob3 = writer->ReserveBlob(2, 2);
+   writer->WriteIntoReservedBlob(&blob3, 1, offBlob3);
+
+   // Reserve a blob, but only write somewhere in the middle.
+   char blob4 = '4';
+   auto offBlob4 = writer->ReserveBlob(3, 3);
+   auto offBlob4Write = offBlob4 + 1;
+   writer->WriteIntoReservedBlob(&blob4, 1, offBlob4Write);
+
+   // Reserve a blob, but don't write it at all.
+   auto offBlob5 = writer->ReserveBlob(2, 2);
+
+   // For good measure, write a final blob to make sure all indices match up.
+   char blob6 = '6';
+   auto offBlob6 = writer->WriteBlob(&blob6, 1, 1);
+
    writer->Commit();
 
    // Manually check the written keys.
@@ -212,6 +284,30 @@ TEST(MiniFile, ProperKeys)
    EXPECT_STREQ(key->GetClassName(), "RBlob");
    EXPECT_EQ(key->GetSeekKey() + key->GetKeylen(), offBlob1);
    EXPECT_EQ(buffer[offBlob1], blob1);
+
+   ASSERT_TRUE(readNextKey());
+   EXPECT_STREQ(key->GetClassName(), "RBlob");
+   EXPECT_EQ(key->GetSeekKey() + key->GetKeylen(), offBlob2);
+   EXPECT_EQ(buffer[offBlob2], blob2);
+
+   ASSERT_TRUE(readNextKey());
+   EXPECT_STREQ(key->GetClassName(), "RBlob");
+   EXPECT_EQ(key->GetSeekKey() + key->GetKeylen(), offBlob3);
+   EXPECT_EQ(buffer[offBlob3], blob3);
+
+   ASSERT_TRUE(readNextKey());
+   EXPECT_STREQ(key->GetClassName(), "RBlob");
+   EXPECT_EQ(key->GetSeekKey() + key->GetKeylen(), offBlob4);
+   EXPECT_EQ(buffer[offBlob4Write], blob4);
+
+   ASSERT_TRUE(readNextKey());
+   EXPECT_STREQ(key->GetClassName(), "RBlob");
+   EXPECT_EQ(key->GetSeekKey() + key->GetKeylen(), offBlob5);
+
+   ASSERT_TRUE(readNextKey());
+   EXPECT_STREQ(key->GetClassName(), "RBlob");
+   EXPECT_EQ(key->GetSeekKey() + key->GetKeylen(), offBlob6);
+   EXPECT_EQ(buffer[offBlob6], blob6);
 
    ASSERT_TRUE(readNextKey());
    EXPECT_STREQ(key->GetClassName(), "ROOT::Experimental::RNTuple");

--- a/tree/ntuple/v7/test/ntuple_minifile.cxx
+++ b/tree/ntuple/v7/test/ntuple_minifile.cxx
@@ -1,4 +1,5 @@
 #include "ntuple_test.hxx"
+#include <TKey.h>
 #include <TTree.h>
 
 namespace {
@@ -113,6 +114,119 @@ TEST(MiniFile, Proper)
    EXPECT_EQ(footer, buf);
 }
 
+TEST(MiniFile, SimpleKeys)
+{
+   FileRaii fileGuard("test_ntuple_minifile_simple_keys.root");
+
+   auto writer = std::unique_ptr<RNTupleFileWriter>(
+      RNTupleFileWriter::Recreate("MyNTuple", fileGuard.GetPath(), 0, ENTupleContainerFormat::kTFile));
+
+   char blob1 = '1';
+   auto offBlob1 = writer->WriteBlob(&blob1, 1, 1);
+   writer->Commit();
+
+   // Manually check the written keys.
+   FILE *f = fopen(fileGuard.GetPath().c_str(), "rb");
+   fseek(f, 0, SEEK_END);
+   long size = ftell(f);
+   rewind(f);
+
+   std::unique_ptr<char[]> buffer(new char[size]);
+   ASSERT_EQ(fread(buffer.get(), 1, size, f), size);
+
+   Long64_t offset = 100;
+   std::unique_ptr<TKey> key;
+   auto readNextKey = [&]() {
+      if (offset >= size) {
+         return false;
+      }
+
+      char *keyBuffer = buffer.get() + offset;
+      key.reset(new TKey(offset, /*size=*/0, nullptr));
+      key->ReadKeyBuffer(keyBuffer);
+      offset = key->GetSeekKey() + key->GetNbytes();
+      return true;
+   };
+
+   ASSERT_TRUE(readNextKey());
+   EXPECT_STREQ(key->GetClassName(), "TFile");
+
+   ASSERT_TRUE(readNextKey());
+   EXPECT_STREQ(key->GetClassName(), "RBlob");
+   EXPECT_EQ(key->GetSeekKey() + key->GetKeylen(), offBlob1);
+   EXPECT_EQ(buffer[offBlob1], blob1);
+
+   ASSERT_TRUE(readNextKey());
+   EXPECT_STREQ(key->GetClassName(), "ROOT::Experimental::RNTuple");
+
+   ASSERT_TRUE(readNextKey());
+   // KeysList
+
+   ASSERT_TRUE(readNextKey());
+   EXPECT_STREQ(key->GetName(), "StreamerInfo");
+
+   ASSERT_TRUE(readNextKey());
+   // FreeSegments
+
+   EXPECT_EQ(offset, size);
+}
+
+TEST(MiniFile, ProperKeys)
+{
+   FileRaii fileGuard("test_ntuple_minifile_proper_keys.root");
+
+   std::unique_ptr<TFile> file;
+   auto writer = std::unique_ptr<RNTupleFileWriter>(RNTupleFileWriter::Recreate("MyNTuple", fileGuard.GetPath(), file));
+
+   char blob1 = '1';
+   auto offBlob1 = writer->WriteBlob(&blob1, 1, 1);
+   writer->Commit();
+
+   // Manually check the written keys.
+   FILE *f = fopen(fileGuard.GetPath().c_str(), "rb");
+   fseek(f, 0, SEEK_END);
+   long size = ftell(f);
+   rewind(f);
+
+   std::unique_ptr<char[]> buffer(new char[size]);
+   ASSERT_EQ(fread(buffer.get(), 1, size, f), size);
+
+   Long64_t offset = 100;
+   std::unique_ptr<TKey> key;
+   auto readNextKey = [&]() {
+      if (offset >= size) {
+         return false;
+      }
+
+      char *keyBuffer = buffer.get() + offset;
+      key.reset(new TKey(offset, /*size=*/0, nullptr));
+      key->ReadKeyBuffer(keyBuffer);
+      offset = key->GetSeekKey() + key->GetNbytes();
+      return true;
+   };
+
+   ASSERT_TRUE(readNextKey());
+   EXPECT_STREQ(key->GetClassName(), "TFile");
+
+   ASSERT_TRUE(readNextKey());
+   EXPECT_STREQ(key->GetClassName(), "RBlob");
+   EXPECT_EQ(key->GetSeekKey() + key->GetKeylen(), offBlob1);
+   EXPECT_EQ(buffer[offBlob1], blob1);
+
+   ASSERT_TRUE(readNextKey());
+   EXPECT_STREQ(key->GetClassName(), "ROOT::Experimental::RNTuple");
+
+   ASSERT_TRUE(readNextKey());
+   // KeysList
+
+   ASSERT_TRUE(readNextKey());
+   EXPECT_STREQ(key->GetName(), "StreamerInfo");
+
+   ASSERT_TRUE(readNextKey());
+   // FreeSegments
+
+   EXPECT_EQ(offset, size);
+}
 
 TEST(MiniFile, Multi)
 {


### PR DESCRIPTION
Instead of writing one key per page, the vector of sealed pages can be written into a single key by first reserving an appropriate size.

---

This PR changes the RNTuple embedding into `TFile`s, in particular we can have both schemes now (key per page, key per cluster, or mixture). I think this is fine because the locator information is solely an offset.