### PR TITLE
[v622] Backport some PyROOT fixes

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/inc/CPyCppyy/API.h
+++ b/bindings/pyroot/cppyy/CPyCppyy/inc/CPyCppyy/API.h
@@ -99,7 +99,7 @@ public:
     virtual PyObject* FromMemory(void* address);
 
 // convert a Python object to a C++ object and store it on address
-    virtual bool ToMemory(PyObject* value, void* address);
+    virtual bool ToMemory(PyObject* value, void* address, PyObject* ctxt = nullptr);
 
 // if a converter has state, it will be unique per function, shared otherwise
     virtual bool HasState() { return false; }

--- a/bindings/pyroot/cppyy/CPyCppyy/src/API.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/API.cxx
@@ -51,7 +51,9 @@ static bool Initialize()
 #endif
         Py_Initialize();
 #if PY_VERSION_HEX >= 0x03020000
-        PyEval_InitThreads();
+#if PY_VERSION_HEX < 0x03090000
+	PyEval_InitThreads();
+#endif
 #endif
 
     // try again to see if the interpreter is initialized

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPConstructor.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPConstructor.cxx
@@ -122,7 +122,7 @@ PyObject* CPyCppyy::CPPConstructor::Call(
             if (pyclass) {
                 self->SetSmart((PyObject*)Py_TYPE(self));
                 Py_DECREF((PyObject*)Py_TYPE(self));
-                Py_TYPE(self) = (PyTypeObject*)pyclass;
+                Py_SET_TYPE(self, (PyTypeObject*)pyclass);
             }
         }
 

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPConstructor.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPConstructor.cxx
@@ -5,6 +5,7 @@
 #include "Executors.h"
 #include "MemoryRegulator.h"
 #include "ProxyWrappers.h"
+#include "PyStrings.h"
 
 #include "CPyCppyy/DispatchPtr.h"
 
@@ -83,10 +84,9 @@ PyObject* CPyCppyy::CPPConstructor::Call(
         address = (ptrdiff_t)((CPPInstance*)pyobj)->GetObject();
         if (address) {
             ((CPPInstance*)pyobj)->CppOwns();
-            PyObject* pyoff = PyObject_CallMethod(dispproxy, (char*)"_dispatchptr_offset", nullptr);
-            size_t disp_offset = PyLong_AsSsize_t(pyoff);
-            Py_DECREF(pyoff);
-            new ((void*)(address + disp_offset)) DispatchPtr{(PyObject*)self};
+            PyObject* res = PyObject_CallMethodObjArgs(
+            dispproxy, PyStrings::gDispInit, pyobj, (PyObject*)self, nullptr);
+            Py_XDECREF(res);
         }
         Py_DECREF(pyobj);
         Py_DECREF(dispproxy);

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPDataMember.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPDataMember.cxx
@@ -122,7 +122,7 @@ static int pp_set(CPPDataMember* pyprop, CPPInstance* pyobj, PyObject* value)
         ptr = &address;
 
 // actual conversion; return on success
-    if (pyprop->fConverter && pyprop->fConverter->ToMemory(value, ptr))
+    if (pyprop->fConverter && pyprop->fConverter->ToMemory(value, ptr, (PyObject*)pyobj))
         return 0;
 
 // set a python error, if not already done

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPMethod.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPMethod.cxx
@@ -575,7 +575,7 @@ PyObject* CPyCppyy::CPPMethod::ProcessKeywords(PyObject* self, PyObject* args, P
 // set all values to zero to be able to check them later (this also guarantees normal
 // cleanup by the tuple deallocation)
     for (Py_ssize_t i = 0; i < nArgs+nKeys; ++i)
-        PyTuple_SET_ITEM(newArgs, i, nullptr);
+        PyTuple_SET_ITEM(newArgs, i, static_cast<PyObject*>(nullptr));
 
 // next, insert the keyword values
     PyObject *key, *value;

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPOverload.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPOverload.cxx
@@ -159,7 +159,7 @@ static inline PyObject* HandleReturn(
         }
 
     // if this new object falls inside self, make sure its lifetime is proper
-        if (pymeth->fMethodInfo->fFlags & CallContext::kSetLifeline)
+        if (pymeth->fMethodInfo->fFlags & CallContext::kSetLifeLine)
             ll_action = 1;
         else if (!(pymeth->fMethodInfo->fFlags & CallContext::kNeverLifeLine) && \
                  CPPInstance_Check(pymeth->fSelf) && CPPInstance_Check(result)) {
@@ -191,7 +191,7 @@ static inline PyObject* HandleReturn(
         if (ll_action == 1 /* directly set */ && CPPInstance_Check(result))
             ((CPPInstance*)result)->fFlags |= CPPInstance::kHasLifeline;   // for chaining
         else
-            pymeth->fMethodInfo->fFlags |= CallContext::kSetLifeline;      // for next time
+            pymeth->fMethodInfo->fFlags |= CallContext::kSetLifeLine;      // for next time
     }
 
 // reset self as necessary to allow re-use of the CPPOverload
@@ -490,7 +490,7 @@ static int mp_set##name(CPPOverload* pymeth, PyObject* value, void*) {       \
     return set_flag(pymeth, value, flag, label);                             \
 }
 
-CPPYY_BOOLEAN_PROPERTY(lifeline, CallContext::kSetLifeline, "__set_lifeline__")
+CPPYY_BOOLEAN_PROPERTY(lifeline, CallContext::kSetLifeLine, "__set_lifeline__")
 CPPYY_BOOLEAN_PROPERTY(threaded, CallContext::kReleaseGIL,  "__release_gil__")
 CPPYY_BOOLEAN_PROPERTY(useffi,   CallContext::kUseFFI,      "__useffi__")
 CPPYY_BOOLEAN_PROPERTY(sig2exc,  CallContext::kProtected,   "__sig2exc__")
@@ -549,6 +549,7 @@ static PyObject* mp_call(CPPOverload* pymeth, PyObject* args, PyObject* kwds)
     ctxt.fFlags |= (mflags & CallContext::kReleaseGIL);
     ctxt.fFlags |= (mflags & CallContext::kProtected);
     if (IsConstructor(pymeth->fMethodInfo->fFlags)) ctxt.fFlags |= CallContext::kIsConstructor;
+    ctxt.fPyContext = (PyObject*)pymeth->fSelf;  // no Py_INCREF as no ownership
 
 // magic variable to prevent recursion passed by keyword?
     if (kwds && PyDict_CheckExact(kwds) && PyDict_Size(kwds) != 0) {

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPOverload.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPOverload.cxx
@@ -1,10 +1,10 @@
 // Bindings
 #include "CPyCppyy.h"
 #include "structmember.h"    // from Python
-#if PY_VERSION_HEX >= 0x02050000
-#include "code.h"            // from Python
-#else
+#if PY_VERSION_HEX < 0x02050000
 #include "compile.h"         // from Python
+#elif PY_VERSION_HEX < 0x030b0000
+#include "code.h"            // from Python
 #endif
 #ifndef CO_NOFREE
 // python2.2 does not have CO_NOFREE defined

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPScope.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPScope.cxx
@@ -254,9 +254,10 @@ static PyObject* pt_new(PyTypeObject* subtype, PyObject* args, PyObject* kwds)
             Py_ssize_t sz = PyDict_Size(dct);
             if (0 < sz && !Cppyy::IsNamespace(result->fCppType)) {
                 result->fFlags |= CPPScope::kIsPython;
-                if (!InsertDispatcher(result, dct)) {
-                    if (!PyErr_Occurred())
-                         PyErr_Warn(PyExc_RuntimeWarning, (char*)"no python-side overrides supported");
+                std::ostringstream errmsg;
+                if (!InsertDispatcher(result, PyTuple_GET_ITEM(args, 1), dct, errmsg)) {
+                    PyErr_Format(PyExc_TypeError, "no python-side overrides supported (%s)", errmsg.str().c_str());
+                    return nullptr;
                 } else {
                 // the direct base can be useful for some templates, such as shared_ptrs,
                 // so make it accessible (the __cpp_cross__ data member also signals that

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyy.h
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyy.h
@@ -304,6 +304,13 @@ inline Py_ssize_t PyNumber_AsSsize_t(PyObject* obj, PyObject*) {
 #define CPyCppyy_PyCFunction_Call PyCFunction_Call
 #endif
 
+// Py_TYPE is changed to an inline static function in 3.11
+#if PY_VERSION_HEX < 0x030900A4 && !defined(Py_SET_TYPE)
+static inline
+void _Py_SET_TYPE(PyObject *ob, PyTypeObject *type) { ob->ob_type = type; }
+#define Py_SET_TYPE(ob, type) _Py_SET_TYPE((PyObject*)(ob), type)
+#endif
+
 // C++ version of the cppyy API
 #include "Cppyy.h"
 

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyy.h
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyy.h
@@ -114,6 +114,8 @@ static inline const char* CPyCppyy_PyText_AsStringAndSize(PyObject* pystr, Py_ss
 
 #define CPyCppyy_PyText_Type PyString_Type
 
+#define CPyCppyy_PyUnicode_GET_SIZE           PyUnicode_GET_SIZE
+
 static inline PyObject* CPyCppyy_PyCapsule_New(
         void* cobj, const char* /* name */, void (*destr)(void*))
 {
@@ -141,7 +143,13 @@ typedef long Py_hash_t;
 #define CPyCppyy_PyText_AsString           PyUnicode_AsUTF8
 #define CPyCppyy_PyText_AsStringChecked    PyUnicode_AsUTF8
 #define CPyCppyy_PyText_GetSize            PyUnicode_GetSize
+#if PY_VERSION_HEX < 0x03090000
 #define CPyCppyy_PyText_GET_SIZE           PyUnicode_GET_SIZE
+#define CPyCppyy_PyUnicode_GET_SIZE        PyUnicode_GET_LENGTH
+#else
+#define CPyCppyy_PyText_GET_SIZE           PyUnicode_GET_LENGTH
+#define CPyCppyy_PyUnicode_GET_SIZE        PyUnicode_GET_LENGTH
+#endif
 #define CPyCppyy_PyText_FromFormat         PyUnicode_FromFormat
 #define CPyCppyy_PyText_FromString         PyUnicode_FromString
 #define CPyCppyy_PyText_InternFromString   PyUnicode_InternFromString
@@ -287,6 +295,13 @@ inline Py_ssize_t PyNumber_AsSsize_t(PyObject* obj, PyObject*) {
 
 #ifndef Py_RETURN_FALSE
 #define Py_RETURN_FALSE return Py_INCREF(Py_False), Py_False
+#endif
+
+// vector call support
+#if PY_VERSION_HEX >= 0x03090000
+#define CPyCppyy_PyCFunction_Call PyObject_Call
+#else
+#define CPyCppyy_PyCFunction_Call PyCFunction_Call
 #endif
 
 // C++ version of the cppyy API

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyyModule.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyyModule.cxx
@@ -810,7 +810,9 @@ LIBCPPYY_INIT_FUNCTION(extern "C" void initlibcppyy, PY_MAJOR_VERSION, _, PY_MIN
         CPYCPPYY_INIT_ERROR;
 
 // setup interpreter
+#if PY_VERSION_HEX < 0x03090000
     PyEval_InitThreads();
+#endif
 
 // prepare for lazyness (the insert is needed to capture the most generic lookup
 // function, just in case ...)

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CallContext.h
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CallContext.h
@@ -43,7 +43,8 @@ struct Parameter {
 
 // extra call information
 struct CallContext {
-    CallContext() : fFlags(0), fCurScope(0), fArgsVec(nullptr), fNArgs(0), fTemps(nullptr) {}
+    CallContext() : fFlags(0), fCurScope(0), fPyContext(nullptr),
+        fArgsVec(nullptr), fNArgs(0), fTemps(nullptr) {}
     CallContext(const CallContext&) = delete;
     CallContext& operator=(const CallContext&) = delete;
     ~CallContext() { if (fTemps) Cleanup(); delete fArgsVec; }
@@ -59,7 +60,7 @@ struct CallContext {
         kUseHeuristics  = 0x0040, // if method applies heuristics memory policy
         kUseStrict      = 0x0080, // if method applies strict memory policy
         kReleaseGIL     = 0x0100, // if method should release the GIL
-        kSetLifeline    = 0x0200, // if return value is part of 'this'
+        kSetLifeLine    = 0x0200, // if return value is part of 'this'
         kNeverLifeLine  = 0x0400, // if the return value is never part of 'this'
         kProtected      = 0x0800, // if method should return on signals
         kUseFFI         = 0x1000, // not implemented
@@ -96,6 +97,7 @@ public:
 // info/status
     uint64_t fFlags;
     Cppyy::TCppScope_t fCurScope;
+    PyObject* fPyContext; // used to set lifelines
 
 private:
 // payload

--- a/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
@@ -757,7 +757,7 @@ bool CPyCppyy::WCharConverter::SetArg(
     PyObject* pyobject, Parameter& para, CallContext* /* ctxt */)
 {
 // convert <pyobject> to C++ <wchar_t>, set arg for call
-    if (!PyUnicode_Check(pyobject) || PyUnicode_GET_SIZE(pyobject) != 1) {
+    if (!PyUnicode_Check(pyobject) || CPyCppyy_PyUnicode_GET_SIZE(pyobject) != 1) {
         PyErr_SetString(PyExc_ValueError, "single wchar_t character expected");
         return false;
     }
@@ -777,7 +777,7 @@ PyObject* CPyCppyy::WCharConverter::FromMemory(void* address)
 
 bool CPyCppyy::WCharConverter::ToMemory(PyObject* value, void* address, PyObject* /* ctxt */)
 {
-    if (!PyUnicode_Check(value) || PyUnicode_GET_SIZE(value) != 1) {
+    if (!PyUnicode_Check(value) || CPyCppyy_PyUnicode_GET_SIZE(value) != 1) {
         PyErr_SetString(PyExc_ValueError, "single wchar_t character expected");
         return false;
     }
@@ -794,7 +794,7 @@ bool CPyCppyy::Char16Converter::SetArg(
     PyObject* pyobject, Parameter& para, CallContext* /* ctxt */)
 {
 // convert <pyobject> to C++ <char16_t>, set arg for call
-    if (!PyUnicode_Check(pyobject) || PyUnicode_GET_SIZE(pyobject) != 1) {
+    if (!PyUnicode_Check(pyobject) || CPyCppyy_PyUnicode_GET_SIZE(pyobject) != 1) {
         PyErr_SetString(PyExc_ValueError, "single char16_t character expected");
         return false;
     }
@@ -816,7 +816,7 @@ PyObject* CPyCppyy::Char16Converter::FromMemory(void* address)
 
 bool CPyCppyy::Char16Converter::ToMemory(PyObject* value, void* address, PyObject* /* ctxt */)
 {
-    if (!PyUnicode_Check(value) || PyUnicode_GET_SIZE(value) != 1) {
+    if (!PyUnicode_Check(value) || CPyCppyy_PyUnicode_GET_SIZE(value) != 1) {
         PyErr_SetString(PyExc_ValueError, "single char16_t character expected");
         return false;
     }
@@ -834,7 +834,7 @@ bool CPyCppyy::Char32Converter::SetArg(
     PyObject* pyobject, Parameter& para, CallContext* /* ctxt */)
 {
 // convert <pyobject> to C++ <char32_t>, set arg for call
-    if (!PyUnicode_Check(pyobject) || 2 < PyUnicode_GET_SIZE(pyobject)) {
+    if (!PyUnicode_Check(pyobject) || 2 < CPyCppyy_PyUnicode_GET_SIZE(pyobject)) {
         PyErr_SetString(PyExc_ValueError, "single char32_t character expected");
         return false;
     }
@@ -856,7 +856,7 @@ PyObject* CPyCppyy::Char32Converter::FromMemory(void* address)
 
 bool CPyCppyy::Char32Converter::ToMemory(PyObject* value, void* address, PyObject* /* ctxt */)
 {
-    if (!PyUnicode_Check(value) || 2 < PyUnicode_GET_SIZE(value)) {
+    if (!PyUnicode_Check(value) || 2 < CPyCppyy_PyUnicode_GET_SIZE(value)) {
         PyErr_SetString(PyExc_ValueError, "single char32_t character expected");
         return false;
     }
@@ -1711,7 +1711,7 @@ bool CPyCppyy::STLWStringConverter::SetArg(
     PyObject* pyobject, Parameter& para, CallContext* ctxt)
 {
     if (PyUnicode_Check(pyobject)) {
-        Py_ssize_t len = PyUnicode_GET_SIZE(pyobject);
+        Py_ssize_t len = CPyCppyy_PyUnicode_GET_SIZE(pyobject);
         fBuffer.resize(len);
         CPyCppyy_PyUnicode_AsWideChar(pyobject, &fBuffer[0], len);
         para.fValue.fVoidp = &fBuffer;
@@ -1739,7 +1739,7 @@ PyObject* CPyCppyy::STLWStringConverter::FromMemory(void* address)
 bool CPyCppyy::STLWStringConverter::ToMemory(PyObject* value, void* address, PyObject* ctxt)
 {
     if (PyUnicode_Check(value)) {
-        Py_ssize_t len = PyUnicode_GET_SIZE(value);
+        Py_ssize_t len = CPyCppyy_PyUnicode_GET_SIZE(value);
         wchar_t* buf = new wchar_t[len+1];
         CPyCppyy_PyUnicode_AsWideChar(value, buf, len);
         *((std::wstring*)address) = std::wstring(buf, len);

--- a/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
@@ -172,8 +172,8 @@ static bool IsPyCArgObject(PyObject* pyobject)
              Py_DECREF(byref); Py_DECREF(cobj); Py_DECREF(ct_t);
              pycarg_type = Py_TYPE(pyptr);  // static, no ref-count needed
              Py_DECREF(pyptr);
+             Py_DECREF(ctmod);
         }
-        Py_DECREF(ctmod);
     }
     return Py_TYPE(pyobject) == pycarg_type;
 }
@@ -2764,7 +2764,8 @@ CPyCppyy::Converter* CPyCppyy::CreateConverter(const std::string& fullType, dims
 
                 return new StdFunctionConverter(cnv,
                     resolvedType.substr(pos+9, sz1), resolvedType.substr(pos1, pos2-pos1+1));
-            }
+            } else if (cnv->HasState())
+                delete cnv;
         }
     }
 

--- a/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
@@ -196,6 +196,22 @@ static bool IsCTypesArrayOrPointer(PyObject* pyobject)
 }
 
 
+//- helper to establish life lines -------------------------------------------
+static inline bool SetLifeLine(PyObject* holder, PyObject* target, intptr_t ref)
+{
+// set a lifeline from on the holder to the target, using the ref as label
+    if (!holder) return false;
+
+// 'ref' is expected to be the converter address or data memory location, so
+// that the combination of holder and ref is unique, but also identifiable for
+// reuse when the C++ side is being overwritten
+    std::ostringstream attr_name;
+    attr_name << "__" << ref;
+    auto attr_name_str = attr_name.str();
+    auto res = PyObject_SetAttrString(holder, attr_name_str.c_str(), target);
+    return res != -1;
+}
+
 //- helper to work with both CPPInstance and CPPExcInstance ------------------
 static inline CPyCppyy::CPPInstance* GetCppInstance(PyObject* pyobject)
 {
@@ -427,7 +443,7 @@ PyObject* CPyCppyy::Converter::FromMemory(void*)
 }
 
 //----------------------------------------------------------------------------
-bool CPyCppyy::Converter::ToMemory(PyObject*, void*)
+bool CPyCppyy::Converter::ToMemory(PyObject*, void*, PyObject* /* ctxt */)
 {
 // could happen if no derived class override
     PyErr_SetString(PyExc_TypeError, "C++ type cannot be converted to memory");
@@ -466,7 +482,8 @@ PyObject* CPyCppyy::name##Converter::FromMemory(void* address)               \
     return F1((stype)*((type*)address));                                     \
 }                                                                            \
                                                                              \
-bool CPyCppyy::name##Converter::ToMemory(PyObject* value, void* address)     \
+bool CPyCppyy::name##Converter::ToMemory(PyObject* value, void* address,     \
+    PyObject* /* ctxt */)                                                    \
 {                                                                            \
     type s = (type)F2(value);                                                \
     if (s == (type)-1 && PyErr_Occurred())                                   \
@@ -566,7 +583,8 @@ PyObject* CPyCppyy::name##Converter::FromMemory(void* address)               \
     return CPyCppyy_PyText_FromFormat("%c", *((type*)address));              \
 }                                                                            \
                                                                              \
-bool CPyCppyy::name##Converter::ToMemory(PyObject* value, void* address)     \
+bool CPyCppyy::name##Converter::ToMemory(PyObject* value, void* address,     \
+    PyObject* /* ctxt */)                                                    \
 {                                                                            \
     Py_ssize_t len;                                                          \
     const char* cstr = CPyCppyy_PyText_AsStringAndSize(value, &len);         \
@@ -757,7 +775,7 @@ PyObject* CPyCppyy::WCharConverter::FromMemory(void* address)
     return PyUnicode_FromWideChar((const wchar_t*)address, 1);
 }
 
-bool CPyCppyy::WCharConverter::ToMemory(PyObject* value, void* address)
+bool CPyCppyy::WCharConverter::ToMemory(PyObject* value, void* address, PyObject* /* ctxt */)
 {
     if (!PyUnicode_Check(value) || PyUnicode_GET_SIZE(value) != 1) {
         PyErr_SetString(PyExc_ValueError, "single wchar_t character expected");
@@ -796,7 +814,7 @@ PyObject* CPyCppyy::Char16Converter::FromMemory(void* address)
     return PyUnicode_DecodeUTF16((const char*)address, sizeof(char16_t), nullptr, nullptr);
 }
 
-bool CPyCppyy::Char16Converter::ToMemory(PyObject* value, void* address)
+bool CPyCppyy::Char16Converter::ToMemory(PyObject* value, void* address, PyObject* /* ctxt */)
 {
     if (!PyUnicode_Check(value) || PyUnicode_GET_SIZE(value) != 1) {
         PyErr_SetString(PyExc_ValueError, "single char16_t character expected");
@@ -836,7 +854,7 @@ PyObject* CPyCppyy::Char32Converter::FromMemory(void* address)
     return PyUnicode_DecodeUTF32((const char*)address, sizeof(char32_t), nullptr, nullptr);
 }
 
-bool CPyCppyy::Char32Converter::ToMemory(PyObject* value, void* address)
+bool CPyCppyy::Char32Converter::ToMemory(PyObject* value, void* address, PyObject* /* ctxt */)
 {
     if (!PyUnicode_Check(value) || 2 < PyUnicode_GET_SIZE(value)) {
         PyErr_SetString(PyExc_ValueError, "single char32_t character expected");
@@ -881,7 +899,7 @@ PyObject* CPyCppyy::ULongConverter::FromMemory(void* address)
     return PyLong_FromUnsignedLong(*((unsigned long*)address));
 }
 
-bool CPyCppyy::ULongConverter::ToMemory(PyObject* value, void* address)
+bool CPyCppyy::ULongConverter::ToMemory(PyObject* value, void* address, PyObject* /* ctxt */)
 {
 // convert <value> to C++ unsigned long, write it at <address>
     unsigned long u = PyLongOrInt_AsULong(value);
@@ -898,7 +916,7 @@ PyObject* CPyCppyy::UIntConverter::FromMemory(void* address)
     return PyLong_FromUnsignedLong(*((UInt_t*)address));
 }
 
-bool CPyCppyy::UIntConverter::ToMemory(PyObject* value, void* address)
+bool CPyCppyy::UIntConverter::ToMemory(PyObject* value, void* address, PyObject* /* ctxt */)
 {
 // convert <value> to C++ unsigned int, write it at <address>
     ULong_t u = PyLongOrInt_AsULong(value);
@@ -948,7 +966,7 @@ PyObject* CPyCppyy::ComplexDConverter::FromMemory(void* address)
     return PyComplex_FromDoubles(dc->real(), dc->imag());
 }
 
-bool CPyCppyy::ComplexDConverter::ToMemory(PyObject* value, void* address)
+bool CPyCppyy::ComplexDConverter::ToMemory(PyObject* value, void* address, PyObject* ctxt)
 {
     const Py_complex& pc = PyComplex_AsCComplex(value);
     if (pc.real != -1.0 || !PyErr_Occurred()) {
@@ -957,7 +975,7 @@ bool CPyCppyy::ComplexDConverter::ToMemory(PyObject* value, void* address)
          dc->imag(pc.imag);
          return true;
     }
-    return this->InstanceConverter::ToMemory(value, address);
+    return this->InstanceConverter::ToMemory(value, address, ctxt);
 }
 
 //----------------------------------------------------------------------------
@@ -1024,7 +1042,7 @@ PyObject* CPyCppyy::LLongConverter::FromMemory(void* address)
     return PyLong_FromLongLong(*(Long64_t*)address);
 }
 
-bool CPyCppyy::LLongConverter::ToMemory(PyObject* value, void* address)
+bool CPyCppyy::LLongConverter::ToMemory(PyObject* value, void* address, PyObject* /* ctxt */)
 {
 // convert <value> to C++ long long, write it at <address>
     Long64_t ll = PyLong_AsLongLong(value);
@@ -1052,7 +1070,7 @@ PyObject* CPyCppyy::ULLongConverter::FromMemory(void* address)
     return PyLong_FromUnsignedLongLong(*(ULong64_t*)address);
 }
 
-bool CPyCppyy::ULLongConverter::ToMemory(PyObject* value, void* address)
+bool CPyCppyy::ULLongConverter::ToMemory(PyObject* value, void* address, PyObject* /* ctxt */)
 {
 // convert <value> to C++ unsigned long long, write it at <address>
     Long64_t ull = PyLongOrInt_AsULong64(value);
@@ -1114,7 +1132,7 @@ PyObject* CPyCppyy::CStringConverter::FromMemory(void* address)
     return PyStrings::gEmptyString;
 }
 
-bool CPyCppyy::CStringConverter::ToMemory(PyObject* value, void* address)
+bool CPyCppyy::CStringConverter::ToMemory(PyObject* value, void* address, PyObject* /* ctxt */)
 {
 // convert <value> to C++ const char*, write it at <address>
     Py_ssize_t len;
@@ -1170,7 +1188,7 @@ PyObject* CPyCppyy::WCStringConverter::FromMemory(void* address)
     return PyUnicode_FromWideChar(&w, 0);
 }
 
-bool CPyCppyy::WCStringConverter::ToMemory(PyObject* value, void* address)
+bool CPyCppyy::WCStringConverter::ToMemory(PyObject* value, void* address, PyObject* /* ctxt */)
 {
 // convert <value> to C++ wchar_t*, write it at <address>
     Py_ssize_t len = PyUnicode_GetSize(value);
@@ -1231,7 +1249,7 @@ PyObject* CPyCppyy::CString16Converter::FromMemory(void* address)
     return PyUnicode_DecodeUTF16((const char*)&w, 0, nullptr, nullptr);
 }
 
-bool CPyCppyy::CString16Converter::ToMemory(PyObject* value, void* address)
+bool CPyCppyy::CString16Converter::ToMemory(PyObject* value, void* address, PyObject* /* ctxt */)
 {
 // convert <value> to C++ char16_t*, write it at <address>
     Py_ssize_t len = PyUnicode_GetSize(value);
@@ -1292,7 +1310,7 @@ PyObject* CPyCppyy::CString32Converter::FromMemory(void* address)
     return PyUnicode_DecodeUTF32((const char*)&w, 0, nullptr, nullptr);
 }
 
-bool CPyCppyy::CString32Converter::ToMemory(PyObject* value, void* address)
+bool CPyCppyy::CString32Converter::ToMemory(PyObject* value, void* address, PyObject* /* ctxt */)
 {
 // convert <value> to C++ char32_t*, write it at <address>
     Py_ssize_t len = PyUnicode_GetSize(value);
@@ -1433,7 +1451,7 @@ PyObject* CPyCppyy::VoidArrayConverter::FromMemory(void* address)
 }
 
 //----------------------------------------------------------------------------
-bool CPyCppyy::VoidArrayConverter::ToMemory(PyObject* value, void* address)
+bool CPyCppyy::VoidArrayConverter::ToMemory(PyObject* value, void* address, PyObject* /* ctxt */)
 {
 // just convert pointer if it is a C++ object
     CPPInstance* pyobj = GetCppInstance(value);
@@ -1464,50 +1482,66 @@ bool CPyCppyy::VoidArrayConverter::ToMemory(PyObject* value, void* address)
     return true;
 }
 
+
+//----------------------------------------------------------------------------
+static inline void init_shape(Py_ssize_t defdim, dims_t dims, Py_ssize_t*& shape)
+{
+    int nalloc = (dims && 0 < dims[0]) ? (int)dims[0]+1: defdim+1;
+    shape = new Py_ssize_t[nalloc];
+    if (dims) {
+        for (int i = 0; i < nalloc; ++i)
+            shape[i] = (Py_ssize_t)dims[i];
+    } else {
+        shape[0] = defdim;
+        for (int i = 1; i < nalloc; ++i) shape[i] = UNKNOWN_SIZE;
+    }
+}
+
 //----------------------------------------------------------------------------
 #define CPPYY_IMPL_ARRAY_CONVERTER(name, ctype, type, code)                  \
-CPyCppyy::name##ArrayConverter::name##ArrayConverter(dims_t dims) {          \
-    int nalloc = (dims && 0 < dims[0]) ? (int)dims[0]+1: 2;                  \
-    fShape = new Py_ssize_t[nalloc];                                         \
-    if (dims) {                                                              \
-        for (int i = 0; i < nalloc; ++i) fShape[i] = (Py_ssize_t)dims[i];    \
-    } else {                                                                 \
-        fShape[0] = 1; fShape[1] = -1;                                       \
-    }                                                                        \
+CPyCppyy::name##ArrayConverter::name##ArrayConverter(dims_t dims, bool init) {\
+    if (init) {                                                              \
+        init_shape(1, dims, fShape);                                         \
+        fIsFixed = fShape[1] != UNKNOWN_SIZE;                                \
+    } else fIsFixed = false;                                                 \
 }                                                                            \
                                                                              \
 bool CPyCppyy::name##ArrayConverter::SetArg(                                 \
-    PyObject* pyobject, Parameter& para, CallContext* /* ctxt */)            \
+    PyObject* pyobject, Parameter& para, CallContext* ctxt)                  \
 {                                                                            \
     /* filter ctypes first b/c their buffer conversion will be wrong */      \
+    bool res = false;                                                        \
     PyTypeObject* ctypes_type = GetCTypesType(ct_##ctype);                   \
     if (Py_TYPE(pyobject) == ctypes_type) {                                  \
         para.fValue.fVoidp = (void*)((CPyCppyy_tagCDataObject*)pyobject)->b_ptr;\
         para.fTypeCode = 'p';                                                \
-        return true;                                                         \
+        res = true;                                                          \
     } else if (Py_TYPE(pyobject) == GetCTypesPtrType(ct_##ctype)) {          \
         para.fValue.fVoidp = (void*)((CPyCppyy_tagCDataObject*)pyobject)->b_ptr;\
         para.fTypeCode = 'V';                                                \
-        return true;                                                         \
+        res = true;                                                          \
     } else if (IsPyCArgObject(pyobject)) {                                   \
         CPyCppyy_tagPyCArgObject* carg = (CPyCppyy_tagPyCArgObject*)pyobject;\
         if (carg->obj && Py_TYPE(carg->obj) == ctypes_type) {                \
             para.fValue.fVoidp = (void*)((CPyCppyy_tagCDataObject*)carg->obj)->b_ptr;\
             para.fTypeCode = 'p';                                            \
-            return true;                                                     \
+            res = true;                                                      \
         }                                                                    \
     }                                                                        \
-    return CArraySetArg(pyobject, para, code, sizeof(type));                 \
+    if (!res) res = CArraySetArg(pyobject, para, code, sizeof(type));        \
+    if (res) SetLifeLine(ctxt->fPyContext, pyobject, (intptr_t)this);        \
+    return res;                                                              \
 }                                                                            \
                                                                              \
 PyObject* CPyCppyy::name##ArrayConverter::FromMemory(void* address)          \
 {                                                                            \
-    if (fShape[1] == UNKNOWN_SIZE)                                           \
+    if (!fIsFixed)                                                           \
         return CreateLowLevelView((type**)address, fShape);                  \
     return CreateLowLevelView(*(type**)address, fShape);                     \
 }                                                                            \
                                                                              \
-bool CPyCppyy::name##ArrayConverter::ToMemory(PyObject* value, void* address)\
+bool CPyCppyy::name##ArrayConverter::ToMemory(                               \
+    PyObject* value, void* address, PyObject* ctxt)                          \
 {                                                                            \
     if (fShape[0] != 1) {                                                    \
         PyErr_SetString(PyExc_ValueError, "only 1-dim arrays supported");    \
@@ -1517,14 +1551,17 @@ bool CPyCppyy::name##ArrayConverter::ToMemory(PyObject* value, void* address)\
     Py_ssize_t buflen = Utility::GetBuffer(value, code, sizeof(type), buf);  \
     if (buflen == 0)                                                         \
         return false;                                                        \
-    if (0 <= fShape[1]) {                                                    \
+    if (fIsFixed) {                                                          \
         if (fShape[1] < buflen) {                                            \
             PyErr_SetString(PyExc_ValueError, "buffer too large for value"); \
             return false;                                                    \
         }                                                                    \
         memcpy(*(type**)address, buf, (0 < buflen ? buflen : 1)*sizeof(type));\
-    } else                                                                   \
+    } else {                                                                 \
         *(type**)address = (type*)buf;                                       \
+        fShape[1] = buflen;                                                  \
+    }                                                                        \
+    SetLifeLine(ctxt, value, (intptr_t)address);                             \
     return true;                                                             \
 }                                                                            \
                                                                              \
@@ -1628,14 +1665,15 @@ PyObject* CPyCppyy::name##Converter::FromMemory(void* address)               \
     return PyStrings::gEmptyString;                                          \
 }                                                                            \
                                                                              \
-bool CPyCppyy::name##Converter::ToMemory(PyObject* value, void* address)     \
+bool CPyCppyy::name##Converter::ToMemory(PyObject* value, void* address,     \
+    PyObject* ctxt)                                                          \
 {                                                                            \
     if (CPyCppyy_PyText_Check(value)) {                                      \
         *((type*)address) = CPyCppyy_PyText_AsString(value);                 \
         return true;                                                         \
     }                                                                        \
                                                                              \
-    return InstanceConverter::ToMemory(value, address);                      \
+    return InstanceConverter::ToMemory(value, address, ctxt);                \
 }
 
 CPPYY_IMPL_STRING_AS_PRIMITIVE_CONVERTER(TString, TString, Data, Length)
@@ -1698,7 +1736,7 @@ PyObject* CPyCppyy::STLWStringConverter::FromMemory(void* address)
     return PyUnicode_FromWideChar(&w, 0);
 }
 
-bool CPyCppyy::STLWStringConverter::ToMemory(PyObject* value, void* address)
+bool CPyCppyy::STLWStringConverter::ToMemory(PyObject* value, void* address, PyObject* ctxt)
 {
     if (PyUnicode_Check(value)) {
         Py_ssize_t len = PyUnicode_GET_SIZE(value);
@@ -1708,7 +1746,7 @@ bool CPyCppyy::STLWStringConverter::ToMemory(PyObject* value, void* address)
         delete[] buf;
         return true;
     }
-    return InstanceConverter::ToMemory(value, address);
+    return InstanceConverter::ToMemory(value, address, ctxt);
 }
 
 
@@ -1784,7 +1822,7 @@ PyObject* CPyCppyy::InstancePtrConverter::FromMemory(void* address)
 }
 
 //----------------------------------------------------------------------------
-bool CPyCppyy::InstancePtrConverter::ToMemory(PyObject* value, void* address)
+bool CPyCppyy::InstancePtrConverter::ToMemory(PyObject* value, void* address, PyObject* /* ctxt */)
 {
 // convert <value> to C++ instance, write it at <address>
     CPPInstance* pyobj = GetCppInstance(value);
@@ -1846,7 +1884,7 @@ PyObject* CPyCppyy::InstanceConverter::FromMemory(void* address)
 }
 
 //----------------------------------------------------------------------------
-bool CPyCppyy::InstanceConverter::ToMemory(PyObject* value, void* address)
+bool CPyCppyy::InstanceConverter::ToMemory(PyObject* value, void* address, PyObject* /* ctxt */)
 {
 // assign value to C++ instance living at <address> through assignment operator
     PyObject* pyobj = BindCppObjectNoCast(address, fClass);
@@ -1966,7 +2004,7 @@ PyObject* CPyCppyy::InstancePtrPtrConverter<ISREFERENCE>::FromMemory(void* addre
 
 //----------------------------------------------------------------------------
 template <bool ISREFERENCE>
-bool CPyCppyy::InstancePtrPtrConverter<ISREFERENCE>::ToMemory(PyObject* value, void* address)
+bool CPyCppyy::InstancePtrPtrConverter<ISREFERENCE>::ToMemory(PyObject* value, void* address, PyObject* /* ctxt */)
 {
 // convert <value> to C++ instance*, write it at <address>
     CPPInstance* pyobj = GetCppInstance(value);
@@ -2031,7 +2069,7 @@ PyObject* CPyCppyy::InstanceArrayConverter::FromMemory(void* address)
 }
 
 //----------------------------------------------------------------------------
-bool CPyCppyy::InstanceArrayConverter::ToMemory(PyObject* /* value */, void* /* address */)
+bool CPyCppyy::InstanceArrayConverter::ToMemory(PyObject* /* value */, void* /* address */, PyObject* /* ctxt */)
 {
 // convert <value> to C++ array of instances, write it at <address>
 
@@ -2140,7 +2178,7 @@ PyObject* CPyCppyy::PyObjectConverter::FromMemory(void* address)
     return pyobject;
 }
 
-bool CPyCppyy::PyObjectConverter::ToMemory(PyObject* value, void* address)
+bool CPyCppyy::PyObjectConverter::ToMemory(PyObject* value, void* address, PyObject* /* ctxt */)
 {
 // no conversion needed, write <value> at <address>
     Py_INCREF(value);
@@ -2379,7 +2417,7 @@ PyObject* CPyCppyy::FunctionPointerConverter::FromMemory(void* address)
     return func;
 }
 
-bool CPyCppyy::FunctionPointerConverter::ToMemory(PyObject* pyobject, void* address)
+bool CPyCppyy::FunctionPointerConverter::ToMemory(PyObject* pyobject, void* address, PyObject* /* ctxt */)
 {
 // special case: allow nullptr singleton:
     if (gNullPtrObject == pyobject) {
@@ -2434,9 +2472,9 @@ PyObject* CPyCppyy::StdFunctionConverter::FromMemory(void* address)
     return fConverter->FromMemory(address);
 }
 
-bool CPyCppyy::StdFunctionConverter::ToMemory(PyObject* value, void* address)
+bool CPyCppyy::StdFunctionConverter::ToMemory(PyObject* value, void* address, PyObject* ctxt)
 {
-    return fConverter->ToMemory(value, address);
+    return fConverter->ToMemory(value, address, ctxt);
 }
 
 

--- a/bindings/pyroot/cppyy/CPyCppyy/src/Converters.h
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Converters.h
@@ -17,7 +17,7 @@ public:
 public:
     virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) = 0;
     virtual PyObject* FromMemory(void* address);
-    virtual bool ToMemory(PyObject* value, void* address);
+    virtual bool ToMemory(PyObject* value, void* address, PyObject* ctxt = nullptr);
     virtual bool HasState() { return false; }
 };
 
@@ -37,7 +37,7 @@ public:
 public:
     virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
     virtual PyObject* FromMemory(void* address);
-    virtual bool ToMemory(PyObject* value, void* address);
+    virtual bool ToMemory(PyObject* value, void* address, PyObject* ctxt = nullptr);
     virtual bool HasState() { return true; }
 
 protected:
@@ -56,7 +56,7 @@ public:
 public:
     virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
     virtual PyObject* FromMemory(void* address);
-    virtual bool ToMemory(PyObject* value, void* address);
+    virtual bool ToMemory(PyObject* value, void* address, PyObject* ctxt = nullptr);
 
 protected:
     Cppyy::TCppType_t fClass;

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.cxx
@@ -201,7 +201,7 @@ static PyObject* im_call(PyObject* meth, PyObject* args, PyObject* kw)
 // the function is globally shared, so set and reset its "self" (ok, b/c of GIL)
     Py_INCREF(self);
     func->m_self = self;
-    PyObject* result = PyCFunction_Call((PyObject*)func, args, kw);
+    PyObject* result = CPyCppyy_PyCFunction_Call((PyObject*)func, args, kw);
     func->m_self = nullptr;
     Py_DECREF(self);
     Py_DECREF(args);

--- a/bindings/pyroot/cppyy/CPyCppyy/src/DeclareConverters.h
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/DeclareConverters.h
@@ -22,7 +22,7 @@ class name##Converter : public Converter {                                   \
 public:                                                                      \
     virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);      \
     virtual PyObject* FromMemory(void*);                                     \
-    virtual bool ToMemory(PyObject*, void*);                                 \
+    virtual bool ToMemory(PyObject*, void*, PyObject* = nullptr);            \
 };                                                                           \
                                                                              \
 class Const##name##RefConverter : public Converter {                         \
@@ -36,7 +36,7 @@ public:                                                                      \
 class name##Converter : public base##Converter {                             \
 public:                                                                      \
     virtual PyObject* FromMemory(void*);                                     \
-    virtual bool ToMemory(PyObject*, void*);                                 \
+    virtual bool ToMemory(PyObject*, void*, PyObject* = nullptr);            \
 };                                                                           \
                                                                              \
 class Const##name##RefConverter : public Converter {                         \
@@ -55,16 +55,17 @@ public:                                                                      \
 #define CPPYY_DECLARE_ARRAY_CONVERTER(name)                                  \
 class name##ArrayConverter : public Converter {                              \
 public:                                                                      \
-    name##ArrayConverter(dims_t shape);                                      \
+    name##ArrayConverter(dims_t shape, bool init = true);                    \
     name##ArrayConverter(const name##ArrayConverter&) = delete;              \
     name##ArrayConverter& operator=(const name##ArrayConverter&) = delete;   \
     virtual ~name##ArrayConverter() { delete [] fShape; }                    \
     virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);      \
     virtual PyObject* FromMemory(void*);                                     \
-    virtual bool ToMemory(PyObject*, void*);                                 \
+    virtual bool ToMemory(PyObject*, void*, PyObject* = nullptr);            \
     virtual bool HasState() { return true; }                                 \
 protected:                                                                   \
     Py_ssize_t* fShape;                                                      \
+    bool fIsFixed;                                                           \
 };                                                                           \
                                                                              \
 class name##ArrayPtrConverter : public name##ArrayConverter {                \
@@ -133,7 +134,7 @@ public:
 public:
     virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
     virtual PyObject* FromMemory(void* address);
-    virtual bool ToMemory(PyObject* value, void* address);
+    virtual bool ToMemory(PyObject* value, void* address, PyObject* = nullptr);
     virtual bool HasState() { return true; }
 
 protected:
@@ -160,7 +161,7 @@ public:
 public:
     virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
     virtual PyObject* FromMemory(void* address);
-    virtual bool ToMemory(PyObject* value, void* address);
+    virtual bool ToMemory(PyObject* value, void* address, PyObject* = nullptr);
     virtual bool HasState() { return true; }
 
 protected:
@@ -178,7 +179,7 @@ public:
 public:
     virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
     virtual PyObject* FromMemory(void* address);
-    virtual bool ToMemory(PyObject* value, void* address);
+    virtual bool ToMemory(PyObject* value, void* address, PyObject* = nullptr);
     virtual bool HasState() { return true; }
  
 protected:
@@ -196,7 +197,7 @@ public:
 public:
     virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
     virtual PyObject* FromMemory(void* address);
-    virtual bool ToMemory(PyObject* value, void* address);
+    virtual bool ToMemory(PyObject* value, void* address, PyObject* = nullptr);
     virtual bool HasState() { return true; }
 
 protected:
@@ -242,7 +243,7 @@ public:
     using StrictInstancePtrConverter::StrictInstancePtrConverter;
     virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
     virtual PyObject* FromMemory(void*);
-    virtual bool ToMemory(PyObject*, void*);
+    virtual bool ToMemory(PyObject*, void*, PyObject* = nullptr);
 };
 
 class InstanceRefConverter : public Converter  {
@@ -274,7 +275,7 @@ public:
 public:
     virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
     virtual PyObject* FromMemory(void* address);
-    virtual bool ToMemory(PyObject* value, void* address);
+    virtual bool ToMemory(PyObject* value, void* address, PyObject* = nullptr);
 };
 
 class InstanceArrayConverter : public InstancePtrConverter {
@@ -296,7 +297,7 @@ public:
 public:
     virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
     virtual PyObject* FromMemory(void* address);
-    virtual bool ToMemory(PyObject* value, void* address);
+    virtual bool ToMemory(PyObject* value, void* address, PyObject* = nullptr);
 
 protected:
     dims_t m_dims;
@@ -310,7 +311,7 @@ public:
 public:
     virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
     virtual PyObject* FromMemory(void* address);
-    virtual bool ToMemory(PyObject* value, void* address);
+    virtual bool ToMemory(PyObject* value, void* address, PyObject* = nullptr);
 
 private:
     std::complex<double> fBuffer;
@@ -352,7 +353,7 @@ public:                                                                      \
 public:                                                                      \
     virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);      \
     virtual PyObject* FromMemory(void* address);                             \
-    virtual bool ToMemory(PyObject* value, void* address);                   \
+    virtual bool ToMemory(PyObject*, void*, PyObject* = nullptr);            \
 protected:                                                                   \
     strtype fBuffer;                                                         \
 }
@@ -384,7 +385,7 @@ public:
 public:
     virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
     virtual PyObject* FromMemory(void* address);
-    virtual bool ToMemory(PyObject*, void*);
+    virtual bool ToMemory(PyObject*, void*, PyObject* = nullptr);
     virtual bool HasState() { return true; }
 
 protected:
@@ -404,7 +405,7 @@ public:
 public:
     virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
     virtual PyObject* FromMemory(void* address);
-    virtual bool ToMemory(PyObject* value, void* address);
+    virtual bool ToMemory(PyObject* value, void* address, PyObject* = nullptr);
 
 protected:
     Converter* fConverter;
@@ -425,7 +426,7 @@ public:
 public:
     virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
     virtual PyObject* FromMemory(void* address);
-    //virtual bool ToMemory(PyObject* value, void* address);
+    //virtual bool ToMemory(PyObject* value, void* address, PyObject* = nullptr);
     virtual bool HasState() { return true; }
 
 protected:

--- a/bindings/pyroot/cppyy/CPyCppyy/src/Dispatcher.h
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Dispatcher.h
@@ -1,12 +1,15 @@
 #ifndef CPYCPPYY_DISPATCHER_H
 #define CPYCPPYY_DISPATCHER_H
 
+// Standard
+#include <sstream>
+
 namespace CPyCppyy {
 
 class CPPScope;
 
 // helper that inserts dispatchers for virtual methods
-bool InsertDispatcher(CPPScope* klass, PyObject* dct);
+bool InsertDispatcher(CPPScope* klass, PyObject* bases, PyObject* dct, std::ostringstream& err);
 
 } // namespace CPyCppyy
 

--- a/bindings/pyroot/cppyy/CPyCppyy/src/PyStrings.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/PyStrings.cxx
@@ -53,6 +53,7 @@ PyObject* CPyCppyy::PyStrings::gCppImag          = nullptr;
 PyObject* CPyCppyy::PyStrings::gThisModule       = nullptr;
 
 PyObject* CPyCppyy::PyStrings::gNoImplicit       = nullptr;
+PyObject* CPyCppyy::PyStrings::gDispInit         = nullptr;
 
 PyObject* CPyCppyy::PyStrings::gExPythonize      = nullptr;
 PyObject* CPyCppyy::PyStrings::gPythonize        = nullptr;
@@ -116,6 +117,7 @@ bool CPyCppyy::CreatePyStrings() {
     CPPYY_INITIALIZE_STRING(gThisModule,     cppyy);
 
     CPPYY_INITIALIZE_STRING(gNoImplicit,     __cppyy_no_implicit);
+    CPPYY_INITIALIZE_STRING(gDispInit,       _init_dispatchptr);
 
     CPPYY_INITIALIZE_STRING(gExPythonize,    __cppyy_explicit_pythonize__);
     CPPYY_INITIALIZE_STRING(gPythonize,      __cppyy_pythonize__);
@@ -175,6 +177,7 @@ PyObject* CPyCppyy::DestroyPyStrings() {
     Py_DECREF(PyStrings::gThisModule);  PyStrings::gThisModule  = nullptr;
 
     Py_DECREF(PyStrings::gNoImplicit);  PyStrings::gNoImplicit  = nullptr;
+    Py_DECREF(PyStrings::gDispInit);    PyStrings::gDispInit    = nullptr;
 
     Py_DECREF(PyStrings::gExPythonize); PyStrings::gExPythonize = nullptr;
     Py_DECREF(PyStrings::gPythonize);   PyStrings::gPythonize   = nullptr;

--- a/bindings/pyroot/cppyy/CPyCppyy/src/PyStrings.h
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/PyStrings.h
@@ -56,6 +56,7 @@ namespace PyStrings {
     extern PyObject* gThisModule;
 
     extern PyObject* gNoImplicit;
+    extern PyObject* gDispInit;
 
     extern PyObject* gExPythonize;
     extern PyObject* gPythonize;

--- a/bindings/pyroot/cppyy/CPyCppyy/src/TemplateProxy.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/TemplateProxy.cxx
@@ -160,7 +160,7 @@ PyObject* TemplateProxy::Instantiate(const std::string& fname,
                     } else
                         PyErr_Clear();
                 }
-                Py_DECREF(pytc); pytc = nullptr;
+                Py_XDECREF(pytc); pytc = nullptr;
                 if (pyactname) {
                     PyTuple_SET_ITEM(tpArgs, i, pyactname);
                     bArgSet = true;

--- a/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
+++ b/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
@@ -886,6 +886,7 @@ Cppyy::TCppObject_t Cppyy::CallO(TCppMethod_t method,
     void* obj = ::operator new(gInterpreter->ClassInfo_Size(cr->GetClassInfo()));
     if (WrapperCall(method, nargs, args, self, obj))
         return (TCppObject_t)obj;
+    ::operator delete(obj);
     return (TCppObject_t)0;
 }
 
@@ -1135,7 +1136,7 @@ std::vector<Cppyy::TCppScope_t> Cppyy::GetUsingNamespaces(TCppScope_t scope)
 
     const std::vector<std::string>& v = gInterpreter->GetUsingNamespaces(cr->GetClassInfo());
     res.reserve(v.size());
-    for (auto uid : v) {
+    for (const auto& uid : v) {
         Cppyy::TCppScope_t uscope = GetScope(uid);
         if (uscope) res.push_back(uscope);
     }

--- a/bindings/pyroot/pythonizations/src/PyROOTWrapper.cxx
+++ b/bindings/pyroot/pythonizations/src/PyROOTWrapper.cxx
@@ -50,7 +50,9 @@ static TMemoryRegulator &GetMemoryRegulator()
 void PyROOT::Init()
 {
    // Initialize and acquire the GIL to allow for threading in ROOT
+#if PY_VERSION_HEX < 0x03090000
    PyEval_InitThreads();
+#endif
 
    // Memory management
    gROOT->GetListOfCleanups()->Add(&GetMemoryRegulator());

--- a/bindings/tpython/src/TPython.cxx
+++ b/bindings/tpython/src/TPython.cxx
@@ -114,7 +114,37 @@ Bool_t TPython::Initialize()
 #if PY_VERSION_HEX < 0x03020000
       PyEval_InitThreads();
 #endif
+
+// set the command line arguments on python's sys.argv
+#if PY_VERSION_HEX < 0x03000000
+      char *argv[] = {const_cast<char *>("root")};
+#else
+      wchar_t *argv[] = {const_cast<wchar_t *>(L"root")};
+#endif
+      int argc = sizeof(argv) / sizeof(argv[0]);
+#if PY_VERSION_HEX < 0x030b0000
       Py_Initialize();
+#else
+      PyStatus status;
+      PyConfig config;
+
+      PyConfig_InitPythonConfig(&config);
+
+      status = PyConfig_SetArgv(&config, argc, argv);
+      if (PyStatus_Exception(status)) {
+         PyConfig_Clear(&config);
+         std::cerr << "Error when setting command line arguments." << std::endl;
+         return kFALSE;
+      }
+
+      status = Py_InitializeFromConfig(&config);
+      if (PyStatus_Exception(status)) {
+         PyConfig_Clear(&config);
+         std::cerr << "Error when initializing Python." << std::endl;
+         return kFALSE;
+      }
+      PyConfig_Clear(&config);
+#endif
 #if PY_VERSION_HEX >= 0x03020000
       PyEval_InitThreads();
 #endif
@@ -126,13 +156,9 @@ Bool_t TPython::Initialize()
          return kFALSE;
       }
 
-// set the command line arguments on python's sys.argv
-#if PY_VERSION_HEX < 0x03000000
-      char *argv[] = {const_cast<char *>("root")};
-#else
-      wchar_t *argv[] = {const_cast<wchar_t *>(L"root")};
+#if PY_VERSION_HEX < 0x030b0000
+      PySys_SetArgv(argc, argv);
 #endif
-      PySys_SetArgv(sizeof(argv) / sizeof(argv[0]), argv);
 
       // force loading of the ROOT module
       PyRun_SimpleString(const_cast<char *>("import ROOT"));

--- a/bindings/tpython/src/TPython.cxx
+++ b/bindings/tpython/src/TPython.cxx
@@ -146,7 +146,9 @@ Bool_t TPython::Initialize()
       PyConfig_Clear(&config);
 #endif
 #if PY_VERSION_HEX >= 0x03020000
+#if PY_VERSION_HEX < 0x03090000
       PyEval_InitThreads();
+#endif
 #endif
 
       // try again to see if the interpreter is initialized


### PR DESCRIPTION
Since ROOT 6.22 is the second latest ROOT version that CMS uses in production, I need to make it compile again in order to do some validations. This means some PyROOT fixes need to be backported to make it compile again with newer Python versions:

  * https://github.com/root-project/root/pull/10734
  * https://github.com/root-project/root/pull/6994
  * https://github.com/root-project/root/pull/7022
  * https://github.com/root-project/root/pull/7961
  * https://github.com/root-project/root/pull/8036
  * https://github.com/root-project/root/pull/8257
  * https://github.com/root-project/root/pull/10047
