### PR TITLE
[webgui] disable rootrc parameters for web-based widgets, disable --web flag

### DIFF
--- a/core/base/inc/TROOT.h
+++ b/core/base/inc/TROOT.h
@@ -123,10 +123,10 @@ protected:
    Int_t           fTimer;                  ///< Timer flag
    std::atomic<TApplication*> fApplication; ///< Pointer to current application
    TInterpreter    *fInterpreter;           ///< Command interpreter
-   Bool_t          fBatch;                  ///< True if session without graphics
+   Bool_t          fBatch = kTRUE;          ///< True if session without graphics
    TString         fWebDisplay;             ///< If not empty it defines where web graphics should be rendered (cef, qt5, browser...)
-   Bool_t          fIsWebDisplay;           ///< True if session with graphics on web
-   Bool_t          fIsWebDisplayBatch;      ///< True if session with graphics on web and batch mode
+   Bool_t          fIsWebDisplay = kFALSE;  ///< True if session with graphics on web
+   Bool_t          fIsWebDisplayBatch = kFALSE; ///< True if session with graphics on web and batch mode
    Bool_t          fEditHistograms;         ///< True if histograms can be edited with the mouse
    Bool_t          fFromPopUp;              ///< True if command executed from a popup menu
    Bool_t          fMustClean;              ///< True if object destructor scans canvases

--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -405,7 +405,16 @@ void TApplication::GetOptions(Int_t *argc, char **argv)
          // the web mode is requested
          const char *opt = argv[i] + 5;
          argv[i] = null;
-         gROOT->SetWebDisplay((*opt == '=') ? opt + 1 : "");
+         if (strcmp(opt, "=off") == 0)
+            gROOT->SetWebDisplay("off");
+         else {
+            printf("\nWARNING!\n");
+            printf("Web mode switch --web is disabled for security reason.\n");
+            printf("See https://root.cern/about/security/#2023-11-26-open-port-for-control-of-web-gui-allows-read-and-write-access-to-file-system for more information.\n");
+            printf("For environments controlling the security issues you can enable web display by calling\n");
+            printf("gROOT->SetWebDisplay(); in ROOT prompt or in startup scripts\n\n");
+            // gROOT->SetWebDisplay((*opt == '=') ? opt + 1 : "");
+         }
       } else if (!strcmp(argv[i], "-e")) {
          argv[i] = null;
          ++i;

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -817,9 +817,19 @@ TROOT::TROOT(const char *name, const char *title, VoidFuncPtr_t *initfunc)
    TStyle::BuildStyles();
    SetStyle(gEnv->GetValue("Canvas.Style", "Modern"));
 
+   // this is required by rootssh
    const char *webdisplay = gSystem->Getenv("ROOT_WEBDISPLAY");
-   if (!webdisplay || !*webdisplay)
-      webdisplay = gEnv->GetValue("WebGui.Display", "");
+   // not allow to configure web display via rootrc
+   if (!webdisplay || !*webdisplay) {
+      const char *webdisplay_rc = gEnv->GetValue("WebGui.Display", "");
+      if (webdisplay_rc && *webdisplay_rc && (strcmp(webdisplay_rc, "off") != 0)) {
+         printf("\nWARNING!\n");
+         printf("rootrc parameter \"WebGui.Display\" is disabled for security reason.\n");
+         printf("See https://root.cern/about/security/#2023-11-26-open-port-for-control-of-web-gui-allows-read-and-write-access-to-file-system for more information.\n");
+         printf("For environments controlling the security issues you can enable web display by calling\n");
+         printf("gROOT->SetWebDisplay(); in ROOT prompt or in startup scripts\n\n");
+      }
+   }
    if (webdisplay && *webdisplay)
       SetWebDisplay(webdisplay);
 

--- a/core/gui/src/TBrowser.cxx
+++ b/core/gui/src/TBrowser.cxx
@@ -113,9 +113,7 @@ Bool_t TBrowser::InitGraphics()
    // make sure that the Gpad and GUI libs are loaded
    TApplication::NeedGraphicsLibs();
 
-   TString hname = gEnv->GetValue("Browser.Name", "TRootBrowserLite");
-
-   Bool_t isweb = gROOT->IsWebDisplay() || (hname == "ROOT::RWebBrowserImp");
+   Bool_t isweb = gROOT->IsWebDisplay();
 
    if (gApplication)
       gApplication->InitializeGraphics(isweb);

--- a/core/gui/src/TGuiFactory.cxx
+++ b/core/gui/src/TGuiFactory.cxx
@@ -95,8 +95,18 @@ TBrowserImp *TGuiFactory::CreateBrowserImp(TBrowser *b, const char *title, UInt_
 
    if (gROOT->IsWebDisplay() && !gROOT->IsWebDisplayBatch())
       browserName = "ROOT::RWebBrowserImp";
-   else if (!gROOT->IsBatch())
+   else if (!gROOT->IsBatch()) {
       browserName = gEnv->GetValue("Browser.Name", "");
+      if (strcmp(browserName, "ROOT::RWebBrowserImp") == 0) {
+         printf("\nWARNING!\n");
+         printf("rootrc parameter \"Browser.Name\" with web browser disabled for security reason.\n");
+         printf("See https://root.cern/about/security/#2023-11-26-open-port-for-control-of-web-gui-allows-read-and-write-access-to-file-system for more information.\n");
+         printf("For environments controlling the security issues you can enable web display by calling\n");
+         printf("gROOT->SetWebDisplay(); in ROOT prompt or in startup scripts\n\n");
+
+         browserName = "TRootBrowser";
+      }
+   }
 
    if (browserName && *browserName) {
       auto ph = gROOT->GetPluginManager()->FindHandler("TBrowserImp", browserName);
@@ -119,8 +129,18 @@ TBrowserImp *TGuiFactory::CreateBrowserImp(TBrowser *b, const char *title, Int_t
 
    if (gROOT->IsWebDisplay() && !gROOT->IsWebDisplayBatch())
       browserName = "ROOT::RWebBrowserImp";
-   else if (!gROOT->IsBatch())
+   else if (!gROOT->IsBatch()) {
       browserName = gEnv->GetValue("Browser.Name", "");
+      if (strcmp(browserName, "ROOT::RWebBrowserImp") == 0) {
+         printf("\nWARNING!\n");
+         printf("rootrc parameter \"Browser.Name\" with web browser disabled for security reason.\n");
+         printf("See https://root.cern/about/security/#2023-11-26-open-port-for-control-of-web-gui-allows-read-and-write-access-to-file-system for more information.\n");
+         printf("For environments controlling the security issues you can enable web display by calling\n");
+         printf("gROOT->SetWebDisplay(); in ROOT prompt or in startup scripts\n\n");
+
+         browserName = "TRootBrowser";
+      }
+   }
 
    if (browserName && *browserName) {
       auto ph = gROOT->GetPluginManager()->FindHandler("TBrowserImp", browserName);

--- a/gui/gui/src/TRootGuiFactory.cxx
+++ b/gui/gui/src/TRootGuiFactory.cxx
@@ -79,6 +79,17 @@ TCanvasImp *TRootGuiFactory::CreateCanvasImp(TCanvas *c, const char *title,
                                              UInt_t width, UInt_t height)
 {
    TString canvName = gEnv->GetValue("Canvas.Name", "TRootCanvas");
+
+   if ((canvName == "TWebCanvas") && !gROOT->IsWebDisplay()) {
+      printf("\nWARNING!\n");
+      printf("rootrc parameter \"Canvas.Name\" with web canvas disabled for security reason.\n");
+      printf("See https://root.cern/about/security/#2023-11-26-open-port-for-control-of-web-gui-allows-read-and-write-access-to-file-system for more information.\n");
+      printf("For environments controlling the security issues you can enable web display by calling\n");
+      printf("gROOT->SetWebDisplay(); in ROOT prompt or in startup scripts\n\n");
+
+      canvName = "TRootCanvas";
+   }
+
    if (canvName == "TWebCanvas") {
       auto ph = gROOT->GetPluginManager()->FindHandler("TCanvasImp", "TWebCanvas");
 
@@ -99,6 +110,17 @@ TCanvasImp *TRootGuiFactory::CreateCanvasImp(TCanvas *c, const char *title,
                                   Int_t x, Int_t y, UInt_t width, UInt_t height)
 {
    TString canvName = gEnv->GetValue("Canvas.Name", "TRootCanvas");
+
+   if ((canvName == "TWebCanvas") && !gROOT->IsWebDisplay()) {
+      printf("\nWARNING!\n");
+      printf("rootrc parameter \"Canvas.Name\" with web canvas disabled for security reason.\n");
+      printf("See https://root.cern/about/security/#2023-11-26-open-port-for-control-of-web-gui-allows-read-and-write-access-to-file-system for more information.\n");
+      printf("For environments controlling the security issues you can enable web display by calling\n");
+      printf("gROOT->SetWebDisplay(); in ROOT prompt or in startup scripts\n\n");
+
+      canvName = "TRootCanvas";
+   }
+
    if (canvName == "TWebCanvas") {
       auto ph = gROOT->GetPluginManager()->FindHandler("TCanvasImp", "TWebCanvas");
 
@@ -120,6 +142,17 @@ TBrowserImp *TRootGuiFactory::CreateBrowserImp(TBrowser *b, const char *title,
                                                Option_t *opt)
 {
    TString browserVersion(gEnv->GetValue("Browser.Name", "TRootBrowserLite"));
+
+   if ((browserVersion == "ROOT::RWebBrowserImp") && !gROOT->IsWebDisplay()) {
+      printf("\nWARNING!\n");
+      printf("rootrc parameter \"Browser.Name\" with web browser disabled for security reason.\n");
+      printf("See https://root.cern/about/security/#2023-11-26-open-port-for-control-of-web-gui-allows-read-and-write-access-to-file-system for more information.\n");
+      printf("For environments controlling the security issues you can enable web display by calling\n");
+      printf("gROOT->SetWebDisplay(); in ROOT prompt or in startup scripts\n\n");
+
+      browserVersion = "TRootBrowser";
+   }
+
    TPluginHandler *ph = gROOT->GetPluginManager()->FindHandler("TBrowserImp",
                                                                browserVersion);
    TString browserOptions(gEnv->GetValue("Browser.Options", "FECI"));
@@ -147,6 +180,17 @@ TBrowserImp *TRootGuiFactory::CreateBrowserImp(TBrowser *b, const char *title,
                                                UInt_t height, Option_t *opt)
 {
    TString browserVersion(gEnv->GetValue("Browser.Name", "TRootBrowserLite"));
+
+   if ((browserVersion == "ROOT::RWebBrowserImp") && !gROOT->IsWebDisplay()) {
+      printf("\nWARNING!\n");
+      printf("rootrc parameter \"Browser.Name\" with web browser disabled for security reason.\n");
+      printf("See https://root.cern/about/security/#2023-11-26-open-port-for-control-of-web-gui-allows-read-and-write-access-to-file-system for more information.\n");
+      printf("For environments controlling the security issues you can enable web display by calling\n");
+      printf("gROOT->SetWebDisplay(); in ROOT prompt or in startup scripts\n\n");
+
+      browserVersion = "TRootBrowser";
+   }
+
    TPluginHandler *ph = gROOT->GetPluginManager()->FindHandler("TBrowserImp",
                                                                browserVersion);
    TString browserOptions(gEnv->GetValue("Browser.Options", "FECI"));

--- a/tree/treeplayer/src/TTreePlayer.cxx
+++ b/tree/treeplayer/src/TTreePlayer.cxx
@@ -2961,6 +2961,16 @@ void TTreePlayer::StartViewer(Int_t ww, Int_t wh)
 
    TString hname = gEnv->GetValue("TreeViewer.Name", "TTreeViewer");
 
+   if ((hname == "RTreeViewer") && !gROOT->IsWebDisplay()) {
+      printf("\nWARNING!\n");
+      printf("rootrc parameter \"TreeViewer.Name\" with web-based viewer disabled for security reason.\n");
+      printf("See https://root.cern/about/security/#2023-11-26-open-port-for-control-of-web-gui-allows-read-and-write-access-to-file-system for more information.\n");
+      printf("For environments controlling the security issues you can enable web display by calling\n");
+      printf("gROOT->SetWebDisplay(); in ROOT prompt or in startup scripts\n\n");
+
+      hname = "TTreeViewer";
+   }
+
    TApplication::NeedGraphicsLibs();
    if (gApplication)
       gApplication->InitializeGraphics(hname == "RTreeViewer");


### PR DESCRIPTION
Shrink version of #14189 

I can add generic `TROOT::PrintWebIssuseWarning()` static method if required.