### PR TITLE
[ci] Enable Pythia8 on Fedora + C++20

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/fedora39.txt
+++ b/.github/workflows/root-ci-config/buildconfig/fedora39.txt
@@ -1,3 +1,2 @@
 builtin_nlohmannjson=On
 builtin_vdt=On
-pythia8=Off

--- a/.github/workflows/root-ci-config/buildconfig/fedora40.txt
+++ b/.github/workflows/root-ci-config/buildconfig/fedora40.txt
@@ -2,4 +2,3 @@ builtin_zstd=ON
 builtin_zlib=ON
 builtin_nlohmannjson=On
 builtin_vdt=On
-pythia8=Off


### PR DESCRIPTION
There was an update to Pythia8 8.310 with my fix for compatibility with C++20.