### PR TITLE
[ntuple] Add RDF factory for datasource with chain

### DIFF
--- a/tree/dataframe/inc/ROOT/RNTupleDS.hxx
+++ b/tree/dataframe/inc/ROOT/RNTupleDS.hxx
@@ -144,6 +144,7 @@ namespace RDF {
 namespace Experimental {
 RDataFrame FromRNTuple(std::string_view ntupleName, std::string_view fileName);
 RDataFrame FromRNTuple(ROOT::Experimental::RNTuple *ntuple);
+RDataFrame FromRNTuple(std::string_view ntupleName, const std::vector<std::string> &fileNames);
 } // namespace Experimental
 } // namespace RDF
 

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -576,3 +576,10 @@ ROOT::RDataFrame ROOT::RDF::Experimental::FromRNTuple(ROOT::Experimental::RNTupl
    ROOT::RDataFrame rdf(std::make_unique<ROOT::Experimental::RNTupleDS>(ntuple->MakePageSource()));
    return rdf;
 }
+
+ROOT::RDataFrame
+ROOT::RDF::Experimental::FromRNTuple(std::string_view ntupleName, const std::vector<std::string> &fileNames)
+{
+   ROOT::RDataFrame rdf(std::make_unique<ROOT::Experimental::RNTupleDS>(ntupleName, fileNames));
+   return rdf;
+}


### PR DESCRIPTION
# This Pull request:

Adds `FromRNTuple` for vectors of file names. Gives easy access to the RNTuple chains in RDF through PyROOT.