### PR TITLE
[cmake] Set policy CMP0116 to OLD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ foreach(policy ${policy_new})
   endif()
 endforeach()
 
-set(policy_old CMP0135 CMP0144)
+set(policy_old CMP0116 CMP0135 CMP0144)
 foreach(policy ${policy_old})
   if(POLICY ${policy})
     cmake_policy(SET ${policy} OLD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,14 +29,12 @@ foreach(policy ${policy_new})
   endif()
 endforeach()
 
-# ignore JAVA_ROOT when find_package(Java 1.8 ...) called
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.27)
-  cmake_policy(SET CMP0144 OLD)
-endif()
-
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
-  cmake_policy(SET CMP0135 OLD)
-endif()
+set(policy_old CMP0135 CMP0144)
+foreach(policy ${policy_old})
+  if(POLICY ${policy})
+    cmake_policy(SET ${policy} OLD)
+  endif()
+endforeach()
 
 include(cmake/modules/CaptureCommandLine.cmake)
 


### PR DESCRIPTION
As done by `interpreter/llvm-project/cmake/Modules/CMakePolicy.cmake`, but this resolves many warnings when building with `builtin_llvm=OFF` (but `builtin_clang=ON`):
```
CMake Warning (dev) at /usr/lib64/cmake/llvm/TableGen.cmake:95 (add_custom_command):
  Policy CMP0116 is not set: Ninja generators transform DEPFILEs from
  add_custom_command().  Run "cmake --help-policy CMP0116" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.
Call Stack (most recent call first):
  interpreter/llvm-project/clang/cmake/modules/AddClang.cmake:25 (tablegen)
  interpreter/llvm-project/clang/include/clang/AST/CMakeLists.txt:73 (clang_tablegen)
This warning is for project developers.  Use -Wno-dev to suppress it.
```