### PR TITLE
Fixes for TGeoTessellated and TGeoVGShape persistency.

### DIFF
--- a/geom/gdml/src/TGDMLWrite.cxx
+++ b/geom/gdml/src/TGDMLWrite.cxx
@@ -1741,11 +1741,11 @@ XMLNodePointer_t TGDMLWrite::CreateTessellatedN(TGeoTessellated *geoShape)
       bool triangular = facet.GetNvert() == 3;
       TString ntype = (triangular) ? "triangular" : "quadrangular";
       childN = fGdmlE->NewChild(nullptr, nullptr, ntype.Data(), nullptr);
-      fGdmlE->NewAttr(childN, nullptr, "vertex1", TString::Format("%s_%d", genname.Data(), facet.GetVertexIndex(0)));
-      fGdmlE->NewAttr(childN, nullptr, "vertex2", TString::Format("%s_%d", genname.Data(), facet.GetVertexIndex(1)));
-      fGdmlE->NewAttr(childN, nullptr, "vertex3", TString::Format("%s_%d", genname.Data(), facet.GetVertexIndex(2)));
+      fGdmlE->NewAttr(childN, nullptr, "vertex1", TString::Format("%s_%d", genname.Data(), facet[0]));
+      fGdmlE->NewAttr(childN, nullptr, "vertex2", TString::Format("%s_%d", genname.Data(), facet[1]));
+      fGdmlE->NewAttr(childN, nullptr, "vertex3", TString::Format("%s_%d", genname.Data(), facet[2]));
       if (!triangular)
-         fGdmlE->NewAttr(childN, nullptr, "vertex4", TString::Format("%s_%d", genname.Data(), facet.GetVertexIndex(3)));
+         fGdmlE->NewAttr(childN, nullptr, "vertex4", TString::Format("%s_%d", genname.Data(), facet[3]));
       fGdmlE->NewAttr(childN, nullptr, "type", "ABSOLUTE");
       fGdmlE->AddChild(mainN, childN);
    }

--- a/geom/geom/inc/TGeoTessellated.h
+++ b/geom/geom/inc/TGeoTessellated.h
@@ -12,6 +12,7 @@
 #ifndef ROOT_TGeoTessellated
 #define ROOT_TGeoTessellated
 
+#include <map>
 #include "TGeoVector3.h"
 #include "TGeoTypedefs.h"
 #include "TGeoBBox.h"
@@ -22,75 +23,28 @@ class TGeoFacet {
 
 private:
    int fIvert[4] = {0, 0, 0, 0};     // Vertex indices in the array
-   VertexVec_t *fVertices = nullptr; //! array of vertices
    int fNvert = 0;                   // number of vertices (can be 3 or 4)
-   bool fShared = false;             // Vector of vertices shared flag
+
+private:
+   void SetVertices(int nvert = 0, int i0 = -1, int i1 = -1, int i2 = -1, int i3 = -1)
+   {
+      fNvert = nvert;
+      fIvert[0] = i0;
+      fIvert[1] = i1;
+      fIvert[2] = i2;
+      fIvert[3] = i3;
+   }
 
 public:
    TGeoFacet() {}
-   TGeoFacet(const TGeoFacet &other);
+   TGeoFacet(int i0, int i1, int i2) { SetVertices(3, i0, i1, i2); }
+   TGeoFacet(int i0, int i1, int i2, int i3) { SetVertices(4, i0, i1, i2, i3); }
 
-   ~TGeoFacet()
-   {
-      if (!fShared)
-         delete fVertices;
-   }
-
-   const TGeoFacet &operator=(const TGeoFacet &other);
-
-   // Triangular facet
-   TGeoFacet(const Vertex_t &pt0, const Vertex_t &pt1, const Vertex_t &pt2) : fIvert{0, 1, 2}
-   {
-      fVertices = new VertexVec_t;
-      fVertices->push_back(pt0);
-      fVertices->push_back(pt1);
-      fVertices->push_back(pt2);
-      fNvert = 3;
-   }
-
-   // Quadrilateral facet
-   TGeoFacet(const Vertex_t &pt0, const Vertex_t &pt1, const Vertex_t &pt2, const Vertex_t &pt3) : fIvert{0, 1, 2, 3}
-   {
-      fVertices = new VertexVec_t;
-      fVertices->push_back(pt0);
-      fVertices->push_back(pt1);
-      fVertices->push_back(pt2);
-      fVertices->push_back(pt3);
-      fNvert = 4;
-   }
-
-   TGeoFacet(VertexVec_t *vertices, int nvert, int i0 = -1, int i1 = -1, int i2 = -1, int i3 = -1)
-   {
-      fShared = true;
-      SetVertices(vertices, nvert, i0, i1, i2, i3);
-   }
-
+   int operator[](int ivert) const { return fIvert[ivert]; }
    static int CompactFacet(Vertex_t *vert, int nvertices);
-
-   void SetVertices(VertexVec_t *vertices, int nvert = 0, int i0 = -1, int i1 = -1, int i2 = -1, int i3 = -1)
-   {
-      if (!fShared)
-         delete fVertices;
-      fVertices = vertices;
-      if (nvert > 0) {
-         fIvert[0] = i0;
-         fIvert[1] = i1;
-         fIvert[2] = i2;
-         fIvert[3] = i3;
-      }
-      fNvert = nvert;
-      fShared = true;
-   }
-
    Vertex_t ComputeNormal(bool &degenerated) const;
    int GetNvert() const { return fNvert; }
 
-   Vertex_t &GetVertex(int ivert) { return fVertices->operator[](fIvert[ivert]); }
-   const Vertex_t &GetVertex(int ivert) const { return fVertices->operator[](fIvert[ivert]); }
-
-   int GetVertexIndex(int ivert) const { return fIvert[ivert]; }
-
-   bool Check() const;
    void Flip()
    {
       int iv = fIvert[0];
@@ -99,8 +53,6 @@ public:
    }
    bool IsNeighbour(const TGeoFacet &other, bool &flip) const;
 };
-
-std::ostream &operator<<(std::ostream &os, TGeoFacet const &facet);
 
 class TGeoTessellated : public TGeoBBox {
 
@@ -115,6 +67,7 @@ private:
    bool fClosedBody = false;        // The faces are making a closed body
    std::vector<Vertex_t> fVertices; // List of vertices
    std::vector<TGeoFacet> fFacets;  // List of facets
+   std::multimap<long, int> fVerticesMap; //! Temporary map used to deduplicate vertices
 
    TGeoTessellated(const TGeoTessellated &) = delete;
    TGeoTessellated &operator=(const TGeoTessellated &) = delete;
@@ -134,6 +87,10 @@ public:
    bool AddFacet(const Vertex_t &pt0, const Vertex_t &pt1, const Vertex_t &pt2, const Vertex_t &pt3);
    bool AddFacet(int i1, int i2, int i3);
    bool AddFacet(int i1, int i2, int i3, int i4);
+   int AddVertex(const Vertex_t &vert);
+
+   bool FacetCheck(int ifacet) const;
+   Vertex_t FacetComputeNormal(int ifacet, bool &degenerated) const;
 
    int GetNfacets() const { return fFacets.size(); }
    int GetNsegments() const { return fNseg; }
@@ -144,7 +101,6 @@ public:
    const TGeoFacet &GetFacet(int i) const { return fFacets[i]; }
    const Vertex_t &GetVertex(int i) const { return fVertices[i]; }
 
-   void AfterStreamer() override;
    int DistancetoPrimitive(int, int) override { return 99999; }
    const TBuffer3D &GetBuffer3D(int reqSections, Bool_t localFrame) const override;
    void GetMeshNumbers(int &nvert, int &nsegs, int &npols) const override;

--- a/geom/vecgeom/inc/LinkDef.h
+++ b/geom/vecgeom/inc/LinkDef.h
@@ -13,6 +13,6 @@
 #pragma link off all functions;
 
 #pragma link C++ class TGeoVGConverter + ;
-#pragma link C++ class TGeoVGShape + ;
+#pragma link C++ class TGeoVGShape - ;
 
 #endif

--- a/geom/vecgeom/inc/TGeoVGShape.h
+++ b/geom/vecgeom/inc/TGeoVGShape.h
@@ -29,7 +29,7 @@ class VUnplacedVolume;
 
 class TGeoVGShape : public TGeoBBox {
 private:
-   vecgeom::cxx::VPlacedVolume *fVGShape; // VecGeom placed solid
+   vecgeom::cxx::VPlacedVolume *fVGShape; //! VecGeom placed solid
    TGeoShape *fShape;                     // ROOT shape
 
    static vecgeom::cxx::VPlacedVolume *CreateVecGeomSolid(TGeoShape *shape);
@@ -105,6 +105,6 @@ public:
    TGeoShape *GetShape() const { return fShape; }
    vecgeom::cxx::VPlacedVolume *GetVGShape() const { return fVGShape; }
 
-   ClassDefOverride(TGeoVGShape, 0) // Adapter for a VecGeom shape
+   ClassDefOverride(TGeoVGShape, 1) // Adapter for a VecGeom shape
 };
 #endif


### PR DESCRIPTION
The previous implementation required TGeoTessellated shapes to be read attached to a TGeoManager. This removes the limitation, and allows also reading geometry files containing shapes converted to VecGeom corresponding solids.

# This Pull request:

## Changes or fixes:
  * Restructured the `TGeoFacet` helper class, eliminating referencing vertices stored in the associated `TGeoTessellated` object, since this required calling a specific method `TGeoTessellated::AfterStreamer` to fix all the facet objects. The new version moves all vertex operations from TGeoFacet to the TGeoTessellated class, making the latter readable from a root file even if not connected to a `TGeoManager`
  * Added persistency to the class `TGeoVGShape` which interfaces `TGeoShape` to `vecgeom::VPlacedVolume`. This allows to write/read geometry files after being converted to VecGeom. Upon reading, a check is made that the current root version was also compiled with VecGeom support, and if this is not the case a `Fatal` exception is fired.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #14283 

