### PR TITLE
[CI] Remove Fedora 37 from the CI workflows

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -330,8 +330,6 @@ jobs:
             overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_CXX_STANDARD=20"]
           - image: fedora38
             overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_CXX_STANDARD=20", "CMAKE_BUILD_TYPE=Debug"]
-          - image: fedora37
-            overrides: ["LLVM_ENABLE_ASSERTIONS=On"]
           - image: alma8
             overrides: ["LLVM_ENABLE_ASSERTIONS=On"]
           - image: alma9


### PR DESCRIPTION
Fedora 37 reached end-of-life on 2023-12-05:
https://en.wikipedia.org/wiki/Fedora_Linux
See the section "Releases".

We should therefore consider removing it from the CI.

This commit is made now because the outdated xrootd version in the Fedora 37 repos is a problem from migrating to the XRootDConfig.cmake file shipped by XRootD itself (see #14180).