### PR TITLE
[cling] Implement value printing for std::source_location

### DIFF
--- a/interpreter/cling/include/cling/Interpreter/RuntimePrintValue.h
+++ b/interpreter/cling/include/cling/Interpreter/RuntimePrintValue.h
@@ -17,6 +17,12 @@
 #include <cling/Interpreter/Visibility.h>
 
 #include <memory>
+#if __cplusplus >= 202002L
+#include <version>
+#endif
+#ifdef __cpp_lib_source_location
+#include <source_location>
+#endif
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -140,6 +146,11 @@ namespace cling {
   inline std::string printValue(char const (*val)[N]) {
     return toUTF8(reinterpret_cast<const char * const>(val), N, 1);
   }
+
+#ifdef __cpp_lib_source_location
+  CLING_LIB_EXPORT
+  std::string printValue(const std::source_location* location);
+#endif
 
   // cling::Value
   CLING_LIB_EXPORT

--- a/interpreter/cling/lib/Interpreter/ValuePrinter.cpp
+++ b/interpreter/cling/lib/Interpreter/ValuePrinter.cpp
@@ -40,6 +40,12 @@
 #include "llvm/Support/Format.h"
 
 #include <locale>
+#if __cplusplus >= 202002L
+#include <version>
+#endif
+#ifdef __cpp_lib_source_location
+#include <source_location>
+#endif
 #include <string>
 
 // GCC 4.x doesn't have the proper UTF-8 conversion routines. So use the
@@ -575,6 +581,17 @@ namespace cling {
   std::string printValue(const wchar_t *Val) {
     return toUnicode(Val, 'L', 'x');
   }
+
+#ifdef __cpp_lib_source_location
+  CLING_LIB_EXPORT
+  std::string printValue(const std::source_location* location) {
+    cling::ostrstream strm;
+    strm << location->file_name() << ":" << location->line() << ":"
+         << location->function_name();
+    return strm.str().str();
+  }
+#endif
+
 } // end namespace cling
 
 namespace {

--- a/interpreter/cling/test/Prompt/ValuePrinter/SourceLocation.C
+++ b/interpreter/cling/test/Prompt/ValuePrinter/SourceLocation.C
@@ -1,0 +1,29 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+
+//------------------------------------------------------------------------------
+// RUN: cat %s | %cling | FileCheck %s
+
+#include <iostream>
+#if __cplusplus >= 202002L
+#include <version>
+#endif
+
+#ifndef __cpp_lib_source_location
+// Hack to prevent failure if __cpp_lib_source_location feature does not exist!
+std::cout << "(std::source_location) ";
+std::cout << "CHECK_SRCLOC:42:std::source_location getsrcloc()\n";
+#else
+#include <source_location>
+std::source_location getsrcloc() {
+#line 42 "CHECK_SRCLOC"
+  return std::source_location::current();
+}
+getsrcloc()
+#endif
+// CHECK: (std::source_location)
+// CHECK: CHECK_SRCLOC:42:std::source_location getsrcloc()


### PR DESCRIPTION
# This Pull request:

Implements value printing for std::source_location.

## Changes or fixes:

Running `std::source_location::current()` 
now shows 
`(std::source_location) filename:line:function_name`. 

Using `std::source_location` requires C++20: https://en.cppreference.com/w/cpp/utility/source_location

```
root [0] std::source_location::current()
(std::source_location) ROOT_prompt_0:1:__cling_Un1Qu30
```

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #14211 

