### PR TITLE
[core] Make some constants constexpr

### DIFF
--- a/core/base/inc/TString.h
+++ b/core/base/inc/TString.h
@@ -277,7 +277,7 @@ private:
 public:
    enum EStripType   { kLeading = 0x1, kTrailing = 0x2, kBoth = 0x3 };
    enum ECaseCompare { kExact, kIgnoreCase };
-   static const Ssiz_t kNPOS = ::kNPOS;
+   static constexpr Ssiz_t kNPOS = ::kNPOS;
 
    TString();                           // Null string
    explicit TString(Ssiz_t ic);         // Suggested capacity

--- a/core/base/src/TString.cxx
+++ b/core/base/src/TString.cxx
@@ -54,12 +54,6 @@ as a TString, construct a TString from it, eg:
 #include "TVirtualMutex.h"
 #include "ThreadLocalStorage.h"
 
-// Definition of the TString static data member. Declaration (even with
-// initialization) in the class body *is not* definition according to C++
-// standard. The definition must be explicitly done in one TU for ODR use. See
-// https://en.cppreference.com/w/cpp/language/definition
-const Ssiz_t TString::kNPOS;
-
 #if defined(R__WIN32)
 #define strtoull _strtoui64
 #endif

--- a/core/foundation/inc/RtypesCore.h
+++ b/core/foundation/inc/RtypesCore.h
@@ -97,31 +97,31 @@ typedef float          Size_t;      //Attribute size (float)
 
 //---- constants ---------------------------------------------------------------
 
-const Bool_t    kTRUE        = true;
-const Bool_t    kFALSE       = false;
+constexpr Bool_t kTRUE = true;
+constexpr Bool_t kFALSE = false;
 
-const Int_t     kMaxUChar    = 256;
-const Int_t     kMaxChar     = kMaxUChar >> 1;
-const Int_t     kMinChar     = -kMaxChar - 1;
+constexpr Int_t kMaxUChar = 256;
+constexpr Int_t kMaxChar = kMaxUChar >> 1;
+constexpr Int_t kMinChar = -kMaxChar - 1;
 
-const Int_t     kMaxUShort   = 65534;
-const Int_t     kMaxShort    = kMaxUShort >> 1;
-const Int_t     kMinShort    = -kMaxShort - 1;
+constexpr Int_t kMaxUShort = 65534;
+constexpr Int_t kMaxShort = kMaxUShort >> 1;
+constexpr Int_t kMinShort = -kMaxShort - 1;
 
-const UInt_t    kMaxUInt     = UInt_t(~0);
-const Int_t     kMaxInt      = Int_t(kMaxUInt >> 1);
-const Int_t     kMinInt      = -kMaxInt - 1;
+constexpr UInt_t kMaxUInt = UInt_t(~0);
+constexpr Int_t kMaxInt = Int_t(kMaxUInt >> 1);
+constexpr Int_t kMinInt = -kMaxInt - 1;
 
-const ULong_t   kMaxULong    = ULong_t(~0);
-const Long_t    kMaxLong     = Long_t(kMaxULong >> 1);
-const Long_t    kMinLong     = -kMaxLong - 1;
+constexpr ULong_t kMaxULong = ULong_t(~0);
+constexpr Long_t kMaxLong = Long_t(kMaxULong >> 1);
+constexpr Long_t kMinLong = -kMaxLong - 1;
 
-const ULong64_t kMaxULong64  = ULong64_t(~0LL);
-const Long64_t  kMaxLong64   = Long64_t(kMaxULong64 >> 1);
-const Long64_t  kMinLong64   = -kMaxLong64 - 1;
+constexpr ULong64_t kMaxULong64 = ULong64_t(~0LL);
+constexpr Long64_t kMaxLong64 = Long64_t(kMaxULong64 >> 1);
+constexpr Long64_t kMinLong64 = -kMaxLong64 - 1;
 
-const ULong_t   kBitsPerByte = 8;
-const Ssiz_t    kNPOS        = ~(Ssiz_t)0;
+constexpr ULong_t kBitsPerByte = 8;
+constexpr Ssiz_t kNPOS = ~(Ssiz_t)0;
 
 //---- debug global ------------------------------------------------------------
 


### PR DESCRIPTION
Now that the machinery of https://github.com/root-project/root/pull/14287 is available, we can begin the process of making constants in ROOT `constexpr` to get the benefit of a faster initialization. I began with `TString::kNPOS` and the ones in `RTypesCore.h`, but do let me know if you see other candidates for the same procedure.
