### PR TITLE
[RF] Deprecate some RooDataSet constructors

### DIFF
--- a/README/ReleaseNotes/v632/index.md
+++ b/README/ReleaseNotes/v632/index.md
@@ -41,6 +41,8 @@ The following people have contributed to this new version:
 ## Deprecation and Removal
 - The RooFit legacy iterators are deprecated and will be removed in ROOT 6.34 (see section "RooFit libraries")
 - Some memory-unsafe RooFit interfaces were removed
+- Some redundant **RooDataSet** constructors are deprecated and will be removed in ROOT 6.34.
+  Please use the RooDataSet constructors that take RooFit command arguments instead
 
 ## Core Libraries
 

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roodataset.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roodataset.py
@@ -85,7 +85,7 @@ class RooDataSet(object):
         if weight_name is None:
             dataset = ROOT.RooDataSet(name, title, variables)
         else:
-            dataset = ROOT.RooDataSet(name, title, variables, weight_name)
+            dataset = ROOT.RooDataSet(name, title, variables, WeightVar=weight_name)
 
         def log_warning(s):
             """Log a string to the RooFit message log for the WARNING level on

--- a/roofit/RDataFrameHelpers/test/testActionHelpers.cxx
+++ b/roofit/RDataFrameHelpers/test/testActionHelpers.cxx
@@ -111,7 +111,7 @@ TEST(RooAbsDataHelper, SkipEventsOutOfRange) {
   RooRealVar x{"x", "x", 0.0, -2.0, 2.0};
 
   // Create a RooDataset from the TTree, and one from the RDataFrame
-  RooDataSet dataSetTree{"dataSetTree", "dataSetTree", tree, x};
+  RooDataSet dataSetTree{"dataSetTree", "dataSetTree", x, RooFit::Import(*tree)};
   auto dataSetRDF = rdf.Book<double>(RooDataSetHelper("dataSetRDF", "dataSetRDF", RooArgSet(x)), {"x"});
 
   // Check if in the creation of the datasets, the entries outside the

--- a/roofit/roofitcore/inc/RooDataSet.h
+++ b/roofit/roofitcore/inc/RooDataSet.h
@@ -67,7 +67,7 @@ public:
   RooDataSet() ;
 
   RooDataSet(RooStringView name, RooStringView title, const RooArgSet& vars, const char* wgtVarName)
-     R__SUGGEST_ALTERNATIVE("Use RooDataSet(name, title, vars, RooFit::WeightVar(wgtVarName)).");
+     R__DEPRECATED(6,34, "Use RooDataSet(name, title, vars, RooFit::WeightVar(wgtVarName)).");
 
   // Universal constructor
   RooDataSet(RooStringView name, RooStringView title, const RooArgSet& vars, const RooCmdArg& arg1={}, const RooCmdArg& arg2={},
@@ -83,9 +83,14 @@ public:
 
   // Constructor importing data from external ROOT Tree
   RooDataSet(RooStringView name, RooStringView title, TTree *tree, const RooArgSet& vars,
-             const char *cuts=nullptr, const char* wgtVarName=nullptr);
+             const char *cuts=nullptr, const char* wgtVarName=nullptr)
+#ifndef ROOFIT_BUILDS_ITSELF // need to guard because this is used in the implementation of other deprecated constructors
+     R__DEPRECATED(6,34, "Use RooDataSet(name, title, vars, Import(*tree), Cut(cuts), WeightVar(wgtVarName)).")
+#endif
+  ;
   RooDataSet(RooStringView name, RooStringView title, TTree *tree, const RooArgSet& vars,
-             const RooFormulaVar& cutVar, const char* wgtVarName=nullptr) ;
+             const RooFormulaVar& cutVar, const char* wgtVarName=nullptr)
+     R__DEPRECATED(6,34, "Use RooDataSet(name, title, vars, Import(*tree), Cut(cutVar), WeightVar(wgtVarName)).");
 
   RooDataSet(RooDataSet const & other, const char* newname=nullptr) ;
   TObject* Clone(const char* newname = "") const override {

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -296,7 +296,7 @@ std::unique_ptr<RooDataSet> makeDataSetFromDataHist(RooDataHist const &hist)
 ///
 /// <table>
 /// <tr><th> %RooCmdArg <th> Effect
-/// <tr><td> Import(TTree*)              <td> Import contents of given TTree. Only branches of the TTree that have names
+/// <tr><td> Import(TTree&)   <td> Import contents of given TTree. Only branches of the TTree that have names
 ///                                corresponding to those of the RooAbsArgs that define the RooDataSet are
 ///                                imported.
 /// <tr><td> ImportFromFile(const char* fileName, const char* treeName) <td> Import tree with given name from file with given name.

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -529,7 +529,7 @@ RooDataSet::RooDataSet(RooStringView name, RooStringView title, const RooArgSet&
          impData = impDataSet.get();
       }
       if (cutSpec) {
-         cutVarTmp = std::make_unique<RooFormulaVar>(cutSpec, cutSpec, *impData->get());
+         cutVarTmp = std::make_unique<RooFormulaVar>(cutSpec, cutSpec, *impData->get(), /*checkVariables=*/false);
          cutVar = cutVarTmp.get();
       }
       _dstore->loadValues(impData->store(), cutVar, cutRange);
@@ -561,7 +561,7 @@ RooDataSet::RooDataSet(RooStringView name, RooStringView title, const RooArgSet&
       }
 
       if (cutSpec) {
-         cutVarTmp = std::make_unique<RooFormulaVar>(cutSpec, cutSpec, _vars);
+         cutVarTmp = std::make_unique<RooFormulaVar>(cutSpec, cutSpec, _vars, /*checkVariables=*/false);
          cutVar = cutVarTmp.get();
       }
 
@@ -1916,7 +1916,7 @@ void RooDataSet::loadValuesFromSlices(RooCategory &indexCat, std::map<std::strin
       indexCatInData.setLabel(item.first.c_str());
       std::unique_ptr<RooFormulaVar> cutVarTmp;
       if (cutSpec) {
-         cutVarTmp = std::make_unique<RooFormulaVar>(cutSpec, cutSpec, *sliceData->get());
+         cutVarTmp = std::make_unique<RooFormulaVar>(cutSpec, cutSpec, *sliceData->get(), /*checkVariables=*/false);
          cutVar = cutVarTmp.get();
       }
       _dstore->loadValues(sliceData->store(), cutVar, rangeName);

--- a/roofit/roofitcore/test/TestStatistics/testRooRealL.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testRooRealL.cxx
@@ -48,7 +48,7 @@ TEST_P(RooRealL, getVal)
    w.factory("Gaussian::g(x[-5,5],mu[0,-3,3],sigma[1,0.01,5.0])");
    auto x = w.var("x");
    RooAbsPdf *pdf = w.pdf("g");
-   std::unique_ptr<RooDataSet> data{pdf->generate(RooArgSet(*x), 10000)};
+   std::unique_ptr<RooDataSet> data{pdf->generate(*x, 10000)};
    std::unique_ptr<RooAbsReal> nll{pdf->createNLL(*data)};
 
    auto nominal_result = nll->getVal();
@@ -208,7 +208,7 @@ TEST_P(RooRealL, setVal)
    w.factory("Gaussian::g(x[-5,5],mu[0,-3,3],sigma[1,0.01,5.0])");
    auto x = w.var("x");
    RooAbsPdf *pdf = w.pdf("g");
-   std::unique_ptr<RooDataSet> data{pdf->generate(RooArgSet(*x), 10000)};
+   std::unique_ptr<RooDataSet> data{pdf->generate(*x, 10000)};
    std::unique_ptr<RooAbsReal> nll{pdf->createNLL(*data)};
 
    RooFit::TestStatistics::RooRealL nll_new("nll_new", "new style NLL",
@@ -259,7 +259,7 @@ TEST_P(RealLVsMPFE, getVal)
    w.factory("Gaussian::g(x[-5,5],mu[0,-3,3],sigma[1,0.01,5.0])");
    auto x = w.var("x");
    RooAbsPdf *pdf = w.pdf("g");
-   std::unique_ptr<RooDataSet> data{pdf->generate(RooArgSet(*x), 10000)};
+   std::unique_ptr<RooDataSet> data{pdf->generate(*x, 10000)};
 
    std::unique_ptr<RooAbsReal> nll_mpfe{pdf->createNLL(*data)};
 
@@ -295,7 +295,7 @@ TEST_P(RealLVsMPFE, minimize)
    RooRealVar *mu = w.var("mu");
    RooRealVar *sigma = w.var("sigma");
 
-   std::unique_ptr<RooDataSet> data{pdf->generate(RooArgSet(*x), 10000)};
+   std::unique_ptr<RooDataSet> data{pdf->generate(*x, 10000)};
    mu->setVal(-2.9);
 
    // If we don't set sigma constant, the fit is not stable as we start with mu

--- a/roofit/roofitcore/test/stressRooFit_tests.h
+++ b/roofit/roofitcore/test/stressRooFit_tests.h
@@ -457,7 +457,7 @@ public:
       // --------------------------------------------
 
       // Sample 2000 events in (dt,mixState,tagFlav) from bmix
-      std::unique_ptr<RooDataSet> data{bmix.generate(RooArgSet(dt, mixState, tagFlav), 2000)};
+      std::unique_ptr<RooDataSet> data{bmix.generate({dt, mixState, tagFlav}, 2000)};
 
       // S h o w   d t   d i s t r i b u t i o n   w i t h   c u s t o m   b i n n i n g
       // -------------------------------------------------------------------------------
@@ -1303,7 +1303,7 @@ public:
       // ---------------------------------------------------------------------------------
 
       // Generate 10000 events in x and y from model
-      std::unique_ptr<RooDataSet> data{model.generate(RooArgSet(x, y), 10000)};
+      std::unique_ptr<RooDataSet> data{model.generate({x, y}, 10000)};
 
       // Plot x distribution of data and projection of model on x = Int(dy) model(x,y)
       RooPlot *xframe = x.frame();
@@ -1528,7 +1528,7 @@ public:
       // ---------------------------------------------------------------------------
 
       // Generate 10000 events in x and y from gaussxy
-      std::unique_ptr<RooDataSet> data{gaussxy.generate(RooArgSet(x, y), 10000)};
+      std::unique_ptr<RooDataSet> data{gaussxy.generate({x, y}, 10000)};
 
       // Plot x distribution of data and projection of gaussxy on x = Int(dy) gaussxy(x,y)
       RooPlot *xframe = x.frame(Title("X projection of gauss(x)*gauss(y)"));
@@ -1589,7 +1589,7 @@ public:
       // ---------------------------------------------------------------
 
       // Generate 1000 events in x and y from model
-      std::unique_ptr<RooDataSet> data{model.generate(RooArgSet(x, y), 10000)};
+      std::unique_ptr<RooDataSet> data{model.generate({x, y}, 10000)};
 
       // Plot x distribution of data and projection of model on x = Int(dy) model(x,y)
       RooPlot *xframe = x.frame();
@@ -1738,7 +1738,7 @@ public:
       // ------------------------------------------------------------------
 
       // Specify external dataset with dterr values to use model_dm as conditional p.d.f.
-      std::unique_ptr<RooDataSet> data{model.generate(RooArgSet(dt, dterr), 10000)};
+      std::unique_ptr<RooDataSet> data{model.generate({dt, dterr}, 10000)};
 
       // F i t   c o n d i t i o n a l   d e c a y _ d m ( d t | d t e r r )
       // ---------------------------------------------------------------------
@@ -1877,7 +1877,7 @@ public:
       RooBMixDecay bmix_gm1("bmix", "decay", dt, mixState, tagFlav, tau, dm, w, dw, gm1, RooBMixDecay::DoubleSided);
 
       // Generate BMixing data with above set of event errors
-      std::unique_ptr<RooDataSet> data{bmix_gm1.generate(RooArgSet(dt, tagFlav, mixState), 20000)};
+      std::unique_ptr<RooDataSet> data{bmix_gm1.generate({dt, tagFlav, mixState}, 20000)};
 
       // P l o t   f u l l   d e c a y   d i s t r i b u t i o n
       // ----------------------------------------------------------
@@ -1945,7 +1945,7 @@ public:
       RooRealVar fsig("fsig", "signal fraction", 0.1, 0., 1.);
       RooAddPdf model("model", "model", RooArgList(sig, bkg), fsig);
 
-      std::unique_ptr<RooDataSet> data{model.generate(RooArgSet(x, y, z), 20000)};
+      std::unique_ptr<RooDataSet> data{model.generate({x, y, z}, 20000)};
 
       // P r o j e c t   p d f   a n d   d a t a   o n   x
       // -------------------------------------------------
@@ -2014,7 +2014,7 @@ public:
       RooAddPdf model("model", "model", RooArgList(sig, bkg), f);
 
       // Sample 10000 events in (x,y) from the model
-      std::unique_ptr<RooDataSet> modelData{model.generate(RooArgSet(x, y), 10000)};
+      std::unique_ptr<RooDataSet> modelData{model.generate({x, y}, 10000)};
 
       // D e f i n e   s i g n a l   a n d   s i d e b a n d   r e g i o n s
       // -------------------------------------------------------------------
@@ -2289,7 +2289,7 @@ public:
       RooRealVar fsig("fsig", "signal fraction", 0.1, 0., 1.);
       RooAddPdf model("model", "model", RooArgList(sig, bkg), fsig);
 
-      std::unique_ptr<RooDataSet> data{model.generate(RooArgSet(x, y, z), 20000)};
+      std::unique_ptr<RooDataSet> data{model.generate({x, y, z}, 20000)};
 
       // P r o j e c t   p d f   a n d   d a t a   o n   x
       // -------------------------------------------------
@@ -2329,7 +2329,7 @@ public:
       // ---------------------------------------------------------------------------------------------
 
       // Generate large number of events for MC integration of pdf projection
-      std::unique_ptr<RooDataSet> mcprojData{model.generate(RooArgSet(x, y, z), 10000)};
+      std::unique_ptr<RooDataSet> mcprojData{model.generate({x, y, z}, 10000)};
 
       // Calculate LL ratio for each generated event and select MC events with llratio)0.7
       mcprojData->addColumn(llratio_func);
@@ -2586,7 +2586,7 @@ public:
 
       // Generate a dummy dataset
       RooRealVar x("x", "x", 0, 10);
-      std::unique_ptr<RooDataSet> data{RooPolynomial("p", "p", x).generate(RooArgSet(x, b0flav, tagCat), 10000)};
+      std::unique_ptr<RooDataSet> data{RooPolynomial("p", "p", x).generate({x, b0flav, tagCat}, 10000)};
 
       // P r i n t   t a b l e s   o f   c a t e g o r y   c o n t e n t s   o f   d a t a s e t s
       // ------------------------------------------------------------------------------------------
@@ -2745,7 +2745,7 @@ public:
       // Construct a dummy dataset with random values of tagCat and b0flav
       RooRealVar x("x", "x", 0, 10);
       RooPolynomial p("p", "p", x);
-      std::unique_ptr<RooDataSet> data{p.generate(RooArgSet(x, b0flav, tagCat), 10000)};
+      std::unique_ptr<RooDataSet> data{p.generate({x, b0flav, tagCat}, 10000)};
 
       // C r e a t e   a   c a t - > c a t   m  a p p i n g   c a t e g o r y
       // ---------------------------------------------------------------------
@@ -2843,8 +2843,8 @@ public:
       // ---------------------------------------------------------------
 
       // Generate 1000 events in x and y from model
-      std::unique_ptr<RooDataSet> data{model.generate(RooArgSet(x), 100)};
-      std::unique_ptr<RooDataSet> data_ctl{model_ctl.generate(RooArgSet(x), 2000)};
+      std::unique_ptr<RooDataSet> data{model.generate({x}, 100)};
+      std::unique_ptr<RooDataSet> data_ctl{model_ctl.generate({x}, 2000)};
 
       // C r e a t e   i n d e x   c a t e g o r y   a n d   j o i n   s a m p l e s
       // ---------------------------------------------------------------------------
@@ -3640,7 +3640,7 @@ public:
       RooProdPdf model("model", "model", shapePdf, Conditional(effPdf, cut));
 
       // Generate some toy data from model
-      std::unique_ptr<RooDataSet> data{model.generate(RooArgSet(x, cut), 10000)};
+      std::unique_ptr<RooDataSet> data{model.generate({x, cut}, 10000)};
 
       // F i t   c o n d i t i o n a l   e f f i c i e n c y   p d f   t o   d a t a
       // --------------------------------------------------------------------------
@@ -3721,7 +3721,7 @@ public:
       RooProdPdf model("model", "model", shapePdf, Conditional(effPdf, cut));
 
       // Generate some toy data from model
-      std::unique_ptr<RooDataSet> data{model.generate(RooArgSet(x, y, cut), 10000)};
+      std::unique_ptr<RooDataSet> data{model.generate({x, y, cut}, 10000)};
 
       // F i t   c o n d i t i o n a l   e f f i c i e n c y   p d f   t o   d a t a
       // --------------------------------------------------------------------------
@@ -3855,7 +3855,7 @@ public:
       RooRealSumPdf pdf("pdf", "pdf", RooArgList(ampl1, ampl2), RooArgList(f1, f2));
 
       // Generate some toy data from pdf
-      std::unique_ptr<RooDataSet> data{pdf.generate(RooArgSet(t, cosa), 10000)};
+      std::unique_ptr<RooDataSet> data{pdf.generate({t, cosa}, 10000)};
 
       // Fit pdf to toy data with only amplitude strength floating
       pdf.fitTo(*data);
@@ -4119,7 +4119,7 @@ public:
       RooRealVar y("y", "y", 0, 20);
       RooPolynomial py("py", "py", y, RooArgList(0.01, 0.01, -0.0004));
       RooProdPdf pxy("pxy", "pxy", RooArgSet(p, py));
-      std::unique_ptr<RooDataSet> data2{pxy.generate(RooArgSet(x, y), 1000)};
+      std::unique_ptr<RooDataSet> data2{pxy.generate({x, y}, 1000)};
 
       // C r e a t e   2 - D   k e r n e l   e s t i m a t i o n   p d f
       // ---------------------------------------------------------------
@@ -4192,7 +4192,7 @@ public:
       // ---------------------------------------------------
 
       // Generate some data
-      std::unique_ptr<RooDataSet> data{bmix.generate(RooArgSet(dt, mixState, tagFlav), 10000)};
+      std::unique_ptr<RooDataSet> data{bmix.generate({dt, mixState, tagFlav}, 10000)};
 
       // Plot B0 and B0bar tagged data separately
       // For all plots below B0 and B0 tagged data will look somewhat differently
@@ -4244,7 +4244,7 @@ public:
       // ---------------------------------------------------------------------------
 
       // Generate some data
-      std::unique_ptr<RooDataSet> data2{bcp.generate(RooArgSet(dt, tagFlav), 10000)};
+      std::unique_ptr<RooDataSet> data2{bcp.generate({dt, tagFlav}, 10000)};
 
       // Plot B0 and B0bar tagged data separately
       RooPlot *frame4 = dt.frame(Title("B decay distribution with CPV(|l|=1,Im(l)=0.7) (B0/B0bar)"));
@@ -4261,7 +4261,7 @@ public:
       absLambda = 0.7;
 
       // Generate some data
-      std::unique_ptr<RooDataSet> data3{bcp.generate(RooArgSet(dt, tagFlav), 10000)};
+      std::unique_ptr<RooDataSet> data3{bcp.generate({dt, tagFlav}, 10000)};
 
       // Plot B0 and B0bar tagged data separately (sin2b = 0.7 plus direct CPV |l|=0.5)
       RooPlot *frame5 = dt.frame(Title("B decay distribution with CPV(|l|=0.7,Im(l)=0.7) (B0/B0bar)"));
@@ -4300,7 +4300,7 @@ public:
       // -------------------------------------------------------------------------------------
 
       // Generate some data
-      std::unique_ptr<RooDataSet> data4{bcpg.generate(RooArgSet(dt, tagFlav), 10000)};
+      std::unique_ptr<RooDataSet> data4{bcpg.generate({dt, tagFlav}, 10000)};
 
       // Plot B0 and B0bar tagged data separately
       RooPlot *frame6 = dt.frame(Title("B decay distribution with CPV(Im(l)=0.7,Re(l)=0.7,|l|=1,dG/G=0.5) (B0/B0bar)"));

--- a/roofit/roostats/inc/RooStats/NumberCountingPdfFactory.h
+++ b/roofit/roostats/inc/RooStats/NumberCountingPdfFactory.h
@@ -23,8 +23,7 @@ namespace RooStats{
 
    public:
       /// need one for expected and one for observed
-      NumberCountingPdfFactory();
-      virtual ~NumberCountingPdfFactory();
+      virtual ~NumberCountingPdfFactory() = default;
 
       void AddModel(double* sigExp, Int_t nchan, RooWorkspace* ws,
                     const char* pdfName = "CombinedPdf", const char* masterSignalName = "masterSignal") ;

--- a/roofit/roostats/src/NumberCountingPdfFactory.cxx
+++ b/roofit/roostats/src/NumberCountingPdfFactory.cxx
@@ -55,23 +55,6 @@ For the future, perhaps this factory should be extended to include the efficienc
 ClassImp(RooStats::NumberCountingPdfFactory); ;
 
 
-using namespace RooStats;
-using namespace RooFit;
-using namespace std;
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// constructor
-
-NumberCountingPdfFactory::NumberCountingPdfFactory() {
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// destructor
-
-NumberCountingPdfFactory::~NumberCountingPdfFactory(){
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 /// This method produces a PDF for N channels with uncorrelated background
 /// uncertainty. It relates the signal in each channel to a master signal strength times the
@@ -79,16 +62,9 @@ NumberCountingPdfFactory::~NumberCountingPdfFactory(){
 ///
 /// For the future, perhaps this method should be extended to include the efficiency terms automatically.
 
-void NumberCountingPdfFactory::AddModel(double* sig,
-               Int_t nbins,
-               RooWorkspace* ws,
-               const char* pdfName, const char* muName) {
-
-
-
-   using namespace RooFit;
-   using std::vector;
-
+void RooStats::NumberCountingPdfFactory::AddModel(double *sig, Int_t nbins, RooWorkspace *ws, const char *pdfName,
+                                                  const char *muName)
+{
    TList likelihoodFactors;
 
    //  double MaxSigma = 8; // Needed to set ranges for variables.
@@ -154,12 +130,9 @@ void NumberCountingPdfFactory::AddModel(double* sig,
 /// Arguments are an array of expected signal, expected background, and relative
 /// background uncertainty (eg. 0.1 for 10% uncertainty), and the number of channels.
 
-void NumberCountingPdfFactory::AddExpData(double* sig,
-                 double* back,
-                 double* back_syst,
-                 Int_t nbins,
-                 RooWorkspace* ws, const char* dsName) {
-
+void RooStats::NumberCountingPdfFactory::AddExpData(double *sig, double *back, double *back_syst, Int_t nbins,
+                                                    RooWorkspace *ws, const char *dsName)
+{
    std::vector<double> mainMeas(nbins);
 
    // loop over channels
@@ -174,12 +147,9 @@ void NumberCountingPdfFactory::AddExpData(double* sig,
 /// ratio of background expected in the sideband to that expected in signal region,
 /// and the number of channels.
 
-void NumberCountingPdfFactory::AddExpDataWithSideband(double* sigExp,
-                                                      double* backExp,
-                                                      double* tau,
-                                                      Int_t nbins,
-                                                      RooWorkspace* ws, const char* dsName) {
-
+void RooStats::NumberCountingPdfFactory::AddExpDataWithSideband(double *sigExp, double *backExp, double *tau,
+                                                                Int_t nbins, RooWorkspace *ws, const char *dsName)
+{
    std::vector<double> mainMeas(nbins);
    std::vector<double> sideband(nbins);
    for(Int_t i=0; i<nbins; ++i){
@@ -194,22 +164,24 @@ void NumberCountingPdfFactory::AddExpDataWithSideband(double* sigExp,
 /// need to be careful here that the range of observable in the dataset is consistent with the one in the workspace
 /// don't rescale unless necessary.  If it is necessary, then rescale by x10 or a defined maximum.
 
-RooRealVar* NumberCountingPdfFactory::SafeObservableCreation(RooWorkspace* ws, const char* varName, double value) {
-   return SafeObservableCreation(ws, varName, value, 10.*value);
-
+RooRealVar *
+RooStats::NumberCountingPdfFactory::SafeObservableCreation(RooWorkspace *ws, const char *varName, double value)
+{
+   return SafeObservableCreation(ws, varName, value, 10. * value);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// need to be careful here that the range of observable in the dataset is consistent with the one in the workspace
 /// don't rescale unless necessary.  If it is necessary, then rescale by x10 or a defined maximum.
 
-RooRealVar* NumberCountingPdfFactory::SafeObservableCreation(RooWorkspace* ws, const char* varName,
-                          double value, double maximum) {
+RooRealVar *RooStats::NumberCountingPdfFactory::SafeObservableCreation(RooWorkspace *ws, const char *varName,
+                                                                       double value, double maximum)
+{
    RooRealVar*   x = ws->var( varName );
    if( !x )
       x = new RooRealVar(varName, varName, value, 0, maximum );
    if( x->getMax() < value )
-      x->setMax( max(x->getMax(), 10*value ) );
+      x->setMax( std::max(x->getMax(), 10*value ) );
    x->setVal( value );
 
    return x;
@@ -220,15 +192,9 @@ RooRealVar* NumberCountingPdfFactory::SafeObservableCreation(RooWorkspace* ws, c
 /// Arguments are an array of results from a main measurement, a measured background,
 ///  and relative background uncertainty (eg. 0.1 for 10% uncertainty), and the number of channels.
 
-void NumberCountingPdfFactory::AddData(double* mainMeas,
-                                       double* back,
-                                       double* back_syst,
-                                       Int_t nbins,
-                                       RooWorkspace* ws, const char* dsName) {
-
-   using namespace RooFit;
-   using std::vector;
-
+void RooStats::NumberCountingPdfFactory::AddData(double *mainMeas, double *back, double *back_syst, Int_t nbins,
+                                                 RooWorkspace *ws, const char *dsName)
+{
    double MaxSigma = 8; // Needed to set ranges for variables.
 
    TList observablesCollection;
@@ -251,10 +217,10 @@ void NumberCountingPdfFactory::AddData(double* mainMeas,
 
       oocoutW(ws,ObjectHandling) << "NumberCountingPdfFactory: changed value of " << tau->GetName() << " to " << tau->getVal() <<
          " to be consistent with background and its uncertainty. " <<
-         " Also stored these values of tau into workspace with name . " << (string(tau->GetName())+string(dsName)).c_str() <<
-         " if you test with a different dataset, you should adjust tau appropriately.\n"<< endl;
+         " Also stored these values of tau into workspace with name . " << (std::string{tau->GetName()}+dsName).c_str() <<
+         " if you test with a different dataset, you should adjust tau appropriately.\n"<< std::endl;
       RooMsgService::instance().setGlobalKillBelow(RooFit::ERROR) ;
-      ws->import(*(static_cast<RooRealVar*>(tau->clone( (string(tau->GetName())+string(dsName)).c_str() )) ) );
+      ws->import(*(static_cast<RooRealVar*>(tau->clone( (std::string{tau->GetName()}+dsName).c_str() )) ) );
       RooMsgService::instance().setGlobalKillBelow(RooFit::DEBUG) ;
 
       // need to be careful
@@ -285,13 +251,11 @@ void NumberCountingPdfFactory::AddData(double* mainMeas,
    //  observableSet->Print();
    //  observableList->Print();
 
-   RooDataSet* data = new RooDataSet(dsName,"Number Counting Data", tree, *observableList); // one experiment
-   //  data->Scan();
-
+   RooDataSet data{dsName,"Number Counting Data", *observableList, RooFit::Import(*tree)}; // one experiment
 
    // import hypothetical data
    RooMsgService::instance().setGlobalKillBelow(RooFit::FATAL) ;
-   ws->import(*data);
+   ws->import(data);
    RooMsgService::instance().setGlobalKillBelow(RooFit::DEBUG) ;
 
 }
@@ -300,15 +264,9 @@ void NumberCountingPdfFactory::AddData(double* mainMeas,
 /// Arguments are an array of expected signal, expected background, and relative
 /// background uncertainty (eg. 0.1 for 10% uncertainty), and the number of channels.
 
-void NumberCountingPdfFactory::AddDataWithSideband(double* mainMeas,
-                                                   double* sideband,
-                                                   double* tauForTree,
-                                                   Int_t nbins,
-                                                   RooWorkspace* ws, const char* dsName) {
-
-   using namespace RooFit;
-   using std::vector;
-
+void RooStats::NumberCountingPdfFactory::AddDataWithSideband(double *mainMeas, double *sideband, double *tauForTree,
+                                                             Int_t nbins, RooWorkspace *ws, const char *dsName)
+{
    double MaxSigma = 8; // Needed to set ranges for variables.
 
    TList observablesCollection;
@@ -333,10 +291,10 @@ void NumberCountingPdfFactory::AddDataWithSideband(double* mainMeas,
 
       oocoutW(ws,ObjectHandling) << "NumberCountingPdfFactory: changed value of " << tau->GetName() << " to " << tau->getVal() <<
          " to be consistent with background and its uncertainty. " <<
-         " Also stored these values of tau into workspace with name . " << (string(tau->GetName())+string(dsName)).c_str() <<
-         " if you test with a different dataset, you should adjust tau appropriately.\n"<< endl;
+         " Also stored these values of tau into workspace with name . " << (std::string{tau->GetName()}+dsName).c_str() <<
+         " if you test with a different dataset, you should adjust tau appropriately.\n"<< std::endl;
       RooMsgService::instance().setGlobalKillBelow(RooFit::ERROR) ;
-      ws->import(*(static_cast<RooRealVar*>(tau->clone( (string(tau->GetName())+string(dsName)).c_str() )) ) );
+      ws->import(*(static_cast<RooRealVar*>(tau->clone( (std::string{tau->GetName()}+dsName).c_str() )) ) );
       RooMsgService::instance().setGlobalKillBelow(RooFit::DEBUG) ;
 
       // need to be careful
@@ -360,21 +318,13 @@ void NumberCountingPdfFactory::AddDataWithSideband(double* mainMeas,
 
    }
    tree->Fill();
-   //  tree->Print();
-   //  tree->Scan();
 
-   RooArgList* observableList = new RooArgList(observablesCollection);
+   RooArgList observableList{observablesCollection};
 
-   //  observableSet->Print();
-   //  observableList->Print();
-
-   RooDataSet* data = new RooDataSet(dsName,"Number Counting Data", tree, *observableList); // one experiment
-   //  data->Scan();
-
+   RooDataSet data{dsName,"Number Counting Data", observableList, RooFit::Import(*tree)}; // one experiment
 
    // import hypothetical data
    RooMsgService::instance().setGlobalKillBelow(RooFit::FATAL) ;
-   ws->import(*data);
+   ws->import(data);
    RooMsgService::instance().setGlobalKillBelow(RooFit::DEBUG) ;
-
 }

--- a/roofit/xroofit/src/xRooFit.cxx
+++ b/roofit/xroofit/src/xRooFit.cxx
@@ -300,8 +300,8 @@ xRooFit::generateFrom(RooAbsPdf &pdf, const RooFitResult &_fr, bool expected, in
       if (auto s = dynamic_cast<RooSimultaneous *>(_pdf)) {
          // do subpdf's individually
          _obs->add(w);
-         _out.first.reset(new RooDataSet(
-            uuid, TString::Format("%s %s", _pdf->GetTitle(), (expected) ? "Expected" : "Toy"), *_obs, "weightVar"));
+         _out.first = std::make_unique<RooDataSet>(
+            uuid, TString::Format("%s %s", _pdf->GetTitle(), (expected) ? "Expected" : "Toy"), *_obs, RooFit::WeightVar("weightVar"));
 
          for (auto &c : s->indexCat()) {
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6, 22, 00)
@@ -356,7 +356,7 @@ xRooFit::generateFrom(RooAbsPdf &pdf, const RooFitResult &_fr, bool expected, in
          _obs->add(w);
          RooArgSet _tmp;
          _tmp.add(w);
-         _out.first.reset(new RooDataSet("", "Toy", _tmp, "weightVar"));
+         _out.first = std::make_unique<RooDataSet>("", "Toy", _tmp, RooFit::WeightVar("weightVar"));
          _out.first->add(_tmp);
       } else {
          if (_pdf->canBeExtended()) {

--- a/roofit/xroofit/src/xRooNLLVar.cxx
+++ b/roofit/xroofit/src/xRooNLLVar.cxx
@@ -2871,7 +2871,7 @@ RooStats::HypoTestResult xRooNLLVar::xRooHypoPoint::result()
    nullDetails.addClone(RooRealVar("seed", "Toy Seed", 0));
    nullDetails.addClone(RooRealVar("ts", "test statistic value", 0));
    nullDetails.addClone(RooRealVar("weight", "weight", 1));
-   auto nullToyDS = new RooDataSet("nullToys", "nullToys", nullDetails, "weight");
+   auto nullToyDS = new RooDataSet("nullToys", "nullToys", nullDetails, RooFit::WeightVar("weight"));
    nullToyDS->setGlobalObservables(nullMeta);
    if (!nullToys.empty()) {
 
@@ -2918,7 +2918,7 @@ RooStats::HypoTestResult xRooNLLVar::xRooHypoPoint::result()
       altDetails.addClone(RooRealVar("seed", "Toy Seed", 0));
       altDetails.addClone(RooRealVar("ts", "test statistic value", 0));
       altDetails.addClone(RooRealVar("weight", "weight", 1));
-      auto altToyDS = new RooDataSet("altToys", "altToys", altDetails, "weight");
+      auto altToyDS = new RooDataSet("altToys", "altToys", altDetails, RooFit::WeightVar("weight"));
       altToyDS->setGlobalObservables(altMeta);
       for (auto &t : altToys) {
          values.push_back(std::get<1>(t));

--- a/roofit/xroofit/src/xRooNode.cxx
+++ b/roofit/xroofit/src/xRooNode.cxx
@@ -1523,7 +1523,7 @@ xRooNode xRooNode::Add(const xRooNode &child, Option_t *opt)
          } else {
             RooRealVar w("weightVar", "weightVar", 1);
             _obs.add(w);
-            RooDataSet d(child.GetName(), child.GetTitle(), _obs, "weightVar");
+            RooDataSet d(child.GetName(), child.GetTitle(), _obs, RooFit::WeightVar("weightVar"));
             _ws->import(d);
             // seems have to set bits after importing, not before
             if (auto __d = _ws->data(child.GetName()))

--- a/test/fit/testFitPerf.cxx
+++ b/test/fit/testFitPerf.cxx
@@ -548,8 +548,7 @@ int  FitUsingRooFit(TTree * tree, TF1 * func) {
       RooRealVar x("x","x",-100,100) ;
       RooRealVar y("y","y",-100,100);
 
-      RooDataSet data("unbindata","unbin dataset with x",tree,RooArgSet(x,y)) ;
-
+      RooDataSet data("unbindata","unbin dataset with x", {x,y}, RooFit::Import(*tree)) ;
 
       RooRealVar mean("mean","Mean of Gaussian",iniPar[0], -100,100) ;
       RooRealVar sigma("sigma","Width of Gaussian",iniPar[1], 0.01, 100) ;
@@ -625,8 +624,7 @@ int  FitUsingRooFit2(TTree * tree) {
          xvars.add( *x[j] );
       }
 
-
-      RooDataSet data("unbindata","unbin dataset with x",tree,xvars) ;
+      RooDataSet data("unbindata","unbin dataset with x",xvars, RooFit::Import(*tree));
 
       // create the gaussians
       for (int j = 0; j < N; ++j) {
@@ -651,9 +649,6 @@ int  FitUsingRooFit2(TTree * tree) {
 //             pdf[0] = g[0];
 
       }
-
-
-
 
 #ifdef DEBUG
       int level = 3;

--- a/test/fit/testRooFit.cxx
+++ b/test/fit/testRooFit.cxx
@@ -205,9 +205,7 @@ int  FitUsingRooFit(TTree & tree, RooAbsPdf & pdf, RooArgSet & xvars) {
 
    for (int i = 0; i < nfit; ++i) {
 
-      RooDataSet data("unbindata","unbin dataset with x",&tree,xvars) ;
-
-
+      RooDataSet data("unbindata","unbin dataset with x", xvars, RooFit::Import(tree));
 
 #ifdef DEBUG
       int level = 2;

--- a/tutorials/roofit/rf609_xychi2fit.C
+++ b/tutorials/roofit/rf609_xychi2fit.C
@@ -35,7 +35,7 @@ void rf609_xychi2fit()
 
    RooRealVar x("x", "x", -11, 11);
    RooRealVar y("y", "y", -10, 200);
-   RooDataSet dxy("dxy", "dxy", RooArgSet(x, y), StoreError(RooArgSet(x, y)));
+   RooDataSet dxy("dxy", "dxy", {x, y}, StoreError({x, y}));
 
    // Fill an example dataset with X,err(X),Y,err(Y) values
    for (int i = 0; i <= 10; i++) {
@@ -48,7 +48,7 @@ void rf609_xychi2fit()
       y = x.getVal() * x.getVal() + 4 * fabs(gRandom->Gaus());
       y.setError(sqrt(y.getVal()));
 
-      dxy.add(RooArgSet(x, y));
+      dxy.add({x, y});
    }
 
    // P e r f o r m   c h i 2   f i t   t o   X + / - d x   a n d   Y + / - d Y   v a l u e s

--- a/tutorials/roostats/rs701_BayesianCalculator.C
+++ b/tutorials/roostats/rs701_BayesianCalculator.C
@@ -38,8 +38,8 @@ void rs701_BayesianCalculator(bool useBkg = true, double confLevel = 0.90)
 
    w->factory("n[3]"); // observed number of events
    // create a data set with n observed events
-   RooDataSet data("data", "", RooArgSet(*(w->var("x")), *(w->var("n"))), "n");
-   data.add(RooArgSet(*(w->var("x"))), w->var("n")->getVal());
+   RooDataSet data("data", "", {*w->var("x"), *w->var("n")}, RooFit::WeightVar("n"));
+   data.add({*(w->var("x"))}, w->var("n")->getVal());
 
    // to suppress messages when pdf goes to zero
    RooMsgService::instance().setGlobalKillBelow(RooFit::FATAL);

--- a/tutorials/roostats/rs701_BayesianCalculator.py
+++ b/tutorials/roostats/rs701_BayesianCalculator.py
@@ -27,7 +27,7 @@ priorPOI2 = w.factory("GenericPdf::priorPOI2('1/sqrt(@0)',s)")
 
 w.factory("n[3]")  # observed number of events
 # create a data set with n observed events
-data = ROOT.RooDataSet("data", "", {w["x"], w["n"]}, "n")
+data = ROOT.RooDataSet("data", "", {w["x"], w["n"]}, WeightVar="n")
 data.add({w["x"]}, w["n"].getVal())
 
 # to suppress messages when pdf goes to zero


### PR DESCRIPTION
The other constructors can cause some confusion to the users.

For now, this change is only to see the result of the CI.

