### PR TITLE
[cling] interpreter/CMakeLists.txt: correct CLANG_INCLUDE_DIRS [v6.30]

### DIFF
--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -466,7 +466,7 @@ if (builtin_clang)
   endif()
   set(CLANG_INCLUDE_DIRS
     ${CMAKE_SOURCE_DIR}/interpreter/llvm-project/clang/include
-    ${CMAKE_BINARY_DIR}/interpreter/llvm-project/llvm/tools/clang/include
+    ${Clang_DIR}/include
     CACHE STRING "Clang include directories.")
 else()
   set(Clang_DIR "${LLVM_BINARY_DIR}/lib/cmake/clang/")


### PR DESCRIPTION
This looks like a regression from https://github.com/root-project/root/commit/7a1cc8ffe576490b2f977ba2c262e10ec53a797a#diff-93558e500b17901f800fbb40a2c2fdfd6ee229077db63413bd4a91ee7ec66ea7. It seems like interpreter/llvm-project/llvm/tools/clang would not be a thing, while a following compilation error is observed:

    In file included from interpreter/cling/lib/Utils/AST.cpp:12:
    In file included from interpreter/llvm-project/clang/include/clang/AST/ASTContext.h:18:
    interpreter/llvm-project/clang/include/clang/AST/ASTFwd.h:21:10: fatal error: 'clang/AST/DeclNodes.inc' file not found
    #include "clang/AST/DeclNodes.inc"
             ^~~~~~~~~~~~~~~~~~~~~~~~~
    1 error generated.

(cherry picked from commit 1477d3adebf27a19f3a8b85f21c27a0a5649c7ff)