### PR TITLE
[tree] Replace [Bool_t, kTrue, kFalse] -> [bool, true, false]

### DIFF
--- a/tree/ntuple/v7/test/SimpleCollectionProxy.hxx
+++ b/tree/ntuple/v7/test/SimpleCollectionProxy.hxx
@@ -56,7 +56,7 @@ public:
    Int_t GetCollectionType() const override { return CollectionKind; }
    ULong_t GetIncrement() const override { return sizeof(typename CollectionT::ValueType); }
    UInt_t Sizeof() const override { return sizeof(CollectionT); }
-   Bool_t HasPointers() const override { return kFALSE; }
+   bool HasPointers() const override { return false; }
 
    TClass *GetValueClass() const override
    {
@@ -81,7 +81,7 @@ public:
    void *At(UInt_t idx) override { return &fObject->v[idx]; }
    void Clear(const char * /*opt*/ = "") override { fObject->v.clear(); }
    UInt_t Size() const override { return fObject->v.size(); }
-   void *Allocate(UInt_t n, Bool_t /*forceDelete*/) override
+   void *Allocate(UInt_t n, bool /*forceDelete*/) override
    {
       fObject->v.resize(n);
       return fObject;
@@ -103,11 +103,11 @@ public:
    TStreamerInfoActions::TActionSequence *GetReadMemberWiseActions(Int_t /*version*/) override { return nullptr; }
    TStreamerInfoActions::TActionSequence *GetWriteMemberWiseActions() override { return nullptr; }
 
-   CreateIterators_t GetFunctionCreateIterators(Bool_t /*read*/ = kTRUE) override { return &Func_CreateIterators; }
-   CopyIterator_t GetFunctionCopyIterator(Bool_t /*read*/ = kTRUE) override { return nullptr; }
-   Next_t GetFunctionNext(Bool_t /*read*/ = kTRUE) override { return &Func_Next; }
-   DeleteIterator_t GetFunctionDeleteIterator(Bool_t /*read*/ = kTRUE) override { return nullptr; }
-   DeleteTwoIterators_t GetFunctionDeleteTwoIterators(Bool_t /*read*/ = kTRUE) override
+   CreateIterators_t GetFunctionCreateIterators(bool /*read*/ = true) override { return &Func_CreateIterators; }
+   CopyIterator_t GetFunctionCopyIterator(bool /*read*/ = true) override { return nullptr; }
+   Next_t GetFunctionNext(bool /*read*/ = true) override { return &Func_Next; }
+   DeleteIterator_t GetFunctionDeleteIterator(bool /*read*/ = true) override { return nullptr; }
+   DeleteTwoIterators_t GetFunctionDeleteTwoIterators(bool /*read*/ = true) override
    {
       return &Func_DeleteTwoIterators;
    }

--- a/tree/readspeed/src/ReadSpeed.cxx
+++ b/tree/readspeed/src/ReadSpeed.cxx
@@ -180,7 +180,7 @@ Result ReadSpeed::EvalThroughputST(const Data &d)
       if (f == nullptr || f->IsZombie())
          throw std::runtime_error("Could not open file '" + fileName + '\'');
 
-      sw.Start(kFALSE);
+      sw.Start(false);
 
       const auto byteData = ReadTree(f.get(), d.fTreeNames[treeIdx], fileBranchNames[fileIdx]);
       uncompressedBytesRead += byteData.fUncompressedBytesRead;

--- a/tree/tree/inc/TBasket.h
+++ b/tree/tree/inc/TBasket.h
@@ -39,7 +39,7 @@ private:
    TBasket& operator=(const TBasket&); ///< TBasket objects are not copiable.
 
    // Internal corner cases for ReadBasketBuffers
-   Int_t ReadBasketBuffersUnzip(char*, Int_t, Bool_t, TFile*);
+   Int_t ReadBasketBuffersUnzip(char*, Int_t, bool, TFile*);
    Int_t ReadBasketBuffersUncompressedCase();
 
    // Helper for managing the compressed buffer.
@@ -52,7 +52,7 @@ private:
    Int_t *GetCalculatedEntryOffset();
 
    // Returns true if the underlying TLeaf can regenerate the entry offsets for us.
-   Bool_t CanGenerateOffsetArray();
+   bool CanGenerateOffsetArray();
 
    // Manage buffer ownership.
    void   DisownBuffer();
@@ -63,17 +63,17 @@ protected:
    Int_t       fNevBufSize{0};                    ///< Length in Int_t of fEntryOffset OR fixed length of each entry if fEntryOffset is null!
    Int_t       fNevBuf{0};                        ///< Number of entries in basket
    Int_t       fLast{0};                          ///< Pointer to last used byte in basket
-   Bool_t      fHeaderOnly{kFALSE};               ///< True when only the basket header must be read/written
+   bool        fHeaderOnly{false};               ///< True when only the basket header must be read/written
    UChar_t     fIOBits{0};                        ///<!IO feature flags.  Serialized in custom portion of streamer to avoid forward compat issues unless needed.
-   Bool_t      fOwnsCompressedBuffer{kFALSE};     ///<! Whether or not we own the compressed buffer.
-   Bool_t      fReadEntryOffset{kFALSE};          ///<!Set to true if offset array was read from a file.
+   bool        fOwnsCompressedBuffer{false};     ///<! Whether or not we own the compressed buffer.
+   bool        fReadEntryOffset{false};          ///<!Set to true if offset array was read from a file.
    Int_t      *fDisplacement{nullptr};            ///<![fNevBuf] Displacement of entries in fBuffer(TKey)
    Int_t      *fEntryOffset{nullptr};             ///<[fNevBuf] Offset of entries in fBuffer(TKey); generated at runtime.  Special value
                                                   /// of `-1` indicates that the offset generation MUST be performed on first read.
    TBranch    *fBranch{nullptr};                  ///<Pointer to the basket support branch
    TBuffer    *fCompressedBufferRef{nullptr};     ///<! Compressed buffer.
    Int_t       fLastWriteBufferSize[3] = {0,0,0}; ///<! Size of the buffer last three buffers we wrote it to disk
-   Bool_t      fResetAllocation{false};           ///<! True if last reset re-allocated the memory
+   bool        fResetAllocation{false};           ///<! True if last reset re-allocated the memory
    UChar_t     fNextBufferSizeRecord{0};          ///<! Index into fLastWriteBufferSize of the last buffer written to disk
 #ifdef R__TRACK_BASKET_ALLOC_TIME
    ULong64_t   fResetAllocationTime{0};           ///<! Time spent reallocating baskets in microseconds during last Reset operation.
@@ -140,7 +140,7 @@ public:
    ULong64_t       GetResetAllocationTime() const { return fResetAllocationTime; }
 #endif
    // Count of resets performed of basket size.
-   Bool_t          GetResetAllocationCount() const { return fResetAllocation; }
+   bool            GetResetAllocationCount() const { return fResetAllocation; }
 
    Int_t           LoadBasketBuffers(Long64_t pos, Int_t len, TFile *file, TTree *tree = nullptr);
    Long64_t        CopyTo(TFile *to);

--- a/tree/tree/inc/TBranch.h
+++ b/tree/tree/inc/TBranch.h
@@ -77,7 +77,7 @@ public:
    /// See TBranch::GetEntriesSerialized(Long64_t evt, TBuffer &user_buf, TBuffer *count_buf);
    Int_t GetEntriesSerialized(Long64_t evt, TBuffer &user_buf, TBuffer *count_buf);
    /// Return true if the branch can be read through the bulk interfaces.
-   Bool_t SupportsBulkRead() const;
+   bool SupportsBulkRead() const;
 
 private:
    TBulkBranchRead(TBranch &parent)
@@ -152,7 +152,7 @@ protected:
    TList      *fBrowsables;       ///<! List of TVirtualBranchBrowsables used for Browse()
    BulkObj     fBulk;             ///<! Helper for performing bulk IO
 
-   Bool_t      fSkipZip;          ///<! After being read, the buffer will not be unzipped.
+   bool        fSkipZip;          ///<! After being read, the buffer will not be unzipped.
 
    using CacheInfo_t = ROOT::Internal::TBranchCacheInfo;
    CacheInfo_t fCacheInfo;        ///<! Hold info about which basket are in the cache and if they have been retrieved from the cache.
@@ -167,7 +167,7 @@ protected:
    void     ReadLeaves2Impl(TBuffer &b);
    void     FillLeavesImpl(TBuffer &b);
 
-   void     SetSkipZip(Bool_t skip = kTRUE) { fSkipZip = skip; }
+   void     SetSkipZip(bool skip = true) { fSkipZip = skip; }
    void     Init(const char *name, const char *leaflist, Int_t compress);
 
    TBasket *GetFreshBasket(Int_t basketnumber, TBuffer *user_buffer);
@@ -176,7 +176,7 @@ protected:
 
    TString  GetRealFileName() const;
 
-   virtual void SetAddressImpl(void *addr, Bool_t /* implied */) { SetAddress(addr); }
+   virtual void SetAddressImpl(void *addr, bool /* implied */) { SetAddress(addr); }
 
 private:
    Int_t    GetBasketAndFirst(TBasket*& basket, Long64_t& first, TBuffer* user_buffer);
@@ -195,7 +195,7 @@ public:
    TBranch(TBranch *parent, const char *name, void *address, const char *leaflist, Int_t basketsize=32000, Int_t compress = ROOT::RCompressionSetting::EAlgorithm::kInherit);
    ~TBranch() override;
 
-   virtual void      AddBasket(TBasket &b, Bool_t ondisk, Long64_t startEntry);
+   virtual void      AddBasket(TBasket &b, bool ondisk, Long64_t startEntry);
    virtual void      AddLastBasket(Long64_t startEntry);
            Int_t     BackFill();
            void      Browse(TBrowser *b) override;
@@ -251,12 +251,12 @@ public:
            Long64_t  GetEntries()     const {return fEntries;}
            TTree    *GetTree()        const {return fTree;}
    virtual Int_t     GetRow(Int_t row);
-   virtual Bool_t    GetMakeClass() const;
+   virtual bool      GetMakeClass() const;
            TBranch  *GetMother() const;
            TBranch  *GetSubBranch(const TBranch *br) const;
            TBuffer  *GetTransientBuffer(Int_t size);
-           Bool_t    IsAutoDelete() const;
-           Bool_t    IsFolder() const override;
+           bool      IsAutoDelete() const;
+           bool      IsFolder() const override;
    virtual void      KeepCircular(Long64_t maxEntries);
    virtual Int_t     LoadBaskets();
            void      Print(Option_t *option="") const override;
@@ -269,24 +269,24 @@ public:
    virtual void      ResetReadEntry() {fReadEntry = -1;}
    virtual void      SetAddress(void *add);
    virtual void      SetObject(void *objadd);
-   virtual void      SetAutoDelete(Bool_t autodel=kTRUE);
+   virtual void      SetAutoDelete(bool autodel=true);
    virtual void      SetBasketSize(Int_t buffsize);
    virtual void      SetBufferAddress(TBuffer *entryBuffer);
            void      SetCompressionAlgorithm(Int_t algorithm = ROOT::RCompressionSetting::EAlgorithm::kUseGlobal);
            void      SetCompressionLevel(Int_t level = ROOT::RCompressionSetting::ELevel::kUseMin);
            void      SetCompressionSettings(Int_t settings = ROOT::RCompressionSetting::EDefaults::kUseCompiledDefault);
    virtual void      SetEntries(Long64_t entries);
-   virtual void      SetEntryOffsetLen(Int_t len, Bool_t updateSubBranches = kFALSE);
+   virtual void      SetEntryOffsetLen(Int_t len, bool updateSubBranches = false);
    virtual void      SetFirstEntry(Long64_t entry);
    virtual void      SetFile(TFile *file = nullptr);
    virtual void      SetFile(const char *filename);
            void      SetIOFeatures(TIOFeatures &features) {fIOFeatures = features;}
-   virtual Bool_t    SetMakeClass(Bool_t decomposeObj = kTRUE);
+   virtual bool      SetMakeClass(bool decomposeObj = true);
    virtual void      SetOffset(Int_t offset=0) {fOffset=offset;}
-   virtual void      SetStatus(Bool_t status=true);
+   virtual void      SetStatus(bool status=true);
    virtual void      SetTree(TTree *tree) { fTree = tree; }
    virtual void      SetupAddresses();
-           Bool_t    SupportsBulkRead() const;
+           bool      SupportsBulkRead() const;
    virtual void      UpdateAddress() {}
    virtual void      UpdateFile();
 
@@ -320,7 +320,7 @@ namespace Internal {
 inline Int_t  TBulkBranchRead::GetBulkEntries(Long64_t evt, TBuffer& user_buf) { return fParent.GetBulkEntries(evt, user_buf); }
 inline Int_t  TBulkBranchRead::GetEntriesSerialized(Long64_t evt, TBuffer& user_buf) { return fParent.GetEntriesSerialized(evt, user_buf); }
 inline Int_t  TBulkBranchRead::GetEntriesSerialized(Long64_t evt, TBuffer& user_buf, TBuffer* count_buf) { return fParent.GetEntriesSerialized(evt, user_buf, count_buf); }
-inline Bool_t TBulkBranchRead::SupportsBulkRead() const { return fParent.SupportsBulkRead(); }
+inline bool   TBulkBranchRead::SupportsBulkRead() const { return fParent.SupportsBulkRead(); }
 
 }  // Internal
 }  // Experimental

--- a/tree/tree/inc/TBranchBrowsable.h
+++ b/tree/tree/inc/TBranchBrowsable.h
@@ -51,7 +51,7 @@ public:
    void GetScope(TString &scope) const;
 
    /** check whether we have sub-elements */
-   Bool_t IsFolder() const override { return (GetLeaves() && GetLeaves()->GetSize()); }
+   bool IsFolder() const override { return (GetLeaves() && GetLeaves()->GetSize()); }
 
    static Int_t FillListOfBrowsables(TList &list, const TBranch *branch,
          const TVirtualBranchBrowsable *parent = nullptr);
@@ -66,7 +66,7 @@ public:
    TClass *GetClassType() const { return fClass; }
 
    /** return whether the type of this browsable object is a pointer */
-   Bool_t TypeIsPointer() const { return fTypeIsPointer; }
+   bool TypeIsPointer() const { return fTypeIsPointer; }
 
    TList *GetLeaves() const;
 
@@ -74,7 +74,7 @@ public:
    // static void Unregister() has to be implemented for all derived classes!
 
 protected:
-   TVirtualBranchBrowsable(const TBranch *b, TClass *type, Bool_t typeIsPointer,
+   TVirtualBranchBrowsable(const TBranch *b, TClass *type, bool typeIsPointer,
          const TVirtualBranchBrowsable *parent = nullptr);
    static TClass* GetCollectionContainedType(const TBranch *b,
          const TVirtualBranchBrowsable *parent, TClass *&contained);
@@ -85,7 +85,7 @@ protected:
    void SetType(TClass* type) { fClass = type; }
 
    /** sets whether the type of this browsable object is a pointer */
-   void SetTypeIsPointer(Bool_t set=kTRUE) { fTypeIsPointer = set; }
+   void SetTypeIsPointer(bool set=true) { fTypeIsPointer = set; }
 
 private:
    static void RegisterDefaultGenerators();
@@ -93,9 +93,9 @@ private:
    const TVirtualBranchBrowsable *fParent{nullptr}; ///< parent method if this method is member of a returned class
    TList            *fLeaves{nullptr}; ///< pointer to leaves
    TClass           *fClass{nullptr};  ///< pointer to TClass representing our type (i.e. return type for methods), 0 if basic type
-   Bool_t            fTypeIsPointer{kFALSE}; ///< return type is pointer to class
+   bool              fTypeIsPointer{false}; ///< return type is pointer to class
    static std::list<MethodCreateListOfBrowsables_t> fgGenerators; ///< list of MethodCreateListOfBrowsables_t called by CreateListOfBrowsables
-   static Bool_t     fgGeneratorsSet; ///< have we set the generators yet? empty is not good enough - user might have removed them
+   static bool       fgGeneratorsSet; ///< have we set the generators yet? empty is not good enough - user might have removed them
    ClassDefOverride(TVirtualBranchBrowsable, 0); ///< Base class for helper objects used for browsing
 };
 
@@ -114,7 +114,7 @@ public:
          return "TMethodBrowsable-branch";
       return "TMethodBrowsable-leaf";
    }
-   static Bool_t IsMethodBrowsable(const TMethod *m);
+   static bool IsMethodBrowsable(const TMethod *m);
    static void Register();
    static void Unregister();
 
@@ -165,7 +165,7 @@ protected:
    TCollectionPropertyBrowsable(const char *name, const char *title,
          const char *draw, const TBranch *branch,
          const TVirtualBranchBrowsable *parent = nullptr) :
-         TVirtualBranchBrowsable(branch, nullptr, kFALSE, parent), fDraw(draw)
+         TVirtualBranchBrowsable(branch, nullptr, false, parent), fDraw(draw)
    {
       SetNameTitle(name, title);
    }

--- a/tree/tree/inc/TBranchCacheInfo.h
+++ b/tree/tree/inc/TBranchCacheInfo.h
@@ -57,10 +57,10 @@ class TBranchCacheInfo {
    }
 
    /// Return true if the basket has been marked as having the 'what' state.
-   Bool_t TestState(Int_t basketNumber, EStates what) const
+   bool TestState(Int_t basketNumber, EStates what) const
    {
       if (basketNumber < fBasketPedestal)
-         return kFALSE;
+         return false;
       return fInfo.TestBitNumber(kSize * (basketNumber - fBasketPedestal) + what);
    }
 
@@ -73,7 +73,7 @@ class TBranchCacheInfo {
 
 public:
    /// Return true if the basket has been marked as 'used'
-   Bool_t HasBeenUsed(Int_t basketNumber) const { return TestState(basketNumber, kUsed); }
+   bool HasBeenUsed(Int_t basketNumber) const { return TestState(basketNumber, kUsed); }
 
    /// Mark if the basket has been marked as 'used'
    void SetUsed(Int_t basketNumber)
@@ -83,7 +83,7 @@ public:
    }
 
    /// Return true if the basket is currently in the cache.
-   Bool_t IsInCache(Int_t basketNumber) const { return TestState(basketNumber, kLoaded); }
+   bool IsInCache(Int_t basketNumber) const { return TestState(basketNumber, kLoaded); }
 
    /// Mark if the basket is currently in the cache.
    void SetIsInCache(Int_t basketNumber)
@@ -102,20 +102,20 @@ public:
    }
 
    /// Return true if the basket is currently vetoed.
-   Bool_t IsVetoed(Int_t basketNumber) const { return TestState(basketNumber, kVetoed); }
+   bool IsVetoed(Int_t basketNumber) const { return TestState(basketNumber, kVetoed); }
 
    /// Return true if all the baskets that are marked loaded are also
    /// mark as used.
-   Bool_t AllUsed() const
+   bool AllUsed() const
    {
       auto len = fInfo.GetNbits() / kSize + 1;
       for (UInt_t b = 0; b < len; ++b) {
          if (fInfo[kSize * b + kLoaded] && !fInfo[kSize * b + kUsed]) {
             // Not loaded or (loaded and used)
-            return kFALSE;
+            return false;
          }
       }
-      return kTRUE;
+      return true;
    }
 
    /// Return a set of unused basket, let's not re-read them.

--- a/tree/tree/inc/TBranchClones.h
+++ b/tree/tree/inc/TBranchClones.h
@@ -52,7 +52,7 @@ public:
    Int_t   GetEntry(Long64_t entry=0, Int_t getall = 0) override;
    virtual Int_t   GetN() const {return fN;}
    TClonesArray    *GetList() const {return fList;}
-   Bool_t          IsFolder() const override {return kTRUE;}
+   bool            IsFolder() const override {return true;}
    void    Print(Option_t *option="") const override;
    void    Reset(Option_t *option="") override;
    void    ResetAfterMerge(TFileMergeInfo *) override;

--- a/tree/tree/inc/TBranchElement.h
+++ b/tree/tree/inc/TBranchElement.h
@@ -85,9 +85,9 @@ protected:
    TStreamerInfo           *fInfo;          ///<! Pointer to StreamerInfo
    char                    *fObject;        ///<! Pointer to object at *fAddress
    TVirtualArray           *fOnfileObject;  ///<! Place holder for the onfile representation of data members.
-   Bool_t                   fInit : 1;      ///<! Initialization flag for branch assignment
-   Bool_t                   fInInitInfo : 1;///<! True during the 2nd part of InitInfo (cut recursion).
-   Bool_t                   fInitOffsets: 1;///<! Initialization flag to not endlessly recalculate offsets
+   bool                     fInit : 1;      ///<! Initialization flag for branch assignment
+   bool                     fInInitInfo : 1;///<! True during the 2nd part of InitInfo (cut recursion).
+   bool                     fInitOffsets: 1;///<! Initialization flag to not endlessly recalculate offsets
    TClassRef                fTargetClass;   ///<! Reference to the target in-memory class
    TClassRef                fCurrentClass;  ///<! Reference to current (transient) class definition
    TClassRef                fParentClass;   ///<! Reference to class definition in fParentName
@@ -114,7 +114,7 @@ protected:
    void                     BuildTitle(const char* name);
    virtual void             InitializeOffsets();
    virtual void             InitInfo();
-   Bool_t                   IsMissingCollection() const;
+   bool                     IsMissingCollection() const;
    TStreamerInfo           *FindOnfileInfo(TClass *valueClass, const TObjArray &branches) const;
    TClass                  *GetParentClass(); // Class referenced by fParentName
    TStreamerInfo           *GetInfoImp() const;
@@ -145,7 +145,7 @@ protected:
    void SetReadLeavesPtr();
    void SetReadActionSequence();
    void SetupAddressesImpl();
-   void SetAddressImpl(void *addr, Bool_t implied) override;
+   void SetAddressImpl(void *addr, bool implied) override;
 
    void FillLeavesImpl(TBuffer& b);
    void FillLeavesMakeClass(TBuffer& b);
@@ -194,7 +194,7 @@ public:
            const char      *GetIconName() const override;
            Int_t            GetID() const { return fID; }
            TStreamerInfo   *GetInfo() const;
-           Bool_t           GetMakeClass() const override;
+           bool             GetMakeClass() const override;
            char            *GetObject() const;
            TVirtualArray   *GetOnfileObject() const { return fOnfileObject; }
    virtual const char      *GetParentName() const { return fParentName.Data(); }
@@ -204,14 +204,14 @@ public:
            Int_t            GetStreamerType() const { return fStreamerType; }
    virtual TClass          *GetTargetClass() { return fTargetClass; }
    virtual const char      *GetTypeName() const;
-           Double_t         GetValue(Int_t i, Int_t len, Bool_t subarr = kFALSE) const { return GetTypedValue<Double_t>(i, len, subarr); }
-   template<typename T > T  GetTypedValue(Int_t i, Int_t len, Bool_t subarr = kFALSE) const;
+           Double_t         GetValue(Int_t i, Int_t len, bool subarr = false) const { return GetTypedValue<Double_t>(i, len, subarr); }
+   template<typename T > T  GetTypedValue(Int_t i, Int_t len, bool subarr = false) const;
    virtual void            *GetValuePointer() const;
            Int_t            GetClassVersion() { return fClassVersion; }
-           Bool_t           IsBranchFolder() const { return TestBit(kBranchFolder); }
-           Bool_t           IsFolder() const override;
-   virtual Bool_t           IsObjectOwner() const { return TestBit(kDeleteObject); }
-           Bool_t           Notify() override { if (fAddress) { ResetAddress(); } return true; }
+           bool             IsBranchFolder() const { return TestBit(kBranchFolder); }
+           bool             IsFolder() const override;
+   virtual bool             IsObjectOwner() const { return TestBit(kDeleteObject); }
+           bool             Notify() override { if (fAddress) { ResetAddress(); } return true; }
            void             Print(Option_t* option = "") const override;
            void             PrintValue(Int_t i) const;
            void             Reset(Option_t* option = "") override;
@@ -220,7 +220,7 @@ public:
    virtual void             ResetDeleteObject();
    virtual void             ResetInitInfo(bool recurse);
            void             SetAddress(void* addobj) override;
-           Bool_t           SetMakeClass(Bool_t decomposeObj = kTRUE) override;
+           bool             SetMakeClass(bool decomposeObj = true) override;
            void             SetObject(void *objadd) override;
            void             SetBasketSize(Int_t buffsize) override;
    virtual void             SetBranchFolder() { SetBit(kBranchFolder); }

--- a/tree/tree/inc/TBranchObject.h
+++ b/tree/tree/inc/TBranchObject.h
@@ -42,12 +42,12 @@ protected:
    TString     fClassName;        ///< Class name of referenced object
    TObject     *fOldObject;       ///< !Pointer to old object
 
-   void Init(TTree *tree, TBranch *parent, const char *name, const char *classname, void *addobj, Int_t basketsize, Int_t splitlevel, Int_t compress, Bool_t isptrptr);
+   void Init(TTree *tree, TBranch *parent, const char *name, const char *classname, void *addobj, Int_t basketsize, Int_t splitlevel, Int_t compress, bool isptrptr);
 
 public:
    TBranchObject();
-   TBranchObject(TBranch *parent, const char *name, const char *classname, void *addobj, Int_t basketsize=32000, Int_t splitlevel = 0, Int_t compress = ROOT::RCompressionSetting::EAlgorithm::kInherit, Bool_t isptrptr = kTRUE);
-   TBranchObject(TTree *tree, const char *name, const char *classname, void *addobj, Int_t basketsize=32000, Int_t splitlevel = 0, Int_t compress = ROOT::RCompressionSetting::EAlgorithm::kInherit, Bool_t isptrptr = kTRUE);
+   TBranchObject(TBranch *parent, const char *name, const char *classname, void *addobj, Int_t basketsize=32000, Int_t splitlevel = 0, Int_t compress = ROOT::RCompressionSetting::EAlgorithm::kInherit, bool isptrptr = true);
+   TBranchObject(TTree *tree, const char *name, const char *classname, void *addobj, Int_t basketsize=32000, Int_t splitlevel = 0, Int_t compress = ROOT::RCompressionSetting::EAlgorithm::kInherit, bool isptrptr = true);
    ~TBranchObject() override;
 
            void        Browse(TBrowser *b) override;
@@ -55,12 +55,12 @@ public:
    virtual const char* GetObjClassName() { return fClassName.Data(); };
            Int_t       GetEntry(Long64_t entry=0, Int_t getall = 0) override;
            Int_t       GetExpectedType(TClass *&clptr,EDataType &type) override;
-           Bool_t      IsFolder() const override;
+           bool        IsFolder() const override;
            void        Print(Option_t *option="") const override;
            void        Reset(Option_t *option="") override;
            void        ResetAfterMerge(TFileMergeInfo *) override;
            void        SetAddress(void *addobj) override;
-           void        SetAutoDelete(Bool_t autodel=kTRUE) override;
+           void        SetAutoDelete(bool autodel=true) override;
            void        SetBasketSize(Int_t buffsize) override;
            void        SetupAddresses() override;
            void        UpdateAddress() override;

--- a/tree/tree/inc/TBranchRef.h
+++ b/tree/tree/inc/TBranchRef.h
@@ -47,7 +47,7 @@ public:
    ~TBranchRef() override;
            void    Clear(Option_t *option="") override;
    TRefTable      *GetRefTable() const {return fRefTable;}
-           Bool_t  Notify() override;
+           bool    Notify() override;
            void    Print(Option_t *option="") const override;
            void    Reset(Option_t *option="") override;
            void    ResetAfterMerge(TFileMergeInfo *) override;

--- a/tree/tree/inc/TBranchSTL.h
+++ b/tree/tree/inc/TBranchSTL.h
@@ -31,7 +31,7 @@ class TBranchSTL: public TBranch {
                   TStreamerInfo* info, Int_t id );
       ~TBranchSTL() override;
               void           Browse( TBrowser *b ) override;
-              Bool_t         IsFolder() const override;
+              bool           IsFolder() const override;
               const char    *GetClassName() const override { return fClassName.Data(); }
               Int_t          GetExpectedType(TClass *&clptr,EDataType &type) override;
               Int_t          GetEntry(Long64_t entry = 0, Int_t getall = 0) override;

--- a/tree/tree/inc/TBufferSQL.h
+++ b/tree/tree/inc/TBufferSQL.h
@@ -44,12 +44,12 @@ public:
    TBufferSQL();
    TBufferSQL(TBuffer::EMode mode, std::vector<Int_t> *vc, TString *insert_query, TSQLRow **rowPtr);
    TBufferSQL(TBuffer::EMode mode, Int_t bufsiz, std::vector<Int_t> *vc, TString *insert_query, TSQLRow **rowPtr);
-   TBufferSQL(TBuffer::EMode mode, Int_t bufsiz, std::vector<Int_t> *vc, TString *insert_query, TSQLRow **rowPtr,void *buf, Bool_t adopt = kTRUE);
+   TBufferSQL(TBuffer::EMode mode, Int_t bufsiz, std::vector<Int_t> *vc, TString *insert_query, TSQLRow **rowPtr,void *buf, bool adopt = true);
    ~TBufferSQL() override;
 
    void ResetOffset();
 
-   void     ReadBool(Bool_t       &b) final;
+   void     ReadBool(bool         &b) final;
    void     ReadChar(Char_t       &c) final;
    void     ReadUChar(UChar_t     &c) final;
    void     ReadShort(Short_t     &s) final;
@@ -68,7 +68,7 @@ public:
    using    TBuffer::ReadStdString;
    void     ReadCharStar(char* &s) final;
 
-   void     WriteBool(Bool_t       b) final;
+   void     WriteBool(bool         b) final;
    void     WriteChar(Char_t       c) final;
    void     WriteUChar(UChar_t     c) final;
    void     WriteShort(Short_t     s) final;
@@ -87,7 +87,7 @@ public:
    using    TBuffer::WriteStdString;
    void     WriteCharStar(char *s) final;
 
-   void     WriteFastArray(const Bool_t    *b, Int_t n) final;
+   void     WriteFastArray(const bool      *b, Int_t n) final;
    void     WriteFastArray(const Char_t    *c, Int_t n) final;
    void     WriteFastArrayString(const Char_t   *c, Int_t n) final;
    void     WriteFastArray(const UChar_t   *c, Int_t n) final;
@@ -102,9 +102,9 @@ public:
    void     WriteFastArray(const Float_t   *f, Int_t n) final;
    void     WriteFastArray(const Double_t  *d, Int_t n) final;
    void     WriteFastArray(void  *start,  const TClass *cl, Int_t n=1, TMemberStreamer *s=nullptr) final;
-   Int_t    WriteFastArray(void **startp, const TClass *cl, Int_t n=1, Bool_t isPreAlloc=kFALSE, TMemberStreamer *s=nullptr) final;
+   Int_t    WriteFastArray(void **startp, const TClass *cl, Int_t n=1, bool isPreAlloc=false, TMemberStreamer *s=nullptr) final;
 
-   void     ReadFastArray(Bool_t    *, Int_t ) final;
+   void     ReadFastArray(bool      *, Int_t ) final;
    void     ReadFastArray(Char_t    *, Int_t ) final;
    void     ReadFastArrayString(Char_t   *, Int_t ) final;
    void     ReadFastArray(UChar_t   *, Int_t ) final;
@@ -125,7 +125,7 @@ public:
    void     ReadFastArrayWithFactor(Double_t *ptr, Int_t n, Double_t factor, Double_t minvalue) final;
    void     ReadFastArrayWithNbits(Double_t *ptr, Int_t n, Int_t nbits)  final;
    void     ReadFastArray(void  *, const TClass *, Int_t n=1, TMemberStreamer *s=nullptr, const TClass *onFileClass=nullptr) final;
-   void     ReadFastArray(void **, const TClass *, Int_t n=1, Bool_t isPreAlloc=kFALSE, TMemberStreamer *s=nullptr, const TClass *onFileClass=nullptr) final;
+   void     ReadFastArray(void **, const TClass *, Int_t n=1, bool isPreAlloc=false, TMemberStreamer *s=nullptr, const TClass *onFileClass=nullptr) final;
 
    ClassDefOverride(TBufferSQL, 0); // Implementation of TBuffer to load and write to a SQL database
 

--- a/tree/tree/inc/TChain.h
+++ b/tree/tree/inc/TChain.h
@@ -37,7 +37,7 @@ protected:
    Int_t        fNtrees;           ///<  Number of trees
    Int_t        fTreeNumber;       ///<! Current Tree number in fTreeOffset table
    Long64_t    *fTreeOffset;       ///<[fTreeOffsetLen] Array of variables
-   Bool_t       fCanDeleteRefs;    ///<! If true, TProcessIDs are deleted when closing a file
+   bool         fCanDeleteRefs;    ///<! If true, TProcessIDs are deleted when closing a file
    TTree       *fTree;             ///<! Pointer to current tree (Note: We do *not* own this tree.)
    TFile       *fFile;             ///<! Pointer to current file (We own the file).
    TObjArray   *fFiles;            ///< -> List of file names containing the trees (TChainElement, owned)
@@ -80,9 +80,9 @@ public:
    virtual Int_t     AddFileInfoList(TCollection* list, Long64_t nfiles = TTree::kMaxEntries);
    TFriendElement *AddFriend(const char* chainname, const char* dummy = "") override;
    TFriendElement *AddFriend(const char* chainname, TFile* dummy) override;
-   TFriendElement *AddFriend(TTree* chain, const char* alias = "", Bool_t warn = kFALSE) override;
+   TFriendElement *AddFriend(TTree* chain, const char* alias = "", bool warn = false) override;
    void      Browse(TBrowser*) override;
-   virtual void      CanDeleteRefs(Bool_t flag = kTRUE);
+   virtual void      CanDeleteRefs(bool flag = true);
    virtual void      CreatePackets();
    void      DirectoryAutoAdd(TDirectory *) override;
    Long64_t  Draw(const char* varexp, const TCut& selection, Option_t* option = "", Long64_t nentries = kMaxEntries, Long64_t firstentry = 0) override;
@@ -92,7 +92,7 @@ public:
    TBranch  *FindBranch(const char* name) override;
    TLeaf    *FindLeaf(const char* name) override;
    TBranch  *GetBranch(const char* name) override;
-   Bool_t    GetBranchStatus(const char* branchname) const override;
+   bool      GetBranchStatus(const char* branchname) const override;
    Long64_t  GetCacheSize() const override { return fTree ? fTree->GetCacheSize() : fCacheSize; }
    Long64_t  GetChainEntryNumber(Long64_t entry) const override;
    TClusterIterator GetClusterIterator(Long64_t firstentry) override;
@@ -121,10 +121,10 @@ public:
            Long64_t *GetTreeOffset() const { return fTreeOffset; }
            Int_t     GetTreeOffsetLen() const { return fTreeOffsetLen; }
    Double_t  GetWeight() const override;
-   Bool_t    InPlaceClone(TDirectory *newdirectory, const char *options = "") override;
+   bool      InPlaceClone(TDirectory *newdirectory, const char *options = "") override;
    Int_t     LoadBaskets(Long64_t maxmemory) override;
    Long64_t  LoadTree(Long64_t entry) override;
-           void      Lookup(Bool_t force = kFALSE);
+           void      Lookup(bool force = false);
    virtual void      Loop(Option_t *option="", Long64_t nentries=kMaxEntries, Long64_t firstentry=0); // *MENU*
    void      ls(Option_t *option="") const override;
    virtual Long64_t  Merge(const char *name, Option_t *option = "");
@@ -142,10 +142,10 @@ public:
    void      ResetBranchAddresses() override;
    void      SavePrimitive (std::ostream &out, Option_t *option="") override;
    Long64_t  Scan(const char *varexp="", const char *selection="", Option_t *option="", Long64_t nentries=kMaxEntries, Long64_t firstentry=0) override; // *MENU*
-   virtual void      SetAutoDelete(Bool_t autodel=kTRUE);
+   virtual void      SetAutoDelete(bool autodel=true);
    Int_t     SetBranchAddress(const char *bname,void *add, TBranch **ptr = nullptr) override;
-   Int_t     SetBranchAddress(const char *bname,void *add, TBranch **ptr, TClass *realClass, EDataType datatype, Bool_t isptr) override;
-   Int_t     SetBranchAddress(const char *bname,void *add, TClass *realClass, EDataType datatype, Bool_t isptr) override;
+   Int_t     SetBranchAddress(const char *bname,void *add, TBranch **ptr, TClass *realClass, EDataType datatype, bool isptr) override;
+   Int_t     SetBranchAddress(const char *bname,void *add, TClass *realClass, EDataType datatype, bool isptr) override;
    template <class T> Int_t SetBranchAddress(const char *bname, T **add, TBranch **ptr = nullptr) {
      return TTree::SetBranchAddress<T>(bname, add, ptr);
    }
@@ -157,7 +157,7 @@ public:
    }
 #endif
 
-   void      SetBranchStatus(const char *bname, Bool_t status = true, UInt_t *found = nullptr) override;
+   void      SetBranchStatus(const char *bname, bool status = true, UInt_t *found = nullptr) override;
    Int_t     SetCacheSize(Long64_t cacheSize = -1) override;
    void      SetDirectory(TDirectory *dir) override;
    void      SetEntryList(TEntryList *elist, Option_t *opt="") override;
@@ -166,7 +166,7 @@ public:
    void      SetMakeClass(Int_t make) override { TTree::SetMakeClass(make); if (fTree) fTree->SetMakeClass(make);}
    void      SetName(const char *name) override;
    virtual void      SetPacketSize(Int_t size = 100);
-   virtual void      SetProof(Bool_t on = kTRUE, Bool_t refresh = kFALSE, Bool_t gettreeheader = kFALSE);
+   virtual void      SetProof(bool on = true, bool refresh = false, bool gettreeheader = false);
    void      SetWeight(Double_t w=1, Option_t *option="") override;
    virtual void      UseCache(Int_t maxCacheSize = 10, Int_t pageSize = 0);
 

--- a/tree/tree/inc/TChainElement.h
+++ b/tree/tree/inc/TChainElement.h
@@ -40,9 +40,9 @@ protected:
    void         *fBaddress;          ///<! branch address when used as a branch
    TString       fBaddressClassName; ///<! Name of the class pointed to by fBaddress
    UInt_t        fBaddressType;      ///<! Type of the value pointed to by fBaddress
-   Bool_t        fBaddressIsPtr : 1; ///<! True if the address is a pointer to an address
-   Bool_t        fDecomposedObj : 1; ///<! True if the address needs the branch in MakeClass/DecomposedObj mode.
-   Bool_t        fCheckedType : 1;   ///<! True if the branch type and the address type have been checked.
+   bool          fBaddressIsPtr : 1; ///<! True if the address is a pointer to an address
+   bool          fDecomposedObj : 1; ///<! True if the address needs the branch in MakeClass/DecomposedObj mode.
+   bool          fCheckedType : 1;   ///<! True if the branch type and the address type have been checked.
    char         *fPackets;           ///<! Packet descriptor string
    TBranch     **fBranchPtr;         ///<! Address of user branch pointer (to updated upon loading a file)
    Int_t         fLoadResult;        ///<! Return value of TChain::LoadTree(); 0 means success
@@ -54,27 +54,27 @@ public:
    virtual void        CreatePackets();
    virtual void       *GetBaddress() const {return fBaddress;}
    virtual const char *GetBaddressClassName() const { return fBaddressClassName; }
-   virtual Bool_t      GetBaddressIsPtr() const { return fBaddressIsPtr; }
+   virtual bool        GetBaddressIsPtr() const { return fBaddressIsPtr; }
    virtual UInt_t      GetBaddressType() const { return fBaddressType; }
    virtual TBranch   **GetBranchPtr() const { return fBranchPtr; }
    virtual Long64_t    GetEntries() const {return fEntries;}
            Int_t       GetLoadResult() const { return fLoadResult; }
-           Bool_t      GetCheckedType() const { return fCheckedType; }
-           Bool_t      GetDecomposedObj() const { return fDecomposedObj; }
+           bool        GetCheckedType() const { return fCheckedType; }
+           bool        GetDecomposedObj() const { return fDecomposedObj; }
    virtual char       *GetPackets() const {return fPackets;}
    virtual Int_t       GetPacketSize() const {return fPacketSize;}
    virtual Int_t       GetStatus() const {return fStatus;}
-   virtual Bool_t      HasBeenLookedUp() { return TestBit(kHasBeenLookedUp); }
+   virtual bool        HasBeenLookedUp() { return TestBit(kHasBeenLookedUp); }
    void        ls(Option_t *option="") const override;
    virtual void        SetBaddress(void *add) {fBaddress = add;}
    virtual void        SetBaddressClassName(const char* clname) { fBaddressClassName = clname; }
-   virtual void        SetBaddressIsPtr(Bool_t isptr) { fBaddressIsPtr = isptr; }
+   virtual void        SetBaddressIsPtr(bool isptr) { fBaddressIsPtr = isptr; }
    virtual void        SetBaddressType(UInt_t type) { fBaddressType = type; }
    virtual void        SetBranchPtr(TBranch **ptr) { fBranchPtr = ptr; }
-           void        SetCheckedType(Bool_t m) { fCheckedType = m; }
-           void        SetDecomposedObj(Bool_t m) { fDecomposedObj = m; }
+           void        SetCheckedType(bool m) { fCheckedType = m; }
+           void        SetDecomposedObj(bool m) { fDecomposedObj = m; }
            void        SetLoadResult(Int_t result) { fLoadResult = result; }
-   virtual void        SetLookedUp(Bool_t y = kTRUE);
+   virtual void        SetLookedUp(bool y = true);
    virtual void        SetNumberEntries(Long64_t n) {fEntries=n;}
    virtual void        SetPacketSize(Int_t size = 100);
    virtual void        SetStatus(Int_t status) {fStatus = status;}

--- a/tree/tree/inc/TCut.h
+++ b/tree/tree/inc/TCut.h
@@ -26,10 +26,10 @@ class TCut : public TNamed {
 private:
    // Prevent meaningless operator (which otherwise can be reached via
    // the conversion to 'const char*'
-   Bool_t operator<(const TCut &rhs); // Intentional left unimplemented
-   Bool_t operator<=(const TCut &rhs); // Intentional left unimplemented
-   Bool_t operator>(const TCut &rhs); // Intentional left unimplemented
-   Bool_t operator>=(const TCut &rhs); // Intentional left unimplemented
+   bool operator<(const TCut &rhs); // Intentional left unimplemented
+   bool operator<=(const TCut &rhs); // Intentional left unimplemented
+   bool operator>(const TCut &rhs); // Intentional left unimplemented
+   bool operator>=(const TCut &rhs); // Intentional left unimplemented
 public:
    TCut();
    TCut(const char *title);
@@ -46,10 +46,10 @@ public:
    TCut&    operator*=(const TCut &rhs);
 
    // Comparison
-   Bool_t   operator==(const char *rhs) const;
-   Bool_t   operator==(const TCut &rhs) const;
-   Bool_t   operator!=(const char *rhs) const;
-   Bool_t   operator!=(const TCut &rhs) const;
+   bool     operator==(const char *rhs) const;
+   bool     operator==(const TCut &rhs) const;
+   bool     operator!=(const char *rhs) const;
+   bool     operator!=(const TCut &rhs) const;
 
    friend TCut operator+(const TCut &lhs, const char *rhs);
    friend TCut operator+(const char *lhs, const TCut &rhs);

--- a/tree/tree/inc/TEntryList.h
+++ b/tree/tree/inc/TEntryList.h
@@ -43,12 +43,12 @@ class TEntryList: public TNamed
 
    Long64_t         fLastIndexQueried;  ///<! used to optimize GetEntry() function from a loop
    Long64_t         fLastIndexReturned; ///<! used to optimize GetEntry() function from a loop
-   Bool_t           fShift;             ///<! true when some sub-lists don't correspond to trees
+   bool             fShift;             ///<! true when some sub-lists don't correspond to trees
                                         ///<  (when the entry list is used as input in TChain)
    TDirectory      *fDirectory;         ///<! Pointer to directory holding this tree
-   Bool_t           fReapply;           ///<  If true, TTree::Draw will 'reapply' the original cut
+   bool             fReapply;           ///<  If true, TTree::Draw will 'reapply' the original cut
 
-   void             GetFileName(const char *filename, TString &fn, Bool_t * = nullptr);
+   void             GetFileName(const char *filename, TString &fn, bool * = nullptr);
 
  public:
    enum {kBlockSize = 64000}; //number of entries in each block (not the physical size).
@@ -65,8 +65,8 @@ class TEntryList: public TNamed
    void                AddSubList(TEntryList *elist);
    virtual Int_t       Contains(Long64_t entry, TTree *tree = nullptr);
    virtual void        DirectoryAutoAdd(TDirectory *);
-   virtual Bool_t      Enter(Long64_t entry, TTree *tree = nullptr);
-   virtual Bool_t      Enter(Long64_t localentry, const char *treename, const char *filename);
+   virtual bool        Enter(Long64_t entry, TTree *tree = nullptr);
+   virtual bool        Enter(Long64_t localentry, const char *treename, const char *filename);
    void                EnterRange(Long64_t start, Long64_t end, TTree *tree = nullptr, UInt_t step = 1U);
    virtual TEntryList *GetCurrentList() const { return fCurrent; };
    virtual TEntryList *GetEntryList(const char *treename, const char *filename, Option_t *opt="");
@@ -79,12 +79,12 @@ class TEntryList: public TNamed
    virtual const char *GetTreeName() const { return fTreeName.Data(); }
    virtual const char *GetFileName() const { return fFileName.Data(); }
    virtual Int_t       GetTreeNumber() const { return fTreeNumber; }
-   virtual Bool_t      GetReapplyCut() const { return fReapply; };
+   virtual bool        GetReapplyCut() const { return fReapply; };
 
-   Bool_t IsValid() const
+   bool IsValid() const
    {
-      if ((fLists || fBlocks)) return kTRUE;
-      return kFALSE;
+      if ((fLists || fBlocks)) return true;
+      return false;
    }
 
    virtual Int_t       Merge(TCollection *list);
@@ -92,20 +92,20 @@ class TEntryList: public TNamed
    virtual Long64_t    Next();
    virtual void        OptimizeStorage();
    virtual Int_t       RelocatePaths(const char *newloc, const char *oldloc = nullptr);
-   virtual Bool_t      Remove(Long64_t entry, TTree *tree = nullptr);
+   virtual bool        Remove(Long64_t entry, TTree *tree = nullptr);
    virtual void        Reset();
-   virtual Int_t       ScanPaths(TList *roots, Bool_t notify = kTRUE);
+   virtual Int_t       ScanPaths(TList *roots, bool notify = true);
 
    void                Print(const Option_t* option = "") const override;
    virtual void        SetDirectory(TDirectory *dir);
    virtual void        SetEntriesToProcess(Long64_t nen) { fEntriesToProcess = nen; }
-   virtual void        SetShift(Bool_t shift) { fShift = shift; };
+   virtual void        SetShift(bool shift) { fShift = shift; };
    virtual void        SetTree(const TTree *tree);
    virtual void        SetTree(const char *treename, const char *filename);
    virtual void        SetTreeName(const char *treename){ fTreeName = treename; };
    virtual void        SetFileName(const char *filename){ fFileName = filename; };
    virtual void        SetTreeNumber(Int_t index) { fTreeNumber=index;  }
-   virtual void        SetReapplyCut(Bool_t apply = kFALSE) {fReapply = apply;}; // *TOGGLE* *GETTER=GetReapplyCut
+   virtual void        SetReapplyCut(bool apply = false) {fReapply = apply;}; // *TOGGLE* *GETTER=GetReapplyCut
    virtual void        Subtract(const TEntryList *elist);
 
    static  Int_t       Relocate(const char *fn,

--- a/tree/tree/inc/TEntryListArray.h
+++ b/tree/tree/inc/TEntryListArray.h
@@ -40,8 +40,8 @@ protected:
 //    virtual TList* GetSubLists() const {
 //       return fSubLists;
 //    };
-   virtual Bool_t      RemoveSubList(TEntryListArray *e, TTree *tree = nullptr);
-   virtual Bool_t      RemoveSubListForEntry(Long64_t entry, TTree *tree = nullptr);
+   virtual bool        RemoveSubList(TEntryListArray *e, TTree *tree = nullptr);
+   virtual bool        RemoveSubListForEntry(Long64_t entry, TTree *tree = nullptr);
    virtual TEntryListArray* SetEntry(Long64_t entry, TTree *tree = nullptr);
 
 
@@ -60,20 +60,20 @@ public:
    Int_t       Contains(Long64_t entry, TTree *tree = nullptr) override {
       return TEntryList::Contains(entry, tree);
    };
-   virtual Bool_t      Enter(Long64_t entry, TTree *tree, Long64_t subentry);
-   virtual Bool_t      Enter(Long64_t entry, const char *treename, const char *filename, Long64_t subentry);
-   Bool_t      Enter(Long64_t entry, TTree *tree = nullptr) override {
+   virtual bool        Enter(Long64_t entry, TTree *tree, Long64_t subentry);
+   virtual bool        Enter(Long64_t entry, const char *treename, const char *filename, Long64_t subentry);
+   bool                Enter(Long64_t entry, TTree *tree = nullptr) override {
       return Enter(entry, tree, -1);
    };
-   Bool_t              Enter(Long64_t entry, const char *treename, const char *filename) override
+   bool                Enter(Long64_t entry, const char *treename, const char *filename) override
    {
       return Enter(entry, treename, filename, -1);
    };
-//    virtual Bool_t      Enter(Long64_t entry, TTree *tree, const TEntryList *e);
+//    virtual bool        Enter(Long64_t entry, TTree *tree, const TEntryList *e);
    virtual TEntryListArray* GetSubListForEntry(Long64_t entry, TTree *tree = nullptr);
    void        Print(const Option_t* option = "") const override;
-   virtual Bool_t      Remove(Long64_t entry, TTree *tree, Long64_t subentry);
-   Bool_t      Remove(Long64_t entry, TTree *tree = nullptr) override {
+   virtual bool        Remove(Long64_t entry, TTree *tree, Long64_t subentry);
+   bool        Remove(Long64_t entry, TTree *tree = nullptr) override {
       return Remove(entry, tree, -1);
    };
    void        Reset() override;

--- a/tree/tree/inc/TEntryListBlock.h
+++ b/tree/tree/inc/TEntryListBlock.h
@@ -48,13 +48,13 @@ class TEntryListBlock:public TObject
    Int_t    fN;                 ///< size of fIndices for I/O  =fNPassed for list, fBlockSize for bits
    UShort_t *fIndices;          ///<[fN]
    Int_t    fType;              ///<0 - bits, 1 - list
-   Bool_t   fPassing;           ///<1 - stores entries that belong to the list
+   bool     fPassing;           ///<1 - stores entries that belong to the list
                                 ///<0 - stores entries that don't belong to the list
    UShort_t fCurrent;           ///<! to fasten  Contains() in list mode
    Int_t    fLastIndexQueried;  ///<! to optimize GetEntry() in a loop
    Int_t    fLastIndexReturned; ///<! to optimize GetEntry() in a loop
 
-   void Transform(Bool_t dir, UShort_t *indexnew);
+   void Transform(bool dir, UShort_t *indexnew);
 
  public:
 
@@ -64,8 +64,8 @@ class TEntryListBlock:public TObject
    ~TEntryListBlock() override;
    TEntryListBlock &operator=(const TEntryListBlock &rhs);
 
-   Bool_t  Enter(Int_t entry);
-   Bool_t  Remove(Int_t entry);
+   bool    Enter(Int_t entry);
+   bool    Remove(Int_t entry);
    Int_t   Contains(Int_t entry);
    void    OptimizeStorage();
    Int_t   Merge(TEntryListBlock *block);

--- a/tree/tree/inc/TEntryListFromFile.h
+++ b/tree/tree/inc/TEntryListFromFile.h
@@ -62,8 +62,8 @@ public:
    ~TEntryListFromFile() override;
    void        Add(const TEntryList * /* elist */) override {};
    Int_t       Contains(Long64_t /* entry */, TTree * /* tree = 0 */) override { return 0; };
-   Bool_t      Enter(Long64_t /* entry */, TTree * /* tree = 0 */) override { return kFALSE; };
-   Bool_t      Enter(Long64_t /* entry */, const char * /* treename */, const char * /* filename */) override { return kFALSE; };
+   bool        Enter(Long64_t /* entry */, TTree * /* tree = 0 */) override { return false; };
+   bool        Enter(Long64_t /* entry */, const char * /* treename */, const char * /* filename */) override { return false; };
    TEntryList *GetCurrentList() const override { return fCurrent; };
    TEntryList *GetEntryList(const char * /* treename */, const char * /* filename */, Option_t * /* opt="" */) override { return nullptr; };
 
@@ -83,7 +83,7 @@ public:
 
    Long64_t    Next() override;
    void        OptimizeStorage() override {};
-   Bool_t      Remove(Long64_t /*entry*/, TTree * /*tree = nullptr */) override{ return kFALSE; }
+   bool        Remove(Long64_t /*entry*/, TTree * /*tree = nullptr */) override{ return false; }
 
    void        Print(const Option_t* option = "") const override;
 

--- a/tree/tree/inc/TEventList.h
+++ b/tree/tree/inc/TEventList.h
@@ -34,7 +34,7 @@ protected:
    Int_t            fN;           ///<  Number of elements in the list
    Int_t            fSize;        ///<  Size of array
    Int_t            fDelta;       ///<  Increment size
-   Bool_t           fReapply;     ///<  If true, TTree::Draw will 'reapply' the original cut
+   bool             fReapply;     ///<  If true, TTree::Draw will 'reapply' the original cut
    Long64_t        *fList;        ///<[fN]Array of elements
    TDirectory      *fDirectory;   ///<! Pointer to directory holding this tree
 
@@ -45,8 +45,8 @@ public:
              ~TEventList() override;
    virtual void      Add(const TEventList *list);
    void      Clear(Option_t *option="") override {Reset(option);}
-   virtual Bool_t    Contains(Long64_t entry);
-   virtual Bool_t    ContainsRange(Long64_t entrymin, Long64_t entrymax);
+   virtual bool      Contains(Long64_t entry);
+   virtual bool      ContainsRange(Long64_t entrymin, Long64_t entrymax);
    virtual void      DirectoryAutoAdd(TDirectory *);
    virtual void      Enter(Long64_t entry);
    TDirectory       *GetDirectory() const {return fDirectory;}
@@ -54,7 +54,7 @@ public:
    virtual Int_t     GetIndex(Long64_t entry) const;
    virtual Long64_t *GetList() const { return fList; }
    virtual Int_t     GetN() const { return fN; }
-   virtual Bool_t    GetReapplyCut() const { return fReapply; };
+   virtual bool      GetReapplyCut() const { return fReapply; };
    virtual Int_t     GetSize() const { return fSize; }
    virtual void      Intersect(const TEventList *list);
    virtual Int_t     Merge(TCollection *list);
@@ -64,7 +64,7 @@ public:
    virtual void      SetDelta(Int_t delta=100) {fDelta = delta;}
    virtual void      SetDirectory(TDirectory *dir);
    void      SetName(const char *name) override; // *MENU*
-   virtual void      SetReapplyCut(Bool_t apply = kFALSE) {fReapply = apply;}; // *TOGGLE*
+   virtual void      SetReapplyCut(bool apply = false) {fReapply = apply;}; // *TOGGLE*
    virtual void      Sort();
    virtual void      Subtract(const TEventList *list);
 

--- a/tree/tree/inc/TFriendElement.h
+++ b/tree/tree/inc/TFriendElement.h
@@ -37,7 +37,7 @@ protected:
    TTree        *fTree;        ///<! pointer to the TTree described by this element
    TFile        *fFile;        ///<! pointer to the file containing the friend TTree
    TString       fTreeName;    ///<  name of the friend TTree
-   Bool_t        fOwnFile;     ///<  true if file is managed by this class
+   bool          fOwnFile;     ///<  true if file is managed by this class
 
    TFriendElement(const TFriendElement&) = delete;
    TFriendElement& operator=(const TFriendElement&) = delete;
@@ -64,7 +64,7 @@ public:
    virtual const char *GetTreeName() const {return fTreeName.Data();}
    void        ls(Option_t *option="") const override;
            void        Reset() { fTree = nullptr; fFile = nullptr; }
-           Bool_t      IsUpdated() const { return TestBit(kUpdated); }
+           bool        IsUpdated() const { return TestBit(kUpdated); }
            void        ResetUpdated() { ResetBit(kUpdated); }
            void        MarkUpdated() { SetBit(kUpdated); }
    void        RecursiveRemove(TObject *obj) override;

--- a/tree/tree/inc/TLeaf.h
+++ b/tree/tree/inc/TLeaf.h
@@ -72,8 +72,8 @@ protected:
    Int_t            fLen;             ///<  Number of fixed length elements in the leaf's data.
    Int_t            fLenType;         ///<  Number of bytes for this data type
    Int_t            fOffset;          ///<  Offset in ClonesArray object (if one)
-   Bool_t           fIsRange;         ///<  (=kTRUE if leaf has a range, kFALSE otherwise).  This is equivalent to being a 'leafcount'.  For a TLeafElement the range information is actually store in the TBranchElement.
-   Bool_t           fIsUnsigned;      ///<  (=kTRUE if unsigned, kFALSE otherwise)
+   bool             fIsRange;         ///<  (=kTRUE if leaf has a range, kFALSE otherwise).  This is equivalent to being a 'leafcount'.  For a TLeafElement the range information is actually store in the TBranchElement.
+   bool             fIsUnsigned;      ///<  (=kTRUE if unsigned, kFALSE otherwise)
    TLeaf           *fLeafCount;       ///<  Pointer to Leaf count if variable length (we do not own the counter)
    TBranch         *fBranch;          ///<! Pointer to supporting branch (we do not own the branch)
    LeafCountValues *fLeafCountValues; ///<! Cache of collection/array sizes
@@ -109,7 +109,7 @@ public:
    ~TLeaf() override;
 
            void     Browse(TBrowser *b) override;
-   virtual Bool_t   CanGenerateOffsetArray() {return fLeafCount;} // overload and return true if this leaf can generate its own offset array.
+   virtual bool     CanGenerateOffsetArray() {return fLeafCount;} // overload and return true if this leaf can generate its own offset array.
    virtual void     Export(TClonesArray *, Int_t) {}
    virtual void     FillBasket(TBuffer &b);
    virtual Int_t   *GenerateOffsetArray(Int_t base, Int_t events) { return GenerateOffsetArrayBase(base, events); }
@@ -143,11 +143,11 @@ public:
    virtual LongDouble_t GetValueLongDouble(Int_t i = 0) const { return GetValue(i); } // overload only when it matters.
    template <typename T> T GetTypedValue(Int_t i = 0) const { return GetValueHelper<T>::Exec(this, i); }
 
-   virtual Bool_t   IncludeRange(TLeaf *) { return kFALSE; } // overload to copy/set fMinimum and fMaximum to include/be wide than those of the parameter
+   virtual bool     IncludeRange(TLeaf *) { return false; } // overload to copy/set fMinimum and fMaximum to include/be wide than those of the parameter
    virtual void     Import(TClonesArray *, Int_t) {}
-   virtual Bool_t   IsOnTerminalBranch() const { return kTRUE; }
-   virtual Bool_t   IsRange() const { return fIsRange; }
-   virtual Bool_t   IsUnsigned() const { return fIsUnsigned; }
+   virtual bool     IsOnTerminalBranch() const { return true; }
+   virtual bool     IsRange() const { return fIsRange; }
+   virtual bool     IsUnsigned() const { return fIsUnsigned; }
    virtual void     PrintValue(Int_t i = 0) const;
    virtual void     ReadBasket(TBuffer &) {}
    virtual void     ReadBasketExport(TBuffer &, TClonesArray *, Int_t) {}
@@ -156,14 +156,14 @@ public:
    virtual void     ReadValue(std::istream & /*s*/, Char_t /*delim*/ = ' ') {
       Error("ReadValue", "Not implemented!");
    }
-           Int_t    ResetAddress(void *add, Bool_t calledFromDestructor = kFALSE);
+           Int_t    ResetAddress(void *add, bool calledFromDestructor = false);
    virtual void     SetAddress(void *add = nullptr);
    virtual void     SetBranch(TBranch *branch) { fBranch = branch; }
    virtual void     SetLeafCount(TLeaf *leaf);
    virtual void     SetLen(Int_t len = 1) { fLen = len; }
    virtual void     SetOffset(Int_t offset = 0) { fOffset = offset; }
-   virtual void     SetRange(Bool_t range = kTRUE) { fIsRange = range; }
-   virtual void     SetUnsigned() { fIsUnsigned = kTRUE; }
+   virtual void     SetRange(bool range = true) { fIsRange = range; }
+   virtual void     SetUnsigned() { fIsUnsigned = true; }
 
    ClassDefOverride(TLeaf, 2); // Leaf: description of a Branch data type
 };

--- a/tree/tree/inc/TLeaf.h
+++ b/tree/tree/inc/TLeaf.h
@@ -72,8 +72,8 @@ protected:
    Int_t            fLen;             ///<  Number of fixed length elements in the leaf's data.
    Int_t            fLenType;         ///<  Number of bytes for this data type
    Int_t            fOffset;          ///<  Offset in ClonesArray object (if one)
-   bool             fIsRange;         ///<  (=kTRUE if leaf has a range, kFALSE otherwise).  This is equivalent to being a 'leafcount'.  For a TLeafElement the range information is actually store in the TBranchElement.
-   bool             fIsUnsigned;      ///<  (=kTRUE if unsigned, kFALSE otherwise)
+   bool             fIsRange;         ///<  (=true if leaf has a range, false otherwise).  This is equivalent to being a 'leafcount'.  For a TLeafElement the range information is actually store in the TBranchElement.
+   bool             fIsUnsigned;      ///<  (=true if unsigned, false otherwise)
    TLeaf           *fLeafCount;       ///<  Pointer to Leaf count if variable length (we do not own the counter)
    TBranch         *fBranch;          ///<! Pointer to supporting branch (we do not own the branch)
    LeafCountValues *fLeafCountValues; ///<! Cache of collection/array sizes

--- a/tree/tree/inc/TLeafB.h
+++ b/tree/tree/inc/TLeafB.h
@@ -44,7 +44,7 @@ public:
    const char     *GetTypeName() const override;
    Double_t        GetValue(Int_t i = 0) const override { return IsUnsigned() ? (Double_t)((UChar_t) fValue[i]) : (Double_t)fValue[i]; }
    void           *GetValuePointer() const override { return fValue; }
-   Bool_t          IncludeRange(TLeaf *) override;
+   bool            IncludeRange(TLeaf *) override;
    void            Import(TClonesArray* list, Int_t n) override;
    void            PrintValue(Int_t i = 0) const override;
    void            ReadBasket(TBuffer&) override;

--- a/tree/tree/inc/TLeafC.h
+++ b/tree/tree/inc/TLeafC.h
@@ -44,7 +44,7 @@ public:
    Double_t        GetValue(Int_t i=0) const override;
    void           *GetValuePointer() const override {return fValue;}
    virtual char   *GetValueString() const {return fValue;}
-   Bool_t          IncludeRange(TLeaf *) override;
+   bool            IncludeRange(TLeaf *) override;
    void            Import(TClonesArray *list, Int_t n) override;
    void            PrintValue(Int_t i=0) const override;
    void            ReadBasket(TBuffer &b) override;

--- a/tree/tree/inc/TLeafElement.h
+++ b/tree/tree/inc/TLeafElement.h
@@ -46,7 +46,7 @@ public:
    TLeafElement(TBranch *parent, const char *name, Int_t id, Int_t type);
    ~TLeafElement() override;
 
-   Bool_t           CanGenerateOffsetArray() override { return fLeafCount && fLenType; }
+   bool             CanGenerateOffsetArray() override { return fLeafCount && fLenType; }
    virtual Int_t   *GenerateOffsetArrayBase(Int_t /*base*/, Int_t /*events*/) { return nullptr; }
    DeserializeType  GetDeserializeType() const override;
 
@@ -58,16 +58,16 @@ public:
    Int_t            GetNdata() const override { return ((TBranchElement*)fBranch)->GetNdata()*fLen; }
    const char      *GetTypeName() const override { return ((TBranchElement*)fBranch)->GetTypeName(); }
 
-   Double_t         GetValue(Int_t i=0) const override { return ((TBranchElement*)fBranch)->GetValue(i, fLen, kFALSE);}
-   Long64_t         GetValueLong64(Int_t i = 0) const override { return ((TBranchElement*)fBranch)->GetTypedValue<Long64_t>(i, fLen, kFALSE); }
-   LongDouble_t     GetValueLongDouble(Int_t i = 0) const override { return ((TBranchElement*)fBranch)->GetTypedValue<LongDouble_t>(i, fLen, kFALSE); }
-   template<typename T> T GetTypedValueSubArray(Int_t i=0, Int_t j=0) const {return ((TBranchElement*)fBranch)->GetTypedValue<T>(i, j, kTRUE);}
+   Double_t         GetValue(Int_t i=0) const override { return ((TBranchElement*)fBranch)->GetValue(i, fLen, false);}
+   Long64_t         GetValueLong64(Int_t i = 0) const override { return ((TBranchElement*)fBranch)->GetTypedValue<Long64_t>(i, fLen, false); }
+   LongDouble_t     GetValueLongDouble(Int_t i = 0) const override { return ((TBranchElement*)fBranch)->GetTypedValue<LongDouble_t>(i, fLen, false); }
+   template<typename T> T GetTypedValueSubArray(Int_t i=0, Int_t j=0) const {return ((TBranchElement*)fBranch)->GetTypedValue<T>(i, j, true);}
 
    bool             ReadBasketFast(TBuffer&, Long64_t) override;
 
    void            *GetValuePointer() const override { return ((TBranchElement*)fBranch)->GetValuePointer(); }
-   Bool_t           IncludeRange(TLeaf *) override;
-   Bool_t           IsOnTerminalBranch() const override;
+   bool             IncludeRange(TLeaf *) override;
+   bool             IsOnTerminalBranch() const override;
    void             PrintValue(Int_t i=0) const override {((TBranchElement*)fBranch)->PrintValue(i);}
    void             SetLeafCount(TLeaf *leaf) override { fLeafCount = leaf; }
 

--- a/tree/tree/inc/TLeafG.h
+++ b/tree/tree/inc/TLeafG.h
@@ -47,7 +47,7 @@ public:
    Long64_t        GetValueLong64(Int_t i = 0) const override;
    LongDouble_t    GetValueLongDouble(Int_t i = 0) const override;
    void           *GetValuePointer() const override { return fValue; }
-   Bool_t          IncludeRange(TLeaf *) override;
+   bool            IncludeRange(TLeaf *) override;
    void            Import(TClonesArray *list, Int_t n) override;
    void            PrintValue(Int_t i=0) const override;
    void            ReadBasket(TBuffer &b) override;

--- a/tree/tree/inc/TLeafI.h
+++ b/tree/tree/inc/TLeafI.h
@@ -45,7 +45,7 @@ public:
    Int_t           GetMinimum() const override { return fMinimum; }
    Double_t        GetValue(Int_t i=0) const override;
    void           *GetValuePointer() const override { return fValue; }
-   Bool_t          IncludeRange(TLeaf *) override;
+   bool            IncludeRange(TLeaf *) override;
    void            Import(TClonesArray *list, Int_t n) override;
    void            PrintValue(Int_t i=0) const override;
    void            ReadBasket(TBuffer &b) override;

--- a/tree/tree/inc/TLeafL.h
+++ b/tree/tree/inc/TLeafL.h
@@ -47,7 +47,7 @@ public:
    Long64_t        GetValueLong64(Int_t i = 0) const override;
    LongDouble_t    GetValueLongDouble(Int_t i = 0) const override;
    void           *GetValuePointer() const override { return fValue; }
-   Bool_t          IncludeRange(TLeaf *) override;
+   bool            IncludeRange(TLeaf *) override;
    void            Import(TClonesArray *list, Int_t n) override;
    void            PrintValue(Int_t i=0) const override;
    void            ReadBasket(TBuffer &b) override;

--- a/tree/tree/inc/TLeafO.h
+++ b/tree/tree/inc/TLeafO.h
@@ -26,10 +26,10 @@
 class TLeafO : public TLeaf {
 
 protected:
-   Bool_t       fMinimum;         ///<  Minimum value if leaf range is specified
-   Bool_t       fMaximum;         ///<  Maximum value if leaf range is specified
-   Bool_t       *fValue;          ///<! Pointer to data buffer
-   Bool_t       **fPointer;       ///<! Address of a pointer to data buffer!
+   bool         fMinimum;         ///<  Minimum value if leaf range is specified
+   bool         fMaximum;         ///<  Maximum value if leaf range is specified
+   bool         *fValue;          ///<! Pointer to data buffer
+   bool         **fPointer;       ///<! Address of a pointer to data buffer!
 
 public:
    TLeafO();
@@ -44,15 +44,15 @@ public:
    const char     *GetTypeName() const override;
    Double_t        GetValue(Int_t i=0) const override;
    void           *GetValuePointer() const override { return fValue; }
-   Bool_t          IncludeRange(TLeaf *) override;
+   bool            IncludeRange(TLeaf *) override;
    void            Import(TClonesArray *list, Int_t n) override;
    void            PrintValue(Int_t i=0) const override;
    void            ReadBasket(TBuffer &b) override;
    void            ReadBasketExport(TBuffer &b, TClonesArray *list, Int_t n) override;
    void            ReadValue(std::istream& s, Char_t delim = ' ') override;
    void            SetAddress(void *add=nullptr) override;
-   virtual void    SetMaximum(Bool_t max) { fMaximum = max; }
-   virtual void    SetMinimum(Bool_t min) { fMinimum = min; }
+   virtual void    SetMaximum(bool max) { fMaximum = max; }
+   virtual void    SetMinimum(bool min) { fMinimum = min; }
 
    // Deserialize N events from an input buffer.  Since chars are stored unchanged, there
    // is nothing to do here but return true if we don't have variable-length arrays.

--- a/tree/tree/inc/TLeafObject.h
+++ b/tree/tree/inc/TLeafObject.h
@@ -33,7 +33,7 @@ class TLeafObject : public TLeaf {
 protected:
    TClassRef    fClass;          ///<! pointer to class
    void       **fObjAddress;     ///<! Address of Pointer to object
-   Bool_t       fVirtual;        ///<  Support for polymorphism, when set classname is written with object.
+   bool         fVirtual;        ///<  Support for polymorphism, when set classname is written with object.
 
 public:
    enum EStatusBits {
@@ -53,7 +53,7 @@ public:
    TLeafObject(TBranch *parent, const char *name, const char *type);
    ~TLeafObject() override;
 
-   Bool_t          CanGenerateOffsetArray() override { return false; }
+   bool            CanGenerateOffsetArray() override { return false; }
    void            FillBasket(TBuffer &b) override;
    virtual Int_t  *GenerateOffsetArrayBase(Int_t /*base*/, Int_t /*events*/) { return nullptr; }
    TClass         *GetClass() const {return fClass;}
@@ -61,13 +61,13 @@ public:
    TObject        *GetObject() const {return (TObject*)(*fObjAddress);}
    const char     *GetTypeName() const override;
    void           *GetValuePointer() const override {return fObjAddress;}
-   Bool_t          IsOnTerminalBranch() const override;
-   Bool_t          IsVirtual() const {return fVirtual;}
-   Bool_t          Notify() override;
+   bool            IsOnTerminalBranch() const override;
+   bool            IsVirtual() const {return fVirtual;}
+   bool            Notify() override;
    void            PrintValue(Int_t i=0) const override;
    void            ReadBasket(TBuffer &b) override;
    void            SetAddress(void *add=nullptr) override;
-   virtual void    SetVirtual(Bool_t virt=kTRUE) {fVirtual=virt;}
+   virtual void    SetVirtual(bool virt=true) {fVirtual=virt;}
 
    ClassDefOverride(TLeafObject,4);  //A TLeaf for a general object derived from TObject.
 };

--- a/tree/tree/inc/TLeafS.h
+++ b/tree/tree/inc/TLeafS.h
@@ -44,7 +44,7 @@ public:
    const char     *GetTypeName() const override;
    Double_t        GetValue(Int_t i=0) const override;
    void           *GetValuePointer() const override { return fValue; }
-   Bool_t          IncludeRange(TLeaf *) override;
+   bool            IncludeRange(TLeaf *) override;
    void            Import(TClonesArray *list, Int_t n) override;
    void            PrintValue(Int_t i=0) const override;
    void            ReadBasket(TBuffer &b) override;

--- a/tree/tree/inc/TQueryResult.h
+++ b/tree/tree/inc/TQueryResult.h
@@ -35,7 +35,7 @@ class TBrowser;
 class TTreePlayer;
 class TQueryResult;
 
-Bool_t operator==(const TQueryResult &qr1, const TQueryResult &qr2);
+bool operator==(const TQueryResult &qr1, const TQueryResult &qr2);
 
 
 class TQueryResult : public TNamed {
@@ -55,7 +55,7 @@ public:
 
 protected:
    Int_t           fSeqNum;       ///< query unique sequential number
-   Bool_t          fDraw;         ///< true if draw action query
+   bool            fDraw;         ///< true if draw action query
    EQueryStatus    fStatus;       ///< query status
    TDatime         fStart;        ///< time when processing started
    TDatime         fEnd;          ///< time when processing ended
@@ -71,8 +71,8 @@ protected:
    TString         fLibList;      ///< blank-separated list of libs loaded at fStart
    TString         fParList;      ///< colon-separated list of PAR loaded at fStart
    TList          *fOutputList;   ///< output list
-   Bool_t          fFinalized;    ///< whether Terminate has been run
-   Bool_t          fArchived;     ///< whether the query has been archived
+   bool            fFinalized;    ///< whether Terminate has been run
+   bool            fArchived;     ///< whether the query has been archived
    TString         fResultFile;   ///< URL of the file where results have been archived
    Float_t         fPrepTime;     ///< Prepare time (seconds) (millisec precision)
    Float_t         fInitTime;     ///< Initialization time (seconds) (millisec precision)
@@ -93,9 +93,9 @@ protected:
    virtual void    RecordEnd(EQueryStatus status, TList *outlist = nullptr);
    void            SaveSelector(const char *selec);
    void            SetArchived(const char *archfile);
-   virtual void    SetFinalized() { fFinalized = kTRUE; }
-   virtual void    SetInputList(TList *in, Bool_t adopt = kTRUE);
-   virtual void    SetOutputList(TList *out, Bool_t adopt = kTRUE);
+   virtual void    SetFinalized() { fFinalized = true; }
+   virtual void    SetInputList(TList *in, bool adopt = true);
+   virtual void    SetOutputList(TList *out, bool adopt = true);
    virtual void    SetProcessInfo(Long64_t ent, Float_t cpu = 0.,
                                   Long64_t siz = -1,
                                   Float_t inittime = 0., Float_t proctime = 0.);
@@ -110,7 +110,7 @@ public:
                     fInputList(nullptr), fEntries(-1), fFirst(-1), fBytes(0),
                     fLogFile(nullptr), fSelecHdr(nullptr), fSelecImp(nullptr),
                     fLibList("-"), fOutputList(nullptr),
-                    fFinalized(kFALSE), fArchived(kFALSE), fPrepTime(0.),
+                    fFinalized(false), fArchived(false), fPrepTime(0.),
                     fInitTime(0.), fProcTime(0.), fMergeTime(0.),
                     fRecvTime(-1), fTermTime(0.), fNumWrks(-1), fNumMergers(-1) { }
    ~TQueryResult() override;
@@ -144,19 +144,19 @@ public:
    Int_t          GetNumWrks() const { return fNumWrks; }
    Int_t          GetNumMergers() const { return fNumMergers; }
 
-   Bool_t         IsArchived() const { return fArchived; }
-   virtual Bool_t IsDone() const { return (fStatus > kRunning); }
-   Bool_t         IsDraw() const { return fDraw; }
-   Bool_t         IsFinalized() const { return fFinalized; }
+   bool           IsArchived() const { return fArchived; }
+   virtual bool   IsDone() const { return (fStatus > kRunning); }
+   bool           IsDraw() const { return fDraw; }
+   bool           IsFinalized() const { return fFinalized; }
 
-   Bool_t         Matches(const char *ref);
+   bool           Matches(const char *ref);
 
    void           Print(Option_t *opt = "") const override;
 
    ClassDefOverride(TQueryResult,5)  //Class describing a query
 };
 
-inline Bool_t operator!=(const TQueryResult &qr1,  const TQueryResult &qr2)
+inline bool operator!=(const TQueryResult &qr1,  const TQueryResult &qr2)
    { return !(qr1 == qr2); }
 
 #endif

--- a/tree/tree/inc/TSelector.h
+++ b/tree/tree/inc/TSelector.h
@@ -53,13 +53,13 @@ public:
    virtual void        Init(TTree *) { }
    virtual void        Begin(TTree *) { }
    virtual void        SlaveBegin(TTree *) { }
-           Bool_t      Notify() override { return kTRUE; }
+           bool        Notify() override { return true; }
            const char *GetOption() const override { return fOption.Data(); }
    virtual Long64_t    GetStatus() const { return fStatus; }
    virtual Int_t       GetEntry(Long64_t /*entry*/, Int_t /*getall*/ = 0) { return 0; }
-   virtual Bool_t      ProcessCut(Long64_t /*entry*/);
+   virtual bool        ProcessCut(Long64_t /*entry*/);
    virtual void        ProcessFill(Long64_t /*entry*/);
-   virtual Bool_t      Process(Long64_t /*entry*/);
+   virtual bool        Process(Long64_t /*entry*/);
    virtual void        ImportOutput(TList *output);
    virtual void        SetOption(const char *option) { fOption = option; }
    virtual void        SetObject(TObject *obj) { fObject = obj; }
@@ -74,7 +74,7 @@ public:
    virtual void        ResetAbort() { fAbort = kContinue; }
 
    static  TSelector  *GetSelector(const char *filename);
-   static  Bool_t      IsStandardDraw(const char *selec);
+   static  bool        IsStandardDraw(const char *selec);
 
    ClassDefOverride(TSelector,2)  //A utility class for tree and object processing
 };

--- a/tree/tree/inc/TSelectorList.h
+++ b/tree/tree/inc/TSelectorList.h
@@ -31,8 +31,8 @@
 class TSelectorList : public THashList {
 
 private:
-   Bool_t UnsetDirectory(TObject *obj);
-   Bool_t CheckDuplicateName(TObject *obj);
+   bool UnsetDirectory(TObject *obj);
+   bool CheckDuplicateName(TObject *obj);
 
 public:
    TSelectorList() : THashList() { SetOwner();}

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -136,10 +136,10 @@ protected:
    TBranchRef    *fBranchRef;             ///<  Branch supporting the TRefTable (if any)
    UInt_t         fFriendLockStatus;      ///<! Record which method is locking the friend recursion
    TBuffer       *fTransientBuffer;       ///<! Pointer to the current transient buffer.
-   Bool_t         fCacheDoAutoInit;       ///<! true if cache auto creation or resize check is needed
-   Bool_t         fCacheDoClusterPrefetch;///<! true if cache is prefetching whole clusters
-   Bool_t         fCacheUserSet;          ///<! true if the cache setting was explicitly given by user
-   Bool_t         fIMTEnabled;            ///<! true if implicit multi-threading is enabled for this tree
+   bool           fCacheDoAutoInit;       ///<! true if cache auto creation or resize check is needed
+   bool           fCacheDoClusterPrefetch;///<! true if cache is prefetching whole clusters
+   bool           fCacheUserSet;          ///<! true if the cache setting was explicitly given by user
+   bool           fIMTEnabled;            ///<! true if implicit multi-threading is enabled for this tree
    UInt_t         fNEntriesSinceSorting;  ///<! Number of entries processed since the last re-sorting of branches
    std::vector<std::pair<Long64_t,TBranch*>> fSortedBranches; ///<! Branches to be processed in parallel when IMT is on, sorted by average task time
    std::vector<TBranch*> fSeqBranches;    ///<! Branches to be processed sequentially when IMT is on
@@ -156,7 +156,7 @@ protected:
 
 private:
    // For simplicity, although fIMTFlush is always disabled in non-IMT builds, we don't #ifdef it out.
-   mutable Bool_t fIMTFlush{false};               ///<! True if we are doing a multithreaded flush.
+   mutable bool fIMTFlush{false};               ///<! True if we are doing a multithreaded flush.
    mutable std::atomic<Long64_t> fIMTTotBytes;    ///<! Total bytes for the IMT flush baskets
    mutable std::atomic<Long64_t> fIMTZipBytes;    ///<! Zip bytes for the IMT flush baskets.
 
@@ -173,24 +173,24 @@ protected:
    virtual TBranch *BranchImpRef(const char* branchname, const char* classname, TClass* ptrClass, void* addobj, Int_t bufsize, Int_t splitlevel);
    virtual TBranch *BranchImpRef(const char* branchname, TClass* ptrClass, EDataType datatype, void* addobj, Int_t bufsize, Int_t splitlevel);
    virtual TBranch *BranchImpArr(const char* branchname, EDataType datatype, std::size_t N, void* addobj, Int_t bufsize, Int_t splitlevel);
-   virtual Int_t    CheckBranchAddressType(TBranch* branch, TClass* ptrClass, EDataType datatype, Bool_t ptr);
-   virtual TBranch *BronchExec(const char* name, const char* classname, void* addobj, Bool_t isptrptr, Int_t bufsize, Int_t splitlevel);
+   virtual Int_t    CheckBranchAddressType(TBranch* branch, TClass* ptrClass, EDataType datatype, bool ptr);
+   virtual TBranch *BronchExec(const char* name, const char* classname, void* addobj, bool isptrptr, Int_t bufsize, Int_t splitlevel);
    friend  TBranch *TTreeBranchImpRef(TTree *tree, const char* branchname, TClass* ptrClass, EDataType datatype, void* addobj, Int_t bufsize, Int_t splitlevel);
    Int_t    SetBranchAddressImp(TBranch *branch, void* addr, TBranch** ptr);
    virtual TLeaf   *GetLeafImpl(const char* branchname, const char* leafname);
 
-   Long64_t         GetCacheAutoSize(Bool_t withDefault = kFALSE);
+   Long64_t         GetCacheAutoSize(bool withDefault = false);
    char             GetNewlineValue(std::istream &inputStream);
    void             ImportClusterRanges(TTree *fromtree);
    void             MoveReadCache(TFile *src, TDirectory *dir);
-   Int_t            SetCacheSizeAux(Bool_t autocache = kTRUE, Long64_t cacheSize = 0);
+   Int_t            SetCacheSizeAux(bool autocache = true, Long64_t cacheSize = 0);
 
    class TFriendLock {
       // Helper class to prevent infinite recursion in the
       // usage of TTree Friends. Implemented in TTree.cxx.
       TTree  *fTree;      // Pointer to the locked tree
       UInt_t  fMethodBit; // BIT for the locked method
-      Bool_t  fPrevious;  // Previous value of the BIT.
+      bool    fPrevious;  // Previous value of the BIT.
 
    protected:
       TFriendLock(const TFriendLock&);
@@ -318,14 +318,14 @@ public:
    TTree(const TTree& tt) = delete;
    TTree& operator=(const TTree& tt) = delete;
 
-   virtual Int_t           AddBranchToCache(const char *bname, Bool_t subbranches = kFALSE);
-   virtual Int_t           AddBranchToCache(TBranch *branch,   Bool_t subbranches = kFALSE);
-   virtual Int_t           DropBranchFromCache(const char *bname, Bool_t subbranches = kFALSE);
-   virtual Int_t           DropBranchFromCache(TBranch *branch,   Bool_t subbranches = kFALSE);
+   virtual Int_t           AddBranchToCache(const char *bname, bool subbranches = false);
+   virtual Int_t           AddBranchToCache(TBranch *branch,   bool subbranches = false);
+   virtual Int_t           DropBranchFromCache(const char *bname, bool subbranches = false);
+   virtual Int_t           DropBranchFromCache(TBranch *branch,   bool subbranches = false);
    void                    AddClone(TTree*);
    virtual TFriendElement *AddFriend(const char* treename, const char* filename = "");
    virtual TFriendElement *AddFriend(const char* treename, TFile* file);
-   virtual TFriendElement *AddFriend(TTree* tree, const char* alias = "", Bool_t warn = kFALSE);
+   virtual TFriendElement *AddFriend(TTree* tree, const char* alias = "", bool warn = false);
    // As the TBasket invokes Add{Tot,Zip}Bytes on its parent tree, we must do these updates in a thread-safe
    // manner only when we are flushing multiple baskets in parallel.
    virtual void            AddTotBytes(Int_t tot) { if (fIMTFlush) { fIMTTotBytes += tot; } else { fTotBytes += tot; } }
@@ -418,11 +418,11 @@ public:
    virtual TBranch        *BranchRef();
            void            Browse(TBrowser*) override;
    virtual Int_t           BuildIndex(const char *majorname, const char *minorname = "0");
-   TStreamerInfo          *BuildStreamerInfo(TClass* cl, void *pointer = nullptr, Bool_t canOptimize = kTRUE);
+   TStreamerInfo          *BuildStreamerInfo(TClass* cl, void *pointer = nullptr, bool canOptimize = true);
    virtual TFile          *ChangeFile(TFile* file);
    virtual TTree          *CloneTree(Long64_t nentries = -1, Option_t* option = "");
-   virtual void            CopyAddresses(TTree*,Bool_t undo = kFALSE);
-   virtual Long64_t        CopyEntries(TTree* tree, Long64_t nentries = -1, Option_t *option = "", Bool_t needCopyAddresses = false);
+   virtual void            CopyAddresses(TTree*,bool undo = false);
+   virtual Long64_t        CopyEntries(TTree* tree, Long64_t nentries = -1, Option_t *option = "", bool needCopyAddresses = false);
    virtual TTree          *CopyTree(const char* selection, Option_t* option = "", Long64_t nentries = kMaxEntries, Long64_t firstentry = 0);
    virtual TBasket        *CreateBasket(TBranch*);
    virtual void            DirectoryAutoAdd(TDirectory *);
@@ -433,12 +433,12 @@ public:
    virtual Long64_t        Draw(const char* varexp, const char* selection, Option_t* option = "", Long64_t nentries = kMaxEntries, Long64_t firstentry = 0); // *MENU*
    virtual void            DropBaskets();
    virtual void            DropBuffers(Int_t nbytes);
-           Bool_t          EnableCache();
+           bool            EnableCache();
    virtual Int_t           Fill();
    virtual TBranch        *FindBranch(const char* name);
    virtual TLeaf          *FindLeaf(const char* name);
    virtual Int_t           Fit(const char* funcname, const char* varexp, const char* selection = "", Option_t* option = "", Option_t* goption = "", Long64_t nentries = kMaxEntries, Long64_t firstentry = 0); // *MENU*
-   virtual Int_t           FlushBaskets(Bool_t create_cluster = true) const;
+   virtual Int_t           FlushBaskets(bool create_cluster = true) const;
    virtual const char     *GetAlias(const char* aliasName) const;
            UInt_t          GetAllocationCount() const { return fAllocationCount; }
 #ifdef R__TRACK_BASKET_ALLOC_TIME
@@ -448,13 +448,13 @@ public:
    virtual Long64_t        GetAutoSave()  const {return fAutoSave;}
    virtual TBranch        *GetBranch(const char* name);
    virtual TBranchRef     *GetBranchRef() const { return fBranchRef; };
-   virtual Bool_t          GetBranchStatus(const char* branchname) const;
+   virtual bool            GetBranchStatus(const char* branchname) const;
    static  Int_t           GetBranchStyle();
    virtual Long64_t        GetCacheSize() const { return fCacheSize; }
    virtual TClusterIterator GetClusterIterator(Long64_t firstentry);
    virtual Long64_t        GetChainEntryNumber(Long64_t entry) const { return entry; }
    virtual Long64_t        GetChainOffset() const { return fChainOffset; }
-   virtual Bool_t          GetClusterPrefetch() const { return fCacheDoClusterPrefetch; }
+   virtual bool            GetClusterPrefetch() const { return fCacheDoClusterPrefetch; }
            TFile          *GetCurrentFile() const;
            Int_t           GetDefaultEntryOffsetLen() const {return fDefaultEntryOffsetLen;}
            Long64_t        GetDebugMax()  const { return fDebugMax; }
@@ -477,11 +477,11 @@ public:
    virtual TTree          *GetFriend(const char*) const;
    virtual const char     *GetFriendAlias(TTree*) const;
            TH1            *GetHistogram() { return GetPlayer()->GetHistogram(); }
-   virtual Bool_t          GetImplicitMT() { return fIMTEnabled; }
+   virtual bool            GetImplicitMT() { return fIMTEnabled; }
    virtual Int_t          *GetIndex() { return &fIndex.fArray[0]; }
    virtual Double_t       *GetIndexValues() { return &fIndexValues.fArray[0]; }
            ROOT::TIOFeatures GetIOFeatures() const;
-   virtual TIterator      *GetIteratorOnAllLeaves(Bool_t dir = kIterForward);
+   virtual TIterator      *GetIteratorOnAllLeaves(bool dir = kIterForward);
    virtual TLeaf          *GetLeaf(const char* branchname, const char* leafname);
    virtual TLeaf          *GetLeaf(const char* name);
    virtual TList          *GetListOfClones() { return fClones; }
@@ -505,7 +505,7 @@ public:
    virtual Int_t           GetPacketSize() const { return fPacketSize; }
    virtual TVirtualPerfStats *GetPerfStats() const { return fPerfStats; }
            TTreeCache     *GetReadCache(TFile *file) const;
-           TTreeCache     *GetReadCache(TFile *file, Bool_t create);
+           TTreeCache     *GetReadCache(TFile *file, bool create);
    virtual Long64_t        GetReadEntry()  const { return fReadEntry; }
    virtual Long64_t        GetReadEvent()  const { return fReadEntry; }
    virtual Int_t           GetScanField()  const { return fScanField; }
@@ -544,8 +544,8 @@ public:
    virtual Double_t        GetWeight() const   { return fWeight; }
    virtual Long64_t        GetZipBytes() const { return fZipBytes; }
    virtual void            IncrementTotalBuffers(Int_t nbytes) { fTotalBuffers += nbytes; }
-           Bool_t          IsFolder() const override { return kTRUE; }
-   virtual Bool_t          InPlaceClone(TDirectory *newdirectory, const char *options = "");
+           bool            IsFolder() const override { return true; }
+   virtual bool            InPlaceClone(TDirectory *newdirectory, const char *options = "");
    virtual Int_t           LoadBaskets(Long64_t maxmemory = 2000000000);
    virtual Long64_t        LoadTree(Long64_t entry);
    virtual Long64_t        LoadTreeFriend(Long64_t entry, TTree* T);
@@ -553,11 +553,11 @@ public:
    virtual Int_t           MakeCode(const char *filename = nullptr);
    virtual Int_t           MakeProxy(const char* classname, const char* macrofilename = nullptr, const char* cutfilename = nullptr, const char* option = nullptr, Int_t maxUnrolling = 3);
    virtual Int_t           MakeSelector(const char *selector = nullptr, Option_t *option = "");
-   Bool_t                  MemoryFull(Int_t nbytes);
+   bool                    MemoryFull(Int_t nbytes);
    virtual Long64_t        Merge(TCollection* list, Option_t* option = "");
    virtual Long64_t        Merge(TCollection* list, TFileMergeInfo *info);
    static  TTree          *MergeTrees(TList* list, Option_t* option = "");
-           Bool_t          Notify() override;
+           bool            Notify() override;
    virtual void            OptimizeBaskets(ULong64_t maxMemory=10000000, Float_t minComp=1.1, Option_t *option="");
            TPrincipal     *Principal(const char* varexp = "", const char* selection = "", Option_t* option = "np", Long64_t nentries = kMaxEntries, Long64_t firstentry = 0);
            void            Print(Option_t* option = "") const override; // *MENU*
@@ -578,13 +578,13 @@ public:
    virtual void            ResetBranchAddress(TBranch *);
    virtual void            ResetBranchAddresses();
    virtual Long64_t        Scan(const char* varexp = "", const char* selection = "", Option_t* option = "", Long64_t nentries = kMaxEntries, Long64_t firstentry = 0); // *MENU*
-   virtual Bool_t          SetAlias(const char* aliasName, const char* aliasFormula);
+   virtual bool            SetAlias(const char* aliasName, const char* aliasFormula);
    virtual void            SetAutoSave(Long64_t autos = -300000000);
    virtual void            SetAutoFlush(Long64_t autof = -30000000);
    virtual void            SetBasketSize(const char* bname, Int_t buffsize = 16000);
    virtual Int_t           SetBranchAddress(const char *bname,void *add, TBranch **ptr = nullptr);
-   virtual Int_t           SetBranchAddress(const char *bname,void *add, TClass *realClass, EDataType datatype, Bool_t isptr);
-   virtual Int_t           SetBranchAddress(const char *bname,void *add, TBranch **ptr, TClass *realClass, EDataType datatype, Bool_t isptr);
+   virtual Int_t           SetBranchAddress(const char *bname,void *add, TClass *realClass, EDataType datatype, bool isptr);
+   virtual Int_t           SetBranchAddress(const char *bname,void *add, TBranch **ptr, TClass *realClass, EDataType datatype, bool isptr);
    template <class T> Int_t SetBranchAddress(const char *bname, T **add, TBranch **ptr = nullptr) {
       TClass *cl = TClass::GetClass<T>();
       EDataType type = kOther_t;
@@ -601,16 +601,16 @@ public:
       return SetBranchAddress(bname,add,ptr,cl,type,false);
    }
 #endif
-   virtual void            SetBranchStatus(const char* bname, Bool_t status = true, UInt_t* found = nullptr);
+   virtual void            SetBranchStatus(const char* bname, bool status = true, UInt_t* found = nullptr);
    static  void            SetBranchStyle(Int_t style = 1);  //style=0 for old branch, =1 for new branch style
    virtual Int_t           SetCacheSize(Long64_t cachesize = -1);
    virtual Int_t           SetCacheEntryRange(Long64_t first, Long64_t last);
    virtual void            SetCacheLearnEntries(Int_t n=10);
    virtual void            SetChainOffset(Long64_t offset = 0) { fChainOffset=offset; }
    virtual void            SetCircular(Long64_t maxEntries);
-   virtual void            SetClusterPrefetch(Bool_t enabled) { fCacheDoClusterPrefetch = enabled; }
+   virtual void            SetClusterPrefetch(bool enabled) { fCacheDoClusterPrefetch = enabled; }
    virtual void            SetDebug(Int_t level = 1, Long64_t min = 0, Long64_t max = 9999999); // *MENU*
-   virtual void            SetDefaultEntryOffsetLen(Int_t newdefault, Bool_t updateExisting = kFALSE);
+   virtual void            SetDefaultEntryOffsetLen(Int_t newdefault, bool updateExisting = false);
    virtual void            SetDirectory(TDirectory* dir);
    virtual Long64_t        SetEntries(Long64_t n = -1);
    virtual void            SetEstimate(Long64_t nentries = 1000000);
@@ -618,7 +618,7 @@ public:
    virtual void            SetFileNumber(Int_t number = 0);
    virtual void            SetEventList(TEventList* list);
    virtual void            SetEntryList(TEntryList* list, Option_t *opt="");
-   virtual void            SetImplicitMT(Bool_t enabled) { fIMTEnabled = enabled; }
+   virtual void            SetImplicitMT(bool enabled) { fIMTEnabled = enabled; }
    virtual void            SetMakeClass(Int_t make);
    virtual void            SetMaxEntryLoop(Long64_t maxev = kMaxEntries) { fMaxEntryLoop = maxev; } // *MENU*
    static  void            SetMaxTreeSize(Long64_t maxsize = 100000000000LL);
@@ -640,7 +640,7 @@ public:
    virtual void            SetNotify(TObject* obj);
 
    virtual void            SetObject(const char* name, const char* title);
-   virtual void            SetParallelUnzip(Bool_t opt=kTRUE, Float_t RelSize=-1);
+   virtual void            SetParallelUnzip(bool opt=true, Float_t RelSize=-1);
    virtual void            SetPerfStats(TVirtualPerfStats* perf);
    virtual void            SetScanField(Int_t n = 50) { fScanField = n; } // *MENU*
    void SetTargetMemoryRatio(Float_t ratio) { fTargetMemoryRatio = ratio; }
@@ -673,13 +673,13 @@ protected:
    TTree             *fTree;         ///< tree being iterated
    TIterator         *fLeafIter;     ///< current leaf sub-iterator.
    TIterator         *fTreeIter;     ///< current tree sub-iterator.
-   Bool_t             fDirection;    ///< iteration direction
+   bool               fDirection;    ///< iteration direction
 
    TTreeFriendLeafIter() : fTree(nullptr), fLeafIter(nullptr), fTreeIter(nullptr),
-       fDirection(kFALSE) { }
+       fDirection(false) { }
 
 public:
-   TTreeFriendLeafIter(const TTree* t, Bool_t dir = kIterForward);
+   TTreeFriendLeafIter(const TTree* t, bool dir = kIterForward);
    TTreeFriendLeafIter(const TTreeFriendLeafIter &iter);
    ~TTreeFriendLeafIter() override { SafeDelete(fLeafIter); SafeDelete(fTreeIter); }
    TIterator &operator=(const TIterator &rhs) override;
@@ -689,11 +689,11 @@ public:
    Option_t          *GetOption() const override;
    TObject           *Next() override;
    void               Reset() override { SafeDelete(fLeafIter); SafeDelete(fTreeIter); }
-   Bool_t operator !=(const TIterator&) const override {
+   bool operator !=(const TIterator&) const override {
       // TODO: Implement me
       return false;
    }
-   Bool_t operator !=(const TTreeFriendLeafIter&) const {
+   bool operator !=(const TTreeFriendLeafIter&) const {
       // TODO: Implement me
       return false;
    }

--- a/tree/tree/inc/TTreeCache.h
+++ b/tree/tree/inc/TTreeCache.h
@@ -51,25 +51,25 @@ protected:
    TObjArray   *fBranches{nullptr};   ///<! List of branches to be stored in the cache
    TList       *fBrNames{nullptr};    ///<! list of branch names in the cache
    TTree       *fTree{nullptr};       ///<! pointer to the current Tree
-   Bool_t       fIsLearning{kTRUE};   ///<! true if cache is in learning mode
-   Bool_t       fIsManual{kFALSE};    ///<! true if cache is StopLearningPhase was used
-   Bool_t       fFirstBuffer{kTRUE};  ///<! true if first buffer is used for prefetching
-   Bool_t       fOneTime{kFALSE};     ///<! used in the learning phase
-   Bool_t       fReverseRead{kFALSE}; ///<! reading in reverse mode
+   bool         fIsLearning{true};   ///<! true if cache is in learning mode
+   bool         fIsManual{false};    ///<! true if cache is StopLearningPhase was used
+   bool         fFirstBuffer{true};  ///<! true if first buffer is used for prefetching
+   bool         fOneTime{false};     ///<! used in the learning phase
+   bool         fReverseRead{false}; ///<! reading in reverse mode
    Int_t        fFillTimes{0};        ///<! how many times we can fill the current buffer
-   Bool_t       fFirstTime{kTRUE};    ///<! save the fact that we processes the first entry
+   bool         fFirstTime{true};    ///<! save the fact that we processes the first entry
    Long64_t     fFirstEntry{-1};      ///<! save the value of the first entry
-   Bool_t       fReadDirectionSet{kFALSE}; ///<! read direction established
-   Bool_t       fEnabled{kTRUE};      ///<! cache enabled for cached reading
+   bool         fReadDirectionSet{false}; ///<! read direction established
+   bool         fEnabled{true};      ///<! cache enabled for cached reading
    EPrefillType fPrefillType;         ///<  Whether a pre-filling is enabled (and if applicable which type)
    static Int_t fgLearnEntries;       ///<  number of entries used for learning mode
-   Bool_t       fAutoCreated{kFALSE}; ///<! true if cache was automatically created
+   bool         fAutoCreated{false}; ///<! true if cache was automatically created
 
-   Bool_t       fLearnPrefilling{kFALSE}; ///<! true if we are in the process of executing LearnPrefill
+   bool         fLearnPrefilling{false}; ///<! true if we are in the process of executing LearnPrefill
 
    // These members hold cached data for missed branches when miss optimization
    // is enabled.  Pointers are only initialized if the miss cache is enabled.
-   Bool_t   fOptimizeMisses{kFALSE}; ///<! true if we should optimize cache misses.
+   bool     fOptimizeMisses{false}; ///<! true if we should optimize cache misses.
    Long64_t fFirstMiss{-1};          ///<! set to the event # of the first miss.
    Long64_t fLastMiss{-1};           ///<! set to the event # of the last miss.
 
@@ -115,27 +115,27 @@ private:
    // The miss cache is more CPU-intensive than the rest of the TTreeCache code;
    // for local work (i.e., laptop with SSD), this CPU cost may outweight the
    // benefit.
-   Bool_t CheckMissCache(char *buf, Long64_t pos,
+   bool CheckMissCache(char *buf, Long64_t pos,
                          int len); ///< Check the miss cache for a particular buffer, fetching if deemed necessary.
-   Bool_t FillMissCache();         ///< Fill the miss cache from the current set of active branches.
-   Bool_t CalculateMissCache();    ///< Calculate the appropriate miss cache to fetch; helper function for FillMissCache
+   bool FillMissCache();         ///< Fill the miss cache from the current set of active branches.
+   bool CalculateMissCache();    ///< Calculate the appropriate miss cache to fetch; helper function for FillMissCache
    IOPos  FindBranchBasketPos(TBranch &, Long64_t entry); ///< Given a branch and an entry, determine the file location
                                                           ///< (offset / size) of the corresponding basket.
    TBranch *CalculateMissEntries(Long64_t, int, bool);    ///< Given an file read, try to determine the corresponding branch.
-   Bool_t   ProcessMiss(Long64_t pos, int len); ///<! Given a file read not in the miss cache, handle (possibly) loading the data.
+   bool     ProcessMiss(Long64_t pos, int len); ///<! Given a file read not in the miss cache, handle (possibly) loading the data.
 
 public:
 
    TTreeCache();
    TTreeCache(TTree *tree, Int_t buffersize=0);
    ~TTreeCache() override;
-   Int_t                AddBranch(TBranch *b, Bool_t subgbranches = kFALSE) override;
-   Int_t                AddBranch(const char *branch, Bool_t subbranches = kFALSE) override;
-   virtual Int_t        DropBranch(TBranch *b, Bool_t subbranches = kFALSE);
-   virtual Int_t        DropBranch(const char *branch, Bool_t subbranches = kFALSE);
-   virtual void         Disable() {fEnabled = kFALSE;}
-   virtual void         Enable() {fEnabled = kTRUE;}
-   Bool_t               GetOptimizeMisses() const { return fOptimizeMisses; }
+   Int_t                AddBranch(TBranch *b, bool subgbranches = false) override;
+   Int_t                AddBranch(const char *branch, bool subbranches = false) override;
+   virtual Int_t        DropBranch(TBranch *b, bool subbranches = false);
+   virtual Int_t        DropBranch(const char *branch, bool subbranches = false);
+   virtual void         Disable() {fEnabled = false;}
+   virtual void         Enable() {fEnabled = true;}
+   bool                 GetOptimizeMisses() const { return fOptimizeMisses; }
    const TObjArray     *GetCachedBranches() const { return fBranches; }
    EPrefillType         GetConfiguredPrefillType() const;
    Double_t             GetEfficiency() const;
@@ -147,12 +147,12 @@ public:
    Double_t             GetMissEfficiency() const;
    Double_t             GetMissEfficiencyRel() const;
    TTree               *GetTree() const {return fTree;}
-   Bool_t               IsAutoCreated() const {return fAutoCreated;}
-   virtual Bool_t       IsEnabled() const {return fEnabled;}
-   Bool_t               IsLearning() const override {return fIsLearning;}
+   bool                 IsAutoCreated() const {return fAutoCreated;}
+   virtual bool         IsEnabled() const {return fEnabled;}
+   bool                 IsLearning() const override {return fIsLearning;}
 
-   virtual Bool_t       FillBuffer();
-   Int_t                LearnBranch(TBranch *b, Bool_t subgbranches = kFALSE) override;
+   virtual bool         FillBuffer();
+   Int_t                LearnBranch(TBranch *b, bool subgbranches = false) override;
    virtual void         LearnPrefill();
 
    void                 Print(Option_t *option="") const override;
@@ -161,13 +161,13 @@ public:
    virtual Int_t        ReadBufferPrefetch(char *buf, Long64_t pos, Int_t len);
    virtual void         ResetCache();
    void                 ResetMissCache(); // Reset the miss cache.
-   void                 SetAutoCreated(Bool_t val) {fAutoCreated = val;}
+   void                 SetAutoCreated(bool val) {fAutoCreated = val;}
    Int_t                SetBufferSize(Int_t buffersize) override;
    virtual void         SetEntryRange(Long64_t emin,   Long64_t emax);
    void                 SetFile(TFile *file, TFile::ECacheAction action=TFile::kDisconnect) override;
    virtual void         SetLearnPrefill(EPrefillType type = kNoPrefill);
    static void          SetLearnEntries(Int_t n = 10);
-   void                 SetOptimizeMisses(Bool_t opt);
+   void                 SetOptimizeMisses(bool opt);
    void                 StartLearningPhase();
    virtual void         StopLearningPhase();
    virtual void         UpdateBranches(TTree *tree);

--- a/tree/tree/inc/TTreeCacheUnzip.h
+++ b/tree/tree/inc/TTreeCacheUnzip.h
@@ -61,27 +61,27 @@ protected:
          if (fUnzipStatus) delete [] fUnzipStatus;
       }
       void   Clear(Int_t size);
-      Bool_t IsUntouched(Int_t index) const;
-      Bool_t IsProgress(Int_t index) const;
-      Bool_t IsFinished(Int_t index) const;
-      Bool_t IsUnzipped(Int_t index) const;
+      bool   IsUntouched(Int_t index) const;
+      bool   IsProgress(Int_t index) const;
+      bool   IsFinished(Int_t index) const;
+      bool   IsUnzipped(Int_t index) const;
       void   Reset(Int_t oldSize, Int_t newSize);
       void   SetUntouched(Int_t index);
       void   SetProgress(Int_t index);
       void   SetFinished(Int_t index);
       void   SetMissed(Int_t index);
       void   SetUnzipped(Int_t index, char* buf, Int_t len);
-      Bool_t TryUnzipping(Int_t index);
+      bool TryUnzipping(Int_t index);
    };
 
    typedef struct UnzipState UnzipState_t;
    UnzipState_t fUnzipState;
 
    // Members for paral. managing
-   Bool_t      fAsyncReading;
-   Bool_t      fEmpty;
+   bool        fAsyncReading;
+   bool        fEmpty;
    Int_t       fCycle;
-   Bool_t      fParallel; ///< Indicate if we want to activate the parallelism (for this instance)
+   bool        fParallel; ///< Indicate if we want to activate the parallelism (for this instance)
 
    std::unique_ptr<TMutex> fIOMutex;
 
@@ -120,9 +120,9 @@ public:
    TTreeCacheUnzip(TTree *tree, Int_t buffersize=0);
    ~TTreeCacheUnzip() override;
 
-   Int_t               AddBranch(TBranch *b, Bool_t subbranches = kFALSE) override;
-   Int_t               AddBranch(const char *branch, Bool_t subbranches = kFALSE) override;
-   Bool_t              FillBuffer() override;
+   Int_t               AddBranch(TBranch *b, bool subbranches = false) override;
+   Int_t               AddBranch(const char *branch, bool subbranches = false) override;
+   bool                FillBuffer() override;
    Int_t               ReadBufferExt(char *buf, Long64_t pos, Int_t len, Int_t &loc) override;
    void                SetEntryRange(Long64_t emin,   Long64_t emax) override;
    void                StopLearningPhase() override;
@@ -130,7 +130,7 @@ public:
 
    // Methods related to the thread
    static EParUnzipMode GetParallelUnzip();
-   static Bool_t        IsParallelUnzip();
+   static bool          IsParallelUnzip();
    static Int_t         SetParallelUnzip(TTreeCacheUnzip::EParUnzipMode option = TTreeCacheUnzip::kEnable);
 
    // Unzipping related methods
@@ -138,7 +138,7 @@ public:
    Int_t          CreateTasks();
 #endif
    Int_t          GetRecordHeader(char *buf, Int_t maxbytes, Int_t &nbytes, Int_t &objlen, Int_t &keylen);
-   Int_t          GetUnzipBuffer(char **buf, Long64_t pos, Int_t len, Bool_t *free) override;
+   Int_t          GetUnzipBuffer(char **buf, Long64_t pos, Int_t len, bool *free) override;
    Int_t          GetUnzipGroupSize() { return fUnzipGroupSize; }
    void           ResetCache() override;
    Int_t          SetBufferSize(Int_t buffersize) override;

--- a/tree/tree/inc/TTreeCloner.h
+++ b/tree/tree/inc/TTreeCloner.h
@@ -31,8 +31,8 @@ class TDirectory;
 class TTreeCloner {
    TString    fWarningMsg;       ///< Text of the error message lead to an 'invalid' state
 
-   Bool_t     fIsValid;
-   Bool_t     fNeedConversion;   ///< True if the fast merge is not possible but a slow merge might possible.
+   bool       fIsValid;
+   bool       fNeedConversion;   ///< True if the fast merge is not possible but a slow merge might possible.
    UInt_t     fOptions;
    TTree     *fFromTree;
    TTree     *fToTree;
@@ -70,14 +70,14 @@ class TTreeCloner {
       TTreeCloner *fObject;
    public:
       CompareSeek(TTreeCloner *obj) : fObject(obj) {}
-      Bool_t operator()(UInt_t i1, UInt_t i2);
+      bool operator()(UInt_t i1, UInt_t i2);
    };
 
    class CompareEntry {
       TTreeCloner *fObject;
    public:
       CompareEntry(TTreeCloner *obj) : fObject(obj) {}
-      Bool_t operator()(UInt_t i1, UInt_t i2);
+      bool operator()(UInt_t i1, UInt_t i2);
    };
 
    friend class CompareSeek;
@@ -115,10 +115,10 @@ public:
    void   CopyStreamerInfos();
    void   CopyProcessIds();
    const char *GetWarning() const { return fWarningMsg; }
-   Bool_t IsInPlace() const { return fFromTree == fToTree; }
-   Bool_t Exec();
-   Bool_t IsValid() { return fIsValid; }
-   Bool_t NeedConversion() { return fNeedConversion; }
+   bool   IsInPlace() const { return fFromTree == fToTree; }
+   bool   Exec();
+   bool   IsValid() { return fIsValid; }
+   bool   NeedConversion() { return fNeedConversion; }
    void   SetCacheSize(Int_t size);
    void   SortBaskets();
    void   WriteBaskets();

--- a/tree/tree/inc/TTreeResult.h
+++ b/tree/tree/inc/TTreeResult.h
@@ -41,7 +41,7 @@ private:
    TObjArray  *fResult;        ///< query result (TTreeRow objects)
    Int_t       fNextRow;       ///< row iterator
 
-   Bool_t  IsValid(Int_t field);
+   bool    IsValid(Int_t field);
    void    AddField(Int_t field, const char *fieldname);
    void    AddRow(TSQLRow *row);
 

--- a/tree/tree/inc/TTreeRow.h
+++ b/tree/tree/inc/TTreeRow.h
@@ -38,7 +38,7 @@ private:
    TTreeRow    *fOriginal;     ///<! pointer to original row
 
    TTreeRow(TSQLRow *original);
-   Bool_t  IsValid(Int_t field);
+   bool    IsValid(Int_t field);
 
    TTreeRow(const TTreeRow&) = delete;
    TTreeRow &operator=(const TTreeRow&) = delete;

--- a/tree/tree/inc/TTreeSQL.h
+++ b/tree/tree/inc/TTreeSQL.h
@@ -50,19 +50,19 @@ protected:
    TSQLResult            *fResult;
    TSQLRow               *fRow;
    TSQLServer            *fServer;
-   Bool_t                 fBranchChecked;
+   bool                   fBranchChecked;
    TSQLTableInfo         *fTableInfo;
 
    void                   CheckBasket(TBranch *tb);
-   Bool_t                 CheckBranch(TBranch *tb);
-   Bool_t                 CheckTable(const TString &table) const;
+   bool                   CheckBranch(TBranch *tb);
+   bool                   CheckTable(const TString &table) const;
    void                   CreateBranches();
    std::vector<Int_t>    *GetColumnIndice(TBranch *branch);
    void                   Init();
    void                   ResetQuery();
    TString                ConvertTypeName(const TString& typeName );
    virtual void           CreateBranch(const TString& branchName,const TString &typeName);
-   Bool_t                 CreateTable(const TString& table);
+   bool                   CreateTable(const TString& table);
    TBasket               *CreateBasket(TBranch * br) override;
 
    TBranch               *BranchImp(const char *branchname, const char *classname, TClass *ptrClass, void *addobj, Int_t bufsize, Int_t splitlevel) override;

--- a/tree/tree/inc/TVirtualIndex.h
+++ b/tree/tree/inc/TVirtualIndex.h
@@ -35,13 +35,13 @@ protected:
 public:
    TVirtualIndex();
                  ~TVirtualIndex() override;
-   virtual void           Append(const TVirtualIndex *,Bool_t delaySort = kFALSE) = 0;
+   virtual void           Append(const TVirtualIndex *,bool delaySort = false) = 0;
    virtual Long64_t       GetEntryNumberFriend(const TTree * /*parent*/) = 0;
    virtual Long64_t       GetEntryNumberWithIndex(Long64_t major, Long64_t minor) const = 0;
    virtual Long64_t       GetEntryNumberWithBestIndex(Long64_t major, Long64_t minor) const = 0;
    virtual const char    *GetMajorName()    const = 0;
    virtual const char    *GetMinorName()    const = 0;
-   virtual Bool_t         IsValidFor(const TTree *parent) = 0;
+   virtual bool           IsValidFor(const TTree *parent) = 0;
    virtual Long64_t       GetN()            const = 0;
    virtual TTree         *GetTree()         const {return fTree;}
    virtual void           UpdateFormulaLeaves(const TTree *parent) = 0;

--- a/tree/tree/src/TBasket.cxx
+++ b/tree/tree/src/TBasket.cxx
@@ -60,7 +60,7 @@ TBasket::TBasket(TDirectory *motherDir) : TKey(motherDir)
 
 TBasket::TBasket(const char *name, const char *title, TBranch *branch)
    : TKey(branch->GetDirectory()), fBufferSize(branch->GetBasketSize()), fNevBufSize(branch->GetEntryOffsetLen()),
-     fHeaderOnly(kTRUE), fIOBits(branch->GetIOFeatures().GetFeatures())
+     fHeaderOnly(true), fIOBits(branch->GetIOFeatures().GetFeatures())
 {
    SetName(name);
    SetTitle(title);
@@ -78,10 +78,10 @@ TBasket::TBasket(const char *name, const char *title, TBranch *branch)
 #else
       fCompressedBufferRef = branch->GetTree()->GetTransientBuffer(fBufferSize);
 #endif
-      fOwnsCompressedBuffer = kFALSE;
+      fOwnsCompressedBuffer = false;
       if (!fCompressedBufferRef) {
          fCompressedBufferRef = new TBufferFile(TBuffer::kRead, fBufferSize);
-         fOwnsCompressedBuffer = kTRUE;
+         fOwnsCompressedBuffer = true;
       }
    }
    fBranch = branch;
@@ -90,7 +90,7 @@ TBasket::TBasket(const char *name, const char *title, TBranch *branch)
    fObjlen      = fBufferSize - fKeylen;
    fLast        = fKeylen;
    fBuffer      = nullptr;
-   fHeaderOnly  = kFALSE;
+   fHeaderOnly  = false;
    if (fNevBufSize) {
       fEntryOffset = new Int_t[fNevBufSize];
       for (Int_t i=0;i<fNevBufSize;i++) fEntryOffset[i] = 0;
@@ -150,9 +150,9 @@ Long64_t TBasket::CopyTo(TFile *to)
    fBuffer = fBufferRef->Buffer();
    Create(nout, to);
    fBufferRef->SetBufferOffset(0);
-   fHeaderOnly = kTRUE;
+   fHeaderOnly = true;
    Streamer(*fBufferRef);
-   fHeaderOnly = kFALSE;
+   fHeaderOnly = false;
    Int_t nBytes = WriteFileKeepBuffer(to);
 
    return nBytes>0 ? nBytes : -1;
@@ -215,10 +215,10 @@ Int_t *TBasket::GetCalculatedEntryOffset()
 /// Determine whether we can generate the offset array when this branch is read.
 ///
 
-Bool_t TBasket::CanGenerateOffsetArray()
+bool TBasket::CanGenerateOffsetArray()
 {
    if (fBranch->GetNleaves() != 1) {
-      return kFALSE;
+      return false;
    }
    TLeaf *leaf = static_cast<TLeaf *>((*fBranch->GetListOfLeaves())[0]);
    return leaf->CanGenerateOffsetArray();
@@ -377,7 +377,7 @@ Int_t TBasket::ReadBasketBuffersUncompressedCase()
 ////////////////////////////////////////////////////////////////////////////////
 /// We always create the TBuffer for the basket but it hold the buffer from the cache.
 
-Int_t TBasket::ReadBasketBuffersUnzip(char* buffer, Int_t size, Bool_t mustFree, TFile* file)
+Int_t TBasket::ReadBasketBuffersUnzip(char* buffer, Int_t size, bool mustFree, TFile* file)
 {
    if (fBufferRef) {
       fBufferRef->SetBuffer(buffer, size, mustFree);
@@ -394,7 +394,7 @@ Int_t TBasket::ReadBasketBuffersUnzip(char* buffer, Int_t size, Bool_t mustFree,
       return -1;
    }
 
-   Bool_t oldCase = OLD_CASE_EXPRESSION;
+   bool oldCase = OLD_CASE_EXPRESSION;
 
    if ((fObjlen > fNbytes-fKeylen || oldCase) && TestBit(TBufferFile::kNotDecompressed) && (fNevBuf==1)) {
       return TBasket::ReadBasketBuffersUncompressedCase();
@@ -431,10 +431,10 @@ static inline TBuffer* R__InitializeReadBasketBuffer(TBuffer* bufferRef, Int_t l
 
 void inline TBasket::InitializeCompressedBuffer(Int_t len, TFile* file)
 {
-   Bool_t compressedBufferExists = fCompressedBufferRef != nullptr;
+   bool compressedBufferExists = fCompressedBufferRef != nullptr;
    fCompressedBufferRef = R__InitializeReadBasketBuffer(fCompressedBufferRef, len, file);
    if (R__unlikely(!compressedBufferExists)) {
-      fOwnsCompressedBuffer = kTRUE;
+      fOwnsCompressedBuffer = true;
    }
 }
 
@@ -467,7 +467,7 @@ Int_t TBasket::ReadBasketBuffers(Long64_t pos, Int_t len, TFile *file)
       return -1;
    }
 
-   Bool_t oldCase;
+   bool oldCase;
    char *rawUncompressedBuffer, *rawCompressedBuffer;
    Int_t uncompressedBufferLen;
 
@@ -479,7 +479,7 @@ Int_t TBasket::ReadBasketBuffers(Long64_t pos, Int_t len, TFile *file)
    }
    if (pf) {
       Int_t res = -1;
-      Bool_t free = kTRUE;
+      bool free = true;
       char *buffer = nullptr;
       res = pf->GetUnzipBuffer(&buffer, pos, len, &free);
       if (R__unlikely(res >= 0)) {
@@ -674,7 +674,7 @@ AfterBuffer:
          fEntryOffset[idx] += fEntryOffset[idx - 1];
       }
    }
-   fReadEntryOffset = kTRUE;
+   fReadEntryOffset = true;
    // Read the array of displacement if any.
    delete [] fDisplacement;
    fDisplacement = nullptr;
@@ -788,7 +788,7 @@ void TBasket::ReadResetBuffer(Int_t basketnumber)
          std::chrono::time_point<std::chrono::system_clock> start, end;
          start = std::chrono::high_resolution_clock::now();
 #endif
-         fBufferRef->Expand(newSize, kFALSE); // Expand without copying the existing data.
+         fBufferRef->Expand(newSize, false); // Expand without copying the existing data.
 #ifdef R__TRACK_BASKET_ALLOC_TIME
          end = std::chrono::high_resolution_clock::now();
          auto us = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
@@ -869,7 +869,7 @@ void TBasket::WriteReset()
       std::chrono::time_point<std::chrono::system_clock> start, end;
       start = std::chrono::high_resolution_clock::now();
 #endif
-      fBufferRef->Expand(newSize,kFALSE);     // Expand without copying the existing data.
+      fBufferRef->Expand(newSize,false);     // Expand without copying the existing data.
 #ifdef R__TRACK_BASKET_ALLOC_TIME
       end = std::chrono::high_resolution_clock::now();
       auto us = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
@@ -902,7 +902,7 @@ void TBasket::WriteReset()
    fBufferRef->Reset();
    fBufferRef->SetWriteMode();
 
-   fHeaderOnly  = kTRUE;
+   fHeaderOnly  = true;
    fLast        = 0;  //Must initialize before calling Streamer()
 
    Streamer(*fBufferRef);
@@ -911,7 +911,7 @@ void TBasket::WriteReset()
    fObjlen      = fBufferSize - fKeylen;
    fLast        = fKeylen;
    fBuffer      = nullptr;
-   fHeaderOnly  = kFALSE;
+   fHeaderOnly  = false;
    fDisplacement= storeDisplacement;
    fEntryOffset = storeEntryOffset;
    if (fNevBufSize) {
@@ -990,7 +990,7 @@ void TBasket::Streamer(TBuffer &b)
       b >> fLast;
       b >> flag;
       if (fLast > fBufferSize) fBufferSize = fLast;
-      Bool_t mustGenerateOffsets = false;
+      bool mustGenerateOffsets = false;
       if (flag >= 80) {
          mustGenerateOffsets = true;
          flag -= 80;
@@ -1044,7 +1044,7 @@ void TBasket::Streamer(TBuffer &b)
       }
       b << fNevBuf;
       b << fLast;
-      Bool_t mustGenerateOffsets = fEntryOffset && fNevBuf &&
+      bool mustGenerateOffsets = fEntryOffset && fNevBuf &&
                                    (fIOBits & static_cast<UChar_t>(TBasket::EIOBits::kGenerateOffsetMap)) &&
                                    CanGenerateOffsetArray();
       // We currently believe that in all cases when offsets can be generated, then the
@@ -1150,7 +1150,7 @@ Int_t TBasket::WriteBuffer()
 
    if (R__unlikely(fBufferRef->TestBit(TBufferFile::kNotDecompressed))) {
       // Read the basket information that was saved inside the buffer.
-      Bool_t writing = fBufferRef->IsWriting();
+      bool writing = fBufferRef->IsWriting();
       fBufferRef->SetReadMode();
       fBufferRef->SetBufferOffset(0);
 
@@ -1162,11 +1162,11 @@ Int_t TBasket::WriteBuffer()
 
       Create(nout,file);
       fBufferRef->SetBufferOffset(0);
-      fHeaderOnly = kTRUE;
+      fHeaderOnly = true;
 
       Streamer(*fBufferRef);         //write key itself again
       int nBytes = WriteFileKeepBuffer();
-      fHeaderOnly = kFALSE;
+      fHeaderOnly = false;
       return nBytes>0 ? fKeylen+nout : -1;
    }
 
@@ -1174,7 +1174,7 @@ Int_t TBasket::WriteBuffer()
    fLast = fBufferRef->Length();
    Int_t *entryOffset = GetEntryOffset();
    if (entryOffset) {
-      Bool_t hasOffsetBit = fIOBits & static_cast<UChar_t>(TBasket::EIOBits::kGenerateOffsetMap);
+      bool hasOffsetBit = fIOBits & static_cast<UChar_t>(TBasket::EIOBits::kGenerateOffsetMap);
       if (!CanGenerateOffsetArray()) {
          // If we have set the offset map flag, but cannot dynamically generate the map, then
          // we should at least convert the offset array to a size array.  Note that we always
@@ -1208,7 +1208,7 @@ Int_t TBasket::WriteBuffer()
 
    fObjlen = fBufferRef->Length() - fKeylen;
 
-   fHeaderOnly = kTRUE;
+   fHeaderOnly = true;
    fCycle = fBranch->GetWriteBasket();
    Int_t cxlevel = fBranch->GetCompressionLevel();
    if (cxlevel == ROOT::RCompressionSetting::ELevel::kInherit)
@@ -1287,6 +1287,6 @@ Int_t TBasket::WriteBuffer()
 
 WriteFile:
    Int_t nBytes = WriteFileKeepBuffer();
-   fHeaderOnly = kFALSE;
+   fHeaderOnly = false;
    return nBytes>0 ? fKeylen+nout : -1;
 }

--- a/tree/tree/src/TBasketSQL.cxx
+++ b/tree/tree/src/TBasketSQL.cxx
@@ -59,12 +59,12 @@ TBasketSQL::TBasketSQL(const char *name, const char *title, TBranch *branch,
    } else {
       fBufferRef = new TBufferSQL(TBuffer::kWrite, fBufferSize, vc, fInsertQuery, fRowPtr);
    }
-   fHeaderOnly  = kTRUE;
+   fHeaderOnly  = true;
    fLast        = 0; // Must initialize before calling Streamer()
    //Streamer(*fBufferRef);
    fBuffer      = nullptr;
    fBranch      = branch;
-   fHeaderOnly  = kFALSE;
+   fHeaderOnly  = false;
    branch->GetTree()->IncrementTotalBuffers(fBufferSize);
 
 }
@@ -100,12 +100,12 @@ void TBasketSQL::CreateBuffer(const char *name, TString title,
    } else {
       fBufferRef   = new TBufferSQL(TBuffer::kWrite, fBufferSize, vc, fInsertQuery, fRowPtr);
    }
-   fHeaderOnly  = kTRUE;
+   fHeaderOnly  = true;
    fLast        = 0;
    //Streamer(*fBufferRef);
    fBuffer      = nullptr;
    fBranch      = branch;
-   fHeaderOnly  = kFALSE;
+   fHeaderOnly  = false;
    branch->GetTree()->IncrementTotalBuffers(fBufferSize);
 }
 

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -123,7 +123,7 @@ TBranch::TBranch()
 , fTransientBuffer(nullptr)
 , fBrowsables(nullptr)
 , fBulk(*this)
-, fSkipZip(kFALSE)
+, fSkipZip(false)
 , fReadLeaves(&TBranch::ReadLeavesImpl)
 , fFillLeaves(&TBranch::FillLeavesImpl)
 {
@@ -160,7 +160,7 @@ TBranch::TBranch()
 ///        - `l` : a 64 bit unsigned integer (`ULong64_t`)
 ///        - `G` : a long signed integer (`Long_t`, which `sizeof` is platform dependent), stored as a 64 bit integer but usually held in memory as a 64 bit integer on 64 bit machines and 32 bit on 32 bit machines. Due to this difference, this data type is **not cross-platform**.
 ///        - `g` : a long unsigned integer (`ULong_t`, which `sizeof` is platform dependent), stored as a 64 bit unsigned integer but held in memory usually as a 64 bit integer on 64 bit machines and 32 bit on 32 bit machines. Due to this difference, this data type is **not cross-platform**.
-///        - `O` : [the letter `o`, not a zero] a boolean (`Bool_t`)
+///        - `O` : [the letter `o`, not a zero] a boolean (`bool`)
 ///
 ///     Arrays of values are supported with the following syntax:
 ///     - If leaf name has the form var[nelem], where nelem is alphanumeric, then
@@ -236,7 +236,7 @@ TBranch::TBranch(TTree *tree, const char *name, void *address, const char *leafl
 , fTransientBuffer(nullptr)
 , fBrowsables(nullptr)
 , fBulk(*this)
-, fSkipZip(kFALSE)
+, fSkipZip(false)
 , fReadLeaves(&TBranch::ReadLeavesImpl)
 , fFillLeaves(&TBranch::FillLeavesImpl)
 {
@@ -290,7 +290,7 @@ TBranch::TBranch(TBranch *parent, const char *name, void *address, const char *l
 , fTransientBuffer(nullptr)
 , fBrowsables(nullptr)
 , fBulk(*this)
-, fSkipZip(kFALSE)
+, fSkipZip(false)
 , fReadLeaves(&TBranch::ReadLeavesImpl)
 , fFillLeaves(&TBranch::FillLeavesImpl)
 {
@@ -542,7 +542,7 @@ TBuffer* TBranch::GetTransientBuffer(Int_t size)
 /// Warning we also assume that the __current__ write basket is
 /// not present (aka has been removed) or is empty (no entries).
 
-void TBranch::AddBasket(TBasket& b, Bool_t ondisk, Long64_t startEntry)
+void TBranch::AddBasket(TBasket& b, bool ondisk, Long64_t startEntry)
 {
    TBasket *basket = &b;
 
@@ -756,11 +756,11 @@ void TBranch::DeleteBaskets(Option_t* option)
 
 void TBranch::DropBaskets(Option_t* options)
 {
-   Bool_t all = kFALSE;
+   bool all = false;
    if (options && options[0]) {
       TString opt = options;
       opt.ToLower();
-      if (opt.Contains("all")) all = kTRUE;
+      if (opt.Contains("all")) all = true;
    }
 
    TBasket *basket;
@@ -1259,7 +1259,7 @@ TBasket* TBranch::GetBasketImpl(Int_t basketnumber, TBuffer *user_buffer)
       R__LOCKGUARD_IMT(gROOTMutex); // Lock for parallel TTree I/O
       TFileCacheRead *pf = fTree->GetReadCache(file);
       if (pf){
-         if (pf->IsLearning()) pf->LearnBranch(this, kFALSE);
+         if (pf->IsLearning()) pf->LearnBranch(this, false);
          if (fSkipZip) pf->SetSkipZip();
       }
    }
@@ -1428,7 +1428,7 @@ Int_t TBranch::GetBasketAndFirst(TBasket *&basket, Long64_t &first,
 /// This will return true if all the various preconditions necessary hold true
 /// to perform bulk IO (reasonable type, single TLeaf, etc); the bulk IO may
 /// still fail, depending on the contents of the individual TBaskets loaded.
-Bool_t TBranch::SupportsBulkRead() const {
+bool TBranch::SupportsBulkRead() const {
    return (fNleaves == 1) &&
           (static_cast<TLeaf*>(fLeaves.UncheckedAt(0))->GetDeserializeType() != TLeaf::DeserializeType::kExternal);
 }
@@ -1481,7 +1481,7 @@ Int_t TBranch::GetBulkEntries(Long64_t entry, TBuffer &user_buf)
    // Remember which entry we are reading.
    fReadEntry = entry;
 
-   Bool_t enabled = !TestBit(kDoNotProcess);
+   bool enabled = !TestBit(kDoNotProcess);
    if (R__unlikely(!enabled)) return -1;
    TBasket *basket = nullptr;
    Long64_t first;
@@ -1599,7 +1599,7 @@ Int_t TBranch::GetEntriesSerialized(Long64_t entry, TBuffer &user_buf, TBuffer *
    // Remember which entry we are reading.
    fReadEntry = entry;
 
-   Bool_t enabled = !TestBit(kDoNotProcess);
+   bool enabled = !TestBit(kDoNotProcess);
    if (R__unlikely(!enabled)) { return -1; }
    TBasket *basket = nullptr;
    Long64_t first;
@@ -2114,11 +2114,11 @@ Int_t TBranch::GetRow(Int_t)
 /// Return whether this branch is in a mode where the object are decomposed
 /// or not (Also known as MakeClass mode).
 
-Bool_t TBranch::GetMakeClass() const
+bool TBranch::GetMakeClass() const
 {
    // Regular TBranch and TBrancObject can not be in makeClass mode
 
-   return kFALSE;
+   return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2258,20 +2258,20 @@ ROOT::TIOFeatures TBranch::GetIOFeatures() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return kTRUE if an existing object in a TBranchObject must be deleted.
+/// Return true if an existing object in a TBranchObject must be deleted.
 
-Bool_t TBranch::IsAutoDelete() const
+bool TBranch::IsAutoDelete() const
 {
    return TestBit(kAutoDelete);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return kTRUE if more than one leaf or browsables, kFALSE otherwise.
+/// Return true if more than one leaf or browsables, false otherwise.
 
-Bool_t TBranch::IsFolder() const
+bool TBranch::IsFolder() const
 {
    if (fNleaves > 1) {
-      return kTRUE;
+      return true;
    }
    TList* browsables = const_cast<TBranch*>(this)->GetBrowsables();
    return browsables && browsables->GetSize();
@@ -2706,14 +2706,14 @@ void TBranch::SetAddress(void* addr)
 /// referenced by a TBranchObject must be deleted or not before reading
 /// a new entry.
 ///
-/// If autodel is kTRUE, this existing object will be deleted, a new object
+/// If autodel is true, this existing object will be deleted, a new object
 /// created by the default constructor, then read from disk by the streamer.
 ///
-/// If autodel is kFALSE, the existing object is not deleted.  Root assumes
+/// If autodel is false, the existing object is not deleted.  Root assumes
 /// that the user is taking care of deleting any internal object or array
 /// (this can be done in the streamer).
 
-void TBranch::SetAutoDelete(Bool_t autodel)
+void TBranch::SetAutoDelete(bool autodel)
 {
    if (autodel) {
       SetBit(kAutoDelete, true);
@@ -2818,7 +2818,7 @@ void TBranch::SetCompressionSettings(Int_t settings)
 /// it was already non zero (and the new value is not zero)
 /// If updateExisting is true, also update all the existing branches.
 
-void TBranch::SetEntryOffsetLen(Int_t newdefault, Bool_t updateExisting)
+void TBranch::SetEntryOffsetLen(Int_t newdefault, bool updateExisting)
 {
    if (fEntryOffsetLen && newdefault) {
       fEntryOffsetLen = newdefault;
@@ -2827,7 +2827,7 @@ void TBranch::SetEntryOffsetLen(Int_t newdefault, Bool_t updateExisting)
       TIter next( GetListOfBranches() );
       TBranch *b;
       while ( ( b = (TBranch*)next() ) ) {
-         b->SetEntryOffsetLen( newdefault, kTRUE );
+         b->SetEntryOffsetLen( newdefault, true );
       }
    }
 }
@@ -2924,10 +2924,10 @@ void TBranch::SetFile(const char* fname)
 /// Return whether the setting was possible (it is not possible for
 /// TBranch and TBranchObject).
 
-Bool_t TBranch::SetMakeClass(Bool_t /* decomposeObj */)
+bool TBranch::SetMakeClass(bool /* decomposeObj */)
 {
    // Regular TBranch and TBrancObject can not be in makeClass mode
-   return kFALSE;
+   return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2944,7 +2944,7 @@ void TBranch::SetObject(void * /* obj */)
 ////////////////////////////////////////////////////////////////////////////////
 /// Set branch status to Process or DoNotProcess.
 
-void TBranch::SetStatus(Bool_t status)
+void TBranch::SetStatus(bool status)
 {
    if (status) ResetBit(kDoNotProcess);
    else        SetBit(kDoNotProcess);
@@ -2959,7 +2959,7 @@ void TBranch::Streamer(TBuffer& b)
       UInt_t R__s, R__c;
       fTree = nullptr; // Will be set by TTree::Streamer
       fAddress = nullptr;
-      gROOT->SetReadingObject(kTRUE);
+      gROOT->SetReadingObject(true);
 
       // Reset transients.
       SetBit(TBranch::kDoNotUseBufferMap);
@@ -3004,7 +3004,7 @@ void TBranch::Streamer(TBuffer& b)
 
          }
          if (!fSplitLevel && fBranches.GetEntriesFast()) fSplitLevel = 1;
-         gROOT->SetReadingObject(kFALSE);
+         gROOT->SetReadingObject(false);
          if (IsA() == TBranch::Class()) {
             if (fNleaves == 0) {
                fReadLeaves = &TBranch::ReadLeaves0Impl;
@@ -3079,7 +3079,7 @@ void TBranch::Streamer(TBuffer& b)
          }
          // Check Byte Count is not needed since it was done in ReadBuffer
          if (!fSplitLevel && fBranches.GetEntriesFast()) fSplitLevel = 1;
-         gROOT->SetReadingObject(kFALSE);
+         gROOT->SetReadingObject(false);
          b.CheckByteCount(R__s, R__c, TBranch::IsA());
          if (IsA() == TBranch::Class()) {
             if (fNleaves == 0) {
@@ -3150,9 +3150,9 @@ void TBranch::Streamer(TBuffer& b)
          fFileName.Streamer(b);
       }
       fDirectory = nullptr;
-      if (v < 4) SetAutoDelete(kTRUE);
+      if (v < 4) SetAutoDelete(true);
       if (!fSplitLevel && fBranches.GetEntriesFast()) fSplitLevel = 1;
-      gROOT->SetReadingObject(kFALSE);
+      gROOT->SetReadingObject(false);
       b.CheckByteCount(R__s, R__c, TBranch::IsA());
       //====end of old versions
       if (IsA() == TBranch::Class()) {

--- a/tree/tree/src/TBranchBrowsable.cxx
+++ b/tree/tree/src/TBranchBrowsable.cxx
@@ -76,13 +76,13 @@ It has to return the number of browsable helper objects for parent
 
 std::list<TVirtualBranchBrowsable::MethodCreateListOfBrowsables_t>
    TVirtualBranchBrowsable::fgGenerators;
-Bool_t TVirtualBranchBrowsable::fgGeneratorsSet=kFALSE;
+bool TVirtualBranchBrowsable::fgGeneratorsSet=false;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor setting all members according to parameters.
 
 TVirtualBranchBrowsable::TVirtualBranchBrowsable(const TBranch *branch, TClass *type,
-                                                 Bool_t typeIsPointer,
+                                                 bool typeIsPointer,
                                                  const TVirtualBranchBrowsable *parent /*=0*/):
 fBranch(branch), fParent(parent), fLeaves(nullptr), fClass(type), fTypeIsPointer(typeIsPointer)
 {
@@ -345,7 +345,7 @@ void TVirtualBranchBrowsable::RegisterDefaultGenerators()
    fgGenerators.push_back(&TMethodBrowsable::GetBrowsables);
    fgGenerators.push_back(&TNonSplitBrowsable::GetBrowsables);
    fgGenerators.push_back(&TCollectionPropertyBrowsable::GetBrowsables);
-   fgGeneratorsSet=kTRUE;
+   fgGeneratorsSet=true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -408,7 +408,7 @@ ClassImp(TMethodBrowsable);
 
 TMethodBrowsable::TMethodBrowsable(const TBranch* branch, TMethod* m,
                                    const TVirtualBranchBrowsable* parent /* =0 */):
-   TVirtualBranchBrowsable(branch, nullptr, kFALSE, parent), fMethod(m)
+   TVirtualBranchBrowsable(branch, nullptr, false, parent), fMethod(m)
 {
    TString name(m->GetName());
    name+="()";
@@ -527,7 +527,7 @@ Int_t TMethodBrowsable::GetBrowsables(TList& li, const TBranch* branch,
 /// persistent data member, the methods GetX(), getX(), and X() will not
 /// be browsable.
 
-Bool_t TMethodBrowsable::IsMethodBrowsable(const TMethod* m)
+bool TMethodBrowsable::IsMethodBrowsable(const TMethod* m)
 {
    long property = m->Property();
    const char* baseName=m->GetName();
@@ -560,13 +560,13 @@ Bool_t TMethodBrowsable::IsMethodBrowsable(const TMethod* m)
 
       // look for matching data member
       TClass* cl=m->GetClass();
-      if (!cl) return kTRUE;
+      if (!cl) return true;
       TList* members=cl->GetListOfDataMembers();
-      if (!members) return kTRUE;
+      if (!members) return true;
       if (!strncmp(baseName, "Get", 3) ||
           !strncmp(baseName, "get", 3))
          baseName+=3;
-      if (!baseName[0]) return kTRUE;
+      if (!baseName[0]) return true;
 
       TObject* mem=nullptr;
       const char* arrMemberNames[3]={"f%s","_%s","m%s"};
@@ -574,7 +574,7 @@ Bool_t TMethodBrowsable::IsMethodBrowsable(const TMethod* m)
          mem=members->FindObject(TString::Format(arrMemberNames[i],baseName));
       return (!mem ||! ((TDataMember*)mem)->IsPersistent());
    };
-   return kFALSE;
+   return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/tree/src/TBranchClones.cxx
+++ b/tree/tree/src/TBranchClones.cxx
@@ -448,7 +448,7 @@ void TBranchClones::Streamer(TBuffer& b)
       }
       b.CheckByteCount(R__s, R__c, TBranchClones::IsA());
    } else {
-      R__c = b.WriteVersion(TBranchClones::IsA(), kTRUE);
+      R__c = b.WriteVersion(TBranchClones::IsA(), true);
       TNamed::Streamer(b);
       b << fCompress;
       b << fBasketSize;
@@ -463,7 +463,7 @@ void TBranchClones::Streamer(TBuffer& b)
       b << fBranchCount;
       fClassName.Streamer(b);
       fBranches.Streamer(b);
-      b.SetByteCount(R__c, kTRUE);
+      b.SetByteCount(R__c, true);
    }
 }
 

--- a/tree/tree/src/TBranchObject.cxx
+++ b/tree/tree/src/TBranchObject.cxx
@@ -47,7 +47,7 @@ TBranchObject::TBranchObject()
 ////////////////////////////////////////////////////////////////////////////////
 /// Create a BranchObject.
 
-TBranchObject::TBranchObject(TTree *tree, const char* name, const char* classname, void* addobj, Int_t basketsize, Int_t splitlevel, Int_t compress, Bool_t isptrptr /* = kTRUE */)
+TBranchObject::TBranchObject(TTree *tree, const char* name, const char* classname, void* addobj, Int_t basketsize, Int_t splitlevel, Int_t compress, bool isptrptr /* = true */)
 : TBranch()
 {
    Init(tree,nullptr,name,classname,addobj,basketsize,splitlevel,compress,isptrptr);
@@ -56,7 +56,7 @@ TBranchObject::TBranchObject(TTree *tree, const char* name, const char* classnam
 ////////////////////////////////////////////////////////////////////////////////
 /// Create a BranchObject.
 
-TBranchObject::TBranchObject(TBranch *parent, const char* name, const char* classname, void* addobj, Int_t basketsize, Int_t splitlevel, Int_t compress, Bool_t isptrptr /* = kTRUE */)
+TBranchObject::TBranchObject(TBranch *parent, const char* name, const char* classname, void* addobj, Int_t basketsize, Int_t splitlevel, Int_t compress, bool isptrptr /* = true */)
 : TBranch()
 {
    Init(nullptr,parent,name,classname,addobj,basketsize,splitlevel,compress,isptrptr);
@@ -65,7 +65,7 @@ TBranchObject::TBranchObject(TBranch *parent, const char* name, const char* clas
 ////////////////////////////////////////////////////////////////////////////////
 /// Initialization routine (run from the constructor so do not make this function virtual)
 
-void TBranchObject::Init(TTree *tree, TBranch *parent, const char* name, const char* classname, void* addobj, Int_t basketsize, Int_t /*splitlevel*/, Int_t compress, Bool_t isptrptr)
+void TBranchObject::Init(TTree *tree, TBranch *parent, const char* name, const char* classname, void* addobj, Int_t basketsize, Int_t /*splitlevel*/, Int_t compress, bool isptrptr)
 {
    if (tree==nullptr && parent!=nullptr) tree = parent->GetTree();
    fTree   = tree;
@@ -89,10 +89,10 @@ void TBranchObject::Init(TTree *tree, TBranch *parent, const char* name, const c
    char** apointer = (char**) addobj;
    TObject* obj = (TObject*) (*apointer);
 
-   Bool_t delobj = kFALSE;
+   bool delobj = false;
    if (!obj) {
       obj = (TObject*) cl->New();
-      delobj = kTRUE;
+      delobj = true;
    }
 
    tree->BuildStreamerInfo(cl, obj);
@@ -137,7 +137,7 @@ void TBranchObject::Init(TTree *tree, TBranch *parent, const char* name, const c
    // in TLeafObject::ReadBasket, the object should be deleted
    // before calling Streamer.
    // It is foreseen to not set this bit in a future version.
-   if (isptrptr) SetAutoDelete(kTRUE);
+   if (isptrptr) SetAutoDelete(true);
 
    fDirectory = fTree->GetDirectory();
    fFileName = "";
@@ -255,12 +255,12 @@ Int_t TBranchObject::GetExpectedType(TClass *&expectedClass,EDataType &expectedT
 ////////////////////////////////////////////////////////////////////////////////
 /// Return TRUE if more than one leaf or if fBrowsables, FALSE otherwise.
 
-Bool_t TBranchObject::IsFolder() const
+bool TBranchObject::IsFolder() const
 {
    Int_t nbranches = fBranches.GetEntriesFast();
 
    if (nbranches >= 1) {
-      return kTRUE;
+      return true;
    }
 
    TList* browsables = const_cast<TBranchObject*>(this)->GetBrowsables();
@@ -500,9 +500,9 @@ void TBranchObject::SetAddress(void* add)
 /// This function can be used to instruct Root in TBranchObject::ReadBasket
 /// to not delete the object referenced by a branchobject before reading a
 /// new entry. By default, the object is deleted.
-/// - If autodel is kTRUE, this existing object will be deleted, a new object
+/// - If autodel is true, this existing object will be deleted, a new object
 ///     created by the default constructor, then object->Streamer called.
-/// - If autodel is kFALSE, the existing object is not deleted. Root assumes
+/// - If autodel is false, the existing object is not deleted. Root assumes
 ///     that the user is taking care of deleting any internal object or array
 ///     This can be done in Streamer itself.
 /// - If this branch has sub-branches, the function sets autodel for these
@@ -514,7 +514,7 @@ void TBranchObject::SetAddress(void* add)
 /// not necessary to specify the option again when reading, unless you
 /// want to set the opposite mode.
 
-void TBranchObject::SetAutoDelete(Bool_t autodel)
+void TBranchObject::SetAutoDelete(bool autodel)
 {
    TBranch::SetAutoDelete(autodel);
 
@@ -557,7 +557,7 @@ void TBranchObject::Streamer(TBuffer& R__b)
 
       // make sure that all TStreamerInfo objects referenced by
       // this class are written to the file
-      R__b.ForceWriteInfo(TClass::GetClass(fClassName.Data())->GetStreamerInfo(), kTRUE);
+      R__b.ForceWriteInfo(TClass::GetClass(fClassName.Data())->GetStreamerInfo(), true);
 
       // if branch is in a separate file save this branch
       // as an independent key

--- a/tree/tree/src/TBranchRef.cxx
+++ b/tree/tree/src/TBranchRef.cxx
@@ -112,7 +112,7 @@ Int_t TBranchRef::FillImpl(ROOT::Internal::TBranchIMTHelper *imtHelper)
 /// The function reads the branch containing the object referenced
 /// by the TRef.
 
-Bool_t TBranchRef::Notify()
+bool TBranchRef::Notify()
 {
    if (!fRefTable) fRefTable = new TRefTable(this,100);
    UInt_t uid = fRefTable->GetUID();
@@ -129,7 +129,7 @@ Bool_t TBranchRef::Notify()
    } else {
       //scan the TRefTable of possible friend Trees
       TList *friends = fTree->GetListOfFriends();
-      if (!friends) return kTRUE;
+      if (!friends) return true;
       TObjLink *lnk = friends->FirstLink();
       while (lnk) {
          TFriendElement* elem = (TFriendElement*)lnk->GetObject();
@@ -144,13 +144,13 @@ Bool_t TBranchRef::Notify()
                // don't re-read, the user might have changed some object
                if (branch->GetReadEntry() != fRequestedEntry)
                   branch->GetEntry(fRequestedEntry);
-               return kTRUE;
+               return true;
             }
          }
          lnk = lnk->Next();
       }
    }
-   return kTRUE;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/tree/src/TBranchSTL.cxx
+++ b/tree/tree/src/TBranchSTL.cxx
@@ -410,7 +410,7 @@ Int_t TBranchSTL::GetEntry( Long64_t entry, Int_t getall )
       fObject = *(char**)fAddress;
    }
    TVirtualCollectionProxy::TPushPop helper( fCollProxy, fObject );
-   void* env = fCollProxy->Allocate( size, kTRUE );
+   void* env = fCollProxy->Allocate( size, true );
 
    //---------------------------------------------------------------------------
    // Process entries
@@ -590,11 +590,11 @@ TStreamerInfo* TBranchSTL::GetInfo() const
 ////////////////////////////////////////////////////////////////////////////////
 /// Branch declared folder if at least one entry.
 
-Bool_t TBranchSTL::IsFolder() const
+bool TBranchSTL::IsFolder() const
 {
    if( fBranches.GetEntriesFast() >= 1 )
-      return kTRUE;
-   return kFALSE;
+      return true;
+   return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/tree/src/TBufferSQL.cxx
+++ b/tree/tree/src/TBufferSQL.cxx
@@ -54,7 +54,7 @@ TBufferSQL::TBufferSQL(TBuffer::EMode mode, Int_t bufsiz, std::vector<Int_t> *vc
 
 TBufferSQL::TBufferSQL(TBuffer::EMode mode, Int_t bufsiz, std::vector<Int_t> *vc,
                        TString *insert_query, TSQLRow ** r,
-                       void *buf, Bool_t adopt) :
+                       void *buf, bool adopt) :
    TBufferFile(mode,bufsiz,buf,adopt),
    fColumnVec(vc), fInsertQuery(insert_query), fRowPtr(r)
 {
@@ -79,9 +79,9 @@ TBufferSQL::~TBufferSQL()
 ////////////////////////////////////////////////////////////////////////////////
 /// Operator>>
 
-void TBufferSQL::ReadBool(Bool_t &b)
+void TBufferSQL::ReadBool(bool &b)
 {
-   b = (Bool_t)atoi((*fRowPtr)->GetField(*fIter));
+   b = (bool)atoi((*fRowPtr)->GetField(*fIter));
 
    if (fIter != fColumnVec->end()) ++fIter;
 }
@@ -149,7 +149,7 @@ void TBufferSQL::ReadDouble(Double_t &d)
 ////////////////////////////////////////////////////////////////////////////////
 /// Operator<<
 
-void TBufferSQL::WriteBool(Bool_t    b)
+void TBufferSQL::WriteBool(bool      b)
 {
    (*fInsertQuery) += b;
    (*fInsertQuery) += ",";
@@ -423,7 +423,7 @@ void TBufferSQL::WriteCharP(const Char_t *str)
 ////////////////////////////////////////////////////////////////////////////////
 /// WriteFastArray SQL implementation.
 
-void TBufferSQL::WriteFastArray(const Bool_t *b, Int_t n)
+void TBufferSQL::WriteFastArray(const bool *b, Int_t n)
 {
    for(int i=0; i<n; ++i) {
       (*fInsertQuery) += b[i];
@@ -599,19 +599,19 @@ void TBufferSQL::WriteFastArray(void*, const TClass*, Int_t, TMemberStreamer *)
 ////////////////////////////////////////////////////////////////////////////////
 /// WriteFastArray SQL implementation.
 
-Int_t TBufferSQL::WriteFastArray(void **, const TClass*, Int_t, Bool_t, TMemberStreamer*)
+Int_t TBufferSQL::WriteFastArray(void **, const TClass*, Int_t, bool, TMemberStreamer*)
 {
-   Fatal("WriteFastArray(void **, const TClass*, Int_t, Bool_t, TMemberStreamer*)","Not implemented yet");
+   Fatal("WriteFastArray(void **, const TClass*, Int_t, bool, TMemberStreamer*)","Not implemented yet");
    return 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// ReadFastArray SQL implementation.
 
-void TBufferSQL::ReadFastArray(Bool_t *b, Int_t n)
+void TBufferSQL::ReadFastArray(bool *b, Int_t n)
 {
    for(int i=0; i<n; ++i) {
-      b[i] = (Bool_t)atoi((*fRowPtr)->GetField(*fIter));
+      b[i] = (bool)atoi((*fRowPtr)->GetField(*fIter));
       ++fIter;
    }
 }
@@ -813,9 +813,9 @@ void     TBufferSQL::ReadFastArray(void  *, const TClass *, Int_t, TMemberStream
 ////////////////////////////////////////////////////////////////////////////////
 /// ReadFastArray SQL implementation.
 
-void     TBufferSQL::ReadFastArray(void **, const TClass *, Int_t, Bool_t, TMemberStreamer *, const TClass *)
+void     TBufferSQL::ReadFastArray(void **, const TClass *, Int_t, bool, TMemberStreamer *, const TClass *)
 {
-   Fatal("ReadFastArray(void **, const TClass *, Int_t, Bool_t, TMemberStreamer *, const TClass *)","Not implemented yet");
+   Fatal("ReadFastArray(void **, const TClass *, Int_t, bool, TMemberStreamer *, const TClass *)","Not implemented yet");
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -70,7 +70,7 @@ ClassImp(TChain);
 /// Default constructor.
 
 TChain::TChain(Mode mode)
-   : TTree(), fTreeOffsetLen(100), fNtrees(0), fTreeNumber(-1), fTreeOffset(nullptr), fCanDeleteRefs(kFALSE), fTree(nullptr),
+   : TTree(), fTreeOffsetLen(100), fNtrees(0), fTreeNumber(-1), fTreeOffset(nullptr), fCanDeleteRefs(false), fTree(nullptr),
      fFile(nullptr), fFiles(nullptr), fStatus(nullptr), fProofChain(nullptr), fGlobalRegistration(mode == kWithGlobalRegistration)
 {
    fTreeOffset = new Long64_t[fTreeOffsetLen];
@@ -139,7 +139,7 @@ TChain::TChain(Mode mode)
 
 TChain::TChain(const char *name, const char *title, Mode mode)
    : TTree(name, title, /*splitlevel*/ 99, nullptr), fTreeOffsetLen(100), fNtrees(0), fTreeNumber(-1), fTreeOffset(nullptr),
-     fCanDeleteRefs(kFALSE), fTree(nullptr), fFile(nullptr), fFiles(nullptr), fStatus(nullptr), fProofChain(nullptr),
+     fCanDeleteRefs(false), fTree(nullptr), fFile(nullptr), fFiles(nullptr), fStatus(nullptr), fProofChain(nullptr),
      fGlobalRegistration(mode == kWithGlobalRegistration)
 {
    //
@@ -709,7 +709,7 @@ TFriendElement* TChain::AddFriend(const char* chain, TFile* dummy)
 ////////////////////////////////////////////////////////////////////////////////
 /// Add the whole chain or tree as a friend of this chain.
 
-TFriendElement* TChain::AddFriend(TTree* chain, const char* alias, Bool_t /* warn = kFALSE */)
+TFriendElement* TChain::AddFriend(TTree* chain, const char* alias, bool /* warn = false */)
 {
    if (!chain) return nullptr;
    if (!fFriends) fFriends = new TList();
@@ -743,8 +743,8 @@ void TChain::Browse(TBrowser* b)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// When closing a file during the chain processing, the file
-/// may be closed with option "R" if flag is set to kTRUE.
-/// by default flag is kTRUE.
+/// may be closed with option "R" if flag is set to true.
+/// by default flag is true.
 /// When closing a file with option "R", all TProcessIDs referenced by this
 /// file are deleted.
 /// Calling TFile::Close("R") might be necessary in case one reads a long list
@@ -754,7 +754,7 @@ void TChain::Browse(TBrowser* b)
 /// of the TProcessID data structures in memory by forcing a delete of
 /// the unused TProcessID.
 
-void TChain::CanDeleteRefs(Bool_t flag /* = kTRUE */)
+void TChain::CanDeleteRefs(bool flag /* = true */)
 {
    fCanDeleteRefs = flag;
 }
@@ -796,7 +796,7 @@ Long64_t TChain::Draw(const char* varexp, const TCut& selection,
    if (fProofChain) {
       // Make sure the element list is up to date
       if (!TestBit(kProofUptodate))
-         SetProof(kTRUE, kTRUE);
+         SetProof(true, true);
       fProofChain->SetEventList(fEventList);
       fProofChain->SetEntryList(fEntryList);
       return fProofChain->Draw(varexp, selection, option, nentries, firstentry);
@@ -816,7 +816,7 @@ Long64_t TChain::Draw(const char* varexp, const char* selection,
    if (fProofChain) {
       // Make sure the element list is up to date
       if (!TestBit(kProofUptodate))
-         SetProof(kTRUE, kTRUE);
+         SetProof(true, true);
       fProofChain->SetEventList(fEventList);
       fProofChain->SetEntryList(fEntryList);
       return fProofChain->Draw(varexp, selection, option, nentries, firstentry);
@@ -834,7 +834,7 @@ TBranch* TChain::FindBranch(const char* branchname)
    if (fProofChain && !(fProofChain->TestBit(kProofLite))) {
       // Make sure the element list is up to date
       if (!TestBit(kProofUptodate))
-         SetProof(kTRUE, kTRUE);
+         SetProof(true, true);
       return fProofChain->FindBranch(branchname);
    }
    if (fTree) {
@@ -855,7 +855,7 @@ TLeaf* TChain::FindLeaf(const char* searchname)
    if (fProofChain && !(fProofChain->TestBit(kProofLite))) {
       // Make sure the element list is up to date
       if (!TestBit(kProofUptodate))
-         SetProof(kTRUE, kTRUE);
+         SetProof(true, true);
       return fProofChain->FindLeaf(searchname);
    }
    if (fTree) {
@@ -895,7 +895,7 @@ TBranch* TChain::GetBranch(const char* name)
    if (fProofChain && !(fProofChain->TestBit(kProofLite))) {
       // Make sure the element list is up to date
       if (!TestBit(kProofUptodate))
-         SetProof(kTRUE, kTRUE);
+         SetProof(true, true);
       return fProofChain->GetBranch(name);
    }
    if (fTree) {
@@ -911,13 +911,13 @@ TBranch* TChain::GetBranch(const char* name)
 ////////////////////////////////////////////////////////////////////////////////
 /// See TTree::GetReadEntry().
 
-Bool_t TChain::GetBranchStatus(const char* branchname) const
+bool TChain::GetBranchStatus(const char* branchname) const
 {
    if (fProofChain && !(fProofChain->TestBit(kProofLite))) {
       // Make sure the element list is up to date
       if (!TestBit(kProofUptodate))
          Warning("GetBranchStatus", "PROOF proxy not up-to-date:"
-                                    " run TChain::SetProof(kTRUE, kTRUE) first");
+                                    " run TChain::SetProof(true, true) first");
       return fProofChain->GetBranchStatus(branchname);
    }
    return TTree::GetBranchStatus(branchname);
@@ -955,7 +955,7 @@ Long64_t TChain::GetEntries() const
       // Make sure the element list is up to date
       if (!TestBit(kProofUptodate))
          Warning("GetEntries", "PROOF proxy not up-to-date:"
-                               " run TChain::SetProof(kTRUE, kTRUE) first");
+                               " run TChain::SetProof(true, true) first");
       return fProofChain->GetEntries();
    }
    if (fEntries == TTree::kMaxEntries) {
@@ -1054,7 +1054,7 @@ TLeaf* TChain::GetLeaf(const char* branchname, const char *leafname)
    if (fProofChain && !(fProofChain->TestBit(kProofLite))) {
       // Make sure the element list is up to date
       if (!TestBit(kProofUptodate))
-         SetProof(kTRUE, kTRUE);
+         SetProof(true, true);
       return fProofChain->GetLeaf(branchname, leafname);
    }
    if (fTree) {
@@ -1075,7 +1075,7 @@ TLeaf* TChain::GetLeaf(const char* name)
    if (fProofChain && !(fProofChain->TestBit(kProofLite))) {
       // Make sure the element list is up to date
       if (!TestBit(kProofUptodate))
-         SetProof(kTRUE, kTRUE);
+         SetProof(true, true);
       return fProofChain->GetLeaf(name);
    }
    if (fTree) {
@@ -1101,7 +1101,7 @@ TObjArray* TChain::GetListOfBranches()
    if (fProofChain && !(fProofChain->TestBit(kProofLite))) {
       // Make sure the element list is up to date
       if (!TestBit(kProofUptodate))
-         SetProof(kTRUE, kTRUE);
+         SetProof(true, true);
       return fProofChain->GetListOfBranches();
    }
    if (fTree) {
@@ -1124,7 +1124,7 @@ TObjArray* TChain::GetListOfLeaves()
    if (fProofChain && !(fProofChain->TestBit(kProofLite))) {
       // Make sure the element list is up to date
       if (!TestBit(kProofUptodate))
-         SetProof(kTRUE, kTRUE);
+         SetProof(true, true);
       return fProofChain->GetListOfLeaves();
    }
    if (fTree) {
@@ -1197,7 +1197,7 @@ Long64_t TChain::GetReadEntry() const
       // Make sure the element list is up to date
       if (!TestBit(kProofUptodate))
          Warning("GetBranchStatus", "PROOF proxy not up-to-date:"
-                                    " run TChain::SetProof(kTRUE, kTRUE) first");
+                                    " run TChain::SetProof(true, true) first");
       return fProofChain->GetReadEntry();
    }
    return TTree::GetReadEntry();
@@ -1230,7 +1230,7 @@ Double_t TChain::GetWeight() const
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Move content to a new file. (NOT IMPLEMENTED for TChain)
-Bool_t TChain::InPlaceClone(TDirectory * /* new directory */, const char * /* options */)
+bool TChain::InPlaceClone(TDirectory * /* new directory */, const char * /* options */)
 {
    Error("InPlaceClone", "not implemented");
    return false;
@@ -1354,11 +1354,11 @@ Long64_t TChain::LoadTree(Long64_t entry)
             // number (treeReadEntry) hence we do:
             at->LoadTreeFriend(entry, this);
          }
-         Bool_t needUpdate = kFALSE;
+         bool needUpdate = false;
          if (fTree->GetListOfFriends()) {
             for(auto fetree : ROOT::Detail::TRangeStaticCast<TFriendElement>(*fTree->GetListOfFriends())) {
                if (fetree->IsUpdated()) {
-                  needUpdate = kTRUE;
+                  needUpdate = true;
                   fetree->ResetUpdated();
                }
             }
@@ -1391,16 +1391,16 @@ Long64_t TChain::LoadTree(Long64_t entry)
                         Int_t res = CheckBranchAddressType(br, TClass::GetClass(frelement->GetBaddressClassName()),
                                                          (EDataType) frelement->GetBaddressType(), frelement->GetBaddressIsPtr());
                         if ((res & kNeedEnableDecomposedObj) && !br->GetMakeClass()) {
-                           br->SetMakeClass(kTRUE);
+                           br->SetMakeClass(true);
                         }
                         frelement->SetDecomposedObj(br->GetMakeClass());
-                        frelement->SetCheckedType(kTRUE);
+                        frelement->SetCheckedType(true);
                      }
                      // FIXME: We may have to tell the branch it should
                      //        not be an owner of the object pointed at.
                      br->SetAddress(addr);
                      if (TestBit(kAutoDelete)) {
-                        br->SetAutoDelete(kTRUE);
+                        br->SetAutoDelete(true);
                      }
                   }
                }
@@ -1684,16 +1684,16 @@ Long64_t TChain::LoadTree(Long64_t entry)
                Int_t res = CheckBranchAddressType(br, TClass::GetClass(element->GetBaddressClassName()),
                                                   (EDataType) element->GetBaddressType(), element->GetBaddressIsPtr());
                if ((res & kNeedEnableDecomposedObj) && !br->GetMakeClass()) {
-                  br->SetMakeClass(kTRUE);
+                  br->SetMakeClass(true);
                }
                element->SetDecomposedObj(br->GetMakeClass());
-               element->SetCheckedType(kTRUE);
+               element->SetCheckedType(true);
             }
             // FIXME: We may have to tell the branch it should
             //        not be an owner of the object pointed at.
             br->SetAddress(addr);
             if (TestBit(kAutoDelete)) {
-               br->SetAutoDelete(kTRUE);
+               br->SetAutoDelete(true);
             }
          }
       }
@@ -1724,9 +1724,9 @@ Long64_t TChain::LoadTree(Long64_t entry)
 ////////////////////////////////////////////////////////////////////////////////
 /// Check / locate the files in the chain.
 /// By default only the files not yet looked up are checked.
-/// Use force = kTRUE to check / re-check every file.
+/// Use force = true to check / re-check every file.
 
-void TChain::Lookup(Bool_t force)
+void TChain::Lookup(bool force)
 {
    TIter next(fFiles);
    TChainElement* element = nullptr;
@@ -1741,7 +1741,7 @@ void TChain::Lookup(Bool_t force)
       // Count
       nlook++;
       // Get the Url
-      TUrl elemurl(element->GetTitle(), kTRUE);
+      TUrl elemurl(element->GetTitle(), true);
       // Save current options and anchor
       TString anchor = elemurl.GetAnchor();
       TString options = elemurl.GetOptions();
@@ -2009,11 +2009,11 @@ Long64_t TChain::Merge(TFile* file, Int_t basketsize, Option_t* option)
    }
 
    // Options
-   Bool_t fastClone = kFALSE;
+   bool fastClone = false;
    TString opt = option;
    opt.ToLower();
    if (opt.Contains("fast")) {
-      fastClone = kTRUE;
+      fastClone = true;
    }
 
    // The chain tree must have a list of branches
@@ -2148,7 +2148,7 @@ void TChain::ParseTreeFilename(const char *name, TString &filename, TString &tre
    suffix.Clear();
 
    // General case
-   TUrl url(name, kTRUE);
+   TUrl url(name, true);
    filename = (strcmp(url.GetProtocol(), "file")) ? url.GetUrl() : url.GetFileAndOptions();
 
    TString fn = url.GetFile();
@@ -2236,7 +2236,7 @@ Long64_t TChain::Process(const char *filename, Option_t *option, Long64_t nentri
    if (fProofChain) {
       // Make sure the element list is up to date
       if (!TestBit(kProofUptodate))
-         SetProof(kTRUE, kTRUE);
+         SetProof(true, true);
       fProofChain->SetEventList(fEventList);
       fProofChain->SetEntryList(fEntryList);
       return fProofChain->Process(filename, option, nentries, firstentry);
@@ -2258,7 +2258,7 @@ Long64_t TChain::Process(TSelector* selector, Option_t* option, Long64_t nentrie
    if (fProofChain) {
       // Make sure the element list is up to date
       if (!TestBit(kProofUptodate))
-         SetProof(kTRUE, kTRUE);
+         SetProof(true, true);
       fProofChain->SetEventList(fEventList);
       fProofChain->SetEntryList(fEntryList);
       return fProofChain->Process(selector, option, nentries, firstentry);
@@ -2424,7 +2424,7 @@ Long64_t TChain::Scan(const char* varexp, const char* selection, Option_t* optio
 /// the address is set will have the option AutoDelete set
 /// For more details on AutoDelete, see TBranch::SetAutoDelete.
 
-void TChain::SetAutoDelete(Bool_t autodelete)
+void TChain::SetAutoDelete(bool autodelete)
 {
    if (autodelete) {
       SetBit(kAutoDelete, true);
@@ -2443,7 +2443,7 @@ Int_t TChain::SetCacheSize(Long64_t cacheSize)
    Int_t res = 0;
 
    // remember user has requested this cache setting
-   fCacheUserSet = kTRUE;
+   fCacheUserSet = true;
 
    if (fTree) {
       res = fTree->SetCacheSize(cacheSize);
@@ -2524,10 +2524,10 @@ Int_t TChain::SetBranchAddress(const char *bname, void* add, TBranch** ptr)
       if (branch) {
          res = CheckBranchAddressType(branch, TClass::GetClass(element->GetBaddressClassName()), (EDataType) element->GetBaddressType(), element->GetBaddressIsPtr());
          if ((res & kNeedEnableDecomposedObj) && !branch->GetMakeClass()) {
-            branch->SetMakeClass(kTRUE);
+            branch->SetMakeClass(true);
          }
          element->SetDecomposedObj(branch->GetMakeClass());
-         element->SetCheckedType(kTRUE);
+         element->SetCheckedType(true);
          if (fClones) {
             void* oldAdd = branch->GetAddress();
             for (TObjLink* lnk = fClones->FirstLink(); lnk; lnk = lnk->Next()) {
@@ -2537,7 +2537,7 @@ Int_t TChain::SetBranchAddress(const char *bname, void* add, TBranch** ptr)
                   // the clone's branch is still pointing to us
                   cloneBr->SetAddress(add);
                   if ((res & kNeedEnableDecomposedObj) && !cloneBr->GetMakeClass()) {
-                     cloneBr->SetMakeClass(kTRUE);
+                     cloneBr->SetMakeClass(true);
                   }
                }
             }
@@ -2563,7 +2563,7 @@ Int_t TChain::SetBranchAddress(const char *bname, void* add, TBranch** ptr)
 /// Note: See the comments in TBranchElement::SetAddress() for a more
 /// detailed discussion of the meaning of the add parameter.
 
-Int_t TChain::SetBranchAddress(const char* bname, void* add, TClass* realClass, EDataType datatype, Bool_t isptr)
+Int_t TChain::SetBranchAddress(const char* bname, void* add, TClass* realClass, EDataType datatype, bool isptr)
 {
    return SetBranchAddress(bname, add, nullptr, realClass, datatype, isptr);
 }
@@ -2575,7 +2575,7 @@ Int_t TChain::SetBranchAddress(const char* bname, void* add, TClass* realClass, 
 /// Note: See the comments in TBranchElement::SetAddress() for a more
 /// detailed discussion of the meaning of the add parameter.
 
-Int_t TChain::SetBranchAddress(const char* bname, void* add, TBranch** ptr, TClass* realClass, EDataType datatype, Bool_t isptr)
+Int_t TChain::SetBranchAddress(const char* bname, void* add, TBranch** ptr, TClass* realClass, EDataType datatype, bool isptr)
 {
    TChainElement* element = (TChainElement*) fStatus->FindObject(bname);
    if (!element) {
@@ -2605,7 +2605,7 @@ Int_t TChain::SetBranchAddress(const char* bname, void* add, TBranch** ptr, TCla
 ///  expression is returned in *found AND the error message 'unknown branch'
 ///  is suppressed.
 
-void TChain::SetBranchStatus(const char* bname, Bool_t status, UInt_t* found)
+void TChain::SetBranchStatus(const char* bname, bool status, UInt_t* found)
 {
    // FIXME: We never explicitly set found to zero!
 
@@ -2777,14 +2777,14 @@ void TChain::SetEntryList(TEntryList *elist, Option_t *opt)
    }
    fEntryList = elist;
    TList *elists = elist->GetLists();
-   Bool_t shift = kFALSE;
+   bool shift = false;
    TIter next(elists);
 
    //check, if there are sub-lists in the entry list, that don't
    //correspond to any trees in the chain
    while((templist = (TEntryList*)next())){
       if (templist->GetTreeNumber() < 0){
-         shift = kTRUE;
+         shift = true;
          break;
       }
    }
@@ -2843,7 +2843,7 @@ void TChain::SetEntryListFile(const char *filename, Option_t * /*opt*/)
       basename.Remove(dotslashpos+5);
    }
    fEntryList = new TEntryListFromFile(basename.Data(), behind_dot_root.Data(), fNtrees);
-   fEntryList->SetBit(kCanDelete, kTRUE);
+   fEntryList->SetBit(kCanDelete, true);
    fEntryList->SetDirectory(nullptr);
    ((TEntryListFromFile*)fEntryList)->SetFileNames(fFiles);
 }
@@ -2927,7 +2927,7 @@ void TChain::SetEventList(TEventList *evlist)
       enlist->SetTree(treename, filename);
       enlist->Enter(localentry);
    }
-   enlist->SetBit(kCanDelete, kTRUE);
+   enlist->SetBit(kCanDelete, true);
    enlist->SetReapplyCut(evlist->GetReapplyCut());
    SetEntryList(enlist);
 }
@@ -2971,14 +2971,14 @@ void TChain::SetPacketSize(Int_t size)
 /// Enable/Disable PROOF processing on the current default Proof (gProof).
 ///
 /// "Draw" and "Processed" commands will be handled by PROOF.
-/// The refresh and gettreeheader are meaningful only if on == kTRUE.
-/// If refresh is kTRUE the underlying fProofChain (chain proxy) is always
+/// The refresh and gettreeheader are meaningful only if on == true.
+/// If refresh is true the underlying fProofChain (chain proxy) is always
 /// rebuilt (even if already existing).
-/// If gettreeheader is kTRUE the header of the tree will be read from the
+/// If gettreeheader is true the header of the tree will be read from the
 /// PROOF cluster: this is only needed for browsing and should be used with
 /// care because it may take a long time to execute.
 
-void TChain::SetProof(Bool_t on, Bool_t refresh, Bool_t gettreeheader)
+void TChain::SetProof(bool on, bool refresh, bool gettreeheader)
 {
    if (!on) {
       // Disable

--- a/tree/tree/src/TChainElement.cxx
+++ b/tree/tree/src/TChainElement.cxx
@@ -26,7 +26,7 @@ ClassImp(TChainElement);
 /// Default constructor for a chain element.
 
 TChainElement::TChainElement() : TNamed(),fBaddress(nullptr),fBaddressType(0),
-   fBaddressIsPtr(kFALSE), fDecomposedObj(kFALSE), fCheckedType(kFALSE), fBranchPtr(nullptr), fLoadResult(0)
+   fBaddressIsPtr(false), fDecomposedObj(false), fCheckedType(false), fBranchPtr(nullptr), fLoadResult(0)
 {
    fNPackets   = 0;
    fPackets    = nullptr;
@@ -41,7 +41,7 @@ TChainElement::TChainElement() : TNamed(),fBaddress(nullptr),fBaddressType(0),
 
 TChainElement::TChainElement(const char *name, const char *title)
    :TNamed(name,title),fBaddress(nullptr),fBaddressType(0),
-    fBaddressIsPtr(kFALSE), fDecomposedObj(kFALSE), fCheckedType(kFALSE), fBranchPtr(nullptr), fLoadResult(0)
+    fBaddressIsPtr(false), fDecomposedObj(false), fCheckedType(false), fBranchPtr(nullptr), fLoadResult(0)
 {
    fNPackets   = 0;
    fPackets    = nullptr;
@@ -97,7 +97,7 @@ void TChainElement::SetPacketSize(Int_t size)
 ////////////////////////////////////////////////////////////////////////////////
 /// Set/Reset the looked-up bit
 
-void TChainElement::SetLookedUp(Bool_t y)
+void TChainElement::SetLookedUp(bool y)
 {
    if (y)
       SetBit(kHasBeenLookedUp);

--- a/tree/tree/src/TCut.cxx
+++ b/tree/tree/src/TCut.cxx
@@ -79,7 +79,7 @@ TCut::~TCut()
 ////////////////////////////////////////////////////////////////////////////////
 /// Comparison.
 
-Bool_t TCut::operator==(const char *rhs) const
+bool TCut::operator==(const char *rhs) const
 {
    return fTitle == rhs;
 }
@@ -87,7 +87,7 @@ Bool_t TCut::operator==(const char *rhs) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Comparison.
 
-Bool_t TCut::operator==(const TCut &rhs) const
+bool TCut::operator==(const TCut &rhs) const
 {
    return fTitle == rhs.fTitle;
 }
@@ -95,7 +95,7 @@ Bool_t TCut::operator==(const TCut &rhs) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Comparison.
 
-Bool_t TCut::operator!=(const char *rhs) const
+bool TCut::operator!=(const char *rhs) const
 {
    return fTitle != rhs;
 }
@@ -103,7 +103,7 @@ Bool_t TCut::operator!=(const char *rhs) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Comparison.
 
-Bool_t TCut::operator!=(const TCut &rhs) const
+bool TCut::operator!=(const TCut &rhs) const
 {
    return fTitle != rhs.fTitle;
 }

--- a/tree/tree/src/TEntryList.cxx
+++ b/tree/tree/src/TEntryList.cxx
@@ -172,10 +172,10 @@ TEntryList::TEntryList() : fEntriesToProcess(0)
    fStringHash = 0;
    fTreeNumber = -1;
    fDirectory = nullptr;
-   fReapply = kFALSE;
+   fReapply = false;
    fLastIndexQueried = -1;
    fLastIndexReturned = 0;
-   fShift = kFALSE;
+   fShift = false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -194,14 +194,14 @@ TEntryList::TEntryList(const char *name, const char *title) :
    fFileName = "";
    fStringHash = 0;
    fTreeNumber = -1;
-   fReapply = kFALSE;
+   fReapply = false;
 
    fDirectory  = gDirectory;
    if (fDirectory) fDirectory->Append(this);
 
    fLastIndexQueried = -1;
    fLastIndexReturned = 0;
-   fShift = kFALSE;
+   fShift = false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -216,14 +216,14 @@ TEntryList::TEntryList(const char *name, const char *title, const TTree *tree):T
    fNBlocks = 0;
    fTreeNumber = -1;
    TEntryList::SetTree(tree);
-   fReapply = kFALSE;
+   fReapply = false;
 
    fDirectory  = gDirectory;
    if (fDirectory) fDirectory->Append(this);
 
    fLastIndexQueried = -1;
    fLastIndexReturned = 0;
-   fShift = kFALSE;
+   fShift = false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -238,14 +238,14 @@ TEntryList::TEntryList(const char *name, const char *title, const char *treename
    fN = 0;
    SetTree(treename, filename);
    fTreeNumber = -1;
-   fReapply = kFALSE;
+   fReapply = false;
 
    fDirectory  = gDirectory;
    if (fDirectory) fDirectory->Append(this);
 
    fLastIndexQueried = -1;
    fLastIndexReturned = 0;
-   fShift = kFALSE;
+   fShift = false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -262,13 +262,13 @@ TEntryList::TEntryList(const TTree *tree) : fEntriesToProcess(0)
    SetTree(tree);
    fTreeNumber = -1;
 
-   fReapply = kFALSE;
+   fReapply = false;
    fDirectory  = gDirectory;
    if (fDirectory) fDirectory->Append(this);
 
    fLastIndexQueried = -1;
    fLastIndexReturned = 0;
-   fShift = kFALSE;
+   fShift = false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -483,7 +483,7 @@ void TEntryList::Add(const TEntryList *elist)
          //the other list doesn't have sublists
          TIter next(fLists);
          TEntryList *el = nullptr;
-         Bool_t found = kFALSE;
+         bool found = false;
          while ((el = (TEntryList*)next())){
             if (!strcmp(el->fTreeName.Data(), elist->fTreeName.Data()) &&
                 !strcmp(el->fFileName.Data(), elist->fFileName.Data())){
@@ -491,7 +491,7 @@ void TEntryList::Add(const TEntryList *elist)
                //found a list for the same tree
                Long64_t oldn = el->GetN();
                el->Add(elist);
-               found = kTRUE;
+               found = true;
                fN = fN - oldn + el->GetN();
                break;
             }
@@ -624,7 +624,7 @@ void TEntryList::DirectoryAutoAdd(TDirectory* dir)
 /// - When tree is a chain, the entry is assumed to be global index and the local
 /// entry is recomputed from the treeoffset information of the chain
 
-Bool_t TEntryList::Enter(Long64_t entry, TTree *tree)
+bool TEntryList::Enter(Long64_t entry, TTree *tree)
 {
    if (!tree){
       if (!fLists) {
@@ -672,7 +672,7 @@ Bool_t TEntryList::Enter(Long64_t entry, TTree *tree)
 
 }
 
-Bool_t TEntryList::Enter(Long64_t localentry, const char *treename, const char *filename)
+bool TEntryList::Enter(Long64_t localentry, const char *treename, const char *filename)
 {
    SetTree(treename, filename);
    if (fCurrent) {
@@ -710,10 +710,10 @@ void TEntryList::EnterRange(Long64_t start, Long64_t end, TTree *tree, UInt_t st
 /// - When tree is a chain, the entry is assumed to be global index and the local
 /// entry is recomputed from the treeoffset information of the chain
 
-Bool_t TEntryList::Remove(Long64_t entry, TTree *tree)
+bool TEntryList::Remove(Long64_t entry, TTree *tree)
 {
    if (entry < 0)
-     return kFALSE;
+     return false;
    if (!tree) {
       if (!fLists) {
          if (!fBlocks) return false;
@@ -836,7 +836,7 @@ Long64_t TEntryList::GetEntryAndTree(Long64_t index, Int_t &treenum)
 //Example:
 //First sublist - 20 entries, second sublist - 5 entries, third sublist - 10 entries
 //Second sublist doesn't correspond to any trees of the chain
-//Then, when GetEntryAndTree(21, treenum, kTRUE) is called, first entry of the
+//Then, when GetEntryAndTree(21, treenum, true) is called, first entry of the
 //third sublist will be returned
 
    Long64_t result = GetEntry(index);
@@ -863,10 +863,10 @@ Long64_t TEntryList::GetEntryAndTree(Long64_t index, Int_t &treenum)
 /// The function optionally (is 'local' is defined) checks file locality (i.e.
 /// protocol 'file://') returning the result in '*local' .
 
-void TEntryList::GetFileName(const char *filename, TString &fn, Bool_t *local)
+void TEntryList::GetFileName(const char *filename, TString &fn, bool *local)
 {
-   TUrl u(filename, kTRUE);
-   if (local) *local = (!strcmp(u.GetProtocol(), "file")) ? kTRUE : kFALSE;
+   TUrl u(filename, true);
+   if (local) *local = (!strcmp(u.GetProtocol(), "file")) ? true : false;
    if (strlen(u.GetAnchor()) > 0) {
       fn.Form("%s#%s", u.GetFile(), u.GetAnchor());
    } else {
@@ -891,12 +891,12 @@ TEntryList *TEntryList::GetEntryList(const char *treename, const char *filename,
    if (!treename || !filename) return nullptr;
    TString option = opt;
    option.ToUpper();
-   Bool_t nexp = option.Contains("NE");
+   bool nexp = option.Contains("NE");
 
    TString fn;
-   Bool_t local;
+   bool local;
    GetFileName(filename, fn, &local);
-   if (nexp) local = kFALSE;
+   if (nexp) local = false;
 
    if (gDebug > 1)
       Info("GetEntryList", "file: %s, local? %d", filename, local);
@@ -1157,7 +1157,7 @@ void TEntryList::Reset()
    fTreeNumber = -1;
    fLastIndexQueried = -1;
    fLastIndexReturned = 0;
-   fReapply = kFALSE;
+   fReapply = false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1305,7 +1305,7 @@ void TEntryList::SetTree(const TTree *tree)
    TString filename;
    if (tree->GetTree()->GetCurrentFile()){
       filename = tree->GetTree()->GetCurrentFile()->GetName();
-      TUrl url(filename.Data(), kTRUE);
+      TUrl url(filename.Data(), true);
       if (!strcmp(url.GetProtocol(), "file")){
          gSystem->ExpandPathName(filename);
          if (!gSystem->IsAbsoluteFileName(filename))
@@ -1350,11 +1350,11 @@ void TEntryList::Subtract(const TEntryList *elist)
          //second list has sublists, try to find one for the same tree as this list
          TIter next1(elist->GetLists());
          templist = nullptr;
-         Bool_t found = kFALSE;
+         bool found = false;
          while ((templist = (TEntryList*)next1())){
             if (!strcmp(templist->fTreeName.Data(),fTreeName.Data()) &&
                 !strcmp(templist->fFileName.Data(),fFileName.Data())){
-               found = kTRUE;
+               found = true;
                break;
             }
          }
@@ -1472,7 +1472,7 @@ Int_t TEntryList::Relocate(const char *fn,
    // Read the lists
    TString nm(enlnm);
    if (nm.IsNull()) nm = "*";
-   TRegexp nmrg(nm, kTRUE);
+   TRegexp nmrg(nm, true);
    TIter nxk(fl->GetListOfKeys());
    TKey *key = nullptr;
    while ((key = (TKey *) nxk())) {
@@ -1523,7 +1523,7 @@ static Int_t GetCommonString(TString a, TString b, TString &c)
       c = "";
       return 2;
    }
-   Bool_t ashort = (a.Length() > b.Length()) ? kFALSE : kTRUE;
+   bool ashort = (a.Length() > b.Length()) ? false : true;
    Ssiz_t len = (ashort) ? a.Length() : b.Length();
    Int_t lcom = 0;
    for (Int_t i = 0; i < len; i++) {
@@ -1544,7 +1544,7 @@ static Int_t GetCommonString(TString a, TString b, TString &c)
 /// the found roots to the list as TObjStrings.
 /// Return the number of roots found.
 
-Int_t TEntryList::ScanPaths(TList *roots, Bool_t notify)
+Int_t TEntryList::ScanPaths(TList *roots, bool notify)
 {
    TList *xrl = roots ? roots : new TList;
 
@@ -1554,10 +1554,10 @@ Int_t TEntryList::ScanPaths(TList *roots, Bool_t notify)
       TIter nxl(fLists);
       TEntryList *enl = nullptr;
       while ((enl = (TEntryList *) nxl()))
-         nrl += enl->ScanPaths(xrl, kFALSE);
+         nrl += enl->ScanPaths(xrl, false);
    }
    // Apply to ourselves
-   Bool_t newobjs = kTRUE;
+   bool newobjs = true;
    TString path = gSystem->GetDirName(fFileName), com;
    TObjString *objs = nullptr;
    TIter nxr(xrl);
@@ -1567,7 +1567,7 @@ Int_t TEntryList::ScanPaths(TList *roots, Bool_t notify)
          TUrl ucom(com);
          if (strlen(ucom.GetFile()) > 0 && strcmp(ucom.GetFile(), "/")) {
             objs->SetString(com.Data());
-            newobjs = kFALSE;
+            newobjs = false;
             break;
          }
       }
@@ -1588,7 +1588,7 @@ Int_t TEntryList::ScanPaths(TList *roots, Bool_t notify)
    }
 
    if (xrl != roots) {
-      xrl->SetOwner(kTRUE);
+      xrl->SetOwner(true);
       SafeDelete(xrl);
    }
 

--- a/tree/tree/src/TEntryListArray.cxx
+++ b/tree/tree/src/TEntryListArray.cxx
@@ -336,14 +336,14 @@ void TEntryListArray::ConvertToTEntryListArray(TEntryList *e)
 /// - When tree is a chain, the entry is assumed to be global index and the local
 /// entry is recomputed from the treeoffset information of the chain
 
-Bool_t TEntryListArray::Enter(Long64_t entry, TTree *tree, Long64_t subentry)
+bool TEntryListArray::Enter(Long64_t entry, TTree *tree, Long64_t subentry)
 {
    //When subentry = -1, add all subentries (remove the sublist if it exists)
    //When subentry != -1 and the entry is not present,
    //add only the given subentry, creating a TEntryListArray to hold the subentries for the given entry
    //Return true only if the entry is new (not the subentry)
 
-   Bool_t result = false;
+   bool result = false;
 
    if (tree) {
       Long64_t localentry = tree->LoadTree(entry);
@@ -382,9 +382,9 @@ Bool_t TEntryListArray::Enter(Long64_t entry, TTree *tree, Long64_t subentry)
    return result;
 }
 
-Bool_t TEntryListArray::Enter(Long64_t localentry, const char *treename, const char *filename, Long64_t subentry)
+bool TEntryListArray::Enter(Long64_t localentry, const char *treename, const char *filename, Long64_t subentry)
 {
-   Bool_t result = false;
+   bool result = false;
    SetTree(treename, filename);
    TEntryListArray *currentArray = dynamic_cast<TEntryListArray *>(fCurrent);
    if (currentArray) {
@@ -454,7 +454,7 @@ void TEntryListArray::Print(const Option_t* option) const
 {
    TString opt = option;
    opt.ToUpper();
-   Bool_t new_line = !opt.Contains("EOL");
+   bool new_line = !opt.Contains("EOL");
 
    if (!opt.Contains("S") && new_line) {
       TEntryList::Print(option);
@@ -500,9 +500,9 @@ void TEntryListArray::Print(const Option_t* option) const
 ///
 /// If subentry != -1, only the given subentry is removed
 
-Bool_t TEntryListArray::Remove(Long64_t entry, TTree *tree, Long64_t subentry)
+bool TEntryListArray::Remove(Long64_t entry, TTree *tree, Long64_t subentry)
 {
-   Bool_t result = kFALSE;
+   bool result = false;
 
    if (tree) {
       Long64_t localentry = tree->LoadTree(entry);
@@ -537,15 +537,15 @@ Bool_t TEntryListArray::Remove(Long64_t entry, TTree *tree, Long64_t subentry)
    } else if (subentry == -1) {
       return TEntryList::Remove(entry);
    }
-   return kFALSE;
+   return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Remove the given sublist and return true if succeeded
 
-Bool_t TEntryListArray::RemoveSubList(TEntryListArray *e, TTree *tree)
+bool TEntryListArray::RemoveSubList(TEntryListArray *e, TTree *tree)
 {
-   if (!e) return kFALSE;
+   if (!e) return false;
    if (tree) {
       SetTree(tree->GetTree());
       TEntryListArray *currentArray = dynamic_cast<TEntryListArray*>(fCurrent);
@@ -555,7 +555,7 @@ Bool_t TEntryListArray::RemoveSubList(TEntryListArray *e, TTree *tree)
    }
 
    if (!fSubLists || !fSubLists->Remove(e)) {
-      return kFALSE;
+      return false;
    }
    // fSubLists->Sort(); --> for TObjArray
    delete e;
@@ -563,13 +563,13 @@ Bool_t TEntryListArray::RemoveSubList(TEntryListArray *e, TTree *tree)
       delete fSubLists;
       fSubLists = nullptr;
    }
-   return kTRUE;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Remove the sublists for the given entry --> not being used...
 
-Bool_t TEntryListArray::RemoveSubListForEntry(Long64_t entry, TTree *tree)
+bool TEntryListArray::RemoveSubListForEntry(Long64_t entry, TTree *tree)
 {
    if (tree) {
       Long64_t localentry = tree->LoadTree(entry);

--- a/tree/tree/src/TEntryListBlock.cxx
+++ b/tree/tree/src/TEntryListBlock.cxx
@@ -125,7 +125,7 @@ TEntryListBlock &TEntryListBlock::operator=(const TEntryListBlock &eblock)
 /// are stored as a list and not as bits, trying to enter a new entry
 /// will make the block switch to bits representation
 
-Bool_t TEntryListBlock::Enter(Int_t entry)
+bool TEntryListBlock::Enter(Int_t entry)
 {
    if (entry > kBlockSize*16) {
       Error("Enter", "illegal entry value!");
@@ -163,7 +163,7 @@ Bool_t TEntryListBlock::Enter(Int_t entry)
 /// are stored as a list and not as bits, trying to remove a new entry
 /// will make the block switch to bits representation
 
-Bool_t TEntryListBlock::Remove(Int_t entry)
+bool TEntryListBlock::Remove(Int_t entry)
 {
    if (entry > kBlockSize*16) {
       Error("Remove", "Illegal entry value!\n");
@@ -203,7 +203,7 @@ Int_t TEntryListBlock::Contains(Int_t entry)
       //bits
       Int_t i = entry>>4;
       Int_t j = entry & 15;
-      Bool_t result = (fIndices[i] & (1<<j))!=0;
+      bool result = (fIndices[i] & (1<<j))!=0;
       return result;
    }
    //list
@@ -212,24 +212,24 @@ Int_t TEntryListBlock::Contains(Int_t entry)
       for (Int_t i = fCurrent; i<fNPassed; i++){
          if (fIndices[i]==entry){
             fCurrent = i;
-            return kTRUE;
+            return true;
          }
       }
    } else {
       if (!fIndices || fNPassed==0){
          //all entries pass
-         return kTRUE;
+         return true;
       }
       if (entry > fIndices[fNPassed-1])
-         return kTRUE;
+         return true;
       for (Int_t i= fCurrent; i<fNPassed; i++){
          if (fIndices[i]==entry){
             fCurrent = i;
-            return kFALSE;
+            return false;
          }
          if (fIndices[i]>entry){
             fCurrent = i;
-            return kTRUE;
+            return true;
          }
       }
    }
@@ -459,7 +459,7 @@ Int_t TEntryListBlock::Next()
       fLastIndexReturned++;
       i = fLastIndexReturned>>4;
       j = fLastIndexReturned & 15;
-      Bool_t result=(fIndices[i] & (1<<j))!=0;
+      bool result=(fIndices[i] & (1<<j))!=0;
       while (!result) {
          if (j==15) {j=0; i++;}
          else j++;
@@ -506,7 +506,7 @@ void TEntryListBlock::PrintWithShift(Int_t shift) const
    Int_t i;
    if (fType==0){
       Int_t ibit, ibite;
-      Bool_t result;
+      bool result;
       for (i=0; i<kBlockSize*16; i++){
          ibite = i>>4;
          ibit = i & 15;
@@ -561,7 +561,7 @@ void TEntryListBlock::OptimizeStorage()
 /// - dir=0 - transform from bits to a list
 /// - dir=1 - tranform from a list to bits
 
-void TEntryListBlock::Transform(Bool_t dir, UShort_t *indexnew)
+void TEntryListBlock::Transform(bool dir, UShort_t *indexnew)
 {
    Int_t i=0;
    Int_t ilist = 0;
@@ -570,7 +570,7 @@ void TEntryListBlock::Transform(Bool_t dir, UShort_t *indexnew)
          for (i=0; i<kBlockSize*16; i++){
             ibite = i >> 4;
             ibit = i & 15;
-            Bool_t result = (fIndices[ibite] & (1<<ibit))!=0;
+            bool result = (fIndices[ibite] & (1<<ibit))!=0;
             if (result && fPassing){
                //fill with the entries that pass
                indexnew[ilist] = i;

--- a/tree/tree/src/TEventList.cxx
+++ b/tree/tree/src/TEventList.cxx
@@ -65,7 +65,7 @@ TEventList::TEventList(): TNamed()
    fDelta      = 100;
    fList       = nullptr;
    fDirectory  = nullptr;
-   fReapply    = kFALSE;
+   fReapply    = false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -74,7 +74,7 @@ TEventList::TEventList(): TNamed()
 /// This Eventlist is added to the list of objects in current directory.
 
 TEventList::TEventList(const char *name, const char *title, Int_t initsize, Int_t delta)
-  :TNamed(name,title), fReapply(kFALSE)
+  :TNamed(name,title), fReapply(false)
 {
    fN = 0;
    if (initsize > 100) fSize  = initsize;
@@ -162,22 +162,22 @@ void TEventList::Add(const TEventList *alist)
 ////////////////////////////////////////////////////////////////////////////////
 /// Return TRUE if list contains entry.
 
-Bool_t TEventList::Contains(Long64_t entry)
+bool TEventList::Contains(Long64_t entry)
 {
-   if (GetIndex(entry) < 0) return kFALSE;
-   return kTRUE;
+   if (GetIndex(entry) < 0) return false;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return TRUE if list contains entries from entrymin to entrymax included.
 
-Bool_t TEventList::ContainsRange(Long64_t entrymin, Long64_t entrymax)
+bool TEventList::ContainsRange(Long64_t entrymin, Long64_t entrymax)
 {
    Long64_t imax = TMath::BinarySearch(fN,fList,entrymax);
    //printf("ContainsRange: entrymin=%lld, entrymax=%lld,imax=%lld, fList[imax]=%lld\n",entrymin,entrymax,imax,fList[imax]);
 
-   if (fList[imax] < entrymin) return kFALSE;
-   return kTRUE;
+   if (fList[imax] < entrymin) return false;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/tree/src/TFriendElement.cxx
+++ b/tree/tree/src/TFriendElement.cxx
@@ -39,7 +39,7 @@ TFriendElement::TFriendElement() : TNamed()
 {
    fFile       = nullptr;
    fTree       = nullptr;
-   fOwnFile    = kFALSE;
+   fOwnFile    = false;
    fParentTree = nullptr;
 }
 
@@ -54,7 +54,7 @@ TFriendElement::TFriendElement(TTree *tree, const char *treename, const char *fi
 {
    fFile       = nullptr;
    fTree       = nullptr;
-   fOwnFile    = kTRUE;
+   fOwnFile    = true;
    fParentTree = tree;
    fTreeName   = treename;
    if (treename && strchr(treename,'=')) {
@@ -82,7 +82,7 @@ TFriendElement::TFriendElement(TTree *tree, const char *treename, TFile *file)
 {
    fFile       = file;
    fTree       = nullptr;
-   fOwnFile    = kFALSE;
+   fOwnFile    = false;
    fParentTree = tree;
    fTreeName   = treename;
    if (fParentTree && fParentTree->GetDirectory()
@@ -120,7 +120,7 @@ TFriendElement::TFriendElement(TTree *tree, TTree* friendtree, const char *alias
    fTree       = friendtree;
    fTreeName   = "";
    fFile       = nullptr;
-   fOwnFile    = kFALSE;
+   fOwnFile    = false;
    fParentTree = tree;
    if (fTree) {
       fTreeName   = fTree->GetName();
@@ -189,12 +189,12 @@ TFile *TFriendElement::GetFile()
    if (strlen(GetTitle())) {
       TDirectory::TContext ctxt;
       fFile = TFile::Open(GetTitle());
-      fOwnFile = kTRUE;
+      fOwnFile = true;
    } else {
       TDirectory *dir = fParentTree->GetDirectory();
       if (dir) {
          fFile = dir->GetFile();
-         fOwnFile = kFALSE;
+         fOwnFile = false;
       }
    }
    if (fFile && fFile->IsZombie()) {

--- a/tree/tree/src/TIOFeatures.cxx
+++ b/tree/tree/src/TIOFeatures.cxx
@@ -120,8 +120,8 @@ static std::string GetUnsupportedName(TBasket::EUnsupportedIOBits enum_flag)
 /// Sets a feature in the `TIOFeatures` object; emits an Error message if
 /// the IO feature is not supported by this version of ROOT.
 ///
-/// If the feature is supported by ROOT, this function returns kTRUE; otherwise,
-/// it returns kFALSE.
+/// If the feature is supported by ROOT, this function returns true; otherwise,
+/// it returns false.
 bool TIOFeatures::Set(Experimental::EIOFeatures input_bits)
 {
    return Set(static_cast<EIOFeatures>(input_bits));
@@ -134,8 +134,8 @@ bool TIOFeatures::Set(Experimental::EIOFeatures input_bits)
 /// Sets a feature in the `TIOFeatures` object; emits an Error message if
 /// the IO feature is not supported by this version of ROOT.
 ///
-/// If the feature is supported by ROOT, this function returns kTRUE; otherwise,
-/// it returns kFALSE.
+/// If the feature is supported by ROOT, this function returns true; otherwise,
+/// it returns false.
 bool TIOFeatures::Set(EIOFeatures input_bits)
 {
    TBasket::EIOBits enum_bits = static_cast<TBasket::EIOBits>(input_bits);
@@ -149,10 +149,10 @@ bool TIOFeatures::Set(EIOFeatures input_bits)
          Error("SetFeature", "An unknown feature was requested (flag=%s); cannot enable it.",
                std::bitset<32>(unsupported).to_string().c_str());
       }
-      return kFALSE;
+      return false;
    }
    fIOBits |= bits;
-   return kTRUE;
+   return true;
 }
 
 
@@ -167,19 +167,19 @@ bool TIOFeatures::Set(EIOFeatures input_bits)
 /// use the type-safe `Set` version instead.  This has been added for better
 /// CLI interfaces.
 ///
-/// Returns kTRUE only if a new feature was set; otherwise emits an error message
-/// and returns kFALSE.
+/// Returns true only if a new feature was set; otherwise emits an error message
+/// and returns false.
 bool TIOFeatures::Set(const std::string &value)
 {
    TClass *cl = TBasket::Class();
    if (cl == nullptr) {
       Error("Set", "Could not retrieve TBasket's class");
-      return kFALSE;
+      return false;
    }
    TEnum *eIOBits = static_cast<TEnum*>(cl->GetListOfEnums()->FindObject("EIOBits"));
    if (eIOBits == nullptr) {
       Error("Set", "Could not locate TBasket::EIOBits enum");
-      return kFALSE;
+      return false;
    }
    for (auto constant : ROOT::Detail::TRangeStaticCast<TEnumConstant>(eIOBits->GetConstants())) {
       if (!strcmp(constant->GetName(), value.c_str())) {
@@ -187,7 +187,7 @@ bool TIOFeatures::Set(const std::string &value)
       }
    }
    Error("Set", "Could not locate %s in TBasket::EIOBits", value.c_str());
-   return kFALSE;
+   return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////
@@ -223,7 +223,7 @@ void TIOFeatures::Print() const
 /// \brief Test to see if a given feature is set
 /// \param[in] input_bits The specific feature to test.
 ///
-/// Returns kTRUE if the feature is enables in this object and supported by
+/// Returns true if the feature is enables in this object and supported by
 /// this version of ROOT.
 bool TIOFeatures::Test(Experimental::EIOFeatures input_bits) const
 {
@@ -234,7 +234,7 @@ bool TIOFeatures::Test(Experimental::EIOFeatures input_bits) const
 /// \brief Test to see if a given feature is set
 /// \param[in] input_bits The specific feature to test.
 ///
-/// Returns kTRUE if the feature is enables in this object and supported by
+/// Returns true if the feature is enables in this object and supported by
 /// this version of ROOT.
 bool TIOFeatures::Test(EIOFeatures input_bits) const
 {
@@ -242,7 +242,7 @@ bool TIOFeatures::Test(EIOFeatures input_bits) const
    auto bits = static_cast<UChar_t>(enum_bits);
    if (R__unlikely((bits & static_cast<UChar_t>(TBasket::EIOBits::kSupported)) != bits)) {
       Error("TestFeature", "A feature is being tested for that is not supported or known.");
-      return kFALSE;
+      return false;
    }
    return (fIOBits & bits) == bits;
 }

--- a/tree/tree/src/TLeaf.cxx
+++ b/tree/tree/src/TLeaf.cxx
@@ -58,8 +58,8 @@ TLeaf::TLeaf()
    , fLen(0)
    , fLenType(0)
    , fOffset(0)
-   , fIsRange(kFALSE)
-   , fIsUnsigned(kFALSE)
+   , fIsRange(false)
+   , fIsUnsigned(false)
    , fLeafCount(nullptr)
    , fBranch(nullptr)
    , fLeafCountValues(nullptr)
@@ -77,8 +77,8 @@ TLeaf::TLeaf(TBranch *parent, const char* name, const char *)
    , fLen(0)
    , fLenType(4)
    , fOffset(0)
-   , fIsRange(kFALSE)
-   , fIsUnsigned(kFALSE)
+   , fIsRange(false)
+   , fIsUnsigned(false)
    , fLeafCount(nullptr)
    , fBranch(parent)
    , fLeafCountValues(nullptr)
@@ -426,14 +426,14 @@ Int_t TLeaf::GetLen() const
 /// and a decision is made whether or not we own the
 /// new value buffer.
 
-Int_t TLeaf::ResetAddress(void* addr, Bool_t calledFromDestructor)
+Int_t TLeaf::ResetAddress(void* addr, bool calledFromDestructor)
 {
    // The kNewValue bit records whether or not we own
    // the current value buffer or not.  If we own it,
    // then we are responsible for deleting it.
-   Bool_t deleteValue = kFALSE;
+   bool deleteValue = false;
    if (TestBit(kNewValue)) {
-      deleteValue = kTRUE;
+      deleteValue = true;
    }
    // If we are not being called from a destructor,
    // recalculate the value buffer size and decide

--- a/tree/tree/src/TLeafB.cxx
+++ b/tree/tree/src/TLeafB.cxx
@@ -54,7 +54,7 @@ TLeafB::TLeafB(TBranch *parent, const char* name, const char* type)
 
 TLeafB::~TLeafB()
 {
-   if (ResetAddress(nullptr, kTRUE)) {
+   if (ResetAddress(nullptr, true)) {
       delete[] fValue;
       fValue = nullptr;
    }
@@ -109,16 +109,16 @@ const char *TLeafB::GetTypeName() const
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy/set fMinimum and fMaximum to include/be wide than those of the parameter
 
-Bool_t TLeafB::IncludeRange(TLeaf *input)
+bool TLeafB::IncludeRange(TLeaf *input)
 {
     if (input) {
         if (input->GetMaximum() > this->GetMaximum())
             this->SetMaximum( input->GetMaximum() );
         if (input->GetMinimum() < this->GetMinimum())
             this->SetMinimum( input->GetMinimum() );
-        return kTRUE;
+        return true;
     } else {
-        return kFALSE;
+        return false;
     }
 }
 

--- a/tree/tree/src/TLeafC.cxx
+++ b/tree/tree/src/TLeafC.cxx
@@ -57,7 +57,7 @@ TLeafC::TLeafC(TBranch *parent, const char *name, const char *type)
 
 TLeafC::~TLeafC()
 {
-   if (ResetAddress(nullptr,kTRUE)) delete [] fValue;
+   if (ResetAddress(nullptr,true)) delete [] fValue;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -96,16 +96,16 @@ const char *TLeafC::GetTypeName() const
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy/set fMinimum and fMaximum to include/be wide than those of the parameter
 
-Bool_t TLeafC::IncludeRange(TLeaf *input)
+bool TLeafC::IncludeRange(TLeaf *input)
 {
     if (input) {
         if (input->GetMaximum() > this->GetMaximum())
             this->SetMaximum( input->GetMaximum() );
         if (input->GetMinimum() < this->GetMinimum())
             this->SetMinimum( input->GetMinimum() );
-        return kTRUE;
+        return true;
     } else {
-        return kFALSE;
+        return false;
     }
 }
 

--- a/tree/tree/src/TLeafD.cxx
+++ b/tree/tree/src/TLeafD.cxx
@@ -53,7 +53,7 @@ TLeafD::TLeafD(TBranch *parent, const char *name, const char *type)
 
 TLeafD::~TLeafD()
 {
-   if (ResetAddress(nullptr,kTRUE)) delete [] fValue;
+   if (ResetAddress(nullptr,true)) delete [] fValue;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/tree/src/TLeafD32.cxx
+++ b/tree/tree/src/TLeafD32.cxx
@@ -59,7 +59,7 @@ TLeafD32::TLeafD32(TBranch *parent, const char *name, const char *type) : TLeaf(
 
 TLeafD32::~TLeafD32()
 {
-   if (ResetAddress(nullptr, kTRUE))
+   if (ResetAddress(nullptr, true))
       delete[] fValue;
 
    if (fElement)

--- a/tree/tree/src/TLeafElement.cxx
+++ b/tree/tree/src/TLeafElement.cxx
@@ -141,7 +141,7 @@ TLeafElement::GetDeserializeType() const
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Deserialize N events from an input buffer.
-Bool_t TLeafElement::ReadBasketFast(TBuffer &input_buf, Long64_t N)
+bool TLeafElement::ReadBasketFast(TBuffer &input_buf, Long64_t N)
 {
    if (R__unlikely(fDeserializeTypeCache.load(std::memory_order_relaxed) == DeserializeType::kInvalid))
       GetDeserializeType(); // Set fDataTypeCache if need be.
@@ -177,22 +177,22 @@ TString TLeafElement::GetFullName() const
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy/set fMinimum and fMaximum to include/be wide than those of the parameter
 
-Bool_t TLeafElement::IncludeRange(TLeaf *input)
+bool TLeafElement::IncludeRange(TLeaf *input)
 {
     if (input) {
         if (input->GetMaximum() > this->GetMaximum())
             ((TBranchElement*)fBranch)->fMaximum = input->GetMaximum();
-        return kTRUE;
+        return true;
     } else {
-        return kFALSE;
+        return false;
     }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return true if this leaf is does not have any sub-branch/leaf.
 
-Bool_t TLeafElement::IsOnTerminalBranch() const
+bool TLeafElement::IsOnTerminalBranch() const
 {
-   if (fBranch->GetListOfBranches()->GetEntriesFast()) return kFALSE;
-   return kTRUE;
+   if (fBranch->GetListOfBranches()->GetEntriesFast()) return false;
+   return true;
 }

--- a/tree/tree/src/TLeafF.cxx
+++ b/tree/tree/src/TLeafF.cxx
@@ -53,7 +53,7 @@ TLeafF::TLeafF(TBranch *parent, const char *name, const char *type)
 
 TLeafF::~TLeafF()
 {
-   if (ResetAddress(nullptr,kTRUE)) delete [] fValue;
+   if (ResetAddress(nullptr,true)) delete [] fValue;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/tree/src/TLeafF16.cxx
+++ b/tree/tree/src/TLeafF16.cxx
@@ -59,7 +59,7 @@ TLeafF16::TLeafF16(TBranch *parent, const char *name, const char *type) : TLeaf(
 
 TLeafF16::~TLeafF16()
 {
-   if (ResetAddress(nullptr, kTRUE))
+   if (ResetAddress(nullptr, true))
       delete[] fValue;
 
    if (fElement)

--- a/tree/tree/src/TLeafG.cxx
+++ b/tree/tree/src/TLeafG.cxx
@@ -53,7 +53,7 @@ TLeafG::TLeafG(TBranch *parent, const char *name, const char *type)
 
 TLeafG::~TLeafG()
 {
-   if (ResetAddress(nullptr,kTRUE)) delete [] fValue;
+   if (ResetAddress(nullptr,true)) delete [] fValue;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -124,16 +124,16 @@ LongDouble_t TLeafG::GetValueLongDouble(Int_t i) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy/set fMinimum and fMaximum to include/be wide than those of the parameter
 
-Bool_t TLeafG::IncludeRange(TLeaf *input)
+bool TLeafG::IncludeRange(TLeaf *input)
 {
     if (input) {
         if (input->GetMaximum() > this->GetMaximum())
             this->SetMaximum( input->GetMaximum() );
         if (input->GetMinimum() < this->GetMinimum())
             this->SetMinimum( input->GetMinimum() );
-        return kTRUE;
+        return true;
     } else {
-        return kFALSE;
+        return false;
     }
 }
 

--- a/tree/tree/src/TLeafI.cxx
+++ b/tree/tree/src/TLeafI.cxx
@@ -53,7 +53,7 @@ TLeafI::TLeafI(TBranch *parent, const char *name, const char *type)
 
 TLeafI::~TLeafI()
 {
-   if (ResetAddress(nullptr,kTRUE)) delete [] fValue;
+   if (ResetAddress(nullptr,true)) delete [] fValue;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -113,16 +113,16 @@ Double_t TLeafI::GetValue(Int_t i) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy/set fMinimum and fMaximum to include/be wide than those of the parameter
 
-Bool_t TLeafI::IncludeRange(TLeaf *input)
+bool TLeafI::IncludeRange(TLeaf *input)
 {
     if (input) {
         if (input->GetMaximum() > this->GetMaximum())
             this->SetMaximum( input->GetMaximum() );
         if (input->GetMinimum() < this->GetMinimum())
             this->SetMinimum( input->GetMinimum() );
-        return kTRUE;
+        return true;
     } else {
-        return kFALSE;
+        return false;
     }
 }
 

--- a/tree/tree/src/TLeafL.cxx
+++ b/tree/tree/src/TLeafL.cxx
@@ -53,7 +53,7 @@ TLeafL::TLeafL(TBranch *parent, const char *name, const char *type)
 
 TLeafL::~TLeafL()
 {
-   if (ResetAddress(nullptr,kTRUE)) delete [] fValue;
+   if (ResetAddress(nullptr,true)) delete [] fValue;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -124,16 +124,16 @@ LongDouble_t TLeafL::GetValueLongDouble(Int_t i) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy/set fMinimum and fMaximum to include/be wide than those of the parameter
 
-Bool_t TLeafL::IncludeRange(TLeaf *input)
+bool TLeafL::IncludeRange(TLeaf *input)
 {
     if (input) {
         if (input->GetMaximum() > this->GetMaximum())
             this->SetMaximum( input->GetMaximum() );
         if (input->GetMinimum() < this->GetMinimum())
             this->SetMinimum( input->GetMinimum() );
-        return kTRUE;
+        return true;
     } else {
-        return kFALSE;
+        return false;
     }
 }
 

--- a/tree/tree/src/TLeafO.cxx
+++ b/tree/tree/src/TLeafO.cxx
@@ -32,7 +32,7 @@ TLeafO::TLeafO(): TLeaf()
    fPointer = nullptr;
    fMinimum = false;
    fMaximum = false;
-   fLenType = sizeof(Bool_t);
+   fLenType = sizeof(bool);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -41,7 +41,7 @@ TLeafO::TLeafO(): TLeaf()
 TLeafO::TLeafO(TBranch *parent, const char *name, const char *type)
    : TLeaf(parent,name,type)
 {
-   fLenType = sizeof(Bool_t);
+   fLenType = sizeof(bool);
    fMinimum = false;
    fMaximum = false;
    fValue   = nullptr;
@@ -53,7 +53,7 @@ TLeafO::TLeafO(TBranch *parent, const char *name, const char *type)
 
 TLeafO::~TLeafO()
 {
-   if (ResetAddress(nullptr,kTRUE)) delete [] fValue;
+   if (ResetAddress(nullptr,true)) delete [] fValue;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -92,16 +92,16 @@ const char *TLeafO::GetTypeName() const
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy/set fMinimum and fMaximum to include/be wide than those of the parameter
 
-Bool_t TLeafO::IncludeRange(TLeaf *input)
+bool TLeafO::IncludeRange(TLeaf *input)
 {
     if (input) {
         if (input->GetMaximum() > this->GetMaximum())
             this->SetMaximum( input->GetMaximum() );
         if (input->GetMinimum() < this->GetMinimum())
             this->SetMinimum( input->GetMinimum() );
-        return kTRUE;
+        return true;
     } else {
-        return kFALSE;
+        return false;
     }
 }
 
@@ -186,21 +186,21 @@ void TLeafO::SetAddress(void *add)
    }
    if (add) {
       if (TestBit(kIndirectAddress)) {
-         fPointer = (Bool_t**) add;
+         fPointer = (bool**) add;
          Int_t ncountmax = fLen;
          if (fLeafCount) ncountmax = fLen*(fLeafCount->GetMaximum() + 1);
          if ((fLeafCount && ncountmax > Int_t(fLeafCount->GetValue())) ||
              ncountmax > fNdata || *fPointer == nullptr) {
             if (*fPointer) delete [] *fPointer;
             if (ncountmax > fNdata) fNdata = ncountmax;
-            *fPointer = new Bool_t[fNdata];
+            *fPointer = new bool[fNdata];
          }
          fValue = *fPointer;
       } else {
-         fValue = (Bool_t*)add;
+         fValue = (bool*)add;
       }
    } else {
-      fValue = new Bool_t[fNdata];
+      fValue = new bool[fNdata];
       fValue[0] = false;
    }
 }

--- a/tree/tree/src/TLeafObject.cxx
+++ b/tree/tree/src/TLeafObject.cxx
@@ -31,7 +31,7 @@ TLeafObject::TLeafObject(): TLeaf()
 {
    fClass      = nullptr;
    fObjAddress = nullptr;
-   fVirtual    = kTRUE;
+   fVirtual    = true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -43,7 +43,7 @@ TLeafObject::TLeafObject(TBranch *parent, const char *name, const char *type)
    SetTitle(type);
    fClass      = TClass::GetClass(type);
    fObjAddress = nullptr;
-   fVirtual    = kTRUE;
+   fVirtual    = true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -116,10 +116,10 @@ const char *TLeafObject::GetTypeName() const
 ////////////////////////////////////////////////////////////////////////////////
 /// This method must be overridden to handle object notification.
 
-Bool_t TLeafObject::Notify()
+bool TLeafObject::Notify()
 {
    fClass      = TClass::GetClass(GetTitle());
-   return kFALSE;
+   return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -196,7 +196,7 @@ void TLeafObject::Streamer(TBuffer &b)
       Version_t R__v = b.ReadVersion(&R__s, &R__c);
       if (R__v > 3 || R__v == 2) {
          b.ReadClassBuffer(TLeafObject::Class(), this, R__v, R__s, R__c);
-         if (R__v == 2) fVirtual = kTRUE;
+         if (R__v == 2) fVirtual = true;
          fObjAddress = nullptr;
          fClass  = TClass::GetClass(fTitle.Data());
          if (!fClass) Warning("Streamer","Cannot find class:%s",fTitle.Data());
@@ -212,8 +212,8 @@ void TLeafObject::Streamer(TBuffer &b)
       fObjAddress = nullptr;
       fClass  = TClass::GetClass(fTitle.Data());
       if (!fClass) Warning("Streamer","Cannot find class:%s",fTitle.Data());
-      if (R__v  < 1) fVirtual = kFALSE;
-      if (R__v == 1) fVirtual = kTRUE;
+      if (R__v  < 1) fVirtual = false;
+      if (R__v == 1) fVirtual = true;
       if (R__v == 3) b >> fVirtual;
       // We should rewarn in this process.
       ResetBit(kOldWarn);
@@ -227,8 +227,8 @@ void TLeafObject::Streamer(TBuffer &b)
 ////////////////////////////////////////////////////////////////////////////////
 /// Return true if this leaf is does not have any sub-branch/leaf.
 
-Bool_t TLeafObject::IsOnTerminalBranch() const
+bool TLeafObject::IsOnTerminalBranch() const
 {
-   if (fBranch->GetListOfBranches()->GetEntriesFast()) return kFALSE;
-   return kTRUE;
+   if (fBranch->GetListOfBranches()->GetEntriesFast()) return false;
+   return true;
 }

--- a/tree/tree/src/TLeafS.cxx
+++ b/tree/tree/src/TLeafS.cxx
@@ -53,7 +53,7 @@ TLeafS::TLeafS(TBranch *parent, const char *name, const char *type)
 
 TLeafS::~TLeafS()
 {
-   if (ResetAddress(nullptr,kTRUE)) delete [] fValue;
+   if (ResetAddress(nullptr,true)) delete [] fValue;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -109,16 +109,16 @@ Double_t TLeafS::GetValue(Int_t i) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy/set fMinimum and fMaximum to include/be wide than those of the parameter
 
-Bool_t TLeafS::IncludeRange(TLeaf *input)
+bool TLeafS::IncludeRange(TLeaf *input)
 {
     if (input) {
         if (input->GetMaximum() > this->GetMaximum())
             this->SetMaximum( input->GetMaximum() );
         if (input->GetMinimum() < this->GetMinimum())
             this->SetMinimum( input->GetMinimum() );
-        return kTRUE;
+        return true;
     } else {
-        return kFALSE;
+        return false;
     }
 }
 

--- a/tree/tree/src/TQueryResult.cxx
+++ b/tree/tree/src/TQueryResult.cxx
@@ -39,7 +39,7 @@ TQueryResult::TQueryResult(Int_t seqnum, const char *opt, TList *inlist,
              : fSeqNum(seqnum), fStatus(kSubmitted), fUsedCPU(0.), fOptions(opt),
                fEntries(entries), fFirst(first),
                fBytes(0), fParList("-"), fOutputList(nullptr),
-               fFinalized(kFALSE), fArchived(kFALSE), fResultFile("-"),
+               fFinalized(false), fArchived(false), fResultFile("-"),
                fPrepTime(0.), fInitTime(0.), fProcTime(0.), fMergeTime(0.),
                fRecvTime(-1), fTermTime(-1), fNumWrks(-1), fNumMergers(-1)
 {
@@ -63,7 +63,7 @@ TQueryResult::TQueryResult(Int_t seqnum, const char *opt, TList *inlist,
    fLogFile = new TMacro("LogFile");
 
    // Selector files
-   fDraw = selec ? TSelector::IsStandardDraw(selec) : kFALSE;
+   fDraw = selec ? TSelector::IsStandardDraw(selec) : false;
    if (fDraw) {
       // The input list should contain info about the variables and
       // selection cuts: save them into the macro title
@@ -303,7 +303,7 @@ void TQueryResult::AddInput(TObject *obj)
 void TQueryResult::SetArchived(const char *archfile)
 {
    if (IsDone()) {
-      fArchived = kTRUE;
+      fArchived = true;
       if (archfile && (strlen(archfile) > 0))
          fResultFile = archfile;
    }
@@ -326,7 +326,7 @@ void TQueryResult::Print(Option_t *opt) const
    Long64_t last = (fEntries > -1) ? fFirst+fEntries-1 : -1;
 
    // Option
-   Bool_t full = ((strchr(opt,'F') || strchr(opt,'f'))) ? kTRUE : kFALSE;
+   bool full = ((strchr(opt,'F') || strchr(opt,'f'))) ? true : false;
 
    // Query number to be printed
    Int_t qry = fSeqNum;
@@ -428,7 +428,7 @@ void TQueryResult::Browse(TBrowser *b)
 /// or cloned. If adopted, object ownership is transferred to this object.
 /// The internal fInputList will always be owner of its objects.
 
-void TQueryResult::SetInputList(TList *in, Bool_t adopt)
+void TQueryResult::SetInputList(TList *in, bool adopt)
 {
    if (!in || in != fInputList)
       SafeDelete(fInputList);
@@ -442,7 +442,7 @@ void TQueryResult::SetInputList(TList *in, Bool_t adopt)
          TObject *o = nullptr;
          while ((o = nxi()))
             fInputList->Add(o);
-         in->SetOwner(kFALSE);
+         in->SetOwner(false);
       }
       fInputList->SetOwner();
    }
@@ -454,7 +454,7 @@ void TQueryResult::SetInputList(TList *in, Bool_t adopt)
 /// or cloned.  If adopted, object ownership is transferred to this object.
 /// The internal fOutputList will always be owner of its objects.
 
-void TQueryResult::SetOutputList(TList *out, Bool_t adopt)
+void TQueryResult::SetOutputList(TList *out, bool adopt)
 {
    if (!out) {
       SafeDelete(fOutputList);
@@ -478,7 +478,7 @@ void TQueryResult::SetOutputList(TList *out, Bool_t adopt)
          o = nullptr;
          while ((o = nxo()))
             fOutputList->Add(o);
-         out->SetOwner(kFALSE);
+         out->SetOwner(false);
       }
       fOutputList->SetOwner();
    }
@@ -488,25 +488,25 @@ void TQueryResult::SetOutputList(TList *out, Bool_t adopt)
 /// Compare two query result instances for equality.
 /// Session name and query number are compared.
 
-Bool_t operator==(const TQueryResult &qr1, const TQueryResult &qr2)
+bool operator==(const TQueryResult &qr1, const TQueryResult &qr2)
 {
    if (!strcmp(qr1.GetTitle(), qr2.GetTitle()))
       if (qr1.GetSeqNum() == qr2.GetSeqNum())
-         return kTRUE;
-   return kFALSE;
+         return true;
+   return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return TRUE if reference ref matches.
 
-Bool_t TQueryResult::Matches(const char *ref)
+bool TQueryResult::Matches(const char *ref)
 {
    TString lref; lref.Form("%s:%s", GetTitle(), GetName());
 
    if (lref == ref)
-      return kTRUE;
+      return true;
 
-   return kFALSE;
+   return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/tree/src/TSelector.cxx
+++ b/tree/tree/src/TSelector.cxx
@@ -29,25 +29,25 @@ It contains the following main methods:
   entries in the Tree. When using PROOF, Begin() is called on the
   client only.
 
-- Bool_t TSelector::Notify(). This method is called at the first entry
+- bool TSelector::Notify(). This method is called at the first entry
   of a new file in a chain.
 
-- Bool_t TSelector::Process(Long64_t entry). This method is called
+- bool TSelector::Process(Long64_t entry). This method is called
   to process an entry. It is the user's responsibility to read
   the corresponding entry in memory (may be just a partial read).
   Once the entry is in memory one can apply a selection and if the
   entry is selected histograms can be filled. Processing stops
-  when this function returns kFALSE. This function combines the
+  when this function returns false. This function combines the
   next two functions in one, avoiding to have to maintain state
   in the class to communicate between these two functions.
   See WARNING below about entry.
   This method is used by PROOF.
 
-- Bool_t TSelector::ProcessCut(Long64_t entry). This method is called
+- bool TSelector::ProcessCut(Long64_t entry). This method is called
   before processing entry. It is the user's responsibility to read
   the corresponding entry in memory (may be just a partial read).
-  The function returns kTRUE if the entry must be processed,
-  kFALSE otherwise. This method is obsolete, use Process().
+  The function returns true if the entry must be processed,
+  false otherwise. This method is obsolete, use Process().
   See WARNING below about entry.
 
 - void TSelector::ProcessFill(Long64_t entry). This method is called
@@ -143,13 +143,13 @@ TSelector *TSelector::GetSelector(const char *filename)
 {
    // If the filename does not contain "." assume class is compiled in
    TString localname;
-   Bool_t fromFile = kFALSE;
+   bool fromFile = false;
    if (strchr(filename, '.') != nullptr) {
       //Interpret/compile filename via CINT
       localname  = ".L ";
       localname += filename;
       gROOT->ProcessLine(localname);
-      fromFile = kTRUE;
+      fromFile = true;
    }
 
    //loop on all classes known to CINT to find the class on filename
@@ -168,9 +168,9 @@ TSelector *TSelector::GetSelector(const char *filename)
    // this returns 0 (== failure) in the case the class is already in memory
    // but does not have a dictionary, so we just raise a flag for better
    // diagnostic in the case the class is not found in the CINT ClassInfo table.
-   Bool_t autoloaderr = kFALSE;
+   bool autoloaderr = false;
    if (!fromFile && gCling->AutoLoad(localname) != 1)
-      autoloaderr = kTRUE;
+      autoloaderr = true;
 
    TClass *selCl = TClass::GetClass(localname);
    if (selCl) {
@@ -195,12 +195,12 @@ TSelector *TSelector::GetSelector(const char *filename)
 
    } else {
       ClassInfo_t *cl = gCling->ClassInfo_Factory(localname);
-      Bool_t ok = kFALSE;
-      Bool_t nameFound = kFALSE;
+      bool ok = false;
+      bool nameFound = false;
       if (cl && gCling->ClassInfo_IsValid(cl)) {
          if (localname == gCling->ClassInfo_FullName(cl)) {
-            nameFound = kTRUE;
-            if (gCling->ClassInfo_IsBase(cl,"TSelector")) ok = kTRUE;
+            nameFound = true;
+            if (gCling->ClassInfo_IsBase(cl,"TSelector")) ok = true;
          }
       }
       if (!ok) {
@@ -234,24 +234,24 @@ TSelector *TSelector::GetSelector(const char *filename)
 /// Find out if this is a standard selection used for Draw actions
 /// (either TSelectorDraw, TProofDraw or deriving from them).
 
-Bool_t TSelector::IsStandardDraw(const char *selec)
+bool TSelector::IsStandardDraw(const char *selec)
 {
    // Make sure we have a name
    if (!selec) {
       ::Info("TSelector::IsStandardDraw",
              "selector name undefined - do nothing");
-      return kFALSE;
+      return false;
    }
 
-   Bool_t stdselec = kFALSE;
+   bool stdselec = false;
    if (!strchr(selec, '.')) {
       if (strstr(selec, "TSelectorDraw")) {
-         stdselec = kTRUE;
+         stdselec = true;
       } else {
          TClass *cl = TClass::GetClass(selec);
          if (cl && (cl->InheritsFrom("TProofDraw") ||
                     cl->InheritsFrom("TSelectorDraw")))
-            stdselec = kTRUE;
+            stdselec = true;
       }
    }
 
@@ -290,7 +290,7 @@ void TSelector::ImportOutput(TList *output) {
    }
 
    // Cleanup original list
-   output->SetOwner(kFALSE);
+   output->SetOwner(false);
    output->Clear("nodelete");
 
    // Done
@@ -300,8 +300,8 @@ void TSelector::ImportOutput(TList *output) {
 ////////////////////////////////////////////////////////////////////////////////
 ///    This method is called before processing entry. It is the user's responsibility to read
 ///    the corresponding entry in memory (may be just a partial read).
-///    The function returns kTRUE if the entry must be processed,
-///    kFALSE otherwise. This method is obsolete, use Process().
+///    The function returns true if the entry must be processed,
+///    false otherwise. This method is obsolete, use Process().
 ///
 /// WARNING when a selector is used with a TChain:
 ///    in the Process, ProcessCut, ProcessFill function, you must use
@@ -310,10 +310,10 @@ void TSelector::ImportOutput(TList *output) {
 ///    Assuming that fChain is the pointer to the TChain being processed,
 ///    use fChain->GetTree()->GetEntry(entry);
 
-Bool_t TSelector::ProcessCut(Long64_t /*entry*/)
+bool TSelector::ProcessCut(Long64_t /*entry*/)
 {
 
-   return kTRUE;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -357,7 +357,7 @@ void TSelector::ProcessFill(Long64_t /*entry*/)
 ///  Assuming that fChain is the pointer to the TChain being processed,
 ///  use: `fChain->GetTree()->GetEntry(entry)`.
 
-Bool_t TSelector::Process(Long64_t /*entry*/) {
+bool TSelector::Process(Long64_t /*entry*/) {
 
-   return kFALSE;
+   return false;
 }

--- a/tree/tree/src/TSelectorList.cxx
+++ b/tree/tree/src/TSelectorList.cxx
@@ -30,20 +30,20 @@ ClassImp(TSelectorList);
 /// selector list or owned by the list and not by the directory that
 /// was active when they were created. Returns true in case of success.
 
-Bool_t TSelectorList::UnsetDirectory(TObject *obj)
+bool TSelectorList::UnsetDirectory(TObject *obj)
 {
    if (!obj || !obj->IsA())
-      return kFALSE;
+      return false;
 
    TMethodCall callEnv;
    callEnv.InitWithPrototype(obj->IsA(), "SetDirectory", "TDirectory*");
    if (!callEnv.IsValid())
-      return kFALSE;
+      return false;
 
    callEnv.SetParam((Longptr_t) nullptr);
    callEnv.Execute(obj);
 
-   return kTRUE;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -52,23 +52,23 @@ Bool_t TSelectorList::UnsetDirectory(TObject *obj)
 /// look up objects in different output lists by name. Returns true
 /// in case name is unique.
 
-Bool_t TSelectorList::CheckDuplicateName(TObject *obj)
+bool TSelectorList::CheckDuplicateName(TObject *obj)
 {
    if (!obj)
-      return kFALSE;
+      return false;
 
    TObject *org = FindObject(obj->GetName());
    if (org == obj) {
       Error("CheckDuplicateName","object with name: %s already in the list",obj->GetName());
-      return kFALSE;
+      return false;
    }
 
    if (org) {
       Error("CheckDuplicateName","an object with the same name: %s is already in the list",obj->GetName());
-      return kFALSE;
+      return false;
    }
 
-   return kTRUE;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -103,7 +103,7 @@ It is strongly recommended to persistify those as objects rather than lists of l
    - `l` : a 64 bit unsigned integer (`ULong64_t`)
    - `G` : a long signed integer, stored as 64 bit (`Long_t`)
    - `g` : a long unsigned integer, stored as 64 bit (`ULong_t`)
-   - `O` : [the letter `o`, not a zero] a boolean (`Bool_t`)
+   - `O` : [the letter `o`, not a zero] a boolean (`bool`)
 
   Examples:
    - A int: "myVar/I"
@@ -790,9 +790,9 @@ TTree::TTree()
 , fBranchRef(nullptr)
 , fFriendLockStatus(0)
 , fTransientBuffer(nullptr)
-, fCacheDoAutoInit(kTRUE)
-, fCacheDoClusterPrefetch(kFALSE)
-, fCacheUserSet(kFALSE)
+, fCacheDoAutoInit(true)
+, fCacheDoClusterPrefetch(false)
+, fCacheUserSet(false)
 , fIMTEnabled(ROOT::IsImplicitMTEnabled())
 , fNEntriesSinceSorting(0)
 {
@@ -802,7 +802,7 @@ TTree::TTree()
    fMaxEntryLoop = 1000000000;
    fMaxEntryLoop *= 1000;
 
-   fBranches.SetOwner(kTRUE);
+   fBranches.SetOwner(true);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -871,9 +871,9 @@ TTree::TTree(const char* name, const char* title, Int_t splitlevel /* = 99 */,
 , fBranchRef(nullptr)
 , fFriendLockStatus(0)
 , fTransientBuffer(nullptr)
-, fCacheDoAutoInit(kTRUE)
-, fCacheDoClusterPrefetch(kFALSE)
-, fCacheUserSet(kFALSE)
+, fCacheDoAutoInit(true)
+, fCacheDoClusterPrefetch(false)
+, fCacheUserSet(false)
 , fIMTEnabled(ROOT::IsImplicitMTEnabled())
 , fNEntriesSinceSorting(0)
 {
@@ -903,7 +903,7 @@ TTree::TTree(const char* name, const char* title, Int_t splitlevel /* = 99 */,
    //        can with a histogram.
    if (fDirectory) fDirectory->Append(this);
 
-   fBranches.SetOwner(kTRUE);
+   fBranches.SetOwner(true);
 
    // If title starts with "/" and is a valid folder name, a superbranch
    // is created.
@@ -962,7 +962,7 @@ TTree::~TTree()
          // clone->ResetBranchAddresses();
 
          // Reset only the branch we have set the address of.
-         CopyAddresses(clone,kTRUE);
+         CopyAddresses(clone,true);
       }
    }
    // Get rid of our branches, note that this will also release
@@ -1057,7 +1057,7 @@ TBuffer* TTree::GetTransientBuffer(Int_t size)
 /// - 0 branch added or already included
 /// - -1 on error
 
-Int_t TTree::AddBranchToCache(const char*bname, Bool_t subbranches)
+Int_t TTree::AddBranchToCache(const char*bname, bool subbranches)
 {
    if (!GetTree()) {
       if (LoadTree(0)<0) {
@@ -1079,7 +1079,7 @@ Int_t TTree::AddBranchToCache(const char*bname, Bool_t subbranches)
       Error("AddBranchToCache", "No file is available. Branch was not added to the cache");
       return -1;
    }
-   TTreeCache *tc = GetReadCache(f,kTRUE);
+   TTreeCache *tc = GetReadCache(f,true);
    if (!tc) {
       Error("AddBranchToCache", "No cache is available, branch not added");
       return -1;
@@ -1096,7 +1096,7 @@ Int_t TTree::AddBranchToCache(const char*bname, Bool_t subbranches)
 /// - 0 branch added or already included
 /// - -1 on error
 
-Int_t TTree::AddBranchToCache(TBranch *b, Bool_t subbranches)
+Int_t TTree::AddBranchToCache(TBranch *b, bool subbranches)
 {
    if (!GetTree()) {
       if (LoadTree(0)<0) {
@@ -1122,7 +1122,7 @@ Int_t TTree::AddBranchToCache(TBranch *b, Bool_t subbranches)
       Error("AddBranchToCache", "No file is available. Branch was not added to the cache");
       return -1;
    }
-   TTreeCache *tc = GetReadCache(f,kTRUE);
+   TTreeCache *tc = GetReadCache(f,true);
    if (!tc) {
       Error("AddBranchToCache", "No cache is available, branch not added");
       return -1;
@@ -1140,7 +1140,7 @@ Int_t TTree::AddBranchToCache(TBranch *b, Bool_t subbranches)
 /// - 0 branch dropped or not in cache
 /// - -1 on error
 
-Int_t TTree::DropBranchFromCache(const char*bname, Bool_t subbranches)
+Int_t TTree::DropBranchFromCache(const char*bname, bool subbranches)
 {
    if (!GetTree()) {
       if (LoadTree(0)<0) {
@@ -1162,7 +1162,7 @@ Int_t TTree::DropBranchFromCache(const char*bname, Bool_t subbranches)
       Error("DropBranchFromCache", "No file is available. Branch was not dropped from the cache");
       return -1;
    }
-   TTreeCache *tc = GetReadCache(f,kTRUE);
+   TTreeCache *tc = GetReadCache(f,true);
    if (!tc) {
       Error("DropBranchFromCache", "No cache is available, branch not dropped");
       return -1;
@@ -1179,7 +1179,7 @@ Int_t TTree::DropBranchFromCache(const char*bname, Bool_t subbranches)
 /// - 0 branch dropped or not in cache
 /// - -1 on error
 
-Int_t TTree::DropBranchFromCache(TBranch *b, Bool_t subbranches)
+Int_t TTree::DropBranchFromCache(TBranch *b, bool subbranches)
 {
    if (!GetTree()) {
       if (LoadTree(0)<0) {
@@ -1205,7 +1205,7 @@ Int_t TTree::DropBranchFromCache(TBranch *b, Bool_t subbranches)
       Error("DropBranchFromCache", "No file is available. Branch was not dropped from the cache");
       return -1;
    }
-   TTreeCache *tc = GetReadCache(f,kTRUE);
+   TTreeCache *tc = GetReadCache(f,true);
    if (!tc) {
       Error("DropBranchFromCache", "No cache is available, branch not dropped");
       return -1;
@@ -1244,7 +1244,7 @@ bool CheckReshuffling(TTree &mainTree, TTree &friendTree)
    const auto isFriendReshuffled = friendTree.TestBit(TTree::kEntriesReshuffled);
    const auto friendHasValidIndex = [&] {
       auto idx = friendTree.GetTreeIndex();
-      return idx ? idx->IsValidFor(&mainTree) : kFALSE;
+      return idx ? idx->IsValidFor(&mainTree) : false;
    }();
 
    if ((isMainReshuffled || isFriendReshuffled) && !friendHasValidIndex) {
@@ -1395,7 +1395,7 @@ TFriendElement *TTree::AddFriend(const char *treename, TFile *file)
 /// The TTree is managed by the user (e.g., the user must delete the file).
 /// For a complete description see AddFriend(const char *, const char *).
 
-TFriendElement *TTree::AddFriend(TTree *tree, const char *alias, Bool_t warn)
+TFriendElement *TTree::AddFriend(TTree *tree, const char *alias, bool warn)
 {
    if (!tree) {
       return nullptr;
@@ -1686,7 +1686,7 @@ TBranch* TTree::BranchImpRef(const char* branchname, const char *classname, TCla
             actualClass->GetName(), branchname, actualClass->GetName());
       return nullptr;
    }
-   return BronchExec(branchname, actualClass->GetName(), (void*) addobj, kFALSE, bufsize, splitlevel);
+   return BronchExec(branchname, actualClass->GetName(), (void*) addobj, false, bufsize, splitlevel);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1723,7 +1723,7 @@ TBranch* TTree::BranchImpRef(const char* branchname, TClass* ptrClass, EDataType
             actualClass->GetName(), branchname, actualClass->GetName());
       return nullptr;
    }
-   return BronchExec(branchname, actualClass->GetName(), (void*) addobj, kFALSE, bufsize, splitlevel);
+   return BronchExec(branchname, actualClass->GetName(), (void*) addobj, false, bufsize, splitlevel);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1954,7 +1954,7 @@ Int_t TTree::Branch(const char* foldername, Int_t bufsize /* = 32000 */, Int_t s
 ///         - `l` : a 64 bit unsigned integer (`ULong64_t`)
 ///         - `G` : a long signed integer, stored as 64 bit (`Long_t`)
 ///         - `g` : a long unsigned integer, stored as 64 bit (`ULong_t`)
-///         - `O` : [the letter `o`, not a zero] a boolean (`Bool_t`)
+///         - `O` : [the letter `o`, not a zero] a boolean (`bool`)
 ///
 ///      Arrays of values are supported with the following syntax:
 ///         - If leaf name has the form var[nelem], where nelem is alphanumeric, then
@@ -2102,10 +2102,10 @@ TBranch* TTree::BranchOld(const char* name, const char* classname, void* addobj,
    TString branchname;
    char** apointer = (char**) addobj;
    TObject* obj = (TObject*) *apointer;
-   Bool_t delobj = kFALSE;
+   bool delobj = false;
    if (!obj) {
       obj = (TObject*) cl->New();
-      delobj = kTRUE;
+      delobj = true;
    }
    // Build the StreamerInfo if first time for the class.
    BuildStreamerInfo(cl, obj);
@@ -2404,13 +2404,13 @@ TBranch* TTree::BranchRef()
 
 TBranch* TTree::Bronch(const char* name, const char* classname, void* addr, Int_t bufsize /* = 32000 */, Int_t splitlevel /* = 99 */)
 {
-   return BronchExec(name, classname, addr, kTRUE, bufsize, splitlevel);
+   return BronchExec(name, classname, addr, true, bufsize, splitlevel);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Helper function implementing TTree::Bronch and TTree::Branch(const char *name, T &obj);
 
-TBranch* TTree::BronchExec(const char* name, const char* classname, void* addr, Bool_t isptrptr, Int_t bufsize /* = 32000 */, Int_t splitlevel /* = 99 */)
+TBranch* TTree::BronchExec(const char* name, const char* classname, void* addr, bool isptrptr, Int_t bufsize /* = 32000 */, Int_t splitlevel /* = 99 */)
 {
    TClass* cl = TClass::GetClass(classname);
    if (!cl) {
@@ -2449,7 +2449,7 @@ TBranch* TTree::BronchExec(const char* name, const char* classname, void* addr, 
          if (hasCustomStreamer)
             Warning("Bronch", "Using split mode on a class: %s with a custom Streamer", clones->GetClass()->GetName());
       } else {
-         if (hasCustomStreamer) clones->BypassStreamer(kFALSE);
+         if (hasCustomStreamer) clones->BypassStreamer(false);
          TBranchObject *branch = new TBranchObject(this,name,classname,addr,bufsize,0,/*compress=*/ -1,isptrptr);
          fBranches.Add(branch);
          return branch;
@@ -2497,7 +2497,7 @@ TBranch* TTree::BronchExec(const char* name, const char* classname, void* addr, 
       return branch;
    }
 
-   Bool_t hasCustomStreamer = kFALSE;
+   bool hasCustomStreamer = false;
    if (!cl->HasDataMemberInfo() && !cl->GetCollectionProxy()) {
       Error("Bronch", "Cannot find dictionary for class: %s", classname);
       return nullptr;
@@ -2505,7 +2505,7 @@ TBranch* TTree::BronchExec(const char* name, const char* classname, void* addr, 
 
    if (!cl->GetCollectionProxy() && cl->TestBit(TClass::kHasCustomStreamerMember)) {
       // Not an STL container and the linkdef file had a "-" after the class name.
-      hasCustomStreamer = kTRUE;
+      hasCustomStreamer = true;
    }
 
    if (splitlevel < 0 || ((splitlevel == 0) && hasCustomStreamer && cl->IsTObject())) {
@@ -2536,11 +2536,11 @@ TBranch* TTree::BronchExec(const char* name, const char* classname, void* addr, 
    // before returning.
    //
 
-   Bool_t delobj = kFALSE;
+   bool delobj = false;
 
    if (!objptr) {
       objptr = (char*) cl->New();
-      delobj = kTRUE;
+      delobj = true;
    }
 
    //
@@ -2650,7 +2650,7 @@ Int_t TTree::BuildIndex(const char* majorname, const char* minorname /* = "0" */
 /// Build StreamerInfo for class cl.
 /// pointer is an optional argument that may contain a pointer to an object of cl.
 
-TStreamerInfo* TTree::BuildStreamerInfo(TClass* cl, void* pointer /* = 0 */, Bool_t canOptimize /* = kTRUE */ )
+TStreamerInfo* TTree::BuildStreamerInfo(TClass* cl, void* pointer /* = 0 */, bool canOptimize /* = true */ )
 {
    if (!cl) {
       return nullptr;
@@ -2683,18 +2683,18 @@ TStreamerInfo* TTree::BuildStreamerInfo(TClass* cl, void* pointer /* = 0 */, Boo
 ///
 /// Return true if there is a cache attached to the `TTree` (either pre-exisiting
 /// or created as part of this call)
-Bool_t TTree::EnableCache()
+bool TTree::EnableCache()
 {
    TFile* file = GetCurrentFile();
    if (!file)
-      return kFALSE;
+      return false;
    // Check for an existing cache
    TTreeCache* pf = GetReadCache(file);
    if (pf)
-      return kTRUE;
+      return true;
    if (fCacheUserSet && fCacheSize == 0)
-      return kFALSE;
-   return (0 == SetCacheSizeAux(kTRUE, -1));
+      return false;
+   return (0 == SetCacheSizeAux(true, -1));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2865,7 +2865,7 @@ TFile* TTree::ChangeFile(TFile* file)
 /// - kNeedDisableDecomposedObj : in order for the address (type) to be 'usable' the branch needs to not be in Decomposed Object (aka MakeClass) mode.
 /// This bits can be masked out by using kDecomposedObjMask
 
-Int_t TTree::CheckBranchAddressType(TBranch* branch, TClass* ptrClass, EDataType datatype, Bool_t isptr)
+Int_t TTree::CheckBranchAddressType(TBranch* branch, TClass* ptrClass, EDataType datatype, bool isptr)
 {
    if (GetMakeClass()) {
       // If we are in MakeClass mode so we do not really use classes.
@@ -3137,12 +3137,12 @@ Int_t TTree::CheckBranchAddressType(TBranch* branch, TClass* ptrClass, EDataType
 TTree* TTree::CloneTree(Long64_t nentries /* = -1 */, Option_t* option /* = "" */)
 {
    // Options
-   Bool_t fastClone = kFALSE;
+   bool fastClone = false;
 
    TString opt = option;
    opt.ToLower();
    if (opt.Contains("fast")) {
-      fastClone = kTRUE;
+      fastClone = true;
    }
 
    // If we are a chain, switch to the first tree.
@@ -3274,7 +3274,7 @@ TTree* TTree::CloneTree(Long64_t nentries /* = -1 */, Option_t* option /* = "" *
 
    if (nentries != 0) {
       if (fastClone && (nentries < 0)) {
-         if ( newtree->CopyEntries( this, -1, option, kFALSE ) < 0 ) {
+         if ( newtree->CopyEntries( this, -1, option, false ) < 0 ) {
             // There was a problem!
             Error("CloneTTree", "TTree has not been cloned\n");
             delete newtree;
@@ -3282,7 +3282,7 @@ TTree* TTree::CloneTree(Long64_t nentries /* = -1 */, Option_t* option /* = "" *
             return nullptr;
          }
       } else {
-         newtree->CopyEntries( this, nentries, option, kFALSE );
+         newtree->CopyEntries( this, nentries, option, false );
       }
    }
 
@@ -3294,7 +3294,7 @@ TTree* TTree::CloneTree(Long64_t nentries /* = -1 */, Option_t* option /* = "" *
 /// If undo is true, reset the branch addresses instead of copying them.
 /// This ensures 'separation' of a cloned tree from its original.
 
-void TTree::CopyAddresses(TTree* tree, Bool_t undo)
+void TTree::CopyAddresses(TTree* tree, bool undo)
 {
    // Copy branch addresses starting from branches.
    TObjArray* branches = GetListOfBranches();
@@ -3428,11 +3428,11 @@ namespace {
 
    enum EOnIndexError { kDrop, kKeep, kBuild };
 
-   Bool_t R__HandleIndex(EOnIndexError onIndexError, TTree *newtree, TTree *oldtree)
+   bool R__HandleIndex(EOnIndexError onIndexError, TTree *newtree, TTree *oldtree)
    {
       // Return true if we should continue to handle indices, false otherwise.
 
-      Bool_t withIndex = kTRUE;
+      bool withIndex = true;
 
       if ( newtree->GetTreeIndex() ) {
          if ( oldtree->GetTree()->GetTreeIndex() == nullptr ) {
@@ -3440,7 +3440,7 @@ namespace {
                case kDrop:
                   delete newtree->GetTreeIndex();
                   newtree->SetTreeIndex(nullptr);
-                  withIndex = kFALSE;
+                  withIndex = false;
                   break;
                case kKeep:
                   // Nothing to do really.
@@ -3448,7 +3448,7 @@ namespace {
                case kBuild:
                   // Build the index then copy it
                   if (oldtree->GetTree()->BuildIndex(newtree->GetTreeIndex()->GetMajorName(), newtree->GetTreeIndex()->GetMinorName())) {
-                     newtree->GetTreeIndex()->Append(oldtree->GetTree()->GetTreeIndex(), kTRUE);
+                     newtree->GetTreeIndex()->Append(oldtree->GetTree()->GetTreeIndex(), true);
                      // Clean up
                      delete oldtree->GetTree()->GetTreeIndex();
                      oldtree->GetTree()->SetTreeIndex(nullptr);
@@ -3456,7 +3456,7 @@ namespace {
                   break;
             }
          } else {
-            newtree->GetTreeIndex()->Append(oldtree->GetTree()->GetTreeIndex(), kTRUE);
+            newtree->GetTreeIndex()->Append(oldtree->GetTree()->GetTreeIndex(), true);
          }
       } else if ( oldtree->GetTree()->GetTreeIndex() != nullptr ) {
          // We discover the first index in the middle of the chain.
@@ -3479,7 +3479,7 @@ namespace {
                } else {
                   // Build the index so far.
                   if (newtree->BuildIndex(oldtree->GetTree()->GetTreeIndex()->GetMajorName(), oldtree->GetTree()->GetTreeIndex()->GetMinorName())) {
-                     newtree->GetTreeIndex()->Append(oldtree->GetTree()->GetTreeIndex(), kTRUE);
+                     newtree->GetTreeIndex()->Append(oldtree->GetTree()->GetTreeIndex(), true);
                   }
                }
                break;
@@ -3487,7 +3487,7 @@ namespace {
       } else if ( onIndexError == kDrop ) {
          // There is no index on this or on tree->GetTree(), we know we have to ignore any further
          // index
-         withIndex = kFALSE;
+         withIndex = false;
       }
       return withIndex;
    }
@@ -3529,7 +3529,7 @@ namespace {
 /// - BuildIndexOnError : If any of the underlying TTree objects do not have a TTreeIndex,
 ///                          all TTreeIndex are 'ignored' and the missing piece are rebuilt.
 
-Long64_t TTree::CopyEntries(TTree* tree, Long64_t nentries /* = -1 */, Option_t* option /* = "" */, Bool_t needCopyAddresses /* = false */)
+Long64_t TTree::CopyEntries(TTree* tree, Long64_t nentries /* = -1 */, Option_t* option /* = "" */, bool needCopyAddresses /* = false */)
 {
    if (!tree) {
       return 0;
@@ -3537,8 +3537,8 @@ Long64_t TTree::CopyEntries(TTree* tree, Long64_t nentries /* = -1 */, Option_t*
    // Options
    TString opt = option;
    opt.ToLower();
-   Bool_t fastClone = opt.Contains("fast");
-   Bool_t withIndex = !opt.Contains("noindex");
+   bool fastClone = opt.Contains("fast");
+   bool withIndex = !opt.Contains("noindex");
    EOnIndexError onIndexError;
    if (opt.Contains("asisindex")) {
       onIndexError = kKeep;
@@ -3624,7 +3624,7 @@ Long64_t TTree::CopyEntries(TTree* tree, Long64_t nentries /* = -1 */, Option_t*
                   if (needCopyAddresses)
                      tree->ResetBranchAddresses();
                   if (this->GetTreeIndex()) {
-                     this->GetTreeIndex()->Append(tree->GetTree()->GetTreeIndex(), kTRUE);
+                     this->GetTreeIndex()->Append(tree->GetTree()->GetTreeIndex(), true);
                   }
                } else {
                   Warning("CopyEntries","%s",cloner.GetWarning());
@@ -3639,7 +3639,7 @@ Long64_t TTree::CopyEntries(TTree* tree, Long64_t nentries /* = -1 */, Option_t*
 
       }
       if (this->GetTreeIndex()) {
-         this->GetTreeIndex()->Append(nullptr,kFALSE); // Force the sorting
+         this->GetTreeIndex()->Append(nullptr,false); // Force the sorting
       }
       nbytes = GetTotBytes() - totbytes;
    } else {
@@ -3673,7 +3673,7 @@ Long64_t TTree::CopyEntries(TTree* tree, Long64_t nentries /* = -1 */, Option_t*
       if (needCopyAddresses)
          tree->ResetBranchAddresses();
       if (this->GetTreeIndex()) {
-         this->GetTreeIndex()->Append(nullptr,kFALSE); // Force the sorting
+         this->GetTreeIndex()->Append(nullptr,false); // Force the sorting
       }
    }
    return nbytes;
@@ -4424,7 +4424,7 @@ Long64_t TTree::Draw(const char* varexp, const TCut& selection, Option_t* option
 /// Example:
 /// ~~~ {.cpp}
 ///     tree.Draw(">>pyplus","fTracks.fPy>0");
-///     pyplus->SetReapplyCut(kTRUE);
+///     pyplus->SetReapplyCut(true);
 ///     tree->SetEventList(pyplus);
 ///     tree->Draw("fTracks.fPy");
 /// ~~~
@@ -5085,9 +5085,9 @@ Int_t TTree::Fit(const char* funcname, const char* varexp, const char* selection
 
 namespace {
 struct BoolRAIIToggle {
-   Bool_t &m_val;
+   bool &m_val;
 
-   BoolRAIIToggle(Bool_t &val) : m_val(val) { m_val = true; }
+   BoolRAIIToggle(bool &val) : m_val(val) { m_val = true; }
    ~BoolRAIIToggle() { m_val = false; }
 };
 }
@@ -5124,7 +5124,7 @@ struct BoolRAIIToggle {
 /// locks when they invoke ROOT.
 ///
 /// Return the number of bytes written or -1 in case of write error.
-Int_t TTree::FlushBaskets(Bool_t create_cluster) const
+Int_t TTree::FlushBaskets(bool create_cluster) const
 {
     Int_t retval = FlushBasketsImpl();
     if (retval == -1) return retval;
@@ -5375,7 +5375,7 @@ TBranch* TTree::GetBranch(const char* name)
 /// - 0 if branch is not activated
 /// - 1 if branch is activated
 
-Bool_t TTree::GetBranchStatus(const char* branchname) const
+bool TTree::GetBranchStatus(const char* branchname) const
 {
    TBranch* br = const_cast<TTree*>(this)->GetBranch(branchname);
    if (br) {
@@ -5402,7 +5402,7 @@ Int_t TTree::GetBranchStyle()
 /// A cache sizing factor is taken from the configuration. If this yields zero
 /// and withDefault is true the historical algorithm for default size is used.
 
-Long64_t TTree::GetCacheAutoSize(Bool_t withDefault /* = kFALSE */ )
+Long64_t TTree::GetCacheAutoSize(bool withDefault /* = false */ )
 {
    auto calculateCacheSize = [this](Double_t cacheFactor)
    {
@@ -5561,7 +5561,7 @@ Long64_t TTree::GetEntriesFriend() const
 ///
 /// By default, GetEntry reuses the space allocated by the previous object
 /// for each branch. You can force the previous object to be automatically
-/// deleted if you call mybranch.SetAutoDelete(kTRUE) (default is kFALSE).
+/// deleted if you call mybranch.SetAutoDelete(true) (default is false).
 ///
 /// Example:
 ///
@@ -5604,7 +5604,7 @@ Long64_t TTree::GetEntriesFriend() const
 /// ~~~ {.cpp}
 ///     TBranch *branch = T.GetBranch("event");
 ///     branch->SetAddress(&event);
-///     branch->SetAutoDelete(kTRUE);
+///     branch->SetAutoDelete(true);
 ///     for (Long64_t i=0;i<nentries;i++) {
 ///        T.GetEntry(i);
 ///        // the object event has been filled at this point
@@ -6077,7 +6077,7 @@ ROOT::TIOFeatures TTree::GetIOFeatures() const
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates a new iterator that will go through all the leaves on the tree itself and its friend.
 
-TIterator* TTree::GetIteratorOnAllLeaves(Bool_t dir)
+TIterator* TTree::GetIteratorOnAllLeaves(bool dir)
 {
    return new TTreeFriendLeafIter(this, dir);
 }
@@ -6326,12 +6326,12 @@ TTreeCache *TTree::GetReadCache(TFile *file) const
 /// contain branches for us. If create is true and there is no cache
 /// a new cache is created with default size.
 
-TTreeCache *TTree::GetReadCache(TFile *file, Bool_t create)
+TTreeCache *TTree::GetReadCache(TFile *file, bool create)
 {
    TTreeCache *pe = GetReadCache(file);
    if (create && !pe) {
       if (fCacheDoAutoInit)
-         SetCacheSizeAux(kTRUE, -1);
+         SetCacheSizeAux(true, -1);
       pe = dynamic_cast<TTreeCache*>(file->GetCacheRead(GetTree()));
       if (pe && pe->GetTree() != GetTree()) pe = nullptr;
    }
@@ -6489,13 +6489,13 @@ Long64_t TTree::LoadTree(Long64_t entry)
    }
    fReadEntry = entry;
 
-   Bool_t friendHasEntry = kFALSE;
+   bool friendHasEntry = false;
    if (fFriends) {
       // Set current entry in friends as well.
       //
       // An alternative would move this code to each of the
       // functions calling LoadTree (and to overload a few more).
-      Bool_t needUpdate = kFALSE;
+      bool needUpdate = false;
       {
          // This scope is need to insure the lock is released at the right time
          TIter nextf(fFriends);
@@ -6510,11 +6510,11 @@ Long64_t TTree::LoadTree(Long64_t entry)
             TTree* friendTree = fe->GetTree();
             if (friendTree) {
                if (friendTree->LoadTreeFriend(entry, this) >= 0) {
-                  friendHasEntry = kTRUE;
+                  friendHasEntry = true;
                }
             }
             if (fe->IsUpdated()) {
-               needUpdate = kTRUE;
+               needUpdate = true;
                fe->ResetUpdated();
             }
          } // for each friend
@@ -6730,8 +6730,8 @@ Int_t TTree::MakeCode(const char* filename)
 /// - The method         calls the method (if it exist)
 /// - Begin           -> void h1analysisProxy_Begin(TTree*);
 /// - SlaveBegin      -> void h1analysisProxy_SlaveBegin(TTree*);
-/// - Notify          -> Bool_t h1analysisProxy_Notify();
-/// - Process         -> Bool_t h1analysisProxy_Process(Long64_t);
+/// - Notify          -> bool h1analysisProxy_Notify();
+/// - Process         -> bool h1analysisProxy_Process(Long64_t);
 /// - SlaveTerminate  -> void h1analysisProxy_SlaveTerminate();
 /// - Terminate       -> void h1analysisProxy_Terminate();
 ///
@@ -6797,8 +6797,8 @@ Int_t TTree::MakeProxy(const char* proxyClassname, const char* macrofilename, co
 ///       - void    Begin(TTree *tree)
 ///       - void    SlaveBegin(TTree *tree)
 ///       - void    Init(TTree *tree)
-///       - Bool_t  Notify()
-///       - Bool_t  Process(Long64_t entry)
+///       - bool    Notify()
+///       - bool    Process(Long64_t entry)
 ///       - void    Terminate()
 ///       - void    SlaveTerminate()
 ///
@@ -6832,12 +6832,12 @@ Int_t TTree::MakeSelector(const char* selector, Option_t* option)
 ////////////////////////////////////////////////////////////////////////////////
 /// Check if adding nbytes to memory we are still below MaxVirtualsize.
 
-Bool_t TTree::MemoryFull(Int_t nbytes)
+bool TTree::MemoryFull(Int_t nbytes)
 {
    if ((fTotalBuffers + nbytes) < fMaxVirtualSize) {
-      return kFALSE;
+      return false;
    }
-   return kTRUE;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -6872,10 +6872,10 @@ TTree* TTree::MergeTrees(TList* li, Option_t* options)
          continue;
       }
 
-      newtree->CopyEntries(tree, -1, options, kTRUE);
+      newtree->CopyEntries(tree, -1, options, true);
    }
    if (newtree && newtree->GetTreeIndex()) {
-      newtree->GetTreeIndex()->Append(nullptr,kFALSE); // Force the sorting
+      newtree->GetTreeIndex()->Append(nullptr,false); // Force the sorting
    }
    return newtree;
 }
@@ -6907,7 +6907,7 @@ Long64_t TTree::Merge(TCollection* li, Option_t *options)
       Long64_t nentries = tree->GetEntries();
       if (nentries == 0) continue;
 
-      CopyEntries(tree, -1, options, kTRUE);
+      CopyEntries(tree, -1, options, true);
    }
    fAutoSave = storeAutoSave;
    return GetEntries();
@@ -6967,7 +6967,7 @@ Long64_t TTree::Merge(TCollection* li, TFileMergeInfo *info)
          return -1;
       }
 
-      CopyEntries(tree, -1, options, kTRUE);
+      CopyEntries(tree, -1, options, true);
    }
    fAutoSave = storeAutoSave;
    return GetEntries();
@@ -7007,7 +7007,7 @@ void TTree::MoveReadCache(TFile *src, TDirectory *dir)
 /// If new and old directory are in the same file, the data is untouched,
 /// this "just" does a call to SetDirectory.
 /// Equivalent to an "in place" cloning of the TTree.
-Bool_t TTree::InPlaceClone(TDirectory *newdirectory, const char *options)
+bool TTree::InPlaceClone(TDirectory *newdirectory, const char *options)
 {
    if (!newdirectory) {
       LoadBaskets(2*fTotBytes);
@@ -7028,7 +7028,7 @@ Bool_t TTree::InPlaceClone(TDirectory *newdirectory, const char *options)
 ////////////////////////////////////////////////////////////////////////////////
 /// Function called when loading a new class library.
 
-Bool_t TTree::Notify()
+bool TTree::Notify()
 {
    TIter next(GetListOfLeaves());
    TLeaf* leaf = nullptr;
@@ -7036,7 +7036,7 @@ Bool_t TTree::Notify()
       leaf->Notify();
       leaf->GetBranch()->Notify();
    }
-   return kTRUE;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -7059,7 +7059,7 @@ void TTree::OptimizeBaskets(ULong64_t maxMemory, Float_t minComp, Option_t *opti
 
    TString opt( option );
    opt.ToLower();
-   Bool_t pDebug = opt.Contains("d");
+   bool pDebug = opt.Contains("d");
    TObjArray *leaves = this->GetListOfLeaves();
    Int_t nleaves = leaves->GetEntries();
    Double_t treeSize = (Double_t)this->GetTotBytes();
@@ -7329,7 +7329,7 @@ void TTree::Print(Option_t* option) const
    } else {
       TString reg = "*";
       if (strlen(option) && strchr(option,'*')) reg = option;
-      TRegexp re(reg,kTRUE);
+      TRegexp re(reg,true);
       TIter next(const_cast<TTree*>(this)->GetListOfBranches());
       TBranch::ResetCount();
       while ((br= (TBranch*)next())) {
@@ -7770,7 +7770,7 @@ Long64_t TTree::ReadStream(std::istream& inputStream, const char *branchDescript
       std::stringstream sToken; // string stream feeding leafData into leaves
       Ssiz_t pos = 0;
       Int_t iBranch = 0;
-      Bool_t goodLine = kTRUE; // whether the row can be filled into the tree
+      bool goodLine = true; // whether the row can be filled into the tree
       Int_t remainingLeafLen = 0; // remaining columns for the current leaf
       while (goodLine && iBranch < nbranches
              && sLine.Tokenize(tok, pos, sDelim)) {
@@ -7834,7 +7834,7 @@ Long64_t TTree::ReadStream(std::istream& inputStream, const char *branchDescript
                Warning("ReadStream",
                        "Couldn't read formatted data in \"%s\" for branch %s on line %lld; ignoring line",
                        tok.Data(), branch->GetName(), nlines);
-               goodLine = kFALSE;
+               goodLine = false;
             } else {
                std::string remainder;
                std::getline(sToken, remainder, newline);
@@ -7851,7 +7851,7 @@ Long64_t TTree::ReadStream(std::istream& inputStream, const char *branchDescript
          Warning("ReadStream",
                  "Read too few columns (%d < %d) in line %lld; ignoring line",
                  iBranch, nbranches, nlines);
-         goodLine = kFALSE;
+         goodLine = false;
       } else if (pos != kNPOS) {
          sLine = sLine.Strip(TString::kTrailing);
          if (pos < sLine.Length()) {
@@ -8131,13 +8131,13 @@ Long64_t TTree::Scan(const char* varexp, const char* selection, Option_t* option
 ///     tree->Draw("theGoodTrack.fPx"); // same as "event.fTracks[3].fPx"
 /// ~~~
 
-Bool_t TTree::SetAlias(const char* aliasName, const char* aliasFormula)
+bool TTree::SetAlias(const char* aliasName, const char* aliasFormula)
 {
    if (!aliasName || !aliasFormula) {
-      return kFALSE;
+      return false;
    }
    if (!aliasName[0] || !aliasFormula[0]) {
-      return kFALSE;
+      return false;
    }
    if (!fAliases) {
       fAliases = new TList;
@@ -8145,12 +8145,12 @@ Bool_t TTree::SetAlias(const char* aliasName, const char* aliasFormula)
       TNamed* oldHolder = (TNamed*) fAliases->FindObject(aliasName);
       if (oldHolder) {
          oldHolder->SetTitle(aliasFormula);
-         return kTRUE;
+         return true;
       }
    }
    TNamed* holder = new TNamed(aliasName, aliasFormula);
    fAliases->Add(holder);
-   return kTRUE;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -8351,7 +8351,7 @@ void TTree::SetAutoSave(Long64_t autos)
 void TTree::SetBasketSize(const char* bname, Int_t buffsize)
 {
    Int_t nleaves = fLeaves.GetEntriesFast();
-   TRegexp re(bname, kTRUE);
+   TRegexp re(bname, true);
    Int_t nb = 0;
    for (Int_t i = 0; i < nleaves; i++)  {
       TLeaf* leaf = (TLeaf*) fLeaves.UncheckedAt(i);
@@ -8393,7 +8393,7 @@ Int_t TTree::SetBranchAddress(const char* bname, void* addr, TBranch** ptr)
 /// Note: See the comments in TBranchElement::SetAddress() for the
 /// meaning of the addr parameter and the object ownership policy.
 
-Int_t TTree::SetBranchAddress(const char* bname, void* addr, TClass* ptrClass, EDataType datatype, Bool_t isptr)
+Int_t TTree::SetBranchAddress(const char* bname, void* addr, TClass* ptrClass, EDataType datatype, bool isptr)
 {
    return SetBranchAddress(bname, addr, nullptr, ptrClass, datatype, isptr);
 }
@@ -8405,7 +8405,7 @@ Int_t TTree::SetBranchAddress(const char* bname, void* addr, TClass* ptrClass, E
 /// Note: See the comments in TBranchElement::SetAddress() for the
 /// meaning of the addr parameter and the object ownership policy.
 
-Int_t TTree::SetBranchAddress(const char* bname, void* addr, TBranch** ptr, TClass* ptrClass, EDataType datatype, Bool_t isptr)
+Int_t TTree::SetBranchAddress(const char* bname, void* addr, TBranch** ptr, TClass* ptrClass, EDataType datatype, bool isptr)
 {
    TBranch* branch = GetBranch(bname);
    if (!branch) {
@@ -8420,7 +8420,7 @@ Int_t TTree::SetBranchAddress(const char* bname, void* addr, TBranch** ptr, TCla
    if (res >= 0) {
       // The check succeeded.
       if ((res & kNeedEnableDecomposedObj) && !branch->GetMakeClass())
-         branch->SetMakeClass(kTRUE);
+         branch->SetMakeClass(true);
       SetBranchAddressImp(branch,addr,ptr);
    } else {
       if (ptr) *ptr = nullptr;
@@ -8524,7 +8524,7 @@ Int_t TTree::SetBranchAddressImp(TBranch *branch, void* addr, TBranch** ptr)
 /// expression is returned in *found AND the error message 'unknown branch'
 /// is suppressed.
 
-void TTree::SetBranchStatus(const char* bname, Bool_t status, UInt_t* found)
+void TTree::SetBranchStatus(const char* bname, bool status, UInt_t* found)
 {
    // We already have been visited while recursively looking
    // through the friends tree, let return
@@ -8542,7 +8542,7 @@ void TTree::SetBranchStatus(const char* bname, Bool_t status, UInt_t* found)
 
    Int_t i,j;
    Int_t nleaves = fLeaves.GetEntriesFast();
-   TRegexp re(bname,kTRUE);
+   TRegexp re(bname,true);
    Int_t nb = 0;
 
    // first pass, loop on all branches
@@ -8674,9 +8674,9 @@ void TTree::SetBranchStyle(Int_t style)
 Int_t TTree::SetCacheSize(Long64_t cacheSize)
 {
    // remember that the user has requested an explicit cache setup
-   fCacheUserSet = kTRUE;
+   fCacheUserSet = true;
 
-   return SetCacheSizeAux(kFALSE, cacheSize);
+   return SetCacheSizeAux(false, cacheSize);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -8697,23 +8697,23 @@ Int_t TTree::SetCacheSize(Long64_t cacheSize)
 ///   (cache was created if possible)
 /// - -1 on error
 
-Int_t TTree::SetCacheSizeAux(Bool_t autocache /* = kTRUE */, Long64_t cacheSize /* = 0 */ )
+Int_t TTree::SetCacheSizeAux(bool autocache /* = true */, Long64_t cacheSize /* = 0 */ )
 {
    if (autocache) {
       // used as a once only control for automatic cache setup
-      fCacheDoAutoInit = kFALSE;
+      fCacheDoAutoInit = false;
    }
 
    if (!autocache) {
       // negative size means the user requests the default
       if (cacheSize < 0) {
-         cacheSize = GetCacheAutoSize(kTRUE);
+         cacheSize = GetCacheAutoSize(true);
       }
    } else {
       if (cacheSize == 0) {
          cacheSize = GetCacheAutoSize();
       } else if (cacheSize < 0) {
-         cacheSize = GetCacheAutoSize(kTRUE);
+         cacheSize = GetCacheAutoSize(true);
       }
    }
 
@@ -8749,7 +8749,7 @@ Int_t TTree::SetCacheSizeAux(Bool_t autocache /* = kTRUE */, Long64_t cacheSize 
       } else {
          // update the cache to ensure it records the user has explicitly
          // requested it
-         pf->SetAutoCreated(kFALSE);
+         pf->SetAutoCreated(false);
       }
 
       // if we're using an automatically calculated size and the existing
@@ -8838,7 +8838,7 @@ Int_t TTree::SetCacheEntryRange(Long64_t first, Long64_t last)
       Error("SetCacheEntryRange", "No file is available. Could not set cache entry range");
       return -1;
    }
-   TTreeCache *tc = GetReadCache(f,kTRUE);
+   TTreeCache *tc = GetReadCache(f,true);
    if (!tc) {
       Error("SetCacheEntryRange", "No cache is available. Could not set entry range");
       return -1;
@@ -8925,7 +8925,7 @@ void TTree::SetDebug(Int_t level, Long64_t min, Long64_t max)
 /// If updateExisting is true, also update all the existing branches.
 /// If newdefault is less than 10, the new default value will be 10.
 
-void TTree::SetDefaultEntryOffsetLen(Int_t newdefault, Bool_t updateExisting)
+void TTree::SetDefaultEntryOffsetLen(Int_t newdefault, bool updateExisting)
 {
    if (newdefault < 10) {
       newdefault = 10;
@@ -8935,10 +8935,10 @@ void TTree::SetDefaultEntryOffsetLen(Int_t newdefault, Bool_t updateExisting)
       TIter next( GetListOfBranches() );
       TBranch *b;
       while ( ( b = (TBranch*)next() ) ) {
-         b->SetEntryOffsetLen( newdefault, kTRUE );
+         b->SetEntryOffsetLen( newdefault, true );
       }
       if (fBranchRef) {
-         fBranchRef->SetEntryOffsetLen( newdefault, kTRUE );
+         fBranchRef->SetEntryOffsetLen( newdefault, true );
       }
    }
 }
@@ -9086,7 +9086,7 @@ void TTree::SetEventList(TEventList *evlist)
       fEntryList->Enter(entry);
    }
    fEntryList->SetReapplyCut(evlist->GetReapplyCut());
-   fEntryList->SetBit(kCanDelete, kTRUE);
+   fEntryList->SetBit(kCanDelete, true);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -9276,7 +9276,7 @@ void TTree::SetObject(const char* name, const char* title)
 ////////////////////////////////////////////////////////////////////////////////
 /// Enable or disable parallel unzipping of Tree buffers.
 
-void TTree::SetParallelUnzip(Bool_t opt, Float_t RelSize)
+void TTree::SetParallelUnzip(bool opt, Float_t RelSize)
 {
 #ifdef R__USE_IMT
    if (GetTree() == nullptr) {
@@ -9298,7 +9298,7 @@ void TTree::SetParallelUnzip(Bool_t opt, Float_t RelSize)
       return;
    }
    delete pf;
-   auto cacheSize = GetCacheAutoSize(kTRUE);
+   auto cacheSize = GetCacheAutoSize(true);
    if (opt) {
       auto unzip = new TTreeCacheUnzip(this, cacheSize);
       unzip->SetUnzipBufferSize( Long64_t(cacheSize * RelSize) );
@@ -9481,7 +9481,7 @@ Int_t TTree::StopCacheLearningPhase()
       Error("StopCacheLearningPhase", "No file is available. Could not stop cache learning phase");
       return -1;
    }
-   TTreeCache *tc = GetReadCache(f,kTRUE);
+   TTreeCache *tc = GetReadCache(f,true);
    if (!tc) {
       Error("StopCacheLearningPhase", "No cache is available. Could not stop learning phase");
       return -1;
@@ -9541,13 +9541,13 @@ void TTree::Streamer(TBuffer& b)
          MoveReadCache(file,nullptr);
       }
       fDirectory = nullptr;
-      fCacheDoAutoInit = kTRUE;
-      fCacheUserSet = kFALSE;
+      fCacheDoAutoInit = true;
+      fCacheUserSet = false;
       Version_t R__v = b.ReadVersion(&R__s, &R__c);
       if (R__v > 4) {
          b.ReadClassBuffer(TTree::Class(), this, R__v, R__s, R__c);
 
-         fBranches.SetOwner(kTRUE); // True needed only for R__v < 19 and most R__v == 19
+         fBranches.SetOwner(true); // True needed only for R__v < 19 and most R__v == 19
 
          if (fBranchRef) fBranchRef->SetTree(this);
          TBranch__SetTree(this,fBranches);
@@ -9575,7 +9575,7 @@ void TTree::Streamer(TBuffer& b)
          // by TTreePlayer::Process, the cache size will be automatically
          // determined unless the user explicitly call `SetCacheSize`
          fCacheSize = 0;
-         fCacheUserSet = kFALSE;
+         fCacheUserSet = false;
 
          ResetBit(kMustCleanup);
          return;
@@ -9754,7 +9754,7 @@ ClassImp(TTreeFriendLeafIter);
 /// Create a new iterator. By default the iteration direction
 /// is kIterForward. To go backward use kIterBackward.
 
-TTreeFriendLeafIter::TTreeFriendLeafIter(const TTree* tree, Bool_t dir)
+TTreeFriendLeafIter::TTreeFriendLeafIter(const TTree* tree, bool dir)
 : fTree(const_cast<TTree*>(tree))
 , fLeafIter(nullptr)
 , fTreeIter(nullptr)

--- a/tree/tree/src/TTreeCache.cxx
+++ b/tree/tree/src/TTreeCache.cxx
@@ -347,7 +347,7 @@ TTreeCache::~TTreeCache()
 ///  - 0 branch added or already included
 ///  - -1 on error
 
-Int_t TTreeCache::LearnBranch(TBranch *b, Bool_t subbranches /*= kFALSE*/)
+Int_t TTreeCache::LearnBranch(TBranch *b, bool subbranches /*= false*/)
 {
    if (!fIsLearning) {
       return -1;
@@ -373,15 +373,15 @@ Int_t TTreeCache::LearnBranch(TBranch *b, Bool_t subbranches /*= kFALSE*/)
 ///  - 0 branch added or already included
 ///  - -1 on error
 
-Int_t TTreeCache::AddBranch(TBranch *b, Bool_t subbranches /*= kFALSE*/)
+Int_t TTreeCache::AddBranch(TBranch *b, bool subbranches /*= false*/)
 {
    // Reject branch that are not from the cached tree.
    if (!b || fTree->GetTree() != b->GetTree()) return -1;
 
    //Is branch already in the cache?
-   Bool_t isNew = kTRUE;
+   bool isNew = true;
    for (int i=0;i<fNbranches;i++) {
-      if (fBranches->UncheckedAt(i) == b) {isNew = kFALSE; break;}
+      if (fBranches->UncheckedAt(i) == b) {isNew = false; break;}
    }
    if (isNew) {
       fTree = b->GetTree();
@@ -443,21 +443,21 @@ Int_t TTreeCache::AddBranch(TBranch *b, Bool_t subbranches /*= kFALSE*/)
 ///  - 0 branch added or already included
 ///  - -1 on error
 
-Int_t TTreeCache::AddBranch(const char *bname, Bool_t subbranches /*= kFALSE*/)
+Int_t TTreeCache::AddBranch(const char *bname, bool subbranches /*= false*/)
 {
    TBranch *branch, *bcount;
    TLeaf *leaf, *leafcount;
 
    Int_t i;
    Int_t nleaves = (fTree->GetListOfLeaves())->GetEntriesFast();
-   TRegexp re(bname,kTRUE);
+   TRegexp re(bname,true);
    Int_t nb = 0;
    Int_t res = 0;
 
    // first pass, loop on all branches
    // for leafcount branches activate/deactivate in function of status
-   Bool_t all = kFALSE;
-   if (!strcmp(bname,"*")) all = kTRUE;
+   bool all = false;
+   if (!strcmp(bname,"*")) all = true;
    for (i=0;i<nleaves;i++)  {
       leaf = (TLeaf*)(fTree->GetListOfLeaves())->UncheckedAt(i);
       branch = (TBranch*)leaf->GetBranch();
@@ -538,7 +538,7 @@ Int_t TTreeCache::AddBranch(const char *bname, Bool_t subbranches /*= kFALSE*/)
 ///  - 0 branch dropped or not in cache
 ///  - -1 on error
 
-Int_t TTreeCache::DropBranch(TBranch *b, Bool_t subbranches /*= kFALSE*/)
+Int_t TTreeCache::DropBranch(TBranch *b, bool subbranches /*= false*/)
 {
    if (!fIsLearning) {
       return -1;
@@ -583,21 +583,21 @@ Int_t TTreeCache::DropBranch(TBranch *b, Bool_t subbranches /*= kFALSE*/)
 ///  - 0 branch dropped or not in cache
 ///  - -1 on error
 
-Int_t TTreeCache::DropBranch(const char *bname, Bool_t subbranches /*= kFALSE*/)
+Int_t TTreeCache::DropBranch(const char *bname, bool subbranches /*= false*/)
 {
    TBranch *branch, *bcount;
    TLeaf *leaf, *leafcount;
 
    Int_t i;
    Int_t nleaves = (fTree->GetListOfLeaves())->GetEntriesFast();
-   TRegexp re(bname,kTRUE);
+   TRegexp re(bname,true);
    Int_t nb = 0;
    Int_t res = 0;
 
    // first pass, loop on all branches
    // for leafcount branches activate/deactivate in function of status
-   Bool_t all = kFALSE;
-   if (!strcmp(bname,"*")) all = kTRUE;
+   bool all = false;
+   if (!strcmp(bname,"*")) all = true;
    for (i=0;i<nleaves;i++)  {
       leaf = (TLeaf*)(fTree->GetListOfLeaves())->UncheckedAt(i);
       branch = (TBranch*)leaf->GetBranch();
@@ -680,7 +680,7 @@ Int_t TTreeCache::DropBranch(const char *bname, Bool_t subbranches /*= kFALSE*/)
 /// The first time this is called on a TTreeCache object, the corresponding
 /// data structures will be allocated.  Subsequent enable / disables will
 /// simply turn the functionality on/off.
-void TTreeCache::SetOptimizeMisses(Bool_t opt)
+void TTreeCache::SetOptimizeMisses(bool opt)
 {
 
    if (opt && !fMissCache) {
@@ -787,7 +787,7 @@ TTreeCache::IOPos TTreeCache::FindBranchBasketPos(TBranch &b, Long64_t entry)
 ///   this IO operation.
 /// - If no corresponding branch could be found (or an error occurs), this
 ///   returns nullptr.
-TBranch *TTreeCache::CalculateMissEntries(Long64_t pos, Int_t len, Bool_t all)
+TBranch *TTreeCache::CalculateMissEntries(Long64_t pos, Int_t len, bool all)
 {
    if (R__unlikely((pos < 0) || (len < 0))) {
       return nullptr;
@@ -796,7 +796,7 @@ TBranch *TTreeCache::CalculateMissEntries(Long64_t pos, Int_t len, Bool_t all)
    int count = all ? (fTree->GetListOfLeaves())->GetEntriesFast() : fMissCache->fBranches.size();
    fMissCache->fEntries.reserve(count);
    fMissCache->fEntries.clear();
-   Bool_t found_request = kFALSE;
+   bool found_request = false;
    TBranch *resultBranch = nullptr;
    Long64_t entry = fTree->GetReadEntry();
 
@@ -813,7 +813,7 @@ TBranch *TTreeCache::CalculateMissEntries(Long64_t pos, Int_t len, Bool_t all)
          continue;
       }
       if (iopos.fPos == pos && iopos.fLen == len) {
-         found_request = kTRUE;
+         found_request = true;
          resultBranch = b;
          // Note that we continue to iterate; fills up the rest of the entries in the cache.
       }
@@ -860,13 +860,13 @@ TBranch *TTreeCache::CalculateMissEntries(Long64_t pos, Int_t len, Bool_t all)
 ///
 /// Returns true if we were able to pull the data into the miss cache.
 ///
-Bool_t TTreeCache::ProcessMiss(Long64_t pos, int len)
+bool TTreeCache::ProcessMiss(Long64_t pos, int len)
 {
 
-   Bool_t firstMiss = kFALSE;
+   bool firstMiss = false;
    if (fFirstMiss == -1) {
       fFirstMiss = fEntryCurrent;
-      firstMiss = kTRUE;
+      firstMiss = true;
    }
    fLastMiss = fEntryCurrent;
    // The first time this is executed, we try to pull in as much data as we can.
@@ -874,14 +874,14 @@ Bool_t TTreeCache::ProcessMiss(Long64_t pos, int len)
    if (!b) {
       if (!firstMiss) {
          // TODO: this recalculates for *all* branches, throwing away the above work.
-         b = CalculateMissEntries(pos, len, kTRUE);
+         b = CalculateMissEntries(pos, len, true);
       }
       if (!b) {
          // printf("ProcessMiss: pos %ld does not appear to correspond to a buffer in this file.\n", pos);
          // We have gone through all the branches in this file and the requested basket
          // doesn't appear to be in any of them.  Likely a logic error / bug.
          fMissCache->fEntries.clear();
-         return kFALSE;
+         return false;
       }
    }
    // TODO: this should be a set.
@@ -908,7 +908,7 @@ Bool_t TTreeCache::ProcessMiss(Long64_t pos, int len)
    fFile->ReadBuffers(&(fMissCache->fData[0]), &(positions[0]), &(lengths[0]), fMissCache->fEntries.size());
    fFirstMiss = fLastMiss = fEntryCurrent;
 
-   return kTRUE;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -918,14 +918,14 @@ Bool_t TTreeCache::ProcessMiss(Long64_t pos, int len)
 /// Returns true if the IO operation was successful and the contents of buf
 /// were populated with the requested data.
 ///
-Bool_t TTreeCache::CheckMissCache(char *buf, Long64_t pos, int len)
+bool TTreeCache::CheckMissCache(char *buf, Long64_t pos, int len)
 {
 
    if (!fOptimizeMisses) {
-      return kFALSE;
+      return false;
    }
    if (R__unlikely((pos < 0) || (len < 0))) {
-      return kFALSE;
+      return false;
    }
 
    // printf("Checking the miss cache for offset=%ld, length=%d\n", pos, len);
@@ -937,13 +937,13 @@ Bool_t TTreeCache::CheckMissCache(char *buf, Long64_t pos, int len)
    if (iter != fMissCache->fEntries.end()) {
       if (len > iter->fIO.fLen) {
          ++fNMissReadMiss;
-         return kFALSE;
+         return false;
       }
       auto offset = iter->fIndex;
       memcpy(buf, &(fMissCache->fData[offset]), len);
       // printf("Returning data from pos=%ld in miss cache.\n", offset);
       ++fNMissReadOk;
-      return kTRUE;
+      return true;
    }
 
    // printf("Data not in miss cache.\n");
@@ -952,7 +952,7 @@ Bool_t TTreeCache::CheckMissCache(char *buf, Long64_t pos, int len)
    if (!ProcessMiss(pos, len)) {
       // printf("Unable to pull data into miss cache.\n");
       ++fNMissReadMiss;
-      return kFALSE;
+      return false;
    }
 
    // OK, we updated the cache with as much information as possible.  Search again for
@@ -964,13 +964,13 @@ Bool_t TTreeCache::CheckMissCache(char *buf, Long64_t pos, int len)
       // printf("Expecting data at offset %ld in miss cache.\n", offset);
       memcpy(buf, &(fMissCache->fData[offset]), len);
       ++fNMissReadOk;
-      return kTRUE;
+      return true;
    }
 
    // This must be a logic bug.  ProcessMiss should return false if (pos, len)
    // wasn't put into fEntries.
    ++fNMissReadMiss;
-   return kFALSE;
+   return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -997,7 +997,7 @@ struct BasketRanges {
             fMax = max;
       }
 
-      Bool_t Contains(Long64_t entry) { return (fMin <= entry && entry <= fMax); }
+      bool Contains(Long64_t entry) { return (fMin <= entry && entry <= fMax); }
    };
 
    std::vector<Range> fRanges;
@@ -1088,14 +1088,14 @@ struct BasketRanges {
 
    // Returns true if at least one of the branch's range contains
    // the entry.
-   Bool_t Contains(Long64_t entry)
+   bool Contains(Long64_t entry)
    {
       for (const auto &r : fRanges) {
          if (r.fMin != -1 && r.fMax != -1)
             if (r.fMin <= entry && entry <= r.fMax)
-               return kTRUE;
+               return true;
       }
-      return kFALSE;
+      return false;
    }
 
    void Print()
@@ -1111,16 +1111,16 @@ struct BasketRanges {
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill the cache buffer with the branches in the cache.
 
-Bool_t TTreeCache::FillBuffer()
+bool TTreeCache::FillBuffer()
 {
 
-   if (fNbranches <= 0) return kFALSE;
+   if (fNbranches <= 0) return false;
    TTree *tree = ((TBranch*)fBranches->UncheckedAt(0))->GetTree();
    Long64_t entry = tree->GetReadEntry();
    Long64_t fEntryCurrentMax = 0;
 
    if (entry != -1 && (entry < fEntryMin || fEntryMax < entry))
-      return kFALSE;
+      return false;
 
    if (fEnablePrefetching) { // Prefetching mode
       if (fIsLearning) { // Learning mode
@@ -1129,7 +1129,7 @@ Bool_t TTreeCache::FillBuffer()
             // phase. Doing so may trigger a recursive call to FillBuffer in
             // the process of filling both prefetching buffers
             StopLearningPhase();
-            fIsManual = kFALSE;
+            fIsManual = false;
          }
       }
       if (fIsLearning) { //  Learning mode
@@ -1141,16 +1141,16 @@ Bool_t TTreeCache::FillBuffer()
          fFirstEntry = entry;
       }
       else {
-         if (fFirstEntry == entry) return kFALSE;
+         if (fFirstEntry == entry) return false;
          // Set the read direction
          if (!fReadDirectionSet) {
             if (entry < fFirstEntry) {
-               fReverseRead = kTRUE;
-               fReadDirectionSet = kTRUE;
+               fReverseRead = true;
+               fReadDirectionSet = true;
             }
             else if (entry > fFirstEntry) {
-               fReverseRead =kFALSE;
-               fReadDirectionSet = kTRUE;
+               fReverseRead =false;
+               fReadDirectionSet = true;
             }
          }
 
@@ -1165,9 +1165,9 @@ Bool_t TTreeCache::FillBuffer()
             }
             else if (fEntryCurrent >= 0) {
                // We are still reading from the oldest buffer, no need to prefetch a new one
-               return kFALSE;
+               return false;
             }
-            if (entry < 0) return kFALSE;
+            if (entry < 0) return false;
             fFirstBuffer = !fFirstBuffer;
          }
          else {
@@ -1183,7 +1183,7 @@ Bool_t TTreeCache::FillBuffer()
                else {
                   // We are still reading from the oldest buffer,
                   // no need to prefetch a new one
-                  return kFALSE;
+                  return false;
                }
                fFirstBuffer = !fFirstBuffer;
             }
@@ -1193,7 +1193,7 @@ Bool_t TTreeCache::FillBuffer()
 
    // Set to true to enable all debug output without having to set gDebug
    // Replace this once we have a per module and/or per class debugging level/setting.
-   static constexpr bool showMore = kFALSE;
+   static constexpr bool showMore = false;
 
    static const auto PrintAllCacheInfo = [](TObjArray *branches) {
       for (Int_t i = 0; i < branches->GetEntries(); i++) {
@@ -1208,11 +1208,11 @@ Bool_t TTreeCache::FillBuffer()
    if (!fIsLearning && fEntryCurrent <= entry && entry < fEntryNext) {
       // Check if all the basket in the cache have already be used and
       // thus we can reuse the cache.
-      Bool_t allUsed = kTRUE;
+      bool allUsed = true;
       for (Int_t i = 0; i < fNbranches; ++i) {
          TBranch *b = (TBranch *)fBranches->UncheckedAt(i);
          if (!b->fCacheInfo.AllUsed()) {
-            allUsed = kFALSE;
+            allUsed = false;
             break;
          }
       }
@@ -1229,16 +1229,16 @@ Bool_t TTreeCache::FillBuffer()
    // no point in retrying.   Note that this will also return false
    // during the training phase (fEntryNext is then set intentional to
    // the end of the training phase).
-   if (fEntryCurrent <= entry && entry < fEntryNext) return kFALSE;
+   if (fEntryCurrent <= entry && entry < fEntryNext) return false;
 
    // Triggered by the user, not the learning phase
    if (entry == -1)
       entry = 0;
 
-   Bool_t resetBranchInfo = kFALSE;
+   bool resetBranchInfo = false;
    if (entry < fCurrentClusterStart || fNextClusterStart <= entry) {
       // We are moving on to another set of clusters.
-      resetBranchInfo = kTRUE;
+      resetBranchInfo = true;
       if (showMore || gDebug > 6)
          Info("FillBuffer", "*** Will reset the branch information about baskets");
    } else if (showMore || gDebug > 6) {
@@ -1256,7 +1256,7 @@ Bool_t TTreeCache::FillBuffer()
       // There is no overlap between the cluster we found [entryCurrent, entryNext[
       // and the authorized range [fEntryMin, fEntryMax]
       // so we have nothing to do
-      return kFALSE;
+      return false;
    }
 
    // If there is overlap between the found cluster and the authorized range
@@ -1275,7 +1275,7 @@ Bool_t TTreeCache::FillBuffer()
    if ( fEnablePrefetching ) {
       if ( entry == fEntryMax ) {
          // We are at the end, no need to do anything else
-         return kFALSE;
+         return false;
       }
    }
 
@@ -1338,7 +1338,7 @@ Bool_t TTreeCache::FillBuffer()
    struct collectionInfo {
       Int_t fClusterStart{-1}; // First basket belonging to the current cluster
       Int_t fCurrent{-1};       // Currently visited basket
-      Bool_t fLoadedOnce{kFALSE};
+      bool fLoadedOnce{false};
 
       void Rewind() { fCurrent = (fClusterStart >= 0) ? fClusterStart : 0; }
    };
@@ -1353,11 +1353,11 @@ Bool_t TTreeCache::FillBuffer()
       prevNtot = ntotCurrentBuf;
       Long64_t lowestMaxEntry = fEntryMax; // The lowest maximum entry in the TTreeCache for each branch for each pass.
 
-      Bool_t reachedEnd = kFALSE;
-      Bool_t skippedFirst = kFALSE;
-      Bool_t oncePerBranch = kFALSE;
+      bool reachedEnd = false;
+      bool skippedFirst = false;
+      bool oncePerBranch = false;
       Int_t nDistinctLoad = 0;
-      Bool_t progress = kTRUE;
+      bool progress = true;
       enum ENarrow {
          kFull = 0,
          kNarrow = 1
@@ -1384,7 +1384,7 @@ Bool_t TTreeCache::FillBuffer()
          if (showMore || gDebug > 7)
             Info("CollectBaskets", "Called with pass=%d narrow=%d maxCollectEntry=%lld", pass, narrow, maxCollectEntry);
 
-         Bool_t filled = kFALSE;
+         bool filled = false;
          for (Int_t i = 0; i < fNbranches; ++i) {
             TBranch *b = (TBranch*)fBranches->UncheckedAt(i);
             if (b->GetDirectory()==nullptr || b->TestBit(TBranch::kDoNotProcess))
@@ -1548,7 +1548,7 @@ Bool_t TTreeCache::FillBuffer()
                            (ntotCurrentBuf + len), fBufferSizeMin, clusterIterations, minEntry);
                      }
                      fEntryNext = minEntry;
-                     filled = kTRUE;
+                     filled = true;
                      break;
                   } else {
                      if (pass == kStart || !cursor[i].fLoadedOnce) {
@@ -1564,7 +1564,7 @@ Bool_t TTreeCache::FillBuffer()
                                                  "%d pass %d will restart at %lld",
                                    (ntotCurrentBuf + len), fBufferSizeMin, clusterIterations, pass, fEntryNext);
                            }
-                           filled = kTRUE;
+                           filled = true;
                            break;
                         }
                      } else {
@@ -1578,7 +1578,7 @@ Bool_t TTreeCache::FillBuffer()
                                                  "%d pass %d will restart at %lld",
                                    (ntotCurrentBuf + len), fBufferSizeMin, clusterIterations, pass, fEntryNext);
                            }
-                           filled = kTRUE;
+                           filled = true;
                            break;
                         }
                      }
@@ -1597,7 +1597,7 @@ Bool_t TTreeCache::FillBuffer()
                   Info("FillBuffer", "*** Registering branch %d basket %d %s", i, j, b->GetName());
 
                if (!cursor[i].fLoadedOnce) {
-                  cursor[i].fLoadedOnce = kTRUE;
+                  cursor[i].fLoadedOnce = true;
                   ++nDistinctLoad;
                }
                if (R__unlikely(perfStats)) {
@@ -1668,7 +1668,7 @@ Bool_t TTreeCache::FillBuffer()
       };
 
       // First collect all the basket containing the request entry.
-      bool full = kFALSE;
+      bool full = false;
 
       full = CollectBaskets(kStart, kNarrow, fEntryNext);
 
@@ -1678,7 +1678,7 @@ Bool_t TTreeCache::FillBuffer()
          full = CollectBaskets(kStart, kFull, std::min(maxReadEntry, fEntryNext));
       }
 
-      resetBranchInfo = kFALSE; // Make sure the 2nd cluster iteration does not erase the info.
+      resetBranchInfo = false; // Make sure the 2nd cluster iteration does not erase the info.
 
       // Then fill out to the end of the cluster.
       if (!full && !fReverseRead) {
@@ -1733,7 +1733,7 @@ Bool_t TTreeCache::FillBuffer()
       fEntryNext = clusterIter.GetNextEntry();
       if (fEntryNext > fEntryMax) fEntryNext = fEntryMax;
       fNextClusterStart = fEntryNext;
-   } while (kTRUE);
+   } while (true);
 
    if (showMore || gDebug > 6) {
       Info("FillBuffer", "Mem ranges");
@@ -1787,11 +1787,11 @@ Bool_t TTreeCache::FillBuffer()
       if (!fIsLearning && fFirstTime){
          // First time we add autoFlush entries , after fFillTimes * autoFlush
          // only in reverse prefetching mode
-         fFirstTime = kFALSE;
+         fFirstTime = false;
       }
    }
-   fIsLearning = kFALSE;
-   return kTRUE;
+   fIsLearning = false;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1931,7 +1931,7 @@ Int_t TTreeCache::ReadBufferNormal(char *buf, Long64_t pos, Int_t len){
       return 1;
    }
 
-   static const auto recordMiss = [](TVirtualPerfStats *perfStats, TObjArray *branches, Bool_t bufferFilled,
+   static const auto recordMiss = [](TVirtualPerfStats *perfStats, TObjArray *branches, bool bufferFilled,
                                      Long64_t basketpos) {
       if (gDebug > 6)
          ::Info("TTreeCache::ReadBufferNormal", "Cache miss after an %s FillBuffer: pos=%lld",
@@ -1950,7 +1950,7 @@ Int_t TTreeCache::ReadBufferNormal(char *buf, Long64_t pos, Int_t len){
    };
 
    //not found in cache. Do we need to fill the cache?
-   Bool_t bufferFilled = FillBuffer();
+   bool bufferFilled = FillBuffer();
    if (bufferFilled) {
       Int_t res = TFileCacheRead::ReadBuffer(buf,pos,len);
 
@@ -2055,7 +2055,7 @@ void TTreeCache::ResetCache()
    TFileCacheRead::Prefetch(0,0);
 
    if (fEnablePrefetching) {
-      fFirstTime = kTRUE;
+      fFirstTime = true;
       TFileCacheRead::SecondPrefetch(0, 0);
    }
 }
@@ -2106,7 +2106,7 @@ void TTreeCache::SetEntryRange(Long64_t emin, Long64_t emax)
 {
    // This is called by TTreePlayer::Process in an automatic way...
    // don't restart it if the user has specified the branches.
-   Bool_t needLearningStart = (fEntryMin != emin) && fIsLearning && !fIsManual;
+   bool needLearningStart = (fEntryMin != emin) && fIsLearning && !fIsManual;
 
    fEntryMin  = emin;
    fEntryMax  = emax;
@@ -2168,11 +2168,11 @@ void TTreeCache::SetLearnPrefill(TTreeCache::EPrefillType type /* = kNoPrefill *
 
 void TTreeCache::StartLearningPhase()
 {
-   fIsLearning = kTRUE;
-   fIsManual = kFALSE;
+   fIsLearning = true;
+   fIsManual = false;
    fNbranches  = 0;
    if (fBrNames) fBrNames->Delete();
-   fIsTransferred = kFALSE;
+   fIsTransferred = false;
    fEntryCurrent = -1;
 }
 
@@ -2188,9 +2188,9 @@ void TTreeCache::StopLearningPhase()
    if (fIsLearning) {
       // This will force FillBuffer to read the buffers.
       fEntryNext = -1;
-      fIsLearning = kFALSE;
+      fIsLearning = false;
    }
-   fIsManual = kTRUE;
+   fIsManual = true;
 
    auto perfStats = GetTree()->GetPerfStats();
    if (perfStats)
@@ -2198,9 +2198,9 @@ void TTreeCache::StopLearningPhase()
 
    //fill the buffers only once during learning
    if (fEnablePrefetching && !fOneTime) {
-      fIsLearning = kTRUE;
+      fIsLearning = true;
       FillBuffer();
-      fOneTime = kTRUE;
+      fOneTime = true;
    }
 }
 
@@ -2222,7 +2222,7 @@ void TTreeCache::UpdateBranches(TTree *tree)
       fEntryNext = fEntryMin + fgLearnEntries;
    } else {
       // We learnt from a previous file.
-      fIsLearning = kFALSE;
+      fIsLearning = false;
       fEntryNext = -1;
    }
    fNbranches = 0;
@@ -2265,7 +2265,7 @@ void TTreeCache::LearnPrefill()
    // Return early if we are out of the requested range.
    if (entry < fEntryMin || entry > fEntryMax) return;
 
-   fLearnPrefilling = kTRUE;
+   fLearnPrefilling = true;
 
 
    // Force only the learn entries to be cached by temporarily setting min/max
@@ -2295,13 +2295,13 @@ void TTreeCache::LearnPrefill()
    // Add all branches to be cached. This also sets fIsManual, stops learning,
    // and makes fEntryNext = -1 (which forces a cache fill, which is good)
    AddBranch("*");
-   fIsManual = kFALSE; // AddBranch sets fIsManual, so we reset it
+   fIsManual = false; // AddBranch sets fIsManual, so we reset it
 
    // Now, fill the buffer with the learning phase entry range
    FillBuffer();
 
    // Leave everything the way we found it
-   fIsLearning = kTRUE;
+   fIsLearning = true;
    DropBranch("*"); // This doesn't work unless we're already learning
 
    // Restore entry values
@@ -2312,5 +2312,5 @@ void TTreeCache::LearnPrefill()
    fCurrentClusterStart = currentClusterStartOld;
    fNextClusterStart = nextClusterStartOld;
 
-   fLearnPrefilling = kFALSE;
+   fLearnPrefilling = false;
 }

--- a/tree/tree/src/TTreeCloner.cxx
+++ b/tree/tree/src/TTreeCloner.cxx
@@ -40,7 +40,7 @@ Class implementing or helping  the various TTree cloning method
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Bool_t TTreeCloner::CompareSeek::operator()(UInt_t i1, UInt_t i2)
+bool TTreeCloner::CompareSeek::operator()(UInt_t i1, UInt_t i2)
 {
    if (fObject->fBasketSeek[i1] ==  fObject->fBasketSeek[i2]) {
       if (fObject->fBasketEntry[i1] ==  fObject->fBasketEntry[i2]) {
@@ -53,7 +53,7 @@ Bool_t TTreeCloner::CompareSeek::operator()(UInt_t i1, UInt_t i2)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Bool_t TTreeCloner::CompareEntry::operator()(UInt_t i1, UInt_t i2)
+bool TTreeCloner::CompareEntry::operator()(UInt_t i1, UInt_t i2)
 {
    if (fObject->fBasketEntry[i1] ==  fObject->fBasketEntry[i2]) {
       return i1 < i2;
@@ -126,8 +126,8 @@ TTreeCloner::TTreeCloner(TTree *from, TDirectory *newdirectory, Option_t *method
 /// Constructor implementation.
 TTreeCloner::TTreeCloner(TTree *from, TTree *to, TDirectory *newdirectory, Option_t *method, UInt_t options) :
    fWarningMsg(),
-   fIsValid(kTRUE),
-   fNeedConversion(kFALSE),
+   fIsValid(true),
+   fNeedConversion(false),
    fOptions(options),
    fFromTree(from),
    fToTree(to),
@@ -172,7 +172,7 @@ TTreeCloner::TTreeCloner(TTree *from, TTree *to, TDirectory *newdirectory, Optio
       if (!(fOptions & kNoWarnings)) {
          Warning("TTreeCloner::TTreeCloner", "%s", fWarningMsg.Data());
       }
-      fIsValid = kFALSE;
+      fIsValid = false;
    }
    if (fToTree == nullptr) {
       fWarningMsg.Form("An output TTree is required (cloning %s).",
@@ -180,21 +180,21 @@ TTreeCloner::TTreeCloner(TTree *from, TTree *to, TDirectory *newdirectory, Optio
       if (!(fOptions & kNoWarnings)) {
          Warning("TTreeCloner::TTreeCloner", "%s", fWarningMsg.Data());
       }
-      fIsValid = kFALSE;
+      fIsValid = false;
    } else if (fToDirectory == nullptr) {
       fWarningMsg.Form("The output TTree (%s) must be associated with a directory.",
                        fToTree->GetName());
       if (!(fOptions & kNoWarnings)) {
          Warning("TTreeCloner::TTreeCloner", "%s", fWarningMsg.Data());
       }
-      fIsValid = kFALSE;
+      fIsValid = false;
    } else if (fToFile == nullptr) {
       fWarningMsg.Form("The output TTree (%s) must be associated with a directory (%s) that is in a file.",
                        fToTree->GetName(),fToDirectory->GetName());
       if (!(fOptions & kNoWarnings)) {
          Warning("TTreeCloner::TTreeCloner", "%s", fWarningMsg.Data());
       }
-      fIsValid = kFALSE;
+      fIsValid = false;
    } else if (! fToDirectory->IsWritable()) {
       if (fToDirectory==fToFile) {
          fWarningMsg.Form("The output TTree (%s) must be associated with a writable file (%s).",
@@ -206,7 +206,7 @@ TTreeCloner::TTreeCloner(TTree *from, TTree *to, TDirectory *newdirectory, Optio
       if (!(fOptions & kNoWarnings)) {
          Warning("TTreeCloner::TTreeCloner", "%s", fWarningMsg.Data());
       }
-      fIsValid = kFALSE;
+      fIsValid = false;
    }
 
    if (fIsValid && (!(fOptions & kNoFileCache))) {
@@ -219,10 +219,10 @@ TTreeCloner::TTreeCloner(TTree *from, TTree *to, TDirectory *newdirectory, Optio
 ////////////////////////////////////////////////////////////////////////////////
 /// Execute the cloning.
 
-Bool_t TTreeCloner::Exec()
+bool TTreeCloner::Exec()
 {
    if (!IsValid()) {
-      return kFALSE;
+      return false;
    }
    CreateCache();
    ImportClusterRanges();
@@ -237,7 +237,7 @@ Bool_t TTreeCloner::Exec()
    if (IsInPlace())
       fToTree->SetDirectory(fToDirectory);
 
-   return kTRUE;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -296,8 +296,8 @@ UInt_t TTreeCloner::CollectBranches(TBranch *from, TBranch *to) {
          if (!(fOptions & kNoWarnings)) {
             Warning("TTreeCloner::CollectBranches", "%s", fWarningMsg.Data());
          }
-         fNeedConversion = kTRUE;
-         fIsValid = kFALSE;
+         fNeedConversion = true;
+         fIsValid = false;
          return 0;
       }
       if (((TBranchElement*) from)->GetStreamerType() != ((TBranchElement*) to)->GetStreamerType()) {
@@ -306,7 +306,7 @@ UInt_t TTreeCloner::CollectBranches(TBranch *from, TBranch *to) {
          if (!(fOptions & kNoWarnings)) {
             Warning("TTreeCloner::CollectBranches", "%s", fWarningMsg.Data());
          }
-         fIsValid = kFALSE;
+         fIsValid = false;
          return 0;
       }
       TBranchElement *fromelem = (TBranchElement*) from;
@@ -322,7 +322,7 @@ UInt_t TTreeCloner::CollectBranches(TBranch *from, TBranch *to) {
          if (!(fOptions & kNoWarnings)) {
             Error("TTreeCloner::CollectBranches", "%s", fWarningMsg.Data());
          }
-         fIsValid = kFALSE;
+         fIsValid = false;
          return 0;
       }
       for (Int_t i=0;i<nb;i++)  {
@@ -336,8 +336,8 @@ UInt_t TTreeCloner::CollectBranches(TBranch *from, TBranch *to) {
             if (! (fOptions & kNoWarnings) ) {
                Warning("TTreeCloner::CollectBranches", "%s", fWarningMsg.Data());
             }
-            fIsValid = kFALSE;
-            fNeedConversion = kTRUE;
+            fIsValid = false;
+            fNeedConversion = true;
             return 0;
          }
          toleaf->IncludeRange( fromleaf );
@@ -407,7 +407,7 @@ UInt_t TTreeCloner::CollectBranches(TObjArray *from, TObjArray *to)
                if (!(fOptions & kNoWarnings)) {
                   Error("TTreeCloner::CollectBranches", "%s", fWarningMsg.Data());
                }
-               fIsValid = kFALSE;
+               fIsValid = false;
             }
          } else {
             fWarningMsg.Form("One of the export sub-branches (%s) is not present in the import TTree.",
@@ -415,7 +415,7 @@ UInt_t TTreeCloner::CollectBranches(TObjArray *from, TObjArray *to)
             if (!(fOptions & kNoWarnings)) {
                Error("TTreeCloner::CollectBranches", "%s", fWarningMsg.Data());
             }
-            fIsValid = kFALSE;
+            fIsValid = false;
          }
       }
       ++ti;
@@ -524,7 +524,7 @@ void TTreeCloner::CopyMemoryBaskets()
       if (basket && basket->GetNevBuf()) {
          basket = (TBasket*)basket->Clone();
          basket->SetBranch(to);
-         to->AddBasket(*basket, kFALSE, fToStartEntries+from->GetBasketEntry()[from->GetWriteBasket()]);
+         to->AddBasket(*basket, false, fToStartEntries+from->GetBasketEntry()[from->GetWriteBasket()]);
       } else {
          to->AddLastBasket(  fToStartEntries+from->GetBasketEntry()[from->GetWriteBasket()] );
       }
@@ -561,9 +561,9 @@ void TTreeCloner::CopyProcessIds()
          UShort_t out = 0;
          TObjArray *pids = tofile->GetListOfProcessIDs();
          Int_t npids = tofile->GetNProcessIDs();
-         Bool_t wasIn = kFALSE;
+         bool wasIn = false;
          for (Int_t i=0;i<npids;i++) {
-            if (pids->At(i) == pid) {out = (UShort_t)i; wasIn = kTRUE; break;}
+            if (pids->At(i) == pid) {out = (UShort_t)i; wasIn = true; break;}
          }
 
          if (!wasIn) {
@@ -763,13 +763,13 @@ void TTreeCloner::WriteBaskets()
          basket->LoadBasketBuffers(pos,len,fromfile,fFromTree);
          basket->IncrementPidOffset(fPidOffset);
          basket->CopyTo(tofile);
-         to->AddBasket(*basket,kTRUE,fToStartEntries + from->GetBasketEntry()[index]);
+         to->AddBasket(*basket,true,fToStartEntries + from->GetBasketEntry()[index]);
       } else {
          TBasket *frombasket = from->GetBasket( index );
          if (frombasket && frombasket->GetNevBuf()>0) {
             TBasket *tobasket = (TBasket*)frombasket->Clone();
             tobasket->SetBranch(to);
-            to->AddBasket(*tobasket, kFALSE, fToStartEntries+from->GetBasketEntry()[index]);
+            to->AddBasket(*tobasket, false, fToStartEntries+from->GetBasketEntry()[index]);
             to->FlushOneBasket(to->GetWriteBasket());
          }
       }

--- a/tree/tree/src/TTreeResult.cxx
+++ b/tree/tree/src/TTreeResult.cxx
@@ -78,17 +78,17 @@ void TTreeResult::Close(Option_t *)
 ////////////////////////////////////////////////////////////////////////////////
 /// Check if result set is open and field index within range.
 
-Bool_t TTreeResult::IsValid(Int_t field)
+bool TTreeResult::IsValid(Int_t field)
 {
    if (!fResult) {
       Error("IsValid", "result set closed");
-      return kFALSE;
+      return false;
    }
    if (field < 0 || field >= GetFieldCount()) {
       Error("IsValid", "field index out of bounds");
-      return kFALSE;
+      return false;
    }
-   return kTRUE;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/tree/src/TTreeRow.cxx
+++ b/tree/tree/src/TTreeRow.cxx
@@ -108,17 +108,17 @@ void TTreeRow::Close(Option_t *)
 ////////////////////////////////////////////////////////////////////////////////
 /// Check if row is open and field index within range.
 
-Bool_t TTreeRow::IsValid(Int_t field)
+bool TTreeRow::IsValid(Int_t field)
 {
    if (!fFields && !fOriginal) {
       Error("IsValid", "row closed");
-      return kFALSE;
+      return false;
    }
    if (field < 0 || field >= fColumnCount) {
       Error("IsValid", "field index out of bounds");
-      return kFALSE;
+      return false;
    }
-   return kTRUE;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -185,13 +185,13 @@ void TTreeRow::Streamer(TBuffer &R__b)
       R__b.ReadFastArray(fRow,nch);
       R__b.CheckByteCount(R__s, R__c, TTreeRow::IsA());
    } else {
-      R__c = R__b.WriteVersion(TTreeRow::Class(),kTRUE);
+      R__c = R__b.WriteVersion(TTreeRow::Class(),true);
       TSQLRow::Streamer(R__b);
       R__b << fColumnCount;
       R__b.WriteFastArray(fFields,fColumnCount);
       Int_t nch = fFields ? fFields[fColumnCount-1] : 0;
       R__b << nch;
       R__b.WriteFastArray(fRow,nch);
-      R__b.SetByteCount(R__c,kTRUE);
+      R__b.SetByteCount(R__c,true);
    }
 }

--- a/tree/tree/src/TTreeSQL.cxx
+++ b/tree/tree/src/TTreeSQL.cxx
@@ -54,7 +54,7 @@ TTreeSQL::TTreeSQL(TSQLServer *server, TString DB, const TString& table) :
    fTable(table.Data()),
    fResult(nullptr), fRow(nullptr),
    fServer(server),
-   fBranchChecked(kFALSE),
+   fBranchChecked(false),
    fTableInfo(nullptr)
 {
    fCurrentEntry = -1;
@@ -212,10 +212,10 @@ void TTreeSQL::CheckBasket(TBranch *branch)
 /// Check if the table has a column corresponding the branch
 /// and that the resultset are properly setup
 
-Bool_t TTreeSQL::CheckBranch(TBranch * tb)
+bool TTreeSQL::CheckBranch(TBranch * tb)
 {
    if (fServer==nullptr) {
-      return kFALSE;
+      return false;
    }
    TString leafName;
    TLeaf *leaf;
@@ -223,15 +223,15 @@ Bool_t TTreeSQL::CheckBranch(TBranch * tb)
    TString str = "";
    TString typeName = "";
 
-   if (!tb) return kFALSE;
+   if (!tb) return false;
 
    TBasketSQL *basket = (TBasketSQL *)tb->GetBasket(0);
-   if (!basket) return kFALSE;
+   if (!basket) return false;
 
    TSQLResult *rs = basket->GetResultSet();
    if (!rs) {
       Error("CheckBranch","%s has basket but no resultset yet",tb->GetName());
-      return kFALSE;
+      return false;
    }
 
    nl = tb->GetNleaves();
@@ -247,28 +247,28 @@ Bool_t TTreeSQL::CheckBranch(TBranch * tb)
       str += leafName;
 
       for (int i=0; i< rs->GetFieldCount(); ++i) {
-         if (str.CompareTo(rs->GetFieldName(i),TString::kIgnoreCase) == 0) return kTRUE;
+         if (str.CompareTo(rs->GetFieldName(i),TString::kIgnoreCase) == 0) return true;
       }
       // We assume that if ONE of the leaf is in the table, then ALL the leaf are in
       // the table.
       // TODO: this assumption is harmful if user changes branch structure while keep its name
       CreateBranch(str, typeName);
    }
-   return kFALSE;
+   return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Check the table exist in the database
 
-Bool_t TTreeSQL::CheckTable(const TString &table) const
+bool TTreeSQL::CheckTable(const TString &table) const
 {
-   if (fServer==nullptr) return kFALSE;
+   if (fServer==nullptr) return false;
    TSQLResult * tables = fServer->GetTables(fDB.Data(),table);
-   if (!tables) return kFALSE;
+   if (!tables) return false;
    TSQLRow * row = nullptr;
    while( (row = tables->Next()) ) {
       if(table.CompareTo(row->GetField(0),TString::kIgnoreCase)==0){
-         return kTRUE;
+         return true;
       }
    }
    // The table is a not a permanent table, let's see if it is a 'temporary' table
@@ -277,11 +277,11 @@ Bool_t TTreeSQL::CheckTable(const TString &table) const
    TSQLResult *res = fServer->GetColumns(fDB.Data(),table);
    if (res) {
       delete res;
-      return kTRUE;
+      return true;
    }
    gErrorIgnoreLevel = before;
 
-   return kFALSE;
+   return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -485,7 +485,7 @@ void TTreeSQL::CreateBranches()
 ////////////////////////////////////////////////////////////////////////////////
 /// Create the database table corresponding to this TTree.
 
-Bool_t TTreeSQL::CreateTable(const TString &table)
+bool TTreeSQL::CreateTable(const TString &table)
 {
    if (fServer==nullptr) {
       Error("CreateTable","No TSQLServer specified");
@@ -595,7 +595,7 @@ Int_t TTreeSQL::Fill()
             Error("Fill","CheckBranch for %s failed",branch->GetName());
          }
       }
-      fBranchChecked = kTRUE;
+      fBranchChecked = true;
    }
    ResetQuery();
 
@@ -757,7 +757,7 @@ Long64_t TTreeSQL::PrepEntry(Long64_t entry)
       fCurrentEntry = -1;
    }
 
-   Bool_t reset = false;
+   bool reset = false;
    while ( fResult && fCurrentEntry < entry ) {
       ++fCurrentEntry;
       delete fRow;

--- a/tree/tree/test/BulkApiMultiple.cxx
+++ b/tree/tree/test/BulkApiMultiple.cxx
@@ -46,13 +46,13 @@ protected:
       TBranch *branch7 = tree->Branch("myLongLong", &ll, 320000, 1);
       TBranch *branch8 = tree->Branch("myChar", &c, 320000, 1);
 
-      branch2->SetAutoDelete(kFALSE);
-      branch3->SetAutoDelete(kFALSE);
-      branch4->SetAutoDelete(kFALSE);
-      branch5->SetAutoDelete(kFALSE);
-      branch6->SetAutoDelete(kFALSE);
-      branch7->SetAutoDelete(kFALSE);
-      branch8->SetAutoDelete(kFALSE);
+      branch2->SetAutoDelete(false);
+      branch3->SetAutoDelete(false);
+      branch4->SetAutoDelete(false);
+      branch5->SetAutoDelete(false);
+      branch6->SetAutoDelete(false);
+      branch7->SetAutoDelete(false);
+      branch8->SetAutoDelete(false);
 
       for (Long64_t ev = 0; ev < fEventCount; ev++) {
          tree->Fill();

--- a/tree/tree/test/BulkApiSillyStruct.cxx
+++ b/tree/tree/test/BulkApiSillyStruct.cxx
@@ -37,7 +37,7 @@ protected:
 
       SillyStruct ss;
       TBranch *branch = tree->Branch("myEvent", &ss, 32000, 99);
-      branch->SetAutoDelete(kFALSE);
+      branch->SetAutoDelete(false);
 
       Int_t nb = 0;
       for (Long64_t ev = 0; ev < fEventCount; ev++) {

--- a/tree/tree/test/BulkApiVarLength.cxx
+++ b/tree/tree/test/BulkApiVarLength.cxx
@@ -44,9 +44,9 @@ protected:
       auto branch2 = tree->Branch("f", &f, "f[myLen]/F", 32000);
       auto branch3 = tree->Branch("d", &d, "d[myLen]/D", 32000);
       auto branch4 = tree->Branch("i", &i, "i[myLen]/I", 32000);
-      branch2->SetAutoDelete(kFALSE);
-      branch3->SetAutoDelete(kFALSE);
-      branch4->SetAutoDelete(kFALSE);
+      branch2->SetAutoDelete(false);
+      branch3->SetAutoDelete(false);
+      branch4->SetAutoDelete(false);
       for (Long64_t ev = 1; ev < fEventCount + 1; ev++) {
 
          for (Int_t idx = 0; idx < (ev % 10); idx++) {

--- a/tree/tree/test/TBasket.cxx
+++ b/tree/tree/test/TBasket.cxx
@@ -63,7 +63,7 @@ TEST(TBasket, IOBits)
    ASSERT_NE(eIOBits, nullptr);
 
    Int_t supported = static_cast<Int_t>(TBasket::EIOBits::kSupported);
-   Bool_t foundSupported = false;
+   bool foundSupported = false;
    for (auto constant : ROOT::Detail::TRangeStaticCast<TEnumConstant>(eIOBits->GetConstants())) {
 
       if (!strcmp(constant->GetName(), "kSupported")) {
@@ -79,7 +79,7 @@ TEST(TBasket, IOBits)
    TEnum *eUnsupportedIOBits = (TEnum *)cl->GetListOfEnums()->FindObject("EUnsupportedIOBits");
    ASSERT_NE(eUnsupportedIOBits, nullptr);
    Int_t unsupported = static_cast<Int_t>(TBasket::EUnsupportedIOBits::kUnsupported);
-   Bool_t foundUnsupported = false;
+   bool foundUnsupported = false;
    for (auto constant : ROOT::Detail::TRangeStaticCast<TEnumConstant>(eUnsupportedIOBits->GetConstants())) {
 
       if (!strcmp(constant->GetName(), "kUnsupported")) {
@@ -406,8 +406,8 @@ TEST(TBasket, TestSettingIOBits)
 
    offset = cl->GetDataMemberOffset("fReadEntryOffset");
    ASSERT_GT(offset, 0);
-   Bool_t *readEntryOffset = reinterpret_cast<Bool_t *>(reinterpret_cast<char *>(basket) + offset);
-   EXPECT_EQ(*readEntryOffset, kFALSE);
-   readEntryOffset = reinterpret_cast<Bool_t *>(reinterpret_cast<char *>(basket2) + offset);
-   EXPECT_EQ(*readEntryOffset, kTRUE);
+   bool *readEntryOffset = reinterpret_cast<bool *>(reinterpret_cast<char *>(basket) + offset);
+   EXPECT_EQ(*readEntryOffset, false);
+   readEntryOffset = reinterpret_cast<bool *>(reinterpret_cast<char *>(basket2) + offset);
+   EXPECT_EQ(*readEntryOffset, true);
 }

--- a/tree/tree/test/TOffsetGeneration.cxx
+++ b/tree/tree/test/TOffsetGeneration.cxx
@@ -119,9 +119,9 @@ protected:
       sample2.i = 1;
       sample2.d = d;
       auto br = tree->Branch("sample", &sample2, 32*1024, 99);
-      br->SetAutoDelete(kFALSE);
+      br->SetAutoDelete(false);
       auto br2 = tree2->Branch("sample", &sample2, 32*1024, 99);
-      br2->SetAutoDelete(kFALSE);
+      br2->SetAutoDelete(false);
       tree->Branch("elem", &elem, "elem/I");
       tree->Branch("sample2", &sample, "sample2[elem]/I");
 

--- a/tree/treeplayer/inc/ROOT/TTreeReaderValueFast.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeReaderValueFast.hxx
@@ -240,26 +240,26 @@ class TTreeReaderValueFast<UInt_t> final : public ROOT::Experimental::Internal::
 };
 
 template <>
-class TTreeReaderValueFast<Bool_t> final : public ROOT::Experimental::Internal::TTreeReaderValueFastBase {
+class TTreeReaderValueFast<bool> final : public ROOT::Experimental::Internal::TTreeReaderValueFastBase {
 
    public:
 
       TTreeReaderValueFast(TTreeReaderFast& tr, const std::string &branchname) :
             TTreeReaderValueFastBase(&tr, branchname) {}
 
-      Bool_t* Get() {
-         return Deserialize(reinterpret_cast<char *>(reinterpret_cast<Bool_t*>(fBuffer.GetCurrent()) + fEvtIndex));
+      bool* Get() {
+         return Deserialize(reinterpret_cast<char *>(reinterpret_cast<bool*>(fBuffer.GetCurrent()) + fEvtIndex));
       }
-      Bool_t* operator->() { return Get(); }
-      Bool_t& operator*() { return *Get(); }
+      bool* operator->() { return Get(); }
+      bool& operator*() { return *Get(); }
 
    protected:
       const char *GetTypeName() override {return "unsigned integer";}
       const char *BranchTypeName() override {return "unsigned integer";}
-      UInt_t GetSize() override {return sizeof(Bool_t);}
-      Bool_t* Deserialize(char *input) {frombuf(input, &fTmp); return &fTmp;}
+      UInt_t GetSize() override {return sizeof(bool);}
+      bool* Deserialize(char *input) {frombuf(input, &fTmp); return &fTmp;}
 
-      Bool_t fTmp;
+      bool fTmp;
 };
 
 }  // Experimental

--- a/tree/treeplayer/inc/TBranchProxy.h
+++ b/tree/treeplayer/inc/TBranchProxy.h
@@ -75,11 +75,11 @@ namespace Detail {
    protected:
       Internal::TBranchProxyDirector *fDirector; // contain pointer to TTree and entry to be read
 
-      Bool_t        fInitialized : 1;
-      const Bool_t  fIsMember : 1;    // true if we proxy an unsplit data member
-      Bool_t        fIsClone : 1;     // true if we proxy the inside of a TClonesArray
-      Bool_t        fIsaPointer : 1;  // true if we proxy a data member of pointer type
-      Bool_t        fHasLeafCount : 1;// true if we proxy a variable size leaf of a leaflist
+      bool          fInitialized : 1;
+      const bool    fIsMember : 1;    // true if we proxy an unsplit data member
+      bool          fIsClone : 1;     // true if we proxy the inside of a TClonesArray
+      bool          fIsaPointer : 1;  // true if we proxy a data member of pointer type
+      bool          fHasLeafCount : 1;// true if we proxy a variable size leaf of a leaflist
 
       const TString fBranchName;  // name of the branch to read
       TBranchProxy *fParent;      // Proxy to a parent object
@@ -123,23 +123,23 @@ namespace Detail {
 
       void Reset();
 
-      Bool_t Notify() {
+      bool Notify() {
          fRead = -1;
          return Setup();
       }
 
-      Bool_t Setup();
+      bool Setup();
 
-      Bool_t IsInitialized() {
+      bool IsInitialized() {
          return fInitialized;
          // return fLastTree && fCurrentTreeNumber == fDirector->GetTree()->GetTreeNumber() && fLastTree == fDirector->GetTree();
       }
 
-      Bool_t IsaPointer() const {
+      bool IsaPointer() const {
          return fIsaPointer;
       }
 
-      Bool_t Read() {
+      bool Read() {
          if (R__unlikely(fDirector == nullptr)) return false;
 
          auto treeEntry = fDirector->GetReadEntry();
@@ -147,10 +147,10 @@ namespace Detail {
             if (!IsInitialized()) {
                if (!Setup()) {
                   ::Error("TBranchProxy::Read","%s",Form("Unable to initialize %s\n",fBranchName.Data()));
-                  return kFALSE;
+                  return false;
                }
             }
-            Bool_t result = kTRUE;
+            bool result = true;
             if (fParent) {
                result = fParent->Read();
             } else {
@@ -226,14 +226,14 @@ private:
          return EReadType::kReadNoParentNoBranchCountNoCollection;
       }
 
-      Bool_t ReadNoDirector() {
+      bool ReadNoDirector() {
          return false;
       }
 
-      Bool_t ReadParentNoCollection() {
+      bool ReadParentNoCollection() {
          auto treeEntry = fDirector->GetReadEntry();
          if (treeEntry != fRead) {
-            const Bool_t result = fParent->Read();
+            const bool result = fParent->Read();
             fRead = treeEntry;
             return result;
          } else {
@@ -241,49 +241,10 @@ private:
          }
       }
 
-      Bool_t ReadParentCollectionNoPointer() {
+      bool ReadParentCollectionNoPointer() {
          auto treeEntry = fDirector->GetReadEntry();
          if (treeEntry != fRead) {
-            const Bool_t result = fParent->Read();
-            fRead = treeEntry;
-            fCollection->PopProxy(); // works even if no proxy env object was set.
-            fCollection->PushProxy( fWhere );
-            return result;
-         } else {
-            return IsInitialized();
-         }
-      }
-
-      Bool_t ReadParentCollectionPointer() {
-         auto treeEntry = fDirector->GetReadEntry();
-         if (treeEntry != fRead) {
-            const Bool_t result = fParent->Read();
-            fRead = treeEntry;
-            fCollection->PopProxy(); // works even if no proxy env object was set.
-            fCollection->PushProxy( *(void**)fWhere );
-            return result;
-         } else {
-            return IsInitialized();
-         }
-      }
-
-      Bool_t ReadNoParentNoBranchCountCollectionPointer() {
-         auto treeEntry = fDirector->GetReadEntry();
-         if (treeEntry != fRead) {
-            Bool_t result = (-1 != fBranch->GetEntry(treeEntry));
-            fRead = treeEntry;
-            fCollection->PopProxy(); // works even if no proxy env object was set.
-            fCollection->PushProxy( *(void**)fWhere );
-            return result;
-         } else {
-            return IsInitialized();
-         }
-      }
-
-      Bool_t ReadNoParentNoBranchCountCollectionNoPointer() {
-         auto treeEntry = fDirector->GetReadEntry();
-         if (treeEntry != fRead) {
-            Bool_t result = (-1 != fBranch->GetEntry(treeEntry));
+            const bool result = fParent->Read();
             fRead = treeEntry;
             fCollection->PopProxy(); // works even if no proxy env object was set.
             fCollection->PushProxy( fWhere );
@@ -293,10 +254,49 @@ private:
          }
       }
 
-      Bool_t ReadNoParentNoBranchCountNoCollection() {
+      bool ReadParentCollectionPointer() {
          auto treeEntry = fDirector->GetReadEntry();
          if (treeEntry != fRead) {
-            Bool_t result = (-1 != fBranch->GetEntry(treeEntry));
+            const bool result = fParent->Read();
+            fRead = treeEntry;
+            fCollection->PopProxy(); // works even if no proxy env object was set.
+            fCollection->PushProxy( *(void**)fWhere );
+            return result;
+         } else {
+            return IsInitialized();
+         }
+      }
+
+      bool ReadNoParentNoBranchCountCollectionPointer() {
+         auto treeEntry = fDirector->GetReadEntry();
+         if (treeEntry != fRead) {
+            bool result = (-1 != fBranch->GetEntry(treeEntry));
+            fRead = treeEntry;
+            fCollection->PopProxy(); // works even if no proxy env object was set.
+            fCollection->PushProxy( *(void**)fWhere );
+            return result;
+         } else {
+            return IsInitialized();
+         }
+      }
+
+      bool ReadNoParentNoBranchCountCollectionNoPointer() {
+         auto treeEntry = fDirector->GetReadEntry();
+         if (treeEntry != fRead) {
+            bool result = (-1 != fBranch->GetEntry(treeEntry));
+            fRead = treeEntry;
+            fCollection->PopProxy(); // works even if no proxy env object was set.
+            fCollection->PushProxy( fWhere );
+            return result;
+         } else {
+            return IsInitialized();
+         }
+      }
+
+      bool ReadNoParentNoBranchCountNoCollection() {
+         auto treeEntry = fDirector->GetReadEntry();
+         if (treeEntry != fRead) {
+            bool result = (-1 != fBranch->GetEntry(treeEntry));
             fRead = treeEntry;
             return result;
          } else {
@@ -304,10 +304,10 @@ private:
          }
       }
 
-      Bool_t ReadNoParentBranchCountCollectionPointer() {
+      bool ReadNoParentBranchCountCollectionPointer() {
          auto treeEntry = fDirector->GetReadEntry();
          if (treeEntry != fRead) {
-            Bool_t result = (-1 != fBranchCount->GetEntry(treeEntry));
+            bool result = (-1 != fBranchCount->GetEntry(treeEntry));
             result &= (-1 != fBranch->GetEntry(treeEntry));
             fRead = treeEntry;
             fCollection->PopProxy(); // works even if no proxy env object was set.
@@ -318,10 +318,10 @@ private:
          }
       }
 
-      Bool_t ReadNoParentBranchCountCollectionNoPointer() {
+      bool ReadNoParentBranchCountCollectionNoPointer() {
          auto treeEntry = fDirector->GetReadEntry();
          if (treeEntry != fRead) {
-            Bool_t result = (-1 != fBranchCount->GetEntry(treeEntry));
+            bool result = (-1 != fBranchCount->GetEntry(treeEntry));
             result &= (-1 != fBranch->GetEntry(treeEntry));
             fRead = treeEntry;
             fCollection->PopProxy(); // works even if no proxy env object was set.
@@ -332,10 +332,10 @@ private:
          }
       }
 
-      Bool_t ReadNoParentBranchCountNoCollection() {
+      bool ReadNoParentBranchCountNoCollection() {
          auto treeEntry = fDirector->GetReadEntry();
          if (treeEntry != fRead) {
-            Bool_t result = (-1 != fBranchCount->GetEntry(treeEntry));
+            bool result = (-1 != fBranchCount->GetEntry(treeEntry));
             result &= (-1 != fBranch->GetEntry(treeEntry));
             fRead = treeEntry;
             return result;
@@ -346,7 +346,7 @@ private:
 
 public:
 
-      Bool_t ReadEntries() {
+      bool ReadEntries() {
          if (R__unlikely(fDirector == nullptr)) return false;
 
          auto treeEntry = fDirector->GetReadEntry();
@@ -886,7 +886,7 @@ namespace Internal {
    typedef TImpProxy<Long64_t>   TLong64Proxy;   // Concrete Implementation of the branch proxy around the data members which are long long
    typedef TImpProxy<Short_t>    TShortProxy;    // Concrete Implementation of the branch proxy around the data members which are short
    typedef TImpProxy<Char_t>     TCharProxy;     // Concrete Implementation of the branch proxy around the data members which are char
-   typedef TImpProxy<Bool_t>     TBoolProxy;     // Concrete Implementation of the branch proxy around the data members which are bool
+   typedef TImpProxy<bool>     TBoolProxy;     // Concrete Implementation of the branch proxy around the data members which are bool
 
    typedef TArrayProxy<TArrayType<Double_t> >   TArrayDoubleProxy;   // Concrete Implementation of the branch proxy around the data members which are array of double
    typedef TArrayProxy<TArrayType<Double32_t> > TArrayDouble32Proxy; // Concrete Implementation of the branch proxy around the data members which are array of double32
@@ -902,7 +902,7 @@ namespace Internal {
    typedef TArrayProxy<TArrayType<Long64_t> >   TArrayLong64Proxy;   // Concrete Implementation of the branch proxy around the data members which are array of long long
    typedef TArrayProxy<TArrayType<UShort_t> >   TArrayShortProxy;    // Concrete Implementation of the branch proxy around the data members which are array of short
    //specialized ! typedef TArrayProxy<TArrayType<Char_t> >  TArrayCharProxy; // Concrete Implementation of the branch proxy around the data members which are array of char
-   typedef TArrayProxy<TArrayType<Bool_t> >     TArrayBoolProxy;     // Concrete Implementation of the branch proxy around the data members which are array of bool
+   typedef TArrayProxy<TArrayType<bool> >     TArrayBoolProxy;     // Concrete Implementation of the branch proxy around the data members which are array of bool
 
    typedef TClaImpProxy<Double_t>   TClaDoubleProxy;   // Concrete Implementation of the branch proxy around the data members of object in TClonesArray which are double
    typedef TClaImpProxy<Double32_t> TClaDouble32Proxy; // Concrete Implementation of the branch proxy around the data members of object in TClonesArray which are double32
@@ -918,7 +918,7 @@ namespace Internal {
    typedef TClaImpProxy<Long64_t>   TClaLong64Proxy;   // Concrete Implementation of the branch proxy around the data members of object in TClonesArray which are long long
    typedef TClaImpProxy<Short_t>    TClaShortProxy;    // Concrete Implementation of the branch proxy around the data members of object in TClonesArray which are short
    typedef TClaImpProxy<Char_t>     TClaCharProxy;     // Concrete Implementation of the branch proxy around the data members of object in TClonesArray which are char
-   typedef TClaImpProxy<Bool_t>     TClaBoolProxy;     // Concrete Implementation of the branch proxy around the data members of object in TClonesArray which are bool
+   typedef TClaImpProxy<bool>     TClaBoolProxy;     // Concrete Implementation of the branch proxy around the data members of object in TClonesArray which are bool
 
    typedef TClaArrayProxy<TArrayType<Double_t> >    TClaArrayDoubleProxy;   // Concrete Implementation of the branch proxy around the data members of object in TClonesArray which are array of double
    typedef TClaArrayProxy<TArrayType<Double32_t> >  TClaArrayDouble32Proxy; // Concrete Implementation of the branch proxy around the data members of object in TClonesArray which are array of double32
@@ -934,7 +934,7 @@ namespace Internal {
    typedef TClaArrayProxy<TArrayType<Long64_t> >    TClaArrayLong64Proxy;   // Concrete Implementation of the branch proxy around the data members of object in TClonesArray which are array of long long
    typedef TClaArrayProxy<TArrayType<UShort_t> >    TClaArrayShortProxy;    // Concrete Implementation of the branch proxy around the data members of object in TClonesArray which are array of short
    typedef TClaArrayProxy<TArrayType<Char_t> >      TClaArrayCharProxy;     // Concrete Implementation of the branch proxy around the data members of object in TClonesArray which are array of char
-   typedef TClaArrayProxy<TArrayType<Bool_t> >      TClaArrayBoolProxy;     // Concrete Implementation of the branch proxy around the data members of object in TClonesArray which are array of bool
+   typedef TClaArrayProxy<TArrayType<bool> >      TClaArrayBoolProxy;     // Concrete Implementation of the branch proxy around the data members of object in TClonesArray which are array of bool
    //specialized ! typedef TClaArrayProxy<TArrayType<Char_t> >  TClaArrayCharProxy;
 
    typedef TStlImpProxy<Double_t>   TStlDoubleProxy;   // Concrete Implementation of the branch proxy around an stl container of double
@@ -951,7 +951,7 @@ namespace Internal {
    typedef TStlImpProxy<Long64_t>   TStlLong64Proxy;   // Concrete Implementation of the branch proxy around an stl container of long long
    typedef TStlImpProxy<Short_t>    TStlShortProxy;    // Concrete Implementation of the branch proxy around an stl container of short
    typedef TStlImpProxy<Char_t>     TStlCharProxy;     // Concrete Implementation of the branch proxy around an stl container of char
-   typedef TStlImpProxy<Bool_t>     TStlBoolProxy;     // Concrete Implementation of the branch proxy around an stl container of bool
+   typedef TStlImpProxy<bool>     TStlBoolProxy;     // Concrete Implementation of the branch proxy around an stl container of bool
 
    typedef TStlArrayProxy<TArrayType<Double_t> >    TStlArrayDoubleProxy;   // Concrete Implementation of the branch proxy around an stl container of double
    typedef TStlArrayProxy<TArrayType<Double32_t> >  TStlArrayDouble32Proxy; // Concrete Implementation of the branch proxy around an stl container of double32
@@ -967,7 +967,7 @@ namespace Internal {
    typedef TStlArrayProxy<TArrayType<Long64_t> >    TStlArrayLong64Proxy;   // Concrete Implementation of the branch proxy around an stl container of long long
    typedef TStlArrayProxy<TArrayType<UShort_t> >    TStlArrayShortProxy;    // Concrete Implementation of the branch proxy around an stl container of UShort_t
    typedef TStlArrayProxy<TArrayType<Char_t> >      TStlArrayCharProxy;     // Concrete Implementation of the branch proxy around an stl container of char
-   typedef TStlArrayProxy<TArrayType<Bool_t> >      TStlArrayBoolProxy;     // Concrete Implementation of the branch proxy around an stl container of bool
+   typedef TStlArrayProxy<TArrayType<bool> >      TStlArrayBoolProxy;     // Concrete Implementation of the branch proxy around an stl container of bool
 
 } // namespace Internal
 

--- a/tree/treeplayer/inc/TBranchProxyClassDescriptor.h
+++ b/tree/treeplayer/inc/TBranchProxyClassDescriptor.h
@@ -32,7 +32,7 @@ namespace Internal {
       TList          fListOfBaseProxies;
       ELocation      fIsClones;      // 0 for the general case, 1 when this a split clases inside a TClonesArray, 2 when this is a split classes inside an STL container.
       TString        fContainerName; // Name of the container if any
-      Bool_t         fIsLeafList;    // true if the branch was constructed from a leaf list.
+      bool           fIsLeafList;    // true if the branch was constructed from a leaf list.
       UInt_t         fSplitLevel;
 
       TString        fRawSymbol;
@@ -66,13 +66,13 @@ namespace Internal {
 
       UInt_t GetSplitLevel() const;
 
-      virtual Bool_t IsEquivalent(const TBranchProxyClassDescriptor* other);
+      virtual bool IsEquivalent(const TBranchProxyClassDescriptor* other);
 
-      void AddDescriptor(TBranchProxyDescriptor *desc, Bool_t isBase);
-      Bool_t IsLoaded() const;
-      static Bool_t IsLoaded(const char*);
-      Bool_t IsClones() const;
-      Bool_t IsSTL() const;
+      void AddDescriptor(TBranchProxyDescriptor *desc, bool isBase);
+      bool IsLoaded() const;
+      static bool IsLoaded(const char*);
+      bool IsClones() const;
+      bool IsSTL() const;
       ELocation GetIsClones() const;
       TString GetContainerName() const;
 

--- a/tree/treeplayer/inc/TBranchProxyDescriptor.h
+++ b/tree/treeplayer/inc/TBranchProxyDescriptor.h
@@ -21,19 +21,19 @@ namespace Internal {
    class TBranchProxyDescriptor : public TNamed {
       TString fDataName;
       TString fBranchName;
-      Bool_t  fIsSplit;
-      Bool_t  fBranchIsSkipped;
-      Bool_t  fIsLeafList;      // true if the branch was constructed from a leaf list.
+      bool    fIsSplit;
+      bool    fBranchIsSkipped;
+      bool    fIsLeafList;      // true if the branch was constructed from a leaf list.
 
    public:
       TBranchProxyDescriptor(const char *dataname, const char *type,
-                             const char *branchname, Bool_t split = true, Bool_t skipped = false, Bool_t isleaflist = false);
+                             const char *branchname, bool split = true, bool skipped = false, bool isleaflist = false);
       const char *GetDataName();
       const char *GetTypeName();
       const char *GetBranchName();
 
-      Bool_t IsEquivalent(const TBranchProxyDescriptor *other, Bool_t inClass = kFALSE);
-      Bool_t IsSplit() const;
+      bool IsEquivalent(const TBranchProxyDescriptor *other, bool inClass = false);
+      bool IsSplit() const;
 
       void OutputDecl(FILE *hf, int offset, UInt_t maxVarname);
       void OutputInit(FILE *hf, int offset, UInt_t maxVarname,

--- a/tree/treeplayer/inc/TBranchProxyDirector.h
+++ b/tree/treeplayer/inc/TBranchProxyDirector.h
@@ -70,7 +70,7 @@ namespace Internal{
          }
       }
       TTree*   SetTree(TTree *newtree);
-      Bool_t   Notify();
+      bool     Notify();
 
    };
 

--- a/tree/treeplayer/inc/TChainIndex.h
+++ b/tree/treeplayer/inc/TChainIndex.h
@@ -79,14 +79,14 @@ public:
    TChainIndex();
    TChainIndex(const TTree *T, const char *majorname, const char *minorname);
                  ~TChainIndex() override;
-   void           Append(const TVirtualIndex *, Bool_t delaySort = kFALSE) override;
+   void           Append(const TVirtualIndex *, bool delaySort = false) override;
    Long64_t       GetEntryNumberFriend(const TTree *parent) override;
    Long64_t       GetEntryNumberWithIndex(Long64_t major, Long64_t minor) const override;
    Long64_t       GetEntryNumberWithBestIndex(Long64_t major, Long64_t minor) const override;
    const char    *GetMajorName()    const override {return fMajorName.Data();}
    const char    *GetMinorName()    const override {return fMinorName.Data();}
    Long64_t       GetN()            const override {return fEntries.size();}
-   Bool_t         IsValidFor(const TTree *parent) override;
+   bool           IsValidFor(const TTree *parent) override;
    void           UpdateFormulaLeaves(const TTree *parent) override;
    void           SetTree(TTree *T) override;
 

--- a/tree/treeplayer/inc/TFileDrawMap.h
+++ b/tree/treeplayer/inc/TFileDrawMap.h
@@ -40,7 +40,7 @@ protected:
    Int_t          fYsize;          ///< Size in K/Mbytes of Y axis
 
    virtual void     DrawMarker(Int_t marker, Long64_t eseek);
-   virtual Bool_t   GetObjectInfoDir(TDirectory *dir, Int_t px, Int_t py, TString &info) const;
+   virtual bool     GetObjectInfoDir(TDirectory *dir, Int_t px, Int_t py, TString &info) const;
    virtual void     PaintBox(TBox &box, Long64_t bseek, Int_t nbytes);
    virtual void     PaintDir(TDirectory *dir, const char *keys);
    virtual TObject *GetObject();

--- a/tree/treeplayer/inc/TFormLeafInfo.h
+++ b/tree/treeplayer/inc/TFormLeafInfo.h
@@ -92,11 +92,11 @@ public:
    virtual void     *GetLocalValuePointer(TLeaf *leaf, Int_t instance = 0);
    virtual void     *GetLocalValuePointer( char *from, Int_t instance = 0);
 
-   virtual Bool_t    HasCounter() const;
-   virtual Bool_t    IsString() const;
+   virtual bool      HasCounter() const;
+   virtual bool      IsString() const;
 
-   virtual Bool_t    IsInteger() const;
-   virtual Bool_t    IsReference() const  {  return kFALSE; }
+   virtual bool      IsInteger() const;
+   virtual bool      IsReference() const  {  return false; }
 
    // Method for multiple variable dimensions.
    virtual Int_t GetPrimaryIndex();
@@ -111,7 +111,7 @@ public:
    virtual void  SetBranch(TBranch* br)  { if ( fNext ) fNext->SetBranch(br); }
    virtual void  UpdateSizes(TArrayI *garr);
 
-   virtual Bool_t    Update();
+   virtual bool      Update();
 
    DECLARE_GETVAL(virtual,);
    DECLARE_READVAL(virtual,);
@@ -181,7 +181,7 @@ public:
 
 class TFormLeafInfoNumerical : public TFormLeafInfo {
    EDataType fKind;
-   Bool_t    fIsBool;
+   bool      fIsBool;
 public:
    TFormLeafInfoNumerical(TVirtualCollectionProxy *holder_of);
    TFormLeafInfoNumerical(EDataType kind);
@@ -193,8 +193,8 @@ public:
 
    ~TFormLeafInfoNumerical() override;
 
-   Bool_t    IsString() const override;
-   Bool_t    Update() override;
+   bool      IsString() const override;
+   bool      Update() override;
 };
 
 // TFormLeafInfoCollectionObject
@@ -202,9 +202,9 @@ public:
 // it is split.
 
 class TFormLeafInfoCollectionObject : public TFormLeafInfo {
-   Bool_t fTop;  //If true, it indicates that the branch itself contains
+   bool fTop;  //If true, it indicates that the branch itself contains
 public:
-   TFormLeafInfoCollectionObject(TClass* classptr = nullptr, Bool_t fTop = kTRUE);
+   TFormLeafInfoCollectionObject(TClass* classptr = nullptr, bool fTop = true);
    TFormLeafInfoCollectionObject(const TFormLeafInfoCollectionObject &orig);
 
    void Swap(TFormLeafInfoCollectionObject &other);
@@ -229,13 +229,13 @@ public:
 // member on a TClonesArray object stored in a TTree.
 
 class TFormLeafInfoClones : public TFormLeafInfo {
-   Bool_t fTop;  //If true, it indicates that the branch itself contains
+   bool fTop;  //If true, it indicates that the branch itself contains
 public:
    //either the clonesArrays or something inside the clonesArray
    TFormLeafInfoClones(TClass* classptr = nullptr, Longptr_t offset = 0);
-   TFormLeafInfoClones(TClass* classptr, Longptr_t offset, Bool_t top);
+   TFormLeafInfoClones(TClass* classptr, Longptr_t offset, bool top);
    TFormLeafInfoClones(TClass* classptr, Longptr_t offset, TStreamerElement* element,
-                       Bool_t top = kFALSE);
+                       bool top = false);
    TFormLeafInfoClones(const TFormLeafInfoClones &orig);
 
    void Swap(TFormLeafInfoClones &other);
@@ -259,7 +259,7 @@ public:
 // on a generic collection object stored in a TTree.
 
 class TFormLeafInfoCollection : public TFormLeafInfo {
-   Bool_t fTop;  //If true, it indicates that the branch itself contains
+   bool fTop;  //If true, it indicates that the branch itself contains
    //either the clonesArrays or something inside the clonesArray
    TClass                  *fCollClass;
    TString                  fCollClassName;
@@ -270,12 +270,12 @@ public:
    TFormLeafInfoCollection(TClass* classptr,
                            Longptr_t offset,
                            TStreamerElement* element,
-                           Bool_t top = kFALSE);
+                           bool top = false);
 
    TFormLeafInfoCollection(TClass* motherclassptr,
                            Longptr_t offset = 0,
                            TClass* elementclassptr = nullptr,
-                           Bool_t top = kFALSE);
+                           bool top = false);
 
    TFormLeafInfoCollection();
    TFormLeafInfoCollection(const TFormLeafInfoCollection& orig);
@@ -287,14 +287,14 @@ public:
 
    TFormLeafInfo* DeepCopy() const override;
 
-   Bool_t    Update() override;
+   bool      Update() override;
 
    DECLARE_GETVAL( , override);
    DECLARE_READVAL( , override);
    Int_t     GetCounterValue(TLeaf* leaf) override;
    Int_t     ReadCounterValue(char* where) override;
    virtual Int_t     GetCounterValue(TLeaf* leaf, Int_t instance);
-   Bool_t    HasCounter() const override;
+   bool      HasCounter() const override;
    void     *GetValuePointer(TLeaf *leaf, Int_t instance = 0) override;
    void     *GetValuePointer(char  *thisobj, Int_t instance = 0) override;
    void     *GetLocalValuePointer(TLeaf *leaf, Int_t instance = 0) override;
@@ -320,7 +320,7 @@ public:
 
    TFormLeafInfo* DeepCopy() const override;
 
-   Bool_t    Update() override;
+   bool      Update() override;
 
    void     *GetValuePointer(TLeaf *leaf, Int_t instance = 0) override;
    void     *GetValuePointer(char  *from, Int_t instance = 0) override;
@@ -358,7 +358,7 @@ class TFormLeafInfoMethod : public TFormLeafInfo {
    TString      fCopyFormat;
    TString      fDeleteFormat;
    void        *fValuePointer;
-   Bool_t       fIsByValue;
+   bool         fIsByValue;
 
 public:
    static TClass *ReturnTClass(TMethodCall *mc);
@@ -376,9 +376,9 @@ public:
    TClass*  GetClass() const override;
    void    *GetLocalValuePointer( TLeaf *from, Int_t instance = 0) override;
    void    *GetLocalValuePointer(char *from, Int_t instance = 0) override;
-   Bool_t   IsInteger() const override;
-   Bool_t   IsString() const override;
-   Bool_t   Update() override;
+   bool     IsInteger() const override;
+   bool     IsString() const override;
+   bool     Update() override;
 };
 
 // TFormLeafInfoMultiVarDim is a small helper class to implement reading a
@@ -430,7 +430,7 @@ public:
    LongDouble_t  GetValueLongDouble(TLeaf *leaf, Int_t i= 0) override { return GetValue(leaf, i); }
    Int_t    GetVarDim() override;
    Int_t    GetVirtVarDim() override;
-   Bool_t   Update() override;
+   bool     Update() override;
    void     UpdateSizes(TArrayI *garr) override;
 };
 
@@ -501,8 +501,8 @@ class TFormLeafInfoCast : public TFormLeafInfo {
 public:
    TClass *fCasted;     //! Pointer to the class we are trying to case to
    TString fCastedName; //! Name of the class we are casting to.
-   Bool_t  fGoodCast;   //! Marked by ReadValue.
-   Bool_t  fIsTObject;  //! Indicated whether the fClass inherits from TObject.
+   bool    fGoodCast;   //! Marked by ReadValue.
+   bool    fIsTObject;  //! Indicated whether the fClass inherits from TObject.
 
    TFormLeafInfoCast(TClass* classptr = nullptr, TClass* casted = nullptr);
    TFormLeafInfoCast(const TFormLeafInfoCast& orig);
@@ -516,7 +516,7 @@ public:
    DECLARE_READVAL( , override);
    // Currently only implemented in TFormLeafInfoCast
    Int_t GetNdata() override;
-   Bool_t    Update() override;
+   bool      Update() override;
 };
 
 // TFormLeafInfoTTree is a small helper class to implement reading
@@ -542,7 +542,7 @@ public:
    DECLARE_GETVAL( , override);
    DECLARE_READVAL( , override);
    void     *GetLocalValuePointer(TLeaf *leaf, Int_t instance = 0) override;
-   Bool_t    Update() override;
+   bool      Update() override;
 };
 
 

--- a/tree/treeplayer/inc/TFormLeafInfoReference.h
+++ b/tree/treeplayer/inc/TFormLeafInfoReference.h
@@ -46,11 +46,11 @@ public:
    /// Access to the offset of the data
    virtual Int_t    GetOffset()       const     {  return fOffset;       }
    /// Return true only if the underlying data is an integral value
-   Bool_t   IsInteger()       const override     {  return kFALSE;         }
+   bool     IsInteger()       const override     {  return false;         }
    /// Return true only if the underlying data is a string
-   Bool_t   IsString()        const override     {  return kFALSE;         }
+   bool     IsString()        const override     {  return false;         }
    /// Return true only if the underlying data is a reference
-   Bool_t   IsReference()     const override     {  return kTRUE;          }
+   bool     IsReference()     const override     {  return true;          }
    /// Access to target class pointer (if available)
    TClass*  GetClass()        const override;
    /// Access to the value class of the reference proxy
@@ -62,7 +62,7 @@ public:
    /// Return the address of the local value
    void    *GetLocalValuePointer(char *from, Int_t instance = 0) override;
    /// Return true if any of underlying data has a array size counter
-   Bool_t HasCounter() const override;
+   bool HasCounter() const override;
    /// Return the size of the underlying array for the current entry in the TTree.
    Int_t ReadCounterValue(char *where) override;
    /// Return the current size of the array container
@@ -73,7 +73,7 @@ public:
    /// Read value of referenced object
    DECLARE_READVAL( , override);
    /// TFormLeafInfo overload: Update (and propagate) cached information
-   Bool_t   Update() override;
+   bool     Update() override;
 };
 
 #endif /* ROOT_TFormLeafInfoReference */

--- a/tree/treeplayer/inc/TFriendProxyDescriptor.h
+++ b/tree/treeplayer/inc/TFriendProxyDescriptor.h
@@ -21,7 +21,7 @@ namespace Internal {
 
    class TFriendProxyDescriptor : public TNamed {
 
-      Bool_t fDuplicate;
+      bool fDuplicate;
       Int_t  fIndex;
       TList  fListOfTopProxies;
 
@@ -35,13 +35,13 @@ namespace Internal {
       Int_t  GetIndex() const { return fIndex; }
       TList *GetListOfTopProxies() { return &fListOfTopProxies; }
 
-      Bool_t IsEquivalent(const TFriendProxyDescriptor *other);
+      bool IsEquivalent(const TFriendProxyDescriptor *other);
 
       void OutputClassDecl(FILE *hf, int offset, UInt_t maxVarname);
       void OutputDecl(FILE *hf, int offset, UInt_t maxVarname);
 
-      Bool_t IsDuplicate() { return fDuplicate; }
-      void   SetDuplicate() { fDuplicate = kTRUE; }
+      bool IsDuplicate() { return fDuplicate; }
+      void   SetDuplicate() { fDuplicate = true; }
 
       ClassDefOverride(TFriendProxyDescriptor,0); // Describe a branch from a TTreeFriend.
    };

--- a/tree/treeplayer/inc/TMPWorkerTree.h
+++ b/tree/treeplayer/inc/TMPWorkerTree.h
@@ -70,8 +70,8 @@ private:
 
    // TTree cache handling
    TTreeCache *fTreeCache;              ///< instance of the tree cache for the tree
-   Bool_t      fTreeCacheIsLearning;    ///< Whether cache is in learning phase
-   Bool_t      fUseTreeCache;           ///< Control usage of the tree cache
+   bool        fTreeCacheIsLearning;    ///< Whether cache is in learning phase
+   bool        fUseTreeCache;           ///< Control usage of the tree cache
    Long64_t    fCacheSize;              ///< Cache size
 };
 

--- a/tree/treeplayer/inc/TRefArrayProxy.h
+++ b/tree/treeplayer/inc/TRefArrayProxy.h
@@ -26,7 +26,7 @@ public:
    // TVirtualRefProxy overload: Clone the reference proxy (virtual constructor)
    TVirtualRefProxy* Clone() const override        { return new TRefArrayProxy(*this);}
    // TVirtualRefProxy overload: Flag to indicate if this is a container reference
-   Bool_t HasCounter()  const override             { return kTRUE;                    }
+   bool HasCounter()  const override             { return true;                    }
    // TVirtualRefProxy overload: Access referenced object(-data)
    void* GetObject(TFormLeafInfoReference* info, void* data, Int_t instance) override;
    // TVirtualRefProxy overload: Access to container size (if container reference (ie TRefArray) etc)

--- a/tree/treeplayer/inc/TRefProxy.h
+++ b/tree/treeplayer/inc/TRefProxy.h
@@ -50,9 +50,9 @@ public:
    /// TVirtualRefProxy overload: Prepare reused reference object (e.g. ZERO data pointers)
    void* GetPreparedReference(void* data) override {  return data;               }
    /// TVirtualRefProxy overload: Update (and propagate) cached information
-   Bool_t Update() override;
+   bool   Update() override;
    /// TVirtualRefProxy overload: Flag to indicate if this is a container reference
-   Bool_t HasCounter()  const override             { return kFALSE;              }
+   bool   HasCounter()  const override             { return false;              }
    /// TVirtualRefProxy overload: Access to container size (if container reference (ie TRefArray) etc)
    Int_t  GetCounterValue(TFormLeafInfoReference* /* info */, void* /* data */) override
    {  return 0;                                                                 }

--- a/tree/treeplayer/inc/TSelectorDraw.h
+++ b/tree/treeplayer/inc/TSelectorDraw.h
@@ -57,15 +57,15 @@ protected:
    Double_t     **fVal;              ///<![fSelectedRows][fDimension] Local buffer for the variables
    Int_t          fValSize;
    Double_t      *fW;                ///<![fSelectedRows]Local buffer for weights
-   Bool_t        *fVarMultiple;      ///<![fDimension] True if fVar[i] has a variable index
-   Bool_t         fSelectMultiple;   ///<  True if selection has a variable index
-   Bool_t         fCleanElist;       ///<  True if original Tree elist must be saved
-   Bool_t         fObjEval;          ///<  True if fVar1 returns an object (or pointer to).
+   bool          *fVarMultiple;      ///<![fDimension] True if fVar[i] has a variable index
+   bool           fSelectMultiple;   ///<  True if selection has a variable index
+   bool           fCleanElist;       ///<  True if original Tree elist must be saved
+   bool           fObjEval;          ///<  True if fVar1 returns an object (or pointer to).
    Long64_t       fCurrentSubEntry;  ///<  Current subentry when fSelectMultiple is true. Used to fill TEntryListArray
 
 protected:
    virtual void      ClearFormula();
-   virtual Bool_t    CompileVariables(const char *varexp="", const char *selection="");
+   virtual bool      CompileVariables(const char *varexp="", const char *selection="");
    virtual void      InitArrays(Int_t newsize);
 
 private:
@@ -78,7 +78,7 @@ public:
 
    void      Begin(TTree *tree) override;
    virtual Int_t     GetAction() const {return fAction;}
-   virtual Bool_t    GetCleanElist() const {return fCleanElist;}
+   virtual bool      GetCleanElist() const {return fCleanElist;}
    virtual Int_t     GetDimension() const {return fDimension;}
    virtual Long64_t  GetDrawFlag() const {return fDraw;}
    TObject          *GetObject() const {return fObject;}
@@ -107,8 +107,8 @@ public:
    /// See TSelectorDraw::GetVal
    virtual Double_t *GetV4() const   {return GetVal(3);}
    virtual Double_t *GetW() const    {return fW;}
-   Bool_t    Notify() override;
-   Bool_t    Process(Long64_t /*entry*/) override { return kFALSE; }
+   bool      Notify() override;
+   bool      Process(Long64_t /*entry*/) override { return false; }
    void      ProcessFill(Long64_t entry) override;
    virtual void      ProcessFillMultiple(Long64_t entry);
    virtual void      ProcessFillObject(Long64_t entry);

--- a/tree/treeplayer/inc/TSelectorEntries.h
+++ b/tree/treeplayer/inc/TSelectorEntries.h
@@ -32,12 +32,12 @@ class TTree;
 class TTreeFormula;
 
 class TSelectorEntries : public TSelector {
-   Bool_t          fOwnInput;       ///<  True if we created the input list.
+   bool            fOwnInput;       ///<  True if we created the input list.
 public :
    TTree          *fChain;          ///<! Pointer to the analyzed TTree or TChain
    TTreeFormula   *fSelect;         ///<  Pointer to selection formula
    Long64_t        fSelectedRows;   ///<  Number of selected entries
-   Bool_t          fSelectMultiple; ///<  True if selection has a variable index
+   bool            fSelectMultiple; ///<  True if selection has a variable index
 
    TSelectorEntries(TTree *tree = nullptr, const char *selection = nullptr);
    TSelectorEntries(const char *selection);
@@ -46,8 +46,8 @@ public :
    void     Begin(TTree *tree) override;
    void     SlaveBegin(TTree *tree) override;
    void     Init(TTree *tree) override;
-   Bool_t   Notify() override;
-   Bool_t   Process(Long64_t entry) override;
+   bool     Notify() override;
+   bool     Process(Long64_t entry) override;
    Int_t    GetEntry(Long64_t entry, Int_t getall = 0) override;
    virtual Long64_t GetSelectedRows() const { return fSelectedRows; }
    void     SetOption(const char *option) override { fOption = option; }

--- a/tree/treeplayer/inc/TTreeDrawArgsParser.h
+++ b/tree/treeplayer/inc/TTreeDrawArgsParser.h
@@ -57,35 +57,35 @@ protected:
                                       ///< If dimension < fgMaxDimension then some
                                       ///< Expressions are empty
 
-   Bool_t         fAdd;               ///< Values should be added to an existing object
+   bool           fAdd;               ///< Values should be added to an existing object
    TString        fName;              ///< Histogram's/plot's name
 
    Int_t          fNoParameters;      ///< If dimensions of the plot was specified
-   Bool_t         fParameterGiven[9]; ///< True if the parameter was given, otherwise false
+   bool           fParameterGiven[9]; ///< True if the parameter was given, otherwise false
    Double_t       fParameters[9];     ///< Parameters in brackets
 
-   Bool_t         fShouldDraw;        ///< If to draw the plot
-   Bool_t         fOptionSame;        ///< If option contained "same"
-   Bool_t         fEntryList;         ///< If fill a TEntryList
+   bool           fShouldDraw;        ///< If to draw the plot
+   bool           fOptionSame;        ///< If option contained "same"
+   bool           fEntryList;         ///< If fill a TEntryList
    TObject       *fOriginal;          ///< Original plot (if it is to be reused)
-   Bool_t         fDrawProfile;       ///< True if the options contain :"prof"
+   bool           fDrawProfile;       ///< True if the options contain :"prof"
    EOutputType    fOutputType;        ///< Type of the output
 
    void           ClearPrevious();
    TTreeDrawArgsParser::EOutputType DefineType();
-   Bool_t         SplitVariables(TString variables);
-   Bool_t         ParseName(TString name);
-   Bool_t         ParseOption();
-   Bool_t         ParseVarExp();
+   bool           SplitVariables(TString variables);
+   bool           ParseName(TString name);
+   bool           ParseOption();
+   bool           ParseVarExp();
 
 public:
    TTreeDrawArgsParser();
    ~TTreeDrawArgsParser() override;
 
-   Bool_t         Parse(const char *varexp, const char *selection, Option_t *option);
-   Bool_t         GetAdd() const { return fAdd; }
+   bool           Parse(const char *varexp, const char *selection, Option_t *option);
+   bool           GetAdd() const { return fAdd; }
    Int_t          GetDimension() const { return fDimension; }
-   Bool_t         GetShouldDraw() const { return fShouldDraw; }
+   bool           GetShouldDraw() const { return fShouldDraw; }
    TString const& GetExp() const { return fExp; }
    Double_t       GetIfSpecified(Int_t num, Double_t def) const;
    Int_t          GetNoParameters() const { return fNoParameters; }
@@ -93,12 +93,12 @@ public:
    TString        GetProofSelectorName() const;
    TString const& GetObjectName() const { return fName; }
    TString        GetObjectTitle() const;
-   Bool_t         GetOptionSame() const { return fOptionSame; }
+   bool           GetOptionSame() const { return fOptionSame; }
    TObject       *GetOriginal() const { return fOriginal; }
    TString const& GetSelection() const { return fSelection; }
    TString        GetVarExp(Int_t num) const;
    TString        GetVarExp() const;
-   Bool_t         IsSpecified(int num) const;
+   bool           IsSpecified(int num) const;
    void           SetObjectName(const char *s) { fName = s; }
    void           SetOriginal(TObject *o) { fOriginal = o; }
    static Int_t   GetMaxDimension();

--- a/tree/treeplayer/inc/TTreeFormula.h
+++ b/tree/treeplayer/inc/TTreeFormula.h
@@ -96,7 +96,7 @@ protected:
    Int_t       fCodes[kMAXCODES]; ///<  List of leaf numbers referenced in formula
    Int_t       fNdata[kMAXCODES]; ///<! This caches the physical number of element in the leaf or data member.
    Int_t       fNcodes;           ///<  Number of leaves referenced in formula
-   Bool_t      fHasCast;          ///<  Record whether the formula contain a cast operation or not
+   bool        fHasCast;          ///<  Record whether the formula contain a cast operation or not
    Int_t       fMultiplicity;     ///<  Indicator of the variability of the formula
    Int_t       fNindex;           ///<  Size of fIndex
    Int_t      *fLookupType;       ///<[fNindex] Array indicating how each leaf should be looked-up
@@ -107,8 +107,8 @@ protected:
    TObjArray   fAliases;          ///<!  List of TTreeFormula for each alias used.
    TObjArray   fLeafNames;        ///<   List of TNamed describing leaves
    TObjArray   fBranches;         ///<!  List of branches to read.  Similar to fLeaves but duplicates are zeroed out.
-   Bool_t      fQuickLoad;        ///<!  If true, branch GetEntry is only called when the entry number changes.
-   Bool_t      fNeedLoading;      ///<!  If true, the current entry has not been loaded yet.
+   bool        fQuickLoad;        ///<!  If true, branch GetEntry is only called when the entry number changes.
+   bool        fNeedLoading;      ///<!  If true, the current entry has not been loaded yet.
 
    Int_t       fNdimensions[kMAXCODES];               ///< Number of array dimensions in each leaf
    Int_t       fFixedSizes[kMAXCODES][kMAXFORMDIM];   ///< Physical sizes of lower dimensions for each leaf
@@ -120,7 +120,7 @@ protected:
    TTreeFormula *fVarIndexes[kMAXCODES][kMAXFORMDIM]; ///< Pointer to a variable index.
 
    TAxis                    *fAxis;                   ///<! pointer to histogram axis if this is a string
-   Bool_t                    fDidBooleanOptimization; ///<! True if we executed one boolean optimization since the last time instance number 0 was evaluated
+   bool                      fDidBooleanOptimization; ///<! True if we executed one boolean optimization since the last time instance number 0 was evaluated
    TTreeFormulaManager      *fManager;                ///<! The dimension coordinator.
 
    // Helper members and function used during the construction and parsing
@@ -133,15 +133,15 @@ protected:
 
    TTreeFormula(const char *name, const char *formula, TTree *tree, const std::vector<std::string>& aliases);
    void Init(const char *name, const char *formula);
-   Bool_t      BranchHasMethod(TLeaf* leaf, TBranch* branch, const char* method,const char* params, Long64_t readentry) const;
+   bool        BranchHasMethod(TLeaf* leaf, TBranch* branch, const char* method,const char* params, Long64_t readentry) const;
    Int_t       DefineAlternate(const char* expression);
    void        DefineDimensions(Int_t code, Int_t size, TFormLeafInfoMultiVarDim * info, Int_t& virt_dim);
-   Int_t       FindLeafForExpression(const char* expression, TLeaf *&leaf, TString &leftover, Bool_t &final, UInt_t &paran_level, TObjArray &castqueue, std::vector<std::string>& aliasUsed, Bool_t &useLeafCollectionObject, const char *fullExpression);
+   Int_t       FindLeafForExpression(const char* expression, TLeaf *&leaf, TString &leftover, bool &final, UInt_t &paran_level, TObjArray &castqueue, std::vector<std::string>& aliasUsed, bool &useLeafCollectionObject, const char *fullExpression);
    TLeaf*      GetLeafWithDatamember(const char* topchoice, const char* nextchice, Long64_t readentry) const;
-   Int_t       ParseWithLeaf(TLeaf *leaf, const char *expression, Bool_t final, UInt_t paran_level, TObjArray &castqueue, Bool_t useLeafCollectionObject, const char *fullExpression);
+   Int_t       ParseWithLeaf(TLeaf *leaf, const char *expression, bool final, UInt_t paran_level, TObjArray &castqueue, bool useLeafCollectionObject, const char *fullExpression);
    Int_t       RegisterDimensions(Int_t code, Int_t size, TFormLeafInfoMultiVarDim *multidim = nullptr);
    Int_t       RegisterDimensions(Int_t code, TBranchElement *branch);
-   Int_t       RegisterDimensions(Int_t code, TFormLeafInfo *info, TFormLeafInfo *maininfo, Bool_t useCollectionObject);
+   Int_t       RegisterDimensions(Int_t code, TFormLeafInfo *info, TFormLeafInfo *maininfo, bool useCollectionObject);
    Int_t       RegisterDimensions(Int_t code, TLeaf *leaf);
    Int_t       RegisterDimensions(const char *size, Int_t code);
 
@@ -150,15 +150,15 @@ protected:
    Int_t             GetRealInstance(Int_t instance, Int_t codeindex);
 
    void              LoadBranches();
-   Bool_t            LoadCurrentDim();
+   bool              LoadCurrentDim();
    void              ResetDimensions();
 
    virtual TClass*   EvalClass(Int_t oper) const;
-   virtual Bool_t    IsLeafInteger(Int_t code) const;
-   Bool_t    IsString(Int_t oper) const override;
-   virtual Bool_t    IsLeafString(Int_t code) const;
-   virtual Bool_t    SwitchToFormLeafInfo(Int_t code);
-   Bool_t    StringToNumber(Int_t code) override;
+   virtual bool      IsLeafInteger(Int_t code) const;
+   bool      IsString(Int_t oper) const override;
+   virtual bool      IsLeafString(Int_t code) const;
+   virtual bool      SwitchToFormLeafInfo(Int_t code);
+   bool      StringToNumber(Int_t code) override;
 
    void              Convert(UInt_t fromVersion) override;
 
@@ -197,14 +197,14 @@ public:
    //mutable.  We will be able to do that only when all the compilers supported for ROOT actually implemented
    //the mutable keyword.
    //NOTE: Also modify the code in PrintValue which current goes around this limitation :(
-   virtual Bool_t      IsInteger(Bool_t fast=kTRUE) const;
-           Bool_t      IsQuickLoad() const { return fQuickLoad; }
-   virtual Bool_t      IsString() const;
-   Bool_t      Notify() override { UpdateFormulaLeaves(); return kTRUE; }
+   virtual bool        IsInteger(bool fast=true) const;
+           bool        IsQuickLoad() const { return fQuickLoad; }
+   virtual bool        IsString() const;
+   bool        Notify() override { UpdateFormulaLeaves(); return true; }
    virtual char       *PrintValue(Int_t mode=0) const;
    virtual char       *PrintValue(Int_t mode, Int_t instance, const char *decform = "9.9") const;
    virtual void        SetAxis(TAxis *axis = nullptr);
-           void        SetQuickLoad(Bool_t quick) { fQuickLoad = quick; }
+           void        SetQuickLoad(bool quick) { fQuickLoad = quick; }
    virtual void        SetTree(TTree *tree) {fTree = tree;}
    virtual void        ResetLoading();
    virtual TTree*      GetTree() const {return fTree;}

--- a/tree/treeplayer/inc/TTreeFormulaManager.h
+++ b/tree/treeplayer/inc/TTreeFormulaManager.h
@@ -31,7 +31,7 @@ class TTreeFormulaManager : public TObject {
 private:
    TObjArray   fFormulas;
    Int_t       fMultiplicity;     ///< Indicator of the variability of the formula
-   Bool_t      fMultiVarDim;      ///< True if one of the variable has 2 variable size dimensions.
+   bool        fMultiVarDim;      ///< True if one of the variable has 2 variable size dimensions.
    Int_t       fNdata;            ///<! Last value calculated by GetNdata
 
    //the next line should be: mutable Int_t fCumulUsedSizes[kMAXFORMDIM+1]; See GetNdata()
@@ -42,7 +42,7 @@ private:
    TArrayI    *fVarDims[kMAXFORMDIM+1];             ///< List of variable sizes dimensions.
    Int_t       fVirtUsedSizes[kMAXFORMDIM+1];       ///< Virtual size of lower dimensions as seen for this formula
 
-   Bool_t      fNeedSync;         // Indicate whether a new formula has been added since the last synchronization
+   bool        fNeedSync;         // Indicate whether a new formula has been added since the last synchronization
 
    friend class TTreeFormula;
 
@@ -64,10 +64,10 @@ public:
 
    virtual void       Add(TTreeFormula*);
    virtual Int_t      GetMultiplicity() const {return fMultiplicity;}
-   virtual Int_t      GetNdata(Bool_t forceLoadDim = kFALSE);
-   Bool_t     Notify() override { UpdateFormulaLeaves(); return kTRUE; }
+   virtual Int_t      GetNdata(bool forceLoadDim = false);
+   bool               Notify() override { UpdateFormulaLeaves(); return true; }
    virtual void       Remove(TTreeFormula*);
-   virtual Bool_t     Sync();
+   virtual bool       Sync();
    virtual void       UpdateFormulaLeaves();
 
    ClassDefOverride(TTreeFormulaManager,0) // A class coordinating several TTreeFormula objects.

--- a/tree/treeplayer/inc/TTreeGeneratorBase.h
+++ b/tree/treeplayer/inc/TTreeGeneratorBase.h
@@ -43,7 +43,7 @@ namespace Internal {
 
          void    AddHeader(TClass *cl);
          void    AddHeader(const char *classname);
-         TString GetContainedClassName(TBranchElement *branch, TStreamerElement *element, Bool_t ispointer);
+         TString GetContainedClassName(TBranchElement *branch, TStreamerElement *element, bool ispointer);
          TVirtualStreamerInfo *GetBaseClass(TStreamerElement *element);
          TVirtualStreamerInfo *GetStreamerInfo(TBranch *branch, TIter current, TClass *cl);
    };

--- a/tree/treeplayer/inc/TTreeIndex.h
+++ b/tree/treeplayer/inc/TTreeIndex.h
@@ -51,21 +51,21 @@ public:
    TTreeIndex();
    TTreeIndex(const TTree *T, const char *majorname, const char *minorname);
                  ~TTreeIndex() override;
-   void           Append(const TVirtualIndex *,Bool_t delaySort = kFALSE) override;
+   void                   Append(const TVirtualIndex *,bool delaySort = false) override;
    bool                   ConvertOldToNew();
    Long64_t               FindValues(Long64_t major, Long64_t minor) const;
-   Long64_t       GetEntryNumberFriend(const TTree *parent) override;
-   Long64_t       GetEntryNumberWithIndex(Long64_t major, Long64_t minor) const override;
-   Long64_t       GetEntryNumberWithBestIndex(Long64_t major, Long64_t minor) const override;
+   Long64_t               GetEntryNumberFriend(const TTree *parent) override;
+   Long64_t               GetEntryNumberWithIndex(Long64_t major, Long64_t minor) const override;
+   Long64_t               GetEntryNumberWithBestIndex(Long64_t major, Long64_t minor) const override;
    virtual Long64_t      *GetIndex()        const {return fIndex;}
    virtual Long64_t      *GetIndexValues()  const {return fIndexValues;}
    virtual Long64_t      *GetIndexValuesMinor()  const;
    const char            *GetMajorName()    const override {return fMajorName.Data();}
    const char            *GetMinorName()    const override {return fMinorName.Data();}
-   Long64_t       GetN()            const override {return fN;}
+   Long64_t               GetN()            const override {return fN;}
    virtual TTreeFormula  *GetMajorFormula();
    virtual TTreeFormula  *GetMinorFormula();
-   Bool_t         IsValidFor(const TTree *parent) override;
+   bool           IsValidFor(const TTree *parent) override;
    void           Print(Option_t *option="") const override;
    void           UpdateFormulaLeaves(const TTree *parent) override;
    void           SetTree(TTree *T) override;

--- a/tree/treeplayer/inc/TTreePerfStats.h
+++ b/tree/treeplayer/inc/TTreePerfStats.h
@@ -115,7 +115,7 @@ public:
    void     SimpleEvent(EEventType) override {}
    void     PacketEvent(const char *, const char *, const char *,
                             Long64_t , Double_t ,Double_t , Double_t ,Long64_t ) override {}
-   void     FileEvent(const char *, const char *, const char *, const char *, Bool_t) override {}
+   void     FileEvent(const char *, const char *, const char *, const char *, bool) override {}
    void     FileOpenEvent(TFile *, const char *, Double_t) override {}
    void     FileReadEvent(TFile *file, Int_t len, Double_t start) override;
    void     UnzipEvent(TObject *tree, Long64_t pos, Double_t start, Int_t complen, Int_t objlen) override;

--- a/tree/treeplayer/inc/TTreePlayer.h
+++ b/tree/treeplayer/inc/TTreePlayer.h
@@ -42,7 +42,7 @@ private:
 
 protected:
    TTree         *fTree;            ///<! Pointer to current Tree
-   Bool_t         fScanRedirect;    ///<  Switch to redirect TTree::Scan output to a file
+   bool           fScanRedirect;    ///<  Switch to redirect TTree::Scan output to a file
    const char    *fScanFileName;    ///<  Name of the file where Scan is redirected
    Int_t          fDimension;       ///<  Dimension of the current expression
    Long64_t       fSelectedRows;    ///<  Number of selected entries
@@ -115,17 +115,17 @@ public:
    void      RecursiveRemove(TObject *obj) override;
    Long64_t  Scan(const char *varexp, const char *selection, Option_t *option
                           ,Long64_t nentries, Long64_t firstentry) override;
-   Bool_t            ScanRedirected() {return fScanRedirect;}
-   TSQLResult *Query(const char *varexp, const char *selection, Option_t *option
+   bool              ScanRedirected() {return fScanRedirect;}
+   TSQLResult       *Query(const char *varexp, const char *selection, Option_t *option
                              ,Long64_t nentries, Long64_t firstentry) override;
-   void      SetEstimate(Long64_t n) override;
-   void              SetScanRedirect(Bool_t on=kFALSE) {fScanRedirect = on;}
+   void              SetEstimate(Long64_t n) override;
+   void              SetScanRedirect(bool on=false) {fScanRedirect = on;}
    void              SetScanFileName(const char *name) {fScanFileName=name;}
-   void      SetTree(TTree *t) override {fTree = t;}
-   void      StartViewer(Int_t ww, Int_t wh) override;
-   Int_t     UnbinnedFit(const char *formula ,const char *varexp, const char *selection,Option_t *option
+   void              SetTree(TTree *t) override {fTree = t;}
+   void              StartViewer(Int_t ww, Int_t wh) override;
+   Int_t             UnbinnedFit(const char *formula ,const char *varexp, const char *selection,Option_t *option
                                  ,Long64_t nentries, Long64_t firstentry) override;
-   void      UpdateFormulaLeaves() override;
+   void              UpdateFormulaLeaves() override;
 
    ClassDefOverride(TTreePlayer,3);  //Manager class to play with TTrees
 };

--- a/tree/treeplayer/inc/TTreeProxyGenerator.h
+++ b/tree/treeplayer/inc/TTreeProxyGenerator.h
@@ -53,11 +53,11 @@ namespace Internal {
       void AddForward(TClass *cl);
       void AddForward(const char *classname);
       void AddFriend(TFriendProxyDescriptor *desc);
-      void AddMissingClassAsEnum(const char *clname, Bool_t isscope);
+      void AddMissingClassAsEnum(const char *clname, bool isscope);
       void AddPragma(const char *pragma_text);
       void CheckForMissingClass(const char *clname);
 
-      Bool_t NeedToEmulate(TClass *cl, UInt_t level);
+      bool NeedToEmulate(TClass *cl, UInt_t level);
 
       void   ParseOptions();
 

--- a/tree/treeplayer/inc/TTreeReader.h
+++ b/tree/treeplayer/inc/TTreeReader.h
@@ -174,9 +174,9 @@ public:
    }
    void SetTree(const char* keyname, TDirectory* dir, TEntryList* entryList = nullptr);
 
-   Bool_t IsChain() const { return TestBit(kBitIsChain); }
+   bool IsChain() const { return TestBit(kBitIsChain); }
 
-   Bool_t IsInvalid() const { return fLoadTreeStatus == kNoTree; }
+   bool IsInvalid() const { return fLoadTreeStatus == kNoTree; }
 
    TTree* GetTree() const { return fTree; }
    TEntryList* GetEntryList() const { return fEntryList; }
@@ -187,7 +187,7 @@ public:
    ///
    /// \return false if the previous entry was already the last entry. This allows
    ///   the function to be used in `while (reader.Next()) { ... }`
-   Bool_t Next() {
+   bool Next() {
       return SetEntry(GetCurrentEntry() + 1) == kEntryValid;
    }
 
@@ -196,7 +196,7 @@ public:
    /// \param entry If not TEntryList is set, the entry is a global entry (i.e.
    /// not the entry number local to the chain's current tree).
    /// \returns the `entry`'s read status, i.e. whether the entry is available.
-   EEntryStatus SetEntry(Long64_t entry) { return SetEntryBase(entry, kFALSE); }
+   EEntryStatus SetEntry(Long64_t entry) { return SetEntryBase(entry, false); }
 
    /// Set the next local tree entry. If a TEntryList is set, this function is
    /// equivalent to `SetEntry()`.
@@ -206,7 +206,7 @@ public:
    /// within `TSelector::Process()` always use `SetLocalEntry()` and not
    /// `SetEntry()`!
    /// \return the `entry`'s read status, i.e. whether the entry is available.
-   EEntryStatus SetLocalEntry(Long64_t entry) { return SetEntryBase(entry, kTRUE); }
+   EEntryStatus SetLocalEntry(Long64_t entry) { return SetEntryBase(entry, true); }
 
    EEntryStatus SetEntriesRange(Long64_t beginEntry, Long64_t endEntry);
 
@@ -223,7 +223,7 @@ public:
    EEntryStatus GetEntryStatus() const { return fEntryStatus; }
 
    Long64_t GetEntries() const;
-   Long64_t GetEntries(Bool_t force);
+   Long64_t GetEntries(bool force);
 
    /// Returns the index of the current entry being read.
    ///
@@ -234,7 +234,7 @@ public:
    /// through `reader.GetEntryList()->GetEntry(reader.GetCurrentEntry())`.
    Long64_t GetCurrentEntry() const { return fEntry; }
 
-   Bool_t Notify() override;
+   bool Notify() override;
 
    /// Return an iterator to the 0th TTree entry.
    Iterator_t begin() {
@@ -265,12 +265,12 @@ protected:
       fProxies[bpName].reset(p);
    }
 
-   Bool_t RegisterValueReader(ROOT::Internal::TTreeReaderValueBase* reader);
+   bool RegisterValueReader(ROOT::Internal::TTreeReaderValueBase* reader);
    void DeregisterValueReader(ROOT::Internal::TTreeReaderValueBase* reader);
 
-   EEntryStatus SetEntryBase(Long64_t entry, Bool_t local);
+   EEntryStatus SetEntryBase(Long64_t entry, bool local);
 
-   Bool_t SetProxies();
+   bool SetProxies();
 
 private:
 
@@ -302,11 +302,11 @@ private:
 
    /// The end of the entry loop. When set (i.e. >= 0), it provides a way
    /// to stop looping over the TTree when we reach a certain entry: Next()
-   /// returns kFALSE when GetCurrentEntry() reaches fEndEntry.
+   /// returns false when GetCurrentEntry() reaches fEndEntry.
    Long64_t fEndEntry = -1LL;
    Long64_t fBeginEntry = 0LL; ///< This allows us to propagate the range to the TTreeCache
-   Bool_t fProxiesSet = kFALSE; ///< True if the proxies have been set, false otherwise
-   Bool_t fSetEntryBaseCallingLoadTree = kFALSE; ///< True if during the LoadTree execution triggered by SetEntryBase.
+   bool fProxiesSet = false; ///< True if the proxies have been set, false otherwise
+   bool fSetEntryBaseCallingLoadTree = false; ///< True if during the LoadTree execution triggered by SetEntryBase.
 
    friend class ROOT::Internal::TTreeReaderValueBase;
    friend class ROOT::Internal::TTreeReaderArrayBase;

--- a/tree/treeplayer/inc/TTreeReaderArray.h
+++ b/tree/treeplayer/inc/TTreeReaderArray.h
@@ -33,7 +33,7 @@ Base class of TTreeReaderArray.
          TTreeReaderValueBase(reader, branchname, dict) {}
 
       std::size_t GetSize() const { return fImpl->GetSize(GetProxy()); }
-      Bool_t IsEmpty() const { return !GetSize(); }
+      bool IsEmpty() const { return !GetSize(); }
 
       EReadStatus GetReadStatus() const override { return fImpl ? fImpl->fReadStatus : kReadError; }
 

--- a/tree/treeplayer/inc/TTreeReaderGenerator.h
+++ b/tree/treeplayer/inc/TTreeReaderGenerator.h
@@ -77,27 +77,27 @@ namespace Internal {
             }
          }
 
-      Bool_t IsClones() const { return fIsClones == kClones; }
+      bool IsClones() const { return fIsClones == kClones; }
 
-      Bool_t IsSTL() const { return fIsClones == kSTL; }
+      bool IsSTL() const { return fIsClones == kSTL; }
    };
 
    class TTreeReaderGenerator : public TTreeGeneratorBase
    {
       TString               fClassname;         ///< Class name of the selector
       TList                 fListOfReaders;     ///< List of readers
-      Bool_t                fIncludeAllLeaves;  ///< Should all leaves be included
-      Bool_t                fIncludeAllTopmost; ///< Should all topmost branches be included
+      bool                  fIncludeAllLeaves;  ///< Should all leaves be included
+      bool                  fIncludeAllTopmost; ///< Should all topmost branches be included
       std::vector<TString>  fIncludeLeaves;     ///< Branches whose leaves should be included
       std::vector<TString>  fIncludeStruct;     ///< Branches whom should be included
 
       void   AddReader(TTreeReaderDescriptor::ReaderType type, TString dataType, TString name,
-                       TString branchName, TBranchDescriptor *parent = nullptr, Bool_t isLeaf = kTRUE);
+                       TString branchName, TBranchDescriptor *parent = nullptr, bool isLeaf = true);
       UInt_t AnalyzeBranches(TBranchDescriptor *desc, TBranchElement *branch, TVirtualStreamerInfo *info);
       UInt_t AnalyzeBranches(TBranchDescriptor *desc, TIter &branches, TVirtualStreamerInfo *info);
       UInt_t AnalyzeOldBranch(TBranch *branch);
       UInt_t AnalyzeOldLeaf(TLeaf *leaf, Int_t nleaves);
-      Bool_t BranchNeedsReader(TString branchName, TBranchDescriptor *parent, Bool_t isLeaf);
+      bool   BranchNeedsReader(TString branchName, TBranchDescriptor *parent, bool isLeaf);
 
       void   ParseOptions();
       void   AnalyzeTree(TTree *tree);

--- a/tree/treeplayer/inc/TTreeReaderValue.h
+++ b/tree/treeplayer/inc/TTreeReaderValue.h
@@ -74,13 +74,13 @@ Base class of TTreeReaderValue.
 
       EReadStatus ProxyReadDefaultImpl();
 
-      typedef Bool_t (ROOT::Detail::TBranchProxy::*BranchProxyRead_t)();
+      typedef bool (ROOT::Detail::TBranchProxy::*BranchProxyRead_t)();
       template <BranchProxyRead_t Func>
       ROOT::Internal::TTreeReaderValueBase::EReadStatus ProxyReadTemplate();
 
       /// Return true if the branch was setup \em and \em read correctly.
       /// Use GetSetupStatus() to only check the setup status.
-      Bool_t IsValid() const { return fProxy && 0 == (int)fSetupStatus && 0 == (int)fReadStatus; }
+      bool IsValid() const { return fProxy && 0 == (int)fSetupStatus && 0 == (int)fReadStatus; }
       /// Return this TTreeReaderValue's setup status.
       /// Use this method to check e.g. whether the TTreeReaderValue is correctly setup and ready for reading.
       ESetupStatus GetSetupStatus() const { return fSetupStatus; }

--- a/tree/treeplayer/inc/TTreeTableInterface.h
+++ b/tree/treeplayer/inc/TTreeTableInterface.h
@@ -34,7 +34,7 @@ private:
    TTreeFormula        *fSelect;     ///< Selection condition
    TSelectorDraw       *fSelector;   ///< Selector
    TList               *fInput;      ///< Used for fSelector.
-   Bool_t               fForceDim;   ///< Force dimension.
+   bool                 fForceDim;   ///< Force dimension.
    TEntryList          *fEntries;    ///< Currently active entries
    UInt_t               fNRows;      ///< Amount of rows in the data
    UInt_t               fNColumns;   ///< Amount of columns in the data

--- a/tree/treeplayer/src/TBranchProxy.cxx
+++ b/tree/treeplayer/src/TBranchProxy.cxx
@@ -199,7 +199,7 @@ void ROOT::Detail::TBranchProxy::Print()
 ////////////////////////////////////////////////////////////////////////////////
 /// Initialize/cache the necessary information.
 
-Bool_t ROOT::Detail::TBranchProxy::Setup()
+bool ROOT::Detail::TBranchProxy::Setup()
 {
    // Should we check the type?
 

--- a/tree/treeplayer/src/TBranchProxyClassDescriptor.cxx
+++ b/tree/treeplayer/src/TBranchProxyClassDescriptor.cxx
@@ -155,37 +155,37 @@ namespace Internal {
    ////////////////////////////////////////////////////////////////////////////////
    /// Return true if this description is the 'same' as the other decription.
 
-   Bool_t TBranchProxyClassDescriptor::IsEquivalent(const TBranchProxyClassDescriptor* other)
+   bool TBranchProxyClassDescriptor::IsEquivalent(const TBranchProxyClassDescriptor* other)
    {
-      if ( !other ) return kFALSE;
+      if ( !other ) return false;
       // Purposely do not test on the name!
-      if ( strcmp(GetTitle(),other->GetTitle()) ) return kFALSE;
-      // if ( fBranchName != other->fBranchName ) return kFALSE;
-      // if ( fSubBranchPrefix != other->fSubBranchPrefix ) return kFALSE;
+      if ( strcmp(GetTitle(),other->GetTitle()) ) return false;
+      // if ( fBranchName != other->fBranchName ) return false;
+      // if ( fSubBranchPrefix != other->fSubBranchPrefix ) return false;
 
-      if (fIsClones != other->fIsClones) return kFALSE;
+      if (fIsClones != other->fIsClones) return false;
       if (fIsClones != kOut) {
-         if (fContainerName != other->fContainerName) return kFALSE;
+         if (fContainerName != other->fContainerName) return false;
       }
 
       TBranchProxyDescriptor *desc;
       TBranchProxyDescriptor *othdesc;
 
-      if ( fListOfBaseProxies.GetSize() != other->fListOfBaseProxies.GetSize() ) return kFALSE;
+      if ( fListOfBaseProxies.GetSize() != other->fListOfBaseProxies.GetSize() ) return false;
       TIter next(&fListOfBaseProxies);
       TIter othnext(&other->fListOfBaseProxies);
       while ( (desc=(TBranchProxyDescriptor*)next()) ) {
          othdesc=(TBranchProxyDescriptor*)othnext();
-         if (!desc->IsEquivalent(othdesc,kTRUE) ) return kFALSE;
+         if (!desc->IsEquivalent(othdesc,true) ) return false;
       }
 
-      if ( fListOfSubProxies.GetSize() != other->fListOfSubProxies.GetSize() ) return kFALSE;
+      if ( fListOfSubProxies.GetSize() != other->fListOfSubProxies.GetSize() ) return false;
       next = &fListOfSubProxies;
       othnext = &(other->fListOfSubProxies);
 
       while ( (desc=(TBranchProxyDescriptor*)next()) ) {
          othdesc=(TBranchProxyDescriptor*)othnext();
-         if (!desc->IsEquivalent(othdesc,kTRUE)) return kFALSE;
+         if (!desc->IsEquivalent(othdesc,true)) return false;
          if (desc->IsSplit()) {
             TString leftname (  desc->GetBranchName() );
             TString rightname(  othdesc->GetBranchName() );
@@ -194,7 +194,7 @@ namespace Internal {
             if (leftname.Length() && leftname[0]=='.') leftname.Remove(0,1);
             if (rightname.Index(other->GetBranchName())==0) rightname.Remove(0,strlen(other->GetBranchName()));
             if (rightname.Length() && rightname[0]=='.') rightname.Remove(0,1);
-            if (leftname != rightname ) return kFALSE;
+            if (leftname != rightname ) return false;
          }
       }
       return true;
@@ -203,7 +203,7 @@ namespace Internal {
    ////////////////////////////////////////////////////////////////////////////////
    /// Add a descriptor to this proxy.
 
-   void TBranchProxyClassDescriptor::AddDescriptor(TBranchProxyDescriptor *desc, Bool_t isBase)
+   void TBranchProxyClassDescriptor::AddDescriptor(TBranchProxyDescriptor *desc, bool isBase)
    {
       if (desc) {
          if (isBase) {
@@ -219,7 +219,7 @@ namespace Internal {
    ////////////////////////////////////////////////////////////////////////////////
    /// Return true if the class needed by the branch is loaded
 
-   Bool_t TBranchProxyClassDescriptor::IsLoaded() const
+   bool TBranchProxyClassDescriptor::IsLoaded() const
    {
       return IsLoaded(GetTitle());
    }
@@ -227,22 +227,22 @@ namespace Internal {
    ////////////////////////////////////////////////////////////////////////////////
    /// Return true if the class needed by the branch is loaded
 
-   Bool_t TBranchProxyClassDescriptor::IsLoaded(const char *classname)
+   bool TBranchProxyClassDescriptor::IsLoaded(const char *classname)
    {
       TClass *cl = TClass::GetClass(classname);
       while (cl) {
-         if (cl->IsLoaded()) return kTRUE;
-         if (!cl->GetCollectionProxy()) return kFALSE;
-         if (!cl->GetCollectionProxy()->GetValueClass()) return kTRUE; // stl container of simple type are always 'loaded'
+         if (cl->IsLoaded()) return true;
+         if (!cl->GetCollectionProxy()) return false;
+         if (!cl->GetCollectionProxy()->GetValueClass()) return true; // stl container of simple type are always 'loaded'
          cl = cl->GetCollectionProxy()->GetValueClass();
       }
-      return kFALSE;
+      return false;
    }
 
    ////////////////////////////////////////////////////////////////////////////////
    /// Return true if this proxy is for a TClonesArray.
 
-   Bool_t TBranchProxyClassDescriptor::IsClones() const
+   bool TBranchProxyClassDescriptor::IsClones() const
    {
       return fIsClones==kClones || fIsClones==kInsideClones;
    }
@@ -250,7 +250,7 @@ namespace Internal {
    ////////////////////////////////////////////////////////////////////////////////
    /// Return true if this proxy is for a TClonesArray.
 
-   Bool_t TBranchProxyClassDescriptor::IsSTL() const
+   bool TBranchProxyClassDescriptor::IsSTL() const
    {
       return fIsClones==kSTL || fIsClones==kInsideSTL;
    }
@@ -303,7 +303,7 @@ namespace Internal {
       fprintf(hf,"%-*s   %s(TBranchProxyDirector* director,const char *top,const char *mid=0) :",
               offset," ", GetName());
 
-      Bool_t wroteFirst = kFALSE;
+      bool wroteFirst = false;
 
       if (fListOfBaseProxies.GetSize()) {
 
@@ -360,7 +360,7 @@ namespace Internal {
       fprintf(hf,"%-*s   %s(TBranchProxyDirector* director, TBranchProxy *parent, const char *membername, const char *top=0, const char *mid=0) :",
               offset," ", GetName());
 
-      wroteFirst = kFALSE;
+      wroteFirst = false;
 
       if (fListOfBaseProxies.GetSize()) {
 

--- a/tree/treeplayer/src/TBranchProxyDescriptor.cxx
+++ b/tree/treeplayer/src/TBranchProxyDescriptor.cxx
@@ -37,9 +37,9 @@ namespace Internal {
    TBranchProxyDescriptor::TBranchProxyDescriptor(const char *dataname,
                                                   const char *type,
                                                   const char *branchname,
-                                                  Bool_t split,
-                                                  Bool_t skipped,
-                                                  Bool_t isleaflist) :
+                                                  bool split,
+                                                  bool skipped,
+                                                  bool isleaflist) :
       TNamed(dataname,type),fBranchName(branchname),fIsSplit(split),fBranchIsSkipped(skipped),fIsLeafList(isleaflist)
    {
       fDataName = GetName();
@@ -83,8 +83,7 @@ namespace Internal {
    ////////////////////////////////////////////////////////////////////////////////
    /// Return true if this description is the 'same' as the other description.
 
-   Bool_t TBranchProxyDescriptor::IsEquivalent(const TBranchProxyDescriptor *other,
-                                               Bool_t inClass)
+   bool TBranchProxyDescriptor::IsEquivalent(const TBranchProxyDescriptor *other, bool inClass)
    {
       if ( !other ) return false;
       if ( other == this ) return true;
@@ -105,7 +104,7 @@ namespace Internal {
    ////////////////////////////////////////////////////////////////////////////////
    /// Return true if the branch is split
 
-   Bool_t TBranchProxyDescriptor::IsSplit() const
+   bool TBranchProxyDescriptor::IsSplit() const
    {
       return fIsSplit;
    }

--- a/tree/treeplayer/src/TBranchProxyDirector.cxx
+++ b/tree/treeplayer/src/TBranchProxyDirector.cxx
@@ -91,10 +91,10 @@ namespace Internal {
       Int_t nbins = gEnv->GetValue("Hist.Binning.1D.x",100);
       Double_t vmin=0, vmax=0;
       Double_t xmin=0, xmax=0;
-      Bool_t canExtend = kTRUE;
+      bool canExtend = true;
       TString opt( options );
-      Bool_t optSame = opt.Contains("same");
-      if (optSame) canExtend = kFALSE;
+      bool optSame = opt.Contains("same");
+      if (optSame) canExtend = false;
 
       if (gPad && optSame) {
          TListIter np(gPad->GetListOfPrimitives());
@@ -114,7 +114,7 @@ namespace Internal {
       } else {
          vmin = xmin;
          vmax = xmax;
-         if (xmin < xmax) canExtend = kFALSE;
+         if (xmin < xmax) canExtend = false;
       }
       TH1F *hist = new TH1F("htemp","htemp",nbins,vmin,vmax);
       hist->SetLineColor(fTree->GetLineColor());
@@ -149,7 +149,7 @@ namespace Internal {
 
    ////////////////////////////////////////////////////////////////////////////////
 
-   Bool_t TBranchProxyDirector::Notify() {
+   bool TBranchProxyDirector::Notify() {
       fEntry = -1;
       bool retVal = true;
       for_each(fDirected.begin(),fDirected.end(),NotifyDirected);

--- a/tree/treeplayer/src/TChainIndex.cxx
+++ b/tree/treeplayer/src/TChainIndex.cxx
@@ -132,9 +132,9 @@ TChainIndex::TChainIndex(const TTree *T, const char *majorname, const char *mino
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Add an index to this chain.
-/// if delaySort is kFALSE (default) check if the indices of different trees are in order.
+/// if delaySort is false (default) check if the indices of different trees are in order.
 
-void TChainIndex::Append(const TVirtualIndex *index, Bool_t delaySort )
+void TChainIndex::Append(const TVirtualIndex *index, bool delaySort )
 {
    if (index) {
       const TTreeIndex *ti_index = dynamic_cast<const TTreeIndex*>(index);
@@ -337,7 +337,7 @@ TTreeFormula *TChainIndex::GetMajorFormulaParent(const TTree *parent)
    if (!fMajorFormulaParent) {
       TTree::TFriendLock friendlock(fTree, TTree::kFindLeaf | TTree::kFindBranch | TTree::kGetBranch | TTree::kGetLeaf);
       fMajorFormulaParent = new TTreeFormula("MajorP",fMajorName.Data(),const_cast<TTree*>(parent));
-      fMajorFormulaParent->SetQuickLoad(kTRUE);
+      fMajorFormulaParent->SetQuickLoad(true);
    }
    if (fMajorFormulaParent->GetTree() != parent) {
       fMajorFormulaParent->SetTree(const_cast<TTree*>(parent));
@@ -356,7 +356,7 @@ TTreeFormula *TChainIndex::GetMinorFormulaParent(const TTree *parent)
       // is a friend of the parent TTree.
       TTree::TFriendLock friendlock(fTree, TTree::kFindLeaf | TTree::kFindBranch | TTree::kGetBranch | TTree::kGetLeaf);
       fMinorFormulaParent = new TTreeFormula("MinorP",fMinorName.Data(),const_cast<TTree*>(parent));
-      fMinorFormulaParent->SetQuickLoad(kTRUE);
+      fMinorFormulaParent->SetQuickLoad(true);
    }
    if (fMinorFormulaParent->GetTree() != parent) {
       fMinorFormulaParent->SetTree(const_cast<TTree*>(parent));
@@ -367,16 +367,16 @@ TTreeFormula *TChainIndex::GetMinorFormulaParent(const TTree *parent)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return kTRUE if index can be applied to the TTree
+/// Return true if index can be applied to the TTree
 
-Bool_t TChainIndex::IsValidFor(const TTree *parent)
+bool TChainIndex::IsValidFor(const TTree *parent)
 {
    auto *majorFormula = GetMajorFormulaParent(parent);
    auto *minorFormula = GetMinorFormulaParent(parent);
    if ((majorFormula == nullptr || majorFormula->GetNdim() == 0) ||
        (minorFormula == nullptr || minorFormula->GetNdim() == 0))
-         return kFALSE;
-   return kTRUE;
+         return false;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/treeplayer/src/TFileDrawMap.cxx
+++ b/tree/treeplayer/src/TFileDrawMap.cxx
@@ -121,7 +121,7 @@ TFileDrawMap::TFileDrawMap(const TFile *file, const char *keys, Option_t *option
    fFrame->SetMaximum(fYsize);
    fFrame->GetYaxis()->SetLimits(0,fYsize);
 
-   //Bool_t show = kFALSE;
+   //bool show = false;
    if (gPad) {
       gPad->Clear();
       //show = gPad->GetCanvas()->GetShowEventStatus();
@@ -382,7 +382,7 @@ char *TFileDrawMap::GetObjectInfo(Int_t px, Int_t py) const
 /// Displays the keys info in the directory
 /// corresponding to cursor position px,py
 
-Bool_t TFileDrawMap::GetObjectInfoDir(TDirectory *dir, Int_t px, Int_t py, TString &info) const
+bool TFileDrawMap::GetObjectInfoDir(TDirectory *dir, Int_t px, Int_t py, TString &info) const
 {
    Double_t x = gPad->AbsPixeltoX(px);
    Double_t y = gPad->AbsPixeltoY(py);
@@ -402,10 +402,10 @@ Bool_t TFileDrawMap::GetObjectInfoDir(TDirectory *dir, Int_t px, Int_t py, TStri
       if (cl && cl == TDirectoryFile::Class()) {
          curdir->cd(key->GetName());
          TDirectory *subdir = gDirectory;
-         Bool_t gotInfo = GetObjectInfoDir(subdir, px, py, info);
+         bool gotInfo = GetObjectInfoDir(subdir, px, py, info);
          if (gotInfo) {
             dirsav->cd();
-            return kTRUE;
+            return true;
          }
          curdir->cd();
          continue;
@@ -432,7 +432,7 @@ Bool_t TFileDrawMap::GetObjectInfoDir(TDirectory *dir, Int_t px, Int_t py, TStri
                   } else {
                      info.Form("%s/%s, branch=%s, basket=%d, entry=%d",curdir->GetPath(),key->GetName(),branch->GetName(),i,entry);
                   }
-                  return kTRUE;
+                  return true;
                }
             }
          }
@@ -446,32 +446,32 @@ Bool_t TFileDrawMap::GetObjectInfoDir(TDirectory *dir, Int_t px, Int_t py, TStri
             info.Form("%s/%s ::%s, nbytes=%d",curdir->GetPath(),key->GetName(),key->GetClassName(),nbytes);
          }
          dirsav->cd();
-         return kTRUE;
+         return true;
       }
    }
    // Are we in the Keys list
    if (pbyte >= dir->GetSeekKeys() && pbyte < dir->GetSeekKeys()+dir->GetNbytesKeys()) {
       info.Form("%sKeys List, nbytes=%d",dir->GetPath(),dir->GetNbytesKeys());
       dirsav->cd();
-      return kTRUE;
+      return true;
    }
    if (dir == (TDirectory*)fFile) {
       // Are we in the TStreamerInfo
       if (pbyte >= fFile->GetSeekInfo() && pbyte < fFile->GetSeekInfo()+fFile->GetNbytesInfo()) {
          info.Form("%sStreamerInfo List, nbytes=%d",dir->GetPath(),fFile->GetNbytesInfo());
          dirsav->cd();
-         return kTRUE;
+         return true;
       }
       // Are we in the Free Segments
       if (pbyte >= fFile->GetSeekFree() && pbyte < fFile->GetSeekFree()+fFile->GetNbytesFree()) {
          info.Form("%sFree List, nbytes=%d",dir->GetPath(),fFile->GetNbytesFree());
          dirsav->cd();
-         return kTRUE;
+         return true;
       }
    }
    info.Form("(byte=%lld)",pbyte);
    dirsav->cd();
-   return kFALSE;
+   return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -546,7 +546,7 @@ void TFileDrawMap::PaintDir(TDirectory *dir, const char *keys)
    TKey *key;
    Int_t color = 0;
    TBox box;
-   TRegexp re(keys,kTRUE);
+   TRegexp re(keys,true);
    while ((key = (TKey*)next())) {
       Int_t nbytes = key->GetNbytes();
       Long64_t bseek = key->GetSeekKey();

--- a/tree/treeplayer/src/TFormLeafInfo.cxx
+++ b/tree/treeplayer/src/TFormLeafInfo.cxx
@@ -338,9 +338,9 @@ Int_t TFormLeafInfo::GetNdata()
 ////////////////////////////////////////////////////////////////////////////////
 /// Return true if any of underlying data has a array size counter
 
-Bool_t TFormLeafInfo::HasCounter() const
+bool TFormLeafInfo::HasCounter() const
 {
-   Bool_t result = kFALSE;
+   bool result = false;
    if (fNext) result = fNext->HasCounter();
    return fCounter!=nullptr || result;
 }
@@ -348,33 +348,33 @@ Bool_t TFormLeafInfo::HasCounter() const
 ////////////////////////////////////////////////////////////////////////////////
 /// Return true if the underlying data is a string
 
-Bool_t TFormLeafInfo::IsString() const
+bool TFormLeafInfo::IsString() const
 {
    if (fNext) return fNext->IsString();
-   if (!fElement) return kFALSE;
+   if (!fElement) return false;
 
    switch (fElement->GetNewType()) {
       // basic types
       case kChar_t:
          // This is new in ROOT 3.02/05
-         return kFALSE;
+         return false;
       case TStreamerInfo::kOffsetL + TStreamerInfo::kChar:
          // This is new in ROOT 3.02/05
-         return kTRUE;
+         return true;
       case TStreamerInfo::kCharStar:
-         return kTRUE;
+         return true;
       default:
-         return kFALSE;
+         return false;
    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return true if the underlying data is an integral value
 
-Bool_t TFormLeafInfo::IsInteger() const
+bool TFormLeafInfo::IsInteger() const
 {
    if (fNext) return fNext->IsInteger();
-   if (!fElement) return kFALSE;
+   if (!fElement) return false;
 
    Int_t atype = fElement->GetNewType();
    if (TStreamerInfo::kOffsetL < atype &&
@@ -399,16 +399,16 @@ Bool_t TFormLeafInfo::IsInteger() const
       case TStreamerInfo::kULong:
       case TStreamerInfo::kLong64:
       case TStreamerInfo::kULong64:
-         return kTRUE;
+         return true;
       case TStreamerInfo::kCharStar:
-         return kTRUE; // For consistency with the leaf list method and proper axis setting
+         return true; // For consistency with the leaf list method and proper axis setting
       case TStreamerInfo::kFloat:
       case TStreamerInfo::kFloat16:
       case TStreamerInfo::kDouble:
       case TStreamerInfo::kDouble32:
-         return kFALSE;
+         return false;
       default:
-         return kFALSE;
+         return false;
    }
 }
 
@@ -506,14 +506,14 @@ void TFormLeafInfo::UpdateSizes(TArrayI *garr)
 /// information has changed (for example when changing from the 'emulated'
 /// class to the real class.
 
-Bool_t TFormLeafInfo::Update()
+bool TFormLeafInfo::Update()
 {
    if (fClass) {
       TClass * new_class = TClass::GetClass(fClassName);
       if (new_class==fClass) {
          if (fNext) fNext->Update();
          if (fCounter) fCounter->Update();
-         return kFALSE;
+         return false;
       }
       fClass = new_class;
    }
@@ -566,7 +566,7 @@ Bool_t TFormLeafInfo::Update()
    }
    if (fNext) fNext->Update();
    if (fCounter) fCounter->Update();
-   return kTRUE;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -665,7 +665,7 @@ void* TFormLeafInfo::GetLocalValuePointer(char *thisobj, Int_t instance)
 
          // array of basic types  array[8]
       case TStreamerInfo::kOffsetL + TStreamerInfo::kBool:
-         {Bool_t *val   = (Bool_t*)(thisobj+fOffset);      return &(val[instance]);}
+         {bool *val   = (bool*)(thisobj+fOffset);      return &(val[instance]);}
       case TStreamerInfo::kOffsetL + TStreamerInfo::kChar:
          {Char_t *val   = (Char_t*)(thisobj+fOffset);      return &(val[instance]);}
       case TStreamerInfo::kOffsetL + TStreamerInfo::kShort:
@@ -712,7 +712,7 @@ void* TFormLeafInfo::GetLocalValuePointer(char *thisobj, Int_t instance)
          }
 
          // pointer to an array of basic types  array[n]
-      case TStreamerInfo::kOffsetP + TStreamerInfo::kBool:    GET_ARRAY(Bool_t)
+      case TStreamerInfo::kOffsetP + TStreamerInfo::kBool:    GET_ARRAY(bool)
       case TStreamerInfo::kOffsetP + TStreamerInfo::kChar:    GET_ARRAY(Char_t)
       case TStreamerInfo::kOffsetP + TStreamerInfo::kShort:   GET_ARRAY(Short_t)
       case TStreamerInfo::kOffsetP + TStreamerInfo::kInt:     GET_ARRAY(Int_t)
@@ -836,7 +836,7 @@ T TFormLeafInfo::ReadValueImpl(char *thisobj, Int_t instance)
    //   return fInfo->ReadValue(thisobj+fOffset,fElement->GetNewType(),instance,1);
    switch (fElement->GetNewType()) {
          // basic types
-      case TStreamerInfo::kBool:       return (T)(*(Bool_t*)(thisobj+fOffset));
+      case TStreamerInfo::kBool:       return (T)(*(bool*)(thisobj+fOffset));
       case TStreamerInfo::kChar:       return (T)(*(Char_t*)(thisobj+fOffset));
       case TStreamerInfo::kUChar:      return (T)(*(UChar_t*)(thisobj+fOffset));
       case TStreamerInfo::kShort:      return (T)(*(Short_t*)(thisobj+fOffset));
@@ -856,7 +856,7 @@ T TFormLeafInfo::ReadValueImpl(char *thisobj, Int_t instance)
 
          // array of basic types  array[8]
       case TStreamerInfo::kOffsetL + TStreamerInfo::kBool:
-         {Bool_t *val    = (Bool_t*)(thisobj+fOffset);    return T(val[instance]);}
+         {bool *val    = (bool*)(thisobj+fOffset);    return T(val[instance]);}
       case TStreamerInfo::kOffsetL + TStreamerInfo::kChar:
          {Char_t *val    = (Char_t*)(thisobj+fOffset);    return T(val[instance]);}
       case TStreamerInfo::kOffsetL + TStreamerInfo::kShort:
@@ -907,7 +907,7 @@ T TFormLeafInfo::ReadValueImpl(char *thisobj, Int_t instance)
          }
 
          // pointer to an array of basic types  array[n]
-      case TStreamerInfo::kOffsetP + TStreamerInfo::kBool:    READ_ARRAY(Bool_t)
+      case TStreamerInfo::kOffsetP + TStreamerInfo::kBool:    READ_ARRAY(bool)
       case TStreamerInfo::kOffsetP + TStreamerInfo::kChar:    READ_ARRAY(Char_t)
       case TStreamerInfo::kOffsetP + TStreamerInfo::kShort:   READ_ARRAY(Short_t)
       case TStreamerInfo::kOffsetP + TStreamerInfo::kInt:     READ_ARRAY(Int_t)
@@ -1003,7 +1003,7 @@ void* TFormLeafInfoDirect::GetLocalValuePointer(char *thisobj, Int_t instance)
 
 TFormLeafInfoNumerical::TFormLeafInfoNumerical(EDataType kind) :
    TFormLeafInfo(nullptr,0,nullptr),
-   fKind(kind), fIsBool(kFALSE)
+   fKind(kind), fIsBool(false)
 {
    fElement = new TStreamerElement("data","in collection", 0, fKind, "");
 }
@@ -1013,7 +1013,7 @@ TFormLeafInfoNumerical::TFormLeafInfoNumerical(EDataType kind) :
 
 TFormLeafInfoNumerical::TFormLeafInfoNumerical(TVirtualCollectionProxy *collection) :
    TFormLeafInfo(nullptr,0,nullptr),
-   fKind(kNoType_t), fIsBool(kFALSE)
+   fKind(kNoType_t), fIsBool(false)
 {
    if (collection) {
       fKind = (EDataType)collection->GetType();
@@ -1021,7 +1021,7 @@ TFormLeafInfoNumerical::TFormLeafInfoNumerical(TVirtualCollectionProxy *collecti
          // Could be a bool
          if (strcmp( collection->GetCollectionClass()->GetName(), "vector<bool>") == 0
              || strncmp( collection->GetCollectionClass()->GetName(), "bitset<", strlen("bitset<") ) ==0 ) {
-            fIsBool = kTRUE;
+            fIsBool = true;
             fKind = (EDataType)18;
          }
       }
@@ -1034,7 +1034,7 @@ TFormLeafInfoNumerical::TFormLeafInfoNumerical(TVirtualCollectionProxy *collecti
 
 TFormLeafInfoNumerical::TFormLeafInfoNumerical(const TFormLeafInfoNumerical& orig) :
    TFormLeafInfo(orig),
-   fKind(orig.fKind), fIsBool(kFALSE)
+   fKind(orig.fKind), fIsBool(false)
 {
    fElement = new TStreamerElement("data","in collection", 0, fKind, "");
 }
@@ -1078,9 +1078,9 @@ TFormLeafInfoNumerical::~TFormLeafInfoNumerical()
 ////////////////////////////////////////////////////////////////////////////////
 /// Return true if the underlying data is a string
 
-Bool_t TFormLeafInfoNumerical::IsString() const
+bool TFormLeafInfoNumerical::IsString() const
 {
-   if (fIsBool) return kFALSE;
+   if (fIsBool) return false;
    return TFormLeafInfo::IsString();
 }
 
@@ -1089,12 +1089,12 @@ Bool_t TFormLeafInfoNumerical::IsString() const
 /// information has changed (for example when changing from the 'emulated'
 /// class to the real class.
 
-Bool_t TFormLeafInfoNumerical::Update()
+bool TFormLeafInfoNumerical::Update()
 {
    //R__ASSERT(fNext==0);
 
    if (fCounter) return fCounter->Update();
-   return kFALSE;
+   return false;
 }
 
 namespace {
@@ -1115,7 +1115,7 @@ namespace {
 /// Constructor.
 
 TFormLeafInfoClones::TFormLeafInfoClones(TClass* classptr, Longptr_t offset) :
-   TFormLeafInfo(classptr,offset,R__GetFakeClonesElem()),fTop(kFALSE)
+   TFormLeafInfo(classptr,offset,R__GetFakeClonesElem()),fTop(false)
 {
 }
 
@@ -1123,7 +1123,7 @@ TFormLeafInfoClones::TFormLeafInfoClones(TClass* classptr, Longptr_t offset) :
 /// Constructor.
 
 TFormLeafInfoClones::TFormLeafInfoClones(TClass* classptr, Longptr_t offset,
-                                         Bool_t top) :
+                                         bool top) :
    TFormLeafInfo(classptr,offset,R__GetFakeClonesElem()),fTop(top)
 {
 }
@@ -1133,7 +1133,7 @@ TFormLeafInfoClones::TFormLeafInfoClones(TClass* classptr, Longptr_t offset,
 
 TFormLeafInfoClones::TFormLeafInfoClones(TClass* classptr, Longptr_t offset,
                                          TStreamerElement* element,
-                                         Bool_t top) :
+                                         bool top) :
    TFormLeafInfo(classptr,offset,element),fTop(top)
 {
 }
@@ -1331,7 +1331,7 @@ void * TFormLeafInfoClones::GetValuePointer(char *where, Int_t instance)
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor.
 
-TFormLeafInfoCollectionObject::TFormLeafInfoCollectionObject(TClass* classptr, Bool_t top) :
+TFormLeafInfoCollectionObject::TFormLeafInfoCollectionObject(TClass* classptr, bool top) :
    TFormLeafInfo(classptr,0,R__GetFakeClonesElem()),fTop(top)
 {
 }
@@ -1456,7 +1456,7 @@ void * TFormLeafInfoCollectionObject::GetValuePointer(char *where, Int_t instanc
 TFormLeafInfoCollection::TFormLeafInfoCollection(TClass* classptr,
                                                  Longptr_t offset,
                                                  TStreamerElement* element,
-                                                 Bool_t top) :
+                                                 bool top) :
    TFormLeafInfo(classptr,offset,element),
    fTop(top),
    fCollClass( nullptr),
@@ -1483,7 +1483,7 @@ TFormLeafInfoCollection::TFormLeafInfoCollection(TClass* classptr,
 TFormLeafInfoCollection::TFormLeafInfoCollection(TClass* motherclassptr,
                                                  Longptr_t offset,
                                                  TClass* elementclassptr,
-                                                 Bool_t top) :
+                                                 bool top) :
    TFormLeafInfo(motherclassptr,offset,
                  new TStreamerElement("collection","in class",
                                       0,
@@ -1518,7 +1518,7 @@ TFormLeafInfoCollection::TFormLeafInfoCollection(TClass* motherclassptr,
 
 TFormLeafInfoCollection::TFormLeafInfoCollection() :
    TFormLeafInfo(),
-   fTop(kFALSE),
+   fTop(false),
    fCollClass( nullptr),
    fCollProxy( nullptr),
    fLocalElement( nullptr)
@@ -1583,9 +1583,9 @@ TFormLeafInfo* TFormLeafInfoCollection::DeepCopy() const
 /// information has changed (for example when changing from the 'emulated'
 /// class to the real class.
 
-Bool_t TFormLeafInfoCollection::Update()
+bool TFormLeafInfoCollection::Update()
 {
-   Bool_t changed = kFALSE;
+   bool changed = false;
    TClass * new_class = TClass::GetClass(fCollClassName);
    if (new_class!=fCollClass) {
       delete fCollProxy; fCollProxy = nullptr;
@@ -1593,7 +1593,7 @@ Bool_t TFormLeafInfoCollection::Update()
       if (fCollClass && fCollClass->GetCollectionProxy()) {
          fCollProxy = fCollClass->GetCollectionProxy()->Generate();
       }
-      changed = kTRUE;
+      changed = true;
    }
    return changed || TFormLeafInfo::Update();
 }
@@ -1601,7 +1601,7 @@ Bool_t TFormLeafInfoCollection::Update()
 ////////////////////////////////////////////////////////////////////////////////
 /// Return true if the underlying data has a array size counter
 
-Bool_t TFormLeafInfoCollection::HasCounter() const
+bool TFormLeafInfoCollection::HasCounter() const
 {
    return fCounter!=nullptr || fCollProxy!=nullptr;
 }
@@ -1904,9 +1904,9 @@ TFormLeafInfo* TFormLeafInfoCollectionSize::DeepCopy() const
 /// information has changed (for example when changing from the 'emulated'
 /// class to the real class.
 
-Bool_t TFormLeafInfoCollectionSize::Update()
+bool TFormLeafInfoCollectionSize::Update()
 {
-   Bool_t changed = kFALSE;
+   bool changed = false;
    TClass *new_class = TClass::GetClass(fCollClassName);
    if (new_class!=fCollClass) {
       delete fCollProxy; fCollProxy = nullptr;
@@ -1914,7 +1914,7 @@ Bool_t TFormLeafInfoCollectionSize::Update()
       if (fCollClass && fCollClass->GetCollectionProxy()) {
          fCollProxy = fCollClass->GetCollectionProxy()->Generate();
       }
-      changed = kTRUE;
+      changed = true;
    }
    return changed;
 }
@@ -2084,7 +2084,7 @@ INSTANTIATE_READVAL(TFormLeafInfoPointer);
 TFormLeafInfoMethod::TFormLeafInfoMethod( TClass* classptr,
                                           TMethodCall *method) :
    TFormLeafInfo(classptr,0,nullptr),fMethod(method),
-   fResult(0), fCopyFormat(),fDeleteFormat(),fValuePointer(nullptr),fIsByValue(kFALSE)
+   fResult(0), fCopyFormat(),fDeleteFormat(),fValuePointer(nullptr),fIsByValue(false)
 {
    if (method) {
       fMethodName = method->GetMethodName();
@@ -2106,7 +2106,7 @@ TFormLeafInfoMethod::TFormLeafInfoMethod( TClass* classptr,
             fDeleteFormat += rtype;
             fDeleteFormat += "*)0x%zx";
 
-            fIsByValue = kTRUE;
+            fIsByValue = true;
          }
       }
    }
@@ -2228,18 +2228,18 @@ TClass* TFormLeafInfoMethod::GetClass() const
 ////////////////////////////////////////////////////////////////////////////////
 /// Return true if the return value is integral.
 
-Bool_t TFormLeafInfoMethod::IsInteger() const
+bool TFormLeafInfoMethod::IsInteger() const
 {
    TMethodCall::EReturnType r = fMethod->ReturnType();
    if (r == TMethodCall::kLong) {
-      return kTRUE;
-   } else return kFALSE;
+      return true;
+   } else return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return true if the return value is a string.
 
-Bool_t TFormLeafInfoMethod::IsString() const
+bool TFormLeafInfoMethod::IsString() const
 {
    if (fNext) return fNext->IsString();
 
@@ -2252,12 +2252,12 @@ Bool_t TFormLeafInfoMethod::IsString() const
 /// information has changed (for example when changing from the 'emulated'
 /// class to the real class.
 
-Bool_t TFormLeafInfoMethod::Update()
+bool TFormLeafInfoMethod::Update()
 {
-   if (!TFormLeafInfo::Update()) return kFALSE;
+   if (!TFormLeafInfo::Update()) return false;
    delete fMethod;
    fMethod = new TMethodCall(fClass, fMethodName, fParams);
-   return kTRUE;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2584,9 +2584,9 @@ Int_t TFormLeafInfoMultiVarDim::GetVirtVarDim()
 /// information has changed (for example when changing from the 'emulated'
 /// class to the real class.
 
-Bool_t TFormLeafInfoMultiVarDim::Update()
+bool TFormLeafInfoMultiVarDim::Update()
 {
-   Bool_t res = TFormLeafInfo::Update();
+   bool res = TFormLeafInfo::Update();
    if (fCounter2) fCounter2->Update();
    return res;
 }
@@ -2871,7 +2871,7 @@ INSTANTIATE_READVAL(TFormLeafInfoMultiVarDimClones);
 /// Constructor.
 
 TFormLeafInfoCast::TFormLeafInfoCast(TClass* classptr, TClass* casted) :
-   TFormLeafInfo(classptr),fCasted(casted),fGoodCast(kTRUE)
+   TFormLeafInfo(classptr),fCasted(casted),fGoodCast(true)
 {
    if (casted) { fCastedName = casted->GetName(); }
    fMultiplicity = -1;
@@ -2949,13 +2949,13 @@ T TFormLeafInfoCast::ReadValueImpl(char *where, Int_t instance)
    // casted class
    // First assume TObject ...
    if ( fIsTObject && !((TObject*)where)->InheritsFrom(fCasted) ) {
-      fGoodCast = kFALSE;
+      fGoodCast = false;
       return 0;
    } else {
       // We know we have a TBranchElement and we need to find out the
       // real class name.
    }
-   fGoodCast = kTRUE;
+   fGoodCast = true;
    return fNext->ReadTypedValue<T>(where,instance);
 }
 
@@ -2967,7 +2967,7 @@ INSTANTIATE_READVAL(TFormLeafInfoCast);
 /// information has changed (for example when changing from the 'emulated'
 /// class to the real class.
 
-Bool_t TFormLeafInfoCast::Update()
+bool TFormLeafInfoCast::Update()
 {
    if (fCasted) {
       TClass * new_class = TClass::GetClass(fCastedName);
@@ -3045,7 +3045,7 @@ INSTANTIATE_READVAL(TFormLeafInfoTTree);
 ////////////////////////////////////////////////////////////////////////////////
 /// Update after a change of file in a chain
 
-Bool_t TFormLeafInfoTTree::Update()
+bool TFormLeafInfoTTree::Update()
 {
    if (fAlias.Length() && fAlias != fTree->GetName()) {
       fCurrent = fTree->GetFriend(fAlias.Data());

--- a/tree/treeplayer/src/TFormLeafInfoReference.cxx
+++ b/tree/treeplayer/src/TFormLeafInfoReference.cxx
@@ -95,9 +95,9 @@ TClass* TFormLeafInfoReference::GetClass() const
 ////////////////////////////////////////////////////////////////////////////////
 /// Return true if any of underlying data has a array size counter
 
-Bool_t TFormLeafInfoReference::HasCounter() const
+bool TFormLeafInfoReference::HasCounter() const
 {
-   Bool_t result = fProxy ? fProxy->HasCounter() : false;
+   bool result = fProxy ? fProxy->HasCounter() : false;
    if (fNext) result |= fNext->HasCounter();
    return fCounter!=nullptr || result;
 }
@@ -154,9 +154,9 @@ TClass* TFormLeafInfoReference::GetValueClass(void* obj)
 ////////////////////////////////////////////////////////////////////////////////
 /// TFormLeafInfo overload: Update (and propagate) cached information
 
-Bool_t TFormLeafInfoReference::Update()
+bool TFormLeafInfoReference::Update()
 {
-   Bool_t res = this->TFormLeafInfo::Update();
+   bool res = this->TFormLeafInfo::Update();
    if ( fProxy ) fProxy->Update();
    return res;
 }

--- a/tree/treeplayer/src/TFriendProxyDescriptor.cxx
+++ b/tree/treeplayer/src/TFriendProxyDescriptor.cxx
@@ -32,7 +32,7 @@ namespace Internal {
                                                   const char *aliasname,
                                                   Int_t index) :
       TNamed(treename,aliasname),
-      fDuplicate(kFALSE),
+      fDuplicate(false),
       fIndex(index)
    {
    }
@@ -41,22 +41,22 @@ namespace Internal {
    /// Return true if this descriptor and the other are equivalent (describe the
    /// same entity).
 
-   Bool_t TFriendProxyDescriptor::IsEquivalent(const TFriendProxyDescriptor *other)
+   bool TFriendProxyDescriptor::IsEquivalent(const TFriendProxyDescriptor *other)
    {
-      if ( !other ) return kFALSE;
-      if ( strcmp(GetName(),other->GetName()) ) return kFALSE;
+      if ( !other ) return false;
+      if ( strcmp(GetName(),other->GetName()) ) return false;
 
       TBranchProxyDescriptor *desc;
       TBranchProxyDescriptor *othdesc;
 
-      if ( fListOfTopProxies.GetSize() != other->fListOfTopProxies.GetSize() ) return kFALSE;
+      if ( fListOfTopProxies.GetSize() != other->fListOfTopProxies.GetSize() ) return false;
       TIter next(&fListOfTopProxies);
       TIter othnext(&other->fListOfTopProxies);
       while ( (desc=(TBranchProxyDescriptor*)next()) ) {
          othdesc=(TBranchProxyDescriptor*)othnext();
-         if (!desc->IsEquivalent(othdesc) ) return kFALSE;
+         if (!desc->IsEquivalent(othdesc) ) return false;
       }
-      return kTRUE;
+      return true;
    }
 
    //////////////////////////////////////////////////////////////////////////

--- a/tree/treeplayer/src/TMPWorkerTree.cxx
+++ b/tree/treeplayer/src/TMPWorkerTree.cxx
@@ -45,7 +45,7 @@
 
 TMPWorkerTree::TMPWorkerTree()
    : TMPWorker(), fFileNames(), fTreeName(), fTree(nullptr), fFile(nullptr), fEntryList(nullptr), fFirstEntry(0),
-     fTreeCache(nullptr), fTreeCacheIsLearning(kFALSE), fUseTreeCache(kTRUE), fCacheSize(-1)
+     fTreeCache(nullptr), fTreeCacheIsLearning(false), fUseTreeCache(true), fCacheSize(-1)
 {
    Setup();
 }
@@ -53,7 +53,7 @@ TMPWorkerTree::TMPWorkerTree()
 TMPWorkerTree::TMPWorkerTree(const std::vector<std::string> &fileNames, TEntryList *entries,
                              const std::string &treeName, UInt_t nWorkers, ULong64_t maxEntries, ULong64_t firstEntry)
    : TMPWorker(nWorkers, maxEntries), fFileNames(fileNames), fTreeName(treeName), fTree(nullptr), fFile(nullptr),
-     fEntryList(entries), fFirstEntry(firstEntry), fTreeCache(nullptr), fTreeCacheIsLearning(kFALSE), fUseTreeCache(kTRUE),
+     fEntryList(entries), fFirstEntry(firstEntry), fTreeCache(nullptr), fTreeCacheIsLearning(false), fUseTreeCache(true),
      fCacheSize(-1)
 {
    Setup();
@@ -62,7 +62,7 @@ TMPWorkerTree::TMPWorkerTree(const std::vector<std::string> &fileNames, TEntryLi
 TMPWorkerTree::TMPWorkerTree(TTree *tree, TEntryList *entries, UInt_t nWorkers, ULong64_t maxEntries,
                              ULong64_t firstEntry)
    : TMPWorker(nWorkers, maxEntries), fTree(tree), fFile(nullptr), fEntryList(entries), fFirstEntry(firstEntry),
-     fTreeCache(nullptr), fTreeCacheIsLearning(kFALSE), fUseTreeCache(kTRUE), fCacheSize(-1)
+     fTreeCache(nullptr), fTreeCacheIsLearning(false), fUseTreeCache(true), fCacheSize(-1)
 {
    Setup();
 }
@@ -78,7 +78,7 @@ TMPWorkerTree::~TMPWorkerTree()
 void TMPWorkerTree::Setup()
 {
    Int_t uc = gEnv->GetValue("MultiProc.UseTreeCache", 1);
-   if (uc != 1) fUseTreeCache = kFALSE;
+   if (uc != 1) fUseTreeCache = false;
    fCacheSize = gEnv->GetValue("MultiProc.CacheSize", -1);
 }
 
@@ -285,7 +285,7 @@ Int_t TMPWorkerTree::LoadTree(UInt_t code, MPCodeBufPair &msg, Long64_t &start, 
 
    UInt_t fileN = 0;
    UInt_t nProcessed = 0;
-   Bool_t setupcache = true;
+   bool setupcache = true;
 
    std::string mgroot = "[S" + std::to_string(GetNWorker()) + "]: ";
 

--- a/tree/treeplayer/src/TRefProxy.cxx
+++ b/tree/treeplayer/src/TRefProxy.cxx
@@ -28,9 +28,9 @@ stored contained in other objects from TTree::Draw
 ////////////////////////////////////////////////////////////////////////////////
 /// TVirtualRefProxy overload: Update (and propagate) cached information
 
-Bool_t TRefProxy::Update()
+bool TRefProxy::Update()
 {
-   return kTRUE;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/treeplayer/src/TSelectorDraw.cxx
+++ b/tree/treeplayer/src/TSelectorDraw.cxx
@@ -53,7 +53,7 @@ TSelectorDraw::TSelectorDraw()
    fVmin           = new Double_t[fValSize];
    fVmax           = new Double_t[fValSize];
    fNbins          = new Int_t[fValSize];
-   fVarMultiple    = new Bool_t[fValSize];
+   fVarMultiple    = new bool[fValSize];
    fVar            = new TTreeFormula*[fValSize];
    for (Int_t i = 0; i < fValSize; ++i) {
       fVal[i] = nullptr;
@@ -66,9 +66,9 @@ TSelectorDraw::TSelectorDraw()
    fDraw           = 0;
    fObject         = nullptr;
    fOldHistogram   = nullptr;
-   fObjEval        = kFALSE;
-   fSelectMultiple = kFALSE;
-   fCleanElist     = kFALSE;
+   fObjEval        = false;
+   fSelectMultiple = false;
+   fCleanElist     = false;
    fTreeElist      = nullptr;
    fAction         = 0;
    fNfill          = 0;
@@ -128,36 +128,36 @@ void TSelectorDraw::Begin(TTree *tree)
    TEntryList *enlist = nullptr;
    TEventList *evlist = nullptr;
    TString htitle;
-   Bool_t profile = kFALSE;
-   Bool_t optSame = kFALSE;
-   Bool_t optEnlist = kFALSE;
-   Bool_t optEnlistArray = kFALSE;
-   Bool_t optpara = kFALSE;
-   Bool_t optcandle = kFALSE;
-   Bool_t opt5d = kFALSE;
+   bool profile = false;
+   bool optSame = false;
+   bool optEnlist = false;
+   bool optEnlistArray = false;
+   bool optpara = false;
+   bool optcandle = false;
+   bool opt5d = false;
    if (opt.Contains("same")) {
-      optSame = kTRUE;
+      optSame = true;
       opt.ReplaceAll("same", "");
    }
    if (opt.Contains("entrylist")) {
-      optEnlist = kTRUE;
+      optEnlist = true;
       if (opt.Contains("entrylistarray")) {
-         optEnlistArray = kTRUE;
+         optEnlistArray = true;
          opt.ReplaceAll("entrylistarray", "");
       } else {
          opt.ReplaceAll("entrylist", "");
       }
    }
    if (opt.Contains("para")) {
-      optpara = kTRUE;
+      optpara = true;
       opt.ReplaceAll("para", "");
    }
    if (opt.Contains("candle")) {
-      optcandle = kTRUE;
+      optcandle = true;
       opt.ReplaceAll("candle", "");
    }
    if (opt.Contains("gl5d")) {
-      opt5d = kTRUE;
+      opt5d = true;
       opt.ReplaceAll("gl5d", "");
    }
    TCut realSelection(selection);
@@ -170,9 +170,9 @@ void TSelectorDraw::Begin(TTree *tree)
       //Calling GetEntryList function changes ownership and here
       //we want fTree to still delete this entry list
 
-      inElist->SetBit(kCanDelete, kTRUE);
+      inElist->SetBit(kCanDelete, true);
    }
-   fCleanElist = kFALSE;
+   fCleanElist = false;
    fTreeElist = inElist;
 
    fTreeElistArray = inElist ? dynamic_cast<TEntryListArray*>(fTreeElist) : nullptr;
@@ -192,8 +192,8 @@ void TSelectorDraw::Begin(TTree *tree)
    //   fOldHistogram     - pointer to hist hname
    //   elist     - pointer to selection list of hname
 
-   Bool_t canExtend = kTRUE;
-   if (optSame) canExtend = kFALSE;
+   bool canExtend = true;
+   if (optSame) canExtend = false;
 
    Int_t nbinsx = 0, nbinsy = 0, nbinsz = 0;
    Double_t xmin = 0, xmax = 0, ymin = 0, ymax = 0, zmin = 0, zmax = 0;
@@ -217,10 +217,10 @@ void TSelectorDraw::Begin(TTree *tree)
       hkeep  = 1;
       varexp = new char[i+1];
       varexp[0] = 0; //necessary if i=0
-      Bool_t hnameplus = kFALSE;
+      bool hnameplus = false;
       while (*hname == ' ') hname++;
       if (*hname == '+') {
-         hnameplus = kTRUE;
+         hnameplus = true;
          hname++;
          while (*hname == ' ') hname++; //skip ' '
       }
@@ -419,7 +419,7 @@ void TSelectorDraw::Begin(TTree *tree)
                      } else {
                         inElist = new TEntryList(*enlist);
                      }
-                     fCleanElist = kTRUE;
+                     fCleanElist = true;
                      fTree->SetEntryList(inElist);
                   }
                   enlist->Reset();
@@ -505,11 +505,11 @@ void TSelectorDraw::Begin(TTree *tree)
       Int_t olddim = fOldHistogram->GetDimension();
       Int_t mustdelete = 0;
       if (fOldHistogram->InheritsFrom(TProfile::Class())) {
-         profile = kTRUE;
+         profile = true;
          olddim = 2;
       }
       if (fOldHistogram->InheritsFrom(TProfile2D::Class())) {
-         profile = kTRUE;
+         profile = true;
          olddim = 3;
       }
       if (opt.Contains("prof") && fDimension > 1) {
@@ -563,7 +563,7 @@ void TSelectorDraw::Begin(TTree *tree)
             fAction   = -1;
             fVmin[0] = xmin;
             fVmax[0] = xmax;
-            if (xmin < xmax) canExtend = kFALSE;
+            if (xmin < xmax) canExtend = false;
          }
       }
       if (fOldHistogram) {
@@ -625,7 +625,7 @@ void TSelectorDraw::Begin(TTree *tree)
             fVmax[1] = xmax;
             fVmin[0] = ymin;
             fVmax[0] = ymax;
-            if (xmin < xmax && ymin < ymax) canExtend = kFALSE;
+            if (xmin < xmax && ymin < ymax) canExtend = false;
          }
       }
       if (profile || opt.Contains("prof")) {
@@ -638,7 +638,7 @@ void TSelectorDraw::Begin(TTree *tree)
                fAction = -4;
                fVmin[1] = xmin;
                fVmax[1] = xmax;
-               if (xmin < xmax) canExtend = kFALSE;
+               if (xmin < xmax) canExtend = false;
             }
             if (fAction == 2) {
                //we come here when option = "same prof"
@@ -706,13 +706,13 @@ void TSelectorDraw::Begin(TTree *tree)
          }
          fVar[0]->SetAxis(h2->GetYaxis());
          fVar[1]->SetAxis(h2->GetXaxis());
-         Bool_t graph = kFALSE;
+         bool graph = false;
          Int_t l = opt.Length();
-         if (l == 0 || optSame) graph = kTRUE;
-         if (opt.Contains("p")     || opt.Contains("*")    || opt.Contains("l"))    graph = kTRUE;
-         if (opt.Contains("surf")  || opt.Contains("lego") || opt.Contains("cont")) graph = kFALSE;
-         if (opt.Contains("col")   || opt.Contains("hist") || opt.Contains("scat")) graph = kFALSE;
-         if (opt.Contains("box"))                                                   graph = kFALSE;
+         if (l == 0 || optSame) graph = true;
+         if (opt.Contains("p")     || opt.Contains("*")    || opt.Contains("l"))    graph = true;
+         if (opt.Contains("surf")  || opt.Contains("lego") || opt.Contains("cont")) graph = false;
+         if (opt.Contains("col")   || opt.Contains("hist") || opt.Contains("scat")) graph = false;
+         if (opt.Contains("box"))                                                   graph = false;
          fObject = h2;
          if (graph) {
             fAction = 12;
@@ -775,7 +775,7 @@ void TSelectorDraw::Begin(TTree *tree)
             fVmax[1] = ymax;
             fVmin[0] = zmin;
             fVmax[0] = zmax;
-            if (xmin < xmax && ymin < ymax && zmin < zmax) canExtend = kFALSE;
+            if (xmin < xmax && ymin < ymax && zmin < zmax) canExtend = false;
          }
       }
       if ((fDimension == 3) && (profile || opt.Contains("prof"))) {
@@ -790,7 +790,7 @@ void TSelectorDraw::Begin(TTree *tree)
                fVmax[2] = xmax;
                fVmin[1] = ymin;
                fVmax[1] = ymax;
-               if (xmin < xmax && ymin < ymax) canExtend = kFALSE;
+               if (xmin < xmax && ymin < ymax) canExtend = false;
             }
             if (opt.Contains("profs")) {
                hp = new TProfile2D(hname, htitle.Data(), fNbins[2], fVmin[2], fVmax[2], fNbins[1], fVmin[1], fVmax[1], "s");
@@ -909,13 +909,13 @@ void TSelectorDraw::Begin(TTree *tree)
    }
    if (varexp) delete[] varexp;
    for (i = 0; i < fValSize; ++i)
-      fVarMultiple[i] = kFALSE;
-   fSelectMultiple = kFALSE;
+      fVarMultiple[i] = false;
+   fSelectMultiple = false;
    for (i = 0; i < fDimension; ++i) {
-      if (fVar[i] && fVar[i]->GetMultiplicity()) fVarMultiple[i] = kTRUE;
+      if (fVar[i] && fVar[i]->GetMultiplicity()) fVarMultiple[i] = true;
    }
 
-   if (fSelect && fSelect->GetMultiplicity()) fSelectMultiple = kTRUE;
+   if (fSelect && fSelect->GetMultiplicity()) fSelectMultiple = true;
 
    fForceRead = fTree->TestBit(TTree::kForceRead);
    fWeight  = fTree->GetWeight();
@@ -971,9 +971,9 @@ void TSelectorDraw::ClearFormula()
 ///
 /// in a selection all the C++ operators are authorized
 ///
-/// Return kFALSE if any of the variable is not compilable.
+/// Return false if any of the variable is not compilable.
 
-Bool_t TSelectorDraw::CompileVariables(const char *varexp, const char *selection)
+bool TSelectorDraw::CompileVariables(const char *varexp, const char *selection)
 {
    Int_t i, nch, ncols;
 
@@ -981,15 +981,15 @@ Bool_t TSelectorDraw::CompileVariables(const char *varexp, const char *selection
    fDimension = 0;
    ClearFormula();
    fMultiplicity = 0;
-   fObjEval = kFALSE;
+   fObjEval = false;
 
    if (strlen(selection)) {
       fSelect = new TTreeFormula("Selection", selection, fTree);
-      fSelect->SetQuickLoad(kTRUE);
+      fSelect->SetQuickLoad(true);
       if (!fSelect->GetNdim()) {
          delete fSelect;
          fSelect = nullptr;
-         return kFALSE;
+         return false;
       }
    }
 
@@ -1009,7 +1009,7 @@ Bool_t TSelectorDraw::CompileVariables(const char *varexp, const char *selection
          if (fManager->GetMultiplicity() >= 1) fMultiplicity = fManager->GetMultiplicity();
       }
 
-      return kTRUE;
+      return true;
    }
 
    // otherwise select only the specified columns
@@ -1023,8 +1023,8 @@ Bool_t TSelectorDraw::CompileVariables(const char *varexp, const char *selection
    fTree->ResetBit(TTree::kForceRead);
    for (i = 0; i < ncols; ++i) {
       fVar[i] = new TTreeFormula(TString::Format("Var%i", i + 1), varnames[i].Data(), fTree);
-      fVar[i]->SetQuickLoad(kTRUE);
-      if(!fVar[i]->GetNdim()) { ClearFormula(); return kFALSE; }
+      fVar[i]->SetQuickLoad(true);
+      if(!fVar[i]->GetNdim()) { ClearFormula(); return false; }
       fManager->Add(fVar[i]);
    }
    fManager->Sync();
@@ -1037,10 +1037,10 @@ Bool_t TSelectorDraw::CompileVariables(const char *varexp, const char *selection
    if (ncols == 1) {
       TClass *cl = fVar[0]->EvalClass();
       if (cl) {
-         fObjEval = kTRUE;
+         fObjEval = true;
       }
    }
-   return kTRUE;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1103,7 +1103,7 @@ void TSelectorDraw::InitArrays(Int_t newsize)
       fNbins = new Int_t[fValSize];
       fVmin = new Double_t[fValSize];
       fVmax = new Double_t[fValSize];
-      fVarMultiple = new Bool_t[fValSize];
+      fVarMultiple = new bool[fValSize];
 
       for (Int_t i = 0; i < oldsize; ++i)
          delete [] fVal[i];
@@ -1126,21 +1126,21 @@ UInt_t TSelectorDraw::SplitNames(const TString &varexp, std::vector<TString> &na
 {
    names.clear();
 
-   Bool_t ternary = kFALSE;
+   bool ternary = false;
    Int_t prev = 0;
    for (Int_t i = 0; i < varexp.Length(); i++) {
       if (varexp[i] == ':'
           && !((i > 0 && varexp[i-1] == ':') || varexp[i+1] == ':')
          ) {
          if (ternary) {
-            ternary = kFALSE;
+            ternary = false;
          } else {
             names.push_back(varexp(prev, i - prev));
             prev = i + 1;
          }
       }
       if (varexp[i] == '?') {
-         ternary = kTRUE;
+         ternary = true;
       }
    }
    names.push_back(varexp(prev, varexp.Length() - prev));
@@ -1151,7 +1151,7 @@ UInt_t TSelectorDraw::SplitNames(const TString &varexp, std::vector<TString> &na
 ////////////////////////////////////////////////////////////////////////////////
 /// This function is called at the first entry of a new tree in a chain.
 
-Bool_t TSelectorDraw::Notify()
+bool TSelectorDraw::Notify()
 {
    if (fTree) fWeight  = fTree->GetWeight();
    if (fVar) {
@@ -1160,7 +1160,7 @@ Bool_t TSelectorDraw::Notify()
       }
    }
    if (fSelect) fSelect->UpdateFormulaLeaves();
-   return kTRUE;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1224,7 +1224,7 @@ void TSelectorDraw::ProcessFillMultiple(Long64_t entry)
 
    // Calculate the first values
    if (fSelect) {
-      // coverity[var_deref_model] fSelectMultiple==kTRUE => fSelect != 0
+      // coverity[var_deref_model] fSelectMultiple==true => fSelect != 0
       fW[fNfill] = fWeight * fSelect->EvalInstance(0);
       if (!fW[fNfill] && !fSelectMultiple) return;
    } else fW[fNfill] = fWeight;
@@ -1253,7 +1253,7 @@ void TSelectorDraw::ProcessFillMultiple(Long64_t entry)
       if (subList && !subList->Contains(i))
          continue;
       if (fSelectMultiple) {
-         // coverity[var_deref_model] fSelectMultiple==kTRUE => fSelect != 0
+         // coverity[var_deref_model] fSelectMultiple==true => fSelect != 0
          ww = fWeight * fSelect->EvalInstance(i);
          if (ww == 0) continue;
          if (fNfill == nfill0) {
@@ -1403,7 +1403,7 @@ void TSelectorDraw::TakeAction()
          THLimitsFinder::GetLimitsFinder()->FindGoodLimits(h2, fVmin[1], fVmax[1], fVmin[0], fVmax[0]);
       }
       TGraph *pm = new TGraph(fNfill, fVal[1], fVal[0]);
-      pm->SetEditable(kFALSE);
+      pm->SetEditable(false);
       pm->SetBit(kCanDelete);
       pm->SetMarkerStyle(fTree->GetMarkerStyle());
       pm->SetMarkerColor(fTree->GetMarkerColor());
@@ -1524,7 +1524,7 @@ void TSelectorDraw::TakeAction()
    //__________________________Parallel coordinates / candle chart_______________________
    else if (fAction == 6 || fAction == 7) {
       TakeEstimate();
-      Bool_t candle = (fAction == 7);
+      bool candle = (fAction == 7);
       // Using CINT to avoid a dependency in TParallelCoord
       if (!fOption.Contains("goff"))
          gROOT->ProcessLine(TString::Format("TParallelCoord::BuildParallelCoord((TSelectorDraw*)0x%zx,0x%zx)",
@@ -1633,7 +1633,7 @@ void TSelectorDraw::TakeEstimate()
             // because h2 will be filled below and we do not want to show
             // the binned scatter-plot, the TGraph being better.
             TH1 *h2c = h2->DrawCopy(fOption.Data(),"");
-            if (h2c) h2c->SetStats(kFALSE);
+            if (h2c) h2c->SetStats(false);
          } else {
             // case like: T.Draw("y:x")
             // h2 is a temporary histogram (htemp). This histogram
@@ -1643,7 +1643,7 @@ void TSelectorDraw::TakeEstimate()
          gPad->Update();
       }
       TGraph *pm = new TGraph(fNfill, fVal[1], fVal[0]);
-      pm->SetEditable(kFALSE);
+      pm->SetEditable(false);
       pm->SetBit(kCanDelete);
       pm->SetMarkerStyle(fTree->GetMarkerStyle());
       pm->SetMarkerColor(fTree->GetMarkerColor());
@@ -1681,10 +1681,10 @@ void TSelectorDraw::TakeEstimate()
    //__________________________3D scatter plot with option col_______________________
    } else if (fAction == 33) {
       TH2 *h2 = (TH2*)fObject;
-      Bool_t process2 = kFALSE;
+      bool process2 = false;
       if (h2->CanExtendAllAxes()) {
          if (vminOld[2] == DBL_MAX)
-            process2 = kTRUE;
+            process2 = true;
          for (i = 0; i < fValSize && i < 4; i++) {
             fVmin[i] = vminOld[i];
             fVmax[i] = vmaxOld[i];
@@ -1742,7 +1742,7 @@ void TSelectorDraw::TakeEstimate()
             // because h3 will be filled below and we do not want to show
             // the binned scatter-plot, the TGraph being better.
             TH1 *h3c = h3->DrawCopy(fOption.Data(),"");
-            if (h3c) h3c->SetStats(kFALSE);
+            if (h3c) h3c->SetStats(false);
          } else {
             // case like: T.Draw("y:x")
             // h3 is a temporary histogram (htemp). This histogram

--- a/tree/treeplayer/src/TSelectorEntries.cxx
+++ b/tree/treeplayer/src/TSelectorEntries.cxx
@@ -44,7 +44,7 @@ To use this file, try the following session on your Tree T:
 /// Default, constructor.
 
 TSelectorEntries::TSelectorEntries(TTree *tree, const char *selection) :
-   fOwnInput(kFALSE), fChain(tree), fSelect(nullptr), fSelectedRows(0), fSelectMultiple(kFALSE)
+   fOwnInput(false), fChain(tree), fSelect(nullptr), fSelectedRows(0), fSelectMultiple(false)
 {
    if (selection && selection[0]) {
       TSelectorEntries::SetSelection(selection);
@@ -55,7 +55,7 @@ TSelectorEntries::TSelectorEntries(TTree *tree, const char *selection) :
 /// Constructor.
 
 TSelectorEntries::TSelectorEntries(const char *selection) :
-   fOwnInput(kFALSE), fChain(nullptr), fSelect(nullptr), fSelectedRows(0), fSelectMultiple(kFALSE)
+   fOwnInput(false), fChain(nullptr), fSelect(nullptr), fSelectedRows(0), fSelectMultiple(false)
 {
    TSelectorEntries::SetSelection(selection);
 }
@@ -101,10 +101,10 @@ void TSelectorEntries::SlaveBegin(TTree *tree)
 
    if (strlen(selection)) {
       fSelect = new TTreeFormula("Selection",selection,fChain);
-      fSelect->SetQuickLoad(kTRUE);
+      fSelect->SetQuickLoad(true);
       if (!fSelect->GetNdim()) {delete fSelect; fSelect = nullptr; return; }
    }
-   if (fSelect && fSelect->GetMultiplicity()) fSelectMultiple = kTRUE;
+   if (fSelect && fSelect->GetMultiplicity()) fSelectMultiple = true;
 
    fChain->ResetBit(TTree::kForceRead);
 }
@@ -133,10 +133,10 @@ void TSelectorEntries::Init(TTree * /* tree */)
 ////////////////////////////////////////////////////////////////////////////////
 /// This function is called at the first entry of a new tree in a chain.
 
-Bool_t TSelectorEntries::Notify()
+bool TSelectorEntries::Notify()
 {
    if (fSelect) fSelect->UpdateFormulaLeaves();
-   return kTRUE;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -158,7 +158,7 @@ Bool_t TSelectorEntries::Notify()
 ///
 /// The return value is currently not used.
 
-Bool_t TSelectorEntries::Process(Long64_t /* entry */)
+bool TSelectorEntries::Process(Long64_t /* entry */)
 {
    if (!fSelectMultiple) {
       if (fSelect) {
@@ -173,7 +173,7 @@ Bool_t TSelectorEntries::Process(Long64_t /* entry */)
       Int_t ndata = fSelect->GetNdata();
 
       // No data at all, let's move on to the next entry.
-      if (!ndata) return kTRUE;
+      if (!ndata) return true;
 
       // Calculate the first values
       // Always call EvalInstance(0) to insure the loading
@@ -189,7 +189,7 @@ Bool_t TSelectorEntries::Process(Long64_t /* entry */)
          }
       }
    }
-   return kTRUE;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -198,7 +198,7 @@ Bool_t TSelectorEntries::Process(Long64_t /* entry */)
 void TSelectorEntries::SetSelection(const char *selection)
 {
    if (!fInput) {
-      fOwnInput = kTRUE;
+      fOwnInput = true;
       fInput = new TList;
    }
    TNamed *cselection = (TNamed*)fInput->FindObject("selection");

--- a/tree/treeplayer/src/TTreeDrawArgsParser.cxx
+++ b/tree/treeplayer/src/TTreeDrawArgsParser.cxx
@@ -60,18 +60,18 @@ void TTreeDrawArgsParser::ClearPrevious()
    for (i = 0; i < fgMaxDimension; i++) {
       fVarExp[i] = "";
    }
-   fAdd = kFALSE;
+   fAdd = false;
    fName = "";
    fNoParameters = 0;
    for (i = 0; i < fgMaxParameters; i++) {
-      fParameterGiven[i] = kFALSE;
+      fParameterGiven[i] = false;
       fParameters[i] = 0;
    }
-   fShouldDraw = kTRUE;
+   fShouldDraw = true;
    fOriginal = nullptr;
-   fDrawProfile = kFALSE;
-   fOptionSame = kFALSE;
-   fEntryList = kFALSE;
+   fDrawProfile = false;
+   fOptionSame = false;
+   fEntryList = false;
    fOutputType = kUNKNOWN;
 }
 
@@ -90,13 +90,13 @@ void TTreeDrawArgsParser::ClearPrevious()
 ///  - `fVarExp[0] := <first variable string>`
 ///  - `fVarExp[1] := <second variable string>`
 /// ..
-/// Returns kFALSE in case of an error.
+/// Returns false in case of an error.
 
-Bool_t TTreeDrawArgsParser::SplitVariables(TString variables)
+bool TTreeDrawArgsParser::SplitVariables(TString variables)
 {
    fDimension = 0;
    if (variables.Length() == 0)
-      return kTRUE;
+      return true;
 
    int prev = 0;
    int i;
@@ -112,9 +112,9 @@ Bool_t TTreeDrawArgsParser::SplitVariables(TString variables)
    if (fDimension < fgMaxDimension && i != prev)
       fVarExp[fDimension++] = variables(prev, i - prev);
    else
-      return kFALSE;
+      return false;
 
-   return kTRUE;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -126,23 +126,23 @@ Bool_t TTreeDrawArgsParser::SplitVariables(TString variables)
 /// sets the fileds fNoParameters, fParameterGiven, fParameters, fAdd, fName
 /// to appropriate values.
 ///
-/// Returns kFALSE in case of an error.
+/// Returns false in case of an error.
 
-Bool_t TTreeDrawArgsParser::ParseName(TString name)
+bool TTreeDrawArgsParser::ParseName(TString name)
 {
    name.ReplaceAll(" ", "");
 
    if (name.Length() != 0 && name[0] == '+') {
-      fAdd = kTRUE;
+      fAdd = true;
       name = name (1, name.Length() - 1);
    }
    else
-      fAdd = kFALSE;
-   Bool_t result = kTRUE;
+      fAdd = false;
+   bool result = true;
 
    fNoParameters = 0;
    for (int i = 0; i < fgMaxParameters; i++)
-      fParameterGiven[i] = kFALSE;
+      fParameterGiven[i] = false;
 
    if (char *p = (char*)strstr(name.Data(), "(")) {
       fName = name(0, p - name.Data());
@@ -155,12 +155,12 @@ Bool_t TTreeDrawArgsParser::ParseName(TString name)
             p++;
          TString s(q, p - q);
          if (sscanf(s.Data(), "%lf", &fParameters[i]) == 1) {
-            fParameterGiven[i] = kTRUE;
+            fParameterGiven[i] = true;
             fNoParameters++;
          }
          if (p == end) {
             Error("ParseName", "expected \')\'");
-            result = kFALSE;
+            result = false;
             break;
          }
          else if (*p == ')')
@@ -169,7 +169,7 @@ Bool_t TTreeDrawArgsParser::ParseName(TString name)
             p++;
          else {
             Error("ParseName", "impossible value for *q!");
-            result = kFALSE;
+            result = false;
             break;
          }
       }
@@ -183,7 +183,7 @@ Bool_t TTreeDrawArgsParser::ParseName(TString name)
 ////////////////////////////////////////////////////////////////////////////////
 /// Split variables and parse name and parameters in brackets.
 
-Bool_t TTreeDrawArgsParser::ParseVarExp()
+bool TTreeDrawArgsParser::ParseVarExp()
 {
    char* gg = (char*)strstr(fExp.Data(), ">>");
    TString variables;
@@ -197,10 +197,10 @@ Bool_t TTreeDrawArgsParser::ParseVarExp()
       variables = fExp;
       name = "";
    }
-   Bool_t result = SplitVariables(variables) && ParseName(name);
+   bool result = SplitVariables(variables) && ParseName(name);
    if (!result) {
       Error("ParseVarExp", "error parsing variable expression");
-      return kFALSE;
+      return false;
    }
    return result;
 }
@@ -209,21 +209,21 @@ Bool_t TTreeDrawArgsParser::ParseVarExp()
 /// Check if options contain some data important for choosing the type of the
 /// drawn object.
 
-Bool_t TTreeDrawArgsParser::ParseOption()
+bool TTreeDrawArgsParser::ParseOption()
 {
    fOption.ToLower();
 
    if (fOption.Contains("goff")) {
-      fShouldDraw = kFALSE;
+      fShouldDraw = false;
    }
    if (fOption.Contains("prof")) {
-      fDrawProfile = kTRUE;
+      fDrawProfile = true;
    }
    if (fOption.Contains("same")) {
-      fOptionSame = kTRUE;
+      fOptionSame = true;
    }
    if (fOption.Contains("entrylist")){
-      fEntryList = kTRUE;
+      fEntryList = true;
    }
    return true;
 }
@@ -234,7 +234,7 @@ Bool_t TTreeDrawArgsParser::ParseOption()
 ///  - selection - selection expression; see TTree::Draw()
 ///  - option - Drawing option; see TTree::Draw
 
-Bool_t TTreeDrawArgsParser::Parse(const char *varexp, const char *selection, Option_t *option)
+bool TTreeDrawArgsParser::Parse(const char *varexp, const char *selection, Option_t *option)
 {
    ClearPrevious();
 
@@ -242,11 +242,11 @@ Bool_t TTreeDrawArgsParser::Parse(const char *varexp, const char *selection, Opt
    fSelection = selection;
    fExp = varexp;
    fOption = option;
-   Bool_t success = ParseVarExp();
+   bool success = ParseVarExp();
    success &= ParseOption();
 
    if (!success)
-      return kFALSE;
+      return false;
 
    // if the name was specified find the existing histogram
    if (fName != "") {
@@ -257,7 +257,7 @@ Bool_t TTreeDrawArgsParser::Parse(const char *varexp, const char *selection, Opt
 
    DefineType();
 
-   return kTRUE;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -277,16 +277,16 @@ TTreeDrawArgsParser::EOutputType TTreeDrawArgsParser::DefineType()
       return fOutputType = kPROFILE2D;
 
    if (fDimension == 2) {
-      Bool_t graph = kFALSE;
+      bool graph = false;
 // GG 9Mar2014: fixing ROOT-5337; should understand why it was like this, but we move to TSelectorDraw
 //              and this will disappear
 //      Int_t l = fOption.Length();
-//      if (l == 0 || fOption.Contains("same")) graph = kTRUE;
-      if (fOption.Contains("same")) graph = kTRUE;
-      if (fOption.Contains("p")     || fOption.Contains("*")    || fOption.Contains("l"))    graph = kTRUE;
-      if (fOption.Contains("surf")  || fOption.Contains("lego") || fOption.Contains("cont")) graph = kFALSE;
-      if (fOption.Contains("col")   || fOption.Contains("hist") || fOption.Contains("scat")) graph = kFALSE;
-      if (fOption.Contains("box"))                                                   graph = kFALSE;
+//      if (l == 0 || fOption.Contains("same")) graph = true;
+      if (fOption.Contains("same")) graph = true;
+      if (fOption.Contains("p")     || fOption.Contains("*")    || fOption.Contains("l"))    graph = true;
+      if (fOption.Contains("surf")  || fOption.Contains("lego") || fOption.Contains("cont")) graph = false;
+      if (fOption.Contains("col")   || fOption.Contains("hist") || fOption.Contains("scat")) graph = false;
+      if (fOption.Contains("box"))                                                   graph = false;
       if (graph)
          return fOutputType = kGRAPH;
       else
@@ -372,18 +372,18 @@ Double_t TTreeDrawArgsParser::GetIfSpecified(Int_t num, Double_t def) const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// returns kTRUE if the *num*-th parameter was specified
+/// returns true if the *num*-th parameter was specified
 /// otherwise returns fFALSE
 /// in case of an error (wrong num) prints an error message and
-/// returns kFALSE.
+/// returns false.
 
-Bool_t TTreeDrawArgsParser::IsSpecified(int num) const
+bool TTreeDrawArgsParser::IsSpecified(int num) const
 {
    if (num >= 0 && num <= fgMaxParameters)
       return fParameterGiven[num];
    else
       Error("Specified", "wrong parameter %d; fgMaxParameters: %d", num, fgMaxParameters);
-   return kFALSE;
+   return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/treeplayer/src/TTreeFormula.cxx
+++ b/tree/treeplayer/src/TTreeFormula.cxx
@@ -96,7 +96,7 @@ ClassImp(TTreeFormula);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-inline static void R__LoadBranch(TBranch* br, Long64_t entry, Bool_t quickLoad)
+inline static void R__LoadBranch(TBranch* br, Long64_t entry, bool quickLoad)
 {
    if (!quickLoad || (br->GetReadEntry() != entry)) {
       br->GetEntry(entry);
@@ -121,8 +121,8 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TTreeFormula::TTreeFormula(): ROOT::v5::TFormula(), fQuickLoad(kFALSE), fNeedLoading(kTRUE),
-   fDidBooleanOptimization(kFALSE), fDimensionSetup(nullptr)
+TTreeFormula::TTreeFormula(): ROOT::v5::TFormula(), fQuickLoad(false), fNeedLoading(true),
+   fDidBooleanOptimization(false), fDimensionSetup(nullptr)
 
 {
    // Tree Formula default constructor
@@ -142,7 +142,7 @@ TTreeFormula::TTreeFormula(): ROOT::v5::TFormula(), fQuickLoad(kFALSE), fNeedLoa
       fNdimensions[j] = 0;
       fCodes[j] = 0;
       fNdata[j] = 1;
-      fHasMultipleVarDim[j] = kFALSE;
+      fHasMultipleVarDim[j] = false;
       for (k = 0; k<kMAXFORMDIM; k++) {
          fIndexes[j][k] = -1;
          fCumulSizes[j][k] = 1;
@@ -155,8 +155,8 @@ TTreeFormula::TTreeFormula(): ROOT::v5::TFormula(), fQuickLoad(kFALSE), fNeedLoa
 /// Normal TTree Formula Constructor
 
 TTreeFormula::TTreeFormula(const char *name,const char *expression, TTree *tree)
-   :ROOT::v5::TFormula(), fTree(tree), fQuickLoad(kFALSE), fNeedLoading(kTRUE),
-    fDidBooleanOptimization(kFALSE), fDimensionSetup(nullptr)
+   :ROOT::v5::TFormula(), fTree(tree), fQuickLoad(false), fNeedLoading(true),
+    fDidBooleanOptimization(false), fDimensionSetup(nullptr)
 {
    Init(name,expression);
 }
@@ -166,8 +166,8 @@ TTreeFormula::TTreeFormula(const char *name,const char *expression, TTree *tree)
 
 TTreeFormula::TTreeFormula(const char *name,const char *expression, TTree *tree,
                            const std::vector<std::string>& aliases)
-   :ROOT::v5::TFormula(), fTree(tree), fQuickLoad(kFALSE), fNeedLoading(kTRUE),
-    fDidBooleanOptimization(kFALSE), fDimensionSetup(nullptr), fAliasesUsed(aliases)
+   :ROOT::v5::TFormula(), fTree(tree), fQuickLoad(false), fNeedLoading(true),
+    fDidBooleanOptimization(false), fDimensionSetup(nullptr), fAliasesUsed(aliases)
 {
    Init(name,expression);
 }
@@ -195,7 +195,7 @@ void TTreeFormula::Init(const char*name, const char* expression)
       fLookupType[j] = kDirect;
       fCodes[j] = 0;
       fNdata[j] = 1;
-      fHasMultipleVarDim[j] = kFALSE;
+      fHasMultipleVarDim[j] = false;
       for (k = 0; k<kMAXFORMDIM; k++) {
          fIndexes[j][k] = -1;
          fCumulSizes[j][k] = 1;
@@ -291,7 +291,7 @@ void TTreeFormula::Init(const char*name, const char* expression)
       fBranches.AddAtAndExpand(branch,k);
    }
 
-   if (IsInteger(kFALSE)) SetBit(kIsInteger);
+   if (IsInteger(false)) SetBit(kIsInteger);
 
    if (TestBit(TTreeFormula::kNeedEntries)) {
       // Call TTree::GetEntries() to insure that it is already calculated.
@@ -449,7 +449,7 @@ Int_t TTreeFormula::RegisterDimensions(Int_t code, Int_t size, TFormLeafInfoMult
 
 Int_t TTreeFormula::RegisterDimensions(Int_t code, TFormLeafInfo *leafinfo,
                                        TFormLeafInfo * /* maininfo */,
-                                       Bool_t useCollectionObject) {
+                                       bool useCollectionObject) {
    Int_t ndim, size, current, vardim;
    vardim = 0;
 
@@ -563,7 +563,7 @@ Int_t TTreeFormula::RegisterDimensions(Int_t code, TBranchElement *branch) {
       fManager->EnableMultiVarDims();
       TFormLeafInfoMultiVarDim * info = new TFormLeafInfoMultiVarDimDirect();
       fDataMembers.AddAtAndExpand(info, code);
-      fHasMultipleVarDim[code] = kTRUE;
+      fHasMultipleVarDim[code] = true;
 
       info->fCounter = new TFormLeafInfoDirect(leafcount);
       info->fCounter2 = new TFormLeafInfoDirect(leafcount2);
@@ -593,7 +593,7 @@ Int_t TTreeFormula::RegisterDimensions(Int_t code, TLeaf *leaf) {
    char *branch_dim = (char*)strstr(bname,"[");
    if (branch_dim) branch_dim++; // skip the '['
 
-   Bool_t isString  = kFALSE;
+   bool isString  = false;
    if  (leaf->IsA() == TLeafElement::Class()) {
       Int_t type =((TBranchElement*)leaf->GetBranch())->GetStreamerType();
       isString =    (type == TStreamerInfo::kOffsetL+TStreamerInfo::kChar)
@@ -761,7 +761,7 @@ Int_t TTreeFormula::DefineAlternate(const char *expression)
 /// -  0
 /// -  >0 the value returns is the action code.
 
-Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t final, UInt_t paran_level, TObjArray& castqueue, Bool_t useLeafCollectionObject, const char* fullExpression)
+Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, bool final, UInt_t paran_level, TObjArray& castqueue, bool useLeafCollectionObject, const char* fullExpression)
 {
    Int_t action = 0;
 
@@ -778,7 +778,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
    Long64_t readentry = fTree->GetTree()->GetReadEntry();
    if (readentry < 0) readentry=0;
 
-   Bool_t useLeafReferenceObject = false;
+   bool useLeafReferenceObject = false;
    Int_t code = fNcodes-1;
 
    // Make a check to prevent problem with some corrupted files (missing TStreamerInfo).
@@ -865,7 +865,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
    TClass * cl = nullptr;
    TFormLeafInfo *maininfo = nullptr;
    TFormLeafInfo *previnfo = nullptr;
-   Bool_t unwindCollection = kFALSE;
+   bool unwindCollection = false;
    const static TClassRef stdStringClass = TClass::GetClass("string");
 
    if (leaf==nullptr) {
@@ -936,7 +936,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                        "Missing TStreamerElement in object in TClonesArray section");
                return -2;
             }
-            TFormLeafInfo* clonesinfo = new TFormLeafInfoClones(cl, 0, element, kTRUE);
+            TFormLeafInfo* clonesinfo = new TFormLeafInfoClones(cl, 0, element, true);
 
             // The following code was commented out because in THIS case
             // the dimension are actually handled by parsing the title and name of the leaf
@@ -964,7 +964,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                previnfo = new TFormLeafInfo(cl,offset+branchEl->GetOffset(),element);
             }
             maininfo->fNext = previnfo;
-            unwindCollection = kTRUE;
+            unwindCollection = true;
 
          } else if (branchEl->GetType()==41) {
 
@@ -983,11 +983,11 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                TClass *collectionCl = collectionElement->GetClassPointer();
 
                collectioninfo =
-                  new TFormLeafInfoCollection(collectionCl, 0, collectionElement, kTRUE);
+                  new TFormLeafInfoCollection(collectionCl, 0, collectionElement, true);
             } else {
                TClass *collectionCl = TClass::GetClass(count->GetClassName());
                collectioninfo =
-                  new TFormLeafInfoCollection(collectionCl, 0, collectionCl, kTRUE);
+                  new TFormLeafInfoCollection(collectionCl, 0, collectionCl, true);
             }
 
             // The following code was commented out because in THIS case
@@ -1016,14 +1016,14 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                previnfo = new TFormLeafInfo(cl,offset+branchEl->GetOffset(),element);
             }
             maininfo->fNext = previnfo;
-            unwindCollection = kTRUE;
+            unwindCollection = true;
          }
       } else if ( branchEl->GetType()==3) {
          TFormLeafInfo* clonesinfo;
          if (useLeafCollectionObject) {
             clonesinfo = new TFormLeafInfoCollectionObject(cl);
          } else {
-            clonesinfo = new TFormLeafInfoClones(cl, 0, kTRUE);
+            clonesinfo = new TFormLeafInfoClones(cl, 0, true);
             // The dimension needs to be handled!
             numberOfVarDim += RegisterDimensions(code,clonesinfo,maininfo,useLeafCollectionObject);
 
@@ -1037,7 +1037,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
          if (useLeafCollectionObject) {
             collectioninfo = new TFormLeafInfoCollectionObject(cl);
          } else {
-            collectioninfo = new TFormLeafInfoCollection(cl, 0, cl, kTRUE);
+            collectioninfo = new TFormLeafInfoCollection(cl, 0, cl, true);
             // The dimension needs to be handled!
             numberOfVarDim += RegisterDimensions(code,collectioninfo,maininfo,useLeafCollectionObject);
          }
@@ -1054,9 +1054,9 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
             previnfo = collectioninfo;
 
          } else {
-            TFormLeafInfo *collectioninfo = new TFormLeafInfoCollection(cl, 0, cl, kTRUE);
+            TFormLeafInfo *collectioninfo = new TFormLeafInfoCollection(cl, 0, cl, true);
             // The dimension needs to be handled!
-            numberOfVarDim += RegisterDimensions(code,collectioninfo,maininfo,kFALSE);
+            numberOfVarDim += RegisterDimensions(code,collectioninfo,maininfo,false);
 
             maininfo = collectioninfo;
             previnfo = collectioninfo;
@@ -1067,8 +1067,8 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                TFormLeafInfo *multi = new TFormLeafInfoMultiVarDimCollection(cl,0,
                      cl->GetCollectionProxy()->GetValueClass(),collectioninfo);
 
-               fHasMultipleVarDim[code] = kTRUE;
-               numberOfVarDim += RegisterDimensions(code,multi,maininfo,kFALSE);
+               fHasMultipleVarDim[code] = true;
+               numberOfVarDim += RegisterDimensions(code,multi,maininfo,false);
                previnfo->fNext = multi;
                cl = cl->GetCollectionProxy()->GetValueClass();
                multi->fNext =  new TFormLeafInfoCollection(cl, 0, cl, false);
@@ -1098,7 +1098,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                new TFormLeafInfoCollection(cl, 0, elemCl);
 
             // The dimension needs to be handled!
-            numberOfVarDim += RegisterDimensions(code,collectioninfo,maininfo,kFALSE);
+            numberOfVarDim += RegisterDimensions(code,collectioninfo,maininfo,false);
 
             maininfo = collectioninfo;
             previnfo = collectioninfo;
@@ -1108,8 +1108,8 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                                                       elemCl->GetCollectionProxy()->GetValueClass(),
                                                       collectioninfo);
 
-            fHasMultipleVarDim[code] = kTRUE;
-            numberOfVarDim += RegisterDimensions(code,multi,maininfo,kFALSE);
+            fHasMultipleVarDim[code] = true;
+            numberOfVarDim += RegisterDimensions(code,multi,maininfo,false);
             previnfo->fNext = multi;
             cl = elemCl->GetCollectionProxy()->GetValueClass();
             multi->fNext =  new TFormLeafInfoCollection(cl, 0, cl, false);
@@ -1137,7 +1137,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                new TFormLeafInfoCollection(cl, 0, elemCl);
 
             // The dimension needs to be handled!
-            numberOfVarDim += RegisterDimensions(code,collectioninfo,maininfo,kFALSE);
+            numberOfVarDim += RegisterDimensions(code,collectioninfo,maininfo,false);
 
             collectioninfo->fNext =
                new TFormLeafInfoNumerical(elemCl->GetCollectionProxy());
@@ -1167,7 +1167,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
          else  {
             if ( !maininfo )  {
                maininfo = previnfo = new TFormLeafInfoReference(cl, element, 0);
-               numberOfVarDim += RegisterDimensions(code,maininfo,maininfo,kFALSE);
+               numberOfVarDim += RegisterDimensions(code,maininfo,maininfo,false);
             }
             TVirtualRefProxy *refproxy = cl->GetReferenceProxy();
             for(Long64_t i=0; i<leaf->GetBranch()->GetEntries()-readentry; ++i)  {
@@ -1204,8 +1204,8 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
          if (!useLeafCollectionObject && cl && cl->GetCollectionProxy()) {
             TFormLeafInfo *multi =
                new TFormLeafInfoMultiVarDimCollection(cl, 0, cl, maininfo);
-            fHasMultipleVarDim[code] = kTRUE;
-            numberOfVarDim += RegisterDimensions(code,multi,maininfo,kFALSE);
+            fHasMultipleVarDim[code] = true;
+            numberOfVarDim += RegisterDimensions(code,multi,maininfo,false);
             previnfo->fNext = multi;
 
             multi->fNext =  new TFormLeafInfoCollection(cl, 0, cl, false);
@@ -1222,8 +1222,8 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
 
             TFormLeafInfo *multi =
                new TFormLeafInfoMultiVarDimClones(cl, 0, cl, maininfo);
-            fHasMultipleVarDim[code] = kTRUE;
-            numberOfVarDim += RegisterDimensions(code,multi,maininfo,kFALSE);
+            fHasMultipleVarDim[code] = true;
+            numberOfVarDim += RegisterDimensions(code,multi,maininfo,false);
             previnfo->fNext = multi;
 
             multi->fNext =  new TFormLeafInfoClones(cl, 0, false);
@@ -1256,7 +1256,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                return -2;
             }
             leafinfo = new TFormLeafInfoCast(cl,casted);
-            fHasCast = kTRUE;
+            fHasCast = true;
             if (maininfo==nullptr) {
                maininfo = leafinfo;
             }
@@ -1273,10 +1273,10 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
          }
       }
       Int_t i;
-      Bool_t prevUseCollectionObject = useLeafCollectionObject;
-      Bool_t useCollectionObject = useLeafCollectionObject;
-      Bool_t useReferenceObject = useLeafReferenceObject;
-      Bool_t prevUseReferenceObject = useLeafReferenceObject;
+      bool prevUseCollectionObject = useLeafCollectionObject;
+      bool useCollectionObject = useLeafCollectionObject;
+      bool useReferenceObject = useLeafReferenceObject;
+      bool prevUseReferenceObject = useLeafReferenceObject;
       for (i=0, current = &(work[0]); i<=nchname;i++ ) {
          // We will treated the terminator as a token.
          if (right[i] == '(') {
@@ -1308,7 +1308,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                TClonesArray * clones;
                if (previnfo) clones = (TClonesArray*)previnfo->GetLocalValuePointer(leaf,0);
                else {
-                  Bool_t top = (clbranch==((TBranchElement*)clbranch)->GetMother()
+                  bool top = (clbranch==((TBranchElement*)clbranch)->GetMother()
                                  || !leaf->IsOnTerminalBranch());
                   TClass *mother_cl;
                   if (leaf->IsA()==TLeafObject::Class()) {
@@ -1320,7 +1320,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                   TFormLeafInfo* clonesinfo = new TFormLeafInfoClones(mother_cl, 0, top);
 
                   // The dimension needs to be handled!
-                  numberOfVarDim += RegisterDimensions(code,clonesinfo,maininfo,kFALSE);
+                  numberOfVarDim += RegisterDimensions(code,clonesinfo,maininfo,false);
 
                   previnfo = clonesinfo;
                   maininfo = clonesinfo;
@@ -1339,7 +1339,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
 
                if (previnfo==nullptr) {
 
-                  Bool_t top = (branch==((TBranchElement*)branch)->GetMother()
+                  bool top = (branch==((TBranchElement*)branch)->GetMother()
                                  || !leaf->IsOnTerminalBranch());
 
                   TClass *mother_cl;
@@ -1353,7 +1353,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                   TFormLeafInfo* collectioninfo =
                      new TFormLeafInfoCollection(mother_cl, 0,cl,top);
                   // The dimension needs to be handled!
-                  numberOfVarDim += RegisterDimensions(code,collectioninfo,maininfo,kFALSE);
+                  numberOfVarDim += RegisterDimensions(code,collectioninfo,maininfo,false);
 
                   previnfo = collectioninfo;
                   maininfo = collectioninfo;
@@ -1381,7 +1381,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                   TFormLeafInfo* collectioninfo=nullptr;
                   if (useLeafCollectionObject) {
 
-                     Bool_t top = (branch==((TBranchElement*)branch)->GetMother()
+                     bool top = (branch==((TBranchElement*)branch)->GetMother()
                                  || !leaf->IsOnTerminalBranch());
                      collectioninfo = new TFormLeafInfoCollectionObject(cl,top);
                   }
@@ -1442,20 +1442,20 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
             leafinfo = nullptr;
             current = &(work[0]);
             *current = 0;
-            prevUseCollectionObject = kFALSE;
-            prevUseReferenceObject = kFALSE;
-            useCollectionObject = kFALSE;
+            prevUseCollectionObject = false;
+            prevUseReferenceObject = false;
+            useCollectionObject = false;
 
             if (cl && cl->GetCollectionProxy()) {
                if (numberOfVarDim>1) {
                   Warning("DefinedVariable","TTreeFormula support only 2 level of variables size collections.  Assuming '@' notation for the collection %s.",
                      cl->GetName());
                   leafinfo = new TFormLeafInfo(cl,0,nullptr);
-                  useCollectionObject = kTRUE;
+                  useCollectionObject = true;
                } else if (numberOfVarDim==0) {
                   R__ASSERT(maininfo);
                   leafinfo = new TFormLeafInfoCollection(cl,0,cl);
-                  numberOfVarDim += RegisterDimensions(code,leafinfo,maininfo,kFALSE);
+                  numberOfVarDim += RegisterDimensions(code,leafinfo,maininfo,false);
                } else if (numberOfVarDim==1) {
                   R__ASSERT(maininfo);
                   leafinfo =
@@ -1465,8 +1465,8 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                   previnfo = leafinfo;
                   leafinfo = new TFormLeafInfoCollection(cl,0,cl);
 
-                  fHasMultipleVarDim[code] = kTRUE;
-                  numberOfVarDim += RegisterDimensions(code,leafinfo,maininfo,kFALSE);
+                  fHasMultipleVarDim[code] = true;
+                  numberOfVarDim += RegisterDimensions(code,leafinfo,maininfo,false);
                }
                previnfo->fNext = leafinfo;
                previnfo = leafinfo;
@@ -1479,7 +1479,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
             TClass * casted = (TClass*) ((int(--paran_level)>=0) ? castqueue.At(paran_level) : nullptr);
             if (casted) {
                leafinfo = new TFormLeafInfoCast(cl,casted);
-               fHasCast = kTRUE;
+               fHasCast = true;
 
                if (maininfo==nullptr) {
                   maininfo = leafinfo;
@@ -1501,7 +1501,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
          } else if (i > 0 && (right[i] == '.' || right[i] == '[' || right[i] == '\0') ) {
             // A delimiter happened let's see if what we have seen
             // so far does point to a data member.
-            Bool_t needClass = kTRUE;
+            bool needClass = true;
             *current = '\0';
 
             // skip it all if there is nothing to look at
@@ -1510,21 +1510,21 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
             prevUseCollectionObject = useCollectionObject;
             prevUseReferenceObject = useReferenceObject;
             if (work[0]=='@') {
-               useReferenceObject = kTRUE;
-               useCollectionObject = kTRUE;
+               useReferenceObject = true;
+               useCollectionObject = true;
                Int_t l = 0;
                for(l=0;work[l+1]!=0;++l) work[l] = work[l+1];
                work[l] = '\0';
             } else if (work[strlen(work)-1]=='@') {
-               useReferenceObject = kTRUE;
-               useCollectionObject = kTRUE;
+               useReferenceObject = true;
+               useCollectionObject = true;
                work[strlen(work)-1] = '\0';
             } else {
-               useReferenceObject = kFALSE;
-               useCollectionObject = kFALSE;
+               useReferenceObject = false;
+               useCollectionObject = false;
             }
 
-            Bool_t mustderef = kFALSE;
+            bool mustderef = false;
             if ( !prevUseReferenceObject && cl && cl->GetReferenceProxy() )  {
                R__LoadBranch(leaf->GetBranch(), readentry, fQuickLoad);
                if ( !maininfo )  {
@@ -1532,7 +1532,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                   if ( cl->GetReferenceProxy()->HasCounter() )  {
                      numberOfVarDim += RegisterDimensions(code,-1);
                   }
-                  prevUseReferenceObject = kFALSE;
+                  prevUseReferenceObject = false;
                } else {
                   previnfo->fNext = new TFormLeafInfoReference(cl, element, offset);
                   previnfo = previnfo->fNext;
@@ -1547,8 +1547,8 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                   }
                   if ( cl ) break;
                }
-               needClass = kFALSE;
-               mustderef = kTRUE;
+               needClass = false;
+               mustderef = true;
             }
             else if (!prevUseCollectionObject && cl == TClonesArray::Class()) {
                // We are not interested in the ClonesArray object but only
@@ -1574,9 +1574,9 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
 
                   TFormLeafInfo* clonesinfo = new TFormLeafInfoClones(mother_cl, 0);
                   // The dimension needs to be handled!
-                  numberOfVarDim += RegisterDimensions(code,clonesinfo,maininfo,kFALSE);
+                  numberOfVarDim += RegisterDimensions(code,clonesinfo,maininfo,false);
 
-                  mustderef = kTRUE;
+                  mustderef = true;
                   previnfo = clonesinfo;
                   maininfo = clonesinfo;
 
@@ -1635,9 +1635,9 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                   TFormLeafInfo* collectioninfo =
                      new TFormLeafInfoCollection(mother_cl, 0, cl);
                   // The dimension needs to be handled!
-                  numberOfVarDim += RegisterDimensions(code,collectioninfo,maininfo,kFALSE);
+                  numberOfVarDim += RegisterDimensions(code,collectioninfo,maininfo,false);
 
-                  mustderef = kTRUE;
+                  mustderef = true;
                   previnfo = collectioninfo;
                   maininfo = collectioninfo;
 
@@ -1694,7 +1694,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
 
                      if (element) {
                         leafinfo = new TFormLeafInfoClones(cl,clones_offset,curelem);
-                        numberOfVarDim += RegisterDimensions(code,leafinfo,maininfo,kFALSE);
+                        numberOfVarDim += RegisterDimensions(code,leafinfo,maininfo,false);
                         if (maininfo==nullptr) maininfo = leafinfo;
                         if (previnfo==nullptr) previnfo = leafinfo;
                         else {
@@ -1720,18 +1720,18 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                            Warning("DefinedVariable","TTreeFormula support only 2 level of variables size collections.  Assuming '@' notation for the collection %s.",
                                    curelem->GetName());
                            leafinfo = new TFormLeafInfo(cl,coll_offset,curelem);
-                           useCollectionObject = kTRUE;
+                           useCollectionObject = true;
                         } else if (numberOfVarDim==1) {
                            R__ASSERT(maininfo);
                            leafinfo =
                               new TFormLeafInfoMultiVarDimCollection(cl,coll_offset,
                                                                      curelem,maininfo);
-                           fHasMultipleVarDim[code] = kTRUE;
+                           fHasMultipleVarDim[code] = true;
                            leafinfo->fNext = new TFormLeafInfoCollection(cl,coll_offset,curelem);
-                           numberOfVarDim += RegisterDimensions(code,leafinfo,maininfo,kFALSE);
+                           numberOfVarDim += RegisterDimensions(code,leafinfo,maininfo,false);
                         } else {
                            leafinfo = new TFormLeafInfoCollection(cl,coll_offset,curelem);
-                           numberOfVarDim += RegisterDimensions(code,leafinfo,maininfo,kFALSE);
+                           numberOfVarDim += RegisterDimensions(code,leafinfo,maininfo,false);
                         }
                         if (maininfo==nullptr) maininfo = leafinfo;
                         if (previnfo==nullptr) previnfo = leafinfo;
@@ -1758,7 +1758,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                   if (numberOfVarDim>=1 && type>40) {
                      // We have a variable array within a variable array!
                      leafinfo = new TFormLeafInfoMultiVarDim(cl,offset,element,maininfo);
-                     fHasMultipleVarDim[code] = kTRUE;
+                     fHasMultipleVarDim[code] = true;
                   } else {
                      if (leafinfo && type<=40 ) {
                         leafinfo->AddOffset(offset,element);
@@ -1767,9 +1767,9 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                      }
                   }
                } else {
-                  Bool_t object = kFALSE;
-                  Bool_t pointer = kFALSE;
-                  Bool_t objarr = kFALSE;
+                  bool object = false;
+                  bool pointer = false;
+                  bool objarr = false;
                   switch(type) {
                      case TStreamerInfo::kObjectp:
                      case TStreamerInfo::kObjectP:
@@ -1781,7 +1781,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                      case TStreamerInfo::kOffsetL + TStreamerInfo::kAnyp:
                      case TStreamerInfo::kOffsetL + TStreamerInfo::kObjectp:
                      case TStreamerInfo::kOffsetL + TStreamerInfo::kAnyP:
-                        pointer = kTRUE;
+                        pointer = true;
                         break;
                      case TStreamerInfo::kBase:
                      case TStreamerInfo::kAny :
@@ -1790,12 +1790,12 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                      case TStreamerInfo::kTString:
                      case TStreamerInfo::kTNamed:
                      case TStreamerInfo::kTObject:
-                        object = kTRUE;
+                        object = true;
                         break;
                      case TStreamerInfo::kOffsetL + TStreamerInfo::kAny:
                      case TStreamerInfo::kOffsetL + TStreamerInfo::kSTL:
                      case TStreamerInfo::kOffsetL + TStreamerInfo::kObject:
-                        objarr = kTRUE;
+                        objarr = true;
                         break;
                      case TStreamerInfo::kStreamer:
                      case TStreamerInfo::kStreamLoop:
@@ -1816,36 +1816,36 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                       ( element->GetClassPointer() ==  TClonesArray::Class()
                         || element->GetClassPointer()->GetCollectionProxy() ) )
                   {
-                     object = kFALSE;
+                     object = false;
                   }
                   if (object && leafinfo) {
                      leafinfo->AddOffset(offset,element);
                   } else if (objarr) {
                      // This is an embedded array of objects. We can not increase the offset.
                      leafinfo = new TFormLeafInfo(cl,offset,element);
-                     mustderef = kTRUE;
+                     mustderef = true;
                   } else {
 
                      if (!useCollectionObject && element->GetClassPointer() ==  TClonesArray::Class()) {
 
                         leafinfo = new TFormLeafInfoClones(cl,offset,element);
-                        mustderef = kTRUE;
+                        mustderef = true;
 
                      } else if (!useCollectionObject &&  element->GetClassPointer()
                                 && element->GetClassPointer()->GetCollectionProxy()) {
 
-                        mustderef = kTRUE;
+                        mustderef = true;
                         if (numberOfVarDim>1) {
                            Warning("DefinedVariable","TTreeFormula support only 2 level of variables size collections.  Assuming '@' notation for the collection %s.",
                                    element->GetName());
                            leafinfo = new TFormLeafInfo(cl,offset,element);
-                           useCollectionObject = kTRUE;
+                           useCollectionObject = true;
                         } else if (numberOfVarDim==1) {
                            R__ASSERT(maininfo);
                            leafinfo =
                               new TFormLeafInfoMultiVarDimCollection(cl,offset,element,maininfo);
 
-                           fHasMultipleVarDim[code] = kTRUE;
+                           fHasMultipleVarDim[code] = true;
                            //numberOfVarDim += RegisterDimensions(code,leafinfo);
                            //cl = cl->GetCollectionProxy()->GetValueClass();
 
@@ -1871,7 +1871,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
 
                            if (valueCl!=nullptr && valueCl->GetCollectionProxy()!=nullptr) {
 
-                              numberOfVarDim += RegisterDimensions(code,leafinfo,maininfo,kFALSE);
+                              numberOfVarDim += RegisterDimensions(code,leafinfo,maininfo,false);
                               if (previnfo==nullptr) previnfo = leafinfo;
                               else {
                                  previnfo->fNext = leafinfo;
@@ -1880,7 +1880,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                               leafinfo = new TFormLeafInfoMultiVarDimCollection(elemCl,0,
                                  elemCl->GetCollectionProxy()->GetValueClass(),maininfo);
                               //numberOfVarDim += RegisterDimensions(code,previnfo->fNext);
-                              fHasMultipleVarDim[code] = kTRUE;
+                              fHasMultipleVarDim[code] = true;
                               //previnfo = previnfo->fNext;
                               leafinfo->fNext =  new TFormLeafInfoCollection(elemCl,0,
                                  valueCl);
@@ -1906,13 +1906,13 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
                         //if ( c->GetReferenceProxy()->HasCounter() )  {
                         //   numberOfVarDim += RegisterDimensions(code,-1);
                         //}
-                        prevUseReferenceObject = kFALSE;
-                        needClass = kFALSE;
-                        mustderef = kTRUE;
+                        prevUseReferenceObject = false;
+                        needClass = false;
+                        mustderef = true;
                      } else if (pointer) {
                         // this is a pointer to be followed.
                         leafinfo = new TFormLeafInfoPointer(cl,offset,element);
-                        mustderef = kTRUE;
+                        mustderef = true;
                      } else {
                         // this is an embedded object.
                         R__ASSERT(object);
@@ -2018,9 +2018,9 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
             mother_cl = ((TBranchElement*)branch)->GetInfo()->GetClass();
          }
 
-         TFormLeafInfo* collectioninfo = new TFormLeafInfoCollection(mother_cl, 0, objClass, kFALSE);
+         TFormLeafInfo* collectioninfo = new TFormLeafInfoCollection(mother_cl, 0, objClass, false);
          // The dimension needs to be handled!
-         numberOfVarDim += RegisterDimensions(code,collectioninfo,maininfo,kFALSE);
+         numberOfVarDim += RegisterDimensions(code,collectioninfo,maininfo,false);
          last->fNext = collectioninfo;
       }
       numberOfVarDim += RegisterDimensions(code,1); //NOTE: changed from 0
@@ -2171,7 +2171,7 @@ Int_t TTreeFormula::ParseWithLeaf(TLeaf* leaf, const char* subExpression, Bool_t
 /// -  Return 0 if a leaf has been found
 /// -  Return 2 if info about the TTree itself has been requested.
 
-Int_t TTreeFormula::FindLeafForExpression(const char* expression, TLeaf*& leaf, TString& leftover, Bool_t& final, UInt_t& paran_level, TObjArray& castqueue, std::vector<std::string>& aliasUsed, Bool_t& useLeafCollectionObject, const char* fullExpression)
+Int_t TTreeFormula::FindLeafForExpression(const char* expression, TLeaf*& leaf, TString& leftover, bool& final, UInt_t& paran_level, TObjArray& castqueue, std::vector<std::string>& aliasUsed, bool& useLeafCollectionObject, const char* fullExpression)
 {
    // Later on we will need to read one entry, let's make sure
    // it is a real entry.
@@ -2196,8 +2196,8 @@ Int_t TTreeFormula::FindLeafForExpression(const char* expression, TLeaf*& leaf, 
    TBranch *branch=nullptr, *tmp_branch=nullptr;
    Int_t nchname = strlen(cname);
    Int_t i;
-   Bool_t foundAtSign = kFALSE;
-   Bool_t startWithParan = kFALSE;
+   bool foundAtSign = false;
+   bool startWithParan = false;
 
    for (i=0, current = &(work[0]); i<=nchname && !final;i++ ) {
       // We will treated the terminator as a token.
@@ -2209,7 +2209,7 @@ Int_t TTreeFormula::FindLeafForExpression(const char* expression, TLeaf*& leaf, 
          if (current==work+1) {
             // If the expression starts with a parenthesis, we are likely
             // to have a cast operator inside.
-            startWithParan = kTRUE;
+            startWithParan = true;
             current--;
          }
          continue;
@@ -2229,7 +2229,7 @@ Int_t TTreeFormula::FindLeafForExpression(const char* expression, TLeaf*& leaf, 
          paran_level--;
 
          if (startWithParan) {
-            startWithParan = kFALSE; // the next match wont be against the starting parenthesis.
+            startWithParan = false; // the next match wont be against the starting parenthesis.
 
             // Let's see if work is a classname and thus we have a cast.
             *(--current) = 0;
@@ -2272,7 +2272,7 @@ Int_t TTreeFormula::FindLeafForExpression(const char* expression, TLeaf*& leaf, 
             TLeaf* leafcur = nullptr;
             while (!leaf && (leafcur = (TLeaf*) next())) {
                TBranch* br = leafcur->GetBranch();
-               Bool_t yes = BranchHasMethod(leafcur, br, work, params, readentry);
+               bool yes = BranchHasMethod(leafcur, br, work, params, readentry);
                if (yes) {
                   leaf = leafcur;
                   //fprintf(stderr, "Does have a method %s for %s found in leafcur %s.\n", work, leafcur->GetBranch()->GetName(), leafcur->GetName());
@@ -2321,7 +2321,7 @@ Int_t TTreeFormula::FindLeafForExpression(const char* expression, TLeaf*& leaf, 
             strlcpy(right,work,2*kMaxLen);
             strncat(right,"(",2*kMaxLen-1-strlen(right));
             strncat(right,params,2*kMaxLen-1-strlen(right));
-            final = kTRUE;
+            final = true;
 
             // Record in 'i' what we consumed
             i += strlen(params);
@@ -2339,18 +2339,18 @@ Int_t TTreeFormula::FindLeafForExpression(const char* expression, TLeaf*& leaf, 
 
          Int_t len = strlen(work);
          if (work[0]=='@') {
-            foundAtSign = kTRUE;
+            foundAtSign = true;
             Int_t l = 0;
             for(l=0;work[l+1]!=0;++l) work[l] = work[l+1];
             work[l] = '\0';
             --current;
          } else if (len>=2 && work[len-2]=='@') {
-            foundAtSign = kTRUE;
+            foundAtSign = true;
             work[len-2] = cname[i];
             work[len-1] = '\0';
             --current;
          } else {
-            foundAtSign = kFALSE;
+            foundAtSign = false;
          }
 
          if (left[0]==0) strlcpy(left,work,kMaxLen);
@@ -2412,7 +2412,7 @@ Int_t TTreeFormula::FindLeafForExpression(const char* expression, TLeaf*& leaf, 
                if ( cl && !cl->GetReferenceProxy() ) cl = nullptr;
             }
             if ( cl )  {  // We have a reference class here....
-               final = kTRUE;
+               final = true;
                useLeafCollectionObject = foundAtSign;
                // we reset work
                current = &(work[0]);
@@ -2433,7 +2433,7 @@ Int_t TTreeFormula::FindLeafForExpression(const char* expression, TLeaf*& leaf, 
                         leaf = (TLeaf*)branch->GetListOfLeaves()->At(0);
                         if (foundAtSign) {
                            useLeafCollectionObject = foundAtSign;
-                           foundAtSign = kFALSE;
+                           foundAtSign = false;
                            current = &(work[0]);
                            *current = 0;
                            ++i;
@@ -2445,7 +2445,7 @@ Int_t TTreeFormula::FindLeafForExpression(const char* expression, TLeaf*& leaf, 
 
                // we reset work
                useLeafCollectionObject = foundAtSign;
-               foundAtSign = kFALSE;
+               foundAtSign = false;
                current = &(work[0]);
                *current = 0;
             } else if (leaf || branch) {
@@ -2460,7 +2460,7 @@ Int_t TTreeFormula::FindLeafForExpression(const char* expression, TLeaf*& leaf, 
                if (leaf && leaf->IsOnTerminalBranch()) {
                   // This is a non-object leaf, it should NOT be specified more except for
                   // dimensions.
-                  final = kTRUE;
+                  final = true;
                }
                // we reset work
                current = &(work[0]);
@@ -2473,7 +2473,7 @@ Int_t TTreeFormula::FindLeafForExpression(const char* expression, TLeaf*& leaf, 
                   leaf = leafcur;
                   branch = leaf->GetBranch();
                   if (leaf->IsOnTerminalBranch()) {
-                     final = kTRUE;
+                     final = true;
                      strlcpy(right,first,kMaxLen);
                      //We need to put the delimiter back!
                      if (foundAtSign) strncat(right,"@",2*kMaxLen-1-strlen(right));
@@ -2527,7 +2527,7 @@ Int_t TTreeFormula::FindLeafForExpression(const char* expression, TLeaf*& leaf, 
             if (tmp_leaf && tmp_leaf->IsOnTerminalBranch() ) {
                // This is a non-object leaf, it should NOT be specified more except for
                // dimensions.
-               final = kTRUE;
+               final = true;
             }
 
             if (branch) {
@@ -2548,7 +2548,7 @@ Int_t TTreeFormula::FindLeafForExpression(const char* expression, TLeaf*& leaf, 
                   if (tmp_leaf && tmp_leaf->IsOnTerminalBranch() ) {
                      // This is a non-object leaf, it should NOT be specified
                      // more except for dimensions.
-                     final = kTRUE;
+                     final = true;
                      leaf = tmp_leaf;
                   }
                }
@@ -2559,7 +2559,7 @@ Int_t TTreeFormula::FindLeafForExpression(const char* expression, TLeaf*& leaf, 
                strncat(second,work,2*kMaxLen-1-strlen(second));
                leaf = tmp_leaf;
                useLeafCollectionObject = foundAtSign;
-               foundAtSign = kFALSE;
+               foundAtSign = false;
 
                // we reset work
                current = &(work[0]);
@@ -2800,7 +2800,7 @@ Int_t TTreeFormula::DefinedVariable(TString &name, Int_t &action)
    char    cname[kMaxLen];  strlcpy(cname,name.Data(),kMaxLen);
    char     dims[kMaxLen];   dims[0] = '\0';
 
-   Bool_t final = kFALSE;
+   bool final = false;
 
    UInt_t paran_level = 0;
    TObjArray castqueue;
@@ -2827,7 +2827,7 @@ Int_t TTreeFormula::DefinedVariable(TString &name, Int_t &action)
    }
    cname[k]='\0';
 
-   Bool_t useLeafCollectionObject = kFALSE;
+   bool useLeafCollectionObject = false;
    TString leftover;
    TLeaf *leaf = nullptr;
    {
@@ -3111,7 +3111,7 @@ TLeaf* TTreeFormula::GetLeafWithDatamember(const char* topchoice, const char* ne
             continue;
 
          } else {
-            Bool_t toplevel = (branch == branch->GetMother());
+            bool toplevel = (branch == branch->GetMother());
             clonesinfo = new TFormLeafInfoClones(cl, 0, toplevel);
             clones = (TClonesArray*)clonesinfo->GetLocalValuePointer(leafcur,0);
          }
@@ -3166,7 +3166,7 @@ TLeaf* TTreeFormula::GetLeafWithDatamember(const char* topchoice, const char* ne
                      TClass * mother_cl = ((TBranchElement*)branch)->GetInfo()->GetClass();
                      TStreamerElement *bel_element =
                         bel_info->GetElement(branchEl->GetID());
-                     leafinfo = new TFormLeafInfoClones(mother_cl, 0, bel_element, kTRUE);
+                     leafinfo = new TFormLeafInfoClones(mother_cl, 0, bel_element, true);
                   }
 
                   Int_t clones_offset = 0;
@@ -3223,7 +3223,7 @@ TLeaf* TTreeFormula::GetLeafWithDatamember(const char* topchoice, const char* ne
 /// Return the leaf (if any) of the tree with contains an object of a class
 /// having a method which has the name provided in the argument.
 
-Bool_t TTreeFormula::BranchHasMethod(TLeaf* leafcur, TBranch* branch, const char* method, const char* params, Long64_t readentry) const
+bool TTreeFormula::BranchHasMethod(TLeaf* leafcur, TBranch* branch, const char* method, const char* params, Long64_t readentry) const
 {
    TClass *cl = nullptr;
    TLeafObject* lobj = nullptr;
@@ -3235,7 +3235,7 @@ Bool_t TTreeFormula::BranchHasMethod(TLeaf* leafcur, TBranch* branch, const char
    // read without warnings/errors.
 
    if (branch->TestBit(kDoNotProcess)) {
-      return kFALSE;
+      return false;
    }
 
    // FIXME: The following code is used somewhere else, we need to factor it out.
@@ -3307,7 +3307,7 @@ Bool_t TTreeFormula::BranchHasMethod(TLeaf* leafcur, TBranch* branch, const char
          }
       } else {
          Error("BranchHasMethod","A TClonesArray was stored in a branch type no yet support (i.e. neither TBranchObject nor TBranchElement): %s",branch->IsA()->GetName());
-         return kFALSE;
+         return false;
       }
       cl = clones ? clones->GetClass() : nullptr;
    } else if (cl && cl->GetCollectionProxy()) {
@@ -3325,13 +3325,13 @@ Bool_t TTreeFormula::BranchHasMethod(TLeaf* leafcur, TBranch* branch, const char
             if (methodcall.GetMethod()) {
                // We have a method that works.
                // We will use it.
-               return kTRUE;
+               return true;
             }
          }
       }
    }
 
-   return kFALSE;
+   return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -3346,10 +3346,10 @@ Int_t TTreeFormula::GetRealInstance(Int_t instance, Int_t codeindex) {
       Int_t real_instance = 0;
       Int_t virt_dim;
 
-      Bool_t check = kFALSE;
+      bool check = false;
       if (codeindex<0) {
          codeindex = 0;
-         check = kTRUE;
+         check = true;
       }
 
       TFormLeafInfo * info = nullptr;
@@ -3661,7 +3661,7 @@ void* TTreeFormula::EvalObject(int instance)
    Int_t real_instance = GetRealInstance(instance,0);
 
    if (instance==0 || fNeedLoading) {
-      fNeedLoading = kFALSE;
+      fNeedLoading = false;
       R__LoadBranch(leaf->GetBranch(),
                     leaf->GetBranch()->GetTree()->GetReadEntry(),
                     fQuickLoad);
@@ -3701,7 +3701,7 @@ const char* TTreeFormula::EvalStringInstance(Int_t instance)
       Int_t real_instance = GetRealInstance(instance,0);
 
       if (instance==0 || fNeedLoading) {
-         fNeedLoading = kFALSE;
+         fNeedLoading = false;
          TBranch *branch = leaf->GetBranch();
          R__LoadBranch(branch,branch->GetTree()->GetReadEntry(),fQuickLoad);
       } else if (real_instance>=fNdata[0]) {
@@ -3725,15 +3725,15 @@ const char* TTreeFormula::EvalStringInstance(Int_t instance)
                                                                                                 \
    const Int_t real_instance = GetRealInstance(instance,0);                                     \
                                                                                                 \
-   if (instance==0) fNeedLoading = kTRUE;                                                       \
-   if (real_instance>=fNdata[0]) return 0;                                                       \
+   if (instance==0) fNeedLoading = true;                                                        \
+   if (real_instance>=fNdata[0]) return 0;                                                      \
                                                                                                 \
    /* Since the only operation in this formula is reading this branch,                          \
       we are guaranteed that this function is first called with instance==0 and                 \
       hence we are guaranteed that the branch is always properly read */                        \
                                                                                                 \
    if (fNeedLoading) {                                                                          \
-      fNeedLoading = kFALSE;                                                                    \
+      fNeedLoading = false;                                                                     \
       TBranch *br = leaf->GetBranch();                                                          \
       Long64_t tentry = br->GetTree()->GetReadEntry();                                          \
       R__LoadBranch(br,tentry,fQuickLoad);                                                      \
@@ -4011,8 +4011,8 @@ T TTreeFormula::EvalInstance(Int_t instance, const char *stringStackArg[])
    const char *stringStackLocal[kMAXSTRINGFOUND];
    const char **stringStack = stringStackArg?stringStackArg:stringStackLocal;
 
-   const Bool_t willLoad = (instance==0 || fNeedLoading); fNeedLoading = kFALSE;
-   if (willLoad) fDidBooleanOptimization = kFALSE;
+   const bool willLoad = (instance==0 || fNeedLoading); fNeedLoading = false;
+   if (willLoad) fDidBooleanOptimization = false;
 
    Int_t pos  = 0;
    Int_t pos2 = 0;
@@ -4137,7 +4137,7 @@ T TTreeFormula::EvalInstance(Int_t instance, const char *stringStackArg[])
                   // skip some of the branch loading (since we remove duplicate branch
                   // request (in TTreeFormula constructor) and so we need to force the
                   // loading here.
-                  if (willLoad) fDidBooleanOptimization = kTRUE;
+                  if (willLoad) fDidBooleanOptimization = true;
                }
                continue;
             }
@@ -4157,13 +4157,13 @@ T TTreeFormula::EvalInstance(Int_t instance, const char *stringStackArg[])
                // boolean operation optimizer
 
                int param = (oper & kTFOperMask);
-               Bool_t skip = kFALSE;
+               bool skip = false;
                int op = param % 10; // 1 is && , 2 is ||
 
                if (op == 1 && (!tab[pos-1]) ) {
                   // &&: skip the right part if the left part is already false
 
-                  skip = kTRUE;
+                  skip = true;
 
                   // Preserve the existing behavior (i.e. the result of a&&b is
                   // either 0 or 1)
@@ -4172,7 +4172,7 @@ T TTreeFormula::EvalInstance(Int_t instance, const char *stringStackArg[])
                } else if (op == 2 && tab[pos-1] ) {
                   // ||: skip the right part if the left part is already true
 
-                  skip = kTRUE;
+                  skip = true;
 
                   // Preserve the existing behavior (i.e. the result of a||b is
                   // either 0 or 1)
@@ -4182,7 +4182,7 @@ T TTreeFormula::EvalInstance(Int_t instance, const char *stringStackArg[])
                if (skip) {
                   int toskip = param / 10;
                   i += toskip;
-                  if (willLoad) fDidBooleanOptimization = kTRUE;
+                  if (willLoad) fDidBooleanOptimization = true;
                }
                continue;
             }
@@ -4373,7 +4373,7 @@ T TTreeFormula::EvalInstance(Int_t instance, const char *stringStackArg[])
                const Int_t real_instance = GetRealInstance(instance,string_code);
 
                if (instance==0 || fNeedLoading) {
-                  fNeedLoading = kFALSE;
+                  fNeedLoading = false;
                   TBranch *branch = leafc->GetBranch();
                   Long64_t readentry = branch->GetTree()->GetReadEntry();
                   R__LoadBranch(branch,readentry,fQuickLoad);
@@ -4384,7 +4384,7 @@ T TTreeFormula::EvalInstance(Int_t instance, const char *stringStackArg[])
                   if (fDidBooleanOptimization) {
                      TBranch *br = leafc->GetBranch();
                      Long64_t treeEntry = br->GetTree()->GetReadEntry();
-                     R__LoadBranch(br,treeEntry,kTRUE);
+                     R__LoadBranch(br,treeEntry,true);
                   }
                   if (real_instance>=fNdata[string_code]) return 0;
                }
@@ -4585,29 +4585,29 @@ void* TTreeFormula::GetValuePointerFromMethod(Int_t i, TLeaf* leaf) const
 /// When a leaf is of type integer or string, the generated histogram is forced
 /// to have an integer bin width
 
-Bool_t TTreeFormula::IsInteger(Bool_t fast) const
+bool TTreeFormula::IsInteger(bool fast) const
 {
    if (fast) {
-      if (TestBit(kIsInteger)) return kTRUE;
-      else                     return kFALSE;
+      if (TestBit(kIsInteger)) return true;
+      else                     return false;
    }
 
    if (fNoper==2 && GetAction(0)==kAlternate) {
       TTreeFormula *subform = static_cast<TTreeFormula*>(fAliases.UncheckedAt(0));
       R__ASSERT(subform);
-      return subform->IsInteger(kFALSE);
+      return subform->IsInteger(false);
    }
 
    if (GetAction(0)==kMinIf || GetAction(0)==kMaxIf) {
-      return kFALSE;
+      return false;
    }
 
-   if (fNoper > 1) return kFALSE;
+   if (fNoper > 1) return false;
 
    if (GetAction(0)==kAlias) {
       TTreeFormula *subform = static_cast<TTreeFormula*>(fAliases.UncheckedAt(0));
       R__ASSERT(subform);
-      return subform->IsInteger(kFALSE);
+      return subform->IsInteger(false);
    }
 
    if (fLeaves.GetEntries() != 1) {
@@ -4619,20 +4619,20 @@ Bool_t TTreeFormula::IsInteger(Bool_t fast) const
          case kLength:
          case kLengthFunc:
          case kIteration:
-           return kTRUE;
+           return true;
          case kSum:
          case kMin:
          case kMax:
          case kEntryList:
          default:
-           return kFALSE;
+           return false;
       }
    }
 
-   if (EvalClass()==TBits::Class()) return kTRUE;
+   if (EvalClass()==TBits::Class()) return true;
 
-   if (IsLeafInteger(0) || IsLeafString(0)) return kTRUE;
-   return kFALSE;
+   if (IsLeafInteger(0) || IsLeafString(0)) return true;
+   return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -4640,7 +4640,7 @@ Bool_t TTreeFormula::IsInteger(Bool_t fast) const
 /// short, int When a leaf is of type integer, the generated histogram is
 /// forced to have an integer bin width
 
-Bool_t TTreeFormula::IsLeafInteger(Int_t code) const
+bool TTreeFormula::IsLeafInteger(Int_t code) const
 {
    TLeaf *leaf = (TLeaf*)fLeaves.At(code);
    if (!leaf) {
@@ -4652,16 +4652,16 @@ Bool_t TTreeFormula::IsLeafInteger(Int_t code) const
          case kLength:
          case kLengthFunc:
          case kIteration:
-            return kTRUE;
+            return true;
          case kSum:
          case kMin:
          case kMax:
          case kEntryList:
          default:
-            return kFALSE;
+            return false;
       }
    }
-   if (fAxis) return kTRUE;
+   if (fAxis) return true;
    TFormLeafInfo * info;
    switch (fLookupType[code]) {
       case kMethod:
@@ -4672,23 +4672,23 @@ Bool_t TTreeFormula::IsLeafInteger(Int_t code) const
       case kDirect:
          break;
    }
-   if (!strcmp(leaf->GetTypeName(),"Int_t"))    return kTRUE;
-   if (!strcmp(leaf->GetTypeName(),"Short_t"))  return kTRUE;
-   if (!strcmp(leaf->GetTypeName(),"UInt_t"))   return kTRUE;
-   if (!strcmp(leaf->GetTypeName(),"UShort_t")) return kTRUE;
-   if (!strcmp(leaf->GetTypeName(),"Bool_t"))   return kTRUE;
-   if (!strcmp(leaf->GetTypeName(),"Char_t"))   return kTRUE;
-   if (!strcmp(leaf->GetTypeName(),"UChar_t"))  return kTRUE;
-   if (!strcmp(leaf->GetTypeName(),"Long64_t"))  return kTRUE;
-   if (!strcmp(leaf->GetTypeName(),"ULong64_t"))  return kTRUE;
-   if (!strcmp(leaf->GetTypeName(),"string"))   return kTRUE;
-   return kFALSE;
+   if (!strcmp(leaf->GetTypeName(),"Int_t"))    return true;
+   if (!strcmp(leaf->GetTypeName(),"Short_t"))  return true;
+   if (!strcmp(leaf->GetTypeName(),"UInt_t"))   return true;
+   if (!strcmp(leaf->GetTypeName(),"UShort_t")) return true;
+   if (!strcmp(leaf->GetTypeName(),"Bool_t"))   return true;
+   if (!strcmp(leaf->GetTypeName(),"Char_t"))   return true;
+   if (!strcmp(leaf->GetTypeName(),"UChar_t"))  return true;
+   if (!strcmp(leaf->GetTypeName(),"Long64_t"))  return true;
+   if (!strcmp(leaf->GetTypeName(),"ULong64_t"))  return true;
+   if (!strcmp(leaf->GetTypeName(),"string"))   return true;
+   return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return TRUE if the formula is a string
 
-Bool_t TTreeFormula::IsString() const
+bool TTreeFormula::IsString() const
 {
    // See TTreeFormula::Init for the setting of kIsCharacter.
    return TestBit(kIsCharacter);
@@ -4698,19 +4698,19 @@ Bool_t TTreeFormula::IsString() const
 /// Return true if the expression at the index 'oper' is to be treated as
 /// as string.
 
-Bool_t TTreeFormula::IsString(Int_t oper) const
+bool TTreeFormula::IsString(Int_t oper) const
 {
-   if (ROOT::v5::TFormula::IsString(oper)) return kTRUE;
-   if (GetAction(oper)==kDefinedString) return kTRUE;
-   if (GetAction(oper)==kAliasString) return kTRUE;
-   if (GetAction(oper)==kAlternateString) return kTRUE;
-   return kFALSE;
+   if (ROOT::v5::TFormula::IsString(oper)) return true;
+   if (GetAction(oper)==kDefinedString) return true;
+   if (GetAction(oper)==kAliasString) return true;
+   if (GetAction(oper)==kAlternateString) return true;
+   return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return TRUE if the leaf or data member corresponding to code is a string
 
-Bool_t  TTreeFormula::IsLeafString(Int_t code) const
+bool TTreeFormula::IsLeafString(Int_t code) const
 {
    TLeaf *leaf = (TLeaf*)fLeaves.At(code);
    TFormLeafInfo * info;
@@ -4723,7 +4723,7 @@ Bool_t  TTreeFormula::IsLeafString(Int_t code) const
       case kDirect:
          if ( !leaf->IsUnsigned() && (leaf->InheritsFrom(TLeafC::Class()) || leaf->InheritsFrom(TLeafB::Class()) ) ) {
             // Need to find out if it is an 'array' or a pointer.
-            if (leaf->GetLenStatic() > 1) return kTRUE;
+            if (leaf->GetLenStatic() > 1) return true;
 
             // Now we need to differentiate between a variable length array and
             // a TClonesArray.
@@ -4731,53 +4731,53 @@ Bool_t  TTreeFormula::IsLeafString(Int_t code) const
                const char* indexname = leaf->GetLeafCount()->GetName();
                if (indexname[strlen(indexname)-1] == '_' ) {
                   // This in a clones array
-                  return kFALSE;
+                  return false;
                } else {
                   // this is a variable length char array
-                  return kTRUE;
+                  return true;
                }
             }
-            return kFALSE;
+            return false;
          } else if (leaf->InheritsFrom(TLeafElement::Class())) {
             TBranchElement * br = (TBranchElement*)leaf->GetBranch();
             Int_t bid = br->GetID();
-            if (bid < 0) return kFALSE;
+            if (bid < 0) return false;
             if (br->GetInfo()==nullptr || !br->GetInfo()->IsCompiled()) {
                // Case where the file is corrupted is some ways.
                // We can not get to the actual type of the data
                // let's assume it is NOT a string.
-               return kFALSE;
+               return false;
             }
             TStreamerElement * elem = (TStreamerElement*) br->GetInfo()->GetElement(bid);
             if (!elem) {
                // Case where the file is corrupted is some ways.
                // We can not get to the actual type of the data
                // let's assume it is NOT a string.
-               return kFALSE;
+               return false;
             }
             if (elem->GetNewType() == TStreamerInfo::kOffsetL + TStreamerInfo::kChar) {
                // Check whether a specific element of the string is specified!
-               if (fIndexes[code][fNdimensions[code]-1] != -1) return kFALSE;
-               return kTRUE;
+               if (fIndexes[code][fNdimensions[code]-1] != -1) return false;
+               return true;
             }
             if ( elem->GetNewType() == TStreamerInfo::kCharStar) {
                // Check whether a specific element of the string is specified!
-               if (fNdimensions[code] && fIndexes[code][fNdimensions[code]-1] != -1) return kFALSE;
-               return kTRUE;
+               if (fNdimensions[code] && fIndexes[code][fNdimensions[code]-1] != -1) return false;
+               return true;
             }
-            return kFALSE;
+            return false;
          } else {
-            return kFALSE;
+            return false;
          }
       case kMethod:
          //TMethodCall *m = GetMethodCall(code);
          //TMethodCall::EReturnType r = m->ReturnType();
-         return kFALSE;
+         return false;
       case kDataMember:
          info = GetLeafInfo(code);
          return info->IsString();
       default:
-         return kFALSE;
+         return false;
    }
 }
 
@@ -4945,8 +4945,8 @@ char *TTreeFormula::PrintValue(Int_t mode, Int_t instance, const char *decform) 
 
 void TTreeFormula::ResetLoading()
 {
-   fNeedLoading = kTRUE;
-   fDidBooleanOptimization = kFALSE;
+   fNeedLoading = true;
+   fDidBooleanOptimization = false;
 
    for(Int_t i=0; i<fNcodes; ++i) {
       UInt_t max_dim = fNdimensions[i];
@@ -5040,23 +5040,23 @@ void TTreeFormula::Streamer(TBuffer &R__b)
 /// Try to 'demote' a string into an array bytes.  If this is not possible,
 /// return false.
 
-Bool_t TTreeFormula::StringToNumber(Int_t oper)
+bool TTreeFormula::StringToNumber(Int_t oper)
 {
    Int_t code = GetActionParam(oper);
    if (GetAction(oper)==kDefinedString && fLookupType[code]==kDirect) {
       if (oper>0 && GetAction(oper-1)==kJump) {
          // We are the second hand of a ternary operator, let's not do the fixing.
-         return kFALSE;
+         return false;
       }
       TLeaf *leaf = (TLeaf*)fLeaves.At(code);
       if (leaf &&  (leaf->InheritsFrom(TLeafC::Class()) || leaf->InheritsFrom(TLeafB::Class()) ) ) {
          SetAction(oper, kDefinedVariable, code );
          fNval++;
          fNstring--;
-         return kTRUE;
+         return true;
       }
    }
-   return kFALSE;
+   return false;
 }
 
 
@@ -5340,7 +5340,7 @@ void TTreeFormula::LoadBranches()
 
       TBranch *br = leaf->GetBranch();
       Long64_t treeEntry = br->GetTree()->GetReadEntry();
-      R__LoadBranch(br,treeEntry,kTRUE);
+      R__LoadBranch(br,treeEntry,true);
 
       TTreeFormula *alias = (TTreeFormula*)fAliases.UncheckedAt(i);
       if (alias) alias->LoadBranches();
@@ -5355,9 +5355,9 @@ void TTreeFormula::LoadBranches()
 ////////////////////////////////////////////////////////////////////////////////
 /// Calculate the actual dimension for the current entry.
 
-Bool_t TTreeFormula::LoadCurrentDim() {
+bool TTreeFormula::LoadCurrentDim() {
    Int_t size;
-   Bool_t outofbounds = kFALSE;
+   bool outofbounds = false;
 
    for (Int_t i=0;i<fNcodes;i++) {
       if (fCodes[i] < 0) continue;
@@ -5381,7 +5381,7 @@ Bool_t TTreeFormula::LoadCurrentDim() {
             case kTreeMember:
             case kDataMember:
                fNdata[i] = 0;
-               outofbounds = kTRUE;
+               outofbounds = true;
          }
          continue;
       }
@@ -5391,13 +5391,13 @@ Bool_t TTreeFormula::LoadCurrentDim() {
       if (tleaf && tleaf != realtree && tleaf->GetTreeIndex()) {
          if (tleaf->GetReadEntry() < 0) {
             fNdata[i] = 0;
-            outofbounds = kTRUE;
+            outofbounds = true;
             continue;
          } else {
             fNdata[i] = fCumulSizes[i][0];
          }
       }
-      Bool_t hasBranchCount2 = kFALSE;
+      bool hasBranchCount2 = false;
       if (leaf->GetLeafCount()) {
          TLeaf* leafcount = leaf->GetLeafCount();
          TBranch *branchcount = leafcount->GetBranch();
@@ -5441,7 +5441,7 @@ Bool_t TTreeFormula::LoadCurrentDim() {
                // double variable length
                // We fill up the array of sizes in the TLeafInfo:
                info->LoadSizes(branch);
-               hasBranchCount2 = kTRUE;
+               hasBranchCount2 = true;
                if (info->GetVirtVarDim()>=0) info->UpdateSizes(fManager->fVarDims[info->GetVirtVarDim()]);
 
                // Refresh the fCumulSizes[i] to have '1' for the
@@ -5494,7 +5494,7 @@ Bool_t TTreeFormula::LoadCurrentDim() {
             // unreachable element requested:
             fManager->fUsedSizes[0] = 0;
             fNdata[i] = 0;
-            outofbounds = kTRUE;
+            outofbounds = true;
          } else if (hasBranchCount2) {
             TFormLeafInfo *info2;
             info2 = (TFormLeafInfo *)fDataMembers.At(i);
@@ -5503,7 +5503,7 @@ Bool_t TTreeFormula::LoadCurrentDim() {
                // unreachable element requested:
                fManager->fUsedSizes[0] = 0;
                fNdata[i] = 0;
-               outofbounds = kTRUE;
+               outofbounds = true;
             }
          }
       } else if (fLookupType[i]==kDataMember) {
@@ -5524,7 +5524,7 @@ Bool_t TTreeFormula::LoadCurrentDim() {
                // unreachable element requested:
                fManager->fUsedSizes[0] = 0;
                fNdata[i] = 0;
-               outofbounds = kTRUE;
+               outofbounds = true;
             } else {
                fNdata[i] = size*fCumulSizes[i][1];
             }
@@ -5536,7 +5536,7 @@ Bool_t TTreeFormula::LoadCurrentDim() {
                // here we can assume that branch is a TBranch element because the other style does NOT support this type
                // of complexity.
                leafinfo->LoadSizes(branch);
-               hasBranchCount2 = kTRUE;
+               hasBranchCount2 = true;
                if (fIndexes[i][0]==-1&&fIndexes[i][vdim] >= 0) {
                   for(int z=0; z<size; ++z) {
                      if (fIndexes[i][vdim] >= leafinfo->GetSize(z)) {
@@ -5565,7 +5565,7 @@ Bool_t TTreeFormula::LoadCurrentDim() {
             if (readentry < 0) readentry=0;
             R__LoadBranch(branch,readentry,fQuickLoad);
             if (leafinfo->GetNdata(leaf)==0) {
-               outofbounds = kTRUE;
+               outofbounds = true;
             }
          }
       }
@@ -5676,11 +5676,11 @@ void TTreeFormula::Convert(UInt_t oldversion)
 /// Return false if the switch was unsuccessful (basically in the
 /// case of an old style split tree).
 
-Bool_t TTreeFormula::SwitchToFormLeafInfo(Int_t code)
+bool TTreeFormula::SwitchToFormLeafInfo(Int_t code)
 {
    TFormLeafInfo *last = nullptr;
    TLeaf *leaf = (TLeaf*)fLeaves.At(code);
-   if (!leaf) return kFALSE;
+   if (!leaf) return false;
 
    if (fLookupType[code]==kDirect) {
       if (leaf->InheritsFrom(TLeafElement::Class())) {
@@ -5690,7 +5690,7 @@ Bool_t TTreeFormula::SwitchToFormLeafInfo(Int_t code)
             TStreamerInfo *info = br->GetInfo();
             TClass* cl = info->GetClass();
             TStreamerElement *element = (TStreamerElement *)info->GetElement(br->GetID());
-            TFormLeafInfo* clonesinfo = new TFormLeafInfoClones(cl, 0, element, kTRUE);
+            TFormLeafInfo* clonesinfo = new TFormLeafInfoClones(cl, 0, element, true);
             Int_t offset;
             info->GetStreamerElement(element->GetName(),offset);
             clonesinfo->fNext = new TFormLeafInfo(cl,offset+br->GetOffset(),element);
@@ -5709,11 +5709,11 @@ Bool_t TTreeFormula::SwitchToFormLeafInfo(Int_t code)
                TClass *collectionCl = collectionElement->GetClassPointer();
 
                collectioninfo =
-                  new TFormLeafInfoCollection(collectionCl, 0, collectionElement, kTRUE);
+                  new TFormLeafInfoCollection(collectionCl, 0, collectionElement, true);
             } else {
                TClass *collectionCl = TClass::GetClass(count->GetClassName());
                collectioninfo =
-                  new TFormLeafInfoCollection(collectionCl, 0, collectionCl, kTRUE);
+                  new TFormLeafInfoCollection(collectionCl, 0, collectionCl, true);
             }
 
             TStreamerInfo *info = br->GetInfo();
@@ -5727,7 +5727,7 @@ Bool_t TTreeFormula::SwitchToFormLeafInfo(Int_t code)
             fLookupType[code]=kDataMember;
 
          } else if (br->GetID()<0) {
-            return kFALSE;
+            return false;
          } else {
             last = new TFormLeafInfoDirect(br);
             fDataMembers.AddAtAndExpand(last,code);
@@ -5737,8 +5737,8 @@ Bool_t TTreeFormula::SwitchToFormLeafInfo(Int_t code)
          //last = new TFormLeafInfoDirect(br);
          //fDataMembers.AddAtAndExpand(last,code);
          //fLookupType[code]=kDataMember;
-         return kFALSE;
+         return false;
       }
    }
-   return kTRUE;
+   return true;
 }

--- a/tree/treeplayer/src/TTreeFormulaManager.cxx
+++ b/tree/treeplayer/src/TTreeFormulaManager.cxx
@@ -30,8 +30,8 @@ ClassImp(TTreeFormulaManager);
 TTreeFormulaManager::TTreeFormulaManager() : TObject()
 {
    fMultiplicity = 0;
-   fMultiVarDim = kFALSE;
-   fNeedSync = kFALSE;
+   fMultiVarDim = false;
+   fNeedSync = false;
    fNdata = 1;
 
    for (Int_t i = 0; i < kMAXFORMDIM + 1; i++) {
@@ -87,7 +87,7 @@ void TTreeFormulaManager::Add(TTreeFormula *adding)
 
    fFormulas.Add(adding);
    adding->fManager = this;
-   fNeedSync = kTRUE;
+   fNeedSync = true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -112,14 +112,14 @@ void TTreeFormulaManager::CancelDimension(Int_t virt_dim)
 
 void TTreeFormulaManager::EnableMultiVarDims()
 {
-   fMultiVarDim = kTRUE;
+   fMultiVarDim = true;
    if (!fCumulUsedVarDims) fCumulUsedVarDims = new TArrayI;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return number of available instances in the formulas.
 
-Int_t TTreeFormulaManager::GetNdata(Bool_t forceLoadDim)
+Int_t TTreeFormulaManager::GetNdata(bool forceLoadDim)
 {
    Int_t k;
 
@@ -216,12 +216,12 @@ Int_t TTreeFormulaManager::GetNdata(Bool_t forceLoadDim)
 ////////////////////////////////////////////////////////////////////////////////
 /// Synchronize all the formulae.
 
-Bool_t TTreeFormulaManager::Sync()
+bool TTreeFormulaManager::Sync()
 {
    if (!fNeedSync) return true;
 
    TTreeFormula *current = nullptr;
-   Bool_t hasCast = kFALSE;
+   bool hasCast = false;
 
    fMultiplicity = 0;
    // We do not use an intermediary variable because ResetDimensions
@@ -277,7 +277,7 @@ Bool_t TTreeFormulaManager::Sync()
    case 2: fNdata = fCumulUsedSizes[0]; break;
    default: fNdata = 0;
    }
-   fNeedSync = kFALSE;
+   fNeedSync = false;
 
    return true;
 }

--- a/tree/treeplayer/src/TTreeGeneratorBase.cxx
+++ b/tree/treeplayer/src/TTreeGeneratorBase.cxx
@@ -158,7 +158,7 @@ namespace Internal {
    ////////////////////////////////////////////////////////////////////////////////
    /// Get name of class inside a container.
 
-   TString TTreeGeneratorBase::GetContainedClassName(TBranchElement *branch, TStreamerElement *element, Bool_t ispointer)
+   TString TTreeGeneratorBase::GetContainedClassName(TBranchElement *branch, TStreamerElement *element, bool ispointer)
    {
       TString cname = branch->GetClonesName();
       if (cname.Length()==0) {

--- a/tree/treeplayer/src/TTreeIndex.cxx
+++ b/tree/treeplayer/src/TTreeIndex.cxx
@@ -233,9 +233,9 @@ TTreeIndex::~TTreeIndex()
 ////////////////////////////////////////////////////////////////////////////////
 /// Append 'add' to this index.  Entry 0 in add will become entry n+1 in this.
 /// If delaySort is true, do not sort the value, then you must call
-/// Append(0,kFALSE);
+/// Append(0,false);
 
-void TTreeIndex::Append(const TVirtualIndex *add, Bool_t delaySort )
+void TTreeIndex::Append(const TVirtualIndex *add, bool delaySort )
 {
 
    if (add && add->GetN()) {
@@ -463,7 +463,7 @@ TTreeFormula *TTreeIndex::GetMajorFormula()
 {
    if (!fMajorFormula) {
       fMajorFormula = new TTreeFormula("Major",fMajorName.Data(),fTree);
-      fMajorFormula->SetQuickLoad(kTRUE);
+      fMajorFormula->SetQuickLoad(true);
    }
    return fMajorFormula;
 }
@@ -475,7 +475,7 @@ TTreeFormula *TTreeIndex::GetMinorFormula()
 {
    if (!fMinorFormula) {
       fMinorFormula = new TTreeFormula("Minor",fMinorName.Data(),fTree);
-      fMinorFormula->SetQuickLoad(kTRUE);
+      fMinorFormula->SetQuickLoad(true);
    }
    return fMinorFormula;
 }
@@ -490,7 +490,7 @@ TTreeFormula *TTreeIndex::GetMajorFormulaParent(const TTree *parent)
       // is a friend of the parent TTree.
       TTree::TFriendLock friendlock(fTree, TTree::kFindLeaf | TTree::kFindBranch | TTree::kGetBranch | TTree::kGetLeaf);
       fMajorFormulaParent = new TTreeFormula("MajorP",fMajorName.Data(),const_cast<TTree*>(parent));
-      fMajorFormulaParent->SetQuickLoad(kTRUE);
+      fMajorFormulaParent->SetQuickLoad(true);
    }
    if (fMajorFormulaParent->GetTree() != parent) {
       fMajorFormulaParent->SetTree(const_cast<TTree*>(parent));
@@ -509,7 +509,7 @@ TTreeFormula *TTreeIndex::GetMinorFormulaParent(const TTree *parent)
       // is a friend of the parent TTree.
       TTree::TFriendLock friendlock(fTree, TTree::kFindLeaf | TTree::kFindBranch | TTree::kGetBranch | TTree::kGetLeaf);
       fMinorFormulaParent = new TTreeFormula("MinorP",fMinorName.Data(),const_cast<TTree*>(parent));
-      fMinorFormulaParent->SetQuickLoad(kTRUE);
+      fMinorFormulaParent->SetQuickLoad(true);
    }
    if (fMinorFormulaParent->GetTree() != parent) {
       fMinorFormulaParent->SetTree(const_cast<TTree*>(parent));
@@ -519,16 +519,16 @@ TTreeFormula *TTreeIndex::GetMinorFormulaParent(const TTree *parent)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return kTRUE if index can be applied to the TTree
+/// Return true if index can be applied to the TTree
 
-Bool_t TTreeIndex::IsValidFor(const TTree *parent)
+bool TTreeIndex::IsValidFor(const TTree *parent)
 {
    auto *majorFormula = GetMajorFormulaParent(parent);
    auto *minorFormula = GetMinorFormulaParent(parent);
    if ((majorFormula == nullptr || majorFormula->GetNdim() == 0) ||
        (minorFormula == nullptr || minorFormula->GetNdim() == 0))
-         return kFALSE;
-   return kTRUE;
+         return false;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -540,13 +540,13 @@ Bool_t TTreeIndex::IsValidFor(const TTree *parent)
 void TTreeIndex::Print(Option_t * option) const
 {
    TString opt = option;
-   Bool_t printEntry = kFALSE;
+   bool printEntry = false;
    Long64_t n = fN;
    if (opt.Contains("10"))   n = 10;
    if (opt.Contains("100"))  n = 100;
    if (opt.Contains("1000")) n = 1000;
    if (opt.Contains("all")) {
-      printEntry = kTRUE;
+      printEntry = true;
    }
 
    if (printEntry) {
@@ -599,7 +599,7 @@ void TTreeIndex::Streamer(TBuffer &R__b)
       R__b.ReadFastArray(fIndex,fN);
       R__b.CheckByteCount(R__s, R__c, TTreeIndex::IsA());
    } else {
-      R__c = R__b.WriteVersion(TTreeIndex::IsA(), kTRUE);
+      R__c = R__b.WriteVersion(TTreeIndex::IsA(), true);
       TVirtualIndex::Streamer(R__b);
       fMajorName.Streamer(R__b);
       fMinorName.Streamer(R__b);
@@ -607,7 +607,7 @@ void TTreeIndex::Streamer(TBuffer &R__b)
       R__b.WriteFastArray(fIndexValues, fN);
       R__b.WriteFastArray(fIndexValuesMinor, fN);
       R__b.WriteFastArray(fIndex, fN);
-      R__b.SetByteCount(R__c, kTRUE);
+      R__b.SetByteCount(R__c, true);
    }
 }
 

--- a/tree/treeplayer/src/TTreePerfStats.cxx
+++ b/tree/treeplayer/src/TTreePerfStats.cxx
@@ -168,7 +168,7 @@ TTreePerfStats::TTreePerfStats(const char *name, TTree *T) : TVirtualPerfStats()
    fRealTimeAxis  = nullptr;
    fCompress      = (T->GetTotBytes()+0.00001)/T->GetZipBytes();
 
-   Bool_t isUNIX = strcmp(gSystem->GetName(), "Unix") == 0;
+   bool isUNIX = strcmp(gSystem->GetName(), "Unix") == 0;
    if (isUNIX)
       fHostInfo = gSystem->GetFromPipe("uname -a");
    else
@@ -435,7 +435,7 @@ TTreePerfStats::BasketList_t TTreePerfStats::GetDuplicateBasketCache() const
 
    auto branches = cache->GetCachedBranches();
    for (size_t i = 0; i < fBasketsInfo.size(); ++i) {
-      Bool_t first = kTRUE;
+      bool first = true;
       for (size_t j = 0; j < fBasketsInfo[i].size(); ++j) {
          auto &info(fBasketsInfo[i][j]);
          if ((info.fLoaded + info.fLoadedMiss) > 1) {
@@ -471,7 +471,7 @@ void TTreePerfStats::Paint(Option_t *option)
 
    TString opts(option);
    opts.ToLower();
-   Bool_t unzip = opts.Contains("unzip");
+   bool unzip = opts.Contains("unzip");
 
    //superimpose the time info (max 10 points)
    if (fGraphTime) {
@@ -541,8 +541,8 @@ void TTreePerfStats::Print(Option_t * option) const
 {
    TString opts(option);
    opts.ToLower();
-   Bool_t unzip = opts.Contains("unzip");
-   Bool_t basket = opts.Contains("basket");
+   bool unzip = opts.Contains("unzip");
+   bool basket = opts.Contains("basket");
    TTreePerfStats *ps = (TTreePerfStats*)this;
    ps->Finish();
 
@@ -583,7 +583,7 @@ void TTreePerfStats::PrintBasketInfo(Option_t *option) const
 
    TString opts(option);
    opts.ToLower();
-   Bool_t all = opts.Contains("allbasketinfo");
+   bool all = opts.Contains("allbasketinfo");
 
    TFile *file = fTree->GetCurrentFile();
    if (!file)

--- a/tree/treeplayer/src/TTreePlayer.cxx
+++ b/tree/treeplayer/src/TTreePlayer.cxx
@@ -100,12 +100,12 @@ TTreePlayer::TTreePlayer()
 {
    fTree           = nullptr;
    fScanFileName   = nullptr;
-   fScanRedirect   = kFALSE;
+   fScanRedirect   = false;
    fSelectedRows   = 0;
    fDimension      = 0;
    fHistogram      = nullptr;
    fFormulaList    = new TList();
-   fFormulaList->SetOwner(kTRUE);
+   fFormulaList->SetOwner(true);
    fSelector         = new TSelectorDraw();
    fSelectorFromFile = nullptr;
    fSelectorClass    = nullptr;
@@ -232,7 +232,7 @@ TTree *TTreePlayer::CopyTree(const char *selection, Option_t *, Long64_t nentrie
       }
       if (select) {
          Int_t ndata = select->GetNdata();
-         Bool_t keep = kFALSE;
+         bool keep = false;
          for(Int_t current = 0; current<ndata && !keep; current++) {
             keep |= (select->EvalInstance(current) != 0);
          }
@@ -387,7 +387,7 @@ Long64_t TTreePlayer::DrawSelect(const char *varexp0, const char *selection, Opt
    TEventList *evlist  = fTree->GetEventList();
    TEntryList *elist = fTree->GetEntryList();
    if (evlist && elist){
-      elist->SetBit(kCanDelete, kTRUE);
+      elist->SetBit(kCanDelete, true);
    }
    TNamed *cvarexp    = (TNamed*)fInput->FindObject("varexp");
    TNamed *cselection = (TNamed*)fInput->FindObject("selection");
@@ -396,19 +396,19 @@ Long64_t TTreePlayer::DrawSelect(const char *varexp0, const char *selection, Opt
 
    TString opt = option;
    opt.ToLower();
-   Bool_t optpara   = kFALSE;
-   Bool_t optcandle = kFALSE;
-   Bool_t optgl5d   = kFALSE;
-   Bool_t optnorm   = kFALSE;
-   if (opt.Contains("norm")) {optnorm = kTRUE; opt.ReplaceAll("norm",""); opt.ReplaceAll(" ","");}
-   if (opt.Contains("para")) optpara = kTRUE;
-   if (opt.Contains("candle")) optcandle = kTRUE;
-   if (opt.Contains("gl5d")) optgl5d = kTRUE;
-   Bool_t pgl = gStyle->GetCanvasPreferGL();
+   bool optpara   = false;
+   bool optcandle = false;
+   bool optgl5d   = false;
+   bool optnorm   = false;
+   if (opt.Contains("norm")) {optnorm = true; opt.ReplaceAll("norm",""); opt.ReplaceAll(" ","");}
+   if (opt.Contains("para")) optpara = true;
+   if (opt.Contains("candle")) optcandle = true;
+   if (opt.Contains("gl5d")) optgl5d = true;
+   bool pgl = gStyle->GetCanvasPreferGL();
    if (optgl5d) {
       fTree->SetEstimate(fTree->GetEntries());
       if (!gPad) {
-         if (pgl == kFALSE) gStyle->SetCanvasPreferGL(kTRUE);
+         if (pgl == false) gStyle->SetCanvasPreferGL(true);
          gROOT->ProcessLineFast("new TCanvas();");
       }
    }
@@ -435,8 +435,8 @@ Long64_t TTreePlayer::DrawSelect(const char *varexp0, const char *selection, Opt
    // Draw generated histogram
    Long64_t drawflag = fSelector->GetDrawFlag();
    Int_t action   = fSelector->GetAction();
-   Bool_t draw = kFALSE;
-   if (!drawflag && !opt.Contains("goff")) draw = kTRUE;
+   bool draw = false;
+   if (!drawflag && !opt.Contains("goff")) draw = true;
    if (!optcandle && !optpara) fHistogram = (TH1*)fSelector->GetObject();
    if (optnorm) {
       Double_t sumh= fHistogram->GetSumOfWeights();
@@ -471,12 +471,12 @@ Long64_t TTreePlayer::DrawSelect(const char *varexp0, const char *selection, Opt
       if (action == 4) {
          if (draw) fHistogram->Draw(opt.Data());
       } else {
-         Bool_t graph = kFALSE;
+         bool graph = false;
          Int_t l = opt.Length();
-         if (l == 0 || opt == "same") graph = kTRUE;
-         if (opt.Contains("p")     || opt.Contains("*")    || opt.Contains("l"))    graph = kTRUE;
-         if (opt.Contains("surf")  || opt.Contains("lego") || opt.Contains("cont")) graph = kFALSE;
-         if (opt.Contains("col")   || opt.Contains("hist") || opt.Contains("scat")) graph = kFALSE;
+         if (l == 0 || opt == "same") graph = true;
+         if (opt.Contains("p")     || opt.Contains("*")    || opt.Contains("l"))    graph = true;
+         if (opt.Contains("surf")  || opt.Contains("lego") || opt.Contains("cont")) graph = false;
+         if (opt.Contains("col")   || opt.Contains("hist") || opt.Contains("scat")) graph = false;
          if (!graph) {
             if (draw) fHistogram->Draw(opt.Data());
          } else {
@@ -636,7 +636,7 @@ const char *TTreePlayer::GetNameByIndex(TString &varexp, Int_t *index,Int_t coli
 ////////////////////////////////////////////////////////////////////////////////
 /// Return the name of the branch pointer needed by MakeClass/MakeSelector
 
-static TString R__GetBranchPointerName(TLeaf *leaf, Bool_t replace = kTRUE)
+static TString R__GetBranchPointerName(TLeaf *leaf, bool replace = true)
 {
    TLeaf *leafcount = leaf->GetLeafCount();
    TBranch *branch = leaf->GetBranch();
@@ -749,8 +749,8 @@ Int_t TTreePlayer::MakeClass(const char *classname, const char *option)
    // In the case of a chain, the GetDirectory information usually does
    // pertain to the Chain itself but to the currently loaded tree.
    // So we can not rely on it.
-   Bool_t ischain = fTree->InheritsFrom(TChain::Class());
-   Bool_t isHbook = fTree->InheritsFrom("THbookTree");
+   bool ischain = fTree->InheritsFrom(TChain::Class());
+   bool isHbook = fTree->InheritsFrom("THbookTree");
    if (isHbook)
       treefile = fTree->GetTitle();
 
@@ -897,7 +897,7 @@ Int_t TTreePlayer::MakeClass(const char *classname, const char *option)
    TObjArray branches(100);
    TObjArray mustInit(100);
    TObjArray mustInitArr(100);
-   mustInitArr.SetOwner(kFALSE);
+   mustInitArr.SetOwner(false);
    Int_t *leafStatus = new Int_t[nleaves];
    for (l=0;l<nleaves;l++) {
       Int_t kmax = 0;
@@ -1100,8 +1100,8 @@ Int_t TTreePlayer::MakeClass(const char *classname, const char *option)
       fprintf(fp,"   void   Begin(TTree *tree) override;\n");
       fprintf(fp,"   void   SlaveBegin(TTree *tree) override;\n");
       fprintf(fp,"   void   Init(TTree *tree) override;\n");
-      fprintf(fp,"   Bool_t Notify() override;\n");
-      fprintf(fp,"   Bool_t Process(Long64_t entry) override;\n");
+      fprintf(fp,"   bool   Notify() override;\n");
+      fprintf(fp,"   bool   Process(Long64_t entry) override;\n");
       fprintf(fp,"   Int_t  GetEntry(Long64_t entry, Int_t getall = 0) override { return fChain ? fChain->GetTree()->GetEntry(entry, getall) : 0; }\n");
       fprintf(fp,"   void   SetOption(const char *option) override { fOption = option; }\n");
       fprintf(fp,"   void   SetObject(TObject *obj) override { fObject = obj; }\n");
@@ -1123,7 +1123,7 @@ Int_t TTreePlayer::MakeClass(const char *classname, const char *option)
       fprintf(fp,"   virtual Long64_t LoadTree(Long64_t entry);\n");
       fprintf(fp,"   virtual void     Init(TTree *tree);\n");
       fprintf(fp,"   virtual void     Loop();\n");
-      fprintf(fp,"   virtual Bool_t   Notify();\n");
+      fprintf(fp,"   virtual bool     Notify();\n");
       fprintf(fp,"   virtual void     Show(Long64_t entry = -1);\n");
       fprintf(fp,"};\n");
       fprintf(fp,"\n");
@@ -1312,7 +1312,7 @@ Int_t TTreePlayer::MakeClass(const char *classname, const char *option)
       }
       const char *maybedisable = "";
       if (branch != fTree->GetBranch(branch->GetName())) {
-         Error("MakeClass","The branch named %s (full path name: %s) is hidden by another branch of the same name and its data will not be loaded.",branch->GetName(),R__GetBranchPointerName(leaf,kFALSE).Data());
+         Error("MakeClass","The branch named %s (full path name: %s) is hidden by another branch of the same name and its data will not be loaded.",branch->GetName(),R__GetBranchPointerName(leaf,false).Data());
          maybedisable = "// ";
       }
       if (branch->IsA() == TBranchObject::Class()) {
@@ -1341,14 +1341,14 @@ Int_t TTreePlayer::MakeClass(const char *classname, const char *option)
    fprintf(fp,"\n");
 
 // generate code for class member function Notify()
-   fprintf(fp,"Bool_t %s::Notify()\n",classname);
+   fprintf(fp,"bool %s::Notify()\n",classname);
    fprintf(fp,"{\n");
    fprintf(fp,"   // The Notify() function is called when a new file is opened. This\n"
               "   // can be either for a new TTree in a TChain or when when a new TTree\n"
               "   // is started when using PROOF. It is normally not necessary to make changes\n"
               "   // to the generated code, but the routine can be extended by the\n"
               "   // user if needed. The return value is currently not used.\n\n");
-   fprintf(fp,"   return kTRUE;\n");
+   fprintf(fp,"   return true;\n");
    fprintf(fp,"}\n");
    fprintf(fp,"\n");
 
@@ -1473,7 +1473,7 @@ Int_t TTreePlayer::MakeClass(const char *classname, const char *option)
       fprintf(fpc,"}\n");
       // generate code for class member function Process
       fprintf(fpc,"\n");
-      fprintf(fpc,"Bool_t %s::Process(Long64_t entry)\n",classname);
+      fprintf(fpc,"bool %s::Process(Long64_t entry)\n",classname);
       fprintf(fpc,"{\n");
       fprintf(fpc,"   // The Process() function is called for each entry in the tree (or possibly\n"
                   "   // keyed object in the case of PROOF) to be processed. The entry argument\n"
@@ -1493,7 +1493,7 @@ Int_t TTreePlayer::MakeClass(const char *classname, const char *option)
                   "   //\n"
                   "   // The return value is currently not used.\n\n", classname);
       fprintf(fpc,"\n");
-      fprintf(fpc,"   return kTRUE;\n");
+      fprintf(fpc,"   return true;\n");
       fprintf(fpc,"}\n");
       // generate code for class member function SlaveTerminate
       fprintf(fpc,"\n");
@@ -1569,7 +1569,7 @@ Int_t TTreePlayer::MakeCode(const char *filename)
    // In the case of a chain, the GetDirectory information usually does
    // pertain to the Chain itself but to the currently loaded tree.
    // So we can not rely on it.
-   Bool_t ischain = fTree->InheritsFrom(TChain::Class());
+   bool ischain = fTree->InheritsFrom(TChain::Class());
 
 // Print header
    TObjArray *leaves = fTree->GetListOfLeaves();
@@ -1878,8 +1878,8 @@ Int_t TTreePlayer::MakeCode(const char *filename)
 /// -  The method         calls the method (if it exist)
 /// -  Begin           -> void h1analysisProxy_Begin(TTree*);
 /// -  SlaveBegin      -> void h1analysisProxy_SlaveBegin(TTree*);
-/// -  Notify          -> Bool_t h1analysisProxy_Notify();
-/// -  Process         -> Bool_t h1analysisProxy_Process(Long64_t);
+/// -  Notify          -> bool h1analysisProxy_Notify();
+/// -  Process         -> bool h1analysisProxy_Process(Long64_t);
 /// -  SlaveTerminate  -> void h1analysisProxy_SlaveTerminate();
 /// -  Terminate       -> void h1analysisProxy_Terminate();
 ///
@@ -1953,8 +1953,8 @@ Int_t TTreePlayer::MakeProxy(const char *proxyClassname,
 ///       - void    Begin(TTree *tree)
 ///       - void    SlaveBegin(TTree *tree)
 ///       - void    Init(TTree *tree)
-///       - Bool_t  Notify()
-///       - Bool_t  Process(Long64_t entry)
+///       - bool    Notify()
+///       - bool    Process(Long64_t entry)
 ///       - void    Terminate()
 ///       - void    SlaveTerminate()
 ///
@@ -2079,21 +2079,21 @@ TPrincipal *TTreePlayer::Principal(const char *varexp, const char *selection, Op
       }
 
       for(int inst=0;inst<ndata;inst++) {
-         Bool_t loaded = kFALSE;
+         bool loaded = false;
          if (select) {
             if (select->EvalInstance(inst) == 0) {
                continue;
             }
          }
 
-         if (inst==0) loaded = kTRUE;
+         if (inst==0) loaded = true;
          else if (!loaded) {
             // EvalInstance(0) always needs to be called so that
             // the proper branches are loaded.
             for (i=0;i<ncols;i++) {
                var[i]->EvalInstance(0);
             }
-            loaded = kTRUE;
+            loaded = true;
          }
 
          for (i=0;i<ncols;i++) {
@@ -2241,10 +2241,10 @@ Long64_t TTreePlayer::Process(TSelector *selector,Option_t *option, Long64_t nen
    selector->Notify();
 
    if (gMonitoringWriter)
-      gMonitoringWriter->SendProcessingStatus("STARTED",kTRUE);
+      gMonitoringWriter->SendProcessingStatus("STARTED",true);
 
-   Bool_t process = (selector->GetAbort() != TSelector::kAbortProcess &&
-                    (selector->Version() != 0 || selector->GetStatus() != -1)) ? kTRUE : kFALSE;
+   bool process = (selector->GetAbort() != TSelector::kAbortProcess &&
+                    (selector->Version() != 0 || selector->GetStatus() != -1)) ? true : false;
    if (process) {
 
       Long64_t readbytesatstart = 0;
@@ -2275,11 +2275,11 @@ Long64_t TTreePlayer::Process(TSelector *selector,Option_t *option, Long64_t nen
       //loop on entries (elist or all entries)
       Long64_t entry, entryNumber, localEntry;
 
-      Bool_t useCutFill = selector->Version() == 0;
+      bool useCutFill = selector->Version() == 0;
 
       // force the first monitoring info
       if (gMonitoringWriter)
-         gMonitoringWriter->SendProcessingProgress(0,0,kTRUE);
+         gMonitoringWriter->SendProcessingProgress(0,0,true);
 
       //trying to set the first tree, because in the Draw function
       //the tree corresponding to firstentry has already been loaded,
@@ -2301,7 +2301,7 @@ Long64_t TTreePlayer::Process(TSelector *selector,Option_t *option, Long64_t nen
             selector->Process(localEntry);        //<==call user analysis function
          }
          if (gMonitoringWriter)
-            gMonitoringWriter->SendProcessingProgress((entry-firstentry),TFile::GetFileBytesRead()-readbytesatstart,kTRUE);
+            gMonitoringWriter->SendProcessingProgress((entry-firstentry),TFile::GetFileBytesRead()-readbytesatstart,true);
          if (selector->GetAbort() == TSelector::kAbortProcess) break;
          if (selector->GetAbort() == TSelector::kAbortFile) {
             // Skip to the next file.
@@ -2322,7 +2322,7 @@ Long64_t TTreePlayer::Process(TSelector *selector,Option_t *option, Long64_t nen
    }
 
    process = (selector->GetAbort() != TSelector::kAbortProcess &&
-             (selector->Version() != 0 || selector->GetStatus() != -1)) ? kTRUE : kFALSE;
+             (selector->Version() != 0 || selector->GetStatus() != -1)) ? true : false;
    Long64_t res = (process) ? 0 : -1;
    if (process) {
       selector->SlaveTerminate();   //<==call user termination function
@@ -2625,8 +2625,8 @@ Long64_t TTreePlayer::Scan(const char *varexp, const char *selection,
 
 //*-*- Create a TreeFormulaManager to coordinate the formulas
    TTreeFormulaManager *manager=nullptr;
-   Bool_t hasArray = kFALSE;
-   Bool_t forceDim = kFALSE;
+   bool hasArray = false;
+   bool forceDim = false;
    if (fFormulaList->LastIndex()>=0) {
       if (select) {
          if (select->GetManager()->GetMultiplicity() > 0 ) {
@@ -2642,11 +2642,11 @@ Long64_t TTreePlayer::Scan(const char *varexp, const char *selection,
          switch( form->GetManager()->GetMultiplicity() ) {
             case  1:
             case  2:
-               hasArray = kTRUE;
-               forceDim = kTRUE;
+               hasArray = true;
+               forceDim = true;
                break;
             case -1:
-               forceDim = kTRUE;
+               forceDim = true;
                break;
             case  0:
                break;
@@ -2690,7 +2690,7 @@ Long64_t TTreePlayer::Scan(const char *varexp, const char *selection,
 //*-*- loop on all selected entries
    fSelectedRows = 0;
    Int_t tnumber = -1;
-   Bool_t exitloop = kFALSE;
+   bool exitloop = false;
    for (entry=firstentry;
         entry<(firstentry+nentries) && !exitloop;
         entry++) {
@@ -2713,7 +2713,7 @@ Long64_t TTreePlayer::Scan(const char *varexp, const char *selection,
 
          if (manager) {
 
-            ndata = manager->GetNdata(kTRUE);
+            ndata = manager->GetNdata(true);
 
          } else {
 
@@ -2729,21 +2729,21 @@ Long64_t TTreePlayer::Scan(const char *varexp, const char *selection,
       }
 
       if (lenmax && ndata>(int)lenmax) ndata = lenmax;
-      Bool_t loaded = kFALSE;
+      bool loaded = false;
       for(int inst=0;inst<ndata;inst++) {
          if (select) {
             if (select->EvalInstance(inst) == 0) {
                continue;
             }
          }
-         if (inst==0) loaded = kTRUE;
+         if (inst==0) loaded = true;
          else if (!loaded) {
             // EvalInstance(0) always needs to be called so that
             // the proper branches are loaded.
             for (ui=0;ui<ncols;ui++) {
                var[ui]->EvalInstance(0);
             }
-            loaded = kTRUE;
+            loaded = true;
          }
          onerow = Form("* %8lld ",entryNumber);
          if (hasArray) {
@@ -2770,7 +2770,7 @@ Long64_t TTreePlayer::Scan(const char *varexp, const char *selection,
                answer = readch;
                while (readch != '\n' && readch != EOF) readch = getchar();
                if (answer == 'q' || answer == 'Q') {
-                  exitloop = kTRUE;
+                  exitloop = true;
                   break;
                }
             }
@@ -2892,7 +2892,7 @@ TSQLResult *TTreePlayer::Query(const char *varexp, const char *selection,
          if (select->EvalInstance(0) == 0) continue;
       }
 
-      Bool_t loaded = kFALSE;
+      bool loaded = false;
       for(int inst=0;inst<ndata;inst++) {
          if (select) {
             if (select->EvalInstance(inst) == 0) {
@@ -2900,14 +2900,14 @@ TSQLResult *TTreePlayer::Query(const char *varexp, const char *selection,
             }
          }
 
-         if (inst==0) loaded = kTRUE;
+         if (inst==0) loaded = true;
          else if (!loaded) {
             // EvalInstance(0) always needs to be called so that
             // the proper branches are loaded.
             for (i=0;i<ncols;i++) {
                var[i]->EvalInstance(0);
             }
-            loaded = kTRUE;
+            loaded = true;
          }
          for (i=0;i<ncols;i++) {
             aresult = var[i]->PrintValue(0,inst);

--- a/tree/treeplayer/src/TTreeProcessorMP.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMP.cxx
@@ -329,7 +329,7 @@ void TTreeProcessorMP::FixLists(std::vector<TObject*> &lists) {
    TIter nxo(oldlist);
    TObject *o = nullptr;
    while ((o = nxo())) { firstlist->Add(o); }
-   oldlist->SetOwner(kFALSE);
+   oldlist->SetOwner(false);
    lists.erase(lists.begin());
    lists.insert(lists.begin(), firstlist);
    delete oldlist;

--- a/tree/treeplayer/src/TTreeProxyGenerator.cxx
+++ b/tree/treeplayer/src/TTreeProxyGenerator.cxx
@@ -90,7 +90,7 @@ void Debug(Int_t level, const char *va_(fmt), ...)
 
 namespace {
 
-   Bool_t AreDifferent(const TString& from, const TString& to)
+   bool AreDifferent(const TString& from, const TString& to)
    {
       FILE *left = fopen(from.Data(),"r");
       FILE *right = fopen(to.Data(),"r");
@@ -100,7 +100,7 @@ namespace {
 
       char *lvalue,*rvalue;
 
-      Bool_t areEqual = kTRUE;
+      bool areEqual = true;
 
       do {
          lvalue = fgets(leftbuffer, sizeof(leftbuffer), left);
@@ -113,8 +113,8 @@ namespace {
                areEqual = areEqual && (0 == strncmp(lvalue,rvalue,sizeof(leftbuffer)));
             }
          }
-         if (lvalue&&!rvalue) areEqual = kFALSE;
-         if (rvalue&&!lvalue) areEqual = kFALSE;
+         if (lvalue&&!rvalue) areEqual = false;
+         if (rvalue&&!lvalue) areEqual = false;
 
       } while(areEqual && lvalue && rvalue);
 
@@ -256,7 +256,7 @@ namespace Internal {
    ////////////////////////////////////////////////////////////////////////////////
    /// Return true if we should create a nested class representing this class
 
-   Bool_t TTreeProxyGenerator::NeedToEmulate(TClass *cl, UInt_t /* level */)
+   bool TTreeProxyGenerator::NeedToEmulate(TClass *cl, UInt_t /* level */)
    {
       return cl!=nullptr && cl->TestBit(TClass::kIsEmulation);
    }
@@ -410,7 +410,7 @@ namespace Internal {
    /// Generate an enum for a given type if it is not known in the list of class
    /// unless the type itself a template.
 
-   void TTreeProxyGenerator::AddMissingClassAsEnum(const char *clname, Bool_t isscope)
+   void TTreeProxyGenerator::AddMissingClassAsEnum(const char *clname, bool isscope)
    {
       if (!TClassEdit::IsStdClass(clname) && !TClass::GetClass(clname) && gROOT->GetType(clname) == nullptr) {
 
@@ -440,15 +440,15 @@ namespace Internal {
       UInt_t len = strlen(clname);
       UInt_t nest = 0;
       UInt_t last = 0;
-      //Bool_t istemplate = kFALSE; // mark whether the current right most entity is a class template.
+      //bool istemplate = false; // mark whether the current right most entity is a class template.
 
       for (UInt_t i = 0; i < len; ++i) {
          switch (clname[i]) {
             case ':':
                if (nest == 0 && clname[i+1] == ':') {
                   TString incName(clname, i);
-                  AddMissingClassAsEnum(incName.Data(), kTRUE);
-                  //istemplate = kFALSE;
+                  AddMissingClassAsEnum(incName.Data(), true);
+                  //istemplate = false;
                }
                break;
             case '<':
@@ -467,13 +467,13 @@ namespace Internal {
                   if (isdigit(incName[0])) {
                      // Not a class name, nothing to do.
                   } else {
-                     AddMissingClassAsEnum(incName.Data(),kFALSE);
+                     AddMissingClassAsEnum(incName.Data(),false);
                   }
                   last = i + 1;
                }
          }
       }
-      AddMissingClassAsEnum(TClassEdit::ShortType(clname, TClassEdit::kDropTrailStar | TClassEdit::kLong64).c_str(),kFALSE);
+      AddMissingClassAsEnum(TClassEdit::ShortType(clname, TClassEdit::kDropTrailStar | TClassEdit::kLong64).c_str(),false);
    }
 
    ////////////////////////////////////////////////////////////////////////////////
@@ -524,7 +524,7 @@ namespace Internal {
       TBranchProxyClassDescriptor::ELocation outer_isclones = TBranchProxyClassDescriptor::kOut;
       TString containerName;
       TString subBranchPrefix;
-      Bool_t skipped = false;
+      bool skipped = false;
 
       {
          TIter peek = branches;
@@ -575,8 +575,8 @@ namespace Internal {
            element;
            element = (TStreamerElement*)elements() )
       {
-         Bool_t isBase = false;
-         Bool_t usedBranch = kTRUE;
+         bool isBase = false;
+         bool usedBranch = true;
          TString prefix;
          TIter peek = branches;
          TBranchElement *branch = (TBranchElement*)peek();
@@ -620,7 +620,7 @@ namespace Internal {
             }
          }
 
-         Bool_t ispointer = false;
+         bool ispointer = false;
          switch(element->GetType()) {
 
             case TVirtualStreamerInfo::kBool:    { proxyTypeName = "T" + middle + "BoolProxy"; break; }
@@ -804,7 +804,7 @@ namespace Internal {
                                                               local_prefix,
                                                               isclones, branch->GetSplitLevel(),
                                                               containerName);
-                     usedBranch = kFALSE;
+                     usedBranch = false;
                      lookedAt += AnalyzeBranches( level, cldesc, branches, objInfo );
                   }
 
@@ -879,8 +879,8 @@ namespace Internal {
                                                               local_prefix,
                                                               isclones, branch->GetSplitLevel(),
                                                               containerName);
-                     usedBranch = kFALSE;
-                     skipped = kTRUE;
+                     usedBranch = false;
+                     skipped = true;
                      lookedAt += AnalyzeBranches( level, cldesc, branches, objInfo );
                   }
 
@@ -1277,7 +1277,7 @@ namespace Internal {
       TString type;
 
       // TString prefix;
-      Bool_t isBase = false;
+      bool isBase = false;
       TString cname;
       TString middle;
       TBranchProxyClassDescriptor::ELocation isclones = TBranchProxyClassDescriptor::kOut;
@@ -1348,7 +1348,7 @@ namespace Internal {
       }
 
 
-      // Bool_t ispointer = false;
+      // bool ispointer = false;
       switch(element->GetType()) {
 
          case TVirtualStreamerInfo::kBool:    { type = "T" + middle + "BoolProxy"; break; }
@@ -1558,34 +1558,34 @@ namespace Internal {
    /// Add the "pragma C++ class" if needed and return
    /// true if it has been added _or_ if it is known to
    /// not be needed.
-   /// (I.e. return kFALSE if a container of this class
+   /// (I.e. return false if a container of this class
    /// can not have a "pragma C++ class"
 
-   static Bool_t R__AddPragmaForClass(TTreeProxyGenerator *gen, TClass *cl)
+   static bool R__AddPragmaForClass(TTreeProxyGenerator *gen, TClass *cl)
    {
-      if (!cl) return kFALSE;
+      if (!cl) return false;
       if (cl->GetCollectionProxy()) {
          TClass *valcl = cl->GetCollectionProxy()->GetValueClass();
          if (!valcl) {
             if (!cl->IsLoaded()) gen->AddPragma(Form("#pragma link C++ class %s;\n", cl->GetName()));
-            return kTRUE;
+            return true;
          } else if (R__AddPragmaForClass(gen, valcl)) {
             if (!cl->IsLoaded()) gen->AddPragma(Form("#pragma link C++ class %s;\n", cl->GetName()));
-            return kTRUE;
+            return true;
          }
       }
-      if (cl->IsLoaded()) return kTRUE;
-      return kFALSE;
+      if (cl->IsLoaded()) return true;
+      return false;
    }
 
    ////////////////////////////////////////////////////////////////////////////////
    /// Add the "pragma C++ class" if needed and return
    /// true if it has been added _or_ if it is known to
    /// not be needed.
-   /// (I.e. return kFALSE if a container of this class
+   /// (I.e. return false if a container of this class
    /// can not have a "pragma C++ class"
 
-   static Bool_t R__AddPragmaForClass(TTreeProxyGenerator *gen, const char *classname)
+   static bool R__AddPragmaForClass(TTreeProxyGenerator *gen, const char *classname)
    {
       return R__AddPragmaForClass( gen, TClass::GetClass(classname) );
 
@@ -1643,15 +1643,15 @@ namespace Internal {
       // If they do we will generate the proxy in temporary file and modify the original
       // if and only if it is different.
 
-      Bool_t updating = kFALSE;
+      bool updating = false;
       if (gSystem->GetPathInfo( fHeaderFileName, nullptr, (Long_t*)nullptr, nullptr, nullptr ) == 0) {
          // file already exist
-         updating = kTRUE;
+         updating = true;
       }
 
 
       TString treefile;
-      Bool_t ischain = fTree->InheritsFrom(TChain::Class());
+      bool ischain = fTree->InheritsFrom(TChain::Class());
       if (fTree->GetDirectory() && fTree->GetDirectory()->GetFile())
          treefile = fTree->GetDirectory()->GetFile()->GetName();
       else
@@ -1784,8 +1784,8 @@ namespace Internal {
       fprintf(hf,"public:\n");
       fprintf(hf,"   void %s_Begin(TTree*) {}\n",scriptfunc.Data());
       fprintf(hf,"   void %s_SlaveBegin(TTree*) {}\n",scriptfunc.Data());
-      fprintf(hf,"   Bool_t %s_Notify() { return kTRUE; }\n",scriptfunc.Data());
-      fprintf(hf,"   Bool_t %s_Process(Long64_t) { return kTRUE; }\n",scriptfunc.Data());
+      fprintf(hf,"   bool %s_Notify() { return true; }\n",scriptfunc.Data());
+      fprintf(hf,"   bool %s_Process(Long64_t) { return true; }\n",scriptfunc.Data());
       fprintf(hf,"   void %s_SlaveTerminate() {}\n",scriptfunc.Data());
       fprintf(hf,"   void %s_Terminate() {}\n",scriptfunc.Data());
       fprintf(hf,"};\n");
@@ -1859,8 +1859,8 @@ namespace Internal {
       fprintf(hf,"   void    Begin(::TTree *tree) override;\n");
       fprintf(hf,"   void    SlaveBegin(::TTree *tree) override;\n");
       fprintf(hf,"   void    Init(::TTree *tree) override;\n");
-      fprintf(hf,"   Bool_t  Notify() override;\n");
-      fprintf(hf,"   Bool_t  Process(Long64_t entry) override;\n");
+      fprintf(hf,"   bool    Notify() override;\n");
+      fprintf(hf,"   bool    Process(Long64_t entry) override;\n");
       fprintf(hf,"   void    SlaveTerminate() override;\n");
       fprintf(hf,"   void    Terminate() override;\n");
       fprintf(hf,"\n");
@@ -1923,14 +1923,14 @@ namespace Internal {
       fprintf(hf,"   }\n");
       fprintf(hf,"}\n");
       fprintf(hf,"\n");
-      fprintf(hf,"Bool_t %s::Notify()\n",classname.Data());
+      fprintf(hf,"bool %s::Notify()\n",classname.Data());
       fprintf(hf,"{\n");
       fprintf(hf,"   // Called when loading a new file.\n");
       fprintf(hf,"   // Get branch pointers.\n");
       fprintf(hf,"   fDirector.SetTree(fChain);\n");
       fprintf(hf,"   %s_Notify();\n",scriptfunc.Data());
       fprintf(hf,"   \n");
-      fprintf(hf,"   return kTRUE;\n");
+      fprintf(hf,"   return true;\n");
       fprintf(hf,"}\n");
       fprintf(hf,"   \n");
 
@@ -1963,7 +1963,7 @@ namespace Internal {
       fprintf(hf,"\n");
 
       // generate code for class member function Process
-      fprintf(hf,"inline Bool_t %s::Process(Long64_t entry)\n",classname.Data());
+      fprintf(hf,"inline bool %s::Process(Long64_t entry)\n",classname.Data());
       fprintf(hf,"{\n");
 
       fprintf(hf,"   // The Process() function is called for each entry in the tree (or possibly\n"
@@ -1999,7 +1999,7 @@ namespace Internal {
          }
       }
       fprintf(hf,"   %s_Process(entry);\n",scriptfunc.Data());
-      fprintf(hf,"   return kTRUE;\n");
+      fprintf(hf,"   return true;\n");
       fprintf(hf,"\n");
       fprintf(hf,"}\n\n");
 

--- a/tree/treeplayer/src/TTreeReader.cxx
+++ b/tree/treeplayer/src/TTreeReader.cxx
@@ -293,9 +293,9 @@ void TTreeReader::Initialize()
 
       if (fTree->GetTree()) {
          // The current TTree is already available.
-         fSetEntryBaseCallingLoadTree = kTRUE;
+         fSetEntryBaseCallingLoadTree = true;
          Notify();
-         fSetEntryBaseCallingLoadTree = kFALSE;
+         fSetEntryBaseCallingLoadTree = false;
       }
    }
 }
@@ -304,7 +304,7 @@ void TTreeReader::Initialize()
 /// Notify director and values of a change in tree. Called from TChain and TTree's LoadTree.
 /// TTreeReader registers its fNotify data member with the TChain/TTree which
 /// in turn leads to this method being called upon the execution of LoadTree.
-Bool_t TTreeReader::Notify()
+bool TTreeReader::Notify()
 {
 
    if (fSetEntryBaseCallingLoadTree) {
@@ -342,7 +342,7 @@ Bool_t TTreeReader::Notify()
       }
    }
 
-   return kTRUE;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -350,13 +350,13 @@ Bool_t TTreeReader::Notify()
 /// fValues gets insertions during this loop (when parametrized arrays are read),
 /// invalidating iterators. Use old-school counting instead.
 
-Bool_t TTreeReader::SetProxies() {
+bool TTreeReader::SetProxies() {
 
    for (size_t i = 0; i < fValues.size(); ++i) {
       ROOT::Internal::TTreeReaderValueBase* reader = fValues[i];
       reader->CreateProxy();
       if (!reader->GetProxy()){
-         return kFALSE;
+         return false;
       }
 
    }
@@ -384,7 +384,7 @@ Bool_t TTreeReader::SetProxies() {
       }
    }
 
-   return kTRUE;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -407,7 +407,7 @@ Bool_t TTreeReader::SetProxies() {
 /// considered.
 ///
 /// \param beginEntry The first entry to be loaded by `Next()`.
-/// \param endEntry   The entry where `Next()` will return kFALSE, not loading it.
+/// \param endEntry   The entry where `Next()` will return false, not loading it.
 
 TTreeReader::EEntryStatus TTreeReader::SetEntriesRange(Long64_t beginEntry, Long64_t endEntry)
 {
@@ -482,17 +482,17 @@ Long64_t TTreeReader::GetEntries() const {
 ///   this TChain should be opened to determine the exact number of entries
 /// of the TChain. If `!IsChain()`, `force` is ignored.
 
-Long64_t TTreeReader::GetEntries(Bool_t force)  {
+Long64_t TTreeReader::GetEntries(bool force)  {
    if (fEntryList)
       return fEntryList->GetN();
    if (!fTree)
       return -1;
    if (force) {
-      fSetEntryBaseCallingLoadTree = kTRUE;
+      fSetEntryBaseCallingLoadTree = true;
       auto res = fTree->GetEntries();
       // Go back to where we were:
       fTree->LoadTree(GetCurrentEntry());
-      fSetEntryBaseCallingLoadTree = kFALSE;
+      fSetEntryBaseCallingLoadTree = false;
       return res;
    }
    return fTree->GetEntriesFast();
@@ -506,7 +506,7 @@ Long64_t TTreeReader::GetEntries(Bool_t force)  {
 /// `local` is `true`, in which case `entry` specifies the entry number within
 /// the current tree. This is needed for instance for TSelector::Process().
 
-TTreeReader::EEntryStatus TTreeReader::SetEntryBase(Long64_t entry, Bool_t local)
+TTreeReader::EEntryStatus TTreeReader::SetEntryBase(Long64_t entry, bool local)
 {
    if (IsInvalid()) {
       fEntryStatus = kEntryNoTree;
@@ -544,9 +544,9 @@ TTreeReader::EEntryStatus TTreeReader::SetEntryBase(Long64_t entry, Bool_t local
 
    TTree* treeToCallLoadOn = local ? fTree->GetTree() : fTree;
 
-   fSetEntryBaseCallingLoadTree = kTRUE;
+   fSetEntryBaseCallingLoadTree = true;
    const Long64_t loadResult = treeToCallLoadOn->LoadTree(entryAfterList);
-   fSetEntryBaseCallingLoadTree = kFALSE;
+   fSetEntryBaseCallingLoadTree = false;
 
    if (loadResult < 0) {
       // ROOT-9628 We cover here the case when:
@@ -669,7 +669,7 @@ void TTreeReader::SetTree(const char* keyname, TDirectory* dir, TEntryList* entr
 ////////////////////////////////////////////////////////////////////////////////
 /// Add a value reader for this tree.
 
-Bool_t TTreeReader::RegisterValueReader(ROOT::Internal::TTreeReaderValueBase* reader)
+bool TTreeReader::RegisterValueReader(ROOT::Internal::TTreeReaderValueBase* reader)
 {
    if (fProxiesSet) {
       Error("RegisterValueReader",

--- a/tree/treeplayer/src/TTreeReaderArray.cxx
+++ b/tree/treeplayer/src/TTreeReaderArray.cxx
@@ -679,7 +679,7 @@ void ROOT::Internal::TTreeReaderArrayBase::SetImpl(TBranch* branch, TLeaf* myLea
       if (id >= 0){ // Not root node?
          // Int_t offset = streamerInfo->GetOffsets()[id];
          TStreamerElement *element = (TStreamerElement*)streamerInfo->GetElements()->At(id);
-         // Bool_t isPointer = element->IsaPointer();
+         // bool isPointer = element->IsaPointer();
          // TClass *classPointer = element->GetClassPointer();
 
          if (fSetupStatus == kSetupInternalError)

--- a/tree/treeplayer/src/TTreeTableInterface.cxx
+++ b/tree/treeplayer/src/TTreeTableInterface.cxx
@@ -45,7 +45,7 @@ TTreeTableInterface::TTreeTableInterface (TTree *tree, const char *varexp,
    Long64_t firstentry)
    : TVirtualTableInterface(), fTree(tree), fFormulas(nullptr), fEntry(0),
      fNEntries(nentries), fFirstEntry(firstentry), fManager(nullptr), fSelect(nullptr), fSelector(nullptr), fInput(nullptr),
-     fForceDim(kFALSE), fEntries(nullptr), fNRows(0), fNColumns(0)
+     fForceDim(false), fEntries(nullptr), fNRows(0), fNColumns(0)
 {
    if (fTree == nullptr) {
       Error("TTreeTableInterface", "No tree supplied");
@@ -101,13 +101,13 @@ void TTreeTableInterface::SetVariablesExpression(const char *varexp)
 {
    // FIXME check if enough protection against wrong expressions is in place
 
-   Bool_t allvar = kFALSE;
+   bool allvar = false;
 
    if (varexp) {
-      if (!strcmp(varexp, "*")) { allvar = kTRUE; }
+      if (!strcmp(varexp, "*")) { allvar = true; }
    } else {
       // if varexp is empty, take all available leaves as a column
-      allvar = kTRUE;
+      allvar = true;
    }
 
    if (allvar) {
@@ -185,7 +185,7 @@ void TTreeTableInterface::SyncFormulas()
             case  1:
             case  2:
             case -1:
-               fForceDim = kTRUE;
+               fForceDim = true;
                break;
             case  0:
                break;
@@ -225,7 +225,7 @@ void TTreeTableInterface::InitEntries()
       Int_t ndata = 1;
       if (fForceDim){
          if (fManager)
-            ndata = fManager->GetNdata(kTRUE);
+            ndata = fManager->GetNdata(true);
          else {
             for (ui = 0; ui < fNColumns; ui++){
                if (ndata < ((TTreeFormula*)fFormulas->At(ui))->GetNdata())
@@ -237,13 +237,13 @@ void TTreeTableInterface::InitEntries()
                ndata = 0;
          }
       }
-      Bool_t skip = kFALSE;
+      bool skip = false;
 
       // Loop over the instances of the selection condition
       for (Int_t inst = 0; inst < ndata; inst++){
          if (fSelect){
             if (fSelect->EvalInstance(inst) == 0){
-               skip = kTRUE;
+               skip = true;
                entry++;
             }
          }

--- a/tree/treeviewer/inc/TParallelCoord.h
+++ b/tree/treeviewer/inc/TParallelCoord.h
@@ -70,25 +70,25 @@ public:
    void           AddVariable(const char* varexp);
    void           AddSelection(const char* title);
    void           ApplySelectionToTree(); // *MENU*
-   static void    BuildParallelCoord(TSelectorDraw* selector, Bool_t candle);
+   static void    BuildParallelCoord(TSelectorDraw* selector, bool candle);
    void           CleanUpSelections(TParallelCoordRange* range);
    void           RemoveVariable(TParallelCoordVar* var);
-   Bool_t         RemoveVariable(const char* var);
+   bool           RemoveVariable(const char* var);
    void           DeleteSelection(TParallelCoordSelect* sel);
-   Int_t  DistancetoPrimitive(Int_t px, Int_t py) override;
-   void   Draw(Option_t* options="") override;
-   void   ExecuteEvent(Int_t entry, Int_t px, Int_t py) override;
-   Bool_t         GetCandleChart() {return TestBit(kCandleChart);}
+   Int_t          DistancetoPrimitive(Int_t px, Int_t py) override;
+   void           Draw(Option_t* options="") override;
+   void           ExecuteEvent(Int_t entry, Int_t px, Int_t py) override;
+   bool           GetCandleChart() {return TestBit(kCandleChart);}
    Long64_t       GetCurrentFirst() {return fCurrentFirst;}
    Long64_t       GetCurrentN() {return fCurrentN;}
    TParallelCoordSelect* GetCurrentSelection();
-   Bool_t         GetCurveDisplay() const {return TestBit(kCurveDisplay);}
+   bool           GetCurveDisplay() const {return TestBit(kCurveDisplay);}
    Int_t          GetDotsSpacing() const {return fDotsSpacing;}
-   TEntryList    *GetEntryList(Bool_t sel=kTRUE);
+   TEntryList    *GetEntryList(bool sel=true);
    Double_t       GetGlobalMin();
    Double_t       GetGlobalMax();
-   Bool_t         GetGlobalScale() {return TestBit(kGlobalScale);}
-   Bool_t         GetGlobalLogScale() {return TestBit(kGlobalLogScale);}
+   bool           GetGlobalScale() {return TestBit(kGlobalScale);}
+   bool           GetGlobalLogScale() {return TestBit(kGlobalLogScale);}
    Color_t        GetLineColor() {return fLineColor;}
    Width_t        GetLineWidth() {return fLineWidth;}
    Int_t          GetNbins();
@@ -100,18 +100,18 @@ public:
    Double_t      *GetVariable(const char* var);
    Double_t      *GetVariable(Int_t i);
    TList         *GetVarList() {return fVarList;}
-   Bool_t         GetVertDisplay() const {return TestBit(kVertDisplay);}
+   bool           GetVertDisplay() const {return TestBit(kVertDisplay);}
    Int_t          GetWeightCut() const {return fWeightCut;};
-   void   Paint(Option_t* options="") override;
+   void           Paint(Option_t* options="") override;
    void           ResetTree();
-   void           SaveEntryLists(const char* filename="", Bool_t overwrite=kFALSE); // *MENU*
+   void           SaveEntryLists(const char* filename="", bool overwrite=false); // *MENU*
    void           SavePrimitive(std::ostream & out,Option_t *options) override;
-   void           SaveTree(const char* filename="", Bool_t overwrite=kFALSE); // *MENU*
+   void           SaveTree(const char* filename="", bool overwrite=false); // *MENU*
    void           SetAxisHistogramBinning(Int_t n=100); // *MENU*
    void           SetAxisHistogramHeight(Double_t h=0.5); // *MENU*
    void           SetAxisHistogramLineWidth(Int_t lw=2); // *MENU*
-   void           SetCandleChart(Bool_t can); // *TOGGLE* *GETTER=GetCandleChart
-   virtual void   SetCurveDisplay(Bool_t curve=true) {SetBit(kCurveDisplay,curve);} // *TOGGLE* *GETTER=GetCurveDisplay
+   void           SetCandleChart(bool can); // *TOGGLE* *GETTER=GetCandleChart
+   virtual void   SetCurveDisplay(bool curve=true) {SetBit(kCurveDisplay,curve);} // *TOGGLE* *GETTER=GetCurveDisplay
    void           SetCurrentEntries(TEntryList* entries) {fCurrentEntries = entries;}
    void           SetCurrentFirst(Long64_t);
    void           SetCurrentN(Long64_t);
@@ -119,17 +119,17 @@ public:
    void           SetCurrentSelection(TParallelCoordSelect* sel);
    void           SetDotsSpacing(Int_t s=0); // *MENU*
    static void    SetEntryList(TParallelCoord* para, TEntryList* enlist);
-   void           SetGlobalScale(Bool_t gl); // *TOGGLE* *GETTER=GetGlobalScale
-   void           SetGlobalLogScale(Bool_t); // *TOGGLE* *GETTER=GetGlobalLogScale
+   void           SetGlobalScale(bool gl); // *TOGGLE* *GETTER=GetGlobalScale
+   void           SetGlobalLogScale(bool); // *TOGGLE* *GETTER=GetGlobalLogScale
    void           SetGlobalMin(Double_t min);
    void           SetGlobalMax(Double_t max);
    void           SetInitEntries(TEntryList* entries) {fInitEntries = entries;}
    void           SetLineColor(Color_t col) {fLineColor = col;}
    void           SetLineWidth(Width_t wid) {fLineWidth = wid;}
-   void           SetLiveRangesUpdate(Bool_t);
+   void           SetLiveRangesUpdate(bool);
    void           SetNentries(Long64_t n) {fNentries = n;}
    void           SetTree(TTree* tree) {fTree = tree;}
-   void           SetVertDisplay(Bool_t vert=kTRUE); // *TOGGLE* *GETTER=GetVertDisplay
+   void           SetVertDisplay(bool vert=true); // *TOGGLE* *GETTER=GetVertDisplay
    void           SetWeightCut(Int_t w=0) {fWeightCut = w;} // *MENU*
    void           UnzoomAll(); // *MENU*
 

--- a/tree/treeviewer/inc/TParallelCoordEditor.h
+++ b/tree/treeviewer/inc/TParallelCoordEditor.h
@@ -68,7 +68,7 @@ protected:
    TGNumberEntryField      *fWeightCutField;
    TGColorSelect           *fHistColorSelect;
    TGedPatternSelect       *fHistPatternSelect;
-   Bool_t                   fDelay;
+   bool                     fDelay;
 
    void                    CleanUpSelections();
    void                    CleanUpVariables();
@@ -82,11 +82,11 @@ public:
                         Pixel_t back = GetDefaultFrameBackground());
    ~TParallelCoordEditor() override;
 
-   virtual void            DoActivateSelection(Bool_t);
+   virtual void            DoActivateSelection(bool);
    virtual void            DoAddSelection();
    virtual void            DoAddVariable();
    virtual void            DoApplySelect();
-   virtual void            DoDelayDrawing(Bool_t);
+   virtual void            DoDelayDrawing(bool);
    virtual void            DoDeleteSelection();
    virtual void            DoDeleteVar();
    virtual void            DoDotsSpacing();
@@ -96,8 +96,8 @@ public:
    virtual void            DoFirstEntry();
    virtual void            DoGlobalLineColor(Pixel_t);
    virtual void            DoGlobalLineWidth(Int_t);
-   virtual void            DoHideAllRanges(Bool_t);
-   virtual void            DoHistShowBoxes(Bool_t);
+   virtual void            DoHideAllRanges(bool);
+   virtual void            DoHistShowBoxes(bool);
    virtual void            DoHistWidth();
    virtual void            DoHistBinning();
    virtual void            DoHistColorSelect(Pixel_t);
@@ -109,11 +109,11 @@ public:
    virtual void            DoLiveEntriesToDraw();
    virtual void            DoLiveWeightCut(Int_t n);
    virtual void            DoNentries();
-   virtual void            DoPaintEntries(Bool_t);
+   virtual void            DoPaintEntries(bool);
    virtual void            DoSelectionSelect(const char* title);
    virtual void            DoSelectLineColor(Pixel_t);
    virtual void            DoSelectLineWidth(Int_t);
-   virtual void            DoShowRanges(Bool_t s);
+   virtual void            DoShowRanges(bool s);
    virtual void            DoUnApply();
    virtual void            DoVariableSelect(const char* var);
    virtual void            DoWeightCut();

--- a/tree/treeviewer/inc/TParallelCoordRange.h
+++ b/tree/treeviewer/inc/TParallelCoordRange.h
@@ -36,7 +36,7 @@ private:
    TParallelCoordVar *fVar;       ///< Variable owning the range.
    TParallelCoordSelect* fSelect; ///< Selection owning the range.
 
-   void              PaintSlider(Double_t value,Bool_t fill=kFALSE);
+   void              PaintSlider(Double_t value,bool fill=false);
    TPoint*           GetBindingLinePoints(Int_t pos,Int_t mindragged);
    TPoint*           GetSliderPoints(Double_t value);
    TPoint*           GetSliderPoints(Int_t pos);
@@ -55,7 +55,7 @@ public:
    virtual Double_t GetMax() {return fMax;}
    TParallelCoordVar* GetVar() {return fVar;}
    TParallelCoordSelect* GetSelection() {return fSelect;}
-   Bool_t IsIn(Double_t evtval);
+   bool IsIn(Double_t evtval);
    void Paint(Option_t *options) override;
    void Print(Option_t *options) const override; // *MENU*
    virtual void SendToBack(); // *MENU*
@@ -82,8 +82,8 @@ public:
    ~TParallelCoordSelect() override;   // Destructor.
 
    const char* GetTitle() const override {return fTitle.Data();}
-   void        SetActivated(Bool_t on);
-   void        SetShowRanges(Bool_t s);
+   void        SetActivated(bool on);
+   void        SetShowRanges(bool s);
    void        SetTitle(const char* title) {fTitle = title;}
 
    ClassDefOverride(TParallelCoordSelect,1); // A TParallelCoordSelect is a specialised TList to hold TParallelCoordRanges used by TParallelCoord.

--- a/tree/treeviewer/inc/TParallelCoordVar.h
+++ b/tree/treeviewer/inc/TParallelCoordVar.h
@@ -61,13 +61,13 @@ public:
    void           DeleteVariable(); // *MENU*
    Int_t  DistancetoPrimitive(Int_t px, Int_t py) override;
    void   Draw(Option_t *option="") override;
-   Bool_t         Eval(Long64_t evtidx, TParallelCoordSelect *select); // Check an entry is within its ranges owned by a given TParallelSelect.
+   bool           Eval(Long64_t evtidx, TParallelCoordSelect *select); // Check an entry is within its ranges owned by a given TParallelSelect.
    void   ExecuteEvent(Int_t entry, Int_t px, Int_t py) override;
-   Bool_t         GetBarHisto() {return TestBit(kShowBarHisto);}
-   Bool_t         GetBoxPlot() {return TestBit(kShowBox);}
+   bool           GetBarHisto() {return TestBit(kShowBarHisto);}
+   bool           GetBoxPlot() {return TestBit(kShowBox);}
    TH1F          *GetHistogram();
    Int_t          GetId() {return fId;}
-   Bool_t         GetLogScale() const {return TestBit (kLogScale);}
+   bool           GetLogScale() const {return TestBit (kLogScale);}
    Int_t          GetHistBinning() const {return fNbins;}
    Double_t       GetCurrentMin() const {return fMinCurrent;}
    Double_t       GetCurrentMax() const {return fMaxCurrent;}
@@ -87,7 +87,7 @@ public:
    TList         *GetRanges() {return fRanges;}
    Double_t      *GetValues() {return fVal;}
    Double_t       GetValuefromXY(Double_t x,Double_t y);
-   Bool_t         GetVert() {return fX1 == fX2;} // Tells if the axis is vertical or not.
+   bool           GetVert() {return fX1 == fX2;} // Tells if the axis is vertical or not.
    void           GetXYfromValue(Double_t value, Double_t & x, Double_t & y);
    void           Init();
    void   Paint(Option_t* option="") override;
@@ -96,8 +96,8 @@ public:
    void           PaintLabels();
    void   Print(Option_t* option="") const override; // *MENU*
    void           SavePrimitive(std::ostream & out, Option_t *options) override;
-   void           SetBoxPlot(Bool_t box); // *TOGGLE* *GETTER=GetBoxPlot
-   void           SetBarHisto(Bool_t h) {SetBit(kShowBarHisto,h);} // *TOGGLE* *GETTER=GetBarHisto
+   void           SetBoxPlot(bool box); // *TOGGLE* *GETTER=GetBoxPlot
+   void           SetBarHisto(bool h) {SetBit(kShowBarHisto,h);} // *TOGGLE* *GETTER=GetBarHisto
    void           SetHistogramLineWidth(Int_t lw=2) {fHistoLW = lw;} // *MENU*
    void           SetHistogramHeight(Double_t h=0); // *MENU*
    void           SetHistogramBinning(Int_t n=100); // *MENU*
@@ -106,12 +106,12 @@ public:
    void           SetCurrentMax(Double_t max);
    void           SetInitMin(Double_t min) {fMinInit = min;}
    void           SetInitMax(Double_t max) {fMaxInit = max;}
-   void           SetLiveRangesUpdate(Bool_t on);
-   void           SetLogScale(Bool_t log); // *TOGGLE* *GETTER=GetLogScale
+   void           SetLiveRangesUpdate(bool on);
+   void           SetLogScale(bool log); // *TOGGLE* *GETTER=GetLogScale
    void           SetTitle(const char* /*title*/) override {} // To hide TNamed::SetTitle.
    void           SetValues(Long64_t length, Double_t* val);
-   void           SetX(Double_t x, Bool_t gl);    // Set a new x position in case of a vertical display.
-   void           SetY(Double_t y, Bool_t gl);    // Set a new y position in case of a horizontal display.
+   void           SetX(Double_t x, bool gl);    // Set a new x position in case of a vertical display.
+   void           SetY(Double_t y, bool gl);    // Set a new y position in case of a horizontal display.
    void           Unzoom() {SetCurrentLimits(fMinInit,fMaxInit);} // *MENU* Reset fMin and fMax to their original value.
 
    ClassDefOverride(TParallelCoordVar,1); // A Variable of a parallel coordinates plot.

--- a/tree/treeviewer/inc/TSpider.h
+++ b/tree/treeviewer/inc/TSpider.h
@@ -62,11 +62,11 @@ private:
    TList*                  fPolyList;       ///< Polygons representing the variables.
    TTreeFormula*           fSelect;         ///< Selection condition
    TSelectorDraw*          fSelector;       ///<! Selector.
-   Bool_t                  fAngularLabels;  ///< True if the labels are oriented according to their axis.
-   Bool_t                  fDisplayAverage; ///< Display or not the average.
-   Bool_t                  fForceDim;       ///< Force dimension.
-   Bool_t                  fSegmentDisplay; ///< True if displaying a segment plot.
-   Bool_t                  fShowRange;      ///< Show range of variables or not.
+   bool                    fAngularLabels;  ///< True if the labels are oriented according to their axis.
+   bool                    fDisplayAverage; ///< Display or not the average.
+   bool                    fForceDim;       ///< Force dimension.
+   bool                    fSegmentDisplay; ///< True if displaying a segment plot.
+   bool                    fShowRange;      ///< Show range of variables or not.
 
    Int_t          FindTextAlign(Double_t theta);
    Double_t       FindTextAngle(Double_t theta);
@@ -96,12 +96,12 @@ public:
    Width_t        GetAverageLineWidth() const;
    Color_t        GetAverageFillColor() const;
    Style_t        GetAverageFillStyle() const;
-   Bool_t         GetDisplayAverage() const {return fDisplayAverage;}
+   bool           GetDisplayAverage() const {return fDisplayAverage;}
    Long64_t       GetCurrentEntry() const {return fEntry;}
    Long64_t       GetEntriesToProcess(Long64_t firstentry, Long64_t nentries) const;
    Int_t          GetNx() const {return fNx;}
    Int_t          GetNy() const {return fNy;}
-   Bool_t         GetSegmentDisplay() const {return fSegmentDisplay;}
+   bool           GetSegmentDisplay() const {return fSegmentDisplay;}
    void           GotoEntry(Long64_t e); // *MENU*
    void           GotoNext(); // *MENU*
    void           GotoPrevious(); // *MENU*
@@ -113,19 +113,19 @@ public:
    void           SetAverageLineWidth(Width_t wid);
    void           SetAverageFillColor(Color_t col);
    void           SetAverageFillStyle(Style_t sty);
-   void   SetLineStyle(Style_t sty) override;
-   void   SetLineColor(Color_t col) override;
-   void   SetLineWidth(Width_t wid) override;
-   void   SetFillColor(Color_t col) override;
-   void   SetFillStyle(Style_t sty) override;
-   void           SetDisplayAverage(Bool_t disp); // *TOGGLE*
+   void           SetLineStyle(Style_t sty) override;
+   void           SetLineColor(Color_t col) override;
+   void           SetLineWidth(Width_t wid) override;
+   void           SetFillColor(Color_t col) override;
+   void           SetFillStyle(Style_t sty) override;
+   void           SetDisplayAverage(bool disp); // *TOGGLE*
    void           SetVariablesExpression(const char* varexp);
    void           SetNdivRadial(Int_t div); // *MENU*
    void           SetNx(UInt_t nx); // *MENU*
    void           SetNy(UInt_t ny); // *MENU*
    void           SetSelectionExpression(const char* selexp);
-   void           SetSegmentDisplay(Bool_t seg); // *TOGGLE*
-   void           SetShowRange(Bool_t showrange) {fShowRange = showrange;}
+   void           SetSegmentDisplay(bool seg); // *TOGGLE*
+   void           SetShowRange(bool showrange) {fShowRange = showrange;}
    void           SuperposeTo(TSpider* sp) {sp->AddSuperposed(this);}
 
    ClassDefOverride(TSpider,0)  //Helper class to draw spider

--- a/tree/treeviewer/inc/TSpiderEditor.h
+++ b/tree/treeviewer/inc/TSpiderEditor.h
@@ -75,7 +75,7 @@ public:
 
    virtual void         DoAddVar();
    virtual void         DoDeleteVar();
-   virtual void         DoDisplayAverage(Bool_t av);
+   virtual void         DoDisplayAverage(bool av);
    virtual void         DoGotoEntry();
    virtual void         DoGotoNext();
    virtual void         DoGotoPrevious();

--- a/tree/treeviewer/inc/TTVLVContainer.h
+++ b/tree/treeviewer/inc/TTVLVContainer.h
@@ -47,7 +47,7 @@ public:
    void         Empty();                         // *MENU*
    void         RemoveItem();                    // *MENU*
    void         Scan();                          // *MENU*
-   void         SetExpression(const char *name="", const char *alias="-empty-", Bool_t cut=kFALSE); // *MENU*
+   void         SetExpression(const char *name="", const char *alias="-empty-", bool cut=false); // *MENU*
 
    ClassDefOverride(TGItemContext, 0)  // Context menu for TTVLVEntry
 };
@@ -61,11 +61,11 @@ protected:
    TString         fAlias;      ///< Alias for this entry
    TString         fConvName;   ///< Name converted into true expressions
    TGToolTip      *fTip;        ///< Tool tip associated with item
-   Bool_t          fIsCut;      ///< Flag for cut type items
+   bool            fIsCut;      ///< Flag for cut type items
    TGItemContext  *fContext;    ///< Associated context menu
 
 protected:
-   Bool_t         FullConverted();
+   bool           FullConverted();
 
 public:
    TTVLVEntry(const TGWindow *p,
@@ -80,14 +80,14 @@ public:
    const char     *GetConvName() {return fConvName;}
    const char     *GetTrueName() {return fTrueName.Data();}
    TGToolTip      *GetTip() {return fTip;}
-   Bool_t  HandleCrossing(Event_t *event) override;
-   Bool_t          HasAlias();
-   Bool_t          IsCut() {return fIsCut;}
+   bool            HandleCrossing(Event_t *event) override;
+   bool            HasAlias();
+   bool            IsCut() {return fIsCut;}
    void            PrependTilde();
-   void            SetCutType(Bool_t type=kFALSE);
+   void            SetCutType(bool type=false);
    void            SetItemName(const char* name);
    void            SetAlias(const char* alias) {fAlias = alias;}
-   void            SetExpression(const char* name, const char* alias, Bool_t cutType=kFALSE);
+   void            SetExpression(const char* name, const char* alias, bool cutType=false);
    void            SetTrueName(const char* name) {fTrueName = name;}
    void            SetToolTipText(const char *text, Long_t delayms = 1000);
    void            SetSmallPic(const TGPicture *spic);
@@ -136,8 +136,8 @@ public:
    void           RemoveNonStatic();
    const char    *ScanList();
    void           SelectItem(const char* name);
-   Bool_t HandleButton(Event_t *event) override;
-   Bool_t HandleMotion(Event_t *event) override;
+   bool           HandleButton(Event_t *event) override;
+   bool           HandleMotion(Event_t *event) override;
 
    ClassDefOverride(TTVLVContainer,0)  // A dragging-capable LVContainer
 };
@@ -184,8 +184,8 @@ public:
    void           SetEntry(TTVLVEntry *entry);
    void           SaveText();
    void           InsertText(const char* text);
-   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
-   Bool_t         ValidateAlias();
+   bool ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
+   bool           ValidateAlias();
 
    static TGSelectBox *GetInstance();
 

--- a/tree/treeviewer/inc/TTVSession.h
+++ b/tree/treeviewer/inc/TTVSession.h
@@ -39,10 +39,10 @@ public:
    TString              fCut;                   ///< Cut expression
    TString              fCutAlias;              ///< Cut alias
    TString              fOption;                ///< Graphic option
-   Bool_t               fScanRedirected;        ///< Redirect switch
-   Bool_t               fCutEnabled;            ///< True if current cut is active
+   bool                 fScanRedirected;        ///< Redirect switch
+   bool                 fCutEnabled;            ///< True if current cut is active
    TString              fUserCode;              ///< Command executed when record is connected
-   Bool_t               fAutoexec;              ///< Autoexecute user code command
+   bool                 fAutoexec;              ///< Autoexecute user code command
 
 public:
    TTVRecord();                                 ///< Default constructor
@@ -56,17 +56,17 @@ public:
    const char    *GetZ() const {return fZ;}
    const char *GetName() const override {return fName;}
    const char    *GetUserCode() const {return fUserCode;}
-   Bool_t         HasUserCode() const {return fUserCode.Length() != 0 ? kTRUE : kFALSE;}
-   Bool_t         MustExecuteCode() const {return fAutoexec;}
-   void           SetAutoexec(Bool_t autoexec=kTRUE) {fAutoexec=autoexec;} // *TOGGLE* *GETTER=MustExecuteCode
+   bool           HasUserCode() const {return fUserCode.Length() != 0 ? true : false;}
+   bool           MustExecuteCode() const {return fAutoexec;}
+   void           SetAutoexec(bool autoexec=true) {fAutoexec=autoexec;} // *TOGGLE* *GETTER=MustExecuteCode
    void           SetName(const char* name = "") {fName = name;}
    void           SetX(const char *x = "", const char *xal = "-empty-") {fX = x; fXAlias = xal;}
    void           SetY(const char *y = "", const char *yal = "-empty-") {fY = y; fYAlias = yal;}
    void           SetZ(const char *z = "", const char *zal = "-empty-") {fZ = z; fZAlias = zal;}
    void           SetCut(const char *cut = "", const char *cal = "-empty-") {fCut = cut; fCutAlias = cal;}
    void           SetOption(const char *option = "")             {fOption = option;}
-   void           SetRC(Bool_t redirect = kFALSE, Bool_t cut = kTRUE) {fScanRedirected = redirect; fCutEnabled = cut;}
-   void           SetUserCode(const char *code, Bool_t autoexec=kTRUE) {fUserCode = code; fAutoexec=autoexec;} // *MENU*
+   void           SetRC(bool redirect = false, bool cut = true) {fScanRedirected = redirect; fCutEnabled = cut;}
+   void           SetUserCode(const char *code, bool autoexec=true) {fUserCode = code; fAutoexec=autoexec;} // *MENU*
    void           SaveSource(std::ofstream &out);
 
    ClassDefOverride(TTVRecord, 0)    // A draw record for TTreeViewer
@@ -87,7 +87,7 @@ public:
    const char *GetName() const override      {return fName;}
    void           SetName(const char *name) {fName = name;}
    void           SetRecordName(const char* name);
-   TTVRecord     *AddRecord(Bool_t fromFile = kFALSE);
+   TTVRecord     *AddRecord(bool fromFile = false);
    Int_t          GetEntries() {return fRecords;}
    TTVRecord     *GetCurrent() {return GetRecord(fCurrent);}
    TTVRecord     *GetRecord(Int_t i);

--- a/tree/treeviewer/inc/TTreeViewer.h
+++ b/tree/treeviewer/inc/TTreeViewer.h
@@ -81,8 +81,8 @@ private:
    TTree                *fMappedTree;           ///< Listed tree
    TBranch              *fMappedBranch;         ///< Listed branch
    Int_t                fDimension;             ///< Histogram dimension
-   Bool_t               fVarDraw;               ///< True if an item is double-clicked
-   Bool_t               fScanMode;              ///< Flag activated when Scan Box is double-clicked
+   bool                 fVarDraw;               ///< True if an item is double-clicked
+   bool                 fScanMode;              ///< Flag activated when Scan Box is double-clicked
    TContextMenu         *fContextMenu;          ///< Context menu for tree viewer
    TGSelectBox          *fDialogBox;            ///< Expression editor
    TList                *fTreeList;             ///< List of mapped trees
@@ -96,9 +96,9 @@ private:
    Cursor_t             fDefaultCursor;         ///< Default cursor
    Cursor_t             fWatchCursor;           ///< Watch cursor
    TTimer               *fTimer;                ///< Tree viewer timer
-   Bool_t               fCounting;              ///< True if timer is counting
-   Bool_t               fStopMapping;           ///< True if branch don't need remapping
-   Bool_t               fEnableCut;             ///< True if cuts are enabled
+   bool                 fCounting;              ///< True if timer is counting
+   bool                 fStopMapping;           ///< True if branch don't need remapping
+   bool                 fEnableCut;             ///< True if cuts are enabled
    Int_t                fNexpressions;          ///< Number of expression widgets
 ///@}
 
@@ -193,9 +193,9 @@ private:
    const char   *Ey();
    const char   *Ez();
    const char   *En(Int_t n);
-   void          MapBranch(TBranch *branch, const char *prefix="", TGListTreeItem *parent = nullptr, Bool_t listIt = kTRUE);
+   void          MapBranch(TBranch *branch, const char *prefix="", TGListTreeItem *parent = nullptr, bool listIt = true);
    void          MapOptions(Long_t parm1);
-   void          MapTree(TTree *tree, TGListTreeItem *parent = nullptr, Bool_t listIt = kTRUE);
+   void          MapTree(TTree *tree, TGListTreeItem *parent = nullptr, bool listIt = true);
    void          SetFile();
    const char   *ScanList();
    void          SetParentTree(TGListTreeItem *item);
@@ -207,47 +207,47 @@ public:
          ~TTreeViewer() override;
 
    void          AppendTree(TTree *tree);
-   void          ActivateButtons(Bool_t first, Bool_t previous,
-                                 Bool_t next , Bool_t last);
+   void          ActivateButtons(bool first, bool previous,
+                                 bool next , bool last);
    void  CloseWindow() override;
    void  Delete(Option_t *) override { }                          // *MENU*
    void          DoRefresh();
    void          EditExpression();
    void          Empty();
    void          EmptyAll();                                     // *MENU*
-   void          ExecuteCommand(const char* command, Bool_t fast = kFALSE); // *MENU*
+   void          ExecuteCommand(const char* command, bool fast = false); // *MENU*
    void          ExecuteDraw();
    void          ExecuteSpider();
    TTVLVEntry   *ExpressionItem(Int_t index);
    TList        *ExpressionList();
    const char   *GetGrOpt();
    TTree        *GetTree() {return fTree;}
-   Bool_t        HandleTimer(TTimer *timer) override;
-   Bool_t        IsCutEnabled() {return fEnableCut;}
-   Bool_t        IsScanRedirected();
+   bool          HandleTimer(TTimer *timer) override;
+   bool          IsCutEnabled() {return fEnableCut;}
+   bool          IsScanRedirected();
    Int_t         MakeSelector(const char* selector = nullptr);         // *MENU*
    void          Message(const char* msg) override;
    void          NewExpression();                                // *MENU*
    void          PrintEntries();
    Long64_t      Process(const char* filename, Option_t *option="", Long64_t nentries=TTree::kMaxEntries, Long64_t firstentry=0); // *MENU*
-   Bool_t        ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
+   bool          ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
    void          RemoveItem();
    void          RemoveLastRecord();                             // *MENU*
    void          SaveSource(const char* filename="", Option_t *option="") override;            // *MENU*
    void          SetHistogramTitle(const char *title);
-   void          SetCutMode(Bool_t enabled = kTRUE) {fEnableCut = enabled;}
+   void          SetCutMode(bool enabled = true) {fEnableCut = enabled;}
    void          SetCurrentRecord(Long64_t entry);
    void          SetGrOpt(const char *option);
    void          SetNexpressions(Int_t expr);
    void          SetRecordName(const char *name);                // *MENU*
    void          SetScanFileName(const char *name="");           // *MENU*
-   void          SetScanMode(Bool_t mode=kTRUE) {fScanMode = mode;}
-   void          SetScanRedirect(Bool_t mode);
+   void          SetScanMode(bool mode=true) {fScanMode = mode;}
+   void          SetScanRedirect(bool mode);
    void          SetSession(TTVSession *session);
-   void          SetUserCode(const char *code, Bool_t autoexec=kTRUE); // *MENU*
+   void          SetUserCode(const char *code, bool autoexec=true); // *MENU*
    void          SetTree(TTree* tree);
    void          SetTreeName(const char* treeName);              // *MENU*
-   Bool_t        SwitchTree(Int_t index);
+   bool          SwitchTree(Int_t index);
    void          UpdateCombo();
    void          UpdateRecord(const char *name="new name");      // *MENU*
 

--- a/tree/treeviewer/src/TParallelCoord.cxx
+++ b/tree/treeviewer/src/TParallelCoord.cxx
@@ -211,7 +211,7 @@ void TParallelCoord::AddVariable(const char* varexp)
    if(!fTree) return; // The tree from which one will get the data must be defined.
 
    // Select in the only the entries of this TParallelCoord.
-   TEntryList *list = GetEntryList(kFALSE);
+   TEntryList *list = GetEntryList(false);
    fTree->SetEntryList(list);
 
    // ensure that there is only one variable given:
@@ -285,7 +285,7 @@ void  TParallelCoord::ApplySelectionToTree()
 ////////////////////////////////////////////////////////////////////////////////
 /// Call constructor and add the variables.
 
-void  TParallelCoord::BuildParallelCoord(TSelectorDraw* selector, Bool_t candle)
+void  TParallelCoord::BuildParallelCoord(TSelectorDraw* selector, bool candle)
 {
    TParallelCoord* pc = new TParallelCoord(selector->GetTree(),selector->GetNfill());
    pc->SetBit(kCanDelete);
@@ -360,17 +360,17 @@ void TParallelCoord::Draw(Option_t* option)
 {
    if (!GetTree()) return;
    if (!fCurrentEntries) fCurrentEntries = fInitEntries;
-   Bool_t optcandle = kFALSE;
+   bool optcandle = false;
    TString opt = option;
    opt.ToLower();
    if(opt.Contains("candle")) {
-      optcandle = kTRUE;
+      optcandle = true;
       opt.ReplaceAll("candle","");
    }
    if(optcandle) {
-      SetBit(kPaintEntries,kFALSE);
-      SetBit(kCandleChart,kTRUE);
-      SetGlobalScale(kTRUE);
+      SetBit(kPaintEntries,false);
+      SetBit(kCandleChart,true);
+      SetGlobalScale(true);
    }
 
    if (gPad) {
@@ -390,7 +390,7 @@ void TParallelCoord::Draw(Option_t* option)
       }
    }
 
-   gPad->SetBit(TGraph::kClipFrame,kTRUE);
+   gPad->SetBit(TGraph::kClipFrame,true);
 
    TFrame *frame = new TFrame(0.1,0.1,0.9,0.9);
    frame->SetBorderSize(0);
@@ -407,7 +407,7 @@ void TParallelCoord::Draw(Option_t* option)
    TParallelCoordVar* var;
    while ((var = (TParallelCoordVar*)next())) {
       if(optcandle) {
-         var->SetBoxPlot(kTRUE);
+         var->SetBoxPlot(true);
          var->SetHistogramHeight(0.5);
          var->SetHistogramLineWidth(0);
       }
@@ -447,7 +447,7 @@ TParallelCoordSelect* TParallelCoord::GetCurrentSelection()
 ////////////////////////////////////////////////////////////////////////////////
 /// Get the whole entry list or one for a selection.
 
-TEntryList* TParallelCoord::GetEntryList(Bool_t sel)
+TEntryList* TParallelCoord::GetEntryList(bool sel)
 {
    if(!sel || fCurrentSelection->GetSize() == 0){ // If no selection is specified, return the entry list of all the entries.
       return fInitEntries;
@@ -456,10 +456,10 @@ TEntryList* TParallelCoord::GetEntryList(Bool_t sel)
       TIter next(fVarList);
       for (Long64_t li=0;li<fNentries;++li) {
          next.Reset();
-         Bool_t inrange=kTRUE;
+         bool inrange=true;
          TParallelCoordVar* var;
          while((var = (TParallelCoordVar*)next())){
-            if(!var->Eval(li,fCurrentSelection)) inrange = kFALSE;
+            if(!var->Eval(li,fCurrentSelection)) inrange = false;
          }
          if(!inrange) continue;
          enlist->Enter(fCurrentEntries->GetEntry(li));
@@ -587,13 +587,13 @@ void TParallelCoord::Init()
    fNentries = 0;
    fVarList = nullptr;
    fSelectList = nullptr;
-   SetBit(kVertDisplay,kTRUE);
-   SetBit(kCurveDisplay,kFALSE);
-   SetBit(kPaintEntries,kTRUE);
-   SetBit(kLiveUpdate,kFALSE);
-   SetBit(kGlobalScale,kFALSE);
-   SetBit(kCandleChart,kFALSE);
-   SetBit(kGlobalLogScale,kFALSE);
+   SetBit(kVertDisplay,true);
+   SetBit(kCurveDisplay,false);
+   SetBit(kPaintEntries,true);
+   SetBit(kLiveUpdate,false);
+   SetBit(kGlobalScale,false);
+   SetBit(kCandleChart,false);
+   SetBit(kGlobalLogScale,false);
    fTree = nullptr;
    fCurrentEntries = nullptr;
    fInitEntries = nullptr;
@@ -677,18 +677,18 @@ void TParallelCoord::PaintEntries(TParallelCoordSelect* sel)
 
    for (n=fCurrentFirst; n<fCurrentFirst+fCurrentN; ++n) {
       TListIter next(fVarList);
-      Bool_t inrange = kTRUE;
+      bool inrange = true;
       // Loop to check whenever the entry must be painted.
       if (sel) {
          while ((var = (TParallelCoordVar*)next())){
-            if (!var->Eval(n,sel)) inrange = kFALSE;
+            if (!var->Eval(n,sel)) inrange = false;
          }
       }
       if (fWeightCut > 0) {
          next.Reset();
          Int_t entryweight = 0;
          while ((var = (TParallelCoordVar*)next())) entryweight+=var->GetEntryWeight(n);
-         if (entryweight/(Int_t)fNvar < fWeightCut) inrange = kFALSE;
+         if (entryweight/(Int_t)fNvar < fWeightCut) inrange = false;
       }
       if(!inrange) continue;
       i = 0;
@@ -736,7 +736,7 @@ void TParallelCoord::RemoveVariable(TParallelCoordVar *var)
 ////////////////////////////////////////////////////////////////////////////////
 /// Delete the variable "vartitle" from the graph.
 
-Bool_t TParallelCoord::RemoveVariable(const char* vartitle)
+bool TParallelCoord::RemoveVariable(const char* vartitle)
 {
    TIter next(fVarList);
    TParallelCoordVar* var=nullptr;
@@ -745,11 +745,11 @@ Bool_t TParallelCoord::RemoveVariable(const char* vartitle)
    }
    if(!var) {
       Error("RemoveVariable","\"%s\" not a variable",vartitle);
-      return kFALSE;
+      return false;
    } else {
       RemoveVariable(var);
       delete var;
-      return kTRUE;
+      return true;
    }
 }
 
@@ -788,7 +788,7 @@ void TParallelCoord::ResetTree()
 ////////////////////////////////////////////////////////////////////////////////
 /// Save the entry lists in a root file "filename.root".
 
-void TParallelCoord::SaveEntryLists(const char* filename, Bool_t overwrite)
+void TParallelCoord::SaveEntryLists(const char* filename, bool overwrite)
 {
    TString sfile = filename;
    if (sfile == "") sfile = Form("%s_parallelcoord_entries.root",fTree->GetName());
@@ -815,11 +815,11 @@ void TParallelCoord::SavePrimitive(std::ostream & out, Option_t* options)
 {
    TString opt = options;
    opt.ToLower();
-   //Bool_t overwrite = opt.Contains("overwrite"); // Is there a way to specify "options" when saving ?
+   //bool overwrite = opt.Contains("overwrite"); // Is there a way to specify "options" when saving ?
    // Save the entrylists.
    const char* filename = Form("%s_parallelcoord_entries.root",fTree->GetName());
-   SaveEntryLists(filename,kTRUE); // FIXME overwriting by default.
-   SaveTree(fTreeFileName,kTRUE);  // FIXME overwriting by default.
+   SaveEntryLists(filename,true); // FIXME overwriting by default.
+   SaveTree(fTreeFileName,true);  // FIXME overwriting by default.
    out<<"   // Create a TParallelCoord."<<std::endl;
    out<<"   TFile *f = TFile::Open(\""<<fTreeFileName.Data()<<"\");"<<std::endl;
    out<<"   TTree* tree = (TTree*)f->Get(\""<<fTreeName.Data()<<"\");"<<std::endl;
@@ -871,16 +871,16 @@ void TParallelCoord::SavePrimitive(std::ostream & out, Option_t* options)
    out<<"   para->SetBit(TParallelCoord::kPaintEntries,"<<TestBit(kPaintEntries)<<");"<<std::endl;
    out<<"   para->SetBit(TParallelCoord::kLiveUpdate,"<<TestBit(kLiveUpdate)<<");"<<std::endl;
    out<<"   para->SetBit(TParallelCoord::kGlobalLogScale,"<<TestBit(kGlobalLogScale)<<");"<<std::endl;
-   if (TestBit(kGlobalScale)) out<<"   para->SetGlobalScale(kTRUE);"<<std::endl;
-   if (TestBit(kCandleChart)) out<<"   para->SetCandleChart(kTRUE);"<<std::endl;
-   if (TestBit(kGlobalLogScale)) out<<"   para->SetGlobalLogScale(kTRUE);"<<std::endl;
+   if (TestBit(kGlobalScale)) out<<"   para->SetGlobalScale(true);"<<std::endl;
+   if (TestBit(kCandleChart)) out<<"   para->SetCandleChart(true);"<<std::endl;
+   if (TestBit(kGlobalLogScale)) out<<"   para->SetGlobalLogScale(true);"<<std::endl;
    out<<std::endl<<"   para->Draw();"<<std::endl;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Save the tree in a file if fTreeFileName == "".
 
-void TParallelCoord::SaveTree(const char* filename, Bool_t overwrite)
+void TParallelCoord::SaveTree(const char* filename, bool overwrite)
 {
    if (!(fTreeFileName=="")) return;
    TString sfile = filename;
@@ -907,7 +907,7 @@ void TParallelCoord::SaveTree(const char* filename, Bool_t overwrite)
 void TParallelCoord::SetAxesPosition()
 {
    if(!gPad) return;
-   Bool_t vert          = TestBit (kVertDisplay);
+   bool vert          = TestBit (kVertDisplay);
    TFrame *frame        = gPad->GetFrame();
    if (fVarList->GetSize() > 1) {
       if (vert) {
@@ -968,20 +968,20 @@ void TParallelCoord::SetAxisHistogramHeight(Double_t h)
 ////////////////////////////////////////////////////////////////////////////////
 /// All axes in log scale.
 
-void TParallelCoord::SetGlobalLogScale(Bool_t lt)
+void TParallelCoord::SetGlobalLogScale(bool lt)
 {
    if (lt == TestBit(kGlobalLogScale)) return;
    SetBit(kGlobalLogScale,lt);
    TIter next(fVarList);
    TParallelCoordVar* var;
    while ((var = (TParallelCoordVar*)next())) var->SetLogScale(lt);
-   if (TestBit(kGlobalScale)) SetGlobalScale(kTRUE);
+   if (TestBit(kGlobalScale)) SetGlobalScale(true);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constraint all axes to the same scale.
 
-void TParallelCoord::SetGlobalScale(Bool_t gl)
+void TParallelCoord::SetGlobalScale(bool gl)
 {
    SetBit(kGlobalScale,gl);
    if (fCandleAxis) {
@@ -1024,7 +1024,7 @@ void TParallelCoord::SetAxisHistogramLineWidth(Int_t lw)
 ////////////////////////////////////////////////////////////////////////////////
 /// Set a candle chart display.
 
-void TParallelCoord::SetCandleChart(Bool_t can)
+void TParallelCoord::SetCandleChart(bool can)
 {
    SetBit(kCandleChart,can);
    SetGlobalScale(can);
@@ -1155,7 +1155,7 @@ void TParallelCoord::SetGlobalMin(Double_t min)
 ////////////////////////////////////////////////////////////////////////////////
 /// If true, the pad is updated while the motion of a dragged range.
 
-void TParallelCoord::SetLiveRangesUpdate(Bool_t on)
+void TParallelCoord::SetLiveRangesUpdate(bool on)
 {
    SetBit(kLiveUpdate,on);
    TIter next(fVarList);
@@ -1166,7 +1166,7 @@ void TParallelCoord::SetLiveRangesUpdate(Bool_t on)
 ////////////////////////////////////////////////////////////////////////////////
 /// Set the vertical or horizontal display.
 
-void TParallelCoord::SetVertDisplay(Bool_t vert)
+void TParallelCoord::SetVertDisplay(bool vert)
 {
    if (vert == TestBit (kVertDisplay)) return;
    SetBit(kVertDisplay,vert);

--- a/tree/treeviewer/src/TParallelCoordEditor.cxx
+++ b/tree/treeviewer/src/TParallelCoordEditor.cxx
@@ -97,7 +97,7 @@ TParallelCoordEditor::TParallelCoordEditor(const TGWindow* /*p*/,
                                            UInt_t /*options*/, Pixel_t /*back*/)
 {
    fPriority = 1;
-   fDelay = kTRUE;
+   fDelay = true;
 
    // Line
    MakeTitle("Line");
@@ -143,7 +143,7 @@ TParallelCoordEditor::TParallelCoordEditor(const TGWindow* /*p*/,
    }
 
    fLineTypeBgroup = new TGButtonGroup(this,2,1,0,0, "Line type");
-   fLineTypeBgroup->SetRadioButtonExclusive(kTRUE);
+   fLineTypeBgroup->SetRadioButtonExclusive(true);
    fLineTypePoly = new TGRadioButton(fLineTypeBgroup,"Polyline", kLineTypePoly);
    fLineTypePoly->SetToolTipText("Draw the entries with a polyline");
    fLineTypeCurves = new TGRadioButton(fLineTypeBgroup,"Curves",
@@ -326,7 +326,7 @@ void TParallelCoordEditor::CleanUpSelections()
 {
    TList *list = fParallel->GetSelectList();
    fSelectionSelect->RemoveAll();
-   Bool_t enable = list->GetSize() > 0;
+   bool enable = list->GetSize() > 0;
    fSelectionSelect->SetEnabled(enable);
    fSelectLineColor->SetEnabled(enable);
    fSelectLineWidth->SetEnabled(enable);
@@ -346,7 +346,7 @@ void TParallelCoordEditor::CleanUpSelections()
       }
       sel = fParallel->GetCurrentSelection();
       if (sel) {
-         fSelectionSelect->Select(list->IndexOf(sel),kFALSE);
+         fSelectionSelect->Select(list->IndexOf(sel),false);
          Color_t c;
          Pixel_t p;
          c = sel->GetLineColor();
@@ -366,7 +366,7 @@ void TParallelCoordEditor::CleanUpVariables()
 {
    TList *list = fParallel->GetVarList();
    fVariables->RemoveAll();
-   Bool_t enable = list->GetSize() > 0;
+   bool enable = list->GetSize() > 0;
    fVariables->SetEnabled(enable);
    fDeleteVar->SetEnabled(enable);
    fHistShowBoxes->SetEnabled(enable);
@@ -381,7 +381,7 @@ void TParallelCoordEditor::CleanUpVariables()
          ++i;
       }
       var = (TParallelCoordVar*)list->First();
-      fVariables->Select(0,kFALSE);
+      fVariables->Select(0,false);
       fHistShowBoxes->SetOn(var->TestBit(TParallelCoordVar::kShowBarHisto));
       fHistWidth->SetNumber(var->GetHistLineWidth());
       fHistBinning->SetNumber(var->GetHistBinning());
@@ -421,16 +421,16 @@ void TParallelCoordEditor::ConnectSignals2Slots()
                              this, "DoSelectLineColor(Pixel_t)");
    fSelectLineWidth->Connect("Selected(Int_t)","TParallelCoordEditor",
                              this, "DoSelectLineWidth(Int_t)");
-   fActivateSelection->Connect("Toggled(Bool_t)","TParallelCoordEditor",
-                               this, "DoActivateSelection(Bool_t)");
-   fShowRanges->Connect("Toggled(Bool_t)","TParallelCoordEditor",
-                        this, "DoShowRanges(Bool_t)");
+   fActivateSelection->Connect("Toggled(bool)","TParallelCoordEditor",
+                               this, "DoActivateSelection(bool)");
+   fShowRanges->Connect("Toggled(bool)","TParallelCoordEditor",
+                        this, "DoShowRanges(bool)");
    fDeleteSelection->Connect("Clicked()","TParallelCoordEditor",
                              this, "DoDeleteSelection()");
    fAddSelection->Connect("Clicked()","TParallelCoordEditor",
                              this, "DoAddSelection()");
-   fPaintEntries->Connect("Toggled(Bool_t)","TParallelCoordEditor",
-                               this, "DoPaintEntries(Bool_t)");
+   fPaintEntries->Connect("Toggled(bool)","TParallelCoordEditor",
+                               this, "DoPaintEntries(bool)");
    fEntriesToDraw->Connect("Released()","TParallelCoordEditor",
                           this, "DoEntriesToDraw()");
    fEntriesToDraw->Connect("PositionChanged()","TParallelCoordEditor",
@@ -443,14 +443,14 @@ void TParallelCoordEditor::ConnectSignals2Slots()
                          this, "DoApplySelect()");
    fUnApply->Connect("Clicked()","TParallelCoordEditor",
                      this, "DoUnApply()");
-   fDelayDrawing->Connect("Toggled(Bool_t)","TParallelCoordEditor",
-                     this, "DoDelayDrawing(Bool_t)");
+   fDelayDrawing->Connect("Toggled(bool)","TParallelCoordEditor",
+                     this, "DoDelayDrawing(bool)");
    fAddVariable->Connect("ReturnPressed()","TParallelCoordEditor",
                      this, "DoAddVariable()");
    fButtonAddVar->Connect("Clicked()","TParallelCoordEditor",
                      this, "DoAddVariable()");
-   fHideAllRanges->Connect("Toggled(Bool_t)","TParallelCoordEditor",
-                           this, "DoHideAllRanges(Bool_t)");
+   fHideAllRanges->Connect("Toggled(bool)","TParallelCoordEditor",
+                           this, "DoHideAllRanges(bool)");
    fVariables->Connect("Selected(const char*)","TParallelCoordEditor",
                       this, "DoVariableSelect(const char*)");
    fDeleteVar->Connect("Clicked()","TParallelCoordEditor",
@@ -469,16 +469,16 @@ void TParallelCoordEditor::ConnectSignals2Slots()
                              this, "DoHistColorSelect(Pixel_t)");
    fHistPatternSelect->Connect("PatternSelected(Style_t)", "TParallelCoordEditor",
                                this, "DoHistPatternSelect(Style_t)");
-   fHistShowBoxes->Connect("Toggled(Bool_t)","TParallelCoordEditor",
-                               this, "DoHistShowBoxes(Bool_t)");
+   fHistShowBoxes->Connect("Toggled(bool)","TParallelCoordEditor",
+                               this, "DoHistShowBoxes(bool)");
 
-   fInit = kFALSE;
+   fInit = false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Slot to activate or not a selection.
 
-void TParallelCoordEditor::DoActivateSelection(Bool_t on)
+void TParallelCoordEditor::DoActivateSelection(bool on)
 {
    if (fAvoidSignal) return;
 
@@ -497,14 +497,14 @@ void TParallelCoordEditor::DoAddSelection()
    TString title = fAddSelectionField->GetText();
    if (title == "") title = "Selection";
    TString titlebis = title;
-   Bool_t found = kTRUE;
+   bool found = true;
    Int_t i=1;
    while (found){
       if (fSelectionSelect->FindEntry(titlebis)) {
          titlebis = title;
          titlebis.Append(Form("(%d)",i));
       }
-      else found = kFALSE;
+      else found = false;
       ++i;
    }
 
@@ -543,7 +543,7 @@ void TParallelCoordEditor::DoApplySelect()
 ////////////////////////////////////////////////////////////////////////////////
 /// Slot to delay the drawing.
 
-void TParallelCoordEditor::DoDelayDrawing(Bool_t on)
+void TParallelCoordEditor::DoDelayDrawing(bool on)
 {
    if (fAvoidSignal) return;
 
@@ -571,7 +571,7 @@ void TParallelCoordEditor::DoDeleteVar()
 {
    if (fAvoidSignal) return;
 
-   Bool_t hasDeleted = fParallel->RemoveVariable(((TGTextLBEntry*)fVariables->GetSelectedEntry())->GetTitle());
+   bool hasDeleted = fParallel->RemoveVariable(((TGTextLBEntry*)fVariables->GetSelectedEntry())->GetTitle());
    CleanUpVariables();
    if (hasDeleted) Update();
 }
@@ -688,7 +688,7 @@ void TParallelCoordEditor::DoGlobalLineWidth(Int_t wid)
 ////////////////////////////////////////////////////////////////////////////////
 /// Slot to hide all the ranges.
 
-void TParallelCoordEditor::DoHideAllRanges(Bool_t on)
+void TParallelCoordEditor::DoHideAllRanges(bool on)
 {
    if (fAvoidSignal) return;
 
@@ -729,7 +729,7 @@ void TParallelCoordEditor::DoHistColorSelect(Pixel_t p)
 ////////////////////////////////////////////////////////////////////////////////
 /// Slot to set histogram height.
 
-void TParallelCoordEditor::DoHistShowBoxes(Bool_t s)
+void TParallelCoordEditor::DoHistShowBoxes(bool s)
 {
    if (fAvoidSignal) return;
 
@@ -770,8 +770,8 @@ void TParallelCoordEditor::DoLineType()
 {
    if (fAvoidSignal) return;
 
-   if (fLineTypePoly->GetState() == kButtonDown) fParallel->SetCurveDisplay(kFALSE);
-   else fParallel->SetCurveDisplay(kTRUE);
+   if (fLineTypePoly->GetState() == kButtonDown) fParallel->SetCurveDisplay(false);
+   else fParallel->SetCurveDisplay(true);
    Update();
 }
 
@@ -848,7 +848,7 @@ void TParallelCoordEditor::DoNentries()
 ////////////////////////////////////////////////////////////////////////////////
 /// Slot to postpone the entries drawing.
 
-void TParallelCoordEditor::DoPaintEntries(Bool_t on)
+void TParallelCoordEditor::DoPaintEntries(bool on)
 {
    if (fAvoidSignal) return;
 
@@ -894,9 +894,9 @@ void TParallelCoordEditor::DoSelectionSelect(const char* title)
 
    Color_t c = fParallel->GetCurrentSelection()->GetLineColor();
    Pixel_t p = TColor::Number2Pixel(c);
-   fSelectLineColor->SetColor(p,kFALSE);
+   fSelectLineColor->SetColor(p,false);
 
-   fSelectLineWidth->Select(fParallel->GetCurrentSelection()->GetLineWidth(),kFALSE);
+   fSelectLineWidth->Select(fParallel->GetCurrentSelection()->GetLineWidth(),false);
 
    fActivateSelection->SetOn(fParallel->GetCurrentSelection()->TestBit(TParallelCoordSelect::kActivated));
    fShowRanges->SetOn(fParallel->GetCurrentSelection()->TestBit(TParallelCoordSelect::kShowRanges));
@@ -905,7 +905,7 @@ void TParallelCoordEditor::DoSelectionSelect(const char* title)
 ////////////////////////////////////////////////////////////////////////////////
 /// Slot to show or not the ranges on the pad.
 
-void TParallelCoordEditor::DoShowRanges(Bool_t s)
+void TParallelCoordEditor::DoShowRanges(bool s)
 {
    if (fAvoidSignal) return;
 
@@ -955,7 +955,7 @@ void TParallelCoordEditor::SetModel(TObject* obj)
    if (!obj) return;
    fParallel = dynamic_cast<TParallelCoord*>(obj);
    if (!fParallel) return;
-   fAvoidSignal = kTRUE;
+   fAvoidSignal = true;
 
    Color_t c = fParallel->GetLineColor();
    Pixel_t p = TColor::Number2Pixel(c);
@@ -976,11 +976,11 @@ void TParallelCoordEditor::SetModel(TObject* obj)
       }
    }
 
-   Bool_t cur = fParallel->GetCurveDisplay();
-   if (cur) fLineTypeBgroup->SetButton(kLineTypeCurves,kTRUE);
-   else     fLineTypeBgroup->SetButton(kLineTypePoly,kTRUE);
+   bool cur = fParallel->GetCurveDisplay();
+   if (cur) fLineTypeBgroup->SetButton(kLineTypeCurves,true);
+   else     fLineTypeBgroup->SetButton(kLineTypePoly,true);
 
-   if (fInit) fHideAllRanges->SetOn(kFALSE);
+   if (fInit) fHideAllRanges->SetOn(false);
 
    CleanUpSelections();
    CleanUpVariables();
@@ -997,10 +997,10 @@ void TParallelCoordEditor::SetModel(TObject* obj)
    fWeightCut->SetPosition(fParallel->GetWeightCut());
    fWeightCutField->SetNumber(fParallel->GetWeightCut());
 
-   fHistColorSelect->SetColor(TColor::Number2Pixel(((TParallelCoordVar*)fParallel->GetVarList()->Last())->GetFillColor()), kFALSE);
-   fHistPatternSelect->SetPattern(((TParallelCoordVar*)fParallel->GetVarList()->Last())->GetFillStyle(),kFALSE);
+   fHistColorSelect->SetColor(TColor::Number2Pixel(((TParallelCoordVar*)fParallel->GetVarList()->Last())->GetFillColor()), false);
+   fHistPatternSelect->SetPattern(((TParallelCoordVar*)fParallel->GetVarList()->Last())->GetFillStyle(),false);
 
    if (fInit) ConnectSignals2Slots();
 
-   fAvoidSignal = kFALSE;
+   fAvoidSignal = false;
 }

--- a/tree/treeviewer/src/TParallelCoordRange.cxx
+++ b/tree/treeviewer/src/TParallelCoordRange.cxx
@@ -40,8 +40,8 @@ TParallelCoordRange::TParallelCoordRange()
    fMax = 0;
    fVar = nullptr;
    fSelect = nullptr;
-   SetBit(kShowOnPad,kTRUE);
-   SetBit(kLiveUpdate,kFALSE);
+   SetBit(kShowOnPad,true);
+   SetBit(kLiveUpdate,false);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -77,7 +77,7 @@ TParallelCoordRange::TParallelCoordRange(TParallelCoordVar *var, Double_t min, D
 
    SetLineColor(fSelect->GetLineColor());
 
-   SetBit(kShowOnPad,kTRUE);
+   SetBit(kShowOnPad,true);
    SetBit(kLiveUpdate,var->GetParallel()->TestBit(TParallelCoord::kLiveUpdate));
 }
 
@@ -142,7 +142,7 @@ void TParallelCoordRange::ExecuteEvent(Int_t entry, Int_t px, Int_t py)
    if (!gPad) return;
    if (!gPad->IsEditable() && entry!=kMouseEnter) return;
 
-   Bool_t vert = fVar->GetVert();
+   bool vert = fVar->GetVert();
    static Int_t pxold, pyold;
    static Int_t mindragged = -1; //-1:nothing dragged, 0:max dragged, 1:mindragged, 2:both dragged;
    Int_t plx1,plx2,ply1,ply2;
@@ -357,7 +357,7 @@ TPoint* TParallelCoordRange::GetSliderPoints(Int_t pos)
 ////////////////////////////////////////////////////////////////////////////////
 /// Evaluate if the given value is within the range or not.
 
-Bool_t TParallelCoordRange::IsIn(Double_t evtval)
+bool TParallelCoordRange::IsIn(Double_t evtval)
 {
    return evtval>=fMin && evtval<=fMax;
 }
@@ -368,15 +368,15 @@ Bool_t TParallelCoordRange::IsIn(Double_t evtval)
 void TParallelCoordRange::Paint(Option_t* /*options*/)
 {
    if(TestBit(kShowOnPad)){
-      PaintSlider(fMin,kTRUE);
-      PaintSlider(fMax,kTRUE);
+      PaintSlider(fMin,true);
+      PaintSlider(fMax,true);
    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Paint a slider.
 
-void TParallelCoordRange::PaintSlider(Double_t value, Bool_t fill)
+void TParallelCoordRange::PaintSlider(Double_t value, bool fill)
 {
    SetLineColor(fSelect->GetLineColor());
 
@@ -473,8 +473,8 @@ TParallelCoordSelect::TParallelCoordSelect()
    : TList(), TAttLine(kBlue,1,1)
 {
    fTitle = "Selection";
-   SetBit(kActivated,kTRUE);
-   SetBit(kShowRanges,kTRUE);
+   SetBit(kActivated,true);
+   SetBit(kShowRanges,true);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -484,8 +484,8 @@ TParallelCoordSelect::TParallelCoordSelect(const char* title)
    : TList(), TAttLine(kBlue,1,1)
 {
    fTitle = title;
-   SetBit(kActivated,kTRUE);
-   SetBit(kShowRanges,kTRUE);
+   SetBit(kActivated,true);
+   SetBit(kShowRanges,true);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -502,7 +502,7 @@ TParallelCoordSelect::~TParallelCoordSelect()
 ////////////////////////////////////////////////////////////////////////////////
 /// Activate the selection.
 
-void TParallelCoordSelect::SetActivated(Bool_t on)
+void TParallelCoordSelect::SetActivated(bool on)
 {
    TIter next(this);
    TParallelCoordRange* range;
@@ -513,7 +513,7 @@ void TParallelCoordSelect::SetActivated(Bool_t on)
 ////////////////////////////////////////////////////////////////////////////////
 /// Show the ranges needles.
 
-void TParallelCoordSelect::SetShowRanges(Bool_t s)
+void TParallelCoordSelect::SetShowRanges(bool s)
 {
    TIter next(this);
    TParallelCoordRange* range;

--- a/tree/treeviewer/src/TParallelCoordVar.cxx
+++ b/tree/treeviewer/src/TParallelCoordVar.cxx
@@ -157,23 +157,23 @@ void TParallelCoordVar::Draw(Option_t *option)
 /// single axis are conjugated as a "or": to be selected, the entry must be in
 /// one of the ranges.
 
-Bool_t TParallelCoordVar::Eval(Long64_t evtidx, TParallelCoordSelect *select)
+bool TParallelCoordVar::Eval(Long64_t evtidx, TParallelCoordSelect *select)
 {
    if (fRanges->GetSize() > 0){
       TIter next(fRanges);
-      Bool_t inarange = kFALSE;
-      Bool_t noOwnedRange = kTRUE;
+      bool inarange = false;
+      bool noOwnedRange = true;
       TParallelCoordRange *range;
       while ((range = (TParallelCoordRange*)next())){
          if(select->Contains(range)) {
-            noOwnedRange = kFALSE;
-            if(range->IsIn(fVal[evtidx])) inarange = kTRUE;
+            noOwnedRange = false;
+            if(range->IsIn(fVal[evtidx])) inarange = true;
          }
       }
-      if (noOwnedRange) return kTRUE;
+      if (noOwnedRange) return true;
       else return inarange;
    }
-   else return kTRUE;
+   else return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -187,7 +187,7 @@ void TParallelCoordVar::ExecuteEvent(Int_t entry, Int_t px, Int_t py)
    static Int_t pxold, pyold;
    static Int_t zoom; // -1:nothing zoomed or translated, 0:translating the axis, 1:zooming
    static Int_t pzoomold;
-   static Bool_t first = kTRUE;
+   static bool first = true;
 
    Int_t px1,px2,py1,py2,n=-1;
    px1 = gPad->XtoAbsPixel(fX1);
@@ -211,7 +211,7 @@ void TParallelCoordVar::ExecuteEvent(Int_t entry, Int_t px, Int_t py)
             if(gPad->AbsPixeltoX(px)-fX1 > 0){
                zoom = 1;
                gVirtualX->DrawLine(gPad->XtoAbsPixel(fX1-0.05),py,gPad->XtoAbsPixel(fX1+0.05),py);
-               first = kTRUE;
+               first = true;
                pzoomold = py;
             } else {
                zoom = 0;
@@ -221,7 +221,7 @@ void TParallelCoordVar::ExecuteEvent(Int_t entry, Int_t px, Int_t py)
             if(gPad->AbsPixeltoY(py)-fY1 > 0){
                zoom = 1;
                gVirtualX->DrawLine(px,gPad->YtoAbsPixel(fY1-0.05),px,gPad->YtoAbsPixel(fY1+0.05));
-               first=kTRUE;
+               first=true;
                pzoomold = px;
             } else {
                zoom = 0;
@@ -291,7 +291,7 @@ void TParallelCoordVar::ExecuteEvent(Int_t entry, Int_t px, Int_t py)
                gPad->SetCursor(kArrowVer);
                if(!first) gVirtualX->DrawLine(gPad->XtoAbsPixel(fX1-0.05),pyold,gPad->XtoAbsPixel(fX1+0.05),pyold);
                gVirtualX->DrawLine(gPad->XtoAbsPixel(fX1-0.05),py,gPad->XtoAbsPixel(fX1+0.05),py);
-               first = kFALSE;
+               first = false;
             }
          } else {
             if(zoom==0){
@@ -302,7 +302,7 @@ void TParallelCoordVar::ExecuteEvent(Int_t entry, Int_t px, Int_t py)
                gPad->SetCursor(kArrowHor);
                if(!first) gVirtualX->DrawLine(pxold,gPad->YtoAbsPixel(fY1-0.05),pxold,gPad->YtoAbsPixel(fY1+0.05));
                gVirtualX->DrawLine(px,gPad->YtoAbsPixel(fY1-0.05),px,gPad->YtoAbsPixel(fY1+0.05));
-               first = kFALSE;
+               first = false;
             }
          }
          pxold = px;
@@ -434,7 +434,7 @@ void TParallelCoordVar::GetQuantiles()
    prob[0]=0.25; prob[1]=0.5; prob[2] = 0.75;
    Long64_t first = fParallel->GetCurrentFirst();
    Long64_t nentries = fParallel->GetCurrentN();
-   if (!TestBit(kLogScale) && first==0 && nentries==fNentries) TMath::Quantiles(fNentries,3,fVal,quantiles,prob,kFALSE);
+   if (!TestBit(kLogScale) && first==0 && nentries==fNentries) TMath::Quantiles(fNentries,3,fVal,quantiles,prob,false);
    else {
       Double_t* val = new Double_t[nentries];
       Int_t selected = 0;
@@ -453,7 +453,7 @@ void TParallelCoordVar::GetQuantiles()
             ++selected;
          }
       }
-      TMath::Quantiles(selected,3,val,quantiles,prob,kFALSE);
+      TMath::Quantiles(selected,3,val,quantiles,prob,false);
       delete [] val;
    }
    fQua1 = quantiles[0];
@@ -538,9 +538,9 @@ void TParallelCoordVar::Init()
    fHistoLW    = 2;
    fHistoHeight     = 0.5;
    fRanges     = nullptr;
-   SetBit(kLogScale,kFALSE);
-   SetBit(kShowBox,kFALSE);
-   SetBit(kShowBarHisto,kTRUE);
+   SetBit(kLogScale,false);
+   SetBit(kShowBox,false);
+   SetBit(kShowBarHisto,true);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -866,7 +866,7 @@ void TParallelCoordVar::SavePrimitive(std::ostream & out, Option_t* options)
 ////////////////////////////////////////////////////////////////////////////////
 /// Set the axis to display a candle.
 
-void TParallelCoordVar::SetBoxPlot(Bool_t box)
+void TParallelCoordVar::SetBoxPlot(bool box)
 {
    SetBit(kShowBox,box);
    if (box) SetHistogramHeight(0.5);
@@ -893,8 +893,8 @@ void TParallelCoordVar::SetHistogramHeight(Double_t h)
 {
    fHistoHeight = h;
    if (!fParallel->TestBit(TParallelCoord::kCandleChart)){
-      if(h!=0) SetBit(kShowBarHisto,kTRUE);
-      else SetBit(kShowBarHisto,kFALSE);
+      if(h!=0) SetBit(kShowBarHisto,true);
+      else SetBit(kShowBarHisto,false);
    }
 }
 
@@ -942,7 +942,7 @@ void TParallelCoordVar::SetCurrentLimits(Double_t min, Double_t max)
 ////////////////////////////////////////////////////////////////////////////////
 /// If true, the pad is updated while the motion of a dragged range.
 
-void TParallelCoordVar::SetLiveRangesUpdate(Bool_t on)
+void TParallelCoordVar::SetLiveRangesUpdate(bool on)
 {
    TIter next(fRanges);
    TParallelCoordRange* range;
@@ -952,18 +952,18 @@ void TParallelCoordVar::SetLiveRangesUpdate(Bool_t on)
 ////////////////////////////////////////////////////////////////////////////////
 /// Set the axis in log scale.
 
-void TParallelCoordVar::SetLogScale(Bool_t log)
+void TParallelCoordVar::SetLogScale(bool log)
 {
    if (log == TestBit (kLogScale)) return;
-   if (fMaxInit < 0)             SetBit(kLogScale,kFALSE);
+   if (fMaxInit < 0)             SetBit(kLogScale,false);
    else if (log) {
       if (fMaxCurrent < 0 ) fMaxCurrent = fMaxInit;
       if (fMinCurrent < 0 ) fMinCurrent = 0.00001*fMaxCurrent;
-      SetBit(kLogScale,kTRUE);
+      SetBit(kLogScale,true);
       SetCurrentMin(fMinCurrent);
       SetCurrentMax(fMaxCurrent);
    } else {
-      SetBit(kLogScale,kFALSE);
+      SetBit(kLogScale,false);
       SetCurrentMin(fMinInit);
       SetCurrentMax(fMaxInit);
    }
@@ -989,7 +989,7 @@ void TParallelCoordVar::SetValues(Long64_t length, Double_t* val)
 /// Set the X position of the axis in the case of a vertical axis.
 /// and rotate the axis if it was horizontal.
 
-void TParallelCoordVar::SetX(Double_t x, Bool_t gl)
+void TParallelCoordVar::SetX(Double_t x, bool gl)
 {
    TFrame *frame = gPad->GetFrame();
    if (!gl) {
@@ -1008,7 +1008,7 @@ void TParallelCoordVar::SetX(Double_t x, Bool_t gl)
 /// Set the Y position of the axis in the case of a horizontal axis.
 /// and rotate the axis if it was vertical.
 
-void TParallelCoordVar::SetY(Double_t y, Bool_t gl)
+void TParallelCoordVar::SetY(Double_t y, bool gl)
 {
    TFrame *frame = gPad->GetFrame();
    if (!gl) {

--- a/tree/treeviewer/src/TSpider.cxx
+++ b/tree/treeviewer/src/TSpider.cxx
@@ -75,8 +75,8 @@ End_Macro
 
 TSpider::TSpider()
 {
-   fDisplayAverage=kFALSE;
-   fForceDim=kFALSE;
+   fDisplayAverage=false;
+   fForceDim=false;
    fPolargram=nullptr;
    fInput=nullptr;
    fManager=nullptr;
@@ -94,10 +94,10 @@ TSpider::TSpider()
    fAveragePoly=nullptr;
    fEntry=0;
    fSuperposed=nullptr;
-   fShowRange=kFALSE;
-   fAngularLabels=kFALSE;
+   fShowRange=false;
+   fAngularLabels=false;
    fAverageSlices=nullptr;
-   fSegmentDisplay=kFALSE;
+   fSegmentDisplay=false;
    fNentries=0;
    fFirstEntry=0;
    fArraySize=0;
@@ -128,18 +128,18 @@ TSpider::TSpider(TTree* tree ,const char *varexp, const char *selection,
    gROOT->GetListOfCleanups()->Add(this);
    fNx=2;
    fNy=2;
-   fDisplayAverage=kFALSE;
+   fDisplayAverage=false;
    fSelect=nullptr;
    fManager=nullptr;
    fCanvas=nullptr;
    fAveragePoly=nullptr;
    fEntry=fFirstEntry;
    fSuperposed=nullptr;
-   fShowRange=kFALSE;
-   fAngularLabels=kTRUE;
-   fForceDim=kFALSE;
+   fShowRange=false;
+   fAngularLabels=true;
+   fForceDim=false;
    fAverageSlices=nullptr;
-   fSegmentDisplay=kFALSE;
+   fSegmentDisplay=false;
    if (firstentry < 0 || firstentry > tree->GetEstimate()) firstentry = 0;
    fFirstEntry = firstentry;
    if (nentries>0) fNentries = nentries;
@@ -156,9 +156,9 @@ TSpider::TSpider(TTree* tree ,const char *varexp, const char *selection,
 
    TString opt = option;
 
-   if (opt.Contains("average")) fDisplayAverage=kTRUE;
-   if (opt.Contains("showrange")) fShowRange=kTRUE;
-   if (opt.Contains("segment")) fSegmentDisplay=kTRUE;
+   if (opt.Contains("average")) fDisplayAverage=true;
+   if (opt.Contains("showrange")) fShowRange=true;
+   if (opt.Contains("segment")) fSegmentDisplay=true;
 
    fNcols=8;
 
@@ -246,7 +246,7 @@ void TSpider::AddVariable(const char* varexp)
       Int_t ndata=1;
       if(fForceDim){
          if(fManager)
-            ndata = fManager->GetNdata(kTRUE);
+            ndata = fManager->GetNdata(true);
          else {
             for(ui=0;ui<fNcols;++ui){
                if(ndata<((TTreeFormula*)fFormulas->At(ui))->GetNdata())
@@ -257,13 +257,13 @@ void TSpider::AddVariable(const char* varexp)
          }
       }
 
-      Bool_t loaded = kFALSE;
-      Bool_t skip = kFALSE;
+      bool loaded = false;
+      bool skip = false;
       // Loop over the instances of the selection condition
       for(Int_t inst=0;inst<ndata;++inst){
          if(fSelect){
             if(fSelect->EvalInstance(inst) == 0){
-               skip = kTRUE;
+               skip = true;
                ++entry;
             }
          }
@@ -271,9 +271,9 @@ void TSpider::AddVariable(const char* varexp)
             // EvalInstance(0) always needs to be called so that
             // the proper branches are loaded.
             ((TTreeFormula*)fFormulas->At(fNcols-1))->EvalInstance(0);
-            loaded = kTRUE;
+            loaded = true;
          } else if (inst == 0) {
-            loaded = kTRUE;
+            loaded = true;
          }
       }
       if(!skip){
@@ -414,7 +414,7 @@ void TSpider::DeleteVariable(const char* varexp)
       fCanvas->Divide(fNx,fNy);
    }
    Draw("");
-   if(fNcols == 2) SetSegmentDisplay(kTRUE);
+   if(fNcols == 2) SetSegmentDisplay(true);
 
    if(fAverageSlices){
       for(ui = 0;ui<fNcols;++ui){
@@ -865,7 +865,7 @@ void TSpider::InitVariables(Long64_t firstentry, Long64_t nentries)
       Int_t ndata=1;
       if(fForceDim){
          if(fManager)
-            ndata = fManager->GetNdata(kTRUE);
+            ndata = fManager->GetNdata(true);
          else {
             for(ui=0;ui<fNcols;++ui){
                if(ndata<((TTreeFormula*)fFormulas->At(ui))->GetNdata())
@@ -875,13 +875,13 @@ void TSpider::InitVariables(Long64_t firstentry, Long64_t nentries)
                ndata = 0;
          }
       }
-      Bool_t loaded = kFALSE;
-      Bool_t skip = kFALSE;
+      bool loaded = false;
+      bool skip = false;
       // Loop over the instances of the selection condition
       for(Int_t inst=0;inst<ndata;++inst){
          if(fSelect){
             if(fSelect->EvalInstance(inst) == 0){
-               skip = kTRUE;
+               skip = true;
                ++entry;
             }
          }
@@ -891,9 +891,9 @@ void TSpider::InitVariables(Long64_t firstentry, Long64_t nentries)
             for (ui=0;ui<fNcols;ui++) {
                ((TTreeFormula*)fFormulas->At(ui))->EvalInstance(0);
             }
-            loaded = kTRUE;
+            loaded = true;
          } else if (inst == 0) {
-            loaded = kTRUE;
+            loaded = true;
          }
       }
       if(!skip){
@@ -1022,7 +1022,7 @@ void TSpider::SetAverageFillStyle(Style_t sty)
 ////////////////////////////////////////////////////////////////////////////////
 /// Display or not the average.
 
-void TSpider::SetDisplayAverage(Bool_t disp)
+void TSpider::SetDisplayAverage(bool disp)
 {
    if(disp == fDisplayAverage) return;
 
@@ -1091,7 +1091,7 @@ void TSpider::SetCurrentEntries()
       Int_t ndata=1;
       if(fForceDim){
          if(fManager)
-            ndata = fManager->GetNdata(kTRUE);
+            ndata = fManager->GetNdata(true);
          else {
             for(ui=0;ui<fNcols;++ui){
                if(ndata < ((TTreeFormula*)fFormulas->At(ui))->GetNdata())
@@ -1101,13 +1101,13 @@ void TSpider::SetCurrentEntries()
                ndata = 0;
          }
       }
-      Bool_t loaded = kFALSE;
-      Bool_t skip = kFALSE;
+      bool loaded = false;
+      bool skip = false;
       // Loop over the instances of the selection condition
       for(Int_t inst=0;inst<ndata;++inst){
          if(fSelect){
             if(fSelect->EvalInstance(inst) == 0){
-               skip = kTRUE;
+               skip = true;
                ++entry;
             }
          }
@@ -1117,9 +1117,9 @@ void TSpider::SetCurrentEntries()
             for (ui=0;ui<fNcols;ui++) {
                ((TTreeFormula*)fFormulas->At(ui))->EvalInstance(0);
             }
-            loaded = kTRUE;
+            loaded = true;
          } else if (inst == 0) {
-            loaded = kTRUE;
+            loaded = true;
          }
       }
       if(!skip){
@@ -1377,7 +1377,7 @@ void TSpider::SetNy(UInt_t ny)
 ////////////////////////////////////////////////////////////////////////////////
 /// Set the segment display or not.
 
-void TSpider::SetSegmentDisplay(Bool_t seg)
+void TSpider::SetSegmentDisplay(bool seg)
 {
    if(seg == fSegmentDisplay) return;
 
@@ -1538,7 +1538,7 @@ void TSpider::SyncFormulas()
             case  1:
             case  2:
             case -1:
-               fForceDim = kTRUE;
+               fForceDim = true;
                break;
             case  0:
                break;

--- a/tree/treeviewer/src/TSpiderEditor.cxx
+++ b/tree/treeviewer/src/TSpiderEditor.cxx
@@ -59,7 +59,7 @@ TSpiderEditor::TSpiderEditor(const TGWindow* /*p*/, Int_t /*width*/, Int_t /*hei
    MakeTitle("Spider");
 
    fBgroup = new TGButtonGroup(this,2,1,0,0, "Plot type");
-   fBgroup->SetRadioButtonExclusive(kTRUE);
+   fBgroup->SetRadioButtonExclusive(true);
    fPolyLines = new TGRadioButton(fBgroup, "PolyLine", kPolyLines);
    fPolyLines->SetToolTipText("Set a polyline plot type");
    fSegment = new TGRadioButton(fBgroup, "Segment", kSegment);
@@ -138,7 +138,7 @@ TSpiderEditor::~TSpiderEditor()
 
 void TSpiderEditor::ConnectSignals2Slots()
 {
-   fDisplayAverage->Connect("Toggled(Bool_t)", "TSpiderEditor", this, "DoDisplayAverage(Bool_t)");
+   fDisplayAverage->Connect("Toggled(bool)", "TSpiderEditor", this, "DoDisplayAverage(bool)");
    fSetNx->Connect("ReturnPressed()", "TSpiderEditor", this, "DoSetNx()");
    fSetNy->Connect("ReturnPressed()", "TSpiderEditor", this, "DoSetNy()");
    fBgroup->Connect("Clicked(Int_t)","TSpiderEditor",this,"DoSetPlotType()");
@@ -155,7 +155,7 @@ void TSpiderEditor::ConnectSignals2Slots()
    fAvFillColorSelect->Connect("ColorSelected(Pixel_t)", "TSpiderEditor", this, "DoAvFillColor(Pixel_t)");
    fAvFillPatternSelect->Connect("PatternSelected(Style_t)", "TSpiderEditor", this, "DoAvFillPattern(Style_t)");
 
-   fInit = kFALSE;
+   fInit = false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -254,19 +254,19 @@ void TSpiderEditor::SetModel(TObject* obj)
    if (!obj) return;
    fSpider = dynamic_cast<TSpider*>(obj);
    if (!fSpider) return;
-   fAvoidSignal = kTRUE;
+   fAvoidSignal = true;
 
-   Bool_t av = fSpider->GetDisplayAverage();
+   bool av = fSpider->GetDisplayAverage();
    if(av) fDisplayAverage->SetState(kButtonDown);
    else fDisplayAverage->SetState(kButtonUp);
 
    fSetNx->SetNumber(fSpider->GetNx());
    fSetNy->SetNumber(fSpider->GetNy());
 
-   Bool_t seg = fSpider->GetSegmentDisplay();
+   bool seg = fSpider->GetSegmentDisplay();
 
-   if(seg) fBgroup->SetButton(kSegment,kTRUE);
-   else fBgroup->SetButton(kPolyLines,kTRUE);
+   if(seg) fBgroup->SetButton(kSegment,true);
+   else fBgroup->SetButton(kPolyLines,true);
 
    fGotoEntry->SetNumber(fSpider->GetCurrentEntry());
 
@@ -280,12 +280,12 @@ void TSpiderEditor::SetModel(TObject* obj)
    fAvLineColorSelect->SetColor(p);
    c = fSpider->GetAverageFillColor();
    p = TColor::Number2Pixel(c);
-   fAvFillColorSelect->SetColor(p,kFALSE);
-   fAvFillPatternSelect->SetPattern(fSpider->GetAverageFillStyle(),kFALSE);
+   fAvFillColorSelect->SetColor(p,false);
+   fAvFillPatternSelect->SetPattern(fSpider->GetAverageFillStyle(),false);
 
    if (fInit) ConnectSignals2Slots();
 
-   fAvoidSignal = kFALSE;
+   fAvoidSignal = false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -370,7 +370,7 @@ void TSpiderEditor::DoDeleteVar()
 ////////////////////////////////////////////////////////////////////////////////
 /// Slot Connected to the average display.
 
-void TSpiderEditor::DoDisplayAverage(Bool_t av)
+void TSpiderEditor::DoDisplayAverage(bool av)
 {
    if (fAvoidSignal) return;
 
@@ -456,7 +456,7 @@ void  TSpiderEditor::DoSetNy()
 
 void  TSpiderEditor::DoSetPlotType()
 {
-   if(fSegment->GetState() == kButtonDown) fSpider->SetSegmentDisplay(kTRUE);
-   else fSpider->SetSegmentDisplay(kFALSE);
+   if(fSegment->GetState() == kButtonDown) fSpider->SetSegmentDisplay(true);
+   else fSpider->SetSegmentDisplay(false);
    Update();
 }

--- a/tree/treeviewer/src/TTVLVContainer.cxx
+++ b/tree/treeviewer/src/TTVLVContainer.cxx
@@ -79,7 +79,7 @@ void TGItemContext::Scan()
 ////////////////////////////////////////////////////////////////////////////////
 /// Set item expression
 
-void TGItemContext::SetExpression(const char *name, const char *alias, Bool_t cut)
+void TGItemContext::SetExpression(const char *name, const char *alias, bool cut)
 {
    fItem->SetExpression(name, alias, cut);
 }
@@ -104,7 +104,7 @@ TTVLVEntry::TTVLVEntry(const TGWindow *p,
    fContainer = (TTVLVContainer *) p;
 
    fTip = nullptr;
-   fIsCut = kFALSE;
+   fIsCut = false;
    fTrueName = name->GetString();
    fContext = new TGItemContext();
    fContext->Associate(this);
@@ -150,17 +150,17 @@ const char *TTVLVEntry::ConvertAliases()
 ////////////////////////////////////////////////////////////////////////////////
 /// Return true if converted name is alias free
 
-Bool_t TTVLVEntry::FullConverted()
+bool TTVLVEntry::FullConverted()
 {
    TList *list = GetContainer()->GetViewer()->ExpressionList();
    TIter next(list);
    TTVLVEntry* item;
    while ((item=(TTVLVEntry*)next())) {
       if (item != this) {
-         if (fConvName.Contains(item->GetAlias())) return kFALSE;
+         if (fConvName.Contains(item->GetAlias())) return false;
       }
    }
-   return kTRUE;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -177,7 +177,7 @@ void TTVLVEntry::CopyItem(TTVLVEntry *dest)
 ////////////////////////////////////////////////////////////////////////////////
 /// Handle mouse crossing event.
 
-Bool_t TTVLVEntry::HandleCrossing(Event_t *event)
+bool TTVLVEntry::HandleCrossing(Event_t *event)
 {
    if (fTip) {
       if (event->fType == kEnterNotify)
@@ -185,16 +185,16 @@ Bool_t TTVLVEntry::HandleCrossing(Event_t *event)
       else
          fTip->Hide();
    }
-   return kTRUE;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Check if alias name is not empty.
 
-Bool_t TTVLVEntry::HasAlias()
+bool TTVLVEntry::HasAlias()
 {
-   if (fAlias.Length()) return kTRUE;
-   return kFALSE;
+   if (fAlias.Length()) return true;
+   return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -225,7 +225,7 @@ void TTVLVEntry::SetItemName(const char* name)
 ////////////////////////////////////////////////////////////////////////////////
 /// Set cut type
 
-void TTVLVEntry::SetCutType(Bool_t type)
+void TTVLVEntry::SetCutType(bool type)
 {
    if (fIsCut && type) return;
    if (!fIsCut && !type) return;
@@ -240,7 +240,7 @@ void TTVLVEntry::SetCutType(Bool_t type)
 ////////////////////////////////////////////////////////////////////////////////
 /// Set the true name, alias and type of the expression, then refresh it
 
-void TTVLVEntry::SetExpression(const char* name, const char* alias, Bool_t cutType)
+void TTVLVEntry::SetExpression(const char* name, const char* alias, bool cutType)
 {
    SetItemName(alias);
    SetAlias(alias);
@@ -317,7 +317,7 @@ TTVLVContainer::TTVLVContainer(const TGWindow *p, UInt_t w, UInt_t h, UInt_t opt
    fExpressionList = new TList;
    fCursor = gVirtualX->CreateCursor(kMove);
    fDefaultCursor = gVirtualX->CreateCursor(kPointer);
-   fMapSubwindows = kTRUE;
+   fMapSubwindows = true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -433,7 +433,7 @@ const char* TTVLVContainer::ScanList()
 ////////////////////////////////////////////////////////////////////////////////
 /// Handle mouse button event in container.
 
-Bool_t TTVLVContainer::HandleButton(Event_t *event)
+bool TTVLVContainer::HandleButton(Event_t *event)
 {
    int total, selected;
 
@@ -441,7 +441,7 @@ Bool_t TTVLVContainer::HandleButton(Event_t *event)
       fXp = event->fX;
       fYp = event->fY;
       if (fLastActive) {
-         fLastActive->Activate(kFALSE);
+         fLastActive->Activate(false);
          fLastActive = nullptr;
       }
       total = selected = 0;
@@ -452,14 +452,14 @@ Bool_t TTVLVContainer::HandleButton(Event_t *event)
          TTVLVEntry *f = (TTVLVEntry *) el->fFrame;
          ++total;
          if (f->GetId() == (Window_t)event->fUser[0]) {  // fUser[0] = subwindow
-            f->Activate(kTRUE);
+            f->Activate(true);
             if (f->GetTip()) (f->GetTip())->Hide();
             fX0 = f->GetX();
             fY0 = f->GetY();
             ++selected;
             fLastActive = f;
          } else {
-            f->Activate(kFALSE);
+            f->Activate(false);
          }
       }
 
@@ -473,7 +473,7 @@ Bool_t TTVLVContainer::HandleButton(Event_t *event)
       if (selected == 1 && event->fCode == 1) {
          ULong_t *itemType = (ULong_t *) fLastActive->GetUserData();
          if (*itemType & TTreeViewer::kLTDragType) {
-            fDragging = kTRUE;
+            fDragging = true;
             gVirtualX->SetCursor(fId,fCursor);
             fXp = event->fX;
             fYp = event->fY;
@@ -483,7 +483,7 @@ Bool_t TTVLVContainer::HandleButton(Event_t *event)
 
    if (event->fType == kButtonRelease) {
       if (fDragging) {
-         fDragging = kFALSE;
+         fDragging = false;
          gVirtualX->SetCursor(fId,fDefaultCursor);
          fLastActive->Move(fX0,fY0);
          TGFrameElement *el;
@@ -492,7 +492,7 @@ Bool_t TTVLVContainer::HandleButton(Event_t *event)
             TTVLVEntry *f = (TTVLVEntry *) el->fFrame;
             if ((f == fLastActive) || !f->IsActive()) continue;
             ULong_t *itemType = (ULong_t *) f->GetUserData();
-            fLastActive->Activate(kFALSE);
+            fLastActive->Activate(false);
             if (!(*itemType & TTreeViewer::kLTPackType)) {
                // dragging items to expressions
                ((TTVLVEntry *) fLastActive)->CopyItem(f);
@@ -536,13 +536,13 @@ Bool_t TTVLVContainer::HandleButton(Event_t *event)
                      event->fCode, (event->fYRoot << 16) | event->fXRoot);
       }
    }
-   return kTRUE;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Handle mouse motion events.
 
-Bool_t TTVLVContainer::HandleMotion(Event_t *event)
+bool TTVLVContainer::HandleMotion(Event_t *event)
 {
    Int_t xf0, xff, yf0, yff;
    Int_t xpos = event->fX - (fXp-fX0);
@@ -565,9 +565,9 @@ Bool_t TTVLVContainer::HandleMotion(Event_t *event)
          itemType = (ULong_t *) f->GetUserData();
          if (*itemType & TTreeViewer::kLTExpressionType) {
             if (xpos>xf0 && xpos<xff && ypos>yf0 && ypos<yff) {
-               f->Activate(kTRUE);
+               f->Activate(true);
             } else {
-               f->Activate(kFALSE);
+               f->Activate(false);
             }
          }
       }
@@ -579,7 +579,7 @@ Bool_t TTVLVContainer::HandleMotion(Event_t *event)
       gVirtualX->RaiseWindow(fLastActive->GetId());
       SendMessage(fMsgWindow, MK_MSG(kC_CONTAINER,(EWidgetMessageTypes)4),event->fX, event->fY);
    }
-   return kTRUE;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -626,7 +626,7 @@ void TTVLVContainer::RemoveNonStatic()
 void TTVLVContainer::SelectItem(const char* name)
 {
    if (fLastActive) {
-      fLastActive->Activate(kFALSE);
+      fLastActive->Activate(false);
       fLastActive = nullptr;
    }
    TGFrameElement *el;
@@ -635,11 +635,11 @@ void TTVLVContainer::SelectItem(const char* name)
    while ((el = (TGFrameElement *) next())) {
       TTVLVEntry *f = (TTVLVEntry *) el->fFrame;
       if (!strcmp(f->GetItemName()->GetString(),name)) {
-         f->Activate(kTRUE);
+         f->Activate(true);
          fLastActive = (TGLVEntry *) f;
          fSelected++;
       } else {
-         f->Activate(kFALSE);
+         f->Activate(false);
       }
    }
 }
@@ -778,7 +778,7 @@ void TGSelectBox::SaveText()
 {
    if (fEntry) {
 
-      Bool_t cutType;
+      bool cutType;
       TString name(fTe->GetText());
       if (name.Length())
          fEntry->SetToolTipText("Double-click to draw. Drag and drop. Use Edit/Expression or context menu to edit.");
@@ -832,7 +832,7 @@ void TGSelectBox::InsertText(const char* text)
 ////////////////////////////////////////////////////////////////////////////////
 /// Message interpreter
 
-Bool_t TGSelectBox::ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2)
+bool TGSelectBox::ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2)
 {
    switch (GET_MSG(msg)) {
       case kC_TEXTENTRY:
@@ -868,17 +868,17 @@ Bool_t TGSelectBox::ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t par
          if (parm2) break;       // just to avoid warning on CC compiler
          break;
    }
-   return kTRUE;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return true if edited alias is not a leading string of other expression aliases
 
-Bool_t TGSelectBox::ValidateAlias()
+bool TGSelectBox::ValidateAlias()
 {
    if (!strcmp(fTeAlias->GetText(), "-empty-") || !strlen(fTeAlias->GetText())) {
       fViewer->Warning("ValidateAlias", "You should define the alias first.");
-      return kFALSE;
+      return false;
    }
    TList *list = fViewer->ExpressionList();
    TIter next(list);
@@ -888,9 +888,9 @@ Bool_t TGSelectBox::ValidateAlias()
          TString itemalias(item->GetAlias());
          if (itemalias.Contains(fTeAlias->GetText())) {
             fViewer->Warning("ValidAlias", "Alias can not be the leading string of other alias.");
-            return kFALSE;
+            return false;
          }
       }
    }
-   return kTRUE;
+   return true;
 }

--- a/tree/treeviewer/src/TTVSession.cxx
+++ b/tree/treeviewer/src/TTVSession.cxx
@@ -32,10 +32,10 @@ I/O classes for TreeViewer session handling.
 TTVRecord::TTVRecord()
 {
    fName = "";
-   fScanRedirected = kFALSE;
-   fCutEnabled     = kTRUE;
+   fScanRedirected = false;
+   fCutEnabled     = true;
    fUserCode = "";
-   fAutoexec = kFALSE;
+   fAutoexec = false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -101,7 +101,7 @@ void TTVRecord::SaveSource(std::ofstream &out)
 {
    char quote = '"';
    out <<"//--- tree viewer record"<<std::endl;
-   out <<"   tv_record = tv_session->AddRecord(kTRUE);"<<std::endl;
+   out <<"   tv_record = tv_session->AddRecord(true);"<<std::endl;
    out <<"   tv_session->SetRecordName("<<quote<<GetName()<<quote<<");"<<std::endl;
    out <<"   tv_record->fX        = "<<quote<<fX.Data()<<quote<<";"<<std::endl;
    out <<"   tv_record->fY        = "<<quote<<fY.Data()<<quote<<";"<<std::endl;
@@ -113,13 +113,13 @@ void TTVRecord::SaveSource(std::ofstream &out)
    out <<"   tv_record->fCutAlias = "<<quote<<fCutAlias.Data()<<quote<<";"<<std::endl;
    out <<"   tv_record->fOption   = "<<quote<<fOption.Data()<<quote<<";"<<std::endl;
    if (fScanRedirected)
-      out <<"   tv_record->fScanRedirected = kTRUE;"<<std::endl;
+      out <<"   tv_record->fScanRedirected = true;"<<std::endl;
    else
-      out <<"   tv_record->fScanRedirected = kFALSE;"<<std::endl;
+      out <<"   tv_record->fScanRedirected = false;"<<std::endl;
    if (fCutEnabled)
-      out <<"   tv_record->fCutEnabled = kTRUE;"<<std::endl;
+      out <<"   tv_record->fCutEnabled = true;"<<std::endl;
    else
-      out <<"   tv_record->fCutEnabled = kFALSE;"<<std::endl;
+      out <<"   tv_record->fCutEnabled = false;"<<std::endl;
    if (fUserCode.Length()) {
       out <<"   tv_record->SetUserCode(\""<<fUserCode.Data()<<"\");"<<std::endl;
       if (fAutoexec) {
@@ -158,14 +158,14 @@ TTVSession::~TTVSession()
 ////////////////////////////////////////////////////////////////////////////////
 /// Add a record
 
-TTVRecord *TTVSession::AddRecord(Bool_t fromFile)
+TTVRecord *TTVSession::AddRecord(bool fromFile)
 {
    TClonesArray &list = *fList;
    TTVRecord *newrec = new(list[fRecords++])TTVRecord();
    if (!fromFile) newrec->FormFrom(fViewer);
    fCurrent = fRecords - 1;
-   if (fRecords > 1) fViewer->ActivateButtons(kTRUE, kTRUE, kFALSE, kTRUE);
-   else              fViewer->ActivateButtons(kTRUE, kFALSE, kFALSE, kTRUE);
+   if (fRecords > 1) fViewer->ActivateButtons(true, true, false, true);
+   else              fViewer->ActivateButtons(true, false, false, true);
    if (!fromFile) {
       TString name = "";
       if (strlen(newrec->GetZ())) name += newrec->GetZ();
@@ -192,14 +192,14 @@ TTVRecord *TTVSession::GetRecord(Int_t i)
    if (i < 0)           fCurrent = 0;
    if (i > fRecords-1)  fCurrent = fRecords - 1;
    if (fCurrent>0 && fCurrent<fRecords-1)
-      fViewer->ActivateButtons(kTRUE, kTRUE, kTRUE, kTRUE);
+      fViewer->ActivateButtons(true, true, true, true);
    if (fCurrent == 0) {
-      if (fRecords > 1) fViewer->ActivateButtons(kTRUE, kFALSE, kTRUE, kTRUE);
-      else              fViewer->ActivateButtons(kTRUE, kFALSE, kFALSE, kTRUE);
+      if (fRecords > 1) fViewer->ActivateButtons(true, false, true, true);
+      else              fViewer->ActivateButtons(true, false, false, true);
    }
    if (fCurrent == fRecords-1) {
-      if (fRecords > 1) fViewer->ActivateButtons(kTRUE, kTRUE, kFALSE, kTRUE);
-      else              fViewer->ActivateButtons(kTRUE, kFALSE, kFALSE, kTRUE);
+      if (fRecords > 1) fViewer->ActivateButtons(true, true, false, true);
+      else              fViewer->ActivateButtons(true, false, false, true);
    }
    fViewer->SetCurrentRecord(fCurrent);
    return (TTVRecord *)fList->UncheckedAt(fCurrent);
@@ -232,7 +232,7 @@ void TTVSession::RemoveLastRecord()
    fViewer->UpdateCombo();
    fCurrent = crt;
    if (!fRecords) {
-      fViewer->ActivateButtons(kFALSE, kFALSE, kFALSE, kFALSE);
+      fViewer->ActivateButtons(false, false, false, false);
       return;
    }
    GetRecord(fCurrent);

--- a/tree/treeviewer/src/TTreeViewer.cxx
+++ b/tree/treeviewer/src/TTreeViewer.cxx
@@ -434,7 +434,7 @@ void TTreeViewer::AppendTree(TTree *tree)
    fTreeIndex++;
    TGListTreeItem *lTreeItem = fLt->AddItem(parent, tree->GetName(), itemType,
                gClient->GetPicture("tree_t.xpm"), gClient->GetPicture("tree_t.xpm"));
-   MapTree(fTree, lTreeItem, kFALSE);
+   MapTree(fTree, lTreeItem, false);
    fLt->OpenItem(parent);
    fLt->HighlightItem(lTreeItem);
    fClient->NeedRedraw(fLt);
@@ -466,7 +466,7 @@ void TTreeViewer::SetScanFileName(const char *name)
 ////////////////////////////////////////////////////////////////////////////////
 /// Set the state of Scan check button.
 
-void TTreeViewer::SetScanRedirect(Bool_t mode)
+void TTreeViewer::SetScanRedirect(bool mode)
 {
    if (mode)
       fBarScan->SetState(kButtonDown);
@@ -498,7 +498,7 @@ void TTreeViewer::SetTree(TTree *tree)
    fTreeIndex++;
    TGListTreeItem *lTreeItem = fLt->AddItem(parent, tree->GetName(), itemType,
                gClient->GetPicture("tree_t.xpm"), gClient->GetPicture("tree_t.xpm"));
-   MapTree(fTree, lTreeItem, kFALSE);
+   MapTree(fTree, lTreeItem, false);
    fLt->OpenItem(parent);
    fLt->HighlightItem(lTreeItem);
    fClient->NeedRedraw(fLt);
@@ -563,7 +563,7 @@ void TTreeViewer::SetTreeName(const char* treeName)
    fTreeIndex++;
    TGListTreeItem *lTreeItem = fLt->AddItem(parent, treeName, itemType,
                gClient->GetPicture("tree_t.xpm"), gClient->GetPicture("tree_t.xpm"));
-   MapTree(fTree, lTreeItem, kFALSE);
+   MapTree(fTree, lTreeItem, false);
    fLt->OpenItem(parent);
    fLt->HighlightItem(lTreeItem);
    fClient->NeedRedraw(fLt);
@@ -607,10 +607,10 @@ void TTreeViewer::SetFile()
 void TTreeViewer::BuildInterface()
 {
    //--- timer & misc
-   fCounting = kFALSE;
-   fScanMode = kFALSE;
-   fEnableCut = kTRUE;
-   fTimer = new TTimer(this, 20, kTRUE);
+   fCounting = false;
+   fScanMode = false;
+   fEnableCut = true;
+   fTimer = new TTimer(this, 20, true);
    fLastOption = "";
    fSession = new TTVSession(this);
    //--- cursors
@@ -630,8 +630,8 @@ void TTreeViewer::BuildInterface()
    fMappedBranch = nullptr;
    fDialogBox = nullptr;
    fDimension = 0;
-   fVarDraw = kFALSE;
-   fStopMapping = kFALSE;
+   fVarDraw = false;
+   fStopMapping = false;
 //   fFilename = "";
    fSourceFile = "treeviewer.C";
    //--- lists : trees and widgets to be removed
@@ -958,7 +958,7 @@ void TTreeViewer::BuildInterface()
 
    //--- vertical splitter
    TGVSplitter *splitter = new TGVSplitter(fHf);
-   splitter->SetFrame(fV1,kTRUE);
+   splitter->SetFrame(fV1,true);
    lo = new TGLayoutHints(kLHintsLeft | kLHintsExpandY);
    fWidgets->Add(splitter);
    fWidgets->Add(lo);
@@ -1014,7 +1014,7 @@ void TTreeViewer::BuildInterface()
    //--- Status bar
    fStatusBar = new TGStatusBar(fBFrame, 10, 10);
    fStatusBar->SetWidth(200);
-   fStatusBar->Draw3DCorner(kFALSE);
+   fStatusBar->Draw3DCorner(false);
    lo = new TGLayoutHints(kLHintsCenterX | kLHintsCenterY | kLHintsLeft | kLHintsExpandX, 2,2,2,2);
    fWidgets->Add(lo);
    fBFrame->AddFrame(fStatusBar, lo);
@@ -1151,7 +1151,7 @@ void TTreeViewer::BuildInterface()
    PrintEntries();
    fProgressBar->SetPosition(0);
    fProgressBar->ShowPosition();
-   ActivateButtons(kFALSE, kFALSE, kFALSE, kFALSE);
+   ActivateButtons(false, false, false, false);
 
    // map the window
    ///SetWindowName("TreeViewer");
@@ -1249,8 +1249,8 @@ TTreeViewer::~TTreeViewer()
 ////////////////////////////////////////////////////////////////////////////////
 /// Enable/disable session buttons.
 
-void TTreeViewer::ActivateButtons(Bool_t first, Bool_t previous,
-                                  Bool_t next, Bool_t last)
+void TTreeViewer::ActivateButtons(bool first, bool previous,
+                                  bool next, bool last)
 {
    if (first)    fBGFirst->SetState(kButtonUp);
    else          fBGFirst->SetState(kButtonDisabled);
@@ -1444,7 +1444,7 @@ void TTreeViewer::ExecuteDraw()
    // find graphics option
    const char* gopt = fBarOption->GetText();
    // just in case a previous interrupt was posted
-   gROOT->SetInterrupt(kFALSE);
+   gROOT->SetInterrupt(false);
    // check if cut is enabled
    const char *cut = "";
    if (fEnableCut) cut = Cut();
@@ -1457,16 +1457,16 @@ void TTreeViewer::ExecuteDraw()
    // check if Scan is checked and if there is something in the box
    if (fScanMode) {
 //      fBarScan->SetState(kButtonUp);
-      fScanMode = kFALSE;
+      fScanMode = false;
       if (ScanList() && strlen(ScanList())) varexp = ScanList();
       command = TString::Format("tv__tree->Scan(\"%s\",\"%s\",\"%s\", %lld, %lld);",
               varexp.Data(), cut, gopt, nentries, firstentry);
       if (fBarScan->GetState() == kButtonDown) {
-         ((TTreePlayer *)fTree->GetPlayer())->SetScanRedirect(kTRUE);
+         ((TTreePlayer *)fTree->GetPlayer())->SetScanRedirect(true);
       } else {
-         ((TTreePlayer *)fTree->GetPlayer())->SetScanRedirect(kFALSE);
+         ((TTreePlayer *)fTree->GetPlayer())->SetScanRedirect(false);
       }
-      ExecuteCommand(command.Data(), kTRUE);
+      ExecuteCommand(command.Data(), true);
       return;
    }
    // check if only histogram has to be updated
@@ -1512,14 +1512,14 @@ void TTreeViewer::ExecuteDraw()
    command = TString::Format("tv__tree->Draw(\"%s\",\"%s\",\"%s\", %lld, %lld);",
            varexp.Data(), cut, gopt, nentries, firstentry);
    if (fCounting) return;
-   fCounting = kTRUE;
+   fCounting = true;
    fTree->SetTimerInterval(200);
    fTimer->TurnOn();
    ExecuteCommand(command.Data());
    HandleTimer(fTimer);
    fTimer->TurnOff();
    fTree->SetTimerInterval(0);
-   fCounting = kFALSE;
+   fCounting = false;
    fProgressBar->SetPosition(0);
    fProgressBar->ShowPosition();
    TH1 *hist = fTree->GetHistogram();
@@ -1554,10 +1554,10 @@ void TTreeViewer::ExecuteSpider()
    Int_t dimension = 0;
    TString alias[3];
    TTVLVEntry *item;
-   Bool_t previousexp = kFALSE;
+   bool previousexp = false;
    // fill in expressions
    if (Ez() && strlen(Ez())) {
-      previousexp = kTRUE;
+      previousexp = true;
       dimension++;
       varexp = Ez();
       item = ExpressionItem(2);
@@ -1566,7 +1566,7 @@ void TTreeViewer::ExecuteSpider()
    }
    if ((Ez() && strlen(Ez())) && ((Ex() && strlen(Ex())) || (Ey() && strlen(Ey())))) varexp += ":";
    if (Ey() && strlen(Ey())) {
-      previousexp = kTRUE;
+      previousexp = true;
       dimension++;
       varexp += Ey();
       item = ExpressionItem(1);
@@ -1575,7 +1575,7 @@ void TTreeViewer::ExecuteSpider()
    }
    if (Ey() && strlen(Ey()) && Ex() && strlen(Ex())) varexp += ":";
    if (Ex() && strlen(Ex())) {
-      previousexp = kTRUE;
+      previousexp = true;
       dimension++;
       varexp += Ex();
       item = ExpressionItem(0);
@@ -1589,7 +1589,7 @@ void TTreeViewer::ExecuteSpider()
             varexp += ":";
             varexp += En(i+5);
          } else varexp = En(i+5);
-         previousexp = kTRUE;
+         previousexp = true;
       }
    }
    if (dimension<3) {
@@ -1611,7 +1611,7 @@ void TTreeViewer::ExecuteSpider()
    // find graphics option
    const char* gopt = fBarOption->GetText();
    // just in case a previous interrupt was posted
-   gROOT->SetInterrupt(kFALSE);
+   gROOT->SetInterrupt(false);
    // check if cut is enabled
    const char *cut = "";
    if (fEnableCut) cut = Cut();
@@ -1732,9 +1732,9 @@ void TTreeViewer::SetGrOpt(const char *option)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return kTRUE if scan is redirected
+/// Return true if scan is redirected
 
-Bool_t TTreeViewer::IsScanRedirected()
+bool TTreeViewer::IsScanRedirected()
 {
    return (fBarScan->GetState()==kButtonDown);
 }
@@ -1772,7 +1772,7 @@ void TTreeViewer::RemoveLastRecord()
 ////////////////////////////////////////////////////////////////////////////////
 /// This function is called by the fTimer object.
 
-Bool_t TTreeViewer::HandleTimer(TTimer *timer)
+bool TTreeViewer::HandleTimer(TTimer *timer)
 {
    if (fCounting) {
       Double_t first = fSlider->GetMinPositionD();
@@ -1783,13 +1783,13 @@ Bool_t TTreeViewer::HandleTimer(TTimer *timer)
       fProgressBar->ShowPosition();
    }
    timer->Reset();
-   return kFALSE;
+   return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Handle menu and other commands generated.
 
-Bool_t TTreeViewer::ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2)
+bool TTreeViewer::ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2)
 {
    TRootHelpDialog *hd;
    TTVRecord *record;
@@ -1808,7 +1808,7 @@ Bool_t TTreeViewer::ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t par
                   fBarCommand->Clear();
                }
                if ((ERootTreeViewerCommands)parm1 == kBarOption) {
-                  fVarDraw = kFALSE;
+                  fVarDraw = false;
                   fBarH->SetState(kButtonDown);
                   ExecuteDraw();
                   fBarH->SetState(kButtonUp);
@@ -1864,7 +1864,7 @@ Bool_t TTreeViewer::ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t par
                         if (branch != fMappedBranch) {
                            fLVContainer->RemoveNonStatic();
                            MapBranch(branch);
-                           fStopMapping = kFALSE;
+                           fStopMapping = false;
                            fListView->Layout();
                         }
                         // activate context menu for this branch (no *MENU* methods ):)
@@ -1892,7 +1892,7 @@ Bool_t TTreeViewer::ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t par
                            if (branch!=fMappedBranch) {
                               fLVContainer->RemoveNonStatic();
                               MapBranch(branch);
-                              fStopMapping = kFALSE;
+                              fStopMapping = false;
                               fListView->Layout();
                            }
                         }
@@ -1930,12 +1930,12 @@ Bool_t TTreeViewer::ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t par
                      EmptyAll();
                      break;
                   case kDRAW:
-                     fVarDraw = kFALSE;
+                     fVarDraw = false;
                      ExecuteDraw();
                      break;
                   case kSTOP:
                      if (fCounting)
-                        gROOT->SetInterrupt(kTRUE);
+                        gROOT->SetInterrupt(true);
                      break;
                   case kCLOSE:
                      SendCloseMessage();
@@ -1995,7 +1995,7 @@ Bool_t TTreeViewer::ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t par
                         info.fFileTypes = gOpenTypes;
                         info.SetIniDir(dir);
                         new TGFileDialog(fClient->GetRoot(), this, kFDOpen, &info);
-                        if (!info.fFilename) return kTRUE;
+                        if (!info.fFilename) return true;
                         dir = info.fIniDir;
                         TString command = TString::Format("tv__tree_file = new TFile(\"%s\");",
                            gSystem->UnixPathName(info.fFilename));
@@ -2023,7 +2023,7 @@ Bool_t TTreeViewer::ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t par
                         info.fFileTypes = gMacroTypes;
                         info.SetIniDir(dir);
                         new TGFileDialog(fClient->GetRoot(), this, kFDOpen, &info);
-                        if (!info.fFilename) return kTRUE;
+                        if (!info.fFilename) return true;
                         dir = info.fIniDir;
                         gInterpreter->Reset();
                         if (!gInterpreter->IsLoaded(info.fFilename)) gInterpreter->LoadMacro(info.fFilename);
@@ -2063,7 +2063,7 @@ Bool_t TTreeViewer::ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t par
                         gSystem->Exec(rootx);
 #else
 #ifdef WIN32
-                        new TWin32SplashThread(kTRUE);
+                        new TWin32SplashThread(true);
 #else
                         char str[32];
                         snprintf(str,32, "About ROOT %s...", gROOT->GetVersion());
@@ -2248,7 +2248,7 @@ Bool_t TTreeViewer::ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t par
                            if (!(*itemType & kLTCutType) && !(*itemType & kLTBranchType)
                                && !(*itemType & kLTPackType)) {
                               if (strlen(item->GetTrueName())) {
-                                 fVarDraw = kTRUE;
+                                 fVarDraw = true;
                                  // draw on double-click
                                  ExecuteDraw();
                                  break;
@@ -2266,7 +2266,7 @@ Bool_t TTreeViewer::ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t par
                               }
                            }
                            if (*itemType & kLTPackType) {
-                              fScanMode = kTRUE;
+                              fScanMode = true;
                               ExecuteDraw();
                            }
                         }
@@ -2289,7 +2289,7 @@ Bool_t TTreeViewer::ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t par
       default:
          break;
    }
-   return kTRUE;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2303,7 +2303,7 @@ void TTreeViewer::CloseWindow()
 ////////////////////////////////////////////////////////////////////////////////
 /// Execute all user commands.
 
-void TTreeViewer::ExecuteCommand(const char* command, Bool_t fast)
+void TTreeViewer::ExecuteCommand(const char* command, bool fast)
 {
    // Execute the command, write it to history file and echo it to output
    if (fBarRec->GetState() == kButtonDown) {
@@ -2326,7 +2326,7 @@ void TTreeViewer::ExecuteCommand(const char* command, Bool_t fast)
       gROOT->ProcessLine(command);
    }
    // make sure that 'draw on double-click' flag is reset
-   fVarDraw = kFALSE;
+   fVarDraw = false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2410,7 +2410,7 @@ void TTreeViewer::MapOptions(Long_t parm1)
 ////////////////////////////////////////////////////////////////////////////////
 /// Map current tree and expand its content (including friends) in the lists.
 
-void TTreeViewer::MapTree(TTree *tree, TGListTreeItem *parent, Bool_t listIt)
+void TTreeViewer::MapTree(TTree *tree, TGListTreeItem *parent, bool listIt)
 {
    if (!tree) return;
    TObjArray *branches = tree->GetListOfBranches();
@@ -2425,7 +2425,7 @@ void TTreeViewer::MapTree(TTree *tree, TGListTreeItem *parent, Bool_t listIt)
       if (name.Contains("fBits") || name.Contains("fUniqueID")) continue;
       // now map sub-branches
       MapBranch(branch, "", parent, listIt);
-      fStopMapping = kFALSE;
+      fStopMapping = false;
    }
    //Map branches of friend Trees (if any)
    //Look at tree->GetTree() to insure we see both the friends of a chain
@@ -2442,7 +2442,7 @@ void TTreeViewer::MapTree(TTree *tree, TGListTreeItem *parent, Bool_t listIt)
          if (name.Contains("fBits") || name.Contains("fUniqueID")) continue;
          // now map sub-branches
          MapBranch(branch, fr->GetName(), parent, listIt);
-         fStopMapping = kFALSE;
+         fStopMapping = false;
       }
    }
 
@@ -2456,7 +2456,7 @@ void TTreeViewer::MapTree(TTree *tree, TGListTreeItem *parent, Bool_t listIt)
 ////////////////////////////////////////////////////////////////////////////////
 /// Map current branch and expand its content in the list view.
 
-void TTreeViewer::MapBranch(TBranch *branch, const char *prefix, TGListTreeItem *parent, Bool_t listIt)
+void TTreeViewer::MapBranch(TBranch *branch, const char *prefix, TGListTreeItem *parent, bool listIt)
 {
    if (!branch) return;
    TString name;
@@ -2528,7 +2528,7 @@ void TTreeViewer::MapBranch(TBranch *branch, const char *prefix, TGListTreeItem 
       if (!fStopMapping) {
          fMappedBranch = branch;
          fMappedTree = nullptr;
-         fStopMapping = kTRUE;
+         fStopMapping = true;
       }
       if ((branch->GetListOfBranches()->GetEntries()) ||
           (branch->GetNleaves())) {
@@ -2584,9 +2584,9 @@ void TTreeViewer::MapBranch(TBranch *branch, const char *prefix, TGListTreeItem 
                   entry->SetAlias(textEntry->GetString());
                }
             } else {
-               pic = (gClient->GetMimeTypeList())->GetIcon("TLeaf",kFALSE);
+               pic = (gClient->GetMimeTypeList())->GetIcon("TLeaf",false);
                if (!pic) pic = gClient->GetPicture("leaf_t.xpm");
-               spic = gClient->GetMimeTypeList()->GetIcon("TLeaf",kTRUE);
+               spic = gClient->GetMimeTypeList()->GetIcon("TLeaf",true);
                if (!spic) spic = gClient->GetPicture("leaf_t.xpm");
                entry = new TTVLVEntry(fLVContainer,pic,spic,textEntry,nullptr,kLVSmallIcons);
                entry->SetUserData(new UInt_t(kLTDragType | kLTLeafType));
@@ -2803,9 +2803,9 @@ void TTreeViewer::SaveSource(const char* filename, Option_t *)
    for (Int_t crt=5; crt<fNexpressions+5; crt++) {
       item = ExpressionItem(crt);
       if (item->IsCut())
-         itemType = "kTRUE";
+         itemType = "true";
       else
-         itemType = "kFALSE";
+         itemType = "false";
       out <<"   item = treeview->ExpressionItem("<<crt<<");"<<std::endl;
       out <<"   item->SetExpression("<<quote<<item->GetTrueName()<<quote
           <<", "<<quote<<item->GetAlias()<<quote<<", "<<itemType.Data()<<");"<<std::endl;
@@ -2820,14 +2820,14 @@ void TTreeViewer::SaveSource(const char* filename, Option_t *)
 ////////////////////////////////////////////////////////////////////////////////
 /// Makes current the tree at a given index in the list.
 
-Bool_t TTreeViewer::SwitchTree(Int_t index)
+bool TTreeViewer::SwitchTree(Int_t index)
 {
    TTree *tree = (TTree *) fTreeList->At(index);
    if (!tree) {
       Warning("SwitchTree", "No tree found.");
-      return kFALSE;
+      return false;
    }
-   if ((tree == fTree) && (tree == fMappedTree)) return kFALSE;     // nothing to switch
+   if ((tree == fTree) && (tree == fMappedTree)) return false;     // nothing to switch
    std::string command;
    if (tree != fTree) {
       command = "tv__tree = (TTree *) tv__tree_list->At";
@@ -2847,7 +2847,7 @@ Bool_t TTreeViewer::SwitchTree(Int_t index)
    MapWindow();
    ///Resize();  //ia
    PrintEntries();
-   return kTRUE;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2882,7 +2882,7 @@ void TTreeViewer::SetHistogramTitle(const char *title)
 ////////////////////////////////////////////////////////////////////////////////
 /// user defined command for current record
 
-void TTreeViewer::SetUserCode(const char *code, Bool_t autoexec)
+void TTreeViewer::SetUserCode(const char *code, bool autoexec)
 {
    TTVRecord *rec = fSession->GetCurrent();
    if (rec) rec->SetUserCode(code, autoexec);

--- a/tree/webviewer/src/RTreeViewer.cxx
+++ b/tree/webviewer/src/RTreeViewer.cxx
@@ -46,29 +46,29 @@ public:
    }
 
    // TFile related info. In general they are gathered and sent only sometimes as summaries
-   Bool_t SendFileCloseEvent(TFile * /*file*/) override { return kFALSE; }
-   Bool_t SendFileReadProgress(TFile * /*file*/) override { return kFALSE; }
-   Bool_t SendFileWriteProgress(TFile * /*file*/) override { return kFALSE; }
+   bool SendFileCloseEvent(TFile * /*file*/) override { return false; }
+   bool SendFileReadProgress(TFile * /*file*/) override { return false; }
+   bool SendFileWriteProgress(TFile * /*file*/) override { return false; }
 
-   Bool_t SendParameters(TList * /*valuelist*/, const char * /*identifier*/ = nullptr) override { return kFALSE; }
-   Bool_t SendInfoTime() override { return kFALSE; }
-   Bool_t SendInfoUser(const char * /*user*/ = nullptr) override { return kFALSE; }
-   Bool_t SendInfoDescription(const char * /*jobtag*/) override { return kFALSE; }
-   Bool_t SendInfoStatus(const char * /*status*/) override { return kFALSE; }
+   bool SendParameters(TList * /*valuelist*/, const char * /*identifier*/ = nullptr) override { return false; }
+   bool SendInfoTime() override { return false; }
+   bool SendInfoUser(const char * /*user*/ = nullptr) override { return false; }
+   bool SendInfoDescription(const char * /*jobtag*/) override { return false; }
+   bool SendInfoStatus(const char * /*status*/) override { return false; }
 
-   Bool_t SendFileOpenProgress(TFile * /*file*/, TList * /*openphases*/, const char * /*openphasename*/,
-                               Bool_t /*forcesend*/ = kFALSE) override
+   bool SendFileOpenProgress(TFile * /*file*/, TList * /*openphases*/, const char * /*openphasename*/,
+                               bool /*forcesend*/ = false) override
    {
-      return kFALSE;
+      return false;
    }
 
-   Bool_t SendProcessingStatus(const char * /*status*/, Bool_t /*restarttimer*/ = kFALSE) override { return kFALSE; }
-   Bool_t SendProcessingProgress(Double_t nevent, Double_t /*nbytes*/, Bool_t /*force*/ = kFALSE) override
+   bool SendProcessingStatus(const char * /*status*/, bool /*restarttimer*/ = false) override { return false; }
+   bool SendProcessingProgress(Double_t nevent, Double_t /*nbytes*/, bool /*force*/ = false) override
    {
       long long millisec = gSystem->Now();
 
       if (fLastProgressSendTm && (millisec < fLastProgressSendTm + fPeriod))
-         return kTRUE;
+         return true;
 
       fLastProgressSendTm = millisec;
 
@@ -76,10 +76,10 @@ public:
 
       fViewer.SendProgress(nevent);
 
-      return kTRUE;
+      return true;
    }
    void SetLogLevel(const char * /*loglevel*/ = "WARNING") override {}
-   void Verbose(Bool_t /*onoff*/) override {}
+   void Verbose(bool /*onoff*/) override {}
 };
 
 
@@ -88,7 +88,7 @@ public:
    RTreeViewer &fViewer;
 
    /// constructor
-   RTreeDrawInvokeTimer(Long_t milliSec, Bool_t mode, RTreeViewer &viewer) : TTimer(milliSec, mode), fViewer(viewer) {}
+   RTreeDrawInvokeTimer(Long_t milliSec, bool mode, RTreeViewer &viewer) : TTimer(milliSec, mode), fViewer(viewer) {}
 
    /// timeout handler
    /// used to process postponed requests in main ROOT thread
@@ -119,7 +119,7 @@ RTreeViewer::RTreeViewer(TTree *tree)
 
    if (tree) SetTree(tree);
 
-   fTimer = std::make_unique<RTreeDrawInvokeTimer>(10, kTRUE, *this);
+   fTimer = std::make_unique<RTreeDrawInvokeTimer>(10, true, *this);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -475,7 +475,7 @@ void RTreeViewer::SendProgress(Double_t nevent)
 
    fLastSendProgress = progress;
 
-   if (fWebWindow->CanSend(0, kTRUE))
+   if (fWebWindow->CanSend(0, true))
       fWebWindow->Send(0, "PROGRESS:"s + progress);
 }
 


### PR DESCRIPTION
These type and value aliases are not necessary anymore.

This is done following a suggestion by @pcanal.
