### PR TITLE
[ntuple] Create `RNTupleInspector` directly from page source

### DIFF
--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -124,7 +124,6 @@ public:
    };
 
 private:
-   std::unique_ptr<TFile> fSourceFile;
    std::unique_ptr<Detail::RPageSource> fPageSource;
    std::unique_ptr<RNTupleDescriptor> fDescriptor;
    int fCompressionSettings = -1;

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -163,19 +163,8 @@ ROOT::Experimental::RNTupleInspector::Create(ROOT::Experimental::RNTuple *source
 std::unique_ptr<ROOT::Experimental::RNTupleInspector>
 ROOT::Experimental::RNTupleInspector::Create(std::string_view ntupleName, std::string_view sourceFileName)
 {
-   auto sourceFile = std::unique_ptr<TFile>(TFile::Open(std::string(sourceFileName).c_str()));
-   if (!sourceFile || sourceFile->IsZombie()) {
-      throw RException(R__FAIL("cannot open source file " + std::string(sourceFileName)));
-   }
-   auto ntuple = std::unique_ptr<ROOT::Experimental::RNTuple>(
-      sourceFile->Get<ROOT::Experimental::RNTuple>(std::string(ntupleName).c_str()));
-   if (!ntuple) {
-      throw RException(
-         R__FAIL("cannot read RNTuple " + std::string(ntupleName) + " from " + std::string(sourceFileName)));
-   }
-
-   auto inspector = std::unique_ptr<RNTupleInspector>(new RNTupleInspector(ntuple->MakePageSource()));
-   inspector->fSourceFile = std::move(sourceFile);
+   auto pageSource = ROOT::Experimental::Detail::RPageSource::Create(ntupleName, sourceFileName);
+   auto inspector = std::unique_ptr<RNTupleInspector>(new RNTupleInspector(std::move(pageSource)));
 
    inspector->CollectColumnInfo();
    inspector->CollectFieldTreeInfo(inspector->GetDescriptor()->GetFieldZeroId());

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -43,11 +43,6 @@ TEST(RNTupleInspector, CreateFromString)
    EXPECT_EQ(inspector->GetDescriptor()->GetName(), "ntuple");
 
    EXPECT_THROW(RNTupleInspector::Create("nonexistent", fileGuard.GetPath()), ROOT::Experimental::RException);
-
-   ROOT::TestSupport::CheckDiagsRAII diag;
-   diag.requiredDiag(kError, "TFile::TFile", "nonexistent.root does not exist",
-                     /*matchFullMessage=*/false);
-   EXPECT_THROW(RNTupleInspector::Create("ntuple", "nonexistent.root"), ROOT::Experimental::RException);
 }
 
 TEST(RNTupleInspector, CompressionSettings)


### PR DESCRIPTION
With this change, the use of TFile when creating an `RNTupleInspector` object from an RNTuple name and source path is removed by directly creating the page source instead. This is in accordance with other places that require the opening of an RNTuple (i.e. `RNTupleReader` and `ROOT::RDF::Experimental::FromRNTuple`).

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)