### PR TITLE
[core] Reduce symbol search only to when autoloading is enabled.

### DIFF
--- a/core/foundation/inc/TError.h
+++ b/core/foundation/inc/TError.h
@@ -39,14 +39,15 @@
 
 class TVirtualMutex;
 
-R__EXTERN const Int_t kUnset;
-R__EXTERN const Int_t kPrint;
-R__EXTERN const Int_t kInfo;
-R__EXTERN const Int_t kWarning;
-R__EXTERN const Int_t kError;
-R__EXTERN const Int_t kBreak;
-R__EXTERN const Int_t kSysError;
-R__EXTERN const Int_t kFatal;
+constexpr Int_t kUnset    =  -1;
+constexpr Int_t kPrint    =   0;
+constexpr Int_t kInfo     =   1000;
+constexpr Int_t kWarning  =   2000;
+constexpr Int_t kError    =   3000;
+constexpr Int_t kBreak    =   4000;
+constexpr Int_t kSysError =   5000;
+constexpr Int_t kFatal    =   6000;
+
 
 // TROOT sets the error ignore level handler, the system error message handler, and the error abort handler on
 // construction such that the "Root.ErrorIgnoreLevel" environment variable is used for the ignore level

--- a/core/foundation/src/RLogger.cxx
+++ b/core/foundation/src/RLogger.cxx
@@ -52,7 +52,7 @@ inline bool RLogHandlerDefault::Emit(const RLogEntry &entry)
    if (!entry.fLocation.fFuncName.empty())
       strm << " in " << entry.fLocation.fFuncName;
 
-   static const int errorLevelOld[] = {kFatal /*unset*/, kFatal, kError, kWarning, kInfo, kInfo /*debug*/};
+   static constexpr const int errorLevelOld[] = {kFatal /*unset*/, kFatal, kError, kWarning, kInfo, kInfo /*debug*/};
    (*::GetErrorHandler())(errorLevelOld[cappedLevel], entry.fLevel == ELogLevel::kFatal, strm.str().c_str(),
                           entry.fMessage.c_str());
    return true;

--- a/core/foundation/src/TError.cxx
+++ b/core/foundation/src/TError.cxx
@@ -28,15 +28,6 @@ to be replaced by the proper DefaultErrorHandler()
 #include <cerrno>
 #include <string>
 
-const Int_t kUnset = -1;
-const Int_t kPrint = 0;
-const Int_t kInfo = 1000;
-const Int_t kWarning = 2000;
-const Int_t kError = 3000;
-const Int_t kBreak = 4000;
-const Int_t kSysError = 5000;
-const Int_t kFatal = 6000;
-
 Int_t  gErrorIgnoreLevel     = kUnset;
 Int_t  gErrorAbortLevel      = kSysError+1;
 Bool_t gPrintViaErrorHandler = kFALSE;

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -4726,6 +4726,9 @@ TInterpreter::DeclId_t TCling::GetDataMember(ClassInfo_t *opaque_cl, const char 
    DeclId_t d;
    TClingClassInfo *cl = (TClingClassInfo*)opaque_cl;
 
+   // Could trigger deserialization of decls.
+   cling::Interpreter::PushTransactionRAII RAII(GetInterpreterImpl());
+
    if (cl) {
       d = cl->GetDataMember(name);
       // We check if the decl of the data member has an annotation which indicates
@@ -4756,8 +4759,6 @@ TInterpreter::DeclId_t TCling::GetDataMember(ClassInfo_t *opaque_cl, const char 
    LookupResult R(SemaR, DName, SourceLocation(), Sema::LookupOrdinaryName,
                   Sema::ForExternalRedeclaration);
 
-   // Could trigger deserialization of decls.
-   cling::Interpreter::PushTransactionRAII RAII(GetInterpreterImpl());
    cling::utils::Lookup::Named(&SemaR, R);
 
    LookupResult::Filter F = R.makeFilter();

--- a/core/metacling/src/TClingCallbacks.h
+++ b/core/metacling/src/TClingCallbacks.h
@@ -58,7 +58,7 @@ public:
    void Initialize();
 
    void SetAutoLoadingEnabled(bool val = true) { fIsAutoLoading = val; }
-   bool IsAutoLoadingEnabled() { return fIsAutoLoading; }
+   bool IsAutoLoadingEnabled() const { return fIsAutoLoading; }
 
    void SetAutoParsingSuspended(bool val = true) { fIsAutoParsingSuspended = val; }
    bool IsAutoParsingSuspended() { return fIsAutoParsingSuspended; }

--- a/core/metacling/src/TClingDataMemberInfo.cxx
+++ b/core/metacling/src/TClingDataMemberInfo.cxx
@@ -354,8 +354,9 @@ Longptr_t TClingDataMemberInfo::Offset()
 
       if (Longptr_t addr = reinterpret_cast<Longptr_t>(fInterp->getAddressOfGlobal(GlobalDecl(VD))))
          return addr;
-      auto evalStmt = VD->ensureEvaluatedStmt();
-      if (evalStmt && evalStmt->Value) {
+      // We can't reassign constexpr or const variables. We can compute the
+      // initializer.
+      if (VD->hasInit() && (VD->isConstexpr() || VD->getType().isConstQualified())) {
          if (const APValue* val = VD->evaluateValue()) {
             if (VD->getType()->isIntegralType(C)) {
                return reinterpret_cast<Longptr_t>(val->getInt().getRawData());

--- a/core/metacling/src/TClingDataMemberInfo.cxx
+++ b/core/metacling/src/TClingDataMemberInfo.cxx
@@ -352,8 +352,6 @@ Longptr_t TClingDataMemberInfo::Offset()
       //   static constexpr Long64_t something = std::numeric_limits<Long64_t>::max();
       cling::Interpreter::PushTransactionRAII RAII(fInterp);
 
-      if (Longptr_t addr = reinterpret_cast<Longptr_t>(fInterp->getAddressOfGlobal(GlobalDecl(VD))))
-         return addr;
       // We can't reassign constexpr or const variables. We can compute the
       // initializer.
       if (VD->hasInit() && (VD->isConstexpr() || VD->getType().isConstQualified())) {
@@ -389,6 +387,10 @@ Longptr_t TClingDataMemberInfo::Offset()
             } // not integral type
          } // have an APValue
       } // have an initializing value
+
+      // Try the slow operation.
+      if (Longptr_t addr = reinterpret_cast<Longptr_t>(fInterp->getAddressOfGlobal(GlobalDecl(VD))))
+         return addr;
    }
    // FIXME: We have to explicitly check for not enum constant because the
    // implementation of getAddressOfGlobal relies on mangling the name and in


### PR DESCRIPTION
The llvm9 JIT issued callbacks when a symbol was missing and we reacted on it by loading the relevant library. In root-project/root@9b2041e3 we have kept the logic but now the JIT started querying more often even for symbols which are okay to be missing. In turn that leads to scanning all libraries causing performance issues.

This patch tries to limit this functionality only in contexts where automatic loading is allowed. In addition when computing the offsets of a constant variable declaration we compute the initializers instead of searching in the shared objects.