### PR TITLE
[cling] Use deduction guides for llvm::ArrayRef

### DIFF
--- a/core/metacling/src/TClingCallbacks.cxx
+++ b/core/metacling/src/TClingCallbacks.cxx
@@ -538,8 +538,7 @@ bool TClingCallbacks::LookupObject(const DeclContext* DC, DeclarationName Name) 
       llvm::SmallVector<NamedDecl*, 4> lookupResults;
       for(LookupResult::iterator I = R.begin(), E = R.end(); I < E; ++I)
          lookupResults.push_back(*I);
-      UpdateWithNewDecls(DC, Name, llvm::makeArrayRef(lookupResults.data(),
-                                                      lookupResults.size()));
+      UpdateWithNewDecls(DC, Name, llvm::ArrayRef(lookupResults.data(), lookupResults.size()));
       return true;
    }
    return false;

--- a/interpreter/cling/lib/Interpreter/LookupHelper.cpp
+++ b/interpreter/cling/lib/Interpreter/LookupHelper.cpp
@@ -1149,8 +1149,9 @@ namespace cling {
           S.AddMethodCandidate(MD, I.getPair(), MD->getParent(),
                                /*ObjectType=*/ClassType,
                                /*ObjectClassification=*/ObjExprClassification,
-                   llvm::makeArrayRef<Expr*>(GivenArgs.data(), GivenArgs.size()),
-                                   Candidates);
+                               llvm::ArrayRef<Expr*>(GivenArgs.data(),
+                                                     GivenArgs.size()),
+                               Candidates);
         }
         else {
           const FunctionProtoType* Proto = dyn_cast<FunctionProtoType>(
@@ -1164,7 +1165,8 @@ namespace cling {
              continue;
           }
           S.AddOverloadCandidate(FD, I.getPair(),
-                   llvm::makeArrayRef<Expr*>(GivenArgs.data(), GivenArgs.size()),
+                                 llvm::ArrayRef<Expr*>(GivenArgs.data(),
+                                                       GivenArgs.size()),
                                  Candidates);
         }
       }
@@ -1175,19 +1177,20 @@ namespace cling {
             !isa<CXXConstructorDecl>(FTD->getTemplatedDecl())) {
           // Class method template, not static, not a constructor, so has
           // an implicit object argument.
-          S.AddMethodTemplateCandidate(FTD, I.getPair(),
-                                      cast<CXXRecordDecl>(FTD->getDeclContext()),
-                         const_cast<TemplateArgumentListInfo*>(FuncTemplateArgs),
-                                       /*ObjectType=*/ClassType,
-                                  /*ObjectClassification=*/ObjExprClassification,
-                   llvm::makeArrayRef<Expr*>(GivenArgs.data(), GivenArgs.size()),
-                                       Candidates);
+          S.AddMethodTemplateCandidate(
+              FTD, I.getPair(), cast<CXXRecordDecl>(FTD->getDeclContext()),
+              const_cast<TemplateArgumentListInfo*>(FuncTemplateArgs),
+              /*ObjectType=*/ClassType,
+              /*ObjectClassification=*/ObjExprClassification,
+              llvm::ArrayRef<Expr*>(GivenArgs.data(), GivenArgs.size()),
+              Candidates);
         }
         else {
-          S.AddTemplateOverloadCandidate(FTD, I.getPair(),
-                const_cast<TemplateArgumentListInfo*>(FuncTemplateArgs),
-                llvm::makeArrayRef<Expr*>(GivenArgs.data(), GivenArgs.size()),
-                Candidates, /*SuppressUserConversions=*/false);
+          S.AddTemplateOverloadCandidate(
+              FTD, I.getPair(),
+              const_cast<TemplateArgumentListInfo*>(FuncTemplateArgs),
+              llvm::ArrayRef<Expr*>(GivenArgs.data(), GivenArgs.size()),
+              Candidates, /*SuppressUserConversions=*/false);
         }
       }
       else {

--- a/interpreter/cling/lib/Utils/AST.cpp
+++ b/interpreter/cling/lib/Utils/AST.cpp
@@ -114,8 +114,7 @@ namespace utils {
 
     Expr* result = nullptr;
     if (CompoundStmt* CS = dyn_cast<CompoundStmt>(FD->getBody())) {
-      ArrayRef<Stmt*> Stmts
-        = llvm::makeArrayRef(CS->body_begin(), CS->size());
+      ArrayRef<Stmt*> Stmts(CS->body_begin(), CS->size());
       int indexOfLastExpr = Stmts.size();
       while(indexOfLastExpr--) {
         if (!isa<NullStmt>(Stmts[indexOfLastExpr]))


### PR DESCRIPTION
# This Pull request:

Removes the usage of `llvm::makeArrayRef` in cling and use deduction guides (https://reviews.llvm.org/D140896) instead.

## Changes or fixes:


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #14219 

