### PR TITLE
[RF] Clarify in rf408_RDataFrameToRooFit that `Book` yields RResultPtr

### DIFF
--- a/tutorials/roofit/rf303_conditional.C
+++ b/tutorials/roofit/rf303_conditional.C
@@ -53,7 +53,8 @@ void rf303_conditional()
    // ---------------------------------------------------------------------------------------------
 
    // Make subset of experimental data with only y values
-   RooDataSet *expDataY = (RooDataSet *)expDataXY->reduce(y);
+   std::unique_ptr<RooAbsData> expAbsDataY{expDataXY->reduce(y)};
+   RooDataSet *expDataY = static_cast<RooDataSet*>(expAbsDataY.get());
 
    // Generate 10000 events in x obtained from _conditional_ model(x|y) with y values taken from experimental data
    std::unique_ptr<RooDataSet> data{model.generate(x, ProtoData(*expDataY))};
@@ -73,12 +74,12 @@ void rf303_conditional()
    model.plotOn(xframe, ProjWData(*expDataY));
 
    // Speed up (and approximate) projection by using binned clone of data for projection
-   RooAbsData *binnedDataY = expDataY->binnedClone();
+   std::unique_ptr<RooDataHist> binnedDataY{expDataY->binnedClone()};
    model.plotOn(xframe, ProjWData(*binnedDataY), LineColor(kCyan), LineStyle(kDotted));
 
    // Show effect of projection with too coarse binning
    ((RooRealVar *)expDataY->get()->find("y"))->setBins(5);
-   RooAbsData *binnedDataY2 = expDataY->binnedClone();
+   std::unique_ptr<RooDataHist> binnedDataY2{expDataY->binnedClone()};
    model.plotOn(xframe, ProjWData(*binnedDataY2), LineColor(kRed));
 
    // Make canvas and draw RooPlots

--- a/tutorials/roofit/rf307_fullpereventerrors.C
+++ b/tutorials/roofit/rf307_fullpereventerrors.C
@@ -48,7 +48,7 @@ void rf307_fullpereventerrors()
    std::unique_ptr<RooDataSet> expDataDterr{pdfDtErr.generate(dterr, 10000)};
 
    // Construct a histogram pdf to describe the shape of the dtErr distribution
-   RooDataHist *expHistDterr = expDataDterr->binnedClone();
+   std::unique_ptr<RooDataHist> expHistDterr{expDataDterr->binnedClone()};
    RooHistPdf pdfErr("pdfErr", "pdfErr", dterr, *expHistDterr);
 
    // C o n s t r u c t   c o n d i t i o n a l   p r o d u c t   d e c a y _ d m ( d t | d t e r r ) * p d f ( d t e r

--- a/tutorials/roofit/rf316_llratioplot.C
+++ b/tutorials/roofit/rf316_llratioplot.C
@@ -77,7 +77,7 @@ void rf316_llratioplot()
    data->addColumn(llratio_func);
 
    // Extract the subset of data with large signal likelihood
-   RooDataSet *dataSel = (RooDataSet *)data->reduce(Cut("llratio>0.7"));
+   std::unique_ptr<RooAbsData> dataSel{data->reduce(Cut("llratio>0.7"))};
 
    // Make plot frame
    RooPlot *frame2 = x.frame(Title("Same projection on X with LLratio(y,z)>0.7"), Bins(40));
@@ -93,7 +93,7 @@ void rf316_llratioplot()
 
    // Calculate LL ratio for each generated event and select MC events with llratio)0.7
    mcprojData->addColumn(llratio_func);
-   RooDataSet *mcprojDataSel = (RooDataSet *)mcprojData->reduce(Cut("llratio>0.7"));
+   std::unique_ptr<RooAbsData> mcprojDataSel{mcprojData->reduce(Cut("llratio>0.7"))};
 
    // Project model on x, integrating projected observables (y,z) with Monte Carlo technique
    // on set of events with the same llratio cut as was applied to data

--- a/tutorials/roofit/rf401_importttreethx.C
+++ b/tutorials/roofit/rf401_importttreethx.C
@@ -97,15 +97,15 @@ void rf401_importttreethx()
    // ----------------------------------------------------------------------------------------
 
    // Create three RooDataSets in (y,z)
-   RooDataSet *dsA = (RooDataSet *)ds2.reduce(RooArgSet(x, y), "z<-5");
-   RooDataSet *dsB = (RooDataSet *)ds2.reduce(RooArgSet(x, y), "abs(z)<5");
-   RooDataSet *dsC = (RooDataSet *)ds2.reduce(RooArgSet(x, y), "z>5");
+   std::unique_ptr<RooAbsData> dsA{ds2.reduce({x, y}, "z<-5")};
+   std::unique_ptr<RooAbsData> dsB{ds2.reduce({x, y}, "abs(z)<5")};
+   std::unique_ptr<RooAbsData> dsC{ds2.reduce({x, y}, "z>5")};
 
    // Create a dataset that imports contents of all the above datasets mapped by index category c
-   RooDataSet *dsABC = new RooDataSet("dsABC", "dsABC", RooArgSet(x, y), Index(c), Import("SampleA", *dsA),
-                                      Import("SampleB", *dsB), Import("SampleC", *dsC));
+   RooDataSet dsABC{"dsABC", "dsABC", RooArgSet(x, y), Index(c), Import("SampleA", *dsA),
+                    Import("SampleB", *dsB), Import("SampleC", *dsC)};
 
-   dsABC->Print();
+   dsABC.Print();
 }
 
 TH1 *makeTH1(const char *name, double mean, double sigma)

--- a/tutorials/roofit/rf402_datahandling.C
+++ b/tutorials/roofit/rf402_datahandling.C
@@ -78,29 +78,29 @@ void rf402_datahandling()
 
    // The reduce() function returns a new dataset which is a subset of the original
    cout << endl << ">> d1 has only columns x,c" << endl;
-   RooDataSet *d1 = (RooDataSet *)d.reduce(RooArgSet(x, c));
+   std::unique_ptr<RooAbsData> d1{d.reduce({x, c})};
    d1->Print("v");
 
    cout << endl << ">> d2 has only column y" << endl;
-   RooDataSet *d2 = (RooDataSet *)d.reduce(RooArgSet(y));
+   std::unique_ptr<RooAbsData> d2{d.reduce({y})};
    d2->Print("v");
 
    cout << endl << ">> d3 has only the points with y>5.17" << endl;
-   RooDataSet *d3 = (RooDataSet *)d.reduce("y>5.17");
+   std::unique_ptr<RooAbsData> d3{d.reduce("y>5.17")};
    d3->Print("v");
 
    cout << endl << ">> d4 has only columns x,c for data points with y>5.17" << endl;
-   RooDataSet *d4 = (RooDataSet *)d.reduce(RooArgSet(x, c), "y>5.17");
+   std::unique_ptr<RooAbsData> d4{d.reduce({x, c}, "y>5.17")};
    d4->Print("v");
 
    // The merge() function adds two data set column-wise
    cout << endl << ">> merge d2(y) with d1(x,c) to form d1(x,c,y)" << endl;
-   d1->merge(d2);
+   static_cast<RooDataSet&>(*d1).merge(&static_cast<RooDataSet&>(*d2));
    d1->Print("v");
 
    // The append() function adds two datasets row-wise
    cout << endl << ">> append data points of d3 to d1" << endl;
-   d1->append(*d3);
+   static_cast<RooDataSet&>(*d1).append(static_cast<RooDataSet&>(*d3));
    d1->Print("v");
 
    // O p e r a t i o n s   o n   b i n n e d   d a t a s e t s
@@ -141,7 +141,7 @@ void rf402_datahandling()
    // All reduce() methods are interfaced in RooAbsData. All reduction techniques
    // demonstrated on unbinned datasets can be applied to binned datasets as well.
    cout << ">> Creating 1-dimensional projection on y of dh for bins with x>0" << endl;
-   RooDataHist *dh2 = (RooDataHist *)dh.reduce(y, "x>0");
+   std::unique_ptr<RooAbsData> dh2{dh.reduce(y, "x>0")};
    dh2->Print("v");
 
    // Add dh2 to yframe and redraw

--- a/tutorials/roofit/rf403_weightedevts.C
+++ b/tutorials/roofit/rf403_weightedevts.C
@@ -122,7 +122,7 @@ void rf403_weightedevts()
    // ------------------------------------------------------------------------------------
 
    // Construct binned clone of unbinned weighted dataset
-   RooDataHist *binnedData = wdata.binnedClone();
+   std::unique_ptr<RooAbsData> binnedData{wdata.binnedClone()};
    binnedData->Print("v");
 
    // Perform chi2 fit to binned weighted dataset using sum-of-weights errors
@@ -130,7 +130,8 @@ void rf403_weightedevts()
    // NB: Within the usual approximations of a chi2 fit, a chi2 fit to weighted
    // data using sum-of-weights-squared errors does give correct error
    // estimates
-   std::unique_ptr<RooAbsReal> chi2{p2.createChi2(*binnedData, DataError(RooAbsData::SumW2))};
+   std::unique_ptr<RooAbsReal> chi2{
+      p2.createChi2(static_cast<RooDataHist &>(*binnedData), DataError(RooAbsData::SumW2))};
    RooMinimizer m(*chi2);
    m.migrad();
    m.hesse();

--- a/tutorials/roofit/rf404_categories.C
+++ b/tutorials/roofit/rf404_categories.C
@@ -128,6 +128,6 @@ void rf404_categories()
    tagCat.addToRange("soso", "NetTagger-2");
 
    // Use category range in dataset reduction specification
-   RooDataSet *goodData = (RooDataSet *)data->reduce(CutRange("good"));
-   goodData->table(tagCat)->Print("v");
+   std::unique_ptr<RooAbsData> goodData{data->reduce(CutRange("good"))};
+   static_cast<RooDataSet&>(*goodData).table(tagCat)->Print("v");
 }

--- a/tutorials/roofit/rf405_realtocatfuncs.C
+++ b/tutorials/roofit/rf405_realtocatfuncs.C
@@ -96,7 +96,7 @@ void rf405_realtocatfuncs()
    xb->setRange("alt", "x_coarse_bin1,x_coarse_bin3,x_coarse_bin5,x_coarse_bin7,x_coarse_bin9");
 
    // Construct subset of data matching range "alt" but only for the first 5000 events and plot it on the frame
-   RooDataSet *dataSel = (RooDataSet *)data->reduce(CutRange("alt"), EventRange(0, 5000));
+   std::unique_ptr<RooAbsData> dataSel{data->reduce(CutRange("alt"), EventRange(0, 5000))};
    dataSel->plotOn(xframe, MarkerColor(kGreen), LineColor(kGreen));
 
    new TCanvas("rf405_realtocatfuncs", "rf405_realtocatfuncs", 600, 600);

--- a/tutorials/roofit/rf408_RDataFrameToRooFit.py
+++ b/tutorials/roofit/rf408_RDataFrameToRooFit.py
@@ -20,8 +20,7 @@ import math
 # ------------------------
 
 # We create an RDataFrame with two columns filled with 2 million random numbers.
-d = ROOT.RDataFrame(2000000)
-dd = d.Define("x", "gRandom->Uniform(-5.,  5.)").Define("y", "gRandom->Gaus(1., 3.)")
+df = ROOT.RDataFrame(2000000).Define("x", "gRandom->Uniform(-5.,  5.)").Define("y", "gRandom->Gaus(1., 3.)")
 
 
 # We create RooFit variables that will represent the dataset.
@@ -41,12 +40,20 @@ y.setBins(20)
 # - the RDataFrame column types as template parameters
 # - the constructor arguments for RooDataSet (they follow the same syntax as the usual RooDataSet constructors)
 # - the column names that RDataFrame should fill into the dataset
-#
+
 # NOTE: RDataFrame columns are matched to RooFit variables by position, *not by name*!
-rooDataSet = dd.Book(
+#
+# The returned object is not yet a RooDataSet, but an RResultPtr that will be
+# lazy-evaluated once you call GetValue() on it. We will only evaluate the
+# RResultPtr once all other RDataFrame related actions are declared. This way
+# we trigger the event loop computation only once, which will improve the
+# runtime significantly.
+#
+# To learn more about lazy actions, see:
+#     https://root.cern/doc/master/classROOT_1_1RDataFrame.html#actions
+roo_data_set_result = df.Book(
     ROOT.std.move(ROOT.RooDataSetHelper("dataset", "Title of dataset", ROOT.RooArgSet(x, y))), ("x", "y")
 )
-
 
 # Method 2:
 # ---------
@@ -54,17 +61,21 @@ rooDataSet = dd.Book(
 rdhMaker = ROOT.RooDataHistHelper("dataset", "Title of dataset", ROOT.RooArgSet(x, y))
 
 # Then, we move it into an RDataFrame action:
-rooDataHist = dd.Book(ROOT.std.move(rdhMaker), ("x", "y"))
+roo_data_hist_result = df.Book(ROOT.std.move(rdhMaker), ("x", "y"))
 
 
 # Run it and inspect the results
 # -------------------------------
 
+# At this point, all RDF actions were defined (namely, the `Book` operations),
+# so we can get values from the RResultPtr objects, triggering the event loop
+# and getting the actual RooFit data objects.
+roo_data_set = roo_data_set_result.GetValue()
+roo_data_hist = roo_data_hist_result.GetValue()
+
 # Let's inspect the dataset / datahist.
-# Note that the first time we touch one of those objects, the RDataFrame event loop will run.
 
-
-def printData(data):
+def print_data(data):
     print("")
     data.Print()
     for i in range(min(data.numEntries(), 20)):
@@ -78,5 +89,5 @@ def printData(data):
     print("mean(y) = {0:.3f}".format(data.mean(y)) + "\tsigma(y) = {0:.3f}\n".format(math.sqrt(data.moment(y, 2.0))))
 
 
-printData(rooDataSet)
-printData(rooDataHist)
+print_data(roo_data_set)
+print_data(roo_data_hist)

--- a/tutorials/roofit/rf602_chi2fit.C
+++ b/tutorials/roofit/rf602_chi2fit.C
@@ -68,8 +68,8 @@ void rf602_chi2fit()
    // Note that entries with zero bins are _not_ allowed
    // for a proper chi^2 calculation and will give error
    // messages
-   RooDataSet *dsmall = (RooDataSet *)d->reduce(EventRange(1, 100));
-   RooDataHist *dhsmall = dsmall->binnedClone();
+   std::unique_ptr<RooAbsData> dsmall{d->reduce(EventRange(1, 100))};
+   std::unique_ptr<RooDataHist> dhsmall{static_cast<RooDataSet&>(*dsmall).binnedClone()};
    std::unique_ptr<RooAbsReal> chi2_lowstat{model.createChi2(*dhsmall)};
    cout << chi2_lowstat->getVal() << endl;
 }

--- a/tutorials/roofit/rf603_multicpu.C
+++ b/tutorials/roofit/rf603_multicpu.C
@@ -71,7 +71,7 @@ void rf603_multicpu()
 
    // Calculate likelihood ratio for each event, define subset of events with high signal likelihood
    data->addColumn(llratio_func);
-   RooDataSet *dataSel = (RooDataSet *)data->reduce(Cut("llratio>0.7"));
+   std::unique_ptr<RooAbsData> dataSel{data->reduce(Cut("llratio>0.7"))};
 
    // Make plot frame and plot data
    RooPlot *frame = x.frame(Title("Projection on X with LLratio(y,z)>0.7"), Bins(40));

--- a/tutorials/roofit/rf605_profilell.C
+++ b/tutorials/roofit/rf605_profilell.C
@@ -65,7 +65,7 @@ void rf605_profilell()
    // The profile likelihood estimator on nll for frac will minimize nll w.r.t
    // all floating parameters except frac for each evaluation
 
-   RooAbsReal *pll_frac = nll->createProfile(frac);
+   std::unique_ptr<RooAbsReal> pll_frac{nll->createProfile(frac)};
 
    // Plot the profile likelihood in frac
    pll_frac->plotOn(frame1, LineColor(kRed));
@@ -79,7 +79,7 @@ void rf605_profilell()
 
    // The profile likelihood estimator on nll for sigma_g2 will minimize nll
    // w.r.t all floating parameters except sigma_g2 for each evaluation
-   RooAbsReal *pll_sigmag2 = nll->createProfile(sigma_g2);
+   std::unique_ptr<RooAbsReal> pll_sigmag2{nll->createProfile(sigma_g2)};
 
    // Plot the profile likelihood in sigma_g2
    pll_sigmag2->plotOn(frame2, LineColor(kRed));
@@ -99,7 +99,4 @@ void rf605_profilell()
    gPad->SetLeftMargin(0.15);
    frame2->GetYaxis()->SetTitleOffset(1.4);
    frame2->Draw();
-
-   delete pll_frac;
-   delete pll_sigmag2;
 }

--- a/tutorials/roofit/rf706_histpdf.C
+++ b/tutorials/roofit/rf706_histpdf.C
@@ -36,7 +36,7 @@ void rf706_histpdf()
    std::unique_ptr<RooDataSet> data1{p.generate(x, 500)};
 
    // Create a binned dataset with 20 bins and 500 events
-   RooDataHist *hist1 = data1->binnedClone();
+   std::unique_ptr<RooDataHist> hist1{data1->binnedClone()};
 
    // Represent data in dh as pdf in x
    RooHistPdf histpdf1("histpdf1", "histpdf1", x, *hist1, 0);
@@ -54,7 +54,7 @@ void rf706_histpdf()
    std::unique_ptr<RooDataSet> data2{p.generate(x, 100000)};
 
    // Create a binned dataset with 10 bins and 100K events
-   RooDataHist *hist2 = data2->binnedClone();
+   std::unique_ptr<RooDataHist> hist2{data2->binnedClone()};
 
    // Represent data in dh as pdf in x, apply 2nd order interpolation
    RooHistPdf histpdf2("histpdf2", "histpdf2", x, *hist2, 2);

--- a/tutorials/roostats/rs101_limitexample.C
+++ b/tutorials/roostats/rs101_limitexample.C
@@ -189,7 +189,7 @@ void rs101_limitexample()
    // 3-d plot of the parameter points
    dataCanvas->cd(2);
    // also plot the points in the markov chain
-   RooDataSet *chainData = mcInt->GetChainAsDataSet();
+   std::unique_ptr<RooDataSet> chainData{mcInt->GetChainAsDataSet()};
 
    assert(chainData);
    std::cout << "plotting the chain data - nentries = " << chainData->numEntries() << std::endl;


### PR DESCRIPTION
Don't rely on implicit `GetValue()` via dereferencing in the RooFit
tutorial `rf408_RDataFrameToRooFit`, because it obscures the fact that
`Book` returns an RResultPtr, which is important to know for the user.

Closes https://github.com/root-project/root/pull/1429.

A second commit in this PR fixes some more memory leaks in the RooFit tutorials.

