### PR TITLE
thisroot.sh: if exe contains qemu, use /proc/$$/comm instead

### DIFF
--- a/config/thisroot.sh
+++ b/config/thisroot.sh
@@ -165,6 +165,11 @@ getTrueShellExeName() { # mklement0 https://stackoverflow.com/a/23011530/7471760
    # Determine the shell executable filename.
    if [ -r "/proc/$$/cmdline" ]; then
       trueExe=$(cut -d '' -f1 /proc/$$/cmdline) || return 1
+      # Qemu emulation has cmdline start with the emulator
+      if [ "${trueExe##*qemu*}" != "${trueExe}" ]; then
+         # but qemu sets comm to the emulated command
+         trueExe=$(cat /proc/$$/comm) || return 1
+      fi
    else
       trueExe=$(ps -p $$ -o comm=) || return 1
    fi


### PR DESCRIPTION
# This Pull request:
This PR aims to address #14085 by making thisroot.sh identify the shell correctly even when run under qemu, for example in emulated docker containers.

## Changes or fixes:
When qemu is run, then `/proc/$$/comm` contains the name of the command that is emulated.

## Checklist:
- [x] tested changes locally
- [ ] ~~updated the docs (if necessary)~~ N/A

This PR fixes #14085.

## Tests
Before:
```console
(Fri Dec-15 2:11:32pm)-(CPU 20.2%:0:Net 1)-(root:/)-(64K:21)
> source thisroot.sh
ERROR: must "cd where/root/is" before calling ". bin/thisroot.sh" for this version of "aarch64-binfmt-P"!
(ERROR)-(Exit Code 1)-(General error)
(Fri Dec-15 2:11:37pm)-(CPU 20.2%:0:Net 1)-(root:/)-(64K:21)
```
After:
```console
(Fri Dec-15 2:12:57pm)-(CPU 20.2%:0:Net 1)-(root:/)-(16M:23)
> source thisroot.sh
(Fri Dec-15 2:13:00pm)-(CPU 20.2%:0:Net 1)-(root:/)-(16M:23)
```