### PR TITLE
[skip-ci] remove useless setting

### DIFF
--- a/tutorials/graphs/scatter.C
+++ b/tutorials/graphs/scatter.C
@@ -30,7 +30,6 @@ void scatter()
 
    auto scatter = new TScatter(n, x, y, c, s);
    scatter->SetMarkerStyle(20);
-   scatter->SetMarkerColor(kRed);
    scatter->SetTitle("Scatter plot;X;Y");
    scatter->Draw("A");
 }


### PR DESCRIPTION
No need to specify the marker color in that example.
