### PR TITLE
[skip-ci] The default marker style is dot.

### DIFF
--- a/tutorials/dataframe/df014_CSVDataSource.C
+++ b/tutorials/dataframe/df014_CSVDataSource.C
@@ -71,6 +71,7 @@ int df014_CSVDataSource()
    leftPad->SetLogy();
    fullSpectrum->DrawClone("Hist");
    dualCanvas->cd(2);
+   jpsi->SetMarkerStyle(20);
    jpsi->DrawClone("HistP");
 
    return 0;

--- a/tutorials/dataframe/df014_CSVDataSource.py
+++ b/tutorials/dataframe/df014_CSVDataSource.py
@@ -69,6 +69,7 @@ leftPad.SetLogx()
 leftPad.SetLogy()
 fullSpectrum.Draw("Hist")
 dualCanvas.cd(2)
+jpsi.SetMarkerStyle(20)
 jpsi.Draw("HistP")
 dualCanvas.SaveAs("df014_jpsi.png")
 


### PR DESCRIPTION
Fix https://github.com/root-project/root/issues/14333
With this default maker style being the dot, the 3rd plot for this macro looked empty.
It will be fixed when the auto-style will appear. For the time being one needs to set
the marker to something more visible.

