### PR TITLE
[RF][HF] Do not access non-existent parameter when setting it to const in HistoToWorkspaceFactoryFast

### DIFF
--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -1253,11 +1253,12 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
     for(unsigned int i=0; i<systToFix.size(); ++i){
       RooRealVar* temp = proto.var(systToFix.at(i));
       if(!temp) {
-        cxcoutE(HistFactory) << "could not find variable " << systToFix.at(i)
+        cxcoutW(HistFactory) << "could not find variable " << systToFix.at(i)
             << " could not set it to constant" << endl;
+      } else {
+        // set the parameter constant
+        temp->setConstant();
       }
-      // set the parameter constant
-      temp->setConstant();
     }
 
     //////////////////////////////////////


### PR DESCRIPTION
# This Pull request:
Fixing a crash in HistoToWorkspaceFactoryFast.cxx where a parameter that was globally set to be constant was not found a given region, but the code was still accessing the parameter even when it was nullptr. 

## Changes or fixes:
Now the parameter is set to constant only when found in a given region. Also demoting the error to warning as this does not always indicate a wrong setup.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #14225

