### PR TITLE
[ntuple] `RNTupleFillContext`: Wait for all tasks before destructing model

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -149,6 +149,8 @@ protected:
 
    std::string fNTupleName;
    RTaskScheduler *fTaskScheduler = nullptr;
+
+public:
    void WaitForAllTasks()
    {
       if (!fTaskScheduler)
@@ -156,7 +158,6 @@ protected:
       fTaskScheduler->Wait();
    }
 
-public:
    explicit RPageStorage(std::string_view name);
    RPageStorage(const RPageStorage &other) = delete;
    RPageStorage &operator=(const RPageStorage &other) = delete;

--- a/tree/ntuple/v7/src/RNTupleFillContext.cxx
+++ b/tree/ntuple/v7/src/RNTupleFillContext.cxx
@@ -48,6 +48,9 @@ ROOT::Experimental::RNTupleFillContext::~RNTupleFillContext()
    } catch (const RException &err) {
       R__LOG_ERROR(NTupleLog()) << "failure committing ntuple: " << err.GetError().GetReport();
    }
+   // In most cases, CommitCluster() already waited for all tasks. Wait once more explicitly to avoid problems in case
+   // of errors because tasks hold on to the model, which is destructed before the sink.
+   fSink->WaitForAllTasks();
 }
 
 void ROOT::Experimental::RNTupleFillContext::CommitCluster()

--- a/tree/ntuple/v7/test/ntuple_extended.cxx
+++ b/tree/ntuple/v7/test/ntuple_extended.cxx
@@ -313,9 +313,6 @@ TEST(RNTuple, LargePages)
    }
 }
 
-// FIXME: apparently, this test continues to be broken for some CI configs, which needs to be investigated carefully;
-// thus disable temporarily.
-#if 0
 TEST(RNTuple, SmallClusters)
 {
    FileRaii fileGuard("test_ntuple_small_clusters.root");
@@ -329,13 +326,13 @@ TEST(RNTuple, SmallClusters)
    }
    {
       auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
-      auto desc = reader->GetDescriptor();
-      auto colId = desc->FindLogicalColumnId(desc->FindFieldId("vec"), 0, 0);
-      EXPECT_EQ(EColumnType::kSplitIndex64, desc->GetColumnDescriptor(colId).GetModel().GetType());
+      auto &desc = reader->GetDescriptor();
+      auto colId = desc.FindLogicalColumnId(desc.FindFieldId("vec"), 0, 0);
+      EXPECT_EQ(EColumnType::kSplitIndex64, desc.GetColumnDescriptor(colId).GetType());
       reader->LoadEntry(0);
-      auto entry = reader->GetModel()->GetDefaultEntry();
-      EXPECT_EQ(1u, entry->Get<std::vector<float>>("vec")->size());
-      EXPECT_FLOAT_EQ(1.0, entry->Get<std::vector<float>>("vec")->at(0));
+      auto &entry = reader->GetModel().GetDefaultEntry();
+      EXPECT_EQ(1u, entry.GetPtr<std::vector<float>>("vec")->size());
+      EXPECT_FLOAT_EQ(1.0, entry.GetPtr<std::vector<float>>("vec")->at(0));
    }
 
    {
@@ -349,13 +346,13 @@ TEST(RNTuple, SmallClusters)
    }
    {
       auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
-      auto desc = reader->GetDescriptor();
-      auto colId = desc->FindLogicalColumnId(desc->FindFieldId("vec"), 0, 0);
-      EXPECT_EQ(EColumnType::kSplitIndex32, desc->GetColumnDescriptor(colId).GetModel().GetType());
+      auto &desc = reader->GetDescriptor();
+      auto colId = desc.FindLogicalColumnId(desc.FindFieldId("vec"), 0, 0);
+      EXPECT_EQ(EColumnType::kSplitIndex32, desc.GetColumnDescriptor(colId).GetType());
       reader->LoadEntry(0);
-      auto entry = reader->GetModel()->GetDefaultEntry();
-      EXPECT_EQ(1u, entry->Get<std::vector<float>>("vec")->size());
-      EXPECT_FLOAT_EQ(1.0, entry->Get<std::vector<float>>("vec")->at(0));
+      auto &entry = reader->GetModel().GetDefaultEntry();
+      EXPECT_EQ(1u, entry.GetPtr<std::vector<float>>("vec")->size());
+      EXPECT_FLOAT_EQ(1.0, entry.GetPtr<std::vector<float>>("vec")->at(0));
    }
 
    // Throw on attempt to commit cluster > 512MB
@@ -382,4 +379,3 @@ TEST(RNTuple, SmallClusters)
       "failure committing ntuple: invalid attempt to write a cluster > 512MiB", false /* matchFullMessage */);
    writer = nullptr;
 }
-#endif


### PR DESCRIPTION
Re-enable the `SmallClusters` test.