### PR TITLE
[cling] Move from legacy to new pass manager

### DIFF
--- a/interpreter/cling/lib/Interpreter/BackendPasses.cpp
+++ b/interpreter/cling/lib/Interpreter/BackendPasses.cpp
@@ -397,7 +397,12 @@ void BackendPasses::CreatePasses(int OptLevel, llvm::ModulePassManager& MPM,
     // Use the default pass pipeline. We also have to map our optimization
     // levels into one of the distinct levels used to configure the pipeline.
     OptimizationLevel Level = mapToLevel(m_CGOpts);
-    MPM.addPass(PB.buildPerModuleDefaultPipeline(Level));
+    if (m_CGOpts.OptimizationLevel == 0) {
+      // TODO: Remove this after https://reviews.llvm.org/D146200
+      MPM.addPass(PB.buildO0DefaultPipeline(Level));
+    } else {
+      MPM.addPass(PB.buildPerModuleDefaultPipeline(Level));
+    }
   }
 
   // The function __cuda_module_ctor and __cuda_module_dtor will just generated,

--- a/interpreter/cling/lib/Interpreter/BackendPasses.cpp
+++ b/interpreter/cling/lib/Interpreter/BackendPasses.cpp
@@ -369,6 +369,22 @@ void BackendPasses::CreatePasses(int OptLevel, llvm::ModulePassManager& MPM,
     // At O0 and O1 we only run the always inliner which is more efficient. At
     // higher optimization levels we run the normal inliner.
     MPM.addPass(AlwaysInlinerPass());
+
+    // Register a callback for disabling all other inliner passes.
+    PIC.registerShouldRunOptionalPassCallback([](StringRef P, Any) {
+      if (P.equals("ModuleInlinerWrapperPass") ||
+          P.equals("InlineAdvisorAnalysisPrinterPass") ||
+          P.equals("PartialInlinerPass") || P.equals("buildInlinerPipeline") ||
+          P.equals("ModuleInlinerPass") || P.equals("InlinerPass") ||
+          P.equals("InlineAdvisorAnalysis") ||
+          P.equals("PartiallyInlineLibCallsPass") ||
+          P.equals("InlineCostAnnotationPrinterPass") ||
+          P.equals("InlineSizeEstimatorAnalysisPrinterPass") ||
+          P.equals("InlineSizeEstimatorAnalysis"))
+        return false;
+
+      return true;
+    });
   }
 
   SI.registerCallbacks(PIC, &FAM);

--- a/interpreter/cling/lib/Interpreter/BackendPasses.h
+++ b/interpreter/cling/lib/Interpreter/BackendPasses.h
@@ -10,7 +10,10 @@
 #ifndef CLING_BACKENDPASSES_H
 #define CLING_BACKENDPASSES_H
 
-#include "llvm/IR/LegacyPassManager.h"
+#include "llvm/Analysis/CGSCCPassManager.h"
+#include "llvm/Analysis/LoopAnalysisManager.h"
+#include "llvm/IR/PassManager.h"
+#include "llvm/Passes/StandardInstrumentations.h"
 
 #include <array>
 #include <memory>
@@ -19,13 +22,7 @@ namespace llvm {
   class Function;
   class LLVMContext;
   class Module;
-  class PassManagerBuilder;
   class TargetMachine;
-
-  namespace legacy {
-    class FunctionPassManager;
-    class PassManager;
-  }
 }
 
 namespace clang {
@@ -40,14 +37,17 @@ namespace cling {
   ///\brief Runs passes on IR. Remove once we can migrate from ModuleBuilder to
   /// what's in clang's CodeGen/BackendUtil.
   class BackendPasses {
-    std::array<std::unique_ptr<llvm::legacy::PassManager>, 4> m_MPM;
-    std::array<std::unique_ptr<llvm::legacy::FunctionPassManager>, 4> m_FPM;
-
     llvm::TargetMachine& m_TM;
     IncrementalJIT &m_JIT;
     const clang::CodeGenOptions &m_CGOpts;
 
-    void CreatePasses(llvm::Module& M, int OptLevel);
+    void CreatePasses(int OptLevel, llvm::ModulePassManager& MPM,
+                      llvm::LoopAnalysisManager& LAM,
+                      llvm::FunctionAnalysisManager& FAM,
+                      llvm::CGSCCAnalysisManager& CGAM,
+                      llvm::ModuleAnalysisManager& MAM,
+                      llvm::PassInstrumentationCallbacks& PIC,
+                      llvm::StandardInstrumentations& SI);
 
   public:
     BackendPasses(const clang::CodeGenOptions &CGOpts, IncrementalJIT &JIT,


### PR DESCRIPTION
# This Pull request:
- Moves away from the legacy pass manager to the new llvm pass manager. Care is take to ensure the same behavior before and after the update. Could benefit from more testing.

## Changes or fixes:
- Adapt the existing passes for the new pass manager.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

