### PR TITLE
Use the `/bigobj` compiler flag for `TCling.cxx` in Debug mode on Windows 64

### DIFF
--- a/core/metacling/src/CMakeLists.txt
+++ b/core/metacling/src/CMakeLists.txt
@@ -71,8 +71,8 @@ if(MSVC)
    target_include_directories(MetaCling PRIVATE
       ${CMAKE_SOURCE_DIR}/core/winnt/inc
    )
-   if(winrtdebug AND CMAKE_SIZEOF_VOID_P EQUAL 8)
-      set_source_files_properties(TCling.cxx COMPILE_FLAGS "/bigobj")
+   if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+     set_source_files_properties(TCling.cxx COMPILE_FLAGS $<$<CONFIG:Debug>:/bigobj>)
    endif()
 endif()
 


### PR DESCRIPTION
This should fix the following error
```
C:\ROOT-CI\src\core\metacling\src\TCling.cxx : fatal  error C1128: number of sections exceeded object file format limit: compile with /bigobj
```
