### PR TITLE
GetTicks should be the analogous of SetTicks

### DIFF
--- a/hist/hist/src/TAxis.cxx
+++ b/hist/hist/src/TAxis.cxx
@@ -635,7 +635,8 @@ const char *TAxis::GetTicks() const
 {
    if (TestBit(kTickPlus) && TestBit(kTickMinus)) return "+-";
    if (TestBit(kTickMinus)) return "-";
-   return "+";
+   if (TestBit(kTickPlus)) return "+";
+   return "";
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1099,6 +1100,7 @@ void TAxis::SetRangeUser(Double_t ufirst, Double_t ulast)
 ///  option = "+"  ticks drawn on the "positive side" (default)
 ///  option = "-"  ticks drawn on the "negative side"
 ///  option = "+-" ticks drawn on both sides
+///  option = "" ticks not drawn
 
 void TAxis::SetTicks(Option_t *option)
 {


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

SetTicks(GetTicks) was not a unity operator.

## Checklist:

- [ ] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes https://github.com/root-project/root/issues/14256
