### PR TITLE
[cling] Fix clad build with LLVM_LIBDIR_SUFFIX

### DIFF
--- a/interpreter/cling/tools/plugins/clad/CMakeLists.txt
+++ b/interpreter/cling/tools/plugins/clad/CMakeLists.txt
@@ -12,7 +12,7 @@ set(clad_install_dir ${CMAKE_BINARY_DIR}/etc/cling/)
 # Specify include dirs for clad
 set(CLAD_INCLUDE_DIRS ${clad_install_dir})
 # Clad Libraries
-set(_CLAD_LIBRARY_PATH ${clad_install_dir}/plugins/lib)
+set(_CLAD_LIBRARY_PATH ${clad_install_dir}/plugins/lib${LLVM_LIBDIR_SUFFIX})
 
 # build byproducts only needed by Ninja
 if("${CMAKE_GENERATOR}" STREQUAL "Ninja")


### PR DESCRIPTION
This fixes `builtin_llvm=OFF` builds on at least EL8 platforms that currently have exactly LLVM 16.0.6.