### PR TITLE
Allow CMake to configure with nvc++

### DIFF
--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -551,9 +551,13 @@ set(pythonvers ${Python3_VERSION})
 set(python${Python3_VERSION_MAJOR}vers ${Python3_VERSION})
 
 #---RConfigure.h---------------------------------------------------------------------------------------------
-try_compile(has__cplusplus "${CMAKE_BINARY_DIR}" SOURCES "${CMAKE_SOURCE_DIR}/config/__cplusplus.cxx"
+if (CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC")
+   execute_process(COMMAND ${CMAKE_CXX_COMPILER} -dM -E /dev/null OUTPUT_VARIABLE __cplusplus_PPout)
+else()
+   try_compile(has__cplusplus "${CMAKE_BINARY_DIR}" SOURCES "${CMAKE_SOURCE_DIR}/config/__cplusplus.cxx"
             OUTPUT_VARIABLE __cplusplus_PPout)
-string(REGEX MATCH "__cplusplus=([0-9]+)" __cplusplus "${__cplusplus_PPout}")
+endif()
+string(REGEX MATCH "__cplusplus[=| ]([0-9]+)" __cplusplus "${__cplusplus_PPout}")
 set(__cplusplus ${CMAKE_MATCH_1}L)
 
 configure_file(${PROJECT_SOURCE_DIR}/config/RConfigure.in ginclude/RConfigure.h NEWLINE_STYLE UNIX)

--- a/config/__cplusplus.cxx
+++ b/config/__cplusplus.cxx
@@ -1,7 +1,7 @@
 #define _STRINGIFY(x) #x
 #define STRINGIFY(x) _STRINGIFY(x)
 
-// `#pragma message` is supported in well-known compilers including gcc, clang, icc, and MSVC
+// `#pragma message` is supported in well-known compilers including gcc, clang, icc, and MSVC. But not nvc++.
 #pragma message("__cplusplus=" STRINGIFY(__cplusplus))
 
 int main(void)


### PR DESCRIPTION
This PR is a successor to #14139, allowing CMake to configure ROOT when nvc++ is used as C++ compiler.