### PR TITLE
[gui] Editable combo box nullptr access if SetEnabled is called

### DIFF
--- a/gui/gui/src/TGComboBox.cxx
+++ b/gui/gui/src/TGComboBox.cxx
@@ -251,7 +251,7 @@ TGComboBox::TGComboBox(const TGWindow *p, const char *text, Int_t id,
 {
    fWidgetId  = id;
    fMsgWindow = p;
-   fSelEntry = 0;
+   fSelEntry = nullptr;
 
    fTextEntry = new TGTextEntry(this, text, id);
    fTextEntry->SetFrameDrawn(kFALSE);
@@ -648,10 +648,10 @@ void TGComboBox::SetEnabled(Bool_t on)
    fDDButton->SetEnabled(on);
    if (on) {
       SetFlags(kWidgetIsEnabled);
-      fSelEntry->SetBackgroundColor(GetBackground());
+      if (fSelEntry) fSelEntry->SetBackgroundColor(GetBackground());
    } else {
       ClearFlags(kWidgetIsEnabled);
-      fSelEntry->SetBackgroundColor(GetDefaultFrameBackground());
+      if (fSelEntry) fSelEntry->SetBackgroundColor(GetDefaultFrameBackground());
    }
    fClient->NeedRedraw(fSelEntry);
 }


### PR DESCRIPTION
Fix bug introduced in https://github.com/root-project/root/commit/bc4e3d3787a30a5e4ccad5371044975f4481232e

fSelEntry is a nullptr or not, depending on which constructor is called. Editable-combo-box constructor leaves fSelEntry as a nullptr, thus guards are needed. There are guards everywhere in the code except in this function.

