### PR TITLE
[ntuple] Pass entries in cluster to `CommitCluster`

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -253,13 +253,15 @@ public:
       };
       struct RPageInfoExtended : RPageInfo {
          /// Index (in cluster) of the first element in page.
-         RClusterSize::ValueType fFirstInPage = 0;
+         ClusterSize_t::ValueType fFirstInPage = 0;
          /// Page number in the corresponding RPageRange.
          NTupleSize_t fPageNo = 0;
 
          RPageInfoExtended() = default;
-         RPageInfoExtended(const RPageInfo &pi, RClusterSize::ValueType i, NTupleSize_t n)
-            : RPageInfo(pi), fFirstInPage(i), fPageNo(n) {}
+         RPageInfoExtended(const RPageInfo &pi, ClusterSize_t::ValueType i, NTupleSize_t n)
+            : RPageInfo(pi), fFirstInPage(i), fPageNo(n)
+         {
+         }
       };
 
       RPageRange() = default;
@@ -276,7 +278,7 @@ public:
       }
 
       /// Find the page in the RPageRange that contains the given element. The element must exist.
-      RPageInfoExtended Find(RClusterSize::ValueType idxInCluster) const;
+      RPageInfoExtended Find(ClusterSize_t::ValueType idxInCluster) const;
 
       DescriptorId_t fPhysicalColumnId = kInvalidDescriptorId;
       std::vector<RPageInfo> fPageInfos;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -47,7 +47,7 @@ enum ENTupleStructure {
 /// Integer type long enough to hold the maximum number of entries in a column
 using NTupleSize_t = std::uint64_t;
 constexpr NTupleSize_t kInvalidNTupleIndex = std::uint64_t(-1);
-/// Wrap the integer in a struct in order to avoid template specialization clash with std::uint32_t
+/// Wrap the integer in a struct in order to avoid template specialization clash with std::uint64_t
 struct RClusterSize {
    using ValueType = std::uint64_t;
 

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -148,7 +148,7 @@ public:
    void CommitPage(ColumnHandle_t columnHandle, const RPage &page) final;
    void CommitSealedPage(DescriptorId_t physicalColumnId, const RSealedPage &sealedPage) final;
    void CommitSealedPageV(std::span<RPageStorage::RSealedPageGroup> ranges) final;
-   std::uint64_t CommitCluster(NTupleSize_t nEntries) final;
+   std::uint64_t CommitCluster(NTupleSize_t nNewEntries) final;
    void CommitClusterGroup() final;
    void CommitDataset() final;
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -235,7 +235,7 @@ public:
    virtual void CommitSealedPageV(std::span<RPageStorage::RSealedPageGroup> ranges) = 0;
    /// Finalize the current cluster and create a new one for the following data.
    /// Returns the number of bytes written to storage (excluding meta-data).
-   virtual std::uint64_t CommitCluster(NTupleSize_t nEntries) = 0;
+   virtual std::uint64_t CommitCluster(NTupleSize_t nNewEntries) = 0;
    /// Write out the page locations (page list envelope) for all the committed clusters since the last call of
    /// CommitClusterGroup (or the beginning of writing).
    virtual void CommitClusterGroup() = 0;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -296,7 +296,7 @@ protected:
    /// optimized implementation though.
    virtual std::vector<RNTupleLocator> CommitSealedPageVImpl(std::span<RPageStorage::RSealedPageGroup> ranges);
    /// Returns the number of bytes written to storage (excluding metadata)
-   virtual std::uint64_t CommitClusterImpl(NTupleSize_t nEntries) = 0;
+   virtual std::uint64_t CommitClusterImpl() = 0;
    /// Returns the locator of the page list envelope of the given buffer that contains the serialized page list.
    /// Typically, the implementation takes care of compressing and writing the provided buffer.
    virtual RNTupleLocator CommitClusterGroupImpl(unsigned char *serializedPageList, std::uint32_t length) = 0;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -173,7 +173,7 @@ protected:
    RNTupleLocator
    CommitSealedPageImpl(DescriptorId_t physicalColumnId, const RPageStorage::RSealedPage &sealedPage) final;
    std::vector<RNTupleLocator> CommitSealedPageVImpl(std::span<RPageStorage::RSealedPageGroup> ranges) final;
-   std::uint64_t CommitClusterImpl(NTupleSize_t nEntries) final;
+   std::uint64_t CommitClusterImpl() final;
    RNTupleLocator CommitClusterGroupImpl(unsigned char *serializedPageList, std::uint32_t length) final;
    void CommitDatasetImpl(unsigned char *serializedFooter, std::uint32_t length) final;
    void WriteNTupleHeader(const void *data, size_t nbytes, size_t lenHeader);

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -74,7 +74,7 @@ protected:
    RNTupleLocator
    CommitSealedPageImpl(DescriptorId_t physicalColumnId, const RPageStorage::RSealedPage &sealedPage) final;
    std::vector<RNTupleLocator> CommitSealedPageVImpl(std::span<RPageStorage::RSealedPageGroup> ranges) final;
-   std::uint64_t CommitClusterImpl(NTupleSize_t nEntries) final;
+   std::uint64_t CommitClusterImpl() final;
    RNTupleLocator CommitClusterGroupImpl(unsigned char *serializedPageList, std::uint32_t length) final;
    void CommitDatasetImpl(unsigned char *serializedFooter, std::uint32_t length) final;
 

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -342,7 +342,8 @@ void ROOT::Experimental::RNTupleWriter::CommitCluster(bool commitClusterGroup)
    for (auto &field : *fModel->GetFieldZero()) {
       field.CommitCluster();
    }
-   fNBytesCommitted += fSink->CommitCluster(fNEntries);
+   auto nEntriesInCluster = fNEntries - fLastCommitted;
+   fNBytesCommitted += fSink->CommitCluster(nEntriesInCluster);
    fNBytesFilled += fUnzippedClusterSize;
 
    // Cap the compression factor at 1000 to prevent overflow of fUnzippedClusterSizeEst

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -111,9 +111,8 @@ ROOT::Experimental::RColumnDescriptor::Clone() const
 
 ////////////////////////////////////////////////////////////////////////////////
 
-
 ROOT::Experimental::RClusterDescriptor::RPageRange::RPageInfoExtended
-ROOT::Experimental::RClusterDescriptor::RPageRange::Find(ROOT::Experimental::RClusterSize::ValueType idxInCluster) const
+ROOT::Experimental::RClusterDescriptor::RPageRange::Find(ClusterSize_t::ValueType idxInCluster) const
 {
    // TODO(jblomer): binary search
    RPageInfo pageInfo;
@@ -531,7 +530,7 @@ ROOT::Experimental::RClusterDescriptorBuilder::CommitColumnRange(DescriptorId_t 
       return R__FAIL("column ID mismatch");
    if (fCluster.fPageRanges.count(physicalId) > 0)
       return R__FAIL("column ID conflict");
-   RClusterDescriptor::RColumnRange columnRange{physicalId, firstElementIndex, RClusterSize(0)};
+   RClusterDescriptor::RColumnRange columnRange{physicalId, firstElementIndex, ClusterSize_t{0}};
    columnRange.fCompressionSettings = compressionSettings;
    for (const auto &pi : pageRange.fPageInfos) {
       columnRange.fNElements += pi.fNElements;

--- a/tree/ntuple/v7/src/RNTupleMerger.cxx
+++ b/tree/ntuple/v7/src/RNTupleMerger.cxx
@@ -104,9 +104,6 @@ void ROOT::Experimental::RNTupleMerger::AddColumnsFromField(
 ////////////////////////////////////////////////////////////////////////////////
 void ROOT::Experimental::RNTupleMerger::Merge(std::span<Detail::RPageSource *> sources, Detail::RPageSink &destination)
 {
-   // Total entries written
-   std::uint64_t nEntries{0};
-
    // Append the sources to the destination one-by-one
    bool isFirstSource = true;
    for (const auto &source : sources) {
@@ -180,8 +177,7 @@ void ROOT::Experimental::RNTupleMerger::Merge(std::span<Detail::RPageSource *> s
          } // end of loop over columns
 
          // Commit the clusters
-         nEntries += cluster.GetNEntries();
-         destination.CommitCluster(nEntries);
+         destination.CommitCluster(cluster.GetNEntries());
 
          // Go to the next cluster
          clusterId = descriptor->FindNextClusterId(clusterId);

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -171,7 +171,7 @@ void ROOT::Experimental::Detail::RPageSinkBuf::CommitSealedPageV(std::span<RPage
    throw RException(R__FAIL("should never commit sealed pages to RPageSinkBuf"));
 }
 
-std::uint64_t ROOT::Experimental::Detail::RPageSinkBuf::CommitCluster(ROOT::Experimental::NTupleSize_t nEntries)
+std::uint64_t ROOT::Experimental::Detail::RPageSinkBuf::CommitCluster(ROOT::Experimental::NTupleSize_t nNewEntries)
 {
    WaitForAllTasks();
 
@@ -186,7 +186,7 @@ std::uint64_t ROOT::Experimental::Detail::RPageSinkBuf::CommitCluster(ROOT::Expe
 
    for (auto &bufColumn : fBufferedColumns)
       bufColumn.DropBufferedPages();
-   return fInnerSink->CommitCluster(nEntries);
+   return fInnerSink->CommitCluster(nNewEntries);
 }
 
 void ROOT::Experimental::Detail::RPageSinkBuf::CommitClusterGroup()

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -543,7 +543,6 @@ std::uint64_t ROOT::Experimental::Detail::RPagePersistentSink::CommitCluster(ROO
 {
    auto nbytes = CommitClusterImpl();
 
-   R__ASSERT((nEntries - fPrevClusterNEntries) < ClusterSize_t(-1));
    auto nEntriesInCluster = ClusterSize_t(nEntries - fPrevClusterNEntries);
    RClusterDescriptorBuilder clusterBuilder;
    clusterBuilder.ClusterId(fDescriptorBuilder.GetDescriptor().GetNActiveClusters())

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -539,15 +539,15 @@ void ROOT::Experimental::Detail::RPagePersistentSink::CommitSealedPageV(
    }
 }
 
-std::uint64_t ROOT::Experimental::Detail::RPagePersistentSink::CommitCluster(ROOT::Experimental::NTupleSize_t nEntries)
+std::uint64_t
+ROOT::Experimental::Detail::RPagePersistentSink::CommitCluster(ROOT::Experimental::NTupleSize_t nNewEntries)
 {
    auto nbytes = CommitClusterImpl();
 
-   auto nEntriesInCluster = ClusterSize_t(nEntries - fPrevClusterNEntries);
    RClusterDescriptorBuilder clusterBuilder;
    clusterBuilder.ClusterId(fDescriptorBuilder.GetDescriptor().GetNActiveClusters())
       .FirstEntryIndex(fPrevClusterNEntries)
-      .NEntries(nEntriesInCluster);
+      .NEntries(nNewEntries);
    for (unsigned int i = 0; i < fOpenColumnRanges.size(); ++i) {
       RClusterDescriptor::RPageRange fullRange;
       fullRange.fPhysicalColumnId = i;
@@ -558,7 +558,7 @@ std::uint64_t ROOT::Experimental::Detail::RPagePersistentSink::CommitCluster(ROO
       fOpenColumnRanges[i].fNElements = 0;
    }
    fDescriptorBuilder.AddCluster(clusterBuilder.MoveDescriptor().Unwrap());
-   fPrevClusterNEntries = nEntries;
+   fPrevClusterNEntries += nNewEntries;
    return nbytes;
 }
 

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -541,7 +541,7 @@ void ROOT::Experimental::Detail::RPagePersistentSink::CommitSealedPageV(
 
 std::uint64_t ROOT::Experimental::Detail::RPagePersistentSink::CommitCluster(ROOT::Experimental::NTupleSize_t nEntries)
 {
-   auto nbytes = CommitClusterImpl(nEntries);
+   auto nbytes = CommitClusterImpl();
 
    R__ASSERT((nEntries - fPrevClusterNEntries) < ClusterSize_t(-1));
    auto nEntriesInCluster = ClusterSize_t(nEntries - fPrevClusterNEntries);

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -392,8 +392,7 @@ ROOT::Experimental::Detail::RPageSinkDaos::CommitSealedPageVImpl(std::span<RPage
    return locators;
 }
 
-std::uint64_t
-ROOT::Experimental::Detail::RPageSinkDaos::CommitClusterImpl(ROOT::Experimental::NTupleSize_t /* nEntries */)
+std::uint64_t ROOT::Experimental::Detail::RPageSinkDaos::CommitClusterImpl()
 {
    return std::exchange(fNBytesCurrentCluster, 0);
 }

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -188,8 +188,7 @@ ROOT::Experimental::Detail::RPageSinkFile::CommitSealedPageVImpl(std::span<RPage
    return locators;
 }
 
-std::uint64_t
-ROOT::Experimental::Detail::RPageSinkFile::CommitClusterImpl(ROOT::Experimental::NTupleSize_t /* nEntries */)
+std::uint64_t ROOT::Experimental::Detail::RPageSinkFile::CommitClusterImpl()
 {
    auto result = fNBytesCurrentCluster;
    fNBytesCurrentCluster = 0;


### PR DESCRIPTION
... instead of the total number of entries. This will make parallel writing much easier because every thread only needs to know about its own cluster size.