### PR TITLE
[hist,skip-ci] document max bin content for th1f,th2f,th3f

### DIFF
--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -630,7 +630,12 @@ public:
    TH1F& operator=(const TH1F &h1);
    ~TH1F() override;
 
+   /// Increment bin content by 1.
+   /// Passing an out-of-range bin leads to undefined behavior
    void     AddBinContent(Int_t bin) override {++fArray[bin];}
+   /// Increment bin content by a weight w.
+   /// \warning The value of w is cast to `Float_t` before being added.
+   /// Passing an out-of-range bin leads to undefined behavior
    void     AddBinContent(Int_t bin, Double_t w) override
                           { fArray[bin] += Float_t (w); }
    void     Copy(TObject &hnew) const override;
@@ -673,7 +678,11 @@ public:
    TH1D& operator=(const TH1D &h1);
    ~TH1D() override;
 
+   /// Increment bin content by 1.
+   /// Passing an out-of-range bin leads to undefined behavior
    void     AddBinContent(Int_t bin) override {++fArray[bin];}
+   /// Increment bin content by a weight w
+   /// Passing an out-of-range bin leads to undefined behavior
    void     AddBinContent(Int_t bin, Double_t w) override
                           {fArray[bin] += Double_t (w);}
    void     Copy(TObject &hnew) const override;

--- a/hist/hist/inc/TH2.h
+++ b/hist/hist/inc/TH2.h
@@ -322,7 +322,12 @@ public:
    TH2F(const TH2F &h2f);
    ~TH2F() override;
 
+           /// Increment bin content by 1.
+           /// Passing an out-of-range bin leads to undefined behavior
            void     AddBinContent(Int_t bin) override {++fArray[bin];}
+           /// Increment bin content by a weight w.
+           /// \warning The value of w is cast to `Float_t` before being added.
+           /// Passing an out-of-range bin leads to undefined behavior
            void     AddBinContent(Int_t bin, Double_t w) override
                                  {fArray[bin] += Float_t (w);}
            void     AddBinContent(Int_t binx, Int_t biny) override { AddBinContent(GetBin(binx, biny)); }
@@ -367,7 +372,11 @@ public:
    TH2D(const TH2D &h2d);
    ~TH2D() override;
 
+           /// Increment bin content by 1.
+           /// Passing an out-of-range bin leads to undefined behavior
            void     AddBinContent(Int_t bin) override {++fArray[bin];}
+           /// Increment bin content by a weight w
+           /// Passing an out-of-range bin leads to undefined behavior
            void     AddBinContent(Int_t bin, Double_t w) override
                                  {fArray[bin] += Double_t (w);}
            void     AddBinContent(Int_t binx, Int_t biny) override { AddBinContent(GetBin(binx, biny)); }

--- a/hist/hist/inc/TH3.h
+++ b/hist/hist/inc/TH3.h
@@ -329,7 +329,12 @@ public:
    TH3F(const TH3F &h3f);
    ~TH3F() override;
 
+           /// Increment bin content by 1.
+           /// Passing an out-of-range bin leads to undefined behavior
            void      AddBinContent(Int_t bin) override {++fArray[bin];}
+           /// Increment bin content by a weight w.
+           /// \warning The value of w is cast to `Float_t` before being added.
+           /// Passing an out-of-range bin leads to undefined behavior
            void      AddBinContent(Int_t bin, Double_t w) override
                                  {fArray[bin] += Float_t (w);}
            void      AddBinContent(Int_t binx, Int_t biny, Int_t binz) override { AddBinContent(GetBin(binx, biny, binz)); }
@@ -370,7 +375,11 @@ public:
    TH3D(const TH3D &h3d);
    ~TH3D() override;
 
+           /// Increment bin content by 1.
+           /// Passing an out-of-range bin leads to undefined behavior
            void      AddBinContent(Int_t bin) override {++fArray[bin];}
+           /// Increment bin content by a weight w
+           /// Passing an out-of-range bin leads to undefined behavior
            void      AddBinContent(Int_t bin, Double_t w) override
                                  {fArray[bin] += Double_t (w);}
            void      AddBinContent(Int_t binx, Int_t biny, Int_t binz) override { AddBinContent(GetBin(binx, biny, binz)); }

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -110,22 +110,22 @@ ROOT supports the following histogram types:
       - TH1S : histograms with one short per channel.  Maximum bin content = 32767
       - TH1I : histograms with one int per channel.    Maximum bin content = INT_MAX (\ref intmax "*")
       - TH1L : histograms with one long64 per channel. Maximum bin content = LLONG_MAX (\ref llongmax "*")
-      - TH1F : histograms with one float per channel.  Maximum precision 7 digits
-      - TH1D : histograms with one double per channel. Maximum precision 14 digits
+      - TH1F : histograms with one float per channel.  Maximum precision 7 digits, maximum integer bin content = +/-16777216 (\ref floatmax "**")
+      - TH1D : histograms with one double per channel. Maximum precision 14 digits, maximum integer bin content = +/-9007199254740992 (\ref doublemax "***")
   - 2-D histograms:
       - TH2C : histograms with one byte per channel.   Maximum bin content = 127
       - TH2S : histograms with one short per channel.  Maximum bin content = 32767
       - TH2I : histograms with one int per channel.    Maximum bin content = INT_MAX (\ref intmax "*")
       - TH2L : histograms with one long64 per channel. Maximum bin content = LLONG_MAX (\ref llongmax "*")
-      - TH2F : histograms with one float per channel.  Maximum precision 7 digits
-      - TH2D : histograms with one double per channel. Maximum precision 14 digits
+      - TH2F : histograms with one float per channel.  Maximum precision 7 digits, maximum integer bin content = +/-16777216 (\ref floatmax "**")
+      - TH2D : histograms with one double per channel. Maximum precision 14 digits, maximum integer bin content = +/-9007199254740992 (\ref doublemax "***")
   - 3-D histograms:
       - TH3C : histograms with one byte per channel.   Maximum bin content = 127
       - TH3S : histograms with one short per channel.  Maximum bin content = 32767
       - TH3I : histograms with one int per channel.    Maximum bin content = INT_MAX (\ref intmax "*")
       - TH3L : histograms with one long64 per channel. Maximum bin content = LLONG_MAX (\ref llongmax "*")
-      - TH3F : histograms with one float per channel.  Maximum precision 7 digits
-      - TH3D : histograms with one double per channel. Maximum precision 14 digits
+      - TH3F : histograms with one float per channel.  Maximum precision 7 digits, maximum integer bin content = +/-16777216 (\ref floatmax "**")
+      - TH3D : histograms with one double per channel. Maximum precision 14 digits, maximum integer bin content = +/-9007199254740992 (\ref doublemax "***")
   - Profile histograms: See classes  TProfile, TProfile2D and TProfile3D.
       Profile histograms are used to display the mean value of Y and its standard deviation
       for each bin in X. Profile histograms are in many cases an elegant
@@ -138,6 +138,8 @@ ROOT supports the following histogram types:
 <sup>
 \anchor intmax (*) INT_MAX = 2147483647 is the [maximum value for a variable of type int.](https://docs.microsoft.com/en-us/cpp/c-language/cpp-integer-limits)
 \anchor llongmax (*) LLONG_MAX = 9223372036854775807 is the [maximum value for a variable of type long64.](https://docs.microsoft.com/en-us/cpp/c-language/cpp-integer-limits)
+\anchor floatmax (**) 2^24 = 16777216 is the [maximum integer that can be properly represented by a float32 with 23-bit mantissa.](https://stackoverflow.com/a/3793950/7471760)
+\anchor doublemax (***) 2^53 = 9007199254740992 is the [maximum integer that can be properly represented by a double64 with 52-bit mantissa.](https://stackoverflow.com/a/3793950/7471760)
 </sup>
 
 The inheritance hierarchy looks as follows:
@@ -9510,6 +9512,7 @@ void TH1C::AddBinContent(Int_t bin)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Increment bin content by w.
+/// \warning The value of w is cast to `Int_t` before being added.
 /// Passing an out-of-range bin leads to undefined behavior
 
 void TH1C::AddBinContent(Int_t bin, Double_t w)
@@ -9694,7 +9697,8 @@ void TH1S::AddBinContent(Int_t bin)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Increment bin content by w
+/// Increment bin content by w.
+/// \warning The value of w is cast to `Int_t` before being added.
 /// Passing an out-of-range bin leads to undefined behavior
 
 void TH1S::AddBinContent(Int_t bin, Double_t w)
@@ -9881,6 +9885,7 @@ void TH1I::AddBinContent(Int_t bin)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Increment bin content by w
+/// \warning The value of w is cast to `Long64_t` before being added.
 /// Passing an out-of-range bin leads to undefined behavior
 
 void TH1I::AddBinContent(Int_t bin, Double_t w)
@@ -10067,7 +10072,8 @@ void TH1L::AddBinContent(Int_t bin)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Increment bin content by w
+/// Increment bin content by w.
+/// \warning The value of w is cast to `Long64_t` before being added.
 /// Passing an out-of-range bin leads to undefined behavior
 
 void TH1L::AddBinContent(Int_t bin, Double_t w)
@@ -10174,7 +10180,7 @@ TH1L operator/(const TH1L &h1, const TH1L &h2)
 
 //______________________________________________________________________________
 //                     TH1F methods
-// TH1F : histograms with one float per channel.  Maximum precision 7 digits
+// TH1F : histograms with one float per channel. Maximum precision 7 digits, maximum integer bin content = +/-16777216
 //______________________________________________________________________________
 
 ClassImp(TH1F);
@@ -10355,7 +10361,7 @@ TH1F operator/(const TH1F &h1, const TH1F &h2)
 
 //______________________________________________________________________________
 //                     TH1D methods
-// TH1D : histograms with one double per channel. Maximum precision 14 digits
+// TH1D : histograms with one double per channel. Maximum precision 14 digits, maximum integer bin content = +/-9007199254740992
 //______________________________________________________________________________
 
 ClassImp(TH1D);

--- a/hist/hist/src/TH2.cxx
+++ b/hist/hist/src/TH2.cxx
@@ -50,12 +50,20 @@ ClassImp(TH2);
 /** \class TH2
  Service class for 2-D histogram classes
 
-- TH2C a 2-D histogram with one byte per cell (char)
-- TH2S a 2-D histogram with two bytes per cell (short integer)
-- TH2I a 2-D histogram with four bytes per cell (32 bit integer)
-- TH2L a 2-D histogram with eight bytes per cell (64 bit integer)
-- TH2F a 2-D histogram with four bytes per cell (float)
-- TH2D a 2-D histogram with eight bytes per cell (double)
+- TH2C a 2-D histogram with one byte per cell (char). Maximum bin content = 127
+- TH2S a 2-D histogram with two bytes per cell (short integer). Maximum bin content = 32767
+- TH2I a 2-D histogram with four bytes per cell (32 bit integer). Maximum bin content = INT_MAX (\ref intmax "*")
+- TH2L a 2-D histogram with eight bytes per cell (64 bit integer). Maximum bin content = LLONG_MAX (\ref llongmax "*")
+- TH2F a 2-D histogram with four bytes per cell (float). Maximum precision 7 digits, maximum integer bin content = +/-16777216 (\ref floatmax "**")
+- TH2D a 2-D histogram with eight bytes per cell (double). Maximum precision 14 digits, maximum integer bin content = +/-9007199254740992 (\ref doublemax "***")
+
+<sup>
+\anchor intmax (*) INT_MAX = 2147483647 is the [maximum value for a variable of type int.](https://docs.microsoft.com/en-us/cpp/c-language/cpp-integer-limits)
+\anchor llongmax (*) LLONG_MAX = 9223372036854775807 is the [maximum value for a variable of type long64.](https://docs.microsoft.com/en-us/cpp/c-language/cpp-integer-limits)
+\anchor floatmax (**) 2^24 = 16777216 is the [maximum integer that can be properly represented by a float32 with 23-bit mantissa.](https://stackoverflow.com/a/3793950/7471760)
+\anchor doublemax (***) 2^53 = 9007199254740992 is the [maximum integer that can be properly represented by a double64 with 52-bit mantissa.](https://stackoverflow.com/a/3793950/7471760)
+</sup>
+
 */
 
 
@@ -2957,6 +2965,7 @@ void TH2C::AddBinContent(Int_t bin)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Increment bin content by w.
+/// \warning The value of w is cast to `Int_t` before being added.
 /// Passing an out-of-range bin leads to undefined behavior
 
 void TH2C::AddBinContent(Int_t bin, Double_t w)
@@ -3220,6 +3229,7 @@ void TH2S::AddBinContent(Int_t bin)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Increment bin content by w.
+/// \warning The value of w is cast to `Int_t` before being added.
 /// Passing an out-of-range bin leads to undefined behavior
 
 void TH2S::AddBinContent(Int_t bin, Double_t w)
@@ -3483,6 +3493,7 @@ void TH2I::AddBinContent(Int_t bin)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Increment bin content by w.
+/// \warning The value of w is cast to `Long64_t` before being added.
 /// Passing an out-of-range bin leads to undefined behavior
 
 void TH2I::AddBinContent(Int_t bin, Double_t w)
@@ -3711,6 +3722,7 @@ void TH2L::AddBinContent(Int_t bin)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Increment bin content by w.
+/// \warning The value of w is cast to `Long64_t` before being added.
 /// Passing an out-of-range bin leads to undefined behavior
 
 void TH2L::AddBinContent(Int_t bin, Double_t w)
@@ -3826,7 +3838,7 @@ TH2L operator/(TH2L &h1, TH2L &h2)
 
 //______________________________________________________________________________
 //                     TH2F methods
-//  TH2F a 2-D histogram with four bytes per cell (float)
+//  TH2F a 2-D histogram with four bytes per cell (float). Maximum precision 7 digits, maximum integer bin content = +/-16777216
 //______________________________________________________________________________
 
 ClassImp(TH2F);
@@ -4098,7 +4110,7 @@ TH2F operator/(TH2F &h1, TH2F &h2)
 
 //______________________________________________________________________________
 //                     TH2D methods
-//  TH2D a 2-D histogram with eight bytes per cell (double)
+//  TH2D a 2-D histogram with eight bytes per cell (double). Maximum precision 14 digits, maximum integer bin content = +/-9007199254740992
 //______________________________________________________________________________
 
 ClassImp(TH2D);

--- a/hist/hist/src/TH3.cxx
+++ b/hist/hist/src/TH3.cxx
@@ -52,12 +52,19 @@ Drawing is currently restricted to one single option.
 A cloud of points is drawn. The number of points is proportional to
 cell content.
 
--   TH3C a 3-D histogram with one byte per cell (char)
--   TH3S a 3-D histogram with two bytes per cell (short integer)
--   TH3I a 3-D histogram with four bytes per cell (32 bit integer)
--   TH3L a 3-D histogram with eight bytes per cell (64 bit integer)
--   TH3F a 3-D histogram with four bytes per cell (float)
--   TH3D a 3-D histogram with eight bytes per cell (double)
+- TH3C a 3-D histogram with one byte per cell (char). Maximum bin content = 127
+- TH3S a 3-D histogram with two bytes per cell (short integer). Maximum bin content = 32767
+- TH3I a 3-D histogram with four bytes per cell (32 bit integer). Maximum bin content = INT_MAX (\ref intmax "*")
+- TH3L a 3-D histogram with eight bytes per cell (64 bit integer). Maximum bin content = LLONG_MAX (\ref llongmax "*")
+- TH3F a 3-D histogram with four bytes per cell (float). Maximum precision 7 digits, maximum integer bin content = +/-16777216 (\ref floatmax "**")
+- TH3D a 3-D histogram with eight bytes per cell (double). Maximum precision 14 digits, maximum integer bin content = +/-9007199254740992 (\ref doublemax "***")
+
+<sup>
+\anchor intmax (*) INT_MAX = 2147483647 is the [maximum value for a variable of type int.](https://docs.microsoft.com/en-us/cpp/c-language/cpp-integer-limits)
+\anchor llongmax (*) LLONG_MAX = 9223372036854775807 is the [maximum value for a variable of type long64.](https://docs.microsoft.com/en-us/cpp/c-language/cpp-integer-limits)
+\anchor floatmax (**) 2^24 = 16777216 is the [maximum integer that can be properly represented by a float32 with 23-bit mantissa.](https://stackoverflow.com/a/3793950/7471760)
+\anchor doublemax (***) 2^53 = 9007199254740992 is the [maximum integer that can be properly represented by a double64 with 52-bit mantissa.](https://stackoverflow.com/a/3793950/7471760)
+</sup>
 */
 
 
@@ -3604,6 +3611,7 @@ void TH3C::AddBinContent(Int_t bin)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Increment bin content by w.
+/// \warning The value of w is cast to `Int_t` before being added.
 /// Passing an out-of-range bin leads to undefined behavior
 
 void TH3C::AddBinContent(Int_t bin, Double_t w)
@@ -3872,6 +3880,7 @@ void TH3S::AddBinContent(Int_t bin)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Increment bin content by w.
+/// \warning The value of w is cast to `Int_t` before being added.
 /// Passing an out-of-range bin leads to undefined behavior
 
 void TH3S::AddBinContent(Int_t bin, Double_t w)
@@ -4111,6 +4120,7 @@ void TH3I::AddBinContent(Int_t bin)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Increment bin content by w.
+/// \warning The value of w is cast to `Long64_t` before being added.
 /// Passing an out-of-range bin leads to undefined behavior
 
 void TH3I::AddBinContent(Int_t bin, Double_t w)
@@ -4317,6 +4327,7 @@ void TH3L::AddBinContent(Int_t bin)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Increment bin content by w.
+/// \warning The value of w is cast to `Long64_t` before being added.
 /// Passing an out-of-range bin leads to undefined behavior
 
 void TH3L::AddBinContent(Int_t bin, Double_t w)
@@ -4433,7 +4444,7 @@ TH3L operator/(TH3L &h1, TH3L &h2)
 
 //______________________________________________________________________________
 //                     TH3F methods
-//  TH3F a 3-D histogram with four bytes per cell (float)
+//  TH3F a 3-D histogram with four bytes per cell (float). Maximum precision 7 digits, maximum integer bin content = +/-16777216
 //______________________________________________________________________________
 
 ClassImp(TH3F);
@@ -4649,7 +4660,7 @@ TH3F operator/(TH3F &h1, TH3F &h2)
 
 //______________________________________________________________________________
 //                     TH3D methods
-//  TH3D a 3-D histogram with eight bytes per cell (double)
+//  TH3D a 3-D histogram with eight bytes per cell (double). Maximum precision 14 digits, maximum integer bin content = +/-9007199254740992
 //______________________________________________________________________________
 
 ClassImp(TH3D);


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Adds a reasonable max bin content (and explicitly stated) for TH1F to prevent nasty silent data drawing errors

If the solution is welcome, I can extend it for TH2 and TH3.

## Checklist:

- [ ] tested changes locally
- [x] updated the docs (if necessary)

Fixes https://github.com/root-project/root/issues/6671

