### PR TITLE
Core: Avoid (indirect) memory hoarding in TPluginManager.

### DIFF
--- a/core/base/inc/TPluginManager.h
+++ b/core/base/inc/TPluginManager.h
@@ -115,7 +115,7 @@ private:
    TString      fOrigin;    // origin of plugin handler definition
    TMethodCall *fCallEnv;   //!ctor method call environment
    TFunction   *fMethod;    //!ctor method or global function
-   std::vector<const TClass *> fArgTupleClasses; //! cached TClass pointers for fast comparison
+   std::vector<std::string> fArgTupleTypeInfo; // Cached type_info name for fast comparison
    AtomicInt_t  fCanCall;   //!if 1 fCallEnv is ok, -1 fCallEnv is not ok, 0 fCallEnv not setup yet.
    Bool_t       fIsMacro;   // plugin is a macro and not a library
    Bool_t       fIsGlobal;  // plugin ctor is a global function
@@ -145,23 +145,34 @@ private:
    Bool_t CheckForExecPlugin(Int_t nargs);
    void LoadPluginImpl();
 
-public:
-   const char *GetClass() const { return fClass; }
-   Int_t       CheckPlugin() const;
-   Int_t       LoadPlugin();
+   bool CheckNameMatch(int iarg, const char *type_name);
 
-   // zero arguments case
-   Longptr_t ExecPluginImpl()
+   template <typename T0>
+   bool CheckExactMatch(int iarg, const T0&)
    {
-      if (!CheckForExecPlugin(0))
-         return 0;
+      return CheckNameMatch(iarg, typeid(T0).name());
+   }
 
-      Longptr_t ret;
-      // locking is handled within this call, but will only be needed
-      // on the first call for initialization
-      fCallEnv->Execute(nullptr, nullptr, 0, &ret);
+   template <typename T0, typename... T>
+   bool CheckExactMatch(int iarg, const T0&, const T&... params)
+   {
+      if (CheckNameMatch(iarg, typeid(T0).name()))
+         return CheckExactMatch(iarg + 1, params...);
+      else
+         return false;
+   }
 
-      return ret;
+   template <typename... T>
+   bool ExactArgMatch(const T&... params)
+   {
+      constexpr auto nargs = sizeof...(T);
+      auto name = typeid(std::tuple<T...>).name();
+      if (!fArgTupleTypeInfo[nargs - 1].empty())
+         return name == fArgTupleTypeInfo[nargs - 1];
+      if (!CheckExactMatch<T...>(0, params...))
+         return false;
+      fArgTupleTypeInfo[nargs - 1] = name;
+      return true;
    }
 
    template <typename... T> Longptr_t ExecPluginImpl(const T&... params)
@@ -172,8 +183,7 @@ public:
       Longptr_t ret;
 
       // check if types match such that function can be called directly
-      const TClass *tupleclass = TClass::GetClass<std::tuple<T...>>();
-      if (tupleclass == fArgTupleClasses[nargs - 1]) {
+      if (ExactArgMatch<T...>(params...)) {
          const void *args[nargs] = {&params...};
          // locking is handled within this call, but will only be needed
          // on the first call for initialization
@@ -192,6 +202,25 @@ public:
       fCallEnv->SetParams(params...);
 
       fCallEnv->Execute(ret);
+
+      return ret;
+   }
+
+public:
+   const char *GetClass() const { return fClass; }
+   Int_t       CheckPlugin() const;
+   Int_t       LoadPlugin();
+
+   // zero arguments case
+   Longptr_t ExecPluginImpl()
+   {
+      if (!CheckForExecPlugin(0))
+         return 0;
+
+      Longptr_t ret;
+      // locking is handled within this call, but will only be needed
+      // on the first call for initialization
+      fCallEnv->Execute(nullptr, nullptr, 0, &ret);
 
       return ret;
    }

--- a/core/base/inc/TPluginManager.h
+++ b/core/base/inc/TPluginManager.h
@@ -145,18 +145,18 @@ private:
    Bool_t CheckForExecPlugin(Int_t nargs);
    void LoadPluginImpl();
 
-   bool CheckNameMatch(int iarg, const char *type_name);
+   bool CheckNameMatch(int iarg, const std::type_info &ti);
 
    template <typename T0>
    bool CheckExactMatch(int iarg, const T0&)
    {
-      return CheckNameMatch(iarg, typeid(T0).name());
+      return CheckNameMatch(iarg, typeid(T0));
    }
 
    template <typename T0, typename... T>
    bool CheckExactMatch(int iarg, const T0&, const T&... params)
    {
-      if (CheckNameMatch(iarg, typeid(T0).name()))
+      if (CheckNameMatch(iarg, typeid(T0)))
          return CheckExactMatch(iarg + 1, params...);
       else
          return false;

--- a/core/base/src/TPluginManager.cxx
+++ b/core/base/src/TPluginManager.cxx
@@ -86,6 +86,7 @@ TFile, TSQLServer, TGrid, etc. functionality.
 #include "THashList.h"
 #include "THashTable.h"
 #include "TClass.h"
+#include "TClassEdit.h"
 #include "TInterpreter.h"
 #include "TMethod.h"
 #include "TMethodArg.h"
@@ -176,6 +177,16 @@ Bool_t TPluginHandler::CanHandle(const char *base, const char *uri)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Return true if the name of the iarg-th argument's type match `type_name`
+Bool_t TPluginHandler::CheckNameMatch(int iarg, const char *type_name)
+{
+   const TMethodArg *arg = static_cast<const TMethodArg *>(fMethod->GetListOfMethodArgs()->At(iarg));
+   std::string norm_name;
+   TClassEdit::GetNormalizedName(norm_name, type_name);
+   return norm_name == arg->GetTypeNormalizedName();
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Setup ctor or static method call environment.
 
 void TPluginHandler::SetupCallEnv()
@@ -229,29 +240,14 @@ void TPluginHandler::SetupCallEnv()
    fCallEnv->Init(fMethod);
 
    // cache argument types for fast comparison
-   fArgTupleClasses.clear();
-
-   std::stringstream typelist;
-   for (int iarg = 0; iarg < fMethod->GetNargs(); ++iarg) {
-      if (iarg > 0) {
-         typelist << ", ";
-      }
-      const TMethodArg *arg = static_cast<const TMethodArg *>(fMethod->GetListOfMethodArgs()->At(iarg));
-      typelist << arg->GetTypeNormalizedName();
-
-      std::stringstream tupletype;
-      tupletype << "std::tuple<" << typelist.str() << ">";
-      const TClass *tupleclass = TClass::GetClass(tupletype.str().c_str());
-      if (!tupleclass) {
-         Error("SetupCallEnv", "couldn't get TClass for tuple of argument types %s", tupletype.str().c_str());
-      }
-      fArgTupleClasses.push_back(tupleclass);
-   }
+   fArgTupleTypeInfo.clear();
+   fArgTupleTypeInfo.resize(fMethod->GetNargs());
 
    setCanCall = 1;
 
    return;
 }
+
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Check if the plugin library for this handler exits. Returns 0

--- a/core/base/src/TPluginManager.cxx
+++ b/core/base/src/TPluginManager.cxx
@@ -178,11 +178,17 @@ Bool_t TPluginHandler::CanHandle(const char *base, const char *uri)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return true if the name of the iarg-th argument's type match `type_name`
-Bool_t TPluginHandler::CheckNameMatch(int iarg, const char *type_name)
+Bool_t TPluginHandler::CheckNameMatch(int iarg, const std::type_info& ti)
 {
-   const TMethodArg *arg = static_cast<const TMethodArg *>(fMethod->GetListOfMethodArgs()->At(iarg));
+   int err = 0;
+   char* demangled_name = TClassEdit::DemangleTypeIdName(ti, err);
+   if (err) {
+      return false;
+   }
    std::string norm_name;
-   TClassEdit::GetNormalizedName(norm_name, type_name);
+   TClassEdit::GetNormalizedName(norm_name, demangled_name);
+   free(demangled_name);
+   const TMethodArg *arg = static_cast<const TMethodArg *>(fMethod->GetListOfMethodArgs()->At(iarg));
    return norm_name == arg->GetTypeNormalizedName();
 }
 


### PR DESCRIPTION
This was reported at https://github.com/art-framework-suite/art/issues/142 and is due to the combination of
(a) We do not generate dictionary for std::tuple instances (b) When TClass::GetClass is called it tries to load the dictonary until there is a full TClass object is in memory (c) The emulated std::tuple TClass are marked as 'not loaded' (d) Searching for the TClass for a templated class will cost memory (during the lookup of the instantiation). (e) TPluginManager::ExecPluginImpl was looking up the TClass for the typle `std::type< list of arguments>`

The lookup induced in (e)  in the user's case (root built with runtime cxx module on) lead to some memory allocation in Clang while trying to find out if there was now a library or dictionary to load.

This fixes #14199