### PR TITLE
[ntuple] fix reading of vector of enums

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -741,6 +741,10 @@ protected:
 
    std::size_t AppendImpl(const void *from) final { return CallAppendOn(*fSubFields[0], from); }
    void ReadGlobalImpl(NTupleSize_t globalIndex, void *to) final { CallReadOn(*fSubFields[0], globalIndex, to); }
+   void ReadInClusterImpl(const RClusterIndex &clusterIndex, void *to) final
+   {
+      CallReadOn(*fSubFields[0], clusterIndex, to);
+   }
 
 public:
    REnumField(std::string_view fieldName, std::string_view enumName);

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -39,6 +39,7 @@ TEST(RNTuple, EnumBasics)
 
    auto model = RNTupleModel::Create();
    auto ptrEnum = model->MakeField<CustomEnum>("e");
+   auto ptrVecEnum = model->MakeField<std::vector<CustomEnum>>("ve");
    model->MakeField<StructWithEnums>("swe");
 
    EXPECT_EQ(model->GetField("e")->GetType(), f->GetType());
@@ -47,6 +48,8 @@ TEST(RNTuple, EnumBasics)
    {
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
       *ptrEnum = kCustomEnumVal;
+      ptrVecEnum->emplace_back(kCustomEnumVal);
+      ptrVecEnum->emplace_back(kCustomEnumVal);
       writer->Fill();
    }
 
@@ -58,6 +61,9 @@ TEST(RNTuple, EnumBasics)
    EXPECT_EQ(42, ptrStructWithEnums->a);
    EXPECT_EQ(137, ptrStructWithEnums->b);
    EXPECT_EQ(kCustomEnumVal, ptrStructWithEnums->e);
+   EXPECT_EQ(2u, reader->GetModel()->GetDefaultEntry()->Get<std::vector<CustomEnum>>("ve")->size());
+   EXPECT_EQ(kCustomEnumVal, reader->GetModel()->GetDefaultEntry()->Get<std::vector<CustomEnum>>("ve")->at(0));
+   EXPECT_EQ(kCustomEnumVal, reader->GetModel()->GetDefaultEntry()->Get<std::vector<CustomEnum>>("ve")->at(1));
 }
 
 using EnumClassInts = ::testing::Types<CustomEnumInt8, CustomEnumUInt8, CustomEnumInt16, CustomEnumUInt16,


### PR DESCRIPTION
Items of vectors are read using ReadInClusterImpl, i.e. relative to the cluster of the enclosing vector. The default implementation of the cluster-relative read translates the call into a global-index read using the principle column of the field. Enum fields, however, don't have columns (their sub field has). Thus, the enum field needs to implement the cluster-relative read callback.