### PR TITLE
[RF] Some documentation fixes

### DIFF
--- a/roofit/doc/index.md
+++ b/roofit/doc/index.md
@@ -8,3 +8,4 @@ For developers, there is also the \ref roofit_dev_docs, which serves as a refere
 
 \defgroup roofit_dev_docs RooFit Developer Documentation
 \brief How-to guides on how to extend \ref Roofitmain with custom classes or to work on %RooFit itself.
+\ingroup Roofitmain

--- a/roofit/histfactory/inc/RooStats/HistFactory/Sample.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/Sample.h
@@ -154,8 +154,8 @@ protected:
   /// Properties
   RooStats::HistFactory::StatError fStatError;
 
-  bool fNormalizeByTheory;
-  bool fStatErrorActivate;
+  bool fNormalizeByTheory = false;
+  bool fStatErrorActivate = false;
 
 
   /// The Nominal Shape

--- a/roofit/histfactory/src/Sample.cxx
+++ b/roofit/histfactory/src/Sample.cxx
@@ -17,9 +17,9 @@
 #include "RooStats/HistFactory/Sample.h"
 #include "RooStats/HistFactory/HistFactoryException.h"
 
-RooStats::HistFactory::Sample::Sample() : fNormalizeByTheory(false), fStatErrorActivate(false) {}
+RooStats::HistFactory::Sample::Sample() {}
 
-// copy constructor (important for python)
+// copy constructor (important for Python)
 RooStats::HistFactory::Sample::Sample(const Sample& other) :
   fName(other.fName), fInputFile(other.fInputFile),
   fHistoName(other.fHistoName), fHistoPath(other.fHistoPath),

--- a/roofit/roofitcore/inc/RooWorkspace.h
+++ b/roofit/roofitcore/inc/RooWorkspace.h
@@ -112,8 +112,6 @@ public:
   RooAbsArg* arg(RooStringView name) const ;
   RooAbsArg* fundArg(RooStringView name) const ;
   RooArgSet argSet(RooStringView nameList) const ;
-  TIterator* componentIterator() const
-  R__DEPRECATED(6,34, "Better iterate over RooWorkspace::components() with range-based loop instead of using RooWorkspace::componentIterator().");
   const RooArgSet& components() const { return _allOwnedNodes ; }
   TObject* genobj(RooStringView name) const ;
   TObject* obj(RooStringView name) const ;
@@ -282,6 +280,13 @@ public:
     RooArgSet _sandboxNodes; ///<! Sandbox for incoming objects in a transaction
 
     ClassDefOverride(RooWorkspace, 8) // Persistable project container for (composite) pdfs, functions, variables and datasets
+
+public:
+   // The deprecated functions need to come last, because the R__DEPRECATED
+   // macro is beaking doxygen in some cases.
+   TIterator *componentIterator() const R__DEPRECATED(6, 34,
+                                                      "Better iterate over RooWorkspace::components() with range-based "
+                                                      "loop instead of using RooWorkspace::componentIterator().");
 } ;
 
 #endif

--- a/roofit/roofitcore/src/RooFit/Evaluator.cxx
+++ b/roofit/roofitcore/src/RooFit/Evaluator.cxx
@@ -13,7 +13,7 @@
 
 /**
 \file Evaluator.cxx
-\class Evaluator
+\class RooFit::Evaluator
 \ingroup Roofitcore
 
 Evaluates a RooAbsReal object in other ways than recursive graph

--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -714,7 +714,7 @@ bool RooWorkspace::import(const RooAbsArg& inArg,
 
 
 ////////////////////////////////////////////////////////////////////////////////
-///  Import a dataset (RooDataSet or RooDataHist) into the work space. The workspace will contain a copy of the data.
+///  Import a dataset (RooDataSet or RooDataHist) into the workspace. The workspace will contain a copy of the data.
 ///  The dataset and its variables can be renamed upon insertion with the options below
 ///
 ///  <table>
@@ -896,7 +896,7 @@ bool RooWorkspace::defineSetInternal(const char *name, const RooArgSet &aset)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Define a named set in the work space through a comma separated list of
+/// Define a named set in the workspace through a comma separated list of
 /// names of objects already in the workspace
 
 bool RooWorkspace::defineSet(const char* name, const char* contentList)
@@ -931,7 +931,7 @@ bool RooWorkspace::defineSet(const char* name, const char* contentList)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Define a named set in the work space through a comma separated list of
+/// Define a named set in the workspace through a comma separated list of
 /// names of objects already in the workspace
 
 bool RooWorkspace::extendSet(const char* name, const char* newContents)


### PR DESCRIPTION
  * More functions with `R__DEPRECATED` at the end of RooWorkspace.h to not break doxygen (thanks @will-cern for noticing the problem!)

  * Put RooFit developer docs in `Roofitmain` doxygen group

  * Don't forget namespace in `\class RooFit::Evaluator`

  * The Python programming language name is capitalized

  * Consistently use "workspace" instead of "work space"