### PR TITLE
[RF] Fix ownership problem in `RooGenProdProj`

### DIFF
--- a/roofit/roofitcore/src/RooGenProdProj.cxx
+++ b/roofit/roofitcore/src/RooGenProdProj.cxx
@@ -166,6 +166,8 @@ RooAbsReal* RooGenProdProj::makeIntegral(const char* name, const RooArgSet& comp
   // normalization.
   RooArgSet emptyNormSet{};
 
+  RooArgSet keepAlive;
+
   for (const auto pdfAsArg : compSet) {
     auto pdf = static_cast<const RooAbsPdf*>(pdfAsArg);
 
@@ -183,8 +185,8 @@ RooAbsReal* RooGenProdProj::makeIntegral(const char* name, const RooArgSet& comp
         // Remove analytically integratable observables from numeric integration list
         numIntSet.remove(anaSet) ;
 
-        // Declare ownership of integral
-        saveSet.addOwned(std::move(pai));
+        // Keep integral alive until the prodSet is cloned later
+        keepAlive.addOwned(std::move(pai));
       } else {
         // Analytic integration of factorizable observable not possible, add straight pdf to product
         prodSet.add(*pdf) ;


### PR DESCRIPTION
At some point in `RooGenProdProj::createIntegral()`, an intermediate integral object that should only live during the scope of the function is accidentally put in the `saveSet` output parameter. This needs to be fixed.

Thanks to the following forum post for noticing this: https://root-forum.cern.ch/t/error-inputarguments-rooargset-error-argument-with-name-is-already-in-this-set-in-roomcstudy/57571