### PR TITLE
[core] Materialize symbols for TError variables

### DIFF
--- a/core/foundation/inc/TError.h
+++ b/core/foundation/inc/TError.h
@@ -39,15 +39,14 @@
 
 class TVirtualMutex;
 
-constexpr Int_t kUnset    =  -1;
-constexpr Int_t kPrint    =   0;
-constexpr Int_t kInfo     =   1000;
-constexpr Int_t kWarning  =   2000;
-constexpr Int_t kError    =   3000;
-constexpr Int_t kBreak    =   4000;
-constexpr Int_t kSysError =   5000;
-constexpr Int_t kFatal    =   6000;
-
+R__EXTERN const Int_t kUnset;
+R__EXTERN const Int_t kPrint;
+R__EXTERN const Int_t kInfo;
+R__EXTERN const Int_t kWarning;
+R__EXTERN const Int_t kError;
+R__EXTERN const Int_t kBreak;
+R__EXTERN const Int_t kSysError;
+R__EXTERN const Int_t kFatal;
 
 // TROOT sets the error ignore level handler, the system error message handler, and the error abort handler on
 // construction such that the "Root.ErrorIgnoreLevel" environment variable is used for the ignore level

--- a/core/foundation/src/RLogger.cxx
+++ b/core/foundation/src/RLogger.cxx
@@ -52,7 +52,7 @@ inline bool RLogHandlerDefault::Emit(const RLogEntry &entry)
    if (!entry.fLocation.fFuncName.empty())
       strm << " in " << entry.fLocation.fFuncName;
 
-   static constexpr const int errorLevelOld[] = {kFatal /*unset*/, kFatal, kError, kWarning, kInfo, kInfo /*debug*/};
+   static const int errorLevelOld[] = {kFatal /*unset*/, kFatal, kError, kWarning, kInfo, kInfo /*debug*/};
    (*::GetErrorHandler())(errorLevelOld[cappedLevel], entry.fLevel == ELogLevel::kFatal, strm.str().c_str(),
                           entry.fMessage.c_str());
    return true;

--- a/core/foundation/src/TError.cxx
+++ b/core/foundation/src/TError.cxx
@@ -28,6 +28,15 @@ to be replaced by the proper DefaultErrorHandler()
 #include <cerrno>
 #include <string>
 
+const Int_t kUnset = -1;
+const Int_t kPrint = 0;
+const Int_t kInfo = 1000;
+const Int_t kWarning = 2000;
+const Int_t kError = 3000;
+const Int_t kBreak = 4000;
+const Int_t kSysError = 5000;
+const Int_t kFatal = 6000;
+
 Int_t  gErrorIgnoreLevel     = kUnset;
 Int_t  gErrorAbortLevel      = kSysError+1;
 Bool_t gPrintViaErrorHandler = kFALSE;


### PR DESCRIPTION
The variables present in TError.h are used throughout the ROOT libraries. Anytime one of these variables is requested, e.g. with a simple test such as `python -c "import ROOT; ROOT.kError"`, the interpreter will lookup the corresponding symbol. Previously, the variables were declared and defined in the header directly but were not generating any symbol since the linkage was internal. With this commit, provide external linkage to these variables so that the corresponding symbols are materialized in libCore.so. As a consequence, a huge number of extra lookups by cling is avoided.

This is in direct reference to https://github.com/root-project/root/pull/14261#issuecomment-1863067950 , a followup issue to the original issue at https://github.com/cms-sw/cmssw/issues/43077

These are the results of the patch:

Before:
```
$: strace -z -f -o log.txt -e trace=openat python3 -c 'import ROOT;print(ROOT.kError);'
$: grep openat log.txt | wc -l
$: 16279
```

After:
```
$: strace -z -f -o log.txt -e trace=openat python3 -c 'import ROOT;print(ROOT.kError);'
$: grep openat log.txt | wc -l
$: 417  
```

FYI @smuzaffar

