### PR TITLE
[ntuple] RPageSinkBuf: Always seal before CommitCluster

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -197,8 +197,8 @@ protected:
    RSealedPage SealPage(const RPage &page, const RColumnElementBase &element, int compressionSetting);
 
    /// Seal a page using the provided buffer.
-   static RSealedPage SealPage(const RPage &page, const RColumnElementBase &element,
-      int compressionSetting, void *buf);
+   static RSealedPage SealPage(const RPage &page, const RColumnElementBase &element, int compressionSetting, void *buf,
+                               bool allowAlias = true);
 
 public:
    RPageSink(std::string_view ntupleName, const RNTupleWriteOptions &options);

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -350,8 +350,8 @@ std::unique_ptr<ROOT::Experimental::Detail::RPageSink> ROOT::Experimental::Detai
 }
 
 ROOT::Experimental::Detail::RPageStorage::RSealedPage
-ROOT::Experimental::Detail::RPageSink::SealPage(const RPage &page,
-   const RColumnElementBase &element, int compressionSetting, void *buf)
+ROOT::Experimental::Detail::RPageSink::SealPage(const RPage &page, const RColumnElementBase &element,
+                                                int compressionSetting, void *buf, bool allowAlias)
 {
    unsigned char *pageBuf = reinterpret_cast<unsigned char *>(page.GetBuffer());
    bool isAdoptedBuffer = true;
@@ -365,7 +365,7 @@ ROOT::Experimental::Detail::RPageSink::SealPage(const RPage &page,
    }
    auto zippedBytes = packedBytes;
 
-   if ((compressionSetting != 0) || !element.IsMappable()) {
+   if ((compressionSetting != 0) || !element.IsMappable() || !allowAlias) {
       zippedBytes = RNTupleCompressor::Zip(pageBuf, packedBytes, compressionSetting, buf);
       if (!isAdoptedBuffer)
          delete[] pageBuf;

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -451,10 +451,10 @@ TEST(RPageSinkBuf, CommitSealedPageV)
       ntuple->Fill();
       ntuple->Fill();
       ntuple->CommitCluster();
-      // Parallel zip not available; all pages committed separately
-      EXPECT_EQ(5, counters.fNCommitPage);
+      // Parallel zip not available, but pages are still vector-commited
+      EXPECT_EQ(0, counters.fNCommitPage);
       EXPECT_EQ(0, counters.fNCommitSealedPage);
-      EXPECT_EQ(0, counters.fNCommitSealedPageV);
+      EXPECT_EQ(1, counters.fNCommitSealedPageV);
    }
 #ifdef R__USE_IMT
    ROOT::EnableImplicitMT();
@@ -471,15 +471,10 @@ TEST(RPageSinkBuf, CommitSealedPageV)
       ntuple->Fill();
       ntuple->Fill();
       ntuple->CommitCluster();
-#ifdef R__USE_IMT
       // All pages in all columns committed via a single call to `CommitSealedPageV()`
       EXPECT_EQ(0, counters.fNCommitPage);
-      EXPECT_EQ(1, counters.fNCommitSealedPageV);
-#else
-      EXPECT_EQ(3, counters.fNCommitPage);
-      EXPECT_EQ(0, counters.fNCommitSealedPageV);
-#endif
       EXPECT_EQ(0, counters.fNCommitSealedPage);
+      EXPECT_EQ(1, counters.fNCommitSealedPageV);
    }
 }
 


### PR DESCRIPTION
Without a task scheduler, seal in `CommitPage`. This avoids a page allocation and, in most cases, a copy of the uncompressed buffer (unless the element type is mappable and compression is disabled, in which case the sealed page would otherwise alias the page buffer). It also ensures that `CommitCluster` can vector-commit all sealed pages.