### PR TITLE
Enhance CMake FindR module

### DIFF
--- a/cmake/modules/FindR.cmake
+++ b/cmake/modules/FindR.cmake
@@ -12,15 +12,68 @@
 #  R_INCLUDE_DIRS - the R include directories
 #  R_LIBRARIES - link these to use R
 #  R_ROOT_DIR - As reported by R
+#  R_EXECUTABLE - the R executable
+#  R_SCRIPT - the Rscript executable, which runs R non-interactively
 # Autor: Omar Andres Zapata Mesa 31/05/2013
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   set(CMAKE_FIND_APPBUNDLE "LAST")
 endif()
 
-find_program(R_EXECUTABLE NAMES R R.exe)
+# Lists subdirectories in a directory
+# https://stackoverflow.com/questions/7787823/cmake-how-to-get-the-name-of-all-subdirectories-of-a-directory
+macro(SUBDIRLIST result curdir)
+  FILE(GLOB children RELATIVE ${curdir} ${curdir}/*)
+  set(dirlist "")
+  foreach(child ${children})
+    if(IS_DIRECTORY ${curdir}/${child})
+      list(APPEND dirlist ${child})
+    endif()
+  endforeach()
+  set(${result} ${dirlist})
+endmacro()
 
-#---searching R installtion unsing R executable
+find_program(R_EXECUTABLE NAMES R R.exe)
+find_program(R_SCRIPT NAMES Rscript Rscript.exe)
+
+# If not found and we are on Windows, try to look for it in the default installation path
+if(WIN32 AND R_EXECUTABLE MATCHES "R_EXECUTABLE-NOTFOUND")
+  GET_FILENAME_COMPONENT(RX64PATH "C:\\Program Files\\R" REALPATH)
+  GET_FILENAME_COMPONENT(RX86PATH "C:\\Program Files (x86)\\R" REALPATH)
+  # default 64-bit Windows installation
+  if(EXISTS "${RX64PATH}")
+    SUBDIRLIST(SUBDIRS "${RX64PATH}")
+    foreach(subdir ${SUBDIRS})
+      if(${subdir} MATCHES "R[-]([0-9][.]).*")
+        set(R_VERSIONED_SUBDIR "${subdir}")
+        if(EXISTS "${RX64PATH}\\${R_VERSIONED_SUBDIR}\\bin\\x64\\R.exe")
+          set(R_EXECUTABLE "${RX64PATH}\\${R_VERSIONED_SUBDIR}\\bin\\x64\\R.exe")
+        endif()
+        if(EXISTS "${RX64PATH}\\${R_VERSIONED_SUBDIR}\\bin\\x64\\Rscript.exe")
+          set(R_SCRIPT "${RX64PATH}\\${R_VERSIONED_SUBDIR}\\bin\\x64\\Rscript.exe")
+        endif()
+        break()
+      endif()
+    endforeach()
+  # ...or the 32-bit installation
+  elseif(EXISTS "${RX86PATH}")
+    SUBDIRLIST(SUBDIRS "${RX86PATH}")
+    foreach(subdir ${SUBDIRS})
+      if(${subdir} MATCHES "R[-]([0-9][.]).*")
+        set(R_VERSIONED_SUBDIR "${subdir}")
+        if(EXISTS "${RX86PATH}\\${R_VERSIONED_SUBDIR}\\bin\\x86\\R.exe")
+          set(R_EXECUTABLE "${RX86PATH}\\${R_VERSIONED_SUBDIR}\\bin\\x86\\R.exe")
+        endif()
+        if(EXISTS "${RX86PATH}\\${R_VERSIONED_SUBDIR}\\bin\\x86\\Rscript.exe")
+          set(R_SCRIPT "${RX86PATH}\\${R_VERSIONED_SUBDIR}\\bin\\x86\\Rscript.exe")
+        endif()
+        break()
+      endif()
+    endforeach()
+  endif()
+endif()
+
+#---searching R installtion using R executable
 if(R_EXECUTABLE)
   execute_process(COMMAND ${R_EXECUTABLE} RHOME
                   OUTPUT_VARIABLE R_ROOT_DIR
@@ -35,6 +88,11 @@ if(R_EXECUTABLE)
   find_library(R_LIBRARY R
             HINTS ${R_ROOT_DIR}/lib
             DOC "R library (example libR.a, libR.dylib, etc.).")
+  # On Windows, this may not be defined. Fall back to the library
+  # folder that holds the DLLs.
+  if(R_LIBRARY MATCHES "R_LIBRARY-NOTFOUND" AND EXISTS "${R_ROOT_DIR}\\library")
+    set(R_LIBRARY "${R_ROOT_DIR}\\library")
+  endif()
 endif()
 
 #---setting include dirs and libraries

--- a/cmake/modules/FindR.cmake
+++ b/cmake/modules/FindR.cmake
@@ -14,7 +14,9 @@
 #  R_ROOT_DIR - As reported by R
 #  R_EXECUTABLE - the R executable
 #  R_SCRIPT - the Rscript executable, which runs R non-interactively
+#
 # Autor: Omar Andres Zapata Mesa 31/05/2013
+# Contributor: Blake Madden 2023-12-10
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   set(CMAKE_FIND_APPBUNDLE "LAST")


### PR DESCRIPTION
- On Windows, attempts to find R in the default installation paths if not found via `find_program`.
- Does the same for the `R_LIBRARY` variable, which may not be reported by the R executable on Windows.
- Adds an `R_SCRIPT` variable to provide the path to RScript. This is useful if the parent CMake script wants to call R non-interactively to run a script. Fixed a typo in the comments.

# This Pull request:

## Changes or fixes:

Adds support for CMake to find R on Windows.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (not necessary, but updated docs in the FindR script)