### PR TITLE
[ntuple] Further improve `RNTupleInspector::GetPageSizeDistribution`

### DIFF
--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -271,6 +271,12 @@ public:
    const std::vector<DescriptorId_t> GetColumnsByType(EColumnType colType);
 
    /////////////////////////////////////////////////////////////////////////////
+   /// \brief Get all column types present in the RNTuple being inspected.
+   ///
+   /// \return A vector containing all column types present in the RNTuple.
+   const std::vector<EColumnType> GetColumnTypes();
+
+   /////////////////////////////////////////////////////////////////////////////
    /// \brief Print storage information per column type.
    ///
    /// \param[in] format Whether to print the information as a (markdown-parseable) table or in CSV format.

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -22,6 +22,7 @@
 
 #include <TFile.h>
 #include <TH1D.h>
+#include <THStack.h>
 
 #include <cstdlib>
 #include <memory>
@@ -357,6 +358,37 @@ public:
    /// The x-axis will range from the smallest page size, to the largest (inclusive).
    std::unique_ptr<TH1D> GetPageSizeDistribution(EColumnType colType, std::string histName = "",
                                                  std::string histTitle = "", size_t nBins = 64);
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Get a histogram containing the size distribution of the compressed pages for a collection columns.
+   ///
+   /// \param[in] colIds The physical IDs of the columns for which to get the page size distribution.
+   /// \param[in] histName The name of the histogram. An empty string means a default name will be used.
+   /// \param[in] histTitle The title of the histogram. An empty string means a default title will be used.
+   /// \param[in] nBins The desired number of histogram bins.
+   ///
+   /// \return A pointer to a `TH1D` containing the (cumulative) page size distribution.
+   ///
+   /// The x-axis will range from the smallest page size, to the largest (inclusive).
+   std::unique_ptr<TH1D> GetPageSizeDistribution(const std::vector<DescriptorId_t> &colIds, std::string histName = "",
+                                                 std::string histTitle = "", size_t nBins = 64);
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Get a histogram containing the size distribution of the compressed pages for all columns of a given list
+   /// of types.
+   ///
+   /// \param[in] colTypes The column types for which to get the size distribution, as defined by
+   /// ROOT::Experimental::EColumnType.
+   /// \param[in] histName The name of the histogram. An empty string means a default name will be used.
+   /// \param[in] histTitle The title of the histogram. An empty string means a default title will be used.
+   /// \param[in] nBins The desired number of histogram bins.
+   ///
+   /// \return A pointer to a `THStack` containing the page size distribution. Options and examples for displaying can
+   /// be found in the `THStack` documentation.
+   ///
+   /// The x-axis will range from the smallest page size, to the largest (inclusive).
+   std::unique_ptr<THStack> GetPageSizeDistribution(const std::vector<EColumnType> &colTypes, std::string histName = "",
+                                                    std::string histTitle = "", size_t nBins = 64);
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Get storage information for a given (sub)field by ID.

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -376,25 +376,44 @@ public:
    /// \return A pointer to a `TH1D` containing the (cumulative) page size distribution.
    ///
    /// The x-axis will range from the smallest page size, to the largest (inclusive).
-   std::unique_ptr<TH1D> GetPageSizeDistribution(const std::vector<DescriptorId_t> &colIds, std::string histName = "",
-                                                 std::string histTitle = "", size_t nBins = 64);
+   std::unique_ptr<TH1D> GetPageSizeDistribution(std::initializer_list<DescriptorId_t> colIds,
+                                                 std::string histName = "", std::string histTitle = "",
+                                                 size_t nBins = 64);
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Get a histogram containing the size distribution of the compressed pages for all columns of a given list
    /// of types.
    ///
    /// \param[in] colTypes The column types for which to get the size distribution, as defined by
-   /// ROOT::Experimental::EColumnType.
-   /// \param[in] histName The name of the histogram. An empty string means a default name will be used.
+   /// ROOT::Experimental::EColumnType. The default is an empty vector, which indicates that the distribution for *all*
+   /// physical columns will be returned.
+   /// \param[in] histName The name of the histogram. An empty string means a default name will be used. The name of
+   /// each histogram inside the `THStack` will be `histName + colType`.
    /// \param[in] histTitle The title of the histogram. An empty string means a default title will be used.
    /// \param[in] nBins The desired number of histogram bins.
    ///
-   /// \return A pointer to a `THStack` containing the page size distribution. Options and examples for displaying can
-   /// be found in the `THStack` documentation.
+   /// \return A pointer to a `THStack` with one histogram for each column type.
    ///
    /// The x-axis will range from the smallest page size, to the largest (inclusive).
-   std::unique_ptr<THStack> GetPageSizeDistribution(const std::vector<EColumnType> &colTypes, std::string histName = "",
-                                                    std::string histTitle = "", size_t nBins = 64);
+   ///
+   /// **Example: Drawing a non-stacked page size distribution with a legend**
+   /// ~~~ {.cpp}
+   /// auto canvas = std::make_unique<TCanvas>();
+   /// auto inspector = RNTupleInspector::Create("myNTuple", "ntuple.root");
+   ///
+   /// // We want to show the page size distributions of columns with type `kSplitReal32` and `kSplitReal64`.
+   /// auto hist = inspector->GetPageSizeDistribution(
+   ///     {ROOT::Experimental::EColumnType::kSplitReal32,
+   ///      ROOT::Experimental::EColumnType::kSplitReal64});
+   /// // The "PLC" option automatically sets the line color for each histogram in the `THStack`.
+   /// // The "NOSTACK" option will draw the histograms on top of each other instead of stacked.
+   /// hist->DrawClone("PLC NOSTACK");
+   /// canvas->BuildLegend(0.7, 0.8, 0.89, 0.89);
+   /// canvas->DrawClone();
+   /// ~~~
+   std::unique_ptr<THStack> GetPageSizeDistribution(std::initializer_list<EColumnType> colTypes = {},
+                                                    std::string histName = "", std::string histTitle = "",
+                                                    size_t nBins = 64);
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Get storage information for a given (sub)field by ID.

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -307,18 +307,24 @@ std::unique_ptr<TH1D> ROOT::Experimental::RNTupleInspector::GetPageSizeDistribut
                                                                                     std::string histName,
                                                                                     std::string histTitle, size_t nBins)
 {
+   auto hist = std::make_unique<TH1D>();
+
    if (histName.empty())
       histName = "pageSizeHistCol" + std::to_string(physicalColumnId);
+   hist->SetName(histName.c_str());
 
    if (histTitle.empty())
       histTitle = "Page size distribution for column with ID " + std::to_string(physicalColumnId);
+   hist->SetTitle(histTitle.c_str());
+   hist->SetXTitle("Page size (B)");
+   hist->SetYTitle("N_{pages}");
 
    auto colInfo = GetColumnInspector(physicalColumnId);
    auto histMinMax =
       std::minmax_element(colInfo.GetCompressedPageSizes().begin(), colInfo.GetCompressedPageSizes().end());
-   auto hist = std::make_unique<TH1D>(
-      std::string(histName).c_str(), std::string(histTitle).c_str(), nBins, *histMinMax.first,
-      *histMinMax.second + ((*histMinMax.second - *histMinMax.first) / static_cast<double>(nBins)));
+
+   hist->SetBins(nBins, *histMinMax.first,
+                 *histMinMax.second + ((*histMinMax.second - *histMinMax.first) / static_cast<double>(nBins)));
 
    for (const auto pageSize : colInfo.GetCompressedPageSizes()) {
       hist->Fill(pageSize);
@@ -331,16 +337,22 @@ std::unique_ptr<TH1D>
 ROOT::Experimental::RNTupleInspector::GetPageSizeDistribution(ROOT::Experimental::EColumnType colType,
                                                               std::string histName, std::string histTitle, size_t nBins)
 {
+   auto hist = std::make_unique<TH1D>();
+
    if (histName.empty())
       histName = "pageSizeHistCol" + Detail::RColumnElementBase::GetTypeName(colType);
+   hist->SetName(histName.c_str());
 
    if (histTitle.empty())
       histTitle = "Page size distribution for columns with type " + Detail::RColumnElementBase::GetTypeName(colType);
+   hist->SetTitle(histTitle.c_str());
+   hist->SetXTitle("Page size (B)");
+   hist->SetYTitle("N_{pages}");
 
    auto colIds = GetColumnsByType(colType);
 
    if (colIds.empty())
-      return std::make_unique<TH1D>(std::string(histName).c_str(), std::string(histTitle).c_str(), nBins, 0, nBins);
+      return hist;
 
    std::vector<std::uint64_t> pageSizes;
    std::for_each(colIds.begin(), colIds.end(), [this, &pageSizes](const auto colId) {
@@ -350,9 +362,8 @@ ROOT::Experimental::RNTupleInspector::GetPageSizeDistribution(ROOT::Experimental
    });
 
    auto histMinMax = std::minmax_element(pageSizes.begin(), pageSizes.end());
-   auto hist = std::make_unique<TH1D>(
-      std::string(histName).c_str(), std::string(histTitle).c_str(), nBins, *histMinMax.first,
-      *histMinMax.second + ((*histMinMax.second - *histMinMax.first) / static_cast<double>(nBins)));
+   hist->SetBins(nBins, *histMinMax.first,
+                 *histMinMax.second + ((*histMinMax.second - *histMinMax.first) / static_cast<double>(nBins)));
 
    for (const auto pageSize : pageSizes) {
       hist->Fill(pageSize);

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -339,6 +339,9 @@ ROOT::Experimental::RNTupleInspector::GetPageSizeDistribution(ROOT::Experimental
 
    auto colIds = GetColumnsByType(colType);
 
+   if (colIds.empty())
+      return std::make_unique<TH1D>(std::string(histName).c_str(), std::string(histTitle).c_str(), nBins, 0, nBins);
+
    std::vector<std::uint64_t> pageSizes;
    std::for_each(colIds.begin(), colIds.end(), [this, &pageSizes](const auto colId) {
       auto colInfo = GetColumnInspector(colId);

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -218,6 +218,17 @@ ROOT::Experimental::RNTupleInspector::GetColumnsByType(ROOT::Experimental::EColu
    return colIds;
 }
 
+const std::vector<ROOT::Experimental::EColumnType> ROOT::Experimental::RNTupleInspector::GetColumnTypes()
+{
+   std::set<EColumnType> colTypes;
+
+   for (const auto &[colId, colInfo] : fColumnInfo) {
+      colTypes.emplace(colInfo.GetType());
+   }
+
+   return std::vector(colTypes.begin(), colTypes.end());
+}
+
 void ROOT::Experimental::RNTupleInspector::PrintColumnTypeInfo(ENTupleInspectorPrintFormat format, std::ostream &output)
 {
    struct ColumnTypeInfo {

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -492,6 +492,14 @@ TEST(RNTupleInspector, PageSizeDistribution)
       nFloatPages += inspector->GetColumnInspector(colId).GetNPages();
    }
    EXPECT_EQ(nFloatPages, floatPageSizeHisto->Integral());
+
+   // Requesting a histogram for a column with a physical ID not present in the given RNTuple should throw
+   EXPECT_THROW(inspector->GetPageSizeDistribution(inspector->GetDescriptor()->GetNPhysicalColumns() + 1),
+                ROOT::Experimental::RException);
+
+   // Requesting a histogram for a column type not present in the given RNTuple should give an empty histogram
+   auto nonExistingTypeHisto = inspector->GetPageSizeDistribution(EColumnType::kReal32);
+   EXPECT_EQ(0, nonExistingTypeHisto->Integral());
 }
 
 TEST(RNTupleInspector, FieldInfoCompressed)

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -477,6 +477,8 @@ TEST(RNTupleInspector, PageSizeDistribution)
    auto intPageSizeHisto = inspector->GetPageSizeDistribution(intColId);
    EXPECT_STREQ(Form("pageSizeHistCol%d", intColId), intPageSizeHisto->GetName());
    EXPECT_STREQ(Form("Page size distribution for column with ID %d", intColId), intPageSizeHisto->GetTitle());
+   EXPECT_STREQ("Page size (B)", intPageSizeHisto->GetXaxis()->GetTitle());
+   EXPECT_STREQ("N_{pages}", intPageSizeHisto->GetYaxis()->GetTitle());
 
    // Make sure that all page sizes are included in the histogram
    EXPECT_EQ(inspector->GetColumnInspector(intColId).GetNPages(), intPageSizeHisto->Integral());
@@ -485,6 +487,8 @@ TEST(RNTupleInspector, PageSizeDistribution)
       inspector->GetPageSizeDistribution(EColumnType::kSplitReal32, "floatPageSize", "Float page size distribution");
    EXPECT_STREQ("floatPageSize", floatPageSizeHisto->GetName());
    EXPECT_STREQ("Float page size distribution", floatPageSizeHisto->GetTitle());
+   EXPECT_STREQ("Page size (B)", floatPageSizeHisto->GetXaxis()->GetTitle());
+   EXPECT_STREQ("N_{pages}", floatPageSizeHisto->GetYaxis()->GetTitle());
 
    // Make sure that all page sizes are included in the histogram
    int nFloatPages = 0;

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -479,17 +479,17 @@ TEST(RNTupleInspector, PageSizeDistribution)
    EXPECT_STREQ(Form("Page size distribution for column with ID %d", intColId), intPageSizeHisto->GetTitle());
    EXPECT_STREQ("Page size (B)", intPageSizeHisto->GetXaxis()->GetTitle());
    EXPECT_STREQ("N_{pages}", intPageSizeHisto->GetYaxis()->GetTitle());
-
+   EXPECT_EQ(64, intPageSizeHisto->GetNbinsX());
    // Make sure that all page sizes are included in the histogram
    EXPECT_EQ(inspector->GetColumnInspector(intColId).GetNPages(), intPageSizeHisto->Integral());
 
-   auto floatPageSizeHisto =
-      inspector->GetPageSizeDistribution(EColumnType::kSplitReal32, "floatPageSize", "Float page size distribution");
+   auto floatPageSizeHisto = inspector->GetPageSizeDistribution(EColumnType::kSplitReal32, "floatPageSize",
+                                                                "Float page size distribution", 100);
    EXPECT_STREQ("floatPageSize", floatPageSizeHisto->GetName());
    EXPECT_STREQ("Float page size distribution", floatPageSizeHisto->GetTitle());
    EXPECT_STREQ("Page size (B)", floatPageSizeHisto->GetXaxis()->GetTitle());
    EXPECT_STREQ("N_{pages}", floatPageSizeHisto->GetYaxis()->GetTitle());
-
+   EXPECT_EQ(100, floatPageSizeHisto->GetNbinsX());
    // Make sure that all page sizes are included in the histogram
    int nFloatPages = 0;
    for (const auto colId : inspector->GetColumnsByType(EColumnType::kSplitReal32)) {


### PR DESCRIPTION
This PR adds the following fixes and improvements to `RNTupleInspector::GetPageSizeDistribution`:
* When the provided column type is not present in the RNTuple being inspected, an empty histogram is returned.
* When a provided column ID is not present in the RNTuple being inspected, an exception is thrown.
* Default axis titles have been added.
* An overloaded method to provide multiple column IDs at once has been added. The method taking only one ID has been adapted to use this overload.
* The option to provide multiple column types at once has been added. Here, a `THStack` is returned rather than a `TH1D`. The method taking only one type has been adapted to use this overload.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)


