### PR TITLE
[cling] Replace llvm::Optional, llvm::None with their std equivalents

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -144,6 +144,7 @@ clang/LLVM technology.
 #include <utility>
 #include <vector>
 #include <functional>
+#include <optional>
 
 #ifndef R__WIN32
 #include <cxxabi.h>
@@ -1412,7 +1413,7 @@ TCling::TCling(const char *name, const char *title, const char* const argv[], vo
    }
 
    // Process externally passed arguments if present.
-   llvm::Optional<std::string> EnvOpt = llvm::sys::Process::GetEnv("EXTRA_CLING_ARGS");
+   std::optional<std::string> EnvOpt = llvm::sys::Process::GetEnv("EXTRA_CLING_ARGS");
    if (EnvOpt.has_value()) {
       StringRef Env(*EnvOpt);
       while (!Env.empty()) {
@@ -1422,9 +1423,8 @@ TCling::TCling(const char *name, const char *title, const char* const argv[], vo
       }
    }
 
-   auto GetEnvVarPath = [](const std::string &EnvVar,
-                       std::vector<std::string> &Paths) {
-      llvm::Optional<std::string> EnvOpt = llvm::sys::Process::GetEnv(EnvVar);
+   auto GetEnvVarPath = [](const std::string &EnvVar, std::vector<std::string> &Paths) {
+      std::optional<std::string> EnvOpt = llvm::sys::Process::GetEnv(EnvVar);
       if (EnvOpt.has_value()) {
          StringRef Env(*EnvOpt);
          while (!Env.empty()) {

--- a/core/metacling/src/TClingCallbacks.cxx
+++ b/core/metacling/src/TClingCallbacks.cxx
@@ -44,6 +44,8 @@
 #include "TClingUtils.h"
 #include "ClingRAII.h"
 
+#include <optional>
+
 using namespace clang;
 using namespace cling;
 using namespace ROOT::Internal;
@@ -414,7 +416,7 @@ bool TClingCallbacks::LookupObject(LookupResult &R, Scope *S) {
 
 bool TClingCallbacks::findInGlobalModuleIndex(DeclarationName Name, bool loadFirstMatchOnly /*=true*/)
 {
-   llvm::Optional<std::string> envUseGMI = llvm::sys::Process::GetEnv("ROOT_USE_GMI");
+   std::optional<std::string> envUseGMI = llvm::sys::Process::GetEnv("ROOT_USE_GMI");
    if (envUseGMI.has_value())
       if (!envUseGMI->empty() && !ROOT::FoundationUtils::ConvertEnvValueToBool(*envUseGMI))
          return false;

--- a/core/metacling/src/TClingCallbacks.h
+++ b/core/metacling/src/TClingCallbacks.h
@@ -13,6 +13,7 @@
 
 #include <stack>
 #include <string>
+#include <optional>
 
 namespace clang {
    class Decl;
@@ -126,8 +127,8 @@ public:
    void UnlockCompilationDuringUserCodeExecution(void *StateInfo) override;
 
 private:
-   bool tryAutoParseInternal(llvm::StringRef Name, clang::LookupResult &R,
-                            clang::Scope *S, clang::OptionalFileEntryRef FE = llvm::None);
+   bool tryAutoParseInternal(llvm::StringRef Name, clang::LookupResult &R, clang::Scope *S,
+                             clang::OptionalFileEntryRef FE = std::nullopt);
    bool tryFindROOTSpecialInternal(clang::LookupResult &R, clang::Scope *S);
    bool tryResolveAtRuntimeInternal(clang::LookupResult &R, clang::Scope *S);
    bool shouldResolveAtRuntime(clang::LookupResult &R, clang::Scope *S);

--- a/interpreter/cling/include/cling/MetaProcessor/MetaSema.h
+++ b/interpreter/cling/include/cling/MetaProcessor/MetaSema.h
@@ -16,7 +16,7 @@
 #include "clang/Basic/FileManager.h" // for DenseMap<FileEntry*>
 
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/Optional.h"
+#include <optional>
 
 namespace llvm {
   class StringRef;
@@ -153,7 +153,7 @@ namespace cling {
     ///
     ///\param[in] mode - either on/off or toggle.
     ///
-    void actOndebugCommand(llvm::Optional<int> mode) const;
+    void actOndebugCommand(std::optional<int> mode) const;
 
     ///\brief Prints out the the Debug information of the state changes.
     ///

--- a/interpreter/cling/lib/Interpreter/IncrementalCUDADeviceCompiler.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalCUDADeviceCompiler.cpp
@@ -27,6 +27,7 @@
 
 #include <algorithm>
 #include <bitset>
+#include <optional>
 #include <string>
 #include <system_error>
 
@@ -292,8 +293,8 @@ namespace cling {
     }
 
     // is not important, because PTX does not use any object format
-    llvm::Optional<llvm::Reloc::Model> RM =
-        llvm::Optional<llvm::Reloc::Model>(llvm::Reloc::Model::PIC_);
+    std::optional<llvm::Reloc::Model> RM =
+        std::optional<llvm::Reloc::Model>(llvm::Reloc::Model::PIC_);
 
     llvm::TargetOptions TO = llvm::TargetOptions();
 

--- a/interpreter/cling/lib/Interpreter/IncrementalJIT.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalJIT.cpp
@@ -31,6 +31,8 @@
 #include <llvm/Support/Host.h>
 #include <llvm/Target/TargetMachine.h>
 
+#include <optional>
+
 #ifdef __linux__
 #include <sys/stat.h>
 #endif
@@ -683,7 +685,7 @@ void* IncrementalJIT::getSymbolAddress(StringRef Name, bool IncludeHostSymbols){
   if (!IncludeHostSymbols)
     G.lock();
 
-  std::pair<llvm::StringMapIterator<llvm::NoneType>, bool> insertInfo;
+  std::pair<llvm::StringMapIterator<std::nullopt_t>, bool> insertInfo;
   if (!IncludeHostSymbols)
     insertInfo = m_ForbidDlSymbols.insert(Name);
 

--- a/interpreter/cling/lib/Interpreter/InterpreterCallbacks.cpp
+++ b/interpreter/cling/lib/Interpreter/InterpreterCallbacks.cpp
@@ -21,6 +21,8 @@
 #include "clang/Serialization/ASTDeserializationListener.h"
 #include "clang/Serialization/ASTReader.h"
 
+#include <optional>
+
 using namespace clang;
 
 namespace cling {
@@ -154,7 +156,7 @@ namespace cling {
       return m_Source->getModule(ID);
     }
 
-    virtual llvm::Optional<ASTSourceDescriptor>
+    virtual std::optional<ASTSourceDescriptor>
     getSourceDescriptor(unsigned ID) override {
       return m_Source->getSourceDescriptor(ID);
     }

--- a/interpreter/cling/lib/MetaProcessor/MetaParser.cpp
+++ b/interpreter/cling/lib/MetaProcessor/MetaParser.cpp
@@ -18,9 +18,10 @@
 #include "cling/Utils/Output.h"
 #include "cling/Utils/Paths.h"
 
-#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Path.h"
+
+#include <optional>
 
 namespace cling {
 
@@ -433,7 +434,7 @@ namespace cling {
   bool MetaParser::isdebugCommand() {
     if (getCurTok().is(tok::ident) &&
         getCurTok().getIdent().equals("debug")) {
-      llvm::Optional<int> mode;
+      std::optional<int> mode;
       consumeToken();
       skipWhitespace();
       if (getCurTok().is(tok::constant))

--- a/interpreter/cling/lib/MetaProcessor/MetaSema.cpp
+++ b/interpreter/cling/lib/MetaProcessor/MetaSema.cpp
@@ -250,7 +250,7 @@ namespace cling {
       m_Interpreter.enableRawInput(mode);
   }
 
-  void MetaSema::actOndebugCommand(llvm::Optional<int> mode) const {
+  void MetaSema::actOndebugCommand(std::optional<int> mode) const {
     constexpr clang::codegenoptions::DebugInfoKind DebugInfo[] = {
       clang::codegenoptions::NoDebugInfo,
       clang::codegenoptions::LocTrackingOnly,


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #14205 

