### PR TITLE
[core] Properly define TString::kNPOS data member according to standard C++

### DIFF
--- a/core/base/src/TString.cxx
+++ b/core/base/src/TString.cxx
@@ -54,6 +54,11 @@ as a TString, construct a TString from it, eg:
 #include "TVirtualMutex.h"
 #include "ThreadLocalStorage.h"
 
+// Definition of the TString static data member. Declaration (even with
+// initialization) in the class body *is not* definition according to C++
+// standard. The definition must be explicitly done in one TU for ODR use. See
+// https://en.cppreference.com/w/cpp/language/definition
+const Ssiz_t TString::kNPOS;
 
 #if defined(R__WIN32)
 #define strtoull _strtoui64


### PR DESCRIPTION
By defining `TString::kNPOS` out of class, the symbol is materialized properly also with LLVM>=13.

Related to https://github.com/cms-sw/cmssw/issues/43077

Using the snippet at https://github.com/cms-sw/cmssw/issues/43077#issuecomment-1781108225 , these are the numbers reported by different ROOT versions:

```
$: for n in `ls *.log`; do echo $n; grep openat $n | sed 's|.*, "||;s|".*||' | sort | uniq | wc -l; done
master-2023-12-18-knpos-constexpr-run.log
2579
master-2023-12-18-knpos-out-of-class-run.log
307
master-2023-12-18-run.log
2577
v6-26-14-run.log
293
v6-28-00-knpos-constexpr-run.log
2578
v6-28-00-knpos-out-of-class-run.log
304
v6-28-00-run.log
2798
```

Note specifically `v6-28-00-knpos-out-of-class-run.log` and `master-2023-12-18-knpos-out-of-class-run.log` which correspond to respectively a 6.28 and a master build **with** this patch applied. In those cases, the number of `openat` calls falls back down to 6.26 levels.

For completennes, @Axel-Naumann suggested to try defining `TString::kNPOS` as `static constexpr Ssiz_t kNPOS{::kNPOS};` inside the class body directly. The numbers are slightly better than the reference, but still quite worse than the case of defining the member variable out of class. See specifically `v6-28-00-knpos-constexpr-run.log` and `master-2023-12-18-knpos-out-of-class-run.log`. 

Also, note that after this patch:
```
$: nm $ROOTSYS/lib/*.so | grep _ZN7TString5kNPOSE | wc -l
52
```