### PR TITLE
[RF][HS3] Fixes for ATLAS usecase

### DIFF
--- a/etc/RooFitHS3_wsfactoryexpressions.json
+++ b/etc/RooFitHS3_wsfactoryexpressions.json
@@ -51,6 +51,14 @@
             "sigma"
         ]
     },
+    "normal_dist": {
+        "class": "RooGaussian",
+        "arguments": [
+            "x",
+            "mean",
+            "sigma"
+        ]
+    },    
     "interpolation0d": {
         "class": "RooStats::HistFactory::FlexibleInterpVar",
         "arguments": [

--- a/roofit/histfactory/src/ParamHistFunc.cxx
+++ b/roofit/histfactory/src/ParamHistFunc.cxx
@@ -208,7 +208,11 @@ RooAbsReal& ParamHistFunc::getParameter( Int_t index ) const {
   const int j = tmp / n.z;
   const int k = tmp % n.z;
 
-  return static_cast<RooAbsReal&>(_paramSet[i + j * n.x + k * n.xy]);
+  const int idx = i + j * n.x + k * n.xy;
+  if (idx >= _numBins) {
+    throw std::runtime_error("invalid index");
+  }
+  return static_cast<RooAbsReal &>(_paramSet[idx]);
 }
 
 

--- a/roofit/hs3/src/Domains.h
+++ b/roofit/hs3/src/Domains.h
@@ -18,6 +18,7 @@
 #include <vector>
 
 class RooRealVar;
+class RooWorkspace;
 
 namespace RooFit {
 namespace Detail {
@@ -39,6 +40,8 @@ public:
    void readJSON(RooFit::Detail::JSONNode const &);
    void writeJSON(RooFit::Detail::JSONNode &) const;
 
+   void populate(RooWorkspace &ws) const;
+
 private:
    class ProductDomain {
    public:
@@ -47,6 +50,8 @@ private:
 
       void readJSON(RooFit::Detail::JSONNode const &);
       void writeJSON(RooFit::Detail::JSONNode &) const;
+
+      void populate(RooWorkspace &ws) const;
 
    private:
       struct ProductDomainElement {

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -93,7 +93,7 @@ tool.writedoc("hs3.tex")
 ~~~
 */
 
-constexpr auto hs3VersionTag = "0.1.90";
+constexpr auto hs3VersionTag = "0.2";
 
 using RooFit::Detail::JSONNode;
 using RooFit::Detail::JSONTree;
@@ -207,6 +207,9 @@ bool isValidName(const std::string &str)
  */
 void configureVariable(RooFit::JSONIO::Detail::Domains &domains, const JSONNode &p, RooRealVar &v)
 {
+   if (!p.has_child("name")) {
+      RooJSONFactoryWSTool::error("cannot instantiate variable without \"name\"!");
+   }
    if (auto n = p.find("value"))
       v.setVal(n->val_double());
    domains.writeVariable(v);
@@ -2072,6 +2075,7 @@ void RooJSONFactoryWSTool::importAllNodes(const JSONNode &n)
    if (auto domains = n.find("domains")) {
       _domains->readJSON(*domains);
    }
+   _domains->populate(_workspace);
 
    _rootnodeInput = &n;
 

--- a/roofit/jsoninterface/src/JSONParser.cxx
+++ b/roofit/jsoninterface/src/JSONParser.cxx
@@ -16,6 +16,17 @@
 
 #include <nlohmann/json.hpp>
 
+namespace {
+inline nlohmann::json parseWrapper(std::istream &is)
+{
+   try {
+      return nlohmann::json::parse(is);
+   } catch (const nlohmann::json::exception &ex) {
+      throw std::runtime_error(ex.what());
+   }
+}
+} // namespace
+
 // TJSONTree methods
 
 TJSONTree::TJSONTree() : root(this){};
@@ -70,7 +81,7 @@ class TJSONTree::Node::Impl::BaseNode : public TJSONTree::Node::Impl {
 public:
    nlohmann::json &get() override { return node; }
    const nlohmann::json &get() const override { return node; }
-   BaseNode(std::istream &is) : Impl(""), node(nlohmann::json::parse(is)) {}
+   BaseNode(std::istream &is) : Impl(""), node(parseWrapper(is)) {}
    BaseNode() : Impl("") {}
 };
 
@@ -107,8 +118,6 @@ TJSONTree::Node::Node(TJSONTree *t, Impl &other)
 }
 
 TJSONTree::Node::Node(const Node &other) : Node(other.tree, *other.node) {}
-
-TJSONTree::Node::~Node() {}
 
 // TJSONNode interface
 
@@ -200,7 +209,7 @@ TJSONTree::Node &TJSONTree::Node::set_map()
    if (isResettingPossible(node->get())) {
       node->get() = nlohmann::json::object();
    } else {
-      throw std::runtime_error("cannot declare " + this->key() + " to be of map-type, already of type " +
+      throw std::runtime_error("cannot declare \"" + this->key() + "\" to be of map - type, already of type " +
                                node->get().type_name());
    }
    return *this;
@@ -214,7 +223,7 @@ TJSONTree::Node &TJSONTree::Node::set_seq()
    if (isResettingPossible(node->get())) {
       node->get() = nlohmann::json::array();
    } else {
-      throw std::runtime_error("cannot declare " + this->key() + " to be of seq-type, already of type " +
+      throw std::runtime_error("cannot declare \"" + this->key() + "\" to be of seq - type, already of type " +
                                node->get().type_name());
    }
    return *this;
@@ -239,8 +248,8 @@ std::string TJSONTree::Node::val() const
    case nlohmann::json::value_t::number_unsigned: return std::to_string(node->get().get<unsigned int>());
    case nlohmann::json::value_t::number_float: return std::to_string(node->get().get<double>());
    default:
-      throw std::runtime_error(std::string("node " + node->key() + ": implicit string conversion for type " +
-                                           node->get().type_name() + " not supported!"));
+      throw std::runtime_error("node \"" + node->key() + "\": implicit string conversion for type " +
+                               node->get().type_name() + " not supported!");
    }
 }
 

--- a/roofit/jsoninterface/src/JSONParser.h
+++ b/roofit/jsoninterface/src/JSONParser.h
@@ -42,7 +42,7 @@ public:
       Node(TJSONTree *t, Impl &other);
       Node(TJSONTree *t);
       Node(const Node &other);
-      virtual ~Node();
+      virtual ~Node() = default;
       Node &operator<<(std::string const &s) override;
       Node &operator<<(int i) override;
       Node &operator<<(double d) override;


### PR DESCRIPTION
# This Pull request:

Fixes various small bugs, makes the implementation more robust and improves error reporting for JSON import of HS3 files.

## Changes or fixes:

 - errors from the nlohmann_json importer are now correctly forwarded to the user, rather than giving an unspecific "std_exception".
 - some missing keys or values no longer trigger segfaults, but instead lead to an actual error being emitted. this includes errors being emitted by ParamHistFuncs if the number of bins is incorrect.
 - the version tag has been correctly updated to 0.2
 - gaussians can now be imported with "normal_dist" as well, as described by the standard
 - the implementation is a bit more lenient when missing some values (e.g. ignoring cases where the histfactory modifier name has been omitted and instead just numbers the systematics)
 - the list of variables in the workspace is now no longer just filled from the parameter_points, but also from the domains, allowing cases where no parameter points are given to be imported successfully

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

