### PR TITLE
[ci] Use builtin_xxhash=ON on Ubuntu 20.04

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/ubuntu20.txt
+++ b/.github/workflows/root-ci-config/buildconfig/ubuntu20.txt
@@ -1,3 +1,4 @@
 builtin_nlohmannjson=ON
 builtin_vdt=ON
 builtin_xrootd=ON
+builtin_xxhash=ON


### PR DESCRIPTION
Since commit 9030460858 ("[ntuple] add xxhash3 checksum handling to anchor"), we require xxHash 0.8 while Ubuntu 20.04 only has version 0.7.3 in its package repositories.