### PR TITLE
[cmake] Set `fail-on-missing=ON` by default

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/global.txt
+++ b/.github/workflows/root-ci-config/buildconfig/global.txt
@@ -48,7 +48,6 @@ davix=ON
 dcache=OFF
 dev=OFF
 distcc=OFF
-fail-on-missing=On
 fcgi=OFF
 fftw3=ON
 fitsio=ON

--- a/README/ReleaseNotes/v632/index.md
+++ b/README/ReleaseNotes/v632/index.md
@@ -214,4 +214,6 @@ Please use the higher-level functions `RooAbsPdf::createNLL()` and `RooAbsPdf::c
 
 ## Build, Configuration and Testing Infrastructure
 
-
+- The behavior that was toggled when passing the `-Dfail-on-missing=ON` option to CMake is now the default.
+  This means ROOT now fails to configure when any required package is missing. The big benefit of this is that ROOT features don't get dynamically disabled anymore based on your environment, making the build more deterministic.
+  For now, you can restore the old behavior by passing `-Dfail-on-missing=OFF` to CMake, but this flag will likely get deprecated in the future.

--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -193,7 +193,7 @@ ROOT_BUILD_OPTION(xrootd ON "Enable support for XRootD file server and client")
 
 option(all "Enable all optional components by default" OFF)
 option(clingtest "Enable cling tests (Note: that this makes llvm/clang symbols visible in libCling)" OFF)
-option(fail-on-missing "Fail at configure time if a required package cannot be found" OFF)
+option(fail-on-missing "Fail at configure time if a required package cannot be found" ON)
 option(gminimal "Enable only required options by default, but include X11" OFF)
 option(minimal "Enable only required options by default" OFF)
 option(rootbench "Build rootbench if rootbench exists in root or if it is a sibling directory." OFF)


### PR DESCRIPTION
Most ROOT developers and users seem to agree that autonomously toggling features at configuration time based on the environment is not good. The feature set that ROOT is built with is then not deterministic.

In past cases, this already resulted in accidentally missing test coverage because features were switched off after environment changes. That's why for the CI, we are always building with the `fail-on-missing-option`.

However, this is not only a problem in testing, but everytime ROOT is built. That's why this commit suggests to make `fail-on-missing` the default, and warn the users of potential future deprecation of this flag in the release notes.

An interesting point is also that the `fail-on-missing` code path in `SearchInstalledSoftware.cmake` is much simpler, which also helps to reduce the margin for error.

See also:
https://github.com/root-project/root/issues/14188#issuecomment-1844965943