### PR TITLE
[DF][NFC] Add missing documentation to several RDF classes. 

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RDatasetSpec.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDatasetSpec.hxx
@@ -41,7 +41,7 @@ and, optionally, the metadata information (using the RMetaData class objects).
 Adding global friend trees and/or setting the range of events to be processed
 are also available.
 
-Note, there exists yet another method to build RDataFrame from the dataset information using the JSON file format: ROOT::RDataFrame FromSpec(const std::string &jsonFile). 
+Note, there exists yet another method to build RDataFrame from the dataset information using the JSON file format: \ref FromSpec(const std::string &jsonFile) "FromSpec()". 
 */
 
 class RDatasetSpec {

--- a/tree/dataframe/inc/ROOT/RDF/RMetaData.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RMetaData.hxx
@@ -32,11 +32,21 @@ namespace Experimental {
 /**
 \class ROOT::RDF::Experimental::RMetaData
 \ingroup dataframe
-\brief Class behaving as a heterogenuous dictionary to store dataset metadata
+\brief Class behaving as a heterogenuous dictionary to store the metadata of a dataset.
 
- This class should be passed to an RSample object which represents a single dataset sample.
- Once a dataframe is built with RMetaData object, it could be accessed via DefinePerSample.
-*/
+ The supported types of the metadata are: std::string, int and double. An example of creating the RMetaData object:
+ ~~~{.cpp}
+ ROOT::RDF::Experimental::RMetaData meta;
+ meta.Add("sample_name", "name"");
+ meta.Add("luminosity", 10064);
+ meta.Add("xsecs", 1.0);
+ ~~~
+
+ The RMetaData object is passed to an RSample object which represents a single dataset sample.
+
+ A dataframe built with the RMetaData object can be accessed with the \ref ROOT::RDF::RInterface< Proxied,
+DS_t>::DefinePerSample "DefinePerSample()" method.
+**/
 class RMetaData {
 public:
 

--- a/tree/dataframe/inc/ROOT/RDF/RSample.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RSample.hxx
@@ -22,11 +22,22 @@ namespace Experimental {
 
 /**
 \ingroup dataframe
-\brief Class representing a sample (grouping of trees (and their fileglobs) and (optional) metadata)
+\brief Class representing a sample which is a grouping of trees and their fileglobs, and, optionally, the sample's
+metadata information via the RMetaData object.
 
- This class should be passed to RDatasetSpec in order to build a RDataFrame.
+ The class is passed to an RDatasetSpec object in order to build an RDataFrame.
+
+ For example, an RSample object can be built as follows:
+ ~~~{.cpp}
+ // First, create the RMetaData object (to, optionally, add to the sample)
+ ROOT::RDF::Experimental::RMetaData meta;
+ meta.Add("sample_name", "name"");
+ // Create an RSample with metadata information
+ ROOT::RDF::Experimental::RSample mySample("mySampleName", "outputTree1", "outputFile.root", meta);
+ ~~~
 */
 class RSample {
+   /// Name of the sample.
    std::string fSampleName;
    /**
     * A list of names of trees.
@@ -40,9 +51,11 @@ class RSample {
     * They can contain the globbing characters supported by TChain. See TChain::Add for more information.
     */
    std::vector<std::string> fFileNameGlobs;
+   /// An instance of the RMetaData class.
    RMetaData fMetaData;
 
-   unsigned int fSampleId{0}; // global sample index, set inside of the RDatasetSpec
+   /// Global sample index, set inside of the RDatasetSpec.
+   unsigned int fSampleId{0};
 
 public:
    RSample(RSample &&) = default;

--- a/tree/dataframe/inc/ROOT/RDF/RSampleInfo.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RSampleInfo.hxx
@@ -25,7 +25,7 @@ namespace ROOT {
 namespace RDF {
 
 /// This type represents a sample identifier, to be used in conjunction with RDataFrame features such as
-/// DefinePerSample() and per-sample callbacks.
+/// \ref ROOT::RDF::RInterface< Proxied, DS_t >::DefinePerSample "DefinePerSample()" and per-sample callbacks.
 ///
 /// When the input data comes from a TTree, the string representation of RSampleInfo (which is returned by AsString()
 /// and that can be queried e.g. with Contains()) is of the form "<filename>/<treename>".
@@ -59,51 +59,56 @@ public:
    RSampleInfo &operator=(RSampleInfo &&) = default;
    ~RSampleInfo() = default;
 
+   /// @brief Get the name of the sample as a string.
    const std::string &GetSampleName() const
    {
       ThrowIfNoSample();
       return fSample->GetSampleName();
    }
 
+   /// @brief Get the sample id as an int.
    unsigned int GetSampleId() const
    {
       ThrowIfNoSample();
       return fSample->GetSampleId();
    }
 
+   /// @brief Return the metadata value of type int given the key.
    int GetI(const std::string &key) const
    {
       ThrowIfNoSample();
       return fSample->GetMetaData().GetI(key);
    }
 
+   /// @brief Return the metadata value of type double given the key.
    double GetD(const std::string &key) const
    {
       ThrowIfNoSample();
       return fSample->GetMetaData().GetD(key);
    }
 
+   /// @brief Return the metadata value of type string given the key.
    std::string GetS(const std::string &key) const
    {
       ThrowIfNoSample();
       return fSample->GetMetaData().GetS(key);
    }
 
-   /// Check whether the sample name contains the given substring.
+   /// @brief Check whether the sample name contains the given substring.
    bool Contains(std::string_view substr) const
    {
       // C++14 needs the conversion from std::string_view to std::string
       return fID.find(std::string(substr)) != std::string::npos;
    }
 
-   /// Check whether the sample name is empty.
+   /// @brief Check whether the sample name is empty.
    ///
    /// This is the case e.g. when using a RDataFrame with no input data, constructed as `RDataFrame(nEntries)`.
    bool Empty() const {
       return fID.empty();
    }
 
-   /// Return a string representation of the sample name.
+   /// @brief Return a string representation of the sample name.
    ///
    /// The representation is of the form "<filename>/<treename>" if the input data comes from a TTree or a TChain.
    const std::string &AsString() const
@@ -111,20 +116,21 @@ public:
       return fID;
    }
 
-   /// Return the entry range in this sample that is being taken into consideration.
+   /// @brief Return the entry range in the sample that is being taken into consideration.
    ///
    /// Multiple multi-threading tasks might process different entry ranges of the same sample.
    std::pair<ULong64_t, ULong64_t> EntryRange() const { return fEntryRange; }
 
-   /// Return the number of entries of this sample that is being taken into consideration.
+   /// @brief Return the number of entries of this sample that is being taken into consideration.
    ULong64_t NEntries() const { return fEntryRange.second - fEntryRange.first; }
 
    bool operator==(const RSampleInfo &other) const { return fID == other.fID; }
    bool operator!=(const RSampleInfo &other) const { return !(*this == other); }
 };
 
-/// The type of a data-block callback, registered with a RDataFrame computation graph via e.g.
-/// DefinePerSample() or by certain actions (e.g. Snapshot()).
+/// The type of a data-block callback, registered with an RDataFrame computation graph via e.g.  \ref
+/// ROOT::RDF::RInterface< Proxied, DS_t >::DefinePerSample "DefinePerSample()" or by certain actions (e.g. \ref
+/// ROOT::RDF::RInterface<Proxied,DataSource>::Snapshot "Snapshot()").
 using SampleCallback_t = std::function<void(unsigned int, const ROOT::RDF::RSampleInfo &)>;
 
 } // namespace RDF

--- a/tree/dataframe/inc/ROOT/RDFHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDFHelpers.hxx
@@ -269,7 +269,32 @@ RResultMap<T> VariationsFor(RResultPtr<T> resPtr)
 using SnapshotPtr_t = ROOT::RDF::RResultPtr<ROOT::RDF::RInterface<ROOT::Detail::RDF::RLoopManager, void>>;
 SnapshotPtr_t VariationsFor(SnapshotPtr_t resPtr);
 
+/// \brief Add ProgressBar to a ROOT::RDF::RNode
+/// \param[in] df RDataFrame node at which ProgressBar is called.
+///
+/// The ProgressBar can be added not only at the RDataFrame head node, but also at any any computational node,
+/// such as Filter or Define.
+/// ###Example usage:
+/// ~~~{.cpp}
+/// ROOT::RDataFrame df("tree", "file.root");
+/// auto df_1 = ROOT::RDF::RNode(df.Filter("x>1"));
+/// ROOT::RDF::Experimental::AddProgressBar(df_1);
+/// ~~~
 void AddProgressBar(ROOT::RDF::RNode df);
+
+/// \brief Add ProgressBar to an RDataFrame
+/// \param[in] df RDataFrame for which ProgressBar is called.
+///
+/// This function adds a ProgressBar to display the event statistics in the terminal every
+/// \b m events and every \b n seconds, including elapsed time, currently processed file,
+/// currently processed events, the rate of event processing
+/// and an estimated remaining time (per file being processed).
+/// ProgressBar should be added after the dataframe object (df) is created first:
+/// ~~~{.cpp}
+/// ROOT::RDataFrame df("tree", "file.root");
+/// ROOT::RDF::Experimental::AddProgressBar(df);
+/// ~~~
+/// For more details see ROOT::RDF::Experimental::ProgressHelper Class.
 void AddProgressBar(ROOT::RDataFrame df);
 
 class ProgressBarAction;

--- a/tree/dataframe/src/RDatasetSpec.cxx
+++ b/tree/dataframe/src/RDatasetSpec.cxx
@@ -117,8 +117,8 @@ std::vector<RSample> RDatasetSpec::MoveOutSamples()
 /// Note that adding this metadata information to the RSample object is optional.
 /// ~~~{.cpp}
 /// // Create the RMetaData object which will be used to create the RSample object.
-/// ROOT::RDF::RMetaData meta;
-/// meta.Add("sample_name", name);
+/// ROOT::RDF::Experimental::RMetaData meta;
+/// meta.Add("sample_name", "name");
 /// // Create the RSample object "mySample" with sample name "mySampleName", tree name "outputTree1",
 /// // file name "outputFile.root" and associated metadata information.
 /// ROOT::RDF::Experimental::RSample mySample("mySampleName", "outputTree1", "outputFile.root", meta);

--- a/tree/dataframe/src/RMetaData.cxx
+++ b/tree/dataframe/src/RMetaData.cxx
@@ -36,77 +36,109 @@ RMetaData &RMetaData::operator=(RMetaData &&) = default;
 
 RMetaData::~RMetaData() = default;
 
+/// @brief Add an RMetaData class instance.
+/// @param[in] key input key for a given RMetaData instance.
+/// @param[in] val value for a given RMetaData instance of type int.
 void RMetaData::Add(const std::string &key, int val)
 {
    fJson->payload[key] = val;
 }
 
+/// @brief Add an RMetaData class instance.
+/// @param[in] key input key for a given RMetaData instance.
+/// @param[in] val metadata value for a given RMetaData instance of type double.
 void RMetaData::Add(const std::string &key, double val)
 {
    fJson->payload[key] = val;
 }
 
+/// @brief Add an RMetaData class instance
+/// @param[in] key input key for a given RMetaData instance.
+/// @param[in] val metadata value for of type string.
 void RMetaData::Add(const std::string &key, const std::string &val)
 {
    fJson->payload[key] = val;
 }
 
+/// @brief Dump the value of the metadata value given the key.
+/// @param[in] key input key for a given RMetaData instance.
+/// @return metadata value (as a string) associated with the input key, irrelevant of the actual type of the metadata
+/// value.
 std::string RMetaData::Dump(const std::string &key) const
 {
    return fJson->payload[key].dump();
 }
-
+/// @brief Return the metadata value of type int given the key, or an error if the metadata value is of a non-int type.
+/// @param[in] key input key for a given RMetaData instance.
 int RMetaData::GetI(const std::string &key) const
 {
    if (!fJson->payload.contains(key))
       throw std::logic_error("No key with name " + key + " in the metadata object.");
    if (!fJson->payload[key].is_number_integer())
-      throw std::logic_error("Key " + key + " is not of type int.");
+      throw std::logic_error("Metadata value found at key '" + key + "' is not of type int.");
    return fJson->payload[key].get<int>();
 }
-
+/// @brief Return the metadata value of type double given the key, or an error if the metadata value is of a non-double
+/// type.
+/// @param[in] key input key for a given RMetaData instance.
 double RMetaData::GetD(const std::string &key) const
 {
    if (!fJson->payload.contains(key))
       throw std::logic_error("No key with name " + key + " in the metadata object.");
    if (!fJson->payload[key].is_number_float())
-      throw std::logic_error("Key " + key + " is not of type double.");
+      throw std::logic_error("Metadata value found at key '" + key + "' is not of type double.");
    return fJson->payload[key].get<double>();
 }
 
+/// @brief Return the metadata value of type string given the key, or an error if the metadata value is of a non-string
+/// type.
+/// @param[in] key input key for a given RMetaData instance.
 std::string RMetaData::GetS(const std::string &key) const
 {
    if (!fJson->payload.contains(key))
       throw std::logic_error("No key with name " + key + " in the metadata object.");
    if (!fJson->payload[key].is_string())
-      throw std::logic_error("Key " + key + " is not of type string.");
+      throw std::logic_error("Metadata value found at key '" + key + "' is not of type string.");
    return fJson->payload[key].get<std::string>();
 }
-
+/// @brief Return the metadata value of type int given the key, a default int metadata value if the key is not found, or
+/// an error if the metadata value is of a non-int type.
+/// @param[in] key input key for a given RMetaData instance.
+/// @param[in] defaultVal metadata value of type int which is read as default while a given key cannot be found in the
+/// dataset.
 int RMetaData::GetI(const std::string &key, int defaultVal) const
 {
    if (!fJson->payload.contains(key))
       return defaultVal;
    if (!fJson->payload[key].is_number_integer())
-      throw std::logic_error("Key " + key + " is not of type int.");
+      throw std::logic_error("Metadata value found at key '" + key + "' is not of type int.");
    return fJson->payload[key].get<int>();
 }
-
+/// @brief Return the metadata value of type int given the key, a default int metadata value if the key is not found, or
+/// an error if the metadata value is of a non-double type.
+/// @param[in] key input key for a given RMetaData instance.
+/// @param[in] defaultVal metadata value of type double which is read as default while a given key cannot be found in
+/// the dataset.
 double RMetaData::GetD(const std::string &key, double defaultVal) const
 {
    if (!fJson->payload.contains(key))
       return defaultVal;
    if (!fJson->payload[key].is_number_float())
-      throw std::logic_error("Key " + key + " is not of type double.");
+      throw std::logic_error("Metadata value found at key '" + key + "' is not of type double.");
    return fJson->payload[key].get<double>();
 }
 
+/// @brief Return the metadata value of type int given the key, a default int metadata value if the key is not found, or
+/// an error if the metadata value is of a non-string type.
+/// @param[in] key input key for a given RMetaData instance.
+/// @param[in] defaultVal metadata value of type string which is read as default while a given key cannot be found in
+/// the dataset.
 const std::string RMetaData::GetS(const std::string &key, const std::string &defaultVal) const
 {
    if (!fJson->payload.contains(key))
       return defaultVal;
    if (!fJson->payload[key].is_string())
-      throw std::logic_error("Key " + key + " is not of type string.");
+      throw std::logic_error("Metadata value found at key '" + key + "' is not of type string.");
    return fJson->payload[key].get<std::string>();
 }
 

--- a/tree/dataframe/src/RSample.cxx
+++ b/tree/dataframe/src/RSample.cxx
@@ -71,21 +71,31 @@ RSample::RSample(const std::string &sampleName, const std::vector<std::string> &
    }
 }
 
+/// @brief Get the name of the sample (RSample object).
 const std::string &RSample::GetSampleName() const
 {
    return fSampleName;
 }
 
+/// @brief Get the collection of the tree names associated with the sample.
 const std::vector<std::string> &RSample::GetTreeNames() const
 {
    return fTreeNames;
 }
 
+/// @brief Get the collection of the filename globs associated with the sample.
 const std::vector<std::string> &RSample::GetFileNameGlobs() const
 {
    return fFileNameGlobs;
 }
 
+/// @brief Get an instance of the RMetaData class.
+///
+/// Once this is done, the further access to the RMetaData information is granted, for example
+/// (given the metadata has a key "sample_name" that has an associated value of type string):
+/// ~~~{.cpp}
+/// mySample.GetMetadata().GetS("sample_name");
+/// ~~~
 const RMetaData &RSample::GetMetaData() const
 {
    return fMetaData;

--- a/tutorials/dataframe/df106_HiggsToFourLeptons.C
+++ b/tutorials/dataframe/df106_HiggsToFourLeptons.C
@@ -86,7 +86,7 @@ void df106_HiggsToFourLeptons()
 
    // Perform the analysis
    // Access metadata information that is stored in the JSON config file of the RDataFrame
-   // The metadata contained in the JSON file is accessible within a `DefinePerSample` call, through the `RDFSampleInfo`
+   // The metadata contained in the JSON file is accessible within a `DefinePerSample` call, through the `RSampleInfo`
    // class
    auto df_analysis =
       df.DefinePerSample("xsecs", [](unsigned int slot, const RSampleInfo &id) { return id.GetD("xsecs"); })

--- a/tutorials/dataframe/df106_HiggsToFourLeptons.py
+++ b/tutorials/dataframe/df106_HiggsToFourLeptons.py
@@ -33,7 +33,7 @@ df = ROOT.RDF.Experimental.FromSpec(dataset_spec)  # Creates a single dataframe 
 ROOT.RDF.Experimental.AddProgressBar(df)
 
 # Access metadata information that is stored in the JSON config file of the RDataFrame.
-# The metadata contained in the JSON file is accessible within a `DefinePerSample` call, through the `RDFSampleInfo` class.
+# The metadata contained in the JSON file is accessible within a `DefinePerSample` call, through the `RSampleInfo` class.
 df = df.DefinePerSample("xsecs", 'rdfsampleinfo_.GetD("xsecs")')
 df = df.DefinePerSample("lumi", 'rdfsampleinfo_.GetD("lumi")')
 df = df.DefinePerSample("sumws", 'rdfsampleinfo_.GetD("sumws")')


### PR DESCRIPTION
Several of the RDF classes (RMetaData, RSample, RSampleInfo) were missing some of the documentation and examples of usage. Additionally, in the process of fixing those noticed a few typos in RDatasetSpec and df106 tutorials. 