### PR TITLE
[cmake] Fix warning about implicit file extensions

### DIFF
--- a/math/mathmore/test/CMakeLists.txt
+++ b/math/mathmore/test/CMakeLists.txt
@@ -55,4 +55,4 @@ foreach(file ${TestMathMoreSource})
 endforeach()
 
 ROOT_ADD_GTEST(stressMathMoreUnit testStress.cxx StatFunction.cxx LIBRARIES Core MathCore MathMore)
-ROOT_ADD_GTEST(testPolynomialRoots testPolynomialRoots LIBRARIES Core MathCore MathMore)
+ROOT_ADD_GTEST(testPolynomialRoots testPolynomialRoots.cxx LIBRARIES Core MathCore MathMore)


### PR DESCRIPTION
```
CMake Warning (dev) at cmake/modules/RootMacros.cmake:1409 (add_executable):
  Policy CMP0115 is not set: Source file extensions must be explicit.  Run
  "cmake --help-policy CMP0115" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
```