### PR TITLE
[math] Add `constexpr` to GenVector constructors

### DIFF
--- a/math/genvector/inc/Math/GenVector/AxisAngle.h
+++ b/math/genvector/inc/Math/GenVector/AxisAngle.h
@@ -91,7 +91,7 @@ public:
       Construct from another supported rotation type (see gv_detail::convert )
    */
    template <class OtherRotation>
-   explicit AxisAngle(const OtherRotation & r) {gv_detail::convert(r,*this);}
+   explicit constexpr AxisAngle(const OtherRotation & r) {gv_detail::convert(r,*this);}
 
 
    /**

--- a/math/genvector/inc/Math/GenVector/Cartesian2D.h
+++ b/math/genvector/inc/Math/GenVector/Cartesian2D.h
@@ -57,7 +57,7 @@ public :
       X() and Y()
    */
    template <class CoordSystem>
-   explicit Cartesian2D(const CoordSystem & v)
+   explicit constexpr Cartesian2D(const CoordSystem & v)
       : fX(v.X()), fY(v.Y()) {  }
 
 
@@ -163,7 +163,7 @@ public :
    // ============= Overloads for improved speed ==================
 
    template <class T2>
-   explicit Cartesian2D( const Polar2D<T2> & v )
+   explicit constexpr Cartesian2D( const Polar2D<T2> & v )
    {
       const Scalar r = v.R(); // re-using this instead of calling v.X() and v.Y()
       // is the speed improvement

--- a/math/genvector/inc/Math/GenVector/Cartesian3D.h
+++ b/math/genvector/inc/Math/GenVector/Cartesian3D.h
@@ -64,7 +64,7 @@ public :
       X(), Y() and Z()
    */
    template <class CoordSystem>
-   explicit Cartesian3D(const CoordSystem & v)
+   explicit constexpr Cartesian3D(const CoordSystem & v)
       : fX(v.X()), fY(v.Y()), fZ(v.Z()) {  }
 
    // for g++  3.2 and 3.4 on 32 bits found that the compiler generated copy ctor and assignment are much slower
@@ -192,7 +192,7 @@ public :
    // ============= Overloads for improved speed ==================
 
    template <class T2>
-   explicit Cartesian3D( const Polar3D<T2> & v ) : fZ (v.Z())
+   explicit constexpr Cartesian3D( const Polar3D<T2> & v ) : fZ (v.Z())
    {
       const T rho = v.Rho();
       // re-using this instead of calling v.X() and v.Y()

--- a/math/genvector/inc/Math/GenVector/Cylindrical3D.h
+++ b/math/genvector/inc/Math/GenVector/Cylindrical3D.h
@@ -61,7 +61,7 @@ public :
       Rho(), Z() and Phi()
    */
    template <class CoordSystem >
-   explicit Cylindrical3D( const CoordSystem & v ) :
+   explicit constexpr Cylindrical3D( const CoordSystem & v ) :
       fRho( v.Rho() ),  fZ( v.Z() ),  fPhi( v.Phi() ) { Restrict(); }
 
    // for g++  3.2 and 3.4 on 32 bits found that the compiler generated copy ctor and assignment are much slower

--- a/math/genvector/inc/Math/GenVector/DisplacementVector2D.h
+++ b/math/genvector/inc/Math/GenVector/DisplacementVector2D.h
@@ -68,7 +68,7 @@ namespace ROOT {
         /**
            Default constructor. Construct an empty object with zero values
         */
-        DisplacementVector2D ( ) :   fCoordinates()  { }
+        constexpr DisplacementVector2D ( ) :   fCoordinates()  { }
 
 
         /**
@@ -76,7 +76,7 @@ namespace ROOT {
            In the case of a XYVector the values are x,y
            In the case of  a polar vector they are r, phi
         */
-        DisplacementVector2D(Scalar a, Scalar b) :
+        constexpr DisplacementVector2D(Scalar a, Scalar b) :
            fCoordinates ( a , b )  { }
 
         /**
@@ -84,7 +84,7 @@ namespace ROOT {
            coordinates, or using a different Scalar type, but with same coordinate system tag
         */
         template <class OtherCoords>
-        explicit DisplacementVector2D( const DisplacementVector2D<OtherCoords, Tag> & v) :
+        explicit constexpr DisplacementVector2D( const DisplacementVector2D<OtherCoords, Tag> & v) :
            fCoordinates ( v.Coordinates() ) { }
 
 
@@ -93,7 +93,7 @@ namespace ROOT {
            but with the same coordinate system tag
         */
         template <class OtherCoords>
-        explicit DisplacementVector2D( const PositionVector2D<OtherCoords,Tag> & p) :
+        explicit constexpr DisplacementVector2D( const PositionVector2D<OtherCoords,Tag> & p) :
            fCoordinates ( p.Coordinates() ) { }
 
 
@@ -102,7 +102,7 @@ namespace ROOT {
            Precondition: v must implement methods x() and  y()
         */
         template <class ForeignVector>
-        explicit DisplacementVector2D( const ForeignVector & v) :
+        explicit constexpr DisplacementVector2D( const ForeignVector & v) :
            fCoordinates ( Cartesian2D<Scalar>( v.x(), v.y() ) ) { }
 
 
@@ -393,10 +393,10 @@ namespace ROOT {
 
         // this should not compile (if from a vector or points with different tag
         template <class OtherCoords, class OtherTag>
-        explicit DisplacementVector2D( const DisplacementVector2D<OtherCoords, OtherTag> & ) {}
+        explicit constexpr DisplacementVector2D( const DisplacementVector2D<OtherCoords, OtherTag> & ) {}
 
         template <class OtherCoords, class OtherTag>
-        explicit DisplacementVector2D( const PositionVector2D<OtherCoords, OtherTag> & ) {}
+        explicit constexpr DisplacementVector2D( const PositionVector2D<OtherCoords, OtherTag> & ) {}
 
         template <class OtherCoords, class OtherTag>
         DisplacementVector2D & operator=( const DisplacementVector2D<OtherCoords, OtherTag> & );

--- a/math/genvector/inc/Math/GenVector/DisplacementVector3D.h
+++ b/math/genvector/inc/Math/GenVector/DisplacementVector3D.h
@@ -68,7 +68,7 @@ namespace ROOT {
       /**
           Default constructor. Construct an empty object with zero values
       */
-      DisplacementVector3D ( ) :   fCoordinates()  { }
+      constexpr DisplacementVector3D ( ) :   fCoordinates()  { }
 
 
       /**
@@ -76,7 +76,7 @@ namespace ROOT {
          In the case of a XYZVector the values are x,y,z
          In the case of  a polar vector they are r,theta, phi
       */
-      DisplacementVector3D(Scalar a, Scalar b, Scalar c) :
+      constexpr DisplacementVector3D(Scalar a, Scalar b, Scalar c) :
         fCoordinates ( a , b,  c )  { }
 
      /**
@@ -84,7 +84,7 @@ namespace ROOT {
           coordinates, or using a different Scalar type, but with same coordinate system tag
       */
       template <class OtherCoords>
-      explicit DisplacementVector3D( const DisplacementVector3D<OtherCoords, Tag> & v) :
+      explicit constexpr DisplacementVector3D( const DisplacementVector3D<OtherCoords, Tag> & v) :
         fCoordinates ( v.Coordinates() ) { }
 
 
@@ -93,7 +93,7 @@ namespace ROOT {
          but with the same coordinate system tag
       */
       template <class OtherCoords>
-      explicit DisplacementVector3D( const PositionVector3D<OtherCoords,Tag> & p) :
+      explicit constexpr DisplacementVector3D( const PositionVector3D<OtherCoords,Tag> & p) :
         fCoordinates ( p.Coordinates() ) { }
 
 
@@ -102,7 +102,7 @@ namespace ROOT {
           Precondition: v must implement methods x(), y() and z()
       */
       template <class ForeignVector>
-      explicit DisplacementVector3D( const ForeignVector & v) :
+      explicit constexpr DisplacementVector3D( const ForeignVector & v) :
         fCoordinates ( Cartesian3D<Scalar>( v.x(), v.y(), v.z() ) ) { }
 
 
@@ -116,7 +116,7 @@ namespace ROOT {
          ( x= v[index0] for Cartesian and r=v[index0] for Polar )
       */
       template <class LAVector>
-      DisplacementVector3D(const LAVector & v, size_t index0 ) {
+      constexpr DisplacementVector3D(const LAVector & v, size_t index0 ) {
         fCoordinates = CoordSystem ( v[index0], v[index0+1], v[index0+2] );
       }
 #endif
@@ -538,10 +538,10 @@ namespace ROOT {
 
       // this should not compile (if from a vector or points with different tag
       template <class OtherCoords, class OtherTag>
-      explicit DisplacementVector3D( const DisplacementVector3D<OtherCoords, OtherTag> & ) {}
+      explicit constexpr DisplacementVector3D( const DisplacementVector3D<OtherCoords, OtherTag> & ) {}
 
       template <class OtherCoords, class OtherTag>
-      explicit DisplacementVector3D( const PositionVector3D<OtherCoords, OtherTag> & ) {}
+      explicit constexpr DisplacementVector3D( const PositionVector3D<OtherCoords, OtherTag> & ) {}
 
       template <class OtherCoords, class OtherTag>
       DisplacementVector3D & operator=( const DisplacementVector3D<OtherCoords, OtherTag> & );

--- a/math/genvector/inc/Math/GenVector/EulerAngles.h
+++ b/math/genvector/inc/Math/GenVector/EulerAngles.h
@@ -51,7 +51,7 @@ public:
   /**
      Default constructor
   */
-   EulerAngles() : fPhi(0.0), fTheta(0.0), fPsi(0.0) { }
+   constexpr EulerAngles() : fPhi(0.0), fTheta(0.0), fPsi(0.0) { }
 
    /**
       Constructor from phi, theta and psi
@@ -66,7 +66,7 @@ public:
       the angles phi, theta and psi.
    */
    template<class IT>
-   EulerAngles(IT begin, IT end) { SetComponents(begin,end); }
+   constexpr EulerAngles(IT begin, IT end) { SetComponents(begin,end); }
 
    // The compiler-generated copy ctor, copy assignment, and dtor are OK.
 
@@ -82,7 +82,7 @@ public:
       Create from any other supported rotation (see gv_detail::convert )
     */
    template <class OtherRotation>
-   explicit EulerAngles(const OtherRotation & r) {gv_detail::convert(r,*this);}
+   explicit constexpr EulerAngles(const OtherRotation & r) {gv_detail::convert(r,*this);}
 
    /**
       Assign from any other rotation (see gv_detail::convert )

--- a/math/genvector/inc/Math/GenVector/LorentzRotation.h
+++ b/math/genvector/inc/Math/GenVector/LorentzRotation.h
@@ -116,7 +116,7 @@ public:
      Note:  (0,0) refers to the XX component; (3,3) refers to the TT component.
   */
   template<class ForeignMatrix>
-  explicit LorentzRotation(const ForeignMatrix & m) { SetComponents(m); }
+  explicit constexpr LorentzRotation(const ForeignMatrix & m) { SetComponents(m); }
 
   /**
      Construct from four orthosymplectic vectors (which must have methods

--- a/math/genvector/inc/Math/GenVector/LorentzVector.h
+++ b/math/genvector/inc/Math/GenVector/LorentzVector.h
@@ -90,7 +90,7 @@ ROOT provides specialisations and aliases to them of the ROOT::Math::LorentzVect
           coordinates, or using a different Scalar type
        */
        template< class Coords >
-       explicit LorentzVector(const LorentzVector<Coords> & v ) :
+       explicit constexpr LorentzVector(const LorentzVector<Coords> & v ) :
           fCoordinates( v.Coordinates() ) { }
 
        /**
@@ -102,7 +102,7 @@ ROOT provides specialisations and aliases to them of the ROOT::Math::LorentzVect
                                     + std::declval<ForeignLorentzVector>().y()
                                     + std::declval<ForeignLorentzVector>().z()
                                     + std::declval<ForeignLorentzVector>().t())>
-       explicit LorentzVector( const ForeignLorentzVector & v) :
+       explicit constexpr LorentzVector( const ForeignLorentzVector & v) :
           fCoordinates(PxPyPzE4D<Scalar>( v.x(), v.y(), v.z(), v.t()  ) ) { }
 
 #ifdef LATER
@@ -115,7 +115,7 @@ ROOT provides specialisations and aliases to them of the ROOT::Math::LorentzVect
           \param index0 index of first vector element (Px)
        */
        template< class LAVector >
-       explicit LorentzVector(const LAVector & v, size_t index0 ) {
+       explicit constexpr LorentzVector(const LAVector & v, size_t index0 ) {
           fCoordinates = CoordSystem ( v[index0], v[index0+1], v[index0+2], v[index0+3] );
        }
 #endif

--- a/math/genvector/inc/Math/GenVector/Polar2D.h
+++ b/math/genvector/inc/Math/GenVector/Polar2D.h
@@ -63,7 +63,7 @@ public :
       R() and Phi()
    */
    template <class CoordSystem >
-   explicit Polar2D( const CoordSystem & v ) :
+   explicit constexpr Polar2D( const CoordSystem & v ) :
       fR(v.R() ),  fPhi(v.Phi() )  { Restrict(); }
 
    // for g++  3.2 and 3.4 on 32 bits found that the compiler generated copy ctor and assignment are much slower

--- a/math/genvector/inc/Math/GenVector/Polar3D.h
+++ b/math/genvector/inc/Math/GenVector/Polar3D.h
@@ -63,7 +63,7 @@ public :
       R(), Theta() and Phi()
    */
    template <class CoordSystem >
-   explicit Polar3D( const CoordSystem & v ) :
+   explicit constexpr Polar3D( const CoordSystem & v ) :
       fR(v.R() ),  fTheta(v.Theta() ),  fPhi(v.Phi() )  { Restrict(); }
 
    // for g++  3.2 and 3.4 on 32 bits found that the compiler generated copy ctor and assignment are much slower

--- a/math/genvector/inc/Math/GenVector/PositionVector2D.h
+++ b/math/genvector/inc/Math/GenVector/PositionVector2D.h
@@ -61,14 +61,14 @@ namespace ROOT {
           Default constructor. Construct an empty object with zero values
       */
 
-       PositionVector2D() : fCoordinates() { }
+       constexpr PositionVector2D() : fCoordinates() { }
 
        /**
           Construct from three values of type <em>Scalar</em>.
           In the case of a XYPoint the values are x,y
           In the case of  a polar vector they are r,phi
        */
-       PositionVector2D(const Scalar & a, const Scalar & b) :
+       constexpr PositionVector2D(const Scalar & a, const Scalar & b) :
           fCoordinates ( a , b)  { }
 
        /**
@@ -76,14 +76,14 @@ namespace ROOT {
           coordinates, or using a different Scalar type
        */
        template <class T>
-       explicit PositionVector2D( const PositionVector2D<T,Tag> & v) :
+       explicit constexpr PositionVector2D( const PositionVector2D<T,Tag> & v) :
           fCoordinates ( v.Coordinates() ) { }
 
        /**
           Construct from an arbitrary displacement vector
        */
        template <class T>
-       explicit PositionVector2D( const DisplacementVector2D<T,Tag> & p) :
+       explicit constexpr PositionVector2D( const DisplacementVector2D<T,Tag> & p) :
           fCoordinates ( p.Coordinates() ) { }
 
        /**
@@ -91,7 +91,7 @@ namespace ROOT {
           Precondition: v must implement methods x() and  y()
        */
        template <class ForeignVector>
-       explicit PositionVector2D( const ForeignVector & v) :
+       explicit constexpr PositionVector2D( const ForeignVector & v) :
           fCoordinates ( Cartesian2D<Scalar>( v.x(), v.y() ) ) { }
 
        // compiler-generated copy ctor and dtor are fine.
@@ -339,10 +339,10 @@ namespace ROOT {
        // this should not compile (if from a vector or points with different tag
 
        template <class OtherCoords, class OtherTag>
-       explicit PositionVector2D( const PositionVector2D<OtherCoords, OtherTag> & );
+       explicit constexpr PositionVector2D( const PositionVector2D<OtherCoords, OtherTag> & );
 
        template <class OtherCoords, class OtherTag>
-       explicit PositionVector2D( const DisplacementVector2D<OtherCoords, OtherTag> & );
+       explicit constexpr PositionVector2D( const DisplacementVector2D<OtherCoords, OtherTag> & );
 
        template <class OtherCoords, class OtherTag>
        PositionVector2D & operator=( const PositionVector2D<OtherCoords, OtherTag> & );

--- a/math/genvector/inc/Math/GenVector/PositionVector3D.h
+++ b/math/genvector/inc/Math/GenVector/PositionVector3D.h
@@ -66,14 +66,14 @@ namespace ROOT {
          Default constructor. Construct an empty object with zero values
       */
 
-      PositionVector3D() : fCoordinates() { }
+      constexpr PositionVector3D() : fCoordinates() { }
 
       /**
          Construct from three values of type <em>Scalar</em>.
          In the case of a XYZPoint the values are x,y,z
          In the case of  a polar vector they are r,theta,phi
       */
-      PositionVector3D(const Scalar & a, const Scalar & b, const Scalar & c) :
+      constexpr PositionVector3D(const Scalar & a, const Scalar & b, const Scalar & c) :
         fCoordinates ( a , b,  c)  { }
 
      /**
@@ -81,14 +81,14 @@ namespace ROOT {
           coordinates, or using a different Scalar type
       */
       template <class T>
-      explicit PositionVector3D( const PositionVector3D<T,Tag> & v) :
+      explicit constexpr PositionVector3D( const PositionVector3D<T,Tag> & v) :
         fCoordinates ( v.Coordinates() ) { }
 
      /**
           Construct from an arbitrary displacement vector
       */
       template <class T>
-      explicit PositionVector3D( const DisplacementVector3D<T,Tag> & p) :
+      explicit constexpr PositionVector3D( const DisplacementVector3D<T,Tag> & p) :
         fCoordinates ( p.Coordinates() ) { }
 
       /**
@@ -96,7 +96,7 @@ namespace ROOT {
           Precondition: v must implement methods x(), y() and z()
       */
       template <class ForeignVector>
-      explicit PositionVector3D( const ForeignVector & v) :
+      explicit constexpr PositionVector3D( const ForeignVector & v) :
         fCoordinates ( Cartesian3D<Scalar>( v.x(), v.y(), v.z() ) ) { }
 
 #ifdef LATER
@@ -464,10 +464,10 @@ namespace ROOT {
       // this should not compile (if from a vector or points with different tag
 
       template <class OtherCoords, class OtherTag>
-      explicit PositionVector3D( const PositionVector3D<OtherCoords, OtherTag> & );
+      explicit constexpr PositionVector3D( const PositionVector3D<OtherCoords, OtherTag> & );
 
       template <class OtherCoords, class OtherTag>
-      explicit PositionVector3D( const DisplacementVector3D<OtherCoords, OtherTag> & );
+      explicit constexpr PositionVector3D( const DisplacementVector3D<OtherCoords, OtherTag> & );
 
       template <class OtherCoords, class OtherTag>
       PositionVector3D & operator=( const PositionVector3D<OtherCoords, OtherTag> & );

--- a/math/genvector/inc/Math/GenVector/PtEtaPhiE4D.h
+++ b/math/genvector/inc/Math/GenVector/PtEtaPhiE4D.h
@@ -75,7 +75,7 @@ public :
       Pt(), Eta(), Phi() and E()
    */
    template <class CoordSystem >
-   explicit PtEtaPhiE4D(const CoordSystem & c) :
+   explicit constexpr PtEtaPhiE4D(const CoordSystem & c) :
       fPt(c.Pt()), fEta(c.Eta()), fPhi(c.Phi()), fE(c.E())  { }
 
    // for g++  3.2 and 3.4 on 32 bits found that the compiler generated copy ctor and assignment are much slower

--- a/math/genvector/inc/Math/GenVector/PtEtaPhiM4D.h
+++ b/math/genvector/inc/Math/GenVector/PtEtaPhiM4D.h
@@ -78,7 +78,7 @@ public :
       Pt(), Eta(), Phi() and M()
    */
    template <class CoordSystem >
-   explicit PtEtaPhiM4D(const CoordSystem & c) :
+   explicit constexpr PtEtaPhiM4D(const CoordSystem & c) :
       fPt(c.Pt()), fEta(c.Eta()), fPhi(c.Phi()), fM(c.M())  { RestrictPhi(); }
 
    // for g++  3.2 and 3.4 on 32 bits found that the compiler generated copy ctor and assignment are much slower

--- a/math/genvector/inc/Math/GenVector/PxPyPzE4D.h
+++ b/math/genvector/inc/Math/GenVector/PxPyPzE4D.h
@@ -67,7 +67,7 @@ public :
       implementing x(), y() and z() and t()
    */
    template <class CoordSystem>
-   explicit PxPyPzE4D(const CoordSystem & v) :
+   explicit constexpr PxPyPzE4D(const CoordSystem & v) :
       fX( v.x() ), fY( v.y() ), fZ( v.z() ), fT( v.t() )  { }
 
    // for g++  3.2 and 3.4 on 32 bits found that the compiler generated copy ctor and assignment are much slower

--- a/math/genvector/inc/Math/GenVector/PxPyPzM4D.h
+++ b/math/genvector/inc/Math/GenVector/PxPyPzM4D.h
@@ -74,7 +74,7 @@ public :
       implementing X(), Y(), X() and M()
    */
    template <class CoordSystem>
-   explicit PxPyPzM4D(const CoordSystem & v) :
+   explicit constexpr PxPyPzM4D(const CoordSystem & v) :
       fX( v.X() ), fY( v.Y() ), fZ( v.Z() ), fM( v.M() )
    { }
 

--- a/math/genvector/inc/Math/GenVector/Quaternion.h
+++ b/math/genvector/inc/Math/GenVector/Quaternion.h
@@ -77,7 +77,7 @@ public:
       Construct from another supported rotation type (see gv_detail::convert )
    */
    template <class OtherRotation>
-   explicit Quaternion(const OtherRotation & r) {gv_detail::convert(r,*this);}
+   explicit constexpr Quaternion(const OtherRotation & r) {gv_detail::convert(r,*this);}
 
 
    /**

--- a/math/genvector/inc/Math/GenVector/Rotation3D.h
+++ b/math/genvector/inc/Math/GenVector/Rotation3D.h
@@ -131,7 +131,7 @@ public:
       or re-adjusting is performed.
    */
    template<class ForeignMatrix>
-   explicit Rotation3D(const ForeignMatrix & m) { SetComponents(m); }
+   explicit constexpr Rotation3D(const ForeignMatrix & m) { SetComponents(m); }
 
    /**
       Construct from three orthonormal vectors (which must have methods

--- a/math/genvector/inc/Math/GenVector/RotationZYX.h
+++ b/math/genvector/inc/Math/GenVector/RotationZYX.h
@@ -103,7 +103,7 @@ public:
       Construct from another supported rotation type (see gv_detail::convert )
    */
    template <class OtherRotation>
-   explicit RotationZYX(const OtherRotation & r) {gv_detail::convert(r,*this);}
+   explicit constexpr RotationZYX(const OtherRotation & r) {gv_detail::convert(r,*this);}
 
 
    /**

--- a/math/genvector/inc/Math/GenVector/Transform3D.h
+++ b/math/genvector/inc/Math/GenVector/Transform3D.h
@@ -162,35 +162,35 @@ public:
    /**
       Construct from a 3D Rotation only with zero translation
    */
-   explicit Transform3D( const Rotation3D & r) {
+   explicit constexpr Transform3D( const Rotation3D & r) {
       AssignFrom(r);
    }
 
    // convenience methods for constructing a Transform3D from all the 3D rotations classes
    // (cannot use templates for conflict with LA)
 
-   explicit Transform3D( const AxisAngle & r) {
+   explicit constexpr Transform3D( const AxisAngle & r) {
       AssignFrom(Rotation3D(r));
    }
-   explicit Transform3D( const EulerAngles & r) {
+   explicit constexpr Transform3D( const EulerAngles & r) {
       AssignFrom(Rotation3D(r));
    }
-   explicit Transform3D( const Quaternion & r) {
+   explicit constexpr Transform3D( const Quaternion & r) {
       AssignFrom(Rotation3D(r));
    }
-   explicit Transform3D( const RotationZYX & r) {
+   explicit constexpr Transform3D( const RotationZYX & r) {
       AssignFrom(Rotation3D(r));
    }
 
    // Constructors from axial rotations
    // TO DO: implement direct methods for axial rotations without going through Rotation3D
-   explicit Transform3D( const RotationX & r) {
+   explicit constexpr Transform3D( const RotationX & r) {
       AssignFrom(Rotation3D(r));
    }
-   explicit Transform3D( const RotationY & r) {
+   explicit constexpr Transform3D( const RotationY & r) {
       AssignFrom(Rotation3D(r));
    }
-   explicit Transform3D( const RotationZ & r) {
+   explicit constexpr Transform3D( const RotationZ & r) {
       AssignFrom(Rotation3D(r));
    }
 
@@ -199,21 +199,21 @@ public:
       and with an identity rotation
    */
    template<class CoordSystem, class Tag>
-   explicit Transform3D( const DisplacementVector3D<CoordSystem,Tag> & v) {
+   explicit constexpr Transform3D( const DisplacementVector3D<CoordSystem,Tag> & v) {
       AssignFrom(Vector(v.X(),v.Y(),v.Z()));
    }
    /**
       Construct from a translation only, represented by a Cartesian 3D Vector,
       and with an identity rotation
    */
-   explicit Transform3D( const Vector & v) {
+   explicit constexpr Transform3D( const Vector & v) {
       AssignFrom(v);
    }
    /**
       Construct from a translation only, represented by a Translation3D class
       and with an identity rotation
    */
-   explicit Transform3D(const Translation3D<T> &t) { AssignFrom(t.Vect()); }
+   explicit constexpr Transform3D(const Translation3D<T> &t) { AssignFrom(t.Vect()); }
 
    //#if !defined(__MAKECINT__) && !defined(G__DICTIONARY)  // this is ambiguous with double * , double *
 
@@ -435,7 +435,7 @@ public:
       are described by the 4-th column
    */
    template<class ForeignMatrix>
-   explicit Transform3D(const ForeignMatrix & m) {
+   explicit constexpr Transform3D(const ForeignMatrix & m) {
       SetComponents(m);
    }
 

--- a/math/genvector/inc/Math/GenVector/Translation3D.h
+++ b/math/genvector/inc/Math/GenVector/Translation3D.h
@@ -81,7 +81,7 @@ public:
       Construct from any Displacement vector in ant tag and coordinate system
    */
    template<class CoordSystem, class Tag>
-   explicit Translation3D( const DisplacementVector3D<CoordSystem,Tag> & v) :
+   explicit constexpr Translation3D( const DisplacementVector3D<CoordSystem,Tag> & v) :
       fVect(Vector(v.X(),v.Y(),v.Z()))
    { }
 


### PR DESCRIPTION
Closes the following JIRA ticket:
https://sft.its.cern.ch/jira/browse/ROOT-9320