### PR TITLE
[RF][HS3] Bugfix for fully constrained shapesys

### DIFF
--- a/roofit/hs3/src/JSONFactories_HistFactory.cxx
+++ b/roofit/hs3/src/JSONFactories_HistFactory.cxx
@@ -319,7 +319,7 @@ bool importHistSample(RooJSONFactoryWSTool &tool, RooDataHist &dh, RooArgSet con
             constraints.add(getConstraint(ws, parname));
          } else if (modtype == "shapesys") {
             std::string funcName = channelName + "_" + sysname + "_ShapeSys";
-            // funName should be "<channel_name>_<sysname>_ShapeSys"
+            // funcName should be "<channel_name>_<sysname>_ShapeSys"
             std::vector<double> vals;
             for (const auto &v : mod["data"]["vals"].children()) {
                vals.push_back(v.val_double());
@@ -327,6 +327,9 @@ bool importHistSample(RooJSONFactoryWSTool &tool, RooDataHist &dh, RooArgSet con
             std::vector<std::string> parnames;
             for (const auto &v : mod["parameters"].children()) {
                parnames.push_back(v.val());
+            }
+            if (vals.empty()) {
+               RooJSONFactoryWSTool::error("unable to instantiate shapesys '" + sysname + "' with 0 values!");
             }
             std::string constraint(mod["constraint"].val());
             shapeElems.add(createPHF(funcName, sysname, parnames, vals, tool, constraints, varlist, constraint,
@@ -925,6 +928,13 @@ bool tryExportHistFactory(RooJSONFactoryWSTool *tool, const std::string &pdfname
             auto &data = mod["data"].set_map();
             auto &vals = data["vals"];
             vals.fill_seq(sys.constraints);
+         } else {
+            auto &data = mod["data"].set_map();
+            auto &vals = data["vals"];
+            vals.set_seq();
+            for (std::size_t i = 0; i < sys.parameters.size(); ++i) {
+               vals.append_child() << 0;
+            }
          }
       }
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

In the current implementation, shapesys with no valid data (all constraints constant) are written out in an invalid way, making it impossible for the reader to then instantiate the correct number of parameters.
This PR fixes this by forcing the write-out of data with all-zeros for such invalid shapesys.
Alternatively, one could imagine dropping these shapesys completely, but that's maybe something of a policy decision that I don't want to make in a bugfix patch :)

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

