### PR TITLE
[math][fitter] Fix return chi2 when fitting user provided chi2 functions

### DIFF
--- a/math/mathcore/src/Fitter.cxx
+++ b/math/mathcore/src/Fitter.cxx
@@ -154,6 +154,7 @@ bool Fitter::DoSetFCN(bool extFcn, const ROOT::Math::IMultiGenFunction & fcn, co
    }
 
    fBinFit = chi2fit;
+   if (chi2fit) fFitType = static_cast<int>(ROOT::Math::FitMethodFunction::kLeastSquare);
    fDataSize = dataSize;
 
    // store external provided FCN without cloning it

--- a/tutorials/fit/combinedFit.C
+++ b/tutorials/fit/combinedFit.C
@@ -127,6 +127,8 @@ void combinedFit()
    ROOT::Fit::FitResult result = fitter.Result();
    result.Print(std::cout);
 
+   std::cout << "Combined fit Chi2 = " << result.Chi2() << std::endl;
+
    TCanvas *c1 = new TCanvas("Simfit", "Simultaneous fit of two histograms", 10, 10, 700, 700);
    c1->Divide(1, 2);
    c1->cd(1);


### PR DESCRIPTION
This fixes a bug introduced in 6.30 for returning the chi2 value when the user provides his own chi2 using `Fitter::FitFCN`, for example in the tutorial combinedFit.C

See https://root-forum.cern.ch/t/problem-with-root-chi2/57649

