### PR TITLE
[ntuple] Fix calculation of compressed size with multiple clusters

### DIFF
--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -77,10 +77,9 @@ void ROOT::Experimental::RNTupleInspector::CollectColumnInfo()
             compressedPageSizes.emplace_back(page.fLocator.fBytesOnStorage);
             fUncompressedSize += page.fNElements * elemSize;
          }
-
-         fCompressedSize += std::accumulate(compressedPageSizes.begin(), compressedPageSizes.end(), 0);
       }
 
+      fCompressedSize += std::accumulate(compressedPageSizes.begin(), compressedPageSizes.end(), 0);
       fColumnInfo.emplace(colId, RColumnInspector(colDesc, compressedPageSizes, elemSize, nElems));
    }
 }

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -130,15 +130,19 @@ TEST(RNTupleInspector, SizeCompressedInt)
       writeOptions.SetCompression(505);
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
 
-      for (int32_t i = 0; i < 50; ++i) {
+      for (int32_t i = 0; i < 500; ++i) {
          *nFldInt = i;
          ntuple->Fill();
+
+         // Store the data in ten clusters to be able to test that the size is correctly computed in this way.
+         if (i % 50 == 49)
+            ntuple->CommitCluster();
       }
    }
 
    auto inspector = RNTupleInspector::Create("ntuple", fileGuard.GetPath());
 
-   EXPECT_EQ(sizeof(int32_t) * 50, inspector->GetUncompressedSize());
+   EXPECT_EQ(sizeof(int32_t) * 500, inspector->GetUncompressedSize());
    EXPECT_GT(inspector->GetCompressedSize(), 0);
    EXPECT_LT(inspector->GetCompressedSize(), inspector->GetUncompressedSize());
    EXPECT_GT(inspector->GetCompressionFactor(), 1);


### PR DESCRIPTION
This PR fixes the incorrect calculation of the compressed size by the `RNTupleInspector`. Because the vector of compressed page sizes is not cleared after each loop iteration, the accumulation needs to happen only after the loop has finished.

- [x] tested changes locally
- [x] updated the docs (if necessary)
