### PR TITLE
[RF] Avoid too verbose printout when doing unbinned toy studies

### DIFF
--- a/roofit/roofit/inc/RooPoisson.h
+++ b/roofit/roofit/inc/RooPoisson.h
@@ -18,7 +18,7 @@
 
 class RooPoisson : public RooAbsPdf {
 public:
-  RooPoisson() { _noRounding = false ;   } ;
+  RooPoisson() : _noRounding{false} {}
   // Original constructor without RooAbsReal::Ref for backwards compatibility.
   inline RooPoisson(const char *name, const char *title, RooAbsReal& _x, RooAbsReal& _mean, bool noRounding=false)
       : RooPoisson{name, title, RooAbsReal::Ref{_x}, RooAbsReal::Ref{_mean}, noRounding} {}

--- a/roofit/roofitcore/inc/RooMCStudy.h
+++ b/roofit/roofitcore/inc/RooMCStudy.h
@@ -104,8 +104,8 @@ protected:
 
   void calcPulls() ;
 
-  RooAbsData*       _genSample ;       ///< Currently generated sample
-  RooAbsPdf*        _genModel ;        ///< Generator model
+  RooAbsData*       _genSample = nullptr;       ///< Currently generated sample
+  RooAbsPdf*        _genModel = nullptr;        ///< Generator model
   std::unique_ptr<RooAbsGenContext> _genContext;      ///< Generator context
   RooArgSet        _genInitParams;   ///< List of original generator parameters
   RooArgSet        _genParams;       ///< List of actual generator parameters

--- a/roofit/roofitcore/inc/RooNameReg.h
+++ b/roofit/roofitcore/inc/RooNameReg.h
@@ -22,8 +22,11 @@
 #include <unordered_map>
 #include <string>
 
+// String name registry
 class RooNameReg : public TNamed {
 public:
+
+  RooNameReg(const RooNameReg& other) = delete;
 
   static RooNameReg& instance() ;
   const TNamed* constPtr(const char* stringPtr) ;
@@ -45,8 +48,6 @@ public:
 
 protected:
   RooNameReg();
-//  RooNameReg(Int_t hashSize = 31) ;
-  RooNameReg(const RooNameReg& other) = delete;
 
   friend class RooAbsArg;
   friend class RooAbsData;
@@ -54,8 +55,6 @@ protected:
 
   std::unordered_map<std::string,std::unique_ptr<TNamed>> _map;
   std::size_t _renameCounter = 0;
-
-//  ClassDefOverride(RooNameReg,1) // String name registry
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooNumIntFactory.h
+++ b/roofit/roofitcore/inc/RooNumIntFactory.h
@@ -33,6 +33,8 @@ typedef void (*RooNumIntInitializerFunc)(RooNumIntFactory&) ;
 class RooNumIntFactory : public TObject {
 public:
 
+  RooNumIntFactory(const RooNumIntFactory& other) = delete;
+
   using Creator = std::function<std::unique_ptr<RooAbsIntegrator>(RooAbsFunc const& function, const RooNumIntConfig& config)>;
 
   static RooNumIntFactory& instance() ;
@@ -66,7 +68,6 @@ private:
   std::map<std::string,PluginInfo> _map;
 
   RooNumIntFactory() {} // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see https://sft.its.cern.ch/jira/browse/ROOT-10300
-  RooNumIntFactory(const RooNumIntFactory& other) = delete;
 
   void init();
 

--- a/roofit/roofitcore/inc/RooPlot.h
+++ b/roofit/roofitcore/inc/RooPlot.h
@@ -54,6 +54,8 @@ public:
      double xmin, double xmax, double ymin, double ymax);
   ~RooPlot() override;
 
+  RooPlot(const RooPlot& other) = delete; // cannot be copied
+
   static RooPlot* frame(const RooAbsRealLValue &var, double xmin, double xmax, Int_t nBins);
   static RooPlot* frameWithLabels(const RooAbsRealLValue &var);
 
@@ -207,8 +209,6 @@ public:
   void createInternalPlotVarClone();
 
 protected:
-
-  RooPlot(const RooPlot& other) = delete; // cannot be copied
 
   class DrawOpt {
     public:

--- a/roofit/roofitcore/src/RooHistFunc.cxx
+++ b/roofit/roofitcore/src/RooHistFunc.cxx
@@ -206,8 +206,7 @@ void RooHistFunc::computeBatch(double* output, size_t size, RooFit::Detail::Data
   for (const auto& obs : _depList) {
     auto realObs = dynamic_cast<const RooAbsReal*>(obs);
     if (realObs) {
-      auto inputs = dataMap.at(realObs);
-      inputValues.push_back(std::move(inputs));
+      inputValues.push_back(dataMap.at(realObs));
     } else {
       inputValues.emplace_back();
     }

--- a/roofit/roofitcore/src/RooMCStudy.cxx
+++ b/roofit/roofitcore/src/RooMCStudy.cxx
@@ -50,35 +50,32 @@ Check the RooFit tutorials
 for usage examples.
 **/
 
-#include "snprintf.h"
+
+#include <RooMCStudy.h>
+
+#include <RooAbsMCStudyModule.h>
+#include <RooAbsPdf.h>
+#include <RooArgList.h>
+#include <RooCmdConfig.h>
+#include <RooDataHist.h>
+#include <RooDataSet.h>
+#include <RooErrorVar.h>
+#include <RooFitResult.h>
+#include <RooFormulaVar.h>
+#include <RooGenContext.h>
+#include <RooGlobalFunc.h>
+#include <RooMsgService.h>
+#include <RooPlot.h>
+#include <RooProdPdf.h>
+#include <RooPullVar.h>
+#include <RooRandom.h>
+#include <RooRealVar.h>
+#include <RooWorkspace.h>
+
+#include <snprintf.h>
 #include <iostream>
 
-#include "RooMCStudy.h"
-#include "RooAbsMCStudyModule.h"
-
-#include "RooGenContext.h"
-#include "RooAbsPdf.h"
-#include "RooDataSet.h"
-#include "RooDataHist.h"
-#include "RooRealVar.h"
-#include "RooFitResult.h"
-#include "RooErrorVar.h"
-#include "RooFormulaVar.h"
-#include "RooArgList.h"
-#include "RooPlot.h"
-#include "RooRandom.h"
-#include "RooCmdConfig.h"
-#include "RooGlobalFunc.h"
-#include "RooPullVar.h"
-#include "RooMsgService.h"
-#include "RooProdPdf.h"
-#include "RooWorkspace.h"
-
-using namespace std ;
-
 ClassImp(RooMCStudy);
-  ;
-
 
 /**
 Construct Monte Carlo Study Manager. This class automates generating data from a given PDF,
@@ -145,7 +142,7 @@ RooMCStudy::RooMCStudy(const RooAbsPdf& model, const RooArgSet& observables,
   // Save fit command options
   if (pc.hasProcessed("FitOptArgs")) {
     RooCmdArg* fitOptArg = static_cast<RooCmdArg*>(cmdList.FindObject("FitOptArgs")) ;
-    for (Int_t i=0 ; i<fitOptArg->subArgs().GetSize() ;i++) {
+    for (int i=0 ; i<fitOptArg->subArgs().GetSize() ;i++) {
       _fitOptList.Add(new RooCmdArg(static_cast<RooCmdArg&>(*fitOptArg->subArgs().At(i)))) ;
     }
   }
@@ -200,13 +197,12 @@ RooMCStudy::RooMCStudy(const RooAbsPdf& model, const RooArgSet& observables,
 
     _perExptGenParams = true ;
 
-    coutI(Generation) << "RooMCStudy::RooMCStudy: INFO have pdf with constraints, will generate parameters from constraint pdf for each experiment" << endl ;
+    coutI(Generation) << "RooMCStudy::RooMCStudy: INFO have pdf with constraints, will generate parameters from constraint pdf for each experiment" << std::endl ;
   }
 
 
   // Extract generator and fit models
   _genModel = const_cast<RooAbsPdf*>(&model) ;
-  _genSample = nullptr ;
   RooAbsPdf* fitModel = static_cast<RooAbsPdf*>(pc.getObject("fitModel",nullptr)) ;
   _fitModel = fitModel ? fitModel : _genModel ;
 
@@ -222,10 +218,10 @@ RooMCStudy::RooMCStudy(const RooAbsPdf& model, const RooArgSet& observables,
   _canAddFitResults = true ;
 
   if (_extendedGen && _genProtoData && !_randProto) {
-    oocoutW(_fitModel,Generation) << "RooMCStudy::RooMCStudy: WARNING Using generator option 'e' (Poisson distribution of #events) together " << endl
-              << "                        with a prototype dataset implies incomplete sampling or oversampling of proto data." << endl
-              << "                        Use option \"r\" to randomize prototype dataset order and thus to randomize" << endl
-              << "                        the set of over/undersampled prototype events for each generation cycle." << endl ;
+    oocoutW(_fitModel,Generation) << "RooMCStudy::RooMCStudy: WARNING Using generator option 'e' (Poisson distribution of #events) together " << std::endl
+              << "                        with a prototype dataset implies incomplete sampling or oversampling of proto data." << std::endl
+              << "                        Use option \"r\" to randomize prototype dataset order and thus to randomize" << std::endl
+              << "                        the set of over/undersampled prototype events for each generation cycle." << std::endl ;
   }
 
   _genModel->getParameters(&_dependents, _genParams);
@@ -277,11 +273,10 @@ RooMCStudy::RooMCStudy(const RooAbsPdf& model, const RooArgSet& observables,
   }
 
   // Call module initializers
-  list<RooAbsMCStudyModule*>::iterator iter ;
-  for (iter=_modList.begin() ; iter!= _modList.end() ; ++iter) {
+  for (auto iter=_modList.begin() ; iter!= _modList.end() ; ++iter) {
     bool ok = (*iter)->doInitializeInstance(*this) ;
     if (!ok) {
-      oocoutE(_fitModel,Generation) << "RooMCStudy::ctor: removing study module " << (*iter)->GetName() << " from analysis chain because initialization failed" << endl ;
+      oocoutE(_fitModel,Generation) << "RooMCStudy::ctor: removing study module " << (*iter)->GetName() << " from analysis chain because initialization failed" << std::endl ;
       iter = _modList.erase(iter) ;
     }
   }
@@ -332,12 +327,11 @@ bool RooMCStudy::run(bool doGenerate, bool DoFit, Int_t nSamples, Int_t nEvtPerS
     RooMsgService::instance().setGlobalKillBelow(RooFit::PROGRESS) ;
   }
 
-  list<RooAbsMCStudyModule*>::iterator iter ;
-  for (iter=_modList.begin() ; iter!= _modList.end() ; ++iter) {
-    (*iter)->initializeRun(nSamples) ;
+  for (RooAbsMCStudyModule *mod : _modList) {
+    mod->initializeRun(nSamples) ;
   }
 
-  Int_t prescale = nSamples>100 ? Int_t(nSamples/100) : 1 ;
+  int prescale = nSamples>100 ? int(nSamples/100) : 1 ;
 
   while(nSamples--) {
 
@@ -346,14 +340,15 @@ bool RooMCStudy::run(bool doGenerate, bool DoFit, Int_t nSamples, Int_t nEvtPerS
       if (doGenerate) ooccoutI(_fitModel,Generation) << "Generating " ;
       if (doGenerate && DoFit) ooccoutI(_fitModel,Generation) << "and " ;
       if (DoFit) ooccoutI(_fitModel,Generation) << "fitting " ;
-      ooccoutP(_fitModel,Generation) << "sample " << nSamples << endl ;
+      ooccoutP(_fitModel,Generation) << "sample " << nSamples << std::endl ;
     }
 
+    std::unique_ptr<RooAbsData> ownedGenSample;
     _genSample = nullptr;
     bool existingData = false ;
     if (doGenerate) {
       // Generate sample
-      Int_t nEvt(nEvtPerSample) ;
+      int nEvt(nEvtPerSample) ;
 
       // Reset generator parameters to initial values
       _genParams.assign(_genInitParams) ;
@@ -369,9 +364,8 @@ bool RooMCStudy::run(bool doGenerate, bool DoFit, Int_t nSamples, Int_t nEvtPerS
       }
 
       // Call module before-generation hook
-      list<RooAbsMCStudyModule*>::iterator iter2 ;
-      for (iter2=_modList.begin() ; iter2!= _modList.end() ; ++iter2) {
-   (*iter2)->processBeforeGen(nSamples) ;
+      for (RooAbsMCStudyModule *mod : _modList) {
+         mod->processBeforeGen(nSamples) ;
       }
 
       if (_binGenData) {
@@ -383,7 +377,7 @@ bool RooMCStudy::run(bool doGenerate, bool DoFit, Int_t nSamples, Int_t nEvtPerS
    }
 
    // Binned generation
-   _genSample = std::unique_ptr<RooDataHist>{_genModel->generateBinned(_dependents,nEvt)}.release();
+   ownedGenSample = std::unique_ptr<RooDataHist>{_genModel->generateBinned(_dependents,nEvt)};
 
       } else {
 
@@ -395,7 +389,7 @@ bool RooMCStudy::run(bool doGenerate, bool DoFit, Int_t nSamples, Int_t nEvtPerS
 
    // Optional randomization of protodata for this run
    if (_randProto && _genProtoData && _genProtoData->numEntries()!=nEvt) {
-     oocoutI(_fitModel,Generation) << "RooMCStudy: (Re)randomizing event order in prototype dataset (Nevt=" << nEvt << ")" << endl ;
+     oocoutI(_fitModel,Generation) << "RooMCStudy: (Re)randomizing event order in prototype dataset (Nevt=" << nEvt << ")" << std::endl ;
      Int_t* newOrder = _genModel->randomizeProtoOrder(_genProtoData->numEntries(),nEvt) ;
      _genContext->setProtoDataOrder(newOrder) ;
      delete[] newOrder ;
@@ -403,13 +397,14 @@ bool RooMCStudy::run(bool doGenerate, bool DoFit, Int_t nSamples, Int_t nEvtPerS
 
    // Actual generation of events
    if (nEvt>0) {
-     _genSample = _genContext->generate(nEvt) ;
+     ownedGenSample = std::unique_ptr<RooAbsData>{_genContext->generate(nEvt)};
    } else {
      // Make empty dataset
-     _genSample = new RooDataSet("emptySample","emptySample",_dependents) ;
+     ownedGenSample = std::make_unique<RooDataSet>("emptySample","emptySample",_dependents);
    }
       }
 
+   _genSample = ownedGenSample.get();
 
     //} else if (asciiFilePat && &asciiFilePat) { //warning: the address of 'asciiFilePat' will always evaluate as 'true'
     } else if (asciiFilePat) {
@@ -418,7 +413,8 @@ bool RooMCStudy::run(bool doGenerate, bool DoFit, Int_t nSamples, Int_t nEvtPerS
       char asciiFile[1024] ;
       snprintf(asciiFile,1024,asciiFilePat,nSamples) ;
       RooArgList depList(_allDependents) ;
-      _genSample = RooDataSet::read(asciiFile,depList,"q") ;
+      ownedGenSample = std::unique_ptr<RooDataSet>{RooDataSet::read(asciiFile,depList,"q")};
+      _genSample = ownedGenSample.get();
 
     } else {
 
@@ -426,7 +422,7 @@ bool RooMCStudy::run(bool doGenerate, bool DoFit, Int_t nSamples, Int_t nEvtPerS
       _genSample = static_cast<RooDataSet*>(_genDataList.At(nSamples)) ;
       existingData = true ;
       if (!_genSample) {
-      oocoutW(_fitModel,Generation) << "RooMCStudy::run: WARNING: Sample #" << nSamples << " not loaded, skipping" << endl ;
+      oocoutW(_fitModel,Generation) << "RooMCStudy::run: WARNING: Sample #" << nSamples << " not loaded, skipping" << std::endl ;
       continue ;
       }
     }
@@ -435,42 +431,38 @@ bool RooMCStudy::run(bool doGenerate, bool DoFit, Int_t nSamples, Int_t nEvtPerS
     _ngenVar->setVal(_genSample->sumEntries()) ;
 
     // Call module between generation and fitting hook
-    list<RooAbsMCStudyModule*>::iterator iter3 ;
-    for (iter3=_modList.begin() ; iter3!= _modList.end() ; ++iter3) {
-      (*iter3)->processBetweenGenAndFit(nSamples) ;
+    for (RooAbsMCStudyModule *mod : _modList) {
+      mod->processBetweenGenAndFit(nSamples) ;
     }
 
     if (DoFit) fitSample(_genSample) ;
 
     // Call module between generation and fitting hook
-    for (iter3=_modList.begin() ; iter3!= _modList.end() ; ++iter3) {
-      (*iter3)->processAfterFit(nSamples) ;
+    for (RooAbsMCStudyModule *mod : _modList) {
+      mod->processAfterFit(nSamples) ;
     }
 
     // Optionally write to ascii file
     if (doGenerate && asciiFilePat && *asciiFilePat) {
       char asciiFile[1024] ;
       snprintf(asciiFile,1024,asciiFilePat,nSamples) ;
-      RooDataSet* unbinnedData = dynamic_cast<RooDataSet*>(_genSample) ;
-      if (unbinnedData) {
+      if (RooDataSet* unbinnedData = dynamic_cast<RooDataSet*>(_genSample)) {
    unbinnedData->write(asciiFile) ;
       } else {
-   coutE(InputArguments) << "RooMCStudy::run(" << GetName() << ") ERROR: ASCII writing of binned datasets is not supported" << endl ;
+   coutE(InputArguments) << "RooMCStudy::run(" << GetName() << ") ERROR: ASCII writing of binned datasets is not supported" << std::endl ;
       }
     }
 
     // Add to list or delete
     if (!existingData) {
       if (keepGenData) {
-   _genDataList.Add(_genSample) ;
-      } else {
-   delete _genSample ;
+   _genDataList.Add(ownedGenSample.release()) ;
       }
     }
   }
 
-  for (iter=_modList.begin() ; iter!= _modList.end() ; ++iter) {
-    if (RooDataSet* auxData = (*iter)->finalizeRun()) {
+  for (RooAbsMCStudyModule *mod : _modList) {
+    if (RooDataSet* auxData = mod->finalizeRun()) {
       _fitParData->merge(auxData) ;
     }
   }
@@ -702,7 +694,7 @@ bool RooMCStudy::fitSample(RooAbsData* genSample)
 bool RooMCStudy::addFitResult(const RooFitResult& fr)
 {
   if (!_canAddFitResults) {
-    oocoutE(_fitModel,InputArguments) << "RooMCStudy::addFitResult: ERROR cannot add fit results in current state" << endl ;
+    oocoutE(_fitModel,InputArguments) << "RooMCStudy::addFitResult: ERROR cannot add fit results in current state" << std::endl ;
     return true ;
   }
 
@@ -823,7 +815,7 @@ const RooArgSet* RooMCStudy::fitParams(Int_t sampleNum) const
 {
   // Check if sampleNum is in range
   if (sampleNum<0 || sampleNum>=_fitParData->numEntries()) {
-    oocoutE(_fitModel,InputArguments) << "RooMCStudy::fitParams: ERROR, invalid sample number: " << sampleNum << endl ;
+    oocoutE(_fitModel,InputArguments) << "RooMCStudy::fitParams: ERROR, invalid sample number: " << sampleNum << std::endl ;
     return nullptr ;
   }
 
@@ -841,7 +833,7 @@ const RooFitResult* RooMCStudy::fitResult(Int_t sampleNum) const
 {
   // Check if sampleNum is in range
   if (sampleNum<0 || sampleNum>=_fitResList.GetSize()) {
-    oocoutE(_fitModel,InputArguments) << "RooMCStudy::fitResult: ERROR, invalid sample number: " << sampleNum << endl ;
+    oocoutE(_fitModel,InputArguments) << "RooMCStudy::fitResult: ERROR, invalid sample number: " << sampleNum << std::endl ;
     return nullptr ;
   }
 
@@ -851,7 +843,7 @@ const RooFitResult* RooMCStudy::fitResult(Int_t sampleNum) const
     return fr ;
   } else {
     oocoutE(_fitModel,InputArguments) << "RooMCStudy::fitResult: ERROR, no fit result saved for sample "
-           << sampleNum << ", did you use the 'r; fit option?" << endl ;
+           << sampleNum << ", did you use the 'r; fit option?" << std::endl ;
   }
   return nullptr ;
 }
@@ -866,13 +858,13 @@ RooAbsData* RooMCStudy::genData(Int_t sampleNum) const
 {
   // Check that generated data was saved
   if (_genDataList.GetSize()==0) {
-    oocoutE(_fitModel,InputArguments) << "RooMCStudy::genData() ERROR, generated data was not saved" << endl ;
+    oocoutE(_fitModel,InputArguments) << "RooMCStudy::genData() ERROR, generated data was not saved" << std::endl ;
     return nullptr ;
   }
 
   // Check if sampleNum is in range
   if (sampleNum<0 || sampleNum>=_genDataList.GetSize()) {
-    oocoutE(_fitModel,InputArguments) << "RooMCStudy::genData() ERROR, invalid sample number: " << sampleNum << endl ;
+    oocoutE(_fitModel,InputArguments) << "RooMCStudy::genData() ERROR, invalid sample number: " << sampleNum << std::endl ;
     return nullptr ;
   }
 
@@ -919,7 +911,7 @@ RooPlot* RooMCStudy::plotParam(const char* paramName, const RooCmdArg& arg1, con
   // Find parameter in fitParDataSet
   RooRealVar* param = static_cast<RooRealVar*>(_fitParData->get()->find(paramName)) ;
   if (!param) {
-    oocoutE(_fitModel,InputArguments) << "RooMCStudy::plotParam: ERROR: no parameter defined with name " << paramName << endl ;
+    oocoutE(_fitModel,InputArguments) << "RooMCStudy::plotParam: ERROR: no parameter defined with name " << paramName << std::endl ;
     return nullptr ;
   }
 

--- a/roofit/roofitcore/src/RooMCStudy.cxx
+++ b/roofit/roofitcore/src/RooMCStudy.cxx
@@ -401,8 +401,6 @@ bool RooMCStudy::run(bool doGenerate, bool DoFit, Int_t nSamples, Int_t nEvtPerS
      delete[] newOrder ;
    }
 
-   coutP(Generation) << "RooMCStudy: now generating " << nEvt << " events" << endl ;
-
    // Actual generation of events
    if (nEvt>0) {
      _genSample = _genContext->generate(nEvt) ;

--- a/roofit/roofitcore/src/ValueChecking.h
+++ b/roofit/roofitcore/src/ValueChecking.h
@@ -17,15 +17,12 @@
 
 class CachingError : public std::exception {
   public:
-    CachingError(const std::string& newMessage) :
-      std::exception(),
-      _messages()
+    CachingError(const std::string& newMessage)
     {
       _messages.push_back(newMessage);
     }
 
     CachingError(CachingError&& previous, const std::string& newMessage) :
-    std::exception(),
     _messages{std::move(previous._messages)}
     {
       _messages.push_back(newMessage);

--- a/roofit/roostats/inc/RooStats/DebuggingSampler.h
+++ b/roofit/roostats/inc/RooStats/DebuggingSampler.h
@@ -35,10 +35,10 @@ namespace RooStats {
  class DebuggingSampler: public TestStatSampler {
 
    public:
-     DebuggingSampler() {
-       fTestStatistic = new RooRealVar("UniformTestStatistic","UniformTestStatistic",0,0,1);
-       fRand = new TRandom();
-     }
+     DebuggingSampler() :
+       fTestStatistic{new RooRealVar("UniformTestStatistic","UniformTestStatistic",0,0,1)},
+       fRand{new TRandom()}
+     {}
      ~DebuggingSampler() override {
        delete fRand;
        delete fTestStatistic;

--- a/roofit/roostats/inc/RooStats/DebuggingTestStat.h
+++ b/roofit/roostats/inc/RooStats/DebuggingTestStat.h
@@ -37,10 +37,10 @@ namespace RooStats {
   class DebuggingTestStat : public TestStatistic {
 
    public:
-     DebuggingTestStat() {
-       fTestStatistic = new RooRealVar("UniformTestStatistic","UniformTestStatistic",0,0,1);
-       fRand = new TRandom();
-     }
+     DebuggingTestStat() :
+       fTestStatistic{new RooRealVar("UniformTestStatistic","UniformTestStatistic",0,0,1)},
+       fRand{new TRandom()}
+     {}
 
      /// Main interface to evaluate the test statistic on a dataset
      double Evaluate(RooAbsData& /*data*/, RooArgSet& /*paramsOfInterest*/) override  {

--- a/roofit/roostats/inc/RooStats/MinNLLTestStat.h
+++ b/roofit/roostats/inc/RooStats/MinNLLTestStat.h
@@ -21,8 +21,6 @@
 #include "RooStats/SamplingDistribution.h"
 #include "RooStats/TestStatistic.h"
 
-#include "RooStats/RooStatsUtils.h"
-
 #include "RooRealVar.h"
 #include "RooProfileLL.h"
 #include "RooMsgService.h"
@@ -47,15 +45,11 @@ Internally it operates by delegating to a MinNLLTestStat object.
   class MinNLLTestStat : public TestStatistic{
 
    public:
-     MinNLLTestStat() {
-        // Proof constructor. Do not use.
-        fProflts = nullptr;
-     }
-     MinNLLTestStat(RooAbsPdf& pdf) {
-        fProflts = new ProfileLikelihoodTestStat(pdf);
-     }
+     // Proof constructor. Do not use.
+     MinNLLTestStat() {}
+     MinNLLTestStat(RooAbsPdf& pdf) : fProflts{new ProfileLikelihoodTestStat(pdf)} {}
 
-     MinNLLTestStat(const MinNLLTestStat& rhs) : TestStatistic(rhs), fProflts(nullptr) {
+     MinNLLTestStat(const MinNLLTestStat& rhs) : TestStatistic(rhs) {
         RooAbsPdf * pdf = rhs.fProflts->GetPdf();
         if (pdf)  fProflts = new ProfileLikelihoodTestStat(*pdf);
      }
@@ -103,7 +97,7 @@ Internally it operates by delegating to a MinNLLTestStat object.
      const TString GetVarName() const override { return fProflts->GetVarName(); }
 
    private:
-     ProfileLikelihoodTestStat* fProflts;
+     ProfileLikelihoodTestStat* fProflts = nullptr;
 
    protected:
       ClassDefOverride(MinNLLTestStat,1)   // implements the minimum NLL as a test statistic to be used with several tools


### PR DESCRIPTION
When doing binned toy studies with the `RooMCStudy`, one gets nice
printouts every 10 events for progress information.

In the unbinned case, there is an extra printout per toy dataset that
should be removed to be consistent with the binned case and to not
clutter the output.

Closes https://github.com/root-project/root/issues/9489.

The PR also has some commits with code modernization.

