### PR TITLE
Add a safety check on `std::multimap::empty()`

### DIFF
--- a/gui/browsable/inc/ROOT/Browsable/RProvider.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RProvider.hxx
@@ -145,6 +145,8 @@ private:
    template<class Map_t>
    void CleanThis(Map_t &fmap)
    {
+      if (fmap.empty())
+         return;
       auto fiter = fmap.begin();
       while (fiter != fmap.end()) {
          if (fiter->second.provider == this)


### PR DESCRIPTION
Prevent a potential crash on Windows in Debug mode when the multimap is empty