### PR TITLE
Always generate `etc/gitinfo.txt` before building ROOT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -361,6 +361,17 @@ add_custom_target(move_artifacts DEPENDS ${stamp_file} ${artifact_files_builddir
 
 add_subdirectory (interpreter)
 
+# Update etc/gitinfo.txt for every build.
+add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/etc/gitinfo.txt ${CMAKE_BINARY_DIR}/etc/dummy.txt
+  COMMAND ${CMAKE_COMMAND} -DSRCDIR=${CMAKE_SOURCE_DIR} -DBINDIR=${CMAKE_BINARY_DIR} -P ${CMAKE_SOURCE_DIR}/cmake/modules/UpdateGitInfo.cmake
+  COMMENT "Updating etc/gitinfo.txt."
+)
+add_custom_target(gitinfotxt
+  ALL
+  DEPENDS ${CMAKE_BINARY_DIR}/etc/gitinfo.txt
+)
+install(FILES ${CMAKE_BINARY_DIR}/etc/gitinfo.txt DESTINATION ${CMAKE_INSTALL_SYSCONFDIR})
+
 #---CXX MODULES-----------------------------------------------------------------------------------
 if(cxxmodules)
   # Copy-pasted from HandleLLVMOptions.cmake, please keep up to date.
@@ -437,7 +448,7 @@ ROOT_ADD_TEST_SUBDIRECTORY(tutorials)
 
 get_property(__allHeaders GLOBAL PROPERTY ROOT_HEADER_TARGETS)
 get_property(__allBuiltins GLOBAL PROPERTY ROOT_BUILTIN_TARGETS)
-add_custom_target(move_headers ALL DEPENDS ${__allHeaders} ${__allBuiltins})
+add_custom_target(move_headers ALL DEPENDS ${__allHeaders} ${__allBuiltins} gitinfotxt)
 
 #---CXX MODULES-----------------------------------------------------------------------------------
 if(MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,13 +362,11 @@ add_custom_target(move_artifacts DEPENDS ${stamp_file} ${artifact_files_builddir
 add_subdirectory (interpreter)
 
 # Update etc/gitinfo.txt for every build.
-add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/etc/gitinfo.txt ${CMAKE_BINARY_DIR}/etc/dummy.txt
-  COMMAND ${CMAKE_COMMAND} -DSRCDIR=${CMAKE_SOURCE_DIR} -DBINDIR=${CMAKE_BINARY_DIR} -P ${CMAKE_SOURCE_DIR}/cmake/modules/UpdateGitInfo.cmake
-  COMMENT "Updating etc/gitinfo.txt."
-)
 add_custom_target(gitinfotxt
   ALL
-  DEPENDS ${CMAKE_BINARY_DIR}/etc/gitinfo.txt
+  COMMAND ${CMAKE_COMMAND} -DSRCDIR=${CMAKE_SOURCE_DIR} -DBINDIR=${CMAKE_BINARY_DIR} -P ${CMAKE_SOURCE_DIR}/cmake/modules/UpdateGitInfo.cmake
+  COMMENT "Updating etc/gitinfo.txt."
+  BYPRODUCTS ${CMAKE_BINARY_DIR}/etc/gitinfo.txt
 )
 install(FILES ${CMAKE_BINARY_DIR}/etc/gitinfo.txt DESTINATION ${CMAKE_INSTALL_SYSCONFDIR})
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -10,16 +10,6 @@
 
 include(SetROOTVersion)
 
-# Update etc/gitinfo.txt for every build.
-add_custom_target(gitinfotxt
-  ALL
-  COMMAND ${CMAKE_COMMAND} -DSRCDIR=${CMAKE_SOURCE_DIR} -DBINDIR=${CMAKE_BINARY_DIR} -P ${CMAKE_SOURCE_DIR}/cmake/modules/UpdateGitInfo.cmake
-  WORKING_DIRECTORY 
-  COMMENT "Updating etc/gitinfo.txt."
-  BYPRODUCTS ${CMAKE_BINARY_DIR}/etc/gitinfo.txt
-)
-install(FILES ${CMAKE_BINARY_DIR}/etc/gitinfo.txt DESTINATION ${CMAKE_INSTALL_SYSCONFDIR})
-
 set_source_files_properties(${CMAKE_BINARY_DIR}/ginclude/RConfigure.h
   PROPERTIES GENERATED TRUE)
 


### PR DESCRIPTION
Make sure `etc/gitinfo.txt` is generated before building ROOT. This should fix the following errors when building from scratch:
```
  Generating G__Gui.cxx, ../../bin/libGui_rdict.pcm, ../../bin/libGui.rootmap
  Error in <UnknownClass::ReadGitInfo()>: Cannot determine git info: etc/gitinfo.txt not found!
```
