### PR TITLE
Remove unused Python modules from PyROOT/cppyy tests by backporting commit from cppyy

### DIFF
--- a/bindings/pyroot/cppyy/cppyy/test/bindexplib.py
+++ b/bindings/pyroot/cppyy/cppyy/test/bindexplib.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 
-import os, sys, subprocess
+import sys, subprocess
 
 target = sys.argv[1]
 output = sys.argv[2]
@@ -29,4 +29,3 @@ for line in stdout.split('\r\n'):
     elif parts[4] == '()' and parts[5] == 'External':
         if isokay(parts[7]):
             outf.write('\t%s\n' % parts[7])
-

--- a/bindings/pyroot/cppyy/cppyy/test/test_aclassloader.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_aclassloader.py
@@ -1,4 +1,4 @@
-import py, os, sys
+import py
 from pytest import raises
 from .support import setup_make
 

--- a/bindings/pyroot/cppyy/cppyy/test/test_advancedcpp.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_advancedcpp.py
@@ -1,4 +1,4 @@
-import py, os, sys
+import py
 from pytest import raises
 from .support import setup_make, pylong, IS_WINDOWS
 

--- a/bindings/pyroot/cppyy/cppyy/test/test_api.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_api.py
@@ -1,4 +1,4 @@
-import py, os, sys
+import py
 from pytest import raises
 
 try:

--- a/bindings/pyroot/cppyy/cppyy/test/test_boost.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_boost.py
@@ -1,4 +1,4 @@
-import py, os, sys
+import os
 from pytest import mark, raises
 from .support import setup_make
 
@@ -122,5 +122,3 @@ class TestBOOSTVARIANT:
         raises(Exception, boost.get['BV::B'], v[0])
         assert type(boost.get['BV::B'](v[1])) == cpp.BV.B
         assert type(boost.get['BV::C'](v[2])) == cpp.BV.C
-
-

--- a/bindings/pyroot/cppyy/cppyy/test/test_boost_any.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_boost_any.py
@@ -1,4 +1,4 @@
-import py, os, sys
+import py
 from pytest import raises
 from .support import setup_make
 

--- a/bindings/pyroot/cppyy/cppyy/test/test_conversions.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_conversions.py
@@ -1,4 +1,4 @@
-import py, os, sys
+import py
 from pytest import raises
 from .support import setup_make, pylong, pyunicode
 

--- a/bindings/pyroot/cppyy/cppyy/test/test_cpp11features.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_cpp11features.py
@@ -1,4 +1,4 @@
-import py, os, sys
+import py, sys
 from pytest import raises
 from .support import setup_make
 
@@ -128,7 +128,7 @@ class TestCPP11FEATURES:
 
     def test05_nullptr(self):
         """Allow the programmer to pass NULL in certain cases"""
-      
+
         import cppyy
 
       # test existence
@@ -136,7 +136,7 @@ class TestCPP11FEATURES:
       # assert not hasattr(cppyy.gbl, 'nullptr')
 
       # usage is tested in datatypes.py:test15_nullptr_passing
- 
+
     def test06_move(self):
         """Move construction, assignment, and methods"""
 

--- a/bindings/pyroot/cppyy/cppyy/test/test_crossinheritance.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_crossinheritance.py
@@ -1,4 +1,4 @@
-import py, os, sys
+import py
 from pytest import raises
 from .support import setup_make, pylong
 

--- a/bindings/pyroot/cppyy/cppyy/test/test_datatypes.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_datatypes.py
@@ -1,4 +1,4 @@
-import py, os, sys
+import py
 from pytest import raises
 from .support import setup_make, pylong, pyunicode
 
@@ -43,7 +43,7 @@ class TestDATATYPES:
 
         # reading integer types
         assert c.m_int8    == - 9; assert c.get_int8_cr()    == - 9; assert c.get_int8_r()    == - 9
-        assert c.m_uint8   ==   9; assert c.get_uint8_cr()   ==   9; assert c.get_uint8_r()   ==   9 
+        assert c.m_uint8   ==   9; assert c.get_uint8_cr()   ==   9; assert c.get_uint8_r()   ==   9
         if self.has_byte:
             assert c.m_byte == ord('d'); assert c.get_byte_cr() == ord('d'); assert c.get_byte_r() == ord('d')
         assert c.m_short   == -11; assert c.get_short_cr()   == -11; assert c.get_short_r()   == -11

--- a/bindings/pyroot/cppyy/cppyy/test/test_doc_features.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_doc_features.py
@@ -1,4 +1,4 @@
-import py, os, sys
+import py
 from pytest import raises
 from .support import setup_make
 
@@ -163,7 +163,7 @@ namespace Namespace {
 
         assert cppyy.gbl.gUint == 0
         raises(ValueError, setattr, cppyy.gbl, 'gUint', -1)
-        
+
     def test_casting(self):
         import cppyy
         from cppyy.gbl import Abstract, Concrete
@@ -293,9 +293,9 @@ namespace Namespace {
 
     def test_operator_overloads(self):
         import cppyy
-        
+
         pass
-        
+
     def test_pointers(self):
         import cppyy
 

--- a/bindings/pyroot/cppyy/cppyy/test/test_eigen.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_eigen.py
@@ -1,4 +1,4 @@
-import py, os, sys
+import os
 from pytest import mark, raises
 from .support import setup_make
 
@@ -133,7 +133,7 @@ class TestEIGEN:
 
         import cppyy
 
-        a = cppyy.gbl.Eigen.MatrixXf(2, 2) 
+        a = cppyy.gbl.Eigen.MatrixXf(2, 2)
         assert a.size() == 4
         b = cppyy.gbl.Eigen.MatrixXf(3, 3)
         assert b.size() == 9

--- a/bindings/pyroot/cppyy/cppyy/test/test_fragile.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_fragile.py
@@ -1,4 +1,4 @@
-import py, os, sys
+import py, os
 from pytest import raises
 from .support import setup_make, IS_WINDOWS
 

--- a/bindings/pyroot/cppyy/cppyy/test/test_lowlevel.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_lowlevel.py
@@ -1,4 +1,4 @@
-import py, os, sys
+import py, sys
 from pytest import raises
 from .support import setup_make, pylong, pyunicode, IS_WINDOWS
 

--- a/bindings/pyroot/cppyy/cppyy/test/test_operators.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_operators.py
@@ -1,4 +1,4 @@
-import py, os, sys
+import py
 from pytest import raises
 from .support import setup_make, pylong, maxvalue
 
@@ -170,7 +170,7 @@ class TestOPERATORS:
         assert d1 == b1
         assert not b1 == d2
         assert not d2 == b1
-        
+
     def test08_call_to_getsetitem_mapping(self):
         """Map () to []"""
 

--- a/bindings/pyroot/cppyy/cppyy/test/test_overloads.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_overloads.py
@@ -1,4 +1,4 @@
-import py, os, sys
+import py
 from pytest import raises
 from .support import setup_make
 

--- a/bindings/pyroot/cppyy/cppyy/test/test_pythonify.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_pythonify.py
@@ -1,4 +1,4 @@
-import py, os, sys
+import py
 from pytest import raises
 from .support import setup_make, pylong
 
@@ -99,7 +99,7 @@ class TestPYTHONIFY:
         instance = example01_class(-13)
         res = instance.addDataToDouble(16)
         assert round(res-3, 8) == 0.
-        instance.__destruct__() 
+        instance.__destruct__()
 
         instance = example01_class(42)
         assert example01_class.getCount() == 1
@@ -452,7 +452,7 @@ class TestPYTHONIFY:
             b = B(17, val=23, out_A=(78,))
 
         with raises(TypeError):
-            b = B(17, out_A=(78,)) 
+            b = B(17, out_A=(78,))
 
       # global function with keywords
         callme = cppyy.gbl.KeyWords.callme

--- a/bindings/pyroot/cppyy/cppyy/test/test_pythonization.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_pythonization.py
@@ -1,4 +1,4 @@
-import py, os, sys
+import py, sys
 from pytest import raises
 from .support import setup_make, pylong
 

--- a/bindings/pyroot/cppyy/cppyy/test/test_stltypes.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_stltypes.py
@@ -1,5 +1,5 @@
 # -*- coding: UTF-8 -*-
-import py, os, sys
+import py
 from pytest import raises
 from .support import setup_make, pylong, pyunicode, maxvalue
 
@@ -228,7 +228,7 @@ class TestSTLVECTOR:
             assert tv1 is tv2
             assert tv1.iterator is cppyy.gbl.std.vector(p_type).iterator
 
-            #----- 
+            #-----
             v = tv1()
             assert not v
             v += range(self.N)

--- a/bindings/pyroot/cppyy/cppyy/test/test_streams.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_streams.py
@@ -1,4 +1,4 @@
-import py, os, sys
+import py
 from pytest import raises
 from .support import setup_make
 

--- a/bindings/pyroot/cppyy/cppyy/test/test_templates.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_templates.py
@@ -1,4 +1,4 @@
-import py, os, sys
+import py, sys
 from pytest import raises
 from .support import setup_make, pylong
 


### PR DESCRIPTION
# This Pull request:

This pull request removes unused Python modules (sys, os, py) from PyROOT/cppyy tests. The modules were imported in certain files, but they were not actually referenced in the code.

## Changes or fixes:

Changes PyROOT/cppyy test files by removing unused Python modules.

## Checklist:
[CTestCostData.txt](https://github.com/root-project/root/files/13743203/CTestCostData.txt)

- [X] tested changes locally
- [ ] updated the docs (if necessary)
[LastTest.log.gz](https://github.com/root-project/root/files/13743200/LastTest.log.gz)
