### PR TITLE
[RF][HF] Ensure globalObservables is always created, even if no lumiError

### DIFF
--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -832,6 +832,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
       constraintTermNames.push_back("lumiConstraint");
     } else {
       proto.var("Lumi")->setConstant();
+      proto.defineSet("globalObservables",RooArgSet()); // create empty set as is assumed it exists later
     }
     //proto.factory("SigXsecOverSM[1.,0.5,1..8]");
     ///////////////////////////////////


### PR DESCRIPTION
I noticed that later bits of the code assume globalObservables set exists, so we should create it, even if it is empty at this point in time
