### PR TITLE
TGeoTessellated remove TGeoFacet::ComputeNormal declaration

### DIFF
--- a/geom/geom/inc/TGeoTessellated.h
+++ b/geom/geom/inc/TGeoTessellated.h
@@ -42,7 +42,6 @@ public:
 
    int operator[](int ivert) const { return fIvert[ivert]; }
    static int CompactFacet(Vertex_t *vert, int nvertices);
-   Vertex_t ComputeNormal(bool &degenerated) const;
    int GetNvert() const { return fNvert; }
 
    void Flip()


### PR DESCRIPTION

# This Pull request:

## Changes or fixes:

The function is no longer implemented, see #14327
Can lead to linking issues when undefined symbols are not ignored, e.g., DD4hep DDCAD

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

