### PR TITLE
Fix JupyROOT crash on Windows. Fixes the issue #14302

### DIFF
--- a/geom/geom/inc/TGeoExtension.h
+++ b/geom/geom/inc/TGeoExtension.h
@@ -12,8 +12,6 @@
 #ifndef ROOT_TGeoExtension
 #define ROOT_TGeoExtension
 
-#include <cassert>
-
 #include "TObject.h"
 
 class TGeoExtension : public TObject {
@@ -45,13 +43,7 @@ public:
       fRC++;
       return this;
    }
-   void Release() const override
-   {
-      assert(fRC > 0);
-      fRC--;
-      if (fRC == 0)
-         delete this;
-   }
+   void Release() const override;
 
    void SetUserObject(TObject *obj) { fUserObject = obj; }
    TObject *GetUserObject() const { return fUserObject; }

--- a/geom/geom/src/TGeoExtension.cxx
+++ b/geom/geom/src/TGeoExtension.cxx
@@ -10,8 +10,8 @@
  *************************************************************************/
 
 #include "TGeoExtension.h"
-
 #include "Rtypes.h"
+#include <cassert>
 
 ClassImp(TGeoExtension);
 
@@ -64,3 +64,11 @@ since the producer code does not release the extension.
 One cannot call directly "delete ext" nor allocate an extension on the stack,
 since the destructor is protected. Use Release instead.
 */
+
+void TGeoRCExtension::Release() const
+{
+   assert(fRC > 0);
+   fRC--;
+   if (fRC == 0)
+      delete this;
+}


### PR DESCRIPTION
Remove `#include <cassert>` from `TGeoExtension.h` and move it to the `TGeoExtension.cxx` source file, fixing a potential crash of JupyROOT when running on a machine with a different version of the Windows SDK than the one used to build ROOT, as described in the Github issue #14302 and as shown below. The issue comes from this code in `JupyROOT\helpers\utils.py`:
```
def GetGeometryDrawer():
    if not hasattr(ROOT,'gGeoManager'): return
    if not ROOT.gGeoManager: return
    if not ROOT.gGeoManager.GetUserPaintVolume(): return
    vol = ROOT.gGeoManager.GetTopVolume()
    if vol:
        return NotebookDrawer(vol)
```
triggering the autoloading of libGeom, leading to this error:
```
In file included from libGeom dictionary payload:17:
In file included from C:/root-dev/root\include\TGeoExtension.h:15:
In file included from C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.38.33130\include\cassert:9:
In file included from C:\Program Files (x86)\Windows Kits\10\include\10.0.22621.0\ucrt\assert.h:12:
C:\Program Files (x86)\Windows Kits\10\include\10.0.22621.0\ucrt\corecrt.h:260:12: error: redefinition of '_CrtEnableIf<true, _Ty>'
    struct _CrtEnableIf<true, _Ty>
           ^~~~~~~~~~~~~~~~~~~~~~~
C:\Program Files (x86)\Windows Kits\10\Include\10.0.22000.0\ucrt\corecrt.h:260:12: note: previous definition is here
    struct _CrtEnableIf<true, _Ty>
           ^
In file included from libGeom dictionary payload:17:
In file included from C:/root-dev/root\include\TGeoExtension.h:15:
In file included from C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.38.33130\include\cassert:9:
In file included from C:\Program Files (x86)\Windows Kits\10\include\10.0.22621.0\ucrt\assert.h:12:
C:\Program Files (x86)\Windows Kits\10\include\10.0.22621.0\ucrt\corecrt.h:610:16: error: redefinition of '__crt_locale_data_public'
typedef struct __crt_locale_data_public
               ^
C:\Program Files (x86)\Windows Kits\10\Include\10.0.22000.0\ucrt\corecrt.h:610:16: note: previous definition is here
typedef struct __crt_locale_data_public
               ^
In file included from libGeom dictionary payload:17:
In file included from C:/root-dev/root\include\TGeoExtension.h:15:
In file included from C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.38.33130\include\cassert:9:
In file included from C:\Program Files (x86)\Windows Kits\10\include\10.0.22621.0\ucrt\assert.h:12:
C:\Program Files (x86)\Windows Kits\10\include\10.0.22621.0\ucrt\corecrt.h:617:16: error: redefinition of '__crt_locale_pointers'
typedef struct __crt_locale_pointers
               ^
C:\Program Files (x86)\Windows Kits\10\Include\10.0.22000.0\ucrt\corecrt.h:617:16: note: previous definition is here
typedef struct __crt_locale_pointers
               ^
In file included from libGeom dictionary payload:17:
In file included from C:/root-dev/root\include\TGeoExtension.h:15:
In file included from C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.38.33130\include\cassert:9:
In file included from C:\Program Files (x86)\Windows Kits\10\include\10.0.22621.0\ucrt\assert.h:12:
C:\Program Files (x86)\Windows Kits\10\include\10.0.22621.0\ucrt\corecrt.h:625:16: error: redefinition of '_Mbstatet'
typedef struct _Mbstatet
               ^
C:\Program Files (x86)\Windows Kits\10\Include\10.0.22000.0\ucrt\corecrt.h:625:16: note: previous definition is here
typedef struct _Mbstatet
               ^
Error in <TInterpreter::AutoParse>: Error parsing payload code for class gGeoManager with content:

...

Assertion failed: !m_Unloading && "Must not nest within unloading transaction", file C:\root-dev\git\master\interpreter\cling\lib\Interpreter\Transaction.cpp, line 98
 *** Break *** abort

==========================================
=============== STACKTRACE ===============
==========================================
...
```
This PR fixes #14302 

